### PR TITLE
I couldn't do run runserver without also installing continuumweb

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ At a minimum, Bokeh requires the following:
  * gevent
  * gevent-websocket
  * Pandas
+ * continuumweb
 
 For an older rich-client prototype of some interactive GGplot functionality, the
 [Chaco](https://github.com/enthought/chaco) plotting library is also required.


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "runserver.py", line 3, in <module>
    from bokeh.server import start
  File "/Users/me/local/Bokeh/bokeh/server/start.py", line 24, in <module>
    from continuumweb import hemlib
ImportError: No module named continuumweb
Exception KeyError: KeyError(4451569168,) in <module 'threading' from '/usr/local/Cellar/python/2.7.3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.pyc'> ignored
```
