### PR TITLE
Add 'legend' Method to Retrieve Current Legends

### DIFF
--- a/bokeh/plotting.py
+++ b/bokeh/plotting.py
@@ -960,6 +960,14 @@ def axis():
     """ Return the axes on the current plot """
     return _list_attr_splat(xaxis() + yaxis())
 
+def legend():
+    """ Return the legend(s) of the current plot """
+    p = curplot()
+    if p is None:
+        return None
+    legends = [obj for obj in p.renderers if isinstance(obj, Legend)]
+    return _list_attr_splat(legends)
+
 def xgrid():
     """ Returns x-grid object on the current plot """
     p = curplot()


### PR DESCRIPTION
I tried this with

```
from bokeh.plotting import *
output_file('test.html')
line([1,2,3],[2,3,2], legend='blah')
legend()[0].orientation='top_left'
show()
```

and it seemed to have the desired effect. I'm totally new to bokeh and not really sure if this is indeed correct, but I couldn't find a method to easily retrieve the legends of a plot.
