### PR TITLE
bokeh-server ImportError handler just prints the error message

### DIFF
--- a/bokeh-server
+++ b/bokeh-server
@@ -4,8 +4,7 @@ import argparse, sys
 try:
     from bokeh.server import start
 except ImportError, ie:
-    print
-    print "Error: required module '{0}' not found".format(ie)
+    print ie
     print sys.exit(1)
 import logging
 


### PR DESCRIPTION
Old method assumed that the missing module was redis, which isn't necessarily true.
