### PR TITLE
Adding link to actual webpage for tutorial information.

### DIFF
--- a/tutorial/tutorial1.py
+++ b/tutorial/tutorial1.py
@@ -1,5 +1,5 @@
 # For information about this tutorial, please consult the
-# Tutorial section of the documentation.
+# Tutorial section of the documentation (http://bokeh.pydata.org/tutorial.html).
 
 from bokeh.plotting import *
 from numpy import *


### PR DESCRIPTION
The tutorial1.py directs the user to the tutorial web page, but does
not provide the specific URL.  I have added it.
