### PR TITLE
Better fix for gevent's KeyError issue

### DIFF
--- a/bokeh/__init__.py
+++ b/bokeh/__init__.py
@@ -1,21 +1,10 @@
 from __future__ import absolute_import, print_function
 
-# NOTE: Execute patch_all() before everything else, especially before
-# importing threading module. Otherwise, annoying KeyError exception
-# will be thrown. gevent is optional, so don't fail if not installed.
-try:
-    import gevent.monkey
-except ImportError:
-    pass
-else:
-    gevent.monkey.patch_all()
-
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 
 from . import sampledata
-from .serverconfig import Server, Cloud
 
 def print_versions():
     """Print all the versions of software that Bokeh relies on."""

--- a/bokeh/server/__init__.py
+++ b/bokeh/server/__init__.py
@@ -1,0 +1,9 @@
+# NOTE: Execute patch_all() before everything else, especially before
+# importing threading module. Otherwise, annoying KeyError exception
+# will be thrown. gevent is optional, so don't fail if not installed.
+try:
+    import gevent.monkey
+except ImportError:
+    pass
+else:
+    gevent.monkey.patch_all()


### PR DESCRIPTION
Previous solution fixed `./bokeh-server` but broke IPython. Now both work, but "import bokeh.server" in IPython will throw `KeyError`, but server code is unlikely to be used interactively. I had to remove import of `serverconfig` from `bokeh/__init__.py`, but I didn't see any use of this shortcut, so I assume this is not an issue.
