### PR TITLE
Avoid pylab and use the specific imports instead.

### DIFF
--- a/examples/mpl/mpltest.py
+++ b/examples/mpl/mpltest.py
@@ -1,15 +1,18 @@
+import numpy as np
+import matplotlib.pyplot as plt
 from bokeh import pyplot
-from pylab import *
 from bokeh import plotting
-x = linspace(-2*pi,2*pi,100)
-y = sin(x)
 
-plot(x,y,"r-")
-title("Matplotlib Figure in Bokeh")
+x = np.linspace(-2 * np.pi, 2 * np.pi, 100)
+y = np.sin(x)
+
+
+plt.plot(x, y, "r-")
+plt.title("Matplotlib Figure in Bokeh")
 
 # dashed lines work
-#plot(x,y,"r-x", linestyle="-.")
+#plt.plot(x,y,"r-x", linestyle="-.")
 
-pyplot.show_bokeh(gcf(), filename="mpltest.html")
+pyplot.show_bokeh(plt.gcf(), filename="mpltest.html")
 
 plotting.session().dumpjson(file="mpltest.json")


### PR DESCRIPTION
The pylab "interface" import a lot of things (too many)... and there is a lot of people (including me) trying to avoid the spread of its use. You can check a blog post about the problem of importing pylab here: http://carreau.github.io/posts/10-No-PyLab-Thanks.ipynb.html

Also, using the specific imports makes easy to integrate the matplotlib examples in bokeh mpl examples, which I will need to do to test the LineCollection support.
