### PR TITLE
Note about dependencies to install PyAudio successfully in debian-based systems.

### DIFF
--- a/bokehjs/demo/spectrogram/README.md
+++ b/bokehjs/demo/spectrogram/README.md
@@ -6,7 +6,9 @@ Build & Prereqs
 
 You will still need to follow the installation instructions in the top-level README.md in the bokehjs directory, i.e. you need to have node, npm, coffeescript, and grunt installed.
 
-You will also need PyAudio and Flask installed.  (These come with Anaconda.)
+You will also need PyAudio and Flask installed (these come with Anaconda).
+
+Note: In some debian-based systems, to install PyAudio, you will need some underlying dependencies, such as libjack-jackd2-dev and portaudio19-dev.
 
 Build the coffeescript:
 


### PR DESCRIPTION
Closes #350.
