### PR TITLE
Adding a missing getsitepackage function to install in dev mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ if sys.platform != 'win32':
 # This is an open bug: https://github.com/pypa/virtualenv/issues/355
 # Workaround to fix our issue: https://github.com/ContinuumIO/bokeh/issues/378
 
+
 def getsitepackages():
     """Returns a list containing all global site-packages directories
     (and possibly site-python)."""
@@ -155,7 +156,6 @@ def getsitepackages():
     return sitepackages
 
 site_packages = getsitepackages()[0]
-print getsitepackages()
 path_file = join(site_packages, "bokeh.pth")
 path = abspath(dirname(__file__))
 


### PR DESCRIPTION
You can't install Bokeh in a virtualenv because the lack of getsitepackages()
This is an open bug at venv: https://github.com/pypa/virtualenv/issues/355
And pretend to offer a workaround to fix our issue until it is fixed upstream (venv): https://github.com/ContinuumIO/bokeh/issues/378
