### PR TITLE
Fix nbviewer issue.

### DIFF
--- a/bokeh/_templates/plot_script.html
+++ b/bokeh/_templates/plot_script.html
@@ -1,5 +1,3 @@
 <script type="text/javascript">
-    $(document).ready(function() {
     {{ plot_js|indent(4) }}
-    });
 </script>

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -65,6 +65,7 @@ def notebook_div(plot_object):
 
     '''
     ref = plot_object.get_ref()
+    resources = Resources()
     elementid = str(uuid.uuid4())
 
     js = PLOT_JS.render(
@@ -74,7 +75,7 @@ def notebook_div(plot_object):
         all_models = serialize_json(plot_object.dump()),
     )
     script = PLOT_SCRIPT.render(
-        plot_js = js,
+        plot_js = resources.js_wrapper(js),
     )
     div = PLOT_DIV.render(elementid=elementid)
     html = NOTEBOOK_DIV.render(


### PR DESCRIPTION
To fix the non-plots issues in nbviewer and nbconvert, I delayed the load of plot_js until the html is ready (the browser has loaded the HTML elements into the DOM). It works with nbconvert exported bokeh notebooks and does not seem to affect files or server plots.

This PR would close #559.
