### PR TITLE
 Example for referencing links using the hover_tool

### DIFF
--- a/bokehjs/demo/coffee/hover.coffee
+++ b/bokehjs/demo/coffee/hover.coffee
@@ -13,6 +13,7 @@ require(['main', 'underscore'], (Bokeh, _) ->
     y: y
     radius: (r.randf()*2 + 2 for i in _.range(N))
     color: ("rgb(#{ Math.floor(50+2*val[0]) }, #{ Math.floor(30+2*val[1]) }, 150)" for val in _.zip(x, y))
+    link: ("http://www.google.com?s=" + x[i] + " " + y[i] for i in _.range(N))
     text: t
   }
 

--- a/bokehjs/src/coffee/tool/hover_tool.coffee
+++ b/bokehjs/src/coffee/tool/hover_tool.coffee
@@ -86,6 +86,30 @@ define [
       )
       @plot_view.canvas_wrapper.css('cursor', 'crosshair')
 
+      @plot_view.canvas.bind("click", (e) =>
+        if not @active
+          return
+        offset = $(e.currentTarget).offset()
+        left = if offset? then offset.left else 0
+        top = if offset? then offset.top else 0
+        e.bokehX = e.pageX - left
+        e.bokehY = e.pageY - top
+
+        [vx, vy] = @view_coords(e.bokehX, e.bokehY)
+
+        irh = @plot_view.view_state.get( 'inner_range_horizontal')
+        irv = @plot_view.view_state.get( 'inner_range_vertical')
+        xstart = irh.get('start')
+        xend = irh.get('end')
+        ystart = irv.get('start')
+        yend = irv.get('end')
+        if vx < xstart  or vx > xend or vy < ystart or vy > yend
+          @div.hide()
+          return
+
+        @_link(vx, vy, e)
+      )
+
     view_coords: (sx, sy) ->
       [vx, vy] = [
         @plot_view.view_state.sx_to_vx(sx),
@@ -184,6 +208,34 @@ define [
           @div.hide()
         datasource_selections[datasource_id].push(selected)
 
+      return null
+
+    _link: (vx, vy, e) ->
+      geometry = {
+        type: 'point'
+        vx: vx
+        vy: vy
+      }
+      x = @plot_view.xmapper.map_from_target(vx)
+      y = @plot_view.ymapper.map_from_target(vy)
+      datasources = {}
+      datasource_selections = {}
+      for renderer in @mget_obj('renderers')
+        datasource = renderer.get_obj('data_source')
+        datasources[datasource.id] = datasource
+      for renderer in @mget_obj('renderers')
+        datasource_id = renderer.get_obj('data_source').id
+        _.setdefault(datasource_selections, datasource_id, [])
+        selected = @plot_view.renderers[renderer.id].hit_test(geometry)
+        ds = datasources[datasource_id]
+        if selected == null
+          continue
+        if selected.length > 0
+          _urls = ds.getcolumn('link')
+          if (_urls != null)
+            _url = _urls[selected[0]];
+            window.open(_url);
+            break
       return null
 
   class HoverTool extends Tool.Model


### PR DESCRIPTION
OK, I know this isn't ready to go by a mile - that's why didn't make it a PR to start with.  To really do this, I would lean towards creating a new tool.  Let's call it pointer_tool.  It would have the current hover capability in it, plus a few others items:
- User can specify full html for tool-tip box (maybe also allow a graph to be in there?)
- Click/double-click can open a new window, or just link to a new page
- Click/double-click can stuff a value into user clipboard.

The code in this PR relies on the 'magic' field name 'link' to be in the datasource.   It's probably better to do what was done in the hover tool and have the link value be pulled in indirectly.  Then, then interface would look something like:

```
pointer = [t for t in curplot().tools if isinstance(t, PointerTool)][0]
pointer.click_action = "link" 
pointer.click_data = "@url"  # data value depends on action
pointer.double_click_action = "clipboard"
pointer.double_click_data = "@directory"
```

Actions:
- link  (data = url and may be $@value_from_datasource)
- newwindow (same as link, but opens in a new window).
- tooltip (data = same as current hover tooltip - data in tabular form)
- tooltip_html (data = a reference to a datasource item which is assumed to be raw html)
- clipboard (data = reference to datasource to be stuffed into clipboard).

Feel free to tell me this is a bad way to go.

Question: how do y'all test this coffee/javascript stuff

G
