### PR TITLE
Changed clean to delete the /build/lib directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ import site
 import subprocess
 import sys
 from distutils.core import setup
+from distutils import dir_util
 from os.path import abspath, exists, join, dirname
 
 # Our own imports
@@ -250,6 +251,9 @@ if 'devjs' in sys.argv or 'develop' in sys.argv:
         print("  - using RELEASED bokehjs (version %s) from bokehjs/release" % v)
     print()
     sys.exit()
+elif 'clean' in sys.argv:
+    print("Removing prior-built items...")
+    dir_util.remove_tree('build/lib/bokeh')
 elif 'install' in sys.argv:
     if exists(path_file):
         os.remove(path_file)


### PR DESCRIPTION
Attempt to close issue #662 by deleting the build/lib/bokeh directory when 'setup.py clean' is used.
