### PR TITLE
Include version '2.0.0-wakari'

### DIFF
--- a/extensions/bokeh_magic.py
+++ b/extensions/bokeh_magic.py
@@ -28,7 +28,7 @@ class BokehMagics(Magics):
     """Magic to embed Bokeh into the IPython notebook."""
 
     ipyones = ['1.0.0', '1.1.1', '1.1.2', '1.2.0', '1.2.1']
-    ipytwos = ['2.0.0-dev', '2.0.0-b1', '2.0.0', '2.1.0', '3.0.0-dev']
+    ipytwos = ['2.0.0-dev', '2.0.0-b1', '2.0.0-wakari', '2.0.0', '2.1.0', '3.0.0-dev']
     if IPython.__version__ in ipyones:
         is_ipytwo = False
     elif IPython.__version__ in ipytwos:


### PR DESCRIPTION
Exception when running bokeh magic extension in Wakari:

Exception: This version of IPython is not currently supported.
Currently supported version are: 1.0.0, 1.1.1, 1.1.2, 1.2.0, 1.2.1 and 2.0.0-dev, 2.0.0-b1, 2.0.0, 2.1.0, 3.0.0-dev.

Added version '2.0.0-wakari' to the list 
