### PR TITLE
add tags option for build and upload script

### DIFF
--- a/build_and_upload.sh
+++ b/build_and_upload.sh
@@ -1,5 +1,24 @@
 #!/bin/bash
 
+if [ "$1" == "-h" ]; then
+    usage="$(basename "$0") [-h] [--tags] -- program to build and upload bokeh pkgs to binstar
+
+    where:
+        -h  show this help text
+        --tags instructs the version number to be the tagged branch
+    "
+    echo "$usage"
+    exit 0
+elif [ "$1" == "--tags" ]; then
+    tag_flag=1
+
+    #needed for build.sh in conda build script
+    touch using_tags.txt
+else
+    tag_flag=0
+fi
+echo The tag flag: $tag_flag
+
 #buld py27 pkg
 echo "Building py27 pkg"
 conda build conda.recipe --quiet;
@@ -29,8 +48,13 @@ do
 	binstar upload -u bokeh $i/bokeh*$date*.tar.bz2 -c dev --force;
 done
 
+if [ "$tag_flag" = "1" ]; then
+    version=`git describe`
+else
+    version=`python build_scripts/get_bump_version.py`
+fi
+
 #create and upload pypi pkgs to binstar
-version=`python build_scripts/get_bump_version.py`
 
 #zip is currently not working
 
@@ -46,6 +70,7 @@ do
 done
 
 rm -rf dist/
+rm using_tags.txt
 
 #####################
 #Removing on binstar#

--- a/conda.recipe/.py
+++ b/conda.recipe/.py
@@ -1,0 +1,6 @@
+
+version_version = 
+version_full = 'THIS IS A DEV VERSION OF BOKEH'
+def get_versions(default={}, verbose=False):
+    return {'version': version_version, 'full': version_full}
+

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -7,7 +7,12 @@ SRC_DIR=$RECIPE_DIR/..
 pushd $SRC_DIR
 
 # X.X.X.dev.YYYYMMDD builds
-version=`$PYTHON build_scripts/get_bump_version.py`
+if [ -e using_tags.txt ]; then
+    version=`git describe`
+else
+    version=`$PYTHON build_scripts/get_bump_version.py`
+fi
+
 date=`date "+%Y%m%d"`
 echo $version.dev.$date > __conda_version__.txt
 cp __conda_version__.txt $BLD_DIR

--- a/conda.recipe/post-link.sh2
+++ b/conda.recipe/post-link.sh2
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+version=`cat __conda_version__.txt`
+cat > $PREFIX_version.py << EOF
+
+version_version = $version
+version_full = 'THIS IS A DEV VERSION OF BOKEH'
+def get_versions(default={}, verbose=False):
+    return {'version': version_version, 'full': version_full}
+
+EOF
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
``` bash
$./build_and_upload.sh -h
build_and_upload.sh [-h] [--tags] -- program to build and upload bokeh pkgs to binstar

    where:
        -h  show this help text
        --tags instructs the version number to be the tagged branch
```
