### PR TITLE
Fixes #682.

### DIFF
--- a/bokeh/plotting.py
+++ b/bokeh/plotting.py
@@ -7,6 +7,7 @@ import logging
 import os
 import uuid
 import warnings
+import io
 
 from . import browserlib
 from . import _glyph_functions as gf
@@ -19,6 +20,7 @@ from .plotting_helpers import (
 )
 from .resources import Resources
 from .session import Cloud, DEFAULT_SERVER_URL, Session
+from .utils import decode_utf8
 
 logger = logging.getLogger(__name__)
 
@@ -280,8 +282,8 @@ def save(filename=None, resources=None):
         return
 
     html = file_html(curdoc(), resources, _default_file['title'])
-    with open(filename, "wb") as f:
-        f.write(html.encode('utf-8'))
+    with io.open(filename, "w", encoding="utf-8") as f:
+        f.write(decode_utf8(html))
 
 def push(session=None, document=None):
     """ Updates the server with the data for the current document.


### PR DESCRIPTION
I am on windows 7 SP1 using python 3.4 64 bit.

When trying the candlestick example I ran into issue #682. By writing the file as binary we get around the charmap issue. However to write as binary we need to convert the unicode string to bytes for Python 3... The below should also work in Python 2.6 and .7 and on none windows systems but I am unable to test that.

I used the below to help figure this out...
http://stackoverflow.com/questions/14630288/unicodeencodeerror-charmap-codec-cant-encode-character-maps-to-undefined

http://stackoverflow.com/questions/5471158/typeerror-str-does-not-support-the-buffer-interface
