### PR TITLE
fix case where colorspecs mishandled serializing to dictionaries when the value was unset

### DIFF
--- a/bokeh/properties.py
+++ b/bokeh/properties.py
@@ -365,7 +365,6 @@ class ColorSpec(DataSpec):
                     return {"field": setval, "default": self.default}
             elif setval is None:
                 return None
-                return {"value": None}
             else:
                 # setval should be a dict at this point
                 assert(isinstance(setval, dict))
@@ -419,11 +418,13 @@ class ColorSpec(DataSpec):
                 return d
         else:
             if self._isset:
-                return {"value": None}
-            # If the user never set a value
-            if self.value is not None:
-                return {"value": self.value}
+                if self.value is None:
+                    return {"value": None}
+                else:
+                    return {"value": getattr(obj, self._name, self.value)}
             else:
+                if self.value:
+                    return {"value": self.value}
                 d = {"field": self.field}
                 if self.default is not None:
                     d["default"] = self._formattuple(self.default)

--- a/bokeh/tests/test_properties.py
+++ b/bokeh/tests/test_properties.py
@@ -226,6 +226,13 @@ class TestColorSpec(unittest.TestCase):
         f.col = None
         self.assertDictEqual(desc.to_dict(f), {"value": None})
 
+    def test_named_value_unset(self):
+        class Foo(HasProps):
+            col = ColorSpec("colorfield")
+        desc = Foo.__dict__["col"]
+        f = Foo()
+        self.assertDictEqual(desc.to_dict(f), {"field": "colorfield"})
+
     def test_named_color_overriding_default(self):
         class Foo(HasProps):
             col = ColorSpec("colorfield", default="blue")


### PR DESCRIPTION
The problem stemmed from using `self._isset` to distinguish between "never having been set" and "explicitly set to None". By ignoring `self.value` the color spec would always serialize to `None` whenever it had been set. The was exposed when running the glyph tests after using the `plotting.py` interface:

```
In [1]: %run test_glyphs.py
............................................................................................
----------------------------------------------------------------------
Ran 92 tests in 0.375s

OK

In [2]: from bokeh.plotting import circle

In [3]: circle([1,2], [3,4])
Out[3]: <bokeh.objects.Plot at 0x1104b8c10>

In [4]: %run test_glyphs.py
..F..F..F.F......F..F.F.F.F.F.F..........F..F..F..F..F..F..F..F..F..F..F..F..F.F.F....F..F.F
```

As of this change, all existing tests pass, a new `test_named_value_unset` test passes. Visual inspection of all test .png outputs also looks correct. However, being a change at a very low level, closer scrutiny is requested from @pzwang @mattpap @damianavila 
