### PR TITLE
Subtypes, such as numpy int64, are not considered instance of np.int.

### DIFF
--- a/bokeh/protocol.py
+++ b/bokeh/protocol.py
@@ -60,9 +60,9 @@ class BokehJSONEncoder(json.JSONEncoder):
         # Pandas Timestamp
         if is_pandas and isinstance(obj, pd.tslib.Timestamp):
             return obj.value / millifactor  #nanosecond to millisecond
-        elif isinstance(obj, np.float):
+        elif np.issubdtype(type(obj), np.float):
             return float(obj)
-        elif isinstance(obj, np.int):
+        elif np.issubdtype(type(obj), np.int):
             return int(obj)
         # Datetime, Date
         elif isinstance(obj, (dt.datetime, dt.date)):


### PR DESCRIPTION
Subtypes, such as numpy int64, are not considered instance of np.int. Use np.issubdtype instead. Issue exists when trying the crossfilter demo at /scripts/crossfilter.py.
