### PR TITLE
Fixed labels in charts interface.

### DIFF
--- a/bokeh/charts/_charts.py
+++ b/bokeh/charts/_charts.py
@@ -258,7 +258,9 @@ class Chart(object):
 
         # Add axis
         xaxis = self.make_axis("bottom", self.xscale, self.xlabel)
+        self.plot.below.append(xaxis)
         yaxis = self.make_axis("left", self.yscale, self.ylabel)
+        self.plot.left.append(yaxis)
 
         # Add grids
         self.make_grid(xaxis, 0)


### PR DESCRIPTION
Quick and easy fix.
Closes #956.

Now it is looking OK (include the labels, not cutted), you can see the probe below :wink:

![fixed](https://cloud.githubusercontent.com/assets/1640669/3798024/3aabc0ea-1be0-11e4-88c7-bbe323535087.png)
