### PR TITLE
test script can not be conda-dependent.

### DIFF
--- a/examples/test
+++ b/examples/test
@@ -25,8 +25,6 @@ from requests.exceptions import ConnectionError
 import colorama
 colorama.init()
 
-from conda.utils import human_bytes
-
 try:
     import gevent
 except ImportError:
@@ -204,6 +202,21 @@ def is_selected(example):
         return True
     else:
         return False
+
+def human_bytes(n):
+    """
+    Return the number of bytes n in more human readable form.
+    """
+    if n < 1024:
+        return '%d B' % n
+    k = n/1024
+    if k < 1024:
+        return '%d KB' % round(k)
+    m = k/1024
+    if m < 1024:
+        return '%.1f MB' % m
+    g = m/1024
+    return '%.2f GB' % g
 
 base_dir = dirname(__file__)
 examples = []


### PR DESCRIPTION
If we have pip users, we have to provide a way to tests things `conda` independently, so I took the `human_bytes` function fro `conda.utils` and now you can test it locally in a pip/virtualenv env.
