### PR TITLE
Use conda-build 1.7.0 until get fixed.

### DIFF
--- a/scripts/travis_install
+++ b/scripts/travis_install
@@ -16,7 +16,7 @@ rm -rf $MINICONDA.sh
 
 python -V
 
-DEPS_TRAVIS="python=$TRAVIS_PYTHON_VERSION conda-build jinja2"
+DEPS_TRAVIS="python=$TRAVIS_PYTHON_VERSION conda-build=1.7.0 jinja2"
 conda install --yes $DEPS_TRAVIS
 
 conda config --add channels bokeh


### PR DESCRIPTION
Making it a PR to easily revert after conda get fixed.
