### PR TITLE
Protocol fix

### DIFF
--- a/bokeh/protocol.py
+++ b/bokeh/protocol.py
@@ -41,7 +41,7 @@ class BokehJSONEncoder(json.JSONEncoder):
         ## not quite correct, truncates to ms..
         if obj.dtype.kind == 'M':
             if self.legacy_datetime64:
-                if obj.dtype == numpy.dtype('datetime[ns]'):
+                if obj.dtype == np.dtype('datetime64[ns]'):
                     return (obj.astype('int64') / millifactor).tolist()
                 # else punt.
             else:


### PR DESCRIPTION
https://github.com/ContinuumIO/bokeh/issues/1104

In this patch, it checks that original is datetime64[ns] before workaround converting.  But if original is some other units it does no conversion at all; let me know if you want some other behavior (raise?)
