### PR TITLE
quick fix to remove toolbars on subplots in gridplots

### DIFF
--- a/bokehjs/src/coffee/common/grid_plot.coffee
+++ b/bokehjs/src/coffee/common/grid_plot.coffee
@@ -42,6 +42,7 @@ define [
       childmodels = []
       for row in @mget('children')
         for plot in row
+          plot.set('toolbar_location', null)
           childmodels.push(plot)
       build_views(@childviews, childmodels, {})
       @set_child_view_states()


### PR DESCRIPTION
This is just a quick fix to make current grid plots presentable. A further PR is needed to:
- put grid plots on one canvas
- use the new toolbar

These should be done together. After spending 15 minutes trying to get the new toolbar on the existing grid plot, it does not seem worthwhile to invest any more time in it. 
