### PR TITLE
Set {np.}random.seed(1) in examples/test

### DIFF
--- a/examples/test
+++ b/examples/test
@@ -288,7 +288,20 @@ class Timeout(Exception):
     pass
 
 def run_example(example):
-    cmd = ["python", basename(example)]
+    code = """\
+filename = '%s'
+
+import random
+random.seed(1)
+
+import numpy as np
+np.random.seed(1)
+
+with open(filename, 'rb') as example:
+    exec(compile(example.read(), filename, 'exec'))
+""" % basename(example)
+
+    cmd = ["python", "-c", code]
     cwd = dirname(example)
     env = make_env()
 


### PR DESCRIPTION
This allows us to run examples as tests and always get the same plots, even if random data is involved. This solution doesn't require any changes to examples. The slight drawback is that tracebacks contain additional `<string>` entry at the beginning, thought the remaining entries and file names are preserved.
