### PR TITLE
Remove unnecessary reference to GMaps API

### DIFF
--- a/bokehjs/src/template/demos.html
+++ b/bokehjs/src/template/demos.html
@@ -9,8 +9,6 @@
   <link type="text/css" rel="stylesheet" href="/static/css/bokeh.css"/>
   <link type="text/css" rel="stylesheet" href="/static/vendor/bootstrap/css/bootstrap.min.css"/>
 
-  <script src="https://maps.googleapis.com/maps/api/js?v=3.exp&sensor=true&libraries=places"></script>
-
   <!-- Your project file goes here -->
 
   <!-- These are 3rd party libs that we depend on.  In debug mode, this


### PR DESCRIPTION
Fixes #936.
