### PR TITLE
Remove 'type' property from guides

### DIFF
--- a/bokeh/models/axes.py
+++ b/bokeh/models/axes.py
@@ -9,8 +9,6 @@ from .tickers import Ticker, BasicTicker, LogTicker, CategoricalTicker, Datetime
 from .formatters import TickFormatter, BasicTickFormatter, LogTickFormatter, CategoricalTickFormatter, DatetimeTickFormatter
 
 class Axis(GuideRenderer):
-    type = String("axis")
-
     location = Either(Enum('auto'), Enum(Location))
     bounds = Either(Enum('auto'), Tuple(Float, Float))
 

--- a/bokeh/models/grids.py
+++ b/bokeh/models/grids.py
@@ -8,8 +8,6 @@ from .tickers import Ticker
 
 class Grid(GuideRenderer):
     """ 1D Grid component """
-    type = String("grid")
-
     dimension = Int(0)
     bounds = String('auto')
 


### PR DESCRIPTION
It doesn't seem to be used anymore.
