### PR TITLE
turn bar plots category (values) width proportional to the number of val...

### DIFF
--- a/bokeh/charts/bar.py
+++ b/bokeh/charts/bar.py
@@ -174,6 +174,9 @@ class Bar(ChartObject):
         """
         self.cat = cat
         self.width = [0.8] * len(self.cat)
+        # width should decrease proportionally to the value length.
+        # 1./len(value) doesn't work well as the width needs to decrease a
+        # little bit faster
         self.width_cat = [min(0.2, (1./len(value))**1.1)] * len(self.cat)
         self.zero = np.zeros(len(self.cat))
         self.data = dict(cat=self.cat, width=self.width, width_cat=self.width_cat, zero=self.zero)


### PR DESCRIPTION
Fixes #1319 . Changed fixed bokeh.charts.Bar bars cat_width calculation to something proportional to the number of values in the chart. This seems to fix issue for more then 4 values that were overlapping due to the fixed 0.2 with value.
