### PR TITLE
fix "python setup.py build"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -316,7 +316,8 @@ if "sdist" in sys.argv:
 
 # check for package install, add "--install_js" to skip prompt
 if not exists(join(ROOT, 'MANIFEST.in')):
-    if "--install_js" not in sys.argv and "--build_js" not in sys.argv:
+    installing = any(arg in sys.argv for arg in ('install', 'develop', 'sdist', 'egg_info'))
+    if installing and "--install_js" not in sys.argv and "--build_js" not in sys.argv:
         print("Adding '--install_js' default for sdist package install")
         sys.argv.append('--install_js')
 


### PR DESCRIPTION
When running "build" the --install_js option got added, but in parse_jsargs an error got thrown, if not in 'install', 'develop', 'sdist', 'egg_info' mode. So build always produced an error. (ran across this while packaging bokey as rpm where the build and install are two separate steps).

Hope this fixes it, but perhaps there is a better way.
