### PR TITLE
Fix spectrogram issues

### DIFF
--- a/examples/embed/spectrogram/spectrogram.coffee
+++ b/examples/embed/spectrogram/spectrogram.coffee
@@ -66,7 +66,21 @@ class SpectrogramApp
         in_flight = false
         @on_data(data)
       )
-    setInterval(helper, 10)
+
+    @interval = Math.floor(1000.0/@config.FRAMES_PER_SECOND)
+
+    @thisTime = Date.now()
+    @lastTime = Date.now()
+
+    looper = () =>
+      @thisTime = Date.now()
+      @deltaTime = @thisTime - @lastTime
+      delay = Math.max(@interval - @deltaTime, 0)
+      timeout = setTimeout(looper, delay)
+      @lastTime = @thisTime + delay
+      helper()
+
+    setTimeout(looper, 0)
 
   on_data: (data) ->
     if _.keys(data).length == 0
@@ -144,7 +158,7 @@ class RadialHistogramPlot
     angle = 2*Math.PI/bins.length
     [inner, outer, start, end, alpha] = [[], [], [], [], []]
     for i in [0...bins.length]
-      range = [0...(Math.min(Math.ceil(bins[i]), 20))]
+      range = [0...(Math.min(Math.ceil(bins[i]), @config.EQ_CLAMP))]
       inner = inner.concat(j+2 for j in range)
       outer = outer.concat(j+2.95 for j in range)
       start = start.concat((i+0.05) * angle for j in range)
@@ -183,5 +197,7 @@ setup = () ->
   id = keys[0]
   app = new SpectrogramApp(index[id].model)
 
-timer = setInterval(setup, 200)
+timer = setInterval(setup, 100)
+
+
 

--- a/examples/embed/spectrogram/spectrogram.py
+++ b/examples/embed/spectrogram/spectrogram.py
@@ -61,14 +61,16 @@ def root():
 @app.route("/params")
 def params():
     return json.dumps({
-        "FREQ_SAMPLES" : FREQ_SAMPLES,
-        "MAX_FREQ" : MAX_FREQ,
-        "NGRAMS" : NGRAMS,
-        "NUM_SAMPLES" : NUM_SAMPLES,
-        "SAMPLING_RATE" : SAMPLING_RATE,
-        "SPECTROGRAM_LENGTH" : SPECTROGRAM_LENGTH,
-        "TILE_WIDTH" : TILE_WIDTH,
-        "TIMESLICE" : TIMESLICE,
+        "FREQ_SAMPLES": FREQ_SAMPLES,
+        "MAX_FREQ": MAX_FREQ,
+        "NGRAMS": NGRAMS,
+        "NUM_SAMPLES": NUM_SAMPLES,
+        "SAMPLING_RATE": SAMPLING_RATE,
+        "SPECTROGRAM_LENGTH": SPECTROGRAM_LENGTH,
+        "TILE_WIDTH": TILE_WIDTH,
+        "TIMESLICE": TIMESLICE,
+        "EQ_CLAMP": 20,
+        "FRAMES_PER_SECOND": 20
     })
 
 

--- a/examples/embed/spectrogram/static/js/spectrogram.js
+++ b/examples/embed/spectrogram/static/js/spectrogram.js
@@ -75,7 +75,7 @@
     };
 
     SpectrogramApp.prototype.request_data = function() {
-      var helper, in_flight,
+      var helper, in_flight, looper,
         _this = this;
       in_flight = false;
       helper = function() {
@@ -92,7 +92,19 @@
           return _this.on_data(data);
         });
       };
-      return setInterval(helper, 10);
+      this.interval = Math.floor(1000.0 / this.config.FRAMES_PER_SECOND);
+      this.thisTime = Date.now();
+      this.lastTime = Date.now();
+      looper = function() {
+        var delay, timeout;
+        _this.thisTime = Date.now();
+        _this.deltaTime = _this.thisTime - _this.lastTime;
+        delay = Math.max(_this.interval - _this.deltaTime, 0);
+        timeout = setTimeout(looper, delay);
+        _this.lastTime = _this.thisTime + delay;
+        return helper();
+      };
+      return setTimeout(looper, 0);
     };
 
     SpectrogramApp.prototype.on_data = function(data) {
@@ -230,7 +242,7 @@
       for (i = _i = 0, _ref1 = bins.length; 0 <= _ref1 ? _i < _ref1 : _i > _ref1; i = 0 <= _ref1 ? ++_i : --_i) {
         range = (function() {
           _results = [];
-          for (var _j = 0, _ref2 = Math.min(Math.ceil(bins[i]), 20); 0 <= _ref2 ? _j < _ref2 : _j > _ref2; 0 <= _ref2 ? _j++ : _j--){ _results.push(_j); }
+          for (var _j = 0, _ref2 = Math.min(Math.ceil(bins[i]), this.config.EQ_CLAMP); 0 <= _ref2 ? _j < _ref2 : _j > _ref2; 0 <= _ref2 ? _j++ : _j--){ _results.push(_j); }
           return _results;
         }).apply(this);
         inner = inner.concat((function() {
@@ -336,6 +348,6 @@
     return app = new SpectrogramApp(index[id].model);
   };
 
-  timer = setInterval(setup, 200);
+  timer = setInterval(setup, 100);
 
 }).call(this);


### PR DESCRIPTION
issues: fixes #1442 

Large amplitudes caused the spectrogram to "hiccup". This was due to the fact that the "radial graphic equalizer" generated a number of wedges proportional to the integrated power spectrum. For large amplitude audio events this could reach to the tens of thousands. Now clamping the the number of wedges to a reasonable value for visual presentation to avoid wasted computation.  
