### PR TITLE
Making line example work (has some API changed?)

### DIFF
--- a/examples/plotting/server/line.py
+++ b/examples/plotting/server/line.py
@@ -10,7 +10,7 @@ y = np.sin(x)
 
 output_server("line")
 
-p = figure(title="simple line example")
-p.line(x,y, color="#2222aa", line_width=2)
+figure(title="simple line example")
+line(x,y, color="#2222aa", line_width=2)
 
-show(p)
+show()


### PR DESCRIPTION
This code was giving:

```
In [6]: p = figure(title="simple line example")

In [7]: p.line(x,y, color="#2222aa", line_width=2)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-7-7c66b5d45f9d> in <module>()
----> 1 p.line(x,y, color="#2222aa", line_width=2)

AttributeError: 'NoneType' object has no attribute 'line'
```

Using:

```
In [1]: import bokeh
In [2]: bokeh.__version__
Out[2]: '0.6.1'
```

If I actually look what figure returns (in iPython):

```
figure?
Type:       function
String Form:<function figure at 0xacc802c>
File:       /usr/local/lib/python2.7/dist-packages/bokeh/plotting.py
Definition: figure(**kwargs)
Docstring:
Activate a new figure for plotting.

All subsequent plotting operations will affect the new figure.

This function accepts all plot style keyword parameters.

Returns:
    None
```

Is this file (and probably others) outdated in some way?
I'm trying to use bokeh for the first time (on a ubuntu 12.04 without using conda, just doing pip install of bokeh and the related needed libraries).
