### PR TITLE
Making animated demo work (API change?)

### DIFF
--- a/examples/plotting/server/animated.py
+++ b/examples/plotting/server/animated.py
@@ -6,7 +6,7 @@ import time
 from numpy import pi, cos, sin, linspace, roll, zeros_like
 
 from bokeh.plotting import *
-from bokeh.objects import GlyphRenderer
+from bokeh.objects import Glyph
 
 N = 50 + 1
 r_base = 8
@@ -21,9 +21,9 @@ cx = cy = zeros_like(rmin)
 
 output_server("animated")
 
-p = figure(x_range=[-11, 11], y_range=[-11, 11])
+figure(x_range=[-11, 11], y_range=[-11, 11])
 
-p.annular_wedge(
+annular_wedge(
     cx, cy, rmin, rmax, theta[:-1], theta[1:],
     inner_radius_units="data",
     outer_radius_units="data",
@@ -31,10 +31,10 @@ p.annular_wedge(
     line_color="black",
 )
 
-show(p)
+show()
 
-renderer = p.select(dict(type=GlyphRenderer))
-ds = renderer[0].data_source
+renderer = [r for r in curplot().renderers if isinstance(r, Glyph)][0]
+ds = renderer.data_source
 
 while True:
 


### PR DESCRIPTION
This code gave some errors when trying to execute it. Firstly the same as I reported here:

https://github.com/bokeh/bokeh/pull/1453

About figure returning `None`.

Then it seems `GlyphRenderer` is now `Glyph`.

And the method `select` was not found, so I took from some other example those lines to choose the renderer.  Other files affected by this:

```
bokeh/examples$ grep -r "select(dict" .
./plotting/notebook/random_walk.ipynb:      "renderer = p.select(dict(name=\"line_example\"))[0]\n",
./plotting/notebook/animated.ipynb:      "renderer = p.select(dict(name=\"aw\"))[0]\n",
./plotting/server/texas.py:hover = p.select(dict(type=HoverTool))
./plotting/server/scatter_selection.py:select_tool = p1.select(dict(type=BoxSelectTool))
./plotting/server/scatter_selection.py:select_tool = p2.select(dict(type=BoxSelectTool))
./plotting/server/hover.py:hover =p.select(dict(type=HoverTool))
./plotting/server/tap.py:tool = p.select(dict(type=TapTool))[0]
./plotting/file/periodic.py:hover = p.select(dict(type=HoverTool))
./plotting/file/les_mis.py:hover = p.select(dict(type=HoverTool))
./plotting/file/unemployment.py:hover = p.select(dict(type=HoverTool))
./plotting/file/texas.py:hover = p.select(dict(type=HoverTool))
./plotting/file/scatter_selection.py:select_tool = p1.select(dict(type=BoxSelectTool))
./plotting/file/scatter_selection.py:select_tool = p2.select(dict(type=BoxSelectTool))
./plotting/file/hover.py:hover =p.select(dict(type=HoverTool))
./plotting/file/tap.py:tool = p.select(dict(type=TapTool))[0]
```
