### PR TITLE
Fall back to "Circle" for unhandled matplotlib markers

### DIFF
--- a/bokeh/mpl.py
+++ b/bokeh/mpl.py
@@ -201,10 +201,14 @@ class BokehRenderer(Renderer):
             "D": Diamond,
             "*": Asterisk,
         }
-        if style['marker'] not in marker_map:
-            warnings.warn("Unable to handle marker: %s" % style['marker'])
-
-        marker = marker_map[style['marker']]()
+       
+        # Not all matplotlib markers are currently handled; fall back to Circle if we encounter an
+        # unhandled marker.  See http://matplotlib.org/api/markers_api.html for a list of markers.
+        try:
+            marker = marker_map[style['marker']]()
+        except KeyError:
+            warnings.warn("Unable to handle marker: %s; defaulting to Circle" % style['marker'])
+            marker = Circle()
         marker.x = self.source.add(x)
         marker.y = self.source.add(y)
         self.xdr.sources.append(self.source.columns(marker.x))


### PR DESCRIPTION
issues: fixes #1524 

Currently, bokeh throws a KeyError if a matplotlib marker not handled by mpl.py is used.  This change causes bokeh to instead fall back to the Circle marker, allowing matplotlib graphs to be visualized even if the chosen marker is not handled (albeit with a different marker shape).
