### PR TITLE
Use conda graphviz package.

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -37,6 +37,7 @@ requirements:
 test:
   requires:
     # docs
+    - graphviz
     - sphinx
     - pygments
     - sphinx-bootstrap-theme

--- a/scripts/travis_install
+++ b/scripts/travis_install
@@ -5,10 +5,6 @@ set -x # echo commands
 
 git fetch origin master
 
-sudo apt-get update # update listing because of graphviz, remove later
-
-sudo apt-get install -qq -y --force-yes graphviz
-
 MINICONDA="Miniconda-$MINICONDA_VERSION-Linux-x86_64"
 MINICONDA_URL="http://repo.continuum.io/miniconda/$MINICONDA.sh"
 


### PR DESCRIPTION
TravisCI is looking for http://security.ubuntu.com/ubuntu/pool/main/g/graphviz/graphviz_2.26.3-10ubuntu1.1_amd64.deb (which doesn't exist). 
It appears that graphviz was updated to graphviz_2.26.3-10ubuntu1.2_amd64.deb
Until the package index get update, let update for ourselves.
