### PR TITLE
Use the containerized TravisCI infrastructure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: python
 
 python:


### PR DESCRIPTION
As suggested by this article... http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/

I have seen build starting sooner and a some improvement in the total run time... but for a definitive answer, we need to run several builds to make a better comparison...

In any case, it seems something adding value with no risk so far... and it is a simple change we can go back if things get buggy in the new docker-based infrastructure....
