### PR TITLE
evaluate rbush spatial indexes lazily

### DIFF
--- a/bokehjs/src/coffee/renderer/glyph/annular_wedge.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/annular_wedge.coffee
@@ -13,12 +13,15 @@ define [
 
     _set_data: () ->
       @max_radius = _.max(@outer_radius)
-      @index = rbush()
+
+    _reindex: () ->
+      index = rbush()
       pts = []
       for i in [0...@x.length]
         if not isNaN(@x[i] + @y[i])
           pts.push([@x[i], @y[i], @x[i], @y[i], {'i': i}])
-      @index.load(pts)
+      index.load(pts)
+      return index
 
     _map_data: () ->
       [@sx, @sy] = @renderer.map_to_screen(@x, @glyph.x.units, @y, @glyph.y.units)
@@ -76,7 +79,7 @@ define [
         y0 = y - @max_radius
         y1 = y + @max_radius
 
-      candidates = (pt[4].i for pt in @index.search([x0, y0, x1, y1]))
+      candidates = (pt[4].i for pt in @index().search([x0, y0, x1, y1]))
 
       candidates2 = []
       if @outer_radius_units == "screen"

--- a/bokehjs/src/coffee/renderer/glyph/annular_wedge.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/annular_wedge.coffee
@@ -1,10 +1,9 @@
 define [
   "underscore",
-  "rbush",
   "common/mathutils",
   "renderer/properties",
   "./glyph",
-], (_, rbush, mathutils, Properties, Glyph) ->
+], (_, mathutils, Properties, Glyph) ->
 
   class AnnularWedgeView extends Glyph.View
 
@@ -15,13 +14,7 @@ define [
       @max_radius = _.max(@outer_radius)
 
     _reindex: () ->
-      index = rbush()
-      pts = []
-      for i in [0...@x.length]
-        if not isNaN(@x[i] + @y[i])
-          pts.push([@x[i], @y[i], @x[i], @y[i], {'i': i}])
-      index.load(pts)
-      return index
+      return @_generic_xy_reindex()
 
     _map_data: () ->
       [@sx, @sy] = @renderer.map_to_screen(@x, @glyph.x.units, @y, @glyph.y.units)

--- a/bokehjs/src/coffee/renderer/glyph/annulus.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/annulus.coffee
@@ -1,9 +1,8 @@
 define [
   "underscore",
-  "rbush",
   "renderer/properties",
   "./glyph",
-], (_, rbush, Properties, Glyph) ->
+], (_, Properties, Glyph) ->
 
   class AnnulusView extends Glyph.View
 
@@ -14,13 +13,7 @@ define [
       @max_radius = _.max(@outer_radius)
 
     _reindex: () ->
-      index = rbush()
-      pts = []
-      for i in [0...@x.length]
-        if not isNaN(@x[i] + @y[i])
-          pts.push([@x[i], @y[i], @x[i], @y[i], {'i': i}])
-      index.load(pts)
-      return index
+      return @_generic_xy_reindex()
 
     _map_data: () ->
       [@sx, @sy] = @renderer.map_to_screen(@x, @glyph.x.units, @y, @glyph.y.units)

--- a/bokehjs/src/coffee/renderer/glyph/annulus.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/annulus.coffee
@@ -12,12 +12,15 @@ define [
 
     _set_data: () ->
       @max_radius = _.max(@outer_radius)
-      @index = rbush()
+
+    _reindex: () ->
+      index = rbush()
       pts = []
       for i in [0...@x.length]
         if not isNaN(@x[i] + @y[i])
           pts.push([@x[i], @y[i], @x[i], @y[i], {'i': i}])
-      @index.load(pts)
+      index.load(pts)
+      return index
 
     _map_data: () ->
       [@sx, @sy] = @renderer.map_to_screen(@x, @glyph.x.units, @y, @glyph.y.units)
@@ -63,7 +66,7 @@ define [
         y0 = y - @max_radius
         y1 = y + @max_radius
 
-      candidates = (pt[4].i for pt in @index.search([x0, y0, x1, y1]))
+      candidates = (pt[4].i for pt in @index().search([x0, y0, x1, y1]))
 
       candidates2 = []
       if @outer_radius_units == "screen"

--- a/bokehjs/src/coffee/renderer/glyph/circle.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/circle.coffee
@@ -1,9 +1,8 @@
 define [
   "underscore",
-  "rbush",
   "renderer/properties",
   "./glyph",
-], (_, rbush, Properties, Glyph) ->
+], (_, Properties, Glyph) ->
 
   point_in_poly = (x, y, px, py) ->
     inside = false
@@ -42,13 +41,7 @@ define [
         @max_radius = _.max(@radius)
 
     _reindex: () ->
-      index = rbush()
-      pts = []
-      for i in [0...@x.length]
-        if not isNaN(@x[i] + @y[i])
-          pts.push([@x[i], @y[i], @x[i], @y[i], {'i': i}])
-      index.load(pts)
-      return index
+      return @_generic_xy_reindex()
 
     _map_data: () ->
       [@sx, @sy] = @renderer.map_to_screen(@x, @glyph.x.units, @y, @glyph.y.units)

--- a/bokehjs/src/coffee/renderer/glyph/circle.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/circle.coffee
@@ -40,12 +40,15 @@ define [
         @max_radius = _.max(@size)/2
       else
         @max_radius = _.max(@radius)
-      @index = rbush()
+
+    _reindex: () ->
+      index = rbush()
       pts = []
       for i in [0...@x.length]
         if not isNaN(@x[i] + @y[i])
           pts.push([@x[i], @y[i], @x[i], @y[i], {'i': i}])
-      @index.load(pts)
+      index.load(pts)
+      return index
 
     _map_data: () ->
       [@sx, @sy] = @renderer.map_to_screen(@x, @glyph.x.units, @y, @glyph.y.units)
@@ -81,7 +84,7 @@ define [
         y0 -= @max_radius
         y1 += @max_radius
 
-      return (x[4].i for x in @index.search([x0, y0, x1, y1]))
+      return (x[4].i for x in @index().search([x0, y0, x1, y1]))
 
     _render: (ctx, indices, sx=@sx, sy=@sy, radius=@radius) ->
       for i in indices
@@ -120,7 +123,7 @@ define [
         y0 = y - @max_radius
         y1 = y + @max_radius
 
-      candidates = (pt[4].i for pt in @index.search([x0, y0, x1, y1]))
+      candidates = (pt[4].i for pt in @index().search([x0, y0, x1, y1]))
 
       hits = []
       if @radius_units == "screen"
@@ -151,7 +154,7 @@ define [
       [x0, x1] = @renderer.xmapper.v_map_from_target([geometry.vx0, geometry.vx1])
       [y0, y1] = @renderer.ymapper.v_map_from_target([geometry.vy0, geometry.vy1])
 
-      return (x[4].i for x in @index.search([x0, y0, x1, y1]))
+      return (x[4].i for x in @index().search([x0, y0, x1, y1]))
 
     _hit_poly: (geometry) ->
       [vx, vy] = [_.clone(geometry.vx), _.clone(geometry.vy)]

--- a/bokehjs/src/coffee/renderer/glyph/glyph.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/glyph.coffee
@@ -61,11 +61,21 @@ define [
 
       @_set_data()
 
+      @_need_reindex = true
+
       # just use the length of the last added field
       [0...@[field].length]
 
     # any additional customization can happen here
     _set_data: () -> null
+
+    index: () ->
+      if @_need_reindex
+        @_index = @_reindex()
+        @_need_reindex = false
+      return @_index
+
+    _reindex: () -> null
 
     distance_vector: (pt, span_prop_name, position, dilate=false) ->
       """ returns an array """

--- a/bokehjs/src/coffee/renderer/glyph/glyph.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/glyph.coffee
@@ -1,11 +1,12 @@
 define [
   "underscore",
+  "rbush",
   "common/logging",
   "common/has_parent",
   "common/collection"
   "common/continuum_view",
   "renderer/properties"
-], (_, Logging, HasParent, Collection, ContinuumView, properties) ->
+], (_, rbush, Logging, HasParent, Collection, ContinuumView, properties) ->
 
   logger = Logging.logger
 
@@ -188,6 +189,15 @@ define [
         ctx.rect(sx0, sy0, sx1-sx0, sy1-sy0)
         @props.line.set_vectorize(ctx, reference_point)
         ctx.stroke()
+
+    _generic_xy_reindex: () ->
+      index = rbush()
+      pts = []
+      for i in [0...@x.length]
+        if not isNaN(@x[i] + @y[i])
+          pts.push([@x[i], @y[i], @x[i], @y[i], {'i': i}])
+      index.load(pts)
+      return index
 
   class Glyph extends HasParent
 

--- a/bokehjs/src/coffee/renderer/glyph/marker/marker.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/marker/marker.coffee
@@ -1,8 +1,7 @@
 define [
   "underscore",
-  "rbush",
   "../glyph",
-], (_, rbush, Glyph) ->
+], (_, Glyph) ->
 
 
   point_in_poly = (x, y, px, py) ->
@@ -45,13 +44,7 @@ define [
       @max_size = _.max(@size)
 
     _reindex: () ->
-      index = rbush()
-      pts = []
-      for i in [0...@x.length]
-        if not isNaN(@x[i] + @y[i])
-          pts.push([@x[i], @y[i], @x[i], @y[i], {'i': i}])
-      index.load(pts)
-      return index
+      return @_generic_xy_reindex()
 
     _map_data: () ->
       [@sx, @sy] = @renderer.map_to_screen(@x, @glyph.x.units, @y, @glyph.y.units)

--- a/bokehjs/src/coffee/renderer/glyph/marker/marker.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/marker/marker.coffee
@@ -43,12 +43,15 @@ define [
 
     _set_data: () ->
       @max_size = _.max(@size)
-      @index = rbush()
+
+    _reindex: () ->
+      index = rbush()
       pts = []
       for i in [0...@x.length]
         if not isNaN(@x[i] + @y[i])
           pts.push([@x[i], @y[i], @x[i], @y[i], {'i': i}])
-      @index.load(pts)
+      index.load(pts)
+      return index
 
     _map_data: () ->
       [@sx, @sy] = @renderer.map_to_screen(@x, @glyph.x.units, @y, @glyph.y.units)
@@ -66,7 +69,7 @@ define [
       vy1 = vr.get('end') + @max_size
       [y0, y1] = @renderer.ymapper.v_map_from_target([vy0, vy1])
 
-      return (x[4].i for x in @index.search([x0, y0, x1, y1]))
+      return (x[4].i for x in @index().search([x0, y0, x1, y1]))
 
     _hit_point: (geometry) ->
       [vx, vy] = [geometry.vx, geometry.vy]
@@ -81,7 +84,7 @@ define [
       vy1 = vy + @max_size
       [y0, y1] = @renderer.ymapper.v_map_from_target([vy0, vy1])
 
-      candidates = (x[4].i for x in @index.search([x0, y0, x1, y1]))
+      candidates = (x[4].i for x in @index().search([x0, y0, x1, y1]))
 
       hits = []
       for i in candidates
@@ -99,7 +102,7 @@ define [
       [x0, x1] = @renderer.xmapper.v_map_from_target([geometry.vx0, geometry.vx1])
       [y0, y1] = @renderer.ymapper.v_map_from_target([geometry.vy0, geometry.vy1])
 
-      return (x[4].i for x in @index.search([x0, y0, x1, y1]))
+      return (x[4].i for x in @index().search([x0, y0, x1, y1]))
 
     _hit_poly: (geometry) ->
       [vx, vy] = [geometry.vx, geometry.vy]

--- a/bokehjs/src/coffee/renderer/glyph/patches.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/patches.coffee
@@ -30,7 +30,9 @@ define [
 
     _set_data: () ->
       @max_size = _.max(@size)
-      @index = rbush()
+
+    _reindex: () ->
+      index = rbush()
       pts = []
       for i in [0...@xs.length]
         xs = (x for x in @xs[i] when not _.isNaN(x))
@@ -42,7 +44,8 @@ define [
           _.max(xs), _.max(ys),
           {'i': i}
         ])
-      @index.load(pts)
+      index.load(pts)
+      return index
 
     _map_data: () ->
       @sxs = []
@@ -63,7 +66,7 @@ define [
       yr = @renderer.plot_view.y_range
       [y0, y1] = [yr.get('start'), yr.get('end')]
 
-      return (x[4].i for x in @index.search([x0, y0, x1, y1]))
+      return (x[4].i for x in @index().search([x0, y0, x1, y1]))
 
     _render: (ctx, indices) ->
       for i in indices
@@ -115,7 +118,7 @@ define [
       x = @renderer.xmapper.map_from_target(vx)
       y = @renderer.ymapper.map_from_target(vy)
 
-      candidates = (x[4].i for x in @index.search([x, y, x, y]))
+      candidates = (x[4].i for x in @index().search([x, y, x, y]))
 
       hits = []
       for i in [0...candidates.length]

--- a/bokehjs/src/coffee/renderer/glyph/rect.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/rect.coffee
@@ -1,9 +1,8 @@
 define [
   "underscore",
-  "rbush",
   "renderer/properties",
   "./glyph",
-], (_, rbush, Properties, Glyph) ->
+], (_, Properties, Glyph) ->
 
   class RectView extends Glyph.View
 
@@ -30,13 +29,7 @@ define [
       @max_height = _.max(@height)
 
     _reindex: () ->
-      index = rbush()
-      pts = []
-      for i in [0...@x.length]
-        if not isNaN(@x[i] + @y[i])
-          pts.push([@x[i], @y[i], @x[i], @y[i], {'i': i}])
-      index.load(pts)
-      return index
+      return @_generic_xy_reindex()
 
     _render: (ctx, indices, sx=@sx, sy=@sy, sw=@sw, sh=@sh) ->
       if @props.fill.do_fill

--- a/bokehjs/src/coffee/renderer/glyph/rect.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/rect.coffee
@@ -29,13 +29,14 @@ define [
       @max_width = _.max(@width)
       @max_height = _.max(@height)
 
-    _set_data: () ->
-      @index = rbush()
+    _reindex: () ->
+      index = rbush()
       pts = []
       for i in [0...@x.length]
         if not isNaN(@x[i] + @y[i])
           pts.push([@x[i], @y[i], @x[i], @y[i], {'i': i}])
-      @index.load(pts)
+      index.load(pts)
+      return index
 
     _render: (ctx, indices, sx=@sx, sy=@sy, sw=@sw, sh=@sh) ->
       if @props.fill.do_fill
@@ -88,7 +89,7 @@ define [
       [x0, x1] = @renderer.xmapper.v_map_from_target([geometry.vx0, geometry.vx1])
       [y0, y1] = @renderer.ymapper.v_map_from_target([geometry.vy0, geometry.vy1])
 
-      return (x[4].i for x in @index.search([x0, y0, x1, y1]))
+      return (x[4].i for x in @index().search([x0, y0, x1, y1]))
 
     _hit_point: (geometry) ->
       [vx, vy] = [geometry.vx, geometry.vy]
@@ -127,7 +128,7 @@ define [
           y0 = y - 2*@max_height
           y1 = y + 2*@max_height
 
-        candidates = (pt[4].i for pt in @index.search([x0, y0, x1, y1]))
+        candidates = (pt[4].i for pt in @index().search([x0, y0, x1, y1]))
 
       hits = []
       for i in candidates

--- a/bokehjs/src/coffee/renderer/glyph/wedge.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/wedge.coffee
@@ -13,12 +13,15 @@ define [
 
     _set_data: () ->
       @max_radius = _.max(@radius)
-      @index = rbush()
+
+    _reindex: () ->
+      index = rbush()
       pts = []
       for i in [0...@x.length]
         if not isNaN(@x[i] + @y[i])
           pts.push([@x[i], @y[i], @x[i], @y[i], {'i': i}])
-      @index.load(pts)
+      index.load(pts)
+      return index
 
     _map_data: () ->
       [@sx, @sy] = @renderer.map_to_screen(@x, @glyph.x.units, @y, @glyph.y.units)
@@ -63,7 +66,7 @@ define [
         y0 = y - @max_radius
         y1 = y + @max_radius
 
-      candidates = (pt[4].i for pt in @index.search([x0, y0, x1, y1]))
+      candidates = (pt[4].i for pt in @index().search([x0, y0, x1, y1]))
 
       candidates2 = []
       if @radius_units == "screen"

--- a/bokehjs/src/coffee/renderer/glyph/wedge.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/wedge.coffee
@@ -1,10 +1,9 @@
 define [
   "underscore",
-  "rbush",
   "common/mathutils",
   "renderer/properties",
   "./glyph",
-], (_, rbush, mathutils, Properties, Glyph) ->
+], (_, mathutils, Properties, Glyph) ->
 
   class WedgeView extends Glyph.View
 
@@ -15,13 +14,7 @@ define [
       @max_radius = _.max(@radius)
 
     _reindex: () ->
-      index = rbush()
-      pts = []
-      for i in [0...@x.length]
-        if not isNaN(@x[i] + @y[i])
-          pts.push([@x[i], @y[i], @x[i], @y[i], {'i': i}])
-      index.load(pts)
-      return index
+      return @_generic_xy_reindex()
 
     _map_data: () ->
       [@sx, @sy] = @renderer.map_to_screen(@x, @glyph.x.units, @y, @glyph.y.units)


### PR DESCRIPTION
issues: closes #1542 

Performance seems to be OK just evaluating lazily all the time. Can add tool hinting for pre-indexing later if necessary. 

Update: I'm no longer convinced this actually addresses the issue in #1542 (more investigation needed) but lazy eval of indices is probably a reasonable thing to do in any case. 