### PR TITLE
allow log tickers to use base, etc.

### DIFF
--- a/bokeh/models/axes.py
+++ b/bokeh/models/axes.py
@@ -52,7 +52,7 @@ class LogAxis(ContinuousAxis):
         if ticker is None:
             ticker = LogTicker(num_minor_ticks=10)
         if formatter is None:
-            formatter = LogTickFormatter()
+            formatter = LogTickFormatter(ticker=ticker)
         super(LogAxis, self).__init__(ticker=ticker, formatter=formatter, **kwargs)
 
 class CategoricalAxis(Axis):

--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 
+from .tickers import Ticker
 from ..plot_object import PlotObject
-from ..properties import Bool, Int, String, Enum, Auto, List, Dict, Either
+from ..properties import Bool, Int, String, Enum, Auto, List, Dict, Either, Instance
 from ..enums import DatetimeUnits
 
 class TickFormatter(PlotObject):
@@ -30,7 +31,7 @@ class LogTickFormatter(TickFormatter):
     Often useful in conjuction with a `LogTicker`
 
     """
-    pass
+    ticker = Instance(Ticker)
 
 class CategoricalTickFormatter(TickFormatter):
     """ Format ticks as categories from categorical ranges"""

--- a/bokeh/models/tickers.py
+++ b/bokeh/models/tickers.py
@@ -51,7 +51,7 @@ class SingleIntervalTicker(Ticker):
     """
     interval = Float
 
-class DaysTicker(Ticker):
+class DaysTicker(SingleIntervalTicker):
     """ Generate ticks spaced apart by specific, even multiples of days.
 
     Attributes:
@@ -60,7 +60,7 @@ class DaysTicker(Ticker):
     """
     days = List(Int)
 
-class MonthsTicker(Ticker):
+class MonthsTicker(SingleIntervalTicker):
     """ Generate ticks spaced apart by specific, even multiples of months.
 
     Attributes:
@@ -69,15 +69,15 @@ class MonthsTicker(Ticker):
     """
     months = List(Int)
 
-class YearsTicker(Ticker):
+class YearsTicker(SingleIntervalTicker):
     """ Generate ticks spaced even numbers of years apart. """
     pass
 
-class BasicTicker(Ticker):
+class BasicTicker(AdaptiveTicker):
     """ Generate ticks on a linear scale. """
     pass
 
-class LogTicker(Ticker):
+class LogTicker(AdaptiveTicker):
     """ Generate ticks on a log scale. """
     pass
 
@@ -85,6 +85,6 @@ class CategoricalTicker(Ticker):
     """ Generate ticks for categorical ranges. """
     pass
 
-class DatetimeTicker(Ticker):
+class DatetimeTicker(CompositeTicker):
     """ Generate nice ticks across different date and time scales. """
     pass

--- a/bokeh/models/tickers.py
+++ b/bokeh/models/tickers.py
@@ -85,6 +85,6 @@ class CategoricalTicker(Ticker):
     """ Generate ticks for categorical ranges. """
     pass
 
-class DatetimeTicker(CompositeTicker):
+class DatetimeTicker(Ticker):
     """ Generate nice ticks across different date and time scales. """
     pass

--- a/bokehjs/src/coffee/ticking/log_tick_formatter.coffee
+++ b/bokehjs/src/coffee/ticking/log_tick_formatter.coffee
@@ -3,8 +3,11 @@ define [
   "underscore",
   "common/collection",
   "common/has_properties",
+  "common/logging",
   "ticking/basic_tick_formatter"
-], (_, Collection, HasProperties, BasicTickFormatter) ->
+], (_, Collection, HasProperties, Logging, BasicTickFormatter) ->
+
+  logger = Logging.logger
 
   class LogTickFormatter extends HasProperties
     type: 'LogTickFormatter'
@@ -12,15 +15,22 @@ define [
     initialize: (attrs, options) ->
       super(attrs, options)
       @basic_formatter = new BasicTickFormatter.Model()
+      if not @get('ticker')?
+        logger.warn("LogTickFormatter not configured with a ticker, using default base of 10 (labels will be incorrect if ticker base is not 10)")
 
     format: (ticks) ->
       if ticks.length == 0
         return []
 
+      if @get('ticker')?
+        base = @get('ticker').get('base')
+      else
+        base = 10
+
       small_interval = false
       labels = new Array(ticks.length)
       for i in [0...ticks.length]
-        labels[i] = "10^#{ Math.round(Math.log(ticks[i]) / Math.log(10)) }"
+        labels[i] = "#{base}^#{ Math.round(Math.log(ticks[i]) / Math.log(base)) }"
         if (i > 0) and (labels[i] == labels[i-1])
           small_interval = true
           break

--- a/bokehjs/src/coffee/ticking/log_ticker.coffee
+++ b/bokehjs/src/coffee/ticking/log_ticker.coffee
@@ -37,8 +37,10 @@ define [
       if data_low > data_high
         [data_low, data_high] = [data_high, data_low]
 
-      log_low = Math.log(data_low) / Math.log(10)
-      log_high = Math.log(data_high) / Math.log(10)
+      base = @get('base')
+
+      log_low = Math.log(data_low) / Math.log(base)
+      log_high = Math.log(data_high) / Math.log(base)
       log_interval = log_high - log_low
 
       if log_interval < 2
@@ -71,10 +73,10 @@ define [
         if (endlog - startlog) % interval == 0
           ticks = ticks.concat [endlog]
 
-        ticks = ticks.map (i) -> Math.pow(10, i)
+        ticks = ticks.map (i) -> Math.pow(base, i)
 
         if num_minor_ticks > 1
-          minor_interval = Math.pow(10, interval) / num_minor_ticks
+          minor_interval = Math.pow(base, interval) / num_minor_ticks
           minor_offsets = (i*minor_interval for i in [1..num_minor_ticks])
           for x in minor_offsets
             minor_ticks.push(ticks[0] / x)


### PR DESCRIPTION
issues: closes #1590 

This was a little more involved. To get the properties correct on the python side, make tickers follow JS inheritance hierarchy properly. However, log axes had hard coded 10 as a base. Plumbed up ticker and formatter on JS side to properly use and display ticks for bases other than 10. Requires that `LogTickFormatters` be configured with a corresponding `LogTicker` (otherwise they default to `base=10` and warn in the console). 