### PR TITLE
Don't request_render() twice during plot initialization

### DIFF
--- a/bokehjs/src/coffee/common/plot.coffee
+++ b/bokehjs/src/coffee/common/plot.coffee
@@ -102,7 +102,6 @@ define [
         })
 
       @unpause()
-      @request_render()
 
       logger.debug("PlotView initialized")
 


### PR DESCRIPTION
This is the first commit of PR #1543.