### PR TITLE
Pin scipy

### DIFF
--- a/scripts/travis_install
+++ b/scripts/travis_install
@@ -14,6 +14,12 @@ rm -rf $MINICONDA.sh
 
 python -V
 
+PINNED_PKGS=$(cat <<EOF
+scipy <0.15.0
+EOF
+)
+echo -e "$PINNED_PKGS" > /home/travis/miniconda/conda-meta/pinned
+
 DEPS_TRAVIS="python=$TRAVIS_PYTHON_VERSION conda-build jinja2"
 conda install --yes $DEPS_TRAVIS
 


### PR DESCRIPTION
Pin scipy to avoid failure with ggplot/statsmodels until statsmodels release the fix (https://github.com/statsmodels/statsmodels/pull/2160).

