### PR TITLE
In the timeseries tutorial, formatting the X-axis as dates

### DIFF
--- a/sphinx/source/tutorial/exercises/stocks.py
+++ b/sphinx/source/tutorial/exercises/stocks.py
@@ -21,7 +21,13 @@ IBM = pd.read_csv(
 output_file("stocks.html", title="stocks.py example")
 
 # create a figure
-p1 = figure(title="Stocks")
+p1 = figure(title="Stocks",
+            x_axis_label="Date",
+            y_axis_label="Close price",
+            x_axis_type="datetime")
+p1.below[0].formatter.formats = dict(years=['%Y'],
+                                     months=['%b %Y'],
+                                     days=['%d %b %Y'])
 
 # EXERCISE: finish this line plot, and add more for the other stocks. Each one should
 # have a legend, and its own color.

--- a/sphinx/source/tutorial/solutions/stocks.py
+++ b/sphinx/source/tutorial/solutions/stocks.py
@@ -21,7 +21,13 @@ IBM = pd.read_csv(
 output_file("stocks.html", title="stocks.py example")
 
 # create a figure
-p1 = figure(title="Stocks")
+p1 = figure(title="Stocks",
+            x_axis_label="Date",
+            y_axis_label="Close price",
+            x_axis_type="datetime")
+p1.below[0].formatter.formats = dict(years=['%Y'],
+                                     months=['%b %Y'],
+                                     days=['%d %b %Y'])
 
 # EXERCISE: finish this line plot, and add more for the other stocks. Each one should
 # have a legend, and its own color.
@@ -39,7 +45,13 @@ p1.title = "Stock Closing Prices"
 p1.grid.grid_line_alpha=0.3
 
 # EXERCISE: start a new figure
-p2 = figure(title="AAPL average")
+p2 = figure(title="AAPL average",
+            x_axis_label="Date",
+            y_axis_label="Close price",
+            x_axis_type="datetime")
+p2.below[0].formatter.formats = dict(years=['%Y'],
+                                     months=['%b %Y'],
+                                     days=['%d %b %Y'])
 
 # Here is some code to compute the 30-day moving average for AAPL
 aapl = AAPL['Adj Close']

--- a/sphinx/source/tutorial/topical.rst
+++ b/sphinx/source/tutorial/topical.rst
@@ -18,7 +18,7 @@ ticks on datetime axes. Here we will plot some stock data taken from the `Yahoo 
 .. literalinclude:: exercises/stocks.py
    :language: python
    :linenos:
-   :emphasize-lines: 29,30,38,40,50,51,53,55
+   :emphasize-lines: 32,33,41,43,53,54,56,58
 
 See the :doc:`solutions/gallery/stocks`.
 


### PR DESCRIPTION
Pull requests with the fixes suggested in #1728. In the timeseries tutorial:

- Displaying the X-axis values as dates (not the numerical representation of the date)
- Customizing the format of the dates
- Naming the axis