### PR TITLE
Make sure sys is available for sys.exit() call on failure

### DIFF
--- a/scripts/get_bump_version.py
+++ b/scripts/get_bump_version.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import subprocess
+import sys
 
 def get_version_from_git():
     cmd = ["git", "describe", "--tags", "--always"]


### PR DESCRIPTION
Ideally this doesn't fail, but at least this allows it to fail the way it's intended to. :-)