### PR TITLE
effectively dilate canvas by 1px

### DIFF
--- a/bokehjs/src/coffee/common/canvas.coffee
+++ b/bokehjs/src/coffee/common/canvas.coffee
@@ -135,7 +135,8 @@ define [
       return x
 
     vy_to_sy: (y) ->
-      return @get('height') - y
+      # Note: +1 to account for 1px canvas dilation
+      return @get('height') - (y + 1)
 
     # vectorized versions of vx_to_sx/vy_to_sy, these are mutating, in-place operations
     v_vx_to_sx: (xx) ->
@@ -145,8 +146,9 @@ define [
 
     v_vy_to_sy: (yy) ->
       canvas_height = @get('height')
+      # Note: +1 to account for 1px canvas dilation
       for y, idx in yy
-        yy[idx] = canvas_height - y
+        yy[idx] = canvas_height - (y + 1)
       return yy
 
     # transform underlying screen coordinates to view coordinates
@@ -154,7 +156,8 @@ define [
       return x
 
     sy_to_vy: (y) ->
-      return @get('height') - y
+      # Note: +1 to account for 1px canvas dilation
+      return @get('height') - (y + 1)
 
     # vectorized versions of sx_to_vx/sy_to_vy, these are mutating, in-place operations
     v_sx_to_vx: (xx) ->
@@ -164,8 +167,9 @@ define [
 
     v_sy_to_vy: (yy) ->
       canvas_height = @get('height')
+      # Note: +1 to account for 1px canvas dilation
       for y, idx in yy
-        yy[idx] = canvas_height - y
+        yy[idx] = canvas_height - (y + 1)
       return yy
 
     _set_width: (width, update=true) ->

--- a/bokehjs/src/coffee/common/plot.coffee
+++ b/bokehjs/src/coffee/common/plot.coffee
@@ -201,8 +201,9 @@ define [
         if th != @model.title_panel.get('height')
           @model.title_panel.set('height', th)
 
-      @model.get('frame').set('width', canvas.get('width'))
-      @model.get('frame').set('height', canvas.get('height'))
+      # Note: -1 to effectively dilate the canvas by 1px
+      @model.get('frame').set('width', canvas.get('width')-1)
+      @model.get('frame').set('height', canvas.get('height')-1)
 
       @canvas.solver.update_variables(false)
 

--- a/examples/plotting/file/burtin.py
+++ b/examples/plotting/file/burtin.py
@@ -67,7 +67,7 @@ output_file("burtin.html", title="burtin.py example")
 p = figure(plot_width=width, plot_height=height, title="",
     x_axis_type=None, y_axis_type=None,
     x_range=[-420, 420], y_range=[-420, 420],
-    min_border=0, outline_line_color=None,
+    min_border=0, outline_line_color="black",
     background_fill="#f0e1d2", border_fill="#f0e1d2")
 
 p.line(x+1, y+1, alpha=0)

--- a/examples/plotting/notebook/burtin.ipynb
+++ b/examples/plotting/notebook/burtin.ipynb
@@ -157,7 +157,7 @@
       "p = figure(plot_width=width, plot_height=height, title=\"\",\n",
       "           x_axis_type=None, y_axis_type=None,\n",
       "           x_range=[-420, 420], y_range=[-420, 420],\n",
-      "           min_border=0, outline_line_color=None,\n",
+      "           min_border=0, outline_line_color=\"black\",\n",
       "           background_fill=\"#f0e1d2\", border_fill=\"#f0e1d2\")"
      ],
      "language": "python",

--- a/examples/plotting/server/burtin.py
+++ b/examples/plotting/server/burtin.py
@@ -70,7 +70,7 @@ output_server("burtin")
 p = figure(plot_width=width, plot_height=height, title="",
     x_axis_type=None, y_axis_type=None,
     x_range=[-420, 420], y_range=[-420, 420],
-    min_border=0, outline_line_color=None,
+    min_border=0, outline_line_color="black",
     background_fill="#f0e1d2", border_fill="#f0e1d2")
 
 p.line(x+1, y+1, alpha=0)


### PR DESCRIPTION
issues: fixes #165 

Fix is actually to reduce the cartesian_frames width/height by 1, and keep canvas size exactly set to what the user specifies. 

Not entirely happy about this fix, there is an asymmetry --- canvas frame is reduced in `plot.coffee` but fixup for view/screen transform happens in `canvas.coffee`. But this is due to a poor separation of concerns and I would rather address that in a larger PR that cleans up some of the layout code. 