### PR TITLE
Task/remove bokeh js

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,15 @@ global-exclude .git*
 include LICENSE.txt
 include versioneer.py
 recursive-include examples *.py *.ipynb *.md
-graft bokehjs
-prune bokehjs/node_modules
-prune examples/plotting/notebook/.ipynb_checkpoints
+prune examples/charts/.ipynb_checkpoints
+prune examples/compat/mpl/.ipynb_checkpoints
 prune examples/glyphs/.ipynb_checkpoints
+prune examples/plotting/notebook/.ipynb_checkpoints
+prune examples/charts/*.html
+prune examples/compat/ggplot/*.html
+prune examples/compat/mpl/*.html
+prune examples/compat/pandas/*.html
+prune examples/compat/seaborn/*.html
+prune examples/embed/*.html
+prune examples/glyphs/*.html
+prune examples/plotting/file/*.html

--- a/setup.py
+++ b/setup.py
@@ -224,7 +224,7 @@ Have you run `npm install` from the bokehjs subdirectory?
         os.chdir('..')
 
     if proc.wait() != 0:
-        print("ERROR: could not build bokehjs")
+        print("ERROR: could not build BokehJS")
         sys.exit(1)
 
 def install_js():
@@ -273,7 +273,8 @@ build process. How would you like to handle BokehJS:
     return mapping[value]
 
 def parse_jsargs():
-    installing = any(arg in sys.argv for arg in ('install', 'develop', 'sdist', 'egg_info'))
+    options = ('install', 'develop', 'sdist', 'egg_info', 'build')
+    installing = any(arg in sys.argv for arg in options)
 
     if '--build_js' in sys.argv:
         if not installing:
@@ -318,7 +319,7 @@ if "sdist" in sys.argv:
 # check for package install, set jsinstall to False to skip prompt
 jsinstall = True
 if not exists(join(ROOT, 'MANIFEST.in')):
-    options = ('install', 'develop', 'sdist', 'egg_info', 'clean', '--help')
+    options = ('install', 'develop', 'sdist', 'egg_info', 'build', 'clean', '--help')
     installing = any(arg in sys.argv for arg in options)
     if installing:
         print("Avoid building or installing JS when BokehJS is not available")
@@ -363,9 +364,9 @@ if 'develop' in sys.argv:
     print("Installing Bokeh for development:")
     print("  - writing path '%s' to %s" % (path, path_file))
     if jsinstall:
-        print("  - using %s built bokehjs from bokehjs/build\n" % ("NEWLY" if jsbuild else "PREVIOUSLY"))
+        print("  - using %s built BokehJS from bokehjs/build\n" % ("NEWLY" if jsbuild else "PREVIOUSLY"))
     else:
-        print("  - using 'PACKAGED' built bokehjs\n")
+        print("  - using 'PACKAGED' built BokehJS\n")
     sys.exit()
 
 elif 'clean' in sys.argv:
@@ -377,9 +378,9 @@ elif 'install' in sys.argv:
     if pth_removed:
         print("  - removed path file at %s" % path_file)
     if jsinstall:
-        print("  - using %s built bokehjs from bokehjs/build\n" % ("NEWLY" if jsbuild else "PREVIOUSLY"))
+        print("  - using %s built BokehJS from bokehjs/build\n" % ("NEWLY" if jsbuild else "PREVIOUSLY"))
     else:
-        print("  - using 'PACKAGED' built bokehjs\n")
+        print("  - using 'PACKAGED' built BokehJS\n")
 
 elif '--help' in sys.argv:
     if jsinstall:
@@ -387,7 +388,7 @@ elif '--help' in sys.argv:
         print("  --build_js          build and install a fresh BokehJS")
         print("  --install_js        install only last previously built BokehJS")
     else:
-        print("Bokeh using 'PACKAGED' built bokehjs\n")
+        print("Bokeh using 'PACKAGED' built BokehJS\n")
 
 print()
 

--- a/setup.py
+++ b/setup.py
@@ -322,7 +322,10 @@ if not exists(join(ROOT, 'MANIFEST.in')):
     options = ('install', 'develop', 'sdist', 'egg_info', 'build', 'clean', '--help')
     installing = any(arg in sys.argv for arg in options)
     if installing:
-        print("Avoid building or installing JS when BokehJS is not available")
+        print("BokehJS source code is not shipped in sdist packages; "
+              "building/installing from the bokehjs source directory is disabled. "
+              "To build or develop BokehJS yourself, you must clone the full "
+              "Bokeh repository from https://github.com/bokeh/bokeh")
         if "--build_js"  in sys.argv:
             sys.argv.remove('--build_js')
         if "--install_js"  in sys.argv: 
@@ -366,7 +369,7 @@ if 'develop' in sys.argv:
     if jsinstall:
         print("  - using %s built BokehJS from bokehjs/build\n" % ("NEWLY" if jsbuild else "PREVIOUSLY"))
     else:
-        print("  - using 'PACKAGED' built BokehJS\n")
+        print("  - using PACKAGED BokehJS, located in 'bokeh.server.static'\n")
     sys.exit()
 
 elif 'clean' in sys.argv:
@@ -380,7 +383,7 @@ elif 'install' in sys.argv:
     if jsinstall:
         print("  - using %s built BokehJS from bokehjs/build\n" % ("NEWLY" if jsbuild else "PREVIOUSLY"))
     else:
-        print("  - using 'PACKAGED' built BokehJS\n")
+        print("  - using PACKAGED BokehJS, located in 'bokeh.server.static'\n")
 
 elif '--help' in sys.argv:
     if jsinstall:
@@ -388,7 +391,7 @@ elif '--help' in sys.argv:
         print("  --build_js          build and install a fresh BokehJS")
         print("  --install_js        install only last previously built BokehJS")
     else:
-        print("Bokeh using 'PACKAGED' built BokehJS\n")
+        print("Bokeh is using PACKAGED BokehJS, located in 'bokeh.server.static'\n")
 
 print()
 

--- a/setup.py
+++ b/setup.py
@@ -318,7 +318,8 @@ if "sdist" in sys.argv:
 # check for package install, set jsinstall to False to skip prompt
 jsinstall = True
 if not exists(join(ROOT, 'MANIFEST.in')):
-    installing = any(arg in sys.argv for arg in ('install', 'develop', 'sdist', 'egg_info'))
+    options = ('install', 'develop', 'sdist', 'egg_info', 'clean', '--help')
+    installing = any(arg in sys.argv for arg in options)
     if installing:
         print("Avoid building or installing JS when BokehJS is not available")
         if "--build_js"  in sys.argv:
@@ -381,9 +382,12 @@ elif 'install' in sys.argv:
         print("  - using 'PACKAGED' built bokehjs\n")
 
 elif '--help' in sys.argv:
-    print("Bokeh-specific options available with 'install' or 'develop':\n")
-    print("  --build_js          build and install a fresh BokehJS")
-    print("  --install_js        install only last previously built BokehJS")
+    if jsinstall:
+        print("Bokeh-specific options available with 'install' or 'develop':\n")
+        print("  --build_js          build and install a fresh BokehJS")
+        print("  --install_js        install only last previously built BokehJS")
+    else:
+        print("Bokeh using 'PACKAGED' built bokehjs\n")
 
 print()
 


### PR DESCRIPTION
We are shipping the BokehJS source inside our tar.gz packages... it does not make sense and add a lot of size to the final packages. So I made some changes to avoid grafting BokehJS when you are building the `sdist` (also remove some files as spurious html). Also, I change the behaviour (and messages) to avoid the `install_js` and `build_js` options when you are installing from a tar.gz package (I think those options make sense only in a dev environment where you are able to build BokehJS).

With this PR the final size goes from above **33 Mb** to **13 Mb**...

I tested a lot of combinations and it seems to work as expected.

Pinging @bokeh/core... 
Also ping @arunpersaud who build rpm packages...