### PR TITLE
include the frame offset in the screen mapping

### DIFF
--- a/bokehjs/src/coffee/common/cartesian_frame.coffee
+++ b/bokehjs/src/coffee/common/cartesian_frame.coffee
@@ -55,14 +55,21 @@ define [
         else
           vx = new Float64Array(x.length)
           vx.set(x)
+        hoff = @get('h_range').get('start')
+        for i in [0...vx.length]
+          vx[i] += hoff
       else
         vx = @get('x_mappers')[x_name].v_map_to_target(x)
+
       if y_units == 'screen'
         if _.isArray(y)
           vy = y[..]
         else
           vy = new Float64Array(y.length)
           vy.set(y)
+        voff = @get('v_range').get('start')
+        for i in [0...vy.length]
+          vy[i] += voff
       else
         vy = @get('y_mappers')[y_name].v_map_to_target(y)
 


### PR DESCRIPTION
issues: fixes #833

The upshot of this is that when users specify "screen" coordinates,
they are really specifying "view" (vx, vy) coordinates.

Furthermore, when mapping from a cartesian frame, the (0,0) is
the lower left corner of the central frame region.

**NOTE**: I believe our terminology and perhaps even some of the concepts around this are still a bit muddled, but I think this is an improvement, and that further improvements or changes can come as more layout work is pursued. 