### PR TITLE
Add support for BOKEH_DEV=True python something.py

### DIFF
--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -5,18 +5,29 @@ from os.path import join, dirname, abspath
 class Settings(object):
     _prefix = "BOKEH_"
     debugjs = False
+
     @property
     def _environ(self):
         return os.environ
 
-    def _get_str(self, key, default):
+    def _get(self, key, default=None):
         return self._environ.get(self._prefix + key, default)
 
-    def _get_bool(self, key, default):
-        value = self._environ.get(self._prefix + key)
+    @property
+    def _is_dev(self):
+        return self._get_bool("DEV", False)
+
+    def _dev_or_default(self, default, dev):
+        return dev if dev is not None and self._is_dev else default
+
+    def _get_str(self, key, default, dev=None):
+        return self._get(key, self._dev_or_default(default, dev))
+
+    def _get_bool(self, key, default, dev=None):
+        value = self._get(key)
 
         if value is None:
-            value = default
+            value = self._dev_or_default(default, dev)
         elif value.lower() in ["true", "yes", "on", "1"]:
             value = True
         elif value.lower() in ["false", "no", "off", "0"]:
@@ -27,10 +38,10 @@ class Settings(object):
         return value
 
     def browser(self, default=None):
-        return self._get_str("BROWSER", default)
+        return self._get_str("BROWSER", default, "none")
 
     def resources(self, default=None):
-        return self._get_str("RESOURCES", default)
+        return self._get_str("RESOURCES", default, "absolute-dev")
 
     def rootdir(self, default=None):
         return self._get_str("ROOTDIR", default)
@@ -39,13 +50,13 @@ class Settings(object):
         return self._get_str("VERSION", default)
 
     def minified(self, default=None):
-        return self._get_bool("MINIFIED", default)
+        return self._get_bool("MINIFIED", default, False)
 
     def log_level(self, default=None):
-        return self._get_str("LOG_LEVEL", default)
+        return self._get_str("LOG_LEVEL", default, "debug")
 
     def py_log_level(self, default='info'):
-        level = self._get_str("PY_LOG_LEVEL", default)
+        level = self._get_str("PY_LOG_LEVEL", default, "debug")
         LEVELS = {'debug': logging.DEBUG,
                   'info' : logging.INFO,
                   'warn' : logging.WARNING,
@@ -54,10 +65,10 @@ class Settings(object):
         return LEVELS[level]
 
     def pretty(self, default=None):
-        return self._get_bool("PRETTY", default)
+        return self._get_bool("PRETTY", default, True)
 
     def simple_ids(self, default=None):
-        return self._get_bool("SIMPLE_IDS", default)
+        return self._get_bool("SIMPLE_IDS", default, True)
 
     def notebook_resources(self, default=None):
         return self._get_str("NOTEBOOK_RESOURCES", default)


### PR DESCRIPTION
This enables all debugging capabilities of bokeh, e.g. development resources, JSON pretty printing, debug mode logging, simple IDs.

Note that JSON pretty printing doesn't work. The code was removed during session refactoring. I will fix this later.