### PR TITLE
Make versioneer aware of our devel build.

### DIFF
--- a/build_and_upload.sh
+++ b/build_and_upload.sh
@@ -75,7 +75,7 @@ complete_version=$(cat __conda_version__.txt)
 #create and upload pypi pkgs to binstar
 #zip is currently not working
 
-BOKEH_DEV_VERSION=$complete_version python setup.py sdist --formats=gztar
+python setup.py sdist --formats=gztar
 binstar upload -u bokeh dist/bokeh*$travis_build_id* --package-type pypi -c dev --force --no-progress;
 
 echo "I'm done uploading to binstar"

--- a/setup.py
+++ b/setup.py
@@ -442,17 +442,8 @@ if platform.python_implementation() != "PyPy":
         'pandas>=0.11.0'
     ])
 
-#need to create throw away class for cmdclass call in setup
-from distutils.command.build_py import build_py as _build_py
-class build_py(_build_py):
-    pass
-
-if 'BOKEH_DEV_VERSION' in os.environ:
-    _version = os.environ['BOKEH_DEV_VERSION']
-    _cmdclass = {'build_py': build_py}
-else:
-    _version = versioneer.get_version()
-    _cmdclass = versioneer.get_cmdclass()
+_version = versioneer.get_version()
+_cmdclass = versioneer.get_cmdclass()
 
 setup(
     name='bokeh',

--- a/versioneer.py
+++ b/versioneer.py
@@ -415,6 +415,15 @@ def versions_from_vcs(tag_prefix, versionfile_source, verbose=False):
     full = stdout.strip()
     if tag.endswith("-dirty"):
         full += "-dirty"
+
+    # accomodate to our devel build process
+    try:
+        from bokeh.__conda_version__ import conda_version
+        tag = conda_version.replace("'","")
+        del conda_version
+    except ImportError:
+        pass
+
     return {"version": tag, "full": full}
 
 


### PR DESCRIPTION
closes: #1148

It essentially injects the conda version into the get_version function, so it can return the dict correctly, with the devel tag as the `version` and the commit sha as the `full` version...