### PR TITLE
Hotfix to support local docs with a correct BokehJS

### DIFF
--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -32,8 +32,8 @@ def _cdn_base_url():
 
 def _get_cdn_urls(version=None, minified=True):
     if version is None:
-        if settings.cdn_version:
-            version = settings.cdn_version()
+        if settings.local_docs_cdn:
+            version = settings.local_docs_cdn()
         else:
             version = __version__.split('-')[0]
 

--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -32,7 +32,7 @@ def _cdn_base_url():
 
 def _get_cdn_urls(version=None, minified=True):
     if version is None:
-        if settings.local_docs_cdn:
+        if settings.local_docs_cdn():
             version = settings.local_docs_cdn()
         else:
             version = __version__.split('-')[0]

--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -32,7 +32,10 @@ def _cdn_base_url():
 
 def _get_cdn_urls(version=None, minified=True):
     if version is None:
-        version = __version__.split('-')[0]
+        if settings.cdn_version:
+            version = settings.cdn_version()
+        else:
+            version = __version__.split('-')[0]
 
     # check the 'dev' fingerprint
     dev = version.split('.')[-2]

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -49,8 +49,8 @@ class Settings(object):
     def version(self, default=None):
         return self._get_str("VERSION", default)
 
-    def cdn_version(self, default=None):
-        return self._get_str("CDN_VERSION", default)
+    def local_docs_cdn(self, default=None):
+        return self._get_str("LOCAL_DOCS_CDN", default)
 
     def minified(self, default=None):
         return self._get_bool("MINIFIED", default, False)

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -49,6 +49,9 @@ class Settings(object):
     def version(self, default=None):
         return self._get_str("VERSION", default)
 
+    def cdn_version(self, default=None):
+        return self._get_str("CDN_VERSION", default)
+
     def minified(self, default=None):
         return self._get_bool("MINIFIED", default, False)
 

--- a/sphinx/source/docs/dev_guide.rst
+++ b/sphinx/source/docs/dev_guide.rst
@@ -631,6 +631,9 @@ There are several environment variables that can be useful for developers:
 * ``BOKEH_VERSION`` --- What version of BokehJS to use with ``cdn`` resources
     See the :class:`~bokeh.resources.Resources` class reference for full details.
 
+* ``BOKEH_LOCAL_DOCS_CDN`` --- What version of BokehJS to use when you are working
+    with sphinx docs locally.
+
 The next four environment variable are related to the IPython/Jupyter notebook:
 
 * ``BOKEH_NOTEBOOK_RESOURCES`` --- How and where to load BokehJS from


### PR DESCRIPTION
This just add an entry point using an env variable to build the docs and get the plot rendered when you are working locally. This let's you use any released BokehJS or any devel version uploaded to the CDN (there could be the case, although not frequently, that you need a newer version that the released one and then, the devel version makes more sense).