### PR TITLE
Fix charts not working with server

### DIFF
--- a/bokeh/charts/_chart.py
+++ b/bokeh/charts/_chart.py
@@ -30,7 +30,7 @@ from ..plotting import DEFAULT_TOOLS
 from ..plotting_helpers import _process_tools_arg
 from ..resources import INLINE
 from ..session import Session
-from ..utils import publish_display_data
+from ..utils import publish_display_data, make_id
 
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -80,6 +80,7 @@ class Chart(Plot):
             title=self._options.title,
             plot_height=self._options.height,
             plot_width=self._options.width,
+            id=self._options.id or make_id()
         )
 
         self._glyphs = []

--- a/bokeh/charts/_chart_options.py
+++ b/bokeh/charts/_chart_options.py
@@ -24,6 +24,10 @@ Scale = enumeration('linear', 'categorical', 'datetime')
 
 class ChartOptions(HasProps):
 
+    id = String(None, help="""
+    Id of the chart.
+    """)
+
     title = String(None, help="""
     A title for the chart.
     """)

--- a/bokeh/plot_object.py
+++ b/bokeh/plot_object.py
@@ -48,6 +48,7 @@ class Viewable(MetaHasProps):
     def _preload_models(cls):
         from . import models
         from .crossfilter import models
+        from .charts import Chart
 
     @classmethod
     def get_class(cls, view_model_name):

--- a/examples/charts/server/line_animate.py
+++ b/examples/charts/server/line_animate.py
@@ -11,15 +11,17 @@ from bokeh.models import GlyphRenderer
 
 N = 80
 x = np.linspace(0, 4*np.pi, N)
-# output_server("line_animate")
+output_server("line_animate")
 xyvalues = OrderedDict(sin=np.sin(x), cos=np.cos(x))
 
-chart = Line(xyvalues, title="Lines", ylabel='measures', server='line_animate')
+chart = Line(xyvalues, title="Lines", ylabel='measures')
+curdoc().add(chart)
+show(chart)
+_session = cursession()
 
-# show(chart)
-# _session = cursession()
-chart.show()
-_session = chart.session
+# it's also possible to use the following with the server='line_animate' arg on chart
+# chart.show()
+# _session = chart.session
 
 renderer = chart.select(dict(type=GlyphRenderer))
 ds = renderer[0].data_source

--- a/examples/charts/server/line_animate.py
+++ b/examples/charts/server/line_animate.py
@@ -1,0 +1,33 @@
+# The plot server must be running
+# Go to http://localhost:5006/bokeh to view this plot
+
+import time
+from collections import OrderedDict
+import numpy as np
+
+from bokeh.plotting import *
+from bokeh.charts import Line
+from bokeh.models import GlyphRenderer
+
+N = 80
+x = np.linspace(0, 4*np.pi, N)
+# output_server("line_animate")
+xyvalues = OrderedDict(sin=np.sin(x), cos=np.cos(x))
+
+chart = Line(xyvalues, title="Lines", ylabel='measures', server='line_animate')
+
+# show(chart)
+# _session = cursession()
+chart.show()
+_session = chart.session
+
+renderer = chart.select(dict(type=GlyphRenderer))
+ds = renderer[0].data_source
+
+while True:
+    for i in np.hstack((np.linspace(1, -1, 100), np.linspace(-1, 1, 100))):
+        for k, values in xyvalues.items():
+            if k != 'x':
+                ds.data['y_%s'%k] = values * i
+        _session.store_objects(ds)
+        time.sleep(0.05)


### PR DESCRIPTION
After builders design refactoring charts were not working with bokeh-server anymore because Chart object was not included in the preloaded_models of plot object. Also, chart id was not being created properly.