### PR TITLE
Change [x,y]_label to [x,y]label in charts examples.

### DIFF
--- a/examples/charts/notebook/donut.ipynb
+++ b/examples/charts/notebook/donut.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:8066454deadd50d456d835a9eccecb9ca218da9c682c38baa9cdba1e35449a11"
+  "signature": "sha256:406244318d694005750a3a50288dbb594cd3878754117588dde51e200a5c2be3"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -45,7 +45,7 @@
       "medals = OrderedDict(bronze=bronze, silver=silver, gold=gold)\n",
       "\n",
       "donut = Donut(medals, countries, notebook=True, title='Medals Count', \n",
-      "              x_label='countries', y_label='medals')\n",
+      "              xlabel='countries', ylabel='medals')\n",
       "donut.show()"
      ],
      "language": "python",
@@ -61,7 +61,7 @@
       "output_notebook()\n",
       "df = pd.DataFrame(medals)\n",
       "donut = Donut(df, countries, notebook=True, title='Medals Count', \n",
-      "              x_label='countries', y_label='medals', legend=True)\n",
+      "              xlabel='countries', ylabel='medals', legend=True)\n",
       "show(donut)"
      ],
      "language": "python",

--- a/examples/charts/notebook/scatter.ipynb
+++ b/examples/charts/notebook/scatter.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:bedbf4b79ee7e9352a36793bd3efba4d15b1b5156a1c0cfc9a12843dd5c91b90"
+  "signature": "sha256:c0022e86254d49a8b6792932ed0f2e7b1a7fedeacbc88fc03409ff739b95ac5c"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -34,8 +34,8 @@
       "\n",
       "xyvalues = OrderedDict([(\"setosa\", setosa.values), (\"versicolor\", versicolor.values), (\"virginica\", virginica.values)])\n",
       "\n",
-      "scatter = Scatter(xyvalues, title=\"iris dataset, dict_input\", x_label=\"petal_length\",\n",
-      "                  y_label=\"petal_width\", legend='top_left', notebook=True)\n",
+      "scatter = Scatter(xyvalues, title=\"iris dataset, dict_input\", xlabel=\"petal_length\",\n",
+      "                  ylabel=\"petal_width\", legend='top_left', notebook=True)\n",
       "scatter.show()"
      ],
      "language": "python",
@@ -47,8 +47,8 @@
      "collapsed": false,
      "input": [
       "groupped_df = flowers[[\"petal_length\", \"petal_width\", \"species\"]].groupby(\"species\")\n",
-      "scatter = Scatter(groupped_df, title=\"iris dataset, dict_input\", x_label=\"petal_length\",\n",
-      "                  y_label=\"petal_width\", legend='top_left', notebook=True)\n",
+      "scatter = Scatter(groupped_df, title=\"iris dataset, dict_input\", xlabel=\"petal_length\",\n",
+      "                  ylabel=\"petal_width\", legend='top_left', notebook=True)\n",
       "scatter.show()"
      ],
      "language": "python",
@@ -73,8 +73,8 @@
       "    pdict[i] = list(zip(x, y))\n",
       "\n",
       "df = pd.DataFrame(pdict)\n",
-      "scatter = Scatter(df, title=\"iris dataset, dict_input\", x_label=\"petal_length\",\n",
-      "                  y_label=\"petal_width\", legend='top_left', notebook=True)\n",
+      "scatter = Scatter(df, title=\"iris dataset, dict_input\", xlabel=\"petal_length\",\n",
+      "                  ylabel=\"petal_width\", legend='top_left', notebook=True)\n",
       "show(scatter)"
      ],
      "language": "python",
@@ -85,8 +85,8 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "scatter = Scatter(list(xyvalues.values()), title=\"iris dataset, dict_input\", x_label=\"petal_length\",\n",
-      "                  y_label=\"petal_width\", legend='top_left', notebook=True)\n",
+      "scatter = Scatter(list(xyvalues.values()), title=\"iris dataset, dict_input\", xlabel=\"petal_length\",\n",
+      "                  ylabel=\"petal_width\", legend='top_left', notebook=True)\n",
       "show(scatter)"
      ],
      "language": "python",

--- a/examples/charts/notebook/timeseries.ipynb
+++ b/examples/charts/notebook/timeseries.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:3497e12f42707e952871e2e7bb7585b407d21f8deba03e97a545f568276c614d"
+  "signature": "sha256:1a29ab08246b104b2008d3b7eee2f8decf860609a92a6da3b61c2221a814c729"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -75,7 +75,7 @@
       "lindex = xyvalues.pop('Date')\n",
       "lxyvalues = list(xyvalues.values())\n",
       "\n",
-      "ts = TimeSeries(lxyvalues, index=lindex, title=\"timeseries, pd_input\", y_label='Stock Prices: 1-AAPL, 2-IBM, 3-MSFT', legend='top_left', notebook=True)\n",
+      "ts = TimeSeries(lxyvalues, index=lindex, title=\"timeseries, pd_input\", ylabel='Stock Prices: 1-AAPL, 2-IBM, 3-MSFT', legend='top_left', notebook=True)\n",
       "show(ts)"
      ],
      "language": "python",


### PR DESCRIPTION
Changed [x,y]_label to [x,y]label in charts/scatter example.

Update '[x,y]label' args