### PR TITLE
Add a sparkline demo

### DIFF
--- a/examples/plotting/file/sparkline.py
+++ b/examples/plotting/file/sparkline.py
@@ -1,0 +1,73 @@
+import pandas as pd
+from bokeh.charts import TimeSeries
+from bokeh.models import (
+    Legend,
+    Circle,
+    HoverTool,
+    ColumnDataSource,
+    GlyphRenderer
+)
+from bokeh.palettes import brewer
+
+TOOLS = "hover"
+palette = brewer["Blues"][3]
+
+apple = pd.read_csv(
+    "http://ichart.yahoo.com/table.csv?s=AAPL&a=0&b=1&c=2000&d=0&e=1&f=2010",
+    parse_dates=['Date']
+)
+
+# Basic sparkline
+
+sparkline = TimeSeries(
+    apple[['Adj Close', 'Date']], index='Date',
+    title="", tools=TOOLS, height=100, palette=palette,
+    ylabel='', xlabel='', xgrid=None, ygrid=None,
+    filename="sparkline.html"
+)
+sparkline.add_layout(
+    Legend(
+        legends=[('Apple', None), ],
+        orientation="top_left",
+        border_line_color="white",
+        label_text_font_style="bold"
+    )
+)
+
+sparkline.left[0].visible = False
+sparkline.below[0].visible = False
+sparkline.toolbar_location = None
+sparkline.min_border = 0
+sparkline.outline_line_color = None
+
+# Optional goodies
+# - Add a dot at either end
+# - with hover information
+fmt = '%d %b \'%y'
+apple['FormattedDate'] = apple['Date'].apply(lambda x: x.strftime(fmt))
+apple['Close'] = apple['Adj Close']  # Can't seem to do tooltips with space in column name
+dot_source = ColumnDataSource(
+    apple[['Close', 'Date', 'FormattedDate']].iloc[[0, -1]]
+)
+
+# A small pink circle
+circle = Circle(
+    x='Date', y='Close',
+    fill_color="#df65b0", size=5, line_color=None
+)
+# A larger blank circle to make it easier to hit the hover
+blank_circle = Circle(
+    x='Date', y='Close',
+    fill_color=None, size=20, line_color=None
+)
+circle_renderer = GlyphRenderer(data_source=dot_source, glyph=circle)
+blank_circle_renderer = GlyphRenderer(data_source=dot_source, glyph=blank_circle)
+sparkline.renderers.extend([circle_renderer, blank_circle_renderer])
+
+# Add a hover
+hover = sparkline.select({"type": HoverTool})[0]
+date = "@FormattedDate"
+close = "@Close"
+hover.tooltips = "{date} <strong>{close}</strong>".format(date=date, close=close)
+
+sparkline.show()


### PR DESCRIPTION
Hi all,

Was just messing around with this this afternoon and was wondering if you'd want it for the examples/gallery.

![sparkline-demo](https://cloud.githubusercontent.com/assets/1796208/6260470/1cea0b66-b794-11e4-9a39-fd98f15c2369.png)

One quick question: If I've used a DataFrame to make the chart with a column such as `Adj Close` am I correct in thinking that I can't just use `@Adj Close` in the tooltip? I couldn't make this work (and ended up making a new column with no spaces in the name) so just wanted to check I wasn't missing something.