### PR TITLE
restore tutorial gallery

### DIFF
--- a/sphinx/source/tutorial/solutions/.gitignore
+++ b/sphinx/source/tutorial/solutions/.gitignore
@@ -1,3 +1,2 @@
-gallery/*
 *.html
 *.json

--- a/sphinx/source/tutorial/solutions/gallery/boxplot.rst
+++ b/sphinx/source/tutorial/solutions/gallery/boxplot.rst
@@ -1,0 +1,6 @@
+
+
+solution
+########
+
+.. bokeh-plot:: source/tutorial/solutions/boxplot.py

--- a/sphinx/source/tutorial/solutions/gallery/brushing.rst
+++ b/sphinx/source/tutorial/solutions/gallery/brushing.rst
@@ -1,0 +1,6 @@
+
+
+solution
+########
+
+.. bokeh-plot:: source/tutorial/solutions/brushing.py

--- a/sphinx/source/tutorial/solutions/gallery/histogram.rst
+++ b/sphinx/source/tutorial/solutions/gallery/histogram.rst
@@ -1,0 +1,6 @@
+
+
+solution
+########
+
+.. bokeh-plot:: source/tutorial/solutions/histogram.py

--- a/sphinx/source/tutorial/solutions/gallery/hover.rst
+++ b/sphinx/source/tutorial/solutions/gallery/hover.rst
@@ -1,0 +1,6 @@
+
+
+solution
+########
+
+.. bokeh-plot:: source/tutorial/solutions/hover.py

--- a/sphinx/source/tutorial/solutions/gallery/image.rst
+++ b/sphinx/source/tutorial/solutions/gallery/image.rst
@@ -1,0 +1,6 @@
+
+
+solution
+########
+
+.. bokeh-plot:: source/tutorial/solutions/image.py

--- a/sphinx/source/tutorial/solutions/gallery/les_mis.rst
+++ b/sphinx/source/tutorial/solutions/gallery/les_mis.rst
@@ -1,0 +1,6 @@
+
+
+solution
+########
+
+.. bokeh-plot:: source/tutorial/solutions/les_mis.py

--- a/sphinx/source/tutorial/solutions/gallery/lines.rst
+++ b/sphinx/source/tutorial/solutions/gallery/lines.rst
@@ -1,0 +1,6 @@
+
+
+solution
+########
+
+.. bokeh-plot:: source/tutorial/solutions/lines.py

--- a/sphinx/source/tutorial/solutions/gallery/olympics.rst
+++ b/sphinx/source/tutorial/solutions/gallery/olympics.rst
@@ -1,0 +1,6 @@
+
+
+solution
+########
+
+.. bokeh-plot:: source/tutorial/solutions/olympics.py

--- a/sphinx/source/tutorial/solutions/gallery/periodic.rst
+++ b/sphinx/source/tutorial/solutions/gallery/periodic.rst
@@ -1,0 +1,6 @@
+
+
+solution
+########
+
+.. bokeh-plot:: source/tutorial/solutions/periodic.py

--- a/sphinx/source/tutorial/solutions/gallery/scatter.rst
+++ b/sphinx/source/tutorial/solutions/gallery/scatter.rst
@@ -1,0 +1,6 @@
+
+
+solution
+########
+
+.. bokeh-plot:: source/tutorial/solutions/scatter.py

--- a/sphinx/source/tutorial/solutions/gallery/stocks.rst
+++ b/sphinx/source/tutorial/solutions/gallery/stocks.rst
@@ -1,0 +1,6 @@
+
+
+solution
+########
+
+.. bokeh-plot:: source/tutorial/solutions/stocks.py

--- a/sphinx/source/tutorial/solutions/gallery/style.rst
+++ b/sphinx/source/tutorial/solutions/gallery/style.rst
@@ -1,0 +1,6 @@
+
+
+solution
+########
+
+.. bokeh-plot:: source/tutorial/solutions/style.py

--- a/sphinx/source/tutorial/solutions/gallery/unemployment.rst
+++ b/sphinx/source/tutorial/solutions/gallery/unemployment.rst
@@ -1,0 +1,6 @@
+
+
+solution
+########
+
+.. bokeh-plot:: source/tutorial/solutions/unemployment.py


### PR DESCRIPTION
issues: fixes #1921

These files can be deleted when entire the gallery gets generated with the ``bokeh-gallery`` sphinx extension. Right now only the individual plots are, with ``bokeh-plot``.