### PR TITLE
fix charts on userguide showing old functionality

### DIFF
--- a/sphinx/source/docs/user_guide/charts.rst
+++ b/sphinx/source/docs/user_guide/charts.rst
@@ -172,18 +172,10 @@ Here are a few examples showing charts using different kind of inputs:
     scatter.show()
 
 
-As you can see, in the first three cases, we inferred the ``x`` and ``y``
-labels from the received object, so don't need to specify them by yourself. This is
-done whenever possible. The following image shows the result:
-
-.. image:: /_images/charts_scatter_w_labels.png
-    :align: center
-
-When that's not possible (like the last two examples using a ``list`` and a numpy ``array``) ``Charts``
-will create a new figure without the inferred labels like the following:
-
-.. image:: /_images/charts_scatter_no_labels.png
-    :align: center
+All the previous examples render the chart in :ref:`charts_generic_arguments_scatter` with
+the difference that numpy ``array`` and ``list`` inputs will render different legends then
+mappings like ``dict``, ``OrderedDict``, pandas ``DataFrame`` or ``GroupBy`` objects
+(if legend=True).
 
 
 Specific arguments
@@ -363,6 +355,8 @@ Example:
 .. bokeh-plot:: ../examples/charts/lines.py
     :source-position: above
 
+
+.. _charts_generic_arguments_scatter:
 
 Scatter
 ~~~~~~~

--- a/sphinx/source/docs/user_guide/charts.rst
+++ b/sphinx/source/docs/user_guide/charts.rst
@@ -173,9 +173,9 @@ Here are a few examples showing charts using different kind of inputs:
 
 
 All the previous examples render the chart in :ref:`charts_generic_arguments_scatter` with
-the difference that numpy ``array`` and ``list`` inputs will render different legends then
+the difference that numpy ``array`` and ``list`` inputs will render different legends from
 mappings like ``dict``, ``OrderedDict``, pandas ``DataFrame`` or ``GroupBy`` objects
-(if legend=True).
+(if ``legend`` is True).
 
 
 Specific arguments


### PR DESCRIPTION
Removes reference to old functionality input types examples section on user guide charts (from bug report on [m.l.](https://groups.google.com/a/continuum.io/forum/?utm_medium=email&utm_source=footer#!msg/bokeh/sy0HabwWzj0/HU9fL5UOg7gJ) . As this is related also to #1901 (which may have different outcomes) this PR just remove the specific reference to axis labels. Builders new design separates charts axis labels creation and builders so the same previous behaviour is not obvious to restore.