### PR TITLE
Fix broken links to BEP in dev docs

### DIFF
--- a/sphinx/source/docs/dev_guide/process.rst
+++ b/sphinx/source/docs/dev_guide/process.rst
@@ -4,11 +4,11 @@ Software Process
 ================
 
 The software development process for Bokeh is outlined in
-`Bokeh Enhancement Proposal 1 <BEP 1>`_. All changes, enhancements,
+`Bokeh Enhancement Proposal 1`_. All changes, enhancements,
 and bugfixes should generally go through the process outlined there.
 
 The process for creating, distributing, and announcing final releases
-of Bokeh is outlined in `Bokeh Enhancement Proposal 2 <BEP 2>`_.
+of Bokeh is outlined in `Bokeh Enhancement Proposal 2`_.
 
-.. _BEP 1: https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management
-.. _BEP 2: https://github.com/bokeh/bokeh/wiki/BEP-2:-Release-Management
+.. _Bokeh Enhancement Proposal 1: https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management
+.. _Bokeh Enhancement Proposal 2: https://github.com/bokeh/bokeh/wiki/BEP-2:-Release-Management


### PR DESCRIPTION
issues: fixes issue #1945

The problem was a malformatted rst link.