### PR TITLE
image glyph has standard palette Greys9

### DIFF
--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -286,9 +286,9 @@ class Image(Glyph):
     def __init__(self, **kwargs):
         if 'palette' in kwargs and 'color_mapper' in kwargs:
             raise ValueError("only one of 'palette' and 'color_mapper' may be specified")
-
-        palette = kwargs.pop('palette', 'Greys9')
-        if palette is not None:
+        elif 'color_mapper' not in kwargs:
+            # Use a palette (given or default)
+            palette = kwargs.pop('palette', 'Greys9')
             mapper = LinearColorMapper(palette)
 
             reserve_val = kwargs.pop('reserve_val', None)

--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -287,7 +287,7 @@ class Image(Glyph):
         if 'palette' in kwargs and 'color_mapper' in kwargs:
             raise ValueError("only one of 'palette' and 'color_mapper' may be specified")
 
-        palette = kwargs.pop('palette', None)
+        palette = kwargs.pop('palette', 'Greys9')
         if palette is not None:
             mapper = LinearColorMapper(palette)
 


### PR DESCRIPTION
issues: closes issue #1929, closes #1928

Question: we don't currently have any code that does *not* provide a palette to an image, so this change will not be tested anywhere. Should I add an example for this?