### PR TITLE
BokehJSONEncoder sets masked values to nan

### DIFF
--- a/bokeh/protocol.py
+++ b/bokeh/protocol.py
@@ -56,6 +56,8 @@ class BokehJSONEncoder(json.JSONEncoder):
     def transform_numerical_array(self, obj):
         """handles nans/inf conversion
         """
+        if isinstance(obj, np.ma.MaskedArray):
+            obj = obj.filled(np.nan)  # Set masked values to nan
         if not np.isnan(obj).any() and not np.isinf(obj).any():
             return obj.tolist()
         else:

--- a/bokehjs/src/coffee/renderer/glyph/line.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/line.coffee
@@ -17,7 +17,7 @@ define [
       @props.line.set(ctx, @props)
 
       for i in indices
-        if isNaN(@sx[i] + @sy[i]) and drawing
+        if !isFinite(@sx[i] + @sy[i]) and drawing
           ctx.stroke()
           ctx.beginPath()
           drawing = false

--- a/examples/glyphs/line_missing_data.py
+++ b/examples/glyphs/line_missing_data.py
@@ -21,7 +21,7 @@ y2 = np.ma.masked_array(y2, y2<-0.9)
 output_file("line_missing_data.html", title="line_missing_data.py example")
 
 p = figure(title="lines with some missing/inf values")
-p.line(x,y1, color="#2222aa", line_with=2)
-p.line(x,y2, color="#22aa22", line_with=2)
+p.line(x,y1, color="#2222aa", line_width=2)
+p.line(x,y2, color="#22aa22", line_width=2)
 
 show(p)

--- a/examples/glyphs/line_missing_data.py
+++ b/examples/glyphs/line_missing_data.py
@@ -1,0 +1,27 @@
+# Example similar to line.py, but demoing special data
+# like masked arrays, nans, and inf
+
+import numpy as np
+
+from bokeh.plotting import *
+
+x = np.linspace(0, 4*np.pi, 200)
+y1 = np.sin(x)
+y2 = np.cos(x)
+
+# Set high/low values to inf
+y1[y1>+0.9] = +np.inf
+y1[y1<-0.9] = -np.inf
+
+# Set high values to nan and mask the low
+y2[y2>0.9] = np.nan
+y2 = np.ma.masked_array(y2, y2<-0.9)
+
+
+output_file("line_missing_data.html", title="line_missing_data.py example")
+
+p = figure(title="lines with some missing/inf values")
+p.line(x,y1, color="#2222aa", line_with=2)
+p.line(x,y2, color="#22aa22", line_with=2)
+
+show(p)

--- a/examples/plotting/file/line.py
+++ b/examples/plotting/file/line.py
@@ -8,6 +8,6 @@ y = np.sin(x)
 output_file("line.html", title="line.py example")
 
 p = figure(title="simple line example")
-p.line(x,y, color="#2222aa", line_with=2)
+p.line(x,y, color="#2222aa", line_width=2)
 
 show(p)


### PR DESCRIPTION
issues: closes #1784

Also adds an example to show what happens with inf/nan/masked values.

One thing that the example shows is that inf/-inf is handled different from nan. Not sure if this is intentional. Edit: bokehjs now also ignores data values that are inf/-inf.