### PR TITLE
Fix getsitepackages() in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,8 @@ def getsitepackages():
                                      "python" + sys.version[:3],
                                      "site-packages"),
                         os.path.join(prefix, "lib", "site-python"),
-                        os.path.join(prefix, "python" + sys.version[:3], "lib-dynload")]
+                        #os.path.join(prefix, "python" + sys.version[:3], "lib-dynload")
+                        ]
             lib64_dir = os.path.join(prefix, "lib64", "python" + sys.version[:3], "site-packages")
             if (os.path.exists(lib64_dir) and
                 os.path.realpath(lib64_dir) not in [os.path.realpath(p) for p in sitedirs]):
@@ -140,17 +141,16 @@ def getsitepackages():
             except AttributeError:
                 pass
             # Debian-specific dist-packages directories:
-            if sys.version[0] == '2':
-                sitedirs.append(os.path.join(prefix, "lib",
-                                             "python" + sys.version[:3],
-                                             "dist-packages"))
-            else:
-                sitedirs.append(os.path.join(prefix, "lib",
-                                             "python" + sys.version[0],
-                                             "dist-packages"))
             sitedirs.append(os.path.join(prefix, "local/lib",
                                          "python" + sys.version[:3],
                                          "dist-packages"))
+            sitedirs.append(os.path.join(prefix, "lib",
+                                         "python" + sys.version[:3],
+                                         "dist-packages"))
+            if sys.version_info[0] >= 3:
+                sitedirs.append(os.path.join(prefix, "lib",
+                                             "python" + sys.version[0],
+                                             "dist-packages"))
             sitedirs.append(os.path.join(prefix, "lib", "dist-python"))
         else:
             sitedirs = [prefix, os.path.join(prefix, "lib", "site-packages")]
@@ -169,6 +169,8 @@ def getsitepackages():
                                      'site-packages'))
         for sitedir in sitedirs:
             sitepackages.append(os.path.abspath(sitedir))
+    
+    sitepackages = [p for p in sitepackages if os.path.isdir(p)]
     return sitepackages
 
 def check_remove_bokeh_install(site_packages):

--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,6 @@ def getsitepackages():
                                      "python" + sys.version[:3],
                                      "site-packages"),
                         os.path.join(prefix, "lib", "site-python"),
-                        #os.path.join(prefix, "python" + sys.version[:3], "lib-dynload")
                         ]
             lib64_dir = os.path.join(prefix, "lib64", "python" + sys.version[:3], "site-packages")
             if (os.path.exists(lib64_dir) and


### PR DESCRIPTION
issues: closes #1953

- the returned list now only contains directories that actually exist
- some changes in ordering to make it more consistent with Debian.
- removed "lib-dynload" dir; that's not site-packages at all, is it?