### PR TITLE
Raise exception when HasProps receives invalid kwargs

### DIFF
--- a/bokeh/_glyph_functions.py
+++ b/bokeh/_glyph_functions.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 
 from .models import glyphs, markers
 from .mixins import FillProps, LineProps
+from .utils import pop_items
 
 def _glyph_function(glyphclass, dsnames, argnames, docstring, xfields=["x"], yfields=["y"]):
 
@@ -22,27 +23,14 @@ def _glyph_function(glyphclass, dsnames, argnames, docstring, xfields=["x"], yfi
             datasource = ColumnDataSource()
         else:
             datasource = source
-
-        legend_name = kwargs.pop("legend", None)
-
+        
         if not isinstance(plot, Plot):
             raise ValueError("expected plot object for first argument")
-
+        
         # TODO (bev) this seems like it should be here but invalid kwargs
         # currently get through (see also below)
         # plot.update(**kwargs)
-
-        name = kwargs.pop('name', None)
         
-        # We extract renderer properties here, so they are not confused for glyph props
-        # TODO (bev) hacky, fix up when glyphspecs are simplified/removed
-        renderer_props = {}
-        for key in ['x_range_name', 'y_range_name']:
-            if key in kwargs:
-                renderer_props[key] = kwargs.pop(key)
-        
-        select_tool = _get_select_tool(plot)
-
         # Process the glyph dataspec parameters
         glyph_params = _match_data_params(dsnames, glyphclass,
                                           datasource,
@@ -62,33 +50,30 @@ def _glyph_function(glyphclass, dsnames, argnames, docstring, xfields=["x"], yfi
     
         nonselection_glyph_params = _materialize_colors_and_alpha(kwargs, prefix='nonselection_', default_alpha=0.1)
         
-        #glyph_props = glyphclass.properties() | set(argnames)
-        #glyph_kwargs = dict((key, value) for (key, value) in iteritems(kwargs) if key in glyph_props)
-        #glyph = glyphclass(**glyph_kwargs)
-        # We pass all remaining (non-popped) kwargs. The HasProps class will check validity
-        for name in ['color', 'alpha']:  # These are valid names, but pseudo-properties
-            kwargs.pop(name, None)
-        
+        # Pop some arguments that we already used or need later
+        legend_name = kwargs.pop("legend", None)
+        pop_items(kwargs, 'color', 'alpha')
+        renderer_kwargs = pop_items(kwargs, 'x_range_name', 'y_range_name', name=None)
+
+        # Create the glyph class with the remaining kwargs
         glyph = glyphclass(**kwargs)
-        nonselection_glyph = glyph.clone()
         
+        # Make a clone for the nonselection glyph
+        nonselection_glyph = glyph.clone()
         # TODO: (bev) This is a bit hacky.
         if hasattr(nonselection_glyph, 'fill_color'):
             nonselection_glyph.fill_color = nonselection_glyph_params['fill_color']
             nonselection_glyph.fill_alpha = nonselection_glyph_params['fill_alpha']
-
         if hasattr(nonselection_glyph, 'line_color'):
             nonselection_glyph.line_color = nonselection_glyph_params['line_color']
             nonselection_glyph.line_alpha = nonselection_glyph_params['line_alpha']
-
+        
+        # Instantiate renderer with kwargs that we extracted above
         glyph_renderer = GlyphRenderer(
             data_source=datasource,
             glyph=glyph,
             nonselection_glyph=nonselection_glyph,
-            name=name)
-        
-        for key, val in renderer_props.items():
-            setattr(glyph_renderer, key, val)
+            **renderer_kwargs)
         
         if legend_name:
             legend = _get_legend(plot)
@@ -98,6 +83,7 @@ def _glyph_function(glyphclass, dsnames, argnames, docstring, xfields=["x"], yfi
             legends.setdefault(legend_name, []).append(glyph_renderer)
             legend.legends = list(legends.items())
 
+        select_tool = _get_select_tool(plot)
         if select_tool :
             select_tool.renderers.append(glyph_renderer)
             select_tool._dirty = True

--- a/bokeh/properties.py
+++ b/bokeh/properties.py
@@ -591,6 +591,9 @@ class HasProps(object):
         self._changed_vars = set()
 
         for name, value in properties.items():
+            if not hasattr(self, name):
+                raise ValueError('Class %r does not have property %r' % 
+                                 (self.__class__.__name__, name))
             setattr(self, name, value)
 
     def __setattr__(self, name, value):

--- a/bokeh/properties.py
+++ b/bokeh/properties.py
@@ -591,9 +591,6 @@ class HasProps(object):
         self._changed_vars = set()
 
         for name, value in properties.items():
-            if not hasattr(self, name):
-                raise ValueError('Class %r does not have property %r' % 
-                                 (self.__class__.__name__, name))
             setattr(self, name, value)
 
     def __setattr__(self, name, value):

--- a/bokeh/utils.py
+++ b/bokeh/utils.py
@@ -161,3 +161,17 @@ def resolve_json(fragment, models):
             logging.error("model not found for %s", fragment)
             return None
     return json_apply(fragment, check_func, func)
+
+
+def pop_items(d, *args, **kwargs):
+    """ Pop items from an existing dict and return as a new dict.
+    Key names to pop can be given as strings, or as keyword
+    arguments to give them a default value.
+    """
+    new_d = {}
+    for key in args:
+        if key in d:
+            new_d[key] = d.pop(key)
+    for key, default in kwargs.items():
+        new_d[key] = d.pop(key, default)
+    return new_d


### PR DESCRIPTION
issues: closes #1960

In `_glyph_function()` we pop all `kwargs` that we need and pass the rest to the `Glyph` class (and effectively to `HasProps.__init__`).