### PR TITLE
change some empty dicts/lists as default args to None

### DIFF
--- a/bokeh/plotting_helpers.py
+++ b/bokeh/plotting_helpers.py
@@ -470,7 +470,7 @@ def _new_xy_plot(x_range=None, y_range=None, plot_width=None, plot_height=None,
 
 
 def _handle_1d_data_args(args, datasource=None, create_autoindex=True,
-        suggested_names=[]):
+        suggested_names=None):
     """ Returns a datasource and a list of names corresponding (roughly)
     to the input data.  If only a single array was given, and an index
     array was created, then the index's name is returned first.
@@ -478,6 +478,7 @@ def _handle_1d_data_args(args, datasource=None, create_autoindex=True,
     arrays = []
     if datasource is None:
         datasource = ColumnDataSource()
+    suggested_names = suggested_names or []
     # First process all the arguments to homogenize shape.  After this
     # process, "arrays" should contain a uniform list of string/ndarray/iterable
     # corresponding to the inputs.

--- a/bokeh/plotting_helpers.py
+++ b/bokeh/plotting_helpers.py
@@ -469,8 +469,7 @@ def _new_xy_plot(x_range=None, y_range=None, plot_width=None, plot_height=None,
     return plot
 
 
-def _handle_1d_data_args(args, datasource=None, create_autoindex=True,
-        suggested_names=None):
+def _handle_1d_data_args(args, datasource=None, create_autoindex=True):
     """ Returns a datasource and a list of names corresponding (roughly)
     to the input data.  If only a single array was given, and an index
     array was created, then the index's name is returned first.
@@ -478,7 +477,6 @@ def _handle_1d_data_args(args, datasource=None, create_autoindex=True,
     arrays = []
     if datasource is None:
         datasource = ColumnDataSource()
-    suggested_names = suggested_names or []
     # First process all the arguments to homogenize shape.  After this
     # process, "arrays" should contain a uniform list of string/ndarray/iterable
     # corresponding to the inputs.
@@ -511,9 +509,7 @@ def _handle_1d_data_args(args, datasource=None, create_autoindex=True,
         if isinstance(ary, string_types):
             name = ary
         else:
-            if i < len(suggested_names):
-                name = suggested_names[i]
-            elif i == 0 and create_autoindex:
+            if i == 0 and create_autoindex:
                 name = datasource.add(ary, name="_autoindex")
             else:
                 name = datasource.add(ary)

--- a/bokeh/properties.py
+++ b/bokeh/properties.py
@@ -837,7 +837,8 @@ class List(Seq):
 
     """
 
-    def __init__(self, item_type, default=[], help=None):
+    def __init__(self, item_type, default=None, help=None):
+        default = default or []
         super(List, self).__init__(item_type, default=default, help=help)
 
     def _is_seq(self, value):
@@ -863,7 +864,8 @@ class Dict(ContainerProperty):
 
     """
 
-    def __init__(self, keys_type, values_type, default={}, help=None):
+    def __init__(self, keys_type, values_type, default=None, help=None):
+        default = default or {}
         self.keys_type = self._validate_type_param(keys_type)
         self.values_type = self._validate_type_param(values_type)
         super(Dict, self).__init__(default=default, help=help)
@@ -1161,7 +1163,8 @@ class DashPattern(Either):
         "dashdot": [6,4,2,4],
     }
 
-    def __init__(self, default=[], help=None):
+    def __init__(self, default=None, help=None):
+        default = default or []
         types = Enum(enums.DashPattern), Regex(r"^(\d+(\s+\d+)*)?$"), Seq(Int)
         super(DashPattern, self).__init__(*types, default=default, help=help)
 
@@ -1268,7 +1271,8 @@ class RelativeDelta(Dict):
 
     """
 
-    def __init__(self, default={}, help=None):
+    def __init__(self, default=None, help=None):
+        default = default or {}
         keys = Enum("years", "months", "days", "hours", "minutes", "seconds", "microseconds")
         values = Int
         super(RelativeDelta, self).__init__(keys, values, default=default, help=help)

--- a/bokeh/properties.py
+++ b/bokeh/properties.py
@@ -1164,8 +1164,7 @@ class DashPattern(Either):
         "dashdot": [6,4,2,4],
     }
 
-    def __init__(self, default=None, help=None):
-        default = default or []
+    def __init__(self, default=[], help=None):
         types = Enum(enums.DashPattern), Regex(r"^(\d+(\s+\d+)*)?$"), Seq(Int)
         super(DashPattern, self).__init__(*types, default=default, help=help)
 
@@ -1272,8 +1271,7 @@ class RelativeDelta(Dict):
 
     """
 
-    def __init__(self, default=None, help=None):
-        default = default or {}
+    def __init__(self, default={}, help=None):
         keys = Enum("years", "months", "days", "hours", "minutes", "seconds", "microseconds")
         values = Int
         super(RelativeDelta, self).__init__(keys, values, default=default, help=help)

--- a/bokeh/properties.py
+++ b/bokeh/properties.py
@@ -837,8 +837,10 @@ class List(Seq):
 
     """
 
-    def __init__(self, item_type, default=None, help=None):
-        default = default or []
+    def __init__(self, item_type, default=[], help=None):
+        # todo: refactor to not use mutable objects as default values.
+        # Left in place for now because we want to allow None to express
+        # opional values. Also in Dict.
         super(List, self).__init__(item_type, default=default, help=help)
 
     def _is_seq(self, value):
@@ -864,8 +866,7 @@ class Dict(ContainerProperty):
 
     """
 
-    def __init__(self, keys_type, values_type, default=None, help=None):
-        default = default or {}
+    def __init__(self, keys_type, values_type, default={}, help=None):
         self.keys_type = self._validate_type_param(keys_type)
         self.values_type = self._validate_type_param(values_type)
         super(Dict, self).__init__(default=default, help=help)

--- a/bokeh/query.py
+++ b/bokeh/query.py
@@ -43,7 +43,7 @@ class LEQ(object): pass
 class NEQ(object): pass
 
 
-def match(obj, selector, context={}):
+def match(obj, selector, context=None):
     ''' Test whether a particular object matches a given
     selector.
 
@@ -80,6 +80,7 @@ def match(obj, selector, context={}):
         1
 
     '''
+    context = context or {}
     for key, val in selector.items():
 
         # test attributes
@@ -135,7 +136,7 @@ def match(obj, selector, context={}):
     return True
 
 
-def find(objs, selector, context={}):
+def find(objs, selector, context=None):
     ''' Query an object and all of its contained references
     and yield objects that match the given selector.
 
@@ -150,6 +151,7 @@ def find(objs, selector, context={}):
     Examples:
 
     '''
+    context = context or {}
     return (obj for obj in objs if match(obj, selector, context))
 
 

--- a/bokeh/query.py
+++ b/bokeh/query.py
@@ -55,7 +55,7 @@ def match(obj, selector, context=None):
     Returns:
         bool : True if the object matches, False otherwise
 
-    There are two selector keyss that are handled specially. The first
+    There are two selector keys that are handled specially. The first
     is 'type', which will do an isinstance check::
 
         >>> from bokeh.plotting import line
@@ -64,7 +64,7 @@ def match(obj, selector, context=None):
         >>> len(list(p.select({'type': Axis})))
         2
 
-    There is also a a 'tags' attribute that `PlotObject` objects have,
+    There is also a 'tags' attribute that `PlotObject` objects have,
     that is a list of user-supplied values. The 'tags' selector key can
     be used to query against this list of tags. An object matches if
     any of the tags in the selector match any of the tags on the
@@ -117,7 +117,7 @@ def match(obj, selector, context=None):
                         return False
 
                 elif isinstance(val, dict):
-                    if not match(attr, val): return False
+                    if not match(attr, val, context): return False
 
                 else:
                     if attr != val: return False
@@ -151,7 +151,6 @@ def find(objs, selector, context=None):
     Examples:
 
     '''
-    context = context or {}
     return (obj for obj in objs if match(obj, selector, context))
 
 

--- a/bokeh/server/utils/reload.py
+++ b/bokeh/server/utils/reload.py
@@ -18,7 +18,7 @@ def broadcast_reload():
     if hasattr(bokeh_app, 'wsmanager'):
         bokeh_app.wsmanager.send('debug:debug', 'reload')
 
-def _wait_for_edit(extra_files=[], interval=1):
+def _wait_for_edit(extra_files=None, interval=1):
     """Waits until one of the files we're using have changed
     """
     from itertools import chain

--- a/bokeh/server/views/__init__.py
+++ b/bokeh/server/views/__init__.py
@@ -2,13 +2,13 @@ from __future__ import absolute_import
 
 from flask import current_app
 
-def make_json(jsonstring, status_code=200, headers={}):
+def make_json(jsonstring, status_code=200, headers=None):
     """ Like jsonify, except accepts string, so we can do our own custom
     json serialization.  should move this to continuumweb later
     """
     return current_app.response_class(
         response=jsonstring,
         status=status_code,
-        headers=headers,
+        headers=(headers or {}),
         mimetype='application/json'
     )

--- a/bokeh/server/zmqpub.py
+++ b/bokeh/server/zmqpub.py
@@ -32,10 +32,11 @@ class Publisher(object):
         finally:
             socket.close()
         log.debug('zmqpub exiting')
-    def send(self, topic, msg, exclude=[]):
+    def send(self, topic, msg, exclude=None):
+        exclude = list(exclude or [])
         msg = json.dumps({'topic' : topic,
                           'msg' : msg,
-                          'exclude' : list(exclude)})
+                          'exclude' : exclude})
         self.queue.put(msg)
 
     def start(self):

--- a/bokeh/sphinxext/bokeh_github.py
+++ b/bokeh/sphinxext/bokeh_github.py
@@ -36,7 +36,7 @@ from six.moves import urllib
 
 BOKEH_GH = "https://github.com/bokeh/bokeh"
 
-def bokeh_commit(name, rawtext, text, lineno, inliner, options=None, content=[]):
+def bokeh_commit(name, rawtext, text, lineno, inliner, options=None, content=None):
     """Link to a Bokeh Github issue.
 
     Returns 2 part tuple containing list of nodes to insert into the
@@ -48,7 +48,7 @@ def bokeh_commit(name, rawtext, text, lineno, inliner, options=None, content=[])
     node = make_gh_link_node(app, rawtext, 'commit', 'commit', 'commit', text, options)
     return [node], []
 
-def bokeh_issue(name, rawtext, text, lineno, inliner, options=None, content=[]):
+def bokeh_issue(name, rawtext, text, lineno, inliner, options=None, content=None):
     """Link to a Bokeh Github issue.
 
     Returns 2 part tuple containing list of nodes to insert into the
@@ -70,7 +70,7 @@ def bokeh_issue(name, rawtext, text, lineno, inliner, options=None, content=[]):
     node = make_gh_link_node(app, rawtext, 'issue', 'issue', 'issues', str(issue_num), options)
     return [node], []
 
-def bokeh_milestone(name, rawtext, text, lineno, inliner, options=None, content=[]):
+def bokeh_milestone(name, rawtext, text, lineno, inliner, options=None, content=None):
     """Link to a Bokeh Github issue.
 
     Returns 2 part tuple containing list of nodes to insert into the
@@ -82,7 +82,7 @@ def bokeh_milestone(name, rawtext, text, lineno, inliner, options=None, content=
     node = make_gh_link_node(app, rawtext, 'milestone', 'milestone', 'milestones', text, options)
     return [node], []
 
-def bokeh_pull(name, rawtext, text, lineno, inliner, options=None, content=[]):
+def bokeh_pull(name, rawtext, text, lineno, inliner, options=None, content=None):
     """Link to a Bokeh Github issue.
 
     Returns 2 part tuple containing list of nodes to insert into the

--- a/bokeh/sphinxext/bokeh_github.py
+++ b/bokeh/sphinxext/bokeh_github.py
@@ -36,7 +36,7 @@ from six.moves import urllib
 
 BOKEH_GH = "https://github.com/bokeh/bokeh"
 
-def bokeh_commit(name, rawtext, text, lineno, inliner, options={}, content=[]):
+def bokeh_commit(name, rawtext, text, lineno, inliner, options=None, content=[]):
     """Link to a Bokeh Github issue.
 
     Returns 2 part tuple containing list of nodes to insert into the
@@ -48,7 +48,7 @@ def bokeh_commit(name, rawtext, text, lineno, inliner, options={}, content=[]):
     node = make_gh_link_node(app, rawtext, 'commit', 'commit', 'commit', text, options)
     return [node], []
 
-def bokeh_issue(name, rawtext, text, lineno, inliner, options={}, content=[]):
+def bokeh_issue(name, rawtext, text, lineno, inliner, options=None, content=[]):
     """Link to a Bokeh Github issue.
 
     Returns 2 part tuple containing list of nodes to insert into the
@@ -70,7 +70,7 @@ def bokeh_issue(name, rawtext, text, lineno, inliner, options={}, content=[]):
     node = make_gh_link_node(app, rawtext, 'issue', 'issue', 'issues', str(issue_num), options)
     return [node], []
 
-def bokeh_milestone(name, rawtext, text, lineno, inliner, options={}, content=[]):
+def bokeh_milestone(name, rawtext, text, lineno, inliner, options=None, content=[]):
     """Link to a Bokeh Github issue.
 
     Returns 2 part tuple containing list of nodes to insert into the
@@ -82,7 +82,7 @@ def bokeh_milestone(name, rawtext, text, lineno, inliner, options={}, content=[]
     node = make_gh_link_node(app, rawtext, 'milestone', 'milestone', 'milestones', text, options)
     return [node], []
 
-def bokeh_pull(name, rawtext, text, lineno, inliner, options={}, content=[]):
+def bokeh_pull(name, rawtext, text, lineno, inliner, options=None, content=[]):
     """Link to a Bokeh Github issue.
 
     Returns 2 part tuple containing list of nodes to insert into the
@@ -104,7 +104,7 @@ def bokeh_pull(name, rawtext, text, lineno, inliner, options={}, content=[]):
     node = make_gh_link_node(app, rawtext, 'pull', 'pull request', 'pull', str(issue_num), options)
     return [node], []
 
-def make_gh_link_node(app, rawtext, role, kind, api_type, id, options={}):
+def make_gh_link_node(app, rawtext, role, kind, api_type, id, options=None):
     """ Return a link to a Bokeh Github resource.
 
     Args:
@@ -118,6 +118,7 @@ def make_gh_link_node(app, rawtext, role, kind, api_type, id, options={}):
 
     """
     url = "%s/%s/%s" % (BOKEH_GH, api_type, id)
+    options = options or {}
     try:
         request = urllib.request.Request(url)
         request.get_method = lambda : 'HEAD'

--- a/bokeh/transforms/ar_downsample.py
+++ b/bokeh/transforms/ar_downsample.py
@@ -406,7 +406,7 @@ class Contour(Shader):
 def replot(plot,
            agg=Count(), info=Const(val=1), shader=Id(),
            remove_original=True,
-           plot_opts={}, **kwargs):
+           plot_opts=None, **kwargs):
     """
     Treat the passed plot as an base plot for abstract rendering, generate the
     proper Bokeh plot based on the passed parameters.
@@ -451,6 +451,7 @@ def replot(plot,
     fig_opts['title'] = kwargs.pop('title', plot.title)
 
     src = source(plot, agg, info, shader, **source_opts)
+    plot_opts = plot_opts or {}
     plot_opts.update(mapping(src))
 
     new_plot = figure(**fig_opts)


### PR DESCRIPTION
issues: closes #1983

I searched the code for `={}` and `=[]`. Assuming pep8 is followed and no arguments are specified as `foo = {}`, I should have got them all.
