### PR TITLE
Add new styles to tweak visual hierarchy

### DIFF
--- a/sphinx/source/_static/my-styles.css
+++ b/sphinx/source/_static/my-styles.css
@@ -6,9 +6,131 @@ a.logo {float:left; margin:9px 5px 0 0}
 
 .col-md-12 {padding-right:80px; /* this makes sure text stays clear of the fork me ribbon*/
 }
-dl.class > dt { background-color: #d6e1c7; }
-dl.class > dt:target { background-color: #fcebb6; }
-dl.method > dt { background-color: #fee6ce; }
-dl.method > dt:target { background-color: #fcebb6; }
-dl.function > dt { background-color: #d6e1c7; }
-dl.function > dt:target { background-color: #fcebb6; }
+
+/*
+ *  Display Class documentation
+ */
+
+code > .pre {
+    color: #2A2A2A;
+}
+
+.class,
+.section {
+    clear: both;
+}
+
+/* I'd like to do something like this but 
+ * it affects too much of the rest of the docs */
+/*
+.section > h2 > a > code > .pre {
+    color: #EB2366;
+    background-color: white;
+    font-weight: bold;
+    font-size: 1.3em;
+}
+.section > h2 > a,
+.section > h2 > a:hover {
+    color: #EB2366;
+}
+*/
+.class > dt > .headerlink {
+    padding-left: 10px;
+    color: #85398C;
+}
+
+.class {
+    margin-top: 20px;
+    padding-top: 10px;
+    border-top: 2px #2A2A2A solid;
+}
+
+.class > dt {
+    font-size: 1.3em;
+    text-align: right;
+    float: right;
+    color: #EB2366;
+}
+
+.class > dd {
+    padding-top: 10px;
+    clear: both;
+}
+
+.attribute > dt > tt:before {
+    content: ' attr ';
+    font-style: italic;
+    color: #B1CE2D;
+    font-size: 0.8em;
+}
+
+.method > dt > tt:before {
+    content: ' method ';
+    font-style: italic;
+    color: #1EA354;
+    font-size: 0.8em;
+}
+
+.classmethod > dt > .property {
+    font-style: italic;
+    color: #20A7AA;
+    font-size: 0.8em;
+}
+
+.classmethod > dd > .table,
+.method > dd > .table,
+.attribute > dd > .table {
+    margin-left: 40px;
+    margin-bottom: 0;
+}
+
+/* Give things some breathing room */
+.class ~ .panel-group {
+    float: left;
+}
+
+.xref .pre {
+    font-weight: normal;
+}
+
+.highlight-python {
+    margin-bottom: 20px;
+}
+
+/* Handle the call out boxes */
+.admonition.alert {
+    color: #2A2A2A;
+    background-color: white;
+    border-color: white;
+    border: 1px white solid;
+    background-image: none;
+    box-shadow: none;
+    padding-left: 10px;
+    border-radius: 10px;
+    margin-bottom: 20px;
+    width: 60%;
+}
+
+.admonition.note {
+   /* border-color: #35A9DE;*/
+    border-left: 2px #35A9DE solid;
+   /* border-bottom: 2px #35A9DE solid;*/
+}
+
+.admonition.warning {
+    border-color: #F89E2E;
+    border-left: 2px #F89E2E solid;
+    border-bottom: 2px #F89E2E solid;
+}
+
+.simple {
+    display: inline-block;
+}
+
+.simple ~ p {
+    clear: both;
+}
+
+.image-reference {
+    float: right;
+}


### PR DESCRIPTION
#1998 

Here's a first go incorporating all the feedback.

![screenshot from 2015-02-27 12 23 49](https://cloud.githubusercontent.com/assets/1796208/6420505/83fcc81e-be7b-11e4-9ccc-6fd646320cc4.png)

I think there are still areas of the docs that don't look as good as they could, but I don't *think* this PR makes them worse. 

For example, in the below, the section heading `bokeh.models.mappers` fades in comparison to the class heading. But messing with the section headings spreads throughout the entire website, so wasn't a quick fix. 

![screenshot from 2015-02-27 12 25 11](https://cloud.githubusercontent.com/assets/1796208/6420545/dca4971c-be7b-11e4-9504-f72522b8bccf.png)



