### PR TITLE
Enable fast development simply by running grunt watch

### DIFF
--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -12,9 +12,7 @@ Attributes:
 
 from __future__ import absolute_import
 
-from os.path import (abspath, join, normpath, realpath, relpath, split, 
-                     splitext, isdir)
-import sys
+from os.path import join, relpath, splitext
 import logging
 logger = logging.getLogger(__name__)
 
@@ -28,21 +26,6 @@ from .settings import settings
 
 _DEV_PAT = re.compile(r"^(\d)+\.(\d)+\.(\d)+(dev|rc)")
 
-def _server_static_dir():
-    return join(abspath(split(__file__)[0]), "server", "static")
-
-def _bokehjs_build_dir():
-    return join(abspath(split(split(__file__)[0])[0]), 'bokehjs', 'build')
-
-def _static_path(path, dev=False):
-    # Prefer sources from bokehjs if dev
-    dir = _bokehjs_build_dir()
-    if (not dev) or (not isdir(dir)):
-        dir = _server_static_dir()
-    # Normalize
-    path = normpath(join(dir, path))
-    if sys.platform == 'cygwin': path = realpath(path)
-    return path
 
 def _cdn_base_url():
     return "http://cdn.pydata.org"
@@ -99,11 +82,6 @@ def _inline(paths):
         end = "/* END %s */" % path
         strings.append(begin + '\n' + middle + '\n' + end)
     return strings
-
-def _file_paths(files, minified, dev=False):
-    if minified:
-        files = [ root + ".min" + ext for (root, ext) in map(splitext, files) ]
-    return [ _static_path(file, dev) for file in files ]
 
 
 class Resources(object):
@@ -195,7 +173,7 @@ class Resources(object):
 
         js_paths = self._js_paths(dev=self.dev, minified=self.minified)
         css_paths = self._css_paths(dev=self.dev, minified=self.minified)
-        base_url = _static_path("js", dev=self.dev)
+        base_url = join(settings.bokehjsdir(self.dev), "js")
 
         self._js_raw = []
         self._css_raw = []
@@ -264,14 +242,19 @@ class Resources(object):
             return self._root_url
         else:
             return self._default_root_url
+    
+    def _file_paths(self, files, minified):
+        if minified:
+            files = [ root + ".min" + ext for (root, ext) in map(splitext, files) ]
+        return [ join(settings.bokehjsdir(self.dev), file) for file in files ]
 
     def _js_paths(self, minified=True, dev=False):
         files = self._default_js_files_dev if self.dev else self._default_js_files
-        return _file_paths(files, False if dev else minified, dev)
+        return self._file_paths(files, False if dev else minified)
 
     def _css_paths(self, minified=True, dev=False):
         files = self._default_css_files_dev if self.dev else self._default_css_files
-        return _file_paths(files, False if dev else minified, dev)
+        return self._file_paths(files, False if dev else minified)
 
     @property
     def js_wrapper(self):

--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -12,17 +12,16 @@ Attributes:
 
 from __future__ import absolute_import
 
-from os.path import join, relpath, splitext
 import logging
 logger = logging.getLogger(__name__)
-
-from os.path import abspath, join, normpath, realpath, relpath, split, splitext
-import re, sys
+from os.path import join, relpath, splitext
+import re
 
 import six
 
 from . import __version__
 from .settings import settings
+from .util.paths import bokehjsdir
 
 _DEV_PAT = re.compile(r"^(\d)+\.(\d)+\.(\d)+(dev|rc)")
 
@@ -173,7 +172,7 @@ class Resources(object):
 
         js_paths = self._js_paths(dev=self.dev, minified=self.minified)
         css_paths = self._css_paths(dev=self.dev, minified=self.minified)
-        base_url = join(settings.bokehjsdir(self.dev), "js")
+        base_url = join(bokehjsdir(self.dev), "js")
 
         self._js_raw = []
         self._css_raw = []
@@ -246,7 +245,7 @@ class Resources(object):
     def _file_paths(self, files, minified):
         if minified:
             files = [ root + ".min" + ext for (root, ext) in map(splitext, files) ]
-        return [ join(settings.bokehjsdir(self.dev), file) for file in files ]
+        return [ join(bokehjsdir(self.dev), file) for file in files ]
 
     def _js_paths(self, minified=True, dev=False):
         files = self._default_js_files_dev if self.dev else self._default_js_files

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -2,13 +2,15 @@ from __future__ import absolute_import
 
 import logging
 import os
-import sys
-from os.path import join, dirname, abspath, realpath, normpath, exists
+from os.path import join, abspath, isdir
+
+from .util.paths import ROOT_DIR, bokehjsdir
+
 
 class Settings(object):
-    debugjs = False
     _prefix = "BOKEH_"
-    
+    debugjs = False
+
     @property
     def _environ(self):
         return os.environ
@@ -83,32 +85,18 @@ class Settings(object):
     """
     Server settings go here:
     """
-    def serverdir(self):
-        path = join(dirname(abspath(__file__)), 'server')
-        path = normpath(path)
-        if sys.platform == 'cygwin': path = realpath(path)
-        return path
     
     def bokehjssrcdir(self):
         if self.debugjs:
-            basedir = dirname(dirname(self.serverdir()))
-            bokehjsdir = join(basedir, 'bokehjs', 'src')
+            bokehjssrcdir = abspath(join(ROOT_DIR, '..', 'bokehjs', 'src'))
 
-            if exists(bokehjsdir):
-                return bokehjsdir
+            if isdir(bokehjssrcdir):
+                return bokehjssrcdir
 
         return None
 
-    def bokehjsdir(self, debugjs=None):
-        debugjs = self.debugjs if debugjs is None else debugjs
-        if debugjs:
-            basedir = dirname(dirname(self.serverdir()))
-            bokehjsdir = join(basedir, 'bokehjs', 'build')
-
-            if exists(bokehjsdir):
-                return bokehjsdir
-
-        return join(self.serverdir(), 'static')
+    def bokehjsdir(self):
+        return bokehjsdir(self.debugjs)
 
     def js_files(self):
         bokehjsdir = self.bokehjsdir()

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -2,12 +2,13 @@ from __future__ import absolute_import
 
 import logging
 import os
-from os.path import join, dirname, abspath, exists
+import sys
+from os.path import join, dirname, abspath, realpath, normpath, exists
 
 class Settings(object):
-    _prefix = "BOKEH_"
     debugjs = False
-
+    _prefix = "BOKEH_"
+    
     @property
     def _environ(self):
         return os.environ
@@ -83,8 +84,11 @@ class Settings(object):
     Server settings go here:
     """
     def serverdir(self):
-        return join(dirname(abspath(__file__)), 'server')
-
+        path = join(dirname(abspath(__file__)), 'server')
+        path = normpath(path)
+        if sys.platform == 'cygwin': path = realpath(path)
+        return path
+    
     def bokehjssrcdir(self):
         if self.debugjs:
             basedir = dirname(dirname(self.serverdir()))
@@ -95,8 +99,9 @@ class Settings(object):
 
         return None
 
-    def bokehjsdir(self):
-        if self.debugjs:
+    def bokehjsdir(self, debugjs=None):
+        debugjs = self.debugjs if debugjs is None else debugjs
+        if debugjs:
             basedir = dirname(dirname(self.serverdir()))
             bokehjsdir = join(basedir, 'bokehjs', 'build')
 

--- a/bokeh/tests/test_resources.py
+++ b/bokeh/tests/test_resources.py
@@ -97,7 +97,7 @@ class TestResources(unittest.TestCase):
 
         self.assertEqual(len(r.js_raw), 1)
         self.assertTrue(r.js_raw[0].startswith('require.config({ baseUrl:'))
-        self.assertTrue(r.js_raw[0].endswith(join('static', 'js') + '" });'))
+        self.assertTrue(r.js_raw[0].endswith(join('bokehjs', 'build', 'js') + '" });'))
         self.assertEqual(r.css_raw, [])
         self.assertEqual(r.messages, [])
 
@@ -105,7 +105,7 @@ class TestResources(unittest.TestCase):
 
         self.assertEqual(len(r.js_raw), 1)
         self.assertTrue(r.js_raw[0].startswith('require.config({ baseUrl:'))
-        self.assertTrue(r.js_raw[0].endswith(join('static', 'js') + '" });'))
+        self.assertTrue(r.js_raw[0].endswith(join('bokehjs', 'build', 'js') + '" });'))
         self.assertEqual(r.css_raw, [])
         self.assertEqual(r.messages, [])
 
@@ -125,7 +125,7 @@ class TestResources(unittest.TestCase):
 
         self.assertEqual(len(r.js_raw), 1)
         self.assertTrue(r.js_raw[0].startswith('require.config({ baseUrl:'))
-        self.assertTrue(r.js_raw[0].endswith(join('static', 'js') + '" });'))
+        self.assertTrue(r.js_raw[0].endswith(join('bokehjs', 'build', 'js') + '" });'))
         self.assertEqual(r.css_raw, [])
         self.assertEqual(r.messages, [])
 
@@ -145,7 +145,7 @@ class TestResources(unittest.TestCase):
 
         self.assertEqual(len(r.js_raw), 1)
         self.assertTrue(r.js_raw[0].startswith('require.config({ baseUrl:'))
-        self.assertTrue(r.js_raw[0].endswith(join('static', 'js') + '" });'))
+        self.assertTrue(r.js_raw[0].endswith(join('bokehjs', 'build', 'js') + '" });'))
         self.assertEqual(r.css_raw, [])
         self.assertEqual(r.messages, [])
 
@@ -169,3 +169,6 @@ class TestResources(unittest.TestCase):
         for mode in ("server-dev", "relative-dev", "absolute-dev"):
             r = resources.Resources(mode)
             self.assertEqual(r.js_wrapper("foo"), WRAPPER_DEV)
+
+t = TestResources()
+t.test_server_dev()

--- a/bokeh/tests/test_resources.py
+++ b/bokeh/tests/test_resources.py
@@ -169,6 +169,3 @@ class TestResources(unittest.TestCase):
         for mode in ("server-dev", "relative-dev", "absolute-dev"):
             r = resources.Resources(mode)
             self.assertEqual(r.js_wrapper("foo"), WRAPPER_DEV)
-
-t = TestResources()
-t.test_server_dev()

--- a/bokeh/util/paths.py
+++ b/bokeh/util/paths.py
@@ -1,0 +1,27 @@
+import sys
+from os.path import join, dirname, abspath, normpath, realpath, isdir
+
+# Root dir of Bokeh package
+ROOT_DIR = dirname(dirname(abspath(__file__)))
+
+
+def serverdir():
+    """ Get the location of the server subpackage
+    """
+    path = join(ROOT_DIR, 'server')
+    path = normpath(path)
+    if sys.platform == 'cygwin': path = realpath(path)
+    return path
+
+
+def bokehjsdir(dev=False):
+    """ Get the location of the bokehjs source files. If dev is True,
+    the files in bokehjs/build are preferred. Otherwise uses the files
+    in bokeh/server/static.
+    """
+    dir1 = join(ROOT_DIR, '..', 'bokehjs', 'build')
+    dir2 = join(serverdir(), 'static')
+    if dev and isdir(dir1):
+        return dir1
+    else:
+        return dir2

--- a/sphinx/source/docs/dev_guide/building.rst
+++ b/sphinx/source/docs/dev_guide/building.rst
@@ -222,8 +222,9 @@ The processes described about result in building and using a full `bokeh.js`
 library. This could be considered "production" mode. It is also possible to
 run Bokeh code in a mode that utilizes ``require.js`` to serve up individual
 JavaScript modules separately. If this is done, then changes to BokehJS
-can be incrementally compiled (e.g. using ``grunt watch``), and the
-development iteration cycle shortened considerably.
+can be incrementally compiled (e.g. by running ``grunt watch`` in the
+``bokehjs`` directory), and the development iteration cycle shortened
+considerably.
 
 For static examples, you can use the ``BOKEH_RESOURCES`` environement variable
 to indicate that BokehJS should be loaded from individual sources::

--- a/sphinx/source/docs/dev_guide/building.rst
+++ b/sphinx/source/docs/dev_guide/building.rst
@@ -221,8 +221,9 @@ Incremental Compilation
 The processes described about result in building and using a full `bokeh.js`
 library. This could be considered "production" mode. It is also possible to
 run Bokeh code in a mode that utilizes ``require.js`` to serve up individual
-JavaScript modules separately. If this is done, then changes to BokehJS can be incrementally compiled, and the development iteration cycle shortened
-considerably.
+JavaScript modules separately. If this is done, then changes to BokehJS
+can be incrementally compiled (e.g. using ``grunt watch``), and the
+development iteration cycle shortened considerably.
 
 For static examples, you can use the ``BOKEH_RESOURCES`` environement variable
 to indicate that BokehJS should be loaded from individual sources::


### PR DESCRIPTION
issues: closes issue #2038 

When `BOKEH_RESOURCES` is in dev mode (e.g. "relative-dev" or "absolute-dev"), the JS files are taken from `bokehjs/build` instead of `bokeh/server/static`. This  means that you can simply edit the coffeescript file, grunt will generate JS, and you can refresh the page to get the new result.