### PR TITLE
Make models and cli subpackages pyflakes compliant

### DIFF
--- a/bokeh/cli/__init__.py
+++ b/bokeh/cli/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import absolute_import
 
-from .core import cli
+from .core import cli; cli

--- a/bokeh/cli/core.py
+++ b/bokeh/cli/core.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, print_function
 import sys, os
 from six.moves.urllib import request as urllib2
 from six.moves import cStringIO as StringIO
-from six import string_types
 import pandas as pd
 
 try:
@@ -17,7 +16,7 @@ from .utils import (get_chart_params, get_charts_mapping,
                     get_data_series, keep_source_input_sync, get_data_from_url)
 from .. import charts as bc
 from ..charts import utils as bc_utils
-from bokeh.models.widgets import Button, VBox
+from bokeh.models.widgets import Button
 
 # Define a mapping to connect chart types supported arguments and chart classes
 CHARTS_MAP = get_charts_mapping()

--- a/bokeh/cli/utils.py
+++ b/bokeh/cli/utils.py
@@ -76,7 +76,6 @@ def get_data_from_url(request, start=0, length=0):
     Returns:
         String read from request
     """
-    ranged = False
     # Add the header to specify the range to download.
     if start and length:
         request.add_header("Range", "bytes=%d-%d" % (start, start + length - 1))

--- a/bokeh/models/__init__.py
+++ b/bokeh/models/__init__.py
@@ -76,7 +76,7 @@ __all__ = ["AbstractButton", "AbstractGroup", "AbstractIcon", "Action",
 
 if False:
     ##
-    def get_classes_here(modname):
+    def get_class_names_in_module(modname):
         # Get module
         m = __import__(modname)
         for part in  modname.split('.')[1:]:
@@ -92,12 +92,5 @@ if False:
                     classnames.append(name)
         classnames.sort()
         return classnames
-    #print(', '.join(get_classes_here('bokeh.models.widgets')))
-    print('", "'.join(get_classes_here('bokeh.models')))
-
-    
-
-# show_classes_in('widgets/tables')
-
-
-# todo: write small snippet that compiles a list of all names imported here, that we can put here to fool pyflakes
+    #print(', '.join(get_class_names_in_module('bokeh.models.widgets')))
+    print('", "'.join(get_class_names_in_module('bokeh.models')))

--- a/bokeh/models/__init__.py
+++ b/bokeh/models/__init__.py
@@ -1,18 +1,103 @@
 from __future__ import absolute_import
 
-from .actions import *
-from .axes import *
-from .formatters import *
-from .glyphs import *
-from .grids import *
-from .map_plots import *
-from .markers import *
-from .mappers import *
-from .plots import *
-from .ranges import *
-from .renderers import *
-from .sources import *
-from .tickers import *
-from .tools import *
-from .widget import *
-from .widgets import *
+
+
+from .actions import PlotObject, Action, OpenURL; PlotObject; Action; OpenURL
+from .axes import (Axis, ContinuousAxis, LinearAxis, LogAxis, CategoricalAxis,
+                   DatetimeAxis)
+from .formatters import (TickFormatter, BasicTickFormatter, NumeralTickFormatter,
+                         PrintfTickFormatter, LogTickFormatter,
+                         CategoricalTickFormatter, DatetimeTickFormatter)
+from .glyphs import (Glyph, AnnularWedge, Annulus, Arc, Bezier, Gear, Image,
+                     ImageRGBA, ImageURL, Line, MultiLine, Oval, Patch, Patches,
+                     Quad, Quadratic, Ray, Rect, Segment, Text, Wedge)
+from .grids import Grid
+from .map_plots import GMapOptions, GMapPlot, GeoJSOptions, GeoJSPlot
+from .markers import (Marker, Asterisk, Circle, CircleCross, CircleX, Cross,
+                      Diamond, DiamondCross, InvertedTriangle, Square,
+                      SquareCross, SquareX, Triangle, X)
+from .mappers import ColorMapper, LinearColorMapper
+from .plots import PlotContext, PlotList, Plot, GridPlot
+from .ranges import Range, Range1d, DataRange, DataRange1d, FactorRange
+from .renderers import Renderer, GlyphRenderer, Legend, GuideRenderer
+from .sources import (DataSource, ColumnsRef, ColumnDataSource, RemoteSource,
+                      AjaxDataSource, BlazeDataSource, ServerDataSource)
+from .tickers import (Ticker, AdaptiveTicker, CompositeTicker, SingleIntervalTicker,
+                      DaysTicker, MonthsTicker, YearsTicker, BasicTicker, LogTicker,
+                      CategoricalTicker, DatetimeTicker)
+from .tools import (ToolEvents, Tool, PanTool, WheelZoomTool, PreviewSaveTool,
+                    ResetTool, ResizeTool, TapTool, CrosshairTool, BoxZoomTool,
+                    BoxSelectTool, BoxSelectionOverlay, LassoSelectTool,
+                    PolySelectTool, HoverTool)
+from .widget import Widget
+from .widgets import (AbstractButton, AbstractGroup, AbstractIcon, AutocompleteInput,
+                      BaseBox, BooleanFormatter, Button, ButtonGroup, CellEditor,
+                      CellFormatter, CheckboxButtonGroup, CheckboxEditor,
+                      CheckboxGroup, DataTable, DateEditor, DateFormatter, DatePicker,
+                       DateRangeSlider, Dialog, Dropdown, Group, HBox, Icon,
+                       InputWidget, IntEditor, Layout, MultiSelect, NumberEditor,
+                       NumberFormatter, Panel, Paragraph, PercentEditor, PreText,
+                       RadioButtonGroup, RadioGroup, Select, SelectEditor, Slider,
+                       StringEditor, StringFormatter, TableColumn, TableWidget, Tabs,
+                       TextEditor, TextInput, TimeEditor, Toggle, VBox, VBoxForm)
+
+# Define __all__ to make pyflakes happy
+__all__ = ["AbstractButton", "AbstractGroup", "AbstractIcon", "Action",
+"AdaptiveTicker", "AjaxDataSource", "AnnularWedge", "Annulus", "Arc",
+"Asterisk", "AutocompleteInput", "Axis", "BaseBox", "BasicTickFormatter",
+"BasicTicker", "Bezier", "BlazeDataSource", "BooleanFormatter",
+"BoxSelectTool", "BoxSelectionOverlay", "BoxZoomTool", "Button",
+"ButtonGroup", "CategoricalAxis", "CategoricalTickFormatter",
+"CategoricalTicker", "CellEditor", "CellFormatter", "CheckboxButtonGroup",
+"CheckboxEditor", "CheckboxGroup", "Circle", "CircleCross", "CircleX",
+"ColorMapper", "ColumnDataSource", "ColumnsRef", "CompositeTicker",
+"ContinuousAxis", "Cross", "CrosshairTool", "DataRange", "DataRange1d",
+"DataSource", "DataTable", "DateEditor", "DateFormatter", "DatePicker",
+"DateRangeSlider", "DatetimeAxis", "DatetimeTickFormatter", "DatetimeTicker",
+"DaysTicker", "Dialog", "Diamond", "DiamondCross", "Dropdown", "FactorRange",
+"GMapOptions", "GMapPlot", "Gear", "GeoJSOptions", "GeoJSPlot", "Glyph",
+"GlyphRenderer", "Grid", "GridPlot", "Group", "GuideRenderer", "HBox",
+"HoverTool", "Icon", "Image", "ImageRGBA", "ImageURL", "InputWidget",
+"IntEditor", "InvertedTriangle", "LassoSelectTool", "Layout", "Legend",
+"Line", "LinearAxis", "LinearColorMapper", "LogAxis", "LogTickFormatter",
+"LogTicker", "Marker", "MonthsTicker", "MultiLine", "MultiSelect",
+"NumberEditor", "NumberFormatter", "NumeralTickFormatter", "OpenURL", "Oval",
+"PanTool", "Panel", "Paragraph", "Patch", "Patches", "PercentEditor", "Plot",
+"PlotContext", "PlotList", "PolySelectTool", "PreText", "PreviewSaveTool",
+"PrintfTickFormatter", "Quad", "Quadratic", "RadioButtonGroup", "RadioGroup",
+"Range", "Range1d", "Ray", "Rect", "RemoteSource", "Renderer", "ResetTool",
+"ResizeTool", "Segment", "Select", "SelectEditor", "ServerDataSource",
+"SingleIntervalTicker", "Slider", "Square", "SquareCross", "SquareX",
+"StringEditor", "StringFormatter", "TableColumn", "TableWidget", "Tabs",
+"TapTool", "Text", "TextEditor", "TextInput", "TickFormatter", "Ticker",
+"TimeEditor", "Toggle", "Tool", "ToolEvents", "Triangle", "VBox", "VBoxForm",
+"Wedge", "WheelZoomTool", "Widget", "X", "YearsTicker"]
+
+
+if False:
+    ##
+    def get_classes_here(modname):
+        # Get module
+        m = __import__(modname)
+        for part in  modname.split('.')[1:]:
+            m = getattr(m, part)
+        # Collect classes that are defined in this module (or deeper)
+        classnames = []
+        for name in dir(m):
+            if name.startswith('_'):
+                continue
+            ob = getattr(m, name)
+            if isinstance(ob, type):
+                if ob.__module__.startswith(modname):
+                    classnames.append(name)
+        classnames.sort()
+        return classnames
+    #print(', '.join(get_classes_here('bokeh.models.widgets')))
+    print('", "'.join(get_classes_here('bokeh.models')))
+
+    
+
+# show_classes_in('widgets/tables')
+
+
+# todo: write small snippet that compiles a list of all names imported here, that we can put here to fool pyflakes

--- a/bokeh/models/__init__.py
+++ b/bokeh/models/__init__.py
@@ -2,32 +2,19 @@ from __future__ import absolute_import
 
 # This file is excluded from flake8 checking in setup.cfg
 
-from .actions import PlotObject, Action, OpenURL; PlotObject; Action; OpenURL
-from .axes import (Axis, ContinuousAxis, LinearAxis, LogAxis, CategoricalAxis,
-                   DatetimeAxis)
-from .formatters import (TickFormatter, BasicTickFormatter, NumeralTickFormatter,
-                         PrintfTickFormatter, LogTickFormatter,
-                         CategoricalTickFormatter, DatetimeTickFormatter)
-from .glyphs import (Glyph, AnnularWedge, Annulus, Arc, Bezier, Gear, Image,
-                     ImageRGBA, ImageURL, Line, MultiLine, Oval, Patch, Patches,
-                     Quad, Quadratic, Ray, Rect, Segment, Text, Wedge)
-from .grids import Grid
-from .map_plots import GMapOptions, GMapPlot, GeoJSOptions, GeoJSPlot
-from .markers import (Marker, Asterisk, Circle, CircleCross, CircleX, Cross,
-                      Diamond, DiamondCross, InvertedTriangle, Square,
-                      SquareCross, SquareX, Triangle, X)
-from .mappers import ColorMapper, LinearColorMapper
-from .plots import PlotContext, PlotList, Plot, GridPlot
-from .ranges import Range, Range1d, DataRange, DataRange1d, FactorRange
-from .renderers import Renderer, GlyphRenderer, Legend, GuideRenderer
-from .sources import (DataSource, ColumnsRef, ColumnDataSource, RemoteSource,
-                      AjaxDataSource, BlazeDataSource, ServerDataSource)
-from .tickers import (Ticker, AdaptiveTicker, CompositeTicker, SingleIntervalTicker,
-                      DaysTicker, MonthsTicker, YearsTicker, BasicTicker, LogTicker,
-                      CategoricalTicker, DatetimeTicker)
-from .tools import (ToolEvents, Tool, PanTool, WheelZoomTool, PreviewSaveTool,
-                    ResetTool, ResizeTool, TapTool, CrosshairTool, BoxZoomTool,
-                    BoxSelectTool, BoxSelectionOverlay, LassoSelectTool,
-                    PolySelectTool, HoverTool)
-from .widget import Widget
-from .widgets import *  # is already a clean namespace with exactly what we want to import
+from .actions import *
+from .axes import *
+from .formatters import *
+from .glyphs import *
+from .grids import *
+from .map_plots import *
+from .markers import *
+from .mappers import *
+from .plots import *
+from .ranges import *
+from .renderers import *
+from .sources import *
+from .tickers import *
+from .tools import *
+from .widget import *
+from .widgets import *

--- a/bokeh/models/__init__.py
+++ b/bokeh/models/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-
+# This file is excluded from flake8 checking in setup.cfg
 
 from .actions import PlotObject, Action, OpenURL; PlotObject; Action; OpenURL
 from .axes import (Axis, ContinuousAxis, LinearAxis, LogAxis, CategoricalAxis,
@@ -30,67 +30,4 @@ from .tools import (ToolEvents, Tool, PanTool, WheelZoomTool, PreviewSaveTool,
                     BoxSelectTool, BoxSelectionOverlay, LassoSelectTool,
                     PolySelectTool, HoverTool)
 from .widget import Widget
-from .widgets import (AbstractButton, AbstractGroup, AbstractIcon, AutocompleteInput,
-                      BaseBox, BooleanFormatter, Button, ButtonGroup, CellEditor,
-                      CellFormatter, CheckboxButtonGroup, CheckboxEditor,
-                      CheckboxGroup, DataTable, DateEditor, DateFormatter, DatePicker,
-                       DateRangeSlider, Dialog, Dropdown, Group, HBox, Icon,
-                       InputWidget, IntEditor, Layout, MultiSelect, NumberEditor,
-                       NumberFormatter, Panel, Paragraph, PercentEditor, PreText,
-                       RadioButtonGroup, RadioGroup, Select, SelectEditor, Slider,
-                       StringEditor, StringFormatter, TableColumn, TableWidget, Tabs,
-                       TextEditor, TextInput, TimeEditor, Toggle, VBox, VBoxForm)
-
-# Define __all__ to make pyflakes happy
-__all__ = ["AbstractButton", "AbstractGroup", "AbstractIcon", "Action",
-"AdaptiveTicker", "AjaxDataSource", "AnnularWedge", "Annulus", "Arc",
-"Asterisk", "AutocompleteInput", "Axis", "BaseBox", "BasicTickFormatter",
-"BasicTicker", "Bezier", "BlazeDataSource", "BooleanFormatter",
-"BoxSelectTool", "BoxSelectionOverlay", "BoxZoomTool", "Button",
-"ButtonGroup", "CategoricalAxis", "CategoricalTickFormatter",
-"CategoricalTicker", "CellEditor", "CellFormatter", "CheckboxButtonGroup",
-"CheckboxEditor", "CheckboxGroup", "Circle", "CircleCross", "CircleX",
-"ColorMapper", "ColumnDataSource", "ColumnsRef", "CompositeTicker",
-"ContinuousAxis", "Cross", "CrosshairTool", "DataRange", "DataRange1d",
-"DataSource", "DataTable", "DateEditor", "DateFormatter", "DatePicker",
-"DateRangeSlider", "DatetimeAxis", "DatetimeTickFormatter", "DatetimeTicker",
-"DaysTicker", "Dialog", "Diamond", "DiamondCross", "Dropdown", "FactorRange",
-"GMapOptions", "GMapPlot", "Gear", "GeoJSOptions", "GeoJSPlot", "Glyph",
-"GlyphRenderer", "Grid", "GridPlot", "Group", "GuideRenderer", "HBox",
-"HoverTool", "Icon", "Image", "ImageRGBA", "ImageURL", "InputWidget",
-"IntEditor", "InvertedTriangle", "LassoSelectTool", "Layout", "Legend",
-"Line", "LinearAxis", "LinearColorMapper", "LogAxis", "LogTickFormatter",
-"LogTicker", "Marker", "MonthsTicker", "MultiLine", "MultiSelect",
-"NumberEditor", "NumberFormatter", "NumeralTickFormatter", "OpenURL", "Oval",
-"PanTool", "Panel", "Paragraph", "Patch", "Patches", "PercentEditor", "Plot",
-"PlotContext", "PlotList", "PolySelectTool", "PreText", "PreviewSaveTool",
-"PrintfTickFormatter", "Quad", "Quadratic", "RadioButtonGroup", "RadioGroup",
-"Range", "Range1d", "Ray", "Rect", "RemoteSource", "Renderer", "ResetTool",
-"ResizeTool", "Segment", "Select", "SelectEditor", "ServerDataSource",
-"SingleIntervalTicker", "Slider", "Square", "SquareCross", "SquareX",
-"StringEditor", "StringFormatter", "TableColumn", "TableWidget", "Tabs",
-"TapTool", "Text", "TextEditor", "TextInput", "TickFormatter", "Ticker",
-"TimeEditor", "Toggle", "Tool", "ToolEvents", "Triangle", "VBox", "VBoxForm",
-"Wedge", "WheelZoomTool", "Widget", "X", "YearsTicker"]
-
-
-if False:
-    ##
-    def get_class_names_in_module(modname):
-        # Get module
-        m = __import__(modname)
-        for part in  modname.split('.')[1:]:
-            m = getattr(m, part)
-        # Collect classes that are defined in this module (or deeper)
-        classnames = []
-        for name in dir(m):
-            if name.startswith('_'):
-                continue
-            ob = getattr(m, name)
-            if isinstance(ob, type):
-                if ob.__module__.startswith(modname):
-                    classnames.append(name)
-        classnames.sort()
-        return classnames
-    #print(', '.join(get_class_names_in_module('bokeh.models.widgets')))
-    print('", "'.join(get_class_names_in_module('bokeh.models')))
+from .widgets import *  # is already a clean namespace with exactly what we want to import

--- a/bokeh/models/axes.py
+++ b/bokeh/models/axes.py
@@ -10,7 +10,8 @@ from ..enums import Location
 
 from .renderers import GuideRenderer
 from .tickers import Ticker, BasicTicker, LogTicker, CategoricalTicker, DatetimeTicker
-from .formatters import TickFormatter, BasicTickFormatter, LogTickFormatter, CategoricalTickFormatter, DatetimeTickFormatter
+from .formatters import (TickFormatter, BasicTickFormatter, LogTickFormatter, 
+                         CategoricalTickFormatter, DatetimeTickFormatter)
 
 class Axis(GuideRenderer):
     """ A base class that defines common properties for all axis types.

--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -7,8 +7,8 @@ from __future__ import absolute_import
 
 from ..plot_object import PlotObject
 from ..mixins import FillProps, LineProps, TextProps
-from ..enums import Units, AngleUnits, Direction, Anchor
-from ..properties import Align, Bool, DataSpec, Enum, HasProps, Include, Instance, Size
+from ..enums import Direction, Anchor
+from ..properties import Bool, DataSpec, Enum, Include, Instance
 
 from .mappers import LinearColorMapper
 
@@ -968,4 +968,10 @@ class Wedge(Glyph):
     """)
 
 # XXX: allow `from bokeh.models.glyphs import *`
-from .markers import *
+from .markers import (Marker, Asterisk, Circle, CircleCross, CircleX, Cross,
+                      Diamond, DiamondCross, InvertedTriangle, Square,
+                      SquareCross, SquareX, Triangle, X)
+
+# Fool pyflakes
+(Marker, Asterisk, Circle, CircleCross, CircleX, Cross, Diamond, DiamondCross,
+InvertedTriangle, Square, SquareCross, SquareX, Triangle, X)

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -177,7 +177,7 @@ class Plot(Widget):
 
         if hasattr(obj, 'plot'):
             if obj.plot is not None:
-                 raise ValueError("object to be added already has 'plot' attribute set")
+                raise ValueError("object to be added already has 'plot' attribute set")
             obj.plot = self
 
         self.renderers.append(obj)
@@ -200,7 +200,7 @@ class Plot(Widget):
 
         for tool in tools:
             if tool.plot is not None:
-                 raise ValueError("tool %s to be added already has 'plot' attribute set" % tool)
+                raise ValueError("tool %s to be added already has 'plot' attribute set" % tool)
             tool.plot = self
             self.tools.append(tool)
 

--- a/bokeh/models/renderers.py
+++ b/bokeh/models/renderers.py
@@ -9,7 +9,7 @@ from ..properties import Int, String, Enum, Instance, List, Dict, Tuple, Include
 from ..mixins import LineProps, TextProps
 from ..enums import Units, Orientation
 
-from .sources import DataSource, ServerDataSource
+from .sources import DataSource
 from .glyphs import Glyph
 
 class Renderer(PlotObject):

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -250,7 +250,7 @@ class BlazeDataSource(RemoteSource):
     def to_blaze(self):
         from blaze.server.client import Client
         from blaze.server import from_tree
-        from blaze import Data, Symbol
+        from blaze import Data
         # hacky - blaze urls have `compute.json` in it, but we need to strip it off
         # to feed it into the blaze client lib
         c = Client(self.data_url.rsplit('compute.json', 1)[0])

--- a/bokeh/models/tests/test_plots.py
+++ b/bokeh/models/tests/test_plots.py
@@ -13,9 +13,8 @@ import unittest
 
 from bokeh.plotting import figure
 from bokeh.models import GlyphRenderer
-from bokeh.models.tools import HoverTool, PanTool
+from bokeh.models.tools import PanTool
 
-import bokeh.models.plots as plots
 
 class TestPlotSelect(unittest.TestCase):
 

--- a/bokeh/models/tests/test_plots.py
+++ b/bokeh/models/tests/test_plots.py
@@ -43,7 +43,7 @@ class TestPlotSelect(unittest.TestCase):
 
     def test_too_many_args(self):
         with self.assertRaises(TypeError) as cm:
-             self._plot.select('foo', 'bar')
+            self._plot.select('foo', 'bar')
         self.assertEqual(
             'select accepts at most ONE positional argument.',
             str(cm.exception)
@@ -51,7 +51,7 @@ class TestPlotSelect(unittest.TestCase):
 
     def test_no_input(self):
         with self.assertRaises(TypeError) as cm:
-             self._plot.select()
+            self._plot.select()
         self.assertEqual(
             'select requires EITHER a positional argument, OR keyword arguments.',
             str(cm.exception)
@@ -59,7 +59,7 @@ class TestPlotSelect(unittest.TestCase):
 
     def test_arg_and_kwarg(self):
         with self.assertRaises(TypeError) as cm:
-             self._plot.select('foo', type=PanTool)
+            self._plot.select('foo', type=PanTool)
         self.assertEqual(
             'select accepts EITHER a positional argument, OR keyword arguments (not both).',
             str(cm.exception)

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -27,7 +27,6 @@ from ..properties import Any, Bool, String, Enum, Instance, Either, List, Dict, 
 from ..enums import Dimension
 
 from .renderers import Renderer
-from .ranges import Range
 from .actions import Action
 
 class ToolEvents(PlotObject):

--- a/bokeh/models/widgets/__init__.py
+++ b/bokeh/models/widgets/__init__.py
@@ -2,18 +2,12 @@ from __future__ import absolute_import
 
 # This file is excluded from flake8 checking in setup.cfg
 
-from .buttons import AbstractButton, Button, Toggle, Dropdown
-from .dialogs import Dialog
-from .groups import (AbstractGroup, ButtonGroup, Group, CheckboxGroup,
-                     RadioGroup, CheckboxButtonGroup, RadioButtonGroup)
-from .icons import AbstractIcon, Icon
-from .inputs import (InputWidget, TextInput, AutocompleteInput, Select,
-                     MultiSelect, Slider, DateRangeSlider, DatePicker)
-from .layouts import Layout, BaseBox, HBox, VBox, VBoxForm
-from .markups import Paragraph, PreText
-from .panels import Panel, Tabs
-from .tables import (CellFormatter, CellEditor, StringFormatter, NumberFormatter,
-                     BooleanFormatter, DateFormatter, StringEditor, TextEditor,
-                     SelectEditor, PercentEditor, CheckboxEditor, IntEditor,
-                     NumberEditor, TimeEditor, DateEditor, TableColumn,
-                     TableWidget, DataTable)
+from .buttons import *
+from .dialogs import *
+from .groups import *
+from .icons import *
+from .inputs import *
+from .layouts import *
+from .markups import *
+from .panels import *
+from .tables import *

--- a/bokeh/models/widgets/__init__.py
+++ b/bokeh/models/widgets/__init__.py
@@ -1,11 +1,29 @@
 from __future__ import absolute_import
 
-from .buttons import *
-from .dialogs import *
-from .groups import *
-from .icons import *
-from .inputs import *
-from .layouts import *
-from .markups import *
-from .panels import *
-from .tables import *
+from .buttons import AbstractButton, Button, Toggle, Dropdown
+from .dialogs import Dialog
+from .groups import (AbstractGroup, ButtonGroup, Group, CheckboxGroup,
+                     RadioGroup, CheckboxButtonGroup, RadioButtonGroup)
+from .icons import AbstractIcon, Icon
+from .inputs import (InputWidget, TextInput, AutocompleteInput, Select,
+                     MultiSelect, Slider, DateRangeSlider, DatePicker)
+from .layouts import Layout, BaseBox, HBox, VBox, VBoxForm
+from .markups import Paragraph, PreText
+from .panels import Panel, Tabs
+from .tables import (CellFormatter, CellEditor, StringFormatter, NumberFormatter,
+                     BooleanFormatter, DateFormatter, StringEditor, TextEditor,
+                     SelectEditor, PercentEditor, CheckboxEditor, IntEditor,
+                     NumberEditor, TimeEditor, DateEditor, TableColumn,
+                     TableWidget, DataTable)
+
+# Define __all__ to make pyflakes happy
+__all__ = ["AbstractButton", "AbstractGroup", "AbstractIcon", "AutocompleteInput",
+"BaseBox", "BooleanFormatter", "Button", "ButtonGroup", "CellEditor",
+"CellFormatter", "CheckboxButtonGroup", "CheckboxEditor", "CheckboxGroup",
+"DataTable", "DateEditor", "DateFormatter", "DatePicker", "DateRangeSlider",
+"Dialog", "Dropdown", "Group", "HBox", "Icon", "InputWidget", "IntEditor",
+"Layout", "MultiSelect", "NumberEditor", "NumberFormatter", "Panel", "Paragraph",
+"PercentEditor", "PreText", "RadioButtonGroup", "RadioGroup", "Select",
+"SelectEditor", "Slider", "StringEditor", "StringFormatter", "TableColumn",
+"TableWidget", "Tabs", "TextEditor", "TextInput", "TimeEditor", "Toggle", "VBox",
+"VBoxForm"]

--- a/bokeh/models/widgets/__init__.py
+++ b/bokeh/models/widgets/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+# This file is excluded from flake8 checking in setup.cfg
+
 from .buttons import AbstractButton, Button, Toggle, Dropdown
 from .dialogs import Dialog
 from .groups import (AbstractGroup, ButtonGroup, Group, CheckboxGroup,
@@ -15,15 +17,3 @@ from .tables import (CellFormatter, CellEditor, StringFormatter, NumberFormatter
                      SelectEditor, PercentEditor, CheckboxEditor, IntEditor,
                      NumberEditor, TimeEditor, DateEditor, TableColumn,
                      TableWidget, DataTable)
-
-# Define __all__ to make pyflakes happy
-__all__ = ["AbstractButton", "AbstractGroup", "AbstractIcon", "AutocompleteInput",
-"BaseBox", "BooleanFormatter", "Button", "ButtonGroup", "CellEditor",
-"CellFormatter", "CheckboxButtonGroup", "CheckboxEditor", "CheckboxGroup",
-"DataTable", "DateEditor", "DateFormatter", "DatePicker", "DateRangeSlider",
-"Dialog", "Dropdown", "Group", "HBox", "Icon", "InputWidget", "IntEditor",
-"Layout", "MultiSelect", "NumberEditor", "NumberFormatter", "Panel", "Paragraph",
-"PercentEditor", "PreText", "RadioButtonGroup", "RadioGroup", "Select",
-"SelectEditor", "Slider", "StringEditor", "StringFormatter", "TableColumn",
-"TableWidget", "Tabs", "TextEditor", "TextInput", "TimeEditor", "Toggle", "VBox",
-"VBoxForm"]

--- a/bokeh/models/widgets/groups.py
+++ b/bokeh/models/widgets/groups.py
@@ -3,7 +3,7 @@
 """
 from __future__ import absolute_import
 
-from ...properties import Bool, Int, String, Enum, Instance, List
+from ...properties import Bool, Int, String, Enum, List
 from ...enums import ButtonType
 from ..widget import Widget
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,15 @@
+[flake8]
+# References:
+# http://flake8.readthedocs.org/en/latest/config.html
+# http://flake8.readthedocs.org/en/latest/warnings.html#error-codes
+#
+# Style checks turned on:
+#   F - all pyflake errors
+#   E101 - indentation contains mixed spaces and tabs
+#   E111 - indentation is not a multiple of four
+#   E501 - line too long (see max-line-length)
+
+exclude = bokeh/models/__init__.py, bokeh/models/widgets/__init__.py
+ignore = E,W
+select = F,E101,E111,E501
+max-line-length = 120


### PR DESCRIPTION
issues: ref #2078 

These changes make the `bokeh.cli` and `bokeh.models` subpackages compliant with pyflakes. Especially the latter needed significant changes in the `__init__`; pyflakes does not allow `from x import *`, so I had to make them all explicit imports. But the list of names to import became so long that I wrote a small function to collect these names. The names to import is particularly long for the widgets module.

To shut pyflakes up about unused imports, apparently you can also use `__all__` which I personally found a bit nicer than just stating the names.  Happy to revert this to just stating a tuple of names though.

I am generally in favor of explicit imports, but in the case of importing all widgets, a star-import would be justified IMO. However, there is no way to shut pyflakes up unless we use flake8 ...
