### PR TITLE
Feature/helptool

### DIFF
--- a/bokeh/charts/tests/test_chart.py
+++ b/bokeh/charts/tests/test_chart.py
@@ -25,7 +25,7 @@ from bokeh.models import (
     ColumnDataSource, Grid, GlyphRenderer, LinearAxis, Range1d, Ticker)
 from bokeh.models.ranges import FactorRange
 from bokeh.models.tools import (
-    BoxZoomTool, LassoSelectTool, PanTool, PreviewSaveTool, ResetTool,
+    BoxZoomTool, HelpTool, LassoSelectTool, PanTool, PreviewSaveTool, ResetTool,
     ResizeTool, WheelZoomTool)
 
 #-----------------------------------------------------------------------------
@@ -156,7 +156,7 @@ class TestChart(unittest.TestCase):
             width=800, height=600, filename=False, server=False, notebook=False
         )
         expected = [
-            [PanTool,  WheelZoomTool, BoxZoomTool, PreviewSaveTool, ResizeTool, ResetTool],
+            [PanTool,  WheelZoomTool, BoxZoomTool, PreviewSaveTool, ResizeTool, ResetTool, HelpTool],
             [],
             [ResizeTool, PanTool,  BoxZoomTool, ResetTool, LassoSelectTool],
         ]

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -412,3 +412,18 @@ class HoverTool(Tool):
         the ``Rect`` and ``Quad`` glyphs are supported.
 
     """)
+
+class HelpTool(Tool):
+    """
+    The help tool is a widget designed to replace the hardcoded 'Help' link.
+    The hover text can be customized through the ``help_tooltip`` attribute
+    and the redirect site overridden as well. 
+    """
+
+    help_tooltip = String(help="""
+    Tooltip displayed when hovering over the help icon.
+    """)
+
+    redirect = String(help="""
+    Site to be redirected through upon click.
+    """)

--- a/bokeh/plotting.py
+++ b/bokeh/plotting.py
@@ -36,7 +36,7 @@ def HBox(*args, **kwargs):
     return hplot(*args, **kwargs)
 
 
-DEFAULT_TOOLS = "pan,wheel_zoom,box_zoom,save,resize,reset"
+DEFAULT_TOOLS = "pan,wheel_zoom,box_zoom,save,resize,reset,help"
 
 class Figure(Plot):
     __subtype__ = "Figure"

--- a/bokeh/plotting_helpers.py
+++ b/bokeh/plotting_helpers.py
@@ -12,7 +12,7 @@ from .models import glyphs
 from .models import (
     BoxSelectionOverlay, BoxSelectTool, BoxZoomTool, CategoricalAxis,
     ColumnDataSource, RemoteSource, TapTool, CrosshairTool, DataRange1d, DatetimeAxis,
-    FactorRange, Grid, HoverTool, LassoSelectTool, Legend, LinearAxis,
+    FactorRange, Grid, HelpTool, HoverTool, LassoSelectTool, Legend, LinearAxis,
     LogAxis, PanTool, Plot, PolySelectTool,
     PreviewSaveTool, Range, Range1d, ResetTool, ResizeTool, Tool,
     WheelZoomTool)
@@ -243,6 +243,7 @@ _known_tools = {
     ]),
     "previewsave": lambda: PreviewSaveTool(),
     "reset": lambda: ResetTool(),
+    "help": lambda: HelpTool(),
 }
 
 def _tool_from_string(name):

--- a/bokehjs/src/coffee/common/base.coffee
+++ b/bokehjs/src/coffee/common/base.coffee
@@ -115,6 +115,7 @@ locations =
   ActionTool:               require '../tool/actions/action_tool'
   PreviewSaveTool:          require '../tool/actions/preview_save_tool'
   ResetTool:                require '../tool/actions/reset_tool'
+  HelpTool:                 require '../tool/actions/help_tool'
 
   BoxSelectTool:            require '../tool/gestures/box_select_tool'
   BoxZoomTool:              require '../tool/gestures/box_zoom_tool'

--- a/bokehjs/src/coffee/common/tool_manager.coffee
+++ b/bokehjs/src/coffee/common/tool_manager.coffee
@@ -7,6 +7,7 @@ else
   $$1 = require "bootstrap/dropdown"
 Backbone = require "backbone"
 ActionTool = require "../tool/actions/action_tool"
+HelpTool = require "../tool/actions/help_tool"
 GestureTool = require "../tool/gestures/gesture_tool"
 InspectTool = require "../tool/inspectors/inspect_tool"
 {logger} = require "./logging"
@@ -46,6 +47,11 @@ class ToolManagerView extends Backbone.View
       ul.appendTo(button_bar_list)
       anchor.dropdown()
 
+    button_bar_list = @$(".bk-button-bar-list[type='help']")
+    _.each(@model.get('help'), (item) ->
+      button_bar_list.append(new ActionTool.ButtonView({model: item}).el)
+    )
+
     button_bar_list = @$(".bk-button-bar-list[type='actions']")
     _.each(@model.get('actions'), (item) ->
       button_bar_list.append(new ActionTool.ButtonView({model: item}).el)
@@ -74,6 +80,11 @@ class ToolManager extends HasProperties
         inspectors = @get('inspectors')
         inspectors.push(tool)
         @set('inspectors', inspectors)
+
+      else if tool instanceof HelpTool.Model
+        help = @get('help')
+        help.push(tool)
+        @set('help', help)
 
       else if tool instanceof ActionTool.Model
         actions = @get('actions')
@@ -131,6 +142,7 @@ class ToolManager extends HasProperties
       }
       actions: []
       inspectors: []
+      help: []
     }
 
 module.exports =

--- a/bokehjs/src/coffee/common/toolbar_template.eco
+++ b/bokehjs/src/coffee/common/toolbar_template.eco
@@ -12,16 +12,4 @@
   <ul class='bk-button-bar-list' type="rotate" />
   <ul class='bk-button-bar-list' type="actions" />
   <div class='bk-button-bar-list bk-bs-dropdown' type="inspectors" />
-  <ul class='bk-button-bar-list' type="help">
-    <li>
-  	  <button class="bk-toolbar-button help" title="Help">
-      <a href="http://bokeh.pydata.org/en/latest/docs/user_guide/objects.html#tools" target="_blank">
-        <img class="bk-btn-icon" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA2hpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYxIDY0LjE0MDk0OSwgMjAxMC8xMi8wNy0xMDo1NzowMSAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iIHhtcE1NOk9yaWdpbmFsRG9jdW1lbnRJRD0ieG1wLmRpZDo3NzIwRUFGMDYyMjE2ODExOTdBNUNBNjVEQTY5OTRDRSIgeG1wTU06RG9jdW1lbnRJRD0ieG1wLmRpZDozMjFERDhDRjIwQjIxMUU0ODREQUYzNzM5QTM2MjBCRSIgeG1wTU06SW5zdGFuY2VJRD0ieG1wLmlpZDozMjFERDhDRTIwQjIxMUU0ODREQUYzNzM5QTM2MjBCRSIgeG1wOkNyZWF0b3JUb29sPSJBZG9iZSBQaG90b3Nob3AgQ1M1LjEgTWFjaW50b3NoIj4gPHhtcE1NOkRlcml2ZWRGcm9tIHN0UmVmOmluc3RhbmNlSUQ9InhtcC5paWQ6OTdFQUZCRjQ4NjIxNjgxMTk3QTVDQTY1REE2OTk0Q0UiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6NzcyMEVBRjA2MjIxNjgxMTk3QTVDQTY1REE2OTk0Q0UiLz4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz6QBYrgAAABb0lEQVR42ozTwUeEQRjH8W3bKEs6JkpESqfVpS4RHaJL2b2sLepUh3To0KFVIjp0iegQUdG21WmVvUWsKBGRlIiU7Q+IVaT0ffi9eY33peFj7cw8zzvzzEzV7v5hxGltGEUvutR3hwvs4ck/OeoET6KACrJolaz6Cprz12L6rcEOajGEFyfxtRxhDX0Yx5e3ggV8IqlgW/4J3vCKddRrLKm5894KOjGCHiVrwDZ+sKKvpRQ0pzkzuETeEqSxpT1aa8ezCmbyuEW3b0sVxaQtQT+mfINXGPT9T+n3xqnLKTYsQQseI8FtWnstYdEZs9o0eqdQZxUNSWD9YwHj36i2UyijOWQFVvmPkOR2P8qW4AwDIQma0BEyZjGlqCo9gXjA1+0ePAQExxWTtwT3KOqG/bfZ3GOL9W7ikrIe6FSsvQdswcZymrvsf0xWpIzqYauZRcIXmFBfUUea8Qobc5a2qQtiz3nVec7nGHaf868AAwDKW1RIPmvhEQAAAABJRU5ErkJggg==">
-      </a>
-      <span class="tip">
-        Click the question mark to learn more about Bokeh plot tools.
-	    </span>
-	  </button>
-    </li>
-  </ul>
 </div>

--- a/bokehjs/src/coffee/common/toolbar_template.eco
+++ b/bokehjs/src/coffee/common/toolbar_template.eco
@@ -12,4 +12,5 @@
   <ul class='bk-button-bar-list' type="rotate" />
   <ul class='bk-button-bar-list' type="actions" />
   <div class='bk-button-bar-list bk-bs-dropdown' type="inspectors" />
+  <ul class='bk-button-bar-list' type="help" />
 </div>

--- a/bokehjs/src/coffee/main.coffee
+++ b/bokehjs/src/coffee/main.coffee
@@ -105,6 +105,7 @@ Bokeh.YearsTicker              = require("./ticking/years_ticker")
 Bokeh.ActionTool             = require("./tool/actions/action_tool")
 Bokeh.PreviewSaveTool        = require("./tool/actions/preview_save_tool")
 Bokeh.ResetTool              = require("./tool/actions/reset_tool")
+Bokeh.HelpTool               = require("./tool/actions/help_tool")
 
 Bokeh.BoxSelectTool          = require("./tool/gestures/box_select_tool")
 Bokeh.BoxZoomTool            = require("./tool/gestures/box_zoom_tool")

--- a/bokehjs/src/coffee/tool/actions/help_tool.coffee
+++ b/bokehjs/src/coffee/tool/actions/help_tool.coffee
@@ -1,0 +1,29 @@
+_ = require "underscore"
+ActionTool = require "./action_tool"
+
+
+class HelpToolView extends ActionTool.View
+  do: () ->
+  	window.open(@mget('redirect'))
+
+
+class HelpTool extends ActionTool.Model
+  default_view: HelpToolView
+  type: "HelpTool"
+  tool_name: "Help"
+  icon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA2hpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYxIDY0LjE0MDk0OSwgMjAxMC8xMi8wNy0xMDo1NzowMSAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iIHhtcE1NOk9yaWdpbmFsRG9jdW1lbnRJRD0ieG1wLmRpZDo3NzIwRUFGMDYyMjE2ODExOTdBNUNBNjVEQTY5OTRDRSIgeG1wTU06RG9jdW1lbnRJRD0ieG1wLmRpZDozMjFERDhDRjIwQjIxMUU0ODREQUYzNzM5QTM2MjBCRSIgeG1wTU06SW5zdGFuY2VJRD0ieG1wLmlpZDozMjFERDhDRTIwQjIxMUU0ODREQUYzNzM5QTM2MjBCRSIgeG1wOkNyZWF0b3JUb29sPSJBZG9iZSBQaG90b3Nob3AgQ1M1LjEgTWFjaW50b3NoIj4gPHhtcE1NOkRlcml2ZWRGcm9tIHN0UmVmOmluc3RhbmNlSUQ9InhtcC5paWQ6OTdFQUZCRjQ4NjIxNjgxMTk3QTVDQTY1REE2OTk0Q0UiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6NzcyMEVBRjA2MjIxNjgxMTk3QTVDQTY1REE2OTk0Q0UiLz4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz6QBYrgAAABb0lEQVR42ozTwUeEQRjH8W3bKEs6JkpESqfVpS4RHaJL2b2sLepUh3To0KFVIjp0iegQUdG21WmVvUWsKBGRlIiU7Q+IVaT0ffi9eY33peFj7cw8zzvzzEzV7v5hxGltGEUvutR3hwvs4ck/OeoET6KACrJolaz6Cprz12L6rcEOajGEFyfxtRxhDX0Yx5e3ggV8IqlgW/4J3vCKddRrLKm5894KOjGCHiVrwDZ+sKKvpRQ0pzkzuETeEqSxpT1aa8ezCmbyuEW3b0sVxaQtQT+mfINXGPT9T+n3xqnLKTYsQQseI8FtWnstYdEZs9o0eqdQZxUNSWD9YwHj36i2UyijOWQFVvmPkOR2P8qW4AwDIQma0BEyZjGlqCo9gXjA1+0ePAQExxWTtwT3KOqG/bfZ3GOL9W7ikrIe6FSsvQdswcZymrvsf0xWpIzqYauZRcIXmFBfUUea8Qobc5a2qQtiz3nVec7nGHaf868AAwDKW1RIPmvhEQAAAABJRU5ErkJggg=="
+
+  initialize: (attrs, options) ->
+    super(attrs, options)
+    @register_property('tooltip', () ->@get('help_tooltip'))
+
+  defaults: ->
+    return _.extend {}, super(), {
+      help_tooltip: 'Click the question mark to learn more about Bokeh plot tools.'
+      redirect: 'http://bokeh.pydata.org/en/latest/docs/user_guide/objects.html#tools'
+    }
+
+module.exports =
+  Model: HelpTool,
+  View: HelpToolView,
+


### PR DESCRIPTION
issues: fixes  #2156

I've created a new tool (a HelpTool) which is enabled by default to preserve functionality. It removes the hardcoded "help" link in the template and allows further customization for the hover text and the link it redirects to.