### PR TITLE
Remove extraneous comma from unemployment csv.

### DIFF
--- a/bokeh/sampledata/unemployment1948.csv
+++ b/bokeh/sampledata/unemployment1948.csv
@@ -1,4 +1,4 @@
-Year,Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec,Annual,
+Year,Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec,Annual
 1948,4.0,4.7,4.5,4.0,3.4,3.9,3.9,3.6,3.4,2.9,3.3,3.6,3.8
 1949,5.0,5.8,5.6,5.4,5.7,6.4,7.0,6.3,5.9,6.1,5.7,6.0,5.9
 1950,7.6,7.9,7.1,6.0,5.3,5.6,5.3,4.1,4.0,3.3,3.8,3.9,5.3


### PR DESCRIPTION
Obviously this is a very minor change, so I haven't created a corresponding issue.