### PR TITLE
Fix error: unable to parse uri to data

### DIFF
--- a/bokeh/server/blaze/config.py
+++ b/bokeh/server/blaze/config.py
@@ -47,7 +47,7 @@ except Exception as e:
 
 path = join(dirname(bokeh.server.tests.__file__), 'data', 'array.hdf5')
 try:
-    arr = resource(path + "::" + "array")
+    arr = resource("hdfstore://%s::__data__" % path)
 except Exception as e:
     arr = None
     log.error(e)


### PR DESCRIPTION
I was trying to squash the typical "mbs.views module could not be imported. This means that you can't use the blaze functionality of bokeh..." message. This required multiuserblaze to be installed, which in turn required PyTables, which required HDF5.

After all that, more messages came up complaining "Unable to parse uri to data resource..." and I traced the error to this file. After making the change here, these messages went away:

    ERROR:_mbs_configuration:Unable to parse uri to data resource: /usr/local/lib/python2.7/site-packages/bokeh/server/tests/data/array.hdf5
    /usr/local/lib/python2.7/site-packages/bokeh/server/blaze/config.py:52: UserWarning: Error loading hdfstore for array. Your version of Blaze is too old, or incompatible
    "Error loading hdfstore for array. Your version of Blaze is too old, or incompatible"

This error had nothing to do with the version of Blaze, which was exactly what was required (0.7.2).