### PR TITLE
Expose desired_num_ticks on tickers

### DIFF
--- a/bokeh/models/tickers.py
+++ b/bokeh/models/tickers.py
@@ -18,6 +18,16 @@ class Ticker(PlotObject):
     adjacent major tick values.
     """)
 
+    desired_num_ticks = Int(6, help="""
+    A desired target number of major tick positions to generate across
+    the plot range.
+
+    .. note:
+        This value is a suggestion, and ticker subclasses may ignore
+        it entirely, or use it only as an ideal goal to approach as well
+        as can be, in the context of a specific ticking strategy.
+    """)
+
 class AdaptiveTicker(Ticker):
     """ Generate "nice" round ticks at any magnitude.
 

--- a/bokehjs/src/coffee/ticking/abstract_ticker.coffee
+++ b/bokehjs/src/coffee/ticking/abstract_ticker.coffee
@@ -30,7 +30,7 @@ repr = (obj) ->
     else
       return obj_as_string
 
-DEFAULT_DESIRED_N_TICKS = 6
+DEFAULT_DESIRED_NUM_TICKS = 6
 
 # The base class for all Ticker objects.  It needs to be subclassed before
 # being used.  The simplest subclass is SingleIntervalTicker.
@@ -49,8 +49,7 @@ class AbstractTicker extends HasProperties
 
   # Generates a nice series of ticks for a given range.
   get_ticks: (data_low, data_high, range, {desired_n_ticks}) ->
-    desired_n_ticks ?= DEFAULT_DESIRED_N_TICKS
-    return @get_ticks_no_defaults(data_low, data_high, desired_n_ticks)
+    return @get_ticks_no_defaults(data_low, data_high, @get('desired_num_ticks'))
 
   # The version of get_ticks() that does the work (and the version that
   # should be overridden in subclasses).
@@ -113,6 +112,7 @@ class AbstractTicker extends HasProperties
     return _.extend {}, super(), {
       toString_properties: []
       num_minor_ticks: 5
+      desired_num_ticks: DEFAULT_DESIRED_NUM_TICKS
     }
 
 module.exports =

--- a/examples/plotting/file/line.py
+++ b/examples/plotting/file/line.py
@@ -10,4 +10,6 @@ output_file("line.html", title="line.py example")
 p = figure(title="simple line example")
 p.line(x,y, color="#2222aa", line_width=2)
 
+p.ygrid[0].ticker.desired_num_ticks = 20
+
 show(p)


### PR DESCRIPTION
issues: fixes #2185

Exposes `desired_num_ticks` on ticker objects to allow users to suggest
a target number of ticks. Adds an example of use in:

https://github.com/bokeh/bokeh/blob/feature/2185_num_ticks/examples/plotting/file/line.py