### PR TITLE
docs should say to use "relative" for incremental builds

### DIFF
--- a/sphinx/source/docs/dev_guide/building.rst
+++ b/sphinx/source/docs/dev_guide/building.rst
@@ -207,7 +207,7 @@ to indicate that BokehJS should be loaded from individual sources:
 
 .. code-block:: sh
 
-    BOKEH_RESOURCES=relative-dev python example.py
+    BOKEH_RESOURCES=relative python example.py
 
 For Bokeh server examples, simply add the ``--dev`` command line flag to the
 server invocation:


### PR DESCRIPTION
The docs say to use `BOKEH_RESOURCES=relative-dev` to do incremental builds. But this fails, because there will be a `<script>` tag to include "/js/vendor/require.js", which does not exist.

Everything works with just "relative" though.

Perhaps more docs need updating, or maybe deprecate the `relative-dev` option?