### PR TITLE
Make relative dev work again

### DIFF
--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -49,7 +49,8 @@ def components(plot_object, resources=None):
     '''
     
     if resources is not None:
-        warn('the ``resources`` argument is deprecated and will be removed in'
+        warn('Because the ``resources`` argument is no longer needed, '
+             'is it deprecated and will be removed in'
              'a future version.', DeprecationWarning, stacklevel=2)
     
     ref = plot_object.ref

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -13,6 +13,7 @@ these different cases.
 
 from __future__ import absolute_import
 
+from warnings import warn
 import uuid
 
 from .protocol import serialize_json
@@ -23,7 +24,14 @@ from .templates import (
 )
 from .util.string import encode_utf8
 
-def components(plot_object, resources):
+
+def _wrap_in_function(code):
+    # Indent and wrap Bokeh function def around
+    code = "\n".join([ "    " + line for line in code.split("\n") ])
+    return 'Bokeh.$(function() {\n%s\n});' % code
+
+
+def components(plot_object, resources=None):
     ''' Return HTML components to embed a Bokeh plot.
 
     The data for the plot is stored directly in the returned HTML.
@@ -34,15 +42,19 @@ def components(plot_object, resources):
     Args:
         plot_object (PlotObject) : Bokeh object to render
             typically a Plot or PlotContext
-        resources (Resources, optional) : BokehJS resources config
-
+        resources : Deprecated argument
     Returns:
         (script, div) : UTF-8 encoded
 
     '''
+    
+    if resources is not None:
+        warn('the ``resources`` argument is deprecated and will be removed in'
+             'a future version.', DeprecationWarning, stacklevel=2)
+    
     ref = plot_object.ref
     elementid = str(uuid.uuid4())
-
+    
     js = PLOT_JS.render(
         elementid = elementid,
         modelid = ref["id"],
@@ -50,7 +62,7 @@ def components(plot_object, resources):
         all_models = serialize_json(plot_object.dump()),
     )
     script = PLOT_SCRIPT.render(
-        plot_js = resources.js_wrapper(js),
+        plot_js = _wrap_in_function(js),
     )
     div = PLOT_DIV.render(elementid=elementid)
 
@@ -75,7 +87,6 @@ def notebook_div(plot_object):
 
     '''
     ref = plot_object.ref
-    resources = Resources()
     elementid = str(uuid.uuid4())
 
     js = PLOT_JS.render(
@@ -85,7 +96,7 @@ def notebook_div(plot_object):
         all_models = serialize_json(plot_object.dump()),
     )
     script = PLOT_SCRIPT.render(
-        plot_js = resources.js_wrapper(js),
+        plot_js = _wrap_in_function(js),
     )
     div = PLOT_DIV.render(elementid=elementid)
     html = NOTEBOOK_DIV.render(
@@ -119,7 +130,7 @@ def file_html(plot_object, resources, title, template=FILE):
         js_files = resources.js_files,
         css_files = resources.css_files,
     )
-    script, div = components(plot_object, resources)
+    script, div = components(plot_object)
     html = template.render(
         title = title,
         plot_resources = plot_resources,

--- a/bokeh/models/widgets/layouts.py
+++ b/bokeh/models/widgets/layouts.py
@@ -68,7 +68,7 @@ class VBox(BaseBox):
 # parent class only, you need to set the fields you want
 class VBoxForm(VBox):
     """
-    Basically,  a VBox, where all components(generally form stuff)
+    Basically, a VBox, where all components (generally form stuff)
     is wrapped in a <form> tag - important for bootstrap css
     """
 class SimpleApp(Widget):

--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -136,7 +136,7 @@ class Resources(object):
     _default_js_files = ["js/bokeh.js"]
     _default_css_files = ["css/bokeh.css"]
 
-    _default_js_files_dev = ['js/bokeh.js']  #'js/vendor/requirejs/require.js', 'js/config.js']
+    _default_js_files_dev = ['js/bokeh.js']
     _default_css_files_dev = ['css/bokeh.css']
 
     _default_root_dir = "."
@@ -204,10 +204,6 @@ class Resources(object):
             self.css_files = list(server['css_files'])
             self.messages.extend(server['messages'])
 
-        # if self.dev:
-        #     require = 'require.config({ baseUrl: "%s" });' % base_url
-        #     self._js_raw.append(require)
-
     @property
     def log_level(self):
         return self._log_level
@@ -264,14 +260,7 @@ class Resources(object):
             return "\n".join([ " "*n + line for line in text.split("\n") ])
 
         wrapper = lambda code: 'Bokeh.$(function() {\n%s\n});' % pad(code)
-
-        if self.dev:
-            template = 'require(["jquery", "main"], function($, Bokeh) {\nBokeh.set_log_level("%s");\n%s\n});'
-            js_wrapper = lambda code: template % (self.log_level, pad(wrapper(code)))
-        else:
-            js_wrapper = wrapper
-
-        return wrapper # js_wrapper
+        return wrapper
 
     def _autoload_path(self, elementid):
         return self.root_url + "bokeh/autoload.js/%s" % elementid

--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -112,11 +112,11 @@ class Resources(object):
     * ``'inline'`` configure to provide entire BokehJS code and CSS inline
     * ``'cdn'`` configure to load BokehJS code and CS from ``http://cdn.pydata.org``
     * ``'server'`` configure to load from a Bokeh Server
-    * ``'server-dev'`` same as ``server`` but supports non-concatenated JS using ``requirejs``
+    * ``'server-dev'`` same as ``server`` but supports non-minified JS
     * ``'relative'`` configure to load relative to the given directory
-    * ``'relative-dev'`` same as ``relative`` but supports non-concatenated JS using ``requirejs``
+    * ``'relative-dev'`` same as ``relative`` but supports non-minified JS 
     * ``'absolute'`` configure to load from the installed Bokeh library static directory
-    * ``'absolute-dev'`` same as ``absolute`` but supports non-concatenated JS using ``requirejs``
+    * ``'absolute-dev'`` same as ``absolute`` but supports non-minified JS
 
     Once configured, a Resource object exposes the following public attributes:
 
@@ -222,10 +222,7 @@ class Resources(object):
     def js_raw(self):
         if six.callable(self._js_raw):
             self._js_raw = self._js_raw()
-        if self.dev:
-            return self._js_raw
-        else:
-            return self._js_raw + ['Bokeh.set_log_level("%s");' % self.log_level]
+        return self._js_raw + ['Bokeh.set_log_level("%s");' % self.log_level]
 
     @property
     def css_raw(self):
@@ -252,16 +249,7 @@ class Resources(object):
     def _css_paths(self, minified=True, dev=False):
         files = self._default_css_files_dev if self.dev else self._default_css_files
         return self._file_paths(files, False if dev else minified)
-
-    @property
-    def js_wrapper(self):
-
-        def pad(text, n=4):
-            return "\n".join([ " "*n + line for line in text.split("\n") ])
-
-        wrapper = lambda code: 'Bokeh.$(function() {\n%s\n});' % pad(code)
-        return wrapper
-
+    
     def _autoload_path(self, elementid):
         return self.root_url + "bokeh/autoload.js/%s" % elementid
 

--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -136,7 +136,7 @@ class Resources(object):
     _default_js_files = ["js/bokeh.js"]
     _default_css_files = ["css/bokeh.css"]
 
-    _default_js_files_dev = ['js/vendor/requirejs/require.js', 'js/config.js']
+    _default_js_files_dev = ['js/bokeh.js']  #'js/vendor/requirejs/require.js', 'js/config.js']
     _default_css_files_dev = ['css/bokeh.css']
 
     _default_root_dir = "."
@@ -204,9 +204,9 @@ class Resources(object):
             self.css_files = list(server['css_files'])
             self.messages.extend(server['messages'])
 
-        if self.dev:
-            require = 'require.config({ baseUrl: "%s" });' % base_url
-            self._js_raw.append(require)
+        # if self.dev:
+        #     require = 'require.config({ baseUrl: "%s" });' % base_url
+        #     self._js_raw.append(require)
 
     @property
     def log_level(self):
@@ -271,7 +271,7 @@ class Resources(object):
         else:
             js_wrapper = wrapper
 
-        return js_wrapper
+        return wrapper # js_wrapper
 
     def _autoload_path(self, elementid):
         return self.root_url + "bokeh/autoload.js/%s" % elementid

--- a/bokeh/tests/test_embed.py
+++ b/bokeh/tests/test_embed.py
@@ -19,18 +19,18 @@ def setUpModule():
 class TestComponents(unittest.TestCase):
 
     def test_return_type(self):
-        r = embed.components(_embed_test_plot, CDN)
+        r = embed.components(_embed_test_plot)
         self.assertEqual(len(r), 2)
 
     def test_result_attrs(self):
-        script, div = embed.components(_embed_test_plot, CDN)
+        script, div = embed.components(_embed_test_plot)
         html = bs4.BeautifulSoup(script)
         scripts = html.findAll(name='script')
         self.assertEqual(len(scripts), 1)
         self.assertTrue(scripts[0].attrs, {'type': 'text/javascript'})
 
     def test_div_attrs(self):
-        script, div = embed.components(_embed_test_plot, CDN)
+        script, div = embed.components(_embed_test_plot)
         html = bs4.BeautifulSoup(div)
 
         divs = html.findAll(name='div')

--- a/bokeh/tests/test_resources.py
+++ b/bokeh/tests/test_resources.py
@@ -2,14 +2,13 @@ from __future__ import absolute_import
 
 import unittest
 
-from os.path import join
-
 import bokeh.resources as resources
 from bokeh.resources import _get_cdn_urls
 
 WRAPPER = """Bokeh.$(function() {
     foo
 });"""
+
 
 WRAPPER_DEV = '''require(["jquery", "main"], function($, Bokeh) {
 Bokeh.set_log_level("info");
@@ -94,17 +93,17 @@ class TestResources(unittest.TestCase):
         self.assertEqual(r.mode, "server")
         self.assertEqual(r.dev, True)
 
-        self.assertEqual(len(r.js_raw), 1)
-        self.assertTrue(r.js_raw[0].startswith('require.config({ baseUrl:'))
-        self.assertTrue(r.js_raw[0].endswith(join('bokehjs', 'build', 'js') + '" });'))
+        self.assertEqual(len(r.js_raw), 0)
+        #self.assertTrue(r.js_raw[0].startswith('require.config({ baseUrl:'))
+        #self.assertTrue(r.js_raw[0].endswith(join('bokehjs', 'build', 'js') + '" });'))
         self.assertEqual(r.css_raw, [])
         self.assertEqual(r.messages, [])
 
         r = resources.Resources(mode="server-dev", root_url="http://foo/")
 
-        self.assertEqual(len(r.js_raw), 1)
-        self.assertTrue(r.js_raw[0].startswith('require.config({ baseUrl:'))
-        self.assertTrue(r.js_raw[0].endswith(join('bokehjs', 'build', 'js') + '" });'))
+        self.assertEqual(len(r.js_raw), 0)
+        #self.assertTrue(r.js_raw[0].startswith('require.config({ baseUrl:'))
+        #self.assertTrue(r.js_raw[0].endswith(join('bokehjs', 'build', 'js') + '" });'))
         self.assertEqual(r.css_raw, [])
         self.assertEqual(r.messages, [])
 
@@ -122,9 +121,9 @@ class TestResources(unittest.TestCase):
         self.assertEqual(r.mode, "relative")
         self.assertEqual(r.dev, True)
 
-        self.assertEqual(len(r.js_raw), 1)
-        self.assertTrue(r.js_raw[0].startswith('require.config({ baseUrl:'))
-        self.assertTrue(r.js_raw[0].endswith(join('bokehjs', 'build', 'js') + '" });'))
+        self.assertEqual(len(r.js_raw), 0)
+        #self.assertTrue(r.js_raw[0].startswith('require.config({ baseUrl:'))
+        #self.assertTrue(r.js_raw[0].endswith(join('bokehjs', 'build', 'js') + '" });'))
         self.assertEqual(r.css_raw, [])
         self.assertEqual(r.messages, [])
 
@@ -142,9 +141,9 @@ class TestResources(unittest.TestCase):
         self.assertEqual(r.mode, "absolute")
         self.assertEqual(r.dev, True)
 
-        self.assertEqual(len(r.js_raw), 1)
-        self.assertTrue(r.js_raw[0].startswith('require.config({ baseUrl:'))
-        self.assertTrue(r.js_raw[0].endswith(join('bokehjs', 'build', 'js') + '" });'))
+        self.assertEqual(len(r.js_raw), 0)
+        #self.assertTrue(r.js_raw[0].startswith('require.config({ baseUrl:'))
+        #self.assertTrue(r.js_raw[0].endswith(join('bokehjs', 'build', 'js') + '" });'))
         self.assertEqual(r.css_raw, [])
         self.assertEqual(r.messages, [])
 
@@ -167,4 +166,8 @@ class TestResources(unittest.TestCase):
 
         for mode in ("server-dev", "relative-dev", "absolute-dev"):
             r = resources.Resources(mode)
-            self.assertEqual(r.js_wrapper("foo"), WRAPPER_DEV)
+            self.assertEqual(r.js_wrapper("foo"), WRAPPER)
+
+if __name__ == '__main__':
+    t = TestResources()
+    t.test_absolute_dev()

--- a/bokeh/tests/test_resources.py
+++ b/bokeh/tests/test_resources.py
@@ -93,17 +93,13 @@ class TestResources(unittest.TestCase):
         self.assertEqual(r.mode, "server")
         self.assertEqual(r.dev, True)
 
-        self.assertEqual(len(r.js_raw), 0)
-        #self.assertTrue(r.js_raw[0].startswith('require.config({ baseUrl:'))
-        #self.assertTrue(r.js_raw[0].endswith(join('bokehjs', 'build', 'js') + '" });'))
+        self.assertEqual(len(r.js_raw), 1)
         self.assertEqual(r.css_raw, [])
         self.assertEqual(r.messages, [])
 
         r = resources.Resources(mode="server-dev", root_url="http://foo/")
 
-        self.assertEqual(len(r.js_raw), 0)
-        #self.assertTrue(r.js_raw[0].startswith('require.config({ baseUrl:'))
-        #self.assertTrue(r.js_raw[0].endswith(join('bokehjs', 'build', 'js') + '" });'))
+        self.assertEqual(r.js_raw, [DEFAULT_JOG_JS_RAW])
         self.assertEqual(r.css_raw, [])
         self.assertEqual(r.messages, [])
 
@@ -121,9 +117,7 @@ class TestResources(unittest.TestCase):
         self.assertEqual(r.mode, "relative")
         self.assertEqual(r.dev, True)
 
-        self.assertEqual(len(r.js_raw), 0)
-        #self.assertTrue(r.js_raw[0].startswith('require.config({ baseUrl:'))
-        #self.assertTrue(r.js_raw[0].endswith(join('bokehjs', 'build', 'js') + '" });'))
+        self.assertEqual(r.js_raw, [DEFAULT_JOG_JS_RAW])
         self.assertEqual(r.css_raw, [])
         self.assertEqual(r.messages, [])
 
@@ -141,9 +135,7 @@ class TestResources(unittest.TestCase):
         self.assertEqual(r.mode, "absolute")
         self.assertEqual(r.dev, True)
 
-        self.assertEqual(len(r.js_raw), 0)
-        #self.assertTrue(r.js_raw[0].startswith('require.config({ baseUrl:'))
-        #self.assertTrue(r.js_raw[0].endswith(join('bokehjs', 'build', 'js') + '" });'))
+        self.assertEqual(r.js_raw, [DEFAULT_JOG_JS_RAW])
         self.assertEqual(r.css_raw, [])
         self.assertEqual(r.messages, [])
 
@@ -158,16 +150,3 @@ class TestResources(unittest.TestCase):
 
         for mode in ("inline", "cdn", "relative", "relative-dev", "absolute", "absolute-dev"):
             self.assertRaises(ValueError, resources.Resources, mode, root_url="foo")
-
-    def test_js_wrapper(self):
-        for mode in ("inline", "server", "cdn", "relative", "absolute"):
-            r = resources.Resources(mode)
-            self.assertEqual(r.js_wrapper("foo"), WRAPPER)
-
-        for mode in ("server-dev", "relative-dev", "absolute-dev"):
-            r = resources.Resources(mode)
-            self.assertEqual(r.js_wrapper("foo"), WRAPPER)
-
-if __name__ == '__main__':
-    t = TestResources()
-    t.test_absolute_dev()

--- a/bokehjs/gulp/tasks/watch.coffee
+++ b/bokehjs/gulp/tasks/watch.coffee
@@ -6,6 +6,6 @@ paths = require "../paths"
 
 gulp.task "watch", ->
   gulp.watch "#{paths.coffee.watchSources}", ->
-    runSequence("scripts:build", "install")
+    runSequence("scripts:build")
   gulp.watch "#{paths.css.watchSources}", ->
-    runSequence("styles:build", "install")
+    runSequence("styles:build")


### PR DESCRIPTION
continuing from #2210

This makes `relative-dev` work again. Basically, in this mode we now simply use the `bokeh.js` and `bokeh.css` (the composed, but not-minified versions).

Also, since the last time I touched the gulp code, we now load the js from `bokehjs/build` instead of `bokeh/server/static`, which means that `gulp watch` does not need the install step.

Is this the way to move forward with this?