### PR TITLE
Feature #2213: bokeh-server with HTTPS enabled

### DIFF
--- a/bokeh/server/__init__.py
+++ b/bokeh/server/__init__.py
@@ -34,6 +34,19 @@ def build_parser():
                          help="URL prefix for server. e.g. 'host:port/<prefix>/bokeh' (default: None)",
                          type=str
                          )
+    general.add_argument("--https",
+                         help="If present, the server will be use HTTPS instead of HTTP (defualt: False).",
+                         action="store_true",
+                         default=False
+                         )
+    general.add_argument("--https-certfile",
+                         help="Required with the --https flag. Must be the filename of a valid HTTPS crt file (default: None)",
+                         type=str
+                         )
+    general.add_argument("--https-keyfile",
+                         help="Required with the --https flag. Must be the filename of a valid HTTPS key file (default: None)",
+                         type=str
+                         )
 
     # advanced configuration
     advanced = parser.add_argument_group('Advanced Options')

--- a/bokeh/server/start.py
+++ b/bokeh/server/start.py
@@ -57,7 +57,7 @@ def start_simple_server(args=None):
     if args is not None and args.https:
         if args.https_certfile and args.https_keyfile:
             server = HTTPServer(tornado_app, ssl_options={"certfile": args.https_certfile, "keyfile": args.https_keyfile})
-            log.info('HTTPS Enabled)
+            log.info('HTTPS Enabled')
         else:
             server = HTTPServer(tornado_app)
             log.warning('WARNING: --https-certfile or --https-keyfile are not specified, using http instead')

--- a/bokeh/server/start.py
+++ b/bokeh/server/start.py
@@ -57,12 +57,12 @@ def start_simple_server(args=None):
     if args is not None and args.https:
         if args.https_certfile and args.https_keyfile:
             server = HTTPServer(tornado_app, ssl_options={"certfile": args.https_certfile, "keyfile": args.https_keyfile})
+            log.info('HTTPS Enabled)
         else:
             server = HTTPServer(tornado_app)
-            print('WARNING: --https-certfile or --https-keyfile are not specified, using http instead')
+            log.warning('WARNING: --https-certfile or --https-keyfile are not specified, using http instead')
     else:
         server = HTTPServer(tornado_app)
-    server = HTTPServer(tornado_app)
     server.listen(server_settings.port, server_settings.ip)
     ioloop.IOLoop.instance().start()
 

--- a/bokeh/server/start.py
+++ b/bokeh/server/start.py
@@ -54,7 +54,7 @@ def start_simple_server(args=None):
         start_redis()
     register_blueprint()
     tornado_app = make_tornado_app(flask_app=app)
-    if args.https:
+    if args is not None and args.https:
         if args.https_certfile and args.https_keyfile:
             server = HTTPServer(tornado_app, ssl_options={"certfile": args.https_certfile, "keyfile": args.https_keyfile})
         else:

--- a/bokeh/server/start.py
+++ b/bokeh/server/start.py
@@ -54,6 +54,14 @@ def start_simple_server(args=None):
         start_redis()
     register_blueprint()
     tornado_app = make_tornado_app(flask_app=app)
+    if args.https:
+        if args.https_certfile and args.https_keyfile:
+            server = HTTPServer(tornado_app, ssl_options={"certfile": args.https_certfile, "keyfile": args.https_keyfile})
+        else:
+            server = HTTPServer(tornado_app)
+            print('WARNING: --https-certfile or --https-keyfile are not specified, using http instead')
+    else:
+        server = HTTPServer(tornado_app)
     server = HTTPServer(tornado_app)
     server.listen(server_settings.port, server_settings.ip)
     ioloop.IOLoop.instance().start()


### PR DESCRIPTION
Addresses #2213 

Tested implementation of a bokeh-server running with HTTPS enabled.

To run:
```
bokeh-server --https --https-certfile=/path/to/certfile.crt --https-keyfile=/path/to/keyfile.pem --script script_name.py
```
To be clear: This has not been successfully tested to work in conjunction with Session, just using --script works however...

What I didn't manage to do was to make session.py compatible with this because I don't think urllib3/requests was configured to know any certificate authorities (including the CERN certificate authority, the one which was used for testing) even after consulting the requests documentation and passing the exact same paths to the certificates. When running a test, a session was started from one computer to the same computer. One process ran the session.py session, which connected to the bokeh-server instance. It so happened that the session.py session was running in a python interpreter created by mod_wsgi under Apache. The SSL connection failed based on an error claiming that the certificates were invalid (which they're clearly not). Our project diverted to using the --script option on bokeh-server because as mentioned somewhere, it removes unnecessary networking and speeds-up the entire solution.
