### PR TITLE
Update model on server when the plot is panned/zoomed.

### DIFF
--- a/bokehjs/src/coffee/common/plot.coffee
+++ b/bokehjs/src/coffee/common/plot.coffee
@@ -128,6 +128,8 @@ class PlotView extends ContinuumView
       rng.set(range_info.xrs[name])
     for name, rng of @frame.get('y_ranges')
       rng.set(range_info.yrs[name])
+    @x_range.save();
+    @y_range.save();
     @unpause()
 
   build_levels: () ->


### PR DESCRIPTION
This addition propagates pan/zoom changes of the plot in the browser to the server.
It provides possibility to update the plot data according to the current x,y ranges.
Possible uses: dynamic plotting, level of detail etc.
Disadvantages: data is send during pan, maybe pan:end would be a better place.