### PR TITLE
Revert "Run binstar upload in the correct 'scripts' location"

### DIFF
--- a/scripts/build_upload.sh
+++ b/scripts/build_upload.sh
@@ -67,14 +67,14 @@ BUILD_PATH=$CONDA_ENV/conda-bld/$PLATFORM
 travis_build_id=$(cat __travis_build_id__.txt)
 
 # convert to platform-specific builds
-conda convert -p all -f $BUILD_PATH/bokeh*$travis_build_id*.tar.bz2 --quiet;
+conda convert -p all -f $BUILD_PATH/bokeh*$travis_build_id*.tar.bz2; # --quiet option will be available soon
 
 # upload conda pkgs to binstar
 array=(osx-64 linux-64 win-64 linux-32 win-32)
 for i in "${array[@]}"
 do
     echo Uploading: $i;
-    binstar -t $bintoken upload -u bokeh scripts/$i/bokeh*$travis_build_id*.tar.bz2 -c dev --force --no-progress;
+    binstar -t $bintoken upload -u bokeh $i/bokeh*$travis_build_id*.tar.bz2 -c dev --force --no-progress;
 done
 
 # create and upload pypi pkgs to binstar

--- a/scripts/release_upload.sh
+++ b/scripts/release_upload.sh
@@ -52,14 +52,14 @@ BUILD_PATH=$CONDA_ENV/conda-bld/$PLATFORM
 travis_build_id=$(cat __travis_build_id__.txt)
 
 # convert to platform-specific builds
-conda convert -p all -f $BUILD_PATH/bokeh*$travis_build_id*.tar.bz2 --quiet;
+conda convert -p all -f $BUILD_PATH/bokeh*$travis_build_id*.tar.bz2; # --quiet option will be available soon
 
 # upload conda pkgs to binstar
 array=(osx-64 linux-64 win-64 linux-32 win-32)
 for i in "${array[@]}"
 do
     echo Uploading: $i;
-    binstar -t $bintoken upload -u bokeh scripts/$i/bokeh*$travis_build_id*.tar.bz2 --force --no-progress;
+    binstar -t $bintoken upload -u bokeh $i/bokeh*$travis_build_id*.tar.bz2 --force --no-progress;
 done
 
 # create and upload pypi pkgs to binstar


### PR DESCRIPTION
Reverts bokeh/bokeh#2253
Because the packages are generated at the top directory:

Travislog:
```
Uploading: osx-64
Using binstar api site https://api.binstar.org
[BinstarError] file scripts/osx-64/bokeh*61605853*.tar.bz2 does not exist 
Uploading: linux-64
Using binstar api site https://api.binstar.org
[BinstarError] file scripts/linux-64/bokeh*61605853*.tar.bz2 does not exist 
Uploading: win-64
Using binstar api site https://api.binstar.org
[BinstarError] file scripts/win-64/bokeh*61605853*.tar.bz2 does not exist 
Uploading: linux-32
Using binstar api site https://api.binstar.org
[BinstarError] file scripts/linux-32/bokeh*61605853*.tar.bz2 does not exist 
Uploading: win-32
Using binstar api site https://api.binstar.org
[BinstarError] file scripts/win-32/bokeh*61605853*.tar.bz2 does not exist 
Adding '--build_js' required for 'sdist'
Building BokehJS... Success!
```