### PR TITLE
force glyphs to always beginPath before rendering

### DIFF
--- a/bokehjs/src/coffee/renderer/glyph/glyph.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/glyph.coffee
@@ -25,6 +25,7 @@ class GlyphView extends ContinuumView
 
   render: (ctx, indicies, data) ->
     if @mget("visible")
+      ctx.beginPath();
       @_render(ctx, indicies, data)
 
   map_data: () ->


### PR DESCRIPTION
In some very specific cases missing beginPath leads to weird behaviours. For instance, creating a patch glyph with an empty source right after a line glyph would create a patch under all the line.