### PR TITLE
Fix bug in outlier attribute handling

### DIFF
--- a/bokeh/charts/builder/boxplot_builder.py
+++ b/bokeh/charts/builder/boxplot_builder.py
@@ -220,7 +220,7 @@ class BoxPlotBuilder(Builder):
         end_y = max(self._data_segment[self._attr_segment[3]])
 
         ## Expand min/max to encompass outliers
-        if self.outliers:
+        if self.outliers and self._data_scatter[self._attr_scatter[1]]:
             start_out_y = min(self._data_scatter[self._attr_scatter[1]])
             end_out_y = max(self._data_scatter[self._attr_scatter[1]])
             # it could be no outliers in some sides...

--- a/bokeh/charts/builder/tests/test_boxplot_builder.py
+++ b/bokeh/charts/builder/tests/test_boxplot_builder.py
@@ -106,3 +106,10 @@ class TestBoxPlot(unittest.TestCase):
 
             for key, expected_v in expected_seg.items():
                 self.assertEqual(builder._data_segment[key], expected_v)
+
+    def test_no_outliers(self):
+        xyvalues = [7.0, 7.0, 8.0, 8.0, 9.0, 9.0]
+        bp = create_chart(BoxPlot, xyvalues, outliers=True)
+        builder = bp._builders[0]
+        outliers = builder._data_scatter['out_y']
+        self.assertEqual(len(outliers), 0)


### PR DESCRIPTION
ref issue: #2338 

When boxplot_builder.py would check the self.outliers attribute (default=True) to see if it had to change the y_range of the figure to include outlier points as scatters, there was no check to see if there existed any outlier points. This caused min to be evaluated over an empty list in the case that there were no outliers.

I didn't add/modify any tests, let me know if/what I should do about that.