### PR TITLE
CSV Endpoint For ColumnDataSources

### DIFF
--- a/bokeh/server/views/backbone.py
+++ b/bokeh/server/views/backbone.py
@@ -164,13 +164,13 @@ def bulkget_with_typename(docid, typename):
     return _bulkget(docid, typename)
 
 @crossdomain(origin="*", methods=['PATCH', 'GET', 'PUT'], headers=None)
-def _handle_specific_model(docid, typename, id, method):
+def _handle_specific_model(docid, typename, id, method, format='json'):
     if method == 'PUT':
         return update(docid, typename, id)
     elif method == 'PATCH':
         return update(docid, typename, id)
     elif method == 'GET':
-        return getbyid(docid, typename, id)
+        return getbyid(docid, typename, id, format)
     elif method == 'DELETE':
         return delete(docid, typename, id)
 

--- a/bokeh/server/views/backbone.py
+++ b/bokeh/server/views/backbone.py
@@ -267,10 +267,12 @@ def getbyid(docid, typename, id, format='json'):
     )
     t.load()
     clientdoc = t.clientdoc
-    attr = clientdoc.dump(clientdoc._models[id])[0]['attributes']
+    model = clientdoc._models[id]
+    
     if format=='csv' and typename=='ColumnDataSource':
-        return clientdoc._models[id].to_df().to_csv()
+        return model.to_df().to_csv()
     else:
+        attr = clientdoc.dump(model)[0]['attributes']
         return make_json(protocol.serialize_json(attr))
 
 @handle_auth_error


### PR DESCRIPTION
I've added a CSV endpoint for ColumnDataSources. The URL is the same as the one for retrieving JSON, except an extra '/' and a ```<format>``` can be added to the end:
```
/bokeh/bb/<docid>/<typename>/<id>/<format>
```
