### PR TITLE
Fix bug in renderer ordering

### DIFF
--- a/bokehjs/src/coffee/common/plot.coffee
+++ b/bokehjs/src/coffee/common/plot.coffee
@@ -283,7 +283,7 @@ class PlotView extends ContinuumView
     indices = {}
     for renderer, i in @mget("renderers")
       indices[renderer.id] = i
-    sortKey = (renderer) -> indices[renderer.model.id]
+    sortKey = (renderer) -> indices[renderer.id]
 
     for level in levels
       renderers = _.sortBy(_.values(@levels[level]), sortKey)


### PR DESCRIPTION
issues: closes #2365 

The order of "glyph" renderers wasn't being preserved due to a bug in the order that they were called (they were called by the order their unique identifier renderer.model.id versus their index renderer.id).