### PR TITLE
Extend embed.component to let multiple objects be rendered in multiple divs

### DIFF
--- a/bokeh/_templates/plot_js.js
+++ b/bokeh/_templates/plot_js.js
@@ -1,12 +1,16 @@
-var modelid = "{{ modelid }}";
-var modeltype = "{{ modeltype }}";
-var elementid = "{{ elementid }}";
-Bokeh.logger.info("Realizing plot:")
-Bokeh.logger.info(" - modeltype: {{ modeltype }}");
-Bokeh.logger.info(" - modelid: {{ modelid }}");
-Bokeh.logger.info(" - elementid: {{ elementid }}");
 var all_models = {{ all_models }};
 Bokeh.load_models(all_models);
-var model = Bokeh.Collections(modeltype).get(modelid);
-var view = new model.default_view({model: model, el: '#{{ elementid }}'});
-Bokeh.index[modelid] = view
+var plots = {{plots}}
+for (idx in plots) {
+	var plot = plots[idx]
+	var model = Bokeh.Collections(plot.modeltype).get(plot.modelid);
+	Bokeh.logger.info('Realizing plot:')
+	Bokeh.logger.info(' - modeltype: ' + plot.modeltype);
+	Bokeh.logger.info(' - modelid: ' + plot.modelid);
+	Bokeh.logger.info(' - elementid: ' + plot.elementid);
+	var view = new model.default_view({
+		model: model,
+		el: plot.elementid
+	});
+	Bokeh.index[plot.modelid] = view;
+}

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -31,7 +31,7 @@ def _wrap_in_function(code):
     return 'Bokeh.$(function() {\n%s\n});' % code
 
 
-def components(plot_object, resources=None):
+def components(plot_objects, resources=None):
     ''' Return HTML components to embed a Bokeh plot.
 
     The data for the plot is stored directly in the returned HTML.
@@ -40,19 +40,41 @@ def components(plot_object, resources=None):
               are **already loaded**.
 
     Args:
-        plot_object (PlotObject) : Bokeh object to render
-            typically a Plot or PlotContext
+        plot_objects (PlotObject|list|dict|tuple) : Will return script
+        and div element to render if PlotObject, or correlating structures
+        of script/div combinations
         resources : Deprecated argument
     Returns:
-        (script, div) : UTF-8 encoded
-
+        (script, div): UTF-8 encoded|list|dict|tuple
     '''
-    
+
     if resources is not None:
         warn('Because the ``resources`` argument is no longer needed, '
              'is it deprecated and will be removed in'
              'a future version.', DeprecationWarning, stacklevel=2)
     
+    if type(plot_objects) is list or type(plot_objects) is tuple:
+        script_divs = []
+        for plot_object in plot_objects:
+            script_divs.append(script_div_gen(plot_object))
+        return tuple(script_divs) if type(plot_objects) is tuple else script_divs
+    elif type(plot_objects) is dict:
+        script_divs = {}
+        for key, plot_object in plot_objects.iteritems():
+            script_divs[key] = script_div_gen(plot_object)
+        return script_divs
+    else:
+        # if single PlotObject
+        return script_div_gen(plot_objects)
+
+
+def script_div_gen(plot_object):
+    '''Args:
+        plot_object (PlotObject) : Bokeh object to render
+            typically a Plot or PlotContext
+    Returns:
+        (script, div) : UTF-8 encoded
+    '''
     ref = plot_object.ref
     elementid = str(uuid.uuid4())
     

--- a/sphinx/source/docs/user_guide/embed.rst
+++ b/sphinx/source/docs/user_guide/embed.rst
@@ -60,7 +60,7 @@ can be used in HTML documents however you like:
     plot = figure()
     plot.circle([1,2], [3,4])
 
-    script, div = components(plot)
+    components(plot)
 
 The returned ``<script>`` will look something like:
 

--- a/sphinx/source/docs/user_guide/embed.rst
+++ b/sphinx/source/docs/user_guide/embed.rst
@@ -60,7 +60,7 @@ can be used in HTML documents however you like:
     plot = figure()
     plot.circle([1,2], [3,4])
 
-    components(plot)
+    script, div = components(plot)
 
 The returned ``<script>`` will look something like:
 
@@ -122,6 +122,17 @@ For example, to use version ``0.8.2``:
 The |components| function takes either a single PlotObject, an array or a 
 touple of PlotObjects, or even a dictionary of keys and PlotObjects. All return
 a corresponding data structure of script and div pairs.
+
+The following illustrates how different input types correlate to outputs:
+
+.. code-block:: python
+    components(foo)                      # (script, foo_div)
+
+    components([foo, bar])               # (script, [foo_div, bar_div])
+
+    components((foo, bar))               # (script, (foo_div, bar_div))
+
+    components({"foo": foo, "bar": bar}) # (script, {"foo": foo_div, "bar": bar_div})
 
 .. _userguide_embed_notebook:
 

--- a/sphinx/source/docs/user_guide/embed.rst
+++ b/sphinx/source/docs/user_guide/embed.rst
@@ -119,6 +119,9 @@ For example, to use version ``0.8.2``:
         rel="stylesheet" type="text/css">
     <script src="http://cdn.pydata.org/bokeh/release/bokeh-0.8.2.min.js">
 
+The |components| function takes either a single PlotObject, an array or a 
+touple of PlotObjects, or even a dictionary of keys and PlotObjects. All return
+a corresponding data structure of script and div pairs.
 
 .. _userguide_embed_notebook:
 


### PR DESCRIPTION
References feature request https://github.com/bokeh/bokeh/issues/2348. 

Allows a single `PlotObject`, list of `PlotObject`, dictionary of keys and `PlotObject`, and tuples of `PlotObject` to be passed into component function, and returns a correlating data structure composed of script/div pairs. 