### PR TITLE
Stop datetime scalar transformation throwing away microsecond 

### DIFF
--- a/bokeh/protocol.py
+++ b/bokeh/protocol.py
@@ -80,12 +80,13 @@ class BokehJSONEncoder(json.JSONEncoder):
             return int(obj)
         elif np.issubdtype(type(obj), np.bool_):
             return bool(obj)
+        # Datetime
+        # datetime is a subclass of date.
+        elif isinstance(obj, dt.datetime):
+            return calendar.timegm(obj.timetuple()) * 1000. + obj.microsecond / 1000.            
         # Date
         elif isinstance(obj, dt.date):
             return calendar.timegm(obj.timetuple()) * 1000.
-        # Datetime    
-        elif isinstance(obj, dt.datetime):
-            return calendar.timegm(obj.timetuple()) * 1000. + obj.microsecond / 1000.
         # Numpy datetime64
         elif isinstance(obj, np.datetime64):
             epoch_delta = obj - np.datetime64('1970-01-01T00:00:00Z')

--- a/bokeh/protocol.py
+++ b/bokeh/protocol.py
@@ -49,7 +49,7 @@ class BokehJSONEncoder(json.JSONEncoder):
                     return (obj.astype('int64') / millifactor).tolist()
                 # else punt.
             else:
-                return obj.astype('datetime64[ms]').astype('int64').tolist()
+                return (obj.astype('datetime64[us]').astype('int64') / 1000.).tolist()
         elif obj.dtype.kind in ('u', 'i', 'f'):
             return self.transform_numerical_array(obj)
         return obj.tolist()

--- a/bokeh/protocol.py
+++ b/bokeh/protocol.py
@@ -80,16 +80,19 @@ class BokehJSONEncoder(json.JSONEncoder):
             return int(obj)
         elif np.issubdtype(type(obj), np.bool_):
             return bool(obj)
-        # Datetime, Date
-        elif isinstance(obj, (dt.datetime, dt.date)):
+        # Date
+        elif isinstance(obj, dt.date):
             return calendar.timegm(obj.timetuple()) * 1000.
+        # Datetime    
+        elif isinstance(obj, dt.datetime):
+            return calendar.timegm(obj.timetuple()) * 1000. + obj.microsecond / 1000.
         # Numpy datetime64
         elif isinstance(obj, np.datetime64):
             epoch_delta = obj - np.datetime64('1970-01-01T00:00:00Z')
             return (epoch_delta / np.timedelta64(1, 'ms'))
         # Time
         elif isinstance(obj, dt.time):
-            return (obj.hour*3600 + obj.minute*60 + obj.second)*1000 + obj.microsecond / 1000.
+            return (obj.hour * 3600 + obj.minute * 60 + obj.second) * 1000 + obj.microsecond / 1000.
         elif is_dateutil and isinstance(obj, relativedelta):
             return dict(years=obj.years, months=obj.months, days=obj.days, hours=obj.hours,
                 minutes=obj.minutes, seconds=obj.seconds, microseconds=obj.microseconds)


### PR DESCRIPTION
See issue #2416

I am not sure if the protocol can handle decimal places (whether we should use `obj.microsecond / 1000.` or `obj.microsecond / 1000`), but since `isinstance(obj, dt.time)` line already used the float way, I will do the same.
