### PR TITLE
Spectrogram

### DIFF
--- a/bokehjs/src/coffee/renderer/glyph/glyph_renderer.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/glyph_renderer.coffee
@@ -50,11 +50,14 @@ class GlyphRendererView extends PlotWidget
   #TODO: There are glyph sub-type-vs-resample_op concordance issues...
   setup_server_data: () ->
 
-  set_data: (request_render=true) ->
+  # TODO (bev) arg is a quick-fix to allow some hinting for things like
+  # partial data updates (especially useful on expensive set_data calls
+  # for image, e.g.)
+  set_data: (request_render=true, arg) ->
     t0 = Date.now()
     source = @mget('data_source')
 
-    @glyph.set_data(source)
+    @glyph.set_data(source, arg)
 
     @glyph.set_visuals(source)
     @selection_glyph.set_visuals(source)

--- a/bokehjs/src/coffee/renderer/glyph/image_rgba.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/image_rgba.coffee
@@ -6,7 +6,9 @@ class ImageRGBAView extends Glyph.View
   _index_data: () ->
     @_xy_index()
 
-  _set_data: () ->
+  # TODO (bev) to improve. Currently, if only one image has changed, can
+  # pass index as "arg" to prevent full re-preocessing (useful for streaming)
+  _set_data: (source, arg) ->
     if not @image_data? or @image_data.length != @image.length
       @image_data = new Array(@image.length)
 
@@ -17,6 +19,9 @@ class ImageRGBAView extends Glyph.View
       @height = new Array(@image.length)
 
     for i in [0...@image.length]
+      if arg?
+        if i != arg
+          continue
       if @rows?
         @height[i] = @rows[i]
         @width[i] = @cols[i]

--- a/bokehjs/src/coffee/renderer/glyph/image_rgba.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/image_rgba.coffee
@@ -47,7 +47,6 @@ class ImageRGBAView extends Glyph.View
       @max_dh = 0
       if @dh.units == "data"
         @max_dh = _.max(@dh)
-      @_xy_index()
 
   _map_data: () ->
     @sw = @sdist(@renderer.xmapper, @x, @dw, 'edge', @mget('dilate'))

--- a/examples/embed/spectrogram/spectrogram.coffee
+++ b/examples/embed/spectrogram/spectrogram.coffee
@@ -137,6 +137,7 @@ class SpectrogramPlot
       @images = [img].concat(@images[0..])
       @xs.pop()
       @xs = [1-@image_width].concat(@xs[0..])
+      @source.set('data', {image: @images, x: @xs})
 
     image32 = new Uint32Array(@images[0])
     buf32 = new Uint32Array(buf)
@@ -144,8 +145,8 @@ class SpectrogramPlot
     for i in [0...@config.SPECTROGRAM_LENGTH]
       image32[i*@image_width+@col] = buf32[i]
 
-    @source.set('data', {image: @images, x: @xs})
-    @source.trigger('change', @source)
+    @source.get('data')['x'] = @xs
+    @source.trigger('change', true, 0)
 
   set_yrange: (y0, y1) ->
     @y_range.set({'start': y0, 'end' : y1})

--- a/examples/embed/spectrogram/spectrogram.py
+++ b/examples/embed/spectrogram/spectrogram.py
@@ -24,7 +24,7 @@ MAX_FREQ = SAMPLING_RATE / 2
 FREQ_SAMPLES = NUM_SAMPLES / 8
 NGRAMS = 800
 SPECTROGRAM_LENGTH = 512
-TILE_WIDTH = 500
+TILE_WIDTH = 200
 TIMESLICE = 40 # ms
 
 mutex = RLock()
@@ -70,7 +70,7 @@ def params():
         "TILE_WIDTH": TILE_WIDTH,
         "TIMESLICE": TIMESLICE,
         "EQ_CLAMP": 20,
-        "FRAMES_PER_SECOND": 20
+        "FRAMES_PER_SECOND": 15
     })
 
 

--- a/examples/embed/spectrogram/static/js/spectrogram.js
+++ b/examples/embed/spectrogram/static/js/spectrogram.js
@@ -206,17 +206,18 @@
         this.images = [img].concat(this.images.slice(0));
         this.xs.pop();
         this.xs = [1 - this.image_width].concat(this.xs.slice(0));
+        this.source.set('data', {
+          image: this.images,
+          x: this.xs
+        });
       }
       image32 = new Uint32Array(this.images[0]);
       buf32 = new Uint32Array(buf);
       for (i = _j = 0, _ref1 = this.config.SPECTROGRAM_LENGTH; 0 <= _ref1 ? _j < _ref1 : _j > _ref1; i = 0 <= _ref1 ? ++_j : --_j) {
         image32[i * this.image_width + this.col] = buf32[i];
       }
-      this.source.set('data', {
-        image: this.images,
-        x: this.xs
-      });
-      return this.source.trigger('change', this.source);
+      this.source.get('data')['x'] = this.xs;
+      return this.source.trigger('change', true, 0);
     };
 
     SpectrogramPlot.prototype.set_yrange = function(y0, y1) {


### PR DESCRIPTION
issues: closes #2433 

This is a quick little PR to make the spectrogram usable again. This brings the CPU usage reliably down to < 50% on Chrome on OS X, making it suitable to demo at conference tables, etc. 

ping @SaraSchnadt @birdsarah I'd like to take this opportunity to also use the new `embed.components` to remove the `vplot`, `hplot` etc and just style this in a visually attractive custom jinja template. Is that something one or both of you could take a quick look at? 