### PR TITLE
Task/standardize callback interface

### DIFF
--- a/bokeh/models/actions.py
+++ b/bokeh/models/actions.py
@@ -29,5 +29,7 @@ class Callback(Action):
     A snippet of JavaScript code to execute in the browser. The code is
     made into the body of a function, and all of of the named objects in
     ``args`` are available as parameters that the code can use. Additionally,
-    a ``cb_obj`` parameter contains the object that triggered the callback.
+    a ``cb_obj`` parameter contains the object that triggered the callback
+    and an optional ``cb_data`` parameter that contains any related data
+    (i.e. mouse coordinates for the HoverTool).
     """)

--- a/bokehjs/src/coffee/action/callback.coffee
+++ b/bokehjs/src/coffee/action/callback.coffee
@@ -13,7 +13,7 @@ class Callback extends HasProperties
     @register_property('func', @_make_func, true)
     @add_dependencies('func', @, ['args', 'code'])
 
-  execute: (cb_obj, cb_data=null) ->
+  execute: (cb_obj, cb_data) ->
     @get('func')(@get('values')..., cb_obj, cb_data)
 
   _make_values: () ->

--- a/bokehjs/src/coffee/action/callback.coffee
+++ b/bokehjs/src/coffee/action/callback.coffee
@@ -13,14 +13,14 @@ class Callback extends HasProperties
     @register_property('func', @_make_func, true)
     @add_dependencies('func', @, ['args', 'code'])
 
-  execute: (value) ->
-    @get('func')(@get('values')..., value)
+  execute: (cb_obj, cb_data=null) ->
+    @get('func')(@get('values')..., cb_obj, cb_data)
 
   _make_values: () ->
     _.map(_.values(@get("args")), @resolve_ref)
 
   _make_func: () ->
-    new Function(_.keys(@get("args"))..., "cb_obj", @get("code"))
+    new Function(_.keys(@get("args"))..., "cb_obj", "cb_data", @get("code"))
 
   defaults: ->
     return _.extend {}, super(), {

--- a/bokehjs/src/coffee/common/plot.coffee
+++ b/bokehjs/src/coffee/common/plot.coffee
@@ -283,7 +283,7 @@ class PlotView extends ContinuumView
     indices = {}
     for renderer, i in @mget("renderers")
       indices[renderer.id] = i
-    sortKey = (renderer) -> indices[renderer.model.id]
+    sortKey = (renderer) -> indices[renderer.id]
 
     for level in levels
       renderers = _.sortBy(_.values(@levels[level]), sortKey)

--- a/bokehjs/test/test_action/test_callback.coffee
+++ b/bokehjs/test/test_action/test_callback.coffee
@@ -60,7 +60,7 @@ describe "callback module", ->
 
     it "should return cb_data with value of null if cb_data kwarg is unset", ->
       r = Collections('Callback').create({code: "return cb_data"})
-      expect(r.execute('foo')).to.be.equal null
+      expect(r.execute('foo')).to.be.equal undefined 
 
     it "should return cb_data with value of kwarg parameter to execute", ->
       r = Collections('Callback').create({code: "return cb_data"})

--- a/bokehjs/test/test_action/test_callback.coffee
+++ b/bokehjs/test/test_action/test_callback.coffee
@@ -35,13 +35,13 @@ describe "callback module", ->
 
     it "should have code property as function body", ->
       r = Collections('Callback').create({code: "return 10"})
-      f = new Function("cb_obj", "return 10")
+      f = new Function("cb_obj", "cb_data", "return 10")
       expect(r.get('func').toString()).to.be.equal f.toString()
 
     it "should have values as function args", ->
       rng = Collections('Range1d').create()
       r = Collections('Callback').create({args: {foo: rng.ref()}, code: "return 10"})
-      f = new Function("foo", "cb_obj", "return 10")
+      f = new Function("foo", "cb_obj", "cb_data", "return 10")
       expect(r.get('func').toString()).to.be.equal f.toString()
 
   describe "execute method", ->
@@ -53,3 +53,15 @@ describe "callback module", ->
     it "should execute the code with args parameters passed", ->
       r = Collections('Callback').create({args: {foo: 5}, code: "return 10 + foo"})
       expect(r.execute()).to.be.equal 15
+
+    it "should return the cb_obj passed an args parameter to execute", ->
+      r = Collections('Callback').create({code: "return cb_obj"})
+      expect(r.execute('foo')).to.be.equal 'foo'
+
+    it "should return cb_data with value of null if cb_data kwarg is unset", ->
+      r = Collections('Callback').create({code: "return cb_data"})
+      expect(r.execute('foo')).to.be.equal null
+
+    it "should return cb_data with value of kwarg parameter to execute", ->
+      r = Collections('Callback').create({code: "return cb_data"})
+      expect(r.execute('foo', 'bar')).to.be.equal 'bar'


### PR DESCRIPTION
ref issue #2412 and PR #2386 

Refactor of callback.coffee so that the execute method has a standardized arguments

execute(cb_obj, cb_data)

where cb_obj is the object that triggered the callback and cb_data is an optional arg that contains any associated data (e.g. mouse coordinates of a HoverTool callback)