### PR TITLE
add example plotting widget with play stop

### DIFF
--- a/examples/plotting/server/line_animate_widget.py
+++ b/examples/plotting/server/line_animate_widget.py
@@ -20,7 +20,7 @@ N = 80
 x = np.linspace(0, 4*np.pi, N)
 y = np.sin(x)
 
-output_server("line_animate")
+output_server("line_animate_widget")
 
 p = figure()
 

--- a/examples/plotting/server/line_animate_widget.py
+++ b/examples/plotting/server/line_animate_widget.py
@@ -1,0 +1,83 @@
+from __future__ import print_function
+
+import time
+import logging
+from threading import Thread
+
+import numpy as np
+
+from bokeh.models.widgets import Button
+from bokeh.plotting import (
+    cursession, figure, show, 
+    output_server, curdoc, vplot, 
+    hplot
+)
+
+logger = logging.getLogger(__name__)
+
+N = 80
+
+x = np.linspace(0, 4*np.pi, N)
+y = np.sin(x)
+
+output_server("line_animate")
+
+p = figure()
+
+p.line(x, y, color="#3333ee", name="sin")
+p.line([0,4*np.pi], [-1, 1], color="#ee3333")
+
+def play_handler():
+    print("button_handler: start click")
+    global play 
+    play = True
+
+def stop_handler():
+    print("button_handler: stop click")
+    global play 
+    play = False
+
+play = True
+
+button_start = Button(label="Start", type="success")
+button_start.on_click(play_handler)
+
+button_stop = Button(label="Stop", type="danger")
+button_stop.on_click(stop_handler)
+
+controls = hplot(button_start, button_stop)
+layout = vplot(controls, p)
+
+show(layout)
+
+renderer = p.select(dict(name="sin"))
+ds = renderer[0].data_source
+
+def should_play():
+    """Return true if we should play animation, otherwise block"""
+    global play
+    while True:
+        if play:
+            return True
+        else:
+            time.sleep(0.05)
+
+def background_thread(ds):
+    """Plot animation, update data if play is True, otherwise stop"""
+    try:
+        while True:
+            for i in np.hstack((np.linspace(1, -1, 100), np.linspace(-1, 1, 100))):
+                if should_play():
+                    ds.data["y"] = y * i
+                    cursession().store_objects(ds)
+                time.sleep(0.05)
+    except:
+        logger.exception("An error occurred")
+        raise
+
+# spin up a background thread with animation
+Thread(target=background_thread, args=(ds,)).start()
+
+# endlessly poll to check widgets
+cursession().poll_document(curdoc(), 0.5)
+

--- a/examples/plotting/server/line_animate_widget.py
+++ b/examples/plotting/server/line_animate_widget.py
@@ -79,5 +79,5 @@ def background_thread(ds):
 Thread(target=background_thread, args=(ds,)).start()
 
 # endlessly poll to check widgets
-cursession().poll_document(curdoc(), 0.5)
+cursession().poll_document(curdoc(), 0.05)
 


### PR DESCRIPTION
Including an example showing widgets together with animations in the plotting interface (using a background thread for updating data)

Related with #2452

Demo:
![startstop](https://cloud.githubusercontent.com/assets/4940549/8364564/d1d8cef6-1b4c-11e5-836b-ab814b19cf9d.gif)