### PR TITLE
Don't overwrite window.$

### DIFF
--- a/bokehjs/src/coffee/jquery-private.coffee
+++ b/bokehjs/src/coffee/jquery-private.coffee
@@ -1,1 +1,0 @@
-module.exports = require("jquery").noConflict(true)

--- a/bokehjs/src/coffee/main.coffee
+++ b/bokehjs/src/coffee/main.coffee
@@ -2,25 +2,26 @@ Bokeh = {}
 Bokeh.require = require
 Bokeh.version = '0.9.0'
 
-Bokeh.index = require("./common/base").index
+# binding the libs that bokeh uses so others can reference them
+Bokeh._                 = require("underscore")
+Bokeh.$                 = require("jquery")
+
+require "jquery-ui"
+Bokeh.Backbone          = require("backbone")
+Bokeh.Backbone.$        = Bokeh.$
+Bokeh.Backbone.$.ui     = Bokeh.$.ui
 
 # set up logger
 logging = require("./common/logging")
-Bokeh.logger = logging.logger
-Bokeh.set_log_level = logging.set_log_level
+Bokeh.logger            = logging.logger
+Bokeh.set_log_level     = logging.set_log_level
 
 # fallback to Array if necessary
 if not window.Float64Array
   Bokeh.logger.warn("Float64Array is not supported. Using generic Array instead.")
   window.Float64Array = Array
 
-# binding the libs that bokeh uses so others can reference them
-Bokeh._                 = require("underscore")
-Bokeh.$ = $ = jQuery    = require("jquery")
-require "jquery-ui"
-Bokeh.Backbone          = require("backbone")
-Bokeh.Backbone.$        = Bokeh.$
-Bokeh.Backbone.$.ui     = jQuery.ui
+Bokeh.index             = require("./common/base").index
 
 # common
 Bokeh.Collections       = require("./common/base").Collections

--- a/bokehjs/src/vendor/jquery-event-2.2/jquery.event.drag.js
+++ b/bokehjs/src/vendor/jquery-event-2.2/jquery.event.drag.js
@@ -7,7 +7,7 @@
 // Updated: 2012-05-21
 // REQUIRES: jquery 1.7.x
 
-$ = require("jquery");
+var $ = require("jquery");
 
 // add the jquery instance method
 $.fn.drag = function( str, arg, opts ){


### PR DESCRIPTION
This PR supersedes #2437. The real issue wasn't lack of `noConflict(true)`, but one missing `var`. `noConflict(true)` is not needed at all because jquery doesn't modify `window` in a nodejs-like module environment which browserify emulates. I will add tests in another PR, so that this one doesn't stall.