### PR TITLE
Use Bokeh's jQuery for server template

### DIFF
--- a/bokeh/server/templates/oneobj.html
+++ b/bokeh/server/templates/oneobj.html
@@ -18,7 +18,7 @@
   window.{{modulename}}.main();
   {% endfor %}
   Bokeh.$(document).ready(function() {
-    container = $("#PlotPane");
+    container = Bokeh.$("#PlotPane");
     Bokeh.set_log_level("{{ loglevel }}")
     Bokeh.embed.add_plot_server(container, "{{ docid }}", "{{ objid }}", {{ public }});
   });


### PR DESCRIPTION
This hotfix enables examples/charts/server/line_animate.py (and probably others) to render.