### PR TITLE
clean up examples, use standard bokeh.io output

### DIFF
--- a/bokeh/compat/mpl.py
+++ b/bokeh/compat/mpl.py
@@ -13,6 +13,8 @@
 
 from __future__ import absolute_import
 
+from warnings import warn
+
 import matplotlib.pyplot as plt
 
 from .bokeh_exporter import BokehExporter
@@ -22,7 +24,7 @@ from .bokeh_renderer import BokehRenderer
 # Classes and functions
 #-----------------------------------------------------------------------------
 
-def to_bokeh(fig=None, name=None, server=None, notebook=False, pd_obj=True, xkcd=False):
+def to_bokeh(fig=None, name=None, server=None, notebook=None, pd_obj=True, xkcd=False):
     """ Uses bokeh to display a Matplotlib Figure.
 
     You can store a bokeh plot in a standalone HTML file, as a document in
@@ -58,6 +60,13 @@ def to_bokeh(fig=None, name=None, server=None, notebook=False, pd_obj=True, xkcd
         If this option is True, then the Bokeh figure will be saved with a
         xkcd style.
     """
+
+    if name is not None:
+        warn("Use standard output_file(...) from bokeh.io")
+    if server is not None:
+        warn("Use standard output_server(...) from bokeh.io")
+    if notebook is not None:
+        warn("Use standard output_notebook() from bokeh.io")
 
     if fig is None:
         fig = plt.gcf()

--- a/bokeh/compat/mpl.py
+++ b/bokeh/compat/mpl.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 
 import matplotlib.pyplot as plt
 
-from ..plotting import curdoc, output_file, output_notebook, output_server
 from .bokeh_exporter import BokehExporter
 from .bokeh_renderer import BokehRenderer
 
@@ -63,31 +62,9 @@ def to_bokeh(fig=None, name=None, server=None, notebook=False, pd_obj=True, xkcd
     if fig is None:
         fig = plt.gcf()
 
-    if any([name, server, notebook]):
-        if name:
-            if not server:
-                filename = name + ".html"
-                output_file(filename)
-            else:
-                output_server(name, url=server)
-        elif server:
-            if not notebook:
-                output_server("unnameuuuuuuuuuuuuuud", url=server)
-            else:
-                output_notebook(url=server)
-        elif notebook:
-            output_notebook()
-    else:
-        output_file("Unnamed.html")
-
-    doc = curdoc()
-
     renderer = BokehRenderer(pd_obj, xkcd)
     exporter = BokehExporter(renderer)
 
     exporter.run(fig)
-
-    doc._current_plot = renderer.fig  # TODO (bev) do not rely on private attrs
-    doc.add(renderer.fig)
 
     return renderer.fig

--- a/examples/compat/ggplot/density.py
+++ b/examples/compat/ggplot/density.py
@@ -1,13 +1,14 @@
-from ggplot import *
-from bokeh import mpl
-from bokeh.plotting import show
+from ggplot import aes, diamonds, geom_density, ggplot
 import matplotlib.pyplot as plt
 
-g = ggplot(diamonds, aes(x='price', color='cut')) + \
-    geom_density()
+from bokeh import mpl
+from bokeh.plotting import output_file, show
 
+g = ggplot(diamonds, aes(x='price', color='cut')) + geom_density()
 g.draw()
 
 plt.title("Density ggplot-based plot in Bokeh.")
 
-show(mpl.to_bokeh(name="density"))
+output_file("density.html")
+
+show(mpl.to_bokeh())

--- a/examples/compat/ggplot/ggplot.ipynb
+++ b/examples/compat/ggplot/ggplot.ipynb
@@ -15,10 +15,11 @@
    },
    "outputs": [],
    "source": [
-    "from ggplot import *\n",
+    "from ggplot import aes, diamonds, geom_density, geom_line, geom_step, ggplot, meat\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
     "from bokeh import mpl\n",
-    "from bokeh.plotting import show\n",
-    "import matplotlib.pyplot as plt"
+    "from bokeh.plotting import output_notebook, show"
    ]
   },
   {
@@ -29,14 +30,23 @@
    },
    "outputs": [],
    "source": [
-    "g = ggplot(diamonds, aes(x='price', color='cut')) + \\\n",
-    "    geom_density()\n",
-    "\n",
+    "output_notebook()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "g = ggplot(diamonds, aes(x='price', color='cut')) + geom_density()\n",
     "g.draw()\n",
     "\n",
     "plt.title(\"Density ggplot-based plot in Bokeh.\")\n",
     "\n",
-    "show(mpl.to_bokeh(notebook=True))"
+    "show(mpl.to_bokeh())"
    ]
   },
   {
@@ -47,14 +57,12 @@
    },
    "outputs": [],
    "source": [
-    "g = ggplot(aes(x='date', y='beef'), data=meat) + \\\n",
-    "    geom_line()\n",
-    "\n",
+    "g = ggplot(aes(x='date', y='beef'), data=meat) + geom_line()\n",
     "g.draw()\n",
     "\n",
     "plt.title(\"Line ggplot-based plot in Bokeh.\")\n",
     "\n",
-    "show(mpl.to_bokeh(notebook=True))"
+    "show(mpl.to_bokeh())"
    ]
   },
   {
@@ -72,16 +80,14 @@
     "    \"x\": range(100),\n",
     "    \"y\": np.random.choice([-1, 1], 100)\n",
     "})\n",
-    "\n",
     "df.y = df.y.cumsum()\n",
     "\n",
-    "g = ggplot(aes(x='x', y='y'), data=df) + \\\n",
-    "    geom_step()\n",
+    "g = ggplot(aes(x='x', y='y'), data=df) + geom_step()\n",
     "g.draw()\n",
     "\n",
     "plt.title(\"Step ggplot-based plot in Bokeh.\")\n",
     "\n",
-    "show(mpl.to_bokeh(notebook=True))"
+    "show(mpl.to_bokeh())"
    ]
   },
   {
@@ -94,7 +100,25 @@
    "source": []
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/compat/ggplot/line.py
+++ b/examples/compat/ggplot/line.py
@@ -1,13 +1,14 @@
-from ggplot import *
-from bokeh import mpl
-from bokeh.plotting import show
+from ggplot import aes, geom_line, ggplot, meat
 import matplotlib.pyplot as plt
 
-g = ggplot(aes(x='date', y='beef'), data=meat) + \
-    geom_line()
+from bokeh import mpl
+from bokeh.plotting import output_file, show
 
+g = ggplot(aes(x='date', y='beef'), data=meat) + geom_line()
 g.draw()
 
 plt.title("Line ggplot-based plot in Bokeh.")
 
-show(mpl.to_bokeh(name="line"))
+output_file("line.html")
+
+show(mpl.to_bokeh())

--- a/examples/compat/ggplot/step.py
+++ b/examples/compat/ggplot/step.py
@@ -1,21 +1,22 @@
-from ggplot import *
-from bokeh import mpl
-from bokeh.plotting import show
+from ggplot import aes, geom_step, ggplot
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
+
+from bokeh import mpl
+from bokeh.plotting import output_file, show
 
 df = pd.DataFrame({
     "x": range(100),
     "y": np.random.choice([-1, 1], 100)
 })
-
 df.y = df.y.cumsum()
 
-g = ggplot(aes(x='x', y='y'), data=df) + \
-    geom_step()
+g = ggplot(aes(x='x', y='y'), data=df) + geom_step()
 g.draw()
 
 plt.title("Step ggplot-based plot in Bokeh.")
 
-show(mpl.to_bokeh(name="step"))
+output_file("step.html")
+
+show(mpl.to_bokeh())

--- a/examples/compat/ggplot/xkcd_density.py
+++ b/examples/compat/ggplot/xkcd_density.py
@@ -1,13 +1,14 @@
-from ggplot import *
-from bokeh import mpl
-from bokeh.plotting import show
+from ggplot import aes, diamonds, geom_density, ggplot
 import matplotlib.pyplot as plt
 
-g = ggplot(diamonds, aes(x='price', color='cut')) + \
-    geom_density()
+from bokeh import mpl
+from bokeh.plotting import output_file, show
 
+g = ggplot(diamonds, aes(x='price', color='cut')) + geom_density()
 g.draw()
 
 plt.title("xkcd-ggplot-mpl based plot in Bokeh.")
 
-show(mpl.to_bokeh(name="xkcd_density", xkcd=True))
+output_file("xkcd_density.html")
+
+show(mpl.to_bokeh(xkcd=True))

--- a/examples/compat/mpl/lc_dashed.py
+++ b/examples/compat/mpl/lc_dashed.py
@@ -1,25 +1,30 @@
-import numpy as np
-import matplotlib.pyplot as plt
 from matplotlib.collections import LineCollection
+import matplotlib.pyplot as plt
+import numpy as np
+
 from bokeh import mpl
-from bokeh.plotting import show
+from bokeh.plotting import output_file, show
 
 # In order to efficiently plot many lines in a single set of axes,
 # add the lines all at once. Here is a simple example showing how it is done.
 
 N = 50
 x = np.arange(N)
+
 # Here are many sets of y to plot vs x
 ys = [x + i for i in x]
 
 colors = ['#ff0000', '#008000', '#0000ff', '#00bfbf', '#bfbf00', '#bf00bf', '#000000']
 
-line_segments = LineCollection([list(zip(x, y)) for y in ys], color=colors,
-                                linewidth=(0.5, 1, 1.5, 2), linestyle='dashed')
+line_segments = LineCollection([list(zip(x, y)) for y in ys],
+                               color=colors,
+                               linewidth=(0.5, 1, 1.5, 2),
+                               linestyle='dashed')
 
 ax = plt.axes()
-
 ax.add_collection(line_segments)
 ax.set_title('Line Collection with dashed colors')
 
-show(mpl.to_bokeh(name="lc_dashed"))
+output_file("lc_dashed.html")
+
+show(mpl.to_bokeh())

--- a/examples/compat/mpl/lc_offsets.py
+++ b/examples/compat/mpl/lc_offsets.py
@@ -1,8 +1,9 @@
-import numpy as np
-import matplotlib.pyplot as plt
 from matplotlib.collections import LineCollection
+import matplotlib.pyplot as plt
+import numpy as np
+
 from bokeh import mpl
-from bokeh.plotting import show
+from bokeh.plotting import output_file, show
 
 # Simulate a series of ocean current profiles, successively
 # offset by 0.1 m/s so that they form what is sometimes called
@@ -35,4 +36,6 @@ ax.set_title('Successive data offsets')
 
 fig = plt.gcf()
 
-show(mpl.to_bokeh(name="lc_offsets"))
+output_file("lc_offsets.html")
+
+show(mpl.to_bokeh())

--- a/examples/compat/mpl/listcollection.py
+++ b/examples/compat/mpl/listcollection.py
@@ -1,8 +1,9 @@
-import numpy as np
-import matplotlib.pyplot as plt
 from matplotlib.collections import LineCollection
+import matplotlib.pyplot as plt
+import numpy as np
+
 from bokeh import mpl
-from bokeh.plotting import show
+from bokeh.plotting import output_file, show
 
 
 def make_segments(x, y):
@@ -52,4 +53,6 @@ plt.title("MPL support for ListCollection in Bokeh")
 plt.xlim(x.min(), x.max())
 plt.ylim(-1.0, 1.0)
 
-show(mpl.to_bokeh(name="listcollection"))
+output_file("listcollection.html")
+
+show(mpl.to_bokeh())

--- a/examples/compat/mpl/mpl.ipynb
+++ b/examples/compat/mpl/mpl.ipynb
@@ -15,10 +15,22 @@
    },
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
     "from bokeh import mpl\n",
-    "from bokeh.plotting import show"
+    "from bokeh.plotting import output_notebook, show"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "output_notebook()"
    ]
   },
   {
@@ -34,12 +46,10 @@
     "z = np.cos(x / 4)\n",
     "\n",
     "plt.title(\"Matplotlib Figure in Bokeh\")\n",
-    "\n",
     "plt.plot(x, y, \"r-\", marker='o')\n",
-    "\n",
     "plt.plot(x, z, \"g-x\", linestyle=\"-.\")\n",
     "\n",
-    "show(mpl.to_bokeh(plt.gcf(), notebook=True))"
+    "show(mpl.to_bokeh())"
    ]
   },
   {
@@ -67,11 +77,10 @@
     "                                linewidth=(0.5, 1, 1.5, 2), linestyle='dashed')\n",
     "\n",
     "ax = plt.axes()\n",
-    "\n",
     "ax.add_collection(line_segments)\n",
     "ax.set_title('Line Collection with dashed colors')\n",
     "\n",
-    "show(mpl.to_bokeh(notebook=True))"
+    "show(mpl.to_bokeh())"
    ]
   },
   {
@@ -103,11 +112,12 @@
     "\n",
     "widths = [5, 10, 20, 10, 5]\n",
     "\n",
-    "ax = plt.axes()\n",
     "\n",
     "# Make the collection and add it to the plot.\n",
     "col = PolyCollection(verts, facecolor=facecolors, edgecolor=edgecolors,\n",
     "                     linewidth=widths, linestyle='--', alpha=0.5)\n",
+    "\n",
+    "ax = plt.axes()\n",
     "ax.add_collection(col)\n",
     "\n",
     "plt.xlim([-60, 60])\n",
@@ -115,7 +125,7 @@
     "\n",
     "plt.title(\"MPL-PolyCollection support in Bokeh\")\n",
     "\n",
-    "show(mpl.to_bokeh(notebook=True))"
+    "show(mpl.to_bokeh())"
    ]
   },
   {
@@ -128,7 +138,25 @@
    "source": []
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/compat/mpl/polycollection.py
+++ b/examples/compat/mpl/polycollection.py
@@ -1,8 +1,9 @@
-import numpy as np
-import matplotlib.pyplot as plt
 from matplotlib.collections import PolyCollection
+import matplotlib.pyplot as plt
+import numpy as np
+
 from bokeh import mpl
-from bokeh.plotting import show
+from bokeh.plotting import output_file, show
 
 # Generate data. In this case, we'll make a bunch of center-points and generate
 # verticies by subtracting random offsets from those center-points
@@ -18,16 +19,15 @@ verts = np.swapaxes(verts, 0, 1)
 # things to suit.
 
 facecolors = ['red', 'green', 'blue', 'cyan', 'yellow', 'magenta', 'black']
-
 edgecolors = ['cyan', 'yellow', 'magenta', 'black', 'red', 'green', 'blue']
-
 widths = [5, 10, 20, 10, 5]
 
-ax = plt.axes()
 
 # Make the collection and add it to the plot.
 col = PolyCollection(verts, facecolor=facecolors, edgecolor=edgecolors,
                      linewidth=widths, linestyle='--', alpha=0.5)
+
+ax = plt.axes()
 ax.add_collection(col)
 
 plt.xlim([-60, 60])
@@ -35,4 +35,6 @@ plt.ylim([-60, 60])
 
 plt.title("MPL-PolyCollection support in Bokeh")
 
-show(mpl.to_bokeh(name="polycollection"))
+output_file("polycollection.html")
+
+show(mpl.to_bokeh())

--- a/examples/compat/mpl/sincos.py
+++ b/examples/compat/mpl/sincos.py
@@ -1,7 +1,8 @@
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+
 from bokeh import mpl
-from bokeh.plotting import show
+from bokeh.plotting import output_file, show
 
 x = np.linspace(-2 * np.pi, 2 * np.pi, 100)
 y = np.sin(x)
@@ -13,8 +14,6 @@ plt.title("Matplotlib Figure in Bokeh")
 # dashed lines work
 plt.plot(x, z, "g-x", linestyle="-.")
 
-#show(mpl.to_bokeh())
-#show(mpl.to_bokeh(name="sincos"))
-show(mpl.to_bokeh(plt.gcf(), name="sincos"))
-#show(mpl.to_bokeh(plt.gcf(), server="default"))
-#show(mpl.to_bokeh(plt.gcf(), name="sincos", server="default"))
+output_file("sincos.html")
+
+show(mpl.to_bokeh())

--- a/examples/compat/mpl/subplots.py
+++ b/examples/compat/mpl/subplots.py
@@ -8,8 +8,9 @@ matplotlib fun for a rainy day
 
 import matplotlib.pyplot as plt
 import numpy as np
+
 from bokeh import mpl
-from bokeh.plotting import show
+from bokeh.plotting import output_file, show
 
 x = np.array([10, 8, 13, 9, 11, 14, 6, 4, 12, 7, 5])
 y1 = np.array([8.04, 6.95, 7.58, 8.81, 8.33, 9.96, 7.24, 4.26, 10.84, 4.82, 5.68])
@@ -17,7 +18,6 @@ y2 = np.array([9.14, 8.14, 8.74, 8.77, 9.26, 8.10, 6.13, 3.10, 9.13, 7.26, 4.74]
 y3 = np.array([7.46, 6.77, 12.74, 7.11, 7.81, 8.84, 6.08, 5.39, 8.15, 6.42, 5.73])
 x4 = np.array([8, 8, 8, 8, 8, 8, 8, 19, 8, 8, 8])
 y4 = np.array([6.58, 5.76, 7.71, 8.84, 8.47, 7.04, 5.25, 12.50, 5.56, 7.91, 6.89])
-
 
 def fit(x):
     return 3 + 0.5 * x
@@ -52,4 +52,6 @@ plt.ylabel('IV', fontsize=20)
 
 # We create the figure in matplotlib and then we "pass it" to Bokeh
 
-show(mpl.to_bokeh(name="subplots"))
+output_file("subplots.html")
+
+show(mpl.to_bokeh())

--- a/examples/compat/pandas/dataframe.py
+++ b/examples/compat/pandas/dataframe.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pandas as pd
+
 from bokeh import mpl
-from bokeh.plotting import show
+from bokeh.plotting import output_file, show
 
 ts = pd.Series(np.random.randn(1000), index=pd.date_range('1/1/2000', periods=1000))
 ts = ts.cumsum()
@@ -10,4 +11,6 @@ df = pd.DataFrame(np.random.randn(1000, 4), index=ts.index, columns=list('ABCD')
 df = df.cumsum()
 df.plot(legend=False)
 
-show(mpl.to_bokeh(name="dataframe"))
+output_file("dataframe.html")
+
+show(mpl.to_bokeh())

--- a/examples/compat/pandas/pandas.ipynb
+++ b/examples/compat/pandas/pandas.ipynb
@@ -17,8 +17,20 @@
    "source": [
     "import numpy as np\n",
     "import pandas as pd\n",
+    "\n",
     "from bokeh import mpl\n",
-    "from bokeh.plotting import show"
+    "from bokeh.plotting import output_notebook, show"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "output_notebook()"
    ]
   },
   {
@@ -33,7 +45,7 @@
     "ts = ts.cumsum()\n",
     "p = ts.plot()\n",
     "\n",
-    "show(mpl.to_bokeh(notebook=True))"
+    "show(mpl.to_bokeh())"
    ]
   },
   {
@@ -51,7 +63,7 @@
     "df = df.cumsum()\n",
     "df.plot(legend=False)\n",
     "\n",
-    "show(mpl.to_bokeh(notebook=True))"
+    "show(mpl.to_bokeh())"
    ]
   },
   {
@@ -64,7 +76,25 @@
    "source": []
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/compat/pandas/series.py
+++ b/examples/compat/pandas/series.py
@@ -1,10 +1,15 @@
 import numpy as np
 import pandas as pd
-from bokeh import mpl
-from bokeh.plotting import show
 
-ts = pd.Series(np.random.randn(1000), index=pd.date_range('1/1/2000', periods=1000))
+from bokeh import mpl
+from bokeh.plotting import output_file, show
+
+ts = pd.Series(np.random.randn(1000),
+               index=pd.date_range('1/1/2000', periods=1000))
 ts = ts.cumsum()
+
 p = ts.plot()
 
-show(mpl.to_bokeh(name="series"))
+output_file("series.html")
+
+show(mpl.to_bokeh())

--- a/examples/compat/seaborn/boxplot.py
+++ b/examples/compat/seaborn/boxplot.py
@@ -1,6 +1,7 @@
 import seaborn as sns
+
 from bokeh import mpl
-from bokeh.plotting import show
+from bokeh.plotting import output_file, show
 
 sns.set(style="ticks")
 
@@ -11,5 +12,7 @@ tips = sns.load_dataset("tips")
 sns.boxplot(x="day", y="total_bill", hue="sex", data=tips, palette="PRGn")
 sns.despine(offset=10, trim=True)
 
-show(mpl.to_bokeh(name="violin"))
+output_file("boxplot.html")
+
+show(mpl.to_bokeh())
 

--- a/examples/compat/seaborn/factorplot.py
+++ b/examples/compat/seaborn/factorplot.py
@@ -1,8 +1,8 @@
 import numpy as np
 import seaborn as sns
-import matplotlib.pyplot as plt
+
 from bokeh import mpl
-from bokeh.plotting import show
+from bokeh.plotting import output_file, show
 
 sns.set(style="white")
 
@@ -16,4 +16,7 @@ years = np.arange(2000, 2015)
 g = sns.factorplot(x="year", data=planets, kind="count",
                    palette="BuPu", size=6, aspect=1.5, order=years)
 g.set_xticklabels(step=2)
-show(mpl.to_bokeh(name="kde"))
+
+output_file("factorplot.html")
+
+show(mpl.to_bokeh())

--- a/examples/compat/seaborn/kde.py
+++ b/examples/compat/seaborn/kde.py
@@ -1,7 +1,8 @@
-import seaborn as sns
 import matplotlib.pyplot as plt
+import seaborn as sns
+
 from bokeh import mpl
-from bokeh.plotting import show
+from bokeh.plotting import output_file, show
 
 sns.set(style="darkgrid")
 iris = sns.load_dataset("iris")
@@ -26,4 +27,6 @@ blue = sns.color_palette("Blues")[-2]
 ax.text(2.5, 8.2, "virginica", size=16, color=blue)
 ax.text(3.8, 4.5, "setosa", size=16, color=red)
 
-show(mpl.to_bokeh(name="kde"))
+output_file("kde.html")
+
+show(mpl.to_bokeh())

--- a/examples/compat/seaborn/seaborn.ipynb
+++ b/examples/compat/seaborn/seaborn.ipynb
@@ -18,8 +18,20 @@
     "import numpy as np\n",
     "import seaborn as sns\n",
     "import matplotlib.pyplot as plt\n",
+    "\n",
     "from bokeh import mpl\n",
-    "from bokeh.plotting import show"
+    "from bokeh.plotting import output_notebook, show"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "output_notebook()"
    ]
   },
   {
@@ -55,7 +67,7 @@
     "\n",
     "plt.title(\"Seaborn tsplot with CI in bokeh.\")\n",
     "\n",
-    "show(mpl.to_bokeh(notebook=True))"
+    "show(mpl.to_bokeh())"
    ]
   },
   {
@@ -79,7 +91,7 @@
     "\n",
     "plt.title(\"Seaborn kdeplot in bokeh.\")\n",
     "\n",
-    "show(mpl.to_bokeh(notebook=True))"
+    "show(mpl.to_bokeh())"
    ]
   },
   {
@@ -90,15 +102,15 @@
    },
    "outputs": [],
    "source": [
-    "# We generated random data\n",
-    "data = 1 + np.random.randn(20, 6)\n",
+    "planets = sns.load_dataset(\"planets\")\n",
     "\n",
-    "# And then just call the violinplot from Seaborn\n",
-    "sns.violinplot(data, color=\"Set3\")\n",
+    "ax = sns.violinplot(x=\"orbital_period\", y=\"method\",\n",
+    "                    data=planets[planets.orbital_period < 1000],\n",
+    "                    scale=\"width\", palette=\"Set3\")\n",
     "\n",
     "plt.title(\"Seaborn violin plot in bokeh.\")\n",
     "\n",
-    "show(mpl.to_bokeh(notebook=True))"
+    "show(mpl.to_bokeh())"
    ]
   },
   {
@@ -111,7 +123,25 @@
    "source": []
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/compat/seaborn/sinerror.py
+++ b/examples/compat/seaborn/sinerror.py
@@ -1,13 +1,13 @@
+import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
-import matplotlib.pyplot as plt
 from scipy import optimize
+
 from bokeh import mpl
-from bokeh.plotting import show
+from bokeh.plotting import output_file, show
 
 # Set the palette colors.
 sns.set(palette="Set2")
-
 
 # Build the sin wave
 def sine_wave(n_x, obs_err_sd=1.5, tp_err_sd=.3):
@@ -28,4 +28,6 @@ plt.plot(xx, np.sin(xx / b) + a, c="#444444")
 
 plt.title("Seaborn tsplot with CI in bokeh.")
 
-show(mpl.to_bokeh(name="sinerror"))
+output_file("sinerror.html")
+
+show(mpl.to_bokeh())

--- a/examples/compat/seaborn/stripplot.py
+++ b/examples/compat/seaborn/stripplot.py
@@ -1,7 +1,8 @@
 import pandas as pd
 import seaborn as sns
+
 from bokeh import mpl
-from bokeh.plotting import show
+from bokeh.plotting import output_file, show
 
 sns.set(style="whitegrid", palette="pastel")
 
@@ -15,5 +16,7 @@ iris = pd.melt(iris, "species", var_name="measurement")
 sns.stripplot(x="measurement", y="value", hue="species", data=iris,
               jitter=True, edgecolor="gray")
 
-show(mpl.to_bokeh(name="violin"))
+output_file("stripplot.html")
+
+show(mpl.to_bokeh())
 

--- a/examples/compat/seaborn/tsplot.py
+++ b/examples/compat/seaborn/tsplot.py
@@ -1,6 +1,7 @@
 import seaborn as sns
+
 from bokeh import mpl
-from bokeh.plotting import show
+from bokeh.plotting import output_file, show
 
 sns.set(style="darkgrid")
 
@@ -11,5 +12,7 @@ gammas = sns.load_dataset("gammas")
 sns.tsplot(data=gammas, time="timepoint", unit="subject",
            condition="ROI", value="BOLD signal")
 
-show(mpl.to_bokeh(name="violin"))
+output_file("tsplot.html")
+
+show(mpl.to_bokeh())
 

--- a/examples/compat/seaborn/violin.py
+++ b/examples/compat/seaborn/violin.py
@@ -1,8 +1,7 @@
 import seaborn as sns
-from bokeh import mpl
-from bokeh.plotting import show
 
-import numpy as np
+from bokeh import mpl
+from bokeh.plotting import output_file, show
 
 tips = sns.load_dataset("tips")
 
@@ -27,4 +26,6 @@ ax = sns.violinplot(x="day", y="total_bill", hue="sex",
 #                     data=planets[planets.orbital_period < 1000],
 #                     scale="width", palette="Set3")
 
-show(mpl.to_bokeh(name="violin"))
+output_file("violin.html")
+
+show(mpl.to_bokeh())


### PR DESCRIPTION
 This change removes all the code from to_bokeh dealing with output, since everything can be accomplished with the standard bokeh.io machinery.