### PR TITLE
Enable create/load/push doc from inside the server process

### DIFF
--- a/bokeh/server/start.py
+++ b/bokeh/server/start.py
@@ -24,7 +24,6 @@ def doc_prepare():
     register_blueprint()
     return app
 
-http_server = None
 def start_redis():
     work_dir = getattr(bokeh_app, 'work_dir', os.getcwd())
     data_file = getattr(bokeh_app, 'data_file', 'redis.db')
@@ -40,23 +39,22 @@ def start_redis():
                                 save=redis_save)
     bokeh_app.redis_proc = mproc
 
-server = None
+server_instance = None
 def make_tornado(config_file=None):
     configure_flask(config_file=config_file)
     register_blueprint()
     tornado_app = make_tornado_app(flask_app=app)
     return tornado_app
 
-def start_simple_server(args=None):
-    global server
-    configure_flask(config_argparse=args)
+def create_listening_server(https=None, https_certfile=None, https_keyfile=None):
+    """Create a server listening for connections, assumes configure_flask has been called"""
     if server_settings.model_backend.get('start-redis', False):
         start_redis()
     register_blueprint()
     tornado_app = make_tornado_app(flask_app=app)
-    if args is not None and args.https:
-        if args.https_certfile and args.https_keyfile:
-            server = HTTPServer(tornado_app, ssl_options={"certfile": args.https_certfile, "keyfile": args.https_keyfile})
+    if https:
+        if https_certfile and https_keyfile:
+            server = HTTPServer(tornado_app, ssl_options={"certfile": https_certfile, "keyfile": https_keyfile})
             log.info('HTTPS Enabled')
         else:
             server = HTTPServer(tornado_app)
@@ -64,9 +62,39 @@ def start_simple_server(args=None):
     else:
         server = HTTPServer(tornado_app)
     server.listen(server_settings.port, server_settings.ip)
+    return server
+
+def start_simple_server(args=None):
+    """Configure and start a server singleton"""
+    global server_instance
+
+    configure_flask(config_argparse=args)
+    if args is not None and args.https:
+        https = args.https
+        https_certfile = args.https_certfile
+        https_keyfile = args.https_keyfile
+    else:
+        https = None
+        https_certfile = None
+        https_keyfile = None
+    server_instance = create_listening_server(https=https, https_certfile=https_certfile, https_keyfile=https_keyfile)
+    start(server_instance)
+
+def start(server=None):
+    """Start server main loop"""
+    global server_instance
+
+    if server is None:
+        server = server_instance
     ioloop.IOLoop.instance().start()
 
-def stop():
+def stop(server=None):
+    """Shut down server main loop"""
+    global server_instance
+
+    if server is None:
+        server = server_instance
+
     if hasattr(bokeh_app, 'redis_proc'):
         bokeh_app.redis_proc.close()
     server.stop()

--- a/bokeh/server/views/main.py
+++ b/bokeh/server/views/main.py
@@ -191,14 +191,7 @@ def show_doc_by_title(title):
     docid = doc['docid']
     return render('show.html', title=title, docid=docid, splitjs=server_settings.splitjs)
 
-@bokeh_app.route('/bokeh/doc/', methods=['GET', 'OPTIONS'])
-@crossdomain(origin="*", headers=None)
-@login_required
-def doc_by_title():
-    if request.json:
-        title = request.json['title']
-    else:
-        title = request.values['title']
+def find_or_create_docid_by_title(title):
     bokehuser = bokeh_app.current_user()
     docs = [doc for doc in bokehuser.docs if doc['title'] == title]
     if len(docs) == 0:
@@ -212,8 +205,22 @@ def doc_by_title():
     else:
         doc = docs[0]
         docid = doc['docid']
-    return get_bokeh_info(docid)
+    return docid
 
+@bokeh_app.route('/bokeh/doc/', methods=['GET', 'OPTIONS'])
+@crossdomain(origin="*", headers=None)
+@login_required
+def doc_by_title():
+    if request.json:
+        title = request.json['title']
+    else:
+        title = request.values['title']
+
+    try:
+        docid = find_or_create_docid_by_title(title)
+        return get_bokeh_info(docid)
+    except DataIntegrityException as e:
+        return abort(409, e.message)
 
 @bokeh_app.route('/bokeh/sampleerror')
 def sampleerror():


### PR DESCRIPTION
This patch enables but does not include the "bokeh develop"
command. To see the code this enables look at https://github.com/bokeh/bokeh/blob/havocp/develop_mode/bokeh/command/server.py

Changes are:

 * http_server unused global var deleted
 * create_listening_server factored out of start_simple_server
   so a server can be created without entering the main loop
 * add a start() function to start the created server later
 * make backbone.init_bokeh work without a request
 * add push_data to push a new doc from inside server process
 * add find_or_create_docid_by_title to find/create an old doc
