### PR TITLE
Hotfix/fixed ticker

### DIFF
--- a/bokehjs/src/coffee/ticking/fixed_ticker.coffee
+++ b/bokehjs/src/coffee/ticking/fixed_ticker.coffee
@@ -1,3 +1,4 @@
+_ = require "underscore"
 AbstractTicker = require "./abstract_ticker"
 
 class FixedTicker extends AbstractTicker.Model

--- a/sphinx/source/docs/user_guide/source_examples/styling_fixed_ticker.py
+++ b/sphinx/source/docs/user_guide/source_examples/styling_fixed_ticker.py
@@ -1,4 +1,5 @@
 from bokeh.plotting import figure, output_file, show
+from bokeh.models import FixedTicker
 
 output_file("axes.html")
 


### PR DESCRIPTION
local testing in the notebook caused a missing underscore require to go undetected. 