### PR TITLE
webgl: use a global gl context (no more limit of 16 webgl plots)

### DIFF
--- a/bokehjs/src/coffee/common/plot.coffee
+++ b/bokehjs/src/coffee/common/plot.coffee
@@ -122,17 +122,17 @@ class PlotView extends ContinuumView
   
   init_webgl: () ->
 
-    # Get visible and invisible canvas 
-    # (doing it like this makes it easy to swap them during debugging)    
-    glcanvas = document.createElement('canvas')
-    
-    # Create GL context to draw to
+    # We use a global invisible canvas and gl context. By having a global context,
+    # we avoid the limitation of max 16 contexts that most browsers have. 
+    glcanvas = window._bokeh_gl_canvas
+    if not glcanvas?
+      window._bokeh_gl_canvas = glcanvas = document.createElement('canvas')
+      opts = {'premultipliedAlpha': true}  # premultipliedAlpha is true by default
+      glcanvas.gl = glcanvas.getContext("webgl", opts) || glcanvas.getContext("experimental-webgl", opts)
+
     # If WebGL is available, we store a reference to the gl canvas on
     # the ctx object, because that's what gets passed everywhere.
-    opts = {'premultipliedAlpha': true}  # premultipliedAlpha is true by default
-    gl = glcanvas.getContext("webgl", opts) || glcanvas.getContext("experimental-webgl", opts)
-    if gl?
-      glcanvas.gl = gl
+    if glcanvas.gl?
       @canvas_view.ctx.glcanvas = glcanvas
     else
       @canvas_view.ctx.glcanvas = false  # disable webgl

--- a/bokehjs/src/coffee/common/plot.coffee
+++ b/bokehjs/src/coffee/common/plot.coffee
@@ -330,7 +330,7 @@ class PlotView extends ContinuumView
       ctx.drawImage(ctx.glcanvas, 0.1, 0.1)
       for prefix in ['image', 'mozImage', 'webkitImage','msImage']
          ctx[prefix + 'SmoothingEnabled'] = true
-      #console.log('drawing with WebGL')
+      logger.debug('drawing with WebGL')
 
     @_render_levels(ctx, ['overlay', 'tool'])
 

--- a/bokehjs/src/coffee/common/plot.coffee
+++ b/bokehjs/src/coffee/common/plot.coffee
@@ -32,6 +32,8 @@ properties = require "./properties"
 # The presence (and not-being-false) of the ctx.glcanvas attribute is the
 # marker that we use throughout that determines whether we have gl support. 
 
+global_gl_canvas = null
+
 
 class PlotView extends ContinuumView
   className: "bk-plot"
@@ -124,9 +126,9 @@ class PlotView extends ContinuumView
 
     # We use a global invisible canvas and gl context. By having a global context,
     # we avoid the limitation of max 16 contexts that most browsers have. 
-    glcanvas = window._bokeh_gl_canvas
+    glcanvas = global_gl_canvas
     if not glcanvas?
-      window._bokeh_gl_canvas = glcanvas = document.createElement('canvas')
+      global_gl_canvas = glcanvas = document.createElement('canvas')
       opts = {'premultipliedAlpha': true}  # premultipliedAlpha is true by default
       glcanvas.gl = glcanvas.getContext("webgl", opts) || glcanvas.getContext("experimental-webgl", opts)
 
@@ -328,7 +330,7 @@ class PlotView extends ContinuumView
       ctx.drawImage(ctx.glcanvas, 0.1, 0.1)
       for prefix in ['image', 'mozImage', 'webkitImage','msImage']
          ctx[prefix + 'SmoothingEnabled'] = true
-      console.log('drawing with WebGL')
+      #console.log('drawing with WebGL')
 
     @_render_levels(ctx, ['overlay', 'tool'])
 

--- a/sphinx/source/docs/user_guide/webgl.rst
+++ b/sphinx/source/docs/user_guide/webgl.rst
@@ -49,10 +49,6 @@ Notes
   rendering.
 * Making a selections of markers on Internet Explorer will reduce the size
   of the markers to 1 pixel (looks like a bug in IE).
-* Typical browsers restrict the number of GL contexts to 16. When there
-  are many plots on one page, some are likely to produce wrong visual
-  output.
-
 
 Example
 -------


### PR DESCRIPTION
issues: #2590 

All plots in one page share the same gl context. 