### PR TITLE
Adding utility functions to convert image to rgba image

### DIFF
--- a/bokeh/util/image.py
+++ b/bokeh/util/image.py
@@ -1,0 +1,42 @@
+""" Functions useful for image manipulations
+"""
+
+import numpy as np
+
+
+def convert_rgb_to_bokehrbga(img):
+    """
+    convert RGB image to two-dimensional array of RGBA values (encoded as 32-bit integers)
+
+    Bokeh require rbga
+    :param img: (N,M, 3) array (dtype = uint8)
+    :return: (K, R, dtype=uint32) array
+    """
+    if img.dtype != np.uint8:
+        raise NotImplementedError
+
+    if img.ndim != 3:
+        raise NotImplementedError
+
+    bokeh_img = np.dstack([img, 255 * np.ones(img.shape[:2], np.uint8)])
+    final_rgba_image = np.squeeze(bokeh_img.view(dtype=np.uint32))
+    return final_rgba_image
+
+
+def convert_gray_to_bokehrbga(img):
+    """
+    convert grayscale image to two-dimensional array of RGBA values (encoded as 32-bit integers)
+
+    :param img: (N,M) array (dtype = uint8)
+    :return: (K, R, dtype=uint32) array
+    """
+    if img.dtype != np.uint8:
+        raise NotImplementedError
+
+    if img.ndim != 2:
+        raise NotImplementedError
+
+    bokeh_img = np.expand_dims(img, img.ndim)
+    bokeh_img = np.concatenate([bokeh_img]*3, axis=-1)
+    return convert_rgb_to_bokehrbga(bokeh_img)
+

--- a/bokeh/util/image.py
+++ b/bokeh/util/image.py
@@ -10,7 +10,7 @@ def convert_rgb_to_bokehrbga(img):
 
     Bokeh require rbga
     :param img: (N,M, 3) array (dtype = uint8)
-    :return: (K, R, dtype=uint32) array
+    :return: (N, M, dtype=uint32) array
     """
     if img.dtype != np.uint8:
         raise NotImplementedError
@@ -28,7 +28,7 @@ def convert_gray_to_bokehrbga(img):
     convert grayscale image to two-dimensional array of RGBA values (encoded as 32-bit integers)
 
     :param img: (N,M) array (dtype = uint8)
-    :return: (K, R, dtype=uint32) array
+    :return: (N, M, dtype=uint32) array
     """
     if img.dtype != np.uint8:
         raise NotImplementedError

--- a/bokeh/util/tests/test_image.py
+++ b/bokeh/util/tests/test_image.py
@@ -1,0 +1,48 @@
+from __future__ import absolute_import
+
+import unittest
+import numpy as np
+
+from bokeh.util.image import convert_gray_to_bokehrbga, convert_rgb_to_bokehrbga
+
+class TestConvertRgbToBokehRgba(unittest.TestCase):
+    def test_basic(self):
+        img = np.ones((10, 100, 3), dtype=np.uint8)
+        img_converted = convert_rgb_to_bokehrbga(img)
+
+        assert(img_converted.dtype == np.uint32)
+        assert(img_converted.shape == (10, 100))
+        view = img_converted.view(dtype=np.uint8).reshape((10, 100, 4))
+
+        assert(np.all(view[:, :, 3] == 255))  # no alpha
+
+        assert(np.all(view[:, :, 0] == img[:, :, 0])) # same red
+        assert(np.all(view[:, :, 1] == img[:, :, 1])) # same green
+        assert(np.all(view[:, :, 2] == img[:, :, 2])) # same blue
+
+class TestConvertRgbToBokehRgba(unittest.TestCase):
+    def test_basic(self):
+        img = np.ones((10, 100), dtype=np.uint8)
+
+        img[0, 0] = 255
+        img[-1, -1] = 0
+
+        img_converted = convert_gray_to_bokehrbga(img)
+
+        assert(img_converted.dtype == np.uint32)
+        assert(img_converted.shape == (10, 100))
+
+        view = img_converted.view(dtype=np.uint8).reshape((10, 100, 4))
+        assert(np.all(view[:, :, 3] == 255))  # no alpha
+
+        assert(view[0, 0, 0] == 255)
+        assert(view[0, 0, 1] == 255)
+        assert(view[0, 0, 2] == 255)
+
+        assert(view[-1, -1, 0] == 0)
+        assert(view[-1, -1, 1] == 0)
+        assert(view[-1, -1, 2] == 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/plotting/file/image_rgba_bis.py
+++ b/examples/plotting/file/image_rgba_bis.py
@@ -1,0 +1,29 @@
+import numpy as np
+import requests
+import shutil
+import pylab
+
+from bokeh.plotting import figure, show, output_file
+import bokeh.util.image
+
+# downloading image
+url_lena_gray = 'http://www.ece.rice.edu/~wakin/images/lena512.bmp'
+response = requests.get(url_lena_gray, stream=True)
+with open('lena_gray.bmp', 'wb') as f:
+    shutil.copyfileobj(response.raw, f)
+del response
+
+img_ = pylab.imread('lena_gray.bmp')
+img = bokeh.util.image.convert_gray_to_bokehrbga(img_)
+
+output_file("image_rgba_bis.html", title="image.py example")
+
+p = figure(x_range=[0, 10], y_range=[0, 10])
+
+p.image_rgba(image=[img], x=[0], y=[0], dw=[10], dh=[10])  # image is upside down, it's similar to pylab.imshow(img_, origin='top')
+# TODO : image_rgba doesn't support origin keyword for now
+show(p)
+
+#p2.image(image=[img], x=[0], y=[0], dw=[10], dh=[10], palette="Spectral11")
+
+

--- a/tests/travis/test.yaml
+++ b/tests/travis/test.yaml
@@ -6,7 +6,7 @@
 - path: "charts"
 - path: "plotting/file"
   type: file
-  skip: ["image.py", "image_rgba.py", "ajax_source.py", "choropleth.py"]
+  skip: ["image.py", "image_rgba.py", "image_rgba_bis.py", "ajax_source.py", "choropleth.py"]
 - path: "plotting/server"
   type: server
   skip: ["image.py", "image_rgba.py", "remote_image.py", "serversource.py", "server_source_upload.py", "embedding_example.py", "abstractrender.py", "census.py"]


### PR DESCRIPTION
Bokeh require image to be a two-dimensional array of RGBA values (encoded as 32-bit integers), but usualy user have image in RGB format, or in grayscale format.

related bug: https://github.com/bokeh/bokeh/issues/1699