### PR TITLE
Add a warning for : in categorical strings

### DIFF
--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -271,7 +271,7 @@ class Plot(Widget):
 
         for range_name in ['x_range', 'y_range']:
             category_range = getattr(self, range_name)
-            if not isinstance(category_range, FactorRange): break
+            if not isinstance(category_range, FactorRange): continue
 
             for value in category_range.factors:
                 if not isinstance(value, string_types): break

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -11,7 +11,8 @@ from ..plot_object import PlotObject
 from ..properties import Bool, Int, String, Color, Enum, Auto, Instance, Either, List, Dict, Include
 from ..query import find
 from ..util.string import nice_join
-from ..validation.warnings import MISSING_RENDERERS, NO_GLYPH_RENDERERS, EMPTY_LAYOUT, COLON_IN_CATEGORY_LABEL
+from ..validation.warnings import (MISSING_RENDERERS, NO_GLYPH_RENDERERS,
+    EMPTY_LAYOUT, MALFORMED_CATEGORY_LABEL)
 from ..validation.errors import REQUIRED_RANGE
 from .. import validation
 
@@ -262,7 +263,7 @@ class Plot(Widget):
         if len(self.select(GlyphRenderer)) == 0:
             return str(self)
 
-    @validation.warning(COLON_IN_CATEGORY_LABEL)
+    @validation.warning(MALFORMED_CATEGORY_LABEL)
     def _check_colon_in_category_label(self):
         if not self.x_range: return
         if not self.y_range: return

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -11,12 +11,12 @@ from ..plot_object import PlotObject
 from ..properties import Bool, Int, String, Color, Enum, Auto, Instance, Either, List, Dict, Include
 from ..query import find
 from ..util.string import nice_join
-from ..validation.warnings import MISSING_RENDERERS, NO_GLYPH_RENDERERS, EMPTY_LAYOUT
+from ..validation.warnings import MISSING_RENDERERS, NO_GLYPH_RENDERERS, EMPTY_LAYOUT, COLON_IN_CATEGORY_LABEL
 from ..validation.errors import REQUIRED_RANGE
 from .. import validation
 
 from .glyphs import Glyph
-from .ranges import Range, Range1d
+from .ranges import Range, Range1d, FactorRange
 from .renderers import Renderer, GlyphRenderer
 from .sources import DataSource, ColumnDataSource
 from .tools import Tool, ToolEvents
@@ -261,6 +261,28 @@ class Plot(Widget):
     def _check_no_glyph_renderers(self):
         if len(self.select(GlyphRenderer)) == 0:
             return str(self)
+
+    @validation.warning(COLON_IN_CATEGORY_LABEL)
+    def _check_colon_in_category_label(self):
+        if not self.x_range: return
+        if not self.y_range: return
+
+        broken = []
+
+        for range_name in ['x_range', 'y_range']:
+            category_range = getattr(self, range_name)
+            if not isinstance(category_range, FactorRange): break
+
+            for value in category_range.factors:
+                if not isinstance(value, string_types): break
+                if ':' in value:
+                    broken.append((range_name, value))
+                    break
+
+        if broken:
+            field_msg = ' '.join('[range:%s] [first_value: %s]' % (field, value)
+                                 for field, value in broken)
+            return '%s [renderer: %s]' % (field_msg, self)
 
     x_range = Instance(Range, help="""
     The (default) data range of the horizontal dimension of the plot.

--- a/bokeh/models/renderers.py
+++ b/bokeh/models/renderers.py
@@ -11,7 +11,7 @@ from ..properties import Int, String, Enum, Instance, List, Dict, Tuple, Include
 from ..mixins import LineProps, TextProps
 from ..enums import Units, Orientation, RenderLevel
 from ..validation.errors import BAD_COLUMN_NAME, MISSING_GLYPH, NO_SOURCE_FOR_GLYPH
-from ..validation.warnings import COLON_IN_CATEGORY_LABEL
+from ..validation.warnings import MALFORMED_CATEGORY_LABEL
 from .. import validation
 
 from .sources import DataSource
@@ -48,7 +48,7 @@ class GlyphRenderer(Renderer):
         if missing:
             return "%s [renderer: %s]" % (", ".join(sorted(missing)), self)
 
-    @validation.warning(COLON_IN_CATEGORY_LABEL)
+    @validation.warning(MALFORMED_CATEGORY_LABEL)
     def _check_colon_in_category_label(self):
         if not self.glyph: return
         if not self.data_source: return

--- a/bokeh/models/renderers.py
+++ b/bokeh/models/renderers.py
@@ -50,25 +50,22 @@ class GlyphRenderer(Renderer):
     def _check_colon_in_category_label(self):
         if not self.glyph: return
         if not self.data_source: return
+        vm = self.glyph.vm_serialize()
+        labels = (label for label in ['x', 'y']
+                  if label in vm and 'field' in vm[label])
 
-        label_list = ['x', 'y']
-        vm_dict = self.glyph.vm_serialize()
-        broken_list = []
+        broken = []
 
-        for label in label_list:
-            if label in vm_dict:
-                for value in self.data_source.data[vm_dict[label]['field']]:
-                    if ':' in value:
-                        broken_list.append((vm_dict[label]['field'], value))
-                        break
+        for label in labels:
+            for value in self.data_source.data[vm[label]['field']]:
+                if ':' in value:
+                    broken.append((vm[label]['field'], value))
+                    break
 
-        if broken_list:
-            field_tpl = '[label:%s] [first_value: %s]'
-            msg_tpl = '%xs [renderer: %s]'
-            field_msg = ' '.join(field_tpl % (label, value) for label, value in broken_list)
-            return msg_tpl % (field_msg, self)
-        else:
-            return
+        if broken:
+            field_msg = ' '.join('[field:%s] [first_value: %s]' % (field, value)
+                                 for field, value in broken)
+            return '%s [renderer: %s]' % (field_msg, self)
 
     data_source = Instance(DataSource, help="""
     Local data source to use when rendering glyphs on the plot.

--- a/bokeh/models/renderers.py
+++ b/bokeh/models/renderers.py
@@ -4,7 +4,7 @@ types that Bokeh supports.
 """
 from __future__ import absolute_import
 
-import six
+from six import string_types
 
 from ..plot_object import PlotObject
 from ..properties import Int, String, Enum, Instance, List, Dict, Tuple, Include
@@ -60,7 +60,7 @@ class GlyphRenderer(Renderer):
 
         for label in labels:
             for value in self.data_source.data[vm[label]['field']]:
-                if not isinstance(value, six.string_types): break
+                if not isinstance(value, string_types): break
                 if ':' in value:
                     broken.append((vm[label]['field'], value))
                     break

--- a/bokeh/models/renderers.py
+++ b/bokeh/models/renderers.py
@@ -4,6 +4,8 @@ types that Bokeh supports.
 """
 from __future__ import absolute_import
 
+import logging
+
 from six import string_types
 
 from ..plot_object import PlotObject
@@ -16,6 +18,9 @@ from .. import validation
 
 from .sources import DataSource
 from .glyphs import Glyph
+
+logger = logging.getLogger(__name__)
+
 
 class Renderer(PlotObject):
     """ A base class for renderer types. ``Renderer`` is not
@@ -59,11 +64,17 @@ class GlyphRenderer(Renderer):
         broken = []
 
         for label in labels:
-            for value in self.data_source.data[vm[label]['field']]:
-                if not isinstance(value, string_types): break
-                if ':' in value:
-                    broken.append((vm[label]['field'], value))
-                    break
+            try:
+                for value in self.data_source.data[vm[label]['field']]:
+                    if not isinstance(value, string_types): break
+                    if ':' in value:
+                        broken.append((vm[label]['field'], value))
+                        break
+            except KeyError:
+                logging.info(
+                    'Can\'t check category labels for %s data source',
+                    self.data_source
+                )
 
         if broken:
             field_msg = ' '.join('[field:%s] [first_value: %s]' % (field, value)

--- a/bokeh/models/renderers.py
+++ b/bokeh/models/renderers.py
@@ -4,6 +4,8 @@ types that Bokeh supports.
 """
 from __future__ import absolute_import
 
+import six
+
 from ..plot_object import PlotObject
 from ..properties import Int, String, Enum, Instance, List, Dict, Tuple, Include
 from ..mixins import LineProps, TextProps
@@ -58,6 +60,7 @@ class GlyphRenderer(Renderer):
 
         for label in labels:
             for value in self.data_source.data[vm[label]['field']]:
+                if not isinstance(value, six.string_types): break
                 if ':' in value:
                     broken.append((vm[label]['field'], value))
                     break

--- a/bokeh/models/tests/test_renderers.py
+++ b/bokeh/models/tests/test_renderers.py
@@ -4,13 +4,15 @@ import unittest
 
 from bokeh.models.renderers import GlyphRenderer
 from bokeh.plotting import ColumnDataSource, figure
+from bokeh.models.ranges import DataRange1d
 
 
 class TestGlyphRenderer(unittest.TestCase):
     def test_warning_about_colons_in_column_labels(self):
-        sh = ['0', '1:0']
+        invalid_labels = ['0', '1:0']
+        ds = ColumnDataSource(data={'a': invalid_labels, 'b': invalid_labels})
         plot = figure()
-        plot.rect('a', 'b', 1, 1, source=ColumnDataSource(data={'a': sh, 'b': sh}))
+        plot.rect('a', 'b', 1, 1, source=ds)
         renderer = plot.select({'type': GlyphRenderer})[0]
 
         errors = renderer._check_colon_in_category_label()
@@ -45,6 +47,27 @@ class TestGlyphRenderer(unittest.TestCase):
             '[renderer: Figure, ViewModel:Plot, ref _id: '
             '%s]' % plot._id
         )])
+
+    def test_validates_colons_only_in_factorial_range(self):
+        plot = figure(
+            x_range=DataRange1d(start=0.0, end=2.2),
+            y_range=['0', '1', '2:0'],
+            plot_width=900,
+            plot_height=400,
+        )
+
+        errors = plot._check_colon_in_category_label()
+
+        self.assertEqual(errors, [(
+            1003,
+            'COLON_IN_CATEGORY_LABEL',
+            'Category label contains colons',
+            '[range:y_range] [first_value: 2:0] '
+            '[renderer: Figure, ViewModel:Plot, ref _id: '
+            '%s]' % plot._id
+        )])
+
+
 
 
 if __name__ == '__main__':

--- a/bokeh/models/tests/test_renderers.py
+++ b/bokeh/models/tests/test_renderers.py
@@ -12,9 +12,9 @@ from bokeh.validation import check_integrity
 class TestGlyphRenderer(unittest.TestCase):
     def test_warning_about_colons_in_column_labels(self):
         sh = ['0', '1:0']
-        p = figure()
-        p.rect('a', 'b', 1, 1, source=ColumnDataSource(data={'a': sh, 'b': sh}))
-        renderer = p.renderers[-1]
+        plot = figure()
+        plot.rect('a', 'b', 1, 1, source=ColumnDataSource(data={'a': sh, 'b': sh}))
+        renderer = plot.select({'type': GlyphRenderer})[0]
 
         errors = renderer._check_colon_in_category_label()
 

--- a/bokeh/models/tests/test_renderers.py
+++ b/bokeh/models/tests/test_renderers.py
@@ -2,11 +2,8 @@ from __future__ import absolute_import
 
 import unittest
 
-from mock import patch
-
 from bokeh.models.renderers import GlyphRenderer
 from bokeh.plotting import ColumnDataSource, figure
-from bokeh.validation import check_integrity
 
 
 class TestGlyphRenderer(unittest.TestCase):
@@ -26,6 +23,27 @@ class TestGlyphRenderer(unittest.TestCase):
             '[renderer: '
             'GlyphRenderer, ViewModel:GlyphRenderer, ref _id: '
             '%s]' % renderer._id
+        )])
+
+    def test_warning_about_colons_in_column_labels_for_axis(self):
+        invalid_labels = ['0', '1', '2:0'] 
+        plot = figure(
+            x_range=invalid_labels,
+            y_range=invalid_labels,
+            plot_width=900,
+            plot_height=400,
+        )
+
+        errors = plot._check_colon_in_category_label()
+
+        self.assertEqual(errors, [(
+            1003,
+            'COLON_IN_CATEGORY_LABEL',
+            'Category label contains colons',
+            '[range:x_range] [first_value: 2:0] '
+            '[range:y_range] [first_value: 2:0] '
+            '[renderer: Figure, ViewModel:Plot, ref _id: '
+            '%s]' % plot._id
         )])
 
 

--- a/bokeh/models/tests/test_renderers.py
+++ b/bokeh/models/tests/test_renderers.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import
+
+import unittest
+
+from mock import patch
+
+from bokeh.models.renderers import GlyphRenderer
+from bokeh.plotting import ColumnDataSource, figure
+from bokeh.validation import check_integrity
+
+
+class TestGlyphRenderer(unittest.TestCase):
+    def test_warning_about_colons_in_column_labels(self):
+        sh = ['0', '1:0']
+        p = figure()
+        p.rect('a', 'b', 1, 1, source=ColumnDataSource(data={'a': sh, 'b': sh}))
+        renderer = p.renderers[-1]
+
+        errors = renderer._check_colon_in_category_label()
+
+        self.assertEqual(errors, [(
+            1003,
+            'COLON_IN_CATEGORY_LABEL',
+            'Category label contains colons',
+            '[field:a] [first_value: 1:0] [field:b] [first_value: 1:0] '
+            '[renderer: '
+            'GlyphRenderer, ViewModel:GlyphRenderer, ref _id: '
+            '%s]' % renderer._id
+        )])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bokeh/models/tests/test_renderers.py
+++ b/bokeh/models/tests/test_renderers.py
@@ -19,8 +19,8 @@ class TestGlyphRenderer(unittest.TestCase):
 
         self.assertEqual(errors, [(
             1003,
-            'COLON_IN_CATEGORY_LABEL',
-            'Category label contains colons',
+            'MALFORMED_CATEGORY_LABEL',
+            'Category labels are malformed',
             '[field:a] [first_value: 1:0] [field:b] [first_value: 1:0] '
             '[renderer: '
             'GlyphRenderer, ViewModel:GlyphRenderer, ref _id: '
@@ -40,8 +40,8 @@ class TestGlyphRenderer(unittest.TestCase):
 
         self.assertEqual(errors, [(
             1003,
-            'COLON_IN_CATEGORY_LABEL',
-            'Category label contains colons',
+            'MALFORMED_CATEGORY_LABEL',
+            'Category labels are malformed',
             '[range:x_range] [first_value: 2:0] '
             '[range:y_range] [first_value: 2:0] '
             '[renderer: Figure, ViewModel:Plot, ref _id: '
@@ -60,8 +60,8 @@ class TestGlyphRenderer(unittest.TestCase):
 
         self.assertEqual(errors, [(
             1003,
-            'COLON_IN_CATEGORY_LABEL',
-            'Category label contains colons',
+            'MALFORMED_CATEGORY_LABEL',
+            'Category labels are malformed',
             '[range:y_range] [first_value: 2:0] '
             '[renderer: Figure, ViewModel:Plot, ref _id: '
             '%s]' % plot._id

--- a/bokeh/validation/warnings.py
+++ b/bokeh/validation/warnings.py
@@ -9,17 +9,20 @@
 1002 : *EMPTY_LAYOUT*
     A layout model has no children (will result in a blank layout).
 
+1003 : *COLON_IN_CATEGORY_LABEL*
+    Category label contains colons (will result in a blank layout).
+
 9999 : *EXT*
     Indicates that a custom warning check has failed.
 
 '''
 
 codes = {
-    1000: ("MISSING_RENDERERS",     "Plot has no renderers"),
-    1001: ("NO_GLYPH_RENDERERS",    "Plot has no glyph renderers"),
-    1002: ("EMPTY_LAYOUT",          "Layout has no children"),
-    1003: ("COLON_IN_CATEGORY_LABEL",        "Category label contains colons"),
-    9999: ("EXT",                   "Custom extension reports warning"),
+    1000: ("MISSING_RENDERERS",         "Plot has no renderers"),
+    1001: ("NO_GLYPH_RENDERERS",        "Plot has no glyph renderers"),
+    1002: ("EMPTY_LAYOUT",              "Layout has no children"),
+    1003: ("COLON_IN_CATEGORY_LABEL",   "Category label contains colons"),
+    9999: ("EXT",                       "Custom extension reports warning"),
 }
 
 for code in codes:

--- a/bokeh/validation/warnings.py
+++ b/bokeh/validation/warnings.py
@@ -9,8 +9,8 @@
 1002 : *EMPTY_LAYOUT*
     A layout model has no children (will result in a blank layout).
 
-1003 : *COLON_IN_CATEGORY_LABEL*
-    Category label contains colons (will result in a blank layout).
+1003 : *MALFORMED_CATEGORY_LABEL*
+    Category labels are malformed (will result in a blank layout).
 
 9999 : *EXT*
     Indicates that a custom warning check has failed.

--- a/bokeh/validation/warnings.py
+++ b/bokeh/validation/warnings.py
@@ -21,7 +21,7 @@ codes = {
     1000: ("MISSING_RENDERERS",         "Plot has no renderers"),
     1001: ("NO_GLYPH_RENDERERS",        "Plot has no glyph renderers"),
     1002: ("EMPTY_LAYOUT",              "Layout has no children"),
-    1003: ("COLON_IN_CATEGORY_LABEL",   "Category label contains colons"),
+    1003: ("MALFORMED_CATEGORY_LABEL",  "Category labels are malformed"),
     9999: ("EXT",                       "Custom extension reports warning"),
 }
 

--- a/bokeh/validation/warnings.py
+++ b/bokeh/validation/warnings.py
@@ -18,6 +18,7 @@ codes = {
     1000: ("MISSING_RENDERERS",     "Plot has no renderers"),
     1001: ("NO_GLYPH_RENDERERS",    "Plot has no glyph renderers"),
     1002: ("EMPTY_LAYOUT",          "Layout has no children"),
+    1003: ("COLON_IN_CATEGORY_LABEL",        "Category label contains colons"),
     9999: ("EXT",                   "Custom extension reports warning"),
 }
 


### PR DESCRIPTION
Show warning when category labels contains `:`. See #516 for details.

Warning message contains field name in data source and first broken value.

```
ERROR:/home/abele/Devel/bokeh/bokeh/validation/check.py:W-1003 (COLON_IN_CATEGORY_LABEL): Category label contains colons: [field:a] [first_value: 1:0] [field:b] [first_value: 1:0] [renderer: GlyphRenderer, ViewModel:GlyphRenderer, ref _id: b6d6665e-70b1-4255-a9c5-baddca45e419]
```

Resolves #2614 