### PR TITLE
Add background fill properties for legend

### DIFF
--- a/bokeh/models/renderers.py
+++ b/bokeh/models/renderers.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 
 from ..plot_object import PlotObject
 from ..properties import Int, String, Enum, Instance, List, Dict, Tuple, Include
-from ..mixins import LineProps, TextProps
+from ..mixins import LineProps, TextProps, FillProps
 from ..enums import Units, Orientation, RenderLevel
 from ..validation.errors import BAD_COLUMN_NAME, MISSING_GLYPH, NO_SOURCE_FOR_GLYPH
 from .. import validation
@@ -99,6 +99,10 @@ class Legend(Renderer):
 
     border_props = Include(LineProps, help="""
     The %s for the legend border outline.
+    """)
+
+    background_props = Include(FillProps, help="""
+    The %s for the legend background style.
     """)
 
     label_props = Include(TextProps, help="""

--- a/bokehjs/src/coffee/renderer/annotation/legend.coffee
+++ b/bokehjs/src/coffee/renderer/annotation/legend.coffee
@@ -28,6 +28,7 @@ class LegendView extends PlotWidget
     super(options)
     @label_props = new properties.Text({obj:@model, prefix: 'label_'})
     @border_props = new properties.Line({obj: @model, prefix: 'border_'})
+    @background_props = new properties.Fill({obj: @model, prefix: 'background_'})
     @need_calc_dims = true
     @listenTo(@plot_model.solver, 'layout_update', () -> @need_calc_dims = true)
 
@@ -83,13 +84,15 @@ class LegendView extends PlotWidget
     ctx = @plot_view.canvas_view.ctx
     ctx.save()
 
-    ctx.fillStyle = @plot_model.get('background_fill')
-    @border_props.set_value(ctx)
     ctx.beginPath()
     ctx.rect(@box_coords[0], @box_coords[1],
       @legend_width, @legend_height
     )
+    # Populate background fill properties (fill_color/fill_alpha) for legend,
+    # defaulting to opaque white
+    @background_props.set_value(ctx)
     ctx.fill()
+    @border_props.set_value(ctx)
     ctx.stroke()
     legend_spacing = @mget('legend_spacing')
     for [legend_name, glyphs], idx in @mget("legends")
@@ -129,6 +132,9 @@ class Legend extends HasParent
       border_line_cap: 'butt'
       border_line_dash: []
       border_line_dash_offset: 0
+
+      background_fill_color: '#fff'
+      background_fill_alpha: 1.0
 
       label_standoff: 15
       label_text_font: "helvetica"

--- a/sphinx/source/docs/user_guide/source_examples/styling_legend_background.py
+++ b/sphinx/source/docs/user_guide/source_examples/styling_legend_background.py
@@ -4,7 +4,7 @@ from bokeh.plotting import output_file, figure, show
 x = np.linspace(0, 4*np.pi, 100)
 y = np.sin(x)
 
-output_file("legend_border.html")
+output_file("legend_background.html")
 
 p = figure()
 
@@ -17,8 +17,10 @@ p.line(x, 2*y, legend="2*sin(x)",
 p.square(x, 3*y, legend="3*sin(x)", fill_color=None, line_color="green")
 p.line(x, 3*y, legend="3*sin(x)", line_color="green")
 
-p.legend.border_line_width = 3
-p.legend.border_line_color = "navy"
-p.legend.border_line_alpha = 0.5
+#  3*sin(x) curve should be under this legend at initial viewing, so
+# we can see that the legend is transparent
+p.legend.orientation = "bottom_right"
+p.legend.background_fill_color = "navy"
+p.legend.background_fill_alpha = 0.5
 
 show(p)

--- a/sphinx/source/docs/user_guide/styling.rst
+++ b/sphinx/source/docs/user_guide/styling.rst
@@ -574,7 +574,7 @@ The default location is ``"top_right"``.
 Label Text
 ~~~~~~~~~~
 
-The visual appearance of the legend labels is controlled by  a collection of
+The visual appearance of the legend labels is controlled by a collection of
 `Text Properties`_, prefixed with ``label_``. For instance, to set the font
 style of the labels, use ``label_text_font_style``.
 
@@ -584,12 +584,23 @@ style of the labels, use ``label_text_font_style``.
 Border
 ~~~~~~
 
-The visual appearance of the legend border is controlled by  a collection of
+The visual appearance of the legend border is controlled by a collection of
 `Line Properties`_, prefixed with ``border_``. For instance, to set the color
 of the border, use ``border_line_color``. To make the border invisible, set
 the border line color to ``None``.
 
 .. bokeh-plot:: source/docs/user_guide/source_examples/styling_legend_border.py
+    :source-position: above
+
+Background
+~~~~~~~~~~
+
+The visual appearance of the legend background is controlled by a collection
+of `Fill Properties`_, prefixed with ``background_``. For instance, to set the
+color of the background, use ``background_fill_color``. To make the background
+transparent, set the ``background_fill_alpha`` to ``0``.
+
+.. bokeh-plot:: source/docs/user_guide/source_examples/styling_legend_background.py
     :source-position: above
 
 Dimensions


### PR DESCRIPTION
Since there's no option right now (according to docs) for moving legend outside of a plot, I think it makes sense to document how to set the legend's background transparency. If this commit is ok I'll update the docs too. Commit message:

Enable legend properties background_fill_color and background_fill_alpha to set the canvas fill property instead of inheriting the plot background color and legend.border_line_alpha, respectively.

I don't know if it was intended that border_line_alpha was to also be used as the legend fill alpha but it
doesn't seem to be documented anywhere. This change might be slightly backwards incompatible as far as legend styles go, maybe it should inherit the old properties if not set? Or maybe it should inherit a 0.0 alpha if not set?

