### PR TITLE
Add channels to "extra" section in meta.yaml

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -5,6 +5,11 @@ package:
 build:
   number: {{ environ.get('BINSTAR_BUILD', 1) }}
 
+extra:
+  channels:
+    - bokeh
+    - javascript
+
 requirements:
   build:
     - python


### PR DESCRIPTION
This isn't used directly by conda, but at least let reader know in the metadata that we use extra channels. This information could be later used programatically, e.g. by conda-env. Yeah, I'm working on conda-env accepting `meta.yaml` as well, which isn't that straightforward unfortunately. Note that this requires most recent conda-build, so update your root environment.