### PR TITLE
Link updates with tab widget's active attribute

### DIFF
--- a/bokeh/models/widgets/panels.py
+++ b/bokeh/models/widgets/panels.py
@@ -38,3 +38,14 @@ class Tabs(Widget):
     The index of the active tab.
     """)
 
+    def on_click(self, handler):
+        """ Set up a handler for tab link clicks.
+
+        Args:
+            handler (func) : handler function to call when button is activated.
+
+        Returns:
+            None
+
+        """
+        self.on_change('active', lambda obj, attr, old, new: handler(new))

--- a/bokehjs/src/coffee/widget/tabs.coffee
+++ b/bokehjs/src/coffee/widget/tabs.coffee
@@ -10,11 +10,14 @@ HasProperties = require "../common/has_properties"
 tabs_template = require "./tabs_template"
 
 class TabsView extends ContinuumView
+  events:
+    "change input": "change_input"
 
   initialize: (options) ->
     super(options)
     @views = {}
     @render()
+    @listenTo(@model, 'change', @render)
 
   render: () ->
     for own key, val of @views
@@ -32,9 +35,12 @@ class TabsView extends ContinuumView
       active: (i) -> if i == active then 'bk-bs-active' else ''
     }))
 
+    that = this  # To keep reference to TabsView
     html.find("> li > a").click (event) ->
       event.preventDefault()
       $(this).tab('show')
+      # Update active index
+      that.change_input($(this).data('index'))
 
     $panels = html.children(".bk-bs-tab-pane")
 
@@ -44,6 +50,11 @@ class TabsView extends ContinuumView
     @$el.append(html)
     @$el.tabs
     return @
+
+  change_input: (active) ->
+    @mset('active', active)
+    @model.save()
+    @mget('callback')?.execute(@model)
 
 class Tabs extends HasProperties
   type: "Tabs"

--- a/bokehjs/src/coffee/widget/tabs_template.eco
+++ b/bokehjs/src/coffee/widget/tabs_template.eco
@@ -1,7 +1,7 @@
 <ul class="bk-bs-nav bk-bs-nav-tabs">
   <% for tab, i in @tabs: %>
     <li class="<%= @active(i) %>">
-      <a href="#tab-<%= tab.get('id') %>"><%= tab.get('title') %></a>
+      <a data-index="<%= i %>" href="#tab-<%= tab.get('id') %>"><%= tab.get('title') %></a>
     </li>
   <% end %>
 </ul>


### PR DESCRIPTION
Add support for interaction with tab's active attribute, credit to @mistakevin's [commit for idea](https://github.com/bokeh/bokeh/commit/dc40d3f0dad5d51f121d62d60abacaa7921bb15a). To be honest I don't really know what some of the changes I made in tabs.coffee actually do, other than that it seems to work and resolves the example in #2455 and my own tab widget use cases. Let me know if this should be documented / tested / etc somewhere. Commit message:

Closes #2455

When a Tabs widget's active attribute is updated, the corresponding
html should be re-rendered. Conversely, when a tab link is clicked,
the active attribute of the python widget object should be updated.

Previously, the only way I could find to update tabs was to create
a new Tabs python widget object, which however seemed to lead to
an assortment of bugs with plot renderings.