### PR TITLE
Fix PreviewSaveTool dom elements not being removed

### DIFF
--- a/bokehjs/src/coffee/common/plot.coffee
+++ b/bokehjs/src/coffee/common/plot.coffee
@@ -40,6 +40,12 @@ class PlotView extends ContinuumView
       @throttled_render(true)
     return
 
+  remove: () =>
+    super()
+    # When this view is removed, also remove all of the tools.
+    for id, tool_view of @tools
+      tool_view.remove()
+
   initialize: (options) ->
     super(options)
     @pause()

--- a/bokehjs/src/coffee/tool/actions/preview_save_tool.coffee
+++ b/bokehjs/src/coffee/tool/actions/preview_save_tool.coffee
@@ -13,9 +13,12 @@ class PreviewSaveToolView extends ActionTool.View
 
   initialize: (options) ->
     super(options)
+    @render()
+
+  render: () ->
+    @$el.empty()
     @$el.html(@template())
     @$el.attr("tabindex", "-1")
-    $('body').append(@$el)
     @$el.on('hidden', () => @$el.modal('hide'))
     @$el.modal({show: false})
 

--- a/sphinx/objects.graffle
+++ b/sphinx/objects.graffle
@@ -2159,7 +2159,7 @@ passive\
 {\colortbl;\red255\green255\blue255;}
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\qc
 
-\f0\b\fs24 \cf0 SaveTool}</string>
+\f0\b\fs24 \cf0 PreviewSaveTool}</string>
 						<key>VerticalPad</key>
 						<integer>0</integer>
 					</dict>

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -74,6 +74,15 @@ containing tool shortcut names:
 
     tools = "pan,wheel_zoom,box_zoom,reset,resize"
 
+However, this method does not allow setting properties of the tools.
+To use shortcut names but also add tools with properties, one can
+also call the ``add_tools`` method:
+
+.. code-block:: python
+
+    fig = figure(tools="pan,wheel_zoom,box_zoom,reset,resize")
+    fig.add_tools(BoxSelectTool(dimensions=["width"]))
+
 .. _userguide_tools_pandrag:
 
 Pan/Drag Tools
@@ -91,7 +100,8 @@ BoxSelectTool
 The box selection tool allows the user to define a rectangular selection
 region by left-dragging a mouse, or dragging a finger across the plot area.
 The box select tool may be configured to select across only one dimension by
-setting the ``dimension`` property to ``width`` or ``height``.
+setting the ``dimensions`` property to a list containing ``width`` or
+``height``.
 
 .. note::
     To make a multiple selection, press the SHIFT key. To clear the
@@ -130,8 +140,9 @@ The pan tool allows the user to pan the plot by left-dragging a mouse or draggin
 finger across the plot region.
 
 It is also possible to constrain the pan tool to only act on either just the x-axis or
-just the y-axis by setting the ``dimension`` property to ``width`` or ``height``.
-Additionally, there are tool aliases ``'xpan'`` and ``'ypan'``, respectively.
+just the y-axis by setting the ``dimensions`` property to a list containing ``width``
+or ``height``. Additionally, there are tool aliases ``'xpan'`` and ``'ypan'``,
+respectively.
 
 ResizeTool
 ''''''''''
@@ -196,9 +207,9 @@ The wheel zoom tool will zoom the plot in and out, centered on the current
 mouse location.
 
 It is also possible to constraint the wheel zoom tool to only act on either
-just the x-axis or just the y-axis by setting the ``dimension`` property to
-``width`` or ``height``. Additionally, there are tool aliases ``'xwheel_zoom'``
-and ``'ywheel_zoom'``, respectively.
+just the x-axis or just the y-axis by setting the ``dimensions`` property to
+a list containing ``width`` or ``height``. Additionally, there are tool aliases
+``'xwheel_zoom'`` and ``'ywheel_zoom'``, respectively.
 
 .. _userguide_tools_actions:
 
@@ -216,8 +227,8 @@ ResetTool
 
 The reset tool will restore the plot ranges to their original values.
 
-SaveTool
-''''''''
+PreviewSaveTool
+'''''''''''''''
 
 * name: ``'save'``
 * icon: |save_icon|
@@ -244,8 +255,8 @@ CrosshairTool
 
 Th crosshair tool draws a crosshair annotation over the plot, centered on
 the current mouse position. The crosshair tool may be configured to draw
-accross only one dimension by setting the ``dimension`` property to
-``width`` or ``height``.
+accross only one dimension by setting the ``dimensions`` property to a
+list containing ``width`` or ``height``.
 
 HoverTool
 '''''''''


### PR DESCRIPTION
When a plot view is removed corresponding previewsavetool views (and their associated dialog div's) are not getting removed, which looks a bit worrying from an html console especially if a large number of plots are being refreshed.

Also renamed SaveTool to PreviewSaveTool at a couple of points in the documentation, and updated the documentation to use `dimensions` instead of `dimension`.