### PR TITLE
Fix to take version into the fab deploy script

### DIFF
--- a/scripts/build_upload.sh
+++ b/scripts/build_upload.sh
@@ -168,7 +168,8 @@ BOKEH_LOCAL_DOCS_CDN=$complete_version BOKEH_DOCS_VERSION=$complete_version make
 
 # to the correct location
 if [[ -z "$travis_build_id" ]]; then
-    fab deploy:$complete_version,latest
+    fab deploy:$complete_version
+    fab latest:$complete_version
     echo "I'm done uploading the release docs"
 else
     fab deploy:dev

--- a/scripts/build_upload.sh
+++ b/scripts/build_upload.sh
@@ -168,10 +168,10 @@ BOKEH_LOCAL_DOCS_CDN=$complete_version BOKEH_DOCS_VERSION=$complete_version make
 
 # to the correct location
 if [[ -z "$travis_build_id" ]]; then
-    fab deploy
+    fab deploy:$complete_version,latest
     echo "I'm done uploading the release docs"
 else
-    fab update:dev
+    fab deploy:dev
     echo "I'm done uploading the devel docs"
 fi
 

--- a/sphinx/README.txt
+++ b/sphinx/README.txt
@@ -30,15 +30,21 @@ To serve the built docs into a local browser:
 
 Issue "make help" to see a list of all make commands.
 
-To deploy the docs to bokeh.pydata.org you have multiple options, such as:
+To deploy docs to bokeh.pydata.org you have multiple options, such as:
 
-    $ fab deploy #will deploy the current version at /version
+     $ fab deploy # deploy the current checked out version at /<version>
 
-    $ fab deploy:0.9.2 #will deploy/redeploy 0.9.2 version at /0.9.2
+     $ fab deploy:<name> # deploy the current checked out version at /<name>
 
-    $ fab deploy:dev #will deploy current version at /dev (same for /test) 
+For example:
 
-    $ fab deploy:0.9.3,latest #should be use to also link /latest to 0.9.3 version (for releases)
+     $ fab deploy:0.9.2 # deploy at /0.9.2
+     $ fab deploy:test  # deploy at /test
+     $ fab deploy:dev   # deploy at /dev
+
+Additionally, you have the "latest" task to update the `/latest` link to the specified version:
+
+    $ fab latest:0.9.3 # link /latest to 0.9.3 version
 
 Note: requires having SSH keys for "bokeh" user.
 

--- a/sphinx/README.txt
+++ b/sphinx/README.txt
@@ -30,15 +30,21 @@ To serve the built docs into a local browser:
 
 Issue "make help" to see a list of all make commands.
 
-To deploy the docs to bokeh.pydata.org:
+To deploy the docs to bokeh.pydata.org you have multiple options, such as:
 
-    $ fab deploy
+    $ fab deploy #will deploy the current version at /version
+
+    $ fab deploy:0.9.2 #will deploy/redeploy 0.9.2 version at /0.9.2
+
+    $ fab deploy:dev #will deploy current version at /dev (same for /test) 
+
+    $ fab deploy:0.9.3,latest #should be use to also link /latest to 0.9.3 version (for releases)
 
 Note: requires having SSH keys for "bokeh" user.
 
 
 objects.graffle
 ===============
-The objects.graffle file was created using the commercial OmniGraffle package. It 
+The objects.graffle file was created using the commercial OmniGraffle package.
 was exported as a PNG image in _images/objects.png.
 

--- a/sphinx/README.txt
+++ b/sphinx/README.txt
@@ -45,6 +45,6 @@ Note: requires having SSH keys for "bokeh" user.
 
 objects.graffle
 ===============
-The objects.graffle file was created using the commercial OmniGraffle package. It
+The objects.graffle file was created using the commercial OmniGraffle package. It 
 was exported as a PNG image in _images/objects.png.
 

--- a/sphinx/README.txt
+++ b/sphinx/README.txt
@@ -45,6 +45,6 @@ Note: requires having SSH keys for "bokeh" user.
 
 objects.graffle
 ===============
-The objects.graffle file was created using the commercial OmniGraffle package.
+The objects.graffle file was created using the commercial OmniGraffle package. It
 was exported as a PNG image in _images/objects.png.
 

--- a/sphinx/fabfile.py
+++ b/sphinx/fabfile.py
@@ -46,4 +46,4 @@ def latest(v=None):
         run("ln -s /www/bokeh/en/%s /www/bokeh/en/latest" % v)
     else:
         raise RuntimeError("We did not detect a %s docs version, please use "
-                           "fab deploy:%s first." % v)
+                           "fab deploy:%s first." % (v, v))

--- a/sphinx/fabfile.py
+++ b/sphinx/fabfile.py
@@ -11,9 +11,11 @@ env.roledefs = {
 env.user = "bokeh"
 
 @roles('web')
-def deploy():
+def deploy(v=None, latest=None):
 
-    v = conf.version
+    # TODO (bev) confirm this version is not the latest
+    if v is None:
+        v = conf.version
 
     # make a backup of the old directory
     run("rm -rf /www/bokeh/en/%s.bak" % v)
@@ -21,8 +23,9 @@ def deploy():
     run("cp -ar /www/bokeh/en/%s /www/bokeh/en/%s.bak" % (v, v))
 
     # switch latest symlink to archive docs
-    run("rm /www/bokeh/en/latest")
-    run("ln -s /www/bokeh/en/%s.bak /www/bokeh/en/latest" % v)
+    if latest == 'latest':
+        run("rm /www/bokeh/en/latest")
+        run("ln -s /www/bokeh/en/%s.bak /www/bokeh/en/latest" % v)
 
     rsync_project(
         local_dir="_build/html/",
@@ -34,26 +37,6 @@ def deploy():
     run("chmod -R g+w /www/bokeh/en/%s" % v)
 
     # switch the current symlink to new docs
-    run("rm /www/bokeh/en/latest")
-    run("ln -s /www/bokeh/en/%s /www/bokeh/en/latest" % v)
-
-@roles('web')
-def update(v=None):
-
-    # TODO (bev) confirm this version is not the latest
-    if v is None:
-        v = conf.version
-
-    # make a backup of the old directory
-    run("rm -rf /www/bokeh/en/%s.bak" % v)
-    run("mkdir -p /www/bokeh/en/%s" % v)
-    run("cp -ar /www/bokeh/en/%s /www/bokeh/en/%s.bak" % (v, v))
-
-    rsync_project(
-        local_dir="_build/html/",
-        remote_dir="/www/bokeh/en/%s" % v,
-        delete=True
-    )
-
-    # set permissions
-    run("chmod -R g+w /www/bokeh/en/%s" % v)
+    if latest == 'latest':
+        run("rm /www/bokeh/en/latest")
+        run("ln -s /www/bokeh/en/%s /www/bokeh/en/latest" % v)

--- a/sphinx/fabfile.py
+++ b/sphinx/fabfile.py
@@ -1,4 +1,5 @@
 from fabric.api import run, env, roles
+from fabric.contrib.files import exists
 from fabric.contrib.project import rsync_project
 
 import sys
@@ -15,6 +16,9 @@ def deploy(v=None):
 
     if v is None:
         v = conf.version
+    elif v == "latest":
+        raise RuntimeError("You can not pass 'latest' as fab argument. Use "
+                           "fab latest:x.x.x instead.")
 
     # make a backup of the old directory
     run("rm -rf /www/bokeh/en/%s.bak" % v)
@@ -34,8 +38,12 @@ def deploy(v=None):
 def latest(v=None):
 
     if v is None:
-        raise RuntimeError("You need to specify version number: fab latest:x.x.x")
+        raise RuntimeError("You need to specify a version number: fab latest:x.x.x")
 
-    # switch the current symlink to new docs
-    run("rm /www/bokeh/en/latest")
-    run("ln -s /www/bokeh/en/%s /www/bokeh/en/latest" % v)
+    if exists("/www/bokeh/en/%s" % v):
+        # switch the current symlink to new docs
+        run("rm /www/bokeh/en/latest")
+        run("ln -s /www/bokeh/en/%s /www/bokeh/en/latest" % v)
+    else:
+        raise RuntimeError("We did not detect a %s docs version, please use "
+                           "fab deploy:%s first." % v)

--- a/sphinx/fabfile.py
+++ b/sphinx/fabfile.py
@@ -11,9 +11,8 @@ env.roledefs = {
 env.user = "bokeh"
 
 @roles('web')
-def deploy(v=None, latest=None):
+def deploy(v=None):
 
-    # TODO (bev) confirm this version is not the latest
     if v is None:
         v = conf.version
 
@@ -21,11 +20,6 @@ def deploy(v=None, latest=None):
     run("rm -rf /www/bokeh/en/%s.bak" % v)
     run("mkdir -p /www/bokeh/en/%s" % v)
     run("cp -ar /www/bokeh/en/%s /www/bokeh/en/%s.bak" % (v, v))
-
-    # switch latest symlink to archive docs
-    if latest == 'latest':
-        run("rm /www/bokeh/en/latest")
-        run("ln -s /www/bokeh/en/%s.bak /www/bokeh/en/latest" % v)
 
     rsync_project(
         local_dir="_build/html/",
@@ -36,7 +30,12 @@ def deploy(v=None, latest=None):
     # set permissions
     run("chmod -R g+w /www/bokeh/en/%s" % v)
 
+@roles('web')
+def latest(v=None):
+
+    if v is None:
+        raise RuntimeError("You need to specify version number: fab latest:x.x.x")
+
     # switch the current symlink to new docs
-    if latest == 'latest':
-        run("rm /www/bokeh/en/latest")
-        run("ln -s /www/bokeh/en/%s /www/bokeh/en/latest" % v)
+    run("rm /www/bokeh/en/latest")
+    run("ln -s /www/bokeh/en/%s /www/bokeh/en/latest" % v)

--- a/sphinx/fabfile.py
+++ b/sphinx/fabfile.py
@@ -17,8 +17,7 @@ def deploy(v=None):
     if v is None:
         v = conf.version
     elif v == "latest":
-        raise RuntimeError("You can not pass 'latest' as fab argument. Use "
-                           "fab latest:x.x.x instead.")
+        raise RuntimeError("You can not pass 'latest' as fab argument. Use fab latest:x.x.x instead.")
 
     # make a backup of the old directory
     run("rm -rf /www/bokeh/en/%s.bak" % v)
@@ -45,5 +44,4 @@ def latest(v=None):
         run("rm /www/bokeh/en/latest")
         run("ln -s /www/bokeh/en/%s /www/bokeh/en/latest" % v)
     else:
-        raise RuntimeError("We did not detect a %s docs version, please use "
-                           "fab deploy:%s first." % (v, v))
+        raise RuntimeError("We did not detect a %s docs version, please use fab deploy:%s first." % (v, v))


### PR DESCRIPTION
Simplify fab script (removes duplication) and make fab deploy to take a version. Also fix the version in the build machinery.

With this change:

`fab deploy`, will deploy the current version at `/version`
`fab deploy:0.9.2`, will deploy/redeploy 0.9.2 version at `/0.9.2`
`fab deploy:test` and `fab deploy:dev`, the same as before...
`fab deploy:0.9.3,latest` should be used for the next release (latest makes the symlinks available). if you are doing manually, you can also use `fab deploy:latest=latest` and it will take the current version, but this is not recommended way to use it because you need to live in the release point (0.9.3 in this example). In addition, this is not longer made manually, it is automated...

