### PR TITLE
Clean up models section of reference guide

### DIFF
--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -144,7 +144,7 @@ html_theme_options = {
 
     # Global TOC depth for "site" navbar tab. (Default: 1)
     # Switching to -1 shows all levels.
-    'globaltoc_depth': 2,
+    'globaltoc_depth': 3,
 
     # Include hidden TOCs in Site navbar?
     #

--- a/sphinx/source/docs/reference/models.rst
+++ b/sphinx/source/docs/reference/models.rst
@@ -16,206 +16,30 @@ This reference documents all the Bokeh models, together with their
 property attributes, as well as a JSON prototype illustrating what
 a serialized version of the model looks like.
 
-.. contents::
-    :local:
-    :depth: 1
-
-.. _bokeh.models.actions:
-
-``bokeh.models.actions``
-------------------------
-
-.. automodule:: bokeh.models.actions
-   :members:
-   :undoc-members:
-
-.. _bokeh.models.axes:
-
-``bokeh.models.axes``
----------------------
-
-.. automodule:: bokeh.models.axes
-   :members:
-   :undoc-members:
-
-.. _bokeh.models.formatters:
-
-``bokeh.models.formatters``
----------------------------
-
-.. automodule:: bokeh.models.formatters
-   :members:
-   :undoc-members:
-
-.. _bokeh.models.glyphs:
-
-``bokeh.models.glyphs``
------------------------
-
-.. automodule:: bokeh.models.glyphs
-   :members:
-   :undoc-members:
-
-.. _bokeh.models.grids:
-
-``bokeh.models.grids``
-----------------------
-
-.. automodule:: bokeh.models.grids
-   :members:
-   :undoc-members:
-
-.. _bokeh.models.map_plots:
-
-``bokeh.models.map_plots``
---------------------------
-
-.. automodule:: bokeh.models.map_plots
-   :members:
-   :undoc-members:
-
-.. _bokeh.models.mappers:
-
-``bokeh.models.mappers``
-------------------------
-
-.. automodule:: bokeh.models.mappers
-   :members:
-   :undoc-members:
-
-.. _bokeh.models.markers:
-
-``bokeh.models.markers``
-------------------------
-
-.. automodule:: bokeh.models.markers
-   :members:
-   :undoc-members:
-
-.. _bokeh.models_plots:
-
-``bokeh.models.plots``
-----------------------
-
-.. automodule:: bokeh.models.plots
-   :members:
-   :undoc-members:
-
-.. _bokeh.models.ranges:
-
-``bokeh.models.ranges``
------------------------
-
-.. automodule:: bokeh.models.ranges
-   :members:
-   :undoc-members:
-
-.. _bokeh.models.renderers:
-
-``bokeh.models.renderers``
---------------------------
-
-.. automodule:: bokeh.models.renderers
-   :members:
-   :undoc-members:
-
-.. _bokeh.models.sources:
-
-``bokeh.models.sources``
-------------------------
-
-.. automodule:: bokeh.models.sources
-   :members:
-   :undoc-members:
-
-.. _bokeh.models.tickers:
-
-``bokeh.models.tickers``
-------------------------
-
-.. automodule:: bokeh.models.tickers
-   :members:
-   :undoc-members:
-
-.. _bokeh.models.tools:
-
-``bokeh.models.tools``
-----------------------
-
-.. automodule:: bokeh.models.tools
-   :members:
-   :undoc-members:
-
-.. _bokeh.models.widget:
-
-``bokeh.models.widget``
-------------------------
-
-.. automodule:: bokeh.models.widget
-   :members:
-   :undoc-members:
-
-``bokeh.models.widgets.buttons``
---------------------------------
-
-.. automodule:: bokeh.models.widgets.buttons
-   :members:
-   :undoc-members:
-
-``bokeh.models.widgets.dialogs``
---------------------------------
-
-.. automodule:: bokeh.models.widgets.dialogs
-   :members:
-   :undoc-members:
-
-``bokeh.models.widgets.groups``
--------------------------------
-
-.. automodule:: bokeh.models.widgets.groups
-   :members:
-   :undoc-members:
-
-``bokeh.models.widgets.icons``
-------------------------------
-
-.. automodule:: bokeh.models.widgets.icons
-   :members:
-   :undoc-members:
-
-``bokeh.models.widgets.inputs``
--------------------------------
-
-.. automodule:: bokeh.models.widgets.inputs
-   :members:
-   :undoc-members:
-
-``bokeh.models.widgets.layouts``
---------------------------------
-
-.. automodule:: bokeh.models.widgets.layouts
-   :members:
-   :undoc-members:
-
-``bokeh.models.widgets.markups``
---------------------------------
-
-.. automodule:: bokeh.models.widgets.markups
-   :members:
-   :undoc-members:
-
-``bokeh.models.widgets.panels``
--------------------------------
-
-.. automodule:: bokeh.models.widgets.panels
-   :members:
-   :undoc-members:
-
-``bokeh.models.widgets.tables``
--------------------------------
-
-.. automodule:: bokeh.models.widgets.tables
-   :members:
-   :undoc-members:
-
-
+.. toctree::
+   :maxdepth: 2
+
+   models/actions
+   models/axes
+   models/formatters
+   models/glyphs
+   models/grids
+   models/map_plots
+   models/mappers
+   models/markers
+   models/plots
+   models/ranges
+   models/renderers
+   models/sources
+   models/tickers
+   models/tools
+   models/widget
+   models/widgets.buttons
+   models/widgets.dialogs
+   models/widgets.groups
+   models/widgets.icons
+   models/widgets.inputs
+   models/widgets.layouts
+   models/widgets.markups
+   models/widgets.panels
+   models/widgets.tables

--- a/sphinx/source/docs/reference/models/actions.rst
+++ b/sphinx/source/docs/reference/models/actions.rst
@@ -1,0 +1,8 @@
+.. _bokeh.models.actions:
+
+``bokeh.models.actions``
+------------------------
+
+.. automodule:: bokeh.models.actions
+   :members:
+   :undoc-members:

--- a/sphinx/source/docs/reference/models/axes.rst
+++ b/sphinx/source/docs/reference/models/axes.rst
@@ -1,0 +1,8 @@
+.. _bokeh.models.axes:
+
+``bokeh.models.axes``
+---------------------
+
+.. automodule:: bokeh.models.axes
+   :members:
+   :undoc-members:

--- a/sphinx/source/docs/reference/models/formatters.rst
+++ b/sphinx/source/docs/reference/models/formatters.rst
@@ -1,0 +1,8 @@
+.. _bokeh.models.formatters:
+
+``bokeh.models.formatters``
+---------------------------
+
+.. automodule:: bokeh.models.formatters
+   :members:
+   :undoc-members:

--- a/sphinx/source/docs/reference/models/glyphs.rst
+++ b/sphinx/source/docs/reference/models/glyphs.rst
@@ -1,0 +1,8 @@
+.. _bokeh.models.glyphs:
+
+``bokeh.models.glyphs``
+-----------------------
+
+.. automodule:: bokeh.models.glyphs
+   :members:
+   :undoc-members:

--- a/sphinx/source/docs/reference/models/grids.rst
+++ b/sphinx/source/docs/reference/models/grids.rst
@@ -1,0 +1,8 @@
+.. _bokeh.models.grids:
+
+``bokeh.models.grids``
+----------------------
+
+.. automodule:: bokeh.models.grids
+   :members:
+   :undoc-members:

--- a/sphinx/source/docs/reference/models/map_plots.rst
+++ b/sphinx/source/docs/reference/models/map_plots.rst
@@ -1,0 +1,8 @@
+.. _bokeh.models.map_plots:
+
+``bokeh.models.map_plots``
+--------------------------
+
+.. automodule:: bokeh.models.map_plots
+   :members:
+   :undoc-members:

--- a/sphinx/source/docs/reference/models/mappers.rst
+++ b/sphinx/source/docs/reference/models/mappers.rst
@@ -1,0 +1,8 @@
+.. _bokeh.models.mappers:
+
+``bokeh.models.mappers``
+------------------------
+
+.. automodule:: bokeh.models.mappers
+   :members:
+   :undoc-members:

--- a/sphinx/source/docs/reference/models/markers.rst
+++ b/sphinx/source/docs/reference/models/markers.rst
@@ -1,0 +1,8 @@
+.. _bokeh.models.markers:
+
+``bokeh.models.markers``
+------------------------
+
+.. automodule:: bokeh.models.markers
+   :members:
+   :undoc-members:

--- a/sphinx/source/docs/reference/models/plots.rst
+++ b/sphinx/source/docs/reference/models/plots.rst
@@ -1,0 +1,8 @@
+.. _bokeh.models_plots:
+
+``bokeh.models.plots``
+----------------------
+
+.. automodule:: bokeh.models.plots
+   :members:
+   :undoc-members:

--- a/sphinx/source/docs/reference/models/ranges.rst
+++ b/sphinx/source/docs/reference/models/ranges.rst
@@ -1,0 +1,8 @@
+.. _bokeh.models.ranges:
+
+``bokeh.models.ranges``
+-----------------------
+
+.. automodule:: bokeh.models.ranges
+   :members:
+   :undoc-members:

--- a/sphinx/source/docs/reference/models/renderers.rst
+++ b/sphinx/source/docs/reference/models/renderers.rst
@@ -1,0 +1,8 @@
+.. _bokeh.models.renderers:
+
+``bokeh.models.renderers``
+--------------------------
+
+.. automodule:: bokeh.models.renderers
+   :members:
+   :undoc-members:

--- a/sphinx/source/docs/reference/models/sources.rst
+++ b/sphinx/source/docs/reference/models/sources.rst
@@ -1,0 +1,8 @@
+.. _bokeh.models.sources:
+
+``bokeh.models.sources``
+------------------------
+
+.. automodule:: bokeh.models.sources
+   :members:
+   :undoc-members:

--- a/sphinx/source/docs/reference/models/tickers.rst
+++ b/sphinx/source/docs/reference/models/tickers.rst
@@ -1,0 +1,8 @@
+.. _bokeh.models.tickers:
+
+``bokeh.models.tickers``
+------------------------
+
+.. automodule:: bokeh.models.tickers
+   :members:
+   :undoc-members:

--- a/sphinx/source/docs/reference/models/tools.rst
+++ b/sphinx/source/docs/reference/models/tools.rst
@@ -1,0 +1,8 @@
+.. _bokeh.models.tools:
+
+``bokeh.models.tools``
+----------------------
+
+.. automodule:: bokeh.models.tools
+   :members:
+   :undoc-members:

--- a/sphinx/source/docs/reference/models/widget.rst
+++ b/sphinx/source/docs/reference/models/widget.rst
@@ -1,0 +1,8 @@
+.. _bokeh.models.widget:
+
+``bokeh.models.widget``
+------------------------
+
+.. automodule:: bokeh.models.widget
+   :members:
+   :undoc-members:

--- a/sphinx/source/docs/reference/models/widgets.buttons.rst
+++ b/sphinx/source/docs/reference/models/widgets.buttons.rst
@@ -1,0 +1,6 @@
+``bokeh.models.widgets.buttons``
+--------------------------------
+
+.. automodule:: bokeh.models.widgets.buttons
+   :members:
+   :undoc-members:

--- a/sphinx/source/docs/reference/models/widgets.dialogs.rst
+++ b/sphinx/source/docs/reference/models/widgets.dialogs.rst
@@ -1,0 +1,6 @@
+``bokeh.models.widgets.dialogs``
+--------------------------------
+
+.. automodule:: bokeh.models.widgets.dialogs
+   :members:
+   :undoc-members:

--- a/sphinx/source/docs/reference/models/widgets.groups.rst
+++ b/sphinx/source/docs/reference/models/widgets.groups.rst
@@ -1,0 +1,6 @@
+``bokeh.models.widgets.groups``
+-------------------------------
+
+.. automodule:: bokeh.models.widgets.groups
+   :members:
+   :undoc-members:

--- a/sphinx/source/docs/reference/models/widgets.icons.rst
+++ b/sphinx/source/docs/reference/models/widgets.icons.rst
@@ -1,0 +1,6 @@
+``bokeh.models.widgets.icons``
+------------------------------
+
+.. automodule:: bokeh.models.widgets.icons
+   :members:
+   :undoc-members:

--- a/sphinx/source/docs/reference/models/widgets.inputs.rst
+++ b/sphinx/source/docs/reference/models/widgets.inputs.rst
@@ -1,0 +1,6 @@
+``bokeh.models.widgets.inputs``
+-------------------------------
+
+.. automodule:: bokeh.models.widgets.inputs
+   :members:
+   :undoc-members:

--- a/sphinx/source/docs/reference/models/widgets.layouts.rst
+++ b/sphinx/source/docs/reference/models/widgets.layouts.rst
@@ -1,0 +1,6 @@
+``bokeh.models.widgets.layouts``
+--------------------------------
+
+.. automodule:: bokeh.models.widgets.layouts
+   :members:
+   :undoc-members:

--- a/sphinx/source/docs/reference/models/widgets.markups.rst
+++ b/sphinx/source/docs/reference/models/widgets.markups.rst
@@ -1,0 +1,6 @@
+``bokeh.models.widgets.markups``
+--------------------------------
+
+.. automodule:: bokeh.models.widgets.markups
+   :members:
+   :undoc-members:

--- a/sphinx/source/docs/reference/models/widgets.panels
+++ b/sphinx/source/docs/reference/models/widgets.panels
@@ -1,0 +1,6 @@
+``bokeh.models.widgets.panels``
+-------------------------------
+
+.. automodule:: bokeh.models.widgets.panels
+   :members:
+   :undoc-members:

--- a/sphinx/source/docs/reference/models/widgets.tables
+++ b/sphinx/source/docs/reference/models/widgets.tables
@@ -1,0 +1,6 @@
+``bokeh.models.widgets.tables``
+-------------------------------
+
+.. automodule:: bokeh.models.widgets.tables
+   :members:
+   :undoc-members:


### PR DESCRIPTION
made **models.rst** into a table of contents page and moved the contents on to individual .rst files in *reference/models*.