### PR TITLE
Add support for --build-dir argument to gulp build

### DIFF
--- a/bokehjs/gulp/paths.coffee
+++ b/bokehjs/gulp/paths.coffee
@@ -1,21 +1,25 @@
-BUILD_DIR = "./build/"
-JS_BUILD = "#{BUILD_DIR}js/"
+path = require("path")
+argv = require("yargs").argv
+
+BUILD_DIR = if typeof argv.buildDir == "string" then argv.buildDir else "./build"
+JS_BUILD_DIR = path.join(BUILD_DIR, "js")
+CSS_BUILD_DIR = path.join(BUILD_DIR, "css")
 SERVER_DIR = "../bokeh/server/static/"
 
-module.exports =
+module.exports = {
   buildDir:
     all: BUILD_DIR
-    js: JS_BUILD
-    css: "#{BUILD_DIR}css/"
+    js: JS_BUILD_DIR
+    css: CSS_BUILD_DIR
   serverDir:
     all: SERVER_DIR
-    js: "#{SERVER_DIR}js/"
-    css: "#{SERVER_DIR}css/"
+    js: path.join(SERVER_DIR, "js")
+    css: path.join(SERVER_DIR, "css")
+
   coffee:
     destination:
       full: "bokeh.js"
-      fullWithPath: "#{JS_BUILD}bokeh.js"
-      minified: "bokeh.min.js"
+      fullWithPath: path.join(JS_BUILD_DIR, "bokeh.js")
     sources: [
       "./src/coffee/main.coffee"
     ]
@@ -25,10 +29,10 @@ module.exports =
 
   css:
     sources: [
-      "./build/css/bokeh.css"
+      path.join(CSS_BUILD_DIR, "bokeh.css")
     ]
     watchSources: [
-      "./build/css/bokeh.css",
+      path.join(CSS_BUILD_DIR, "bokeh.css")
     ]
 
   less:
@@ -44,4 +48,4 @@ module.exports =
       "./test/**/**",
       "./src/coffee/**/**",
     ]
-
+}

--- a/bokehjs/gulp/tasks/scripts.coffee
+++ b/bokehjs/gulp/tasks/scripts.coffee
@@ -34,7 +34,7 @@ gulp.task "scripts:build", ->
 
 gulp.task "scripts:minify", ->
   gulp.src paths.coffee.destination.fullWithPath
-    .pipe rename paths.coffee.destination.minified
+    .pipe rename((path) -> path.basename += ".min")
     .pipe gulp.dest paths.buildDir.js
     .pipe sourcemaps.init
       loadMaps: true

--- a/bokehjs/gulp/tasks/styles.coffee
+++ b/bokehjs/gulp/tasks/styles.coffee
@@ -13,18 +13,17 @@ utils = require "../utils"
 gulp.task "styles:build", ->
   gulp.src paths.less.sources
     .pipe less()
-    .pipe gulp.dest paths.buildDir.css
+    .pipe gulp.dest(paths.buildDir.css)
 
 gulp.task "styles:minify", ->
   opts = {}
   gulp.src paths.css.sources
-    .pipe rename "bokeh.min.css"
-    .pipe gulp.dest paths.buildDir.css
-    .pipe sourcemaps.init
-      loadMaps: true
+    .pipe rename((path) -> path.basename += ".min")
+    .pipe gulp.dest(paths.buildDir.css)
+    .pipe sourcemaps.init({loadMaps: true})
     .pipe minifyCSS opts
-    .pipe sourcemaps.write './'
-    .pipe gulp.dest paths.buildDir.css
+    .pipe sourcemaps.write("./")
+    .pipe gulp.dest(paths.buildDir.css)
 
 gulp.task "styles", (cb) ->
   runSequence("styles:build", "styles:minify", cb)

--- a/sphinx/source/docs/dev_guide/building.rst
+++ b/sphinx/source/docs/dev_guide/building.rst
@@ -10,8 +10,8 @@ Building and Installing
 
 The Bokeh project encompasses two major components: the Bokeh package source
 code, written in Python, and the BokehJS client-side library, written in
-CoffeeScript. Accordingly, development of Bokeh is slightly complicated by the
-fact that BokehJS requires an explicit compilation step to render the
+CoffeeScript. Accordingly, development of Bokeh is slightly complicated by
+the fact that BokehJS requires an explicit compilation step to render the
 CoffeeScript source into deployable JavaScript.
 
 For this reason, in order to develop Bokeh from a source checkout, you must
@@ -97,12 +97,19 @@ use ``bokehjs/node_modules/.bin/gulp``, install Gulp globally via
 
     conda install -c javascript gulp
 
-To generate the compiled and optimized BokehJS libraries with source maps, and deploy
-them to the ``build`` subdirectory:
+To generate the compiled and optimized BokehJS libraries with source maps,
+and deploy them to the ``build`` subdirectory:
 
 .. code-block:: sh
 
     gulp build
+
+Additionally, ``gulp build`` accepts a ``--build-dir`` argument to specify
+where the built resources should be produced:
+
+.. code-block:: sh
+
+    gulp build --build-dir=/home/bokeh/mybuilddir
 
 To direct Gulp to automatically watch the source tree for changes and
 trigger a recompile if any source file changes:
@@ -111,8 +118,8 @@ trigger a recompile if any source file changes:
 
     gulp watch
 
-To enable inline coffeescript source mapping, you may add the ``--debug`` flag
-to either of the ``gulp build`` or ``gulp watch`` commands:
+To enable inline coffeescript source mapping, you may add the ``--debug``
+flag to either of the ``gulp build`` or ``gulp watch`` commands:
 
 .. code-block:: sh
 
@@ -124,8 +131,8 @@ to either of the ``gulp build`` or ``gulp watch`` commands:
 Python Setup
 ------------
 
-Once you have a working BokehJS build (which you can verify by completing the
-steps described in :ref:`devguide_building_bokehjs`), you can use the
+Once you have a working BokehJS build (which you can verify by completing
+the steps described in :ref:`devguide_building_bokehjs`), you can use the
 ``setup.py`` script at the top level of the source checkout to install or
 develop the full Bokeh library from source.
 
@@ -167,9 +174,9 @@ If you have any problems with the steps here, please contact the developers
 Dependencies
 ~~~~~~~~~~~~
 
-If you are working within a Conda environment, you will need to make sure you
-have the python requirements installed. You can install these via ``conda
-install`` or ``pip install`` for the packages referenced at
+If you are working within a Conda environment, you will need to make sure
+you have the python requirements installed. You can install these via
+``conda install`` or ``pip install`` for the packages referenced at
 :ref:`install_dependencies`.
 
 Testing dependencies include the following additional libraries:
@@ -187,9 +194,9 @@ Testing dependencies include the following additional libraries:
 
 ----
 
-To quickly and easily confirm that your environment contains all of the necessary
-dependencies to build both the docs and the development version of Bokeh,
-run the ``devdeps.py`` file inside the ``bokeh/scripts`` directory.
+To quickly and easily confirm that your environment contains all of the
+necessary dependencies to build both the docs and the development version
+of Bokeh, run the ``devdeps.py`` file inside the ``bokeh/scripts`` directory.
 
 If any needed packages are missing, you will be given output like this
 
@@ -215,8 +222,8 @@ Otherwise, you should see this message
     All Docs dependencies installed!  You are good to go!
 
 
-Additionally, ``devdeps.py`` will check that the ``bokehjs/node_modules`` directory exists,
-which is where npm packages are installed.
+Additionally, ``devdeps.py`` will check that the ``bokehjs/node_modules``
+directory exists, which is where npm packages are installed.
 
 If this directory is not found, it will provide instructions on how and where to
 install npm packages.


### PR DESCRIPTION
This will be useful when using gulp build from other build systems, like sbt. This commit also fixes the build to not use hard-coded paths. Also uses `path.join()` instead of naive path string concatenation.