### PR TITLE
webgl: fall back to 2D canvas when webgl is not available.

### DIFF
--- a/bokehjs/src/coffee/common/plot.coffee
+++ b/bokehjs/src/coffee/common/plot.coffee
@@ -135,7 +135,8 @@ class PlotView extends ContinuumView
       glcanvas.gl = gl
       @canvas_view.ctx.glcanvas = glcanvas
     else
-      @canvas_view.ctx.glcanvas = false  # disable webgl
+      logger.warn('WebGL is not supported, falling back to 2D canvas.')
+      # Do not set @canvas_view.ctx.glcanvas
 
   update_dataranges: () ->
     # Update any DataRange1ds here


### PR DESCRIPTION
I thought I had a fallback in place by setting `ctx.glcanvas = false`, but this does not work if you later use `ctx.glcanvas?` :)  This fixes it and also warns about falling back.