### PR TITLE
fix typo on image glyph docstring

### DIFF
--- a/bokeh/_glyph_functions.py
+++ b/bokeh/_glyph_functions.py
@@ -376,7 +376,7 @@ Args:
     dw (str or list[float]) : values or field names of image width distances
     dh (str or list[float]) : values or field names of image height distances
     palette (str or list[str]) : values or field names of palettes to use for color-mapping (see :ref:`bokeh_dot_palettes` for more details)
-    colorMapper (LinearColorMapper) : a LinearColorMapper instance
+    color_mapper (LinearColorMapper) : a LinearColorMapper instance
     dilate (bool, optional) : whether to dilate pixel distance computations when drawing, defaults to False
 
 Returns:


### PR DESCRIPTION
As reported on [m.l.](https://groups.google.com/a/continuum.io/forum/?utm_medium=email&utm_source=footer#!msg/bokeh/b_4YOgI7psM/dadCL7qlJQAJ)