### PR TITLE
Remove jsdom

### DIFF
--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -39,7 +39,6 @@
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.4",
     "hammerjs": "^2.0.4",
-    "jsdom": "^5.0.0",
     "phantomjs": "^1.9.7",
     "run-sequence": "^1.0.0",
     "sandboxed-module": "^2.0.0",

--- a/bokehjs/test/utils.coffee
+++ b/bokehjs/test/utils.coffee
@@ -1,4 +1,3 @@
-jsdom = require "jsdom"
 SandboxedModule = require "sandboxed-module"
 
 moduleRequire = (name) ->
@@ -8,13 +7,6 @@ moduleRequire = (name) ->
 global._bokehTest =
   kiwi: require "../src/vendor/kiwi/kiwi"
 
-jsdom.env "<html><body></body></html>", (error, window) ->
-  global._bokehTest.Hammer = SandboxedModule.require "hammerjs",
-    globals:
-      window: window
-      document: window.document
-
-# Register the eco template loading
 require "eco"
 
 

--- a/bokehjs/test/utils.coffee
+++ b/bokehjs/test/utils.coffee
@@ -7,9 +7,8 @@ moduleRequire = (name) ->
 global._bokehTest =
   kiwi: require "../src/vendor/kiwi/kiwi"
 
+# Register the eco template loading
 require "eco"
-
-
 
 module.exports =
   require: moduleRequire

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -27,6 +27,8 @@ fi
 cp __conda_version__.txt $BLD_DIR
 
 pushd bokehjs
+echo "npm version $(npm -v)"
+echo "node version $(node -v)"
 npm install
 popd
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -8,14 +8,12 @@ build:
 extra:
   channels:
     - bokeh
-    - javascript
 
 requirements:
   build:
     - python
     - distribute
     - setuptools
-    - gulp  # in javascript channel
 
   run:
     # bokeh
@@ -62,7 +60,6 @@ test:
     - websocket-client
     - ipython
     - ipython-notebook
-    - gulp
     - flake8
 
     # examples

--- a/scripts/travis_install
+++ b/scripts/travis_install
@@ -24,7 +24,6 @@ DEPS_TRAVIS="python=$TRAVIS_PYTHON_VERSION conda-build jinja2"
 conda install --yes $DEPS_TRAVIS
 
 conda config --add channels bokeh
-conda config --add channels javascript   # TODO: move packages to bokeh?
 conda config --add channels mutirri   # TODO: remove when packages are moved to bokeh
 
 CONDA_PY="${TRAVIS_PYTHON_VERSION/./}" conda build --quiet conda.recipe

--- a/sphinx/source/docs/dev_guide/building.rst
+++ b/sphinx/source/docs/dev_guide/building.rst
@@ -93,7 +93,13 @@ Building BokehJS with Gulp
 Below are the main Gulp commands for development (to be executed from
 the ``bokehjs`` subdirectory). To run these commands, you can either
 use ``bokehjs/node_modules/.bin/gulp``, install Gulp globally via
-`npm`, or install gulp via conda (recommended):
+`npm`:
+
+.. code-block:: sh
+
+    npm install -g gulp
+
+or install gulp via conda (recommended):
 
 .. code-block:: sh
 


### PR DESCRIPTION
Pretty sure we don't need jsdom. It's very bulky, causing problems with node, and we can use [cheerio](https://github.com/cheeriojs/cheerio) which seems more user friendly for a dummy DOM. See [here](https://github.com/bokeh/bokeh/pull/2666/files#diff-f32e449a1ce9901c770335f031be8e65R22) for an example of cheerio in a test

resolves issue https://github.com/bokeh/bokeh/issues/2629