### PR TITLE
Resolving conflict between RequireJS and Browserify with Backbone

### DIFF
--- a/bokehjs/gulp/tasks/scripts.coffee
+++ b/bokehjs/gulp/tasks/scripts.coffee
@@ -10,6 +10,7 @@ sourcemaps = require "gulp-sourcemaps"
 source = require 'vinyl-source-stream'
 buffer = require 'vinyl-buffer'
 paths = require "../paths"
+change = require "gulp-change"
 
 gulp.task "scripts:build", ->
   opts =
@@ -25,6 +26,12 @@ gulp.task "scripts:build", ->
     .pipe buffer()
     .pipe sourcemaps.init
       loadMaps: true
+
+    # This solves a conflict when requirejs is loaded on the page. Backbone
+    # looks for `define` before looking for `module.exports`, which eats up
+    # our backbone.
+    .pipe change (content) ->
+      '(function() { var define = undefined; #{content} })()'
     .pipe sourcemaps.write './'
     .pipe gulp.dest paths.buildDir.js
 

--- a/bokehjs/gulp/tasks/scripts.coffee
+++ b/bokehjs/gulp/tasks/scripts.coffee
@@ -31,7 +31,7 @@ gulp.task "scripts:build", ->
     # looks for `define` before looking for `module.exports`, which eats up
     # our backbone.
     .pipe change (content) ->
-      '(function() { var define = undefined; #{content} })()'
+      "(function() { var define = undefined; #{content} })()"
     .pipe sourcemaps.write './'
     .pipe gulp.dest paths.buildDir.js
 

--- a/bokehjs/gulp/tasks/styles.coffee
+++ b/bokehjs/gulp/tasks/styles.coffee
@@ -21,7 +21,7 @@ gulp.task "styles:build", ->
 gulp.task "styles:minify", ->
   gulp.src paths.css.sources
     .pipe rename (path) -> path.basename += ".min"
-    .pipe gulp.dest(paths.buildDir.css)
+    .pipe gulp.dest paths.buildDir.css
     .pipe sourcemaps.init
       loadMaps: true
     .pipe uglifycss()

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -71,9 +71,7 @@
     "gear_utils": "./src/vendor/gear-utils/gear-utils.js",
     "kiwi": "./src/vendor/kiwi/kiwi.js"
   },
-  "browserify-shim": {
-    "backbone": "node_modules/backbone/backbone.js"
-  },
+  "browserify-shim": {},
   "dependencies": {
     "jquery": "^2.1.1",
     "jquery-mousewheel": "^3.1.12",

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -27,6 +27,7 @@
     "del": "^1.1.1",
     "eco": "^1.1.0-rc-3",
     "gulp": "^3.8.10",
+    "gulp-change": "https://registry.npmjs.org/gulp-change/-/gulp-change-1.0.0.tgz",
     "gulp-coffeeify": "^0.1.2",
     "gulp-eco-template": "^0.1.0",
     "gulp-less": "^3.0.2",
@@ -70,7 +71,9 @@
     "gear_utils": "./src/vendor/gear-utils/gear-utils.js",
     "kiwi": "./src/vendor/kiwi/kiwi.js"
   },
-  "browserify-shim": {},
+  "browserify-shim": {
+    "backbone": "node_modules/backbone/backbone.js"
+  },
   "dependencies": {
     "jquery": "^2.1.1",
     "jquery-mousewheel": "^3.1.12",

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -27,7 +27,7 @@
     "del": "^1.1.1",
     "eco": "^1.1.0-rc-3",
     "gulp": "^3.8.10",
-    "gulp-change": "https://registry.npmjs.org/gulp-change/-/gulp-change-1.0.0.tgz",
+    "gulp-change": "^1.0.0",
     "gulp-coffeeify": "^0.1.2",
     "gulp-eco-template": "^0.1.0",
     "gulp-less": "^3.0.2",


### PR DESCRIPTION
This solves a conflict when requirejs is preloaded on the page. Backbone
looks for `define` before looking for `module.exports`, which eats up our Backbone.