### PR TITLE
adds callback to groups widgets

### DIFF
--- a/bokeh/models/widgets/groups.py
+++ b/bokeh/models/widgets/groups.py
@@ -3,7 +3,8 @@
 """
 from __future__ import absolute_import
 
-from ...properties import Bool, Int, String, Enum, List
+from ...properties import Bool, Int, String, Enum, List, Instance
+from ..actions import Callback
 from ...enums import ButtonType
 from ..widget import Widget
 
@@ -15,6 +16,10 @@ class AbstractGroup(Widget):
 
     labels = List(String, help="""
     List of text labels contained in this group.
+    """)
+
+    callback = Instance(Callback, help="""
+    A callback to run in the browser whenever the input's value changes.
     """)
 
     def on_click(self, handler):

--- a/bokehjs/src/coffee/widget/radio_group.coffee
+++ b/bokehjs/src/coffee/widget/radio_group.coffee
@@ -36,6 +36,7 @@ class RadioGroupView extends ContinuumView
     active = (i for radio, i in @$("input") when radio.checked)
     @mset('active', active[0])
     @model.save()
+    @mget('callback')?.execute(@model)
 
 class RadioGroup extends HasParent
   type: "RadioGroup"


### PR DESCRIPTION
This adds callbacks to all of the "AbstractGroup" widgets. It was only the Python AbstractGroup class that needed to be updated; the CoffeeScript was already set up to make the callbacks. I've tested the code in my #2715 issue on my own machine to verify that it works. 

contributing.md specifies that "We don't accept code contributions without tests" but I'm not sure how or where to do that, sorry, so if you'd like me to add them please point me in the right direction.

Fixes: Can't add callbacks to CheckboxGroups #2715 