### PR TITLE
Scroll to first row of selection in DataTable

### DIFF
--- a/bokeh/models/widgets/tables.py
+++ b/bokeh/models/widgets/tables.py
@@ -349,3 +349,9 @@ class DataTable(TableWidget):
     row_headers = Bool(True, help="""
     Enable or disable row headers, i.e. the index column.
     """)
+
+    scroll_to_selection = Bool(True, help="""
+    Whenever a selection is made on the data source, scroll the selected
+    rows into the table's viewport if none of the selected rows are already
+    in the viewport.
+    """)

--- a/bokehjs/src/coffee/widget/data_table.coffee
+++ b/bokehjs/src/coffee/widget/data_table.coffee
@@ -110,12 +110,19 @@ class DataTableView extends ContinuumView
     selected = @mget("source").get("selected")
     indices = selected['1d'].indices
     @grid.setSelectedRows(indices)
-    # Scroll datatable to start at the row before the first selected row,
-    # to immediately bring selections into view.
-    # TODO: should this be default behavior / configurable?
-    min_index = Math.max(0, Math.min.apply(null, indices) - 1)
-    # console.log("DataTableView::updateSelection", min_index, indices)
-    @grid.scrollRowToTop(min_index)
+    # If the selection is not in the current slickgrid viewport, scroll the
+    # datatable to start at the row before the first selected row, so that
+    # the selection is immediately brought into view. We don't scroll when
+    # the selection is already in the viewport so that selecting from the
+    # datatable itself does not re-scroll.
+    # console.log("DataTableView::updateSelection",
+    #             @grid.getViewport(), @grid.getRenderedRange())
+    cur_grid_range = @grid.getViewport()
+    if @mget("scroll_to_selection") and not _.any(_.map(indices, (index) ->
+        cur_grid_range["top"] <= index and index <= cur_grid_range["bottom"]))
+      # console.log("DataTableView::updateSelection", min_index, indices)
+      min_index = Math.max(0, Math.min.apply(null, indices) - 1)
+      @grid.scrollRowToTop(min_index)
 
   newIndexColumn: () ->
     return {
@@ -192,6 +199,7 @@ class DataTable extends HasProperties
       editable: false
       selectable: true
       row_headers: true
+      scroll_to_selection: true
     }
 
 module.exports =

--- a/bokehjs/src/coffee/widget/data_table.coffee
+++ b/bokehjs/src/coffee/widget/data_table.coffee
@@ -108,7 +108,14 @@ class DataTableView extends ContinuumView
 
   updateSelection: () ->
     selected = @mget("source").get("selected")
-    @grid.setSelectedRows(selected['1d'].indices)
+    indices = selected['1d'].indices
+    @grid.setSelectedRows(indices)
+    # Scroll datatable to start at the row before the first selected row,
+    # to immediately bring selections into view.
+    # TODO: should this be default behavior / configurable?
+    min_index = Math.max(0, Math.min.apply(null, indices) - 1)
+    # console.log("DataTableView::updateSelection", min_index, indices)
+    @grid.scrollRowToTop(min_index)
 
   newIndexColumn: () ->
     return {


### PR DESCRIPTION
Partially closes #2732

On a selection change, inform slickgrid to scroll to the [row
before the] first row of the selected values in the ColumnDataSource.
If the slickgrid table does not have enough rows to have a vertical scrollbar,
then this will do nothing, i.e. retain the current behavior.

Happy to make this more configurable, however I do feel that this is a more natural default then the current behavior.