### PR TITLE
Do not zoom if BoxZoomTool selects range <= 5 pixels

### DIFF
--- a/bokehjs/src/coffee/tool/gestures/box_zoom_tool.coffee
+++ b/bokehjs/src/coffee/tool/gestures/box_zoom_tool.coffee
@@ -37,12 +37,18 @@ class BoxZoomToolView extends GestureTool.View
 
     [vxlim, vylim] = @model._get_dim_limits(@_baseboint, curpoint, frame, dims)
     @_update(vxlim, vylim)
-    @mget('overlay').set('data', {})
 
+    @mget('overlay').set('data', {})
     @_baseboint = null
     return null
 
   _update: (vxlim, vylim) ->
+    # If the viewing window is too small, no-op: it is likely that the user did
+    # not intend to make this box zoom and instead was trying to cancel out of the
+    # zoom, a la matplotlib's ToolZoom. Like matplotlib, set the threshold at 5 pixels.
+    if Math.abs(vxlim[1] - vxlim[0]) <= 5 or Math.abs(vylim[1] - vylim[0]) <= 5
+      return
+
     xrs = {}
     for name, mapper of @plot_view.frame.get('x_mappers')
       [start, end] = mapper.v_map_from_target(vxlim, true)


### PR DESCRIPTION
As far as I know, there is no way to cancel out of a BoxZoomTool selection after the mouse is held down (and then there's no way to undo the zoom after the mouse is released). To get around this,
use the behavior of the zoom on other plotting tools like matplotlib: if either dimension of the range selection is <= 5 pixels, do not apply the zoom.

Happy to make this more configurable, however I do feel that this is a more natural default then the current behavior.