### PR TITLE
Remove 3.3 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: python
 
 python:
     - 2.7
-    - 3.3
     - 3.4
 
 env:

--- a/scripts/build_upload.sh
+++ b/scripts/build_upload.sh
@@ -96,7 +96,7 @@ echo "Removing first bokeh build at $first_build_loc"
 #########################
 
 # build for each python version
-for py in 27 33 34;
+for py in 27 34;
 do
     echo "Building py$py pkg"
     CONDA_PY=$py conda build conda.recipe --quiet


### PR DESCRIPTION
Since anaconda dropped support for 3.3, let do the same and make our testing and building tools faster than now :wink: