### PR TITLE
Restore method of sorting renderers and improve naming convention

### DIFF
--- a/bokehjs/src/coffee/common/plot.coffee
+++ b/bokehjs/src/coffee/common/plot.coffee
@@ -295,12 +295,14 @@ class PlotView extends ContinuumView
     indices = {}
     for renderer, i in @mget("renderers")
       indices[renderer.id] = i
-    sortKey = (renderer) -> indices[renderer.id]
+
+    sortKey = (renderer_view) -> indices[renderer_view.model.id]
 
     for level in levels
-      renderers = _.sortBy(_.values(@levels[level]), sortKey)
-      for renderer in renderers
-        renderer.render()
+      renderer_views = _.sortBy(_.values(@levels[level]), sortKey)
+
+      for renderer_view in renderer_views
+        renderer_view.render()
 
     ctx.restore()
 


### PR DESCRIPTION
Sorting was broken in PR #2393. This restores the original approach and improves naming convention, so that we explicitly see that we sort renderer views and not models.

I don't know what caused the original issue (#2365), but it doesn't seem to be renderer order dependent, see https://s3.amazonaws.com/bokeh-travis/0.9.1dev-5ce7a15-27-g25610e6/report.html (search for `sinerror`). There is a difference, but it's caused by an offset, so perhaps ranges are different.

fixes #2674