### PR TITLE
Use _.isUndefined() instead of ? when checking for undefined

### DIFF
--- a/bokehjs/src/coffee/common/properties.coffee
+++ b/bokehjs/src/coffee/common/properties.coffee
@@ -41,6 +41,7 @@ class Property extends HasProperties
       @validate(@fixed_value, @attr)
 
   value: () ->
+    # XXX: this `?' needs to be investigated for 0.10
     result = if @fixed_value? then @fixed_value else NaN
     return @transform([result])[0]
 

--- a/bokehjs/src/coffee/common/properties.coffee
+++ b/bokehjs/src/coffee/common/properties.coffee
@@ -24,7 +24,7 @@ class Property extends HasProperties
     if _.isObject(attr_value) and not _.isArray(attr_value)
       # use whichever the spec provides if there is a spec
       @spec = attr_value
-      if @spec.value?
+      if not _.isUndefined(@spec.value)
         @fixed_value = @spec.value
       else if @spec.field?
         @field = @spec.field

--- a/bokehjs/test/test_common/test_properties.coffee
+++ b/bokehjs/test/test_common/test_properties.coffee
@@ -20,9 +20,10 @@ describe "properties module", ->
   generate_source = () ->
     Collections('ColumnDataSource').create({data: {foo: [10, 20]}})
 
-  fixed = {a: 1}
-  spec_field = {a: {field: 'foo'}, b: 30}
-  spec_value = {a: {value: 2}}
+  fixed           = {a: 1}
+  spec_field      = {a: {field: 'foo'}, b: 30}
+  spec_value      = {a: {value: 2}}
+  spec_value_null = {a: {value: null}}
 
   describe "Property", ->
 
@@ -36,7 +37,6 @@ describe "properties module", ->
         new Properties.Property({obj: generate_obj({a: {field: 10}}), attr: 'a'})
       expect(fn).to.throw Error
 
-
     describe "value", ->
       it "should return a fixed value if there is one on the object", ->
         prop = new Properties.Property({obj: generate_obj(fixed), attr: 'a'})
@@ -45,6 +45,11 @@ describe "properties module", ->
       it "should return a fixed value if there is a value spec", ->
         prop = new Properties.Property({obj: generate_obj(spec_value), attr: 'a'})
         expect(prop.value()).to.be.equal 2
+
+      it "should allow a fixed null value", ->
+        prop = new Properties.Property({obj: generate_obj(spec_value_null), attr: 'a'})
+        # XXX: expect(prop.value()).to.be.equal null
+        expect(prop.value()).to.be.NaN
 
       it "should return NaN otherwise", ->
         prop = new Properties.Property({obj: generate_obj(fixed), attr: 'b'})


### PR DESCRIPTION
The `?` operator in coffeescript treats `null` and `undefined` the same, so when we want to distinguish between those values and ask only if a property exists (but allow it to have `null` value), then we need to use `_.isUndefined()` instead.

Also, this entire module should be reexamined, as there might be more cases like this.

fixes #2664