### PR TITLE
Disable canteen and xfail integration test

### DIFF
--- a/bokehjs/src/coffee/common/canvas.coffee
+++ b/bokehjs/src/coffee/common/canvas.coffee
@@ -6,7 +6,9 @@ ContinuumView = require "./continuum_view"
 LayoutBox = require "./layout_box"
 {logger} = require "./logging"
 Solver = require "./solver"
-require 'Canteen'
+
+# TODO - This should only be on in testing
+#require 'Canteen'
 
 class CanvasView extends ContinuumView
   className: "bk-canvas-wrapper"

--- a/bokehjs/src/coffee/common/plot.coffee
+++ b/bokehjs/src/coffee/common/plot.coffee
@@ -283,7 +283,9 @@ class PlotView extends ContinuumView
     if not @initial_range_info?
       @set_initial_range()
 
-    @$el.find('canvas').attr('data-hash', ctx.hash());
+    # TODO - This should only be on in testing
+    # @$el.find('canvas').attr('data-hash', ctx.hash());
+    
 
   _render_levels: (ctx, levels, clip_region) ->
     ctx.save()

--- a/tests/integration/file/test_tap.py
+++ b/tests/integration/file/test_tap.py
@@ -27,6 +27,7 @@ def click_glyph_at_position(selenium, element, x, y):
     actions.perform()
 
 
+@pytest.mark.xfail(reason='Canteen is currently disabled')
 def test_select_rectangle_glyph(output_file_url, selenium):
 
     save(make_plot('tap'))
@@ -42,7 +43,7 @@ def test_select_rectangle_glyph(output_file_url, selenium):
     # Click right
     click_glyph_at_position(selenium, canvas, 750, 400)
     wait.until(value_to_be_present_in_datahash(canvas, '36d1329732f484e483d48eac88434828'))
-    # CLick off glyph to reset plot 
+    # CLick off glyph to reset plot
     # TODO: why isn't this the same as first hash?
     click_glyph_at_position(selenium, canvas, 0, 0)
     wait.until(value_to_be_present_in_datahash(canvas, '1ea37ccb5cfbc9146bf50764a423bcc9'))


### PR DESCRIPTION
Canteen is a performance bottleneck and should only be running in test
environment. This commit disables it globally and xfails the integration test
that expects it to be present.

This is a short-term measure while we work on a better solution to enable it
only for testing.