### PR TITLE
change image_url onload callback to render request

### DIFF
--- a/bokehjs/src/coffee/renderer/glyph/image_url.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/image_url.coffee
@@ -27,18 +27,7 @@ class ImageURLView extends Glyph.View
           return () =>
             @loaded[i] = true
             image[i] = img
-            ctx.save()
-            ctx.beginPath()
-            # TODO should take the real axis rule width into account, for now shrink region by 1 px
-            frame = @renderer.plot_view.frame
-            # use bottom here because frame is view coords
-            ctx.rect(
-              frame.get('left')+1, frame.get('bottom')+1,
-              frame.get('width')-2, frame.get('height')-2,
-            )
-            ctx.clip()
-            @_render_image(ctx, i, image[i], sx, sy, sw, sh, angle)
-            ctx.restore()
+            @renderer.request_render()
 
         img.src = url[i]
         need_load[i] = false
@@ -64,6 +53,7 @@ class ImageURLView extends Glyph.View
     anchor = @mget('anchor') or "top_left"
     [sx, sy] = @_final_sx_sy(anchor, sx[i], sy[i], sw[i], sh[i])
 
+    ctx.save()
     if angle[i]
       ctx.translate(sx, sy)
       ctx.rotate(angle[i])
@@ -72,6 +62,7 @@ class ImageURLView extends Glyph.View
       ctx.translate(-sx, -sy)
     else
       ctx.drawImage(image, sx, sy, sw[i], sh[i])
+    ctx.restore()
 
 class ImageURL extends Glyph.Model
   default_view: ImageURLView


### PR DESCRIPTION
issues: fixes #2785 

Current behavior unconditionally renders the image as part of the onload callback. This changes the render to a render_request, which uses the whole bokeh render sequence.

Question: Is it worth adding any sort of logic in the case of a 404 for the image?