### PR TITLE
Re-enable UI behaviors on bokeh-server index page.

### DIFF
--- a/bokeh/server/templates/bokeh.html
+++ b/bokeh/server/templates/bokeh.html
@@ -4,6 +4,12 @@
 Bokeh Plot Server
 {% endblock %}
 
+{# Needed for index page UI behaviors (so divs aren't stuck collapsed). #}
+{% block extra_scripts %}
+<script src="{{ url_for('static', filename='jquery.min.js') }}"></script>
+<script src="{{ url_for('static', filename='bootstrap/js/bootstrap.min.js') }}"></script>
+{% endblock %}
+
 {% block script %}
 Bokeh.embed.server_page();
 {% endblock %}


### PR DESCRIPTION
Fixes #2787, and by the sound of it, a lot of other open issues.

The problem boiled down to the removal of jQuery and Bootstrap JS files from the `_base.html` template, which had the unintended side effect of removing them from inclusion on the index page.

This didn't affect code using e.g. `Bokeh.$(...)` but the index page (rendered by template `bokeh.html`) relies on the third-party versions being loaded as all of that stuff seems to be driven by some combination
of those two JS files and CSS classes attached to elements.

It turns out the `_page_base.html` template already has a slot for things like this so I've shoved these includes inside the existing `extra_scripts` block from within `bokeh.html`.