### PR TITLE
Pin ipython and ipython notebook to 3.2.1

### DIFF
--- a/scripts/travis_install
+++ b/scripts/travis_install
@@ -15,7 +15,8 @@ rm -rf $MINICONDA.sh
 python -V
 
 PINNED_PKGS=$(cat <<EOF
-
+ipython ==3.2.1
+ipython-notebook ==3.2.1
 EOF
 )
 echo -e "$PINNED_PKGS" > /home/travis/miniconda/conda-meta/pinned


### PR DESCRIPTION
To enable the test machinery. This is a temporary fix, we need to address the Jupyter update in a general way...