### PR TITLE
Fix bug in LinearColorMapper.build_palette.

### DIFF
--- a/bokehjs/src/coffee/mapper/linear_color_mapper.coffee
+++ b/bokehjs/src/coffee/mapper/linear_color_mapper.coffee
@@ -70,12 +70,14 @@ class LinearColorMapper extends HasProperties
 
   _build_palette: (palette) ->
     new_palette = new Uint32Array(palette.length+1)
-    for i in [0...palette.length]
-      if _.isNumber(palette[i])
-        new_palette[i] = palette[i]
+    _convert = (value) ->
+      if _.isNumber(value)
+        return value
       else
-        new_palette[i] = parseInt(palette[i].slice(1), 16)
-    new_palette[new_palette.length-1] = palette[palette.length-1]
+        return parseInt(value.slice(1), 16)
+    for i in [0...palette.length]
+      new_palette[i] = _convert(palette[i])
+    new_palette[new_palette.length-1] = _convert(palette[palette.length-1])
     return new_palette
 
 module.exports =


### PR DESCRIPTION
Fixes #2801, by correctly converting non-number values for the last value of the passed in palette when assigning to the last entry in the new palette.

Note that I am unclear on why extending the palette by one entry is necessary in the first place. It seems like a better solution to just make `new_palette.length` equal to `palette.length`, and delete the offending line after the loop.