### PR TITLE
Task/build fixes

### DIFF
--- a/scripts/build_upload.sh
+++ b/scripts/build_upload.sh
@@ -187,8 +187,7 @@ popd
 pushd bokehjs
 
 if [[ -z "$travis_build_id" ]]; then
-    npm publish --tag $complete_version
-    npm tag bokehjs@$complete_version latest
+    npm publish
     echo "I'm done publishing to npmjs.org"
 fi
 

--- a/scripts/build_upload.sh
+++ b/scripts/build_upload.sh
@@ -164,7 +164,7 @@ pushd sphinx
 # being explicit to pass the correct version
 # Note: we need to override the version here to avoid being bitten by the
 # __version__ used from the first build (by travis_install)
-BOKEH_LOCAL_DOCS_CDN=$complete_version BOKEH_DOCS_VERSION=$complete_version make clean all
+BOKEH_DOCS_CDN=$complete_version BOKEH_DOCS_VERSION=$complete_version make clean all
 
 # to the correct location
 if [[ -z "$travis_build_id" ]]; then

--- a/sphinx/source/docs/dev_guide/notes.rst
+++ b/sphinx/source/docs/dev_guide/notes.rst
@@ -17,10 +17,11 @@ There are several environment variables that can be useful for developers:
     Valid values are any of the browser names understood by the python
     standard library webbrowser_ module.
 
-* ``BOKEH_LOCAL_DOCS_CDN`` --- What version of BokehJS to use when building  sphinx docs locally.
+* ``BOKEH_DOCS_CDN`` --- What version of BokehJS to use when building sphinx
+    docs locally.
 
-* ``BOKEH_RELEASED_DOCS`` --- Whether to use the x.x.x version for re-deployment of the docs.
-    Accepted values are ``yes``/``no``, ``true``/``false`` or ``0``/``1``.
+* ``BOKEH_DOCS_VERSION`` --- What version of Bokeh to show when building sphinx
+    docs locally. Useful for re-deployment purposes.
 
 * ``BOKEH_LOG_LEVEL`` --- The BokehJS console logging level to use
     Valid values are, in order of increasing severity:


### PR DESCRIPTION
This one:
    * Use the correct env variable to build the docs properly
    * Fix the npm publishing command because right now you can not tag with semver versions