### PR TITLE
Fix regex to take 0.10.0 versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ matrix:
 branches:
   only:
     - master
-    - /^\d.\d.\ddev-.+$/
-    - /^\d.\d.\drc-.+$/
-    - /^\d.\d.\d$/
+    - /^\d+.\d+.\d+dev-.+$/
+    - /^\d+.\d+.\d+rc-.+$/
+    - /^\d+.\d+.\d+$/
 
 before_install:
     - export PATH="$HOME/miniconda/bin:$PATH"


### PR DESCRIPTION
Fixed regex to enable builds with versions containing more than on digit in the server scheme 