### PR TITLE
Better names for the devel builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,8 +76,8 @@ after_success:
           echo "devel" > __travis_job_id__.txt
         else
           echo "Building a release package."
-          #we signal the release with an empty __travis_job_id__.txt file
-          echo "" > __travis_job_id__.txt
+          #we signal the release with an the "release" string into the __travis_job_id__.txt file
+          echo "release" > __travis_job_id__.txt
         fi
         bash scripts/build_upload.sh -b $BINSTAR_TOKEN -u $RSUSER -k $RSAPIKEY
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,10 @@ branches:
 before_install:
     - export PATH="$HOME/miniconda/bin:$PATH"
     - echo $TRAVIS_JOB_ID > __travis_job_id__.txt
+    - echo $TRAVIS_BUILD_ID
+    - echo $TRAVIS_BUILD_NUMBER
+    - echo $TRAVIS_JOB_ID
+    - echo $TRAVIS_JOB_NUMBER
     - nvm install stable
     - nvm use stable
     # Use xvfb to run tests that require firefox

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ branches:
 
 before_install:
     - export PATH="$HOME/miniconda/bin:$PATH"
-    - echo $TRAVIS_BUILD_ID > __travis_build_id__.txt
+    - echo $TRAVIS_JOB_ID > __travis_job_id__.txt
     - nvm install stable
     - nvm use stable
     # Use xvfb to run tests that require firefox
@@ -74,8 +74,8 @@ after_success:
           echo "Building a dev or rc package."
         else
           echo "Building a release package."
-          #we signal the release with an empty __travis_build_id__.txt file
-          echo "" > __travis_build_id__.txt
+          #we signal the release with an empty __travis_job_id__.txt file
+          echo "" > __travis_job_id__.txt
         fi
         bash scripts/build_upload.sh -b $BINSTAR_TOKEN -u $RSUSER -k $RSAPIKEY
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,7 @@ branches:
 
 before_install:
     - export PATH="$HOME/miniconda/bin:$PATH"
-    - echo $TRAVIS_JOB_ID > __travis_job_id__.txt
-    - echo $TRAVIS_BUILD_ID
-    - echo $TRAVIS_BUILD_NUMBER
-    - echo $TRAVIS_JOB_ID
-    - echo $TRAVIS_JOB_NUMBER
+    - echo $TRAVIS_BUILD_NUMBER > __travis_build_number__.txt
     - nvm install stable
     - nvm use stable
     # Use xvfb to run tests that require firefox
@@ -76,12 +72,12 @@ after_success:
         #signal the correct build
         if [[ "$TRAVIS_TAG" == *"dev"* ]] || [[ "$TRAVIS_TAG" == *"rc"* ]]; then
           echo "Building a dev or rc package."
-          #we signal the devel build with the "devel" string into the __travis_job_id__.txt file
-          echo "devel" > __travis_job_id__.txt
+          #we signal the devel build with the "devel" string into the __travis_build_number__.txt file
+          echo "devel" > __travis_build_number__.txt
         else
           echo "Building a release package."
-          #we signal the release with an the "release" string into the __travis_job_id__.txt file
-          echo "release" > __travis_job_id__.txt
+          #we signal the release with an the "release" string into the __travis_build_number__.txt file
+          echo "release" > __travis_build_number__.txt
         fi
         bash scripts/build_upload.sh -b $BINSTAR_TOKEN -u $RSUSER -k $RSAPIKEY
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,8 @@ after_success:
         #signal the correct build
         if [[ "$TRAVIS_TAG" == *"dev"* ]] || [[ "$TRAVIS_TAG" == *"rc"* ]]; then
           echo "Building a dev or rc package."
+          #we signal the devel build with the "devel" string into the __travis_job_id__.txt file
+          echo "devel" > __travis_job_id__.txt
         else
           echo "Building a release package."
           #we signal the release with an empty __travis_job_id__.txt file

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -10,17 +10,17 @@ pushd $SRC_DIR
 
 version=`$PYTHON scripts/get_bump_version.py`
 
-if [ -e "__travis_build_id__.txt" ]; then
-    travis_build_id=$(cat __travis_build_id__.txt)
-    if [[ -z "$travis_build_id" ]]; then
+if [ -e "__travis_job_id__.txt" ]; then
+    travis_job_id=$(cat __travis_job_id__.txt)
+    if [[ -z "$travis_job_id" ]]; then
         # for releases we just need the tag
         echo $version > __conda_version__.txt
     else
-        # for devel builds we also need the travis_build__id
-        echo $version.$travis_build_id > __conda_version__.txt
+        # for devel builds we also need the travis_job__id
+        echo $version.$travis_job_id > __conda_version__.txt
     fi
 else
-    # for local building we don't have the travis_build__id
+    # for local building we don't have the travis_job__id
     echo $version > __conda_version__.txt
 fi
 

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -15,8 +15,11 @@ if [ -e "__travis_job_id__.txt" ]; then
     if [[ -z "$travis_job_id" ]]; then
         # for releases we just need the tag
         echo $version > __conda_version__.txt
+    elif [[ "$travis_job_id" == "devel" ]]; then
+        # for devel build we just need the tag
+        echo $version > __conda_version__.txt
     else
-        # for devel builds we also need the travis_job__id
+        # for the testing machinery we also need the travis_job__id
         echo $version.$travis_job_id > __conda_version__.txt
     fi
 else

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -12,11 +12,8 @@ version=`$PYTHON scripts/get_bump_version.py`
 
 if [ -e "__travis_job_id__.txt" ]; then
     travis_job_id=$(cat __travis_job_id__.txt)
-    if [[ -z "$travis_job_id" ]]; then
-        # for releases we just need the tag
-        echo $version > __conda_version__.txt
-    elif [[ "$travis_job_id" == "devel" ]]; then
-        # for devel build we just need the tag
+    if [[ "$travis_job_id" == "release" || "$travis_job_id" == "devel" ]]; then
+        # for releases and devel builds we just need the tag
         echo $version > __conda_version__.txt
     else
         # for the testing machinery we also need the travis_job__id

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -10,17 +10,17 @@ pushd $SRC_DIR
 
 version=`$PYTHON scripts/get_bump_version.py`
 
-if [ -e "__travis_job_id__.txt" ]; then
-    travis_job_id=$(cat __travis_job_id__.txt)
-    if [[ "$travis_job_id" == "release" || "$travis_job_id" == "devel" ]]; then
+if [ -e "__travis_build_number__.txt" ]; then
+    travis_build_number=$(cat __travis_build_number__.txt)
+    if [[ "$travis_build_number" == "release" || "$travis_build_number" == "devel" ]]; then
         # for releases and devel builds we just need the tag
         echo $version > __conda_version__.txt
     else
-        # for the testing machinery we also need the travis_job__id
-        echo $version.$travis_job_id > __conda_version__.txt
+        # for the testing machinery we also need the travis_build_number
+        echo $version.$travis_build_number > __conda_version__.txt
     fi
 else
-    # for local building we don't have the travis_job__id
+    # for local building we don't have the travis_build_number
     echo $version > __conda_version__.txt
 fi
 

--- a/scripts/build_upload.sh
+++ b/scripts/build_upload.sh
@@ -63,22 +63,22 @@ CONDA_ENV=$(conda_info root_prefix)
 PLATFORM=$(conda_info platform)
 BUILD_PATH=$CONDA_ENV/conda-bld/$PLATFORM
 
-# create an empty __travis_job_id__.txt file if you are building locally
+# create an empty __travis_build_number__.txt file if you are building locally
 if [ $local == true ]; then
-    echo "" > __travis_job_id__.txt
+    echo "" > __travis_build_number__.txt
 fi
 
-# get travis_job_id
-travis_job_id=$(cat __travis_job_id__.txt)
+# get travis_build_number
+travis_build_number=$(cat __travis_build_number__.txt)
 
 # specify some varibles specific of the release or devel build process
-if [[ "$travis_job_id" == "release" ]]; then
+if [[ "$travis_build_number" == "release" ]]; then
     #release
     channel=main              #anaconda.org channel
     register=register         #register to pypi
     upload=upload             #upload to pypi
     subdir=release            #CDN subdir where to upload the js and css
-elif [[ "$travis_job_id" == "devel" ]]; then
+elif [[ "$travis_build_number" == "devel" ]]; then
     #devel build
     channel=dev               #anaconda.org channel
     register=""               #register to pypi
@@ -167,11 +167,11 @@ pushd sphinx
 BOKEH_DOCS_CDN=$complete_version BOKEH_DOCS_VERSION=$complete_version make clean all
 
 # to the correct location
-if [[ "$travis_job_id" == "release" ]]; then
+if [[ "$travis_build_number" == "release" ]]; then
     fab deploy:$complete_version
     fab latest:$complete_version
     echo "I'm done uploading the release docs"
-elif [[ "$travis_job_id" == "devel" ]]; then
+elif [[ "$travis_build_number" == "devel" ]]; then
     fab deploy:dev
     echo "I'm done uploading the devel docs"
 fi
@@ -184,7 +184,7 @@ popd
 
 pushd bokehjs
 
-if [[ "$travis_job_id" == "release" ]]; then
+if [[ "$travis_build_number" == "release" ]]; then
     npm publish
     echo "I'm done publishing to npmjs.org"
 fi

--- a/scripts/build_upload.sh
+++ b/scripts/build_upload.sh
@@ -63,16 +63,16 @@ CONDA_ENV=$(conda_info root_prefix)
 PLATFORM=$(conda_info platform)
 BUILD_PATH=$CONDA_ENV/conda-bld/$PLATFORM
 
-# create an empty __travis_build_id__.txt file if you are building locally
+# create an empty __travis_job_id__.txt file if you are building locally
 if [ $local == true ]; then
-    echo "" > __travis_build_id__.txt
+    echo "" > __travis_job_id__.txt
 fi
 
-# get travis_build_id
-travis_build_id=$(cat __travis_build_id__.txt)
+# get travis_job_id
+travis_job_id=$(cat __travis_job_id__.txt)
 
 # specify some varibles specific of the release or devel build process
-if [[ -z "$travis_build_id" ]]; then
+if [[ -z "$travis_job_id" ]]; then
     #release
     channel=main              #anaconda.org channel
     register=register         #register to pypi
@@ -103,7 +103,7 @@ do
 done
 
 # convert to platform-specific builds
-conda convert -p all -f $BUILD_PATH/bokeh*$travis_build_id*.tar.bz2 --quiet
+conda convert -p all -f $BUILD_PATH/bokeh*$travis_job_id*.tar.bz2 --quiet
 echo "pkgs converted"
 
 # upload conda pkgs to anaconda.org
@@ -111,7 +111,7 @@ platforms=(osx-64 linux-64 win-64 linux-32 win-32)
 for plat in "${platforms[@]}"
 do
     echo Uploading: $plat
-    anaconda -t $bintoken upload -u bokeh $plat/bokeh*$travis_build_id*.tar.bz2 -c $channel --force --no-progress
+    anaconda -t $bintoken upload -u bokeh $plat/bokeh*$travis_job_id*.tar.bz2 -c $channel --force --no-progress
 done
 
 # create, register and upload pypi pkgs to pypi and anaconda.org
@@ -122,7 +122,7 @@ if [[ ! -z "$upload" ]]; then
     echo "I'm done uploading to pypi"
 fi
 
-anaconda -t $bintoken upload -u bokeh dist/bokeh*$travis_build_id*.tar.gz --package-type pypi -c $channel --force --no-progress
+anaconda -t $bintoken upload -u bokeh dist/bokeh*$travis_job_id*.tar.gz --package-type pypi -c $channel --force --no-progress
 echo "I'm done uploading to anaconda.org"
 
 ###########################
@@ -167,7 +167,7 @@ pushd sphinx
 BOKEH_DOCS_CDN=$complete_version BOKEH_DOCS_VERSION=$complete_version make clean all
 
 # to the correct location
-if [[ -z "$travis_build_id" ]]; then
+if [[ -z "$travis_job_id" ]]; then
     fab deploy:$complete_version
     fab latest:$complete_version
     echo "I'm done uploading the release docs"
@@ -178,15 +178,13 @@ fi
 
 popd
 
-
-
 ######################
 # Publish to npm.org #
 ######################
 
 pushd bokehjs
 
-if [[ -z "$travis_build_id" ]]; then
+if [[ -z "$travis_job_id" ]]; then
     npm publish
     echo "I'm done publishing to npmjs.org"
 fi

--- a/scripts/build_upload.sh
+++ b/scripts/build_upload.sh
@@ -72,13 +72,13 @@ fi
 travis_job_id=$(cat __travis_job_id__.txt)
 
 # specify some varibles specific of the release or devel build process
-if [[ -z "$travis_job_id" ]]; then
+if [[ "$travis_job_id" == "release" ]]; then
     #release
     channel=main              #anaconda.org channel
     register=register         #register to pypi
     upload=upload             #upload to pypi
     subdir=release            #CDN subdir where to upload the js and css
-else
+elif [[ "$travis_job_id" == "devel" ]]; then
     #devel build
     channel=dev               #anaconda.org channel
     register=""               #register to pypi
@@ -103,7 +103,7 @@ do
 done
 
 # convert to platform-specific builds
-conda convert -p all -f $BUILD_PATH/bokeh*$travis_job_id*.tar.bz2 --quiet
+conda convert -p all -f $BUILD_PATH/bokeh*.tar.bz2 --quiet
 echo "pkgs converted"
 
 # upload conda pkgs to anaconda.org
@@ -111,7 +111,7 @@ platforms=(osx-64 linux-64 win-64 linux-32 win-32)
 for plat in "${platforms[@]}"
 do
     echo Uploading: $plat
-    anaconda -t $bintoken upload -u bokeh $plat/bokeh*$travis_job_id*.tar.bz2 -c $channel --force --no-progress
+    anaconda -t $bintoken upload -u bokeh $plat/bokeh*.tar.bz2 -c $channel --force --no-progress
 done
 
 # create, register and upload pypi pkgs to pypi and anaconda.org
@@ -122,7 +122,7 @@ if [[ ! -z "$upload" ]]; then
     echo "I'm done uploading to pypi"
 fi
 
-anaconda -t $bintoken upload -u bokeh dist/bokeh*$travis_job_id*.tar.gz --package-type pypi -c $channel --force --no-progress
+anaconda -t $bintoken upload -u bokeh dist/bokeh*.tar.gz --package-type pypi -c $channel --force --no-progress
 echo "I'm done uploading to anaconda.org"
 
 ###########################
@@ -167,11 +167,11 @@ pushd sphinx
 BOKEH_DOCS_CDN=$complete_version BOKEH_DOCS_VERSION=$complete_version make clean all
 
 # to the correct location
-if [[ -z "$travis_job_id" ]]; then
+if [[ "$travis_job_id" == "release" ]]; then
     fab deploy:$complete_version
     fab latest:$complete_version
     echo "I'm done uploading the release docs"
-else
+elif [[ "$travis_job_id" == "devel" ]]; then
     fab deploy:dev
     echo "I'm done uploading the devel docs"
 fi
@@ -184,7 +184,7 @@ popd
 
 pushd bokehjs
 
-if [[ -z "$travis_job_id" ]]; then
+if [[ "$travis_job_id" == "release" ]]; then
     npm publish
     echo "I'm done publishing to npmjs.org"
 fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,7 +6,7 @@ if [ "$1" == "-h" ]; then
 
     where:
         -h     show this help text
-        -d     devel build tag in the form X.X.Xdev[rc]
+        -d     devel build tag in the form X.X.X[dev]/[rc]number, ie: 0.10.0dev1
         -p     previous tag in the form X.X.X (for releases)
         -r     proposed new tag in the form X.X.X (for releases)
     "
@@ -62,16 +62,20 @@ if [[ -z "$dtag" && ! -z "$ptag" && ! -z "$rtag" ]]; then
 elif [[ ! -z "$dtag" && -z "$ptag" && -z "$rtag" ]]; then
     echo "You have triggered the devel build process"
 
-    # get the HEAD commit hash
-    commit=`git rev-parse --short HEAD`
-    completetag=$dtag-$commit
-    echo "The complete devel[rc] tag will be" $completetag
+    # check the tag
+    taglist=`git tag --list --sort=version:refname`
+    tagarray=($taglist)
+    lasttag=${tagarray[-1]}
+    if [[ "$lasttag" == "$dtag" ]]; then
+        echo "The latest tag detected is $lasttag and you are trying to use the same tag, please bump your dev/rc tag."
+        exit 1
+    fi
 
-    # and tag it locally
-    git tag -a $completetag -m "New devel[rc] build $completetag."
+    # tag it locally
+    git tag -a $dtag -m "New devel[rc] build $dtag."
 
     # and push the tag
-    git push origin $completetag
+    git push origin $dtag
     echo "The new devel build was triggered."
 
 else


### PR DESCRIPTION
Using `TRAVIS_JOB_ID` to have smaller number than now... BUT also changing to a tag-based name for devel builds... so the `TRAVIS_JOB_ID` is only relevant for the testing machinery without conflicting with conda...