### PR TITLE
Trying to use phosphor boxpanel for our hbox/vbox

### DIFF
--- a/bokehjs/gulp/tasks/scripts.coffee
+++ b/bokehjs/gulp/tasks/scripts.coffee
@@ -17,8 +17,9 @@ gulp.task "scripts:build", ->
     entries: ['./src/coffee/main.coffee']
     extensions: [".coffee", ".eco"]
     debug: true
-
+  
   browserify opts
+    .transform("browserify-css", {'global': true, 'minify':true})
     .transform "browserify-eco"
     .transform "coffeeify"
     .bundle()

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -21,6 +21,7 @@
     "browserify": "^6.2.0",
     "browserify-eco": "^0.2.4",
     "browserify-shim": "^3.8.0",
+    "browserify-css": "*",
     "Canteen": "git+https://github.com/platfora/Canteen.git#f1182e3396e76e0acb32849823ac4b4f404d6a72",
     "chai": "^2.2.0",
     "cheerio": "^0.19.0",
@@ -53,7 +54,10 @@
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "vinyl-transform": "^1.0.0",
-    "yargs": "^3.11.0"
+    "yargs": "^3.11.0",
+    "phosphor-widget": "*",
+    "phosphor-messaging": "*",
+    "phosphor-boxpanel": "*"
   },
   "browserify": {
     "extensions": [

--- a/bokehjs/src/coffee/widget/hbox.coffee
+++ b/bokehjs/src/coffee/widget/hbox.coffee
@@ -2,13 +2,26 @@ _ = require "underscore"
 build_views = require "../common/build_views"
 ContinuumView = require "../common/continuum_view"
 HasParent = require "../common/has_parent"
+boxpanel = require "phosphor-boxpanel"
+widget = require "phosphor-widget"
+messaging = require "phosphor-messaging"
 
 class HBoxView extends ContinuumView
-  tag: "div"
-  attributes:
-    class: "bk-hbox"
+  #tag: "div"
+  #attributes:
+  #  class: "bk-hbox"
 
   initialize: (options) ->
+    window.box = this
+    @panel = new boxpanel.BoxPanel()
+    @panel.direction = boxpanel.BoxPanel.LeftToRight
+    @panel.node.style.width = '100%'
+    @panel.node.style.height = '100%'
+    @panel.node.style.position = 'absolute'
+    @el.appendChild(@panel.node)
+    # simulate widget.attachWidget(@panel, @el), but allow @el to be unbound to DOM
+    messaging.sendMessage(@panel, widget.MSG_AFTER_ATTACH)
+    
     super(options)
     @views = {}
     @render()
@@ -19,13 +32,22 @@ class HBoxView extends ContinuumView
     build_views(@views, children)
     for own key, val of @views
       val.$el.detach()
-    @$el.empty()
     width = @mget("width")
     if width? then @$el.css(width: width + "px")
     height = @mget("height")
     if height? then @$el.css(height: height + "px")
-    for child in children
-      @$el.append(@views[child.id].$el)
+    if true
+      @panel.clearChildren()
+      for child in children
+        w = new widget.Widget()
+        boxpanel.BoxPanel.setStretch(w, 0)
+        w.node.appendChild(@views[child.id].$el[0])
+        @panel.addChild(w)
+      @panel.update()
+    else
+      @$el.empty()
+      for child in children
+        @$el.append(@views[child.id].$el)
 
     return @
 

--- a/examples/plotting/file/clustering.py
+++ b/examples/plotting/file/clustering.py
@@ -17,8 +17,9 @@ from sklearn.preprocessing import StandardScaler
 
 from bokeh.plotting import figure, show, output_file
 from bokeh.models import HBox, VBox
+from bokeh.models.widgets import Slider
 
-N = 50000
+N = 500
 PLOT_SIZE = 400
 
 # Generate datasets. 
@@ -60,7 +61,10 @@ for i_dataset, dataset in enumerate([noisy_circles, noisy_moons, blobs1, blobs2]
     p.scatter(X[:, 0], X[:, 1], color=colors[y_pred].tolist(), alpha=0.1,)
     plots.append(p)
 
+slider = Slider(start=1, end=20, value=4, step=1, title="Order:")
+
 # Genearate and show the plot
-box = VBox(HBox(plots[0], plots[1]), HBox(plots[2], plots[3]))
+box = HBox(plots[0], slider, plots[1])
+# box = VBox(HBox(plots[0], slider, plots[1]), HBox(plots[2], plots[3]))
 output_file("clustering.html", title="clustering with sklearn")
 show(box)


### PR DESCRIPTION
I've been trying to swap out Bokeh's vbox/hbox with phosphor's BoxPanel, but this does not really work. Have been discussing this with @sccolbert and the point is that for things to work well, we need all widgets to be phosphor widgets (even if they're just thin wrappers). I also think the current hbox and vbox should be done as a flexbox (which can be via a new FlexPanel phosphor widget).

So this would be a process that would take some more time and planning.

----

I wrote down some of the problems that I ran into before talking to Chris. Most can be explained by the above, though the last point may need some thoughts.

Problems:
* See the first image below. The width of the screen is divided in three equal bins, and the slider stretches to take all available space (as it should). The plots have a fixed size, so they do not scale along. It would be nice if Bokeh plots could be told to take all space they have available, though we can add that later. The plots do not align to the center, however, and if we enforce that (`text-align:center`) as I tried for the plot on the right, things go wrong. This might be fixable with the appropriate CSS.
* The second image below shows that the slider needs less space than a plot (obviously) but the boxpanel cannot be aware of its natural size. This can be remedied by setting the max-size of the phosphor-container-widget, but we don't want our users to have to set this, which implies, I think, that *we'd need all our widgets to be defined/wrapped in phosphor widgets for this to work*.
* Even if I set the max-height of the widget that wraps the slider in the second example, this does not affect the distribution of the content, though this can probably be fixed in phosphor itself.
* And even then ... Phosphor works with absolute positioning, in this case it uses the full vertical space as the "work area", which is good, because Phosphor wants to be like a desktop GUI system. However, *Bokeh is currently expecting the page to be a "document"*, with infinite space in the vertical direction. Thus the clipping. (Also related to my point above that Bokeh plots do not scale to the available space, which would be more desktop-like.)

![screenshot from 2015-09-16 15 34 18](https://cloud.githubusercontent.com/assets/3015475/9906000/710ae60e-5c88-11e5-9eb9-addce59786fb.png)

![screenshot from 2015-09-16 15 20 38](https://cloud.githubusercontent.com/assets/3015475/9905737/fac56632-5c86-11e5-849c-67a44b08bd2a.png)
