### PR TITLE
Wrap testing import so testing libraries aren't required.

### DIFF
--- a/bokeh/__init__.py
+++ b/bokeh/__init__.py
@@ -24,4 +24,8 @@ del logconfig
 # module as transitive imports
 
 from . import sampledata; sampledata
-from .util.testing import runtests as test; test
+
+
+def test(args=None):
+    from .util.testing import runtests
+    return runtests(args)


### PR DESCRIPTION
Without this, the move of a bunch of utils into util.testing
combined with with the reference to util.testing in bokeh.__init__
meant that users would need a bunch of testing dependencies installed
just to run bokeh!