### PR TITLE
testing addopts are note recognized with listed dependencies installed

### DIFF
--- a/sphinx/source/docs/dev_guide/building.rst
+++ b/sphinx/source/docs/dev_guide/building.rst
@@ -198,6 +198,7 @@ Testing dependencies include the following additional libraries:
 * mock
 * coverage
 * websocket-client
+* pytest-selenium >= 1.0
 
 .. This comment is just here to fix a weird Sphinx formatting bug
 


### PR DESCRIPTION
It seems that I cannot run the tests locally with these two ``addopts``, even though the packages listed as dependencies [1] are installed. 

```
bsipocz@tegla2:~/munka/devel/bokeh$ py.test -m 'not (js or examples)'
usage: py.test [options] [file_or_dir] [file_or_dir] [...]
py.test: error: unrecognized arguments: --driver=Firefox --sensitive-url=None
```

[1] http://bokeh.pydata.org/en/latest/docs/dev_guide/building.html#dependencies
