### PR TITLE
#2904 - fixed a bug editing a sorted or filtered datatable

### DIFF
--- a/bokehjs/src/coffee/widget/data_table.coffee
+++ b/bokehjs/src/coffee/widget/data_table.coffee
@@ -21,26 +21,28 @@ class DataProvider
 
   getLength: () -> @source.get_length()
 
-  getItem: (index) ->
-    item = {index: index}
+  getItem: (offset) ->
+    item = {}
     for field in @fields
-      item[field] = @data[field][index]
+      item[field] = @data[field][offset]
     return item
 
-  _setItem: (index, item) ->
+  _setItem: (offset, item) ->
     for field, value of item
-      @data[field][index] = value
+      @data[field][offset] = value
     return
 
-  setItem: (index, item) ->
-    @_setItem(index, item)
+  setItem: (offset, item) ->
+    @_setItem(offset, item)
     @updateSource()
 
   getField: (index, field) ->
-    return @data[field][index]
+    offset = @data["index"].indexOf(index)
+    return @data[field][offset]
 
   _setField: (index, field, value) ->
-    @data[field][index] = value
+    offset = @data["index"].indexOf(index)
+    @data[field][offset] = value
     return
 
   setField: (index, field, value) ->


### PR DESCRIPTION
#2904 - fixed a bug when a table was sorted by a column other than the index then edited.

supersede #2906 

This changes the semantics of getItem/setItem to use an offset into the data array, while getField/setField still take an item index.  The index and the offset will be the same for a data array that is sorted by the index field and has not been filtered.