### PR TITLE
Use custom function to compute the maximum value of a large array

### DIFF
--- a/bokehjs/src/coffee/common/mathutils.coffee
+++ b/bokehjs/src/coffee/common/mathutils.coffee
@@ -1,3 +1,21 @@
+arrayMin = (arr) ->
+  len = arr.length
+  min = Infinity
+  while len--
+    val = arr[len]
+    if val < min
+      min = val
+  min
+
+arrayMax = (arr) ->
+  len = arr.length
+  max = -Infinity
+  while len--
+    val = arr[len]
+    if val > max
+      max = val
+  max
+
 angle_norm = (angle) ->
   while (angle < 0)
     angle += 2*Math.PI
@@ -17,6 +35,8 @@ angle_between = (mid, lhs, rhs, direction) ->
     return not (angle_dist(lhs, mid) <= d and angle_dist(mid, rhs) <= d)
 
 module.exports =
-  angle_norm: angle_norm,
-  angle_dist: angle_dist,
+  arrayMin: arrayMin
+  arrayMax: arrayMax
+  angle_norm: angle_norm
+  angle_dist: angle_dist
   angle_between: angle_between

--- a/bokehjs/src/coffee/renderer/glyph/glyph.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/glyph.coffee
@@ -2,6 +2,7 @@ _ = require "underscore"
 rbush = require "rbush"
 bbox = require "../../common/bbox"
 {logger} = require "../../common/logging"
+{arrayMax} = require "../../common/mathutils"
 HasParent = require "../../common/has_parent"
 ContinuumView = require "../../common/continuum_view"
 properties = require "../../common/properties"
@@ -108,7 +109,7 @@ class GlyphView extends ContinuumView
     # set any distances as well as their max
     for name, prop of @distances
       @[name] = prop.array(source)
-      @["max_#{name}"] = Math.max.apply(null, @[name])
+      @["max_#{name}"] = arrayMax(@[name])
 
     # set any misc fields
     for name, prop of @fields


### PR DESCRIPTION
Previously `Math.max.apply(null, array)` idiom was used to compute the maximum value of an array. This was prone to the maximum call stack limitation, not allowing bokehjs to render more than a few hundred thousand points.