### PR TITLE
Fix gulp watch task

### DIFF
--- a/bokehjs/gulp/tasks/watch.coffee
+++ b/bokehjs/gulp/tasks/watch.coffee
@@ -5,7 +5,7 @@ runSequence = require "run-sequence"
 paths = require "../paths"
 
 gulp.task "watch", ->
-  gulp.watch "#{paths.coffee.watchSources}", ->
+  gulp.watch "#{paths.bokehjs.coffee.watchSources}", ->
     runSequence("scripts:build")
   gulp.watch "#{paths.css.watchSources}", ->
     runSequence("styles:build")


### PR DESCRIPTION
Can someone confirm that `gulp watch` is broken? This fixes it for me.

It seems `path.coffee` should now be `paths.bokehjs.coffee`