### PR TITLE
Fix #2945: webgl fails for large numbers

### DIFF
--- a/bokehjs/src/coffee/renderer/glyph/glyph.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/glyph.coffee
@@ -42,15 +42,21 @@ class GlyphView extends ContinuumView
       @_render(ctx, indices, data)
   
   _render_gl: (ctx, indices, mainglyph) ->
-    # Get transform, and verify that its linear
-    [dx, dy] = @renderer.map_to_screen([0, 1, 2], [0, 1, 2])
+    # Get transform
+    wx = wy = 1  # Weights to scale our vectors
+    [dx, dy] = @renderer.map_to_screen([0*wx, 1*wx, 2*wx], [0*wy, 1*wy, 2*wy])
+    # Try again, but with weighs so we're looking at ~100 in screen coordinates
+    wx = 100 / Math.max(Math.abs(dx[1] - dx[0]), 1e-12)
+    wy = 100 / Math.max(Math.abs(dy[1] - dy[0]), 1e-12)
+    [dx, dy] = @renderer.map_to_screen([0*wx, 1*wx, 2*wx], [0*wy, 1*wy, 2*wy])
+    # Test how linear it is
     if (Math.abs((dx[1] - dx[0]) - (dx[2] - dx[1])) > 1e-6 ||
         Math.abs((dy[1] - dy[0]) - (dy[2] - dy[1])) > 1e-6)
       return false 
     
     trans = 
         width: ctx.glcanvas.width, height: ctx.glcanvas.height, 
-        dx: dx, dy: dy, sx: (dx[1]-dx[0]), sy: (dy[1]-dy[0])  
+        dx: dx, dy: dy, sx: (dx[1]-dx[0])/wx, sy: (dy[1]-dy[0])/wy
     @glglyph.draw(indices, mainglyph, trans)
     return true  # success
 

--- a/bokehjs/src/coffee/renderer/glyph/glyph.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/glyph.coffee
@@ -46,8 +46,8 @@ class GlyphView extends ContinuumView
     wx = wy = 1  # Weights to scale our vectors
     [dx, dy] = @renderer.map_to_screen([0*wx, 1*wx, 2*wx], [0*wy, 1*wy, 2*wy])
     # Try again, but with weighs so we're looking at ~100 in screen coordinates
-    wx = 100 / Math.max(Math.abs(dx[1] - dx[0]), 1e-12)
-    wy = 100 / Math.max(Math.abs(dy[1] - dy[0]), 1e-12)
+    wx = 100 / Math.min(Math.max(Math.abs(dx[1] - dx[0]), 1e-12), 1e12)
+    wy = 100 / Math.min(Math.max(Math.abs(dy[1] - dy[0]), 1e-12), 1e12)
     [dx, dy] = @renderer.map_to_screen([0*wx, 1*wx, 2*wx], [0*wy, 1*wy, 2*wy])
     # Test how linear it is
     if (Math.abs((dx[1] - dx[0]) - (dx[2] - dx[1])) > 1e-6 ||


### PR DESCRIPTION
issues: closes #2945 

Problem was in the calculation of the data-to-screen transformation. A vector of size ~1 was used, which on a scale of 1e15 gives rise to significant roundoff errors. Changed to use a vector size that depends on the transform itself.