### PR TITLE
Added standard string props and note of regex match to line_props docs

### DIFF
--- a/sphinx/source/docs/includes/line_props.txt
+++ b/sphinx/source/docs/includes/line_props.txt
@@ -23,7 +23,16 @@
     - ``'square'`` |square_cap|
 
 ``line_dash``
-    array of integer pixel distances that describe the on-off pattern of dashing to use
+    a line style to use
+
+    - ``'solid'``
+    - ``'dashed'``
+    - ``'dotted'``
+    - ``'dotdash'``
+    - ``'dashdot'``
+    - an array of integer pixel distances that describe the on-off pattern of dashing to use
+    - a string of spaced integers matching the regular expression '^(\\d+(\\s+\\d+)*)?$'
+      that describe the on-off pattern of dashing to use
 
 ``line_dash_offset``
     the distance in pixels into the ``line_dash`` that the pattern should start from


### PR DESCRIPTION
issues: fixes #2954

The current line_dash prop in user_guide/styling.rst only mentions an array of ints as an acceptable argument. This PR expands that description to include the string arguments ('solid', 'dashed') as well as a string that matches a specific regex.