### PR TITLE
support for flexible datatable formatters

### DIFF
--- a/bokeh/models/widgets/tables.py
+++ b/bokeh/models/widgets/tables.py
@@ -193,6 +193,18 @@ class DateFormatter(CellFormatter):
         single quote
     """)
 
+class HTMLTemplateFormatter(CellFormatter):
+    """ HTML formatter using a template.
+    This uses Underscore's `template` method and syntax.  http://underscorejs.org/#template
+    The formatter has access other items in the row via the `dataContext` object passed to the formatter.
+    So, for example, if another column in the datasource was named `url`, the template could access it as:
+        '<a href="<%= url %>"><%= value %></a>'
+
+    """
+    template = String('<%= value %>', help="""
+    Template string to be used by Underscore's template method.
+    """)
+
 class StringEditor(CellEditor):
     """ Basic string cell editor with auto-completion.
 

--- a/bokeh/models/widgets/tables.py
+++ b/bokeh/models/widgets/tables.py
@@ -200,6 +200,15 @@ class HTMLTemplateFormatter(CellFormatter):
     So, for example, if another column in the datasource was named `url`, the template could access it as:
         '<a href="<%= url %>"><%= value %></a>'
 
+    To use a different set of template delimiters, pass the appropriate values for `evaluate`, `interpolate',
+    or `escape`.  See the Underscore `template` documentation for more information.  http://underscorejs.org/#template
+
+    Example: Simple HTML template to format the column value as code.
+        HTMLTemplateFormatter(template='<code><%= value %></code>')
+
+    Example: Use values from other columns (`manufacturer` and `model`) to build a hyperlink.
+        HTMLTemplateFormatter(template='<a href="https:/www.google.com/search?q=<%= manufacturer %>+<%= model %>" target="_blank"><%= value %></a>')
+
     """
     template = String('<%= value %>', help="""
     Template string to be used by Underscore's template method.

--- a/bokehjs/src/coffee/widget/cell_formatters.coffee
+++ b/bokehjs/src/coffee/widget/cell_formatters.coffee
@@ -93,6 +93,20 @@ class DateFormatter extends CellFormatter
     date = $.datepicker.formatDate(@getFormat(), new Date(value))
     return super(row, cell, date, columnDef, dataContext)
 
+class HTMLTemplateFormatter extends CellFormatter
+  type: 'HTMLTemplateFormatter'
+  formatterDefaults:
+    template: '<%= value %>'
+
+  format: (row, cell, value, columnDef, dataContext) ->
+    template = @get("template")
+    if value == null
+      return ""
+    else
+      dataContext = _.extend({}, dataContext, {value: value})
+      compiled_template = _.template(template)
+      return compiled_template(dataContext)
+
 module.exports =
   String:
     Model: StringFormatter
@@ -105,3 +119,6 @@ module.exports =
 
   Date:
     Model: DateFormatter
+
+  HTMLTemplate:
+    Model: HTMLTemplateFormatter


### PR DESCRIPTION
The goal here is to add support for a flexible cell formatter in DataTables.  More specific goals:

1. Support for HTML in the cells.
1. Support column sorting based on the value of the cell, not the resulting HTML.
1. Templates can reference values from other columns within the row.

This PR adds the `HTMLTemplateFormatter` class.  This object takes a `template` argument which follows the template style of Underscore.js.  http://underscorejs.org/#template

Some examples:

```Python
# Simple HTML template to format the column value as code.
# The keyword `value` refers to the column the formatter is applied to.
HTMLTemplateFormatter(template='<code><%= value %></code>')

# Use values from other columns (`manufacturer` and `model`) to build a hyperlink.
# Here `value` refers to the current column, and `manufacturer` and `model` are named columns.
HTMLTemplateFormatter(template='<a href="https:/www.google.com/search?q=<%= manufacturer %>+<%= model %>" target="_blank"><%= value %></a>')
```

This is related to issue #2923 

Any feedback would be greatly appreciated.

thanks,
Dennis