### PR TITLE
remove leftover debugger statement from render loop

### DIFF
--- a/bokehjs/src/coffee/renderer/annotation/span.coffee
+++ b/bokehjs/src/coffee/renderer/annotation/span.coffee
@@ -40,7 +40,6 @@ class SpanView extends PlotWidget
       width = @mget('line_width')
       height = frame.get('height')
 
-    debugger;
     if @mget("render_mode") == "css"
       @$el.css({
         'top': stop,


### PR DESCRIPTION
There's was a debugger statement left in the render call of span.coffee. This is a hotfix to remove it.