### PR TITLE
Bugfix/3036 gulp build

### DIFF
--- a/bokehjs/gulp/tasks/install.coffee
+++ b/bokehjs/gulp/tasks/install.coffee
@@ -15,7 +15,9 @@ handleOutput = (data) ->
     .forEach outputLine
 
 gulp.task "install", ->
-  setup = spawn "python", ["../setup.py", "--install_js"]  # installs js and css
+  # installs js and css
+  # note: sets cwd as parent dir so that LICENSE.txt is accessible to setup.py 
+  setup = spawn "python", ["setup.py", "--install_js"], {cwd: "../"}
   for output in ["stdout", "stderr"]
     setup[output].setEncoding "utf8"
     setup[output].on "data", handleOutput

--- a/bokehjs/gulp/tasks/scripts.coffee
+++ b/bokehjs/gulp/tasks/scripts.coffee
@@ -130,6 +130,7 @@ gulp.task "scripts:build", (cb) ->
       .bundle()
       .pipe(source(paths.coffee.bokehjs.destination.full))
       .pipe(buffer())
+      # .pipe(insert.prepend(license))
       .pipe(sourcemaps.init({loadMaps: true}))
       # This solves a conflict when requirejs is loaded on the page. Backbone
       # looks for `define` before looking for `module.exports`, which eats up
@@ -137,8 +138,7 @@ gulp.task "scripts:build", (cb) ->
       .pipe change (content) ->
         "(function() { var define = undefined; return #{content} })()"
       .pipe change (content) ->
-        "bokehRequire = #{content}"
-      .pipe(insert.prepend(license))
+        "bokehRequire = #{content} \n #{license}"
       .pipe(sourcemaps.write('./'))
       .pipe(gulp.dest(paths.buildDir.js))
       .on 'end', () -> next()

--- a/bokehjs/gulp/tasks/scripts.coffee
+++ b/bokehjs/gulp/tasks/scripts.coffee
@@ -135,7 +135,7 @@ gulp.task "scripts:build", (cb) ->
       # looks for `define` before looking for `module.exports`, which eats up
       # our backbone.
       .pipe change (content) ->
-        "(function() { var define = undefined; return #{content} })() \n\n"
+        "(function() { var define = undefined; return #{content} })()"
       .pipe change (content) ->
         "bokehRequire = #{content}"
       .pipe(insert.append(license))
@@ -159,7 +159,7 @@ gulp.task "scripts:build", (cb) ->
       # looks for `define` before looking for `module.exports`, which eats up
       # our backbone.
       .pipe change (content) ->
-        "(function() { var define = undefined; return #{content} })() \n\n"
+        "(function() { var define = undefined; return #{content} })()"
       .pipe(insert.append(license))
       .pipe(sourcemaps.write('./'))
       .pipe(gulp.dest(paths.buildDir.js))
@@ -174,6 +174,7 @@ gulp.task "scripts:minify", ->
       .pipe(rename((path) -> path.basename += '.min'))
       .pipe(sourcemaps.init({loadMaps: true}))
       .pipe(uglify({ output: {comments: /^!|copyright|license|\(c\)/i} }))
+      .pipe(insert.append(license))
       .pipe(sourcemaps.write('./'))
       .pipe(gulp.dest(paths.buildDir.js))
   es.merge.apply(null, tasks)

--- a/bokehjs/gulp/tasks/scripts.coffee
+++ b/bokehjs/gulp/tasks/scripts.coffee
@@ -130,15 +130,15 @@ gulp.task "scripts:build", (cb) ->
       .bundle()
       .pipe(source(paths.coffee.bokehjs.destination.full))
       .pipe(buffer())
-      # .pipe(insert.prepend(license))
       .pipe(sourcemaps.init({loadMaps: true}))
       # This solves a conflict when requirejs is loaded on the page. Backbone
       # looks for `define` before looking for `module.exports`, which eats up
       # our backbone.
       .pipe change (content) ->
-        "(function() { var define = undefined; return #{content} })()"
+        "(function() { var define = undefined; return #{content} })() \n\n"
       .pipe change (content) ->
-        "bokehRequire = #{content} \n #{license}"
+        "bokehRequire = #{content}"
+      .pipe(insert.append(license))
       .pipe(sourcemaps.write('./'))
       .pipe(gulp.dest(paths.buildDir.js))
       .on 'end', () -> next()
@@ -159,8 +159,8 @@ gulp.task "scripts:build", (cb) ->
       # looks for `define` before looking for `module.exports`, which eats up
       # our backbone.
       .pipe change (content) ->
-        "(function() { var define = undefined; return #{content} })()"
-      .pipe(insert.prepend(license))
+        "(function() { var define = undefined; return #{content} })() \n\n"
+      .pipe(insert.append(license))
       .pipe(sourcemaps.write('./'))
       .pipe(gulp.dest(paths.buildDir.js))
       .on 'end', () -> next()

--- a/setup.py
+++ b/setup.py
@@ -83,8 +83,11 @@ versioneer.parentdir_prefix = 'Bokeh-'  # dirname like 'myproject-1.2.0'
 # -----------------------------------------------------------------------------
 # Classes and functions
 # -----------------------------------------------------------------------------
-
-copy("LICENSE.txt", "bokeh/")
+try:
+    copy("LICENSE.txt", "bokeh/")
+except FileNotFoundError:
+    # setup.py called from bokehjs dir by gulp watch process
+    copy("../LICENSE.txt", "../bokeh/")
 
 package_data = ['LICENSE.txt']
 

--- a/setup.py
+++ b/setup.py
@@ -83,11 +83,8 @@ versioneer.parentdir_prefix = 'Bokeh-'  # dirname like 'myproject-1.2.0'
 # -----------------------------------------------------------------------------
 # Classes and functions
 # -----------------------------------------------------------------------------
-try:
-    copy("LICENSE.txt", "bokeh/")
-except FileNotFoundError:
-    # setup.py called from bokehjs dir by gulp watch process
-    copy("../LICENSE.txt", "../bokeh/")
+
+copy("LICENSE.txt", "bokeh/")
 
 package_data = ['LICENSE.txt']
 


### PR DESCRIPTION
issues: fixes #3036 

Fixes bug in source map generate caused by license by appending license to bottom of bokeh.js

Fixes bug where setup.py called by gulp watch process has bad path to LICENSE.txt