### PR TITLE
Documentation/python only tests

### DIFF
--- a/bokeh/__init__.py
+++ b/bokeh/__init__.py
@@ -37,6 +37,6 @@ def license():
         None
 
     '''
-    from os.path import join
-    with open(join(__path__[0], 'LICENSE.txt')) as lic:
+    import os
+    with open(os.path.join(__path__[0], os.pardir, 'LICENSE.txt')) as lic:
         print(lic.read())

--- a/bokeh/__init__.py
+++ b/bokeh/__init__.py
@@ -37,6 +37,6 @@ def license():
         None
 
     '''
-    import os
-    with open(os.path.join(__path__[0], os.pardir, 'LICENSE.txt')) as lic:
+    from os.path import join
+    with open(join(__path__[0], 'LICENSE.txt')) as lic:
         print(lic.read())

--- a/sphinx/source/docs/dev_guide/testing.rst
+++ b/sphinx/source/docs/dev_guide/testing.rst
@@ -11,7 +11,7 @@ There is a TravisCI project configured to execute on every GitHub push, it can
 be viewed at: https://travis-ci.org/bokeh/bokeh.
 
 You can run all available tests (python and JS unit tests, as well as example
-and integration tests) from the top level directory by executing:
+and integration tests) **from the top level directory** by executing:
 
 .. code-block:: sh
 
@@ -20,11 +20,13 @@ and integration tests) from the top level directory by executing:
 .. note::
     Currently this script does not support Windows.
 
-To run just the python unit tests, run the command:
+To run just the python unit tests, run either command:
 
 .. code-block:: sh
 
     py.test -m 'not (js or examples or integration)'
+
+    python -c 'import bokeh; bokeh.test()'
 
 To run just the examples, run the command:
 
@@ -49,6 +51,10 @@ Or, in the `bokehjs` subdirectory of the source checkout.
 .. code-block:: sh
 
     gulp test
+
+To learn more about marking test functions and selecting/deselecting them for
+a run, please consult the pytest documentation about `custom markers
+<http://pytest.org/latest/example/markers.html#working-with-custom-markers>`_.
 
 To help the test script choose the appropriate test runner, there are some
 naming conventions that examples should adhere to. Non-IPython notebook

--- a/sphinx/source/docs/dev_guide/testing.rst
+++ b/sphinx/source/docs/dev_guide/testing.rst
@@ -10,35 +10,8 @@ Testing
 There is a TravisCI project configured to execute on every GitHub push, it can
 be viewed at: https://travis-ci.org/bokeh/bokeh.
 
-To run the just the python unit tests, run the command:
-
-.. code-block:: sh
-
-    py.test -m 'not (js or examples)' 
-
-
-To run just the examples, run the command:
-
-.. code-block:: sh
-
-    py.test -m examples 
-
-To run just the BokehJS unit tests, execute:
-
-.. code-block:: sh
-
-    py.test -m js
-
-
-Or, in the `bokehjs` subdirectory of the source checkout.
-
-.. code-block:: sh
-
-    gulp test
-
-
-You can run all available tests (python and JS unit tests and example tests)
-from the top level directory by executing:
+You can run all available tests (python and JS unit tests, as well as example
+and integration tests) from the top level directory by executing:
 
 .. code-block:: sh
 
@@ -46,6 +19,36 @@ from the top level directory by executing:
 
 .. note::
     Currently this script does not support Windows.
+
+To run the just the python unit tests, run the command:
+
+.. code-block:: sh
+
+    py.test -m 'not (js or examples or integration)'
+
+To run just the examples, run the command:
+
+.. code-block:: sh
+
+    py.test -m examples
+
+To run just the integration tests, run the command:
+
+.. code-block:: sh
+
+    py.test -m integration
+
+To run just the BokehJS unit tests, execute:
+
+.. code-block:: sh
+
+    py.test -m js
+
+Or, in the `bokehjs` subdirectory of the source checkout.
+
+.. code-block:: sh
+
+    gulp test
 
 To help the test script choose the appropriate test runner, there are some
 naming conventions that examples should adhere to. Non-IPython notebook

--- a/sphinx/source/docs/dev_guide/testing.rst
+++ b/sphinx/source/docs/dev_guide/testing.rst
@@ -20,7 +20,7 @@ and integration tests) from the top level directory by executing:
 .. note::
     Currently this script does not support Windows.
 
-To run the just the python unit tests, run the command:
+To run just the python unit tests, run the command:
 
 .. code-block:: sh
 


### PR DESCRIPTION
supercedes: #2991 

Adds to the developer_guide/testing the mention that python-only unit tests can be run via
``py.test -m 'not (js or examples or integration)'``