### PR TITLE
hotfix/image_rgba

### DIFF
--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -358,11 +358,11 @@ class ImageRGBA(Glyph):
     The y-coordinates to locate the image anchors.
     """)
 
-    rows = NumberSpec("rows", help="""
+    rows = NumberSpec(None, help="""
     The numbers of rows in the images
     """)
 
-    cols = NumberSpec("cols", help="""
+    cols = NumberSpec(None, help="""
     The numbers of columns in the images
     """)
 

--- a/bokeh/models/tests/test_glyphs.py
+++ b/bokeh/models/tests/test_glyphs.py
@@ -228,8 +228,8 @@ def test_ImageRGBA():
     assert glyph.y == "y"
     assert glyph.dw == "dw"
     assert glyph.dh == "dh"
-    assert glyph.rows == "rows"
-    assert glyph.cols == "cols"
+    assert glyph.rows == None
+    assert glyph.cols == None
     assert glyph.dilate == False
     yield (check_props, glyph, [
         "image",


### PR DESCRIPTION
set defaults for rows, cols to None, so that they are computed on JS side ny default

@bokeh/core anyone using `image_rgba` please check this out. I think this is the best most correct way to handle this for now. In the future we will support better more robust "array" communication.  