### PR TITLE
Add PlotObject.to_json and to_json_string

### DIFF
--- a/bokeh/plot_object.py
+++ b/bokeh/plot_object.py
@@ -232,6 +232,7 @@ class PlotObject(HasProps, CallbackManager):
     def vm_props(self, changed_only=True):
         """ Returns the ViewModel-related properties of this object.
 
+        .. note::
             In the future this method may always return all properties,
             ignoring the changed_only argument.
 
@@ -256,7 +257,7 @@ class PlotObject(HasProps, CallbackManager):
         return props
 
     def vm_serialize(self, changed_only=True):
-        """Returns a dictionary of the attributes of this object, in
+        """ Returns a dictionary of the attributes of this object, in
         a layout corresponding to what BokehJS expects at unmarshalling time.
 
         This method does not convert "Bokeh types" into "plain JSON types,"
@@ -285,9 +286,9 @@ class PlotObject(HasProps, CallbackManager):
         return attrs
 
     def to_json(self):
-        """Returns a dictionary of the attributes of this object,
-           containing only "JSON types" (string, number, boolean,
-           none, dict, list).
+        """ Returns a dictionary of the attributes of this object,
+        containing only "JSON types" (string, number, boolean,
+        none, dict, list).
 
         References to other objects are serialized as "refs" (just
         the object ID and type info), so the deserializer will

--- a/bokeh/tests/test_objects.py
+++ b/bokeh/tests/test_objects.py
@@ -82,6 +82,11 @@ class TestCollectPlotObjects(unittest.TestCase):
         root, objects = large_plot(500)
         self.assertEqual(set(root.references()), objects)
 
+class SomeModelToJson(PlotObject):
+    child = Instance(PlotObject)
+    foo = Int()
+    bar = String()
+
 class TestPlotObject(unittest.TestCase):
 
     def setUp(self):
@@ -154,6 +159,22 @@ class TestPlotObject(unittest.TestCase):
         v = V(u1=u1, u2=[u2], u3=(3, u3), u4={"4": u4}, u5={"5": [u5]})
 
         self.assertEqual(v.references(), set([v, u1, u2, u3, u4, u5]))
+
+    def test_to_json(self):
+        child_obj = SomeModelToJson(foo=57, bar="hello")
+        obj = SomeModelToJson(child=child_obj,
+                              foo=42, bar="world")
+        json = obj.to_json()
+        json_string = obj.to_json_string()
+        self.assertEqual({ "child" : { "id" : child_obj._id, "type" : "SomeModelToJson" },
+                           "id" : obj._id,
+                           "name" : None,
+                           "tags" : [],
+                           "foo" : 42,
+                           "bar" : "world" },
+                         json)
+        self.assertEqual('{"bar": "world", "child": {"id": "%s", "type": "SomeModelToJson"}, "foo": 42, "id": "%s", "name": null, "tags": []}' % (child_obj._id, obj._id),
+                         json_string)
 
 class SomeModelInTestObjects(PlotObject):
     child = Instance(PlotObject)

--- a/bokeh/tests/test_objects.py
+++ b/bokeh/tests/test_objects.py
@@ -175,7 +175,10 @@ class TestPlotObject(unittest.TestCase):
                            "foo" : 42,
                            "bar" : "world" },
                          json)
-        self.assertEqual('{"bar": "world", "child": {"id": "%s", "type": "SomeModelToJson"}, "foo": 42, "id": "%s", "name": null, "tags": []}' % (child_obj._id, obj._id),
+        self.assertEqual(('{"bar": "world", ' +
+                          '"child": {"id": "%s", "type": "SomeModelToJson"}, ' +
+                          '"foo": 42, "id": "%s", "name": null, "tags": []}') %
+                         (child_obj._id, obj._id),
                          json_string)
 
 class SomeModelInTestObjects(PlotObject):


### PR DESCRIPTION
These are like vm_serialize but don't expose the ugly implementation
detail of our magic JSON encoder that "fixes" certain types into
plain JSON types.