### PR TITLE
Change text_font_size prop defaults to list-style from deprecated str

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,4 +198,3 @@ Interactive gallery
 </tr>
 </table>
 </p>
-

--- a/bokeh/models/tests/test_annotations.py
+++ b/bokeh/models/tests/test_annotations.py
@@ -28,7 +28,7 @@ def check_border(annotation):
 
 def check_label(annotation):
     assert annotation.label_text_font == "Helvetica"
-    assert annotation.label_text_font_size == dict(value="10pt")
+    assert annotation.label_text_font_size == ["10pt"]
     assert annotation.label_text_font_style == FontStyle.normal
     assert annotation.label_text_color == "#444444"
     assert annotation.label_text_alpha == 1.0

--- a/bokeh/models/tests/test_annotations.py
+++ b/bokeh/models/tests/test_annotations.py
@@ -28,7 +28,7 @@ def check_border(annotation):
 
 def check_label(annotation):
     assert annotation.label_text_font == "Helvetica"
-    assert annotation.label_text_font_size == ["10pt"]
+    assert annotation.label_text_font_size == {"value": "10pt"}
     assert annotation.label_text_font_style == FontStyle.normal
     assert annotation.label_text_color == "#444444"
     assert annotation.label_text_alpha == 1.0

--- a/bokeh/models/tests/test_glyphs.py
+++ b/bokeh/models/tests/test_glyphs.py
@@ -80,7 +80,7 @@ def check_line(glyph):
 
 def check_text(glyph):
     assert glyph.text_font == "Helvetica"
-    assert glyph.text_font_size == dict(value="12pt")
+    assert glyph.text_font_size == ["12pt"]
     assert glyph.text_font_style == FontStyle.normal
     assert glyph.text_color == "#444444"
     assert glyph.text_alpha == 1.0

--- a/bokeh/models/tests/test_glyphs.py
+++ b/bokeh/models/tests/test_glyphs.py
@@ -80,7 +80,7 @@ def check_line(glyph):
 
 def check_text(glyph):
     assert glyph.text_font == "Helvetica"
-    assert glyph.text_font_size == ["12pt"]
+    assert glyph.text_font_size == {"value": "12pt"}
     assert glyph.text_font_style == FontStyle.normal
     assert glyph.text_color == "#444444"
     assert glyph.text_alpha == 1.0

--- a/bokeh/themes/default.yaml
+++ b/bokeh/themes/default.yaml
@@ -13,7 +13,7 @@ line_defaults:
 
 text_defaults:
   text_font: "Helvetica"
-  text_font_size: ["12pt"]
+  text_font_size: { "value" : "12pt" }
   text_font_style: "normal"
   text_color: "#444444"
   text_alpha: 1.0
@@ -56,7 +56,7 @@ attrs:
     major_label_standoff: 5
     major_label_orientation: "horizontal"
     major_label_text_font: "Helvetica"
-    major_label_text_font_size: ["10pt"]
+    major_label_text_font_size: { "value" : "10pt" }
     major_label_text_font_style: "normal"
     major_label_text_color: "#444444"
     major_label_text_alpha: 1.0
@@ -66,7 +66,7 @@ attrs:
     axis_label: ""
     axis_label_standoff: 5
     axis_label_text_font: "Helvetica"
-    axis_label_text_font_size: ["16pt"]
+    axis_label_text_font_size: { "value" : "16pt" }
     axis_label_text_font_style: "normal"
     axis_label_text_color: "#444444"
     axis_label_text_alpha: 1.0
@@ -128,7 +128,7 @@ attrs:
     label_width: 50
     label_standoff: 15
     label_text_font: "Helvetica"
-    label_text_font_size: ["10pt"]
+    label_text_font_size: { "value" : "10pt" }
     label_text_font_style: "normal"
     label_text_color: "#444444"
     label_text_alpha: 1.0
@@ -166,7 +166,7 @@ attrs:
     border_fill: "#ffffff"
     min_border: 40
     title_text_font: "Helvetica"
-    title_text_font_size: ["20pt"]
+    title_text_font_size: { "value" : "20pt" }
     title_text_font_style: "normal"
     title_text_color: "#444444"
     title_text_alpha: 1.0

--- a/bokeh/themes/default.yaml
+++ b/bokeh/themes/default.yaml
@@ -13,7 +13,7 @@ line_defaults:
 
 text_defaults:
   text_font: "Helvetica"
-  text_font_size: "12pt"
+  text_font_size: ["12pt"]
   text_font_style: "normal"
   text_color: "#444444"
   text_alpha: 1.0
@@ -56,7 +56,7 @@ attrs:
     major_label_standoff: 5
     major_label_orientation: "horizontal"
     major_label_text_font: "Helvetica"
-    major_label_text_font_size: "10pt"
+    major_label_text_font_size: ["10pt"]
     major_label_text_font_style: "normal"
     major_label_text_color: "#444444"
     major_label_text_alpha: 1.0
@@ -66,7 +66,7 @@ attrs:
     axis_label: ""
     axis_label_standoff: 5
     axis_label_text_font: "Helvetica"
-    axis_label_text_font_size: "16pt"
+    axis_label_text_font_size: ["16pt"]
     axis_label_text_font_style: "normal"
     axis_label_text_color: "#444444"
     axis_label_text_alpha: 1.0
@@ -128,7 +128,7 @@ attrs:
     label_width: 50
     label_standoff: 15
     label_text_font: "Helvetica"
-    label_text_font_size: "10pt"
+    label_text_font_size: ["10pt"]
     label_text_font_style: "normal"
     label_text_color: "#444444"
     label_text_alpha: 1.0
@@ -166,7 +166,7 @@ attrs:
     border_fill: "#ffffff"
     min_border: 40
     title_text_font: "Helvetica"
-    title_text_font_size: "20pt"
+    title_text_font_size: ["20pt"]
     title_text_font_style: "normal"
     title_text_color: "#444444"
     title_text_alpha: 1.0


### PR DESCRIPTION
issues: fixes #3094 

The default text_font_size props in default.yaml were set as deprecated string types. This PR updates them to single element lists, e.g. ``['20pt']``