### PR TITLE
Property cache cleanups

### DIFF
--- a/bokeh/charts/attributes.py
+++ b/bokeh/charts/attributes.py
@@ -48,6 +48,11 @@ class AttrSpec(HasProps):
         found in `columns` and the attribute value that has been assigned.
         """)
 
+    # TODO it is not correct to define this here and then narrow
+    # its type in subclasses, because this definition here says
+    # that Any can be assigned to `iterable`, and in fact it can't
+    # be. The Any version should be copy-pasted or mixed-in to only
+    # those subtypes that actually support Any.
     iterable = List(Any, default=None, help="""
         The iterable of attribute values to assign to the distinct values found in
         `columns` of `data`.

--- a/bokeh/models/widgets/icons.py
+++ b/bokeh/models/widgets/icons.py
@@ -20,6 +20,7 @@ class Icon(AbstractIcon):
 
     """
 
+    # TODO this conflicts with PlotObject.name and should be renamed
     name = Enum(NamedIcon, help="""
     What icon to use. See http://fortawesome.github.io/Font-Awesome/icons/
     for the list of available icons.

--- a/bokeh/properties.py
+++ b/bokeh/properties.py
@@ -422,7 +422,7 @@ class MetaHasProps(type):
 
         return type.__new__(cls, class_name, bases, class_dict)
 
-def accumulate_from_subclasses(cls, propname):
+def accumulate_from_superclasses(cls, propname):
     s = set()
     for c in inspect.getmro(cls):
         if issubclass(c, HasProps):
@@ -477,7 +477,7 @@ class HasProps(object):
         pull together the full list of properties.
         """
         if not hasattr(cls, "__cached_allprops_with_refs"):
-            s = accumulate_from_subclasses(cls, "__properties_with_refs__")
+            s = accumulate_from_superclasses(cls, "__properties_with_refs__")
             cls.__cached_allprops_with_refs = s
         return cls.__cached_allprops_with_refs
 
@@ -486,7 +486,7 @@ class HasProps(object):
         """ Returns a list of properties that are containers
         """
         if not hasattr(cls, "__cached_allprops_containers"):
-            s = accumulate_from_subclasses(cls, "__container_props__")
+            s = accumulate_from_superclasses(cls, "__container_props__")
             cls.__cached_allprops_containers = s
         return cls.__cached_allprops_containers
 
@@ -544,7 +544,7 @@ class HasProps(object):
     @classmethod
     def class_properties(cls, withbases=True):
         if withbases:
-            return accumulate_from_subclasses(cls, "__properties__")
+            return accumulate_from_superclasses(cls, "__properties__")
         else:
             return set(cls.__properties__)
 

--- a/bokeh/properties.py
+++ b/bokeh/properties.py
@@ -447,9 +447,15 @@ class HasProps(object):
             setattr(self, name, value)
 
     def __setattr__(self, name, value):
+        # self.properties() below can be expensive so avoid it
+        # if we're just setting a private underscore field
+        if name.startswith("_"):
+            super(HasProps, self).__setattr__(name, value)
+            return
+
         props = sorted(self.properties())
 
-        if name.startswith("_") or name in props:
+        if name in props:
             super(HasProps, self).__setattr__(name, value)
         else:
             matches, text = difflib.get_close_matches(name.lower(), props), "similar"

--- a/bokeh/tests/test_properties.py
+++ b/bokeh/tests/test_properties.py
@@ -88,6 +88,71 @@ class Basictest(unittest.TestCase):
         f.x = 13
         self.assertEqual(f.x, 13)
 
+    def test_accurate_properties_sets(self):
+        class Base(HasProps):
+            num = Int(12)
+            container = List(String)
+            child = Instance(HasProps)
+
+        class Mixin(HasProps):
+            mixin_num = Int(12)
+            mixin_container = List(String)
+            mixin_child = Instance(HasProps)
+
+        class Sub(Base, Mixin):
+            sub_num = Int(12)
+            sub_container = List(String)
+            sub_child = Instance(HasProps)
+
+        b = Base()
+        self.assertEqual(set(["child"]),
+                         b.properties_with_refs())
+        self.assertEqual(set(["container"]),
+                         b.properties_containers())
+        self.assertEqual(set(["num", "container", "child"]),
+                         b.properties())
+        self.assertEqual(set(["num", "container", "child"]),
+                         b.class_properties(withbases=True))
+        self.assertEqual(set(["num", "container", "child"]),
+                         b.class_properties(withbases=False))
+
+        m = Mixin()
+        self.assertEqual(set(["mixin_child"]),
+                         m.properties_with_refs())
+        self.assertEqual(set(["mixin_container"]),
+                         m.properties_containers())
+        self.assertEqual(set(["mixin_num", "mixin_container", "mixin_child"]),
+                         m.properties())
+        self.assertEqual(set(["mixin_num", "mixin_container", "mixin_child"]),
+                         m.class_properties(withbases=True))
+        self.assertEqual(set(["mixin_num", "mixin_container", "mixin_child"]),
+                         m.class_properties(withbases=False))
+
+        s = Sub()
+        self.assertEqual(set(["child", "sub_child", "mixin_child"]),
+                         s.properties_with_refs())
+        self.assertEqual(set(["container", "sub_container", "mixin_container"]),
+                         s.properties_containers())
+        self.assertEqual(set(["num", "container", "child",
+                              "mixin_num", "mixin_container", "mixin_child",
+                              "sub_num", "sub_container", "sub_child"]),
+                         s.properties())
+        self.assertEqual(set(["num", "container", "child",
+                              "mixin_num", "mixin_container", "mixin_child",
+                              "sub_num", "sub_container", "sub_child"]),
+                         s.class_properties(withbases=True))
+        self.assertEqual(set(["sub_num", "sub_container", "sub_child"]),
+                         s.class_properties(withbases=False))
+
+        # verify caching
+        self.assertIs(s.properties_with_refs(), s.properties_with_refs())
+        self.assertIs(s.properties_containers(), s.properties_containers())
+        self.assertIs(s.properties(), s.properties())
+        self.assertIs(s.class_properties(withbases=True), s.class_properties(withbases=True))
+        # this one isn't cached because we store it as a list __properties__ and wrap it
+        # in a new set every time
+        #self.assertIs(s.class_properties(withbases=False), s.class_properties(withbases=False))
+
     # def test_kwargs_init(self):
     #     class Foo(HasProps):
     #         x = String


### PR DESCRIPTION
There's one bugfix (using the wrong cache from base classes), one optimization (always cache the merged __properties__ from base classes), one new warning (when a subclass tries to override a base class property, which seems to be a bug in the two cases TODO-commented here), and a refactor to decrease LOC by sharing cache logic. Also, rename accumulate_from_subclasses to be accurate.
