### PR TITLE
Add Document.get_model_by_name

### DIFF
--- a/bokeh/document.py
+++ b/bokeh/document.py
@@ -91,6 +91,8 @@ class _MultiValuedDict(object):
         self._dict = dict()
 
     def add_value(self, key, value):
+        if key is None:
+            raise ValueError("Key is None")
         if value is None:
             raise ValueError("Can't put None in this dict")
         if isinstance(value, set):
@@ -104,6 +106,8 @@ class _MultiValuedDict(object):
             self._dict[key] = set([existing, value])
 
     def remove_value(self, key, value):
+        if key is None:
+            raise ValueError("Key is None")
         existing = self._dict.get(key, None)
         if isinstance(existing, set):
             existing.discard(value)
@@ -379,7 +383,8 @@ class Document(object):
         '''
         # if name changes, update by-name index
         if attr == 'name':
-            self._all_models_by_name.remove_value(old, model)
+            if old is not None:
+                self._all_models_by_name.remove_value(old, model)
             if new is not None:
                 self._all_models_by_name.add_value(new, model)
 

--- a/bokeh/document.py
+++ b/bokeh/document.py
@@ -209,7 +209,7 @@ class Document(object):
         recomputed_by_name = _MultiValuedDict()
         for m in new_all_models_set:
             recomputed[m._id] = m
-            if m.name is not None and not m._naughty_model_overrides_name():
+            if m.name is not None:
                 recomputed_by_name.add_value(m.name, m)
         for d in to_detach:
             d._detach_document()
@@ -379,10 +379,9 @@ class Document(object):
         '''
         # if name changes, update by-name index
         if attr == 'name':
-            if not model._naughty_model_overrides_name():
-                self._all_models_by_name.remove_value(old, model)
-                if new is not None:
-                    self._all_models_by_name.add_value(new, model)
+            self._all_models_by_name.remove_value(old, model)
+            if new is not None:
+                self._all_models_by_name.add_value(new, model)
 
         self._trigger_on_change(ModelChangedEvent(self, model, attr, old, new))
 

--- a/bokeh/document.py
+++ b/bokeh/document.py
@@ -120,7 +120,7 @@ class _MultiValuedDict(object):
             if len(existing) == 1:
                 return next(iter(existing))
             else:
-                raise ValueError(duplicate_error)
+                raise ValueError(duplicate_error + (": %r" % (existing)))
         else:
             return existing
 
@@ -328,7 +328,7 @@ class Document(object):
         '''
         result = list(self.select(selector))
         if len(result) > 1:
-            raise ValueError("Found more than one model matching %s" % selector)
+            raise ValueError("Found more than one model matching %s: %r" % (selector, result))
         if len(result) == 0:
             return None
         return result[0]

--- a/bokeh/document.py
+++ b/bokeh/document.py
@@ -145,10 +145,6 @@ class Document(object):
         if self._all_models_freeze_count == 0:
             self._recompute_all_models()
 
-    @classmethod
-    def _naughty_model_overrides_name(cls, model):
-        return getattr(model.__class__, 'name') != getattr(PlotObject, 'name')
-
     def _recompute_all_models(self):
         new_all_models_set = set()
         for r in self.roots:
@@ -160,7 +156,7 @@ class Document(object):
         recomputed_by_name = {}
         for m in new_all_models_set:
             recomputed[m._id] = m
-            if m.name is not None and not self._naughty_model_overrides_name(m):
+            if m.name is not None and not m._naughty_model_overrides_name():
                 recomputed_by_name[m.name] = m
         for d in to_detach:
             d._detach_document()
@@ -272,7 +268,7 @@ class Document(object):
         '''
         # if name changes, update by-name index
         if attr == 'name':
-            if not self._naughty_model_overrides_name(model):
+            if not model._naughty_model_overrides_name():
                 if self._all_models_by_name.get(old, None) == model:
                     del self._all_models_by_name[old]
                 self._all_models_by_name[new] = model

--- a/bokeh/plot_object.py
+++ b/bokeh/plot_object.py
@@ -91,6 +91,10 @@ class PlotObject(HasProps, CallbackManager):
         '''This should only be called by the Document implementation to unset the document field'''
         self._document = None
 
+    def _naughty_model_overrides_name(self):
+        '''This should only be called by the Document implementation to work around broken models that override the name field with something unrelated'''
+        return getattr(self.__class__, 'name') != getattr(PlotObject, 'name')
+
     @property
     def document(self):
         return self._document

--- a/bokeh/plot_object.py
+++ b/bokeh/plot_object.py
@@ -91,10 +91,6 @@ class PlotObject(HasProps, CallbackManager):
         '''This should only be called by the Document implementation to unset the document field'''
         self._document = None
 
-    def _naughty_model_overrides_name(self):
-        '''This should only be called by the Document implementation to work around broken models that override the name field with something unrelated'''
-        return getattr(self.__class__, 'name') != getattr(PlotObject, 'name')
-
     @property
     def document(self):
         return self._document

--- a/bokeh/plot_object.py
+++ b/bokeh/plot_object.py
@@ -10,8 +10,6 @@ from .query import find
 from . import themes
 from .util.callback_manager import CallbackManager
 from .util.serialization import make_id
-from .validation import warning
-from .validation.warnings import DUPLICATE_NAMES
 
 class Viewable(MetaHasProps):
     """ Any plot object (Data Model) which has its own View Model in the
@@ -286,15 +284,6 @@ class PlotObject(HasProps, CallbackManager):
     def update(self, **kwargs):
         for k,v in kwargs.items():
             setattr(self, k, v)
-
-    @warning(DUPLICATE_NAMES)
-    def _check_duplicate_names(self):
-        if self.name is not None and \
-           self.document is not None and \
-           not self._naughty_model_overrides_name():
-            other = self.document.get_model_by_name(self.name)
-            if other != self:
-                return ("Both named '%s': %r and %r" % (self.name, self, other))
 
     def __str__(self):
         return "%s, ViewModel:%s, ref _id: %s" % (self.__class__.__name__,

--- a/bokeh/plot_object.py
+++ b/bokeh/plot_object.py
@@ -10,6 +10,8 @@ from .query import find
 from . import themes
 from .util.callback_manager import CallbackManager
 from .util.serialization import make_id
+from .validation import warning
+from .validation.warnings import DUPLICATE_NAMES
 
 class Viewable(MetaHasProps):
     """ Any plot object (Data Model) which has its own View Model in the
@@ -284,6 +286,15 @@ class PlotObject(HasProps, CallbackManager):
     def update(self, **kwargs):
         for k,v in kwargs.items():
             setattr(self, k, v)
+
+    @warning(DUPLICATE_NAMES)
+    def _check_duplicate_names(self):
+        if self.name is not None and \
+           self.document is not None and \
+           not self._naughty_model_overrides_name():
+            other = self.document.get_model_by_name(self.name)
+            if other != self:
+                return ("Both named '%s': %r and %r" % (self.name, self, other))
 
     def __str__(self):
         return "%s, ViewModel:%s, ref _id: %s" % (self.__class__.__name__,

--- a/bokeh/plot_object.py
+++ b/bokeh/plot_object.py
@@ -151,7 +151,7 @@ class PlotObject(HasProps, CallbackManager):
         '''
         result = list(self.select(selector))
         if len(result) > 1:
-            raise ValueError("Found more than one object matching %s" % selector)
+            raise ValueError("Found more than one object matching %s: %r" % (selector, result))
         if len(result) == 0:
             return None
         return result[0]

--- a/bokeh/plot_object.py
+++ b/bokeh/plot_object.py
@@ -151,7 +151,7 @@ class PlotObject(HasProps, CallbackManager):
         '''
         result = list(self.select(selector))
         if len(result) > 1:
-            raise ValueError("found more than one object matching %s" % selector)
+            raise ValueError("Found more than one object matching %s" % selector)
         if len(result) == 0:
             return None
         return result[0]

--- a/bokeh/tests/test_document.py
+++ b/bokeh/tests/test_document.py
@@ -109,10 +109,67 @@ class TestDocument(unittest.TestCase):
             d.get_model_by_name("foo")
         except ValueError as e:
             got_error = True
-            assert 'Multiple models' in repr(e)
+            assert 'Found more than one' in repr(e)
         assert got_error
         d.remove_root(m)
         assert d.get_model_by_name("foo") == m2
+
+    def test_select(self):
+        # we aren't trying to replace test_query here, only test
+        # our wrappers around it, so no need to try every kind of
+        # query
+        d = document.Document()
+        root1 = SomeModelInTestDocument(foo=42, name='a')
+        child1 = SomeModelInTestDocument(foo=43, name='b')
+        root2 = SomeModelInTestDocument(foo=44, name='c')
+        root3 = SomeModelInTestDocument(foo=44, name='d')
+        child3 = SomeModelInTestDocument(foo=45, name='c')
+        root1.child = child1
+        root3.child = child3
+        d.add_root(root1)
+        d.add_root(root2)
+        d.add_root(root3)
+
+        # select()
+        assert set([root1]) == set(d.select(dict(foo=42)))
+        assert set([root1]) == set(d.select(dict(name='a')))
+        assert set([root2, child3])  == set(d.select(dict(name='c')))
+        assert set()  == set(d.select(dict(name='nope')))
+
+        # select() on object
+        assert set() == set(root3.select(dict(name='a')))
+        assert set([child3]) == set(root3.select(dict(name='c')))
+
+        # select_one()
+        assert root3 == d.select_one(dict(name='d'))
+        assert None == d.select_one(dict(name='nope'))
+        got_error = False
+        try:
+            d.select_one(dict(name='c'))
+        except ValueError as e:
+            got_error = True
+            assert 'Found more than one' in repr(e)
+
+        # select_one() on object
+        assert None == root3.select_one(dict(name='a'))
+        assert child3 == root3.select_one(dict(name='c'))
+
+        # set_select()
+        d.set_select(dict(foo=44), dict(name='c'))
+        assert set([root2, child3, root3])  == set(d.select(dict(name='c')))
+
+        # set_select() on object
+        root3.set_select(dict(name='c'), dict(foo=57))
+        assert set([child3, root3]) == set(d.select(dict(foo=57)))
+        assert set([child3, root3]) == set(root3.select(dict(foo=57)))
+
+    def test_is_single_string_selector(self):
+        d = document.Document()
+        # this is an implementation detail but just ensuring it works
+        assert d._is_single_string_selector(dict(foo='c'), 'foo')
+        assert d._is_single_string_selector(dict(foo=u'c'), 'foo')
+        assert not d._is_single_string_selector(dict(foo='c', bar='d'), 'foo')
+        assert not d._is_single_string_selector(dict(foo=42), 'foo')
 
     def test_all_models_with_multiple_references(self):
         d = document.Document()

--- a/bokeh/tests/test_document.py
+++ b/bokeh/tests/test_document.py
@@ -5,7 +5,7 @@ import unittest
 import bokeh.document as document
 from bokeh.plot_object import PlotObject
 from bokeh.properties import Int, Instance, String
-from mock import patch, Mock
+from mock import patch
 
 class AnotherModelInTestDocument(PlotObject):
     bar = Int(1)

--- a/bokeh/tests/test_document.py
+++ b/bokeh/tests/test_document.py
@@ -90,13 +90,13 @@ class TestDocument(unittest.TestCase):
         assert d.get_model_by_name("foo") == None
         assert d.get_model_by_name("bar") == m
 
-    def test_cannot_get_name_overriding_model_by_name(self):
+    def test_can_get_name_overriding_model_by_name(self):
         d = document.Document()
         m = ModelThatOverridesName(name="foo")
         d.add_root(m)
-        assert d.get_model_by_name("foo") == None
+        assert d.get_model_by_name("foo") == m
         m.name = "bar"
-        assert d.get_model_by_name("bar") == None
+        assert d.get_model_by_name("bar") == m
 
     def test_cannot_get_model_with_duplicate_name(self):
         d = document.Document()

--- a/bokeh/tests/test_document.py
+++ b/bokeh/tests/test_document.py
@@ -165,6 +165,7 @@ class TestDocument(unittest.TestCase):
         except ValueError as e:
             got_error = True
             assert 'Found more than one' in repr(e)
+        assert got_error
 
         # select_one() on object
         assert None == root3.select_one(dict(name='a'))

--- a/bokeh/tests/test_document.py
+++ b/bokeh/tests/test_document.py
@@ -90,6 +90,22 @@ class TestDocument(unittest.TestCase):
         assert d.get_model_by_name("foo") == None
         assert d.get_model_by_name("bar") == m
 
+    def test_get_model_by_changed_from_none_name(self):
+        d = document.Document()
+        m = SomeModelInTestDocument(name=None)
+        d.add_root(m)
+        assert d.get_model_by_name("bar") == None
+        m.name = "bar"
+        assert d.get_model_by_name("bar") == m
+
+    def test_get_model_by_changed_to_none_name(self):
+        d = document.Document()
+        m = SomeModelInTestDocument(name="bar")
+        d.add_root(m)
+        assert d.get_model_by_name("bar") == m
+        m.name = None
+        assert d.get_model_by_name("bar") == None
+
     def test_can_get_name_overriding_model_by_name(self):
         d = document.Document()
         m = ModelThatOverridesName(name="foo")

--- a/bokeh/tests/test_document.py
+++ b/bokeh/tests/test_document.py
@@ -76,7 +76,7 @@ class TestDocument(unittest.TestCase):
         d.add_root(m)
         assert len(d.roots) == 1
         assert len(d._all_models) == 2
-        assert len(d._all_models_by_name) == 2
+        assert len(d._all_models_by_name._dict) == 2
         assert d.get_model_by_name(m.name) == m
         assert d.get_model_by_name(m2.name) == m2
         assert d.get_model_by_name("not a valid name") is None
@@ -97,6 +97,22 @@ class TestDocument(unittest.TestCase):
         assert d.get_model_by_name("foo") == None
         m.name = "bar"
         assert d.get_model_by_name("bar") == None
+
+    def test_cannot_get_model_with_duplicate_name(self):
+        d = document.Document()
+        m = SomeModelInTestDocument(name="foo")
+        m2 = SomeModelInTestDocument(name="foo")
+        d.add_root(m)
+        d.add_root(m2)
+        got_error = False
+        try:
+            d.get_model_by_name("foo")
+        except ValueError as e:
+            got_error = True
+            assert 'Multiple models' in repr(e)
+        assert got_error
+        d.remove_root(m)
+        assert d.get_model_by_name("foo") == m2
 
     def test_all_models_with_multiple_references(self):
         d = document.Document()

--- a/bokeh/tests/test_document.py
+++ b/bokeh/tests/test_document.py
@@ -5,7 +5,6 @@ import unittest
 import bokeh.document as document
 from bokeh.plot_object import PlotObject
 from bokeh.properties import Int, Instance, String
-from mock import patch
 
 class AnotherModelInTestDocument(PlotObject):
     bar = Int(1)
@@ -433,25 +432,6 @@ class TestDocument(unittest.TestCase):
         y = np.sin(x)
         p1.scatter(x,y, color="#FF00FF", nonselection_fill_color="#FFFF00", nonselection_fill_alpha=1)
         assert len(d.roots) == 1
-
-    @patch('bokeh.validation.check.logger')
-    def test_validate_duplicate_names(self, check_logger):
-        d = document.Document()
-        m = SomeModelInTestDocument(name="foo")
-        m2 = AnotherModelInTestDocument(name="bar")
-        m.child = m2
-        d.add_root(m)
-        d.validate()
-        self.assertFalse(check_logger.error.called)
-
-        m3 = SomeModelInTestDocument(name="bar")
-        d.add_root(m3)
-        d.validate()
-        self.assertTrue(check_logger.error.called)
-        error_args = check_logger.error.call_args[0]
-        self.assertEqual(1, len(error_args))
-        self.assertTrue(error_args[0].startswith("W-1005 (DUPLICATE_NAMES)"))
-        self.assertEqual(dict(), check_logger.error.call_args[1])
 
     # TODO test serialize/deserialize with list-and-dict-valued properties
 

--- a/bokeh/validation/warnings.py
+++ b/bokeh/validation/warnings.py
@@ -15,9 +15,6 @@
 1004 : *BOTH_CHILD_AND_ROOT*
     Each component can be rendered in only one place, can't be both a root and in a layout.
 
-1005 : *DUPLICATE_NAMES*
-    Each model's name field should be either None or a unique name.
-
 9999 : *EXT*
     Indicates that a custom warning check has failed.
 
@@ -29,7 +26,6 @@ codes = {
     1002: ("EMPTY_LAYOUT",              "Layout has no children"),
     1003: ("MALFORMED_CATEGORY_LABEL",  "Category labels cannot contain colons"),
     1004: ("BOTH_CHILD_AND_ROOT",       "Models should not be a document root if they are in a layout box"),
-    1005: ("DUPLICATE_NAMES",           "Two models have the same name field"),
     9999: ("EXT",                       "Custom extension reports warning"),
 }
 

--- a/bokeh/validation/warnings.py
+++ b/bokeh/validation/warnings.py
@@ -15,6 +15,9 @@
 1004 : *BOTH_CHILD_AND_ROOT*
     Each component can be rendered in only one place, can't be both a root and in a layout.
 
+1005 : *DUPLICATE_NAMES*
+    Each model's name field should be either None or a unique name.
+
 9999 : *EXT*
     Indicates that a custom warning check has failed.
 
@@ -26,6 +29,7 @@ codes = {
     1002: ("EMPTY_LAYOUT",              "Layout has no children"),
     1003: ("MALFORMED_CATEGORY_LABEL",  "Category labels cannot contain colons"),
     1004: ("BOTH_CHILD_AND_ROOT",       "Models should not be a document root if they are in a layout box"),
+    1005: ("DUPLICATE_NAMES",           "Two models have the same name field"),
     9999: ("EXT",                       "Custom extension reports warning"),
 }
 

--- a/bokehjs/src/coffee/common/has_properties.coffee
+++ b/bokehjs/src/coffee/common/has_properties.coffee
@@ -312,7 +312,7 @@ class HasProperties extends Backbone.Model
     # make this a no-op, we sync the whole document never individual models
     return options.success(model.attributes, null, {})
 
-  defaults: -> {}
+  defaults: () -> { 'name' : null }
 
   # TODO remove this, for now it's just to help find nonserializable_attribute_names we
   # need to add.

--- a/bokehjs/test/test_common/test_document.coffee
+++ b/bokehjs/test/test_common/test_document.coffee
@@ -136,6 +136,20 @@ describe "Document", ->
     expect(d.get_model_by_name("foo")).to.equal(null)
     expect(d.get_model_by_name("bar")).to.equal(m)
 
+  it "throws on get_model_by_name with duplicate name", ->
+    d = new Document()
+    m = new SomeModel({ name : "foo" })
+    m2 = new AnotherModel({ name : "foo" })
+    d.add_root(m)
+    d.add_root(m2)
+    got_error = false
+    try
+      d.get_model_by_name('foo')
+    catch e
+      got_error = true
+      expect(e.message).to.include('Multiple models')
+    expect(got_error).to.equal(true)
+
   # TODO copy the following tests from test_document.py here
   # TODO(havocp) test_all_models_with_multiple_references
   # TODO(havocp) test_all_models_with_cycles

--- a/bokehjs/test/test_common/test_document.coffee
+++ b/bokehjs/test/test_common/test_document.coffee
@@ -116,6 +116,26 @@ describe "Document", ->
     expect(d.get_model_by_id(m2.id)).to.equal(m2)
     expect(d.get_model_by_id("invalidid")).to.equal(null)
 
+  it "lets us get_model_by_name", ->
+    d = new Document()
+    m = new SomeModel({ name : "foo" })
+    m2 = new AnotherModel({ name : "bar" })
+    m.set({ child: m2 })
+    d.add_root(m)
+    expect(d.get_model_by_name(m.get('name'))).to.equal(m)
+    expect(d.get_model_by_name(m2.get('name'))).to.equal(m2)
+    expect(d.get_model_by_name("invalidid")).to.equal(null)
+
+  it "lets us get_model_by_name after changing name", ->
+    d = new Document()
+    m = new SomeModel({ name : "foo" })
+    d.add_root(m)
+    expect(d.get_model_by_name("foo")).to.equal(m)
+    expect(d.get_model_by_name("bar")).to.equal(null)
+    m.set({ name : "bar" })
+    expect(d.get_model_by_name("foo")).to.equal(null)
+    expect(d.get_model_by_name("bar")).to.equal(m)
+
   # TODO copy the following tests from test_document.py here
   # TODO(havocp) test_all_models_with_multiple_references
   # TODO(havocp) test_all_models_with_cycles
@@ -236,14 +256,16 @@ describe "Document", ->
 
     patch = Document._compute_patch_since_json(JSON.parse(json), copy)
 
+    expect(root1.get('name')).to.equal undefined
     expect(root1.get('list_prop')).to.equal undefined
     expect(root1.get('dict_prop')).to.equal undefined
     expect(root1.get('obj_prop')).to.equal undefined
     expect(root1.get('dict_of_list_prop')).to.equal undefined
 
-    expect(patch.events.length).to.equal 4
+    expect(patch.events.length).to.equal 5
 
     d.apply_json_patch(patch)
+    expect(root1.get('name')).to.equal null
     expect(root1.get('list_prop').length).to.equal 1
     expect(Object.keys(root1.get('dict_prop')).length).to.equal 1
     expect(root1.get('obj_prop')).to.be.an.instanceof(ModelWithConstructTimeChanges)


### PR DESCRIPTION
This is a request from @birdsarah we talked about yesterday. Some motivating examples for this.

* @birdsarah wants to allow one glyph to pull from multiple data sources, so an idea is to allow them to refer to fields prefixed by a model name. It could look like `MyGlyph(x="name1:x", fill_color="name2:color")` for example (syntax TBD, colon-separator is one idea).
* @fpliger was talking about a way for an app directory to have data files that are auto-loaded, say for example you have `foo.xls` or `foo.csv` in your app directory, we could have a spelling handler which would automatically load that into a data source model and name it `foo` or `data_source_foo` or whatever. Then you could refer to it from syntax like @birdsarah's or you could `curdoc().get_model_by_name('foo')` in the script portion of your application.
* Another use for this would be in the browser using JavaScript, if you name a model you can easily grab it from JS or coffee using `doc.get_model_by_name()`. (We don't necessarily have an easy way to get the _document_ right now, but we'll have to fix that too.)
* Finally we could let you set styles by name, once we have styles.

There's an ugly hack in here to deal with models that override `PlotObject.name` with an unrelated name. I submitted https://github.com/bokeh/bokeh/pull/3109 which whines about and prevents stuff like that in the future, but for the time being PlotObject and Document hack around this situation.

One caveat here, `PlotObject` already had a `name` field, but other than using it in `select` I wasn't sure what it was currently for, so maybe I'm abusing it. Technically, `PlotObject.select({ 'name' : name })` or something along those lines could be used already instead of this new `get_model_by_name` but I think `get_model_by_name` is more obvious and convenient.
