### PR TITLE
Async writes and session lock fixes

### DIFF
--- a/bokeh/server/connection.py
+++ b/bokeh/server/connection.py
@@ -35,8 +35,9 @@ class ServerConnection(object):
         return self.protocol.create('ERROR', message.header['msgid'], text)
 
     def send_patch_document(self, event):
+        """ Sends a PATCH-DOC message, returning a Future that's completed when it's written out. """
         msg = self.protocol.create('PATCH-DOC', [event])
-        self._socket.send_message(msg)
+        return self._socket.send_message(msg)
 
     @property
     def protocol(self):

--- a/bokeh/server/session.py
+++ b/bokeh/server/session.py
@@ -39,6 +39,42 @@ def _needs_document_lock(func):
         raise gen.Return(result)
     return _needs_document_lock_wrapper
 
+class _AsyncPeriodic(object):
+    """Like ioloop.PeriodicCallback except the 'func' is async and
+        returns a Future, and we wait for func to finish each time
+        before we call it again.  Plain ioloop.PeriodicCallback
+        can "pile up" invocations if they are taking too long.
+
+    """
+    def __init__(self, func, period, io_loop):
+        self._func = func
+        self._loop = io_loop
+        self._period = period
+        self._handle = None
+        self._last_start_time = None
+
+    def _step(self):
+        ''' Invoke async _func() and re-schedule next invocation '''
+        future = self._func()
+        def on_done(future):
+            now = self._loop.time()
+            duration = now - self._last_start_time
+            self._last_start_time = now
+            next_period = max(self._period - duration, 0)
+            self._handle = self._loop.call_later(next_period, self._step)
+            if future.exception() is not None:
+                log.error("Error thrown from periodic callback: %r", future.exception())
+        self._loop.add_future(future, on_done)
+
+    def start(self):
+        self._last_start_time = self._loop.time()
+        self._handle = self._loop.call_later(self._period, self._step)
+
+    def stop(self):
+        if self._handle is not None:
+            self._loop.remove_timeout(self._handle)
+            self._handle = None
+
 class ServerSession(object):
     ''' Hosts an application "instance" (an instantiated Document) for one or more connections.
 
@@ -108,8 +144,7 @@ class ServerSession(object):
         NOTE: periodic callbacks can only work within a session. It'll take no effect when bokeh output is html or notebook
 
         '''
-        from tornado import ioloop
-        cb = self._callbacks[callback.id] = ioloop.PeriodicCallback(
+        cb = self._callbacks[callback.id] = _AsyncPeriodic(
             self._wrap_document_callback(callback.callback), callback.period, io_loop=self._loop
         )
         cb.start()

--- a/bokeh/tests/test_client_server.py
+++ b/bokeh/tests/test_client_server.py
@@ -209,7 +209,10 @@ class TestClientServer(unittest.TestCase):
             assert len(client_session.document.roots) == 0
             server_root = SomeModelInTestClientServer(foo=42)
 
-            server_session.document.add_root(server_root)
+            def do_add_server_root():
+                server_session.document.add_root(server_root)
+            server_session.with_document_locked(do_add_server_root)
+
             def client_has_root():
                 return len(doc.roots) > 0
             client_session._connection._loop_until(client_has_root)
@@ -219,7 +222,10 @@ class TestClientServer(unittest.TestCase):
             assert server_root.foo == 42
 
             # Now try setting title on server side
-            server_session.document.title = "Server Title"
+            def do_set_server_title():
+                server_session.document.title = "Server Title"
+            server_session.with_document_locked(do_set_server_title)
+
             def client_title_set():
                 return client_session.document.title != document.DEFAULT_TITLE
             client_session._connection._loop_until(client_title_set)
@@ -227,7 +233,9 @@ class TestClientServer(unittest.TestCase):
             assert client_session.document.title == "Server Title"
 
             # Now modify a model within the server document
-            server_root.foo = 57
+            def do_set_property_on_server():
+                server_root.foo = 57
+            server_session.with_document_locked(do_set_property_on_server)
 
             # there is no great way to block until the server
             # has applied changes, since patches are sent
@@ -237,7 +245,10 @@ class TestClientServer(unittest.TestCase):
             client_session._connection._loop_until(client_change_made)
             assert client_root.foo == 57
 
-            server_session.document.remove_root(server_root)
+            def do_remove_server_root():
+                server_session.document.remove_root(server_root)
+            server_session.with_document_locked(do_remove_server_root)
+
             def client_lacks_root():
                 return len(doc.roots) == 0
             client_session._connection._loop_until(client_lacks_root)
@@ -316,7 +327,6 @@ class TestClientServer(unittest.TestCase):
             for ss in [server_session, client_session, server_session2]:
                 iocb = ss._callbacks[callback.id]
                 assert isinstance(iocb, PeriodicCallback)
-                assert iocb.callback == cb
                 assert iocb.callback_time == 1
                 assert iocb.io_loop == server.io_loop
                 assert iocb.is_running()
@@ -449,7 +459,9 @@ def test_server_changes_do_not_boomerang(monkeypatch):
         monkeypatch.setattr(server_session, '_handle_patch', get_angry)
 
         # Now modify the server document
-        server_root.foo = 57
+        def do_set_foo_property():
+            server_root.foo = 57
+        server_session.with_document_locked(do_set_foo_property)
 
         # there is no great way to block until the server
         # has applied changes, since patches are sent


### PR DESCRIPTION
This is supposed to close #3133 

TLDR fixes here are:
 * avoid backlog by waiting for writes and periodic callbacks to finish before queueing up more
 * take the session._lock when we run periodic and timeout callbacks

The avoid-write-backlog thing only "really" works with Tornado 4.3, which isn't in conda right now - so I'm testing here with compat shims that simulate 4.3 without actually waiting on the writes.
I guess that's better than hard-requiring 4.3, though with 4.3 things should work better on a loaded server.
