### PR TITLE
Move columns out of DataSource into ColumnDataSource.

### DIFF
--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -15,11 +15,6 @@ class DataSource(PlotObject):
     not generally useful to instantiate on its own.
 
     """
-
-    column_names = List(String, help="""
-    An list of names for all the columns in this DataSource.
-    """)
-
     selected = Dict(String, Dict(String, Any), default={
         '0d': {'flag': False, 'indices': []},
         '1d': {'indices': []},
@@ -48,19 +43,6 @@ class DataSource(PlotObject):
     A callback to run in the browser whenever the selection is changed.
     """)
 
-    def columns(self, *columns):
-        """ Returns a ColumnsRef object for a column or set of columns
-        on this data source.
-
-        Args:
-            *columns
-
-        Returns:
-            ColumnsRef
-
-        """
-        return ColumnsRef(source=self, columns=list(columns))
-
 class ColumnsRef(HasProps):
     """ A utility object to allow referring to a collection of columns
     from a specified data source, all together.
@@ -74,6 +56,7 @@ class ColumnsRef(HasProps):
     columns = List(String, help="""
     A list of column names to reference from ``source``.
     """)
+
 
 class ColumnDataSource(DataSource):
     """ Maps names of columns to sequences or arrays.
@@ -94,6 +77,10 @@ class ColumnDataSource(DataSource):
     data = Dict(String, Any, help="""
     Mapping of column names to sequences of data. The data can be, e.g,
     Python lists or tuples, NumPy arrays, etc.
+    """)
+
+    column_names = List(String, help="""
+    An list of names for all the columns in this DataSource.
     """)
 
     def __init__(self, *args, **kw):
@@ -218,6 +205,21 @@ class ColumnDataSource(DataSource):
         except (ValueError, KeyError):
             import warnings
             warnings.warn("Unable to find column '%s' in data source" % name)
+
+
+    def columns(self, *columns):
+        """ Returns a ColumnsRef object for a column or set of columns
+        on this data source.
+
+        Args:
+            *columns
+
+        Returns:
+            ColumnsRef
+
+        """
+        return ColumnsRef(source=self, columns=list(columns))
+
 
     # def push_notebook(self):
     #     """ Update date for a plot in the IPthon notebook in place.


### PR DESCRIPTION
Not all DataSources will have columns in the future. In particular, this is setting up creating a new GeoJSONDataSource.

I have tested this on the AjaxDataSource examples in plotting and they still work but nothing else.

Some questions / notes:
1) I'm thinking selected property should stay on DataSource, is that correct? I think it's ok if DataSources have to implement some way of populating that. If we don't then it will be hard to have a common infrastructure for handling selections. ping @bryevdv 
2) remove ServerDataSource (made a note on #3140)
3) Worth noting that the class hierarchy is DataSource -> RemoteDataSource -> AjaxDataSource in python, but on JS side it's ColumnDataSource -> RemoteDataSource -> AjaxDataSource. Don't think we need to change this now (esp as I'm about to do the same thing for GeoJSON but it is a bit inconsistent)