### PR TITLE
Embed Bokeh version information in Document.to_json

### DIFF
--- a/bokeh/document.py
+++ b/bokeh/document.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__file__)
 
 import uuid
 from bokeh.util.callback_manager import _check_callback
+from bokeh.util.version import __version__, __base_version__
 from bokeh._json_encoder import serialize_json
 from .plot_object import PlotObject
 from .validation import check_integrity
@@ -346,6 +347,10 @@ class Document(object):
             'roots' : {
                 'root_ids' : root_ids,
                 'references' : self._references_json(root_references)
+            },
+            'version' : {
+                'full' : __version__,
+                'base' : __base_version__
             }
         }
 

--- a/bokeh/tests/test_document.py
+++ b/bokeh/tests/test_document.py
@@ -320,6 +320,14 @@ class TestDocument(unittest.TestCase):
         some_root = next(iter(copy.roots))
         assert some_root.child.foo == 44
 
+    def test_serialization_has_version(self):
+        from bokeh import __version__
+        from bokeh import __base_version__
+        d = document.Document()
+        json = d.to_json()
+        assert json['version']['base'] == __base_version__
+        assert json['version']['full'] == __version__
+
     def test_patch_integer_property(self):
         d = document.Document()
         assert not d.roots


### PR DESCRIPTION
This is for #3104 but doesn't include adding the version info to the BokehJS side because to do that I think I need the scripts:generate setup which is in #3099 PR. Anyway we could merge the Python part here I suppose.
