### PR TITLE
Remove blue :focus styling from chrome

### DIFF
--- a/bokehjs/src/less/main.less
+++ b/bokehjs/src/less/main.less
@@ -148,3 +148,7 @@
   padding-left: 50px;
   padding-bottom: 10px;
 }
+
+.bk-toolbar-button.hover:focus {
+  outline: none;
+}


### PR DESCRIPTION
Fixes #3167 (at least the blue bit - the tools are working fine for me)