### PR TITLE
Add gulp dev-build task for faster development

### DIFF
--- a/bokehjs/gulp/tasks/build.coffee
+++ b/bokehjs/gulp/tasks/build.coffee
@@ -5,3 +5,6 @@ runSequence = require "run-sequence"
 
 gulp.task "build", (cb) ->
   runSequence(["scripts", "styles"], cb)
+
+gulp.task "dev-build", (cb) ->
+  runSequence(["scripts:build", "styles:build"], cb)

--- a/sphinx/source/docs/dev_guide/building.rst
+++ b/sphinx/source/docs/dev_guide/building.rst
@@ -119,6 +119,13 @@ where the built resources should be produced:
 
     gulp build --build-dir=/home/bokeh/mybuilddir
 
+For faster development turnaround, you can skip the very slow minification
+step of the build by issuing:
+
+.. code-block:: sh
+
+    gulp dev-build
+
 To direct Gulp to automatically watch the source tree for changes and
 trigger a recompile if any source file changes:
 


### PR DESCRIPTION
Add `gulp dev-build`, an equivalent to `gulp scripts:build styles:build` (no minification step).