### PR TITLE
Add missing call to output_file in quickstart.rst

### DIFF
--- a/sphinx/source/docs/quickstart.rst
+++ b/sphinx/source/docs/quickstart.rst
@@ -342,6 +342,9 @@ things to look out for in this example:
     y1 = np.cos(x)
     y2 = np.sin(x) + np.cos(x)
 
+    # output to static HTML file
+    output_file("linked_panning.html")
+
     # create a new plot
     s1 = figure(width=250, plot_height=250, title=None)
     s1.circle(x, y0, size=10, color="navy", alpha=0.5)


### PR DESCRIPTION
The example in the section "Linked panning and brushing"
in the Quickstart documentation appear to be missing a call to
bokeh.plotting.output_file. Without this call, running the example
produces no output.