### PR TITLE
Fix typos in documentation, comments, and strings.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ and let everybody know that you intend to work on it.
 
       `python -c "import bokeh; print(bokeh.print_versions())"`
 
-5. Include relevent browser information (if the issue is browser-related). Just saying that you 
+5. Include relevant browser information (if the issue is browser-related). Just saying that you
    use Chrome is generally not sufficient. We may ask you for additional information to 
    reproduce and fix the issue.
 6. Include relevant JavaScript console and/or `bokeh-server` logs. 

--- a/bokeh/charts/builders/line_builder.py
+++ b/bokeh/charts/builders/line_builder.py
@@ -57,7 +57,7 @@ def Line(data=None, x=None, y=None, **kws):
     .. note::
         This chart type differs on input types as compared to other charts,
         due to the way that line charts typically are plotting labeled series. For
-        example, a column for APPL stock prices over time. Another way this could be
+        example, a column for AAPL stock prices over time. Another way this could be
         plotted is to have a DataFrame with a column of `stock_label` and columns of
         `price`, which is the stacked format. Both should be supported, but the former
         is the expected one. Internally, the latter format is being derived.

--- a/bokeh/charts/data_source.py
+++ b/bokeh/charts/data_source.py
@@ -140,7 +140,7 @@ class DataGroup(object):
     """
 
     def __init__(self, label, data, attr_specs):
-        """Create a DataGroup for the data, with a label and assoicated attributes.
+        """Create a DataGroup for the data, with a label and associated attributes.
 
         Args:
             label (str): the label for the group based on unique values of each column

--- a/bokeh/charts/models.py
+++ b/bokeh/charts/models.py
@@ -24,7 +24,7 @@ class CompositeGlyph(HasProps):
     oriented data source level, segmenting and assigning
     attributes from a large selection, while the composite glyphs
     will typically be passed an array-like structures with
-    one or more singlular attributes to apply.
+    one or more singular attributes to apply.
 
     Another way to explain the concept is that the Builder
     operates as the groupby, as in pandas, while the

--- a/bokeh/charts/properties.py
+++ b/bokeh/charts/properties.py
@@ -60,7 +60,7 @@ class Logical(Bool):
             if isinstance(value, list):
                 value = np.array(value)
 
-            # If not a Bool, then look for psuedo-logical types
+            # If not a Bool, then look for pseudo-logical types
             if isinstance(value, np.ndarray):
                 values = np.unique(value)
                 if len(values) == 2:

--- a/bokeh/command/bootstrap.py
+++ b/bokeh/command/bootstrap.py
@@ -12,7 +12,7 @@ from .util import die
 from . import subcommands
 
 def main(argv):
-    ''' Exectute the Bokeh command.
+    ''' Execute the Bokeh command.
 
     Args:
         argv (seq[str]) : a list of command line arguments to process

--- a/bokeh/compat/bokeh_renderer.py
+++ b/bokeh/compat/bokeh_renderer.py
@@ -258,7 +258,7 @@ class BokehRenderer(Renderer):
         text = Text(x=x, y=y, text=[text])
 
         alignment_map = {"center": "middle", "top": "top", "bottom": "bottom", "baseline": "bottom"}
-        # baseline not implemented in Bokeh, deafulting to bottom.
+        # baseline not implemented in Bokeh, defaulting to bottom.
         text.text_alpha = style['alpha']
         text.text_font_size = "%dpx" % style['fontsize']
         text.text_color = style['color']

--- a/bokeh/compat/mpl.py
+++ b/bokeh/compat/mpl.py
@@ -44,7 +44,7 @@ def to_bokeh(fig=None, name=None, server=None, notebook=None, pd_obj=True, xkcd=
 
     server: str (default=None)
         Fully specified URL of bokeh plot server. Default bokeh plot server
-        URL is "http://localhost:5006" or simply "deault"
+        URL is "http://localhost:5006" or simply "default"
 
     notebook: bool (default=False)
         Return an output value from this function which represents an HTML
@@ -52,7 +52,7 @@ def to_bokeh(fig=None, name=None, server=None, notebook=None, pd_obj=True, xkcd=
         a bokeh plot server just specifying the URL.
 
     pd_obj: bool (default=True)
-        The implementation asumes you are plotting using the pandas.
+        The implementation assumes you are plotting using the pandas.
         You have the option to turn it off (False) to plot the datetime xaxis
         with other non-pandas interfaces.
 

--- a/bokeh/compat/mpl_helpers.py
+++ b/bokeh/compat/mpl_helpers.py
@@ -72,8 +72,8 @@ def get_props_cycled(col, prop, fx=lambda x: x):
 
     col: matplotlib collection object
     prop: property we want to get from matplotlib collection
-    fx: funtion (optional) to transform the elements from list obtained
-        after the property call. Deafults to identity function.
+    fx: function (optional) to transform the elements from list obtained
+        after the property call. Defaults to identity function.
     """
     n = len(col.get_paths())
     t_prop = [fx(x) for x in prop]

--- a/bokeh/compat/mplexporter/exporter.py
+++ b/bokeh/compat/mplexporter/exporter.py
@@ -35,7 +35,7 @@ class Exporter(object):
         """
         Run the exporter on the given figure
 
-        Parmeters
+        Parameters
         ---------
         fig : matplotlib.Figure instance
             The figure to export
@@ -173,9 +173,9 @@ class Exporter(object):
                     self.draw_collection(ax, child,
                                          force_pathtrans=ax.transAxes)
                 else:
-                    warnings.warn("Legend element %s not impemented" % child)
+                    warnings.warn("Legend element %s not implemented" % child)
             except NotImplementedError:
-                warnings.warn("Legend element %s not impemented" % child)
+                warnings.warn("Legend element %s not implemented" % child)
 
     def draw_line(self, ax, line, force_trans=None):
         """Process a matplotlib line and call renderer.draw_line"""

--- a/bokeh/compat/mplexporter/renderers/base.py
+++ b/bokeh/compat/mplexporter/renderers/base.py
@@ -120,7 +120,7 @@ class Renderer(object):
 
     def open_legend(self, legend, props):
         """
-        Beging commands for a particular legend.
+        Begin commands for a particular legend.
 
         Parameters
         ----------

--- a/bokeh/compat/mplexporter/utils.py
+++ b/bokeh/compat/mplexporter/utils.py
@@ -307,7 +307,7 @@ def get_axes_properties(ax):
 
 def iter_all_children(obj, skipContainers=False):
     """
-    Returns an iterator over all childen and nested children using
+    Returns an iterator over all children and nested children using
     obj's get_children() method
 
     if skipContainers is true, only childless objects are returned.

--- a/bokeh/document.py
+++ b/bokeh/document.py
@@ -1,5 +1,5 @@
 """ The document module provides the Document class, which is a container
-for all Bokeh objects that mustbe reflected to the client side BokehJS
+for all Bokeh objects that must be reflected to the client side BokehJS
 library.
 
 """

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -154,7 +154,7 @@ def components(models, resources=None, wrap_script=True, wrap_plot_info=True):
         return script, tuple(results)
 
 def _escape_code(code):
-    """ Escape JS/CS source code, so that it can be embbeded in a JS string.
+    """ Escape JS/CS source code, so that it can be embedded in a JS string.
 
     This is based on https://github.com/joliss/js-string-escape.
     """

--- a/bokeh/models/axes.py
+++ b/bokeh/models/axes.py
@@ -122,7 +122,7 @@ class Axis(GuideRenderer):
 
 @abstract
 class ContinuousAxis(Axis):
-    """ A base class for all numeric, non-categorica axes types.
+    """ A base class for all numeric, non-categorical axes types.
     ``ContinuousAxis`` is not generally useful to instantiate on its own.
 
     """

--- a/bokeh/models/component.py
+++ b/bokeh/models/component.py
@@ -7,7 +7,7 @@ from ..embed import notebook_div
 
 @abstract
 class Component(Model):
-    """ A base class for all embeddable models, i.e. plots and wigets. """
+    """ A base class for all embeddable models, i.e. plots and widgets. """
 
     disabled = Bool(False, help="""
     Whether the widget will be disabled when rendered. If ``True``,

--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -136,7 +136,7 @@ class PrintfTickFormatter(TickFormatter):
     """ Tick formatter based on a printf-style format string. """
 
     format = String("%s", help="""
-    The numer format, as defined as follows: the placeholder in the format
+    The number format, as defined as follows: the placeholder in the format
     string is marked by % and is followed by one or more of these elements,
     in this order:
 
@@ -146,7 +146,7 @@ class PrintfTickFormatter(TickFormatter):
 
     * An optional padding specifier
         Specifies what (if any) character to use for padding. Possible values
-        are 0 or any other character precedeed by a ``'`` (single quote). The
+        are 0 or any other character preceded by a ``'`` (single quote). The
         default is to pad with spaces.
 
     * An optional ``-`` sign

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -27,7 +27,7 @@ from .component import Component
 
 def _select_helper(args, kwargs):
     """
-    Allow fexible selector syntax.
+    Allow flexible selector syntax.
     Returns:
         a dict
     """
@@ -594,7 +594,7 @@ class GridPlot(Plot):
 
     def select(self, *args, **kwargs):
         ''' Query this object and all of its references for objects that
-        match the given selector. See Plot.select for detailed usage infomation.
+        match the given selector. See Plot.select for detailed usage information.
 
         Returns:
             seq[Model]

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -222,7 +222,7 @@ class ColumnDataSource(DataSource):
 
 
     # def push_notebook(self):
-    #     """ Update date for a plot in the IPthon notebook in place.
+    #     """ Update date for a plot in the IPython notebook in place.
 
     #     This function can be be used to update data in plot data sources
     #     in the IPython notebook, without having to use the Bokeh server.

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -110,7 +110,7 @@ class PreviewSaveTool(Tool):
 
     .. note::
         Work is ongoing to support headless (svg, png) image creation without
-        requireing user interaction. See  :bokeh-issue:`538` to track progress
+        requiring user interaction. See  :bokeh-issue:`538` to track progress
         or contribute.
 
     .. |save_icon| image:: /_images/icons/Save.png
@@ -122,7 +122,7 @@ class PreviewSaveTool(Tool):
 class ResetTool(Tool):
     """ *toolbar icon*: |reset_icon|
 
-    The reset tool is an action. When activated in teh toolbar, the tool
+    The reset tool is an action. When activated in the toolbar, the tool
     resets the data bounds of the plot to their values when the plot was
     initially created.
 
@@ -497,7 +497,7 @@ class HoverTool(Tool):
     .. note::
         The tooltips attribute can also be configured with a mapping type,
         e.g. ``dict`` or ``OrderedDict``. However, if a ``dict`` is used,
-        the visual presentation order is unpecified.
+        the visual presentation order is unspecified.
 
     """).accepts(Dict(String, String), lambda d: list(d.items()))
 

--- a/bokeh/models/widgets/layouts.py
+++ b/bokeh/models/widgets/layouts.py
@@ -1,4 +1,4 @@
-""" Various kinds of lyaout widgets.
+""" Various kinds of layout widgets.
 
 """
 from __future__ import absolute_import

--- a/bokeh/properties.py
+++ b/bokeh/properties.py
@@ -596,7 +596,7 @@ class MetaHasProps(type):
         # Historically code also tried changing the Property's
         # type or changing from Property to non-Property: these
         # overrides are bad conceptually because the type of a
-        # read-write propery is invariant.
+        # read-write property is invariant.
         cls_attrs = cls.__dict__.keys() # we do NOT want inherited attrs here
         for attr in cls_attrs:
             for base in bases:
@@ -952,7 +952,7 @@ class List(Seq):
     def __init__(self, item_type, default=[], help=None):
         # todo: refactor to not use mutable objects as default values.
         # Left in place for now because we want to allow None to express
-        # opional values. Also in Dict.
+        # optional values. Also in Dict.
         super(List, self).__init__(item_type, default=default, help=help)
 
     def _is_seq(self, value):

--- a/bokeh/query.py
+++ b/bokeh/query.py
@@ -55,7 +55,7 @@ def match(obj, selector, context=None):
     Returns:
         bool : True if the object matches, False otherwise
 
-    There are two selector keys that are handled specially. The first
+    There are two selector keys that are handled especially. The first
     is 'type', which will do an isinstance check::
 
         >>> from bokeh.plotting import line

--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -277,8 +277,8 @@ class JSResources(BaseResources):
     Attributes:
         logo_url : location of the BokehJS logo image
         css_raw : any raw CSS that needs to be places inside ``<style>`` tags
-        css_files : URLS od any CSS files that need to be loaed by ``<link>`` tags
-        messages : any informational messages concering this configuration
+        css_files : URLs of any CSS files that need to be loaded by ``<link>`` tags
+        messages : any informational messages concerning this configuration
 
     These attributes are often useful as template parameters when embedding
     Bokeh plots.
@@ -340,8 +340,8 @@ class CSSResources(BaseResources):
     Attributes:
         logo_url : location of the BokehJS logo image
         css_raw : any raw CSS that needs to be places inside ``<style>`` tags
-        css_files : URLS od any CSS files that need to be loaed by ``<link>`` tags
-        messages : any informational messages concering this configuration
+        css_files : URLs of any CSS files that need to be loaded by ``<link>`` tags
+        messages : any informational messages concerning this configuration
 
     These attributes are often useful as template parameters when embedding Bokeh plots.
 
@@ -402,8 +402,8 @@ class Resources(JSResources, CSSResources):
         js_raw : any raw JS that needs to be placed inside ``<script>`` tags
         css_raw : any raw CSS that needs to be places inside ``<style>`` tags
         js_files : URLs of any JS files that need to be loaded by ``<script>`` tags
-        css_files : URLS od any CSS files that need to be loaed by ``<link>`` tags
-        messages : any informational messages concering this configuration
+        css_files : URLs of any CSS files that need to be loaded by ``<link>`` tags
+        messages : any informational messages concerning this configuration
 
     These attributes are often useful as template parameters when embedding
     Bokeh plots.

--- a/bokeh/sampledata/stocks.py
+++ b/bokeh/sampledata/stocks.py
@@ -1,5 +1,5 @@
 '''
-This module provides some recorded stock data for the follwing stocks: AAPL, FB, GOOG, IBM, MSFT.
+This module provides some recorded stock data for the following stocks: AAPL, FB, GOOG, IBM, MSFT.
 Each set of data is available as an attribute on the module (e.g., stocks.AAPL) and the value is
 a dictionary with the structure:
 

--- a/bokeh/sampledata/world_cities.py
+++ b/bokeh/sampledata/world_cities.py
@@ -13,5 +13,5 @@ except (IOError, OSError):
 
 """
 The data in world_cities.csv was taken from the GeoNames cities5000.zip downloaded from http://www.geonames.org/export/
-on Tuesday September 15, 2015. Under cc-by licence (creative commons attributions license).
+on Tuesday September 15, 2015. Under cc-by license (creative commons attributions license).
 """

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -33,7 +33,7 @@ class BokehTornado(TornadoApplication):
         applications (dict of str : bokeh.application.Application) : map from paths to Application instances
             The application is used to create documents for each session.
         extra_patterns (seq[tuple]) : tuples of (str, http or websocket handler)
-            Use this argmument to add additional endpoints to custom deployments
+            Use this argument to add additional endpoints to custom deployments
             of the Bokeh Server.
 
     '''

--- a/bokeh/sphinxext/collapsible_code_block.py
+++ b/bokeh/sphinxext/collapsible_code_block.py
@@ -21,7 +21,7 @@ that Sphinx supplies, with the addition of one new option:
 
 heading : string
     A heading to put for the collapsible block. Clicking the heading
-    expands or collapes the block
+    expands or collapses the block
 
 Examples
 --------

--- a/bokeh/util/testing.py
+++ b/bokeh/util/testing.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import, print_function
 
 def skipIfPy3(message):
-    """ unittest decoractor to skip a test for Python 3
+    """ unittest decorator to skip a test for Python 3
 
     """
     from unittest import skipIf
@@ -12,7 +12,7 @@ def skipIfPy3(message):
 
 
 def skipIfPyPy(message):
-    """ unittest decoractor to skip a test for PyPy
+    """ unittest decorator to skip a test for PyPy
 
     """
     from unittest import skipIf

--- a/examples/app/crossfilter/README.md
+++ b/examples/app/crossfilter/README.md
@@ -1,5 +1,5 @@
 
-This example shows how to create a crossfiter applet in Bokeh, which can
+This example shows how to create a crossfilter applet in Bokeh, which can
 be viewed directly on a bokeh-server.
 
 Running

--- a/examples/embed/README.md
+++ b/examples/embed/README.md
@@ -1,4 +1,4 @@
-### Embed mutltiple
+### Embed multiple
 
 To run the example:
 

--- a/examples/plotting/notebook/README.md
+++ b/examples/plotting/notebook/README.md
@@ -1,6 +1,6 @@
 
 The examples in this directory illustrate the use of Bokeh inside the IPython
-noteboook. To view the examples here, first execute 'ipython notebook' in this 
+notebook. To view the examples here, first execute 'ipython notebook' in this
 directory. A web browser should automatically open up to the IPython Dashboard
 at localhost:8891 (or you may navigate there manually). Click on any of the 
 notebooks listed to open and explore.


### PR DESCRIPTION
I ignored any typos with legacy charts since they will soon be deprecated.

Fixes #3228.