### PR TITLE
Add more missing calls to output_file in plotting

### DIFF
--- a/sphinx/source/docs/user_guide/source_examples/plotting_ovals.py
+++ b/sphinx/source/docs/user_guide/source_examples/plotting_ovals.py
@@ -1,5 +1,7 @@
 from math import pi
-from bokeh.plotting import figure, show
+from bokeh.plotting import figure, show, output_file
+
+output_file('ovals.html')
 
 p = figure(width=400, height=400)
 p.oval(x=[1, 2, 3], y=[1, 2, 3], width=0.2, height=40, color="#CAB2D6",

--- a/sphinx/source/docs/user_guide/source_examples/plotting_rectangles.py
+++ b/sphinx/source/docs/user_guide/source_examples/plotting_rectangles.py
@@ -1,4 +1,6 @@
-from bokeh.plotting import figure, show
+from bokeh.plotting import figure, show, output_file
+
+output_file('rectangles.html')
 
 p = figure(width=400, height=400)
 p.quad(top=[2, 3, 4], bottom=[1, 2, 3], left=[1, 2, 3],

--- a/sphinx/source/docs/user_guide/source_examples/plotting_rectangles_rotated.py
+++ b/sphinx/source/docs/user_guide/source_examples/plotting_rectangles_rotated.py
@@ -1,5 +1,7 @@
 from math import pi
-from bokeh.plotting import figure, show
+from bokeh.plotting import figure, show, output_file
+
+output_file('rectangles_rotated.html')
 
 p = figure(width=400, height=400)
 p.rect(x=[1, 2, 3], y=[1, 2, 3], width=0.2, height=40, color="#CAB2D6",


### PR DESCRIPTION
Examples in subsection "Rectangles and Ovals" lack
calls to output_file