### PR TITLE
Add tags default in coffeescript

### DIFF
--- a/bokehjs/src/coffee/common/has_properties.coffee
+++ b/bokehjs/src/coffee/common/has_properties.coffee
@@ -312,7 +312,10 @@ class HasProperties extends Backbone.Model
     # make this a no-op, we sync the whole document never individual models
     return options.success(model.attributes, null, {})
 
-  defaults: () -> { 'name' : null }
+  defaults: -> {
+    'name' : null,
+    'tags' : []
+  }
 
   # TODO remove this, for now it's just to help find nonserializable_attribute_names we
   # need to add.

--- a/bokehjs/src/coffee/renderer/glyph/glyph.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/glyph.coffee
@@ -309,7 +309,7 @@ class Glyph extends HasParent
   }
 
   defaults: ->
-    return _.extend {
+    return _.extend {}, super(), {
       visible: true
     }
 

--- a/bokehjs/test/test_common/test_document.coffee
+++ b/bokehjs/test/test_common/test_document.coffee
@@ -275,11 +275,14 @@ describe "Document", ->
     expect(root1.get('dict_prop')).to.equal undefined
     expect(root1.get('obj_prop')).to.equal undefined
     expect(root1.get('dict_of_list_prop')).to.equal undefined
+    expect(root1.get('name')).to.equal undefined
+    expect(root1.get('tags')).to.equal undefined
 
-    expect(patch.events.length).to.equal 5
+    expect(patch.events.length).to.equal 6
 
     d.apply_json_patch(patch)
     expect(root1.get('name')).to.equal null
+    expect(root1.get('tags').length).to.equal 0
     expect(root1.get('list_prop').length).to.equal 1
     expect(Object.keys(root1.get('dict_prop')).length).to.equal 1
     expect(root1.get('obj_prop')).to.be.an.instanceof(ModelWithConstructTimeChanges)


### PR DESCRIPTION
This is pulling some work out of #3099 in order to shrink that PR. We will probably close #3099 after pulling everything out but for now #3099 is useful for coordinating the remaining tasks to sync defaults.
