### PR TITLE
Always use skinny arrow for methods, add `gulp lint`

### DIFF
--- a/bokehjs/gulp/tasks/lint.coffee
+++ b/bokehjs/gulp/tasks/lint.coffee
@@ -1,0 +1,35 @@
+gulp = require "gulp"
+paths = require "../paths"
+es = require "event-stream"
+coffeelint = require('gulp-coffeelint')
+
+rule_levels = {
+  'max_line_length' : 'ignore'
+
+  # This is disabled because @register_property and @listenTo
+  # cause false positives since they automatically set up `this`
+  # 'missing_fat_arrows' : 'warn'
+
+  # this should DEFINITELY not be ignored but fixing one thing at
+  # a time...
+  'duplicate_key' : 'ignore'
+
+  # these should probably be enabled, though it's fairly annoying
+  # to have a linter that complains about whitespace when it could
+  # just auto-fix it. So we could consider adding a formatter
+  # instead.
+  'no_trailing_whitespace' : 'ignore'
+  'indentation' : 'ignore'
+  'no_trailing_semicolons' : 'ignore'
+  'no_tabs' : 'ignore'
+}
+
+options = {}
+
+for k, v of rule_levels
+  options[k] = { 'level' : v }
+
+gulp.task "lint", ->
+  gulp.src('./src/coffee/**/*.coffee')
+    .pipe(coffeelint(null, options))
+    .pipe(coffeelint.reporter())

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -29,6 +29,7 @@
     "eco": "^1.1.0-rc-3",
     "gulp": "^3.9.0",
     "gulp-change": "^1.0.0",
+    "gulp-coffeelint": "^0.5.0",
     "gulp-eco-template": "^0.1.0",
     "gulp-insert": "^0.5.0",
     "gulp-less": "^3.0.2",

--- a/bokehjs/src/coffee/common/cartesian_frame.coffee
+++ b/bokehjs/src/coffee/common/cartesian_frame.coffee
@@ -41,7 +41,7 @@ class CartesianFrame extends LayoutBox.Model
       , true)
     @add_dependencies('mapper', this, ['x_mapper', 'y_mapper'])
 
-    @listenTo(@solver, 'layout_update', @_update_mappers)
+    @listenTo(@solver, 'layout_update', () => @_update_mappers())
 
   map_to_screen: (x, y, canvas, x_name='default', y_name='default') ->
     vx = @get('x_mappers')[x_name].v_map_to_target(x)

--- a/bokehjs/src/coffee/common/client.coffee
+++ b/bokehjs/src/coffee/common/client.coffee
@@ -298,7 +298,7 @@ class ClientConnection
       @_pending_ack[1](new Error("Lost websocket connection, #{event.code} (#{event.reason})"))
       @_pending_ack = null
 
-    pop_pending = () ->
+    pop_pending = () =>
       for reqid, promise_funcs of @_pending_replies
         delete @_pending_replies[reqid]
         return promise_funcs

--- a/bokehjs/src/coffee/common/gmap_plot.coffee
+++ b/bokehjs/src/coffee/common/gmap_plot.coffee
@@ -10,7 +10,7 @@ class GMapPlotView extends Plot.View
     super(_.defaults(options, @default_options))
     @zoom_count = 0
 
-  getLatLngBounds: () =>
+  getLatLngBounds: () ->
     bounds = @map.getBounds()
     top_right = bounds.getNorthEast()
     bottom_left = bounds.getSouthWest()
@@ -21,13 +21,13 @@ class GMapPlotView extends Plot.View
     yend = top_right.lat()
     return [xstart, xend, ystart, yend]
 
-  getProjectedBounds: () =>
+  getProjectedBounds: () ->
     [xstart, xend, ystart, yend] = @getLatLngBounds()
     [proj_xstart, proj_ystart] = proj4(toProjection, [xstart, ystart])
     [proj_xend, proj_yend] = proj4(toProjection, [xend, yend])
     return [proj_xstart, proj_xend, proj_ystart, proj_yend]
 
-  setRanges: () =>
+  setRanges: () ->
     [proj_xstart, proj_xend, proj_ystart, proj_yend] = @getProjectedBounds()
     @x_range.set({start: proj_xstart, end: proj_xend, silent:true})
     @y_range.set({start: proj_ystart, end: proj_yend, silent:true})
@@ -108,7 +108,7 @@ class GMapPlotView extends Plot.View
 
       # Create the map with above options in div
       @map = new maps.Map(@canvas_view.map_div[0], map_options)
-      maps.event.addListenerOnce(@map, 'idle', @setRanges)
+      maps.event.addListenerOnce(@map, 'idle', () => @setRanges())
 
     if not window._bokeh_gmap_loads?
       window._bokeh_gmap_loads = []

--- a/bokehjs/src/coffee/common/grid_plot.coffee
+++ b/bokehjs/src/coffee/common/grid_plot.coffee
@@ -130,7 +130,7 @@ class GridToolManager extends ToolManager.Model
 
 class GridViewState extends HasProperties
 
-  setup_layout_properties: () =>
+  setup_layout_properties: () ->
     @register_property('layout_heights', @layout_heights, false)
     @register_property('layout_widths', @layout_widths, false)
     for row in @get('viewstates')
@@ -141,7 +141,7 @@ class GridViewState extends HasProperties
   initialize: (attrs, options) ->
     super(attrs, options)
     @setup_layout_properties()
-    @listenTo(this, 'change:viewstates', @setup_layout_properties)
+    @listenTo(this, 'change:viewstates', () => @setup_layout_properties())
     calculateHeight = =>
       _.reduce @get("layout_heights"), ((x, y) -> x + y), 0
     @register_property('height', calculateHeight, false)
@@ -168,11 +168,11 @@ class GridViewState extends HasProperties
         return 0
       ))
 
-  layout_heights: () =>
+  layout_heights: () ->
     row_heights = (@maxdim('height',row) for row in @get('viewstates'))
     return row_heights
 
-  layout_widths: () =>
+  layout_widths: () ->
     num_cols = @get('viewstates')[0].length
     columns = ((row[n] for row in @get('viewstates')) for n in _.range(num_cols))
     col_widths = (@maxdim('width', col) for col in columns)

--- a/bokehjs/src/coffee/common/grid_plot.coffee
+++ b/bokehjs/src/coffee/common/grid_plot.coffee
@@ -15,8 +15,8 @@ class ToolProxy extends Backbone.Model
     # OK this is pretty lame but should work until we make a new
     # better grid plot. This just mimics all the events that
     # any of the tool types might expect to get.
-    @listenTo(@, 'do', @do)
-    @listenTo(@, 'change:active', @active)
+    @listenTo(@, 'do', () => @do())
+    @listenTo(@, 'change:active', () => @active())
     return null
 
   do: () ->
@@ -210,10 +210,10 @@ class GridPlotView extends ContinuumView
     return this
 
   bind_bokeh_events: () ->
-    @listenTo(@model, 'change:children', @build_children)
-    @listenTo(@model, 'change', @render)
-    @listenTo(@viewstate, 'change', @render)
-    @listenTo(@model, 'destroy', @remove)
+    @listenTo(@model, 'change:children', () => @build_children())
+    @listenTo(@model, 'change', () => @render())
+    @listenTo(@viewstate, 'change', () => @render())
+    @listenTo(@model, 'destroy', () => @remove())
 
   build_children: () ->
     childmodels = []
@@ -239,7 +239,7 @@ class GridPlotView extends ContinuumView
       for plot in row
         if not plot?
           continue
-        @listenTo(plot.solver, 'layout_update', @render)
+        @listenTo(plot.solver, 'layout_update', () => @render())
 
   render: () ->
     super()

--- a/bokehjs/src/coffee/common/grid_plot.coffee
+++ b/bokehjs/src/coffee/common/grid_plot.coffee
@@ -76,7 +76,8 @@ class GridToolManager extends ToolManager.Model
           continue
         proxy = new ToolProxy({tools: tools})
         @get('gestures')[et].tools.push(proxy)
-        @listenTo(proxy, 'change:active', _.bind(@_active_change, proxy))
+        do (proxy) =>
+          @listenTo(proxy, 'change:active', () => @_active_change(proxy))
 
     for typ, tools of actions
       if tools.length != @get('num_plots')
@@ -101,7 +102,7 @@ class GridToolManager extends ToolManager.Model
       info.tools = _.sortBy(tools, (tool) -> tool.get('default_order'))
       info.tools[0].set('active', true)
 
-  _active_change: (tool) =>
+  _active_change: (tool) ->
     et = tool.get('event_type')
 
     active = tool.get('active')

--- a/bokehjs/src/coffee/common/has_properties.coffee
+++ b/bokehjs/src/coffee/common/has_properties.coffee
@@ -137,11 +137,11 @@ class HasProperties extends Backbone.Model
       for key, value of attrs
         @_tell_document_about_change(key, old[key], @get(key, resolve_refs=false))
 
-  convert_to_ref: (value) =>
+  convert_to_ref: (value) ->
     # converts value into a refrence if necessary
     # works vectorized
     if _.isArray(value)
-      return _.map(value, @convert_to_ref)
+      return _.map(value, (v) => @convert_to_ref(v))
     else
       if value instanceof HasProperties
         return value.ref()

--- a/bokehjs/src/coffee/common/plot.coffee
+++ b/bokehjs/src/coffee/common/plot.coffee
@@ -153,7 +153,7 @@ class PlotView extends ContinuumView
       throttled_resize = _.throttle((() => @resize()), 100)
       $(window).on("resize", throttled_resize)
       # Just need to wait a small delay so container has a width
-      _.delay(@resize, 10)
+      _.delay((() => @resize()), 10)
 
     @unpause()
 

--- a/bokehjs/src/coffee/common/plot.coffee
+++ b/bokehjs/src/coffee/common/plot.coffee
@@ -32,7 +32,7 @@ properties = require "./properties"
 
 global_gl_canvas = null
 
-get_size_for_available_space = (use_width, use_height, client_width, client_height, aspect_ratio, min_size) =>
+get_size_for_available_space = (use_width, use_height, client_width, client_height, aspect_ratio, min_size) ->
     # client_width and height represent the available size
     
     if use_width
@@ -74,12 +74,12 @@ class PlotView extends ContinuumView
     @is_paused = false
     @request_render()
 
-  request_render: () =>
+  request_render: () ->
     if not @is_paused
       @throttled_render(true)
     return
 
-  remove: () =>
+  remove: () ->
     super()
     # When this view is removed, also remove all of the tools.
     for id, tool_view of @tools
@@ -129,7 +129,7 @@ class PlotView extends ContinuumView
     @bind_bokeh_events()
 
     @model.add_constraints(@canvas.solver)
-    @listenTo(@canvas.solver, 'layout_update', @request_render)
+    @listenTo(@canvas.solver, 'layout_update', () => @request_render())
 
     @ui_event_bus = new UIEvents({
       tool_manager: @mget('tool_manager')
@@ -150,7 +150,7 @@ class PlotView extends ContinuumView
     @update_dataranges()
 
     if @mget('responsive')
-      throttled_resize = _.throttle(@resize, 100)
+      throttled_resize = _.throttle((() => @resize()), 100)
       $(window).on("resize", throttled_resize)
       # Just need to wait a small delay so container has a width
       _.delay(@resize, 10)
@@ -388,10 +388,10 @@ class PlotView extends ContinuumView
     # TODO - This should only be on in testing
     # @$el.find('canvas').attr('data-hash', ctx.hash());
 
-  resize: () =>
+  resize: () ->
     @resize_width_height(true, false)
   
-  resize_width_height: (use_width, use_height, maintain_ar=true) =>
+  resize_width_height: (use_width, use_height, maintain_ar=true) ->
     # Resize plot based on available width and/or height
     
     # kiwi.js falls over if we try and resize too small.

--- a/bokehjs/src/coffee/common/plot.coffee
+++ b/bokehjs/src/coffee/common/plot.coffee
@@ -112,7 +112,7 @@ class PlotView extends ContinuumView
       if window.location.search.indexOf('webgl=0') == -1
         @init_webgl()
 
-    @throttled_render = plot_utils.throttle_animation(@render, 15)
+    @throttled_render = plot_utils.throttle_animation(((force_canvas) -> @render(force_canvas)), 15)
 
     @outline_props = new properties.Line({obj: @model, prefix: 'outline_'})
     @title_props = new properties.Text({obj: @model, prefix: 'title_'})
@@ -233,12 +233,12 @@ class PlotView extends ContinuumView
 
   bind_bokeh_events: () ->
     for name, rng of @mget('frame').get('x_ranges')
-      @listenTo(rng, 'change', @request_render)
+      @listenTo(rng, 'change', () => @request_render())
     for name, rng of @mget('frame').get('y_ranges')
-      @listenTo(rng, 'change', @request_render)
-    @listenTo(@model, 'change:renderers', @build_levels)
-    @listenTo(@model, 'change:tool', @build_levels)
-    @listenTo(@model, 'change', @request_render)
+      @listenTo(rng, 'change', () => @request_render())
+    @listenTo(@model, 'change:renderers', () => @build_levels())
+    @listenTo(@model, 'change:tool', () => @build_levels())
+    @listenTo(@model, 'change', () => @request_render())
     @listenTo(@model, 'destroy', () => @remove())
 
   set_initial_range : () ->

--- a/bokehjs/src/coffee/common/tool_manager.coffee
+++ b/bokehjs/src/coffee/common/tool_manager.coffee
@@ -99,7 +99,8 @@ class ToolManager extends HasProperties
           continue
 
         gestures[et].tools.push(tool)
-        @listenTo(tool, 'change:active', () => @_active_change(tool))
+        do (tool) =>
+          @listenTo(tool, 'change:active', () => @_active_change(tool))
 
     for et of gestures
       tools = gestures[et].tools

--- a/bokehjs/src/coffee/common/tool_manager.coffee
+++ b/bokehjs/src/coffee/common/tool_manager.coffee
@@ -15,7 +15,7 @@ class ToolManagerView extends Backbone.View
 
   initialize: (options) ->
     super(options)
-    @listenTo(@model, 'change', @render)
+    @listenTo(@model, 'change', () => @render())
     @render()
 
   render: () ->

--- a/bokehjs/src/coffee/common/tool_manager.coffee
+++ b/bokehjs/src/coffee/common/tool_manager.coffee
@@ -99,7 +99,7 @@ class ToolManager extends HasProperties
           continue
 
         gestures[et].tools.push(tool)
-        @listenTo(tool, 'change:active', _.bind(@_active_change, tool))
+        @listenTo(tool, 'change:active', () => @_active_change(tool))
 
     for et of gestures
       tools = gestures[et].tools
@@ -109,7 +109,7 @@ class ToolManager extends HasProperties
       if et not in ['pinch', 'scroll']
         gestures[et].tools[0].set('active', true)
 
-  _active_change: (tool) =>
+  _active_change: (tool) ->
     event_type = tool.get('event_type')
     gestures = @get('gestures')
 

--- a/bokehjs/src/coffee/common/ui_events.coffee
+++ b/bokehjs/src/coffee/common/ui_events.coffee
@@ -57,36 +57,35 @@ class UIEvents extends Backbone.Model
       logger.debug("Button tool: #{type}")
       return
 
+    listenTo = (event_name, method_name) =>
+      if tool_view[method_name]?
+        tool_view.listenTo(@, event_name, () -> tool_view[method_name].apply(tool_view, arguments))
+
     if et in ['pan', 'pinch', 'rotate']
       logger.debug("Registering tool: #{type} for event '#{et}'")
-      if tool_view["_#{et}_start"]?
-        tool_view.listenTo(@, "#{et}:start:#{id}", tool_view["_#{et}_start"])
-      if tool_view["_#{et}"]
-        tool_view.listenTo(@, "#{et}:#{id}",       tool_view["_#{et}"])
-      if tool_view["_#{et}_end"]
-        tool_view.listenTo(@, "#{et}:end:#{id}",   tool_view["_#{et}_end"])
+      listenTo("#{et}:start:#{id}", "_#{et}_start")
+      listenTo("#{et}:#{id}",       "_#{et}")
+      listenTo("#{et}:end:#{id}",   "_#{et}_end")
     else if et == "move"
       logger.debug("Registering tool: #{type} for event '#{et}'")
-      if tool_view._move_enter?
-        tool_view.listenTo(@, "move:enter", tool_view._move_enter)
-      tool_view.listenTo(@, "move", tool_view["_move"])
-      if tool_view._move_exit?
-        tool_view.listenTo(@, "move:exit", tool_view._move_exit)
+      listenTo("move:enter", "_move_enter")
+      listenTo("move", "_move")
+      listenTo("move:exit", "_move_exit")
     else
       logger.debug("Registering tool: #{type} for event '#{et}'")
-      tool_view.listenTo(@, "#{et}:#{id}", tool_view["_#{et}"])
+      listenTo("#{et}:#{id}", "_#{et}")
 
     if tool_view._keydown?
       logger.debug("Registering tool: #{type} for event 'keydown'")
-      tool_view.listenTo(@, "keydown", tool_view._keydown)
+      listenTo("keydown", "_keydown")
 
     if tool_view._keyup?
       logger.debug("Registering tool: #{type} for event 'keyup'")
-      tool_view.listenTo(@, "keyup", tool_view._keyup)
+      listenTo("keyup", "_keyup")
 
     if tool_view._doubletap?
       logger.debug("Registering tool: #{type} for event 'doubletap'")
-      tool_view.listenTo(@, "doubletap", tool_view._doubletap)
+      listenTo("doubletap", "_doubletap")
 
   _trigger: (event_type, e) ->
     tm = @get('tool_manager')

--- a/bokehjs/src/coffee/renderer/annotation/span.coffee
+++ b/bokehjs/src/coffee/renderer/annotation/span.coffee
@@ -14,7 +14,7 @@ class SpanView extends PlotWidget
     @$el.hide()
 
   bind_bokeh_events: () ->
-    @listenTo(@model, 'change:location', @_draw_span)
+    @listenTo(@model, 'change:location', () => @_draw_span())
 
   render: () ->
     @_draw_span()

--- a/bokehjs/src/coffee/renderer/annotation/tooltip.coffee
+++ b/bokehjs/src/coffee/renderer/annotation/tooltip.coffee
@@ -15,7 +15,7 @@ class TooltipView extends PlotWidget
     @$el.hide()
 
   bind_bokeh_events: () ->
-    @listenTo(@model, 'change:data', @_draw_tips)
+    @listenTo(@model, 'change:data', () => @_draw_tips())
 
   render: () ->
     @_draw_tips()

--- a/bokehjs/src/coffee/renderer/glyph/glyph_renderer.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/glyph_renderer.coffee
@@ -44,10 +44,10 @@ class GlyphRendererView extends PlotWidget
     new model.default_view({model: model, renderer: this})
 
   bind_bokeh_events: () ->
-    @listenTo(@model, 'change', @request_render)
-    @listenTo(@mget('data_source'), 'change', @set_data)
-    @listenTo(@mget('data_source'), 'select', @request_render)
-    @listenTo(@mget('data_source'), 'inspect', @request_render)
+    @listenTo(@model, 'change', () => @request_render)
+    @listenTo(@mget('data_source'), 'change', (request_render, arg) => @set_data(request_render, arg))
+    @listenTo(@mget('data_source'), 'select', () => @request_render())
+    @listenTo(@mget('data_source'), 'inspect', () => @request_render())
 
     # TODO (bev) This is a quick change that  allows the plot to be
     # update/re-rendered when properties change on the JS side. It would

--- a/bokehjs/src/coffee/renderer/glyph/image_url.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/image_url.coffee
@@ -6,7 +6,7 @@ class ImageURLView extends Glyph.View
 
   initialize: (options) ->
     super(options)
-    @listenTo(@model, 'change:global_alpha', @renderer.request_render)
+    @listenTo(@model, 'change:global_alpha', () => @renderer.request_render())
 
   _index_data: () ->
 

--- a/bokehjs/src/coffee/renderer/guide/axis.coffee
+++ b/bokehjs/src/coffee/renderer/guide/axis.coffee
@@ -175,7 +175,7 @@ class AxisView extends PlotWidget
     ctx.restore()
 
   bind_bokeh_events: () ->
-    @listenTo(@model, 'change', @plot_view.request_render)
+    @listenTo(@model, 'change', () => @plot_view.request_render())
 
   _draw_rule: (ctx) ->
     if not @rule_props.do_stroke

--- a/bokehjs/src/coffee/renderer/guide/grid.coffee
+++ b/bokehjs/src/coffee/renderer/guide/grid.coffee
@@ -22,7 +22,7 @@ class GridView extends PlotWidget
     ctx.restore()
 
   bind_bokeh_events: () ->
-    @listenTo(@model, 'change', @request_render)
+    @listenTo(@model, 'change', () => @request_render())
 
   _draw_regions: (ctx) ->
     if not @band_props.do_fill

--- a/bokehjs/src/coffee/renderer/overlay/box_selection.coffee
+++ b/bokehjs/src/coffee/renderer/overlay/box_selection.coffee
@@ -11,7 +11,7 @@ class BoxSelectionView extends PlotWidget
     @$el.hide()
 
   bind_bokeh_events: () ->
-    @listenTo(@model, 'change:data', @_draw_box)
+    @listenTo(@model, 'change:data', () => @_draw_box())
 
   render: () ->
     @_draw_box()

--- a/bokehjs/src/coffee/renderer/overlay/poly_selection.coffee
+++ b/bokehjs/src/coffee/renderer/overlay/poly_selection.coffee
@@ -11,7 +11,7 @@ class PolySelectionView extends PlotWidget
     @fill = new properties.Fill({obj: @model, prefix: ""})
 
   bind_bokeh_events: () ->
-    @listenTo(@model, 'change:data', @plot_view.request_render)
+    @listenTo(@model, 'change:data', () => @plot_view.request_render())
 
   render: (ctx) ->
     data = _.clone(@mget('data'))

--- a/bokehjs/src/coffee/renderer/tile/tile_renderer.coffee
+++ b/bokehjs/src/coffee/renderer/tile/tile_renderer.coffee
@@ -66,19 +66,19 @@ class TileRendererView extends PlotWidget
     @y_range.set('end', new_extent[3])
     @_add_attribution()
 
-  _on_tile_load: (e) =>
+  _on_tile_load: (e) ->
     tile_data = e.target.tile_data
     tile_data.img = e.target
     tile_data.current = true
     tile_data.loaded = true
     @request_render()
 
-  _on_tile_cache_load: (e) =>
+  _on_tile_cache_load: (e) ->
     tile_data = e.target.tile_data
     tile_data.img = e.target
     tile_data.loaded = true
 
-  _on_tile_error: (e) =>
+  _on_tile_error: (e) ->
     return ''
 
   _is_valid_tile: (x, y, z) ->
@@ -92,11 +92,11 @@ class TileRendererView extends PlotWidget
     tile = @pool.pop()
 
     if cache_only
-      tile.onload = @_on_tile_cache_load
+      tile.onload = (e) => @_on_tile_cache_load(e)
     else
-      tile.onload = @_on_tile_load
+      tile.onload = (e) => @_on_tile_load(e)
 
-    tile.onerror = @_on_tile_error
+    tile.onerror = (e) => @_on_tile_error(e)
     tile.alt = ''
 
     tile.tile_data =

--- a/bokehjs/src/coffee/source/ajax_data_source.coffee
+++ b/bokehjs/src/coffee/source/ajax_data_source.coffee
@@ -7,19 +7,21 @@ RemoteDataSource = require "./remote_data_source"
 #maybe generalize to ajax data source later?
 class AjaxDataSource extends RemoteDataSource.RemoteDataSource
   type: 'AjaxDataSource'
-  destroy : () =>
+  destroy : () ->
     if @interval?
       clearInterval(@interval)
 
-  setup : (plot_view, glyph) =>
+  setup : (plot_view, glyph) ->
     @pv = plot_view
     @get_data(@get('mode'))
     if @get('polling_interval')
-      @interval = setInterval(@get_data, @get('polling_interval'),
+      @interval = setInterval(((mode, max_size, if_modified) =>
+                                @get_data(mode, max_size, if_modified)),
+                              @get('polling_interval'),
                               @get('mode'), @get('max_size'),
                               @get('if_modified'))
 
-  get_data : (mode, max_size=0, if_modified=false) =>
+  get_data : (mode, max_size=0, if_modified=false) ->
     $.ajax(
       dataType: 'json'
       ifModified: if_modified
@@ -45,7 +47,7 @@ class AjaxDataSource extends RemoteDataSource.RemoteDataSource
     )
     return null
 
-  defaults: =>
+  defaults: ->
     return _.extend {}, super(), {
       mode: 'replace'
     }

--- a/bokehjs/src/coffee/source/blaze_data_source.coffee
+++ b/bokehjs/src/coffee/source/blaze_data_source.coffee
@@ -7,17 +7,17 @@ RemoteDataSource = require "./remote_data_source"
 
 class BlazeDataSource extends RemoteDataSource.RemoteDataSource
   type: 'BlazeDataSource'
-  destroy : () =>
+  destroy : () ->
     if @interval?
       clearInterval(@interval)
 
-  setup : (plot_view, glyph) =>
+  setup : (plot_view, glyph) ->
     @pv = plot_view
     @update()
     if @get('polling_interval')
-      @interval = setInterval(@update, @get('polling_interval'))
+      @interval = setInterval((() => @update()), @get('polling_interval'))
 
-  update : () =>
+  update : () ->
     data = JSON.stringify(
       expr : @get('expr')
       namespace : @get('namespace')

--- a/bokehjs/src/coffee/source/column_data_source.coffee
+++ b/bokehjs/src/coffee/source/column_data_source.coffee
@@ -40,7 +40,7 @@ class ColumnDataSource extends HasProperties
     # return the column names in this data source
     return _.keys(@get('data'))
 
-  defaults: =>
+  defaults: ->
     return _.extend {}, super(), {
       data: {}
       selection_manager: new SelectionManager({'source':@})

--- a/bokehjs/src/coffee/ticking/days_ticker.coffee
+++ b/bokehjs/src/coffee/ticking/days_ticker.coffee
@@ -49,7 +49,7 @@ class DaysTicker extends SingleIntervalTicker.Model
     month_dates = date_range_by_month(data_low, data_high)
 
     days = @get('days')
-    days_of_month = (month_date, interval) =>
+    days_of_month = (month_date, interval) ->
       dates = []
       for day in days
         day_date = copy_date(month_date)

--- a/bokehjs/src/coffee/tool/actions/action_tool.coffee
+++ b/bokehjs/src/coffee/tool/actions/action_tool.coffee
@@ -9,7 +9,7 @@ class ActionToolView extends ButtonTool.View
 
   initialize: (options) ->
     super(options)
-    @listenTo(@model, 'do', @do)
+    @listenTo(@model, 'do', () => @do())
 
 class ActionTool extends ButtonTool.Model
 

--- a/bokehjs/src/coffee/tool/button_tool.coffee
+++ b/bokehjs/src/coffee/tool/button_tool.coffee
@@ -17,7 +17,7 @@ class ButtonToolButtonView extends Backbone.View
   initialize: (options) ->
     super(options)
     @$el.html(@template(@model.attrs_and_props()))
-    @listenTo(@model, 'change:active', @render)
+    @listenTo(@model, 'change:active', () => @render())
     @render()
 
   render: () ->

--- a/bokehjs/src/coffee/tool/gestures/lasso_select_tool.coffee
+++ b/bokehjs/src/coffee/tool/gestures/lasso_select_tool.coffee
@@ -6,7 +6,7 @@ class LassoSelectToolView extends SelectTool.View
 
   initialize: (options) ->
     super(options)
-    @listenTo(@model, 'change:active', @_active_change)
+    @listenTo(@model, 'change:active', () => @_active_change(@model))
     @data = null
 
   _active_change: () ->

--- a/bokehjs/src/coffee/tool/gestures/poly_select_tool.coffee
+++ b/bokehjs/src/coffee/tool/gestures/poly_select_tool.coffee
@@ -6,7 +6,7 @@ class PolySelectToolView extends SelectTool.View
 
   initialize: (options) ->
     super(options)
-    @listenTo(@model, 'change:active', @_active_change)
+    @listenTo(@model, 'change:active', () => @_active_change(@model))
     @data = null
 
   _active_change: () ->

--- a/bokehjs/src/coffee/tool/inspectors/inspect_tool.coffee
+++ b/bokehjs/src/coffee/tool/inspectors/inspect_tool.coffee
@@ -12,7 +12,7 @@ class InspectToolListItemView extends Backbone.View
   }
 
   initialize: (options) ->
-    @listenTo(@model, 'change:active', @render)
+    @listenTo(@model, 'change:active', () => @render())
     @render()
 
   render: () ->

--- a/bokehjs/src/coffee/util/dom_util.coffee
+++ b/bokehjs/src/coffee/util/dom_util.coffee
@@ -2,7 +2,7 @@ _ = require "underscore"
 $ = require "jquery"
 
 waitForElement = (el, fn) ->
-  handler = () =>
+  handler = () ->
     if $.contains(document.documentElement, el)
       clearInterval(interval)
       fn()

--- a/bokehjs/src/coffee/util/util.coffee
+++ b/bokehjs/src/coffee/util/util.coffee
@@ -17,9 +17,9 @@ _format_number = (number) ->
     return "#{number}" # get strings for categorical types
 
 replace_placeholders = (string, data_source, i, special_vars={}) ->
-  string = string.replace /(^|[^\$])\$(\w+)/g, (match, prefix, name) => "#{prefix}@$#{name}"
+  string = string.replace /(^|[^\$])\$(\w+)/g, (match, prefix, name) -> "#{prefix}@$#{name}"
 
-  string = string.replace /(^|[^@])@(?:(\$?\w+)|{([^{}]+)})(?:{([^{}]+)})?/g, (match, prefix, name, long_name, format) =>
+  string = string.replace /(^|[^@])@(?:(\$?\w+)|{([^{}]+)})(?:{([^{}]+)})?/g, (match, prefix, name, long_name, format) ->
     name = if long_name? then long_name else name
 
     value =

--- a/bokehjs/src/coffee/widget/button.coffee
+++ b/bokehjs/src/coffee/widget/button.coffee
@@ -12,7 +12,7 @@ class ButtonView extends ContinuumView
     super(options)
     @views = {}
     @render()
-    @listenTo(@model, 'change', @render)
+    @listenTo(@model, 'change', () => @render())
 
   render: () ->
     icon = @mget('icon')

--- a/bokehjs/src/coffee/widget/cell_editors.coffee
+++ b/bokehjs/src/coffee/widget/cell_editors.coffee
@@ -38,7 +38,7 @@ class CellEditorView extends ContinuumView
   renderEditor: () ->
 
   disableNavigation: () ->
-    @$input.keydown (event) =>
+    @$input.keydown (event) ->
       stop = () -> event.stopImmediatePropagation()
       switch event.keyCode
         when $.ui.keyCode.LEFT      then stop()

--- a/bokehjs/src/coffee/widget/checkbox_button_group.coffee
+++ b/bokehjs/src/coffee/widget/checkbox_button_group.coffee
@@ -12,7 +12,7 @@ class CheckboxButtonGroupView extends ContinuumView
   initialize: (options) ->
     super(options)
     @render()
-    @listenTo(@model, 'change', @render)
+    @listenTo(@model, 'change', () => @render())
 
   render: () ->
     @$el.empty()

--- a/bokehjs/src/coffee/widget/checkbox_group.coffee
+++ b/bokehjs/src/coffee/widget/checkbox_group.coffee
@@ -11,7 +11,7 @@ class CheckboxGroupView extends ContinuumView
   initialize: (options) ->
     super(options)
     @render()
-    @listenTo(@model, 'change', @render)
+    @listenTo(@model, 'change', () => @render())
 
   render: () ->
     @$el.empty()

--- a/bokehjs/src/coffee/widget/crossfilter.coffee
+++ b/bokehjs/src/coffee/widget/crossfilter.coffee
@@ -19,7 +19,7 @@ class CrossFilterView extends ContinuumView
   initialize: (options) ->
     super(options)
     @views = {}
-    @listenTo(@model, 'change:plot', @render_plot)
+    @listenTo(@model, 'change:plot', () => @render_plot())
     @render()
     @render_plot()
 
@@ -86,10 +86,10 @@ class PlotAttributeSelector extends ContinuumView
 
   initialize: (options) ->
     super(options)
-    @listenTo(@model, "change:plot_selector", _.bind(@render_selector, 'plot'))
-    @listenTo(@model, "change:x_selector", _.bind(@render_selector, 'x'))
-    @listenTo(@model, "change:y_selector", _.bind(@render_selector, 'y'))
-    @listenTo(@model, "change:agg_selector", _.bind(@render_selector, 'agg'))
+    @listenTo(@model, "change:plot_selector", () => @render_selector('plot'))
+    @listenTo(@model, "change:x_selector", () => @render_selector('x'))
+    @listenTo(@model, "change:y_selector", () => @render_selector('y'))
+    @listenTo(@model, "change:agg_selector", () => @render_selector('agg'))
     @render_selector('plot')
     @render_selector('x')
     @render_selector('y')
@@ -106,7 +106,7 @@ class ColumnsView extends ContinuumView
   initialize: (options) ->
     super(options)
     @views = {}
-    @listenTo(@collection, 'all', @render)
+    @listenTo(@collection, 'all', () => @render())
     @render()
 
   render: () ->
@@ -138,9 +138,9 @@ class FacetsView extends ContinuumView
     @render_init()
     @render_all_facets()
 
-    @listenTo(@model, 'change:facet_x', @render_all_facets)
-    @listenTo(@model, 'change:facet_y', @render_all_facets)
-    @listenTo(@model, 'change:facet_tab', @render_all_facets)
+    @listenTo(@model, 'change:facet_x', () => @render_all_facets())
+    @listenTo(@model, 'change:facet_y', () => @render_all_facets())
+    @listenTo(@model, 'change:facet_tab', () => @render_all_facets())
 
   render_init: () ->
     @facet_x_node = @$('.bk-facet-x')

--- a/bokehjs/src/coffee/widget/date_picker.coffee
+++ b/bokehjs/src/coffee/widget/date_picker.coffee
@@ -17,12 +17,12 @@ class DatePickerView extends ContinuumView
       defaultDate: new Date(@mget('value'))
       minDate: if @mget('min_date')? then new Date(@mget('min_date')) else null
       maxDate: if @mget('max_date')? then new Date(@mget('max_date')) else null
-      onSelect: @onSelect
+      onSelect: (dateText, ui) => @onSelect(dateText, ui)
     })
     @$el.append([$label, $datepicker])
     return @
 
-  onSelect: (dateText, ui) =>
+  onSelect: (dateText, ui) ->
     @mset('value', new Date(dateText))
     @mget('callback')?.execute(@model)
 

--- a/bokehjs/src/coffee/widget/date_range_slider.coffee
+++ b/bokehjs/src/coffee/widget/date_range_slider.coffee
@@ -9,7 +9,7 @@ class DateRangeSliderView extends ContinuumView
   initialize: (options) ->
     super(options)
     @render()
-    @listenTo(@model, 'change', () => @render)
+    @listenTo(@model, 'change', () => @render())
 
   render: () ->
     @$el.empty()

--- a/bokehjs/src/coffee/widget/dialog.coffee
+++ b/bokehjs/src/coffee/widget/dialog.coffee
@@ -13,9 +13,9 @@ class DialogView extends ContinuumView
     @render_content()
     @render_buttons()
 
-    @listenTo(@model, 'destroy', @remove)
-    @listenTo(@model, 'change:visible', @change_visibility)
-    @listenTo(@model, 'change:content', @change_content)
+    @listenTo(@model, 'destroy', () => @remove())
+    @listenTo(@model, 'change:visible', () => @change_visibility())
+    @listenTo(@model, 'change:content', () => @change_content())
 
   render_content: () ->
     if @content_view?
@@ -45,17 +45,17 @@ class DialogView extends ContinuumView
   render: () ->
     @$modal = $(dialog_template(@model.attributes))
     @$modal.modal({show: @mget("visible")})
-    @$modal.on('hidden.bk-bs.modal', @onHide)
+    @$modal.on('hidden.bk-bs.modal', () => @onHide())
     @$el.html(@$modal)
     return @
 
-  onHide: (event) =>
+  onHide: (event) ->
     @mset("visible", false, {silent: true})
 
-  change_visibility: () =>
+  change_visibility: () ->
     @$modal.modal(if @mget("visible") then "show" else "hide")
 
-  change_content: () =>
+  change_content: () ->
     @render_content()
 
 class Dialog extends HasProperties

--- a/bokehjs/src/coffee/widget/dropdown.coffee
+++ b/bokehjs/src/coffee/widget/dropdown.coffee
@@ -9,7 +9,7 @@ class DropdownView extends ContinuumView
   initialize: (options) ->
     super(options)
     @render()
-    @listenTo(@model, 'change', @render)
+    @listenTo(@model, 'change', () => @render())
 
   render: () ->
     @$el.empty()

--- a/bokehjs/src/coffee/widget/hbox.coffee
+++ b/bokehjs/src/coffee/widget/hbox.coffee
@@ -12,7 +12,7 @@ class HBoxView extends ContinuumView
     super(options)
     @views = {}
     @render()
-    @listenTo(@model, 'change', @render)
+    @listenTo(@model, 'change', () => @render())
 
   render: () ->
     children = @model.children()

--- a/bokehjs/src/coffee/widget/icon.coffee
+++ b/bokehjs/src/coffee/widget/icon.coffee
@@ -8,7 +8,7 @@ class IconView extends ContinuumView
   initialize: (options) ->
     super(options)
     @render()
-    @listenTo(@model, 'change', @render)
+    @listenTo(@model, 'change', () => @render())
 
   render: () ->
     @$el.empty()

--- a/bokehjs/src/coffee/widget/multiselect.coffee
+++ b/bokehjs/src/coffee/widget/multiselect.coffee
@@ -14,9 +14,9 @@ class MultiSelectView extends ContinuumView
     super(options)
     @render()
     @listenTo(@model, 'change:value', () => @render_selection())
-    @listenTo(@model, 'change:options', @render)
-    @listenTo(@model, 'change:name', @render)
-    @listenTo(@model, 'change:title', @render)
+    @listenTo(@model, 'change:options', () => @render())
+    @listenTo(@model, 'change:name', () => @render())
+    @listenTo(@model, 'change:title', () => @render())
 
   render: () ->
     @$el.empty()

--- a/bokehjs/src/coffee/widget/multiselect.coffee
+++ b/bokehjs/src/coffee/widget/multiselect.coffee
@@ -13,7 +13,7 @@ class MultiSelectView extends ContinuumView
   initialize: (options) ->
     super(options)
     @render()
-    @listenTo(@model, 'change:value', @render_selection)
+    @listenTo(@model, 'change:value', () => @render_selection())
     @listenTo(@model, 'change:options', @render)
     @listenTo(@model, 'change:name', @render)
     @listenTo(@model, 'change:title', @render)
@@ -25,7 +25,7 @@ class MultiSelectView extends ContinuumView
     @render_selection()
     return @
 
-  render_selection: () =>
+  render_selection: () ->
     values = {}
     _.map(@mget('value'), (x) -> values[x] = true)
     @$('option').each((el) =>

--- a/bokehjs/src/coffee/widget/paragraph.coffee
+++ b/bokehjs/src/coffee/widget/paragraph.coffee
@@ -8,7 +8,7 @@ class ParagraphView extends ContinuumView
   initialize: (options) ->
     super(options)
     @render()
-    @listenTo(@model, 'change', @render)
+    @listenTo(@model, 'change', () => @render())
 
   render: () ->
     if @mget('height')

--- a/bokehjs/src/coffee/widget/radio_button_group.coffee
+++ b/bokehjs/src/coffee/widget/radio_button_group.coffee
@@ -12,7 +12,7 @@ class RadioButtonGroupView extends ContinuumView
   initialize: (options) ->
     super(options)
     @render()
-    @listenTo(@model, 'change', @render)
+    @listenTo(@model, 'change', () => @render())
 
   render: () ->
     @$el.empty()

--- a/bokehjs/src/coffee/widget/radio_group.coffee
+++ b/bokehjs/src/coffee/widget/radio_group.coffee
@@ -11,7 +11,7 @@ class RadioGroupView extends ContinuumView
   initialize: (options) ->
     super(options)
     @render()
-    @listenTo(@model, 'change', @render)
+    @listenTo(@model, 'change', () => @render())
 
   render: () ->
     @$el.empty()

--- a/bokehjs/src/coffee/widget/selectbox.coffee
+++ b/bokehjs/src/coffee/widget/selectbox.coffee
@@ -19,7 +19,7 @@ class SelectView extends ContinuumView
   initialize: (options) ->
     super(options)
     @render()
-    @listenTo(@model, 'change', @render)
+    @listenTo(@model, 'change', () => @render())
 
   render: () ->
     @$el.empty()

--- a/bokehjs/src/coffee/widget/slider.coffee
+++ b/bokehjs/src/coffee/widget/slider.coffee
@@ -24,7 +24,7 @@ class SliderView extends ContinuumView
     @$('.slider').slider({
       orientation: @mget('orientation')
       animate: "fast",
-      slide: _.throttle(@slide, 200),
+      slide: _.throttle(((event, ui) => @slide(event, ui)), 200),
       value: @mget('value')
       min: min,
       max: max,
@@ -33,7 +33,7 @@ class SliderView extends ContinuumView
     @$( "##{ @mget('id') }" ).val( @$('.slider').slider('value') )
     return @
 
-  slide: (event, ui) =>
+  slide: (event, ui) ->
     value = ui.value
     logger.debug("slide value = #{value}")
     @$( "##{ @mget('id') }" ).val( ui.value )

--- a/bokehjs/src/coffee/widget/text_input.coffee
+++ b/bokehjs/src/coffee/widget/text_input.coffee
@@ -16,7 +16,7 @@ class TextInputView extends ContinuumView
   initialize: (options) ->
     super(options)
     @render()
-    @listenTo(@model, 'change', @render)
+    @listenTo(@model, 'change', () => @render())
 
   render: () ->
     @$el.html(@template(@model.attributes))

--- a/bokehjs/src/coffee/widget/toggle.coffee
+++ b/bokehjs/src/coffee/widget/toggle.coffee
@@ -10,7 +10,7 @@ class ToggleView extends ContinuumView
   initialize: (options) ->
     super(options)
     @render()
-    @listenTo(@model, 'change', @render)
+    @listenTo(@model, 'change', () => @render())
 
   render: () ->
     icon = @mget('icon')

--- a/bokehjs/src/coffee/widget/vbox.coffee
+++ b/bokehjs/src/coffee/widget/vbox.coffee
@@ -12,7 +12,7 @@ class VBoxView extends ContinuumView
     super(options)
     @views = {}
     @render()
-    @listenTo(@model, 'change', @render)
+    @listenTo(@model, 'change', () => @render())
 
   render: () ->
     children = @model.children()


### PR DESCRIPTION
This is a more thorough version of a commit that's in #3099  (https://github.com/bokeh/bokeh/commit/4e03d100ddc3b814e77d3fdbf210a92f0c224608). That commit is broken, too, and isn't related to #3099.

Rationale in the commit message https://github.com/bokeh/bokeh/commit/920d9af9ccd969b5d204936d375de345c2044d88
