### PR TITLE
Do not default NumberSpec/AngleSpec/DistanceSpec to field name

### DIFF
--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -96,7 +96,7 @@ class BoxAnnotation(Annotation):
 
     """
 
-    left = Either(Auto, NumberSpec("left"), default=None, help="""
+    left = Either(Auto, NumberSpec(), default=None, help="""
     The x-coordinates of the left edge of the box annotation.
     """)
 
@@ -105,7 +105,7 @@ class BoxAnnotation(Annotation):
     by default.
     """)
 
-    right = Either(Auto, NumberSpec("right"), default=None, help="""
+    right = Either(Auto, NumberSpec(), default=None, help="""
     The x-coordinates of the right edge of the box annotation.
     """)
 
@@ -114,7 +114,7 @@ class BoxAnnotation(Annotation):
     by default.
     """)
 
-    bottom = Either(Auto, NumberSpec("bottom"), default=None, help="""
+    bottom = Either(Auto, NumberSpec(), default=None, help="""
     The y-coordinates of the bottom edge of the box annotation.
     """)
 
@@ -123,7 +123,7 @@ class BoxAnnotation(Annotation):
     by default.
     """)
 
-    top = Either(Auto, NumberSpec("top"), default=None, help="""
+    top = Either(Auto, NumberSpec(), default=None, help="""
     The y-coordinates of the top edge of the box annotation.
     """)
 

--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -30,27 +30,27 @@ class AnnularWedge(Glyph):
     # functions derived from this class
     _args = ('x', 'y', 'inner_radius', 'outer_radius', 'start_angle', 'end_angle', 'direction')
 
-    x = NumberSpec("x", help="""
+    x = NumberSpec(help="""
     The x-coordinates of the center of the annular wedges.
     """)
 
-    y = NumberSpec("y", help="""
+    y = NumberSpec(help="""
     The y-coordinates of the center of the annular wedges.
     """)
 
-    inner_radius = DistanceSpec("inner_radius", help="""
+    inner_radius = DistanceSpec(help="""
     The inner radii of the annular wedges.
     """)
 
-    outer_radius = DistanceSpec("outer_radius", help="""
+    outer_radius = DistanceSpec(help="""
     The outer radii of the annular wedges.
     """)
 
-    start_angle = AngleSpec("start_angle", help="""
+    start_angle = AngleSpec(help="""
     The angles to start the annular wedges, as measured from the horizontal.
     """)
 
-    end_angle = AngleSpec("end_angle", help="""
+    end_angle = AngleSpec(help="""
     The angles to end the annular wedges, as measured from the horizontal.
     """)
 
@@ -75,19 +75,19 @@ class Annulus(Glyph):
     # functions derived from this class
     _args = ('x', 'y', 'inner_radius', 'outer_radius')
 
-    x = NumberSpec("x", help="""
+    x = NumberSpec(help="""
     The x-coordinates of the center of the annuli.
     """)
 
-    y = NumberSpec("y", help="""
+    y = NumberSpec(help="""
     The y-coordinates of the center of the annuli.
     """)
 
-    inner_radius = DistanceSpec("inner_radius", help="""
+    inner_radius = DistanceSpec(help="""
     The inner radii of the annuli.
     """)
 
-    outer_radius = DistanceSpec("outer_radius", help="""
+    outer_radius = DistanceSpec(help="""
     The outer radii of the annuli.
     """)
 
@@ -108,23 +108,23 @@ class Arc(Glyph):
     # functions derived from this class
     _args = ('x', 'y', 'radius', 'start_angle', 'end_angle', 'direction')
 
-    x = NumberSpec("x", help="""
+    x = NumberSpec(help="""
     The x-coordinates of the center of the arcs.
     """)
 
-    y = NumberSpec("y", help="""
+    y = NumberSpec(help="""
     The y-coordinates of the center of the arcs.
     """)
 
-    radius = DistanceSpec("radius", help="""
+    radius = DistanceSpec(help="""
     Radius of the arc.
     """)
 
-    start_angle = AngleSpec("start_angle", help="""
+    start_angle = AngleSpec(help="""
     The angles to start the arcs, as measured from the horizontal.
     """)
 
-    end_angle = AngleSpec("end_angle", help="""
+    end_angle = AngleSpec(help="""
     The angles to end the arcs, as measured from the horizontal.
     """)
 
@@ -150,35 +150,35 @@ class Bezier(Glyph):
     # functions derived from this class
     _args = ('x0', 'y0', 'x1', 'y1', 'cx0', 'cy0', 'cx1', 'cy1')
 
-    x0 = NumberSpec("x0", help="""
+    x0 = NumberSpec(help="""
     The x-coordinates of the starting points.
     """)
 
-    y0 = NumberSpec("y0", help="""
+    y0 = NumberSpec(help="""
     The y-coordinates of the starting points.
     """)
 
-    x1 = NumberSpec("x1", help="""
+    x1 = NumberSpec(help="""
     The x-coordinates of the ending points.
     """)
 
-    y1 = NumberSpec("y1", help="""
+    y1 = NumberSpec(help="""
     The y-coordinates of the ending points.
     """)
 
-    cx0 = NumberSpec("cx0", help="""
+    cx0 = NumberSpec(help="""
     The x-coordinates of first control points.
     """)
 
-    cy0 = NumberSpec("cy0", help="""
+    cy0 = NumberSpec(help="""
     The y-coordinates of first control points.
     """)
 
-    cx1 = NumberSpec("cx1", help="""
+    cx1 = NumberSpec(help="""
     The x-coordinates of second control points.
     """)
 
-    cy1 = NumberSpec("cy1", help="""
+    cy1 = NumberSpec(help="""
     The y-coordinates of second control points.
     """)
 
@@ -202,11 +202,11 @@ class Gear(Glyph):
     # functions derived from this class
     _args = ('x', 'y', 'angle', 'module', 'teeth', 'pressure_angle', 'shaft_size', 'internal')
 
-    x = NumberSpec("x", help="""
+    x = NumberSpec(help="""
     The x-coordinates of the center of the gears.
     """)
 
-    y = NumberSpec("y", help="""
+    y = NumberSpec(help="""
     The y-coordinates of the center of the gears.
     """)
 
@@ -214,7 +214,7 @@ class Gear(Glyph):
     The angle the gears are rotated from horizontal. [rad]
     """)
 
-    module = NumberSpec("module", help="""
+    module = NumberSpec(help="""
     A scaling factor, given by::
 
         m = p / pi
@@ -224,7 +224,7 @@ class Gear(Glyph):
     the same gear, measured along the pitch circle. [float]
     """)
 
-    teeth = NumberSpec("teeth", help="""
+    teeth = NumberSpec(help="""
     How many teeth the gears have. [int]
     """)
 
@@ -280,19 +280,19 @@ class Image(Glyph):
     # functions derived from this class
     _args = ('image', 'x', 'y', 'dw', 'dh', 'dilate')
 
-    image = NumberSpec("image", help="""
+    image = NumberSpec(help="""
     The arrays of scalar data for the images to be colormapped.
     """)
 
-    x = NumberSpec("x", help="""
+    x = NumberSpec(help="""
     The x-coordinates to locate the image anchors.
     """)
 
-    y = NumberSpec("y", help="""
+    y = NumberSpec(help="""
     The y-coordinates to locate the image anchors.
     """)
 
-    dw = DistanceSpec("dw", help="""
+    dw = DistanceSpec(help="""
     The widths of the plot regions that the images will occupy.
 
     .. note::
@@ -300,7 +300,7 @@ class Image(Glyph):
         That number is fixed by the image itself.
     """)
 
-    dh = DistanceSpec("dh", help="""
+    dh = DistanceSpec(help="""
     The height of the plot region that the image will occupy.
 
     .. note::
@@ -334,15 +334,15 @@ class ImageRGBA(Glyph):
     # functions derived from this class
     _args = ('image', 'x', 'y', 'dw', 'dh', 'dilate')
 
-    image = NumberSpec("image", help="""
+    image = NumberSpec(help="""
     The arrays of RGBA data for the images.
     """)
 
-    x = NumberSpec("x", help="""
+    x = NumberSpec(help="""
     The x-coordinates to locate the image anchors.
     """)
 
-    y = NumberSpec("y", help="""
+    y = NumberSpec(help="""
     The y-coordinates to locate the image anchors.
     """)
 
@@ -354,7 +354,7 @@ class ImageRGBA(Glyph):
     The numbers of columns in the images
     """)
 
-    dw = DistanceSpec("dw", help="""
+    dw = DistanceSpec(help="""
     The widths of the plot regions that the images will occupy.
 
     .. note::
@@ -362,7 +362,7 @@ class ImageRGBA(Glyph):
         That number is fixed by the image itself.
     """)
 
-    dh = DistanceSpec("dh", help="""
+    dh = DistanceSpec(help="""
     The height of the plot region that the image will occupy.
 
     .. note::
@@ -390,7 +390,7 @@ class ImageURL(Glyph):
     # functions derived from this class
     _args = ('url', 'x', 'y', 'w', 'h', 'angle', 'global_alpha', 'dilate')
 
-    url = NumberSpec("url", help="""
+    url = NumberSpec(help="""
     The URLs to retrieve images from.
 
     .. note::
@@ -398,16 +398,16 @@ class ImageURL(Glyph):
         the client.
     """)
 
-    x = NumberSpec("x", help="""
+    x = NumberSpec(help="""
     The x-coordinates to locate the image anchors.
     """)
 
-    y = NumberSpec("y", help="""
+    y = NumberSpec(help="""
     The y-coordinates to locate the image anchors.
     """)
 
     # TODO: (bev) rename to "dw" for consistency
-    w = DistanceSpec("w", help="""
+    w = DistanceSpec(help="""
     The widths of the plot regions that the images will occupy.
 
     .. note::
@@ -419,7 +419,7 @@ class ImageURL(Glyph):
     """)
 
     # TODO: (bev) rename to "dh" for consistency
-    h = DistanceSpec("h", help="""
+    h = DistanceSpec(help="""
     The height of the plot region that the image will occupy.
 
     .. note::
@@ -475,11 +475,11 @@ class Line(Glyph):
 
     __example__ = "tests/glyphs/Line.py"
 
-    x = NumberSpec("x", help="""
+    x = NumberSpec(help="""
     The x-coordinates for the points of the line.
     """)
 
-    y = NumberSpec("y", help="""
+    y = NumberSpec(help="""
     The y-coordinates for the points of the line.
     """)
 
@@ -502,11 +502,11 @@ class MultiLine(Glyph):
     # functions derived from this class
     _args = ('xs', 'ys')
 
-    xs = NumberSpec("xs", help="""
+    xs = NumberSpec(help="""
     The x-coordinates for all the lines, given as a "list of lists".
     """)
 
-    ys = NumberSpec("ys", help="""
+    ys = NumberSpec(help="""
     The x-coordinates for all the lines, given as a "list of lists".
     """)
 
@@ -528,23 +528,23 @@ class Oval(Glyph):
     # functions derived from this class
     _args = ('x', 'y', 'width', 'height', 'angle')
 
-    x = NumberSpec("x", help="""
+    x = NumberSpec(help="""
     The x-coordinates of the centers of the ovals.
     """)
 
-    y = NumberSpec("y", help="""
+    y = NumberSpec(help="""
     The y-coordinates of the centers of the ovals.
     """)
 
-    width = DistanceSpec("width", help="""
+    width = DistanceSpec(help="""
     The overall widths of each oval.
     """)
 
-    height = DistanceSpec("height", help="""
+    height = DistanceSpec(help="""
     The overall height of each oval.
     """)
 
-    angle = AngleSpec(default=0, help="""
+    angle = AngleSpec(default=0.0, help="""
     The angle the ovals are rotated from horizontal. [rad]
     """)
 
@@ -570,7 +570,7 @@ class Patch(Glyph):
     # functions derived from this class
     _args = ('x', 'y')
 
-    x = NumberSpec("x", help="""
+    x = NumberSpec(help="""
     The x-coordinates for the points of the patch.
 
     .. note::
@@ -579,7 +579,7 @@ class Patch(Glyph):
         values in the sequence.
     """)
 
-    y = NumberSpec("y", help="""
+    y = NumberSpec(help="""
     The y-coordinates for the points of the patch.
 
     .. note::
@@ -611,7 +611,7 @@ class Patches(Glyph):
     # functions derived from this class
     _args = ('xs', 'ys')
 
-    xs = NumberSpec("xs", help="""
+    xs = NumberSpec(help="""
     The x-coordinates for all the patches, given as a "list of lists".
 
     .. note::
@@ -620,7 +620,7 @@ class Patches(Glyph):
         values in the sublists.
     """)
 
-    ys = NumberSpec("ys", help="""
+    ys = NumberSpec(help="""
     The y-coordinates for all the patches, given as a "list of lists".
 
     .. note::
@@ -646,19 +646,19 @@ class Quad(Glyph):
     # functions derived from this class
     _args = ('left', 'right', 'top', 'bottom')
 
-    left = NumberSpec("left", help="""
+    left = NumberSpec(help="""
     The x-coordinates of the left edges.
     """)
 
-    right = NumberSpec("right", help="""
+    right = NumberSpec(help="""
     The x-coordinates of the right edges.
     """)
 
-    bottom = NumberSpec("bottom", help="""
+    bottom = NumberSpec(help="""
     The y-coordinates of the bottom edges.
     """)
 
-    top = NumberSpec("top", help="""
+    top = NumberSpec(help="""
     The y-coordinates of the top edges.
     """)
 
@@ -679,27 +679,27 @@ class Quadratic(Glyph):
     # functions derived from this class
     _args = ('x0', 'y0', 'x1', 'y1', 'cx', 'cy')
 
-    x0 = NumberSpec("x0", help="""
+    x0 = NumberSpec(help="""
     The x-coordinates of the starting points.
     """)
 
-    y0 = NumberSpec("y0", help="""
+    y0 = NumberSpec(help="""
     The y-coordinates of the starting points.
     """)
 
-    x1 = NumberSpec("x1", help="""
+    x1 = NumberSpec(help="""
     The x-coordinates of the ending points.
     """)
 
-    y1 = NumberSpec("y1", help="""
+    y1 = NumberSpec(help="""
     The y-coordinates of the ending points.
     """)
 
-    cx = NumberSpec("cx", help="""
+    cx = NumberSpec(help="""
     The x-coordinates of the control points.
     """)
 
-    cy = NumberSpec("cy", help="""
+    cy = NumberSpec(help="""
     The y-coordinates of the control points.
     """)
 
@@ -716,19 +716,19 @@ class Ray(Glyph):
     # functions derived from this class
     _args = ('x', 'y', 'length', 'angle')
 
-    x = NumberSpec("x", help="""
+    x = NumberSpec(help="""
     The x-coordinates to start the rays.
     """)
 
-    y = NumberSpec("y", help="""
+    y = NumberSpec(help="""
     The y-coordinates to start the rays.
     """)
 
-    angle = AngleSpec("angle", help="""
+    angle = AngleSpec(help="""
     The angles in radians to extend the rays, as measured from the horizontal.
     """)
 
-    length = DistanceSpec("length", help="""
+    length = DistanceSpec(help="""
     The length to extend the ray. Note that this ``length`` defaults
     to screen units.
     """)
@@ -746,19 +746,19 @@ class Rect(Glyph):
     # functions derived from this class
     _args = ('x', 'y', 'width', 'height', 'angle', 'dilate')
 
-    x = NumberSpec("x", help="""
+    x = NumberSpec(help="""
     The x-coordinates of the centers of the rectangles.
     """)
 
-    y = NumberSpec("y", help="""
+    y = NumberSpec(help="""
     The y-coordinates of the centers of the rectangles.
     """)
 
-    width = DistanceSpec("width", help="""
+    width = DistanceSpec(help="""
     The overall widths of the rectangles.
     """)
 
-    height = DistanceSpec("height", help="""
+    height = DistanceSpec(help="""
     The overall heights of the rectangles.
     """)
 
@@ -792,19 +792,19 @@ class Segment(Glyph):
     # functions derived from this class
     _args = ('x0', 'y0', 'x1', 'y1')
 
-    x0 = NumberSpec("x0", help="""
+    x0 = NumberSpec(help="""
     The x-coordinates of the starting points.
     """)
 
-    y0 = NumberSpec("y0", help="""
+    y0 = NumberSpec(help="""
     The y-coordinates of the starting points.
     """)
 
-    x1 = NumberSpec("x1", help="""
+    x1 = NumberSpec(help="""
     The x-coordinates of the ending points.
     """)
 
-    y1 = NumberSpec("y1", help="""
+    y1 = NumberSpec(help="""
     The y-coordinates of the ending points.
     """)
 
@@ -821,11 +821,11 @@ class Text(Glyph):
     # functions derived from this class
     _args = ('x', 'y', 'text', 'angle', 'x_offset', 'y_offset')
 
-    x = NumberSpec("x", help="""
+    x = NumberSpec(help="""
     The x-coordinates to locate the text anchors.
     """)
 
-    y = NumberSpec("y", help="""
+    y = NumberSpec(help="""
     The y-coordinates to locate the text anchors.
     """)
 
@@ -865,23 +865,23 @@ class Wedge(Glyph):
     # functions derived from this class
     _args = ('x', 'y', 'radius', 'start_angle', 'end_angle', 'direction')
 
-    x = NumberSpec("x", help="""
+    x = NumberSpec(help="""
     The x-coordinates of the points of the wedges.
     """)
 
-    y = NumberSpec("y", help="""
+    y = NumberSpec(help="""
     The y-coordinates of the points of the wedges.
     """)
 
-    radius = DistanceSpec("radius", help="""
+    radius = DistanceSpec(help="""
     Radii of the wedges.
     """)
 
-    start_angle = AngleSpec("start_angle", help="""
+    start_angle = AngleSpec(help="""
     The angles to start the wedges, as measured from the horizontal.
     """)
 
-    end_angle = AngleSpec("end_angle", help="""
+    end_angle = AngleSpec(help="""
     The angles to end the wedges, as measured from the horizontal.
     """)
 

--- a/bokeh/models/markers.py
+++ b/bokeh/models/markers.py
@@ -8,7 +8,7 @@ from .glyphs import Glyph
 from ..enums import enumeration
 from ..mixins import FillProps, LineProps
 from ..properties import abstract
-from ..properties import DistanceSpec, Enum, Include, NumberSpec, ScreenDistanceSpec
+from ..properties import DistanceSpec, Enum, Include, NumberSpec, AngleSpec, ScreenDistanceSpec
 
 @abstract
 class Marker(Glyph):
@@ -28,11 +28,11 @@ class Marker(Glyph):
     # functions derived from this class
     _args = ('x', 'y', 'size', 'angle')
 
-    x = NumberSpec("x", help="""
+    x = NumberSpec(help="""
     The x-axis coordinates for the center of the markers.
     """)
 
-    y = NumberSpec("y", help="""
+    y = NumberSpec(help="""
     The y-axis coordinates for the center of the markers.
     """)
 
@@ -40,7 +40,7 @@ class Marker(Glyph):
     The size (diameter) values for the markers in screen space units.
     """)
 
-    angle = NumberSpec(0, help="""
+    angle = AngleSpec(default=0.0, help="""
     The angles to rotate the markers.
     """)
 

--- a/bokeh/models/tests/test_glyphs.py
+++ b/bokeh/models/tests/test_glyphs.py
@@ -55,7 +55,7 @@ TEXT = ["text_font", "text_font_size", "text_font_style", "text_color", "text_al
 
 PROPS = ["name", "tags"]
 GLYPH = ["visible"]
-MARKER = ["x", "y", "size", "angle"]
+MARKER = ["x", "y", "size", "angle", "angle_units"]
 
 def check_props(glyph, *props):
     expected = set(sum((PROPS, GLYPH) + props, []))
@@ -88,18 +88,18 @@ def check_text(glyph):
     assert glyph.text_baseline == TextBaseline.bottom
 
 def check_marker(marker):
-    assert marker.x == "x"
-    assert marker.y == "y"
+    assert marker.x is None
+    assert marker.y is None
     assert marker.size == 4
 
 def test_AnnularWedge():
     glyph = AnnularWedge()
-    assert glyph.x == "x"
-    assert glyph.y == "y"
-    assert glyph.inner_radius == "inner_radius"
-    assert glyph.outer_radius == "outer_radius"
-    assert glyph.start_angle == "start_angle"
-    assert glyph.end_angle == "end_angle"
+    assert glyph.x is None
+    assert glyph.y is None
+    assert glyph.inner_radius is None
+    assert glyph.outer_radius is None
+    assert glyph.start_angle is None
+    assert glyph.end_angle is None
     assert glyph.direction == "anticlock"
     yield check_fill, glyph
     yield check_line, glyph
@@ -119,10 +119,10 @@ def test_AnnularWedge():
 
 def test_Annulus():
     glyph = Annulus()
-    assert glyph.x == "x"
-    assert glyph.y == "y"
-    assert glyph.inner_radius == "inner_radius"
-    assert glyph.outer_radius == "outer_radius"
+    assert glyph.x is None
+    assert glyph.y is None
+    assert glyph.inner_radius is None
+    assert glyph.outer_radius is None
     yield check_fill, glyph
     yield check_line, glyph
     yield (check_props, glyph, [
@@ -136,11 +136,11 @@ def test_Annulus():
 
 def test_Arc():
     glyph = Arc()
-    assert glyph.x == "x"
-    assert glyph.y == "y"
-    assert glyph.radius == "radius"
-    assert glyph.start_angle == "start_angle"
-    assert glyph.end_angle == "end_angle"
+    assert glyph.x is None
+    assert glyph.y is None
+    assert glyph.radius is None
+    assert glyph.start_angle is None
+    assert glyph.end_angle is None
     assert glyph.direction == "clock"
     yield check_line, glyph
     yield (check_props, glyph, [
@@ -157,14 +157,14 @@ def test_Arc():
 
 def test_Bezier():
     glyph = Bezier()
-    assert glyph.x0 == "x0"
-    assert glyph.y0 == "y0"
-    assert glyph.x1 == "x1"
-    assert glyph.y1 == "y1"
-    assert glyph.cx0 == "cx0"
-    assert glyph.cy0 == "cy0"
-    assert glyph.cx1 == "cx1"
-    assert glyph.cy1 == "cy1"
+    assert glyph.x0 is None
+    assert glyph.y0 is None
+    assert glyph.x1 is None
+    assert glyph.y1 is None
+    assert glyph.cx0 is None
+    assert glyph.cy0 is None
+    assert glyph.cx1 is None
+    assert glyph.cy1 is None
     yield check_line, glyph
     yield (check_props, glyph, [
         "x0",
@@ -179,11 +179,11 @@ def test_Bezier():
 
 def test_Gear():
     glyph = Gear()
-    assert glyph.x == "x"
-    assert glyph.y == "y"
+    assert glyph.x is None
+    assert glyph.y is None
     assert glyph.angle == 0
-    assert glyph.module == "module"
-    assert glyph.teeth == "teeth"
+    assert glyph.module is None
+    assert glyph.teeth is None
     assert glyph.pressure_angle == 20
     assert glyph.shaft_size == 0.3
     assert glyph.internal == False
@@ -203,11 +203,11 @@ def test_Gear():
 
 def test_Image():
     glyph = Image()
-    assert glyph.image == "image"
-    assert glyph.x == "x"
-    assert glyph.y == "y"
-    assert glyph.dw == "dw"
-    assert glyph.dh == "dh"
+    assert glyph.image is None
+    assert glyph.x is None
+    assert glyph.y is None
+    assert glyph.dw is None
+    assert glyph.dh is None
     assert glyph.dilate == False
     yield (check_props, glyph, [
         "image",
@@ -223,11 +223,11 @@ def test_Image():
 
 def test_ImageRGBA():
     glyph = ImageRGBA()
-    assert glyph.image == "image"
-    assert glyph.x == "x"
-    assert glyph.y == "y"
-    assert glyph.dw == "dw"
-    assert glyph.dh == "dh"
+    assert glyph.image is None
+    assert glyph.x is None
+    assert glyph.y is None
+    assert glyph.dw is None
+    assert glyph.dh is None
     assert glyph.rows == None
     assert glyph.cols == None
     assert glyph.dilate == False
@@ -246,11 +246,11 @@ def test_ImageRGBA():
 
 def test_ImageURL():
     glyph = ImageURL()
-    assert glyph.url == "url"
-    assert glyph.x == "x"
-    assert glyph.y == "y"
-    assert glyph.w == "w"
-    assert glyph.h == "h"
+    assert glyph.url is None
+    assert glyph.x is None
+    assert glyph.y is None
+    assert glyph.w is None
+    assert glyph.h is None
     assert glyph.angle == 0
     assert glyph.dilate == False
     assert glyph.anchor == Anchor.top_left
@@ -276,8 +276,8 @@ def test_ImageURL():
 
 def test_Line():
     glyph = Line()
-    assert glyph.x == "x"
-    assert glyph.y == "y"
+    assert glyph.x is None
+    assert glyph.y is None
     yield check_line, glyph
     yield (check_props, glyph, [
         "x",
@@ -286,8 +286,8 @@ def test_Line():
 
 def test_MultiLine():
     glyph = MultiLine()
-    assert glyph.xs == "xs"
-    assert glyph.ys == "ys"
+    assert glyph.xs is None
+    assert glyph.ys is None
     yield check_line, glyph
     yield (check_props, glyph, [
         "xs",
@@ -296,10 +296,10 @@ def test_MultiLine():
 
 def test_Oval():
     glyph = Oval()
-    assert glyph.x == "x"
-    assert glyph.y == "y"
-    assert glyph.width == "width"
-    assert glyph.height == "height"
+    assert glyph.x is None
+    assert glyph.y is None
+    assert glyph.width is None
+    assert glyph.height is None
     assert glyph.angle == 0
     yield check_fill, glyph
     yield check_line, glyph
@@ -316,8 +316,8 @@ def test_Oval():
 
 def test_Patch():
     glyph = Patch()
-    assert glyph.x == "x"
-    assert glyph.y == "y"
+    assert glyph.x is None
+    assert glyph.y is None
     yield check_fill, glyph
     yield check_line, glyph
     yield (check_props, glyph, [
@@ -327,8 +327,8 @@ def test_Patch():
 
 def test_Patches():
     glyph = Patches()
-    assert glyph.xs == "xs"
-    assert glyph.ys == "ys"
+    assert glyph.xs is None
+    assert glyph.ys is None
     yield check_fill, glyph
     yield check_line, glyph
     yield (check_props, glyph, [
@@ -338,10 +338,10 @@ def test_Patches():
 
 def test_Quad():
     glyph = Quad()
-    assert glyph.left == "left"
-    assert glyph.right == "right"
-    assert glyph.bottom == "bottom"
-    assert glyph.top == "top"
+    assert glyph.left is None
+    assert glyph.right is None
+    assert glyph.bottom is None
+    assert glyph.top is None
     yield check_fill, glyph
     yield check_line, glyph
     yield (check_props, glyph, [
@@ -353,12 +353,12 @@ def test_Quad():
 
 def test_Quadratic():
     glyph = Quadratic()
-    assert glyph.x0 == "x0"
-    assert glyph.y0 == "y0"
-    assert glyph.x1 == "x1"
-    assert glyph.y1 == "y1"
-    assert glyph.cx == "cx"
-    assert glyph.cy == "cy"
+    assert glyph.x0 is None
+    assert glyph.y0 is None
+    assert glyph.x1 is None
+    assert glyph.y1 is None
+    assert glyph.cx is None
+    assert glyph.cy is None
     yield check_line, glyph
     yield (check_props, glyph, [
         "x0",
@@ -371,10 +371,10 @@ def test_Quadratic():
 
 def test_Ray():
     glyph = Ray()
-    assert glyph.x == "x"
-    assert glyph.y == "y"
-    assert glyph.angle == "angle"
-    assert glyph.length == "length"
+    assert glyph.x is None
+    assert glyph.y is None
+    assert glyph.angle is None
+    assert glyph.length is None
     yield check_line, glyph
     yield (check_props, glyph, [
         "x",
@@ -387,10 +387,10 @@ def test_Ray():
 
 def test_Rect():
     glyph = Rect()
-    assert glyph.x == "x"
-    assert glyph.y == "y"
-    assert glyph.width == "width"
-    assert glyph.height == "height"
+    assert glyph.x is None
+    assert glyph.y is None
+    assert glyph.width is None
+    assert glyph.height is None
     assert glyph.angle == 0
     assert glyph.dilate == False
     yield check_fill, glyph
@@ -409,10 +409,10 @@ def test_Rect():
 
 def test_Segment():
     glyph = Segment()
-    assert glyph.x0 == "x0"
-    assert glyph.y0 == "y0"
-    assert glyph.x1 == "x1"
-    assert glyph.y1 == "y1"
+    assert glyph.x0 is None
+    assert glyph.y0 is None
+    assert glyph.x1 is None
+    assert glyph.y1 is None
     yield check_line, glyph
     yield (check_props, glyph, [
         "x0",
@@ -423,8 +423,8 @@ def test_Segment():
 
 def test_Text():
     glyph = Text()
-    assert glyph.x == "x"
-    assert glyph.y == "y"
+    assert glyph.x is None
+    assert glyph.y is None
     assert glyph.text == "text"
     assert glyph.angle == 0
     yield check_text, glyph
@@ -440,11 +440,11 @@ def test_Text():
 
 def test_Wedge():
     glyph = Wedge()
-    assert glyph.x == "x"
-    assert glyph.y == "y"
-    assert glyph.radius == "radius"
-    assert glyph.start_angle == "start_angle"
-    assert glyph.end_angle == "end_angle"
+    assert glyph.x is None
+    assert glyph.y is None
+    assert glyph.radius is None
+    assert glyph.start_angle is None
+    assert glyph.end_angle is None
     assert glyph.direction == "anticlock"
     yield check_fill, glyph
     yield check_line, glyph


### PR DESCRIPTION
(continuing to break up #3099)

This reverts to Bokeh 0.10 behavior.
In Bokeh 0.10, the CoffeeScript default was undefined
(or 0, for some angles). After the tornado merge, we were sending
the field name default from Python when we did not ever use that
name before. In 0.10, we'd never send the default so CoffeeScript
never saw it.

The field name doesn't seem like a good default because in general
it ends up being very magical and unclear; if I type
`Line(source=source)` then it magically uses the `x` and `y` columns,
but if I later rename those columns, or if I'm adapting an example
and my columns aren't named that, it gets confusing what's going on.

Requiring the field name to be written out is better for "programming
by example."

If we do want to default to the field name, we should probably do
it in properties.py anyway instead of typing it out in every class
definition.
