### PR TITLE
Add skipped test to compare Python and Coffee defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,7 @@ win-64
 /bokeh/LICENSE.txt
 /examples/refs
 .cache/
+
+# generated coffeescript
+/bokehjs/src/coffee/widget/defaults.coffee
+/bokehjs/src/coffee/common/defaults.coffee

--- a/bokehjs/gulp/paths.coffee
+++ b/bokehjs/gulp/paths.coffee
@@ -4,12 +4,19 @@ argv = require("yargs").argv
 BUILD_DIR = if typeof argv.buildDir == "string" then argv.buildDir else "./build"
 JS_BUILD_DIR = path.join(BUILD_DIR, "js")
 CSS_BUILD_DIR = path.join(BUILD_DIR, "css")
+# TODO FIXME how can we generate coffeescript and have require
+# find it without putting it in src/ ? The browserify docs
+# seem to say we have to put it in node_modules... maybe
+# that's the answer, I don't know. Doesn't seem much better
+# than putting it in src though.
+COFFEE_BUILD_DIR = path.join('./src', "coffee")
 SERVER_DIR = "../bokeh/server/static/"
 
 module.exports = {
   buildDir:
     all: BUILD_DIR
     js: JS_BUILD_DIR
+    coffee: COFFEE_BUILD_DIR
     css: CSS_BUILD_DIR
   serverDir:
     all: SERVER_DIR

--- a/bokehjs/gulp/tasks/generate_defaults.py
+++ b/bokehjs/gulp/tasks/generate_defaults.py
@@ -1,0 +1,110 @@
+from bokeh.model import Model
+import bokeh.models as models
+from bokeh.properties import DataSpec
+import inspect
+from bokeh._json_encoder import serialize_json
+from json import loads
+import codecs
+import sys
+import os
+
+dest_dir = sys.argv[1]
+
+classes = [member for name, member in inspect.getmembers(models) if inspect.isclass(member)]
+
+model_class = next(klass for klass in classes if klass.__name__ == 'Model')
+widget_class = next(klass for klass in classes if klass.__name__ == 'Widget')
+
+# getclasstree returns a list which contains [ (class, parentClass), [(subClassOfClass, class), ...]]
+# where the subclass list is omitted if there are no subclasses.
+# If you say unique=True then mixins will be registered as leaves so don't use unique=True,
+# and expect to have duplicates in the result of leaves()
+all_tree = inspect.getclasstree(classes, unique=False)
+
+def leaves(tree, underneath):
+    if len(tree) == 0:
+        return []
+    elif len(tree) > 1 and isinstance(tree[1], list):
+        subs = tree[1]
+        if underneath is None or tree[0][0] != underneath:
+            return leaves(subs, underneath) + leaves(tree[2:], underneath)
+        else:
+            # underneath=None to return all leaves from here out
+            return leaves(subs, underneath=None)
+    else:
+        leaf = tree[0]
+        tail = tree[1:]
+        if leaf[0] == underneath:
+            return [leaf]
+        elif underneath is not None:
+            return leaves(tail, underneath)
+        else:
+            return [leaf] + leaves(tail, underneath)
+
+all_json = {}
+for leaf in leaves(all_tree, model_class):
+    klass = leaf[0]
+    vm_name = klass.__view_model__
+    if vm_name in all_json:
+        continue
+    defaults = {}
+    instance = klass()
+    for name, default in instance.properties_with_values().items():
+        if isinstance(default, Model):
+            ref = default.ref
+            raw_attrs = default._to_json_like(include_defaults=True)
+            attrs = loads(serialize_json(raw_attrs, sort_keys=True))
+            ref['attributes'] = attrs
+            del ref['id'] # there's no way the ID will match coffee
+            default = ref
+        elif isinstance(default, float) and default == float('inf'):
+            default = None
+        defaults[name] = default
+    all_json[vm_name] = defaults
+
+widgets_json = {}
+for leaf_widget in leaves(all_tree, widget_class):
+    klass = leaf_widget[0]
+    vm_name = klass.__view_model__
+    if vm_name not in widgets_json:
+        widgets_json[vm_name] = all_json[vm_name]
+        del all_json[vm_name]
+
+def output_defaults_module(filename, defaults):
+    output = serialize_json(defaults, sort_keys=True, indent=4, separators=[',', ':'])
+    coffee_template = \
+    """
+all_defaults = %s;
+
+get_defaults = (name) ->
+  if name of all_defaults
+    all_defaults[name]
+  else
+    null
+
+all_view_model_names = () ->
+  Object.keys(all_defaults)
+
+module.exports = {
+  get_defaults: get_defaults
+  all_view_model_names: all_view_model_names
+}
+"""
+    try:
+        os.makedirs(os.path.dirname(filename))
+    except OSError as e:
+        pass
+    f = codecs.open(filename, 'w', 'utf-8')
+    f.write(coffee_template % output)
+    f.close()
+
+    print("Wrote %s with %d model classes" % (filename, len(defaults)))
+
+
+output_defaults_module(filename = os.path.join(dest_dir, 'common/defaults.coffee'),
+                       defaults = all_json)
+output_defaults_module(filename = os.path.join(dest_dir, 'widget/defaults.coffee'),
+                       defaults = widgets_json)
+
+
+

--- a/bokehjs/gulp/tasks/scripts.coffee
+++ b/bokehjs/gulp/tasks/scripts.coffee
@@ -1,5 +1,6 @@
 # scripts - build or minify JS
 
+_ = require "underscore"
 browserify = require "browserify"
 gulp = require "gulp"
 util = require "gulp-util"
@@ -22,7 +23,36 @@ resolve = require "resolve"
 rootRequire = require("root-require")
 pkg = rootRequire("./package.json")
 insert = require('gulp-insert')
+child_process = require "child_process"
 license = '/*\n' + fs.readFileSync('../LICENSE.txt', 'utf-8') + '*/\n';
+
+gulp.task "scripts:generate", (cb) ->
+  generateDefaults = (next) ->
+    if argv.verbose then util.log("Generating defaults.coffee")
+    bokehjsdir = path.normalize(process.cwd())
+    basedir = path.normalize(bokehjsdir + "/..")
+    oldpath = process.env['PYTHONPATH']
+    if oldpath?
+      pypath = "#{basedir}:#{oldpath}"
+    else
+      pypath = basedir
+    env = _.extend({}, process.env, { PYTHONPATH: pypath })
+    handle = child_process.spawn("python", ['./gulp/tasks/generate_defaults.py', paths.buildDir.coffee], {
+      env: env,
+      cwd: bokehjsdir
+    })
+    handle.stdout.on 'data', (data) ->
+      console.log("generate_defaults.py: #{data}")
+    handle.stderr.on 'data', (data) ->
+      console.log("generate_defaults.py: #{data}")
+    handle.on 'close', (code) ->
+      if code != 0
+        cb(new Error("generate_defaults.py exited code #{code}"))
+      else
+        cb()
+
+  generateDefaults(cb)
+  null # XXX: this is extremely important to allow cb() to work
 
 customLabeler = (bundle, parentLabels, fn) ->
   labels = {}
@@ -180,4 +210,4 @@ gulp.task "scripts:minify", ->
   es.merge.apply(null, tasks)
 
 gulp.task "scripts", (cb) ->
-  runSequence("scripts:build", "scripts:minify", cb)
+  runSequence("scripts:generate", "scripts:build", "scripts:minify", cb)

--- a/bokehjs/src/coffee/common/base.coffee
+++ b/bokehjs/src/coffee/common/base.coffee
@@ -245,6 +245,10 @@ Collections.register_models = (specs) ->
   for own name, impl of specs
     Collections.register_model(name, impl)
 
+
+Collections.registered_names = () ->
+  Object.keys(_get_mod_cache())
+
 # "index" is a map from the toplevel model IDs rendered by
 # embed.coffee, to the view objects for those models.  It doesn't
 # contain all views, only those explicitly rendered to an element

--- a/bokehjs/src/coffee/tool/inspectors/crosshair_tool.coffee
+++ b/bokehjs/src/coffee/tool/inspectors/crosshair_tool.coffee
@@ -66,8 +66,6 @@ class CrosshairTool extends InspectTool.Model
     renderers.push(@get('spans').height)
     @get('plot').set('renderers', renderers)
 
-    ast = @display_defaults
-
   nonserializable_attribute_names: () ->
     super().concat(['location_units', 'render_mode', 'spans'])
 
@@ -75,15 +73,11 @@ class CrosshairTool extends InspectTool.Model
     return _.extend({}, super(), {
       dimensions: ["width", "height"]
       location_units: "screen"
-      render_mode: "css"
-    })
-
-  display_defaults: () ->
-    return _.extend {}, super(), {
-      line_color: 'black'
-      line_width: 1
+      render_mode: "css",
+      line_color: 'black',
+      line_width: 1,
       line_alpha: 1.0
-    }
+    })
 
 module.exports =
   Model: CrosshairTool

--- a/bokehjs/src/coffee/widget/main.coffee
+++ b/bokehjs/src/coffee/widget/main.coffee
@@ -32,3 +32,6 @@ locations = {
 
 {Collections} = require('../common/base')
 Collections.register_plugin('widgets', locations)
+
+module.exports =
+  locations: locations

--- a/bokehjs/test/test_common/index.coffee
+++ b/bokehjs/test/test_common/index.coffee
@@ -1,6 +1,7 @@
 require "./test_build_views"
 require "./test_client"
 require "./test_color"
+require "./test_defaults"
 require "./test_document"
 require "./test_has_parent"
 require "./test_has_properties"

--- a/bokehjs/test/test_common/test_defaults.coffee
+++ b/bokehjs/test/test_common/test_defaults.coffee
@@ -100,8 +100,7 @@ describe "Defaults", ->
       console.log("'base.locations[\"#{m}\"]' not found but there's a Python model '#{m}'")
     expect(missing.length).to.equal 0
 
-  # this is skipped until it passes
-  it.skip "match between Python and CoffeeScript", ->
+  it "match between Python and CoffeeScript", ->
     fail_count = 0
     for name in all_view_model_names
       coll = Collections(name)
@@ -172,4 +171,6 @@ describe "Defaults", ->
 
       if not check_matching_defaults(name, get_defaults(name), attrs)
         fail_count = fail_count + 1
-    expect(fail_count).to.equal 0
+
+    # TODO this is skipped until it passes
+    #expect(fail_count).to.equal 0

--- a/bokehjs/test/test_common/test_defaults.coffee
+++ b/bokehjs/test/test_common/test_defaults.coffee
@@ -1,0 +1,174 @@
+_ = require "underscore"
+{expect} = require "chai"
+utils = require "../utils"
+
+core_defaults = utils.require "common/defaults"
+widget_defaults = utils.require "widget/defaults"
+
+{Collections} = utils.require "common/base"
+HasProperties = utils.require "common/has_properties"
+properties = utils.require "common/properties"
+Bokeh = utils.require "main"
+# for side-effect of loading widgets into locations, as well as to get 'widget_locations'
+widget_locations = (utils.require "widget/main").locations
+
+all_view_model_names = []
+all_view_model_names = all_view_model_names.concat(core_defaults.all_view_model_names())
+all_view_model_names = all_view_model_names.concat(widget_defaults.all_view_model_names())
+
+get_defaults = (name) ->
+  core_defaults.get_defaults(name) or widget_defaults.get_defaults(name)
+
+safe_stringify = (v) ->
+  if v == Infinity
+    "Infinity"
+  else
+    try
+      "#{JSON.stringify(v)}"
+    catch e
+      "#{v}"
+
+check_matching_defaults = (name, python_defaults, coffee_defaults) ->
+  different = []
+  python_missing = []
+  coffee_missing = []
+  for k, v of coffee_defaults
+    if k == 'id'
+      continue
+    if k of python_defaults
+      py_v = python_defaults[k]
+      if not _.isEqual(py_v, v)
+        different.push("#{name}.#{k}: coffee defaults to #{safe_stringify(v)} but python defaults to #{safe_stringify(py_v)}")
+    else
+      python_missing.push("#{name}.#{k}: coffee defaults to #{safe_stringify(v)} but python has no such property")
+  for k, v of python_defaults
+    if k not of coffee_defaults
+      coffee_missing.push("#{name}.#{k}: python defaults to #{safe_stringify(v)} but coffee has no such property")
+
+  complain = (failures, message) ->
+    if failures.length > 0
+      console.error(message)
+      for f in failures
+        console.error("    #{f}")
+
+  complain(different, "#{name}: defaults are out of sync between Python and CoffeeScript")
+  complain(python_missing, "#{name}: python is missing some properties found in CoffeeScript")
+  complain(coffee_missing, "#{name}: coffee is missing some properties found in Python")
+
+  different.length == 0 and python_missing.length == 0 and coffee_missing.length == 0
+
+strip_ids = (value) ->
+  if _.isArray(value)
+    for v in value
+      strip_ids(v)
+  else if _.isObject(value) and ('id' of value)
+    delete value['id']
+    for k, v of value
+      strip_ids(v)
+
+describe "Defaults", ->
+
+  # this is skipped while we decide whether to automate putting them all
+  # in Bokeh or just leave it as a curated (or ad hoc?) subset
+  it.skip "have all non-Widget view models from Python in the Bokeh object", ->
+    missing = []
+    for name in core_defaults.all_view_model_names()
+      if name not of Bokeh
+        missing.push(name)
+    for m in missing
+      console.log("'Bokeh.#{m}' not found but there's a Python model '#{m}'")
+    expect(missing.length).to.equal 0
+
+  it "have all Widget view models from Python in widget locations registry", ->
+    missing = []
+    for name in widget_defaults.all_view_model_names()
+      if name not of widget_locations
+        missing.push(name)
+    for m in missing
+      console.log("'widget.locations.#{m}' not found but there's a Python model '#{m}'")
+    expect(missing.length).to.equal 0
+
+  it "have all view models from Python in registered locations", ->
+    registered = {}
+    for name in Collections.registered_names()
+      registered[name] = true
+    missing = []
+    for name in all_view_model_names
+      if name not of registered
+        missing.push(name)
+    for m in missing
+      console.log("'base.locations[\"#{m}\"]' not found but there's a Python model '#{m}'")
+    expect(missing.length).to.equal 0
+
+  it "match between Python and CoffeeScript", ->
+    fail_count = 0
+    for name in all_view_model_names
+      coll = Collections(name)
+      instance = new coll.model({}, {'silent' : true, 'defer_initialization' : true})
+      attrs = instance.attributes_as_json()
+      strip_ids(attrs)
+      # merge in display_defaults() which aren't in the main
+      # attributes, the overall setup here is sketchy right now
+      # because python never leaves these things unset. We need an
+      # "inherit" value, like in CSS, perhaps.
+      # But at least we can check that display_defaults() matches
+      # what Python sends.
+      display_specs = [ 'line_color', 'line_width', 'line_alpha', 'fill_color', 'fill_alpha',
+                        'text_font_size', 'text_color', 'text_alpha' ]
+      display_attr_is_spec = (name) ->
+        for s in display_specs
+          if name.endsWith(s) # gratuitous ES6
+            return true
+        return false
+      if 'display_defaults' of instance
+        display = instance.display_defaults()
+        for k in Object.keys(display)
+          if k of attrs
+            console.error("#{name}.#{k}: property present in both CoffeeScript attrs and display_defaults()")
+
+          if display_attr_is_spec(k)
+            orig = display[k]
+            if not (_.isObject(orig) and ('field' of orig or 'value' of orig))
+              # convert to 'spec dict' format
+              display[k] = { 'value' : display[k] }
+
+        attrs = _.extend({}, display, attrs)
+
+      # Merge in "factory" attrs, which don't go in attributes
+      # in the actual code, but for our current purpose
+      # let's pretend they do because they do "in effect"
+      # and we probably want to put them there eventually
+      for prop_kind, func of properties.factories
+        if prop_kind == 'visuals' # visuals is the display_defaults() case above
+          continue
+        if prop_kind of instance
+          props_of_this_kind = func(instance)
+          prop_values = {}
+          for p, v of props_of_this_kind
+            if v.field?
+              prop_values[p] = { 'field' : v.field }
+            else if v.fixed_value?
+              prop_values[p] = { 'value' : v.fixed_value }
+            else
+              n = v.value()
+              if isNaN(n) or n == null
+                prop_values[p] = null
+              else
+                prop_values[p] = { 'value' : n }
+
+            dict = prop_values[p]
+            if dict?
+              if v.units?
+                prop_values[p]['units'] = v.units
+              else
+                # properties.coffee hardcodes these units defaults
+                if prop_kind == 'distances' and 'units' not of dict
+                  dict['units'] = "data"
+                if prop_kind == 'angles' and 'units' not of dict
+                  dict['units'] = "rad"
+
+          _.extend(attrs, prop_values)
+
+      if not check_matching_defaults(name, get_defaults(name), attrs)
+        fail_count = fail_count + 1
+    expect(fail_count).to.equal 0

--- a/bokehjs/test/test_common/test_defaults.coffee
+++ b/bokehjs/test/test_common/test_defaults.coffee
@@ -100,7 +100,8 @@ describe "Defaults", ->
       console.log("'base.locations[\"#{m}\"]' not found but there's a Python model '#{m}'")
     expect(missing.length).to.equal 0
 
-  it "match between Python and CoffeeScript", ->
+  # this is skipped until it passes
+  it.skip "match between Python and CoffeeScript", ->
     fail_count = 0
     for name in all_view_model_names
       coll = Collections(name)

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -15,6 +15,13 @@ requirements:
     - distribute
     - setuptools
     - nodejs >=4.1
+    - six
+    - python-dateutil
+    - numpy
+    - yaml
+    - pyyaml
+    - jinja2
+    - tornado
 
   run:
     # bokeh

--- a/setup.py
+++ b/setup.py
@@ -232,7 +232,12 @@ For more information, see the Dev Guide:
 
 BUILD_FAIL_MSG = bright(red("Failed.")) + """
 
-ERROR: 'gulp build' returned error message:
+ERROR: 'gulp build' returned the following
+
+---- on stdout:
+%s
+
+---- on stderr:
 %s
 """
 
@@ -272,9 +277,11 @@ def build_js():
 
     if result != 0:
         indented_msg = ""
-        msg = proc.stderr.read().decode('ascii', errors='ignore')
-        msg = "\n".join(["    " + x for x in msg.split("\n")])
-        print(BUILD_FAIL_MSG % red(msg))
+        outmsg = proc.stdout.read().decode('ascii', errors='ignore')
+        outmsg = "\n".join(["    " + x for x in outmsg.split("\n")])
+        errmsg = proc.stderr.read().decode('ascii', errors='ignore')
+        errmsg = "\n".join(["    " + x for x in errmsg.split("\n")])
+        print(BUILD_FAIL_MSG % (red(outmsg), red(errmsg)))
         sys.exit(1)
 
     indented_msg = ""

--- a/setup.py
+++ b/setup.py
@@ -281,7 +281,9 @@ def build_js():
     msg = proc.stdout.read().decode('ascii', errors='ignore')
     pat = re.compile(r"(\[.*\]) (.*)", re.DOTALL)
     for line in msg.strip().split("\n"):
-        stamp, txt = pat.match(line).groups()
+        m = pat.match(line)
+        if not m: continue # skip generate.py output lines
+        stamp, txt = m.groups()
         indented_msg += "   " + dim(green(stamp)) + " " + dim(txt) + "\n"
     msg = "\n".join(["    " + x for x in msg.split("\n")])
     print(BUILD_SUCCESS_MSG % indented_msg)


### PR DESCRIPTION
The fix to CrosshairTool is in here because it breaks the test code (when it tries to use display_defaults
on an object that isn't a HasParent)
