### PR TITLE
Shrink test_objects.py::TestCollectModels::test_references_large

### DIFF
--- a/bokeh/tests/test_objects.py
+++ b/bokeh/tests/test_objects.py
@@ -77,10 +77,27 @@ class TestViewable(unittest.TestCase):
         self.assertTrue(hasattr(tclass, 'foo'))
         self.assertRaises(KeyError, self.viewable.get_class, 'Imaginary_Class')
 
+class DeepModel(Model):
+    child = Instance(Model)
+
 class TestCollectModels(unittest.TestCase):
 
     def test_references_large(self):
         root, objects = large_plot(10)
+        self.assertEqual(set(root.references()), objects)
+
+    def test_references_deep(self):
+        root = DeepModel()
+        objects = set([root])
+        parent = root
+        # in a previous implementation, about 400 would blow max
+        # recursion depth, so we double that and a little bit,
+        # here.
+        for i in xrange(900):
+            model = DeepModel()
+            objects.add(model)
+            parent.child = model
+            parent = model
         self.assertEqual(set(root.references()), objects)
 
 class SomeModelToJson(Model):

--- a/bokeh/tests/test_objects.py
+++ b/bokeh/tests/test_objects.py
@@ -80,7 +80,7 @@ class TestViewable(unittest.TestCase):
 class TestCollectModels(unittest.TestCase):
 
     def test_references_large(self):
-        root, objects = large_plot(500)
+        root, objects = large_plot(10)
         self.assertEqual(set(root.references()), objects)
 
 class SomeModelToJson(Model):


### PR DESCRIPTION
Checking 500 large plots is not testing more than checking 10,
and this test took 1.5 seconds (out of 5.5 seconds for the entire
test suite).