### PR TITLE
Rename Legend.{orientation->location} and implement more locations

### DIFF
--- a/bokeh/__init__.py
+++ b/bokeh/__init__.py
@@ -20,6 +20,11 @@ from .util.version import __base_version__; __base_version__
 from .util import logconfig
 del logconfig
 
+# configure deprecation warnings
+import warnings
+from .deprecate import BokehDeprecationWarning
+warnings.simplefilter('always', BokehDeprecationWarning)
+
 # imports below are names we want to make available in the bokeh
 # module as transitive imports
 

--- a/bokeh/charts/chart.py
+++ b/bokeh/charts/chart.py
@@ -200,14 +200,14 @@ class Chart(Plot):
                 renderers that should draw sample representations for those
                 labels.
         """
-        orientation = None
+        location = None
         if self._options.legend is True:
-            orientation = "top_left"
+            location = "top_left"
         else:
-            orientation = self._options.legend
+            location = self._options.legend
 
-        if orientation:
-            legend = Legend(orientation=orientation, legends=legends)
+        if location:
+            legend = Legend(location=location, legends=legends)
             self.add_layout(legend)
 
     def make_axis(self, dim, location, scale, label):

--- a/bokeh/charts/chart_options.py
+++ b/bokeh/charts/chart_options.py
@@ -15,7 +15,7 @@
 
 from ..enums import enumeration, LegendLocation
 from ..model import Model
-from ..properties import Auto, Bool, Either, Enum, Int, String
+from ..properties import Auto, Bool, Either, Enum, Int, Float, String, Tuple
 
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -38,7 +38,7 @@ class ChartOptions(Model):
     A title for the chart.
     """)
 
-    legend = Either(Bool, Enum(LegendLocation), help="""
+    legend = Either(Bool, Enum(LegendLocation), Tuple(Float, Float), help="""
     A location where the legend should draw itself.
     """)
 

--- a/bokeh/charts/chart_options.py
+++ b/bokeh/charts/chart_options.py
@@ -13,7 +13,7 @@
 # Imports
 #-----------------------------------------------------------------------------
 
-from ..enums import enumeration, Orientation
+from ..enums import enumeration, LegendLocation
 from ..model import Model
 from ..properties import Auto, Bool, Either, Enum, Int, String
 
@@ -38,7 +38,7 @@ class ChartOptions(Model):
     A title for the chart.
     """)
 
-    legend = Either(Bool, Enum(Orientation), help="""
+    legend = Either(Bool, Enum(LegendLocation), help="""
     A location where the legend should draw itself.
     """)
 

--- a/bokeh/compat/bokeh_renderer.py
+++ b/bokeh/compat/bokeh_renderer.py
@@ -156,7 +156,7 @@ class BokehRenderer(Renderer):
         self.plot.renderers.append(GlyphRenderer(data_source=dummy_source, glyph=X()))
 
     def open_legend(self, legend, props):
-        lgnd = Legend(orientation="top_right")
+        lgnd = Legend(location="top_right")
         try:
             for label, obj in zip(props['labels'], props['handles']):
                 lgnd.legends.append((label, [self.handles[id(obj)]]))

--- a/bokeh/deprecate.py
+++ b/bokeh/deprecate.py
@@ -48,6 +48,7 @@ from __future__ import absolute_import
 __all__ = [
     'deprecated_module',
     'deprecated',
+    'BokehDeprecationWarning',
     'getDeprecationWarningString',
     'getWarningMethod',
     'setWarningMethod',
@@ -58,6 +59,8 @@ import types, sys, inspect
 from warnings import warn, warn_explicit
 from dis import findlinestarts
 
+class BokehDeprecationWarning(DeprecationWarning):
+    pass
 
 def mergeFunctionMetadata(f, g):
     """
@@ -254,7 +257,7 @@ def getDeprecationWarningString(callableThing, version, format=None,
 
 def deprecated_module(name, version, replacement):
     message = _getDeprecationWarningString(name, version, DEPRECATION_WARNING_FORMAT + ': ' + replacement)
-    warn(message, DeprecationWarning, stacklevel=2)
+    warn(message, BokehDeprecationWarning, stacklevel=2)
 
 def deprecated(version, replacement=None):
     """
@@ -284,7 +287,7 @@ def deprecated(version, replacement=None):
         def deprecatedFunction(*args, **kwargs):
             warn(
                 warningString,
-                DeprecationWarning,
+                BokehDeprecationWarning,
                 stacklevel=2)
             return function(*args, **kwargs)
 
@@ -428,7 +431,7 @@ class _DeprecatedAttribute(object):
         result = getattr(self.module, self.__name__)
         message = _getDeprecationWarningString(self.fqpn, self.version,
             DEPRECATION_WARNING_FORMAT + ': ' + self.message)
-        warn(message, DeprecationWarning, stacklevel=3)
+        warn(message, BokehDeprecationWarning, stacklevel=3)
         return result
 
 
@@ -510,7 +513,7 @@ def warnAboutFunction(offender, warningString):
     globals = offender.func_globals
 
     kwargs = dict(
-        category=DeprecationWarning,
+        category=BokehDeprecationWarning,
         filename=filename,
         lineno=lastLineNo,
         module=offenderModule.__name__,

--- a/bokeh/enums.py
+++ b/bokeh/enums.py
@@ -49,10 +49,9 @@ AngleUnits = enumeration("deg", "rad")
 DatetimeUnits = enumeration("microseconds", "milliseconds", "seconds", "minsec",
                             "minutes", "hourmin", "hours", "days", "months", "years")
 Dimension = enumeration("width", "height", "x", "y")
-Anchor = enumeration("top_left", "top_center", "top_right", "right_center",
-                     "bottom_right", "bottom_center", "bottom_left", "left_center", "center")
+LegendLocation = Anchor = enumeration("top_left", "top_center", "top_right",
+    "right_center", "bottom_right", "bottom_center", "bottom_left", "left_center", "center")
 Location = enumeration("above", "below", "left", "right")
-LegendLocation = enumeration("top_right", "top_left", "bottom_left", "bottom_right")
 DashPattern = enumeration("solid", "dashed", "dotted", "dotdash", "dashdot")
 ButtonType = enumeration("default", "primary", "success", "warning", "danger", "link")
 NamedColor = enumeration(*colors.__colors__, case_sensitive=False)

--- a/bokeh/enums.py
+++ b/bokeh/enums.py
@@ -52,7 +52,7 @@ Dimension = enumeration("width", "height", "x", "y")
 Anchor = enumeration("top_left", "top_center", "top_right", "right_center",
                      "bottom_right", "bottom_center", "bottom_left", "left_center", "center")
 Location = enumeration("above", "below", "left", "right")
-Orientation = enumeration("top_right", "top_left", "bottom_left", "bottom_right")
+LegendLocation = enumeration("top_right", "top_left", "bottom_left", "bottom_right")
 DashPattern = enumeration("solid", "dashed", "dotted", "dotdash", "dashdot")
 ButtonType = enumeration("default", "primary", "success", "warning", "danger", "link")
 NamedColor = enumeration(*colors.__colors__, case_sensitive=False)

--- a/bokeh/enums.py
+++ b/bokeh/enums.py
@@ -10,6 +10,9 @@ class Enumeration(object):
 
     __slots__ = ()
 
+    def __iter__(self):
+        return iter(self._values)
+
     def __contains__(self, value):
         if not self._case_sensitive:
             value = value.lower()

--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -44,7 +44,8 @@ class Legend(Annotation):
         default="top_right", help="""
     The location where the legend should draw itself. It's either one of
     ``bokeh.enums.LegendLocation``'s enumerated values, or a ``(x, y)``
-    tuple indicating an absolute location (from the bottom-left corner).
+    tuple indicating an absolute location absolute location in screen
+    coordinates (pixels from the bottom-left corner).
     """)
 
     border_props = Include(LineProps, help="""

--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -40,7 +40,8 @@ class Legend(Annotation):
     def orientation(self, location):
         self.location = location
 
-    location = Either(Enum(LegendLocation), Tuple(Float, Float), help="""
+    location = Either(Enum(LegendLocation), Tuple(Float, Float),
+        default="top_right", help="""
     The location where the legend should draw itself. It's either one of
     ``bokeh.enums.LegendLocation``'s enumerated values, or a ``(x, y)``
     tuple indicating an absolute location (from the bottom-left corner).

--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -40,7 +40,7 @@ class Legend(Annotation):
     def orientation(self, location):
         self.location = location
 
-    location = Enum(LegendLocation, help="""
+    location = Either(Enum(LegendLocation), Tuple(Float, Float), help="""
     The location where the legend should draw itself.
     """)
 

--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -41,7 +41,9 @@ class Legend(Annotation):
         self.location = location
 
     location = Either(Enum(LegendLocation), Tuple(Float, Float), help="""
-    The location where the legend should draw itself.
+    The location where the legend should draw itself. It's either one of
+    ``bokeh.enums.LegendLocation``'s enumerated values, or a ``(x, y)``
+    tuple indicating an absolute location (from the bottom-left corner).
     """)
 
     border_props = Include(LineProps, help="""

--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -4,8 +4,8 @@ Bokeh plots
 """
 from __future__ import absolute_import
 
-from ..enums import (Orientation, SpatialUnits, RenderLevel, Dimension,
-                     RenderMode)
+from ..deprecate import deprecated
+from ..enums import LegendLocation, SpatialUnits, RenderLevel, Dimension, RenderMode
 from ..mixins import LineProps, FillProps, TextProps
 from ..properties import abstract
 from ..properties import (Int, String, Enum, Instance, List, Dict, Tuple,
@@ -28,7 +28,19 @@ class Legend(Annotation):
 
     """
 
-    orientation = Enum(Orientation, help="""
+    __deprecated_attributes__ = ('orientation',)
+
+    @property
+    @deprecated("Bokeh 0.11", "Legend.location")
+    def orientation(self):
+        return self.location
+
+    @orientation.setter
+    @deprecated("Bokeh 0.11", "Legend.location")
+    def orientation(self, location):
+        self.location = location
+
+    location = Enum(LegendLocation, help="""
     The location where the legend should draw itself.
     """)
 

--- a/bokeh/models/tests/test_annotations.py
+++ b/bokeh/models/tests/test_annotations.py
@@ -63,7 +63,7 @@ def check_line(annotation, line_color='#cccccc', line_width=0.3, line_alpha=1.0)
 def test_Legend():
     legend = Legend()
     assert legend.plot is None
-    assert legend.orientation == 'top_right'
+    assert legend.location == 'top_right'
     assert legend.label_standoff == 15
     assert legend.label_height == 20
     assert legend.label_width == 50
@@ -77,7 +77,7 @@ def test_Legend():
     yield check_background, legend
     yield (check_props, legend, [
         "plot",
-        "orientation",
+        "location",
         "label_standoff",
         "label_height",
         "label_width",

--- a/bokeh/models/tests/test_glyphs.py
+++ b/bokeh/models/tests/test_glyphs.py
@@ -32,7 +32,7 @@ from bokeh.enums import (
     Direction,
     Units, AngleUnits, DatetimeUnits,
     Dimension,
-    Anchor, Location, Orientation,
+    Anchor, Location, LegendLocation,
     DashPattern,
     ButtonType, MapType,
     NamedColor as Color, NamedIcon)
@@ -44,7 +44,7 @@ from bokeh.enums import (
     Direction,
     Units, AngleUnits, DatetimeUnits,
     Dimension,
-    Anchor, Location, Orientation,
+    Anchor, Location, LegendLocation,
     DashPattern,
     ButtonType, MapType,
     Color, NamedIcon)

--- a/bokehjs/src/coffee/renderer/annotation/legend.coffee
+++ b/bokehjs/src/coffee/renderer/annotation/legend.coffee
@@ -59,20 +59,35 @@ class LegendView extends PlotWidget
     legend_padding = @mget('legend_padding')
     h_range = @plot_view.frame.get('h_range')
     v_range = @plot_view.frame.get('v_range')
-    if location == "top_right"
-      x = h_range.get('end') - legend_padding - @legend_width
-      y = v_range.get('end') - legend_padding
-    else if location == "top_left"
-      x = h_range.get('start') + legend_padding
-      y = v_range.get('end') - legend_padding
-    else if location == "bottom_left"
-      x = h_range.get('start') + legend_padding
-      y = v_range.get('start') + legend_padding + @legend_height
-    else if location == "bottom_right"
-      x = h_range.get('end') - legend_padding - @legend_width
-      y = v_range.get('start') + legend_padding + @legend_height
-    else if location == "absolute"
-      [x,y] = @absolute_coords
+
+    switch location
+      when 'top_left'
+        x = h_range.get('start') + legend_padding
+        y = v_range.get('end') - legend_padding
+      when 'top_center'
+        x = (h_range.get('end') + h_range.get('start'))/2 - @legend_width/2
+        y = v_range.get('end') - legend_padding
+      when 'top_right'
+        x = h_range.get('end') - legend_padding - @legend_width
+        y = v_range.get('end') - legend_padding
+      when 'right_center'
+        x = h_range.get('end') - legend_padding - @legend_width
+        y = (v_range.get('end') + v_range.get('start'))/2 + @legend_height/2
+      when 'bottom_right'
+        x = h_range.get('end') - legend_padding - @legend_width
+        y = v_range.get('start') + legend_padding + @legend_height
+      when 'bottom_center'
+        x = (h_range.get('end') + h_range.get('start'))/2 - @legend_width/2
+        y = v_range.get('start') + legend_padding + @legend_height
+      when 'bottom_left'
+        x = h_range.get('start') + legend_padding
+        y = v_range.get('start') + legend_padding + @legend_height
+      when 'left_center'
+        x = h_range.get('start') + legend_padding
+        y = (v_range.get('end') + v_range.get('start'))/2 + @legend_height/2
+      when 'center'
+        x = (h_range.get('end') + h_range.get('start'))/2 - @legend_width/2
+        y = (v_range.get('end') + v_range.get('start'))/2 + @legend_height/2
 
     x = @plot_view.canvas.vx_to_sx(x)
     y = @plot_view.canvas.vy_to_sy(y)

--- a/bokehjs/src/coffee/renderer/annotation/legend.coffee
+++ b/bokehjs/src/coffee/renderer/annotation/legend.coffee
@@ -60,34 +60,37 @@ class LegendView extends PlotWidget
     h_range = @plot_view.frame.get('h_range')
     v_range = @plot_view.frame.get('v_range')
 
-    switch location
-      when 'top_left'
-        x = h_range.get('start') + legend_padding
-        y = v_range.get('end') - legend_padding
-      when 'top_center'
-        x = (h_range.get('end') + h_range.get('start'))/2 - @legend_width/2
-        y = v_range.get('end') - legend_padding
-      when 'top_right'
-        x = h_range.get('end') - legend_padding - @legend_width
-        y = v_range.get('end') - legend_padding
-      when 'right_center'
-        x = h_range.get('end') - legend_padding - @legend_width
-        y = (v_range.get('end') + v_range.get('start'))/2 + @legend_height/2
-      when 'bottom_right'
-        x = h_range.get('end') - legend_padding - @legend_width
-        y = v_range.get('start') + legend_padding + @legend_height
-      when 'bottom_center'
-        x = (h_range.get('end') + h_range.get('start'))/2 - @legend_width/2
-        y = v_range.get('start') + legend_padding + @legend_height
-      when 'bottom_left'
-        x = h_range.get('start') + legend_padding
-        y = v_range.get('start') + legend_padding + @legend_height
-      when 'left_center'
-        x = h_range.get('start') + legend_padding
-        y = (v_range.get('end') + v_range.get('start'))/2 + @legend_height/2
-      when 'center'
-        x = (h_range.get('end') + h_range.get('start'))/2 - @legend_width/2
-        y = (v_range.get('end') + v_range.get('start'))/2 + @legend_height/2
+    if _.isString(location)
+      switch location
+        when 'top_left'
+          x = h_range.get('start') + legend_padding
+          y = v_range.get('end') - legend_padding
+        when 'top_center'
+          x = (h_range.get('end') + h_range.get('start'))/2 - @legend_width/2
+          y = v_range.get('end') - legend_padding
+        when 'top_right'
+          x = h_range.get('end') - legend_padding - @legend_width
+          y = v_range.get('end') - legend_padding
+        when 'right_center'
+          x = h_range.get('end') - legend_padding - @legend_width
+          y = (v_range.get('end') + v_range.get('start'))/2 + @legend_height/2
+        when 'bottom_right'
+          x = h_range.get('end') - legend_padding - @legend_width
+          y = v_range.get('start') + legend_padding + @legend_height
+        when 'bottom_center'
+          x = (h_range.get('end') + h_range.get('start'))/2 - @legend_width/2
+          y = v_range.get('start') + legend_padding + @legend_height
+        when 'bottom_left'
+          x = h_range.get('start') + legend_padding
+          y = v_range.get('start') + legend_padding + @legend_height
+        when 'left_center'
+          x = h_range.get('start') + legend_padding
+          y = (v_range.get('end') + v_range.get('start'))/2 + @legend_height/2
+        when 'center'
+          x = (h_range.get('end') + h_range.get('start'))/2 - @legend_width/2
+          y = (v_range.get('end') + v_range.get('start'))/2 + @legend_height/2
+    else if _.isArray(location) and location.length == 2
+      [x, y] = location
 
     x = @plot_view.canvas.vx_to_sx(x)
     y = @plot_view.canvas.vy_to_sy(y)

--- a/bokehjs/src/coffee/renderer/annotation/legend.coffee
+++ b/bokehjs/src/coffee/renderer/annotation/legend.coffee
@@ -55,24 +55,25 @@ class LegendView extends PlotWidget
     text_width = _.max(text_widths)
     @label_width = _.max([text_width, label_width])
     @legend_width = @label_width + @glyph_width + 3 * legend_spacing
-    orientation = @mget('orientation')
+    location = @mget('location')
     legend_padding = @mget('legend_padding')
     h_range = @plot_view.frame.get('h_range')
     v_range = @plot_view.frame.get('v_range')
-    if orientation == "top_right"
+    if location == "top_right"
       x = h_range.get('end') - legend_padding - @legend_width
       y = v_range.get('end') - legend_padding
-    else if orientation == "top_left"
+    else if location == "top_left"
       x = h_range.get('start') + legend_padding
       y = v_range.get('end') - legend_padding
-    else if orientation == "bottom_left"
+    else if location == "bottom_left"
       x = h_range.get('start') + legend_padding
       y = v_range.get('start') + legend_padding + @legend_height
-    else if orientation == "bottom_right"
+    else if location == "bottom_right"
       x = h_range.get('end') - legend_padding - @legend_width
       y = v_range.get('start') + legend_padding + @legend_height
-    else if orientation == "absolute"
+    else if location == "absolute"
       [x,y] = @absolute_coords
+
     x = @plot_view.canvas.vx_to_sx(x)
     y = @plot_view.canvas.vy_to_sy(y)
     @box_coords = [x,y]
@@ -152,7 +153,7 @@ class Legend extends HasParent
       label_width: 50
       legend_padding: 10
       legend_spacing: 3
-      orientation: "top_right"
+      location: 'top_right'
       datapoint: null
     }
 

--- a/examples/embed/slideshow/app_reveal.py
+++ b/examples/embed/slideshow/app_reveal.py
@@ -72,7 +72,7 @@ def distribution():
     p.line(x, pdf, line_color="#348abd", line_width=8, alpha=0.7, legend="PDF")
     p.line(x, cdf, line_color="#7a68a6", line_width=8, alpha=0.7, legend="CDF")
 
-    p.legend.orientation = "top_left"
+    p.legend.location = "top_left"
 
     p.xaxis.axis_label = 'x'
     p.xgrid[0].grid_line_color = "white"

--- a/examples/glyphs/legends.py
+++ b/examples/glyphs/legends.py
@@ -40,8 +40,8 @@ plot.add_tools(pan, wheel_zoom, preview_save)
 
 from bokeh.enums import LegendLocation
 
-for loc in LegendLocation._values:
-    legend = Legend(legends=[(loc, [line])], location=loc)
+for location in LegendLocation:
+    legend = Legend(legends=[(location, [line])], location=location)
     plot.add_layout(legend)
 
 legend = Legend(legends=[("x=100px, y=150px", [line])], location=(100, 150))

--- a/examples/glyphs/legends.py
+++ b/examples/glyphs/legends.py
@@ -41,10 +41,10 @@ plot.add_tools(pan, wheel_zoom, preview_save)
 from bokeh.enums import LegendLocation
 
 for loc in LegendLocation._values:
-    legend = Legend(legends=[(loc, [line])], orientation=loc)
+    legend = Legend(legends=[(loc, [line])], location=loc)
     plot.add_layout(legend)
 
-legend = Legend(legends=[("x=100px, y=150px", [line])], orientation=(100, 150))
+legend = Legend(legends=[("x=100px, y=150px", [line])], location=(100, 150))
 plot.add_layout(legend)
 
 doc = Document()

--- a/examples/glyphs/legends.py
+++ b/examples/glyphs/legends.py
@@ -44,6 +44,9 @@ for loc in LegendLocation._values:
     legend = Legend(legends=[(loc, [line])], orientation=loc)
     plot.add_layout(legend)
 
+legend = Legend(legends=[("x=100px, y=150px", [line])], orientation=(100, 150))
+plot.add_layout(legend)
+
 doc = Document()
 doc.add_root(plot)
 

--- a/examples/glyphs/legends.py
+++ b/examples/glyphs/legends.py
@@ -1,0 +1,55 @@
+from __future__ import print_function
+
+from numpy import pi, sin, cos
+import numpy as np
+
+from bokeh.browserlib import view
+from bokeh.document import Document
+from bokeh.embed import file_html
+from bokeh.models.glyphs import Line
+from bokeh.models import (
+    Plot, DataRange1d, LinearAxis, ColumnDataSource,
+    PanTool, WheelZoomTool, PreviewSaveTool, Legend,
+)
+from bokeh.resources import INLINE
+
+x = np.linspace(-2*pi, 2*pi, 1000)
+y = sin(x)
+z = cos(x)
+
+source = ColumnDataSource(data=dict(x=x, y=y))
+
+xdr = DataRange1d()
+ydr = DataRange1d()
+
+plot = Plot(x_range=xdr, y_range=ydr, min_border=50)
+
+line_glyph = Line(x="x", y="y", line_color="blue")
+line = plot.add_glyph(source, line_glyph)
+
+plot.add_layout(LinearAxis(), 'above')
+plot.add_layout(LinearAxis(), 'below')
+plot.add_layout(LinearAxis(), 'left')
+plot.add_layout(LinearAxis(), 'right')
+
+pan = PanTool()
+wheel_zoom = WheelZoomTool()
+preview_save = PreviewSaveTool()
+
+plot.add_tools(pan, wheel_zoom, preview_save)
+
+from bokeh.enums import LegendLocation
+
+for loc in LegendLocation._values:
+    legend = Legend(legends=[(loc, [line])], orientation=loc)
+    plot.add_layout(legend)
+
+doc = Document()
+doc.add_root(plot)
+
+if __name__ == "__main__":
+    filename = "legends.html"
+    with open(filename, "w") as f:
+        f.write(file_html(doc, INLINE, "Legends Example"))
+    print("Wrote %s" % filename)
+    view(filename)

--- a/examples/glyphs/population_server.py
+++ b/examples/glyphs/population_server.py
@@ -71,7 +71,7 @@ def population():
 
     plot.add_layout(
         Legend(
-            orientation="bottom_right",
+            location="bottom_right",
             legends=[("known", [line_known_glyph]), ("predicted", [line_predicted_glyph])],
         )
     )

--- a/examples/glyphs/taylor_server.py
+++ b/examples/glyphs/taylor_server.py
@@ -68,7 +68,7 @@ plot.add_layout(yaxis, 'left')
 xgrid = Grid(dimension=0, ticker=xaxis.ticker)
 ygrid = Grid(dimension=1, ticker=yaxis.ticker)
 
-legend = Legend(orientation="bottom_left")
+legend = Legend(location="bottom_left")
 plot.add_layout(legend)
 
 def on_slider_value_change(attr, old, new):

--- a/examples/plotting/file/histogram.py
+++ b/examples/plotting/file/histogram.py
@@ -25,7 +25,7 @@ p1.quad(top=hist, bottom=0, left=edges[:-1], right=edges[1:],
 p1.line(x, pdf, line_color="#D95B43", line_width=8, alpha=0.7, legend="PDF")
 p1.line(x, cdf, line_color="white", line_width=2, alpha=0.7, legend="CDF")
 
-p1.legend.orientation = "top_left"
+p1.legend.location = "top_left"
 p1.xaxis.axis_label = 'x'
 p1.yaxis.axis_label = 'Pr(x)'
 
@@ -48,7 +48,7 @@ p2.quad(top=hist, bottom=0, left=edges[:-1], right=edges[1:],
 p2.line(x, pdf, line_color="#D95B43", line_width=8, alpha=0.7, legend="PDF")
 p2.line(x, cdf, line_color="white", line_width=2, alpha=0.7, legend="CDF")
 
-p2.legend.orientation = "bottom_right"
+p2.legend.location = "bottom_right"
 p2.xaxis.axis_label = 'x'
 p2.yaxis.axis_label = 'Pr(x)'
 
@@ -71,7 +71,7 @@ p3.quad(top=hist, bottom=0, left=edges[:-1], right=edges[1:],
 p3.line(x, pdf, line_color="#D95B43", line_width=8, alpha=0.7, legend="PDF")
 p3.line(x, cdf, line_color="white", line_width=2, alpha=0.7, legend="CDF")
 
-p3.legend.orientation = "top_left"
+p3.legend.location = "top_left"
 p3.xaxis.axis_label = 'x'
 p3.yaxis.axis_label = 'Pr(x)'
 
@@ -116,7 +116,7 @@ p5.quad(top=hist, bottom=0, left=edges[:-1], right=edges[1:],
 p5.line(x, pdf, line_color="#D95B43", line_width=8, alpha=0.7, legend="PDF")
 p5.line(x, cdf, line_color="white", line_width=2, alpha=0.7, legend="CDF")
 
-p5.legend.orientation = "top_left"
+p5.legend.location = "top_left"
 p5.xaxis.axis_label = 'x'
 p5.yaxis.axis_label = 'Pr(x)'
 

--- a/sphinx/source/docs/quickstart.rst
+++ b/sphinx/source/docs/quickstart.rst
@@ -455,7 +455,7 @@ of interest to look out for in this example:
 
     # NEW: customize by setting attributes
     p.title = "AAPL One-Month Average"
-    p.legend.orientation = "top_left"
+    p.legend.location = "top_left"
     p.grid.grid_line_alpha=0
     p.xaxis.axis_label = 'Date'
     p.yaxis.axis_label = 'Price'

--- a/sphinx/source/docs/user_guide/source_examples/styling_legend_background.py
+++ b/sphinx/source/docs/user_guide/source_examples/styling_legend_background.py
@@ -19,7 +19,7 @@ p.line(x, 3*y, legend="3*sin(x)", line_color="green")
 
 #  3*sin(x) curve should be under this legend at initial viewing, so
 # we can see that the legend is transparent
-p.legend.orientation = "bottom_right"
+p.legend.location = "bottom_right"
 p.legend.background_fill_color = "navy"
 p.legend.background_fill_alpha = 0.5
 

--- a/sphinx/source/docs/user_guide/source_examples/styling_legend_location.py
+++ b/sphinx/source/docs/user_guide/source_examples/styling_legend_location.py
@@ -17,6 +17,6 @@ p.line(x, 2*y, legend="2*sin(x)",
 p.square(x, 3*y, legend="3*sin(x)", fill_color=None, line_color="green")
 p.line(x, 3*y, legend="3*sin(x)", line_color="green")
 
-p.legend.orientation = "bottom_left"
+p.legend.location = "bottom_left"
 
 show(p)

--- a/sphinx/source/docs/user_guide/styling.rst
+++ b/sphinx/source/docs/user_guide/styling.rst
@@ -649,8 +649,9 @@ or a ``(x, y)`` tuple indicating an absolute location in screen coordinates
     :source-position: above
 
 .. note::
-    It is not currently possible to position a legend outside the plot area,
-    or using absolute coordinates. These and other improvements are planned.
+    It is currently not possible to position a legend outside the plot area,
+    or in an optimal, automatically computed location within the canvas.
+    These and other improvements are planned.
 
 Label Text
 ~~~~~~~~~~

--- a/sphinx/source/docs/user_guide/styling.rst
+++ b/sphinx/source/docs/user_guide/styling.rst
@@ -621,7 +621,7 @@ for every element of the list:
 Location
 ~~~~~~~~
 
-The location of the legend labels is controlled by the ``orientation``
+The location of the legend labels is controlled by the ``location``
 property. Valid values for this property are:
 
 ``"top_right"``

--- a/sphinx/source/docs/user_guide/styling.rst
+++ b/sphinx/source/docs/user_guide/styling.rst
@@ -622,17 +622,28 @@ Location
 ~~~~~~~~
 
 The location of the legend labels is controlled by the ``location``
-property. Valid values for this property are:
-
-``"top_right"``
+property. Valid values for this property are either:
 
 ``"top_left"``
 
-``"bottom_left"``
+``"top_center"``
+
+``"top_right"`` (the default)
+
+``"right_center"``
 
 ``"bottom_right"``
 
-The default location is ``"top_right"``.
+``"bottom_center"``
+
+``"bottom_left"``
+
+``"left_center"``
+
+``"center"``
+
+or a ``(x, y)`` tuple indicating an absolute location (measured from
+the bottom-left corner).
 
 .. bokeh-plot:: source/docs/user_guide/source_examples/styling_legend_location.py
     :source-position: above

--- a/sphinx/source/docs/user_guide/styling.rst
+++ b/sphinx/source/docs/user_guide/styling.rst
@@ -642,8 +642,8 @@ property. Valid values for this property are either:
 
 ``"center"``
 
-or a ``(x, y)`` tuple indicating an absolute location (measured from
-the bottom-left corner).
+or a ``(x, y)`` tuple indicating an absolute location in screen coordinates
+(pixels from the bottom-left corner).
 
 .. bokeh-plot:: source/docs/user_guide/source_examples/styling_legend_location.py
     :source-position: above


### PR DESCRIPTION
Now we have total of ten locations: four corners, five centered and absolute locations. See `glyphs/legends`. This PR won't implement automatic location at this point. `Legend.orientation` is deprecated, but `@deprecated` decorator doesn't seem to work.

TODO:
- [x] be explicit about screen coordinates
- [x] update note in the documentation (absolute location)
- [x] make sure deprecation warning is shown