### PR TITLE
add sphinx directive to create versioned links into the repo

### DIFF
--- a/bokeh/sphinxext/bokeh_github.py
+++ b/bokeh/sphinxext/bokeh_github.py
@@ -134,7 +134,7 @@ def bokeh_tree(name, rawtext, text, lineno, inliner, options=None, content=None)
         tag = 'master'
 
     url = "%s/tree/%s/%s" % (BOKEH_GH, tag, text)
-    _try_url(url, 'tree')
+    _try_url(app, url, 'tree')
     options = options or {}
     set_classes(options)
     node = nodes.reference(
@@ -158,14 +158,14 @@ def make_gh_link_node(app, rawtext, role, kind, api_type, id, options=None):
     """
     url = "%s/%s/%s" % (BOKEH_GH, api_type, id)
     options = options or {}
-    _try_url(url, role)
+    _try_url(app, url, role)
     set_classes(options)
     node = nodes.reference(
         rawtext, kind + ' ' + utils.unescape(id), refuri=url, **options)
     return node
 
 
-def _try_url(url, role):
+def _try_url(app, url, role):
     try:
         request = urllib.request.Request(url)
         request.get_method = lambda : 'HEAD'

--- a/sphinx/source/docs/gallery.rst
+++ b/sphinx/source/docs/gallery.rst
@@ -30,9 +30,8 @@ Bokeh server.
 Standalone Examples
 ===================
 
-All of the examples below are located in the
-`examples <https://github.com/bokeh/bokeh/tree/master/examples>`_
-subdirectory of your Bokeh checkout. By "standalone" we mean that 
+All of the examples below are located in the :bokeh-tree:`examples`
+subdirectory of your Bokeh checkout. By "standalone" we mean that
 these examples make no use of the Bokeh server. These plots still
 have many interactive tools and features, including linked panning
 and brushing, and hover inspectors.


### PR DESCRIPTION
issues: ref #3186 

And update the "examples" link in the main gallery to use it to point to the correct checkout for the actual docs version being viewed. 