### PR TITLE
try some other build matrix configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,23 +23,28 @@ env:
         - secure: "v9VkMz6cjFBZhlf6iiXSr0o2Eo/HKMMOseAxE6H+sr1vbPg19edGU+7+aAQrn09lE4oKU5JwZSzQ2KalJgrNTGrRrGyEtWGAcuS6oP17zg9LsutLGptNwyHBnCvB5aUPW7JSNs+kor7CmvZ8sVnUh810YSREjt2ZsjEG3ysZjVc="
         - secure: "OI9ErePcqSewA8ZheZq5YtNyeLA8UM1UGskcMEAmPMf9AisYasJaPoY8NeqLGDyMcg7TcXbFQBZv7jPEngZ3RZMsDajfC3p63WOBDS7PfurKTVWTXZ28Z6vzwa3riFIca3D0eVP6bt8KZrYMo7HvWQG3vzmTSxRjx4e2wHxciKo="
     matrix:
-      - GROUP=js_tests
-      - GROUP=python_tests
-      - GROUP=integration_tests
-      - GROUP=examples_flake_docs
+      - GROUP=unit
+      - GROUP=integration
+      - GROUP=examples
+      - GROUP=flake_docs
 
 matrix:
     exclude:
+        # integration tests only py 3.4
         - python: 2.7
-          env: GROUP=js_tests
-        - python: 2.7
-          env: GROUP=integration_tests
+          env: GROUP=integration
         - python: 3.5
-          env: GROUP=js_tests
+          env: GROUP=integration
+        #
+        # flake_docs only py 2.7
+        - python: 3.7
+          env: GROUP=flake_docs
         - python: 3.5
-          env: GROUP=integration_tests
+          env: GROUP=flake_docs
+        #
+        # TEMPORARILY DISABLE EXAMPLES for py 3.5
         - python: 3.5
-          env: examples_flake_docs
+          env: GROUP=examples
 
 branches:
   only:
@@ -65,16 +70,22 @@ install:
 script:
     # Deactivate tests on building to avoid huge packages contaning the pics and outout html
     # Eventually, we need to get rid of the generated stuff before packaging
-    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == js_tests ]]; then py.test -s -m js -rs; fi  # Run just the JS first so we see the output
-    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == python_tests ]]; then py.test -m 'not (examples or js or integration)' --cov=bokeh --cov-config=bokeh/.coveragerc -rs; fi  # Run the not examples or js tests (we can eat stdout for this one)
-    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration_tests ]]; then py.test -m integration -rs; fi  # Run the integration tests
-    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == examples_flake_docs && $TRAVIS_PYTHON_VERSION == '2.7' ]]; then export BOKEH_DEFAULT_DIFF=FETCH_HEAD; export IPYTHON_ALLOW_DRAFT_WEBSOCKETS_FOR_PHANTOMJS=1; fi # Add env variable for pdiff machinery
-    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == examples_flake_docs ]]; then if [[ $TRAVIS_COMMIT_MSG == *"[ci disable examples]"* ]]; then echo "Examples run disabled by commit"; else py.test -s -m examples -rs; fi; fi # Run the examples
+    #
+    # Run (JS and Python) unit tests on all python versions
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == unit ]]; then py.test -s -m js -rs; fi  # Run just the JS first so we see the output
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == unit ]]; then py.test -m 'not (examples or js or integration)' --cov=bokeh --cov-config=bokeh/.coveragerc -rs; fi  # Run the not examples or js tests (we can eat stdout for this one)
+    #
+    # Run integration tests only once (Py 3.4)
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration ]]; then py.test -m integration -rs; fi  # Run the integration tests
+    #
+    # Flake/docs testing only once (Py 2.7)
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == flake_docs ]]; then ( flake8 bokeh; cd sphinx; make all ) ; fi
+    #
+    #
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == examples && $TRAVIS_PYTHON_VERSION == '2.7' ]]; then export BOKEH_DEFAULT_DIFF=FETCH_HEAD; export IPYTHON_ALLOW_DRAFT_WEBSOCKETS_FOR_PHANTOMJS=1; fi # Add env variable for pdiff machinery
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == examples ]]; then if [[ $TRAVIS_COMMIT_MSG == *"[ci disable examples]"* ]]; then echo "Examples run disabled by commit"; else py.test -s -m examples -rs; fi; fi # Run the examples
     - echo "poor man logger"
     - echo $BOKEH_DEFAULT_DIFF; echo $TRAVIS_COMMIT_MSG; echo $TRAVIS_PULL_REQUEST
-    # Flake/style testing (only needed on one machine)
-    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == examples_flake_docs && $TRAVIS_PYTHON_VERSION == '3.4' ]]; then flake8 bokeh; fi
-    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == examples_flake_docs ]]; then ( cd sphinx; make all ) ; fi #Run docs
 
 after_success:
     |

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
           env: GROUP=integration
         #
         # flake_docs only py 2.7
-        - python: 3.7
+        - python: 3.4
           env: GROUP=flake_docs
         - python: 3.5
           env: GROUP=flake_docs
@@ -84,6 +84,7 @@ script:
     #
     - if [[ -z "$TRAVIS_TAG" && "$GROUP" == examples && $TRAVIS_PYTHON_VERSION == '2.7' ]]; then export BOKEH_DEFAULT_DIFF=FETCH_HEAD; export IPYTHON_ALLOW_DRAFT_WEBSOCKETS_FOR_PHANTOMJS=1; fi # Add env variable for pdiff machinery
     - if [[ -z "$TRAVIS_TAG" && "$GROUP" == examples ]]; then if [[ $TRAVIS_COMMIT_MSG == *"[ci disable examples]"* ]]; then echo "Examples run disabled by commit"; else py.test -s -m examples -rs; fi; fi # Run the examples
+    #
     - echo "poor man logger"
     - echo $BOKEH_DEFAULT_DIFF; echo $TRAVIS_COMMIT_MSG; echo $TRAVIS_PULL_REQUEST
 


### PR DESCRIPTION
issues: ref #3236 

ping @damianavila 

This results in the following build matrix:

<img width="720" alt="screen shot 2015-12-07 at 2 50 50 pm" src="https://cloud.githubusercontent.com/assets/1078448/11639352/f87e375e-9cf1-11e5-90c4-472f302b8af3.png">

This a little different from the changes suggested in the referenced issue. Basically:

* Python+JS unit tests everywhere, but together to save on install times. (The tests suites themselves are both very fast compared to install time)
* Integration tests only once, on Py 3.4 
* flake_docs only once, on py2.7 (since that is where they are deployed from)
* examples tests everywhere (except disabled for py3.5 temporarily for now)

***NOTE***: the 3.5 examples tests are unfortunately disabled (for now) because we simply cannot afford three "long" tests with only five workers, with the volume of PRs we have. It results in an immediate logjam.  Looking into adding resources. 