### PR TITLE
Use a custom message for keep-alive ping

### DIFF
--- a/bokeh/client/connection.py
+++ b/bokeh/client/connection.py
@@ -97,6 +97,7 @@ class ClientConnection(object):
         self._until_predicate = None
         self._protocol = Protocol("1.0")
         self._server_info = None
+        self._ping_count = 0
 
     @property
     def url(self):
@@ -196,13 +197,6 @@ class ClientConnection(object):
         else:
             reply.push_to_document(document)
 
-    def _send_request_server_info(self):
-        msg = self._protocol.create('SERVER-INFO-REQ')
-        reply = self._send_message_wait_for_reply(msg)
-        if reply is None:
-            raise RuntimeError("Did not get a reply to server info request before disconnect")
-        return reply.content
-
     def request_server_info(self):
         '''
         Ask for information about the server.
@@ -211,8 +205,30 @@ class ClientConnection(object):
             A dictionary of server attributes.
         '''
         if self._server_info is None:
-            self._server_info = self._send_request_server_info()
+            msg = self._protocol.create('SERVER-INFO-REQ')
+            reply = self._send_message_wait_for_reply(msg)
+            if reply is None:
+                raise RuntimeError("Did not get a reply to server info request before disconnect")
+            self._server_info = reply.content
         return self._server_info
+
+    def _ping_message(self):
+        msg = self._protocol.create('PING-REQ', self._ping_count)
+        self._ping_count += 1
+        return msg
+
+    def ping(self):
+        """ Ping the server, "fire-and-forget" style (do not wait for a reply).
+        """
+        self._send_message(self._ping_message())
+
+    def ping_wait_for_reply(self):
+        """ Ping the server, and wait in the IOLoop until a reply is received.
+        """
+        reply = self._send_message_wait_for_reply(self._ping_message())
+        if reply is None:
+            raise RuntimeError("Did not get a reply to ping before disconnect")
+        return reply.content
 
     def force_roundtrip(self):
         '''
@@ -223,7 +239,7 @@ class ClientConnection(object):
         Returns:
            None
         '''
-        self._send_request_server_info()
+        self.ping_wait_for_reply()
 
     def _loop_until(self, predicate):
         self._until_predicate = predicate

--- a/bokeh/client/session.py
+++ b/bokeh/client/session.py
@@ -309,6 +309,16 @@ class ClientSession(object):
         '''
         return self._connection.request_server_info()
 
+    def ping(self):
+        """ Ping the server, "fire-and-forget" style (do not wait for a reply).
+        """
+        return self._connection.ping()
+
+    def ping_wait_for_reply(self):
+        """ Ping the server, and wait in the IOLoop until a reply is received.
+        """
+        return self._connection.ping_wait_for_reply()
+
     def force_roundtrip(self):
         ''' Used in unit testing to force a request/reply pair in order to avoid races '''
         self._connection.force_roundtrip()

--- a/bokeh/server/connection.py
+++ b/bokeh/server/connection.py
@@ -41,8 +41,9 @@ class ServerConnection(object):
         return self._socket.send_message(msg)
 
     def send_ping(self):
-        self._socket.ping(str(self._ping_count))
+        msg = self.protocol.create('PING-REQ', self._ping_count)
         self._ping_count += 1
+        self._socket.send_message(msg)
 
     @property
     def protocol(self):

--- a/bokeh/server/protocol/messages/__init__.py
+++ b/bokeh/server/protocol/messages/__init__.py
@@ -20,6 +20,7 @@ def register(cls):
 from .ack import *
 from .ok import *
 from .patch_doc import *
+from .ping_req import *
 from .pull_doc_req import *
 from .pull_doc_reply import *
 from .push_doc import *

--- a/bokeh/server/protocol/messages/ping_req.py
+++ b/bokeh/server/protocol/messages/ping_req.py
@@ -1,0 +1,25 @@
+'''
+
+'''
+from __future__ import absolute_import
+
+from ..message import Message
+from . import register
+
+@register
+class ping_req_1(Message):
+    '''
+
+    '''
+
+    msgtype   = 'PING-REQ'
+    revision = 1
+
+    @classmethod
+    def create(cls, sequence, **metadata):
+        '''
+
+        '''
+        header = cls.create_header()
+        content = { 'sequence' : sequence }
+        return cls(header, metadata, content)

--- a/bokeh/server/protocol/messages/tests/test_ping_req.py
+++ b/bokeh/server/protocol/messages/tests/test_ping_req.py
@@ -1,0 +1,10 @@
+from __future__ import absolute_import, print_function
+
+import unittest
+
+from bokeh.server.protocol import Protocol
+
+class TestPingReq(unittest.TestCase):
+
+    def test_create(self):
+        msg = Protocol("1.0").create("PING-REQ", 42)

--- a/bokeh/server/protocol/server_handler.py
+++ b/bokeh/server/protocol/server_handler.py
@@ -23,6 +23,7 @@ class ServerHandler(object):
         self._handlers['PUSH-DOC'] = ServerSession.push
         self._handlers['PATCH-DOC'] = ServerSession.patch
         self._handlers['SERVER-INFO-REQ'] = self._server_info_req
+        self._handlers['PING-REQ'] = self._ping_req
 
     @gen.coroutine
     def handle(self, message, connection):
@@ -46,3 +47,6 @@ class ServerHandler(object):
     def _server_info_req(self, message, connection):
         raise gen.Return(connection.protocol.create('SERVER-INFO-REPLY', message.header['msgid']))
 
+    @gen.coroutine
+    def _ping_req(self, message, connection):
+        raise gen.Return(connection.ok(message))

--- a/bokeh/server/protocol/tests/test_versions.py
+++ b/bokeh/server/protocol/tests/test_versions.py
@@ -32,5 +32,6 @@ def test_version_1_0():
         ('PULL-DOC-REQ', 1),
         ('PULL-DOC-REPLY', 1),
         ('PUSH-DOC', 1),
-        ('PATCH-DOC', 1)
+        ('PATCH-DOC', 1),
+        ('PING-REQ', 1)
     )

--- a/bokeh/server/protocol/versions.py
+++ b/bokeh/server/protocol/versions.py
@@ -57,7 +57,8 @@ spec = {
         ('PULL-DOC-REQ', 1),
         ('PULL-DOC-REPLY', 1),
         ('PUSH-DOC', 1),
-        ('PATCH-DOC', 1)
+        ('PATCH-DOC', 1),
+        ('PING-REQ', 1)
     ),
 
 }

--- a/bokeh/server/views/ws.py
+++ b/bokeh/server/views/ws.py
@@ -123,10 +123,6 @@ class WSHandler(WebSocketHandler):
 
         raise gen.Return(None)
 
-    def on_pong(self, data):
-        #log.debug("received a pong: %r", data)
-        pass
-
     @gen.coroutine
     def send_message(self, message):
         ''' Send a Bokeh Server protocol message to the connected client.

--- a/bokeh/tests/test_client_server.py
+++ b/bokeh/tests/test_client_server.py
@@ -147,6 +147,22 @@ class TestClientServer(unittest.TestCase):
             session.loop_until_closed()
             assert not session.connected
 
+    def test_ping(self):
+        application = Application()
+        with ManagedServerLoop(application) as server:
+            session = ClientSession(url=server.ws_url, io_loop=server.io_loop)
+            session.connect()
+            assert session.connected
+            assert session.document is None
+
+            result = session.ping_wait_for_reply()
+
+            self.assertDictEqual(dict(), result)
+
+            session.close()
+            session.loop_until_closed()
+            assert not session.connected
+
     def test_client_changes_go_to_server(self):
         application = Application()
         with ManagedServerLoop(application) as server:

--- a/bokehjs/src/coffee/common/client.coffee
+++ b/bokehjs/src/coffee/common/client.coffee
@@ -91,6 +91,9 @@ message_handlers = {
 
   'ERROR' : (connection, message) ->
     logger.error("Unhandled ERROR reply to #{message.reqid()}: #{message.content['text']}")
+
+  'PING-REQ' : (connection, message) ->
+    connection.send(Message.create('OK', { 'msgid' : message.msgid() }))
 }
 
 class ClientConnection


### PR DESCRIPTION
This is a probably-wrong fix for #3291 

Also switch force_roundtrip over to use ping.

What this does is that instead of sending a websocket ping
frame with opcode 0x9 and getting back a pong with opcode 0xA
(see https://tools.ietf.org/html/rfc6455#section-5.5.2),
we send several text data frames with opcode 0x1 which is our
usual message structure (https://tools.ietf.org/html/rfc6455#section-5.6 ).

I know of no reason this should make any difference to a reverse proxy
like nginx, and in a quick glance through nginx source code it
looks like sending and receiving any kind of bytes as a ping/pong
ought to work... maybe there's an issue with buffering or something
that makes the message size matter? If so we could send more data
in the ping/pong frames...
Buffering: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering

Until we understand why/whether this change matters we probably should
not apply it.