### PR TITLE
Use the correct name for the Server(keep_alive_milliseconds) kwarg

### DIFF
--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -198,7 +198,7 @@ class Serve(Subcommand):
 
         server_kwargs = { key: getattr(args, key) for key in ['port',
                                                               'address',
-                                                              'keep_alive']
+                                                              'keep_alive_milliseconds']
                           if getattr(args, key, None) is not None }
 
         server = Server(applications, **server_kwargs)


### PR DESCRIPTION
`--keep-alive` option was being silently ignored.
