### PR TITLE
New example - custom axis tickformatter

### DIFF
--- a/examples/plotting/file/custom_datetime_axis.py
+++ b/examples/plotting/file/custom_datetime_axis.py
@@ -38,7 +38,7 @@ inc = df.close > df.open
 dec = df.open > df.close
 w = 0.5
 
-output_file("candlestick_custom_axis.html", title="custom_datetime_axis.py example")
+output_file("custom_datetime_axis.html", title="custom_datetime_axis.py example")
 
 TOOLS = "pan,wheel_zoom,box_zoom,reset,save"
 

--- a/examples/plotting/file/custom_datetime_axis.py
+++ b/examples/plotting/file/custom_datetime_axis.py
@@ -1,3 +1,4 @@
+from pdb import set_trace as bp
 from math import pi
 
 import pandas as pd
@@ -6,6 +7,8 @@ from bokeh.sampledata.stocks import MSFT
 from bokeh.plotting import figure, show, output_file
 from bokeh.models.formatters import TickFormatter, String, List
 
+# In this custom TickFormatter, xaxis labels are taken from an array of date
+# Strings (e.g. ['Sep 01', 'Sep 02', ...]) passed to the date_labels property. 
 class DateGapTickFormatter(TickFormatter):
   date_labels = List(item_type=String)
   __implementation__ = """
@@ -28,8 +31,9 @@ module.exports =
 		"""
 
 df = pd.DataFrame(MSFT)[:50]
-df = df.set_index([range(0,len(df))])
-date_labels = map(lambda x: x.strftime('%b %d'), pd.to_datetime(df["date"]))
+
+# xaxis date labels used in the custom TickFormatter
+date_labels = [date.strftime('%b %d') for date in pd.to_datetime(df["date"])]
 
 mids = (df.open + df.close)/2
 spans = abs(df.close-df.open)
@@ -44,8 +48,11 @@ TOOLS = "pan,wheel_zoom,box_zoom,reset,save"
 
 p = figure(tools=TOOLS, plot_width=1000, toolbar_location="left")
 
+# Using the custom TickFormatter. You must always define date_labels
 p.xaxis[0].formatter = DateGapTickFormatter(date_labels = date_labels)
 
+# x coordinates must be integers. If for example df.index are 
+# datetimes, you should replace them with a integer sequence
 p.segment(df.index, df.high, df.index, df.low, color="black")
 p.rect(df.index[inc], mids[inc], w, spans[inc], fill_color="#D5E1DD", line_color="black")
 p.rect(df.index[dec], mids[dec], w, spans[dec], fill_color="#F2583E", line_color="black")

--- a/examples/plotting/file/custom_datetime_axis.py
+++ b/examples/plotting/file/custom_datetime_axis.py
@@ -1,0 +1,58 @@
+from math import pi
+
+import pandas as pd
+
+from bokeh.sampledata.stocks import MSFT
+from bokeh.plotting import figure, show, output_file
+from bokeh.models.formatters import TickFormatter, String, List
+
+class DateGapTickFormatter(TickFormatter):
+  date_labels = List(item_type=String)
+  __implementation__ = """
+_ = require "underscore"
+HasProperties = require "common/has_properties"
+
+class DateGapTickFormatter extends HasProperties
+  type: 'DateGapTickFormatter'
+
+  format: (ticks) ->
+    date_labels = @get("date_labels")
+    labels = ( 
+      for tick, i in ticks
+        date_labels[tick] ? ""
+      )
+    return labels
+
+module.exports =
+  Model: DateGapTickFormatter
+		"""
+
+df = pd.DataFrame(MSFT)[:50]
+df = df.set_index([range(0,len(df))])
+date_labels = map(lambda x: x.strftime('%b %d'), pd.to_datetime(df["date"]))
+
+mids = (df.open + df.close)/2
+spans = abs(df.close-df.open)
+
+inc = df.close > df.open
+dec = df.open > df.close
+w = 0.5
+
+output_file("candlestick_custom_axis.html", title="custom_datetime_axis.py example")
+
+TOOLS = "pan,wheel_zoom,box_zoom,reset,save"
+
+p = figure(tools=TOOLS, plot_width=1000, toolbar_location="left")
+
+p.xaxis[0].formatter = DateGapTickFormatter(date_labels = date_labels)
+
+p.segment(df.index, df.high, df.index, df.low, color="black")
+p.rect(df.index[inc], mids[inc], w, spans[inc], fill_color="#D5E1DD", line_color="black")
+p.rect(df.index[dec], mids[dec], w, spans[dec], fill_color="#F2583E", line_color="black")
+
+p.title = "MSFT Candlestick with custom x axis"
+p.xaxis.major_label_orientation = pi/4
+
+p.grid[0].ticker.desired_num_ticks = 6
+
+show(p)  # open a browser

--- a/examples/plotting/file/custom_datetime_axis.py
+++ b/examples/plotting/file/custom_datetime_axis.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as bp
 from math import pi
 
 import pandas as pd
@@ -10,8 +9,9 @@ from bokeh.models.formatters import TickFormatter, String, List
 # In this custom TickFormatter, xaxis labels are taken from an array of date
 # Strings (e.g. ['Sep 01', 'Sep 02', ...]) passed to the date_labels property. 
 class DateGapTickFormatter(TickFormatter):
-  date_labels = List(item_type=String)
-  __implementation__ = """
+    date_labels = List(String)
+
+    __implementation__ = """
 _ = require "underscore"
 HasProperties = require "common/has_properties"
 
@@ -20,15 +20,11 @@ class DateGapTickFormatter extends HasProperties
 
   format: (ticks) ->
     date_labels = @get("date_labels")
-    labels = ( 
-      for tick, i in ticks
-        date_labels[tick] ? ""
-      )
-    return labels
+    return (date_labels[tick] ? "" for tick in ticks)
 
 module.exports =
   Model: DateGapTickFormatter
-		"""
+"""
 
 df = pd.DataFrame(MSFT)[:50]
 


### PR DESCRIPTION
issues: fixes #3193

By defining a custom TickFormatter model, we are able to remove the weekend/holiday gaps in the candlestick financial chart. Dates are formatted into an array of Strings, e.g. ['Sep 01', 'Sep 02', ...], which is passed to the custom ticker as a property and then rendered on the axis.

The downside to this approach is that we lose the dynamic nature of Datetimei. This can be overcome by making DateGapTickFormatter receive more than one list of Strings, each one representing a different Date format, e.g. List 1 = ['Sep 01', 'Sep 02', ...]; List 2 = ['Sep', 'Sep', ... 'Oct', ...] and so on. This remains as a suggestion only and is not implemented by this commit.