### PR TITLE
Signed session IDs and consistent session/url/app_path params

### DIFF
--- a/bokeh/client/connection.py
+++ b/bokeh/client/connection.py
@@ -13,7 +13,6 @@ from tornado.concurrent import Future
 from bokeh.server.exceptions import MessageError, ProtocolError, ValidationError
 from bokeh.server.protocol.receiver import Receiver
 from bokeh.server.protocol import Protocol
-from bokeh.resources import DEFAULT_SERVER_WEBSOCKET_URL
 
 class _WebSocketClientConnectionWrapper(object):
     ''' Used for compat across Tornado versions '''
@@ -79,11 +78,11 @@ class ClientConnection(object):
             else:
                 yield connection._next()
 
-    def __init__(self, session, io_loop=None, url=DEFAULT_SERVER_WEBSOCKET_URL):
+    def __init__(self, session, websocket_url, io_loop=None):
         '''
           Opens a websocket connection to the server.
         '''
-        self._url = url
+        self._url = websocket_url
         self._session = session
         self._protocol = Protocol("1.0")
         self._receiver = Receiver(self._protocol)

--- a/bokeh/client/session.py
+++ b/bokeh/client/session.py
@@ -19,12 +19,28 @@ import uuid
 DEFAULT_SESSION_ID = "default"
 
 def push_session(document, session_id=None, url='default', app_path='/', io_loop=None):
-    """Create a session by pushing the given document to the server, overwriting any existing server-side document.
+    """ Create a session by pushing the given document to the server,
+       overwriting any existing server-side document.
 
-       session.document in the returned session will be your supplied document. While the
-       connection to the server is open, changes made on the server side will be applied
-       to this document, and changes made on the client side will be synced
-       to the server.
+       ``session.document`` in the returned session will be your
+       supplied document. While the connection to the server is
+       open, changes made on the server side will be applied to
+       this document, and changes made on the client side will be
+       synced to the server.
+
+       In a production scenario, the ``session_id`` should be
+       unique for each browser tab, which keeps users from
+       stomping on each other. It's neither scalable nor secure to
+       use predictable session IDs or to share session IDs across
+       users.
+
+       For a notebook running on a single machine, ``session_id``
+       could be something human-readable such as ``"default"`` for
+       convenience.
+
+       If you allow ``push_session()`` to generate a unique
+       ``session_id``, you can obtain the generated ID with the
+       ``id`` property on the returned ``ClientSession``.
 
        Args:
             document : bokeh.document.Document
@@ -40,6 +56,7 @@ def push_session(document, session_id=None, url='default', app_path='/', io_loop
        Returns:
             session : ClientSession
                 A new ClientSession connected to the server
+
     """
     coords = _SessionCoordinates(dict(session_id=session_id, url=url, app_path=app_path))
     session = ClientSession(session_id=coords.session_id, websocket_url=coords.websocket_url, io_loop=io_loop)
@@ -47,12 +64,34 @@ def push_session(document, session_id=None, url='default', app_path='/', io_loop
     return session
 
 def pull_session(session_id=None, url='default', app_path='/', io_loop=None):
-    """Create a session by loading the current server-side document.
+    """ Create a session by loading the current server-side document.
 
-       session.document will be a fresh document loaded from the server. While the
-       connection to the server is open, changes made on the server side will be
-       applied to this document, and changes made on the client side will be synced
-       to the server.
+       ``session.document`` will be a fresh document loaded from
+       the server. While the connection to the server is open,
+       changes made on the server side will be applied to this
+       document, and changes made on the client side will be
+       synced to the server.
+
+       If you don't plan to modify ``session.document`` you probably
+       don't need to use this function; instead you can directly
+       ``show_session()`` or ``autoload_server()`` without downloading
+       the session's document into your process first. It's much
+       more efficient to avoid downloading the session if you don't need
+       to.
+
+       In a production scenario, the ``session_id`` should be
+       unique for each browser tab, which keeps users from
+       stomping on each other. It's neither scalable nor secure to
+       use predictable session IDs or to share session IDs across
+       users.
+
+       For a notebook running on a single machine, ``session_id``
+       could be something human-readable such as ``"default"`` for
+       convenience.
+
+       If you allow ``push_session()`` to generate a unique
+       ``session_id``, you can obtain the generated ID with the
+       ``id`` property on the returned ``ClientSession``.
 
        Args:
             session_id : string, optional
@@ -66,6 +105,7 @@ def pull_session(session_id=None, url='default', app_path='/', io_loop=None):
        Returns:
             session : ClientSession
                 A new ClientSession connected to the server
+
     """
     coords = _SessionCoordinates(dict(session_id=session_id, url=url, app_path=app_path))
     session = ClientSession(session_id=session_id, websocket_url=coords.websocket_url, io_loop=io_loop)
@@ -85,7 +125,14 @@ _new_param = {'tab': 2, 'window': 1}
 
 def show_session(session_id=None, url='default', app_path='/',
                  session=None, browser=None, new="tab", controller=None):
-        """ Open a browser displaying a session document.
+        """Open a browser displaying a session document.
+
+        If you have a session from ``pull_session()`` or
+        ``push_session`` you can
+        ``show_session(session=mysession)``. If you don't need to
+        open a connection to the server yourself, you can show a new
+        session in a browser by providing just the ``url`` and
+        ``app_path``.
 
         Args:
 
@@ -111,6 +158,7 @@ def show_session(session_id=None, url='default', app_path='/',
             For file-based output, opens or raises the browser window
             showing the current output file.  If **new** is 'tab', then
             opens a new tab. If **new** is 'window', then opens a new window.
+
         """
 
         if session is not None:

--- a/bokeh/client/session.py
+++ b/bokeh/client/session.py
@@ -14,7 +14,7 @@ from bokeh.resources import ( DEFAULT_SERVER_WEBSOCKET_URL,
                               server_url_for_websocket_url,
                               _SessionCoordinates )
 from bokeh.document import Document, PeriodicCallback, TimeoutCallback
-import uuid
+from bokeh.util.session_id import generate_session_id
 
 DEFAULT_SESSION_ID = "default"
 
@@ -185,7 +185,7 @@ class ClientSession(object):
 
     """
 
-    def __init__(self, session_id, websocket_url, io_loop=None):
+    def __init__(self, session_id=None, websocket_url=DEFAULT_SERVER_WEBSOCKET_URL, io_loop=None):
         '''
           A connection which attaches to a particular named session on the server.
 
@@ -198,7 +198,7 @@ class ClientSession(object):
 
           Args:
             session_id : str
-                The name of the session
+                The name of the session or None to generate one
             websocket_url : str
                 Websocket URL to connect to
             io_loop : tornado.ioloop.IOLoop, optional
@@ -327,10 +327,9 @@ class ClientSession(object):
         show_session(session=self)
 
     @classmethod
-    def _ensure_session_id(cls, session_id=DEFAULT_SESSION_ID):
-        # if someone explicitly sets session_id=None that means make one up
+    def _ensure_session_id(cls, session_id):
         if session_id is None:
-            session_id = str(uuid.uuid4())
+            session_id = generate_session_id()
         return session_id
 
     @property

--- a/bokeh/client/session.py
+++ b/bokeh/client/session.py
@@ -128,11 +128,10 @@ def show_session(session_id=None, url='default', app_path='/',
         """Open a browser displaying a session document.
 
         If you have a session from ``pull_session()`` or
-        ``push_session`` you can
-        ``show_session(session=mysession)``. If you don't need to
-        open a connection to the server yourself, you can show a new
-        session in a browser by providing just the ``url`` and
-        ``app_path``.
+        ``push_session`` you can ``show_session(session=mysession)``.
+        If you don't need to open a connection to the server yourself,
+        you can show a new session in a browser by providing just the
+        ``url`` and ``app_path``.
 
         Args:
 

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -352,10 +352,32 @@ def autoload_static(model, resources, script_path):
         return encode_utf8(js), encode_utf8(tag)
 
 def autoload_server(model, app_path="/", session_id=None, url="default", loglevel="info"):
-    ''' Return a script tag that can be used to embed Bokeh Plots from
-    a Bokeh Server.
+    '''Return a script tag that embeds the given model (or entire
+    Document) from a Bokeh server session.
 
-    The data for the plot is stored on the Bokeh Server.
+    In a typical deployment, each browser tab connecting to a
+    Bokeh application will have its own unique session ID. The session ID
+    identifies a unique Document instance for each session (so the state
+    of the Document can be different in every tab).
+
+    If you call ``autoload_server(model=None)``, you'll embed the
+    entire Document for a freshly-generated session ID. Typically,
+    you should call ``autoload_server()`` again for each page load so
+    that every new browser tab gets its own session.
+
+    Sometimes when doodling around on a local machine, it's fine
+    to set ``session_id`` to something human-readable such as
+    ``"default"``.  That way you can easily reload the same
+    session each time and keep your state.  But don't do this in
+    production!
+
+    In some applications, you may want to "set up" the session
+    before you embed it. For example, you might ``session =
+    bokeh.client.pull_session()`` to load up a session, modify
+    ``session.document`` in some way (perhaps adding per-user
+    data?), and then call ``autoload_server(model=None,
+    session_id=session.id)``. The session ID obtained from
+    ``pull_session()`` can be passed to ``autoload_server()``.
 
     Args:
         model (Model) : the object to render from the session, or None for entire document
@@ -369,6 +391,11 @@ def autoload_server(model, app_path="/", session_id=None, url="default", logleve
         tag :
             a ``<script>`` tag that will execute an autoload script
             loaded from the Bokeh Server
+
+    .. note:: It is a very bad idea to use the same ``session_id`` for
+    every page load; you are likely to create scalability and
+    security problems. So ``autoload_server()`` should be called
+    again on each page load.
 
     '''
 

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -25,7 +25,7 @@ from .util.string import encode_utf8
 
 from .model import Model, _ModelInDocument
 from ._json_encoder import serialize_json
-from .resources import DEFAULT_SERVER_HTTP_URL, _SessionCoordinates
+from .resources import _SessionCoordinates
 from .document import Document, DEFAULT_TITLE
 from collections import Sequence
 from six import string_types
@@ -383,19 +383,13 @@ def autoload_server(model, app_path="/", session_id=None, url="default", logleve
     if model is not None:
         model_id = model._id
 
-    server_url = coords.server_url
-    session_id = coords.session_id
-
-    if not server_url.endswith("/"):
-        server_url = server_url + "/"
-
-    src_path = server_url + "autoload.js" + "?bokeh-autoload-element=" + elementid
+    src_path = coords.server_url + "/autoload.js" + "?bokeh-autoload-element=" + elementid
 
     tag = AUTOLOAD_TAG.render(
         src_path = src_path,
         elementid = elementid,
         modelid = model_id,
-        sessionid = session_id,
+        sessionid = coords.session_id,
         loglevel = loglevel
     )
 

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -392,10 +392,10 @@ def autoload_server(model, app_path="/", session_id=None, url="default", logleve
             a ``<script>`` tag that will execute an autoload script
             loaded from the Bokeh Server
 
-    .. note:: It is a very bad idea to use the same ``session_id`` for
-    every page load; you are likely to create scalability and
-    security problems. So ``autoload_server()`` should be called
-    again on each page load.
+    .. note:: It is a very bad idea to use the same ``session_id``
+        for every page load; you are likely to create scalability
+        and security problems. So ``autoload_server()`` should be
+        called again on each page load.
 
     '''
 

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -34,7 +34,7 @@ from .state import State
 from .util.notebook import load_notebook, publish_display_data
 from .util.string import decode_utf8
 from .client import DEFAULT_SESSION_ID, push_session, show_session
-from bokeh.resources import DEFAULT_SERVER_HTTP_URL, websocket_url_for_server_url
+from bokeh.resources import websocket_url_for_server_url
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -130,7 +130,10 @@ def output_notebook(resources=None, verbose=False, hide_banner=False):
     load_notebook(resources, verbose, hide_banner)
     _state.output_notebook()
 
-def output_server(session_id=DEFAULT_SESSION_ID, url="default", autopush=False):
+# usually we default session_id to "generate a random one" but
+# here we default to a hardcoded one. This is to support local
+# usage e.g. with a notebook.
+def output_server(session_id=DEFAULT_SESSION_ID, url="default", app_path="/", autopush=False):
     """Store Bokeh plots and objects on a Bokeh server.
 
     File, server, and notebook output may be active at the
@@ -147,6 +150,8 @@ def output_server(session_id=DEFAULT_SESSION_ID, url="default", autopush=False):
         url (str, optional) : base URL of the Bokeh server (default: "default")
             If "default" use the default localhost URL.
 
+        app_path (str, optional) : relative path of the app on the Bokeh server (default: "/")
+
         autopush (bool, optional) : whether to automatically push (default: False)
             If True, then Bokeh plotting APIs may opt to automatically
             push the document more frequently (e.g., after any plotting
@@ -161,7 +166,7 @@ def output_server(session_id=DEFAULT_SESSION_ID, url="default", autopush=False):
 
     """
 
-    _state.output_server(session_id=session_id, url=url, autopush=autopush)
+    _state.output_server(session_id=session_id, url=url, app_path=app_path, autopush=autopush)
 
 def set_curdoc(doc):
     '''Configure the current document (returned by curdoc()).
@@ -243,7 +248,7 @@ def _show_with_state(obj, state, browser, new):
     if state.notebook:
         _show_notebook_with_state(obj, state)
 
-    elif state.session_id and state.server_url:
+    elif state.server_enabled:
         _show_server_with_state(obj, state, new, controller)
 
     if state.file:
@@ -254,16 +259,16 @@ def _show_file_with_state(obj, state, new, controller):
     controller.open("file://" + os.path.abspath(state.file['filename']), new=_new_param[new])
 
 def _show_notebook_with_state(obj, state):
-    if state.session_id:
+    if state.server_enabled:
         push(state=state)
-        snippet = autoload_server(obj, session_id=state.session_id, url=state.server_url)
+        snippet = autoload_server(obj, session_id=state.session_id, url=state.url, app_path=state.app_path)
         publish_display_data({'text/html': snippet})
     else:
         publish_display_data({'text/html': notebook_div(obj)})
 
 def _show_server_with_state(obj, state, new, controller):
     push(state=state)
-    show_session(session_id=state.session_id, server_url=state.server_url,
+    show_session(session_id=state.session_id, url=state.url, app_path=state.app_path,
                  new=new, controller=controller)
 
 def save(obj, filename=None, resources=None, title=None, state=None, validate=True):
@@ -347,22 +352,24 @@ def _save_helper(obj, filename, resources, title, validate):
             f.write(decode_utf8(html))
 
 # this function exists mostly to be mocked in tests
-def _push_to_server(websocket_url, document, session_id, io_loop):
-    session = push_session(document, session_id=session_id, url=websocket_url, io_loop=io_loop)
+def _push_to_server(session_id, url, app_path, document, io_loop):
+    session = push_session(document, session_id=session_id, url=url, app_path=app_path, io_loop=io_loop)
     session.close()
     session.loop_until_closed()
 
-def push(session_id=None, url=None, document=None, state=None, io_loop=None, validate=True):
+def push(session_id=None, url=None, app_path=None, document=None, state=None, io_loop=None, validate=True):
     ''' Update the server with the data for the current document.
 
-    Will fall back to the default output state (or an explicitly provided
-    :class:`State` object) for ``session_id``, ``url``, or ``document`` if they are not
-    provided.
+    Will fall back to the default output state (or an explicitly
+    provided :class:`State` object) for ``session_id``, ``url``,
+    ``app_path``, or ``document`` if they are not provided.
 
     Args:
         session_id (str, optional) : a Bokeh server session ID to push objects to
 
         url (str, optional) : a Bokeh server URL to push objects to
+
+        app_path (str, optional) : Relative application path to push objects to
 
         document (Document, optional) : A :class:`bokeh.document.Document` to use
 
@@ -382,14 +389,16 @@ def push(session_id=None, url=None, document=None, state=None, io_loop=None, val
     if not session_id:
         session_id = state.session_id
 
-    if not session_id:
-        session_id = DEFAULT_SESSION_ID
-
     if not url:
-        url = state.server_url
+        url = state.url
 
-    if not url:
-        url = DEFAULT_SERVER_HTTP_URL
+    if not app_path:
+        app_path = state.app_path
+
+    # State is supposed to ensure these are set
+    assert session_id is not None
+    assert url is not None
+    assert app_path is not None
 
     if not document:
         document = state.document
@@ -400,8 +409,8 @@ def push(session_id=None, url=None, document=None, state=None, io_loop=None, val
     if validate:
         document.validate()
 
-    _push_to_server(websocket_url=websocket_url_for_server_url(url), document=document,
-                    session_id=session_id, io_loop=io_loop)
+    _push_to_server(session_id=session_id, url=url, app_path=app_path,
+                    document=document, io_loop=io_loop)
 
 def reset_output(state=None):
     ''' Clear the default state of all output modes.
@@ -419,7 +428,7 @@ def _remove_roots(subplots):
             doc.remove_root(sub)
 
 def _push_or_save(obj):
-    if _state.session_id and _state.autopush:
+    if _state.server_enabled and _state.autopush:
         push()
     if _state.file and _state.autosave:
         save(obj)

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -137,10 +137,16 @@ def output_server(session_id=DEFAULT_SESSION_ID, url="default", app_path="/", au
     """ Configure the default output state to push its document to a
     session on a Bokeh server.
 
-    Sessions are in-memory and not persisted to disk, making
-    output_server() most useful for single-user scripts
-    (output_server() isn't appropriate for an application deployed
-    on the web where each person will need their own session).
+    Sessions are in-memory and not persisted to disk; in a typical
+    production deployment, you would have a fresh session ID for each
+    browser tab. If different users share the same session ID, it will
+    create security and scalability problems.
+
+    ``output_server()`` defaults to always using the
+    ``session_id`` ``"default"``, which is useful for running
+    local demos or notebooks. However, if you are creating
+    production sessions, you'll need to set ``session_id`` to None
+    (to generate a fresh ID) or to a session ID generated elsewhere.
 
     File, server, and notebook output may be active at the same
     time, so output_server() does not clear the effects of

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -134,14 +134,20 @@ def output_notebook(resources=None, verbose=False, hide_banner=False):
 # here we default to a hardcoded one. This is to support local
 # usage e.g. with a notebook.
 def output_server(session_id=DEFAULT_SESSION_ID, url="default", app_path="/", autopush=False):
-    """Store Bokeh plots and objects on a Bokeh server.
+    """ Configure the default output state to push its document to a
+    session on a Bokeh server.
 
-    File, server, and notebook output may be active at the
-    same time, so this does not clear the effects of
-    output_file() or output_notebook(). output_server()
-    changes the behavior of output_notebook(), so the notebook
-    will load output cells from the server rather than
-    receiving them as inline HTML.
+    Sessions are in-memory and not persisted to disk, making
+    output_server() most useful for single-user scripts
+    (output_server() isn't appropriate for an application deployed
+    on the web where each person will need their own session).
+
+    File, server, and notebook output may be active at the same
+    time, so output_server() does not clear the effects of
+    output_file() or output_notebook(). output_server() changes
+    the behavior of output_notebook(), so the notebook will load
+    output cells from the server rather than receiving them as
+    inline HTML.
 
     Args:
         session_id (str, optional) : Name of session to push on Bokeh server (default: "default")

--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -58,34 +58,25 @@ class _SessionCoordinates(object):
     def __init__(self, kwargs):
         """ Using kwargs which may have extra stuff we don't care about, compute websocket url and session ID."""
 
-        if 'url' in kwargs:
-            self._base_url = kwargs['url']
-            if self._base_url is None:
-                raise ValueError("url cannot be None")
-            if self._base_url == 'default':
-                self._base_url = DEFAULT_SERVER_HTTP_URL
-            if self._base_url.startswith("ws"):
-                raise ValueError("url should be the http or https URL for the server, not the websocket URL")
-        else:
+        self._base_url = kwargs.get('url', DEFAULT_SERVER_HTTP_URL)
+        if self._base_url is None:
+            raise ValueError("url cannot be None")
+        if self._base_url == 'default':
             self._base_url = DEFAULT_SERVER_HTTP_URL
+        if self._base_url.startswith("ws"):
+            raise ValueError("url should be the http or https URL for the server, not the websocket URL")
 
         if not self._base_url.endswith("/"):
             self._base_url = self._base_url + "/"
 
-        if 'app_path' in kwargs:
-            self._app_path = kwargs['app_path']
-            if self._app_path is None:
-                raise ValueError("app_path cannot be None")
-            if not self._app_path.startswith("/"):
-                raise ValueError("app_path should start with a '/' character")
-        else:
-            self._app_path = '/'
+        self._app_path = kwargs.get('app_path', '/')
+        if self._app_path is None:
+            raise ValueError("app_path cannot be None")
+        if not self._app_path.startswith("/"):
+            raise ValueError("app_path should start with a '/' character")
 
-        if 'session_id' in kwargs:
-            self._session_id = kwargs['session_id']
-            if self._session_id is None:
-                self._session_id = generate_session_id()
-        else:
+        self._session_id = kwargs.get('session_id', None)
+        if self._session_id is None:
             self._session_id = generate_session_id()
 
         if self._app_path == '/':

--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -28,7 +28,6 @@ DEFAULT_SERVER_HOST = "localhost"
 DEFAULT_SERVER_PORT = 5006
 DEFAULT_SERVER_HTTP_URL = "http://%s:%d/" % (DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT)
 
-
 def websocket_url_for_server_url(url):
     if url.startswith("http:"):
         reprotocoled = "ws" + url[4:]
@@ -66,6 +65,7 @@ class _SessionCoordinates(object):
         if self._base_url.startswith("ws"):
             raise ValueError("url should be the http or https URL for the server, not the websocket URL")
 
+        # base_url always has trailing slash, host:port/{prefix/}
         if not self._base_url.endswith("/"):
             self._base_url = self._base_url + "/"
 
@@ -74,13 +74,17 @@ class _SessionCoordinates(object):
             raise ValueError("app_path cannot be None")
         if not self._app_path.startswith("/"):
             raise ValueError("app_path should start with a '/' character")
+        if self._app_path != '/' and self._app_path.endswith("/"):
+            self._app_path = self._app_path[:-1] # chop off trailing slash
 
         self._session_id = kwargs.get('session_id', None)
         if self._session_id is None:
             self._session_id = generate_session_id()
 
+        # server_url never has trailing slash because it's
+        # prettier like host:port/app_path without a slash
         if self._app_path == '/':
-            self._server_url = self._base_url
+            self._server_url = self._base_url[:-1] # chop off trailing slash
         else:
             self._server_url = self._base_url + self._app_path[1:]
 

--- a/bokeh/server/views/doc_handler.py
+++ b/bokeh/server/views/doc_handler.py
@@ -6,53 +6,11 @@ from __future__ import absolute_import, print_function
 import logging
 log = logging.getLogger(__name__)
 
-import hashlib
-import random
-import time
-
-from tornado.web import RequestHandler
+from tornado.web import RequestHandler, HTTPError
 
 from bokeh.embed import server_html_page_for_session
 from bokeh.settings import settings
-
-# Use the system PRNG for session id generation (if possible)
-# NOTE: secure random string generation implementation is adapted
-#       from the Django project. Reference:
-#       https://github.com/django/django/blob/0ed7d155635da9f79d4dd67e4889087d3673c6da/django/utils/crypto.py
-try:
-    random = random.SystemRandom()
-    using_sysrandom = True
-except NotImplementedError:
-    import warnings
-    warnings.warn('A secure pseudo-random number generator is not available '
-                  'on your system. Falling back to Mersenne Twister.')
-    using_sysrandom = False
-
-def get_random_string(length=36,
-                      allowed_chars='abcdefghijklmnopqrstuvwxyz'
-                                    'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'):
-    """
-    Return a securely generated random string.
-    The default length of 12 with the a-z, A-Z, 0-9 character set returns
-    a 71-bit value. log_2((26+26+10)^12) =~ 71 bits
-    """
-    if not using_sysrandom:
-        # This is ugly, and a hack, but it makes things better than
-        # the alternative of predictability. This re-seeds the PRNG
-        # using a value that is hard for an attacker to predict, every
-        # time a random string is required. This may change the
-        # properties of the chosen random sequence slightly, but this
-        # is better than absolute predictability.
-        random.seed(
-            hashlib.sha256(
-                ("%s%s%s" % (
-                    random.getstate(),
-                    time.time(),
-                    settings.SECRET_KEY)).encode('utf-8')
-            ).digest())
-
-    return ''.join(random.choice(allowed_chars) for i in range(length))
-
+from bokeh.util.session_id import generate_session_id, check_session_id_signature
 
 class DocHandler(RequestHandler):
     ''' Implements a custom Tornado handler for document display page
@@ -70,7 +28,11 @@ class DocHandler(RequestHandler):
     def get(self, *args, **kwargs):
         session_id = self.get_argument("bokeh-session-id", default=None)
         if session_id is None:
-            session_id = get_random_string()
+            session_id = generate_session_id()
+        elif not check_session_id_signature(session_id):
+            log.error("Session id had invalid signature: %r", session_id)
+            raise HTTPError(status_code=403, reason="Invalid session ID")
+
         session = self.application_context.create_session_if_needed(session_id)
 
         websocket_url = self.application.websocket_url_for_request(self.request, self.bokeh_websocket_path)

--- a/bokeh/server/views/ws.py
+++ b/bokeh/server/views/ws.py
@@ -20,6 +20,8 @@ from ..protocol.message import Message
 from ..protocol.receiver import Receiver
 from ..protocol.server_handler import ServerHandler
 
+from bokeh.util.session_id import check_session_id_signature
+
 def do_background_stuff(msgid):
     delay = random.random() * 2.0
     log.info("start working for %.2f s. on %s", delay, msgid)
@@ -65,6 +67,10 @@ class WSHandler(WebSocketHandler):
         if session_id is None:
             self.close()
             raise ProtocolError("No bokeh-session-id specified")
+
+        if not check_session_id_signature(session_id):
+            log.error("Session id had invalid signature: %r", session_id)
+            raise ProtocolError("Invalid session ID")
 
         try:
             self.application_context.create_session_if_needed(session_id)

--- a/bokeh/state.py
+++ b/bokeh/state.py
@@ -44,7 +44,6 @@ import os
 from .document import Document
 from .resources import Resources, _SessionCoordinates
 from .client import DEFAULT_SESSION_ID
-from bokeh.resources import DEFAULT_SERVER_HTTP_URL
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/bokeh/state.py
+++ b/bokeh/state.py
@@ -42,7 +42,7 @@ import os
 
 # Bokeh imports
 from .document import Document
-from .resources import Resources
+from .resources import Resources, _SessionCoordinates
 from .client import DEFAULT_SESSION_ID
 from bokeh.resources import DEFAULT_SERVER_HTTP_URL
 
@@ -107,12 +107,26 @@ class State(object):
         return self._notebook
 
     @property
+    def server_enabled(self):
+        return self._server_enabled
+
+    @property
     def session_id(self):
-        return self._session_id
+        return self._session_coords.session_id
+
+    @property
+    def url(self):
+        """ Gets the server base URL (not including any app path)."""
+        return self._session_coords.url
 
     @property
     def server_url(self):
-        return self._server_url
+        """ Gets the full server URL (including the app path)."""
+        return self._session_coords.server_url
+
+    @property
+    def app_path(self):
+        return self._session_coords.app_path
 
     @property
     def autoadd(self):
@@ -129,8 +143,8 @@ class State(object):
     def _reset_keeping_doc(self):
         self._file = None
         self._notebook = False
-        self._session_id = None
-        self._server_url = None
+        self._session_coords = _SessionCoordinates(dict())
+        self._server_enabled = False
         self._autosave = False
         self._autopush = False
 
@@ -209,7 +223,8 @@ class State(object):
         """
         self._notebook = True
 
-    def output_server(self, session_id=DEFAULT_SESSION_ID, url="default", autopush=False):
+    def output_server(self, session_id=DEFAULT_SESSION_ID, url="default",
+                      app_path='/', autopush=False):
         """Store Bokeh plots and objects on a Bokeh server.
 
         File, server, and notebook output may be active at the
@@ -226,6 +241,8 @@ class State(object):
             url (str, optional) : base URL of the Bokeh server (default: "default")
                 If "default" use the default localhost URL.
 
+            app_path (str, optional) : relative path of the app on the Bokeh server (default: "/")
+
             autopush (bool, optional) : whether to automatically push (default: False)
                 If True, then Bokeh plotting APIs may opt to automatically
                 push the document more frequently (e.g., after any plotting
@@ -239,9 +256,9 @@ class State(object):
             Calling this function will replace any existing server-side document in the named session.
 
         """
-        if url == "default":
-            url = DEFAULT_SERVER_HTTP_URL
+        self._session_coords = _SessionCoordinates(dict(session_id=session_id,
+                                                        url=url,
+                                                        app_path=app_path))
 
-        self._session_id = session_id
-        self._server_url = url
         self._autopush = autopush
+        self._server_enabled = True

--- a/bokeh/tests/test_client_server.py
+++ b/bokeh/tests/test_client_server.py
@@ -91,14 +91,14 @@ class TestClientServer(unittest.TestCase):
             # uses the same main loop as the client, so
             # if we start either one it starts both
             session = ClientSession(io_loop = server.io_loop,
-                                    url = ws_url(server, "/foo"))
+                                    websocket_url = ws_url(server, "/foo"))
             session.connect()
             assert session.connected
             session.close()
             session.loop_until_closed()
 
             session = ClientSession(io_loop = server.io_loop,
-                                    url = ws_url(server))
+                                    websocket_url = ws_url(server))
             session.connect()
             assert not session.connected
             session.close()
@@ -109,7 +109,7 @@ class TestClientServer(unittest.TestCase):
 
         # succeed no host value with defaults
         with ManagedServerLoop(application, host=None) as server:
-            session = ClientSession(url=ws_url(server), io_loop = server.io_loop)
+            session = ClientSession(websocket_url=ws_url(server), io_loop = server.io_loop)
             session.connect()
             assert session.connected
             session.close()
@@ -117,7 +117,7 @@ class TestClientServer(unittest.TestCase):
 
         # succeed no host value with port
         with ManagedServerLoop(application, port=8080, host=None) as server:
-            session = ClientSession(url=ws_url(server), io_loop = server.io_loop)
+            session = ClientSession(websocket_url=ws_url(server), io_loop = server.io_loop)
             session.connect()
             assert session.connected
             session.close()
@@ -125,7 +125,7 @@ class TestClientServer(unittest.TestCase):
 
         # succeed matching host value
         with ManagedServerLoop(application, port=8080, host=["localhost:8080"]) as server:
-            session = ClientSession(url=ws_url(server), io_loop = server.io_loop)
+            session = ClientSession(websocket_url=ws_url(server), io_loop = server.io_loop)
             session.connect()
             assert session.connected
             session.close()
@@ -133,7 +133,7 @@ class TestClientServer(unittest.TestCase):
 
         # succeed matching host value one of multiple
         with ManagedServerLoop(application, port=8080, host=["bad_host", "localhost:8080"]) as server:
-            session = ClientSession(url=ws_url(server), io_loop = server.io_loop)
+            session = ClientSession(websocket_url=ws_url(server), io_loop = server.io_loop)
             session.connect()
             assert session.connected
             session.close()
@@ -144,14 +144,14 @@ class TestClientServer(unittest.TestCase):
 
         # failure bad host
         with ManagedServerLoop(application, host=["bad_host"]) as server:
-            session = ClientSession(url=ws_url(server), io_loop = server.io_loop)
+            session = ClientSession(websocket_url=ws_url(server), io_loop = server.io_loop)
             session.connect()
             assert not session.connected
             session.close()
             session.loop_until_closed()
 
         with ManagedServerLoop(application, host=["bad_host:5006"]) as server:
-            session = ClientSession(url=ws_url(server), io_loop = server.io_loop)
+            session = ClientSession(websocket_url=ws_url(server), io_loop = server.io_loop)
             session.connect()
             assert not session.connected
             session.close()
@@ -159,7 +159,7 @@ class TestClientServer(unittest.TestCase):
 
         # failure good host, bad port
         with ManagedServerLoop(application, host=["localhost:80"]) as server:
-            session = ClientSession(url=ws_url(server), io_loop = server.io_loop)
+            session = ClientSession(websocket_url=ws_url(server), io_loop = server.io_loop)
             session.connect()
             assert not session.connected
             session.close()
@@ -167,7 +167,7 @@ class TestClientServer(unittest.TestCase):
 
         # failure good host, bad default port
         with ManagedServerLoop(application, host=["localhost"]) as server:
-            session = ClientSession(url=ws_url(server), io_loop = server.io_loop)
+            session = ClientSession(websocket_url=ws_url(server), io_loop = server.io_loop)
             session.connect()
             assert not session.connected
             session.close()
@@ -175,7 +175,7 @@ class TestClientServer(unittest.TestCase):
 
         # failure with custom port
         with ManagedServerLoop(application, port=8080, host=["localhost:8081"]) as server:
-            session = ClientSession(url=ws_url(server), io_loop = server.io_loop)
+            session = ClientSession(websocket_url=ws_url(server), io_loop = server.io_loop)
             session.connect()
             assert not session.connected
             session.close()

--- a/bokeh/tests/test_io.py
+++ b/bokeh/tests/test_io.py
@@ -11,7 +11,7 @@ from mock import patch, Mock
 import unittest
 
 import bokeh.io as io
-from bokeh.resources import Resources
+from bokeh.resources import Resources, _SessionCoordinates
 from bokeh.document import Document
 
 class TestDefaultState(unittest.TestCase):
@@ -74,12 +74,12 @@ class TestOutputNotebook(DefaultStateTester):
 class TestOutputServer(DefaultStateTester):
 
     def test_noarg(self):
-        default_kwargs = dict(session_id="default", url="default", autopush=False)
+        default_kwargs = dict(session_id="default", url="default", app_path='/', autopush=False)
         io.output_server()
         self._check_func_called(io._state.output_server, (), default_kwargs)
 
     def test_args(self):
-        kwargs = dict(session_id="foo", url="http://example.com", autopush=True)
+        kwargs = dict(session_id="foo", url="http://example.com", app_path='/foo', autopush=True)
         io.output_server(**kwargs)
         self._check_func_called(io._state.output_server, (), kwargs)
 
@@ -151,82 +151,85 @@ class TestPush(DefaultStateTester):
 
     @patch('bokeh.io._push_to_server')
     def test_missing_output_server(self, mock_push_to_server):
-        # set to None rather than mock objects,
-        # this simulates never calling output_server
-        io._state.session_id = None
-        io._state.server_url = None
+        # never calling output_server should pull session coords
+        # off the io._state object
+        io._state.server_enabled = False
         io._state.document = Document()
         io.push()
         self._check_func_called(mock_push_to_server, (),
-                                dict(websocket_url="ws://localhost:5006/ws",
+                                dict(url=io._state.url,
+                                     app_path=io._state.app_path,
+                                     session_id=io._state.session_id,
                                      document=io._state.document,
-                                     session_id="default",
                                      io_loop=None))
 
     @patch('bokeh.io._push_to_server')
     def test_noargs(self, mock_push_to_server):
-        # this simulates having called output_server with these params
+        # if we had called output_server, the state object would be set
+        # up like this
         io._state.session_id = "fakesessionid"
-        io._state.server_url = "https://example.com/"
+        io._state.url = "http://example.com/"
+        io._state.app_path = "/bar"
+        io._state.server_enabled = True
         io.push()
         self._check_func_called(mock_push_to_server, (),
-                                dict(websocket_url="wss://example.com/ws",
+                                dict(url="http://example.com/",
                                      document=io._state.document,
                                      session_id="fakesessionid",
+                                     app_path="/bar",
                                      io_loop=None))
 
     @patch('bokeh.io._push_to_server')
     def test_session_arg(self, mock_push_to_server):
-        # set to None rather than mock objects,
         # this simulates never calling output_server
-        io._state.session_id = None
-        io._state.server_url = None
+        io._state.server_enabled = False
         io.push(session_id="somesession")
         self._check_func_called(mock_push_to_server, (),
-                                dict(websocket_url="ws://localhost:5006/ws",
+                                dict(url=io._state.url,
+                                     app_path=io._state.app_path,
                                      document=io._state.document,
                                      session_id="somesession",
                                      io_loop=None))
 
     @patch('bokeh.io._push_to_server')
     def test_url_arg(self, mock_push_to_server):
-        # set to None rather than mock objects,
         # this simulates never calling output_server
-        io._state.session_id = None
-        io._state.server_url = None
+        io._state.server_enabled = False
         io.push(url="http://example.com/")
         self._check_func_called(mock_push_to_server, (),
-                                dict(websocket_url="ws://example.com/ws",
+                                dict(url="http://example.com/",
+                                     app_path=io._state.app_path,
+                                     session_id=io._state.session_id,
                                      document=io._state.document,
-                                     session_id="default",
                                      io_loop=None))
 
     @patch('bokeh.io._push_to_server')
     def test_document_arg(self, mock_push_to_server):
-        # set to None rather than mock objects,
         # this simulates never calling output_server
-        io._state.session_id = None
-        io._state.server_url = None
+        io._state.server_enabled = False
         d = Document()
         io.push(document=d)
         self._check_func_called(mock_push_to_server, (),
-                                dict(websocket_url="ws://localhost:5006/ws",
+                                dict(url=io._state.url,
+                                     app_path=io._state.app_path,
+                                     session_id=io._state.session_id,
                                      document=d,
-                                     session_id="default",
                                      io_loop=None))
 
 
     @patch('bokeh.io._push_to_server')
     def test_all_args(self, mock_push_to_server):
         d = Document()
-        url = "https://example.com/foo"
+        url = "https://example.com/"
         session_id = "all_args_session"
+        app_path = "/foo"
         # state should get ignored since we specified everything otherwise
         state = Mock()
         io_loop = Mock()
-        io.push(document=d, url=url, state=state, session_id=session_id, io_loop=io_loop)
+        io.push(document=d, url=url, app_path=app_path, state=state, session_id=session_id, io_loop=io_loop)
         self._check_func_called(mock_push_to_server, (),
-                                dict(websocket_url="wss://example.com/foo/ws",
+                                dict(url="https://example.com/",
+                                     app_path="/foo",
                                      document=d,
                                      session_id="all_args_session",
                                      io_loop=io_loop))
@@ -234,18 +237,19 @@ class TestPush(DefaultStateTester):
     @patch('bokeh.io._push_to_server')
     def test_state_arg(self, mock_push_to_server):
         d = Document()
-        url = "https://example.com/state"
+        url = "https://example.com/state/"
         session_id = "state_arg_session"
         # state should get ignored since we specified everything otherwise
         state = Mock()
         state.document = d
-        state.server_url = url
+        state.url = url
         state.session_id = session_id
         io.push(state=state)
         self._check_func_called(mock_push_to_server, (),
-                                dict(websocket_url="wss://example.com/state/ws",
+                                dict(url="https://example.com/state/",
                                      document=d,
                                      session_id="state_arg_session",
+                                     app_path = state.app_path,
                                      io_loop=None))
 
 class TestShow(DefaultStateTester):
@@ -307,8 +311,10 @@ class Test_ShowWithState(DefaultStateTester):
         self.assertFalse(mock__show_server_with_state.called)
         self._check_func_called(mock__show_file_with_state, ("obj", s, "new", "controller"), {})
 
-        s._session_id = "fakesession"
-        s._server_url = "http://example.com"
+        s._session_coords = _SessionCoordinates(dict(session_id="fakesession",
+                                                     url="http://example.com",
+                                                     app_path='/'))
+        s._server_enabled = True
         io._show_with_state("obj", s, "browser", "new")
         self.assertFalse(mock__show_notebook_with_state.called)
         self._check_func_called(mock__show_server_with_state, ("obj", s, "new", "controller"), {})
@@ -339,7 +345,7 @@ class Test_ShowNotebookWithState(DefaultStateTester):
     @patch('bokeh.io.push')
     def test_with_server(self, mock_push, mock_autoload_server, mock_publish_display_data):
         s = io.State()
-        s._session_id = "fakesession"
+        s._server_enabled = True
         mock_autoload_server.return_value = "snippet"
 
         io._show_notebook_with_state("obj", s)
@@ -350,7 +356,6 @@ class Test_ShowNotebookWithState(DefaultStateTester):
     @patch('bokeh.io.notebook_div')
     def test_no_server(self, mock_notebook_div, mock_publish_display_data):
         s = io.State()
-        s._session = None
         mock_notebook_div.return_value = "notebook_div"
 
         io._show_notebook_with_state("obj", s)
@@ -361,17 +366,19 @@ class Test_ShowServerWithState(DefaultStateTester):
     @patch('bokeh.io.push')
     def test(self, mock_push):
         s = io.State()
-        s._session_id = "thesession"
-        s._server_url = "http://example.com"
+        s._session_coords = _SessionCoordinates(dict(session_id="thesession",
+                                                     url="http://example.com",
+                                                     app_path='/foo'))
+        s._server_enabled = True
         controller = Mock()
 
         io._show_server_with_state("obj", s, "window", controller)
         self._check_func_called(mock_push, (), {"state": s})
-        self._check_func_called(controller.open, ("http://example.com?bokeh-session-id=thesession",), {"new": 1})
+        self._check_func_called(controller.open, ("http://example.com/foo?bokeh-session-id=thesession",), {"new": 1})
 
         io._show_server_with_state("obj", s, "tab", controller)
         self._check_func_called(mock_push, (), {"state": s})
-        self._check_func_called(controller.open, ("http://example.com?bokeh-session-id=thesession",), {"new": 2})
+        self._check_func_called(controller.open, ("http://example.com/foo?bokeh-session-id=thesession",), {"new": 2})
 
 class TestResetOutput(DefaultStateTester):
 

--- a/bokeh/tests/test_state.py
+++ b/bokeh/tests/test_state.py
@@ -15,6 +15,8 @@ from bokeh.resources import DEFAULT_SERVER_HTTP_URL
 
 import bokeh.state as state
 
+GENERATED_SESSION_ID_LEN = 36
+
 class TestState(unittest.TestCase):
 
     def test_creation(self):
@@ -22,7 +24,7 @@ class TestState(unittest.TestCase):
         self.assertTrue(isinstance(s.document, Document))
         self.assertEqual(s.file, None)
         self.assertEqual(s.notebook, False)
-        self.assertEqual(s.session_id, None)
+        self.assertEqual(GENERATED_SESSION_ID_LEN, len(s.session_id))
 
     def test_default_file_resources(self):
         s = state.State()
@@ -58,15 +60,20 @@ class TestState(unittest.TestCase):
     def test_output_notebook_noarg(self):
         s = state.State()
         s.output_notebook()
-        self.assertEqual(s.session_id, None)
+        self.assertEqual(GENERATED_SESSION_ID_LEN, len(s.session_id))
         self.assertEqual(s.notebook, True)
 
     def test_output_server(self):
         s = state.State()
-        self.assertEqual(s.session_id, None)
-        s.output_server("default")
+        self.assertEqual(GENERATED_SESSION_ID_LEN, len(s.session_id))
+        s.output_server()
         self.assertEqual(s.session_id, "default")
         self.assertEqual(s.server_url, DEFAULT_SERVER_HTTP_URL)
+        self.assertEqual(s.app_path, '/')
+        s.output_server("foo")
+        self.assertEqual(s.session_id, "foo")
+        self.assertEqual(s.server_url, DEFAULT_SERVER_HTTP_URL)
+        self.assertEqual(s.app_path, '/')
 
     def test_reset(self):
         s = state.State()
@@ -77,7 +84,7 @@ class TestState(unittest.TestCase):
         s.reset()
         self.assertEqual(s.file, None)
         self.assertEqual(s.notebook, False)
-        self.assertEqual(s.session_id, None)
+        self.assertEqual(GENERATED_SESSION_ID_LEN, len(s.session_id))
         self.assertTrue(isinstance(s.document, Document))
         self.assertTrue(s.document != d)
 

--- a/bokeh/tests/test_state.py
+++ b/bokeh/tests/test_state.py
@@ -68,11 +68,11 @@ class TestState(unittest.TestCase):
         self.assertEqual(GENERATED_SESSION_ID_LEN, len(s.session_id))
         s.output_server()
         self.assertEqual(s.session_id, "default")
-        self.assertEqual(s.server_url, DEFAULT_SERVER_HTTP_URL)
+        self.assertEqual(s.server_url + "/", DEFAULT_SERVER_HTTP_URL)
         self.assertEqual(s.app_path, '/')
         s.output_server("foo")
         self.assertEqual(s.session_id, "foo")
-        self.assertEqual(s.server_url, DEFAULT_SERVER_HTTP_URL)
+        self.assertEqual(s.server_url + "/", DEFAULT_SERVER_HTTP_URL)
         self.assertEqual(s.app_path, '/')
 
     def test_reset(self):

--- a/bokeh/util/session_id.py
+++ b/bokeh/util/session_id.py
@@ -1,0 +1,119 @@
+''' Provide a request handler that returns a page displaying a document.
+
+'''
+from __future__ import absolute_import, print_function
+
+import base64
+import codecs
+import hashlib
+import hmac
+import random
+import time
+
+from six import string_types
+
+from bokeh.settings import settings
+
+# Use the system PRNG for session id generation (if possible)
+# NOTE: secure random string generation implementation is adapted
+#       from the Django project. Reference:
+#       https://github.com/django/django/blob/0ed7d155635da9f79d4dd67e4889087d3673c6da/django/utils/crypto.py
+try:
+    random = random.SystemRandom()
+    using_sysrandom = True
+except NotImplementedError:
+    import warnings
+    warnings.warn('A secure pseudo-random number generator is not available '
+                  'on your system. Falling back to Mersenne Twister.')
+    if settings.secret_key() is None:
+        warnings.warn('A secure pseudo-random number generator is not available '
+                      'and no BOKEH_SECRET_KEY has been set. '
+                      'Setting a secret key will mitigate the lack of a secure '
+                      'generator.')
+    using_sysrandom = False
+
+def _ensure_bytes(secret_key):
+    if isinstance(secret_key, string_types):
+        return codecs.encode(secret_key, 'utf-8')
+    else:
+        return secret_key
+
+# this is broken out for unit testability
+def _reseed_if_needed(using_sysrandom, secret_key):
+    secret_key = _ensure_bytes(secret_key)
+    if not using_sysrandom:
+        # This is ugly, and a hack, but it makes things better than
+        # the alternative of predictability. This re-seeds the PRNG
+        # using a value that is hard for an attacker to predict, every
+        # time a random string is required. This may change the
+        # properties of the chosen random sequence slightly, but this
+        # is better than absolute predictability.
+        random.seed(
+            hashlib.sha256(
+                ("%s%s%s" % (
+                    random.getstate(),
+                    time.time(),
+                    secret_key)).encode('utf-8')
+            ).digest())
+
+def _base64_encode(decoded):
+    # base64 encode both takes and returns bytes, we want to work with strings.
+    # If 'decoded' isn't bytes already, assume it's utf-8
+    decoded_as_bytes = _ensure_bytes(decoded)
+    encoded = codecs.decode(base64.urlsafe_b64encode(decoded_as_bytes), 'ascii')
+    # remove padding char that causes trouble
+    return encoded.rstrip('=')
+
+def _signature(base_id, secret_key):
+    secret_key = _ensure_bytes(secret_key)
+    base_id = codecs.encode(base_id, "utf-8")
+    signer = hmac.new(secret_key, base_id, hashlib.sha256)
+    return _base64_encode(signer.digest())
+
+def _get_random_string(length=36,
+                       allowed_chars='abcdefghijklmnopqrstuvwxyz'
+                       'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+                       secret_key=settings.secret_key_bytes()):
+    """
+    Return a securely generated random string.
+    The default length of 12 with the a-z, A-Z, 0-9 character set returns
+    a 71-bit value. log_2((26+26+10)^12) =~ 71 bits
+    """
+    secret_key = _ensure_bytes(secret_key)
+    _reseed_if_needed(using_sysrandom, secret_key)
+    return ''.join(random.choice(allowed_chars) for i in range(length))
+
+def generate_session_id(secret_key=settings.secret_key_bytes(), signed=settings.sign_sessions()):
+    """ Generate a random session ID.
+    Args:
+        secret_key (str, optional) : Secret key (default: value of 'BOKEH_SECRET_KEY' env var)
+        signed (bool, optional) : Whether to sign the session ID (default: value of 'BOKEH_SIGN_SESSIONS' env var)
+    """
+    secret_key = _ensure_bytes(secret_key)
+    if signed:
+        # note: '-' can also be in the base64 encoded signature
+        base_id = _get_random_string(secret_key=secret_key)
+        return base_id + '-' + _signature(base_id, secret_key)
+    else:
+        return _get_random_string(secret_key=secret_key)
+
+def check_session_id_signature(session_id, secret_key=settings.secret_key_bytes(), signed=settings.sign_sessions()):
+    """ Check the signature of a session ID.
+    Args:
+        session_id (str) : The session ID to check
+        secret_key (str, optional) : Secret key (default: value of 'BOKEH_SECRET_KEY' env var)
+        signed (bool, optional) : Whether to check anything (default: value of 'BOKEH_SIGN_SESSIONS' env var)
+    """
+    secret_key = _ensure_bytes(secret_key)
+    if signed:
+        pieces = session_id.split(sep='-', maxsplit=1)
+        if len(pieces) != 2:
+            return False
+        base_id = pieces[0]
+        provided_signature = pieces[1]
+        expected_signature = _signature(base_id, secret_key)
+        # hmac.compare_digest() uses a string compare algorithm that doesn't
+        # short-circuit so we don't allow timing analysis
+        return hmac.compare_digest(expected_signature, provided_signature)
+    else:
+        return True

--- a/bokeh/util/tests/test_session_id.py
+++ b/bokeh/util/tests/test_session_id.py
@@ -1,0 +1,86 @@
+from __future__ import absolute_import
+
+import base64
+import codecs
+import unittest
+
+import bokeh.util.session_id
+from bokeh.util.session_id import ( generate_session_id,
+                                    check_session_id_signature,
+                                    _signature,
+                                    _reseed_if_needed,
+                                    _base64_encode )
+import random
+
+# decoder for our flavor of base64 that converts to ascii
+# and drops '=' padding
+def _base64_decode(encoded):
+    # put the padding back
+    mod = len(encoded) % 4
+    if mod != 0:
+        encoded = encoded + ("=" * (4 - mod))
+    assert (len(encoded) % 4) == 0
+    # base64 lib both takes and returns bytes, we want to work with strings
+    encoded_as_bytes = codecs.encode(encoded, 'ascii')
+    return base64.urlsafe_b64decode(encoded_as_bytes)
+
+def _base64_decode_utf8(encoded):
+    return codecs.decode(_base64_decode(encoded), 'utf-8')
+
+class TestSessionId(unittest.TestCase):
+    def test_base64_roundtrip(self):
+        for s in [ "", "a", "ab", "abc", "abcd", "abcde", "abcdef", "abcdefg",
+                   "abcdefgh", "abcdefghi",
+                   "abcdefghijklmnopqrstuvwxyz" ]:
+            self.assertEqual(s, _base64_decode_utf8(_base64_encode(s)))
+
+    def test_reseed_if_needed(self):
+        # we have to set a seed in order to be able to get state
+        random.seed(codecs.encode("abcdefg", "utf-8"))
+        state = random.getstate()
+        _reseed_if_needed(using_sysrandom=True, secret_key=None)
+        # did NOT reseed
+        self.assertEqual(state, random.getstate())
+        # monkeypatch
+        saved = bokeh.util.session_id.random
+        try:
+            bokeh.util.session_id.random = random
+            _reseed_if_needed(using_sysrandom=False, secret_key="abc")
+            # DID reseed
+            self.assertNotEqual(state, random.getstate())
+        finally:
+            bokeh.util.session_id.random = saved
+
+    def test_signature(self):
+        sig = _signature("xyz", secret_key="abc")
+        with_same_key = _signature("xyz", secret_key="abc")
+        self.assertEqual(sig, with_same_key)
+        with_different_key = _signature("xyz", secret_key="qrs")
+        self.assertNotEqual(sig, with_different_key)
+
+    def test_generate_unsigned(self):
+        session_id = generate_session_id(signed=False)
+        self.assertEqual(36, len(session_id))
+        another_session_id = generate_session_id(signed=False)
+        self.assertEqual(36, len(another_session_id))
+
+        self.assertNotEqual(session_id, another_session_id)
+
+    def test_generate_signed(self):
+        session_id = generate_session_id(signed=True, secret_key="abc")
+        self.assertTrue('-' in session_id)
+        self.assertTrue(check_session_id_signature(session_id, secret_key="abc", signed=True))
+        self.assertFalse(check_session_id_signature(session_id, secret_key="qrs", signed=True))
+
+    def test_check_signature_of_unsigned(self):
+        session_id = generate_session_id(signed=False, secret_key="abc") # secret shouldn't be used
+        self.assertFalse(check_session_id_signature(session_id, secret_key="abc", signed=True))
+
+    def test_check_signature_of_empty_string(self):
+        self.assertFalse(check_session_id_signature("", secret_key="abc", signed=True))
+
+    def test_check_signature_of_junk_with_hyphen_in_it(self):
+        self.assertFalse(check_session_id_signature("foo-bar-baz", secret_key="abc", signed=True))
+
+    def test_check_signature_with_signing_disabled(self):
+        self.assertTrue(check_session_id_signature("gobbledygook", secret_key="abc", signed=False))

--- a/examples/embed/animated.py
+++ b/examples/embed/animated.py
@@ -32,7 +32,7 @@ p.annular_wedge(
     line_color="black",
 )
 
-tag = embed.autoload_server(p)
+tag = embed.autoload_server(session_id=session.id, p)
 html = """
 <html>
   <head></head>

--- a/examples/embed/animated.py
+++ b/examples/embed/animated.py
@@ -32,7 +32,7 @@ p.annular_wedge(
     line_color="black",
 )
 
-tag = embed.autoload_server(session_id=session.id, p)
+tag = embed.autoload_server(p, session_id=session.id)
 html = """
 <html>
   <head></head>

--- a/examples/embed/widget.py
+++ b/examples/embed/widget.py
@@ -103,7 +103,7 @@ import bokeh.embed as embed
 pop = Population()
 pop.render()
 
-tag = embed.autoload_server(pop.layout)
+tag = embed.autoload_server(session_id=pop.session.id, pop.layout)
 
 html = """
 <html>

--- a/examples/embed/widget.py
+++ b/examples/embed/widget.py
@@ -103,7 +103,7 @@ import bokeh.embed as embed
 pop = Population()
 pop.render()
 
-tag = embed.autoload_server(session_id=pop.session.id, pop.layout)
+tag = embed.autoload_server(pop.layout, session_id=pop.session.id)
 
 html = """
 <html>


### PR DESCRIPTION
This is intended to fix #3324 and fix #3171 and also fix output_server to have an app_path which is in the wiki (https://github.com/bokeh/bokeh/wiki/Issue-list:-new-Bokeh-server ) but not an open issue.

Signed sessions are a partial step toward https://github.com/bokeh/bokeh/issues/3287 but there's a missing piece (doc_handler.py will still autogenerate an ID, there has to be a way to disable that).
