### PR TITLE
hotfix to only render toolbar once

### DIFF
--- a/bokehjs/src/coffee/common/tool_manager.coffee
+++ b/bokehjs/src/coffee/common/tool_manager.coffee
@@ -16,9 +16,12 @@ class ToolManagerView extends Backbone.View
   initialize: (options) ->
     super(options)
     @listenTo(@model, 'change', @render)
-    @render()
+    @have_rendered = false
 
   render: () ->
+    if @have_rendered
+      return
+    @have_rendered = true
     @$el.html(@template(@model.attributes))
     @$el.addClass("bk-sidebar")
     @$el.addClass("bk-toolbar-active")


### PR DESCRIPTION
Fixes a bug that caused the toolbar to be unresponsive on streaming updates. 

@birdsarah @mattpap @brendancol any comments welcome, I am sure this is a simplistic fix but it does seem to be an improvement. 