### PR TITLE
When we customize property serialization, also customize deserialization

### DIFF
--- a/bokeh/document.py
+++ b/bokeh/document.py
@@ -43,12 +43,13 @@ class DocumentPatchedEvent(DocumentChangedEvent):
             receiver._document_patched(self)
 
 class ModelChangedEvent(DocumentPatchedEvent):
-    def __init__(self, document, model, attr, old, new):
+    def __init__(self, document, model, attr, old, new, serializable_new):
         super(ModelChangedEvent, self).__init__(document)
         self.model = model
         self.attr = attr
         self.old = old
         self.new = new
+        self.serializable_new = serializable_new
 
     def dispatch(self, receiver):
         super(ModelChangedEvent, self).dispatch(receiver)
@@ -480,7 +481,8 @@ class Document(object):
             if new is not None:
                 self._all_models_by_name.add_value(new, model)
 
-        self._trigger_on_change(ModelChangedEvent(self, model, attr, old, new))
+        serializable_new = model.lookup(attr).serializable_value(model)
+        self._trigger_on_change(ModelChangedEvent(self, model, attr, old, new, serializable_new))
 
     @classmethod
     def _references_json(cls, references):
@@ -521,21 +523,7 @@ class Document(object):
 
             instance = references[obj_id]
 
-            # replace references with actual instances in obj_attrs
-            for p in instance.properties_with_refs():
-                if p in obj_attrs:
-                    prop = instance.lookup(p)
-                    obj_attrs[p] = prop.from_json(obj_attrs[p], models=references)
-
-            # set all properties on the instance
-            remove = []
-            for key in obj_attrs:
-                if key not in instance.properties():
-                    logger.warn("Client sent attr %r for instance %r, which is a client-only or invalid attribute that shouldn't have been sent", key, instance)
-                    remove.append(key)
-            for key in remove:
-                del obj_attrs[key]
-            instance.update(**obj_attrs)
+            instance.update_from_json(obj_attrs, models=references)
 
     def to_json_string(self, indent=None):
         ''' Convert the document to a JSON string.
@@ -619,7 +607,7 @@ class Document(object):
                 raise ValueError("Cannot create a patch using events from a different document " + repr(event))
 
             if isinstance(event, ModelChangedEvent):
-                value = event.new
+                value = event.serializable_new
 
                 # the new value is an object that may have
                 # not-yet-in-the-remote-doc references, and may also
@@ -695,14 +683,7 @@ class Document(object):
                 patched_obj = self._all_models[patched_id]
                 attr = event_json['attr']
                 value = event_json['new']
-                if attr in patched_obj.properties_with_refs():
-                    prop = patched_obj.lookup(attr)
-                    value = prop.from_json(value, models=references)
-                if attr in patched_obj.properties():
-                    #logger.debug("Patching attribute %s of %r", attr, patched_obj)
-                    patched_obj.update(** { attr : value })
-                else:
-                    logger.warn("Client sent attr %r on obj %r, which is a client-only or invalid attribute that shouldn't have been sent", attr, patched_obj)
+                patched_obj.set_from_json(attr, value, models=references)
             elif event_json['kind'] == 'RootAdded':
                 root_id = event_json['model']['id']
                 root_obj = references[root_id]

--- a/bokeh/model.py
+++ b/bokeh/model.py
@@ -315,10 +315,6 @@ class Model(with_metaclass(Viewable, HasProps, CallbackManager)):
         # (it converts Model into refs, for example).
         return serialize_json(json_like, sort_keys=True)
 
-    def update(self, **kwargs):
-        for k,v in kwargs.items():
-            setattr(self, k, v)
-
     def __str__(self):
         return "%s, ViewModel:%s, ref _id: %s" % (self.__class__.__name__,
                 self.__view_model__, getattr(self, "_id", None))

--- a/bokeh/server/protocol/messages/tests/test_patch_doc.py
+++ b/bokeh/server/protocol/messages/tests/test_patch_doc.py
@@ -26,7 +26,7 @@ class TestPatchDocument(unittest.TestCase):
     def test_create_model_changed(self):
         sample = self._sample_doc()
         obj = next(iter(sample.roots))
-        event = document.ModelChangedEvent(sample, obj, 'foo', obj.foo, 42)
+        event = document.ModelChangedEvent(sample, obj, 'foo', obj.foo, 42, 42)
         Protocol("1.0").create("PATCH-DOC", [event])
 
     def test_create_then_apply_model_changed(self):
@@ -39,7 +39,7 @@ class TestPatchDocument(unittest.TestCase):
 
         obj = next(iter(sample.roots))
         assert obj.foo == 2
-        event = document.ModelChangedEvent(sample, obj, 'foo', obj.foo, 42)
+        event = document.ModelChangedEvent(sample, obj, 'foo', obj.foo, 42, 42)
         msg = Protocol("1.0").create("PATCH-DOC", [event])
 
         copy = document.Document.from_json_string(sample.to_json_string())
@@ -65,36 +65,36 @@ class TestPatchDocument(unittest.TestCase):
         new_child = AnotherModelInTestPatchDoc(bar=56)
 
         # integer property changed
-        event1 = document.ModelChangedEvent(sample, root, 'foo', root.foo, 42)
+        event1 = document.ModelChangedEvent(sample, root, 'foo', root.foo, 42, 42)
         msg = Protocol("1.0").create("PATCH-DOC", [event1])
         assert msg.should_suppress_on_change(event1)
-        assert not msg.should_suppress_on_change(document.ModelChangedEvent(sample, root, 'foo', root.foo, 43))
-        assert not msg.should_suppress_on_change(document.ModelChangedEvent(sample, root, 'bar', root.foo, 43))
-        assert not msg.should_suppress_on_change(document.ModelChangedEvent(sample, other_root, 'foo', root.foo, 43))
+        assert not msg.should_suppress_on_change(document.ModelChangedEvent(sample, root, 'foo', root.foo, 43, 43))
+        assert not msg.should_suppress_on_change(document.ModelChangedEvent(sample, root, 'bar', root.foo, 43, 43))
+        assert not msg.should_suppress_on_change(document.ModelChangedEvent(sample, other_root, 'foo', root.foo, 43, 43))
 
         # Model property changed
-        event2 = document.ModelChangedEvent(sample, root, 'child', root.child, new_child)
+        event2 = document.ModelChangedEvent(sample, root, 'child', root.child, new_child, new_child)
         msg2 = Protocol("1.0").create("PATCH-DOC", [event2])
         assert msg2.should_suppress_on_change(event2)
-        assert not msg2.should_suppress_on_change(document.ModelChangedEvent(sample, root, 'child', root.child, other_root))
-        assert not msg2.should_suppress_on_change(document.ModelChangedEvent(sample, root, 'blah', root.child, new_child))
-        assert not msg2.should_suppress_on_change(document.ModelChangedEvent(sample, other_root, 'child', other_root.child, new_child))
+        assert not msg2.should_suppress_on_change(document.ModelChangedEvent(sample, root, 'child', root.child, other_root, other_root))
+        assert not msg2.should_suppress_on_change(document.ModelChangedEvent(sample, root, 'blah', root.child, new_child, new_child))
+        assert not msg2.should_suppress_on_change(document.ModelChangedEvent(sample, other_root, 'child', other_root.child, new_child, new_child))
 
         # Model property changed to None
-        event3 = document.ModelChangedEvent(sample, root, 'child', root.child, None)
+        event3 = document.ModelChangedEvent(sample, root, 'child', root.child, None, None)
         msg3 = Protocol("1.0").create("PATCH-DOC", [event3])
         assert msg3.should_suppress_on_change(event3)
-        assert not msg3.should_suppress_on_change(document.ModelChangedEvent(sample, root, 'child', root.child, other_root))
-        assert not msg3.should_suppress_on_change(document.ModelChangedEvent(sample, root, 'blah', root.child, None))
-        assert not msg3.should_suppress_on_change(document.ModelChangedEvent(sample, other_root, 'child', other_root.child, None))
+        assert not msg3.should_suppress_on_change(document.ModelChangedEvent(sample, root, 'child', root.child, other_root, other_root))
+        assert not msg3.should_suppress_on_change(document.ModelChangedEvent(sample, root, 'blah', root.child, None, None))
+        assert not msg3.should_suppress_on_change(document.ModelChangedEvent(sample, other_root, 'child', other_root.child, None, None))
 
         # Model property changed from None
-        event4 = document.ModelChangedEvent(sample, other_root, 'child', other_root.child, None)
+        event4 = document.ModelChangedEvent(sample, other_root, 'child', other_root.child, None, None)
         msg4 = Protocol("1.0").create("PATCH-DOC", [event4])
         assert msg4.should_suppress_on_change(event4)
-        assert not msg4.should_suppress_on_change(document.ModelChangedEvent(sample, other_root, 'child', other_root.child, root))
-        assert not msg4.should_suppress_on_change(document.ModelChangedEvent(sample, other_root, 'blah', other_root.child, None))
-        assert not msg4.should_suppress_on_change(document.ModelChangedEvent(sample, root, 'child', other_root.child, None))
+        assert not msg4.should_suppress_on_change(document.ModelChangedEvent(sample, other_root, 'child', other_root.child, root, root))
+        assert not msg4.should_suppress_on_change(document.ModelChangedEvent(sample, other_root, 'blah', other_root.child, None, None))
+        assert not msg4.should_suppress_on_change(document.ModelChangedEvent(sample, root, 'child', other_root.child, None, None))
 
         # RootAdded
         event5 = document.RootAddedEvent(sample, root)

--- a/bokeh/tests/test_document.py
+++ b/bokeh/tests/test_document.py
@@ -2,10 +2,12 @@ from __future__ import absolute_import, print_function
 
 import unittest
 
+from copy import copy
+
 import bokeh.document as document
 from bokeh.io import curdoc
 from bokeh.model import Model
-from bokeh.properties import Int, Instance, String
+from bokeh.properties import Int, Instance, String, DistanceSpec
 
 class AnotherModelInTestDocument(Model):
     bar = Int(1)
@@ -16,6 +18,9 @@ class SomeModelInTestDocument(Model):
 
 class ModelThatOverridesName(Model):
     name = String()
+
+class ModelWithSpecInTestDocument(Model):
+    foo = DistanceSpec(2)
 
 class TestDocument(unittest.TestCase):
 
@@ -520,17 +525,71 @@ class TestDocument(unittest.TestCase):
         d.add_root(root2)
         assert len(d.roots) == 2
 
-        event1 = document.ModelChangedEvent(d, root1, 'foo', root1.foo, 57)
+        event1 = document.ModelChangedEvent(d, root1, 'foo', root1.foo, 57, 57)
         patch1 = d.create_json_patch_string([event1])
         d.apply_json_patch_string(patch1)
 
         assert root1.foo == 57
 
-        event2 = document.ModelChangedEvent(d, child1, 'foo', child1.foo, 67)
+        event2 = document.ModelChangedEvent(d, child1, 'foo', child1.foo, 67, 67)
         patch2 = d.create_json_patch_string([event2])
         d.apply_json_patch_string(patch2)
 
         assert child1.foo == 67
+
+    def test_patch_spec_property(self):
+        d = document.Document()
+        assert not d.roots
+        assert len(d._all_models) == 0
+        root1 = ModelWithSpecInTestDocument(foo=42)
+        d.add_root(root1)
+        assert len(d.roots) == 1
+
+        def patch_test(new_value):
+            serializable_new = root1.lookup('foo').descriptor.to_serializable(root1,
+                                                                              'foo',
+                                                                              new_value)
+            event1 = document.ModelChangedEvent(d, root1, 'foo', root1.foo, new_value,
+                                                serializable_new)
+            patch1 = d.create_json_patch_string([event1])
+            d.apply_json_patch_string(patch1)
+            if isinstance(new_value, dict):
+                expected = copy(new_value)
+                if 'units' not in expected:
+                    expected['units'] = root1.foo_units
+                self.assertDictEqual(expected, root1.lookup('foo').serializable_value(root1))
+            else:
+                self.assertEqual(new_value, root1.foo)
+        patch_test(57)
+        self.assertEqual('data', root1.foo_units)
+        patch_test(dict(value=58))
+        self.assertEqual('data', root1.foo_units)
+        patch_test(dict(value=58, units='screen'))
+        self.assertEqual('screen', root1.foo_units)
+        patch_test(dict(value=59, units='screen'))
+        self.assertEqual('screen', root1.foo_units)
+        patch_test(dict(value=59, units='data'))
+        self.assertEqual('data', root1.foo_units)
+        patch_test(dict(value=60, units='data'))
+        self.assertEqual('data', root1.foo_units)
+        patch_test(dict(value=60, units='data'))
+        self.assertEqual('data', root1.foo_units)
+        patch_test(61)
+        self.assertEqual('data', root1.foo_units)
+        root1.foo = "a_string" # so "woot" gets set as a string
+        patch_test("woot")
+        self.assertEqual('data', root1.foo_units)
+        patch_test(dict(field="woot2"))
+        self.assertEqual('data', root1.foo_units)
+        patch_test(dict(field="woot2", units='screen'))
+        self.assertEqual('screen', root1.foo_units)
+        patch_test(dict(field="woot3"))
+        self.assertEqual('screen', root1.foo_units)
+        patch_test(dict(value=70))
+        self.assertEqual('screen', root1.foo_units)
+        root1.foo = 123 # so 71 gets set as a number
+        patch_test(71)
+        self.assertEqual('screen', root1.foo_units)
 
     def test_patch_reference_property(self):
         d = document.Document()
@@ -551,7 +610,7 @@ class TestDocument(unittest.TestCase):
         assert child2._id not in d._all_models
         assert child3._id not in d._all_models
 
-        event1 = document.ModelChangedEvent(d, root1, 'child', root1.child, child3)
+        event1 = document.ModelChangedEvent(d, root1, 'child', root1.child, child3, child3)
         patch1 = d.create_json_patch_string([event1])
         d.apply_json_patch_string(patch1)
 
@@ -562,7 +621,7 @@ class TestDocument(unittest.TestCase):
         assert child3._id in d._all_models
 
         # put it back how it was before
-        event2 = document.ModelChangedEvent(d, root1, 'child', root1.child, child1)
+        event2 = document.ModelChangedEvent(d, root1, 'child', root1.child, child1, child1)
         patch2 = d.create_json_patch_string([event2])
         d.apply_json_patch_string(patch2)
 
@@ -588,8 +647,8 @@ class TestDocument(unittest.TestCase):
 
         child2 = SomeModelInTestDocument(foo=44)
 
-        event1 = document.ModelChangedEvent(d, root1, 'foo', root1.foo, 57)
-        event2 = document.ModelChangedEvent(d, root1, 'child', root1.child, child2)
+        event1 = document.ModelChangedEvent(d, root1, 'foo', root1.foo, 57, 57)
+        event2 = document.ModelChangedEvent(d, root1, 'child', root1.child, child2, child2)
         patch1 = d.create_json_patch_string([event1, event2])
         d.apply_json_patch_string(patch1)
 

--- a/bokeh/tests/test_properties.py
+++ b/bokeh/tests/test_properties.py
@@ -442,6 +442,34 @@ class TestNumberSpec(unittest.TestCase):
         a.x = 14
         self.assertEqual(a.x, 14)
 
+    def test_set_from_json_keeps_mode(self):
+        class Foo(HasProps):
+            x = NumberSpec(default=None)
+
+        a = Foo()
+
+        self.assertIs(a.x, None)
+
+        # set as a value
+        a.x = 14
+        self.assertEqual(a.x, 14)
+        # set_from_json keeps the previous dict-ness or lack thereof
+        a.set_from_json('x', dict(value=16))
+        self.assertEqual(a.x, 16)
+        # but regular assignment overwrites the previous dict-ness
+        a.x = dict(value=17)
+        self.assertDictEqual(a.x, dict(value=17))
+
+        # set as a field
+        a.x = "bar"
+        self.assertEqual(a.x, "bar")
+        # set_from_json keeps the previous dict-ness or lack thereof
+        a.set_from_json('x', dict(field="foo"))
+        self.assertEqual(a.x, "foo")
+        # but regular assignment overwrites the previous dict-ness
+        a.x = dict(field="baz")
+        self.assertDictEqual(a.x, dict(field="baz"))
+
 class TestAngleSpec(unittest.TestCase):
     def test_default_none(self):
         class Foo(HasProps):
@@ -487,6 +515,19 @@ class TestAngleSpec(unittest.TestCase):
 
         a.x = { 'value' : 180, 'units' : 'deg' }
         self.assertDictEqual(a.x, { 'value' : 180 })
+        self.assertEqual(a.x_units, 'deg')
+
+    def test_setting_json_sets_units_keeps_dictness(self):
+        class Foo(HasProps):
+            x = AngleSpec(default=14)
+
+        a = Foo()
+
+        self.assertEqual(a.x, 14)
+        self.assertEqual(a.x_units, 'rad')
+
+        a.set_from_json('x', { 'value' : 180, 'units' : 'deg' })
+        self.assertEqual(a.x, 180)
         self.assertEqual(a.x_units, 'deg')
 
 class TestDistanceSpec(unittest.TestCase):


### PR DESCRIPTION
TLDR the client in examples/plotting/server/glyphs.py ended up with `inner_radius = { value: 10 }` instead of `inner_radius = { value: 10, units: 'screen' }` and now it keeps the units.

This fixes a problem with examples/plotting/server/glyphs.py where
we'd have AnnularWedge.inner_radius as a single value, we'd send it
to the client as a dict, at some point the client sent it back to us
as a dict, we then stripped the units out and emitted a ModelChangedEvent
as a dict sans units (because ModelChangedEvent contains the new regular
value, not the new serializable_value()). This new units-less dict was
then sent to the client causing the client to use default units instead
of the originally-provided units.

To fix this we need the serializable_value() in ModelChangedEvent.

We also need to be able to get a change event back from the client
without "forgetting" the dict-ness of our local attribute.
"dict-ness" means that we remember whether you set `foo = 42` or
`foo = { 'value' : 42 }`.

So we move the logic that does from_json and then sets the prop
from Document into a HasProps.set_from_json which in turn delegates
to Property, so that DataSpecProperty can process the JSON and
decide to preserve its dict-ness in the JSON case but not in the
regular `__set__` case.
