### PR TITLE
Make `bokeh json` and `bokeh html` work in a similar way

### DIFF
--- a/bokeh/command/bootstrap.py
+++ b/bokeh/command/bootstrap.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 
 import argparse
 
-from bokeh.settings import settings
+from bokeh import __version__
 from bokeh.util.string import nice_join
 
 from .util import die
@@ -26,11 +26,10 @@ def main(argv):
 
     parser = argparse.ArgumentParser(prog=argv[0])
 
-    # does this get set by anything other than BOKEH_VERSION env var?
-    version = settings.version()
-    if not version:
-        version = "unknown version"
-    parser.add_argument('-v', '--version', action='version', version=version)
+    # we don't use settings.version() because the point of this option
+    # is to report the actual version of Bokeh, while settings.version()
+    # lets people change the version used for CDN for example.
+    parser.add_argument('-v', '--version', action='version', version=__version__)
 
     subs = parser.add_subparsers(help="Sub-commands")
 

--- a/bokeh/command/subcommand.py
+++ b/bokeh/command/subcommand.py
@@ -38,7 +38,10 @@ class Subcommand(with_metaclass(ABCMeta)):
         self.parser = parser
         args = getattr(self, 'args', ())
         for arg in args:
-            self.parser.add_argument(arg[0], **arg[1])
+            flags = arg[0]
+            if not isinstance(flags, tuple):
+                flags = (flags,)
+            self.parser.add_argument(*flags, **arg[1])
 
     @abstractmethod
     def invoke(self, args):

--- a/bokeh/command/subcommands/__init__.py
+++ b/bokeh/command/subcommands/__init__.py
@@ -22,6 +22,8 @@ def _collect():
                 if not hasattr(attr, 'name'): continue # excludes abstract bases
                 results.append(attr)
 
+    results = sorted(results, key=lambda attr: attr.name)
+
     return results
 
 all = _collect()

--- a/bokeh/command/subcommands/__init__.py
+++ b/bokeh/command/subcommands/__init__.py
@@ -18,8 +18,8 @@ def _collect():
 
         for name in dir(mod):
             attr = getattr(mod, name)
-            if attr is Subcommand: continue
             if isinstance(attr, type) and issubclass(attr, Subcommand):
+                if not hasattr(attr, 'name'): continue # excludes abstract bases
                 results.append(attr)
 
     return results

--- a/bokeh/command/subcommands/file_output.py
+++ b/bokeh/command/subcommands/file_output.py
@@ -51,7 +51,10 @@ class FileOutputSubcommand(Subcommand):
     def invoke(self, args):
         applications = build_single_handler_applications(args.files)
 
-        outputs = list(args.output) # copy so we can pop from it
+        if args.output is None:
+            outputs = []
+        else:
+            outputs = list(args.output) # copy so we can pop from it
 
         if len(outputs) > len(applications):
             die("--output/-o was given too many times (%d times for %d applications)" %

--- a/bokeh/command/subcommands/file_output.py
+++ b/bokeh/command/subcommands/file_output.py
@@ -1,0 +1,48 @@
+'''
+Abstract base class for subcommands that output to a file (or stdout).
+'''
+from __future__ import absolute_import
+
+from abc import abstractmethod
+
+from ..subcommand import Subcommand
+from ..util import build_single_handler_applications
+
+class FileOutputSubcommand(Subcommand):
+    ''' Abstract subcommand to output applications as some type of file.
+
+    '''
+
+    extension = None # subtype must set this to file extension
+
+    @classmethod
+    def files_arg(cls, output_type_name):
+        """ Subtypes must use this to make a files arg and include it in their args. """
+        return ('files', dict(
+            metavar='DIRECTORY-OR-SCRIPT',
+            nargs='+',
+            help=("The app directories or scripts to generate %s for" % (output_type_name)),
+            default=None
+        ))
+
+    def filename_from_route(self, route, ext):
+        if route == "/":
+            base = "index"
+        else:
+            base = route[1:]
+
+        return "%s.%s" % (base, ext)
+
+    def invoke(self, args):
+        applications = build_single_handler_applications(args.files)
+
+        for (route, app) in applications.items():
+            doc = app.create_document()
+
+            filename = self.filename_from_route(route, self.extension)
+
+            self.write_file(args, filename, doc)
+
+    @abstractmethod
+    def write_file(self, args, filename, doc):
+        raise NotImplementedError("write_file")

--- a/bokeh/command/subcommands/file_output.py
+++ b/bokeh/command/subcommands/file_output.py
@@ -4,6 +4,9 @@ Abstract base class for subcommands that output to a file (or stdout).
 from __future__ import absolute_import
 
 from abc import abstractmethod
+import io
+
+from bokeh.util.string import decode_utf8
 
 from ..subcommand import Subcommand
 from ..util import build_single_handler_applications
@@ -43,6 +46,17 @@ class FileOutputSubcommand(Subcommand):
 
             self.write_file(args, filename, doc)
 
-    @abstractmethod
     def write_file(self, args, filename, doc):
-        raise NotImplementedError("write_file")
+        contents = self.file_contents(args, doc)
+        with io.open(filename, "w", encoding="utf-8") as file:
+            file.write(decode_utf8(contents))
+        self.after_write_file(args, filename, doc)
+
+    # can be overridden optionally
+    def after_write_file(self, args, filename, doc):
+        pass
+
+    @abstractmethod
+    def file_contents(self, args, doc):
+        """ Subtypes must override this to return the contents of the output file for the given doc."""
+        raise NotImplementedError("file_contents")

--- a/bokeh/command/subcommands/file_output.py
+++ b/bokeh/command/subcommands/file_output.py
@@ -36,7 +36,7 @@ class FileOutputSubcommand(Subcommand):
                 metavar='FILENAME',
                 action='append',
                 type=str,
-                help="Name of the output file."
+                help="Name of the output file or - for standard output."
             )),
         )
 
@@ -69,8 +69,11 @@ class FileOutputSubcommand(Subcommand):
 
     def write_file(self, args, filename, doc):
         contents = self.file_contents(args, doc)
-        with io.open(filename, "w", encoding="utf-8") as file:
-            file.write(decode_utf8(contents))
+        if filename == '-':
+            print(decode_utf8(contents))
+        else:
+            with io.open(filename, "w", encoding="utf-8") as file:
+                file.write(decode_utf8(contents))
         self.after_write_file(args, filename, doc)
 
     # can be overridden optionally

--- a/bokeh/command/subcommands/html.py
+++ b/bokeh/command/subcommands/html.py
@@ -44,7 +44,8 @@ respectively.
 '''
 from __future__ import absolute_import
 
-from bokeh.io import output_file, save, show
+from bokeh.resources import Resources
+from bokeh.embed import standalone_html_page_for_models
 
 from ..util import build_single_handler_applications
 
@@ -73,10 +74,11 @@ class HTML(FileOutputSubcommand):
 
     )
 
-    def write_file(self, args, filename, doc):
-        output_file(filename)
-
+    def after_write_file(self, args, filename, doc):
         if args.show:
-            show(doc, new='tab')
-        else:
-            save(doc)
+            from bokeh.browserlib import view
+            view(filename)
+
+    def file_contents(self, args, doc):
+        resources = Resources(mode="cdn", root_dir=None)
+        return standalone_html_page_for_models(doc, resources=resources, title=None)

--- a/bokeh/command/subcommands/html.py
+++ b/bokeh/command/subcommands/html.py
@@ -46,26 +46,24 @@ from __future__ import absolute_import
 
 from bokeh.io import output_file, save, show
 
-from ..subcommand import Subcommand
 from ..util import build_single_handler_applications
 
-class HTML(Subcommand):
+from .file_output import FileOutputSubcommand
+
+class HTML(FileOutputSubcommand):
     ''' Subcommand to output applications as standalone HTML files.
 
     '''
 
     name = "html"
 
+    extension = "html"
+
     help = "Create standalone HTML files for one or more applications"
 
     args = (
 
-        ('files', dict(
-            metavar='DIRECTORY-OR-SCRIPT',
-            nargs='+',
-            help="The app directories or scripts to generate HTML for",
-            default=None,
-        )),
+        FileOutputSubcommand.files_arg("HTML"),
 
         (
             '--show', dict(
@@ -75,20 +73,10 @@ class HTML(Subcommand):
 
     )
 
-    def invoke(self, args):
-        applications = build_single_handler_applications(args.files)
+    def write_file(self, args, filename, doc):
+        output_file(filename)
 
-        for (route, app) in applications.items():
-            doc = app.create_document()
-
-            if route == "/":
-                filename = "index.html"
-            else:
-                filename = route[1:] + ".html"
-
-            output_file(filename)
-
-            if args.show:
-                show(doc, new='tab')
-            else:
-                save(doc)
+        if args.show:
+            show(doc, new='tab')
+        else:
+            save(doc)

--- a/bokeh/command/subcommands/html.py
+++ b/bokeh/command/subcommands/html.py
@@ -72,7 +72,7 @@ class HTML(FileOutputSubcommand):
             help="Open generated file(s) in a browser"
         )),
 
-    )
+    ) + FileOutputSubcommand.other_args()
 
     def after_write_file(self, args, filename, doc):
         if args.show:

--- a/bokeh/command/subcommands/json.py
+++ b/bokeh/command/subcommands/json.py
@@ -56,7 +56,7 @@ class JSON(FileOutputSubcommand):
             default=None
         )),
 
-    )
+    ) + FileOutputSubcommand.other_args()
 
     def file_contents(self, args, doc):
         return doc.to_json_string(indent=args.indent)

--- a/bokeh/command/subcommands/json.py
+++ b/bokeh/command/subcommands/json.py
@@ -58,7 +58,5 @@ class JSON(FileOutputSubcommand):
 
     )
 
-    def write_file(self, args, filename, doc):
-        json = doc.to_json_string(indent=args.indent)
-        with open(filename, "w") as file:
-            file.write(json)
+    def file_contents(self, args, doc):
+        return doc.to_json_string(indent=args.indent)

--- a/bokeh/command/subcommands/json.py
+++ b/bokeh/command/subcommands/json.py
@@ -1,5 +1,5 @@
 '''
-To generate a the serialized JSON represenation for a Bokeh application
+To generate the serialized JSON representation for a Bokeh application
 from a single Python script, pass the script name to ``bokeh json`` on the
 command line:
 
@@ -7,8 +7,8 @@ command line:
 
     bokeh json app_script.py
 
-The resulting JSON will be output to the console ("standard out"), and will
-have the keys of each block sorted alphabetically.
+The generated JSON will be saved in the current working directory with
+the name ``app_script.json``.
 
 Applications can also be created from directories. The directory should
 contain a ``main.py`` (and any other helper modules that are required) as
@@ -30,25 +30,24 @@ indentation level with the ``--indent`` argument:
 '''
 from __future__ import print_function
 
-from ..subcommand import Subcommand
 from ..util import build_single_handler_application
 
-class JSON(Subcommand):
+from .file_output import FileOutputSubcommand
+
+class JSON(FileOutputSubcommand):
     ''' Subcommand to output applications as serialized JSON
 
     '''
 
     name = "json"
 
-    help = "Emit serialized JSON for one application"
+    extension = "json"
+
+    help = "Create JSON files for one or more applications"
 
     args = (
 
-        ('file', dict(
-            metavar='DIRECTORY-OR-SCRIPT',
-            help="The app directory or script to generate JSON for",
-            default=None
-        )),
+        FileOutputSubcommand.files_arg("JSON"),
 
         ('--indent', dict(
             metavar='LEVEL',
@@ -59,8 +58,7 @@ class JSON(Subcommand):
 
     )
 
-    def invoke(self, args):
-        application = build_single_handler_application(args.file)
-
-        doc = application.create_document()
-        print(doc.to_json_string(indent=args.indent))
+    def write_file(self, args, filename, doc):
+        json = doc.to_json_string(indent=args.indent)
+        with open(filename, "w") as file:
+            file.write(json)

--- a/bokeh/command/subcommands/tests/__init__.py
+++ b/bokeh/command/subcommands/tests/__init__.py
@@ -1,0 +1,44 @@
+import tempfile
+import shutil
+import os
+
+class WorkingDir(object):
+    def __init__(self, pwd):
+        self._new = pwd
+        self._old = os.getcwd()
+
+    def __exit__(self, type, value, traceback):
+        os.chdir(self._old)
+
+    def __enter__(self):
+        os.chdir(self._new)
+        return self._new
+
+class TmpDir(object):
+    def __init__(self, prefix):
+        self._dir = tempfile.mkdtemp(prefix=prefix)
+
+    def __exit__(self, type, value, traceback):
+        shutil.rmtree(path=self._dir)
+
+    def __enter__(self):
+        return self._dir
+
+def with_directory_contents(contents, func):
+    with (TmpDir(prefix="bokeh-subcommand-tests")) as dirname:
+        for filename, file_content in contents.items():
+            f = open(os.path.join(dirname, filename), 'w')
+            f.write(file_content)
+            f.flush()
+        func(dirname)
+
+
+basic_scatter_script = """
+import numpy as np
+from bokeh.plotting import figure
+N = 5
+x = np.linspace(0, 4*np.pi, N)
+y = np.sin(x)
+p1 = figure()
+p1.scatter(x,y, color="#FF00FF")
+"""

--- a/bokeh/command/subcommands/tests/test_html.py
+++ b/bokeh/command/subcommands/tests/test_html.py
@@ -2,6 +2,9 @@ from __future__ import absolute_import
 
 import pytest
 import os
+import sys
+
+is_python2 = sys.version_info[0] == 2
 
 import bokeh.command.subcommands.html as schtml
 from bokeh.command.bootstrap import main
@@ -54,10 +57,14 @@ def test_no_script(capsys):
             with pytest.raises(SystemExit):
                 main(["bokeh", "html"])
         out, err = capsys.readouterr()
+        if is_python2:
+            too_few = "too few arguments"
+        else:
+            too_few = "the following arguments are required: DIRECTORY-OR-SCRIPT"
         assert err == """usage: bokeh html [-h] [--show] [-o FILENAME]
                   DIRECTORY-OR-SCRIPT [DIRECTORY-OR-SCRIPT ...]
-bokeh html: error: too few arguments
-"""
+bokeh html: error: %s
+""" % (too_few)
         assert out == ""
 
 def test_basic_script(capsys):

--- a/bokeh/command/subcommands/tests/test_html.py
+++ b/bokeh/command/subcommands/tests/test_html.py
@@ -31,6 +31,13 @@ def test_args():
             help="Open generated file(s) in a browser"
         )),
 
+        (('-o', '--output'), dict(
+            metavar='FILENAME',
+            action='append',
+            type=str,
+            help="Name of the output file or - for standard output."
+        )),
+
     )
 
 

--- a/bokeh/command/subcommands/tests/test_json.py
+++ b/bokeh/command/subcommands/tests/test_json.py
@@ -2,6 +2,9 @@ from __future__ import absolute_import
 
 import pytest
 import os
+import sys
+
+is_python2 = sys.version_info[0] == 2
 
 import bokeh.command.subcommands.json as scjson
 from bokeh.command.bootstrap import main
@@ -54,10 +57,14 @@ def test_no_script(capsys):
             with pytest.raises(SystemExit):
                 main(["bokeh", "json"])
         out, err = capsys.readouterr()
+        if is_python2:
+            too_few = "too few arguments"
+        else:
+            too_few = "the following arguments are required: DIRECTORY-OR-SCRIPT"
         assert err == """usage: bokeh json [-h] [--indent LEVEL] [-o FILENAME]
                   DIRECTORY-OR-SCRIPT [DIRECTORY-OR-SCRIPT ...]
-bokeh json: error: too few arguments
-"""
+bokeh json: error: %s
+""" % (too_few)
         assert out == ""
 
 def test_basic_script(capsys):

--- a/bokeh/command/subcommands/tests/test_json.py
+++ b/bokeh/command/subcommands/tests/test_json.py
@@ -13,7 +13,7 @@ def test_name():
     assert scjson.JSON.name == "json"
 
 def test_help():
-    assert scjson.JSON.help == "Emit serialized JSON for one application"
+    assert scjson.JSON.help == "Create JSON files for one or more applications"
 
 def test_args():
     assert scjson.JSON.args == (
@@ -32,6 +32,12 @@ def test_args():
             default=None
         )),
 
+        (('-o', '--output'), dict(
+                metavar='FILENAME',
+                action='append',
+                type=str,
+                help="Name of the output file or - for standard output."
+        )),
     )
 
 

--- a/bokeh/command/subcommands/tests/test_json.py
+++ b/bokeh/command/subcommands/tests/test_json.py
@@ -18,9 +18,10 @@ def test_help():
 def test_args():
     assert scjson.JSON.args == (
 
-        ('file', dict(
+        ('files', dict(
             metavar='DIRECTORY-OR-SCRIPT',
-            help="The app directory or script to generate JSON for",
+            nargs='+',
+            help="The app directories or scripts to generate JSON for",
             default=None
         )),
 

--- a/bokeh/command/subcommands/tests/test_json.py
+++ b/bokeh/command/subcommands/tests/test_json.py
@@ -1,6 +1,14 @@
 from __future__ import absolute_import
 
+import pytest
+import os
+
 import bokeh.command.subcommands.json as scjson
+from bokeh.command.bootstrap import main
+
+from . import (
+    TmpDir, WorkingDir, with_directory_contents, basic_scatter_script
+)
 
 def test_create():
     import argparse
@@ -40,6 +48,53 @@ def test_args():
         )),
     )
 
+def test_no_script(capsys):
+    with (TmpDir(prefix="bokeh-json-no-script")) as dirname:
+        with WorkingDir(dirname):
+            with pytest.raises(SystemExit):
+                main(["bokeh", "json"])
+        out, err = capsys.readouterr()
+        assert err == """usage: bokeh json [-h] [--indent LEVEL] [-o FILENAME]
+                  DIRECTORY-OR-SCRIPT [DIRECTORY-OR-SCRIPT ...]
+bokeh json: error: too few arguments
+"""
+        assert out == ""
 
+def test_basic_script(capsys):
+    def run(dirname):
+        with WorkingDir(dirname):
+            main(["bokeh", "json", "scatter.py"])
+        out, err = capsys.readouterr()
+        assert err == ""
+        assert out == ""
 
+        assert set(["scatter.json", "scatter.py"]) == set(os.listdir(dirname))
 
+    with_directory_contents({ 'scatter.py' : basic_scatter_script },
+                            run)
+
+def test_basic_script_with_output_after(capsys):
+    def run(dirname):
+        with WorkingDir(dirname):
+            main(["bokeh", "json", "scatter.py", "--output", "foo.json"])
+        out, err = capsys.readouterr()
+        assert err == ""
+        assert out == ""
+
+        assert set(["foo.json", "scatter.py"]) == set(os.listdir(dirname))
+
+    with_directory_contents({ 'scatter.py' : basic_scatter_script },
+                            run)
+
+def test_basic_script_with_output_before(capsys):
+    def run(dirname):
+        with WorkingDir(dirname):
+            main(["bokeh", "json", "--output", "foo.json", "scatter.py"])
+        out, err = capsys.readouterr()
+        assert err == ""
+        assert out == ""
+
+        assert set(["foo.json", "scatter.py"]) == set(os.listdir(dirname))
+
+    with_directory_contents({ 'scatter.py' : basic_scatter_script },
+                            run)

--- a/bokeh/command/subcommands/tests/test_subcommands_package.py
+++ b/bokeh/command/subcommands/tests/test_subcommands_package.py
@@ -18,5 +18,5 @@ def test_all_count():
     files = listdir(dirname(sc.__file__))
     pyfiles = [x for x in files if x.endswith(".py")]
 
-    # the -1 accounts for __init__.py
-    assert len(sc.all) == len(pyfiles) - 1
+    # the -2 accounts for __init__.py and file_output.py
+    assert len(sc.all) == len(pyfiles) - 2

--- a/bokeh/command/tests/test_bootstrap.py
+++ b/bokeh/command/tests/test_bootstrap.py
@@ -1,7 +1,11 @@
 import pytest
 
+import sys
+
 from bokeh.command.bootstrap import main
 from bokeh import __version__
+
+is_python2 = sys.version_info[0] == 2
 
 def test_no_subcommand(capsys):
     with pytest.raises(SystemExit):
@@ -10,16 +14,23 @@ def test_no_subcommand(capsys):
     assert err == "ERROR: Must specify subcommand, one of: html, json or serve\n"
     assert out == ""
 
+def _assert_version_output(capsys):
+    out, err = capsys.readouterr()
+    if is_python2:
+        err_expected = ("%s\n" % __version__)
+        out_expected = ""
+    else:
+        err_expected = ""
+        out_expected = ("%s\n" % __version__)
+    assert err == err_expected
+    assert out == out_expected
+
 def test_version(capsys):
     with pytest.raises(SystemExit):
         main(["bokeh", "--version"])
-    out, err = capsys.readouterr()
-    assert err == ("%s\n" % __version__)
-    assert out == ""
+    _assert_version_output(capsys)
 
 def test_version_short(capsys):
     with pytest.raises(SystemExit):
         main(["bokeh", "-v"])
-    out, err = capsys.readouterr()
-    assert err == ("%s\n" % __version__)
-    assert out == ""
+    _assert_version_output(capsys)

--- a/bokeh/command/tests/test_bootstrap.py
+++ b/bokeh/command/tests/test_bootstrap.py
@@ -1,0 +1,10 @@
+import pytest
+
+from bokeh.command.bootstrap import main
+
+def test_no_subcommand(capsys):
+    with pytest.raises(SystemExit):
+        main(["bokeh"])
+    out, err = capsys.readouterr()
+    assert err == "ERROR: Must specify subcommand, one of: html, json or serve\n"
+    assert out == ""

--- a/bokeh/command/tests/test_bootstrap.py
+++ b/bokeh/command/tests/test_bootstrap.py
@@ -1,10 +1,25 @@
 import pytest
 
 from bokeh.command.bootstrap import main
+from bokeh import __version__
 
 def test_no_subcommand(capsys):
     with pytest.raises(SystemExit):
         main(["bokeh"])
     out, err = capsys.readouterr()
     assert err == "ERROR: Must specify subcommand, one of: html, json or serve\n"
+    assert out == ""
+
+def test_version(capsys):
+    with pytest.raises(SystemExit):
+        main(["bokeh", "--version"])
+    out, err = capsys.readouterr()
+    assert err == ("%s\n" % __version__)
+    assert out == ""
+
+def test_version_short(capsys):
+    with pytest.raises(SystemExit):
+        main(["bokeh", "-v"])
+    out, err = capsys.readouterr()
+    assert err == ("%s\n" % __version__)
     assert out == ""


### PR DESCRIPTION
The main point here is to keep these consistent from the perspective of someone using the bokeh command.
But also we're sharing implementation so that adding any new file output formats should be straightforward.
(To support a binary output format like png, some minor tweaks to the `FileOutputSubcommand` base class will be needed, since it assumes text output right now.)
