### PR TITLE
Add ?v=CONTENTHASH to static paths served by the server

### DIFF
--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -99,11 +99,14 @@ def _get_cdn_urls(components, version=None, minified=True):
     return result
 
 
-def _get_server_urls(components, root_url, minified=True):
+def _get_server_urls(components, root_url, minified=True, path_versioner=None):
     _min = ".min" if minified else ""
 
     def mk_url(comp, kind):
-        return '%sstatic/%s/%s%s.%s' % (root_url, kind, comp, _min, kind)
+        path = "%s/%s%s.%s" % (kind, comp, _min, kind)
+        if path_versioner is not None:
+            path = path_versioner(path)
+        return '%sstatic/%s' % (root_url, path)
 
     return {
         'urls'     : lambda kind: [ mk_url(component, kind)  for component in components ],
@@ -118,7 +121,8 @@ class BaseResources(object):
     logo_url = "http://bokeh.pydata.org/static/bokeh-transparent.png"
 
     def __init__(self, mode='inline', version=None, root_dir=None,
-                 minified=True, log_level="info", root_url=None):
+                 minified=True, log_level="info", root_url=None,
+                 path_versioner=None):
         self.components = ["bokeh", "bokeh-widgets"]
 
         self.mode = settings.resources(mode)
@@ -126,6 +130,7 @@ class BaseResources(object):
         self.version = settings.version(version)
         self.minified = settings.minified(minified)
         self.log_level = settings.log_level(log_level)
+        self.path_versioner = path_versioner
 
         if root_url and not root_url.endswith("/"):
             logger.warning("root_url should end with a /, adding one")
@@ -188,7 +193,7 @@ class BaseResources(object):
         return _get_cdn_urls(self.components, self.version, self.minified)
 
     def _server_urls(self):
-        return _get_server_urls(self.components, self.root_url, self.minified)
+        return _get_server_urls(self.components, self.root_url, self.minified, self.path_versioner)
 
     def _resolve(self, kind):
         paths = self._file_paths(kind)

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -23,6 +23,7 @@ from .settings import settings
 from .urls import per_app_patterns, toplevel_patterns
 from .connection import ServerConnection
 from .application_context import ApplicationContext
+from .views.static_handler import StaticHandler
 
 def _whitelist(handler_class):
     if hasattr(handler_class.prepare, 'patched'):
@@ -143,7 +144,9 @@ class BokehTornado(TornadoApplication):
     def resources(self, request):
         root_url = self.root_url_for_request(request)
         if root_url not in self._resources:
-            self._resources[root_url] = Resources(mode="server", root_url=root_url)
+            self._resources[root_url] =  Resources(mode="server",
+                                                   root_url=root_url,
+                                                   path_versioner=StaticHandler.append_version)
         return self._resources[root_url]
 
     def start(self):

--- a/bokeh/server/views/static_handler.py
+++ b/bokeh/server/views/static_handler.py
@@ -19,3 +19,18 @@ class StaticHandler(StaticFileHandler):
 
         # Note: tornado_app is stored as self.application
         super(StaticHandler, self).__init__(tornado_app, *args, **kw)
+
+    # We aren't using tornado's built-in static_path function
+    # because it relies on TornadoApplication's autoconfigured
+    # static handler instead of our custom one. We have a
+    # custom one because we think we might want to serve
+    # static files from multiple paths at once in the future.
+    @classmethod
+    def append_version(cls, path):
+        # this version is cached on the StaticFileHandler class,
+        # keyed by absolute filesystem path, and only invalidated
+        # on an explicit StaticFileHandler.reset(). The reset is
+        # automatic on every request if you set
+        # static_hash_cache=False in TornadoApplication kwargs.
+        version = StaticFileHandler.get_version(dict(static_path=settings.bokehjsdir()), path)
+        return ("%s?v=%s" % (path, version))

--- a/bokeh/tests/test_resources.py
+++ b/bokeh/tests/test_resources.py
@@ -142,6 +142,18 @@ class TestResources(unittest.TestCase):
         self.assertEqual(r.css_raw, [])
         self.assertEqual(r.messages, [])
 
+    def test_server_with_versioner(self):
+        def versioner(path):
+            return path + "?v=VERSIONED"
+
+        r = resources.Resources(mode="server", root_url="http://foo/",
+                                path_versioner=versioner)
+
+        self.assertEqual(r.js_files, ['http://foo/static/js/bokeh.min.js?v=VERSIONED',
+                                      'http://foo/static/js/bokeh-widgets.min.js?v=VERSIONED'])
+        self.assertEqual(r.css_files, ['http://foo/static/css/bokeh.min.css?v=VERSIONED',
+                                       'http://foo/static/css/bokeh-widgets.min.css?v=VERSIONED'])
+
     def test_server_dev(self):
         r = resources.Resources(mode="server-dev")
         self.assertEqual(r.mode, "server")


### PR DESCRIPTION
This allows an nginx configuration to set aggressive caching
headers, as described at http://www.tornadoweb.org/en/stable/guide/running.html

This isn't especially important in the short term but I was reading the docs and saw it and it was easier to just do it than file an issue.

The point of this is to avoid using up server CPU serving static assets.
