### PR TITLE
Register modules from plugins in the main bokeh bundle

### DIFF
--- a/bokehjs/gulp/tasks/scripts.coffee
+++ b/bokehjs/gulp/tasks/scripts.coffee
@@ -167,7 +167,7 @@ gulp.task "scripts:build", (cb) ->
       .pipe change (content) ->
         "(function() { var define = undefined; return #{content} })()"
       .pipe change (content) ->
-        "bokehRequire = #{content}"
+        "Bokeh = #{content}"
       .pipe(insert.append(license))
       .pipe(sourcemaps.write('./'))
       .pipe(gulp.dest(paths.buildDir.js))

--- a/bokehjs/src/coffee/common/base.coffee
+++ b/bokehjs/src/coffee/common/base.coffee
@@ -209,6 +209,13 @@ browserify = {
   cache: arguments[5]
 }
 
+register_modules = (modules) ->
+  for own name, module of modules
+    if not browserify.modules[name]
+      browserify.modules[name] = module
+    else
+      throw new Error("Module `#{name}' already exists. Can't reassign.")
+
 Collections.register_plugin = (plugin, locations) ->
   logger.info("Registering plugin: #{plugin}")
   Collections.register_locations locations, errorFn = (name) ->
@@ -245,7 +252,6 @@ Collections.register_models = (specs) ->
   for own name, impl of specs
     Collections.register_model(name, impl)
 
-
 Collections.registered_names = () ->
   Object.keys(_get_mod_cache())
 
@@ -257,6 +263,7 @@ index = {}
 
 module.exports =
   collection_overrides: collection_overrides # for testing only
+  register_modules: register_modules
   locations: locations #
   index: index
   Collections: Collections

--- a/bokehjs/src/coffee/main.coffee
+++ b/bokehjs/src/coffee/main.coffee
@@ -24,6 +24,8 @@ Bokeh.index             = require("./common/base").index
 # common
 Bokeh.Collections       = require("./common/base").Collections
 Bokeh.Config            = require("./common/base").Config
+Bokeh.register_modules  = require("./common/base").register_modules
+
 Bokeh.Document          = require("./common/document").Document
 Bokeh.CartesianFrame    = require("./common/cartesian_frame")
 Bokeh.Canvas            = require("./common/canvas")
@@ -122,5 +124,4 @@ require("./api/plugin")
 
 # Here for backwards capability?
 Bokeh.Bokeh = Bokeh
-window.Bokeh = Bokeh
 module.exports = Bokeh

--- a/bokehjs/src/js/plugin-prelude.js
+++ b/bokehjs/src/js/plugin-prelude.js
@@ -1,39 +1,11 @@
 (function outer(modules, cache, entry) {
-    // Save the require from previous bundle to this closure if any
-    var previousRequire = typeof bokehRequire == "function" && bokehRequire;
-
-    function newRequire(name, jumped) {
-        if (!cache[name]) {
-            if (!modules[name]) {
-                // if we cannot find the the module within our internal map or
-                // cache jump to the current global require ie. the last bundle
-                // that was added to the page.
-                var currentRequire = typeof bokehRequire == "function" && bokehRequire;
-                if (!jumped && currentRequire) return currentRequire(name, true);
-
-                // If there are other bundles on this page the require from the
-                // previous one is saved to 'previousRequire'. Repeat this as
-                // many times as there are bundles until the module is found or
-                // we exhaust the require chain.
-                if (previousRequire) return previousRequire(name, true);
-                var err = new Error('Cannot find module \'' + name + '\'');
-                err.code = 'MODULE_NOT_FOUND';
-                throw err;
-            }
-
-            var m = cache[name] = {exports: {}};
-            modules[name][0].call(m.exports, function(x) {
-                var id = modules[name][1][x];
-                return newRequire(id ? id : x);
-            }, m, m.exports, outer, modules, cache, entry);
-        }
-
-        return cache[name].exports;
-    }
+  if (Bokeh) {
+    Bokeh.register_modules(modules);
 
     for (var i = 0; i < entry.length; i++) {
-        newRequire(entry[i]);
+        Bokeh.require(entry[i]);
     }
-
-    return newRequire;
+  } else {
+    throw new Error("Cannot find Bokeh. You have to load it prior to loading plugins.");
+  }
 })

--- a/bokehjs/src/js/prelude.js
+++ b/bokehjs/src/js/prelude.js
@@ -17,9 +17,11 @@
         return cache[name].exports;
     }
 
+    var lastEntryResult = null;
+
     for (var i = 0; i < entry.length; i++) {
-        newRequire(entry[i]);
+        lastEntryResult = newRequire(entry[i]);
     }
 
-    return newRequire;
+    return lastEntryResult;
 })

--- a/examples/glyphs/custom.py
+++ b/examples/glyphs/custom.py
@@ -7,6 +7,7 @@ from bokeh.properties import String
 from bokeh.models.callbacks import Callback
 from bokeh.models.glyphs import Circle
 from bokeh.models import Plot, DataRange1d, LinearAxis, ColumnDataSource, PanTool, WheelZoomTool, TapTool
+from bokeh.models.widgets import HBox
 from bokeh.resources import INLINE
 
 class Popup(Callback):
@@ -39,6 +40,29 @@ module.exports =
     which will be formatted with data from the data source.
     """)
 
+class MyHBox(HBox):
+
+    __implementation__ = """
+_ = require "underscore"
+build_views = require "common/build_views"
+ContinuumView = require "common/continuum_view"
+HBox = require "widget/hbox"
+
+class MyHBoxView extends HBox.View
+  render: () ->
+    super()
+    @$el.css({border: "5px solid black"})
+
+class MyHBox extends HBox.Model
+  type: "MyHBox"
+  default_view: MyHBoxView
+
+module.exports = {
+  Model: MyHBox
+  View: MyHBoxView
+}
+"""
+
 source = ColumnDataSource(
     data = dict(
         x = [1, 2, 3, 4, 4,   5, 5],
@@ -62,7 +86,7 @@ tap = TapTool(renderers=[circle_renderer], callback=Popup(message="Selected colo
 plot.add_tools(PanTool(), WheelZoomTool(), tap)
 
 doc = Document()
-doc.add_root(plot)
+doc.add_root(MyHBox(children=[plot]))
 
 if __name__ == "__main__":
     filename = "custom.html"


### PR DESCRIPTION
This allows bokeh to know about plugins' modules, to allow custom models to require such modules. Previously this resulted in module not found exception. The new approach is to register plugins' modules in the main bundle (so there is one set of modules, instead of 1 + n), resulting in one `require()` being used by all involved parties (main bundle, plugins and custom models).

fixes #3339