### PR TITLE
Cleanup embed examples

### DIFF
--- a/examples/embed/README.md
+++ b/examples/embed/README.md
@@ -1,61 +1,90 @@
-### Embed multiple
 
-To run the example:
 
-    python embed_multiple.py
+## animated.py
 
----
+To view this example, first start a Bokeh server:
 
-### Widget, animated
+    bokeh serve
 
-To try these example you first have to start the bokeh-server, ie.,
-
-    bokeh-server
-
-Then run the examples:
-
-    python widget.py
-
-or
+And then load the example into the Bokeh server by
+running the script:
 
     python animated.py
 
+in this directory. Finally, start a simple web server
+by running:
 
-To view them, start a web server in this directory, for instance, the server
-built into python:
+    python -m SimpleHTTPServer  (python 2)
 
-If you are using python 2, run:
+or
 
-    python -m SimpleHTTPServer
+    python -m http.server  (python 3)
 
-or if you are using python 3, run:
+in this directory. Navigate to
 
-    python -m http.server
+    http://localhost:8000/animated.html
 
-and use the links provided when you run the scripts.
+## embed_multiple.py
 
----
+Execute the script:
 
-### Bokeh plots in an online slideshow
+    python embed_multiple.py
 
-    cd slideshow
-    python app_reveal.py
+## embed_multiple_responsive.py
 
-and then navigate to:
+Execute the script:
 
-    http://127.0.0.1:5000/
+    python embed_multiple_responsive.py
 
----
+## embed_responsive_width_height.py
 
-### Spectrogram
+Execute the script:
 
-The spectrogram example requires the pyaudio library, which is available
-via conda on py27. Or see the documentation here: https://people.csail.mit.edu/hubert/pyaudio/
+    python embed_responsive_width_height.py
 
-    conda install -c mutirri pyaudio
+## simple
 
-To run the spectrogram example:
+See instructions in simple/README.md
 
-    python spectogram.py
+## slideshow
 
-Then open your webbrowser at: http://localhost:5000
+See instructions in slideshow/README.md
+
+## spectrogram
+
+See instructions in spectrogram/README.md
+
+## widget.py
+
+To view this example, first start a Bokeh server:
+
+    bokeh serve
+
+And then load the example into the Bokeh server by
+running the script:
+
+    python widget.py
+
+in this directory. Finally, start a simple web server
+by running:
+
+    python -m SimpleHTTPServer  (python 2)
+
+or
+
+    python -m http.server  (python 3)
+
+in this directory. Navigate to
+
+    http://localhost:8000/widget.html
+
+
+
+
+
+
+
+
+
+
+

--- a/examples/embed/animated.py
+++ b/examples/embed/animated.py
@@ -1,38 +1,43 @@
-# The bokeh-server must be running to see this example
+""" To view this example, run
 
+    python -m SimpleHTTPServer  (python 2)
+
+or
+
+    python -m http.server  (python 3)
+
+in this directory, then navigate to
+
+    http://localhost:8000/animated_embed.html
+
+"""
 from __future__ import print_function
 
-from bokeh.plotting import figure, output_server, show, curdoc
-from bokeh.models import GlyphRenderer
-import bokeh.embed as embed
-from bokeh.client import push_session
-
-import time
 from numpy import pi, cos, sin, linspace, roll
 
-N = 50 + 1
+from bokeh.client import push_session
+from bokeh.embed import autoload_server
+from bokeh.plotting import figure, curdoc
+
+M = 5
+N = M*10 + 1
 r_base = 8
-theta = linspace(0, 2 * pi, N)
-r_x = linspace(0, 6 * pi, N - 1)
+theta = linspace(0, 2*pi, N)
+r_x = linspace(0, 6*pi, N-1)
 rmin = r_base - cos(r_x) - 1
 rmax = r_base + sin(r_x) + 1
 
 colors = ["FFFFCC", "#C7E9B4", "#7FCDBB", "#41B6C4", "#2C7FB8",
           "#253494", "#2C7FB8", "#41B6C4", "#7FCDBB", "#C7E9B4"] * 5
 
-# Open a session which will keep our local doc in sync with server
+# figure() function auto-adds the figure to curdoc()
+p = figure(x_range=(-11, 11), y_range=(-11, 11))
+r = p.annular_wedge(0, 0, rmin, rmax, theta[:-1], theta[1:],
+                    fill_color=colors, line_color="white")
+
+# open a session which will keep our local doc in sync with server
 session = push_session(curdoc())
 
-p = figure(x_range=[-11, 11], y_range=[-11, 11])
-p.annular_wedge(
-    0, 0, rmin, rmax, theta[:-1], theta[1:],
-    inner_radius_units="data",
-    outer_radius_units="data",
-    fill_color = colors,
-    line_color="black",
-)
-
-tag = embed.autoload_server(p)
 html = """
 <html>
   <head></head>
@@ -40,32 +45,20 @@ html = """
     %s
   </body>
 </html>
-"""
-html = html % (tag)
+""" % autoload_server(p)
+
 with open("animated_embed.html", "w+") as f:
     f.write(html)
 
-print("""
-To view this example, run
+print(__doc__)
 
-    python -m SimpleHTTPServer (or http.server on python 3)
+ds = r.data_source
 
-in this directory, then navigate to
+def update():
+    rmin = roll(ds.data["inner_radius"], 1)
+    rmax = roll(ds.data["outer_radius"], -1)
+    ds.data.update(inner_radius=rmin, outer_radius=rmax)
 
-    http://localhost:8000/animated_embed.html
-""")
+curdoc().add_periodic_callback(update, 30)
 
-renderer = p.select(dict(type=GlyphRenderer))
-ds = renderer[0].data_source
-
-while True:
-
-    rmin = ds.data["inner_radius"]
-    rmin = roll(rmin, 1)
-    ds.data["inner_radius"] = rmin
-
-    rmax = ds.data["outer_radius"]
-    rmax = roll(rmax, -1)
-    ds.data["outer_radius"] = rmax
-
-    time.sleep(0.1)
+session.loop_until_closed() # run forever

--- a/examples/embed/animated.py
+++ b/examples/embed/animated.py
@@ -1,4 +1,14 @@
-""" To view this example, run
+""" To view this example, first start a Bokeh server:
+
+    bokeh serve
+
+And then load the example into the Bokeh server by
+running the script:
+
+    python animated.py
+
+in this directory. Finally, start a simple web server
+by running:
 
     python -m SimpleHTTPServer  (python 2)
 
@@ -6,9 +16,9 @@ or
 
     python -m http.server  (python 3)
 
-in this directory, then navigate to
+in this directory. Navigate to
 
-    http://localhost:8000/animated_embed.html
+    http://localhost:8000/animated.html
 
 """
 from __future__ import print_function
@@ -47,7 +57,7 @@ html = """
 </html>
 """ % autoload_server(p)
 
-with open("animated_embed.html", "w+") as f:
+with open("animated.html", "w+") as f:
     f.write(html)
 
 print(__doc__)

--- a/examples/embed/embed_multiple.py
+++ b/examples/embed/embed_multiple.py
@@ -1,11 +1,11 @@
-from bokeh.plotting import figure
-from bokeh.models import Range1d
-from bokeh.embed import components
-from bokeh.resources import INLINE
+
 from jinja2 import Template
-import webbrowser
-import os
-import six
+
+from bokeh.embed import components
+from bokeh.models import Range1d
+from bokeh.plotting import figure
+from bokeh.resources import INLINE
+from bokeh.browserlib import view
 
 # create some data
 x1 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
@@ -62,15 +62,14 @@ template = Template('''<!DOCTYPE html>
 js_resources = INLINE.render_js()
 css_resources = INLINE.render_css()
 
-html_file = 'embed_multiple.html'
+filename = 'embed_multiple.html'
 
 html = template.render(js_resources=js_resources,
                        css_resources=css_resources,
                        script=script,
                        div=div)
 
-with open(html_file, 'w') as textfile:
-    textfile.write(html)
+with open(filename, 'w') as f:
+    f.write(html)
 
-url = 'file:{}'.format(six.moves.urllib.request.pathname2url(os.path.abspath(html_file)))
-webbrowser.open(url)
+view(filename)

--- a/examples/embed/embed_multiple_responsive.py
+++ b/examples/embed/embed_multiple_responsive.py
@@ -1,20 +1,26 @@
-from bokeh.browserlib import view
-from bokeh.plotting import figure
-from bokeh.embed import components
-from bokeh.resources import INLINE
+
+import random
 
 from jinja2 import Template
-import random
+
+from bokeh.browserlib import view
+from bokeh.embed import components
+from bokeh.plotting import figure
+from bokeh.resources import INLINE
 
 ########## BUILD FIGURES ################
 
 PLOT_OPTIONS = dict(plot_width=800, plot_height=300)
 SCATTER_OPTIONS = dict(size=12, alpha=0.5)
+
 data = lambda: [random.choice([i for i in range(100)]) for r in range(10)]
+
 red = figure(responsive=True, tools='pan', **PLOT_OPTIONS)
 red.scatter(data(), data(), color="red", **SCATTER_OPTIONS)
+
 blue = figure(responsive=False, tools='pan', **PLOT_OPTIONS)
 blue.scatter(data(), data(), color="blue", **SCATTER_OPTIONS)
+
 green = figure(responsive=True, tools='pan,resize', **PLOT_OPTIONS)
 green.scatter(data(), data(), color="green", **SCATTER_OPTIONS)
 
@@ -55,9 +61,9 @@ html = template.render(js_resources=js_resources,
                        plot_script=script,
                        plot_div=div)
 
-html_file = 'embed_multiple_responsive.html'
+filename = 'embed_multiple_responsive.html'
 
-with open(html_file, 'w') as f:
+with open(filename, 'w') as f:
     f.write(html)
 
-view(html_file)
+view(filename)

--- a/examples/embed/embed_responsive_width_height.py
+++ b/examples/embed/embed_responsive_width_height.py
@@ -1,27 +1,30 @@
-"""
-This example shows how a Bokeh plot can be embedded in an HTML document,
-in a way that the plot resizes to make use of the available width and
-height (while keeping the aspect ratio fixed).
+""" This example shows how a Bokeh plot can be embedded in an HTML
+document, in a way that the plot resizes to make use of the available
+width and height (while keeping the aspect ratio fixed).
 
 To make this work well, the plot should be placed in a container that
 *has* a certain width and height (i.e. non-scrollable), which is the
 body element in this case. A more realistic example might be embedding
 a plot in a Phosphor widget.
+
 """
 
-from bokeh.browserlib import view
-from bokeh.plotting import figure
-from bokeh.embed import components
-from bokeh.resources import INLINE
+import random
 
 from jinja2 import Template
-import random
+
+from bokeh.browserlib import view
+from bokeh.embed import components
+from bokeh.plotting import figure
+from bokeh.resources import INLINE
 
 ########## BUILD FIGURES ################
 
 PLOT_OPTIONS = dict(plot_width=600, plot_height=400)
 SCATTER_OPTIONS = dict(size=12, alpha=0.5)
+
 data = lambda: [random.choice([i for i in range(100)]) for r in range(10)]
+
 red = figure(responsive=False, tools='pan', **PLOT_OPTIONS)
 red.scatter(data(), data(), color="red", **SCATTER_OPTIONS)
 
@@ -74,9 +77,9 @@ html = template.render(js_resources=js_resources,
                        plot_script=script,
                        plot_div=div)
 
-html_file = 'embed_responsive_width_height.html'
+filename = 'embed_responsive_width_height.html'
 
-with open(html_file, 'w') as f:
+with open(filename, 'w') as f:
     f.write(html)
 
-view(html_file)
+view(filename)

--- a/examples/embed/simple/README.md
+++ b/examples/embed/simple/README.md
@@ -1,9 +1,11 @@
 
-# Polynomial Graph Example
+This example demonstrates embedding a standalone Bokeh document
+into a simple Flask application, with a basic HTML web form.
 
-This demonstrates the ability of bokeh to easily embed into a webpage.
+To view the example, run:
 
-This example uses the excellent python library Flask to handle creating the web page and
-handling the data to populate the graph.
+    python simple.py
 
-With this example, you should be able to embed bokeh into pretty much any webpage!
+in this directory, and navigate to:
+
+    http://localhost:5000

--- a/examples/embed/simple/simple.py
+++ b/examples/embed/simple/simple.py
@@ -1,16 +1,17 @@
+'''This example demonstrates embedding a standalone Bokeh document
+into a simple Flask application, with a basic HTML web form.
+
+To view the example, run:
+
+    python simple.py
+
+in this directory, and navigate to:
+
+    http://localhost:5000
+
 '''
-This script is loosely based on the bokeh spectogram example,
-but is much simpler:
+from __future__ import print_function
 
-    https://github.com/bokeh/bokeh/tree/master/examples/embed/spectrogram
-
-This creates a simple form for generating polynomials of the form y = x^2.
-
-This is done using a form that has a method of GET, allowing you to share the
-graphs you create with your friends though the link!
-
-You should know at least the basics of Flask to understand this example
-'''
 import flask
 
 from bokeh.embed import components
@@ -27,17 +28,18 @@ colors = {
     'Blue':  '#0000FF',
 }
 
-
 def getitem(obj, item, default):
     if item not in obj:
         return default
     else:
         return obj[item]
 
-
 @app.route("/")
 def polynomial():
-    """ Very simple embedding of a polynomial chart"""
+    """ Very simple embedding of a polynomial chart
+
+    """
+
     # Grab the inputs arguments from the URL
     # This is automated by the button
     args = flask.request.args
@@ -73,10 +75,6 @@ def polynomial():
     )
     return encode_utf8(html)
 
-
-def main():
-    app.debug = True
-    app.run()
-
 if __name__ == "__main__":
-    main()
+    print(__doc__)
+    app.run()

--- a/examples/embed/slideshow/slideshow.py
+++ b/examples/embed/slideshow/slideshow.py
@@ -8,50 +8,40 @@ We are using this "building blocks" approach here because we believe it has some
 conceptual advantages for people trying to quickly understand, and more
 importantly, use the embed API, in a more complex way than just a simple script.
 """
-import time
-from threading import Thread
-
-import numpy as np
-import scipy.special
-
-from bokeh.embed import autoload_server
-from bokeh.models import GlyphRenderer
-from bokeh.plotting import figure, output_server, push, curdoc
-from bokeh.client import push_session
+from __future__ import print_function
 
 from flask import Flask, render_template
+import numpy as np
+from numpy import roll, pi, cos, sin, linspace
+import scipy.special
+
+from bokeh.client import push_session
+from bokeh.embed import autoload_server
+from bokeh.models import GlyphRenderer, Select, HBox, VBox, ColumnDataSource
+from bokeh.plotting import figure, push, curdoc
+from bokeh.sampledata.population import load_population
+
 app = Flask(__name__)
 
 session = push_session(curdoc())
 
 @app.route('/')
 def render_plot():
-    """
-    Get the script tags from each plot object and "insert" them into the template.
+    dist_plot = distribution()
 
-    This also starts different threads for each update function, so you can have
-    a non-blocking update.
-    """
-    dist_plot, dist_session = distribution()
-    dist_tag = autoload_server(dist_plot)
+    anim_plot = animated()
+    curdoc().add_periodic_callback(update_animated, 50)
 
-    anim_plot, anim_session = animated()
-    anim_tag = autoload_server(anim_plot)
-    # for update_animation as target we need to pass the anim_plot and anim_session as args
-    thread = Thread(target=update_animation, args=(anim_plot, anim_session))
-    thread.start()
+    pop = Population(curdoc())
 
-    pop = Population()
-    pop_tag = autoload_server(pop.layout)
-    # for update_population as target we need to pass the pop instance as args
-    thread = Thread(target=update_population, args=(pop,))
-    thread.start()
-
-    return render_template('app_plot.html', tag1=dist_tag, tag2=anim_tag, tag3=pop_tag)
-
+    return render_template(
+        'app_plot.html',
+        tag1=autoload_server(dist_plot),
+        tag2=autoload_server(anim_plot),
+        tag3=autoload_server(pop.layout)
+    )
 
 def distribution():
-
     mu, sigma = 0, 0.5
 
     measured = np.random.normal(mu, sigma, 1000)
@@ -61,10 +51,8 @@ def distribution():
     pdf = 1 / (sigma * np.sqrt(2 * np.pi)) * np.exp(-(x - mu) ** 2 / (2 * sigma ** 2))
     cdf = (1 + scipy.special.erf((x - mu) / np.sqrt(2 * sigma ** 2))) / 2
 
-    output_server("distribution_reveal")
+    p = figure(title="Interactive plots", background_fill_color="#E5E5E5")
 
-    p = figure(title="Interactive plots",
-               background_fill_color="#E5E5E5")
     p.quad(top=hist, bottom=0, left=edges[:-1], right=edges[1:],
            fill_color="#333333", line_color="#E5E5E5", line_width=3)
 
@@ -82,74 +70,42 @@ def distribution():
     p.ygrid[0].grid_line_color = "white"
     p.ygrid[0].grid_line_width = 3
 
-    return p, session
-
+    return p
 
 def animated():
-
-    from numpy import pi, cos, sin, linspace
-
-    N = 50 + 1
+    M = 5
+    N = M*10 + 1
     r_base = 8
-    theta = linspace(0, 2 * pi, N)
-    r_x = linspace(0, 6 * pi, N - 1)
+    theta = linspace(0, 2*pi, N)
+    r_x = linspace(0, 6*pi, N-1)
     rmin = r_base - cos(r_x) - 1
     rmax = r_base + sin(r_x) + 1
 
     colors = ["FFFFCC", "#C7E9B4", "#7FCDBB", "#41B6C4", "#2C7FB8",
               "#253494", "#2C7FB8", "#41B6C4", "#7FCDBB", "#C7E9B4"] * 5
 
-    output_server("animated_reveal")
-
     p = figure(title="Animations", x_range=[-11, 11], y_range=[-11, 11])
 
-    p.annular_wedge(
-        0, 0, rmin, rmax, theta[:-1], theta[1:],
-        inner_radius_units="data",
-        outer_radius_units="data",
-        fill_color=colors,
-        line_color="black",
-    )
+    # figure() function auto-adds the figure to curdoc()
+    p = figure(x_range=(-11, 11), y_range=(-11, 11))
+    r = p.annular_wedge(0, 0, rmin, rmax, theta[:-1], theta[1:],
+                        fill_color=colors, line_color="white")
 
-    return p, session
+    return p
 
-
-def update_animation(plot, session):
-
-    from numpy import roll
-
-    renderer = plot.select(dict(type=GlyphRenderer))
-    ds = renderer[0].data_source
-
-    while True:
-
-        rmin = ds.data["inner_radius"]
-        rmin = roll(rmin, 1)
-        ds.data["inner_radius"] = rmin
-
-        rmax = ds.data["outer_radius"]
-        rmax = roll(rmax, -1)
-        ds.data["outer_radius"] = rmax
-
-        time.sleep(0.1)
-
+def update_animated(plot):
+    ds = r.data_source
+    rmin = roll(ds.data["inner_radius"], 1)
+    rmax = roll(ds.data["outer_radius"], -1)
+    ds.data.update(inner_radius=rmin, outer_radius=rmax)
 
 class Population(object):
 
     year = 2010
     location = "World"
 
-    def __init__(self):
-        from bokeh.models import ColumnDataSource
-        from bokeh.document import Document
-        # from bokeh.session import Session
-        from bokeh.sampledata.population import load_population
-
-        self.document = curdoc() #Document()
-        self.session = session
-        # self.session = Session()
-        # self.session.use_doc('population_reveal')
-        # self.session.load_document(self.document)
+    def __init__(self, document):
+        self.document = document
 
         self.df = load_population()
         self.source_pyramid = ColumnDataSource(data=dict())
@@ -202,8 +158,6 @@ class Population(object):
         self.update_pyramid()
 
     def create_layout(self):
-        from bokeh.models.widgets import Select, HBox, VBox
-
         years = list(map(str, sorted(self.df.Year.unique())))
         locations = sorted(self.df.Location.unique())
 
@@ -237,11 +191,6 @@ class Population(object):
             female=female_percent,
         )
 
-
-def update_population(plot):
-    while True:
-        time.sleep(0.1)
-
 if __name__ == '__main__':
-    print "STARTED"
-    app.run(debug=True)
+    print(__doc__)
+    app.run()

--- a/examples/embed/slideshow/templates/app_plot.html
+++ b/examples/embed/slideshow/templates/app_plot.html
@@ -2,101 +2,120 @@
 <html>
 <head>
 
-<meta charset="utf-8" />
-<meta http-equiv="X-UA-Compatible" content="chrome=1" />
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="chrome=1" />
 
-<meta name="apple-mobile-web-app-capable" content="yes" />
-<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 
-<!-- General and theme style sheets -->
-<link rel="stylesheet" href="//cdn.jsdelivr.net/reveal.js/2.6.2/css/reveal.css">
-<link rel="stylesheet" href="//cdn.jsdelivr.net/reveal.js/2.6.2/css/theme/night.css" id="theme">
+  <!-- General and theme style sheets -->
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/reveal.js/2.6.2/css/reveal.css">
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/reveal.js/2.6.2/css/theme/night.css" id="theme">
 
-<!-- For syntax highlighting -->
-<link rel="stylesheet" href="//cdn.jsdelivr.net/reveal.js/2.6.2/lib/css/zenburn.css">
+  <!-- For syntax highlighting -->
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/reveal.js/2.6.2/lib/css/zenburn.css">
 
-<!-- If the query includes 'print-pdf', include the PDF print sheet -->
-<script>
-if( window.location.search.match( /print-pdf/gi ) ) {
-        var link = document.createElement( 'link' );
-        link.rel = 'stylesheet';
-        link.type = 'text/css';
-        link.href = '//cdn.jsdelivr.net/reveal.js/2.6.2/css/print/pdf.css';
-        document.getElementsByTagName( 'head' )[0].appendChild( link );
-}
-</script>
+  <!-- If the query includes 'print-pdf', include the PDF print sheet -->
+  <script type="text/javascript">
+    if( window.location.search.match( /print-pdf/gi ) ) {
+      var link = document.createElement( 'link' );
+      link.rel = 'stylesheet';
+      link.type = 'text/css';
+      link.href = '//cdn.jsdelivr.net/reveal.js/2.6.2/css/print/pdf.css';
+      document.getElementsByTagName( 'head' )[0].appendChild( link );
+    }
+  </script>
 
-<!--[if lt IE 9]>
-<script src="//cdn.jsdelivr.net/reveal.js/2.6.2/lib/js/html5shiv.js"></script>
-<![endif]-->
+  <!--[if lt IE 9]>
+  <script src="//cdn.jsdelivr.net/reveal.js/2.6.2/lib/js/html5shiv.js"></script>
+  <![endif]-->
 
-<style>
-.bk-hbox {
-  margin-top: -1em !important;
-}
-.bk-sidebar {
-  background: #111111;
-  height: 33px;
-}
-canvas {
-  top: 33px;
-  left: 0px;
-}
-.reveal div {
-  margin-left: 0.7em;
-}
+  <style>
+    .bk-hbox {
+      margin-top: -1em !important;
+    }
 
-</style>
+    .bk-sidebar {
+      background: #111111;
+      height: 33px;
+    }
+
+    canvas {
+      top: 33px;
+      left: 0px;
+    }
+
+    .reveal div {
+      margin-left: 0.7em;
+    }
+  </style>
 
 </head>
 
 <body>
-<div class="reveal">
-<div class="slides">
-<section>
-<h1>Bokeh Showcase</h1>
-</section>
-<section>
-    <div>
-        {{ tag1 | safe }}
+
+  <div class="reveal">
+
+    <div class="slides">
+
+      <section>
+      <h1>Bokeh Showcase</h1>
+      </section>
+
+      <section>
+          <div>
+              {{ tag1 | safe }}
+          </div>
+      </section>
+
+      <section>
+          <div>
+              {{ tag2 | safe }}
+          </div>
+      </section>
+
+      <section>
+          <div>
+              {{ tag3 | safe }}
+          </div>
+      </section>
+
     </div>
-</section>
-<section>
-    <div>
-        {{ tag2 | safe }}
-    </div>
-</section>
-<section>
-    <div>
-        {{ tag3 | safe }}
-    </div>
-</section>
-</div>
-</div>
 
-<script src="//cdn.jsdelivr.net/reveal.js/2.6.2/lib/js/head.min.js"></script>
+  </div>
 
-<script src="//cdn.jsdelivr.net/reveal.js/2.6.2/js/reveal.js"></script>
+  <script src="//cdn.jsdelivr.net/reveal.js/2.6.2/lib/js/head.min.js"></script>
 
-<script>
+  <script src="//cdn.jsdelivr.net/reveal.js/2.6.2/js/reveal.js"></script>
 
-// Full list of configuration options available here: https://github.com/hakimel/reveal.js#configuration
-Reveal.initialize({
-controls: true,
-progress: true,
-history: true,
+  <script type="text/javascript">
 
-theme: Reveal.getQueryHash().theme, // available themes are in /css/theme
-transition: Reveal.getQueryHash().transition || 'zoom', // default/cube/page/concave/zoom/linear/none
+    // Full list of configuration options available here: https://github.com/hakimel/reveal.js#configuration
+    Reveal.initialize({
 
-// Optional libraries used to extend on reveal.js
-dependencies: [
-{ src: "//cdn.jsdelivr.net/reveal.js/2.6.2/lib/js/classList.js", condition: function() { return !document.body.classList; } },
-{ src: "//cdn.jsdelivr.net/reveal.js/2.6.2/plugin/highlight/highlight.js", async: true, callback: function() { hljs.initHighlightingOnLoad(); } },
-{ src: "//cdn.jsdelivr.net/reveal.js/2.6.2/plugin/notes/notes.js", async: true, condition: function() { return !!document.body.classList; } }
-]
-});
-</script>
+      controls: true,
+      progress: true,
+      history: true,
+      theme: Reveal.getQueryHash().theme, // available themes are in /css/theme
+      transition: Reveal.getQueryHash().transition || 'zoom',
+
+      // Optional libraries used to extend on reveal.js
+      dependencies: [
+        { src: "//cdn.jsdelivr.net/reveal.js/2.6.2/lib/js/classList.js",
+          condition: function() { return !document.body.classList; }
+        },
+        { src: "//cdn.jsdelivr.net/reveal.js/2.6.2/plugin/highlight/highlight.js",
+          async: true,
+          callback: function() { hljs.initHighlightingOnLoad(); }
+        },
+        { src: "//cdn.jsdelivr.net/reveal.js/2.6.2/plugin/notes/notes.js",
+          async: true,
+          condition: function() { return !!document.body.classList; }
+        }
+      ]
+
+    });
+  </script>
 
 </body>
 </html>

--- a/examples/embed/spectrogram/README.md
+++ b/examples/embed/spectrogram/README.md
@@ -1,0 +1,15 @@
+The spectrogram example requires the pyaudio library, which is
+available via conda (python 2.7 only):
+
+    conda install -c bokeh pyaudio
+
+Or to build pyaudio from source, see the documentation
+here:
+
+    https://people.csail.mit.edu/hubert/pyaudio/
+
+To run the spectrogram example:
+
+    python spectogram.py
+
+Then open your webbrowser at: http://localhost:5000

--- a/examples/embed/widget.py
+++ b/examples/embed/widget.py
@@ -1,136 +1,171 @@
-class Population(object):
+""" To view this example, run
 
-    year = 2010
-    location = "World"
+    python -m SimpleHTTPServer  (python 2)
 
-    def __init__(self):
-        from bokeh.document import Document
-        from bokeh.client import push_session
-        from bokeh.models import ColumnDataSource
-        from bokeh.sampledata.population import load_population
+or
 
-        self.document = Document()
-        self.session = push_session(self.document)
-
-        self.df = load_population()
-        self.source_pyramid = ColumnDataSource(data=dict())
-
-    def render(self):
-        self.pyramid_plot()
-        self.create_layout()
-        self.document.add_root(self.layout)
-        self.update_pyramid()
-
-    def pyramid_plot(self):
-        from bokeh.models import (
-            Plot, DataRange1d, LinearAxis, Grid, Legend,
-            SingleIntervalTicker
-        )
-        from bokeh.models.glyphs import Quad
-
-        xdr = DataRange1d()
-        ydr = DataRange1d()
-
-        self.plot = Plot(title=None, x_range=xdr, y_range=ydr,
-                         plot_width=600, plot_height=600)
-
-        xaxis = LinearAxis()
-        self.plot.add_layout(xaxis, 'below')
-        yaxis = LinearAxis(ticker=SingleIntervalTicker(interval=5))
-        self.plot.add_layout(yaxis, 'left')
-
-        self.plot.add_layout(Grid(dimension=0, ticker=xaxis.ticker))
-        self.plot.add_layout(Grid(dimension=1, ticker=yaxis.ticker))
-
-        male_quad = Quad(left="male", right=0, bottom="groups", top="shifted",
-                         fill_color="#3B8686")
-        male_quad_glyph = self.plot.add_glyph(self.source_pyramid, male_quad)
-
-        female_quad = Quad(left=0, right="female", bottom="groups", top="shifted",
-                           fill_color="#CFF09E")
-        female_quad_glyph = self.plot.add_glyph(self.source_pyramid, female_quad)
-
-        self.plot.add_layout(Legend(legends=dict(Male=[male_quad_glyph],
-                                                 Female=[female_quad_glyph])))
-
-    def on_year_change(self, attr, old, new):
-        self.year = int(new)
-        self.update_pyramid()
-
-    def on_location_change(self, attr, old, new):
-        self.location = new
-        self.update_pyramid()
-
-    def create_layout(self):
-        from bokeh.models.widgets import Select, HBox, VBox
-
-        years = list(map(str, sorted(self.df.Year.unique())))
-        locations = sorted(self.df.Location.unique())
-
-        year_select = Select(title="Year:", value="2010", options=years)
-        location_select = Select(title="Location:", value="World", options=locations)
-
-        year_select.on_change('value', self.on_year_change)
-        location_select.on_change('value', self.on_location_change)
-
-        controls = HBox(year_select, location_select)
-        self.layout = VBox(controls, self.plot)
-
-    def update_pyramid(self):
-        pyramid = self.df[(self.df.Location == self.location) & (self.df.Year == self.year)]
-
-        male = pyramid[pyramid.Sex == "Male"]
-        female = pyramid[pyramid.Sex == "Female"]
-
-        total = male.Value.sum() + female.Value.sum()
-
-        male_percent = -male.Value / total
-        female_percent = female.Value / total
-
-        groups = male.AgeGrpStart.tolist()
-        shifted = groups[1:] + [groups[-1] + 5]
-
-        self.source_pyramid.data = dict(
-            groups=groups,
-            shifted=shifted,
-            male=male_percent,
-            female=female_percent,
-        )
-
-
-import bokeh.embed as embed
-
-pop = Population()
-pop.render()
-
-tag = embed.autoload_server(pop.layout)
-
-html = """
-<html>
-<head></head>
-<body>
-%s
-</body>
-</html>
-"""
-html = html % (tag)
-with open("population_embed.html", "w+") as f:
-    f.write(html)
-
-print("""
-To view this example, run
-
-    python -m SimpleHTTPServer (or http.server on python 3)
+    python -m http.server  (python 3)
 
 in this directory, then navigate to
 
     http://localhost:8000/population_embed.html
-""")
 
-import time
+"""
+from __future__ import print_function
 
-try:
-    while True:
-        time.sleep(0.1)
-except KeyboardInterrupt:
-    print()
+from numpy import pi
+
+from bokeh.document import Document
+from bokeh.client import push_session
+from bokeh.embed import autoload_server
+from bokeh.models import (Plot, DataRange1d, LinearAxis, CategoricalAxis,
+                          Legend, HBox, VBox, ColumnDataSource, Grid, Line,
+                          SingleIntervalTicker, Quad, Select, FactorRange)
+from bokeh.sampledata.population import load_population
+
+document = Document()
+
+session = push_session(document)
+
+df = load_population()
+revision = 2012
+
+year = 2010
+location = "World"
+
+years = [str(x) for x in sorted(df.Year.unique())]
+locations = sorted(df.Location.unique())
+
+source_pyramid = ColumnDataSource(data=dict())
+
+def pyramid():
+    xdr = DataRange1d()
+    ydr = DataRange1d()
+
+    plot = Plot(title=None, x_range=xdr, y_range=ydr, plot_width=600, plot_height=600)
+
+    xaxis = LinearAxis()
+    plot.add_layout(xaxis, 'below')
+    yaxis = LinearAxis(ticker=SingleIntervalTicker(interval=5))
+    plot.add_layout(yaxis, 'left')
+
+    plot.add_layout(Grid(dimension=0, ticker=xaxis.ticker))
+    plot.add_layout(Grid(dimension=1, ticker=yaxis.ticker))
+
+    male_quad = Quad(left="male", right=0, bottom="groups", top="shifted", fill_color="#3B8686")
+    male_quad_glyph = plot.add_glyph(source_pyramid, male_quad)
+
+    female_quad = Quad(left=0, right="female", bottom="groups", top="shifted", fill_color="#CFF09E")
+    female_quad_glyph = plot.add_glyph(source_pyramid, female_quad)
+
+    plot.add_layout(Legend(legends=[("Male", [male_quad_glyph]), ("Female", [female_quad_glyph])]))
+
+    return plot
+
+source_known = ColumnDataSource(data=dict(x=[], y=[]))
+source_predicted = ColumnDataSource(data=dict(x=[], y=[]))
+
+def population():
+    xdr = FactorRange(factors=years)
+    ydr = DataRange1d()
+
+    plot = Plot(title=None, x_range=xdr, y_range=ydr, plot_width=800, plot_height=200)
+
+    plot.add_layout(CategoricalAxis(major_label_orientation=pi/4), 'below')
+
+    line_known = Line(x="x", y="y", line_color="violet", line_width=2)
+    line_known_glyph = plot.add_glyph(source_known, line_known)
+
+    line_predicted = Line(x="x", y="y", line_color="violet", line_width=2, line_dash="dashed")
+    line_predicted_glyph = plot.add_glyph(source_predicted, line_predicted)
+
+    plot.add_layout(
+        Legend(
+            location="bottom_right",
+            legends=[("known", [line_known_glyph]), ("predicted", [line_predicted_glyph])],
+        )
+    )
+
+    return plot
+
+def update_pyramid():
+    pyramid = df[(df.Location == location) & (df.Year == year)]
+
+    male = pyramid[pyramid.Sex == "Male"]
+    female = pyramid[pyramid.Sex == "Female"]
+
+    total = male.Value.sum() + female.Value.sum()
+
+    male_percent = -male.Value/total
+    female_percent = female.Value/total
+
+    groups = male.AgeGrpStart.tolist()
+    shifted = groups[1:] + [groups[-1] + 5]
+
+    source_pyramid.data = dict(
+        groups=groups,
+        shifted=shifted,
+        male=male_percent,
+        female=female_percent,
+    )
+
+def update_population():
+    population = df[df.Location == location].groupby(df.Year).Value.sum()
+    aligned_revision = revision//10 * 10
+
+    known = population[population.index <= aligned_revision]
+    predicted = population[population.index >= aligned_revision]
+
+    source_known.data = dict(x=known.index.map(str), y=known.values)
+    source_predicted.data = dict(x=predicted.index.map(str), y=predicted.values)
+
+def update_data():
+    update_population()
+    update_pyramid()
+
+def on_year_change(attr, old, new):
+    global year
+    year = int(new)
+    update_data()
+
+def on_location_change(attr, old, new):
+    global location
+    location = new
+    update_data()
+
+def create_layout():
+    year_select = Select(title="Year:", value="2010", options=years)
+    location_select = Select(title="Location:", value="World", options=locations)
+
+    year_select.on_change('value', on_year_change)
+    location_select.on_change('value', on_location_change)
+
+    controls = HBox(children=[year_select, location_select])
+    layout = VBox(children=[controls, pyramid(), population()])
+
+    return layout
+
+layout = create_layout()
+
+update_data()
+
+html = """
+<html>
+    <head></head>
+    <body>
+        %s
+    </body>
+</html>
+""" % autoload_server(layout)
+
+with open("population_embed.html", "w+") as f:
+    f.write(html)
+
+print(__doc__)
+
+document.add_root(layout)
+
+if __name__ == "__main__":
+    print("\npress ctrl-C to exit")
+    session.loop_until_closed()
+

--- a/examples/embed/widget.py
+++ b/examples/embed/widget.py
@@ -1,4 +1,14 @@
-""" To view this example, run
+""" To view this example, first start a Bokeh server:
+
+    bokeh serve
+
+And then load the example into the Bokeh server by
+running the script:
+
+    python widget.py
+
+in this directory. Finally, start a simple web server
+by running:
 
     python -m SimpleHTTPServer  (python 2)
 
@@ -6,9 +16,9 @@ or
 
     python -m http.server  (python 3)
 
-in this directory, then navigate to
+in this directory. Navigate to
 
-    http://localhost:8000/population_embed.html
+    http://localhost:8000/widget.html
 
 """
 from __future__ import print_function
@@ -158,7 +168,7 @@ html = """
 </html>
 """ % autoload_server(layout)
 
-with open("population_embed.html", "w+") as f:
+with open("widget.html", "w+") as f:
     f.write(html)
 
 print(__doc__)


### PR DESCRIPTION
This PR cleans up, normalizes and verifies that (almost) all the example in `examples/embed` work. 

The one current exception is the slideshow. There appears to be something about the way reveal.js "renders everything" but only "shows one part at a time" that confuses the Bokeh server's tab-per-session (or something) the plots/widgets show up, but do not animate/respond. ping @havocp @damianavila if there is some alternate way to organize things that can work, I'd love to keep it (maybe simplify the examples a bit) otherwise we should just remove the example. 

Note, this is based off #3330 so has some extra junk in the diff