### PR TITLE
inspected is a non-serializable attr at least for now

### DIFF
--- a/bokehjs/src/coffee/source/column_data_source.coffee
+++ b/bokehjs/src/coffee/source/column_data_source.coffee
@@ -16,7 +16,7 @@ class ColumnDataSource extends HasProperties
     )
 
   nonserializable_attribute_names: () ->
-    super().concat(['selection_manager'])
+    super().concat(['selection_manager', 'inspected'])
 
   get_column: (colname) ->
     return @get('data')[colname] ? null


### PR DESCRIPTION
This was causing problems with `us_marriages_divorce` it seemed especially highlighted by line inspections. Some day might be nice to offer serializations of inspections as an option but this keeps the status quo working for now. 