### PR TITLE
Add connection write_lock

### DIFF
--- a/bokeh/client/connection.py
+++ b/bokeh/client/connection.py
@@ -47,7 +47,7 @@ class _WebSocketClientConnectionWrapper(object):
             raise gen.Return(future)
 
         if locked:
-            with (self.write_lock.acquire()):
+            with (yield self.write_lock.acquire()):
                 write_message_unlocked()
         else:
             write_message_unlocked()

--- a/bokeh/server/protocol/__init__.py
+++ b/bokeh/server/protocol/__init__.py
@@ -4,6 +4,9 @@ Servers and clients.
 '''
 from __future__ import absolute_import
 
+import logging
+log = logging.getLogger(__name__)
+
 from tornado.escape import json_decode
 
 from ..exceptions import ProtocolError
@@ -55,6 +58,9 @@ class Protocol(object):
 
         '''
         header = json_decode(header_json)
+        if 'msgtype' not in header:
+            log.error("Bad header with no msgtype was: %r", header)
+            raise ProtocolError("No 'msgtype' in header")
         return self._messages[header['msgtype']].assemble(
             header_json, metadata_json, content_json
         )

--- a/bokeh/tests/test_client_server.py
+++ b/bokeh/tests/test_client_server.py
@@ -7,6 +7,7 @@ import bokeh.document as document
 from bokeh.application import Application
 from bokeh.application.handlers import FunctionHandler
 from bokeh.client import pull_session, push_session, ClientSession
+from bokeh.document import ModelChangedEvent, TitleChangedEvent
 from bokeh.server.server import Server
 from bokeh.server.session import ServerSession
 from bokeh.model import Model
@@ -671,6 +672,95 @@ class TestClientServer(unittest.TestCase):
             server_session.document.remove_periodic_callback(cb)
 
             self.assertDictEqual(dict(a=0, b=1, c=2, d=3, e=4), result.values)
+
+    def test_lots_of_concurrent_messages(self):
+        application = Application()
+        def setup_stuff(doc):
+            m1 = AnotherModelInTestClientServer(bar=43, name='m1')
+            m2 = SomeModelInTestClientServer(foo=42, name='m2')
+            m3 = SomeModelInTestClientServer(foo=68, name='m3')
+            doc.add_root(m1)
+            doc.add_root(m2)
+            doc.add_root(m3)
+            def timeout1():
+                m1.bar += 1
+            doc.add_timeout_callback(timeout1, 1)
+            def timeout2():
+                m2.foo +=1
+            doc.add_timeout_callback(timeout2, 3)
+            def periodic1():
+                m1.bar += 1
+                doc.remove_timeout_callback(timeout1)
+                doc.add_timeout_callback(timeout1, m1.bar % 7)
+            doc.add_periodic_callback(periodic1, 3)
+            def periodic2():
+                m2.foo += 1
+                doc.remove_timeout_callback(timeout2)
+                doc.add_timeout_callback(timeout2, m2.foo % 7)
+            doc.add_periodic_callback(periodic2, 1)
+
+            def server_on_change(event):
+                if isinstance(event, ModelChangedEvent) and event.model is m3:
+                    return
+                m3.foo += 1
+
+            doc.on_change(server_on_change)
+
+        handler = FunctionHandler(setup_stuff)
+        application.add(handler)
+
+        # keep_alive_milliseconds=1 sends pings as fast as the OS will let us
+        with ManagedServerLoop(application, keep_alive_milliseconds=1) as server:
+            session = pull_session(session_id='test_lots_of_concurrent_messages',
+                                   url=url(server),
+                                   io_loop=server.io_loop)
+            assert session.connected
+
+            server_session = server.get_session('/', session.id)
+
+            def client_timeout():
+                m = session.document.roots[0]
+                m.name = m.name[::-1]
+            session.document.add_timeout_callback(client_timeout, 3)
+
+            def client_periodic():
+                m = session.document.roots[1]
+                m.name = m.name[::-1]
+                session.document.remove_timeout_callback(client_timeout)
+                session.document.add_timeout_callback(client_timeout, 3)
+
+            session.document.add_periodic_callback(client_periodic, 1)
+
+            result = {}
+            def end_test():
+                result['connected'] = session.connected
+                result['server_connection_count'] = server_session.connection_count
+                result['server_close_code'] = next(iter(server._tornado._clients))._socket.close_code
+                result['doc'] = session.document.to_json()
+                session.close()
+
+            # making this longer is more likely to trigger bugs, but it also
+            # makes the test take however much time you put here
+            session.document.add_timeout_callback(end_test, 250)
+
+            def client_on_change(event):
+                if not isinstance(event, TitleChangedEvent):
+                    session.document.title = session.document.title[::-1]
+
+            session.document.on_change(client_on_change)
+
+            session.loop_until_closed()
+
+            assert not session.connected
+
+            # we should have still been connected at the end,
+            # if we didn't have any crazy protocol errors
+            assert 'connected' in result
+            assert result['connected']
+
+            # server should also still have been connected
+            assert result['server_connection_count'] == 1
+            assert result['server_close_code'] is None
 
 # This isn't in the unittest.TestCase because per-test fixtures
 # don't work there (see note at bottom of https://pytest.org/latest/unittest.html#unittest-testcase)


### PR DESCRIPTION
Keeps us from interleaving websocket frames that belong to distinct messages.
