### PR TITLE
Periodic callback refactor

### DIFF
--- a/bokeh/client/session.py
+++ b/bokeh/client/session.py
@@ -15,6 +15,7 @@ from bokeh.resources import ( DEFAULT_SERVER_WEBSOCKET_URL,
                               _SessionCoordinates )
 from bokeh.document import Document, PeriodicCallback, TimeoutCallback
 from bokeh.util.session_id import generate_session_id
+from bokeh.util.tornado import _AsyncPeriodic
 
 DEFAULT_SESSION_ID = "default"
 
@@ -225,8 +226,7 @@ class ClientSession(object):
         NOTE: periodic callbacks can only work within a session. It'll take no effect when bokeh output is html or notebook
 
         '''
-        from tornado import ioloop
-        cb = self._callbacks[callback.id] = ioloop.PeriodicCallback(
+        cb = self._callbacks[callback.id] = _AsyncPeriodic(
             callback.callback, callback.period, io_loop=self._connection._loop
         )
         cb.start()

--- a/bokeh/server/session.py
+++ b/bokeh/server/session.py
@@ -8,6 +8,7 @@ log = logging.getLogger(__name__)
 
 from tornado import gen, locks
 from bokeh.document import PeriodicCallback, TimeoutCallback
+from bokeh.util.tornado import _AsyncPeriodic
 
 import time
 
@@ -52,41 +53,6 @@ def _needs_document_lock(func):
                 yield p
         raise gen.Return(result)
     return _needs_document_lock_wrapper
-
-class _AsyncPeriodic(object):
-    """Like ioloop.PeriodicCallback except the 'func' is async and
-        returns a Future, and we wait for func to finish each time
-        before we call it again.  Plain ioloop.PeriodicCallback
-        can "pile up" invocations if they are taking too long.
-
-    """
-    def __init__(self, func, period, io_loop):
-        self._func = func
-        self._loop = io_loop
-        self._period = period
-        self._started = False
-        self._stopped = False
-
-    def start(self):
-        if self._started:
-            raise RuntimeError("called start() twice on _AsyncPeriodic")
-        self._started = True
-        def schedule():
-            # important to start the sleep before starting callback
-            # so any initial time spent in callback "counts against"
-            # the period.
-            sleep_future = gen.sleep(self._period / 1000.0)
-            callback_future = self._func()
-            return gen.multi([sleep_future, callback_future])
-        def on_done(future):
-            if not self._stopped:
-                self._loop.add_future(schedule(), on_done)
-            if future.exception() is not None:
-                log.error("Error thrown from periodic callback: %r", future.exception())
-        self._loop.add_future(schedule(), on_done)
-
-    def stop(self):
-        self._stopped = True
 
 class ServerSession(object):
     ''' Hosts an application "instance" (an instantiated Document) for one or more connections.

--- a/bokeh/server/session.py
+++ b/bokeh/server/session.py
@@ -64,32 +64,29 @@ class _AsyncPeriodic(object):
         self._func = func
         self._loop = io_loop
         self._period = period
-        self._handle = None
-        self._last_start_time = None
-
-    def _step(self):
-        ''' Invoke async _func() and re-schedule next invocation '''
-        future = self._func()
-        def on_done(future):
-            now = self._loop.time()
-            duration = (now - self._last_start_time)
-            self._last_start_time = now
-            next_period = max(self._period - duration, 0)
-            # IOLoop.call_later takes a delay in seconds
-            self._handle = self._loop.call_later(next_period/1000.0, self._step)
-            if future.exception() is not None:
-                log.error("Error thrown from periodic callback: %r", future.exception())
-        self._loop.add_future(future, on_done)
+        self._started = False
+        self._stopped = False
 
     def start(self):
-        self._last_start_time = self._loop.time()
-        # IOLoop.call_later takes a delay in seconds
-        self._handle = self._loop.call_later(self._period/1000.0, self._step)
+        if self._started:
+            raise RuntimeError("called start() twice on _AsyncPeriodic")
+        self._started = True
+        def schedule():
+            # important to start the sleep before starting callback
+            # so any initial time spent in callback "counts against"
+            # the period.
+            sleep_future = gen.sleep(self._period / 1000.0)
+            callback_future = self._func()
+            return gen.multi([sleep_future, callback_future])
+        def on_done(future):
+            if not self._stopped:
+                self._loop.add_future(schedule(), on_done)
+            if future.exception() is not None:
+                log.error("Error thrown from periodic callback: %r", future.exception())
+        self._loop.add_future(schedule(), on_done)
 
     def stop(self):
-        if self._handle is not None:
-            self._loop.remove_timeout(self._handle)
-            self._handle = None
+        self._stopped = True
 
 class ServerSession(object):
     ''' Hosts an application "instance" (an instantiated Document) for one or more connections.

--- a/bokeh/tests/test_client_server.py
+++ b/bokeh/tests/test_client_server.py
@@ -478,10 +478,10 @@ class TestClientServer(unittest.TestCase):
 
             for ss in [client_session]:
                 iocb = ss._callbacks[callback.id]
-                assert isinstance(iocb, PeriodicCallback)
-                assert iocb.callback_time == 1
-                assert iocb.io_loop == server.io_loop
-                assert iocb.is_running()
+                assert iocb._period == 1
+                assert iocb._loop == server.io_loop
+                assert iocb._started
+                assert not iocb._stopped
                 started_callbacks.append(iocb)
 
             callback = doc.remove_periodic_callback(cb)
@@ -490,10 +490,7 @@ class TestClientServer(unittest.TestCase):
             assert len(server_session._callbacks) == 0
 
             for iocb in started_callbacks:
-                if hasattr(iocb, '_stopped'):
-                    assert iocb._stopped # server
-                else:
-                    assert not iocb.is_running() # client
+                assert iocb._stopped # server
 
     def test_session_timeout_callback(self):
         application = Application()

--- a/bokeh/tests/test_client_server.py
+++ b/bokeh/tests/test_client_server.py
@@ -472,7 +472,8 @@ class TestClientServer(unittest.TestCase):
                 iocb = ss._callbacks[callback.id]
                 assert iocb._period == 1
                 assert iocb._loop == server.io_loop
-                assert iocb._handle is not None
+                assert iocb._started
+                assert not iocb._stopped
                 started_callbacks.append(iocb)
 
             for ss in [client_session]:
@@ -489,10 +490,10 @@ class TestClientServer(unittest.TestCase):
             assert len(server_session._callbacks) == 0
 
             for iocb in started_callbacks:
-                if hasattr(iocb, '_handle'):
-                    assert iocb._handle is None
+                if hasattr(iocb, '_stopped'):
+                    assert iocb._stopped # server
                 else:
-                    assert not iocb.is_running()
+                    assert not iocb.is_running() # client
 
     def test_session_timeout_callback(self):
         application = Application()

--- a/bokeh/util/tornado.py
+++ b/bokeh/util/tornado.py
@@ -1,0 +1,50 @@
+""" Internal utils related to Tornado
+
+"""
+from __future__ import absolute_import
+
+import logging
+log = logging.getLogger(__name__)
+
+from tornado import gen
+
+class _AsyncPeriodic(object):
+    """Like ioloop.PeriodicCallback except the 'func' can be async and
+        return a Future, and we wait for func to finish each time
+        before we call it again.  Plain ioloop.PeriodicCallback
+        can "pile up" invocations if they are taking too long.
+
+    """
+    def __init__(self, func, period, io_loop):
+        self._func = func
+        self._loop = io_loop
+        self._period = period
+        self._started = False
+        self._stopped = False
+
+    def start(self):
+        if self._started:
+            raise RuntimeError("called start() twice on _AsyncPeriodic")
+        self._started = True
+        def schedule():
+            # important to start the sleep before starting callback
+            # so any initial time spent in callback "counts against"
+            # the period.
+            sleep_future = gen.sleep(self._period / 1000.0)
+            result = self._func()
+            try:
+                callback_future = gen.convert_yielded(result)
+            except gen.BadYieldError:
+                # result is not a yieldable thing
+                return sleep_future
+            else:
+                return gen.multi([sleep_future, callback_future])
+        def on_done(future):
+            if not self._stopped:
+                self._loop.add_future(schedule(), on_done)
+            if future.exception() is not None:
+                log.error("Error thrown from periodic callback: %r", future.exception())
+        self._loop.add_future(schedule(), on_done)
+
+    def stop(self):
+        self._stopped = True


### PR DESCRIPTION
I was hoping this would fix the test_lots_of_concurrent test taking forever, but I guess that's due to message backlog not periodic callback pileup.

Anyway, what this does: ClientSession now uses _AsyncPeriodic from the server, which means it shouldn't "pile up" async periodic callbacks that take longer than the period.

Also redid _AsyncPeriodic to work in a simpler way with gen.sleep, avoiding the math that was there before.