### PR TITLE
Fix change suppression on units-spec values

### DIFF
--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -1595,16 +1595,19 @@ class UnitsSpecProperty(DataSpecProperty):
 
     def _extract_units(self, obj, value):
         if isinstance(value, dict):
+            if 'units' in value:
+                value = copy(value) # so we can modify it
             units = value.pop("units", None)
             if units:
                 self.units_prop.__set__(obj, units)
+        return value
 
     def __set__(self, obj, value):
-        self._extract_units(obj, value)
+        value = self._extract_units(obj, value)
         super(UnitsSpecProperty, self).__set__(obj, value)
 
     def set_from_json(self, obj, json, models=None):
-        self._extract_units(obj, json)
+        json = self._extract_units(obj, json)
         super(UnitsSpecProperty, self).set_from_json(obj, json, models)
 
 class UnitsSpec(NumberSpec):

--- a/bokeh/core/tests/test_properties.py
+++ b/bokeh/core/tests/test_properties.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import
 import unittest
 import numpy as np
+from copy import copy
 
 from bokeh.core.properties import (
     HasProps, NumberSpec, ColorSpec, Bool, Int, Float, Complex, String,
     Regex, List, Dict, Tuple, Array, Instance, Any, Interval, Either,
     Enum, Color, Align, DashPattern, Size, Percent, Angle, AngleSpec,
     DistanceSpec, Override, Include)
-
 
 class Basictest(unittest.TestCase):
 
@@ -529,6 +529,25 @@ class TestAngleSpec(unittest.TestCase):
         a.set_from_json('x', { 'value' : 180, 'units' : 'deg' })
         self.assertEqual(a.x, 180)
         self.assertEqual(a.x_units, 'deg')
+
+    def test_setting_dict_does_not_modify_original_dict(self):
+        class Foo(HasProps):
+            x = AngleSpec(default=14)
+
+        a = Foo()
+
+        self.assertEqual(a.x, 14)
+        self.assertEqual(a.x_units, 'rad')
+
+        new_value = { 'value' : 180, 'units' : 'deg' }
+        new_value_copy = copy(new_value)
+        self.assertDictEqual(new_value_copy, new_value)
+
+        a.x = new_value
+        self.assertDictEqual(a.x, { 'value' : 180 })
+        self.assertEqual(a.x_units, 'deg')
+
+        self.assertDictEqual(new_value_copy, new_value)
 
 class TestDistanceSpec(unittest.TestCase):
     def test_default_none(self):

--- a/bokeh/server/protocol/messages/patch_doc.py
+++ b/bokeh/server/protocol/messages/patch_doc.py
@@ -54,7 +54,7 @@ class patch_doc_1(Message):
                         if patch_new is not None and 'id' in patch_new and patch_new['id'] == event.new._id:
                             return True
                     else:
-                        if patch_new == event.new:
+                        if patch_new == event.serializable_new:
                             return True
         elif isinstance(event, RootAddedEvent):
             for event_json in self.content['events']:

--- a/bokeh/tests/test_client_server.py
+++ b/bokeh/tests/test_client_server.py
@@ -12,7 +12,7 @@ from bokeh.server.server import Server
 from bokeh.server.session import ServerSession
 from bokeh.model import Model
 from bokeh.resources import websocket_url_for_server_url
-from bokeh.core.properties import Int, Instance, Dict, String, Any
+from bokeh.core.properties import Int, Instance, Dict, String, Any, DistanceSpec, AngleSpec
 from tornado.ioloop import IOLoop, PeriodicCallback, _Timeout
 from tornado import gen
 
@@ -26,6 +26,10 @@ class SomeModelInTestClientServer(Model):
 
 class DictModel(Model):
     values = Dict(String, Any)
+
+class UnitsSpecModel(Model):
+    distance = DistanceSpec(42)
+    angle = AngleSpec(0)
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -859,3 +863,53 @@ def test_server_changes_do_not_boomerang(monkeypatch):
         client_session.close()
         client_session.loop_until_closed()
         assert not client_session.connected
+
+# this test is because we do the funky serializable_value
+# tricks with the units specs
+def test_unit_spec_changes_do_not_boomerang(monkeypatch):
+    application = Application()
+    with ManagedServerLoop(application) as server:
+        doc = document.Document()
+        client_root = UnitsSpecModel()
+        doc.add_root(client_root)
+
+        client_session = push_session(doc,
+                                      session_id='test_unit_spec_changes_do_not_boomerang',
+                                      url=url(server),
+                                      io_loop=server.io_loop)
+        server_session = server.get_session('/', client_session.id)
+
+        assert len(server_session.document.roots) == 1
+        server_root = next(iter(server_session.document.roots))
+
+        assert client_root.distance == 42
+        assert server_root.angle == 0
+
+        got_angry = {}
+        got_angry['result'] = None
+        # trap any boomerang
+        def get_angry(message):
+            got_angry['result'] = message
+        monkeypatch.setattr(client_session, '_handle_patch', get_angry)
+
+        # Now modify the client document
+        client_root.distance = 57
+        client_root.angle = 1
+
+        # wait until server side change made ... but we may not have the
+        # boomerang yet
+        def server_change_made():
+            return server_root.distance == 57 and server_root.angle == 1
+        client_session._connection._loop_until(server_change_made)
+        assert server_root.distance == 57
+        assert server_root.angle == 1
+
+        # force a round trip to be sure we get the boomerang if we're going to
+        client_session.force_roundtrip()
+
+        assert got_angry['result'] is None
+
+        client_session.close()
+        client_session.loop_until_closed()
+        assert not client_session.connected
+        server.unlisten() # clean up so next test can run


### PR DESCRIPTION
One issue created by this was to defeat patch-doc should_suppress_on_change,
since we compared two dicts and one of them had the units accidentally
stripped out.