### PR TITLE
Update dev_guide/setup.rst to align develop deps in line with scripts/devdeps.py

### DIFF
--- a/sphinx/source/docs/dev_guide/setup.rst
+++ b/sphinx/source/docs/dev_guide/setup.rst
@@ -194,13 +194,11 @@ Testing dependencies include the following additional libraries:
 
 * beautiful-soup
 * colorama
-* pdiff
-* boto
-* nose
-* mock
-* coverage
-* websocket-client
+* pytest
+* pytest-cov
 * pytest-selenium >= 1.0
+* mock
+* websocket-client
 
 .. This comment is just here to fix a weird Sphinx formatting bug
 

--- a/sphinx/source/docs/dev_guide/setup.rst
+++ b/sphinx/source/docs/dev_guide/setup.rst
@@ -185,12 +185,13 @@ If you have any problems with the steps here, please contact the developers
 Dependencies
 ~~~~~~~~~~~~
 
-If you are working within a Conda environment, you will need to make sure
-you have the python requirements installed. You can install these via
-``conda install`` or ``pip install`` for the packages referenced at
-:ref:`install_dependencies`.
+In order to build Bokeh from its source, you'll have to install the project's
+python dependencies. If you're using Conda or pip + virtualenv to setup a
+development environment, you'll be able to install these via ``conda install``
+or ``pip install`` for the packages references at :ref:`install_dependencies`.
 
-Testing dependencies include the following additional libraries:
+There are additional testing dependencies required to run the unit tests,
+which include:
 
 * beautiful-soup
 * colorama
@@ -199,6 +200,11 @@ Testing dependencies include the following additional libraries:
 * pytest-selenium >= 1.0
 * mock
 * websocket-client
+
+Both the build and test dependencies can potentially change between releases
+and be out of sync with the hosted Bokeh site documentation, so the best way
+to view the current required packages is the review the meta.yaml_ file included
+in the Github repository.
 
 .. This comment is just here to fix a weird Sphinx formatting bug
 
@@ -395,3 +401,4 @@ There are several environment variables that can be useful for developers:
 .. _Gulp: http://gulpjs.com/
 .. _NodeJS: http://nodejs.org/
 .. _webbrowser: https://docs.python.org/2/library/webbrowser.html
+.. _meta.yaml: http://github.com/bokeh/bokeh/blob/master/conda.recipe/meta.yaml

--- a/sphinx/source/docs/dev_guide/setup.rst
+++ b/sphinx/source/docs/dev_guide/setup.rst
@@ -399,6 +399,6 @@ There are several environment variables that can be useful for developers:
 .. _conda: http://conda.pydata.org/
 .. _GitHub: https://github.com
 .. _Gulp: http://gulpjs.com/
+.. _meta.yaml: http://github.com/bokeh/bokeh/blob/master/conda.recipe/meta.yaml
 .. _NodeJS: http://nodejs.org/
 .. _webbrowser: https://docs.python.org/2/library/webbrowser.html
-.. _meta.yaml: http://github.com/bokeh/bokeh/blob/master/conda.recipe/meta.yaml

--- a/sphinx/source/docs/dev_guide/setup.rst
+++ b/sphinx/source/docs/dev_guide/setup.rst
@@ -219,7 +219,7 @@ If any needed packages are missing, you will be given output like this
     ------------------------------------------------------------------
     You are missing the following Docs dependencies:
      *  sphinx
-     *  sphinxcontrib-httpdomain
+     *  pygments
 
 Otherwise, you should see this message
 


### PR DESCRIPTION
Update dev_guide/setup.rst to match dependencies required (and tested for) in scripts/devdeps.py

Note: I removed pdiff and boto from the listed deps in setup.rst because they're only used by Travis CI and not the developer. They're not tested for in devdeps.py because they're not required to develop/test locally. Removing them may be a point of debate.