### PR TITLE
Default sync

### DIFF
--- a/bokeh/charts/tests/test_chart.py
+++ b/bokeh/charts/tests/test_chart.py
@@ -82,7 +82,6 @@ class TestChart(unittest.TestCase):
 
         axis = self.chart.make_axis("x", "left", "datetime", "foo")
         self.assertEqual(axis.location, "auto")
-        self.assertEqual(axis.scale, "time")
         self.assertEqual(axis.axis_label, "foo")
 
         axis = self.chart.make_axis("x", "left", "categorical", "bar")

--- a/bokeh/models/axes.py
+++ b/bokeh/models/axes.py
@@ -145,37 +145,27 @@ class LinearAxis(ContinuousAxis):
     linear scale. Configured with a ``BasicTickFormatter`` by default.
 
     """
-    def __init__(self, ticker=None, formatter=None, **kwargs):
-        if ticker is None:
-            ticker = BasicTicker()
-        if formatter is None:
-            formatter = BasicTickFormatter()
-        super(LinearAxis, self).__init__(ticker=ticker, formatter=formatter, **kwargs)
+    ticker = Override(default=lambda: BasicTicker())
+
+    formatter = Override(default=lambda: BasicTickFormatter())
 
 class LogAxis(ContinuousAxis):
     """ An axis that picks nice numbers for tick locations on a
     log scale. Configured with a ``LogTickFormatter`` by default.
 
     """
+    ticker = Override(default=lambda: LogTicker())
 
-    def __init__(self, ticker=None, formatter=None, **kwargs):
-        if ticker is None:
-            ticker = LogTicker(num_minor_ticks=10)
-        if formatter is None:
-            formatter = LogTickFormatter(ticker=ticker)
-        super(LogAxis, self).__init__(ticker=ticker, formatter=formatter, **kwargs)
+    formatter = Override(default=lambda: LogTickFormatter())
 
 class CategoricalAxis(Axis):
     """ An axis that picks evenly spaced tick locations for a
     collection of categories/factors.
 
     """
-    def __init__(self, ticker=None, formatter=None, **kwargs):
-        if ticker is None:
-            ticker = CategoricalTicker()
-        if formatter is None:
-            formatter = CategoricalTickFormatter()
-        super(CategoricalAxis, self).__init__(ticker=ticker, formatter=formatter, **kwargs)
+    ticker = Override(default=lambda: CategoricalTicker())
+
+    formatter = Override(default=lambda: CategoricalTickFormatter())
 
 class DatetimeAxis(LinearAxis):
     """ An LinearAxis that picks nice numbers for tick locations on
@@ -184,18 +174,6 @@ class DatetimeAxis(LinearAxis):
 
     """
 
-    # TODO: (bev) this should be an Enum, if it is exposed at all
-    scale = String("time")
+    ticker = Override(default=lambda: DatetimeTicker())
 
-    num_labels = Int(8)
-
-    char_width = Int(10)
-
-    fill_ratio = Float(0.3)
-
-    def __init__(self, ticker=None, formatter=None, **kwargs):
-        if ticker is None:
-            ticker = DatetimeTicker()
-        if formatter is None:
-            formatter = DatetimeTickFormatter()
-        super(DatetimeAxis, self).__init__(ticker=ticker, formatter=formatter, **kwargs)
+    formatter = Override(default=lambda: DatetimeTickFormatter())

--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -128,7 +128,7 @@ class Arc(Glyph):
     The angles to end the arcs, as measured from the horizontal.
     """)
 
-    direction = Enum(Direction, help="""
+    direction = Enum(Direction, default='anticlock', help="""
     Which direction to stroke between the start and end angles.
     """)
 

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -348,6 +348,15 @@ class Plot(Component):
     This is useful for adding additional axes.
     """)
 
+    hidpi = Bool(default=True, help="""
+    Whether to use HiDPI mode when available.
+    """)
+
+    title_standoff = Int(default=8, help="""
+    How far (in screen units) to place a title away from the central
+    plot region.
+    """)
+
     title = String('', help="""
     A title for the plot.
     """)
@@ -479,7 +488,7 @@ class Plot(Component):
 
     border_fill_color = Override(default='#ffffff')
 
-    min_border_top = Int(50, help="""
+    min_border_top = Int(40, help="""
     Minimum size in pixels of the padding region above the top of the
     central plot region.
 
@@ -489,7 +498,7 @@ class Plot(Component):
 
     """)
 
-    min_border_bottom = Int(50, help="""
+    min_border_bottom = Int(40, help="""
     Minimum size in pixels of the padding region below the bottom of
     the central plot region.
 
@@ -499,7 +508,7 @@ class Plot(Component):
 
     """)
 
-    min_border_left = Int(50, help="""
+    min_border_left = Int(40, help="""
     Minimum size in pixels of the padding region to the left of
     the central plot region.
 
@@ -509,7 +518,7 @@ class Plot(Component):
 
     """)
 
-    min_border_right = Int(50, help="""
+    min_border_right = Int(40, help="""
     Minimum size in pixels of the padding region to the right of
     the central plot region.
 

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -495,7 +495,7 @@ class Plot(Component):
 
     border_fill_color = Override(default='#ffffff')
 
-    min_border_top = Int(40, help="""
+    min_border_top = Int(50, help="""
     Minimum size in pixels of the padding region above the top of the
     central plot region.
 
@@ -505,7 +505,7 @@ class Plot(Component):
 
     """)
 
-    min_border_bottom = Int(40, help="""
+    min_border_bottom = Int(50, help="""
     Minimum size in pixels of the padding region below the bottom of
     the central plot region.
 
@@ -515,7 +515,7 @@ class Plot(Component):
 
     """)
 
-    min_border_left = Int(40, help="""
+    min_border_left = Int(50, help="""
     Minimum size in pixels of the padding region to the left of
     the central plot region.
 
@@ -525,7 +525,7 @@ class Plot(Component):
 
     """)
 
-    min_border_right = Int(40, help="""
+    min_border_right = Int(50, help="""
     Minimum size in pixels of the padding region to the right of
     the central plot region.
 
@@ -535,7 +535,7 @@ class Plot(Component):
 
     """)
 
-    min_border = Int(40, help="""
+    min_border = Int(50, help="""
     A convenience property to set all all the ``min_X_border`` properties
     to the same value. If an individual border property is explicitly set,
     it will override ``min_border``.

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -55,6 +55,11 @@ def _select_helper(args, kwargs):
         selector = kwargs
     return selector
 
+class LayoutBox(Model):
+    ''' Represents an **on-cavas** layout.
+
+    '''
+
 class Plot(Component):
     """ Model representing a plot, containing glyphs, guides, annotations.
 
@@ -402,7 +407,9 @@ class Plot(Component):
     A list of renderers to occupy the area to the right of the plot.
     """)
 
-    above = List(Instance(Renderer), help="""
+    # TODO (bev) LayoutBox here is a temporary workaround to the fact that
+    # plot titles are not proper renderers
+    above = List(Either(Instance(Renderer), Instance(LayoutBox)), help="""
     A list of renderers to occupy the area above of the plot.
     """)
 

--- a/bokeh/models/ranges.py
+++ b/bokeh/models/ranges.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 
 from ..model import Model
 from ..core.properties import abstract
-from ..core.properties import Int, Float, String, Datetime, Instance, List, Either
+from ..core.properties import Bool, Int, Float, String, Datetime, Instance, List, Either
 from .callbacks import Callback
 from .renderers import Renderer
 
@@ -88,6 +88,10 @@ class DataRange1d(DataRange):
     end = Float(help="""
     An explicitly supplied range end. If provided, will override
     automatically computed end value.
+    """)
+
+    flipped = Bool(default=False, help="""
+    Whether the range should be "flipped" from its normal direction.
     """)
 
 class FactorRange(Range):

--- a/bokeh/models/renderers.py
+++ b/bokeh/models/renderers.py
@@ -5,20 +5,19 @@ types that Bokeh supports.
 from __future__ import absolute_import
 
 import logging
+logger = logging.getLogger(__name__)
 
-from ..core import validation
-from ..core.validation.errors import BAD_COLUMN_NAME, MISSING_GLYPH, NO_SOURCE_FOR_GLYPH
 from ..model import Model
+from ..core.enums import RenderLevel
 from ..core.properties import abstract
 from ..core.properties import String, Enum, Instance, Float, Bool
-from ..core.enums import RenderLevel
+from ..core import validation
+from ..core.validation.errors import BAD_COLUMN_NAME, MISSING_GLYPH, NO_SOURCE_FOR_GLYPH
 
-from .sources import DataSource, RemoteSource
 from .glyphs import Glyph
-from .tiles import TileSource
 from .images import ImageSource
-
-logger = logging.getLogger(__name__)
+from .sources import DataSource, RemoteSource
+from .tiles import TileSource, WMTSTileSource
 
 @abstract
 class Renderer(Model):
@@ -28,7 +27,7 @@ class Renderer(Model):
     """
 class TileRenderer(Renderer):
 
-    tile_source = Instance(TileSource, help="""
+    tile_source = Instance(TileSource, default=lambda: WMTSTileSource(), help="""
     Local data source to use when rendering glyphs on the plot.
     """)
 

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -230,7 +230,8 @@ class ColumnDataSource(DataSource):
             return str(self)
 
 
-class GeoJSONDataSource(DataSource):
+class GeoJSONDataSource(ColumnDataSource):
+
     geojson = JSON(help="""
     GeoJSON that contains features for plotting. Currently GeoJSONDataSource can
     only process a FeatureCollection or GeometryCollection.

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -19,7 +19,7 @@ class DataSource(Model):
 
     """
     selected = Dict(String, Dict(String, Any), default={
-        '0d': {'flag': False, 'indices': []},
+        '0d': {'glyph': None, 'indices': []},
         '1d': {'indices': []},
         '2d': {'indices': []}
     }, help="""

--- a/bokeh/models/tests/test_glyphs.py
+++ b/bokeh/models/tests/test_glyphs.py
@@ -141,7 +141,7 @@ def test_Arc():
     assert glyph.radius is None
     assert glyph.start_angle is None
     assert glyph.end_angle is None
-    assert glyph.direction == "clock"
+    assert glyph.direction == "anticlock"
     yield check_line, glyph
     yield (check_props, glyph, [
         "x",

--- a/bokehjs/src/coffee/common/gmap_plot.coffee
+++ b/bokehjs/src/coffee/common/gmap_plot.coffee
@@ -162,23 +162,15 @@ class GMapPlot extends Plot.Model
   type: 'GMapPlot'
   default_view: GMapPlotView
 
+  defaults: ->
+    return _.extend {}, super(), {
+      map_options: null
+      disabled: false
+    }
+
   initialize: (attrs, options) ->
     @use_map = true
     super(attrs, options)
-
-  parent_properties: [
-    'border_fill',
-    'min_border',
-    'min_border_top',
-    'min_border_bottom'
-    'min_border_left'
-    'min_border_right'
-  ]
-
-  defaults: ->
-    return _.extend {}, super(), {
-      title: 'GMapPlot'
-    }
 
 module.exports =
   Model: GMapPlot

--- a/bokehjs/src/coffee/common/layout_box.coffee
+++ b/bokehjs/src/coffee/common/layout_box.coffee
@@ -9,6 +9,9 @@ Range1d = require "../range/range1d"
 class LayoutBox extends HasProperties
   type: 'LayoutBox'
 
+  nonserializable_attribute_names: () ->
+    super().concat(['solver', 'layout_location'])
+
   initialize: (attrs, options) ->
     super(attrs, options)
     @solver = @get('solver')
@@ -67,8 +70,6 @@ class LayoutBox extends HasProperties
     @register_setter('aspect', @_set_aspect)
     @add_dependencies('aspect', this, ['width', 'height'])
 
-  serializable_in_document: () -> false
-
   contains: (vx, vy) ->
     return (
       vx >= @get('left') and vx <= @get('right') and
@@ -97,16 +98,6 @@ class LayoutBox extends HasProperties
       c = new Constraint(new Expression([aspect, @_height], [-1, @_width]), Eq)
       @_aspect_constraint = c
       @solver.add_constraint(c)
-
-  defaults: ->
-    return _.extend {}, super(), {
-      'top_strength': kiwi.Strength.strong,
-      'bottom_strength': kiwi.Strength.strong,
-      'left_strength': kiwi.Strength.strong,
-      'right_strength': kiwi.Strength.strong,
-      'width_strength': kiwi.Strength.strong,
-      'height_strength': kiwi.Strength.strong
-    }
 
 module.exports =
   Model: LayoutBox

--- a/bokehjs/src/coffee/common/plot.coffee
+++ b/bokehjs/src/coffee/common/plot.coffee
@@ -17,6 +17,7 @@ Solver = require "./solver"
 ToolManager = require "./tool_manager"
 plot_template = require "./plot_template"
 properties = require "./properties"
+ToolEvents = require "./tool_events"
 
 
 # Notes on WebGL support:
@@ -31,6 +32,8 @@ properties = require "./properties"
 # marker that we use throughout that determines whether we have gl support.
 
 global_gl_canvas = null
+
+MIN_BORDER = 40
 
 get_size_for_available_space = (use_width, use_height, client_width, client_height, aspect_ratio, min_size) =>
     # client_width and height represent the available size
@@ -516,10 +519,10 @@ class Plot extends HasParent
     @set('above', elts)
 
   add_constraints: (solver) ->
-    min_border_top    = @get('min_border_top')    ? @get('min_border')
-    min_border_bottom = @get('min_border_bottom') ? @get('min_border')
-    min_border_left   = @get('min_border_left')   ? @get('min_border')
-    min_border_right  = @get('min_border_right')  ? @get('min_border')
+    min_border_top    = @get('min_border_top')
+    min_border_bottom = @get('min_border_bottom')
+    min_border_left   = @get('min_border_left')
+    min_border_right  = @get('min_border_right')
 
     do_side = (solver, min_size, side, cnames, dim, op) =>
       canvas = @get('canvas')
@@ -567,19 +570,8 @@ class Plot extends HasParent
     renderers = renderers.concat(new_renderers)
     @set('renderers', renderers)
 
-  parent_properties: [
-    'background_fill',
-    'border_fill',
-    'min_border',
-    'min_border_top',
-    'min_border_bottom'
-    'min_border_left'
-    'min_border_right'
-  ]
-
   nonserializable_attribute_names: () ->
-    super().concat(['solver', 'above', 'below', 'left', 'right', 'canvas', 'tool_manager', 'frame',
-    'min_size'])
+    super().concat(['solver', 'canvas', 'tool_manager', 'frame', 'min_size'])
 
   serializable_attributes: () ->
     attrs = super()
@@ -591,6 +583,7 @@ class Plot extends HasParent
     return _.extend {}, super(), {
       renderers: [],
       tools: [],
+      tool_events: new ToolEvents.Model(),
       h_symmetry: true,
       v_symmetry: false,
       x_mapper_type: 'auto',
@@ -611,18 +604,25 @@ class Plot extends HasParent
       webgl: false
       responsive: false
       min_size: 120
-    }
-
-  display_defaults: ->
-    return _.extend {}, super(), {
       hidpi: true,
+      title_standoff: 8,
+
+      x_range: null
+      extra_x_ranges: {}
+
+      y_range: null
+      extra_y_ranges: {}
+
       background_fill_color: "#ffffff",
       background_fill_alpha: 1.0,
       border_fill_color: "#ffffff",
       border_fill_alpha: 1.0
-      min_border: 40,
+      min_border: MIN_BORDER,
+      min_border_top: MIN_BORDER,
+      min_border_left: MIN_BORDER,
+      min_border_bottom: MIN_BORDER,
+      min_border_right: MIN_BORDER,
 
-      title_standoff: 8,
       title_text_font: "helvetica",
       title_text_font_size: "20pt",
       title_text_font_style: "normal",

--- a/bokehjs/src/coffee/common/plot.coffee
+++ b/bokehjs/src/coffee/common/plot.coffee
@@ -33,7 +33,7 @@ ToolEvents = require "./tool_events"
 
 global_gl_canvas = null
 
-MIN_BORDER = 40
+MIN_BORDER = 50
 
 get_size_for_available_space = (use_width, use_height, client_width, client_height, aspect_ratio, min_size) =>
     # client_width and height represent the available size

--- a/bokehjs/src/coffee/common/tool_events.coffee
+++ b/bokehjs/src/coffee/common/tool_events.coffee
@@ -4,5 +4,12 @@ HasProperties = require "./has_properties"
 class ToolEvents extends HasProperties
   type: 'ToolEvents'
 
+  defaults: () ->
+    return {
+      geometries: []
+      name: null
+      tags: []
+    }
+
 module.exports =
   Model: ToolEvents

--- a/bokehjs/src/coffee/main.coffee
+++ b/bokehjs/src/coffee/main.coffee
@@ -76,6 +76,8 @@ Bokeh.LinearAxis      = require("./renderer/guide/linear_axis")
 Bokeh.LogAxis         = require("./renderer/guide/log_axis")
 
 # data sources
+Bokeh.DataSource = require("./source/data_source")
+Bokeh.RemoteDataSource = require("./source/remote_data_source")
 Bokeh.ColumnDataSource = require("./source/column_data_source")
 Bokeh.GeoJSONDataSource = require("./source/geojson_data_source")
 

--- a/bokehjs/src/coffee/mapper/linear_color_mapper.coffee
+++ b/bokehjs/src/coffee/mapper/linear_color_mapper.coffee
@@ -90,4 +90,4 @@ class LinearColorMapper extends HasProperties
     return new_palette
 
 module.exports =
-  Model: LinearColorMapper,
+  Model: LinearColorMapper

--- a/bokehjs/src/coffee/range/data_range.coffee
+++ b/bokehjs/src/coffee/range/data_range.coffee
@@ -1,0 +1,14 @@
+_ = require "underscore"
+Range = require "./range"
+
+class DataRange extends Range.Model
+  type: 'DataRange'
+
+  defaults: ->
+    return _.extend {}, super(), {
+      names: []
+      renderers: []
+    }
+
+module.exports =
+  Model: DataRange

--- a/bokehjs/src/coffee/range/data_range1d.coffee
+++ b/bokehjs/src/coffee/range/data_range1d.coffee
@@ -1,10 +1,10 @@
 _ = require "underscore"
 bbox = require "../common/bbox"
 {logger} = require "../common/logging"
-Range1d = require "./range1d"
+DataRange = require "./data_range"
 
 
-class DataRange1d extends Range1d.Model
+class DataRange1d extends DataRange.Model
   type: 'DataRange1d'
 
   _get_start: () ->
@@ -38,6 +38,16 @@ class DataRange1d extends Range1d.Model
       '_end', 'flipped', '_auto_end', 'range_padding', 'default_span'
     ])
 
+    @register_property('min',
+        () -> Math.min(@get('start'), @get('end'))
+      , true)
+    @add_dependencies('min', this, ['start', 'end'])
+    @register_property('max',
+        () ->
+          Math.max(@get('start'), @get('end'))
+      , true)
+    @add_dependencies('max', this, ['start', 'end'])
+
     if attrs?.start?
       @set('start', attrs.start)
       delete attrs.start
@@ -52,7 +62,7 @@ class DataRange1d extends Range1d.Model
 
   nonserializable_attribute_names: () ->
     super().concat(['_auto_end', '_auto_start', '_start', '_end',
-      'flipped', 'sources', 'default_span', 'plots'])
+      'sources', 'default_span', 'plots'])
 
   update: (bounds, dimension, plot_view) ->
     if not @renderers_computed
@@ -99,6 +109,8 @@ class DataRange1d extends Range1d.Model
 
   defaults: ->
     return _.extend {}, super(), {
+      start: 0
+      end: 1
       plots: []
       sources: []
       renderers: []

--- a/bokehjs/src/coffee/range/factor_range.coffee
+++ b/bokehjs/src/coffee/range/factor_range.coffee
@@ -1,8 +1,9 @@
 _ = require "underscore"
-HasProperties = require "../common/has_properties"
+Range = require "./range"
 
-class FactorRange extends HasProperties
+class FactorRange extends Range.Model
   type: 'FactorRange'
+
   initialize: (attrs, options) ->
     super(attrs, options)
     @_init()

--- a/bokehjs/src/coffee/range/range.coffee
+++ b/bokehjs/src/coffee/range/range.coffee
@@ -1,0 +1,13 @@
+_ = require "underscore"
+HasProperties = require "../common/has_properties"
+
+class Range extends HasProperties
+  type: 'Range'
+
+  defaults: ->
+    return _.extend {}, super(), {
+      callback: null
+    }
+
+module.exports =
+  Model: Range

--- a/bokehjs/src/coffee/range/range1d.coffee
+++ b/bokehjs/src/coffee/range/range1d.coffee
@@ -1,8 +1,9 @@
 _ = require "underscore"
-HasProperties = require "../common/has_properties"
+Range = require "./range"
 
-class Range1d extends HasProperties
+class Range1d extends Range.Model
   type: 'Range1d'
+
   initialize: (attrs, options) ->
     super(attrs, options)
     @register_property('min',

--- a/bokehjs/src/coffee/renderer/annotation/annotation.coffee
+++ b/bokehjs/src/coffee/renderer/annotation/annotation.coffee
@@ -1,0 +1,14 @@
+_ = require "underscore"
+HasParent = require "../../common/has_parent"
+
+class Annotation extends HasParent
+  type: 'Annotation'
+
+  defaults: ->
+    return _.extend {}, super(), {
+      level: 'overlay'
+      plot: null
+    }
+
+module.exports =
+  Model: Annotation

--- a/bokehjs/src/coffee/renderer/annotation/box_annotation.coffee
+++ b/bokehjs/src/coffee/renderer/annotation/box_annotation.coffee
@@ -1,5 +1,5 @@
 _ = require "underscore"
-HasParent = require "../../common/has_parent"
+Annotation = require "./annotation"
 PlotWidget = require "../../common/plot_widget"
 properties = require "../../common/properties"
 
@@ -87,7 +87,7 @@ class BoxAnnotationView extends PlotWidget
       vdim = frame_extrema
     return vdim
 
-class BoxAnnotation extends HasParent
+class BoxAnnotation extends Annotation.Model
   default_view: BoxAnnotationView
   type: 'BoxAnnotation'
 
@@ -111,6 +111,10 @@ class BoxAnnotation extends HasParent
       x_range_name: "default"
       y_range_name: "default"
       level: 'annotation'
+      left: null
+      right: null
+      top: null
+      bottom: null
       left_units: 'data'
       right_units: 'data'
       top_units: 'data'

--- a/bokehjs/src/coffee/renderer/annotation/legend.coffee
+++ b/bokehjs/src/coffee/renderer/annotation/legend.coffee
@@ -139,6 +139,7 @@ class Legend extends Annotation.Model
   defaults: ->
     return _.extend {}, super(), {
       legends: []
+      level: "annotation"
     }
 
   display_defaults: ->

--- a/bokehjs/src/coffee/renderer/annotation/legend.coffee
+++ b/bokehjs/src/coffee/renderer/annotation/legend.coffee
@@ -1,5 +1,5 @@
 _ = require "underscore"
-HasParent = require "../../common/has_parent"
+Annotation = require "./annotation"
 PlotWidget = require "../../common/plot_widget"
 properties = require "../../common/properties"
 textutils = require "../../common/textutils"
@@ -132,7 +132,7 @@ class LegendView extends PlotWidget
 
     ctx.restore()
 
-class Legend extends HasParent
+class Legend extends Annotation.Model
   default_view: LegendView
   type: 'Legend'
 
@@ -143,8 +143,6 @@ class Legend extends HasParent
 
   display_defaults: ->
     return _.extend {}, super(), {
-      level: 'overlay'
-
       border_line_color: 'black'
       border_line_width: 1
       border_line_alpha: 1.0

--- a/bokehjs/src/coffee/renderer/annotation/poly_annotation.coffee
+++ b/bokehjs/src/coffee/renderer/annotation/poly_annotation.coffee
@@ -67,11 +67,17 @@ class PolyAnnotation extends HasParent
   defaults: () ->
     return _.extend({}, super(), {
       silent_update: false
+      plot: null
       xs: []
       ys: []
+      xs_units: "data"
+      ys_units: "data"
+      x_range_name: "default"
+      y_range_name: "default"
       level: 'annotation'
       fill_color: "#fff9ba"
       fill_alpha: 0.4
+      line_width: 1
       line_color: "#cccccc"
       line_alpha: 0.3
       line_alpha: 0.3

--- a/bokehjs/src/coffee/renderer/annotation/span.coffee
+++ b/bokehjs/src/coffee/renderer/annotation/span.coffee
@@ -1,5 +1,5 @@
 _ = require "underscore"
-HasParent = require "../../common/has_parent"
+Annotation = require "./annotation"
 PlotWidget = require "../../common/plot_widget"
 properties = require "../../common/properties"
 
@@ -81,7 +81,7 @@ class SpanView extends PlotWidget
         vdim = location
       return vdim
 
-class Span extends HasParent
+class Span extends Annotation.Model
   default_view: SpanView
   type: 'Span'
 
@@ -95,11 +95,11 @@ class Span extends HasParent
       y_range_name: "default"
       render_mode: "canvas"
       location_units: "data"
+      level: 'annotation'
     }
 
   display_defaults: ->
     return _.extend {}, super(), {
-      level: 'annotation'
       dimension: "width"
       location: null
       line_color: 'black'

--- a/bokehjs/src/coffee/renderer/annotation/tooltip.coffee
+++ b/bokehjs/src/coffee/renderer/annotation/tooltip.coffee
@@ -1,6 +1,6 @@
 $ = require "jquery"
 _ = require "underscore"
-HasParent = require "../../common/has_parent"
+Annotation = require "./annotation"
 PlotWidget = require "../../common/plot_widget"
 {logger} = require "../../common/logging"
 
@@ -68,7 +68,7 @@ class TooltipView extends PlotWidget
       @$el.css({top: top, left: left})
       @$el.show()
 
-class Tooltip extends HasParent
+class Tooltip extends Annotation.Model
   default_view: TooltipView
   type: 'Tooltip'
 

--- a/bokehjs/src/coffee/renderer/glyph/arc.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/arc.coffee
@@ -35,7 +35,7 @@ class Arc extends Glyph.Model
   angles: ['start_angle', 'end_angle']
   fields: ['direction:direction']
 
-  display_defaults: ->
+  defaults: ->
     return _.extend {}, super(), {
       direction: 'anticlock'
     }

--- a/bokehjs/src/coffee/renderer/glyph/circle.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/circle.coffee
@@ -4,7 +4,7 @@ Glyph = require "./glyph"
 hittest = require "../../common/hittest"
 
 class CircleView extends Glyph.View
- 
+
   _init_gl: (gl) ->
     # This is how you enable gl for a glyph
     @glglyph = new bokehgl.CircleGLGlyph(gl, this)
@@ -215,13 +215,11 @@ class Circle extends Glyph.Model
   distances: ['?radius', '?size']
   fields: ['radius_dimension:string']
 
-  display_defaults: ->
-    return _.extend {}, super(), {
-      size: 4 # XXX: Circle should be a marker, then this wouldn't be necessary.
-    }
-
   defaults: ->
     return _.extend {}, super(), {
+      size: { units: "screen", value: 4 } # marker, some day
+      angle: { units : "rad", value : 0 } # marker, some day
+      radius: null
       radius_dimension: 'x'
     }
 

--- a/bokehjs/src/coffee/renderer/glyph/glyph_renderer.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/glyph_renderer.coffee
@@ -37,7 +37,7 @@ class GlyphRendererView extends PlotWidget
 
     @set_data(false)
 
-    if @mget('data_source') instanceof RemoteDataSource.RemoteDataSource
+    if @mget('data_source') instanceof RemoteDataSource.Model
       @mget('data_source').setup(@plot_view, @glyph)
 
   build_glyph_view: (model) ->

--- a/bokehjs/src/coffee/renderer/glyph/glyph_renderer.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/glyph_renderer.coffee
@@ -72,7 +72,7 @@ class GlyphRendererView extends PlotWidget
 
     @glyph.set_visuals(source)
     @decimated_glyph.set_visuals(source)
-    if @have_selection_glyphs()      
+    if @have_selection_glyphs()
       @selection_glyph.set_visuals(source)
       @nonselection_glyph.set_visuals(source)
     if @hover_glyph?
@@ -221,11 +221,11 @@ class GlyphRenderer extends HasParent
       x_range_name: "default"
       y_range_name: "default"
       data_source: null
-    }
-
-  display_defaults: ->
-    return _.extend {}, super(), {
       level: 'glyph'
+      glyph: null
+      hover_glyph: null
+      nonselection_glyph: null
+      selection_glyph: null
     }
 
 module.exports =

--- a/bokehjs/src/coffee/renderer/glyph/image.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/image.coffee
@@ -1,6 +1,7 @@
 _ = require "underscore"
 Glyph = require "./glyph"
 LinearColorMapper = require "../../mapper/linear_color_mapper"
+{Greys9} = require '../../palettes/palettes'
 
 class ImageView extends Glyph.View
 
@@ -88,9 +89,10 @@ class Image extends Glyph.Model
   distances: ['dw', 'dh']
   fields: ['image:array', '?rows', '?cols']
 
-  display_defaults: ->
+  defaults: ->
     return _.extend {}, super(), {
       dilate: false
+      color_mapper: new LinearColorMapper.Model(palette: Greys9)
     }
 
 module.exports =

--- a/bokehjs/src/coffee/renderer/glyph/image_rgba.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/image_rgba.coffee
@@ -95,6 +95,8 @@ class ImageRGBA extends Glyph.Model
   display_defaults: ->
     return _.extend {}, super(), {
       dilate: false
+      rows: null
+      cols: null
     }
 
 module.exports =

--- a/bokehjs/src/coffee/renderer/glyph/image_url.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/image_url.coffee
@@ -77,7 +77,7 @@ class ImageURLView extends Glyph.View
     if isNaN(sw[i]) then sw[i] = image.width
     if isNaN(sh[i]) then sh[i] = image.height
 
-    anchor = @mget('anchor') or "top_left"
+    anchor = @mget('anchor')
     [sx, sy] = @_final_sx_sy(anchor, sx[i], sy[i], sw[i], sh[i])
 
     ctx.save()
@@ -104,7 +104,9 @@ class ImageURL extends Glyph.Model
 
   defaults: ->
     return _.extend {}, super(), {
+      anchor: "top_left"
       angle: 0
+      dilate: false
       retry_attempts: 0
       retry_timeout: 0
       global_alpha: 1.0

--- a/bokehjs/src/coffee/renderer/glyph/marker/marker.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/marker/marker.coffee
@@ -99,9 +99,9 @@ class Marker extends Glyph.Model
   distances: ['size']
   angles: ['angle']
 
-  display_defaults: ->
+  defaults: ->
     return _.extend {}, super(), {
-      size: 4
+      size: { units: "screen", value: 4 }
       angle: 0
     }
 

--- a/bokehjs/src/coffee/renderer/glyph/text.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/text.coffee
@@ -38,15 +38,15 @@ class Text extends Glyph.Model
   default_view: TextView
   type: 'Text'
   visuals: ['text']
-  distances: ['x_offset', 'y_offset']
   angles: ['angle']
-  fields: ['text:string']
+  fields: ['text:string', 'x_offset', 'y_offset']
 
   defaults: ->
     return _.extend {}, super(), {
       angle: 0
       x_offset: 0
       y_offset: 0
+      text: { field :"text" }
     }
 
 module.exports =

--- a/bokehjs/src/coffee/renderer/guide/axis.coffee
+++ b/bokehjs/src/coffee/renderer/guide/axis.coffee
@@ -1,6 +1,6 @@
 _ = require "underscore"
 kiwi = require "kiwi"
-HasParent = require "../../common/has_parent"
+GuideRenderer = require "./guide_renderer"
 LayoutBox = require "../../common/layout_box"
 {logger} = require "../../common/logging"
 PlotWidget = require "../../common/plot_widget"
@@ -296,7 +296,7 @@ class AxisView extends PlotWidget
     else
       ctx.fillText(label, sx+nx*standoff+nx*xoff, sy+ny*standoff+ny*yoff)
 
-class Axis extends HasParent
+class Axis extends GuideRenderer.Model
   default_view: AxisView
   type: 'Axis'
 
@@ -583,11 +583,11 @@ class Axis extends HasParent
       bounds: "auto"
       x_range_name: "default"
       y_range_name: "default"
+      axis_label: ""
     }
 
   display_defaults: ->
     return _.extend {}, super(), {
-      level: 'overlay'
       visible: true
 
       axis_line_color: 'black'
@@ -628,7 +628,6 @@ class Axis extends HasParent
       major_label_text_align: "center"
       major_label_text_baseline: "alphabetic"
 
-      axis_label: ""
       axis_label_standoff: 5
       axis_label_text_font: "helvetica"
       axis_label_text_font_size: "16pt"

--- a/bokehjs/src/coffee/renderer/guide/categorical_axis.coffee
+++ b/bokehjs/src/coffee/renderer/guide/categorical_axis.coffee
@@ -1,4 +1,7 @@
+_ = require "underscore"
 {logger} = require "../../common/logging"
+CategoricalTicker = require "../../ticking/categorical_ticker"
+CategoricalTickFormatter = require "../../ticking/categorical_tick_formatter"
 Axis = require "./axis"
 
 class CategoricalAxisView extends Axis.View
@@ -7,13 +10,11 @@ class CategoricalAxis extends Axis.Model
   default_view: CategoricalAxisView
   type: 'CategoricalAxis'
 
-  initialize: (attrs, objects) ->
-    super(attrs, objects)
-    Collections = require("../../common/base").Collections
-    if not @get('ticker')?
-      @set_obj('ticker', Collections('CategoricalTicker').create())
-    if not @get('formatter')?
-      @set_obj('formatter', Collections('CategoricalTickFormatter').create())
+  defaults: ->
+    return _.extend {}, super(), {
+      ticker: new CategoricalTicker.Model()
+      formatter: new CategoricalTickFormatter.Model()
+    }
 
   _computed_bounds: () ->
     [range, cross_range] = @get('ranges')

--- a/bokehjs/src/coffee/renderer/guide/continuous_axis.coffee
+++ b/bokehjs/src/coffee/renderer/guide/continuous_axis.coffee
@@ -1,0 +1,7 @@
+Axis = require "./axis"
+
+class ContinuousAxis extends Axis.Model
+  type: 'ContinuousAxis'
+
+module.exports =
+  Model: ContinuousAxis

--- a/bokehjs/src/coffee/renderer/guide/datetime_axis.coffee
+++ b/bokehjs/src/coffee/renderer/guide/datetime_axis.coffee
@@ -11,7 +11,7 @@ class DatetimeAxis extends LinearAxis.Model
 
   defaults: ->
     return _.extend {}, super(), {
-      axis_label: "date"
+      axis_label: ""
       ticker: new DatetimeTicker.Model()
       formatter: new DatetimeTickFormatter.Model()
     }

--- a/bokehjs/src/coffee/renderer/guide/datetime_axis.coffee
+++ b/bokehjs/src/coffee/renderer/guide/datetime_axis.coffee
@@ -1,20 +1,20 @@
-Collections = require("../../common/base").Collections
+_ = require "underscore"
+LinearAxis = require "./axis"
 DatetimeTicker = require "../../ticking/datetime_ticker"
 DatetimeTickFormatter = require "../../ticking/datetime_tick_formatter"
-Axis = require "./axis"
 
-class DatetimeAxisView extends Axis.View
+class DatetimeAxisView extends LinearAxis.View
 
-class DatetimeAxis extends Axis.Model
+class DatetimeAxis extends LinearAxis.Model
   default_view: DatetimeAxisView
   type: 'DatetimeAxis'
 
-  initialize: (attrs, objects) ->
-    super(attrs, objects)
-    if not @get('ticker')?
-      @set_obj('ticker', Collections('DatetimeTicker').create())
-    if not @get('formatter')?
-      @set_obj('formatter', Collections('DatetimeTickFormatter').create())
+  defaults: ->
+    return _.extend {}, super(), {
+      axis_label: "date"
+      ticker: new DatetimeTicker.Model()
+      formatter: new DatetimeTickFormatter.Model()
+    }
 
 module.exports =
   Model: DatetimeAxis

--- a/bokehjs/src/coffee/renderer/guide/grid.coffee
+++ b/bokehjs/src/coffee/renderer/guide/grid.coffee
@@ -1,5 +1,5 @@
 _ = require "underscore"
-HasParent = require "../../common/has_parent"
+GuideRenderer = require "./guide_renderer"
 PlotWidget = require "../../common/plot_widget"
 properties = require "../../common/properties"
 
@@ -63,7 +63,7 @@ class GridView extends PlotWidget
       ctx.stroke()
     return
 
-class Grid extends HasParent
+class Grid extends GuideRenderer.Model
   default_view: GridView
   type: 'Grid'
 
@@ -160,11 +160,11 @@ class Grid extends HasParent
     return _.extend {}, super(), {
       x_range_name: "default"
       y_range_name: "default"
+      level: "underlay"
     }
 
   display_defaults: ->
     return _.extend {}, super(), {
-      level: 'underlay'
       bounds: 'auto'
       dimension: 0
       ticker: null

--- a/bokehjs/src/coffee/renderer/guide/guide_renderer.coffee
+++ b/bokehjs/src/coffee/renderer/guide/guide_renderer.coffee
@@ -1,0 +1,14 @@
+_ = require "underscore"
+HasParent = require "../../common/has_parent"
+
+class GuideRenderer extends HasParent
+  type: 'GuideRenderer'
+
+  defaults: ->
+    return _.extend {}, super(), {
+      plot: null
+      level: "overlay"
+    }
+
+module.exports =
+  Model: GuideRenderer

--- a/bokehjs/src/coffee/renderer/guide/linear_axis.coffee
+++ b/bokehjs/src/coffee/renderer/guide/linear_axis.coffee
@@ -1,18 +1,20 @@
+_ = require "underscore"
 Axis = require "./axis"
+ContinuousAxis = require "./continuous_axis"
+BasicTicker = require "../../ticking/basic_ticker"
+BasicTickFormatter = require "../../ticking/basic_tick_formatter"
 
 class LinearAxisView extends Axis.View
 
-class LinearAxis extends Axis.Model
+class LinearAxis extends ContinuousAxis.Model
   default_view: LinearAxisView
   type: 'LinearAxis'
 
-  initialize: (attrs, objects) ->
-    super(attrs, objects)
-    Collections = require("../../common/base").Collections
-    if not @get('ticker')?
-      @set_obj('ticker', Collections('BasicTicker').create())
-    if not @get('formatter')?
-      @set_obj('formatter', Collections('BasicTickFormatter').create())
+  defaults: ->
+    return _.extend {}, super(), {
+      ticker: new BasicTicker.Model()
+      formatter: new BasicTickFormatter.Model()
+    }
 
 module.exports =
   Model: LinearAxis

--- a/bokehjs/src/coffee/renderer/guide/log_axis.coffee
+++ b/bokehjs/src/coffee/renderer/guide/log_axis.coffee
@@ -1,18 +1,20 @@
+_ = require "underscore"
 Axis = require "./axis"
+ContinuousAxis = require "./continuous_axis"
+LogTicker = require "../../ticking/log_ticker"
+LogTickFormatter = require "../../ticking/log_tick_formatter"
 
 class LogAxisView extends Axis.View
 
-class LogAxis extends Axis.Model
+class LogAxis extends ContinuousAxis.Model
   default_view: LogAxisView
   type: 'LogAxis'
 
-  initialize: (attrs, objects) ->
-    super(attrs, objects)
-    Collections = require("../../common/base").Collections
-    if not @get('ticker')?
-      @set_obj('ticker', Collections('LogTicker').create())
-    if not @get('formatter')?
-      @set_obj('formatter', Collections('LogTickFormatter').create())
+  defaults: ->
+    return _.extend {}, super(), {
+      ticker: new LogTicker.Model()
+      formatter: new LogTickFormatter.Model()
+    }
 
 module.exports =
   Model: LogAxis

--- a/bokehjs/src/coffee/renderer/tile/dynamic_image_renderer.coffee
+++ b/bokehjs/src/coffee/renderer/tile/dynamic_image_renderer.coffee
@@ -107,13 +107,12 @@ class DynamicImageRenderer extends HasParent
   default_view: DynamicImageView
   type: 'DynamicImageRenderer'
   visuals: []
-  angles: ['angle']
 
   defaults: ->
     return _.extend {}, super(), {
-      angle: 0
       alpha: 1.0
-      image_source:undefined
+      image_source: null
+      render_parents: true
     }
 
   display_defaults: ->

--- a/bokehjs/src/coffee/renderer/tile/tile_renderer.coffee
+++ b/bokehjs/src/coffee/renderer/tile/tile_renderer.coffee
@@ -279,11 +279,9 @@ class TileRenderer extends HasParent
   default_view: TileRendererView
   type: 'TileRenderer'
   visuals: []
-  angles: ['angle']
 
   defaults: ->
     return _.extend {}, super(), {
-      angle: 0
       alpha: 1.0
       x_range_name: "default"
       y_range_name: "default"

--- a/bokehjs/src/coffee/source/ajax_data_source.coffee
+++ b/bokehjs/src/coffee/source/ajax_data_source.coffee
@@ -5,7 +5,7 @@ Backbone = require "backbone"
 RemoteDataSource = require "./remote_data_source"
 
 #maybe generalize to ajax data source later?
-class AjaxDataSource extends RemoteDataSource.RemoteDataSource
+class AjaxDataSource extends RemoteDataSource.Model
   type: 'AjaxDataSource'
   destroy : () =>
     if @interval?
@@ -48,6 +48,9 @@ class AjaxDataSource extends RemoteDataSource.RemoteDataSource
   defaults: =>
     return _.extend {}, super(), {
       mode: 'replace'
+      max_size: null
+      method: 'POST'
+      if_modified: false
     }
 
 class AjaxDataSources extends Backbone.Collection

--- a/bokehjs/src/coffee/source/blaze_data_source.coffee
+++ b/bokehjs/src/coffee/source/blaze_data_source.coffee
@@ -5,8 +5,16 @@ Backbone = require "backbone"
 RemoteDataSource = require "./remote_data_source"
 
 
-class BlazeDataSource extends RemoteDataSource.RemoteDataSource
+class BlazeDataSource extends RemoteDataSource.Model
   type: 'BlazeDataSource'
+
+  defaults: =>
+    return _.extend {}, super(), {
+      expr: {}
+      local: null
+      namespace: {}
+    }
+
   destroy : () =>
     if @interval?
       clearInterval(@interval)
@@ -43,9 +51,6 @@ class BlazeDataSource extends RemoteDataSource.RemoteDataSource
 
 class BlazeDataSources extends Backbone.Collection
   model: BlazeDataSource
-  defaults:
-    url : ""
-    expr : null
 
 module.exports =
   Model: BlazeDataSource

--- a/bokehjs/src/coffee/source/column_data_source.coffee
+++ b/bokehjs/src/coffee/source/column_data_source.coffee
@@ -1,19 +1,13 @@
 _ = require "underscore"
-HasProperties = require "../common/has_properties"
+DataSource = require './data_source'
 SelectionManager = require "../common/selection_manager"
 hittest = require "../common/hittest"
 
 # Datasource where the data is defined column-wise, i.e. each key in the
 # the data attribute is a column name, and its value is an array of scalars.
 # Each column should be the same length.
-class ColumnDataSource extends HasProperties
+class ColumnDataSource extends DataSource.Model
   type: 'ColumnDataSource'
-
-  initialize: (options) ->
-    super(options)
-    @listenTo(@, 'change:selected', () =>
-      @get('callback')?.execute(@)
-    )
 
   nonserializable_attribute_names: () ->
     super().concat(['selection_manager', 'inspected'])
@@ -44,7 +38,7 @@ class ColumnDataSource extends HasProperties
     return _.extend {}, super(), {
       data: {}
       selection_manager: new SelectionManager({'source':@})
-      selected: hittest.create_hit_test_result()
+      column_names: []
     }
 
 module.exports =

--- a/bokehjs/src/coffee/source/data_source.coffee
+++ b/bokehjs/src/coffee/source/data_source.coffee
@@ -1,0 +1,21 @@
+_ = require "underscore"
+HasProperties = require "../common/has_properties"
+hittest = require "../common/hittest"
+
+class DataSource extends HasProperties
+  type: 'DataSource'
+
+  defaults: =>
+    return _.extend {}, super(), {
+      selected: hittest.create_hit_test_result()
+      callback: null
+    }
+
+  initialize: (options) ->
+    super(options)
+    @listenTo(@, 'change:selected', () =>
+      @get('callback')?.execute(@)
+    )
+
+module.exports =
+  Model: DataSource

--- a/bokehjs/src/coffee/source/geojson_data_source.coffee
+++ b/bokehjs/src/coffee/source/geojson_data_source.coffee
@@ -1,8 +1,8 @@
 _ = require "underscore"
 {logger} = require "../common/logging"
-DataSource = require "./data_source"
+ColumnDataSource = require "./column_data_source"
 
-class GeoJSONDataSource extends DataSource.Model
+class GeoJSONDataSource extends ColumnDataSource.Model
   type: 'GeoJSONDataSource'
 
   initialize: (options) ->

--- a/bokehjs/src/coffee/source/geojson_data_source.coffee
+++ b/bokehjs/src/coffee/source/geojson_data_source.coffee
@@ -1,11 +1,13 @@
 _ = require "underscore"
 {logger} = require "../common/logging"
-ColumnDataSource = require "./column_data_source"
+DataSource = require "./data_source"
 
-class GeoJSONDataSource extends ColumnDataSource.Model
+class GeoJSONDataSource extends DataSource.Model
+  type: 'GeoJSONDataSource'
 
   initialize: (options) ->
     super(options)
+    @geojson_to_column_data() # this just validates the initial geojson value
     @register_property('data', @geojson_to_column_data, true)
     @add_dependencies('data', this, ['geojson'])
 

--- a/bokehjs/src/coffee/source/remote_data_source.coffee
+++ b/bokehjs/src/coffee/source/remote_data_source.coffee
@@ -1,8 +1,15 @@
 _ = require "underscore"
-Backbone = require "backbone"
-ColumnDataSource = require "./column_data_source"
+DataSource = require "./data_source"
 
-class RemoteDataSource extends ColumnDataSource.Model
+class RemoteDataSource extends DataSource.Model
+  type: 'RemoteDataSource'
+
+  defaults: =>
+    return _.extend {}, super(), {
+      data: {}
+      data_url: null
+      polling_interval: null
+    }
 
 module.exports =
-  RemoteDataSource: RemoteDataSource
+  Model: RemoteDataSource

--- a/bokehjs/src/coffee/ticking/basic_tick_formatter.coffee
+++ b/bokehjs/src/coffee/ticking/basic_tick_formatter.coffee
@@ -1,7 +1,7 @@
 _ = require "underscore"
-HasProperties = require "../common/has_properties"
+TickFormatter = require "./tick_formatter"
 
-class BasicTickFormatter extends HasProperties
+class BasicTickFormatter extends TickFormatter.Model
   type: 'BasicTickFormatter'
 
   initialize: (attrs, options) ->

--- a/bokehjs/src/coffee/ticking/categorical_tick_formatter.coffee
+++ b/bokehjs/src/coffee/ticking/categorical_tick_formatter.coffee
@@ -1,6 +1,6 @@
-HasProperties = require "../common/has_properties"
+TickFormatter = require "./tick_formatter"
 
-class CategoricalTickFormatter extends HasProperties
+class CategoricalTickFormatter extends TickFormatter.Model
   type: 'CategoricalTickFormatter'
 
   format: (ticks) ->

--- a/bokehjs/src/coffee/ticking/datetime_tick_formatter.coffee
+++ b/bokehjs/src/coffee/ticking/datetime_tick_formatter.coffee
@@ -1,7 +1,7 @@
 _ = require "underscore"
 SPrintf = require "sprintf"
 tz = require "timezone"
-HasProperties = require "../common/has_properties"
+TickFormatter = require "./tick_formatter"
 {logger} = require "../common/logging"
 
 _us = (t) ->
@@ -50,7 +50,7 @@ _strftime = (t, format) ->
       return format
     return tz(t, format)
 
-class DatetimeTickFormatter extends HasProperties
+class DatetimeTickFormatter extends TickFormatter.Model
   type: 'DatetimeTickFormatter'
 
   # Labels of time units, from finest to coarsest.

--- a/bokehjs/src/coffee/ticking/log_tick_formatter.coffee
+++ b/bokehjs/src/coffee/ticking/log_tick_formatter.coffee
@@ -2,6 +2,7 @@ _ = require "underscore"
 HasProperties = require "../common/has_properties"
 {logger} = require "../common/logging"
 TickFormatter = require "./tick_formatter"
+BasicTickFormatter = require "./basic_tick_formatter"
 
 class LogTickFormatter extends TickFormatter.Model
   type: 'LogTickFormatter'

--- a/bokehjs/src/coffee/ticking/log_tick_formatter.coffee
+++ b/bokehjs/src/coffee/ticking/log_tick_formatter.coffee
@@ -1,10 +1,15 @@
 _ = require "underscore"
 HasProperties = require "../common/has_properties"
 {logger} = require "../common/logging"
-BasicTickFormatter = require "./basic_tick_formatter"
+TickFormatter = require "./tick_formatter"
 
-class LogTickFormatter extends HasProperties
+class LogTickFormatter extends TickFormatter.Model
   type: 'LogTickFormatter'
+
+  defaults: () ->
+    return _.extend {}, super(), {
+      ticker: null
+    }
 
   initialize: (attrs, options) ->
     super(attrs, options)

--- a/bokehjs/src/coffee/ticking/numeral_tick_formatter.coffee
+++ b/bokehjs/src/coffee/ticking/numeral_tick_formatter.coffee
@@ -1,8 +1,8 @@
 _ = require "underscore"
 Numeral = require "numeral"
-HasProperties = require "../common/has_properties"
+TickFormatter = require "./tick_formatter"
 
-class NumeralTickFormatter extends HasProperties
+class NumeralTickFormatter extends TickFormatter.Model
   type: 'NumeralTickFormatter'
 
   format: (ticks) ->

--- a/bokehjs/src/coffee/ticking/printf_tick_formatter.coffee
+++ b/bokehjs/src/coffee/ticking/printf_tick_formatter.coffee
@@ -1,8 +1,8 @@
 _ = require "underscore"
 SPrintf = require "sprintf"
-HasProperties = require "../common/has_properties"
+TickFormatter = require "./tick_formatter"
 
-class PrintfTickFormatter extends HasProperties
+class PrintfTickFormatter extends TickFormatter.Model
   type: 'PrintfTickFormatter'
 
   format: (ticks) ->

--- a/bokehjs/src/coffee/ticking/tick_formatter.coffee
+++ b/bokehjs/src/coffee/ticking/tick_formatter.coffee
@@ -1,0 +1,8 @@
+_ = require "underscore"
+HasProperties = require "../common/has_properties"
+
+class TickFormatter extends HasProperties
+  type: 'TickFormatter'
+
+module.exports =
+  Model: TickFormatter

--- a/bokehjs/src/coffee/tool/gestures/box_select_tool.coffee
+++ b/bokehjs/src/coffee/tool/gestures/box_select_tool.coffee
@@ -1,5 +1,6 @@
 _ = require "underscore"
 SelectTool = require "./select_tool"
+BoxAnnotation = require "../../renderer/annotation/box_annotation"
 
 class BoxSelectToolView extends SelectTool.View
 
@@ -113,6 +114,20 @@ class BoxSelectTool extends SelectTool.Model
       dimensions: ["width", "height"]
       select_every_mousemove: false
       callback: null
+      overlay: new BoxAnnotation.Model({
+        level: "overlay"
+        render_mode: "css"
+        top_units: "screen"
+        left_units: "screen"
+        bottom_units: "screen"
+        right_units: "screen"
+        fill_color: "lightgrey"
+        fill_alpha: 0.5
+        line_color: "black"
+        line_alpha: 1.0
+        line_width: 2
+        line_dash: [4, 4]
+      })
     })
 
 module.exports =

--- a/bokehjs/src/coffee/tool/gestures/box_zoom_tool.coffee
+++ b/bokehjs/src/coffee/tool/gestures/box_zoom_tool.coffee
@@ -1,5 +1,6 @@
 _ = require "underscore"
 GestureTool = require "./gesture_tool"
+BoxAnnotation = require "../../renderer/annotation/box_annotation"
 
 class BoxZoomToolView extends GestureTool.View
 
@@ -86,6 +87,20 @@ class BoxZoomTool extends GestureTool.Model
   defaults: () ->
     return _.extend({}, super(), {
       dimensions: ["width", "height"]
+      overlay: new BoxAnnotation.Model({
+        level: "overlay"
+        render_mode: "css"
+        top_units: "screen"
+        left_units: "screen"
+        bottom_units: "screen"
+        right_units: "screen"
+        fill_color: "lightgrey"
+        fill_alpha: 0.5
+        line_color: "black"
+        line_alpha: 1.0
+        line_width: 2
+        line_dash: [4, 4]
+      })
     })
 
 module.exports =

--- a/bokehjs/src/coffee/tool/gestures/gesture_tool.coffee
+++ b/bokehjs/src/coffee/tool/gestures/gesture_tool.coffee
@@ -12,7 +12,7 @@ class GestureToolView extends ButtonTool.View
 class GestureTool extends ButtonTool.Model
 
   nonserializable_attribute_names: () ->
-    super().concat(['overlay', 'event_type', 'default_order'])
+    super().concat(['event_type', 'default_order'])
 
   defaults: () ->
     return _.extend({}, super(), {

--- a/bokehjs/src/coffee/tool/gestures/lasso_select_tool.coffee
+++ b/bokehjs/src/coffee/tool/gestures/lasso_select_tool.coffee
@@ -1,5 +1,6 @@
 _ = require "underscore"
 SelectTool = require "./select_tool"
+PolyAnnotation = require "../../renderer/annotation/poly_annotation"
 
 class LassoSelectToolView extends SelectTool.View
 
@@ -78,6 +79,16 @@ class LassoSelectTool extends SelectTool.Model
   defaults: () ->
     return _.extend({}, super(), {
       select_every_mousemove: true
+      overlay: new PolyAnnotation.Model({
+        xs_units: "screen"
+        ys_units: "screen"
+        fill_color: "lightgrey"
+        fill_alpha: 0.5
+        line_color: "black"
+        line_alpha: 1.0
+        line_width: 2
+        line_dash: [4, 4]
+      })
     })
 
 module.exports =

--- a/bokehjs/src/coffee/tool/gestures/poly_select_tool.coffee
+++ b/bokehjs/src/coffee/tool/gestures/poly_select_tool.coffee
@@ -1,5 +1,6 @@
 _ = require "underscore"
 SelectTool = require "./select_tool"
+PolyAnnotation = require "../../renderer/annotation/poly_annotation"
 
 class PolySelectToolView extends SelectTool.View
 
@@ -67,6 +68,20 @@ class PolySelectTool extends SelectTool.Model
   icon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAQCAYAAAAbBi9cAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAABx0RVh0U29mdHdhcmUAQWRvYmUgRmlyZXdvcmtzIENTNui8sowAAAGdSURBVDiNjdO/axRBGMbxT8IiwSBBi4AiBBVRJE3UIqIIilrYLGuxMYo/AimsrNTCWkH/AbFR78Dc5dZiWW3SKQaVaKWlIFEiithooaiIZ7EbPM7b3D0wzLzzvvOdZ5iZviTNmnKN4gE2YSteYjW24A2+Yh/ux1G4uVij2cyXB0V8AYuYwBq8x5Ei/wEH8LNoHRVgWxyFr4v4RUvuScv4ESRpFhTQ/9SPmSTNdpbt1KZhXCsD7cZQj6AB7OqUCDCCTz2C3mF/maNnGOsRtB53y0BD/t1eN32T32pH0HY870ZI0mwMFZwvA73F+AqA4STNduCS3PlSpdbY0F4XFKAfJZA9mMO9OAonl+crtcZcpdaYP3ti4mqro0Py79AKOJqk2TwGMRVH4XTbHqtwpVJrVKv1ZGDZ0SIO4mGSZqNYh2m8wtM4Cr93MPur6E9jY7WenAvkz38pSbO9eIzrcRQe63TUFg3iDz7iIj73Yxa3i4LxOAovr0S4MzPbhzoOYy1GzkzGXwLcxC0sxFH4u4sTUyePN3EDKrXGAk4h/QvU5XGB9rRYawAAAABJRU5ErkJggg=="
   event_type: "tap"
   default_order: 11
+
+  defaults: () ->
+    return _.extend({}, super(), {
+      overlay: new PolyAnnotation.Model({
+        xs_units: "screen"
+        ys_units: "screen"
+        fill_color: "lightgrey"
+        fill_alpha: 0.5
+        line_color: "black"
+        line_alpha: 1.0
+        line_width: 2
+        line_dash: [4, 4]
+      })
+    })
 
   initialize: (attrs, options) ->
     super(attrs, options)

--- a/bokehjs/src/coffee/widget/table_column.coffee
+++ b/bokehjs/src/coffee/widget/table_column.coffee
@@ -1,5 +1,7 @@
 _ = require "underscore"
 HasProperties = require "../common/has_properties"
+CellEditors = require "./cell_formatters"
+CellFormatters = require "./cell_formatters"
 
 class TableColumn extends HasProperties
   type: 'TableColumn'
@@ -10,8 +12,8 @@ class TableColumn extends HasProperties
       field: null
       title: null
       width: 300
-      formatter: null
-      editor: null
+      formatter: new CellFormatters.String.Model()
+      editor: new CellEditors.String.Model()
       sortable: true
       default_sort: "ascending"
     }

--- a/bokehjs/test/test_common/test_defaults.coffee
+++ b/bokehjs/test/test_common/test_defaults.coffee
@@ -33,14 +33,25 @@ check_matching_defaults = (name, python_defaults, coffee_defaults) ->
   python_missing = []
   coffee_missing = []
   for k, v of coffee_defaults
+
+    # special case for date picker, default is "now"
+    if name == 'DatePicker' and k == 'value'
+      continue
+
     if k == 'id'
       continue
+
     if k of python_defaults
       py_v = python_defaults[k]
       if not _.isEqual(py_v, v)
+
+        # these two conditionals compare 'foo' and {value: 'foo'}
         if _.isObject(v) and 'value' of v and _.isEqual(py_v, v['value'])
           continue
+        if _.isObject(py_v) and 'value' of py_v and _.isEqual(py_v['value'], v)
+          continue
 
+        # compare arrays of objects
         if _.isArray(v) and _.isArray(py_v)
           equal = true
 

--- a/bokehjs/test/test_common/test_defaults.coffee
+++ b/bokehjs/test/test_common/test_defaults.coffee
@@ -205,4 +205,4 @@ describe "Defaults", ->
     # then edit this number to be lower. If it's failing because
     # it's higher, fix the newly-introduced errors. Eventually we
     # will get to zero.
-    expect(fail_count).to.equal 12
+    expect(fail_count).to.equal 13

--- a/bokehjs/test/test_common/test_defaults.coffee
+++ b/bokehjs/test/test_common/test_defaults.coffee
@@ -205,4 +205,4 @@ describe "Defaults", ->
     # then edit this number to be lower. If it's failing because
     # it's higher, fix the newly-introduced errors. Eventually we
     # will get to zero.
-    expect(fail_count).to.equal 46
+    expect(fail_count).to.equal 12

--- a/bokehjs/test/test_range/test_datarange1d.coffee
+++ b/bokehjs/test/test_range/test_datarange1d.coffee
@@ -9,7 +9,7 @@ describe "datarange1d module", ->
   describe "default creation", ->
     r = Collections('DataRange1d').create()
 
-    it "should have start = 10", ->
+    it "should have start = 0", ->
       expect(r.get('start')).to.be.equal 0
 
     it "should have end = 1", ->

--- a/examples/plotting/file/geojson_points.py
+++ b/examples/plotting/file/geojson_points.py
@@ -6,7 +6,7 @@ from bokeh.sampledata.sample_geojson import geojson
 
 p = figure()
 
-p.circle(line_color=None, fill_alpha=0.8, size=20,
+p.circle(x='x', y='y', line_color=None, fill_alpha=0.8, size=20,
          source=GeoJSONDataSource(geojson=geojson))
 
 p.add_tools(HoverTool(tooltips=[(


### PR DESCRIPTION
Replaces/finishes #3414 is based on #3416 so shows those commits as well.

ping @mattpap @havocp 

Tested with all server apps and examples. 

Current report:
```
BoxSelectTool: coffee is missing some properties found in Python
    BoxSelectTool.overlay: python defaults to {"attributes":{"bottom":null,"bottom_units":"screen","fill_alpha":{"value":0.5},"fill_color":{"value":"lightgrey"},"left":null,"left_units":"screen","level":"overlay","line_alpha":{"value":1},"line_cap":"butt","line_color":{"value":"black"},"line_dash":[4,4],"line_dash_offset":0,"line_join":"miter","line_width":{"value":2},"name":null,"plot":null,"render_mode":"css","right":null,"right_units":"screen","tags":[],"top":null,"top_units":"screen","x_range_name":"default","y_range_name":"default"},"type":"BoxAnnotation"} but coffee has no such property
BoxZoomTool: coffee is missing some properties found in Python
    BoxZoomTool.overlay: python defaults to {"attributes":{"bottom":null,"bottom_units":"screen","fill_alpha":{"value":0.5},"fill_color":{"value":"lightgrey"},"left":null,"left_units":"screen","level":"overlay","line_alpha":{"value":1},"line_cap":"butt","line_color":{"value":"black"},"line_dash":[4,4],"line_dash_offset":0,"line_join":"miter","line_width":{"value":2},"name":null,"plot":null,"render_mode":"css","right":null,"right_units":"screen","tags":[],"top":null,"top_units":"screen","x_range_name":"default","y_range_name":"default"},"type":"BoxAnnotation"} but coffee has no such property
CategoricalAxis: defaults are out of sync between Python and CoffeeScript
    CategoricalAxis.ticker: coffee defaults to {"type":"CategoricalTicker"} but python defaults to {"attributes":{"name":null,"tags":[]},"type":"CategoricalTicker"}
    CategoricalAxis.formatter: coffee defaults to {"type":"CategoricalTickFormatter"} but python defaults to {"attributes":{"name":null,"tags":[]},"type":"CategoricalTickFormatter"}
DataRange1d: defaults are out of sync between Python and CoffeeScript
    DataRange1d.start: coffee defaults to 0 but python defaults to null
    DataRange1d.end: coffee defaults to 1 but python defaults to null
DatetimeAxis: defaults are out of sync between Python and CoffeeScript
    DatetimeAxis.ticker: coffee defaults to {"type":"DatetimeTicker"} but python defaults to {"attributes":{"desired_num_ticks":6,"name":null,"num_minor_ticks":0,"tags":[],"tickers":[{"id":"2a94e8e7-9695-43b9-a61c-60d63b8d98f8","type":"AdaptiveTicker"},{"id":"61c6e900-1788-4d94-8389-b43b0820da69","type":"AdaptiveTicker"},{"id":"f55d6b89-0b59-4913-ae71-7ba5da208975","type":"AdaptiveTicker"},{"id":"84b9e331-16f1-4b25-80b9-1fefbaaac552","type":"DaysTicker"},{"id":"ce4cd5bd-7fb8-45f5-9265-e530c203fe33","type":"DaysTicker"},{"id":"c9e3d529-9698-4ed6-af7a-066d862c1cf1","type":"DaysTicker"},{"id":"0a803b58-49f2-43c6-845f-e259f5bfab38","type":"DaysTicker"},{"id":"8acf9c96-2e0d-4138-8d7a-dc0dc11338ed","type":"MonthsTicker"},{"id":"93ddfcd4-7b0d-435c-a70a-e69ad98782cd","type":"MonthsTicker"},{"id":"c2f6e6d4-272e-41ab-9fc8-fefcf3501dad","type":"MonthsTicker"},{"id":"75e2b57f-1dac-4f63-a8a8-9791592d4361","type":"MonthsTicker"},{"id":"e48ee58c-fd14-4c20-86a7-cbac270c9d3c","type":"YearsTicker"}]},"type":"DatetimeTicker"}
    DatetimeAxis.formatter: coffee defaults to {"type":"DatetimeTickFormatter"} but python defaults to {"attributes":{"formats":{},"name":null,"tags":[]},"type":"DatetimeTickFormatter"}
GMapPlot: defaults are out of sync between Python and CoffeeScript
    GMapPlot.tool_events: coffee defaults to {"type":"ToolEvents"} but python defaults to {"attributes":{"geometries":[],"name":null,"tags":[]},"type":"ToolEvents"}
Image: defaults are out of sync between Python and CoffeeScript
    Image.color_mapper: coffee defaults to {} but python defaults to {"attributes":{"high":null,"low":null,"name":null,"palette":["#000000","#252525","#525252","#737373","#969696","#bdbdbd","#d9d9d9","#f0f0f0","#ffffff"],"reserve_color":"#ffffff","reserve_val":null,"tags":[]},"type":"LinearColorMapper"}
LassoSelectTool: coffee is missing some properties found in Python
    LassoSelectTool.overlay: python defaults to {"attributes":{"fill_alpha":{"value":0.5},"fill_color":{"value":"lightgrey"},"level":"overlay","line_alpha":{"value":1},"line_cap":"butt","line_color":{"value":"black"},"line_dash":[4,4],"line_dash_offset":0,"line_join":"miter","line_width":{"value":2},"name":null,"plot":null,"tags":[],"x_range_name":"default","xs":[],"xs_units":"screen","y_range_name":"default","ys":[],"ys_units":"screen"},"type":"PolyAnnotation"} but coffee has no such property
Bokeh: LogTickFormatter not configured with a ticker, using default base of 10 (labels will be incorrect if ticker base is not 10)
LogAxis: defaults are out of sync between Python and CoffeeScript
    LogAxis.ticker: coffee defaults to {"type":"LogTicker"} but python defaults to {"attributes":{"base":10,"desired_num_ticks":6,"mantissas":[1,5],"max_interval":null,"min_interval":0,"name":null,"num_minor_ticks":5,"tags":[]},"type":"LogTicker"}
    LogAxis.formatter: coffee defaults to {"type":"LogTickFormatter"} but python defaults to {"attributes":{"name":null,"tags":[],"ticker":null},"type":"LogTickFormatter"}
PolySelectTool: coffee is missing some properties found in Python
    PolySelectTool.overlay: python defaults to {"attributes":{"fill_alpha":{"value":0.5},"fill_color":{"value":"lightgrey"},"level":"overlay","line_alpha":{"value":1},"line_cap":"butt","line_color":{"value":"black"},"line_dash":[4,4],"line_dash_offset":0,"line_join":"miter","line_width":{"value":2},"name":null,"plot":null,"tags":[],"x_range_name":"default","xs":[],"xs_units":"screen","y_range_name":"default","ys":[],"ys_units":"screen"},"type":"PolyAnnotation"} but coffee has no such property
TableColumn: defaults are out of sync between Python and CoffeeScript
    TableColumn.formatter: coffee defaults to {"type":"StringFormatter"} but python defaults to {"attributes":{"font_style":"normal","name":null,"tags":[],"text_align":"left","text_color":null},"type":"StringFormatter"}
    TableColumn.editor: coffee defaults to {"type":"StringFormatter"} but python defaults to {"attributes":{"completions":[],"name":null,"tags":[]},"type":"StringEditor"}
TileRenderer: defaults are out of sync between Python and CoffeeScript
    TileRenderer.tile_source: coffee defaults to {"type":"WMTSTileSource"} but python defaults to {"attributes":{"attribution":"","extra_url_vars":{},"initial_resolution":156543.03392804097,"max_zoom":30,"min_zoom":0,"name":null,"tags":[],"tile_size":256,"url":"","x_origin_offset":20037508.34,"y_origin_offset":20037508.34},"type":"WMTSTileSource"}
Python/Coffee matching defaults problems: 12
```
Recap, things break down like this:
* ~~~`DataRange1d --- messed up because computed props.~~~  fixed in other PR
* Things like: `coffee defaults to {"type":"ToolEvents"} but python defaults to {"attributes":{"geometries":[],"name":null,"tags":[]},"type":"ToolEvents"}`  I am not sure if this is a real problem  with how the instances are being created on the JS side (e.g., `new ToolEvents.Model()`), or if it just some artifact of the testing process. Advice on how to proceed welcomed. 
* Whatever (if anything) is going on with `Image`