### PR TITLE
fix refefences clobbering

### DIFF
--- a/bokehjs/src/coffee/common/document.coffee
+++ b/bokehjs/src/coffee/common/document.coffee
@@ -307,7 +307,8 @@ class Document
 
     # this first pass removes all 'refs' replacing them with real instances
     foreach_depth_first to_update, (instance, attrs, was_new) ->
-      instance.set(attrs)
+      if was_new
+        instance.set(attrs)
 
     # after removing all the refs, we can run the initialize code safely
     foreach_depth_first to_update, (instance, attrs, was_new) ->


### PR DESCRIPTION
only update models from references in a patch-doc message when it is
required, otherwise existing models can get erroneously overwritten

Note: branch against `movies_example` because that demo most easily showed the problem. 
