### PR TITLE
Refactor document callbacks

### DIFF
--- a/bokeh/client/connection.py
+++ b/bokeh/client/connection.py
@@ -125,6 +125,10 @@ class ClientConnection(object):
         return self._url
 
     @property
+    def io_loop(self):
+        return self._loop
+
+    @property
     def connected(self):
         """True if we've connected the websocket and exchanged initial handshake messages."""
         return isinstance(self._state, self.CONNECTED_AFTER_ACK)

--- a/bokeh/client/session.py
+++ b/bokeh/client/session.py
@@ -211,7 +211,7 @@ class ClientSession(object):
         self._connection = ClientConnection(session=self, io_loop=io_loop, websocket_url=websocket_url)
 
         self._current_patch = None
-        self._callbacks = _DocumentCallbackGroup(io_loop)
+        self._callbacks = _DocumentCallbackGroup(self._connection.io_loop)
 
     def _attach_document(self, document):
         self._document = document

--- a/bokeh/client/session.py
+++ b/bokeh/client/session.py
@@ -13,9 +13,9 @@ from bokeh.resources import ( DEFAULT_SERVER_WEBSOCKET_URL,
                               DEFAULT_SERVER_HTTP_URL,
                               server_url_for_websocket_url,
                               _SessionCoordinates )
-from bokeh.document import Document, PeriodicCallback, TimeoutCallback
+from bokeh.document import Document
 from bokeh.util.session_id import generate_session_id
-from bokeh.util.tornado import _AsyncPeriodic
+from bokeh.util.tornado import _DocumentCallbackGroup
 
 DEFAULT_SESSION_ID = "default"
 
@@ -211,52 +211,13 @@ class ClientSession(object):
         self._connection = ClientConnection(session=self, io_loop=io_loop, websocket_url=websocket_url)
 
         self._current_patch = None
-        self._callbacks = {}
+        self._callbacks = _DocumentCallbackGroup(io_loop)
 
     def _attach_document(self, document):
         self._document = document
         self._document.on_change_dispatch_to(self)
 
-        for cb in self._document.session_callbacks:
-            self._add_periodic_callback(cb)
-
-    def _add_periodic_callback(self, callback):
-        ''' Add callback so it can be invoked on a session periodically accordingly to period.
-
-        NOTE: periodic callbacks can only work within a session. It'll take no effect when bokeh output is html or notebook
-
-        '''
-        cb = self._callbacks[callback.id] = _AsyncPeriodic(
-            callback.callback, callback.period, io_loop=self._connection._loop
-        )
-        cb.start()
-
-    def _remove_periodic_callback(self, callback):
-        ''' Remove a callback added earlier with add_periodic_callback()
-
-            Throws an error if the callback wasn't added
-
-        '''
-        self._callbacks.pop(callback.id).stop()
-
-    def _add_timeout_callback(self, callback):
-        ''' Add callback so it can be invoked on a session after timeout
-
-        NOTE: timeout callbacks can only work within a session. It'll take no effect when bokeh output is html or notebook
-
-        '''
-        # IOLoop.call_later takes a delay in seconds
-        cb = self._connection._loop.call_later(callback.timeout/1000.0, callback.callback)
-        self._callbacks[callback.id] = cb
-
-    def _remove_timeout_callback(self, callback):
-        ''' Remove a callback added earlier with _add_timeout_callback()
-
-            Throws an error if the callback wasn't added
-
-        '''
-        cb = self._callbacks.pop(callback.id)
-        self._connection._loop.remove_timeout(cb)
+        self._callbacks.add_session_callbacks(self._document.session_callbacks)
 
     def pull(self):
         """ Pull the server's state and set it as session.document.
@@ -374,6 +335,7 @@ class ClientSession(object):
         '''Called by the ClientConnection we are using to notify us of disconnect'''
         if self._document is not None:
             self._document.remove_on_change(self)
+            self._callbacks.remove_all_callbacks()
 
     def _document_patched(self, event):
 
@@ -395,17 +357,7 @@ class ClientSession(object):
             self._current_patch = None
 
     def _session_callback_added(self, event):
-        if isinstance(event.callback, PeriodicCallback):
-            self._add_periodic_callback(event.callback)
-        elif isinstance(event.callback, TimeoutCallback):
-            self._add_timeout_callback(event.callback)
-        else:
-            raise ValueError("Expected callback of type PeriodicCallback or TimeoutCallback, got: %s" % event.callback)
+        self._callbacks.add_session_callback(event.callback)
 
     def _session_callback_removed(self, event):
-        if isinstance(event.callback, PeriodicCallback):
-            self._remove_periodic_callback(event.callback)
-        elif isinstance(event.callback, TimeoutCallback):
-            self._remove_timeout_callback(event.callback)
-        else:
-            raise ValueError("Expected callback of type PeriodicCallback or TimeoutCallback, got: %s" % event.callback)
+        self._callbacks.remove_session_callback(event.callback)

--- a/bokeh/document.py
+++ b/bokeh/document.py
@@ -139,6 +139,13 @@ class TimeoutCallback(SessionCallback):
     def _copy_with_changed_callback(self, new_callback):
         return TimeoutCallback(self._document, new_callback, self._timeout, self._id)
 
+class NextTickCallback(SessionCallback):
+    def __init__(self, document, callback, id=None):
+        super(NextTickCallback, self).__init__(document, callback, id)
+
+    def _copy_with_changed_callback(self, new_callback):
+        return NextTickCallback(self._document, new_callback, self._id)
+
 class _MultiValuedDict(object):
     """
     This is to store a mapping from keys to multiple values, while avoiding
@@ -789,6 +796,26 @@ class Document(object):
 
     def remove_timeout_callback(self, callback):
         ''' Remove a callback added earlier with add_timeout_callback()
+
+            Throws an error if the callback wasn't added
+
+        '''
+        self._remove_session_callback(callback)
+
+    def add_next_tick_callback(self, callback):
+        ''' Add callback to be invoked once on the next "tick" of the event loop.
+
+        .. note::
+            Next tick callbacks only work within the context of a Bokeh server
+            session. This function will no effect when Bokeh outputs to
+            standalone HTML or Jupyter notebook cells.
+
+        '''
+        cb = NextTickCallback(self, None)
+        return self._add_session_callback(cb, callback, one_shot=True)
+
+    def remove_next_tick_callback(self, callback):
+        ''' Remove a callback added earlier with add_next_tick_callback()
 
             Throws an error if the callback wasn't added
 

--- a/bokeh/tests/test_client_server.py
+++ b/bokeh/tests/test_client_server.py
@@ -447,99 +447,6 @@ class TestClientServer(unittest.TestCase):
             # Clean up global IO state
             reset_output()
 
-    def test_session_periodic_callback(self):
-        application = Application()
-        with ManagedServerLoop(application) as server:
-            doc = document.Document()
-
-            client_session = ClientSession(session_id='test_client_session_callback',
-                                          websocket_url=ws_url(server),
-                                          io_loop=server.io_loop)
-            server_session = ServerSession(session_id='test_server_session_callback',
-                                           document=doc, io_loop=server.io_loop)
-            client_session._attach_document(doc)
-
-            assert len(server_session._callbacks) == 0
-            assert len(client_session._callbacks) == 0
-
-            def cb(): pass
-            callback = doc.add_periodic_callback(cb, 1, 'abc')
-            server_session2 = ServerSession('test_server_session_callback',
-                                            doc, server.io_loop)
-
-            assert server_session2._callbacks
-            assert len(server_session._callbacks) == 1
-            assert len(client_session._callbacks) == 1
-
-            started_callbacks = []
-            for ss in [server_session, server_session2]:
-                iocb = ss._callbacks[callback.id]
-                assert iocb._period == 1
-                assert iocb._loop == server.io_loop
-                assert iocb._started
-                assert not iocb._stopped
-                started_callbacks.append(iocb)
-
-            for ss in [client_session]:
-                iocb = ss._callbacks[callback.id]
-                assert iocb._period == 1
-                assert iocb._loop == server.io_loop
-                assert iocb._started
-                assert not iocb._stopped
-                started_callbacks.append(iocb)
-
-            callback = doc.remove_periodic_callback(cb)
-            assert len(server_session._callbacks) == 0
-            assert len(client_session._callbacks) == 0
-            assert len(server_session._callbacks) == 0
-
-            for iocb in started_callbacks:
-                assert iocb._stopped # server
-
-    def test_session_timeout_callback(self):
-        application = Application()
-        with ManagedServerLoop(application) as server:
-            doc = document.Document()
-
-            client_session = ClientSession(session_id='test_client_session_callback',
-                                          websocket_url=ws_url(server),
-                                          io_loop=server.io_loop)
-            server_session = ServerSession(session_id='test_server_session_callback',
-                                           document=doc, io_loop=server.io_loop)
-            client_session._attach_document(doc)
-
-            assert len(server_session._callbacks) == 0
-            assert len(client_session._callbacks) == 0
-
-            def cb(): pass
-
-            x = server.io_loop.time()
-            callback = doc.add_timeout_callback(cb, 10, 'abc')
-            server_session2 = ServerSession('test_server_session_callback',
-                                            doc, server.io_loop)
-
-            assert server_session2._callbacks
-            assert len(server_session._callbacks) == 1
-            assert len(client_session._callbacks) == 1
-
-            started_callbacks = []
-            for ss in [server_session, client_session, server_session2]:
-                iocb = ss._callbacks[callback.id]
-                assert isinstance(iocb, _Timeout)
-
-                # check that the callback deadline is 10
-                # milliseconds later from when we called
-                # add_timeout_callback (using int to avoid ms
-                # differences between the x definition and the
-                # call)
-                assert abs(int(iocb.deadline) - int(x + 10/1000.0)) < 1e6
-                started_callbacks.append(iocb)
-
-            callback = doc.remove_timeout_callback(cb)
-            assert len(server_session._callbacks) == 0
-            assert len(client_session._callbacks) == 0
-            assert len(server_session._callbacks) == 0
-
     @gen.coroutine
     def async_value(self, value):
         yield gen.moment # this ensures we actually return to the loop
@@ -572,7 +479,42 @@ class TestClientServer(unittest.TestCase):
 
             client_session.loop_until_closed()
 
-            doc.remove_timeout_callback(cb)
+            with (self.assertRaises(ValueError)) as manager:
+                doc.remove_timeout_callback(cb)
+            self.assertTrue('already removed' in repr(manager.exception))
+
+            self.assertDictEqual(dict(a=0, b=1, c=2, d=3, e=4), result.values)
+
+    def test_client_session_timeout_async_added_before_push(self):
+        application = Application()
+        with ManagedServerLoop(application) as server:
+            doc = document.Document()
+
+            result = DictModel()
+            doc.add_root(result)
+
+            @gen.coroutine
+            def cb():
+                result.values['a'] = 0
+                result.values['b'] = yield self.async_value(1)
+                result.values['c'] = yield self.async_value(2)
+                result.values['d'] = yield self.async_value(3)
+                result.values['e'] = yield self.async_value(4)
+                client_session.close()
+                raise gen.Return(5)
+
+            callback = doc.add_timeout_callback(cb, 10)
+
+            client_session = push_session(doc,
+                                          session_id='test_client_session_timeout_async',
+                                          url=url(server),
+                                          io_loop=server.io_loop)
+
+            client_session.loop_until_closed()
+
+            with (self.assertRaises(ValueError)) as manager:
+                doc.remove_timeout_callback(cb)
+            self.assertTrue('already removed' in repr(manager.exception))
 
             self.assertDictEqual(dict(a=0, b=1, c=2, d=3, e=4), result.values)
 
@@ -606,7 +548,9 @@ class TestClientServer(unittest.TestCase):
 
             client_session.loop_until_closed()
 
-            server_session.document.remove_timeout_callback(cb)
+            with (self.assertRaises(ValueError)) as manager:
+                server_session.document.remove_timeout_callback(cb)
+            self.assertTrue('already removed' in repr(manager.exception))
 
             self.assertDictEqual(dict(a=0, b=1, c=2, d=3, e=4), result.values)
 
@@ -634,6 +578,37 @@ class TestClientServer(unittest.TestCase):
                 raise gen.Return(5)
 
             callback = doc.add_periodic_callback(cb, 10)
+
+            client_session.loop_until_closed()
+
+            doc.remove_periodic_callback(cb)
+
+            self.assertDictEqual(dict(a=0, b=1, c=2, d=3, e=4), result.values)
+
+    def test_client_session_periodic_async_added_before_push(self):
+        application = Application()
+        with ManagedServerLoop(application) as server:
+            doc = document.Document()
+
+            result = DictModel()
+            doc.add_root(result)
+
+            @gen.coroutine
+            def cb():
+                result.values['a'] = 0
+                result.values['b'] = yield self.async_value(1)
+                result.values['c'] = yield self.async_value(2)
+                result.values['d'] = yield self.async_value(3)
+                result.values['e'] = yield self.async_value(4)
+                client_session.close()
+                raise gen.Return(5)
+
+            callback = doc.add_periodic_callback(cb, 10)
+
+            client_session = push_session(doc,
+                                          session_id='test_client_session_periodic_async',
+                                          url=url(server),
+                                          io_loop=server.io_loop)
 
             client_session.loop_until_closed()
 

--- a/bokeh/tests/test_document.py
+++ b/bokeh/tests/test_document.py
@@ -378,11 +378,10 @@ class TestDocument(unittest.TestCase):
 
         def cb(): pass
 
-        callback = d.add_periodic_callback(cb, 1, 'abc')
+        callback = d.add_periodic_callback(cb, 1)
         assert len(d.session_callbacks) == len(events) == 1
         assert isinstance(events[0], document.SessionCallbackAdded)
         assert callback == d.session_callbacks[0] == events[0].callback
-        assert callback.id == 'abc'
         assert callback.period == 1
 
         callback = d.remove_periodic_callback(cb)
@@ -404,11 +403,10 @@ class TestDocument(unittest.TestCase):
 
         def cb(): pass
 
-        callback = d.add_timeout_callback(cb, 1, 'abc')
+        callback = d.add_timeout_callback(cb, 1)
         assert len(d.session_callbacks) == len(events) == 1
         assert isinstance(events[0], document.SessionCallbackAdded)
         assert callback == d.session_callbacks[0] == events[0].callback
-        assert callback.id == 'abc'
         assert callback.timeout == 1
 
         callback = d.remove_timeout_callback(cb)

--- a/bokeh/util/tests/test_tornado.py
+++ b/bokeh/util/tests/test_tornado.py
@@ -1,0 +1,261 @@
+from __future__ import absolute_import, print_function
+
+import unittest
+
+from tornado import gen
+from tornado.ioloop import IOLoop
+
+from bokeh.util.tornado import _CallbackGroup
+
+def _make_invocation_counter(loop, stop_after=1):
+    from types import MethodType
+    counter = { 'count' : 0 }
+    def func():
+        counter['count'] += 1
+        if stop_after is not None and counter['count'] >= stop_after:
+            loop.stop()
+    def count(self):
+        return self.counter['count']
+    func.count = MethodType(count, func)
+    func.counter = counter
+    return func
+
+# this is so ctrl+c out of the tests will show the actual
+# error, which pytest otherwise won't do by default
+def run(loop):
+    try:
+        loop.start()
+    except KeyboardInterrupt as e:
+        print("Keyboard interrupt")
+        pass
+
+class LoopAndGroup(object):
+    def __init__(self, quit_after=None):
+        self.io_loop = IOLoop()
+        self.group = _CallbackGroup(self.io_loop)
+
+        if quit_after is not None:
+            self.io_loop.call_later(quit_after / 1000.0,
+                                    lambda: self.io_loop.stop())
+
+    def __exit__(self, type, value, traceback):
+        run(self.io_loop)
+        self.io_loop.close()
+
+    def __enter__(self):
+        return self
+
+class TestCallbackGroup(unittest.TestCase):
+    def test_next_tick_runs(self):
+        with (LoopAndGroup()) as ctx:
+            func = _make_invocation_counter(ctx.io_loop)
+            self.assertEqual(0, len(ctx.group._next_tick_callbacks))
+            ctx.group.add_next_tick_callback(func)
+            self.assertEqual(1, len(ctx.group._next_tick_callbacks))
+        self.assertEqual(1, func.count())
+        # check for leaks
+        self.assertEqual(0, len(ctx.group._next_tick_callbacks))
+
+    def test_timeout_runs(self):
+        with (LoopAndGroup()) as ctx:
+            func = _make_invocation_counter(ctx.io_loop)
+            self.assertEqual(0, len(ctx.group._timeout_callbacks))
+            ctx.group.add_timeout_callback(func, timeout_milliseconds=1)
+            self.assertEqual(1, len(ctx.group._timeout_callbacks))
+        self.assertEqual(1, func.count())
+        # check for leaks
+        self.assertEqual(0, len(ctx.group._timeout_callbacks))
+
+    def test_periodic_runs(self):
+        with (LoopAndGroup()) as ctx:
+            func = _make_invocation_counter(ctx.io_loop, stop_after=5)
+            self.assertEqual(0, len(ctx.group._periodic_callbacks))
+            ctx.group.add_periodic_callback(func, period_milliseconds=1)
+            self.assertEqual(1, len(ctx.group._periodic_callbacks))
+        self.assertEqual(5, func.count())
+        # check for leaks... periodic doesn't self-remove though
+        self.assertEqual(1, len(ctx.group._periodic_callbacks))
+        ctx.group.remove_periodic_callback(func)
+        self.assertEqual(0, len(ctx.group._periodic_callbacks))
+
+    def test_next_tick_does_not_run_if_removed_immediately(self):
+        with (LoopAndGroup(quit_after=15)) as ctx:
+            func = _make_invocation_counter(ctx.io_loop)
+            ctx.group.add_next_tick_callback(func)
+            ctx.group.remove_next_tick_callback(func)
+        self.assertEqual(0, func.count())
+
+    def test_timeout_does_not_run_if_removed_immediately(self):
+        with (LoopAndGroup(quit_after=15)) as ctx:
+            func = _make_invocation_counter(ctx.io_loop)
+            ctx.group.add_timeout_callback(func, timeout_milliseconds=1)
+            ctx.group.remove_timeout_callback(func)
+        self.assertEqual(0, func.count())
+
+    def test_periodic_does_not_run_if_removed_immediately(self):
+        with (LoopAndGroup(quit_after=15)) as ctx:
+            func = _make_invocation_counter(ctx.io_loop, stop_after=5)
+            ctx.group.add_periodic_callback(func, period_milliseconds=1)
+            ctx.group.remove_periodic_callback(func)
+        self.assertEqual(0, func.count())
+
+    def test_next_tick_remove_with_returned_callable(self):
+        with (LoopAndGroup(quit_after=15)) as ctx:
+            func = _make_invocation_counter(ctx.io_loop)
+            remover = ctx.group.add_next_tick_callback(func)
+            remover()
+        self.assertEqual(0, func.count())
+
+    def test_timeout_remove_with_returned_callable(self):
+        with (LoopAndGroup(quit_after=15)) as ctx:
+            func = _make_invocation_counter(ctx.io_loop)
+            remover = ctx.group.add_timeout_callback(func, timeout_milliseconds=1)
+            remover()
+        self.assertEqual(0, func.count())
+
+    def test_periodic_remove_with_returned_callable(self):
+        with (LoopAndGroup(quit_after=15)) as ctx:
+            func = _make_invocation_counter(ctx.io_loop, stop_after=5)
+            remover = ctx.group.add_periodic_callback(func, period_milliseconds=1)
+            remover()
+        self.assertEqual(0, func.count())
+
+    def test_same_callback_as_all_three_types(self):
+        with (LoopAndGroup()) as ctx:
+            func = _make_invocation_counter(ctx.io_loop, stop_after=5)
+            # we want the timeout and next_tick to run before the periodic
+            ctx.group.add_periodic_callback(func, period_milliseconds=2)
+            ctx.group.add_timeout_callback(func, timeout_milliseconds=1)
+            ctx.group.add_next_tick_callback(func)
+        self.assertEqual(5, func.count())
+
+    def test_adding_next_tick_twice(self):
+        with (LoopAndGroup()) as ctx:
+            def func():
+                pass
+            with (self.assertRaises(ValueError)) as manager:
+                ctx.group.add_next_tick_callback(func)
+                ctx.group.add_next_tick_callback(func)
+            ctx.io_loop.add_callback(lambda: ctx.io_loop.stop())
+        self.assertTrue("twice" in repr(manager.exception))
+
+    def test_adding_timeout_twice(self):
+        with (LoopAndGroup()) as ctx:
+            def func():
+                pass
+            with (self.assertRaises(ValueError)) as manager:
+                ctx.group.add_timeout_callback(func, timeout_milliseconds=1)
+                ctx.group.add_timeout_callback(func, timeout_milliseconds=2)
+            ctx.io_loop.add_callback(lambda: ctx.io_loop.stop())
+        self.assertTrue("twice" in repr(manager.exception))
+
+    def test_adding_periodic_twice(self):
+        with (LoopAndGroup()) as ctx:
+            def func():
+                pass
+            with (self.assertRaises(ValueError)) as manager:
+                ctx.group.add_periodic_callback(func, period_milliseconds=1)
+                ctx.group.add_periodic_callback(func, period_milliseconds=2)
+            ctx.io_loop.add_callback(lambda: ctx.io_loop.stop())
+        self.assertTrue("twice" in repr(manager.exception))
+
+    def test_remove_all_callbacks(self):
+        with (LoopAndGroup(quit_after=15)) as ctx:
+            # add a callback that will remove all the others
+            def remove_all():
+                ctx.group.remove_all_callbacks()
+            ctx.group.add_next_tick_callback(remove_all)
+            # none of these should run
+            func = _make_invocation_counter(ctx.io_loop, stop_after=5)
+            ctx.group.add_periodic_callback(func, period_milliseconds=2)
+            ctx.group.add_timeout_callback(func, timeout_milliseconds=1)
+            ctx.group.add_next_tick_callback(func)
+        self.assertEqual(0, func.count())
+
+    def test_removing_next_tick_twice(self):
+        with (LoopAndGroup(quit_after=15)) as ctx:
+            func = _make_invocation_counter(ctx.io_loop)
+            remover = ctx.group.add_next_tick_callback(func)
+            remover()
+            with (self.assertRaises(ValueError)) as manager:
+                remover()
+        self.assertEqual(0, func.count())
+        self.assertTrue("twice" in repr(manager.exception))
+
+    def test_removing_timeout_twice(self):
+        with (LoopAndGroup(quit_after=15)) as ctx:
+            func = _make_invocation_counter(ctx.io_loop)
+            remover = ctx.group.add_timeout_callback(func, timeout_milliseconds=1)
+            remover()
+            with (self.assertRaises(ValueError)) as manager:
+                remover()
+        self.assertEqual(0, func.count())
+        self.assertTrue("twice" in repr(manager.exception))
+
+    def test_removing_periodic_twice(self):
+        with (LoopAndGroup(quit_after=15)) as ctx:
+            func = _make_invocation_counter(ctx.io_loop, stop_after=5)
+            remover = ctx.group.add_periodic_callback(func, period_milliseconds=1)
+            remover()
+            with (self.assertRaises(ValueError)) as manager:
+                remover()
+        self.assertEqual(0, func.count())
+        self.assertTrue("twice" in repr(manager.exception))
+
+    def test_next_tick_cleanup_when_removed(self):
+        result = { 'ok' : False }
+        with (LoopAndGroup(quit_after=15)) as ctx:
+            func = _make_invocation_counter(ctx.io_loop)
+            def cleanup(callback):
+                self.assertIs(callback, func)
+                result['ok'] = True
+            remover = ctx.group.add_next_tick_callback(func, cleanup=cleanup)
+            remover()
+        self.assertEqual(0, func.count())
+        self.assertTrue(result['ok'])
+
+    def test_timeout_cleanup_when_removed(self):
+        result = { 'ok' : False }
+        with (LoopAndGroup(quit_after=15)) as ctx:
+            func = _make_invocation_counter(ctx.io_loop)
+            def cleanup(callback):
+                self.assertIs(callback, func)
+                result['ok'] = True
+            remover = ctx.group.add_timeout_callback(func, timeout_milliseconds=1, cleanup=cleanup)
+            remover()
+        self.assertEqual(0, func.count())
+        self.assertTrue(result['ok'])
+
+    def test_periodic_cleanup_when_removed(self):
+        result = { 'ok' : False }
+        with (LoopAndGroup(quit_after=15)) as ctx:
+            func = _make_invocation_counter(ctx.io_loop, stop_after=5)
+            def cleanup(callback):
+                self.assertIs(callback, func)
+                result['ok'] = True
+            remover = ctx.group.add_periodic_callback(func, period_milliseconds=1, cleanup=cleanup)
+            remover()
+        self.assertEqual(0, func.count())
+        self.assertTrue(result['ok'])
+
+    def test_next_tick_cleanup_when_run(self):
+        result = { 'ok' : False }
+        with (LoopAndGroup()) as ctx:
+            func = _make_invocation_counter(ctx.io_loop)
+            def cleanup(callback):
+                self.assertIs(callback, func)
+                result['ok'] = True
+            ctx.group.add_next_tick_callback(func, cleanup=cleanup)
+        self.assertEqual(1, func.count())
+        self.assertTrue(result['ok'])
+
+    def test_timeout_cleanup_when_run(self):
+        result = { 'ok' : False }
+        with (LoopAndGroup()) as ctx:
+            func = _make_invocation_counter(ctx.io_loop)
+            def cleanup(callback):
+                self.assertIs(callback, func)
+                result['ok'] = True
+            ctx.group.add_timeout_callback(func, timeout_milliseconds=1, cleanup=cleanup)
+        self.assertEqual(1, func.count())
+        self.assertTrue(result['ok'])

--- a/bokeh/util/tornado.py
+++ b/bokeh/util/tornado.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 
 from tornado import gen
 
-from bokeh.document import PeriodicCallback, TimeoutCallback
+from bokeh.document import NextTickCallback, PeriodicCallback, TimeoutCallback
 
 class _AsyncPeriodic(object):
     """Like ioloop.PeriodicCallback except the 'func' can be async and
@@ -190,8 +190,10 @@ class _DocumentCallbackGroup(object):
             remover = self._group.add_periodic_callback(callback.callback, callback.period, cleanup)
         elif isinstance(callback, TimeoutCallback):
             remover = self._group.add_timeout_callback(callback.callback, callback.timeout, cleanup)
+        elif isinstance(callback, NextTickCallback):
+            remover = self._group.add_next_tick_callback(callback.callback, cleanup)
         else:
-            raise ValueError("Expected callback of type PeriodicCallback or TimeoutCallback, got: %s" % event.callback)
+            raise ValueError("Expected callback of type PeriodicCallback, TimeoutCallback, NextTickCallback, got: %s" % event.callback)
         self._removers[callback.id] = remover
 
     def remove_session_callback(self, callback):

--- a/bokeh/util/tornado.py
+++ b/bokeh/util/tornado.py
@@ -63,6 +63,8 @@ class _CallbackGroup(object):
     want to remove as a group. """
 
     def __init__(self, io_loop):
+        if io_loop is None:
+            raise ValueError("must provide an io loop")
         self._loop = io_loop
         # dicts from callback to remove callable. These are
         # separate only because it's allowed to add the same

--- a/bokeh/util/tornado.py
+++ b/bokeh/util/tornado.py
@@ -1,12 +1,14 @@
 """ Internal utils related to Tornado
 
 """
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import logging
 log = logging.getLogger(__name__)
 
 from tornado import gen
+
+from bokeh.document import PeriodicCallback, TimeoutCallback
 
 class _AsyncPeriodic(object):
     """Like ioloop.PeriodicCallback except the 'func' can be async and
@@ -22,15 +24,22 @@ class _AsyncPeriodic(object):
         self._started = False
         self._stopped = False
 
+    # this is like gen.sleep but uses our IOLoop instead of the
+    # current IOLoop
+    def sleep(self):
+        f = gen.Future()
+        self._loop.call_later(self._period / 1000.0, lambda: f.set_result(None))
+        return f
+
     def start(self):
         if self._started:
             raise RuntimeError("called start() twice on _AsyncPeriodic")
         self._started = True
-        def schedule():
+        def invoke():
             # important to start the sleep before starting callback
             # so any initial time spent in callback "counts against"
             # the period.
-            sleep_future = gen.sleep(self._period / 1000.0)
+            sleep_future = self.sleep()
             result = self._func()
             try:
                 callback_future = gen.convert_yielded(result)
@@ -41,10 +50,155 @@ class _AsyncPeriodic(object):
                 return gen.multi([sleep_future, callback_future])
         def on_done(future):
             if not self._stopped:
-                self._loop.add_future(schedule(), on_done)
+                self._loop.add_future(invoke(), on_done)
             if future.exception() is not None:
                 log.error("Error thrown from periodic callback: %r", future.exception())
-        self._loop.add_future(schedule(), on_done)
+        self._loop.add_future(self.sleep(), on_done)
 
     def stop(self):
         self._stopped = True
+
+class _CallbackGroup(object):
+    """ A collection of callbacks added to a Tornado IOLoop that we may
+    want to remove as a group. """
+
+    def __init__(self, io_loop):
+        self._loop = io_loop
+        # dicts from callback to remove callable. These are
+        # separate only because it's allowed to add the same
+        # callback as multiple kinds of callback at once.
+        self._next_tick_callbacks = {}
+        self._timeout_callbacks = {}
+        self._periodic_callbacks = {}
+
+    def remove_all_callbacks(self):
+        """ Removes all registered callbacks."""
+        for cb in list(self._next_tick_callbacks.keys()):
+            self.remove_next_tick_callback(cb)
+        for cb in list(self._timeout_callbacks.keys()):
+            self.remove_timeout_callback(cb)
+        for cb in list(self._periodic_callbacks.keys()):
+            self.remove_periodic_callback(cb)
+
+    def _error_on_double_remove(self, callback, callbacks):
+        if callback not in callbacks:
+            raise ValueError("Removing a callback twice (or after it's already been run)")
+
+    def _remover(self, callback, callbacks, cleanup):
+        self._error_on_double_remove(callback, callbacks)
+        del callbacks[callback]
+        if cleanup is not None:
+            cleanup(callback)
+
+    def _wrap_next_tick(self, callback, cleanup):
+        # this 'removed' flag is a hack because Tornado has no way
+        # to remove a "next tick" callback added with
+        # IOLoop.add_callback. So instead we make our wrapper skip
+        # invoking the callback.
+        handle = { 'removed' : False }
+        def wrapper(*args, **kwargs):
+            was_removed = handle['removed']
+            if not was_removed:
+                self.remove_next_tick_callback(callback)
+                return callback(*args, **kwargs)
+            else:
+                return None
+        wrapper.handle = handle
+        return wrapper
+
+    def add_next_tick_callback(self, callback, cleanup=None):
+        """ Adds a callback to be run on the next tick.
+        Returns a callable that removes the callback if called."""
+        if callback in self._next_tick_callbacks:
+            raise ValueError("Next-tick callback added twice")
+        wrapper = self._wrap_next_tick(callback, cleanup)
+        self._loop.add_callback(wrapper)
+        def remover():
+            wrapper.handle['removed'] = True
+            self._remover(callback, self._next_tick_callbacks, cleanup)
+        self._next_tick_callbacks[callback] = remover
+        return remover
+
+    def _remove(self, callback, callbacks):
+        self._error_on_double_remove(callback, callbacks)
+        callbacks[callback]()
+
+    def remove_next_tick_callback(self, callback):
+        """ Removes a callback added with add_next_tick_callback."""
+        self._remove(callback, self._next_tick_callbacks)
+
+    def _wrap_timeout(self, callback):
+        def wrapper(*args, **kwargs):
+            self.remove_timeout_callback(callback)
+            return callback(*args, **kwargs)
+        return wrapper
+
+    def add_timeout_callback(self, callback, timeout_milliseconds, cleanup=None):
+        """ Adds a callback to be run once after timeout_milliseconds.
+        Returns a callable that removes the callback if called."""
+        if callback in self._timeout_callbacks:
+            raise ValueError("Callback added as a timeout twice")
+        handle = self._loop.call_later(timeout_milliseconds / 1000.0,
+                                       self._wrap_timeout(callback))
+        def remover():
+            self._loop.remove_timeout(handle)
+            self._remover(callback, self._timeout_callbacks, cleanup)
+        self._timeout_callbacks[callback] = remover
+        return remover
+
+    def remove_timeout_callback(self, callback):
+        """ Removes a callback added with add_timeout_callback, before it runs."""
+        self._remove(callback, self._timeout_callbacks)
+
+    def add_periodic_callback(self, callback, period_milliseconds, cleanup=None):
+        """ Adds a callback to be run every period_milliseconds until it is removed."""
+        if callback in self._periodic_callbacks:
+            raise ValueError("Callback added as a periodic callback twice")
+        cb = _AsyncPeriodic(
+            callback, period_milliseconds, io_loop=self._loop
+        )
+        def remover():
+            cb.stop()
+            self._remover(callback, self._periodic_callbacks, cleanup)
+        self._periodic_callbacks[callback] = remover
+        cb.start()
+        return remover
+
+    def remove_periodic_callback(self, callback):
+        """ Removes a callback added with add_periodic_callback."""
+        self._remove(callback, self._periodic_callbacks)
+
+class _DocumentCallbackGroup(object):
+    def __init__(self, io_loop):
+        self._group = _CallbackGroup(io_loop)
+        # from callback ids to removers
+        self._removers = dict()
+
+    def remove_all_callbacks(self):
+        for r in list(self._removers.values()):
+            r()
+
+    def add_session_callbacks(self, callbacks):
+        for cb in callbacks:
+            self.add_session_callback(cb)
+
+    def add_session_callback(self, callback):
+        def cleanup(func):
+            if callback.id in self._removers:
+                del self._removers[callback.id]
+        if isinstance(callback, PeriodicCallback):
+            remover = self._group.add_periodic_callback(callback.callback, callback.period, cleanup)
+        elif isinstance(callback, TimeoutCallback):
+            remover = self._group.add_timeout_callback(callback.callback, callback.timeout, cleanup)
+        else:
+            raise ValueError("Expected callback of type PeriodicCallback or TimeoutCallback, got: %s" % event.callback)
+        self._removers[callback.id] = remover
+
+    def remove_session_callback(self, callback):
+        # we may be called multiple times because of multiple
+        # views on a document - the document has to notify that
+        # the callback was removed even if only one view invoked
+        # it. So we need to silently no-op if we're already
+        # removed.
+        if callback.id in self._removers:
+            self._removers[callback.id]()


### PR DESCRIPTION
This is sort of overkill to fix the two bugs, but it also lays the groundwork for the lifecycle hooks PR because `_CallbackGroup` could be used in that PR for callbacks that don't go with a Document.
Also `_DocumentCallbackGroup.remove_all_callbacks()` will be used in ServerSession in that PR to remove callbacks when a session expires.

But, other than being kind of overkill without seeing the next PR, this PR does stand alone I hope - it fixes a couple of bugs, removes some duplicate code, and adds `Document.add_next_tick_callback`.
