### PR TITLE
turn off sending defaults to BokehJS

### DIFF
--- a/bokeh/charts/chart.py
+++ b/bokeh/charts/chart.py
@@ -127,6 +127,10 @@ class Chart(Plot):
         if tools is not None:
             self._tools = tools
 
+        # TODO (bev) have to force serialization of overriden defaults on subtypes for now
+        self.title_text_font_size = "10pt"
+        self.title_text_font_size = "14pt"
+
         self._glyphs = []
         self._built = False
 

--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -811,7 +811,9 @@ class HasProps(with_metaclass(MetaHasProps, object)):
         if include_defaults:
             keys = self.properties()
         else:
-            keys = self._property_values.keys()
+            keys = set(self._property_values.keys())
+            if self.themed_values():
+                keys |= set(self.themed_values().keys())
 
         for key in keys:
             prop = self.lookup(key)

--- a/bokeh/document.py
+++ b/bokeh/document.py
@@ -496,7 +496,7 @@ class Document(object):
         references_json = []
         for r in references:
             ref = r.ref
-            ref['attributes'] = r._to_json_like(include_defaults=True)
+            ref['attributes'] = r._to_json_like(include_defaults=False)
             references_json.append(ref)
 
         return references_json


### PR DESCRIPTION
Defaults should now all be in sync. We will only send theme values and user-set values to BokehJS.

Let's see how Travis, the report, and some hand testing look. 