### PR TITLE
fix error in snap_back. Now will not request tiles outside of min/max zoom

### DIFF
--- a/bokehjs/src/coffee/renderer/tile/tile_renderer.coffee
+++ b/bokehjs/src/coffee/renderer/tile/tile_renderer.coffee
@@ -222,7 +222,6 @@ class TileRendererView extends PlotWidget
       snap_back = true
 
     if snap_back
-      @plot_model.set({x_range:k})
       @x_range.set(x_range:{start:extent[0], end: extent[2]})
       @y_range.set({start:extent[1], end: extent[3]})
       @extent = extent


### PR DESCRIPTION
bug I discovered while making example.  This logic will probably be replace in the future but at least it won't throw error.  Tiles are now not request beyond min / max zoom.