### PR TITLE
Make Plot use the title_panel from the server if one is provided

### DIFF
--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -56,7 +56,7 @@ def _select_helper(args, kwargs):
     return selector
 
 class LayoutBox(Model):
-    ''' Represents an **on-cavas** layout.
+    ''' Represents an **on-canvas** layout.
 
     '''
 

--- a/bokehjs/src/coffee/common/layout_box.coffee
+++ b/bokehjs/src/coffee/common/layout_box.coffee
@@ -12,9 +12,35 @@ class LayoutBox extends HasProperties
   nonserializable_attribute_names: () ->
     super().concat(['solver', 'layout_location'])
 
+  constructor: (attrs, options) ->
+    @solver = null
+    @_initialized = false
+    super(attrs, options)
+
   initialize: (attrs, options) ->
     super(attrs, options)
+    @_initialized = true
+    @_initialize_if_we_have_solver()
+
+  set: (key, value, options) ->
+    super(key, value, options)
+    @_initialize_if_we_have_solver()
+
+  _initialize_if_we_have_solver: () ->
+    if not @_initialized
+      # if someone sets the solver in the constructor, defer
+      # until we get to initialize
+      return
+
+    if @solver?
+      if @get('solver') != @solver
+          throw new Error("We do not support changing the solver attribute on LayoutBox")
+      # we already initialized
+      return
+
     @solver = @get('solver')
+    if not @solver?
+      return # we don't have one yet
 
     @var_constraints = {}
 

--- a/bokehjs/src/coffee/common/plot.coffee
+++ b/bokehjs/src/coffee/common/plot.coffee
@@ -560,8 +560,10 @@ class Plot extends HasParent
       if box?
         box.set('solver', solver)
       else
-        box = new LayoutBox.Model({ name: name,
-        solver: solver })
+        box = new LayoutBox.Model({
+          name: name,
+          solver: solver
+        })
         list.push(box)
         @set(side, list)
       return box

--- a/bokehjs/src/coffee/common/plot.coffee
+++ b/bokehjs/src/coffee/common/plot.coffee
@@ -550,6 +550,22 @@ class Plot extends HasParent
     logger.debug("Plot initialized")
 
   initialize_layout: (solver) ->
+    existing_or_new_layout = (side, name) =>
+      list = @get(side)
+      box = null
+      for model in list
+        if model.get('name') == name
+          box = model
+          break
+      if box?
+        box.set('solver', solver)
+      else
+        box = new LayoutBox.Model({ name: name,
+        solver: solver })
+        list.push(box)
+        @set(side, list)
+      return box
+
     canvas = @get('canvas')
     frame = new CartesianFrame.Model({
       x_range: @get('x_range'),
@@ -564,11 +580,8 @@ class Plot extends HasParent
 
     # TODO (bev) titles should probably be a proper guide, then they could go
     # on any side, this will do to get the PR merged
-    @title_panel = new LayoutBox.Model({solver: solver})
+    @title_panel = existing_or_new_layout('above', 'title_panel')
     @title_panel._anchor = @title_panel._bottom
-    elts = @get('above')
-    elts.push(@title_panel)
-    @set('above', elts)
 
   add_constraints: (solver) ->
     min_border_top    = @get('min_border_top')


### PR DESCRIPTION
Requires the following changes:
 * modify LayoutBox so the solver can be set post-initialization
 * in Plot, set 'title_panel' name on the LayoutBox, then
   use the name to find an existing LayoutBox if any

Another approach could be to create the layout box on the server
always and then set the solver on it in Plot, but this way is
less of a change perhaps so could be safer during a release
freeze.