### PR TITLE
Fix extra events on initial application load

### DIFF
--- a/bokehjs/src/coffee/common/document.coffee
+++ b/bokehjs/src/coffee/common/document.coffee
@@ -218,14 +218,14 @@ class Document
       for obj in references_json
           obj_id = obj['id']
           obj_type = obj['type']
-          if 'subtype' in obj
-            obj_type = obj['subtype']
           obj_attrs = obj['attributes']
 
           if obj_id of existing_models
             instance = existing_models[obj_id]
           else
             instance = Document._instantiate_object(obj_id, obj_type, obj_attrs)
+            if 'subtype' of obj
+              instance.set_subtype(obj['subtype'])
           references[instance.id] = instance
 
       references

--- a/bokehjs/src/coffee/common/document.coffee
+++ b/bokehjs/src/coffee/common/document.coffee
@@ -385,7 +385,8 @@ class Document
     from_root_ids.sort()
     to_root_ids.sort()
 
-    if _.difference(from_root_ids, to_root_ids).length > 0
+    if _.difference(from_root_ids, to_root_ids).length > 0 or
+       _.difference(to_root_ids, from_root_ids).length > 0
       # this would arise if someone does add_root/remove_root during
       # document deserialization, hopefully they won't ever do so.
       throw new Error("Not implemented: computing add/remove of document roots")

--- a/bokehjs/src/coffee/common/has_properties.coffee
+++ b/bokehjs/src/coffee/common/has_properties.coffee
@@ -265,8 +265,12 @@ class HasProperties extends Backbone.Model
   ref: () ->
     # ### method: HasProperties::ref
     # generates a reference to this model
-    'type': this.type
-    'id': this.id
+    base =
+      'type': this.type
+      'id': this.id
+    if @_subtype?
+      base['subtype'] = @_subtype
+    base
 
   @_is_ref: (arg) ->
     if _.isObject(arg)
@@ -276,6 +280,11 @@ class HasProperties extends Backbone.Model
       if keys.length==3
         return keys[0]=='id' and keys[1]=='subtype' and keys[2]=='type'
     return false
+
+  # we only keep the subtype so we match Python;
+  # only Python cares about this
+  set_subtype: (subtype) ->
+    @_subtype = subtype
 
   # TODO (havocp) I suspect any use of this is broken, because
   # if we're in a Document we should have already resolved refs,

--- a/bokehjs/src/coffee/common/has_properties.coffee
+++ b/bokehjs/src/coffee/common/has_properties.coffee
@@ -39,8 +39,13 @@ class HasProperties extends Backbone.Model
       this.collection = options.collection
     if options.parse
       attrs = this.parse(attrs, options) || {}
-    attrs = _.defaults({}, attrs, _.result(this, 'defaults'))
+    defaults = _.result(this, 'defaults')
+    this.set(defaults, { defaults: true })
+    this._set_after_defaults = {}
     this.set(attrs, options)
+
+    # this is maintained by backbone ("changes since the last
+    # set()") and probably isn't relevant to us
     this.changed = {}
 
     ## bokeh custom constructor code
@@ -120,6 +125,8 @@ class HasProperties extends Backbone.Model
       attrs[key] = value
     toremove  = []
     for own key, val of attrs
+      if not (options? and options.defaults)
+        @_set_after_defaults[key] = true
       if _.has(this, 'properties') and
          _.has(@properties, key) and
          @properties[key]['setter']
@@ -395,17 +402,22 @@ class HasProperties extends Backbone.Model
   # are included as just references)
   # TODO (havocp) can this just be toJSON (from Backbone / JSON.stingify?)
   # backbone will have implemented a toJSON already that we may need to override
-  attributes_as_json: () ->
-    # TODO remove serializable_in_document and this check once we aren't seeing these
-    # warnings anymore
+  attributes_as_json: (include_defaults=true) ->
+    attrs = {}
     fail = false
     for own key, value of @serializable_attributes()
+      if include_defaults
+        attrs[key] = value
+      else if key of @_set_after_defaults
+        attrs[key] = value
+      # TODO remove serializable_in_document and this check once we aren't seeing these
+      # warnings anymore
       if value instanceof HasProperties and not value.serializable_in_document()
         console.log("May need to add #{key} to nonserializable_attribute_names of #{@.constructor.name} because value #{value.constructor.name} is not serializable")
         fail = true
     if fail
       return {}
-    HasProperties._value_to_json("attributes", @serializable_attributes(), @)
+    HasProperties._value_to_json("attributes", attrs, @)
 
   # this is like _value_record_references but expects to find refs
   # instead of models, and takes a doc to look up the refs in


### PR DESCRIPTION
Fixes #3479 

This is not the safest patch on earth, but without it we send a ton of extra events on application load, which is a performance problem and also makes it pretty hard to debug anything else that's going wrong on application load.

Careful review/test probably a good idea...
