### PR TITLE
Fix tracking of _all_models with list-of-instance properties

### DIFF
--- a/bokehjs/src/coffee/common/has_properties.coffee
+++ b/bokehjs/src/coffee/common/has_properties.coffee
@@ -423,12 +423,10 @@ class HasProperties extends Backbone.Model
     else if v instanceof HasProperties
       if v.id not of result
         result[v.id] = v
-        attrs = v.serializable_attributes()
-        for key of attrs
-          value = attrs[key]
-          if value instanceof HasProperties and not value.serializable_in_document()
-            console.log("May need to add #{key} to nonserializable_attribute_names of #{v.constructor.name} because value #{value.constructor.name} is not serializable")
-          HasProperties._value_record_references(value, result, recurse)
+        if recurse
+          immediate = v._immediate_references()
+          for obj in immediate
+            HasProperties._value_record_references(obj, result, true) # true=recurse
     else if _.isArray(v)
       for elem in v
         if elem instanceof HasProperties and not elem.serializable_in_document()
@@ -446,8 +444,13 @@ class HasProperties extends Backbone.Model
   # (do not recurse, do not include ourselves)
   _immediate_references: () ->
     result = {}
-    HasProperties._value_record_references(@, result, false) # false = no recurse
-    delete result[@id]
+    attrs = @serializable_attributes()
+    for key of attrs
+      value = attrs[key]
+      if value instanceof HasProperties and not value.serializable_in_document()
+          console.log("May need to add #{key} to nonserializable_attribute_names of #{v.constructor.name} because value #{value.constructor.name} is not serializable")
+      HasProperties._value_record_references(value, result, false) # false = no recurse
+
     _.values(result)
 
   attach_document: (doc) ->
@@ -469,6 +472,8 @@ class HasProperties extends Backbone.Model
           c.detach_document()
 
   _tell_document_about_change: (attr, old, new_) ->
+    if attr == 'children'
+      console.log("changing children on ", @id)
     if not @attribute_is_serializable(attr)
       return
 
@@ -484,16 +489,10 @@ class HasProperties extends Backbone.Model
 
     if @document != null
       new_refs = {}
-      if new_ instanceof HasProperties
-        new_refs[new_.id] = new_
-      else
-        HasProperties._value_record_references(new_, new_refs, false)
+      HasProperties._value_record_references(new_, new_refs, false)
 
       old_refs = {}
-      if old instanceof HasProperties
-        old_refs[old.id] = old
-      else
-        HasProperties._value_record_references(old, old_refs, false)
+      HasProperties._value_record_references(old, old_refs, false)
 
       for new_id, new_ref of new_refs
         if new_id not of old_refs

--- a/bokehjs/test/test_common/test_document.coffee
+++ b/bokehjs/test/test_common/test_document.coffee
@@ -271,6 +271,31 @@ describe "Document", ->
     root1.set('child', child1)
     expect(_.size(d._all_models)).to.equal 3
 
+  it "can have all_models with cycles through lists", ->
+    d = new Document()
+    expect(d.roots().length).to.equal 0
+    expect(_.size(d._all_models)).to.equal 0
+
+    root1 = new SomeModelWithChildren()
+    root2 = new SomeModelWithChildren()
+    child1 = new SomeModelWithChildren()
+    root1.set('children', [child1])
+    root2.set('children', [child1])
+    child1.set('children', [root1])
+    d.add_root(root1)
+    d.add_root(root2)
+    expect(d.roots().length).to.equal 2
+    expect(_.size(d._all_models)).to.equal 3
+
+    root1.set('children', [])
+    expect(_.size(d._all_models)).to.equal 3
+
+    root2.set('children', [])
+    expect(_.size(d._all_models)).to.equal 2
+
+    root1.set('children', [child1])
+    expect(_.size(d._all_models)).to.equal 3
+
   it "can notify on changes", ->
     d = new Document()
     expect(d.roots().length).to.equal 0


### PR DESCRIPTION
The issue here was that HasProperties._value_record_references
ignored its 'recurse' flag which led to bogus behavior when
_tell_document_about_change tried to do its attach_document
and detach_document.

This fixes #3361, where for Plot.renderers in particular, we
thought the new Span was already in the document, because
_value_record_references was messed up and recursed too far.

In the long run, a better fix would be to port the way we do
_all_models in Python (constantly reconstructing it from scratch),
because the way we do it in Coffee cannot avoid leaks when there
are cycles. However, with this fix we avoid failing to include
models in _all_models that should be there. In memory management
terms we're replacing an early free (memory corruption) with
a leak.

The test case added here triggers the bug which was fixed, and
illustrates it in a simpler scenario than #3361.