### PR TITLE
fix selection clear calling nonexistent method

### DIFF
--- a/bokehjs/src/coffee/common/selection_manager.coffee
+++ b/bokehjs/src/coffee/common/selection_manager.coffee
@@ -14,11 +14,6 @@ class SelectionManager extends HasProperties
 
   serializable_in_document: () -> false
 
-  set_selection: (indices) ->
-    @_save_indices(indices)
-    source = @get('source')
-    source.trigger('select')
-
   select: (tool, renderer_view, geometry, final, append=false) ->
     source = @get('source')
     if source != renderer_view.mget('data_source')
@@ -63,7 +58,7 @@ class SelectionManager extends HasProperties
     else
       for k, s of @selectors
         s.clear()
-    @_save_indices(hittest.create_hit_test_result())
+    @get('source').set({ "selected": hittest.create_hit_test_result()})
 
   _get_selector: (rview) ->
     _.setdefault(@selectors, rview.model.id, new Selector())


### PR DESCRIPTION
The problem was `clear` calling a method to set the indices that used to exist, but no longer exists. Obviously a test would have helped here. Adding more unit tests for BokehJS after `0.11` a high priority. 

This PR also removes the completely unused `set_selection` method. Proof:
```
bryan@0199-bryanv (git:master) ~/work/bokeh/bokehjs/src/coffee $ grin set_selection
bryan@0199-bryanv (git:master) ~/work/bokeh/bokehjs/src/coffee $ 
```

Tested with standalone and server apps for correct behaviour. 