### PR TITLE
fix 'over-render' due to hover inspections

### DIFF
--- a/bokehjs/src/coffee/common/selection_manager.coffee
+++ b/bokehjs/src/coffee/common/selection_manager.coffee
@@ -11,6 +11,8 @@ class SelectionManager extends HasProperties
     super(attrs, options)
     @selectors = {}
     @inspectors = {}
+    @empty = hittest.create_hit_test_result()
+    @last_inspection_was_empty = false
 
   serializable_in_document: () -> false
 
@@ -43,6 +45,15 @@ class SelectionManager extends HasProperties
     indices = renderer_view.hit_test(geometry)
 
     if indices?
+
+      if _.isEqual(indices, @empty)
+        if @last_inspection_was_empty
+          return
+        else
+          @last_inspection_was_empty = true
+      else
+        @last_inspection_was_empty = false
+
       inspector = @_get_inspector(renderer_view)
       inspector.update(indices, true, false, true)
 

--- a/bokehjs/src/coffee/renderer/glyph/glyph_renderer.coffee
+++ b/bokehjs/src/coffee/renderer/glyph/glyph_renderer.coffee
@@ -47,7 +47,8 @@ class GlyphRendererView extends PlotWidget
     @listenTo(@model, 'change', @request_render)
     @listenTo(@mget('data_source'), 'change', @set_data)
     @listenTo(@mget('data_source'), 'select', @request_render)
-    @listenTo(@mget('data_source'), 'inspect', @request_render)
+    if @hover_glyph?
+      @listenTo(@mget('data_source'), 'inspect', @request_render)
 
     # TODO (bev) This is a quick change that  allows the plot to be
     # update/re-rendered when properties change on the JS side. It would


### PR DESCRIPTION
issues: fixes #3467 

@birdsarah this was a pretty simple one: we added a `request_render` on `inspect` events. But the code that triggered `inspect` events was mistakenly looking for `null` to indicate no hits, not an "empty" selection object. So it was triggering every hit-test, even if there was no result. 

There's a slight complication in that we do need to trigger the *first* empty inspection, so e.g., that hover tools turn off when they are supposed to. 

This stops all the over-rendering. I will say it did not improved the `texas.py` hover as much as I thought maybe it should. There is still a slight lag, but maybe there always was, and I am just imagining that it was better. In any case, I do think this should be merged. I tested it behaving correctly with every hover and hover glyph example, including server ones. 