### PR TITLE
Make bokeh.js set window.Bokeh not only Bokeh in current scope

### DIFF
--- a/bokehjs/gulp/tasks/scripts.coffee
+++ b/bokehjs/gulp/tasks/scripts.coffee
@@ -196,7 +196,7 @@ gulp.task "scripts:build", ["scripts:compile"], (cb) ->
       .pipe change (content) ->
         "(function() { var define = undefined; return #{content} })()"
       .pipe change (content) ->
-        "Bokeh = #{content}"
+        "window.Bokeh = Bokeh = #{content}"
       .pipe(insert.append(license))
       .pipe(sourcemaps.write('./'))
       .pipe(gulp.dest(paths.buildDir.js))


### PR DESCRIPTION
Possible fix for #3500, though I'm not very confident and am not sure I really understand the issue.
