### PR TITLE
Async load fix

### DIFF
--- a/bokeh/core/_templates/autoload_js.js
+++ b/bokeh/core/_templates/autoload_js.js
@@ -21,10 +21,10 @@ calls it with the rendered model.
 :type bootstrap_js: str
 
 #}
+
+{{ bootstrap_js }}
+
 (function(global) {
-
-  {{ bootstrap_js }}
-
   var elt = document.getElementById("{{ elementid }}");
   if(elt==null) {
     console.log("Bokeh: ERROR: autoload.js configured with elementid '{{ elementid }}' but no matching script tag was found. ")

--- a/bokeh/core/_templates/bootstrap_js.js
+++ b/bokeh/core/_templates/bootstrap_js.js
@@ -1,0 +1,67 @@
+{#
+Bootstraps the Bokeh library by defining a function ``bokeh_load()``.
+
+``bokeh_load()`` accepts a callback parameter, loads Bokeh, and then
+runs the callback. When the callback runs, ``window.Bokeh`` will
+be defined.
+
+:param js_urls: URLs of JS files making up Bokeh library
+:type js_urls: list
+
+:param css_files: CSS files to inject
+:type css_files: list
+
+#}
+(function(global) {
+  if (typeof (window._bokeh_onload_callbacks) === "undefined"){
+    window._bokeh_onload_callbacks = [];
+  }
+  if (typeof(window.bokeh_load) === 'undefined') {
+    window.bokeh_load = function(callback) {
+      {% if js_urls -%}
+      var js_urls = {{ js_urls }};
+      {%- else %}
+      var js_urls = [];
+      {%- endif %}
+      // in the INLINE case, js_urls has zero length
+      if (js_urls.length === 0 ||
+          (typeof(window._bokeh_is_loading) !== undefined && window._bokeh_is_loading == 0)) {
+        console.log("Bokeh: BokehJS has already been loaded, scheduling callback for next tick.");
+        // we setTimeout rather than callback() due to
+        // http://blog.ometer.com/2011/07/24/callbacks-synchronous-and-asynchronous/
+        setTimeout(callback);
+        return;
+      }
+      window._bokeh_onload_callbacks.push(callback);
+      if (window._bokeh_is_loading > 0) {
+        console.log("Bokeh: BokehJS is being loaded, scheduled callback for post-load");
+        return null;
+      }
+      console.log("Bokeh: BokehJS not loaded, scheduling load and callback");
+      window._bokeh_is_loading = js_urls.length;
+      for (i = 0; i < js_urls.length; i++) {
+        var url = js_urls[i];
+        var s = document.createElement('script');
+        s.src = url;
+        s.async = false;
+        s.onreadystatechange = s.onload = function() {
+          window._bokeh_is_loading--;
+          if (window._bokeh_is_loading === 0) {
+            console.log("Bokeh: all BokehJS libraries loaded");
+            {%- for file in css_files %}
+            console.log("Bokeh: injecting CSS: {{ file }}");
+            Bokeh.embed.inject_css("{{ file }}");
+            {%- endfor %}
+            window._bokeh_onload_callbacks.forEach(function(callback){callback()});
+            delete window._bokeh_onload_callbacks
+          }
+        };
+        s.onerror = function() {
+          console.warn("failed to load library " + url);
+        };
+        console.log("Bokeh: injecting script tag for BokehJS library: ", url);
+        document.getElementsByTagName("head")[0].appendChild(s);
+      }
+    };
+  }
+}(this));

--- a/bokeh/core/_templates/doc_js.js
+++ b/bokeh/core/_templates/doc_js.js
@@ -1,4 +1,8 @@
 var docs_json = {{ docs_json }};
 var render_items = {{ render_items }};
 
-Bokeh.embed.embed_items(docs_json, render_items{%- if websocket_url -%}, "{{ websocket_url }}" {%- endif -%});
+bokeh_load(function() {
+  Bokeh.$(function() {
+    Bokeh.embed.embed_items(docs_json, render_items{%- if websocket_url -%}, "{{ websocket_url }}" {%- endif -%});
+  });
+});

--- a/bokeh/core/_templates/js_resources.html
+++ b/bokeh/core/_templates/js_resources.html
@@ -10,7 +10,7 @@ configuration in a Resources object.
 
 #}
 
-<script type="text/javascript"">
+<script type="text/javascript">
     {{ bootstrap_js|indent(8) }}
 </script>
 

--- a/bokeh/core/_templates/js_resources.html
+++ b/bokeh/core/_templates/js_resources.html
@@ -2,19 +2,22 @@
 Renders HTML that loads BokehJS JavaScript code and CSS according to the
 configuration in a Resources object.
 
-:param js_files: a list of URIs for JS files to include
-:type js_files: list[str]
+:param bootstrap_js: JS to define window.bokeh_load
+:type bootstrap_js: str
 
-:param js_raw: a list of raw JS snippets to put between ``<style>`` tags
+:param js_raw: a list of raw JS snippets to put between ``<script>`` tags
 :type js_raw: list[str]
 
 #}
-{%- for file in js_files %}
-<script type="text/javascript" src="{{ file }}"></script>
-{%- endfor %}
+
+<script type="text/javascript"">
+    {{ bootstrap_js|indent(8) }}
+</script>
 
 {%- for js in js_raw %}
 <script type="text/javascript">
+bokeh_load(function() {
     {{ js|indent(8) }}
+});
 </script>
 {%- endfor %}

--- a/bokeh/core/_templates/js_resources.html
+++ b/bokeh/core/_templates/js_resources.html
@@ -16,8 +16,6 @@ configuration in a Resources object.
 
 {%- for js in js_raw %}
 <script type="text/javascript">
-bokeh_load(function() {
     {{ js|indent(8) }}
-});
 </script>
 {%- endfor %}

--- a/bokeh/core/_templates/notebook_load.html
+++ b/bokeh/core/_templates/notebook_load.html
@@ -30,8 +30,13 @@ Notebook according to a Resources object.
     {%- if not hide_banner %}
     <div>
         <a href="http://bokeh.pydata.org" target="_blank" class="bk-logo bk-logo-small bk-logo-notebook"></a>
-        <span>BokehJS successfully loaded.</span>
+        <span class="bokeh-load-status">Loading Bokeh's JavaScript...</span>
     </div>
+    <script type="text/javascript">
+        bokeh_load(function() {
+          Bokeh.$('.bokeh-load-status').text("Successfully loaded Bokeh's JavaScript.")
+        });
+    </script>
 
     {%- if verbose %}
     <style>

--- a/bokeh/core/templates.py
+++ b/bokeh/core/templates.py
@@ -3,6 +3,7 @@ Bokeh models (e.g. plots, widgets, layouts) in various ways.
 
 .. bokeh-jinja:: bokeh.core.templates.AUTOLOAD_JS
 .. bokeh-jinja:: bokeh.core.templates.AUTOLOAD_TAG
+.. bokeh-jinja:: bokeh.core.templates.BOOTSTRAP_JS
 .. bokeh-jinja:: bokeh.core.templates.CSS_RESOURCES
 .. bokeh-jinja:: bokeh.core.templates.DOC_JS
 .. bokeh-jinja:: bokeh.core.templates.FILE
@@ -35,3 +36,5 @@ NOTEBOOK_DIV = _env.get_template("notebook_div.html")
 
 AUTOLOAD_JS = _env.get_template("autoload_js.js")
 AUTOLOAD_TAG = _env.get_template("autoload_tag.html")
+
+BOOTSTRAP_JS = _env.get_template("bootstrap_js.js")

--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -371,7 +371,11 @@ class JSResources(BaseResources):
         _, raw = self._resolve('js')
 
         if self.log_level is not None:
-            raw.append('Bokeh.set_log_level("%s");' % self.log_level)
+            raw.append('''
+bokeh_load(function() {
+  Bokeh.set_log_level("%s");
+});
+''' % self.log_level)
 
         custom_models = self._render_custom_models_static()
         if custom_models is not None:
@@ -382,7 +386,7 @@ class JSResources(BaseResources):
     _plugin_template = \
 """
 (function outer(modules, cache, entry) {
-  if (Bokeh) {
+  bokeh_load(function() {
     for (var name in modules) {
       var module = modules[name];
 
@@ -409,9 +413,7 @@ class JSResources(BaseResources):
     for (var i = 0; i < entry.length; i++) {
       Bokeh.Collections.register_locations(Bokeh.require(entry[i]));
     }
-  } else {
-    throw new Error("Cannot find Bokeh. You have to load it prior to loading plugins.");
-  }
+  });
 })({
  "custom/main":[function(require,module,exports){
    module.exports = { %(exports)s };

--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -20,7 +20,7 @@ from os.path import basename, join, relpath
 import re
 
 from . import __version__
-from .core.templates import JS_RESOURCES, CSS_RESOURCES
+from .core.templates import JS_RESOURCES, CSS_RESOURCES, BOOTSTRAP_JS
 from .settings import settings
 
 from .util.paths import bokehjsdir
@@ -467,7 +467,8 @@ class JSResources(BaseResources):
         return self._plugin_template % dict(exports=exports, models=models)
 
     def render_js(self):
-        return JS_RESOURCES.render(js_raw=self.js_raw, js_files=self.js_files)
+        bootstrap_js = BOOTSTRAP_JS.render(js_urls=self.js_files, css_files=[])
+        return JS_RESOURCES.render(bootstrap_js=bootstrap_js, js_raw=self.js_raw)
 
 class CSSResources(BaseResources):
     ''' The CSSResources class encapsulates information relating to loading or embedding Bokeh client-side CSS.

--- a/bokeh/server/views/autoload_js_handler.py
+++ b/bokeh/server/views/autoload_js_handler.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 from tornado import gen
 from tornado.web import RequestHandler
 
-from bokeh.core.templates import AUTOLOAD_JS
+from bokeh.core.templates import AUTOLOAD_JS, BOOTSTRAP_JS
 from bokeh.util.string import encode_utf8
 
 from .session_handler import SessionHandler
@@ -36,10 +36,14 @@ class AutoloadJsHandler(SessionHandler):
         resources = self.application.resources(self.request)
         websocket_url = self.application.websocket_url_for_request(self.request, self.bokeh_websocket_path)
 
+        bootstrap_js = BOOTSTRAP_JS.render(
+            js_urls = resources.js_files,
+            css_files = resources.css_files
+        )
+
         js = AUTOLOAD_JS.render(
             docs_json = None,
-            js_urls = resources.js_files,
-            css_files = resources.css_files,
+            bootstrap_js = bootstrap_js,
             elementid = element_id,
             sessionid = session.id,
             websocket_url = websocket_url

--- a/bokeh/tests/test_embed.py
+++ b/bokeh/tests/test_embed.py
@@ -98,8 +98,9 @@ class TestNotebookDiv(unittest.TestCase):
         r = embed.notebook_div(_embed_test_plot)
         html = bs4.BeautifulSoup(r)
         scripts = html.findAll(name='script')
-        self.assertEqual(len(scripts), 1)
+        self.assertEqual(len(scripts), 2)
         self.assertTrue(scripts[0].attrs, {'type': 'text/javascript'})
+        self.assertTrue(scripts[1].attrs, {'type': 'text/javascript'})
 
     def test_div_attrs(self):
         r = embed.notebook_div(_embed_test_plot)

--- a/bokeh/tests/test_resources.py
+++ b/bokeh/tests/test_resources.py
@@ -26,7 +26,7 @@ Bokeh.set_log_level("info");
 
 LOG_LEVELS = ['trace', 'debug', 'info', 'warn', 'error', 'fatal']
 
-DEFAULT_LOG_JS_RAW = 'Bokeh.set_log_level("info");'
+DEFAULT_LOG_JS_RAW = '\nbokeh_load(function() {\n  Bokeh.set_log_level("info");\n});\n'
 
 
 ## Test JSResources
@@ -87,7 +87,7 @@ class TestResources(unittest.TestCase):
             r.log_level = level
             self.assertEqual(r.log_level, level)
             if not r.dev:
-                self.assertEqual(r.js_raw[-1], 'Bokeh.set_log_level("%s");' % level)
+                self.assertEqual(r.js_raw[-1], DEFAULT_LOG_JS_RAW.replace("info", level))
         self.assertRaises(ValueError, setattr, r, "log_level", "foo")
 
     def test_module_attrs(self):


### PR DESCRIPTION
An attempt to fix #3500 

This is kind of a risky change. I changed how Bokeh works always, not only for notebooks, because it ended up seeming trickier to think about doing it only for notebooks and I was less confident in that.

Supposed to work in IE10 and above: http://caniuse.com/#feat=script-async

The essence of the change is that now you should NEVER assume "Bokeh" exists unless you are wrapped in `bokeh_load` like `bokeh_load(function() { Bokeh.foo })`.

I just realized I didn't test the autoload stuff yet, so it's probably hosed. Let's get travis going on this as-is though.

