### PR TITLE
Add some more Host and Origin tests

### DIFF
--- a/bokeh/server/tests/utils.py
+++ b/bokeh/server/tests/utils.py
@@ -11,7 +11,7 @@ def url(server, prefix=""):
 def ws_url(server, prefix=""):
     return "ws://localhost:" + str(server._port) + prefix + "/ws"
 
-def http_get(io_loop, url):
+def http_get(io_loop, url, host=None):
     result = {}
     def handle_request(response):
         result['response'] = response
@@ -20,7 +20,10 @@ def http_get(io_loop, url):
     # for some reason passing a loop to AsyncHTTPClient is deprecated
     assert io_loop is IOLoop.current()
     http_client = AsyncHTTPClient()
-    http_client.fetch(url, handle_request)
+    headers = dict()
+    if host is not None:
+        headers['Host'] = host
+    http_client.fetch(url, handle_request, headers=headers)
     io_loop.start()
 
     if 'response' not in result:
@@ -31,7 +34,7 @@ def http_get(io_loop, url):
     else:
         return response
 
-def websocket_open(io_loop, url, origin=None):
+def websocket_open(io_loop, url, origin=None, host=None):
     result = {}
     def handle_connection(future):
         result['connection'] = future
@@ -40,6 +43,8 @@ def websocket_open(io_loop, url, origin=None):
     request = HTTPRequest(url)
     if origin is not None:
         request.headers['Origin'] = origin
+    if host is not None:
+        request.headers['Host'] = host
     websocket_connect(request, callback=handle_connection, io_loop=io_loop)
 
     io_loop.start()

--- a/bokeh/tests/test_client_server.py
+++ b/bokeh/tests/test_client_server.py
@@ -84,38 +84,40 @@ class TestClientServer(unittest.TestCase):
             session.close()
             session.loop_until_closed()
 
-    def check_http_gets_fail(self, server):
+    def check_http_gets_fail(self, server, host=None):
         with (self.assertRaises(HTTPError)) as manager:
-            http_get(server.io_loop, url(server))
+            http_get(server.io_loop, url(server), host)
         with (self.assertRaises(HTTPError)) as manager:
-            http_get(server.io_loop, url(server) + "autoload.js?bokeh-autoload-element=foo")
+            http_get(server.io_loop, url(server) + "autoload.js?bokeh-autoload-element=foo", host)
 
-    def check_connect_session_fails(self, server, origin):
+    def check_connect_session_fails(self, server, origin, host=None):
         with (self.assertRaises(HTTPError)) as manager:
             websocket_open(server.io_loop,
                            ws_url(server)+"?bokeh-protocol-version=1.0&bokeh-session-id=foo",
-                           origin=origin)
+                           origin=origin,
+                           host=host)
 
-    def check_http_gets(self, server):
-        http_get(server.io_loop, url(server))
-        http_get(server.io_loop, url(server) + "autoload.js?bokeh-autoload-element=foo")
+    def check_http_gets(self, server, host=None):
+        http_get(server.io_loop, url(server), host)
+        http_get(server.io_loop, url(server) + "autoload.js?bokeh-autoload-element=foo", host)
 
-    def check_connect_session(self, server, origin):
+    def check_connect_session(self, server, origin, host=None):
         websocket_open(server.io_loop,
                        ws_url(server)+"?bokeh-protocol-version=1.0&bokeh-session-id=foo",
-                       origin=origin)
+                       origin=origin,
+                       host=host)
 
-    def check_http_ok_socket_ok(self, server, origin=None):
-        self.check_http_gets(server)
-        self.check_connect_session(server, origin=origin)
+    def check_http_ok_socket_ok(self, server, origin=None, host=None):
+        self.check_http_gets(server, host=host)
+        self.check_connect_session(server, origin=origin, host=host)
 
-    def check_http_ok_socket_blocked(self, server, origin=None):
-        self.check_http_gets(server)
-        self.check_connect_session_fails(server, origin=origin)
+    def check_http_ok_socket_blocked(self, server, origin=None, host=None):
+        self.check_http_gets(server, host=host)
+        self.check_connect_session_fails(server, origin=origin, host=host)
 
-    def check_http_blocked_socket_blocked(self, server, origin=None):
-        self.check_http_gets_fail(server)
-        self.check_connect_session_fails(server, origin=origin)
+    def check_http_blocked_socket_blocked(self, server, origin=None, host=None):
+        self.check_http_gets_fail(server, host=host)
+        self.check_connect_session_fails(server, origin=origin, host=host)
 
     def test_host_whitelist_success(self):
         application = Application()
@@ -128,23 +130,40 @@ class TestClientServer(unittest.TestCase):
         with ManagedServerLoop(application, port=8080, host=None) as server:
             self.check_http_ok_socket_ok(server)
 
-        # succeed matching host value
+        # succeed matching host value (localhost)
         with ManagedServerLoop(application, port=8080, host=["localhost:8080"]) as server:
             self.check_http_ok_socket_ok(server)
+
+        # succeed matching host value (not localhost)
+        with ManagedServerLoop(application, port=8080, host=["example.com:8080"]) as server:
+            self.check_http_ok_socket_ok(server, host="example.com:8080")
 
         # succeed matching host value one of multiple
         with ManagedServerLoop(application, port=8080, host=["bad_host", "localhost:8080"]) as server:
             self.check_http_ok_socket_ok(server)
 
+        # succeed matching host value with implicit port 80 (note
+        # that the server is in fact on 8080, as if we were behind
+        # a reverse proxy)
+        with ManagedServerLoop(application, port=8080, host=["example.com:80"]) as server:
+            self.check_http_ok_socket_ok(server, host="example.com")
+
     def test_host_whitelist_failure(self):
         application = Application()
 
-        # failure bad host
+        # failure bad host with localhost provided as Host
         with ManagedServerLoop(application, host=["bad_host"]) as server:
             self.check_http_blocked_socket_blocked(server)
 
         with ManagedServerLoop(application, host=["bad_host:5006"]) as server:
             self.check_http_blocked_socket_blocked(server)
+
+        # failure bad host with localhost expected and bad_host provided
+        with ManagedServerLoop(application, port=5006) as server:
+            self.check_http_blocked_socket_blocked(server, host="bad_host")
+
+        with ManagedServerLoop(application, port=5006) as server:
+            self.check_http_blocked_socket_blocked(server, host="bad_host:5006")
 
         # failure good host, bad port
         with ManagedServerLoop(application, host=["localhost:80"]) as server:
@@ -157,6 +176,10 @@ class TestClientServer(unittest.TestCase):
         # failure with custom port
         with ManagedServerLoop(application, port=8080, host=["localhost:8081"]) as server:
             self.check_http_blocked_socket_blocked(server)
+
+        # failure with implicit port 80 in Host when server is on another port
+        with ManagedServerLoop(application, port=5006, host=["example.com:5007"]) as server:
+            self.check_http_blocked_socket_blocked(server, host="example.com")
 
     def test_allow_websocket_origin(self):
         application = Application()
@@ -175,6 +198,11 @@ class TestClientServer(unittest.TestCase):
         with ManagedServerLoop(application, host=None,
                                allow_websocket_origin=["example.com:8080"]) as server:
             self.check_http_ok_socket_ok(server, origin="http://example.com:8080")
+
+        # allow good host and origin header with an implicit 80
+        with ManagedServerLoop(application, host=None,
+                               allow_websocket_origin=["example.com"]) as server:
+            self.check_http_ok_socket_ok(server, origin="http://example.com")
 
         # block non-Host origins by default even if no extra origins specified
         with ManagedServerLoop(application, host=None) as server:


### PR DESCRIPTION
Wanting to be sure that the HTTP stack doesn't break anything.
Looks good.

Not urgent to merge this for 0.11, the thing I wanted to do for 0.11 was run the tests, which will happen just by submitting the PR.

Should be harmless to merge whenever though (only affects tests).