### PR TITLE
Support raw javascript in autoload and use autoload in the notebook

### DIFF
--- a/bokeh/core/_templates/autoload_js.js
+++ b/bokeh/core/_templates/autoload_js.js
@@ -20,22 +20,27 @@ calls it with the rendered model.
 :param js_urls: URLs of JS files making up Bokeh library
 :type js_urls: list
 
-:param css_files: CSS files to inject
-:type css_files: list
+:param css_urls: CSS urls to inject
+:type css_urls: list
 
 
 #}
 (function(global) {
-  if (typeof (window._bokeh_onload_callbacks) === "undefined"){
+  function now() {
+    return new Date();
+  }
+
+  if (typeof (window._bokeh_onload_callbacks) === "undefined") {
     window._bokeh_onload_callbacks = [];
   }
+
   function load_libs(js_urls, callback) {
     window._bokeh_onload_callbacks.push(callback);
     if (window._bokeh_is_loading > 0) {
-      console.log("Bokeh: BokehJS is being loaded, scheduling callback at", new Date());
+      console.log("Bokeh: BokehJS is being loaded, scheduling callback at", now());
       return null;
     }
-    console.log("Bokeh: BokehJS not loaded, scheduling load and callback at", new Date());
+    console.log("Bokeh: BokehJS not loaded, scheduling load and callback at", now());
     window._bokeh_is_loading = js_urls.length;
     for (i = 0; i < js_urls.length; i++) {
       var url = js_urls[i];
@@ -46,10 +51,11 @@ calls it with the rendered model.
         window._bokeh_is_loading--;
         if (window._bokeh_is_loading === 0) {
           console.log("Bokeh: all BokehJS libraries loaded");
-          {%- for file in css_files %}
-          console.log("Bokeh: injecting CSS: {{ file }}");
-          Bokeh.embed.inject_css("{{ file }}");
+          {%- for url in css_urls %}
+          console.log("Bokeh: injecting CSS: {{ url }}");
+          Bokeh.embed.inject_css("{{ url }}");
           {%- endfor %}
+          // TODO: inject raw CSS
           window._bokeh_onload_callbacks.forEach(function(callback){callback()});
           delete window._bokeh_onload_callbacks
         }
@@ -62,36 +68,38 @@ calls it with the rendered model.
     }
   };
 
-  var elt = document.getElementById("{{ elementid }}");
-  if(elt==null) {
+  var element = document.getElementById("{{ elementid }}");
+  if (element == null) {
     console.log("Bokeh: ERROR: autoload.js configured with elementid '{{ elementid }}' but no matching script tag was found. ")
     return false;
   }
 
-  {% if websocket_url -%}
-  var websocket_url = "{{ websocket_url }}";
-  {%- else %}
-  var websocket_url = null;
-  {%- endif %}
+  var js_urls = {{ js_urls }};
 
-  // Docs will be set for the static case
-  {%- if docs_json %}
-  var docs_json = {{ docs_json }};
-  {%- else %}
-  var docs_json = {};
-  {%- endif %}
+  var inline_js = [
+    {%- for js in js_raw %}
+    function(Bokeh) {
+      {{ js|indent(6) }}
+    },
+    {% endfor -%}
+    function(Bokeh) {
+      console.info("Bokeh: all callbacks have finished");
+    }
+  ];
 
-  var render_items = [{ 'elementid' : "{{ elementid }}",
-                        'sessionid' : "{{ sessionid }}" }];
-
-  if (typeof(window._bokeh_is_loading) !== undefined && window._bokeh_is_loading == 0) {
-    console.log("Bokeh: BokehJS loaded, going straight to plotting");
-    Bokeh.embed.embed_items(docs_json, render_items, websocket_url);
-  } else {
-    load_libs({{ js_urls }}, function() {
-      console.log("Bokeh: BokehJS plotting callback run at", new Date());
-      Bokeh.embed.embed_items(docs_json, render_items, websocket_url);
-    });
+  function run_inline_js() {
+    for (var i = 0; i < inline_js.length; i++) {
+      inline_js[i](global.Bokeh);
+    }
   }
 
+  if (window._bokeh_is_loading === 0) {
+    console.log("Bokeh: BokehJS loaded, going straight to plotting");
+    run_inline_js();
+  } else {
+    load_libs(js_urls, function() {
+      console.log("Bokeh: BokehJS plotting callback run at", now());
+      run_inline_js();
+    });
+  }
 }(this));

--- a/bokeh/core/_templates/autoload_js.js
+++ b/bokeh/core/_templates/autoload_js.js
@@ -68,11 +68,13 @@ calls it with the rendered model.
     }
   };
 
+  {%- if elementid -%}
   var element = document.getElementById("{{ elementid }}");
   if (element == null) {
     console.log("Bokeh: ERROR: autoload.js configured with elementid '{{ elementid }}' but no matching script tag was found. ")
     return false;
   }
+  {%- endif -%}
 
   var js_urls = {{ js_urls }};
 

--- a/bokeh/core/_templates/autoload_js.js
+++ b/bokeh/core/_templates/autoload_js.js
@@ -42,7 +42,7 @@ calls it with the rendered model.
     }
     console.log("Bokeh: BokehJS not loaded, scheduling load and callback at", now());
     window._bokeh_is_loading = js_urls.length;
-    for (i = 0; i < js_urls.length; i++) {
+    for (var i = 0; i < js_urls.length; i++) {
       var url = js_urls[i];
       var s = document.createElement('script');
       s.src = url;

--- a/bokeh/core/_templates/autoload_js.js
+++ b/bokeh/core/_templates/autoload_js.js
@@ -91,7 +91,7 @@ calls it with the rendered model.
 
   function run_inline_js() {
     for (var i = 0; i < inline_js.length; i++) {
-      inline_js[i](global.Bokeh);
+      inline_js[i](window.Bokeh);
     }
   }
 

--- a/bokeh/core/_templates/autoload_tag.html
+++ b/bokeh/core/_templates/autoload_tag.html
@@ -24,8 +24,6 @@ ID is not specified, the entire document will be rendered.
 <script
     src="{{ src_path }}"
     id="{{ elementid }}"
-    async="false"
     data-bokeh-model-id="{{ modelid }}"
     data-bokeh-doc-id="{{ docid }}"
-    data-bokeh-log-level="{{ loglevel }}"
 ></script>

--- a/bokeh/core/_templates/notebook_div.html
+++ b/bokeh/core/_templates/notebook_div.html
@@ -8,7 +8,7 @@ Renders a ``div`` to display a Bokeh model into a Jupyter Notebook.
 :type plot_div: str
 
 #}
-{{ plot_script|indent(4) }}
+<script type="text/javascript">
+  {{ plot_script|indent(2) }}
+</script>
 {{ plot_div|indent(4) }}
-
-

--- a/bokeh/core/_templates/notebook_load.html
+++ b/bokeh/core/_templates/notebook_load.html
@@ -24,8 +24,10 @@ Notebook according to a Resources object.
 :type warnings: list[str]
 
 #}
-    {{ bokeh_js }}
-    {{ bokeh_css }}
+
+    <script type="text/javascript">
+      {{ bootstrap|indent(6) }}
+    </script>
 
     {%- if not hide_banner %}
     <div>

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -347,7 +347,7 @@ def autoload_static(model, resources, script_path):
 
     return encode_utf8(js), encode_utf8(tag)
 
-def autoload_server(model, app_path="/", session_id=None, url="default", loglevel="info"):
+def autoload_server(model, app_path="/", session_id=None, url="default"):
     '''Return a script tag that embeds the given model (or entire
     Document) from a Bokeh server session.
 
@@ -383,7 +383,6 @@ def autoload_server(model, app_path="/", session_id=None, url="default", logleve
           a specific model to render, you must also supply the session ID containing
           that model, though.
         url (str, optional) : server root URL (where static resources live, not where a specific app lives)
-        loglevel (str, optional) : "trace", "debug", "info", "warn", "error", "fatal"
 
     Returns:
         tag :
@@ -427,7 +426,6 @@ def autoload_server(model, app_path="/", session_id=None, url="default", logleve
         src_path = src_path,
         elementid = elementid,
         modelid = model_id,
-        loglevel = loglevel
     )
 
     return encode_utf8(tag)

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -30,11 +30,6 @@ from .model import Model, _ModelInDocument
 from .resources import BaseResources, _SessionCoordinates, EMPTY
 from .util.string import encode_utf8
 
-def _wrap_in_function(code):
-    # indent and wrap Bokeh function def around
-    code = "\n".join(["    " + line for line in code.split("\n")])
-    return 'Bokeh.$(function() {\n%s\n});' % code
-
 def components(models, resources=None, wrap_script=True, wrap_plot_info=True):
     '''
     Return HTML components to embed a Bokeh plot. The data for the plot is
@@ -327,41 +322,30 @@ def autoload_static(model, resources, script_path):
     if resources.mode == 'inline':
         raise ValueError("autoload_static() requires non-inline resources")
 
-    # TODO why is this?
-    if resources.dev:
-        raise ValueError("autoload_static() only works with non-dev resources")
-
     model = _check_one_model(model)
 
     with _ModelInDocument(model):
-
         (docs_json, render_items) = _standalone_docs_json_and_render_items([model])
-        item = render_items[0]
 
-        model_id = ""
-        if 'modelid' in item:
-            model_id = item['modelid']
-        doc_id = ""
-        if 'docid' in item:
-            doc_id = item['docid']
+    script = _script_for_render_items(docs_json, render_items, wrap_script=False)
+    item = render_items[0]
 
-        js = AUTOLOAD_JS.render(
-            docs_json = serialize_json(docs_json),
-            js_urls = resources.js_files,
-            css_files = resources.css_files,
-            elementid = item['elementid'],
-            websocket_url = None
-        )
+    js = AUTOLOAD_JS.render(
+        js_urls = resources.js_files,
+        css_urls = resources.css_files,
+        js_raw = resources.js_raw + [script],
+        css_raw = resources.css_raw,
+        elementid = item['elementid'],
+    )
 
-        tag = AUTOLOAD_TAG.render(
-            src_path = script_path,
-            elementid = item['elementid'],
-            modelid = model_id,
-            docid = doc_id,
-            loglevel = resources.log_level
-        )
+    tag = AUTOLOAD_TAG.render(
+        src_path = script_path,
+        elementid = item['elementid'],
+        modelid = item.get('modelid', ''),
+        docid = item.get('docid', ''),
+    )
 
-        return encode_utf8(js), encode_utf8(tag)
+    return encode_utf8(js), encode_utf8(tag)
 
 def autoload_server(model, app_path="/", session_id=None, url="default", loglevel="info"):
     '''Return a script tag that embeds the given model (or entire
@@ -449,12 +433,10 @@ def autoload_server(model, app_path="/", session_id=None, url="default", logleve
     return encode_utf8(tag)
 
 def _script_for_render_items(docs_json, render_items, websocket_url=None, wrap_script=True):
-    plot_js = _wrap_in_function(
-        DOC_JS.render(
-            websocket_url=websocket_url,
-            docs_json=serialize_json(docs_json),
-            render_items=serialize_json(render_items)
-        )
+    plot_js = DOC_JS.render(
+        websocket_url=websocket_url,
+        docs_json=serialize_json(docs_json),
+        render_items=serialize_json(render_items)
     )
     if wrap_script:
         return SCRIPT_TAG.render(js_code=plot_js)

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -244,16 +244,23 @@ def notebook_div(model, notebook_comms_target=None):
     with _ModelInDocument(model):
         (docs_json, render_items) = _standalone_docs_json_and_render_items([model])
 
-    render_items[0]['notebook_comms_target'] = notebook_comms_target
-
-    preamble = EMPTY.render() # XXX: this only includes custom models
-    script = preamble + "\n" + _script_for_render_items(docs_json, render_items)
-
     item = render_items[0]
+    item['notebook_comms_target'] = notebook_comms_target
+
+    script = _script_for_render_items(docs_json, render_items, wrap_script=False)
+    resources = EMPTY
+
+    js = AUTOLOAD_JS.render(
+        js_urls = resources.js_files,
+        css_urls = resources.css_files,
+        js_raw = resources.js_raw + [script],
+        css_raw = resources.css_raw,
+        elementid = item['elementid'],
+    )
     div = _div_for_render_item(item)
 
     html = NOTEBOOK_DIV.render(
-        plot_script = script,
+        plot_script = js,
         plot_div = div,
     )
     return encode_utf8(html)

--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -382,7 +382,7 @@ class JSResources(BaseResources):
     _plugin_template = \
 """
 (function outer(modules, cache, entry) {
-  if (Bokeh) {
+  if (typeof Bokeh !== "undefined") {
     for (var name in modules) {
       var module = modules[name];
 

--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -280,7 +280,7 @@ class BaseResources(object):
         return _get_cdn_urls(self.components, self.version, self.minified)
 
     def _server_urls(self):
-        return _get_server_urls(self.components, self.root_url, self.minified, self.path_versioner)
+        return _get_server_urls(self.components, self.root_url, False if self.dev else self.minified, self.path_versioner)
 
     def _resolve(self, kind):
         paths = self._file_paths(kind)

--- a/bokeh/server/views/autoload_js_handler.py
+++ b/bokeh/server/views/autoload_js_handler.py
@@ -39,7 +39,7 @@ class AutoloadJsHandler(SessionHandler):
         js = AUTOLOAD_JS.render(
             docs_json = None,
             js_urls = resources.js_files,
-            css_files = resources.css_files,
+            css_urls = resources.css_files,
             elementid = element_id,
             sessionid = session.id,
             websocket_url = websocket_url

--- a/bokeh/server/views/autoload_js_handler.py
+++ b/bokeh/server/views/autoload_js_handler.py
@@ -11,6 +11,7 @@ from tornado.web import RequestHandler
 
 from bokeh.core.templates import AUTOLOAD_JS
 from bokeh.util.string import encode_utf8
+from bokeh.embed import _script_for_render_items
 
 from .session_handler import SessionHandler
 
@@ -36,13 +37,16 @@ class AutoloadJsHandler(SessionHandler):
         resources = self.application.resources(self.request)
         websocket_url = self.application.websocket_url_for_request(self.request, self.bokeh_websocket_path)
 
+        # TODO: yes, this should resuse code from bokeh.embed more directly
+        render_items = [dict(sessionid=session.id, elementid=element_id, use_for_title=True)]
+        script = _script_for_render_items(None, render_items, websocket_url=websocket_url, wrap_script=False)
+
         js = AUTOLOAD_JS.render(
-            docs_json = None,
             js_urls = resources.js_files,
             css_urls = resources.css_files,
+            js_raw = resources.js_raw + [script],
+            css_raw = resources.css_raw,
             elementid = element_id,
-            sessionid = session.id,
-            websocket_url = websocket_url
         )
 
         self.set_header("Content-Type", 'application/javascript')

--- a/bokeh/tests/test_embed.py
+++ b/bokeh/tests/test_embed.py
@@ -185,13 +185,6 @@ def test_file_html_provides_warning_if_no_js(mock_warn):
 
 class TestAutoloadStatic(unittest.TestCase):
 
-    def test_invalid_resources(self):
-        self.assertRaises(ValueError, embed.autoload_static, _embed_test_plot, INLINE, "some/path")
-
-        dev_resources = (Resources("absolute-dev"), Resources("server-dev"),Resources("relative-dev"))
-        for x in dev_resources:
-            self.assertRaises(ValueError, embed.autoload_static, _embed_test_plot, x, "some/path")
-
     def test_return_type(self):
         r = embed.autoload_static(_embed_test_plot, CDN, "some/path")
         self.assertEqual(len(r), 2)
@@ -207,10 +200,8 @@ class TestAutoloadStatic(unittest.TestCase):
         attrs = scripts[0].attrs
         self.assertTrue(set(attrs), set(['src',
             'data-bokeh-model-id',
-            'async',
             'id',
             'data-bokeh-doc-id']))
-        self.assertEqual(attrs['async'], 'false')
         self.assertEqual(attrs['data-bokeh-doc-id'], 'uuid')
         self.assertEqual(attrs['data-bokeh-model-id'], str(_embed_test_plot._id))
         self.assertEqual(attrs['src'], 'some/path')
@@ -233,17 +224,13 @@ class TestAutoloadServer(unittest.TestCase):
             'src',
             'data-bokeh-doc-id',
             'data-bokeh-model-id',
-            'data-bokeh-log-level',
-            'async',
             'id'
         ]))
         divid = attrs['id']
         src = "%s/autoload.js?bokeh-autoload-element=%s&bokeh-session-id=fakesession" % \
               ("http://localhost:5006", divid)
-        self.assertDictEqual({ 'async' : 'false',
-                               'data-bokeh-doc-id' : '',
+        self.assertDictEqual({ 'data-bokeh-doc-id' : '',
                                'data-bokeh-model-id' : str(_embed_test_plot._id),
-                               'data-bokeh-log-level' : 'info',
                                'id' : divid,
                                'src' : src },
                              attrs)
@@ -259,17 +246,13 @@ class TestAutoloadServer(unittest.TestCase):
             'src',
             'data-bokeh-doc-id',
             'data-bokeh-model-id',
-            'data-bokeh-log-level',
-            'async',
             'id'
         ]))
         divid = attrs['id']
         src = "%s/autoload.js?bokeh-autoload-element=%s" % \
               ("http://localhost:5006", divid)
-        self.assertDictEqual({ 'async' : 'false',
-                               'data-bokeh-doc-id' : '',
+        self.assertDictEqual({ 'data-bokeh-doc-id' : '',
                                'data-bokeh-model-id' : '',
-                               'data-bokeh-log-level' : 'info',
                                'id' : divid,
                                'src' : src },
                              attrs)

--- a/bokeh/util/notebook.py
+++ b/bokeh/util/notebook.py
@@ -27,10 +27,14 @@ def load_notebook(resources=None, verbose=False, hide_banner=False):
         None
 
     '''
+    html = _load_notebook_html(resources, verbose, hide_banner)
+    publish_display_data({'text/html': html})
+
+def _load_notebook_html(resources=None, verbose=False, hide_banner=False):
     global _notebook_loaded
 
     from .. import __version__
-    from ..core.templates import NOTEBOOK_LOAD
+    from ..core.templates import AUTOLOAD_JS, NOTEBOOK_LOAD
     from ..resources import CDN
 
     if resources is None:
@@ -50,9 +54,16 @@ def load_notebook(resources=None, verbose=False, hide_banner=False):
 
     _notebook_loaded = resources
 
+    js = AUTOLOAD_JS.render(
+        js_urls = resources.js_files,
+        css_urls = resources.css_files,
+        js_raw = resources.js_raw,
+        css_raw = resources.css_raw,
+        elementid = None,
+    )
+
     html = NOTEBOOK_LOAD.render(
-        bokeh_js=resources.render_js(),
-        bokeh_css=resources.render_css(),
+        bootstrap=js,
         logo_url=resources.logo_url,
         verbose=verbose,
         js_info=js_info,
@@ -61,7 +72,8 @@ def load_notebook(resources=None, verbose=False, hide_banner=False):
         warnings=warnings,
         hide_banner=hide_banner,
     )
-    publish_display_data({'text/html': html})
+
+    return html
 
 def publish_display_data(data, source='bokeh'):
     ''' Compatibility wrapper for IPython ``publish_display_data``

--- a/bokehjs/src/coffee/common/embed.coffee
+++ b/bokehjs/src/coffee/common/embed.coffee
@@ -119,6 +119,8 @@ inject_css = (url) ->
   link = $("<link href='#{url}' rel='stylesheet' type='text/css'>")
   $('body').append(link)
 
+# TODO: inject_raw_css
+
 # pull missing render item fields from data- attributes
 fill_render_item_from_script_tag = (script, item) ->
   info = script.data()

--- a/bokehjs/src/js/plugin-prelude.js
+++ b/bokehjs/src/js/plugin-prelude.js
@@ -1,5 +1,5 @@
 (function outer(modules, cache, entry) {
-  if (Bokeh) {
+  if (typeof Bokeh !== "undefined") {
     for (var name in modules) {
       Bokeh.require.modules[name] = modules[name];
     }

--- a/examples/embed/custom_server/color_scatter_server.py
+++ b/examples/embed/custom_server/color_scatter_server.py
@@ -1,0 +1,61 @@
+from flask import Flask, Response
+
+app = Flask(__name__)
+port = 8878
+
+def render_plot():
+    import numpy as np
+
+    from bokeh.embed import autoload_static
+    from bokeh.plotting import figure
+    from bokeh.resources import CDN
+
+    N = 4000
+    x = np.random.random(size=N) * 100
+    y = np.random.random(size=N) * 100
+    radii = np.random.random(size=N) * 1.5
+    colors = [
+        "#%02x%02x%02x" % (int(r), int(g), 150) for r, g in zip(50+2*x, 30+2*y)
+    ]
+
+    TOOLS="resize,crosshair,pan,wheel_zoom,box_zoom,reset,tap,previewsave,box_select,poly_select,lasso_select"
+
+    p = figure(tools=TOOLS)
+
+    p.scatter(x, y, radius=radii,
+              fill_color=colors, fill_alpha=0.6,
+              line_color=None)
+
+    js, tag = autoload_static(p, CDN, "http://localhost:%s/plot.js" % port)
+
+    html = """
+    <html>
+        <head>
+            <title>color_scatter example</title>
+        </head>
+        <body>
+            %s
+        </body>
+    </html>
+    """ % tag
+
+    return html, js
+
+html, js = render_plot()
+
+@app.route('/plot.html')
+def plot_html():
+    return html
+
+@app.route('/plot.js')
+def plot_js():
+    return Response(js, mimetype='text/javascript')
+
+    #import ipdb; ipdb.set_trace()
+    #return app.send_static_file("plot.js")
+    #with open("plot.js") as plot_js:
+    #    js = plot_js.read()
+    #return Response(js, mimetype='text/javascript')
+
+if __name__ == "__main__":
+    app.run(port=port)

--- a/sphinx/source/docs/user_guide/embed.rst
+++ b/sphinx/source/docs/user_guide/embed.rst
@@ -321,7 +321,6 @@ a document looks like:
     <script
         src="http://localhost:5006/bokeh/autoload.js/f64f7959-017d-4d1b-924e-899a61fed42b"
         id="f64f7959-017d-4d1b-924e-899a61fed42b"
-        async="true"
         data-bokeh-data="server"
         data-bokeh-modelid="82ef36f7-9d58-47c8-9b0d-201947febb00"
         data-bokeh-root-url="http://localhost:5006/"


### PR DESCRIPTION
This makes autoload support raw javascrip, te.g. logging through resources, not some custom code. Added an example showing that `autoload_static()` works (`embed/custom_server`). Notebook now uses autoload for initialization bokeh and rendering plots. Fixed `plugin-prelude.js` and `sever-dev`. There is some unfortunate code duplication around `AUTOLOAD_JS` template, but that can be improved in a follow-up PR. ~~Tests may fail at this point~~.

fixes #3500