### PR TITLE
Improve initialization of plot size

### DIFF
--- a/bokehjs/src/coffee/common/plot.coffee
+++ b/bokehjs/src/coffee/common/plot.coffee
@@ -455,6 +455,16 @@ class PlotView extends ContinuumView
     # user-configurable in the future, as it may not be the right number
     # if people set a large border on their plots, for example.
 
+    # We need the parent node, because the el node itself collapses to zero
+    # height. It might not be available though, if the initial resize
+    # happened before Bokeh got properly initialized. If that happens, we
+    # will try again, but only once.
+    if not @.el.parentNode and not @_re_resized
+      that = this
+      setTimeout( (-> that.resize_width_height(use_width, use_height, maintain_ar)), 10)
+      @_re_resized = true
+      return
+
     avail_width = @.el.clientWidth
     avail_height = @.el.parentNode.clientHeight - 50  # -50 for x ticks
     min_size = @mget('min_size')

--- a/bokehjs/src/coffee/common/plot.coffee
+++ b/bokehjs/src/coffee/common/plot.coffee
@@ -457,12 +457,13 @@ class PlotView extends ContinuumView
 
     # We need the parent node, because the el node itself collapses to zero
     # height. It might not be available though, if the initial resize
-    # happened before Bokeh got properly initialized. If that happens, we
-    # will try again, but only once.
-    if not @.el.parentNode and not @_re_resized
-      that = this
-      setTimeout( (-> that.resize_width_height(use_width, use_height, maintain_ar)), 10)
-      @_re_resized = true
+    # happened before the plot was added to the DOM. If that happens, we
+    # try again in increasingly larger intervals (the first try should just
+    # work, but lets play it safe).
+    @_re_resized = @_re_resized or 0
+    if not @.el.parentNode and @_re_resized < 14  # 2**14 ~ 16s
+      setTimeout( (=> this.resize_width_height(use_width, use_height, maintain_ar)), 2**@_re_resized)
+      @_re_resized += 1
       return
 
     avail_width = @.el.clientWidth


### PR DESCRIPTION
issues: fixes #3468

The problem described in #3468 was related to a resize event being handled before the plot was fully initialized. This is why there was a `this.el.parentNode is null` error in the console, causing the initial sizing to fail. The solution is to test for this situation and schedule a new event in a future event-loop iteration.