### PR TITLE
Report that annulus is broken in release notes (+ typo fixes)

### DIFF
--- a/examples/plotting/file/glyphs.py
+++ b/examples/plotting/file/glyphs.py
@@ -18,7 +18,7 @@ p.annular_wedge(x, y, 10, 20, 0.6, 4.1, color="#8888ee",
                 inner_radius_units="screen", outer_radius_units="screen")
 children.append(p)
 
-p = figure(title="annular_wedge")
+p = figure(title="annulus")
 p.annulus(x, y, 10, 20, color="#7FC97F",
           inner_radius_units="screen", outer_radius_units = "screen")
 children.append(p)

--- a/examples/plotting/notebook/glyphs.ipynb
+++ b/examples/plotting/notebook/glyphs.ipynb
@@ -82,7 +82,7 @@
    },
    "outputs": [],
    "source": [
-    "p = figure(title=\"annular_wedge\")\n",
+    "p = figure(title=\"annulus\")\n",
     "p.annulus(x, y, 10, 20, color=\"#7FC97F\",\n",
     "    inner_radius_units=\"screen\", outer_radius_units = \"screen\")\n",
     "show(p)"

--- a/scripts/interactive_tester.py
+++ b/scripts/interactive_tester.py
@@ -283,7 +283,7 @@ if __name__ == '__main__':
         test_dir = None
 
     if results.location == 'server' or test_dir is None:
-        print("Server examples require bokeh-server. Make sure you've typed 'bokeh-server' in another terminal tab.")
+        print("Server examples require the bokeh server. Make sure you've typed 'bokeh serve' in another terminal tab.")
         time.sleep(4)
 
     if test_dir is None or 'notebook' in results.location:

--- a/sphinx/source/docs/releases/0.11.0.rst
+++ b/sphinx/source/docs/releases/0.11.0.rst
@@ -28,6 +28,10 @@ Bokeh Version ``0.11.0`` is a large release with many new improvements
   - hover policy for glyphs
   - responsive improvements
 
+* Known issues
+
+  - annulus glyph does not render correctly on IE and Edge
+
 * many small bug fixes
 
 Migration Guide


### PR DESCRIPTION
issues: related to #3543

* Mention that annulus glyph is broken on IE
* Fix typo in titles
* Also snuck in a fix for a reference to `bokeh-server`