### PR TITLE
Latest versions of firefox have a heavy to load startpage that we don't need

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,4 +23,4 @@ markers =
     js: mark a test as a javascript test
     examples: mark a test as an examples test
 
-addopts = --driver=Firefox --sensitive-url=None
+addopts = --driver=Firefox --sensitive-url=None --firefox-preference startup.homepage_welcome_url.additional about:blank


### PR DESCRIPTION
When a new release of selenium comes out this should be fixed, this is a
workaround in the meant time. For more information see:
https://github.com/davehunt/pytest-selenium/issues/48