### PR TITLE
Small fix in scatter.ipynb - allow making selection

### DIFF
--- a/examples/plotting/notebook/scatter.ipynb
+++ b/examples/plotting/notebook/scatter.ipynb
@@ -65,7 +65,7 @@
    },
    "outputs": [],
    "source": [
-    "p1 = figure()\n",
+    "p1 = figure(tools='pan,lasso_select,wheel_zoom')\n",
     "p1.scatter(x,y, color=\"#FF00FF\", nonselection_fill_color=\"#FFFF00\", nonselection_fill_alpha=1)\n",
     "show(p1)"
    ]


### PR DESCRIPTION
There was one plot in this example that specified a `nonselection_fill_color`, but did not allow a way to make a selection. I assumed the intention was to demonstrate how scatter glyphs behave under a selection, so I added the lasso tool.