### PR TITLE
Updated ImageURL url path to new image static url

### DIFF
--- a/examples/glyphs/image_url.py
+++ b/examples/glyphs/image_url.py
@@ -8,7 +8,7 @@ from bokeh.models.glyphs import ImageURL
 from bokeh.models import ColumnDataSource, Range1d, Plot, LinearAxis, Grid
 from bokeh.resources import INLINE
 
-url = "http://bokeh.pydata.org/en/latest/_static/bokeh-transparent.png"
+url = "http://bokeh.pydata.org/en/latest/_static/images/logo.png"
 N = 5
 
 source = ColumnDataSource(dict(

--- a/tests/glyphs/ImageURL.py
+++ b/tests/glyphs/ImageURL.py
@@ -6,7 +6,7 @@ from bokeh.models import ColumnDataSource, Range1d, Plot, LinearAxis, Grid
 from bokeh.models.glyphs import ImageURL
 from bokeh.plotting import show
 
-url = "http://bokeh.pydata.org/en/latest/_static/bokeh-transparent.png"
+url = "http://bokeh.pydata.org/en/latest/_static/images/logo.png"
 N = 5
 
 source = ColumnDataSource(dict(


### PR DESCRIPTION
issues: fixes #3569 

Docfix - update url argument of ImageURL examples to use new bokeh logo static location.