### PR TITLE
Update periodic table sample data

### DIFF
--- a/bokeh/sampledata/elements.csv
+++ b/bokeh/sampledata/elements.csv
@@ -112,7 +112,8 @@ atomic number,symbol,name,atomic mass,CPK,electronic configuration,electronegati
 110,111,Rg,Roentgenium,[280],#FF1493,[Rn].5f14.6d10.7s1,,,,,,,,,,,,transition metal,1994,11,7
 111,112,Cn,Copernicium,[285],#FF1493,[Rn].5f14.6d10.7s2,,,,,,,,,,,,transition metal,1996,12,7
 112,113,Uut,Ununtrium,[284],#FF1493,[Rn].5f14.6d10.7s2.7p1,,,,,,,,,,,,metal,2003,13,7
-113,114,Uuq,Ununquadium,[289],#FF1493,[Rn].5f14.6d10.7s2.7p2,,,,,,,,,,,,metal,1998,14,7
+113,114,Fl,Flerovium,[289],#FF1493,[Rn].5f14.6d10.7s2.7p2,,,,,,,,,,,,metal,1998,14,7
 114,115,Uup,Ununpentium,[288],#FF1493,[Rn].5f14.6d10.7s2.7p3,,,,,,,,,,,,metal,2003,15,7
-115,116,Uuh,Ununhexium,[293],#FF1493,[Rn].5f14.6d10.7s2.7p4,,,,,,,,,,,,metal,2000,16,7
-116,117,Uus,Ununseptium,,#FF1493,[Rn].5f14.6d10.7s2.7p5,,,,,,,,,,,,halogen,2010,17,7
+115,116,Lv,Livermorium,[293],#FF1493,[Rn].5f14.6d10.7s2.7p4,,,,,,,,,,,,metal,2000,16,7
+116,117,Uus,Ununseptium,[294],#FF1493,[Rn].5f14.6d10.7s2.7p5,,,,,,,,,,,,halogen,2010,17,7
+117,118,Uuo,Ununoctium,[294],#FF1493,[Rn].5f14.6d10.7s2.7p6,,,,,,,,,,,,noble gas,2002,18,7


### PR DESCRIPTION
I added Ununoctium (118), renamed Ununquadium to Flerovium, renamed
Ununhexium to Livermorium, and added the estimated atomic weight for
element 117.

Fixes #3599.