### PR TITLE
Improve how webgl canvas is blitted into the visible canvas

### DIFF
--- a/bokehjs/src/coffee/common/plot.coffee
+++ b/bokehjs/src/coffee/common/plot.coffee
@@ -417,16 +417,20 @@ class PlotView extends ContinuumView
     @_render_levels(ctx, ['image', 'underlay', 'glyph', 'annotation'], frame_box)
 
     if ctx.glcanvas
-      # Blit gl canvas into the 2D canvas. We need to turn off interpolation, otherwise
-      # all gl-rendered content is blurry. The 0.1 offset is to force the samples
-      # to be *inside* the pixels, otherwise round-off errors can sometimes cause
-      # missing/double scanlines (seen in Chrome).
-      for prefix in ['image', 'mozImage', 'webkitImage','msImage']
-         ctx[prefix + 'SmoothingEnabled'] = false
+      # Blit gl canvas into the 2D canvas. We set up offsets so the pixel
+      # mapping is one-on-one and we do not get any blurring due to
+      # interpolation. In theory, we could disable the image interpolation,
+      # and we can on Chrome, but then the result looks ugly on Firefox. Since
+      # the image *does* look sharp, this might be a bug in Firefox'
+      # interpolation-less image rendering.
+      # This is how we would disable image interpolation (keep as a reference) 
+      #for prefix in ['image', 'mozImage', 'webkitImage','msImage']
+      #   ctx[prefix + 'SmoothingEnabled'] = window.SmoothingEnabled
       #ctx.globalCompositeOperation = "source-over"  -> OK; is the default
-      ctx.drawImage(ctx.glcanvas, 0.1, 0.1)
-      for prefix in ['image', 'mozImage', 'webkitImage','msImage']
-         ctx[prefix + 'SmoothingEnabled'] = true
+      src_offset = 0.5
+      dst_offset = 0.0
+      ctx.drawImage(ctx.glcanvas, src_offset, src_offset, ctx.glcanvas.width, ctx.glcanvas.height,
+                                  dst_offset, dst_offset, ctx.glcanvas.width, ctx.glcanvas.height)
       logger.debug('drawing with WebGL')
 
     @_render_levels(ctx, ['overlay', 'tool'])

--- a/examples/plotting/file/scatter10k.py
+++ b/examples/plotting/file/scatter10k.py
@@ -10,7 +10,7 @@ y = np.sin(x) + np.random.normal(0, 0.2, N)
 
 TOOLS = "pan,wheel_zoom,box_zoom,reset,save,box_select"
 
-p = figure(tools=TOOLS  , webgl=True)
+p = figure(tools=TOOLS, webgl=True)
 
 p.circle(x, y, alpha=0.1, nonselection_alpha=0.001)
 


### PR DESCRIPTION
issues: fixes #3605

Previously, we blitted without interpolation. Apparently this causes problems for firefox. Now we do it with interpolation, but align the image such that the pixel correspondence is one-to-one, and the resulting visualization is crisp.
