### PR TITLE
Added unsorted_label parameter to chart builder to don't sort labels

### DIFF
--- a/bokeh/charts/builder.py
+++ b/bokeh/charts/builder.py
@@ -230,6 +230,10 @@ class Builder(HasProps):
         using the valid input for the `HoverTool` tooltips kwarg.
         """)
 
+    unsorted_label = Bool(default=False, help="""
+        A boolean flag to tell to don't sort the labels.
+        """)
+
     def __init__(self, *args, **kws):
         """Common arguments to be used by all the inherited classes.
 
@@ -340,6 +344,9 @@ class Builder(HasProps):
                     attributes[attr_name].iterable = custom_palette
                 else:
                     attributes[attr_name] = self.default_attributes[attr_name]._clone()
+
+        if kws.get('unsorted_label', False):
+            attributes['label'].sort = False
 
         # make sure all have access to data source
         for attr_name in attr_names:


### PR DESCRIPTION
This pull request solves the issue #3606.

I don't know if it is the right way to achieve this but it works.

Example to test:

    from bokeh.charts import Bar, output_file, show
    data = {
        'labels': ('EN', 'PD', 'AD'),
        'counts': (10, 20, 30),
    }
    p = Bar(data, values='counts', label='labels', unsorted_label=True)
    output_file("bar.html")
    show(p)






