### PR TITLE
Fix bad path to bokeh logo static

### DIFF
--- a/examples/glyphs/glyphs.py
+++ b/examples/glyphs/glyphs.py
@@ -46,7 +46,7 @@ glyphs = [
     ("arc", Arc(x="x", y="y", radius=screen(20), start_angle=0.6, end_angle=4.1, line_color="#BEAED4", line_width=3)),
     ("bezier", Bezier(x0="x", y0="y", x1="xp02", y1="y", cx0="xp01", cy0="yp01", cx1="xm01", cy1="ym01", line_color="#D95F02", line_width=2)),
     ("gear", Gear(x="x", y="y", module=0.1, teeth=8, angle=0, shaft_size=0.02, fill_color="#FDF6E3", line_color="D95F02")),
-    ("image_url",  ImageURL(x="x", y="y", w=0.4, h=0.4, url=dict(value="http://bokeh.pydata.org/en/latest/_static/bokeh-transparent.png"), anchor="center")),
+    ("image_url",  ImageURL(x="x", y="y", w=0.4, h=0.4, url=dict(value="http://bokeh.pydata.org/en/latest/_static/images/logo.png"), anchor="center")),
     ("line", Line(x="x", y="y", line_color="#F46D43")),
     ("multi_line", MultiLine(xs="xs", ys="ys", line_color="#8073AC", line_width=2)),
     ("oval", Oval(x="x", y="y", width=screen(15), height=screen(25), angle=-0.7, fill_color="#1D91C0")),


### PR DESCRIPTION
Potential solution for broken bokeh master:

The url arg in the ImageURL glyph test example in examples/glyphs/glyph.py is wrong and gives a 404 warn. It's unclear why the tests seem to pass for py27 and not py34 though

I'm unable to reproduce the failed test w/ py34 locally, so if the hotfix doesn't work I'll add a print statement on the stdout of glyph.py to see what response TravisCI is getting that I'm not.