### PR TITLE
Remove inline style from embed_multiple.py

### DIFF
--- a/examples/embed/embed_multiple.py
+++ b/examples/embed/embed_multiple.py
@@ -46,15 +46,14 @@ template = Template('''<!DOCTYPE html>
     <head>
         <meta charset="utf-8">
         <title>Bokeh Scatter Plots</title>
-        <style> div{float: left;} </style>
         {{ js_resources }}
         {{ css_resources }}
         {{ script }}
     </head>
     <body>
-    {% for key in div.keys() %}
-        {{ div[key] }}
-    {% endfor %}
+        {% for key in div.keys() %}
+            {{ div[key] }}
+        {% endfor %}
     </body>
 </html>
 ''')


### PR DESCRIPTION
issue: fixes #3705 

Remove inline style of div tag that overrides bokeh button icon style. Plots are now vertically aligned (as consecutive divs) and not horizontal. It's be possible to wrap them in an HBox, but that seems to detract from demonstration of embedding/jinja templating of multiple components.