### PR TITLE
Use make_id() instead of str(uuid.uuid4())

### DIFF
--- a/bokeh/application/handlers/code_runner.py
+++ b/bokeh/application/handlers/code_runner.py
@@ -6,7 +6,8 @@ import codecs
 import os
 import sys
 import traceback
-import uuid
+
+from bokeh.util.serialization import make_id
 
 class _CodeRunner(object):
     """Load and run a Python file."""
@@ -54,7 +55,7 @@ class _CodeRunner(object):
         if self.failed:
             return None
 
-        module_name = 'bk_script_' + str(uuid.uuid4()).replace('-', '')
+        module_name = 'bk_script_' + make_id().replace('-', '')
         module = ModuleType(module_name)
         module.__dict__['__file__'] = abspath(self._path)
 

--- a/bokeh/document.py
+++ b/bokeh/document.py
@@ -9,7 +9,6 @@ import logging
 logger = logging.getLogger(__file__)
 
 from json import loads
-import uuid
 
 from six import string_types
 
@@ -22,6 +21,7 @@ from .themes import Theme
 from .util.callback_manager import _check_callback
 from .util.deprecate import deprecated
 from .util.version import __version__
+from .util.serialization import make_id
 
 DEFAULT_TITLE = "Bokeh Application"
 
@@ -93,10 +93,7 @@ class SessionCallbackRemoved(DocumentChangedEvent):
 
 class SessionCallback(object):
     def __init__(self, document, callback, id=None):
-        if id is None:
-            self._id = str(uuid.uuid4())
-        else:
-            self._id = id
+        self._id = make_id() if id is None else id
         self._document = document
         self._callback = callback
 

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -14,7 +14,6 @@ these different cases.
 from __future__ import absolute_import
 
 from collections import Sequence
-import uuid
 from warnings import warn
 
 from six import string_types
@@ -28,6 +27,7 @@ from .document import Document, DEFAULT_TITLE
 from .model import Model, _ModelInDocument
 from .resources import BaseResources, _SessionCoordinates, EMPTY
 from .util.string import encode_utf8
+from .util.serialization import make_id
 
 def _wrap_in_function(code):
     # indent and wrap Bokeh function def around
@@ -411,7 +411,7 @@ def autoload_server(model, app_path="/", session_id=None, url="default"):
                                       session_id=session_id,
                                       app_path=app_path))
 
-    elementid = str(uuid.uuid4())
+    elementid = make_id()
 
     # empty model_id means render the entire doc from session_id
     model_id = ""
@@ -549,10 +549,10 @@ def _standalone_docs_json_and_render_items(models):
             if docs_by_id[key] == doc:
                 docid = key
         if docid is None:
-            docid = str(uuid.uuid4())
+            docid = make_id()
             docs_by_id[docid] = doc
 
-        elementid = str(uuid.uuid4())
+        elementid = make_id()
 
         render_items.append({
             'docid' : docid,
@@ -599,7 +599,7 @@ def server_html_page_for_models(session_id, model_ids, resources, title, websock
         if modelid is None:
             raise ValueError("None found in list of model_ids")
 
-        elementid = str(uuid.uuid4())
+        elementid = make_id()
 
         render_items.append({
             'sessionid' : session_id,
@@ -611,7 +611,7 @@ def server_html_page_for_models(session_id, model_ids, resources, title, websock
     return _html_page_for_render_items(bundle, {}, render_items, title, websocket_url=websocket_url)
 
 def server_html_page_for_session(session_id, resources, title, websocket_url):
-    elementid = str(uuid.uuid4())
+    elementid = make_id()
     render_items = [{
         'sessionid' : session_id,
         'elementid' : elementid,

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -22,7 +22,6 @@ import io
 import itertools
 import json
 import os
-import uuid
 import warnings
 
 # Third-party imports
@@ -37,6 +36,7 @@ from .models.widgets.layouts import HBox, VBox, VBoxForm
 from .model import _ModelInDocument
 from .util.notebook import load_notebook, publish_display_data, get_comms
 from .util.string import decode_utf8
+from .util.serialization import make_id
 import bokeh.util.browser as browserlib # full import needed for test mocking to work
 from .client import DEFAULT_SESSION_ID, push_session, show_session
 
@@ -326,7 +326,7 @@ def _show_notebook_with_state(obj, state):
         snippet = autoload_server(obj, session_id=state.session_id_allowing_none, url=state.url, app_path=state.app_path)
         publish_display_data({'text/html': snippet})
     else:
-        comms_target = str(uuid.uuid4())
+        comms_target = make_id()
         publish_display_data({'text/html': notebook_div(obj, comms_target)})
         handle = _CommsHandle(get_comms(comms_target), state.document, state.document.to_json())
         state.last_comms_handle = handle

--- a/bokeh/tests/test_embed.py
+++ b/bokeh/tests/test_embed.py
@@ -18,6 +18,9 @@ def setUpModule():
     _embed_test_plot = figure()
     _embed_test_plot.circle([1,2], [2,3])
 
+def _stable_id():
+    return 'ID'
+
 class TestComponents(unittest.TestCase):
 
     def test_return_type(self):
@@ -56,11 +59,8 @@ class TestComponents(unittest.TestCase):
         script, div = embed.components(_embed_test_plot)
         self.assertTrue(isinstance(script, str))
 
-    @mock.patch('bokeh.embed.uuid')
-    def test_output_is_without_script_tag_when_wrap_script_is_false(self, mock_uuid):
-        mock_uuid.uuid4 = mock.Mock()
-        mock_uuid.uuid4.return_value = 'uuid'
-
+    @mock.patch('bokeh.embed.make_id', new_callable=lambda: _stable_id)
+    def test_output_is_without_script_tag_when_wrap_script_is_false(self, mock_make_id):
         script, div = embed.components(_embed_test_plot)
         html = bs4.BeautifulSoup(script)
         scripts = html.findAll(name='script')
@@ -71,13 +71,10 @@ class TestComponents(unittest.TestCase):
         self.maxDiff = None
         self.assertEqual(rawscript.strip(), script_content.strip())
 
-    @mock.patch('bokeh.embed.uuid')
-    def test_plot_dict_returned_when_wrap_plot_info_is_false(self, mock_uuid):
-        mock_uuid.uuid4 = mock.Mock()
-        mock_uuid.uuid4.return_value = 'uuid'
-
+    @mock.patch('bokeh.embed.make_id', new_callable=lambda: _stable_id)
+    def test_plot_dict_returned_when_wrap_plot_info_is_false(self, mock_make_id):
         plot = _embed_test_plot
-        expected_plotdict = {"modelid": plot.ref["id"], "elementid": "uuid", "docid": "uuid"}
+        expected_plotdict = {"modelid": plot.ref["id"], "elementid": "ID", "docid": "ID"}
         script, plotdict = embed.components(_embed_test_plot, wrap_plot_info=False)
         self.assertEqual(plotdict, expected_plotdict)
 
@@ -189,10 +186,8 @@ class TestAutoloadStatic(unittest.TestCase):
         r = embed.autoload_static(_embed_test_plot, CDN, "some/path")
         self.assertEqual(len(r), 2)
 
-    @mock.patch('bokeh.embed.uuid')
-    def test_script_attrs(self, mock_uuid):
-        mock_uuid.uuid4 = mock.Mock()
-        mock_uuid.uuid4.return_value = 'uuid'
+    @mock.patch('bokeh.embed.make_id', new_callable=lambda: _stable_id)
+    def test_script_attrs(self, mock_make_id):
         js, tag = embed.autoload_static(_embed_test_plot, CDN, "some/path")
         html = bs4.BeautifulSoup(tag)
         scripts = html.findAll(name='script')
@@ -202,7 +197,7 @@ class TestAutoloadStatic(unittest.TestCase):
             'data-bokeh-model-id',
             'id',
             'data-bokeh-doc-id']))
-        self.assertEqual(attrs['data-bokeh-doc-id'], 'uuid')
+        self.assertEqual(attrs['data-bokeh-doc-id'], 'ID')
         self.assertEqual(attrs['data-bokeh-model-id'], str(_embed_test_plot._id))
         self.assertEqual(attrs['src'], 'some/path')
 


### PR DESCRIPTION
This restores support for custom ID generators and simple IDs in particular, which is useful for debugging.