### PR TITLE
Fix layout update for non-visible axes

### DIFF
--- a/bokehjs/src/coffee/renderer/guide/axis.coffee
+++ b/bokehjs/src/coffee/renderer/guide/axis.coffee
@@ -361,6 +361,7 @@ class Axis extends GuideRenderer.Model
   update_layout: (view, solver) ->
     if not @get('visible')
       size = 0
+      @_last_size = 0
     else
       size = (@_tick_extent(view) + @_tick_label_extent(view) +
               @_axis_label_extent(view))

--- a/bokehjs/src/coffee/renderer/guide/axis.coffee
+++ b/bokehjs/src/coffee/renderer/guide/axis.coffee
@@ -360,16 +360,18 @@ class Axis extends GuideRenderer.Model
 
   update_layout: (view, solver) ->
     if not @get('visible')
-      size = 0
-      @_last_size = 0
-    else
-      size = (@_tick_extent(view) + @_tick_label_extent(view) +
-              @_axis_label_extent(view))
+      # if not visible, avoid applying constraints until visible again
+      return
+
+    size = (@_tick_extent(view) + @_tick_label_extent(view) +
+      @_axis_label_extent(view))
+
     if not @_last_size?
       @_last_size = -1
     if size == @_last_size
       return
     @_last_size = size
+
     if @_size_constraint?
       solver.remove_constraint(@_size_constraint)
     @_size_constraint = new kiwi.Constraint(new kiwi.Expression(@_size, -size), kiwi.Operator.Eq)


### PR DESCRIPTION
This resolves #3626 based on the research outlined in the issue. In short, there were two methods of supporting swapping axes out after the chart has been rendered. This approach is probably the least desired option because we should have a simple method to add axes as, as needed, but it is the most simple. Currently, the only alternative approach to this problem is to recreate the entire plot.

Whether more work will be done or not to fix this issue upstream in the rendering logic, this simple change should be there, otherwise layout constraints will be solved for non visible axes, which kiwi will error out on when arguments provided are 0, -0.