### PR TITLE
Don't generate source maps for *.min.js files

### DIFF
--- a/bokehjs/gulp/tasks/scripts.coffee
+++ b/bokehjs/gulp/tasks/scripts.coffee
@@ -249,7 +249,6 @@ gulp.task "scripts:minify", ->
   tasks = [paths.coffee.bokehjs, paths.coffee.widgets, paths.coffee.compiler].map (entry) ->
     gulp.src(entry.destination.fullWithPath)
       .pipe(rename((path) -> path.basename += '.min'))
-      .pipe(sourcemaps.init({loadMaps: true}))
       .pipe(uglify({ output: {comments: /^!|copyright|license|\(c\)/i} }))
       .pipe(insert.append(license))
       .pipe(sourcemaps.write('./'))


### PR DESCRIPTION
This fixes #3676.