### PR TITLE
Remove version pin from pytest-selenium

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -55,7 +55,7 @@ test:
     - pandas
     - pytest
     - pytest-cov ==1.8.1
-    - pytest-selenium ==1.0b1
+    - pytest-selenium
     - beautiful-soup
     - scipy
     - pillow

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,4 +23,4 @@ markers =
     js: mark a test as a javascript test
     examples: mark a test as an examples test
 
-addopts = --driver=Firefox --sensitive-url=None --firefox-preference startup.homepage_welcome_url.additional about:blank
+addopts = --driver=Firefox --sensitive-url=None


### PR DESCRIPTION
Latest 1.1 is on bokeh's conda package (along with other up-to-date related packages)