### PR TITLE
Output pytest report as html and upload to s3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 .sw[nop]
 *.tmp
 *.coverage.*
+pytest-report.html
 
 # Compiled source #
 ###################

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,9 @@ script:
     - if [[ -z "$TRAVIS_TAG" && "$GROUP" == unit ]]; then py.test -m 'not (examples or js or integration)' --cov=bokeh --cov-config=bokeh/.coveragerc -rs; fi  # Run the not examples or js tests (we can eat stdout for this one)
     #
     # Run integration tests only once (Py 3.4)
-    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration ]]; then py.test -m integration -rs -v; fi  # Run the integration tests
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration ]]; then export UPLOAD_PYTEST_HTML=True; fi
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration ]]; then py.test -m integration; fi  # Run the integration tests
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration ]]; then export UPLOAD_PYTEST_HTML=False; fi
     #
     # Flake/docs testing only once (Py 2.7)
     - if [[ -z "$TRAVIS_TAG" && "$GROUP" == flake_docs ]]; then ( flake8 bokeh; cd sphinx; make all ) ; fi

--- a/scripts/travis_install
+++ b/scripts/travis_install
@@ -48,9 +48,10 @@ conda install --yes nodejs
 echo "node version $(node -v)"
 echo "npm version $(npm -v)"
 
+conda install --yes boto
+
 if [[ "$TRAVIS_PYTHON_VERSION" == '2.7' ]]; then
     conda install --yes pdiff
-    conda install --yes boto
 fi
 
 MATPLOTLIB_RC=$(python -c "import matplotlib; print(matplotlib.matplotlib_fname())")

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,9 +18,10 @@ max-line-length = 160
 [pytest]
 norecursedirs = build _build node_modules
 python_files = *_tests.py *_test.py test_*.py
+selenium_exclude_debug = html logs
 markers =
     integration: mark a test as an integration test - used for selenium tests
     js: mark a test as a javascript test
     examples: mark a test as an examples test
 
-addopts = --driver=Firefox --sensitive-url=None
+addopts = --driver=Firefox --sensitive-url=None --html=tests/pytest-report.html

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+from __future__ import print_function
+
+import os
+import boto
+from boto.s3.key import Key as S3Key
+from boto.exception import NoAuthHandlerFound
+from os.path import join
+
+s3_bucket = "bokeh-travis"
+s3 = "https://s3.amazonaws.com/%s" % s3_bucket
+build_id = os.environ.get('TRAVIS_BUILD_ID')
+
+
+def pytest_sessionfinish(session, exitstatus):
+    if os.environ.get('UPLOAD_PYTEST_HTML', "False") == "True":
+        try:
+            conn = boto.connect_s3()
+            bucket = conn.get_bucket(s3_bucket)
+            upload = True
+        except NoAuthHandlerFound:
+            print("Upload was requested but could not connect to S3.")
+            upload = False
+
+        if upload is True:
+            # Can we make this not hard coded and read in the report location from pytest?
+            with open('tests/pytest-report.html', 'r') as f:
+                html = f.read()
+            filename = join(build_id, "report.html")
+            key = S3Key(bucket, filename)
+            key.set_metadata("Content-Type", "text/html")
+            key.set_contents_from_string(html, policy="public-read")
+            print("\n%s Access report at: %s" % ("---", join(s3, filename)))


### PR DESCRIPTION
This is an incremental piece of doing browser testing on saucelabs and imagediff testing.

@mattpap started commenting on the WIP PR #3741 and I realized that this bit is totally standalone which'll keep the diff smaller on the rest of #3741.

You can see a successful upload to s3 here: https://s3.amazonaws.com/bokeh-travis/104764781/report.html

<img width="1234" alt="screen shot 2016-01-25 at 6 53 25 pm" src="https://cloud.githubusercontent.com/assets/1796208/12571332/f1356566-c394-11e5-95a2-1287f40b2c41.png">
