### PR TITLE
Remove bokeh.models attribute import from examples (always import from bokeh.models parent)

### DIFF
--- a/bokeh/tests/test_layouts.py
+++ b/bokeh/tests/test_layouts.py
@@ -1,9 +1,7 @@
 from __future__ import absolute_import
 
 from bokeh.plotting import Figure
-from bokeh.models.layouts import HBox, VBox, VBoxForm
-from bokeh.models.widgets import Slider
-from bokeh.models.sources import ColumnDataSource
+from bokeh.models import HBox, VBox, VBoxForm, Slider, ColumnDataSource
 
 import pytest
 

--- a/bokeh/tests/test_widgets.py
+++ b/bokeh/tests/test_widgets.py
@@ -19,7 +19,7 @@ def get_prop_set(class_object):
 class TestPanel(unittest.TestCase):
 
     def setUp(self):
-        from bokeh.models import Panel
+        from bokeh.models.widgets import Panel
         self.panelCls = Panel
 
     def test_expectedprops(self):
@@ -39,7 +39,7 @@ class TestPanel(unittest.TestCase):
 class TestTabs(unittest.TestCase):
 
     def setUp(self):
-        from bokeh.models import Tabs, Panel
+        from bokeh.models.widgets import Tabs, Panel
         self.tabsCls = Tabs
         self.panelCls = Panel
 
@@ -56,7 +56,7 @@ class TestTabs(unittest.TestCase):
 class TestDialog(unittest.TestCase):
 
     def setUp(self):
-        from bokeh.models import Dialog
+        from bokeh.models.widgets import Dialog
         self.dialogCls = Dialog
 
     def test_expected_props(self):

--- a/bokeh/tests/test_widgets.py
+++ b/bokeh/tests/test_widgets.py
@@ -19,7 +19,7 @@ def get_prop_set(class_object):
 class TestPanel(unittest.TestCase):
 
     def setUp(self):
-        from bokeh.models.widgets.panels import Panel
+        from bokeh.models import Panel
         self.panelCls = Panel
 
     def test_expectedprops(self):
@@ -39,7 +39,7 @@ class TestPanel(unittest.TestCase):
 class TestTabs(unittest.TestCase):
 
     def setUp(self):
-        from bokeh.models.widgets.panels import Tabs, Panel
+        from bokeh.models import Tabs, Panel
         self.tabsCls = Tabs
         self.panelCls = Panel
 
@@ -56,7 +56,7 @@ class TestTabs(unittest.TestCase):
 class TestDialog(unittest.TestCase):
 
     def setUp(self):
-        from bokeh.models.widgets.dialogs import Dialog
+        from bokeh.models import Dialog
         self.dialogCls = Dialog
 
     def test_expected_props(self):

--- a/examples/app/fourier_animated.py
+++ b/examples/app/fourier_animated.py
@@ -21,7 +21,7 @@ import numpy as np
 from numpy import pi
 
 from bokeh.io import vplot
-from bokeh.models.sources import ColumnDataSource as CDS
+from bokeh.models import ColumnDataSource as CDS
 from bokeh.plotting import curdoc, figure
 from bokeh.driving import repeat
 
@@ -186,4 +186,3 @@ def cb(gind):
         update_centric_sources(p['csources'], p['fs'], newx, gind, p['cfs'])
 
 curdoc().add_periodic_callback(cb, 100)
-

--- a/examples/app/movies/main.py
+++ b/examples/app/movies/main.py
@@ -5,8 +5,8 @@ import pandas.io.sql as psql
 import sqlite3 as sql
 
 from bokeh.plotting import Figure
-from bokeh.models import ColumnDataSource, HoverTool
-from bokeh.models.widgets import HBox, Slider, VBoxForm, Select, TextInput
+from bokeh.models import (ColumnDataSource, HoverTool, HBox, Slider, VBoxForm,
+    Select, TextInput)
 from bokeh.io import curdoc
 from bokeh.sampledata.movies_data import movie_path
 

--- a/examples/app/random_tiles/main.py
+++ b/examples/app/random_tiles/main.py
@@ -1,8 +1,7 @@
 from bokeh.plotting import Figure
 from bokeh.io import curdoc
 from bokeh.core.properties import (String, List)
-from bokeh.models import Range1d
-from bokeh.models.tiles import MercatorTileSource
+from bokeh.models import Range1d, MercatorTileSource
 from bokeh.tile_providers import STAMEN_TONER
 
 class RandomTileSource(MercatorTileSource):

--- a/examples/app/sliders.py
+++ b/examples/app/sliders.py
@@ -17,8 +17,7 @@ in your browser.
 import numpy as np
 
 from bokeh.plotting import Figure
-from bokeh.models import ColumnDataSource
-from bokeh.models.widgets import HBox, Slider, TextInput, VBoxForm
+from bokeh.models import ColumnDataSource, HBox, Slider, TextInput, VBoxForm
 from bokeh.io import curdoc
 
 # Set up data

--- a/examples/app/stocks/main.py
+++ b/examples/app/stocks/main.py
@@ -36,8 +36,7 @@ from os.path import dirname, join
 import pandas as pd
 
 from bokeh.charts import Histogram
-from bokeh.models import ColumnDataSource, GridPlot
-from bokeh.models.widgets import HBox, VBox, PreText, Select
+from bokeh.models import ColumnDataSource, GridPlot, HBox, VBox, PreText, Select
 from bokeh.plotting import Figure
 
 from bokeh.io import curdoc

--- a/examples/howto/ajax_source.py
+++ b/examples/howto/ajax_source.py
@@ -6,7 +6,7 @@ from random import random
 from six import string_types
 
 from bokeh.plotting import figure, show, output_file
-from bokeh.models.sources import AjaxDataSource
+from bokeh.models import AjaxDataSource
 
 output_file("ajax_source.html", title="ajax_source.py example")
 source = AjaxDataSource(data_url='http://localhost:5050/data',

--- a/examples/models/anscombe.py
+++ b/examples/models/anscombe.py
@@ -6,9 +6,8 @@ import pandas as pd
 from bokeh.util.browser import view
 from bokeh.document import Document
 from bokeh.embed import file_html
-from bokeh.models.glyphs import Circle, Line
 from bokeh.models import (
-    ColumnDataSource, Grid, GridPlot, LinearAxis, Plot, Range1d
+    ColumnDataSource, Grid, GridPlot, LinearAxis, Plot, Range1d, Circle, Line
 )
 from bokeh.resources import INLINE
 

--- a/examples/models/buttons_server.py
+++ b/examples/models/buttons_server.py
@@ -2,11 +2,10 @@ from __future__ import print_function
 
 from bokeh.client import push_session
 from bokeh.document import Document
-from bokeh.models.layouts import VBox
-from bokeh.models.widgets import (
+from bokeh.models import (
     Icon, Button, Toggle, Dropdown, CheckboxGroup, RadioGroup,
-    CheckboxButtonGroup, RadioButtonGroup,
-)
+    CheckboxButtonGroup, RadioButtonGroup, VBox
+    )
 
 def button_handler():
     print("button_handler: click")

--- a/examples/models/calendars.py
+++ b/examples/models/calendars.py
@@ -2,8 +2,10 @@ from __future__ import absolute_import, print_function
 
 from calendar import Calendar, day_abbr as day_abbrs, month_name as month_names
 
-from bokeh.models import GridPlot, Plot, ColumnDataSource, FactorRange, CategoricalAxis, HoverTool
-from bokeh.models.glyphs import Text, Rect
+from bokeh.models import (
+    GridPlot, Plot, ColumnDataSource, FactorRange, CategoricalAxis, HoverTool,
+    Text, Rect
+    )
 from bokeh.document import Document
 from bokeh.embed import file_html
 from bokeh.resources import INLINE

--- a/examples/models/choropleth.py
+++ b/examples/models/choropleth.py
@@ -3,9 +3,8 @@ from __future__ import print_function
 from bokeh.util.browser import view
 from bokeh.document import Document
 from bokeh.embed import file_html
-from bokeh.models.glyphs import Patches
 from bokeh.models import (
-    Plot, DataRange1d, ColumnDataSource, ResizeTool
+    Patches, Plot, DataRange1d, ColumnDataSource, ResizeTool
 )
 from bokeh.resources import INLINE
 from bokeh.sampledata import us_states, us_counties, unemployment

--- a/examples/models/colors.py
+++ b/examples/models/colors.py
@@ -3,8 +3,10 @@ from __future__ import print_function
 from math import pi
 import pandas as pd
 
-from bokeh.models import Plot, ColumnDataSource, FactorRange, CategoricalAxis, TapTool, HoverTool, OpenURL
-from bokeh.models.glyphs import Rect
+from bokeh.models import (
+    Plot, ColumnDataSource, FactorRange, CategoricalAxis, TapTool, HoverTool,
+    OpenURL, Rect
+    )
 from bokeh.document import Document
 from bokeh.embed import file_html
 from bokeh.resources import INLINE

--- a/examples/models/colorspec.py
+++ b/examples/models/colorspec.py
@@ -3,9 +3,8 @@ from __future__ import print_function
 from bokeh.util.browser import view
 from bokeh.document import Document
 from bokeh.embed import file_html
-from bokeh.models.glyphs import Circle
 from bokeh.models import (
-    Plot, DataRange1d, LinearAxis, ColumnDataSource, PanTool, WheelZoomTool
+    Circle, Plot, DataRange1d, LinearAxis, ColumnDataSource, PanTool, WheelZoomTool
 )
 from bokeh.resources import INLINE
 

--- a/examples/models/custom.py
+++ b/examples/models/custom.py
@@ -3,10 +3,9 @@ from __future__ import print_function
 from bokeh.core.properties import String
 from bokeh.document import Document
 from bokeh.embed import file_html
-from bokeh.models.callbacks import Callback
-from bokeh.models.glyphs import Circle
-from bokeh.models import Plot, DataRange1d, LinearAxis, ColumnDataSource, PanTool, WheelZoomTool, TapTool
-from bokeh.models.layouts import HBox
+from bokeh.models import (
+    Plot, DataRange1d, LinearAxis, ColumnDataSource, PanTool, WheelZoomTool,
+    TapTool, Callback, Circle, HBox)
 from bokeh.resources import INLINE
 from bokeh.util.browser import view
 

--- a/examples/models/customjs.py
+++ b/examples/models/customjs.py
@@ -3,9 +3,10 @@ from __future__ import print_function
 from bokeh.util.browser import view
 from bokeh.document import Document
 from bokeh.embed import file_html
-from bokeh.models.callbacks import CustomJS
-from bokeh.models.glyphs import Circle
-from bokeh.models import Plot, DataRange1d, LinearAxis, ColumnDataSource, PanTool, WheelZoomTool, TapTool
+from bokeh.models import (
+    Plot, DataRange1d, LinearAxis, ColumnDataSource, PanTool, WheelZoomTool,
+    TapTool, Circle, CustomJS
+    )
 from bokeh.resources import INLINE
 
 source = ColumnDataSource(

--- a/examples/models/data_tables.py
+++ b/examples/models/data_tables.py
@@ -1,6 +1,9 @@
 from bokeh.io import vplot
-from bokeh.models import ColumnDataSource, DataRange1d, Plot, LinearAxis, Grid, Circle, HoverTool, BoxSelectTool
-from bokeh.models.widgets import DataTable, TableColumn, StringFormatter, NumberFormatter, StringEditor, IntEditor, NumberEditor, SelectEditor
+from bokeh.models import (
+    ColumnDataSource, DataRange1d, Plot, LinearAxis, Grid, Circle, HoverTool,
+    BoxSelectTool, DataTable, TableColumn, StringFormatter, NumberFormatter,
+    StringEditor, IntEditor, NumberEditor, SelectEditor
+    )
 from bokeh.embed import file_html
 from bokeh.resources import INLINE
 from bokeh.util.browser import view

--- a/examples/models/data_tables_server.py
+++ b/examples/models/data_tables_server.py
@@ -3,13 +3,11 @@ from __future__ import print_function
 from bokeh.client import push_session
 from bokeh.document import Document
 from bokeh.models import (
-    ColumnDataSource, DataRange1d, Plot, LinearAxis, Grid,
-    Circle, HoverTool, BoxSelectTool
-)
-from bokeh.models.widgets import (
-    Select, DataTable, TableColumn, StringFormatter,
-    NumberFormatter, StringEditor, IntEditor, NumberEditor, SelectEditor)
-from bokeh.models.layouts import HBox, VBox
+    ColumnDataSource, DataRange1d, Plot, LinearAxis, Grid, Circle, HoverTool,
+    BoxSelectTool, Select, DataTable, TableColumn, StringFormatter,
+    NumberFormatter, StringEditor, IntEditor, NumberEditor, SelectEditor,
+    HBox, VBox
+    )
 from bokeh.sampledata.autompg2 import autompg2 as mpg
 
 class DataTables(object):

--- a/examples/models/dateaxis.py
+++ b/examples/models/dateaxis.py
@@ -7,9 +7,8 @@ import time
 from bokeh.util.browser import view
 from bokeh.document import Document
 from bokeh.embed import file_html
-from bokeh.models.glyphs import Circle
 from bokeh.models import (
-    Plot, DataRange1d, DatetimeAxis,
+    Circle, Plot, DataRange1d, DatetimeAxis,
     ColumnDataSource, PanTool, WheelZoomTool
 )
 from bokeh.resources import INLINE

--- a/examples/models/daylight.py
+++ b/examples/models/daylight.py
@@ -6,9 +6,8 @@ import datetime as dt
 from bokeh.util.browser import view
 from bokeh.document import Document
 from bokeh.embed import file_html
-from bokeh.models.glyphs import Patch, Line, Text
 from bokeh.models import (
-    ColumnDataSource, DataRange1d, DatetimeAxis,
+    Patch, Line, Text, ColumnDataSource, DataRange1d, DatetimeAxis,
     DatetimeTickFormatter, Grid, Legend, Plot
 )
 from bokeh.resources import INLINE

--- a/examples/models/donut.py
+++ b/examples/models/donut.py
@@ -7,8 +7,9 @@ from bokeh.util.browser import view
 from bokeh.colors import skyblue, seagreen, tomato, orchid, firebrick, lightgray
 from bokeh.document import Document
 from bokeh.embed import file_html
-from bokeh.models.glyphs import Wedge, AnnularWedge, ImageURL, Text
-from bokeh.models import ColumnDataSource, Plot, Range1d
+from bokeh.models import (
+    Wedge, AnnularWedge, ImageURL, Text, ColumnDataSource, Plot, Range1d
+    )
 from bokeh.resources import INLINE
 from bokeh.sampledata.browsers import browsers_nov_2013, icons
 

--- a/examples/models/gauges.py
+++ b/examples/models/gauges.py
@@ -7,8 +7,7 @@ from bokeh.embed import file_html
 from bokeh.resources import INLINE
 from bokeh.util.browser import view
 
-from bokeh.models.glyphs import Circle, Arc, Ray, Text
-from bokeh.models import ColumnDataSource, Range1d, Plot
+from bokeh.models import Circle, Arc, Ray, Text, ColumnDataSource, Range1d, Plot
 
 xdr = Range1d(start=-1.25, end=1.25)
 ydr = Range1d(start=-1.25, end=1.25)

--- a/examples/models/glyph1.py
+++ b/examples/models/glyph1.py
@@ -5,9 +5,8 @@ from numpy import pi, arange, sin
 from bokeh.util.browser import view
 from bokeh.document import Document
 from bokeh.embed import file_html
-from bokeh.models.glyphs import Circle
 from bokeh.models import (
-    Plot, DataRange1d, LinearAxis, ColumnDataSource, PanTool, WheelZoomTool
+    Circle, Plot, DataRange1d, LinearAxis, ColumnDataSource, PanTool, WheelZoomTool
 )
 from bokeh.resources import INLINE
 

--- a/examples/models/glyph2_server.py
+++ b/examples/models/glyph2_server.py
@@ -4,9 +4,8 @@ from numpy import pi, arange, sin, cos
 
 from bokeh.client import push_session
 from bokeh.document import Document
-from bokeh.models.glyphs import Circle
 from bokeh.models import (
-    Plot, DataRange1d, LinearAxis, Grid,
+    Circle, Plot, DataRange1d, LinearAxis, Grid,
     ColumnDataSource, PanTool, WheelZoomTool
 )
 

--- a/examples/models/glyphs.py
+++ b/examples/models/glyphs.py
@@ -1,13 +1,11 @@
 import numpy as np
 
-from bokeh.models import ColumnDataSource, DataRange1d, Plot, LinearAxis, Grid, HoverTool
-from bokeh.models.widgets import Tabs, Panel, Paragraph
-from bokeh.models.layouts import VBox
-from bokeh.models.glyphs import (
+from bokeh.models import (
     AnnularWedge, Annulus, Arc, Bezier, Gear, Circle, ImageURL, Line, MultiLine, Oval,
     Patch, Patches, Quad, Quadratic, Ray, Rect, Segment, Square, Text, Wedge, CircleX, Triangle,
-    Cross, Diamond, InvertedTriangle, SquareX, Asterisk, SquareCross, DiamondCross, CircleCross, X
-)
+    Cross, Diamond, InvertedTriangle, SquareX, Asterisk, SquareCross, DiamondCross, CircleCross,
+    X, Tabs, Panel, Paragraph, VBox, ColumnDataSource, DataRange1d, Plot, LinearAxis, Grid, HoverTool
+    )
 from bokeh.document import Document
 from bokeh.embed import file_html
 from bokeh.resources import INLINE

--- a/examples/models/grid.py
+++ b/examples/models/grid.py
@@ -5,9 +5,8 @@ from numpy import pi, sin, cos, linspace, tan
 from bokeh.util.browser import view
 from bokeh.document import Document
 from bokeh.embed import file_html
-from bokeh.models.glyphs import Line
 from bokeh.models import (
-    Plot, DataRange1d, LinearAxis, ColumnDataSource,
+    Line, Plot, DataRange1d, LinearAxis, ColumnDataSource,
     PanTool, WheelZoomTool, GridPlot
 )
 from bokeh.resources import INLINE

--- a/examples/models/image_url.py
+++ b/examples/models/image_url.py
@@ -4,8 +4,7 @@ import numpy as np
 from bokeh.util.browser import view
 from bokeh.document import Document
 from bokeh.embed import file_html
-from bokeh.models.glyphs import ImageURL
-from bokeh.models import ColumnDataSource, Range1d, Plot, LinearAxis, Grid
+from bokeh.models import ImageURL, ColumnDataSource, Range1d, Plot, LinearAxis, Grid
 from bokeh.resources import INLINE
 
 url = "http://bokeh.pydata.org/en/latest/_static/images/logo.png"

--- a/examples/models/iris.py
+++ b/examples/models/iris.py
@@ -3,9 +3,9 @@ from __future__ import print_function
 from bokeh.util.browser import view
 from bokeh.document import Document
 from bokeh.embed import file_html
-from bokeh.models.glyphs import Circle
 from bokeh.models import (
-    Plot, DataRange1d, LinearAxis, Grid, ColumnDataSource, PanTool, WheelZoomTool
+    Circle, Plot, DataRange1d, LinearAxis, Grid, ColumnDataSource,
+    PanTool, WheelZoomTool
 )
 from bokeh.resources import INLINE
 from bokeh.sampledata.iris import flowers

--- a/examples/models/iris_splom.py
+++ b/examples/models/iris_splom.py
@@ -2,9 +2,8 @@ from __future__ import print_function
 
 from bokeh.document import Document
 from bokeh.embed import file_html
-from bokeh.models.glyphs import Circle
 from bokeh.models import (
-    BasicTicker, ColumnDataSource, Grid, GridPlot, LinearAxis,
+    Circle, BasicTicker, ColumnDataSource, Grid, GridPlot, LinearAxis,
     DataRange1d, PanTool, Plot, WheelZoomTool
 )
 from bokeh.resources import INLINE

--- a/examples/models/legends.py
+++ b/examples/models/legends.py
@@ -6,9 +6,8 @@ import numpy as np
 from bokeh.util.browser import view
 from bokeh.document import Document
 from bokeh.embed import file_html
-from bokeh.models.glyphs import Line
 from bokeh.models import (
-    Plot, DataRange1d, LinearAxis, ColumnDataSource,
+    Line, Plot, DataRange1d, LinearAxis, ColumnDataSource,
     PanTool, WheelZoomTool, PreviewSaveTool, Legend,
 )
 from bokeh.resources import INLINE

--- a/examples/models/line.py
+++ b/examples/models/line.py
@@ -6,9 +6,8 @@ import numpy as np
 from bokeh.util.browser import view
 from bokeh.document import Document
 from bokeh.embed import file_html
-from bokeh.models.glyphs import Line
 from bokeh.models import (
-    Plot, DataRange1d, LinearAxis, ColumnDataSource,
+    Line, Plot, DataRange1d, LinearAxis, ColumnDataSource,
     PanTool, WheelZoomTool, PreviewSaveTool
 )
 from bokeh.resources import INLINE

--- a/examples/models/maps.py
+++ b/examples/models/maps.py
@@ -3,9 +3,10 @@ from __future__ import print_function
 from bokeh.util.browser import view
 from bokeh.document import Document
 from bokeh.embed import file_html
-from bokeh.models.glyphs import Circle
 from bokeh.models import (
-    GMapPlot, Range1d, ColumnDataSource, PanTool, WheelZoomTool, BoxSelectTool, GMapOptions)
+    Circle, GMapPlot, Range1d, ColumnDataSource, PanTool, WheelZoomTool,
+    BoxSelectTool, GMapOptions
+    )
 from bokeh.resources import INLINE
 
 x_range = Range1d()

--- a/examples/models/maps_cities.py
+++ b/examples/models/maps_cities.py
@@ -2,10 +2,9 @@ from __future__ import print_function
 
 from bokeh.util.browser import view
 from bokeh.embed import file_html
-from bokeh.models.glyphs import Circle
 from bokeh.models import (
     GMapPlot, Range1d, ColumnDataSource,
-    PanTool, WheelZoomTool, GMapOptions)
+    PanTool, WheelZoomTool, GMapOptions, Circle)
 from bokeh.resources import INLINE
 from bokeh.sampledata.world_cities import data
 

--- a/examples/models/population_server.py
+++ b/examples/models/population_server.py
@@ -4,15 +4,11 @@ from math import pi
 
 from bokeh.client import push_session
 from bokeh.document import Document
-from bokeh.models.glyphs import Line, Quad
 from bokeh.models import (
-    Plot, ColumnDataSource, DataRange1d, FactorRange,
-    LinearAxis, CategoricalAxis, Grid, Legend,
-    SingleIntervalTicker
-)
+    Line, Quad, Plot, ColumnDataSource, DataRange1d, FactorRange, LinearAxis,
+    CategoricalAxis, Grid, Legend, SingleIntervalTicker, Select, HBox, VBox
+    )
 from bokeh.sampledata.population import load_population
-from bokeh.models.widgets import Select
-from bokeh.models.layouts import HBox, VBox
 
 document = Document()
 session = push_session(document)

--- a/examples/models/sprint.py
+++ b/examples/models/sprint.py
@@ -4,8 +4,10 @@ from bokeh.document import Document
 from bokeh.embed import file_html
 from bokeh.util.browser import view
 from bokeh.resources import INLINE
-from bokeh.models.glyphs import Circle, Text
-from bokeh.models import ColumnDataSource, Range1d, DataRange1d, Plot, LinearAxis, SingleIntervalTicker, Grid, HoverTool
+from bokeh.models import (
+    Circle, Text, ColumnDataSource, Range1d, DataRange1d, Plot, LinearAxis,
+    SingleIntervalTicker, Grid, HoverTool
+    )
 from bokeh.sampledata.sprint import sprint
 
 # Based on http://www.nytimes.com/interactive/2012/08/05/sports/olympics/the-100-meter-dash-one-race-every-medalist-ever.html

--- a/examples/models/taylor_server.py
+++ b/examples/models/taylor_server.py
@@ -5,10 +5,10 @@ import sympy as sy
 
 from bokeh.client import push_session
 from bokeh.document import Document
-from bokeh.models.glyphs import Line
-from bokeh.models import Plot, Range1d, LinearAxis, ColumnDataSource, Grid, Legend
-from bokeh.models.widgets import Slider, TextInput, Dialog
-from bokeh.models.layouts import HBox, VBox
+from bokeh.models import (
+    Plot, Range1d, LinearAxis, ColumnDataSource, Grid, Legend, Line, Slider,
+    TextInput, Dialog, HBox, VBox
+    )
 
 document = Document()
 session = push_session(document)

--- a/examples/models/tile_source.py
+++ b/examples/models/tile_source.py
@@ -7,10 +7,10 @@ from bokeh.resources import INLINE
 
 from bokeh.plotting import output_file
 
-from bokeh.models import Plot
-from bokeh.models import Range1d
-from bokeh.models import WheelZoomTool, ResizeTool, PanTool, BoxZoomTool
-from bokeh.models import WMTSTileSource
+from bokeh.models import (
+    Plot, Range1d, WheelZoomTool, ResizeTool, PanTool,
+    BoxZoomTool, WMTSTileSource
+    )
 
 output_file("tile_source_example.html", title="Tile Source Example")
 

--- a/examples/models/trail.py
+++ b/examples/models/trail.py
@@ -12,13 +12,12 @@ from bokeh.embed import file_html
 from bokeh.resources import INLINE
 from bokeh.util.browser import view
 
-from bokeh.models.glyphs import Line, Patches
-from bokeh.models.layouts import VBox
 from bokeh.models import (
     Plot, GMapPlot, GMapOptions,
     DataRange1d, ColumnDataSource,
     LinearAxis, Grid,
-    PanTool, WheelZoomTool, ResetTool)
+    PanTool, WheelZoomTool, ResetTool,
+    Line, Patches, VBox)
 
 from bokeh.sampledata.mtb import obiszow_mtb_xcm
 

--- a/examples/models/twin_axis.py
+++ b/examples/models/twin_axis.py
@@ -5,9 +5,8 @@ from numpy import pi, arange, sin, linspace
 from bokeh.util.browser import view
 from bokeh.document import Document
 from bokeh.embed import file_html
-from bokeh.models.glyphs import Circle
 from bokeh.models import (
-    Plot, LinearAxis, ColumnDataSource, Range1d, PanTool, WheelZoomTool
+    Plot, LinearAxis, ColumnDataSource, Range1d, PanTool, WheelZoomTool, Circle
 )
 from bokeh.resources import INLINE
 

--- a/examples/models/widgets_server.py
+++ b/examples/models/widgets_server.py
@@ -5,15 +5,11 @@ from random import randint
 
 from bokeh.client import push_session
 from bokeh.document import Document
-from bokeh.models.glyphs import Line, Circle
 from bokeh.models import (
     Plot, ColumnDataSource, DataRange1d,
-    LinearAxis, DatetimeAxis, Grid, HoverTool
-)
-from bokeh.models.widgets import (
-    Button, TableColumn, DataTable,
-    DateEditor, DateFormatter, IntEditor)
-from bokeh.models.layouts import VBox
+    LinearAxis, DatetimeAxis, Grid, HoverTool, Line, Circle, Button, TableColumn, DataTable,
+    DateEditor, DateFormatter, IntEditor, VBox
+    )
 
 document = Document()
 session = push_session(document)

--- a/examples/plotting/file/custom_datetime_axis.py
+++ b/examples/plotting/file/custom_datetime_axis.py
@@ -2,7 +2,7 @@ from math import pi
 
 import pandas as pd
 
-from bokeh.models.formatters import TickFormatter, String, List
+from bokeh.models import TickFormatter, String, List
 from bokeh.plotting import figure, show, output_file
 from bokeh.sampledata.stocks import MSFT
 

--- a/examples/plotting/server/fourier_animated.py
+++ b/examples/plotting/server/fourier_animated.py
@@ -14,7 +14,7 @@ import numpy as np
 from bokeh.client import push_session
 from bokeh.driving import repeat
 from bokeh.io import vplot
-from bokeh.models.sources import ColumnDataSource as CDS
+from bokeh.models import ColumnDataSource as CDS
 from bokeh.plotting import figure, curdoc
 
 N = 100

--- a/examples/plotting/server/line_animate_widget.py
+++ b/examples/plotting/server/line_animate_widget.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from bokeh.client import push_session
 from bokeh.driving import cosine
-from bokeh.models.widgets import Button
+from bokeh.models import Button
 from bokeh.plotting import figure, curdoc, vplot,  hplot
 
 x = np.linspace(0, 4*pi, 100)
@@ -52,4 +52,3 @@ curdoc().add_periodic_callback(update, 50)
 session.show() # open the document in a browser
 
 session.loop_until_closed() # run forever
-

--- a/setup.py
+++ b/setup.py
@@ -548,7 +548,6 @@ setup(
         'bokeh.application.handlers.tests',
         'bokeh.models',
         'bokeh.models.tests',
-        'bokeh.models.widgets',
         'bokeh.charts',
         'bokeh.charts.builders',
         'bokeh.charts.builders.tests',

--- a/sphinx/source/docs/user_guide/source_examples/interaction_button.py
+++ b/sphinx/source/docs/user_guide/source_examples/interaction_button.py
@@ -1,4 +1,4 @@
-from bokeh.models.widgets import Button
+from bokeh.models import Button
 from bokeh.io import output_file, show, vform
 
 output_file("button.html")

--- a/sphinx/source/docs/user_guide/source_examples/interaction_checkbox_button_group.py
+++ b/sphinx/source/docs/user_guide/source_examples/interaction_checkbox_button_group.py
@@ -1,4 +1,4 @@
-from bokeh.models.widgets import CheckboxButtonGroup
+from bokeh.models import CheckboxButtonGroup
 from bokeh.io import output_file, show, vform
 
 output_file("checkbox_button_group.html")

--- a/sphinx/source/docs/user_guide/source_examples/interaction_checkbox_group.py
+++ b/sphinx/source/docs/user_guide/source_examples/interaction_checkbox_group.py
@@ -1,4 +1,4 @@
-from bokeh.models.widgets import CheckboxGroup
+from bokeh.models import CheckboxGroup
 from bokeh.io import output_file, show, vform
 
 output_file("checkbox_group.html")

--- a/sphinx/source/docs/user_guide/source_examples/interaction_data_table.py
+++ b/sphinx/source/docs/user_guide/source_examples/interaction_data_table.py
@@ -1,8 +1,7 @@
 from datetime import date
 from random import randint
 
-from bokeh.models import ColumnDataSource
-from bokeh.models.widgets import DataTable, DateFormatter, TableColumn
+from bokeh.models import DataTable, DateFormatter, TableColumn, ColumnDataSource
 from bokeh.io import output_file, show, vform
 
 output_file("data_table.html")

--- a/sphinx/source/docs/user_guide/source_examples/interaction_dropdown_menu.py
+++ b/sphinx/source/docs/user_guide/source_examples/interaction_dropdown_menu.py
@@ -1,4 +1,4 @@
-from bokeh.models.widgets import Dropdown
+from bokeh.models import Dropdown
 from bokeh.io import output_file, show, vform
 
 output_file("dropdown.html")

--- a/sphinx/source/docs/user_guide/source_examples/interaction_multiselect.py
+++ b/sphinx/source/docs/user_guide/source_examples/interaction_multiselect.py
@@ -1,4 +1,4 @@
-from bokeh.models.widgets import MultiSelect
+from bokeh.models import MultiSelect
 from bokeh.io import output_file, show, vform
 
 output_file("multi_select.html")

--- a/sphinx/source/docs/user_guide/source_examples/interaction_radio_button_group.py
+++ b/sphinx/source/docs/user_guide/source_examples/interaction_radio_button_group.py
@@ -1,4 +1,4 @@
-from bokeh.models.widgets import RadioButtonGroup
+from bokeh.models import RadioButtonGroup
 from bokeh.io import output_file, show, vform
 
 output_file("radio_button_group.html")

--- a/sphinx/source/docs/user_guide/source_examples/interaction_radio_group.py
+++ b/sphinx/source/docs/user_guide/source_examples/interaction_radio_group.py
@@ -1,4 +1,4 @@
-from bokeh.models.widgets import RadioGroup
+from bokeh.models import RadioGroup
 from bokeh.io import output_file, show, vform
 
 output_file("radio_group.html")

--- a/sphinx/source/docs/user_guide/source_examples/interaction_select.py
+++ b/sphinx/source/docs/user_guide/source_examples/interaction_select.py
@@ -1,4 +1,4 @@
-from bokeh.models.widgets import Select
+from bokeh.models import Select
 from bokeh.io import output_file, show, vform
 
 output_file("select.html")

--- a/sphinx/source/docs/user_guide/source_examples/interaction_slider.py
+++ b/sphinx/source/docs/user_guide/source_examples/interaction_slider.py
@@ -1,4 +1,4 @@
-from bokeh.models.widgets import Slider
+from bokeh.models import Slider
 from bokeh.io import output_file, show, vform
 
 output_file("slider.html")

--- a/sphinx/source/docs/user_guide/source_examples/interaction_tab_panes.py
+++ b/sphinx/source/docs/user_guide/source_examples/interaction_tab_panes.py
@@ -1,4 +1,4 @@
-from bokeh.models.widgets import Panel, Tabs
+from bokeh.models import Panel, Tabs
 from bokeh.io import output_file, show
 from bokeh.plotting import figure
 

--- a/sphinx/source/docs/user_guide/source_examples/interaction_textinput.py
+++ b/sphinx/source/docs/user_guide/source_examples/interaction_textinput.py
@@ -1,4 +1,4 @@
-from bokeh.models.widgets import TextInput
+from bokeh.models import TextInput
 from bokeh.io import output_file, show, vform
 
 output_file("text_input.html")

--- a/sphinx/source/docs/user_guide/source_examples/interaction_toggle_button.py
+++ b/sphinx/source/docs/user_guide/source_examples/interaction_toggle_button.py
@@ -1,4 +1,4 @@
-from bokeh.models.widgets import Toggle
+from bokeh.models import Toggle
 from bokeh.io import output_file, show, vform
 
 output_file("toggle.html")


### PR DESCRIPTION
Remove attribute imports from examples so that:

```python
from bokeh.models.sources import ColumnDataSource
from bokeh.models.widgets import HBox
from bokeh.models.glyphs import Rect, Circle
...
```
becomes
```python
from bokeh.models import ColumnDataSource, HBox, Rect, Circle
```

Todo: deprecate something