### PR TITLE
Fix bad layouts imports in examples

### DIFF
--- a/bokeh/models/__init__.py
+++ b/bokeh/models/__init__.py
@@ -21,4 +21,14 @@ from .sources import *
 from .tickers import *
 from .tiles import *
 from .tools import *
-from .widgets import *
+
+## in order to not import .widgets.layouts
+from .widgets.buttons import *
+from .widgets.dialogs import *
+from .widgets.groups import *
+from .widgets.icons import *
+from .widgets.inputs import *
+from .widgets.markups import *
+from .widgets.panels import *
+from .widgets.tables import *
+from .widgets.widget import *

--- a/bokeh/models/__init__.py
+++ b/bokeh/models/__init__.py
@@ -22,7 +22,12 @@ from .tickers import *
 from .tiles import *
 from .tools import *
 
-## in order to not import .widgets.layouts
+### Deprecation note:
+### bokeh.models.widgets.layouts was deprecated in 0.11.1 in favor of 
+### bokeh.models.layouts and is awaiting removal. The following imports will
+### load all widgets modules except layouts, in order to prevent raising a
+### deprecation warning.
+
 from .widgets.buttons import *
 from .widgets.dialogs import *
 from .widgets.groups import *

--- a/bokeh/models/widgets/__init__.py
+++ b/bokeh/models/widgets/__init__.py
@@ -14,7 +14,11 @@ from .panels import *
 from .tables import *
 from .widget import *
 
-# Deprecation for layouts imports from bokeh.models.widgets
+### Deprecation note:
+### bokeh.models.widgets.layouts has been deprecated in 0.11.1 in favor of
+### bokeh.models.layouts and is awaiting removal. The following imports will
+### allow layouts to be imported from bokeh.models.widgets during the
+### deprecation cycle, but doing so will raise a warning.
 
 from bokeh.models.layouts import *
 

--- a/bokeh/models/widgets/__init__.py
+++ b/bokeh/models/widgets/__init__.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 
-# This file is excluded from flake8 checking in setup.cfg
+from bokeh.util.deprecate import deprecatedModuleAttribute
 
+# This file is excluded from flake8 checking in setup.cfg
 
 from .buttons import *
 from .dialogs import *
@@ -12,3 +13,17 @@ from .markups import *
 from .panels import *
 from .tables import *
 from .widget import *
+
+# Deprecation for layouts imports from bokeh.models.widgets
+
+from bokeh.models.layouts import *
+
+for layout in [BaseBox, Layout, HBox, VBox, VBoxForm]:
+    deprecatedModuleAttribute(
+        "0.11.1",
+        "use 'bokeh.models.%s' or 'bokeh.models.layouts.%s'" % (layout.__name__, layout.__name__),
+        __name__,
+        "%s" % (layout.__name__)
+    )
+
+del deprecatedModuleAttribute

--- a/bokeh/models/widgets/layouts.py
+++ b/bokeh/models/widgets/layouts.py
@@ -1,0 +1,9 @@
+
+from bokeh.util.deprecate import deprecated_module
+deprecated_module(
+    'bokeh.models.widgets.layouts',
+    '0.11.1',
+    'use bokeh.models.layouts instead')
+del deprecated_module
+
+from ..layouts import * # NOQA

--- a/bokeh/models/widgets/layouts.py
+++ b/bokeh/models/widgets/layouts.py
@@ -1,4 +1,10 @@
 
+### Deprecation note:
+### bokeh.models.widgets.layouts has been deprecated in 0.11.1 in favor of
+### bokeh.models.layouts and is awaiting removal. The following imports will
+### allow layouts to be imported from bokeh.models.widgets during the
+### deprecation cycle, but doing so will raise a warning.
+
 from bokeh.util.deprecate import deprecated_module
 deprecated_module(
     'bokeh.models.widgets.layouts',

--- a/examples/app/movies/main.py
+++ b/examples/app/movies/main.py
@@ -5,8 +5,8 @@ import pandas.io.sql as psql
 import sqlite3 as sql
 
 from bokeh.plotting import Figure
-from bokeh.models import ColumnDataSource, HoverTool
-from bokeh.models.widgets import HBox, Slider, VBoxForm, Select, TextInput
+from bokeh.models import ColumnDataSource, HoverTool, HBox, VBoxForm
+from bokeh.models.widgets import Slider, Select, TextInput
 from bokeh.io import curdoc
 from bokeh.sampledata.movies_data import movie_path
 

--- a/examples/app/sliders.py
+++ b/examples/app/sliders.py
@@ -17,8 +17,8 @@ in your browser.
 import numpy as np
 
 from bokeh.plotting import Figure
-from bokeh.models import ColumnDataSource
-from bokeh.models.widgets import HBox, Slider, TextInput, VBoxForm
+from bokeh.models import ColumnDataSource, HBox, VBoxForm
+from bokeh.models.widgets import Slider, TextInput
 from bokeh.io import curdoc
 
 # Set up data

--- a/examples/app/stocks/main.py
+++ b/examples/app/stocks/main.py
@@ -36,8 +36,8 @@ from os.path import dirname, join
 import pandas as pd
 
 from bokeh.charts import Histogram
-from bokeh.models import ColumnDataSource, GridPlot
-from bokeh.models.widgets import HBox, VBox, PreText, Select
+from bokeh.models import ColumnDataSource, GridPlot, HBox, VBox
+from bokeh.models.widgets import PreText, Select
 from bokeh.plotting import Figure
 
 from bokeh.io import curdoc


### PR DESCRIPTION
supersedes #3756 

Todo:
deprecate `bokeh.models.widgets.layouts` import path