### PR TITLE
Don't use spaces in JSON separators to reduce data size

### DIFF
--- a/bokeh/core/json_encoder.py
+++ b/bokeh/core/json_encoder.py
@@ -80,10 +80,18 @@ class BokehJSONEncoder(json.JSONEncoder):
         else:
             return self.transform_python_types(obj)
 
-def serialize_json(obj, encoder=BokehJSONEncoder, **kwargs):
+def serialize_json(obj, encoder=BokehJSONEncoder, indent=None, **kwargs):
     ''' Return a serialized JSON representation of a Bokeh model.
 
     '''
-    if kwargs.get("indent", None) is None and settings.pretty(False):
-        kwargs["indent"] = 2
-    return json.dumps(obj, cls=encoder, sort_keys=True, allow_nan=False, **kwargs)
+    pretty = settings.pretty(False)
+
+    if pretty:
+        separators=(",", ": ")
+    else:
+        separators=(",", ":")
+
+    if pretty and indent is None:
+        indent = 2
+
+    return json.dumps(obj, cls=encoder, allow_nan=False, indent=indent, separators=separators, sort_keys=True, **kwargs)

--- a/bokeh/core/tests/test_json_encoder.py
+++ b/bokeh/core/tests/test_json_encoder.py
@@ -60,16 +60,16 @@ class TestSerializeJson(unittest.TestCase):
         self.deserialize = loads
 
     def test_with_basic(self):
-        self.assertEqual(self.serialize({'test': [1, 2, 3]}), '{"test": [1, 2, 3]}')
+        self.assertEqual(self.serialize({'test': [1, 2, 3]}), '{"test":[1,2,3]}')
 
     def test_with_np_array(self):
         a = np.arange(5)
-        self.assertEqual(self.serialize(a), '[0, 1, 2, 3, 4]')
+        self.assertEqual(self.serialize(a), '[0,1,2,3,4]')
 
     @skipIf(not is_pandas, "pandas does not work in PyPy.")
     def test_with_pd_series(self):
         s = pd.Series([0, 1, 2, 3, 4])
-        self.assertEqual(self.serialize(s), '[0, 1, 2, 3, 4]')
+        self.assertEqual(self.serialize(s), '[0,1,2,3,4]')
 
     def test_nans_and_infs(self):
         arr = np.array([np.nan, np.inf, -np.inf, 0])

--- a/bokeh/tests/test_objects.py
+++ b/bokeh/tests/test_objects.py
@@ -194,9 +194,9 @@ class TestModel(unittest.TestCase):
                            "foo" : 42,
                            "bar" : "world" },
                          json)
-        self.assertEqual(('{"bar": "world", ' +
-                          '"child": {"id": "%s", "type": "SomeModelToJson"}, ' +
-                          '"foo": 42, "id": "%s", "name": null, "tags": []}') %
+        self.assertEqual(('{"bar":"world",' +
+                          '"child":{"id":"%s","type":"SomeModelToJson"},' +
+                          '"foo":42,"id":"%s","name":null,"tags":[]}') %
                          (child_obj._id, obj._id),
                          json_string)
 

--- a/bokehjs/gulp/tasks/defaults.coffee
+++ b/bokehjs/gulp/tasks/defaults.coffee
@@ -21,9 +21,12 @@ gulp.task "defaults:generate", (cb) ->
       cwd: bokehjsdir
     })
     handle.stdout.on 'data', (data) ->
-      console.log("generate_defaults.py: #{data}")
+      ("" + data)
+        .split('\n')
+        .filter (line) -> line.trim().length != 0
+        .forEach (line) -> gutil.log("generate_defaults.py: #{line}")
     handle.stderr.on 'data', (data) ->
-      console.log("generate_defaults.py: #{data}")
+      gutil.log("generate_defaults.py: #{data}")
     handle.on 'close', (code) ->
       if code != 0
         cb(new Error("generate_defaults.py exited code #{code}"))
@@ -32,4 +35,3 @@ gulp.task "defaults:generate", (cb) ->
 
   generateDefaults(cb)
   null # XXX: this is extremely important to allow cb() to work
-

--- a/bokehjs/gulp/tasks/generate_defaults.py
+++ b/bokehjs/gulp/tasks/generate_defaults.py
@@ -72,10 +72,9 @@ for leaf_widget in leaves(all_tree, widget_class):
         del all_json[vm_name]
 
 def output_defaults_module(filename, defaults):
-    output = serialize_json(defaults, indent=4, separators=[',', ':'])
-    coffee_template = \
-    """
-all_defaults = %s;
+    output = serialize_json(defaults, indent=2)
+    coffee_template = """\
+all_defaults = %s
 
 get_defaults = (name) ->
   if name of all_defaults


### PR DESCRIPTION
This reduces size of choropleth.html by ~10% (1MB).