### PR TITLE
Publish bokehjs separately in a notebook to avoid parsing issues in jquery

### DIFF
--- a/bokeh/core/_templates/autoload_js.js
+++ b/bokeh/core/_templates/autoload_js.js
@@ -78,7 +78,7 @@ calls it with the rendered model.
     console.log("Bokeh: ERROR: autoload.js configured with elementid '{{ elementid }}' but no matching script tag was found. ")
     return false;
   }
-  {%- endif -%}
+  {%- endif %}
 
   var js_urls = {{ js_urls }};
 

--- a/bokeh/core/_templates/notebook_load.html
+++ b/bokeh/core/_templates/notebook_load.html
@@ -24,11 +24,6 @@ Notebook according to a Resources object.
 :type warnings: list[str]
 
 #}
-
-    <script type="text/javascript">
-      {{ bootstrap|indent(6) }}
-    </script>
-
     {%- if not hide_banner %}
     <div>
         <a href="http://bokeh.pydata.org" target="_blank" class="bk-logo bk-logo-small bk-logo-notebook"></a>

--- a/bokeh/core/_templates/notebook_load.html
+++ b/bokeh/core/_templates/notebook_load.html
@@ -27,7 +27,7 @@ Notebook according to a Resources object.
     {%- if not hide_banner %}
     <div>
         <a href="http://bokeh.pydata.org" target="_blank" class="bk-logo bk-logo-small bk-logo-notebook"></a>
-        <span>BokehJS successfully loaded.</span>
+        <span id="{{ element_id }}">Loading BokehJS ...</span>
     </div>
 
     {%- if verbose %}

--- a/bokeh/core/_templates/notebook_load.html
+++ b/bokeh/core/_templates/notebook_load.html
@@ -25,7 +25,7 @@ Notebook according to a Resources object.
 
 #}
     {%- if not hide_banner %}
-    <div>
+    <div class="bk-banner">
         <a href="http://bokeh.pydata.org" target="_blank" class="bk-logo bk-logo-small bk-logo-notebook"></a>
         <span id="{{ element_id }}">Loading BokehJS ...</span>
     </div>

--- a/bokeh/util/notebook.py
+++ b/bokeh/util/notebook.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 
 _notebook_loaded = None
 
-
 def load_notebook(resources=None, verbose=False, hide_banner=False):
     ''' Prepare the IPython notebook for displaying Bokeh plots.
 
@@ -27,8 +26,9 @@ def load_notebook(resources=None, verbose=False, hide_banner=False):
         None
 
     '''
-    html = _load_notebook_html(resources, verbose, hide_banner)
+    html, js = _load_notebook_html(resources, verbose, hide_banner)
     publish_display_data({'text/html': html})
+    publish_display_data({'application/javascript': js})
 
 def _load_notebook_html(resources=None, verbose=False, hide_banner=False):
     global _notebook_loaded
@@ -54,26 +54,25 @@ def _load_notebook_html(resources=None, verbose=False, hide_banner=False):
 
     _notebook_loaded = resources
 
-    js = AUTOLOAD_JS.render(
-        js_urls = resources.js_files,
-        css_urls = resources.css_files,
-        js_raw = resources.js_raw,
-        css_raw = resources.css_raw_str,
-        elementid = None,
-    )
 
     html = NOTEBOOK_LOAD.render(
-        bootstrap=js,
-        logo_url=resources.logo_url,
-        verbose=verbose,
-        js_info=js_info,
-        css_info=css_info,
-        bokeh_version=__version__,
-        warnings=warnings,
-        hide_banner=hide_banner,
+        logo_url      = resources.logo_url,
+        verbose       = verbose,
+        js_info       = js_info,
+        css_info      = css_info,
+        bokeh_version = __version__,
+        warnings      = warnings,
+        hide_banner   = hide_banner,
     )
 
-    return html
+    js = AUTOLOAD_JS.render(
+        js_urls  = resources.js_files,
+        css_urls = resources.css_files,
+        js_raw   = resources.js_raw],
+        css_raw  = resources.css_raw_str,
+    )
+
+    return html, js
 
 def publish_display_data(data, source='bokeh'):
     ''' Compatibility wrapper for IPython ``publish_display_data``

--- a/bokeh/util/notebook.py
+++ b/bokeh/util/notebook.py
@@ -35,6 +35,7 @@ def _load_notebook_html(resources=None, verbose=False, hide_banner=False):
 
     from .. import __version__
     from ..core.templates import AUTOLOAD_JS, NOTEBOOK_LOAD
+    from ..util.serialization import make_id
     from ..resources import CDN
 
     if resources is None:
@@ -54,8 +55,10 @@ def _load_notebook_html(resources=None, verbose=False, hide_banner=False):
 
     _notebook_loaded = resources
 
+    element_id = make_id()
 
     html = NOTEBOOK_LOAD.render(
+        element_id    = element_id,
         logo_url      = resources.logo_url,
         verbose       = verbose,
         js_info       = js_info,
@@ -65,10 +68,12 @@ def _load_notebook_html(resources=None, verbose=False, hide_banner=False):
         hide_banner   = hide_banner,
     )
 
+    finalize_js = """Bokeh.$("#%s").text("BokehJS successfully loaded");""" % element_id
+
     js = AUTOLOAD_JS.render(
         js_urls  = resources.js_files,
         css_urls = resources.css_files,
-        js_raw   = resources.js_raw],
+        js_raw   = resources.js_raw + [finalize_js],
         css_raw  = resources.css_raw_str,
     )
 

--- a/bokehjs/src/less/continuum.less
+++ b/bokehjs/src/less/continuum.less
@@ -94,7 +94,14 @@
 }
 
 .bk-logo-notebook {
-  margin-right: 10px;
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 5px;
+}
+
+.bk-banner > span {
+  display: inline-block;
+  vertical-align: middle;
 }
 
 .bk-logo-small {


### PR DESCRIPTION
Publishing separately as `application/json` allows to use a different code path in ipython notebook, which doesn't require jquery (just a simple eval) and thus allows to load bokehjs without issues. I also added simple notification when bokehjs is actually loaded and improved styling of bokehjs' notebook banner.