### PR TITLE
use import_required for nbformat and nbconvert

### DIFF
--- a/bokeh/application/handlers/notebook.py
+++ b/bokeh/application/handlers/notebook.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, print_function
 
-import nbformat
-from nbconvert import PythonExporter
+from bokeh.util.dependencies import import_required
 
 from .code import CodeHandler
 
@@ -12,18 +11,22 @@ class NotebookHandler(CodeHandler):
         filename (str) : a path to a Jupyter notebook (".ipynb") file
 
     """
-
+    
     _logger_text = "%s: call to %s() ignored when running notebooks with the 'bokeh' command."
 
     _origin = "Notebook"
 
     def __init__(self, *args, **kwargs):
+        
+        nbformat = import_required('nbformat', 'The Bokeh notebook application handler requires Jupyter Notebook to be installed.')
+        nbconvert = import_required('nbconvert', 'The Bokeh notebook application handler requires Jupyter Notebook to be installed.')
+        
         if 'filename' not in kwargs:
             raise ValueError('Must pass a filename to NotebookHandler')
 
         with open(kwargs['filename']) as f:
             nb = nbformat.read(f, nbformat.NO_CONVERT)
-            exporter = PythonExporter()
+            exporter = nbconvert.PythonExporter()
             source, meta = exporter.from_notebook_node(nb)
             kwargs['source'] = source
 


### PR DESCRIPTION
Use import_required for nbformat and nbconvert and move the import
into __init__ so that not having Jupyter Notebook installed doesn't
cause errors when attempting unrelated uses of Bokeh.