### PR TITLE
Remove 0.11.0 versions from ALL_VERSIONS tag which controls dropdown

### DIFF
--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -165,7 +165,7 @@ html_context = {
         ('Releases', 'releases/%s' % version),
         ('Developer Guide', 'dev_guide'),
     ),
-    'ALL_VERSIONS': ['0.11.0', '0.11.0', '0.10.0', '0.9.3', '0.8.2'],
+    'ALL_VERSIONS': ['0.10.0', '0.9.3', '0.8.2'],
     'css_server': os.environ.get('BOKEH_DOCS_CSS_SERVER', 'bokehplots.com'),
 }
 


### PR DESCRIPTION
0.11.1 is the latest 0.11 release, so we don't need to reference it in the
dropdown (following the previous pattern)