### PR TITLE
Simplify shapefile (.shp) w/ Bokeh Server + GeoPandas

### DIFF
--- a/bokeh/sampledata/__init__.py
+++ b/bokeh/sampledata/__init__.py
@@ -112,12 +112,17 @@ def _getfile(base_url, file_name, data_dir, progress=True):
     real_name, ext = splitext(file_name)
 
     if ext == '.zip':
+
         if not splitext(real_name)[1]:
             real_name += ".csv"
 
         print("Unpacking: %s" % real_name)
 
-        with ZipFile(file_path, 'r') as zip_file:
-            zip_file.extract(real_name, data_dir)
+        if splitext(real_name)[1] == '.shp':
+            with ZipFile(file_path, 'r') as zip_file:
+                zip_file.extractall(data_dir)
+        else:
+            with ZipFile(file_path, 'r') as zip_file:
+                zip_file.extract(real_name, data_dir)
 
         remove(file_path)

--- a/bokeh/sampledata/__init__.py
+++ b/bokeh/sampledata/__init__.py
@@ -74,6 +74,7 @@ def download(progress=True):
         (s3, 'world_cities.zip'),
         (s3, 'airports.json'),
         (s3, 'movies.db.zip'),
+        (s3, 'us_states.shp.zip'),
     ]
 
     for base_url, file_name in files:

--- a/bokeh/sampledata/us_states_shp.py
+++ b/bokeh/sampledata/us_states_shp.py
@@ -6,5 +6,5 @@ path1 = join(dirname(__file__), 'us_states.shp')
 path2 = expanduser('~/.bokeh/data/us_states.shp')
 shp_path = path1 if isfile(path1) else path2
 
-if not isfile(movie_path):
+if not isfile(shp_path):
     raise RuntimeError('Use bokeh.sampledata.download to get the US State shapefile data.')

--- a/bokeh/sampledata/us_states_shp.py
+++ b/bokeh/sampledata/us_states_shp.py
@@ -1,0 +1,10 @@
+from __future__ import absolute_import
+
+from os.path import dirname, join, isfile, expanduser
+
+path1 = join(dirname(__file__), 'us_states.shp')
+path2 = expanduser('~/.bokeh/data/us_states.shp')
+shp_path = path1 if isfile(path1) else path2
+
+if not isfile(movie_path):
+    raise RuntimeError('Use bokeh.sampledata.download to get the US State shapefile data.')

--- a/examples/app/simplify_shapefile/README.md
+++ b/examples/app/simplify_shapefile/README.md
@@ -11,10 +11,7 @@ To verify GeoPandas has been installed, start an interactive python session and 
 `bokeh serve examples/app/simplify_shapefile`
 
 - To simplify geometry, drag the slider at the top of the screen to the desired amount of simplification
-- Once the desired amount of simplification is achieved, the user can save the geometry to a new shapefile.
 
 ####Notes:
 
 - Simplification uses the [Ramer-Douglas-Peucker](https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm) algorithm available through [GeoPandas](http://geopandas.org) which does not preserve shared boundaries between independent polygon features.
-
-- Output shapefile will be written to the current user's home directory `_simplified_{tolerance}.shp` suffix.

--- a/examples/app/simplify_shapefile/README.md
+++ b/examples/app/simplify_shapefile/README.md
@@ -1,0 +1,13 @@
+### Interactive Polygon Simplification using Bokeh Server and GeoPandas
+
+The following example uses GeoPandas to simplify a shapefile.
+
+The amount of simplification is determined by the user through use of a slider component.
+
+Once the desired amount of simplification is achieved, the user can save the geometry to a new shapefile.
+
+####Note:
+
+- Simplification uses the [Ramer-Douglas-Peucker](https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm) algorithm available through [GeoPandas](http://geopandas.org) which does not preserve shared boundaries between independent polygon features.
+
+- Output shapefile will be written to directory which contains input shapefile with a `_simplified.shp` suffix.

--- a/examples/app/simplify_shapefile/README.md
+++ b/examples/app/simplify_shapefile/README.md
@@ -1,13 +1,20 @@
 ### Interactive Polygon Simplification using Bokeh Server and GeoPandas
 
-The following example uses GeoPandas to simplify a shapefile.
+#### Prerequisites:
+- This example requires [GeoPandas](http://geopandas.org). The simpliest way to install geopandas is through the `ioos` conda channel using:
+`conda install -c ioos geopandas`
 
-The amount of simplification is determined by the user through use of a slider component.
+To verify GeoPandas has been installed, start an interactive python session and type `import geopandas` to confirm it imports without error. 
 
-Once the desired amount of simplification is achieved, the user can save the geometry to a new shapefile.
+#### Usage:
+- To run example:
+`bokeh serve examples/app/simplify_shapefile`
 
-####Note:
+- To simplify geometry, drag the slider at the top of the screen to the desired amount of simplification
+- Once the desired amount of simplification is achieved, the user can save the geometry to a new shapefile.
+
+####Notes:
 
 - Simplification uses the [Ramer-Douglas-Peucker](https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm) algorithm available through [GeoPandas](http://geopandas.org) which does not preserve shared boundaries between independent polygon features.
 
-- Output shapefile will be written to directory which contains input shapefile with a `_simplified.shp` suffix.
+- Output shapefile will be written to the current user's home directory `_simplified_{tolerance}.shp` suffix.

--- a/examples/app/simplify_shapefile/main.py
+++ b/examples/app/simplify_shapefile/main.py
@@ -1,0 +1,59 @@
+from __future__ import print_function
+
+try:
+    import geopandas as gpd
+except ImportError:
+    print('''This example requires GeoPandas
+          (http://geopandas.org/)
+          \n try: pip install geopandas''')
+
+from bokeh.plotting import Figure
+from bokeh.io import curdoc
+from bokeh.models import (GeoJSONDataSource, Slider,
+                          VBox, Button, Paragraph, HBox)
+
+def simplify_features():
+    global geo_source
+    states_view['geometry'] = states.simplify(simplify_tolerance,
+                                              preserve_topology=True)
+    geo_source.geojson = states_view.to_json()
+
+def save_to_shapefile():
+    states_view.to_file('fout.shp')
+
+def on_slider_change(attr, old, new):
+    global simplify_tolerance
+    simplify_tolerance = new
+    simplify_features()
+
+# TODO: Add description paragraph
+
+# TODO: Ouput file paragraph
+
+# TODO: Resize button
+
+# load shapefile
+simplify_tolerance = 0
+shapefile_path = '/Users/bcollins/Downloads/states_21basic/states.shp'
+states = gpd.read_file(shapefile_path)
+states_view = gpd.read_file(shapefile_path)
+geo_source = GeoJSONDataSource(geojson=states_view.to_json())
+bounds = states.total_bounds
+
+# let's read some shapefile metadata
+crs = states.crs
+simplify_slider = Slider(title='Simplify Tolerance',
+                         value=0, start=0, end=1, step=.01)
+simplify_slider.on_change('value', on_slider_change)
+
+save_button = Button(label='Save')
+save_button.on_click(save_to_shapefile)
+
+p = Figure(plot_height=600, plot_width=900,
+           x_range=(bounds[0], bounds[2]), y_range=(bounds[1], bounds[3]))
+
+polys = p.patches(xs='xs', ys='ys', alpha=0.9, source=geo_source)
+
+controls = HBox(width=p.plot_width, children=[simplify_slider, save_button])
+layout = VBox(width=p.plot_width, children=[controls, p])
+curdoc().add_root(layout)

--- a/examples/app/simplify_shapefile/main.py
+++ b/examples/app/simplify_shapefile/main.py
@@ -1,12 +1,10 @@
 from __future__ import print_function
-from os import path
 
 import geopandas as gpd
 
 from bokeh.plotting import Figure
 from bokeh.io import curdoc
-from bokeh.models import (GeoJSONDataSource, Slider,
-                          VBox, Button, Paragraph, HBox)
+from bokeh.models import GeoJSONDataSource, Slider, VBox
 
 from bokeh.sampledata.us_states_shp import shp_path
 
@@ -15,13 +13,6 @@ def simplify_features():
     states_view['geometry'] = states.simplify(simplify_tolerance,
                                               preserve_topology=True)
     geo_source.geojson = states_view.to_json()
-
-def save_to_shapefile():
-    _, input_file = path.split(shp_path)
-    input_shp_name = path.splitext(input_file)[0]
-    output_shp_name = '{}_simplified_{}.shp'.format(input_shp_name, simplify_tolerance)
-    output_full_path = path.join(path.expanduser('~'), output_shp_name)
-    status.text = 'Saved file: {}'.format(output_full_path)
 
 def on_slider_change(attr, old, new):
     global simplify_tolerance
@@ -36,19 +27,13 @@ bounds = states.total_bounds
 
 simplify_slider = Slider(title='Simplify Tolerance',
                          value=0, start=0, end=3, step=.1)
-
 simplify_slider.on_change('value', on_slider_change)
-
-save_button = Button(label='Save')
-save_button.on_click(save_to_shapefile)
 
 p = Figure(plot_height=600, plot_width=900,
            x_range=(bounds[0], bounds[2]),
            y_range=(bounds[1], bounds[3]),
            tools='pan,wheel_zoom')
 
-polys = p.patches(xs='xs', ys='ys', alpha=0.9, source=geo_source)
-status = Paragraph(text='')
-controls = HBox(width=p.plot_width, children=[simplify_slider, save_button, status])
-layout = VBox(width=p.plot_width, children=[controls, p])
+p.patches(xs='xs', ys='ys', alpha=0.9, source=geo_source)
+layout = VBox(width=p.plot_width, children=[simplify_slider, p])
 curdoc().add_root(layout)

--- a/examples/app/simplify_shapefile/main.py
+++ b/examples/app/simplify_shapefile/main.py
@@ -1,16 +1,14 @@
 from __future__ import print_function
+from os import path
 
-try:
-    import geopandas as gpd
-except ImportError:
-    print('''This example requires GeoPandas
-          (http://geopandas.org/)
-          \n try: pip install geopandas''')
+import geopandas as gpd
 
 from bokeh.plotting import Figure
 from bokeh.io import curdoc
 from bokeh.models import (GeoJSONDataSource, Slider,
                           VBox, Button, Paragraph, HBox)
+
+from bokeh.sampledata.us_states_shp import shp_path
 
 def simplify_features():
     global geo_source
@@ -19,41 +17,38 @@ def simplify_features():
     geo_source.geojson = states_view.to_json()
 
 def save_to_shapefile():
-    states_view.to_file('fout.shp')
+    _, input_file = path.split(shp_path)
+    input_shp_name = path.splitext(input_file)[0]
+    output_shp_name = '{}_simplified_{}.shp'.format(input_shp_name, simplify_tolerance) 
+    output_full_path = path.join(path.expanduser('~'), output_shp_name)
+    status.text = 'Saved file: {}'.format(output_full_path)
 
 def on_slider_change(attr, old, new):
     global simplify_tolerance
     simplify_tolerance = new
     simplify_features()
 
-# TODO: Add description paragraph
-
-# TODO: Ouput file paragraph
-
-# TODO: Resize button
-
-# load shapefile
 simplify_tolerance = 0
-shapefile_path = '/Users/bcollins/Downloads/states_21basic/states.shp'
-states = gpd.read_file(shapefile_path)
-states_view = gpd.read_file(shapefile_path)
+states = gpd.read_file(shp_path)
+states_view = states.copy()
 geo_source = GeoJSONDataSource(geojson=states_view.to_json())
 bounds = states.total_bounds
 
-# let's read some shapefile metadata
-crs = states.crs
 simplify_slider = Slider(title='Simplify Tolerance',
-                         value=0, start=0, end=1, step=.01)
+                         value=0, start=0, end=3, step=.1)
+
 simplify_slider.on_change('value', on_slider_change)
 
 save_button = Button(label='Save')
 save_button.on_click(save_to_shapefile)
 
 p = Figure(plot_height=600, plot_width=900,
-           x_range=(bounds[0], bounds[2]), y_range=(bounds[1], bounds[3]))
+           x_range=(bounds[0], bounds[2]), 
+           y_range=(bounds[1], bounds[3]),
+           tools='pan,wheel_zoom')
 
 polys = p.patches(xs='xs', ys='ys', alpha=0.9, source=geo_source)
-
-controls = HBox(width=p.plot_width, children=[simplify_slider, save_button])
+status  = Paragraph(text='')
+controls = HBox(width=p.plot_width, children=[simplify_slider, save_button, status])
 layout = VBox(width=p.plot_width, children=[controls, p])
 curdoc().add_root(layout)

--- a/examples/app/simplify_shapefile/main.py
+++ b/examples/app/simplify_shapefile/main.py
@@ -19,7 +19,7 @@ def simplify_features():
 def save_to_shapefile():
     _, input_file = path.split(shp_path)
     input_shp_name = path.splitext(input_file)[0]
-    output_shp_name = '{}_simplified_{}.shp'.format(input_shp_name, simplify_tolerance) 
+    output_shp_name = '{}_simplified_{}.shp'.format(input_shp_name, simplify_tolerance)
     output_full_path = path.join(path.expanduser('~'), output_shp_name)
     status.text = 'Saved file: {}'.format(output_full_path)
 
@@ -43,12 +43,12 @@ save_button = Button(label='Save')
 save_button.on_click(save_to_shapefile)
 
 p = Figure(plot_height=600, plot_width=900,
-           x_range=(bounds[0], bounds[2]), 
+           x_range=(bounds[0], bounds[2]),
            y_range=(bounds[1], bounds[3]),
            tools='pan,wheel_zoom')
 
 polys = p.patches(xs='xs', ys='ys', alpha=0.9, source=geo_source)
-status  = Paragraph(text='')
+status = Paragraph(text='')
 controls = HBox(width=p.plot_width, children=[simplify_slider, save_button, status])
 layout = VBox(width=p.plot_width, children=[controls, p])
 curdoc().add_root(layout)


### PR DESCRIPTION
This example demonstrates consuming a shapefile and displaying it via a `GeoJSONDataSource`. Couple of things to note (which are also in README.md):

- installing geopandas can be a pain. Fortunately there is a conda channel with geopandas:
`conda install -c ioos geopandas` (this should be copied the bokeh channel)
- to get example shapefile...`import bokeh.sampledata; bokeh.sampledata.download()`

remaining items:
- [ ] move geopandas to bokeh channel: `anaconda copy ioos/geopandas/0.1.1  --to-owner bokeh`