### PR TITLE
Issue #3871: MultiSelect - Remove 'silent': true

### DIFF
--- a/bokehjs/src/coffee/models/widgets/multiselect.coffee
+++ b/bokehjs/src/coffee/models/widgets/multiselect.coffee
@@ -37,7 +37,7 @@ class MultiSelectView extends BokehView
     )
 
   change_input: () ->
-    @mset('value', @$('select').val(), {'silent': true})
+    @mset('value', @$('select').val())
     @mget('callback')?.execute(@model)
 
 class MultiSelect extends InputWidget.Model


### PR DESCRIPTION
Remove the {‘silent’: true} option in the MultiSelect coffee script to
debug issue #3871 in the Bokeh master. It seems to have fixed the issue.