### PR TITLE
Add KML --> GeoJSONDataSource Example

### DIFF
--- a/bokeh/sampledata/__init__.py
+++ b/bokeh/sampledata/__init__.py
@@ -74,6 +74,7 @@ def download(progress=True):
         (s3, 'world_cities.zip'),
         (s3, 'airports.json'),
         (s3, 'movies.db.zip'),
+        (s3, 'countries.kml.zip'),
     ]
 
     for base_url, file_name in files:

--- a/bokeh/sampledata/countries_kml.py
+++ b/bokeh/sampledata/countries_kml.py
@@ -1,0 +1,10 @@
+from __future__ import absolute_import
+
+from os.path import dirname, join, isfile, expanduser
+
+path1 = join(dirname(__file__), 'countries.kml')
+path2 = expanduser('~/.bokeh/data/countries.kml')
+shp_path = path1 if isfile(path1) else path2
+
+if not isfile(movie_path):
+        raise RuntimeError('Use bokeh.sampledata.download to get Countries KML data.')

--- a/bokeh/sampledata/countries_kml.py
+++ b/bokeh/sampledata/countries_kml.py
@@ -4,7 +4,7 @@ from os.path import dirname, join, isfile, expanduser
 
 path1 = join(dirname(__file__), 'countries.kml')
 path2 = expanduser('~/.bokeh/data/countries.kml')
-shp_path = path1 if isfile(path1) else path2
+countries_kml_path = path1 if isfile(path1) else path2
 
-if not isfile(movie_path):
+if not isfile(countries_kml_path):
         raise RuntimeError('Use bokeh.sampledata.download to get Countries KML data.')

--- a/examples/plotting/file/kml_countries.py
+++ b/examples/plotting/file/kml_countries.py
@@ -1,12 +1,9 @@
-from itertools import chain
-
-from bokeh.models import GeoJSONDataSource 
+from bokeh.models import GeoJSONDataSource
 from bokeh.plotting import figure, show, output_file
+from bokeh.sampledata.countries_kml import countries_kml_path
 
 from fastkml import kml
 from geojson import GeometryCollection, dumps
-
-from bokeh.sampledata.countries_kml import countries_kml_path
 
 with open(countries_kml_path) as f:
     content = kml.KML()
@@ -22,12 +19,10 @@ for f in features:
 geom = GeometryCollection(geometries)
 geo_source = GeoJSONDataSource(geojson=dumps(geom))
 
-p = figure(plot_height=600, plot_width=900, tools='pan,wheel_zoom')
-p.background_fill = 'black'
+p = figure(plot_height=600, plot_width=900, tools='pan,wheel_zoom', background_fill='black')
 p.axis.visible = False
 p.grid.grid_line_alpha = 0
-p.patches(xs='xs', ys='ys',
-          source=geo_source, line_color='white', 
+p.patches(xs='xs', ys='ys', source=geo_source, line_color='white',
           line_alpha=.2, fill_alpha=.85)
 
 output_file('kml_countries_example.html', title='KML Countries Example')

--- a/examples/plotting/file/kml_countries.py
+++ b/examples/plotting/file/kml_countries.py
@@ -1,0 +1,34 @@
+from itertools import chain
+
+from bokeh.models import GeoJSONDataSource 
+from bokeh.plotting import figure, show, output_file
+
+from fastkml import kml
+from geojson import GeometryCollection, dumps
+
+from bokeh.sampledata.countries_kml import countries_kml_path
+
+with open(countries_kml_path) as f:
+    content = kml.KML()
+    content.from_string(f.read().encode('utf-8'))
+
+documents = list(content.features())
+features = list(documents[0].features())
+
+geometries = []
+for f in features:
+    geometries += list(f.geometry.geoms)
+
+geom = GeometryCollection(geometries)
+geo_source = GeoJSONDataSource(geojson=dumps(geom))
+
+p = figure(plot_height=600, plot_width=900, tools='pan,wheel_zoom')
+p.background_fill = 'black'
+p.axis.visible = False
+p.grid.grid_line_alpha = 0
+p.patches(xs='xs', ys='ys',
+          source=geo_source, line_color='white', 
+          line_alpha=.2, fill_alpha=.85)
+
+output_file('kml_countries_example.html', title='KML Countries Example')
+show(p)


### PR DESCRIPTION
This is a short example which parses a kml file of world countries into a `GeoJSONDataSource`. 

Note:
- There are dependencies on `fastkml (pip install fastkml)` and `geojson (pip install geojson)`
- To get source data you will need to:
```python
import bokeh.sampledata
bokeh.sampledata.download()
```

<img width="912" alt="screen shot 2016-02-15 at 9 14 11 pm" src="https://cloud.githubusercontent.com/assets/433221/13066319/623526f2-d42a-11e5-9ccb-7fb77798bb4b.png">

