### PR TITLE
Remove mention of hex RGBA as supported color prop

### DIFF
--- a/sphinx/source/docs/includes/colors.txt
+++ b/sphinx/source/docs/includes/colors.txt
@@ -1,6 +1,6 @@
 
-- any of the `147 named CSS colors`_, e.g ``'green'``, ``'indigo'``
-- an RGB(A) hex value, e.g., ``'#FF0000'``, ``'#44444444'``
+- any of the `147 named CSS colors`_, e.g. ``'green'``, ``'indigo'``
+- an RGB hex value, e.g. ``'#FF0000'``, ``'#4b0082'``
 - a 3-tuple of integers *(r,g,b)* between 0 and 255
 - a 4-tuple of *(r,g,b,a)* where *r*, *g*, *b* are integers between 0 and 255 and *a* is a floating point value between 0 and 1
 


### PR DESCRIPTION
issues: fixes #3891 

This PR removes the mention of hexadecimal RGBA strings from the list of supported color formats.

Per this thread: http://stackoverflow.com/questions/7015302/css-hexidecimal-rgba, hex-encoded RGBA color notation isn't supported by CSS3 (and therefore HTML 5 Canvas). It's expected to be added in CSS4, but it's not currently supported by any browser.

Our color property code only supports 6-character hex colors, so there's no code changes necessary.

https://github.com/bokeh/bokeh/blob/master/bokeh/core/properties.py#L1378