### PR TITLE
Canavandl/2622 color tuple seq

### DIFF
--- a/sphinx/source/docs/includes/colors.txt
+++ b/sphinx/source/docs/includes/colors.txt
@@ -1,6 +1,6 @@
 
-- any of the `147 named CSS colors`_, e.g ``'green'``, ``'indigo'``
-- an RGB(A) hex value, e.g., ``'#FF0000'``, ``'#44444444'``
+- any of the `147 named CSS colors`_, e.g. ``'green'``, ``'indigo'``
+- an RGB hex value, e.g. ``'#FF0000'``, ``'#4b0082'``
 - a 3-tuple of integers *(r,g,b)* between 0 and 255
 - a 4-tuple of *(r,g,b,a)* where *r*, *g*, *b* are integers between 0 and 255 and *a* is a floating point value between 0 and 1
 

--- a/sphinx/source/docs/includes/colors.txt
+++ b/sphinx/source/docs/includes/colors.txt
@@ -1,6 +1,6 @@
 
-- any of the `147 named CSS colors`_, e.g. ``'green'``, ``'indigo'``
-- an RGB hex value, e.g. ``'#FF0000'``, ``'#4b0082'``
+- any of the `147 named CSS colors`_, e.g ``'green'``, ``'indigo'``
+- an RGB(A) hex value, e.g., ``'#FF0000'``, ``'#44444444'``
 - a 3-tuple of integers *(r,g,b)* between 0 and 255
 - a 4-tuple of *(r,g,b,a)* where *r*, *g*, *b* are integers between 0 and 255 and *a* is a floating point value between 0 and 1
 

--- a/sphinx/source/docs/user_guide/styling.rst
+++ b/sphinx/source/docs/user_guide/styling.rst
@@ -93,6 +93,17 @@ the inputs for line and fill alphas:
     provide ``fill|line_alpha`` or ``fill|line_color`` in combination with
     the ``color``/``alpha`` keywords, and the former will take precedence.
 
+.. warning::
+    Supplying lists of RGB or RGBA color tuples as color arguments (either
+    directly or as a DataSource column) doesn't work. You may read a discussion
+    of the issue on our project `GitHub`_ page. Suggested work-around include
+    using lists of:
+    - RGB hexadecimal values
+    - `bokeh.colors.RGB objects`
+    - CSS-format RGB/RGBA strings (i.e. ``["rgb(255, 0, 0)", "rgb(0, 255, 0)"]``)
+
+.. _GitHub: https://github.com/bokeh/bokeh/issues/2622
+
 .. _userguide_styling_selecting:
 
 Selecting Plot Objects

--- a/sphinx/source/docs/user_guide/styling.rst
+++ b/sphinx/source/docs/user_guide/styling.rst
@@ -74,6 +74,18 @@ following ways:
 
 .. include:: ../includes/colors.txt
 
+.. warning::
+    Supplying lists of RGB or RGBA color tuples as color arguments (either
+    directly or as a DataSource column reference) doesn't work. You may read a
+    discussion of the issue on our project `GitHub`_ page. Suggested
+    work-arounds include using lists of:
+
+    * RGB hexadecimal values
+    * `bokeh.colors.RGB` objects (i.e. ``[RGB(255, 0, 0), RGB(0, 255, 0)"]``)
+    * CSS-format RGB/RGBA strings (i.e. ``["rgb(255, 0, 0)", "rgb(0, 255, 0)"]``)
+
+.. _GitHub: https://github.com/bokeh/bokeh/issues/2622
+
 Color alpha can be specified in multiple ways for the visual properties. This
 can be by specifying the alpha directly with ``line|fill_alpha``, or by
 providing the alpha through the RGBA 4-tuple for the ``line|fill_color``.
@@ -92,17 +104,6 @@ the inputs for line and fill alphas:
     corresponding ``line`` and ``fill`` properties. However, you can still
     provide ``fill|line_alpha`` or ``fill|line_color`` in combination with
     the ``color``/``alpha`` keywords, and the former will take precedence.
-
-.. warning::
-    Supplying lists of RGB or RGBA color tuples as color arguments (either
-    directly or as a DataSource column) doesn't work. You may read a discussion
-    of the issue on our project `GitHub`_ page. Suggested work-around include
-    using lists of:
-    - RGB hexadecimal values
-    - `bokeh.colors.RGB objects`
-    - CSS-format RGB/RGBA strings (i.e. ``["rgb(255, 0, 0)", "rgb(0, 255, 0)"]``)
-
-.. _GitHub: https://github.com/bokeh/bokeh/issues/2622
 
 .. _userguide_styling_selecting:
 


### PR DESCRIPTION
issues: fixes: #2622

Bokeh doesn't support lists of color tuples as color arguments. As discussed in #2622, there's not an obvious path forward to resolve this, as it's unclear to how distinguish between a 3-element field that's intended to be a color tuple or a multi-list.

This PR adds an explicit warning to the 'styling visual attributes' docs sections about this edge case and suggests a couple of work-arounds.