### PR TITLE
Add doit conditional for null handling in text render method

### DIFF
--- a/bokehjs/src/coffee/models/glyphs/text.coffee
+++ b/bokehjs/src/coffee/models/glyphs/text.coffee
@@ -13,13 +13,14 @@ class TextView extends Glyph.View
       if (isNaN(sx[i]+sy[i]+x_offset[i]+y_offset[i]+angle[i]) or not text[i]?)
         continue
 
-      ctx.save()
-      ctx.translate(sx[i]+x_offset[i], sy[i]+y_offset[i])
-      ctx.rotate(angle[i])
+      if @visuals.text.doit
+        ctx.save()
+        ctx.translate(sx[i]+x_offset[i], sy[i]+y_offset[i])
+        ctx.rotate(angle[i])
 
-      @visuals.text.set_vectorize(ctx, i)
-      ctx.fillText(text[i], 0, 0)
-      ctx.restore()
+        @visuals.text.set_vectorize(ctx, i)
+        ctx.fillText(text[i], 0, 0)
+        ctx.restore()
 
   draw_legend: (ctx, x1, x2, y1, y2) ->
     ctx.save()


### PR DESCRIPTION
issues: fixes #3226 

Added `doit` conditional to text glyph render method to be inline w/ all other glyphs.

The same code as in issue #3226 now doesn't render the text:

<img width="610" alt="screen shot 2016-02-20 at 10 39 16 pm" src="https://cloud.githubusercontent.com/assets/2198981/13200957/05911954-d823-11e5-9347-a249172a6e03.png">
