### PR TITLE
Take shallow copy of DataFrame in `ChartDataSource`

### DIFF
--- a/bokeh/charts/data_source.py
+++ b/bokeh/charts/data_source.py
@@ -151,7 +151,7 @@ class DataGroup(object):
             data (:class:`pandas.DataFrame`): the subset of data associated with the group
             attr_specs dict(str, :class:`AttrSpec`): mapping between attribute name and
             the associated :class:`AttrSpec`.
-            
+
         """
         self.label = label
         self.data = data.reset_index()
@@ -319,12 +319,15 @@ class ChartDataSource(object):
 
         self.input_type = kwargs.pop('input_type', None)
         self.attrs = attrs or []
-        self._data = df
+        self._data = df.copy(deep=False)
         self._dims = dims
         self.operations = []
         self._required_dims = required_dims
-        self.column_assigner = column_assigner(df=df, dims=list(self._dims),
-                                               attrs=self.attrs)
+        self.column_assigner = column_assigner(
+            df=self._data,
+            dims=list(self._dims),
+            attrs=self.attrs,
+        )
         self._selections = self.get_selections(selections, **kwargs)
         self.setup_derived_columns()
         self.apply_operations()

--- a/bokeh/charts/tests/test_data_source.py
+++ b/bokeh/charts/tests/test_data_source.py
@@ -41,13 +41,18 @@ def test_array(test_data):
 
 def test_pandas(test_data):
     """Test creating chart data source from existing dataframe."""
-    ds = ChartDataSource.from_data(test_data.pd_data)
+    pd_data = test_data.pd_data.copy()
+    ds = ChartDataSource.from_data(pd_data)
     assert len(ds.columns) == 2
     assert len(ds.index) == 4
 
-    ds = ChartDataSource(test_data.pd_data)
+    ds = ChartDataSource(pd_data)
     assert len(ds.columns) == 2
     assert len(ds.index) == 4
+
+    # Test for issue #3899
+    # ChartDataSource shouldn't modify the input DataFrame
+    assert pd_data.equals(test_data.pd_data)
 
 
 def test_dict(test_data):


### PR DESCRIPTION
Avoids modifying the input DataFrame inplace
Fixes #3899