### PR TITLE
Add correct server dev instruction to docs

### DIFF
--- a/sphinx/source/docs/dev_guide/setup.rst
+++ b/sphinx/source/docs/dev_guide/setup.rst
@@ -285,8 +285,8 @@ Bokeh to use relative paths to development resources, issue:
 
     BOKEH_RESOURCES=relative-dev python example.py
 
-For Bokeh server examples, it's necessary to add ``BOKEH_RESOURCES=server-dev``
-to the server invocation:
+For Bokeh server examples, add ``BOKEH_RESOURCES=server-dev`` to the server
+invocation:
 
 .. code-block:: sh
 

--- a/sphinx/source/docs/dev_guide/setup.rst
+++ b/sphinx/source/docs/dev_guide/setup.rst
@@ -285,11 +285,12 @@ Bokeh to use relative paths to development resources, issue:
 
     BOKEH_RESOURCES=relative-dev python example.py
 
-For Bokeh server examples, add ``BOKEH_DEV=true`` to the server invocation:
+For Bokeh server examples, it's necessary to add ``BOKEH_RESOURCES=server-dev``
+to the server invocation:
 
 .. code-block:: sh
 
-    BOKEH_DEV=true bokeh serve example-server.py
+    BOKEH_RESOURCES=server-dev bokeh serve example-server.py
 
 Environment Variables
 ---------------------


### PR DESCRIPTION
fixes: issues #3622 

Docfix to note the correct BOKEH_RESOURCES value (server-dev not absolute-dev, as is set by BOKEH_DEV=true) to load local JS/CSS resources.