### PR TITLE
More robust (?) way of labeling _process module

### DIFF
--- a/bokehjs/gulp/labeler.coffee
+++ b/bokehjs/gulp/labeler.coffee
@@ -70,7 +70,9 @@ namedLabeler = (bundle, parentLabels) -> customLabeler bundle, parentLabels, (ro
     .replace(/\.(coffee|js|eco)$/, "")
     .split(path.sep).join("/")
     .replace(/^(src\/(coffee|vendor)|node_modules|build\/js\/tree)\//, "")
-    .replace("browserify/node_modules/process/browser", "_process")
+
+  if modName.indexOf("process/browser") != -1
+    modName = "_process"
 
   if argv.verbose
     gutil.log("Processing #{modName}")


### PR DESCRIPTION
This should fix #3581. Originally I attributed this to newer version of node.js/npm being installed, but apparently even older versions cause problems when gulp is run from `node_modules/.bin` instead of the conda-installed one. This PR helps, but I'm not sure where the difference comes from.