### PR TITLE
Fix typo in docs: toolbar_position -> toolbar_location

### DIFF
--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -42,7 +42,7 @@ Valid values are:
 If you would like to hide the toolbar entirely, pass ``None``.
 
 Below is some code that positions the toolbar below the plot. Try
-running the code and changing the ``toolbar_position`` value.
+running the code and changing the ``toolbar_location`` value.
 
 .. bokeh-plot:: source/docs/user_guide/source_examples/tools_position_toolbar.py
     :source-position: above


### PR DESCRIPTION
The docs say:

> Try running the code and changing the `toolbar_position` value.

(http://bokeh.pydata.org/en/0.11.1/docs/user_guide/tools.html#positioning-the-toolbar)

This is incorrect, the parameter name is `toolbar_location`.