### PR TITLE
added type=button attribute to ButtonView class

### DIFF
--- a/bokehjs/src/coffee/models/widgets/button.coffee
+++ b/bokehjs/src/coffee/models/widgets/button.coffee
@@ -24,6 +24,7 @@ class ButtonView extends BokehView
         val.$el.detach()
 
     @$el.empty()
+    @$el.attr("type","button")
     @$el.addClass("bk-bs-btn")
     @$el.addClass("bk-bs-btn-" + @mget("type"))
     if @mget("disabled") then @$el.attr("disabled", "disabled")


### PR DESCRIPTION
Added 
```
@$el.attr("type","button")
```
to `Class ButtonView` in order to fix the issue of the page reloading/redirecting as described in issue #3895.
 