### PR TITLE
Disable saucelabs tests for external contributors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,13 @@ before_install:
     # test run, but we can manually use travis' saucelabs start/stop commands
     - if [[ -z "${SAUCE_USERNAME}" ]] || [[ -z "${SAUCE_ACCESS_KEY}" ]]; then echo "External committer, not using saucelabs"; else export SAUCELABS=True; fi
     - echo $SAUCELABS
-    - if [[ -z "${SAUCELABS}" ]]; then "source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh)"; else "export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start"; fi
+    - if [[ -z "${SAUCELABS}" ]]; 
+      then
+        source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh); 
+      else 
+        export DISPLAY=:99.0;
+        sh -e /etc/init.d/xvfb start; 
+      fi
 
 install:
     - scripts/travis_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
     # test run, but we can manually use travis' saucelabs start/stop commands
     - if [[ -z "${SAUCE_USERNAME}" ]] || [[ -z "${SAUCE_ACCESS_KEY}" ]]; then export SAUCELABS=False; else export SAUCELABS=True; fi
     - echo $SAUCELABS
-    - if [[ -z "$SAUCELABS" == "True" ]]; then "source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh)"; fi
+    - if [[ -z "${SAUCELABS}" == "True" ]]; then "source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh)"; fi
     - if [[ -z "$SAUCELABS" == "False" ]]; then "export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start"; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,10 +54,10 @@ before_install:
     - export TRAVIS_COMMIT_MSG="$(git log --format=%B --no-merges -n 1)"
     # We don't use the travis saucelabs add on because it installs on every
     # test run, but we can manually use travis' saucelabs start/stop commands
-    - if [[ -z "${SAUCE_USERNAME}" ]] && [[ -z "${SAUCE_ACCESS_KEY}" ]]; then export SAUCELABS=True; else export SAUCELABS=False; fi
+    - if [[ -z "${SAUCE_USERNAME}" ]] || [[ -z "${SAUCE_ACCESS_KEY}" ]]; then export SAUCELABS=False; else export SAUCELABS=True; fi
     - echo $SAUCELABS
-    - if [ -z $SAUCELABS == "True" ]; then "source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh)"; fi
-    - if [ -z $SAUCELABS = False ]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; fi
+    - if [[ -z "$SAUCELABS" == "True" ]]; then "source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh)"; fi
+    - if [[ -z "$SAUCELABS" == "False" ]]; then "export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start"; fi
 
 install:
     - scripts/travis_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,8 @@ before_install:
     # We don't use the travis saucelabs add on because it installs on every
     # test run, but we can manually use travis' saucelabs start/stop commands
     - if [[ -z "${SAUCE_USERNAME}" ]] || [[ -z "${SAUCE_ACCESS_KEY}" ]]; then export SAUCELABS="True"; else export SAUCELABS="False"; fi
-    - if [[ -z "$SAUCELABS" == "True" ]]; then source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh); fi
-    - if [[ -s "$SAUCELABS" == "False" ]]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; fi
+    - if [[ -z "$SAUCELABS" = "True" ]]; then source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh); fi
+    - if [[ -s "$SAUCELABS" = "False" ]]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; fi
 
 install:
     - scripts/travis_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,10 +54,10 @@ before_install:
     - export TRAVIS_COMMIT_MSG="$(git log --format=%B --no-merges -n 1)"
     # We don't use the travis saucelabs add on because it installs on every
     # test run, but we can manually use travis' saucelabs start/stop commands
-    - if [[ -z "${SAUCE_USERNAME}" ]] || [[ -z "${SAUCE_ACCESS_KEY}" ]]; then export SAUCELABS=True; else export SAUCELABS=False; fi
+    - if [[ -z "${SAUCE_USERNAME}" ]] && [[ -z "${SAUCE_ACCESS_KEY}" ]]; then export SAUCELABS=True; else export SAUCELABS=False; fi
     - echo $SAUCELABS
-    - if [[ -z "${SAUCELABS}" == "True" ]]; then source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh); fi
-    - if [[ -z "${SAUCELABS}" == "False" ]]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; fi
+    - if [ -z $SAUCELABS = True ]; then source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh); fi
+    - if [ -z $SAUCELABS = False ]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; fi
 
 install:
     - scripts/travis_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
     # test run, but we can manually use travis' saucelabs start/stop commands
     - if [[ -z "${SAUCE_USERNAME}" ]] && [[ -z "${SAUCE_ACCESS_KEY}" ]]; then export SAUCELABS=True; else export SAUCELABS=False; fi
     - echo $SAUCELABS
-    - if [ -z $SAUCELABS == "True" ]; then source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh); fi
+    - if [ -z $SAUCELABS == "True" ]; then "source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh)"; fi
     - if [ -z $SAUCELABS = False ]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,13 +56,9 @@ before_install:
     # test run, but we can manually use travis' saucelabs start/stop commands
     - if [[ -z "${SAUCE_USERNAME}" ]] || [[ -z "${SAUCE_ACCESS_KEY}" ]]; then echo "External committer, not using saucelabs"; else export SAUCELABS=True; fi
     - echo $SAUCELABS
-    - if [[ -z "${SAUCELABS}" ]]; 
-      then
-        source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh); 
-      else 
-        export DISPLAY=:99.0;
-        sh -e /etc/init.d/xvfb start; 
-      fi
+    - if [[ "${SAUCELABS}" == "True" ]]; then source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh); fi
+    - if [[ -z "${SAUCELABS}" ]]; then export DISPLAY=:99.0; fi
+    - if [[ -z "${SAUCELABS}" ]]; then sh -e /etc/init.d/xvfb start; fi
 
 install:
     - scripts/travis_install
@@ -77,10 +73,10 @@ script:
     #
     # Run integration tests only once (Py 3.4)
     - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration ]]; then export UPLOAD_PYTEST_HTML=True; fi
-    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && "$SAUCELABS" = "True" ]]; then travis_start_sauce_connect; fi
-    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && "$SAUCELABS" = "True" ]]; then py.test -m integration --driver SauceLabs --html=tests/pytest-report.html -n 4; fi  # Run the integration tests on saucelabs
-    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && "$SAUCELABS" = "True" ]]; then travis_stop_sauce_connect; fi
-    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && "$SAUCELABS" = "False" ]]; then py.test -m integration --html=tests/pytest-report.html; fi  # Run the integration tests on saucelabs
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && "$SAUCELABS" == "True" ]]; then travis_start_sauce_connect; fi
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && "$SAUCELABS" == "True" ]]; then py.test -m integration --driver SauceLabs --html=tests/pytest-report.html -n 4; fi  # Run the integration tests on saucelabs
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && "$SAUCELABS" == "True" ]]; then travis_stop_sauce_connect; fi
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && "$SAUCELABS" == "False" ]]; then py.test -m integration --html=tests/pytest-report.html; fi  # Run the integration tests on saucelabs
     - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration ]]; then export UPLOAD_PYTEST_HTML=False; fi
     #
     # Flake/docs testing only once (Py 2.7)

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,10 +54,9 @@ before_install:
     - export TRAVIS_COMMIT_MSG="$(git log --format=%B --no-merges -n 1)"
     # We don't use the travis saucelabs add on because it installs on every
     # test run, but we can manually use travis' saucelabs start/stop commands
-    - if [[ -z "${SAUCE_USERNAME}" ]] || [[ -z "${SAUCE_ACCESS_KEY}" ]]; then export SAUCELABS=False; else export SAUCELABS=True; fi
+    - if [[ -z "${SAUCE_USERNAME}" ]] || [[ -z "${SAUCE_ACCESS_KEY}" ]]; then echo "External committer, not using saucelabs"; else export SAUCELABS=True; fi
     - echo $SAUCELABS
-    - if [[ -z "${SAUCELABS}" == "True" ]]; then "source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh)"; fi
-    - if [[ -z "$SAUCELABS" == "False" ]]; then "export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start"; fi
+    - if [[ -z "${SAUCELABS}" ]]; then "source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh)"; else "export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start"; fi
 
 install:
     - scripts/travis_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,9 +54,9 @@ before_install:
     - export TRAVIS_COMMIT_MSG="$(git log --format=%B --no-merges -n 1)"
     # We don't use the travis saucelabs add on because it installs on every
     # test run, but we can manually use travis' saucelabs start/stop commands
-    - if [[ -z "${SAUCE_USERNAME}" ]] || [[ -z "${SAUCE_ACCESS_KEY}" ]]; then export SAUCELABS="True"; else export SAUCELABS="False"; fi
-    - if [[ -z "$SAUCELABS" = "True" ]]; then source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh); fi
-    - if [[ -s "$SAUCELABS" = "False" ]]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; fi
+    - if [[ -z "${SAUCE_USERNAME}" ]] || [[ -z "${SAUCE_ACCESS_KEY}" ]]; then export SAUCELABS=True; else export SAUCELABS=False; fi
+    - if [[ -z "${SAUCELABS}" = True ]]; then source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh); fi
+    - if [[ -z "${SAUCELABS}" = False ]]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; fi
 
 install:
     - scripts/travis_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,9 @@ before_install:
     # We don't use the travis saucelabs add on because it installs on every
     # test run, but we can manually use travis' saucelabs start/stop commands
     - if [[ -z "${SAUCE_USERNAME}" ]] || [[ -z "${SAUCE_ACCESS_KEY}" ]]; then export SAUCELABS=True; else export SAUCELABS=False; fi
-    - if [[ -z "${SAUCELABS}" == True ]]; then source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh); fi
-    - if [[ -z "${SAUCELABS}" == False ]]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; fi
+    - echo $SAUCELABS
+    - if [[ -z "${SAUCELABS}" == "True" ]]; then source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh); fi
+    - if [[ -z "${SAUCELABS}" == "False" ]]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; fi
 
 install:
     - scripts/travis_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,8 @@ before_install:
     # We don't use the travis saucelabs add on because it installs on every
     # test run, but we can manually use travis' saucelabs start/stop commands
     - if [[ -z "${SAUCE_USERNAME}" ]] || [[ -z "${SAUCE_ACCESS_KEY}" ]]; then export SAUCELABS=True; else export SAUCELABS=False; fi
-    - if [[ -z "${SAUCELABS}" = True ]]; then source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh); fi
-    - if [[ -z "${SAUCELABS}" = False ]]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; fi
+    - if [[ -z "${SAUCELABS}" == True ]]; then source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh); fi
+    - if [[ -z "${SAUCELABS}" == False ]]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; fi
 
 install:
     - scripts/travis_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,9 +68,9 @@ script:
     - if [[ -z "$TRAVIS_TAG" && "$GROUP" == unit ]]; then py.test -m 'not (examples or js or integration)' --cov=bokeh --cov-config=bokeh/.coveragerc -rs; fi  # Run the not examples or js tests (we can eat stdout for this one)
     #
     # Run integration tests only once (Py 3.4)
-    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration ]]; then export UPLOAD_PYTEST_HTML=True; travis_start_sauce_connect; fi
-    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration ]]; then py.test -m integration --driver SauceLabs --html=tests/pytest-report.html -n 4; fi  # Run the integration tests on saucelabs
-    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration ]]; then export UPLOAD_PYTEST_HTML=False; travis_stop_sauce_connect; fi
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && "${TRAVIS_PULL_REQUEST}" = "false" ]]; then export UPLOAD_PYTEST_HTML=True; travis_start_sauce_connect; fi
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && "${TRAVIS_PULL_REQUEST}" = "false" ]]; then py.test -m integration --driver SauceLabs --html=tests/pytest-report.html -n 4; fi  # Run the integration tests on saucelabs
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && "${TRAVIS_PULL_REQUEST}" = "false" ]]; then export UPLOAD_PYTEST_HTML=False; travis_stop_sauce_connect; fi
     #
     # Flake/docs testing only once (Py 2.7)
     - if [[ -z "$TRAVIS_TAG" && "$GROUP" == flake_docs ]]; then ( flake8 bokeh; cd sphinx; make all ) ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
     # test run, but we can manually use travis' saucelabs start/stop commands
     - if [[ -z "${SAUCE_USERNAME}" ]] && [[ -z "${SAUCE_ACCESS_KEY}" ]]; then export SAUCELABS=True; else export SAUCELABS=False; fi
     - echo $SAUCELABS
-    - if [ -z $SAUCELABS = True ]; then source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh); fi
+    - if [ -z $SAUCELABS == "True" ]; then source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh); fi
     - if [ -z $SAUCELABS = False ]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,9 @@ before_install:
     - export TRAVIS_COMMIT_MSG="$(git log --format=%B --no-merges -n 1)"
     # We don't use the travis saucelabs add on because it installs on every
     # test run, but we can manually use travis' saucelabs start/stop commands
-    - source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh)
+    - if [[ -z "${SAUCE_USERNAME}" ]] || [[ -z "${SAUCE_ACCESS_KEY}" ]]; then export SAUCELABS="True"; else export SAUCELABS="False"; fi
+    - if [[ -z "$SAUCELABS" == "True" ]]; then source <(curl -s https://raw.githubusercontent.com/travis-ci/travis-build/master/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh); fi
+    - if [[ -s "$SAUCELABS" == "False" ]]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; fi
 
 install:
     - scripts/travis_install
@@ -68,9 +70,12 @@ script:
     - if [[ -z "$TRAVIS_TAG" && "$GROUP" == unit ]]; then py.test -m 'not (examples or js or integration)' --cov=bokeh --cov-config=bokeh/.coveragerc -rs; fi  # Run the not examples or js tests (we can eat stdout for this one)
     #
     # Run integration tests only once (Py 3.4)
-    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && "${TRAVIS_PULL_REQUEST}" = "false" ]]; then export UPLOAD_PYTEST_HTML=True; travis_start_sauce_connect; fi
-    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && "${TRAVIS_PULL_REQUEST}" = "false" ]]; then py.test -m integration --driver SauceLabs --html=tests/pytest-report.html -n 4; fi  # Run the integration tests on saucelabs
-    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && "${TRAVIS_PULL_REQUEST}" = "false" ]]; then export UPLOAD_PYTEST_HTML=False; travis_stop_sauce_connect; fi
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration ]]; then export UPLOAD_PYTEST_HTML=True; fi
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && "$SAUCELABS" = "True" ]]; then travis_start_sauce_connect; fi
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && "$SAUCELABS" = "True" ]]; then py.test -m integration --driver SauceLabs --html=tests/pytest-report.html -n 4; fi  # Run the integration tests on saucelabs
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && "$SAUCELABS" = "True" ]]; then travis_stop_sauce_connect; fi
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && "$SAUCELABS" = "False" ]]; then py.test -m integration --html=tests/pytest-report.html; fi  # Run the integration tests on saucelabs
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration ]]; then export UPLOAD_PYTEST_HTML=False; fi
     #
     # Flake/docs testing only once (Py 2.7)
     - if [[ -z "$TRAVIS_TAG" && "$GROUP" == flake_docs ]]; then ( flake8 bokeh; cd sphinx; make all ) ; fi


### PR DESCRIPTION
The saucelabs tests require access to secure environment variables, external
contributors don't have access to them. For an explanation see:
https://docs.travis-ci.com/user/pull-requests#Security-Restrictions-when-testing-Pull-Requests

This disables the integration tests for external contributor PRs. There are
ways to finess this later.