### PR TITLE
Changed .bk-plot to .bk-root for style wrapper

### DIFF
--- a/bokeh/core/_templates/plot_div.html
+++ b/bokeh/core/_templates/plot_div.html
@@ -6,4 +6,4 @@ Renders a basic plot div, that can be used in conjunction with PLOT_JS.
 :type elementid: str
 
 #}
-<div class="plotdiv bk" id="{{ elementid }}"></div>
+<div class="plotdiv bokeh" id="{{ elementid }}"></div>

--- a/bokeh/core/_templates/plot_div.html
+++ b/bokeh/core/_templates/plot_div.html
@@ -6,4 +6,4 @@ Renders a basic plot div, that can be used in conjunction with PLOT_JS.
 :type elementid: str
 
 #}
-<div class="plotdiv bokeh" id="{{ elementid }}"></div>
+<div class="plotdiv bk-root" id="{{ elementid }}"></div>

--- a/bokeh/core/_templates/plot_div.html
+++ b/bokeh/core/_templates/plot_div.html
@@ -6,4 +6,4 @@ Renders a basic plot div, that can be used in conjunction with PLOT_JS.
 :type elementid: str
 
 #}
-<div class="plotdiv bk-plot" id="{{ elementid }}"></div>
+<div class="plotdiv bk" id="{{ elementid }}"></div>

--- a/bokeh/tests/test_embed.py
+++ b/bokeh/tests/test_embed.py
@@ -52,7 +52,7 @@ class TestComponents(unittest.TestCase):
 
         div = divs[0]
         self.assertTrue(set(div.attrs), set(['class', 'id']))
-        self.assertEqual(div.attrs['class'], ['plotdiv', 'bk-plot'])
+        self.assertEqual(div.attrs['class'], ['plotdiv', 'bk'])
         self.assertEqual(div.text, "")
 
     def test_script_is_utf8_encoded(self):
@@ -106,7 +106,7 @@ class TestNotebookDiv(unittest.TestCase):
 
         div = divs[0]
         self.assertTrue(set(div.attrs), set(['class', 'id']))
-        self.assertEqual(div.attrs['class'], ['plotdiv', 'bk-plot'])
+        self.assertEqual(div.attrs['class'], ['plotdiv', 'bk'])
         self.assertEqual(div.text, "")
 
 class TestFileHTML(unittest.TestCase):

--- a/bokeh/tests/test_embed.py
+++ b/bokeh/tests/test_embed.py
@@ -52,7 +52,7 @@ class TestComponents(unittest.TestCase):
 
         div = divs[0]
         self.assertTrue(set(div.attrs), set(['class', 'id']))
-        self.assertEqual(div.attrs['class'], ['plotdiv', 'bk'])
+        self.assertEqual(div.attrs['class'], ['plotdiv', 'bokeh'])
         self.assertEqual(div.text, "")
 
     def test_script_is_utf8_encoded(self):
@@ -106,7 +106,7 @@ class TestNotebookDiv(unittest.TestCase):
 
         div = divs[0]
         self.assertTrue(set(div.attrs), set(['class', 'id']))
-        self.assertEqual(div.attrs['class'], ['plotdiv', 'bk'])
+        self.assertEqual(div.attrs['class'], ['plotdiv', 'bokeh'])
         self.assertEqual(div.text, "")
 
 class TestFileHTML(unittest.TestCase):

--- a/bokeh/tests/test_embed.py
+++ b/bokeh/tests/test_embed.py
@@ -52,7 +52,7 @@ class TestComponents(unittest.TestCase):
 
         div = divs[0]
         self.assertTrue(set(div.attrs), set(['class', 'id']))
-        self.assertEqual(div.attrs['class'], ['plotdiv', 'bokeh'])
+        self.assertEqual(div.attrs['class'], ['plotdiv', 'bk-root'])
         self.assertEqual(div.text, "")
 
     def test_script_is_utf8_encoded(self):
@@ -106,7 +106,7 @@ class TestNotebookDiv(unittest.TestCase):
 
         div = divs[0]
         self.assertTrue(set(div.attrs), set(['class', 'id']))
-        self.assertEqual(div.attrs['class'], ['plotdiv', 'bokeh'])
+        self.assertEqual(div.attrs['class'], ['plotdiv', 'bk-root'])
         self.assertEqual(div.text, "")
 
 class TestFileHTML(unittest.TestCase):

--- a/bokehjs/src/less/bokeh-widgets.less
+++ b/bokehjs/src/less/bokeh-widgets.less
@@ -1,4 +1,4 @@
-.bokeh {
+.bk-root {
   @import "vendor.less";
   @import "overrides.less";
   @import "widgets.less";

--- a/bokehjs/src/less/bokeh-widgets.less
+++ b/bokehjs/src/less/bokeh-widgets.less
@@ -1,4 +1,4 @@
-.bk {
+.bokeh {
   @import "vendor.less";
   @import "overrides.less";
   @import "widgets.less";

--- a/bokehjs/src/less/bokeh-widgets.less
+++ b/bokehjs/src/less/bokeh-widgets.less
@@ -1,4 +1,4 @@
-.bk-plot {
+.bk {
   @import "vendor.less";
   @import "overrides.less";
   @import "widgets.less";

--- a/bokehjs/src/less/bokeh.less
+++ b/bokehjs/src/less/bokeh.less
@@ -1,4 +1,4 @@
-.bk-plot {
+.bk {
   @import "bootstrap.less"; // XXX: core bokeh shouldn't depend on bootstrap
   @import "continuum.less";
   @import "main.less";

--- a/bokehjs/src/less/bokeh.less
+++ b/bokehjs/src/less/bokeh.less
@@ -1,4 +1,4 @@
-.bk {
+.bokeh {
   @import "bootstrap.less"; // XXX: core bokeh shouldn't depend on bootstrap
   @import "continuum.less";
   @import "main.less";

--- a/bokehjs/src/less/bokeh.less
+++ b/bokehjs/src/less/bokeh.less
@@ -1,4 +1,4 @@
-.bokeh {
+.bk-root {
   @import "bootstrap.less"; // XXX: core bokeh shouldn't depend on bootstrap
   @import "continuum.less";
   @import "main.less";


### PR DESCRIPTION
This is to help the namespace clash with the other `.bk-plot` class in use.

Follow-up to https://github.com/bokeh/bokeh/pull/3797