### PR TITLE
Disable data_tables_server example

### DIFF
--- a/tests/examples/examples.yaml
+++ b/tests/examples/examples.yaml
@@ -1,5 +1,5 @@
 - path: "models"
-  skip: ["choropleth.py", "maps_cities.py"]
+  skip: ["choropleth.py", "maps_cities.py", "data_tables_server.py"]
 - path: "compat"
 - path: "charts/file"
   type: file


### PR DESCRIPTION
Looking at recent examples failures data_tables_server often seems to be the source of hang-ups. This particular example offers little incremental benefit over others:
* we have another test for the data table
* the server tests have no image diff at the moment
* other server tests test dropdowns

It could be that data_tables_server isn't the problem it's just an early test and so because we now bail out early it's just always looking like this one, but I don't see any harm in trying disabling it (due to reasons above)

In addition:
* ~~i can't seem to get it to run locally~~
* has out-dated bokeh code in it

Edit: I can get it running locally

The code has a deprecation warning in it: 

```sh
data_tables_server.py:134: BokehDeprecationWarning: bokeh.models.sources.from_df was deprecated in Bokeh 0.9.3; please use ColumnDataSource initializer instead
  self.source.data = ColumnDataSource.from_df(df)
```

which we should probably fix.