### PR TITLE
Update capabilities to match new pytest-selenium version

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -55,7 +55,7 @@ test:
     - pandas
     - pytest
     - pytest-cov ==1.8.1
-    - pytest-selenium
+    - pytest-selenium >= 1.2.1
     - pytest-xdist
     - pytest-rerunfailures
     - beautiful-soup

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -35,7 +35,7 @@ def output_file_url(request, file_server):
 
 
 @pytest.fixture(scope="session")
-def capabilities(capabilities):
-    capabilities["browserName"] = "firefox"
-    capabilities["tunnel-identifier"] = os.environ.get("TRAVIS_JOB_NUMBER")
-    return capabilities
+def session_capabilities(session_capabilities):
+    session_capabilities["browserName"] = "firefox"
+    session_capabilities["tunnel-identifier"] = os.environ.get("TRAVIS_JOB_NUMBER")
+    return session_capabilities


### PR DESCRIPTION
pytest-selenium released a breaking change for capabilities fixture:
http://pytest-selenium.readthedocs.org/en/latest/news.html

This brings our code inline with the new change. Ping @bryevdv - this should be merged ASAP.