### PR TITLE
Hold at pytest-selenium_1.1

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -55,7 +55,7 @@ test:
     - pandas
     - pytest
     - pytest-cov ==1.8.1
-    - pytest-selenium
+    - pytest-selenium ==1.1
     - pytest-xdist
     - pytest-rerunfailures
     - beautiful-soup


### PR DESCRIPTION
pytest-selenium 1.2 changes the capabilities fixture:
http://pytest-selenium.readthedocs.org/en/latest/news.html

Unfortunately pytest-selenium 1.2 uses features that aren't compatible with the
combination of pytest-2.8 and pytest-xdist. This has apparently been fixed in
pytest-2.9 which is about to be released. But for the time being we'll hold at
pytest-selenium-1.1.