### PR TITLE
Add cross browser capabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ script:
     #
     # Run integration tests only once (Py 3.4)
     - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && -n "${SAUCELABS}" ]]; then travis_start_sauce_connect; fi
-    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && -n "${SAUCELABS}" ]]; then py.test -m integration --driver SauceLabs --html=tests/pytest-report.html -n4 --upload --cross-browser; fi  # Run the integration tests on saucelabs
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && -n "${SAUCELABS}" ]]; then py.test -m integration --driver SauceLabs --html=tests/pytest-report.html -n4 --upload; fi  # Run the integration tests on saucelabs
     - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && -n "${SAUCELABS}" ]]; then travis_stop_sauce_connect; fi
     - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && -z "${SAUCELABS}" ]]; then py.test -m integration --driver Firefox; fi
     #

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ script:
     #
     # Run integration tests only once (Py 3.4)
     - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && -n "${SAUCELABS}" ]]; then travis_start_sauce_connect; fi
-    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && -n "${SAUCELABS}" ]]; then py.test -m integration --driver SauceLabs --html=tests/pytest-report.html -n4 --upload; fi  # Run the integration tests on saucelabs
+    - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && -n "${SAUCELABS}" ]]; then py.test -m integration --driver SauceLabs --html=tests/pytest-report.html -n4 --upload --cross-browser; fi  # Run the integration tests on saucelabs
     - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && -n "${SAUCELABS}" ]]; then travis_stop_sauce_connect; fi
     - if [[ -z "$TRAVIS_TAG" && "$GROUP" == integration && -z "${SAUCELABS}" ]]; then py.test -m integration --driver Firefox; fi
     #

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -55,7 +55,7 @@ test:
     - pandas
     - pytest
     - pytest-cov ==1.8.1
-    - pytest-selenium
+    - pytest-selenium ==1.1
     - pytest-xdist
     - pytest-rerunfailures
     - beautiful-soup

--- a/sphinx/source/docs/dev_guide/testing.rst
+++ b/sphinx/source/docs/dev_guide/testing.rst
@@ -81,3 +81,18 @@ To run any of the tests without standard output captured use:
   py.test -s
 
 See the py.test documentation at http://pytest.org/latest/ for further information on py.test and it's options.
+
+Selenium Testing
+----------------
+
+The tests that run with the ``-m integration`` run on selenium. By default,
+these will run locally using firefox, but you can also run them against
+SauceLabs. You will need a SauceLabs account and the environment variables
+``SAUCELABS_USERNAME`` and ``SAUCELABS_API_KEY`` set. In addition, you will
+need to be running an instance of SauceConnect:
+https://wiki.saucelabs.com/display/DOCS/Setting+Up+Sauce+Connect
+
+To run with SauceLabs use ``--driver=SauceLabs``. If you are using the
+SauceLabs driver, you can also use the ``--cross-browser`` command line
+argument to run the integration tests against a combination of browsers and
+platforms.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from tests.plugins.upload_to_s3 import upload_file_to_s3_by_job_id
 
 pytest_plugins = (
     "tests.examples.examples_report_plugin",
+    "tests.integration.integration_tests_plugin",
     "tests.plugins.bokeh_server",
     "tests.plugins.jupyter_notebook",
     "tests.plugins.phantomjs_screenshot",

--- a/tests/integration/integration_tests_plugin.py
+++ b/tests/integration/integration_tests_plugin.py
@@ -34,8 +34,23 @@ def output_file_url(request, file_server):
     return file_server.where_is(file_path)
 
 
+def pytest_addoption(parser):
+    parser.addoption("--cross-browser", action="store_true", default=False, help="Run tests against cross browser configuration")
+
+
+def pytest_generate_tests(metafunc):
+    if metafunc.config.option.cross_browser:
+        metafunc.parametrize('browserName', ["firefox", "chrome", "internet explorer"], scope="session")
+
+
 @pytest.fixture(scope="session")
-def capabilities(capabilities):
-    capabilities["browserName"] = "firefox"
+def browserName():
+    return "firefox"
+
+
+@pytest.fixture(scope="session")
+def capabilities(capabilities, browserName):
+    capabilities["browserName"] = browserName
+    capabilities["platform"] = "Windows 10"
     capabilities["tunnel-identifier"] = os.environ.get("TRAVIS_JOB_NUMBER")
     return capabilities

--- a/tests/integration/integration_tests_plugin.py
+++ b/tests/integration/integration_tests_plugin.py
@@ -47,23 +47,13 @@ def pytest_generate_tests(metafunc):
         cross_browser_list = [
             {
                 "browserName": "firefox",
-                "platform": "Windows 10",
+                "platform": "Linux",
                 "version": None
             },
             {
                 "browserName": "chrome",
-                "platform": "Windows 10",
+                "platform": "Linux",
                 "version": None
-            },
-            {
-                "browserName": "internet explorer",
-                "platform": "Windows 10",
-                "version": "11.0"
-            },
-            {
-                "browserName": "safari",
-                "platform": "OS X 10.11",
-                "version": "9.0"
             },
         ]
         metafunc.parametrize('cross_browser', cross_browser_list, scope="session")
@@ -72,7 +62,7 @@ def pytest_generate_tests(metafunc):
 @pytest.fixture(scope="session")
 def cross_browser():
     # If version is None, latest will be used
-    return {"browserName": "firefox", "platform": "Windows 10", "version": None}
+    return {"browserName": "firefox", "platform": "Linux", "version": None}
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Fixes: #3827 

This adds a command line argument --cross-browser, that causes tests to run against Firefox, Chrome, and Internet Explorer. It leaves the default as Firefox.

It also switches the default platform to run against to Windows 10 because:
* windows is needed to run internet explorer
* probably good to have our integration tests running against windows as no regular bokeh devs use windows