### PR TITLE
Add cross browser capabilities

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -53,9 +53,9 @@ test:
     - flake8
     - mock
     - pandas
-    - pytest
+    - pytest >=2.9.0
     - pytest-cov ==1.8.1
-    - pytest-selenium
+    - pytest-selenium >=1.2.1
     - pytest-xdist
     - pytest-rerunfailures
     - beautiful-soup

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,8 @@ python_files = *_tests.py *_test.py test_*.py
 selenium_exclude_debug = html logs
 markers =
     integration: mark a test as an integration test - used for selenium tests
+    cross_browser: mark an integration test to run across multiple browsers (only has an effect when --driver=SauceLabs)
     js: mark a test as a javascript test
     examples: mark a test as an examples test
 
-addopts = --driver=Firefox --sensitive-url=None -rxs
+addopts = --driver=Firefox --sensitive-url=None -rxsw

--- a/tests/integration/interaction/test_wheel_zoom.py
+++ b/tests/integration/interaction/test_wheel_zoom.py
@@ -59,6 +59,7 @@ def test_wheel_zoom_can_be_selected(output_file_url, selenium):
     assert 'active' in scroll_classes
 
 
+@pytest.mark.cross_browser
 def test_wheel_zoom_can_be_selected_and_deselected(output_file_url, selenium):
 
     # Make plot and add a taptool callback that generates an alert


### PR DESCRIPTION
Fixes #3827 

Builds on #3975 (which should be merged first)

Supersedes #3974 

cross browser tests need to be explicitly written to be cross browser so the author can take care with any selenium nuances. This implements a marker that marks a test to be run as a cross browser test, rather than providing a global option. 

This should make it easier to get started with cross-browser tests and provides ongoing flexibility to write targeted tests (e.g. just something for touch).