### PR TITLE
simulate sys.path behavior of regular python script in Bokeh app

### DIFF
--- a/bokeh/application/handlers/code_runner.py
+++ b/bokeh/application/handlers/code_runner.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function
 
-from os.path import abspath
+from os.path import abspath, dirname
 from types import ModuleType
 import os
 import sys
@@ -11,7 +11,7 @@ from bokeh.util.serialization import make_id
 class _CodeRunner(object):
     """ Compile and run a Python source code."""
 
-    def __init__(self, source, path):
+    def __init__(self, source, path, **kwargs):
         self._failed = False
         self._error = None
         self._error_detail = None
@@ -68,7 +68,19 @@ class _CodeRunner(object):
 
     def run(self, module, post_check):
         try:
+            # Simulate the sys.path behaviour decribed here:
+            #
+            # https://docs.python.org/2/library/sys.html#sys.path
+            _cwd = os.getcwd()
+            os.chdir(dirname(self._path))
+            sys.path.insert(0, '')
+
             exec(self._code, module.__dict__)
+
+            # undo sys.path, cwd fixups
+            del sys.path[0]
+            os.chdir(_cwd)
+            
             post_check()
         except Exception as e:
             self._failed = True

--- a/bokeh/application/handlers/code_runner.py
+++ b/bokeh/application/handlers/code_runner.py
@@ -76,12 +76,8 @@ class _CodeRunner(object):
             sys.path.insert(0, '')
 
             exec(self._code, module.__dict__)
-
-            # undo sys.path, cwd fixups
-            del sys.path[0]
-            os.chdir(_cwd)
-            
             post_check()
+
         except Exception as e:
             self._failed = True
             self._error_detail = traceback.format_exc()
@@ -90,3 +86,8 @@ class _CodeRunner(object):
             filename, line_number, func, txt = traceback.extract_tb(exc_traceback)[-1]
 
             self._error = "%s\nFile \"%s\", line %d, in %s:\n%s" % (str(e), os.path.basename(filename), line_number, func, txt)
+
+        finally:
+            # undo sys.path, CWD fixups
+            del sys.path[0]
+            os.chdir(_cwd)

--- a/bokeh/application/handlers/code_runner.py
+++ b/bokeh/application/handlers/code_runner.py
@@ -72,6 +72,7 @@ class _CodeRunner(object):
             #
             # https://docs.python.org/2/library/sys.html#sys.path
             _cwd = os.getcwd()
+            _sys_path = list(sys.path)
             os.chdir(dirname(self._path))
             sys.path.insert(0, '')
 
@@ -89,5 +90,5 @@ class _CodeRunner(object):
 
         finally:
             # undo sys.path, CWD fixups
-            del sys.path[0]
             os.chdir(_cwd)
+            sys.path = _sys_path

--- a/bokeh/application/handlers/code_runner.py
+++ b/bokeh/application/handlers/code_runner.py
@@ -11,7 +11,7 @@ from bokeh.util.serialization import make_id
 class _CodeRunner(object):
     """ Compile and run a Python source code."""
 
-    def __init__(self, source, path, **kwargs):
+    def __init__(self, source, path):
         self._failed = False
         self._error = None
         self._error_detail = None

--- a/bokeh/application/handlers/tests/test_code.py
+++ b/bokeh/application/handlers/tests/test_code.py
@@ -40,7 +40,7 @@ class TestCodeHandler(unittest.TestCase):
 
     def test_empty_script(self):
         doc = Document()
-        handler = CodeHandler("# This script does nothing", "test_filename")
+        handler = CodeHandler("# This script does nothing", "/test_filename")
         handler.modify_document(doc)
         if handler.failed:
             raise RuntimeError(handler.error)
@@ -49,7 +49,7 @@ class TestCodeHandler(unittest.TestCase):
 
     def test_script_adds_roots(self):
         doc = Document()
-        handler = CodeHandler(script_adds_two_roots, "test_filename")
+        handler = CodeHandler(script_adds_two_roots, "/test_filename")
         handler.modify_document(doc)
         if handler.failed:
             raise RuntimeError(handler.error)
@@ -58,7 +58,7 @@ class TestCodeHandler(unittest.TestCase):
 
     def test_script_bad_syntax(self):
         doc = Document()
-        handler = CodeHandler("This is a syntax error", "test_filename")
+        handler = CodeHandler("This is a syntax error", "/test_filename")
         handler.modify_document(doc)
 
         assert handler.error is not None
@@ -66,7 +66,7 @@ class TestCodeHandler(unittest.TestCase):
 
     def test_script_runtime_error(self):
         doc = Document()
-        handler = CodeHandler("raise RuntimeError('nope')", "test_filename")
+        handler = CodeHandler("raise RuntimeError('nope')", "/test_filename")
         handler.modify_document(doc)
 
         assert handler.error is not None

--- a/bokeh/application/handlers/tests/test_code.py
+++ b/bokeh/application/handlers/tests/test_code.py
@@ -71,3 +71,19 @@ class TestCodeHandler(unittest.TestCase):
 
         assert handler.error is not None
         assert 'nope' in handler.error
+
+    def test_script_sys_path(self):
+        doc = Document()
+        handler = CodeHandler("""import sys; raise RuntimeError("path: '%s'" % sys.path[0])""", "/test_filename")
+        handler.modify_document(doc)
+
+        assert handler.error is not None
+        assert "path: ''" in handler.error
+
+    def test_script_cwd(self):
+        doc = Document()
+        handler = CodeHandler("""import os; raise RuntimeError("cwd: '%s'" % os.getcwd())""", "/test_filename")
+        handler.modify_document(doc)
+
+        assert handler.error is not None
+        assert "cwd: '/'" in handler.error

--- a/examples/app/crossfilter/main.py
+++ b/examples/app/crossfilter/main.py
@@ -10,11 +10,6 @@ from bokeh.models import HBox, Select
 from bokeh.plotting import Figure
 from bokeh.sampledata.autompg import autompg
 
-# this is to be able to import modules from the app directory
-import sys
-from os.path import dirname
-sys.path.append(dirname(__file__))
-
 from models import StyleableBox, StatsBox
 from models.helpers import load_component
 

--- a/examples/app/crossfilter/models/models.py
+++ b/examples/app/crossfilter/models/models.py
@@ -3,11 +3,7 @@ from bokeh.models.layouts import BaseBox
 from bokeh.core import validation
 from bokeh.core.validation.warnings import EMPTY_LAYOUT
 
-import sys
-from os.path import dirname
-sys.path.append(dirname(__file__))
-
-from helpers import load_component
+from .helpers import load_component
 
 class StyleableBox(BaseBox):
     '''
@@ -21,7 +17,7 @@ class StatsBox(BaseBox):
     __implementation__ = load_component('./stats_box.coffee')
     styles = String(default=None)
     display_items = Dict(String, Any, default=None)
-    
+
     @validation.warning(EMPTY_LAYOUT)
     def _check_empty_layout(self):
         pass


### PR DESCRIPTION
issues: closes # 3994

To summarize, this PR causes code runner to:

* set CWD to app location
* prepend the empty string to `sys.path`

before `exec`ing code, and then undoes those afterward.

@bokeh/dev  ready for review