### PR TITLE
clarify that default mode is 'cdn' rather than 'inline'

### DIFF
--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -117,7 +117,7 @@ def output_file(filename, title="Bokeh Plot", autosave=False, mode="cdn", root_d
             command). If False, then the file is only saved upon calling
             :func:`show` or :func:`save`.
 
-        mode (str, optional) : how to include BokehJS (default: ``'inline'``)
+        mode (str, optional) : how to include BokehJS (default: ``'cdn'``)
             One of: ``'inline'``, ``'cdn'``, ``'relative(-dev)'`` or
             ``'absolute(-dev)'``. See :class:`bokeh.resources.Resources` for more details.
 

--- a/sphinx/source/docs/user_guide/quickstart.rst
+++ b/sphinx/source/docs/user_guide/quickstart.rst
@@ -252,12 +252,11 @@ As a convenience these can also typically be spelled as 2-tuples or lists::
 Resources
 ---------
 
-To generate plots, the client library BokehJS JavaScript and CSS code must
-be loaded into the browser. By default, the |output_file| function will
-configure Bokeh to generate static HTML files with BokehJS resources embedded
-directly inside. All the examples so far do this. However, you can also
-generate output that loads BokehJS from a Content Delivery Network (CDN), by 
-passing the argument ``mode="cdn"`` to the |output_file| function.
+To generate plots, the client library BokehJS JavaScript and CSS code must 
+be loaded into the browser. By default, the |output_file| function will 
+load BokehJS from http://cdn.pydata.org . However, you can also configure Bokeh 
+to generate static HTML files with BokehJS resources embedded directly inside, 
+by passing the argument ``mode="inline"`` to the |output_file| function.
 
 More examples
 =============


### PR DESCRIPTION
Clarify that default mode for output_file() is 'cdn' rather than
'inline'.