### PR TITLE
Fix up formatting of calendars example

### DIFF
--- a/examples/models/calendars.py
+++ b/examples/models/calendars.py
@@ -49,7 +49,12 @@ def make_calendar(year, month, firstweekday="Mon"):
     ydr = FactorRange(factors=list(reversed([ str(week) for week in range(month_weeks) ])))
 
     plot = Plot(title=month_names[month], x_range=xdr, y_range=ydr, plot_width=300, plot_height=300, outline_line_color=None)
+    plot.title_text_align = "left"
+    plot.title_text_font_size = "12pt"
     plot.title_text_color = "darkolivegreen"
+    plot.title_standoff = 25
+    plot.min_border_left = 0
+    plot.min_border_bottom = 5
 
     rect = Rect(x="days", y="weeks", width=0.9, height=0.9, fill_color="day_backgrounds", line_color="silver")
     plot.add_glyph(source, rect)


### PR DESCRIPTION
Not sure when this got a bit borked, but this is what master was looking like for me:

<img width="510" alt="screen shot 2016-03-10 at 12 33 22 pm" src="https://cloud.githubusercontent.com/assets/1796208/13683608/7175d96e-e6bc-11e5-8b98-361a0f1302ca.png">

and here's after this PR:

<img width="482" alt="screen shot 2016-03-10 at 12 32 45 pm" src="https://cloud.githubusercontent.com/assets/1796208/13683602/69578610-e6bc-11e5-9c33-1ea38d314724.png">

