### PR TITLE
Make docserver.py run on both windows and unix by using threading instead of os.fork.

### DIFF
--- a/sphinx/docserver.py
+++ b/sphinx/docserver.py
@@ -2,15 +2,21 @@ from __future__ import print_function
 
 import flask
 import os
+import threading
+import time
+import webbrowser
 
 from tornado.wsgi import WSGIContainer
 from tornado.httpserver import HTTPServer
 from tornado.ioloop import IOLoop
 
+
+
 _basedir = os.path.join("..", os.path.dirname(__file__))
 
 app = flask.Flask(__name__, static_path="/unused")
 PORT=5009
+http_server = HTTPServer(WSGIContainer(app))
 
 """this is a simple server to facilitate developing the docs.  by
 serving up static files from this server, we avoid the need to use a
@@ -32,21 +38,38 @@ def send_pic(filename):
         os.path.join(_basedir,"sphinx/_build/html/"), filename)
 
 
+def open_browser():
+    # Child process
+    time.sleep(0.5)
+    webbrowser.open("http://localhost:%d/en/latest/index.html" % PORT, new="tab")
+
+def serve_http():
+    http_server.listen(PORT)
+    IOLoop.instance().start()
+
+def shutdown_server():
+    ioloop = IOLoop.instance()
+    ioloop.add_callback(ioloop.stop)
+    print("Asked Server to shut down.")
+
+def ui():
+    time.sleep(0.5)
+    input("Press any key to exit...")
+
+
 if __name__ == "__main__":
-    http_server = HTTPServer(WSGIContainer(app))
+
     print("\nStarting Bokeh plot server on port %d..." % PORT)
     print("Visit http://localhost:%d/en/latest/index.html to see plots\n" % PORT)
 
-    pid = os.fork()
-    if pid != 0:
-        # Parent process
-        http_server.listen(PORT)
-        IOLoop.instance().start()
-    else:
-        # Child process
-        import time
-        import webbrowser
-        time.sleep(0.5)
-        webbrowser.open("http://localhost:%d/en/latest/index.html" % PORT, new="tab")
+    t_server = threading.Thread(target=serve_http)  
+    t_server.start()
+    t_browser = threading.Thread(target=open_browser)
+    t_browser.start()
 
+    ui()
 
+    shutdown_server()
+    t_server.join()
+    t_browser.join()
+    print("Server shut down.")


### PR DESCRIPTION
issues: closes #4027

See the discussion in [this issue](https://github.com/bokeh/bokeh/issues/4027).

I exchanged the use of `os.fork()` in `sphinx/docserver.py` against using the `threading` module, which should work regardless of the os. I also added the possibility to shutdown the server.

My implementation is mainly due to [this GH answer](http://stackoverflow.com/a/17325148/2207840).

Caution: My experience with web programming in python is near-zero, so there is a real chance that what I did is plain nonsense. I tried the new version on both Win 7 and Arch linux and it seemed to work on both systems.

Happy to provide further relevant information!