### PR TITLE
Fix that a bar chart with one "item" does not show a label

### DIFF
--- a/bokeh/charts/builders/bar_builder.py
+++ b/bokeh/charts/builders/bar_builder.py
@@ -320,7 +320,7 @@ def Bar(data, label=None, values=None, color=None, stack=None, group=None, agg="
     chart = create_and_build(BarBuilder, data, **kw)
 
     # hide x labels if there is a single value, implying stacking only
-    if len(chart.x_range.factors) == 1:
+    if len(chart.x_range.factors) == 1 and not label:
         chart.below[0].visible = False
 
     return chart

--- a/bokeh/charts/tests/test_chart.py
+++ b/bokeh/charts/tests/test_chart.py
@@ -171,3 +171,24 @@ def test_charts_theme_validation():
 
     with pytest.raises(ValueError):
         defaults.apply(p)
+
+
+def test_bar_chart_below_visibility():
+    from bokeh.charts import Bar
+    
+    # Visible because we have multiple bars
+    df = dict(types=['foo', 'bar'], counts=[3, 2])
+    p = Bar(df, values='counts')
+    p.below[0].visible
+    
+    # Visible because we excplicitly specify labels
+    df = dict(types=['foo'], counts=[3])
+    p = Bar(df, values='counts', label='types')
+    assert p.below[0].visible
+    
+    # Not visible because only one item and no labels
+    df = dict(types=['foo'], counts=[3])
+    p = Bar(df, values='counts')
+    assert not p.below[0].visible
+    
+    


### PR DESCRIPTION
Fixes #3661 

There was code to explicitly hide the x-axis, ticks and labels when there is but one item in the bar chart. But when the label is explicitly specified, it should be shown regardless.