### PR TITLE
Don't attach document multiple times when traversing the graph

### DIFF
--- a/bokehjs/src/coffee/core/has_props.coffee
+++ b/bokehjs/src/coffee/core/has_props.coffee
@@ -373,23 +373,19 @@ class HasProps extends Backbone.Model
         throw new Error("models must be owned by only a single document")
       else
         @document._notify_attach(@)
-        return
+    else
+      @document = doc
+      @document._notify_attach(@)
 
-    first_attach = @document == null
-    @document = doc
+      for ref in @_immediate_references()
+        ref.attach_document(@document)
 
-    if doc != null
-      doc._notify_attach(@)
-      if first_attach
-        for c in @_immediate_references()
-          c.attach_document(doc)
+      # TODO (bev) is there are way to get rid of this?
+      for name, prop of @properties
+        prop.update()
 
-    # TODO (bev) is there are way to get rid of this?
-    for name, prop of @properties
-      prop.update()
-
-    if @_doc_attached?
-      @_doc_attached()
+      if @_doc_attached?
+        @_doc_attached()
 
   detach_document: () ->
     if @document != null

--- a/bokehjs/src/coffee/core/has_props.coffee
+++ b/bokehjs/src/coffee/core/has_props.coffee
@@ -368,10 +368,16 @@ class HasProps extends Backbone.Model
     _.values(result)
 
   attach_document: (doc) ->
-    if @document != null and @document != doc
-      throw new Error("Models must be owned by only a single document")
+    if @document != null
+      if @document != doc
+        throw new Error("models must be owned by only a single document")
+      else
+        @document._notify_attach(@)
+        return
+
     first_attach = @document == null
     @document = doc
+
     if doc != null
       doc._notify_attach(@)
       if first_attach


### PR DESCRIPTION
This fixes the problem with `_doc_attach()` being called multiple times, specifically `Canvas._doc_attached()`, which caused substantial performance degradation.
