### PR TITLE
Add Ellipse glyph

### DIFF
--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -594,8 +594,6 @@ class Oval(Glyph):
     The %s values for the ovals.
     """)
 
-
-
 class Patch(Glyph):
     """ Render a single patch.
 

--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -186,6 +186,43 @@ class Bezier(Glyph):
     The %s values for the Bézier curves.
     """)
 
+class Ellipse(Glyph):
+    u""" Render ellipses. """
+
+    __example__ = "tests/glyphs/Ellipse.py"
+
+    # a canonical order for positional args that can be used for any
+    # functions derived from this class
+    _args = ('x', 'y', 'width', 'height', 'angle')
+
+    x = NumberSpec(help="""
+    The x-coordinates of the centers of the ellipses.
+    """)
+
+    y = NumberSpec(help="""
+    The y-coordinates of the centers of the ellipses.
+    """)
+
+    width = DistanceSpec(help="""
+    The widths of each ellipse.
+    """)
+
+    height = DistanceSpec(help="""
+    The heights of each ellipse.
+    """)
+
+    angle = AngleSpec(default=0.0, help="""
+    The angle the ellipses are rotated from horizontal. [rad]
+    """)
+
+    line_props = Include(LineProps, use_prefix=False, help="""
+    The %s values for the ovals.
+    """)
+
+    fill_props = Include(FillProps, use_prefix=False, help="""
+    The %s values for the ovals.
+    """)
+
 class Gear(Glyph):
     """ Render gears.
 
@@ -519,7 +556,8 @@ class Oval(Glyph):
 
     .. note::
         This glyph renders ovals using Bézier curves, which are similar,
-        but not identical to ellipses.
+        but not identical to ellipses. In particular, widths equal to heights
+        will not render circles. Use the ``Ellipse`` glyph for that.
     """
 
     __example__ = "tests/glyphs/Oval.py"
@@ -555,6 +593,8 @@ class Oval(Glyph):
     fill_props = Include(FillProps, use_prefix=False, help="""
     The %s values for the ovals.
     """)
+
+
 
 class Patch(Glyph):
     """ Render a single patch.

--- a/bokeh/plotting/figure.py
+++ b/bokeh/plotting/figure.py
@@ -251,6 +251,22 @@ Examples:
 
 """)
 
+    ellipse = _glyph_function(glyphs.Ellipse, """
+Examples:
+
+    .. bokeh-plot::
+        :source-position: above
+
+        from bokeh.plotting import figure, output_file, show
+
+        plot = figure(width=300, height=300)
+        plot.ellipse(x=[1, 2, 3], y=[1, 2, 3], width=30, height=20,
+                     color="#386CB0", fill_color=None, line_width=2)
+
+        show(plot)
+
+""")
+
     image = _glyph_function(glyphs.Image)
 
     image_rgba = _glyph_function(glyphs.ImageRGBA, """

--- a/bokehjs/src/coffee/api/models.coffee
+++ b/bokehjs/src/coffee/api/models.coffee
@@ -39,6 +39,7 @@ module.exports = {
   Annulus:                                require("../models/glyphs/annulus").Model
   Arc:                                    require("../models/glyphs/arc").Model
   Bezier:                                 require("../models/glyphs/bezier").Model
+  Ellipse:                                require("../models/glyphs/ellipse").Model
   ImageRGBA:                              require("../models/glyphs/image_rgba").Model
   Image:                                  require("../models/glyphs/image").Model
   ImageURL:                               require("../models/glyphs/image_url").Model

--- a/bokehjs/src/coffee/api/plotting.coffee
+++ b/bokehjs/src/coffee/api/plotting.coffee
@@ -116,6 +116,7 @@ class Figure extends models.Plot
   annulus:           (args...) -> @_glyph(models.Annulus,      "x,y,inner_radius,outer_radius",                       args)
   arc:               (args...) -> @_glyph(models.Arc,          "x,y,radius,start_angle,end_angle",                    args)
   bezier:            (args...) -> @_glyph(models.Bezier,       "x0,y0,x1,y1,cx0,cy0,cx1,cy1",                         args)
+  ellipse:           (args...) -> @_glyph(models.Ellipse,      "x,y,width,height",                                    args)
   gear:              (args...) -> @_glyph(models.Gear,         "x,y,module,teeth",                                    args)
   image:             (args...) -> @_glyph(models.Image,        "color_mapper,image,rows,cols,x,y,dw,dh",              args)
   image_rgba:        (args...) -> @_glyph(models.ImageRGBA,    "image,rows,cols,x,y,dw,dh",                           args)

--- a/bokehjs/src/coffee/api/typings/models/glyphs.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/glyphs.d.ts
@@ -49,6 +49,16 @@ declare namespace Bokeh {
         cy1?: Numerical | Categorical;
     }
 
+    export var Ellipse: { new(attributes?: IEllipse, options?: ModelOpts): Ellipse };
+    export interface Ellipse extends Glyph, IEllipse {}
+    export interface IEllipse extends IGlyph, FillProps, LineProps {
+        x?: Numerical | Categorical;
+        y?: Numerical | Categorical;
+        width?: Spatial;
+        height?: Spatial;
+        angle?: Angular;
+    }
+
     export var ImageRGBA: { new(attributes?: IImageRGBA, options?: ModelOpts): ImageRGBA };
     export interface ImageRGBA extends Glyph, IImageRGBA {}
     export interface IImageRGBA extends IGlyph {

--- a/bokehjs/src/coffee/api/typings/plotting.d.ts
+++ b/bokehjs/src/coffee/api/typings/plotting.d.ts
@@ -60,6 +60,7 @@ declare namespace Bokeh.Plotting {
         annulus           (attrs: AnnulusAttrs):          GlyphRenderer;
         arc               (attrs: ArcAttrs):              GlyphRenderer;
         bezier            (attrs: BezierAttrs):           GlyphRenderer;
+        ellipse           (attrs: EllipseAttrs):          GlyphRenderer;
         gear              (attrs: GearAttrs):             GlyphRenderer;
         image             (attrs: ImageAttrs):            GlyphRenderer;
         image_rgba        (attrs: ImageRGBAAttrs):        GlyphRenderer;
@@ -122,6 +123,12 @@ declare namespace Bokeh.Plotting {
             cx1: DataAttr,
             cy1: DataAttr,
             opts?: BezierOpts):           GlyphRenderer;
+        ellipse(
+            x: DataAttr,
+            y: DataAttr,
+            width: SpatialAttr,
+            height: SpatialAttr,
+            opts?: EllipseOpts):             GlyphRenderer;
         gear(
             x: DataAttr,
             y: DataAttr,
@@ -364,6 +371,16 @@ declare namespace Bokeh.Plotting {
         cy0: DataAttr;
         cx1: DataAttr;
         cy1: DataAttr;
+    }
+
+    export interface EllipseOpts extends GlyphOpts, FillPropsOpts, LinePropsOpts {
+        angle?: AngularAttr;
+    }
+    export interface EllipseAttrs extends EllipseOpts {
+        x: DataAttr;
+        y: DataAttr;
+        width: SpatialAttr;
+        height: SpatialAttr;
     }
 
     export interface GearOpts extends GlyphOpts, LinePropsOpts, FillPropsOpts {

--- a/bokehjs/src/coffee/common/models.coffee
+++ b/bokehjs/src/coffee/common/models.coffee
@@ -35,6 +35,7 @@ module.exports = {
   Arc:                      require '../models/glyphs/arc'
   Bezier:                   require '../models/glyphs/bezier'
   Circle:                   require '../models/glyphs/circle'
+  Ellipse:                  require '../models/glyphs/ellipse'
   Gear:                     require '../models/glyphs/gear'
   Image:                    require '../models/glyphs/image'
   ImageRGBA:                require '../models/glyphs/image_rgba'

--- a/bokehjs/src/coffee/core/util/canvas.coffee
+++ b/bokehjs/src/coffee/core/util/canvas.coffee
@@ -47,9 +47,38 @@ get_scale_ratio = (ctx, hidpi) ->
   else
     return 1
 
+fixup_ellipse = (ctx) ->
+  # implementing the ctx.ellipse function with bezier curves
+  # we don't implement the startAngle, endAngle and anticlockwise arguments.
+  ellipse_bezier = (x, y, radiusX, radiusY, rotation, startAngle, endAngle, anticlockwise = false) ->
+    c = 0.551784 # see http://www.tinaja.com/glib/ellipse4.pdf
+
+    ctx.translate(x, y)
+    ctx.rotate(rotation)
+
+    rx = radiusX
+    ry = radiusY
+    if anticlockwise
+      rx = -radiusX
+      ry = -radiusY
+
+    ctx.moveTo(-rx, 0) # start point of first curve
+    ctx.bezierCurveTo(-rx,  ry * c, -rx * c,  ry, 0,  ry)
+    ctx.bezierCurveTo( rx * c,  ry,  rx,  ry * c,  rx, 0)
+    ctx.bezierCurveTo( rx, -ry * c,  rx * c, -ry, 0, -ry)
+    ctx.bezierCurveTo(-rx * c, -ry, -rx, -ry * c, -rx, 0)
+
+    ctx.rotate(-rotation)
+    ctx.translate(-x, -y)
+    return
+
+  if (!ctx.ellipse)
+    ctx.ellipse = ellipse_bezier
+
 module.exports =
   fixup_image_smoothing: fixup_image_smoothing
   fixup_line_dash: fixup_line_dash
   fixup_line_dash_offset: fixup_line_dash_offset
   fixup_measure_text: fixup_measure_text
   get_scale_ratio: get_scale_ratio
+  fixup_ellipse: fixup_ellipse

--- a/bokehjs/src/coffee/models/canvas/canvas.coffee
+++ b/bokehjs/src/coffee/models/canvas/canvas.coffee
@@ -7,7 +7,7 @@ BokehView = require "../../core/bokeh_view"
 {EQ} = require "../../core/layout/solver"
 {logger} = require "../../core/logging"
 p = require "../../core/properties"
-{fixup_image_smoothing, fixup_line_dash, fixup_line_dash_offset, fixup_measure_text, get_scale_ratio} = require "../../core/util/canvas"
+{fixup_image_smoothing, fixup_line_dash, fixup_line_dash_offset, fixup_measure_text, get_scale_ratio, fixup_ellipse} = require "../../core/util/canvas"
 
 class CanvasView extends BokehView
   className: "bk-canvas-wrapper"
@@ -33,6 +33,7 @@ class CanvasView extends BokehView
     fixup_line_dash_offset(@ctx)
     fixup_image_smoothing(@ctx)
     fixup_measure_text(@ctx)
+    fixup_ellipse(@ctx)
 
     # map plots reference this attribute
     @map_div = @$('div.bk-canvas-map') ? null

--- a/bokehjs/src/coffee/models/glyphs/ellipse.coffee
+++ b/bokehjs/src/coffee/models/glyphs/ellipse.coffee
@@ -42,31 +42,6 @@ class EllipseView extends Glyph.View
          @visuals.line.set_vectorize(ctx, i)
          ctx.stroke()
 
-
-    # for i in indices
-    #   if isNaN(sx[i]+sy[i]+sw[i]+sh[i]+@_angle[i])
-    #     continue
-    #
-    #   ctx.translate(sx[i], sy[i])
-    #   ctx.rotate(@_angle[i])
-    #
-    #   ctx.beginPath()
-    #   ctx.moveTo(0, -sh[i]/2)
-    #   ctx.bezierCurveTo( sw[i]/2, -sh[i]/2,  sw[i]/2,  sh[i]/2, 0,  sh[i]/2)
-    #   ctx.bezierCurveTo(-sw[i]/2,  sh[i]/2, -sw[i]/2, -sh[i]/2, 0, -sh[i]/2)
-    #   ctx.closePath()
-    #
-    #   if @visuals.fill.doit
-    #     @visuals.fill.set_vectorize(ctx, i)
-    #     ctx.fill()
-    #
-    #   if @visuals.line.doit
-    #     @visuals.line.set_vectorize(ctx, i)
-    #     ctx.stroke()
-    #
-    #   ctx.rotate(-@_angle[i])
-    #   ctx.translate(-sx[i], -sy[i])
-
   draw_legend: (ctx, x0, x1, y0, y1) ->
     reference_point = @get_reference_point() ? 0
 

--- a/bokehjs/src/coffee/models/glyphs/ellipse.coffee
+++ b/bokehjs/src/coffee/models/glyphs/ellipse.coffee
@@ -1,0 +1,114 @@
+_ = require "underscore"
+
+Glyph = require "./glyph"
+p = require "../../core/properties"
+
+class EllipseView extends Glyph.View
+
+  _set_data: () ->
+    @max_w2 = 0
+    if @model.properties.width.units == "data"
+      @max_w2 = @max_width/2
+    @max_h2 = 0
+    if @model.properties.height.units == "data"
+      @max_h2 = @max_height/2
+
+  _index_data: () ->
+    @_xy_index()
+
+  _map_data: () ->
+    if @model.properties.width.units == "data"
+      @sw = @sdist(@renderer.xmapper, @_x, @_width, 'center')
+    else
+      @sw = @_width
+    if @model.properties.height.units == "data"
+      @sh = @sdist(@renderer.ymapper, @_y, @_height, 'center')
+    else
+      @sh = @_height
+
+  _render: (ctx, indices, {sx, sy, sw, sh}) ->
+     for i in indices
+       if isNaN(sx[i]+sy[i]+sw[i]+sh[i]+@_angle[i])
+         continue
+
+       ctx.beginPath()
+       ctx.ellipse(sx[i], sy[i], sw[i]/2.0, sh[i]/2.0, @_angle[i], 0, 2 * Math.PI)
+
+       if @visuals.fill.doit
+         @visuals.fill.set_vectorize(ctx, i)
+         ctx.fill()
+
+       if @visuals.line.doit
+         @visuals.line.set_vectorize(ctx, i)
+         ctx.stroke()
+
+
+    # for i in indices
+    #   if isNaN(sx[i]+sy[i]+sw[i]+sh[i]+@_angle[i])
+    #     continue
+    #
+    #   ctx.translate(sx[i], sy[i])
+    #   ctx.rotate(@_angle[i])
+    #
+    #   ctx.beginPath()
+    #   ctx.moveTo(0, -sh[i]/2)
+    #   ctx.bezierCurveTo( sw[i]/2, -sh[i]/2,  sw[i]/2,  sh[i]/2, 0,  sh[i]/2)
+    #   ctx.bezierCurveTo(-sw[i]/2,  sh[i]/2, -sw[i]/2, -sh[i]/2, 0, -sh[i]/2)
+    #   ctx.closePath()
+    #
+    #   if @visuals.fill.doit
+    #     @visuals.fill.set_vectorize(ctx, i)
+    #     ctx.fill()
+    #
+    #   if @visuals.line.doit
+    #     @visuals.line.set_vectorize(ctx, i)
+    #     ctx.stroke()
+    #
+    #   ctx.rotate(-@_angle[i])
+    #   ctx.translate(-sx[i], -sy[i])
+
+  draw_legend: (ctx, x0, x1, y0, y1) ->
+    reference_point = @get_reference_point() ? 0
+
+    indices = [reference_point]
+    sx = { }
+    sx[reference_point] = (x0+x1)/2
+    sy = { }
+    sy[reference_point] = (y0+y1)/2
+
+    scale = @sw[reference_point] / @sh[reference_point]
+    d = Math.min(Math.abs(x1-x0), Math.abs(y1-y0)) * 0.8
+    sw = { }
+    sh = { }
+    if scale > 1
+      sw[reference_point] = d
+      sh[reference_point] = d/scale
+    else
+      sw[reference_point] = d*scale
+      sh[reference_point] = d
+
+    data = {sx, sy, sw, sh}
+    @_render(ctx, indices, data)
+
+  _bounds: (bds) ->
+    return [
+      [bds[0][0]-@max_w2, bds[0][1]+@max_w2],
+      [bds[1][0]-@max_h2, bds[1][1]+@max_h2]
+    ]
+
+class Ellipse extends Glyph.Model
+  default_view: EllipseView
+
+  type: 'Ellipse'
+
+  @coords [['x', 'y']]
+  @mixins ['line', 'fill']
+  @define {
+      angle:  [ p.AngleSpec,   0.0 ]
+      width:  [ p.DistanceSpec     ]
+      height: [ p.DistanceSpec     ]
+    }
+
+module.exports =
+  Model: Ellipse
+  View: EllipseView

--- a/examples/plotting/file/glyphs.py
+++ b/examples/plotting/file/glyphs.py
@@ -35,6 +35,11 @@ p = figure(title="circle")
 p.circle(x, y, radius=0.1, color="#3288BD")
 children.append(p)
 
+p = figure(title="ellipse")
+p.ellipse(x, y, 15, 25, angle=-0.7, color="#1D91C0",
+       width_units="screen", height_units="screen")
+children.append(p)
+
 p = figure(title="line")
 p.line(x, y, color="#F46D43")
 children.append(p)

--- a/examples/plotting/notebook/glyphs.ipynb
+++ b/examples/plotting/notebook/glyphs.ipynb
@@ -137,6 +137,20 @@
    },
    "outputs": [],
    "source": [
+    "p = figure(title=\"ellipse\")\n",
+    "p.ellipse(x, y, 15, 25, angle=-0.7, color=\"#1D91C0\",\n",
+    "    width_units=\"screen\", height_units=\"screen\")\n",
+    "show(p)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
     "p = figure(title=\"line\")\n",
     "p.line(x, y, color=\"#F46D43\")\n",
     "show(p)"

--- a/sphinx/source/docs/reference/bokehjs.rst
+++ b/sphinx/source/docs/reference/bokehjs.rst
@@ -291,6 +291,29 @@ together with a crossbar (+) at the given coordinates.
     :alt: Click to view JSFiddle
     :target: http://jsfiddle.net/bokeh/tx3Z4/
 
+.. _bokehjs_ellipse:
+
+``ellipse``
+~~~~~~~~
+
+The ellipse glyph displays ellipses centered on the given coordinates with the
+given dimensions and angle.
+
+* ``x``, ``y`` - center point coordinates
+* ``width``
+* ``height``
+* ``angle``
+
+  * default: 0
+
+* :ref:`bokehjs_line_properties`
+* :ref:`bokehjs_fill_properties`
+
+.. image:: ../../_images/bokehjs_glyphs/ellipse.png
+    :height: 300px
+    :alt: Click to view JSFiddle
+    :target: http://jsfiddle.net/bokeh/h6eXz/
+
 .. _bokehjs_image:
 
 ``image``
@@ -707,4 +730,3 @@ the given coordinates.
     :height: 300px
     :alt: Click to view JSFiddle
     :target: http://jsfiddle.net/bokeh/3hXa8/
-

--- a/sphinx/source/docs/user_guide/plotting.rst
+++ b/sphinx/source/docs/user_guide/plotting.rst
@@ -49,8 +49,8 @@ example plots for all of them by clicking on entries in the list below:
     * |x|
 
 All the markers have the same set of properties: ``x``, ``y``, ``size`` (in
-:ref:`screen units <userguide_styling_units>`), and ``angle`` (radians by 
-default). Additionally, |circle| has a ``radius`` property that can be used to 
+:ref:`screen units <userguide_styling_units>`), and ``angle`` (radians by
+default). Additionally, |circle| has a ``radius`` property that can be used to
 specify :ref:`data-space units <userguide_styling_units>`.
 
 .. _userguide_plotting_line_glyphs:
@@ -135,8 +135,8 @@ patch objects, that have multiple disjoint components when rendered:
 
 .. _userguide_plotting_quads_rects:
 
-Rectangles and Ovals
-~~~~~~~~~~~~~~~~~~~~
+Rectangles, Ovals and Ellipses
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To draw *axis aligned* rectangles ("quads"), use the |quad| glyph function,
 which accepts ``left``, ``right``, ``top``, and ``bottom`` values to specify
@@ -155,6 +155,14 @@ The |oval| glyph method accepts the same properties as |rect|, but renders
 oval shapes:
 
 .. bokeh-plot:: source/docs/user_guide/source_examples/plotting_ovals.py
+    :source-position: above
+
+The |ellipse| glyph accepts the same properties as |oval| and |rect| but
+renders ellipse shapes, which are different from oval ones. In particular,
+the same value for width and height will render a circle using the |ellipse|
+glyph but not the |oval| one:
+
+.. bokeh-plot:: source/docs/user_guide/source_examples/plotting_ellipses.py
     :source-position: above
 
 .. _userguide_plotting_images:
@@ -190,9 +198,9 @@ The |segment| function accepts start points ``x0``, ``y0`` and end points
     :source-position: above
 
 The |ray| function accepts start points ``x``, ``y`` with a ``length``
-(in :ref:`screen units <userguide_styling_units>`) and an ``angle``. The default 
-``angle_units`` are ``"rad"`` but can also be changed to ``"deg"``. To have an 
-"infinite" ray, that always extends to the edge of the plot, specify ``0`` for 
+(in :ref:`screen units <userguide_styling_units>`) and an ``angle``. The default
+``angle_units`` are ``"rad"`` but can also be changed to ``"deg"``. To have an
+"infinite" ray, that always extends to the edge of the plot, specify ``0`` for
 the length:
 
 .. bokeh-plot:: source/docs/user_guide/source_examples/plotting_ray.py

--- a/sphinx/source/docs/user_guide/source_examples/plotting_ellipses.py
+++ b/sphinx/source/docs/user_guide/source_examples/plotting_ellipses.py
@@ -1,0 +1,10 @@
+from math import pi
+from bokeh.plotting import figure, show, output_file
+
+output_file('ellipses.html')
+
+p = figure(width=400, height=400)
+p.ellipse(x=[1, 2, 3], y=[1, 2, 3], width=[0.2, 0.3, 0.1], height=0.3,
+          angle=pi/3, color="#CAB2D6")
+
+show(p)

--- a/tests/glyphs/Ellipse.py
+++ b/tests/glyphs/Ellipse.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+from bokeh.document import Document
+from bokeh.models import ColumnDataSource, DataRange1d, Plot, LinearAxis, Grid
+from bokeh.models.glyphs import Ellipse
+from bokeh.plotting import show
+
+N = 9
+x = np.linspace(-2, 2, N)
+y = x**2
+w = x/15.0 + 0.3
+h = y/20.0 + 0.3
+
+source = ColumnDataSource(dict(x=x, y=y, w=w, h=h))
+
+xdr = DataRange1d()
+ydr = DataRange1d()
+
+plot = Plot(
+    title=None, x_range=xdr, y_range=ydr, plot_width=300, plot_height=300,
+    h_symmetry=False, v_symmetry=False, min_border=0, toolbar_location=None)
+
+glyph = Ellipse(x="x", y="y", width="w", height="h", angle=-0.7, fill_color="#CAB2D6")
+plot.add_glyph(source, glyph)
+
+xaxis = LinearAxis()
+plot.add_layout(xaxis, 'below')
+
+yaxis = LinearAxis()
+plot.add_layout(yaxis, 'left')
+
+plot.add_layout(Grid(dimension=0, ticker=xaxis.ticker))
+plot.add_layout(Grid(dimension=1, ticker=yaxis.ticker))
+
+doc = Document()
+doc.add_root(plot)
+
+show(doc)


### PR DESCRIPTION
- [x] fixes #3848
- [x] added test in `tests/glyphs/Ellipse.py`
- [x] .rst files were edited to add the new documentation (and to edit the Oval one)

The Ellipse glyph is implemented with the CanvasRenderingContext2D.ellipse()
function, which is currently marked as experimental, and unsupported on some
mobile platform. A more robust implementation would need to use Bezier curves
until more platforms support the function.