### PR TITLE
Improve docs for python -m bokeh command

### DIFF
--- a/sphinx/source/docs/dev_guide/setup.rst
+++ b/sphinx/source/docs/dev_guide/setup.rst
@@ -251,13 +251,13 @@ If you build Bokeh on a Windows machine in a Conda environment with either
 ``setup.py install`` or ``setup.py develop``, running ``bokeh serve`` will
 not work correctly. The .exe will not be available within the Conda
 environment, which means you will use the version available in the base
-install, if it is available. Instead, you can make sure you use the version
-within the environment by explicitly running the ``bokeh serve`` python script
-in the root of the bokeh repository, similar to the following example:
+install, if it is available. Instead, you can make sure you use the Python
+version within the environment by making use of Python's ``-m`` flag,
+as in the following example:
 
 .. code-block:: sh
 
-    python bokeh serve path\to\<yourapp>.py
+    python -m bokeh serve path\to\<yourapp>.py
 
 Developing Examples
 -------------------

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -117,6 +117,12 @@ First, we must have a Bokeh Server running. To do that, execute the command:
 
     bokeh serve
 
+or, alternatively:
+
+.. code-block:: sh
+
+    python -m bokeh serve
+
 When the server starts you should see output similar to the following on your
 console:
 


### PR DESCRIPTION
Issues: fixes #4092 

The ability to use `python -m bokeh` was added when we implemented `__main__.py` sometime ago. It is mentioned in the docs [here](http://bokeh.pydata.org/en/latest/docs/user_guide/server.html) but there are two places where it makes sense mentioning it too (which is what this PR does).

