### PR TITLE
Allow getting ref to view again in line click/select event

### DIFF
--- a/bokehjs/src/coffee/api/typings/selected.d.ts
+++ b/bokehjs/src/coffee/api/typings/selected.d.ts
@@ -1,8 +1,14 @@
 declare namespace Bokeh {
     // get_view() returns null or View, but View is not typed yet
-    export type Selected0d = {indices: Array<Int>, glyph?: Glyph, get_view(): any};
+    export type Selected0d = {indices: Array<Int>};
     export type Selected1d = {indices: Array<Int>};
     export type Selected2d = {indices: Array<Array<Int>>};
 
-    export type Selected = { '0d': Selected0d, '1d': Selected1d, '2d': Selected2d };
+    export type Selected = {
+        get_model(): any,
+        get_view(): any,
+        '0d': Selected0d,
+        '1d': Selected1d,
+        '2d': Selected2d,
+         };
 }

--- a/bokehjs/src/coffee/api/typings/selected.d.ts
+++ b/bokehjs/src/coffee/api/typings/selected.d.ts
@@ -1,5 +1,6 @@
 declare namespace Bokeh {
-    export type Selected0d = {indices: Array<Int>, glyph?: Glyph};
+    // get_view() returns null or View, but View is not typed yet
+    export type Selected0d = {indices: Array<Int>, glyph?: Glyph, get_view(): any};
     export type Selected1d = {indices: Array<Int>};
     export type Selected2d = {indices: Array<Array<Int>>};
 

--- a/bokehjs/src/coffee/common/hittest.coffee
+++ b/bokehjs/src/coffee/common/hittest.coffee
@@ -17,11 +17,11 @@ point_in_poly = (x, y, px, py) ->
 
 create_hit_test_result = ->
   result = {
+    # the glyph that was picked
+    get_view: () -> null,  # function, to avoid infinite recursion
+    get_model: () -> null,  # also a function, for consistency
     # 0d is only valid for line and patch glyphs
     '0d': {
-      # the glyph that was picked
-      glyph: null,
-      get_view: () -> null,  # this is a function, because setting the view causes inf. recursion
       # array with the [smallest] index of the segment of the line that was hit
       indices: []
     }

--- a/bokehjs/src/coffee/common/hittest.coffee
+++ b/bokehjs/src/coffee/common/hittest.coffee
@@ -21,6 +21,7 @@ create_hit_test_result = ->
     '0d': {
       # the glyph that was picked
       glyph: null,
+      get_view: () -> null,  # this is a function, because setting the view causes inf. recursion
       # array with the [smallest] index of the segment of the line that was hit
       indices: []
     }

--- a/bokehjs/src/coffee/common/selector.coffee
+++ b/bokehjs/src/coffee/common/selector.coffee
@@ -10,8 +10,9 @@ class Selector extends HasProps
     @set('timestamp', new Date(), {silent: silent})
     @set('final', final, {silent: silent})
     if append
-      indices['0d'].indices =  _.union(@get('indices')['0d'].indices, indices['0d'].indices)
-      indices['0d'].glyph =  @get('indices')['0d'].glyph or indices['0d'].glyph
+      if @get('indices').get_model()
+        indices.get_model = @get('indices').get_model
+        indices.get_view = @get('indices').get_view
       indices['1d'].indices =  _.union(@get('indices')['1d'].indices, indices['1d'].indices)
       indices['2d'].indices =  _.union(@get('indices')['2d'].indices, indices['2d'].indices)
     @set('indices', indices, {silent: silent})

--- a/bokehjs/src/coffee/common/selector.coffee
+++ b/bokehjs/src/coffee/common/selector.coffee
@@ -13,6 +13,7 @@ class Selector extends HasProps
       if @get('indices').get_model()
         indices.get_model = @get('indices').get_model
         indices.get_view = @get('indices').get_view
+      indices['0d'].indices =  _.union(@get('indices')['0d'].indices, indices['0d'].indices)
       indices['1d'].indices =  _.union(@get('indices')['1d'].indices, indices['1d'].indices)
       indices['2d'].indices =  _.union(@get('indices')['2d'].indices, indices['2d'].indices)
     @set('indices', indices, {silent: silent})

--- a/bokehjs/src/coffee/models/glyphs/line.coffee
+++ b/bokehjs/src/coffee/models/glyphs/line.coffee
@@ -59,9 +59,8 @@ class LineView extends Glyph.View
 
       if dist < threshold && dist < shortest
         shortest = dist
-        result['0d'].glyph = this.model
-        result['0d'].get_view = (() -> this).bind(this);
-        result['0d'].flag = true  # backward compat
+        result.get_model = (() -> this).bind(this.model)
+        result.get_view = (() -> this).bind(this)
         result['0d'].indices = [i]
 
     return result
@@ -79,9 +78,8 @@ class LineView extends Glyph.View
 
     for i in [0...values.length-1]
       if values[i]<=val<=values[i+1]
-        result['0d'].glyph = this.model
-        result['0d'].get_view = (() -> this).bind(this);
-        result['0d'].flag = true  # backward compat
+        result.get_model = (() -> this).bind(this.model)
+        result.get_view = (() -> this).bind(this)
         result['0d'].indices.push(i)
 
     return result

--- a/bokehjs/src/coffee/models/glyphs/line.coffee
+++ b/bokehjs/src/coffee/models/glyphs/line.coffee
@@ -60,6 +60,7 @@ class LineView extends Glyph.View
       if dist < threshold && dist < shortest
         shortest = dist
         result['0d'].glyph = this.model
+        result['0d'].get_view = (() -> this).bind(this);
         result['0d'].flag = true  # backward compat
         result['0d'].indices = [i]
 
@@ -79,6 +80,7 @@ class LineView extends Glyph.View
     for i in [0...values.length-1]
       if values[i]<=val<=values[i+1]
         result['0d'].glyph = this.model
+        result['0d'].get_view = (() -> this).bind(this);
         result['0d'].flag = true  # backward compat
         result['0d'].indices.push(i)
 

--- a/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
+++ b/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
@@ -125,8 +125,8 @@ class GlyphRendererView extends Renderer.View
     if !selected or selected.length == 0
       selected = []
     else
-      if selected['0d'].glyph
-        selected = indices
+      if selected['0d'].indices.length > 0
+        selected = indices  # for lines and patches use all
       else if selected['1d'].indices.length > 0
         selected = selected['1d'].indices
       else if selected['2d'].indices.length > 0
@@ -138,8 +138,8 @@ class GlyphRendererView extends Renderer.View
     if !inspected or inspected.length == 0
       inspected = []
     else
-      if inspected['0d'].glyph
-        inspected = indices
+      if inspected['0d'].indices.length > 0
+        inspected = indices  # for lines and patches use all
       else if inspected['1d'].indices.length > 0
         inspected = inspected['1d'].indices
       else if inspected['2d'].indices.length > 0

--- a/bokehjs/src/coffee/models/tools/inspectors/hover_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/inspectors/hover_tool.coffee
@@ -80,7 +80,7 @@ class HoverToolView extends InspectTool.View
     tooltip.clear()
 
     [i1d, i2d] = [indices['1d'].indices, indices['2d'].indices]
-    if indices['0d'].glyph == null and i1d.length == 0 and i2d.length == 0
+    if indices['0d'].length == 0 and i1d.length == 0 and i2d.length == 0
       return
 
     vx = geometry.vx

--- a/bokehjs/src/coffee/util/util.coffee
+++ b/bokehjs/src/coffee/util/util.coffee
@@ -42,7 +42,7 @@ replace_placeholders = (string, data_source, i, special_vars={}) ->
 get_indices = (data_source) ->
   selected = data_source.get("selected")
 
-  if selected['0d'].glyph
+  if selected['0d'].indices.length > 0
     selected['0d'].indices
   else if selected['1d'].indices.length > 0
     selected['1d'].indices

--- a/examples/plotting/file/line_select.py
+++ b/examples/plotting/file/line_select.py
@@ -16,7 +16,7 @@ t = np.linspace(0, 0.1, 100)
 code = """
 d0 = cb_obj.get("selected")["0d"];
 if (d0.glyph) {
-    var color = d0.glyph.glyph_view.visuals.line.color.value();
+    var color = d0.get_view().visuals.line.line_color.value();
     var data = source.get('data');
     data['text'] = ['Selected the ' + color + ' line'];
     source.trigger('change');

--- a/examples/plotting/file/line_select.py
+++ b/examples/plotting/file/line_select.py
@@ -14,9 +14,9 @@ from bokeh.plotting import output_file, show, figure
 t = np.linspace(0, 0.1, 100)
 
 code = """
-d0 = cb_obj.get("selected")["0d"];
-if (d0.glyph) {
-    var color = d0.get_view().visuals.line.line_color.value();
+glyph_view = cb_obj.get("selected").get_view();
+if (glyph_view) {
+    var color = glyph_view.visuals.line.line_color.value();
     var data = source.get('data');
     data['text'] = ['Selected the ' + color + ' line'];
     source.trigger('change');


### PR DESCRIPTION
fixes #4069

This PR proposes a fix to #4069 by adding a `get_view()` function to the "event object" when a line is clicked or selected. By allowing the user to get a ref to the view via the event object, we avoid having to put a reference of the view on the model. Could not give the event object a direct reference to the view, because that results in a recursion error in `HasProps._value_record_references()`. Thus the workaround using a function.




