### PR TITLE
Fix box select for reversed ranges

### DIFF
--- a/bokehjs/src/coffee/common/hittest.coffee
+++ b/bokehjs/src/coffee/common/hittest.coffee
@@ -37,6 +37,12 @@ create_hit_test_result = ->
 
   return result
 
+validate_bbox_coords = ([x0, x1], [y0, y1]) ->
+  # rbush expects x0, y0 to be min, x1, y1 max
+  if x0 > x1 then [x0, x1] = [x1, x0]
+  if y0 > y1 then [y0, y1] = [y1, y0]
+  return [x0, y0, x1, y1]
+
 sqr = (x) -> x * x
 dist_2_pts = (vx, vy, wx, wy) -> sqr(vx - wx) + sqr(vy - wy)
 
@@ -88,3 +94,4 @@ module.exports =
   dist_2_pts: dist_2_pts
   dist_to_segment: dist_to_segment
   check_2_segments_intersect: check_2_segments_intersect
+  validate_bbox_coords: validate_bbox_coords

--- a/bokehjs/src/coffee/models/glyphs/annular_wedge.coffee
+++ b/bokehjs/src/coffee/models/glyphs/annular_wedge.coffee
@@ -74,7 +74,9 @@ class AnnularWedgeView extends Glyph.View
       [y0, y1] = @renderer.ymapper.v_map_from_target([vy0, vy1], true)
 
     candidates = []
-    for i in (pt[4].i for pt in @index.search([x0, y0, x1, y1]))
+
+    bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
+    for i in (pt[4].i for pt in @index.search(bbox))
       or2 = Math.pow(@souter_radius[i], 2)
       ir2 = Math.pow(@sinner_radius[i], 2)
       sx0 = @renderer.xmapper.map_to_target(x, true)

--- a/bokehjs/src/coffee/models/glyphs/annulus.coffee
+++ b/bokehjs/src/coffee/models/glyphs/annulus.coffee
@@ -69,7 +69,9 @@ class AnnulusView extends Glyph.View
     y1 = y + @max_radius
 
     hits = []
-    for i in (pt[4].i for pt in @index.search([x0, y0, x1, y1]))
+
+    bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
+    for i in (pt[4].i for pt in @index.search(bbox))
       or2 = Math.pow(@souter_radius[i], 2)
       ir2 = Math.pow(@sinner_radius[i], 2)
       sx0 = @renderer.xmapper.map_to_target(x)

--- a/bokehjs/src/coffee/models/glyphs/circle.coffee
+++ b/bokehjs/src/coffee/models/glyphs/circle.coffee
@@ -98,7 +98,8 @@ class CircleView extends Glyph.View
       [y0, y1] = @renderer.ymapper.v_map_from_target([vy0, vy1], true)
       [y0, y1] = [Math.min(y0, y1), Math.max(y0, y1)]
 
-    candidates = (pt[4].i for pt in @index.search([x0, y0, x1, y1]))
+    bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
+    candidates = (pt[4].i for pt in @index.search(bbox))
 
     hits = []
     if @_radius? and @model.properties.radius.units == "data"
@@ -160,7 +161,8 @@ class CircleView extends Glyph.View
           vy1 = vy + ms
           [y0, y1] = @renderer.ymapper.v_map_from_target([vy0, vy1], true)
 
-      hits = (xx[4].i for xx in @index.search([x0, y0, x1, y1]))
+      bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
+      hits = (xx[4].i for xx in @index.search(bbox))
 
       result['1d'].indices = hits
       return result

--- a/bokehjs/src/coffee/models/glyphs/circle.coffee
+++ b/bokehjs/src/coffee/models/glyphs/circle.coffee
@@ -54,11 +54,8 @@ class CircleView extends Glyph.View
       sy1 = vr.get('end') + @max_size
       [y0, y1] = @renderer.ymapper.v_map_from_target([sy0, sy1], true)
 
-    # rbush expects x0, y0 to be min, x1, y1 max
-    if x0 > x1 then [x0, x1] = [x1, x0]
-    if y0 > y1 then [y0, y1] = [y1, y0]
-
-    return (x[4].i for x in @index.search([x0, y0, x1, y1]))
+    bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
+    return (x[4].i for x in @index.search(bbox))
 
   _render: (ctx, indices, {sx, sy, sradius}) ->
 
@@ -171,8 +168,9 @@ class CircleView extends Glyph.View
   _hit_rect: (geometry) ->
     [x0, x1] = @renderer.xmapper.v_map_from_target([geometry.vx0, geometry.vx1], true)
     [y0, y1] = @renderer.ymapper.v_map_from_target([geometry.vy0, geometry.vy1], true)
+    bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
     result = hittest.create_hit_test_result()
-    result['1d'].indices = (x[4].i for x in @index.search([x0, y0, x1, y1]))
+    result['1d'].indices = (x[4].i for x in @index.search(bbox))
     return result
 
   _hit_poly: (geometry) ->

--- a/bokehjs/src/coffee/models/glyphs/patches.coffee
+++ b/bokehjs/src/coffee/models/glyphs/patches.coffee
@@ -69,7 +69,8 @@ class PatchesView extends Glyph.View
     yr = @renderer.plot_view.y_range
     [y0, y1] = [yr.get('min'), yr.get('max')]
 
-    return (x[4].i for x in @index.search([x0, y0, x1, y1]))
+    bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
+    return (x[4].i for x in @index.search(bbox))
 
   _render: (ctx, indices, {sxs, sys}) ->
     # @sxss and @syss are used by _hit_point and sxc, syc

--- a/bokehjs/src/coffee/models/glyphs/rect.coffee
+++ b/bokehjs/src/coffee/models/glyphs/rect.coffee
@@ -77,9 +77,9 @@ class RectView extends Glyph.View
   _hit_rect: (geometry) ->
     [x0, x1] = @renderer.xmapper.v_map_from_target([geometry.vx0, geometry.vx1], true)
     [y0, y1] = @renderer.ymapper.v_map_from_target([geometry.vy0, geometry.vy1], true)
-
+    bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
     result = hittest.create_hit_test_result()
-    result['1d'].indices = (x[4].i for x in @index.search([x0, y0, x1, y1]))
+    result['1d'].indices = (x[4].i for x in @index.search(bbox))
     return result
 
   _hit_point: (geometry) ->

--- a/bokehjs/src/coffee/models/glyphs/rect.coffee
+++ b/bokehjs/src/coffee/models/glyphs/rect.coffee
@@ -106,7 +106,9 @@ class RectView extends Glyph.View
       y1 = y + 2*@max_height
 
     hits = []
-    for i in (pt[4].i for pt in @index.search([x0, y0, x1, y1]))
+
+    bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
+    for i in (pt[4].i for pt in @index.search(bbox))
       sx = @renderer.plot_view.canvas.vx_to_sx(vx)
       sy = @renderer.plot_view.canvas.vy_to_sy(vy)
 

--- a/bokehjs/src/coffee/models/glyphs/wedge.coffee
+++ b/bokehjs/src/coffee/models/glyphs/wedge.coffee
@@ -58,7 +58,9 @@ class WedgeView extends Glyph.View
       [y0, y1] = @renderer.ymapper.v_map_from_target([vy0, vy1], true)
 
     candidates = []
-    for i in (pt[4].i for pt in @index.search([x0, y0, x1, y1]))
+
+    bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
+    for i in (pt[4].i for pt in @index.search(bbox))
       r2 = Math.pow(@sradius[i], 2)
       sx0 = @renderer.xmapper.map_to_target(x, true)
       sx1 = @renderer.xmapper.map_to_target(@_x[i], true)

--- a/bokehjs/src/coffee/models/markers/marker.coffee
+++ b/bokehjs/src/coffee/models/markers/marker.coffee
@@ -56,7 +56,8 @@ class MarkerView extends Glyph.View
     vy1 = vy + @max_size
     [y0, y1] = @renderer.ymapper.v_map_from_target([vy0, vy1], true)
 
-    candidates = (x[4].i for x in @index.search([x0, y0, x1, y1]))
+    bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
+    candidates = (x[4].i for x in @index.search(bbox))
 
     hits = []
     for i in candidates

--- a/bokehjs/src/coffee/models/markers/marker.coffee
+++ b/bokehjs/src/coffee/models/markers/marker.coffee
@@ -34,15 +34,14 @@ class MarkerView extends Glyph.View
     vx0 = hr.get('start') - @max_size
     vx1 = hr.get('end') + @max_size
     [x0, x1] = @renderer.xmapper.v_map_from_target([vx0, vx1], true)
-    [x0, x1] = [Math.min(x0, x1), Math.max(x0, x1)]
 
     vr = @renderer.plot_view.frame.get('v_range')
     vy0 = vr.get('start') - @max_size
     vy1 = vr.get('end') + @max_size
     [y0, y1] = @renderer.ymapper.v_map_from_target([vy0, vy1], true)
-    [y0, y1] = [Math.min(y0, y1), Math.max(y0, y1)]
 
-    return (x[4].i for x in @index.search([x0, y0, x1, y1]))
+    bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
+    return (x[4].i for x in @index.search(bbox))
 
   _hit_point: (geometry) ->
     [vx, vy] = [geometry.vx, geometry.vy]
@@ -75,9 +74,9 @@ class MarkerView extends Glyph.View
   _hit_rect: (geometry) ->
     [x0, x1] = @renderer.xmapper.v_map_from_target([geometry.vx0, geometry.vx1], true)
     [y0, y1] = @renderer.ymapper.v_map_from_target([geometry.vy0, geometry.vy1], true)
-
+    bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
     result = hittest.create_hit_test_result()
-    result['1d'].indices = (x[4].i for x in @index.search([x0, y0, x1, y1]))
+    result['1d'].indices = (x[4].i for x in @index.search(bbox))
     return result
 
   _hit_poly: (geometry) ->

--- a/bokehjs/test/test_common/index.coffee
+++ b/bokehjs/test/test_common/index.coffee
@@ -1,5 +1,6 @@
 require "./test_build_views"
 require "./test_defaults"
 require "./test_resizing"
+require "./test_selection_manager"
 require "./test_selector"
 require "./test_ui_events"

--- a/bokehjs/test/test_common/test_selection_manager.coffee
+++ b/bokehjs/test/test_common/test_selection_manager.coffee
@@ -1,0 +1,127 @@
+{expect} = require "chai"
+utils = require "../utils"
+
+SelectionManager = utils.require "common/selection_manager"
+
+SomeMarker = utils.require("models/markers/circle_x").Model
+GlyphRenderer = utils.require("models/renderers/glyph_renderer").Model
+GlyphRendererView = utils.require("models/renderers/glyph_renderer").View
+ColumnDataSource = utils.require("models/sources/column_data_source").Model
+LinearMapper = utils.require("models/mappers/linear_mapper").Model
+Range1d = utils.require("models/ranges/range1d").Model
+
+hittest = utils.require "common/hittest"
+empty_selection = hittest.create_hit_test_result()
+
+describe "SelectionManager", ->
+
+  source_normal = {start: 0, end: 10}
+  source_reverse = {start: 10, end: 0}
+  target = {start: 0, end: 100}
+
+  mapper_normal = new LinearMapper({
+    source_range: new Range1d(source_normal)
+    target_range: new Range1d(target)
+  })
+
+  mapper_reverse = new LinearMapper({
+    source_range: new Range1d(source_reverse)
+    target_range: new Range1d(target)
+  })
+
+  plot_view_stub_normal = {
+    frame:
+      get: (param) -> 
+        if param is 'x_mappers' or param is 'y_mappers'
+          {'default': mapper_normal}
+    canvas_view:
+      ctx: {'glcanvas': null}
+  }
+
+  plot_view_stub_reverse = {
+    frame:
+      get: (param) -> 
+        if param is 'x_mappers' or param is 'y_mappers'
+          {'default': mapper_reverse}
+    canvas_view:
+      ctx: {'glcanvas': null}
+  }
+
+  plot_model_stub = {
+    use_map: false
+    get: (param) -> 1 if param is 'lod_factor'
+  }
+
+  column_data_source = new ColumnDataSource({
+    data:
+      x: [0, 1, 2, 3, 4]
+      y: [0, 1, 2, 3, 4]
+  })
+
+  glyph_renderer = new GlyphRenderer({
+    data_source:  column_data_source
+    glyph:        new SomeMarker({x: {field: "x"}, y: {field: "y"}})
+  })
+
+  glyph_renderer_view_normal = new GlyphRendererView({
+    plot_model: plot_model_stub
+    plot_view: plot_view_stub_normal
+    model: glyph_renderer
+  })
+
+  glyph_renderer_view_reverse = new GlyphRendererView({
+    plot_model: plot_model_stub
+    plot_view: plot_view_stub_reverse
+    model: glyph_renderer
+  })
+
+  sm = new SelectionManager()
+
+  it "should have a reference to an empty selection", ->
+    expect(sm.empty).to.deep.equal empty_selection
+
+  it "should start with no selectors", ->
+    expect(sm.selectors).to.deep.equal {}
+
+  selector = null
+
+  it "should add a selector when encountering a new renderer", ->
+    utils.require("core/util/underscore").patch()
+    selector = sm._get_selector(glyph_renderer_view_normal)
+    expect(Object.keys(sm.selectors)).to.have.lengthOf(1)
+    expect(sm.selectors).to.have.property glyph_renderer_view_normal.model.id
+
+  it "should create a selector with an empty selection", ->
+    expect(selector.get('indices')).to.deep.equal empty_selection
+
+  it "should return the right selector", ->
+    selector2 = sm._get_selector(glyph_renderer_view_normal)
+    expect(Object.keys(sm.selectors)).to.have.lengthOf(1)
+    expect(selector2).to.equal(selector)
+
+  describe "using rect geometry (like that from box select tool)", ->
+
+    geometry = {
+      type: 'rect'
+      vx0: 0
+      vx1: 100
+      vy0: 0
+      vy1: 100
+    }
+
+    it "should update its data source's selected property", ->
+      sm = new SelectionManager({'source': column_data_source})
+      expect(sm.get('source').get('selected')).to.deep.equal empty_selection
+      sm.select('tool', glyph_renderer_view_normal, geometry, true)
+      expect(sm.get('source').get('selected')).to.not.deep.equal empty_selection
+
+    it "should update its selectors", ->
+      sm = new SelectionManager({'source': column_data_source})
+      sm.select('tool', glyph_renderer_view_normal, geometry, true)
+      expect(sm.selectors[glyph_renderer_view_normal.model.id]).to.not.deep.equal empty_selection
+
+    it "should work when mappers are reversed", ->
+      sm = new SelectionManager({'source': column_data_source})
+      sm.select('tool', glyph_renderer_view_reverse, geometry, true)
+      expect(sm.get('source').get('selected')).to.not.deep.equal empty_selection
+      expect(sm.selectors[glyph_renderer_view_reverse.model.id]).to.not.deep.equal empty_selection


### PR DESCRIPTION
This PR fixes the bug where the box select tool doesn't work if any of the ranges are reversed. 

I added a function ```validate_bbox_coords([x0, x1], [y0, y1])``` to the hittest module, which takes x and y coords and returns the correct bounding box coordinates for [rbush](https://github.com/mourner/rbush), making sure it's ```[minX, minY, maxX, maxY]```.

I also added some tests for the selection manager. The last test, ```it "should work when mappers are reversed"```, fails before the fix.  

- [x] issues: fixes #3996 
- [x] tests added / passed

~~- [ ] release document entry (if new feature or API change)~~