### PR TITLE
Fix function naming in embed.coffee

### DIFF
--- a/bokehjs/examples/anscombe/anscombe.ts
+++ b/bokehjs/examples/anscombe/anscombe.ts
@@ -73,5 +73,5 @@ namespace Anscombe {
     doc.add_root(grid);
 
     const div = document.getElementById("plot");
-    Bokeh.embed.add_document_static(div, doc);
+    Bokeh.embed.add_document_standalone(doc, div);
 }

--- a/bokehjs/src/coffee/api/typings/bokeh.d.ts
+++ b/bokehjs/src/coffee/api/typings/bokeh.d.ts
@@ -11,7 +11,7 @@ declare namespace Bokeh {
     function set_log_level(level: LogLevel): void;
 
     namespace embed {
-        export function add_document_static(element: HTMLElement, doc: Document, use_for_title?: boolean): void;
+        export function add_document_standalone(doc: Document, element: HTMLElement, use_for_title?: boolean): void;
     }
 
     namespace LinAlg {

--- a/bokehjs/src/coffee/embed.coffee
+++ b/bokehjs/src/coffee/embed.coffee
@@ -34,15 +34,7 @@ _create_view = (model) ->
   base.index[model.id] = view
   view
 
-# Replace element with a view of model_id from document
-add_model_static = (element, model_id, doc) ->
-  model = doc.get_model_by_id(model_id)
-  if not model?
-    throw new Error("Model #{model_id} was not in document #{doc}")
-  view = _create_view(model)
-  _.delay(-> $(element).replaceWith(view.$el))
-
-add_document_standalone = (document, element, use_for_title=false) ->
+_render_document_to_element = (element, document, use_for_title) ->
   # this is a LOCAL index of views used only by this
   # particular rendering call, so we can remove
   # the views we create.
@@ -74,9 +66,20 @@ add_document_standalone = (document, element, use_for_title=false) ->
 
   return views
 
+# Replace element with a view of model_id from document
+add_model_static = (element, model_id, doc) ->
+  model = doc.get_model_by_id(model_id)
+  if not model?
+    throw new Error("Model #{model_id} was not in document #{doc}")
+  view = _create_view(model)
+  _.delay(-> $(element).replaceWith(view.$el))
+
 # Fill element with the roots from doc
 add_document_static = (element, doc, use_for_title) ->
-  _.delay(-> add_document_standalone(doc, $(element), use_for_title))
+  _.delay(-> _render_document_to_element($(element), doc, use_for_title))
+
+add_document_standalone = (document, element, use_for_title=false) ->
+  return _render_document_to_element($(element), document, use_for_title)
 
 # map { websocket url to map { session id to promise of ClientSession } }
 _sessions = {}


### PR DESCRIPTION
This makes server work again. Why this wasn't caught earlier? Because server code in bokehjs catches all errors, even if they are unrelated to user input. Logging programming errors isn't the right approach. Wrong code should fail as soon as possible. This also raises a question if our testing framework could do a better job in such situation.