### PR TITLE
overlay annotations respond to backbone changes

### DIFF
--- a/bokehjs/src/coffee/models/annotations/box_annotation.coffee
+++ b/bokehjs/src/coffee/models/annotations/box_annotation.coffee
@@ -12,10 +12,14 @@ class BoxAnnotationView extends Renderer.View
     @$el.hide()
 
   bind_bokeh_events: () ->
+    # need to respond to either normal BB change events or silent
+    # "data only updates" that tools might want to use
     if @mget('render_mode') == 'css'
       # dispatch CSS update immediately
+      @listenTo(@model, 'change', @render)
       @listenTo(@model, 'data_update', @render)
     else
+      @listenTo(@model, 'change', @plot_view.request_render)
       @listenTo(@model, 'data_update', @plot_view.request_render)
 
   render: () ->
@@ -114,22 +118,12 @@ class BoxAnnotation extends Annotation.Model
       fill_alpha: 0.4
       line_color: '#cccccc'
       line_alpha: 0.3
-
-      # internal
-      silent_update: false
     }
 
-  nonserializable_attribute_names: () ->
-    super().concat(['silent_update'])
-
+  # The purpose of this function is so that overlays can update visually
+  # without triggering Backbone change events
   update:({left, right, top, bottom}) ->
-    if @get('silent_update')
-      @attributes['left'] = left
-      @attributes['right'] = right
-      @attributes['top'] = top
-      @attributes['bottom'] = bottom
-    else
-      @set({left: left, right: right, top: top, bottom: bottom})
+    @set({left: left, right: right, top: top, bottom: bottom}, {silent: true})
     @trigger('data_update')
 
 module.exports =

--- a/bokehjs/src/coffee/models/annotations/poly_annotation.coffee
+++ b/bokehjs/src/coffee/models/annotations/poly_annotation.coffee
@@ -7,6 +7,9 @@ p = require "../../core/properties"
 class PolyAnnotationView extends Renderer.View
 
   bind_bokeh_events: () ->
+    # need to respond to either normal BB change events or silent
+    # "data only updates" that tools might want to use
+    @listenTo(@model, 'change', @plot_view.request_render)
     @listenTo(@model, 'data_update', @plot_view.request_render)
 
   render: (ctx) ->
@@ -69,20 +72,12 @@ class PolyAnnotation extends Annotation.Model
       line_color: "#cccccc"
       line_alpha: 0.3
       line_alpha: 0.3
-
-      # internal
-      silent_update: false
     })
-
-  nonserializable_attribute_names: () ->
-    super().concat(['silent_update'])
-
+    
+  # The purpose of this function is so that overlays can update visually
+  # without triggering Backbone change events
   update:({xs, ys}) ->
-    if @get('silent_update')
-      @attributes['xs'] = xs
-      @attributes['ys'] = ys
-    else
-      @set({xs: xs, ys: ys})
+    @set({xs: xs, ys: ys}, {silent: true})
     @trigger('data_update')
 
 module.exports =

--- a/bokehjs/src/coffee/models/tools/gestures/box_select_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/gestures/box_select_tool.coffee
@@ -127,7 +127,6 @@ class BoxSelectTool extends SelectTool.Model
 
   initialize: (attrs, options) ->
     super(attrs, options)
-    @get('overlay').set('silent_update', true, {silent: true})
     @register_property('tooltip', () ->
         @_get_dim_tooltip(
           @get("tool_name"),

--- a/bokehjs/src/coffee/models/tools/gestures/box_zoom_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/gestures/box_zoom_tool.coffee
@@ -94,7 +94,6 @@ class BoxZoomTool extends GestureTool.Model
 
   initialize: (attrs, options) ->
     super(attrs, options)
-    @get('overlay').set('silent_update', true, {silent: true})
     @register_property('tooltip', () ->
         @_get_dim_tooltip(
           @get("tool_name"),

--- a/bokehjs/src/coffee/models/tools/gestures/lasso_select_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/gestures/lasso_select_tool.coffee
@@ -92,10 +92,6 @@ class LassoSelectTool extends SelectTool.Model
       overlay:                [ p.Instance, DEFAULT_POLY_OVERLAY ]
     }
 
-  initialize: (attrs, options) ->
-    super(attrs, options)
-    @get('overlay').set('silent_update', true, {silent: true})
-
 module.exports =
   Model: LassoSelectTool
   View: LassoSelectToolView

--- a/bokehjs/src/coffee/models/tools/gestures/poly_select_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/gestures/poly_select_tool.coffee
@@ -88,10 +88,6 @@ class PolySelectTool extends SelectTool.Model
       overlay: [ p.Instance, DEFAULT_POLY_OVERLAY ]
     }
 
-  initialize: (attrs, options) ->
-    super(attrs, options)
-    @get('overlay').set('silent_update', true, {silent: true})
-
 module.exports =
   Model: PolySelectTool
   View: PolySelectToolView


### PR DESCRIPTION
issues: fixes #3992

Noticed that `PolyAnnotation` almosts had the same issue. Also realized that the `update` functions only purpose was to be for silent updates (normal updates that trigger `change` can just use standard `.set`) so removed that internal property and simplified associated logic)