### PR TITLE
Add per-app static file handling

### DIFF
--- a/bokeh/application/application.py
+++ b/bokeh/application/application.py
@@ -131,9 +131,21 @@ class Application(object):
         '''
         self._handlers.append(handler)
 
+        static_paths = set(h.static_path() for h in self.handlers)
+        static_paths.discard(None)
+        if len(static_paths) > 1:
+            raise RuntimeError("More than one static path requested for app: %r" % list(static_paths))
+
     @property
     def handlers(self):
         return tuple(self._handlers)
+
+    @property
+    def static_path(self):
+        # guaranteed to be at most one
+        for h in self.handlers:
+            if h.static_path() is not None: return h.static_path()
+        return None
 
     def on_server_loaded(self, server_context):
         """ Invoked after server startup but before any sessions are created."""

--- a/bokeh/application/handlers/directory.py
+++ b/bokeh/application/handlers/directory.py
@@ -49,12 +49,23 @@ class DirectoryHandler(Handler):
             from bokeh.themes import Theme
             self._theme = Theme(filename=themeyaml)
 
+        self._static = None
+        appstatic = join(src_path, 'static')
+        if exists(appstatic):
+            self._static = appstatic
+
     def url_path(self):
         if self.failed:
             return None
         else:
             # TODO should fix invalid URL characters
             return '/' + basename(self._path)
+
+    def static_path(self):
+        if self.failed:
+            return None
+        else:
+            return self._static
 
     def modify_document(self, doc):
         if self.failed:

--- a/bokeh/application/handlers/directory.py
+++ b/bokeh/application/handlers/directory.py
@@ -49,7 +49,6 @@ class DirectoryHandler(Handler):
             from bokeh.themes import Theme
             self._theme = Theme(filename=themeyaml)
 
-        self._static = None
         appstatic = join(src_path, 'static')
         if exists(appstatic):
             self._static = appstatic

--- a/bokeh/application/handlers/directory.py
+++ b/bokeh/application/handlers/directory.py
@@ -61,12 +61,6 @@ class DirectoryHandler(Handler):
             # TODO should fix invalid URL characters
             return '/' + basename(self._path)
 
-    def static_path(self):
-        if self.failed:
-            return None
-        else:
-            return self._static
-
     def modify_document(self, doc):
         if self.failed:
             return

--- a/bokeh/application/handlers/handler.py
+++ b/bokeh/application/handlers/handler.py
@@ -12,6 +12,10 @@ class Handler(object):
         """Returns a default URL path if the spelling specified one."""
         return None
 
+    def static_path(self):
+        """Returns a path to app-specific static resources, if applicaple."""
+        return None
+
     def modify_document(self, doc):
         """Modifies the application document however the spelling specifies."""
         pass

--- a/bokeh/application/handlers/handler.py
+++ b/bokeh/application/handlers/handler.py
@@ -13,7 +13,7 @@ class Handler(object):
         return None
 
     def static_path(self):
-        """Returns a path to app-specific static resources, if applicaple."""
+        """Returns a path to app-specific static resources, if applicable."""
         return None
 
     def modify_document(self, doc):

--- a/bokeh/application/handlers/handler.py
+++ b/bokeh/application/handlers/handler.py
@@ -7,6 +7,7 @@ class Handler(object):
         self._failed = False
         self._error = None
         self._error_detail = None
+        self._static = None
 
     def url_path(self):
         """Returns a default URL path if the spelling specified one."""
@@ -14,7 +15,10 @@ class Handler(object):
 
     def static_path(self):
         """Returns a path to app-specific static resources, if applicable."""
-        return None
+        if self.failed:
+            return None
+        else:
+            return self._static
 
     def modify_document(self, doc):
         """Modifies the application document however the spelling specifies."""

--- a/bokeh/application/handlers/tests/test_directory.py
+++ b/bokeh/application/handlers/tests/test_directory.py
@@ -4,6 +4,7 @@ import unittest
 
 import tempfile
 import shutil
+import os
 import os.path
 
 from bokeh.application.handlers import DirectoryHandler
@@ -22,7 +23,11 @@ class TmpDir(object):
 def _with_directory_contents(contents, func):
     with (TmpDir(prefix="bokeh-directory-handler-test")) as dirname:
         for filename, file_content in contents.items():
-            f = open(os.path.join(dirname, filename), 'w')
+            filepath = os.path.join(dirname, filename)
+            filedir = os.path.dirname(filepath)
+            if not os.path.exists(filedir):
+                os.makedirs(filedir)
+            f = open(filepath, 'w')
             f.write(file_content)
             f.flush()
         func(dirname)
@@ -148,7 +153,48 @@ some.foo = 57
         assert len(doc.roots) == 2
 
         handler = result['handler']
+
         assert "on_server_loaded" == handler.on_server_loaded(None)
         assert "on_server_unloaded" == handler.on_server_unloaded(None)
         assert "on_session_created" == handler.on_session_created(None)
         assert "on_session_destroyed" == handler.on_session_destroyed(None)
+
+    def test_directory_with_static(self):
+        doc = Document()
+        result = {}
+        def load(filename):
+            handler = DirectoryHandler(filename=filename)
+            result['handler'] = handler
+            handler.modify_document(doc)
+            if handler.failed:
+                raise RuntimeError(handler.error)
+
+        _with_directory_contents({
+            'main.py' : "# This script does nothing",
+            'static/js/foo.js' : "# some JS"
+        }, load)
+
+        assert not doc.roots
+
+        handler = result['handler']
+        assert handler.static_path() is not None
+        assert handler.static_path().endswith("static")
+
+    def test_directory_without_static(self):
+        doc = Document()
+        result = {}
+        def load(filename):
+            handler = DirectoryHandler(filename=filename)
+            result['handler'] = handler
+            handler.modify_document(doc)
+            if handler.failed:
+                raise RuntimeError(handler.error)
+
+        _with_directory_contents({
+            'main.py' : "# This script does nothing",
+        }, load)
+
+        assert not doc.roots
+
+        handler = result['handler']
+        assert handler.static_path() is None

--- a/bokeh/application/tests/test_application.py
+++ b/bokeh/application/tests/test_application.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function
 
-import unittest
+import pytest
 
 from bokeh.application.handlers import FunctionHandler
 from bokeh.application import Application
@@ -14,33 +14,74 @@ class SomeModelInTestApplication(Model):
     foo = Int(2)
     child = Instance(Model)
 
-class TestApplication(unittest.TestCase):
 
-    def test_empty(self):
-        a = Application()
-        doc = a.create_document()
-        assert not doc.roots
+def test_empty():
+    a = Application()
+    doc = a.create_document()
+    assert not doc.roots
 
-    def test_one_handler(self):
-        a = Application()
-        def add_roots(doc):
-            doc.add_root(AnotherModelInTestApplication())
-            doc.add_root(SomeModelInTestApplication())
-        handler = FunctionHandler(add_roots)
-        a.add(handler)
-        doc = a.create_document()
-        assert len(doc.roots) == 2
+def test_one_handler():
+    a = Application()
+    def add_roots(doc):
+        doc.add_root(AnotherModelInTestApplication())
+        doc.add_root(SomeModelInTestApplication())
+    handler = FunctionHandler(add_roots)
+    a.add(handler)
+    doc = a.create_document()
+    assert len(doc.roots) == 2
 
-    def test_two_handlers(self):
-        a = Application()
-        def add_roots(doc):
-            doc.add_root(AnotherModelInTestApplication())
-            doc.add_root(SomeModelInTestApplication())
-        def add_one_root(doc):
-            doc.add_root(AnotherModelInTestApplication())
-        handler = FunctionHandler(add_roots)
-        a.add(handler)
-        handler2 = FunctionHandler(add_one_root)
+def test_two_handlers():
+    a = Application()
+    def add_roots(doc):
+        doc.add_root(AnotherModelInTestApplication())
+        doc.add_root(SomeModelInTestApplication())
+    def add_one_root(doc):
+        doc.add_root(AnotherModelInTestApplication())
+    handler = FunctionHandler(add_roots)
+    a.add(handler)
+    handler2 = FunctionHandler(add_one_root)
+    a.add(handler2)
+    doc = a.create_document()
+    assert len(doc.roots) == 3
+
+def test_no_static_path():
+    a = Application()
+    def add_roots(doc):
+        doc.add_root(AnotherModelInTestApplication())
+        doc.add_root(SomeModelInTestApplication())
+    def add_one_root(doc):
+        doc.add_root(AnotherModelInTestApplication())
+    handler = FunctionHandler(add_roots)
+    a.add(handler)
+    handler2 = FunctionHandler(add_one_root)
+    a.add(handler2)
+    assert a.static_path == None
+
+def test_static_path():
+    a = Application()
+    def add_roots(doc):
+        doc.add_root(AnotherModelInTestApplication())
+        doc.add_root(SomeModelInTestApplication())
+    def add_one_root(doc):
+        doc.add_root(AnotherModelInTestApplication())
+    handler = FunctionHandler(add_roots)
+    handler._static = "foo"
+    a.add(handler)
+    handler2 = FunctionHandler(add_one_root)
+    a.add(handler2)
+    assert a.static_path == "foo"
+
+def test_excess_static_path():
+    a = Application()
+    def add_roots(doc):
+        doc.add_root(AnotherModelInTestApplication())
+        doc.add_root(SomeModelInTestApplication())
+    def add_one_root(doc):
+        doc.add_root(AnotherModelInTestApplication())
+    handler = FunctionHandler(add_roots)
+    handler._static = "foo"
+    a.add(handler)
+    handler2 = FunctionHandler(add_one_root)
+    handler2._static = "bar"
+    with pytest.raises(RuntimeError):
         a.add(handler2)
-        doc = a.create_document()
-        assert len(doc.roots) == 3

--- a/bokeh/command/bootstrap.py
+++ b/bokeh/command/bootstrap.py
@@ -42,4 +42,4 @@ def main(argv):
     try:
         args.invoke(args)
     except Exception as e:
-        die(str(e))
+        die("ERROR:" + str(e))

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -190,19 +190,14 @@ class BokehTornado(TornadoApplication):
 
             all_patterns.extend(app_patterns)
 
-            # add a per-app static path if requested by any app handler
-            # (there should be at most one that requests a static path)
-            static_paths = set(h.static_path() for h in app.handlers)
-            static_paths.discard(None)
-            if len(static_paths) > 1:
-                raise RuntimeError("More than one static path requested for app %r: %r" % (key, list(static_paths)))
-            if static_paths:
+            # add a per-app static path if requested by the application
+            if app.static_path is not None:
                 if key == "/":
                     route = "/static/(.*)"
                 else:
                     route = key + "/static/(.*)"
                 route = self._prefix + route
-                all_patterns.append((route, StaticFileHandler, { "path" : static_paths.pop() }))
+                all_patterns.append((route, StaticFileHandler, { "path" : app.static_path }))
 
         for p in extra_patterns + toplevel_patterns:
             prefixed_pat = (self._prefix+p[0],) + p[1:]

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -10,12 +10,14 @@ import atexit
 # NOTE: needs PyPI backport on Python 2 (https://pypi.python.org/pypi/futures)
 from concurrent.futures import ProcessPoolExecutor
 import os
+from pprint import pformat
 import signal
 
 from tornado import gen
 from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado.web import Application as TornadoApplication
 from tornado.web import HTTPError
+from tornado.web import StaticFileHandler
 
 from bokeh.resources import Resources
 from bokeh.settings import settings
@@ -167,7 +169,7 @@ class BokehTornado(TornadoApplication):
 
         extra_patterns = extra_patterns or []
         all_patterns = []
-        for key in applications:
+        for key, app in applications.items():
             app_patterns = []
             for p in per_app_patterns:
                 if key == "/":
@@ -188,6 +190,20 @@ class BokehTornado(TornadoApplication):
 
             all_patterns.extend(app_patterns)
 
+            # add a per-app static path if requested by any app handler
+            # (there should be at most one that requests a static path)
+            static_paths = set(h.static_path() for h in app.handlers)
+            static_paths.discard(None)
+            if len(static_paths) > 1:
+                raise RuntimeError("More than one static path requested for app %r: %r" % (key, list(static_paths)))
+            if static_paths:
+                if key == "/":
+                    route = "/static/(.*)"
+                else:
+                    route = key + "/static/(.*)"
+                route = self._prefix + route
+                all_patterns.append((route, StaticFileHandler, { "path" : static_paths.pop() }))
+
         for p in extra_patterns + toplevel_patterns:
             prefixed_pat = (self._prefix+p[0],) + p[1:]
             all_patterns.append(prefixed_pat)
@@ -195,7 +211,9 @@ class BokehTornado(TornadoApplication):
         for pat in all_patterns:
             _whitelist(pat[1])
 
-        log.debug("Patterns are: %r", all_patterns)
+        log.debug("Patterns are:")
+        for line in pformat(all_patterns, width=60).split("\n"):
+            log.debug("  " + line)
 
         super(BokehTornado, self).__init__(all_patterns)
 

--- a/bokeh/server/views/static_handler.py
+++ b/bokeh/server/views/static_handler.py
@@ -11,7 +11,8 @@ from tornado.web import StaticFileHandler
 from bokeh.settings import settings
 
 class StaticHandler(StaticFileHandler):
-    ''' Implements a custom Tornado static file handler
+    ''' Implements a custom Tornado static file handler for BokehJS
+    JavaScript and CSS resources.
 
     '''
     def __init__(self, tornado_app, *args, **kw):

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -97,7 +97,7 @@ Another possibility is to have a single centrally created app (perhaps by an
 organization), that can access data or other artifacts published by many
 different people (possibly with access controls). This sort of scenario *is*
 possible with the Bokeh server, but often involves integrating a Bokeh
-server with other web application frameworks. See a complete example at 
+server with other web application frameworks. See a complete example at
 https://github.com/bokeh/bokeh-demos/tree/master/happiness
 
 
@@ -360,41 +360,62 @@ The full set of files that Bokeh server knows about is:
        +---main.py
        +---server_lifecycle.py
        +---theme.yaml
+       +---static
+
+The optional components are
+
+* A ``server_lifecycle.py`` file that allows optional callbacks to be triggered at different stages of application creation, as descriped in :ref:`userguide_server_applications_lifecycle`.
+
+* A ``theme.yaml`` file that declaratively defines default attributes to be applied to Bokeh model types.
+
+* a ``static`` subdirectory that can be used to serve static resources associated with this application.
 
 When executing your ``main.py`` Bokeh server ensures that the standard
 ``__file__`` module attribute works as you would expect. So it is possible
 to include data files or custom user defined models in your directory
-however you like. An example might be:
+however you like. Additionally, the application directory is also added
+to ``sys.path`` so that python modules in the application directory may
+be easily imported.
+
+An example might be:
 
 .. code-block:: none
 
     myapp
        |
        +---data
-       |      +---things.csv
+       |    +---things.csv
        |
+       +---helpers.py
        +---main.py
        |---models
-       |      +---custom.js
+       |    +---custom.js
        |
        +---server_lifecycle.py
        +---theme.yaml
+       +---static
+            +---css
+            |    +---special.css
+            |
+            +---images
+            |    +---foo.png
+            |    +---bar.png
+            |
+            +---js
+                 +---special.js
 
 In this case you might have code similar to:
 
 .. code-block:: python
 
     from os.path import dirname, join
-    import pandas
+    from helpers import load_data
 
-    pandas.read_csv(join(dirname(__file__), 'data', 'things.csv')
+    load_data(join(dirname(__file__), 'data', 'things.csv')
 
 And similar code to load the JavaScript implementation for a custom model
-from ``custom.js``
+from ``models/custom.js``
 
-.. note::
-    Currently only absolute imports are supported in ``main.py``. We hope to
-    lift this limitation in future releases.
 
 .. _userguide_server_applications_callbacks:
 
@@ -518,7 +539,7 @@ Next, issue the following command on the **local machine** to establish an ssh t
 .. code-block:: sh
 
     ssh -NfL localhost:5006:localhost:5006  user@remote.host
-    
+
 Replace *user* with your username on the remote host and *remote.host* with the hostname/IP address of the system hosting the Bokeh server. You may be prompted for login credentials for the remote system. After the connection is set up you will be able to navigate to ``localhost:5006`` as though the Bokeh server were running on the local machine.
 
 The second, slightly more complicated case occurs when there is a gateway between the server and the local machine.  In that situation a reverse tunnel must be estabished from the server to the gateway. Additionally the tunnel from the local machine will also point to the gateway.
@@ -529,7 +550,7 @@ Issue the following commands on the **remote host** where the Bokeh server will 
 
     nohup bokeh server &
     ssh -NfR 5006:localhost:5006 user@gateway.host
-    
+
 Replace *user* with your username on the gateway and *gateway.host* with the hostname/IP address of the gateway. You may be prompted for login credentials for the gateway.
 
 Now set up the other half of the tunnel, from the local machine to the gateway. On the **local machine**:
@@ -537,7 +558,7 @@ Now set up the other half of the tunnel, from the local machine to the gateway. 
 .. code-block:: sh
 
     ssh -NfL localhost:5006:localhost:5006 user@gateway.host
-    
+
 Again, replace *user* with your username on the gateway and *gateway.host* with the hostname/IP address of the gateway. You should now be able to access the Bokeh server from the local machine by navigating to ``localhost:5006`` on the local machine, as if the Bokeh server were running on the local machine. You can even set up client connections from a Jupyter notebook running on the local machine.
 
 .. note::


### PR DESCRIPTION
- [x] issues: fixes #4150
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

This PR causes an `app/static` route to be added whenever a directory format app has a `static` subdirectory. It also improves the startup logging output to make the available routes more legible:
```
DEBUG:bokeh.server.tornado:Patterns are:
DEBUG:bokeh.server.tornado:  [ ( '/movies/?',
DEBUG:bokeh.server.tornado:      <class 'bokeh.server.views.doc_handler.DocHandler'>,
DEBUG:bokeh.server.tornado:      { 'application_context': <bokeh.server.application_context.ApplicationContext object at 0x107be5128>,
DEBUG:bokeh.server.tornado:        'bokeh_websocket_path': '/movies/ws'}),
DEBUG:bokeh.server.tornado:    ( '/movies/ws',
DEBUG:bokeh.server.tornado:      <class 'bokeh.server.views.ws.WSHandler'>,
DEBUG:bokeh.server.tornado:      { 'application_context': <bokeh.server.application_context.ApplicationContext object at 0x107be5128>,
DEBUG:bokeh.server.tornado:        'bokeh_websocket_path': '/movies/ws'}),
DEBUG:bokeh.server.tornado:    ( '/movies/autoload.js',
DEBUG:bokeh.server.tornado:      <class 'bokeh.server.views.autoload_js_handler.AutoloadJsHandler'>,
DEBUG:bokeh.server.tornado:      { 'application_context': <bokeh.server.application_context.ApplicationContext object at 0x107be5128>,
DEBUG:bokeh.server.tornado:        'bokeh_websocket_path': '/movies/ws'}),
DEBUG:bokeh.server.tornado:    ( '/movies/static/(.*)',
DEBUG:bokeh.server.tornado:      <class 'tornado.web.StaticFileHandler'>,
DEBUG:bokeh.server.tornado:      {'path': '/Users/bryan/work/bokeh/examples/app/movies/static'}),
DEBUG:bokeh.server.tornado:    ('/static/(.*)', <class 'bokeh.server.views.static_handler.StaticHandler'>)]
```

