### PR TITLE
Add linked plotting example to bokehjs

### DIFF
--- a/bokehjs/examples/linked/.gitignore
+++ b/bokehjs/examples/linked/.gitignore
@@ -1,0 +1,1 @@
+linked.js

--- a/bokehjs/examples/linked/linked.html
+++ b/bokehjs/examples/linked/linked.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Linked Brushing &amp; Panning</title>
+    <link rel="stylesheet" href="../../build/css/bokeh.css" type="text/css" />
+    <script type="text/javascript" src="../../build/js/bokeh.js"></script>
+  </head>
+  <body>
+    <script type="text/javascript" src="linked.js"></script>
+  </body>
+</html>

--- a/bokehjs/examples/linked/linked.ts
+++ b/bokehjs/examples/linked/linked.ts
@@ -1,0 +1,30 @@
+namespace LinkedBrushingAndPanning {
+    import plt = Bokeh.Plotting;
+    import linspace = Bokeh.LinAlg.linspace;
+
+    Bokeh.set_log_level("info");
+    Bokeh.logger.info(`Bokeh ${Bokeh.version}`);
+
+    const N = 100
+    const x = linspace(0, 4*Math.PI, N)
+    const y1 = x.map((xi) => Math.sin(xi))
+    const y2 = x.map((xi) => Math.cos(xi))
+    const y3 = x.map((xi) => Math.sin(xi) + Math.cos(xi))
+
+    const source = new Bokeh.ColumnDataSource()
+    const tools = "pan,box_select"
+
+    // linked brushing is expressed by sharing data sources between renderers
+    const s1 = plt.figure({width: 350, height: 350, tools: tools})
+    s1.circle(x, y1, {source: source, color: "navy", size: 8, alpha: 0.5})
+
+    // linked panning is expressed by sharing ranges between plots
+    const s2 = plt.figure({width: 350, height: 350, tools: tools, x_range: s1.x_range, y_range: s1.y_range})
+    s2.circle(x, y2, {source: source, color: "firebrick", size: 8, alpha: 0.5})
+
+    // it is possible to share just one range or the other
+    const s3 = plt.figure({width: 350, height: 350, tools: tools, x_range: s1.x_range})
+    s3.circle(x, y3, {source: source, color: "olive", size: 8, alpha: 0.5})
+
+    plt.show(Bokeh.GridPlot([[s1, s2, s3]]))
+}

--- a/bokehjs/examples/linked/tsconfig.json
+++ b/bokehjs/examples/linked/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "noImplicitAny": true,
+    "noEmitOnError": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "ES5"
+  },
+  "files": [
+    "../../src/coffee/api/typings.d.ts",
+    "linked.ts"
+  ]
+}

--- a/bokehjs/gulp/tasks/examples.coffee
+++ b/bokehjs/gulp/tasks/examples.coffee
@@ -12,7 +12,7 @@ compile = (name) ->
          .js
          .pipe(gulp.dest("./"))
 
-examples = ["anscombe", "burtin", "hover", "legends", "tap", "stocks"]
+examples = ["anscombe", "burtin", "hover", "legends", "linked", "tap", "stocks"]
 
 for example in examples
   do (example) ->

--- a/bokehjs/src/coffee/api/plotting.coffee
+++ b/bokehjs/src/coffee/api/plotting.coffee
@@ -75,6 +75,20 @@ class Figure extends models.Plot
     delete attrs.x_axis_label
     delete attrs.y_axis_label
 
+    if not _.isUndefined(attrs.width)
+      if _.isUndefined(attrs.plot_width)
+        attrs.plot_width = attrs.width
+      else
+        throw new Error("both 'width' and 'plot_width' can't be given at the same time")
+      delete attrs.width
+
+    if not _.isUndefined(attrs.height)
+      if _.isUndefined(attrs.plot_height)
+        attrs.plot_height = attrs.height
+      else
+        throw new Error("both 'height' and 'plot_height' can't be given at the same time")
+      delete attrs.height
+
     super(attrs, options)
 
     @_process_guides(0, x_axis_type, x_axis_location, x_minor_ticks, x_axis_label)

--- a/bokehjs/src/coffee/api/plotting.coffee
+++ b/bokehjs/src/coffee/api/plotting.coffee
@@ -314,7 +314,7 @@ class Figure extends models.Plot
     if axis_type == "auto"
       if range instanceof models.FactorRange
         return models.CategoricalAxis
-      if range instanceof models.Range1d
+      else
         # TODO: return models.DatetimeAxis (Date type)
         return models.LinearAxis
 

--- a/bokehjs/src/coffee/api/typings/models/plots.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/plots.d.ts
@@ -87,7 +87,10 @@ declare namespace Bokeh {
         responsive?: boolean;
     }
 
-    export var GridPlot: { new(attributes?: IGridPlot, options?: ModelOpts): GridPlot };
+    export var GridPlot: {
+        new(attributes?: IGridPlot, options?: ModelOpts): GridPlot;
+        (children: Array<Array<Plot>>): GridPlot;
+    };
     export interface GridPlot extends Component, IGridPlot {}
     export interface IGridPlot extends IComponent {
         children?: Array<Array<Plot>>;

--- a/bokehjs/src/coffee/api/typings/plotting.d.ts
+++ b/bokehjs/src/coffee/api/typings/plotting.d.ts
@@ -45,6 +45,9 @@ declare namespace Bokeh.Plotting {
 
         x_axis_label?: string;
         y_axis_label?: string;
+
+        width?: Int;
+        height?: Int;
     }
     export interface Figure extends Plot {
         xgrid: Grid;

--- a/bokehjs/src/coffee/models/layouts/grid_plot.coffee
+++ b/bokehjs/src/coffee/models/layouts/grid_plot.coffee
@@ -309,6 +309,14 @@ class GridPlot extends Component.Model
   type: 'GridPlot'
   default_view: GridPlotView
 
+  constructor: () ->
+    # new GridPlot({children: [...]}) or GridPlot([...])
+    if this instanceof GridPlot
+      return super(arguments...)
+    else
+      [children] = arguments
+      return new GridPlot({children: children})
+
   initialize: (attrs, options) ->
     super(attrs, options)
     @define_computed_property('tool_manager', () ->


### PR DESCRIPTION
- [x] create an example based on `linked_brushing.py` and `linked_panning.py`
- [x] make axes and grids appear for data ranges
- [x] add `GridPlot(children)` syntax (on top of `new GridPlot({children: children})`)
- [x] allow to reuse the same data source; create unique indexed field names to avoid conflicts

fixes #4159