### PR TITLE
Enable xul browser to show plots standalone (not in browser)

### DIFF
--- a/bokeh/util/browser.py
+++ b/bokeh/util/browser.py
@@ -5,6 +5,9 @@ import webbrowser
 
 from ..settings import settings
 
+# todo: need this locally
+ICON = 'http://bokeh.pydata.org/en/latest/_static/images/favicon.ico'
+
 def get_browser_controller(browser=None):
     browser = settings.browser(browser)
 
@@ -15,12 +18,20 @@ def get_browser_controller(browser=None):
                     pass
 
             controller = DummyWebBrowser()
+        elif browser.lower() in ('xul', ):
+            from flexx.webruntime import launch
+            class XulWebBrowser(object):
+                def open(self, url, new=0, autoraise=True):
+                    self.c = launch(url,  browser, title='Bokeh plot', icon=ICON)
+
+            controller = XulWebBrowser()
         else:
             controller = webbrowser.get(browser)
     else:
         controller = webbrowser
 
     return controller
+
 
 def view(location, browser=None, new="same", autoraise=True):
         ''' Opens a browser to view the specified location.

--- a/examples/plotting/file/les_mis.py
+++ b/examples/plotting/file/les_mis.py
@@ -64,4 +64,4 @@ p.select_one(HoverTool).tooltips = [
 
 output_file("les_mis.html", title="les_mis.py example")
 
-show(p) # show the plot
+show(p, 'xul') # show the plot


### PR DESCRIPTION
issues: would close #3885 

This is a quick demonstration of what I mean in point 2 of #3885. You can show a plot using `show(p, 'xul')` or `view(.., 'xul')`, and it will end up in a native looking window with a Bokeh icon in the task bar. To test, run the `plotting/file/les_mis.py` example. You need flexx installed (`conda install -b bokeh flexx`).

@bryevdv if you're still -1 on this, we can just close it. It was simple enough to demo it quickly so that I'm sure you know what I mean :)