### PR TITLE
added support for GeoJSON GeometryCollection

### DIFF
--- a/bokehjs/src/coffee/models/sources/geojson_data_source.coffee
+++ b/bokehjs/src/coffee/models/sources/geojson_data_source.coffee
@@ -70,7 +70,7 @@ class GeoJSONDataSource extends ColumnDataSource.Model
         logger.warn('MultiPoint not supported in Bokeh')
 
       when "MultiLineString"
-        flattened_coord_list = _.reduce(geometry.coordinates, @flatten_function)
+        flattened_coord_list = _.reduce(geometry.coordinates, @_flatten_function)
         for coords, j in flattened_coord_list
           data.xs[i][j] = coords[0]
           data.ys[i][j] = coords[1]
@@ -82,7 +82,8 @@ class GeoJSONDataSource extends ColumnDataSource.Model
           if polygon.length > 1
             logger.warn('Bokeh does not support Polygons with holes in, only exterior ring used.')
           exterior_rings.push(polygon[0])
-        flattened_coord_list = _.reduce(exterior_rings, @flatten_function)
+
+        flattened_coord_list = _.reduce(exterior_rings, @_flatten_function)
         for coords, j in flattened_coord_list
           data.xs[i][j] = coords[0]
           data.ys[i][j] = coords[1]

--- a/bokehjs/src/coffee/models/sources/geojson_data_source.coffee
+++ b/bokehjs/src/coffee/models/sources/geojson_data_source.coffee
@@ -150,7 +150,7 @@ class GeoJSONDataSource extends ColumnDataSource.Model
         if item.type == 'Feature'
           @_add_properties(item, data, arr_index, item_count)
 
-      arr_index += 1
+        arr_index += 1
 
     return data
 

--- a/bokehjs/src/coffee/models/sources/geojson_data_source.coffee
+++ b/bokehjs/src/coffee/models/sources/geojson_data_source.coffee
@@ -31,6 +31,77 @@ class GeoJSONDataSource extends ColumnDataSource.Model
     nan_array = _.map(array, (x) -> NaN)
     return nan_array
 
+  _flatten_function: (accumulator, currentItem) ->
+      return accumulator.concat([[NaN, NaN, NaN]]).concat(currentItem)
+
+  _add_properties: (item, data, i, item_count) ->
+    for property of item.properties
+      if !data.hasOwnProperty(property)
+        data[property] = @_get_new_nan_array(item_count)
+      data[property][i] = item.properties[property]
+
+  _add_geometry: (geometry, data, i) ->
+
+    switch geometry.type
+
+      when "Point"
+        coords = geometry.coordinates
+        data.x[i] = coords[0]
+        data.y[i] = coords[1]
+        data.z[i] = coords[2] ? NaN
+
+      when "LineString"
+        coord_list = geometry.coordinates
+        for coords, j in coord_list
+          data.xs[i][j] = coords[0]
+          data.ys[i][j] = coords[1]
+          data.zs[i][j] = coords[2] ? NaN
+
+      when "Polygon"
+        if geometry.coordinates.length > 1
+          logger.warn('Bokeh does not support Polygons with holes in, only exterior ring used.')
+        exterior_ring = geometry.coordinates[0]
+        for coords, j in exterior_ring
+          data.xs[i][j] = coords[0]
+          data.ys[i][j] = coords[1]
+          data.zs[i][j] = coords[2] ? NaN
+
+      when "MultiPoint"
+        logger.warn('MultiPoint not supported in Bokeh')
+
+      when "MultiLineString"
+        flattened_coord_list = _.reduce(geometry.coordinates, @flatten_function)
+        for coords, j in flattened_coord_list
+          data.xs[i][j] = coords[0]
+          data.ys[i][j] = coords[1]
+          data.zs[i][j] = coords[2] ? NaN
+
+      when "MultiPolygon"
+        exterior_rings = []
+        for polygon in geometry.coordinates
+          if polygon.length > 1
+            logger.warn('Bokeh does not support Polygons with holes in, only exterior ring used.')
+          exterior_rings.push(polygon[0])
+        flattened_coord_list = _.reduce(exterior_rings, @flatten_function)
+        for coords, j in flattened_coord_list
+          data.xs[i][j] = coords[0]
+          data.ys[i][j] = coords[1]
+          data.zs[i][j] = coords[2] ? NaN
+
+      else
+        throw new Error('Invalid type ' + geometry.type)
+
+  _get_items_length: (items) ->
+    count = 0
+    for item, i in items
+      geometry = if item.type == 'Feature' then item.geometry else item
+      if geometry.type == 'GeometryCollection'
+        for g, j in geometry.geometries
+          count += 1
+      else
+	      count += 1
+    return count
+
   geojson_to_column_data: () ->
     geojson = JSON.parse(@get('geojson'))
 
@@ -51,84 +122,34 @@ class GeoJSONDataSource extends ColumnDataSource.Model
         throw new Error('geojson.features must have one or more items')
       items = geojson.features
 
+    item_count = @_get_items_length(items)
+
     data = {
-      'x': @_get_new_nan_array(items.length),
-      'y': @_get_new_nan_array(items.length),
-      'z': @_get_new_nan_array(items.length),
-      'xs': @_get_new_list_array(items.length),
-      'ys': @_get_new_list_array(items.length),
-      'zs': @_get_new_list_array(items.length)
+      'x': @_get_new_nan_array(item_count),
+      'y': @_get_new_nan_array(item_count),
+      'z': @_get_new_nan_array(item_count),
+      'xs': @_get_new_list_array(item_count),
+      'ys': @_get_new_list_array(item_count),
+      'zs': @_get_new_list_array(item_count)
     }
 
-    # The flatten function is used to link together MultiLines and MultPolygons with NaNs
-    flatten_function = (accumulator, currentItem) ->
-      return accumulator.concat([[NaN, NaN, NaN]]).concat(currentItem)
-
+    arr_index = 0
     for item, i in items
+      geometry = if item.type == 'Feature' then item.geometry else item
 
-
-      if item.type == 'Feature'
-        geometry = item.geometry
-
-        # Only Features have properties
-        for property of item.properties
-          if !data.hasOwnProperty(property)
-            data[property] = @_get_new_nan_array(items.length)
-          data[property][i] = item.properties[property]
-
+      if geometry.type == 'GeometryCollection'
+        for g, j in geometry.geometries
+          @_add_geometry(g, data, arr_index)
+          if item.type == 'Feature'
+            @_add_properties(item, data, arr_index, item_count)
+          arr_index += 1
       else
-        geometry = item
+        # Now populate based on Geometry type
+        @_add_geometry(geometry, data, arr_index)
+        if item.type == 'Feature'
+          @_add_properties(item, data, arr_index, item_count)
 
-      # Now populate based on Geometry type
-
-      switch geometry.type
-
-        when "Point"
-          coords = geometry.coordinates
-          data.x[i] = coords[0]
-          data.y[i] = coords[1]
-          data.z[i] = coords[2] ? NaN
-
-        when "LineString"
-          coord_list = geometry.coordinates
-          for coords, j in coord_list
-            data.xs[i][j] = coords[0]
-            data.ys[i][j] = coords[1]
-            data.zs[i][j] = coords[2] ? NaN
-
-        when "Polygon"
-          if geometry.coordinates.length > 1
-            logger.warn('Bokeh does not support Polygons with holes in, only exterior ring used.')
-          exterior_ring = geometry.coordinates[0]
-          for coords, j in exterior_ring
-            data.xs[i][j] = coords[0]
-            data.ys[i][j] = coords[1]
-            data.zs[i][j] = coords[2] ? NaN
-
-        when "MultiPoint"
-          logger.warn('MultiPoint not supported in Bokeh')
-
-        when "MultiLineString"
-          flattened_coord_list = _.reduce(geometry.coordinates, flatten_function)
-          for coords, j in flattened_coord_list
-            data.xs[i][j] = coords[0]
-            data.ys[i][j] = coords[1]
-            data.zs[i][j] = coords[2] ? NaN
-
-        when "MultiPolygon"
-          exterior_rings = []
-          for polygon in geometry.coordinates
-            if polygon.length > 1
-              logger.warn('Bokeh does not support Polygons with holes in, only exterior ring used.')
-            exterior_rings.push(polygon[0])
-          flattened_coord_list = _.reduce(exterior_rings, flatten_function)
-          for coords, j in flattened_coord_list
-            data.xs[i][j] = coords[0]
-            data.ys[i][j] = coords[1]
-            data.zs[i][j] = coords[2] ? NaN
-
-        else
-          throw new Error('Invalid type ' + geometry.type)
+      arr_index += 1
 
     return data
 


### PR DESCRIPTION
This PR address the issue: https://github.com/bokeh/bokeh/issues/3881



- [x] Add Support for GeometryCollection as GeoJSON Geometry Type

A Geometry Collection means that a feature has multiple geometries and those geometries map to a single properties object.  This PR handles that scenario by flattening that list of geometries and repeating the properties object for each geometry.  I feel this is an acceptable approach for supporting this feature. 

Example:

```python
from bokeh.io import output_file, show
from bokeh.plotting import figure
from bokeh.models import Range1d, GeoJSONDataSource
output_file('test_multigeometry.html')

x_range=(-122.44255, -122.44285)
y_range=(37.80, 37.81)

def base_plot(tools='pan,wheel_zoom,reset',plot_width=900, plot_height=600, **plot_args):
    p = figure(tools=tools, plot_width=plot_width, plot_height=plot_height,
        x_range=x_range, y_range=y_range, outline_line_color=None,
        min_border=0, min_border_left=0, min_border_right=0,
        min_border_top=10, min_border_bottom=0, **plot_args)

    p.axis.visible = True
    p.xgrid.grid_line_color = None
    p.ygrid.grid_line_color = None
    return p

fig = base_plot()

geojson = '''{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"GeometryCollection","geometries":[{"type":"LineString","coordinates":[[-122.4425587930444,37.80666418607323,0],[-122.4428379594768,37.80663578323093,0]]},{"type":"LineString","coordinates":[[-122.4425509770566,37.80662588061205,0],[-122.4428340530617,37.8065999493009,0]]}]},"properties":{"name":"SF Marina Harbor Master","visibility":"0"}}]}'''

geojson_ds = GeoJSONDataSource(geojson=geojson)

fig.multi_line(xs='xs',
               ys='ys',
               color="blue",
               alpha=0.7,
               line_width=1,
               source=geojson_ds)
show(fig)
```