### PR TITLE
Fix previewSaveTool' modal view

### DIFF
--- a/bokehjs/src/coffee/models/tools/actions/preview_save_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/actions/preview_save_tool.coffee
@@ -27,7 +27,7 @@ class PreviewSaveToolView extends ActionTool.View
     @$('.bk-bs-modal-body img').attr("src", canvas.toDataURL());
     @$el.modal('show')
     # Bootstrap creates backdrop DOM element in the body, we move it to
-    # somwhere inder bk-root so that css works it should.
+    # somwhere under bk-root so that css works as it should.
     bd = document.getElementsByClassName('bk-bs-modal-backdrop')[0]
     @plot_view.el.appendChild(bd)
 

--- a/bokehjs/src/coffee/models/tools/actions/preview_save_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/actions/preview_save_tool.coffee
@@ -11,6 +11,8 @@ class PreviewSaveToolView extends ActionTool.View
 
   initialize: (options) ->
     super(options)
+    # Attach to DOM (should be somewhere under bk-root to make css work)
+    @plot_view.el.appendChild(@el)
     @render()
 
   render: () ->

--- a/bokehjs/src/coffee/models/tools/actions/preview_save_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/actions/preview_save_tool.coffee
@@ -26,6 +26,10 @@ class PreviewSaveToolView extends ActionTool.View
     canvas = @plot_view.canvas_view.canvas[0]
     @$('.bk-bs-modal-body img').attr("src", canvas.toDataURL());
     @$el.modal('show')
+    # Bootstrap creates backdrop DOM element in the body, we move it to
+    # somwhere inder bk-root so that css works it should.
+    bd = document.getElementsByClassName('bk-bs-modal-backdrop')[0]
+    @plot_view.el.appendChild(bd)
 
 class PreviewSaveTool extends ActionTool.Model
   default_view: PreviewSaveToolView


### PR DESCRIPTION
Fixes #4058 and fixes #4081, by attaching the tool's element to the DOM under the plot' element. 

Would perhaps be a bit nicer if we could put it directly under `bk-root` instead of under the plot, but the plot is not attached to the DOM at the time that the tool initializes, and fiddling with timeouts seems too much fuss. 

cc @mattpap 