### PR TITLE
Set defaults to none so that the HTML will render with auto unless sp…

### DIFF
--- a/bokeh/models/widgets/markups.py
+++ b/bokeh/models/widgets/markups.py
@@ -15,11 +15,11 @@ class Markup(Widget):
     The contents of the widget.
     """)
 
-    width = Int(500, help="""
+    width = Int(None, help="""
     The width of the block in pixels.
     """)
 
-    height = Int(400, help="""
+    height = Int(None, help="""
     The height of the block in pixels.
     """)
 

--- a/bokehjs/src/coffee/models/widgets/markup.coffee
+++ b/bokehjs/src/coffee/models/widgets/markup.coffee
@@ -24,8 +24,8 @@ class Markup extends Widget.Model
 
   @define {
     text: [ p.String, '' ]
-    width: [ p.Number, 500]
-    height: [ p.Number, 400]
+    width: [ p.Number, none]
+    height: [ p.Number, none]
   }
 
 module.exports =


### PR DESCRIPTION
This is a simple PR to change the default settings for the width and the height of the various Markup widgets (Paragraph, Div) to "None".  This change will result in generated HTML with no specification for width or height.  If the user wants to have a specific size, for layout purposes, he or she can specify them when they instantiate, or update the object model.

- [x] issues: fixes #4180 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)