### PR TITLE
Let toggle button have consistent state (#4190)

### DIFF
--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -527,6 +527,6 @@ class Serve(Subcommand):
                  address_string,
                  sorted(applications.keys()))
 
-        log.info("Staring Bokeh server with process id: %d" % getpid())
+        log.info("Starting Bokeh server with process id: %d" % getpid())
 
         server.start()

--- a/bokehjs/src/coffee/models/widgets/toggle.coffee
+++ b/bokehjs/src/coffee/models/widgets/toggle.coffee
@@ -34,8 +34,8 @@ class ToggleView extends BokehView
 
     if @mget("active")
       @$el.addClass("bk-bs-active")
-
-    @$el.attr("data-bk-bs-toggle", "button")
+    else
+      @$el.removeClass("bk-bs-active")
     return @
 
   change_input: () ->


### PR DESCRIPTION
Fixes #4190 

The problem was the `<button ... data-bk-bs-toggle="button">` which made bootstrap override the style that we set in the render method. Also snuck in a typo-fix in the server-code.