### PR TITLE
Histogram deals better with ill-defined ranges (#3660)

### DIFF
--- a/bokeh/charts/builders/histogram_builder.py
+++ b/bokeh/charts/builders/histogram_builder.py
@@ -46,9 +46,11 @@ def Histogram(data, values=None, label=None, color=None, agg="count",
     This chart implements functionality to provide convenience in optimal
     selection of bin count, but also for segmenting and comparing segments of
     the variable by a categorical variable.
-
+    
     Args:
-      data (:ref:`userguide_charts_data_types`): the data source for the chart
+      data (:ref:`userguide_charts_data_types`): the data source for the chart.
+        Must consist of at least 2 values. If all values are equal, the result
+        is a single bin with arbitrary width.
       values (str, optional): the values to use for producing the histogram using
         table-like input data
       label (str or list(str), optional): the categorical variable to use for creating
@@ -110,8 +112,8 @@ class HistogramBuilder(BarBuilder):
     """
 
     bins = Int(default=None, help="""
-    Number of bins to use for the histogram. (default: None
-    (use Freedman-Diaconis rule)
+    Number of bins to use for the histogram. (default: None,
+    use Freedman-Diaconis rule)
     """)
 
     density = Bool(True, help="""

--- a/bokeh/charts/stats.py
+++ b/bokeh/charts/stats.py
@@ -334,7 +334,18 @@ class Bins(Stat):
         self.bin_column = self.column + bin_str
         bin_models = []
 
-        binned, bin_bounds = pd.cut(self.bin_stat.get_data(), self.bin_stat.bin_count,
+        data = self.bin_stat.get_data()
+        bins = self.bin_stat.bin_count
+
+        # Choose bin bounds when data range is ill-defined; pd.cut()
+        # does not handle this well for values that are <= 0
+        if data.size < 2:
+            raise ValueError('Histogram data must have at least two elements.')
+        if data.ndim == 1 and not data.std():
+            margin = 0.01 * abs(float(data[0])) or 0.01
+            bins = np.linspace(data[0] - margin, data[0] + margin, bins+1)
+
+        binned, bin_bounds = pd.cut(data, bins,
                                     retbins=True, include_lowest=True, precision=0)
 
         self.bin_width = np.round(bin_bounds[2] - bin_bounds[1], 1)

--- a/bokeh/charts/stats.py
+++ b/bokeh/charts/stats.py
@@ -341,7 +341,7 @@ class Bins(Stat):
         # does not handle this well for values that are <= 0
         if data.size < 2:
             raise ValueError('Histogram data must have at least two elements.')
-        if data.ndim == 1 and not data.std():
+        if data.ndim == 1 and data.std() == 0:
             margin = 0.01 * abs(float(data[0])) or 0.01
             bins = np.linspace(data[0] - margin, data[0] + margin, bins+1)
 


### PR DESCRIPTION
Fixes #3660 

I played with different approaches to deal with this problem, but this seemed to be the least intrusive. The problem can be considered an upsteam problem of pandas: Pandas selects bin bounds that are 1% wider than the actual min/max range, to ensure inclusion of all values. When the data is no range (e.g. `[3, 3, 3]`), the bin width seems to be 1% of the (mean) *value* of the data. This breaks down for values that are zero or smaller than zero though. This PR fixes this by specifying bin bounds when the data std is zero.

