### PR TITLE
Add paragraph and pretext widgets and examples to user guide.

### DIFF
--- a/sphinx/source/docs/user_guide/interaction.rst
+++ b/sphinx/source/docs/user_guide/interaction.rst
@@ -213,11 +213,27 @@ The toggle button holds an on/off state:
 .. _userguide_interaction_actions:
 
 Div
-~~~~~~~~~
+~~~
 
-A widget for displaying text that can support HTML:
+A widget for displaying text that can support HTML in a <div> tag:
 
 .. bokeh-plot:: source/docs/user_guide/source_examples/interaction_div.py
+    :source-position: below
+
+Paragraph
+~~~~~~~~~
+
+A widget for displaying a block of text in an HTML <p> tag:
+
+.. bokeh-plot:: source/docs/user_guide/source_examples/interaction_paragraph.py
+    :source-position: below
+
+PreText
+~~~~~~~
+
+A widget for displaying a block of pre-formatted text in an HTML <pre> tag:
+
+.. bokeh-plot:: source/docs/user_guide/source_examples/interaction_pretext.py
     :source-position: below
 
 JavaScript Callbacks

--- a/sphinx/source/docs/user_guide/source_examples/interaction_paragraph.py
+++ b/sphinx/source/docs/user_guide/source_examples/interaction_paragraph.py
@@ -1,0 +1,11 @@
+from bokeh.models.widgets import Paragraph
+from bokeh.io import output_file, show, vform
+
+output_file("div.html")
+
+p = Paragraph(text="""Your text is initialized with the 'text' argument.  The
+remaining Paragraph arguments are 'width' and 'height'. For this example, those values
+are 200 and 100 respectively.""",
+width=200, height=100)
+
+show(vform(p))

--- a/sphinx/source/docs/user_guide/source_examples/interaction_pretext.py
+++ b/sphinx/source/docs/user_guide/source_examples/interaction_pretext.py
@@ -1,0 +1,12 @@
+from bokeh.models.widgets import PreText
+from bokeh.io import output_file, show, vform
+
+output_file("div.html")
+
+pre = PreText(text="""Your text is initialized with the 'text' argument.
+
+The remaining Paragraph arguments are 'width' and 'height'. For this example,
+those values are 500 and 100 respectively.""",
+width=500, height=100)
+
+show(vform(pre))


### PR DESCRIPTION
issues: fixes #4217 

