### PR TITLE
store computed final props on a private attribute

### DIFF
--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -200,13 +200,26 @@ class CategoricalTickFormatter(TickFormatter):
     """
     pass
 
+DEFAULT_DATETIME_FORMATS = lambda : {
+    'microseconds': ['%fus'],
+    'milliseconds': ['%3Nms', '%S.%3Ns'],
+    'seconds':      ['%Ss'],
+    'minsec':       [':%M:%S'],
+    'minutes':      [':%M', '%Mm'],
+    'hourmin':      ['%H:%M'],
+    'hours':        ['%Hh', '%H:%M'],
+    'days':         ['%m/%d', '%a%d'],
+    'months':       ['%m/%Y', '%b%y'],
+    'years':        ['%Y'],
+}
+
 class DatetimeTickFormatter(TickFormatter):
     """ Display tick values from a continuous range as formatted
     datetimes.
 
     """
 
-    formats = Dict(Enum(DatetimeUnits), List(String), help="""
+    formats = Dict(Enum(DatetimeUnits), List(String), default=DEFAULT_DATETIME_FORMATS, help="""
     User defined formats for displaying datetime values.
 
     The enum values correspond roughly to different "time scales". The
@@ -393,9 +406,6 @@ class DatetimeTickFormatter(TickFormatter):
     %X
         The preferred time representation for the current locale
         without the date.
-
-    %y
-        The year as a decimal number without a century (range 00 to 99).
 
     %Y
         The year as a decimal number including the century.

--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -407,6 +407,9 @@ class DatetimeTickFormatter(TickFormatter):
         The preferred time representation for the current locale
         without the date.
 
+    %y
+        The year as a decimal number without a century (range 00 to 99).
+
     %Y
         The year as a decimal number including the century.
 

--- a/bokehjs/src/coffee/models/formatters/datetime_tick_formatter.coffee
+++ b/bokehjs/src/coffee/models/formatters/datetime_tick_formatter.coffee
@@ -36,11 +36,24 @@ _strftime = (t, format) ->
       return format
     return tz(t, format)
 
+DEFAULT_DATETIME_FORMATS = {
+  'microseconds': ['%fus']
+  'milliseconds': ['%3Nms', '%S.%3Ns']
+  'seconds':      ['%Ss']
+  'minsec':       [':%M:%S']
+  'minutes':      [':%M', '%Mm']
+  'hourmin':      ['%H:%M']
+  'hours':        ['%Hh', '%H:%M']
+  'days':         ['%m/%d', '%a%d']
+  'months':       ['%m/%Y', '%b%y']
+  'years':        ['%Y']
+}
+
 class DatetimeTickFormatter extends TickFormatter.Model
   type: 'DatetimeTickFormatter'
 
   @define {
-    formats: [ p.Any, {} ] # TODO (bev)
+    formats: [ p.Any, DEFAULT_DATETIME_FORMATS ] # TODO (bev)
   }
 
   # Labels of time units, from finest to coarsest.
@@ -48,30 +61,13 @@ class DatetimeTickFormatter extends TickFormatter.Model
     'microseconds', 'milliseconds', 'seconds', 'minsec', 'minutes', 'hourmin', 'hours', 'days', 'months', 'years'
   ]
 
-  # This table of formats is convert into the 'formats' dict.
-  # TODO: please add to documentation, especially as to why
-  # there are multiple formatters per time scale.
-  _formats: {
-    'microseconds': ['%fus']
-    'milliseconds': ['%3Nms', '%S.%3Ns']
-    'seconds':      ['%Ss']
-    'minsec':       [':%M:%S']
-    'minutes':      [':%M', '%Mm']
-    'hourmin':      ['%H:%M']
-    'hours':        ['%Hh', '%H:%M']
-    'days':         ['%m/%d', '%a%d']
-    'months':       ['%m/%Y', '%b%y']
-    'years':        ['%Y']
-  }
-
   # Whether or not to strip the leading zeros on tick labels.
   strip_leading_zeros: true
 
   initialize: (attrs, options) ->
     super(attrs, options)
-    @formats = _.extend({}, @_formats, @get("formats"))
-    @_update_width_formats()
     # TODO (bev) trigger update on format change
+    @_update_width_formats()
 
   _update_width_formats: () ->
     now = tz(new Date())


### PR DESCRIPTION
- [x] issues: fixes #4219
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

This PR makes the "internal" formats dict on a datetime tick formatter actually be internal. This PR also removes some unused "function" formats that were not compatible with serialization. 

Note that it is less than ideal that the `formats` bokeh property is always set from the JS side, it migh tbe better to set "base formats" and overlay the "diff formats" from python. This PR does not address that. 
