### PR TITLE
send date without TZ as-is, do not assume gmt

### DIFF
--- a/bokeh/core/json_encoder.py
+++ b/bokeh/core/json_encoder.py
@@ -6,10 +6,10 @@ from __future__ import absolute_import
 import logging
 log = logging.getLogger(__name__)
 
-import calendar
 import datetime as dt
 import decimal
 import json
+import time
 
 import numpy as np
 
@@ -41,10 +41,10 @@ class BokehJSONEncoder(json.JSONEncoder):
         # Datetime
         # datetime is a subclass of date.
         elif isinstance(obj, dt.datetime):
-            return calendar.timegm(obj.timetuple()) * 1000. + obj.microsecond / 1000.
+            return time.mktime(obj.timetuple()) * 1000. + obj.microsecond / 1000.
         # Date
         elif isinstance(obj, dt.date):
-            return calendar.timegm(obj.timetuple()) * 1000.
+            return time.mktime(obj.timetuple()) * 1000.
         # Numpy datetime64
         elif isinstance(obj, np.datetime64):
             epoch_delta = obj - np.datetime64('1970-01-01T00:00:00Z')

--- a/bokeh/core/tests/test_json_encoder.py
+++ b/bokeh/core/tests/test_json_encoder.py
@@ -128,8 +128,8 @@ class TestSerializeJson(unittest.TestCase):
         #
         # In [6]: time.mktime(dt.datetime(2016, 4, 28, 2, 20, 50).timetuple())
         # Out[6]: 1461828050.0
-        baseline = {u'date': [1461819600000],
-                    u'datetime': [1461828050000],
+        baseline = {u'date': [1461819600000.0],
+                    u'datetime': [1461828050000.0],
         }
         assert deserialized == baseline
 if __name__ == "__main__":

--- a/bokeh/core/tests/test_json_encoder.py
+++ b/bokeh/core/tests/test_json_encoder.py
@@ -119,17 +119,14 @@ class TestSerializeJson(unittest.TestCase):
         """ should convert to millis as-is
         """
 
-        serialized = self.serialize({'date' : [dt.date(2016, 4, 28)],
-                                     'datetime' : [dt.datetime(2016, 4, 28, 2, 20, 50)]})
+        a = dt.date(2016, 4, 28)
+        b = dt.datetime(2016, 4, 28, 2, 20, 50)
+        serialized = self.serialize({'a' : [a],
+                                     'b' : [b]})
         deserialized = self.deserialize(serialized)
 
-        # In [5]: time.mktime(dt.date(2016, 4, 28).timetuple())
-        # Out[5]: 1461819600.0
-        #
-        # In [6]: time.mktime(dt.datetime(2016, 4, 28, 2, 20, 50).timetuple())
-        # Out[6]: 1461828050.0
-        baseline = {u'date': [1461819600000.0],
-                    u'datetime': [1461828050000.0],
+        baseline = {u'a': [time.mktime(a.timetuple())*1000],
+                    u'b': [time.mktime(b.timetuple())*1000],
         }
         assert deserialized == baseline
 if __name__ == "__main__":

--- a/bokeh/core/tests/test_json_encoder.py
+++ b/bokeh/core/tests/test_json_encoder.py
@@ -3,6 +3,9 @@ from __future__ import absolute_import
 import unittest
 from unittest import skipIf
 
+import datetime as dt
+import time
+
 import numpy as np
 
 try:
@@ -91,7 +94,7 @@ class TestSerializeJson(unittest.TestCase):
         assert deserialized[3] == 0
 
     @skipIf(not is_pandas, "pandas does not work in PyPy.")
-    def test_datetime_types(self):
+    def test_pandas_datetime_types(self):
         """should convert to millis
         """
         idx = pd.date_range('2001-1-1', '2001-1-5')
@@ -112,5 +115,22 @@ class TestSerializeJson(unittest.TestCase):
         }
         assert deserialized == baseline
 
+    def test_builtin_datetime_types(self):
+        """ should convert to millis as-is
+        """
+
+        serialized = self.serialize({'date' : [dt.date(2016, 4, 28)],
+                                     'datetime' : [dt.datetime(2016, 4, 28, 2, 20, 50)]})
+        deserialized = self.deserialize(serialized)
+
+        # In [5]: time.mktime(dt.date(2016, 4, 28).timetuple())
+        # Out[5]: 1461819600.0
+        #
+        # In [6]: time.mktime(dt.datetime(2016, 4, 28, 2, 20, 50).timetuple())
+        # Out[6]: 1461828050.0
+        baseline = {u'date': [1461819600000],
+                    u'datetime': [1461828050000],
+        }
+        assert deserialized == baseline
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- [x] issues: fixes #4139
- [x] tests added / passed
- [x] ~~~release document entry (if new feature or API change)~~~

This PR changes the JSON encoder to not use `calendar.timegm`, which converts to local timestap, assuming that the datetimes provided are already GMT, causing them to be offset incorrectly. 