### PR TITLE
Integrate ComputedTransforms into the DataSpec System

### DIFF
--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -1600,7 +1600,7 @@ class DataSpecProperty(BasicProperty):
 
 class DataSpec(Either):
     def __init__(self, typ, default, help=None):
-        super(DataSpec, self).__init__(String, Dict(String, Either(String, typ)), typ, default=default, help=help)
+        super(DataSpec, self).__init__(String, Dict(String, Either(String, Instance(HasProps), typ)), typ, default=default, help=help)
         self._type = self._validate_type_param(typ)
 
     def make_properties(self, base_name):

--- a/bokehjs/src/coffee/core/properties.coffee
+++ b/bokehjs/src/coffee/core/properties.coffee
@@ -49,7 +49,10 @@ class Property extends Backbone.Model
   value: () ->
     if _.isUndefined(@spec.value)
       throw new Error("attempted to retrieve property value for property without value specification")
-    return @transform([@spec.value])[0]
+    ret = @transform([@spec.value])[0]
+    if @spec.transform?
+      ret = @spec.transform.compute(ret)
+    return ret
 
   array: (source) ->
     if not @dataspec
@@ -57,7 +60,10 @@ class Property extends Backbone.Model
     data = source.get('data')
     if @spec.field?
       if @spec.field of data
-        return @transform(source.get_column(@spec.field))
+        ret = @transform(source.get_column(@spec.field))
+        if @spec.transform?
+          ret = @spec.transform.v_compute(ret)
+        return (ret)
       else
         throw new Error("attempted to retrieve property array for nonexistent field '#{@spec.field}'")
     else


### PR DESCRIPTION
This PR will integrate the new Computed Transforms into the DataSpec system.  This will allow the user to apply transforms to the data provided to various plotting functions.

As an example usage, the following line will apply a random jitter to the x coordinate of a set of circles

    bk.circle(x={'field': 'xvalues', 'transform': Jitter(width=0.3)}, y='yvalues', source=mydata)

- [ ] issues: fixes #4205 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

This is no where near ready but I wanted to put the PR in to begin the necessary work.