### PR TITLE
only wrap autoload_static in an onload handler

### DIFF
--- a/bokeh/core/_templates/autoload_js.js
+++ b/bokeh/core/_templates/autoload_js.js
@@ -25,96 +25,94 @@ calls it with the rendered model.
 
 
 #}
-document.addEventListener("DOMContentLoaded", function(event) { 
-  (function(global) {
-    function now() {
-      return new Date();
+(function(global) {
+  function now() {
+    return new Date();
+  }
+
+  if (typeof (window._bokeh_onload_callbacks) === "undefined") {
+    window._bokeh_onload_callbacks = [];
+  }
+
+  function run_callbacks() {
+    window._bokeh_onload_callbacks.forEach(function(callback) { callback() });
+    delete window._bokeh_onload_callbacks
+    console.info("Bokeh: all callbacks have finished");
+  }
+
+  function load_libs(js_urls, callback) {
+    window._bokeh_onload_callbacks.push(callback);
+    if (window._bokeh_is_loading > 0) {
+      console.log("Bokeh: BokehJS is being loaded, scheduling callback at", now());
+      return null;
     }
-
-    if (typeof (window._bokeh_onload_callbacks) === "undefined") {
-      window._bokeh_onload_callbacks = [];
+    if (js_urls == null || js_urls.length === 0) {
+      run_callbacks();
+      return null;
     }
-
-    function run_callbacks() {
-      window._bokeh_onload_callbacks.forEach(function(callback) { callback() });
-      delete window._bokeh_onload_callbacks
-      console.info("Bokeh: all callbacks have finished");
+    console.log("Bokeh: BokehJS not loaded, scheduling load and callback at", now());
+    window._bokeh_is_loading = js_urls.length;
+    for (var i = 0; i < js_urls.length; i++) {
+      var url = js_urls[i];
+      var s = document.createElement('script');
+      s.src = url;
+      s.async = false;
+      s.onreadystatechange = s.onload = function() {
+        window._bokeh_is_loading--;
+        if (window._bokeh_is_loading === 0) {
+          console.log("Bokeh: all BokehJS libraries loaded");
+          run_callbacks()
+        }
+      };
+      s.onerror = function() {
+        console.warn("failed to load library " + url);
+      };
+      console.log("Bokeh: injecting script tag for BokehJS library: ", url);
+      document.getElementsByTagName("head")[0].appendChild(s);
     }
+  };
 
-    function load_libs(js_urls, callback) {
-      window._bokeh_onload_callbacks.push(callback);
-      if (window._bokeh_is_loading > 0) {
-        console.log("Bokeh: BokehJS is being loaded, scheduling callback at", now());
-        return null;
-      }
-      if (js_urls == null || js_urls.length === 0) {
-        run_callbacks();
-        return null;
-      }
-      console.log("Bokeh: BokehJS not loaded, scheduling load and callback at", now());
-      window._bokeh_is_loading = js_urls.length;
-      for (var i = 0; i < js_urls.length; i++) {
-        var url = js_urls[i];
-        var s = document.createElement('script');
-        s.src = url;
-        s.async = false;
-        s.onreadystatechange = s.onload = function() {
-          window._bokeh_is_loading--;
-          if (window._bokeh_is_loading === 0) {
-            console.log("Bokeh: all BokehJS libraries loaded");
-            run_callbacks()
-          }
-        };
-        s.onerror = function() {
-          console.warn("failed to load library " + url);
-        };
-        console.log("Bokeh: injecting script tag for BokehJS library: ", url);
-        document.getElementsByTagName("head")[0].appendChild(s);
-      }
-    };
+  {%- if elementid -%}
+  var element = document.getElementById("{{ elementid }}");
+  if (element == null) {
+    console.log("Bokeh: ERROR: autoload.js configured with elementid '{{ elementid }}' but no matching script tag was found. ")
+    return false;
+  }
+  {%- endif %}
 
-    {%- if elementid -%}
-    var element = document.getElementById("{{ elementid }}");
-    if (element == null) {
-      console.log("Bokeh: ERROR: autoload.js configured with elementid '{{ elementid }}' but no matching script tag was found. ")
-      return false;
+  var js_urls = {{ js_urls }};
+
+  var inline_js = [
+    {%- for js in js_raw %}
+    function(Bokeh) {
+      {{ js|indent(6) }}
+    },
+    {% endfor -%}
+    function(Bokeh) {
+      {%- for url in css_urls %}
+      console.log("Bokeh: injecting CSS: {{ url }}");
+      Bokeh.embed.inject_css("{{ url }}");
+      {%- endfor %}
+      {%- for css in css_raw %}
+      console.log("Bokeh: injecting raw CSS");
+      Bokeh.embed.inject_raw_css({{ css }});
+      {%- endfor %}
     }
-    {%- endif %}
+  ];
 
-    var js_urls = {{ js_urls }};
-
-    var inline_js = [
-      {%- for js in js_raw %}
-      function(Bokeh) {
-        {{ js|indent(6) }}
-      },
-      {% endfor -%}
-      function(Bokeh) {
-        {%- for url in css_urls %}
-        console.log("Bokeh: injecting CSS: {{ url }}");
-        Bokeh.embed.inject_css("{{ url }}");
-        {%- endfor %}
-        {%- for css in css_raw %}
-        console.log("Bokeh: injecting raw CSS");
-        Bokeh.embed.inject_raw_css({{ css }});
-        {%- endfor %}
-      }
-    ];
-
-    function run_inline_js() {
-      for (var i = 0; i < inline_js.length; i++) {
-        inline_js[i](window.Bokeh);
-      }
+  function run_inline_js() {
+    for (var i = 0; i < inline_js.length; i++) {
+      inline_js[i](window.Bokeh);
     }
+  }
 
-    if (window._bokeh_is_loading === 0) {
-      console.log("Bokeh: BokehJS loaded, going straight to plotting");
+  if (window._bokeh_is_loading === 0) {
+    console.log("Bokeh: BokehJS loaded, going straight to plotting");
+    run_inline_js();
+  } else {
+    load_libs(js_urls, function() {
+      console.log("Bokeh: BokehJS plotting callback run at", now());
       run_inline_js();
-    } else {
-      load_libs(js_urls, function() {
-        console.log("Bokeh: BokehJS plotting callback run at", now());
-        run_inline_js();
-      });
-    }
-  }(this));
-});
+    });
+  }
+}(this));

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -314,7 +314,7 @@ def file_html(models,
                                            template=template, template_variables=template_variables)
 
 # TODO rename this "standalone"?
-def autoload_static(model, resources, script_path, onload=True):
+def autoload_static(model, resources, script_path):
     ''' Return JavaScript code and a script tag that can be used to embed
     Bokeh Plots.
 

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -34,6 +34,11 @@ def _wrap_in_function(code):
     code = "\n".join(["    " + line for line in code.split("\n")])
     return 'Bokeh.$(function() {\n%s\n});' % code
 
+def _wrap_in_onload(code):
+    # indent and wrap Bokeh function def around
+    code = "\n".join(["    " + line for line in code.split("\n")])
+    return 'document.addEventListener("DOMContentLoaded", function(event) {\n%s\n});' % code
+
 def components(models, resources=None, wrap_script=True, wrap_plot_info=True):
     '''
     Return HTML components to embed a Bokeh plot. The data for the plot is
@@ -309,7 +314,7 @@ def file_html(models,
                                            template=template, template_variables=template_variables)
 
 # TODO rename this "standalone"?
-def autoload_static(model, resources, script_path):
+def autoload_static(model, resources, script_path, onload=True):
     ''' Return JavaScript code and a script tag that can be used to embed
     Bokeh Plots.
 
@@ -341,13 +346,13 @@ def autoload_static(model, resources, script_path):
     script = _script_for_render_items(docs_json, render_items, wrap_script=False)
     item = render_items[0]
 
-    js = AUTOLOAD_JS.render(
+    js = _wrap_in_onload(AUTOLOAD_JS.render(
         js_urls = resources.js_files,
         css_urls = resources.css_files,
         js_raw = resources.js_raw + [script],
         css_raw = resources.css_raw_str,
         elementid = item['elementid'],
-    )
+    ))
 
     tag = AUTOLOAD_TAG.render(
         src_path = script_path,


### PR DESCRIPTION
issues: fixes #4254

This PR changes the embedding code to only wrap the JS for `autoload_static` in a document `onload` handler, and reverts the notebook embedding code to the way it was previously. 

I have verified that the notebook functions with this PR. 

@seanlaw if possible, can you check whether `autoload_static` functions as expected for you? (Looking at the output in an ipython console, it looks good, but independent verification is certainly welcome)

@mattpap I do want to take a deeper dive into all of our embedding/templating soon, but I'd like to get your opinion if this is acceptable as an immediate fix. 