### PR TITLE
Add WebGL support for more kinds of markers

### DIFF
--- a/bokehjs/src/coffee/models/canvas/canvas.coffee
+++ b/bokehjs/src/coffee/models/canvas/canvas.coffee
@@ -39,6 +39,9 @@ class CanvasView extends BokehView
 
     logger.debug("CanvasView initialized")
 
+  get_canvas_element: () ->
+    return @$('canvas.bk-canvas')[0]
+
   get_ctx: () ->
     canvas_el = @$('canvas.bk-canvas')
     ctx = canvas_el[0].getContext('2d')

--- a/bokehjs/src/coffee/models/glyphs/bokehgl.coffee
+++ b/bokehjs/src/coffee/models/glyphs/bokehgl.coffee
@@ -1270,7 +1270,7 @@ class MarkerGLGlyph extends BaseGLGlyph
     attach_color(@prog, @vbo_fg_color, 'a_fg_color', nvertices, @glyph.visuals.line, 'line')
     attach_color(@prog, @vbo_bg_color, 'a_bg_color', nvertices, @glyph.visuals.fill, 'fill')
     # Static value for antialias. Smaller aa-region to obtain crisper images
-    @prog.set_uniform('u_antialias', 'float', [0.9])
+    @prog.set_uniform('u_antialias', 'float', [0.4])
 
 
 class CircleGLGlyph extends MarkerGLGlyph

--- a/bokehjs/src/coffee/models/glyphs/bokehgl.coffee
+++ b/bokehjs/src/coffee/models/glyphs/bokehgl.coffee
@@ -1297,8 +1297,250 @@ class SquareGLGlyph extends MarkerGLGlyph
     }
     """
 
+class AnnulusGLGlyph extends MarkerGLGlyph
+
+  GLYPH: 'annulus'
+
+  MARKERCODE: """
+    float marker(vec2 P, float size)
+    {
+        float r1 = length(P) - size/2.0;
+        float r2 = length(P) - size/4.0;  // half width
+        return max(r1, -r2);
+    }
+    """
+
+class DiamondGLGlyph extends MarkerGLGlyph
+
+  GLYPH: 'diamond'
+
+  MARKERCODE: """
+    // --- diamond
+    float marker(vec2 P, float size)
+    {
+        float x = SQRT_2 / 2.0 * (P.x * 1.5 - P.y);
+        float y = SQRT_2 / 2.0 * (P.x * 1.5 + P.y);
+        float r1 = max(abs(x), abs(y)) - size / (2.0 * SQRT_2);
+        return r1;
+    }
+    """
+
+class TriangleGLGlyph extends MarkerGLGlyph
+
+  GLYPH: 'triangle'
+
+  MARKERCODE: """
+    float marker(vec2 P, float size)
+    {
+        P.y -= size * 0.3;
+        float x = SQRT_2 / 2.0 * (P.x * 1.7 - P.y);
+        float y = SQRT_2 / 2.0 * (P.x * 1.7 + P.y);
+        float r1 = max(abs(x), abs(y)) - size / 1.6;
+        float r2 = P.y;
+        return max(r1, r2);  // Instersect diamond with rectangle
+    }
+    """
+
+class InvertedTriangleGLGlyph extends MarkerGLGlyph
+
+  GLYPH: 'invertedtriangle'
+
+  MARKERCODE: """
+    float marker(vec2 P, float size)
+    {
+        P.y += size * 0.3;
+        float x = SQRT_2 / 2.0 * (P.x * 1.7 - P.y);
+        float y = SQRT_2 / 2.0 * (P.x * 1.7 + P.y);
+        float r1 = max(abs(x), abs(y)) - size / 1.6;
+        float r2 = - P.y;
+        return max(r1, r2);  // Instersect diamond with rectangle
+    }
+    """
+
+class CrossGLGlyph extends MarkerGLGlyph
+
+  GLYPH: 'cross'
+
+  MARKERCODE: """
+    float marker(vec2 P, float size)
+    {
+        float square = max(abs(P.x), abs(P.y)) - size/2.0 + 0.5;
+        float cross = min(abs(P.x), abs(P.y)) - size / 100.0;  // bit of "width" for aa
+        return max(square, cross);
+    }
+    """
+
+class CircleCrossGLGlyph extends MarkerGLGlyph
+
+  GLYPH: 'circlecross'
+
+  MARKERCODE: """
+    float marker(vec2 P, float size)
+    {
+        // Define quadrants
+        float qs = size / 4.0;  // quadrant size
+        float s1 = max(abs(P.x - qs), abs(P.y - qs)) - qs;
+        float s2 = max(abs(P.x + qs), abs(P.y - qs)) - qs;
+        float s3 = max(abs(P.x - qs), abs(P.y + qs)) - qs;
+        float s4 = max(abs(P.x + qs), abs(P.y + qs)) - qs;
+        // Intersect main shape with quadrants (to form cross)
+        float circle = length(P) - size/2.0;
+        float c1 = max(circle, s1);
+        float c2 = max(circle, s2);
+        float c3 = max(circle, s3);
+        float c4 = max(circle, s4);
+        // Union
+        return min(min(min(c1, c2), c3), c4);
+    }
+    """
+
+class SquareCrossGLGlyph extends MarkerGLGlyph
+
+  GLYPH: 'squarecross'
+
+  MARKERCODE: """
+    float marker(vec2 P, float size)
+    {
+        // Define quadrants
+        float qs = size / 4.0;  // quadrant size
+        float s1 = max(abs(P.x - qs), abs(P.y - qs)) - qs;
+        float s2 = max(abs(P.x + qs), abs(P.y - qs)) - qs;
+        float s3 = max(abs(P.x - qs), abs(P.y + qs)) - qs;
+        float s4 = max(abs(P.x + qs), abs(P.y + qs)) - qs;
+        // Intersect main shape with quadrants (to form cross)
+        float square = max(abs(P.x), abs(P.y)) - size/2.0;
+        float c1 = max(square, s1);
+        float c2 = max(square, s2);
+        float c3 = max(square, s3);
+        float c4 = max(square, s4);
+        // Union
+        return min(min(min(c1, c2), c3), c4);
+    }
+    """
+
+class DiamondCrossGLGlyph extends MarkerGLGlyph
+
+  GLYPH: 'diamondcross'
+
+  MARKERCODE: """
+    float marker(vec2 P, float size)
+    {
+        // Define quadrants
+        float qs = size / 4.0;  // quadrant size
+        float s1 = max(abs(P.x - qs), abs(P.y - qs)) - qs;
+        float s2 = max(abs(P.x + qs), abs(P.y - qs)) - qs;
+        float s3 = max(abs(P.x - qs), abs(P.y + qs)) - qs;
+        float s4 = max(abs(P.x + qs), abs(P.y + qs)) - qs;
+        // Intersect main shape with quadrants (to form cross)
+        float x = SQRT_2 / 2.0 * (P.x * 1.5 - P.y);
+        float y = SQRT_2 / 2.0 * (P.x * 1.5 + P.y);
+        float diamond = max(abs(x), abs(y)) - size / (2.0 * SQRT_2);
+        float c1 = max(diamond, s1);
+        float c2 = max(diamond, s2);
+        float c3 = max(diamond, s3);
+        float c4 = max(diamond, s4);
+        // Union
+        return min(min(min(c1, c2), c3), c4);
+    }
+    """
+
+class XGLGlyph extends MarkerGLGlyph
+
+  GLYPH: 'x'
+
+  MARKERCODE: """
+    float marker(vec2 P, float size)
+    {
+        float square = max(abs(P.x), abs(P.y)) - size/2.0 + 0.5;
+        float X = min(abs(P.x - P.y), abs(P.x + P.y)) - size / 100.0;  // bit of "width" for aa
+        return max(square, X);
+    }
+    """
+
+class CircleXGLGlyph extends MarkerGLGlyph
+
+  GLYPH: 'circlex'
+
+  MARKERCODE: """
+    float marker(vec2 P, float size)
+    {
+        float x = P.x - P.y;
+        float y = P.x + P.y;
+        // Define quadrants
+        float qs = size / 2.0;  // quadrant size
+        float s1 = max(abs(x - qs), abs(y - qs)) - qs;
+        float s2 = max(abs(x + qs), abs(y - qs)) - qs;
+        float s3 = max(abs(x - qs), abs(y + qs)) - qs;
+        float s4 = max(abs(x + qs), abs(y + qs)) - qs;
+        // Intersect main shape with quadrants (to form cross)
+        float circle = length(P) - size/2.0;
+        float c1 = max(circle, s1);
+        float c2 = max(circle, s2);
+        float c3 = max(circle, s3);
+        float c4 = max(circle, s4);
+        // Union
+        float almost = min(min(min(c1, c2), c3), c4);
+        // In this case, the X is also outside of the main shape
+        float square = max(abs(P.x), abs(P.y)) - size/2.0;
+        float X = min(abs(P.x - P.y), abs(P.x + P.y)) - size / 100.0;  // bit of "width" for aa
+        return min(max(X, square), almost);
+    }
+    """
+
+class SquareXGLGlyph extends MarkerGLGlyph
+
+  GLYPH: 'squarex'
+
+  MARKERCODE: """
+    float marker(vec2 P, float size)
+    {
+        float x = P.x - P.y;
+        float y = P.x + P.y;
+        // Define quadrants
+        float qs = size / 2.0;  // quadrant size
+        float s1 = max(abs(x - qs), abs(y - qs)) - qs;
+        float s2 = max(abs(x + qs), abs(y - qs)) - qs;
+        float s3 = max(abs(x - qs), abs(y + qs)) - qs;
+        float s4 = max(abs(x + qs), abs(y + qs)) - qs;
+        // Intersect main shape with quadrants (to form cross)
+        float square = max(abs(P.x), abs(P.y)) - size/2.0;
+        float c1 = max(square, s1);
+        float c2 = max(square, s2);
+        float c3 = max(square, s3);
+        float c4 = max(square, s4);
+        // Union
+        return min(min(min(c1, c2), c3), c4);
+    }
+    """
+
+class AsteriskGLGlyph extends MarkerGLGlyph
+
+  GLYPH: 'asterisk'
+
+  MARKERCODE: """
+    float marker(vec2 P, float size)
+    {
+        float circle = length(P) - size/2.0 + 1.0;
+        float X = min(abs(P.x - P.y), abs(P.x + P.y)) - size / 100.0;  // bit of "width" for aa
+        float cross = min(abs(P.x), abs(P.y)) - size / 100.0;  // bit of "width" for aa
+        float asterisk = min(X, cross);
+        return max(circle, asterisk);  // limit to size of circle
+    }
+    """
 
 module.exports =
+  LineGLGlyph: LineGLGlyph
   CircleGLGlyph: CircleGLGlyph
   SquareGLGlyph: SquareGLGlyph
-  LineGLGlyph: LineGLGlyph
+  AnnulusGLGlyph: AnnulusGLGlyph
+  DiamondGLGlyph: DiamondGLGlyph
+  TriangleGLGlyph: TriangleGLGlyph
+  InvertedTriangleGLGlyph: InvertedTriangleGLGlyph
+  CrossGLGlyph: CrossGLGlyph
+  CircleCrossGLGlyph: CircleCrossGLGlyph
+  SquareCrossGLGlyph: SquareCrossGLGlyph
+  DiamondCrossGLGlyph: DiamondCrossGLGlyph
+  XGLGlyph: XGLGlyph
+  CircleXGLGlyph: CircleXGLGlyph
+  SquareXGLGlyph: SquareXGLGlyph
+  AsteriskGLGlyph: AsteriskGLGlyph

--- a/bokehjs/src/coffee/models/glyphs/circle.coffee
+++ b/bokehjs/src/coffee/models/glyphs/circle.coffee
@@ -1,15 +1,10 @@
 _ = require "underscore"
 
-bokehgl = require "./bokehgl"
 Glyph = require "./glyph"
 hittest = require "../../common/hittest"
 p = require "../../core/properties"
 
 class CircleView extends Glyph.View
-
-  _init_gl: (gl) ->
-    # This is how you enable gl for a glyph
-    @glglyph = new bokehgl.CircleGLGlyph(gl, this)
 
   _index_data: () ->
     return @_xy_index()

--- a/bokehjs/src/coffee/models/glyphs/glyph.coffee
+++ b/bokehjs/src/coffee/models/glyphs/glyph.coffee
@@ -6,6 +6,7 @@ Renderer = require "../renderers/renderer"
 p = require "../../core/properties"
 bbox = require "../../core/util/bbox"
 Model = require "../../model"
+bokehgl = require "../glyphs/bokehgl"
 
 class GlyphView extends Renderer.View
 
@@ -21,7 +22,10 @@ class GlyphView extends Renderer.View
     if @renderer?.plot_view?
       ctx = @renderer.plot_view.canvas_view.ctx
       if ctx.glcanvas?
-        @_init_gl(ctx.glcanvas.gl)
+        window.ggg = this
+        Cls = bokehgl[@model.type + 'GLGlyph']
+        if Cls
+          @glglyph = new Cls(ctx.glcanvas.gl, this)
 
   render: (ctx, indices, data) ->
 
@@ -68,10 +72,6 @@ class GlyphView extends Renderer.View
   # snapping to a patch centroid, e.g, should override these
   scx: (i) -> return @sx[i]
   scy: (i) -> return @sy[i]
-
-  # any additional customization can happen here
-  _init_gl: () -> false
-
 
   _xy_index: () ->
     index = rbush()

--- a/bokehjs/src/coffee/models/glyphs/line.coffee
+++ b/bokehjs/src/coffee/models/glyphs/line.coffee
@@ -1,13 +1,9 @@
 _ = require "underscore"
 
-bokehgl = require "./bokehgl"
 Glyph = require "./glyph"
 hittest = require "../../common/hittest"
 
 class LineView extends Glyph.View
-
-  _init_gl: (gl) ->
-    @glglyph = new bokehgl.LineGLGlyph(gl, this)
 
   _index_data: () ->
     @_xy_index()

--- a/bokehjs/src/coffee/models/markers/square.coffee
+++ b/bokehjs/src/coffee/models/markers/square.coffee
@@ -1,12 +1,7 @@
 _ = require "underscore"
 Marker = require "./marker"
-bokehgl = require "../glyphs/bokehgl"
-
 
 class SquareView extends Marker.View
-
-  _init_gl: (gl) ->
-    @glglyph = new bokehgl.SquareGLGlyph(gl, this)
 
   _render: (ctx, indices, {sx, sy, _size, _angle}) ->
     for i in indices

--- a/bokehjs/src/coffee/models/plots/plot.coffee
+++ b/bokehjs/src/coffee/models/plots/plot.coffee
@@ -512,8 +512,8 @@ class PlotView extends Renderer.View
       #for prefix in ['image', 'mozImage', 'webkitImage','msImage']
       #   ctx[prefix + 'SmoothingEnabled'] = window.SmoothingEnabled
       #ctx.globalCompositeOperation = "source-over"  -> OK; is the default
-      src_offset = 0.5
-      dst_offset = 0.0
+      src_offset = 0.0
+      dst_offset = 0.5
       ctx.drawImage(ctx.glcanvas, src_offset, src_offset, ctx.glcanvas.width, ctx.glcanvas.height,
                                   dst_offset, dst_offset, ctx.glcanvas.width, ctx.glcanvas.height)
       logger.debug('drawing with WebGL')

--- a/bokehjs/src/coffee/models/plots/plot.coffee
+++ b/bokehjs/src/coffee/models/plots/plot.coffee
@@ -127,7 +127,7 @@ class PlotView extends Renderer.View
     @canvas_view = new @canvas.default_view({'model': @canvas})
 
     @$('.bk-plot-canvas-wrapper').append(@canvas_view.el)
-    
+
     @canvas_view.render(true)
 
     # If requested, try enabling webgl
@@ -478,8 +478,9 @@ class PlotView extends Renderer.View
 
     if ctx.glcanvas
       # Sync canvas size
-      ctx.glcanvas.width = @canvas_view.canvas[0].width
-      ctx.glcanvas.height = @canvas_view.canvas[0].height
+      canvas = @canvas_view.get_canvas_element()
+      ctx.glcanvas.width = canvas.width
+      ctx.glcanvas.height = canvas.height
       # Prepare GL for drawing
       gl = ctx.glcanvas.gl
       gl.viewport(0, 0, ctx.glcanvas.width, ctx.glcanvas.height)
@@ -537,7 +538,7 @@ class PlotView extends Renderer.View
 
   update_constraints: () ->
     s = @model.document.solver()
-    
+
     # Note: -1 to effectively dilate the canvas by 1px
     s.suggest_value(@frame._width, @canvas.get('width') - 1)
     s.suggest_value(@frame._height, @canvas.get('height') - 1)
@@ -560,11 +561,11 @@ class PlotView extends Renderer.View
 
   resize_width_height: (use_width, use_height, maintain_ar=true, width=null, height=null) =>
     # Resize plot based on available width and/or height
-    
+
     # If size is explicitly given, we don't have to measure any DOM elements. Shortcut for Phosphor.
     if typeof width is 'number' and typeof height is 'number' and width >=0 and height >= 0
       return @_resize_width_height(use_width, use_height, maintain_ar, width, height)
-    
+
     # the solver falls over if we try and resize too small.
     # min_size is currently set in defaults to 120, we can make this
     # user-configurable in the future, as it may not be the right number
@@ -587,7 +588,7 @@ class PlotView extends Renderer.View
       @_re_resized += 1
       return
 
-    # Check that what we found is a bk-root. If not, this is probably a subplot, which we 
+    # Check that what we found is a bk-root. If not, this is probably a subplot, which we
     # can not currently make responsive in a good way
     if not node.classList.contains('bk-root')
        logger.warn('subplots cannot be responsive')
@@ -604,7 +605,7 @@ class PlotView extends Renderer.View
     width_offset = height_offset = 20
     if @model.toolbar_location == 'above' then height_offset += 30
     if @model.toolbar_location == 'below' then height_offset += 80  # bug in layout?
-    if @model.toolbar_location in ['left', 'right'] then width_offset += 30    
+    if @model.toolbar_location in ['left', 'right'] then width_offset += 30
     avail_width -= width_offset
     avail_height -= height_offset
 
@@ -695,7 +696,7 @@ class Plot extends LayoutDOM.Model
         @set('min_border_left', min_border)
       if not @get('min_border_right')?
         @set('min_border_right', min_border)
-    
+
     @_width = new Variable("plot_width")
     @_height = new Variable("plot_height")
 

--- a/examples/plotting/file/marker_compare.py
+++ b/examples/plotting/file/marker_compare.py
@@ -1,0 +1,31 @@
+"""
+Compare WebGL markers with canvas markers. This covers all markers
+supported by scatter. The plots are put in tabs, so that you can easily
+switch to compare positioning and appearance.
+"""
+
+import numpy as np
+
+from bokeh.plotting import show, output_file, Figure
+from bokeh.models.widgets import Tabs, Panel
+from bokeh.sampledata.iris import flowers
+
+
+def make_tab(title, marker, webgl):
+    p = Figure(title=title, webgl=webgl)
+    p.scatter(flowers["petal_length"], flowers["petal_width"],
+              color='blue', fill_alpha=0.2, size=12, marker=marker)
+    return Panel(child=p, title=title)
+
+markers = ['asterisk', 'circle', 'square', 'diamond',
+           'triangle', 'inverted_triangle',
+           'cross', 'circle_cross', 'square_cross', 'diamond_cross',
+           'x', 'square_x',  'circle_x']
+
+tabs = []
+for marker in markers:
+    tabs.append(make_tab(marker, marker, False))
+    tabs.append(make_tab(marker + ' GL', marker, True))
+
+output_file("marker_compare.html", title="Compare regular and WebGL markers")
+show(Tabs(tabs=tabs))

--- a/examples/plotting/file/webgl_tests.md
+++ b/examples/plotting/file/webgl_tests.md
@@ -5,6 +5,7 @@ run successfully after significant changes in BokehJS.
 Examples usefull for testing:
 
 - line_compare.py - puts regular and webgl line glyphs side by side
+- marker_compare.py - to compare regular and webgl markers
 - line10k.py - uses the webgl line glyph
 - scatter10k - uses the webgl circle glyph and selections
 - iris_blend.py - to test color names and blending of semi-transparent glyphs

--- a/sphinx/source/docs/user_guide/webgl.rst
+++ b/sphinx/source/docs/user_guide/webgl.rst
@@ -32,10 +32,11 @@ Support
 -------
 
 Only a subset of Bokeh's objects are capable of rendering in WebGL.
-Currently this is limited to the line, circle marker, and square marker. We plan
-to extend the support to more markers, lines, and other objects such
-as maps. You can safely combine multiple glyphs in a plot, of which
-some are rendered in WebGL, and some are not.
+Currently supported are the circle and line glyphs, and all markers
+supported by ``scatter()`` (asterisk, circle, square, diamond, triangle,
+inverted_triangle, cross, circle_cross, square_cross, diamond_cross,
+x, square_x, circle_x). You can safely combine multiple glyphs in a
+plot, even if some are rendered in WebGL, and some are not.
 
 The performance improvements when using WebGL varies per situation. Due
 to overhead in some places of BokehJS, we can currently not benefit


### PR DESCRIPTION
Implements part of #2590

Markers that we already have:
* circle
* square

Markers that can be done:
* [x] triangle and inverted_triangle
* [x] diamond
* [x] cross, circle_cross, square_cross, diamond_cross
* [x] x, circle_x, square_x
* [x] asterix

Markers that we can/should (probably) not do:
* annulus - can make the shape, but cannot parametrize at this point and API has no default ratio, so skipping for now
* oval, ellipse - same as annulus, but is also more difficult to make shape (can be done though, I think)
* rect
* bezier stuff, etc.

Other tasks in this PR:
* [x] WebGL was broken again (related to canvas element)
* [x] It appears that all WebGL markers are drawn a few pixels off the correct position
* [x] A (visual) test for the above
* [x] Update docs on WebGL
* [x] Investigate WebGL blurryness