### PR TITLE
Comment out css sourcemap generation

### DIFF
--- a/bokehjs/gulp/tasks/styles.coffee
+++ b/bokehjs/gulp/tasks/styles.coffee
@@ -12,20 +12,20 @@ utils = require "../utils"
 
 gulp.task "styles:build", ->
   gulp.src paths.less.sources
-    .pipe sourcemaps.init
-      loadMaps: true
+    # .pipe sourcemaps.init
+    #   loadMaps: true
     .pipe less()
-    .pipe sourcemaps.write './'
+    # .pipe sourcemaps.write './'
     .pipe gulp.dest paths.buildDir.css
 
 gulp.task "styles:minify", ->
   gulp.src paths.css.sources
     .pipe rename (path) -> path.basename += ".min"
     .pipe gulp.dest paths.buildDir.css
-    .pipe sourcemaps.init
-      loadMaps: true
+    # .pipe sourcemaps.init
+    #   loadMaps: true
     .pipe uglifycss()
-    .pipe sourcemaps.write './'
+    # .pipe sourcemaps.write './'
     .pipe gulp.dest paths.buildDir.css
 
 gulp.task "styles", (cb) ->


### PR DESCRIPTION
- [x] issues: fixes #4299 

This hotfix comments out the css sourcemap initialization/write steps, so that css sourcemaps aren't generated during the gulp build process.

This should be a **temporary solution** until the "less" project maintainers merge a bugfix and publish a new release. Here's their issue that tracks the regression: https://github.com/less/less.js/issues/2896

Alternatively, we could shrinkwrap our npm dependencies and modify the less dependency of gulp-less. This would allow us to continue building the css sourcemaps in the interim, but would require more work to modify the travis builds that doesn't seem worth the benefit.

I expect the less folks to have the issue resolved in a matter of hours to a couple of days, then we just uncomment the css sourcemap stuff in a new PR.
