### PR TITLE
Pin less version to 2.6.1

### DIFF
--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -41,6 +41,7 @@
     "gulp-newer": "^1.1.0",
     "gulp-if": "^2.0.0",
     "merge": "^1.2.0",
+    "less": "2.6.1",
     "logtrap": "^0.0.1",
     "hammerjs": "^2.0.4",
     "mocha": "^2.2.5",


### PR DESCRIPTION
- [x] issues: fixes #4299

Pin less version to 2.6.1.

I'd be open to adding a comment to remove this dep in the future, but npm doesn't seem to support comments in package.json files.
