### PR TITLE
Using ArrayBuffers instead of arrays

### DIFF
--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -4,6 +4,7 @@ Bokeh objects.
 """
 from __future__ import absolute_import
 
+from base64 import encodebytes
 from six import iterkeys
 
 from .dependencies import import_optional
@@ -76,14 +77,17 @@ def transform_numerical_array(obj):
     """
     if isinstance(obj, np.ma.MaskedArray):
         obj = obj.filled(np.nan)  # Set masked values to nan
-    if not np.isnan(obj).any() and not np.isinf(obj).any():
-        return obj.tolist()
-    else:
-        transformed = obj.astype('object')
-        transformed[np.isnan(obj)] = 'NaN'
-        transformed[np.isposinf(obj)] = 'Infinity'
-        transformed[np.isneginf(obj)] = '-Infinity'
-        return transformed.tolist()
+    bb = obj.tostring()  # alias for tobytes() but works pre numpy 1.9
+    text = encodebytes(bb).decode()
+    return dict(reviver_type='ArrayBuffer', dtype=str(obj.dtype), data=text)
+    # if not np.isnan(obj).any() and not np.isinf(obj).any():
+    #     return obj.tolist()
+    # else:
+    #     transformed = obj.astype('object')
+    #     transformed[np.isnan(obj)] = 'NaN'
+    #     transformed[np.isposinf(obj)] = 'Infinity'
+    #     transformed[np.isneginf(obj)] = '-Infinity'
+    #     return transformed.tolist()
 
 def traverse_data(datum, is_numpy=is_numpy, use_numpy=True):
     """recursively dig until a flat list is found

--- a/bokehjs/src/coffee/client.coffee
+++ b/bokehjs/src/coffee/client.coffee
@@ -4,6 +4,7 @@ _ = require "underscore"
 HasProps = require "./core/has_props"
 {logger} = require "./core/logging"
 {Document, ModelChangedEvent, RootAddedEvent, RootRemovedEvent} = require "./document"
+{json_parse} = require "./util/jsondecode"
 
 DEFAULT_SERVER_WEBSOCKET_URL = "ws://localhost:5006/ws"
 DEFAULT_SESSION_ID = "default"
@@ -14,9 +15,9 @@ class Message
 
   @assemble : (header_json, metadata_json, content_json) ->
     try
-      header = JSON.parse(header_json)
-      metadata = JSON.parse(metadata_json)
-      content = JSON.parse(content_json)
+      header = json_parse(header_json)
+      metadata = json_parse(metadata_json)
+      content = json_parse(content_json)
       new Message(header, metadata, content)
     catch e
       logger.error("Failure parsing json #{e} #{header_json} #{metadata_json} #{content_json}", e)

--- a/bokehjs/src/coffee/document.coffee
+++ b/bokehjs/src/coffee/document.coffee
@@ -1,6 +1,7 @@
 _ = require "underscore"
 
 {Models} = require "./base"
+{json_parse} = require "./util/jsondecode"
 {Solver} = require "./core/layout/solver"
 {logger} = require "./core/logging"
 HasProps = require "./core/has_props"
@@ -434,7 +435,7 @@ class Document
   @from_json_string : (s) ->
     if s == null or not s?
       throw new Error("JSON string is #{typeof s}")
-    json = JSON.parse(s)
+    json = json_parse(s)
     Document.from_json(json)
 
   @from_json : (json) ->
@@ -519,7 +520,7 @@ class Document
     }
 
   apply_json_patch_string: (patch) ->
-    @apply_json_patch(JSON.parse(patch))
+    @apply_json_patch(json_parse(patch))
 
   apply_json_patch: (patch) ->
     references_json = patch['references']

--- a/bokehjs/src/coffee/embed.coffee
+++ b/bokehjs/src/coffee/embed.coffee
@@ -7,11 +7,12 @@ base = require "./base"
 {pull_session} = require "./client"
 {logger, set_log_level} = require "./core/logging"
 {Document, RootAddedEvent, RootRemovedEvent, TitleChangedEvent} = require "./document"
+{json_parse, revive_docs_json} = require "./util/jsondecode"
 
 _handle_notebook_comms = (msg) ->
   logger.debug("handling notebook comms")
   # @ is bound to the doc
-  data = JSON.parse(msg.content.data)
+  data = json_parse(msg.content.data)
   if 'events' of data and 'references' of data
     @apply_json_patch(data)
   else if 'doc' of data
@@ -149,6 +150,7 @@ fill_render_item_from_script_tag = (script, item) ->
 
 embed_items = (docs_json, render_items, websocket_url=null) ->
   docs = {}
+  docs_json = revive_docs_json(docs_json)
   for docid of docs_json
     docs[docid] = Document.from_json(docs_json[docid])
 

--- a/bokehjs/src/coffee/models/plots/gmap_plot.coffee
+++ b/bokehjs/src/coffee/models/plots/gmap_plot.coffee
@@ -1,6 +1,7 @@
 _ = require "underscore"
 proj4 = require "proj4"
 toProjection = proj4.defs('GOOGLE')
+{json_parse} = require "../../util/jsondecode"
 
 Plot = require "./plot"
 p = require "../../core/properties"
@@ -105,7 +106,7 @@ class GMapPlotView extends Plot.View
         mapTypeId: map_types[mo.map_type]
 
       if mo.styles?
-        map_options.styles = JSON.parse(mo.styles)
+        map_options.styles = json_parse(mo.styles)
 
       # Create the map with above options in div
       @map = new maps.Map(@canvas_view.map_div[0], map_options)

--- a/bokehjs/src/coffee/models/sources/geojson_data_source.coffee
+++ b/bokehjs/src/coffee/models/sources/geojson_data_source.coffee
@@ -2,6 +2,7 @@ _ = require "underscore"
 
 ColumnDataSource = require "./column_data_source"
 {logger} = require "../../core/logging"
+{json_parse} = require "../../util/jsondecode"
 p = require "../../core/properties"
 
 class GeoJSONDataSource extends ColumnDataSource.Model
@@ -104,7 +105,7 @@ class GeoJSONDataSource extends ColumnDataSource.Model
     return count
 
   geojson_to_column_data: () ->
-    geojson = JSON.parse(@get('geojson'))
+    geojson = json_parse(@get('geojson'))
 
     if geojson.type not in ['GeometryCollection', 'FeatureCollection']
       throw new Error('Bokeh only supports type GeometryCollection and FeatureCollection at top level')

--- a/bokehjs/src/coffee/util/jsondecode.coffee
+++ b/bokehjs/src/coffee/util/jsondecode.coffee
@@ -10,27 +10,10 @@ reviver = (k, v) ->
     if v.reviver_type == 'ArrayBuffer'
       data = base64encode2uint8(v.data)
       #console.log('found array data!', v.dtype, v.shape)
-      if v.dtype == 'float32'
-        return new Float32Array(data.buffer)
-      if v.dtype == 'float64'
-        return new Float64Array(data.buffer)
-      if v.dtype == 'int8'
-        return new Int8Array(data.buffer)
-      if v.dtype == 'uint8'
-        return new Uint8Array(data.buffer)
-      if v.dtype == 'int16'
-        return new Int16Array(data.buffer)
-      if v.dtype == 'uint16'
-        return new Uint16Array(data.buffer)
-      if v.dtype == 'int32'
-        return new Int32Array(data.buffer)
-      if v.dtype == 'uint32'
-        return new Uint32Array(data.buffer)
-      if v.dtype == 'int64'
-        return new Int64Array(data.buffer)
-      if v.dtype == 'uint64'
-        return new Uint64Array(data.buffer)
-      throw "Unknown dtype for array: " + dtype
+      Cls = window[v.dtype[0].toUpperCase() + v.dtype.slice(1) + 'Array']
+      if Cls
+        return new Cls(data.buffer)
+      throw "Unknown dtype for array: " + v.dtype
     else
       throw "Unknown reviver_type: " + v.reviver_type
   else
@@ -48,7 +31,6 @@ revive_docs_json = (d) ->
   return d
 
 json_parse = (s) ->
-  throw "wtf"
   return JSON.parse(s, reviver)
 
 module.exports =

--- a/bokehjs/src/coffee/util/jsondecode.coffee
+++ b/bokehjs/src/coffee/util/jsondecode.coffee
@@ -1,0 +1,56 @@
+base64encode2uint8 = (data) ->
+  raw = window.atob(data)  # Convert to string
+  array = new Uint8Array(new ArrayBuffer(raw.length))
+  for i in [0...raw.length]
+    array[i] = raw.charCodeAt(i)
+  return array
+
+reviver = (k, v) ->
+  if v and typeof v is 'object' and v.reviver_type
+    if v.reviver_type == 'ArrayBuffer'
+      data = base64encode2uint8(v.data)
+      #console.log('found array data!', v.dtype, v.shape)
+      if v.dtype == 'float32'
+        return new Float32Array(data.buffer)
+      if v.dtype == 'float64'
+        return new Float64Array(data.buffer)
+      if v.dtype == 'int8'
+        return new Int8Array(data.buffer)
+      if v.dtype == 'uint8'
+        return new Uint8Array(data.buffer)
+      if v.dtype == 'int16'
+        return new Int16Array(data.buffer)
+      if v.dtype == 'uint16'
+        return new Uint16Array(data.buffer)
+      if v.dtype == 'int32'
+        return new Int32Array(data.buffer)
+      if v.dtype == 'uint32'
+        return new Uint32Array(data.buffer)
+      if v.dtype == 'int64'
+        return new Int64Array(data.buffer)
+      if v.dtype == 'uint64'
+        return new Uint64Array(data.buffer)
+      throw "Unknown dtype for array: " + dtype
+    else
+      throw "Unknown reviver_type: " + v.reviver_type
+  else
+    return v
+
+revive_docs_json = (d) ->
+  for key of d
+    val1 = d[key]
+    if typeof val1 is "object"
+       val2 = reviver(key, val1)
+       if val1 is not val2
+          d[key] = val2
+       else
+          revive_docs_json(val1)
+  return d
+
+json_parse = (s) ->
+  throw "wtf"
+  return JSON.parse(s, reviver)
+
+module.exports =
+  json_parse: json_parse
+  revive_docs_json: revive_docs_json


### PR DESCRIPTION
Issues: related to #2204 and #2590

Currently, we serialize arrays to a list of scalars on the Python side, which is then interpreted as a JS Array. When the example contains larger datasets, this bloats the generated HTML document, but JS Arrays are also know to be inefficient (memory wise and speed wise). 

This PR is a start at a possible approach to improve this, to get some discussion going on this topic. This only covers the bit for exporting a plot to an HTML document (i.e. does not include server/websocket stuff yet), and how to unpack it at the JS side. Also, the rest of BokehJS would need some changed to correctly deal with the data being an ArrayBuffer rather than an Array.

For reference, the scatter10k example exports to 222kb instead of 1340kb (6x smaller) with this change (though the difference will be much smaller for examples with little data).

(Higher level discussions should probably occur in #2240 or in a new issue.)