### PR TITLE
Fix toolbar for chrome

### DIFF
--- a/bokehjs/src/coffee/models/tools/button_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/button_tool.coffee
@@ -10,11 +10,7 @@ class ButtonToolButtonView extends Backbone.View
   template: button_tool_template
 
   events: () ->
-    # TODO (bev) this seems to work OK but maybe there is a better way
-    if 'ontouchstart' of document
-      return { 'touchstart .bk-toolbar-button': '_clicked' }
-    else
-      return { 'click .bk-toolbar-button': '_clicked' }
+    return { 'click .bk-toolbar-button': '_clicked' }
 
   initialize: (options) ->
     super(options)


### PR DESCRIPTION
Fixes: #1848 

This is effectively a revert of commit 9e57a12

Couldn't do an actual clean revert due to file having been subsequently moved.

Ping @bryevdv - the original commit is yours. I have done a quick test and I found that, on my phone, I could still click toolbar buttons - but this was not a thorough test. 

We have lots of woes in touch support land (#2997) so I would propose putting this change back in to get desktop users working again and then we can focus on touch later.

I haven't added a test, as I have a lot going on at the moment, and it would be a somewhat involved selenium tests to detect the regression. There's already a test that detects whether buttons can be selected or deselected. But to test the regression we'l'l need to have that test not only run against standard firefox, as all our tests do now, but against a browser with the joint touch functionality. I've added an issue: #4352