### PR TITLE
Make hidpi work for webgl - again

### DIFF
--- a/bokehjs/src/coffee/models/canvas/canvas.coffee
+++ b/bokehjs/src/coffee/models/canvas/canvas.coffee
@@ -69,12 +69,12 @@ class CanvasView extends BokehView
       @$('div.bk-canvas-overlays').attr('style', "z-index:75; position:absolute; top:0; left:0; width:#{width}px; height:#{height}px;")
       @$('div.bk-canvas-events').attr('style', "z-index:100; position:absolute; top:0; left:0; width:#{width}px; height:#{height}px;")
 
-      @ctx.scale(ratio, ratio)
-      @ctx.translate(0.5, 0.5)
-
       @last_dims = [width, height]
 
-    return
+    else
+      ratio = get_scale_ratio(@ctx, @mget('use_hidpi'))
+
+    return ratio
 
   set_dims: (dims, trigger=true) ->
     @requested_width = dims[0]

--- a/bokehjs/src/coffee/models/glyphs/glyph.coffee
+++ b/bokehjs/src/coffee/models/glyphs/glyph.coffee
@@ -53,6 +53,7 @@ class GlyphView extends Renderer.View
       return false
     [sx, sy] = [(dx[1]-dx[0]) / wx, (dy[1]-dy[0]) / wy]
     trans =
+        pixel_ratio: ctx.pixel_ratio,  # pass pixel_ratio to webgl
         width: ctx.glcanvas.width, height: ctx.glcanvas.height,
         dx: dx[0]/sx, dy: dy[0]/sy, sx: sx, sy: sy
     @glglyph.draw(indices, mainglyph, trans)

--- a/bokehjs/src/coffee/models/glyphs/webgl/base.coffee
+++ b/bokehjs/src/coffee/models/glyphs/webgl/base.coffee
@@ -119,4 +119,5 @@ module.exports = {
   line_width: line_width
   attach_float: attach_float
   attach_color: attach_color
+  color2rgba: color2rgba
 }

--- a/bokehjs/src/coffee/models/glyphs/webgl/line.coffee
+++ b/bokehjs/src/coffee/models/glyphs/webgl/line.coffee
@@ -1,6 +1,6 @@
 gloo2 = require "gloo2"
 {logger} = require "../../../core/logging"
-{BaseGLGlyph, line_width, attach_float, attach_color} = require "./base"
+{BaseGLGlyph, line_width, attach_float, attach_color, color2rgba} = require "./base"
 
 
 class DashAtlas
@@ -89,6 +89,7 @@ class LineGLGlyph extends BaseGLGlyph
       const float PI = 3.14159265358979323846264;
       const float THETA = 15.0 * 3.14159265358979323846264/180.0;
 
+      uniform float u_pixel_ratio;
       uniform vec2 u_canvas_size, u_offset;
       uniform vec2 u_scale_aspect;
       uniform float u_scale_length;
@@ -138,7 +139,7 @@ class LineGLGlyph extends BaseGLGlyph
 
           // Attributes and uniforms to varyings
           v_color = u_color;
-          v_linewidth = u_linewidth;
+          v_linewidth = u_linewidth * u_pixel_ratio;
           v_segment = a_segment * u_scale_length;
           v_length = u_length * u_scale_length;
 
@@ -166,7 +167,7 @@ class LineGLGlyph extends BaseGLGlyph
           }
 
           // This is the actual half width of the line
-          float w = ceil(1.25*u_antialias+v_linewidth)/2.0;
+          float w = ceil(u_antialias+v_linewidth)/2.0;
 
           vec2 position = (a_position + u_offset) * abs_scale;
 
@@ -296,8 +297,9 @@ class LineGLGlyph extends BaseGLGlyph
 
           // Calculate position in device coordinates. Note that we
           // already scaled with abs scale above.
-          vec2 normpos = position * sign(u_scale_aspect) - vec2(0.5, 0.5);
-          normpos /= u_canvas_size;  // in 0..1
+          vec2 normpos = position * sign(u_scale_aspect);
+          normpos += 0.5;  // make up for Bokeh's offset
+          normpos /= u_canvas_size / u_pixel_ratio;  // in 0..1
           gl_Position = vec4(normpos*2.0-1.0, 0.0, 1.0);
           gl_Position.y *= -1.0;
       }
@@ -682,6 +684,7 @@ class LineGLGlyph extends BaseGLGlyph
 
       # Handle transformation to device coordinates
       baked_offset = mainGlGlyph._baked_offset
+      @prog.set_uniform('u_pixel_ratio', 'float', [trans.pixel_ratio])
       @prog.set_uniform('u_canvas_size', 'vec2', [trans.width, trans.height])
       @prog.set_uniform('u_offset', 'vec2', [trans.dx - baked_offset[0], trans.dy - baked_offset[1]])
       @prog.set_uniform('u_scale_aspect', 'vec2', [sx, sy])

--- a/bokehjs/src/coffee/models/glyphs/webgl/markers.coffee
+++ b/bokehjs/src/coffee/models/glyphs/webgl/markers.coffee
@@ -11,6 +11,7 @@ class MarkerGLGlyph extends BaseGLGlyph
     precision mediump float;
     const float SQRT_2 = 1.4142135623730951;
     //
+    uniform float u_pixel_ratio;
     uniform vec2 u_canvas_size;
     uniform vec2 u_offset;
     uniform vec2 u_scale;
@@ -32,17 +33,18 @@ class MarkerGLGlyph extends BaseGLGlyph
 
     void main (void)
     {
-        v_size = a_size;
-        v_linewidth = a_linewidth;
+        v_size = a_size * u_pixel_ratio;
+        v_linewidth = a_linewidth * u_pixel_ratio;
         v_fg_color = a_fg_color;
         v_bg_color = a_bg_color;
         v_rotation = vec2(cos(-a_angle), sin(-a_angle));
         // Calculate position - the -0.5 is to correct for canvas origin
-        vec2 pos = (vec2(a_x, a_y) + u_offset) * u_scale - vec2(0.5, 0.5); // in pixels
-        pos /= u_canvas_size;  // in 0..1
+        vec2 pos = (vec2(a_x, a_y) + u_offset) * u_scale; // in pixels
+        pos += 0.5;  // make up for Bokeh's offset
+        pos /= u_canvas_size / u_pixel_ratio;  // in 0..1
         gl_Position = vec4(pos*2.0-1.0, 0.0, 1.0);
         gl_Position.y *= -1.0;
-        gl_PointSize = SQRT_2 * v_size + 2.0 * (a_linewidth + 1.5*u_antialias);
+        gl_PointSize = SQRT_2 * v_size + 2.0 * (v_linewidth + 1.5*u_antialias);
     }
     """
 
@@ -155,6 +157,7 @@ class MarkerGLGlyph extends BaseGLGlyph
     # Handle transformation to device coordinates
     # Note the baked-in offset to avoid float32 precision problems
     baked_offset = mainGlGlyph._baked_offset
+    @prog.set_uniform('u_pixel_ratio', 'float', [trans.pixel_ratio])
     @prog.set_uniform('u_canvas_size', 'vec2', [trans.width, trans.height])
     @prog.set_uniform('u_offset', 'vec2', [trans.dx - baked_offset[0], trans.dy - baked_offset[1]])
     @prog.set_uniform('u_scale', 'vec2', [trans.sx, trans.sy])
@@ -247,7 +250,7 @@ class MarkerGLGlyph extends BaseGLGlyph
     attach_color(@prog, @vbo_fg_color, 'a_fg_color', nvertices, @glyph.visuals.line, 'line')
     attach_color(@prog, @vbo_bg_color, 'a_bg_color', nvertices, @glyph.visuals.fill, 'fill')
     # Static value for antialias. Smaller aa-region to obtain crisper images
-    @prog.set_uniform('u_antialias', 'float', [0.4])
+    @prog.set_uniform('u_antialias', 'float', [0.8])
 
 
 class CircleGLGlyph extends MarkerGLGlyph
@@ -298,7 +301,7 @@ class DiamondGLGlyph extends MarkerGLGlyph
         float x = SQRT_2 / 2.0 * (P.x * 1.5 - P.y);
         float y = SQRT_2 / 2.0 * (P.x * 1.5 + P.y);
         float r1 = max(abs(x), abs(y)) - size / (2.0 * SQRT_2);
-        return r1;
+        return r1 / SQRT_2;
     }
     """
 
@@ -314,7 +317,7 @@ class TriangleGLGlyph extends MarkerGLGlyph
         float y = SQRT_2 / 2.0 * (P.x * 1.7 + P.y);
         float r1 = max(abs(x), abs(y)) - size / 1.6;
         float r2 = P.y;
-        return max(r1, r2);  // Instersect diamond with rectangle
+        return max(r1 / SQRT_2, r2);  // Instersect diamond with rectangle
     }
     """
 
@@ -330,7 +333,7 @@ class InvertedTriangleGLGlyph extends MarkerGLGlyph
         float y = SQRT_2 / 2.0 * (P.x * 1.7 + P.y);
         float r1 = max(abs(x), abs(y)) - size / 1.6;
         float r2 = - P.y;
-        return max(r1, r2);  // Instersect diamond with rectangle
+        return max(r1 / SQRT_2, r2);  // Instersect diamond with rectangle
     }
     """
 
@@ -341,7 +344,7 @@ class CrossGLGlyph extends MarkerGLGlyph
   MARKERCODE: """
     float marker(vec2 P, float size)
     {
-        float square = max(abs(P.x), abs(P.y)) - size/2.0 + 0.5;
+        float square = max(abs(P.x), abs(P.y)) - size / 2.5;  // 2.5 is a tweak
         float cross = min(abs(P.x), abs(P.y)) - size / 100.0;  // bit of "width" for aa
         return max(square, cross);
     }
@@ -355,7 +358,7 @@ class CircleCrossGLGlyph extends MarkerGLGlyph
     float marker(vec2 P, float size)
     {
         // Define quadrants
-        float qs = size / 4.0;  // quadrant size
+        float qs = size / 2.0;  // quadrant size
         float s1 = max(abs(P.x - qs), abs(P.y - qs)) - qs;
         float s2 = max(abs(P.x + qs), abs(P.y - qs)) - qs;
         float s3 = max(abs(P.x - qs), abs(P.y + qs)) - qs;
@@ -379,7 +382,7 @@ class SquareCrossGLGlyph extends MarkerGLGlyph
     float marker(vec2 P, float size)
     {
         // Define quadrants
-        float qs = size / 4.0;  // quadrant size
+        float qs = size / 2.0;  // quadrant size
         float s1 = max(abs(P.x - qs), abs(P.y - qs)) - qs;
         float s2 = max(abs(P.x + qs), abs(P.y - qs)) - qs;
         float s3 = max(abs(P.x - qs), abs(P.y + qs)) - qs;
@@ -403,7 +406,7 @@ class DiamondCrossGLGlyph extends MarkerGLGlyph
     float marker(vec2 P, float size)
     {
         // Define quadrants
-        float qs = size / 4.0;  // quadrant size
+        float qs = size / 2.0;  // quadrant size
         float s1 = max(abs(P.x - qs), abs(P.y - qs)) - qs;
         float s2 = max(abs(P.x + qs), abs(P.y - qs)) - qs;
         float s3 = max(abs(P.x - qs), abs(P.y + qs)) - qs;
@@ -412,6 +415,7 @@ class DiamondCrossGLGlyph extends MarkerGLGlyph
         float x = SQRT_2 / 2.0 * (P.x * 1.5 - P.y);
         float y = SQRT_2 / 2.0 * (P.x * 1.5 + P.y);
         float diamond = max(abs(x), abs(y)) - size / (2.0 * SQRT_2);
+        diamond /= SQRT_2;
         float c1 = max(diamond, s1);
         float c2 = max(diamond, s2);
         float c3 = max(diamond, s3);
@@ -428,9 +432,9 @@ class XGLGlyph extends MarkerGLGlyph
   MARKERCODE: """
     float marker(vec2 P, float size)
     {
-        float square = max(abs(P.x), abs(P.y)) - size/2.0 + 0.5;
+        float circle = length(P) - size / 1.6;
         float X = min(abs(P.x - P.y), abs(P.x + P.y)) - size / 100.0;  // bit of "width" for aa
-        return max(square, X);
+        return max(circle, X);
     }
     """
 
@@ -458,9 +462,9 @@ class CircleXGLGlyph extends MarkerGLGlyph
         // Union
         float almost = min(min(min(c1, c2), c3), c4);
         // In this case, the X is also outside of the main shape
-        float square = max(abs(P.x), abs(P.y)) - size/2.0;
+        float Xmask = length(P) - size / 1.6;  // a circle
         float X = min(abs(P.x - P.y), abs(P.x + P.y)) - size / 100.0;  // bit of "width" for aa
-        return min(max(X, square), almost);
+        return min(max(X, Xmask), almost);
     }
     """
 
@@ -497,11 +501,14 @@ class AsteriskGLGlyph extends MarkerGLGlyph
   MARKERCODE: """
     float marker(vec2 P, float size)
     {
-        float circle = length(P) - size/2.0 + 1.0;
+        // Masks
+        float diamond = max(abs(SQRT_2 / 2.0 * (P.x - P.y)), abs(SQRT_2 / 2.0 * (P.x + P.y))) - size / (2.0 * SQRT_2);
+        float square = max(abs(P.x), abs(P.y)) - size / (2.0 * SQRT_2);
+        // Shapes
         float X = min(abs(P.x - P.y), abs(P.x + P.y)) - size / 100.0;  // bit of "width" for aa
         float cross = min(abs(P.x), abs(P.y)) - size / 100.0;  // bit of "width" for aa
-        float asterisk = min(X, cross);
-        return max(circle, asterisk);  // limit to size of circle
+        // Result is union of masked shapes
+        return min(max(X, diamond), max(cross, square));
     }
     """
 


### PR DESCRIPTION
Reverts bokeh/bokeh#4358

Ping @almarklein. #4358 reverts your original PR. This PR exists to restore that work. I had bad merge results and so wanted to look at this again. Sorry for the noise.

----
Original message:

Issues: fixes #4293. This is like #4346 but without the browser-zoom update stuff.

This PR:
* makes WebGL aware of the pixel_ratio for HDPI support. 
* improves/simplifies the blitting of the gl canvas into the 2d canvas. 
* tweaks some WebGL markers to look better when zoomed in.
* ~~makes plot update when the browser zoom is changed.~~

Consequently, our WebGL glyphs have never looked so nice! Maybe even nicer than the 2D glyphs (due to better aa). Should also look great on retina displays now.