### PR TITLE
Adjust hidpi on browser zoom (against layout branch)

### DIFF
--- a/bokehjs/src/coffee/models/canvas/canvas.coffee
+++ b/bokehjs/src/coffee/models/canvas/canvas.coffee
@@ -45,14 +45,16 @@ class CanvasView extends BokehView
     ctx = canvas_el[0].getContext('2d')
     return ctx
 
-  render: (force=false) ->
+  prepare_canvas: (force=false) ->
+    # Ensure canvas has the correct size, taking HIDPI into account
+    # returns true if the canvas was updated
 
     width = @model._width._value
     height = @model._height._value
+    dpr = window.devicePixelRatio
 
     # only render the canvas when the canvas dimensions change unless force==true
-    if not _.isEqual(@last_dims, [width, height]) or force
-
+    if not _.isEqual(@last_dims, [width, height, dpr]) or force
 
       @$el.css({
         width: width
@@ -60,7 +62,7 @@ class CanvasView extends BokehView
       })
 
       # Scale the canvas
-      ratio = get_scale_ratio(@ctx, @mget('use_hidpi'))
+      @pixel_ratio = ratio = get_scale_ratio(@ctx, @mget('use_hidpi'))
       canvas_el = @$('.bk-canvas')
       canvas_el.css({
         width: width
@@ -70,12 +72,8 @@ class CanvasView extends BokehView
       canvas_el.attr('height', height*ratio)
 
       logger.debug("Rendering CanvasView [force=#{force}] with width: #{width}, height: #{height}, ratio: #{ratio}")
-      @last_dims = [width, height]
-
-    else
-      ratio = get_scale_ratio(@ctx, @mget('use_hidpi'))
-
-    return ratio
+      @last_dims = [width, height, dpr]
+      return true
 
   set_dims: (dims, trigger=true) ->
     @requested_width = dims[0]

--- a/bokehjs/src/coffee/models/glyphs/webgl/line.coffee
+++ b/bokehjs/src/coffee/models/glyphs/webgl/line.coffee
@@ -654,6 +654,8 @@ class LineGLGlyph extends BaseGLGlyph
       mainGlGlyph = mainGlyph.glglyph
 
       if mainGlGlyph.data_changed
+        if not (isFinite(trans.dx) and isFinite(trans.dy))
+          return  # not sure why, but it happens on init sometimes (#4367)
         mainGlGlyph._baked_offset = [trans.dx, trans.dy]  # float32 precision workaround; used in _bake() and below
         mainGlGlyph._set_data()
         mainGlGlyph.data_changed = false

--- a/bokehjs/src/coffee/models/glyphs/webgl/markers.coffee
+++ b/bokehjs/src/coffee/models/glyphs/webgl/markers.coffee
@@ -141,6 +141,8 @@ class MarkerGLGlyph extends BaseGLGlyph
 
     # Upload data if we must. Only happens for main glyph.
     if mainGlGlyph.data_changed
+      if not (isFinite(trans.dx) and isFinite(trans.dy))
+          return  # not sure why, but it happens on init sometimes (#4367)
       mainGlGlyph._baked_offset = [trans.dx, trans.dy]  # float32 precision workaround; used in _set_data() and below
       mainGlGlyph._set_data(nvertices)
       mainGlGlyph.data_changed = false

--- a/bokehjs/src/coffee/models/plots/plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.coffee
@@ -406,8 +406,8 @@ class PlotCanvasView extends Renderer.View
     ctx = @canvas_view.ctx
 
     # Get hidpi ratio
-    ratio = @canvas_view.render(force_canvas)
-    ctx.pixel_ratio = ratio  # we need this in WebGL
+    @canvas_view.prepare_canvas(force_canvas)
+    ctx.pixel_ratio = ratio = @canvas_view.pixel_ratio  # Also store on cts for WebGL
 
     # Set hidpi-transform
     ctx.save()  # Save default state, do *after* getting ratio, cause setting canvas.width resets transforms


### PR DESCRIPTION
Fixes #4345 and fixes #4367.

This makes the hidpi pixel ratio adapt when the browser zoom changes. This turned out to be easier than the original PR that I made against master earlier (#4346), because we already get an update now when the browser zoom changes.

I tested that all the HIDPI stuff works in embedded plots as well. This means that the document does an update when it gets a `window.resize` event, regardless whether the size did not actually change, and regardless whether the plot is embedded or not. In case someone ever tries to add efficiency here, please keep in mind this use-case.

cc @birdsarah 