### PR TITLE
Updated package requirements for building docs

### DIFF
--- a/sphinx/source/docs/dev_guide/documentation.rst
+++ b/sphinx/source/docs/dev_guide/documentation.rst
@@ -7,16 +7,14 @@ Requirements
 ------------
 
 We use Sphinx_ to generate our HTML documentation. You will need the following
-packages installed in order to build Bokeh documentation:
+packages installed in order to build and view the Bokeh documentation:
 
 * docutils
 * sphinx
-* sphinxcontrib-httpdomain
-* seaborn
 * pygments
 * yaml
 * pyyaml
-* ggplot
+* flask
 
 These can be installed using ``conda`` or ``pip`` or from source. In
 addition to the package requirements, you will also need to have the sample


### PR DESCRIPTION
Fixes #4020, among others.
Removed `sphinxcontrib-httpdomain`, `ggplot` and `seaborn` from the list of packages required to build the docs. Added `flask` (which is required to run the docserver). I wasn't exactly sure about `ggplot` and `seaborn`, but I could successfully build the docs without them and had the impression that everything was where it belonged. Are these still required anywhere?