### PR TITLE
Changed docserver shutdown instruction.

### DIFF
--- a/sphinx/docserver.py
+++ b/sphinx/docserver.py
@@ -54,7 +54,7 @@ def shutdown_server():
 
 def ui():
     time.sleep(0.5)
-    input("Press any key to exit...")
+    input("Press <ENTER> to exit...\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As commented on my previous PR #4033, changed message during docserver startup from 

    Press any key to exit...

to

    Press <ENTER> to exit...