### PR TITLE
Chord diagram colors

### DIFF
--- a/bokeh/charts/builders/chord_builder.py
+++ b/bokeh/charts/builders/chord_builder.py
@@ -16,7 +16,7 @@ functions.
 # -----------------------------------------------------------------------------
 # Imports
 # -----------------------------------------------------------------------------
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import numpy as np
 import pandas as pd

--- a/bokeh/charts/builders/tests/test_chord_builder.py
+++ b/bokeh/charts/builders/tests/test_chord_builder.py
@@ -1,0 +1,20 @@
+""" This is the Bokeh charts testing interface for the Chord Diagram
+
+"""
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+from __future__ import absolute_import
+
+from bokeh.charts.builders.chord_builder import ChordBuilder
+
+#-----------------------------------------------------------------------------
+# Classes and functions
+#-----------------------------------------------------------------------------
+
+def test_colors(test_data):
+    builder = ChordBuilder(test_data.pd_data, origin='col1', destination='col2')
+    builder.create()
+    colors = builder.connection_data.data['colors']
+    assert colors[0] != colors[1]


### PR DESCRIPTION
Color generation in the chord builder is on line 138. 

```python
colors = [color_in_equal_space(area / areas_in_radians.shape[0]) for area in range(areas_in_radians.shape[0])]
```

In Python 2.7, ```colors``` becomes a list of all the same color because ```area / area_in_radians.shape[0]``` is always 0. 

To fix this, I added ```division``` to the ```from __future__``` import statement. 

- [x] issues: fixes #4435
- [x] tests added / passed
- [ NA ] release document entry (if new feature or API change)
