### PR TITLE
Feature/multiple processes

### DIFF
--- a/bokeh/application/application.py
+++ b/bokeh/application/application.py
@@ -149,6 +149,10 @@ class Application(object):
         return tuple(self._handlers)
 
     @property
+    def safe_to_fork(self):
+        return all(handler.safe_to_fork for handler in self._handlers)
+
+    @property
     def static_path(self):
         return self._static_path
 

--- a/bokeh/application/handlers/code.py
+++ b/bokeh/application/handlers/code.py
@@ -110,3 +110,7 @@ class CodeHandler(Handler):
     @property
     def error_detail(self):
         return self._runner.error_detail
+
+    @property
+    def safe_to_fork(self):
+        return not self._runner.ran

--- a/bokeh/application/handlers/code_runner.py
+++ b/bokeh/application/handlers/code_runner.py
@@ -31,6 +31,7 @@ class _CodeRunner(object):
         self._path = path
         self._source = source
         self._argv = argv
+        self.ran = False
 
     @property
     def source(self):
@@ -96,3 +97,4 @@ class _CodeRunner(object):
             os.chdir(_cwd)
             sys.path = _sys_path
             sys.argv = _sys_argv
+            self.ran = True

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -142,7 +142,7 @@ processes
 
 .. code-block:: sh
 
-    bokeh serve app_script.py --num_procs 2
+    bokeh serve app_script.py --num-procs 2
 
 By default, cross site connections to the Bokeh server websocket are not
 allowed. You can enable websocket connections originating from additional

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -373,7 +373,6 @@ class Serve(Subcommand):
     name = "serve"
 
     help = "Run a Bokeh server hosting one or more applications"
-
     args = base_serve_args + (
         ('files', dict(
             metavar='DIRECTORY-OR-SCRIPT',
@@ -469,6 +468,15 @@ class Serve(Subcommand):
             action = 'store_true',
             help    = 'Do not redirect to running app from root path',
         )),
+
+        ('--nprocs', dict(
+            metavar='N',
+            action='store',
+            help="Number of worker processes for app. Default to one. Using "
+                 "0 will autodetect number of cores",
+            default=1,
+            type=int,
+        )),
     )
 
 
@@ -510,6 +518,7 @@ class Serve(Subcommand):
                                                               'address',
                                                               'allow_websocket_origin',
                                                               'host',
+                                                              'nprocs',
                                                               'prefix',
                                                               'develop',
                                                               'keep_alive_milliseconds',

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -134,6 +134,16 @@ the end users.
 Also note that the host whitelist applies to all request handlers,
 including any extra ones added to extend the Bokeh server.
 
+Bokeh server can fork the underlying tornado server into multiprocess.  This is
+useful when trying to handle multiple connections especially in the context of
+apps which require high computational loads.  Default behavior is one process.
+using 0 will auto-detect the number of cores and spin up corresponding number of
+processes
+
+.. code-block:: sh
+
+    bokeh serve app_script.py --num_procs 2
+
 By default, cross site connections to the Bokeh server websocket are not
 allowed. You can enable websocket connections originating from additional
 hosts by specifying them with the ``--allow-websocket-origin`` option:
@@ -469,10 +479,10 @@ class Serve(Subcommand):
             help    = 'Do not redirect to running app from root path',
         )),
 
-        ('--nprocs', dict(
+        ('--num-procs', dict(
             metavar='N',
             action='store',
-            help="Number of worker processes for app. Default to one. Using "
+            help="Number of worker processes for an app. Default to one. Using "
                  "0 will autodetect number of cores",
             default=1,
             type=int,
@@ -518,7 +528,7 @@ class Serve(Subcommand):
                                                               'address',
                                                               'allow_websocket_origin',
                                                               'host',
-                                                              'nprocs',
+                                                              'num_procs',
                                                               'prefix',
                                                               'develop',
                                                               'keep_alive_milliseconds',

--- a/bokeh/command/subcommands/tests/test_serve.py
+++ b/bokeh/command/subcommands/tests/test_serve.py
@@ -147,4 +147,13 @@ def test_args():
             action = 'store_true',
             help    = 'Do not redirect to running app from root path',
         )),
+
+        ('--num-procs', dict(
+             metavar='N',
+             action='store',
+             help="Number of worker processes for an app. Default to one. Using "
+                  "0 will autodetect number of cores",
+             default=1,
+             type=int,
+         )),
     )

--- a/bokeh/server/application_context.py
+++ b/bokeh/server/application_context.py
@@ -18,7 +18,7 @@ from bokeh.util.tornado import _CallbackGroup, yield_for_all_futures
 class BokehServerContext(ServerContext):
     def __init__(self, application_context):
         self.application_context = application_context
-        self._callbacks = _CallbackGroup(self.application_context.io_loop)
+        self._callbacks = _CallbackGroup() #self.application_context.io_loop)
 
     def _remove_all_callbacks(self):
         self._callbacks.remove_all_callbacks()
@@ -92,7 +92,7 @@ class ApplicationContext(object):
         self._sessions = dict()
         self._pending_sessions = dict()
         self._session_contexts = dict()
-        self._server_context = BokehServerContext(self)
+        self._server_context = None
 
     @property
     def io_loop(self):
@@ -108,6 +108,8 @@ class ApplicationContext(object):
 
     @property
     def server_context(self):
+        if self._server_context is None:
+            self._server_context = BokehServerContext(self)
         return self._server_context
 
     @property

--- a/bokeh/server/server.py
+++ b/bokeh/server/server.py
@@ -100,14 +100,17 @@ class Server(object):
         self._tornado = BokehTornado(self._applications, self.prefix, **tornado_kwargs)
         self._http = HTTPServer(self._tornado, xheaders=kwargs.get('use_xheaders', False))
         self._address = None
+
         if 'address' in kwargs:
             self._address = kwargs['address']
+
+        self._nprocs = kwargs.get('nprocs', 1)
 
         # these queue a callback on the ioloop rather than
         # doing the operation immediately (I think - havocp)
         try:
             self._http.bind(self._port, address=self._address)
-            self._http.start(0)
+            self._http.start(self._nprocs)
             self._tornado.initialize(**tornado_kwargs)
         except OSError as e:
             import errno

--- a/bokeh/server/server.py
+++ b/bokeh/server/server.py
@@ -58,6 +58,9 @@ class Server(object):
             mapping from URL paths to Application instances, or a single Application to put at the root URL
             The Application is a factory for Document, with a new Document initialized for each Session.
             Each application should be identified by a path meant to go in a URL, like "/" or "/foo"
+    Kwargs:
+        num_procs (str):
+            Number of worker processes for an app. Default to one. Using 0 will autodetect number of cores
     '''
 
     def __init__(self, applications, **kwargs):

--- a/bokeh/server/server.py
+++ b/bokeh/server/server.py
@@ -104,13 +104,13 @@ class Server(object):
         if 'address' in kwargs:
             self._address = kwargs['address']
 
-        self._nprocs = kwargs.get('nprocs', 1)
+        self._num_procs = kwargs.get('num_procs', 1)
 
         # these queue a callback on the ioloop rather than
         # doing the operation immediately (I think - havocp)
         try:
             self._http.bind(self._port, address=self._address)
-            self._http.start(self._nprocs)
+            self._http.start(self._num_procs)
             self._tornado.initialize(**tornado_kwargs)
         except OSError as e:
             import errno

--- a/bokeh/server/server.py
+++ b/bokeh/server/server.py
@@ -108,6 +108,10 @@ class Server(object):
             self._address = kwargs['address']
 
         self._num_procs = kwargs.get('num_procs', 1)
+        if self._num_procs != 1:
+            assert all(app.safe_to_fork for app in self._applications.values()), (
+                      'User code has ran before attempting to run multiple '
+                      'processes. This is considered an unsafe operation.')
 
         # these queue a callback on the ioloop rather than
         # doing the operation immediately (I think - havocp)

--- a/bokeh/server/server.py
+++ b/bokeh/server/server.py
@@ -107,7 +107,8 @@ class Server(object):
         # doing the operation immediately (I think - havocp)
         try:
             self._http.bind(self._port, address=self._address)
-            self._http.start(1)
+            self._http.start(0)
+            self._tornado.initialize(**tornado_kwargs)
         except OSError as e:
             import errno
             if e.errno == errno.EADDRINUSE:

--- a/bokeh/server/tests/test_server.py
+++ b/bokeh/server/tests/test_server.py
@@ -4,7 +4,7 @@ import pytest
 import logging
 import re
 
-from unittest.mock import patch
+import mock
 
 from tornado import gen
 from tornado.ioloop import PeriodicCallback, IOLoop
@@ -450,7 +450,7 @@ def test__no_generate_session_doc():
         assert 0 == len(sessions)
 
 def test__server_multiple_processes():
-    with patch('tornado.process.fork_processes') as tornado_fp:
+    with mock.patch('tornado.process.fork_processes') as tornado_fp:
         application = Application()
         with ManagedServerLoop(application, num_procs=3) as server:
             pass

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -272,7 +272,6 @@ class BokehTornado(TornadoApplication):
 
         self._clients = set()
         self._executor = ProcessPoolExecutor(max_workers=4)
-        print(self._loop)
         self._loop.add_callback(self._start_async)
         self._stats_job = PeriodicCallback(self.log_stats,
                                            stats_log_frequency_milliseconds,

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -169,10 +169,6 @@ class BokehTornado(TornadoApplication):
         self._prefix = prefix
         self.use_index = use_index
 
-        if io_loop is None:
-            io_loop = IOLoop.current()
-        self._loop = io_loop
-
         if keep_alive_milliseconds < 0:
             # 0 means "disable"
             raise ValueError("keep_alive_milliseconds must be >= 0")
@@ -200,7 +196,7 @@ class BokehTornado(TornadoApplication):
         # Wrap applications in ApplicationContext
         self._applications = dict()
         for k,v in applications.items():
-            self._applications[k] = ApplicationContext(v, self._develop, self._loop)
+            self._applications[k] = ApplicationContext(v, self._develop)
 
         extra_patterns = extra_patterns or []
         all_patterns = []
@@ -255,8 +251,28 @@ class BokehTornado(TornadoApplication):
 
         super(BokehTornado, self).__init__(all_patterns)
 
+    def initialize(self,
+                 io_loop=None,
+                 keep_alive_milliseconds=37000,
+                 # how often to check for unused sessions
+                 check_unused_sessions_milliseconds=17000,
+                 # how long unused sessions last
+                 unused_session_lifetime_milliseconds=15000,
+                 # how often to log stats
+                 stats_log_frequency_milliseconds=15000,
+                 develop=False,
+                 **kw):
+
+        if io_loop is None:
+            io_loop = IOLoop.current()
+        self._loop = io_loop
+
+        for app_context in self._applications.values():
+            app_context._loop = self._loop
+
         self._clients = set()
         self._executor = ProcessPoolExecutor(max_workers=4)
+        print(self._loop)
         self._loop.add_callback(self._start_async)
         self._stats_job = PeriodicCallback(self.log_stats,
                                            stats_log_frequency_milliseconds,

--- a/bokeh/util/tornado.py
+++ b/bokeh/util/tornado.py
@@ -79,7 +79,7 @@ class _CallbackGroup(object):
     """ A collection of callbacks added to a Tornado IOLoop that we may
     want to remove as a group. """
 
-    def __init__(self, io_loop):
+    def __init__(self, io_loop=None):
         if io_loop is None:
             raise ValueError("must provide an io loop")
         self._loop = io_loop
@@ -188,7 +188,7 @@ class _CallbackGroup(object):
         self._remove(callback, self._periodic_callbacks)
 
 class _DocumentCallbackGroup(object):
-    def __init__(self, io_loop):
+    def __init__(self, io_loop=None):
         self._group = _CallbackGroup(io_loop)
         # from callback ids to removers
         self._removers = dict()

--- a/sphinx/source/docs/reference/server.rst
+++ b/sphinx/source/docs/reference/server.rst
@@ -5,3 +5,11 @@
 
 .. automodule:: bokeh.server
   :members:
+
+.. _bokeh.server.server:
+
+``bokeh.server.server``
+''''''''''''''''''''''''
+
+.. automodule:: bokeh.server.server
+   :members:

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -1066,6 +1066,20 @@ And to update the process control after editing the config file, run:
 
     supervisorctl -c /path/to/supervisord.conf update
 
+.. _userguide_server_scaling:
+
+Scaling the server
+~~~~~~~~~~~~~~~~~~
+
+You can fork multiple server processes with the `num-procs` option. For example, to fork 3 processes:
+
+.. code-block:: sh
+
+    bokeh serve --num-procs 3
+
+Note that the forking operation happens in the underlying Tornado Server, see notes in the `Tornado docs`_.
+
+.. _Tornado docs: http://www.tornadoweb.org/en/stable/tcpserver.html#tornado.tcpserver.TCPServer.start
 
 .. _userguide_server_deployment_automation:
 


### PR DESCRIPTION
- [x] issues: fixes #4363
- [x] tests added / passed
- [ ] release document entry

This PR is to continue the work done in PR #4364, which addresses Issue #4363 

From the Tornado docs:

> Note that multiple processes are not compatible with the autoreload
> module (or the ``autoreload=True`` option to `tornado.web.Application`
> which defaults to True when ``debug=True``).
> When using multiple processes, no IOLoops can be created or
> referenced until after the call to ``TCPServer.start(n)``.

I'd like to think more about how this affects bokeh and the way it references IOLoops