### PR TITLE
Fix bug in throttling of render

### DIFF
--- a/bokehjs/src/coffee/core/util/throttle.coffee
+++ b/bokehjs/src/coffee/core/util/throttle.coffee
@@ -35,7 +35,7 @@ throttle = (func, wait) ->
       clearTimeout(timeout)
       pending = true
       delay_animation(later)
-    else if (!timeout)
+    else if (!timeout and !pending)
       timeout = setTimeout((-> delay_animation(later)), remaining)
     return result
 


### PR DESCRIPTION
This PR fixes a bug where multiple calls to ```request_render``` in the same throttling interval will cause two renders when it should only cause one.

The fix is to make sure that any calls to ```request_render``` don't generate a new render (through setTimeout) when one is already pending. 

I didn't add any tests for this. I would need some guidance on how that should be done if anyone has any ideas. 

- [x] issues: fixes #4439
- [ ] tests added / passed
- [ NA ] release document entry (if new feature or API change)

