### PR TITLE
Add styling to bokeh apps index page and add docs

### DIFF
--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -67,6 +67,14 @@ Note that if multiple scripts or directories are provided, they
 all receive the same set of command line arguments (if any) given by
 ``--args``.
 
+You can see an index of all running applications at the server root:
+
+.. code-block:: none
+
+    http://localhost:5006/
+
+This index can be disabled with the ``--disable-index`` option
+
 Network Configuration
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -462,6 +462,11 @@ class Serve(Subcommand):
             action = 'store_true',
             help    = 'Do not use the default index on the root path',
         )),
+
+        ('--disable-index-redirect', dict(
+            action = 'store_true',
+            help    = 'Do not redirect to running app from root path',
+        )),
     )
 
 
@@ -535,6 +540,7 @@ class Serve(Subcommand):
                 "the `bokeh secret` command can be used to generate a new key.")
 
         server_kwargs['use_index'] = not args.disable_index
+        server_kwargs['redirect_root'] = not args.disable_index_redirect
 
         server = Server(applications, **server_kwargs)
 

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -67,13 +67,15 @@ Note that if multiple scripts or directories are provided, they
 all receive the same set of command line arguments (if any) given by
 ``--args``.
 
-You can see an index of all running applications at the server root:
+If you have only one application, the server root will redirect to it.
+Otherwise, You can see an index of all running applications at the server root:
 
 .. code-block:: none
 
     http://localhost:5006/
 
-This index can be disabled with the ``--disable-index`` option
+This index can be disabled with the ``--disable-index`` option, and the redirect
+behavior can be disabled with the ``--disable-index-redirect`` option.
 
 Network Configuration
 ~~~~~~~~~~~~~~~~~~~~~

--- a/bokeh/command/subcommands/tests/test_serve.py
+++ b/bokeh/command/subcommands/tests/test_serve.py
@@ -142,4 +142,9 @@ def test_args():
             action = 'store_true',
             help    = 'Do not use the default index on the root path',
         )),
+
+        ('--disable-index-redirect', dict(
+            action = 'store_true',
+            help    = 'Do not redirect to running app from root path',
+        )),
     )

--- a/bokeh/server/server.py
+++ b/bokeh/server/server.py
@@ -95,6 +95,7 @@ class Server(object):
         tornado_kwargs['hosts'] = _create_hosts_whitelist(kwargs.get('host', None), self._port)
         tornado_kwargs['extra_websocket_origins'] = _create_hosts_whitelist(kwargs.get('allow_websocket_origin', None), self._port)
         tornado_kwargs['use_index'] = kwargs.get('use_index', True)
+        tornado_kwargs['redirect_root'] = kwargs.get('redirect_root', True)
 
         self._tornado = BokehTornado(self._applications, self.prefix, **tornado_kwargs)
         self._http = HTTPServer(self._tornado, xheaders=kwargs.get('use_xheaders', False))

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -163,7 +163,8 @@ class BokehTornado(TornadoApplication):
                  # how often to log stats
                  stats_log_frequency_milliseconds=15000,
                  develop=False,
-                 use_index=True):
+                 use_index=True,
+                 redirect_root=True):
 
         self._prefix = prefix
         self.use_index = use_index
@@ -236,7 +237,9 @@ class BokehTornado(TornadoApplication):
         for p in extra_patterns + toplevel_patterns:
             if p[1] == RootHandler:
                 if self.use_index:
-                    data = {"applications": self._applications, "prefix": self._prefix}
+                    data = {"applications": self._applications,
+                            "prefix": self._prefix,
+                            "use_redirect": redirect_root}
                     prefixed_pat = (self._prefix + p[0],) + p[1:] + (data,)
                     all_patterns.append(prefixed_pat)
             else:

--- a/bokeh/server/views/app_index.html
+++ b/bokeh/server/views/app_index.html
@@ -44,7 +44,6 @@
            <li><a href={{ item }}>{{ item[1:] }}</a></li>
          {% end %}
        </ul>
-      <p>To disable this index page, launch Bokeh server with the --disable-index option<p>
     </div>
   </div>
 

--- a/bokeh/server/views/app_index.html
+++ b/bokeh/server/views/app_index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+
+  <!-- Basic Page Needs
+  –––––––––––––––––––––––––––––––––––––––––––––––––– -->
+  <meta charset="utf-8">
+  <title>Active Apps</title>
+
+  <!-- Mobile Specific Metas
+  –––––––––––––––––––––––––––––––––––––––––––––––––– -->
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <!-- FONT
+  –––––––––––––––––––––––––––––––––––––––––––––––––– -->
+  <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600%7CNoto+Sans:400,700' rel='stylesheet' type='text/css'>
+
+  <!-- CSS
+  –––––––––––––––––––––––––––––––––––––––––––––––––– -->
+  <link rel="stylesheet" href="http://bokehplots.com/theme/css/main.css">
+
+  <!-- Favicon
+  –––––––––––––––––––––––––––––––––––––––––––––––––– -->
+  <link rel="icon" type="image/png" href="http://bokeh.pydata.org/en/latest/_static/images/favicon.ico">
+
+</head>
+<body class="">
+
+  <header class="navigation">
+    <div class="wrapper">
+      <a href="http://bokeh.pydata.org" class="logo">
+        <img src="http://bokeh.pydata.org/en/latest/_static/images/logo.png" alt="Bokeh Logo">
+      </a>
+      <a href="#" class="navigation-menu logo-text">Bokeh</a>
+    </div>
+  </header>
+
+  <div class="docs section wrapper">
+    <div class="content">
+       <h1>Active Bokeh Applications</h1>
+       Current Running applications:
+       <ul>
+         {% for item in items %}
+           <li><a href={{ item }}>{{ item[1:] }}</a></li>
+         {% end %}
+       </ul>
+      <p>To disable this index page, launch Bokeh server with the --disable-index option<p>
+    </div>
+  </div>
+
+
+ </body>
+</html>

--- a/bokeh/server/views/root_handler.py
+++ b/bokeh/server/views/root_handler.py
@@ -16,17 +16,15 @@ class RootHandler(RequestHandler):
     ''' Implements a custom Tornado handler to display the available applications
     If only one application it redirects to that application route
     '''
-    def __init__(self, tornado_app, *args, **kw):
-        super(RootHandler, self).__init__(tornado_app, *args, **kw)
-        # self.applications = None
 
     def initialize(self, *args, **kw):
         self.applications = kw["applications"]
         self.prefix = kw["prefix"]
+        self.use_redirect = kw["use_redirect"]
 
     @gen.coroutine
     def get(self, *args, **kwargs):
-        if len(self.applications) == 1:
+        if self.use_redirect and len(self.applications) == 1:
             app_names = list(self.applications.keys())
             redirect_to = (self.prefix if self.prefix else "") + app_names[0]
             self.redirect(redirect_to)

--- a/bokeh/server/views/root_handler.py
+++ b/bokeh/server/views/root_handler.py
@@ -26,4 +26,9 @@ class RootHandler(RequestHandler):
 
     @gen.coroutine
     def get(self, *args, **kwargs):
-        self.render("app_index.html", items=self.applications.keys())
+        if len(self.applications) == 1:
+            app_names = list(self.applications.keys())
+            redirect_to = (self.prefix if self.prefix else "") + app_names[0]
+            self.redirect(redirect_to)
+        else:
+            self.render("app_index.html", items=self.applications.keys())

--- a/bokeh/server/views/root_handler.py
+++ b/bokeh/server/views/root_handler.py
@@ -26,12 +26,4 @@ class RootHandler(RequestHandler):
 
     @gen.coroutine
     def get(self, *args, **kwargs):
-        if len(self.applications) == 1:
-            app_names = list(self.applications.keys())
-            redirect_to = (self.prefix if self.prefix else "") + app_names[0]
-            self.redirect(redirect_to)
-        else:
-            self.write("<ul>")
-            for app_route, _ in self.applications.items():
-                self.write("<li><a href={0}>{0}</a></li>".format(app_route))
-            self.write("</ul>")
+        self.render("app_index.html", items=self.applications.keys())

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -12,7 +12,7 @@ The architecture of Bokeh is such that high-level "model objects"
 (representing things like plots, ranges, axes, glyphs, etc.) are created
 in Python, and then converted to a JSON format that is consumed by the
 client library, BokehJS. (See :ref:`userguide_concepts` for a more detailed
-disussion.) By itself, this flexible and decoupled design offers advantages,
+discussion.) By itself, this flexible and decoupled design offers advantages,
 for instance it is easy to have other languages (R, Scala, Lua, ...) drive
 the exact same Bokeh plots and visualizations in the browser.
 
@@ -23,7 +23,7 @@ possibilities immediately open up:
 * respond to UI and tool events generated in a browser with computations or
   queries using the full power of python
 * automatically push updates the UI (i.e. widgets or plots), in a browser
-* use periodic, timeout, and asychronous callbacks drive streaming updates
+* use periodic, timeout, and asynchronous callbacks drive streaming updates
 
 **This capability to synchronize between python and the browser is the main
 purpose of the Bokeh Server.**
@@ -324,13 +324,15 @@ to the address of the running application, which in this case is:
 
     http://localhost:5006/myapp
 
-You can see an index of all running applications at the server root:
+If you have only one application, the server root will redirect to it.
+Otherwise, You can see an index of all running applications at the server root:
 
 .. code-block:: none
 
     http://localhost:5006/
 
-This index can be disabled with the ``--disable-index`` option
+This index can be disabled with the ``--disable-index`` option, and the redirect
+behavior can be disabled with the ``--disable-index-redirect`` option.
 
 In addition to creating Bokeh applications from single python files, it is
 also possible to create applications from directories.

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -324,6 +324,14 @@ to the address of the running application, which in this case is:
 
     http://localhost:5006/myapp
 
+You can see an index of all running applications at the server root:
+
+.. code-block:: none
+
+    http://localhost:5006/
+
+This index can be disabled with the ``--disable-index`` option
+
 In addition to creating Bokeh applications from single python files, it is
 also possible to create applications from directories.
 


### PR DESCRIPTION
Solves issue #4425 

This makes the server app index presentable

Here is a screenshot of the index page for two running applications:

<img width="796" alt="screen shot 2016-06-04 at 6 33 40 pm" src="https://cloud.githubusercontent.com/assets/1609952/15803115/fe6b2054-2a82-11e6-8802-493ecfff85a2.png">

- [ ] issues: fixes #xxxx
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
