### PR TITLE
De-duplicate helptools with the same redirect

### DIFF
--- a/bokehjs/src/coffee/models/tools/toolbar_box.coffee
+++ b/bokehjs/src/coffee/models/tools/toolbar_box.coffee
@@ -50,6 +50,14 @@ class ToolbarBoxToolbar extends ToolbarBase.Model
     actions = {}
     gestures = {}
 
+    new_help_tools = []
+    new_help_urls = []
+    for helptool in @help
+      if not _.contains(new_help_urls, helptool.redirect)
+        new_help_tools.push(helptool)
+        new_help_urls.push(helptool.redirect)
+    @help = new_help_tools
+
     for event_type, info of @gestures
       if event_type not of gestures
         gestures[event_type] = {}


### PR DESCRIPTION
Fixes #4385

Helptools that have the same `redirect` attribute are "combined" (as in only the first is used). The `help_tooltip` attribute is ignored in the comparison.

To test (a variation on the code mentioned in #4385):
```python
import numpy as np

from bokeh.plotting import figure, gridplot, output_file, show
from bokeh.models.tools import HelpTool, WheelZoomTool

n = 50

x = np.linspace(0, 4*np.pi, n)
y = np.sin(x)

tools = "pan,wheel_zoom,box_zoom,reset,save,crosshair,help"

l = figure(title="line", tools=tools, plot_width=300, plot_height=300)
l.line(x,y, line_width=3, color="gold")

aw = figure(title="annular wedge", tools=tools, plot_width=300, plot_height=300)
aw.annular_wedge(x, y, 10, 20, 0.6, 4.1, color="navy", alpha=0.5,
    inner_radius_units="screen", outer_radius_units="screen")

bez = figure(title="bezier", tools=tools, plot_width=300, plot_height=300)
bez.bezier(x, y, x+0.4, y, x+0.1, y+0.2, x-0.1, y-0.2,
    line_width=2, color="olive")


tools = WheelZoomTool(), HelpTool(redirect='http://stackoverflow.com/', help_tooltip='look it up')
q = figure(title="quad", tools=tools, plot_width=300, plot_height=300)
q.quad(x, x-0.2, y, y-0.2, color="tomato", alpha=0.4)

# specify "empty" grid cells with none
p = gridplot([[l, None, aw], [bez, q, None]])

output_file("grid.html", title="grid.py example")

show(p)
```