### PR TITLE
Fixes to legend rendering

### DIFF
--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -74,7 +74,7 @@ class Legend(Annotation):
 
     label_text_font_size = Override(default={ 'value' : '10pt' })
 
-    label_standoff = Int(15, help="""
+    label_standoff = Int(5, help="""
     The distance (in pixels) to separate the label from its associated glyph.
     """)
 

--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -79,11 +79,11 @@ class Legend(Annotation):
     """)
 
     label_height = Int(20, help="""
-    The height (in pixels) of the area that legend labels should occupy.
+    The minimum height (in pixels) of the area that legend labels should occupy.
     """)
 
-    label_width = Int(50, help="""
-    The width (in pixels) of the area that legend labels should occupy.
+    label_width = Int(20, help="""
+    The minimum width (in pixels) of the area that legend labels should occupy.
     """)
 
     glyph_height = Int(20, help="""
@@ -94,8 +94,12 @@ class Legend(Annotation):
     The width (in pixels) that the rendered legend glyph should occupy.
     """)
 
+    legend_margin = Int(10, help="""
+    Amount of margin around the legend.
+    """)
+
     legend_padding = Int(10, help="""
-    Amount of padding around the legend.
+    Amount of padding around the contents of the legend.
     """)
 
     legend_spacing = Int(3, help="""

--- a/bokeh/models/tests/test_annotations.py
+++ b/bokeh/models/tests/test_annotations.py
@@ -75,6 +75,7 @@ def test_Legend():
         "label_width",
         "glyph_height",
         "glyph_width",
+        "legend_margin",
         "legend_padding",
         "legend_spacing",
         "legends",

--- a/bokeh/models/tests/test_annotations.py
+++ b/bokeh/models/tests/test_annotations.py
@@ -55,9 +55,9 @@ def test_Legend():
     legend = Legend()
     assert legend.plot is None
     assert legend.location == 'top_right'
-    assert legend.label_standoff == 15
+    assert legend.label_standoff == 5
     assert legend.label_height == 20
-    assert legend.label_width == 50
+    assert legend.label_width == 20
     assert legend.glyph_height == 20
     assert legend.glyph_width == 20
     assert legend.legend_padding == 10

--- a/bokehjs/src/coffee/models/annotations/legend.coffee
+++ b/bokehjs/src/coffee/models/annotations/legend.coffee
@@ -17,8 +17,6 @@ class LegendView extends Annotation.View
     label_height = @mget('label_height')
     label_width = @mget('label_width')
 
-    legend_spacing = @mget('legend_spacing')
-
     @max_label_height = _.max(
       [get_text_height(@visuals.label_text.font_value()).height, label_height, glyph_height]
     )
@@ -36,14 +34,16 @@ class LegendView extends Annotation.View
 
     legend_margin = @mget('legend_margin')
     legend_padding = @mget('legend_padding')
+    legend_spacing = @mget('legend_spacing')
+    label_standoff =  @mget('label_standoff')
 
     if @mget("orientation") == "vertical"
       legend_height = legend_names.length * @max_label_height + (legend_names.length - 1) * legend_spacing + 2 * legend_padding
-      legend_width = max_label_width + glyph_width + 2 * legend_padding
+      legend_width = max_label_width + glyph_width + label_standoff + 2 * legend_padding
     else
       legend_width = 2 * legend_padding + (legend_names.length - 1) * legend_spacing
       for name, width of @text_widths
-        legend_width += _.max([width, label_width]) + glyph_width
+        legend_width += _.max([width, label_width]) + glyph_width + label_standoff
       legend_height = @max_label_height + 2 * legend_padding
 
     location = @mget('location')
@@ -115,6 +115,7 @@ class LegendView extends Annotation.View
 
     N = @mget("legends").length
     legend_spacing = @mget('legend_spacing')
+    label_standoff = @mget('label_standoff')
     xoffset = yoffset = @mget('legend_padding')
     for [legend_name, glyphs], idx in @mget("legends")
       x1 = bbox.x + xoffset
@@ -124,10 +125,10 @@ class LegendView extends Annotation.View
       if orientation == "vertical"
         yoffset += @max_label_height + legend_spacing
       else
-        xoffset += @text_widths[legend_name] + glyph_width + legend_spacing
+        xoffset += @text_widths[legend_name] + glyph_width + label_standoff + legend_spacing
 
       @visuals.label_text.set_value(ctx)
-      ctx.fillText(legend_name, x2, y1 + @max_label_height / 2.0)
+      ctx.fillText(legend_name, x2 + label_standoff, y1 + @max_label_height / 2.0)
       for renderer in glyphs
         view = @plot_view.renderer_views[renderer.id]
         view.draw_legend(ctx, x1, x2, y1, y2)
@@ -159,7 +160,7 @@ class Legend extends Annotation.Model
       legends:        [ p.Array,          []          ]
       orientation:    [ p.Orientation,    'vertical'  ]
       location:       [ p.Any,            'top_right' ] # TODO (bev)
-      label_standoff: [ p.Number,         15          ]
+      label_standoff: [ p.Number,         5           ]
       glyph_height:   [ p.Number,         20          ]
       glyph_width:    [ p.Number,         20          ]
       label_height:   [ p.Number,         20          ]

--- a/bokehjs/src/coffee/models/annotations/legend.coffee
+++ b/bokehjs/src/coffee/models/annotations/legend.coffee
@@ -20,7 +20,7 @@ class LegendView extends Annotation.View
     legend_spacing = @mget('legend_spacing')
 
     @max_label_height = _.max(
-      [get_text_height(@visuals.label_text.font_value()), label_height, glyph_height]
+      [get_text_height(@visuals.label_text.font_value()).height, label_height, glyph_height]
     )
 
     # this is to measure text properties
@@ -34,17 +34,17 @@ class LegendView extends Annotation.View
 
     max_label_width = _.max(_.values(@text_widths))
 
+    legend_margin = @mget('legend_margin')
     legend_padding = @mget('legend_padding')
 
     if @mget("orientation") == "vertical"
-      legend_height = (legend_names.length * @max_label_height + (1 + legend_names.length) * legend_spacing) + legend_padding * 2
-      legend_width = (max_label_width + glyph_width + 3 * legend_spacing) + legend_padding * 2
+      legend_height = legend_names.length * @max_label_height + (legend_names.length - 1) * legend_spacing + 2 * legend_padding
+      legend_width = max_label_width + glyph_width + 2 * legend_padding
     else
-      legend_width = 0
+      legend_width = 2 * legend_padding + (legend_names.length - 1) * legend_spacing
       for name, width of @text_widths
-        legend_width += (_.max([width, label_width]) + glyph_width + 3 * legend_spacing)
-      legend_width += legend_padding
-      legend_height = (@max_label_height + 2 * legend_spacing) + legend_padding * 2
+        legend_width += _.max([width, label_width]) + glyph_width
+      legend_height = @max_label_height + 2 * legend_padding
 
     location = @mget('location')
     h_range = @plot_view.frame.get('h_range')
@@ -53,28 +53,28 @@ class LegendView extends Annotation.View
     if _.isString(location)
       switch location
         when 'top_left'
-          x = h_range.get('start') + legend_padding
-          y = v_range.get('end') - legend_padding
+          x = h_range.get('start') + legend_margin
+          y = v_range.get('end') - legend_margin
         when 'top_center'
           x = (h_range.get('end') + h_range.get('start'))/2 - legend_width/2
-          y = v_range.get('end') - legend_padding
+          y = v_range.get('end') - legend_margin
         when 'top_right'
-          x = h_range.get('end') - legend_padding - legend_width
-          y = v_range.get('end') - legend_padding
+          x = h_range.get('end') - legend_margin - legend_width
+          y = v_range.get('end') - legend_margin
         when 'right_center'
-          x = h_range.get('end') - legend_padding - legend_width
+          x = h_range.get('end') - legend_margin - legend_width
           y = (v_range.get('end') + v_range.get('start'))/2 + legend_height/2
         when 'bottom_right'
-          x = h_range.get('end') - legend_padding - legend_width
-          y = v_range.get('start') + legend_padding + legend_height
+          x = h_range.get('end') - legend_margin - legend_width
+          y = v_range.get('start') + legend_margin + legend_height
         when 'bottom_center'
           x = (h_range.get('end') + h_range.get('start'))/2 - legend_width/2
-          y = v_range.get('start') + legend_padding + legend_height
+          y = v_range.get('start') + legend_margin + legend_height
         when 'bottom_left'
-          x = h_range.get('start') + legend_padding
-          y = v_range.get('start') + legend_padding + legend_height
+          x = h_range.get('start') + legend_margin
+          y = v_range.get('start') + legend_margin + legend_height
         when 'left_center'
-          x = h_range.get('start') + legend_padding
+          x = h_range.get('start') + legend_margin
           y = (v_range.get('end') + v_range.get('start'))/2 + legend_height/2
         when 'center'
           x = (h_range.get('end') + h_range.get('start'))/2 - legend_width/2
@@ -113,31 +113,21 @@ class LegendView extends Annotation.View
       @visuals.border_line.set_value(ctx)
       ctx.stroke()
 
-    legend_padding = @mget('legend_padding')
-    legend_spacing = @mget('legend_spacing')
     N = @mget("legends").length
-
-    xoffset = 0
-    yoffset = 0
+    legend_spacing = @mget('legend_spacing')
+    xoffset = yoffset = @mget('legend_padding')
     for [legend_name, glyphs], idx in @mget("legends")
+      x1 = bbox.x + xoffset
+      y1 = bbox.y + yoffset
+      x2 = x1 + glyph_width
+      y2 = y1 + glyph_height
       if orientation == "vertical"
-        x1 = bbox.x + legend_spacing + legend_padding
-        x2 = x1 + glyph_width
-        y1 = bbox.y + yoffset + legend_spacing + legend_padding
-        y2 = y1 + glyph_height
-        yoffset += (bbox.height/N) - legend_padding
+        yoffset += @max_label_height + legend_spacing
       else
-        x1 = bbox.x + xoffset + legend_spacing + legend_padding
-        x2 = x1 + glyph_width
-        y1 = bbox.y + legend_spacing + legend_padding
-        y2 = y1 + glyph_height
-        xoffset += @text_widths[legend_name] + 3*legend_spacing + glyph_width
-
-      tx = x2 + legend_spacing
-      ty = y1 + @max_label_height / 2.0
+        xoffset += @text_widths[legend_name] + glyph_width + legend_spacing
 
       @visuals.label_text.set_value(ctx)
-      ctx.fillText(legend_name, tx, ty)
+      ctx.fillText(legend_name, x2, y1 + @max_label_height / 2.0)
       for renderer in glyphs
         view = @plot_view.renderer_views[renderer.id]
         view.draw_legend(ctx, x1, x2, y1, y2)
@@ -173,7 +163,8 @@ class Legend extends Annotation.Model
       glyph_height:   [ p.Number,         20          ]
       glyph_width:    [ p.Number,         20          ]
       label_height:   [ p.Number,         20          ]
-      label_width:    [ p.Number,         50          ]
+      label_width:    [ p.Number,         20          ]
+      legend_margin:  [ p.Number,         10          ]
       legend_padding: [ p.Number,         10          ]
       legend_spacing: [ p.Number,         3           ]
   }


### PR DESCRIPTION
Fixes #4390

There were several things wrong with the current implementation of the legend rendering:
* It followed a rather peculiar version of the box model:
  * the `legend_padding` was used as padding *and* as margin
  * the `legend_spacing` was used as spacing *and* as padding
* the legend items were not rendered at their correct position (which was the main cause of #4390)
* The text height was not correctly taken into account
* the `label_standoff` was not used, instead the `legend_spacing` was used as standoff.

It now should follow the standard box model. I added a `legend_margin` property to complete it. Further I reduced the default value of the `label_width`, because some labels are just real short (and the actual text length is taken into account anyway), an of the `label_standoff` because it was huge.

cc @birdsarah 