### PR TITLE
Move toolbar to right of plots

### DIFF
--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -450,7 +450,7 @@ class Plot(LayoutDOM):
         The toolbar is automatically created with the plot.
     """)
 
-    toolbar_location = Enum(Location, default="above", help="""
+    toolbar_location = Enum(Location, default="right", help="""
     Where the toolbar will be located. If set to None, no toolbar
     will be attached to the plot.
     """)

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -84,7 +84,7 @@ class ToolbarBox(LayoutDOM):
 
     """
 
-    toolbar_location = Enum(Location, default='above', help="""
+    toolbar_location = Enum(Location, default='right', help="""
         Should the toolbar be presented as if it was stuck to the `above`, `right`, `left`, `below`
         edge of a plot. Default is `above`.
     """)

--- a/bokehjs/src/coffee/models/plots/plot.coffee
+++ b/bokehjs/src/coffee/models/plots/plot.coffee
@@ -224,7 +224,7 @@ class Plot extends LayoutDOM.Model
 
   @define {
       toolbar:           [ p.Instance, () -> new Toolbar.Model() ]
-      toolbar_location:  [ p.Location, 'above'                   ]
+      toolbar_location:  [ p.Location, 'right'                ]
       toolbar_sticky:    [ p.Bool, true                       ]
 
       # ALL BELOW ARE FOR PLOT CANVAS

--- a/bokehjs/src/coffee/models/tools/toolbar_base.coffee
+++ b/bokehjs/src/coffee/models/tools/toolbar_base.coffee
@@ -116,7 +116,7 @@ class ToolbarBase extends LayoutDOM.Model
     actions:    [ p.Array, [] ]
     inspectors: [ p.Array, [] ]
     help:       [ p.Array, [] ]
-    toolbar_location: [ p.Location, 'above' ]
+    toolbar_location: [ p.Location, 'right' ]
     toolbar_sticky: [ p.Bool ]
   }
 

--- a/bokehjs/src/coffee/models/tools/toolbar_box.coffee
+++ b/bokehjs/src/coffee/models/tools/toolbar_box.coffee
@@ -149,7 +149,7 @@ class ToolbarBox extends LayoutDOM.Model
     return [@_toolbar]
 
   @define {
-    toolbar_location: [ p.Location, "above"  ]
+    toolbar_location: [ p.Location, "right"  ]
     merge_tools:      [ p.Bool,     true     ]
     tools:            [ p.Any,  []   ]
   }

--- a/bokehjs/test/models/plots/plot.coffee
+++ b/bokehjs/test/models/plots/plot.coffee
@@ -99,8 +99,8 @@ describe "Plot", ->
 
   describe "Plot.Model", ->
 
-    it "should have _horizontal set to false by default", ->
-      expect(@p._horizontal).to.false
+    it "should have _horizontal set to true by default", ->
+      expect(@p._horizontal).to.true
 
     it "should have a PlotCanvas set on initialization with all the options passed to Plot", ->
       expect(@p.plot_canvas()).to.exist

--- a/examples/howto/layouts/dashboard.py
+++ b/examples/howto/layouts/dashboard.py
@@ -39,7 +39,7 @@ def slider():
 
     plot = figure(
         y_range=(-10, 10), tools='', toolbar_location=None,
-        title="Sliders example", title_location='right')
+        title="Sliders example")
     plot.line('x', 'y', source=source, line_width=3, line_alpha=0.6)
 
     callback = CustomJS(args=dict(source=source), code="""
@@ -79,11 +79,11 @@ def linked_panning():
     y2 = np.cos(x)
     y3 = np.sin(x) + np.cos(x)
 
-    s1 = figure(tools=tools, toolbar_location='right')
+    s1 = figure(tools=tools)
     s1.circle(x, y1, color="navy", size=8, alpha=0.5)
-    s2 = figure(tools=tools, toolbar_location='right', x_range=s1.x_range, y_range=s1.y_range)
+    s2 = figure(tools=tools, x_range=s1.x_range, y_range=s1.y_range)
     s2.circle(x, y2, color="firebrick", size=8, alpha=0.5)
-    s3 = figure(tools='pan, box_select', toolbar_location='right', x_range=s1.x_range)
+    s3 = figure(tools='pan, box_select', x_range=s1.x_range)
     s3.circle(x, y3, color="olive", size=8, alpha=0.5)
     return [s1, s2, s3]
 

--- a/examples/howto/layouts/words_and_plots.py
+++ b/examples/howto/layouts/words_and_plots.py
@@ -35,7 +35,7 @@ def text():
 def scatter():
     s = Scatter(
         flowers,
-        title="Fisher's Iris data set", toolbar_location='right', tools='tap,box_select,save',
+        title="Fisher's Iris data set", tools='tap,box_select,save',
         x=blend('petal_length', name='Length'),
         y=blend('petal_width', name='Width'),
         color='species', palette=Spectral4, legend=True,

--- a/examples/models/choropleth.py
+++ b/examples/models/choropleth.py
@@ -49,7 +49,7 @@ xdr = DataRange1d()
 ydr = DataRange1d()
 
 plot = Plot(x_range=xdr, y_range=ydr, min_border=0, border_fill_color="white",
-            title="2009 Unemployment Data", plot_width=1300, plot_height=800, toolbar_location="left")
+            title="2009 Unemployment Data", plot_width=1300, plot_height=800)
 
 county_patches = Patches(xs="county_xs", ys="county_ys", fill_color="county_colors", fill_alpha=0.7, line_color="white", line_width=0.5)
 plot.add_glyph(county_source, county_patches)

--- a/examples/plotting/file/candlestick.py
+++ b/examples/plotting/file/candlestick.py
@@ -17,7 +17,7 @@ w = 12*60*60*1000 # half day in ms
 
 TOOLS = "pan,wheel_zoom,box_zoom,reset,save"
 
-p = figure(x_axis_type="datetime", tools=TOOLS, plot_width=1000, toolbar_location="left")
+p = figure(x_axis_type="datetime", tools=TOOLS, plot_width=1000)
 
 p.title = "MSFT Candlestick"
 p.xaxis.major_label_orientation = pi/4

--- a/examples/plotting/file/choropleth.py
+++ b/examples/plotting/file/choropleth.py
@@ -27,7 +27,7 @@ for county_id in counties:
     except KeyError:
         county_colors.append("black")
 
-p = figure(title="US Unemployment 2009", toolbar_location="left",
+p = figure(title="US Unemployment 2009",
            plot_width=1100, plot_height=700)
 
 p.patches(county_xs, county_ys,

--- a/examples/plotting/file/custom_datetime_axis.py
+++ b/examples/plotting/file/custom_datetime_axis.py
@@ -53,7 +53,7 @@ w = 0.5
 
 TOOLS = "pan,wheel_zoom,box_zoom,reset,save"
 
-p = figure(tools=TOOLS, plot_width=1000, toolbar_location="left")
+p = figure(tools=TOOLS, plot_width=1000)
 
 p.title = "MSFT Candlestick with custom x axis"
 p.xaxis.major_label_orientation = pi/4

--- a/examples/plotting/file/elements.py
+++ b/examples/plotting/file/elements.py
@@ -19,7 +19,7 @@ melting_colors = [palette[i] for i in melting_point_inds]
 
 TOOLS = "pan,wheel_zoom,box_zoom,reset,resize,save"
 
-p = figure(tools=TOOLS, toolbar_location="left", logo="grey", plot_width=1200)
+p = figure(tools=TOOLS, toolbar_location="above", logo="grey", plot_width=1200)
 
 p.title = "Density vs Atomic Weight of Elements (colored by melting point)"
 p.background_fill_color= "#cccccc"

--- a/examples/plotting/file/unemployment.py
+++ b/examples/plotting/file/unemployment.py
@@ -38,7 +38,7 @@ TOOLS = "resize,hover,save,pan,box_zoom,wheel_zoom"
 p = figure(title="US Unemployment (1948 - 2013)",
            x_range=years, y_range=list(reversed(months)),
            x_axis_location="above", plot_width=900, plot_height=400,
-           toolbar_location="left", tools=TOOLS)
+           tools=TOOLS)
 
 p.grid.grid_line_color = None
 p.axis.axis_line_color = None

--- a/tests/integration/annotations/test_arrow.py
+++ b/tests/integration/annotations/test_arrow.py
@@ -16,7 +16,7 @@ WIDTH = 600
 def test_arrow(output_file_url, selenium, screenshot):
 
     # Have to specify x/y range as labels aren't included in the plot area solver
-    plot = figure(height=HEIGHT, width=WIDTH, x_range=(0,10), y_range=(0,10), tools='')
+    plot = figure(height=HEIGHT, width=WIDTH, x_range=(0,10), y_range=(0,10), tools='', toolbar_location="above")
 
     arrow1 = Arrow(x_start=1, y_start=3, x_end=6, y_end=8,
                    line_color='green', line_alpha=0.7,

--- a/tests/integration/interaction/test_hover.py
+++ b/tests/integration/interaction/test_hover.py
@@ -23,7 +23,7 @@ def hover_at_position(selenium, canvas, x, y):
 def test_hover_changes_color(output_file_url, selenium, screenshot):
 
     # Make plot and add a taptool callback that generates an alert
-    plot = figure(height=HEIGHT, width=WIDTH, tools='')
+    plot = figure(height=HEIGHT, width=WIDTH, tools='', toolbar_location="above")
     rect = plot.rect(
         x=[1, 2], y=[1, 1],
         width=1, height=1,


### PR DESCRIPTION
issues: fixes #4399

<img width="610" alt="screen shot 2016-06-10 at 10 04 11 am" src="https://cloud.githubusercontent.com/assets/1417520/15968917/4f938f38-2ef3-11e6-841f-93df637bd3f6.png">

The new toolbar location leaves the top of the y-axis flush with the top of the browser window

<img width="614" alt="screen shot 2016-06-10 at 10 05 18 am" src="https://cloud.githubusercontent.com/assets/1417520/15968935/647022ae-2ef3-11e6-9675-b4b2db8fcb04.png">
