### PR TITLE
Initialize colorama on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ try:
     def red(text): return "%s%s%s" % (colorama.Fore.RED, text, colorama.Style.RESET_ALL)
     def green(text): return "%s%s%s" % (colorama.Fore.GREEN, text, colorama.Style.RESET_ALL)
     def yellow(text): return "%s%s%s" % (colorama.Fore.YELLOW, text, colorama.Style.RESET_ALL)
+    sys.platform == "win32" and colorama.init()
 except ImportError:
     def bright(text): return text
     def dim(text): return text


### PR DESCRIPTION
From https://github.com/tartley/colorama#initialisation: on Windows `colorama.init()` should be called. On other platforms initialization call should not have any effect, but anyway I limited the call only for Windows

closes #4480