### PR TITLE
Canavandl/4373 lasso improvements

### DIFF
--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -450,6 +450,14 @@ class LassoSelectTool(Tool):
     event, or only once, when the selection region is completed. Default: True
     """)
 
+    callback = Instance(Callback, help="""
+    A callback to run in the browser on every selection of a lasso area.
+    The cb_data parameter that is available to the Callback code will contain
+    one LassoSelectTool-specific field:
+
+    :geometry: object containing the coordinates of the lasso area
+    """)
+
     overlay = Instance(PolyAnnotation, default=DEFAULT_POLY_OVERLAY, help="""
     A shaded annotation drawn to indicate the selection region.
     """)

--- a/bokehjs/src/coffee/models/tools/gestures/lasso_select_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/gestures/lasso_select_tool.coffee
@@ -63,9 +63,29 @@ class LassoSelectToolView extends SelectTool.View
       sm = ds.get('selection_manager')
       sm.select(@, @plot_view.renderer_views[r.id], geometry, final, append)
 
+    if @mget('callback')?
+      @_emit_callback(geometry)
+
     @_save_geometry(geometry, final, append)
 
     return null
+
+  _emit_callback: (geometry) ->
+    r = @mget('computed_renderers')[0]
+    canvas = @plot_model.get('canvas')
+    frame = @plot_model.get('frame')
+
+    geometry['sx'] = canvas.v_vx_to_sx(geometry.vx)
+    geometry['sy'] = canvas.v_vy_to_sy(geometry.vy)
+
+    xmapper = frame.get('x_mappers')[r.get('x_range_name')]
+    ymapper = frame.get('y_mappers')[r.get('y_range_name')]
+    geometry['x'] = xmapper.v_map_from_target(geometry.vx)
+    geometry['y'] = ymapper.v_map_from_target(geometry.vy)
+
+    @mget('callback').execute(@model, {geometry: geometry})
+
+    return
 
 DEFAULT_POLY_OVERLAY = () -> new PolyAnnotation.Model({
   level: "overlay"
@@ -89,6 +109,7 @@ class LassoSelectTool extends SelectTool.Model
 
   @define {
       select_every_mousemove: [ p.Bool,    true                  ]
+      callback:               [ p.Instance                       ]
       overlay:                [ p.Instance, DEFAULT_POLY_OVERLAY ]
     }
 

--- a/bokehjs/src/coffee/models/tools/gestures/lasso_select_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/gestures/lasso_select_tool.coffee
@@ -32,6 +32,18 @@ class LassoSelectToolView extends SelectTool.View
     vx = canvas.sx_to_vx(e.bokeh.sx)
     vy = canvas.sy_to_vy(e.bokeh.sy)
 
+    h_range = @plot_model.get('frame').get('h_range')
+    v_range = @plot_model.get('frame').get('v_range')
+    if vx > h_range.get('end')
+      vx = h_range.get('end')
+    if vx < h_range.get('start')
+      vx = h_range.get('start')
+
+    if vy > v_range.get('end')
+      vy = v_range.get('end')
+    if vy < v_range.get('start')
+      vy = v_range.get('start')
+
     @data.vx.push(vx)
     @data.vy.push(vy)
 

--- a/tests/integration/interaction/test_tools.py
+++ b/tests/integration/interaction/test_tools.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from bokeh.io import save
-from bokeh.models import BoxSelectTool, ColumnDataSource, CustomJS
+from bokeh.models import BoxSelectTool, ColumnDataSource, CustomJS, LassoSelectTool
 from bokeh.plotting import figure
 from selenium.webdriver.common.action_chains import ActionChains
 from tests.integration.utils import has_no_console_errors
@@ -9,8 +9,7 @@ from tests.integration.utils import has_no_console_errors
 import pytest
 pytestmark = pytest.mark.integration
 
-
-def test_box_select(output_file_url, selenium):
+def generate_plot():
     PLOT_DIM = 600
 
     source = ColumnDataSource(dict(
@@ -19,7 +18,7 @@ def test_box_select(output_file_url, selenium):
         name=['top_left', 'middle', 'top_right'],
     ))
     # Make plot and add a taptool callback that generates an alert
-    plot = figure(tools='box_select', height=PLOT_DIM, width=PLOT_DIM, x_range=[1, 3], y_range=[1, 3])
+    plot = figure(tools='', height=PLOT_DIM, width=PLOT_DIM, x_range=[1, 3], y_range=[1, 3])
     plot.circle(x='x', y='y', radius=0.2, source=source)
 
     source.callback = CustomJS(code="""
@@ -34,6 +33,13 @@ def test_box_select(output_file_url, selenium):
         alert(selected_names);
     """)
 
+    return plot
+
+def test_box_select(output_file_url, selenium):
+    plot = generate_plot()
+
+    plot.add_tools(BoxSelectTool())
+
     # Save the plot and start the test
     save(plot)
     selenium.get(output_file_url)
@@ -46,6 +52,33 @@ def test_box_select(output_file_url, selenium):
     actions.move_to_element_with_offset(canvas, PLOT_DIM * 0.25, PLOT_DIM * 0.25)
     actions.click_and_hold()
     actions.move_by_offset(PLOT_DIM * 0.5, PLOT_DIM * 0.5)
+    actions.release()
+    actions.perform()
+
+    # Get the alert from box select and assert that the middle item is selected
+    alert = selenium.switch_to_alert()
+    assert alert.text == 'middle'
+
+def test_lasso_select(output_file_url, selenium):
+    plot = generate_plot()
+
+    #limit to one callback on click release
+    plot.add_tools(LassoSelectTool(select_every_mousemove=False))
+
+    # Save the plot and start the test
+    save(plot)
+    selenium.get(output_file_url)
+    assert has_no_console_errors(selenium)
+
+    # Drag a lasso selection area around middle point
+    canvas = selenium.find_element_by_tag_name('canvas')
+
+    actions = ActionChains(selenium)
+    actions.move_to_element_with_offset(canvas, PLOT_DIM * 0.25, PLOT_DIM * 0.25)
+    actions.click_and_hold()
+    actions.move_by_offset(0, PLOT_DIM * 0.5)
+    actions.move_by_offset(PLOT_DIM * 0.5, 0)
+    actions.move_by_offset(0, PLOT_DIM * -0.5)
     actions.release()
     actions.perform()
 

--- a/tests/integration/interaction/test_tools.py
+++ b/tests/integration/interaction/test_tools.py
@@ -9,9 +9,9 @@ from tests.integration.utils import has_no_console_errors
 import pytest
 pytestmark = pytest.mark.integration
 
-def generate_plot():
-    PLOT_DIM = 600
+PLOT_DIM = 600
 
+def generate_plot():
     source = ColumnDataSource(dict(
         x=[1, 2, 3],
         y=[3, 2, 3],


### PR DESCRIPTION
- [x] issues: fixes #2297 #4373 
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)

Contains:
* Constrains lasso overlay to plot frame
* Adds callback support on select (to match BoxSelectTool)

<img width="561" alt="screen shot 2016-06-15 at 4 02 39 pm" src="https://cloud.githubusercontent.com/assets/2198981/16097287/b60effd6-3312-11e6-9242-d6c7d53a103d.png">


discussion:
* Perhaps gives resolution path for #3412 via a CustomJS callback (can mark as resolved?)
* Should we make the default change to `select_every_mousemove=False` per #4172 to match BoxSelectTool?