### PR TITLE
Update link to w3schools.com

### DIFF
--- a/sphinx/source/docs/includes/colors.txt
+++ b/sphinx/source/docs/includes/colors.txt
@@ -4,4 +4,4 @@
 - a 3-tuple of integers *(r,g,b)* between 0 and 255
 - a 4-tuple of *(r,g,b,a)* where *r*, *g*, *b* are integers between 0 and 255 and *a* is a floating point value between 0 and 1
 
-.. _147 named CSS colors: http://www.w3schools.com/cssref/css_colornames.asp
+.. _147 named CSS colors: http://www.w3schools.com/colors/colors_names.asp


### PR DESCRIPTION
This PR fixes the hyperlink in [this file](https://github.com/bokeh/bokeh/blob/9491d517a84edc528ac84970cb338b5c24ac1d66/sphinx/source/docs/includes/colors.txt)

Associated with issue #4530 