### PR TITLE
Improvements to layout functions

### DIFF
--- a/bokeh/layouts.py
+++ b/bokeh/layouts.py
@@ -193,9 +193,9 @@ def layout(children=None, sizing_mode='fixed', responsive=None, *args):
 
     # Make the grid
     rows = []
-    for row in children:
+    for r in children:
         row_children = []
-        for item in row:
+        for item in r:
             if isinstance(item, LayoutDOM):
                 item.sizing_mode = sizing_mode
                 row_children.append(item)
@@ -204,7 +204,7 @@ def layout(children=None, sizing_mode='fixed', responsive=None, *args):
                     """Only LayoutDOM items can be inserted into a layout.
                     Tried to insert: %s of type %s""" % (item, type(item))
                 )
-        rows.append(row(children=row, sizing_mode=sizing_mode))
+        rows.append(row(children=row_children, sizing_mode=sizing_mode))
     grid = column(children=rows, sizing_mode=sizing_mode)
     return grid
 

--- a/bokeh/layouts.py
+++ b/bokeh/layouts.py
@@ -18,12 +18,15 @@ from .util._plot_arg_helpers import _convert_responsive
 #-----------------------------------------------------------------------------
 # Common helper functions
 #-----------------------------------------------------------------------------
-def _handle_children(children, *args):
+def _handle_children(children, wrap=True, *args):
     # Set-up Children from args or kwargs
     if len(args) > 0 and children is not None:
         raise ValueError("'children' keyword cannot be used with positional arguments")
     elif len(args) > 0:
-        children = list(args)
+        if wrap:
+            children = list(args)
+        else:
+            children = args
     if not children:
         return
     return children
@@ -209,7 +212,16 @@ def layout(children=None, sizing_mode='fixed', responsive=None, *args):
     return grid
 
 
-def gridplot(children=None, toolbar_location='left', sizing_mode='fixed', responsive=None, toolbar_options=None, plot_width=None, plot_height=None, *args):
+def chunks(l, n):
+    """Yield successive n-sized chunks from list, l."""
+    for i in range(0, len(l), n):
+        yield l[i: i+n]
+
+
+def gridplot(
+    children=None, toolbar_location='left', sizing_mode='fixed',
+    responsive=None, toolbar_options=None, plot_width=None, plot_height=None,
+    ncols=None, *args):
     """ Create a grid of plots rendered on separate canvases.
 
     Args:
@@ -252,7 +264,14 @@ def gridplot(children=None, toolbar_location='left', sizing_mode='fixed', respon
     if toolbar_location:
         if not hasattr(Location, toolbar_location):
             raise ValueError("Invalid value of toolbar_location: %s" % toolbar_location)
-    children = _handle_children(children, *args)
+    if ncols:
+        children = _handle_children(children, wrap=False, *args)
+        has_list = [isinstance(child, list) for child in children]
+        if sum(has_list) > 0:
+            raise ValueError("Cannot provide a nested list when using ncols")
+        children = list(chunks(children, ncols))
+    else:
+        children = _handle_children(children, *args)
 
     # Additional children set-up for GridPlot
     if not children:

--- a/bokeh/layouts.py
+++ b/bokeh/layouts.py
@@ -266,8 +266,7 @@ def gridplot(
             raise ValueError("Invalid value of toolbar_location: %s" % toolbar_location)
     if ncols:
         children = _handle_children(children, wrap=False, *args)
-        has_list = [isinstance(child, list) for child in children]
-        if sum(has_list) > 0:
+        if any(isinstance(child, list) for child in children):
             raise ValueError("Cannot provide a nested list when using ncols")
         children = list(chunks(children, ncols))
     else:

--- a/bokeh/layouts.py
+++ b/bokeh/layouts.py
@@ -209,7 +209,7 @@ def layout(children=None, sizing_mode='fixed', responsive=None, *args):
     return grid
 
 
-def gridplot(children=None, toolbar_location='left', sizing_mode='fixed', responsive=None, toolbar_options=None, *args):
+def gridplot(children=None, toolbar_location='left', sizing_mode='fixed', responsive=None, toolbar_options=None, plot_width=None, plot_height=None, *args):
     """ Create a grid of plots rendered on separate canvases.
 
     Args:
@@ -278,6 +278,11 @@ def gridplot(children=None, toolbar_location='left', sizing_mode='fixed', respon
                 item = Spacer(width=neighbor.plot_width, height=neighbor.plot_height)
             if isinstance(item, LayoutDOM):
                 item.sizing_mode = sizing_mode
+                if isinstance(item, Plot):
+                    if plot_width:
+                        item.plot_width = plot_width
+                    if plot_height:
+                        item.plot_height = plot_height
                 row_children.append(item)
             else:
                 raise ValueError("Only LayoutDOM items can be inserted into Grid")

--- a/examples/howto/layouts/dashboard.py
+++ b/examples/howto/layouts/dashboard.py
@@ -91,6 +91,6 @@ l = layout([
     bollinger(),
     slider(),
     linked_panning(),
-])
+], sizing_mode='stretch_both')
 
 show(l)

--- a/examples/plotting/notebook/glyphs.ipynb
+++ b/examples/plotting/notebook/glyphs.ipynb
@@ -20,7 +20,9 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from bokeh.plotting import figure, show, output_notebook"
+    "from bokeh.plotting import figure, show, output_notebook\n",
+    "from bokeh.layouts import gridplot\n",
+    "output_notebook()"
    ]
   },
   {
@@ -31,33 +33,13 @@
    },
    "outputs": [],
    "source": [
-    "N = 9"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
+    "N = 9\n",
     "x = np.linspace(-2, 2, N)\n",
     "y = x**2\n",
     "sizes = np.linspace(10, 20, N)\n",
     "xpts = np.array([-.09, -.12, .0, .12, .09])\n",
-    "ypts = np.array([-.1, .02, .1, .02, -.1])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "output_notebook()"
+    "ypts = np.array([-.1, .02, .1, .02, -.1])\n",
+    "figures = []"
    ]
   },
   {
@@ -71,7 +53,7 @@
     "p = figure(title=\"annular_wedge\")\n",
     "p.annular_wedge(x, y, 10, 20, 0.6, 4.1, color=\"#8888ee\",\n",
     "    inner_radius_units=\"screen\", outer_radius_units=\"screen\")\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -85,7 +67,7 @@
     "p = figure(title=\"annulus\")\n",
     "p.annulus(x, y, 10, 20, color=\"#7FC97F\",\n",
     "    inner_radius_units=\"screen\", outer_radius_units = \"screen\")\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -99,7 +81,7 @@
     "p = figure(title=\"arc\")\n",
     "p.arc(x, y, 20, 0.6, 4.1,\n",
     "    radius_units=\"screen\", color=\"#BEAED4\", line_width=3)\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -113,7 +95,7 @@
     "p = figure(title=\"bezier\")\n",
     "p.bezier(x, y, x+0.2, y, x+0.1, y+0.1, x-0.1, y-0.1,\n",
     "    color=\"#D95F02\", line_width=2)\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -126,7 +108,7 @@
    "source": [
     "p = figure(title=\"circle\")\n",
     "p.circle(x, y, radius=0.1, color=\"#3288BD\")\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -140,7 +122,7 @@
     "p = figure(title=\"ellipse\")\n",
     "p.ellipse(x, y, 15, 25, angle=-0.7, color=\"#1D91C0\",\n",
     "    width_units=\"screen\", height_units=\"screen\")\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -153,7 +135,7 @@
    "source": [
     "p = figure(title=\"line\")\n",
     "p.line(x, y, color=\"#F46D43\")\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -165,9 +147,8 @@
    "outputs": [],
    "source": [
     "p = figure(title=\"multi_line\")\n",
-    "p.multi_line([xpts+xx for xx in x], [ypts+yy for yy in y],\n",
-    "    color=\"#8073AC\", line_width=2)\n",
-    "show(p)"
+    "p.multi_line([xpts+xx for xx in x], [ypts+yy for yy in y], color=\"#8073AC\", line_width=2)\n",
+    "figures.append(p)"
    ]
   },
   {
@@ -179,9 +160,9 @@
    "outputs": [],
    "source": [
     "p = figure(title=\"oval\")\n",
-    "p.oval(x, y, 15, 25, angle=-0.7, color=\"#1D91C0\",\n",
+    "p.oval(x, y, 15, 25, angle=-0.7, color=\"#1D91C0\", \n",
     "    width_units=\"screen\", height_units=\"screen\")\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -194,7 +175,7 @@
    "source": [
     "p = figure(title=\"patch\")\n",
     "p.patch(x, y, color=\"#A6CEE3\")\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -207,7 +188,7 @@
    "source": [
     "p = figure(title=\"patches\")\n",
     "p.patches([xpts+xx for xx in x], [ypts+yy for yy in y], color=\"#FB9A99\")\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -220,7 +201,7 @@
    "source": [
     "p = figure(title=\"quad\")\n",
     "p.quad(x, x-0.1, y, y-0.1, color=\"#B3DE69\")\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -233,7 +214,7 @@
    "source": [
     "p = figure(title=\"quadratic\")\n",
     "p.quadratic(x, y, x+0.2, y, x+0.1, y+0.1, color=\"#4DAF4A\", line_width=3)\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -246,7 +227,7 @@
    "source": [
     "p = figure(title=\"ray\")\n",
     "p.ray(x, y, 45, -0.7, color=\"#FB8072\", line_width=2)\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -258,9 +239,8 @@
    "outputs": [],
    "source": [
     "p = figure(title=\"rect\")\n",
-    "p.rect(x, y, 10, 20, color=\"#CAB2D6\",\n",
-    "    width_units=\"screen\", height_units=\"screen\")\n",
-    "show(p)"
+    "p.rect(x, y, 10, 20, color=\"#CAB2D6\", width_units=\"screen\", height_units=\"screen\")\n",
+    "figures.append(p)"
    ]
   },
   {
@@ -273,7 +253,7 @@
    "source": [
     "p = figure(title=\"segment\")\n",
     "p.segment(x, y, x-0.1, y-0.1, color=\"#F4A582\", line_width=3)\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -286,7 +266,7 @@
    "source": [
     "p = figure(title=\"square\")\n",
     "p.square(x, y, size=sizes, color=\"#74ADD1\")\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -299,7 +279,7 @@
    "source": [
     "p = figure(title=\"wedge\")\n",
     "p.wedge(x, y, 15, 0.6, 4.1, radius_units=\"screen\", color=\"#B3DE69\")\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -312,7 +292,7 @@
    "source": [
     "p = figure(title=\"circle_x\")\n",
     "p.scatter(x, y, marker=\"circle_x\", size=sizes, color=\"#DD1C77\", fill_color=None)\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -325,7 +305,7 @@
    "source": [
     "p = figure(title=\"triangle\")\n",
     "p.scatter(x, y, marker=\"triangle\", size=sizes, color=\"#99D594\", line_width=2)\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -338,7 +318,7 @@
    "source": [
     "p = figure(title=\"circle\")\n",
     "p.scatter(x, y, marker=\"o\", size=sizes, color=\"#80B1D3\", line_width=3)\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -351,7 +331,7 @@
    "source": [
     "p = figure(title=\"cross\")\n",
     "p.scatter(x, y, marker=\"cross\", size=sizes, color=\"#E6550D\", line_width=2)\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -364,7 +344,7 @@
    "source": [
     "p = figure(title=\"diamond\")\n",
     "p.scatter(x, y, marker=\"diamond\", size=sizes, color=\"#1C9099\", line_width=2)\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -377,7 +357,7 @@
    "source": [
     "p = figure(title=\"inverted_triangle\")\n",
     "p.scatter(x, y, marker=\"inverted_triangle\", size=sizes, color=\"#DE2D26\")\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -391,7 +371,7 @@
     "p = figure(title=\"square_x\")\n",
     "p.scatter(x, y, marker=\"square_x\", size=sizes, color=\"#FDAE6B\",\n",
     "    fill_color=None, line_width=2)\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -403,8 +383,9 @@
    "outputs": [],
    "source": [
     "p = figure(title=\"asterisk\")\n",
-    "p.scatter(x, y, marker=\"asterisk\", size=sizes, color=\"#F0027F\", line_width=2)\n",
-    "show(p)"
+    "p.scatter(x, y, marker=\"asterisk\", size=sizes, color=\"#F0027F\", \n",
+    "    line_width=2)\n",
+    "figures.append(p)"
    ]
   },
   {
@@ -418,7 +399,7 @@
     "p = figure(title=\"square_cross\")\n",
     "p.scatter(x, y, marker=\"square_cross\", size=sizes, color=\"#7FC97F\",\n",
     "    fill_color=None, line_width=2)\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -432,7 +413,7 @@
     "p = figure(title=\"diamond_cross\")\n",
     "p.scatter(x, y, marker=\"diamond_cross\", size=sizes, color=\"#386CB0\",\n",
     "    fill_color=None, line_width=2)\n",
-    "show(p)"
+    "figures.append(p)"
    ]
   },
   {
@@ -446,27 +427,38 @@
     "p = figure(title=\"circle_cross\")\n",
     "p.scatter(x, y, marker=\"circle_cross\", size=sizes, color=\"#FB8072\",\n",
     "    fill_color=None, line_width=2)\n",
-    "show(p)"
+    "figures.append(p)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "show(gridplot(figures, ncols=3, plot_width=200, plot_height=200))"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.9"
+   "pygments_lexer": "ipython3",
+   "version": "3.4.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Don't have an issue on this yet. Have just been tweaking as I have been using layout and wanting to improve my convenience.

1) supply a plot_width and plot_height to griplot and it sets them all for you (great for a fixed layout with lots of plots and less typing) `gridplot([[p1, p2, p3, p4], [p5, p6, p7, p8]], plot_width=200, plot_height=200)`

2) supply a list of plots (and/or None's) to gridplot and a number of columns (as opposed to a list of lists) and it'll make the grid for you. `gridplot([p1, p2, p3, p4, p5, p6, p7, p8], ncols=4, plot_width=200, plot_height=200)`