### PR TITLE
pin ggplot version preceding uploading new versions to anaconda.org

### DIFF
--- a/scripts/travis_install
+++ b/scripts/travis_install
@@ -9,7 +9,7 @@ MINICONDA="Miniconda-$MINICONDA_VERSION-Linux-x86_64"
 MINICONDA_URL="http://repo.continuum.io/miniconda/$MINICONDA.sh"
 
 PINNED_PKGS=$(cat <<EOF
-ggplot=0.6.5
+ggplot ==0.6.5
 EOF
 )
 

--- a/scripts/travis_install
+++ b/scripts/travis_install
@@ -21,10 +21,10 @@ python -V
 
 echo -e "$PINNED_PKGS" > /home/travis/miniconda/conda-meta/pinned
 
+conda config --add channels bokeh
+
 DEPS_TRAVIS="python=$TRAVIS_PYTHON_VERSION conda-build jinja2"
 conda install --yes $DEPS_TRAVIS
-
-conda config --add channels bokeh
 
 CONDA_PY="${TRAVIS_PYTHON_VERSION/./}" conda build --quiet --no-test conda.recipe
 

--- a/scripts/travis_install
+++ b/scripts/travis_install
@@ -9,6 +9,7 @@ MINICONDA="Miniconda-$MINICONDA_VERSION-Linux-x86_64"
 MINICONDA_URL="http://repo.continuum.io/miniconda/$MINICONDA.sh"
 
 PINNED_PKGS=$(cat <<EOF
+ggplot=0.6.5
 EOF
 )
 


### PR DESCRIPTION
This is needed as part of #4559, otherwise when new ggplot pkgs are uploaded, the tests will break. The open should be removed when #4559 is completed. 