### PR TITLE
minimal server + notebook support

### DIFF
--- a/bokeh/application/handlers/tests/test_code.py
+++ b/bokeh/application/handlers/tests/test_code.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import, print_function
-
-import unittest
+import pytest
 
 from bokeh.application.handlers import CodeHandler
 from bokeh.document import Document
@@ -36,69 +34,131 @@ curdoc().add_root(AnotherModelInTestScript())
 curdoc().add_root(SomeModelInTestScript())
 """
 
-class TestCodeHandler(unittest.TestCase):
+script_uses_iofuncs = """
+from bokeh.io import curdoc
+from bokeh.model import Model
+from bokeh.core.properties import Int
+import bokeh.io as io
 
-    def test_empty_script(self):
-        doc = Document()
-        handler = CodeHandler(source="# This script does nothing", filename="/test_filename")
-        handler.modify_document(doc)
-        if handler.failed:
-            raise RuntimeError(handler.error)
+io.output_server()
+io.output_notebook()
+io.output_file("foo")
 
-        assert not doc.roots
+class IOFuncModelInTestScript(Model):
+    bar = Int(1)
 
-    def test_script_adds_roots(self):
-        doc = Document()
-        handler = CodeHandler(source=script_adds_two_roots, filename="/test_filename")
-        handler.modify_document(doc)
-        if handler.failed:
-            raise RuntimeError(handler.error)
+curdoc().add_root(IOFuncModelInTestScript())
 
-        assert len(doc.roots) == 2
+io.save()
+io.show()
+io.push()
+io.reset_output()
 
-    def test_script_bad_syntax(self):
-        doc = Document()
-        handler = CodeHandler(source="This is a syntax error", filename="/test_filename")
-        handler.modify_document(doc)
+"""
 
-        assert handler.error is not None
-        assert 'Invalid syntax' in handler.error
+script_uses_client = """
+from bokeh.io import curdoc
+from bokeh.model import Model
+from bokeh.core.properties import Int
+import bokeh.client as client
 
-    def test_script_runtime_error(self):
-        doc = Document()
-        handler = CodeHandler(source="raise RuntimeError('nope')", filename="/test_filename")
-        handler.modify_document(doc)
+session = client.push_session()
 
-        assert handler.error is not None
-        assert 'nope' in handler.error
+class ClientModelInTestScript(Model):
+    bar = Int(1)
 
-    def test_script_sys_path(self):
-        doc = Document()
-        handler = CodeHandler(source="""import sys; raise RuntimeError("path: '%s'" % sys.path[0])""", filename="/test_filename")
-        handler.modify_document(doc)
+curdoc().add_root(ClientModelInTestScript())
 
-        assert handler.error is not None
-        assert "path: ''" in handler.error
+session.show()
+session.loop_until_closed()
 
-    def test_script_cwd(self):
-        doc = Document()
-        handler = CodeHandler(source="""import os; raise RuntimeError("cwd: '%s'" % os.getcwd())""", filename="/test_filename")
-        handler.modify_document(doc)
+"""
 
-        assert handler.error is not None
-        assert "cwd: '/'" in handler.error
 
-    def test_script_argv(self):
-        doc = Document()
-        handler = CodeHandler(source="""import sys; raise RuntimeError("argv: %r" % sys.argv)""", filename="/test_filename")
-        handler.modify_document(doc)
+def test_empty_script():
+    doc = Document()
+    handler = CodeHandler(source="# This script does nothing", filename="/test_filename")
+    handler.modify_document(doc)
+    if handler.failed:
+        raise RuntimeError(handler.error)
 
-        assert handler.error is not None
-        assert "argv: ['test_filename']" in handler.error
+    assert not doc.roots
 
-        doc = Document()
-        handler = CodeHandler(source="""import sys; raise RuntimeError("argv: %r" % sys.argv)""", filename="/test_filename", argv=[10, 20, 30])
-        handler.modify_document(doc)
+def test_script_adds_roots():
+    doc = Document()
+    handler = CodeHandler(source=script_adds_two_roots, filename="/test_filename")
+    handler.modify_document(doc)
+    if handler.failed:
+        raise RuntimeError(handler.error)
 
-        assert handler.error is not None
-        assert "argv: ['test_filename', 10, 20, 30]" in handler.error
+    assert len(doc.roots) == 2
+
+def test_script_bad_syntax():
+    doc = Document()
+    handler = CodeHandler(source="This is a syntax error", filename="/test_filename")
+    handler.modify_document(doc)
+
+    assert handler.error is not None
+    assert 'Invalid syntax' in handler.error
+
+def test_script_runtime_error():
+    doc = Document()
+    handler = CodeHandler(source="raise RuntimeError('nope')", filename="/test_filename")
+    handler.modify_document(doc)
+
+    assert handler.error is not None
+    assert 'nope' in handler.error
+
+def test_script_sys_path():
+    doc = Document()
+    handler = CodeHandler(source="""import sys; raise RuntimeError("path: '%s'" % sys.path[0])""", filename="/test_filename")
+    handler.modify_document(doc)
+
+    assert handler.error is not None
+    assert "path: ''" in handler.error
+
+def test_script_cwd():
+    doc = Document()
+    handler = CodeHandler(source="""import os; raise RuntimeError("cwd: '%s'" % os.getcwd())""", filename="/test_filename")
+    handler.modify_document(doc)
+
+    assert handler.error is not None
+    assert "cwd: '/'" in handler.error
+
+def test_script_argv():
+    doc = Document()
+    handler = CodeHandler(source="""import sys; raise RuntimeError("argv: %r" % sys.argv)""", filename="/test_filename")
+    handler.modify_document(doc)
+
+    assert handler.error is not None
+    assert "argv: ['test_filename']" in handler.error
+
+    doc = Document()
+    handler = CodeHandler(source="""import sys; raise RuntimeError("argv: %r" % sys.argv)""", filename="/test_filename", argv=[10, 20, 30])
+    handler.modify_document(doc)
+
+    assert handler.error is not None
+    assert "argv: ['test_filename', 10, 20, 30]" in handler.error
+
+def test_script_uses_iofuncs():
+    doc = Document()
+    handler = CodeHandler(source=script_uses_iofuncs, filename="/test_filename")
+    handler._logger_text = "%s, %s"
+    handler.modify_document(doc)
+    if handler.failed:
+        raise RuntimeError(handler.error)
+    assert handler.failed is False
+    assert handler.error is None
+    assert len(doc.roots) == 1
+    import sys; sys.stderr.flush()
+
+def test_script_uses_client():
+    doc = Document()
+    handler = CodeHandler(source=script_uses_client, filename="/test_filename")
+    handler._logger_text = "%s, %s"
+    handler.modify_document(doc)
+    if handler.failed:
+        raise RuntimeError(handler.error)
+    assert handler.failed is False
+    assert handler.error is None
+    assert len(doc.roots) == 1

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -327,7 +327,6 @@ def _show_file_with_state(obj, state, new, controller):
 
 def _show_notebook_with_state(obj, state):
     if state.server_enabled:
-        push(state=state)
         snippet = autoload_server(obj, session_id=state.session_id_allowing_none, url=state.url, app_path=state.app_path)
         publish_display_data({'text/html': snippet})
     else:
@@ -338,6 +337,7 @@ def _show_notebook_with_state(obj, state):
         return handle
 
 def _show_server_with_state(obj, state, new, controller):
+    push(state=state)
     show_session(session_id=state.session_id_allowing_none, url=state.url, app_path=state.app_path,
                  new=new, controller=controller)
 

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -338,7 +338,7 @@ def _show_notebook_with_state(obj, state):
         return handle
 
 def _show_server_with_state(obj, state, new, controller):
-    push(state=state)
+    #push(state=state)
     show_session(session_id=state.session_id_allowing_none, url=state.url, app_path=state.app_path,
                  new=new, controller=controller)
 

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -338,7 +338,6 @@ def _show_notebook_with_state(obj, state):
         return handle
 
 def _show_server_with_state(obj, state, new, controller):
-    #push(state=state)
     show_session(session_id=state.session_id_allowing_none, url=state.url, app_path=state.app_path,
                  new=new, controller=controller)
 

--- a/bokeh/tests/test_io.py
+++ b/bokeh/tests/test_io.py
@@ -371,14 +371,12 @@ class Test_ShowNotebookWithState(DefaultStateTester):
 
     @patch('bokeh.io.publish_display_data')
     @patch('bokeh.io.autoload_server')
-    @patch('bokeh.io.push')
-    def test_with_server(self, mock_push, mock_autoload_server, mock_publish_display_data):
+    def test_with_server(self, mock_autoload_server, mock_publish_display_data):
         s = io.State()
         s._server_enabled = True
         mock_autoload_server.return_value = "snippet"
 
         io._show_notebook_with_state("obj", s)
-        self._check_func_called(mock_push, (), {"state": s})
         self._check_func_called(mock_publish_display_data, ({"text/html":"snippet"},), {})
 
     @patch('bokeh.io.get_comms')

--- a/examples/howto/server_animated.ipynb
+++ b/examples/howto/server_animated.ipynb
@@ -1,0 +1,304 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "from numpy import pi, cos, sin, linspace, roll, zeros_like\n",
+    "from bokeh.plotting import figure, show, output_notebook, output_server, curdoc\n",
+    "from bokeh.client import push_session"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "N = 50 + 1\n",
+    "r_base = 8\n",
+    "theta = linspace(0, 2*pi, N)\n",
+    "r_x = linspace(0, 6*pi, N-1)\n",
+    "rmin = r_base - cos(r_x) - 1\n",
+    "rmax = r_base + sin(r_x) + 1\n",
+    "colors = [\n",
+    "    \"FFFFCC\", \"#C7E9B4\", \"#7FCDBB\", \"#41B6C4\", \"#2C7FB8\", \n",
+    "    \"#253494\", \"#2C7FB8\", \"#41B6C4\", \"#7FCDBB\", \"#C7E9B4\"\n",
+    "] * 5\n",
+    "cx = cy = zeros_like(rmin)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*To run these examples you must execute the command `python bokeh-server` in the top-level Bokeh source directory first.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <div class=\"bk-banner\">\n",
+       "        <a href=\"http://bokeh.pydata.org\" target=\"_blank\" class=\"bk-logo bk-logo-small bk-logo-notebook\"></a>\n",
+       "        <span id=\"9d37c8c3-feb4-4b7b-954f-0d762217f6f7\">Loading BokehJS ...</span>\n",
+       "    </div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "\n",
+       "(function(global) {\n",
+       "  function now() {\n",
+       "    return new Date();\n",
+       "  }\n",
+       "\n",
+       "  if (typeof (window._bokeh_onload_callbacks) === \"undefined\") {\n",
+       "    window._bokeh_onload_callbacks = [];\n",
+       "  }\n",
+       "\n",
+       "  function run_callbacks() {\n",
+       "    window._bokeh_onload_callbacks.forEach(function(callback) { callback() });\n",
+       "    delete window._bokeh_onload_callbacks\n",
+       "    console.info(\"Bokeh: all callbacks have finished\");\n",
+       "  }\n",
+       "\n",
+       "  function load_libs(js_urls, callback) {\n",
+       "    window._bokeh_onload_callbacks.push(callback);\n",
+       "    if (window._bokeh_is_loading > 0) {\n",
+       "      console.log(\"Bokeh: BokehJS is being loaded, scheduling callback at\", now());\n",
+       "      return null;\n",
+       "    }\n",
+       "    if (js_urls == null || js_urls.length === 0) {\n",
+       "      run_callbacks();\n",
+       "      return null;\n",
+       "    }\n",
+       "    console.log(\"Bokeh: BokehJS not loaded, scheduling load and callback at\", now());\n",
+       "    window._bokeh_is_loading = js_urls.length;\n",
+       "    for (var i = 0; i < js_urls.length; i++) {\n",
+       "      var url = js_urls[i];\n",
+       "      var s = document.createElement('script');\n",
+       "      s.src = url;\n",
+       "      s.async = false;\n",
+       "      s.onreadystatechange = s.onload = function() {\n",
+       "        window._bokeh_is_loading--;\n",
+       "        if (window._bokeh_is_loading === 0) {\n",
+       "          console.log(\"Bokeh: all BokehJS libraries loaded\");\n",
+       "          run_callbacks()\n",
+       "        }\n",
+       "      };\n",
+       "      s.onerror = function() {\n",
+       "        console.warn(\"failed to load library \" + url);\n",
+       "      };\n",
+       "      console.log(\"Bokeh: injecting script tag for BokehJS library: \", url);\n",
+       "      document.getElementsByTagName(\"head\")[0].appendChild(s);\n",
+       "    }\n",
+       "  };\n",
+       "\n",
+       "  var js_urls = ['https://cdn.pydata.org/bokeh/dev/bokeh-0.12.0dev12.min.js', 'https://cdn.pydata.org/bokeh/dev/bokeh-widgets-0.12.0dev12.min.js', 'https://cdn.pydata.org/bokeh/dev/bokeh-compiler-0.12.0dev12.min.js'];\n",
+       "\n",
+       "  var inline_js = [\n",
+       "    function(Bokeh) {\n",
+       "      Bokeh.set_log_level(\"info\");\n",
+       "    },\n",
+       "    \n",
+       "    function(Bokeh) {\n",
+       "      Bokeh.$(\"#9d37c8c3-feb4-4b7b-954f-0d762217f6f7\").text(\"BokehJS successfully loaded\");\n",
+       "    },\n",
+       "    function(Bokeh) {\n",
+       "      console.log(\"Bokeh: injecting CSS: https://cdn.pydata.org/bokeh/dev/bokeh-0.12.0dev12.min.css\");\n",
+       "      Bokeh.embed.inject_css(\"https://cdn.pydata.org/bokeh/dev/bokeh-0.12.0dev12.min.css\");\n",
+       "      console.log(\"Bokeh: injecting CSS: https://cdn.pydata.org/bokeh/dev/bokeh-widgets-0.12.0dev12.min.css\");\n",
+       "      Bokeh.embed.inject_css(\"https://cdn.pydata.org/bokeh/dev/bokeh-widgets-0.12.0dev12.min.css\");\n",
+       "    }\n",
+       "  ];\n",
+       "\n",
+       "  function run_inline_js() {\n",
+       "    for (var i = 0; i < inline_js.length; i++) {\n",
+       "      inline_js[i](window.Bokeh);\n",
+       "    }\n",
+       "  }\n",
+       "\n",
+       "  if (window._bokeh_is_loading === 0) {\n",
+       "    console.log(\"Bokeh: BokehJS loaded, going straight to plotting\");\n",
+       "    run_inline_js();\n",
+       "  } else {\n",
+       "    load_libs(js_urls, function() {\n",
+       "      console.log(\"Bokeh: BokehJS plotting callback run at\", now());\n",
+       "      run_inline_js();\n",
+       "    });\n",
+       "  }\n",
+       "}(this));"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "output_server()\n",
+    "output_notebook()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "session = push_session(curdoc(), session_id='default')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "p = figure(x_range=[-11, 11], y_range=[-11, 11])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "r = p.annular_wedge(cx, cy, rmin, rmax, theta[:-1], theta[1:],\n",
+    "                fill_color = colors, line_color=\"black\", name=\"aw\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "ds = r.data_source\n",
+    "\n",
+    "def update():\n",
+    "    rmin = roll(ds.data[\"inner_radius\"], 1)\n",
+    "    rmax = roll(ds.data[\"outer_radius\"], -1)\n",
+    "    ds.data.update(inner_radius=rmin, outer_radius=rmax)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<bokeh.document.PeriodicCallback at 0x10bfe4400>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "curdoc().add_root(p)\n",
+    "curdoc().add_periodic_callback(update, 30)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<script\n",
+       "    src=\"http://localhost:5006/autoload.js?bokeh-autoload-element=53420906-c21d-4850-b4c8-2ef6828bab4d&bokeh-session-id=default\"\n",
+       "    id=\"53420906-c21d-4850-b4c8-2ef6828bab4d\"\n",
+       "    data-bokeh-model-id=\"854cad67-ea89-4054-ba5d-6a28df889251\"\n",
+       "    data-bokeh-doc-id=\"\"\n",
+       "></script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#session.show(p)\n",
+    "show(p)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "session.loop_until_closed() "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/examples/howto/server_animated.ipynb
+++ b/examples/howto/server_animated.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -44,115 +44,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "    <div class=\"bk-banner\">\n",
-       "        <a href=\"http://bokeh.pydata.org\" target=\"_blank\" class=\"bk-logo bk-logo-small bk-logo-notebook\"></a>\n",
-       "        <span id=\"9d37c8c3-feb4-4b7b-954f-0d762217f6f7\">Loading BokehJS ...</span>\n",
-       "    </div>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "(function(global) {\n",
-       "  function now() {\n",
-       "    return new Date();\n",
-       "  }\n",
-       "\n",
-       "  if (typeof (window._bokeh_onload_callbacks) === \"undefined\") {\n",
-       "    window._bokeh_onload_callbacks = [];\n",
-       "  }\n",
-       "\n",
-       "  function run_callbacks() {\n",
-       "    window._bokeh_onload_callbacks.forEach(function(callback) { callback() });\n",
-       "    delete window._bokeh_onload_callbacks\n",
-       "    console.info(\"Bokeh: all callbacks have finished\");\n",
-       "  }\n",
-       "\n",
-       "  function load_libs(js_urls, callback) {\n",
-       "    window._bokeh_onload_callbacks.push(callback);\n",
-       "    if (window._bokeh_is_loading > 0) {\n",
-       "      console.log(\"Bokeh: BokehJS is being loaded, scheduling callback at\", now());\n",
-       "      return null;\n",
-       "    }\n",
-       "    if (js_urls == null || js_urls.length === 0) {\n",
-       "      run_callbacks();\n",
-       "      return null;\n",
-       "    }\n",
-       "    console.log(\"Bokeh: BokehJS not loaded, scheduling load and callback at\", now());\n",
-       "    window._bokeh_is_loading = js_urls.length;\n",
-       "    for (var i = 0; i < js_urls.length; i++) {\n",
-       "      var url = js_urls[i];\n",
-       "      var s = document.createElement('script');\n",
-       "      s.src = url;\n",
-       "      s.async = false;\n",
-       "      s.onreadystatechange = s.onload = function() {\n",
-       "        window._bokeh_is_loading--;\n",
-       "        if (window._bokeh_is_loading === 0) {\n",
-       "          console.log(\"Bokeh: all BokehJS libraries loaded\");\n",
-       "          run_callbacks()\n",
-       "        }\n",
-       "      };\n",
-       "      s.onerror = function() {\n",
-       "        console.warn(\"failed to load library \" + url);\n",
-       "      };\n",
-       "      console.log(\"Bokeh: injecting script tag for BokehJS library: \", url);\n",
-       "      document.getElementsByTagName(\"head\")[0].appendChild(s);\n",
-       "    }\n",
-       "  };\n",
-       "\n",
-       "  var js_urls = ['https://cdn.pydata.org/bokeh/dev/bokeh-0.12.0dev12.min.js', 'https://cdn.pydata.org/bokeh/dev/bokeh-widgets-0.12.0dev12.min.js', 'https://cdn.pydata.org/bokeh/dev/bokeh-compiler-0.12.0dev12.min.js'];\n",
-       "\n",
-       "  var inline_js = [\n",
-       "    function(Bokeh) {\n",
-       "      Bokeh.set_log_level(\"info\");\n",
-       "    },\n",
-       "    \n",
-       "    function(Bokeh) {\n",
-       "      Bokeh.$(\"#9d37c8c3-feb4-4b7b-954f-0d762217f6f7\").text(\"BokehJS successfully loaded\");\n",
-       "    },\n",
-       "    function(Bokeh) {\n",
-       "      console.log(\"Bokeh: injecting CSS: https://cdn.pydata.org/bokeh/dev/bokeh-0.12.0dev12.min.css\");\n",
-       "      Bokeh.embed.inject_css(\"https://cdn.pydata.org/bokeh/dev/bokeh-0.12.0dev12.min.css\");\n",
-       "      console.log(\"Bokeh: injecting CSS: https://cdn.pydata.org/bokeh/dev/bokeh-widgets-0.12.0dev12.min.css\");\n",
-       "      Bokeh.embed.inject_css(\"https://cdn.pydata.org/bokeh/dev/bokeh-widgets-0.12.0dev12.min.css\");\n",
-       "    }\n",
-       "  ];\n",
-       "\n",
-       "  function run_inline_js() {\n",
-       "    for (var i = 0; i < inline_js.length; i++) {\n",
-       "      inline_js[i](window.Bokeh);\n",
-       "    }\n",
-       "  }\n",
-       "\n",
-       "  if (window._bokeh_is_loading === 0) {\n",
-       "    console.log(\"Bokeh: BokehJS loaded, going straight to plotting\");\n",
-       "    run_inline_js();\n",
-       "  } else {\n",
-       "    load_libs(js_urls, function() {\n",
-       "      console.log(\"Bokeh: BokehJS plotting callback run at\", now());\n",
-       "      run_inline_js();\n",
-       "    });\n",
-       "  }\n",
-       "}(this));"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "output_server()\n",
     "output_notebook()"
@@ -160,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -171,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -182,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -194,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -210,22 +106,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<bokeh.document.PeriodicCallback at 0x10bfe4400>"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "curdoc().add_root(p)\n",
     "curdoc().add_periodic_callback(update, 30)\n"
@@ -233,35 +118,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "<script\n",
-       "    src=\"http://localhost:5006/autoload.js?bokeh-autoload-element=53420906-c21d-4850-b4c8-2ef6828bab4d&bokeh-session-id=default\"\n",
-       "    id=\"53420906-c21d-4850-b4c8-2ef6828bab4d\"\n",
-       "    data-bokeh-model-id=\"854cad67-ea89-4054-ba5d-6a28df889251\"\n",
-       "    data-bokeh-doc-id=\"\"\n",
-       "></script>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "#session.show(p)\n",
     "show(p)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -296,7 +164,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.4.4"
   }
  },
  "nbformat": 4,

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -100,11 +100,15 @@ possible with the Bokeh server, but often involves integrating a Bokeh
 server with other web application frameworks. See a complete example at
 https://github.com/bokeh/bokeh-demos/tree/master/happiness
 
+.. _userguide_server_ways_to_use:
+
+Ways to Use the Bokeh Server
+----------------------------
 
 .. _userguide_server_output_server:
 
 Specifying ``output_server``
-----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 With the previous Flask-based Bokeh server, there was a function
 :func:`bokeh.io.output_server` that could be used to load Bokeh documents
@@ -155,12 +159,16 @@ to the correct URL to view the document, which in this case is:
 
 .. code-block:: none
 
-    http://localhost:5006/?bokeh-session-id=hover
+    http://localhost:5006/?bokeh-session-id=hovero
+
+.. warning::
+    The ``output_server`` method is generally only useful for local,
+    individual exploration, and not for "deployment" scenarios.
 
 .. _userguide_server_bokeh_client:
 
 Connecting with ``bokeh.client``
---------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 With the new Tornado and websocket-based server introduced in Bokeh 0.11,
 there is also a proper client API for interacting directly with a Bokeh
@@ -247,14 +255,32 @@ and the server, there is network traffic between the python client and the
 server as well. Depending on the particular usage, this could be a
 significant consideration.
 
+.. _userguide_server_bokeh_applications:
+
+Bokeh Applications
+~~~~~~~~~~~~~~~~~~
+
+By far the most flexible way to create interactive data visualizations using
+the Bokeh server is to create Bokeh Applications, and serve them with the
+``bokeh serve`` command. This typically looks like:
+
+.. code-block:: sh
+
+    bokeh serve --show myapp.py
+
+where ``myapp.py`` is a simple Python script that sets up the widgets and
+plots that you need. The Bokeh server is designed to be horizontally
+scalable, so running applications in this way is suitable for individual
+or exploratory usage, as well as for deploying rich interactive web
+apps to a wider audience in a scalable way.
+
 .. _userguide_server_applications:
 
 Building Bokeh Applications
 ---------------------------
 
-By far the most flexible way to create interactive data visualizations using
-the Bokeh server is to create Bokeh Applications, and serve them with the
-``bokeh serve`` command.
+There are various different formats that can be used to create Bokeh
+applications.
 
 .. _userguide_server_applications_single_module:
 
@@ -434,7 +460,6 @@ In this case you might have code similar to:
 And similar code to load the JavaScript implementation for a custom model
 from ``models/custom.js``
 
-
 .. _userguide_server_applications_callbacks:
 
 Callbacks and Events
@@ -449,7 +474,8 @@ JavaScript Callbacks in the Browser
 
 Regardless of whether there is a Bokeh Server involved, it is possible to
 create callbacks that execute in the browser, using ``CustomJS`` and other
-methods. See :ref:`userguide_interaction_actions` for more detailed information and examples.
+methods. See :ref:`userguide_interaction_actions` for more detailed information
+and examples.
 
 It is critical to note that **no python code is ever executed when a CustomJS
 callback is used**. This is true even when the call back is supplied as python
@@ -660,6 +686,52 @@ any or all of the following conventionally named functions:
         ''' If present, this function is called when a session is closed. '''
         pass
 
+.. _userguide_server_notebook_applications:
+
+Creating Applications from Notebooks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It is possible to use a Bokeh server in conjunction with a running Jupyter
+notebook. In this case, code will need to use the methods described in
+:ref:`userguide_server_bokeh_client` inside the notebook. You will need
+to create your ``session`` in the following way:
+
+.. code-block:: python
+
+    session = push_session(curdoc(), session_id='default')
+
+
+
+The Bokeh server itself will need to be started in a way that allows
+connections from the notebook. Typically, if the notebook is running
+locally on its default port 8888, this is:
+
+.. code-block:: sh
+
+    bokeh serve --allow-websocket-origin=localhost:8888
+
+Then Bokeh widgets and plots will appear inline in your notebook cells,
+but be connected to the running Bokeh server, triggering callbacks and
+events.
+
+.. note::
+    We hope to automate the startup/shutdown of a properly configured
+    Bokeh server for user with the notebook in future work.
+
+A full example notebook demonstrating thee techniques can be seen at:
+:bokeh-tree:`examples/howto/server_animated.ipynb`
+
+The method described above can be useful for local exploration, or
+prototyping. However it may be desirable to turn a notebook into a full
+Bokeh app that runs directly in the Bokeh server. Fortunatetly this is as
+simple as running the notebook, unmodified, with the Bokeh server, e.g.:
+``bokeh serve myfile.ipynb``. In this context, the Bokeh server will ignore
+any ``bokeh.client`` code that was used to enable interactions while
+working directly in the notebook. It is also possible to use all the features
+of a :ref:`userguide_server_applications_directory` application, by naming
+the notebook ``main.ipynb``. An app created by running the server on a
+notebook is scalable and deployable in the same way as any other Bokeh
+application.
 
 .. _userguide_server_deployment:
 
@@ -678,7 +750,8 @@ Standalone Bokeh Server
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 First, it is possible to simply run the Bokeh server on a network for users
-to interact with directly. Depending on the computational burden of your application code, the number of users, the power of the machine used to run
+to interact with directly. Depending on the computational burden of your
+application code, the number of users, the power of the machine used to run
 on, etc., this could be a simple and immediate option for deployment an
 internal network.
 
@@ -690,9 +763,12 @@ these considerations.
 SSH Tunnels
 '''''''''''
 
-It may be convenient or necessary to run a standalone instance of the Bokeh server on a host to which direct access cannot be allowed. In such cases, ssh can be used to "tunnel" to the server.
+It may be convenient or necessary to run a standalone instance of the Bokeh
+server on a host to which direct access cannot be allowed. In such cases,
+ssh can be used to "tunnel" to the server.
 
-In the simplest scenario, the Bokeh server will run on one host and will be accessed from another location, e.g., a laptop, with no intermediary machines.
+In the simplest scenario, the Bokeh server will run on one host and will be
+accessed from another location, e.g., a laptop, with no intermediary machines.
 
 Run the server as usual on the **remote host**:
 
@@ -700,32 +776,49 @@ Run the server as usual on the **remote host**:
 
     bokeh server
 
-Next, issue the following command on the **local machine** to establish an ssh tunnel to the remote host:
+Next, issue the following command on the **local machine** to establish an ssh
+tunnel to the remote host:
 
 .. code-block:: sh
 
     ssh -NfL localhost:5006:localhost:5006  user@remote.host
 
-Replace *user* with your username on the remote host and *remote.host* with the hostname/IP address of the system hosting the Bokeh server. You may be prompted for login credentials for the remote system. After the connection is set up you will be able to navigate to ``localhost:5006`` as though the Bokeh server were running on the local machine.
+Replace *user* with your username on the remote host and *remote.host* with
+the hostname/IP address of the system hosting the Bokeh server. You may be
+prompted for login credentials for the remote system. After the connection
+is set up you will be able to navigate to ``localhost:5006`` as though the
+Bokeh server were running on the local machine.
 
-The second, slightly more complicated case occurs when there is a gateway between the server and the local machine.  In that situation a reverse tunnel must be estabished from the server to the gateway. Additionally the tunnel from the local machine will also point to the gateway.
+The second, slightly more complicated case occurs when there is a gateway
+between the server and the local machine.  In that situation a reverse tunnel
+must be estabished from the server to the gateway. Additionally the tunnel
+from the local machine will also point to the gateway.
 
-Issue the following commands on the **remote host** where the Bokeh server will run:
+Issue the following commands on the **remote host** where the Bokeh server
+will run:
 
 .. code-block:: sh
 
     nohup bokeh server &
     ssh -NfR 5006:localhost:5006 user@gateway.host
 
-Replace *user* with your username on the gateway and *gateway.host* with the hostname/IP address of the gateway. You may be prompted for login credentials for the gateway.
+Replace *user* with your username on the gateway and *gateway.host* with
+the hostname/IP address of the gateway. You may be prompted for login
+credentials for the gateway.
 
-Now set up the other half of the tunnel, from the local machine to the gateway. On the **local machine**:
+Now set up the other half of the tunnel, from the local machine to the
+gateway. On the **local machine**:
 
 .. code-block:: sh
 
     ssh -NfL localhost:5006:localhost:5006 user@gateway.host
 
-Again, replace *user* with your username on the gateway and *gateway.host* with the hostname/IP address of the gateway. You should now be able to access the Bokeh server from the local machine by navigating to ``localhost:5006`` on the local machine, as if the Bokeh server were running on the local machine. You can even set up client connections from a Jupyter notebook running on the local machine.
+Again, replace *user* with your username on the gateway and *gateway.host*
+with the hostname/IP address of the gateway. You should now be able to access
+the Bokeh server from the local machine by navigating to ``localhost:5006`` on
+the local machine, as if the Bokeh server were running on the local machine.
+You can even set up client connections from a Jupyter notebook running on the
+local machine.
 
 .. note::
     We intend to expand this section with more guidance for other tools and


### PR DESCRIPTION
- [x] issues: fixes #3461
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

With this, the notebook can either be run with:

    bokeh serve --allow-websocket-origin=localhost:8888

in one terminal, and

    ipython server_animated.ipynb

and *Cell -> Run All*. This uses `bokeh.client` to connect the python code running in the Jupyter kernel to the server, the same as the examples in `examples/plotting/server`.

Alternatively, the app can be run directly in the server with:

    bokeh server server_animated.ipynb

Running this way, the server monkey patches all the relevant `bokeh.io` and `bokeh.client` to duo nothing, and runs the code from the notebook as a true app, directly in the server. 