### PR TITLE
properly update button appearance on button_type

### DIFF
--- a/bokehjs/src/coffee/models/widgets/toggle.coffee
+++ b/bokehjs/src/coffee/models/widgets/toggle.coffee
@@ -22,6 +22,7 @@ class ToggleView extends Widget.View
         val.$el.detach()
 
     @$el.empty()
+    @$el.removeClass()
     @$el.addClass("bk-bs-btn")
     @$el.addClass("bk-bs-btn-" + @mget("button_type"))
     if @mget("disabled") then @$el.attr("disabled", "disabled")


### PR DESCRIPTION
issues: fixes #4572

`@$el.empty()` does not remove classes, so CSS classes for the type were
simply accumulating. Use `@$el.removeClass()` to properly remove all CSS
classes on start of render.