### PR TITLE
Revert performance regression "fix" from #4493

### DIFF
--- a/bokehjs/src/coffee/models/layouts/layout_dom.coffee
+++ b/bokehjs/src/coffee/models/layouts/layout_dom.coffee
@@ -56,11 +56,7 @@ class LayoutDOMView extends BokehView
 
   bind_bokeh_events: () ->
     @listenTo(@model, 'change', @render)
-
-    if @model.sizing_mode == 'fixed'
-      @listenToOnce(@model.document.solver(), 'resize', @render)
-    else
-      @listenTo(@model.document.solver(), 'resize', @render)
+    @listenTo(@model.document.solver(), 'resize', () => @render())
 
     # Note: `sizing_mode` update is not supported because changing the
     # sizing_mode mode necessitates stripping out all the relevant constraints

--- a/bokehjs/src/coffee/models/plots/plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.coffee
@@ -413,8 +413,8 @@ class PlotCanvasView extends Renderer.View
     @listenTo(@model.plot.toolbar, 'change:tools', @build_levels)
     @listenTo(@model.plot, 'change', @request_render)
     @listenTo(@model.plot, 'destroy', () => @remove())
-    @listenTo(@model.plot.document.solver(), 'layout_update', @request_render)
-    @listenTo(@model.plot.document.solver(), 'resize', @resize)
+    @listenTo(@model.plot.document.solver(), 'layout_update', () => @request_render())
+    @listenTo(@model.plot.document.solver(), 'resize', () => @resize())
 
   set_initial_range : () ->
     # check for good values for ranges before setting initial range

--- a/bokehjs/test/models/layouts/layout_dom.coffee
+++ b/bokehjs/test/models/layouts/layout_dom.coffee
@@ -122,7 +122,7 @@ describe "LayoutDOM.View", ->
       expect(@solver_suggest.args[0]).to.be.deep.equal [@layout._width, 22]
       expect(@solver_suggest.args[1]).to.be.deep.equal [@layout._height, 33]
 
-    it "should only listen to resize event once if sizing_mode is fixed", ->
+    it.skip "should only listen to resize event once if sizing_mode is fixed", ->
       @layout.sizing_mode = 'fixed'
       render_spy = sinon.spy(LayoutDOMView.prototype, 'render')
       layout_view = new LayoutDOMView({ model: @layout })


### PR DESCRIPTION
This fixes #4611, but reverts #4493, so #4488 performance regression is still there. I shouldn't be using the word *fixes* at all right now, because I don't fully understand what is going on in the rendering pipeline.