### PR TITLE
Update scale on mainGlGlyph obj and not self

### DIFF
--- a/bokehjs/src/coffee/models/glyphs/webgl/line.coffee
+++ b/bokehjs/src/coffee/models/glyphs/webgl/line.coffee
@@ -670,7 +670,7 @@ class LineGLGlyph extends BaseGLGlyph
 
       # Do we need to re-calculate segment data and cumsum?
       if Math.abs(@_scale_aspect - (sy / sx)) > Math.abs(1e-3 * @_scale_aspect)
-        @_update_scale(sx, sy)
+        mainGlGlyph.update_scale(sx, sy)
         @_scale_aspect = sy / sx
 
       # Select buffers from main glyph
@@ -692,6 +692,7 @@ class LineGLGlyph extends BaseGLGlyph
       @prog.set_uniform('u_scale_aspect', 'vec2', [sx, sy])
       @prog.set_uniform('u_scale_length', 'float', [scale_length])
 
+      @I_triangles = mainGlGlyph.I_triangles
       if @I_triangles.length < 65535
         # Data is small enough to draw in one pass
         @index_buffer.set_size(@I_triangles.length*2)
@@ -873,7 +874,7 @@ class LineGLGlyph extends BaseGLGlyph
         I[i*6+4] = 0 + 4*i
         I[i*6+5] = 3 + 4*i
 
-    _update_scale: (sx, sy) ->
+    update_scale: (sx, sy) ->
       # Update segment data and cumsum so the length along the line has the
       # scale aspect ratio in it. In the vertex shader we multiply with the
       # "isotropic part" of the scale.

--- a/bokehjs/src/coffee/models/glyphs/webgl/line.coffee
+++ b/bokehjs/src/coffee/models/glyphs/webgl/line.coffee
@@ -670,7 +670,7 @@ class LineGLGlyph extends BaseGLGlyph
 
       # Do we need to re-calculate segment data and cumsum?
       if Math.abs(@_scale_aspect - (sy / sx)) > Math.abs(1e-3 * @_scale_aspect)
-        mainGlGlyph.update_scale(sx, sy)
+        mainGlGlyph._update_scale(sx, sy)
         @_scale_aspect = sy / sx
 
       # Select buffers from main glyph
@@ -874,7 +874,7 @@ class LineGLGlyph extends BaseGLGlyph
         I[i*6+4] = 0 + 4*i
         I[i*6+5] = 3 + 4*i
 
-    update_scale: (sx, sy) ->
+    _update_scale: (sx, sy) ->
       # Update segment data and cumsum so the length along the line has the
       # scale aspect ratio in it. In the vertex shader we multiply with the
       # "isotropic part" of the scale.


### PR DESCRIPTION
- [x] issues: fixes #4633

I'm not entirely sure of the consequences of the changes. It seems that the computed attributes were being set on the wrong object (self and not the mainGlGlyph arg), so I just changed it.

The webgl examples still seem to work... 

ping @almarklein 

Discussion:
* Any good strategies for preventing regressions beyond a selenium test?

