### PR TITLE
Render widgets and widget box correctly

### DIFF
--- a/bokeh/models/widgets/buttons.py
+++ b/bokeh/models/widgets/buttons.py
@@ -60,6 +60,7 @@ class AbstractButton(Widget, ButtonLike):
     A callback to run in the browser whenever the button is activated.
     """)
 
+
 class Button(AbstractButton):
     """ A click button.
 
@@ -68,8 +69,6 @@ class Button(AbstractButton):
     clicks = Int(0, help="""
     A private property used to trigger ``on_click`` event handler.
     """)
-
-    height = Override(default=45)
 
     def on_click(self, handler):
         """ Set up a handler for button clicks.
@@ -82,6 +81,7 @@ class Button(AbstractButton):
 
         """
         self.on_change('clicks', lambda attr, old, new: handler())
+
 
 class Toggle(AbstractButton):
     """ A two-state toggle button.

--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -58,6 +58,7 @@ class TextInput(InputWidget):
     widget by hitting Enter or clicking outside of the text box area.
     """)
 
+
 class AutocompleteInput(TextInput):
     """ Single-line input widget with auto-completion. """
 
@@ -66,7 +67,6 @@ class AutocompleteInput(TextInput):
     user upon typing the beginning of a desired value.
     """)
 
-    height = Override(default=65)
 
 class Select(InputWidget):
     """ Single-select widget.
@@ -85,8 +85,6 @@ class Select(InputWidget):
     A callback to run in the browser whenever the current Select dropdown
     value changes.
     """)
-
-    height = Override(default=65)
 
     @classmethod
     def create(self, *args, **kwargs):

--- a/bokehjs/src/coffee/models/layouts/widget_box.coffee
+++ b/bokehjs/src/coffee/models/layouts/widget_box.coffee
@@ -14,6 +14,10 @@ LayoutDOM = require "../layouts/layout_dom"
 class WidgetBoxView extends LayoutDOM.View
   className: "bk-widget-box"
 
+  initialize: (options) ->
+    super()
+    @render()
+
   bind_bokeh_events: () ->
     super()
     @listenTo(@model, 'change:children', @build_child_views)

--- a/bokehjs/src/coffee/models/layouts/widget_box.coffee
+++ b/bokehjs/src/coffee/models/layouts/widget_box.coffee
@@ -16,9 +16,6 @@ class WidgetBoxView extends LayoutDOM.View
 
   initialize: (options) ->
     super(options)
-    if not @model.document._unrendered_widgetboxes?
-      @model.document._unrendered_widgetboxes = {}  # poor man's set
-    @model.document._unrendered_widgetboxes[@id] = true
     @render()
 
   bind_bokeh_events: () ->
@@ -57,15 +54,11 @@ class WidgetBoxView extends LayoutDOM.View
     else
       @$el.css({
         width: css_width
-        height: @model._height._value + 20
+        # Note we DO NOT want to set a height (except in stretch_both). Widgets
+        # are happier sizing themselves. We've tried to tell the layout what
+        # the height is with the suggest_value. But that doesn't mean we need
+        # to put it in the dom.
       })
-
-    # As with plot_canvas, this is necessary to kick widget boxes into action
-    if @model.document._unrendered_widgetboxes?
-      delete @model.document._unrendered_widgetboxes[@id]
-      if _.isEmpty(@model.document._unrendered_widgetboxes)
-        @model.document._unrendered_widgetboxes = null
-        _.delay($.proxy(@model.document.resize, @model.document), 1)
 
   get_height: () ->
     height = 0

--- a/bokehjs/src/coffee/models/widgets/abstract_button.coffee
+++ b/bokehjs/src/coffee/models/widgets/abstract_button.coffee
@@ -29,8 +29,12 @@ class AbstractButtonView extends Widget.View
     html = @template(@model.attributes)
     @$el.append(html)
 
+    $button = @$el.find('button')
+
     if icon?
-      @$el.find('button').prepend(@icon_views[icon.id].$el)
+      $button.prepend(@icon_views[icon.id].$el)
+
+    $button.prop("disabled", @model.disabled)
 
     return @
 

--- a/bokehjs/src/coffee/models/widgets/abstract_button.coffee
+++ b/bokehjs/src/coffee/models/widgets/abstract_button.coffee
@@ -18,6 +18,7 @@ class AbstractButtonView extends Widget.View
 
   render: () ->
     super()
+
     icon = @model.icon
     if icon?
       build_views(@icon_views, [icon])
@@ -30,13 +31,11 @@ class AbstractButtonView extends Widget.View
 
     if icon?
       @$el.find('button').prepend(@icon_views[icon.id].$el)
-    @$el.find('button').prop("disabled", @model.disabled)
 
     return @
 
   change_input: () ->
-    if not @model.disabled
-      @model.callback?.execute(@model)
+    @model.callback?.execute(@model)
 
 
 class AbstractButton extends Widget.Model

--- a/bokehjs/src/coffee/models/widgets/abstract_button.coffee
+++ b/bokehjs/src/coffee/models/widgets/abstract_button.coffee
@@ -1,10 +1,47 @@
 p = require "../../core/properties"
 
+build_views = require "../../common/build_views"
 Widget = require "./widget"
+template = require "./button_template"
+
+
+class AbstractButtonView extends Widget.View
+  events:
+    "click": "change_input"
+  template: template
+
+  initialize: (options) ->
+    super(options)
+    @icon_views = {}
+    @listenTo(@model, 'change', @render)
+    @render()
+
+  render: () ->
+    super()
+    icon = @model.icon
+    if icon?
+      build_views(@icon_views, [icon])
+      for own key, val of @icon_views
+        val.$el.detach()
+
+    @$el.empty()
+    html = @template(@model.attributes)
+    @$el.append(html)
+
+    if icon?
+      @$el.find('button').prepend(@icon_views[icon.id].$el)
+    @$el.find('button').prop("disabled", @model.disabled)
+
+    return @
+
+  change_input: () ->
+    if not @model.disabled
+      @model.callback?.execute(@model)
 
 
 class AbstractButton extends Widget.Model
   type: "AbstractButton"
+  default_view: AbstractButtonView
 
   @define {
     callback:    [ p.Instance          ]
@@ -16,3 +53,4 @@ class AbstractButton extends Widget.Model
 
 module.exports =
   Model: AbstractButton
+  View: AbstractButtonView

--- a/bokehjs/src/coffee/models/widgets/button.coffee
+++ b/bokehjs/src/coffee/models/widgets/button.coffee
@@ -20,10 +20,6 @@ class Button extends AbstractButton.Model
     clicks: [ p.Number, 0        ]
   }
 
-  @override {
-    height: 45
-  }
-
 module.exports =
   Model: Button
   View: ButtonView

--- a/bokehjs/src/coffee/models/widgets/button.coffee
+++ b/bokehjs/src/coffee/models/widgets/button.coffee
@@ -1,61 +1,28 @@
 _ = require "underscore"
 
-build_views = require "../../common/build_views"
 p = require "../../core/properties"
 
 AbstractButton = require "./abstract_button"
-Widget = require "./widget"
 
-template = require "./button_template"
 
-class ButtonView extends Widget.View
-  events:
-    "click": "change_input"
-  template: template
-
-  initialize: (options) ->
-    super(options)
-    @icon_views = {}
-    @listenTo(@model, 'change', @render)
-    @render()
-
-  render: () ->
-    super()
-
-    icon = @mget('icon')
-    if icon?
-      build_views(@icon_views, [icon])
-      for own key, val of @icon_views
-        val.$el.detach()
-
-    @$el.empty()
-    html = @template(@model.attributes)
-    @$el.append(html)
-
-    label = @mget("label")
-    if icon?
-      @$el.find('button').append(@icon_views[icon.id].$el)
-      label = " #{label}"
-
-    @$el.find('button').append(label)
-
-    return @
+class ButtonView extends AbstractButton.View
 
   change_input: () ->
+    super()
     @mset('clicks', @mget('clicks') + 1)
-    @mget('callback')?.execute(@model)
+
 
 class Button extends AbstractButton.Model
   type: "Button"
   default_view: ButtonView
 
   @define {
-      clicks: [ p.Number, 0        ]
-    }
+    clicks: [ p.Number, 0        ]
+  }
 
   @override {
-      height: 45
-    }
+    height: 45
+  }
 
 module.exports =
   Model: Button

--- a/bokehjs/src/coffee/models/widgets/button_group_template.eco
+++ b/bokehjs/src/coffee/models/widgets/button_group_template.eco
@@ -1,0 +1,2 @@
+<div class="bk-bs-btn-group" data-bk-bs-toggle="buttons">
+</div>

--- a/bokehjs/src/coffee/models/widgets/button_template.eco
+++ b/bokehjs/src/coffee/models/widgets/button_template.eco
@@ -1,1 +1,3 @@
-<button type="button" class="bk-bs-btn bk-bs-btn-<%=@button_type%>" <%=@disabled%> ></button>
+<button type="button" class="bk-bs-btn bk-bs-btn-<%=@button_type%>">
+  <%=@label%>
+</button>

--- a/bokehjs/src/coffee/models/widgets/checkbox_button_group.coffee
+++ b/bokehjs/src/coffee/models/widgets/checkbox_button_group.coffee
@@ -5,11 +5,13 @@ $1 = require "bootstrap/button"
 Widget = require "./widget"
 BokehView = require "../../core/bokeh_view"
 p = require "../../core/properties"
+template = require "./button_group_template"
+
 
 class CheckboxButtonGroupView extends Widget.View
-  tagName: "div"
   events:
     "change input": "change_input"
+  template: template
 
   initialize: (options) ->
     super(options)
@@ -18,20 +20,20 @@ class CheckboxButtonGroupView extends Widget.View
 
   render: () ->
     super()
+
     @$el.empty()
+    html = @template()
+    @$el.append(html)
 
-    @$el.addClass("bk-bs-btn-group")
-    @$el.attr("data-bk-bs-toggle", "buttons")
-
-    active = @mget("active")
-    for label, i in @mget("labels")
+    active = @model.active
+    for label, i in @model.labels
       $input = $('<input type="checkbox">').attr(value: "#{i}")
       if i in active then $input.prop("checked", true)
       $label = $('<label class="bk-bs-btn"></label>')
       $label.text(label).prepend($input)
       $label.addClass("bk-bs-btn-" + @mget("button_type"))
       if i in active then $label.addClass("bk-bs-active")
-      @$el.append($label)
+      @$el.find('.bk-bs-btn-group').append($label)
 
     return @
 

--- a/bokehjs/src/coffee/models/widgets/checkbox_group.coffee
+++ b/bokehjs/src/coffee/models/widgets/checkbox_group.coffee
@@ -5,8 +5,8 @@ Widget = require "./widget"
 BokehView = require "../../core/bokeh_view"
 p = require "../../core/properties"
 
-class CheckboxGroupView extends BokehView
-  tagName: "div"
+
+class CheckboxGroupView extends Widget.View
   events:
     "change input": "change_input"
 
@@ -16,6 +16,7 @@ class CheckboxGroupView extends BokehView
     @listenTo(@model, 'change', @render)
 
   render: () ->
+    super()
     @$el.empty()
 
     active = @mget("active")

--- a/bokehjs/src/coffee/models/widgets/data_table.coffee
+++ b/bokehjs/src/coffee/models/widgets/data_table.coffee
@@ -161,6 +161,8 @@ class DataTableView extends Widget.View
 
     if width?
       @$el.css(width: "#{@mget("width")}px")
+    else
+      @$el.css(width: "#{@mget("default_width")}px")
     if height? and height != "auto"
       @$el.css(height: "#{@mget("height")}px")
 
@@ -200,6 +202,10 @@ class DataTable extends TableWidget.Model
 
   @override {
     height: 400
+  }
+
+  @internal {
+    default_width:        [ p.Number, 600   ]
   }
 
 module.exports =

--- a/bokehjs/src/coffee/models/widgets/data_table.coffee
+++ b/bokehjs/src/coffee/models/widgets/data_table.coffee
@@ -138,7 +138,6 @@ class DataTableView extends Widget.View
     }
 
   render: () ->
-    super()
     columns = (column.toColumn() for column in @mget("columns"))
 
     if @mget("selectable") == "checkbox"

--- a/bokehjs/src/coffee/models/widgets/date_picker.coffee
+++ b/bokehjs/src/coffee/models/widgets/date_picker.coffee
@@ -5,9 +5,9 @@ $1 = require "jquery-ui/datepicker"
 p = require "../../core/properties"
 
 InputWidget = require "./input_widget"
-Widget = require "./widget"
 
-class DatePickerView extends Widget.View
+
+class DatePickerView extends InputWidget.View
 
   initialize: (options) ->
     super(options)

--- a/bokehjs/src/coffee/models/widgets/date_range_slider.coffee
+++ b/bokehjs/src/coffee/models/widgets/date_range_slider.coffee
@@ -5,9 +5,9 @@ $1 = require "jqrangeslider/jQDateRangeSlider"
 p = require "../../core/properties"
 
 InputWidget = require "./input_widget"
-Widget = require "./widget"
 
-class DateRangeSliderView extends Widget.View
+
+class DateRangeSliderView extends InputWidget.View
 
   initialize: (options) ->
     super(options)

--- a/bokehjs/src/coffee/models/widgets/div.coffee
+++ b/bokehjs/src/coffee/models/widgets/div.coffee
@@ -1,17 +1,17 @@
-_ = require "underscore"
+$ = require "jquery"
 
 Markup = require "./markup"
 p = require "../../core/properties"
 
 class DivView extends Markup.View
-  tagName: "div"
 
   render: () ->
     super()
-    if @mget('render_as_text') == true
-      @$el.text(@mget('text'))
+    if @model.render_as_text == true
+      $content = $('<div></div>').text(@model.text)
     else
-      @$el.html(@mget('text'))
+      $content = $('<div></div>').html(@model.text)
+    @$el.find('.bk-markup').append($content)
     return @
 
 class Div extends Markup.Model

--- a/bokehjs/src/coffee/models/widgets/dropdown.coffee
+++ b/bokehjs/src/coffee/models/widgets/dropdown.coffee
@@ -4,65 +4,38 @@ $ = require "jquery"
 p = require "../../core/properties"
 
 AbstractButton = require "./abstract_button"
-Widget = require "./widget"
 
+template = require "./dropdown_template"
 
-class DropdownView extends Widget.View
-  tagName: "div"
-
-  initialize: (options) ->
-    super(options)
-    @render()
-    @listenTo(@model, 'change', @render)
+class DropdownView extends AbstractButton.View
+  template: template
 
   render: () ->
     super()
-    @$el.empty()
 
-    split = @mget("default_value")?
-
-    $button = $('<button></button>')
-    $button.addClass("bk-bs-btn")
-    $button.addClass("bk-bs-btn-" + @mget("button_type"))
-    $button.text(@mget("label"))
-
-    $caret = $('<span class="bk-bs-caret"></span>')
-    if not split
-      $button.addClass("bk-bs-dropdown-toggle")
-      $button.attr("data-bk-bs-toggle", "dropdown")
-      $button.append(document.createTextNode(" "))
-      $button.append($caret)
-      $toggle = $('')
-    else
-      $button.click(() => @change_input(@mget("default_value")))
-      $toggle = $('<button></button>')
-      $toggle.addClass("bk-bs-btn")
-      $toggle.addClass("bk-bs-btn-" + @mget("button_type"))
-      $toggle.addClass("bk-bs-dropdown-toggle")
-      $toggle.attr("data-bk-bs-toggle", "dropdown")
-      $toggle.append($caret)
-
-    $menu = $('<ul class="bk-bs-dropdown-menu"></ul>')
-    $divider = $('<li class="bk-bs-divider"></li>')
-
-    for item in @mget("menu")
+    items = []
+    for item in @model.menu
       $item = if item?
         [label, value] = item
-        $a = $('<a></a>').text(label).data('value', value)
+        $a = $("<a data-value='#{value}'>#{label}</a>")
         that = this
-        $a.click((e) -> that.change_input($(this).data('value')))
+        $a.click((e) -> that.set_value($(this).data('value')))
         $('<li></li>').append($a)
       else
-        $divider
-      $menu.append($item)
+        $('<li class="bk-bs-divider"></li>')
+      items.push($item)
 
-    @$el.addClass("bk-bs-btn-group")
-    @$el.append([$button, $toggle, $menu])
+    @$el.find('.bk-bs-dropdown-menu').append(items)
+    @$el.find('button').val(@model.default_value)
     return @
 
-  change_input: (value) ->
-    @mset('value', value)
-    @mget('callback')?.execute(@model)
+  set_value: (value) ->
+    # Set the bokeh model to value
+    @model.value = value
+    # Set the html button value to value
+    @$el.find('button').val(value)
+
+
 
 class Dropdown extends AbstractButton.Model
   type: "Dropdown"

--- a/bokehjs/src/coffee/models/widgets/dropdown_template.eco
+++ b/bokehjs/src/coffee/models/widgets/dropdown_template.eco
@@ -1,0 +1,5 @@
+<button type="button" class="bk-bs-btn bk-bs-btn-<%=@button_type%> bk-bs-dropdown-toggle" data-bk-bs-toggle="dropdown">
+  <%=@label%> <span class="bk-bs-caret"></span>
+</button>
+<ul class="bk-bs-dropdown-menu">
+</ul>

--- a/bokehjs/src/coffee/models/widgets/dropdown_template.eco
+++ b/bokehjs/src/coffee/models/widgets/dropdown_template.eco
@@ -1,4 +1,4 @@
-<button type="button" class="bk-bs-btn bk-bs-btn-<%=@button_type%> bk-bs-dropdown-toggle" data-bk-bs-toggle="dropdown">
+<button type="button" class="bk-bs-btn bk-bs-btn-<%=@button_type%> bk-bs-dropdown-toggle bk-bs-dropdown-btn" data-bk-bs-toggle="dropdown">
   <%=@label%> <span class="bk-bs-caret"></span>
 </button>
 <ul class="bk-bs-dropdown-menu">

--- a/bokehjs/src/coffee/models/widgets/input_widget.coffee
+++ b/bokehjs/src/coffee/models/widgets/input_widget.coffee
@@ -3,8 +3,16 @@ _ = require "underscore"
 Widget = require "./widget"
 p = require "../../core/properties"
 
+class InputWidgetView extends Widget.View
+
+  render:
+    super()
+    @$el.find('input').prop("disabled", @model.disabled)
+
+
 class InputWidget extends Widget.Model
   type: "InputWidget"
+  default_view: InputWidgetView
 
   @define {
       callback: [ p.Instance   ]
@@ -13,3 +21,4 @@ class InputWidget extends Widget.Model
 
 module.exports =
   Model: InputWidget
+  View: InputWidgetView

--- a/bokehjs/src/coffee/models/widgets/input_widget.coffee
+++ b/bokehjs/src/coffee/models/widgets/input_widget.coffee
@@ -5,9 +5,12 @@ p = require "../../core/properties"
 
 class InputWidgetView extends Widget.View
 
-  render:
+  render: () ->
     super()
     @$el.find('input').prop("disabled", @model.disabled)
+
+  change_input: () ->
+    @mget('callback')?.execute(@model)
 
 
 class InputWidget extends Widget.Model

--- a/bokehjs/src/coffee/models/widgets/markup.coffee
+++ b/bokehjs/src/coffee/models/widgets/markup.coffee
@@ -1,11 +1,12 @@
-_ = require "underscore"
-
 p = require "../../core/properties"
 
 Widget = require "./widget"
+template = require "./markup_template"
 
 
 class MarkupView extends Widget.View
+  template: template
+
   initialize: (options) ->
     super(options)
     @render()
@@ -13,6 +14,8 @@ class MarkupView extends Widget.View
 
   render: () ->
     super()
+    @$el.empty()
+    @$el.html(@template())
     if @mget('height')
       @$el.height(@mget('height'))
     if @mget('width')

--- a/bokehjs/src/coffee/models/widgets/markup_template.eco
+++ b/bokehjs/src/coffee/models/widgets/markup_template.eco
@@ -1,0 +1,2 @@
+<div class="bk-markup">
+</div>

--- a/bokehjs/src/coffee/models/widgets/multiselect.coffee
+++ b/bokehjs/src/coffee/models/widgets/multiselect.coffee
@@ -4,12 +4,11 @@ $ = require "underscore"
 p = require "../../core/properties"
 
 InputWidget = require "./input_widget"
-Widget = require "./widget"
 
 multiselecttemplate = require "./multiselecttemplate"
 
 
-class MultiSelectView extends Widget.View
+class MultiSelectView extends InputWidget.View
   tagName: "div"
   template: multiselecttemplate
   events:

--- a/bokehjs/src/coffee/models/widgets/multiselect.coffee
+++ b/bokehjs/src/coffee/models/widgets/multiselect.coffee
@@ -40,8 +40,12 @@ class MultiSelectView extends InputWidget.View
     )
 
   change_input: () ->
-    @mset('value', @$('select').val())
-    @mget('callback')?.execute(@model)
+    super()
+    value = @$el.find('select').val()
+    if value
+      @model.value = value
+    else 
+      @model.value = []
 
 class MultiSelect extends InputWidget.Model
   type: "MultiSelect"

--- a/bokehjs/src/coffee/models/widgets/multiselect.coffee
+++ b/bokehjs/src/coffee/models/widgets/multiselect.coffee
@@ -44,7 +44,7 @@ class MultiSelectView extends InputWidget.View
     value = @$el.find('select').val()
     if value
       @model.value = value
-    else 
+    else
       @model.value = []
 
 class MultiSelect extends InputWidget.Model

--- a/bokehjs/src/coffee/models/widgets/paragraph.coffee
+++ b/bokehjs/src/coffee/models/widgets/paragraph.coffee
@@ -1,18 +1,14 @@
-_ = require "underscore"
+$ = require "jquery"
 
 Markup = require "./markup"
-p = require "../../core/properties"
 
 class ParagraphView extends Markup.View
-  tagName: "p"
 
   render: () ->
     super()
-    @$el.text(@mget('text'))
     # This overrides default user-agent styling and helps layout work
-    @$el.css({
-      margin: 0
-    })
+    $para = $('<p style="margin: 0;"></p>').text(@model.text)
+    @$el.find('.bk-markup').append($para)
 
 class Paragraph extends Markup.Model
   type: "Paragraph"

--- a/bokehjs/src/coffee/models/widgets/pretext.coffee
+++ b/bokehjs/src/coffee/models/widgets/pretext.coffee
@@ -7,7 +7,7 @@ class PreTextView extends Markup.View
 
   render: () ->
     super()
-    $pre = $('<pre></pre>').text(@model.text)
+    $pre = $('<pre style="overflow: auto"></pre>').text(@model.text)
     @$el.find('.bk-markup').append($pre)
 
 class PreText extends Markup.Model

--- a/bokehjs/src/coffee/models/widgets/pretext.coffee
+++ b/bokehjs/src/coffee/models/widgets/pretext.coffee
@@ -1,14 +1,16 @@
-_ = require "underscore"
+$ = require "jquery"
 
-Paragraph = require "./paragraph"
+Markup = require "./markup"
 p = require "../../core/properties"
 
-class PreTextView extends Paragraph.View
-  tagName: "pre"
-  attributes:
-    style: "overflow:scroll"
+class PreTextView extends Markup.View
 
-class PreText extends Paragraph.Model
+  render: () ->
+    super()
+    $pre = $('<pre></pre>').text(@model.text)
+    @$el.find('.bk-markup').append($pre)
+
+class PreText extends Markup.Model
   type: "PreText"
   default_view: PreTextView
 

--- a/bokehjs/src/coffee/models/widgets/radio_button_group.coffee
+++ b/bokehjs/src/coffee/models/widgets/radio_button_group.coffee
@@ -5,12 +5,13 @@ $1 = require "bootstrap/button"
 p = require "../../core/properties"
 
 Widget = require "./widget"
+template = require "./button_group_template"
 
 
 class RadioButtonGroupView extends Widget.View
-  tagName: "div"
   events:
     "change input": "change_input"
+  template: template
 
   initialize: (options) ->
     super(options)
@@ -19,10 +20,10 @@ class RadioButtonGroupView extends Widget.View
 
   render: () ->
     super()
-    @$el.empty()
 
-    @$el.addClass("bk-bs-btn-group")
-    @$el.attr("data-bk-bs-toggle", "buttons")
+    @$el.empty()
+    html = @template()
+    @$el.append(html)
 
     name = _.uniqueId("RadioButtonGroup")
     active = @mget("active")
@@ -33,7 +34,8 @@ class RadioButtonGroupView extends Widget.View
       $label.text(label).prepend($input)
       $label.addClass("bk-bs-btn-" + @mget("button_type"))
       if i == active then $label.addClass("bk-bs-active")
-      @$el.append($label)
+      @$el.find('.bk-bs-btn-group').append($label)
+
     return @
 
   change_input: () ->

--- a/bokehjs/src/coffee/models/widgets/selectbox.coffee
+++ b/bokehjs/src/coffee/models/widgets/selectbox.coffee
@@ -14,10 +14,10 @@ class SelectView extends InputWidget.View
     "change select": "change_input"
 
   change_input: () ->
+    super()
     value = @$('select').val()
     logger.debug("selectbox: value = #{value}")
     @mset('value', value)
-    @mget('callback')?.execute(@model)
 
   initialize: (options) ->
     super(options)
@@ -39,10 +39,6 @@ class Select extends InputWidget.Model
   @define {
       value:   [ p.String, '' ]
       options: [ p.Any,    [] ] # TODO (bev) is this used?
-    }
-
-  @override {
-      height: 65
     }
 
 module.exports =

--- a/bokehjs/src/coffee/models/widgets/selectbox.coffee
+++ b/bokehjs/src/coffee/models/widgets/selectbox.coffee
@@ -4,12 +4,11 @@ _ = require "underscore"
 p = require "../../core/properties"
 
 InputWidget = require "./input_widget"
-Widget = require "./widget"
 
 template = require "./selecttemplate"
 
 
-class SelectView extends Widget.View
+class SelectView extends InputWidget.View
   template: template
   events:
     "change select": "change_input"

--- a/bokehjs/src/coffee/models/widgets/slider.coffee
+++ b/bokehjs/src/coffee/models/widgets/slider.coffee
@@ -10,7 +10,7 @@ Widget = require "./widget"
 slidertemplate = require "./slidertemplate"
 
 
-class SliderView extends Widget.View
+class SliderView extends InputWidget.View
   tagName: "div"
   template: slidertemplate
 

--- a/bokehjs/src/coffee/models/widgets/text_input.coffee
+++ b/bokehjs/src/coffee/models/widgets/text_input.coffee
@@ -7,10 +7,9 @@ p = require "../../core/properties"
 
 InputWidget = require "./input_widget"
 template = require "./text_input_template"
-Widget = require "./widget"
 
 
-class TextInputView extends Widget.View
+class TextInputView extends InputWidget.View
   tagName: "div"
   attributes:
      class: "bk-widget-form-group"

--- a/bokehjs/src/coffee/models/widgets/text_input.coffee
+++ b/bokehjs/src/coffee/models/widgets/text_input.coffee
@@ -26,14 +26,15 @@ class TextInputView extends InputWidget.View
     super()
     @$el.html(@template(@model.attributes))
     # TODO - This 35 is a hack we should be able to compute it
-    @$el.find('input').height(@mget('height') - 35)
+    if @model.height
+      @$el.find('input').height(@mget('height') - 35)
     return @
 
   change_input: () ->
+    super()
     value = @$('input').val()
     logger.debug("widget/text_input: value = #{value}")
     @mset('value', value)
-    @mget('callback')?.execute(@model)
 
 class TextInput extends InputWidget.Model
   type: "TextInput"
@@ -41,10 +42,6 @@ class TextInput extends InputWidget.Model
 
   @define {
       value: [ p.String, "" ]
-    }
-
-  @override {
-      height: 65
     }
 
 module.exports =

--- a/bokehjs/src/coffee/models/widgets/toggle.coffee
+++ b/bokehjs/src/coffee/models/widgets/toggle.coffee
@@ -1,47 +1,21 @@
 p = require "../../core/properties"
 
 AbstractButton = require "./abstract_button"
-Widget = require "./widget"
 
 
-class ToggleView extends Widget.View
-  tagName: "button"
-  events:
-    "click": "change_input"
-
-  initialize: (options) ->
-    super(options)
-    @render()
-    @listenTo(@model, 'change', @render)
+class ToggleView extends AbstractButton.View
 
   render: () ->
-    icon = @mget('icon')
-    if icon?
-      build_views(@views, [icon])
-      for own key, val of @views
-        val.$el.detach()
-
-    @$el.empty()
-    @$el.removeClass()
-    @$el.addClass("bk-bs-btn")
-    @$el.addClass("bk-bs-btn-" + @mget("button_type"))
-    if @mget("disabled") then @$el.attr("disabled", "disabled")
-
-    label = @mget("label")
-    if icon?
-      @$el.append(@views[icon.id].$el)
-      label = " #{label}"
-    @$el.append(document.createTextNode(label))
-
+    super()
     if @mget("active")
-      @$el.addClass("bk-bs-active")
+      @$el.find('button').addClass("bk-bs-active")
     else
-      @$el.removeClass("bk-bs-active")
+      @$el.find('button').removeClass("bk-bs-active")
     return @
 
   change_input: () ->
+    super()
     @mset('active', not @mget('active'))
-    @mget('callback')?.execute(@model)
 
 
 class Toggle extends AbstractButton.Model

--- a/bokehjs/src/coffee/models/widgets/widget.coffee
+++ b/bokehjs/src/coffee/models/widgets/widget.coffee
@@ -8,7 +8,10 @@ class WidgetView extends LayoutDOM.View
     # LayoutDOM.View sets up lots of helpful things, but
     # it's render method is not suitable for widgets - who
     # should provide their own.
-    null
+    if @model.height
+      @$el.height(@model.height)
+    if @model.width
+      @$el.width(@model.width)
 
 
 class Widget extends LayoutDOM.Model

--- a/bokehjs/src/less/widgets.less
+++ b/bokehjs/src/less/widgets.less
@@ -56,17 +56,17 @@
 }
 
 /* dropdown */
-.bk-bs-dropdown-toggle .bk-bs-caret {
+.bk-bs-dropdown-btn .bk-bs-caret {
   margin-right: 5px;
   margin-bottom: 5px;
   left: 0px;
   color: #A1A6A9;
 }
 
-.bk-bs-dropdown-toggle.bk-bs-btn-danger .bk-bs-caret,
-.bk-bs-dropdown-toggle.bk-bs-btn-warning .bk-bs-caret,
-.bk-bs-dropdown-toggle.bk-bs-btn-primary .bk-bs-caret,
-.bk-bs-dropdown-toggle.bk-bs-btn-success .bk-bs-caret {
+.bk-bs-dropdown-btn.bk-bs-btn-danger .bk-bs-caret,
+.bk-bs-dropdown-btn.bk-bs-btn-warning .bk-bs-caret,
+.bk-bs-dropdown-btn.bk-bs-btn-primary .bk-bs-caret,
+.bk-bs-dropdown-btn.bk-bs-btn-success .bk-bs-caret {
   color: white;
 }
 

--- a/bokehjs/src/less/widgets.less
+++ b/bokehjs/src/less/widgets.less
@@ -46,7 +46,7 @@
 
 /* misc */
 .bk-widget button {
-  min-width: 50%;
+  min-width: 100%;
 }
 .bk-widget input[type="text"] {
   min-width: 90%;
@@ -59,7 +59,19 @@
 .bk-bs-dropdown-toggle .bk-bs-caret {
   margin-right: 5px;
   margin-bottom: 5px;
+  left: 0px;
   color: #A1A6A9;
+}
+
+.bk-bs-dropdown-toggle.bk-bs-btn-danger .bk-bs-caret,
+.bk-bs-dropdown-toggle.bk-bs-btn-warning .bk-bs-caret,
+.bk-bs-dropdown-toggle.bk-bs-btn-primary .bk-bs-caret,
+.bk-bs-dropdown-toggle.bk-bs-btn-success .bk-bs-caret {
+  color: white;
+}
+
+.bk-bs-dropdown-menu {
+  width: 100%;
 }
 
 /* tabs */

--- a/bokehjs/test/models/layouts/widget_box.coffee
+++ b/bokehjs/test/models/layouts/widget_box.coffee
@@ -59,8 +59,8 @@ describe "WidgetBox", ->
       widget_box_view = new @widget_box.default_view({ model: @widget_box })
       widget_box_view.child_views = {'child_view_1': {'el': {'scrollHeight': 222}}}
       widget_box_view.render()
-      # Note we do not set margin & padding on WidgetBox
-      expected_style = "width: #{width - 20}px; height: #{height + 10}px;"
+      # Note we do not set margin & padding or height on fixed WidgetBox
+      expected_style = "width: #{width - 20}px;"
       expect(widget_box_view.$el.attr('style')).to.be.equal expected_style
 
     it "get_height should return the height of the widget children plus 10 for margin + 10 overall", ->
@@ -74,9 +74,10 @@ describe "WidgetBox", ->
         'child_view_1': {'el': {'scrollHeight': 222}}
         'child_view_2': {'el': {'scrollHeight': 23}}
       }
-      expect(widget_box_view.get_height()).to.be.equal 222 + 10 + 23 + 10 + 10
+      expect(widget_box_view.get_height()).to.be.equal 222 + 10 + 23 + 10
 
     it "get_width should return the max of it and the children", ->
+      @widget_box.width = null  # Manually set to null to check calc
       widget_box_view = new @widget_box.default_view({ model: @widget_box })
       widget_box_view.el = {'scrollWidth': 99}
       widget_box_view.child_views = {
@@ -87,6 +88,7 @@ describe "WidgetBox", ->
       expect(widget_box_view.get_width()).to.be.equal 189
 
     it "get_width should return itself + 20 if no children", ->
+      @widget_box.width = null  # Manually set to null to check calc
       widget_box_view = new @widget_box.default_view({ model: @widget_box })
       widget_box_view.el = {'scrollWidth': 99}
       widget_box_view.child_views = {

--- a/bokehjs/test/models/widgets/paragraph.coffee
+++ b/bokehjs/test/models/widgets/paragraph.coffee
@@ -19,5 +19,5 @@ describe "Paragraph.View render", ->
     p.attach_document(new Document())
     p_view = new p.default_view({ model: p })
     p_view.render()
-    expected_style = "margin: 0px;"
-    expect(p_view.$el.attr('style')).to.contain expected_style
+    expected_style = "margin: 0;"
+    expect(p_view.$el.find('p').attr('style')).to.contain expected_style

--- a/examples/models/buttons_server.py
+++ b/examples/models/buttons_server.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 
 from bokeh.client import push_session
 from bokeh.document import Document
-from bokeh.layouts import widgetbox
 from bokeh.models.layouts import WidgetBox
 from bokeh.models.widgets import (
     Icon, Button, Toggle, Dropdown, CheckboxGroup, RadioGroup,
@@ -33,14 +32,14 @@ def checkbox_button_group_handler(active):
 def radio_button_group_handler(active):
     print("radio_button_group_handler: %s" % active)
 
-button = Button(label="Push button", icon=Icon(icon_name="check"), button_type="primary", disabled=True)
+button = Button(label="Push button", icon=Icon(icon_name="check"), button_type="primary")
 button.on_click(button_handler)
 
 toggle = Toggle(label="Toggle button", button_type="success")
 toggle.on_click(toggle_handler)
 
 menu = [("Item 1", "item_1_value"), ("Item 2", "item_2_value"), ("Item 3", "item_3_value")]
-dropdown = Dropdown(label="Dropdown button", button_type="default", menu=menu, default_value="item_1_value")
+dropdown = Dropdown(label="Dropdown button", button_type="warning", menu=menu, default_value="item_1_value")
 dropdown.on_click(dropdown_handler)
 
 split_menu = [("Item 1", "item_1_value"), ("Item 2", "item_2_value"), None, ("Item 3", "item_3_value")]
@@ -59,7 +58,7 @@ checkbox_button_group.on_click(checkbox_button_group_handler)
 radio_button_group = RadioButtonGroup(labels=["Option 1", "Option 2", "Option 3"], active=0)
 radio_button_group.on_click(radio_button_group_handler)
 
-widgetBox = widgetbox(children=[button, toggle, dropdown, split, checkbox_group, radio_group, checkbox_button_group, radio_button_group], sizing_mode='scale_width')
+widgetBox = WidgetBox(children=[button, toggle, dropdown, split, checkbox_group, radio_group, checkbox_button_group, radio_button_group])
 
 document = Document()
 document.add_root(widgetBox)

--- a/examples/models/buttons_server.py
+++ b/examples/models/buttons_server.py
@@ -32,7 +32,7 @@ def checkbox_button_group_handler(active):
 def radio_button_group_handler(active):
     print("radio_button_group_handler: %s" % active)
 
-button = Button(label="Push button", icon=Icon(icon_name="check"), button_type="primary")
+button = Button(label="Button (disabled) - still has click event", icon=Icon(icon_name="check"), button_type="primary", disabled=True)
 button.on_click(button_handler)
 
 toggle = Toggle(label="Toggle button", button_type="success")

--- a/examples/models/buttons_server.py
+++ b/examples/models/buttons_server.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 from bokeh.client import push_session
 from bokeh.document import Document
+from bokeh.layouts import widgetbox
 from bokeh.models.layouts import WidgetBox
 from bokeh.models.widgets import (
     Icon, Button, Toggle, Dropdown, CheckboxGroup, RadioGroup,
@@ -32,18 +33,18 @@ def checkbox_button_group_handler(active):
 def radio_button_group_handler(active):
     print("radio_button_group_handler: %s" % active)
 
-button = Button(label="Push button", icon=Icon(icon_name="check"), button_type="primary")
+button = Button(label="Push button", icon=Icon(icon_name="check"), button_type="primary", disabled=True)
 button.on_click(button_handler)
 
 toggle = Toggle(label="Toggle button", button_type="success")
 toggle.on_click(toggle_handler)
 
-menu = [("Item 1", "item_1"), ("Item 2", "item_2"), None, ("Item 3", "item_3")]
-dropdown = Dropdown(label="Dropdown button", button_type="warning", menu=menu)
+menu = [("Item 1", "item_1_value"), ("Item 2", "item_2_value"), ("Item 3", "item_3_value")]
+dropdown = Dropdown(label="Dropdown button", button_type="default", menu=menu, default_value="item_1_value")
 dropdown.on_click(dropdown_handler)
 
-menu = [("Item 1", "foo"), ("Item 2", "bar"), None, ("Item 3", "baz")]
-split = Dropdown(label="Split button", button_type="danger", menu=menu, default_value="baz")
+split_menu = [("Item 1", "item_1_value"), ("Item 2", "item_2_value"), None, ("Item 3", "item_3_value")]
+split = Dropdown(label="Split button", button_type="danger", menu=split_menu)
 split.on_click(split_handler)
 
 checkbox_group = CheckboxGroup(labels=["Option 1", "Option 2", "Option 3"], active=[0, 1])
@@ -58,7 +59,7 @@ checkbox_button_group.on_click(checkbox_button_group_handler)
 radio_button_group = RadioButtonGroup(labels=["Option 1", "Option 2", "Option 3"], active=0)
 radio_button_group.on_click(radio_button_group_handler)
 
-widgetBox = WidgetBox(children=[button, toggle, dropdown, split, checkbox_group, radio_group, checkbox_button_group, radio_button_group])
+widgetBox = widgetbox(children=[button, toggle, dropdown, split, checkbox_group, radio_group, checkbox_button_group, radio_button_group], sizing_mode='scale_width')
 
 document = Document()
 document.add_root(widgetBox)


### PR DESCRIPTION
This PR takes care of some clean-up that should have been done before, and fixes a bug in widgetbox rendering. Fixes: #4601, #4636, #3346

1) All widgets should not pollute their widget wrapper. The widget wrapper looks something like this `<div id="1234" class="bk-widget bk-layout-fixed">` and may have a width/height/x/y position. All html and classes related to the widget should be inside this box for predictable widget results. I did some of this during the layout PR, but forgot to go back and clean-up the others.  (I'm leaving data_table as an exception to this as it's very complicated and I wouldn't want to break it, and I think it'll be ok).
2) I have fixed some rendering issues with the WidgetBox. Some of this was due to bugs introduced by the initialization PR, I also now set a sensible default for a fixed widgetbox (which has some implications, but is overall a good thing).

There's also some small clean-up of the `buttons_server.py` example, which could have been in a different PR, but snuck in here.