### PR TITLE
Updated ggplot & mpl_exporter Legend Fix

### DIFF
--- a/bokeh/core/compat/mplexporter/exporter.py
+++ b/bokeh/core/compat/mplexporter/exporter.py
@@ -168,7 +168,7 @@ class Exporter(object):
                             and child.get_text() == 'None'):
                         self.draw_text(ax, child, force_trans=ax.transAxes)
                 elif isinstance(child, matplotlib.lines.Line2D):
-                    self.draw_line(ax, child, force_trans=ax.transAxes)
+                    warnings.warn("Legend element %s not implemented" % child)
                 elif isinstance(child, matplotlib.collections.Collection):
                     self.draw_collection(ax, child,
                                          force_pathtrans=ax.transAxes)

--- a/examples/compat/ggplot_density.py
+++ b/examples/compat/ggplot_density.py
@@ -5,7 +5,7 @@ from bokeh import mpl
 from bokeh.plotting import output_file, show
 
 g = ggplot(diamonds, aes(x='price', color='cut')) + geom_density()
-g.draw()
+g.make()
 
 plt.title("Density ggplot-based plot in Bokeh.")
 

--- a/examples/compat/ggplot_line.py
+++ b/examples/compat/ggplot_line.py
@@ -5,7 +5,7 @@ from bokeh import mpl
 from bokeh.plotting import output_file, show
 
 g = ggplot(aes(x='date', y='beef'), data=meat) + geom_line()
-g.draw()
+g.make()
 
 plt.title("Line ggplot-based plot in Bokeh.")
 

--- a/examples/compat/ggplot_step.py
+++ b/examples/compat/ggplot_step.py
@@ -13,7 +13,7 @@ df = pd.DataFrame({
 df.y = df.y.cumsum()
 
 g = ggplot(aes(x='x', y='y'), data=df) + geom_step()
-g.draw()
+g.make()
 
 plt.title("Step ggplot-based plot in Bokeh.")
 

--- a/scripts/travis_install
+++ b/scripts/travis_install
@@ -9,7 +9,6 @@ MINICONDA="Miniconda-$MINICONDA_VERSION-Linux-x86_64"
 MINICONDA_URL="http://repo.continuum.io/miniconda/$MINICONDA.sh"
 
 PINNED_PKGS=$(cat <<EOF
-ggplot ==0.6.5
 EOF
 )
 


### PR DESCRIPTION
Fixes #4559
Partially Fixes #4424 (geom_point with colors still unpredictable at best)
Supersedes #4628 

Updated .draw() to .make() to match yhat ggplot API changes.

Replaced mpl exporter legend line drawing with a warning due to it causing issues with seaborn_tsplot and ggplot_density by graphing the legend as line glyphs.