### PR TITLE
Fix 'defult' -> 'default' in TapTool.behavior attr

### DIFF
--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -274,7 +274,7 @@ class TapTool(Tap):
     defaults to all renderers on a plot.
     """)
 
-    behavior = Enum("select", "inspect", defult="select", help="""
+    behavior = Enum("select", "inspect", default="select", help="""
     This tool can be configured to either make selections or inspections
     on associated data sources. The difference is that selection changes
     propagate across bokeh and other components (e.g. selection glyph)


### PR DESCRIPTION
Fix 'defult' -> 'default' in TapTool.behavior attr

- [ ] issues: fixes #4716 


