### PR TITLE
Geom_Point Fix

### DIFF
--- a/bokeh/core/compat/bokeh_renderer.py
+++ b/bokeh/core/compat/bokeh_renderer.py
@@ -17,6 +17,7 @@ import itertools
 import warnings
 
 import matplotlib as mpl
+from matplotlib.colors import ColorConverter
 import numpy as np
 from six import string_types
 
@@ -191,7 +192,6 @@ class BokehRenderer(Renderer):
         source = ColumnDataSource()
         line.x = source.add(x)
         line.y = source.add(y)
-
         line.line_color = convert_color(style['color'])
         line.line_width = style['linewidth']
         line.line_alpha = style['alpha']
@@ -246,7 +246,32 @@ class BokehRenderer(Renderer):
 
     def draw_path(self, data, coordinates, pathcodes, style,
                   offset=None, offset_coordinates="data", mplobj=None):
+        warnings.warn("Path drawing skipped due to performance issues, please use a mpl PathCollection instead")
         pass
+
+    def draw_path_collection(self, paths, path_coordinates, path_transforms,
+                             offsets, offset_coordinates, offset_order,
+                             styles, mplobj=None):
+        "Given a mpl PathCollection instance create a Bokeh Marker glyph."
+        x = offsets[:, 0]
+        y = offsets[:, 1]
+        style = styles
+
+        warnings.warn("Path markers currently do not handled, defaulting to Circle")
+        marker = Circle()
+        source = ColumnDataSource()
+        marker.x = source.add(x)
+        marker.y = source.add(y)
+
+        marker.line_color = convert_color(tuple(map(tuple,style['edgecolor']))[0])
+        marker.fill_color = convert_color(tuple(map(tuple,style['facecolor']))[0])
+        marker.line_width = style['linewidth'][0]
+        marker.size = 10#style['markersize']
+        marker.fill_alpha = marker.line_alpha = style['alpha']
+
+        r = self.plot.add_glyph(source, marker)
+        self.zorder[r._id] = style['zorder']
+        self.handles[id(mplobj)] = r
 
     def draw_text(self, text, position, coordinates, style,
                   text_type=None, mplobj=None):

--- a/bokeh/core/compat/bokeh_renderer.py
+++ b/bokeh/core/compat/bokeh_renderer.py
@@ -17,7 +17,6 @@ import itertools
 import warnings
 
 import matplotlib as mpl
-from matplotlib.colors import ColorConverter
 import numpy as np
 from six import string_types
 

--- a/bokeh/core/compat/bokeh_renderer.py
+++ b/bokeh/core/compat/bokeh_renderer.py
@@ -245,7 +245,7 @@ class BokehRenderer(Renderer):
 
     def draw_path(self, data, coordinates, pathcodes, style,
                   offset=None, offset_coordinates="data", mplobj=None):
-        # warnings.warn("Path drawing has performance issues")
+        warnings.warn("Path drawing has performance issues, please use mpl PathCollection instead")
         pass
 
     def draw_path_collection(self, paths, path_coordinates, path_transforms,

--- a/examples/compat/ggplot_point.py
+++ b/examples/compat/ggplot_point.py
@@ -8,7 +8,7 @@ from bokeh.plotting import output_file, show
 
 g = ggplot(mtcars, aes(x='wt', y='mpg', color='qsec')) + geom_point()
 g.make()
-import pdb; pdb.set_trace()
+
 plt.title("Point ggplot-based plot in Bokeh.")
 
 output_file("ggplot_point.html", title="ggplot_point.py example")

--- a/examples/compat/ggplot_point.py
+++ b/examples/compat/ggplot_point.py
@@ -12,5 +12,5 @@ import pdb; pdb.set_trace()
 plt.title("Point ggplot-based plot in Bokeh.")
 
 output_file("ggplot_point.html", title="ggplot_point.py example")
-#plt.show()
+
 show(mpl.to_bokeh())


### PR DESCRIPTION
Fixed issue mentioned in #4424 

Previously converting mpl Paths or PathCollections to Bokeh glyphs was not supported. Unfortunately, mpl.gcf() for whatever reason returns a PathCollection instead of a Line2D when handling geom_point from ggplot. This caused the geom_point-turned-PathCollection not to render on the Bokeh plot. Shamelessly copying the draw_markers function from bokeh_renderer into a new draw_path_collection and modifying it a bit to work allows for the paths to be turned into Bokeh glyphs.

Unfortunately there are three limitations:
1. Since the PathCollection stores the shape of the glyph as a path and Bokeh does not yet handle custom glyph shapes, all converted paths default to circle.
2. If someone were to pass a PathCollection for a type of graph other than a scatter plot, it would most likely (untested) result in a scatter plot of the major points instead of, for example, a line plot. Although, this is still better than drawing nothing at all imo.
3. My method of calculating the sizes is no where close to an exact science.

Before Fix:
![3c419be0-28d2-11e6-8161-0b7964395ab0](https://cloud.githubusercontent.com/assets/19802403/16502728/63f8e166-3ed5-11e6-96ce-94b43ebdbaf6.png)

After Fix:
![ggplot_works_mostly](https://cloud.githubusercontent.com/assets/19802403/16502794/ba946f9a-3ed5-11e6-91dd-00d7d05d0ea6.png)
