### PR TITLE
factor JS version into version.coffee, compare to document version

### DIFF
--- a/bokehjs/src/coffee/document.coffee
+++ b/bokehjs/src/coffee/document.coffee
@@ -2,6 +2,7 @@ _ = require "underscore"
 $ = require "jquery"
 
 {Models} = require "./base"
+js_version = require("./version")
 {EQ, Solver, Variable} = require "./core/layout/solver"
 {logger} = require "./core/logging"
 HasProps = require "./core/has_props"
@@ -567,8 +568,17 @@ class Document
     Document.from_json(json)
 
   @from_json : (json) ->
+    logger.debug("Creating Document from JSON")
     if typeof json != 'object'
       throw new Error("JSON object has wrong type #{typeof json}")
+    py_version = json['version']
+    versions_string = "Library versions: JS (#{js_version})  /  Python (#{py_version})"
+    if js_version.split('-')[0] != py_version.split('-')[0]
+      logger.warn("JS/Python version mismatch")
+      logger.warn(versions_string)
+    else
+      logger.debug(versions_string)
+
     roots_json = json['roots']
     root_ids = roots_json['root_ids']
     references_json = roots_json['references']

--- a/bokehjs/src/coffee/main.coffee
+++ b/bokehjs/src/coffee/main.coffee
@@ -2,7 +2,7 @@ _ = require("underscore")
 
 Bokeh = {}
 Bokeh.require = require
-Bokeh.version = '0.12.0'
+Bokeh.version = require("./version")
 
 # binding the libs that bokeh uses so others can reference them
 Bokeh._                 = require("underscore")

--- a/bokehjs/src/coffee/version.coffee
+++ b/bokehjs/src/coffee/version.coffee
@@ -1,0 +1,3 @@
+version = '0.12.0'
+
+module.exports = version

--- a/scripts/version_update.py
+++ b/scripts/version_update.py
@@ -65,7 +65,7 @@ if __name__ == '__main__':
 
     os.chdir('../')
 
-    files_to_update = ['bokehjs/src/coffee/main.coffee', 'bokehjs/package.json']
+    files_to_update = ['bokehjs/src/coffee/version.coffee', 'bokehjs/package.json']
     files_to_add = ['sphinx/source/conf.py']
     updated_version = sys.argv[1]
     last_version = sys.argv[2]


### PR DESCRIPTION
issues: fixes #3001

versions show up on `debug` when they match:

<img width="457" alt="screen shot 2016-07-01 at 1 21 08 pm" src="https://cloud.githubusercontent.com/assets/1078448/16530751/2fcebe3c-3f8f-11e6-8373-af294bd87b20.png">

but accompany a warning if they fail to match:

<img width="460" alt="screen shot 2016-07-01 at 1 22 03 pm" src="https://cloud.githubusercontent.com/assets/1078448/16530744/2aaeae9e-3f8f-11e6-900f-a8ea14317afc.png">

Assumption is that `x.y.z-FOO` matches `x.y.z-BAR` 
