### PR TITLE
allow scripts failures to fail the build

### DIFF
--- a/bokehjs/gulp/tasks/scripts.coffee
+++ b/bokehjs/gulp/tasks/scripts.coffee
@@ -33,13 +33,13 @@ ts = require 'gulp-typescript'
 gulp.task "scripts:coffee", () ->
   gulp.src('./src/coffee/**/*.coffee')
       .pipe(gulpif(argv.incremental, newer({dest: paths.buildDir.jsTree, ext: '.js'})))
-      .pipe(coffee({bare: true}).on('error', gutil.log))
+      .pipe(coffee({bare: true}))
       .pipe(gulp.dest(paths.buildDir.jsTree))
 
 gulp.task "scripts:eco", () ->
   gulp.src('./src/coffee/**/*.eco')
       .pipe(gulpif(argv.incremental, newer({dest: paths.buildDir.jsTree, ext: '.js'})))
-      .pipe(eco().on('error', gutil.log))
+      .pipe(eco())
       .pipe(gulp.dest(paths.buildDir.jsTree))
 
 tsOpts = {


### PR DESCRIPTION
issues: fixes #4525

The problem was that the `scripts` task was configured to "log" errors, instead of letting them fail the build, as described here:

https://github.com/contra/gulp-coffee#error-handling

With this change, e.g. a syntax error now results in:

<img width="724" alt="screen shot 2016-07-01 at 2 02 01 pm" src="https://cloud.githubusercontent.com/assets/1078448/16531919/770231bc-3f94-11e6-9b72-8f035c66b1c6.png">
