### PR TITLE
Fix documented name for ResizeTool

### DIFF
--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -204,7 +204,7 @@ respectively.
 ResizeTool
 ''''''''''
 
-* name: ``'resize_select'``
+* name: ``'resize'``
 * icon: |resize_icon|
 
 The resize tool allows the user to left-drag a mouse or drag a finger to resize


### PR DESCRIPTION
issues: none

Latest (0.12.0) [docs](http://bokeh.pydata.org/en/latest/docs/user_guide/tools.html#resizetool) specify `'resize_select'` as the name for ResizeTool tool, but correct name is just `'resize'`. Fixes doc.

