### PR TITLE
more robust checking for BokehJS load, enable re-rerun of output_note…

### DIFF
--- a/bokeh/core/_templates/autoload_js.js
+++ b/bokeh/core/_templates/autoload_js.js
@@ -23,15 +23,17 @@ calls it with the rendered model.
 :param css_urls: CSS urls to inject
 :type css_urls: list
 
-
 #}
 (function(global) {
   function now() {
     return new Date();
   }
 
-  if (typeof (window._bokeh_onload_callbacks) === "undefined") {
+  var force = "{{ force }}";
+
+  if (typeof (window._bokeh_onload_callbacks) === "undefined" || force !== "") {
     window._bokeh_onload_callbacks = [];
+    window._bokeh_is_loading = undefined;
   }
 
   function run_callbacks() {

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -47,6 +47,8 @@ _new_param = {'tab': 2, 'window': 1}
 
 _state = State()
 
+_nb_loaded = False
+
 #-----------------------------------------------------------------------------
 # Local utilities
 #-----------------------------------------------------------------------------
@@ -325,12 +327,27 @@ def _show_file_with_state(obj, state, new, controller):
     filename = save(obj, state=state)
     controller.open("file://" + filename, new=_new_param[new])
 
+_NB_LOAD_WARNING = """
+
+BokehJS does not appear to have successfully loaded. If loading BokehJS from CDN, this
+may be due to a slow or bad network connection. To attempt to fix:
+
+* re-rerun `output_notebook()` to attempt to load from CDN again, or
+* use INLINE resources instead, as so:
+
+    from bokeh.resources import INLINE
+    output_notebook(resources=INLINE)
+"""
+
 def _show_notebook_with_state(obj, state):
     if state.server_enabled:
         push(state=state)
         snippet = autoload_server(obj, session_id=state.session_id_allowing_none, url=state.url, app_path=state.app_path)
         publish_display_data({'text/html': snippet})
     else:
+        if not _nb_loaded:
+            warnings.warn(_NB_LOAD_WARNING)
+            return
         comms_target = make_id()
         publish_display_data({'text/html': notebook_div(obj, comms_target)})
         handle = _CommsHandle(get_comms(comms_target), state.document, state.document.to_json())

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -330,8 +330,9 @@ def _show_file_with_state(obj, state, new, controller):
 _NB_LOAD_WARNING = """
 
 BokehJS does not appear to have successfully loaded. If loading BokehJS from CDN, this
-may be due to a slow or bad network connection. To attempt to fix:
+may be due to a slow or bad network connection. Possible fixes:
 
+* ALWAYS run `output_notebook()` in a cell BY ITSELF, AT THE TOP, with no other code
 * re-rerun `output_notebook()` to attempt to load from CDN again, or
 * use INLINE resources instead, as so:
 

--- a/bokeh/tests/test_io.py
+++ b/bokeh/tests/test_io.py
@@ -360,8 +360,9 @@ class Test_ShowWithState(DefaultStateTester):
         self.assertEqual(mock_warn.call_args[0], ("""
 
 BokehJS does not appear to have successfully loaded. If loading BokehJS from CDN, this
-may be due to a slow or bad network connection. To attempt to fix:
+may be due to a slow or bad network connection. Possible fixes:
 
+* ALWAYS run `output_notebook()` in a cell BY ITSELF, AT THE TOP, with no other code
 * re-rerun `output_notebook()` to attempt to load from CDN again, or
 * use INLINE resources instead, as so:
 

--- a/bokeh/util/notebook.py
+++ b/bokeh/util/notebook.py
@@ -32,8 +32,10 @@ def load_notebook(resources=None, verbose=False, hide_banner=False):
 
 FINALIZE_JS = """
 Bokeh.$("#%s").text("BokehJS successfully loaded");
-var kernel = IPython.notebook.kernel
-kernel.execute("import bokeh.io; bokeh.io._nb_loaded = True");
+var kernel = Jupyter.notebook.kernel
+if (kernel.execute !== undefined) {
+    kernel.execute("import bokeh.io; bokeh.io._nb_loaded = True");
+}
 """
 
 def _load_notebook_html(resources=None, verbose=False, hide_banner=False):

--- a/bokeh/util/notebook.py
+++ b/bokeh/util/notebook.py
@@ -30,6 +30,12 @@ def load_notebook(resources=None, verbose=False, hide_banner=False):
     publish_display_data({'text/html': html})
     publish_display_data({'application/javascript': js})
 
+FINALIZE_JS = """
+Bokeh.$("#%s").text("BokehJS successfully loaded");
+var kernel = IPython.notebook.kernel
+kernel.execute("import bokeh.io; bokeh.io._nb_loaded = True");
+"""
+
 def _load_notebook_html(resources=None, verbose=False, hide_banner=False):
     global _notebook_loaded
 
@@ -67,13 +73,12 @@ def _load_notebook_html(resources=None, verbose=False, hide_banner=False):
         hide_banner   = hide_banner,
     )
 
-    finalize_js = """Bokeh.$("#%s").text("BokehJS successfully loaded");""" % element_id
-
     js = AUTOLOAD_JS.render(
         js_urls  = resources.js_files,
         css_urls = resources.css_files,
-        js_raw   = resources.js_raw + [finalize_js],
+        js_raw   = resources.js_raw + [FINALIZE_JS % element_id],
         css_raw  = resources.css_raw_str,
+        force    = 1,
     )
 
     return html, js


### PR DESCRIPTION
- [x] issues: fixes #3639
- [x] tests added / passed

This PR should prevent the notebook from becoming unusable without a complete re-start in the event that `show` is called when BokehJS is not truly loaded. It also allows for re-trying `output_notebook`

<img width="1033" alt="screen shot 2016-07-10 at 2 08 36 pm" src="https://cloud.githubusercontent.com/assets/1078448/16719552/6c9595de-46f1-11e6-8c5d-a5e4955a5096.png">
 