### PR TITLE
update last bounds computations to use correct rbush format

### DIFF
--- a/bokehjs/src/coffee/models/glyphs/ellipse.coffee
+++ b/bokehjs/src/coffee/models/glyphs/ellipse.coffee
@@ -66,10 +66,7 @@ class EllipseView extends Glyph.View
     @_render(ctx, indices, data)
 
   _bounds: (bds) ->
-    return [
-      [bds[0][0]-@max_w2, bds[0][1]+@max_w2],
-      [bds[1][0]-@max_h2, bds[1][1]+@max_h2]
-    ]
+    return @max_wh2_bounds(bds)
 
 class Ellipse extends Glyph.Model
   default_view: EllipseView

--- a/bokehjs/src/coffee/models/glyphs/glyph.coffee
+++ b/bokehjs/src/coffee/models/glyphs/glyph.coffee
@@ -66,6 +66,15 @@ class GlyphView extends Renderer.View
     bb = {minX: d.minX, minY: d.minY, maxX: d.maxX, maxY: d.maxY}
     return @_bounds(bb)
 
+  # this is available for subclasses to use, if appropriate.
+  max_wh2_bounds: (bds) ->
+    return {
+        minX: bds.minX - @max_w2,
+        maxX: bds.maxX + @max_w2,
+        minY: bds.minY - @max_h2,
+        maxY: bds.maxY + @max_h2,
+    }
+
   get_anchor_point: (anchor, i, [sx, sy]) ->
     switch anchor
       when "center" then {x: @scx(i, sx, sy), y: @scy(i, sx, sy)}

--- a/bokehjs/src/coffee/models/glyphs/oval.coffee
+++ b/bokehjs/src/coffee/models/glyphs/oval.coffee
@@ -75,10 +75,7 @@ class OvalView extends Glyph.View
     @_render(ctx, indices, data)
 
   _bounds: (bds) ->
-    return [
-      [bds[0][0]-@max_w2, bds[0][1]+@max_w2],
-      [bds[1][0]-@max_h2, bds[1][1]+@max_h2]
-    ]
+    return @max_wh2_bounds(bds)
 
 class Oval extends Glyph.Model
   default_view: OvalView

--- a/bokehjs/src/coffee/models/glyphs/rect.coffee
+++ b/bokehjs/src/coffee/models/glyphs/rect.coffee
@@ -134,12 +134,7 @@ class RectView extends Glyph.View
     @_generic_area_legend(ctx, x0, x1, y0, y1)
 
   _bounds: (bds) ->
-    return {
-      minX: bds.minX - @max_w2,
-      maxX: bds.maxX + @max_w2,
-      minY: bds.minY - @max_h2,
-      maxY: bds.maxY + @max_h2,
-    }
+    return @max_wh2_bounds(bds)
 
 class Rect extends Glyph.Model
   default_view: RectView


### PR DESCRIPTION
issues: fixes #4793

glyphs notebook now fully works:

<img width="535" alt="screen shot 2016-07-12 at 10 35 56 am" src="https://cloud.githubusercontent.com/assets/1078448/16773170/77e6a9ec-481c-11e6-9e0a-4971e87d8c87.png">


