### PR TITLE
moved the wheel speed zoom from internal to defined.

### DIFF
--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -197,6 +197,12 @@ class WheelZoomTool(Scroll):
     vertically across the height of the plot.
     """)
 
+    speed = Float(default=1/600, help="""
+    Speed at which the wheel zooms. Default is 1/600. Optimal range is between 
+    0.001 and 0.09. High values will be clipped. Speed may very between browsers.
+    """)
+
+
 
 class SaveTool(Action):
     """ *toolbar icon*: |save_icon|

--- a/bokehjs/src/coffee/models/tools/gestures/wheel_zoom_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/gestures/wheel_zoom_tool.coffee
@@ -115,11 +115,9 @@ class WheelZoomTool extends GestureTool.Model
 
   @define {
       dimensions: [ p.Array, ["width", "height"] ]
+      speed: [ p.Number, 1/600 ]
     }
 
-  @internal {
-    speed: [ p.Number, 1/600 ]
-  }
 
 module.exports =
   Model: WheelZoomTool


### PR DESCRIPTION
moved the wheel speed zoom from internal to defined. 
Default 1/600.
High values will be clipped.

- [x] issues: fixes #3125
- [x] release document entry (if new feature or API change)

