### PR TITLE
use specific call signatures for select and inspect

### DIFF
--- a/bokehjs/src/coffee/models/tools/gestures/tap_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/gestures/tap_tool.coffee
@@ -29,8 +29,11 @@ class TapToolView extends SelectTool.View
       ds = r.get('data_source')
       sm = ds.get('selection_manager')
 
-      fn = if @model.behavior == "select" then sm.select else sm.inspect
-      did_hit = fn.bind(sm)(@, @plot_view.renderer_views[r.id], geometry, final, append)
+      view = @plot_view.renderer_views[r.id]
+      if @model.behavior == "select"
+        did_hit = sm.select(@, view, geometry, final, append)
+      else
+        did_hit = sm.inspect(@, view, geometry, {geometry: geometry})
 
       if did_hit and callback?
         if _.isFunction(callback)


### PR DESCRIPTION
 issues: fixes #4839

ping @mattpap this seemed to be an overzealous optimization -- `select` and `inspect` have different function signatures. 
