### PR TITLE
Version Mismatch Fix

### DIFF
--- a/bokehjs/src/coffee/document.coffee
+++ b/bokehjs/src/coffee/document.coffee
@@ -573,7 +573,7 @@ class Document
       throw new Error("JSON object has wrong type #{typeof json}")
     py_version = json['version']
     versions_string = "Library versions: JS (#{js_version})  /  Python (#{py_version})"
-    if js_version != py_version
+    if py_version.indexOf('-') < 0 and js_version != py_version
       logger.warn("JS/Python version mismatch")
       logger.warn(versions_string)
     else

--- a/bokehjs/src/coffee/document.coffee
+++ b/bokehjs/src/coffee/document.coffee
@@ -573,7 +573,7 @@ class Document
       throw new Error("JSON object has wrong type #{typeof json}")
     py_version = json['version']
     versions_string = "Library versions: JS (#{js_version})  /  Python (#{py_version})"
-    if js_version.split('-')[0] != py_version.split('-')[0]
+    if js_version != py_version
       logger.warn("JS/Python version mismatch")
       logger.warn(versions_string)
     else

--- a/bokehjs/test/document.coffee
+++ b/bokehjs/test/document.coffee
@@ -545,16 +545,32 @@ describe "Document", ->
     logging.set_log_level("warn")
     json = d.to_json_string()
     parsed = JSON.parse(json)
-    parsed['version'] = "0.0.1"
+    parsed['version'] = "#{js_version}"
     out = stderrTrap -> Document.from_json_string(JSON.stringify(parsed))
-    expect(out).to.be.equal "Bokeh: JS/Python version mismatch\nBokeh: Library versions: JS (#{js_version})  /  Python (0.0.1)\n"
-
-    parsed['version'] = "#{js_version}-foo"
-    out = stdoutTrap -> Document.from_json_string(JSON.stringify(parsed))
     expect(out).to.be.equal ""
 
+    parsed['version'] = "0.0.1"
+    out = stderrTrap -> Document.from_json_string(JSON.stringify(parsed))
+    expect(out).to.be.equal "Bokeh: JS/Python version mismatch\nBokeh: Library versions: JS (#{js_version})  /  Python (#{parsed["version"]})\n"
+
     parsed['version'] = "#{js_version}rc123"
-    out = stdoutTrap -> Document.from_json_string(JSON.stringify(parsed))
+    out = stderrTrap -> Document.from_json_string(JSON.stringify(parsed))
+    expect(out).to.be.equal "Bokeh: JS/Python version mismatch\nBokeh: Library versions: JS (#{js_version})  /  Python (#{parsed["version"]})\n"
+
+    parsed['version'] = "#{js_version}dev123"
+    out = stderrTrap -> Document.from_json_string(JSON.stringify(parsed))
+    expect(out).to.be.equal "Bokeh: JS/Python version mismatch\nBokeh: Library versions: JS (#{js_version})  /  Python (#{parsed["version"]})\n"
+
+    parsed['version'] = "#{js_version}-foo"
+    out = stderrTrap -> Document.from_json_string(JSON.stringify(parsed))
+    expect(out).to.be.equal ""
+
+    parsed['version'] = "#{js_version}rc123-foo"
+    out = stderrTrap -> Document.from_json_string(JSON.stringify(parsed))
+    expect(out).to.be.equal ""
+
+    parsed['version'] = "#{js_version}dev123-bar"
+    out = stderrTrap -> Document.from_json_string(JSON.stringify(parsed))
     expect(out).to.be.equal ""
 
   it "can serialize with one model in it", ->

--- a/bokehjs/test/document.coffee
+++ b/bokehjs/test/document.coffee
@@ -553,6 +553,10 @@ describe "Document", ->
     out = stdoutTrap -> Document.from_json_string(JSON.stringify(parsed))
     expect(out).to.be.equal ""
 
+    parsed['version'] = "#{js_version}rc123"
+    out = stdoutTrap -> Document.from_json_string(JSON.stringify(parsed))
+    expect(out).to.be.equal ""
+
   it "can serialize with one model in it", ->
     d = new Document()
     expect(d.roots().length).to.equal 0

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -84,18 +84,18 @@ elif [[ ! -z "$dtag" && ! -z "$ptag" && -z "$rtag" ]]; then
     # Merge branch into master and push to origin
     git checkout master
     git pull origin
-    git merge --no-ff release_$rtag -m "Merge branch devel_$rtag"
+    git merge --no-ff devel_$dtag -m "Merge branch devel_$dtag"
     git push origin master
-    git branch -d release_$rtag
+    git branch -d devel_$dtag
 
     # Tag the version locally.
-    git tag -a $dtag -m "New devel[rc] build $dtag."
-    git push origin $rtag
+    git tag -a $dtag -m "New devel/rc build $dtag."
+    git push origin $dtag
 
     echo "The new devel build was triggered."
 
 else
-    echo "You must pass a -d tag (dev build) OR -r tags (for releases) and a -p tag (previous version)."
+    echo "You must pass a a -d tag and a -p tag OR a -r tag and -p tag."
     echo "Run ./deploy.sh -h to get some more help with the args to pass."
     exit 0
 fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -67,7 +67,7 @@ elif [[ ! -z "$dtag" && ! -z "$ptag" && -z "$rtag" ]]; then
 
     # version number updates
     python version_update.py $dtag $ptag
-    git add ../bokehjs/src/coffee/main.coffee
+    git add ../bokehjs/src/coffee/version.coffee
     git add ../bokehjs/package.json
     git add ../sphinx/source/conf.py
     git commit -m "Updating version to $dtag."

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -59,8 +59,18 @@ if [[ -z "$dtag" && ! -z "$ptag" && ! -z "$rtag" ]]; then
     git tag -a $rtag -m "Release $rtag".
     git push origin $rtag
 
-elif [[ ! -z "$dtag" && -z "$ptag" && -z "$rtag" ]]; then
+elif [[ ! -z "$dtag" && ! -z "$ptag" && -z "$rtag" ]]; then
     echo "You have triggered the devel build process"
+
+    # create a new branch
+    git checkout -b devel_$dtag
+
+    # version number updates
+    python version_update.py $dtag $ptag
+    git add ../bokehjs/src/coffee/main.coffee
+    git add ../bokehjs/package.json
+    git add ../sphinx/source/conf.py
+    git commit -m "Updating version to $dtag."
 
     # check the tag
     taglist=`git tag --list --sort=version:refname`
@@ -71,15 +81,21 @@ elif [[ ! -z "$dtag" && -z "$ptag" && -z "$rtag" ]]; then
         exit 1
     fi
 
-    # tag it locally
-    git tag -a $dtag -m "New devel[rc] build $dtag."
+    # Merge branch into master and push to origin
+    git checkout master
+    git pull origin
+    git merge --no-ff release_$rtag -m "Merge branch devel_$rtag"
+    git push origin master
+    git branch -d release_$rtag
 
-    # and push the tag
-    git push origin $dtag
+    # Tag the version locally.
+    git tag -a $dtag -m "New devel[rc] build $dtag."
+    git push origin $rtag
+
     echo "The new devel build was triggered."
 
 else
-    echo "You have to pass a -d tag (dev build) OR -p and -r tags (for releases)."
+    echo "You must pass a -d tag (dev build) OR -r tags (for releases) and a -p tag (previous version)."
     echo "Run ./deploy.sh -h to get some more help with the args to pass."
     exit 0
 fi


### PR DESCRIPTION
Fixes the problem of tagging between Bokeh and BokehJS. Development builds now also run `scripts/version_update.py`, to change the value of the version strings in `version.coffee` and `package.json`. 

Submitting a new release candidate or development release now requires a previous version argument in addition to a new version argument. 

fixes #4882 
