### PR TITLE
deploy.sh needs explicit list of files updated

### DIFF
--- a/bokehjs/src/coffee/version.coffee
+++ b/bokehjs/src/coffee/version.coffee
@@ -1,3 +1,3 @@
-version = '0.12.0'
+version = '0.12.1'
 
 module.exports = version

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -33,7 +33,7 @@ if [[ -z "$dtag" && ! -z "$ptag" && ! -z "$rtag" ]]; then
 
     # version number updates
     python version_update.py $rtag $ptag
-    git add ../bokehjs/src/coffee/main.coffee
+    git add ../bokehjs/src/coffee/version.coffee
     git add ../bokehjs/package.json
     git add ../sphinx/source/conf.py
     git commit -m "Updating version to $rtag."


### PR DESCRIPTION
This fixes a problem with committing the updated BokehJS version file. Note: because of this bug BokehJS `0.12.1` incorrectly reports `Bokeh.version` as `0.12.0`. Will need to have another point release very soon. 