### PR TITLE
Add HoverTool.show_arrow

### DIFF
--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -662,3 +662,7 @@ class Tooltip(Annotation):
     inner_only = Bool(default=True, help="""
     Whether to display outside a central plot frame area.
     """)
+
+    show_arrow = Bool(default=True, help="""
+    Whether tooltip's arrow should be showed.
+    """)

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -682,6 +682,10 @@ class HoverTool(Inspection):
     Whether tooltip's arrow should appear in the horizontal or vertical dimension.
     """)
 
+    show_arrow = Bool(default=True, help="""
+    Whether tooltip's arrow should be showed.
+    """)
+
 DEFAULT_HELP_TIP = "Click the question mark to learn more about Bokeh plot tools."
 DEFAULT_HELP_URL = "http://bokeh.pydata.org/en/latest/docs/user_guide/tools.html"
 

--- a/bokehjs/src/coffee/api/charts.coffee
+++ b/bokehjs/src/coffee/api/charts.coffee
@@ -272,7 +272,10 @@ bar = (data, opts={}) ->
   hover = new models.HoverTool({
     renderers: renderers,
     tooltips: tooltip,
-    point_policy: "snap_to_data", anchor: anchor, attachment: attachment,
+    point_policy: "snap_to_data",
+    anchor: anchor,
+    attachment: attachment,
+    show_arrow: opts.show_arrow
   })
   plot.add_tools(hover)
 

--- a/bokehjs/src/coffee/api/typings/models/tools.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/tools.d.ts
@@ -131,6 +131,7 @@ declare namespace Bokeh {
         line_policy?: LinePolicy;
         anchor?: Anchor;
         attachment?: "horizontal" | "vertical";
+        show_arrow?: boolean;
     }
 
     export var HelpTool: { new(attributes?: IHelpTool, options?: ModelOpts): HelpTool };

--- a/bokehjs/src/coffee/models/annotations/tooltip.coffee
+++ b/bokehjs/src/coffee/models/annotations/tooltip.coffee
@@ -81,6 +81,9 @@ class TooltipView extends Annotation.View
         top = sy - @$el.outerHeight() - arrow_size
         left = Math.round(sx - @$el.outerWidth()/2)
 
+    if @model.show_arrow
+        @$el.addClass("bk-tooltip-arrow")
+
     # TODO (bev) this is not currently bulletproof. If there are
     # two hits, not colocated and one is off the screen, that can
     # be problematic
@@ -96,6 +99,7 @@ class Tooltip extends Annotation.Model
   @define {
     attachment: [ p.String, 'horizontal' ] # TODO enum: "horizontal" | "vertical" | "left" | "right" | "above" | "below"
     inner_only: [ p.Bool,   true         ]
+    show_arrow: [ p.Bool,   true         ]
   }
 
   @override {

--- a/bokehjs/src/coffee/models/tools/inspectors/hover_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/inspectors/hover_tool.coffee
@@ -259,6 +259,7 @@ class HoverTool extends InspectTool.Model
       mode:         [ p.String, 'mouse'        ] # TODO (bev)
       point_policy: [ p.String, 'snap_to_data' ] # TODO (bev) "follow_mouse", "none"
       line_policy:  [ p.String, 'prev'         ] # TODO (bev) "next", "nearest", "interp", "none"
+      show_arrow:   [ p.Boolean, true          ]
       anchor:       [ p.String, 'center'       ] # TODO: enum
       attachment:   [ p.String, 'horizontal'   ] # TODO: enum
       callback:     [ p.Any                    ] # TODO: p.Either(p.Instance(Callback), p.Function) ]
@@ -294,6 +295,7 @@ class HoverTool extends InspectTool.Model
             tooltip = new Tooltip.Model({
               custom: _.isString(tooltips) or _.isFunction(tooltips)
               attachment: @attachment
+              show_arrow: @show_arrow
             })
             ttmodels[r.id] = tooltip
 

--- a/bokehjs/src/less/main.less
+++ b/bokehjs/src/less/main.less
@@ -77,15 +77,27 @@
   display: block;
 }
 
-.bk-tooltip.bk-left::before {
+.bk-tooltip.bk-left.bk-tooltip-arrow::before {
   .bk-tooltip-arrow-horizontal();
   left: -@tooltipArrowWidth;
   border-right-width: @tooltipArrowWidth;
   border-right-color: @defaultTooltipBorder;
 }
 
-.bk-tooltip.bk-right::after {
+.bk-tooltip.bk-left::before {
+  left: -@tooltipArrowWidth;
+  border-right-width: @tooltipArrowWidth;
+  border-right-color: @defaultTooltipBorder;
+}
+
+.bk-tooltip.bk-right.bk-tooltip-arrow::after {
   .bk-tooltip-arrow-horizontal();
+  right: -@tooltipArrowWidth;
+  border-left-width: @tooltipArrowWidth;
+  border-left-color: @defaultTooltipBorder;
+}
+
+.bk-tooltip.bk-right::after {
   right: -@tooltipArrowWidth;
   border-left-width: @tooltipArrowWidth;
   border-left-color: @defaultTooltipBorder;


### PR DESCRIPTION
This patch adds a `show_arrow` to `HoverTool`. It is a simple boolean to disable arrow on toolip. `True` by default.

- [x] issues: fixes #4906 and [this question on Stack Overflow](https://stackoverflow.com/questions/38651060/how-to-remove-arrow-on-tooltip-from-bokeh-plot/)
- [x] release document entry

Usage (check the last line):
```python
hover = p.select_one(HoverTool)
hover.point_policy = "follow_mouse"
hover.tooltips = [
    ("Name", "@name"),
    ("Unemployment rate)", "@rate%"),
    ("(Long, Lat)", "($x, $y)"),
]
hover.show_arrow = False
```