### PR TITLE
update `devdeps.py` to including the missing dependencies

### DIFF
--- a/scripts/devdeps.py
+++ b/scripts/devdeps.py
@@ -67,7 +67,9 @@ if __name__ == '__main__':
         'pytest_cov',
         'pytest_selenium',
         'mock',
-        'websocket'
+        'websocket',
+        'flake8',
+        'boto'
     ]
     depend_check('Dev', *dev_deps)
 

--- a/scripts/devdeps.py
+++ b/scripts/devdeps.py
@@ -35,6 +35,7 @@ def depend_check(deps_name, *args):
             missing.append(dependency)
 
     print('-'*80)
+
     if missing:
         print(red("You are missing the following %s dependencies:") % deps_name)
 
@@ -42,10 +43,10 @@ def depend_check(deps_name, *args):
             name = pkg_info_dict.get(dep, dep)
             print(" * ", name)
         print()
-        return False
+
     else:
         print(blue("All %s dependencies installed!  You are good to go!\n") % deps_name)
-        return True
+
 
 
 if __name__ == '__main__':

--- a/scripts/devdeps.py
+++ b/scripts/devdeps.py
@@ -9,15 +9,15 @@ except ImportError:
     def blue(text) : return text
     def red(text) : return text
 
-npm_missing = """
-npm packages do not appear to be installed.
-Please navigate to the bokehjs directory and type 'npm install'\n
-"""
 
 def npm_check():
     """Check that the bokehjs/node_modules directory exists, as its absence
     is the best indication that npm is not installed."""
 
+    npm_missing = """
+    npm packages do not appear to be installed.
+    Please navigate to the bokehjs directory and type 'npm install'\n
+    """
 
     if not path.exists('../bokehjs/node_modules'):
         print(red(npm_missing))
@@ -33,10 +33,9 @@ def depend_check(deps_name, *args):
             __import__(dependency)
         except ImportError:
             missing.append(dependency)
-            found = False
 
     print('-'*80)
-    if len(missing):
+    if missing:
         print(red("You are missing the following %s dependencies:") % deps_name)
 
         for dep in missing:
@@ -47,6 +46,7 @@ def depend_check(deps_name, *args):
     else:
         print(blue("All %s dependencies installed!  You are good to go!\n") % deps_name)
         return True
+
 
 if __name__ == '__main__':
 

--- a/scripts/devdeps.py
+++ b/scripts/devdeps.py
@@ -58,6 +58,9 @@ if __name__ == '__main__':
         'websocket': 'websocket-client',
         'pytest_selenium': 'pytest-selenium',
         'pytest_cov': 'pytest-cov',
+        # 'mkl': 'mkl',
+        'dateutil': 'python-dateutil',
+        # 'yaml': 'pyyaml'
     }
 
     dev_deps = [
@@ -78,3 +81,18 @@ if __name__ == '__main__':
         'pygments',
     ]
     depend_check('Docs', *docs_deps)
+
+    base_deps = [
+        'backports_abc',
+        'jinja2',
+        'markupsafe',
+        # 'mkl',
+        'numpy',
+        'dateutil',
+        # 'pyyaml',
+        'requests',
+        'six',
+        'tornado',
+        'yaml'
+    ]
+    depend_check('Base', *base_deps)

--- a/scripts/devdeps.py
+++ b/scripts/devdeps.py
@@ -48,7 +48,6 @@ def depend_check(deps_name, *args):
         print(blue("All %s dependencies installed!  You are good to go!\n") % deps_name)
 
 
-
 if __name__ == '__main__':
 
     npm_check()
@@ -59,9 +58,8 @@ if __name__ == '__main__':
         'websocket': 'websocket-client',
         'pytest_selenium': 'pytest-selenium',
         'pytest_cov': 'pytest-cov',
-        # 'mkl': 'mkl',
         'dateutil': 'python-dateutil',
-        # 'yaml': 'pyyaml'
+        'yaml': 'pyyaml',
     }
 
     dev_deps = [
@@ -73,7 +71,7 @@ if __name__ == '__main__':
         'mock',
         'websocket',
         'flake8',
-        'boto'
+        'boto',
     ]
     depend_check('Dev', *dev_deps)
 
@@ -84,16 +82,11 @@ if __name__ == '__main__':
     depend_check('Docs', *docs_deps)
 
     base_deps = [
-        'backports_abc',
         'jinja2',
-        'markupsafe',
-        # 'mkl',
         'numpy',
         'dateutil',
-        # 'pyyaml',
         'requests',
-        'six',
         'tornado',
-        'yaml'
+        'yaml',
     ]
     depend_check('Base', *base_deps)


### PR DESCRIPTION
fixes #4824 
Added `flake8` and `boto` as well as the base dependencies required for bokeh: 
- `backports_abc`,
- `jinja2`,
- `markupsafe`,
- `mkl`, (pending correct import call)
- `bumpy`,
- `dateutil`,
- `pyyaml`, (pending correct import call)
- `requests`,
- `six`,
- `tornado`,
- `yaml`

- [ ] issues: fixes #4824 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)