### PR TITLE
Store scss on renderer not on glyph

### DIFF
--- a/bokehjs/src/coffee/models/glyphs/patches.coffee
+++ b/bokehjs/src/coffee/models/glyphs/patches.coffee
@@ -77,8 +77,8 @@ class PatchesView extends Glyph.View
   _render: (ctx, indices, {sxs, sys}) ->
     # @sxss and @syss are used by _hit_point and sxc, syc
     # This is the earliest we can build them, and only build them once
-    @sxss = @_build_discontinuous_object(sxs)
-    @syss = @_build_discontinuous_object(sys)
+    @renderer.sxss = @_build_discontinuous_object(sxs)
+    @renderer.syss = @_build_discontinuous_object(sys)
     for i in indices
       [sx, sy] = [sxs[i], sys[i]]
 
@@ -133,8 +133,8 @@ class PatchesView extends Glyph.View
     hits = []
     for i in [0...candidates.length]
       idx = candidates[i]
-      sxs = @sxss[idx]
-      sys = @syss[idx]
+      sxs = @renderer.sxss[idx]
+      sys = @renderer.syss[idx]
       for j in [0...sxs.length]
         if hittest.point_in_poly(sx, sy, sxs[j], sys[j])
           hits.push(idx)
@@ -150,14 +150,14 @@ class PatchesView extends Glyph.View
       return sum / array.length
 
   scx: (i, sx, sy) ->
-    if @sxss[i].length is 1
+    if @renderer.sxss[i].length is 1
       # We don't have discontinuous objects so we're ok
       return @_get_snap_coord(@sxs[i])
     else
       # We have discontinuous objects, so we need to find which
       # one we're in, we can use point_in_poly again
-      sxs = @sxss[i]
-      sys = @syss[i]
+      sxs = @renderer.sxss[i]
+      sys = @renderer.syss[i]
       for j in [0...sxs.length]
         if hittest.point_in_poly(sx, sy, sxs[j], sys[j])
           return @_get_snap_coord(sxs[j])
@@ -170,8 +170,8 @@ class PatchesView extends Glyph.View
     else
       # We have discontinuous objects, so we need to find which
       # one we're in, we can use point_in_poly again
-      sxs = @sxss[i]
-      sys = @syss[i]
+      sxs = @renderer.sxss[i]
+      sys = @renderer.syss[i]
       for j in [0...sxs.length]
         if hittest.point_in_poly(sx, sy, sxs[j], sys[j])
           return @_get_snap_coord(sys[j])

--- a/bokehjs/src/coffee/models/glyphs/patches.coffee
+++ b/bokehjs/src/coffee/models/glyphs/patches.coffee
@@ -164,7 +164,7 @@ class PatchesView extends Glyph.View
     return null
 
   scy: (i, sx, sy) ->
-    if @syss[i].length is 1
+    if @renderer.syss[i].length is 1
       # We don't have discontinuous objects so we're ok
       return @_get_snap_coord(@sys[i])
     else

--- a/tests/integration/interaction/test_patches_preselection.py
+++ b/tests/integration/interaction/test_patches_preselection.py
@@ -1,0 +1,51 @@
+from bokeh.io import save
+from bokeh.models import (
+    ColumnDataSource,
+    HoverTool,
+    LinearAxis,
+    Patches,
+    Plot,
+    Range1d,
+)
+from selenium.webdriver.common.action_chains import ActionChains
+from tests.integration.utils import has_no_console_errors
+
+import pytest
+pytestmark = pytest.mark.integration
+
+
+def test_patches_hover_still_works_when_a_seleciton_is_preselcted(output_file_url, selenium):
+    # This tests an edge case interaction when Patches (specifically) is used
+    # with a tool that requires hit testing e.g. HitTool AND a selection is
+    # pre-made on the data source driving it.
+    plot = Plot(
+        x_range=Range1d(0, 100),
+        y_range=Range1d(0, 100),
+        min_border=0
+    )
+    source = ColumnDataSource(dict(
+        xs=[[0, 50, 50, 0], [50, 100, 100, 50]],
+        ys=[[0, 0, 100, 100], [0, 0, 100, 100]],
+        color=['pink', 'blue']
+    ))
+    source.selected = {
+        '0d': {'glyph': None, 'indices': []},
+        '1d': {'indices': [1]},
+        '2d': {}
+    }
+    plot.add_glyph(source, Patches(xs='xs', ys='ys', fill_color='color'))
+    plot.add_tools(HoverTool())
+    plot.add_layout(LinearAxis(), 'below')
+    plot.add_layout(LinearAxis(), 'left')
+    save(plot)
+    selenium.get(output_file_url)
+    assert has_no_console_errors(selenium)
+
+    # Hover plot and test no error
+    canvas = selenium.find_element_by_tag_name('canvas')
+    actions = ActionChains(selenium)
+    actions.move_to_element_with_offset(canvas, 100, 100)
+    actions.perform()
+
+    # If this assertion fails then there were likely errors on hover
+    assert has_no_console_errors(selenium)

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -14,8 +14,8 @@ def has_no_console_errors(selenium):
     Helper function to detect console errors.
     """
     logs = selenium.get_log('browser')
-    severe_errors = [l for l in logs if l['level'] == 'SEVERE']
-    non_network_errors = [l for l in severe_errors if l['type'] != 'network']
+    severe_errors = [l for l in logs if l.get('level') == 'SEVERE']
+    non_network_errors = [l for l in severe_errors if l.get('type') != 'network']
     if len(non_network_errors) == 0:
         return True
     else:


### PR DESCRIPTION
- [x] issues: fixes #4949
- [x] tests added / passed

This allows the sxss to be available for hit testing - which is not done on the main glyph (but on the selection and nonselection glyph)