### PR TITLE
Transform data with ColorMapper

### DIFF
--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -1645,8 +1645,17 @@ class DataSpecProperty(BasicProperty):
 class DataSpec(Either):
     def __init__(self, typ, default, help=None):
         super(DataSpec, self).__init__(
-            String, Dict(String, Either(String, Instance('bokeh.models.transforms.Transform'), typ)),
-            typ, default=default, help=help
+            String,
+            Dict(
+                String,
+                Either(
+                    String,
+                    Instance('bokeh.models.transforms.Transform'),
+                    Instance('bokeh.models.mappers.ColorMapper'),
+                    typ)),
+            typ,
+            default=default,
+            help=help
         )
         self._type = self._validate_type_param(typ)
 

--- a/bokehjs/src/coffee/models/mappers/color_mapper.coffee
+++ b/bokehjs/src/coffee/models/mappers/color_mapper.coffee
@@ -19,7 +19,36 @@ class ColorMapper extends Model
       @_palette = @_build_palette(@get('palette')))
 
   v_map_screen: (data) ->
+    values = @_get_values(data, @_palette)
+    buf = new ArrayBuffer(data.length * 4)
+    color = new Uint32Array(buf)
+
+    if @_little_endian
+      for i in [0...data.length]
+        value = values[i]
+        color[i] =
+          (0xff << 24)                   | # alpha
+          ((value & 0xff0000) >> 16)     | # blue
+          (value & 0xff00)               | # green
+          ((value & 0xff) << 16);          # red
+    else
+      for i in [0...data.length]
+        value = values[i]
+        color[i] = (value << 8) | 0xff     # alpha
+    return buf
+
+  compute: (x) ->
+    # If it's just a single value, then a color mapper doesn't
+    # really make sense, so return nothing
     return null
+
+  v_compute: (xs) ->
+    values = @_get_values(xs, @palette)
+    return values
+
+  _get_values: (data, palette) ->
+    # Should be defined by subclass
+    return []
 
   _is_little_endian: () ->
     buf = new ArrayBuffer(4)

--- a/bokehjs/src/coffee/models/mappers/linear_color_mapper.coffee
+++ b/bokehjs/src/coffee/models/mappers/linear_color_mapper.coffee
@@ -23,7 +23,7 @@ class LinearColorMapper extends ColorMapper.Model
      low = @get('low') ? _.min(data)
      high = @get('high') ? _.max(data)
 
-     N = palette.length - 1
+     N = palette.length
      scale = N/(high-low)
      offset = -scale*low
      values = []

--- a/bokehjs/src/coffee/models/mappers/linear_color_mapper.coffee
+++ b/bokehjs/src/coffee/models/mappers/linear_color_mapper.coffee
@@ -19,52 +19,27 @@ class LinearColorMapper extends ColorMapper.Model
       @_reserve_color = parseInt(@get('reserve_color').slice(1), 16)
       @_reserve_val   = @get('reserve_val')
 
-  v_map_screen: (data) ->
-    buf = new ArrayBuffer(data.length * 4)
-    color = new Uint32Array(buf)
+  _get_values: (data, palette) ->
+     low = @get('low') ? _.min(data)
+     high = @get('high') ? _.max(data)
 
-    low = @get('low') ? _.min(data)
-    high = @get('high') ? _.max(data)
+     N = palette.length - 1
+     scale = N/(high-low)
+     offset = -scale*low
+     values = []
 
-    N = @_palette.length - 1
-    scale = N/(high-low)
-    offset = -scale*low
+     for i in [0...data.length]
+       d = data[i]
 
-    if @_little_endian
-      for i in [0...data.length]
-        d = data[i]
-
-        if (d == @_reserve_val)
-          value = @_reserve_color
-        else
-          if (d > high)
-            d = high
-          if (d < low)
-            d = low
-          value = @_palette[Math.floor(d*scale+offset)]
-
-        color[i] =
-          (0xff << 24)               | # alpha
-          ((value & 0xff0000) >> 16) | # blue
-          (value & 0xff00)           | # green
-          ((value & 0xff) << 16);      # red
-
-    else
-      for i in [0...data.length]
-        d = data[i]
-
-        if (d == @_reserve_val)
-          value = @_reserve_color
-        else
-          if (d > high)
-            d = high
-          if (d < low)
-            d = low
-          value = @_palette[Math.floor(d*scale+offset)] # rgb
-
-        color[i] = (value << 8) | 0xff               # alpha
-
-    return buf
+       if (d == @_reserve_val)
+         value = @_reserve_color
+       else
+         if (d > high)
+           d = high
+         if (d < low)
+           d = low
+         values[i] = palette[Math.floor(d*scale+offset)]
+     return values
 
 module.exports =
   Model: LinearColorMapper

--- a/bokehjs/src/coffee/models/mappers/log_color_mapper.coffee
+++ b/bokehjs/src/coffee/models/mappers/log_color_mapper.coffee
@@ -11,48 +11,24 @@ class LogColorMapper extends ColorMapper.Model
       low:           [ p.Number           ]
     }
 
-  v_map_screen: (data) ->
-    buf = new ArrayBuffer(data.length * 4)
-    color = new Uint32Array(buf)
+  _get_values: (data, palette) ->
+     low = @get('low') ? _.min(data)
+     high = @get('high') ? _.max(data)
+     N = @_palette.length - 1
+     scale = N / (Math.log1p(high) - Math.log1p(low))  # subtract the low offset
+     values = []
 
-    low = @get('low') ? _.min(data)
-    high = @get('high') ? _.max(data)
+     for i in [0...data.length]
+       d = data[i]
 
-    N = @_palette.length - 1
-    scale = N / (Math.log1p(high) - Math.log1p(low)) #substract the low offset
+       if (d > high)
+         d = high
+       else if (d < low)
+         d = low
 
-    if @_little_endian
-      for i in [0...data.length]
-        d = data[i]
-
-        if (d > high)
-          d = high
-        else if (d < low)
-          d = low
-
-        log = Math.log1p(d) - Math.log1p(low) #substract the low offset
-        value = @_palette[Math.floor(log * scale)]
-
-        color[i] =
-          (0xff << 24)               | # alpha
-          ((value & 0xff0000) >> 16) | # blue
-          (value & 0xff00)           | # green
-          ((value & 0xff) << 16);      # red
-
-    else
-      for i in [0...data.length]
-        d = data[i]
-
-        if (d > high)
-          d = high
-        else if (d < low)
-          d = low
-
-        log = Math.log1p(d) - Math.log1p(low) #substract the low offset
-        value = @_palette[Math.floor(log * scale)]
-
-        color[i] = (value << 8) | 0xff                 # alpha
-    return buf
+       log = Math.log1p(d) - Math.log1p(low)  # subtract the low offset
+       values[i] = palette[Math.floor(log * scale)]
+     return values
 
 module.exports =
   Model: LogColorMapper

--- a/examples/plotting/file/color_data_map.py
+++ b/examples/plotting/file/color_data_map.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+from bokeh.io import show
+from bokeh.models.sources import ColumnDataSource
+from bokeh.models.mappers import LinearColorMapper, LogColorMapper
+from bokeh.palettes import Viridis3
+from bokeh.plotting import figure
+
+x = np.random.random(2500) * 10
+y = np.random.normal(size=2500) * 2 + 5
+source = ColumnDataSource(dict(x=x, y1=y, y2=y - 10))
+
+log_mapper = LogColorMapper(palette=Viridis3)
+lin_mapper = LinearColorMapper(palette=Viridis3)
+
+p = figure()
+opts = dict(x='x', line_color=None, source=source)
+p.circle(y='y1', fill_color={'field': 'x', 'transform': log_mapper}, legend="Log mapper", **opts)
+p.triangle(y='y2', fill_color={'field': 'x', 'transform': lin_mapper}, legend="Lin mapper", **opts)
+
+show(p)


### PR DESCRIPTION
- [x] issues: fixes #4981
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

```python
import numpy as np

from bokeh.io import show
from bokeh.models.sources import ColumnDataSource
from bokeh.models.mappers import LinearColorMapper, LogColorMapper
from bokeh.palettes import Viridis3
from bokeh.plotting import figure

x = np.random.random(2500) * 10
y = np.random.normal(size=2500) * 2 + 5
source = ColumnDataSource(dict(x=x, y1=y, y2=y - 10))

log_mapper = LogColorMapper(palette=Viridis3)
lin_mapper = LinearColorMapper(palette=Viridis3)

p = figure()
opts = dict(x='x', line_color=None, source=source)
p.circle(y='y1', fill_color={'field': 'x', 'transform': log_mapper}, legend="Log mapper", **opts)
p.triangle(y='y2', fill_color={'field': 'x', 'transform': lin_mapper}, legend="Lin mapper", **opts)

show(p)
```

![bokeh_plot](https://cloud.githubusercontent.com/assets/1796208/17766489/35a46f48-64e0-11e6-8da7-3f0137d899b1.png)
