### PR TITLE
add link to sizing_mode in Responsive Dimensions section of Styling user guide

### DIFF
--- a/sphinx/source/docs/user_guide/styling.rst
+++ b/sphinx/source/docs/user_guide/styling.rst
@@ -216,6 +216,9 @@ those parameters will be used to calculate the initial aspect ratio for your
 plot, so you may want to keep them. Plots will only resize down to a minimum of
 100px (height or width) to prevent problems in displaying your plot.
 
+For more precise control over how the plot scales to fill its container,
+see the documentation on the :ref:`~bokeh.models.layouts.LayoutDOM.sizing_mode` parameter.
+
 .. warning::
     This feature is known not to work when combined with HBox.
     This is a new feature and may have other issues when used in different circumstances.


### PR DESCRIPTION
This adds a link to the ``sizing_mode`` reference documentation in the Responsive Dimensions section of the Styling user guide. I'm not entirely sure whether ``responsive`` is deprecated in favor of ``sizing_mode`` or not (for my own purposes, it turned out that ``sizing_mode`` wouldn't even give me the behavior I want, so I ended up not using either), so I opted to just link to those docs. I'll be happy to rework this as needed.

- [x] issues: fixes #4869 
- **N/A** tests added / passed
- **N/A** release document entry (if new feature or API change)