### PR TITLE
Remove trailing whitespace

### DIFF
--- a/sphinx/source/docs/user_guide/embed.rst
+++ b/sphinx/source/docs/user_guide/embed.rst
@@ -134,12 +134,12 @@ For example, to use version ``0.12.0``, including widgets support:
 
 .. note::
     You must provide the closing `</script>` tag. This is required by all
-    browsers and the page will typically not render without it. 
-    
+    browsers and the page will typically not render without it.
+
 When embedding in a page served via HTTPS, any scripts and resources must also
-be loaded via HTTPS or the browser will refuse to load due to an "unsafe" script. 
-For this situation, the Bokeh CDN resources are also available via HTTPS, by 
-replacing "http" with "https" in the above URLs. 
+be loaded via HTTPS or the browser will refuse to load due to an "unsafe" script.
+For this situation, the Bokeh CDN resources are also available via HTTPS, by
+replacing "http" with "https" in the above URLs.
 
 The |components| function takes either a single Bokeh Model a list/tuple of
 Models, or a dictionary of keys and Models. Each returns a corresponding


### PR DESCRIPTION
Hotfix to remove trailing whitespace in docs/user_guide/embed.rst

