### PR TITLE
Notebook output waits until bokehJS is loaded

### DIFF
--- a/bokeh/core/_templates/autoload_js.js
+++ b/bokeh/core/_templates/autoload_js.js
@@ -34,6 +34,8 @@ calls it with the rendered model.
   if (typeof (window._bokeh_onload_callbacks) === "undefined" || force !== "") {
     window._bokeh_onload_callbacks = [];
     window._bokeh_is_loading = undefined;
+    window._bokeh_init_load = Date.now();
+    window._bokeh_failed_load = false;
   }
 
   function run_callbacks() {
@@ -107,9 +109,12 @@ calls it with the rendered model.
       for (var i = 0; i < inline_js.length; i++) {
         inline_js[i](window.Bokeh);
       }
-    } else {
+    } else if (Date.now() < (window._bokeh_init_load+10000)) {
       setTimeout(run_inline_js, 500);
-    }
+    } else if (!window._bokeh_failed_load) {
+	  console.log("Bokeh: BokehJS failed to load within specified timeout.");
+	  window._bokeh_failed_load = true;
+	}
   }
 
   if (window._bokeh_is_loading === 0) {

--- a/bokeh/core/_templates/autoload_js.js
+++ b/bokeh/core/_templates/autoload_js.js
@@ -32,10 +32,10 @@ calls it with the rendered model.
   var force = "{{ force }}";
 
   if (typeof (window._bokeh_onload_callbacks) === "undefined" || force !== "") {
+    {% block init_window %}
     window._bokeh_onload_callbacks = [];
     window._bokeh_is_loading = undefined;
-    window._bokeh_init_load = Date.now();
-    window._bokeh_failed_load = false;
+    {% endblock %}
   }
 
   function run_callbacks() {
@@ -105,16 +105,11 @@ calls it with the rendered model.
   ];
 
   function run_inline_js() {
-    if (window.Bokeh !== undefined || force === "1") {
-      for (var i = 0; i < inline_js.length; i++) {
-        inline_js[i](window.Bokeh);
-      }
-    } else if (Date.now() < (window._bokeh_init_load+10000)) {
-      setTimeout(run_inline_js, 500);
-    } else if (!window._bokeh_failed_load) {
-	  console.log("Bokeh: BokehJS failed to load within specified timeout.");
-	  window._bokeh_failed_load = true;
-	}
+    {% block run_inline_js %}
+    for (var i = 0; i < inline_js.length; i++) {
+      inline_js[i](window.Bokeh);
+    }
+    {% endblock %}
   }
 
   if (window._bokeh_is_loading === 0) {

--- a/bokeh/core/_templates/autoload_js.js
+++ b/bokeh/core/_templates/autoload_js.js
@@ -103,8 +103,12 @@ calls it with the rendered model.
   ];
 
   function run_inline_js() {
-    for (var i = 0; i < inline_js.length; i++) {
-      inline_js[i](window.Bokeh);
+    if (window.Bokeh !== undefined || force === "1") {
+      for (var i = 0; i < inline_js.length; i++) {
+        inline_js[i](window.Bokeh);
+      }
+    } else {
+      setTimeout(run_inline_js, 500);
     }
   }
 

--- a/bokeh/core/_templates/autoload_js.js
+++ b/bokeh/core/_templates/autoload_js.js
@@ -32,11 +32,13 @@ calls it with the rendered model.
   var force = "{{ force }}";
 
   if (typeof (window._bokeh_onload_callbacks) === "undefined" || force !== "") {
-    {% block init_window %}
     window._bokeh_onload_callbacks = [];
     window._bokeh_is_loading = undefined;
-    {% endblock %}
   }
+
+
+  {% block autoload_init %}
+  {% endblock %}
 
   function run_callbacks() {
     window._bokeh_onload_callbacks.forEach(function(callback) { callback() });

--- a/bokeh/core/_templates/autoload_nb_js.js
+++ b/bokeh/core/_templates/autoload_nb_js.js
@@ -5,6 +5,23 @@
     window._bokeh_timeout = Date.now() + {{ timeout|default(0) }};
     window._bokeh_failed_load = false;
   }
+
+  var NB_LOAD_WARNING = {'data': {'text/html':
+     "<div style='background-color: #fdd'>\n"+
+	 "<p>\n"+
+     "BokehJS does not appear to have successfully loaded. If loading BokehJS from CDN, this \n"+
+     "may be due to a slow or bad network connection. Possible fixes:\n"+
+     "</p>\n"+
+     "<ul>\n"+
+     "<li>ALWAYS run `output_notebook()` in a cell <b>BY ITSELF</b>, <b>AT THE TOP</b>, with no other code</li>\n"+
+     "<li>re-rerun `output_notebook()` to attempt to load from CDN again, or</li>\n"+
+     "<li>use INLINE resources instead, as so:</li>\n"+
+     "</ul>\n"+
+     "<code>\n"+
+	 "from bokeh.resources import INLINE\n"+
+     "output_notebook(resources=INLINE)\n"+
+	 "</code>\n"+
+     "</div>"}}
 {% endblock %}
 
 {% block run_inline_js %}
@@ -16,6 +33,9 @@
       setTimeout(run_inline_js, 100);
     } else if (!window._bokeh_failed_load) {
       console.log("Bokeh: BokehJS failed to load within specified timeout.");
-      window._bokeh_failed_load = true;
-    }
+		window._bokeh_failed_load = true;
+    } else if (!force) {
+		cell = $("#{{ elementid }}").parents('.cell').data().cell;
+		cell.output_area.append_execute_result(NB_LOAD_WARNING)
+	}
 {% endblock %}

--- a/bokeh/core/_templates/autoload_nb_js.js
+++ b/bokeh/core/_templates/autoload_nb_js.js
@@ -10,7 +10,7 @@
 
   var NB_LOAD_WARNING = {'data': {'text/html':
      "<div style='background-color: #fdd'>\n"+
-	 "<p>\n"+
+     "<p>\n"+
      "BokehJS does not appear to have successfully loaded. If loading BokehJS from CDN, this \n"+
      "may be due to a slow or bad network connection. Possible fixes:\n"+
      "</p>\n"+
@@ -19,9 +19,9 @@
      "<li>use INLINE resources instead, as so:</li>\n"+
      "</ul>\n"+
      "<code>\n"+
-	 "from bokeh.resources import INLINE\n"+
+     "from bokeh.resources import INLINE\n"+
      "output_notebook(resources=INLINE)\n"+
-	 "</code>\n"+
+     "</code>\n"+
      "</div>"}};
 
   function display_loaded() {

--- a/bokeh/core/_templates/autoload_nb_js.js
+++ b/bokeh/core/_templates/autoload_nb_js.js
@@ -31,7 +31,7 @@
   }
 
   {%- if comms_target -%}
-  if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel != undefined)) {
+  if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel !== undefined)) {
     comm_manager = Jupyter.notebook.kernel.comm_manager
     comm_manager.register_target("{{ comms_target }}", function () {});
   }

--- a/bokeh/core/_templates/autoload_nb_js.js
+++ b/bokeh/core/_templates/autoload_nb_js.js
@@ -1,18 +1,18 @@
 {% extends "autoload_js.js" %}
 
-{% block init_window %}
-    window._bokeh_onload_callbacks = [];
-    window._bokeh_is_loading = undefined;
-    window._bokeh_init_load = Date.now() + {{ timeout|default(0) }};
+{% block autoload_init %}
+  if (typeof (window._bokeh_timeout) === "undefined" || force !== "") {
+    window._bokeh_timeout = Date.now() + {{ timeout|default(0) }};
     window._bokeh_failed_load = false;
+  }
 {% endblock %}
 
 {% block run_inline_js %}
-    if (window.Bokeh !== undefined || force === "1") {
+    if ((window.Bokeh !== undefined) || (force === "1")) {
       for (var i = 0; i < inline_js.length; i++) {
         inline_js[i](window.Bokeh);
       }
-    } else if (Date.now() < (window._bokeh_init_load)) {
+    } else if (Date.now() < window._bokeh_timeout) {
       setTimeout(run_inline_js, 100);
     } else if (!window._bokeh_failed_load) {
       console.log("Bokeh: BokehJS failed to load within specified timeout.");

--- a/bokeh/core/_templates/autoload_nb_js.js
+++ b/bokeh/core/_templates/autoload_nb_js.js
@@ -36,7 +36,7 @@
       for (var i = 0; i < inline_js.length; i++) {
         inline_js[i](window.Bokeh);
       }
-      if (force === "1") {
+      if ((force === "1"){%- if elementid -%} && element{%- endif -%}) {
         display_loaded();
       }
     } else if (Date.now() < window._bokeh_timeout) {

--- a/bokeh/core/_templates/autoload_nb_js.js
+++ b/bokeh/core/_templates/autoload_nb_js.js
@@ -6,8 +6,6 @@
     window._bokeh_failed_load = false;
   }
 
-  var NB_LOADED_MSG = {'data': {'text/html': 'Bokeh loaded.'}};
-
   var NB_LOAD_WARNING = {'data': {'text/html':
      "<div style='background-color: #fdd'>\n"+
      "<p>\n"+
@@ -25,9 +23,8 @@
      "</div>"}};
 
   function display_loaded() {
-	if (window.Bokeh !== undefined) {
-      var cell = $("#{{ elementid }}").parents('.cell').data().cell;
-      cell.output_area.append_execute_result(NB_LOADED_MSG)
+    if (window.Bokeh !== undefined) {
+      Bokeh.$("#{{ elementid }}").text("BokehJS successfully loaded.");
     } else if (Date.now() < window._bokeh_timeout)
       setTimeout(display_loaded, 100)
   }

--- a/bokeh/core/_templates/autoload_nb_js.js
+++ b/bokeh/core/_templates/autoload_nb_js.js
@@ -36,9 +36,11 @@
       for (var i = 0; i < inline_js.length; i++) {
         inline_js[i](window.Bokeh);
       }
-      if ((force === "1"){%- if elementid -%} && element{%- endif -%}) {
+      {%- if elementid -%}
+      if (force === "1") {
         display_loaded();
       }
+      {%- endif -%}
     } else if (Date.now() < window._bokeh_timeout) {
       setTimeout(run_inline_js, 100);
     } else if (!window._bokeh_failed_load) {

--- a/bokeh/core/_templates/autoload_nb_js.js
+++ b/bokeh/core/_templates/autoload_nb_js.js
@@ -6,6 +6,8 @@
     window._bokeh_failed_load = false;
   }
 
+  var NB_LOADED_MSG = {'data': {'text/html': 'Bokeh loaded.'}};
+
   var NB_LOAD_WARNING = {'data': {'text/html':
      "<div style='background-color: #fdd'>\n"+
 	 "<p>\n"+
@@ -13,7 +15,6 @@
      "may be due to a slow or bad network connection. Possible fixes:\n"+
      "</p>\n"+
      "<ul>\n"+
-     "<li>ALWAYS run `output_notebook()` in a cell <b>BY ITSELF</b>, <b>AT THE TOP</b>, with no other code</li>\n"+
      "<li>re-rerun `output_notebook()` to attempt to load from CDN again, or</li>\n"+
      "<li>use INLINE resources instead, as so:</li>\n"+
      "</ul>\n"+
@@ -21,7 +22,15 @@
 	 "from bokeh.resources import INLINE\n"+
      "output_notebook(resources=INLINE)\n"+
 	 "</code>\n"+
-     "</div>"}}
+     "</div>"}};
+
+  function display_loaded() {
+	if (window.Bokeh !== undefined) {
+      var cell = $("#{{ elementid }}").parents('.cell').data().cell;
+      cell.output_area.append_execute_result(NB_LOADED_MSG)
+    } else if (Date.now() < window._bokeh_timeout)
+      setTimeout(display_loaded, 100)
+  }
 {% endblock %}
 
 {% block run_inline_js %}
@@ -29,13 +38,16 @@
       for (var i = 0; i < inline_js.length; i++) {
         inline_js[i](window.Bokeh);
       }
+      if (force === "1") {
+        display_loaded();
+      }
     } else if (Date.now() < window._bokeh_timeout) {
       setTimeout(run_inline_js, 100);
     } else if (!window._bokeh_failed_load) {
       console.log("Bokeh: BokehJS failed to load within specified timeout.");
-		window._bokeh_failed_load = true;
+      window._bokeh_failed_load = true;
     } else if (!force) {
-		cell = $("#{{ elementid }}").parents('.cell').data().cell;
-		cell.output_area.append_execute_result(NB_LOAD_WARNING)
+      var cell = $("#{{ elementid }}").parents('.cell').data().cell;
+      cell.output_area.append_execute_result(NB_LOAD_WARNING)
 	}
 {% endblock %}

--- a/bokeh/core/_templates/autoload_nb_js.js
+++ b/bokeh/core/_templates/autoload_nb_js.js
@@ -29,6 +29,13 @@
       setTimeout(display_loaded, 100)
     }
   }
+
+  {%- if comms_target -%}
+  if (window.Jupyter !== undefined) {
+    comm_manager = Jupyter.notebook.kernel.comm_manager
+    comm_manager.register_target("{{ comms_target }}", function () {});
+  }
+  {%- endif -%}
 {% endblock %}
 
 {% block run_inline_js %}

--- a/bokeh/core/_templates/autoload_nb_js.js
+++ b/bokeh/core/_templates/autoload_nb_js.js
@@ -31,7 +31,7 @@
   }
 
   {%- if comms_target -%}
-  if (window.Jupyter !== undefined) {
+  if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel != undefined)) {
     comm_manager = Jupyter.notebook.kernel.comm_manager
     comm_manager.register_target("{{ comms_target }}", function () {});
   }

--- a/bokeh/core/_templates/autoload_nb_js.js
+++ b/bokeh/core/_templates/autoload_nb_js.js
@@ -25,8 +25,9 @@
   function display_loaded() {
     if (window.Bokeh !== undefined) {
       Bokeh.$("#{{ elementid }}").text("BokehJS successfully loaded.");
-    } else if (Date.now() < window._bokeh_timeout)
+    } else if (Date.now() < window._bokeh_timeout) {
       setTimeout(display_loaded, 100)
+    }
   }
 {% endblock %}
 
@@ -46,5 +47,5 @@
     } else if (!force) {
       var cell = $("#{{ elementid }}").parents('.cell').data().cell;
       cell.output_area.append_execute_result(NB_LOAD_WARNING)
-	}
+    }
 {% endblock %}

--- a/bokeh/core/_templates/autoload_nb_js.js
+++ b/bokeh/core/_templates/autoload_nb_js.js
@@ -1,0 +1,21 @@
+{% extends "autoload_js.js" %}
+
+{% block init_window %}
+    window._bokeh_onload_callbacks = [];
+    window._bokeh_is_loading = undefined;
+    window._bokeh_init_load = Date.now() + {{ timeout|default(0) }};
+    window._bokeh_failed_load = false;
+{% endblock %}
+
+{% block run_inline_js %}
+    if (window.Bokeh !== undefined || force === "1") {
+      for (var i = 0; i < inline_js.length; i++) {
+        inline_js[i](window.Bokeh);
+      }
+    } else if (Date.now() < (window._bokeh_init_load)) {
+      setTimeout(run_inline_js, 100);
+    } else if (!window._bokeh_failed_load) {
+      console.log("Bokeh: BokehJS failed to load within specified timeout.");
+      window._bokeh_failed_load = true;
+    }
+{% endblock %}

--- a/bokeh/core/_templates/notebook_js.js
+++ b/bokeh/core/_templates/notebook_js.js
@@ -2,13 +2,7 @@ var docs_json = {{ docs_json }};
 var render_items = {{ render_items }};
 var comms_target = "{{ comms_target }}";
 
-(function embed_items() {
-  if (window.Bokeh !== undefined) {
-    Bokeh.embed.embed_items(docs_json, render_items{%- if websocket_url -%}, "{{ websocket_url }}" {%- endif -%});
-    if (window.Jupyter !== undefined) {
-      Jupyter.notebook.kernel.execute("import bokeh; bokeh.io._comms_handles['"+comms_target+"'].init()");
-	}
-  } else if (Date.now() < (window._bokeh_init_load)) {
-    setTimeout(run_inline_js, 100);
-  }
-})();
+Bokeh.embed.embed_items(docs_json, render_items{%- if websocket_url -%}, "{{ websocket_url }}" {%- endif -%});
+if (window.Jupyter !== undefined) {
+  Jupyter.notebook.kernel.execute("import bokeh; bokeh.io._comms_handles['"+comms_target+"'].init()");
+}

--- a/bokeh/core/_templates/notebook_js.js
+++ b/bokeh/core/_templates/notebook_js.js
@@ -8,7 +8,7 @@ var comms_target = "{{ comms_target }}";
     if (window.Jupyter !== undefined) {
       Jupyter.notebook.kernel.execute("import bokeh; bokeh.io._comms_handles['"+comms_target+"'].init()");
 	}
-  } else if (Date.now() < (window._bokeh_init_load+10000)) {
-    setTimeout(run_inline_js, 500);
+  } else if (Date.now() < (window._bokeh_init_load)) {
+    setTimeout(run_inline_js, 100);
   }
 })();

--- a/bokeh/core/_templates/notebook_js.js
+++ b/bokeh/core/_templates/notebook_js.js
@@ -1,0 +1,14 @@
+var docs_json = {{ docs_json }};
+var render_items = {{ render_items }};
+var comms_target = "{{ comms_target }}";
+
+(function embed_items() {
+  if (window.Bokeh !== undefined) {
+    Bokeh.embed.embed_items(docs_json, render_items{%- if websocket_url -%}, "{{ websocket_url }}" {%- endif -%});
+    if (typeof Jupyter !== "undefined") {
+      Jupyter.notebook.kernel.execute("import bokeh; bokeh.io._comms_handles['"+comms_target+"'].init()");
+	}
+  } else {
+    setTimeout(embed_items, 500)
+  }
+})();

--- a/bokeh/core/_templates/notebook_js.js
+++ b/bokeh/core/_templates/notebook_js.js
@@ -5,10 +5,10 @@ var comms_target = "{{ comms_target }}";
 (function embed_items() {
   if (window.Bokeh !== undefined) {
     Bokeh.embed.embed_items(docs_json, render_items{%- if websocket_url -%}, "{{ websocket_url }}" {%- endif -%});
-    if (typeof Jupyter !== "undefined") {
+    if (window.Jupyter !== undefined) {
       Jupyter.notebook.kernel.execute("import bokeh; bokeh.io._comms_handles['"+comms_target+"'].init()");
 	}
-  } else {
-    setTimeout(embed_items, 500)
+  } else if (Date.now() < (window._bokeh_init_load+10000)) {
+    setTimeout(run_inline_js, 500);
   }
 })();

--- a/bokeh/core/_templates/notebook_js.js
+++ b/bokeh/core/_templates/notebook_js.js
@@ -1,8 +1,0 @@
-var docs_json = {{ docs_json }};
-var render_items = {{ render_items }};
-var comms_target = "{{ comms_target }}";
-
-Bokeh.embed.embed_items(docs_json, render_items{%- if websocket_url -%}, "{{ websocket_url }}" {%- endif -%});
-if (window.Jupyter !== undefined) {
-  Jupyter.notebook.kernel.execute("import bokeh; bokeh.io._comms_handles['"+comms_target+"'].init()");
-}

--- a/bokeh/core/templates.py
+++ b/bokeh/core/templates.py
@@ -27,7 +27,6 @@ SCRIPT_TAG = _env.get_template("script_tag.html")
 PLOT_DIV = _env.get_template("plot_div.html")
 
 DOC_JS = _env.get_template("doc_js.js")
-NOTEBOOK_JS = _env.get_template("notebook_js.js")
 
 FILE = _env.get_template("file.html")
 

--- a/bokeh/core/templates.py
+++ b/bokeh/core/templates.py
@@ -35,4 +35,5 @@ NOTEBOOK_LOAD = _env.get_template("notebook_load.html")
 NOTEBOOK_DIV = _env.get_template("notebook_div.html")
 
 AUTOLOAD_JS = _env.get_template("autoload_js.js")
+AUTOLOAD_NB_JS = _env.get_template("autoload_nb_js.js")
 AUTOLOAD_TAG = _env.get_template("autoload_tag.html")

--- a/bokeh/core/templates.py
+++ b/bokeh/core/templates.py
@@ -27,6 +27,7 @@ SCRIPT_TAG = _env.get_template("script_tag.html")
 PLOT_DIV = _env.get_template("plot_div.html")
 
 DOC_JS = _env.get_template("doc_js.js")
+NOTEBOOK_JS = _env.get_template("notebook_js.js")
 
 FILE = _env.get_template("file.html")
 

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -260,9 +260,11 @@ def notebook_div(model, notebook_comms_target=None):
     item = render_items[0]
     item['notebook_comms_target'] = notebook_comms_target
 
-    script = _script_for_notebook_render_items(docs_json, render_items,
-                                               notebook_comms_target,
-                                               wrap_script=False)
+    script = _wrap_in_function(NOTEBOOK_JS.render(
+        docs_json=serialize_json(docs_json),
+        render_items=serialize_json(render_items),
+        comms_target=notebook_comms_target
+    ))
     resources = EMPTY
 
     js = AUTOLOAD_JS.render(
@@ -452,26 +454,11 @@ def autoload_server(model, app_path="/", session_id=None, url="default"):
 
     return encode_utf8(tag)
 
-def _script_for_render_items(docs_json, render_items,
-                             websocket_url=None, wrap_script=True):
+def _script_for_render_items(docs_json, render_items, websocket_url=None, wrap_script=True):
     plot_js = _wrap_in_function(DOC_JS.render(
         websocket_url=websocket_url,
         docs_json=serialize_json(docs_json),
         render_items=serialize_json(render_items)
-    ))
-
-    if wrap_script:
-        return SCRIPT_TAG.render(js_code=plot_js)
-    else:
-        return plot_js
-
-
-def _script_for_notebook_render_items(docs_json, render_items, notebook_comms_target=None,
-                                      wrap_script=True):
-    plot_js = _wrap_in_function(NOTEBOOK_JS.render(
-        docs_json=serialize_json(docs_json),
-        render_items=serialize_json(render_items),
-        comms_target=notebook_comms_target
     ))
 
     if wrap_script:

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -20,8 +20,7 @@ from six import string_types
 
 from .core.templates import (
     AUTOLOAD_JS, AUTOLOAD_NB_JS, AUTOLOAD_TAG,
-    FILE, NOTEBOOK_JS, NOTEBOOK_DIV, PLOT_DIV,
-    DOC_JS, SCRIPT_TAG
+    FILE, NOTEBOOK_DIV, PLOT_DIV, DOC_JS, SCRIPT_TAG
 )
 from .core.json_encoder import serialize_json
 from .document import Document, DEFAULT_TITLE
@@ -261,19 +260,19 @@ def notebook_div(model, notebook_comms_target=None):
     item = render_items[0]
     item['notebook_comms_target'] = notebook_comms_target
 
-    script = _wrap_in_function(NOTEBOOK_JS.render(
+    script = _wrap_in_function(DOC_JS.render(
         docs_json=serialize_json(docs_json),
-        render_items=serialize_json(render_items),
-        comms_target=notebook_comms_target
+        render_items=serialize_json(render_items)
     ))
     resources = EMPTY
 
     js = AUTOLOAD_NB_JS.render(
+        comms_target=notebook_comms_target,
         js_urls = resources.js_files,
         css_urls = resources.css_files,
         js_raw = resources.js_raw + [script],
         css_raw = resources.css_raw_str,
-        elementid = item['elementid'],
+        elementid = item['elementid']
     )
     div = _div_for_render_item(item)
 

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -19,8 +19,9 @@ from warnings import warn
 from six import string_types
 
 from .core.templates import (
-    AUTOLOAD_JS, AUTOLOAD_TAG, FILE, NOTEBOOK_JS,
-    NOTEBOOK_DIV, PLOT_DIV, DOC_JS, SCRIPT_TAG
+    AUTOLOAD_JS, AUTOLOAD_NB_JS, AUTOLOAD_TAG,
+    FILE, NOTEBOOK_JS, NOTEBOOK_DIV, PLOT_DIV,
+    DOC_JS, SCRIPT_TAG
 )
 from .core.json_encoder import serialize_json
 from .document import Document, DEFAULT_TITLE
@@ -267,7 +268,7 @@ def notebook_div(model, notebook_comms_target=None):
     ))
     resources = EMPTY
 
-    js = AUTOLOAD_JS.render(
+    js = AUTOLOAD_NB_JS.render(
         js_urls = resources.js_files,
         css_urls = resources.css_files,
         js_raw = resources.js_raw + [script],

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -19,7 +19,7 @@ from warnings import warn
 from six import string_types
 
 from .core.templates import (
-    AUTOLOAD_JS, AUTOLOAD_TAG, FILE,
+    AUTOLOAD_JS, AUTOLOAD_TAG, FILE, NOTEBOOK_JS,
     NOTEBOOK_DIV, PLOT_DIV, DOC_JS, SCRIPT_TAG
 )
 from .core.json_encoder import serialize_json
@@ -260,7 +260,9 @@ def notebook_div(model, notebook_comms_target=None):
     item = render_items[0]
     item['notebook_comms_target'] = notebook_comms_target
 
-    script = _script_for_render_items(docs_json, render_items, wrap_script=False)
+    script = _script_for_notebook_render_items(docs_json, render_items,
+                                               notebook_comms_target,
+                                               wrap_script=False)
     resources = EMPTY
 
     js = AUTOLOAD_JS.render(
@@ -450,11 +452,26 @@ def autoload_server(model, app_path="/", session_id=None, url="default"):
 
     return encode_utf8(tag)
 
-def _script_for_render_items(docs_json, render_items, websocket_url=None, wrap_script=True):
+def _script_for_render_items(docs_json, render_items,
+                             websocket_url=None, wrap_script=True):
     plot_js = _wrap_in_function(DOC_JS.render(
         websocket_url=websocket_url,
         docs_json=serialize_json(docs_json),
         render_items=serialize_json(render_items)
+    ))
+
+    if wrap_script:
+        return SCRIPT_TAG.render(js_code=plot_js)
+    else:
+        return plot_js
+
+
+def _script_for_notebook_render_items(docs_json, render_items, notebook_comms_target=None,
+                                      wrap_script=True):
+    plot_js = _wrap_in_function(NOTEBOOK_JS.render(
+        docs_json=serialize_json(docs_json),
+        render_items=serialize_json(render_items),
+        comms_target=notebook_comms_target
     ))
 
     if wrap_script:

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -258,7 +258,10 @@ def notebook_div(model, notebook_comms_target=None):
         (docs_json, render_items) = _standalone_docs_json_and_render_items([model])
 
     item = render_items[0]
-    item['notebook_comms_target'] = notebook_comms_target
+    if notebook_comms_target:
+        item['notebook_comms_target'] = notebook_comms_target
+    else:
+        notebook_comms_target = ''
 
     script = _wrap_in_function(DOC_JS.render(
         docs_json=serialize_json(docs_json),

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -582,6 +582,9 @@ def push_notebook(document=None, state=None, handle=None):
         msg = dict(doc=to_json)
     else:
         msg = Document._compute_patch_between_json(handle.json, to_json)
+
+    if handle.comms is None:
+        handle.init()
     handle.comms.send(json.dumps(msg))
     handle.update(document, to_json)
 

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -335,18 +335,6 @@ def _show_file_with_state(obj, state, new, controller):
     filename = save(obj, state=state)
     controller.open("file://" + filename, new=_new_param[new])
 
-_NB_LOAD_WARNING = """
-
-BokehJS does not appear to have successfully loaded. If loading BokehJS from CDN, this
-may be due to a slow or bad network connection. Possible fixes:
-
-* ALWAYS run `output_notebook()` in a cell BY ITSELF, AT THE TOP, with no other code
-* re-rerun `output_notebook()` to attempt to load from CDN again, or
-* use INLINE resources instead, as so:
-
-    from bokeh.resources import INLINE
-    output_notebook(resources=INLINE)
-"""
 
 def _show_notebook_with_state(obj, state):
     if state.server_enabled:

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -152,7 +152,7 @@ def output_file(filename, title="Bokeh Plot", autosave=False, mode="cdn", root_d
         root_dir=root_dir
     )
 
-def output_notebook(resources=None, verbose=False, hide_banner=False):
+def output_notebook(resources=None, verbose=False, hide_banner=False, load_timeout=5000):
     ''' Configure the default output state to generate output in
     Jupyter/IPython notebook cells when :func:`show` is called.
 
@@ -170,6 +170,9 @@ def output_notebook(resources=None, verbose=False, hide_banner=False):
         hide_banner (bool, optional):
             whether to hide the Bokeh banner (default: False)
 
+        load_timeout (int, optional) :
+            Timeout in milliseconds when plots assume load timed out (default: 5000)
+
     Returns:
         None
 
@@ -178,7 +181,7 @@ def output_notebook(resources=None, verbose=False, hide_banner=False):
         session or the top of a script.
 
     '''
-    load_notebook(resources, verbose, hide_banner)
+    load_notebook(resources, verbose, hide_banner, load_timeout)
     _state.output_notebook()
 
 # usually we default session_id to "generate a random one" but

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -310,7 +310,7 @@ def show(obj, browser=None, new="tab", notebook_handle=False):
     return _show_with_state(obj, _state, browser, new, notebook_handle=notebook_handle)
 
 
-def _show_with_state(obj, state, browser, new, notebook_handle=None):
+def _show_with_state(obj, state, browser, new, notebook_handle=False):
     controller = browserlib.get_browser_controller(browser=browser)
 
     comms_handle = None

--- a/bokeh/tests/test_io.py
+++ b/bokeh/tests/test_io.py
@@ -66,14 +66,14 @@ class TestOutputNotebook(DefaultStateTester):
 
     @patch('bokeh.io.load_notebook')
     def test_noarg(self, mock_load_notebook):
-        default_load_notebook_args = (None, False, False)
+        default_load_notebook_args = (None, False, False, 5000)
         io.output_notebook()
         self._check_func_called(io._state.output_notebook, (), {})
         self._check_func_called(mock_load_notebook, default_load_notebook_args, {})
 
     @patch('bokeh.io.load_notebook')
     def test_args(self, mock_load_notebook):
-        load_notebook_args = (Resources(), True, True)
+        load_notebook_args = (Resources(), True, True, 1000)
         io.output_notebook(*load_notebook_args)
         self._check_func_called(io._state.output_notebook, (), {})
         self._check_func_called(mock_load_notebook, load_notebook_args, {})
@@ -348,28 +348,6 @@ class Test_ShowWithState(DefaultStateTester):
         self.assertFalse(mock__show_notebook_with_state.called)
         self._check_func_called(mock__show_server_with_state, ("obj", s, "new", "controller"), {})
         self._check_func_called(mock__show_file_with_state, ("obj", s, "new", "controller"), {})
-
-    @patch('warnings.warn')
-    @patch('bokeh.util.browser.get_browser_controller')
-    def test_ShowNotebookWithState_bokehjs_load_failed(self, mock_get_browser_controller, mock_warn):
-        mock_get_browser_controller.return_value = "controller"
-        s = io.State()
-        s.output_notebook()
-        io._show_with_state("obj", s, "browser", "new")
-        self.assertTrue(mock_warn.called)
-        self.assertEqual(mock_warn.call_args[0], ("""
-
-BokehJS does not appear to have successfully loaded. If loading BokehJS from CDN, this
-may be due to a slow or bad network connection. Possible fixes:
-
-* ALWAYS run `output_notebook()` in a cell BY ITSELF, AT THE TOP, with no other code
-* re-rerun `output_notebook()` to attempt to load from CDN again, or
-* use INLINE resources instead, as so:
-
-    from bokeh.resources import INLINE
-    output_notebook(resources=INLINE)
-""",))
-        self.assertEqual(mock_warn.call_args[1], {})
 
 class Test_ShowFileWithState(DefaultStateTester):
 

--- a/bokeh/tests/test_io.py
+++ b/bokeh/tests/test_io.py
@@ -263,15 +263,15 @@ class TestShow(DefaultStateTester):
 
     @patch('bokeh.io._show_with_state')
     def test_default_args(self, mock__show_with_state):
-        default_kwargs = dict(browser=None, new="tab")
+        default_kwargs = dict(browser=None, new="tab", notebook_handle=False)
         io.show("obj", **default_kwargs)
-        self._check_func_called(mock__show_with_state, ("obj", io._state, None, "tab"), {})
+        self._check_func_called(mock__show_with_state, ("obj", io._state, None, "tab"), {'notebook_handle': False})
 
     @patch('bokeh.io._show_with_state')
     def test_explicit_args(self, mock__show_with_state):
-        default_kwargs = dict(browser="browser", new="new")
+        default_kwargs = dict(browser="browser", new="new", notebook_handle=True)
         io.show("obj", **default_kwargs)
-        self._check_func_called(mock__show_with_state, ("obj", io._state, "browser", "new"), {})
+        self._check_func_called(mock__show_with_state, ("obj", io._state, "browser", "new"), {'notebook_handle': True})
 
 
 @patch('bokeh.io._show_with_state')
@@ -305,19 +305,19 @@ class Test_ShowWithState(DefaultStateTester):
         s = io.State()
         s.output_notebook()
         io._show_with_state("obj", s, "browser", "new")
-        self._check_func_called(mock__show_notebook_with_state, ("obj", s), {})
+        self._check_func_called(mock__show_notebook_with_state, ("obj", s, False), {})
         self.assertFalse(mock__show_server_with_state.called)
         self.assertFalse(mock__show_file_with_state.called)
 
         s.output_file("foo.html")
         io._show_with_state("obj", s, "browser", "new")
-        self._check_func_called(mock__show_notebook_with_state, ("obj", s), {})
+        self._check_func_called(mock__show_notebook_with_state, ("obj", s, False), {})
         self.assertFalse(mock__show_server_with_state.called)
         self._check_func_called(mock__show_file_with_state, ("obj", s, "new", "controller"), {})
 
         s._session = Mock
         io._show_with_state("obj", s, "browser", "new")
-        self._check_func_called(mock__show_notebook_with_state, ("obj", s), {})
+        self._check_func_called(mock__show_notebook_with_state, ("obj", s, False), {})
         self.assertFalse(mock__show_server_with_state.called)
         self._check_func_called(mock__show_file_with_state, ("obj", s, "new", "controller"), {})
 
@@ -377,7 +377,7 @@ class Test_ShowNotebookWithState(DefaultStateTester):
         s._server_enabled = True
         mock_autoload_server.return_value = "snippet"
 
-        io._show_notebook_with_state("obj", s)
+        io._show_notebook_with_state("obj", s, True)
         self._check_func_called(mock_push, (), {"state": s})
         self._check_func_called(mock_publish_display_data, ({"text/html":"snippet"},), {})
 
@@ -390,7 +390,7 @@ class Test_ShowNotebookWithState(DefaultStateTester):
         mock_notebook_div.return_value = "notebook_div"
 
         io._nb_loaded = True
-        io._show_notebook_with_state("obj", s)
+        io._show_notebook_with_state("obj", s, True)
         io._nb_loaded = False
         self._check_func_called(mock_publish_display_data, ({"text/html": "notebook_div"},), {})
 

--- a/bokeh/util/notebook.py
+++ b/bokeh/util/notebook.py
@@ -31,7 +31,7 @@ def load_notebook(resources=None, verbose=False, hide_banner=False):
     publish_display_data({'application/javascript': js})
 
 FINALIZE_JS = """
-Bokeh.$("#%s").text("BokehJS successfully loaded");
+Bokeh.$("#%s").text("BokehJS is loading...");
 """
 
 def _load_notebook_html(resources=None, verbose=False, hide_banner=False):

--- a/bokeh/util/notebook.py
+++ b/bokeh/util/notebook.py
@@ -76,7 +76,7 @@ def _load_notebook_html(resources=None, verbose=False, hide_banner=False,
     )
 
     js = AUTOLOAD_NB_JS.render(
-        elementid = element_id,
+        elementid = '' if hide_banner else element_id,
         js_urls  = resources.js_files,
         css_urls = resources.css_files,
         js_raw   = resources.js_raw + [FINALIZE_JS % element_id],

--- a/bokeh/util/notebook.py
+++ b/bokeh/util/notebook.py
@@ -32,10 +32,6 @@ def load_notebook(resources=None, verbose=False, hide_banner=False):
 
 FINALIZE_JS = """
 Bokeh.$("#%s").text("BokehJS successfully loaded");
-var kernel = Jupyter.notebook.kernel
-if (kernel.execute !== undefined) {
-    kernel.execute("import bokeh.io; bokeh.io._nb_loaded = True");
-}
 """
 
 def _load_notebook_html(resources=None, verbose=False, hide_banner=False):

--- a/bokeh/util/notebook.py
+++ b/bokeh/util/notebook.py
@@ -76,6 +76,7 @@ def _load_notebook_html(resources=None, verbose=False, hide_banner=False,
     )
 
     js = AUTOLOAD_NB_JS.render(
+        elementid = element_id,
         js_urls  = resources.js_files,
         css_urls = resources.css_files,
         js_raw   = resources.js_raw + [FINALIZE_JS % element_id],

--- a/bokeh/util/notebook.py
+++ b/bokeh/util/notebook.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 
 _notebook_loaded = None
 
-def load_notebook(resources=None, verbose=False, hide_banner=False):
+def load_notebook(resources=None, verbose=False, hide_banner=False, load_timeout=5000):
     ''' Prepare the IPython notebook for displaying Bokeh plots.
 
     Args:
@@ -18,6 +18,9 @@ def load_notebook(resources=None, verbose=False, hide_banner=False):
         hide_banner (bool, optional):
             whether to hide the Bokeh banner (default: False)
 
+        load_timeout (int, optional) :
+            Timeout in milliseconds when plots assume load timed out (default: 5000)
+
     .. warning::
         Clearing the output cell containing the published BokehJS
         resources HTML code may cause Bokeh CSS styling to be removed.
@@ -26,7 +29,7 @@ def load_notebook(resources=None, verbose=False, hide_banner=False):
         None
 
     '''
-    html, js = _load_notebook_html(resources, verbose, hide_banner)
+    html, js = _load_notebook_html(resources, verbose, hide_banner, load_timeout)
     publish_display_data({'text/html': html})
     publish_display_data({'application/javascript': js})
 
@@ -34,7 +37,8 @@ FINALIZE_JS = """
 Bokeh.$("#%s").text("BokehJS is loading...");
 """
 
-def _load_notebook_html(resources=None, verbose=False, hide_banner=False):
+def _load_notebook_html(resources=None, verbose=False, hide_banner=False,
+                        load_timeout=5000):
     global _notebook_loaded
 
     from .. import __version__
@@ -77,6 +81,7 @@ def _load_notebook_html(resources=None, verbose=False, hide_banner=False):
         js_raw   = resources.js_raw + [FINALIZE_JS % element_id],
         css_raw  = resources.css_raw_str,
         force    = 1,
+        timeout  = load_timeout
     )
 
     return html, js

--- a/bokeh/util/notebook.py
+++ b/bokeh/util/notebook.py
@@ -42,7 +42,7 @@ def _load_notebook_html(resources=None, verbose=False, hide_banner=False,
     global _notebook_loaded
 
     from .. import __version__
-    from ..core.templates import AUTOLOAD_JS, NOTEBOOK_LOAD
+    from ..core.templates import AUTOLOAD_NB_JS, NOTEBOOK_LOAD
     from ..util.serialization import make_id
     from ..resources import CDN
 
@@ -75,7 +75,7 @@ def _load_notebook_html(resources=None, verbose=False, hide_banner=False,
         hide_banner   = hide_banner,
     )
 
-    js = AUTOLOAD_JS.render(
+    js = AUTOLOAD_NB_JS.render(
         js_urls  = resources.js_files,
         css_urls = resources.css_files,
         js_raw   = resources.js_raw + [FINALIZE_JS % element_id],

--- a/bokehjs/src/coffee/embed.coffee
+++ b/bokehjs/src/coffee/embed.coffee
@@ -23,10 +23,18 @@ _handle_notebook_comms = (msg) ->
   else
     throw new Error("handling notebook comms message: ", msg)
 
+_update_comms_callback = (target, doc, comm) ->
+  if target == comm.target_name
+    comm.on_msg(_.bind(_handle_notebook_comms, doc))
+
 _init_comms = (target, doc) ->
   if Jupyter?
+    logger.info("Registering Jupyter comms for target #{target}")
+    comm_manager = Jupyter.notebook.kernel.comm_manager
+    update_comms = _.partial(_update_comms_callback, target, doc)
+    for id, promise of comm_manager.comms
+      promise.then(update_comms)
     try
-      comm_manager = Jupyter.notebook.kernel.comm_manager
       comm_manager.register_target(target, (comm, msg) ->
         logger.info("Registering Jupyter comms for target #{target}")
         comm.on_msg(_.bind(_handle_notebook_comms, doc))
@@ -34,7 +42,7 @@ _init_comms = (target, doc) ->
     catch e
       logger.warn("Jupyter comms failed to register. push_notebook() will not function. (exception reported: #{e})")
   else
-    console.warn('Juptyer notebooks comms not available. push_notebook() will not function');
+    console.warn('Jupyter notebooks comms not available. push_notebook() will not function');
 
 _create_view = (model) ->
   view = new model.default_view({model : model})

--- a/examples/howto/notebook_comms/Basic Usage.ipynb
+++ b/examples/howto/notebook_comms/Basic Usage.ipynb
@@ -40,7 +40,7 @@
     "r2 = p2.circle([1,2,3], [4,5,6], size=20)\n",
     "\n",
     "# get a handle to update the shown cell with\n",
-    "t = show(row(p1, p2))"
+    "t = show(row(p1, p2), notebook_handle=True)"
    ]
   },
   {
@@ -93,7 +93,7 @@
     "r3 = p3.circle([1,2,3], [4,5,6], size=20)\n",
     "\n",
     "# get a handle to update the shown cell with\n",
-    "t2 = show(p3) "
+    "t2 = show(p3, notebook_handle=True) "
    ]
   },
   {
@@ -143,7 +143,7 @@
    "outputs": [],
    "source": [
     "# get a handle to update the shown cell with\n",
-    "t3 = show(p2)"
+    "t3 = show(p2, notebook_handle=True)"
    ]
   },
   {

--- a/examples/howto/notebook_comms/Continuous Updating.ipynb
+++ b/examples/howto/notebook_comms/Continuous Updating.ipynb
@@ -71,7 +71,7 @@
    "outputs": [],
    "source": [
     "# get and explicit handle to update the next show cell with\n",
-    "target = show(p)"
+    "target = show(p, notebook_handle=True)"
    ]
   },
   {
@@ -86,7 +86,7 @@
     "i = 0\n",
     "while True:\n",
     "    i +=1 \n",
-    "    p.title = str(i)\n",
+    "    p.title.text = str(i)\n",
     "    \n",
     "    r.data_source.data['radius'] = radii * (2 + np.sin(i/5))\n",
     "    \n",

--- a/examples/howto/notebook_comms/Jupyter Interactors.ipynb
+++ b/examples/howto/notebook_comms/Jupyter Interactors.ipynb
@@ -78,7 +78,7 @@
    },
    "outputs": [],
    "source": [
-    "show(p)"
+    "show(p, notebook_handle=True)"
    ]
   },
   {

--- a/examples/howto/notebook_comms/Numba Image Example.ipynb
+++ b/examples/howto/notebook_comms/Numba Image Example.ipynb
@@ -132,7 +132,7 @@
    },
    "outputs": [],
    "source": [
-    "t_blur = show(p_blur)"
+    "t_blur = show(p_blur, notebook_handle=True)"
    ]
   },
   {
@@ -385,7 +385,7 @@
    },
    "outputs": [],
    "source": [
-    "t_kernel = show(p_kernel)"
+    "t_kernel = show(p_kernel, notebook_handle=True)"
    ]
   },
   {
@@ -507,7 +507,7 @@
    },
    "outputs": [],
    "source": [
-    "t_wavelet = show(p_wavelet)"
+    "t_wavelet = show(p_wavelet, notebook_handle=True)"
    ]
   },
   {


### PR DESCRIPTION
With this PR the code which initializes plots polls whether bokehJS is initialized, delaying rendering of the plot until it is fully loaded. It fixes the issue with Run All (#4987) and nbconvert works again (#4980). To test it you run ``output_notebook``, clear the notebook and reload the page to ensure bokehJS is no longer loaded and then display a plot. The plot will wait to display until you run ``output_notebook`` a second time to load bokehJS. 

- [x] Add a customizable timeout.
- [x] Inject warning into DOM when timeout is reached.
- [x] Update tests

Since keeping around a registry of handles is quite expensive maybe there should be some way to explicitly request a comms handle to be created.