### PR TITLE
Update hover styling to match other bokeh elements

### DIFF
--- a/bokehjs/src/less/bokeh.less
+++ b/bokehjs/src/less/bokeh.less
@@ -22,9 +22,9 @@
 /* notebook specific tweaks so no black outline and matching padding
 /* can't be wrapped inside bk-root. here are the offending jupyter lines:
 /* https://github.com/jupyter/notebook/blob/master/notebook/static/notebook/less/renderedhtml.less#L59-L76 */
-.rendered_html .bk-root .bk-tooltip table, 
-.rendered_html .bk-root .bk-tooltip tr, 
-.rendered_html .bk-root .bk-tooltip th, 
+.rendered_html .bk-root .bk-tooltip table,
+.rendered_html .bk-root .bk-tooltip tr,
+.rendered_html .bk-root .bk-tooltip th,
 .rendered_html .bk-root .bk-tooltip td {
   border: none;
   padding: 1px;

--- a/bokehjs/src/less/bokeh.less
+++ b/bokehjs/src/less/bokeh.less
@@ -19,3 +19,13 @@
   width: 100%;
   height: 100%;
 }
+/* notebook specific tweaks so no black outline and matching padding
+/* can't be wrapped inside bk-root. here are the offending jupyter lines:
+/* https://github.com/jupyter/notebook/blob/master/notebook/static/notebook/less/renderedhtml.less#L59-L76 */
+.rendered_html .bk-root .bk-tooltip table, 
+.rendered_html .bk-root .bk-tooltip tr, 
+.rendered_html .bk-root .bk-tooltip th, 
+.rendered_html .bk-root .bk-tooltip td {
+  border: none;
+  padding: 1px;
+}

--- a/bokehjs/src/less/main.less
+++ b/bokehjs/src/less/main.less
@@ -50,6 +50,12 @@
   opacity: 0.95;
 }
 
+.bk-tooltip > div:not(:first-child) {
+  /* gives space when multiple elements are being hovered over */
+  margin-top: 5px;
+  border-top: @tooltipBorder 1px dashed;
+}
+
 .bk-tooltip-arrow-horizontal() {
   position: absolute;
   margin: -@tooltipArrowHalfHeight 0 0 0;

--- a/bokehjs/src/less/main.less
+++ b/bokehjs/src/less/main.less
@@ -30,25 +30,24 @@
   z-index: -5;
 }
 
-@defaultTooltipBorder: #1E4B6C;
-@defaultTooltipColor: #1E4B6C;
+@tooltipBorder: #e5e5e5;  /* Same border color used everywhere */
+@tooltipColor: white;
 
-@customTooltipBorder: black;
-@customTooltipColor: white;
-
+@tooltipArrowColor: #909599;  /* Gray of icons */
 @tooltipArrowWidth: 10px;
-@tooltipArrowHalfHeight: 7px;
-
 @tooltipArrowHeight: 10px;
 @tooltipArrowHalfWidth: 7px;
+@tooltipArrowHalfHeight: 7px;
 
 .bk-tooltip {
+  font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif; 
+  font-weight: 300;
   position: absolute;
   padding: 5px;
-  border: 1px solid @defaultTooltipBorder;
-  background-color: @defaultTooltipColor;
-  border-radius: 5px;
+  border: 1px solid @tooltipBorder;
+  background-color: @tooltipColor;
   pointer-events: none;
+  opacity: 0.95;
 }
 
 .bk-tooltip-arrow-horizontal() {
@@ -81,72 +80,45 @@
   .bk-tooltip-arrow-horizontal();
   left: -@tooltipArrowWidth;
   border-right-width: @tooltipArrowWidth;
-  border-right-color: @defaultTooltipBorder;
+  border-right-color: @tooltipArrowColor;
 }
 
 .bk-tooltip.bk-left::before {
   left: -@tooltipArrowWidth;
   border-right-width: @tooltipArrowWidth;
-  border-right-color: @defaultTooltipBorder;
+  border-right-color: @tooltipArrowColor;
 }
 
 .bk-tooltip.bk-right.bk-tooltip-arrow::after {
   .bk-tooltip-arrow-horizontal();
   right: -@tooltipArrowWidth;
   border-left-width: @tooltipArrowWidth;
-  border-left-color: @defaultTooltipBorder;
+  border-left-color: @tooltipArrowColor;
 }
 
 .bk-tooltip.bk-right::after {
   right: -@tooltipArrowWidth;
   border-left-width: @tooltipArrowWidth;
-  border-left-color: @defaultTooltipBorder;
+  border-left-color: @tooltipArrowColor;
 }
 
 .bk-tooltip.bk-above::before {
   .bk-tooltip-arrow-vertical();
   top: -@tooltipArrowHeight;
   border-bottom-width: @tooltipArrowHeight;
-  border-bottom-color: @defaultTooltipBorder;
+  border-bottom-color: @tooltipArrowColor;
 }
 
 .bk-tooltip.bk-below::after {
   .bk-tooltip-arrow-vertical();
   bottom: -@tooltipArrowHeight;
   border-top-width: @tooltipArrowHeight;
-  border-top-color: @defaultTooltipBorder;
-}
-
-.bk-tooltip.bk-tooltip-custom.bk-left::before {
-  border-right-color: @customTooltipBorder;
-}
-
-.bk-tooltip.bk-tooltip-custom.bk-right::after {
-  border-left-color: @customTooltipBorder;
-}
-
-.bk-tooltip.bk-tooltip-custom.bk-above::before {
-  border-bottom-color: @customTooltipBorder;
-}
-
-.bk-tooltip.bk-tooltip-custom.bk-below::after {
-  border-top-color: @customTooltipBorder;
-}
-
-.bk-tooltip.bk-tooltip-custom {
-  border-color: @customTooltipBorder;
-  background-color: @customTooltipColor;
+  border-top-color: @tooltipArrowColor;
 }
 
 .bk-tooltip-row-label {
-  color: #9ab9b1;
-  font-family: Helvetica, sans-serif;
   text-align: right;
-}
-
-.bk-tooltip-row-value {
-  color: #e2ddbd;
-  font-family: Helvetica, sans-serif;
+  color: #26aae1;  /* blue from toolbar highlighting */
 }
 
 .bk-tooltip-color-block {

--- a/bokehjs/src/less/main.less
+++ b/bokehjs/src/less/main.less
@@ -40,7 +40,7 @@
 @tooltipArrowHalfHeight: 7px;
 
 .bk-tooltip {
-  font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif; 
+  font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
   font-weight: 300;
   font-size: 12px;
   position: absolute;

--- a/bokehjs/src/less/main.less
+++ b/bokehjs/src/less/main.less
@@ -42,6 +42,7 @@
 .bk-tooltip {
   font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif; 
   font-weight: 300;
+  font-size: 12px;
   position: absolute;
   padding: 5px;
   border: 1px solid @tooltipBorder;
@@ -125,6 +126,10 @@
 .bk-tooltip-row-label {
   text-align: right;
   color: #26aae1;  /* blue from toolbar highlighting */
+}
+
+.bk-tooltip-row-value {
+  color: default; /* seems to be necessary for notebook */
 }
 
 .bk-tooltip-color-block {

--- a/examples/plotting/file/color_scatter.py
+++ b/examples/plotting/file/color_scatter.py
@@ -10,7 +10,7 @@ colors = [
     "#%02x%02x%02x" % (int(r), int(g), 150) for r, g in zip(50+2*x, 30+2*y)
 ]
 
-TOOLS="crosshair,pan,wheel_zoom,box_zoom,undo,redo,reset,tap,save,box_select,poly_select,lasso_select"
+TOOLS="hover,crosshair,pan,wheel_zoom,box_zoom,undo,redo,reset,tap,save,box_select,poly_select,lasso_select"
 
 p = figure(tools=TOOLS)
 

--- a/examples/plotting/notebook/color_scatterplot.ipynb
+++ b/examples/plotting/notebook/color_scatterplot.ipynb
@@ -78,31 +78,12 @@
    },
    "outputs": [],
    "source": [
-    "TOOLS=\"crosshair,pan,wheel_zoom,box_zoom,reset,tap,save,box_select,poly_select,lasso_select\"\n",
+    "TOOLS=\"hover,crosshair,pan,wheel_zoom,box_zoom,reset,tap,save,box_select,poly_select,lasso_select\"\n",
     "\n",
     "p = figure(tools=TOOLS)\n",
-    "p.scatter(x,y, radius=radii, fill_color=colors, fill_alpha=0.6, line_color=None)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
+    "p.scatter(x,y, radius=radii, fill_color=colors, fill_alpha=0.6, line_color=None)\n",
     "show(p)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -121,7 +102,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.4"
+   "version": "3.4.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes: #5008

Updates the hover styling to match other bokeh elements. See #5008 for description.
Also adds a gray line between elements for when you're hovered over multiple elements.

Notebook was a big pain

