### PR TITLE
Use custom proj4 to reduce bokeh.min.js' size

### DIFF
--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -92,7 +92,6 @@
     "jquery-mousewheel": "^3.1.12",
     "jquery-ui": "~1.10.5",
     "jsnlog": "^2.7.5",
-    "mathutils": "0.0.1",
     "rbush": "^2.0.1",
     "proj4": "^2.3.10",
     "sprintf": "^0.1.5",

--- a/bokehjs/src/coffee/common/proj4.coffee
+++ b/bokehjs/src/coffee/common/proj4.coffee
@@ -1,0 +1,37 @@
+module.exports = proj4 = require('proj4/lib/core')
+proj4.defaultDatum = 'WGS84' # default datum
+proj4.Proj = require('proj4/lib/Proj')
+proj4.WGS84 = new proj4.Proj('WGS84')
+proj4.toPoint = require('proj4/lib/common/toPoint')
+proj4.defs = require('proj4/lib/defs')
+proj4.transform = require('proj4/lib/transform')
+
+###
+projs = [
+  require('proj4/lib/projections/tmerc')
+  require('proj4/lib/projections/utm')
+  require('proj4/lib/projections/sterea')
+  require('proj4/lib/projections/stere')
+  require('proj4/lib/projections/somerc')
+  require('proj4/lib/projections/omerc')
+  require('proj4/lib/projections/lcc')
+  require('proj4/lib/projections/krovak')
+  require('proj4/lib/projections/cass')
+  require('proj4/lib/projections/laea')
+  require('proj4/lib/projections/aea')
+  require('proj4/lib/projections/gnom')
+  require('proj4/lib/projections/cea')
+  require('proj4/lib/projections/eqc')
+  require('proj4/lib/projections/poly')
+  require('proj4/lib/projections/nzmg')
+  require('proj4/lib/projections/mill')
+  require('proj4/lib/projections/sinu')
+  require('proj4/lib/projections/moll')
+  require('proj4/lib/projections/eqdc')
+  require('proj4/lib/projections/vandg')
+  require('proj4/lib/projections/aeqd')
+]
+
+for proj in projs
+  proj4.Proj.projections.add(proj)
+###

--- a/bokehjs/src/coffee/models/plots/gmap_plot.coffee
+++ b/bokehjs/src/coffee/models/plots/gmap_plot.coffee
@@ -1,6 +1,4 @@
 _ = require "underscore"
-proj4 = require "proj4"
-toProjection = proj4.defs('GOOGLE')
 {logger} = require "../../core/logging"
 
 GMapPlotCanvas = require "./gmap_plot_canvas"

--- a/bokehjs/src/coffee/models/plots/gmap_plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/gmap_plot_canvas.coffee
@@ -1,5 +1,5 @@
 _ = require "underscore"
-proj4 = require "proj4"
+proj4 = require "../../common/proj4"
 toProjection = proj4.defs('GOOGLE')
 
 PlotCanvas = require "./plot_canvas"

--- a/bokehjs/src/coffee/models/renderers/renderer.coffee
+++ b/bokehjs/src/coffee/models/renderers/renderer.coffee
@@ -1,5 +1,5 @@
 _ = require "underscore"
-proj4 = require "proj4"
+proj4 = require "../../common/proj4"
 toProjection = proj4.defs('GOOGLE')
 Backbone = require "backbone"
 

--- a/bokehjs/src/coffee/models/tiles/tile_utils.coffee
+++ b/bokehjs/src/coffee/models/tiles/tile_utils.coffee
@@ -1,4 +1,4 @@
-proj4 = require "proj4"
+proj4 = require "../../common/proj4"
 mercator = proj4.defs('GOOGLE')
 wgs84 = proj4.defs('WGS84')
 


### PR DESCRIPTION
This shaves off about 55 kB from bokeh.min.js. This PR removes unnecessary imports and projections from `proj4/index.js`, so this isn't the same "custom" approach as e.g. with backbone.js. Just make sure to use `common/proj4` instead of `proj4` in new code.