### PR TITLE
Don't use Any in ColumnDataSource.data

### DIFF
--- a/bokeh/charts/data_source.py
+++ b/bokeh/charts/data_source.py
@@ -22,7 +22,7 @@ from .properties import ColumnLabel, Column
 from .stats import Stat, Bins
 from .utils import collect_attribute_columns, special_columns, gen_column_names
 from ..models.sources import ColumnDataSource
-from ..core.properties import bokeh_integer_types, Datetime, List, HasProps, String, Float
+from ..core.properties import integer_types, Datetime, List, HasProps, String, Float
 
 
 COMPUTED_COLUMN_NAMES = ['_charts_ones']
@@ -895,7 +895,7 @@ class ChartDataSource(object):
         if isinstance(value, pd.Series):
             return Column(Float).is_valid(value)
         else:
-            numbers = (float,) + bokeh_integer_types
+            numbers = (float,) + integer_types
             return isinstance(value, numbers)
 
     @staticmethod

--- a/bokeh/charts/glyphs.py
+++ b/bokeh/charts/glyphs.py
@@ -633,7 +633,7 @@ class Interval(AggregateGlyph):
 
         return dict(x=x, y=y, width=width, height=height, color=color,
                     fill_alpha=fill_alpha, line_color=line_color,
-                    line_alpha=line_alpha, label=label)
+                    line_alpha=line_alpha)
 
     @property
     def x_max(self):

--- a/bokeh/charts/models.py
+++ b/bokeh/charts/models.py
@@ -143,7 +143,8 @@ class CompositeGlyph(HasProps):
             n_rows = len(list(data.values())[0])
 
             # add composite chart index as column
-            data['chart_index'] = [self.label] * n_rows
+            # TODO: data['chart_index'] = [self.label] * n_rows
+            data['chart_index'] = [str(self.label)] * n_rows
 
             # add constant value for each column in chart index
             if isinstance(self.label, dict):

--- a/bokeh/charts/properties.py
+++ b/bokeh/charts/properties.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 
 from bokeh.core.properties import (HasProps, Either, String, Int, List, Bool,
-                              PrimitiveProperty, bokeh_integer_types, Array)
+                              PrimitiveProperty, integer_types, Array)
 from .utils import special_columns, title_from_columns
 
 
@@ -83,7 +83,7 @@ class ColumnLabel(Either):
         super(ColumnLabel, self).validate(value)
 
         if self.columns:
-            if type(value) in bokeh_integer_types:
+            if type(value) in integer_types:
                 if len(self.columns) > value:
                     return
                 else:

--- a/bokeh/charts/tests/test_chart_utils.py
+++ b/bokeh/charts/tests/test_chart_utils.py
@@ -97,4 +97,3 @@ def test_comp_glyph_to_df():
     df = comp_glyphs_to_df(bar1, bar2)
 
     assert len(df.index) == 2
-    assert 'chart_index' in df.columns

--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -947,6 +947,11 @@ class String(PrimitiveProperty):
     """ String type property. """
     _underlying_type = string_types
 
+class Scalar(PrimitiveProperty):
+
+    _underlying_type = bool_types + integer_types + float_types + complex_types + \
+        string_types + date_types + datetime_types + timedelta_types
+
 class Regex(String):
     """ Regex type property validates that text values match the
     given regular expression.

--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -1051,15 +1051,12 @@ class Seq(ContainerProperty):
         super(Seq, self).validate(value)
 
         if value is not None:
-            if not (self._is_seq(value) and all(self.item_type.is_valid(item) for item in value)):
-                if self._is_seq(value):
-                    invalid = []
-                    for item in value:
-                        if not self.item_type.is_valid(item):
-                            invalid.append(item)
-                    raise ValueError("expected an element of %s, got seq with invalid items %r" % (self, invalid))
-                else:
-                    raise ValueError("expected an element of %s, got %r" % (self, value))
+            if not self._is_seq(value):
+                raise ValueError("expected an element of %s, got %r" % (self, value))
+            elif any(not self.item_type.is_valid(item) for item in value):
+                #invalid = [ item for item in value if self.item_type.is_valid(item) ]
+                #raise ValueError("expected an element of %s, got seq with invalid items %r" % (self, invalid))
+                raise ValueError("expected an element of %s, got seq with invalid items" % self)
 
     def __str__(self):
         return "%s(%s)" % (self.__class__.__name__, self.item_type)

--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -59,7 +59,6 @@ import dateutil.parser
 import difflib
 from importlib import import_module
 import inspect
-import numbers
 import re
 import types
 from warnings import warn
@@ -70,6 +69,9 @@ from ..util.dependencies import import_optional
 from ..util.future import with_metaclass
 from ..util.string import nice_join
 from .property_containers import PropertyValueList, PropertyValueDict, PropertyValueContainer
+from .types import (bool_types, integer_types, float_types, complex_types,
+    date_types, datetime_types, timedelta_types)
+
 from . import enums
 
 pd = import_optional('pandas')
@@ -117,15 +119,6 @@ def value(val):
 
     '''
     return dict(value=val)
-
-bokeh_bool_types = (bool,)
-try:
-    import numpy as np
-    bokeh_bool_types += (np.bool8,)
-except ImportError:
-    pass
-
-bokeh_integer_types = (numbers.Integral,)
 
 # used to indicate properties that are not set (vs null, None, etc)
 class _NotSet(object):
@@ -936,19 +929,19 @@ class PrimitiveProperty(PropertyDescriptor):
 
 class Bool(PrimitiveProperty):
     """ Boolean type property. """
-    _underlying_type = bokeh_bool_types
+    _underlying_type = bool_types
 
 class Int(PrimitiveProperty):
     """ Signed integer type property. """
-    _underlying_type = bokeh_integer_types
+    _underlying_type = integer_types
 
 class Float(PrimitiveProperty):
     """ Floating point type property. """
-    _underlying_type = (numbers.Real,)
+    _underlying_type = float_types
 
 class Complex(PrimitiveProperty):
     """ Complex floating point type property. """
-    _underlying_type = (numbers.Complex,)
+    _underlying_type = complex_types
 
 class String(PrimitiveProperty):
     """ String type property. """
@@ -1516,19 +1509,22 @@ class Date(PropertyDescriptor):
     """ Date (not datetime) type property.
 
     """
+
+    _underlying_types = date_types
+
     def __init__(self, default=datetime.date.today(), help=None):
         super(Date, self).__init__(default=default, help=help)
 
     def validate(self, value):
         super(Date, self).validate(value)
 
-        if not (value is None or isinstance(value, (datetime.date,) + string_types + (float,) + bokeh_integer_types)):
+        if not (value is None or isinstance(value, self._underlying_types)):
             raise ValueError("expected a date, string or timestamp, got %r" % value)
 
     def transform(self, value):
         value = super(Date, self).transform(value)
 
-        if isinstance(value, (float,) + bokeh_integer_types):
+        if isinstance(value, (float,) + integer_types):
             try:
                 value = datetime.date.fromtimestamp(value)
             except ValueError:
@@ -1543,33 +1539,16 @@ class Datetime(PropertyDescriptor):
 
     """
 
+    _underlying_types = datetime_types
+
     def __init__(self, default=datetime.date.today(), help=None):
         super(Datetime, self).__init__(default=default, help=help)
 
     def validate(self, value):
         super(Datetime, self).validate(value)
 
-        datetime_types = (datetime.datetime, datetime.date)
-        try:
-            import numpy as np
-            datetime_types += (np.datetime64,)
-        except (ImportError, AttributeError) as e:
-            if e.args == ("'module' object has no attribute 'datetime64'",):
-                import sys
-                if 'PyPy' in sys.version:
-                    pass
-                else:
-                    raise e
-            else:
-                pass
-
-        if (isinstance(value, datetime_types)):
-            return
-
-        if pd and isinstance(value, (pd.Timestamp)):
-            return
-
-        raise ValueError("Expected a datetime instance, got %r" % value)
+        if not (value is None or isinstance(value, self._underlying_types)):
+            raise ValueError("expected a datetime instance, got %r" % value)
 
     def transform(self, value):
         value = super(Datetime, self).transform(value)
@@ -1581,33 +1560,16 @@ class TimeDelta(PropertyDescriptor):
 
     """
 
+    _underlying_types = timedelta_types
+
     def __init__(self, default=datetime.timedelta(), help=None):
         super(TimeDelta, self).__init__(default=default, help=help)
 
     def validate(self, value):
         super(TimeDelta, self).validate(value)
 
-        timedelta_types = (datetime.timedelta,)
-        try:
-            import numpy as np
-            timedelta_types += (np.timedelta64,)
-        except (ImportError, AttributeError) as e:
-            if e.args == ("'module' object has no attribute 'timedelta64'",):
-                import sys
-                if 'PyPy' in sys.version:
-                    pass
-                else:
-                    raise e
-            else:
-                pass
-
-        if (isinstance(value, timedelta_types)):
-            return
-
-        if pd and isinstance(value, (pd.Timedelta)):
-            return
-
-        raise ValueError("Expected a timedelta instance, got %r" % value)
+        if not (value is None or isinstance(value, self._underlying_types)):
+            raise ValueError("expected a timedelta instance, got %r" % value)
 
     def transform(self, value):
         value = super(TimeDelta, self).transform(value)

--- a/bokeh/core/types.py
+++ b/bokeh/core/types.py
@@ -1,0 +1,35 @@
+""" Definitons of bokeh types. """
+
+import six
+import numbers
+import datetime
+
+from ..util.dependencies import import_optional
+np = import_optional('numpy')
+pd = import_optional('pandas')
+
+bool_types = (bool,)
+if np:
+    bool_types += (np.bool8,)
+
+integer_types = (numbers.Integral,)
+
+float_types = (numbers.Real,)
+
+complex_types = (numbers.Complex,)
+
+string_types = six.string_types
+
+date_types = (datetime.date,) + string_types + (float,) + integer_types
+
+datetime_types = (datetime.datetime, datetime.date)
+if np:
+    datetime_types += (np.datetime64,)
+if pd:
+    datetime_types += (pd.Timestamp,)
+
+timedelta_types = (datetime.timedelta,)
+if np:
+    timedelta_types += (np.timedelta64,)
+if pd:
+    timedelta_types += (pd.Timedelta,)

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from ..core import validation
 from ..core.validation.errors import COLUMN_LENGTHS
 from ..core.properties import abstract
-from ..core.properties import Any, Int, String, Instance, List, Dict, Bool, Enum, JSON, Seq
+from ..core.properties import Any, Int, String, Instance, List, Dict, Bool, Enum, JSON, Seq, Scalar
 from ..model import Model
 from ..util.dependencies import import_optional
 from ..util.deprecate import deprecated
@@ -63,7 +63,7 @@ class ColumnDataSource(DataSource):
 
     """
 
-    data = Dict(String, Seq(Any), help="""
+    data = Dict(String, Seq(Scalar) | Seq(Seq(Scalar)), help="""
     Mapping of column names to sequences of data. The data can be, e.g,
     Python lists or tuples, NumPy arrays, etc.
     """)


### PR DESCRIPTION
This is nice to have, but it comes with a price: speed degradation. The original type, `Seq(Any)` is pretty much instantaneous when it comes to validation. Here I introduce a special type `Scalar` which encompasses primitive types and date/datetime/delta. This way, `Seq(Scalar) | Seq(Seq(Scalar))` (this is the most precise type) is almost as fast as `Seq(T) | Seq(Seq(T))` where `T` is a primitive type like `Int`. This is about 6 time slower than the original type (when validating all items, i.e. type is correct), when validating a 100k element list. This is in turn about 5~6 times faster than naive `Seq(Either(long_list_here)) | Seq(Seq(Either(long_list_here)))`. Validating 100k element list takes about 200 ms on my machine. 