### PR TITLE
Ensure Jupyter.notebook.kernel exists before connecting to comm

### DIFF
--- a/bokeh/core/_templates/autoload_nb_js.js
+++ b/bokeh/core/_templates/autoload_nb_js.js
@@ -31,7 +31,7 @@
   }
 
   {%- if comms_target -%}
-  if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel !== undefined)) {
+  if ((window.Jupyter !== undefined) && Jupyter.notebook.kernel) {
     comm_manager = Jupyter.notebook.kernel.comm_manager
     comm_manager.register_target("{{ comms_target }}", function () {});
   }

--- a/bokehjs/src/coffee/embed.coffee
+++ b/bokehjs/src/coffee/embed.coffee
@@ -28,7 +28,7 @@ _update_comms_callback = (target, doc, comm) ->
     comm.on_msg(_.bind(_handle_notebook_comms, doc))
 
 _init_comms = (target, doc) ->
-  if Jupyter?
+  if Jupyter? and Jupyter.notebook.kernel?
     logger.info("Registering Jupyter comms for target #{target}")
     comm_manager = Jupyter.notebook.kernel.comm_manager
     update_comms = _.partial(_update_comms_callback, target, doc)


### PR DESCRIPTION
Fixes #5081, ensuring that a comm is only initialized when a Jupyter.kernel.notebook is defined.