### PR TITLE
Initialize notebook comms on the frontend

### DIFF
--- a/bokeh/core/_templates/autoload_nb_js.js
+++ b/bokeh/core/_templates/autoload_nb_js.js
@@ -31,7 +31,7 @@
   }
 
   {%- if comms_target -%}
-  if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel !== undefined)) {
+  if ((window.Jupyter !== undefined) && Jupyter.notebook.kernel) {
     comm_manager = Jupyter.notebook.kernel.comm_manager
     comm_manager.register_target("{{ comms_target }}", function () {});
   }

--- a/bokeh/core/_templates/autoload_nb_js.js
+++ b/bokeh/core/_templates/autoload_nb_js.js
@@ -29,13 +29,6 @@
       setTimeout(display_loaded, 100)
     }
   }
-
-  {%- if comms_target -%}
-  if ((window.Jupyter !== undefined) && Jupyter.notebook.kernel) {
-    comm_manager = Jupyter.notebook.kernel.comm_manager
-    comm_manager.register_target("{{ comms_target }}", function () {});
-  }
-  {%- endif -%}
 {% endblock %}
 
 {% block run_inline_js %}

--- a/bokehjs/src/coffee/embed.coffee
+++ b/bokehjs/src/coffee/embed.coffee
@@ -23,22 +23,14 @@ _handle_notebook_comms = (msg) ->
   else
     throw new Error("handling notebook comms message: ", msg)
 
-_update_comms_callback = (target, doc, comm) ->
-  if target == comm.target_name
-    comm.on_msg(_.bind(_handle_notebook_comms, doc))
 
 _init_comms = (target, doc) ->
   if Jupyter? and Jupyter.notebook.kernel?
     logger.info("Registering Jupyter comms for target #{target}")
     comm_manager = Jupyter.notebook.kernel.comm_manager
-    update_comms = _.partial(_update_comms_callback, target, doc)
-    for id, promise of comm_manager.comms
-      promise.then(update_comms)
     try
-      comm_manager.register_target(target, (comm, msg) ->
-        logger.info("Registering Jupyter comms for target #{target}")
-        comm.on_msg(_.bind(_handle_notebook_comms, doc))
-      )
+      comm = comm_manager.new_comm(target, {}, {}, {}, target);
+      comm.on_msg(_.bind(_handle_notebook_comms, doc))
     catch e
       logger.warn("Jupyter comms failed to register. push_notebook() will not function. (exception reported: #{e})")
   else

--- a/bokehjs/src/coffee/embed.coffee
+++ b/bokehjs/src/coffee/embed.coffee
@@ -28,7 +28,7 @@ _update_comms_callback = (target, doc, comm) ->
     comm.on_msg(_.bind(_handle_notebook_comms, doc))
 
 _init_comms = (target, doc) ->
-  if Jupyter?
+  if Jupyter? and Jupyter.notebook.kernel?
     logger.info("Registering Jupyter comms for target #{target}")
     comm_manager = Jupyter.notebook.kernel.comm_manager
     update_comms = _.partial(_update_comms_callback, target, doc)


### PR DESCRIPTION
This PR provides an alternative to the way Comms are currently initialized. The current approach registers a Comms target on the frontend and the Comms is then created on the first ``push_notebook`` call in the notebook. The problem with this approach is that it is possible for the frontend to take some time to receive and execute the code that registers the target (and renders the plot), so that the attempt by Python to create the Comm fails.

This PR simply inverts the responsibility for registering and initializing the Comm. The Python process immediately registers a Comm target and the backend then initializes the Comm, triggering a callback on the python process, which set the ``_comms`` attribute on the ``_CommsHandle``. Until the frontend has displayed the plot all attempts at sending data will be ignored.