### PR TITLE
Don't require tornado to run non-server bokeh

### DIFF
--- a/bokeh/client/session.py
+++ b/bokeh/client/session.py
@@ -7,14 +7,11 @@ import logging
 
 log = logging.getLogger(__name__)
 
-from ._connection import ClientConnection
-
 from bokeh.resources import ( DEFAULT_SERVER_WEBSOCKET_URL,
                               server_url_for_websocket_url,
                               _SessionCoordinates )
 from bokeh.document import Document
 from bokeh.util.session_id import generate_session_id
-from bokeh.util.tornado import _DocumentCallbackGroup
 
 DEFAULT_SESSION_ID = "default"
 
@@ -206,9 +203,11 @@ class ClientSession(object):
         self._document = None
         self._id = self._ensure_session_id(session_id)
 
+        from ._connection import ClientConnection
         self._connection = ClientConnection(session=self, io_loop=io_loop, websocket_url=websocket_url)
 
         self._current_patch = None
+        from bokeh.util.tornado import _DocumentCallbackGroup
         self._callbacks = _DocumentCallbackGroup(self._connection.io_loop)
 
     def _attach_document(self, document):

--- a/tests/test_no_tornado_common.py
+++ b/tests/test_no_tornado_common.py
@@ -1,0 +1,22 @@
+from __future__ import print_function
+
+import pytest
+import subprocess
+
+basic_imports = [
+    "import bokeh.charts",
+    "import bokeh.client",
+    "import bokeh.embed",
+    "import bokeh.io",
+    "import bokeh.models",
+    "import bokeh.plotting",
+]
+
+def test_no_tornado_common():
+    proc = subprocess.Popen([
+        "python", "-c", "import sys; %s; sys.exit(1 if any('tornado' in x for x in sys.modules.keys()) else 0)" % ";".join(basic_imports)
+    ],stdout=subprocess.PIPE)
+    out, errs = proc.communicate()
+    msg = out.decode('utf-8', errors='ignore')
+    if proc.returncode != 0:
+        assert False


### PR DESCRIPTION
I don't like this solution, but don't see anything better right now to make, e.g., `bokeh.io` (and related) not fail to import without tornado.

fixes #5119

