### PR TITLE
Executing range callbacks on reset_range (additional fix) and initialization (new)

### DIFF
--- a/bokehjs/src/coffee/models/plots/plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.coffee
@@ -121,6 +121,11 @@ class PlotCanvasView extends Renderer.View
 
     @update_dataranges()
 
+    for name, rng of @frame.x_ranges
+      rng.callback?.execute(rng)
+    for name, rng of @frame.y_ranges
+      rng.callback?.execute(rng)
+
     @unpause()
 
     logger.debug("PlotView initialized")

--- a/bokehjs/src/coffee/models/plots/plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.coffee
@@ -404,11 +404,15 @@ class PlotCanvasView extends Renderer.View
     if not range_info?
       for name, rng of @frame.x_ranges
         rng.reset()
-        rng.callback?.execute(rng)
       for name, rng of @frame.y_ranges
         rng.reset()
-        rng.callback?.execute(rng)
       @update_dataranges()
+
+      for name, rng of @frame.x_ranges
+        rng.callback?.execute(rng)
+      for name, rng of @frame.y_ranges
+        rng.callback?.execute(rng)
+
     else
       range_info_iter = []
       for name, rng of @frame.x_ranges


### PR DESCRIPTION
I experienced update issues with #4615, concretely the range callbacks are not executed correctly. I had to call reset twice for my callbacks to work correctly. This pull request fixes this.

Additionally I added the analog calls to the callbacks within the initialization such that dynamic ``update_datarange`` is followed by a call to the callbacks here too.

It may be preferable to move the callback executions to ``update_datarange`` directly

- [x] issues: fixes #4614 #4615
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
