### PR TITLE
Fix tooltips after replacing computed properties with getters

### DIFF
--- a/bokehjs/src/coffee/models/tools/inspectors/hover_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/inspectors/hover_tool.coffee
@@ -331,9 +331,7 @@ class HoverTool extends InspectTool.Model
     @add_dependencies('computed_renderers', this, ['renderers', 'names', 'plot'])
     @add_dependencies('computed_renderers', @plot, ['renderers'])
 
-  @getters {
-    computed_renderers: () -> @_get_computed('computed_renderers')
-    ttmodels: () ->
+    @define_computed_property 'ttmodels', () ->
       ttmodels = {}
       tooltips = @tooltips
 
@@ -347,6 +345,11 @@ class HoverTool extends InspectTool.Model
           ttmodels[r.id] = tooltip
 
       return ttmodels
+    @add_dependencies('ttmodels', this, ['computed_renderers', 'tooltips'])
+
+  @getters {
+    computed_renderers: () -> @_get_computed('computed_renderers')
+    ttmodels: () -> @_get_computed('ttmodels')
     synthetic_renderers: () -> _.values(@ttmodels)
   }
 


### PR DESCRIPTION
~~@bryevdv's fix in a form of PR.~~ Nope, that didn't work, I had to restore `ttmodels` as a computed property. This needs to be changed appropriately in future.

fixes #5123

