### PR TITLE
Replace {get,set} ->{get,set}v and deprecate {get,set}

### DIFF
--- a/bokehjs/src/coffee/common/selection_manager.coffee
+++ b/bokehjs/src/coffee/common/selection_manager.coffee
@@ -61,7 +61,7 @@ class SelectionManager extends HasProps
       inspector = @_get_inspector(renderer_view)
       inspector.update(indices, true, false, true)
 
-      @source.set({ "inspected": inspector.indices}, {"silent": true })
+      @source.setv({inspected: inspector.indices}, {"silent": true })
 
       source.trigger(
         'inspect', indices, tool, renderer_view, source, data

--- a/bokehjs/src/coffee/common/selector.coffee
+++ b/bokehjs/src/coffee/common/selector.coffee
@@ -8,14 +8,14 @@ class Selector extends HasProps
   type: 'Selector'
 
   update: (indices, final, append, silent=false) ->
-    @set('timestamp', new Date(), {silent: silent})
-    @set('final', final, {silent: silent})
+    @setv('timestamp', new Date(), {silent: silent})
+    @setv('final', final, {silent: silent})
     if append
       indices['0d'].indices =  _.union(@indices['0d'].indices, indices['0d'].indices)
       indices['0d'].glyph =  @indices['0d'].glyph or indices['0d'].glyph
       indices['1d'].indices =  _.union(@indices['1d'].indices, indices['1d'].indices)
       indices['2d'].indices =  _.union(@indices['2d'].indices, indices['2d'].indices)
-    @set('indices', indices, {silent: silent})
+    @setv('indices', indices, {silent: silent})
 
   clear: () ->
     @timestamp = new Date()

--- a/bokehjs/src/coffee/common/ui_events.coffee
+++ b/bokehjs/src/coffee/common/ui_events.coffee
@@ -6,12 +6,17 @@ mousewheel = require("jquery-mousewheel")($)
 
 class UIEvents extends Backbone.Model
 
+  @getters {
+    toolbar: () -> @get('toolbar')
+    hit_area: () -> @get('hit_area')
+  }
+
   initialize: (attrs, options) ->
     super(attrs, options)
     @_hammer_element()
 
   _hammer_element: ->
-    hit_area = @get('hit_area')
+    hit_area = @hit_area
     @hammer = new Hammer(hit_area[0])
 
     # This is to be able to distinguish double taps from single taps
@@ -96,7 +101,6 @@ class UIEvents extends Backbone.Model
         tool_view.listenTo(@, "scroll:#{id}", tool_view["_scroll"])
 
   _trigger: (event_type, e) ->
-    toolbar = @get('toolbar')
     base_event_type = event_type.split(":")[0]
 
     # Dual touch hack part 2/2
@@ -107,7 +111,7 @@ class UIEvents extends Backbone.Model
       if event_type == 'scroll'
         base_event_type = 'pinch'
 
-    gestures = toolbar.gestures
+    gestures = @toolbar.gestures
     active_tool = gestures[base_event_type].active
 
     if active_tool?

--- a/bokehjs/src/coffee/common/ui_events.coffee
+++ b/bokehjs/src/coffee/common/ui_events.coffee
@@ -7,8 +7,8 @@ mousewheel = require("jquery-mousewheel")($)
 class UIEvents extends Backbone.Model
 
   @getters {
-    toolbar: () -> @get('toolbar')
-    hit_area: () -> @get('hit_area')
+    toolbar: () -> @getv('toolbar')
+    hit_area: () -> @getv('hit_area')
   }
 
   initialize: (attrs, options) ->

--- a/bokehjs/src/coffee/core/backbone.js
+++ b/bokehjs/src/coffee/core/backbone.js
@@ -265,10 +265,6 @@ var triggerEvents = function(events, args) {
   }
 };
 
-// Aliases for backwards compatibility.
-Events.bind   = Events.on;
-Events.unbind = Events.off;
-
 // Backbone.Model
 // --------------
 

--- a/bokehjs/src/coffee/core/backbone.js
+++ b/bokehjs/src/coffee/core/backbone.js
@@ -312,12 +312,6 @@ _.extend(Model.prototype, Events, {
     return this.attributes[attr];
   },
 
-  // Returns `true` if the attribute contains a value that is not null
-  // or undefined.
-  has: function(attr) {
-    return this.get(attr) != null;
-  },
-
   // Set a hash of model attributes on the object, firing `"change"`. This is
   // the core primitive operation of a model, updating the data and notifying
   // anyone who needs to know about the change in state. The heart of the beast.
@@ -384,57 +378,6 @@ _.extend(Model.prototype, Events, {
     this._pending = false;
     this._changing = false;
     return this;
-  },
-
-  // Remove an attribute from the model, firing `"change"`. `unset` is a noop
-  // if the attribute doesn't exist.
-  unset: function(attr, options) {
-    return this.set(attr, void 0, _.extend({}, options, {unset: true}));
-  },
-
-  // Clear all attributes on the model, firing `"change"`.
-  clear: function(options) {
-    var attrs = {};
-    for (var key in this.attributes) attrs[key] = void 0;
-    return this.set(attrs, _.extend({}, options, {unset: true}));
-  },
-
-  // Determine if the model has changed since the last `"change"` event.
-  // If you specify an attribute name, determine if that attribute has changed.
-  hasChanged: function(attr) {
-    if (attr == null) return !_.isEmpty(this.changed);
-    return _.has(this.changed, attr);
-  },
-
-  // Return an object containing all the attributes that have changed, or
-  // false if there are no changed attributes. Useful for determining what
-  // parts of a view need to be updated and/or what attributes need to be
-  // persisted to the server. Unset attributes will be set to undefined.
-  // You can also pass an attributes object to diff against the model,
-  // determining if there *would be* a change.
-  changedAttributes: function(diff) {
-    if (!diff) return this.hasChanged() ? _.clone(this.changed) : false;
-    var old = this._changing ? this._previousAttributes : this.attributes;
-    var changed = {};
-    for (var attr in diff) {
-      var val = diff[attr];
-      if (_.isEqual(old[attr], val)) continue;
-      changed[attr] = val;
-    }
-    return _.size(changed) ? changed : false;
-  },
-
-  // Get the previous value of an attribute, recorded at the time the last
-  // `"change"` event was fired.
-  previous: function(attr) {
-    if (attr == null || !this._previousAttributes) return null;
-    return this._previousAttributes[attr];
-  },
-
-  // Get all of the attributes of the model at the time of the previous
-  // `"change"` event.
-  previousAttributes: function() {
-    return _.clone(this._previousAttributes);
   },
 
   destroy: function(options) {

--- a/bokehjs/src/coffee/core/backbone.js
+++ b/bokehjs/src/coffee/core/backbone.js
@@ -326,7 +326,6 @@ _.extend(Model.prototype, Events, {
     options || (options = {});
 
     // Extract attributes and options.
-    var unset      = options.unset;
     var silent     = options.silent;
     var changes    = [];
     var changing   = this._changing;
@@ -350,7 +349,7 @@ _.extend(Model.prototype, Events, {
       } else {
         delete changed[attr];
       }
-      unset ? delete current[attr] : current[attr] = val;
+      current[attr] = val;
     }
 
     // Trigger all relevant attribute changes.

--- a/bokehjs/src/coffee/core/backbone.js
+++ b/bokehjs/src/coffee/core/backbone.js
@@ -354,9 +354,9 @@ _.extend(Model.prototype, Events, {
 
     // Trigger all relevant attribute changes.
     if (!silent) {
-      if (changes.length) this._pending = options;
+      if (changes.length) this._pending = true;
       for (var i = 0; i < changes.length; i++) {
-        this.trigger('change:' + changes[i], this, current[changes[i]], options);
+        this.trigger('change:' + changes[i], this, current[changes[i]]);
       }
     }
 
@@ -365,9 +365,8 @@ _.extend(Model.prototype, Events, {
     if (changing) return this;
     if (!silent) {
       while (this._pending) {
-        options = this._pending;
         this._pending = false;
-        this.trigger('change', this, options);
+        this.trigger('change', this);
       }
     }
     this._pending = false;

--- a/bokehjs/src/coffee/core/backbone.js
+++ b/bokehjs/src/coffee/core/backbone.js
@@ -282,7 +282,7 @@ var Model = function(attributes, options) {
   var attrs = attributes || {};
   options || (options = {});
   this.attributes = {};
-  this.set(attrs, options);
+  this.setv(attrs, options);
   this.changed = {};
   this.initialize.apply(this, arguments);
 };
@@ -308,14 +308,14 @@ _.extend(Model.prototype, Events, {
   initialize: function(){},
 
   // Get the value of an attribute.
-  get: function(attr) {
+  getv: function(attr) {
     return this.attributes[attr];
   },
 
   // Set a hash of model attributes on the object, firing `"change"`. This is
   // the core primitive operation of a model, updating the data and notifying
   // anyone who needs to know about the change in state. The heart of the beast.
-  set: function(key, val, options) {
+  setv: function(key, val, options) {
     if (key == null) return this;
 
     // Handle both `"key", value` and `{key: value}` -style arguments.

--- a/bokehjs/src/coffee/core/backbone.js
+++ b/bokehjs/src/coffee/core/backbone.js
@@ -282,8 +282,6 @@ var Model = function(attributes, options) {
   var attrs = attributes || {};
   options || (options = {});
   this.attributes = {};
-  var defaults = _.result(this, 'defaults');
-  attrs = _.defaults(_.extend({}, defaults, attrs), defaults);
   this.set(attrs, options);
   this.changed = {};
   this.initialize.apply(this, arguments);

--- a/bokehjs/src/coffee/core/backbone.js
+++ b/bokehjs/src/coffee/core/backbone.js
@@ -289,6 +289,16 @@ var Model = function(attributes, options) {
   this.initialize.apply(this, arguments);
 };
 
+Model.getter = function(name, get) {
+  Object.defineProperty(this.prototype, name, { get: get });
+};
+
+Model.getters = function(specs) {
+  for (var name in specs) {
+    this.getter(name, specs[name]);
+  }
+};
+
 // Attach all inheritable methods to the Model prototype.
 _.extend(Model.prototype, Events, {
 

--- a/bokehjs/src/coffee/core/backbone.js
+++ b/bokehjs/src/coffee/core/backbone.js
@@ -375,12 +375,9 @@ _.extend(Model.prototype, Events, {
     return this;
   },
 
-  destroy: function(options) {
-    options = options ? _.clone(options) : {};
-    var model = this;
-
-    model.stopListening();
-    model.trigger('destroy', model, null, options);
+  destroy: function() {
+    this.stopListening();
+    this.trigger('destroy', this);
   },
 
   // Create a new model with identical attributes to this one.

--- a/bokehjs/src/coffee/core/has_props.coffee
+++ b/bokehjs/src/coffee/core/has_props.coffee
@@ -22,8 +22,8 @@ class HasProps extends Backbone.Model
           throw new Error("attempted to redefine attribute '#{this.name}.#{name}'")
 
         Object.defineProperty(this.prototype, name, {
-          get: ()      -> this.get(name)
-          set: (value) -> this.set(name, value)
+          get: ()      -> this.getv(name)
+          set: (value) -> this.setv(name, value)
         }, {
           configurable: false
           enumerable: true
@@ -95,10 +95,10 @@ class HasProps extends Backbone.Model
     # Bokeh specific
     this._set_after_defaults = {}
 
-    this.set(attrs, options)
+    this.setv(attrs, options)
 
     # this is maintained by backbone ("changes since the last
-    # set()") and probably isn't relevant to us
+    # setv()") and probably isn't relevant to us
     this.changed = {}
 
     ## bokeh custom constructor code
@@ -117,7 +117,7 @@ class HasProps extends Backbone.Model
     if not options.defer_initialization
       this.initialize.apply(this, arguments)
 
-  set: (key, value, options) ->
+  setv: (key, value, options) ->
     # backbones set function supports 2 call signatures, either a dictionary of
     # key value pairs, and then options, or one key, one value, and then options.
     # replicating that logic here
@@ -130,19 +130,19 @@ class HasProps extends Backbone.Model
     for own key, val of attrs
       prop_name = key
       if not @props[prop_name]?
-        throw new Error("#{@type}.set('#{prop_name}'): #{prop_name} wasn't declared")
+        throw new Error("property #{@type}.#{prop_name} wasn't declared")
 
       if not (options? and options.defaults)
         @_set_after_defaults[key] = true
     if not _.isEmpty(attrs)
       old = {}
       for key, value of attrs
-        old[key] = @get(key)
+        old[key] = @getv(key)
       super(attrs, options)
 
       if not options?.silent?
         for key, value of attrs
-          @_tell_document_about_change(key, old[key], @get(key))
+          @_tell_document_about_change(key, old[key], @getv(key))
 
   add_dependencies:  (prop_name, object, fields) ->
     # * prop_name - name of property
@@ -203,9 +203,9 @@ class HasProps extends Backbone.Model
 
     return prop_spec
 
-  get: (prop_name) ->
+  getv: (prop_name) ->
     if not @props[prop_name]?
-      throw new Error("#{@type}.get('#{prop_name}'): #{prop_name} wasn't declared")
+      throw new Error("property #{@type}.#{prop_name} wasn't declared")
     else
       return super(prop_name)
 

--- a/bokehjs/src/coffee/core/has_props.coffee
+++ b/bokehjs/src/coffee/core/has_props.coffee
@@ -229,8 +229,6 @@ class HasProps extends Backbone.Model
   set_subtype: (subtype) ->
     @_subtype = subtype
 
-  defaults: -> throw new Error("don't use HasProps.defaults anymore")
-
   attribute_is_serializable: (attr) ->
     prop = @props[attr]
     if not prop?

--- a/bokehjs/src/coffee/core/has_props.coffee
+++ b/bokehjs/src/coffee/core/has_props.coffee
@@ -203,6 +203,14 @@ class HasProps extends Backbone.Model
 
     return prop_spec
 
+  set: (key, value, options) ->
+    logger.warn("HasProps.set('prop_name', value) is deprecated, use HasProps.prop_name = value instead")
+    return @setv(key, value, options)
+
+  get: (prop_name) ->
+    logger.warn("HasProps.get('prop_name') is deprecated, use HasProps.prop_name instead")
+    return @getv(prop_name)
+
   getv: (prop_name) ->
     if not @props[prop_name]?
       throw new Error("property #{@type}.#{prop_name} wasn't declared")

--- a/bokehjs/src/coffee/core/has_props.coffee
+++ b/bokehjs/src/coffee/core/has_props.coffee
@@ -9,13 +9,6 @@ p = require "./properties"
 
 class HasProps extends Backbone.Model
 
-  @getter: (name, get) ->
-    Object.defineProperty(this.prototype, name, { get: get })
-
-  @getters: (specs) ->
-    for name, get of specs
-      @getter(name, get)
-
   props: {}
   mixins: []
 

--- a/bokehjs/src/coffee/core/properties.coffee
+++ b/bokehjs/src/coffee/core/properties.coffee
@@ -15,9 +15,9 @@ class Property extends Backbone.Model
   specifiers: ['field', 'value']
 
   @getters {
-    obj: () -> @get('obj')
-    attr: () -> @get('attr')
-    default_value: () -> @get('default_value')
+    obj: () -> @getv('obj')
+    attr: () -> @getv('attr')
+    default_value: () -> @getv('default_value')
   }
 
   initialize: (attrs, options) ->
@@ -87,11 +87,11 @@ class Property extends Backbone.Model
     if not obj.properties?
       throw new Error("property object must be a HasProps")
 
-    attr = @gattr
+    attr = @attr
     if not attr?
       throw new Error("missing property attr")
 
-    attr_value = obj.get(attr)
+    attr_value = obj.getv(attr)
 
     if _.isUndefined(attr_value)
       default_value = @default_value
@@ -102,7 +102,7 @@ class Property extends Backbone.Model
         when _.isFunction(default_value)  then default_value(obj)
         else                                   default_value
 
-      obj.set(attr, attr_value, {silent: true, defaults: true})
+      obj.setv(attr, attr_value, {silent: true, defaults: true})
 
     # if _.isObject(attr_value) and not _.isArray(attr_value) and not attr_value.properties?
     #   @spec = attr_value

--- a/bokehjs/src/coffee/document.coffee
+++ b/bokehjs/src/coffee/document.coffee
@@ -439,7 +439,7 @@ class Document
     # this first pass removes all 'refs' replacing them with real instances
     foreach_depth_first to_update, (instance, attrs, was_new) ->
       if was_new
-        instance.set(attrs)
+        instance.setv(attrs)
 
     # after removing all the refs, we can run the initialize code safely
     foreach_depth_first to_update, (instance, attrs, was_new) ->
@@ -655,7 +655,7 @@ class Document
           patched_obj = @_all_models[patched_id]
           attr = event_json['attr']
           value = Document._resolve_refs(event_json['new'], old_references, new_references)
-          patched_obj.set({ "#{attr}" : value })
+          patched_obj.setv({ "#{attr}" : value })
 
         when 'ColumnsStreamed'
           column_source_id = event_json['column_source']['id']

--- a/bokehjs/src/coffee/models/annotations/box_annotation.coffee
+++ b/bokehjs/src/coffee/models/annotations/box_annotation.coffee
@@ -117,7 +117,7 @@ class BoxAnnotation extends Annotation.Model
   }
 
   update:({left, right, top, bottom}) ->
-    @set({left: left, right: right, top: top, bottom: bottom}, {silent: true})
+    @setv({left: left, right: right, top: top, bottom: bottom}, {silent: true})
     @trigger('data_update')
 
 module.exports =

--- a/bokehjs/src/coffee/models/annotations/poly_annotation.coffee
+++ b/bokehjs/src/coffee/models/annotations/poly_annotation.coffee
@@ -71,7 +71,7 @@ class PolyAnnotation extends Annotation.Model
   }
 
   update:({xs, ys}) ->
-    @set({xs: xs, ys: ys}, {silent: true})
+    @setv({xs: xs, ys: ys}, {silent: true})
     @trigger('data_update')
 
 module.exports =

--- a/bokehjs/src/coffee/models/plots/gmap_plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/gmap_plot_canvas.coffee
@@ -30,8 +30,8 @@ class GMapPlotCanvasView extends PlotCanvas.View
 
   setRanges: () =>
     [proj_xstart, proj_xend, proj_ystart, proj_yend] = @getProjectedBounds()
-    @x_range.set({start: proj_xstart, end: proj_xend})
-    @y_range.set({start: proj_ystart, end: proj_yend})
+    @x_range.setv({start: proj_xstart, end: proj_xend})
+    @y_range.setv({start: proj_ystart, end: proj_yend})
 
   update_range: (range_info) ->
     @pause()

--- a/bokehjs/src/coffee/models/plots/plot.coffee
+++ b/bokehjs/src/coffee/models/plots/plot.coffee
@@ -124,7 +124,7 @@ class Plot extends LayoutDOM.Model
   _doc_attached: () ->
     # Setup side renderers
     for side in ['above', 'below', 'left', 'right']
-      layout_renderers = @get(side)
+      layout_renderers = @getv(side)
       for r in layout_renderers
         @plot_canvas.add_renderer_to_canvas_side(r, side)
     @plot_canvas.attach_document(@document)
@@ -147,7 +147,7 @@ class Plot extends LayoutDOM.Model
       renderer.plot = this
     @add_renderers(renderer)
     if side != 'center'
-      side_renderers = @get(side)
+      side_renderers = @getv(side)
       side_renderers.push(renderer)
 
   add_glyph: (glyph, source, attrs={}) ->

--- a/bokehjs/src/coffee/models/plots/plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.coffee
@@ -370,7 +370,7 @@ class PlotCanvasView extends Renderer.View
     for [rng, range_info] in range_info_iter
       rng.have_updated_interactively = true
       if rng.start != range_info['start'] or rng.end != range_info['end']
-          rng.set(range_info)
+          rng.setv(range_info)
           rng.callback?.execute(rng)
 
   _get_weight_to_constrain_interval: (rng, range_info) ->

--- a/bokehjs/src/coffee/models/ranges/data_range1d.coffee
+++ b/bokehjs/src/coffee/models/ranges/data_range1d.coffee
@@ -137,14 +137,14 @@ class DataRange1d extends DataRange.Model
         new_range.start = start
       if end != _end
         new_range.end = end
-      @set(new_range)
+      @setv(new_range)
 
     if @bounds == 'auto'
       @bounds = [start, end]
 
   reset: () ->
     @have_updated_interactively = false
-    @set({
+    @setv({
       range_padding: @_initial_range_padding
       follow: @_initial_follow
       follow_interval: @_initial_follow_interval

--- a/bokehjs/src/coffee/models/ranges/range1d.coffee
+++ b/bokehjs/src/coffee/models/ranges/range1d.coffee
@@ -42,7 +42,7 @@ class Range1d extends Range.Model
   }
 
   reset: () ->
-    @set({start: @_initial_start, end: @_initial_end})
+    @setv({start: @_initial_start, end: @_initial_end})
     @_set_auto_bounds()
 
 module.exports =

--- a/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
+++ b/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
@@ -81,7 +81,7 @@ class GlyphRendererView extends Renderer.View
 
     # TODO (bev) this is a bit clunky, need to make sure glyphs use the correct ranges when they call
     # mapping functions on the base Renderer class
-    @glyph.model.set({x_range_name: @model.x_range_name, y_range_name: @model.y_range_name}, {silent: true})
+    @glyph.model.setv({x_range_name: @model.x_range_name, y_range_name: @model.y_range_name}, {silent: true})
     @glyph.set_data(source, arg)
 
     @glyph.set_visuals(source)

--- a/bokehjs/src/coffee/models/renderers/renderer.coffee
+++ b/bokehjs/src/coffee/models/renderers/renderer.coffee
@@ -14,8 +14,8 @@ Model = require "../../model"
 class _ContextProperties extends Backbone.Model
 
   @getters {
-    obj: () -> @get('obj')
-    prefix: () -> @get('prefix')
+    obj: () -> @getv('obj')
+    prefix: () -> @getv('prefix')
   }
 
   constructor: (attrs, options) ->

--- a/bokehjs/src/coffee/models/renderers/renderer.coffee
+++ b/bokehjs/src/coffee/models/renderers/renderer.coffee
@@ -13,6 +13,11 @@ Model = require "../../model"
 
 class _ContextProperties extends Backbone.Model
 
+  @getters {
+    obj: () -> @get('obj')
+    prefix: () -> @get('prefix')
+  }
+
   constructor: (attrs, options) ->
     if not attrs.prefix?
       attrs.prefix = ""
@@ -20,8 +25,8 @@ class _ContextProperties extends Backbone.Model
 
     @cache = {}
 
-    obj = @get('obj')
-    prefix = @get('prefix')
+    obj = @obj
+    prefix = @prefix
 
     do_spec = obj.properties[prefix+@do_attr].spec
     @doit = not _.isNull(do_spec.value)
@@ -31,8 +36,8 @@ class _ContextProperties extends Backbone.Model
 
   warm_cache: (source) ->
     for attr in @attrs
-      obj = @get('obj')
-      prefix = @get('prefix')
+      obj = @obj
+      prefix = @prefix
       prop = obj.properties[prefix+attr]
       if not _.isUndefined(prop.spec.value) # TODO (bev) better test?
         @cache[attr] = prop.spec.value
@@ -40,8 +45,8 @@ class _ContextProperties extends Backbone.Model
         @cache[attr+"_array"] = prop.array(source)
 
   cache_select: (attr, i) ->
-    obj = @get('obj')
-    prefix = @get('prefix')
+    obj = @obj
+    prefix = @prefix
     prop = obj.properties[prefix+attr]
     if not _.isUndefined(prop.spec.value) # TODO (bev) better test?
       @cache[attr] = prop.spec.value

--- a/bokehjs/src/coffee/models/sources/column_data_source.coffee
+++ b/bokehjs/src/coffee/models/sources/column_data_source.coffee
@@ -54,7 +54,7 @@ class ColumnDataSource extends DataSource.Model
       data[k] = data[k].concat(new_data[k])
       if data[k].length > rollover
         data[k] = data[k].slice(-rollover)
-    @set('data', data, {silent: true})
+    @setv('data', data, {silent: true})
     @trigger('stream')
 
   patch: (patches) ->
@@ -63,7 +63,7 @@ class ColumnDataSource extends DataSource.Model
       for i in [0...patch.length]
         [ind, value] = patch[i]
         data[k][ind] = value
-    @set('data', data, {silent: true})
+    @setv('data', data, {silent: true})
     @trigger('patch')
 
 module.exports =

--- a/bokehjs/src/coffee/models/tiles/tile_renderer.coffee
+++ b/bokehjs/src/coffee/models/tiles/tile_renderer.coffee
@@ -116,8 +116,8 @@ class TileRendererView extends Renderer.View
       extent = @get_extent()
       zoom_level = @model.tile_source.get_level_by_extent(extent, @map_frame.height, @map_frame.width)
       new_extent = @model.tile_source.snap_to_zoom(extent, @map_frame.height, @map_frame.width, zoom_level)
-      @x_range.set({start:new_extent[0], end: new_extent[2]})
-      @y_range.set({start:new_extent[1], end: new_extent[3]})
+      @x_range.setv({start:new_extent[0], end: new_extent[2]})
+      @y_range.setv({start:new_extent[1], end: new_extent[3]})
       @extent = new_extent
       @_last_height = @map_frame.height
       @_last_width = @map_frame.width
@@ -220,8 +220,8 @@ class TileRendererView extends Renderer.View
       snap_back = true
 
     if snap_back
-      @x_range.set(x_range:{start:extent[0], end: extent[2]})
-      @y_range.set({start:extent[1], end: extent[3]})
+      @x_range.setv(x_range:{start:extent[0], end: extent[2]})
+      @y_range.setv({start:extent[1], end: extent[3]})
       @extent = extent
 
     @extent = extent

--- a/bokehjs/src/coffee/models/transforms/interpolator.coffee
+++ b/bokehjs/src/coffee/models/transforms/interpolator.coffee
@@ -11,7 +11,7 @@ class Interpolator extends Transform.Model
     @_y_sorted = []
     @_sorted_dirty = true
 
-    @bind 'change', () ->
+    @on 'change', () ->
       @_sorted_dirty = true
 
   @define {

--- a/bokehjs/src/coffee/models/widgets/dialog.coffee
+++ b/bokehjs/src/coffee/models/widgets/dialog.coffee
@@ -53,7 +53,7 @@ class DialogView extends Widget.View
     return @
 
   onHide: (event) =>
-    @model.set("visible", false, {silent: true})
+    @model.setv("visible", false, {silent: true})
 
   change_visibility: () =>
     @$modal.modal(if @model.visible then "show" else "hide")

--- a/bokehjs/test/core/properties.coffee
+++ b/bokehjs/test/core/properties.coffee
@@ -109,10 +109,10 @@ describe "properties module", ->
       it "should throw an Error", ->
         prop = new properties.Property({obj: new SomeHasProps(a: {value: 10}), attr: 'a'})
         fn = ->
-          prop.set('obj', new SomeHasProps(a: {value: 20}))
+          prop.setv('obj', new SomeHasProps(a: {value: 20}))
         expect(fn).to.throw Error, "attempted to reset 'obj' on Property"
         fn = ->
-          prop.set('attr', 'b')
+          prop.setv('attr', 'b')
         expect(fn).to.throw Error, "attempted to reset 'attr' on Property"
 
 

--- a/bokehjs/test/document.coffee
+++ b/bokehjs/test/document.coffee
@@ -634,8 +634,8 @@ describe "Document", ->
     root1 = new SomeModel({ foo: 42 })
     root2 = new SomeModel({ foo: 43 })
     child1 = new SomeModel({ foo: 44 })
-    root1.set { child: child1 }
-    root2.set { child: child1 }
+    root1.setv({ child: child1 })
+    root2.setv({ child: child1 })
     d.add_root(root1)
     d.add_root(root2)
     expect(d.roots().length).to.equal 2
@@ -662,8 +662,8 @@ describe "Document", ->
     child1 = new SomeModel({ foo: 44 })
     child2 = new SomeModel({ foo: 45 })
     child3 = new SomeModel({ foo: 46, child: child2})
-    root1.set { child: child1 }
-    root2.set { child: child1 }
+    root1.setv({ child: child1 })
+    root2.setv({ child: child1 })
     d.add_root(root1)
     d.add_root(root2)
     expect(d.roots().length).to.equal 2
@@ -700,7 +700,7 @@ describe "Document", ->
 
     root1 = new SomeModel({ foo: 42 })
     child1 = new SomeModel({ foo: 43 })
-    root1.set { child: child1 }
+    root1.setv({ child: child1 })
     d.add_root(root1)
     expect(d.roots().length).to.equal 1
 
@@ -787,7 +787,7 @@ describe "Document", ->
       'obj_prop' : new ModelWithConstructTimeChanges(),
       'dict_of_list_prop' : { foo: [new AnotherModel({ 'bar' : 44 })] }
       }
-    root1.set(serialized_values)
+    root1.setv(serialized_values)
 
     d.add_root(root1)
 
@@ -803,7 +803,7 @@ describe "Document", ->
 
     # document should have the values we set above
     for own key, value of serialized_values
-      expect(root1.get(key)).to.deep.equal value
+      expect(root1.getv(key)).to.deep.equal value
     expect(root1.list_prop[0].bar).to.equal 42
     expect(root1.dict_prop['foo'].bar).to.equal 43
 


### PR DESCRIPTION
This is to ease transition from `get,set` to getters and setters. This way using `get,set` will be discouraged. At some point in future I will change deprecation to a hard error. Additionally, `{get,set}v` are easier to distinguish from uses of different `get,set` in other contexts. Note that complete removal of at least `setv()` may not be possible, due to features like "simultaneous" and silent assignment.

fixes #5160