### PR TITLE
session.show(): take into account browser and new keywords

### DIFF
--- a/bokeh/client/session.py
+++ b/bokeh/client/session.py
@@ -292,7 +292,7 @@ class ClientSession(object):
         """
         if obj and obj not in self.document.roots:
             self.document.add_root(obj)
-        show_session(session=self)
+        show_session(session=self, browser=browser, new=new)
 
     @classmethod
     def _ensure_session_id(cls, session_id):


### PR DESCRIPTION
This little patch fixes the ignorance of `browser` and `new` keywords into `session.show()` and `show_session()`. 

- [x] issues: fixes #5156
- [x] tests passed

Now, it is possible to call a customized browser:

    # ...
    session = push_session(curdoc())
    custom_firefox = '/usr/bin/firefox -P ipython --new-tab %s'
    session.show(browser=custom_firefox)