### PR TITLE
Revert "Pin conda-build version to 1.21.14"

### DIFF
--- a/scripts/travis_install
+++ b/scripts/travis_install
@@ -22,7 +22,7 @@ echo -e "$PINNED_PKGS" > /home/travis/miniconda/conda-meta/pinned
 
 conda config --add channels bokeh
 
-DEPS_TRAVIS="python=$TRAVIS_PYTHON_VERSION conda-build=1.21.14 jinja2"
+DEPS_TRAVIS="python=$TRAVIS_PYTHON_VERSION conda-build jinja2"
 conda install --yes $DEPS_TRAVIS
 
 CONDA_PY="${TRAVIS_PYTHON_VERSION/./}" conda build --quiet --no-test conda.recipe


### PR DESCRIPTION
Our builds are currently failing with an exception, because there is API incompatibility between newest conda and obsolete pinned conda-build. This reverts #5084, because conda-build 2.0.1 fixes the original issue with building noarch package. Note that conda-build 2.0.1 was released several days ago, so if only there was a followup on issue #5084, then we wouldn't need to fix this in hurry and deal with a dozen of PRs which now need updating.