### PR TITLE
Replace jsnlog with a custom, line number preserving logger

### DIFF
--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -93,7 +93,6 @@
     "jquery": "^2.1.1",
     "jquery-mousewheel": "^3.1.12",
     "jquery-ui": "~1.10.5",
-    "jsnlog": "^2.7.5",
     "rbush": "^2.0.1",
     "proj4": "^2.3.10",
     "sprintf": "^0.1.5",

--- a/bokehjs/src/coffee/api/typings/bokeh.d.ts
+++ b/bokehjs/src/coffee/api/typings/bokeh.d.ts
@@ -6,10 +6,27 @@ declare namespace Bokeh {
     var _: UnderscoreStatic;
     var $: JQueryStatic;
 
-    var logger: JSNLog.JSNLogLogger;
+    class LogLevel {
+      name: string;
+      level: number;
+    }
 
-    type LogLevel = "trace" | "debug" | "info" | "warn" | "error" | "fatal";
-    function set_log_level(level: LogLevel): void;
+    type NamedLogLevel = "trace" | "debug" | "info" | "warn" | "error" | "fatal" | "off";
+
+    function set_log_level(level: NamedLogLevel): void;
+
+    class Logger {
+      get_level: () => LogLevel;
+      set_level: (log_level: LogLevel | NamedLogLevel) => void;
+
+      trace: (...args: any[]) => void;
+      debug: (...args: any[]) => void;
+      info:  (...args: any[]) => void;
+      warn:  (...args: any[]) => void;
+      error: (...args: any[]) => void;
+      fatal: (...args: any[]) => void;
+    }
+    var logger: Logger;
 
     function sprintf(fmt: string, ...args: any[]): string;
 

--- a/bokehjs/src/coffee/core/logging.coffee
+++ b/bokehjs/src/coffee/core/logging.coffee
@@ -1,36 +1,97 @@
-{JL} = require "jsnlog"
+# This is based on https://github.com/pimterry/loglevel
 
-logger = JL("Bokeh")
-logger.setOptions({
-  "appenders": [JL.createConsoleAppender('consoleAppender')],
-  "level": JL.getInfoLevel()
-})
+_ = require 'underscore'
 
-levels = {
-  "trace" : JL.getTraceLevel()
-  "debug" : JL.getDebugLevel()
-  "info"  : JL.getInfoLevel()
-  "warn"  : JL.getWarnLevel()
-  "error" : JL.getErrorLevel()
-  "fatal" : JL.getFatalLevel()
-}
+noop = () ->
 
-# Set the global logging level for Bokeh JS console output
-#
-# @param level [string] the log level to set
-#
-# valid log levels are: trace, debug, info, warn, error, fatal
-#
+_method_factory = (method_name, logger_name) ->
+  if console[method_name]?
+    return console[method_name].bind(console, logger_name)
+  else if console.log?
+    return console.log.bind(console, logger_name)
+  else
+    return noop
+
+_loggers = {}
+
+class LogLevel
+
+  constructor: (name, level) ->
+    @name = name
+    @level = level
+
+class Logger
+
+  @TRACE: new LogLevel("trace", 0)
+  @DEBUG: new LogLevel("debug", 1)
+  @INFO:  new LogLevel("info",  2)
+  @WARN:  new LogLevel("warn",  6)
+  @ERROR: new LogLevel("error", 7)
+  @FATAL: new LogLevel("fatal", 8)
+  @OFF:   new LogLevel("off",   9)
+
+  @log_levels: {
+    trace: @TRACE
+    debug: @DEBUG
+    info:  @INFO
+    warn:  @WARN
+    error: @ERROR
+    fatal: @FATAL
+    off:   @OFF
+  }
+
+  Object.defineProperty(this, 'levels', { get: () -> Object.keys(Logger.log_levels) })
+
+  @get: (name, level=Logger.INFO) ->
+    if _.isString(name) and name.length > 0
+      logger = _loggers[name]
+      if not logger?
+        logger = _loggers[name] = new Logger(name, level)
+      return logger
+    else
+      throw new TypeError("Logger.get() expects a string name and an optional log-level")
+
+  constructor: (name, level=Logger.INFO) ->
+    @_name = name
+    @set_level(level)
+
+  Object.defineProperty(this.prototype, 'level', { get: () -> @get_level() })
+
+  get_level: () -> @_log_level
+
+  set_level: (log_level) ->
+    if log_level instanceof LogLevel
+      @_log_level = log_level
+    else if _.isString(log_level) and Logger.log_levels[log_level]?
+      @_log_level = Logger.log_levels[log_level]
+    else
+      throw new Error("Logger.set_level() expects a log-level object or a string name of a log-level")
+
+    logger_name = "[#{@_name}]"
+
+    for __, log_level of Logger.log_levels
+      if log_level == Logger.OFF
+        break
+      else
+        method_name = log_level.name
+
+        if log_level.level < @_log_level.level
+          @[method_name] = noop
+        else
+          @[method_name] = _method_factory(method_name, logger_name)
+
+logger = Logger.get("bokeh")
+
 set_log_level = (level) ->
-  if level not of levels
-    console.log "Bokeh: Unrecognized logging level '#{level}' passed to Bokeh.set_log_level, ignoring."
-    console.log "Bokeh: Valid log levels are: #{Object.keys(levels)}"
-    return
-  console.log "Bokeh: setting log level to: '#{level}'"
-  logger.setOptions({"level": levels[level]})
-  return null
+  if level not in Logger.levels
+    console.log("[bokeh] unrecognized logging level '#{level}' passed to Bokeh.set_log_level(), ignoring")
+    console.log("[bokeh] valid log levels are: #{Logger.levels.join(', ')}")
+  else
+    console.log("[bokeh] setting log level to: '#{level}'")
+    logger.set_level(level)
 
-module.exports =
-  levels: levels
+module.exports = {
+  Logger: Logger
   logger: logger
   set_log_level: set_log_level
+}

--- a/bokehjs/test/core/logging.coffee
+++ b/bokehjs/test/core/logging.coffee
@@ -2,56 +2,52 @@
 utils = require "../utils"
 { stdoutTrap, stderrTrap } = require 'logtrap'
 
-logging = utils.require "core/logging"
+{Logger, logger, set_log_level} = utils.require "core/logging"
 
 describe "logging module", ->
 
-  describe "exports", ->
-    it "should have levels", ->
-      expect("levels" of logging).to.be.true
-
-    it "should have logger", ->
-      expect("logger" of logging).to.be.true
-
-    it "should have set_log_level", ->
-      expect("set_log_level" of logging).to.be.true
-
   describe "logger", ->
     it "should default to log level 'info'", ->
-      expect(logging.logger.level).to.be.equal logging.levels.info
+      debugger;
+      expect(logger.level).to.be.equal(Logger.INFO)
 
   describe "set_log_level", ->
 
     describe "sets accepted levels", ->
 
       it "trace", ->
-        out = stdoutTrap -> logging.set_log_level("trace")
-        expect(out).to.be.equal "Bokeh: setting log level to: 'trace'\n"
-        expect(logging.logger.level).to.be.equal logging.levels.trace
+        out = stdoutTrap -> set_log_level("trace")
+        expect(out).to.be.equal "[bokeh] setting log level to: 'trace'\n"
+        expect(logger.level).to.be.equal(Logger.TRACE)
 
       it "debug", ->
-        out = stdoutTrap -> logging.set_log_level("debug")
-        expect(out).to.be.equal "Bokeh: setting log level to: 'debug'\n"
-        expect(logging.logger.level).to.be.equal logging.levels.debug
+        out = stdoutTrap -> set_log_level("debug")
+        expect(out).to.be.equal "[bokeh] setting log level to: 'debug'\n"
+        expect(logger.level).to.be.equal(Logger.DEBUG)
 
       it "info", ->
-        out = stdoutTrap -> logging.set_log_level("info")
-        expect(out).to.be.equal "Bokeh: setting log level to: 'info'\n"
-        expect(logging.logger.level).to.be.equal logging.levels.info
+        out = stdoutTrap -> set_log_level("info")
+        expect(out).to.be.equal "[bokeh] setting log level to: 'info'\n"
+        expect(logger.level).to.be.equal(Logger.INFO)
       it "warn", ->
-        out = stdoutTrap -> logging.set_log_level("warn")
-        expect(out).to.be.equal "Bokeh: setting log level to: 'warn'\n"
-        expect(logging.logger.level).to.be.equal logging.levels.warn
+        out = stdoutTrap -> set_log_level("warn")
+        expect(out).to.be.equal "[bokeh] setting log level to: 'warn'\n"
+        expect(logger.level).to.be.equal(Logger.WARN)
       it "error", ->
-        out = stdoutTrap -> logging.set_log_level("error")
-        expect(out).to.be.equal "Bokeh: setting log level to: 'error'\n"
-        expect(logging.logger.level).to.be.equal logging.levels.error
+        out = stdoutTrap -> set_log_level("error")
+        expect(out).to.be.equal "[bokeh] setting log level to: 'error'\n"
+        expect(logger.level).to.be.equal(Logger.ERROR)
 
       it "fatal", ->
-        out = stdoutTrap -> logging.set_log_level("fatal")
-        expect(out).to.be.equal "Bokeh: setting log level to: 'fatal'\n"
-        expect(logging.logger.level).to.be.equal logging.levels.fatal
+        out = stdoutTrap -> set_log_level("fatal")
+        expect(out).to.be.equal "[bokeh] setting log level to: 'fatal'\n"
+        expect(logger.level).to.be.equal(Logger.FATAL)
+
+      it "off", ->
+        out = stdoutTrap -> set_log_level("off")
+        expect(out).to.be.equal "[bokeh] setting log level to: 'off'\n"
+        expect(logger.level).to.be.equal(Logger.OFF)
 
     it "ignores unknown levels", ->
-      out = stdoutTrap -> logging.set_log_level("bad")
-      expect(out).to.be.equal "Bokeh: Unrecognized logging level 'bad' passed to Bokeh.set_log_level, ignoring.\nBokeh: Valid log levels are: trace,debug,info,warn,error,fatal\n"
+      out = stdoutTrap -> set_log_level("bad")
+      expect(out).to.be.equal("[bokeh] unrecognized logging level 'bad' passed to Bokeh.set_log_level(), ignoring\n[bokeh] valid log levels are: trace, debug, info, warn, error, fatal, off\n")

--- a/bokehjs/test/document.coffee
+++ b/bokehjs/test/document.coffee
@@ -551,15 +551,15 @@ describe "Document", ->
 
     parsed['version'] = "0.0.1"
     out = stderrTrap -> Document.from_json_string(JSON.stringify(parsed))
-    expect(out).to.be.equal "Bokeh: JS/Python version mismatch\nBokeh: Library versions: JS (#{js_version})  /  Python (#{parsed["version"]})\n"
+    expect(out).to.be.equal "[bokeh] JS/Python version mismatch\n[bokeh] Library versions: JS (#{js_version})  /  Python (#{parsed["version"]})\n"
 
     parsed['version'] = "#{js_version}rc123"
     out = stderrTrap -> Document.from_json_string(JSON.stringify(parsed))
-    expect(out).to.be.equal "Bokeh: JS/Python version mismatch\nBokeh: Library versions: JS (#{js_version})  /  Python (#{parsed["version"]})\n"
+    expect(out).to.be.equal "[bokeh] JS/Python version mismatch\n[bokeh] Library versions: JS (#{js_version})  /  Python (#{parsed["version"]})\n"
 
     parsed['version'] = "#{js_version}dev123"
     out = stderrTrap -> Document.from_json_string(JSON.stringify(parsed))
-    expect(out).to.be.equal "Bokeh: JS/Python version mismatch\nBokeh: Library versions: JS (#{js_version})  /  Python (#{parsed["version"]})\n"
+    expect(out).to.be.equal "[bokeh] JS/Python version mismatch\n[bokeh] Library versions: JS (#{js_version})  /  Python (#{parsed["version"]})\n"
 
     parsed['version'] = "#{js_version}-foo"
     out = stderrTrap -> Document.from_json_string(JSON.stringify(parsed))

--- a/bokehjs/typings.json
+++ b/bokehjs/typings.json
@@ -4,7 +4,6 @@
   "dependencies": {},
   "ambientDependencies": {
     "jquery": "registry:dt/jquery#1.10.0+20160316155526",
-    "jsnlog": "registry:dt/jsnlog#2.11.0+20160317120654",
     "underscore": "registry:dt/underscore#1.7.0+20160316155526"
   }
 }


### PR DESCRIPTION
This implements a custom logger. It preserves line numbers and allows for logger naming (prefixes). This also slightly reduces bokehjs size and avoids issues that were present in jsnlog (`window.onerror` and AJAX requests). This should work across modern web browsers, but unfortunately it may be broken in some versions of Firefox (you will get '(unknown)' location). This is FF's bug.

fixes #5171