### PR TITLE
Add very crude HTML representation of models

### DIFF
--- a/bokeh/core/tests/test_properties.py
+++ b/bokeh/core/tests/test_properties.py
@@ -15,8 +15,6 @@ from bokeh.core.properties import (
 from bokeh.models import Plot
 from bokeh.models.annotations import Title
 
-from IPython.lib.pretty import pretty
-
 class Basictest(unittest.TestCase):
 
     def test_simple_class(self):
@@ -1514,19 +1512,19 @@ def test_HasProps_clone():
     c2 = p2.properties_with_values(include_defaults=False)
     assert c1 == c2
 
-def test_HasProps__repr_pretty_():
+def test_HasProps_pretty():
     class Foo1(HasProps):
         a = Int(12)
         b = String("hello")
 
-    assert pretty(Foo1()) == "bokeh.core.tests.test_properties.Foo1(a=12, b='hello')"
+    assert Foo1().pretty() == "bokeh.core.tests.test_properties.Foo1(a=12, b='hello')"
 
     class Foo2(HasProps):
         a = Int(12)
         b = String("hello")
         c = List(Int, [1, 2, 3])
 
-    assert pretty(Foo2()) == "bokeh.core.tests.test_properties.Foo2(a=12, b='hello', c=[1, 2, 3])"
+    assert Foo2().pretty() == "bokeh.core.tests.test_properties.Foo2(a=12, b='hello', c=[1, 2, 3])"
 
     class Foo3(HasProps):
         a = Int(12)
@@ -1534,7 +1532,7 @@ def test_HasProps__repr_pretty_():
         c = List(Int, [1, 2, 3])
         d = Float(None)
 
-    assert pretty(Foo3()) == "bokeh.core.tests.test_properties.Foo3(a=12, b='hello', c=[1, 2, 3], d=None)"
+    assert Foo3().pretty() == "bokeh.core.tests.test_properties.Foo3(a=12, b='hello', c=[1, 2, 3], d=None)"
 
     class Foo4(HasProps):
         a = Int(12)
@@ -1543,7 +1541,7 @@ def test_HasProps__repr_pretty_():
         d = Float(None)
         e = Instance(Foo1, lambda: Foo1())
 
-    assert pretty(Foo4()) == """\
+    assert Foo4().pretty() == """\
 bokeh.core.tests.test_properties.Foo4(
     a=12,
     b='hello',
@@ -1561,7 +1559,7 @@ bokeh.core.tests.test_properties.Foo4(
     f6 = Foo6(foo5=f5)
     f5.foo6 = f6
 
-    assert pretty(f5) == """\
+    assert f5.pretty() == """\
 bokeh.core.tests.test_properties.Foo5(
     foo6=bokeh.core.tests.test_properties.Foo6(
         foo5=bokeh.core.tests.test_properties.Foo5(...)))"""

--- a/bokeh/model.py
+++ b/bokeh/model.py
@@ -344,11 +344,11 @@ class Model(with_metaclass(Viewable, HasProps, CallbackManager)):
         return serialize_json(json_like)
 
     def __str__(self):
-        return "%s(id=%s, ...)" % (self.__class__.__name__, getattr(self, "_id", None))
+        return "%s(id=%r, ...)" % (self.__class__.__name__, getattr(self, "_id", None))
 
     __repr__ = __str__
 
-    def _repr_pretty_(self, p, cycle):
+    def _bokeh_repr_pretty_(self, p, cycle):
         name = "%s.%s" % (self.__class__.__module__, self.__class__.__name__)
         _id = getattr(self, "_id", None)
 

--- a/bokeh/models/layouts.py
+++ b/bokeh/models/layouts.py
@@ -66,15 +66,10 @@ class LayoutDOM(Model):
 
     """)
 
-    # TODO: (mp) Not yet, because it breaks plotting/notebook examples.
-    # Rename to _repr_html_ if we decide to enable this by default.
-    def __repr_html__(self):
-        return notebook_div(self)
-
     @property
     def html(self):
         from IPython.core.display import HTML
-        return HTML(self.__repr_html__())
+        return HTML(notebook_div(self))
 
 
 class Spacer(LayoutDOM):

--- a/bokeh/models/tests/test_renderers.py
+++ b/bokeh/models/tests/test_renderers.py
@@ -23,7 +23,7 @@ class TestGlyphRenderer(unittest.TestCase):
             'Category labels cannot contain colons',
             '[range:x_range] [first_value: 2:0] '
             '[range:y_range] [first_value: 2:0] '
-            '[renderer: Figure(id=%s, ...)]' % plot._id
+            '[renderer: Figure(id=%r, ...)]' % plot._id
         )])
 
     def test_validates_colons_only_in_factorial_range(self):
@@ -41,7 +41,7 @@ class TestGlyphRenderer(unittest.TestCase):
             'MALFORMED_CATEGORY_LABEL',
             'Category labels cannot contain colons',
             '[range:y_range] [first_value: 2:0] '
-            '[renderer: Figure(id=%s, ...)]' % plot._id
+            '[renderer: Figure(id=%r, ...)]' % plot._id
         )])
 
 if __name__ == '__main__':

--- a/bokeh/models/tests/test_renderers.py
+++ b/bokeh/models/tests/test_renderers.py
@@ -5,7 +5,6 @@ import unittest
 from bokeh.plotting import figure
 from bokeh.models.ranges import DataRange1d
 
-
 class TestGlyphRenderer(unittest.TestCase):
     def test_warning_about_colons_in_column_labels_for_axis(self):
         invalid_labels = ['0', '1', '2:0']
@@ -24,8 +23,7 @@ class TestGlyphRenderer(unittest.TestCase):
             'Category labels cannot contain colons',
             '[range:x_range] [first_value: 2:0] '
             '[range:y_range] [first_value: 2:0] '
-            '[renderer: Figure, ViewModel:Plot, ref _id: '
-            '%s]' % plot._id
+            '[renderer: Figure(id=%s, ...)]' % plot._id
         )])
 
     def test_validates_colons_only_in_factorial_range(self):
@@ -43,12 +41,8 @@ class TestGlyphRenderer(unittest.TestCase):
             'MALFORMED_CATEGORY_LABEL',
             'Category labels cannot contain colons',
             '[range:y_range] [first_value: 2:0] '
-            '[renderer: Figure, ViewModel:Plot, ref _id: '
-            '%s]' % plot._id
+            '[renderer: Figure(id=%s, ...)]' % plot._id
         )])
-
-
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/bokeh/tests/test_model.py
+++ b/bokeh/tests/test_model.py
@@ -3,8 +3,6 @@ from bokeh.core.properties import Int, String, Float, Instance, List, Any
 from bokeh.plotting import figure
 from bokeh.io import curdoc
 
-from IPython.lib.pretty import pretty
-
 def test_model_in_empty_document_sets_a_new_document_on_model_and_then_restores():
     doc = curdoc()
     plot = figure()
@@ -35,19 +33,19 @@ def test_model_in_empty_document_unsets_curdoc_on_model_references_and_then_rest
     # Check old document is replaced
     assert a_ref._document == doc
 
-def test_Model__repr_pretty_():
+def test_Model_pretty():
     class Foo1(Model):
         a = Int(12)
         b = String("hello")
 
-    assert pretty(Foo1(id='xyz')) == "bokeh.tests.test_model.Foo1(id='xyz', a=12, b='hello', name=None, tags=[])"
+    assert Foo1(id='xyz').pretty() == "bokeh.tests.test_model.Foo1(id='xyz', a=12, b='hello', name=None, tags=[])"
 
     class Foo2(Model):
         a = Int(12)
         b = String("hello")
         c = List(Int, [1, 2, 3])
 
-    assert pretty(Foo2(id='xyz')) == """\
+    assert Foo2(id='xyz').pretty() == """\
 bokeh.tests.test_model.Foo2(
     id='xyz',
     a=12,
@@ -62,7 +60,7 @@ bokeh.tests.test_model.Foo2(
         c = List(Int, [1, 2, 3])
         d = Float(None)
 
-    assert pretty(Foo3(id='xyz')) == """\
+    assert Foo3(id='xyz').pretty() == """\
 bokeh.tests.test_model.Foo3(
     id='xyz',
     a=12,
@@ -79,7 +77,7 @@ bokeh.tests.test_model.Foo3(
         d = Float(None)
         e = Instance(Foo1, lambda: Foo1(id='xyz'))
 
-    assert pretty(Foo4(id='xyz')) == """\
+    assert Foo4(id='xyz').pretty() == """\
 bokeh.tests.test_model.Foo4(
     id='xyz',
     a=12,
@@ -105,7 +103,7 @@ bokeh.tests.test_model.Foo4(
     f6 = Foo6(id='uvw', foo5=f5)
     f5.foo6 = f6
 
-    assert pretty(f5) == """\
+    assert f5.pretty() == """\
 bokeh.tests.test_model.Foo5(
     id='xyz',
     foo6=bokeh.tests.test_model.Foo6(


### PR DESCRIPTION
By default this displays concise representation consisting of model's name, id and expand button. After expansion, it shows all model's properties and their values (formatted with `repr()`) and collapse button, which allows to return to concise representation. This is very crude, doesn't work recursively (thus `repr()`) and doesn't take too much advantage of HTML/CSS (colors, at al.). All this can be improved later, but for now we have something that works and doesn't interfere with notebook workflow. Note this is implemented in vanilla JS, so there are no assumptions about JQuery, etc. We shouldn't use bokehjs' JQuery, because HTML repr of a model may be displayed before `output_notebook()`. Also note that this makes original (commented out) `_repr_html_`, that displayed a plot automatically, obsolete and resolves that discussion as well.

fixes #5164