### PR TITLE
Fix legend merging broken

### DIFF
--- a/bokeh/plotting/figure.py
+++ b/bokeh/plotting/figure.py
@@ -10,6 +10,7 @@ from ..util._plot_arg_helpers import _convert_responsive
 
 DEFAULT_TOOLS = "pan,wheel_zoom,box_zoom,save,reset,help"
 
+
 class Figure(Plot):
     ''' A subclass of :class:`~bokeh.models.plots.Plot` that simplifies plot
     creation with default axes, grids, tools, etc.
@@ -57,6 +58,8 @@ class Figure(Plot):
         tool_objs, tool_map = _process_tools_arg(self, tools)
         self.add_tools(*tool_objs)
         _process_active_tools(self.toolbar, tool_map, active_drag, active_scroll, active_tap)
+
+        self._compound_legend = False
 
     annular_wedge = _glyph_function(glyphs.AnnularWedge)
 

--- a/bokeh/plotting/helpers.py
+++ b/bokeh/plotting/helpers.py
@@ -17,7 +17,7 @@ from ..models import (
     SaveTool, Range, Range1d, UndoTool, RedoTool, ResetTool, ResizeTool, Tool,
     WheelPanTool, WheelZoomTool, ColumnDataSource, GlyphRenderer)
 
-from ..core.properties import ColorSpec, Datetime, value
+from ..core.properties import ColorSpec, Datetime, value, field
 from ..util.deprecate import BokehDeprecationWarning
 from ..util.string import nice_join
 
@@ -107,18 +107,18 @@ def _process_legend_kwargs(kwargs):
     legend = kwargs.pop('legend', None)
     source = kwargs.get('source')
     if legend:
-        if isinstance(legend, string_types):
-            # Try and do something intelligent with a legend string:
-            # * value if it's not in column data source
-            # * field if it is
+        kwargs['label'] = legend
+
+    label = kwargs.get('label')
+    if label:
+        # Try and be smart
+        if isinstance(label, string_types):
+            # Do the simple thing first
+            kwargs['label'] = value(label)
+            # But if there's a source - try and do something smart
             if source and hasattr(source, 'column_names'):
-                if legend in source.column_names:
-                    kwargs['label'] = legend
-                else:
-                    kwargs['label'] = value(legend)
-        else:
-            # Otherwise just accept folks were being intentional
-            kwargs['label'] = legend
+                if label in source.column_names:
+                    kwargs['label'] = field(label)
 
 _GLYPH_SOURCE_MSG = """
 Supplying a user-defined data source AND iterable values to glyph methods is deprecated.

--- a/bokeh/plotting/tests/test_figure.py
+++ b/bokeh/plotting/tests/test_figure.py
@@ -245,7 +245,7 @@ def p():
 
 def test_glyph_label_is_legend_if_column_in_datasouurce_is_added_as_legend(p, source):
     renderer = p.circle(x='x', y='y', legend='label', source=source)
-    assert renderer.glyph.label == 'label'
+    assert renderer.glyph.label == {'field': 'label'}
 
 
 def test_glyph_label_is_value_if_column_not_in_datasouurce_is_added_as_legend(p, source):

--- a/bokeh/plotting/tests/test_figure.py
+++ b/bokeh/plotting/tests/test_figure.py
@@ -263,11 +263,6 @@ def test_glyph_label_is_None_if_legend_is_none(p, source):
     assert renderer.glyph.label is None
 
 
-def test_cannot_set_legend_and_label(p, source):
-    with pytest.raises(RuntimeError):
-        p.circle(x='x', y='y', legend='label', label='label', source=source)
-
-
 def test_legend_added_when_legend_set(p, source):
     renderer = p.circle(x='x', y='y', legend='label', source=source)
     legends = p.select(Legend)
@@ -296,8 +291,16 @@ def test_adding_legend_doesnt_work_when_legends_already_added(p, source):
 
 
 def test_multiple_renderers_correctly_added_to_legend(p, source):
-    square = p.square(x='x', y='y', label='label', source=source)
-    circle = p.circle(x='x', y='y', label='label', source=source)
+    square = p.square(x='x', y='y', legend='square', source=source)
+    circle = p.circle(x='x', y='y', legend='circle', source=source)
     legends = p.select(Legend)
     assert len(legends) == 1
     assert legends[0].legends == [square, circle]
+
+
+def test_compound_legend_behavior_initiated_if_labels_are_same_on_multiple_renderers(p, source):
+    square = p.square(x='x', y='y', legend='compound legend string', source=source)
+    circle = p.circle(x='x', y='y', legend='compound legend string', source=source)
+    legends = p.select(Legend)
+    assert len(legends) == 1
+    assert legends[0].legends == [('compound legend string', [square, circle]),]

--- a/bokeh/plotting/tests/test_helpers.py
+++ b/bokeh/plotting/tests/test_helpers.py
@@ -1,5 +1,6 @@
 import pytest
 
+from bokeh.models import ColumnDataSource
 from bokeh.plotting.helpers import (
     _process_legend_kwargs
 )
@@ -8,5 +9,83 @@ from bokeh.plotting.helpers import (
 # _process_legend_kwargs
 def test_process_legend_kwargs_raises_error_if_both_legend_and_label():
     with pytest.raises(RuntimeError):
-        kwargs = dict(label='1', legend='2')
+        kwargs = {
+            'label': 'label',
+            'legend': 'legend'
+        }
         _process_legend_kwargs(kwargs)
+
+
+def test_if_exotic_label_passed_it_is_unchanged():
+    kwargs = {
+        'label': ['exotic', 'label']
+    }
+    _process_legend_kwargs(kwargs)
+    assert kwargs.get('label') == ['exotic', 'label']
+
+
+
+def test_if_legend_is_something_exotic_that_it_is_passed_directly_to_label():
+    kwargs = {
+        'legend': {'field': 'milk'}
+    }
+    _process_legend_kwargs(kwargs)
+    assert kwargs.get('legend') is None
+    assert kwargs.get('label') == {'field': 'milk'}
+
+
+def test_if_legend_is_a_string_but_no_source_then_label_is_set_as_value():
+    kwargs = {
+        'legend': 'label'
+    }
+    _process_legend_kwargs(kwargs)
+    assert kwargs.get('legend') is None
+    assert kwargs.get('label') == {'value': 'label'}
+
+
+def test_if_label_is_a_string_but_no_source_label_is_value():
+    kwargs = {
+        'label': 'label'
+    }
+    _process_legend_kwargs(kwargs)
+    assert kwargs.get('label') == {'value': 'label'}
+
+
+def test_if_legend_is_a_string_and_source_with_that_column_then_field():
+    kwargs = {
+        'legend': 'label',
+        'source': ColumnDataSource(dict(label=[1, 2]))
+    }
+    _process_legend_kwargs(kwargs)
+    assert kwargs.get('legend') is None
+    assert kwargs.get('label') == {'field': 'label'}
+
+
+def test_if_label_is_a_string_and_source_with_that_column_then_field():
+    kwargs = {
+        'label': 'label',
+        'source': ColumnDataSource(dict(label=[1, 2]))
+    }
+    _process_legend_kwargs(kwargs)
+    assert kwargs.get('legend') is None
+    assert kwargs.get('label') == {'field': 'label'}
+
+
+def test_if_legend_is_a_string_and_source_without_column_name_then_value():
+    kwargs = {
+        'legend': 'not_a_column_label',
+        'source': ColumnDataSource(dict(label=[1, 2]))
+    }
+    _process_legend_kwargs(kwargs)
+    assert kwargs.get('legend') is None
+    assert kwargs.get('label') == {'value': 'not_a_column_label'}
+
+
+def test_if_label_is_a_string_and_source_without_column_name_then_value():
+    kwargs = {
+        'label': 'not_a_column_label',
+        'source': ColumnDataSource(dict(label=[1, 2]))
+    }
+    _process_legend_kwargs(kwargs)
+    assert kwargs.get('legend') is None
+    assert kwargs.get('label') == {'value': 'not_a_column_label'}

--- a/bokeh/plotting/tests/test_helpers.py
+++ b/bokeh/plotting/tests/test_helpers.py
@@ -1,0 +1,12 @@
+import pytest
+
+from bokeh.plotting.helpers import (
+    _process_legend_kwargs
+)
+
+
+# _process_legend_kwargs
+def test_process_legend_kwargs_raises_error_if_both_legend_and_label():
+    with pytest.raises(RuntimeError):
+        kwargs = dict(label='1', legend='2')
+        _process_legend_kwargs(kwargs)


### PR DESCRIPTION
- [x] issues: fixes #5202
- [x] tests added / passed

This fixes #5202. @bryevdv also suggested a legend_mode that lets users explicitly decide the behavior they want.

I'm doing that in a separate PR as this one should be straight forward to merge for an RC. The other one might require futher API discussion.

This restores the behavior where a user sets the same string for multiple legend and auto-magically gets a compound legend glyph.

It also keeps the recently added behavior where if a label is a field on the column data source then the actual data will be used as the legend's label.

This leads to a potential conflict where a user defined label matches with the a column name, and they actually just want a string - and the explicit modes will provide this ability.