### PR TITLE
Catch any exception in `import_optional`

### DIFF
--- a/bokeh/util/dependencies.py
+++ b/bokeh/util/dependencies.py
@@ -1,10 +1,8 @@
 ''' Utilities for checking dependencies
 
 '''
-from __future__ import print_function
 from importlib import import_module
 import logging
-import traceback
 
 
 logger = logging.getLogger(__name__)
@@ -29,7 +27,6 @@ def import_optional(mod_name):
     except Exception as e:
         msg = "Failed to import optional module `{}`".format(mod_name)
         logger.exception(msg)
-        print('\n'.join([msg, traceback.format_exc()]))
         
 
 def import_required(mod_name, error_msg):

--- a/bokeh/util/dependencies.py
+++ b/bokeh/util/dependencies.py
@@ -27,7 +27,6 @@ def import_optional(mod_name):
     except Exception:
         msg = "Failed to import optional module `{}`".format(mod_name)
         logger.exception(msg)
-        
 
 def import_required(mod_name, error_msg):
     ''' Attempt to import a required dependency.

--- a/bokeh/util/dependencies.py
+++ b/bokeh/util/dependencies.py
@@ -3,7 +3,11 @@
 '''
 from importlib import import_module
 import traceback
-import warnings
+import logging
+
+
+logger = logging.getLogger(__name__)
+
 
 def import_optional(mod_name):
     ''' Attempt to import an optional dependency.
@@ -20,9 +24,10 @@ def import_optional(mod_name):
     try:
         return import_module(mod_name)
     except ImportError:
-        return None
+        pass
     except Exception as exc:
-        warnings.warn(traceback.format_exc(), RuntimeWarning)
+        msg = "Failed to import optional module `{}`".format(mod_name)
+        logger.exception(msg)
         
 
 def import_required(mod_name, error_msg):

--- a/bokeh/util/dependencies.py
+++ b/bokeh/util/dependencies.py
@@ -2,6 +2,8 @@
 
 '''
 from importlib import import_module
+import traceback
+import warnings
 
 def import_optional(mod_name):
     ''' Attempt to import an optional dependency.
@@ -17,8 +19,11 @@ def import_optional(mod_name):
     '''
     try:
         return import_module(mod_name)
-    except Exception:
+    except ImportError:
         return None
+    except Exception as exc:
+        warnings.warn(traceback.format_exc(), RuntimeWarning)
+        
 
 def import_required(mod_name, error_msg):
     ''' Attempt to import a required dependency.

--- a/bokeh/util/dependencies.py
+++ b/bokeh/util/dependencies.py
@@ -17,7 +17,7 @@ def import_optional(mod_name):
     '''
     try:
         return import_module(mod_name)
-    except ImportError:
+    except Exception:
         return None
 
 def import_required(mod_name, error_msg):

--- a/bokeh/util/dependencies.py
+++ b/bokeh/util/dependencies.py
@@ -1,8 +1,10 @@
 ''' Utilities for checking dependencies
 
 '''
+from __future__ import print_function
 from importlib import import_module
 import logging
+import traceback
 
 
 logger = logging.getLogger(__name__)
@@ -24,9 +26,10 @@ def import_optional(mod_name):
         return import_module(mod_name)
     except ImportError:
         pass
-    except Exception as exc:
+    except Exception as e:
         msg = "Failed to import optional module `{}`".format(mod_name)
         logger.exception(msg)
+        print('\n'.join([msg, traceback.format_exc()]))
         
 
 def import_required(mod_name, error_msg):

--- a/bokeh/util/dependencies.py
+++ b/bokeh/util/dependencies.py
@@ -2,7 +2,6 @@
 
 '''
 from importlib import import_module
-import traceback
 import logging
 
 

--- a/bokeh/util/dependencies.py
+++ b/bokeh/util/dependencies.py
@@ -24,7 +24,7 @@ def import_optional(mod_name):
         return import_module(mod_name)
     except ImportError:
         pass
-    except Exception as e:
+    except Exception:
         msg = "Failed to import optional module `{}`".format(mod_name)
         logger.exception(msg)
         


### PR DESCRIPTION
Imports can trigger side effects which may result in any exception
potentially being thrown. In this case simply return None rather than
crashing on an optional import.

Fixes #5242