### PR TITLE
Replace DatetimeTickFormatter.formats with individual fields

### DIFF
--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -12,7 +12,7 @@ from ..model import Model
 from ..core.properties import abstract
 from ..core.properties import (Bool, Int, String, Enum, Auto, List, Dict,
     Either, Instance)
-from ..core.enums import DatetimeUnits, RoundingFunction, NumeralLanguage
+from ..core.enums import RoundingFunction, NumeralLanguage
 from ..util.dependencies import import_required
 from ..util.deprecation import deprecated
 from ..util.compiler import nodejs_compile, CompilationError

--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -14,6 +14,7 @@ from ..core.properties import (Bool, Int, String, Enum, Auto, List, Dict,
     Either, Instance)
 from ..core.enums import DatetimeUnits, RoundingFunction, NumeralLanguage
 from ..util.dependencies import import_required
+from ..util.deprecation import deprecated
 from ..util.compiler import nodejs_compile, CompilationError
 
 @abstract
@@ -282,26 +283,7 @@ class FuncTickFormatter(TickFormatter):
 
     """)
 
-DEFAULT_DATETIME_FORMATS = lambda : {
-    'microseconds': ['%fus'],
-    'milliseconds': ['%3Nms', '%S.%3Ns'],
-    'seconds':      ['%Ss'],
-    'minsec':       [':%M:%S'],
-    'minutes':      [':%M', '%Mm'],
-    'hourmin':      ['%H:%M'],
-    'hours':        ['%Hh', '%H:%M'],
-    'days':         ['%m/%d', '%a%d'],
-    'months':       ['%m/%Y', '%b%y'],
-    'years':        ['%Y'],
-}
-
-class DatetimeTickFormatter(TickFormatter):
-    """ Display tick values from a continuous range as formatted
-    datetimes.
-
-    """
-
-    formats = Dict(Enum(DatetimeUnits), List(String), default=DEFAULT_DATETIME_FORMATS, help="""
+DATETIME_TICK_FORMATTER_HELP="""
     User defined formats for displaying datetime values.
 
     The enum values correspond roughly to different "time scales". The
@@ -312,19 +294,7 @@ class DatetimeTickFormatter(TickFormatter):
     will be used. By default, all leading zeros are stripped away from
     the formatted labels. These behaviors cannot be changed as of now.
 
-    An example of specifying the same date format over a range of time scales::
-
-        DatetimeTickFormatter(
-            formats=dict(
-                hours=["%B %Y"],
-                days=["%B %Y"],
-                months=["%B %Y"],
-                years=["%B %Y"],
-            )
-        )
-
     This list of supported `strftime`_ formats is reproduced below.
-
 
     .. warning::
         The client library BokehJS uses the `timezone`_ library to
@@ -509,4 +479,59 @@ class DatetimeTickFormatter(TickFormatter):
     .. _timezone: http://bigeasy.github.io/timezone/
     .. _github issue: https://github.com/bokeh/bokeh/issues
 
-    """)
+"""
+
+class DatetimeTickFormatter(TickFormatter):
+    """ Display tick values from a continuous range as formatted datetimes. """
+
+    microseconds = List(String, default=['%fus'],
+        help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+    milliseconds = List(String, default=['%3Nms', '%S.%3Ns'],
+        help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+    seconds      = List(String, default=['%Ss'],
+        help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+    minsec       = List(String, default=[':%M:%S'],
+        help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+    minutes      = List(String, default=[':%M', '%Mm'],
+        help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+    hourmin      = List(String, default=['%H:%M'],
+        help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+    hours        = List(String, default=['%Hh', '%H:%M'],
+        help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+    days         = List(String, default=['%m/%d', '%a%d'],
+        help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+    months       = List(String, default=['%m/%Y', '%b%y'],
+        help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+    years        = List(String, default=['%Y'],
+        help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+
+    __deprecated_attributes__ = ('formats',)
+
+    @property
+    def formats(self):
+        deprecated((0, 12, 4), 'DatetimeTickFormatter.formats', 'individual fields')
+        return dict(
+            microseconds = self.microseconds,
+            milliseconds = self.milliseconds,
+            seconds      = self.seconds,
+            minsec       = self.minsec,
+            minutes      = self.minutes,
+            hourmin      = self.hourmin,
+            hours        = self.hours,
+            days         = self.days,
+            months       = self.months,
+            years        = self.years)
+
+    @formats.setter
+    def formats(self, value):
+        deprecated((0, 12, 4), 'DatetimeTickFormatter.formats', 'individual fields')
+        if 'microseconds' in value: self.microseconds = value['microseconds']
+        if 'milliseconds' in value: self.milliseconds = value['milliseconds']
+        if 'seconds'      in value: self.seconds      = value['seconds']
+        if 'minsec'       in value: self.minsec       = value['minsec']
+        if 'minutes'      in value: self.minutes      = value['minutes']
+        if 'hourmin'      in value: self.hourmin      = value['hourmin']
+        if 'hours'        in value: self.hours        = value['hours']
+        if 'days'         in value: self.days         = value['days']
+        if 'months'       in value: self.months       = value['months']
+        if 'years'        in value: self.years        = value['years']

--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -298,27 +298,38 @@ def DEFAULT_DATETIME_FORMATS():
         'years':        ['%Y'],
     }
 
-DATETIME_TICK_FORMATTER_HELP="""
-    User defined formats for displaying datetime values.
+def _DATETIME_TICK_FORMATTER_HELP(field):
+    return """
+    Formats for displaying datetime values in the %s range.
 
-    The enum values correspond roughly to different "time scales". The
-    corresponding value is a list of `strftime`_ formats to use for
+    See the :class:`~bokeh.models.formatters.DatetimeTickFormatter` help for a list of all supported formats.
+    """ % field
+
+class DatetimeTickFormatter(TickFormatter):
+    """ A ``TickFormatter`` for displaying datetime values nicely across a
+    range of scales.
+
+    ``DatetimeTickFormatter`` has the following properties for setting formats
+    at different scales scales:
+
+    * ``microseconds``
+    * ``milliseconds``
+    * ``seconds``
+    * ``minsec``
+    * ``minutes``
+    * ``hourmin``
+    * ``hours``
+    * ``days``
+    * ``months``
+    * ``years``
+
+    Each scale property can be set to format or list of formats to use for
     formatting datetime tick values that fall in in that "time scale".
-
     By default, only the first format string passed for each time scale
     will be used. By default, all leading zeros are stripped away from
-    the formatted labels. These behaviors cannot be changed as of now.
+    the formatted labels.
 
     This list of supported `strftime`_ formats is reproduced below.
-
-    .. warning::
-        The client library BokehJS uses the `timezone`_ library to
-        format datetimes. The inclusion of the list below is based on the
-        claim that `timezone`_ makes to support "the full compliment
-        of GNU date format specifiers." However, this claim has not
-        been tested exhaustively against this list. If you find formats
-        that do not function as expected, please submit a `github issue`_,
-        so that the documentation can be updated appropriately.
 
     %a
         The abbreviated name of the day of the week according to the
@@ -490,49 +501,69 @@ DATETIME_TICK_FORMATTER_HELP="""
     %%
         A literal '%' character.
 
+    .. warning::
+        The client library BokehJS uses the `timezone`_ library to
+        format datetimes. The inclusion of the list below is based on the
+        claim that `timezone`_ makes to support "the full compliment
+        of GNU date format specifiers." However, this claim has not
+        been tested exhaustively against this list. If you find formats
+        that do not function as expected, please submit a `github issue`_,
+        so that the documentation can be updated appropriately.
+
     .. _strftime: http://man7.org/linux/man-pages/man3/strftime.3.html
     .. _timezone: http://bigeasy.github.io/timezone/
     .. _github issue: https://github.com/bokeh/bokeh/issues
 
-"""
+    """
+    microseconds = List(String,
+                        help=_DATETIME_TICK_FORMATTER_HELP("``microseconds``"),
+                        default=['%fus']).accepts(String, lambda fmt: [fmt])
 
-class DatetimeTickFormatter(TickFormatter):
-    """ Display tick values from a continuous range as formatted datetimes. """
+    milliseconds = List(String,
+                        help=_DATETIME_TICK_FORMATTER_HELP("``milliseconds``"),
+                        default=['%3Nms', '%S.%3Ns']).accepts(String, lambda fmt: [fmt])
 
-    microseconds = List(String, default=['%fus'],
-        help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+    seconds      = List(String,
+                        help=_DATETIME_TICK_FORMATTER_HELP("``seconds``"),
+                        default=['%Ss']).accepts(String, lambda fmt: [fmt])
 
-    milliseconds = List(String, default=['%3Nms', '%S.%3Ns'],
-        help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+    minsec       = List(String,
+                        help=_DATETIME_TICK_FORMATTER_HELP("``minsec`` (for combined minutes and seconds)"),
+                        default=[':%M:%S']).accepts(String, lambda fmt: [fmt])
 
-    seconds      = List(String, default=['%Ss'],
-        help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+    minutes      = List(String,
+                        help=_DATETIME_TICK_FORMATTER_HELP("``minutes``"),
+                        default=[':%M', '%Mm']).accepts(String, lambda fmt: [fmt])
 
-    minsec       = List(String, default=[':%M:%S'],
-        help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+    hourmin      = List(String,
+                        help=_DATETIME_TICK_FORMATTER_HELP("``hourmin`` (for combined hours and minutes)"),
+                        default=['%H:%M']).accepts(String, lambda fmt: [fmt])
 
-    minutes      = List(String, default=[':%M', '%Mm'],
-        help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+    hours        = List(String,
+                        help=_DATETIME_TICK_FORMATTER_HELP("``hours``"),
+                        default=['%Hh', '%H:%M']).accepts(String, lambda fmt: [fmt])
 
-    hourmin      = List(String, default=['%H:%M'],
-        help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+    days         = List(String,
+                        help=_DATETIME_TICK_FORMATTER_HELP("``days``"),
+                        default=['%m/%d', '%a%d']).accepts(String, lambda fmt: [fmt])
 
-    hours        = List(String, default=['%Hh', '%H:%M'],
-        help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+    months       = List(String,
+                        help=_DATETIME_TICK_FORMATTER_HELP("``months``"),
+                        default=['%m/%Y', '%b%y']).accepts(String, lambda fmt: [fmt])
 
-    days         = List(String, default=['%m/%d', '%a%d'],
-        help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
-
-    months       = List(String, default=['%m/%Y', '%b%y'],
-        help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
-
-    years        = List(String, default=['%Y'],
-        help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+    years        = List(String,
+                        help=_DATETIME_TICK_FORMATTER_HELP("``years``"),
+                        default=['%Y']).accepts(String, lambda fmt: [fmt])
 
     __deprecated_attributes__ = ('formats',)
 
     @property
     def formats(self):
+        ''' A dictionary containing formats for all scales.
+
+        THIS PROPERTY IS DEPRECTATED. Use individual DatetimeTickFormatter fields instead.
+
+        '''
         deprecated((0, 12, 4), 'DatetimeTickFormatter.formats', 'individual DatetimeTickFormatter fields')
         return dict(
             microseconds = self.microseconds,

--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -283,6 +283,21 @@ class FuncTickFormatter(TickFormatter):
 
     """)
 
+def DEFAULT_DATETIME_FORMATS():
+    deprecated((0, 12, 4), 'DEFAULT_DATETIME_FORMATS', 'individual DatetimeTickFormatter fields')
+    return {
+        'microseconds': ['%fus'],
+        'milliseconds': ['%3Nms', '%S.%3Ns'],
+        'seconds':      ['%Ss'],
+        'minsec':       [':%M:%S'],
+        'minutes':      [':%M', '%Mm'],
+        'hourmin':      ['%H:%M'],
+        'hours':        ['%Hh', '%H:%M'],
+        'days':         ['%m/%d', '%a%d'],
+        'months':       ['%m/%Y', '%b%y'],
+        'years':        ['%Y'],
+    }
+
 DATETIME_TICK_FORMATTER_HELP="""
     User defined formats for displaying datetime values.
 
@@ -486,22 +501,31 @@ class DatetimeTickFormatter(TickFormatter):
 
     microseconds = List(String, default=['%fus'],
         help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+
     milliseconds = List(String, default=['%3Nms', '%S.%3Ns'],
         help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+
     seconds      = List(String, default=['%Ss'],
         help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+
     minsec       = List(String, default=[':%M:%S'],
         help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+
     minutes      = List(String, default=[':%M', '%Mm'],
         help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+
     hourmin      = List(String, default=['%H:%M'],
         help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+
     hours        = List(String, default=['%Hh', '%H:%M'],
         help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+
     days         = List(String, default=['%m/%d', '%a%d'],
         help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+
     months       = List(String, default=['%m/%Y', '%b%y'],
         help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
+
     years        = List(String, default=['%Y'],
         help=DATETIME_TICK_FORMATTER_HELP).accepts(String, lambda fmt: [fmt])
 
@@ -509,7 +533,7 @@ class DatetimeTickFormatter(TickFormatter):
 
     @property
     def formats(self):
-        deprecated((0, 12, 4), 'DatetimeTickFormatter.formats', 'individual fields')
+        deprecated((0, 12, 4), 'DatetimeTickFormatter.formats', 'individual DatetimeTickFormatter fields')
         return dict(
             microseconds = self.microseconds,
             milliseconds = self.milliseconds,
@@ -524,7 +548,7 @@ class DatetimeTickFormatter(TickFormatter):
 
     @formats.setter
     def formats(self, value):
-        deprecated((0, 12, 4), 'DatetimeTickFormatter.formats', 'individual fields')
+        deprecated((0, 12, 4), 'DatetimeTickFormatter.formats', 'individual DatetimeTickFormatter fields')
         if 'microseconds' in value: self.microseconds = value['microseconds']
         if 'milliseconds' in value: self.milliseconds = value['milliseconds']
         if 'seconds'      in value: self.seconds      = value['seconds']

--- a/bokeh/models/tests/test_glyphs.py
+++ b/bokeh/models/tests/test_glyphs.py
@@ -37,7 +37,7 @@ from bokeh.core.enums import (
     FontStyle,
     TextAlign, TextBaseline,
     Direction,
-    Units, AngleUnits, DatetimeUnits,
+    Units, AngleUnits,
     Dimension,
     Anchor, Location, LegendLocation,
     DashPattern,
@@ -46,7 +46,7 @@ from bokeh.core.enums import (
 
 # fool flake8
 (LineJoin, LineDash, LineCap, FontStyle, TextAlign, TextBaseline, Direction,
- Units, AngleUnits, DatetimeUnits, Dimension, Anchor, Location, LegendLocation,
+ Units, AngleUnits, Dimension, Anchor, Location, LegendLocation,
  DashPattern, ButtonType, MapType, Color, NamedIcon)
 
 

--- a/bokehjs/src/coffee/api/typings/models/formatters.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/formatters.d.ts
@@ -22,7 +22,16 @@ declare namespace Bokeh {
     export var DatetimeTickFormatter: { new(attributes?: IDatetimeTickFormatter, options?: ModelOpts): DatetimeTickFormatter };
     export interface DatetimeTickFormatter extends TickFormatter, IDatetimeTickFormatter {}
     export interface IDatetimeTickFormatter extends ITickFormatter {
-        formats?: Map<Array<string>>; // XXX: key: DatetimeUnits
+        microseconds?: Array<string>;
+        milliseconds?: Array<string>;
+        seconds?:      Array<string>;
+        minsec?:       Array<string>;
+        minutes?:      Array<string>;
+        hourmin?:      Array<string>;
+        hours?:        Array<string>;
+        days?:         Array<string>;
+        months?:       Array<string>;
+        years?:        Array<string>;
     }
 
     export var FuncTickFormatter: { new(attributes?: IFuncTickFormatter, options?: ModelOpts): FuncTickFormatter };

--- a/bokehjs/src/coffee/models/formatters/datetime_tick_formatter.coffee
+++ b/bokehjs/src/coffee/models/formatters/datetime_tick_formatter.coffee
@@ -95,31 +95,17 @@ class DatetimeTickFormatter extends TickFormatter.Model
     # numbers, as we've worked hard to ensure).  Consequently, we adjust the
     # resolution upwards a small amount (less than any possible step in
     # scales) to make the effective boundaries slightly lower.
-    adjusted_resolution_secs = resolution_secs * 1.1
+    adjusted_secs = resolution_secs * 1.1
 
-    if adjusted_resolution_secs < 1e-3
-      str = "microseconds"
-    else if adjusted_resolution_secs < 1.0
-      str = "milliseconds"
-    else if adjusted_resolution_secs < 60
-      if span_secs >= 60
-        str = "minsec"
-      else
-        str = "seconds"
-    else if adjusted_resolution_secs < 3600
-      if span_secs >= 3600
-        str = "hourmin"
-      else
-        str = "minutes"
-    else if adjusted_resolution_secs < 24*3600
-      str = "hours"
-    else if adjusted_resolution_secs < 31*24*3600
-      str = "days"
-    else if adjusted_resolution_secs < 365*24*3600
-      str = "months"
-    else
-      str = "years"
-    return str
+    return switch
+      when adjusted_secs < 1e-3        then "microseconds"
+      when adjusted_secs < 1.0         then "milliseconds"
+      when adjusted_secs < 60          then (if span_secs >= 60   then "minsec"  else "seconds")
+      when adjusted_secs < 3600        then (if span_secs >= 3600 then "hourmin" else "minutes")
+      when adjusted_secs < 24*3600     then "hours"
+      when adjusted_secs < 31*24*3600  then "days"
+      when adjusted_secs < 365*24*3600 then "months"
+      else                                  "years"
 
   doFormat: (ticks, num_labels=null, char_width=null, fill_ratio=0.3, ticker=null) ->
 

--- a/bokehjs/src/coffee/models/formatters/datetime_tick_formatter.coffee
+++ b/bokehjs/src/coffee/models/formatters/datetime_tick_formatter.coffee
@@ -36,24 +36,20 @@ _strftime = (t, format) ->
       return format
     return tz(t, format)
 
-DEFAULT_DATETIME_FORMATS = {
-  'microseconds': ['%fus']
-  'milliseconds': ['%3Nms', '%S.%3Ns']
-  'seconds':      ['%Ss']
-  'minsec':       [':%M:%S']
-  'minutes':      [':%M', '%Mm']
-  'hourmin':      ['%H:%M']
-  'hours':        ['%Hh', '%H:%M']
-  'days':         ['%m/%d', '%a%d']
-  'months':       ['%m/%Y', '%b%y']
-  'years':        ['%Y']
-}
-
 class DatetimeTickFormatter extends TickFormatter.Model
   type: 'DatetimeTickFormatter'
 
   @define {
-    formats: [ p.Any, DEFAULT_DATETIME_FORMATS ] # TODO (bev)
+    microseconds: [ p.Array, ['%fus'] ]
+    milliseconds: [ p.Array, ['%3Nms', '%S.%3Ns'] ]
+    seconds:      [ p.Array, ['%Ss'] ]
+    minsec:       [ p.Array, [':%M:%S'] ]
+    minutes:      [ p.Array, [':%M', '%Mm'] ]
+    hourmin:      [ p.Array, ['%H:%M'] ]
+    hours:        [ p.Array, ['%Hh', '%H:%M'] ]
+    days:         [ p.Array, ['%m/%d', '%a%d'] ]
+    months:       [ p.Array, ['%m/%Y', '%b%y'] ]
+    years:        [ p.Array, ['%Y'] ]
   }
 
   # Labels of time units, from finest to coarsest.
@@ -71,12 +67,24 @@ class DatetimeTickFormatter extends TickFormatter.Model
 
   _update_width_formats: () ->
     now = tz(new Date())
-    @_width_formats = {}
 
-    for fmt_name, fmt_strings of @formats
+    _widths = (fmt_strings) ->
       sizes = (_strftime(now, fmt_string).length for fmt_string in fmt_strings)
       sorted = _.sortBy(_.zip(sizes, fmt_strings), ([size, fmt]) -> size)
-      @_width_formats[fmt_name] = _.zip.apply(_, sorted)
+      return _.zip.apply(_, sorted)
+
+    @_width_formats = {
+      microseconds: _widths(@microseconds)
+      milliseconds: _widths(@milliseconds)
+      seconds:      _widths(@seconds)
+      minsec:       _widths(@minsec)
+      minutes:      _widths(@minutes)
+      hourmin:      _widths(@hourmin)
+      hours:        _widths(@hours)
+      days:         _widths(@days)
+      months:       _widths(@months)
+      years:        _widths(@years)
+    }
 
   # FIXME There is some unfortunate flicker when panning/zooming near the
   # span boundaries.

--- a/examples/models/daylight.py
+++ b/examples/models/daylight.py
@@ -75,7 +75,7 @@ sunset_line_renderer = plot.add_glyph(source, sunset_line)
 text = Text(x="dates", y="times", text="texts", text_align="center")
 plot.add_glyph(text_source, text)
 
-xformatter = DatetimeTickFormatter(formats=dict(months=["%b %Y"]))
+xformatter = DatetimeTickFormatter(months="%b %Y")
 xaxis = DatetimeAxis(formatter=xformatter)
 plot.add_layout(xaxis, 'below')
 


### PR DESCRIPTION
`formats` was deprecated and now `DatetimeTickFormatter` has all `format`'s keys as its properties. The second commit isn't strictly necessary, but shows usage of "expression statements" (switch and if) to produce more compact and, I think, more readable code.

fixes #5234