### PR TITLE
Fix CSV Reading of Samples for Py 3

### DIFF
--- a/bokeh/sampledata/__init__.py
+++ b/bokeh/sampledata/__init__.py
@@ -128,4 +128,3 @@ def _open_csv_file(filename):
         return open(filename, 'rb')
     else:
         return open(filename, 'r', newline='', encoding='utf8')
-

--- a/bokeh/sampledata/__init__.py
+++ b/bokeh/sampledata/__init__.py
@@ -4,6 +4,7 @@ from os import mkdir, remove
 from os.path import exists, expanduser, isdir, join, splitext
 from sys import stdout
 from zipfile import ZipFile
+import six
 from six.moves.urllib.request import urlopen
 
 def _bokeh_dir(create=False):
@@ -120,3 +121,10 @@ def _getfile(base_url, file_name, data_dir, progress=True):
             zip_file.extract(real_name, data_dir)
 
         remove(file_path)
+
+def _open_csv_file(filename):
+    # csv differs in Python 2.x and Python 3.x. Open the file differently in each.
+    if six.PY2:
+        return open(filename, 'rb')
+    else:
+        return open(filename, 'r', newline='', encoding='utf8')

--- a/bokeh/sampledata/__init__.py
+++ b/bokeh/sampledata/__init__.py
@@ -128,3 +128,4 @@ def _open_csv_file(filename):
         return open(filename, 'rb')
     else:
         return open(filename, 'r', newline='', encoding='utf8')
+

--- a/bokeh/sampledata/stocks.py
+++ b/bokeh/sampledata/stocks.py
@@ -29,7 +29,14 @@ def _load_stock(filename):
         'volume' : [],
         'adj_close': [],
     }
-    with open(filename) as f:
+
+    # csv differs in Python 2.x and Python 3.x. Open the file differently in each.
+    if sys.version_info[0] < 3:
+        f = open(filename, 'rb')
+    else:
+        f = open(filename, 'r', newline='', encoding='utf8')
+
+    with f:
         next(f)
         reader = csv.reader(f, delimiter=',')
         for row in reader:

--- a/bokeh/sampledata/stocks.py
+++ b/bokeh/sampledata/stocks.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 
 import csv
 from os.path import exists, isfile, join
+import six
 import sys
 from . import _data_dir
 
@@ -31,7 +32,7 @@ def _load_stock(filename):
     }
 
     # csv differs in Python 2.x and Python 3.x. Open the file differently in each.
-    if sys.version_info[0] < 3:
+    if six.PY2:
         f = open(filename, 'rb')
     else:
         f = open(filename, 'r', newline='', encoding='utf8')

--- a/bokeh/sampledata/stocks.py
+++ b/bokeh/sampledata/stocks.py
@@ -16,9 +16,9 @@ from __future__ import absolute_import
 
 import csv
 from os.path import exists, isfile, join
-import six
 import sys
 from . import _data_dir
+from . import _open_csv_file
 
 def _load_stock(filename):
     data = {
@@ -30,14 +30,7 @@ def _load_stock(filename):
         'volume' : [],
         'adj_close': [],
     }
-
-    # csv differs in Python 2.x and Python 3.x. Open the file differently in each.
-    if six.PY2:
-        f = open(filename, 'rb')
-    else:
-        f = open(filename, 'r', newline='', encoding='utf8')
-
-    with f:
+    with _open_csv_file(filename) as f:
         next(f)
         reader = csv.reader(f, delimiter=',')
         for row in reader:

--- a/bokeh/sampledata/unemployment.py
+++ b/bokeh/sampledata/unemployment.py
@@ -7,7 +7,7 @@ unemployment rate (2009) as the associated value.
 from __future__ import absolute_import
 
 import csv
-import sys
+import six
 from os.path import join
 from . import _data_dir
 
@@ -17,7 +17,7 @@ data = {}
 
 # csv differs in Python 2.x and Python 3.x. Open the file differently in each.
 filename = join(data_dir, 'unemployment09.csv')
-if sys.version_info[0] < 3:
+if six.PY2:
     f = open(filename, 'rb')
 else:
     f = open(filename, 'r', newline='', encoding='utf8')

--- a/bokeh/sampledata/unemployment.py
+++ b/bokeh/sampledata/unemployment.py
@@ -7,13 +7,22 @@ unemployment rate (2009) as the associated value.
 from __future__ import absolute_import
 
 import csv
+import sys
 from os.path import join
 from . import _data_dir
 
 data_dir = _data_dir()
 
 data = {}
-with open(join(data_dir, 'unemployment09.csv')) as f:
+
+# csv differs in Python 2.x and Python 3.x. Open the file differently in each.
+filename = join(data_dir, 'unemployment09.csv')
+if sys.version_info[0] < 3:
+    f = open(filename, 'rb')
+else:
+    f = open(filename, 'r', newline='', encoding='utf8')
+
+with f:
     reader = csv.reader(f, delimiter=',', quotechar='"')
     for row in reader:
         dummy, state_id, county_id, dumm, dummy, dummy, dummy, dummy, rate = row

--- a/bokeh/sampledata/unemployment.py
+++ b/bokeh/sampledata/unemployment.py
@@ -7,22 +7,14 @@ unemployment rate (2009) as the associated value.
 from __future__ import absolute_import
 
 import csv
-import six
 from os.path import join
 from . import _data_dir
+from . import _open_csv_file
 
 data_dir = _data_dir()
 
 data = {}
-
-# csv differs in Python 2.x and Python 3.x. Open the file differently in each.
-filename = join(data_dir, 'unemployment09.csv')
-if six.PY2:
-    f = open(filename, 'rb')
-else:
-    f = open(filename, 'r', newline='', encoding='utf8')
-
-with f:
+with _open_csv_file(join(data_dir, 'unemployment09.csv')) as f:
     reader = csv.reader(f, delimiter=',', quotechar='"')
     for row in reader:
         dummy, state_id, county_id, dumm, dummy, dummy, dummy, dummy, rate = row

--- a/bokeh/sampledata/us_counties.py
+++ b/bokeh/sampledata/us_counties.py
@@ -10,8 +10,8 @@ associated value:
 '''
 from __future__ import absolute_import
 
-import io
 import csv
+import sys
 import xml.etree.cElementTree as et
 from os.path import join
 from . import _data_dir
@@ -22,7 +22,14 @@ nan = float('NaN')
 
 data = {}
 
-with io.open(join(data_dir, 'US_Counties.csv'), encoding = 'utf-8') as f:
+
+# csv differs in Python 2.x and Python 3.x. Open the file differently in each.
+if sys.version_info[0] < 3: 
+    f = open(join(data_dir, 'US_Counties.csv'), 'rb')
+else:
+    f = open(join(data_dir, 'US_Counties.csv'), 'r', newline='', encoding='utf8')
+
+with  f:
     next(f)
     reader = csv.reader(f, delimiter=',', quotechar='"')
     for row in reader:

--- a/bokeh/sampledata/us_counties.py
+++ b/bokeh/sampledata/us_counties.py
@@ -22,12 +22,12 @@ nan = float('NaN')
 
 data = {}
 
-
 # csv differs in Python 2.x and Python 3.x. Open the file differently in each.
-if sys.version_info[0] < 3: 
-    f = open(join(data_dir, 'US_Counties.csv'), 'rb')
+filename = join(data_dir, 'US_Counties.csv')
+if sys.version_info[0] < 3:
+    f = open(filename, 'rb')
 else:
-    f = open(join(data_dir, 'US_Counties.csv'), 'r', newline='', encoding='utf8')
+    f = open(filename, 'r', newline='', encoding='utf8')
 
 with  f:
     next(f)

--- a/bokeh/sampledata/us_counties.py
+++ b/bokeh/sampledata/us_counties.py
@@ -10,6 +10,7 @@ associated value:
 '''
 from __future__ import absolute_import
 
+import io
 import csv
 import xml.etree.cElementTree as et
 from os.path import join
@@ -20,7 +21,8 @@ data_dir = _data_dir()
 nan = float('NaN')
 
 data = {}
-with open(join(data_dir, 'US_Counties.csv')) as f:
+
+with io.open(join(data_dir, 'US_Counties.csv'), encoding = 'utf-8') as f:
     next(f)
     reader = csv.reader(f, delimiter=',', quotechar='"')
     for row in reader:

--- a/bokeh/sampledata/us_counties.py
+++ b/bokeh/sampledata/us_counties.py
@@ -11,25 +11,17 @@ associated value:
 from __future__ import absolute_import
 
 import csv
-import six
 import xml.etree.cElementTree as et
 from os.path import join
 from . import _data_dir
+from . import _open_csv_file
 
 data_dir = _data_dir()
 
 nan = float('NaN')
 
 data = {}
-
-# csv differs in Python 2.x and Python 3.x. Open the file differently in each.
-filename = join(data_dir, 'US_Counties.csv')
-if six.PY2:
-    f = open(filename, 'rb')
-else:
-    f = open(filename, 'r', newline='', encoding='utf8')
-
-with  f:
+with _open_csv_file(join(data_dir, 'US_Counties.csv')) as f:
     next(f)
     reader = csv.reader(f, delimiter=',', quotechar='"')
     for row in reader:

--- a/bokeh/sampledata/us_counties.py
+++ b/bokeh/sampledata/us_counties.py
@@ -11,7 +11,7 @@ associated value:
 from __future__ import absolute_import
 
 import csv
-import sys
+import six
 import xml.etree.cElementTree as et
 from os.path import join
 from . import _data_dir
@@ -24,7 +24,7 @@ data = {}
 
 # csv differs in Python 2.x and Python 3.x. Open the file differently in each.
 filename = join(data_dir, 'US_Counties.csv')
-if sys.version_info[0] < 3:
+if six.PY2:
     f = open(filename, 'rb')
 else:
     f = open(filename, 'r', newline='', encoding='utf8')


### PR DESCRIPTION
Fixes Issue #5029 where downloading sample US_Counties data on Ubuntu 16 with an ansi preferred local encountered issues decoding the csv encoded as utf-8.

Replaces Rejected/Abandoned PR #5030