### PR TITLE
Bryanv/4926 aload static

### DIFF
--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -104,13 +104,6 @@ SOURCE_TEMPLATE = jinja2.Template(u"""
 """)
 
 
-SCRIPT_TEMPLATE = jinja2.Template(u"""
-<div class="bk-root">
-    {{ script|indent(4) }}
-</div>
-""")
-
-
 class bokeh_plot(nodes.General, nodes.Element):
     pass
 
@@ -299,8 +292,7 @@ def html_visit_bokeh_plot(self, node):
             with open(dest_path, "w") as f:
                 f.write(js)
 
-        html = SCRIPT_TEMPLATE.render(script=script)
-        self.body.append(html)
+        self.body.append(script)
     except Exception as e:
         raise SphinxError("Unable to generate Bokeh plot at %s:%d:%s" % (node['rst_source'], node['rst_lineno'], e))
     else:

--- a/bokehjs/src/coffee/embed.coffee
+++ b/bokehjs/src/coffee/embed.coffee
@@ -86,7 +86,7 @@ add_model_static = (element, model_id, doc) ->
   if not model?
     throw new Error("Model #{model_id} was not in document #{doc}")
   view = _create_view(model)
-  _.delay(-> $(element).replaceWith(view.$el))
+  _.delay(-> $(element).append(view.$el))
 
 # Fill element with the roots from doc
 add_document_static = (element, doc, use_for_title) ->

--- a/bokehjs/src/coffee/embed.coffee
+++ b/bokehjs/src/coffee/embed.coffee
@@ -86,7 +86,7 @@ add_model_static = (element, model_id, doc) ->
   if not model?
     throw new Error("Model #{model_id} was not in document #{doc}")
   view = _create_view(model)
-  _.delay(-> $(element).append(view.$el))
+  _.delay(-> $(element).replaceWith(view.$el))
 
 # Fill element with the roots from doc
 add_document_static = (element, doc, use_for_title) ->
@@ -181,7 +181,9 @@ embed_items = (docs_json, render_items, websocket_url=null) ->
       fill_render_item_from_script_tag(elem, item)
       container = $('<div>', {class: BOKEH_ROOT})
       elem.replaceWith(container)
-      elem = container
+      child = $('<div>')
+      container.append(child)
+      elem = child
 
     use_for_title = item.use_for_title? and item.use_for_title
 


### PR DESCRIPTION
issues: fixes #4926

The problem was that the function that got called for embedding static plots was passed the `bk-root` div but then called `replaceWith`. Changing to `append` fixes. The custom server example was failing before. After, with `BOKEH_RESOURCES=server` it looks correct:
<img width="609" alt="screen shot 2016-10-04 at 10 21 29 pm" src="https://cloud.githubusercontent.com/assets/1078448/19100048/2135ffb0-8a81-11e6-934f-0188619f13a5.png">
