### PR TITLE
Fix broken responsive layouts on window resize

### DIFF
--- a/bokehjs/src/coffee/document.coffee
+++ b/bokehjs/src/coffee/document.coffee
@@ -102,21 +102,24 @@ class Document
   solver: () ->
     @_solver
 
-  resize: (width=null, height=null) ->
+  resize: (jquery_event, width=null, height=null) ->
     # Notes on resizing (xx:yy means event yy on object xx):
     # window:event -> document.resize() -> solver:resize
     #   -> LayoutDOM.render()
     #   -> PlotCanvas.resize() -> solver:update_layout
 
+    # Note: JQuery.proxy passes the resize event as the first argument to the
+    # resize method. We don't currently use that argument for anything, but
+    # need it as a positional arg.
+
     # Ideally the solver would  settle in one pass (can that be done?),
     # but it currently needs two passes to get it right.
     # Seems to be needed everywhere on initialization, and on Windows
     # it seems necessary on each Draw
-    @_resize(width=width, height=height)
-    @_resize(width=width, height=height)
+    @_resize(width, height)
+    @_resize(width, height)
 
   _resize: (width=null, height=null) ->
-
     for root in @_roots
       if root.layoutable isnt true
         continue

--- a/bokehjs/test/document.coffee
+++ b/bokehjs/test/document.coffee
@@ -969,7 +969,7 @@ describe "Document", ->
     spy = sinon.spy(s, 'suggest_value')
     root_model = new ModelWithConstrainedVariables({sizing_mode: "scale_both"})
     d.add_root(root_model)
-    d.resize(width=200, height=300)
+    d.resize(null, 200, 300)
     expect(spy.callCount).is.equal(4)
     expect(spy.calledWithExactly(d._doc_width, 200)).is.true
     expect(spy.calledWithExactly(d._doc_height, 300)).is.true


### PR DESCRIPTION
In #5205 we added support for width/height argument to the document.resize method, so that we could suggest resize sizes in non-window layouts (i.e. jupyterlab (phosphorjs) panels)). This causes a regression where ``jquery.proxy`` would pass the jquery event as an argument to the resize function as the first arg (this didn't fail previous because JS is fun and ignores extra arguments to functions signatures)

This PR adds a positional argument to placehold the jquery event

- [x] issues: fixes #5294 
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)