### PR TITLE
Append conda channels to wrangle channel precendence

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -11,7 +11,6 @@ build:
 extra:
   channels:
     - bokeh
-    - javascript
     - conda-forge
 
 requirements:

--- a/scripts/travis_install
+++ b/scripts/travis_install
@@ -20,9 +20,9 @@ python -V
 
 echo -e "$PINNED_PKGS" > /home/travis/miniconda/conda-meta/pinned
 
-conda config --remove channels defaults
 conda config --add channels conda-forge
 conda config --add channels bokeh
+conda config --remove channels defaults
 conda config --add channels defaults
 
 DEPS_TRAVIS="python=$TRAVIS_PYTHON_VERSION conda=4.1.11 conda-env=2.5.2 conda-build=1.21.14"

--- a/scripts/travis_install
+++ b/scripts/travis_install
@@ -25,7 +25,7 @@ conda install --yes $DEPS_TRAVIS
 
 conda config --append channels bokeh
 conda config --append channels conda-forge
-echo "conda config $(conda config --show-sources)"
+echo "conda config: $(conda config --get channels)"
 
 CONDA_PY="${TRAVIS_PYTHON_VERSION/./}" conda build --quiet --no-test conda.recipe
 

--- a/scripts/travis_install
+++ b/scripts/travis_install
@@ -20,8 +20,10 @@ python -V
 
 echo -e "$PINNED_PKGS" > /home/travis/miniconda/conda-meta/pinned
 
-conda config --add channels bokeh
+conda config --remove channels defaults
 conda config --add channels conda-forge
+conda config --add channels bokeh
+conda config --add channels defaults
 
 DEPS_TRAVIS="python=$TRAVIS_PYTHON_VERSION conda=4.1.11 conda-env=2.5.2 conda-build=1.21.14"
 conda install --yes $DEPS_TRAVIS

--- a/scripts/travis_install
+++ b/scripts/travis_install
@@ -25,7 +25,7 @@ conda install --yes $DEPS_TRAVIS
 
 conda config --append channels bokeh
 conda config --append channels conda-forge
-echo "conda config: $(conda config --get channels)"
+conda config --get channels
 
 CONDA_PY="${TRAVIS_PYTHON_VERSION/./}" conda build --quiet --no-test conda.recipe
 

--- a/scripts/travis_install
+++ b/scripts/travis_install
@@ -23,10 +23,9 @@ echo -e "$PINNED_PKGS" > /home/travis/miniconda/conda-meta/pinned
 DEPS_TRAVIS="python=$TRAVIS_PYTHON_VERSION conda=4.1.11 conda-env=2.5.2 conda-build=1.21.14"
 conda install --yes $DEPS_TRAVIS
 
-conda config --add channels conda-forge
-conda config --add channels bokeh
-conda config --remove channels defaults
-conda config --add channels defaults
+conda config --append channels bokeh
+conda config --append channels conda-forge
+echo "conda config $(conda config --show-sources)"
 
 CONDA_PY="${TRAVIS_PYTHON_VERSION/./}" conda build --quiet --no-test conda.recipe
 

--- a/scripts/travis_install
+++ b/scripts/travis_install
@@ -20,13 +20,13 @@ python -V
 
 echo -e "$PINNED_PKGS" > /home/travis/miniconda/conda-meta/pinned
 
+DEPS_TRAVIS="python=$TRAVIS_PYTHON_VERSION conda=4.1.11 conda-env=2.5.2 conda-build=1.21.14"
+conda install --yes $DEPS_TRAVIS
+
 conda config --add channels conda-forge
 conda config --add channels bokeh
 conda config --remove channels defaults
 conda config --add channels defaults
-
-DEPS_TRAVIS="python=$TRAVIS_PYTHON_VERSION conda=4.1.11 conda-env=2.5.2 conda-build=1.21.14"
-conda install --yes $DEPS_TRAVIS
 
 CONDA_PY="${TRAVIS_PYTHON_VERSION/./}" conda build --quiet --no-test conda.recipe
 


### PR DESCRIPTION
- [x] issues: fixes #5299 #5105

This PR:
* Appends (instead of prepends via the --add arg) the bokeh and conda-forge channels so that our channel precedence (high to low) is "defaults, bokeh, conda-forge" instead of "conda-forge,bokeh,default".
  * This appears to reduce the CI unit test matrix times to 5:45-7:00min (as opposed to over 9min). It's unclear if the defaults CDN is faster or we're installing fewer dependencies. [ninja edit: it seems to be both]
* Also removes the (unused) javascript channel from our meta.yaml (we're now installing nodejs from conda-forge)


