### PR TITLE
Fix Gapminder on Py2 / handle source codings better

### DIFF
--- a/bokeh/application/handlers/script.py
+++ b/bokeh/application/handlers/script.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, print_function
 
-import codecs
-
 from .code import CodeHandler
 
 class ScriptHandler(CodeHandler):
@@ -21,7 +19,7 @@ class ScriptHandler(CodeHandler):
             raise ValueError('Must pass a filename to ScriptHandler')
         filename = kwargs['filename']
 
-        with codecs.open(filename, 'r', 'UTF-8') as f:
+        with open(filename, 'r') as f:
             kwargs['source'] = f.read()
 
         super(ScriptHandler, self).__init__(*args, **kwargs)

--- a/bokeh/application/handlers/tests/test_script.py
+++ b/bokeh/application/handlers/tests/test_script.py
@@ -22,3 +22,18 @@ class TestScriptHandler(unittest.TestCase):
         assert result['handler']._runner.path == result['filename']
         assert result['handler']._runner.source == source
         assert not doc.roots
+
+    def test_runner_script_with_encoding(self):
+        doc = Document()
+        source = "# -*- coding: utf-8 -*-\nimport os"
+        result = {}
+        def load(filename):
+            handler = ScriptHandler(filename=filename)
+            handler.modify_document(doc)
+            result['handler'] = handler
+            result['filename'] = filename
+        with_file_contents(source, load)
+
+        assert result['handler'].error is None
+        assert result['handler'].failed is False
+        assert not doc.roots

--- a/bokeh/sampledata/gapminder.py
+++ b/bokeh/sampledata/gapminder.py
@@ -30,7 +30,7 @@ for dataset in datasets:
         setattr(
             sys.modules[__name__],
             dataset,
-            pd.read_csv(filename, index_col='Country')
+            pd.read_csv(filename, index_col='Country', encoding='utf-8')
         )
     except (IOError, OSError):
         raise RuntimeError('Could not load gapminder data file "%s". Please execute bokeh.sampledata.download()' % filename)

--- a/tests/examples/examples.yaml
+++ b/tests/examples/examples.yaml
@@ -3,6 +3,7 @@
 - path: "custom/gears"
   skip: ["gear.py"]
 - path: "compat"
+  skip: ["ggplot_density.py"]
 - path: "charts/file"
   type: file
 - path: "howto/charts"


### PR DESCRIPTION
- [x] issues: fixes #5302
- [x] tests added / passed

@birdsarah @mattpap @canavandl @havocp would appreciate quick eyes on this. 

AFAICT the correct thing to do is to read the scripts in as bytes, then pass along any coding comment to `compile` to deal with, instead of using `codecs.open` to always read in `utf-8` (then we have to try and strip out coding comments which seems unreliable)

Additionally, gapminder data has unicode characters, so I added the encoding to `read_csv`. 

With this changes gapminder runs without error on py3 and py3