### PR TITLE
Support special colors on image glyph

### DIFF
--- a/bokeh/models/mappers.py
+++ b/bokeh/models/mappers.py
@@ -25,7 +25,7 @@ class ColorMapper(Model):
     any of the palettes shown in :ref:`bokeh.palettes`.
     """).accepts(Enum(Palette), lambda pal: getattr(palettes, pal))
 
-    nan_color = Color(default="#808080", help="""
+    nan_color = Color(default="gray", help="""
     Color to be used if data is NaN. Default: 'gray'
     """)
 

--- a/bokeh/models/mappers.py
+++ b/bokeh/models/mappers.py
@@ -25,7 +25,7 @@ class ColorMapper(Model):
     any of the palettes shown in :ref:`bokeh.palettes`.
     """).accepts(Enum(Palette), lambda pal: getattr(palettes, pal))
 
-    nan_color = Color(default="gray", help="""
+    nan_color = Color(default="#808080", help="""
     Color to be used if data is NaN. Default: 'gray'
     """)
 

--- a/bokehjs/src/coffee/models/glyphs/image.coffee
+++ b/bokehjs/src/coffee/models/glyphs/image.coffee
@@ -46,7 +46,7 @@ export class ImageView extends GlyphView
         img = @_image[i]
       else
         img = _.flatten(@_image[i])
-      buf = cmap.v_map_screen(img)
+      buf = cmap.v_map_screen(img, true)
       buf8 = new Uint8ClampedArray(buf)
       image_data.data.set(buf8)
       ctx.putImageData(image_data, 0, 0)

--- a/bokehjs/src/coffee/models/mappers/color_mapper.coffee
+++ b/bokehjs/src/coffee/models/mappers/color_mapper.coffee
@@ -9,7 +9,7 @@ export class ColorMapper extends Model
 
   @define {
       palette:       [ p.Any              ] # TODO (bev)
-      nan_color:     [ p.Color, "gray"    ]
+      nan_color:     [ p.Color, "#808080" ]
     }
 
   initialize: (attrs, options) ->
@@ -22,7 +22,7 @@ export class ColorMapper extends Model
     )
 
   v_map_screen: (data) ->
-    values = @_get_values(data, @_palette)
+    values = @_get_values(data, @_palette, true)
     buf = new ArrayBuffer(data.length * 4)
     color = new Uint32Array(buf)
 
@@ -49,7 +49,7 @@ export class ColorMapper extends Model
     values = @_get_values(xs, @palette)
     return values
 
-  _get_values: (data, palette) ->
+  _get_values: (data, palette, image_glyph=false) ->
     # Should be defined by subclass
     return []
 

--- a/bokehjs/src/coffee/models/mappers/color_mapper.coffee
+++ b/bokehjs/src/coffee/models/mappers/color_mapper.coffee
@@ -21,8 +21,8 @@ export class ColorMapper extends Model
       @_palette = @_build_palette(@palette)
     )
 
-  v_map_screen: (data) ->
-    values = @_get_values(data, @_palette, true)
+  v_map_screen: (data, image_glyph=false) ->
+    values = @_get_values(data, @_palette, image_glyph)
     buf = new ArrayBuffer(data.length * 4)
     color = new Uint32Array(buf)
 

--- a/bokehjs/src/coffee/models/mappers/color_mapper.coffee
+++ b/bokehjs/src/coffee/models/mappers/color_mapper.coffee
@@ -9,7 +9,7 @@ export class ColorMapper extends Model
 
   @define {
       palette:       [ p.Any              ] # TODO (bev)
-      nan_color:     [ p.Color, "#808080" ]
+      nan_color:     [ p.Color, "gray"    ]
     }
 
   initialize: (attrs, options) ->

--- a/bokehjs/src/coffee/models/mappers/linear_color_mapper.coffee
+++ b/bokehjs/src/coffee/models/mappers/linear_color_mapper.coffee
@@ -27,6 +27,8 @@ export class LinearColorMapper extends ColorMapper
     values = []
 
     nan_color = if image_glyph then @_nan_color else @nan_color
+    low_color = if image_glyph then @_low_color else @low_color
+    high_color = if image_glyph then @_high_color else @high_color
 
     norm_factor = 1 / (high - low)
     normed_interval = 1 / palette.length
@@ -47,13 +49,11 @@ export class LinearColorMapper extends ColorMapper
       key = Math.floor(normed_d / normed_interval)
       if key < 0
         if @low_color?
-          low_color = if image_glyph then @_low_color else @low_color
           values.push(low_color)
         else
           values.push(palette[0])
       else if key > max_key
         if @high_color?
-          high_color = if image_glyph then @_high_color else @high_color
           values.push(high_color)
         else
           values.push(palette[max_key])

--- a/bokehjs/src/coffee/models/mappers/linear_color_mapper.coffee
+++ b/bokehjs/src/coffee/models/mappers/linear_color_mapper.coffee
@@ -1,6 +1,7 @@
 import * as _ from "underscore"
 import * as p from "../../core/properties"
 
+import {color2hex} from "../../core/util/color"
 import {ColorMapper} from "./color_mapper"
 
 export class LinearColorMapper extends ColorMapper
@@ -13,13 +14,19 @@ export class LinearColorMapper extends ColorMapper
       low_color:  [ p.Color  ]
     }
 
+  initialize: (attrs, options) ->
+    super(attrs, options)
+    @_nan_color = @_build_palette([color2hex(@nan_color)])[0]
+    @_high_color = if @high_color? then @_build_palette([color2hex(@high_color)])[0]
+    @_low_color = if @low_color? then @_build_palette([color2hex(@low_color)])[0]
+
   _get_values: (data, palette, image_glyph=false) ->
     low = @low ? _.min(data)
     high = @high ? _.max(data)
     max_key = palette.length - 1
     values = []
 
-    nan_color = if image_glyph then @_build_palette([@nan_color])[0] else @nan_color
+    nan_color = if image_glyph then @_nan_color else @nan_color
 
     norm_factor = 1 / (high - low)
     normed_interval = 1 / palette.length
@@ -40,14 +47,13 @@ export class LinearColorMapper extends ColorMapper
       key = Math.floor(normed_d / normed_interval)
       if key < 0
         if @low_color?
-          # low_color = if image_glyph then @_build_palette([@low_color])[0] else @low_color
-          low_color = 4276128512
+          low_color = if image_glyph then @_low_color else @low_color
           values.push(low_color)
         else
           values.push(palette[0])
       else if key > max_key
         if @high_color?
-          high_color = if image_glyph then @_build_palette([@high_color])[0] else @high_color
+          high_color = if image_glyph then @_high_color else @high_color
           values.push(high_color)
         else
           values.push(palette[max_key])

--- a/bokehjs/src/coffee/models/mappers/linear_color_mapper.coffee
+++ b/bokehjs/src/coffee/models/mappers/linear_color_mapper.coffee
@@ -13,18 +13,20 @@ export class LinearColorMapper extends ColorMapper
       low_color:  [ p.Color  ]
     }
 
-  _get_values: (data, palette) ->
+  _get_values: (data, palette, image_glyph=false) ->
     low = @low ? _.min(data)
     high = @high ? _.max(data)
     max_key = palette.length - 1
     values = []
+
+    nan_color = if image_glyph then @_build_palette([@nan_color])[0] else @nan_color
 
     norm_factor = 1 / (high - low)
     normed_interval = 1 / palette.length
 
     for d in data
       if isNaN(d)
-        values.push(@nan_color)
+        values.push(nan_color)
         continue
 
       # This handles the edge case where d == high, since the code below maps
@@ -38,12 +40,15 @@ export class LinearColorMapper extends ColorMapper
       key = Math.floor(normed_d / normed_interval)
       if key < 0
         if @low_color?
-          values.push(@low_color)
+          # low_color = if image_glyph then @_build_palette([@low_color])[0] else @low_color
+          low_color = 4276128512
+          values.push(low_color)
         else
           values.push(palette[0])
       else if key > max_key
         if @high_color?
-          values.push(@high_color)
+          high_color = if image_glyph then @_build_palette([@high_color])[0] else @high_color
+          values.push(high_color)
         else
           values.push(palette[max_key])
       else

--- a/bokehjs/src/coffee/models/mappers/log_color_mapper.coffee
+++ b/bokehjs/src/coffee/models/mappers/log_color_mapper.coffee
@@ -35,12 +35,14 @@ export class LogColorMapper extends ColorMapper
     for d in data
       # Check NaN
       if isNaN(d)
-        values.push(@nan_color)
+        nan_color = if image_glyph then @_nan_color else @nan_color
+        values.push(nan_color)
         continue
 
       if d > high
         if @high_color?
-          values.push(@high_color)
+          high_color = if image_glyph then @_high_color else @high_color
+          values.push(high_color)
         else
           values.push(palette[max_key])
         continue
@@ -54,7 +56,8 @@ export class LogColorMapper extends ColorMapper
 
       if d < low
         if @low_color?
-          values.push(@low_color)
+          low_color = if image_glyph then @_low_color else @low_color
+          values.push(low_color)
         else
           values.push(palette[0])
         continue

--- a/bokehjs/src/coffee/models/mappers/log_color_mapper.coffee
+++ b/bokehjs/src/coffee/models/mappers/log_color_mapper.coffee
@@ -32,16 +32,18 @@ export class LogColorMapper extends ColorMapper
     max_key = palette.length - 1
     values = []
 
+    nan_color = if image_glyph then @_nan_color else @nan_color
+    high_color = if image_glyph then @_high_color else @high_color
+    low_color = if image_glyph then @_low_color else @low_color
+
     for d in data
       # Check NaN
       if isNaN(d)
-        nan_color = if image_glyph then @_nan_color else @nan_color
         values.push(nan_color)
         continue
 
       if d > high
         if @high_color?
-          high_color = if image_glyph then @_high_color else @high_color
           values.push(high_color)
         else
           values.push(palette[max_key])
@@ -56,7 +58,6 @@ export class LogColorMapper extends ColorMapper
 
       if d < low
         if @low_color?
-          low_color = if image_glyph then @_low_color else @low_color
           values.push(low_color)
         else
           values.push(palette[0])

--- a/bokehjs/src/coffee/models/mappers/log_color_mapper.coffee
+++ b/bokehjs/src/coffee/models/mappers/log_color_mapper.coffee
@@ -17,7 +17,7 @@ export class LogColorMapper extends ColorMapper
       low_color:  [ p.Color  ]
     }
 
-  _get_values: (data, palette) ->
+  _get_values: (data, palette, image_glyph=false) ->
     n = palette.length
     low = @low ? _.min(data)
     high = @high ? _.max(data)

--- a/bokehjs/src/coffee/models/mappers/log_color_mapper.coffee
+++ b/bokehjs/src/coffee/models/mappers/log_color_mapper.coffee
@@ -1,6 +1,7 @@
 import * as _ from "underscore"
 import * as p from "../../core/properties"
 
+import {color2hex} from "../../core/util/color"
 import {ColorMapper} from "./color_mapper"
 
 # Math.log1p() is not supported by any version of IE, so let's use a polyfill based on
@@ -16,6 +17,12 @@ export class LogColorMapper extends ColorMapper
       high_color: [ p.Color  ]
       low_color:  [ p.Color  ]
     }
+
+  initialize: (attrs, options) ->
+    super(attrs, options)
+    @_nan_color = @_build_palette([color2hex(@nan_color)])[0]
+    @_high_color = if @high_color? then @_build_palette([color2hex(@high_color)])[0]
+    @_low_color = if @low_color? then @_build_palette([color2hex(@low_color)])[0]
 
   _get_values: (data, palette, image_glyph=false) ->
     n = palette.length

--- a/bokehjs/test/models/mappers/linear_color_mapper.coffee
+++ b/bokehjs/test/models/mappers/linear_color_mapper.coffee
@@ -5,6 +5,28 @@ utils = require "../../utils"
 
 describe "LinearColorMapper module", ->
 
+  describe "LinearColorMapper initialization", ->
+
+    it "Should set _nan_color, _low_color, _high_color attributes as ints", ->
+
+      color_mapper = new LinearColorMapper({
+        palette: ["red", "green", "blue"]
+        nan_color: "cadetblue"
+        low_color: "rgb(95,158,160)"
+        high_color: "#5F9EA0"
+        })
+
+      expect(color_mapper._nan_color).to.be.equal(6266528)
+      expect(color_mapper._low_color).to.be.equal(6266528)
+      expect(color_mapper._high_color).to.be.equal(6266528)
+
+    it "If unset _low_color, _high_color should be undefined", ->
+      color_mapper = new LinearColorMapper({
+        palette: ["red", "green", "blue"]
+        })
+      expect(color_mapper._low_color).to.be.undefined
+      expect(color_mapper._high_color).to.be.undefined
+
   describe "LinearColorMapper._get_values method", ->
 
     it "Should map values along linear scale with high/low unset", ->
@@ -115,3 +137,17 @@ describe "LinearColorMapper module", ->
 
       vals = color_mapper._get_values([-1, 0, 1, 2, 3], palette)
       expect(vals).to.be.deep.equal(["pink", "red", "green", "blue", "orange"])
+
+  describe "LinearColorMapper.v_map_screen method", ->
+
+    it "Should map values and stuff", ->
+      palette = ["#5e4fa2", "#3288bd", "#66c2a5"]
+      color_mapper = new LinearColorMapper({
+          palette: palette
+        })
+      img = [0, 0.020038738821815002, 0.040069430259003856]
+
+      buf = color_mapper.v_map_screen(img)
+      buf8 = new Uint8ClampedArray(buf)
+      expect(buf8).to.be.deep.equal(new Uint8Array([94, 79, 162, 255, 50, 136, 189, 255, 102, 194, 165, 255]))
+      # expect(true).to.be.false

--- a/bokehjs/test/models/mappers/linear_color_mapper.coffee
+++ b/bokehjs/test/models/mappers/linear_color_mapper.coffee
@@ -138,16 +138,15 @@ describe "LinearColorMapper module", ->
       vals = color_mapper._get_values([-1, 0, 1, 2, 3], palette)
       expect(vals).to.be.deep.equal(["pink", "red", "green", "blue", "orange"])
 
-  describe "LinearColorMapper.v_map_screen method", ->
-
-    it "Should map values and stuff", ->
-      palette = ["#5e4fa2", "#3288bd", "#66c2a5"]
+    it "Should map high/low values to _high_color/_low_color, if image_glyph=true", ->
+      palette = [1, 2, 3]
       color_mapper = new LinearColorMapper({
+          low: 0
+          high: 2
           palette: palette
+          low_color: "pink" # converts to 16761035
+          high_color: "orange" # converts to 16753920
         })
-      img = [0, 0.020038738821815002, 0.040069430259003856]
 
-      buf = color_mapper.v_map_screen(img)
-      buf8 = new Uint8ClampedArray(buf)
-      expect(buf8).to.be.deep.equal(new Uint8Array([94, 79, 162, 255, 50, 136, 189, 255, 102, 194, 165, 255]))
-      # expect(true).to.be.false
+      vals = color_mapper._get_values([-1, 0, 1, 2, 3], palette, true)
+      expect(vals).to.be.deep.equal([16761035, 1, 2, 3, 16753920])

--- a/bokehjs/test/models/mappers/log_color_mapper.coffee
+++ b/bokehjs/test/models/mappers/log_color_mapper.coffee
@@ -5,6 +5,28 @@ utils = require "../../utils"
 
 describe "LogColorMapper module", ->
 
+  describe "LogColorMapper initialization", ->
+
+    it "Should set _nan_color, _low_color, _high_color attributes as ints", ->
+
+      color_mapper = new LogColorMapper({
+        palette: ["red", "green", "blue"]
+        nan_color: "cadetblue"
+        low_color: "rgb(95,158,160)"
+        high_color: "#5F9EA0"
+        })
+
+      expect(color_mapper._nan_color).to.be.equal(6266528)
+      expect(color_mapper._low_color).to.be.equal(6266528)
+      expect(color_mapper._high_color).to.be.equal(6266528)
+
+    it "If unset _low_color, _high_color should be undefined", ->
+      color_mapper = new LogColorMapper({
+        palette: ["red", "green", "blue"]
+        })
+      expect(color_mapper._low_color).to.be.undefined
+      expect(color_mapper._high_color).to.be.undefined
+
   describe "LogColorMapper.v_map_screen method", ->
 
     it "Should correctly map values along log scale", ->

--- a/bokehjs/test/models/mappers/log_color_mapper.coffee
+++ b/bokehjs/test/models/mappers/log_color_mapper.coffee
@@ -110,3 +110,16 @@ describe "LogColorMapper module", ->
 
       vals = color_mapper._get_values([0.5, 1, 10, 100, 101], palette)
       expect(vals).to.be.deep.equal(["pink", "red", "green", "blue", "orange"])
+
+    it "Should map high/low values to _high_color/_low_color, if image_glyph=true", ->
+      palette = [1, 2, 3]
+      color_mapper = new LogColorMapper({
+          low: 1
+          high: 100
+          palette: palette
+          low_color: "pink" # converts to 16761035
+          high_color: "orange" # converts to 16753920
+        })
+
+      vals = color_mapper._get_values([-1, 1, 10, 100, 101], palette, true)
+      expect(vals).to.be.deep.equal([16761035, 1, 2, 3, 16753920])


### PR DESCRIPTION
- [x] issues: fixes #5323
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)

~~Todo: add tests~~

~~This PR is probably more proof that we need to outline our needs for the color mappers and then refactor.~~ was able to make relatively small changes

~~Note: only hex colors are now supported for Image glyph special colors (nan/high/low)~~ Resolved