### PR TITLE
fix errors in Document.destructively_move

### DIFF
--- a/bokehjs/src/coffee/document.coffee
+++ b/bokehjs/src/coffee/document.coffee
@@ -159,7 +159,7 @@ export class Document
     finally
       @_pop_all_models_freeze()
 
-  _destructively_move : (dest_doc) ->
+  destructively_move : (dest_doc) ->
     if dest_doc is @
       throw new Error("Attempted to overwrite a document with itself")
 
@@ -168,19 +168,15 @@ export class Document
     # to the new doc or else models referenced from multiple
     # roots could be in both docs at once, which isn't allowed.
     roots = []
-    @_push_all_models_freeze()
-    try
-      while @_roots.length > 0
-        @remove_root(@_roots[0])
-        roots.push(r)
-    finally
-        @_pop_all_models_freeze()
+    for r in @_roots
+      roots.push(r)
+    @clear()
 
     for r in roots
       if r.document != null
         throw new Error("Somehow we didn't detach #{r}")
-    if _all_models.length != 0
-        throw new Error("_all_models still had stuff in it: #{ @_all_models }")
+    if _.size(@_all_models) != 0
+      throw new Error("@_all_models still had stuff in it: #{ @_all_models }")
 
     for r in roots
       dest_doc.add_root(r)
@@ -596,7 +592,7 @@ export class Document
 
   replace_with_json : (json) ->
     replacement = Document.from_json(json)
-    replacement._destructively_move(@)
+    replacement.destructively_move(@)
 
   create_json_patch_string : (events) ->
     JSON.stringify(@create_json_patch(events))

--- a/bokehjs/test/document.coffee
+++ b/bokehjs/test/document.coffee
@@ -583,6 +583,7 @@ it "can destructively move", ->
     expect(d.roots().length).to.equal 1
     d.set_title("Foo")
 
+    old_log_level = logging.logger.level.name
     logging.set_log_level("warn")
     json = d.to_json_string()
     parsed = JSON.parse(json)
@@ -613,6 +614,9 @@ it "can destructively move", ->
     parsed['version'] = "#{js_version}dev123-bar"
     out = stderrTrap -> Document.from_json_string(JSON.stringify(parsed))
     expect(out).to.be.equal ""
+
+    # need to reset old log level
+    logging.set_log_level(old_log_level)
 
   it "can serialize with one model in it", ->
     d = new Document()

--- a/bokehjs/test/document.coffee
+++ b/bokehjs/test/document.coffee
@@ -534,6 +534,47 @@ describe "Document", ->
     # does not reset title
     expect(d.title()).to.equal 'Foo'
 
+  it "throws on destructive move of itself", ->
+    d = new Document()
+    expect(d.roots().length).to.equal 0
+    expect(d.title()).to.equal DEFAULT_TITLE
+    d.add_root(new AnotherModel())
+    d.add_root(new AnotherModel())
+    d.set_title('Foo')
+    expect(d.roots().length).to.equal 2
+    expect(d.title()).to.equal 'Foo'
+    try
+      d.destructively_move(d)
+    catch e
+      got_error = true
+      expect(e.message).to.include('Attempted to overwrite a document with itself')
+    expect(got_error).to.equal(true)
+
+it "can destructively move", ->
+    d = new Document()
+    expect(d.roots().length).to.equal 0
+    expect(d.title()).to.equal DEFAULT_TITLE
+    d.add_root(new AnotherModel())
+    d.add_root(new AnotherModel())
+    d.set_title('Foo')
+    expect(d.roots().length).to.equal 2
+    expect(d.title()).to.equal 'Foo'
+
+    d2 = new Document()
+    expect(d2.roots().length).to.equal 0
+    expect(d2.title()).to.equal DEFAULT_TITLE
+    d2.add_root(new SomeModel())
+    d2.set_title('Bar')
+    expect(d2.roots().length).to.equal 1
+    expect(d2.title()).to.equal 'Bar'
+
+    d2.destructively_move(d)
+    expect(d.roots().length).to.equal 1
+    expect(d.roots()[0].foo).to.equal 2
+    expect(d.title()).to.equal 'Bar'
+
+    expect(d2.roots().length).to.equal 0
+
   it "checks for versions matching", ->
     d = new Document()
     expect(d.roots().length).to.equal 0


### PR DESCRIPTION
- [x] issues: fixes #5333
- [x] tests added / passed

In fixing the typo, I added a test, which uncovered other logic errors. Is this actually used anywhere? If not we can just remove it. 

ping @mattpap @havocp this is ready, comments welcome. 