### PR TITLE
Correct comment in syling dimension example

### DIFF
--- a/sphinx/source/docs/user_guide/source_examples/styling_dimensions.py
+++ b/sphinx/source/docs/user_guide/source_examples/styling_dimensions.py
@@ -2,7 +2,7 @@ from bokeh.plotting import figure, output_file, show
 
 output_file("dimensions.html")
 
-# create a new plot with a title
+# create a new plot with specific dimensions
 p = figure(plot_width=700)
 p.plot_height = 300
 


### PR DESCRIPTION
changed comment to apply to example content

- [x] issues: fixes #5377 
- [ ] tests added / passed
- [x] release document entry (if new feature or API change)

