### PR TITLE
Don't use tail calls in getters/setters to avoid a bug in Safari

### DIFF
--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -43,7 +43,7 @@ class TextInput(InputWidget):
     A callback to run in the browser whenever the user unfocuses the TextInput
     widget by hitting Enter or clicking outside of the text box area.
     """)
-    
+
     placeholder = String(default="", help="""
     Placeholder for empty input field
     """)

--- a/bokehjs/src/coffee/core/has_props.coffee
+++ b/bokehjs/src/coffee/core/has_props.coffee
@@ -23,8 +23,9 @@ export class HasProps extends Backbone.Model
           throw new Error("attempted to redefine attribute '#{this.name}.#{name}'")
 
         Object.defineProperty(this.prototype, name, {
-          get: ()      -> this.getv(name)
-          set: (value) -> this.setv(name, value)
+          # XXX: don't use tail calls in getters/setters due to https://bugs.webkit.org/show_bug.cgi?id=164306
+          get: ()      -> value = this.getv(name); return value
+          set: (value) -> this.setv(name, value); return this
         }, {
           configurable: false
           enumerable: true


### PR DESCRIPTION
@bryevdv, if I understand https://bugs.webkit.org/show_bug.cgi?id=164306#c4, this should fix the problem. We use other getters (setters are uncommon), but they aren't used as intensively as those used for property access.

fixes #5392 

