### PR TITLE
Fix tab completion for bokeh.palettes

### DIFF
--- a/bokeh/palettes.py
+++ b/bokeh/palettes.py
@@ -82,7 +82,10 @@ The complete contents of ``small_palettes`` is show below.
 
 """
 
-class _Palettes(object):
+import sys as _sys
+import types as _types
+
+class _PalettesModule(_types.ModuleType):
     @property
     def YlGn3(self):
         return ["#31a354", "#addd8e", "#f7fcb9"]
@@ -1601,6 +1604,9 @@ class _Palettes(object):
             __palettes__ += [ name + str(index) for index in sorted(palettes.keys()) ]
         return __palettes__
 
+    def __dir__(self):
+        return [name for name in dir(type(self)) if not name.startswith('_')]
+
     def _linear_cmap_func_generator(self, name, cmap):
         import math
         import numpy as np
@@ -1631,16 +1637,9 @@ class _Palettes(object):
     def gray(self):
         return self._linear_cmap_func_generator('gray', self.Greys256)
 
-import sys as _sys
-import types as _types
-
-class _PalettesModule(_types.ModuleType, _Palettes):
-    def __dir__(self):
-        return list(self.__dict__.keys()) + \
-               [ name for name in dir(_Palettes) if not name.startswith("_") ]
 
 # need to explicitly transfer the docstring for Sphinx docs to build correctly
 _mod = _PalettesModule('bokeh.palettes')
 _mod.__doc__ = __doc__
 _sys.modules['bokeh.palettes'] = _mod
-del _mod
+del _mod, _sys, _types

--- a/bokeh/tests/test_palettes.py
+++ b/bokeh/tests/test_palettes.py
@@ -15,3 +15,7 @@ def test_palettes_immutability():
 
 def test_all_palettes___palettes__():
     assert sum([ len(p) for p in pal.all_palettes.values() ]) == len(pal.__palettes__)
+
+def test_palettes_dir():
+    assert 'viridis' in dir(pal)
+    assert not '__new__' in dir(pal)


### PR DESCRIPTION
Fixes the implementation of `__dir__` on the dynamically generated
`palettes` module. Previously this would fail on python 2, due to a
quirk in how globals were handled (this is fixed in python 3).

Fixes #5453.