### PR TITLE
Fix off-by-one and missing test in LinearInterpolator

### DIFF
--- a/bokehjs/src/coffee/models/transforms/interpolator.coffee
+++ b/bokehjs/src/coffee/models/transforms/interpolator.coffee
@@ -78,7 +78,7 @@ export class Interpolator extends Transform
         return ((a.x > b.x) ? -1 : ((a.x == b.x) ? 0 : 1));
       )
 
-    for k in [0..list.length-1]
+    for k in [0...list.length]
       @_x_sorted[k] = list[k].x;
       @_y_sorted[k] = list[k].y;
 

--- a/bokehjs/src/coffee/models/transforms/linear_interpolator.coffee
+++ b/bokehjs/src/coffee/models/transforms/linear_interpolator.coffee
@@ -9,15 +9,18 @@ export class LinearInterpolator extends Interpolator
 
     if @clip == true
       if x < @_x_sorted[0] or x > @_x_sorted[@_x_sorted.length-1]
-        return(null)
+        return null
     else
       if x < @_x_sorted[0]
         return @_y_sorted[0]
       if x > @_x_sorted[@_x_sorted.length-1]
         return @_y_sorted[@_y_sorted.length-1]
 
+    if x == @_x_sorted[0]
+      return @_y_sorted[0]
+
     ind = _.findLastIndex(@_x_sorted, (num) ->
-      return x >= num
+      return num < x
     )
 
     x1 = @_x_sorted[ind]
@@ -26,7 +29,7 @@ export class LinearInterpolator extends Interpolator
     y2 = @_y_sorted[ind+1]
 
     ret = y1 + (((x-x1) / (x2-x1)) * (y2-y1))
-    return(ret)
+    return ret
 
   v_compute: (xs) ->
     # Apply the tranform to a vector of values

--- a/bokehjs/test/models/transforms/linear_interpolator_transform.coffee
+++ b/bokehjs/test/models/transforms/linear_interpolator_transform.coffee
@@ -31,6 +31,7 @@ describe "linear_interpolator_transform module", ->
     it "should return control points", ->
       expect(transform.compute(0)).to.be.equal 10
       expect(transform.compute(5)).to.be.equal 20
+      expect(transform.compute(15)).to.be.equal 30
 
     it "should linearly interpolate between control points", ->
       expect(transform.compute(2)).to.be.equal 14
@@ -47,6 +48,7 @@ describe "linear_interpolator_transform module", ->
     it "should return control points", ->
       expect(transform.compute(0)).to.be.equal 10
       expect(transform.compute(5)).to.be.equal 20
+      expect(transform.compute(15)).to.be.equal 30
 
     it "should linearly interpolate between control points", ->
       expect(transform.compute(2)).to.be.equal 14


### PR DESCRIPTION
- [x] issues: fixes #5370
- [x] tests added / passed

There was no test that the final control point matched, which is how this bug crept in. The problem was the predicate for `_.findLastIndex`, which was `x >= num`. This could return the last index for `@_x_sorted`, and the subsequent `x2 = @_x_sorted[ind+1]` would then yield `null` -> `NaN`.

The predicate was changed to `num < x` which will always be at most the next to last index. But this also necessitates special casing the first control point, so the following check was added first:
```
if x == @_x_sorted[0]
  return @_y_sorted[0]
```