### PR TITLE
Correcting docstring for function push_notebook

### DIFF
--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -569,7 +569,7 @@ def push_notebook(document=None, state=None, handle=None):
 
             # Update the plot title in the earlier cell
             plot.title = "New Title"
-            push_notebook(handle)
+            push_notebook(handle=handle)
 
     '''
     if state is None:


### PR DESCRIPTION
#issues: fixes #5467

Correcting docstring for function push_notebook. Adding missing key word, "handle".
https://github.com/bokeh/bokeh/blob/master/bokeh/io.py#L572