### PR TITLE
Wrap long error output correctly

### DIFF
--- a/bokehjs/src/coffee/safely.coffee
+++ b/bokehjs/src/coffee/safely.coffee
@@ -38,6 +38,7 @@ _burst_into_flames = (error) ->
   # Make message
   message = document.createElement("pre")
   message.style["white-space"] = "unset"
+  message.style["overflow-x"] = "auto"
   message.appendChild(document.createTextNode(error.message ? error))
 
   # Add pieces to box


### PR DESCRIPTION
- [ ] issues: fixes #5322

Adds `overflow-x: auto;` style to messages generated by `safely.coffee`

New output:

<img width="1069" alt="screen shot 2016-11-20 at 1 58 13 pm" src="https://cloud.githubusercontent.com/assets/1078448/20465716/ad9b7850-af29-11e6-9469-a7db439151b9.png">
