### PR TITLE
Pass keyword arguments through Serve

### DIFF
--- a/bokeh/command/subcommand.py
+++ b/bokeh/command/subcommand.py
@@ -44,7 +44,7 @@ class Subcommand(with_metaclass(ABCMeta)):
             self.parser.add_argument(*flags, **arg[1])
 
     @abstractmethod
-    def invoke(self, args):
+    def invoke(self, args, **kwargs):
         ''' Takes over main program flow to perform the subcommand.
 
         Args:

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -324,7 +324,7 @@ import argparse
 
 from bokeh.application import Application
 from bokeh.resources import DEFAULT_SERVER_PORT
-from bokeh.server.server import Server
+from bokeh.server.server import Server, _tornado_kwargs
 from bokeh.util.string import nice_join
 from bokeh.settings import settings
 
@@ -532,6 +532,10 @@ class Serve(Subcommand):
                                                               'use_xheaders',
                                                             ]
                           if getattr(args, key, None) is not None }
+
+        for key in _tornado_kwargs:
+            if key in kwargs:
+                server_kwargs[key] = kwargs.pop(key)
 
         server_kwargs['sign_sessions'] = settings.sign_sessions()
         server_kwargs['secret_key'] = settings.secret_key_bytes()

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -485,7 +485,7 @@ class Serve(Subcommand):
     )
 
 
-    def invoke(self, args):
+    def invoke(self, args, **kwargs):
         argvs = { f : args.args for f in args.files}
         applications = build_single_handler_applications(args.files, argvs)
 
@@ -577,4 +577,5 @@ class Serve(Subcommand):
 
         log.info("Starting Bokeh server with process id: %d" % getpid())
 
-        server.start()
+        server.start(**kwargs)
+        return server

--- a/bokeh/command/subcommands/tests/test_serve.py
+++ b/bokeh/command/subcommands/tests/test_serve.py
@@ -152,3 +152,15 @@ def test_args():
              type=int,
          )),
     )
+
+
+def test_create_server_manually():
+    from tornado.ioloop import IOLoop
+    loop = IOLoop()
+    argv = ['bokeh', 'examples/app/crossfilter']  # TODO: better test example
+    parser = argparse.ArgumentParser(prog=argv[0])
+    serve = scserve.Serve(parser)
+    args = parser.parse_args(argv[1:])
+    server = serve.invoke(args, start_loop=False, io_loop=loop)
+    assert server.io_loop is loop
+    assert not loop._running

--- a/bokeh/server/server.py
+++ b/bokeh/server/server.py
@@ -50,6 +50,18 @@ def _create_hosts_whitelist(host_list, port):
             raise ValueError("Invalid host value: %s" % host)
     return hosts
 
+
+_tornado_kwargs = ['io_loop',
+                   'extra_patterns',
+                   'secret_key',
+                   'sign_sessions',
+                   'generate_session_ids',
+                   'keep_alive_milliseconds',
+                   'check_unused_sessions_milliseconds',
+                   'unused_session_lifetime_milliseconds',
+                   'stats_log_frequency_milliseconds']
+
+
 class Server(object):
     ''' A Server which creates a new Session for each connection, using an Application to initialize each Session.
 
@@ -71,15 +83,7 @@ class Server(object):
         else:
             self._applications = applications
 
-        tornado_kwargs = { key: kwargs[key] for key in ['io_loop',
-                                                        'extra_patterns',
-                                                        'secret_key',
-                                                        'sign_sessions',
-                                                        'generate_session_ids',
-                                                        'keep_alive_milliseconds',
-                                                        'check_unused_sessions_milliseconds',
-                                                        'unused_session_lifetime_milliseconds',
-                                                        'stats_log_frequency_milliseconds']
+        tornado_kwargs = { key: kwargs[key] for key in _tornado_kwargs
                            if key in kwargs }
 
         prefix = kwargs.get('prefix')

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -342,7 +342,7 @@ class BokehTornado(TornadoApplication):
         for context in self._applications.values():
             context.run_load_hook()
 
-        if start_loop:
+        if start_loop and not self._loop._running:
             try:
                 self._loop.start()
             except KeyboardInterrupt:


### PR DESCRIPTION
This helps with the manual creation of a Bokeh Server with a predefined Tornado IOLoop.  We pass a few keyword arguments through `invoke` and return the server object.  This enables the following example:

```python
In [1]: from tornado.ioloop import IOLoop

In [2]: loop = IOLoop()

In [3]: import argparse
   ...: argv = ['bokeh', 'examples/app/crossfilter']
   ...: parser = argparse.ArgumentParser(prog=argv[0])
   ...: from bokeh.command.subcommands.serve import Serve
   ...: serve = Serve(parser)
   ...: args = parser.parse_args(argv[1:])
   ...: server = serve.invoke(args, start_loop=False)
   ...: 
2016-11-26 13:25:39,015 Starting Bokeh server version 0.12.3dev4-283-g0db3db9-dirty
2016-11-26 13:25:39,017 Starting Bokeh server on port 5006 with applications at paths ['/crossfilter']
2016-11-26 13:25:39,018 Starting Bokeh server with process id: 15055

In [4]: server.io_loop is loop
Out[4]: True

In [5]: server.io_loop._running
Out[5]: False

In [6]: server.io_loop.start()  # everything works fine
```