### PR TITLE
Add support for specifying CSS classes on all LayoutDOM

### DIFF
--- a/bokeh/models/layouts.py
+++ b/bokeh/models/layouts.py
@@ -14,7 +14,7 @@ from ..core.validation.warnings import (
     BOTH_CHILD_AND_ROOT,
 )
 from ..core.enums import SizingMode
-from ..core.properties import abstract, Bool, Enum, Int, Instance, List
+from ..core.properties import abstract, Bool, Enum, Int, Instance, List, Seq, String
 from ..embed import notebook_div
 from ..model import Model
 from ..util.deprecation import deprecated
@@ -64,6 +64,11 @@ class LayoutDOM(Model):
     ``"scale_both"`` elements will responsively resize to fir both the width and height available,
     *while maintaining the original aspect ratio*.
 
+    """)
+
+    css_classes = Seq(String, help="""
+    A list of css class names to add to this DOM element. Note: the class names are
+    simply added as-is, no other guarantees are provided.
     """)
 
     @property

--- a/bokehjs/src/coffee/models/layouts/layout_dom.coffee
+++ b/bokehjs/src/coffee/models/layouts/layout_dom.coffee
@@ -15,6 +15,9 @@ export class LayoutDOMView extends BokehView
     # Provides a hook so document can measure
     @$el.attr("id", "modelid_#{@model.id}")
     @$el.addClass("bk-layout-#{@model.sizing_mode}")
+    if @model.css_classes?
+      for cls in @model.css_classes
+        @$el.addClass(cls)
     @child_views = {}
 
     # init_solver = false becuase we only need to init solver on subsequent
@@ -254,6 +257,7 @@ export class LayoutDOM extends Model
       width:       [ p.Number              ]
       disabled:    [ p.Bool,       false   ]
       sizing_mode: [ p.SizingMode, "fixed" ]
+      css_classes: [ p.Array               ]
     }
 
   @internal {

--- a/bokehjs/test/models/layouts/layout_dom.coffee
+++ b/bokehjs/test/models/layouts/layout_dom.coffee
@@ -46,6 +46,12 @@ describe "LayoutDOMView", ->
       layout_view = new LayoutDOMView({ model: @test_layout })
       expect(layout_view.$el.attr('class')).to.be.equal 'bk-layout-scale_height'
 
+    it "should set classes from css_classes", ->
+      @test_layout.sizing_mode = 'fixed'
+      @test_layout.css_classes = ['FOO', 'BAR']
+      layout_view = new LayoutDOMView({ model: @test_layout })
+      expect(layout_view.$el.attr('class')).to.be.equal 'bk-layout-fixed FOO BAR'
+
     it "should set an id matching the model.id", ->
       # This is used by document to find the model and its parents on resize events
       layout_view = new LayoutDOMView({ model: @test_layout })

--- a/examples/plotting/file/css_classes.py
+++ b/examples/plotting/file/css_classes.py
@@ -1,0 +1,76 @@
+from jinja2 import Template
+
+from bokeh.embed import file_html
+from bokeh.layouts import column
+from bokeh.models import Div, Paragraph
+from bokeh.resources import CDN
+from bokeh.util.browser import view
+
+template = Template("""
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>{{ title if title else "Bokeh Plot" }}</title>
+        {{ bokeh_css }}
+        {{ bokeh_js }}
+        <style>
+        .custom {
+            border-radius: 0.5em;
+            padding: 1em;
+        }
+        .custom-1 {
+            border: 3px solid #2397D8;
+        }
+        .custom-2 {
+            border: 3px solid #14999A;
+            background-color: whitesmoke;
+        }
+        </style>
+    </head>
+    <body>
+        {{ plot_div|indent(8) }}
+        {{ plot_script|indent(8) }}
+    </body>
+</html>
+""")
+
+p = Paragraph(text="The divs below were configured with additional css_classes:")
+
+div1 = Div(text="""
+<p> This Bokeh Div adds the style classes:<p>
+<pre>
+.custom {
+    border-radius: 0.5em;
+    padding: 1em;
+}
+.custom-1 {
+    border: 3px solid #2397D8;
+}
+</pre>
+""")
+div1.css_classes = ["custom", "custom-1"]
+
+div2 = Div(text="""
+<p> This Bokeh Div adds the style classes:<p>
+<pre>
+.custom {
+    border-radius: 0.5em;
+    padding: 1em;
+}
+.custom-2 {
+    border: 3px solid #14999A;
+    background-color: whitesmoke;
+}
+</pre>
+""")
+div2.css_classes = ["custom", "custom-2"]
+
+html = file_html(column(p, div1, div2), template=template, resources=CDN)
+
+output_file = 'css_classes.html'
+
+with open(output_file, 'w') as f:
+    f.write(html)
+
+view(output_file)


### PR DESCRIPTION
- [x] issues: fixes #5471
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

Adds .css_classes property to LayoutDOM, which accepts a sequence of strings. These are added as-is to the LayoutDOM element.