### PR TITLE
Use native methods instead of underscore

### DIFF
--- a/bokehjs/src/coffee/api/charts.coffee
+++ b/bokehjs/src/coffee/api/charts.coffee
@@ -151,7 +151,7 @@ export bar = (data, opts={}) ->
     for v, i in row
       columns[i].push(v)
 
-  labels = _.map(columns[0], (v) -> v.toString())
+  labels = columns[0].map((v) -> v.toString())
   columns = columns.slice(1)
 
   yaxis = new models.CategoricalAxis()

--- a/bokehjs/src/coffee/core/backbone.js
+++ b/bokehjs/src/coffee/core/backbone.js
@@ -224,7 +224,7 @@ _.extend(View.prototype, Events, {
       if (!_.isFunction(method)) method = this[method];
       if (!method) continue;
       var match = key.match(delegateEventSplitter);
-      this.delegate(match[1], match[2], _.bind(method, this));
+      this.delegate(match[1], match[2], method.bind(this));
     }
     return this;
   },

--- a/bokehjs/src/coffee/core/build_views.coffee
+++ b/bokehjs/src/coffee/core/build_views.coffee
@@ -43,7 +43,7 @@ export build_views = (view_storage, view_models, options, view_types=[]) ->
 export jQueryUIPrefixer = (el) ->
   return unless el.className?
   classList = el.className.split " "
-  prefixedClassList = _.map classList, (a) ->
+  prefixedClassList = classList.map (a) ->
     a = a.trim()
     return if a.indexOf("ui-") is 0 then "bk-#{a}" else a
   return prefixedClassList.join " "

--- a/bokehjs/src/coffee/core/build_views.coffee
+++ b/bokehjs/src/coffee/core/build_views.coffee
@@ -18,7 +18,7 @@ export build_views = (view_storage, view_models, options, view_types=[]) ->
   # * view_option: array, optional view specific options passed in to the construction of the view
 
   created_views = []
-  newmodels = _.filter(view_models, (x) -> return not _.has(view_storage, x.id))
+  newmodels = view_models.filter((x) -> not _.has(view_storage, x.id))
 
   for model, i_model in newmodels
     view_specific_option = _.extend({}, options, {'model': model})

--- a/bokehjs/src/coffee/core/events.js
+++ b/bokehjs/src/coffee/core/events.js
@@ -198,7 +198,7 @@ var offApi = function(events, name, callback, options) {
 // once for each event, not once for a combination of all events.
 Events.once = function(name, callback, context) {
   // Map the event into a `{event: once}` object.
-  var events = eventsApi(onceMap, {}, name, callback, _.bind(this.off, this));
+  var events = eventsApi(onceMap, {}, name, callback, this.off.bind(this));
   if (typeof name === 'string' && context == null) callback = void 0;
   return this.on(events, callback, context);
 };
@@ -206,7 +206,7 @@ Events.once = function(name, callback, context) {
 // Inversion-of-control versions of `once`.
 Events.listenToOnce = function(obj, name, callback) {
   // Map the event into a `{event: once}` object.
-  var events = eventsApi(onceMap, {}, name, callback, _.bind(this.stopListening, this, obj));
+  var events = eventsApi(onceMap, {}, name, callback, this.stopListening.bind(this, obj));
   return this.listenTo(obj, events);
 };
 

--- a/bokehjs/src/coffee/core/util/refs.coffee
+++ b/bokehjs/src/coffee/core/util/refs.coffee
@@ -42,7 +42,7 @@ export is_ref = (arg) ->
 #
 export convert_to_ref = (value) ->
   if _.isArray(value)
-    return _.map(value, convert_to_ref)
+    return value.map(convert_to_ref)
   else
     if value instanceof HasProps
       return value.ref()

--- a/bokehjs/src/coffee/core/util/underscore.coffee
+++ b/bokehjs/src/coffee/core/util/underscore.coffee
@@ -16,9 +16,6 @@ _.uniqueId = (prefix) ->
   else
     return uuid;
 
-_.isNullOrUndefined = (x) ->
-  return _.isNull(x) || _.isUndefined(x)
-
 _.setdefault = (obj, key, value) ->
   if _.has(obj, key)
     return obj[key]

--- a/bokehjs/src/coffee/document.coffee
+++ b/bokehjs/src/coffee/document.coffee
@@ -486,7 +486,7 @@ export class Document
         if not _.isEqual(old_value, new_value)
           events.push(Document._event_for_attribute_change(from_obj, key, new_value, to_doc, value_refs))
 
-    _.filter(events, (e) -> e != null)
+    events.filter((e) -> e != null)
 
   # we use this to detect changes during document deserialization
   # (in model constructors and initializers)

--- a/bokehjs/src/coffee/embed.coffee
+++ b/bokehjs/src/coffee/embed.coffee
@@ -24,7 +24,7 @@ _handle_notebook_comms = (msg) ->
 
 _update_comms_callback = (target, doc, comm) ->
   if target == comm.target_name
-    comm.on_msg(_.bind(_handle_notebook_comms, doc))
+    comm.on_msg(_handle_notebook_comms.bind(doc))
 
 _init_comms = (target, doc) ->
   if Jupyter? and Jupyter.notebook.kernel?
@@ -36,7 +36,7 @@ _init_comms = (target, doc) ->
     try
       comm_manager.register_target(target, (comm, msg) ->
         logger.info("Registering Jupyter comms for target #{target}")
-        comm.on_msg(_.bind(_handle_notebook_comms, doc))
+        comm.on_msg(_handle_notebook_comms.bind(doc))
       )
     catch e
       logger.warn("Jupyter comms failed to register. push_notebook() will not function. (exception reported: #{e})")

--- a/bokehjs/src/coffee/models/layouts/box.coffee
+++ b/bokehjs/src/coffee/models/layouts/box.coffee
@@ -17,18 +17,18 @@ export class BoxView extends LayoutDOMView
     children = @model.get_layoutable_children()
     child_heights = _.map(children, ((child) -> child._height._value))
     if @model._horizontal
-      height = _.reduce(child_heights, ((a, b) -> Math.max(a, b)))
+      height = child_heights.reduce((a, b) -> Math.max(a, b))
     else
-      height = _.reduce(child_heights, ((a, b) -> a + b))
+      height = child_heights.reduce((a, b) -> a + b)
     return height
 
   get_width: () ->
     children = @model.get_layoutable_children()
     child_widths = _.map(children, ((child) -> child._width._value))
     if @model._horizontal
-      width = _.reduce(child_widths, ((a, b) -> a + b))
+      width = child_widths.reduce((a, b) -> a + b)
     else
-      width = _.reduce(child_widths, ((a, b) -> Math.max(a, b)))
+      width = child_widths.reduce((a, b) -> Math.max(a, b))
     return width
 
 

--- a/bokehjs/src/coffee/models/layouts/box.coffee
+++ b/bokehjs/src/coffee/models/layouts/box.coffee
@@ -15,7 +15,7 @@ export class BoxView extends LayoutDOMView
 
   get_height: () ->
     children = @model.get_layoutable_children()
-    child_heights = _.map(children, ((child) -> child._height._value))
+    child_heights = children.map((child) -> child._height._value)
     if @model._horizontal
       height = child_heights.reduce((a, b) -> Math.max(a, b))
     else
@@ -24,7 +24,7 @@ export class BoxView extends LayoutDOMView
 
   get_width: () ->
     children = @model.get_layoutable_children()
-    child_widths = _.map(children, ((child) -> child._width._value))
+    child_widths = children.map((child) -> child._width._value)
     if @model._horizontal
       width = child_widths.reduce((a, b) -> a + b)
     else
@@ -394,8 +394,8 @@ export class Box extends LayoutDOM
             leaves[0].push(child)
             leaves[1].push(child)
 
-    # console.log("  start leaves ", _.map(leaves[0], (leaf) -> leaf.id))
-    # console.log("  end leaves ", _.map(leaves[1], (leaf) -> leaf.id))
+    # console.log("  start leaves ", leaves[0].map((leaf) -> leaf.id)
+    # console.log("  end leaves ", leaves[1].map((leaf) -> leaf.id)
 
     return leaves
 

--- a/bokehjs/src/coffee/models/plots/gmap_plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/gmap_plot_canvas.coffee
@@ -121,8 +121,7 @@ export class GMapPlotCanvasView extends PlotCanvasView
 
     else
       window._bokeh_gmap_loads.push(build_map)
-      window._bokeh_gmap_callback = () ->
-        _.each(window._bokeh_gmap_loads, _.defer)
+      window._bokeh_gmap_callback = () -> window._bokeh_gmap_loads.forEach(_.defer)
       script = document.createElement('script')
       script.type = 'text/javascript'
       script.src = "https://maps.googleapis.com/maps/api/js?key=#{@model.plot.api_key}&callback=_bokeh_gmap_callback"

--- a/bokehjs/src/coffee/models/plots/gmap_plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/gmap_plot_canvas.coffee
@@ -7,7 +7,7 @@ import * as p from "../../core/properties"
 export class GMapPlotCanvasView extends PlotCanvasView
 
   initialize: (options) ->
-    super(_.defaults(options, @default_options))
+    super(options)
     @zoom_count = 0
 
   getLatLngBounds: () =>

--- a/bokehjs/src/coffee/models/plots/plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.coffee
@@ -1,5 +1,4 @@
 import * as _ from "underscore"
-import * as $ from "jquery"
 
 import {Canvas} from "../canvas/canvas"
 import {CartesianFrame} from "../canvas/cartesian_frame"
@@ -546,7 +545,7 @@ export class PlotCanvasView extends BokehView
       delete @model.document._unrendered_plots[@id]
       if _.isEmpty(@model.document._unrendered_plots)
         @model.document._unrendered_plots = null
-        _.delay($.proxy(@model.document.resize, @model.document), 1)
+        _.delay(@model.document.resize.bind(@model.document), 1)
 
   resize: () ->
     # Set the plot and canvas to the current model's size

--- a/bokehjs/src/coffee/models/sources/geojson_data_source.coffee
+++ b/bokehjs/src/coffee/models/sources/geojson_data_source.coffee
@@ -20,12 +20,12 @@ export class GeoJSONDataSource extends ColumnDataSource
 
   _get_new_list_array: (length) ->
     array = new Array(length)
-    list_array = _.map(array, (x) -> [])
+    list_array = array.map((x) -> [])
     return list_array
 
   _get_new_nan_array: (length) ->
     array = new Array(length)
-    nan_array = _.map(array, (x) -> NaN)
+    nan_array = array.map((x) -> NaN)
     return nan_array
 
   _flatten_function: (accumulator, currentItem) ->

--- a/bokehjs/src/coffee/models/sources/geojson_data_source.coffee
+++ b/bokehjs/src/coffee/models/sources/geojson_data_source.coffee
@@ -67,7 +67,7 @@ export class GeoJSONDataSource extends ColumnDataSource
         logger.warn('MultiPoint not supported in Bokeh')
 
       when "MultiLineString"
-        flattened_coord_list = _.reduce(geometry.coordinates, @_flatten_function)
+        flattened_coord_list = geometry.coordinates.reduce(@_flatten_function)
         for coords, j in flattened_coord_list
           data.xs[i][j] = coords[0]
           data.ys[i][j] = coords[1]
@@ -80,7 +80,7 @@ export class GeoJSONDataSource extends ColumnDataSource
             logger.warn('Bokeh does not support Polygons with holes in, only exterior ring used.')
           exterior_rings.push(polygon[0])
 
-        flattened_coord_list = _.reduce(exterior_rings, @_flatten_function)
+        flattened_coord_list = exterior_rings.reduce(@_flatten_function)
         for coords, j in flattened_coord_list
           data.xs[i][j] = coords[0]
           data.ys[i][j] = coords[1]

--- a/bokehjs/src/coffee/models/sources/geojson_data_source.coffee
+++ b/bokehjs/src/coffee/models/sources/geojson_data_source.coffee
@@ -18,15 +18,9 @@ export class GeoJSONDataSource extends ColumnDataSource
 
   _update_data: () -> @data = @geojson_to_column_data()
 
-  _get_new_list_array: (length) ->
-    array = new Array(length)
-    list_array = array.map((x) -> [])
-    return list_array
+  _get_new_list_array: (length) -> ([] for i in [0...length])
 
-  _get_new_nan_array: (length) ->
-    array = new Array(length)
-    nan_array = array.map((x) -> NaN)
-    return nan_array
+  _get_new_nan_array: (length) -> (NaN for i in [0...length])
 
   _flatten_function: (accumulator, currentItem) ->
     return accumulator.concat([[NaN, NaN, NaN]]).concat(currentItem)

--- a/bokehjs/src/coffee/models/tickers/composite_ticker.coffee
+++ b/bokehjs/src/coffee/models/tickers/composite_ticker.coffee
@@ -19,8 +19,8 @@ export class CompositeTicker extends ContinuousTicker
   # FIXME Enforce this automatically.
 
   @getters {
-    min_intervals: () -> _.invoke(@tickers, 'get_min_interval')
-    max_intervals: () -> _.invoke(@tickers, 'get_max_interval')
+    min_intervals: () -> (ticker.get_min_interval() for ticker in @tickers)
+    max_intervals: () -> (ticker.get_max_interval() for ticker in @tickers)
     min_interval: () -> _.first(@min_intervals)
     max_interval: () -> _.first(@max_intervals)
   }

--- a/bokehjs/src/coffee/models/tickers/days_ticker.coffee
+++ b/bokehjs/src/coffee/models/tickers/days_ticker.coffee
@@ -75,8 +75,7 @@ export class DaysTicker extends SingleIntervalTicker
 
     all_ticks = (day_date.getTime() for day_date in day_dates)
     # FIXME Since the ticks are sorted, this could be done more efficiently.
-    ticks_in_range = _.filter(all_ticks,
-                              ((tick) -> data_low <= tick <= data_high))
+    ticks_in_range = all_ticks.filter((tick) -> data_low <= tick <= data_high)
 
     return {
       "major": ticks_in_range,

--- a/bokehjs/src/coffee/models/tickers/days_ticker.coffee
+++ b/bokehjs/src/coffee/models/tickers/days_ticker.coffee
@@ -73,7 +73,7 @@ export class DaysTicker extends SingleIntervalTicker
     interval = @interval
     day_dates = _.flatten(days_of_month(date, interval) for date in month_dates)
 
-    all_ticks = _.invoke(day_dates, 'getTime')
+    all_ticks = (day_date.getTime() for day_date in day_dates)
     # FIXME Since the ticks are sorted, this could be done more efficiently.
     ticks_in_range = _.filter(all_ticks,
                               ((tick) -> data_low <= tick <= data_high))

--- a/bokehjs/src/coffee/models/tickers/months_ticker.coffee
+++ b/bokehjs/src/coffee/models/tickers/months_ticker.coffee
@@ -58,7 +58,7 @@ export class MonthsTicker extends SingleIntervalTicker
 
     month_dates = _.flatten(months_of_year(date) for date in year_dates)
 
-    all_ticks = _.invoke(month_dates, 'getTime')
+    all_ticks = (month_date.getTime() for month_date in month_dates)
     ticks_in_range = _.filter(all_ticks,
                               ((tick) -> data_low <= tick <= data_high))
 

--- a/bokehjs/src/coffee/models/tickers/months_ticker.coffee
+++ b/bokehjs/src/coffee/models/tickers/months_ticker.coffee
@@ -59,8 +59,7 @@ export class MonthsTicker extends SingleIntervalTicker
     month_dates = _.flatten(months_of_year(date) for date in year_dates)
 
     all_ticks = (month_date.getTime() for month_date in month_dates)
-    ticks_in_range = _.filter(all_ticks,
-                              ((tick) -> data_low <= tick <= data_high))
+    ticks_in_range = all_ticks.filter((tick) -> data_low <= tick <= data_high)
 
     return {
       "major": ticks_in_range,

--- a/bokehjs/src/coffee/models/tickers/years_ticker.coffee
+++ b/bokehjs/src/coffee/models/tickers/years_ticker.coffee
@@ -22,9 +22,7 @@ export class YearsTicker extends SingleIntervalTicker
     years = @basic_ticker.get_ticks_no_defaults(start_year, end_year, desired_n_ticks).major
 
     all_ticks = (Date.UTC(year, 0, 1) for year in years)
-
-    ticks_in_range = _.filter(all_ticks,
-                              ((tick) -> data_low <= tick <= data_high))
+    ticks_in_range = all_ticks.filter((tick) -> data_low <= tick <= data_high)
 
     return {
       major: ticks_in_range

--- a/bokehjs/src/coffee/models/tools/toolbar.coffee
+++ b/bokehjs/src/coffee/models/tools/toolbar.coffee
@@ -39,7 +39,7 @@ export class Toolbar extends ToolbarBase
 
         if not _.some(@gestures[et].tools, (t) => t.id == tool.id)
           @gestures[et].tools = @gestures[et].tools.concat([tool])
-        @listenTo(tool, 'change:active', _.bind(@_active_change, tool))
+        @listenTo(tool, 'change:active', @_active_change.bind(tool))
 
     for et of @gestures
       tools = @gestures[et].tools

--- a/bokehjs/src/coffee/models/tools/toolbar_box.coffee
+++ b/bokehjs/src/coffee/models/tools/toolbar_box.coffee
@@ -92,7 +92,7 @@ export class ToolbarBoxToolbar extends ToolbarBase
         if tools.length > 0
           proxy = make_proxy(tools)
           @gestures[event_type].tools.push(proxy)
-          @listenTo(proxy, 'change:active', _.bind(@_active_change, proxy))
+          @listenTo(proxy, 'change:active', @_active_change.bind(proxy))
 
     @actions = []
     for tool_type, tools of actions

--- a/bokehjs/src/coffee/models/widgets/data_table.coffee
+++ b/bokehjs/src/coffee/models/widgets/data_table.coffee
@@ -127,8 +127,7 @@ export class DataTableView extends WidgetView
     # console.log("DataTableView::updateSelection",
     #             @grid.getViewport(), @grid.getRenderedRange())
     cur_grid_range = @grid.getViewport()
-    if @model.scroll_to_selection and not _.any(_.map(indices, (index) ->
-        cur_grid_range["top"] <= index and index <= cur_grid_range["bottom"]))
+    if @model.scroll_to_selection and not _.any(indices, (i) -> cur_grid_range.top <= i <= cur_grid_range.bottom)
       # console.log("DataTableView::updateSelection", min_index, indices)
       min_index = Math.max(0, Math.min.apply(null, indices) - 1)
       @grid.scrollRowToTop(min_index)

--- a/bokehjs/src/coffee/models/widgets/multiselect.coffee
+++ b/bokehjs/src/coffee/models/widgets/multiselect.coffee
@@ -31,7 +31,8 @@ export class MultiSelectView extends InputWidgetView
 
   render_selection: () =>
     values = {}
-    _.map(@model.value, (x) -> values[x] = true)
+    for x in @model.value
+      values[x] = true
     @$('option').each((el) =>
       el = @$(el)
       if values[el.attr('value')]

--- a/bokehjs/src/coffee/models/widgets/tabs.coffee
+++ b/bokehjs/src/coffee/models/widgets/tabs.coffee
@@ -30,9 +30,7 @@ export class TabsView extends WidgetView
       $(this).tab('show')
       panelId = $(this).attr('href').replace('#tab-','')
       tabs = that.model.tabs
-      panelIdx = _.indexOf(tabs, _.find(tabs, (panel) ->
-        return panel.id == panelId
-      ))
+      panelIdx = _.findIndex(tabs, (panel) -> panel.id == panelId)
       that.model.active = panelIdx
       that.model.callback?.execute(that.model)
 


### PR DESCRIPTION
Quick clean up. A lot more could be done, but those changes may be a lot more subtle than these. Note that compatibility isn't an issue, because all browsers and IE 9+ support these methods.

fixes #5507 
