### PR TITLE
fixups for some versions if IE11

### DIFF
--- a/bokehjs/src/coffee/models/annotations/color_bar.coffee
+++ b/bokehjs/src/coffee/models/annotations/color_bar.coffee
@@ -63,7 +63,7 @@ export class ColorBarView extends AnnotationView
     # length = palette.length to get each palette color in order.
     cmap = new LinearColorMapper({palette: palette})
     buf = cmap.v_map_screen([0...palette.length])
-    buf8 = new Uint8ClampedArray(buf)
+    buf8 = new Uint8Array(buf)
     image_data.data.set(buf8)
     image_ctx.putImageData(image_data, 0, 0)
 

--- a/bokehjs/src/coffee/models/canvas/canvas.coffee
+++ b/bokehjs/src/coffee/models/canvas/canvas.coffee
@@ -32,6 +32,13 @@ export class CanvasView extends BokehView
     fixup_measure_text(@ctx)
     fixup_ellipse(@ctx)
 
+    # fixes up a problem with some versions of IE11
+    # ref: http://stackoverflow.com/questions/22062313/imagedata-set-in-internetexplorer
+    if window.CanvasPixelArray?
+      CanvasPixelArray.prototype.set = (arr) ->
+        for i in [0...@length]
+            @[i] = arr[i]
+
     # map plots reference this attribute
     @map_div = @$('div.bk-canvas-map') ? null
     @set_dims([@model.initial_width, @model.initial_height])

--- a/bokehjs/src/coffee/models/glyphs/image.coffee
+++ b/bokehjs/src/coffee/models/glyphs/image.coffee
@@ -47,7 +47,7 @@ export class ImageView extends GlyphView
       else
         img = _.flatten(@_image[i])
       buf = cmap.v_map_screen(img, true)
-      buf8 = new Uint8ClampedArray(buf)
+      buf8 = new Uint8Array(buf)
       image_data.data.set(buf8)
       ctx.putImageData(image_data, 0, 0)
       @image_data[i] = canvas

--- a/bokehjs/src/coffee/models/glyphs/image_rgba.coffee
+++ b/bokehjs/src/coffee/models/glyphs/image_rgba.coffee
@@ -43,7 +43,7 @@ export class ImageRGBAView extends GlyphView
         color = new Uint32Array(buf)
         for j in [0...flat.length]
           color[j] = flat[j]
-        buf8 = new Uint8ClampedArray(buf)
+        buf8 = new Uint8Array(buf)
         image_data.data.set(buf8)
       ctx.putImageData(image_data, 0, 0)
       @image_data[i] = canvas

--- a/bokehjs/src/coffee/models/mappers/color_mapper.coffee
+++ b/bokehjs/src/coffee/models/mappers/color_mapper.coffee
@@ -55,7 +55,7 @@ export class ColorMapper extends Model
 
   _is_little_endian: () ->
     buf = new ArrayBuffer(4)
-    buf8 = new Uint8ClampedArray(buf)
+    buf8 = new Uint8Array(buf)
     buf32 = new Uint32Array(buf)
     buf32[1] = 0x0a0b0c0d
 


### PR DESCRIPTION
issues: fixes #5526

This is hard for me to test on different windows VMs from dev. I tested that `image.py` `image_url.py` and `color_data_map.py` work on Win7 + IE 11. I'd like to merge this and make a dev build, which will be much easier to test. 

ping @bokeh/dev 