### PR TITLE
get fonts to load properly on IE11

### DIFF
--- a/sphinx/source/bokeh_theme/layout.html
+++ b/sphinx/source/bokeh_theme/layout.html
@@ -15,7 +15,14 @@
 
   <!-- FONT
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-  <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600%7CNoto+Sans:400,700' rel='stylesheet' type='text/css'>
+  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
+  <script>
+    WebFont.load({
+      google: {
+        families: ['Source Sans Pro']
+      }
+    });
+  </script>
 
   <!-- CSS
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->


### PR DESCRIPTION
 issues: fixes #5522 

Solves the problem for real. c.f. http://bokeh.pydata.org/en/test/ on Win7 IE11

Also:

<img width="1533" alt="screen shot 2016-12-09 at 4 44 24 pm" src="https://cloud.githubusercontent.com/assets/1078448/21067125/e9ff4e5c-be2e-11e6-9896-2d351b674b08.png">



