### PR TITLE
use io.open with encoding whenever file writing by hand

### DIFF
--- a/examples/embed/animated.py
+++ b/examples/embed/animated.py
@@ -23,6 +23,8 @@ in this directory. Navigate to
 """
 from __future__ import print_function
 
+import io
+
 from numpy import pi, cos, sin, linspace, roll
 
 from bokeh.client import push_session
@@ -59,7 +61,7 @@ html = """
 </html>
 """ % autoload_server(p, session_id=session.id)
 
-with open("animated.html", "w+") as f:
+with io.open("animated.html", mode='w+', encoding='utf-8') as f:
     f.write(html)
 
 print(__doc__)

--- a/examples/embed/embed_multiple.py
+++ b/examples/embed/embed_multiple.py
@@ -1,3 +1,5 @@
+import io
+
 from jinja2 import Template
 
 from bokeh.embed import components
@@ -76,7 +78,7 @@ html = template.render(js_resources=js_resources,
                        script=script,
                        div=div)
 
-with open(filename, 'w') as f:
+with io.open(filename, mode='w', encoding='utf-8') as f:
     f.write(html)
 
 view(filename)

--- a/examples/embed/embed_multiple_responsive.py
+++ b/examples/embed/embed_multiple_responsive.py
@@ -1,3 +1,4 @@
+import io
 import random
 
 from jinja2 import Template
@@ -62,7 +63,7 @@ html = template.render(js_resources=js_resources,
 
 filename = 'embed_multiple_responsive.html'
 
-with open(filename, 'w') as f:
+with io.open(filename, mode='w', encoding='utf-8') as f:
     f.write(html)
 
 view(filename)

--- a/examples/embed/widget.py
+++ b/examples/embed/widget.py
@@ -23,6 +23,8 @@ in this directory. Navigate to
 """
 from __future__ import print_function
 
+import io
+
 from numpy import pi
 
 from bokeh.client import push_session
@@ -173,7 +175,7 @@ html = """
 </html>
 """ % autoload_server(layout, session_id=session.id)
 
-with open("widget.html", "w+") as f:
+with io.open("widget.html", mode='w+', encoding='utf-8') as f:
     f.write(html)
 
 print(__doc__)

--- a/examples/howto/interactive_bubble/gapminder.py
+++ b/examples/howto/interactive_bubble/gapminder.py
@@ -1,6 +1,7 @@
-import pandas as pd
+import io
 
 from jinja2 import Template
+import pandas as pd
 
 from bokeh.core.properties import field
 from bokeh.embed import file_html
@@ -124,6 +125,6 @@ title = "Bokeh - Gapminder Bubble Plot"
 html = file_html(layout, resources=(js_resources, None), title=title, template=template)
 
 output_file = 'gapminder.html'
-with open(output_file, 'w') as f:
+with io.open(output_file, mode='w', encoding='utf-8') as f:
     f.write(html)
 view(output_file)


### PR DESCRIPTION
 issues: fixes #5306


Went ahead and updated all the examples that did an explicit `open` and `write`