### PR TITLE
have Color convert tuples to css rgb(a) values)

### DIFF
--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -68,6 +68,7 @@ from operator import itemgetter
 
 from six import string_types, iteritems, StringIO
 
+from ..colors import RGB
 from ..util.dependencies import import_optional
 from ..util.deprecation import deprecated
 from ..util.future import with_metaclass
@@ -1503,6 +1504,11 @@ class Color(Either):
                  Tuple(Byte, Byte, Byte),
                  Tuple(Byte, Byte, Byte, Percent))
         super(Color, self).__init__(*types, default=default, help=help)
+
+    def transform(self, value):
+        if isinstance(value, tuple):
+            value = RGB(*value).to_css()
+        return value
 
     def __str__(self):
         return self.__class__.__name__

--- a/bokeh/core/tests/test_properties.py
+++ b/bokeh/core/tests/test_properties.py
@@ -1409,6 +1409,9 @@ class TestProperties(unittest.TestCase):
         self.assertTrue(prop.is_valid("BLUE"))
         self.assertFalse(prop.is_valid("foobar"))
 
+        self.assertEqual(prop.transform((0, 127, 255)), "rgb(0, 127, 255)")
+        self.assertEqual(prop.transform((0, 127, 255, 0.1)), "rgba(0, 127, 255, 0.1)")
+
     def test_Align(self):
         prop = Align() # TODO
         assert prop

--- a/bokehjs/src/coffee/models/annotations/legend.coffee
+++ b/bokehjs/src/coffee/models/annotations/legend.coffee
@@ -141,6 +141,8 @@ export class LegendView extends AnnotationView
           view = @plot_view.renderer_views[r.id]
           view.draw_legend(ctx, x1, x2, y1, y2, field, label)
 
+    return null
+
   _get_size: () ->
     bbox = @compute_legend_bbox()
     side = @model.panel.side


### PR DESCRIPTION
- [x] issues: fixes #5324
- [x] tests added / passed

The following code
```
import numpy as np
from bokeh.plotting import figure, output_file, show
from bokeh.models import LinearColorMapper, ColumnDataSource
from bokeh.palettes import viridis

x = np.linspace(0, 1, 100)
z = np.linspace(0, 1, 100)
z[40:45] = np.NaN

p = figure(plot_width=800, plot_height=400)

source= ColumnDataSource(data=dict(x=x, z=z))
cmapper = LinearColorMapper(viridis(256), low=0.25, high=0.75, nan_color='#ff33dd',
                            low_color='grey', high_color=(100, 100, 255, 0.3))
p.scatter(x='x', y=1, size=10, color={'field': 'z', 'transform': cmapper}, source=source)

output_file("foo.html")

show(p)
```

Generates the output:

<img width="871" alt="screen shot 2016-12-12 at 12 04 23 pm" src="https://cloud.githubusercontent.com/assets/1078448/21110522/2307d6f2-c063-11e6-9d67-6ade38d9453c.png">

