### PR TITLE
hotfix for data<=0 in log axes

### DIFF
--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -18,8 +18,8 @@
   },
   "devDependencies": {
     "browserify": "^11.1.0",
-    "resolve": "^1.1.6",
-    "chai": "^2.2.0",
+    "resolve": "^1.1.7",
+    "chai": "^3.5.0",
     "chai-as-promised" : "^5.1.0",
     "cheerio": "^0.19.0",
     "coffeeify": "^0.7.0",

--- a/bokehjs/src/coffee/models/ranges/data_range1d.coffee
+++ b/bokehjs/src/coffee/models/ranges/data_range1d.coffee
@@ -86,6 +86,10 @@ export class DataRange1d extends DataRange
     if range_padding? and range_padding > 0
 
       if @_mapper_type == "log"
+        if min <= 0 #hotfix
+          min = 1
+        if max <= 0
+          max = 10
         log_min = Math.log(min) / Math.log(10)
         log_max = Math.log(max) / Math.log(10)
         if max == min

--- a/bokehjs/src/coffee/models/ranges/data_range1d.coffee
+++ b/bokehjs/src/coffee/models/ranges/data_range1d.coffee
@@ -1,6 +1,7 @@
 import * as _ from "underscore"
 
 import {DataRange} from "./data_range"
+import {GlyphRenderer} from "../renderers/glyph_renderer"
 import {logger} from "../../core/logging"
 import * as p from "../../core/properties"
 import * as bbox from "../../core/util/bbox"
@@ -48,7 +49,7 @@ export class DataRange1d extends DataRange
     if renderers.length == 0
       for plot in @plots
         all_renderers = plot.renderers
-        rs = (r for r in all_renderers when r.type == "GlyphRenderer")
+        rs = (r for r in all_renderers when r instanceof GlyphRenderer)
         renderers = renderers.concat(rs)
 
     if names.length > 0

--- a/bokehjs/test/models/ranges/data_range1d.coffee
+++ b/bokehjs/test/models/ranges/data_range1d.coffee
@@ -7,6 +7,7 @@ p = utils.require "core/properties"
 
 {CustomJS} = utils.require("models/callbacks/customjs")
 {DataRange1d} = utils.require("models/ranges/data_range1d")
+{GlyphRenderer} = utils.require("models/renderers/glyph_renderer")
 
 class TestObject extends HasProps
   type: 'TestObject'
@@ -107,15 +108,13 @@ describe "datarange1d module", ->
     it "should add renderers from one plot", ->
       r = new DataRange1d()
       p = new TestObject()
-      g = new TestObject()
-      g.type = "GlyphRenderer"
+      g = new GlyphRenderer()
       p.renderers = [g]
       r.plots = [p]
       expect(r.computed_renderers()).to.be.deep.equal [g]
 
       r = new DataRange1d()
-      g2 = new TestObject()
-      g2.type = "GlyphRenderer"
+      g2 = new GlyphRenderer()
       p.renderers = [g, g2]
       r.plots = [p]
       expect(r.computed_renderers()).to.be.deep.equal [g, g2]
@@ -124,13 +123,11 @@ describe "datarange1d module", ->
     it "should add renderers from multiple plot", ->
       r = new DataRange1d()
       p = new TestObject()
-      g = new TestObject()
-      g.type = "GlyphRenderer"
+      g = new GlyphRenderer()
       p.renderers = [g]
 
       p2 = new TestObject()
-      g2 = new TestObject()
-      g2.type = "GlyphRenderer"
+      g2 = new GlyphRenderer()
       p2.renderers = [g2]
 
       r.plots = [p, p2]
@@ -139,13 +136,11 @@ describe "datarange1d module", ->
     it "should respect user-set renderers", ->
       r = new DataRange1d()
       p = new TestObject()
-      g = new TestObject()
-      g.type = "GlyphRenderer"
+      g = new GlyphRenderer()
       p.renderers = [g]
 
       p2 = new TestObject()
-      g2 = new TestObject()
-      g2.type = "GlyphRenderer"
+      g2 = new GlyphRenderer()
       p2.renderers = [g2]
 
       r.plots = [p, p2]
@@ -268,8 +263,7 @@ describe "datarange1d module", ->
     it "should update its start and end values", ->
       r = new DataRange1d()
       p = new TestObject()
-      g = new TestObject()
-      g.type = "GlyphRenderer"
+      g = new GlyphRenderer()
       g.id = 1
       p.renderers = [g]
       r.plots = [p]
@@ -285,8 +279,7 @@ describe "datarange1d module", ->
       r = new DataRange1d()
       r._mapper_type = "log"
       p = new TestObject()
-      g = new TestObject()
-      g.type = "GlyphRenderer"
+      g = new GlyphRenderer()
       g.id = 1
       p.renderers = [g]
       r.plots = [p]

--- a/bokehjs/test/models/ranges/data_range1d.coffee
+++ b/bokehjs/test/models/ranges/data_range1d.coffee
@@ -289,8 +289,8 @@ describe "datarange1d module", ->
       }
 
       r.update(bds, 0, 1)
-      expect(r.start).to.be.equal r.start #test will fail when r.start is NaN because NaN != NaN
-      expect(r.end).to.be.equal r.end
+      expect(r.start).not.to.be.NaN
+      expect(r.end).not.to.be.NaN
 
   describe "changing model attribute", ->
 

--- a/bokehjs/test/models/ranges/data_range1d.coffee
+++ b/bokehjs/test/models/ranges/data_range1d.coffee
@@ -263,6 +263,42 @@ describe "datarange1d module", ->
       expect(r._compute_plot_bounds([g1], bds)).to.be.deep.equal {minX: 0, maxX: 10, minY: 5, maxY: 6}
       expect(r._compute_plot_bounds([g1, g2], bds)).to.be.deep.equal {minX: 0, maxX: 15, minY: 5, maxY: 6}
 
+  describe "update", ->
+
+    it "should update its start and end values", ->
+      r = new DataRange1d()
+      p = new TestObject()
+      g = new TestObject()
+      g.type = "GlyphRenderer"
+      g.id = 1
+      p.renderers = [g]
+      r.plots = [p]
+
+      bds = {
+        1: {minX: -10, maxX: -6, minY: 5, maxY: 6}
+      }
+
+      r.update(bds, 0, 1)
+      expect(r.start).to.be.equal -10.2
+
+    it "should not update its start or end values to NaN when log", ->
+      r = new DataRange1d()
+      r._mapper_type = "log"
+      p = new TestObject()
+      g = new TestObject()
+      g.type = "GlyphRenderer"
+      g.id = 1
+      p.renderers = [g]
+      r.plots = [p]
+
+      bds = {
+        1: {minX: -10, maxX: -6, minY: 5, maxY: 6}
+      }
+
+      r.update(bds, 0, 1)
+      expect(r.start).to.be.equal r.start #test will fail when r.start is NaN because NaN != NaN
+      expect(r.end).to.be.equal r.end
+
   describe "changing model attribute", ->
 
     it "should execute callback once", ->


### PR DESCRIPTION
Changing the way log ranges compute their `start` and `end` values in PR [5477](https://github.com/bokeh/bokeh/pull/5477) introduced a bug where plot bounds cannot be computed if there are values <= 0 in the data. 

This first commit is a hotfix and results in (check related issue #5549 for test code):
![image](https://cloud.githubusercontent.com/assets/4241244/21171912/e5fe2104-c183-11e6-8245-d53da7ec4f9f.png)
for `values = np.linspace(-0.1, 10, 21)`

and
![image](https://cloud.githubusercontent.com/assets/4241244/21171928/ff8191ba-c183-11e6-855b-86b66ec50d51.png)
for `values = np.linspace(-0.1, 0.9, 21)`

The reason the second one looks worse than the first is because the maximum value is less than the hotfixed minimum value of 1. Line plots where there is a value of 0 in the log axis also show lines pointing to -Infinity. 

I can add on to this PR once I've figured out a better solution (there's a comment in related issue #5549 about what would be necessary), or start another PR if this new bug needs a fast fix. 


EDIT: I created a new issue #5576 that is fixed by this PR. Addressing #5549 will take some more investigation and I won't have that much time in the next couple days. After this PR the plots generated by the test code in #5576 are restored to their original (semi-broken) selves. 

- [x] issues: fixes #5576
- [x] tests added / passed

