### PR TITLE
Custom context arguments for the jinja template

### DIFF
--- a/bokeh/document.py
+++ b/bokeh/document.py
@@ -301,6 +301,7 @@ class Document(object):
         self._session_callbacks = {}
         self._session_context = None
         self._modules = []
+        self._template_variables = {}
 
     def __del__(self):
         for module in self._modules:
@@ -407,6 +408,10 @@ class Document(object):
         if not isinstance(template, jinja2.Template):
             raise ValueError("Document templates must be Jinja2 Templates")
         self._template = template
+
+    @property
+    def template_variables(self):
+        return self._template_variables
 
     @property
     def theme(self):

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -616,7 +616,8 @@ def server_html_page_for_models(session_id, model_ids, resources, title, websock
     bundle = _bundle_for_objs_and_resources(None, resources)
     return _html_page_for_render_items(bundle, {}, render_items, title, template=template, websocket_url=websocket_url)
 
-def server_html_page_for_session(session_id, resources, title, websocket_url, template=FILE):
+def server_html_page_for_session(session_id, resources, title, websocket_url, template=FILE,
+                                 template_variables=None):
     elementid = make_id()
     render_items = [{
         'sessionid' : session_id,
@@ -625,5 +626,9 @@ def server_html_page_for_session(session_id, resources, title, websocket_url, te
         # no 'modelid' implies the entire session document
     }]
 
+    if template_variables is None:
+        template_variables = {}
+
     bundle = _bundle_for_objs_and_resources(None, resources)
-    return _html_page_for_render_items(bundle, {}, render_items, title, template=template, websocket_url=websocket_url)
+    return _html_page_for_render_items(bundle, {}, render_items, title, template=template,
+            websocket_url=websocket_url, template_variables=template_variables)

--- a/bokeh/server/views/doc_handler.py
+++ b/bokeh/server/views/doc_handler.py
@@ -30,7 +30,8 @@ class DocHandler(SessionHandler):
         page = server_html_page_for_session(session.id, self.application.resources(self.request),
                                             title=session.document.title,
                                             template=session.document.template,
-                                            websocket_url=websocket_url)
+                                            websocket_url=websocket_url,
+                                            template_variables=session.document.template_variables)
 
         self.set_header("Content-Type", 'text/html')
         self.write(page)

--- a/bokeh/tests/test_document.py
+++ b/bokeh/tests/test_document.py
@@ -29,7 +29,7 @@ class TestDocument(unittest.TestCase):
     def test_empty(self):
         d = document.Document()
         assert not d.roots
-        
+
     def test_default_template_vars(self):
         d = document.Document()
         assert not d.roots

--- a/bokeh/tests/test_document.py
+++ b/bokeh/tests/test_document.py
@@ -31,7 +31,7 @@ class TestDocument(unittest.TestCase):
         assert not d.roots
         
     def test_default_template_vars(self):
-        d = = document.Document()
+        d = document.Document()
         assert not d.roots
         assert d.template_variables == {}
 

--- a/bokeh/tests/test_document.py
+++ b/bokeh/tests/test_document.py
@@ -29,6 +29,11 @@ class TestDocument(unittest.TestCase):
     def test_empty(self):
         d = document.Document()
         assert not d.roots
+        
+    def test_default_template_vars(self):
+        d = = document.Document()
+        assert not d.roots
+        assert d.template_variables == {}
 
     def test_add_roots(self):
         d = document.Document()

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -241,8 +241,7 @@ The optional components are
 
 * A ``templates`` subdirectory with ``index.html`` Jinja template file. The directory may contain additional Jinja templates for ``index.html`` to refer to. The template should have the same parameters as the :class:`~bokeh.core.templates.FILE` template.
 
-Custom variables can be passed to the template via the ``curdoc().template_variables`` 
-dictionary in place:
+Custom variables can be passed to the template via the ``curdoc().template_variables`` dictionary in place:
 
 .. code-block:: python
 

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -240,7 +240,17 @@ The optional components are
 * A ``theme.yaml`` file that declaratively defines default attributes to be applied to Bokeh model types.
 
 * A ``templates`` subdirectory with ``index.html`` Jinja template file. The directory may contain additional Jinja templates for ``index.html`` to refer to. The template should have the same parameters as the :class:`~bokeh.core.templates.FILE` template.
-Custom variables can be passed to the template via the ``curdoc().template_variables`` dictionary.
+
+Custom variables can be passed to the template via the ``curdoc().template_variables`` 
+dictionary in place:
+
+.. code-block:: python
+
+    # set a new single key/value
+    curdoc().template_variables["user_id"] = user_id
+
+    # or update multiple at once
+    curdoc().template_variables.update(first_name="Mary", last_name="Jones")
 
 When executing your ``main.py`` Bokeh server ensures that the standard
 ``__file__`` module attribute works as you would expect. So it is possible

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -240,6 +240,7 @@ The optional components are
 * A ``theme.yaml`` file that declaratively defines default attributes to be applied to Bokeh model types.
 
 * A ``templates`` subdirectory with ``index.html`` Jinja template file. The directory may contain additional Jinja templates for ``index.html`` to refer to. The template should have the same parameters as the :class:`~bokeh.core.templates.FILE` template.
+Custom variables can be passed to the template via the ``curdoc().template_variables`` dictionary.
 
 When executing your ``main.py`` Bokeh server ensures that the standard
 ``__file__`` module attribute works as you would expect. So it is possible


### PR DESCRIPTION
With this you can use something like:
```
curdoc().template_variables['myvariable'] = '42'
```
And add `{{ myvariable }}` to the `index.html`.

I wasn't quite sure if `Document.template_variables` needs a setter as well. Thoughts?

fixes #5583