### PR TITLE
Fix autoload templates to inject data into JS templates properly

### DIFF
--- a/bokeh/core/_templates/autoload_js.js
+++ b/bokeh/core/_templates/autoload_js.js
@@ -29,7 +29,7 @@ calls it with the rendered model.
     return new Date();
   }
 
-  var force = {{ force|json }};
+  var force = {{ force|default(False)|json }};
 
   if (typeof (window._bokeh_onload_callbacks) === "undefined" || force === true) {
     window._bokeh_onload_callbacks = [];

--- a/bokeh/core/_templates/autoload_js.js
+++ b/bokeh/core/_templates/autoload_js.js
@@ -29,9 +29,9 @@ calls it with the rendered model.
     return new Date();
   }
 
-  var force = "{{ force }}";
+  var force = {{ force|json }};
 
-  if (typeof (window._bokeh_onload_callbacks) === "undefined" || force !== "") {
+  if (typeof (window._bokeh_onload_callbacks) === "undefined" || force === true) {
     window._bokeh_onload_callbacks = [];
     window._bokeh_is_loading = undefined;
   }
@@ -79,14 +79,14 @@ calls it with the rendered model.
   };
 
   {%- if elementid -%}
-  var element = document.getElementById("{{ elementid }}");
+  var element = document.getElementById({{ elementid|json }});
   if (element == null) {
     console.log("Bokeh: ERROR: autoload.js configured with elementid '{{ elementid }}' but no matching script tag was found. ")
     return false;
   }
   {%- endif %}
 
-  var js_urls = {{ js_urls }};
+  var js_urls = {{ js_urls|json }};
 
   var inline_js = [
     {%- for js in js_raw %}
@@ -97,7 +97,7 @@ calls it with the rendered model.
     function(Bokeh) {
       {%- for url in css_urls %}
       console.log("Bokeh: injecting CSS: {{ url }}");
-      Bokeh.embed.inject_css("{{ url }}");
+      Bokeh.embed.inject_css({{ url|json }});
       {%- endfor %}
       {%- for css in css_raw %}
       console.log("Bokeh: injecting raw CSS");

--- a/bokeh/core/_templates/autoload_nb_js.js
+++ b/bokeh/core/_templates/autoload_nb_js.js
@@ -1,8 +1,8 @@
 {% extends "autoload_js.js" %}
 
 {% block autoload_init %}
-  if (typeof (window._bokeh_timeout) === "undefined" || force !== "") {
-    window._bokeh_timeout = Date.now() + {{ timeout|default(0) }};
+  if (typeof (window._bokeh_timeout) === "undefined" || force === true) {
+    window._bokeh_timeout = Date.now() + {{ timeout|default(0)|json }};
     window._bokeh_failed_load = false;
   }
 
@@ -24,7 +24,7 @@
 
   function display_loaded() {
     if (window.Bokeh !== undefined) {
-      document.getElementById("{{ elementid }}").textContent = "BokehJS successfully loaded.";
+      document.getElementById({{ elementid|json }}).textContent = "BokehJS successfully loaded.";
     } else if (Date.now() < window._bokeh_timeout) {
       setTimeout(display_loaded, 100)
     }
@@ -33,18 +33,18 @@
   {%- if comms_target -%}
   if ((window.Jupyter !== undefined) && Jupyter.notebook.kernel) {
     comm_manager = Jupyter.notebook.kernel.comm_manager
-    comm_manager.register_target("{{ comms_target }}", function () {});
+    comm_manager.register_target({{ comms_target|json }}, function () {});
   }
   {%- endif -%}
 {% endblock %}
 
 {% block run_inline_js %}
-    if ((window.Bokeh !== undefined) || (force === "1")) {
+    if ((window.Bokeh !== undefined) || (force === true)) {
       for (var i = 0; i < inline_js.length; i++) {
         inline_js[i](window.Bokeh);
       }
       {%- if elementid -%}
-      if (force === "1") {
+      if (force === true) {
         display_loaded();
       }
       {%- endif -%}
@@ -53,8 +53,8 @@
     } else if (!window._bokeh_failed_load) {
       console.log("Bokeh: BokehJS failed to load within specified timeout.");
       window._bokeh_failed_load = true;
-    } else if (!force) {
-      var cell = $("#{{ elementid }}").parents('.cell').data().cell;
+    } else if (force !== true) {
+      var cell = $(document.getElementById({{ elementid|json }})).parents('.cell').data().cell;
       cell.output_area.append_execute_result(NB_LOAD_WARNING)
     }
 {% endblock %}

--- a/bokeh/core/templates.py
+++ b/bokeh/core/templates.py
@@ -16,9 +16,12 @@ Bokeh models (e.g. plots, widgets, layouts) in various ways.
 '''
 from __future__ import absolute_import
 
-from jinja2 import Environment, PackageLoader
+import json
+
+from jinja2 import Environment, PackageLoader, Markup
 
 _env = Environment(loader=PackageLoader('bokeh.core', '_templates'))
+_env.filters['json'] = lambda obj: Markup(json.dumps(obj))
 
 JS_RESOURCES = _env.get_template("js_resources.html")
 CSS_RESOURCES = _env.get_template("css_resources.html")

--- a/bokeh/util/notebook.py
+++ b/bokeh/util/notebook.py
@@ -81,7 +81,7 @@ def _load_notebook_html(resources=None, verbose=False, hide_banner=False,
         css_urls = resources.css_files,
         js_raw   = resources.js_raw + ([] if hide_banner else [FINALIZE_JS % element_id]),
         css_raw  = resources.css_raw_str,
-        force    = 1,
+        force    = True,
         timeout  = load_timeout
     )
 


### PR DESCRIPTION
Previously we relied on Python's `str()` returning valid JS. Sometimes it actually and very deceptively does.

fixes #5558