### PR TITLE
Don't inherit __future__ flags in compile()

### DIFF
--- a/bokeh/application/handlers/code_runner.py
+++ b/bokeh/application/handlers/code_runner.py
@@ -20,7 +20,7 @@ class _CodeRunner(object):
 
         try:
             nodes = ast.parse(source, path)
-            self._code = compile(nodes, filename=path, mode='exec')
+            self._code = compile(nodes, filename=path, mode='exec', dont_inherit=True)
         except SyntaxError as e:
             self._failed = True
             self._error = ("Invalid syntax in \"%s\" on line %d:\n%s" % (os.path.basename(e.filename), e.lineno, e.text))

--- a/bokeh/application/handlers/tests/test_code.py
+++ b/bokeh/application/handlers/tests/test_code.py
@@ -5,6 +5,8 @@ import unittest
 from bokeh.application.handlers import CodeHandler
 from bokeh.document import Document
 
+from bokeh.util.testing import skipIfPy3
+
 script_adds_two_roots = """
 from bokeh.io import curdoc
 from bokeh.model import Model
@@ -26,6 +28,16 @@ class TestCodeHandler(unittest.TestCase):
     def test_empty_script(self):
         doc = Document()
         handler = CodeHandler(source="# This script does nothing", filename="path/to/test_filename")
+        handler.modify_document(doc)
+        if handler.failed:
+            raise RuntimeError(handler.error)
+
+        assert not doc.roots
+
+    @skipIfPy3("this test doesn't have a Python 3 equivalent")
+    def test_exec_and___future___flags(self):
+        doc = Document()
+        handler = CodeHandler(source="exec(\"print \\\"XXX\\\"\")", filename="path/to/test_filename")
         handler.modify_document(doc)
         if handler.failed:
             raise RuntimeError(handler.error)


### PR DESCRIPTION
Apparently `__future__` flags (imports) from the parent environment (so `code_runner.py`) are forwarded to `compile()`. There exists `dont_inherit` boolean argument that doesn't allow that. I tested this manually, but we may want to write tests for this some how. It's sufficient to test for `exec("print 'XXX'")`, but I'm not sure what to do about Python 3. 

fixes #5590
