### PR TITLE
Resolve overlapping histogram bars (#3315)

### DIFF
--- a/bokeh/charts/stats.py
+++ b/bokeh/charts/stats.py
@@ -434,9 +434,9 @@ class Histogram(BinnedStat):
         for i, b in enumerate(binned):
             width = bin_bounds[i+1] - bin_bounds[i]
             if i == 0:
-                lbl = "[%.1f, %.1f]" % (bin_bounds[i], bin_bounds[i+1])
+                lbl = "[%f, %f]" % (bin_bounds[i], bin_bounds[i+1])
             else:
-                lbl = "(%.1f, %.1f]" % (bin_bounds[i], bin_bounds[i+1])
+                lbl = "(%f, %f]" % (bin_bounds[i], bin_bounds[i+1])
             self.bins.append(Bin(bin_label=lbl, values=[binned[i]], stat=Max(),
                 width=width))
 

--- a/bokeh/charts/tests/test_stats.py
+++ b/bokeh/charts/tests/test_stats.py
@@ -37,7 +37,7 @@ def test_histogram_wo_density():
     h = Histogram(values=values, bins=3)
 
     assert len(h.bins) == 3
-    assert [b.label[0] for b in h.bins] == ['[0.0, 3.0]', '(3.0, 6.0]', '(6.0, 9.0]']
+    assert [b.label[0] for b in h.bins] == ['[0.000000, 3.000000]', '(3.000000, 6.000000]', '(6.000000, 9.000000]']
     assert [b.values[0] for b in h.bins] == [3, 3, 4]
 
 
@@ -46,7 +46,7 @@ def test_histogram_w_density():
     h = Histogram(values=values, bins=3, density=True)
 
     assert len(h.bins) == 3
-    assert [b.label[0] for b in h.bins] == ['[0.0, 3.0]', '(3.0, 6.0]', '(6.0, 9.0]']
+    assert [b.label[0] for b in h.bins] == ['[0.000000, 3.000000]', '(3.000000, 6.000000]', '(6.000000, 9.000000]']
     assert [b.values[0] for b in h.bins] == [0.1, 0.1, 0.13333333333333333]
 
 


### PR DESCRIPTION
Trivial fix that skips rounding of `center` position strings.

- [x] issues: fixes #3315
- [x] tests passed
