### PR TITLE
Make use of Fabric3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ matrix:
       env: GROUP=examples
     - python: 3.4
       env: GROUP=examples
-    # Linting and Docs (no python3 version of fabric)
-    - python: 2.7
+    # Linting and Docs
+    - python: 3.4
       env: GROUP=flake_docs
     # Integration test
     - python: 3.4
@@ -105,7 +105,8 @@ script:
 after_success: |
   if [[ ! -z "$TRAVIS_TAG" && "$TRAVIS_PYTHON_VERSION" == '2.7' && "$GROUP" == flake_docs ]]; then
       # Install some additional dependencies
-      conda install anaconda-client fabric3 --yes
+      conda install anaconda-client --yes
+      conda install -c conda-forge fabric3
       # Decrypt some files and place them in the correct location
       openssl aes-256-cbc -K $encrypted_c19429b59af5_key -iv $encrypted_c19429b59af5_iv -in secrets.tar.enc -out secrets.tar -d
       tar xvf secrets.tar

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ script:
 after_success: |
   if [[ ! -z "$TRAVIS_TAG" && "$TRAVIS_PYTHON_VERSION" == '2.7' && "$GROUP" == flake_docs ]]; then
       # Install some additional dependencies
-      conda install anaconda-client fabric --yes
+      conda install anaconda-client fabric3 --yes
       # Decrypt some files and place them in the correct location
       openssl aes-256-cbc -K $encrypted_c19429b59af5_key -iv $encrypted_c19429b59af5_iv -in secrets.tar.enc -out secrets.tar -d
       tar xvf secrets.tar


### PR DESCRIPTION
Since Bokeh is moving towards Python3, it would make sense to use Python 3 fork of Fabric.

Reference Conversation: https://github.com/bokeh/bokeh/issues/5557

- [x] issues: fixes #5557 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
