### PR TITLE
Add custom extensions for autocompletion widgets

### DIFF
--- a/examples/custom/autocomplete/autocomplete_input.coffee
+++ b/examples/custom/autocomplete/autocomplete_input.coffee
@@ -1,0 +1,28 @@
+import * as _ from "underscore"
+# import "jquery-ui/autocomplete"
+
+import {TextInput, TextInputView} from "models/widgets/text_input"
+import * as p from "core/properties"
+
+export class AutocompleteInputView extends TextInputView
+
+  render: () ->
+    super()
+    $input = @$el.find("input")
+    $input.autocomplete({source: @model.completions
+                         minLength: @model.min_chars
+                         autoFocus: @model.auto_first
+                        })
+    # TODO: add css?
+    $input.autocomplete("widget").addClass("bk-ui-autocomplete")
+    return @
+
+export class AutocompleteInput extends TextInput
+  type: "AutocompleteInput"
+  default_view: AutocompleteInputView
+
+  @define {
+    completions: [ p.Array, [] ]
+    min_chars: [ p.Number, 2 ]
+    auto_first: [ p.Bool, false ]
+  }

--- a/examples/custom/autocomplete/autocomplete_input.py
+++ b/examples/custom/autocomplete/autocomplete_input.py
@@ -1,0 +1,22 @@
+from bokeh.core.properties import List, String, Int, Bool
+from bokeh.models.widgets import TextInput
+
+class AutocompleteInput(TextInput):
+    """ Single-line input widget with auto-completion. """
+
+    __implementation__ = "autocomplete_input.coffee"
+    __css__ = ["https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.css"]
+
+    completions = List(String, help="""
+    A list of completion strings. This will be used to guide the
+    user upon typing the beginning of a desired value.
+    """)
+
+    min_chars = Int(default=2, help="""
+    Minimum characteres the user has to type before the autocomplete
+    popup shows up.
+    """)
+
+    auto_first = Bool(default=False, help="""
+    Whether the first element should be automatically selected
+    """)

--- a/examples/custom/autocomplete/awesomplete_input.coffee
+++ b/examples/custom/autocomplete/awesomplete_input.coffee
@@ -1,0 +1,36 @@
+import {TextInput, TextInputView} from "models/widgets/text_input"
+import * as p from "core/properties"
+
+
+export class AwesompleteInputView extends TextInputView
+
+  # initialize: (options) ->
+  #   super(options)
+
+  render: () ->
+    super()
+    $input = @$el.find("input")
+    $input.addClass("dropdown-input")
+    # NOTE: creating new Awesomplete object here, because render()
+    # will cause the entire input element to be redrawn. Not sure
+    # if there's significant performance penalty to this.
+    @awesomplete = new Awesomplete($input[0])
+    @awesomplete.list = @model.completions
+    @awesomplete.minChars = @model.min_chars
+    @awesomplete.maxItems = @model.max_items
+    @awesomplete.autoFirst = @model.auto_first
+    # Normalize label display to other textinput widgets
+    @$el.find("div.awesomplete").css("display", "block")
+    return @
+
+export class AwesompleteInput extends TextInput
+  type: "AwesompleteInput"
+  default_view: AwesompleteInputView
+
+  # defaults are from awesomplete
+  @define {
+    completions: [ p.Array, [] ]
+    min_chars: [ p.Number, 2 ]
+    max_items: [ p.Number, 10 ]
+    auto_first: [ p.Bool, false ]
+  }

--- a/examples/custom/autocomplete/awesomplete_input.py
+++ b/examples/custom/autocomplete/awesomplete_input.py
@@ -1,0 +1,27 @@
+from bokeh.core.properties import List, String, Int, Bool
+from bokeh.models.widgets import TextInput
+
+class AwesompleteInput(TextInput):
+    """ Single-line input widget with auto-completion. """
+
+    __implementation__ = "awesomplete_input.coffee"
+    __css__ = ["https://cdnjs.cloudflare.com/ajax/libs/awesomplete/1.1.1/awesomplete.css"]
+    __javascript__ = ["https://cdnjs.cloudflare.com/ajax/libs/awesomplete/1.1.1/awesomplete.js"]
+
+    completions = List(String, help="""
+    A list of completion strings. This will be used to guide the
+    user upon typing a substring of a desired value.
+    """)
+
+    min_chars = Int(default=2, help="""
+    Minimum characteres the user has to type before the autocomplete
+    popup shows up.
+    """)
+
+    max_items = Int(default=10, help="""
+    Maximum number of suggestions to display.
+    """)
+
+    auto_first = Bool(default=False, help="""
+    Whether the first element should be automatically selected
+    """)

--- a/examples/custom/autocomplete/main.py
+++ b/examples/custom/autocomplete/main.py
@@ -1,6 +1,7 @@
 """
 Example bokeh app for custom extensions to render a simple autocomplete
-text input box, using JQuery, awesomplete libraries respectively.
+text input box, using JQuery, awesomplete, jquery-textext, and jquery-tokeninput
+libraries respectively.
 
 As it turns out, there are a lot of independent autocomplete implementations.
 Some suggested libraries appear in these lists (many focus on ajax
@@ -26,6 +27,8 @@ from bokeh.plotting import curdoc
 
 from awesomplete_input import AwesompleteInput
 from autocomplete_input import AutocompleteInput
+# from textext_input import TextExtInput
+from token_input import TokenInput
 
 # Properties for autocompletion
 completions = dir(__builtins__)
@@ -45,7 +48,23 @@ awes_input = AwesompleteInput(completions=completions,
                               min_chars=min_chars,
                               auto_first=auto_first,
                               title="awesomplete")
-all_inputs = [auto_input, awes_input]
+# FIXME
+# Please note that these input widgets are not currently functional.
+# The main issues:
+#  1. CSS is not yet figured out, especially after the first pss.
+#  2. Both of these autocompleters support tags, and do not directly
+#     update the textinput's value field. Have not yet done any
+#     wiring for such.
+#  3. Selecting an autocompletion and then losing focus / pressing enter
+#     does not seem to trigger an on_change() callback.
+## text_input = TextExtInput(completions=completions,
+##                           title="textext")
+token_input = TokenInput(completions=completions,
+                         title="token")
+all_inputs = [auto_input,
+              awes_input,
+              # text_input,
+              token_input]
 
 new_input = TextInput(value="foo bar",
                       placeholder="option",
@@ -64,8 +83,9 @@ checkboxes = CheckboxButtonGroup(labels=["Auto Focus First",
 # autocompletion widgets, such as those with multiple tags.
 def on_input_value_update(attr, old_value, new_value):
     """Display current contents of autocompletion inputs"""
-    div_values.text = "Current values:" + " | ".join([a.value for a in all_inputs])
-for a_input in all_inputs:
+    div_values.text = "Current values:" + " | ".join([a.value for a in (auto_input, awes_input)] +
+                                                     [str(a.values) for a in (token_input,)])
+for a_input in [auto_input, awes_input]:
     a_input.on_change("value", on_input_value_update)
 
 # Register callbacks to change properties of autocompletion menus,

--- a/examples/custom/autocomplete/main.py
+++ b/examples/custom/autocomplete/main.py
@@ -1,0 +1,101 @@
+"""
+Example bokeh app for custom extensions to render a simple autocomplete
+text input box, using JQuery, awesomplete libraries respectively.
+
+As it turns out, there are a lot of independent autocomplete implementations.
+Some suggested libraries appear in these lists (many focus on ajax
+support though which may be extraneous for bokeh apps):
+* http://techslides.com/list-of-autocomplete-plugins-and-libraries
+* http://ourcodeworld.com/articles/read/193/top-10-best-autocomplete-jquery-and-javascript-plugins
+* http://jqueryhouse.com/20-best-jquery-autocomplete-plugins/
+
+Some niche autocompletion libraries that may be of interest:
+* http://vyasrao.github.io/tAutocomplete/ : tabular dropdown
+
+Run with bokeh server, e.g.:
+
+Examples:
+    >>> bokeh serve -m examples/custom/autocomplete
+"""
+from __future__ import print_function
+
+from bokeh.layouts import layout
+from bokeh.models.widgets import (Button, CheckboxButtonGroup,
+                                  Div, Slider, TextInput)
+from bokeh.plotting import curdoc
+
+from awesomplete_input import AwesompleteInput
+from autocomplete_input import AutocompleteInput
+
+# Properties for autocompletion
+completions = dir(__builtins__)
+min_chars = 2
+auto_first = False
+
+div = Div(text="This is an example dashboard for playing with parameters for "
+               "a few autocompletion libraries.<br />"
+               "Autocomplete the name of a python built-in function/member;"
+               " such as \"getattr\" and \"setattr\".")
+div_values = Div(text="Current values:")
+auto_input = AutocompleteInput(completions=completions,
+                               min_chars=min_chars,
+                               auto_first=auto_first,
+                               title="jquery")
+awes_input = AwesompleteInput(completions=completions,
+                              min_chars=min_chars,
+                              auto_first=auto_first,
+                              title="awesomplete")
+all_inputs = [auto_input, awes_input]
+
+new_input = TextInput(value="foo bar",
+                      placeholder="option",
+                      title="Add a new option to autocomplete:"
+                     )
+button = Button(label="Submit new option",
+                button_type="primary")
+slider = Slider(start=0, end=10, value=min_chars, step=1,
+                title="Min length to trigger autocomplete")
+
+checkboxes = CheckboxButtonGroup(labels=["Auto Focus First",
+                                        ],
+                                 active=[])
+
+# Register callbacks to show what the input value is for the more complicated
+# autocompletion widgets, such as those with multiple tags.
+def on_input_value_update(attr, old_value, new_value):
+    """Display current contents of autocompletion inputs"""
+    div_values.text = "Current values:" + " | ".join([a.value for a in all_inputs])
+for a_input in all_inputs:
+    a_input.on_change("value", on_input_value_update)
+
+# Register callbacks to change properties of autocompletion menus,
+# to get a sense of how the various properties work.
+def on_new_option():
+    """Add new option to autocomplete menu"""
+    new_option = new_input.value
+    print("Adding option:", new_option)
+    for a_input in all_inputs:
+        a_input.completions.append(new_option)
+button.on_click(on_new_option)
+
+def on_min_chars_change(attr, old_value, new_value):
+    """Add min chars"""
+    print("Changing min_chars from", old_value, "to", new_value)
+    for a_input in all_inputs:
+        a_input.min_chars = new_value
+slider.on_change("value", on_min_chars_change)
+
+def on_checkbox(attr, old_value, new_value):
+    print("Checked options:", attr, new_value)
+    auto_first = 0 in new_value
+    for a_input in all_inputs:
+        a_input.auto_first = auto_first
+checkboxes.on_change("active", on_checkbox)
+
+curdoc().add_root(layout([[div],
+                          all_inputs,
+                          [div_values],
+                          [new_input, button],
+                          [slider, checkboxes],
+                         ], responsive=True
+                         ))

--- a/examples/custom/autocomplete/tag_input_template.tsx
+++ b/examples/custom/autocomplete/tag_input_template.tsx
@@ -1,0 +1,18 @@
+import * as DOM from "core/util/dom";
+
+interface TagsInputProps {
+  id: string;
+  title: string;
+  name: string;
+  placeholder: string;
+}
+
+export default (props: TagsInputProps): HTMLElement => {
+  return (
+    <fragment>
+      <label for={props.id}> {props.title} </label>
+      <input class="bk-widget-form-input" type="text"
+        id={props.id} name={props.name} placeholder={props.placeholder} />
+    </fragment>
+  )
+}

--- a/examples/custom/autocomplete/textext_input.coffee
+++ b/examples/custom/autocomplete/textext_input.coffee
@@ -1,0 +1,47 @@
+import * as _ from "underscore"
+# Cannot import jquery here, otherwise it overwrites (?) the
+# globally loaded jquery object with function plugins
+# import * as $ from "jquery"
+
+import {TextInput, TextInputView} from "models/widgets/text_input"
+import * as p from "core/properties"
+
+export class TextExtInputView extends TextInputView
+
+  render: () ->
+    super()
+    # TODO: using below hack to use globally loaded jquery, which has
+    # the function plugin extensions, instead of saved @$el object
+    $input = $(@$el.find("input"))
+    completions = @model.completions
+    if $input.textext?
+      # TODO: implement contains instead of match from start:
+      # https://github.com/alexgorbatchev/jquery-textext/issues/168
+      # http://stackoverflow.com/questions/29688035/jquery-textext-set-autocomplete-suggestions-to-filter-based-on-contains-rather
+      $input.textext(
+        # TODO: is using tags plugin too complicated?
+        # For one, need to retrieve value correctly:
+        # http://stackoverflow.com/questions/34007494/get-textext-tags-in-javascript
+        plugins: 'arrow tags autocomplete'
+      ).bind('getSuggestions',
+        (e, data) ->
+          $(this).trigger(
+            'setSuggestions',
+            result: $(e.target).textext()[0].itemManager().filter(
+              completions, (if data then data.query else '') || ''
+            )
+         )
+      )
+    # # TODO: add css?
+    # $input.autocomplete("widget").addClass("bk-ui-autocomplete")
+    return @
+
+export class TextExtInput extends TextInput
+  type: "TextExtInput"
+  default_view: TextExtInputView
+
+  @define {
+    completions: [ p.Array, [] ]
+    min_chars: [ p.Number, 2 ]
+    auto_first: [ p.Bool, false ]
+  }

--- a/examples/custom/autocomplete/textext_input.py
+++ b/examples/custom/autocomplete/textext_input.py
@@ -1,0 +1,29 @@
+from bokeh.core.properties import List, String, Int, Bool
+from bokeh.models.widgets import TextInput
+
+class TextExtInput(TextInput):
+    """ Single-line input widget with multiple tag auto-completion.
+
+    FIXME: JQuery plugin?
+    """
+
+    __implementation__ = "textext_input.coffee"
+    __javascript__ = ["https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.js",
+                      "https://cdnjs.cloudflare.com/ajax/libs/jquery-textext/1.3.0/jquery.textext.min.js",
+                     ]
+    __css__ = ["https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.css"]
+
+    completions = List(String, help="""
+    A list of completion strings. This will be used to guide the
+    user upon typing the beginning of a desired value.
+    """)
+
+    min_chars = Int(default=2, help="""
+    Minimum characteres the user has to type before the autocomplete
+    popup shows up. (Not yet implemented.)
+    """)
+
+    auto_first = Bool(default=False, help="""
+    Whether the first element should be automatically selected
+    (Not yet implemented.)
+    """)

--- a/examples/custom/autocomplete/token_input.coffee
+++ b/examples/custom/autocomplete/token_input.coffee
@@ -1,0 +1,69 @@
+import * as _ from "underscore"
+# Cannot import jquery here, otherwise it overwrites (?) the
+# globally loaded jquery object with function plugins
+# import * as $ from "jquery"
+
+# import {TextInput, TextInputView} from "models/widgets/text_input"
+import {InputWidget, InputWidgetView} from "models/widgets/input_widget"
+import template from "./tag_input_template"
+import * as p from "core/properties"
+
+export class TokenInputView extends InputWidgetView
+  tagName: "div"
+  className: "bk-widget-form-group"
+  template: template
+  # events:
+  #   "change input": "change_input"
+
+  initialize: (options) ->
+    super(options)
+    @render()
+    @listenTo(@model, 'change', @render)
+
+  render: () ->
+    super()
+    @$el.html(@template(@model.attributes))
+
+    # TODO: using below hack to use globally loaded jquery, which has
+    # the function plugin extensions, instead of saved @$el object
+    $input = $(@$el.find("input.bk-widget-form-input"))
+    if $input.tokenInput?
+      completions = ({"name": val} for val in @model.completions)
+      values = ({"name": val} for val in @model.values)
+      this_wrap = @  # bind to closure?
+      $input.tokenInput(completions, {
+          prePopulate: values
+          # propertyToSearch: "name"
+          theme: "facebook"
+          minChars: @model.min_chars
+          onAdd:
+            (item) -> this_wrap.change_tags()
+          onDelete:
+            (item) -> this_wrap.change_tags()
+          # TODO
+          # resultsLimit: @model.max_items
+          })
+    # TODO: listen to onAdd/onDelete to get triggers for when value changed?
+    # And map value to selector.tokenInput("get"); ?
+    # TODO: add css?
+    # $input.autocomplete("widget").addClass("bk-ui-autocomplete")
+    return @
+
+  change_tags: () ->
+    $input = $(@$el.find("input.bk-widget-form-input"))
+    if $input.tokenInput?
+      values = $input.tokenInput("get")
+      console.log("widget/token_input: values #{values}", values)
+      @model.values = (val["name"] for val in values)
+
+export class TokenInput extends InputWidget
+  type: "TokenInput"
+  default_view: TokenInputView
+
+  @define {
+    values: [ p.Array, [] ]
+    placeholder: [ p.String, "" ]
+    completions: [ p.Array, [] ]
+    min_chars: [ p.Number, 2 ]
+    auto_first: [ p.Bool, false ]
+  }

--- a/examples/custom/autocomplete/token_input.py
+++ b/examples/custom/autocomplete/token_input.py
@@ -1,0 +1,39 @@
+from bokeh.core.properties import List, String, Int, Bool
+from bokeh.models.widgets import InputWidget
+
+class TokenInput(InputWidget):
+    """ Single-line input widget with multiple tag auto-completion.
+
+    FIXME: JQuery plugin?
+    """
+
+    __implementation__ = "token_input.coffee"
+    # __javascript__ = ["js/textext.core.js"]
+    __javascript__ = ["https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.js",
+                      "https://cdn.jsdelivr.net/jquery.tokeninput/1.6.0/jquery.tokeninput.js",
+                     ]
+    __css__ = ["https://cdn.jsdelivr.net/jquery.tokeninput/1.6.0/styles/token-input.css",
+               "https://cdn.jsdelivr.net/jquery.tokeninput/1.6.0/styles/token-input-facebook.css",
+               # https://cdn.jsdelivr.net/jquery.tokeninput/1.6.0/styles/token-input-mac.css
+              ]
+
+    values = List(String, help="""
+    """)
+
+    placeholder = String(help="""
+    """)
+
+    completions = List(String, help="""
+    A list of completion strings. This will be used to guide the
+    user upon typing the beginning of a desired value.
+    """)
+
+    min_chars = Int(default=2, help="""
+    Minimum characteres the user has to type before the autocomplete
+    popup shows up.
+    """)
+
+    auto_first = Bool(default=False, help="""
+    Whether the first element should be automatically selected
+    (Not yet implemented.)
+    """)


### PR DESCRIPTION
**Not ready to merge.** Just an initial kind of working attempt at replacing autocomplete widget. Please let me know if the scope of this change looks okay, for example since the `textext` and `tokeninput` extensions are currently non-functional, I can drop them out or spend a bit more time seeing if they can be made to work. There are several other issues mentioned in the TODOs.

The existing jquery-ui based autocompletion widget is non-functional (at
the very least, no css is loaded for the dropdown menu etc). These
custom extensions implement several variations of an autocompletion
widget, using a few of the many available libraries (jquery-ui,
awesomplete, jquery-textext, jquery-tokeninput), as well as a demo app
that can be served by bokeh server.



The jquery-ui and awesomplete extensions are roughly functional, the
textext and tokeninput are just proofs of concept and are effectively
non-functional currently.

- [x] issues: fixes #5596
- [ ] tests added / passed: N/A?
- [ ] release document entry (if new feature or API change)
