### PR TITLE
Render labels as HTML

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,3 +15,4 @@ prune examples/compat/seaborn/*.html
 prune examples/embed/*.html
 prune examples/glyphs/*.html
 prune examples/plotting/file/*.html
+include bokeh/_version.py

--- a/bokehjs/src/coffee/models/widgets/date_picker.coffee
+++ b/bokehjs/src/coffee/models/widgets/date_picker.coffee
@@ -11,7 +11,7 @@ export class DatePickerView extends InputWidgetView
 
   initialize: (options) ->
     super(options)
-    @label = $('<label>').text(@model.title)
+    @label = $('<label>').html(@model.title)
     @input = $('<input type="text">')
     @datepicker = @input.datepicker({
       defaultDate: new Date(@model.value)

--- a/bokehjs/src/coffee/models/widgets/input_widget.coffee
+++ b/bokehjs/src/coffee/models/widgets/input_widget.coffee
@@ -12,6 +12,10 @@ export class InputWidgetView extends WidgetView
   change_input: () ->
     @model.callback?.execute(@model)
 
+  make_html_label: () ->
+    # Render html tags in label, should not have any need for an option
+    # to render as raw text?
+    @$el.find('label').first().html(@model.title)
 
 export class InputWidget extends Widget
   type: "InputWidget"

--- a/bokehjs/src/coffee/models/widgets/multiselect.coffee
+++ b/bokehjs/src/coffee/models/widgets/multiselect.coffee
@@ -27,6 +27,7 @@ export class MultiSelectView extends InputWidgetView
     @$el.empty()
     html = @template(@model.attributes)
     @$el.html(html)
+    @make_html_label()
     @render_selection()
     return @
 
@@ -44,7 +45,6 @@ export class MultiSelectView extends InputWidgetView
     @$el.find('select').attr('size', this.model.size)
 
   change_input: () ->
-    # Haven't checked if :focus selector works for IE <= 7
     is_focused = @$el.find('select:focus').size()
     value = @$el.find('select').val()
     if value

--- a/bokehjs/src/coffee/models/widgets/range_slider.coffee
+++ b/bokehjs/src/coffee/models/widgets/range_slider.coffee
@@ -19,6 +19,7 @@ export class RangeSliderView extends InputWidgetView
     @$el.empty()
     html = @template(@model.attributes)
     @$el.html(html)
+    @make_html_label()
     @callbackWrapper = null
     if @model.callback_policy == 'continuous'
       @callbackWrapper = () ->

--- a/bokehjs/src/coffee/models/widgets/selectbox.coffee
+++ b/bokehjs/src/coffee/models/widgets/selectbox.coffee
@@ -23,6 +23,7 @@ export class SelectView extends InputWidgetView
     @$el.empty()
     html = @template(@model.attributes)
     @$el.html(html)
+    @make_html_label()
     return @
 
   change_input: () ->

--- a/bokehjs/src/coffee/models/widgets/slider.coffee
+++ b/bokehjs/src/coffee/models/widgets/slider.coffee
@@ -19,6 +19,7 @@ export class SliderView extends InputWidgetView
     @$el.empty()
     html = @template(@model.attributes)
     @$el.html(html)
+    @make_html_label()
     @callbackWrapper = null
     if @model.callback_policy == 'continuous'
       @callbackWrapper = () ->

--- a/bokehjs/src/coffee/models/widgets/text_input.coffee
+++ b/bokehjs/src/coffee/models/widgets/text_input.coffee
@@ -23,6 +23,7 @@ export class TextInputView extends InputWidgetView
   render: () ->
     super()
     @$el.html(@template(@model.attributes))
+    @make_html_label()
     # TODO - This 35 is a hack we should be able to compute it
     if @model.height
       @$el.find('input').height(@model.height - 35)

--- a/examples/models/widgets.py
+++ b/examples/models/widgets.py
@@ -39,7 +39,7 @@ checkbox_button_group = CheckboxButtonGroup(labels=["Option 1", "Option 2", "Opt
 
 radio_button_group = RadioButtonGroup(labels=["Option 1", "Option 2", "Option 3"], active=0)
 
-text_input = TextInput(placeholder="Enter value ...")
+text_input = TextInput(placeholder="Enter value ...", title="<b>text</b>")
 
 autocomplete_input = AutocompleteInput()
 
@@ -47,7 +47,7 @@ select = Select(options=["Option 1", "Option 2", "Option 3"])
 
 multi_select = MultiSelect(options=["Option %d" % (i+1) for i in range(16)], size=6)
 
-slider = Slider(value=10, start=0, end=100)
+slider = Slider(value=10, start=0, end=100, title="<b>slider</b>")
 
 range_slider = RangeSlider()
 


### PR DESCRIPTION
There's no need for raw text labels for form elements here, afaik. On
the other hand there are a lot of reasonable reasons to want to use HTML
tags in labels, for example adding a link or a help dialog widget.

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [x] issues: fixes #5623
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
