### PR TITLE
Overhaul bokeh.core docs

### DIFF
--- a/bokeh/.coveragerc
+++ b/bokeh/.coveragerc
@@ -1,2 +1,2 @@
 [run]
-omit = *tests/*, *sphinxext/*, *compat/mplexporter/*, *sampledata/*,
+omit = *tests/*, *sphinxext/*, *compat/*, *sampledata/*,

--- a/bokeh/core/compat/__init__.py
+++ b/bokeh/core/compat/__init__.py
@@ -1,11 +1,24 @@
 ''' Implement compatibility between Bokeh and Matplotlib.
 
-Currently, compatibility is implemented using the third-party `mplexporter`_
-library. This library does not provide a full interface to all of Matplotlib
-functionality, and accordingly Bokeh's Matplotlib compatibility is limited.
-A full serialization interface for Matplotlib is being planned in `MEP25`_,
-and when this work is completed, a much closer and more complete integration
-will be possible.
+All of the functions and classes in ``bokeh.core.compat`` are internal
+implementation details, and not user-facing. For information on the public
+API for MPL compatibility, see :ref:`bokeh.mpl`.
+
+.. warning::
+
+    **THIS MODULE IN ITS CURRENT FORM IS NO LONGER MAINTAINED**
+
+    Currently, compatibility is implemented using the third-party
+    `mplexporter`_ library. This library does not provide a full interface
+    to all of Matplotlib functionality, and is no longer being actively
+    maintained. Accordingly Bokeh's Matplotlib compatibility is extremely
+    limited.
+
+    A full JSON serialization interface for Matplotlib is being planned in
+    `MEP25`_. When this proposal is implemented is completed, work can
+    proceed on a more comprehensive and maintainable integration. Until
+    that time, no further improvements or fixes are planned for Bokeh MPL
+    integration, and it is provided AS-IS, in case it happens to be useful.
 
 .. _MEP25: https://github.com/matplotlib/matplotlib/wiki/MEP25
 .. _mplexporter: https://github.com/mpld3/mplexporter/tree/master/mplexporter

--- a/bokeh/core/enums.py
+++ b/bokeh/core/enums.py
@@ -1,20 +1,56 @@
 ''' Common enumerations to be used together with |Enum| property.
 
-Typical usage of the enumerations in this module look similar to this:
+This module provides many pre-defined enumerations, as well as functions
+for creating new enumerations.
+
+New enumerations can be created using the |enumeration| function:
+
+.. code-block:: python
+
+    #: Specify a nautically named side, port or starboard
+    MyEnum = enumeration("port", "starboard")
+
+Typically, enumerations are used to define |Enum| properties:
 
 .. code-block:: python
 
     from bokeh.model import Model
-    from bokeh.core.enums import StartEnd
     from bokeh.core.properties import Enum
 
     class MyModel(Model):
 
-        location = Enum(StartEnd, help="""
-        Whether the thing should be located at the start or the end.
+        location = Enum(MyEnum, help="""
+        Whether the thing should be a port or starboard.
         """)
 
+Enumerations have a defined order and support iteration:
+
+.. code-block:: python
+
+    >>> for loc in MyEnum:
+    ...     print(loc)
+    ...
+    port
+    starboard
+
+as well as containment tests:
+
+.. code-block:: python
+
+    >>> "port" in MyEnum
+    True
+
+Enumerations can be easily documented in Sphinx documentation with the
+:ref:`bokeh.sphinxext.bokeh_enum` Sphinx extension.
+
+----
+
+.. autofunction:: bokeh.core.enums.enumeration
+
+----
+
 .. |Enum| replace:: :class:`~bokeh.core.properties.Enum`
+.. |enumeration| replace:: :func:`~bokeh.core.enums.enumeration`
 
 '''
 
@@ -27,6 +63,10 @@ from ..util.deprecation import deprecated
 
 class Enumeration(object):
     ''' Represent an enumerated collection of values.
+
+    .. note::
+        Instances of ``Enumeration`` typically should not be constructed
+        directly. Instead, use the |enumeration| function.
 
     '''
     __slots__ = ()
@@ -45,16 +85,32 @@ class Enumeration(object):
     __repr__ = __str__
 
 def enumeration(*values, **kwargs):
-    ''' Create an |Enumeration| from a sequence of values.
+    ''' Create an |Enumeration| object from a sequence of values.
+
+    Call ``enumeration`` with a sequence of (unique) strings to create an
+    Enumeration object:
+
+    .. code-block:: python
+
+        #: Specify the horizontal alignment for rendering text
+        TextAlign = enumeration("left", "right", "center")
 
     Args:
+        values (str) : string enumeration values, passed as positional arguments
+
+            The order of arguments is the order of the enumeration, and the
+            first element will be considered the default value when used
+            to create |Enum| properties.
+
+    Keyword Args:
         case_sensitive (bool, optional) :
             Whether validation should consider case or not (default: True)
 
-    Returns:
-        |Enumeration|: enum
+    Raises:
+        ValueError if values empty, if any value is not a string or not unique
 
-    .. |Enumeration| replace:: :class:`~bokeh.core.enums.Enumeration`
+    Returns:
+        Enumeration
 
     '''
     if not (values and all(isinstance(value, string_types) and value for value in values)):
@@ -121,6 +177,14 @@ LegendLocation = Anchor = enumeration(
 #: Deprecated legend location/anchor
 DeprecatedLegendLocation = DeprecatedAnchor = enumeration("left_center", "right_center")
 def accept_left_right_center(value):
+    ''' Accept and convert deprecated location values.
+
+    NOT FOR GENERAL USE
+
+    This is a temporary function to support a deprecation, and will be removed
+    when the deprecation is completed.
+
+    '''
     deprecated((0, 12, 4), "'left_center' and 'right_center' enumerations",
                            "'center_left' or 'center_right' respectively")
     return {"left_center": "center_left", "right_center": "center_right"}[value]

--- a/bokeh/core/json_encoder.py
+++ b/bokeh/core/json_encoder.py
@@ -1,4 +1,32 @@
-''' Provide a custom JSON encoder for serializing Bokeh models.
+''' Provide a functions and classes to implement a custom JSON encoder for
+serializing objects for BokehJS.
+
+The primary interface is provided by the |serialize_json| function, which
+uses the custom |BokehJSONEncoder| to produce JSON output.
+
+In general, functions in this module convert values in the following way:
+
+* Datetime values (Python, Pandas, NumPy) are converted to floating point
+  milliseconds since epoch.
+
+* Decimal values are converted to floating point.
+
+* Sequences (Pandas Series, NumPy arrays, python sequences) that are passed
+  though this interface are converted to lists. Note, however, that arrays in
+  data sources inside Bokeh Documents are converted elsewhere, and by default
+  use a binary encoded format.
+
+* Bokeh ``Model`` instances are usually serialized elsewhere in the context
+  of an entire Bokeh Document. Models passed trough this interface are
+  converted to references.
+
+* ``HasProps`` (that are not Bokeh models) are converted to key/value dicts or
+  all their properties and values.
+
+* ``Color`` instances are converted to CSS color values.
+
+.. |serialize_json| replace:: :class:`~bokeh.core.json_encoder.serialize_json`
+.. |BokehJSONEncoder| replace:: :class:`~bokeh.core.json_encoder.BokehJSONEncoder`
 
 '''
 from __future__ import absolute_import
@@ -25,12 +53,19 @@ NP_EPOCH = np.datetime64('1970-01-01T00:00:00Z')
 NP_MS_DELTA = np.timedelta64(1, 'ms')
 
 class BokehJSONEncoder(json.JSONEncoder):
-    ''' Encode values to be used in Bokeh documents or communicated to
-    a Bokeh server.
+    ''' A custom ``json.JSONEncoder`` subclass for encoding objects in
+    accordance with the BokehJS protocol.
 
     '''
     def transform_python_types(self, obj):
-        ''' Handle special scalars, use default json encoder otherwise
+        ''' Handle special scalars such as (Python, NumPy, or Pandas)
+        datetimes, or Decimal values.
+
+        Args:
+            obj (obj) :
+
+                The object to encode. Anything not specifically handled in
+                this method is passed on to the default system JSON encoder.
 
         '''
 
@@ -81,6 +116,16 @@ class BokehJSONEncoder(json.JSONEncoder):
             return super(BokehJSONEncoder, self).default(obj)
 
     def default(self, obj):
+        ''' The required ``default`` method for JSONEncoder subclasses.
+
+        Args:
+            obj (obj) :
+
+                The object to encode. Anything not specifically handled in
+                this method is passed on to the default system JSON encoder.
+
+        '''
+
         from ..model import Model
         from ..colors import Color
         from .properties import HasProps
@@ -103,11 +148,72 @@ class BokehJSONEncoder(json.JSONEncoder):
         else:
             return self.transform_python_types(obj)
 
-def serialize_json(obj, encoder=BokehJSONEncoder, indent=None, **kwargs):
-    ''' Return a serialized JSON representation of a Bokeh model.
+def serialize_json(obj, pretty=False, indent=None, **kwargs):
+    ''' Return a serialized JSON representation of objects, suitable to
+    send to BokehJS.
+
+    This function is typically used to serialize single python objects in
+    the manner expected by BokehJS. In particular, many datetime values are
+    automatically normalized to an expected format. Some Bokeh objects can
+    also be passed, but note that Bokeh models are typically properly
+    serialized in the context of an entire Bokeh document.
+
+    The resulting JSON always has sorted keys. By default. the output is
+    as compact as possible unless pretty output or indentation is requested.
+
+    Args:
+        obj (obj) : the object to serialize to JSON format
+
+        pretty (bool, optional) :
+
+            Whether to generate prettified output. If ``True``, spaces are
+            added after added after separators, and indentation and newlines
+            are applied. (default: False)
+
+            Pretty output can also be enabled with the environment variable
+            ``BOKEH_PRETTY``, which overrides this argument, if set.
+
+        indent (int or None, optional) :
+
+            Amount of indentation to use in generated JSON output. If ``None``
+            then no indentation is used, unless pretty output is enabled,
+            in which case two spaces are used. (default: None)
+
+    Any additional keyword arguments are passed to ``json.dumps``, except for
+    some that  are computed internally, and cannot be overridden:
+
+    * allow_nan
+    * indent
+    * separators
+    * sort_keys
+
+    Examples:
+
+        .. code-block:: python
+
+            >>> data = dict(b=np.datetime64('2017-01-01'), a = np.arange(3))
+
+            >>>print(serialize_json(data))
+            {"a":[0,1,2],"b":1483228800000.0}
+
+            >>> print(serialize_json(data, pretty=True))
+            {
+              "a": [
+                0,
+                1,
+                2
+              ],
+              "b": 1483228800000.0
+            }
 
     '''
-    pretty = settings.pretty(False)
+
+    # these args to json.dumps are computed internally and should not be passed along
+    for name in ['allow_nan', 'indent', 'separators', 'sort_keys']:
+        if name in kwargs:
+            raise ValueError("The value of %r is computed internally, overriding is not permissable." % name)
+
+    pretty = settings.pretty(pretty)
 
     if pretty:
         separators=(",", ": ")
@@ -117,4 +223,4 @@ def serialize_json(obj, encoder=BokehJSONEncoder, indent=None, **kwargs):
     if pretty and indent is None:
         indent = 2
 
-    return json.dumps(obj, cls=encoder, allow_nan=False, indent=indent, separators=separators, sort_keys=True, **kwargs)
+    return json.dumps(obj, cls=BokehJSONEncoder, allow_nan=False, indent=indent, separators=separators, sort_keys=True, **kwargs)

--- a/bokeh/core/property_mixins.py
+++ b/bokeh/core/property_mixins.py
@@ -1,18 +1,55 @@
-""" Classes that can be mixed-in to Bokeh model classes to add sets of
-related properties in bulk. """
+''' Mix-in classes that bulk add groups of properties to Bokeh models.
 
+Some groups of properties often show up in Bokeh models together. For
+instance, any model that exposes a fill color property for use when
+rendering will almost always want to expose a fill alpha as well. To
+reduce boilerplate code and simplify defining models with these sets
+of properties, use the mix-in classes in this module:
+
+* |FillProps| --- properties for fill color and alpha
+
+* |LineProps| --- properties for line color, dashing, width, etc.
+
+* |TextProps| --- properties for text color, font, etc.
+
+To include these properties in a Bokeh model, use the |Include| property
+as shown here:
+
+.. code-block:: python
+
+    class SomeGlyph(Glyph):
+
+        fill_props = Include(FillProps, use_prefix=False, help="""
+        The %s values for the annular wedges.
+        """)
+
+This adds all the fill properties ``fill_color`` and ``fill_alpha`` to this
+model with one simple statement. Note that the help string contains a
+placeholder format `%s`. When docs for this class are rendered by the
+:ref:`bokeh.sphinxext.bokeh_model` Sphinx extension, the placeholder will
+be replaced with more information specific to each property. The setting
+``use_prefix`` means that the names of the properties added to ``SomeGlyph``
+are exactly ``fill_alpha`` and ``fill_color``. Some situations require a
+different usage, for more information see the docs for |Include|.
+
+.. |Include| replace:: :class:`~bokeh.core.properties.Include`
+
+.. |FillProps| replace:: :class:`~bokeh.core.property_mixins.FillProps`
+.. |LineProps| replace:: :class:`~bokeh.core.property_mixins.LineProps`
+.. |TextProps| replace:: :class:`~bokeh.core.property_mixins.TextProps`
+
+'''
 from __future__ import absolute_import
 
 from .enums import LineJoin, LineCap, FontStyle, TextAlign, TextBaseline
-from .properties import (
-    value, HasProps, ColorSpec, Enum, DashPattern, Int, NumberSpec, String, FontSizeSpec)
+from .properties import ColorSpec, DashPattern, Enum, FontSizeSpec, HasProps, Int, NumberSpec, String, value
 
 class FillProps(HasProps):
-    """ Properties to use when performing fill operations while rendering.
+    ''' Properties relevant to rendering fill regions.
 
     Mirrors the BokehJS ``properties.Fill`` class.
 
-    """
+    '''
 
     fill_color = ColorSpec(default="gray", help="""
     A color to use to fill paths with.
@@ -37,11 +74,11 @@ class FillProps(HasProps):
     """)
 
 class LineProps(HasProps):
-    """ Properties to use when performing stroke operations while rendering.
+    ''' Properties relevant to rendering path operations.
 
     Mirrors the BokehJS ``properties.Line`` class.
 
-    """
+    '''
 
     line_color = ColorSpec(default="black", help="""
     A color to use to stroke paths with.
@@ -115,8 +152,7 @@ class LineProps(HasProps):
     """)
 
 class TextProps(HasProps):
-    """ Properties to use when performing text drawing operations while
-    rendering.
+    ''' Properties relevant to rendering text.
 
     Mirrors the BokehJS ``properties.Text`` class.
 
@@ -124,7 +160,7 @@ class TextProps(HasProps):
         There is currently only support for filling text. An interface
         to stroke the outlines of text has not yet been exposed.
 
-    """
+    '''
 
     text_font = String("helvetica", help="""
     Name of a font to use for rendering text, e.g., ``'times'``,

--- a/bokeh/core/query.py
+++ b/bokeh/core/query.py
@@ -1,85 +1,208 @@
-''' The query module provides functions for searching Bokeh object
-graphs for objects that match specified criteria.
-
-Queries are specified as selectors similar to MongoDB style query
-selectors.
-
-Examples::
-
-    .. code-block:: python
-
-        # find all objects with type "grid"
-        find(p, {'type': 'grid'})
-
-        # find all objects with type "grid" or "axis"
-        find(p, {OR: [
-            {'type': 'grid'}, {'type': 'axis'}
-        ]})
-
-        # same query, using IN operator
-        find(p, {'type': {IN: ['grid', 'axis']}})
-
-        # find all plot objects on the 'left' layout of the Plot
-        find(p, {'layout': 'left'}, {'plot': p})
-
-        # find all subplots in column 0
-        find(p, {'type': 'plot', 'column': 0}, {'gridplot': p})
-
-        # find all subplots the last row
-        find(p, {'type': 'plot', 'row': -1}, {'gridplot': p})
+''' The query module provides functions for searching collections of Bokeh
+models for instances that match specified criteria.
 
 '''
-
 from __future__ import absolute_import
 
 from six import string_types
 
-class OR(object): pass
+class OR(object):
+    ''' Form disjunctions from other query predicates.
 
-class IN(object): pass
-class GT(object): pass
-class LT(object): pass
-class EQ(object): pass
-class GEQ(object): pass
-class LEQ(object): pass
-class NEQ(object): pass
+    Construct an ``OR`` expression by making a dict with ``OR`` as the key,
+    and a list of other query expressions as the value:
+
+    .. code-block:: python
+
+        # matches any Axis subclasses or models with .name == "mycircle"
+        { OR: [dict(type=Axis), dict(name="mycircle")] }
+
+    '''
+    pass
+
+class IN(object):
+    ''' Predicate to test if property values are in some collection.
+
+    Construct and ``IN`` predicate as a dict with ``IN`` as the key,
+    and a list of values to check against.
+
+    .. code-block:: python
+
+        # matches any models with .name in ['a', 'mycircle', 'myline']
+        dict(name={ IN: ['a', 'mycircle', 'myline'] })
+
+    '''
+    pass
+
+class GT(object):
+    ''' Predicate to test if property values are greater than some value.
+
+    Construct and ``GT`` predicate as a dict with ``GT`` as the key,
+    and a value to compare against.
+
+    .. code-block:: python
+
+        # matches any models with .size > 10
+        dict(size={ GT: 10 })
+
+    '''
+    pass
+
+class LT(object):
+    ''' Predicate to test if property values are less than some value.
+
+    Construct and ``LT`` predicate as a dict with ``LT`` as the key,
+    and a value to compare against.
+
+    .. code-block:: python
+
+        # matches any models with .size < 10
+        dict(size={ LT: 10 })
+
+    '''
+    pass
+
+class EQ(object):
+    ''' Predicate to test if property values are equal to some value.
+
+    Construct and ``EQ`` predicate as a dict with ``EQ`` as the key,
+    and a value to compare against.
+
+    .. code-block:: python
+
+        # matches any models with .size == 10
+        dict(size={ EQ: 10 })
+
+    '''
+    pass
+
+class GEQ(object):
+    ''' Predicate to test if property values are greater than or equal to
+    some value.
+
+    Construct and ``GEQ`` predicate as a dict with ``GEQ`` as the key,
+    and a value to compare against.
+
+    .. code-block:: python
+
+        # matches any models with .size >= 10
+        dict(size={ GEQ: 10 })
+
+    '''
+    pass
+
+class LEQ(object):
+    ''' Predicate to test if property values are less than or equal to
+    some value.
+
+    Construct and ``LEQ`` predicate as a dict with ``LEQ`` as the key,
+    and a value to compare against.
+
+    .. code-block:: python
+
+        # matches any models with .size <= 10
+        dict(size={ LEQ: 10 })
+
+    '''
+    pass
+
+class NEQ(object):
+    ''' Predicate to test if property values are unequal to some value.
+
+    Construct and ``NEQ`` predicate as a dict with ``NEQ`` as the key,
+    and a value to compare against.
+
+    .. code-block:: python
+
+        # matches any models with .size != 10
+        dict(size={ NEQ: 10 })
+
+    '''
+    pass
+
+# realizations of the abstract predicate operators
+_operators = {
+   IN:  lambda x, y: x in y,
+   GT:  lambda x, y: x > y,
+   LT:  lambda x, y: x < y,
+   EQ:  lambda x, y: x == y,
+   GEQ: lambda x, y: x >= y,
+   LEQ: lambda x, y: x <= y,
+   NEQ: lambda x, y: x != y,
+}
+
+# realization of the OR operator
+def _or(obj, selectors):
+    return any(match(obj, selector) for selector in selectors)
 
 
 def match(obj, selector, context=None):
-    ''' Test whether a particular object matches a given
-    selector.
+    ''' Test whether a given Bokeh model matches a given selector.
 
     Args:
-        obj (Model) : object to Test
+        obj (Model) : object to test
         selector (JSON-like) : query selector
-            See module docs for details
+        context (dict) : kwargs to supply callable query attributes
 
     Returns:
         bool : True if the object matches, False otherwise
 
+    In general, the selectors have the form:
+
+    .. code-block:: python
+
+        { attrname : predicate }
+
+    Where a predicate is constructed from the operators ``EQ``, ``GT``, etc.
+    and is used to compare against values of model attributes named
+    ``attrname``.
+
+    For example:
+
+    .. code-block:: python
+
+        >>> from bokeh.plotting import figure
+        >>> p = figure(plot_width=400)
+
+        >>> match(p, {'plot_width': {EQ: 400}})
+        True
+
+        >>> match(p, {'plot_width': {GT: 500}})
+        False
+
     There are two selector keys that are handled especially. The first
-    is 'type', which will do an isinstance check::
+    is 'type', which will do an isinstance check:
 
-        >>> from bokeh.plotting import line
+    .. code-block:: python
+
+        >>> from bokeh.plotting import figure
         >>> from bokeh.models import Axis
-        >>> p = line([1,2,3], [4,5,6])
-        >>> len(list(p.select({'type': Axis})))
-        2
+        >>> p = figure()
 
-    There is also a 'tags' attribute that `Model` objects have,
-    that is a list of user-supplied values. The 'tags' selector key can
-    be used to query against this list of tags. An object matches if
-    any of the tags in the selector match any of the tags on the
-    object::
+        >>> match(p.xaxis[0], {'type': Axis})
+        True
 
-        >>> from bokeh.plotting import line
-        >>> from bokeh.models import Axis
-        >>> p = line([1,2,3], [4,5,6])
-        >>> p.tags = ["my plot", 10]
-        >>> len(list(p.select({'tags': "my plot"})))
-        1
-        >>> len(list(p.select({'tags': ["my plot", 10]})))
-        1
+        >>> match(p.title, {'type': Axis})
+        False
+
+    There is also a ``'tags'`` attribute that ``Model`` objects have, that
+    is a list of user-supplied values. The ``'tags'`` selector key can be
+    used to query against this list of tags. An object matches if any of the
+    tags in the selector match any of the tags on the object:
+
+    .. code-block:: python
+
+        >>> from bokeh.plotting import figure
+        >>> p = figure(tags = ["my plot", 10])
+
+        >>> match(p, {'tags': "my plot"})
+        True
+
+        >>> match(p, {'tags': ["my plot", 10]})
+        True
+
+        >>> match(p, {'tags': ["foo"]})
+        False
 
     '''
     context = context or {}
@@ -139,33 +262,38 @@ def match(obj, selector, context=None):
 
 
 def find(objs, selector, context=None):
-    ''' Query an object and all of its contained references
-    and yield objects that match the given selector.
+    ''' Query a collection of Bokeh models and yield any that match the
+    a selector.
 
     Args:
-        obj (Model) : object to query
+        obj (Model) : object to test
         selector (JSON-like) : query selector
-            See module docs for details
+        context (dict) : kwargs to supply callable query attributes
 
     Yields:
         Model : objects that match the query
 
+    Queries are specified as selectors similar to MongoDB style query
+    selectors, as described for :func:`~bokeh.core.query.match`.
+
     Examples:
+
+        .. code-block:: python
+
+            # find all objects with type Grid
+            find(p.references(), {'type': Grid})
+
+            # find all objects with type Grid or Axis
+            find(p.references(), {OR: [
+                {'type': Grid}, {'type': Axis}
+            ]})
+
+            # same query, using IN operator
+            find(p.references(), {'type': {IN: [Grid, Axis]}})
+
+            # find all plot objects on the 'left' layout of the Plot
+            # here layout is a method that takes a plot as context
+            find(p.references(), {'layout': 'left'}, {'plot': p})
 
     '''
     return (obj for obj in objs if match(obj, selector, context))
-
-
-def _or(obj, selectors):
-    return any(match(obj, selector) for selector in selectors)
-
-
-_operators = {
-   IN:  lambda x, y: x in y,
-   GT:  lambda x, y: x > y,
-   LT:  lambda x, y: x < y,
-   EQ:  lambda x, y: x == y,
-   GEQ: lambda x, y: x >= y,
-   LEQ: lambda x, y: x <= y,
-   NEQ: lambda x, y: x != y,
-}

--- a/bokeh/core/state.py
+++ b/bokeh/core/state.py
@@ -1,36 +1,29 @@
-#-----------------------------------------------------------------------------
-# Copyright (c) 2012 - 2015, Continuum Analytics, Inc. All rights reserved.
-#
-# Powered by the Bokeh Development Team.
-#
-# The full license is in the file LICENSE.txt, distributed with this software.
-#-----------------------------------------------------------------------------
-""" Encapsulate implicit state that is useful for Bokeh plotting APIs.
+''' Encapsulate implicit state that is useful for Bokeh plotting APIs.
+
+.. note::
+    While ``State`` objects can also be manipulated explicitly, they are
+    automatically configured when the functions :func:`~bokeh.io.output_file`,
+    etc. from :ref:`bokeh.io` are used, so this is not necessary under
+    typical usage.
 
 Generating output for Bokeh plots requires coordinating several things:
 
-:class:`Documents <bokeh.document>`
-    Group together Bokeh models that may be shared between plots (e.g.,
-    range or data source objects) into one common namespace.
+:class:`~bokeh.document.Document`
+    Groups together Bokeh models that may be shared between plots (e.g.,
+    range or data source objects) into one common strucure.
 
-:class:`Resources <bokeh.resources>`
+:class:`~bokeh.resources.Resources`
     Control how JavaScript and CSS for the client library BokehJS are
     included and used in the generated output.
 
-It is certainly possible to handle the configuration of these objects
-manually, and several examples of this can be found in ``examples/models``.
-When developing sophisticated applications, it may be necessary or
-desirable to work at this level. However, for general use this would
-quickly become burdensome. The ``bokeh.state`` module provides a ``State``
-class that encapsulates these objects and ensures their proper configuration.
+It is possible to handle the configuration of these things manually, and some
+examples of doing this can be found in ``examples/models`` directory. When
+developing sophisticated applications, it may be necessary or desirable to work
+at this level. However, for general use this would quickly become burdensome.
+This module provides a ``State`` class that encapsulates these objects and
+ensures their proper configuration in many common usage scenarios.
 
-"""
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
-
-# Stdlib imports
+'''
 from __future__ import absolute_import
 
 import logging
@@ -38,45 +31,14 @@ logger = logging.getLogger(__name__)
 
 import os
 
-# Third-party imports
-
-# Bokeh imports
 from ..document import Document
 from ..resources import Resources, _SessionCoordinates
 from ..client import DEFAULT_SESSION_ID
 
-#-----------------------------------------------------------------------------
-# Globals and constants
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Local utilities
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Classes and functions
-#-----------------------------------------------------------------------------
-
 class State(object):
-    """ Manage state related to controlling Bokeh output.
+    ''' Manage state related to controlling Bokeh output.
 
-    Attributes:
-        document (:class:`bokeh.document.Document`): a default document to use
-
-        file (dict) : default filename, resources, etc. for file output
-            This dictionary has the following form::
-
-                {
-                    'filename'  : # filename to use when saving
-                    'resources' : # resources configuration
-                    'title'     : # a title for the HTML document
-                }
-
-        notebook (bool) : whether to generate notebook output
-
-        session_id (str) : a default session ID for Bokeh server output
-
-    """
+    '''
 
     def __init__(self):
         self.last_comms_handle = None
@@ -84,6 +46,10 @@ class State(object):
 
     @property
     def document(self):
+        ''' A default :class:`~bokeh.document.Document` to use for all
+        output operations.
+
+        '''
         return self._document
 
     @document.setter
@@ -92,53 +58,110 @@ class State(object):
 
     @property
     def file(self):
+        ''' A dict with the default configuration for file output (READ ONLY)
+
+        The dictionary value has the following form:
+
+        .. code-block:: python
+
+            {
+                'filename'  : # filename to use when saving
+                'resources' : # resources configuration
+                'title'     : # a title for the HTML document
+            }
+
+        '''
         return self._file
 
     @property
     def notebook(self):
+        ''' Whether to generate notebook output on show operations. (READ ONLY)
+
+        '''
         return self._notebook
 
     @property
     def server_enabled(self):
+        ''' Whether to generate output on a Bokeh server. (READ ONLY)
+
+        .. warning::
+            This property is deprecated.
+
+        '''
         return self._server_enabled
 
     @property
     def session_id(self):
+        ''' A default session ID for Bokeh server output. (READ ONLY)
+
+        .. warning::
+            This property is deprecated.
+
+        '''
         return self._session_coords.session_id
 
     @property
     def session_id_allowing_none(self):
+        ''' A session ID for Bokeh server output, or ``None``. (READ ONLY)
+
+        .. warning::
+            This property is deprecated.
+
+        '''
         return self._session_coords.session_id_allowing_none
 
     @property
     def url(self):
-        """ Gets the server base URL (not including any app path)."""
+        ''' A base URL (not including any app path) for a Bokeh server.
+
+        .. warning::
+            This property is deprecated.
+
+        '''
         return self._session_coords.url
 
     @property
     def server_url(self):
-        """ Gets the full server URL (including the app path)."""
+        ''' A full URL (including the app path) for a Bokeh server app.
+
+        .. warning::
+            This property is deprecated.
+
+        '''
         return self._session_coords.server_url
 
     @property
     def app_path(self):
+        ''' A relative app path for a Bokeh server app.
+
+        .. warning::
+            This property is deprecated.
+
+        '''
         return self._session_coords.app_path
 
     def _reset_keeping_doc(self):
+        ''' Reset output modes but DO NOT replace the default Document
+
+        '''
         self._file = None
         self._notebook = False
         self._session_coords = _SessionCoordinates(dict())
         self._server_enabled = False
 
     def _reset_with_doc(self, doc):
+        ''' Reset output modes but DO replace the default Document
+
+        '''
         self._document = doc
         self._reset_keeping_doc()
 
     def reset(self):
-        ''' Deactivate all currently active output modes and set curdoc() to a fresh empty Document.
+        ''' Deactivate all currently active output modes and set ``curdoc()``
+        to a fresh empty ``Document``.
 
-        Subsequent calls to show() will not render until a new output mode is
-        activated.
+        Subsequent calls to ``show()`` will not render until a new output mode
+        is activated.
 
         Returns:
             None
@@ -147,12 +170,12 @@ class State(object):
         self._reset_with_doc(Document())
 
     def output_file(self, filename, title="Bokeh Plot", mode="cdn", root_dir=None):
-        """Output to a standalone HTML file.
+        ''' Configure output to a standalone HTML file.
 
-        Does not change the current Document from curdoc(). File,
-        server, and notebook output may be active at the same
-        time, so this does not clear the effects of
-        output_server() or output_notebook().
+        Calling ``output_file`` not clear the effects of any other calls to
+        ``output_notebook``, etc. It adds an additional output destination
+        (publishing to HTML files). Any other active output modes continue
+        to be active.
 
         Args:
             filename (str) : a filename for saving the HTML document
@@ -160,18 +183,21 @@ class State(object):
             title (str, optional) : a title for the HTML document
 
             mode (str, optional) : how to include BokehJS (default: ``'cdn'``)
-                One of: ``'inline'``, ``'cdn'``, ``'relative(-dev)'`` or
-                ``'absolute(-dev)'``. See :class:`bokeh.resources.Resources` for more details.
 
-            root_dir (str, optional) :  root directory to use for 'absolute' resources.
-                (default: None) This value is ignored for other resource types, e.g. ``INLINE`` or
-                ``CDN``.
+                One of: ``'inline'``, ``'cdn'``, ``'relative(-dev)'`` or
+                ``'absolute(-dev)'``. See :class:`~bokeh.resources.Resources`
+                for more details.
+
+            root_dir (str, optional) : root dir to use for absolute resources
+                (default: None)
+
+                This value is ignored for other resource types, e.g. ``INLINE`` or``CDN``.
 
         .. warning::
-            This output file will be overwritten on every save, e.g., each time
-            show() or save() is invoked.
+            The specified output file will be overwritten on every save, e.g.,
+            every time ``show()`` or ``save()`` is called.
 
-        """
+        '''
         self._file = {
             'filename'  : filename,
             'resources' : Resources(mode=mode, root_dir=root_dir),
@@ -182,47 +208,42 @@ class State(object):
             logger.info("Session output file '%s' already exists, will be overwritten." % filename)
 
     def output_notebook(self):
-        """Generate output in Jupyter/IPython notebook cells.
+        ''' Generate output in Jupyter  notebook cells.
 
-        This does not clear the effects of output_file() or
-        output_server(), it only adds an additional output
-        destination (publishing to IPython Notebook). If
-        output_server() has been called, the notebook output cell
-        will be loaded from a Bokeh server; otherwise, Bokeh
-        publishes HTML to the notebook directly.
+        Calling ``output_notebook`` not clear the effects of any other calls
+        to ``output_file``, etc. It adds an additional output destination
+        (publishing to notebook output cells). Any other active output modes
+        continue to be active.
 
         Returns:
             None
 
-        """
+        '''
         self._notebook = True
 
     def output_server(self, session_id=DEFAULT_SESSION_ID, url="default", app_path='/'):
-        """Store Bokeh plots and objects on a Bokeh server.
+        ''' Store Bokeh plots and documents on a Bokeh server.
 
-        File, server, and notebook output may be active at the
-        same time, so this does not clear the effects of
-        output_file() or output_notebook(). output_server()
-        changes the behavior of output_notebook(), so the notebook
-        will load output cells from the server rather than
-        receiving them as inline HTML.
+        .. warning::
+            The use of the higher level function ``bokeh.io.output_server``
+            has be deprecated. This support function will also be removed
+            when that deprecation is complete.
 
         Args:
             session_id (str) : Name of session to push on Bokeh server
-                Any existing session with the same name will be overwritten.
+
+                ***Any existing session with the same id will be overwritten.***
 
             url (str, optional) : base URL of the Bokeh server (default: "default")
                 If "default" use the default localhost URL.
 
-            app_path (str, optional) : relative path of the app on the Bokeh server (default: "/")
+            app_path (str, optional) : relative path of the app on the Bokeh server
+                (default: "/")
 
         Returns:
             None
 
-        .. warning::
-            Calling this function will replace any existing server-side document in the named session.
-
-        """
+        '''
         self._session_coords = _SessionCoordinates(dict(session_id=session_id,
                                                         url=url,
                                                         app_path=app_path))

--- a/bokeh/core/templates.py
+++ b/bokeh/core/templates.py
@@ -1,5 +1,5 @@
-''' The templates module contains Jinja2 templates used by Bokeh embed
-Bokeh models (e.g. plots, widgets, layouts) in various ways.
+''' Provide Jinja2 templates used by Bokeh to embed Bokeh models
+(e.g. plots, widgets, layouts) in various ways.
 
 .. bokeh-jinja:: bokeh.core.templates.AUTOLOAD_JS
 .. bokeh-jinja:: bokeh.core.templates.AUTOLOAD_NB_JS
@@ -24,6 +24,7 @@ _env = Environment(loader=PackageLoader('bokeh.core', '_templates'))
 _env.filters['json'] = lambda obj: Markup(json.dumps(obj))
 
 JS_RESOURCES = _env.get_template("js_resources.html")
+
 CSS_RESOURCES = _env.get_template("css_resources.html")
 
 SCRIPT_TAG = _env.get_template("script_tag.html")
@@ -35,8 +36,11 @@ DOC_JS = _env.get_template("doc_js.js")
 FILE = _env.get_template("file.html")
 
 NOTEBOOK_LOAD = _env.get_template("notebook_load.html")
+
 NOTEBOOK_DIV = _env.get_template("notebook_div.html")
 
 AUTOLOAD_JS = _env.get_template("autoload_js.js")
+
 AUTOLOAD_NB_JS = _env.get_template("autoload_nb_js.js")
+
 AUTOLOAD_TAG = _env.get_template("autoload_tag.html")

--- a/bokeh/core/validation/__init__.py
+++ b/bokeh/core/validation/__init__.py
@@ -1,9 +1,22 @@
 ''' The validation module provides the capability to perform integrity
 checks on an entire collection of Bokeh models.
 
+To create a Bokeh visualization, the central task is to assemble a collection
+model objects from |bokeh.models| into a graph that represents the scene that
+should be created in the client. It is possible to to this "by hand", using the
+model objects directly. However, to make this process easier, Bokeh provides
+higher level interfaces such as |bokeh.plotting| and |bokeh.charts| for users.
+These interfaces automate common "assembly" steps, to ensure a Bokeh object
+graph is created in a consistent, predictable way. However, regardless of what
+interface is used, it is possible to put Bokeh models together in ways that are
+incomplete, or that do not make sense in some way.
+
+To assist with diagnosing potential problems, Bokeh performs a validation step
+when outputting a visualization for display. This module contains error and
+warning codes as well as helper functions for defining validation checks.
+
 '''
 from __future__ import absolute_import
 
 from .check import check_integrity
 from .decorators import error, warning
-from .exceptions import ValidationError

--- a/bokeh/core/validation/check.py
+++ b/bokeh/core/validation/check.py
@@ -6,9 +6,27 @@ from __future__ import absolute_import
 import logging
 logger = logging.getLogger(__file__)
 
-
 def check_integrity(models):
+    ''' Apply validation and integrity checks to a collection of Bokeh models.
 
+    Args:
+        models (seq[Model]) : a collection of Models to test
+
+    Returns:
+        None
+
+    This function will emit log warning and error messages for all error or
+    warning conditions that are detected. For example, layouts without any
+    children will trigger a warning:
+
+    .. code-block:: python
+
+        >>> empty_row = Row
+
+        >>> check_integrity([empty_row])
+        W-1002 (EMPTY_LAYOUT): Layout has no children: Row(id='2404a029-c69b-4e30-9b7d-4b7b6cdaad5b', ...)
+
+    '''
     messages = dict(error=[], warning=[])
 
     for model in models:
@@ -29,4 +47,4 @@ def check_integrity(models):
 
     # This will be turned on in a future release
     # if len(messages['error']) or (len(messages['warning']) and settings.strict()):
-    #     raise ValidationError("Errors encountered during validation (see log output)")
+    #     raise RuntimeError("Errors encountered during validation (see log output)")

--- a/bokeh/core/validation/decorators.py
+++ b/bokeh/core/validation/decorators.py
@@ -8,7 +8,17 @@ from functools import partial
 from six import string_types
 
 def _validator(code_or_name, validator_type):
+    ''' Internal shared implementation to handle both error and warning
+    validation checks.
 
+    Args:
+        code code_or_name (int or str) : a defined error code or custom message
+        validator_type (str) : either "error" or "warning"
+
+    Returns:
+        validation decorator
+
+    '''
     if validator_type == "error":
         from .errors import codes
         from .errors import EXT
@@ -16,7 +26,7 @@ def _validator(code_or_name, validator_type):
         from .warnings import codes
         from .warnings import EXT
     else:
-        pass
+        pass # TODO (bev) ValueError?
 
     def decorator(func):
         def wrapper(*args, **kw):
@@ -35,71 +45,72 @@ def _validator(code_or_name, validator_type):
 
     return decorator
 
-error = partial(_validator, validator_type="error")
-error.__doc__ = ''' Mark a validator method for a Bokeh error condition
+_error = partial(_validator, validator_type="error")
+def error(code_or_name):
+    ''' Decorator to mark a validator method for a Bokeh error condition
 
-Args:
-    code_or_name (int or str) : a code from ``bokeh.validation.errors`` or a string label for a custom check
+    Args:
+        code_or_name (int or str) : a code from ``bokeh.validation.errors`` or a string label for a custom check
 
-Returns:
-    callable : decorator for Bokeh model methods
+    Returns:
+        callable : decorator for Bokeh model methods
 
-Examples:
+    Examples:
 
-The first example uses a numeric code for a standard error provided in
-``bokeh.validation.errors``. This usage is primarily of interest to Bokeh
-core developers.
+    The first example uses a numeric code for a standard error provided in
+    ``bokeh.validation.errors``. This usage is primarily of interest to Bokeh
+    core developers.
 
-.. code-block:: python
+    .. code-block:: python
 
-    from bokeh.validation.errors import REQUIRED_RANGES
+        from bokeh.validation.errors import REQUIRED_RANGES
 
-    @error(REQUIRED_RANGES)
-    def _check_no_glyph_renderers(self):
+        @error(REQUIRED_RANGES)
+        def _check_no_glyph_renderers(self):
 
-The second example shows how a custom warning check can be implemented by
-passing an arbitrary string label to the decorator. This usage is primarily
-of interest to anyone extending Bokeh with their own custom models.
+    The second example shows how a custom warning check can be implemented by
+    passing an arbitrary string label to the decorator. This usage is primarily
+    of interest to anyone extending Bokeh with their own custom models.
 
-.. code-block:: python
+    .. code-block:: python
 
-    @error("MY_CUSTOM_WARNING")
-    def _check_my_custom_warning(self):
+        @error("MY_CUSTOM_WARNING")
+        def _check_my_custom_warning(self):
 
+    '''
+    return _error(code_or_name)
 
-'''
+_warning = partial(_validator, validator_type="warning")
+def warning(code_or_name):
+    ''' Decorator to mark a validator method for a Bokeh error condition
 
-warning = partial(_validator, validator_type="warning")
-warning.__doc__ = ''' Mark a validator method for a Bokeh error condition
+    Args:
+        code_or_name (int or str) : a code from ``bokeh.validation.errors`` or a string label for a custom check
 
-Args:
-    code_or_name (int or str) : a code from ``bokeh.validation.errors`` or a string label for a custom check
+    Returns:
+        callable : decorator for Bokeh model methods
 
-Returns:
-    callable : decorator for Bokeh model methods
+    Examples:
 
-Examples:
+    The first example uses a numeric code for a standard warning provided in
+    ``bokeh.validation.warnings``. This usage is primarily of interest to Bokeh
+    core developers.
 
-The first example uses a numeric code for a standard warning provided in
-``bokeh.validation.warnings``. This usage is primarily of interest to Bokeh
-core developers.
+    .. code-block:: python
 
-.. code-block:: python
+        from bokeh.validation.warnings import NO_DATA_RENDERERS
 
-    from bokeh.validation.warnings import NO_DATA_RENDERERS
+        @warning(NO_DATA_RENDERERS)
+        def _check_no_glyph_renderers(self):
 
-    @warning(NO_DATA_RENDERERS)
-    def _check_no_glyph_renderers(self):
+    The second example shows how a custom warning check can be implemented by
+    passing an arbitrary string label to the decorator. This usage is primarily
+    of interest to anyone extending Bokeh with their own custom models.
 
-The second example shows how a custom warning check can be implemented by
-passing an arbitrary string label to the decorator. This usage is primarily
-of interest to anyone extending Bokeh with their own custom models.
+    .. code-block:: python
 
-.. code-block:: python
+        @warning("MY_CUSTOM_WARNING")
+        def _check_my_custom_warning(self):
 
-    @warning("MY_CUSTOM_WARNING")
-    def _check_my_custom_warning(self):
-
-
-
-'''
+    '''
+    return _warning(code_or_name)

--- a/bokeh/core/validation/errors.py
+++ b/bokeh/core/validation/errors.py
@@ -1,33 +1,34 @@
-''' Define standard error codes and messages for Bokeh validation checks.
+''' These define the standard error codes and messages for Bokeh
+validation checks.
 
-1000 : *COLUMN_LENGTHS*
+1000 *(COLUMN_LENGTHS)*
     A |ColumnDataSource| has columns whose lengths are not all the same.
 
-1001 : *BAD_COLUMN_NAME*
+1001 *(BAD_COLUMN_NAME)*
     A glyph has a property set to a field name that does not correspond to any
     column in the |GlyphRenderer|'s data source.
 
-1002 : *MISSING_GLYPH*
+1002 *(MISSING_GLYPH)*
     A |GlyphRenderer| has no glyph configured.
 
-1003 : *NO_SOURCE_FOR_GLYPH*
+1003 *(NO_SOURCE_FOR_GLYPH)*
     A |GlyphRenderer| has no data source configured.
 
-1004 : *REQUIRED_RANGE*
+1004 *(REQUIRED_RANGE)*
     A |Plot| is missing one or more required default ranges (will result in
     blank plot).
 
-1005 : *MISSING_GOOGLE_API_KEY*
+1005 *(MISSING_GOOGLE_API_KEY)*
     Google Maps API now requires an API key for all use. See
     https://developers.google.com/maps/documentation/javascript/get-api-key
     for more information on how to obtain your own, to use for the
     ``api_key`` property of your Google Map plot .
 
-1006 : *NON_MATCHING_DATA_SOURCES_ON_LEGEND_ITEM_RENDERERS*
+1006 *(NON_MATCHING_DATA_SOURCES_ON_LEGEND_ITEM_RENDERERS)*
     All data_sources on ``LegendItem.renderers`` must match when LegendItem.label
     is type field.
 
-9999 : *EXT*
+9999 *(EXT)*
     Indicates that a custom error check has failed.
 
 '''

--- a/bokeh/core/validation/exceptions.py
+++ b/bokeh/core/validation/exceptions.py
@@ -1,9 +1,0 @@
-''' Provide exception types for Bokeh object graph validation.
-
-'''
-
-class ValidationError(Exception):
-    ''' Failed Bokeh validation check
-
-    '''
-    pass

--- a/bokeh/core/validation/warnings.py
+++ b/bokeh/core/validation/warnings.py
@@ -1,21 +1,22 @@
-''' Define standard warning codes and messages for Bokeh validation checks.
+''' These define the standard warning codes and messages for Bokeh
+validation checks.
 
-1000 : *MISSING_RENDERERS*
+1000 *(MISSING_RENDERERS)*
     A |Plot| object has no renderers configured (will result in a blank plot).
 
-1001 : *NO_DATA_RENDERERS*
+1001 *(NO_DATA_RENDERERS)*
     A |Plot| object has no data renderers (will result in an empty plot frame).
 
-1002 : *EMPTY_LAYOUT*
+1002 *(EMPTY_LAYOUT)*
     A layout model has no children (will result in a blank layout).
 
-1003 : *MALFORMED_CATEGORY_LABEL*
+1003 *(MALFORMED_CATEGORY_LABEL)*
     Category labels cannot contain colons (will result in a blank layout).
 
-1004 : *BOTH_CHILD_AND_ROOT*
+1004 *(BOTH_CHILD_AND_ROOT)*
     Each component can be rendered in only one place, can't be both a root and in a layout.
 
-9999 : *EXT*
+9999 *(EXT)*
     Indicates that a custom warning check has failed.
 
 '''

--- a/examples/app/export_csv/main.py
+++ b/examples/app/export_csv/main.py
@@ -7,7 +7,7 @@ from bokeh.models import ColumnDataSource, CustomJS
 from bokeh.models.widgets import Slider, Button, DataTable, TableColumn, NumberFormatter
 from bokeh.io import curdoc
 
-df = pd.read_csv('salary_data.csv')
+df = pd.read_csv(join(dirname(__file__), 'salary_data.csv'))
 
 source = ColumnDataSource(data=dict())
 

--- a/sphinx/source/docs/reference/core.rst
+++ b/sphinx/source/docs/reference/core.rst
@@ -3,166 +3,42 @@
 bokeh.core
 ==========
 
-.. automodule:: bokeh.core
-
-
-.. _bokeh.core.compat:
-
-bokeh.core.compat
------------------
-
-
-.. automodule:: bokeh.core.compat
-  :members:
-
-
-.. _bokeh.core.enums:
-
-bokeh.core.enums
-----------------
-
-.. automodule:: bokeh.core.enums
-  :members:
-  :undoc-members:
-
-.. _bokeh.core.json_encoder:
-
-bokeh.core.json_encoder
------------------------
-
-.. automodule:: bokeh.core.json_encoder
-  :members:
-
-
-.. _bokeh.core.properties:
-
-bokeh.core.properties
----------------------
-
-In order to streamline and automate the creation and use of models that can
-for describing plots and scenes, Bokeh provides a collection of properties
-and property mixins. Property classes provide automatic validation and
-serialization for a large collection of useful types. Mixin and container
-classes provide for easy bulk addition of properties to model classes.
-
-.. automodule:: bokeh.core.properties
-    :members:
-
-
-.. _bokeh.core.property_containers:
-
-bokeh.core.property_containers
-------------------------------
-
-.. automodule:: bokeh.core.property_containers
-    :members:
-
-
-.. _bokeh.core.property_mixins:
-
-bokeh.core.property_mixins
---------------------------
-
-.. autoclass:: bokeh.core.property_mixins.FillProps
-    :members:
-
-.. autoclass:: bokeh.core.property_mixins.LineProps
-    :members:
-
-.. autoclass:: bokeh.core.property_mixins.TextProps
-    :members:
-
-
-.. _bokeh.core.query:
-
-bokeh.core.query
-----------------
-
-.. automodule:: bokeh.core.query
-  :members:
-
-
-.. _bokeh.core.state:
-
-bokeh.core.state
-----------------
-
-.. automodule:: bokeh.core.state
-  :members:
-
-
-.. _bokeh.core.templates:
-
-bokeh.core.templates
---------------------
-
-.. automodule:: bokeh.core.templates
-
-
-.. _bokeh.core.validation:
-
-bokeh.core.validation
----------------------
-
-To create a Bokeh visualization, the central task is to assemble a collection
-model objects from |bokeh.models| into a graph that represents the scene that
-should be created in the client. It is possible to to this "by hand", using the
-model objects directly. However, to make this process easier, Bokeh provides
-higher level interfaces such as |bokeh.plotting| and |bokeh.charts| for users.
-These interfaces automate common "assembly" steps, to ensure a Bokeh object
-graph is created in a consistent, predictable way. However, regardless of what
-interface is used, it is possible to put Bokeh models together in ways that are
-incomplete, or that do not make sense in some way.
-
-To assist with diagnosing potential problems, Bokeh performs a validation step
-when outputting a visualization for display. These errors and warnings are
-outlined below.
-
-.. _bokeh.core.validation.errors:
-
-bokeh.core.validation.errors
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: bokeh.core.validation.errors
-   :members:
-   :undoc-members:
-
-
-.. _bokeh.core.validation.warnings:
-
-bokeh.core.validation.warnings
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: bokeh.core.validation.warnings
-   :members:
-   :undoc-members:
-
-
-.. _bokeh.core.validation.decorators:
-
-bokeh.core.validation.decorators
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autofunction:: bokeh.core.validation.decorators.error
-
-.. autofunction:: bokeh.core.validation.decorators.warning
-
-
-.. _bokeh.core.validation.exceptions:
-
-bokeh.core.validation.exceptions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: bokeh.core.validation.exceptions
-   :members:
-   :undoc-members:
-
-
-
-.. |bokeh.charts| replace:: :ref:`bokeh.plotting <bokeh.charts>`
-.. |bokeh.models| replace:: :ref:`bokeh.plotting <bokeh.plotting>`
-.. |bokeh.plotting| replace:: :ref:`bokeh.plotting <bokeh.plotting>`
-
-.. |ColumnDataSource| replace:: :class:`~bokeh.models.sources.ColumnDataSource`
-.. |GlyphRenderer| replace:: :class:`~bokeh.models.renderers.GlyphRenderer`
-.. |Plot| replace:: :class:`~bokeh.models.plots.Plot`
+The ``bokeh.core`` package provides modules that are useful for implementing
+Bokeh itself. Documentation for all of them can be accessed through the
+sidebar menu. Most of the modules here are probably not of general interest
+to most users. However, some are more useful, especially to anyone writing
+custom extensions to Bokeh. These are listed below:
+
+:ref:`bokeh.core.enums`
+    Properties on Bokeh models support automatic type validation, including
+    specifying and validating enumerated values. There are many enumerations
+    used across Bokeh. This section has documentation on all the ones that
+    are built-in, as well as information about how to create new ones.
+
+:ref:`bokeh.core.properties`
+    The fundamental building block of Bokeh apps and documents is the Bokeh
+    models, for instance plots, ranges, axes, etc. Bokeh models are comrpised
+    of properties, which are named attributes with specified types. Model
+    properties can automatically validate and serialize themselves. This
+    section describes all the property types that can be attached to Bokeh
+    models, which is of interest when creating custom extensions.
+
+:ref:`bokeh.core.property_mixins`
+    Some collections of properties appear together often. Property mixins
+    are groups of properties, such as a ``fill_color`` and ``fill_alpha``,
+    that make up a single unit that can be easily applied to Bokeh models
+    all at once.
+
+:ref:`bokeh.core.validation`
+    When serializing a Document for use by BokehJS, the Bokeh python
+    library attempts to detect potential or actual usage problems. These
+    are reported as validation warnings or errors, which have unique
+    numeric codes and names associated with them. This section is useful
+    to find out more specifics about such warnings and errors.
+
+
+.. toctree::
+    :maxdepth: 2
+    :glob:
+
+    core/*

--- a/sphinx/source/docs/reference/core/compat.rst
+++ b/sphinx/source/docs/reference/core/compat.rst
@@ -1,0 +1,7 @@
+.. _bokeh.core.compat:
+
+bokeh.core.compat
+-----------------
+
+.. automodule:: bokeh.core.compat
+  :members:

--- a/sphinx/source/docs/reference/core/enums.rst
+++ b/sphinx/source/docs/reference/core/enums.rst
@@ -1,0 +1,12 @@
+.. _bokeh.core.enums:
+
+bokeh.core.enums
+----------------
+
+.. enumeration is excluded below so that it can be explicitly
+.. included earlier in the module docstring
+
+.. automodule:: bokeh.core.enums
+  :members:
+  :undoc-members:
+  :exclude-members: enumeration

--- a/sphinx/source/docs/reference/core/json_encoder.rst
+++ b/sphinx/source/docs/reference/core/json_encoder.rst
@@ -1,0 +1,11 @@
+.. _bokeh.core.json_encoder:
+
+bokeh.core.json_encoder
+-----------------------
+
+.. automodule:: bokeh.core.json_encoder
+
+    .. autofunction:: serialize_json
+
+    .. autoclass:: BokehJSONEncoder
+        :members:

--- a/sphinx/source/docs/reference/core/properties.rst
+++ b/sphinx/source/docs/reference/core/properties.rst
@@ -1,0 +1,13 @@
+.. _bokeh.core.properties:
+
+bokeh.core.properties
+---------------------
+
+In order to streamline and automate the creation and use of models that can
+for describing plots and scenes, Bokeh provides a collection of properties
+and property mixins. Property classes provide automatic validation and
+serialization for a large collection of useful types. Mixin and container
+classes provide for easy bulk addition of properties to model classes.
+
+.. automodule:: bokeh.core.properties
+    :members:

--- a/sphinx/source/docs/reference/core/property_containers.rst
+++ b/sphinx/source/docs/reference/core/property_containers.rst
@@ -1,0 +1,9 @@
+.. _bokeh.core.property_containers:
+
+bokeh.core.property_containers
+------------------------------
+
+.. automodule:: bokeh.core.property_containers
+    :members:
+    :special-members:
+    :exclude-members: __weakref__

--- a/sphinx/source/docs/reference/core/property_mixins.rst
+++ b/sphinx/source/docs/reference/core/property_mixins.rst
@@ -1,0 +1,7 @@
+.. _bokeh.core.property_mixins:
+
+bokeh.core.property_mixins
+--------------------------
+
+.. automodule:: bokeh.core.property_mixins
+    :members:

--- a/sphinx/source/docs/reference/core/query.rst
+++ b/sphinx/source/docs/reference/core/query.rst
@@ -1,0 +1,7 @@
+.. _bokeh.core.query:
+
+bokeh.core.query
+----------------
+
+.. automodule:: bokeh.core.query
+  :members:

--- a/sphinx/source/docs/reference/core/state.rst
+++ b/sphinx/source/docs/reference/core/state.rst
@@ -1,0 +1,7 @@
+.. _bokeh.core.state:
+
+bokeh.core.state
+----------------
+
+.. automodule:: bokeh.core.state
+  :members:

--- a/sphinx/source/docs/reference/core/templates.rst
+++ b/sphinx/source/docs/reference/core/templates.rst
@@ -1,0 +1,6 @@
+.. _bokeh.core.templates:
+
+bokeh.core.templates
+--------------------
+
+.. automodule:: bokeh.core.templates

--- a/sphinx/source/docs/reference/core/validation.rst
+++ b/sphinx/source/docs/reference/core/validation.rst
@@ -1,0 +1,47 @@
+.. _bokeh.core.validation:
+
+bokeh.core.validation
+---------------------
+
+.. automodule:: bokeh.core.validation
+
+.. _bokeh.core.validation.errors:
+
+Error Codes
+~~~~~~~~~~~
+
+.. automodule:: bokeh.core.validation.errors
+   :members:
+   :undoc-members:
+
+.. _bokeh.core.validation.warnings:
+
+Warning Codes
+~~~~~~~~~~~~~
+
+.. automodule:: bokeh.core.validation.warnings
+   :members:
+   :undoc-members:
+
+.. _bokeh.core.validation.helpers:
+
+Helper Functions
+~~~~~~~~~~~~~~~~
+
+These helper functions can be used to perform integrity checks on collections
+of Bokeh models, or mark methods on Models as warning or error checks.
+
+.. autofunction:: bokeh.core.validation.check.check_integrity
+
+.. autofunction:: bokeh.core.validation.decorators.error
+
+.. autofunction:: bokeh.core.validation.decorators.warning
+
+
+.. |bokeh.charts| replace:: :ref:`bokeh.plotting <bokeh.charts>`
+.. |bokeh.models| replace:: :ref:`bokeh.plotting <bokeh.plotting>`
+.. |bokeh.plotting| replace:: :ref:`bokeh.plotting <bokeh.plotting>`
+
+.. |ColumnDataSource| replace:: :class:`~bokeh.models.sources.ColumnDataSource`
+.. |GlyphRenderer| replace:: :class:`~bokeh.models.renderers.GlyphRenderer`
+.. |Plot| replace:: :class:`~bokeh.models.plots.Plot`


### PR DESCRIPTION
issues: fixes #5627 

This PR splits the overly long docs page for `bokeh.core` up into individual pages for each module [*]. It also adds expanded and complete docstrings for all public and private functions, with the exception of:

* `bokeh.compat` I have described this as unmaintained until MEP25, and have also removed the directory from the test reporting

* `bokeh.properties` A follow on PR is planned to move low level things into `property_bases.py` and will update the docs then. 

This PR also:

* removes the `encoder` argument to `serialize_json` as it was unused
* removes `bokeh.core.validation.exceptions` which was unused. 
* fixes a small bug in `export_csv` app example

[*] slight fib, the `bokeh.validation` package is documented as if it was a single module (which it probably should be)