### PR TITLE
Refactor bokeh.core.properties to support better documentation

### DIFF
--- a/bokeh/.coveragerc
+++ b/bokeh/.coveragerc
@@ -1,2 +1,2 @@
 [run]
-omit = *tests/*, *sphinxext/*, *compat/*, *sampledata/*,
+omit = *tests/*, *sphinxext/*, *compat/*, *sampledata/*, */_version.py

--- a/bokeh/charts/attributes.py
+++ b/bokeh/charts/attributes.py
@@ -1,19 +1,23 @@
+'''
+
+'''
 from __future__ import absolute_import
 
 from copy import copy
 from itertools import cycle
+
 import pandas as pd
 
-from bokeh.charts import DEFAULT_PALETTE
-from bokeh.charts.properties import ColumnLabel
-from bokeh.charts.utils import marker_types
-from bokeh.charts.data_source import ChartDataSource
-from bokeh.charts.stats import Bins
 from bokeh.core.enums import DashPattern
+from bokeh.core.has_props import HasProps
+from bokeh.core.properties import Any, Bool, Dict, Either, Instance, List, Override, String
 from bokeh.models.sources import ColumnDataSource
-from bokeh.core.properties import (HasProps, String, List, Instance, Either, Any, Dict,
-                              Bool, Override)
 
+from . import DEFAULT_PALETTE
+from .data_source import ChartDataSource
+from .properties import ColumnLabel
+from .utils import marker_types
+from .stats import Bins
 
 class AttrSpec(HasProps):
     """A container for assigning attributes to values and retrieving them as needed.

--- a/bokeh/charts/builder.py
+++ b/bokeh/charts/builder.py
@@ -1,44 +1,28 @@
-"""This is the Bokeh charts interface. It gives you a high level API to build
+''' This is the Bokeh charts interface. It gives you a high level API to build
 complex plot is a simple way.
 
 This is the Builder class, a minimal prototype class to build more chart
 types on top of it.
-"""
-#-----------------------------------------------------------------------------
-# Copyright (c) 2012 - 2014, Continuum Analytics, Inc. All rights reserved.
-#
-# Powered by the Bokeh Development Team.
-#
-# The full license is in the file LICENSE.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
-
+'''
 from __future__ import absolute_import
 
 import numpy as np
-
 from six import string_types
-from .attributes import AttrSpec, ColorAttr, CatAttr
+
+from bokeh.core.enums import SortDirection
+from bokeh.core.has_props import HasProps
+from bokeh.core.properties import Bool, Color, Dict, Either, Enum, Instance, List, String, Tuple
+from bokeh.models.ranges import FactorRange, Range, Range1d
+from bokeh.models.sources import ColumnDataSource
+from bokeh.util.deprecation import deprecated
+
+from .attributes import AttrSpec, CatAttr, ColorAttr
 from .chart import Chart
-from .data_source import ChartDataSource
+from .data_source import ChartDataSource, OrderedAssigner
 from .models import CompositeGlyph
 from .properties import Dimension, ColumnLabel
-from .utils import collect_attribute_columns, label_from_index_dict, build_hover_tooltips
-from .data_source import OrderedAssigner
-from ..models.ranges import Range, Range1d, FactorRange
-from ..models.sources import ColumnDataSource
-from ..core.properties import (HasProps, Instance, List, String, Dict,
-                          Color, Bool, Tuple, Either, Enum)
-from ..core.enums import SortDirection
-from ..util.deprecation import deprecated
-
-#-----------------------------------------------------------------------------
-# Classes and functions
-#-----------------------------------------------------------------------------
-
+from .utils import build_hover_tooltips, collect_attribute_columns, label_from_index_dict
 
 def create_and_build(builder_class, *data, **kws):
     """A factory function for handling Chart and Builder generation.

--- a/bokeh/charts/chart.py
+++ b/bokeh/charts/chart.py
@@ -1,43 +1,25 @@
-"""This is the Bokeh charts interface. It gives you a high level API to build
+''' This is the Bokeh charts interface. It gives you a high level API to build
 complex plot is a simple way.
 
 This is the main Chart class which is able to build several plots using the low
 level Bokeh API. It setups all the plot characteristics and lets you plot
 different chart types, taking OrderedDict as the main input. It also supports
 the generation of several outputs (file, server, notebook).
-"""
-#-----------------------------------------------------------------------------
-# Copyright (c) 2012 - 2014, Continuum Analytics, Inc. All rights reserved.
-#
-# Powered by the Bokeh Development Team.
-#
-# The full license is in the file LICENSE.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
-
+'''
 from __future__ import absolute_import
 
-import warnings
 from collections import defaultdict
+import warnings
+
 import numpy as np
 
-from ..core.enums import enumeration
-from ..core.properties import value
-from ..models import (
-    CategoricalAxis, DatetimeAxis, glyphs, Grid, Legend, LegendItem, LinearAxis, markers,
-    Plot, HoverTool, FactorRange
-)
-from ..plotting import DEFAULT_TOOLS
-from ..plotting.helpers import _process_tools_arg, _glyph_function, _process_active_tools
-from ..core.properties import Auto, Either, Enum, String
-from ..util._plot_arg_helpers import _convert_responsive
-
-#-----------------------------------------------------------------------------
-# Classes and functions
-#-----------------------------------------------------------------------------
+from bokeh.core.enums import enumeration
+from bokeh.core.properties import Auto, Either, Enum, String, value
+from bokeh.models import CategoricalAxis, DatetimeAxis, FactorRange, glyphs, Grid, HoverTool, Legend, LegendItem, LinearAxis, markers, Plot
+from bokeh.plotting import DEFAULT_TOOLS
+from bokeh.plotting.helpers import _process_tools_arg, _glyph_function, _process_active_tools
+from bokeh.util._plot_arg_helpers import _convert_responsive
 
 Scale = enumeration('linear', 'categorical', 'datetime')
 

--- a/bokeh/charts/data_source.py
+++ b/bokeh/charts/data_source.py
@@ -1,12 +1,7 @@
-"""The classes and functionality used to transform data inputs to consistent types."""
-# -----------------------------------------------------------------------------
-# Copyright (c) 2012 - 2014, Continuum Analytics, Inc. All rights reserved.
-#
-# Powered by the Bokeh Development Team.
-#
-# The full license is in the file LICENSE.txt, distributed with this software.
-# -----------------------------------------------------------------------------
+''' The classes and functionality used to transform data inputs to consistent
+types.
 
+'''
 from __future__ import absolute_import
 
 from copy import copy
@@ -18,12 +13,13 @@ import pandas as pd
 from six import iteritems
 from six.moves import zip
 
-from .properties import ColumnLabel, Column
-from .stats import Stat, Bins
-from .utils import collect_attribute_columns, special_columns, gen_column_names
-from ..models.sources import ColumnDataSource
-from ..core.properties import bokeh_integer_types, Datetime, List, HasProps, String, Float
+from bokeh.core.has_props import HasProps
+from bokeh.core.properties import bokeh_integer_types, Datetime, Float, List, String
+from bokeh.models.sources import ColumnDataSource
 
+from .properties import Column, ColumnLabel
+from .stats import Bins, Stat
+from .utils import collect_attribute_columns, gen_column_names, special_columns
 
 COMPUTED_COLUMN_NAMES = ['_charts_ones']
 ARRAY_TYPES = [tuple, list, np.ndarray, pd.Series]

--- a/bokeh/charts/glyphs.py
+++ b/bokeh/charts/glyphs.py
@@ -1,3 +1,6 @@
+'''
+
+'''
 from __future__ import absolute_import, division
 
 from collections import defaultdict
@@ -7,17 +10,15 @@ import pandas as pd
 
 from bokeh.charts import DEFAULT_PALETTE
 from bokeh.core.enums import DashPattern
-from bokeh.models.glyphs import Rect, Segment, Line, Patches, Arc
+from bokeh.models.glyphs import Arc, Line, Patches, Rect, Segment
 from bokeh.models.renderers import GlyphRenderer
-from bokeh.core.properties import (Float, String, Datetime, Bool, Instance,
-                                   List, Either, Int, Enum, Color, Override, Any, Angle)
+from bokeh.core.properties import Any, Angle, Bool, Color, Datetime, Either, Enum, Float, List, Override, Instance, Int, String
+
+from .data_source import ChartDataSource
 from .models import CompositeGlyph
 from .properties import Column, EitherColumn
-from .stats import (Stat, Quantile, Sum, Min, Max, Bins, stats, Histogram,
-                    BinnedStat)
-from .data_source import ChartDataSource
-from .utils import marker_types, generate_patch_base, label_from_index_dict
-
+from .stats import BinnedStat, Bins, Histogram, Max, Min, Quantile, Stat, stats, Sum
+from .utils import generate_patch_base, label_from_index_dict, marker_types
 
 class NestedCompositeGlyph(CompositeGlyph):
     """A composite glyph that consists of other composite glyphs.

--- a/bokeh/charts/models.py
+++ b/bokeh/charts/models.py
@@ -1,14 +1,17 @@
+'''
+
+'''
 from __future__ import absolute_import
 
-from six import iteritems
 import pandas as pd
+from six import iteritems
 
+from bokeh.core.has_props import HasProps
 from bokeh.models.renderers import GlyphRenderer
 from bokeh.models.sources import ColumnDataSource
-from bokeh.core.properties import (HasProps, String, Either, Float, Color, Instance, List,
-                              Any, Dict)
-from .properties import ColumnLabel, Column
+from bokeh.core.properties import Any, Color, Dict, Either, Float, Instance, List, String
 
+from .properties import Column, ColumnLabel
 
 class CompositeGlyph(HasProps):
     """Represents a subset of data.

--- a/bokeh/charts/operations.py
+++ b/bokeh/charts/operations.py
@@ -1,21 +1,20 @@
-""" CollisionModifiers and DataOperators used to specify Chart manipulations.
+''' CollisionModifiers and DataOperators used to specify Chart manipulations.
 
 The general approach for these operations is to use a class for modeling the
 operation, which is lazy evaluated, and doesn't require the data on initialization.
 
 An associated, user-facing function is provided for a more friendly interface.
-"""
-
+'''
 from __future__ import absolute_import
 
 from copy import copy
 
-from bokeh.core.properties import Override, String, List, Instance
+from bokeh.core.properties import Instance, List, Override, String
+
 from .data_source import DataOperator
 from .models import CollisionModifier
 from .properties import ColumnLabel
-from .stats import Stat, Count, stats
-
+from .stats import Count, Stat, stats
 
 class Stack(CollisionModifier):
     """Cumulates elements in the order of grouped values.

--- a/bokeh/charts/properties.py
+++ b/bokeh/charts/properties.py
@@ -1,20 +1,20 @@
-""" Properties for modeling Chart inputs, constraints, and dependencies.
+''' Properties for modeling Chart inputs, constraints, and dependencies.
 
 selection spec:
     [['x'], ['x', 'y']]
     [{'x': categorical, 'y': numerical}]
 
-"""
-
+'''
 from __future__ import absolute_import
 
 import numpy as np
 import pandas as pd
 
-from bokeh.core.properties import (HasProps, Either, String, Int, List, Bool,
-                              PrimitiveProperty, bokeh_integer_types, Array)
-from .utils import special_columns, title_from_columns
+from bokeh.core.has_props import HasProps
+from bokeh.core.property.bases import PrimitiveProperty
+from bokeh.core.properties import Array, bokeh_integer_types, Bool, Either, Int, List, String
 
+from .utils import special_columns, title_from_columns
 
 class Column(Array):
     """Represents column-oriented data.

--- a/bokeh/charts/stats.py
+++ b/bokeh/charts/stats.py
@@ -1,4 +1,4 @@
-""" Statistical methods used to define or modify position of glyphs.
+''' Statistical methods used to define or modify position of glyphs.
 
 References:
     Wilkinson L. The Grammer of Graphics, sections 7, 7.1
@@ -10,18 +10,17 @@ Method Types:
     - Smooth: Produces values representing smoothed versions of the input data.
     - Link: Produces edges from pairs of nodes in a graph.
 
-"""
-
+'''
 from __future__ import absolute_import
 
 import numpy as np
 import pandas as pd
 
 from bokeh.models.sources import ColumnDataSource
-from bokeh.core.properties import (HasProps, Float, Either, String, Date, Datetime, Int,
-                              Bool, List, Instance)
-from .properties import Column, EitherColumn, ColumnLabel
+from bokeh.core.has_props import HasProps
+from bokeh.core.properties import Bool, Date, Datetime, Either, Float, Instance, Int, List, String
 
+from .properties import Column, ColumnLabel, EitherColumn
 
 class Stat(HasProps):
     """Represents a statistical operation to summarize a column of data.

--- a/bokeh/charts/utils.py
+++ b/bokeh/charts/utils.py
@@ -1,41 +1,27 @@
-""" This is the utils module that collects convenience functions and code that are
+''' This is the utils module that collects convenience functions and code that are
 useful for charts ecosystem.
-"""
-#-----------------------------------------------------------------------------
-# Copyright (c) 2012 - 2014, Continuum Analytics, Inc. All rights reserved.
-#
-# Powered by the Bokeh Development Team.
-#
-# The full license is in the file LICENSE.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+'''
 from __future__ import absolute_import, division, print_function
 
-import itertools
-import json
 from collections import OrderedDict, defaultdict
 from copy import copy
+import itertools
+import json
 from math import cos, sin
-from colorsys import hsv_to_rgb
 
-from pandas.io.json import json_normalize
+from colorsys import hsv_to_rgb
 import pandas as pd
+from pandas.io.json import json_normalize
 import numpy as np
 from six import iteritems
 
-from ..models.glyphs import (
+from bokeh.models.glyphs import (
     Asterisk, Circle, CircleCross, CircleX, Cross, Diamond, DiamondCross,
-    InvertedTriangle, Square, SquareCross, SquareX, Triangle, X)
-from ..models.sources import ColumnDataSource
-from ..plotting.helpers import DEFAULT_PALETTE
-
-#-----------------------------------------------------------------------------
-# Classes and functions
-#-----------------------------------------------------------------------------
-
+    InvertedTriangle, Square, SquareCross, SquareX, Triangle, X
+)
+from bokeh.plotting.helpers import DEFAULT_PALETTE
+from bokeh.models.sources import ColumnDataSource
 
 DEFAULT_COLUMN_NAMES = 'abcdefghijklmnopqrstuvwxyz'
 

--- a/bokeh/client/session.py
+++ b/bokeh/client/session.py
@@ -51,7 +51,7 @@ def push_session(document, session_id=None, url='default', app_path='/', io_loop
             io_loop : tornado.ioloop.IOLoop, optional
                 The IOLoop to use for the websocket
        Returns:
-            session : ClientSession
+            ClientSession
                 A new ClientSession connected to the server
 
     """
@@ -100,7 +100,7 @@ def pull_session(session_id=None, url='default', app_path='/', io_loop=None):
         io_loop (``tornado.ioloop.IOLoop``, optional) :
             The IOLoop to use for the websocket
     Returns:
-        session (ClientSession) :
+        ClientSession :
             A new ClientSession connected to the server
 
     """

--- a/bokeh/core/compat/__init__.py
+++ b/bokeh/core/compat/__init__.py
@@ -4,9 +4,9 @@ All of the functions and classes in ``bokeh.core.compat`` are internal
 implementation details, and not user-facing. For information on the public
 API for MPL compatibility, see :ref:`bokeh.mpl`.
 
-.. warning::
+**THIS MODULE IN ITS CURRENT FORM IS NO LONGER MAINTAINED**
 
-    **THIS MODULE IN ITS CURRENT FORM IS NO LONGER MAINTAINED**
+.. warning::
 
     Currently, compatibility is implemented using the third-party
     `mplexporter`_ library. This library does not provide a full interface

--- a/bokeh/core/has_props.py
+++ b/bokeh/core/has_props.py
@@ -1,0 +1,755 @@
+'''
+
+.. note::
+    These classes form part of the very low-level machinery that implements
+    the Bokeh model and property system. It is unlikely that any of these
+    classes or their methods will be applicable to any standard usage or to
+    anyone who is not directly developing on Bokeh's own infrastructure.
+
+.. |HasProps| replace:: :class:`~bokeh.core.has_props.HasProps`
+.. |Property| replace:: :class:`~bokeh.core.property.bases.Property`
+.. |PropertyDescriptor| replace:: :class:`~bokeh.core.property.descriptors.PropertyDescriptor`
+
+'''
+from __future__ import absolute_import
+
+import logging
+logger = logging.getLogger(__name__)
+
+import difflib
+import inspect
+from operator import itemgetter
+import sys
+from warnings import warn
+
+from six import StringIO
+
+from ..util.dependencies import import_optional
+from ..util.future import with_metaclass
+from ..util.string import nice_join
+from .property.containers import PropertyValueContainer
+from .property.factory import PropertyFactory
+from .property.override import Override
+
+IPython = import_optional('IPython')
+
+if IPython:
+    from IPython.lib.pretty import RepresentationPrinter
+
+    class _BokehPrettyPrinter(RepresentationPrinter):
+        def __init__(self, output, verbose=False, max_width=79, newline='\n'):
+            super(_BokehPrettyPrinter, self).__init__(output, verbose, max_width, newline)
+            self.type_pprinters[HasProps] = lambda obj, p, cycle: obj._bokeh_repr_pretty_(p, cycle)
+
+_EXAMPLE_TEMPLATE = '''
+
+    Example
+    -------
+
+    .. bokeh-plot:: ../%(path)s
+        :source-position: none
+
+    *source:* :bokeh-tree:`%(path)s`
+
+'''
+
+class MetaHasProps(type):
+    ''' Specialize the construction of |HasProps| classes.
+
+    This class is a `metaclass`_ for |HasProps| that is responsible for
+    creating and adding the |PropertyDescriptor| instances that delegate
+    validation and serialization to |Property| attributes.
+
+    .. _metaclass: https://docs.python.org/3/reference/datamodel.html#metaclasses
+
+    '''
+    def __new__(meta_cls, class_name, bases, class_dict):
+        '''
+
+        '''
+        names_with_refs = set()
+        container_names = set()
+
+        # Now handle all the Override
+        overridden_defaults = {}
+        for name, prop in class_dict.items():
+            if not isinstance(prop, Override):
+                continue
+            if prop.default_overridden:
+                overridden_defaults[name] = prop.default
+
+        for name, default in overridden_defaults.items():
+            del class_dict[name]
+
+        generators = dict()
+        for name, generator in class_dict.items():
+            if isinstance(generator, PropertyFactory):
+                generators[name] = generator
+            elif isinstance(generator, type) and issubclass(generator, PropertyFactory):
+                # Support the user adding a property without using parens,
+                # i.e. using just the Property subclass instead of an
+                # instance of the subclass
+                generators[name] = generator.autocreate()
+
+        dataspecs = {}
+        new_class_attrs = {}
+
+        for name, generator in generators.items():
+            prop_descriptors = generator.make_descriptors(name)
+            replaced_self = False
+            for prop_descriptor in prop_descriptors:
+                if prop_descriptor.name in generators:
+                    if generators[prop_descriptor.name] is generator:
+                        # a generator can replace itself, this is the
+                        # standard case like `foo = Int()`
+                        replaced_self = True
+                        prop_descriptor.add_prop_descriptor_to_class(class_name, new_class_attrs, names_with_refs, container_names, dataspecs)
+                    else:
+                        # if a generator tries to overwrite another
+                        # generator that's been explicitly provided,
+                        # use the prop that was manually provided
+                        # and ignore this one.
+                        pass
+                else:
+                    prop_descriptor.add_prop_descriptor_to_class(class_name, new_class_attrs, names_with_refs, container_names, dataspecs)
+            # if we won't overwrite ourselves anyway, delete the generator
+            if not replaced_self:
+                del class_dict[name]
+
+        class_dict.update(new_class_attrs)
+
+        class_dict["__properties__"] = set(new_class_attrs)
+        class_dict["__properties_with_refs__"] = names_with_refs
+        class_dict["__container_props__"] = container_names
+        if len(overridden_defaults) > 0:
+            class_dict["__overridden_defaults__"] = overridden_defaults
+        if dataspecs:
+            class_dict["__dataspecs__"] = dataspecs
+
+        if "__example__" in class_dict:
+            path = class_dict["__example__"]
+            class_dict["__doc__"] += _EXAMPLE_TEMPLATE % dict(path=path)
+
+        return super(MetaHasProps, meta_cls).__new__(meta_cls, class_name, bases, class_dict)
+
+    def __init__(cls, class_name, bases, nmspc):
+        if class_name == 'HasProps':
+            return
+        # Check for improperly overriding a Property attribute.
+        # Overriding makes no sense except through the Override
+        # class which can be used to tweak the default.
+        # Historically code also tried changing the Property's
+        # type or changing from Property to non-Property: these
+        # overrides are bad conceptually because the type of a
+        # read-write property is invariant.
+        cls_attrs = cls.__dict__.keys() # we do NOT want inherited attrs here
+        for attr in cls_attrs:
+            for base in bases:
+                if issubclass(base, HasProps) and attr in base.properties():
+                    warn(('Property "%s" in class %s was overridden by a class attribute ' + \
+                          '"%s" in class %s; it never makes sense to do this. ' + \
+                          'Either %s.%s or %s.%s should be removed, or %s.%s should not ' + \
+                          'be a Property, or use Override(), depending on the intended effect.') %
+                         (attr, base.__name__, attr, class_name,
+                          base.__name__, attr,
+                          class_name, attr,
+                          base.__name__, attr),
+                         RuntimeWarning, stacklevel=2)
+
+        if "__overridden_defaults__" in cls.__dict__:
+            our_props = cls.properties()
+            for key in cls.__dict__["__overridden_defaults__"].keys():
+                if key not in our_props:
+                    warn(('Override() of %s in class %s does not override anything.') % (key, class_name),
+                         RuntimeWarning, stacklevel=2)
+
+def accumulate_from_superclasses(cls, propname):
+    ''' Traverse the class hierarchy and accumulate the special sets of names
+    ``MetaHasProps`` stores on classes:
+
+    Args:
+        name (str) : name of the special attribute to collect.
+
+            Typically meaningful values are: ``__container_props__``,
+            ``__properties__``, ``__properties_with_refs__``
+
+    '''
+    cachename = "__cached_all" + propname
+    # we MUST use cls.__dict__ NOT hasattr(). hasattr() would also look at base
+    # classes, and the cache must be separate for each class
+    if cachename not in cls.__dict__:
+        s = set()
+        for c in inspect.getmro(cls):
+            if issubclass(c, HasProps) and hasattr(c, propname):
+                base = getattr(c, propname)
+                s.update(base)
+        setattr(cls, cachename, s)
+    return cls.__dict__[cachename]
+
+def accumulate_dict_from_superclasses(cls, propname):
+    ''' Traverse the class hierarchy and accumulate the special dicts
+    ``MetaHasProps`` stores on classes:
+
+    Args:
+        name (str) : name of the special attribute to collect.
+
+            Typically meaningful values are: ``__dataspecs__``,
+            ``__overridden_defaults__``
+
+    '''
+    cachename = "__cached_all" + propname
+    # we MUST use cls.__dict__ NOT hasattr(). hasattr() would also look at base
+    # classes, and the cache must be separate for each class
+    if cachename not in cls.__dict__:
+        d = dict()
+        for c in inspect.getmro(cls):
+            if issubclass(c, HasProps) and hasattr(c, propname):
+                base = getattr(c, propname)
+                for k,v in base.items():
+                    if k not in d:
+                        d[k] = v
+        setattr(cls, cachename, d)
+    return cls.__dict__[cachename]
+
+class HasProps(with_metaclass(MetaHasProps, object)):
+    ''' Base class for all class types that have Bokeh properties.
+
+    '''
+    def __init__(self, **properties):
+        '''
+
+        '''
+        super(HasProps, self).__init__()
+        self._property_values = dict()
+
+        for name, value in properties.items():
+            setattr(self, name, value)
+
+    def __setattr__(self, name, value):
+        ''' Intercept attribute setting on HasProps in order to special case
+        a few situations:
+
+        * short circuit all property machinery for ``_private`` attributes
+        * handle setting ``__deprecated_attributes__``
+        * suggest similar attribute names on attribute errors
+
+        Args:
+            name (str) : the name of the attribute to set on this object
+            value (obj) : the value to set
+
+        Returns:
+            None
+
+        '''
+        # self.properties() below can be expensive so avoid it
+        # if we're just setting a private underscore field
+        if name.startswith("_"):
+            super(HasProps, self).__setattr__(name, value)
+            return
+
+        props = sorted(self.properties())
+        deprecated = getattr(self, '__deprecated_attributes__', [])
+
+        if name in props or name in deprecated:
+            super(HasProps, self).__setattr__(name, value)
+        else:
+            matches, text = difflib.get_close_matches(name.lower(), props), "similar"
+
+            if not matches:
+                matches, text = props, "possible"
+
+            raise AttributeError("unexpected attribute '%s' to %s, %s attributes are %s" %
+                (name, self.__class__.__name__, text, nice_join(matches)))
+
+    def __str__(self):
+        return "%s(...)" % self.__class__.__name__
+
+    __repr__ = __str__
+
+    def equals(self, other):
+        ''' Structural equality of models.
+
+        Args:
+            other (HasProps) : the other instance to compare to
+
+        Returns:
+            True, if properties are structurally equal, otherwise False
+
+        '''
+        # NOTE: don't try to use this to implement __eq__. Because then
+        # you will be tempted to implement __hash__, which would interfere
+        # with mutability of models. However, not implementing __hash__
+        # will make bokeh unusable in Python 3, where proper implementation
+        # of __hash__ is required when implementing __eq__.
+        if not isinstance(other, self.__class__):
+            return False
+        else:
+            return self.properties_with_values() == other.properties_with_values()
+
+    def set_from_json(self, name, json, models=None, setter=None):
+        ''' Set a property value on this object from JSON.
+
+        Args:
+            name: (str) : name of the attribute to set
+
+            json: (JSON-value) : value to set to the attribute to
+
+            models (dict or None, optional) :
+                Mapping of model ids to models (default: None)
+
+                This is needed in cases where the attributes to update also
+                have values that have references.
+
+            setter(ClientSession or ServerSession or None, optional) :
+                This is used to prevent "boomerang" updates to Bokeh apps.
+
+                In the context of a Bokeh server application, incoming updates
+                to properties will be annotated with the session that is
+                doing the updating. This value is propagated through any
+                subsequent change notifications that the update triggers.
+                The session can compare the event setter to itself, and
+                suppress any updates that originate from itself.
+
+        Returns:
+            None
+
+        '''
+        if name in self.properties():
+            #logger.debug("Patching attribute %s of %r", attr, patched_obj)
+            prop = self.lookup(name)
+            prop.set_from_json(self, json, models, setter)
+        else:
+            logger.warn("JSON had attr %r on obj %r, which is a client-only or invalid attribute that shouldn't have been sent", name, self)
+
+    def update(self, **kwargs):
+        ''' Updates the object's properties from the given keyword arguments.
+
+        Returns:
+            None
+
+        Examples:
+
+            The following are equivalent:
+
+            .. code-block:: python
+
+                from bokeh.models import Range1d
+
+                r = Range1d
+
+                # set properties individually:
+                r.start = 10
+                r.end = 20
+
+                # update properties together:
+                r.update(start=10, end=20)
+
+        '''
+        for k,v in kwargs.items():
+            setattr(self, k, v)
+
+    def update_from_json(self, json_attributes, models=None, setter=None):
+        ''' Updates the object's properties from a JSON attributes dictionary.
+
+        Args:
+            json_attributes: (JSON-dict) : attributes and values to update
+
+            models (dict or None, optional) :
+                Mapping of model ids to models (default: None)
+
+                This is needed in cases where the attributes to update also
+                have values that have references.
+
+            setter(ClientSession or ServerSession or None, optional) :
+                This is used to prevent "boomerang" updates to Bokeh apps.
+
+                In the context of a Bokeh server application, incoming updates
+                to properties will be annotated with the session that is
+                doing the updating. This value is propagated through any
+                subsequent change notifications that the update triggers.
+                The session can compare the event setter to itself, and
+                suppress any updates that originate from itself.
+
+        Returns:
+            None
+
+        '''
+        for k, v in json_attributes.items():
+            self.set_from_json(k, v, models, setter)
+
+    @classmethod
+    def lookup(cls, name):
+        ''' Find the ``PropertyDescriptor`` for a Bokeh property on a class,
+        given the property name.
+
+        Args:
+            name (str) : name of the property to search for
+
+        Returns:
+            PropertyDescriptor : descriptor for property named ``name``
+
+        '''
+        return getattr(cls, name)
+
+    @classmethod
+    def properties_with_refs(cls):
+        ''' Collect the names of all properties on this class that also have
+        references.
+
+        This method *always* traverses the class hierarchy and includes
+        properties defined on any parent classes.
+
+        Returns:
+            set[str] : names of properties that have references
+
+        '''
+        return accumulate_from_superclasses(cls, "__properties_with_refs__")
+
+    @classmethod
+    def properties_containers(cls):
+        ''' Collect the names of all container properties on this class.
+
+        This method *always* traverses the class hierarchy and includes
+        properties defined on any parent classes.
+
+        Returns:
+            set[str] : names of container properties
+
+        '''
+        return accumulate_from_superclasses(cls, "__container_props__")
+
+    @classmethod
+    def properties(cls, with_bases=True):
+        ''' Collect the names of properties on this class.
+
+        This method *optionally* traverses the class hierarchy and includes
+        properties defined on any parent classes.
+
+        Args:
+            with_bases (bool, optional) :
+                Whether to include properties defined on parent classes in
+                the results. (default: True)
+
+        Returns:
+           set[str] : property names
+
+        '''
+        if with_bases:
+            return accumulate_from_superclasses(cls, "__properties__")
+        else:
+            return set(cls.__properties__)
+
+    @classmethod
+    def dataspecs(cls):
+        ''' Collect the names of all ``DataSpec`` properties on this class.
+
+        This method *always* traverses the class hierarchy and includes
+        properties defined on any parent classes.
+
+        Returns:
+            set[str] : names of DataSpec properties
+
+        '''
+        return set(cls.dataspecs_with_props().keys())
+
+    @classmethod
+    def dataspecs_with_props(cls):
+        ''' Collect a dict mapping the names of all ``DataSpec`` properties
+        on this class to the associated properties.
+
+        This method *always* traverses the class hierarchy and includes
+        properties defined on any parent classes.
+
+        Returns:
+            dict[str, DataSpec] : mapping of names and ``DataSpec`` properties
+
+        '''
+        return accumulate_dict_from_superclasses(cls, "__dataspecs__")
+
+    def properties_with_values(self, include_defaults=True):
+        ''' Collect a dict mapping property names to their values.
+
+        This method *always* traverses the class hierarchy and includes
+        properties defined on any parent classes.
+
+        Non-serializable properties are skipped and property values are in
+        "serialized" format which may be slightly different from the values
+        you would normally read from the properties; the intent of this method
+        is to return the information needed to losslessly reconstitute the
+        object instance.
+
+        Args:
+            include_defaults (bool, optional) :
+                Whether to include properties that haven't been explicitly set
+                since the object was created. (default: True)
+
+        Returns:
+           dict : mapping from property names to their values
+
+        '''
+        return self.query_properties_with_values(lambda prop: prop.serialized, include_defaults)
+
+    @classmethod
+    def _overridden_defaults(cls):
+        ''' Returns a dictionary of defaults that have been overridden.
+
+        This is an implementation detail of Property.
+
+        '''
+        return accumulate_dict_from_superclasses(cls, "__overridden_defaults__")
+
+    def query_properties_with_values(self, query, include_defaults=True):
+        ''' Query the properties values of |HasProps| instances with a
+        predicate.
+
+        Args:
+            query (callable) :
+                A callable that accepts property descriptors and returns True
+                or False
+
+            include_defaults (bool, optional) :
+                Whether to include properties that have not been explicitly
+                set by a user (default: True)
+
+        Returns:
+            dict : mapping of property names and values for matching properties
+
+        '''
+        result = dict()
+        if include_defaults:
+            keys = self.properties()
+        else:
+            keys = set(self._property_values.keys())
+            if self.themed_values():
+                keys |= set(self.themed_values().keys())
+
+        for key in keys:
+            prop = self.lookup(key)
+            if not query(prop):
+                continue
+
+            value = prop.serializable_value(self)
+            if not include_defaults:
+                if isinstance(value, PropertyValueContainer) and value._unmodified_default_value:
+                    continue
+            result[key] = value
+
+        return result
+
+    def set(self, **kwargs):
+        ''' Updates the object's properties from the given keyword arguments.
+
+        THIS FUNCTION IS DEPRECATED. Use the .update method instead.
+
+        Returns:
+            None
+
+        Examples:
+
+            The following are equivalent:
+
+            .. code-block:: python
+
+                from bokeh.models import Range1d
+
+                r = Range1d
+
+                # set properties individually:
+                r.start = 10
+                r.end = 20
+
+                # update properties together:
+                r.update(start=10, end=20)
+
+        '''
+
+        from bokeh.util.deprecation import deprecated
+        deprecated((0, 12, 4), 'set method', 'update method')
+
+        for kw in kwargs:
+            setattr(self, kw, kwargs[kw])
+
+    # TODO (bev) could this return an empty dict instead of None?
+    def themed_values(self):
+        ''' Get any theme-provided overrides.
+
+        Results are returned as a dict from property name to value, or
+        ``None`` if no theme overrides any values for this instance.
+
+        Returns:
+            dict or None
+
+        '''
+        if hasattr(self, '__themed_values__'):
+            return getattr(self, '__themed_values__')
+        else:
+            return None
+
+    def apply_theme(self, property_values):
+        ''' Apply a set of theme values which will be used rather than
+        defaults, but will not override application-set values.
+
+        The passed-in dictionary may be kept around as-is and shared with
+        other instances to save memory (so neither the caller nor the
+        |HasProps| instance should modify it).
+
+        Args:
+            property_values (dict) : theme values to use in place of defaults
+
+        Returns:
+            None
+
+        '''
+        old_dict = None
+        if hasattr(self, '__themed_values__'):
+            old_dict = getattr(self, '__themed_values__')
+
+        # if the same theme is set again, it should reuse the
+        # same dict
+        if old_dict is property_values:
+            return
+
+        removed = set()
+        # we're doing a little song-and-dance to avoid storing __themed_values__ or
+        # an empty dict, if there's no theme that applies to this HasProps instance.
+        if old_dict is not None:
+            removed.update(set(old_dict.keys()))
+        added = set(property_values.keys())
+        old_values = dict()
+        for k in added.union(removed):
+            old_values[k] = getattr(self, k)
+
+        if len(property_values) > 0:
+            setattr(self, '__themed_values__', property_values)
+        elif hasattr(self, '__themed_values__'):
+            delattr(self, '__themed_values__')
+
+        # Emit any change notifications that result
+        for k, v in old_values.items():
+            prop = self.lookup(k)
+            prop.trigger_if_changed(self, v)
+
+    def unapply_theme(self):
+        ''' Remove any themed values and restore defaults.
+
+        Returns:
+            None
+
+        '''
+        self.apply_theme(property_values=dict())
+
+    def pretty(self, verbose=False, max_width=79, newline='\n'):
+        ''' Generate a "pretty" string representation of the object.
+
+        .. note::
+            This function only functions in the IPython shell or
+            Jupyter Notebooks.
+
+        Args:
+            Verbose (bool, optional) :
+                This is a conventional argument for IPython representation
+                printers but is unused by Bokeh. (default: False)
+
+            max_width (int, optional) :
+                Minimum width to start breaking lines when possible. (default: 79)
+
+            newline (str, optional) :
+                Character to use to separate each line (default: ``\\n``)
+
+        Returns:
+            str : pretty object representation
+
+        Raises:
+            ValueError, if ``IPython`` cannot be imported
+
+        '''
+        if not IPython:
+            cls = self.__class__
+            raise RuntimeError("%s.%s.pretty() requires IPython" % (cls.__module__, cls.__name__))
+        else:
+            stream = StringIO()
+            printer = _BokehPrettyPrinter(stream, verbose, max_width, newline)
+            printer.pretty(self)
+            printer.flush()
+            return stream.getvalue()
+
+    def pprint(self, verbose=False, max_width=79, newline='\n'):
+        ''' Print a "pretty" string representation of the object to stdout.
+
+        .. note::
+            This function only functions in the IPython shell or
+            Jupyter Notebooks.
+
+        Args:
+            Verbose (bool, optional) :
+                This is a conventional argument for IPython representation
+                printers but is unused by Bokeh. (default: False)
+
+            max_width (int, optional) :
+                Minimum width to start breaking lines when possible. (default: 79)
+
+            newline (str, optional) :
+                Character to use to separate each line (default: ``\\n``)
+
+        Returns:
+            None
+
+        Raises:
+            ValueError, if ``IPython`` cannot be imported
+
+        Examples:
+
+            .. code-block:: python
+
+                In [1]: from bokeh.models import Range1d
+
+                In [1]: r = Range1d(start=10, end=20)
+
+                In [2]: r.pprint()
+                bokeh.models.ranges.Range1d(
+                    id='1576d21a-0c74-4214-8d8f-ad415e1e4ed4',
+                    bounds=None,
+                    callback=None,
+                    end=20,
+                    js_callbacks={},
+                    max_interval=None,
+                    min_interval=None,
+                    name=None,
+                    start=10,
+                    tags=[])
+
+        '''
+        sys.stdout.write(self.pretty())
+        sys.stdout.write(newline)
+        sys.stdout.flush()
+
+    def _clone(self):
+        ''' Duplicate a HasProps object.
+
+        Values that are containers are shallow-copied.
+
+        '''
+        return self.__class__(**self._property_values)
+
+    def _bokeh_repr_pretty_(self, p, cycle):
+        '''
+
+        '''
+        name = "%s.%s" % (self.__class__.__module__, self.__class__.__name__)
+
+        if cycle:
+            p.text("%s(...)" % name)
+        else:
+            with p.group(4, '%s(' % name, ')'):
+                props = self.properties_with_values().items()
+                sorted_props = sorted(props, key=itemgetter(0))
+                all_props = sorted_props
+                for i, (prop, value) in enumerate(all_props):
+                    if i == 0:
+                        p.breakable('')
+                    else:
+                        p.text(',')
+                        p.breakable()
+                    p.text(prop)
+                    p.text('=')
+                    p.pretty(value)

--- a/bokeh/core/has_props.py
+++ b/bokeh/core/has_props.py
@@ -28,7 +28,7 @@ from ..util.dependencies import import_optional
 from ..util.future import with_metaclass
 from ..util.string import nice_join
 from .property.containers import PropertyValueContainer
-from .property.factory import PropertyFactory
+from .property.descriptor_factory import PropertyDescriptorFactory
 from .property.override import Override
 
 IPython = import_optional('IPython')
@@ -83,9 +83,9 @@ class MetaHasProps(type):
 
         generators = dict()
         for name, generator in class_dict.items():
-            if isinstance(generator, PropertyFactory):
+            if isinstance(generator, PropertyDescriptorFactory):
                 generators[name] = generator
-            elif isinstance(generator, type) and issubclass(generator, PropertyFactory):
+            elif isinstance(generator, type) and issubclass(generator, PropertyDescriptorFactory):
                 # Support the user adding a property without using parens,
                 # i.e. using just the Property subclass instead of an
                 # instance of the subclass

--- a/bokeh/core/json_encoder.py
+++ b/bokeh/core/json_encoder.py
@@ -128,7 +128,7 @@ class BokehJSONEncoder(json.JSONEncoder):
 
         from ..model import Model
         from ..colors import Color
-        from .properties import HasProps
+        from .has_props import HasProps
 
         # array types -- use force_list here, only binary
         # encoding CDS columns for now
@@ -209,7 +209,7 @@ def serialize_json(obj, pretty=False, indent=None, **kwargs):
     '''
 
     # these args to json.dumps are computed internally and should not be passed along
-    for name in ['allow_nan', 'indent', 'separators', 'sort_keys']:
+    for name in ['allow_nan', 'separators', 'sort_keys']:
         if name in kwargs:
             raise ValueError("The value of %r is computed internally, overriding is not permissable." % name)
 

--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -116,9 +116,8 @@ from ..util.dependencies import import_optional
 from ..util.deprecation import deprecated
 from ..util.serialization import transform_column_source_data, decode_base64_dict
 from ..util.string import nice_join
-from .property.bases import (
-    ContainerProperty, ParameterizedProperty, Property,
-    PropertyFactory,  PrimitiveProperty, DeserializationError)
+from .property.bases import ContainerProperty, DeserializationError, ParameterizedProperty, Property, PrimitiveProperty
+from .property.descriptor_factory import PropertyDescriptorFactory
 from .property.descriptors import BasicPropertyDescriptor, DataSpecPropertyDescriptor, UnitsSpecPropertyDescriptor
 from . import enums
 
@@ -1853,7 +1852,7 @@ def value(val):
 # intentional transitive import to put Override in this module, DO NOT REMOVE
 from .property.override import Override ; Override
 
-class Include(PropertyFactory):
+class Include(PropertyDescriptorFactory):
     ''' Include "mix-in" property collection in a Bokeh model.
 
     See :ref:`bokeh.core.property_mixins` for more details.

--- a/bokeh/core/property/bases.py
+++ b/bokeh/core/property/bases.py
@@ -19,13 +19,13 @@ from six import string_types
 
 from ...util.string import nice_join
 from .containers import PropertyValueList, PropertyValueDict
+from .descriptor_factory import PropertyDescriptorFactory
 from .descriptors import BasicPropertyDescriptor
-from .factory import PropertyFactory
 
 class DeserializationError(Exception):
     pass
 
-class Property(PropertyFactory):
+class Property(PropertyDescriptorFactory):
     ''' Base class for Bokeh property instances, which can be added to Bokeh
     Models.
 

--- a/bokeh/core/property/bases.py
+++ b/bokeh/core/property/bases.py
@@ -1,0 +1,378 @@
+''' Provide base classes for the Bokeh property system.
+
+.. note::
+    These classes form part of the very low-level machinery that implements
+    the Bokeh model and property system. It is unlikely that any of these
+    classes or their methods will be applicable to any standard usage or to
+    anyone who is not directly developing on Bokeh's own infrastructure.
+
+'''
+from __future__ import absolute_import
+
+import logging
+logger = logging.getLogger(__name__)
+
+from copy import copy
+import types
+
+from six import string_types
+
+from ...util.string import nice_join
+from .containers import PropertyValueList, PropertyValueDict
+from .descriptors import BasicPropertyDescriptor
+from .factory import PropertyFactory
+
+class DeserializationError(Exception):
+    pass
+
+class Property(PropertyFactory):
+    ''' Base class for Bokeh property instances, which can be added to Bokeh
+    Models.
+
+    Args:
+        default (obj or None, optional) :
+            A default value for attributes created from this property to
+            have (default: None)
+
+        help (str or None, optional) :
+            A documentation string for this property. It will be automatically
+            used by the :ref:`bokeh.sphinxext.bokeh_prop` extension when
+            generating Spinx documentation. (default: None)
+
+        serialized (bool, optional) :
+            Whether attributes created from this property should be included
+            in serialization (default: True)
+
+        readonly (bool, optional) :
+            Whether attributes created from this property are read-only.
+            (default: False)
+
+    '''
+
+    def __init__(self, default=None, help=None, serialized=True, readonly=False):
+        # This is how the descriptor is created in the class declaration.
+        self._serialized = False if readonly else serialized
+        self._readonly = readonly
+        self._default = default
+        self.__doc__ = help
+        self.alternatives = []
+        self.assertions = []
+
+        # "fail early" when a default is invalid
+        self.validate(self._raw_default())
+
+    def __str__(self):
+        return self.__class__.__name__
+
+    @classmethod
+    def _sphinx_prop_link(cls):
+        ''' Generate a sphinx :class: link to this property.
+
+        '''
+        return ":class:`~bokeh.core.properties.%s` " % cls.__name__
+
+    @staticmethod
+    def _sphinx_model_link(name):
+        ''' Generate a sphinx :class: link to given named model.
+
+        '''
+        return ":class:`~%s` " % name
+
+    def _sphinx_type(self):
+        ''' Generate a Sphinx-style reference to this type for documentation
+        automation purposes.
+
+        '''
+        return self._sphinx_prop_link()
+
+    def make_descriptors(self, base_name):
+        ''' Return a list of ``BasicPropertyDescriptor`` instances to install
+        on a class, in order to delegate attribute access to this property.
+
+        Args:
+            name (str) : the name of the property these descriptors are for
+
+        Returns:
+            list[BasicPropertyDescriptor]
+
+        The descriptors returned are collected by the ``MetaHasProps``
+        metaclass and added to ``HasProps`` subclasses during class creation.
+        '''
+        return [ BasicPropertyDescriptor(base_name, self) ]
+
+    def _has_stable_default(self):
+        ''' True if we have a default that is immutable, and will be the
+        same every time (some defaults are generated on demand by a function
+        to be called).
+
+        '''
+        if isinstance(self._default, types.FunctionType):
+            return False
+        else:
+            return True
+
+    @classmethod
+    def _copy_default(cls, default):
+        ''' Return a copy of the default, or a new value if the default
+        is specified by a function.
+
+        '''
+        if not isinstance(default, types.FunctionType):
+            return copy(default)
+        else:
+            return default()
+
+    def _raw_default(self):
+        ''' Return the untransformed default value.
+
+        The raw_default() needs to be validated and transformed by
+        prepare_value() before use, and may also be replaced later by
+        subclass overrides or by themes.
+
+        '''
+        return self._copy_default(self._default)
+
+    def themed_default(self, cls, name, theme_overrides):
+        ''' The default, transformed by prepare_value() and the theme overrides.
+
+        '''
+        overrides = theme_overrides
+        if overrides is None or name not in overrides:
+            overrides = cls._overridden_defaults()
+
+        if name in overrides:
+            default = self._copy_default(overrides[name])
+        else:
+            default = self._raw_default()
+        return self.prepare_value(cls, name, default)
+
+    @property
+    def serialized(self):
+        ''' Whether the property should be serialized when serializing an object.
+
+        This would be False for a "virtual" or "convenience" property that duplicates
+        information already available in other properties, for example.
+        '''
+        return self._serialized
+
+    @property
+    def readonly(self):
+        ''' Whether this property is read-only.
+
+        Read-only properties may only be modified by the client (i.e., by BokehJS
+        in the browser).
+
+        '''
+        return self._readonly
+
+    def matches(self, new, old):
+        # XXX: originally this code warned about not being able to compare values, but that
+        # doesn't make sense, because most comparisons involving numpy arrays will fail with
+        # ValueError exception, thus warning about inevitable.
+        try:
+            if new is None or old is None:
+                return new is old           # XXX: silence FutureWarning from NumPy
+            else:
+                return new == old
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception:
+            # if we cannot compare (e.g. arrays) just punt return False for match
+            pass
+        return False
+
+    def from_json(self, json, models=None):
+        ''' Convert from JSON-compatible values into a value for this property.
+
+        JSON-compatible values are: list, dict, number, string, bool, None
+
+        '''
+        return json
+
+    def serialize_value(self, value):
+        ''' Change the value into a JSON serializable format.
+
+        '''
+        return value
+
+    def transform(self, value):
+        ''' Change the value into the canonical format for this property.
+
+        Args:
+            value (obj) : the value to apply transformation to.
+
+        Returns:
+            obj: transformed value
+
+        '''
+        return value
+
+    def validate(self, value):
+        ''' Determine whether we can set this property from this value.
+
+        Validation happens before transform()
+
+        Args:
+            value (obj) : the value to validate against this property type
+
+        Returns:
+            None
+
+        Raises:
+            ValueError if the value is not valid for this property type
+
+        '''
+        pass
+
+    def is_valid(self, value):
+        ''' Whether the value passes validation
+
+        Args:
+            value (obj) : the value to validate against this property type
+
+        Returns:
+            True if valid, False otherwise
+
+        '''
+        try:
+            self.validate(value)
+        except ValueError:
+            return False
+        else:
+            return True
+
+    @classmethod
+    def _wrap_container(cls, value):
+        if isinstance(value, list):
+            if isinstance(value, PropertyValueList):
+                return value
+            else:
+                return PropertyValueList(value)
+        elif isinstance(value, dict):
+            if isinstance(value, PropertyValueDict):
+                return value
+            else:
+                return PropertyValueDict(value)
+        else:
+            return value
+
+    def prepare_value(self, obj_or_cls, name, value):
+        try:
+            self.validate(value)
+        except ValueError as e:
+            for tp, converter in self.alternatives:
+                if tp.is_valid(value):
+                    value = converter(value)
+                    break
+            else:
+                raise e
+        else:
+            value = self.transform(value)
+
+        from ..has_props import HasProps
+        if isinstance(obj_or_cls, HasProps):
+            obj = obj_or_cls
+
+            for fn, msg_or_fn in self.assertions:
+                if isinstance(fn, bool):
+                    result = fn
+                else:
+                    result = fn(obj, value)
+
+                if isinstance(result, bool):
+                    if not result:
+                        if isinstance(msg_or_fn, string_types):
+                            raise ValueError(msg_or_fn)
+                        else:
+                            msg_or_fn()
+                elif result is not None:
+                    if isinstance(msg_or_fn, string_types):
+                        raise ValueError(msg_or_fn % result)
+                    else:
+                        msg_or_fn(result)
+
+        return self._wrap_container(value)
+
+    @property
+    def has_ref(self):
+        return False
+
+    def accepts(self, tp, converter):
+        tp = ParameterizedProperty._validate_type_param(tp)
+        self.alternatives.append((tp, converter))
+        return self
+
+    def asserts(self, fn, msg_or_fn):
+        self.assertions.append((fn, msg_or_fn))
+        return self
+
+class ParameterizedProperty(Property):
+    ''' A base class for Properties that have type parameters, e.g.
+    ``List(String)``.
+
+    '''
+
+    @staticmethod
+    def _validate_type_param(type_param):
+        if isinstance(type_param, type):
+            if issubclass(type_param, Property):
+                return type_param()
+            else:
+                type_param = type_param.__name__
+        elif isinstance(type_param, Property):
+            return type_param
+
+        raise ValueError("expected a Propertyas type parameter, got %s" % type_param)
+
+    @property
+    def type_params(self):
+        raise NotImplementedError("abstract method")
+
+    @property
+    def has_ref(self):
+        return any(type_param.has_ref for type_param in self.type_params)
+
+class PrimitiveProperty(Property):
+    ''' A base class for simple property types.
+
+    Subclasses should define a class attribute ``_underlying_type`` that is
+    a tuple of acceptable type values for the property.
+
+    Example:
+
+        A trivial version of a ``Float`` property might look like:
+
+        .. code-block:: python
+
+            class Float(PrimitiveProperty):
+                _underlying_type = (numbers.Real,)
+
+    '''
+
+    _underlying_type = None
+
+    def validate(self, value):
+        super(PrimitiveProperty, self).validate(value)
+
+        if not (value is None or isinstance(value, self._underlying_type)):
+            raise ValueError("expected a value of type %s, got %s of type %s" %
+                (nice_join([ cls.__name__ for cls in self._underlying_type ]), value, type(value).__name__))
+
+    def from_json(self, json, models=None):
+        if json is None or isinstance(json, self._underlying_type):
+            return json
+        else:
+            expected = nice_join([ cls.__name__ for cls in self._underlying_type ])
+            raise DeserializationError("%s expected %s, got %s" % (self, expected, json))
+
+    def _sphinx_type(self):
+        return self._sphinx_prop_link()
+
+class ContainerProperty(ParameterizedProperty):
+    ''' A base class for Container-like type properties.
+
+    '''
+
+    def _has_stable_default(self):
+        # all containers are mutable, so the default can be modified
+        return False

--- a/bokeh/core/property/descriptor_factory.py
+++ b/bokeh/core/property/descriptor_factory.py
@@ -5,10 +5,10 @@ Bokeh properties work by contributing Python descriptor objects to
 to the Bokeh property class, which handles validation, serialization, and
 documentation needs.
 
-The ``PropertyFactory`` class provides two methods ``autocreate`` and
+The ``PropertyDescriptorFactory`` class provides two methods ``autocreate`` and
 ``make_descriptors`` that are used by the metaclass ``MetaHasProps`` during
-class creation. to install the necessary descriptors corresponding to the
-declared properties.
+class creation to create and install the necessary descriptors corresponding
+to the declared properties.
 
 This machinery helps to make Bokeh much more user friendly. For example,
 the DataSpec properties mediate between fixed values and references to column
@@ -39,7 +39,7 @@ details around validation, serialization, and documentation.
 
 '''
 
-class PropertyFactory(object):
+class PropertyDescriptorFactory(object):
     ''' Base class for all Bokeh properties.
 
     A Bokeh property really consist of two parts: the familar "property"
@@ -101,8 +101,9 @@ class PropertyFactory(object):
         The descriptors returned are collected by the ``MetaHasProps``
         metaclass and added to ``HasProps`` subclasses during class creation.
 
-        Subclasses of ``PropertyFactory`` are responsible for implementing
-        this function to return descriptors specific to their needs.
+        Subclasses of ``PropertyDescriptorFactory`` are responsible for
+        implementing this function to return descriptors specific to their
+        needs.
 
         '''
         raise NotImplementedError("make_descriptors not implemented")

--- a/bokeh/core/property/descriptors.py
+++ b/bokeh/core/property/descriptors.py
@@ -1,0 +1,1022 @@
+''' Provide Python descriptors for delegating to Bokeh properties.
+
+The Python `descriptor protocol`_ allows fine-grained control over all
+attribute access on instances ("You control the dot"). Bokeh uses the
+descriptor protocol to provide easy-to-use, declarative, type-based
+class properties that can automatically validate and serialize their
+values, as well as help provide sophisticated documentation.
+
+A Bokeh property really consist of two parts: a familar "property"
+portion, such as ``Int``, ``String``, etc., as well as an associated
+Python descriptor that delegates attribute access to the property instance.
+
+For example, a very simplified definition of a range-like object might
+be:
+
+.. code-block:: python
+
+    from bokeh.model import Model
+    from bokeh.core.properties import Float
+
+    class Range(Model):
+        start = Float(help="start point")
+        end   = Float(help="end point")
+
+When this class is created, the ``MetaHasProps`` metaclass wires up both
+the ``start`` and ``end`` attributes to a ``Float`` property. Then, when
+a user accesses those attributes, the descriptor delegates all get and
+set operations to the ``Float`` property.
+
+.. code-block:: python
+
+    rng = Range()
+
+    # The descriptor __set__ method delegates to Float, which can validate
+    # the value 10.3 as a valid floating point value
+    rng.start = 10.3
+
+    # But can raise a validation exception if an attempt to set to a list
+    # is made
+    rnd.end = [1,2,3]   # ValueError !
+
+More sophisticated properties such as ``DataSpec`` and its subclasses can
+exert control over how values are serialized. Consider this example with
+the ``Circle`` glyph and its ``x`` attribute that is a ``NumberSpec``:
+
+.. code-block:: python
+
+    from bokeh.models import Circle
+
+    c = Circle()
+
+    c.x = 10      # serializes to {'value': 10}
+
+    c.x = 'foo'   # serializes to {'field': 'foo'}
+
+There are many other examples like this throughout Bokeh. In this way users
+may operate simply and naturally, and not be concerned with the low-level
+details around validation, serialization, and documentation.
+
+This module provides the class |PropertyDescriptor| and various subclasses
+that can be used to attach Bokeh properties to Bokeh models.
+
+.. note::
+    These classes form part of the very low-level machinery that implements
+    the Bokeh model and property system. It is unlikely that any of these
+    classes or their methods will be applicable to any standard usage or to
+    anyone who is not directly developing on Bokeh's own infrastructure.
+
+.. _descriptor protocol: https://docs.python.org/3/howto/descriptor.html
+
+.. |DataSpec| replace:: :class:`~bokeh.core.properties.DataSpec`
+.. |HasProps| replace:: :class:`~bokeh.core.has_props.HasProps`
+.. |Property| replace:: :class:`~bokeh.core.properties.Property`
+.. |PropertyContainer| replace:: :class:`~bokeh.core.property.containers.PropertyContainer`
+.. |PropertyDescriptor| replace:: :class:`~bokeh.core.property.descriptor.PropertyDescriptor`
+.. |UnitsSpec| replace:: :class:`~bokeh.core.properties.UnitsSpec`
+
+'''
+from __future__ import absolute_import
+
+from copy import copy
+
+from six import string_types
+
+from .containers import PropertyValueContainer
+
+class PropertyDescriptor(object):
+    ''' Base class for a python descriptor that delegates access for a named
+    attribute to a Bokeh |Property| instance.
+
+    '''
+
+    def __init__(self, name):
+        ''' Create a descriptor for a hooking up a named Bokeh property
+        as an attribute on a |HasProps| class.
+
+        Args:
+            name (str) : the attribute name that this descriptor is for
+
+        '''
+        self.name = name
+
+    def __str__(self):
+        ''' Basic string representation of ``PropertyDescriptor``.
+
+        **Subclasses must implement this to serve their specific needs.**
+
+        '''
+        return "PropertyDescriptor(%s)" % (self.name)
+
+    def __get__(self, obj, owner):
+        ''' Implement the getter for the Python `descriptor protocol`_.
+
+        Args:
+            obj (HasProps or None) :
+                The instance to set a new property value on (for instance
+                attribute access), or None (for class attribute access)
+
+            owner (obj) :
+                The new value to set the property to
+
+        Returns:
+            None
+
+        Raises:
+            NotImplementedError
+
+        **Subclasses must implement this to serve their specific needs.**
+
+        '''
+        raise NotImplementedError("Implement __get__")
+
+    def __set__(self, obj, value, setter=None):
+        ''' Implement the setter for the Python `descriptor protocol`_.
+
+        .. note::
+            An optional argument ``setter`` has been added to the standard
+            setter arguments. When needed, this value should be provided by
+            explicitly invoking ``__set__``. See below for more information.
+
+        Args:
+            obj (HasProps) :
+                The instance to set a new property value on
+
+            value (obj) :
+                The new value to set the property to
+
+            setter (ClientSession or ServerSession or None, optional) :
+                This is used to prevent "boomerang" updates to Bokeh apps.
+                (default: None)
+
+                In the context of a Bokeh server application, incoming updates
+                to properties will be annotated with the session that is
+                doing the updating. This value is propagated through any
+                subsequent change notifications that the update triggers.
+                The session can compare the event setter to itself, and
+                suppress any updates that originate from itself.
+
+        Returns:
+            None
+
+        Raises:
+            NotImplementedError
+
+        **Subclasses must implement this to serve their specific needs.**
+
+        '''
+        raise NotImplementedError("Implement __set__")
+
+    def __delete__(self, obj):
+        ''' Implement the deleter for the Python `descriptor protocol`_.
+
+        Args:
+            obj (HasProps) : An instance to delete this property from
+
+        Raises:
+            NotImplementedError
+
+        **Subclasses must implement this to serve their specific needs.**
+
+        '''
+        raise NotImplementedError("Implement __delete__")
+
+    # This would probably be cleaner with some form of multiple dispatch
+    # on (descriptor, property). Currently this method has to know about
+    # various other classes, and that is annoying.
+    def add_prop_descriptor_to_class(self, class_name, new_class_attrs, names_with_refs, container_names, dataspecs):
+        ''' ``MetaHasProps`` calls this during class creation as it iterates
+        over properties to add, to update its registry of new properties.
+
+        The parameters passed in are mutable and this function is expected to
+        update them accordingly.
+
+        Args:
+            class_name (str) :
+                name of the class this descriptor is added to
+
+            new_class_attrs(dict[str, PropertyDescriptor]) :
+                mapping of attribute names to PropertyDescriptor that this
+                function will update
+
+            names_with_refs (set[str]) :
+                set of all property names for properties that also have
+                references, that this function will update
+
+            container_names (set[str]) :
+                set of all property names for properties that are
+                container props, that this function will update
+
+            dataspecs(dict[str, PropertyDescriptor]) :
+                mapping of attribute names to PropertyDescriptor for DataSpec
+                properties that this function will update
+
+        Return:
+            None
+
+        '''
+        from ..properties import DataSpec, ContainerProperty
+        name = self.name
+        if name in new_class_attrs:
+            raise RuntimeError("Two property generators both created %s.%s" % (class_name, name))
+        new_class_attrs[name] = self
+
+        if self.has_ref:
+            names_with_refs.add(name)
+
+        if isinstance(self, BasicPropertyDescriptor):
+            if isinstance(self.property, ContainerProperty):
+                container_names.add(name)
+
+            if isinstance(self.property, DataSpec):
+                dataspecs[name] = self
+
+    def class_default(self, cls):
+        ''' The default as computed for a certain class, ignoring any
+        per-instance theming.
+
+        Raises:
+            NotImplementedError
+
+        **Subclasses must implement this to serve their specific needs.**
+
+        '''
+        raise NotImplementedError("Implement class_default()")
+
+    def serializable_value(self, obj):
+        ''' Produce the value as it should be serialized.
+
+        Sometimes it is desirable for the serialized value to differ from
+        the ``__get__`` in order for the ``__get__`` value to appear simpler
+        for user or developer convenience.
+
+        Args:
+            obj (HasProps) : the object to get the serialized attribute for
+
+        Returns:
+            JSON-like
+
+        '''
+        value = self.__get__(obj, obj.__class__)
+        return self.property.serialize_value(value)
+
+    def set_from_json(self, obj, json, models, setter=None):
+        '''Sets the value of this property from a JSON value.
+
+        Args:
+            obj: (HasProps) : instance to set the property value on
+
+            json: (JSON-value) : value to set to the attribute to
+
+            models (dict or None, optional) :
+                Mapping of model ids to models (default: None)
+
+                This is needed in cases where the attributes to update also
+                have values that have references.
+
+            setter (ClientSession or ServerSession or None, optional) :
+                This is used to prevent "boomerang" updates to Bokeh apps.
+                (default: None)
+
+                In the context of a Bokeh server application, incoming updates
+                to properties will be annotated with the session that is
+                doing the updating. This value is propagated through any
+                subsequent change notifications that the update triggers.
+                The session can compare the event setter to itself, and
+                suppress any updates that originate from itself.
+
+        Returns:
+            None
+
+        '''
+        self._internal_set(obj, json, setter)
+
+    def trigger_if_changed(self, obj, old):
+        ''' Send a change event notification if the property is set to a
+        value is not equal to ``old``.
+
+        Args:
+            obj (HasProps)
+                The object the property is being set on.
+
+            old (obj) :
+                The previous value of the property to compare
+
+        Raises:
+            NotImplementedError
+
+        **Subclasses must implement this to serve their specific needs.**
+
+        '''
+        raise NotImplementedError("Implement trigger_if_changed()")
+
+    @property
+    def has_ref(self):
+        ''' Whether the property can refer to another ``HasProps`` instance.
+
+        This is typically True for container properties, ``Instance``, etc.
+
+        Raises:
+            NotImplementedError
+
+        **Subclasses must implement this to serve their specific needs.**
+
+        '''
+        raise NotImplementedError("Implement has_ref()")
+
+    @property
+    def readonly(self):
+        ''' Whether this property is read-only.
+
+        Read-only properties may only be modified by the client (i.e., by
+        BokehJS, in the browser). Read only properties are useful for
+        quantities that originate or that can only be computed in the
+        browser, for instance the "inner" plot dimension of a plot area,
+        which depend on the current layout state. It is useful for Python
+        callbacks to be able to know these values, but they can only be
+        computed in the actual browser.
+
+        Raises:
+            NotImplementedError
+
+        **Subclasses must implement this to serve their specific needs.**
+
+        '''
+        raise NotImplementedError("Implement readonly()")
+
+    @property
+    def serialized(self):
+        ''' Whether the property should be serialized when serializing
+        an object.
+
+        This would be False for a "virtual" or "convenience" property that
+        duplicates information already available in other properties, for
+        example.
+
+        Raises:
+            NotImplementedError
+
+        **Subclasses must implement this to serve their specific needs.**
+
+        '''
+        raise NotImplementedError("Implement serialized()")
+
+    def _internal_set(self, obj, value, setter=None):
+        ''' Internal implementation to set property values, that is used
+        by __set__, set_from_json, etc.
+
+        Args:
+            obj (HasProps)
+                The object the property is being set on.
+
+            old (obj) :
+                The previous value of the property to compare
+
+            setter (ClientSession or ServerSession or None, optional) :
+                This is used to prevent "boomerang" updates to Bokeh apps.
+                (default: None)
+
+                In the context of a Bokeh server application, incoming updates
+                to properties will be annotated with the session that is
+                doing the updating. This value is propagated through any
+                subsequent change notifications that the update triggers.
+                The session can compare the event setter to itself, and
+                suppress any updates that originate from itself.
+
+        Raises:
+            NotImplementedError
+
+        **Subclasses must implement this to serve their specific needs.**
+
+        '''
+        raise NotImplementedError("Implement _internal_set()")
+
+class BasicPropertyDescriptor(PropertyDescriptor):
+    ''' A PropertyDescriptor for basic Bokeh properties (e.g, ``Int``,
+    ``String``, ``Float``, etc.) with simple get/set and serialization
+    behavior.
+
+    '''
+
+    def __init__(self, name, property):
+        ''' Create a PropertyDescriptor for basic Bokeh properties.
+
+        Args:
+            name (str) : The attribute name that this property is for
+            property (Property) : A basic property to create a descriptor for
+
+        '''
+        super(BasicPropertyDescriptor, self).__init__(name)
+        self.property = property
+        self.__doc__ = self.property.__doc__
+
+    def __str__(self):
+        ''' Basic string representation of ``BasicPropertyDescriptor``.
+
+        Delegates to ``self.property.__str__``
+
+        '''
+        return "%s" % self.property
+
+    def __get__(self, obj, owner):
+        ''' Implement the getter for the Python `descriptor protocol`_.
+
+        For instance attribute access, we delegate to the |Property|. For
+        class attribute access, we return ourself.
+
+        Args:
+            obj (HasProps or None) :
+                The instance to set a new property value on (for instance
+                attribute access), or None (for class attribute access)
+
+            owner (obj) :
+                The new value to set the property to
+
+        Returns:
+            None
+
+        Examples:
+
+            .. code-block:: python
+
+                >>> from bokeh.models import Range1d
+
+                >>> r = Range1d(start=10, end=20)
+
+                # instance attribute access, returns the property value
+                >>> r.start
+                10
+
+                # class attribute access, returns the property descriptor
+                >>> Range1d.start
+                <bokeh.core.property.descriptors.BasicPropertyDescriptor at 0x1148b3390>
+
+        '''
+        if obj is not None:
+            return self._get(obj)
+        elif owner is not None:
+            return self
+        else:
+            # This should really never happen. If it does, it means we've
+            # called __get__ explicitly but in a bad way.
+            raise ValueError("both 'obj' and 'owner' are None, don't know what to do")
+
+    def __set__(self, obj, value, setter=None):
+        ''' Implement the setter for the Python `descriptor protocol`_.
+
+        .. note::
+            An optional argument ``setter`` has been added to the standard
+            setter arguments. When needed, this value should be provided by
+            explicitly invoking ``__set__``. See below for more information.
+
+        Args:
+            obj (HasProps) :
+                The instance to set a new property value on
+
+            value (obj) :
+                The new value to set the property to
+
+            setter (ClientSession or ServerSession or None, optional) :
+                This is used to prevent "boomerang" updates to Bokeh apps.
+                (default: None)
+
+                In the context of a Bokeh server application, incoming updates
+                to properties will be annotated with the session that is
+                doing the updating. This value is propagated through any
+                subsequent change notifications that the update triggers.
+                The session can compare the event setter to itself, and
+                suppress any updates that originate from itself.
+
+        Returns:
+            None
+
+        '''
+        if not hasattr(obj, '_property_values'):
+            # Initial values should be passed in to __init__, not set directly
+            raise RuntimeError("Cannot set a property value '%s' on a %s instance before HasProps.__init__" %
+                               (self.name, obj.__class__.__name__))
+
+        if self.property._readonly:
+            raise RuntimeError("%s.%s is a readonly property" % (obj.__class__.__name__, self.name))
+
+        self._internal_set(obj, value, setter)
+
+    def __delete__(self, obj):
+        ''' Implement the deleter for the Python `descriptor protocol`_.
+
+        Args:
+            obj (HasProps) : An instance to delete this property from
+
+        '''
+        if self.name in obj._property_values:
+            del obj._property_values[self.name]
+
+    def class_default(self, cls):
+        ''' Get the default value for a specific subtype of ``HasProps``,
+        which may not be used for an individual instance.
+
+        Args:
+            cls (class) : The class to get the default value for.
+
+        Returns:
+            object
+
+
+        '''
+        return self.property.themed_default(cls, self.name, None)
+
+    def instance_default(self, obj):
+        ''' Get the default value that will be used for a specific instance.
+
+        Args:
+            obj (HasProps) : The instance to get the default value for.
+
+        Returns:
+            object
+
+        '''
+        return self.property.themed_default(obj.__class__, self.name, obj.themed_values())
+
+    def set_from_json(self, obj, json, models=None, setter=None):
+        ''' Sets the value of this property from a JSON value.
+
+        This method first
+
+        Args:
+            obj (HasProps) :
+
+            json (JSON) :
+
+            models(seq[Model], optional) :
+
+            setter (ClientSession or ServerSession or None, optional) :
+                This is used to prevent "boomerang" updates to Bokeh apps.
+                (default: None)
+
+                In the context of a Bokeh server application, incoming updates
+                to properties will be annotated with the session that is
+                doing the updating. This value is propagated through any
+                subsequent change notifications that the update triggers.
+                The session can compare the event setter to itself, and
+                suppress any updates that originate from itself.
+
+        Returns:
+            None
+
+        '''
+        return super(BasicPropertyDescriptor, self).set_from_json(obj,
+                                                        self.property.from_json(json, models),
+                                                        models, setter)
+
+    def trigger_if_changed(self, obj, old):
+        ''' Send a change event notification if the property is set to a
+        value is not equal to ``old``.
+
+        Args:
+            obj (HasProps)
+                The object the property is being set on.
+
+            old (obj) :
+                The previous value of the property to compare
+
+        Returns:
+            None
+
+        '''
+        new_value = self.__get__(obj, obj.__class__)
+        if not self.property.matches(old, new_value):
+            self._trigger(obj, old, new_value)
+
+    @property
+    def has_ref(self):
+        ''' Whether the property can refer to another ``HasProps`` instance.
+
+        For basic properties, delegate to the ``has_ref`` attribute on the
+        |Property|.
+
+        '''
+        return self.property.has_ref
+
+    @property
+    def readonly(self):
+        ''' Whether this property is read-only.
+
+        Read-only properties may only be modified by the client (i.e., by BokehJS
+        in the browser).
+
+        '''
+        return self.property.readonly
+
+    @property
+    def serialized(self):
+        ''' Whether the property should be serialized when serializing an
+        object.
+
+        This would be False for a "virtual" or "convenience" property that
+        duplicates information already available in other properties, for
+        example.
+
+        '''
+        return self.property.serialized
+
+    def _get(self, obj):
+        ''' Internal implementation of instance attribute access for the
+        ``BasicPropertyDescriptor`` getter.
+
+        If the value has not been explicitly set by a user, return that
+        value. Otherwise, return the default.
+
+        Args:
+            obj (HasProps) : the instance to get a value of this property for
+
+        Returns:
+            object
+
+        Raises:
+            RuntimeError
+                If the |HasProps| instance has not yet been initialized, or if
+                this descriptor is on a class that is not a |HasProps|.
+
+        '''
+        if not hasattr(obj, '_property_values'):
+            raise RuntimeError("Cannot get a property value '%s' from a %s instance before HasProps.__init__" %
+                               (self.name, obj.__class__.__name__))
+
+        if self.name not in obj._property_values:
+            return self._get_default(obj)
+        else:
+            return obj._property_values[self.name]
+
+    def _get_default(self, obj):
+        ''' Internal implementation of instance attribute access for default
+        values.
+
+        Handles bookeeping around |PropertyContainer| value, etc.
+
+        '''
+        if self.name in obj._property_values:
+            # this shouldn't happen because we should have checked before _get_default()
+            raise RuntimeError("Bokeh internal error, does not handle the case of self.name already in _property_values")
+
+        # merely getting a default may force us to put it in
+        # _property_values if we need to wrap the container, if
+        # the default is a Model that may change out from
+        # underneath us, or if the default is generated anew each
+        # time by a function.
+        default = self.instance_default(obj)
+        if not self.property._has_stable_default():
+            if isinstance(default, PropertyValueContainer):
+                # this is a special-case so we can avoid returning the container
+                # as a non-default or application-overridden value, when
+                # it has not been modified.
+                default._unmodified_default_value = True
+                default._register_owner(obj, self)
+
+            obj._property_values[self.name] = default
+
+        return default
+
+    def _internal_set(self, obj, value, setter=None):
+        ''' Internal implementation to set property values, that is used
+        by __set__, set_from_json, etc.
+
+        Delegate to the |Property| instance to prepare the value appropriately,
+        then `set.
+
+        Args:
+            obj (HasProps)
+                The object the property is being set on.
+
+            old (obj) :
+                The previous value of the property to compare
+
+            setter (ClientSession or ServerSession or None, optional) :
+                This is used to prevent "boomerang" updates to Bokeh apps.
+                (default: None)
+
+                In the context of a Bokeh server application, incoming updates
+                to properties will be annotated with the session that is
+                doing the updating. This value is propagated through any
+                subsequent change notifications that the update triggers.
+                The session can compare the event setter to itself, and
+                suppress any updates that originate from itself.
+
+        Returns:
+            None
+
+        '''
+        value = self.property.prepare_value(obj, self.name, value)
+
+        old = self.__get__(obj, obj.__class__)
+        self._real_set(obj, old, value, setter=setter)
+
+    def _real_set(self, obj, old, value, hint=None, setter=None):
+        ''' Internal implementation helper to set property values.
+
+        This function handles bookkeeping around noting whether values have
+        been explicitly set, or setting up |PropertyContainer| wrappers when
+        values are containers, etc.
+
+        Args:
+            obj (HasProps)
+                The object the property is being set on.
+
+            old (obj) :
+                The previous value of the property to compare
+
+            setter (ClientSession or ServerSession or None, optional) :
+                This is used to prevent "boomerang" updates to Bokeh apps.
+                (default: None)
+
+                In the context of a Bokeh server application, incoming updates
+                to properties will be annotated with the session that is
+                doing the updating. This value is propagated through any
+                subsequent change notifications that the update triggers.
+                The session can compare the event setter to itself, and
+                suppress any updates that originate from itself.
+
+        Returns:
+            None
+
+        '''
+        # As of Bokeh 0.11.1, all hinted events modify in place. However this
+        # may need refining later if this assumption changes.
+        unchanged = self.property.matches(value, old) and (hint is None)
+        if unchanged:
+            return
+
+        was_set = self.name in obj._property_values
+
+        # "old" is the logical old value, but it may not be
+        # the actual current attribute value if our value
+        # was mutated behind our back and we got _notify_mutated.
+        if was_set:
+            old_attr_value = obj._property_values[self.name]
+        else:
+            old_attr_value = old
+
+        if old_attr_value is not value:
+            if isinstance(old_attr_value, PropertyValueContainer):
+                old_attr_value._unregister_owner(obj, self)
+            if isinstance(value, PropertyValueContainer):
+                value._register_owner(obj, self)
+
+            obj._property_values[self.name] = value
+
+        # for notification purposes, "old" should be the logical old
+        self._trigger(obj, old, value, hint, setter)
+
+    # called when a container is mutated "behind our back" and
+    # we detect it with our collection wrappers.
+    def _notify_mutated(self, obj, old, hint=None):
+        ''' A method to call when a container is mutated "behind our back"
+        and we detect it with our |PropertyContainer| wrappers.
+
+        Args:
+            obj (HasProps) :
+                The object who's container value was mutated
+
+            old (object) :
+                The "old" value of the container
+
+                In this case, somewhat weirdly, ``old`` is a copy and the
+                new value should already be set unless we change it due to
+                validation.
+
+            hint (event hint or None, optional)
+                An optional update event hint, e.g. ``ColumnStreamedEvent``
+                (default: None)
+
+                Update event hints are usually used at times when better
+                update performance can be obtained by special-casing in
+                some way (e.g. streaming or patching column data sources)
+
+        Returns:
+            None
+
+        '''
+        value = self.__get__(obj, obj.__class__)
+
+        # re-validate because the contents of 'old' have changed,
+        # in some cases this could give us a new object for the value
+        value = self.property.prepare_value(obj, self.name, value)
+
+        self._real_set(obj, old, value, hint)
+
+    def _trigger(self, obj, old, value, hint=None, setter=None):
+        ''' Unconditionally send a change event notification for the property.
+
+        Args:
+            obj (HasProps)
+                The object the property is being set on.
+
+            old (obj) :
+                The previous value of the property
+
+            new (obj) :
+                The new value of the property
+
+            hint (event hint or None, optional)
+                An optional update event hint, e.g. ``ColumnStreamedEvent``
+                (default: None)
+
+                Update event hints are usually used at times when better
+                update performance can be obtained by special-casing in
+                some way (e.g. streaming or patching column data sources)
+
+            setter (ClientSession or ServerSession or None, optional) :
+                This is used to prevent "boomerang" updates to Bokeh apps.
+                (default: None)
+
+                In the context of a Bokeh server application, incoming updates
+                to properties will be annotated with the session that is
+                doing the updating. This value is propagated through any
+                subsequent change notifications that the update triggers.
+                The session can compare the event setter to itself, and
+                suppress any updates that originate from itself.
+
+
+        Returns:
+            None
+
+        '''
+        if hasattr(obj, 'trigger'):
+            obj.trigger(self.name, old, value, hint, setter)
+
+
+class DataSpecPropertyDescriptor(BasicPropertyDescriptor):
+    ''' A PropertyDescriptor for Bokeh |DataSpec| properties that serialize to
+    field/value dictionaries.
+
+    '''
+
+    def serializable_value(self, obj):
+        '''
+
+        '''
+        return self.property.to_serializable(obj, self.name, getattr(obj, self.name))
+
+    def set_from_json(self, obj, json, models=None, setter=None):
+        ''' Sets the value of this property from a JSON value.
+
+        This method first
+
+        Args:
+            obj (HasProps) :
+
+            json (JSON) :
+
+            models(seq[Model], optional) :
+
+            setter (ClientSession or ServerSession or None, optional) :
+                This is used to prevent "boomerang" updates to Bokeh apps.
+                (default: None)
+
+                In the context of a Bokeh server application, incoming updates
+                to properties will be annotated with the session that is
+                doing the updating. This value is propagated through any
+                subsequent change notifications that the update triggers.
+                The session can compare the event setter to itself, and
+                suppress any updates that originate from itself.
+
+        Returns:
+            None
+
+        '''
+        if isinstance(json, dict):
+            # we want to try to keep the "format" of the data spec as string, dict, or number,
+            # assuming the serialized dict is compatible with that.
+            old = getattr(obj, self.name)
+            if old is not None:
+                try:
+                    self.property._type.validate(old)
+                    if 'value' in json:
+                        json = json['value']
+                except ValueError:
+                    if isinstance(old, string_types) and 'field' in json:
+                        json = json['field']
+                # leave it as a dict if 'old' was a dict
+
+        super(DataSpecPropertyDescriptor, self).set_from_json(obj, json, models, setter)
+
+class UnitsSpecPropertyDescriptor(DataSpecPropertyDescriptor):
+    ''' A PropertyDecscriptor for Bokeh |UnitsSpec| properties that contribute
+    associated ``_units`` properties automatically as a side effect.
+
+    '''
+
+    def __init__(self, name, property, units_property):
+        '''
+
+        Args:
+            name (str) :
+                The attribute name that this property is for
+
+            property (Property) :
+                A basic property to create a descriptor for
+
+            units_property (Property) :
+                An associated property to hold units information
+
+        '''
+        super(UnitsSpecPropertyDescriptor, self).__init__(name, property)
+        self.units_prop = units_property
+
+    def __set__(self, obj, value, setter=None):
+        ''' Implement the setter for the Python `descriptor protocol`_.
+
+        This method first separately extracts and removes any ``units`` field
+        in the JSON, and sets the associated units property directly. The
+        remaining value is then passed to the superclass ``__set__`` to
+        be handled.
+
+        .. note::
+            An optional argument ``setter`` has been added to the standard
+            setter arguments. When needed, this value should be provided by
+            explicitly invoking ``__set__``. See below for more information.
+
+        Args:
+            obj (HasProps) :
+                The instance to set a new property value on
+
+            value (obj) :
+                The new value to set the property to
+
+            setter (ClientSession or ServerSession or None, optional) :
+                This is used to prevent "boomerang" updates to Bokeh apps.
+                (default: None)
+
+                In the context of a Bokeh server application, incoming updates
+                to properties will be annotated with the session that is
+                doing the updating. This value is propagated through any
+                subsequent change notifications that the update triggers.
+                The session can compare the event setter to itself, and
+                suppress any updates that originate from itself.
+
+        Returns:
+            None
+
+        '''
+        value = self._extract_units(obj, value)
+        super(UnitsSpecPropertyDescriptor, self).__set__(obj, value, setter)
+
+    def set_from_json(self, obj, json, models=None, setter=None):
+        ''' Sets the value of this property from a JSON value.
+
+        This method first separately extracts and removes any ``units`` field
+        in the JSON, and sets the associated units property directly. The
+        remaining JSON is then passed to the superclass ``set_from_json`` to
+        be handled.
+
+        Args:
+            obj: (HasProps) : instance to set the property value on
+
+            json: (JSON-value) : value to set to the attribute to
+
+            models (dict or None, optional) :
+                Mapping of model ids to models (default: None)
+
+                This is needed in cases where the attributes to update also
+                have values that have references.
+
+            setter (ClientSession or ServerSession or None, optional) :
+                This is used to prevent "boomerang" updates to Bokeh apps.
+                (default: None)
+
+                In the context of a Bokeh server application, incoming updates
+                to properties will be annotated with the session that is
+                doing the updating. This value is propagated through any
+                subsequent change notifications that the update triggers.
+                The session can compare the event setter to itself, and
+                suppress any updates that originate from itself.
+
+        Returns:
+            None
+
+        '''
+        json = self._extract_units(obj, json)
+        super(UnitsSpecPropertyDescriptor, self).set_from_json(obj, json, models, setter)
+
+    def _extract_units(self, obj, value):
+        ''' Internal helper for dealing with units associated units properties
+        when setting values on |UnitsSpec| properties.
+
+        When ``value`` is a dict, this function may mutate the value of the
+        associated units property.
+
+        Args:
+            obj (HasProps) : instance to update units spec property value for
+            value (obj) : new value to set for the property
+
+        Returns:
+            copy of ``value``, with 'units' key and value removed when
+            applicable
+
+        '''
+        if isinstance(value, dict):
+            if 'units' in value:
+                value = copy(value) # so we can modify it
+            units = value.pop("units", None)
+            if units:
+                self.units_prop.__set__(obj, units)
+        return value

--- a/bokeh/core/property/factory.py
+++ b/bokeh/core/property/factory.py
@@ -1,0 +1,108 @@
+''' Provide a Base class for all Bokeh properties.
+
+Bokeh properties work by contributing Python descriptor objects to
+``HasProps`` classes. These descriptors then delegate attribute access back
+to the Bokeh property class, which handles validation, serialization, and
+documentation needs.
+
+The ``PropertyFactory`` class provides two methods ``autocreate`` and
+``make_descriptors`` that are used by the metaclass ``MetaHasProps`` during
+class creation. to install the necessary descriptors corresponding to the
+declared properties.
+
+This machinery helps to make Bokeh much more user friendly. For example,
+the DataSpec properties mediate between fixed values and references to column
+data source columns. A user can use a very simple syntax, and the property
+will correctly serialize and validate automatically:
+
+.. code-block:: python
+
+    from bokeh.models import Circle
+
+    c = Circle()
+
+    c.x = 10      # serializes to {'value': 10}
+
+    c.x = 'foo'   # serializes to {'field': 'foo'}
+
+    c.x = [1,2,3] # raises a ValueError validation exception
+
+There are many other examples like this throughout Bokeh. In this way users
+may operate simply and naturally, and not be concerned with the low-level
+details around validation, serialization, and documentation.
+
+.. note::
+    These classes form part of the very low-level machinery that implements
+    the Bokeh model and property system. It is unlikely that any of these
+    classes or their methods will be applicable to any standard usage or to
+    anyone who is not directly developing on Bokeh's own infrastructure.
+
+'''
+
+class PropertyFactory(object):
+    ''' Base class for all Bokeh properties.
+
+    A Bokeh property really consist of two parts: the familar "property"
+    portion, such as ``Int``, ``String``, etc., as well as an associated
+    Python descriptor that delegates attribute access (e.g. ``range.start``)
+    to the property instance.
+
+    Consider the following class definition:
+
+    .. code-block:: python
+
+        from bokeh.model import Model
+        from bokeh.core.properties import Int
+
+        class SomeModel(Model):
+            foo = Int(default=10)
+
+    Then we can observe the following:
+
+    .. code-block:: python
+
+        >>> m = SomeModel()
+
+        # The class itself has had a descriptor for 'foo' installed
+        >>> getattr(SomeModel, 'foo')
+        <bokeh.core.property.descriptors.BasicPropertyDescriptor at 0x1065ffb38>
+
+        # which is used when 'foo' is accessed on instances
+        >>> m.foo
+        10
+
+    '''
+
+    @classmethod
+    def autocreate(cls):
+        ''' Called by the ``MetaHasProps`` metaclass to create a new instance
+        of this descriptor when the property is assigned using only the
+        property type. For example:
+
+        .. code-block:: python
+
+            class Foo(Model):
+
+                bar = String   # no parens used here
+
+        '''
+        return cls()
+
+    def make_descriptors(self, name):
+        ''' Return a list of ``PropertyDescriptor`` instances to install on a
+        class, in order to delegate attribute access to this property.
+
+        Args:
+            name (str) : the name of the property these descriptors are for
+
+        Returns:
+            list[PropertyDescriptor]
+
+        The descriptors returned are collected by the ``MetaHasProps``
+        metaclass and added to ``HasProps`` subclasses during class creation.
+
+        Subclasses of ``PropertyFactory`` are responsible for implementing
+        this function to return descriptors specific to their needs.
+
+        '''
+        raise NotImplementedError("make_descriptors not implemented")

--- a/bokeh/core/property/override.py
+++ b/bokeh/core/property/override.py
@@ -1,0 +1,67 @@
+''' Provide the ``Override`` class, for overriding base class property
+attributes.
+
+.. note::
+    This class should normally be imported from ``bokeh.core.properties``
+    instead of directly from this module.
+
+'''
+
+class Override(object):
+    ''' Override attributes of Bokeh property in derived Models.
+
+    When subclassing a Bokeh Model, it may be desirable to change some of the
+    attributes of the property itself, from those on the base class. This is
+    accomplished using the ``Override`` class.
+
+    Currently, ``Override`` can only be use to override the ``default`` value
+    for the property.
+
+    Keyword Args:
+        default (obj) : a default value for this property on a subclass
+
+    Example:
+
+        Consider the following class definitions:
+
+        .. code-block:: python
+
+            from bokeh.model import Model
+            from bokeh.properties import Int, Override
+
+            class Parent(Model):
+                foo = Int(default=10)
+
+            class Child(Parent):
+                foo = Override(default=20)
+
+        The parent class has an integer property ``foo`` with default value
+        10.  The child class uses the following code:
+
+        .. code-block:: python
+
+            foo = Override(default=20)
+
+        to specify that the default value for the ``foo`` property should be
+        20 on instances of the child class:
+
+        .. code-block:: python
+
+            >>> p = Parent()
+            >>> p.foo
+            10
+
+            >>> c = Child()
+            >>> c.foo
+            20
+
+    '''
+
+    def __init__(self, **kwargs):
+        if len(kwargs) == 0:
+            raise ValueError("Override() doesn't override anything, needs keyword args")
+        self.default_overridden = 'default' in kwargs
+        if self.default_overridden:
+            self.default = kwargs.pop('default')
+        if len(kwargs) > 0:
+            raise ValueError("Unknown keyword args to Override: %r" % (kwargs))

--- a/bokeh/core/property/tests/test_containers.py
+++ b/bokeh/core/property/tests/test_containers.py
@@ -1,0 +1,226 @@
+from mock import patch
+import pytest
+
+from bokeh.models import ColumnDataSource
+
+import bokeh.core.property.containers as pc
+
+def test_notify_owner():
+    result = {}
+    class Foo(object):
+        @pc.notify_owner
+        def test(self): pass
+
+        def _notify_owners(self, old):
+            result['old'] = old
+
+        def _saved_copy(self): return "foo"
+
+    f = Foo()
+    f.test()
+    assert result['old'] == 'foo'
+    assert f.test.__doc__ == "Container method ``test`` instrumented to notify property owners"
+
+def test_PropertyValueContainer():
+    pvc = pc.PropertyValueContainer()
+    assert pvc._owners == set()
+    assert pvc._unmodified_default_value == False
+
+    pvc._register_owner("owner", "prop")
+    assert pvc._owners == set((("owner", "prop"), ))
+
+    pvc._unregister_owner("owner", "prop")
+    assert pvc._owners == set()
+
+    with pytest.raises(RuntimeError):
+        pvc._saved_copy()
+
+@patch('bokeh.core.property.containers.PropertyValueContainer._notify_owners')
+def test_PropertyValueDict_mutators(mock_notify):
+    pvd = pc.PropertyValueDict(dict(foo=10, bar=20, baz=30))
+
+    mock_notify.reset()
+    del pvd['foo']
+    assert mock_notify.called
+
+    mock_notify.reset()
+    pvd['foo'] = 11
+    assert mock_notify.called
+
+    mock_notify.reset()
+    pvd.pop('foo')
+    assert mock_notify.called
+
+    mock_notify.reset()
+    pvd.popitem()
+    assert mock_notify.called
+
+    mock_notify.reset()
+    pvd.setdefault('baz')
+    assert mock_notify.called
+
+    mock_notify.reset()
+    pvd.clear()
+    assert mock_notify.called
+
+    mock_notify.reset()
+    pvd.update(bar=1)
+    assert mock_notify.called
+
+@patch('bokeh.core.property.containers.PropertyValueContainer._notify_owners')
+def test_PropertyValueDict__stream_list(mock_notify):
+    from bokeh.document import ColumnsStreamedEvent
+
+    source = ColumnDataSource(data=dict(foo=[10]))
+    pvd = pc.PropertyValueDict(source.data)
+
+    mock_notify.reset()
+    pvd._stream("doc", source, dict(foo=[20]), setter="setter")
+    assert mock_notify.called_once
+    assert mock_notify.call_args[0] == ({'foo': [10, 20]},)
+    assert 'hint' in mock_notify.call_args[1]
+    assert isinstance(mock_notify.call_args[1]['hint'], ColumnsStreamedEvent)
+    assert mock_notify.call_args[1]['hint'].setter == 'setter'
+    assert mock_notify.call_args[1]['hint'].rollover == None
+
+@patch('bokeh.core.property.containers.PropertyValueContainer._notify_owners')
+def test_PropertyValueDict__stream_list_with_rollover(mock_notify):
+    from bokeh.document import ColumnsStreamedEvent
+
+    source = ColumnDataSource(data=dict(foo=[10, 20, 30]))
+    pvd = pc.PropertyValueDict(source.data)
+
+    mock_notify.reset()
+    pvd._stream("doc", source, dict(foo=[40]), rollover=3, setter="setter")
+    assert mock_notify.called_once
+    assert mock_notify.call_args[0] == ({'foo': [20, 30, 40]},)
+    assert 'hint' in mock_notify.call_args[1]
+    assert isinstance(mock_notify.call_args[1]['hint'], ColumnsStreamedEvent)
+    assert mock_notify.call_args[1]['hint'].setter == 'setter'
+    assert mock_notify.call_args[1]['hint'].rollover == 3
+
+@patch('bokeh.core.property.containers.PropertyValueContainer._notify_owners')
+def test_PropertyValueDict__stream_array(mock_notify):
+    from bokeh.document import ColumnsStreamedEvent
+    import numpy as np
+
+    source = ColumnDataSource(data=dict(foo=np.array([10])))
+    pvd = pc.PropertyValueDict(source.data)
+
+    mock_notify.reset()
+    pvd._stream("doc", source, dict(foo=[20]), setter="setter")
+    assert mock_notify.called_once
+    assert len(mock_notify.call_args[0]) == 1
+    assert 'foo' in mock_notify.call_args[0][0]
+    assert (mock_notify.call_args[0][0]['foo'] == np.array([10])).all()
+    assert 'hint' in mock_notify.call_args[1]
+    assert isinstance(mock_notify.call_args[1]['hint'], ColumnsStreamedEvent)
+    assert mock_notify.call_args[1]['hint'].setter == 'setter'
+    assert mock_notify.call_args[1]['hint'].rollover == None
+
+@patch('bokeh.core.property.containers.PropertyValueContainer._notify_owners')
+def test_PropertyValueDict__stream_array_with_rollover(mock_notify):
+    from bokeh.document import ColumnsStreamedEvent
+    import numpy as np
+
+    source = ColumnDataSource(data=dict(foo=np.array([10, 20, 30])))
+    pvd = pc.PropertyValueDict(source.data)
+
+    mock_notify.reset()
+    pvd._stream("doc", source, dict(foo=[40]), rollover=3, setter="setter")
+    assert mock_notify.called_once
+    assert len(mock_notify.call_args[0]) == 1
+    assert 'foo' in mock_notify.call_args[0][0]
+    assert (mock_notify.call_args[0][0]['foo'] == np.array([10, 20, 30])).all()
+    assert 'hint' in mock_notify.call_args[1]
+    assert isinstance(mock_notify.call_args[1]['hint'], ColumnsStreamedEvent)
+    assert mock_notify.call_args[1]['hint'].setter == 'setter'
+    assert mock_notify.call_args[1]['hint'].rollover == 3
+
+@patch('bokeh.core.property.containers.PropertyValueContainer._notify_owners')
+def test_PropertyValueDict__patch(mock_notify):
+    from bokeh.document import ColumnsPatchedEvent
+    source = ColumnDataSource(data=dict(foo=[10, 20]))
+    pvd = pc.PropertyValueDict(source.data)
+
+    mock_notify.reset()
+    pvd._patch("doc", source, dict(foo=[(1, 40)]), setter='setter')
+    assert mock_notify.called_once
+    assert mock_notify.call_args[0] == ({'foo': [10, 40]},)
+    assert 'hint' in mock_notify.call_args[1]
+    assert isinstance(mock_notify.call_args[1]['hint'], ColumnsPatchedEvent)
+    assert mock_notify.call_args[1]['hint'].setter == 'setter'
+
+@patch('bokeh.core.property.containers.PropertyValueContainer._notify_owners')
+def test_PropertyValueList_mutators(mock_notify):
+    pvl = pc.PropertyValueList([10, 20, 30, 40, 50])
+
+    mock_notify.reset()
+    del pvl[2]
+    assert mock_notify.called
+
+    # this exercises __delslice__ on Py2 but not Py3 which just
+    # uses __delitem__ and a slice index
+    mock_notify.reset()
+    del pvl[1:2]
+    assert mock_notify.called
+
+    mock_notify.reset()
+    pvl += [888]
+    assert mock_notify.called
+
+    mock_notify.reset()
+    pvl *= 2
+    assert mock_notify.called
+
+    mock_notify.reset()
+    pvl[0] = 2
+    assert mock_notify.called
+
+    # this exercises __setslice__ on Py2 but not Py3 which just
+    # uses __setitem__ and a slice index
+    mock_notify.reset()
+    pvl[3:1:-1] = [21, 31]
+    assert mock_notify.called
+
+    mock_notify.reset()
+    pvl.append(999)
+    assert mock_notify.called
+
+    mock_notify.reset()
+    pvl.extend([1000])
+    assert mock_notify.called
+
+    mock_notify.reset()
+    pvl.insert(0, 100)
+    assert mock_notify.called
+
+    mock_notify.reset()
+    pvl.pop()
+    assert mock_notify.called
+
+    mock_notify.reset()
+    pvl.remove(100)
+    assert mock_notify.called
+
+    mock_notify.reset()
+    pvl.reverse()
+    assert mock_notify.called
+
+    mock_notify.reset()
+    pvl.sort()
+    assert mock_notify.called
+
+    # OK, this is just to get a 100% test coverage inpy3 due to differences in
+    # py2 vs py2. The slice methods are only exist in py2. The tests above
+    # exercise all the  cases, this just makes py3 report the non-py3 relevan
+    # code as covered.
+    try:
+        pvl.__setslice__(1,2,3)
+    except:
+        pass
+
+    try:
+        pvl.__delslice__(1,2)
+    except:
+        pass

--- a/bokeh/core/property/tests/test_descriptor_factory.py
+++ b/bokeh/core/property/tests/test_descriptor_factory.py
@@ -1,8 +1,8 @@
 import pytest
 
-import bokeh.core.property.factory as pf
+import bokeh.core.property.descriptor_factory as pf
 
-class Child(pf.PropertyFactory):
+class Child(pf.PropertyDescriptorFactory):
     pass
 
 def test_autocreate():
@@ -11,6 +11,6 @@ def test_autocreate():
     assert isinstance(value, Child)
 
 def test_make_descriptors_not_implemented():
-    obj = pf.PropertyFactory()
+    obj = pf.PropertyDescriptorFactory()
     with pytest.raises(NotImplementedError):
         obj.make_descriptors("foo")

--- a/bokeh/core/property/tests/test_descriptors.py
+++ b/bokeh/core/property/tests/test_descriptors.py
@@ -1,0 +1,181 @@
+from mock import patch
+import pytest
+
+import bokeh.core.property.descriptors as pd
+
+def test_PropertyDescriptor__init__():
+    d = pd.PropertyDescriptor("foo")
+    assert d.name == "foo"
+
+def test_PropertyDescriptor__str__():
+    d = pd.PropertyDescriptor("foo")
+    assert str(d) == "PropertyDescriptor(foo)"
+
+def test_PropertyDescriptor_abstract():
+    d = pd.PropertyDescriptor("foo")
+    class Foo(object): pass
+    f = Foo()
+    with pytest.raises(NotImplementedError):
+        d.__get__(f, f.__class__)
+
+    with pytest.raises(NotImplementedError):
+        d.__set__(f, 11)
+
+    with pytest.raises(NotImplementedError):
+        d.__delete__(f)
+
+    with pytest.raises(NotImplementedError):
+        d.class_default(f)
+
+    with pytest.raises(NotImplementedError):
+        d.serialized
+
+    with pytest.raises(NotImplementedError):
+        d.readonly
+
+    with pytest.raises(NotImplementedError):
+        d.has_ref
+
+    with pytest.raises(NotImplementedError):
+        d.trigger_if_changed(f, 11)
+
+    with pytest.raises(NotImplementedError):
+        d._internal_set(f, 11)
+
+@patch('bokeh.core.property.descriptors.PropertyDescriptor._internal_set')
+def test_PropertyDescriptor_set_from_json(mock_iset):
+    class Foo(object): pass
+    f = Foo()
+    d = pd.PropertyDescriptor("foo")
+    d.set_from_json(f, "bar", 10)
+    assert mock_iset.called_once_with((f, "bar", 10), {})
+
+def test_PropertyDescriptor_serializable_value():
+    result = {}
+    class Foo(object):
+        def serialize_value(self, val):
+            result['foo'] = val
+    f = Foo()
+    f.foo = 10
+
+    d = pd.PropertyDescriptor("foo")
+    d.property = Foo()
+
+    # simulate the __get__ a subclass would have
+    d.__get__ = lambda obj, owner: f.foo
+
+    d.serializable_value(f)
+    assert result['foo'] == 10
+
+def test_add_prop_descriptor_to_class_dupe_name():
+    d = pd.PropertyDescriptor("foo")
+    new_class_attrs = {'foo': 10}
+    with pytest.raises(RuntimeError) as e:
+        d.add_prop_descriptor_to_class("bar", new_class_attrs, [], [], {})
+    assert str(e).endswith("Two property generators both created bar.foo")
+
+def test_BasicPropertyDescriptor__init__():
+    class Foo(object):
+        '''doc'''
+        pass
+    f = Foo()
+    d = pd.BasicPropertyDescriptor("foo", f)
+    assert d.name == "foo"
+    assert d.property == f
+    assert d.__doc__ == f.__doc__
+
+def test_BasicPropertyDescriptor__str__():
+    class Foo(object): pass
+    f = Foo()
+    d = pd.BasicPropertyDescriptor("foo", f)
+    assert str(d) == str(f)
+
+def test_BasicPropertyDescriptor__get__improper():
+    class Foo(object): pass
+    f = Foo()
+    d = pd.BasicPropertyDescriptor("foo", f)
+    with pytest.raises(ValueError) as e:
+        d.__get__(None, None)
+    assert str(e).endswith("both 'obj' and 'owner' are None, don't know what to do")
+
+def test_BasicPropertyDescriptor__set__improper():
+    class Foo(object): pass
+    f = Foo()
+    d = pd.BasicPropertyDescriptor("foo", f)
+    with pytest.raises(RuntimeError) as e:
+        d.__set__("junk", None)
+    assert str(e).endswith("Cannot set a property value 'foo' on a str instance before HasProps.__init__")
+
+def test_BasicPropertyDescriptor__delete__():
+    class Foo(object):
+        _property_values = dict(foo=0)
+    f = Foo()
+    d1 = pd.BasicPropertyDescriptor("foo", f)
+    d2 = pd.BasicPropertyDescriptor("bar", f)
+    d1.__delete__(f)
+    assert f._property_values == {}
+    d2.__delete__(f)
+    assert f._property_values == {}
+
+def test_BasicPropertyDescriptor_class_default():
+    result = {}
+    class Foo(object):
+        def themed_default(*args, **kw):
+            result['called'] = True
+    f = Foo()
+    f.readonly = "stuff"
+    d = pd.BasicPropertyDescriptor("foo", f)
+    d.class_default(d)
+    assert result['called']
+
+def test_BasicPropertyDescriptor_serialized():
+    class Foo(object): pass
+    f = Foo()
+    f.serialized = "stuff"
+    d = pd.BasicPropertyDescriptor("foo", f)
+    assert d.serialized == "stuff"
+
+def test_BasicPropertyDescriptor_readonly():
+    class Foo(object): pass
+    f = Foo()
+    f.readonly = "stuff"
+    d = pd.BasicPropertyDescriptor("foo", f)
+    assert d.readonly == "stuff"
+
+def test_BasicPropertyDescriptor_has_ref():
+    class Foo(object): pass
+    f = Foo()
+    f.has_ref = "stuff"
+    d = pd.BasicPropertyDescriptor("foo", f)
+    assert d.has_ref == "stuff"
+
+@patch('bokeh.core.property.descriptors.BasicPropertyDescriptor._trigger')
+def test_BasicPropertyDescriptor__trigger(mock_trigger):
+    class Foo(object):
+        _property_values = dict(foo=10, bar=20)
+    class Match(object):
+        def matches(*args, **kw): return True
+    class NoMatch(object):
+        def matches(*args, **kw): return False
+    m = Match()
+    nm = NoMatch()
+    d1 = pd.BasicPropertyDescriptor("foo", m)
+    d2 = pd.BasicPropertyDescriptor("bar", nm)
+
+    d1.trigger_if_changed(Foo, "junk")
+    assert not mock_trigger.called
+
+    d2.trigger_if_changed(Foo, "junk")
+    assert mock_trigger.called
+
+def test_UnitsSpecPropertyDescriptor__init__():
+    class Foo(object):
+        '''doc'''
+        pass
+    f = Foo()
+    g = Foo()
+    d = pd.UnitsSpecPropertyDescriptor("foo", f, g)
+    assert d.name == "foo"
+    assert d.property == f
+    assert d.__doc__ == f.__doc__
+    assert d.units_prop == g

--- a/bokeh/core/property/tests/test_factory.py
+++ b/bokeh/core/property/tests/test_factory.py
@@ -1,0 +1,16 @@
+import pytest
+
+import bokeh.core.property.factory as pf
+
+class Child(pf.PropertyFactory):
+    pass
+
+def test_autocreate():
+    obj = Child()
+    value = obj.autocreate()
+    assert isinstance(value, Child)
+
+def test_make_descriptors_not_implemented():
+    obj = pf.PropertyFactory()
+    with pytest.raises(NotImplementedError):
+        obj.make_descriptors("foo")

--- a/bokeh/core/property/tests/test_override.py
+++ b/bokeh/core/property/tests/test_override.py
@@ -1,0 +1,19 @@
+import pytest
+
+import bokeh.core.property.override as po
+
+def test_create_default():
+    o = po.Override(default=10)
+    assert o.default_overridden
+    assert o.default == 10
+
+def test_create_no_args():
+    with pytest.raises(ValueError):
+        po.Override()
+
+def test_create_unkown_args():
+    with pytest.raises(ValueError):
+        po.Override(default=10, junk=20)
+
+    with pytest.raises(ValueError):
+        po.Override(junk=20)

--- a/bokeh/core/property_mixins.py
+++ b/bokeh/core/property_mixins.py
@@ -42,7 +42,8 @@ different usage, for more information see the docs for |Include|.
 from __future__ import absolute_import
 
 from .enums import LineJoin, LineCap, FontStyle, TextAlign, TextBaseline
-from .properties import ColorSpec, DashPattern, Enum, FontSizeSpec, HasProps, Int, NumberSpec, String, value
+from .has_props import HasProps
+from .properties import ColorSpec, DashPattern, Enum, FontSizeSpec, Int, NumberSpec, String, value
 
 class FillProps(HasProps):
     ''' Properties relevant to rendering fill regions.

--- a/bokeh/core/tests/test_enums.py
+++ b/bokeh/core/tests/test_enums.py
@@ -1,0 +1,76 @@
+import bokeh.core.enums as enums
+
+def test_Enumeration_default():
+    e = enums.Enumeration()
+    assert e.__slots__ == ()
+
+def test_enumeration_basic():
+    e = enums.enumeration("foo", "bar", "baz")
+    assert isinstance(e, enums.Enumeration)
+    assert str(e) == "Enumeration(foo, bar, baz)"
+    assert [x for x in e] == ["foo", "bar", "baz"]
+    for x in ["foo", "bar", "baz"]:
+        assert x in e
+    assert "junk" not in e
+
+def test_enumeration_case():
+    e = enums.enumeration("foo", "bar", "baz", case_sensitive=False)
+    assert isinstance(e, enums.Enumeration)
+    assert str(e) == "Enumeration(foo, bar, baz)"
+    assert [x for x in e] == ["foo", "bar", "baz"]
+    for x in ["foo", "FOO", "bar", "bAr", "baz", "BAZ"]:
+        assert x in e
+    assert "junk" not in e
+
+def test_enumeration_default():
+    # this is private but used by properties
+    e = enums.enumeration("foo", "bar", "baz")
+    assert e._default == "foo"
+
+# This can be removed when deprecation is complete
+def test_accept_left_right_center():
+    assert enums.accept_left_right_center("left_center") == "center_left"
+    assert enums.accept_left_right_center("right_center") == "center_right"
+
+# any changes to contents of enums.py easily trackable here
+def test_enums_contents():
+    assert [x for x in dir(enums) if x[0].isupper()] == [
+        'Aggregation',
+        'Anchor',
+        'AngleUnits',
+        'ButtonType',
+        'DashPattern',
+        'DateFormat',
+        'DatetimeUnits',
+        'DeprecatedAnchor',
+        'DeprecatedLegendLocation',
+        'Dimension',
+        'Dimensions',
+        'Direction',
+        'Enumeration',
+        'FontStyle',
+        'HorizontalLocation',
+        'JitterRandomDistribution',
+        'LegendLocation',
+        'LineCap',
+        'LineDash',
+        'LineJoin',
+        'Location',
+        'MapType',
+        'NamedColor',
+        'NumeralLanguage',
+        'Orientation',
+        'Palette',
+        'RenderLevel',
+        'RenderMode',
+        'RoundingFunction',
+        'SizingMode',
+        'SliderCallbackPolicy',
+        'SortDirection',
+        'SpatialUnits',
+        'StartEnd',
+        'StepMode',
+        'TextAlign',
+        'TextBaseline',
+        'VerticalLocation',
+    ]

--- a/bokeh/core/tests/test_has_props.py
+++ b/bokeh/core/tests/test_has_props.py
@@ -1,0 +1,237 @@
+from mock import patch
+import pytest
+
+import bokeh.core.has_props as hp
+
+from bokeh.core.properties import Int, String, NumberSpec, List, Override
+from bokeh.core.property.descriptors import BasicPropertyDescriptor, DataSpecPropertyDescriptor
+
+class Parent(hp.HasProps):
+    int1 = Int(default=10)
+    ds1 = NumberSpec()
+    lst1 = List(String)
+
+class Child(Parent):
+    int2 = Int()
+    str2 = String(default="foo")
+    ds2 = NumberSpec()
+    lst2 = List(Int, default=[1,2,3])
+
+class OverrideChild(Parent):
+    int1 = Override(default=20)
+
+def test_HasProps_default_init():
+    p = Parent()
+    assert p.int1 == 10
+    assert p.ds1 == None
+    assert p.lst1 == []
+
+    c = Child()
+    assert c.int1 == 10
+    assert c.ds1 == None
+    assert c.lst1 == []
+    assert c.int2 == None
+    assert c.str2 == "foo"
+    assert c.ds2 == None
+    assert c.lst2 == [1,2,3]
+
+def test_HasProps_kw_init():
+    p = Parent(int1=30, ds1="foo")
+    assert p.int1 == 30
+    assert p.ds1 == "foo"
+    assert p.lst1 == []
+
+    c = Child(str2="bar", lst2=[2,3,4], ds2=10)
+    assert c.int1 == 10
+    assert c.ds1 == None
+    assert c.lst1 == []
+    assert c.int2 == None
+    assert c.str2 == "bar"
+    assert c.ds2 == 10
+    assert c.lst2 == [2,3,4]
+
+def test_HasProps_override():
+    ov = OverrideChild()
+    assert ov.int1 == 20
+    assert ov.ds1 == None
+    assert ov.lst1 == []
+
+def test_HasProps_equals():
+    p1 = Parent()
+    p2 = Parent()
+    assert p1.equals(p2)
+    p1.int1 = 25
+    assert not p1.equals(p2)
+    p2.int1 = 25
+    assert p1.equals(p2)
+
+def test_HasProps_update():
+    c = Child()
+    c.update(**dict(lst2=[1,2], str2="baz", int1=25, ds1=dict(field="foo")))
+    assert c.int1 == 25
+    assert c.ds1 == dict(field="foo")
+    assert c.lst1 == []
+    assert c.int2 == None
+    assert c.str2 == "baz"
+    assert c.ds2 ==  None
+    assert c.lst2 == [1,2]
+
+def test_HasProps_set_from_json():
+    c = Child()
+    c.set_from_json('lst2', [1,2])
+    assert c.int1 == 10
+    assert c.ds1 == None
+    assert c.lst1 == []
+    assert c.int2 == None
+    assert c.str2 == "foo"
+    assert c.ds2 ==  None
+    assert c.lst2 == [1,2]
+
+    c.set_from_json('ds1', "foo")
+    assert c.int1 == 10
+    assert c.ds1 == "foo"
+    assert c.lst1 == []
+    assert c.int2 == None
+    assert c.str2 == "foo"
+    assert c.ds2 ==  None
+    assert c.lst2 == [1,2]
+
+    c.set_from_json('int2', 100)
+    assert c.int1 == 10
+    assert c.ds1 == "foo"
+    assert c.lst1 == []
+    assert c.int2 == 100
+    assert c.str2 == "foo"
+    assert c.ds2 ==  None
+    assert c.lst2 == [1,2]
+
+
+def test_HasProps_update_from_json():
+    c = Child()
+    c.update_from_json(dict(lst2=[1,2], str2="baz", int1=25, ds1=dict(field="foo")))
+    assert c.int1 == 25
+    assert c.ds1 == dict(field="foo")
+    assert c.lst1 == []
+    assert c.int2 == None
+    assert c.str2 == "baz"
+    assert c.ds2 ==  None
+    assert c.lst2 == [1,2]
+
+@patch('bokeh.core.has_props.HasProps.set_from_json')
+def test_HasProps_update_from_json_passes_models_and_setter(mock_set):
+    c = Child()
+    c.update_from_json(dict(lst1=[1,2]), models="foo", setter="bar")
+    assert mock_set.called
+    assert mock_set.call_args[0] == ('lst1', [1, 2], 'foo', 'bar')
+    assert mock_set.call_args[1] == {}
+
+def test_HasProps_set():
+    c = Child()
+    c.set(**dict(lst2=[1,2], str2="baz", int1=25, ds1=dict(field="foo")))
+    assert c.int1 == 25
+    assert c.ds1 == dict(field="foo")
+    assert c.lst1 == []
+    assert c.int2 == None
+    assert c.str2 == "baz"
+    assert c.ds2 ==  None
+    assert c.lst2 == [1,2]
+
+def test_HasProps_set_error():
+    c = Child()
+    with pytest.raises(AttributeError) as e:
+        c.int3 = 10
+    assert str(e).endswith("unexpected attribute 'int3' to Child, similar attributes are int2 or int1")
+    with pytest.raises(AttributeError) as e:
+        c.junkjunk = 10
+    assert str(e).endswith("unexpected attribute 'junkjunk' to Child, possible attributes are ds1, ds2, int1, int2, lst1, lst2 or str2")
+
+
+def test_HasProps_lookup():
+    p = Parent()
+    d = p.lookup('int1')
+    assert isinstance(d, BasicPropertyDescriptor)
+    assert d.name == 'int1'
+    d = p.lookup('ds1')
+    assert isinstance(d, DataSpecPropertyDescriptor)
+    assert d.name == 'ds1'
+    d = p.lookup('lst1')
+    assert isinstance(d, BasicPropertyDescriptor)
+    assert d.name == 'lst1'
+
+def test_HasProps_apply_theme():
+    c = Child()
+    theme = dict(int2=10, lst1=["foo", "bar"])
+    c.apply_theme(theme)
+    assert c.themed_values() is theme
+    c.apply_theme(theme)
+    assert c.themed_values() is theme
+
+    assert c.int2 == 10
+    #assert c.lst1 == ["foo", "bar"] # https://github.com/bokeh/bokeh/issues/5644
+
+    assert c.int1 == 10
+    assert c.ds1 == None
+    assert c.str2 == "foo"
+    assert c.ds2 == None
+    assert c.lst2 == [1,2,3]
+
+    c.int2 = 25
+    assert c.int2 == 25
+    #assert c.lst1 == ["foo", "bar"] # https://github.com/bokeh/bokeh/issues/5644
+
+    assert c.int1 == 10
+    assert c.ds1 == None
+    assert c.str2 == "foo"
+    assert c.ds2 == None
+    assert c.lst2 == [1,2,3]
+
+    c.ds2 = "foo"
+    assert c.int2 == 25
+    #assert c.lst1 == ["foo", "bar"] # https://github.com/bokeh/bokeh/issues/5644
+
+    assert c.int1 == 10
+    assert c.ds1 == None
+    assert c.str2 == "foo"
+    assert c.ds2 == "foo"
+    assert c.lst2 == [1,2,3]
+
+def test_HasProps_unapply_theme():
+    c = Child()
+    theme = dict(int2=10, lst1=["foo", "bar"])
+    c.apply_theme(theme)
+    assert c.int2 == 10
+    #assert c.lst1 == ["foo", "bar"] # https://github.com/bokeh/bokeh/issues/5644
+
+    assert c.int1 == 10
+    assert c.ds1 == None
+    assert c.str2 == "foo"
+    assert c.ds2 == None
+    assert c.lst2 == [1,2,3]
+
+    c.unapply_theme()
+    assert c.int2 == None
+    assert c.lst1 == []
+
+    assert c.int1 == 10
+    assert c.ds1 == None
+    assert c.str2 == "foo"
+    assert c.ds2 == None
+    assert c.lst2 == [1,2,3]
+
+    assert c.themed_values() == None
+
+def test_HasProps_pretty():
+    p = Parent()
+    assert p.pretty() == "bokeh.core.tests.test_has_props.Parent(ds1=None, int1=10, lst1=[])"
+    old = hp.IPython
+    hp.IPython = False
+    with pytest.raises(RuntimeError):
+        p.pretty()
+    hp.IPython = old
+
+def test_HasProps_pprint(capsys):
+    p = Parent()
+    p.pprint()
+    out, err = capsys.readouterr()
+    assert out == "bokeh.core.tests.test_has_props.Parent(ds1=None, int1=10, lst1=[])\n"
+    assert err == ""

--- a/bokeh/core/tests/test_json_encoder.py
+++ b/bokeh/core/tests/test_json_encoder.py
@@ -5,9 +5,11 @@ from unittest import skipIf
 
 from collections import deque
 import datetime as dt
+import decimal
 import time
 
 import numpy as np
+from six import string_types
 
 try:
     import pandas as pd
@@ -15,6 +17,16 @@ try:
 except ImportError as e:
     is_pandas = False
 
+import dateutil.relativedelta as rd
+
+from bokeh.colors import RGB
+from bokeh.core.has_props import HasProps
+from bokeh.core.properties import Int, String
+from bokeh.models import Range1d
+
+class HP(HasProps):
+    foo = Int(default=10)
+    bar = String()
 
 class TestBokehJSONEncoder(unittest.TestCase):
 
@@ -49,6 +61,52 @@ class TestBokehJSONEncoder(unittest.TestCase):
         self.assertEqual(self.encoder.default(nptrue), True)
         self.assertIsInstance(self.encoder.default(nptrue), bool)
 
+    def test_numpydatetime64(self):
+        npdt64 = np.datetime64('2017-01-01')
+        self.assertEqual(self.encoder.default(npdt64), 1483228800000.0)
+        self.assertIsInstance(self.encoder.default(npdt64), float)
+
+    def test_time(self):
+        dttime = dt.time(12, 32, 15)
+        self.assertEqual(self.encoder.default(dttime), 45135000.0)
+        self.assertIsInstance(self.encoder.default(dttime), float)
+
+    def test_relativedelta(self):
+        rdelt = rd.relativedelta()
+        self.assertIsInstance(self.encoder.default(rdelt), dict)
+
+    def test_decimal(self):
+        dec = decimal.Decimal(20.3)
+        self.assertEqual(self.encoder.default(dec), 20.3)
+        self.assertIsInstance(self.encoder.default(dec), float)
+
+    def test_model(self):
+        m = Range1d(start=10, end=20)
+        self.assertEqual(self.encoder.default(m), m.ref)
+        self.assertIsInstance(self.encoder.default(m), dict)
+
+    def test_hasprops(self):
+        hp = HP()
+        self.assertEqual(self.encoder.default(hp), {})
+        self.assertIsInstance(self.encoder.default(hp), dict)
+
+        hp.foo = 15
+        self.assertEqual(self.encoder.default(hp), {'foo': 15})
+        self.assertIsInstance(self.encoder.default(hp), dict)
+
+        hp.bar = "test"
+        self.assertEqual(self.encoder.default(hp), {'foo': 15, 'bar': 'test'})
+        self.assertIsInstance(self.encoder.default(hp), dict)
+
+    def test_color(self):
+        c = RGB(16, 32, 64)
+        self.assertEqual(self.encoder.default(c), "rgb(16, 32, 64)")
+        self.assertIsInstance(self.encoder.default(c), string_types)
+
+        c = RGB(16, 32, 64, 0.1)
+        self.assertEqual(self.encoder.default(c), "rgba(16, 32, 64, 0.1)")
+        self.assertIsInstance(self.encoder.default(c), string_types)
+
     @skipIf(not is_pandas, "pandas does not work in PyPy.")
     def test_pd_timestamp(self):
         ts = pd.tslib.Timestamp('April 28, 1948')
@@ -64,6 +122,9 @@ class TestSerializeJson(unittest.TestCase):
 
     def test_with_basic(self):
         self.assertEqual(self.serialize({'test': [1, 2, 3]}), '{"test":[1,2,3]}')
+
+    def test_pretty(self):
+        self.assertEqual(self.serialize({'test': [1, 2, 3]}, pretty=True), '{\n  "test": [\n    1,\n    2,\n    3\n  ]\n}')
 
     def test_with_np_array(self):
         a = np.arange(5)
@@ -141,6 +202,11 @@ class TestSerializeJson(unittest.TestCase):
     def test_deque(self):
         """Test that a deque is deserialized as a list."""
         self.assertEqual(self.serialize(deque([0, 1, 2])), '[0,1,2]')
+
+    def test_bad_kwargs(self):
+        self.assertRaises(ValueError, self.serialize, [1], allow_nan=True)
+        self.assertRaises(ValueError, self.serialize, [1], separators=("a", "b"))
+        self.assertRaises(ValueError, self.serialize, [1], sort_keys=False)
 
 if __name__ == "__main__":
     unittest.main()

--- a/bokeh/core/tests/test_properties.py
+++ b/bokeh/core/tests/test_properties.py
@@ -6,11 +6,13 @@ import numpy as np
 import pandas as pd
 from copy import copy
 
-from bokeh.core.properties import (
-    HasProps, NumberSpec, ColorSpec, Bool, Int, Float, Complex, String,
+from bokeh.core.properties import (field, value,
+    NumberSpec, ColorSpec, Bool, Int, Float, Complex, String,
     Regex, Seq, List, Dict, Tuple, Array, Instance, Any, Interval, Either,
-    Enum, Color, Align, DashPattern, Size, Percent, Angle, AngleSpec,
+    Enum, Color, DashPattern, Size, Percent, Angle, AngleSpec,
     DistanceSpec, FontSizeSpec, Override, Include, MinMaxBounds, TitleProp)
+
+from bokeh.core.has_props import HasProps
 
 from bokeh.models import Plot
 from bokeh.models.annotations import Title
@@ -1446,10 +1448,6 @@ class TestProperties(unittest.TestCase):
         self.assertEqual(prop.transform((0, 127, 255)), "rgb(0, 127, 255)")
         self.assertEqual(prop.transform((0, 127, 255, 0.1)), "rgba(0, 127, 255, 0.1)")
 
-    def test_Align(self):
-        prop = Align() # TODO
-        assert prop
-
     def test_DashPattern(self):
         prop = DashPattern()
 
@@ -1660,3 +1658,13 @@ def test_titleprop_transforms_string_into_title_object():
     f = Foo(title="hello")
     assert isinstance(f.title, Title)
     assert f.title.text == "hello"
+
+def test_field_function():
+    assert field("foo") == dict(field="foo")
+    # TODO (bev) would like this to work I think
+    #assert field("foo", transform="junk") == dict(field="foo", transform="junk")
+
+def test_value_function():
+    assert value("foo") == dict(value="foo")
+    # TODO (bev) would like this to work I think
+    #assert value("foo", transform="junk") == dict(value="foo", transform="junk")

--- a/bokeh/core/tests/test_validation.py
+++ b/bokeh/core/tests/test_validation.py
@@ -1,0 +1,91 @@
+from mock import patch
+import bokeh.core.validation as v
+
+from bokeh.core.validation.errors import codes as ec
+from bokeh.core.validation.warnings import codes as wc
+
+from bokeh.model import Model
+from bokeh.core.properties import Int
+
+def test_error_decorator_code():
+    for code in ec:
+        @v.error(code)
+        def good():
+            return None
+        assert good() == []
+
+        @v.error(code)
+        def bad():
+            return "bad"
+        assert bad() == [(code,) + ec[code] + ('bad',)]
+
+def test_warning_decorator_code():
+    for code in wc:
+        @v.warning(code)
+        def good():
+            return None
+        assert good() == []
+
+        @v.warning(code)
+        def bad():
+            return "bad"
+        assert bad() == [(code,) + wc[code] + ('bad',)]
+
+def test_error_decorator_custom():
+    @v.error("E1")
+    def good():
+        return None
+    assert good() == []
+
+    @v.error("E2")
+    def bad():
+        return "bad"
+    assert bad() == [(9999, 'EXT:E2', 'Custom extension reports error', 'bad')]
+
+def test_warning_decorator_custom():
+    @v.warning("W1")
+    def good():
+        return None
+    assert good() == []
+
+    @v.warning("W2")
+    def bad():
+        return "bad"
+    assert bad() == [ (9999, 'EXT:W2', 'Custom extension reports warning', 'bad')]
+
+class Mod(Model):
+
+    foo = Int(default=0)
+
+    @v.error("E")
+    def _check_error(self):
+        if self.foo > 5: return "err"
+
+    @v.warning("W")
+    def _check_warning(self):
+        if self.foo < -5: return "wrn"
+
+@patch('bokeh.core.validation.check.logger.error')
+@patch('bokeh.core.validation.check.logger.warning')
+def test_check_pass(mock_warn, mock_error):
+    m = Mod()
+
+    v.check_integrity([m])
+    assert not mock_error.called
+    assert not mock_warn.called
+
+@patch('bokeh.core.validation.check.logger.error')
+@patch('bokeh.core.validation.check.logger.warning')
+def test_check_error(mock_warn, mock_error):
+    m = Mod(foo=10)
+    v.check_integrity([m])
+    assert mock_error.called
+    assert not mock_warn.called
+
+@patch('bokeh.core.validation.check.logger.error')
+@patch('bokeh.core.validation.check.logger.warning')
+def test_check_warn(mock_warn, mock_error):
+    m = Mod(foo=-10)
+    v.check_integrity([m])
+    assert not mock_error.called
+    assert mock_warn.called

--- a/bokeh/core/validation/decorators.py
+++ b/bokeh/core/validation/decorators.py
@@ -55,6 +55,10 @@ def error(code_or_name):
     Returns:
         callable : decorator for Bokeh model methods
 
+    The function that is decoratate should have a name that starts with
+    ``_check``, and return a string message in case a bad condition is
+    detected, and ``None`` if no bad condition is detected.
+
     Examples:
 
     The first example uses a numeric code for a standard error provided in
@@ -67,6 +71,7 @@ def error(code_or_name):
 
         @error(REQUIRED_RANGES)
         def _check_no_glyph_renderers(self):
+            if bad_condition: return "message"
 
     The second example shows how a custom warning check can be implemented by
     passing an arbitrary string label to the decorator. This usage is primarily
@@ -76,6 +81,7 @@ def error(code_or_name):
 
         @error("MY_CUSTOM_WARNING")
         def _check_my_custom_warning(self):
+            if bad_condition: return "message"
 
     '''
     return _error(code_or_name)
@@ -90,6 +96,10 @@ def warning(code_or_name):
     Returns:
         callable : decorator for Bokeh model methods
 
+    The function that is decoratate should have a name that starts with
+    ``_check``, and return a string message in case a bad condition is
+    detected, and ``None`` if no bad condition is detected.
+
     Examples:
 
     The first example uses a numeric code for a standard warning provided in
@@ -102,6 +112,7 @@ def warning(code_or_name):
 
         @warning(NO_DATA_RENDERERS)
         def _check_no_glyph_renderers(self):
+            if bad_condition: return "message"
 
     The second example shows how a custom warning check can be implemented by
     passing an arbitrary string label to the decorator. This usage is primarily
@@ -111,6 +122,7 @@ def warning(code_or_name):
 
         @warning("MY_CUSTOM_WARNING")
         def _check_my_custom_warning(self):
+            if bad_condition: return "message"
 
     '''
     return _warning(code_or_name)

--- a/bokeh/core/validation/errors.py
+++ b/bokeh/core/validation/errors.py
@@ -1,9 +1,6 @@
 ''' These define the standard error codes and messages for Bokeh
 validation checks.
 
-1000 *(COLUMN_LENGTHS)*
-    A |ColumnDataSource| has columns whose lengths are not all the same.
-
 1001 *(BAD_COLUMN_NAME)*
     A glyph has a property set to a field name that does not correspond to any
     column in the |GlyphRenderer|'s data source.

--- a/bokeh/core/validation/warnings.py
+++ b/bokeh/core/validation/warnings.py
@@ -16,6 +16,9 @@ validation checks.
 1004 *(BOTH_CHILD_AND_ROOT)*
     Each component can be rendered in only one place, can't be both a root and in a layout.
 
+1005 (*SNAPPED_TOOLBAR_ANNOTATIONS*)
+    Snapped toolbars and annotations on the same side MAY overlap visually.
+
 9999 *(EXT)*
     Indicates that a custom warning check has failed.
 

--- a/bokeh/model.py
+++ b/bokeh/model.py
@@ -22,7 +22,8 @@ from operator import itemgetter
 from six import iteritems
 
 from .core.json_encoder import serialize_json
-from .core.properties import Any, Dict, HasProps, Instance, List, MetaHasProps, String
+from .core.properties import Any, Dict, Instance, List, String
+from .core.has_props import HasProps, MetaHasProps
 from .core.query import find
 from .themes import default as default_theme
 from .util.callback_manager import CallbackManager

--- a/bokeh/models/map_plots.py
+++ b/bokeh/models/map_plots.py
@@ -6,7 +6,8 @@ from __future__ import absolute_import
 from ..core import validation
 from ..core.validation.warnings import MISSING_RENDERERS, NO_DATA_RENDERERS
 from ..core.validation.errors import REQUIRED_RANGE, MISSING_GOOGLE_API_KEY
-from ..core.properties import HasProps, abstract
+from ..core.has_props import HasProps
+from ..core.properties import abstract
 from ..core.properties import Enum, Float, Instance, Int, JSON, Override, String
 from ..core.enums import MapType
 

--- a/bokeh/models/tiles.py
+++ b/bokeh/models/tiles.py
@@ -1,39 +1,41 @@
+'''
+
+'''
 from __future__ import absolute_import
+
+from ..core.properties import Any, Bool, Dict, Float, Int, Override, String
 from ..model import Model
 
-from ..core.properties import Any, Dict, Float, String, Int, Bool, Override
-
 class TileSource(Model):
-    """ A base class for all tile source types. ``TileSource`` is
-    not generally useful to instantiate on its own. In general, tile sources are used as a required input for ``TileRenderer``.
+    """ A base class for all tile source types. ``TileSource`` is not generally
+    useful to instantiate on its own. In general, tile sources are used as a
+    required input for ``TileRenderer``.
 
-     Subclasses should have these properties as well:
-     x_origin_offset = Float
-     y_origin_offset = Float
-     initial_resolution = Float
     """
 
     _args = ('url', 'tile_size', 'min_zoom', 'max_zoom', 'extra_url_vars')
 
     url = String("", help="""
-    tile service url (example: http://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png)
+    Tile service url e.g., http://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png
     """)
 
     tile_size = Int(default=256, help="""
-    tile size in pixels (e.g. 256)
+    Tile size in pixels (e.g. 256)
     """)
 
     min_zoom = Int(default=0, help="""
-    the minimum zoom level for the tile layer. This is the most "zoomed-out" level.
+    A minimum zoom level for the tile layer. This is the most zoomed-out level.
     """)
 
     max_zoom = Int(default=30, help="""
-    the maximum zoom level for the tile layer. This is the most "zoomed-in" level.
+    A maximum zoom level for the tile layer. This is the most zoomed-in level.
     """)
 
     extra_url_vars = Dict(String, Any, help="""
     A dictionary that maps url variable template keys to values.
-    These variables are useful for parts of tile urls which do not change from tile to tile (e.g. server host name, or layer name).
+
+    These variables are useful for parts of tile urls which do not change from
+    tile to tile (e.g. server host name, or layer name).
     """)
 
     attribution = String("", help="""
@@ -41,19 +43,23 @@ class TileSource(Model):
     """)
 
     x_origin_offset = Float(help="""
-    x offset in plot coordinates
+    An x-offset in plot coordinates
     """)
 
     y_origin_offset = Float(help="""
-    y offset in plot coordinates
+    A y-offset in plot coordinates
     """)
 
     initial_resolution = Float(help="""
-    resolution (plot_units / pixels) of minimum zoom level of tileset projection. None to auto-compute.
+    Resolution (plot_units / pixels) of minimum zoom level of tileset
+    projection. None to auto-compute.
     """)
 
 class MercatorTileSource(TileSource):
-    """``MercatorTileSource`` is not generally useful to instantiate on its own, but is the parent class of mercator tile services (e.g. ``WMTSTileSource``).
+    """ ``MercatorTileSource`` is not generally useful to instantiate on its
+    own, but is the parent class of other mercator tile services (e.g.
+    ``WMTSTileSource``).
+
     """
 
     _args = ('url', 'tile_size', 'min_zoom', 'max_zoom', 'x_origin_offset', 'y_origin_offset', 'extra_url_vars', 'initial_resolution')
@@ -65,40 +71,51 @@ class MercatorTileSource(TileSource):
     initial_resolution = Override(default=156543.03392804097)
 
     wrap_around = Bool(default=True, help="""
-    Enables continuous horizontal panning by wrapping the x-axis based on bounds of map.
-    Note that axis coordinates are not wrapped. To toggle axis label visibility, use ``plot.axis.visible = False``.
+    Enables continuous horizontal panning by wrapping the x-axis based on
+    bounds of map.
+
+    ..note::
+        Axis coordinates are not wrapped. To toggle axis label visibility,
+        use ``plot.axis.visible = False``.
+
     """)
 
 class TMSTileSource(MercatorTileSource):
-    """
-    The TMSTileSource contains tile config info and provides urls for tiles based on a templated url e.g. ``http://your.tms.server.host/{Z}/{X}/{Y}.png``.
+    """ The TMSTileSource contains tile config info and provides urls for
+    tiles based on a templated url e.g. ``http://your.tms.server.host/{Z}/{X}/{Y}.png``.
     The defining feature of TMS is the tile-origin in located at the bottom-left.
 
-    The TMSTileSource can also be helpful in implementing tile renderers for custom tile sets, including non-spatial datasets.
+    The TMSTileSource can also be helpful in implementing tile renderers for
+    custom tile sets, including non-spatial datasets.
+
     """
     pass
 
 class WMTSTileSource(MercatorTileSource):
-    """
-    The ``WMTSTileSource`` behaves much like ``TMSTileSource`` but has its tile-origin in the top-left.
+    """ The ``WMTSTileSource`` behaves much like ``TMSTileSource`` but has its
+    tile-origin in the top-left.
+
     This is the most common used tile source for web mapping applications.
-    Such companies as Google, MapQuest, Stamen, Esri, and OpenStreetMap provide service which use the WMTS specification
-    e.g. ``http://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png``.
+    Such companies as Google, MapQuest, Stamen, Esri, and OpenStreetMap provide
+    service which use the WMTS specification e.g. ``http://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png``.
+
     """
     pass
 
 class QUADKEYTileSource(MercatorTileSource):
-    """
-    The QUADKEYTileSource has the same tile origin as the WMTSTileSource but requests tiles using a `quadkey` argument instead of X, Y, Z
-    e.g. ``http://your.quadkey.tile.host/{Q}.png``
+    """ The QUADKEYTileSource has the same tile origin as the WMTSTileSource
+    but requests tiles using a `quadkey` argument instead of X, Y, Z e.g. ``http://your.quadkey.tile.host/{Q}.png``
+
     """
     pass
 
 class BBoxTileSource(MercatorTileSource):
-    """
-    The BBoxTileSource has the same default tile origin as the WMTSTileSource but requested tiles use a ``{XMIN}``, ``{YMIN}``,
+    """ The BBoxTileSource has the same default tile origin as the
+    WMTSTileSource but requested tiles use a ``{XMIN}``, ``{YMIN}``,
     ``{XMAX}``, ``{YMAX}`` e.g. ``http://your.custom.tile.service?bbox={XMIN},{YMIN},{XMAX},{YMAX}``.
+
     """
+
     use_latlon = Bool(default=False, help="""
     Flag which indicates option to output {XMIN},{YMIN},{XMAX},{YMAX} in meters or latitude and longitude.
     """)

--- a/bokeh/models/widgets/buttons.py
+++ b/bokeh/models/widgets/buttons.py
@@ -5,7 +5,8 @@ from __future__ import absolute_import
 
 import warnings
 
-from ...core.properties import abstract, HasProps
+from ...core.has_props import HasProps
+from ...core.properties import abstract
 from ...core.properties import Bool, Int, String, Enum, Instance, List, Tuple, Override
 from ...core.enums import ButtonType
 from ..callbacks import Callback

--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -142,11 +142,11 @@ class Slider(InputWidget):
     callback_policy = Enum(SliderCallbackPolicy, default="throttle", help="""
     When the callback is initiated. This parameter can take on only one of three options:
 
-       "continuous": the callback will be executed immediately for each movement of the slider
-       "throttle": the callback will be executed at most every ``callback_throttle`` milliseconds.
-       "mouseup": the callback will be executed only once when the slider is released.
+    * "continuous": the callback will be executed immediately for each movement of the slider
+    * "throttle": the callback will be executed at most every ``callback_throttle`` milliseconds.
+    * "mouseup": the callback will be executed only once when the slider is released.
 
-       The `mouseup` policy is intended for scenarios in which the callback is expensive in time.
+    The "mouseup" policy is intended for scenarios in which the callback is expensive in time.
     """)
 
 class RangeSlider(InputWidget):
@@ -185,11 +185,11 @@ class RangeSlider(InputWidget):
     callback_policy = Enum(SliderCallbackPolicy, default="throttle", help="""
     When the callback is initiated. This parameter can take on only one of three options:
 
-       "continuous": the callback will be executed immediately for each movement of the slider
-       "throttle": the callback will be executed at most every ``callback_throttle`` milliseconds.
-       "mouseup": the callback will be executed only once when the slider is released.
+    * "continuous": the callback will be executed immediately for each movement of the slider
+    * "throttle": the callback will be executed at most every ``callback_throttle`` milliseconds.
+    * "mouseup": the callback will be executed only once when the slider is released.
 
-       The `mouseup` policy is intended for scenarios in which the callback is expensive in time.
+    The "mouseup" policy is intended for scenarios in which the callback is expensive in time.
     """)
 
 

--- a/bokeh/plotting/helpers.py
+++ b/bokeh/plotting/helpers.py
@@ -133,7 +133,7 @@ def _process_sequence_literals(glyphclass, kwargs, source, is_user_source):
         if isinstance(val, string_types):
             continue
         # similarly colorspecs handle color tuple sequences as-is
-        if (isinstance(dataspecs[var].descriptor, ColorSpec) and ColorSpec.is_color_tuple(val)):
+        if (isinstance(dataspecs[var].property, ColorSpec) and isinstance(val, tuple)):
             continue
 
         if isinstance(val, np.ndarray) and val.ndim != 1:

--- a/bokeh/sphinxext/bokeh_autodoc.py
+++ b/bokeh/sphinxext/bokeh_autodoc.py
@@ -11,8 +11,8 @@ from six import class_types
 from sphinx.ext.autodoc import AttributeDocumenter, ClassDocumenter, ModuleLevelDocumenter
 
 from bokeh.model import Model
-from bokeh.core.properties import Property
 from bokeh.core.enums import Enumeration
+from bokeh.core.property.descriptors import PropertyDescriptor
 
 class EnumDocumenter(ModuleLevelDocumenter):
     directivetype = 'bokeh-enum'
@@ -30,7 +30,7 @@ class PropDocumenter(AttributeDocumenter):
 
     @classmethod
     def can_document_member(cls, member, membername, isattr, parent):
-        return isinstance(member, Property)
+        return isinstance(member, PropertyDescriptor)
 
 class ModelDocumenter(ClassDocumenter):
     directivetype = 'bokeh-model'

--- a/bokeh/sphinxext/bokeh_options.py
+++ b/bokeh/sphinxext/bokeh_options.py
@@ -77,12 +77,12 @@ class BokehOptionsDirective(BokehDirective):
 
         opts = [];
         for prop_name in sorted(options_obj.properties()):
-            prop = getattr(options_obj.__class__, prop_name)
+            descriptor = getattr(options_obj.__class__, prop_name)
             opts.append(dict(
                 name=prop_name,
-                type=prop._sphinx_type(),
+                type=descriptor.property._sphinx_type(),
                 default=None,
-                doc="" if prop.__doc__ is None else textwrap.dedent(prop.__doc__),
+                doc="" if descriptor.__doc__ is None else textwrap.dedent(descriptor.__doc__),
             ))
 
         rst_text = OPTIONS_DETAIL.render(opts=opts)

--- a/bokeh/sphinxext/bokeh_prop.py
+++ b/bokeh/sphinxext/bokeh_prop.py
@@ -64,15 +64,15 @@ class BokehPropDirective(BokehDirective):
         model_obj = model()
 
         try:
-            prop = getattr(model_obj.__class__, prop_name)
+            descriptor = getattr(model_obj.__class__, prop_name)
         except AttributeError:
             raise SphinxError("Unable to generate reference docs for %s, no property '%s' in %s" % (self.arguments[0], prop_name, model_name))
 
         rst_text = PROP_DETAIL.render(
             name=prop_name,
             module=self.options['module'],
-            type_info=prop._sphinx_type(),
-            doc="" if prop.__doc__ is None else textwrap.dedent(prop.__doc__),
+            type_info=descriptor.property._sphinx_type(),
+            doc="" if descriptor.__doc__ is None else textwrap.dedent(descriptor.__doc__),
         )
 
         return self._parse(rst_text, "<bokeh-prop>")

--- a/bokeh/tests/test_document.py
+++ b/bokeh/tests/test_document.py
@@ -667,7 +667,7 @@ class TestDocument(unittest.TestCase):
         assert len(d.roots) == 1
 
         def patch_test(new_value):
-            serializable_new = root1.lookup('foo').descriptor.to_serializable(root1,
+            serializable_new = root1.lookup('foo').property.to_serializable(root1,
                                                                               'foo',
                                                                               new_value)
             event1 = document.ModelChangedEvent(d, root1, 'foo', root1.foo, new_value,

--- a/bokeh/tests/test_objects.py
+++ b/bokeh/tests/test_objects.py
@@ -6,7 +6,7 @@ import copy
 from bokeh.core.properties import List, String, Instance, Dict, Any, Int
 from bokeh.model import Model, _ModelInDocument
 from bokeh.document import Document
-from bokeh.core.property_containers import PropertyValueList, PropertyValueDict
+from bokeh.core.property.containers import PropertyValueList, PropertyValueDict
 from bokeh.util.future import with_metaclass
 
 
@@ -133,7 +133,8 @@ class TestModel(unittest.TestCase):
         self.assertEqual({'type': 'Model', 'id': 'test_id'}, testObject.ref)
 
     def test_references_by_ref_by_value(self):
-        from bokeh.core.properties import HasProps, Instance, Int
+        from bokeh.core.has_props import HasProps
+        from bokeh.core.properties import Instance, Int
 
         class T(self.pObjectClass):
             t = Int(0)

--- a/bokeh/themes/theme.py
+++ b/bokeh/themes/theme.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, print_function
 
 import yaml
 
-from ..core.properties import HasProps
+from ..core.has_props import HasProps
 
 # whenever we cache that there's nothing themed for a class, we
 # use this same dict instance, so we don't have a zillion empty

--- a/bokeh/util/options.py
+++ b/bokeh/util/options.py
@@ -2,7 +2,7 @@
 options.
 
 """
-from ..core.properties import HasProps
+from ..core.has_props import HasProps
 
 class Options(HasProps):
     ''' Leverage the Bokeh properties type system for specifying and

--- a/sphinx/source/docs/reference/core/has_props.rst
+++ b/sphinx/source/docs/reference/core/has_props.rst
@@ -1,0 +1,8 @@
+.. _bokeh.core.has_props:
+
+bokeh.core.has_props
+--------------------
+
+.. automodule:: bokeh.core.has_props
+  :members:
+  :undoc-members:

--- a/sphinx/source/docs/reference/core/properties.rst
+++ b/sphinx/source/docs/reference/core/properties.rst
@@ -10,4 +10,3 @@ serialization for a large collection of useful types. Mixin and container
 classes provide for easy bulk addition of properties to model classes.
 
 .. automodule:: bokeh.core.properties
-    :members:

--- a/sphinx/source/docs/reference/core/property.rst
+++ b/sphinx/source/docs/reference/core/property.rst
@@ -1,0 +1,5 @@
+.. toctree::
+   :maxdepth: 2
+   :glob:
+
+   property/*

--- a/sphinx/source/docs/reference/core/property/bases.rst
+++ b/sphinx/source/docs/reference/core/property/bases.rst
@@ -1,0 +1,9 @@
+.. _bokeh.core.property.bases:
+
+bokeh.core.property.bases
+-------------------------
+
+.. automodule:: bokeh.core.property.bases
+    :members:
+    :special-members:
+    :exclude-members: __weakref__

--- a/sphinx/source/docs/reference/core/property/containers.rst
+++ b/sphinx/source/docs/reference/core/property/containers.rst
@@ -1,0 +1,9 @@
+.. _bokeh.core.property.containers:
+
+bokeh.core.property.containers
+------------------------------
+
+.. automodule:: bokeh.core.property.containers
+    :members:
+    :special-members:
+    :exclude-members: __weakref__

--- a/sphinx/source/docs/reference/core/property/descriptor_factory.rst
+++ b/sphinx/source/docs/reference/core/property/descriptor_factory.rst
@@ -1,0 +1,9 @@
+.. _bokeh.core.property.descriptor_factory:
+
+bokeh.core.property.descriptor_factory
+--------------------------------------
+
+.. automodule:: bokeh.core.property.descriptor_factory
+    :members:
+    :special-members:
+    :exclude-members: __weakref__

--- a/sphinx/source/docs/reference/core/property/descriptors.rst
+++ b/sphinx/source/docs/reference/core/property/descriptors.rst
@@ -1,0 +1,11 @@
+.. _bokeh.core.property.descriptors:
+
+
+bokeh.core.property.descriptors
+-------------------------------
+
+.. automodule:: bokeh.core.property.descriptors
+    :members:
+    :member-order: bysource
+    :special-members:
+    :exclude-members: __weakref__

--- a/sphinx/source/docs/reference/core/property/factory.rst
+++ b/sphinx/source/docs/reference/core/property/factory.rst
@@ -1,0 +1,9 @@
+.. _bokeh.core.property.factory:
+
+bokeh.core.property.factory
+---------------------------
+
+.. automodule:: bokeh.core.property.factory
+    :members:
+    :special-members:
+    :exclude-members: __weakref__

--- a/sphinx/source/docs/reference/core/property/factory.rst
+++ b/sphinx/source/docs/reference/core/property/factory.rst
@@ -1,9 +1,0 @@
-.. _bokeh.core.property.factory:
-
-bokeh.core.property.factory
----------------------------
-
-.. automodule:: bokeh.core.property.factory
-    :members:
-    :special-members:
-    :exclude-members: __weakref__

--- a/sphinx/source/docs/reference/core/property/override.rst
+++ b/sphinx/source/docs/reference/core/property/override.rst
@@ -1,0 +1,9 @@
+.. _bokeh.core.property.override:
+
+bokeh.core.property.override
+----------------------------
+
+.. automodule:: bokeh.core.property.override
+    :members:
+    :special-members:
+    :exclude-members: __weakref__

--- a/sphinx/source/docs/reference/core/property_containers.rst
+++ b/sphinx/source/docs/reference/core/property_containers.rst
@@ -1,9 +1,0 @@
-.. _bokeh.core.property_containers:
-
-bokeh.core.property_containers
-------------------------------
-
-.. automodule:: bokeh.core.property_containers
-    :members:
-    :special-members:
-    :exclude-members: __weakref__

--- a/sphinx/source/docs/reference/server.rst
+++ b/sphinx/source/docs/reference/server.rst
@@ -6,10 +6,42 @@ bokeh.server
 .. automodule:: bokeh.server
   :members:
 
+.. _bokeh.server.application_context:
+
+bokeh.server.application_context
+--------------------------------
+
+.. automodule:: bokeh.server.application_context
+   :members:
+
 .. _bokeh.server.server:
 
 bokeh.server.server
 -------------------
 
 .. automodule:: bokeh.server.server
+   :members:
+
+.. _bokeh.server.session:
+
+bokeh.server.session
+--------------------
+
+.. automodule:: bokeh.server.session
+   :members:
+
+.. _bokeh.server.tornado:
+
+bokeh.server.tornado
+--------------------
+
+.. automodule:: bokeh.server.tornado
+   :members:
+
+.. _bokeh.server.urls:
+
+bokeh.server.urls
+-----------------
+
+.. automodule:: bokeh.server.urls
    :members:


### PR DESCRIPTION
issues: closes #5626 

This is an WIP PR for some early feedback @mattpap @havocp @pzwang @philippjfr (anyone who has a little time to comment). 

This PR:

* keeps all existing tests passing
* makes everything that is actually a python descriptor be called "descriptor" in some way, and makes anything that is not a python descriptor not be called a descriptor
* now makes it easy to explain: properties are things that create descriptor for themselves (that delegate back to the property for validation, etc.).  HasProps is the thing that coordinates using properties to add those descriptors to classes.
* splits the enormous `bokeh.core.properties` module and also moves other related super low level modules into a `property` dir:
  - `bokeh.core.property.bases`
  - `bokeh.core.property.container`
  - `bokeh.core.property.descriptors`
  - `bokeh.core.property.factory`
  - `bokeh.core.property.override`
* everything left in `properties.py` is jsut the stuff users writing extensions might care typically about

Here is the relevant portion of the class hierarchy:

![classes_bokeh](https://cloud.githubusercontent.com/assets/1078448/21575608/d599695c-ced7-11e6-8098-4c00165e35c1.png)

This seems fairly reasonable to me and makes much more sense.

More importantly, here is the module dependencies:

![packages_bokeh](https://cloud.githubusercontent.com/assets/1078448/21575610/e82cf6ba-ced7-11e6-82d1-ff4cc6485ce2.png)

Note that all arrows point in the same direction (there is one circular internal dependency that does not seem to show up here) I am sure this could still be improved, suggestions very welcome. 

Things still to do:

* add a ton of docs
* get all of `bokeh.core` up to 100% coverage
* find a way to move `_sphinx_type` off the classes
