### PR TITLE
Use custom code instead of gulp-mocha for running tests

### DIFF
--- a/bokehjs/gulp/tasks/test.coffee
+++ b/bokehjs/gulp/tasks/test.coffee
@@ -1,43 +1,55 @@
 gulp = require "gulp"
-mocha = require "gulp-mocha"
+gutil = require "gulp-util"
+through = require "through"
+cp = require "child_process"
 
 paths = require "../paths"
 utils = require "../utils"
 
-gulp.task "test", ["defaults:generate"], ->
-  gulp.src ["./test", "./test/all.coffee"], read: false
-    .pipe mocha()
+mocha = (options={}) ->
+  return through(
+    (file) ->
+      if @_files? then @_files.push(file.path) else @_files = [file.path]
+    () ->
+      proc = cp.spawn("node_modules/.bin/mocha",
+                      ["--compilers", "coffee:coffee-script/register", "./test/index.coffee"].concat(@_files),
+                      {stdio: 'inherit'})
+
+      proc.on "error", (err) =>
+        @emit("error", new gutil.PluginError("mocha", err))
+
+      proc.on "exit", (code) =>
+        if code != 0
+          @emit("error", new gutil.PluginError("mocha", "tests failed"))
+        else
+          @emit("end")
+  )
+
+gulp.task "test", ["defaults:generate"], () ->
+  gulp.src(["./test/all.coffee"]).pipe(mocha())
 
 gulp.task "test:client", ->
-  gulp.src ["./test", "./test/client.coffee"], read: false
-    .pipe mocha()
+  gulp.src(["./test/client.coffee"]).pipe(mocha())
 
 gulp.task "test:core", ->
-  gulp.src ["./test", "./test/core"], read: false
-    .pipe mocha()
+  gulp.src(["./test/core"]).pipe(mocha())
 
 gulp.task "test:document", ->
-  gulp.src ["./test", "./test/document.coffee"], read: false
-    .pipe mocha()
+  gulp.src(["./test/document.coffee"]).pipe(mocha())
 
 gulp.task "test:model", ->
-  gulp.src ["./test", "./test/model.coffee"], read: false
-    .pipe mocha()
+  gulp.src(["./test/model.coffee"]).pipe(mocha())
 
 gulp.task "test:models", ->
-  gulp.src ["./test", "./test/models"], read: false
-    .pipe mocha()
+  gulp.src(["./test/models"]).pipe(mocha())
 
 gulp.task "test:utils", ->
-  gulp.src ["./test", "./test/utils.coffee"], read: false
-    .pipe mocha()
+  gulp.src(["./test/utils.coffee"]).pipe(mocha())
 
 gulp.task "test:common", ["defaults:generate"], ->
-  gulp.src ["./test", "./test/common"], read: false
-    .pipe mocha()
+  gulp.src(["./test/common"]).pipe(mocha())
 
 gulp.task "test:size", ->
-  gulp.src ["./test", "./test/size.coffee"], read: false
-    .pipe mocha()
+  gulp.src(["./test/size.coffee"]).pipe(mocha())
 
-utils.buildWatchTask "test", paths.test.watchSources
+utils.buildWatchTask("test", paths.test.watchSources)

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -28,7 +28,6 @@
     "gulp-change": "^1.0.0",
     "gulp-insert": "^0.5.0",
     "gulp-less": "^3.0.2",
-    "gulp-mocha": "^2.0.0",
     "gulp-rename": "^1.2.0",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-task-listing": "^1.0.0",


### PR DESCRIPTION
gulp-mocha doesn't work and is unmaintained, so just use `child_process.spawn()` and run mocha natively.

fixes #5659
