### PR TITLE
allow auto for non/selection glyphs

### DIFF
--- a/bokeh/models/renderers.py
+++ b/bokeh/models/renderers.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 from ..model import Model
 from ..core.enums import RenderLevel
 from ..core.properties import abstract
-from ..core.properties import String, Enum, Instance, Float, Bool, Override
+from ..core.properties import Auto, Bool, Either, Enum, Float, Instance, Override, String
 from ..core import validation
 from ..core.validation.errors import BAD_COLUMN_NAME, MISSING_GLYPH, NO_SOURCE_FOR_GLYPH
 
@@ -131,14 +131,20 @@ class GlyphRenderer(DataRenderer):
     and ranges.
     """)
 
-    selection_glyph = Instance(Glyph, help="""
+    selection_glyph = Either(Auto, Instance(Glyph), default="auto", help="""
     An optional glyph used for selected points.
+
+    If set to "auto" then the standard glyph will be used for selected
+    points.
     """)
 
-    nonselection_glyph = Instance(Glyph, help="""
+    nonselection_glyph = Either(Auto, Instance(Glyph), default="auto", help="""
     An optional glyph used for explicitly non-selected points
     (i.e., non-selected when there are other points that are selected,
     but not when no points at all are selected.)
+
+    If set to "auto" then a glyph with a low alpha value (0.1) will
+    be used for non-selected points.
     """)
 
     hover_glyph = Instance(Glyph, help="""

--- a/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
+++ b/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
@@ -25,11 +25,15 @@ export class GlyphRendererView extends RendererView
 
     selection_glyph = @model.selection_glyph
     if not selection_glyph?
+      selection_glyph = mk_glyph({fill: {}, line: {}})
+    else if selection_glyph == "auto"
       selection_glyph = mk_glyph(@model.selection_defaults)
     @selection_glyph = @build_glyph_view(selection_glyph)
 
     nonselection_glyph = @model.nonselection_glyph
     if not nonselection_glyph?
+      nonselection_glyph = mk_glyph({fill: {}, line: {}})
+    else if nonselection_glyph == "auto"
       nonselection_glyph = mk_glyph(@model.nonselection_defaults)
     @nonselection_glyph = @build_glyph_view(nonselection_glyph)
 
@@ -236,13 +240,13 @@ export class GlyphRenderer extends Renderer
     return index
 
   @define {
-      x_range_name:       [ p.String,      'default' ]
-      y_range_name:       [ p.String,      'default' ]
-      data_source:        [ p.Instance               ]
-      glyph:              [ p.Instance               ]
-      hover_glyph:        [ p.Instance               ]
-      nonselection_glyph: [ p.Instance               ]
-      selection_glyph:    [ p.Instance               ]
+      x_range_name:       [ p.String,  'default' ]
+      y_range_name:       [ p.String,  'default' ]
+      data_source:        [ p.Instance           ]
+      glyph:              [ p.Instance           ]
+      hover_glyph:        [ p.Instance           ]
+      nonselection_glyph: [ p.Any,      'auto'   ] # Instance or "auto"
+      selection_glyph:    [ p.Any,      'auto'   ] # Instance or "auto"
     }
 
   @override {


### PR DESCRIPTION
issues: fixes #2414 

Makes it possible to specify `selection_glyph=None` to mean no policy (i.e. use regular glyph)

Default behaviors are unchanged. 