### PR TITLE
Automatically destroying servers in the notebook embed example

### DIFF
--- a/bokeh/core/_templates/notebook_cell_observer.js
+++ b/bokeh/core/_templates/notebook_cell_observer.js
@@ -1,3 +1,14 @@
+{#
+Registers a MutationObserver that can detect deletion of cells with a
+class of 'bokeh_class'
+
+:param inner_block: Javascript block to be executed when deletion detected
+:type inner_block: str
+
+The supplied Javascript is executed with the id of the destroyed div in
+ scope as variable destroyed_id.
+
+#}
 
 var target = document.getElementById('notebook-container');
 

--- a/bokeh/core/_templates/notebook_cell_observer.js
+++ b/bokeh/core/_templates/notebook_cell_observer.js
@@ -1,0 +1,19 @@
+
+var target = document.getElementById('notebook-container');
+
+var observer = new MutationObserver(function(mutations) {
+
+   for (var i = 0; i < mutations.length; i++) {
+      for (var j=0; j < mutations[i].removedNodes.length; j++) {
+        for (var k=0; k < mutations[i].removedNodes[j].childNodes.length; k++)
+          var bokeh_selector = $(mutations[i].removedNodes[j].childNodes[k]).find(".bokeh_class");
+          if (bokeh_selector) {
+            if (bokeh_selector.length > 0) {
+               var destroyed_id = bokeh_selector[0].id;
+                {{inner_block}}
+            }
+          }
+      }
+   }
+});
+observer.observe(target, { childList: true, subtree:true });

--- a/bokeh/core/state.py
+++ b/bokeh/core/state.py
@@ -41,6 +41,7 @@ class State(object):
 
     def __init__(self):
         self.last_comms_handle = None
+        self.uuid_to_server = {} # Mapping from uuid to server instance
         self.reset()
 
     @property

--- a/bokeh/core/templates.py
+++ b/bokeh/core/templates.py
@@ -12,6 +12,7 @@
 .. bokeh-jinja:: bokeh.core.templates.NOTEBOOK_DIV
 .. bokeh-jinja:: bokeh.core.templates.PLOT_DIV
 .. bokeh-jinja:: bokeh.core.templates.SCRIPT_TAG
+.. bokeh-jinja:: bokeh.core.templates.NOTEBOOK_CELL_OBSERVER
 
 '''
 from __future__ import absolute_import

--- a/bokeh/core/templates.py
+++ b/bokeh/core/templates.py
@@ -44,3 +44,5 @@ AUTOLOAD_JS = _env.get_template("autoload_js.js")
 AUTOLOAD_NB_JS = _env.get_template("autoload_nb_js.js")
 
 AUTOLOAD_TAG = _env.get_template("autoload_tag.html")
+
+NOTEBOOK_CELL_OBSERVER = _env.get_template("notebook_cell_observer.js")

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -644,7 +644,7 @@ def _destroy_server(div_id):
     Given a uuid id of a div removed or replaced in the Jupyter
     notebook, destroy the corresponding server sessions and stop it.
     '''
-    server = _state.uuid_to_server.pop(div_id, None)
+    server = _state.uuid_to_server.get(div_id, None)
     if server is None:
         logger.debug("No server instance found for uuid: %r" % div_id)
         return

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -319,7 +319,7 @@ def _show_notebook_app_with_state(app, _state, app_path, notebook_url):
                     allow_websocket_origin=[notebook_url])
     server.start()
     script = autoload_server(model=None, url='http://127.0.0.1:%d' % server.port)
-    display(HTML(server_cell(server, script)))
+    display(HTML(_server_cell(server, script)))
 
 
 def _show_with_state(obj, state, browser, new, notebook_handle=False):
@@ -629,7 +629,7 @@ def _remove_roots(subplots):
         if sub in doc.roots:
             doc.remove_root(sub)
 
-def server_cell(server, script):
+def _server_cell(server, script):
     '''
     Wraps a script returned by autoload_server in a div that allows cell
     destruction/replacement to be detected.

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -652,7 +652,6 @@ def _destroy_server(div_id):
     try:
         for session in server.get_sessions('/'):
             session.destroy()
-        server.stop()
 
     except Exception as e:
         logger.debug("Could not destroy server for id %r: %s" % (div_id, e))

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -22,6 +22,7 @@ import io
 import json
 import os
 import warnings
+import uuid
 
 # Third-party imports
 
@@ -609,3 +610,14 @@ def _remove_roots(subplots):
     for sub in subplots:
         if sub in doc.roots:
             doc.remove_root(sub)
+
+def server_cell(server, script):
+    '''
+    Wraps a script returned by autoload_server in a div that allows cell
+    destruction/replacement to be detected.
+    '''
+    divid = uuid.uuid4().hex
+    _state.uuid_to_server[divid] = server
+    div_html = "<div class='bokeh_class' id='{divid}'>{script}</div>'"
+    return div_html.format(script=script, divid=divid)
+

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -621,3 +621,20 @@ def server_cell(server, script):
     div_html = "<div class='bokeh_class' id='{divid}'>{script}</div>'"
     return div_html.format(script=script, divid=divid)
 
+def _destroy_server(div_id):
+    '''
+    Given a uuid id of a div removed or replaced in the Jupyter
+    notebook, destroy the corresponding server sessions and stop it.
+    '''
+    server = _state.uuid_to_server.pop(div_id, None)
+    if server is None:
+        logger.debug("No server instance found for uuid: %r" % div_id)
+        return
+
+    try:
+        for session in server.get_sessions('/'):
+            session.destroy()
+        server.stop()
+
+    except Exception as e:
+        logger.debug("Could not destroy server for id %r: %s" % (div_id, e))

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -41,7 +41,6 @@ from .util.serialization import make_id
 
 from .application import Application
 from .server.server import Server
-from tornado.ioloop import IOLoop
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -314,6 +313,7 @@ def show(obj, browser=None, new="tab", notebook_handle=False,
 
 def _show_notebook_app_with_state(app, _state, app_path, notebook_url):
     from IPython.display import HTML, display
+    from tornado.ioloop import IOLoop
     loop = IOLoop.current()
     server = Server({'/': app}, io_loop=loop, port=0, host='*',
                     allow_websocket_origin=[notebook_url])

--- a/bokeh/util/notebook.py
+++ b/bokeh/util/notebook.py
@@ -133,7 +133,7 @@ var observer = new MutationObserver(function(mutations) {
           if (bokeh_selector) {
             if (bokeh_selector.length > 0) {
                var destroyed_id = bokeh_selector[0].id;
-               IPython.notebook.kernel.execute("from bokeh import io;"
+               Jupyter.notebook.kernel.execute("from bokeh import io;"
                                                + "io._destroy_server('"
                                                + destroyed_id + "')");
                console.log('Destroying server with id:' + destroyed_id);

--- a/bokeh/util/notebook.py
+++ b/bokeh/util/notebook.py
@@ -118,3 +118,37 @@ def get_comms(target_name):
     '''
     from ipykernel.comm import Comm
     return Comm(target_name=target_name, data={})
+
+
+mutation_observer = """
+<script type='text/javascript'>
+var target = document.getElementById('notebook-container');
+
+var observer = new MutationObserver(function(mutations) {
+
+   for (var i = 0; i < mutations.length; i++) {
+      for (var j=0; j < mutations[i].removedNodes.length; j++) {
+        for (var k=0; k < mutations[i].removedNodes[j].childNodes.length; k++)
+          var bokeh_selector = $(mutations[i].removedNodes[j].childNodes[k]).find(".bokeh_class");
+          if (bokeh_selector) {
+            if (bokeh_selector.length > 0) {
+               var destroyed_id = bokeh_selector[0].id;
+               IPython.notebook.kernel.execute("from bokeh import io;"
+                                               + "io._destroy_server('"
+                                               + destroyed_id + "')");
+               console.log('Destroying server with id:' + destroyed_id);
+             }
+          }
+      }
+  }
+});
+observer.observe(target, { childList: true, subtree:true });
+</script>
+"""
+
+def watch_server_cells():
+    """
+    Installs a MutationObserver that detects deletion of cells using
+    io.server_cell to wrap the output.
+    """
+    publish_display_data({'text/html': mutation_observer}, source='bokeh')

--- a/examples/howto/server_embed/notebook_embed.ipynb
+++ b/examples/howto/server_embed/notebook_embed.ipynb
@@ -21,7 +21,10 @@
     "\n",
     "from bokeh.layouts import column\n",
     "from bokeh.models import ColumnDataSource, Slider\n",
-    "from bokeh.plotting import figure"
+    "from bokeh.plotting import figure\n",
+    "\n",
+    "from bokeh.util.notebook import watch_server_cells\n",
+    "watch_server_cells()"
    ]
   },
   {
@@ -105,12 +108,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Below is a convenience function for showing the resulting app inline in a Jupyter notebook. In the future, there will be an API built into Bokeh that does this. \n",
-    "\n",
-    "**WARNING** The function below leaks resources. It creates a new `Server` (with app and handler) every time it is executed, so re-executing some (or all) cells will leave stray Bokeh servers attached to the notebook `IOLoop`. For apps *without periodioc callbacks* this is probably often \"OK\", because the leftover server objects are effectively completely dormant when no events come in to them. But if an app has periodic callbacks, they will ***continue to run indefinitely***, which is probably undesirable. In this case, until there is proper Bokeh API to handle cleanup, it is recommended to run the code below explicitly, and \"keep track\" of any servers you create. Their sessions can be shut off by executing:\n",
-    "```\n",
-    "server.get_sessions()[0].destroy()\n",
-    "```"
+    "Below is a convenience function for showing the resulting app inline in a Jupyter notebook. In the future, there will be an API built into Bokeh that does this. "
    ]
   },
   {
@@ -125,13 +123,13 @@
     "    from IPython.display import HTML, display\n",
     "    from bokeh.embed import autoload_server\n",
     "    from bokeh.server.server import Server\n",
+    "    from bokeh.io import server_cell \n",
     "    \n",
     "    server = Server({'/': app}, io_loop=loop, port=0, host='*', allow_websocket_origin=[notebook_url])\n",
     "    server.start()\n",
     "    \n",
     "    script = autoload_server(model=None, url='http://127.0.0.1:%d' % server.port)\n",
-    "    \n",
-    "    display(HTML(script))"
+    "    display(HTML(server_cell(server, script)))"
    ]
   },
   {

--- a/examples/howto/server_embed/notebook_embed.ipynb
+++ b/examples/howto/server_embed/notebook_embed.ipynb
@@ -22,9 +22,7 @@
     "from bokeh.layouts import column\n",
     "from bokeh.models import ColumnDataSource, Slider\n",
     "from bokeh.plotting import figure\n",
-    "\n",
-    "from bokeh.util.notebook import watch_server_cells\n",
-    "watch_server_cells()"
+    "from bokeh.io import show"
    ]
   },
   {
@@ -89,7 +87,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Bokeh server runs on a Tornado `IOLoop`. When we run `bokeh serve` at the command line, an `IOLoop` is created and started automatically. In this case we are going to piggy-back off an existing `IOLoop`, the one that the Jupyter Notebook has. "
+    "Before we use ``show`` to display the app inline, we should watch the cells of the notebook to ensure that any Bokeh servers associated with our application are correctly shut down as cells are updated or deleted:"
    ]
   },
   {
@@ -100,47 +98,15 @@
    },
    "outputs": [],
    "source": [
-    "from tornado.ioloop import IOLoop\n",
-    "loop = IOLoop.current()"
+    "from bokeh.util.notebook import watch_server_cells\n",
+    "watch_server_cells()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Below is a convenience function for showing the resulting app inline in a Jupyter notebook. In the future, there will be an API built into Bokeh that does this. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "def show_app(app, notebook_url=\"127.0.0.1:8888\"):\n",
-    "    from IPython.display import HTML, display\n",
-    "    from bokeh.embed import autoload_server\n",
-    "    from bokeh.server.server import Server\n",
-    "    from bokeh.io import server_cell \n",
-    "    \n",
-    "    server = Server({'/': app}, io_loop=loop, port=0, host='*', allow_websocket_origin=[notebook_url])\n",
-    "    server.start()\n",
-    "    \n",
-    "    script = autoload_server(model=None, url='http://127.0.0.1:%d' % server.port)\n",
-    "    display(HTML(server_cell(server, script)))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "show_app(app)"
+    "We can display our application using ``show``:"
    ]
   },
   {
@@ -150,7 +116,9 @@
     "collapsed": true
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "show(app)"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION

This PR aims to address one of the issues raised in #3461 regarding the new [notebook embed](https://github.com/bokeh/bokeh/blob/master/examples/howto/server_embed/notebook_embed.ipynb) example, namely the problem of cleaning up servers when cells are deleted/re-executed. The approach shown here has been developed with a lot of helpful input from  @bryevdv.

Right now I would consider this PR to illustrate one possible implementation that can work. It does not track cell deletion/replacement in a particularly elegant way and I am still hoping to find a better approach.

## What it does

When a cell with output from ``show_app`` is deleted or replaced, a callback is fired using ``kernel.execute`` to destroy the corresponding server sessions (and then stop it).

## Approach

1. The ``watch_server_cells`` is called at the top of the notebook. This sets up a ``MutationObserver`` on 'notebook-container' div, allowing it to detect when any DOM nodes with ``class='bokeh_class'`` are deleted. To detect removal of DOM nodes, the ``MutationObserver`` needs to be set on a DOM element holding those nodes (i.e I could not get this working by setting the mutation observer on the cells themselves).

2. Invoking ``show_app`` uses the ``server_cell`` function to wrap the HTML output in a div that holds a freshly generated uuid. This uuid is associated with the server instance in the ``_state.uuid_to_server`` dictionary.

3. When these cells containing the wrapping div (with a class of 'bokeh_class') are deleted, ``kernel.execute`` is used to pass the uuid to ``bokeh.io._destroy_server``. This can then lookup the server instance and perform the necessary clean up.

## Outstanding issues

* Running 'Edit -> Undo Delete Cells' in the notebook menu restores a div associated with a server that will have been destroyed. This is why ``_destroy_server`` can receive a uuid corresponding to a  server that has already been destroyed.
* I don't think the clean up code is actually stopping the server instances properly. After running 'Undo Delete Cells', the app is still responsive! I understand it might be waiting for the tornado event loop to terminate?
* The ``MutationObserver`` is on a DOM node nearer the root than is ideal and the callback is invoked a lot, especially using ``subtree:true``.

It might be worth asking the notebook devs how they would recommend detecting the removal/update of cells. At any rate, I think the prospect of being able to embed the bokeh server in notebook cells is very exciting!