### PR TITLE
WIP: Allow reselection of objects

### DIFF
--- a/bokehjs/src/coffee/core/selector.coffee
+++ b/bokehjs/src/coffee/core/selector.coffee
@@ -2,7 +2,7 @@ import {HasProps} from "./has_props"
 import * as hittest from "./hittest"
 import {logger} from "./logging"
 import * as p from "./properties"
-import {union, concat} from "./util/array"
+import {concat} from "./util/array"
 
 merge = (obj1, obj2) ->
   result = {}
@@ -13,7 +13,7 @@ merge = (obj1, obj2) ->
   for key in keys
     arr1 = obj1[key] or []
     arr2 = obj2[key] or []
-    result[key] = union(arr1, arr2)
+    result[key] = concat(arr1, arr2)
 
   return result
 
@@ -24,9 +24,9 @@ export class Selector extends HasProps
     @setv('timestamp', new Date(), {silent: silent})
     @setv('final', final, {silent: silent})
     if append
-      indices['0d'].indices = union(@indices['0d'].indices, indices['0d'].indices)
+      indices['0d'].indices = concat(@indices['0d'].indices, indices['0d'].indices)
       indices['0d'].glyph =  @indices['0d'].glyph or indices['0d'].glyph
-      indices['1d'].indices = union(@indices['1d'].indices, indices['1d'].indices)
+      indices['1d'].indices = concat(@indices['1d'].indices, indices['1d'].indices)
       indices['2d'].indices = merge(@indices['2d'].indices, indices['2d'].indices)
     @setv('indices', indices, {silent: silent})
 


### PR DESCRIPTION
Related https://github.com/bokeh/bokeh/issues/2326

Instead of computing the union of indices, simply concatenate the previously selected indices with the currently provided ones. This should allow for things like deselection on a second click. Though it doesn't require that per se as it could also be interpreted as selecting the same object again thus resulting in later selections being no-ops.