### PR TITLE
pin MPL < 2.0

### DIFF
--- a/scripts/travis_install
+++ b/scripts/travis_install
@@ -10,6 +10,7 @@ MINICONDA_URL="http://repo.continuum.io/miniconda/$MINICONDA.sh"
 
 PINNED_PKGS=$(cat <<EOF
 notebook ==4.2.3
+matplotlib <2.0
 EOF
 )
 


### PR DESCRIPTION
MPL 2.0 is breaking our mpl compat tests. Assuming this pinning works, we should probably add a note to the release notes, and possibly an explicit version check and error in `bokeh.core.compat`

ping @bokeh/dev