### PR TITLE
Provide an abstraction layer on top of rbush

### DIFF
--- a/bokehjs/src/coffee/core/util/spatial.ts
+++ b/bokehjs/src/coffee/core/util/spatial.ts
@@ -1,0 +1,36 @@
+/// <reference types="@types/rbush" />
+import * as rbush from "rbush"
+
+export type Rect = {minX: number, minY: number, maxX: number, maxY: number}
+
+export abstract class SpatialIndex {
+  abstract indices(rect: Rect): number[]
+}
+
+export class RBush extends SpatialIndex {
+  private readonly index: rbush.RBush<Rect & {i: number}>
+
+  constructor(points: (Rect & {i: number})[]) {
+    super()
+    this.index = rbush<Rect & {i: number}>()
+    this.index.load(points)
+  }
+
+  get bbox(): Rect {
+    const {minX, minY, maxX, maxY} = this.index.toJSON()
+    return {minX, minY, maxX, maxY}
+  }
+
+  search(rect: Rect): (Rect & {i: number})[] {
+    return this.index.search(rect)
+  }
+
+  indices(rect: Rect): number[] {
+    const points = this.search(rect)
+    const indices = new Array<number>(points.length)
+    for (const {i} of points) {
+      indices.push(i)
+    }
+    return indices
+  }
+}

--- a/bokehjs/src/coffee/core/util/spatial.ts
+++ b/bokehjs/src/coffee/core/util/spatial.ts
@@ -27,9 +27,10 @@ export class RBush extends SpatialIndex {
 
   indices(rect: Rect): number[] {
     const points = this.search(rect)
-    const indices = new Array<number>(points.length)
-    for (const {i} of points) {
-      indices.push(i)
+    const n = points.length
+    const indices = new Array<number>(n)
+    for (let j = 0; j < n; j++) {
+      indices[j] = points[j].i
     }
     return indices
   }

--- a/bokehjs/src/coffee/models/glyphs/annular_wedge.coffee
+++ b/bokehjs/src/coffee/models/glyphs/annular_wedge.coffee
@@ -1,12 +1,9 @@
-import {Glyph, GlyphView} from "./glyph"
+import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import * as hittest from "../../core/hittest"
 import * as p from "../../core/properties"
 import {angle_between} from "../../core/util/math"
 
-export class AnnularWedgeView extends GlyphView
-
-  _index_data: () ->
-    @_xy_index()
+export class AnnularWedgeView extends XYGlyphView
 
   _map_data: () ->
     if @model.properties.inner_radius.units == "data"
@@ -108,12 +105,11 @@ export class AnnularWedgeView extends GlyphView
   scx: (i) -> @_scxy(i).x
   scy: (i) -> @_scxy(i).y
 
-export class AnnularWedge extends Glyph
+export class AnnularWedge extends XYGlyph
   default_view: AnnularWedgeView
 
   type: 'AnnularWedge'
 
-  @coords [['x', 'y']]
   @mixins ['line', 'fill']
   @define {
       direction:    [ p.Direction,   'anticlock' ]

--- a/bokehjs/src/coffee/models/glyphs/annular_wedge.coffee
+++ b/bokehjs/src/coffee/models/glyphs/annular_wedge.coffee
@@ -71,7 +71,7 @@ export class AnnularWedgeView extends XYGlyphView
     candidates = []
 
     bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-    for i in (pt.i for pt in @index.search(bbox))
+    for i in @index.indices(bbox)
       or2 = Math.pow(@souter_radius[i], 2)
       ir2 = Math.pow(@sinner_radius[i], 2)
       sx0 = @renderer.xmapper.map_to_target(x, true)

--- a/bokehjs/src/coffee/models/glyphs/annulus.coffee
+++ b/bokehjs/src/coffee/models/glyphs/annulus.coffee
@@ -66,7 +66,7 @@ export class AnnulusView extends XYGlyphView
     hits = []
 
     bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-    for i in (pt.i for pt in @index.search(bbox))
+    for i in @index.indices(bbox)
       or2 = Math.pow(@souter_radius[i], 2)
       ir2 = Math.pow(@sinner_radius[i], 2)
       sx0 = @renderer.xmapper.map_to_target(x)

--- a/bokehjs/src/coffee/models/glyphs/annulus.coffee
+++ b/bokehjs/src/coffee/models/glyphs/annulus.coffee
@@ -1,11 +1,8 @@
-import {Glyph, GlyphView} from "./glyph"
+import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import * as hittest from "../../core/hittest"
 import * as p from "../../core/properties"
 
-export class AnnulusView extends GlyphView
-
-  _index_data: () ->
-    @_xy_index()
+export class AnnulusView extends XYGlyphView
 
   _map_data: () ->
     if @model.properties.inner_radius.units == "data"
@@ -99,12 +96,11 @@ export class AnnulusView extends GlyphView
 
     @_render(ctx, indices, data)
 
-export class Annulus extends Glyph
+export class Annulus extends XYGlyph
   default_view: AnnulusView
 
   type: 'Annulus'
 
-  @coords [['x', 'y']]
   @mixins ['line', 'fill']
   @define {
       inner_radius: [ p.DistanceSpec ]

--- a/bokehjs/src/coffee/models/glyphs/arc.coffee
+++ b/bokehjs/src/coffee/models/glyphs/arc.coffee
@@ -1,10 +1,7 @@
-import {Glyph, GlyphView} from "./glyph"
+import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import * as p from "../../core/properties"
 
-export class ArcView extends GlyphView
-
-  _index_data: () ->
-    @_xy_index()
+export class ArcView extends XYGlyphView
 
   _map_data: () ->
     if @model.properties.radius.units == "data"
@@ -28,12 +25,11 @@ export class ArcView extends GlyphView
   draw_legend_for_index: (ctx, x0, x1, y0, y1, index) ->
     @_generic_line_legend(ctx, x0, x1, y0, y1, index)
 
-export class Arc extends Glyph
+export class Arc extends XYGlyph
   default_view: ArcView
 
   type: 'Arc'
 
-  @coords [['x', 'y']]
   @mixins ['line']
   @define {
       direction:   [ p.Direction,   'anticlock' ]

--- a/bokehjs/src/coffee/models/glyphs/bezier.coffee
+++ b/bokehjs/src/coffee/models/glyphs/bezier.coffee
@@ -1,5 +1,4 @@
-import * as rbush from "rbush"
-
+import {RBush} from "../../core/util/spatial"
 import {Glyph, GlyphView} from "./glyph"
 
 # algorithm adapted from http://stackoverflow.com/a/14429749/3406693
@@ -74,9 +73,7 @@ export class BezierView extends GlyphView
       [x0, y0, x1, y1] = _cbb(@_x0[i], @_y0[i], @_x1[i], @_y1[i], @_cx0[i], @_cy0[i], @_cx1[i], @_cy1[i])
       points.push({minX: x0, minY: y0, maxX: x1, maxY: y1, i: i})
 
-    index = rbush()
-    index.load(points)
-    return index
+    return new RBush(points)
 
   _render: (ctx, indices, {sx0, sy0, sx1, sy1, scx, scx0, scy0, scx1, scy1}) ->
     if @visuals.line.doit

--- a/bokehjs/src/coffee/models/glyphs/bezier.coffee
+++ b/bokehjs/src/coffee/models/glyphs/bezier.coffee
@@ -66,17 +66,16 @@ _cbb = (x0, y0, x1, y1, x2, y2, x3, y3) ->
 export class BezierView extends GlyphView
 
   _index_data: () ->
-    index = rbush()
-    pts = []
+    points = []
     for i in [0...@_x0.length]
       if isNaN(@_x0[i]+@_x1[i]+@_y0[i]+@_y1[i]+@_cx0[i]+@_cy0[i]+@_cx1[i]+@_cy1[i])
         continue
 
       [x0, y0, x1, y1] = _cbb(@_x0[i], @_y0[i], @_x1[i], @_y1[i], @_cx0[i], @_cy0[i], @_cx1[i], @_cy1[i])
+      points.push({minX: x0, minY: y0, maxX: x1, maxY: y1, i: i})
 
-      pts.push({minX: x0, minY: y0, maxX: x1, maxY: y1, i: i})
-
-    index.load(pts)
+    index = rbush()
+    index.load(points)
     return index
 
   _render: (ctx, indices, {sx0, sy0, sx1, sy1, scx, scx0, scy0, scx1, scy1}) ->

--- a/bokehjs/src/coffee/models/glyphs/circle.coffee
+++ b/bokehjs/src/coffee/models/glyphs/circle.coffee
@@ -1,11 +1,8 @@
-import {Glyph, GlyphView} from "./glyph"
+import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import * as hittest from "../../core/hittest"
 import * as p from "../../core/properties"
 
-export class CircleView extends GlyphView
-
-  _index_data: () ->
-    return @_xy_index()
+export class CircleView extends XYGlyphView
 
   _map_data: () ->
     # NOTE: Order is important here: size is always present (at least
@@ -196,12 +193,11 @@ export class CircleView extends GlyphView
     data = {sx: sx, sy: sy, sradius: sradius}
     @_render(ctx, indices, data)
 
-export class Circle extends Glyph # XXX: Marker
+export class Circle extends XYGlyph # XXX: Marker
   default_view: CircleView
 
   type: 'Circle'
 
-  @coords [['x', 'y']]
   @mixins ['line', 'fill']
   @define {
       angle:            [ p.AngleSpec,    0                             ]

--- a/bokehjs/src/coffee/models/glyphs/circle.coffee
+++ b/bokehjs/src/coffee/models/glyphs/circle.coffee
@@ -45,7 +45,7 @@ export class CircleView extends XYGlyphView
       [y0, y1] = @renderer.ymapper.v_map_from_target([sy0, sy1], true)
 
     bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-    return (x.i for x in @index.search(bbox))
+    return @index.indices(bbox)
 
   _render: (ctx, indices, {sx, sy, sradius}) ->
 
@@ -89,7 +89,7 @@ export class CircleView extends XYGlyphView
       [y0, y1] = [Math.min(y0, y1), Math.max(y0, y1)]
 
     bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-    candidates = (pt.i for pt in @index.search(bbox))
+    candidates = @index.indices(bbox)
 
     hits = []
     if @_radius? and @model.properties.radius.units == "data"
@@ -146,7 +146,7 @@ export class CircleView extends XYGlyphView
           [y0, y1] = @renderer.ymapper.v_map_from_target([vy0, vy1], true)
 
       bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-      hits = (xx.i for xx in @index.search(bbox))
+      hits = @index.indices(bbox)
 
       result['1d'].indices = hits
       return result
@@ -156,7 +156,7 @@ export class CircleView extends XYGlyphView
     [y0, y1] = @renderer.ymapper.v_map_from_target([geometry.vy0, geometry.vy1], true)
     bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
     result = hittest.create_hit_test_result()
-    result['1d'].indices = (x.i for x in @index.search(bbox))
+    result['1d'].indices = @index.indices(bbox)
     return result
 
   _hit_poly: (geometry) ->

--- a/bokehjs/src/coffee/models/glyphs/ellipse.coffee
+++ b/bokehjs/src/coffee/models/glyphs/ellipse.coffee
@@ -1,7 +1,7 @@
-import {Glyph, GlyphView} from "./glyph"
+import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import * as p from "../../core/properties"
 
-export class EllipseView extends GlyphView
+export class EllipseView extends XYGlyphView
 
   _set_data: () ->
     @max_w2 = 0
@@ -10,9 +10,6 @@ export class EllipseView extends GlyphView
     @max_h2 = 0
     if @model.properties.height.units == "data"
       @max_h2 = @max_height/2
-
-  _index_data: () ->
-    @_xy_index()
 
   _map_data: () ->
     if @model.properties.width.units == "data"
@@ -64,12 +61,11 @@ export class EllipseView extends GlyphView
   _bounds: (bds) ->
     return @max_wh2_bounds(bds)
 
-export class Ellipse extends Glyph
+export class Ellipse extends XYGlyph
   default_view: EllipseView
 
   type: 'Ellipse'
 
-  @coords [['x', 'y']]
   @mixins ['line', 'fill']
   @define {
       angle:  [ p.AngleSpec,   0.0 ]

--- a/bokehjs/src/coffee/models/glyphs/glyph.coffee
+++ b/bokehjs/src/coffee/models/glyphs/glyph.coffee
@@ -49,9 +49,8 @@ export class GlyphView extends BokehView
   bounds: () ->
     if not @index?
       return bbox.empty()
-    d = @index.data
-    bb = {minX: d.minX, minY: d.minY, maxX: d.maxX, maxY: d.maxY}
-    return @_bounds(bb)
+    else
+      return @_bounds(@index.bbox)
 
   log_bounds: () ->
     if not @index?

--- a/bokehjs/src/coffee/models/glyphs/glyph.coffee
+++ b/bokehjs/src/coffee/models/glyphs/glyph.coffee
@@ -1,6 +1,3 @@
-import * as rbush from "rbush"
-
-import {CategoricalMapper} from "../mappers/categorical_mapper"
 import * as p from "../../core/properties"
 import * as bbox from "../../core/util/bbox"
 import * as proj from "../../core/util/projections"
@@ -94,32 +91,6 @@ export class GlyphView extends BokehView
   # snapping to a patch centroid, e.g, should override these
   scx: (i) -> return @sx[i]
   scy: (i) -> return @sy[i]
-
-  _xy_index: () ->
-    index = rbush()
-    pts = []
-
-    # if the range is categorical, map to synthetic coordinates first
-    if @renderer.xmapper instanceof CategoricalMapper
-      xx = @renderer.xmapper.v_map_to_target(@_x, true)
-    else
-      xx = @_x
-    if @renderer.ymapper instanceof CategoricalMapper
-      yy = @renderer.ymapper.v_map_to_target(@_y, true)
-    else
-      yy = @_y
-
-    for i in [0...xx.length]
-      x = xx[i]
-      if isNaN(x) or not isFinite(x)
-        continue
-      y = yy[i]
-      if isNaN(y) or not isFinite(y)
-        continue
-      pts.push({minX: x, minY: y, maxX: x, maxY: y, i: i})
-
-    index.load(pts)
-    return index
 
   sdist: (mapper, pts, spans, pts_location="edge", dilate=false) ->
     if isString(pts[0])

--- a/bokehjs/src/coffee/models/glyphs/hbar.coffee
+++ b/bokehjs/src/coffee/models/glyphs/hbar.coffee
@@ -1,4 +1,4 @@
-import * as rbush from "rbush"
+import {RBush} from "../../core/util/spatial"
 import * as Quad from "./quad"
 import {Glyph, GlyphView} from "./glyph"
 import {CategoricalMapper} from "../mappers/categorical_mapper"
@@ -49,9 +49,7 @@ export class HBarView extends GlyphView
         continue
       points.push({minX: l, minY: b, maxX: r, maxY: t, i: i})
 
-    index = rbush()
-    index.load(points)
-    return index
+    return new RBush(points)
 
   _render: (ctx, indices, {sleft, sright, stop, sbottom}) ->
     for i in indices
@@ -73,7 +71,7 @@ export class HBarView extends GlyphView
     x = @renderer.xmapper.map_from_target(vx, true)
     y = @renderer.ymapper.map_from_target(vy, true)
 
-    hits = (x.i for x in @index.search({minX: x, minY: y, maxX: x, maxY: y}))
+    hits = @index.indices({minX: x, minY: y, maxX: x, maxY: y})
 
     result = hittest.create_hit_test_result()
     result['1d'].indices = hits

--- a/bokehjs/src/coffee/models/glyphs/hbar.coffee
+++ b/bokehjs/src/coffee/models/glyphs/hbar.coffee
@@ -38,8 +38,7 @@ export class HBarView extends GlyphView
     y = map_to_synthetic(@renderer.ymapper, @_y)
     height = map_to_synthetic(@renderer.ymapper, @_height)
 
-    index = rbush()
-    pts = []
+    points = []
 
     for i in [0...y.length]
       l = left[i]
@@ -48,9 +47,10 @@ export class HBarView extends GlyphView
       b = y[i] - 0.5 * height[i]
       if isNaN(l+r+t+b) or not isFinite(l+r+t+b)
         continue
-      pts.push({minX: l, minY: b, maxX: r, maxY: t, i: i})
+      points.push({minX: l, minY: b, maxX: r, maxY: t, i: i})
 
-    index.load(pts)
+    index = rbush()
+    index.load(points)
     return index
 
   _render: (ctx, indices, {sleft, sright, stop, sbottom}) ->

--- a/bokehjs/src/coffee/models/glyphs/image.coffee
+++ b/bokehjs/src/coffee/models/glyphs/image.coffee
@@ -1,9 +1,9 @@
-import {Glyph, GlyphView} from "./glyph"
+import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import {LinearColorMapper} from "../mappers/linear_color_mapper"
 import * as p from "../../core/properties"
 import {max, concat} from "../../core/util/array"
 
-export class ImageView extends GlyphView
+export class ImageView extends XYGlyphView
 
   initialize: (options) ->
     super(options)
@@ -14,9 +14,6 @@ export class ImageView extends GlyphView
     if @image_data?
       @_set_data()
       @renderer.plot_view.request_render()
-
-  _index_data: () ->
-    @_xy_index()
 
   _set_data: () ->
     if not @image_data? or @image_data.length != @_image.length
@@ -109,13 +106,11 @@ export class ImageView extends GlyphView
 # NOTE: this needs to be redefined here, because palettes are located in bokeh-api.js bundle
 Greys9 = () -> [0x000000, 0x252525, 0x525252, 0x737373, 0x969696, 0xbdbdbd, 0xd9d9d9, 0xf0f0f0, 0xffffff]
 
-export class Image extends Glyph
+export class Image extends XYGlyph
   default_view: ImageView
 
   type: 'Image'
 
-  @coords [['x', 'y']]
-  @mixins []
   @define {
       image:        [ p.NumberSpec       ] # TODO (bev) array spec?
       dw:           [ p.DistanceSpec     ]

--- a/bokehjs/src/coffee/models/glyphs/image.coffee
+++ b/bokehjs/src/coffee/models/glyphs/image.coffee
@@ -94,13 +94,10 @@ export class ImageView extends XYGlyphView
     ctx.setImageSmoothingEnabled(old_smoothing)
 
   bounds: () ->
-    d = @index.data
-    return {
-      minX: d.minX,
-      minY: d.minY,
-      maxX: d.maxX + @max_dw,
-      maxY: d.maxY + @max_dh
-    }
+    bbox = @index.bbox
+    bbox.maxX += @max_dw
+    bbox.maxY += @max_dh
+    return bbox
 
 # NOTE: this needs to be redefined here, because palettes are located in bokeh-api.js bundle
 Greys9 = () -> [0x000000, 0x252525, 0x525252, 0x737373, 0x969696, 0xbdbdbd, 0xd9d9d9, 0xf0f0f0, 0xffffff]

--- a/bokehjs/src/coffee/models/glyphs/image.coffee
+++ b/bokehjs/src/coffee/models/glyphs/image.coffee
@@ -61,7 +61,6 @@ export class ImageView extends XYGlyphView
       @max_dh = 0
       if @_dh.units == "data"
         @max_dh = max(@_dh)
-      @_xy_index()
 
   _map_data: () ->
     switch @model.properties.dw.units

--- a/bokehjs/src/coffee/models/glyphs/image_rgba.coffee
+++ b/bokehjs/src/coffee/models/glyphs/image_rgba.coffee
@@ -1,11 +1,8 @@
-import {Glyph, GlyphView} from "./glyph"
+import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import * as p from "../../core/properties"
 import {max, concat} from "../../core/util/array"
 
-export class ImageRGBAView extends GlyphView
-
-  _index_data: () ->
-    @_xy_index()
+export class ImageRGBAView extends XYGlyphView
 
   # TODO (bev) to improve. Currently, if only one image has changed, can
   # pass index as "arg" to prevent full re-preocessing (useful for streaming)
@@ -113,13 +110,11 @@ export class ImageRGBAView extends GlyphView
       maxY: d.maxY + @max_dh
     }
 
-export class ImageRGBA extends Glyph
+export class ImageRGBA extends XYGlyph
   default_view: ImageRGBAView
 
   type: 'ImageRGBA'
 
-  @coords [['x', 'y']]
-  @mixins []
   @define {
       image:  [ p.NumberSpec       ] # TODO (bev) array spec?
       rows:   [ p.NumberSpec       ]

--- a/bokehjs/src/coffee/models/glyphs/image_rgba.coffee
+++ b/bokehjs/src/coffee/models/glyphs/image_rgba.coffee
@@ -102,13 +102,10 @@ export class ImageRGBAView extends XYGlyphView
     ctx.setImageSmoothingEnabled(old_smoothing)
 
   bounds: () ->
-    d = @index.data
-    return {
-      minX: d.minX,
-      minY: d.minY,
-      maxX: d.maxX + @max_dw,
-      maxY: d.maxY + @max_dh
-    }
+    bbox = @index.bbox
+    bbox.maxX += @max_dw
+    bbox.maxY += @max_dh
+    return bbox
 
 export class ImageRGBA extends XYGlyph
   default_view: ImageRGBAView

--- a/bokehjs/src/coffee/models/glyphs/line.coffee
+++ b/bokehjs/src/coffee/models/glyphs/line.coffee
@@ -1,10 +1,7 @@
-import {Glyph, GlyphView} from "./glyph"
+import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import * as hittest from "../../core/hittest"
 
-export class LineView extends GlyphView
-
-  _index_data: () ->
-    @_xy_index()
+export class LineView extends XYGlyphView
 
   _render: (ctx, indices, {sx, sy}) ->
     drawing = false
@@ -101,10 +98,9 @@ export class LineView extends GlyphView
   draw_legend_for_index: (ctx, x0, x1, y0, y1, index) ->
     @_generic_line_legend(ctx, x0, x1, y0, y1, index)
 
-export class Line extends Glyph
+export class Line extends XYGlyph
   default_view: LineView
 
   type: 'Line'
 
-  @coords [['x', 'y']]
   @mixins ['line']

--- a/bokehjs/src/coffee/models/glyphs/multi_line.coffee
+++ b/bokehjs/src/coffee/models/glyphs/multi_line.coffee
@@ -1,5 +1,4 @@
-import * as rbush from "rbush"
-
+import {RBush} from "../../core/util/spatial"
 import * as hittest from "../../core/hittest"
 import {min, max} from "../../core/util/array"
 import {isStrictNaN} from "../../core/util/types"
@@ -22,9 +21,7 @@ export class MultiLineView extends GlyphView
         i: i
       })
 
-    index = rbush()
-    index.load(points)
-    return index
+    return new RBush(points)
 
   _render: (ctx, indices, {sxs, sys}) ->
     for i in indices

--- a/bokehjs/src/coffee/models/glyphs/multi_line.coffee
+++ b/bokehjs/src/coffee/models/glyphs/multi_line.coffee
@@ -8,21 +8,22 @@ import {Glyph, GlyphView} from "./glyph"
 export class MultiLineView extends GlyphView
 
   _index_data: () ->
-    index = rbush()
-    pts = []
+    points = []
     for i in [0...@_xs.length]
       xs = (x for x in @_xs[i] when not isStrictNaN(x))
       ys = (y for y in @_ys[i] when not isStrictNaN(y))
       if xs.length == 0
         continue
-      pts.push({
+      points.push({
         minX: min(xs),
         minY: min(ys),
         maxX: max(xs),
         maxY: max(ys),
         i: i
       })
-    index.load(pts)
+
+    index = rbush()
+    index.load(points)
     return index
 
   _render: (ctx, indices, {sxs, sys}) ->

--- a/bokehjs/src/coffee/models/glyphs/oval.coffee
+++ b/bokehjs/src/coffee/models/glyphs/oval.coffee
@@ -1,7 +1,7 @@
-import {Glyph, GlyphView} from "./glyph"
+import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import * as p from "../../core/properties"
 
-export class OvalView extends GlyphView
+export class OvalView extends XYGlyphView
 
   _set_data: () ->
     @max_w2 = 0
@@ -10,9 +10,6 @@ export class OvalView extends GlyphView
     @max_h2 = 0
     if @model.properties.height.units == "data"
       @max_h2 = @max_height/2
-
-  _index_data: () ->
-    @_xy_index()
 
   _map_data: () ->
     if @model.properties.width.units == "data"
@@ -73,12 +70,11 @@ export class OvalView extends GlyphView
   _bounds: (bds) ->
     return @max_wh2_bounds(bds)
 
-export class Oval extends Glyph
+export class Oval extends XYGlyph
   default_view: OvalView
 
   type: 'Oval'
 
-  @coords [['x', 'y']]
   @mixins ['line', 'fill']
   @define {
       angle:  [ p.AngleSpec,   0.0 ]

--- a/bokehjs/src/coffee/models/glyphs/patch.coffee
+++ b/bokehjs/src/coffee/models/glyphs/patch.coffee
@@ -1,9 +1,6 @@
-import {Glyph, GlyphView} from "./glyph"
+import {XYGlyph, XYGlyphView} from "./xy_glyph"
 
-export class PatchView extends GlyphView
-
-  _index_data: () ->
-    @_xy_index()
+export class PatchView extends XYGlyphView
 
   _render: (ctx, indices, {sx, sy}) ->
     if @visuals.fill.doit
@@ -47,10 +44,9 @@ export class PatchView extends GlyphView
   draw_legend_for_index: (ctx, x0, x1, y0, y1, index) ->
     @_generic_area_legend(ctx, x0, x1, y0, y1, index)
 
-export class Patch extends Glyph
+export class Patch extends XYGlyph
   default_view: PatchView
 
   type: 'Patch'
 
-  @coords [['x', 'y']]
   @mixins ['line', 'fill']

--- a/bokehjs/src/coffee/models/glyphs/patches.coffee
+++ b/bokehjs/src/coffee/models/glyphs/patches.coffee
@@ -1,5 +1,4 @@
-import * as rbush from "rbush"
-
+import {RBush} from "../../core/util/spatial"
 import {Glyph, GlyphView} from "./glyph"
 import {min, max, copy, findLastIndex} from "../../core/util/array"
 import {isStrictNaN} from "../../core/util/types"
@@ -62,9 +61,7 @@ export class PatchesView extends GlyphView
           i: i
         })
 
-    index = rbush()
-    index.load(points)
-    return index
+    return new RBush(points)
 
   _mask_data: (all_indices) ->
     xr = @renderer.plot_view.x_range
@@ -74,7 +71,7 @@ export class PatchesView extends GlyphView
     [y0, y1] = [yr.min, yr.max]
 
     bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-    return (x.i for x in @index.search(bbox))
+    return @index.indices(bbox)
 
   _render: (ctx, indices, {sxs, sys}) ->
     # @sxss and @syss are used by _hit_point and sxc, syc
@@ -130,7 +127,7 @@ export class PatchesView extends GlyphView
     x = @renderer.xmapper.map_from_target(vx, true)
     y = @renderer.ymapper.map_from_target(vy, true)
 
-    candidates = (x.i for x in @index.search({minX: x, minY: y, maxX: x, maxY: y}))
+    candidates = @index.indices({minX: x, minY: y, maxX: x, maxY: y})
 
     hits = []
     for i in [0...candidates.length]

--- a/bokehjs/src/coffee/models/glyphs/patches.coffee
+++ b/bokehjs/src/coffee/models/glyphs/patches.coffee
@@ -44,25 +44,26 @@ export class PatchesView extends GlyphView
 
 
   _index_data: () ->
-    index = rbush()
-    pts = []
     xss = @_build_discontinuous_object(@_xs)
     yss = @_build_discontinuous_object(@_ys)
 
+    points = []
     for i in [0...@_xs.length]
       for j in [0...xss[i].length]
         xs = xss[i][j]
         ys = yss[i][j]
         if xs.length == 0
           continue
-        pts.push({
+        points.push({
           minX: min(xs),
           minY: min(ys),
           maxX: max(xs),
           maxY: max(ys),
           i: i
         })
-    index.load(pts)
+
+    index = rbush()
+    index.load(points)
     return index
 
   _mask_data: (all_indices) ->

--- a/bokehjs/src/coffee/models/glyphs/quad.coffee
+++ b/bokehjs/src/coffee/models/glyphs/quad.coffee
@@ -1,5 +1,4 @@
-import * as rbush from "rbush"
-
+import {RBush} from "../../core/util/spatial"
 import {Glyph, GlyphView} from "./glyph"
 import {CategoricalMapper} from "../mappers/categorical_mapper"
 import * as hittest from "../../core/hittest"
@@ -29,9 +28,7 @@ export class QuadView extends GlyphView
         continue
       points.push({minX: l, minY: b, maxX: r, maxY: t, i: i})
 
-    index = rbush()
-    index.load(points)
-    return index
+    return new RBush(points)
 
   _render: (ctx, indices, {sleft, sright, stop, sbottom}) ->
     for i in indices
@@ -53,7 +50,7 @@ export class QuadView extends GlyphView
     x = @renderer.xmapper.map_from_target(vx, true)
     y = @renderer.ymapper.map_from_target(vy, true)
 
-    hits = (x.i for x in @index.search({minX: x, minY: y, maxX: x, maxY: y}))
+    hits = @index.indices({minX: x, minY: y, maxX: x, maxY: y})
 
     result = hittest.create_hit_test_result()
     result['1d'].indices = hits

--- a/bokehjs/src/coffee/models/glyphs/quad.coffee
+++ b/bokehjs/src/coffee/models/glyphs/quad.coffee
@@ -19,9 +19,7 @@ export class QuadView extends GlyphView
     top = map_to_synthetic(@renderer.ymapper, @_top)
     bottom = map_to_synthetic(@renderer.ymapper, @_bottom)
 
-    index = rbush()
-    pts = []
-
+    points = []
     for i in [0...left.length]
       l = left[i]
       r = right[i]
@@ -29,9 +27,10 @@ export class QuadView extends GlyphView
       b = bottom[i]
       if isNaN(l+r+t+b) or not isFinite(l+r+t+b)
         continue
-      pts.push({minX: l, minY: b, maxX: r, maxY: t, i: i})
+      points.push({minX: l, minY: b, maxX: r, maxY: t, i: i})
 
-    index.load(pts)
+    index = rbush()
+    index.load(points)
     return index
 
   _render: (ctx, indices, {sleft, sright, stop, sbottom}) ->

--- a/bokehjs/src/coffee/models/glyphs/quadratic.coffee
+++ b/bokehjs/src/coffee/models/glyphs/quadratic.coffee
@@ -23,8 +23,7 @@ _qbb = (u, v, w) ->
 export class QuadraticView extends GlyphView
 
   _index_data: () ->
-    index = rbush()
-    pts = []
+    points = []
     for i in [0...@_x0.length]
       if isNaN(@_x0[i] + @_x1[i] + @_y0[i] + @_y1[i] + @_cx[i] + @_cy[i])
         continue
@@ -32,9 +31,10 @@ export class QuadraticView extends GlyphView
       [x0, x1] = _qbb(@_x0[i], @_cx[i], @_x1[i])
       [y0, y1] = _qbb(@_y0[i], @_cy[i], @_y1[i])
 
-      pts.push({minX: x0, minY: y0, maxX: x1, maxY: y1, i: i})
+      points.push({minX: x0, minY: y0, maxX: x1, maxY: y1, i: i})
 
-    index.load(pts)
+    index = rbush()
+    index.load(points)
     return index
 
   _render: (ctx, indices, {sx0, sy0, sx1, sy1, scx, scy}) ->

--- a/bokehjs/src/coffee/models/glyphs/quadratic.coffee
+++ b/bokehjs/src/coffee/models/glyphs/quadratic.coffee
@@ -1,5 +1,4 @@
-import * as rbush from "rbush"
-
+import {RBush} from "../../core/util/spatial"
 import {Glyph, GlyphView} from "./glyph"
 
 # Formula from: http://pomax.nihongoresources.com/pages/bezier/
@@ -33,9 +32,7 @@ export class QuadraticView extends GlyphView
 
       points.push({minX: x0, minY: y0, maxX: x1, maxY: y1, i: i})
 
-    index = rbush()
-    index.load(points)
-    return index
+    return new RBush(points)
 
   _render: (ctx, indices, {sx0, sy0, sx1, sy1, scx, scy}) ->
     if @visuals.line.doit

--- a/bokehjs/src/coffee/models/glyphs/ray.coffee
+++ b/bokehjs/src/coffee/models/glyphs/ray.coffee
@@ -1,10 +1,7 @@
-import {Glyph, GlyphView} from "./glyph"
+import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import * as p from "../../core/properties"
 
-export class RayView extends GlyphView
-
-  _index_data: () ->
-    @_xy_index()
+export class RayView extends XYGlyphView
 
   _map_data: () ->
     @slength = @sdist(@renderer.xmapper, @_x, @_length)
@@ -39,12 +36,11 @@ export class RayView extends GlyphView
   draw_legend_for_index: (ctx, x0, x1, y0, y1, index) ->
     @_generic_line_legend(ctx, x0, x1, y0, y1, index)
 
-export class Ray extends Glyph
+export class Ray extends XYGlyph
   default_view: RayView
 
   type: 'Ray'
 
-  @coords [['x', 'y']]
   @mixins ['line']
   @define {
       length: [ p.DistanceSpec ]

--- a/bokehjs/src/coffee/models/glyphs/rect.coffee
+++ b/bokehjs/src/coffee/models/glyphs/rect.coffee
@@ -85,7 +85,7 @@ export class RectView extends XYGlyphView
     [y0, y1] = @renderer.ymapper.v_map_from_target([geometry.vy0, geometry.vy1], true)
     bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
     result = hittest.create_hit_test_result()
-    result['1d'].indices = (x.i for x in @index.search(bbox))
+    result['1d'].indices = @index.indices(bbox)
     return result
 
   _hit_point: (geometry) ->
@@ -107,7 +107,7 @@ export class RectView extends XYGlyphView
     hits = []
 
     bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-    for i in (pt.i for pt in @index.search(bbox))
+    for i in @index.indices(bbox)
       sx = @renderer.plot_view.canvas.vx_to_sx(vx)
       sy = @renderer.plot_view.canvas.vy_to_sy(vy)
 

--- a/bokehjs/src/coffee/models/glyphs/rect.coffee
+++ b/bokehjs/src/coffee/models/glyphs/rect.coffee
@@ -1,9 +1,9 @@
-import {Glyph, GlyphView} from "./glyph"
+import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import * as hittest from "../../core/hittest"
 import * as p from "../../core/properties"
 import {max} from "../../core/util/array"
 
-export class RectView extends GlyphView
+export class RectView extends XYGlyphView
 
   _set_data: () ->
     @max_w2 = 0
@@ -12,9 +12,6 @@ export class RectView extends GlyphView
     @max_h2 = 0
     if @model.properties.height.units == "data"
       @max_h2 = @max_height/2
-
-  _index_data: () ->
-    @_xy_index()
 
   _map_data: () ->
     if @model.properties.width.units == "data"
@@ -157,12 +154,11 @@ export class RectView extends GlyphView
   _bounds: (bds) ->
     return @max_wh2_bounds(bds)
 
-export class Rect extends Glyph
+export class Rect extends XYGlyph
   default_view: RectView
 
   type: 'Rect'
 
-  @coords [['x', 'y']]
   @mixins ['line', 'fill']
   @define {
       angle:  [ p.AngleSpec,   0     ]

--- a/bokehjs/src/coffee/models/glyphs/segment.coffee
+++ b/bokehjs/src/coffee/models/glyphs/segment.coffee
@@ -1,5 +1,4 @@
-import * as rbush from "rbush"
-
+import {RBush} from "../../core/util/spatial"
 import {Glyph, GlyphView} from "./glyph"
 
 export class SegmentView extends GlyphView
@@ -16,9 +15,7 @@ export class SegmentView extends GlyphView
           i: i
         })
 
-    index = rbush()
-    index.load(points)
-    return index
+    return new RBush(points)
 
   _render: (ctx, indices, {sx0, sy0, sx1, sy1}) ->
     if @visuals.line.doit

--- a/bokehjs/src/coffee/models/glyphs/segment.coffee
+++ b/bokehjs/src/coffee/models/glyphs/segment.coffee
@@ -5,18 +5,19 @@ import {Glyph, GlyphView} from "./glyph"
 export class SegmentView extends GlyphView
 
   _index_data: () ->
-    index = rbush()
-    pts = []
+    points = []
     for i in [0...@_x0.length]
       if not isNaN(@_x0[i] + @_x1[i] + @_y0[i] + @_y1[i])
-        pts.push({
+        points.push({
           minX: Math.min(@_x0[i], @_x1[i]),
           minY: Math.min(@_y0[i], @_y1[i]),
           maxX: Math.max(@_x0[i], @_x1[i]),
           maxY: Math.max(@_y0[i], @_y1[i]),
           i: i
         })
-    index.load(pts)
+
+    index = rbush()
+    index.load(points)
     return index
 
   _render: (ctx, indices, {sx0, sy0, sx1, sy1}) ->

--- a/bokehjs/src/coffee/models/glyphs/text.coffee
+++ b/bokehjs/src/coffee/models/glyphs/text.coffee
@@ -1,10 +1,7 @@
-import {Glyph, GlyphView} from "./glyph"
+import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import * as p from "../../core/properties"
 
-export class TextView extends GlyphView
-
-  _index_data: () ->
-    @_xy_index()
+export class TextView extends XYGlyphView
 
   _render: (ctx, indices, {sx, sy, _x_offset, _y_offset, _angle, _text}) ->
     for i in indices
@@ -31,12 +28,11 @@ export class TextView extends GlyphView
     ctx.fillText("text", x2, (y1+y2)/2)
     ctx.restore()
 
-export class Text extends Glyph
+export class Text extends XYGlyph
   default_view: TextView
 
   type: 'Text'
 
-  @coords [['x', 'y']]
   @mixins ['text']
   @define {
       text:     [ p.StringSpec, { field :"text" } ]

--- a/bokehjs/src/coffee/models/glyphs/vbar.coffee
+++ b/bokehjs/src/coffee/models/glyphs/vbar.coffee
@@ -1,4 +1,4 @@
-import * as rbush from "rbush"
+import {RBush} from "../../core/util/spatial"
 import * as Quad from "./quad"
 import {Glyph, GlyphView} from "./glyph"
 import {CategoricalMapper} from "../mappers/categorical_mapper"
@@ -46,9 +46,7 @@ export class VBarView extends GlyphView
         continue
       points.push({minX: l, minY: b, maxX: r, maxY: t, i: i})
 
-    index = rbush()
-    index.load(points)
-    return index
+    return new RBush(points)
 
   _render: (ctx, indices, {sleft, sright, stop, sbottom}) ->
     for i in indices
@@ -70,7 +68,7 @@ export class VBarView extends GlyphView
     x = @renderer.xmapper.map_from_target(vx, true)
     y = @renderer.ymapper.map_from_target(vy, true)
 
-    hits = (x.i for x in @index.search({minX: x, minY: y, maxX: x, maxY: y}))
+    hits = @index.indices({minX: x, minY: y, maxX: x, maxY: y})
 
     result = hittest.create_hit_test_result()
     result['1d'].indices = hits

--- a/bokehjs/src/coffee/models/glyphs/vbar.coffee
+++ b/bokehjs/src/coffee/models/glyphs/vbar.coffee
@@ -36,9 +36,7 @@ export class VBarView extends GlyphView
     top = map_to_synthetic(@renderer.ymapper, @_top)
     bottom = map_to_synthetic(@renderer.ymapper, @_bottom)
 
-    index = rbush()
-    pts = []
-
+    points = []
     for i in [0...x.length]
       l = x[i] - width[i]/2
       r = x[i] + width[i]/2
@@ -46,9 +44,10 @@ export class VBarView extends GlyphView
       b = bottom[i]
       if isNaN(l+r+t+b) or not isFinite(l+r+t+b)
         continue
-      pts.push({minX: l, minY: b, maxX: r, maxY: t, i: i})
+      points.push({minX: l, minY: b, maxX: r, maxY: t, i: i})
 
-    index.load(pts)
+    index = rbush()
+    index.load(points)
     return index
 
   _render: (ctx, indices, {sleft, sright, stop, sbottom}) ->

--- a/bokehjs/src/coffee/models/glyphs/wedge.coffee
+++ b/bokehjs/src/coffee/models/glyphs/wedge.coffee
@@ -55,7 +55,7 @@ export class WedgeView extends XYGlyphView
     candidates = []
 
     bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-    for i in (pt.i for pt in @index.search(bbox))
+    for i in @index.indices(bbox)
       r2 = Math.pow(@sradius[i], 2)
       sx0 = @renderer.xmapper.map_to_target(x, true)
       sx1 = @renderer.xmapper.map_to_target(@_x[i], true)

--- a/bokehjs/src/coffee/models/glyphs/wedge.coffee
+++ b/bokehjs/src/coffee/models/glyphs/wedge.coffee
@@ -1,12 +1,9 @@
-import {Glyph, GlyphView} from "./glyph"
+import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import * as hittest from "../../core/hittest"
 import * as p from "../../core/properties"
 import {angle_between} from "../../core/util/math"
 
-export class WedgeView extends GlyphView
-
-  _index_data: () ->
-    @_xy_index()
+export class WedgeView extends XYGlyphView
 
   _map_data: () ->
     if @model.properties.radius.units == "data"
@@ -83,12 +80,11 @@ export class WedgeView extends GlyphView
   draw_legend_for_index: (ctx, x0, x1, y0, y1, index) ->
     @_generic_area_legend(ctx, x0, x1, y0, y1, index)
 
-export class Wedge extends Glyph
+export class Wedge extends XYGlyph
   default_view: WedgeView
 
   type: 'Wedge'
 
-  @coords [['x', 'y']]
   @mixins ['line', 'fill']
   @define {
       direction:    [ p.Direction,   'anticlock' ]

--- a/bokehjs/src/coffee/models/glyphs/xy_glyph.coffee
+++ b/bokehjs/src/coffee/models/glyphs/xy_glyph.coffee
@@ -6,9 +6,6 @@ import {CategoricalMapper} from "../mappers/categorical_mapper"
 export class XYGlyphView extends GlyphView
 
   _index_data: () ->
-    index = rbush()
-    pts = []
-
     # if the range is categorical, map to synthetic coordinates first
     if @renderer.xmapper instanceof CategoricalMapper
       xx = @renderer.xmapper.v_map_to_target(@_x, true)
@@ -19,6 +16,7 @@ export class XYGlyphView extends GlyphView
     else
       yy = @_y
 
+    points = []
     for i in [0...xx.length]
       x = xx[i]
       if isNaN(x) or not isFinite(x)
@@ -26,9 +24,10 @@ export class XYGlyphView extends GlyphView
       y = yy[i]
       if isNaN(y) or not isFinite(y)
         continue
-      pts.push({minX: x, minY: y, maxX: x, maxY: y, i: i})
+      points.push({minX: x, minY: y, maxX: x, maxY: y, i: i})
 
-    index.load(pts)
+    index = rbush()
+    index.load(points)
     return index
 
 export class XYGlyph extends Glyph

--- a/bokehjs/src/coffee/models/glyphs/xy_glyph.coffee
+++ b/bokehjs/src/coffee/models/glyphs/xy_glyph.coffee
@@ -1,0 +1,38 @@
+import * as rbush from "rbush"
+
+import {Glyph, GlyphView} from "./glyph"
+import {CategoricalMapper} from "../mappers/categorical_mapper"
+
+export class XYGlyphView extends GlyphView
+
+  _index_data: () ->
+    index = rbush()
+    pts = []
+
+    # if the range is categorical, map to synthetic coordinates first
+    if @renderer.xmapper instanceof CategoricalMapper
+      xx = @renderer.xmapper.v_map_to_target(@_x, true)
+    else
+      xx = @_x
+    if @renderer.ymapper instanceof CategoricalMapper
+      yy = @renderer.ymapper.v_map_to_target(@_y, true)
+    else
+      yy = @_y
+
+    for i in [0...xx.length]
+      x = xx[i]
+      if isNaN(x) or not isFinite(x)
+        continue
+      y = yy[i]
+      if isNaN(y) or not isFinite(y)
+        continue
+      pts.push({minX: x, minY: y, maxX: x, maxY: y, i: i})
+
+    index.load(pts)
+    return index
+
+export class XYGlyph extends Glyph
+  type: "XYGlyph"
+  default_view: XYGlyphView
+
+  @coords [['x', 'y']]

--- a/bokehjs/src/coffee/models/glyphs/xy_glyph.coffee
+++ b/bokehjs/src/coffee/models/glyphs/xy_glyph.coffee
@@ -1,5 +1,4 @@
-import * as rbush from "rbush"
-
+import {RBush} from "../../core/util/spatial"
 import {Glyph, GlyphView} from "./glyph"
 import {CategoricalMapper} from "../mappers/categorical_mapper"
 
@@ -26,9 +25,7 @@ export class XYGlyphView extends GlyphView
         continue
       points.push({minX: x, minY: y, maxX: x, maxY: y, i: i})
 
-    index = rbush()
-    index.load(points)
-    return index
+    return new RBush(points)
 
 export class XYGlyph extends Glyph
   type: "XYGlyph"

--- a/bokehjs/src/coffee/models/markers/marker.coffee
+++ b/bokehjs/src/coffee/models/markers/marker.coffee
@@ -54,7 +54,7 @@ export class MarkerView extends XYGlyphView
     [y0, y1] = @renderer.ymapper.v_map_from_target([vy0, vy1], true)
 
     bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-    return (x.i for x in @index.search(bbox))
+    return @index.indices(bbox)
 
   _hit_point: (geometry) ->
     [vx, vy] = [geometry.vx, geometry.vy]
@@ -70,7 +70,7 @@ export class MarkerView extends XYGlyphView
     [y0, y1] = @renderer.ymapper.v_map_from_target([vy0, vy1], true)
 
     bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-    candidates = (x.i for x in @index.search(bbox))
+    candidates = @index.indices(bbox)
 
     hits = []
     for i in candidates
@@ -85,7 +85,7 @@ export class MarkerView extends XYGlyphView
     [y0, y1] = @renderer.ymapper.v_map_from_target([geometry.vy0, geometry.vy1], true)
     bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
     result = hittest.create_hit_test_result()
-    result['1d'].indices = (x.i for x in @index.search(bbox))
+    result['1d'].indices = @index.indices(bbox)
     return result
 
   _hit_poly: (geometry) ->

--- a/bokehjs/src/coffee/models/markers/marker.coffee
+++ b/bokehjs/src/coffee/models/markers/marker.coffee
@@ -1,8 +1,8 @@
-import {Glyph, GlyphView} from "../glyphs/glyph"
+import {XYGlyph, XYGlyphView} from "../glyphs/xy_glyph"
 import * as hittest from "../../core/hittest"
 import * as p from "../../core/properties"
 
-export class MarkerView extends GlyphView
+export class MarkerView extends XYGlyphView
 
   draw_legend_for_index: (ctx, x0, x1, y0, y1, index) ->
     # using objects like this seems a little wonky, since the keys are coerced to
@@ -39,9 +39,6 @@ export class MarkerView extends GlyphView
         ctx.rotate(-_angle[i])
 
       ctx.translate(-sx[i], -sy[i])
-
-  _index_data: () ->
-    @_xy_index()
 
   _mask_data: (all_indices) ->
     # dilate the inner screen region by max_size and map back to data space for use in
@@ -108,9 +105,8 @@ export class MarkerView extends GlyphView
     result['1d'].indices = hits
     return result
 
-export class Marker extends Glyph
+export class Marker extends XYGlyph
 
-  @coords [ ['x', 'y'] ]
   @mixins ['line', 'fill']
   @define {
     size:  [ p.DistanceSpec, { units: "screen", value: 4 } ]

--- a/examples/custom/gears/gear.coffee
+++ b/examples/custom/gears/gear.coffee
@@ -1,14 +1,11 @@
 import * as p from "core/properties"
 import {isString} from "core/util/types"
-import {Glyph, GlyphView} from "models/glyphs/glyph"
+import {XYGlyph, XYGlyphView} from "models/glyphs/xy_glyph"
 
 import {arc_to_bezier} from "./bezier"
 import * as gear_utils from "./gear_utils"
 
-export class GearView extends GlyphView
-
-  _index_data: () ->
-    return @_xy_index()
+export class GearView extends XYGlyphView
 
   _map_data: () ->
     @smodule = @sdist(@renderer.xmapper, @_x, @_module, 'edge')
@@ -114,12 +111,10 @@ export class GearView extends GlyphView
   draw_legend_for_index: (ctx, x0, x1, y0, y1, index) ->
     @_generic_area_legend(ctx, x0, x1, y0, y1, index)
 
-export class Gear extends Glyph
+export class Gear extends XYGlyph
+  type: 'Gear'
   default_view: GearView
 
-  type: 'Gear'
-
-  @coords [['x', 'y']]
   @mixins ['line', 'fill']
   @define {
     angle:          [ p.AngleSpec,  0     ]


### PR DESCRIPTION
Originally this was supposed to fix issue #5783, but as kdbush doesn't support rectangles, it cannot be universally used, just as an optimization for point search, but a cleanup and addition of an abstraction layer is still useful. This can be used to add support for kdbush in fugure.