### PR TITLE
improve the helpstring for CDS selected property

### DIFF
--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -25,21 +25,29 @@ class DataSource(Model):
     }, help="""
     A dict to indicate selected indices on different dimensions on this DataSource. Keys are:
 
-    - 0d: indicates whether a Line or Patch glyphs have been hit. Value is a
-            dict with the following keys:
+    .. code-block:: python
 
-            - flag (boolean): true if glyph was with false otherwise
-            - indices (list): indices hit (if applicable)
+        # selection information for line and patch glyphs
+        '0d' : {
+          # the glyph that was selected
+          'glyph': None
 
-    - 1d: indicates whether any of all other glyph (except [multi]line or
-            patches) was hit:
+          # array with the [smallest] index of the segment of the line that was hit
+          'indices': []
+        }
 
-            - indices (list): indices that were hit/selected
+        # selection for most (point-like) glyphs, except lines and patches
+        '1d': {
+          # indices of the points included in the selection
+          indices: []
+        }
 
-    - 2d: indicates whether a [multi]line or patches) were hit:
+        # selection information for multiline and patches glyphs
+        '2d': {
+          # mapping of indices of the multiglyph to array of glyph indices that were hit
+          # e.g. {3: [5, 6], 4, [5]}
+        }
 
-            - indices (list(list)): indices of the lines/patches that were
-                hit/selected
     """)
 
     callback = Instance(Callback, help="""


### PR DESCRIPTION
fixes #5718

New section renders like this:

<img width="738" alt="screen shot 2017-01-28 at 11 03 55 am" src="https://cloud.githubusercontent.com/assets/1078448/22398218/82afd996-e549-11e6-8bce-32a961dcc2e6.png">

@birdsarah is this reasonable, is there anything else to add?