### PR TITLE
Allow configuring server to provide relative URLS for resources

### DIFF
--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -99,44 +99,6 @@ Similarly, a specific network address can be specified with the
 
 will have the Bokeh server listen all available network addresses.
 
-Additionally, it is possible to configure a hosts whitelist that must be
-matched by the ``Host`` header in new requests. You can specify multiple
-acceptable host values with the ``--host`` option:
-
-.. code-block:: sh
-
-    bokeh serve app_script.py --host foo.com:8081 --host bar.com
-
-If no port is specified in a host value, then port 80 will be used. In
-the example above Bokeh server will accept requests from ``foo.com:8081``
-and ``bar.com:80``.
-
-If no host values are specified, then by default the Bokeh server will
-accept requests from ``localhost:<port>`` where ``<port>`` is the port
-that the server is configured to listen on (by default: {DEFAULT_PORT}).
-
-If an asterix ``*`` is used in the host value then it will be treated as a
-wildcard:
-
-.. code-block:: sh
-
-    bokeh serve app_script.py --address 0.0.0.0 --host '*'
-
-Using the wildcard can be helpful when testing applications that are deployed
-with cloud orchestration tools and when the public endpoint is not known ahead
-of time: for instance if the public IP is dynamically allocated during the
-deployment process and no public DNS has been configured for the testing
-environment.
-
-As a warning, using permissive host values like ``*`` may be insecure and open
-your application to HTTP host header attacks. Production deployments should
-always set the ``--host`` flag to use the DNS name of the public endpoint such
-as a TLS-enabled load balancer or reverse proxy that serves the application to
-the end users.
-
-Also note that the host whitelist applies to all request handlers,
-including any extra ones added to extend the Bokeh server.
-
 Bokeh server can fork the underlying tornado server into multiprocess.  This is
 useful when trying to handle multiple connections especially in the context of
 apps which require high computational loads.  Default behavior is one process.
@@ -324,6 +286,7 @@ import logging
 log = logging.getLogger(__name__)
 
 import argparse
+import warnings
 
 from bokeh.application import Application
 from bokeh.resources import DEFAULT_SERVER_PORT
@@ -416,7 +379,7 @@ class Serve(Subcommand):
             metavar='HOST[:PORT]',
             action='append',
             type=str,
-            help="Public hostnames to allow in requests",
+            help="*** IGNORED, NO LONGER USED OR NECESSARY ***",
         )),
 
         ('--prefix', dict(
@@ -495,6 +458,9 @@ class Serve(Subcommand):
         log_level = getattr(logging, args.log_level.upper())
         logging.basicConfig(level=log_level, format=args.log_format)
 
+        if args.host is not None and len(args.host) > 0:
+            warnings.warn("The --hosts parameter is no longer needed or necessary and is ignored. It will be removed and trigger an error in a future release")
+
         if len(applications) == 0:
             # create an empty application by default, typically used with output_server
             applications['/'] = Application()
@@ -525,14 +491,13 @@ class Serve(Subcommand):
         server_kwargs = { key: getattr(args, key) for key in ['port',
                                                               'address',
                                                               'allow_websocket_origin',
-                                                              'host',
                                                               'num_procs',
                                                               'prefix',
                                                               'keep_alive_milliseconds',
                                                               'check_unused_sessions_milliseconds',
                                                               'unused_session_lifetime_milliseconds',
                                                               'stats_log_frequency_milliseconds',
-                                                              'use_xheaders'
+                                                              'use_xheaders',
                                                             ]
                           if getattr(args, key, None) is not None }
 

--- a/bokeh/command/subcommands/tests/test_serve.py
+++ b/bokeh/command/subcommands/tests/test_serve.py
@@ -94,7 +94,7 @@ def test_args():
             metavar='HOST[:PORT]',
             action='append',
             type=str,
-            help="Public hostnames to allow in requests",
+            help="*** IGNORED, NO LONGER USED OR NECESSARY ***",
         )),
 
         ('--prefix', dict(

--- a/bokeh/core/_templates/autoload_js.js
+++ b/bokeh/core/_templates/autoload_js.js
@@ -8,15 +8,6 @@ calls it with the rendered model.
 :param elementid: the unique id for the script tag
 :type elementid: str
 
-:param websocket_url: path to use to open websocket, or null if we are not using a server
-:type websocket_url: str
-
-:param sessionid: The id of the Bokeh server session to get a document from
-:type sessionid: str
-
-:param docs_json: embedded JSON serialization of documents
-:type docs_json: dict
-
 :param js_urls: URLs of JS files making up Bokeh library
 :type js_urls: list
 

--- a/bokeh/core/_templates/doc_js.js
+++ b/bokeh/core/_templates/doc_js.js
@@ -1,4 +1,4 @@
 var docs_json = {{ docs_json }};
 var render_items = {{ render_items }};
 
-Bokeh.embed.embed_items(docs_json, render_items{%- if websocket_url -%}, "{{ websocket_url }}" {%- endif -%});
+Bokeh.embed.embed_items(docs_json, render_items);

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -136,7 +136,7 @@ def components(models, wrap_script=True, wrap_plot_info=True):
     with _ModelInDocument(models):
         (docs_json, render_items) = _standalone_docs_json_and_render_items(models)
 
-    script = _script_for_render_items(docs_json, render_items, websocket_url=None, wrap_script=wrap_script)
+    script = _script_for_render_items(docs_json, render_items, wrap_script=wrap_script)
     script = encode_utf8(script)
 
     if wrap_plot_info:
@@ -439,9 +439,8 @@ def autoload_server(model, app_path="/", session_id=None, url="default"):
 
     return encode_utf8(tag)
 
-def _script_for_render_items(docs_json, render_items, websocket_url=None, wrap_script=True):
+def _script_for_render_items(docs_json, render_items, wrap_script=True):
     plot_js = _wrap_in_onload(_wrap_in_safely(DOC_JS.render(
-        websocket_url=websocket_url,
         docs_json=serialize_json(docs_json),
         render_items=serialize_json(render_items),
     )))
@@ -451,14 +450,14 @@ def _script_for_render_items(docs_json, render_items, websocket_url=None, wrap_s
     else:
         return plot_js
 
-def _html_page_for_render_items(bundle, docs_json, render_items, title, websocket_url=None,
+def _html_page_for_render_items(bundle, docs_json, render_items, title,
                                 template=FILE, template_variables={}):
     if title is None:
         title = DEFAULT_TITLE
 
     bokeh_js, bokeh_css = bundle
 
-    script = _script_for_render_items(docs_json, render_items, websocket_url)
+    script = _script_for_render_items(docs_json, render_items)
 
     template_variables_full = template_variables.copy()
 
@@ -591,7 +590,7 @@ def standalone_html_page_for_models(models, resources, title):
     '''
     return file_html(models, resources, title)
 
-def server_html_page_for_models(session_id, model_ids, resources, title, websocket_url, template=FILE):
+def server_html_page_for_models(session_id, model_ids, resources, title, template=FILE):
     render_items = []
     for modelid in model_ids:
         if modelid is None:
@@ -606,10 +605,9 @@ def server_html_page_for_models(session_id, model_ids, resources, title, websock
             })
 
     bundle = _bundle_for_objs_and_resources(None, resources)
-    return _html_page_for_render_items(bundle, {}, render_items, title, template=template, websocket_url=websocket_url)
+    return _html_page_for_render_items(bundle, {}, render_items, title, template=template)
 
-def server_html_page_for_session(session_id, resources, title, websocket_url, template=FILE,
-                                 template_variables=None):
+def server_html_page_for_session(session_id, resources, title, template=FILE, template_variables=None):
     elementid = make_id()
     render_items = [{
         'sessionid' : session_id,
@@ -622,5 +620,4 @@ def server_html_page_for_session(session_id, resources, title, websocket_url, te
         template_variables = {}
 
     bundle = _bundle_for_objs_and_resources(None, resources)
-    return _html_page_for_render_items(bundle, {}, render_items, title, template=template,
-            websocket_url=websocket_url, template_variables=template_variables)
+    return _html_page_for_render_items(bundle, dict(), render_items, title, template=template, template_variables=template_variables)

--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -34,30 +34,6 @@ DEFAULT_SERVER_HOST = "localhost"
 DEFAULT_SERVER_PORT = 5006
 DEFAULT_SERVER_HTTP_URL = "http://%s:%d/" % (DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT)
 
-def websocket_url_for_server_url(url):
-    if url.startswith("http:"):
-        reprotocoled = "ws" + url[4:]
-    elif url.startswith("https:"):
-        reprotocoled = "wss" + url[5:]
-    else:
-        raise ValueError("URL has unknown protocol " + url)
-    if reprotocoled.endswith("/"):
-        return reprotocoled + "ws"
-    else:
-        return reprotocoled + "/ws"
-
-
-def server_url_for_websocket_url(url):
-    if url.startswith("ws:"):
-        reprotocoled = "http" + url[2:]
-    elif url.startswith("wss:"):
-        reprotocoled = "https" + url[3:]
-    else:
-        raise ValueError("URL has non-websocket protocol " + url)
-    if not reprotocoled.endswith("/ws"):
-        raise ValueError("websocket URL does not end in /ws")
-    return reprotocoled[:-2]
-
 class _SessionCoordinates(object):
     """ Internal class used to parse kwargs for server URL, app_path, and session_id."""
     def __init__(self, kwargs):
@@ -95,11 +71,6 @@ class _SessionCoordinates(object):
             self._server_url = self._base_url + self._app_path[1:]
 
     @property
-    def websocket_url(self):
-        """ Websocket URL derived from the kwargs provided."""
-        return websocket_url_for_server_url(self._server_url)
-
-    @property
     def server_url(self):
         """ Server URL including app path derived from the kwargs provided."""
         return self._server_url
@@ -130,10 +101,7 @@ class _SessionCoordinates(object):
         """ App path derived from the kwargs provided."""
         return self._app_path
 
-DEFAULT_SERVER_WEBSOCKET_URL = websocket_url_for_server_url(DEFAULT_SERVER_HTTP_URL)
-
 _DEV_PAT = re.compile(r"^(\d)+\.(\d)+\.(\d)+(dev|rc)")
-
 
 def _cdn_base_url():
     return "https://cdn.pydata.org"
@@ -254,7 +222,7 @@ class BaseResources(object):
 
     @property
     def root_url(self):
-        if self._root_url:
+        if self._root_url is not None:
             return self._root_url
         else:
             return self._default_root_url
@@ -325,7 +293,7 @@ class JSResources(BaseResources):
     ''' The Resources class encapsulates information relating to loading or embedding Bokeh Javascript.
 
     Args:
-        mode (str) : how should Bokeh JS be included in output
+        mode (str) : How should Bokeh JS be included in output
 
             See below for descriptions of available modes
 
@@ -339,7 +307,13 @@ class JSResources(BaseResources):
 
         minified (bool, optional) : whether JavaScript should be minified or not (default: True)
 
-        root_url (str, optional) : URL and port of Bokeh Server to load resources from
+        root_url (str, optional) : URL and port of Bokeh Server to load resources from (default: None)
+
+            If ``None``, absoute URLs based on the default server configuration will
+            be generated.
+
+            ``root_url`` can also be the empty string, in which case relative URLs,
+            e.g., "static/css/bokeh.min.js", are generated.
 
             Only valid with ``'server'`` and ``'server-dev'`` modes
 

--- a/bokeh/server/server.py
+++ b/bokeh/server/server.py
@@ -95,7 +95,8 @@ class Server(object):
                                                         'keep_alive_milliseconds',
                                                         'check_unused_sessions_milliseconds',
                                                         'unused_session_lifetime_milliseconds',
-                                                        'stats_log_frequency_milliseconds']
+                                                        'stats_log_frequency_milliseconds',
+                                                        ]
                            if key in kwargs }
 
         prefix = kwargs.get('prefix')
@@ -120,7 +121,6 @@ class Server(object):
 
         sockets, self._port = _bind_sockets(self._address, port)
         try:
-            tornado_kwargs['hosts'] = _create_hosts_whitelist(kwargs.get('host'), self._port)
             tornado_kwargs['extra_websocket_origins'] = _create_hosts_whitelist(kwargs.get('allow_websocket_origin'), self._port)
             tornado_kwargs['use_index'] = kwargs.get('use_index', True)
             tornado_kwargs['redirect_root'] = kwargs.get('redirect_root', True)

--- a/bokeh/server/tests/test_tornado.py
+++ b/bokeh/server/tests/test_tornado.py
@@ -11,23 +11,6 @@ from .utils import ManagedServerLoop, url
 
 logging.basicConfig(level=logging.DEBUG)
 
-class _Handler(object):
-    def prepare(self, *args, **kw): pass
-
-def test__whitelist_replaces_prepare():
-    h = _Handler()
-    old_prepare = h.prepare
-    tornado._whitelist(h)
-    assert h.prepare != old_prepare
-    assert hasattr(h.prepare, 'patched')
-
-def test__whitelist_replaces_prepare_only_once():
-    h = _Handler()
-    tornado._whitelist(h)
-    new_prepare = h.prepare
-    tornado._whitelist(h)
-    assert h.prepare == new_prepare
-
 def test_check_whitelist_rejects_port_mismatch():
     assert False == tornado.check_whitelist("foo:100", ["foo:101", "foo:102"])
 

--- a/bokeh/server/tests/utils.py
+++ b/bokeh/server/tests/utils.py
@@ -11,7 +11,7 @@ def url(server, prefix=""):
 def ws_url(server, prefix=""):
     return "ws://localhost:" + str(server.port) + prefix + "/ws"
 
-def http_get(io_loop, url, host=None):
+def http_get(io_loop, url):
     result = {}
     def handle_request(response):
         result['response'] = response
@@ -21,8 +21,6 @@ def http_get(io_loop, url, host=None):
     assert io_loop is IOLoop.current()
     http_client = AsyncHTTPClient()
     headers = dict()
-    if host is not None:
-        headers['Host'] = host
     http_client.fetch(url, handle_request, headers=headers)
     io_loop.start()
 
@@ -34,7 +32,7 @@ def http_get(io_loop, url, host=None):
     else:
         return response
 
-def websocket_open(io_loop, url, origin=None, host=None):
+def websocket_open(io_loop, url, origin=None):
     result = {}
     def handle_connection(future):
         result['connection'] = future
@@ -43,8 +41,6 @@ def websocket_open(io_loop, url, origin=None, host=None):
     request = HTTPRequest(url)
     if origin is not None:
         request.headers['Origin'] = origin
-    if host is not None:
-        request.headers['Host'] = host
     websocket_connect(request, callback=handle_connection, io_loop=io_loop)
 
     io_loop.start()

--- a/bokeh/server/views/autoload_js_handler.py
+++ b/bokeh/server/views/autoload_js_handler.py
@@ -33,12 +33,11 @@ class AutoloadJsHandler(SessionHandler):
             self.send_error(status_code=400, reason='No bokeh-autoload-element query parameter')
             return
 
-        resources = self.application.resources(self.request)
-        websocket_url = self.application.websocket_url_for_request(self.request, self.bokeh_websocket_path)
+        resources = self.application.resources()
 
         # TODO: yes, this should resuse code from bokeh.embed more directly
         render_items = [dict(sessionid=session.id, elementid=element_id, use_for_title=False)]
-        script = _script_for_render_items(None, render_items, websocket_url=websocket_url, wrap_script=False)
+        script = _script_for_render_items(None, render_items, wrap_script=False)
 
         js = AUTOLOAD_JS.render(
             js_urls = resources.js_files,

--- a/bokeh/server/views/doc_handler.py
+++ b/bokeh/server/views/doc_handler.py
@@ -26,11 +26,9 @@ class DocHandler(SessionHandler):
     def get(self, *args, **kwargs):
         session = yield self.get_session()
 
-        websocket_url = self.application.websocket_url_for_request(self.request, self.bokeh_websocket_path)
-        page = server_html_page_for_session(session.id, self.application.resources(self.request),
+        page = server_html_page_for_session(session.id, self.application.resources(),
                                             title=session.document.title,
                                             template=session.document.template,
-                                            websocket_url=websocket_url,
                                             template_variables=session.document.template_variables)
 
         self.set_header("Content-Type", 'text/html')

--- a/bokeh/tests/test_resources.py
+++ b/bokeh/tests/test_resources.py
@@ -6,7 +6,7 @@ import os
 
 import bokeh.resources as resources
 from bokeh.models import Model
-from bokeh.resources import _get_cdn_urls, websocket_url_for_server_url
+from bokeh.resources import _get_cdn_urls
 
 # if BOKEH_RESOURCES is set many tests in this file fail
 if os.environ.get("BOKEH_RESOURCES"):
@@ -52,17 +52,6 @@ def test_inline_css_resources():
 
 
 class TestResources(unittest.TestCase):
-
-    def test_websocket_url(self):
-        self.assertEqual("ws://example.com:4000/ws", websocket_url_for_server_url("http://example.com:4000"))
-        # with trailing / on original url
-        self.assertEqual("ws://example.com:4000/ws", websocket_url_for_server_url("http://example.com:4000/"))
-        # with https
-        self.assertEqual("wss://example.com:4000/ws", websocket_url_for_server_url("https://example.com:4000"))
-        # with a path
-        self.assertEqual("wss://example.com:4000/bar/ws", websocket_url_for_server_url("https://example.com:4000/bar"))
-        # with path with trailing slash
-        self.assertEqual("wss://example.com:4000/bar/ws", websocket_url_for_server_url("https://example.com:4000/bar/"))
 
     def test_basic(self):
         r = resources.Resources()
@@ -114,7 +103,7 @@ class TestResources(unittest.TestCase):
             'type': 'warn'}
         ])
 
-    def test_server(self):
+    def test_server_default(self):
         r = resources.Resources(mode="server")
         self.assertEqual(r.mode, "server")
         self.assertEqual(r.dev, False)
@@ -122,12 +111,33 @@ class TestResources(unittest.TestCase):
         self.assertEqual(r.js_raw, [DEFAULT_LOG_JS_RAW])
         self.assertEqual(r.css_raw, [])
         self.assertEqual(r.messages, [])
+        self.assertEqual(r.js_files, ['http://localhost:5006/static/js/bokeh.min.js',
+                                      'http://localhost:5006/static/js/bokeh-widgets.min.js'])
+        self.assertEqual(r.css_files, ['http://localhost:5006/static/css/bokeh.min.css',
+                                       'http://localhost:5006/static/css/bokeh-widgets.min.css'])
 
+    def test_server_root_url(self):
         r = resources.Resources(mode="server", root_url="http://foo/")
 
         self.assertEqual(r.js_raw, [DEFAULT_LOG_JS_RAW])
         self.assertEqual(r.css_raw, [])
         self.assertEqual(r.messages, [])
+        self.assertEqual(r.js_files, ['http://foo/static/js/bokeh.min.js',
+                                      'http://foo/static/js/bokeh-widgets.min.js'])
+        self.assertEqual(r.css_files, ['http://foo/static/css/bokeh.min.css',
+                                       'http://foo/static/css/bokeh-widgets.min.css'])
+
+    def test_server_root_url_empty(self):
+        r = resources.Resources(mode="server", root_url="")
+
+        self.assertEqual(r.js_raw, [DEFAULT_LOG_JS_RAW])
+        self.assertEqual(r.css_raw, [])
+        self.assertEqual(r.messages, [])
+        self.assertEqual(r.js_files, ['static/js/bokeh.min.js',
+                                      'static/js/bokeh-widgets.min.js'])
+        self.assertEqual(r.css_files, ['static/css/bokeh.min.css',
+                                       'static/css/bokeh-widgets.min.css'])
+
 
     def test_server_with_versioner(self):
         def versioner(path):

--- a/bokehjs/src/coffee/embed.coffee
+++ b/bokehjs/src/coffee/embed.coffee
@@ -158,7 +158,13 @@ fill_render_item_from_script_tag = (script, item) ->
 
   logger.info("Will inject Bokeh script tag with params #{JSON.stringify(item)}")
 
-export embed_items = (docs_json, render_items, websocket_url=null) ->
+export embed_items = (docs_json, render_items) ->
+  protocol = 'ws:'
+  if (window.location.protocol == 'https:')
+    protocol = 'wss:'
+  ws_pathname = window.location.pathname.replace(/\/+$/, '') + '/ws'
+  websocket_url = protocol + '//' + window.location.host + ws_pathname
+
   docs = {}
   for docid of docs_json
     docs[docid] = Document.from_json(docs_json[docid])

--- a/scripts/tests/test_api_report.py
+++ b/scripts/tests/test_api_report.py
@@ -5,7 +5,7 @@ import pytest
 from ..api_report import diff_versions
 
 
-@pytest.mark.api_test
+@pytest.mark.skip(reason="version checkouts currently too disruptive")
 def test_working_pipeline():
     first = diff_versions("0.11.0", "0.12.0").split("\n")
     with open("scripts/tests/samples/sample_diff.txt") as f:

--- a/sphinx/source/docs/releases/0.12.5.rst
+++ b/sphinx/source/docs/releases/0.12.5.rst
@@ -70,9 +70,9 @@ The ``--host`` parameter for the Bokeh server was confusing and difficult to
 explain. As long as the Bokeh server relied on the HTTP "host" header to
 provide URLs to resources, the ``--host`` parameter was a necessary precaution
 against certain kinds of HTTP spoofing attacks. However, the Bokeh server
-has be updated to no longer require the use of the "host" header (and this is
-now maintained under test). Accordingly, there is no need to have any checks
-on the value of the "host" header, and ``--host`` is no longer needed.
+has been updated to no longer require the use of the "host" header (and this
+is maintained under test). Accordingly, there is no need to have any check
+on the value of the "host" header, and so ``--host`` is no longer needed.
 
 Document and Model Refactoring
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/sphinx/source/docs/releases/0.12.5.rst
+++ b/sphinx/source/docs/releases/0.12.5.rst
@@ -59,6 +59,21 @@ removed, as well as the following properties of ``Plot``
 * ``title_text_font``
 * ``title_text_font_size``
 
+Host Parameter Obsoleted
+~~~~~~~~~~~~~~~~~~~~~~~~
+The ``--host`` parameter is now unnecessary. For compatibility, supplying
+it will currently cause a warning to be displayed, but it will otherwise
+be ignored, and apps will run as normal. In a future release, supplying it
+will result in an error.
+
+The ``--host`` parameter for the Bokeh server was confusing and difficult to
+explain. As long as the Bokeh server relied on the HTTP "host" header to
+provide URLs to resources, the ``--host`` parameter was a necessary precaution
+against certain kinds of HTTP spoofing attacks. However, the Bokeh server
+has be updated to no longer require the use of the "host" header (and this is
+now maintained under test). Accordingly, there is no need to have any checks
+on the value of the "host" header, and ``--host`` is no longer needed.
+
 Document and Model Refactoring
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -283,7 +283,8 @@ The optional components are
 
 * A ``templates`` subdirectory with ``index.html`` Jinja template file. The directory may contain additional Jinja templates for ``index.html`` to refer to. The template should have the same parameters as the :class:`~bokeh.core.templates.FILE` template.
 
-Custom variables can be passed to the template via the ``curdoc().template_variables`` dictionary in place:
+Custom variables can be passed to the template via the
+``curdoc().template_variables`` dictionary in place:
 
 .. code-block:: python
 
@@ -391,7 +392,8 @@ JavaScript Callbacks in the Browser
 
 Regardless of whether there is a Bokeh Server involved, it is possible to
 create callbacks that execute in the browser, using ``CustomJS`` and other
-methods. See :ref:`userguide_interaction_actions` for more detailed information and examples.
+methods. See :ref:`userguide_interaction_actions` for more detailed
+information and examples.
 
 It is critical to note that **no python code is ever executed when a CustomJS
 callback is used**. This is true even when the call back is supplied as python
@@ -781,7 +783,8 @@ Standalone Bokeh Server
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 First, it is possible to simply run the Bokeh server on a network for users
-to interact with directly. Depending on the computational burden of your application code, the number of users, the power of the machine used to run
+to interact with directly. Depending on the computational burden of your
+application code, the number of users, the power of the machine used to run
 on, etc., this could be a simple and immediate option for deployment an
 internal network.
 
@@ -793,9 +796,12 @@ these considerations.
 SSH Tunnels
 '''''''''''
 
-It may be convenient or necessary to run a standalone instance of the Bokeh server on a host to which direct access cannot be allowed. In such cases, ssh can be used to "tunnel" to the server.
+It may be convenient or necessary to run a standalone instance of the Bokeh
+server on a host to which direct access cannot be allowed. In such cases, SSH
+can be used to "tunnel" to the server.
 
-In the simplest scenario, the Bokeh server will run on one host and will be accessed from another location, e.g., a laptop, with no intermediary machines.
+In the simplest scenario, the Bokeh server will run on one host and will be
+accessed from another location, e.g., a laptop, with no intermediary machines.
 
 Run the server as usual on the **remote host**:
 
@@ -803,32 +809,49 @@ Run the server as usual on the **remote host**:
 
     bokeh server
 
-Next, issue the following command on the **local machine** to establish an ssh tunnel to the remote host:
+Next, issue the following command on the **local machine** to establish an SSH
+tunnel to the remote host:
 
 .. code-block:: sh
 
-    ssh -NfL localhost:5006:localhost:5006  user@remote.host
+    ssh -NfL localhost:5006:localhost:5006 user@remote.host
 
-Replace *user* with your username on the remote host and *remote.host* with the hostname/IP address of the system hosting the Bokeh server. You may be prompted for login credentials for the remote system. After the connection is set up you will be able to navigate to ``localhost:5006`` as though the Bokeh server were running on the local machine.
+Replace *user* with your username on the remote host and *remote.host* with
+the hostname/IP address of the system hosting the Bokeh server. You may be
+prompted for login credentials for the remote system. After the connection
+is set up you will be able to navigate to ``localhost:5006`` as though the
+Bokeh server were running on the local machine.
 
-The second, slightly more complicated case occurs when there is a gateway between the server and the local machine.  In that situation a reverse tunnel must be estabished from the server to the gateway. Additionally the tunnel from the local machine will also point to the gateway.
+The second, slightly more complicated case occurs when there is a gateway
+between the server and the local machine.  In that situation a reverse tunnel
+must be estabished from the server to the gateway. Additionally the tunnel
+from the local machine will also point to the gateway.
 
-Issue the following commands on the **remote host** where the Bokeh server will run:
+Issue the following commands on the **remote host** where the Bokeh server
+will run:
 
 .. code-block:: sh
 
     nohup bokeh server &
     ssh -NfR 5006:localhost:5006 user@gateway.host
 
-Replace *user* with your username on the gateway and *gateway.host* with the hostname/IP address of the gateway. You may be prompted for login credentials for the gateway.
+Replace *user* with your username on the gateway and *gateway.host* with the
+hostname/IP address of the gateway. You may be prompted for login credentials
+for the gateway.
 
-Now set up the other half of the tunnel, from the local machine to the gateway. On the **local machine**:
+Now set up the other half of the tunnel, from the local machine to the
+gateway. On the **local machine**:
 
 .. code-block:: sh
 
     ssh -NfL localhost:5006:localhost:5006 user@gateway.host
 
-Again, replace *user* with your username on the gateway and *gateway.host* with the hostname/IP address of the gateway. You should now be able to access the Bokeh server from the local machine by navigating to ``localhost:5006`` on the local machine, as if the Bokeh server were running on the local machine. You can even set up client connections from a Jupyter notebook running on the local machine.
+Again, replace *user* with your username on the gateway and *gateway.host*
+with the hostname/IP address of the gateway. You should now be able to access
+the Bokeh server from the local machine by navigating to ``localhost:5006``
+on the local machine, as if the Bokeh server were running on the local machine.
+You can even set up client connections from a Jupyter notebook running on the
+local machine.
 
 .. note::
     We intend to expand this section with more guidance for other tools and
@@ -879,20 +902,11 @@ The above ``server`` block sets up Nginx to to proxy incoming connections
 to ``127.0.0.1`` on port 80 to ``127.0.0.1:5100`` internally. To work in this
 configuration, we will need to use some of the command line options to
 configure the Bokeh Server. In particular we need to use ``--port`` to specify
-that the Bokeh Server should listen itself on port 5100. We also need to
-set the ``--host`` option to whitelist ``127.0.0.1:80`` as an acceptable `Host`
-on the incoming request header:
+that the Bokeh Server should listen itself on port 5100.
 
 .. code-block:: sh
 
-    bokeh serve myapp.py --port 5100 --host 127.0.0.1:80
-
-.. note::
-    The ``--host`` option is to guard against spoofed ``Host`` values. In a
-    more realistic scenario where you have Nginx and the Bokeh server server
-    running on ``foo.com``, you would set ``--host foo.com:80``. Then any
-    attempted connections that do not report this ``Host`` in the request
-    header (as *all* connections from Nginx do) will be rejected.
+    bokeh serve myapp.py --port 5100
 
 Note that in the basic server block above we have not configured any special
 handling for static resources, e.g., the Bokeh JS and CSS files. This means
@@ -968,7 +982,7 @@ As before, you would run the Bokeh server with the command:
 
 .. code-block:: sh
 
-    bokeh serve myapp.py --port 5100 --host 127.0.0.1:80
+    bokeh serve myapp.py --port 5100
 
 .. _userguide_server_deployment_nginx_proxy_ssl:
 
@@ -976,13 +990,12 @@ Reverse Proxying with Nginx and SSL
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you would like to deploy a Bokeh Server behind an SSL-terminated Nginx
-proxy, then a few additional customizations are needed. First, the Bokeh
-server must be configured for a ``--host`` with the HTTP port 443, and
-you must also add the ``--use-xheaders`` flag:
+proxy, then a few additional customizations are needed. In particular, the
+Bokeh server must be configured with the ``--use-xheaders`` flag:
 
 .. code-block:: sh
 
-    bokeh serve myapp.py --port 5100 --host foo.com:443 --use-xheaders
+    bokeh serve myapp.py --port 5100 --use-xheaders
 
 The ``--use-xheaders`` option causes Bokeh to override the remote IP and
 URI scheme/protocol for all requests with ``X-Real-Ip``, ``X-Forwarded-For``,
@@ -1088,8 +1101,8 @@ You would run the Bokeh servers with commands similar to:
 
 .. code-block:: sh
 
-    serve myapp.py --port 5100 --host 127.0.0.1:80
-    serve myapp.py --port 5101 --host 127.0.0.1:80
+    serve myapp.py --port 5100
+    serve myapp.py --port 5101
     ...
 
 Next, in the ``location`` stanza for our Bokeh server, change the
@@ -1149,7 +1162,7 @@ Server app is below:
     serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL for a unix socket
 
     [program:myapp]
-    command=/path/to/bokeh serve myapp.py --host foo.com:80
+    command=/path/to/bokeh serve myapp.py
     directory=/path/to/workdir
     autostart=false
     autorestart=true
@@ -1194,13 +1207,15 @@ And to update the process control after editing the config file, run:
 Scaling the server
 ~~~~~~~~~~~~~~~~~~
 
-You can fork multiple server processes with the `num-procs` option. For example, to fork 3 processes:
+You can fork multiple server processes with the `num-procs` option. For
+example, to fork 3 processes:
 
 .. code-block:: sh
 
     bokeh serve --num-procs 3
 
-Note that the forking operation happens in the underlying Tornado Server, see notes in the `Tornado docs`_.
+Note that the forking operation happens in the underlying Tornado Server,
+see notes in the `Tornado docs`_.
 
 .. _Tornado docs: http://www.tornadoweb.org/en/stable/tcpserver.html#tornado.tcpserver.TCPServer.start
 

--- a/tests/test_no_request_host.py
+++ b/tests/test_no_request_host.py
@@ -1,0 +1,45 @@
+# This is based on sympy's sympy/utilities/tests/test_code_quality.py
+
+import io
+import subprocess
+from os import pardir
+from os.path import split, join, abspath, relpath
+
+import pytest
+
+TOP_PATH = abspath(join(split(__file__)[0], pardir))
+
+message = "File contains refers to 'request.host': %s, line %s."
+
+def collect_errors():
+    errors = []
+
+    def test_this_file(fname, test_file):
+        for line_no, line in enumerate(test_file, 1):
+            if "request.host" in line.split("#")[0]:
+                errors.append((message, fname, line_no))
+
+    paths = subprocess.check_output(["git", "ls-files"]).decode('utf-8').split("\n")
+
+    for path in paths:
+        if not path:
+            continue
+
+        if not path.endswith(".py"):
+            continue
+
+        if not path.startswith("bokeh/server"):
+            continue
+
+        with io.open(path, 'r', encoding='utf-8') as file:
+            test_this_file(path, file)
+
+    return [ msg % (relpath(fname, TOP_PATH), line_no) for (msg, fname, line_no) in errors ]
+
+@pytest.mark.quality
+def test_files():
+    errors = collect_errors()
+    assert len(errors) == 0, "request.host usage issues:\n%s" % "\n".join(errors)
+
+if __name__ == "__main__":
+    test_files()


### PR DESCRIPTION
- [x] issues: fixes #5692
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

This PR makes it possible for the server to supply relative URLs for resources, which may be needed for certain kinds of deployments behind proxies. It's not yet clear if the WS code also needs changing, awaiting more input from @dhuebner