### PR TITLE
use sinon.test to increase layout test robustness

### DIFF
--- a/bokehjs/test/models/annotations/annotation.coffee
+++ b/bokehjs/test/models/annotations/annotation.coffee
@@ -1,6 +1,5 @@
 {expect} = require "chai"
 utils = require "../../utils"
-sinon = require 'sinon'
 
 {SidePanel} = utils.require("core/layout/side_panel")
 

--- a/bokehjs/test/models/axes/axis.coffee
+++ b/bokehjs/test/models/axes/axis.coffee
@@ -102,8 +102,8 @@ describe "AxisView", ->
   it "_axis_label_extent should be 0 if no axis_label", ->
     expect(@axis_view._axis_label_extent()).to.be.equal 0
 
-  it "_get_size should return sum of _tick_extent, _axis_label_extent, and _tick_label_extent", ->
-    sinon.stub(@axis_view, '_tick_extent', () -> 0.11)
-    sinon.stub(@axis_view, '_axis_label_extent', () -> 0.11)
-    sinon.stub(@axis_view, '_tick_label_extent', () -> 0.11)
+  it "_get_size should return sum of _tick_extent, _axis_label_extent, and _tick_label_extent", sinon.test ->
+    this.stub(@axis_view, '_tick_extent', () -> 0.11)
+    this.stub(@axis_view, '_axis_label_extent', () -> 0.11)
+    this.stub(@axis_view, '_tick_label_extent', () -> 0.11)
     expect(@axis_view._get_size()).to.be.equal 0.33

--- a/bokehjs/test/models/canvas/canvas.coffee
+++ b/bokehjs/test/models/canvas/canvas.coffee
@@ -83,15 +83,14 @@ describe "CanvasView", ->
     @c = new Canvas()
     @c.document = new Document()
 
-  it "initialize should call set_dims", ->
-    spy = sinon.spy(CanvasView.prototype, 'set_dims')
+  it "initialize should call set_dims", sinon.test ->
+    spy = this.spy(CanvasView.prototype, 'set_dims')
     c_view = new @c.default_view({'model': @c})
     expect(spy.calledOnce).to.be.true
-    spy.restore()
 
-  it "set_dims should call update_constraints", ->
+  it "set_dims should call update_constraints", sinon.test ->
     canvas_view = new @c.default_view({'model': @c})
-    spy = sinon.spy(canvas_view, 'update_constraints')
+    spy = this.spy(canvas_view, 'update_constraints')
     canvas_view.set_dims([1, 2])
     expect(spy.calledOnce).to.be.true
 

--- a/bokehjs/test/models/plots/plot.coffee
+++ b/bokehjs/test/models/plots/plot.coffee
@@ -33,7 +33,7 @@ describe "Plot", ->
       doc = new Document()
       doc.add_root(@p)
 
-    it "render should set the appropriate positions and paddings on the element when it is mode box", ->
+    it "render should set the appropriate positions and paddings on the element when it is mode box", sinon.test () ->
       dom_left = 12
       dom_top = 13
       width = 80
@@ -49,42 +49,38 @@ describe "Plot", ->
       expected_style = "position: absolute; left: #{dom_left}px; top: #{dom_top}px; width: #{width}px; height: #{height}px;"
       expect(plot_view.el.style.cssText).to.be.equal expected_style
 
-    it "should call suggest value with the model height and width if sizing_mode is scale_both", ->
+    it "should call suggest value with the model height and width if sizing_mode is scale_both", sinon.test () ->
       @p.sizing_mode = 'scale_both'
       plot_view = new @p.default_view({ model: @p })
-      sinon.stub(plot_view, 'get_width_height').returns([34, 77])
+      this.stub(plot_view, 'get_width_height').returns([34, 77])
       @solver_suggest.reset()
       plot_view.render()
       expect(@solver_suggest.callCount).is.equal 2
       expect(@solver_suggest.args[0]).to.be.deep.equal [@p._width, 34]
       expect(@solver_suggest.args[1]).to.be.deep.equal [@p._height, 77]
 
-    # TODO (bird) A number of these tests are skipped because of flakiness.
-    # We get kiwi unknown edit variable errors, although we shouldn't
-    # because the solver should have been stubbed out.
-
-    it.skip "get_height should return the height from the aspect ratio", ->
+    it "get_height should return the height from the aspect ratio", sinon.test () ->
       @p.width = 22
       @p.height = 44
       plot_view = new @p.default_view({ model: @p })
       @p._width = {_value: 33}
       expect(plot_view.get_height()).to.be.equal 66
 
-    it.skip "get_width should return the width from the aspect ratio", ->
+    it "get_width should return the width from the aspect ratio", sinon.test () ->
       @p.width = 2
       @p.height = 10
       plot_view = new @p.default_view({ model: @p })
       @p._height= {_value: 100}
       expect(plot_view.get_width()).to.be.equal 20
 
-    it.skip "get_width should return the width from the aspect ratio", ->
+    it "get_width should return the width from the aspect ratio", sinon.test () ->
       @p.width = 2
       @p.height = 10
       plot_view = new @p.default_view({ model: @p })
       @p._height= {_value: 100}
       expect(plot_view.get_width()).to.be.equal 20
 
-    it.skip "get_width_height should return a constrained width if plot is landscape oriented", ->
+    it "get_width_height should return a constrained width if plot is landscape oriented", sinon.test () ->
       @p.width = 4
       @p.height = 2
       plot_view = new @p.default_view({ model: @p })
@@ -93,7 +89,7 @@ describe "Plot", ->
       expect(w).to.be.equal 56
       expect(h).to.be.equal 56 / (4/2)
 
-    it.skip "get_width_height should return a constrained height if plot is portrait oriented", ->
+    it "get_width_height should return a constrained height if plot is portrait oriented", sinon.test () ->
       @p.width = 3
       @p.height = 5
       plot_view = new @p.default_view({ model: @p })
@@ -102,21 +98,21 @@ describe "Plot", ->
       expect(h).to.be.equal 49
       expect(w).to.be.equal 49 * (3/5)
 
-    it "should set min_border_x to value of min_border if min_border_x is not specified", ->
+    it "should set min_border_x to value of min_border if min_border_x is not specified", sinon.test () ->
       p = new Plot({x_range: new DataRange1d(), y_range: new DataRange1d(), min_border: 33.33})
       expect(p.min_border_top).to.be.equal 33.33
       expect(p.min_border_bottom).to.be.equal 33.33
       expect(p.min_border_left).to.be.equal 33.33
       expect(p.min_border_right).to.be.equal 33.33
 
-    it "should set min_border_x to value of specified, and others to value of min_border", ->
+    it "should set min_border_x to value of specified, and others to value of min_border", sinon.test () ->
       p = new Plot({x_range: new DataRange1d(), y_range: new DataRange1d(), min_border: 33.33, min_border_left: 66.66})
       expect(p.min_border_top).to.be.equal 33.33
       expect(p.min_border_bottom).to.be.equal 33.33
       expect(p.min_border_left).to.be.equal 66.66
       expect(p.min_border_right).to.be.equal 33.33
 
-    it "should set min_border_x to value of specified, and others to default min_border", ->
+    it "should set min_border_x to value of specified, and others to default min_border", sinon.test () ->
       p = new Plot({x_range: new DataRange1d(), y_range: new DataRange1d(), min_border_left: 4})
       # MIN_BORDER is 5
       expect(p.min_border_top).to.be.equal 5
@@ -124,7 +120,7 @@ describe "Plot", ->
       expect(p.min_border_left).to.be.equal 4
       expect(p.min_border_right).to.be.equal 5
 
-    it.skip "should add the title to the list of renderers", ->
+    it "should add the title to the list of renderers", sinon.test () ->
       # TODO(bird) Write this test.
       null
 
@@ -138,22 +134,22 @@ describe "Plot", ->
       utils.stub_canvas()
       utils.stub_solver()
 
-    it "should have _horizontal set to true by default", ->
+    it "should have _horizontal set to true by default", sinon.test () ->
       expect(@p._horizontal).to.true
 
-    it "should have a PlotCanvas set on initialization with plot on it", ->
+    it "should have a PlotCanvas set on initialization with plot on it", sinon.test () ->
       expect(@p.plot_canvas).to.exist
       expect(@p.plot_canvas.plot).to.be.deep.equal @p
 
-    it "should attach document to plot canvas when document is attached to it", ->
+    it "should attach document to plot canvas when document is attached to it", sinon.test () ->
       expect(@p.plot_canvas.document).to.be.null
       doc = new Document()
       @p.attach_document(doc)
       expect(@p.plot_canvas.document).to.be.equal doc
 
-    it "should not execute range callbacks on initialization", ->
+    it "should not execute range callbacks on initialization", sinon.test () ->
       cb = new CustomJS()
-      spy = sinon.spy(cb, 'execute')
+      spy = this.spy(cb, 'execute')
 
       plot = new Plot({
          x_range: new Range1d({callback: cb})
@@ -192,24 +188,24 @@ describe "Plot", ->
           'box-cell-align-right' : plot_canvas._width_minus_right
         }
 
-      it "should return correct constrained_variables in box mode", ->
+      it "should return correct constrained_variables in box mode", sinon.test () ->
         @p.sizing_mode = 'stretch_both'
         constrained_variables = @p.get_constrained_variables()
         expect(constrained_variables).to.be.deep.equal @expected_constrained_variables
 
-      it "should return correct constrained_variables in scale_width mode", ->
+      it "should return correct constrained_variables in scale_width mode", sinon.test () ->
         @p.sizing_mode = 'scale_width'
         expected_constrained_variables = _.omit(@expected_constrained_variables, ['height'])
         constrained_variables = @p.get_constrained_variables()
         expect(constrained_variables).to.be.deep.equal expected_constrained_variables
 
-      it "should return correct constrained_variables in scale_height mode", ->
+      it "should return correct constrained_variables in scale_height mode", sinon.test () ->
         @p.sizing_mode = 'scale_height'
         expected_constrained_variables = _.omit(@expected_constrained_variables, ['width'])
         constrained_variables = @p.get_constrained_variables()
         expect(constrained_variables).to.be.deep.equal expected_constrained_variables
 
-      it "should return correct constrained_variables in fixed mode", ->
+      it "should return correct constrained_variables in fixed mode", sinon.test () ->
         @p.sizing_mode = 'fixed'
         expected_constrained_variables = _.omit(@expected_constrained_variables, ['height', 'width', 'box-equal-size-left', 'box-equal-size-right'])
         constrained_variables = @p.get_constrained_variables()

--- a/bokehjs/test/models/plots/plot_canvas.coffee
+++ b/bokehjs/test/models/plots/plot_canvas.coffee
@@ -47,16 +47,16 @@ describe "PlotCanvas", ->
     @plot_canvas = new PlotCanvas({ 'plot': @plot })
     @plot_canvas.attach_document(@doc)
 
-  it "should set the sizing_mode to box by default", ->
+  it "should set the sizing_mode to box by default", sinon.test () ->
     expect(@plot_canvas.sizing_mode).to.be.equal 'stretch_both'
 
-  it "should have a four LayoutCanvases", ->
+  it "should have a four LayoutCanvases", sinon.test () ->
     expect(@plot_canvas.above_panel).to.be.an.instanceOf(LayoutCanvas)
     expect(@plot_canvas.below_panel).to.be.an.instanceOf(LayoutCanvas)
     expect(@plot_canvas.left_panel).to.be.an.instanceOf(LayoutCanvas)
     expect(@plot_canvas.right_panel).to.be.an.instanceOf(LayoutCanvas)
 
-  it "should have panels, frame, and canvas returned in get_layoutable_children", ->
+  it "should have panels, frame, and canvas returned in get_layoutable_children", sinon.test () ->
     layoutable_children = @plot_canvas.get_layoutable_children()
     expect(layoutable_children.length).to.be.equal 6
     expect(@plot_canvas.above_panel in layoutable_children).to.be.true
@@ -66,7 +66,7 @@ describe "PlotCanvas", ->
     expect(@plot_canvas.frame       in layoutable_children).to.be.true
     expect(@plot_canvas.canvas      in layoutable_children).to.be.true
 
-  it "should have axis panels in get_layoutable_children if axes added", ->
+  it "should have axis panels in get_layoutable_children if axes added", sinon.test () ->
     plot = new Plot({x_range: new DataRange1d(), y_range: new DataRange1d(), title: null})
     above_axis = new LinearAxis()
     below_axis = new LinearAxis()
@@ -85,14 +85,14 @@ describe "PlotCanvas", ->
     expect(left_axis.panel  in layoutable_children).to.be.true
     expect(right_axis.panel in layoutable_children).to.be.true
 
-  it "should call get_edit_variables on layoutable children", ->
+  it "should call get_edit_variables on layoutable children", sinon.test () ->
     plot = new Plot({x_range: new DataRange1d(), y_range: new DataRange1d(), title: null})
     @doc.add_root(plot)
     plot_canvas = plot.plot_canvas
     children = plot_canvas.get_layoutable_children()
     expect(children.length).to.be.equal 6
     for child in children
-      child.get_edit_variables = sinon.spy()
+      child.get_edit_variables = this.spy()
       expect(child.get_edit_variables.callCount).to.be.equal 0
     plot_canvas.get_edit_variables()
     for child in children
@@ -119,26 +119,26 @@ describe "PlotCanvas constraints", ->
     @plot_canvas = new PlotCanvas({ 'plot': plot })
     @plot_canvas.attach_document(doc)
 
-  it "should return 20 constraints from _get_constant_constraints", ->
+  it "should return 20 constraints from _get_constant_constraints", sinon.test () ->
     expect(@plot_canvas._get_constant_constraints().length).to.be.equal 20
 
-  it "should return 0 constraints from _get_side_constraints if there are no side renderers", ->
+  it "should return 0 constraints from _get_side_constraints if there are no side renderers", sinon.test () ->
     expect(@plot_canvas._get_side_constraints().length).to.be.equal 0
 
-  it "should call _get_side_constraints, _get_constant_constraints", ->
-    @plot_canvas._get_side_constraints = sinon.spy()
-    @plot_canvas._get_constant_constraints = sinon.spy()
+  it "should call _get_side_constraints, _get_constant_constraints", sinon.test () ->
+    @plot_canvas._get_side_constraints = this.spy()
+    @plot_canvas._get_constant_constraints = this.spy()
     expect(@plot_canvas._get_side_constraints.callCount).to.be.equal 0
     expect(@plot_canvas._get_constant_constraints.callCount).to.be.equal 0
     @plot_canvas.get_constraints()
     expect(@plot_canvas._get_side_constraints.callCount).to.be.equal 1
     expect(@plot_canvas._get_constant_constraints.callCount).to.be.equal 1
 
-  it "should call _get_constraints on children", ->
+  it "should call _get_constraints on children", sinon.test () ->
     children = @plot_canvas.get_layoutable_children()
     expect(children.length).to.be.equal 6
     for child in children
-      child.get_constraints = sinon.spy()
+      child.get_constraints = this.spy()
       expect(child.get_constraints.callCount).to.be.equal 0
     @plot_canvas.get_constraints()
     for child in children
@@ -155,38 +155,38 @@ describe "PlotCanvas constraints with different layouts", ->
       title: null
     })
 
-  it "should return 2 constraints from _get_side_constraints if there is one side renderer on above", ->
+  it "should return 2 constraints from _get_side_constraints if there is one side renderer on above", sinon.test () ->
     @plot.add_layout(new LinearAxis(), 'above')
     @plot.attach_document(@doc)
     plot_canvas = new PlotCanvas({ 'plot': @plot })
     expect(plot_canvas._get_side_constraints().length).to.be.equal 2
 
-  it "should return 3 constraints from _get_side_constraints if there are two side renderers on one side", ->
+  it "should return 3 constraints from _get_side_constraints if there are two side renderers on one side", sinon.test () ->
     @plot.add_layout(new LinearAxis(), 'left')
     @plot.add_layout(new LinearAxis(), 'left')
     @plot.attach_document(@doc)
     plot_canvas = new PlotCanvas({ 'plot': @plot })
     expect(plot_canvas._get_side_constraints().length).to.be.equal 3
 
-  it "should return 2 constraints from _get_side_constraints if there is one side renderer on below", ->
+  it "should return 2 constraints from _get_side_constraints if there is one side renderer on below", sinon.test () ->
     @plot.add_layout(new LinearAxis(), 'below')
     @plot.attach_document(@doc)
     plot_canvas = new PlotCanvas({ 'plot': @plot })
     expect(plot_canvas._get_side_constraints().length).to.be.equal 2
 
-  it "should return 2 constraints from _get_side_constraints if there is one side renderer on left", ->
+  it "should return 2 constraints from _get_side_constraints if there is one side renderer on left", sinon.test () ->
     @plot.add_layout(new LinearAxis(), 'left')
     @plot.attach_document(@doc)
     plot_canvas = new PlotCanvas({ 'plot': @plot })
     expect(plot_canvas._get_side_constraints().length).to.be.equal 2
 
-  it "should return 2 constraints from _get_side_constraints if there is one side renderer on right", ->
+  it "should return 2 constraints from _get_side_constraints if there is one side renderer on right", sinon.test () ->
     @plot.add_layout(new LinearAxis(), 'right')
     @plot.attach_document(@doc)
     plot_canvas = new PlotCanvas({ 'plot': @plot })
     expect(plot_canvas._get_side_constraints().length).to.be.equal 2
 
-  it "should return 4 constraints from _get_side_constraints if there are two side renderers", ->
+  it "should return 4 constraints from _get_side_constraints if there are two side renderers", sinon.test () ->
     @plot.add_layout(new LinearAxis(), 'left')
     @plot.add_layout(new LinearAxis(), 'right')
     @plot.attach_document(@doc)
@@ -215,8 +215,8 @@ describe "PlotCanvasView render", ->
     plot_canvas.attach_document(doc)
     @plot_canvas_view = new plot_canvas.default_view({ 'model': plot_canvas })
 
-  it "should call own update_constraints method", ->
-    spy = sinon.spy(@plot_canvas_view, 'update_constraints')
+  it "should call own update_constraints method", sinon.test () ->
+    spy = this.spy(@plot_canvas_view, 'update_constraints')
     @plot_canvas_view.render()
     expect(spy.calledOnce).to.be.true
 
@@ -258,35 +258,35 @@ describe "PlotCanvasView resize", ->
     @plot_canvas._whitespace_bottom = {_value: wb}
     @plot_canvas_view = new @plot_canvas.default_view({ 'model': @plot_canvas })
 
-  it "should set the appropriate positions and paddings on the element", ->
+  it "should set the appropriate positions and paddings on the element", sinon.test () ->
     @plot_canvas.sizing_mode = 'stretch_both'
     @plot_canvas_view.resize()
     expected_style = "position: absolute; left: #{dom_left}px; top: #{dom_top}px; width: #{width}px; height: #{height}px;"
     expect(@plot_canvas_view.el.style.cssText).to.be.equal expected_style
 
-  it "should call canvas.set_dims with width & height if sizing_mode is box, and trigger true", ->
-    spy = sinon.spy(@plot_canvas_view.canvas_view, 'set_dims')
+  it "should call canvas.set_dims with width & height if sizing_mode is box, and trigger true", sinon.test () ->
+    spy = this.spy(@plot_canvas_view.canvas_view, 'set_dims')
     @plot_canvas.sizing_mode = 'stretch_both'
     @plot_canvas_view.resize()
     expect(spy.calledOnce).to.be.true
     expect(spy.calledWith([width, height], true)).to.be.true
 
-  it "should call canvas.set_dims and trigger if plot is_root", ->
-    spy = sinon.spy(@plot_canvas_view.canvas_view, 'set_dims')
+  it "should call canvas.set_dims and trigger if plot is_root", sinon.test () ->
+    spy = this.spy(@plot_canvas_view.canvas_view, 'set_dims')
     @plot_canvas._is_root = true
     @plot_canvas.sizing_mode = 'stretch_both'
     @plot_canvas_view.resize()
     expect(spy.calledOnce).to.be.true
     expect(spy.calledWith([width, height], true)).to.be.true
 
-  it "should call solver.suggest_value for width and height if sizing_mode is fixed", ->
-    spy = sinon.spy(@plot_canvas_view.canvas_view, 'set_dims')
+  it "should call solver.suggest_value for width and height if sizing_mode is fixed", sinon.test () ->
+    spy = this.spy(@plot_canvas_view.canvas_view, 'set_dims')
     @plot_canvas.sizing_mode = 'fixed'
     @plot_canvas_view.resize()
     expect(spy.calledOnce, 'set_dims was not called').to.be.true
     expect(spy.calledWith([width, height], true)).to.be.true
 
-  it "should throw an error if height is 0", ->
+  it "should throw an error if height is 0", sinon.test () ->
     @plot_canvas._height = {_value: 0}
     @plot_canvas.sizing_mode = 'stretch_both'
     expect(@plot_canvas_view.resize).to.throw Error
@@ -326,16 +326,14 @@ describe "PlotCanvasView update_constraints", ->
   #  test_plot_view.update_constraints()
   #  expect(spy.calledOnce).to.be.true
 
-  # Skipping due to solver causing failures
-  it.skip "should call solver suggest twice for frame sizing", ->
+  it "should call solver suggest twice for frame sizing", sinon.test () ->
     test_plot_canvas_view = new @plot_canvas.default_view({ 'model': @plot_canvas })
 
     initial_count = @solver_suggest_stub.callCount
     test_plot_canvas_view.update_constraints()
     expect(@solver_suggest_stub.callCount).to.be.equal initial_count + 2
 
-  # Skipping due to solver causing failures
-  it.skip "should call solver update_variables with false for trigger", ->
+  it "should call solver update_variables with false for trigger", sinon.test () ->
     test_plot_canvas_view = new @plot_canvas.default_view({ 'model': @plot_canvas })
 
     initial_count = @solver_update_stub.callCount
@@ -366,10 +364,10 @@ describe "PlotCanvasView get_canvas_element", ->
     plot_canvas.attach_document(doc)
     @plot_canvas_view = new plot_canvas.default_view({ 'model': plot_canvas })
 
-  it.skip "should exist because get_canvas_element depends on it", ->
+  it "should exist because get_canvas_element depends on it", sinon.test () ->
     expect(@plot_canvas_view.canvas_view.ctx).to.exist
 
-  it.skip "should exist to grab the canvas DOM element using canvas_view.ctx", ->
+  it "should exist to grab the canvas DOM element using canvas_view.ctx", sinon.test () ->
     expect(@plot_canvas_view.canvas_view.get_canvas_element).to.exist
 
 
@@ -398,13 +396,13 @@ describe "PlotCanvasView dimensions", ->
     @plot_canvas.attach_document(@doc)
     @plot_canvas_view = new @plot_canvas.default_view({ 'model': @plot_canvas })
 
-  it "reset_dimensions should call document resize", ->
-    spy = sinon.spy(@doc, 'resize')
+  it "reset_dimensions should call document resize", sinon.test () ->
+    spy = this.spy(@doc, 'resize')
     expect(spy.callCount).to.be.equal 0
     @plot_canvas_view.reset_dimensions()
     expect(spy.callCount).to.be.equal 1
 
-  it "reset_dimensions should set plot width and height to initial width and height", ->
+  it "reset_dimensions should set plot width and height to initial width and height", sinon.test () ->
     # Explicitly set to 1 to make sure they're being set
     @plot_canvas.plot.width = 1
     @plot_canvas.plot.height = 1
@@ -412,13 +410,13 @@ describe "PlotCanvasView dimensions", ->
     expect(@plot_canvas.plot.width).to.be.equal 444 # Comes from plot_width
     expect(@plot_canvas.plot.height).to.be.equal 555
 
-  it "update_dimensions should call document resize", ->
-    spy = sinon.spy(@doc, 'resize')
+  it "update_dimensions should call document resize", sinon.test () ->
+    spy = this.spy(@doc, 'resize')
     expect(spy.callCount).to.be.equal 0
     @plot_canvas_view.update_dimensions(1, 2)
     expect(spy.callCount).to.be.equal 1
 
-  it "update_dimensions should set plot width and height to requested width and height", ->
+  it "update_dimensions should set plot width and height to requested width and height", sinon.test () ->
     @plot_canvas_view.update_dimensions(22, 33)
     expect(@plot_canvas.plot.width).to.be.equal 22
     expect(@plot_canvas.plot.height).to.be.equal 33

--- a/bokehjs/test/models/tools/actions/zoom_in_tool.coffee
+++ b/bokehjs/test/models/tools/actions/zoom_in_tool.coffee
@@ -1,6 +1,5 @@
 {expect} = require "chai"
 utils = require "../../../utils"
-sinon = require 'sinon'
 
 {Document} = utils.require("document")
 {ZoomInTool} = utils.require("models/tools/actions/zoom_in_tool")

--- a/bokehjs/test/models/tools/actions/zoom_out_tool.coffee
+++ b/bokehjs/test/models/tools/actions/zoom_out_tool.coffee
@@ -1,6 +1,5 @@
 {expect} = require "chai"
 utils = require "../../../utils"
-sinon = require 'sinon'
 
 {Document} = utils.require("document")
 {ZoomOutTool} = utils.require("models/tools/actions/zoom_out_tool")

--- a/bokehjs/test/models/tools/gestures/wheel_pan_tool.coffee
+++ b/bokehjs/test/models/tools/gestures/wheel_pan_tool.coffee
@@ -1,6 +1,5 @@
 {expect} = require "chai"
 utils = require "../../../utils"
-sinon = require 'sinon'
 
 {Document} = utils.require("document")
 {WheelPanTool} = utils.require("models/tools/gestures/wheel_pan_tool")

--- a/bokehjs/test/models/tools/gestures/wheel_zoom_tool.coffee
+++ b/bokehjs/test/models/tools/gestures/wheel_zoom_tool.coffee
@@ -1,6 +1,5 @@
 {expect} = require "chai"
 utils = require "../../../utils"
-sinon = require 'sinon'
 
 {Document} = utils.require("document")
 {WheelZoomTool} = utils.require("models/tools/gestures/wheel_zoom_tool")

--- a/bokehjs/test/models/tools/inspectors/crosshair_tool.coffee
+++ b/bokehjs/test/models/tools/inspectors/crosshair_tool.coffee
@@ -1,6 +1,5 @@
 {expect} = require "chai"
 utils = require "../../../utils"
-sinon = require 'sinon'
 
 {CrosshairTool} = utils.require("models/tools/inspectors/crosshair_tool")
 {DataRange1d} = utils.require("models/ranges/data_range1d")


### PR DESCRIPTION
issues: fixes #4539 

In this PR, I wrapped test functions with `sinon.test`. From ["Best Practices for Spies, Stubs and Mocks in Sinon.js"](https://semaphoreci.com/community/tutorials/best-practices-for-spies-stubs-and-mocks-in-sinon-js):

> Use sinon.test Whenever Possible
When you use spies, stubs or mocks, wrap your test function in sinon.test. This allows you to use Sinon's automatic clean-up functionality. Without it, if your test fails before your test-doubles are cleaned up, it can cause a cascading failure - more test failures resulting from the initial failure. Cascading failures can easily mask the real source of the problem, so we want to avoid them where possible.

These changes fix the errors from the layout tests for me. @mattpap 
