### PR TITLE
add detailed name in counties sampledata api to enable matching by name

### DIFF
--- a/bokeh/sampledata/us_counties.py
+++ b/bokeh/sampledata/us_counties.py
@@ -4,9 +4,13 @@ indexed by the two-tuple containing (state_id, county_id) and has the following 
 associated value:
 
     data[(1,1)]['name']
+    data[(1,1)]['state']
+    data[(1,1)]['detailed name']
     data[(1,1)]['lats']
     data[(1,1)]['lons']
 
+'name' can have duplicates for certain states (especially Virginia). 'detailed name' and 'state'
+combinations are unique.
 '''
 from __future__ import absolute_import
 
@@ -25,7 +29,7 @@ with _open_csv_file(join(data_dir, 'US_Counties.csv')) as f:
     next(f)
     reader = csv.reader(f, delimiter=',', quotechar='"')
     for row in reader:
-        name, dummy, state, dummy, geometry, dummy, dummy, dummy, dummy, state_id, county_id, dummy, dummy = row
+        name, dummy, state, dummy, geometry, dummy, dummy, dummy, det_name, state_id, county_id, dummy, dummy = row
         xml = et.fromstring(geometry)
         lats = []
         lons = []
@@ -40,6 +44,7 @@ with _open_csv_file(join(data_dir, 'US_Counties.csv')) as f:
             lons.extend(lon)
         data[(int(state_id), int(county_id))] = {
             'name' : name,
+            'detailed name' : det_name,
             'state' : state,
             'lats' : lats,
             'lons' : lons,


### PR DESCRIPTION
Deals with #5835. I did not add any tests. I put relevant info in the docstring of the us_counties module.

I know this is just sample data but it is actually an incredibly useful source of data. This PR enables people to match to counties by name and state (in the case that the FIPS code is not in the data). Here is some code showing the data contains duplicates on 'state' and 'name':

![dups](https://cloud.githubusercontent.com/assets/6889910/22538889/ba2a767c-e8ca-11e6-9590-0b970ef2efc4.png)

and here is an example of an occurrence of a duplicate in the data source:

![example](https://cloud.githubusercontent.com/assets/6889910/22538907/daf917dc-e8ca-11e6-9fc8-43c26b0da8ba.png)

This issue came about because I had some data without FIPS codes for the states and counties but had the names of the states and counties. I happened to be plotting Virginia and I immediately noticed that some of the counties were not being found in the sample data:

![before](https://cloud.githubusercontent.com/assets/6889910/22538928/0490e2f0-e8cb-11e6-8e49-632a8faeb276.png)

Then I did my little hack that I propose here so that I could match all the counties:

![after](https://cloud.githubusercontent.com/assets/6889910/22538947/239469f6-e8cb-11e6-99e9-6266c29f8218.png)

Let me know what you think about having both the 'name' and 'detailed name'. For me I know it was very useful..

