### PR TITLE
Ensure all dataspec properties are updated before glyph render

### DIFF
--- a/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
+++ b/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
@@ -118,8 +118,9 @@ export class GlyphRendererView extends RendererView
     if @model.visible == false
       return
 
-    t0 = Date.now()
+    extend(@glyph, @model.glyph.materialize_dataspecs(@model.data_source))
 
+    t0 = Date.now()
     glsupport = @glyph.glglyph
 
     tmap = Date.now()


### PR DESCRIPTION
Currently, if only dataspec properties change for a given glyph, when `push_notebook` is called, the graphs are not updated because the `View`'s properties never get updated. By calling `set_data` in the `render` function, it makes sure that all dataspec properties of the given `Glyph` are updated with the new properties of the `Model`.

- [x] issues: fixes #5811
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
