### PR TITLE
Document: fix memory leak by explicitly deleting sys.modules on session destroy

### DIFF
--- a/bokeh/document.py
+++ b/bokeh/document.py
@@ -97,7 +97,9 @@ class Document(object):
         self._modules = []
         self._template_variables = {}
 
-    def __del__(self):
+    def delete_modules(self):
+        ''' Clean up sys.modules after the session is destroyed.
+        '''
         for module in self._modules:
             if module.__name__ in sys.modules:
                 del sys.modules[module.__name__]

--- a/bokeh/server/session.py
+++ b/bokeh/server/session.py
@@ -111,6 +111,7 @@ class ServerSession(object):
         return self._expiration_blocked_count
 
     def destroy(self):
+        self._document.delete_modules()
         self._destroyed = True
         self._document.remove_on_change(self)
         self._callbacks.remove_all_callbacks()

--- a/bokeh/server/session.py
+++ b/bokeh/server/session.py
@@ -111,8 +111,8 @@ class ServerSession(object):
         return self._expiration_blocked_count
 
     def destroy(self):
-        self._document.delete_modules()
         self._destroyed = True
+        self._document.delete_modules()
         self._document.remove_on_change(self)
         self._callbacks.remove_all_callbacks()
 

--- a/bokeh/server/tests/test_session.py
+++ b/bokeh/server/tests/test_session.py
@@ -1,5 +1,4 @@
 import mock
-import pytest
 
 from bokeh.document import Document
 
@@ -40,5 +39,3 @@ def test_destroy():
         s.destroy()
         assert s.destroyed
         docroc.assert_called_with(s)
-
-

--- a/bokeh/server/tests/test_session.py
+++ b/bokeh/server/tests/test_session.py
@@ -1,0 +1,44 @@
+import mock
+import pytest
+
+from bokeh.document import Document
+
+import bokeh.server.session as bss
+
+def test_creation():
+    d = Document()
+    s = bss.ServerSession('some-id', d, 'ioloop')
+    assert s.id == 'some-id'
+    assert s.document == d
+    assert s.destroyed is False
+    assert s.expiration_requested is False
+    assert s.expiration_blocked == 0
+
+def test_subscribe():
+    d = Document()
+    s = bss.ServerSession('some-id', d, 'ioloop')
+    assert s.connection_count == 0
+    s.subscribe('connection1')
+    assert s.connection_count == 1
+    s.subscribe('connection2')
+    assert s.connection_count == 2
+    s.unsubscribe('connection1')
+    assert s.connection_count == 1
+    s.unsubscribe('connection2')
+    assert s.connection_count == 0
+
+def test_destroy():
+    d = Document()
+    s = bss.ServerSession('some-id', d, 'ioloop')
+    with mock.patch('bokeh.document.Document.delete_modules') as docdm:
+        s.destroy()
+        assert s.destroyed
+        docdm.assert_called_once()
+
+    s = bss.ServerSession('some-id', d, 'ioloop')
+    with mock.patch('bokeh.document.Document.remove_on_change') as docroc:
+        s.destroy()
+        assert s.destroyed
+        docroc.assert_called_with(s)
+
+

--- a/bokeh/tests/test_document.py
+++ b/bokeh/tests/test_document.py
@@ -37,6 +37,20 @@ class TestDocument(unittest.TestCase):
         assert not d.roots
         assert d.template_variables == {}
 
+    def test_delete_modules(self):
+        d = document.Document()
+        assert not d.roots
+        class FakeMod(object):
+            __name__ = 'junkjunkjunk'
+        mod = FakeMod()
+        import sys
+        assert 'junkjunkjunk' not in sys.modules
+        sys.modules['junkjunkjunk'] = mod
+        d._modules.append(mod)
+        assert 'junkjunkjunk' in sys.modules
+        d.delete_modules()
+        assert 'junkjunkjunk' not in sys.modules
+
     def test_add_roots(self):
         d = document.Document()
         assert not d.roots


### PR DESCRIPTION
Previously, due to circular references, a Document was never GC'd, and thus
sys.modules kept increasing for each page request.

This patch explicitly cleans up sys.modules after a session is destroyed.

Verified that `len(sys.modules)` does not increase over time (which it did before).

Fixes #5848

TODO: add tests