### PR TITLE
ColumnDataSource constructor optimization

### DIFF
--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -105,8 +105,8 @@ class ColumnDataSource(ColumnarDataSource):
             else:
                 raise ValueError("expected a dict or pandas.DataFrame, got %s" % raw_data)
         super(ColumnDataSource, self).__init__(**kw)
-        for name, data in raw_data.items():
-            self.add(data, name)
+        self.column_names[:] = list(raw_data.keys())
+        self.data.update(raw_data)
 
     @staticmethod
     def _data_from_df(df):


### PR DESCRIPTION
As described in https://github.com/bokeh/bokeh/issues/5871, the ColumnDataSource constructor triggers validation on all the columns for every column that is passed to the constructor, which is highly inefficient. By using ``self.data.update`` the validation is only triggered once resulting in considerably speed improvements for large datasets.

It would be important to know if there is any particular reason why it was using ``.add`` in the first place.