### PR TITLE
Use `master@{upstream}` instead of `origin/master` as the default diff-ref

### DIFF
--- a/tests/examples/examples_report_plugin.py
+++ b/tests/examples/examples_report_plugin.py
@@ -29,7 +29,7 @@ def pytest_addoption(parser):
         "--report-path", action='store', dest='report_path', metavar='path', default='report.html', help='create examples html report file at given path.'
     )
     parser.addoption(
-        "--diff-ref", type=resolve_ref, default="origin/master", help="compare generated images against this ref"
+        "--diff-ref", type=resolve_ref, default="master@{upstream}", help="compare generated images against this ref"
     )
     parser.addoption(
         "--incremental", action="store_true", default=False, help="write report after each example"


### PR DESCRIPTION
Using `origin` is presumptuous and works only for core dev workflow, but not necessarily in forks, which can have the origin (upstream) configured to something different than the literal `origin`.

fixes #5888