### PR TITLE
Fix broken link in top of dev_guide/server.html (#5891)

### DIFF
--- a/sphinx/source/docs/dev_guide/server.rst
+++ b/sphinx/source/docs/dev_guide/server.rst
@@ -4,7 +4,7 @@ Server Architecture
 ===================
 
 This chapter is a "deep dive" into Bokeh server's internals. It assumes you're
-already familiar with the information on Bokeh server in the :ref`userguide`.
+already familiar with the information on Bokeh server in :ref:`userguide_server`.
 
 You might want to read this if you are:
 


### PR DESCRIPTION
* Just fixing a typo so that the link at the top of dev_guide/server.html
  correctly points to user_guide/server.html

- [x] issues: fixes #5891
- [x] tests added / passed
  * doc change only.  locally built docs to confirm fixed link
