### PR TITLE
added use_cached kwarg to references

### DIFF
--- a/bokeh/document.py
+++ b/bokeh/document.py
@@ -96,6 +96,7 @@ class Document(object):
         self._session_context = None
         self._modules = []
         self._template_variables = {}
+        self._use_cached = kwargs.pop('use_cached', False)
 
     def delete_modules(self):
         ''' Clean up sys.modules after the session is destroyed.
@@ -1072,7 +1073,7 @@ class Document(object):
         '''
         new_all_models_set = set()
         for r in self.roots:
-            new_all_models_set = new_all_models_set.union(r.references())
+            new_all_models_set = new_all_models_set.union(r.references(use_cached=self._use_cached))
         old_all_models_set = set(self._all_models.values())
         to_detach = old_all_models_set - new_all_models_set
         to_attach = new_all_models_set - old_all_models_set

--- a/bokeh/document.py
+++ b/bokeh/document.py
@@ -96,7 +96,6 @@ class Document(object):
         self._session_context = None
         self._modules = []
         self._template_variables = {}
-        self._use_cached = kwargs.pop('use_cached', False)
 
     def delete_modules(self):
         ''' Clean up sys.modules after the session is destroyed.
@@ -231,7 +230,7 @@ class Document(object):
                               period_milliseconds)
         return self._add_session_callback(cb, callback, one_shot=False)
 
-    def add_root(self, model, setter=None):
+    def add_root(self, model, setter=None, references=None):
         ''' Add a model as a root of this Document.
 
         Any changes to this model (including to other models referred to
@@ -267,7 +266,7 @@ class Document(object):
         try:
             self._roots.append(model)
         finally:
-            self._pop_all_models_freeze()
+            self._pop_all_models_freeze(model, references=references)
         self._trigger_on_change(RootAddedEvent(self, model, setter))
 
     def add_timeout_callback(self, callback, timeout_milliseconds):
@@ -1059,13 +1058,42 @@ class Document(object):
         '''
         self._all_models_freeze_count += 1
 
-    def _pop_all_models_freeze(self):
+    def _pop_all_models_freeze(self, model=None, references=None):
         '''
 
         '''
         self._all_models_freeze_count -= 1
         if self._all_models_freeze_count == 0:
-            self._recompute_all_models()
+            if model is None:
+                self._recompute_all_models()
+            else:
+                self._recompute_model(model, references=references)
+
+    def _recompute_model(self, model, references=None):
+        '''
+
+        '''
+        old_all_models_set = set(self._all_models.values())
+        if references is None:
+            references = model.references()
+        new_all_models_set = old_all_models_set.union(references)
+
+        to_detach = old_all_models_set - new_all_models_set
+        to_attach = new_all_models_set - old_all_models_set
+
+        recomputed = {}
+        recomputed_by_name = MultiValuedDict()
+        for m in new_all_models_set:
+            recomputed[m._id] = m
+            if m.name is not None:
+                recomputed_by_name.add_value(m.name, m)
+        for d in to_detach:
+            d._detach_document()
+        for a in to_attach:
+            a._attach_document(self)
+        self._all_models = recomputed
+        self._all_models_by_name = recomputed_by_name
+
 
     def _recompute_all_models(self):
         '''
@@ -1073,7 +1101,7 @@ class Document(object):
         '''
         new_all_models_set = set()
         for r in self.roots:
-            new_all_models_set = new_all_models_set.union(r.references(use_cached=self._use_cached))
+            new_all_models_set = new_all_models_set.union(r.references())
         old_all_models_set = set(self._all_models.values())
         to_detach = old_all_models_set - new_all_models_set
         to_attach = new_all_models_set - old_all_models_set

--- a/bokeh/model.py
+++ b/bokeh/model.py
@@ -649,7 +649,7 @@ class Model(with_metaclass(MetaModel, HasProps, CallbackManager)):
                     p.text('=')
                     p.pretty(value)
 
-def _find_some_document(models):
+def _find_some_document(models, _to_remove_after=None):
     '''
 
     '''
@@ -677,16 +677,17 @@ def _find_some_document(models):
                 #   box = HBox(children=[p])
                 #   show(box)
                 references = model.references()
-                references_lookup[model] = references
+                references_lookup[model._id] = references
                 for r in references:
                     if r.document is not None:
                         doc = r.document
                         break
-    if doc is None:
+    if doc is None and _to_remove_after is not None:
         doc = Document()
         for model in models:
-            doc.add_root(model, references=references_lookup[model])
-
+            if isinstance(model, Model):
+                doc.add_root(model, references=references_lookup[model._id])
+                _to_remove_after.append(model)
     return doc
 
 def _visit_immediate_value_references(value, visitor):
@@ -732,7 +733,7 @@ class _ModelInDocument(object):
         if not isinstance(models, list):
             models = [models]
 
-        self._doc = _find_some_document(models)
+        self._doc = _find_some_document(models, _to_remove_after=self._to_remove_after)
 
         for model in models:
             if isinstance(model, Model):


### PR DESCRIPTION
- [x] issues: fixes #5905

profiling this example:

```python
from bokeh.plotting import figure
from bokeh.embed import components

x1 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
y1 = [0, 8, 2, 4, 6, 9, 5, 6, 25, 28, 4]

p1 = figure()
p1.scatter(x1, y1)

script, div = components(p1)
```

before:
<img width="1127" alt="screen shot 2017-02-22 at 10 26 12 am" src="https://cloud.githubusercontent.com/assets/4806877/23218724/f87bd79c-f8ea-11e6-9cc8-8bb748990a03.png">

after:
<img width="1124" alt="screen shot 2017-02-22 at 10 22 22 am" src="https://cloud.githubusercontent.com/assets/4806877/23218720/f676503a-f8ea-11e6-9698-d74198bff1f3.png">

raw after:
9642 function calls (9573 primitive calls) in 0.008 seconds

Ordered by: internal time

ncalls  tottime  percall  cumtime  percall filename:lineno(function)
1834    0.000    0.000    0.001    0.000 {built-in method builtins.isinstance}
 3    0.000    0.000    0.001    0.000 encoder.py:203(iterencode)
100    0.000    0.000    0.003    0.000 bases.py:259(prepare_value)
732    0.000    0.000    0.000    0.000 {built-in method builtins.hasattr}
125    0.000    0.000    0.000    0.000 has_props.py:554(themed_values)
149    0.000    0.000    0.001    0.000 bases.py:354(validate)
185/161    0.000    0.000    0.000    0.000 model.py:703(_visit_value_and_its_immediate_references)
298    0.000    0.000    0.004    0.000 {built-in method builtins.getattr}
25    0.000    0.000    0.005    0.000 model.py:690(_visit_immediate_value_references)
281    0.000    0.000    0.004    0.000 descriptors.py:615(_get)
39    0.000    0.000    0.000    0.000 json_encoder.py:118(default)
80/75    0.000    0.000    0.002    0.000 properties.py:669(validate)
100    0.000    0.000    0.003    0.000 bases.py:135(themed_default)
25    0.000    0.000    0.001    0.000 has_props.py:515(query_properties_with_values)
101    0.000    0.000    0.000    0.000 {method 'join' of 'str' objects}
377    0.000    0.000    0.004    0.000 descriptors.py:414(__get__)
100    0.000    0.000    0.004    0.000 descriptors.py:521(instance_default)
167/152    0.000    0.000    0.001    0.000 bases.py:227(is_valid)
47    0.000    0.000    0.001    0.000 properties.py:1246(validate)
50    0.000    0.000    0.000    0.000 has_props.py:569(apply_theme)
225/215    0.000    0.000    0.001    0.000 properties.py:672(<genexpr>)
100    0.000    0.000    0.004    0.000 descriptors.py:643(_get_default)
100    0.000    0.000    0.000    0.000 copy.py:67(copy)
 1    0.000    0.000    0.000    0.000 decoder.py:345(raw_decode)
225    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:996(_handle_fromlist)
100    0.000    0.000    0.000    0.000 bases.py:114(_copy_default)
 2    0.000    0.000    0.001    0.000 document.py:1070(_recompute_all_models)
84    0.000    0.000    0.000    0.000 properties.py:419(__str__)
42    0.000    0.000    0.000    0.000 properties.py:1231(__str__)
75    0.000    0.000    0.000    0.000 properties.py:660(transform)
51    0.000    0.000    0.000    0.000 string.py:38(nice_join)
100    0.000    0.000    0.000    0.000 has_props.py:202(accumulate_dict_from_superclasses)
51    0.000    0.000    0.000    0.000 has_props.py:241(__setattr__)
100    0.000    0.000    0.000    0.000 bases.py:244(_wrap_container)
42    0.000    0.000    0.000    0.000 properties.py:644(__str__)
25    0.000    0.000    0.001    0.000 model.py:544(_to_json_like)
81    0.000    0.000    0.000    0.000 descriptors.py:239(serializable_value)
 1    0.000    0.000    0.005    0.005 model.py:25(collect_models)
53    0.000    0.000    0.000    0.000 abc.py:178(__instancecheck__)
50    0.000    0.000    0.000    0.000 theme.py:95(apply_to_model)
96    0.000    0.000    0.000    0.000 descriptors.py:603(serialized)
83    0.000    0.000    0.000    0.000 bases.py:125(_raw_default)
100    0.000    0.000    0.000    0.000 has_props.py:506(_overridden_defaults)
84    0.000    0.000    0.000    0.000 properties.py:426(instance_type)
276    0.000    0.000    0.000    0.000 bases.py:210(validate)
185    0.000    0.000    0.000    0.000 properties.py:647(type_params)
25    0.000    0.000    0.000    0.000 has_props.py:179(accumulate_from_superclasses)
57    0.000    0.000    0.000    0.000 _weakrefset.py:70(__contains__)
100    0.000    0.000    0.000    0.000 bases.py:103(_has_stable_default)
64    0.000    0.000    0.000    0.000 model.py:301(ref)
 1    0.000    0.000    0.001    0.001 document.py:1094(_references_json)
37    0.000    0.000    0.000    0.000 six.py:580(iteritems)
96    0.000    0.000    0.000    0.000 has_props.py:504(<lambda>)
40    0.000    0.000    0.000    0.000 model.py:46(queue_one)
 1    0.000    0.000    0.008    0.008 embed.py:52(components)
68/63    0.000    0.000    0.002    0.000 {built-in method builtins.any}
25    0.000    0.000    0.000    0.000 model.py:522(_attach_document)
 1    0.000    0.000    0.005    0.005 model.py:655(_find_some_document)
96    0.000    0.000    0.000    0.000 has_props.py:394(lookup)
 2    0.000    0.000    0.000    0.000 serialization.py:47(make_id)
51    0.000    0.000    0.000    0.000 bases.py:359(<listcomp>)
 1    0.000    0.000    0.008    0.008 <string>:2(<module>)
 3    0.000    0.000    0.000    0.000 runtime.py:115(__init__)
 1    0.000    0.000    0.005    0.005 model.py:725(__init__)
51    0.000    0.000    0.000    0.000 string.py:54(<listcomp>)
 1    0.000    0.000    0.008    0.008 {built-in method builtins.exec}
 1    0.000    0.000    0.001    0.001 document.py:234(add_root)
 2    0.000    0.000    0.000    0.000 {built-in method posix.urandom}
25    0.000    0.000    0.000    0.000 model.py:534(_detach_document)
10    0.000    0.000    0.000    0.000 os.py:720(__getitem__)
 2    0.000    0.000    0.000    0.000 uuid.py:601(uuid4)
 1    0.000    0.000    0.000    0.000 document.py:85(__init__)
25    0.000    0.000    0.000    0.000 has_props.py:408(properties_with_refs)
126    0.000    0.000    0.000    0.000 bases.py:64(__str__)
50    0.000    0.000    0.000    0.000 theme.py:80(_for_class)
22    0.000    0.000    0.000    0.000 properties.py:1740(prepare_value)
96    0.000    0.000    0.000    0.000 bases.py:149(serialized)
 1    0.000    0.000    0.002    0.002 embed.py:531(_standalone_docs_json_and_render_items)
25    0.000    0.000    0.001    0.000 has_props.py:483(properties_with_values)
 2    0.000    0.000    0.000    0.000 serialization.py:194(traverse_data)
 3    0.000    0.000    0.001    0.000 json_encoder.py:151(serialize_json)
 3    0.000    0.000    0.000    0.000 runtime.py:55(new_context)
10    0.000    0.000    0.000    0.000 _collections_abc.py:594(get)
 2    0.000    0.000    0.000    0.000 uuid.py:106(__init__)
 1    0.000    0.000    0.000    0.000 serialization.py:229(transform_column_source_data)
 1    0.000    0.000    0.002    0.002 document.py:721(to_json_string)
 2    0.000    0.000    0.000    0.000 embed.py:476(_check_models)
 1    0.000    0.000    0.000    0.000 embed.py:442(_script_for_render_items)
15    0.000    0.000    0.000    0.000 descriptors.py:846(serializable_value)
10    0.000    0.000    0.000    0.000 settings.py:26(_get)
 9    0.000    0.000    0.000    0.000 properties.py:1465(to_serializable)
 3    0.000    0.000    0.001    0.000 __init__.py:182(dumps)
 1    0.000    0.000    0.002    0.002 document.py:708(to_json)
 6    0.000    0.000    0.000    0.000 properties.py:1705(isconst)
 2    0.000    0.000    0.000    0.000 document.py:1170(_with_self_as_curdoc)
 2    0.000    0.000    0.005    0.002 model.py:394(references)
95    0.000    0.000    0.000    0.000 copy.py:110(_copy_immutable)
100    0.000    0.000    0.000    0.000 bases.py:198(transform)
30    0.000    0.000    0.000    0.000 model.py:294(document)
51    0.000    0.000    0.000    0.000 {method 'union' of 'set' objects}
160    0.000    0.000    0.000    0.000 {built-in method builtins.len}
 1    0.000    0.000    0.000    0.000 document.py:594(remove_root)
 5    0.000    0.000    0.000    0.000 containers.py:92(__init__)
 3    0.000    0.000    0.000    0.000 environment.py:974(render)
10/5    0.000    0.000    0.000    0.000 settings.py:42(_get_bool)
52    0.000    0.000    0.000    0.000 {method 'startswith' of 'str' objects}
100    0.000    0.000    0.000    0.000 {method 'get' of 'dict' objects}
 2    0.000    0.000    0.000    0.000 enums.py:77(__contains__)
10    0.000    0.000    0.000    0.000 os.py:796(encode)
 3    0.000    0.000    0.000    0.000 environment.py:1015(new_context)
 3    0.000    0.000    0.000    0.000 doc_js.js:5(root)
29    0.000    0.000    0.000    0.000 {method 'pop' of 'list' objects}
10    0.000    0.000    0.000    0.000 properties.py:1251(<genexpr>)
117    0.000    0.000    0.000    0.000 {method 'items' of 'dict' objects}
105    0.000    0.000    0.000    0.000 {method 'append' of 'list' objects}
 1    0.000    0.000    0.000    0.000 decoder.py:334(decode)
 3    0.000    0.000    0.001    0.000 encoder.py:181(encode)
 9    0.000    0.000    0.000    0.000 {built-in method builtins.all}
 2    0.000    0.000    0.000    0.000 uuid.py:226(__str__)
 3    0.000    0.000    0.000    0.000 nodes.py:81(__init__)
 2    0.000    0.000    0.000    0.000 io.py:245(curdoc)
10    0.000    0.000    0.000    0.000 settings.py:22(_environ)
 1    0.000    0.000    0.000    0.000 embed.py:35(_wrap_in_safely)
 1    0.000    0.000    0.001    0.001 model.py:744(__enter__)
 2    0.000    0.000    0.001    0.000 document.py:1062(_pop_all_models_freeze)
 2    0.000    0.000    0.000    0.000 embed.py:32(_indent)
 1    0.000    0.000    0.000    0.000 embed.py:41(_wrap_in_onload)
 5    0.000    0.000    0.000    0.000 containers.py:260(__init__)
10/5    0.000    0.000    0.000    0.000 settings.py:33(_dev_or_default)
 5    0.000    0.000    0.000    0.000 properties.py:1551(prepare_value)
41    0.000    0.000    0.000    0.000 {built-in method builtins.iter}
 2    0.000    0.000    0.000    0.000 {method 'split' of 'str' objects}
25    0.000    0.000    0.000    0.000 {method 'add' of 'set' objects}
 3    0.000    0.000    0.000    0.000 encoder.py:104(__init__)
 6    0.000    0.000    0.000    0.000 properties.py:1721(to_serializable)
80    0.000    0.000    0.000    0.000 bases.py:192(serialize_value)
 1    0.000    0.000    0.000    0.000 events.py:125(__init__)
 2    0.000    0.000    0.000    0.000 document.py:1140(_trigger_on_change)
 4    0.000    0.000    0.000    0.000 io.py:223(set_curdoc)
 1    0.000    0.000    0.000    0.000 model.py:740(__exit__)
76    0.000    0.000    0.000    0.000 {method 'keys' of 'dict' objects}
 2    0.000    0.000    0.000    0.000 embed.py:33(<listcomp>)
 5    0.000    0.000    0.000    0.000 copy.py:125(_copy_with_constructor)
 2    0.000    0.000    0.000    0.000 properties.py:1642(prepare_value)
 3    0.000    0.000    0.000    0.000 settings.py:127(pretty)
 1    0.000    0.000    0.000    0.000 string.py:8(encode_utf8)
 3    0.000    0.000    0.000    0.000 datatypes.py:12(__init__)
 2    0.000    0.000    0.000    0.000 script_tag.html:5(root)
 5    0.000    0.000    0.000    0.000 {method 'values' of 'dict' objects}
10    0.000    0.000    0.000    0.000 {method 'encode' of 'str' objects}
 2    0.000    0.000    0.000    0.000 plot_div.html:5(root)
 5    0.000    0.000    0.000    0.000 settings.py:29(_is_dev)
 3    0.000    0.000    0.000    0.000 _compat.py:29(<lambda>)
 1    0.000    0.000    0.000    0.000 __init__.py:271(loads)
 2    0.000    0.000    0.000    0.000 {built-in method from_bytes}
 2    0.000    0.000    0.000    0.000 settings.py:133(simple_ids)
 2    0.000    0.000    0.000    0.000 properties.py:1625(prepare_value)
 1    0.000    0.000    0.000    0.000 properties.py:1293(serialize_value)
 2    0.000    0.000    0.000    0.000 {method 'match' of '_sre.SRE_Pattern' objects}
 4    0.000    0.000    0.000    0.000 serialization.py:211(<genexpr>)
 1    0.000    0.000    0.000    0.000 embed.py:509(_div_for_render_item)
25    0.000    0.000    0.000    0.000 document.py:150(theme)
 2    0.000    0.000    0.000    0.000 document.py:108(roots)
 2    0.000    0.000    0.000    0.000 state.py:46(document)
 5    0.000    0.000    0.000    0.000 runtime.py:149(resolve)
 4    0.000    0.000    0.000    0.000 embed.py:484(<genexpr>)
 1    0.000    0.000    0.000    0.000 events.py:137(__init__)
 2    0.000    0.000    0.000    0.000 document.py:1056(_push_all_models_freeze)
 2    0.000    0.000    0.000    0.000 embed.py:143(<genexpr>)
 2    0.000    0.000    0.000    0.000 {method 'lower' of 'str' objects}
 1    0.000    0.000    0.000    0.000 {method 'remove' of 'list' objects}
 2    0.000    0.000    0.000    0.000 document.py:1145(invoke_callbacks)
 1    0.000    0.000    0.000    0.000 six.py:574(iterkeys)
 2    0.000    0.000    0.000    0.000 {method 'end' of '_sre.SRE_Match' objects}
 3    0.000    0.000    0.000    0.000 runtime.py:126(<genexpr>)
 2    0.000    0.000    0.000    0.000 events.py:11(__init__)
 4    0.000    0.000    0.000    0.000 state.py:54(document)
 3    0.000    0.000    0.000    0.000 {method 'pop' of 'dict' objects}
 1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
 2    0.000    0.000    0.000    0.000 {method 'count' of 'list' objects}
 3    0.000    0.000    0.000    0.000 {built-in method builtins.callable}
 1    0.000    0.000    0.000    0.000 document.py:175(title)
