### PR TITLE
Including the color option in the embed simple example

### DIFF
--- a/examples/embed/simple/simple.py
+++ b/examples/embed/simple/simple.py
@@ -44,14 +44,14 @@ def polynomial():
     args = flask.request.args
 
     # Get all the form arguments in the url with defaults
-    color = colors[getitem(args, 'color', 'Black')]
+    color = getitem(args, 'color', 'Black')
     _from = int(getitem(args, '_from', 0))
     to = int(getitem(args, 'to', 10))
 
     # Create a polynomial line graph with those arguments
     x = list(range(_from, to + 1))
     fig = figure(title="Polynomial")
-    fig.line(x, [i ** 2 for i in x], color=color, line_width=2)
+    fig.line(x, [i ** 2 for i in x], color=colors[color], line_width=2)
 
     js_resources = INLINE.render_js()
     css_resources = INLINE.render_css()

--- a/examples/embed/simple/templates/embed.html
+++ b/examples/embed/simple/templates/embed.html
@@ -19,10 +19,10 @@
     <form name="color_button" method='GET'>
         Color:
         <select name="color">
-            <option value="Red">Red</option>
-            <option value="Green">Green</option>
-            <option value="Blue">Blue</option>
-            <option selected="selected" value="Black">Black</option>
+            <option {{ "selected" if color|indent(4)|safe == "Red" }} value="Red">Red</option>
+            <option {{ "selected" if color|indent(4)|safe == "Green" }} value="Green">Green</option>
+            <option {{ "selected" if color|indent(4)|safe == "Blue" }} value="Blue">Blue</option>
+            <option {{ "selected" if color|indent(4)|safe == "Black" }} value="Black">Black</option>
         </select>
         <br>
         From:


### PR DESCRIPTION
The color information was passed to the template but was not used at all. I did very minor changes to:

1. Send the color name instead of the color numerical code in the simple.py app.
2. Use conditional `if` in the `embed.html` template in order to put the `selected` parameter in the right color.

With this changes, the selected color in the form is used for the default value.