### PR TITLE
Fix for small bug in array intersection method

### DIFF
--- a/bokehjs/src/coffee/core/util/array.ts
+++ b/bokehjs/src/coffee/core/util/array.ts
@@ -260,7 +260,7 @@ export function intersection<T>(array: Array<T>, ...arrays: Array<Array<T>>): Ar
       continue
     for (const other of arrays) {
       if (!contains(other, item))
-        break top;
+        continue top;
     }
     result.push(item)
   }

--- a/bokehjs/test/core/util/array.coffee
+++ b/bokehjs/test/core/util/array.coffee
@@ -1,0 +1,11 @@
+{expect} = require "chai"
+utils = require "../../utils"
+
+array = utils.require "core/util/array"
+
+describe "array module", ->
+
+  it "intersection should return array of values in first array found in all others", ->
+    a = [0, 1, 2]
+    b = [1, 5, 2]
+    expect(array.intersection(a, b)).to.deep.equal [1, 2]

--- a/bokehjs/test/core/util/index.coffee
+++ b/bokehjs/test/core/util/index.coffee
@@ -1,3 +1,4 @@
+require "./array"
 require "./bbox"
 require "./color"
 require "./math"


### PR DESCRIPTION
The intersection method in core.util.array returns the intersection between an array and others by looping over values in the first array and seeing whether each value is in all other arrays. There was a small bug where the outer loop would terminate if any value in the first array was not in all others instead of continuing to the next value. 

The only place that intersection is used currently is [here in document.coffee](https://github.com/bokeh/bokeh/blob/master/bokehjs/src/coffee/document.coffee#L463), and I didn't investigate that any further. 

I'm just probably going to need this method for CDS filtering/grouping.

I didn't create an issue since it was such a small fix, but let me know if anyone thinks I should. 

~- [ ] issues: fixes #xxxx~
- [x] tests added / passed
