### PR TITLE
Make sure properties are updated on (deferred) init

### DIFF
--- a/bokehjs/src/coffee/core/has_props.coffee
+++ b/bokehjs/src/coffee/core/has_props.coffee
@@ -119,6 +119,19 @@ export class HasProps extends Backbone.Model
     if not options.defer_initialization
       this.initialize.apply(this, arguments)
 
+  initialize: (options) ->
+    # This is necessary because the initial creation of properties relies on
+    # model.get which is not usable at that point yet in the constructor. This
+    # initializer is called when deferred initialization happens for all models
+    # and insures that the Bokeh properties are initialized from Backbone
+    # attributes in a consistent way.
+    #
+    # TODO (bev) split property creation up into two parts so that only the
+    # portion of init that can be done happens in HasProps constructor and so
+    # that subsequent updates do not duplicate that setup work.
+    for name, prop of @properties
+      prop.update()
+
   setv: (key, value, options) ->
     # backbones set function supports 2 call signatures, either a dictionary of
     # key value pairs, and then options, or one key, one value, and then options.
@@ -347,12 +360,6 @@ export class HasProps extends Backbone.Model
       throw new Error("models must be owned by only a single document")
 
     @document = doc
-
-    # XXXXXXX not sure about the things below yet
-
-    # TODO (bev) is there are way to get rid of this?
-    for name, prop of @properties
-      prop.update()
 
     if @_doc_attached?
       @_doc_attached()

--- a/bokehjs/test/document.coffee
+++ b/bokehjs/test/document.coffee
@@ -760,6 +760,30 @@ it "can destructively move", ->
     expect(root1.foo).to.equal 57
     expect(root1.child.foo).to.be.equal 44
 
+  it "sets proper document on models added during patching", ->
+    d = new Document()
+    expect(d.roots().length).to.equal 0
+    expect(Object.keys(d._all_models).length).to.equal 0
+
+    root1 = new SomeModel({ foo: 42 })
+    child1 = new SomeModel({ foo: 44 })
+    d.add_root(root1)
+    expect(d.roots().length).to.equal 1
+
+    # can't create copy of doc here like other test. Testing explicitly that
+    # doc attach happens when *not* creating a new document (i.e only patching)
+    # Testing only for/against null .document is not the strongest test but it
+    # should suffice.
+
+    expect(root1.document.roots().length).equal 1
+    expect(root1.child).to.equal null
+
+    event1 = new ModelChangedEvent(d, root1, 'child', root1.child, child1)
+    patch1 = d.create_json_patch_string([event1])
+    d.apply_json_patch_string(patch1)
+
+    expect(root1.document.roots().length).equal 1
+    expect(root1.child.document.roots().length).equal 1
 
   it "sets proper document on models added during construction", ->
     d = new Document()


### PR DESCRIPTION
- [x] issues: fixes #4875

Previously, a call to `prop.update` for model properties happened in `attach_document`. But attach_document was not being called for new models added in patches to existing documents, causing problems. This PR adds a (deferred) initializer to HasProps that ensures proper property setup for all models is completed in a consistent way, always.

I don't have a good test to add at the moment. I am going to add a separate issue to improve/refactor BokehJS properties to split up the creation/initialization into more usable and testable chunks. 



