### PR TITLE
Filterable and groupable CDS

### DIFF
--- a/bokeh/models/data_stores.py
+++ b/bokeh/models/data_stores.py
@@ -1,0 +1,97 @@
+from __future__ import absolute_import
+
+from ..core.properties import Any, ColumnData, Dict, Instance, List, Seq, String
+from ..model import Model
+from ..util.dependencies import import_optional
+
+pd = import_optional('pandas')
+
+class ColumnDataStore(Model):
+
+    selected = Dict(String, Dict(String, Any), default={
+        '0d': {'glyph': None, 'indices': []},
+        '1d': {'indices': []},
+        '2d': {}
+    }, help="""
+    A dict to indicate selected indices on different dimensions on this DataSource. Keys are:
+
+    .. code-block:: python
+
+        # selection information for line and patch glyphs
+        '0d' : {
+          # the glyph that was selected
+          'glyph': None
+
+          # array with the [smallest] index of the segment of the line that was hit
+          'indices': []
+        }
+
+        # selection for most (point-like) glyphs, except lines and patches
+        '1d': {
+          # indices of the points included in the selection
+          indices: []
+        }
+
+        # selection information for multiline and patches glyphs
+        '2d': {
+          # mapping of indices of the multiglyph to array of glyph indices that were hit
+          # e.g. {3: [5, 6], 4, [5]}
+        }
+
+    """)
+
+    column_names = List(String, help="""
+    A list of names for all the columns in this ColumnDataStore.
+    """)
+
+    data = ColumnData(String, Seq(Any), help="""
+    Mapping of column names to sequences of data. The data can be, e.g,
+    Python lists or tuples, NumPy arrays, etc.
+    """).asserts(lambda _, data: len(set(len(x) for x in data.values())) <= 1,
+                 lambda: warnings.warn("ColumnDataStore's columns must be of the same length", BokehUserWarning))
+
+    def __init__(self, *args, **kw):
+        ''' If called with a single argument that is a dict or
+        pandas.DataFrame, treat that implicitly as the "data" attribute.
+
+        '''
+        if len(args) == 1 and "data" not in kw:
+            kw["data"] = args[0]
+
+        # TODO (bev) invalid to pass args and "data", check and raise exception
+        raw_data = kw.pop("data", {})
+
+        if not isinstance(raw_data, dict):
+            if pd and isinstance(raw_data, pd.DataFrame):
+                raw_data = self._data_from_df(raw_data)
+            else:
+                raise ValueError("expected a dict or pandas.DataFrame, got %s" % raw_data)
+
+        super(ColumnDataStore, self).__init__(**kw)
+
+        self.column_names[:] = list(raw_data.keys())
+        self.data.update(raw_data)
+
+    @staticmethod
+    def _data_from_df(df):
+        ''' Create a ``dict`` of columns from a Pandas DataFrame,
+        suitable for creating a ColumnDataSource.
+
+        Args:
+            df (DataFrame) : data to convert
+
+        Returns:
+            dict(str, list)
+
+        '''
+        index = df.index
+        new_data = {}
+        for colname in df:
+            new_data[colname] = df[colname].tolist()
+        if index.name:
+            new_data[index.name] = index.tolist()
+        elif index.names and not all([x is None for x in index.names]):
+            new_data["_".join(index.names)] = index.tolist()
+        else:
+            new_data["index"] = index.tolist()
+        return new_data

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -83,6 +83,11 @@ class ColumnDataSource(ColumnarDataSource):
 
     filter = Either(Seq(Int), Seq(Bool), default=[])
 
+    group = Seq(String, default=[], help="""
+    A tuple or list of length 2 that specifies the groupby column
+    and the group name.
+    """)
+
     def __init__(self, *args, **kw):
         ''' If called with a single argument that is a dict or
         pandas.DataFrame, treat that implicitly as the "data" attribute for 

--- a/bokehjs/src/coffee/core/selection_manager.coffee
+++ b/bokehjs/src/coffee/core/selection_manager.coffee
@@ -28,7 +28,8 @@ export class SelectionManager extends HasProps
       selector = @_get_selector(renderer_view)
       selector.update(indices, final, append)
 
-      @source.selected = selector.indices
+      @source.data_store.selected = @source.convert_selection_to_data_store(selector.indices)
+      @source.data_store.trigger('select')
 
       source.trigger('select')
       source.trigger('select-' + renderer_view.model.id)

--- a/bokehjs/src/coffee/models/data_stores/column_data_store.coffee
+++ b/bokehjs/src/coffee/models/data_stores/column_data_store.coffee
@@ -1,0 +1,48 @@
+import {Model} from "../../model"
+import * as p from "../../core/properties"
+import * as serialization from "../../core/util/serialization"
+import * as hittest from "../../core/hittest"
+import {SelectionManager} from "../../core/selection_manager"
+import {uniq} from "../../core/util/array"
+
+export class ColumnDataStore extends Model
+  type: 'ColumnDataStore'
+
+  initialize: (options) ->
+    super(options)
+    [@data, @_shapes] = serialization.decode_column_data(@data)
+
+  @define {
+      data: [p.Any]
+      column_names: [p.Array]
+      selected: [ p.Any, hittest.create_hit_test_result() ] # TODO (bev)
+    }
+
+  @internal {
+    selection_manager: [ p.Instance, (self) -> new SelectionManager({source: self}) ]
+    inspected:         [ p.Any ]
+    _shapes:      [ p.Any, {}]
+  }
+
+  get_column: (colname) ->
+    return @data[colname] ? null
+
+  columns: () ->
+    # return the column names in this data source
+    return Object.keys(@data)
+
+  get_length: (soft=true) ->
+    lengths = uniq((val.length for _key, val of @data))
+
+    switch lengths.length
+      when 0
+        return null # XXX: don't guess, treat on case-by-case basis
+      when 1
+        return lengths[0]
+      else
+        msg = "data store has columns of inconsistent lengths"
+        if soft
+          logger.warn(msg)
+          return lengths.sort()[0]
+        else
+          throw new Error(msg)

--- a/bokehjs/src/coffee/models/data_stores/index.coffee
+++ b/bokehjs/src/coffee/models/data_stores/index.coffee
@@ -1,0 +1,1 @@
+export {ColumnDataStore}   from "./column_data_store"

--- a/bokehjs/src/coffee/models/index.coffee
+++ b/bokehjs/src/coffee/models/index.coffee
@@ -1,6 +1,7 @@
 export * from "./annotations"
 export * from "./axes"
 export * from "./callbacks"
+export * from "./data_stores"
 export * from "./formatters"
 export * from "./glyphs"
 export * from "./grids"

--- a/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
+++ b/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
@@ -247,6 +247,7 @@ export class GlyphRenderer extends Renderer
       x_range_name:       [ p.String,  'default' ]
       y_range_name:       [ p.String,  'default' ]
       data_source:        [ p.Instance           ]
+      group:              [ p.Array,       []    ]
       glyph:              [ p.Instance           ]
       hover_glyph:        [ p.Instance           ]
       nonselection_glyph: [ p.Any,      'auto'   ] # Instance or "auto"


### PR DESCRIPTION
This PR is a second attempt to create a filterable CDS. The first attempt in [this PR](https://github.com/bokeh/bokeh/pull/5828) created a new data source called the TableDataSource. This second attempt instead puts the filtering functionality into the ColumnDataSource (CDS). 

In this approach, the data and filters are separated by pulling out the CDS's data into a new model called the ColumnDataStore (data store). The data store would be responsible for holding the data as well as the selection on the full data set. (It would also be responsible for streaming and patching the data and the CDS could have stream and patch methods that called the data store's stream and patch methods.)

I additionally added a group property to the CDS, which specifies a column name and a group name to restrict to. This allows for an API that looks like (described by @bryevdv [here](https://github.com/bokeh/bokeh/issues/5884#issuecomment-280669400))

```python
fig.circle('sepal_width', 'petal_width', source=source, group=('species', 'setosa'))
```

With the first two commits in this PR, you can have something like:

![iris_groups](https://cloud.githubusercontent.com/assets/4241244/23443241/578a736e-fde2-11e6-9863-a87f930828b4.gif)

```python
from bokeh.plotting import figure
from bokeh.layouts import row, column
from bokeh.models.sources import ColumnDataSource
from bokeh.models.data_stores import ColumnDataStore
from bokeh.io import output_file, show

from bokeh.sampledata.iris import flowers

output_file("filter_group_cds.html")

import numpy as np

data_store = ColumnDataStore(flowers)
source0 = ColumnDataSource(data_store)
source1 = ColumnDataSource(data_store, filter=lambda cds: np.array(cds.data_store.data['species']) == 'setosa')
source2 = ColumnDataSource(data_store, group=['species', 'versicolor'])
source3 = ColumnDataSource(data_store, group=['species', 'virginica'])

plot_size_and_tools = {'plot_height': 300, 'plot_width': 300,
                        'tools':['box_select', 'reset']}

fig1 = figure(title="Full data set", **plot_size_and_tools)
fig1.circle(x='petal_length', y='petal_width', source=source0, color='black')

fig2 = figure(title="Composed of filtered and grouped data", x_range=fig1.x_range, y_range=fig1.y_range, **plot_size_and_tools)
fig2.circle(x='petal_length', y='petal_width', source=source1, color='red')
fig2.square(x='petal_length', y='petal_width', source=source2, color='green')
fig2.diamond(x='petal_length', y='petal_width', source=source3, color='blue')

show(row(fig1, fig2))
```

One issue shown the GIF above is that selecting points on the right figure only works with the last renderer. This issue is discussed in [issue 2136](https://github.com/bokeh/bokeh/issues/2136) and [issue 2989](https://github.com/bokeh/bokeh/issues/2989).

This PR is still in early stages, and I'm looking for feedback at any level. The group property may not be strictly necessary. Users can filter as in source1 in the above example for a specific group on their own and a higher-level plot.scatter method (with a groupby parameter) could use filter internally as well. 

With this PR, each filter is represented through one CDS. Another approach could be to have a CDS contain a mapping of renderers to filters. Then, each renderer could use the same CDS. The filter could be made on the creation of a renderer and be added to the CDS's renderer-filter mapping. 

- [ ] issues: fixes #4070
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
