### PR TITLE
Disable Saucelabs tests for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,10 @@ matrix:
       env: GROUP=flake_docs
 
     # integration tests (python 3.4)
-    - python: 3.4
-      env: GROUP=integration
-      addons:
-        sauce_connect: true
+    # - python: 3.4
+    #   env: GROUP=integration
+    #   addons:
+    #     sauce_connect: true
 
 branches:
   only:


### PR DESCRIPTION
Disable Saucelabs tests until time can be set aside to diagnose the current unexpected failures. 