### PR TITLE
DOC : Transforms methods dedent for Sphinx

### DIFF
--- a/bokeh/models/transforms.py
+++ b/bokeh/models/transforms.py
@@ -19,11 +19,11 @@ class Transform(Model):
 
     .. code-block: coffeescript
 
-        compute: (x) ->
-            # compute the transform of a single value
+       compute: (x) ->
+           # compute the transform of a single value
 
-        v_compute: (xs) ->
-            # compute the transform of an array of values
+       v_compute: (xs) ->
+           # compute the transform of an array of values
 
     '''
     pass


### PR DESCRIPTION
issues: fixes #5887 

Looks like the methods to be implemented were indented one space too many, and missed by sphinx.

