### PR TITLE
Remove blocking server.start() from flask_embed example

### DIFF
--- a/examples/howto/server_embed/flask_embed.py
+++ b/examples/howto/server_embed/flask_embed.py
@@ -35,7 +35,6 @@ bokeh_app = Application(FunctionHandler(modify_doc))
 io_loop = IOLoop.current()
 
 server = Server({'/bkapp': bokeh_app}, io_loop=io_loop, allow_websocket_origin=["localhost:8080"])
-server.start()
 
 @flask_app.route('/', methods=['GET'])
 def bkapp_page():


### PR DESCRIPTION
This PR fixed the issue for the flask_embed.py example

- [x] issues: fixes #5980
- [NA] tests added / passed
- [NA] release document entry (if new feature or API change)
