### PR TITLE
Move webgl glyphs and related code to bokeh-gl bundle

### DIFF
--- a/bokehjs/gulp/paths.coffee
+++ b/bokehjs/gulp/paths.coffee
@@ -40,6 +40,11 @@ module.exports = {
         full: "bokeh-widgets.js"
         fullWithPath: path.join(JS_BUILD_DIR, "bokeh-widgets.js")
         minified: "bokeh-widgets.min.js"
+    gl:
+      destination:
+        full: "bokeh-gl.js"
+        fullWithPath: path.join(JS_BUILD_DIR, "bokeh-gl.js")
+        minified: "bokeh-gl.min.js"
     sources: [
         "./src/coffee/main.coffee"
         "./src/coffee/widget/main.coffee"

--- a/bokehjs/gulp/tasks/scripts.coffee
+++ b/bokehjs/gulp/tasks/scripts.coffee
@@ -107,6 +107,7 @@ gulp.task "scripts:bundle", ["scripts:compile"], (cb) ->
 
   buildBokehjs = (next) ->
     if argv.verbose then util.log("Building bokehjs")
+    bokehjs.exclude(path.resolve("build/js/tree/models/glyphs/webgl/index.js"))
     labels.bokehjs = namedLabeler(bokehjs, {})
     bokehjs
       .bundle()
@@ -162,6 +163,8 @@ gulp.task "scripts:bundle", ["scripts:compile"], (cb) ->
 
   buildWidgets = mkBuildPlugin("widgets", 'models/widgets/main.js')
 
+  buildGL = mkBuildPlugin("gl", "models/glyphs/webgl/main.js")
+
   writeLabels = (next) ->
     data = {}
     for own name, module_labels of labels
@@ -169,7 +172,7 @@ gulp.task "scripts:bundle", ["scripts:compile"], (cb) ->
     modulesPath = path.join(paths.buildDir.js, "modules.json")
     fs.writeFile(modulesPath, JSON.stringify(data), () -> next())
 
-  buildBokehjs(() -> buildAPI(() -> buildWidgets(() -> writeLabels(cb))))
+  buildBokehjs(() -> buildAPI(() -> buildWidgets(() -> buildGL(() -> writeLabels(cb)))))
   null # XXX: this is extremely important to allow cb() to work
 
 gulp.task "scripts:build", ["scripts:bundle"]
@@ -196,7 +199,7 @@ gulp.task "compiler:build", ->
     .pipe(gulp.dest(paths.buildDir.js))
 
 gulp.task "scripts:minify", ["scripts:bundle"], ->
-  tasks = [paths.coffee.bokehjs, paths.coffee.api, paths.coffee.widgets].map (entry) ->
+  tasks = [paths.coffee.bokehjs, paths.coffee.api, paths.coffee.widgets, paths.coffee.gl].map (entry) ->
     gulp.src(entry.destination.fullWithPath)
       .pipe(rename((path) -> path.basename += '.min'))
       .pipe(uglify({ output: {comments: /^!|copyright|license|\(c\)/i} }))

--- a/bokehjs/src/coffee/core/util/color.coffee
+++ b/bokehjs/src/coffee/core/util/color.coffee
@@ -1,5 +1,3 @@
-# Used by webgl to convert colors to rgba tuples.
-
 import * as svg_colors from "./svg_colors"
 
 _component2hex = (v) ->

--- a/bokehjs/src/coffee/models/canvas/canvas.coffee
+++ b/bokehjs/src/coffee/models/canvas/canvas.coffee
@@ -21,9 +21,6 @@ export class CanvasView extends BokehView
     # create the canvas context that gets passed around for drawing
     @ctx = @get_ctx()
 
-    # init without webgl support (can be overriden in plot.coffee)
-    @ctx.glcanvas = null
-
     # work around canvas incompatibilities
     fixup_line_dash(@ctx)
     fixup_line_dash_offset(@ctx)

--- a/bokehjs/src/coffee/models/glyphs/webgl/index.ts
+++ b/bokehjs/src/coffee/models/glyphs/webgl/index.ts
@@ -1,0 +1,18 @@
+/*
+Copyright notice: many of the awesome techniques and  GLSL code contained in
+this module are based on work by Nicolas Rougier as part of the Glumpy and
+Vispy projects. The algorithms are published in
+http://jcgt.org/published/0003/04/01/ and http://jcgt.org/published/0002/02/08/
+
+This module contains all gl-specific code to add gl support for the glyphs.
+By implementing it separetely, the GL functionality can be spun off in a
+separate library.
+Other locations where we work with GL, or prepare for GL-rendering:
+- canvas.coffee
+- plot.coffee
+- glyph.coffee
+- glyph_renderer.coffee
+*/
+
+export * from "./line"
+export * from "./markers"

--- a/bokehjs/src/coffee/models/glyphs/webgl/main.coffee
+++ b/bokehjs/src/coffee/models/glyphs/webgl/main.coffee
@@ -1,16 +1,1 @@
-# Copyright notice: many of the awesome techniques and  GLSL code contained in
-# this module are based on work by Nicolas Rougier as part of the Glumpy and
-# Vispy projects. The algorithms are published in
-# http://jcgt.org/published/0003/04/01/ and http://jcgt.org/published/0002/02/08/
-#
-# This module contains all gl-specific code to add gl support for the glyphs.
-# By implementing it separetely, the GL functionality can be spun off in a
-# separate library.
-# Other locations where we work with GL, or prepare for GL-rendering:
-# - canvas.coffee
-# - plot.coffee
-# - glyph.coffee
-# - glyph_renderer.coffee
-
-export * from "./line"
-export * from "./markers"
+import "./index"

--- a/bokehjs/src/coffee/models/plots/plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.coffee
@@ -32,7 +32,7 @@ import {update_constraints as update_panel_constraints} from "core/layout/side_p
 # The presence (and not-being-false) of the ctx.glcanvas attribute is the
 # marker that we use throughout that determines whether we have gl support.
 
-global_gl_canvas = null
+global_glcanvas = null
 
 export class PlotCanvasView extends BokehView
   className: "bk-plot-wrapper"
@@ -88,9 +88,8 @@ export class PlotCanvasView extends BokehView
     @canvas_view.render(true)
 
     # If requested, try enabling webgl
-    if @model.plot.webgl or window.location.search.indexOf('webgl=1') > 0
-      if window.location.search.indexOf('webgl=0') == -1
-        @init_webgl()
+    if @model.plot.webgl
+      @init_webgl()
 
     @throttled_render = throttle(@render, 15) # TODO (bev) configurable
 
@@ -134,9 +133,9 @@ export class PlotCanvasView extends BokehView
 
     # We use a global invisible canvas and gl context. By having a global context,
     # we avoid the limitation of max 16 contexts that most browsers have.
-    glcanvas = global_gl_canvas
+    glcanvas = global_glcanvas
     if not glcanvas?
-      global_gl_canvas = glcanvas = document.createElement('canvas')
+      global_glcanvas = glcanvas = document.createElement('canvas')
       opts = {'premultipliedAlpha': true}  # premultipliedAlpha is true by default
       glcanvas.gl = glcanvas.getContext("webgl", opts) || glcanvas.getContext("experimental-webgl", opts)
 
@@ -146,7 +145,6 @@ export class PlotCanvasView extends BokehView
       ctx.glcanvas = glcanvas
     else
       logger.warn('WebGL is not supported, falling back to 2D canvas.')
-      # Do not set @canvas_view.ctx.glcanvas
 
   prepare_webgl: (ratio, frame_box) ->
     # Prepare WebGL for a drawing pass

--- a/bokehjs/test/common/selection_manager.coffee
+++ b/bokehjs/test/common/selection_manager.coffee
@@ -52,7 +52,7 @@ describe "SelectionManager", ->
       'y_mappers':
         {'default': mapper_normal}
     canvas_view:
-      ctx: {'glcanvas': null}
+      ctx: {}
     model:
       plot_model_stub
   }
@@ -64,7 +64,7 @@ describe "SelectionManager", ->
       'y_mappers':
         {'default': mapper_reverse}
     canvas_view:
-      ctx: {'glcanvas': null}
+      ctx: {}
     model:
       plot_model_stub
   }

--- a/bokehjs/test/size.coffee
+++ b/bokehjs/test/size.coffee
@@ -7,10 +7,11 @@ build_dir = path.normalize("#{__dirname}/../build")
 
 LIMITS = {
   "css/bokeh-widgets.min.css": 160
-  "css/bokeh.min.css":         60
+  "css/bokeh.min.css":          60
   "js/bokeh-widgets.min.js":   380
   "js/bokeh-api.min.js":        75
-  "js/bokeh.min.js":           699
+  "js/bokeh-gl.min.js":         70
+  "js/bokeh.min.js":           650
 }
 
 for filename, maxsize of LIMITS

--- a/scripts/build_upload.py
+++ b/scripts/build_upload.py
@@ -346,7 +346,7 @@ def upload_cdn(cdn_token, cdn_id):
     version = CONFIG.version
 
     content_type = "application/javascript"
-    for name in ('bokeh', 'bokeh-api', 'bokeh-widgets'):
+    for name in ('bokeh', 'bokeh-api', 'bokeh-widgets', 'bokeh-gl'):
         for suffix in ('js', 'min.js'):
             local_path = 'bokehjs/build/js/%s.%s' % (name, suffix)
             cdn_path = 'bokeh/bokeh/%s/%s-%s.%s' % (subdir, name, version, suffix)

--- a/sphinx/source/docs/releases/0.12.5.rst
+++ b/sphinx/source/docs/releases/0.12.5.rst
@@ -170,3 +170,10 @@ The ``bokeh.io.output_server`` function, which was deprecated in ``0.12.3``,
 has been removed. Additionally, ``bokeh.io.push`` and other supporting
 functions or properties that are useless without ``output_server`` have
 also been removed.
+
+Enabling WebGL rendering with URL parameters was disallowed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously it was allowed to enable WebGL with `?webgl=1` URL parameter. This
+isn't possible anymore since addition of `bokeh-gl` bundle. Configure WebGL
+rendering with `Plot.webgl` property.

--- a/sphinx/source/docs/user_guide/webgl.rst
+++ b/sphinx/source/docs/user_guide/webgl.rst
@@ -24,10 +24,6 @@ To enable WebGL, set the plot's ``webgl`` property to ``True``:
     p = Plot(webgl=True)  # for the glyph API
     p = figure(webgl=True)  # for the plotting API
 
-Alternatively, WebGL can be explicitly enabled or disabled on a page
-by adding ``?webgl=1`` or ``#webgl=0`` to the URL.
-
-
 Support
 -------
 


### PR DESCRIPTION
Reduces `bokeh.min.js` size from 699 to 636 kB. `gloo2` and `models/glyphs/webgl` were moved to `bokeh-gl` bundle, which is automatically included if `Plot.webgl == True`. The logic is the same, i.e. there are no new models and `webgl` is left. This also means that the code is still a mess, with webgl popping up everywhere, but at least the bulk of the webgl code is in the new bundle.

fixes #4321
