### PR TITLE
Make custom models' bundle part of embed instead of resources

### DIFF
--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -28,10 +28,11 @@ from .core.templates import (
 from .core.json_encoder import serialize_json
 from .document import Document, DEFAULT_TITLE
 from .model import Model
-from .resources import BaseResources, _SessionCoordinates, EMPTY
+from .resources import BaseResources, _SessionCoordinates
 from .util.deprecation import deprecated
 from .util.string import encode_utf8
 from .util.serialization import make_id
+from .util.compiler import bundle_all_models
 
 def _indent(text, n=2):
     return "\n".join([ " "*n + line for line in text.split("\n") ])
@@ -52,6 +53,9 @@ def _wrap_in_onload(code):
   else document.addEventListener("DOMContentLoaded", fn);
 })();
 """ % dict(code=_indent(code, 4))
+
+def _wrap_in_script_tag(js):
+    return SCRIPT_TAG.render(js_code=js)
 
 @contextmanager
 def _ModelInDocument(models, apply_theme=None):
@@ -202,7 +206,10 @@ def components(models, wrap_script=True, wrap_plot_info=True, theme=FromCurdoc):
     with _ModelInDocument(models, apply_theme=theme):
         (docs_json, render_items) = _standalone_docs_json_and_render_items(models)
 
-    script = _script_for_render_items(docs_json, render_items, wrap_script=wrap_script)
+    script  = bundle_all_models()
+    script += _script_for_render_items(docs_json, render_items)
+    if wrap_script:
+        script = _wrap_in_script_tag(script)
     script = encode_utf8(script)
 
     if wrap_plot_info:
@@ -317,14 +324,13 @@ def notebook_div(model, notebook_comms_target=None, theme=FromCurdoc):
         docs_json=serialize_json(docs_json),
         render_items=serialize_json(render_items)
     ))
-    resources = EMPTY
 
     js = AUTOLOAD_NB_JS.render(
         comms_target=notebook_comms_target,
-        js_urls = resources.js_files,
-        css_urls = resources.css_files,
-        js_raw = resources.js_raw + [script],
-        css_raw = resources.css_raw_str,
+        js_urls = [],
+        css_urls = [],
+        js_raw = [script],
+        css_raw = "",
         elementid = item['elementid']
     )
     div = _div_for_render_item(item)
@@ -402,13 +408,14 @@ def autoload_static(model, resources, script_path):
     with _ModelInDocument([model]):
         (docs_json, render_items) = _standalone_docs_json_and_render_items([model])
 
-    script = _script_for_render_items(docs_json, render_items, wrap_script=False)
+    bundle = bundle_all_models()
+    script = _script_for_render_items(docs_json, render_items)
     item = render_items[0]
 
     js = _wrap_in_onload(AUTOLOAD_JS.render(
         js_urls = resources.js_files,
         css_urls = resources.css_files,
-        js_raw = resources.js_raw + [script],
+        js_raw = resources.js_raw + [bundle, script],
         css_raw = resources.css_raw_str,
         elementid = item['elementid'],
     ))
@@ -532,18 +539,13 @@ def autoload_server(model, app_path=None, session_id=None, url="default", relati
 
     return encode_utf8(tag)
 
-def _script_for_render_items(docs_json, render_items, app_path=None, absolute_url=None, wrap_script=True):
-    plot_js = _wrap_in_onload(_wrap_in_safely(DOC_JS.render(
+def _script_for_render_items(docs_json, render_items, app_path=None, absolute_url=None):
+    return _wrap_in_onload(_wrap_in_safely(DOC_JS.render(
         docs_json=serialize_json(docs_json),
         render_items=serialize_json(render_items),
         app_path=app_path,
-        absolute_url=absolute_url
+        absolute_url=absolute_url,
     )))
-
-    if wrap_script:
-        return SCRIPT_TAG.render(js_code=plot_js)
-    else:
-        return plot_js
 
 def _html_page_for_render_items(bundle, docs_json, render_items, title,
                                 template=FILE, template_variables={}):
@@ -552,7 +554,8 @@ def _html_page_for_render_items(bundle, docs_json, render_items, title,
 
     bokeh_js, bokeh_css = bundle
 
-    script = _script_for_render_items(docs_json, render_items)
+    script  = bundle_all_models()
+    script += _script_for_render_items(docs_json, render_items)
 
     template_variables_full = template_variables.copy()
 
@@ -560,7 +563,7 @@ def _html_page_for_render_items(bundle, docs_json, render_items, title,
         title = title,
         bokeh_js = bokeh_js,
         bokeh_css = bokeh_css,
-        plot_script = script,
+        plot_script = _wrap_in_script_tag(script),
         plot_div = "\n".join(_div_for_render_item(item) for item in render_items)
     ))
 

--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -27,7 +27,6 @@ from .settings import settings
 
 from .util.paths import bokehjsdir
 from .util.session_id import generate_session_id
-from .util.compiler import gen_custom_models_static
 from .model import Model
 
 DEFAULT_SERVER_HOST = "localhost"
@@ -331,10 +330,6 @@ class JSResources(BaseResources):
         if self.log_level is not None:
             raw.append('Bokeh.set_log_level("%s");' % self.log_level)
 
-        custom_models = gen_custom_models_static()
-        if custom_models is not None:
-            raw.append(custom_models)
-
         return raw
 
     def render_js(self):
@@ -459,5 +454,3 @@ class Resources(JSResources, CSSResources):
 CDN = Resources(mode="cdn")
 
 INLINE = Resources(mode="inline")
-
-EMPTY = Resources(mode="inline", components=[], log_level=None)

--- a/bokeh/server/views/autoload_js_handler.py
+++ b/bokeh/server/views/autoload_js_handler.py
@@ -11,6 +11,7 @@ from tornado import gen
 
 from bokeh.core.templates import AUTOLOAD_JS
 from bokeh.util.string import encode_utf8
+from bokeh.util.compiler import bundle_all_models
 from bokeh.embed import _script_for_render_items
 
 from .session_handler import SessionHandler
@@ -43,13 +44,15 @@ class AutoloadJsHandler(SessionHandler):
             server_url = None
         resources = self.application.resources(server_url)
 
+        bundle = bundle_all_models()
+
         render_items = [dict(sessionid=session.id, elementid=element_id, use_for_title=False)]
-        script = _script_for_render_items(None, render_items, app_path=app_path, absolute_url=absolute_url, wrap_script=False)
+        script = _script_for_render_items(None, render_items, app_path=app_path, absolute_url=absolute_url)
 
         js = AUTOLOAD_JS.render(
             js_urls = resources.js_files,
             css_urls = resources.css_files,
-            js_raw = resources.js_raw + [script],
+            js_raw = resources.js_raw + [bundle, script],
             css_raw = resources.css_raw_str,
             elementid = element_id,
         )

--- a/bokeh/util/compiler.py
+++ b/bokeh/util/compiler.py
@@ -273,10 +273,11 @@ class CustomModel(object):
     def module(self):
         return "custom/%s" % snakify(self.full_name)
 
-def gen_custom_models_static():
+def bundle_models(models):
+    """Create a bundle of `models`. """
     custom_models = {}
 
-    for cls in Model.model_class_reverse_map.values():
+    for cls in models:
         impl = getattr(cls, "__implementation__", None)
 
         if impl is not None:
@@ -383,3 +384,6 @@ def gen_custom_models_static():
     modules = sep.join([ _module_template % dict(module=module, code=code, deps=json.dumps(deps)) for (module, code, deps) in modules ])
 
     return _plugin_template % dict(prelude=_plugin_prelude, exports=exports, modules=modules)
+
+def bundle_all_models():
+    return bundle_models(Model.model_class_reverse_map.values()) or ""

--- a/bokeh/util/notebook.py
+++ b/bokeh/util/notebook.py
@@ -44,6 +44,7 @@ def _load_notebook_html(resources=None, verbose=False, hide_banner=False,
     from .. import __version__
     from ..core.templates import AUTOLOAD_NB_JS, NOTEBOOK_LOAD
     from ..util.serialization import make_id
+    from ..util.compiler import bundle_all_models
     from ..resources import CDN
 
     if resources is None:
@@ -75,11 +76,13 @@ def _load_notebook_html(resources=None, verbose=False, hide_banner=False,
         hide_banner   = hide_banner,
     )
 
+    custom_models_js = bundle_all_models()
+
     js = AUTOLOAD_NB_JS.render(
         elementid = '' if hide_banner else element_id,
         js_urls  = resources.js_files,
         css_urls = resources.css_files,
-        js_raw   = resources.js_raw + ([] if hide_banner else [FINALIZE_JS % element_id]),
+        js_raw   = resources.js_raw + [custom_models_js] + ([] if hide_banner else [FINALIZE_JS % element_id]),
         css_raw  = resources.css_raw_str,
         force    = True,
         timeout  = load_timeout


### PR DESCRIPTION
This allows to use custom models with `components()` by moving custom models' bundles from resources to embed.

fixes #5353