### PR TITLE
Fixed bug in Model._process_event method

### DIFF
--- a/bokehjs/src/coffee/model.coffee
+++ b/bokehjs/src/coffee/model.coffee
@@ -30,7 +30,7 @@ export class Model extends HasProps
       for callback in @js_event_callbacks[event.event_name] ? []
         callback.execute({event: event}, {})
 
-      if @subscribed_events.some((m) -> m == event_name)
+      if @subscribed_events.some((m) -> m == event.event_name)
         @document.event_manager.send_event(event)
 
   trigger_event: (event) ->


### PR DESCRIPTION

Small fix to code merged from #5941: in ``Model._process_event`` the variable``event_name`` is undefined and it should be ``event.event_name``. 

After this fix, there are no more exceptions in the web console when running ``events_app.py``. Note this code path isn't executed when running ``js_events.py`` which is why I didn't notice this problem earlier.