### PR TITLE
Avoid isinstance checks in _visit_value_and_its_immediate_references

### DIFF
--- a/bokeh/model.py
+++ b/bokeh/model.py
@@ -700,8 +700,12 @@ _common_types = {int, float, str}
 
 
 def _visit_value_and_its_immediate_references(obj, visitor):
-    '''
+    ''' Recurse down Models, HasProps, and Python containers
 
+    The ordering in this function is to optimize performance.  We check the
+    most comomn types (int, float, str) first so that we can quickly return in
+    the common case.  We avoid isinstance and issubclass checks in a couple
+    places with `type` checks because isinstance checks can be slow.
     '''
     typ = type(obj)
     if typ in _common_types:  # short circuit on common base types

--- a/bokeh/model.py
+++ b/bokeh/model.py
@@ -695,19 +695,27 @@ def _visit_immediate_value_references(value, visitor):
     else:
         _visit_value_and_its_immediate_references(value, visitor)
 
+
+_common_types = {int, float, str}
+
+
 def _visit_value_and_its_immediate_references(obj, visitor):
     '''
 
     '''
-    if isinstance(obj, Model):
-        visitor(obj)
-    elif isinstance(obj, HasProps):
-        # this isn't a Model, so recurse into it
-        _visit_immediate_value_references(obj, visitor)
-    elif isinstance(obj, (list, tuple)):
+    typ = type(obj)
+    if typ in _common_types:  # short circuit on common base types
+        return
+    if typ is list or issubclass(typ, (list, tuple)):  # check common containers
         for item in obj:
             _visit_value_and_its_immediate_references(item, visitor)
-    elif isinstance(obj, dict):
+    elif issubclass(typ, dict):
         for key, value in iteritems(obj):
             _visit_value_and_its_immediate_references(key, visitor)
             _visit_value_and_its_immediate_references(value, visitor)
+    elif issubclass(typ, HasProps):
+        if issubclass(typ, Model):
+            visitor(obj)
+        else:
+            # this isn't a Model, so recurse into it
+            _visit_immediate_value_references(obj, visitor)

--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -216,9 +216,7 @@ def traverse_data(obj, is_numpy=is_numpy, use_numpy=True):
         return [transform_array(el) for el in obj]
     obj_copy = []
     for item in obj:
-        if isinstance(item, (list, tuple)):
-            obj_copy.append(traverse_data(item))
-        elif isinstance(item, float):
+        if isinstance(item, float):
             if np.isnan(item):
                 item = 'NaN'
             elif np.isposinf(item):
@@ -226,6 +224,8 @@ def traverse_data(obj, is_numpy=is_numpy, use_numpy=True):
             elif np.isneginf(item):
                 item = '-Infinity'
             obj_copy.append(item)
+        elif isinstance(item, (list, tuple)):
+            obj_copy.append(traverse_data(item))
         else:
             obj_copy.append(item)
     return obj_copy

--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -216,6 +216,8 @@ def traverse_data(obj, is_numpy=is_numpy, use_numpy=True):
         return [transform_array(el) for el in obj]
     obj_copy = []
     for item in obj:
+        # Check the base/common case first for performance reasons
+        # Also use type(x) is float because it's faster than isinstance
         if type(item) is float:
             if np.isnan(item):
                 item = 'NaN'
@@ -224,7 +226,7 @@ def traverse_data(obj, is_numpy=is_numpy, use_numpy=True):
             elif np.isneginf(item):
                 item = '-Infinity'
             obj_copy.append(item)
-        elif isinstance(item, (list, tuple)):
+        elif isinstance(item, (list, tuple)):  # check less common type second
             obj_copy.append(traverse_data(item))
         else:
             obj_copy.append(item)

--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -216,7 +216,7 @@ def traverse_data(obj, is_numpy=is_numpy, use_numpy=True):
         return [transform_array(el) for el in obj]
     obj_copy = []
     for item in obj:
-        if isinstance(item, float):
+        if type(item) is float:
             if np.isnan(item):
                 item = 'NaN'
             elif np.isposinf(item):


### PR DESCRIPTION
Isinstance checks can be surprisingly costly when applied to many small
objects.  This avoids many calls to isinstance in
_visit_value_and_its_immediate_references by doing two things:

1.  Short circuiting on common types.  These appear to be 90% of all
    inputs to this funciton
2.  Rearranging the if-tree to prefer more commonly succeeding checks
    before less commonly succeeding ones

In my benchmark isinstance calls took up around 5% of computation time
and now they take up around 2%
