### PR TITLE
Event system fixes and improvements

### DIFF
--- a/bokeh/events.py
+++ b/bokeh/events.py
@@ -7,28 +7,39 @@ others. The classes in this module represent these different events, so that
 callbacks can be attached and executed when they occur.
 
 It is possible to respond to events with ``CustomJS`` callbacks, which will
-function with or without a Bokeh server. This can be accomplished with the
-:func:`~bokeh.model.Model.js_on_event` method:
+function with or without a Bokeh server. This can be accomplished by passing
+and event class, and a ``CustomJS`` model to the
+:func:`~bokeh.model.Model.js_on_event` method. When the ``CustomJS`` is
+executed in the browser, its ``cb_obj`` argument will contain the concrete
+event object that triggered the callback.
 
 .. code-block:: python
 
-    from bokh.models import Button
+    from bokeh.events import ButtonClick
+    from bokeh.models import Button, CustomJS
+
     button = Button()
-    button.js_on_event(events.ButtonClick, CustomJS(code='console.log("JS:Click")'))
+
+    button.js_on_event(ButtonClick, CustomJS(code='console.log("JS:Click")'))
 
 Alternatively it is possible to trigger Python code to run when events
 happen, in the context of a Bokeh application running on a Bokeh server.
-This can ccomplished with the :func:`~bokeh.model.Model.on_event` method:
+This can accomplished by passing an event class, and a callback function
+to the the :func:`~bokeh.model.Model.on_event` method. The callback should
+accept a single argument ``event``, which will be passed the concrete
+event object that triggered the callback.
 
-. code-block:: python
+.. code-block:: python
 
-    from bokh.models import Button
+    from bokeh.events import ButtonClick
+    from bokeh.models import Button
+
     button = Button()
 
-    def click_callback(event):
-       print('Python:Click')
+    def callback(event):
+        print('Python:Click')
 
-    button.on_event(events.ButtonClick, click_callback)
+    button.on_event(ButtonClick, callback)
 
 '''
 from __future__ import absolute_import

--- a/bokeh/events.py
+++ b/bokeh/events.py
@@ -82,13 +82,6 @@ class Event(with_metaclass(MetaEvent, object)):
         logger.warn("Could not find appropriate Event class for %r" % dct['event_name'])
 
 
-    def pprint(self, attributes):
-        ''' Pretty print the event with the given set of attributes'''
-        cls_name = self.__class__.__name__
-        attrs = ', '.join(['{attr}={val}'.format(attr=attr, val=self.__dict__[attr])
-                           for attr in attributes])
-        return '{cls_name}({attrs})'.format(cls_name=cls_name, attrs=attrs)
-
 class ButtonClick(Event):
     ''' Announce a button click event on a Bokeh Button widget
 

--- a/bokeh/events.py
+++ b/bokeh/events.py
@@ -32,13 +32,13 @@ This can ccomplished with the :func:`~bokeh.model.Model.on_event` method:
 
 '''
 from __future__ import absolute_import
-from .util.future import with_metaclass
+
 import logging
 logger = logging.getLogger(__file__)
 
+from .util.future import with_metaclass
+
 EVENT_CLASSES = set()
-
-
 
 class _MetaEvent(type):
     ''' Metaclass used to keep track of all classes subclassed from Event.
@@ -50,7 +50,6 @@ class _MetaEvent(type):
         newclass = super(_MetaEvent, cls).__new__(cls, clsname, bases, attrs)
         EVENT_CLASSES.add(newclass)
         return newclass
-
 
 class Event(with_metaclass(_MetaEvent, object)):
     ''' Base class for all Bokeh events.
@@ -81,7 +80,6 @@ class Event(with_metaclass(_MetaEvent, object)):
                 return event
         logger.warn("Could not find appropriate Event class for %r" % dct['event_name'])
 
-
 class ButtonClick(Event):
     ''' Announce a button click event on a Bokeh Button widget
 
@@ -95,10 +93,9 @@ class ButtonClick(Event):
             raise ValueError(msg.format(clsname=self.__class__.__name__))
         super(ButtonClick, self).__init__(model=model)
 
-
-
 class PlotEvent(Event):
     ''' PlotEvent is the baseclass for all events applicable to Plot models
+
     '''
 
     def __init__(self, model):
@@ -107,7 +104,6 @@ class PlotEvent(Event):
             msg ='{clsname} event only applies to Plot models'
             raise ValueError(msg.format(clsname=self.__class__.__name__))
         super(PlotEvent, self).__init__(model=model)
-
 
 class LODStart(PlotEvent):
     ''' Announce the start of "interactive level-of-detail" mode on a plot.
@@ -142,7 +138,6 @@ class Tap(PointEvent):
     '''
     event_name = 'tap'
 
-
 class DoubleTap(PointEvent):
     ''' Announce a double-tap or double-click event on a Bokeh plot.
 
@@ -154,7 +149,6 @@ class Press(PointEvent):
 
     '''
     event_name = 'press'
-
 
 class MouseEnter(PointEvent):
     ''' Announce a mouse enter event onto a Bokeh plot.

--- a/bokeh/events.py
+++ b/bokeh/events.py
@@ -298,11 +298,10 @@ class MouseWheel(PointEvent):
         y (float) : y-coordinate of the event in *data* space
 
 
-    By default, Bokeh plots do not capture scroll events, because prevents
-    the page from scrolling which can be annoying unless it was explicitly
-    requested. In order for ``MouseWheel`` events to fire, either the
-    ``WheelZoomTool`` must be active, or some custom extension must have
-    requested wheel UI events to propagate.
+    .. note::
+        By default, Bokeh plots do not prevent default scroll events unless a
+        WheelZoomTool or WheelPanTool is active. This may change in future
+        releases.
 
     '''
     event_name = 'wheel'

--- a/bokeh/events.py
+++ b/bokeh/events.py
@@ -40,19 +40,19 @@ EVENT_CLASSES = set()
 
 
 
-class MetaEvent(type):
+class _MetaEvent(type):
     ''' Metaclass used to keep track of all classes subclassed from Event.
 
     All Event classes will be added to the EVENT_CLASSES set which is
     used to decode event instances from JSON.
     '''
     def __new__(cls, clsname, bases, attrs):
-        newclass = super(MetaEvent, cls).__new__(cls, clsname, bases, attrs)
+        newclass = super(_MetaEvent, cls).__new__(cls, clsname, bases, attrs)
         EVENT_CLASSES.add(newclass)
         return newclass
 
 
-class Event(with_metaclass(MetaEvent, object)):
+class Event(with_metaclass(_MetaEvent, object)):
     ''' Base class for all Bokeh events.
 
     '''

--- a/bokeh/tests/test_events.py
+++ b/bokeh/tests/test_events.py
@@ -3,8 +3,8 @@ import pytest
 from bokeh.models import Plot, Button, Div
 from bokeh import events
 
-all_events = set([v for v in globals().values()
-                  if isinstance(v,type) and issubclass(v, events.Event)])
+concrete_events = set([v for v in globals().values()
+                      if isinstance(v,type) and issubclass(v, events.Event) and v.event_name is not None])
 
 point_events = set([v for v in globals().values()
                     if isinstance(v,type) and issubclass(v, events.PointEvent)])
@@ -22,11 +22,11 @@ class EventCallback(object):
 
 def test_event_metaclass():
     # All events currently in the namespace should be in the EVENT_CLASSES set
-    assert len(all_events - events.EVENT_CLASSES) == 0
+    assert len(concrete_events - set(events._CONCRETE_EVENT_CLASSES.values())) == 0
 
 def test_common_decode_json():
-    for event_cls in events.EVENT_CLASSES:
-        if event_cls.event_name is None: continue # Skip abstract base class
+    for event_name, event_cls in events._CONCRETE_EVENT_CLASSES.items():
+        if event_name is None: continue # Skip abstract base class
         event = events.Event.decode_json({'event_name':event_cls.event_name,
                                           'event_values':{'model_id':'test-model-id'}})
         assert event._model_id == 'test-model-id'

--- a/bokehjs/src/coffee/document.coffee
+++ b/bokehjs/src/coffee/document.coffee
@@ -21,15 +21,16 @@ class EventManager
 
   send_event: (event) ->
     # Send message to Python via session
-    @session.send_event(event)
+    if @session
+      @session.send_event(event)
 
   trigger: (event) ->
     for model_id in @subscribed_models.values
-        if event.model_id != null and event.model_id != model_id
-            continue
-        model = @document._all_models[model_id]
-        if model?
-            model._process_event(event)
+      if event.model_id != null and event.model_id != model_id
+        continue
+      model = @document._all_models[model_id]
+      if model?
+        model._process_event(event)
 
 export class DocumentChangedEvent
   constructor : (@document) ->

--- a/bokehjs/src/coffee/model.coffee
+++ b/bokehjs/src/coffee/model.coffee
@@ -22,6 +22,7 @@ export class Model extends HasProps
         @listenTo(@, evt, () -> cb.execute(@))
 
     @listenTo(@, 'change:js_event_callbacks', () -> @_update_event_callbacks)
+    @listenTo(@, 'change:subscribed_events', () -> @_update_event_callbacks)
 
   _process_event: (event) ->
     if event.is_applicable_to(this)
@@ -46,6 +47,8 @@ export class Model extends HasProps
 
   _doc_attached: () ->
     if not isEmpty(@js_event_callbacks)
+      @_update_event_callbacks()
+    if not isEmpty(@subscribed_events)
       @_update_event_callbacks()
 
   select: (selector) ->

--- a/bokehjs/src/coffee/model.coffee
+++ b/bokehjs/src/coffee/model.coffee
@@ -29,7 +29,7 @@ export class Model extends HasProps
       event = event._customize_event(@)
 
       for callback in @js_event_callbacks[event.event_name] ? []
-        callback.execute({event: event}, {})
+        callback.execute(event, {})
 
       if @subscribed_events.some((m) -> m == event.event_name)
         @document.event_manager.send_event(event)

--- a/bokehjs/src/coffee/model.coffee
+++ b/bokehjs/src/coffee/model.coffee
@@ -46,9 +46,7 @@ export class Model extends HasProps
     @document.event_manager.subscribed_models.push(@id)
 
   _doc_attached: () ->
-    if not isEmpty(@js_event_callbacks)
-      @_update_event_callbacks()
-    if not isEmpty(@subscribed_events)
+    if not isEmpty(@js_event_callbacks) or not isEmpty(@subscribed_events)
       @_update_event_callbacks()
 
   select: (selector) ->

--- a/examples/howto/events_app.py
+++ b/examples/howto/events_app.py
@@ -27,13 +27,19 @@ def display_event(div, attributes=[]):
     l2 = "div.text = '<b>JS Events (see console for Python events)</b><br><font size=\"0.5pt\">' + text.split('<br>',20).join('<br>')+ '</font>';"
     return CustomJS(code=l1+l2, args={'div': div})
 
+def pprint(cls, attributes):
+    ''' Pretty print the event with the given set of attributes'''
+
 
 def print_event(attributes=[]):
     """
     Function that returns a Python callback to pretty print the events.
     """
     def python_callback(event):
-        print(event.pprint(attributes))
+        cls_name = event.__class__.__name__
+        attrs = ', '.join(['{attr}={val}'.format(attr=attr, val=event.__dict__[attr])
+                       for attr in attributes])
+        print('{cls_name}({attrs})'.format(cls_name=cls_name, attrs=attrs))
     return python_callback
 
 # Follows the color_scatter gallery example

--- a/examples/howto/events_app.py
+++ b/examples/howto/events_app.py
@@ -18,8 +18,8 @@ def display_event(div, attributes=[]):
     Function to build a suitable CustomJS to display the current event
     in the div model.
     """
-    name = "cb_obj.event.event_name"
-    attrs =  [("'{attr}='+ Number(cb_obj.event['{attr}']).toFixed(2)"
+    name = "cb_obj.event_name"
+    attrs =  [("'{attr}='+ Number(cb_obj['{attr}']).toFixed(2)"
                + " + ', '").format(attr=attr) for attr in attributes]
     args = '+'.join(attrs) if attributes else repr('')
     l1 = "text = {name} + '(' + {args} + ')' + \

--- a/examples/howto/events_app.py
+++ b/examples/howto/events_app.py
@@ -18,18 +18,19 @@ def display_event(div, attributes=[]):
     Function to build a suitable CustomJS to display the current event
     in the div model.
     """
-    name = "cb_obj.event_name"
-    attrs =  [("'{attr}='+ Number(cb_obj['{attr}']).toFixed(2)"
-               + " + ', '").format(attr=attr) for attr in attributes]
-    args = '+'.join(attrs) if attributes else repr('')
-    l1 = "text = {name} + '(' + {args} + ')' + \
-             div.text.replace('<b>JS Events (see console for Python events)</b>','');".format(name=name, args=args )
-    l2 = "div.text = '<b>JS Events (see console for Python events)</b><br><font size=\"0.5pt\">' + text.split('<br>',20).join('<br>')+ '</font>';"
-    return CustomJS(code=l1+l2, args={'div': div})
-
-def pprint(cls, attributes):
-    ''' Pretty print the event with the given set of attributes'''
-
+    style = 'float:left;clear:left;font_size=0.5pt'
+    return CustomJS(args=dict(div=div), code="""
+        attrs = %s;
+        args = [];
+        for ( i=0; i<attrs.length; i++ ) {
+            args.push(attrs[i] + '=' + Number(cb_obj[attrs[i]]).toFixed(2));
+        }
+        line = "'<span style=%r><b>" + cb_obj.event_name + "</b>(" + args.join(", ") + ")</span>\\n";
+        text = div.text.concat(line);
+        lines = text.split("\\n")
+        if ( lines.length > 35 ) { lines.shift(); }
+        div.text = lines.join("\\n");
+    """ % (attributes, style))
 
 def print_event(attributes=[]):
     """

--- a/examples/howto/events_app.py
+++ b/examples/howto/events_app.py
@@ -25,7 +25,7 @@ def display_event(div, attributes=[]):
         for (var i=0; i<attrs.length; i++ ) {
             args.push(attrs[i] + '=' + Number(cb_obj[attrs[i]]).toFixed(2));
         }
-        var line = "'<span style=%r><b>" + cb_obj.event_name + "</b>(" + args.join(", ") + ")</span>\\n";
+        var line = "<span style=%r><b>" + cb_obj.event_name + "</b>(" + args.join(", ") + ")</span>\\n";
         var text = div.text.concat(line);
         var lines = text.split("\\n")
         if ( lines.length > 35 ) { lines.shift(); }

--- a/examples/howto/events_app.py
+++ b/examples/howto/events_app.py
@@ -20,14 +20,14 @@ def display_event(div, attributes=[]):
     """
     style = 'float:left;clear:left;font_size=0.5pt'
     return CustomJS(args=dict(div=div), code="""
-        attrs = %s;
-        args = [];
-        for ( i=0; i<attrs.length; i++ ) {
+        var attrs = %s;
+        var args = [];
+        for (var i=0; i<attrs.length; i++ ) {
             args.push(attrs[i] + '=' + Number(cb_obj[attrs[i]]).toFixed(2));
         }
-        line = "'<span style=%r><b>" + cb_obj.event_name + "</b>(" + args.join(", ") + ")</span>\\n";
-        text = div.text.concat(line);
-        lines = text.split("\\n")
+        var line = "'<span style=%r><b>" + cb_obj.event_name + "</b>(" + args.join(", ") + ")</span>\\n";
+        var text = div.text.concat(line);
+        var lines = text.split("\\n")
         if ( lines.length > 35 ) { lines.shift(); }
         div.text = lines.join("\\n");
     """ % (attributes, style))

--- a/examples/howto/js_events.py
+++ b/examples/howto/js_events.py
@@ -18,14 +18,14 @@ def display_event(div, attributes=[]):
     """
     style = 'float:left;clear:left;font_size=0.5pt'
     return CustomJS(args=dict(div=div), code="""
-        attrs = %s;
-        args = [];
-        for ( i=0; i<attrs.length; i++ ) {
+        var attrs = %s;
+        var args = [];
+        for (var i=0; i<attrs.length; i++ ) {
             args.push(attrs[i] + '=' + Number(cb_obj[attrs[i]]).toFixed(2));
         }
-        line = "<span style=%r><b>" + cb_obj.event_name + "</b>(" + args.join(", ") + ")</span>\\n";
-        text = div.text.concat(line);
-        lines = text.split("\\n")
+        var line = "'<span style=%r><b>" + cb_obj.event_name + "</b>(" + args.join(", ") + ")</span>\\n";
+        var text = div.text.concat(line);
+        var lines = text.split("\\n")
         if ( lines.length > 35 ) { lines.shift(); }
         div.text = lines.join("\\n");
     """ % (attributes, style))

--- a/examples/howto/js_events.py
+++ b/examples/howto/js_events.py
@@ -16,8 +16,8 @@ def display_event(div, attributes=[]):
     Function to build a suitable CustomJS to display the current event
     in the div model.
     """
-    name = "cb_obj.event.event_name"
-    attrs =  [("'{attr}='+ Number(cb_obj.event['{attr}']).toFixed(2)"
+    name = "cb_obj.event_name"
+    attrs =  [("'{attr}='+ Number(cb_obj['{attr}']).toFixed(2)"
                + " + ', '").format(attr=attr) for attr in attributes]
     args = '+'.join(attrs) if attributes else repr('')
     l1 = "text = {name} + '(' + {args} + ')' + \

--- a/examples/howto/js_events.py
+++ b/examples/howto/js_events.py
@@ -16,15 +16,19 @@ def display_event(div, attributes=[]):
     Function to build a suitable CustomJS to display the current event
     in the div model.
     """
-    name = "cb_obj.event_name"
-    attrs =  [("'{attr}='+ Number(cb_obj['{attr}']).toFixed(2)"
-               + " + ', '").format(attr=attr) for attr in attributes]
-    args = '+'.join(attrs) if attributes else repr('')
-    l1 = "text = {name} + '(' + {args} + ')' + \
-             div.text.replace('<b>Events</b>','');".format(name=name, args=args )
-    l2 = "div.text = '<b>Events</b><br><font size=\"0.5pt\">' + text.split('<br>',20).join('<br>')+ '</font>';"
-    return CustomJS(code=l1+l2, args={'div': div})
-
+    style = 'float:left;clear:left;font_size=0.5pt'
+    return CustomJS(args=dict(div=div), code="""
+        attrs = %s;
+        args = [];
+        for ( i=0; i<attrs.length; i++ ) {
+            args.push(attrs[i] + '=' + Number(cb_obj[attrs[i]]).toFixed(2));
+        }
+        line = "'<span style=%r><b>" + cb_obj.event_name + "</b>(" + args.join(", ") + ")</span>\\n";
+        text = div.text.concat(line);
+        lines = text.split("\\n")
+        if ( lines.length > 35 ) { lines.shift(); }
+        div.text = lines.join("\\n");
+    """ % (attributes, style))
 
 # Follows the color_scatter gallery example
 
@@ -36,8 +40,7 @@ colors = [
     "#%02x%02x%02x" % (int(r), int(g), 150) for r, g in zip(50+2*x, 30+2*y)
 ]
 
-p = figure(tools="pan,wheel_zoom,zoom_in,zoom_out,reset",
-           plot_width=400, plot_height=400)
+p = figure(tools="pan,wheel_zoom,zoom_in,zoom_out,reset")
 
 p.scatter(x, y, radius=radii,
           fill_color=colors, fill_alpha=0.6,

--- a/sphinx/source/docs/reference/events.rst
+++ b/sphinx/source/docs/reference/events.rst
@@ -1,0 +1,7 @@
+.. _bokeh.events:
+
+bokeh.events
+============
+
+.. automodule:: bokeh.events
+  :members:

--- a/sphinx/source/docs/releases/0.12.5.rst
+++ b/sphinx/source/docs/releases/0.12.5.rst
@@ -32,8 +32,8 @@ Known Issues
 
 The ClientSession APIs defined in `bokeh.client.session`, such as
 `push_session`, don't currently support the new `on_event` interface for
-UI event callbacks in Bokeh Server application. This deficiency is expected
-to be addressed in the next Bokeh release.
+UI event callbacks in Bokeh Server application. You may track the issue on
+GitHub (:bokeh-issue:`6092`).
 
 Migration Guide
 ---------------

--- a/sphinx/source/docs/releases/0.12.5.rst
+++ b/sphinx/source/docs/releases/0.12.5.rst
@@ -27,6 +27,14 @@ version 1.0 release. The focus of the 1.0 release will be implementing
 build automation to enforce API stability, and a very small number of
 high value features. For more information see the `project roadmap`_.
 
+Known Issues
+------------
+
+The ClientSession APIs defined in `bokeh.client.session`, such as
+`push_session`, don't currently support the new `on_event` interface for
+UI event callbacks in Bokeh Server application. This deficiency is expected
+to be addressed in the next Bokeh release.
+
 Migration Guide
 ---------------
 

--- a/sphinx/source/docs/user_guide/examples/js_events.py
+++ b/sphinx/source/docs/user_guide/examples/js_events.py
@@ -57,4 +57,5 @@ p.js_on_event(events.MouseWheel, display_event(div,attributes=wheel_attributes))
 p.js_on_event(events.Pan,        display_event(div, attributes=pan_attributes))
 p.js_on_event(events.Pinch,      display_event(div, attributes=pinch_attributes))
 
+output_file("js_events.html", title="JS Events Example")
 show(layout)

--- a/sphinx/source/docs/user_guide/examples/js_events.py
+++ b/sphinx/source/docs/user_guide/examples/js_events.py
@@ -1,0 +1,60 @@
+""" Demonstration of how to register event callbacks using an adaptation
+of the color_scatter example from the bokeh gallery
+"""
+import numpy as np
+from bokeh.io import show, output_file
+from bokeh.plotting import figure
+from bokeh import events
+from bokeh.models import CustomJS, Div, Button
+from bokeh.layouts import column, row
+
+def display_event(div, attributes=[], style = 'float:left;clear:left;font_size=0.5pt'):
+    "Build a suitable CustomJS to display the current event in the div model."
+    return CustomJS(args=dict(div=div), code="""
+        var attrs = %s; var args = [];
+        for (var i=0; i<attrs.length; i++ ) {
+            args.push(attrs[i] + '=' + Number(cb_obj[attrs[i]]).toFixed(2));
+        }
+        var line = "<span style=%r><b>" + cb_obj.event_name + "</b>(" + args.join(", ") + ")</span>\\n";
+        var text = div.text.concat(line);
+        var lines = text.split("\\n")
+        if ( lines.length > 35 ) { lines.shift(); }
+        div.text = lines.join("\\n");
+    """ % (attributes, style))
+
+x = np.random.random(size=4000) * 100
+y = np.random.random(size=4000) * 100
+radii = np.random.random(size=4000) * 1.5
+colors = ["#%02x%02x%02x" % (int(r), int(g), 150) for r, g in zip(50+2*x, 30+2*y)]
+
+p = figure(tools="pan,wheel_zoom,zoom_in,zoom_out,reset")
+p.scatter(x, y, radius=np.random.random(size=4000) * 1.5,
+          fill_color=colors, fill_alpha=0.6, line_color=None)
+
+div = Div(width=1000)
+button = Button(label="Button", button_type="success")
+layout = column(button, row(p, div))
+
+## Events with no attributes
+button.js_on_event(events.ButtonClick, display_event(div)) # Button click
+p.js_on_event(events.LODStart, display_event(div))         # Start of LOD display
+p.js_on_event(events.LODEnd, display_event(div))           # End of LOD display
+
+## Events with attributes
+point_attributes = ['x','y','sx','sy']                     # Point events
+wheel_attributes = point_attributes+['delta']              # Mouse wheel event
+pan_attributes = point_attributes + ['delta_x', 'delta_y'] # Pan event
+pinch_attributes = point_attributes + ['scale']            # Pinch event
+
+point_events =  [events.Tap, events.DoubleTap, events.Press,
+                 events.MouseMove, events.MouseEnter, events.MouseLeave,
+                 events.PanStart, events.PanEnd, events.PinchStart, events.PinchEnd]
+
+for event in point_events:
+    p.js_on_event(event,display_event(div, attributes=point_attributes))
+
+p.js_on_event(events.MouseWheel, display_event(div,attributes=wheel_attributes))
+p.js_on_event(events.Pan,        display_event(div, attributes=pan_attributes))
+p.js_on_event(events.Pinch,      display_event(div, attributes=pinch_attributes))
+
+show(layout)

--- a/sphinx/source/docs/user_guide/interaction/callbacks.rst
+++ b/sphinx/source/docs/user_guide/interaction/callbacks.rst
@@ -50,6 +50,9 @@ automatically be available to the JavaScript code by the corresponding name.
 Additionally, the model that triggers the callback (i.e. the model that
 the callback is attached to) will be available as ``cb_obj``.
 
+CustomJS for Model Property Events
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 These ``CustomJS`` callbacks can be attached to property change events on
 any Bokeh model, using the ``js_on_change`` method of Bokeh models:
 
@@ -76,20 +79,16 @@ is executed to update some data:
 .. bokeh-plot:: docs/user_guide/examples/interaction_callbacks_js_on_change.py
     :source-position: above
 
+CustomJS for User Interaction Events
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+In addition to responding to property change events using js_on_change, Bokeh
+allows CustomJS callbacks to be triggered by specific interaction events with
+the plot canvas, on button click events, and on LOD events.
 
-CustomJS for Event classes
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-In addition to responding to Backbone events using ``js_on_change``,
-Bokeh allows ``CustomJS`` callbacks to be triggered by a set of
-dedicated event objects. These events include interaction events with
-the plot canvas, button click events and LOD events.
-
-When registering with these events, the ``CustomJS`` callbacks is
-attached to the event using the ``js_on_event`` method of Bokeh models
-and the callback receives the event object as ``cb_obj``:
-
+These event callbacks are defined on models using the js_on_event method,
+with the callback receiving the event object as a locally defined cb_obj
+variable:
 
 .. code:: python
 
@@ -106,24 +105,21 @@ and the callback receives the event object as ``cb_obj``:
     # execute a callback whenever the plot canvas is tapped
     p.js_on_event('tap', callback)
 
+The event can be specified as a string such as ``'tap'`` above, or an event
+class import from the ``bokeh.events`` module
+(i.e. ``from bokeh.events import Tap``).
 
-Although the event can be specified as a string such as ``'tap'`` above,
-it is often more appropriate to specify the first argument of
-``js_on_event`` using the event class. The full set of event classes can
-be imported from the ``bokeh.events`` module.
-
-The following code imports ``bokeh.events`` and registered all the
-available event classes using the ``display_event`` function to generate
-the ``CustomJS`` objects. This function is used to update the ``Div``
+The following code imports ``bokeh.events`` and registers all of the
+available event classes using the ``display_event`` function in order to
+generate the ``CustomJS`` objects. This function is used to update the ``Div``
 with the event name (always accessible from the ``event_name``
 attribute) as well as all the other applicable event attributes. The
 result is a plot that when interacted with, displays the corresponding
 event on the right:
-    
+
 .. bokeh-plot:: docs/user_guide/examples/js_events.py
     :source-position: above
 
- 
 CustomJS for Specialized Events
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -158,8 +154,6 @@ changes the source of a plot when the slider is used.
     :source-position: above
 
 .. _userguide_interaction_actions_tool_callbacks:
-
-
 
 CustomJS for Tools
 ''''''''''''''''''

--- a/sphinx/source/docs/user_guide/interaction/callbacks.rst
+++ b/sphinx/source/docs/user_guide/interaction/callbacks.rst
@@ -77,10 +77,57 @@ is executed to update some data:
     :source-position: above
 
 
+
+CustomJS for Event classes
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In addition to responding to Backbone events using ``js_on_change``,
+Bokeh allows ``CustomJS`` callbacks to be triggered by a set of
+dedicated event objects. These events include interaction events with
+the plot canvas, button click events and LOD events.
+
+When registering with these events, the ``CustomJS`` callbacks is
+attached to the event using the ``js_on_event`` method of Bokeh models
+and the callback receives the event object as ``cb_obj``:
+
+
+.. code:: python
+
+    from bokeh.models.callbacks import CustomJS
+
+    callback = CustomJS(code="""
+    // the event that triggered the callback is cb_obj:
+    var event = cb_obj.value;
+    // The event type determines the relevant attributes
+    console.log('Tap event occured at x-position: ' + event.x)
+    """)
+
+    p = figure()
+    # execute a callback whenever the plot canvas is tapped
+    p.js_on_event('tap', callback)
+
+
+Although the event can be specified as a string such as ``'tap'`` above,
+it is often more appropriate to specify the first argument of
+``js_on_event`` using the event class. The full set of event classes can
+be imported from the ``bokeh.events`` module.
+
+The following code imports ``bokeh.events`` and registered all the
+available event classes using the ``display_event`` function to generate
+the ``CustomJS`` objects. This function is used to update the ``Div``
+with the event name (always accessible from the ``event_name``
+attribute) as well as all the other applicable event attributes. The
+result is a plot that when interacted with, displays the corresponding
+event on the right:
+    
+.. bokeh-plot:: docs/user_guide/examples/js_events.py
+    :source-position: above
+
+ 
 CustomJS for Specialized Events
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In addition to the generic mechanism described above for adding ``CustomJS``
+In addition to the generic mechanisms described above for adding ``CustomJS``
 callbacks to Bokeh models, there are also a some Bokeh models that have a
 ``.callback`` property specifically for executing ``CustomJS`` in response
 to specific events or situations.
@@ -111,6 +158,8 @@ changes the source of a plot when the slider is used.
     :source-position: above
 
 .. _userguide_interaction_actions_tool_callbacks:
+
+
 
 CustomJS for Tools
 ''''''''''''''''''


### PR DESCRIPTION

This PR fixes the issue described in #6059 and tweaks how JS callbacks are used.

The fix was to make sure the event managers ``subscribed_models`` attribute was being updated when Python callbacks are registered without needing a corresponding JS callback. The model now also listens to changes to the ``subscribed_events`` property instead of just listening to changes to the ``js_event_callbacks`` property.

In addition, the event instance is now passed as the ``cb_obj`` which is more consistent with how the Python callbacks are defined as well as with other usage of ``CustomJS`` callbacks.
