### PR TITLE
Ensure Range1d triggers start/end change events on reset

### DIFF
--- a/bokehjs/src/coffee/models/ranges/data_range1d.coffee
+++ b/bokehjs/src/coffee/models/ranges/data_range1d.coffee
@@ -180,6 +180,7 @@ export class DataRange1d extends DataRange
 
   reset: () ->
     @have_updated_interactively = false
+    # change events silenced as PlotCanvasView.update_dataranges triggers update
     @setv({
       range_padding: @_initial_range_padding
       follow: @_initial_follow

--- a/bokehjs/src/coffee/models/ranges/data_range1d.coffee
+++ b/bokehjs/src/coffee/models/ranges/data_range1d.coffee
@@ -180,7 +180,7 @@ export class DataRange1d extends DataRange
 
   reset: () ->
     @have_updated_interactively = false
-    # change events silenced as PlotCanvasView.update_dataranges triggers update
+    # change events silenced as PlotCanvasView.update_dataranges triggers property callbacks
     @setv({
       range_padding: @_initial_range_padding
       follow: @_initial_follow

--- a/bokehjs/src/coffee/models/ranges/range1d.coffee
+++ b/bokehjs/src/coffee/models/ranges/range1d.coffee
@@ -40,6 +40,7 @@ export class Range1d extends Range
   }
 
   reset: () ->
-    @setv({start: @_initial_start, end: @_initial_end}, {silent: true})
+    # start/end change events not silenced to trigger callbacks
+    @setv({start: @_initial_start, end: @_initial_end})
     @_set_auto_bounds()
     @trigger('change')

--- a/bokehjs/src/coffee/models/ranges/range1d.coffee
+++ b/bokehjs/src/coffee/models/ranges/range1d.coffee
@@ -43,4 +43,3 @@ export class Range1d extends Range
     # start/end change events not silenced to trigger callbacks
     @setv({start: @_initial_start, end: @_initial_end})
     @_set_auto_bounds()
-    @trigger('change')

--- a/bokehjs/src/coffee/models/ranges/range1d.coffee
+++ b/bokehjs/src/coffee/models/ranges/range1d.coffee
@@ -40,6 +40,7 @@ export class Range1d extends Range
   }
 
   reset: () ->
-    # start/end change events not silenced to trigger callbacks
-    @setv({start: @_initial_start, end: @_initial_end})
     @_set_auto_bounds()
+    # start/end change events not silenced to trigger property callbacks
+    @setv({start: @_initial_start, end: @_initial_end})
+    @trigger('change')

--- a/bokehjs/src/coffee/models/ranges/range1d.coffee
+++ b/bokehjs/src/coffee/models/ranges/range1d.coffee
@@ -41,6 +41,7 @@ export class Range1d extends Range
 
   reset: () ->
     @_set_auto_bounds()
-    # start/end change events not silenced to trigger property callbacks
-    @setv({start: @_initial_start, end: @_initial_end})
-    @trigger('change')
+    if @start != @_initial_start or @end != @_initial_end
+      @setv({start: @_initial_start, end: @_initial_end})
+    else
+      @trigger('change')

--- a/bokehjs/test/models/ranges/range1d.coffee
+++ b/bokehjs/test/models/ranges/range1d.coffee
@@ -94,14 +94,13 @@ describe "range1d module", ->
       expect(r.start).to.be.equal 10
       expect(r.end).to.be.equal 20
 
-    it "should execute update callback once", ->
+    it "should execute update callback twice", ->
       cb = new CustomJS()
       r = new Range1d({callback: cb})
-      r.start = -2.1
-
       spy = sinon.spy(cb, 'execute')
+      r.start = -2.1
       r.reset()
-      expect(spy.calledOnce).to.be.true
+      expect(spy.calledTwice).to.be.true
 
   describe "changing model attribute", ->
 

--- a/bokehjs/test/models/ranges/range1d.coffee
+++ b/bokehjs/test/models/ranges/range1d.coffee
@@ -94,11 +94,19 @@ describe "range1d module", ->
       expect(r.start).to.be.equal 10
       expect(r.end).to.be.equal 20
 
-    it "should execute update callback twice", ->
+    it "should execute update callback once", ->
       cb = new CustomJS()
       r = new Range1d({callback: cb})
       spy = sinon.spy(cb, 'execute')
-      r.start = -2.1
+      r.reset()
+      expect(spy.calledOnce).to.be.true
+
+    it "should execute update callback twice if resetting start/end", ->
+      cb = new CustomJS()
+      r = new Range1d({callback: cb})
+      r.start = 2
+      r.end = 3
+      spy = sinon.spy(cb, 'execute')
       r.reset()
       expect(spy.calledTwice).to.be.true
 

--- a/bokehjs/test/models/ranges/range1d.coffee
+++ b/bokehjs/test/models/ranges/range1d.coffee
@@ -101,14 +101,14 @@ describe "range1d module", ->
       r.reset()
       expect(spy.calledOnce).to.be.true
 
-    it "should execute update callback twice if resetting start/end", ->
+    it "should execute update callback once even if resetting start/end", ->
       cb = new CustomJS()
-      r = new Range1d({callback: cb})
+      r = new Range1d({callback: cb, start:0, end:1})
       r.start = 2
       r.end = 3
       spy = sinon.spy(cb, 'execute')
       r.reset()
-      expect(spy.calledTwice).to.be.true
+      expect(spy.calledOnce).to.be.true
 
   describe "changing model attribute", ->
 

--- a/tests/integration/interaction/test_reset_tool.py
+++ b/tests/integration/interaction/test_reset_tool.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from bokeh.io import save
 from bokeh.plotting import figure
-from bokeh.models import CustomJS, Range1d
+from bokeh.models import CustomJS, Range1d, FactorRange
 from selenium.webdriver.common.action_chains import ActionChains
 from tests.integration.utils import has_no_console_errors
 
@@ -10,10 +10,9 @@ import pytest
 pytestmark = pytest.mark.integration
 
 
-def make_plot(tools=''):
+def make_plot(x_range, y_range, tools=''):
     plot = figure(height=800, width=1000, tools=tools,
-                  x_range=Range1d(0,10), y_range=Range1d(0,10))
-    plot.rect(x=[1, 2], y=[1, 1], width=1, height=1)
+                  x_range=x_range, y_range=y_range)
     return plot
 
 
@@ -25,12 +24,33 @@ def click_element_at_position(selenium, element, x, y):
     actions.perform()
 
 
-def test_reset_triggers_range_callback(output_file_url, selenium):
+def test_reset_triggers_range1d_callback(output_file_url, selenium):
+    x_range = Range1d(start=0, end=10)
+    x_range.callback = CustomJS(code='alert("plot reset")')
+    y_range = Range1d()
 
     # Make plot and add a range callback that generates an alert
-    plot = make_plot('reset')
-    range1d = plot.select(dict(type=Range1d))[0]
-    range1d.callback = CustomJS(code='alert("plot reset")')
+    plot = make_plot(x_range, y_range, tools='reset')
+
+    # Save the plot and start the test
+    save(plot)
+    selenium.get(output_file_url)
+    assert has_no_console_errors(selenium)
+
+    # Tap the plot and test for alert
+    reset_button = selenium.find_element_by_class_name('bk-tool-icon-reset')
+    click_element_at_position(selenium, reset_button, 10, 10)
+    alert = selenium.switch_to_alert()
+    assert alert.text == 'plot reset'
+
+
+def test_reset_triggers_factorrange_callback(output_file_url, selenium):
+    x_range = FactorRange(factors=["a", "b", "c"])
+    x_range.callback = CustomJS(code='alert("plot reset")')
+    y_range = FactorRange()
+
+    # Make plot and add a range callback that generates an alert
+    plot = make_plot(x_range, y_range, tools='reset')
 
     # Save the plot and start the test
     save(plot)


### PR DESCRIPTION
After discussing https://github.com/bokeh/bokeh/issues/6075 with @canavandl we determined that for the time being it should be safe to trigger Range1d change events on reset. Unlike DataRange1d the ranges on Range1d are not recomputed by ``PlotCanvasView.update_dataranges``, which ends up triggering a "loud" change when it eventually call ``DataRange1d.update``. So this change simply ensures that both trigger the appropriate changes. In future it might be nice to move some of the logic on PlotCanvasView onto the ranges and handle triggering of events more consistently but for the time being this addresses the immediate issue.

WIP as I probably need to update some tests.