### PR TITLE
Use --install-js not install_js to silence warn

### DIFF
--- a/bokehjs/gulp/tasks/install.coffee
+++ b/bokehjs/gulp/tasks/install.coffee
@@ -17,7 +17,7 @@ handleOutput = (data) ->
 gulp.task "install", ->
   # installs js and css
   # note: sets cwd as parent dir so that LICENSE.txt is accessible to setup.py
-  setup = spawn "python", ["setup.py", "--install_js"], {cwd: "../"}
+  setup = spawn "python", ["setup.py", "--install-js"], {cwd: "../"}
   for output in ["stdout", "stderr"]
     setup[output].setEncoding "utf8"
     setup[output].on "data", handleOutput


### PR DESCRIPTION
tiny tweak. Use --install-js (not --install_js) in gulp install task to silence warn.
