### PR TITLE
Fix typo in selection documentation.

### DIFF
--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -45,7 +45,7 @@ class DataSource(Model):
         # selection information for multiline and patches glyphs
         '2d': {
           # mapping of indices of the multiglyph to array of glyph indices that were hit
-          # e.g. {3: [5, 6], 4, [5]}
+          # e.g. {3: [5, 6], 4: [5]}
           indices: {}
         }
 


### PR DESCRIPTION
Do this because it misled me for quite a while until I figured out what was going on.

I respect wanting matching issues, but I really couldn't bring myself to do so for such a small thing.  Feel free to reject of course.