### PR TITLE
Fix packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ include versioneer.py
 include _setup_support.py
 include bokeh/themes/*.yaml
 recursive-include examples *.py *.ipynb *.md
+recursive-include tests *.py *.ipynb *.jinja *.js *.md *.png
 prune examples/charts/.ipynb_checkpoints
 prune examples/compat/mpl/.ipynb_checkpoints
 prune examples/glyphs/.ipynb_checkpoints

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ setup(
 
     # details needed by setup
     install_requires=REQUIRES,
-    packages=find_packages(),
+    packages=find_packages(exclude=["scripts*", "tests*"]),
     package_data=get_package_data(),
     entry_points={'console_scripts': ['bokeh = bokeh.__main__:main',], },
     zip_safe=False,


### PR DESCRIPTION
Fixes https://github.com/bokeh/bokeh/issues/6113

* Excludes `scripts` and `tests` when looking for packages to install.
* Packages the `tests` so they remain accessible from PyPI packages.