### PR TITLE
Add support for Toolbar.active_inspect property

### DIFF
--- a/bokeh/charts/chart.py
+++ b/bokeh/charts/chart.py
@@ -111,6 +111,7 @@ class Chart(Plot):
             del kwargs['responsive']
 
         self._active_drag = kwargs.pop('active_drag', 'auto')
+        self._active_inspect = kwargs.pop('active_inspect', 'auto')
         self._active_scroll = kwargs.pop('active_scroll', 'auto')
         self._active_tap = kwargs.pop('active_tap', 'auto')
 
@@ -142,7 +143,7 @@ class Chart(Plot):
         self._tooltips = []
 
         if hasattr(self, '_tools'):
-            self.create_tools(self._tools, self._active_drag, self._active_scroll, self._active_tap)
+            self.create_tools(self._tools, self._active_drag, self._active_inspect, self._active_scroll, self._active_tap)
 
     def add_renderers(self, builder, renderers):
         self.renderers += renderers
@@ -180,7 +181,7 @@ class Chart(Plot):
         if ygrid:
             self.make_grid(1, self._yaxis.ticker)
 
-    def create_tools(self, tools, active_drag, active_scroll, active_tap):
+    def create_tools(self, tools, active_drag, active_inspect, active_scroll, active_tap):
         """Create tools if given tools=True input.
 
         Only adds tools if given boolean and does not already have
@@ -197,7 +198,7 @@ class Chart(Plot):
             # if no tools customization let's create the default tools
             tool_objs, tool_map = _process_tools_arg(self, tools)
             self.add_tools(*tool_objs)
-            _process_active_tools(self.toolbar, tool_map, self._active_drag, self._active_scroll, self._active_tap)
+            _process_active_tools(self.toolbar, tool_map, self._active_drag, self._active_inspect, self._active_scroll, self._active_tap)
 
     def start_plot(self):
         """Add the axis, grids and tools
@@ -206,7 +207,7 @@ class Chart(Plot):
         self.create_grids(self._xgrid, self._ygrid)
 
         if self.toolbar.tools:
-            self.create_tools(self._tools, self._active_drag, self._active_scroll, self._active_tap)
+            self.create_tools(self._tools, self._active_drag, self._active_inspect, self._active_scroll, self._active_tap)
 
         if len(self._tooltips) > 0:
             self.add_tools(HoverTool(tooltips=self._tooltips))

--- a/bokeh/models/tests/test_tools.py
+++ b/bokeh/models/tests/test_tools.py
@@ -12,6 +12,7 @@ from bokeh.models.tools import Toolbar, ToolbarBox
 def test_Toolbar():
     tb = Toolbar()
     assert tb.active_drag == 'auto'
+    assert tb.active_inspect == 'auto'
     assert tb.active_scroll == 'auto'
     assert tb.active_tap == 'auto'
 

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -24,7 +24,10 @@ from __future__ import absolute_import
 
 from ..core.enums import accept_left_right_center, Anchor, DeprecatedAnchor, Dimension, Dimensions, Location
 from ..core.has_props import abstract
-from ..core.properties import Any, Auto, Bool, Color, Dict, Either, Enum, Float, Percent, Instance, List, Override, String, Tuple
+from ..core.properties import (
+    Any, Auto, Bool, Color, Dict, Either, Enum, Float, Percent, Instance, List,
+    Override, Seq, String, Tuple
+)
 from ..model import Model
 from ..util.deprecation import deprecated
 
@@ -131,6 +134,11 @@ class Toolbar(ToolbarBase):
 
     active_drag = Either(Auto, Instance(Drag), help="""
     Specify a drag tool to be active when the plot is displayed.
+    """)
+
+    active_inspect = Either(Auto, Instance(Inspection), Seq(Instance(Inspection)), help="""
+    Specify an inspection tool or sequence of inspection tools to be active when
+    the plot is displayed.
     """)
 
     active_scroll = Either(Auto, Instance(Scroll), help="""

--- a/bokeh/plotting/figure.py
+++ b/bokeh/plotting/figure.py
@@ -9,6 +9,7 @@ from ..core.properties import Auto, Either, Enum, Float, Int, Seq, Instance, Str
 from ..core.enums import HorizontalLocation, VerticalLocation
 from ..models import Plot, Range, Title, Tool
 from ..models import glyphs, markers
+from ..models.tools import Drag, Inspection, Scroll, Tap
 from ..util.options import Options
 from ..util._plot_arg_helpers import _convert_responsive
 from .helpers import _get_range, _process_axis_and_grid, _process_tools_arg, _glyph_function, _process_active_tools
@@ -54,15 +55,20 @@ class FigureOptions(Options):
     A label for the y-axis.
     """)
 
-    active_drag = Either(Auto, String, Instance(Tool), default="auto", help="""
+    active_drag = Either(Auto, String, Instance(Drag), default="auto", help="""
     Which drag tool should initially be active.
     """)
 
-    active_scroll = Either(Auto, String, Instance(Tool), default="auto", help="""
+    active_inspect = Either(Auto, String, Instance(Inspection), Seq(Instance(Inspection)),
+    default="auto", help="""
+    Which drag tool should initially be active.
+    """)
+
+    active_scroll = Either(Auto, String, Instance(Scroll), default="auto", help="""
     Which scroll tool should initially be active.
     """)
 
-    active_tap = Either(Auto, String, Instance(Tool), default="auto", help="""
+    active_tap = Either(Auto, String, Instance(Tap), default="auto", help="""
     Which tap tool should initially be active.
     """)
 
@@ -123,7 +129,7 @@ class Figure(Plot):
 
         tool_objs, tool_map = _process_tools_arg(self, opts.tools)
         self.add_tools(*tool_objs)
-        _process_active_tools(self.toolbar, tool_map, opts.active_drag, opts.active_scroll, opts.active_tap)
+        _process_active_tools(self.toolbar, tool_map, opts.active_drag, opts.active_inspect, opts.active_scroll, opts.active_tap)
 
     annular_wedge = _glyph_function(glyphs.AnnularWedge)
 

--- a/bokeh/plotting/figure.py
+++ b/bokeh/plotting/figure.py
@@ -59,8 +59,7 @@ class FigureOptions(Options):
     Which drag tool should initially be active.
     """)
 
-    active_inspect = Either(Auto, String, Instance(Inspection), Seq(Instance(Inspection)),
-    default="auto", help="""
+    active_inspect = Either(Auto, String, Instance(Inspection), Seq(Instance(Inspection)), default="auto", help="""
     Which drag tool should initially be active.
     """)
 

--- a/bokeh/plotting/gmap.py
+++ b/bokeh/plotting/gmap.py
@@ -9,6 +9,7 @@ from ..core.enums import HorizontalLocation, VerticalLocation
 from ..core.properties import Auto, Either, Enum, Int, Seq, Instance, String
 from ..models import GMapPlot, LinearAxis, MercatorTicker, MercatorTickFormatter, Range1d, Title, Tool
 from ..models import glyphs, markers
+from ..models.tools import Drag, Inspection, Scroll, Tap
 from ..util.options import Options
 from .helpers import _process_tools_arg, _process_active_tools, _glyph_function
 
@@ -44,15 +45,19 @@ class GMapFigureOptions(Options):
     A label for the y-axis.
     """)
 
-    active_drag = Either(Auto, String, Instance(Tool), default="auto", help="""
+    active_drag = Either(Auto, String, Instance(Drag), default="auto", help="""
     Which drag tool should initially be active.
     """)
 
-    active_scroll = Either(Auto, String, Instance(Tool), default="auto", help="""
+    active_inspect = Either(Auto, String, Instance(Inspection), Seq(Instance(Inspection)), default="auto", help="""
+    Which drag tool should initially be active.
+    """)
+
+    active_scroll = Either(Auto, String, Instance(Scroll), default="auto", help="""
     Which scroll tool should initially be active.
     """)
 
-    active_tap = Either(Auto, String, Instance(Tool), default="auto", help="""
+    active_tap = Either(Auto, String, Instance(Tap), default="auto", help="""
     Which tap tool should initially be active.
     """)
 
@@ -102,7 +107,7 @@ class GMap(GMapPlot):
 
         tool_objs, tool_map = _process_tools_arg(self, opts.tools)
         self.add_tools(*tool_objs)
-        _process_active_tools(self.toolbar, tool_map, opts.active_drag, opts.active_scroll, opts.active_tap)
+        _process_active_tools(self.toolbar, tool_map, opts.active_drag, opts.active_inspect, opts.active_scroll, opts.active_tap)
 
     annular_wedge = _glyph_function(glyphs.AnnularWedge)
 

--- a/bokeh/plotting/helpers.py
+++ b/bokeh/plotting/helpers.py
@@ -373,13 +373,14 @@ def _process_tools_arg(plot, tools):
     return tool_objs, tool_map
 
 
-def _process_active_tools(toolbar, tool_map, active_drag, active_scroll, active_tap):
+def _process_active_tools(toolbar, tool_map, active_drag, active_inspect, active_scroll, active_tap):
     """ Adds tools to the plot object
 
     Args:
         toolbar (Toolbar): instance of a Toolbar object
         tools_map (dict[str]|Tool): tool_map from _process_tools_arg
         active_drag (str or Tool): the tool to set active for drag
+        active_inspect (str or Tool): the tool to set active for inspect
         active_scroll (str or Tool): the tool to set active for scroll
         active_tap (str or Tool): the tool to set active for tap
 
@@ -395,6 +396,13 @@ def _process_active_tools(toolbar, tool_map, active_drag, active_scroll, active_
         toolbar.active_drag = tool_map[active_drag]
     else:
         raise ValueError("Got unknown %r for 'active_drag', which was not a string supplied in 'tools' argument" % active_drag)
+
+    if active_inspect in ['auto', None] or isinstance(active_inspect, Tool) or all([isinstance(t, Tool) for t in active_inspect]):
+        toolbar.active_inspect = active_inspect
+    elif active_inspect in tool_map:
+        toolbar.active_inspect = tool_map[active_inspect]
+    else:
+        raise ValueError("Got unknown %r for 'active_inspect', which was not a string supplied in 'tools' argument" % active_scroll)
 
     if active_scroll in ['auto', None] or isinstance(active_scroll, Tool):
         toolbar.active_scroll = active_scroll

--- a/bokehjs/src/coffee/models/tools/inspectors/hover_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/inspectors/hover_tool.coffee
@@ -27,8 +27,6 @@ export class HoverToolView extends InspectToolView
     for r in @model.computed_renderers
       @listenTo(r.data_source, 'inspect', @_update)
 
-    @plot_view.canvas_view.el.style.cursor = "crosshair"
-
   _clear: () ->
 
     @_inspect(Infinity, Infinity)
@@ -78,6 +76,9 @@ export class HoverToolView extends InspectToolView
     return
 
   _update: (indices, tool, renderer, ds, {geometry}) ->
+    if not @model.active
+      return
+
     tooltip = @model.ttmodels[renderer.model.id] ? null
     if not tooltip?
       return

--- a/bokehjs/src/coffee/models/tools/toolbar.coffee
+++ b/bokehjs/src/coffee/models/tools/toolbar.coffee
@@ -40,6 +40,15 @@ export class Toolbar extends ToolbarBase
           @gestures[et].tools = @gestures[et].tools.concat([tool])
         @listenTo(tool, 'change:active', @_active_change.bind(tool))
 
+    if @active_inspect is 'auto'
+      # do nothing as all tools are active be default
+    else if @active_inspect instanceof InspectTool
+      @inspectors.map((inspector) => if inspector != @active_inspect then inspector.active = false)
+    else if @active_inspect instanceof Array
+      @inspectors.map((inspector) => if inspector not in @active_inspect then inspector.active = false)
+    else if @active_inspect is null
+      @inspectors.map((inspector) -> inspector.active = false)
+
     for et of @gestures
       tools = @gestures[et].tools
       if tools.length == 0
@@ -68,7 +77,8 @@ export class Toolbar extends ToolbarBase
         @active_scroll.active = true
 
   @define {
-      active_drag:   [ p.Any, 'auto' ]
-      active_scroll: [ p.Any, 'auto' ]
-      active_tap:    [ p.Any, 'auto' ]
+      active_drag:     [ p.Any, 'auto' ]
+      active_inspect:  [ p.Any, 'auto' ]
+      active_scroll:   [ p.Any, 'auto' ]
+      active_tap:      [ p.Any, 'auto' ]
   }

--- a/bokehjs/src/coffee/models/tools/toolbar.coffee
+++ b/bokehjs/src/coffee/models/tools/toolbar.coffee
@@ -40,8 +40,9 @@ export class Toolbar extends ToolbarBase
           @gestures[et].tools = @gestures[et].tools.concat([tool])
         @listenTo(tool, 'change:active', @_active_change.bind(tool))
 
-    if @active_inspect is 'auto'
+    if @active_inspect == 'auto'
       # do nothing as all tools are active be default
+      ;
     else if @active_inspect instanceof InspectTool
       @inspectors.map((inspector) => if inspector != @active_inspect then inspector.active = false)
     else if @active_inspect instanceof Array

--- a/bokehjs/test/common/ui_events.coffee
+++ b/bokehjs/test/common/ui_events.coffee
@@ -58,17 +58,42 @@ describe "ui_events module", ->
 
         @spy_cursor = sinon.spy(@plot_canvas_view, "set_cursor")
 
-      it "should handle base case", ->
-        # no inspectors or view_renderers
+      it "should trigger move event for active inspectors", ->
+        inspector = new CrosshairTool({active: true})
+        @plot.add_tools(inspector)
+
         @ui_events._trigger("move", @e)
 
         assert(@spy_trigger.calledOnce)
-        expect(@spy_trigger.args[0]).to.be.deep.equal(["move", @e])
+        expect(@spy_trigger.args[0]).to.be.deep.equal(["move:#{inspector.id}", @e])
+
+      it "should not trigger move event for inactive inspectors", ->
+        inspector = new CrosshairTool({active: false})
+        @plot.add_tools(inspector)
+
+        @ui_events._trigger("move", @e)
+
+        assert(@spy_trigger.notCalled)
+
+      it "should use default cursor no active inspector", ->
+        @ui_events._trigger("move", @e)
 
         assert(@spy_cursor.calledOnce)
         assert(@spy_cursor.calledWith("default"))
 
-      it "should change cursor if active inspector is present", ->
+      it "should use default cursor if active inspector but mouse is off-frame", ->
+        inspector = new CrosshairTool()
+        @plot.add_tools(inspector)
+
+        ss = sinon.stub(@ui_events, "_hit_test_frame").returns(false)
+
+        @ui_events._trigger("move", @e)
+        assert(@spy_cursor.calledOnce)
+        assert(@spy_cursor.calledWith("default"))
+
+        ss.restore()
+
+      it "should change cursor if active inspector is present and over frame", ->
         inspector = new CrosshairTool()
         @plot.add_tools(inspector)
 
@@ -103,7 +128,7 @@ describe "ui_events module", ->
 
         @ui_events._trigger("move", @e)
         assert(@spy_trigger.calledOnce)
-        expect(@spy_trigger.args[0]).to.be.deep.equal(["move:exit", @e])
+        expect(@spy_trigger.args[0]).to.be.deep.equal(["move:exit:#{inspector.id}", @e])
         # should also use view renderer cursor and not inspector cursor
         assert(@spy_cursor.calledOnce)
         assert(@spy_cursor.calledWith("pointer"))

--- a/bokehjs/test/models/tools/toolbar.coffee
+++ b/bokehjs/test/models/tools/toolbar.coffee
@@ -6,6 +6,7 @@ sinon = require "sinon"
 
 {Document} = utils.require("document")
 {Toolbar} = utils.require("models/tools/toolbar")
+{HoverTool} = utils.require("models/tools/inspectors/hover_tool")
 
 describe "ToolbarView", ->
 
@@ -80,3 +81,38 @@ describe "Toolbar", ->
     tb = new Toolbar()
     ev = tb.get_edit_variables()
     expect(ev.length).to.be.equal 0
+
+  describe "_init_tools method", ->
+
+    beforeEach ->
+      @hover_1 = new HoverTool()
+      @hover_2 = new HoverTool()
+      @hover_3 = new HoverTool()
+
+    it "should set inspect tools as array on Toolbar.inspector property", ->
+      toolbar = new Toolbar({tools:[@hover_1, @hover_2, @hover_3]})
+      expect(toolbar.inspectors).to.deep.equal([@hover_1, @hover_2, @hover_3])
+
+    it "should have all inspect tools active when active_inspect='auto'", ->
+      toolbar = new Toolbar({tools:[@hover_1, @hover_2, @hover_3], active_inspect: 'auto'})
+      expect(@hover_1.active).to.be.true
+      expect(@hover_2.active).to.be.true
+      expect(@hover_3.active).to.be.true
+
+    it "should have arg inspect tool active when active_inspect=tool instance", ->
+      toolbar = new Toolbar({tools:[@hover_1, @hover_2, @hover_3], active_inspect: @hover_1})
+      expect(@hover_1.active).to.be.true
+      expect(@hover_2.active).to.be.false
+      expect(@hover_3.active).to.be.false
+
+    it "should have args inspect tools active when active_inspect=Array(tools)", ->
+      toolbar = new Toolbar({tools:[@hover_1, @hover_2, @hover_3], active_inspect: [@hover_1, @hover_2]})
+      expect(@hover_1.active).to.be.true
+      expect(@hover_2.active).to.be.true
+      expect(@hover_3.active).to.be.false
+
+    it "should have none inspect tools active when active_inspect=null)", ->
+      toolbar = new Toolbar({tools:[@hover_1, @hover_2, @hover_3], active_inspect: null})
+      expect(@hover_1.active).to.be.false
+      expect(@hover_2.active).to.be.false
+      expect(@hover_3.active).to.be.false

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -109,12 +109,15 @@ tools, to be active.
 
 However it is possible to exert control over which tool is active. At the
 lowest ``bokeh.models`` level, this is accomplished by using the ``active_drag``,
-``active_scroll``, and ``active_tap`` properties of ``Toolbar``. These
-properties can take the following values:
+``active_inspect``, ``active_scroll``, and ``active_tap`` properties of
+``Toolbar``. These properties can take the following values:
 
 * ``None`` --- there is no active tool of this kind
 * ``"auto"`` --- Bokeh chooses a tool of this kind to be active (possibly none)
 * a ``Tool`` instance --- Bokeh sets the given tool to be the active tool
+
+Additionally, the ``active_inspect`` tool may accept:
+* A sequence of ``Tool`` instances to be set as the active tools
 
 As an example:
 
@@ -128,6 +131,10 @@ As an example:
 
     # configure so that a specific PolySelect tap tool is active
     plot.toolbar.active_tap = poly_select
+
+    # configure so that a sequence of specific inspect tools are active
+    # note: this only works for inspect tools
+    plot.toolbar.active_inspect = [hover_tool, crosshair_tool]
 
 The default value for all of these properties is ``"auto"``.
 


### PR DESCRIPTION
Add support for Toolbar.active_inspect property, so that users can specify which inspect tools are active on plot initialization.

- [x] issues: fixes #5599 
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
