### PR TITLE
Silence invalid type cast error in core/dom.ts

### DIFF
--- a/bokehjs/src/coffee/core/dom.ts
+++ b/bokehjs/src/coffee/core/dom.ts
@@ -10,7 +10,7 @@ const _createElement = (tag: string) => (attrs: HTMLAttrs = {}, ...children: HTM
   if (tag === "fragment") {
     // XXX: this is wrong, but the the common super type of DocumentFragment and HTMLElement is
     // Node, which doesn't support classList, style, etc. attributes.
-    element = document.createDocumentFragment() as HTMLElement
+    element = (document.createDocumentFragment() as any) as HTMLElement
   } else {
     element = document.createElement(tag)
     for (const attr in attrs) {


### PR DESCRIPTION
This is wrong on top of being wrong. The problem is that DOM doesn't have a reasonable solution for maintaining a group of HTML elements. I'm gradually replacing templates with inline code, so this branch will be removed sooner or later.

fixes #6124