### PR TITLE
update openurl docs

### DIFF
--- a/sphinx/source/docs/user_guide/examples/interaction_open_url.py
+++ b/sphinx/source/docs/user_guide/examples/interaction_open_url.py
@@ -14,6 +14,9 @@ source = ColumnDataSource(data=dict(
 
 p.circle('x', 'y', color='color', size=20, source=source)
 
+# use the "color" column of the CDS to complete the URL
+# e.g. if the glyph at index 10 is selected, then @color
+# will be replaced with source.data['color'][10]
 url = "http://www.colors.commutercreative.com/@color/"
 taptool = p.select(type=TapTool)
 taptool.callback = OpenURL(url=url)

--- a/sphinx/source/docs/user_guide/interaction.rst
+++ b/sphinx/source/docs/user_guide/interaction.rst
@@ -23,6 +23,6 @@ Adding Interactions
     client-side JavaScript callbacks, or with real python code in a Bokeh
     server application.
 
-:ref:`userguide_interaction_callbacks`
+:ref:`userguide_interaction_jscallbacks`
     See how to attach ``CustomJS`` callbacks to various widgets and events
     in Bokeh documents.

--- a/sphinx/source/docs/user_guide/interaction/callbacks.rst
+++ b/sphinx/source/docs/user_guide/interaction/callbacks.rst
@@ -1,4 +1,4 @@
-.. _userguide_interaction_callbacks:
+.. _userguide_interaction_jscallbacks:
 
 JavaScript Callbacks
 --------------------
@@ -16,10 +16,10 @@ values change. This kind of callback can be used to add interesting
 interactions to Bokeh documents without the need to use a Bokeh server (but
 can also be used in conjunction with a Bokeh server).
 
-.. _userguide_interaction_actions_customjs:
+.. _userguide_interaction_jscallbacks_customjs:
 
-CustomJS for Generic Events
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+CustomJS Callbacks
+~~~~~~~~~~~~~~~~~~
 
 To supply a snippet of JavaScript code that should be executed (in the
 browser) when some event occurs, use the ``CustomJS`` model:
@@ -50,6 +50,8 @@ automatically be available to the JavaScript code by the corresponding name.
 Additionally, the model that triggers the callback (i.e. the model that
 the callback is attached to) will be available as ``cb_obj``.
 
+.. _userguide_interaction_jscallbacks_customjs_properties:
+
 CustomJS for Model Property Events
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -78,6 +80,8 @@ is executed to update some data:
 
 .. bokeh-plot:: docs/user_guide/examples/interaction_callbacks_js_on_change.py
     :source-position: above
+
+.. _userguide_interaction_jscallbacks_customjs_interactions:
 
 CustomJS for User Interaction Events
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -134,8 +138,6 @@ to specific events or situations.
     described above, and as such, may be deprecated in favor of the generic
     mechanism in the future.
 
-.. _userguide_interaction_actions_widget_callbacks:
-
 CustomJS for Widgets
 ''''''''''''''''''''
 
@@ -153,8 +155,6 @@ changes the source of a plot when the slider is used.
 .. bokeh-plot:: docs/user_guide/examples/interaction_callbacks_for_widgets.py
     :source-position: above
 
-.. _userguide_interaction_actions_tool_callbacks:
-
 CustomJS for Tools
 ''''''''''''''''''
 
@@ -166,8 +166,6 @@ add a Rect glyph to the plot with identical dimensions.
 
 .. bokeh-plot:: docs/user_guide/examples/interaction_callbacks_for_tools.py
     :source-position: above
-
-.. _userguide_interaction_actions_selection_callbacks:
 
 CustomJS for Selections
 '''''''''''''''''''''''
@@ -188,8 +186,6 @@ a line through that value.
 .. bokeh-plot:: docs/user_guide/examples/interaction_callbacks_for_selections_lasso_mean.py
     :source-position: above
 
-.. _userguide_interaction_actions_hover_callbacks:
-
 CustomJS for Hover
 ''''''''''''''''''
 
@@ -200,8 +196,6 @@ hover tool is over.
 .. bokeh-plot:: docs/user_guide/examples/interaction_callbacks_for_hover.py
     :source-position: above
 
-.. _userguide_interaction_actions_range_update_callbacks:
-
 CustomJS for Range Update
 '''''''''''''''''''''''''
 
@@ -211,9 +205,6 @@ interactions such as a box zoom, wheel scroll or pan.
 
 .. bokeh-plot:: docs/user_guide/examples/interaction_callbacks_for_range_update.py
     :source-position: above
-
-
-.. _userguide_interaction_actions_in coffeescript:
 
 CustomJS with CoffeeScript code
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -227,8 +218,6 @@ the same ``args`` and ``code`` parameters:
     callback = CustomJS.from_coffeescript(args=dict(p=plot), code="""
     # coffeescript code here
     """)
-
-.. _userguide_interaction_actions_in_python:
 
 CustomJS with a Python function
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -289,8 +278,6 @@ to avoid confusion and help static code analysis tools. You can add
 .. bokeh-plot:: docs/user_guide/examples/interaction_callbacks_for_widgets.py
     :source-position: none
 
-.. _userguide_interaction_actions_openurl:
-
 OpenURL
 ~~~~~~~
 
@@ -306,7 +293,9 @@ to open an URL whenever the user clicks on a circle.
     :source-position: above
 
 Please note that ``OpenURL`` callbacks specifically and only work with
-``TapTool``.
+``TapTool``, and are only invoked when a glyph is hit. That is, they do not
+execute on every tap. If you would like to execute a callback on every
+mouse tap, please see :ref:`userguide_interaction_jscallbacks_customjs_interactions`.
 
 .. _CoffeeScript: http://coffeescript.org
 .. _PyScript documentation: http://flexx.readthedocs.org/en/stable/pyscript

--- a/sphinx/source/docs/user_guide/interaction/widgets.rst
+++ b/sphinx/source/docs/user_guide/interaction/widgets.rst
@@ -14,7 +14,7 @@ To use widgets, you must add them to your document and define their functionalit
 Widgets can be added directly to the document root or nested inside a layout. There
 are two ways to program a widget's functionality:
 
-    * Use the ``CustomJS`` callback (see :ref:`userguide_interaction_actions_widget_callbacks`). This will work in standalone HTML documents.
+    * Use the ``CustomJS`` callback (see :ref:`userguide_interaction_jscallbacks`). This will work in standalone HTML documents.
     * Use ``bokeh serve`` to start the Bokeh server and set up event handlers with ``.on_change`` (or for some widgets, ``.on_click``).
 
 Event handlers are user-defined Python functions that can be attached to widgets. These functions are

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -392,7 +392,7 @@ JavaScript Callbacks in the Browser
 
 Regardless of whether there is a Bokeh Server involved, it is possible to
 create callbacks that execute in the browser, using ``CustomJS`` and other
-methods. See :ref:`userguide_interaction_actions_customjs` for more detailed
+methods. See :ref:`userguide_interaction_jscallbacks` for more detailed
 information and examples.
 
 It is critical to note that **no python code is ever executed when a CustomJS


### PR DESCRIPTION
issues: closes #5819

This makes it clear that OpenURL is only for TapTool and only happens on
selections. Offers link to CustomJS for UI events section for general
tap callbacks.

Also rationalizes sphinx link names in this section, and removes unused
link refs for "specialized" callbacks.