### PR TITLE
Allow for richer property assertion messages

### DIFF
--- a/bokeh/core/property/bases.py
+++ b/bokeh/core/property/bases.py
@@ -276,17 +276,13 @@ class Property(PropertyDescriptorFactory):
                 else:
                     result = fn(obj, value)
 
-                if isinstance(result, bool):
-                    if not result:
-                        if isinstance(msg_or_fn, string_types):
-                            raise ValueError(msg_or_fn)
-                        else:
-                            msg_or_fn()
-                elif result is not None:
+                assert isinstance(result, bool)
+
+                if not result:
                     if isinstance(msg_or_fn, string_types):
-                        raise ValueError(msg_or_fn % result)
+                        raise ValueError(msg_or_fn)
                     else:
-                        msg_or_fn(result)
+                        msg_or_fn(obj, name, value)
 
         return self._wrap_container(value)
 
@@ -295,11 +291,48 @@ class Property(PropertyDescriptorFactory):
         return False
 
     def accepts(self, tp, converter):
+        ''' Declare that other types may be converted to this property type.
+
+        Args:
+            tp (Property) :
+                A type that may be converted automatically to this property
+                type.
+
+            converter (callable) :
+                A function accepting ``value`` to perform conversion of the
+                value to this property type.
+
+        Returns:
+            self
+
+        '''
+
         tp = ParameterizedProperty._validate_type_param(tp)
         self.alternatives.append((tp, converter))
         return self
 
     def asserts(self, fn, msg_or_fn):
+        ''' Assert that prepared values satisfy given conditions.
+
+        Assertions are intended in enforce conditions beyond simple value
+        type validation. For instance, this method can be use to assert that
+        the columns of a ``ColumnDataSource`` all collectively have the same
+        length at all times.
+
+        Args:
+            fn (callable) :
+                A function accepting ``(obj, value)`` that returns True if the value
+                passes the assertion, or False othwise
+
+            msg_or_fn (str or callable) :
+                A message to print in case the assertion fails, or a function
+                accepting ``(obj, name, value)`` to call in in case the assertion
+                fails.
+
+        Returns:
+            self
+
+        '''
         self.assertions.append((fn, msg_or_fn))
         return self
 

--- a/bokeh/core/property/tests/test_bases.py
+++ b/bokeh/core/property/tests/test_bases.py
@@ -1,0 +1,44 @@
+import pytest
+
+from bokeh.core.has_props import HasProps
+
+import bokeh.core.property.bases as pb
+
+def test_property_assert_bools():
+    hp = HasProps()
+    p = pb.Property()
+
+    p.asserts(True, "true")
+    assert p.prepare_value(hp, "foo", 10) == 10
+
+    p.asserts(False, "false")
+    with pytest.raises(ValueError) as e:
+        p.prepare_value(hp, "foo", 10)
+        assert str(e) == "false"
+
+def test_property_assert_functions():
+    hp = HasProps()
+    p = pb.Property()
+
+    p.asserts(lambda obj, value: True, "true")
+    p.asserts(lambda obj, value: obj is hp, "true")
+    p.asserts(lambda obj, value: value==10, "true")
+    assert p.prepare_value(hp, "foo", 10) == 10
+
+    p.asserts(lambda obj, value: False, "false")
+    with pytest.raises(ValueError) as e:
+        p.prepare_value(hp, "foo", 10)
+        assert str(e) == "false"
+
+def test_property_assert_msg_funcs():
+    hp = HasProps()
+    p = pb.Property()
+
+    def raise_(ex):
+        raise ex
+
+    p.asserts(False, lambda obj, name, value: raise_(ValueError("bad %s %s %s" % (hp==obj, name, value))))
+
+    with pytest.raises(ValueError) as e:
+        p.prepare_value(hp, "foo", 10)
+        assert str(e) == "bad True name, 10"

--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -407,11 +407,11 @@ class ImageRGBA(Glyph):
 
     rows = NumberSpec(None, help="""
     The numbers of rows in the images
-    """).asserts(False, lambda: deprecated((0, 12, 4), "ImageRGBA.rows", "2D array representation"))
+    """).asserts(False, lambda obj, name, value: deprecated((0, 12, 4), "ImageRGBA.rows", "2D array representation"))
 
     cols = NumberSpec(None, help="""
     The numbers of columns in the images
-    """).asserts(False, lambda: deprecated((0, 12, 4), "ImageRGBA.cols", "2D array representation"))
+    """).asserts(False, lambda obj, name, value: deprecated((0, 12, 4), "ImageRGBA.cols", "2D array representation"))
 
     dw = DistanceSpec(help="""
     The widths of the plot regions that the images will occupy.

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -86,8 +86,9 @@ class ColumnDataSource(ColumnarDataSource):
     Mapping of column names to sequences of data. The data can be, e.g,
     Python lists or tuples, NumPy arrays, etc.
     """).asserts(lambda _, data: len(set(len(x) for x in data.values())) <= 1,
-                 lambda: warnings.warn("ColumnDataSource's columns must be of the same length", BokehUserWarning))
-
+                 lambda obj, name, data: warnings.warn(
+                    "ColumnDataSource's columns must be of the same length. " +
+                    "Current lengths: %s" % ", ".join(sorted(str((k, len(v))) for k, v in data.items())), BokehUserWarning))
 
     def __init__(self, *args, **kw):
         ''' If called with a single argument that is a dict or

--- a/bokeh/models/tests/test_sources.py
+++ b/bokeh/models/tests/test_sources.py
@@ -178,25 +178,25 @@ class TestColumnDataSource(unittest.TestCase):
         with warnings.catch_warnings(record=True) as warns:
             ColumnDataSource(data=dict(a=[10, 11], b=[20, 21, 22]))
             self.assertEquals(len(warns), 1)
-            self.assertEquals(str(warns[0].message), "ColumnDataSource's columns must be of the same length")
+            self.assertEquals(str(warns[0].message), "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 2), ('b', 3)")
 
         ds = ColumnDataSource()
         with warnings.catch_warnings(record=True) as warns:
             ds.data = dict(a=[10, 11], b=[20, 21, 22])
             self.assertEquals(len(warns), 1)
-            self.assertEquals(str(warns[0].message), "ColumnDataSource's columns must be of the same length")
+            self.assertEquals(str(warns[0].message), "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 2), ('b', 3)")
 
         ds = ColumnDataSource(data=dict(a=[10, 11]))
         with warnings.catch_warnings(record=True) as warns:
             ds.data["b"] = [20, 21, 22]
             self.assertEquals(len(warns), 1)
-            self.assertEquals(str(warns[0].message), "ColumnDataSource's columns must be of the same length")
+            self.assertEquals(str(warns[0].message), "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 2), ('b', 3)")
 
         ds = ColumnDataSource(data=dict(a=[10, 11], b=[20, 21]))
         with warnings.catch_warnings(record=True) as warns:
             ds.data.update(dict(a=[10, 11, 12]))
             self.assertEquals(len(warns), 1)
-            self.assertEquals(str(warns[0].message), "ColumnDataSource's columns must be of the same length")
+            self.assertEquals(str(warns[0].message), "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 3), ('b', 2)")
 
     def test_set_data_from_json_list(self):
         ds = ColumnDataSource()


### PR DESCRIPTION
issues: closes #6044

Previously, `Property.asserts` could be provided a function accepting no
arguments to call when an assertion failed. This PR modifies he Property
machinery to expect and call a function accepting `(obj, name, value)` so
that error messages can be more informative.

This PR also adds a new ``core/property/tests/test_bases.py`` to maintain the
property assertion functionality.

Finally, this PR removes an unused code path for assertions that would
automatically raise a ValueError if the assertion function returned a
value other than `True` or` False`, on the grounds that explicitly
separating th check and message is preferable, and to simplify the
logic. A (python) assertion was added to enforce that a (Bokeh) assertion
returns a bool, always.