### PR TITLE
Steven c howell/6158 muted color

### DIFF
--- a/sphinx/source/docs/user_guide/examples/interaction_legend_mute.py
+++ b/sphinx/source/docs/user_guide/examples/interaction_legend_mute.py
@@ -11,7 +11,8 @@ for name, color in zip(['AAPL', 'IBM', 'MSFT', 'GOOG'], Spectral4):
         "http://ichart.yahoo.com/table.csv?s=%s&a=0&b=1&c=2005&d=0&e=1&f=2014" % name,
         parse_dates=['Date']
     )
-    p.line(df['Date'], df['Close'], line_width=2, color=color, alpha=0.8, muted_alpha=0.2, legend=name)
+    p.line(df['Date'], df['Close'], line_width=2, color=color, alpha=0.8,
+           muted_color=color, muted_alpha=0.2, legend=name)
 
 p.legend.location = "top_left"
 p.legend.click_policy="mute"

--- a/sphinx/source/docs/user_guide/interaction/legends.rst
+++ b/sphinx/source/docs/user_guide/interaction/legends.rst
@@ -30,11 +30,11 @@ Muting Glyphs
 Other times it is preferable for legend interaction to mute a glyph, instead
 of hiding it entirely. In this case, set ``click_policy`` property to
 ``"mute"``. Additionally, the visual properties of a "muted glyph" also
-need to be specified. In general this is does exactly in the same way as for
+need to be specified. In general this is does in exactly the same way as for
 :ref:`userguide_styling_selected_unselected_glyphs` or
 :ref:`userguide_styling_hover_inspections`. In the example below,
-``muted_alpha=0.2`` is passed to ``circle`` to specify that muted lines
-should be drawn with a low alpha muted glyph.
+``muted_alpha=0.2`` and ``muted_color=color`` are passed to ``circle`` to
+specify that muted lines should be drawn with a low alpha muted glyph.
 
 .. bokeh-plot:: docs/user_guide/examples/interaction_legend_mute.py
     :source-position: above


### PR DESCRIPTION
This updates the example by including the visual property `muted_color`. 

- [ ] issues: fixes #6158 