### PR TITLE
remove deprecations up to 0.12.3

### DIFF
--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -17,7 +17,6 @@ from ..core.property_mixins import FillProps, LineProps, TextProps
 from ..core.validation import error
 from ..core.validation.errors import BAD_COLUMN_NAME, NON_MATCHING_DATA_SOURCES_ON_LEGEND_ITEM_RENDERERS
 from ..model import Model
-from ..util.deprecation import deprecated
 
 from .formatters import BasicTickFormatter, TickFormatter
 from .mappers import ContinuousColorMapper
@@ -191,63 +190,6 @@ class Legend(Annotation):
     where each tuple is of the form: *(label, renderers)*.
 
     """).accepts(List(Tuple(String, List(Instance(GlyphRenderer)))), lambda items: [LegendItem(label=item[0], renderers=item[1]) for item in items])
-
-    # --- DEPRECATIONS --------------------------------------------------------
-
-    __deprecated_attributes__ = (
-        'legends', 'legend_margin', 'legend_padding', 'legend_spacing'
-    )
-
-    @property
-    def legends(self):
-        deprecated((0, 12, 3), 'legends', 'Legend.items')
-        return self.items
-
-    @legends.setter
-    def legends(self, legends):
-        deprecated((0, 12, 3), 'legends', 'Legend.items')
-        # Legends are [('label', [glyph_renderer_1, glyph_renderer_2]), ....]
-        # Or {'label', [glyph_renderer_1, glyph_renderer_2], ....}
-        if isinstance(legends, dict):
-            legends = list(legends.items())
-        items_list = []
-        for legend in legends:
-            item = LegendItem()
-            item.label = value(legend[0])
-            item.renderers = legend[1]
-            items_list.append(item)
-        self.items = items_list
-
-    @property
-    def legend_margin(self):
-        deprecated((0, 12, 3), 'legend_margin', 'Legend.margin')
-        return self.margin
-
-    @legend_margin.setter
-    def legend_margin(self, margin):
-        deprecated((0, 12, 3), 'legend_margin', 'Legend.margin')
-        self.margin = margin
-
-    @property
-    def legend_padding(self):
-        deprecated((0, 12, 3), 'legend_padding', 'Legend.padding')
-        return self.padding
-
-    @legend_padding.setter
-    def legend_padding(self, padding):
-        deprecated((0, 12, 3), 'legend_padding', 'Legend.padding')
-        self.padding = padding
-
-    @property
-    def legend_spacing(self):
-        deprecated((0, 12, 3), 'legend_spacing', 'Legend.spacing')
-        return self.spacing
-
-    @legend_spacing.setter
-    def legend_spacing(self, spacing):
-        deprecated((0, 12, 3), 'legend_spacing', 'Legend.spacing')
-        self.spacing = spacing
-
 
 class ColorBar(Annotation):
     ''' Render a color bar based on a color mapper.

--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -15,8 +15,6 @@ from ..core.validation.errors import MISSING_MERCATOR_DIMENSION
 from ..model import Model
 from ..util.compiler import nodejs_compile, CompilationError
 from ..util.dependencies import import_required
-from ..util.deprecation import deprecated
-
 from .tickers import Ticker
 
 @abstract
@@ -331,21 +329,6 @@ class FuncTickFormatter(TickFormatter):
             '''
     """)
 
-def DEFAULT_DATETIME_FORMATS():
-    deprecated((0, 12, 3), 'DEFAULT_DATETIME_FORMATS', 'individual DatetimeTickFormatter fields')
-    return {
-        'microseconds': ['%fus'],
-        'milliseconds': ['%3Nms', '%S.%3Ns'],
-        'seconds':      ['%Ss'],
-        'minsec':       [':%M:%S'],
-        'minutes':      [':%M', '%Mm'],
-        'hourmin':      ['%H:%M'],
-        'hours':        ['%Hh', '%H:%M'],
-        'days':         ['%m/%d', '%a%d'],
-        'months':       ['%m/%Y', '%b%y'],
-        'years':        ['%Y'],
-    }
-
 def _DATETIME_TICK_FORMATTER_HELP(field):
     return """
     Formats for displaying datetime values in the %s range.
@@ -596,42 +579,6 @@ class DatetimeTickFormatter(TickFormatter):
     years        = List(String,
                         help=_DATETIME_TICK_FORMATTER_HELP("``years``"),
                         default=['%Y']).accepts(String, lambda fmt: [fmt])
-
-    __deprecated_attributes__ = ('formats',)
-
-    @property
-    def formats(self):
-        ''' A dictionary containing formats for all scales.
-
-        THIS PROPERTY IS DEPRECTATED. Use individual DatetimeTickFormatter fields instead.
-
-        '''
-        deprecated((0, 12, 3), 'DatetimeTickFormatter.formats', 'individual DatetimeTickFormatter fields')
-        return dict(
-            microseconds = self.microseconds,
-            milliseconds = self.milliseconds,
-            seconds      = self.seconds,
-            minsec       = self.minsec,
-            minutes      = self.minutes,
-            hourmin      = self.hourmin,
-            hours        = self.hours,
-            days         = self.days,
-            months       = self.months,
-            years        = self.years)
-
-    @formats.setter
-    def formats(self, value):
-        deprecated((0, 12, 3), 'DatetimeTickFormatter.formats', 'individual DatetimeTickFormatter fields')
-        if 'microseconds' in value: self.microseconds = value['microseconds']
-        if 'milliseconds' in value: self.milliseconds = value['milliseconds']
-        if 'seconds'      in value: self.seconds      = value['seconds']
-        if 'minsec'       in value: self.minsec       = value['minsec']
-        if 'minutes'      in value: self.minutes      = value['minutes']
-        if 'hourmin'      in value: self.hourmin      = value['hourmin']
-        if 'hours'        in value: self.hours        = value['hours']
-        if 'days'         in value: self.days         = value['days']
-        if 'months'       in value: self.months       = value['months']
-        if 'years'        in value: self.years        = value['years']
 
 # This is to automate documentation of DatetimeTickFormatter formats and their defaults
 _df = DatetimeTickFormatter()

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -26,25 +26,11 @@ from ..core.enums import accept_left_right_center, Anchor, DeprecatedAnchor, Dim
 from ..core.has_props import abstract
 from ..core.properties import Any, Auto, Bool, Color, Dict, Either, Enum, Float, Percent, Instance, List, Override, String, Tuple
 from ..model import Model
-from ..util.deprecation import deprecated
 
 from .annotations import BoxAnnotation, PolyAnnotation
 from .callbacks import Callback
 from .renderers import Renderer
 from .layouts import Box, LayoutDOM
-
-def _deprecated_dimensions(tool):
-    def transformer(value):
-        deprecated((0, 12, 3), "List(Enum(Dimension)) in %s.dimensions" % tool, "Enum(Dimensions)")
-
-        if "width" in value and "height" in value:
-            return "both"
-        elif "width" in value or "height" in value:
-            return value
-        else:
-            raise ValueError("empty dimensions' list doesn't make sense")
-
-    return transformer
 
 class ToolEvents(Model):
     ''' A class for reporting tools geometries from BokehJS.
@@ -193,7 +179,7 @@ class PanTool(Drag):
     the pan tool will pan in any dimension, but can be configured to only
     pan horizontally across the width of the plot, or vertically across the
     height of the plot.
-    """).accepts(List(Enum(Dimension)), _deprecated_dimensions("PanTool"))
+    """)
 
 class WheelPanTool(Scroll):
     ''' *toolbar icon*: |wheel_pan_icon|
@@ -233,7 +219,7 @@ class WheelZoomTool(Scroll):
     default the wheel zoom tool will zoom in any dimension, but can be
     configured to only zoom horizontally across the width of the plot, or
     vertically across the height of the plot.
-    """).accepts(List(Enum(Dimension)), _deprecated_dimensions("WheelZoomTool"))
+    """)
 
 
 class SaveTool(Action):
@@ -353,7 +339,7 @@ class CrosshairTool(Inspection):
     vertical and horizontal line will be drawn. If only "width" is supplied,
     only a horizontal line will be drawn. If only "height" is supplied,
     only a vertical line will be drawn.
-    """).accepts(List(Enum(Dimension)), _deprecated_dimensions("CrosshairTool"))
+    """)
 
     line_color = Color(default="black", help="""
     A color to use to stroke paths with.
@@ -417,7 +403,7 @@ class BoxZoomTool(Drag):
     controlled. If only "height" is supplied, the box will be constrained
     to span the entire horizontal space of the plot, and the vertical
     dimension can be controlled.
-    """).accepts(List(Enum(Dimension)), _deprecated_dimensions("BoxZoomTool"))
+    """)
 
     overlay = Instance(BoxAnnotation, default=DEFAULT_BOX_OVERLAY, help="""
     A shaded annotation drawn to indicate the selection region.
@@ -449,7 +435,7 @@ class ZoomInTool(Action):
     default the zoom-in zoom tool will zoom in any dimension, but can be
     configured to only zoom horizontally across the width of the plot, or
     vertically across the height of the plot.
-    """).accepts(List(Enum(Dimension)), _deprecated_dimensions("ZoomInTool"))
+    """)
 
     factor = Percent(default=0.1, help="""
     Percentage to zoom for each click of the zoom-in tool.
@@ -470,7 +456,7 @@ class ZoomOutTool(Action):
     default the zoom-out tool will zoom in any dimension, but can be
     configured to only zoom horizontally across the width of the plot, or
     vertically across the height of the plot.
-    """).accepts(List(Enum(Dimension)), _deprecated_dimensions("ZoomOutTool"))
+    """)
 
     factor = Percent(default=0.1, help="""
     Percentage to zoom for each click of the zoom-in tool.
@@ -517,7 +503,7 @@ class BoxSelectTool(Drag):
     controlled. If only "height" is supplied, the box will be constrained
     to span the entire horizontal space of the plot, and the vertical
     dimension can be controlled.
-    """).accepts(List(Enum(Dimension)), _deprecated_dimensions("BoxSelectTool"))
+    """)
 
     callback = Instance(Callback, help="""
     A callback to run in the browser on completion of drawing a selection box.

--- a/bokeh/models/widgets/buttons.py
+++ b/bokeh/models/widgets/buttons.py
@@ -3,8 +3,6 @@
 '''
 from __future__ import absolute_import
 
-import warnings
-
 from ...core.enums import ButtonType
 from ...core.has_props import abstract, HasProps
 from ...core.properties import Bool, Enum, Instance, Int, List, Override, String, Tuple
@@ -23,26 +21,6 @@ class ButtonLike(HasProps):
     button_type = Enum(ButtonType, help="""
     A style for the button, signifying it's role.
     """)
-
-    @property
-    def type(self):
-        warnings.warn(
-            """
-            Property 'type' was deprecated in Bokeh 0.12.0
-            and will be removed. Use 'button_type' instead.
-            """)
-        return self.button_type
-
-    @type.setter
-    def type(self, type):
-        warnings.warn(
-            """
-            Property 'type' was deprecated in Bokeh 0.12.0
-            and will be removed. Use 'button_type' instead.
-            """)
-        self.button_type = type
-
-    __deprecated_attributes__ = ('type',)
 
 @abstract
 class AbstractButton(Widget, ButtonLike):

--- a/sphinx/source/docs/releases/0.12.6.rst
+++ b/sphinx/source/docs/releases/0.12.6.rst
@@ -1,0 +1,26 @@
+0.12.6 (May 2017)
+=================
+
+Bokeh Version ``0.12.6`` is an incremental update that adds a few important
+features and fixes several bugs. Some of the highlights include:
+
+Migration Guide
+---------------
+
+As the project approaches a 1.0 release, it is necessary to make some changes
+to bring interfaces and functionality up to a point that can be maintained
+long-term. We try to limit such changes as much as possible, and have a
+period of deprecation.
+
+Deprecations removed
+~~~~~~~~~~~~~~~~~~~~
+
+All previous deprecations up to ``0.12.3`` have be removed. Below is the
+complete list of removals.
+
+* Deperecated ``Legend`` properties: ``legends``, ``legend_margin``,
+  ``legend_padding``, ``legend_spacing`` have been removed.
+* Deprecated ``DatetimeTickFormatter.formats`` dict property has been removed.
+* ``Tool`` dimensions specified as a list value rather than an enum, are no
+  longer accepted.
+* Deprecated ``Button.type`` property has been removed.

--- a/sphinx/source/docs/releases/0.12.6.rst
+++ b/sphinx/source/docs/releases/0.12.6.rst
@@ -18,7 +18,7 @@ Deprecations removed
 All previous deprecations up to ``0.12.3`` have be removed. Below is the
 complete list of removals.
 
-* Deperecated ``Legend`` properties: ``legends``, ``legend_margin``,
+* Deprecated ``Legend`` properties: ``legends``, ``legend_margin``,
   ``legend_padding``, ``legend_spacing`` have been removed.
 * Deprecated ``DatetimeTickFormatter.formats`` dict property has been removed.
 * ``Tool`` dimensions specified as a list value rather than an enum, are no


### PR DESCRIPTION
- [x] release document entry (if new feature or API change)

@bokeh/dev this removes all deprecations up through `0.12.3` which includes some fairly gorpy code that will be good to jettison. Absent comments or concerns I will plan to merge this tomorrow. 
