### PR TITLE
Add hover tool support for Segment

### DIFF
--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -675,12 +675,10 @@ class HoverTool(Inspection):
             * image
             * image_rgba
             * image_url
-            * multi_line
             * oval
             * patch
             * quadratic
             * ray
-            * segment
             * text
 
     .. |hover_icon| image:: /_images/icons/Hover.png

--- a/bokehjs/src/coffee/models/glyphs/line.coffee
+++ b/bokehjs/src/coffee/models/glyphs/line.coffee
@@ -69,7 +69,7 @@ export class LineView extends XYGlyphView
       values = @_x
 
     for i in [0...values.length-1]
-      if values[i]<=val<=values[i+1]
+      if values[i]<=val<=values[i+1] or values[i+1]<=val<=values[i]
         result['0d'].glyph = this.model
         result['0d'].get_view = (() -> this).bind(this);
         result['0d'].flag = true  # backward compat

--- a/bokehjs/src/coffee/models/glyphs/segment.coffee
+++ b/bokehjs/src/coffee/models/glyphs/segment.coffee
@@ -36,8 +36,6 @@ export class SegmentView extends GlyphView
     x = @renderer.xmapper.map_from_target(vx, true)
     y = @renderer.ymapper.map_from_target(vy, true)
 
-    threshold = Math.max(2, @visuals.line.line_width.value() / 2)
-
     point =
       x: this.renderer.plot_view.canvas.vx_to_sx(vx)
       y: this.renderer.plot_view.canvas.vy_to_sy(vy)
@@ -46,6 +44,7 @@ export class SegmentView extends GlyphView
 
     candidates = @index.indices({minX: x, minY: y, maxX: x, maxY: y})
     for i in candidates
+      threshold = Math.max(2, @visuals.line.cache_select('line_width', i) / 2)
       [p0, p1] = [{x: @sx0[i], y: @sy0[i]}, {x: @sx1[i], y: @sy1[i]}]
       dist = hittest.dist_to_segment(point, p0, p1)
       if dist < threshold

--- a/bokehjs/src/coffee/models/glyphs/segment.coffee
+++ b/bokehjs/src/coffee/models/glyphs/segment.coffee
@@ -75,7 +75,7 @@ export class SegmentView extends GlyphView
       maxX: @renderer.xmapper.map_from_target(hr.max),
       maxY: @renderer.ymapper.map_from_target(vr.max)
     })
-    console.log (candidates)
+
     for i in candidates
       if v0[i]<=val<=v1[i] or v1[i]<=val<=v0[i]
         hits.push(i)

--- a/bokehjs/src/coffee/models/glyphs/segment.coffee
+++ b/bokehjs/src/coffee/models/glyphs/segment.coffee
@@ -1,3 +1,4 @@
+import * as hittest from "core/hittest"
 import {RBush} from "core/util/spatial"
 import {Glyph, GlyphView} from "./glyph"
 
@@ -29,6 +30,66 @@ export class SegmentView extends GlyphView
 
         @visuals.line.set_vectorize(ctx, i)
         ctx.stroke()
+
+  _hit_point: (geometry) ->
+    [vx, vy] = [geometry.vx, geometry.vy]
+    x = @renderer.xmapper.map_from_target(vx, true)
+    y = @renderer.ymapper.map_from_target(vy, true)
+
+    threshold = Math.max(2, @visuals.line.line_width.value() / 2)
+
+    point =
+      x: this.renderer.plot_view.canvas.vx_to_sx(vx)
+      y: this.renderer.plot_view.canvas.vy_to_sy(vy)
+
+    hits = []
+
+    candidates = @index.indices({minX: x, minY: y, maxX: x, maxY: y})
+    for i in candidates
+      [p0, p1] = [{x: @sx0[i], y: @sy0[i]}, {x: @sx1[i], y: @sy1[i]}]
+      dist = hittest.dist_to_segment(point, p0, p1)
+      if dist < threshold
+        hits.push(i)
+
+    result = hittest.create_hit_test_result()
+    result['1d'].indices = hits
+    return result
+
+  _hit_span: (geometry) ->
+    hr = @renderer.plot_view.frame.h_range
+    vr = @renderer.plot_view.frame.v_range
+
+    [vx, vy] = [geometry.vx, geometry.vy]
+
+    if geometry.direction == 'v'
+      val = @renderer.ymapper.map_from_target(vy)
+      [v0, v1] = [@_y0, @_y1]
+    else
+      val = @renderer.xmapper.map_from_target(vx)
+      [v0, v1] = [@_x0, @_x1]
+
+    hits = []
+
+    candidates = @index.indices({
+      minX: @renderer.xmapper.map_from_target(hr.min),
+      minY: @renderer.ymapper.map_from_target(vr.min),
+      maxX: @renderer.xmapper.map_from_target(hr.max),
+      maxY: @renderer.ymapper.map_from_target(vr.max)
+    })
+    console.log (candidates)
+    for i in candidates
+      if v0[i]<=val<=v1[i] or v1[i]<=val<=v0[i]
+        hits.push(i)
+
+    result = hittest.create_hit_test_result()
+    result['1d'].indices = hits
+    return result
+
+  scx: (i) ->
+    return (@sx0[i] + @sx1[i])/2
+
+  scy: (i) ->
+    return (@sy0[i] + @sy1[i])/2
 
   draw_legend_for_index: (ctx, x0, x1, y0, y1, index) ->
     @_generic_line_legend(ctx, x0, x1, y0, y1, index)


### PR DESCRIPTION
issues: closes #6161

adds _hit_point and _hit_span to the Segment glyph so that it can work with hover tools.

Also updates HoverTool docstring to indicate segments is not functional with hover tools (as well as multi line which was erroneosly listed as unsupported)

Also makes a minor change to line hit-testing. From inspection the existing code would appear to fail on lines that "go backwards"
