### PR TITLE
Use cache select to get line_widths correctly in all cases

### DIFF
--- a/bokehjs/src/coffee/models/glyphs/multi_line.coffee
+++ b/bokehjs/src/coffee/models/glyphs/multi_line.coffee
@@ -47,10 +47,10 @@ export class MultiLineView extends GlyphView
       x: this.renderer.plot_view.canvas.vx_to_sx(geometry.vx)
       y: this.renderer.plot_view.canvas.vy_to_sy(geometry.vy)
     shortest = 9999
-    threshold = Math.max(2, @visuals.line.line_width.value() / 2)
 
     hits = {}
     for i in [0...@sxs.length]
+      threshold = Math.max(2, @visuals.line.cache_select('line_width', i) / 2)
       points = null
       for j in [0...@sxs[i].length-1]
         [p0, p1] = [{x: @sxs[i][j], y: @sys[i][j]}, {x: @sxs[i][j+1], y: @sys[i][j+1]}]


### PR DESCRIPTION
issues: fixes #6130

Not really a good way to add a  test for a view, definitely want to visit adding view models to hold "view state" that's not directly part of the model. 
