### PR TITLE
use proper alignment for vertical ticks below a plot

### DIFF
--- a/bokehjs/src/coffee/core/layout/side_panel.coffee
+++ b/bokehjs/src/coffee/core/layout/side_panel.coffee
@@ -106,7 +106,7 @@ _align_lookup = {
     parallel   : CENTER
     normal     : LEFT
     horizontal : CENTER
-    vertical   : RIGHT
+    vertical   : LEFT
   left:
     justified  : CENTER
     parallel   : CENTER


### PR DESCRIPTION
issues: fixes #5914

with this fix:

<img width="886" alt="screen shot 2017-04-20 at 14 35 18" src="https://cloud.githubusercontent.com/assets/1078448/25249201/b31c9e5c-25d6-11e7-9038-5d2e3fd9dce9.png">
