### PR TITLE
better validation for font size values

### DIFF
--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -1547,7 +1547,7 @@ class FontSizeSpec(DataSpec):
     https://drafts.csswg.org/css-values/#lengths
 
     '''
-    _font_size_re = re.compile("^[0-9]+(\.[0-9]+)?(%|em|ex|ch|ic|rem|vw|vh|vi|vb|vmin|vmax|cm|mm|q|in|pc|pt|px)$", re.I)
+    _font_size_re = re.compile(r"^[0-9]+(.[0-9]+)?(%|em|ex|ch|ic|rem|vw|vh|vi|vb|vmin|vmax|cm|mm|q|in|pc|pt|px)$", re.I)
 
     def __init__(self, default, help=None):
         super(FontSizeSpec, self).__init__(List(String), default=default, help=help)
@@ -1556,6 +1556,15 @@ class FontSizeSpec(DataSpec):
         if isinstance(value, string_types) and self._font_size_re.match(value) is not None:
             value = dict(value=value)
         return super(FontSizeSpec, self).prepare_value(cls, name, value)
+
+    def validate(self, value):
+        super(FontSizeSpec, self).validate(value)
+
+        if isinstance(value, dict) and 'value' in value:
+            value = value['value']
+
+        if isinstance(value, string_types) and value[0].isdigit() and self._font_size_re.match(value) is None:
+            raise ValueError("%r is not a valid font size value" % value)
 
 class UnitsSpec(NumberSpec):
     ''' A |DataSpec| property that accepts numeric fixed values, and also

--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -1565,8 +1565,11 @@ class FontSizeSpec(DataSpec):
         if isinstance(value, dict) and 'value' in value:
             value = value['value']
 
-        if isinstance(value, string_types) and value[0].isdigit() and self._font_size_re.match(value) is None:
-            raise ValueError("%r is not a valid font size value" % value)
+        if isinstance(value, string_types):
+            if len(value) == 0:
+                raise ValueError("empty string is not a valid font size value")
+            elif value[0].isdigit() and self._font_size_re.match(value) is None:
+                raise ValueError("%r is not a valid font size value" % value)
 
 _FieldValueTransformUnits = Enum("field", "value", "transform", "units")
 

--- a/bokeh/core/tests/test_properties.py
+++ b/bokeh/core/tests/test_properties.py
@@ -582,7 +582,7 @@ class TestFontSizeSpec(unittest.TestCase):
         with self.assertRaises(ValueError):
             a.x = 6
 
-    def test_bad_field(self):
+    def test_fields(self):
         class Foo(HasProps):
             x = FontSizeSpec(default=None)
 

--- a/bokeh/core/tests/test_properties.py
+++ b/bokeh/core/tests/test_properties.py
@@ -570,6 +570,36 @@ class TestFontSizeSpec(unittest.TestCase):
             self.assertEqual(a.x, f)
             self.assertEqual(a.lookup('x').serializable_value(a), dict(field=f))
 
+    def test_bad_font_size_values(self):
+        class Foo(HasProps):
+            x = FontSizeSpec(default=None)
+
+        a = Foo()
+
+        with self.assertRaises(ValueError):
+            a.x = "6"
+
+        with self.assertRaises(ValueError):
+            a.x = 6
+
+    def test_bad_field(self):
+        class Foo(HasProps):
+            x = FontSizeSpec(default=None)
+
+        a = Foo()
+
+        a.x = "_120"
+        self.assertEqual(a.x, "_120")
+
+        a.x = dict(field="_120")
+        self.assertEqual(a.x, dict(field="_120"))
+
+        a.x = "foo"
+        self.assertEqual(a.x, "foo")
+
+        a.x = dict(field="foo")
+        self.assertEqual(a.x, dict(field="foo"))
+
 class TestAngleSpec(unittest.TestCase):
     def test_default_none(self):
         class Foo(HasProps):

--- a/bokeh/core/tests/test_properties.py
+++ b/bokeh/core/tests/test_properties.py
@@ -585,6 +585,9 @@ class TestFontSizeSpec(unittest.TestCase):
         with self.assertRaises(ValueError):
             a.x = 6
 
+        with self.assertRaises(ValueError):
+            a.x = ""
+
     def test_fields(self):
         class Foo(HasProps):
             x = FontSizeSpec(default=None)


### PR DESCRIPTION
- [x] issues: fixes #4948
- [x] tests added / passed

This PR doesn't add any validation on the JS side but should alert to bad values set from python. 

makes the assumption that column names do not begin with digits (or if they do, that `field` is used explicitly)