### PR TITLE
stab at fixing selections + sorting in data table

### DIFF
--- a/bokehjs/src/coffee/models/widgets/cell_editors.coffee
+++ b/bokehjs/src/coffee/models/widgets/cell_editors.coffee
@@ -7,6 +7,7 @@ import {extend} from "core/util/object"
 
 import {DOMView} from "core/dom_view"
 import {Model} from "../../model"
+import {DTINDEX_NAME} from "./data_table"
 import {JQueryable} from "./jqueryable"
 
 export class CellEditorView extends DOMView
@@ -69,8 +70,7 @@ export class CellEditorView extends DOMView
   isValueChanged: () -> return not (@getValue() == "" and not @defaultValue?) and (@getValue() != @defaultValue)
 
   applyValue: (item, state) ->
-    # XXX: In perfect world this would be `item[@args.column.field] = state`.
-    @args.grid.getData().setField(item.index, @args.column.field, state)
+    @args.grid.getData().setField(item[DTINDEX_NAME], @args.column.field, state)
 
   loadValue: (item) ->
     value = item[@args.column.field]

--- a/bokehjs/src/coffee/models/widgets/data_table.coffee
+++ b/bokehjs/src/coffee/models/widgets/data_table.coffee
@@ -12,6 +12,8 @@ import {any} from "core/util/array"
 import {TableWidget} from "./table_widget"
 import {WidgetView} from "./widget"
 
+export DTINDEX_NAME = "__bkdt_internal_index__"
+
 wait_for_element = (el, fn) ->
   handler = () =>
     if $.contains(document.documentElement, el)
@@ -22,47 +24,37 @@ wait_for_element = (el, fn) ->
 export class DataProvider
 
   constructor: (@source) ->
-    @data = @source.data
-    @fields = Object.keys(@data)
-
-    if "index" not in @fields
-      @data["index"] = [0...@getLength()]
-      @fields.push("index")
+    if DTINDEX_NAME of @source.data
+      throw new Error("special name #{DTINDEX_NAME} cannot be used as a data table column")
+    @index = [0...@getLength()]
 
   getLength: () -> @source.get_length()
 
   getItem: (offset) ->
     item = {}
-    for field in @fields
-      item[field] = @data[field][offset]
+    for field in Object.keys(@source.data)
+      item[field] = @source.data[field][@index[offset]]
+    item[DTINDEX_NAME] = @index[offset]
     return item
 
-  _setItem: (offset, item) ->
-    for field, value of item
-      @data[field][offset] = value
-    return
-
   setItem: (offset, item) ->
-    @_setItem(offset, item)
-    @updateSource()
+    for field, value of item
+      # internal index is maintained independently, ignore
+      if field != DTINDEX_NAME
+        @source.data[field][@index[offset]] = value
+    @_update_source_inplace()
+    return null
 
-  getField: (index, field) ->
-    offset = @data["index"].indexOf(index)
-    return @data[field][offset]
+  getField: (offset, field) ->
+    if field == DTINDEX_NAME
+      return @index[offset]
+    return @source.data[field][@index[offset]]
 
-  _setField: (index, field, value) ->
-    offset = @data["index"].indexOf(index)
-    @data[field][offset] = value
-    return
-
-  setField: (index, field, value) ->
-    @_setField(index, field, value)
-    @updateSource()
-
-  updateSource: () ->
-    # XXX: We should say `@source.data = @data`, but data was updated in-place,
-    # so that would be a no-op. We have to trigger change events manually instead.
-    @source.trigger("change:data", @, @source.attributes['data'])
+  setField: (offset, field, value) ->
+    # field assumed never to be internal index name (ctor would throw)
+    @source.data[field][@index[offset]] = value
+    @_update_source_inplace()
+    return null
 
   getItemMetadata: (index) -> null
 
@@ -74,26 +66,27 @@ export class DataProvider
       [column.sortCol.field, if column.sortAsc then 1 else -1]
 
     if cols.length == 0
-      cols = [["index", 1]]
+      cols = [[DTINDEX_NAME, 1]]
 
     records = @getRecords()
-    records.sort (record1, record2) ->
+    old_index = @index.slice()
+
+    # TODO (bev) this sort is unstable, which is not great
+    @index.sort (i1, i2) ->
       for [field, sign] in cols
-        value1 = record1[field]
-        value2 = record2[field]
+        value1 = records[old_index.indexOf(i1)][field]
+        value2 = records[old_index.indexOf(i2)][field]
         result =
           if      value1 == value2 then 0
           else if value1 >  value2 then sign
           else                         -sign
         if result != 0
           return result
-
       return 0
 
-    for record, i in records
-      @_setItem(i, record)
-
-    @updateSource()
+  _update_source_inplace: () ->
+    @source.trigger("change:data", @, @source.attributes['data'])
+    return
 
 export class DataTableView extends WidgetView
   className: "bk-data-table"
@@ -107,38 +100,40 @@ export class DataTableView extends WidgetView
     @listenTo(@model.source, 'patch', () => @updateGrid())
     @listenTo(@model.source, 'change:selected', () => @updateSelection())
 
+    @in_selection_update = false
+
   updateGrid: () ->
     @data.constructor(@model.source)
     @grid.invalidate()
     @grid.render()
 
-    # XXX: Workaround for `@model.source.trigger('change')` not triggering an event within python.
-    # But we still need it to trigger render updates
-    @model.source.data = @model.source.data
-    @model.source.trigger('change')
-
   updateSelection: () ->
+    if @in_selection_update
+      return
+
     selected = @model.source.selected
-    indices = selected['1d'].indices
-    @grid.setSelectedRows(indices)
+    selected_indices = selected['1d'].indices
+
+    permuted_indices = (@data.index.indexOf(x) for x in selected_indices)
+
+    @in_selection_update = true
+    @grid.setSelectedRows(permuted_indices)
+    @in_selection_update = false
     # If the selection is not in the current slickgrid viewport, scroll the
     # datatable to start at the row before the first selected row, so that
     # the selection is immediately brought into view. We don't scroll when
     # the selection is already in the viewport so that selecting from the
     # datatable itself does not re-scroll.
-    # console.log("DataTableView::updateSelection",
-    #             @grid.getViewport(), @grid.getRenderedRange())
     cur_grid_range = @grid.getViewport()
-    if @model.scroll_to_selection and not any(indices, (i) -> cur_grid_range.top <= i <= cur_grid_range.bottom)
-      # console.log("DataTableView::updateSelection", min_index, indices)
-      min_index = Math.max(0, Math.min.apply(null, indices) - 1)
+    if @model.scroll_to_selection and not any(permuted_indices, (i) -> cur_grid_range.top <= i <= cur_grid_range.bottom)
+      min_index = Math.max(0, Math.min.apply(null, permuted_indices) - 1)
       @grid.scrollRowToTop(min_index)
 
   newIndexColumn: () ->
     return {
       id: uniqueId()
       name: "#"
-      field: "index"
+      field: DTINDEX_NAME
       width: 40
       behavior: "select"
       cannotTriggerInsert: true
@@ -155,26 +150,24 @@ export class DataTableView extends WidgetView
       checkboxSelector = new CheckboxSelectColumn(cssClass: "bk-cell-select")
       columns.unshift(checkboxSelector.getColumnDefinition())
 
-    if @model.row_headers and @model.source.get_column("index")?
+    if @model.row_headers
       columns.unshift(@newIndexColumn())
-
-    width = @model.width
-    height = @model.height
 
     options =
       enableCellNavigation: @model.selectable != false
       enableColumnReorder: true
       forceFitColumns: @model.fit_columns
-      autoHeight: height == "auto"
+      autoHeight: @model.height == "auto"
       multiColumnSort: @model.sortable
       editable: @model.editable
       autoEdit: false
 
-    if width?
+    if @model.width?
       @el.style.width = "#{@model.width}px"
     else
       @el.style.width = "#{@model.default_width}px"
-    if height? and height != "auto"
+
+    if @model.height? and @model.height != "auto"
       @el.style.height = "#{@model.height}px"
 
     @data = new DataProvider(@model.source)
@@ -184,6 +177,7 @@ export class DataTableView extends WidgetView
       columns = args.sortCols
       @data.sort(columns)
       @grid.invalidate()
+      @updateSelection()
       @grid.render()
 
     if @model.selectable != false
@@ -191,8 +185,11 @@ export class DataTableView extends WidgetView
       if checkboxSelector? then @grid.registerPlugin(checkboxSelector)
 
       @grid.onSelectedRowsChanged.subscribe (event, args) =>
+        if @in_selection_update
+          return
+
         selected = hittest.create_hit_test_result()
-        selected['1d'].indices = args.rows
+        selected['1d'].indices = (@data.index[i] for i in args.rows)
         @model.source.selected = selected
 
     @_prefix_ui()

--- a/bokehjs/test/models/widgets/data_table.coffee
+++ b/bokehjs/test/models/widgets/data_table.coffee
@@ -1,0 +1,155 @@
+{expect} = require "chai"
+utils = require "../../utils"
+
+{ColumnDataSource} = utils.require("models/sources/column_data_source")
+
+{DataProvider, DataTable, DTINDEX_NAME} = utils.require("models/widgets/data_table")
+
+describe "data_table module", ->
+
+  it "should define DTINDEX_NAME", ->
+    expect(DTINDEX_NAME).to.equal "__bkdt_internal_index__"
+
+  describe "DataProvider class", ->
+
+    it "should raise an error if DTINDEX_NAME is in source", ->
+      bad = new ColumnDataSource({data: {"__bkdt_internal_index__": [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      expect(() -> new DataProvider(bad)).to.throw Error
+
+    it "should construct an internal index", ->
+      source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      dp = new DataProvider(source)
+      expect(dp.index).to.deep.equal [0,1,2,3]
+
+    it "should report the data source length", ->
+      source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      dp = new DataProvider(source)
+      expect(dp.getLength()).to.equal 4
+
+    it "should return items when unsorted", ->
+      source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      dp = new DataProvider(source)
+
+      expect(dp.getItem(0)).to.deep.equal {"__bkdt_internal_index__": 0, index:0,  bar: 3.4}
+      expect(dp.getItem(1)).to.deep.equal {"__bkdt_internal_index__": 1, index:1,  bar: 1.2}
+      expect(dp.getItem(2)).to.deep.equal {"__bkdt_internal_index__": 2, index:2,  bar: 0}
+      expect(dp.getItem(3)).to.deep.equal {"__bkdt_internal_index__": 3, index:10, bar: -10}
+
+    it "should return items when sorted", ->
+      source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      dp = new DataProvider(source)
+      fake_col = {sortAsc: true, sortCol: {field: "bar"}}
+      dp.sort([fake_col])
+
+      expect(dp.getItem(0)).to.deep.equal {"__bkdt_internal_index__": 3, index:10, bar: -10}
+      expect(dp.getItem(1)).to.deep.equal {"__bkdt_internal_index__": 2, index:2,  bar: 0}
+      expect(dp.getItem(2)).to.deep.equal {"__bkdt_internal_index__": 1, index:1,  bar: 1.2}
+      expect(dp.getItem(3)).to.deep.equal {"__bkdt_internal_index__": 0, index:0,  bar: 3.4}
+
+    it "should return fields when unsorted", ->
+      source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      dp = new DataProvider(source)
+
+      expect(dp.getField(0, "index")).to.deep.equal 0
+      expect(dp.getField(1, "index")).to.deep.equal 1
+      expect(dp.getField(2, "index")).to.deep.equal 2
+      expect(dp.getField(3, "index")).to.deep.equal 10
+
+      expect(dp.getField(0, "bar")).to.deep.equal 3.4
+      expect(dp.getField(1, "bar")).to.deep.equal 1.2
+      expect(dp.getField(2, "bar")).to.deep.equal 0
+      expect(dp.getField(3, "bar")).to.deep.equal -10
+
+      expect(dp.getField(0, DTINDEX_NAME)).to.deep.equal 0
+      expect(dp.getField(1, DTINDEX_NAME)).to.deep.equal 1
+      expect(dp.getField(2, DTINDEX_NAME)).to.deep.equal 2
+      expect(dp.getField(3, DTINDEX_NAME)).to.deep.equal 3
+
+    it "should return fields when sorted", ->
+      source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      dp = new DataProvider(source)
+      fake_col = {sortAsc: true, sortCol: {field: "bar"}}
+      dp.sort([fake_col])
+
+      expect(dp.getField(0, "index")).to.deep.equal 10
+      expect(dp.getField(1, "index")).to.deep.equal 2
+      expect(dp.getField(2, "index")).to.deep.equal 1
+      expect(dp.getField(3, "index")).to.deep.equal 0
+
+      expect(dp.getField(0, "bar")).to.deep.equal -10
+      expect(dp.getField(1, "bar")).to.deep.equal 0
+      expect(dp.getField(2, "bar")).to.deep.equal 1.2
+      expect(dp.getField(3, "bar")).to.deep.equal 3.4
+
+      expect(dp.getField(0, DTINDEX_NAME)).to.deep.equal 3
+      expect(dp.getField(1, DTINDEX_NAME)).to.deep.equal 2
+      expect(dp.getField(2, DTINDEX_NAME)).to.deep.equal 1
+      expect(dp.getField(3, DTINDEX_NAME)).to.deep.equal 0
+
+    it "should get all records", ->
+      source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      dp = new DataProvider(source)
+      expect(dp.getRecords()).to.deep.equal (dp.getItem(i) for i in [0...dp.getLength()])
+
+      fake_col = {sortAsc: true, sortCol: {field: "bar"}}
+      dp.sort([fake_col])
+      expect(dp.getRecords()).to.deep.equal (dp.getItem(i) for i in [0...dp.getLength()])
+
+    it "should re-order only the index when sorted", ->
+      source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      dp = new DataProvider(source)
+      expect(dp.index).to.deep.equal [0,1,2,3]
+
+      fake_col = {sortAsc: true, sortCol: {field: "bar"}}
+      dp.sort([fake_col])
+      expect(dp.index).to.deep.equal [3,2,1,0]
+      expect(dp.source.data).to.deep.equal {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}
+
+    it "should return null metadata", ->
+      source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      dp = new DataProvider(source)
+      expect(dp.getItemMetadata()).to.be.null
+
+    it "should set fields when unsorted", ->
+      source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      dp = new DataProvider(source)
+
+      r = dp.setField(0, "index", 10.1)
+      expect(r).to.equal null
+      expect(dp.source.data).to.deep.equal {index: [10.1,1,2,10], bar: [3.4, 1.2, 0, -10]}
+
+      r = dp.setField(2, "bar", 100)
+      expect(r).to.equal null
+      expect(dp.source.data).to.deep.equal {index: [10.1,1,2,10], bar: [3.4, 1.2, 100, -10]}
+
+    it "should set fields when sorted", ->
+      source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      dp = new DataProvider(source)
+      fake_col = {sortAsc: true, sortCol: {field: "bar"}}
+      dp.sort([fake_col])
+
+      r = dp.setField(0, "index", 10.1)
+      expect(r).to.equal null
+      expect(dp.source.data).to.deep.equal {index: [0,1,2,10.1], bar: [3.4, 1.2, 0, -10]}
+
+      r = dp.setField(2, "bar", 100)
+      expect(r).to.equal null
+      expect(dp.source.data).to.deep.equal {index: [0,1,2,10.1], bar: [3.4, 100, 0, -10]}
+
+    it "should set items when unsorted", ->
+      source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      dp = new DataProvider(source)
+
+      r = dp.setItem(2, {index:100, bar:200})
+      expect(r).to.equal null
+      expect(dp.source.data).to.deep.equal {index: [0,1,100,10], bar: [3.4, 1.2, 200, -10]}
+
+    it "should set fields when sorted", ->
+      source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      dp = new DataProvider(source)
+      fake_col = {sortAsc: true, sortCol: {field: "bar"}}
+      dp.sort([fake_col])
+
+      r = dp.setItem(2, {index:100, bar:200})
+      expect(r).to.equal null
+      expect(dp.source.data).to.deep.equal {index: [0,100,2,10], bar: [3.4, 200, 0, -10]}

--- a/bokehjs/test/models/widgets/index.coffee
+++ b/bokehjs/test/models/widgets/index.coffee
@@ -1,3 +1,4 @@
+require "./data_table"
 require "./paragraph"
 require "./tabs"
 require "./widget"


### PR DESCRIPTION
- [x] issues: fixes #3564 
- [x] issues: fixes #6115
- [x] tests added / passed

This PR allows for sorting and selection on data tables to work properly together. Except for explicit cell editing, this PR changes the table implementation so that no modifications are made to the input data source (except by explicit user edits). Instead, an index is created (and stored outside the source data). The index is permuted by sorts, and is used to inform get, set, and selections operations. 