### PR TITLE
Add support for absolute range padding amounts

### DIFF
--- a/bokeh/core/enums.py
+++ b/bokeh/core/enums.py
@@ -258,3 +258,6 @@ SizingMode = enumeration("stretch_both", "scale_width", "scale_height", "scale_b
 
 #: Legend's click policies
 LegendClickPolicy = enumeration("none", "hide", "mute")
+
+#: Whether range padding should be interpreted a percentage or and absolute quantity
+PaddingUnits = enumeration("percent", "absolute")

--- a/bokeh/core/tests/test_enums.py
+++ b/bokeh/core/tests/test_enums.py
@@ -62,6 +62,7 @@ def test_enums_contents():
         'NamedColor',
         'NumeralLanguage',
         'Orientation',
+        'PaddingUnits',
         'Palette',
         'RenderLevel',
         'RenderMode',

--- a/bokeh/models/ranges.py
+++ b/bokeh/models/ranges.py
@@ -5,7 +5,7 @@ and with options for "auto sizing".
 '''
 from __future__ import absolute_import
 
-from ..core.enums import StartEnd
+from ..core.enums import PaddingUnits, StartEnd
 from ..core.has_props import abstract
 from ..core.properties import (Auto, Bool, Datetime, Either, Enum, Float, Instance, Int,
                                List, MinMaxBounds, String, TimeDelta)
@@ -113,8 +113,18 @@ class DataRange1d(DataRange):
     '''
 
     range_padding = Float(default=0.1, help="""
-    A fraction of the total range size to add as padding to
-    the range start and end.
+    How much padding to add around the computed data bounds.
+
+    When ``range_padding_units`` is set to ``"percent"``, the span of the
+    range span is expanded to make the range ``range_padding`` percent larger.
+
+    When ``range_padding_units`` is set to ``"absolute"``, the start and end
+    of the range span are extended by the amount ``range_padding``.
+    """)
+
+    range_padding_units = Enum(PaddingUnits, default="percent", help="""
+    Whether the ``range_padding`` should be interpreted as a percentage, or
+    as an absolute quantity. (default: ``"percent"``)
     """)
 
     start = Float(help="""
@@ -131,15 +141,17 @@ class DataRange1d(DataRange):
     The bounds that the range is allowed to go to - typically used to prevent
     the user from panning/zooming/etc away from the data.
 
-    By default, the bounds will be None, allowing your plot to pan/zoom as far as you want.
-    If bounds are 'auto' they will be computed to be the same as the start and end of the DataRange1d.
+    By default, the bounds will be None, allowing your plot to pan/zoom as far
+    as you want. If bounds are 'auto' they will be computed to be the same as
+    the start and end of the DataRange1d.
 
-    Bounds are provided as a tuple of ``(min, max)`` so regardless of whether your range is
-    increasing or decreasing, the first item should be the minimum value of the range and the
-    second item should be the maximum. Setting min > max will result in a ``ValueError``.
+    Bounds are provided as a tuple of ``(min, max)`` so regardless of whether
+    your range is increasing or decreasing, the first item should be the
+    minimum value of the range and the second item should be the maximum.
+    Setting ``min > max`` will result in a ``ValueError``.
 
-    If you only want to constrain one end of the plot, you can set min or max to
-    ``None`` e.g. ``DataRange1d(bounds=(None, 12))``
+    If you only want to constrain one end of the plot, you can set ``min`` or
+    ``max`` to ``None`` e.g. ``DataRange1d(bounds=(None, 12))``
     """)
 
     min_interval = Float(default=None, help="""
@@ -172,7 +184,8 @@ class DataRange1d(DataRange):
     If set to ``None`` (default), then auto-ranging does not follow, and
     the range will encompass both the minimum and maximum data values.
 
-    ``follow`` cannot be used with bounds, and if set, bounds will be set to ``None``.
+    ``follow`` cannot be used with bounds, and if set, bounds will be set to
+    ``None``.
     """)
 
     follow_interval = Float(default=None, help="""

--- a/bokehjs/src/coffee/core/enums.coffee
+++ b/bokehjs/src/coffee/core/enums.coffee
@@ -43,3 +43,5 @@ export DistributionTypes = ["uniform", "normal"]
 export TransformStepModes = ["after", "before", "center"]
 
 export SizingMode = ["stretch_both", "scale_width", "scale_height", "scale_both", "fixed"]
+
+export PaddingUnits = ["percent", "absolute"]

--- a/bokehjs/src/coffee/core/properties.coffee
+++ b/bokehjs/src/coffee/core/properties.coffee
@@ -203,6 +203,10 @@ export class Distribution extends enum_prop("Distribution", enums.DistributionTy
 
 export class TransformStepMode extends enum_prop("TransformStepMode", enums.TransformStepModes)
 
+export class PaddingUnits extends enum_prop("PaddingUnits", enums.PaddingUnits)
+
+export class StartEnd extends enum_prop("StartEnd", enums.StartEnd)
+
 #
 # Units Properties
 #

--- a/bokehjs/test/models/ranges/data_range1d.coffee
+++ b/bokehjs/test/models/ranges/data_range1d.coffee
@@ -78,11 +78,13 @@ describe "datarange1d module", ->
     it "should reset configuration to initial values", ->
       r = new DataRange1d()
       r.range_padding = 0.2
+      r.range_padding_units = 'absolute'
       r.follow = 'end'
       r.follow_interval = 10
       r.default_span = 10
       r.reset()
       expect(r.range_padding).to.be.equal 0.1
+      expect(r.range_padding_units).to.be.equal "percent"
       expect(r.follow).to.be.null
       expect(r.follow_interval).to.be.null
       expect(r.default_span).to.be.equal 2
@@ -201,16 +203,25 @@ describe "datarange1d module", ->
       expect(r._compute_range(1, 3)).to.be.deep.equal [3, 1]
       expect(r._compute_range(1, 7)).to.be.deep.equal [5, 1]
 
-    it "should apply range_padding", ->
+    it "should apply percentage range_padding", ->
       r = new DataRange1d()
       r.range_padding = 0.5
       expect(r._compute_range(1, 3)).to.be.deep.equal [0.5, 3.5]
+
+    it "should apply absolute range_padding", ->
+      r = new DataRange1d()
+      r.range_padding = 0.2
+      r.range_padding_units = "absolute"
+      expect(r._compute_range(1, 3)).to.be.deep.equal [0.8, 3.2]
 
     it "should apply range_padding logly when mapper_hint='log'", ->
       r = new DataRange1d()
       r.range_padding = 0.5
       r.mapper_hint = "log"
       expect(r._compute_range(0.01, 10)).to.be.deep.equal [0.0017782794100389264, 56.23413251903488]
+
+      r.range_padding_units = "absolute"
+      expect(r._compute_range(1, 10)).to.be.deep.equal [0.5000000000000001, 10.5]
 
   describe "_compute_min_max", ->
 


### PR DESCRIPTION
Adds range_padding_units property to DataRange1d which can be either
"percent" or "absolute". The default is "percent" (matching existing
behaviour)

Also tightens up the follow property with a proper enum.

- [x] issues: fixes #1482
- [x] tests added / passed
- [x] release document entry (if new feature or API change)
