### PR TITLE
fix up hit testing with 'next' policy

### DIFF
--- a/bokehjs/src/coffee/models/tools/inspectors/hover_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/inspectors/hover_tool.coffee
@@ -103,6 +103,7 @@ export class HoverToolView extends InspectToolView
     for i in indices['0d'].indices
       data_x = renderer.glyph._x[i+1]
       data_y = renderer.glyph._y[i+1]
+      ii = i
 
       switch @model.line_policy
         when "interp" # and renderer.get_interpolation_hit?
@@ -117,6 +118,7 @@ export class HoverToolView extends InspectToolView
         when "next"
           rx = canvas.sx_to_vx(renderer.glyph.sx[i+1])
           ry = canvas.sy_to_vy(renderer.glyph.sy[i+1])
+          ii = i+1
 
         when "nearest"
           d1x = renderer.glyph.sx[i]
@@ -131,7 +133,7 @@ export class HoverToolView extends InspectToolView
             [sdatax, sdatay] = [d1x, d1y]
           else
             [sdatax, sdatay] = [d2x, d2y]
-            i = i+1
+            ii = i+1
 
           data_x = renderer.glyph._x[i]
           data_y = renderer.glyph._y[i]
@@ -141,9 +143,9 @@ export class HoverToolView extends InspectToolView
         else
           [rx, ry] = [vx, vy]
 
-      vars = {index: i, x: x, y: y, vx: vx, vy: vy, sx: sx, sy: sy, data_x: data_x, data_y: data_y, rx:rx, ry:ry}
+      vars = {index: ii, x: x, y: y, vx: vx, vy: vy, sx: sx, sy: sy, data_x: data_x, data_y: data_y, rx:rx, ry:ry}
 
-      tooltip.add(rx, ry, @_render_tooltips(ds, i, vars))
+      tooltip.add(rx, ry, @_render_tooltips(ds, ii, vars))
 
     for i in indices['1d'].indices
       # multiglyphs will set '1d' and '2d' results, but have different tooltips
@@ -151,6 +153,7 @@ export class HoverToolView extends InspectToolView
         for i, [j] of indices['2d'].indices
           data_x = renderer.glyph._xs[i][j]
           data_y = renderer.glyph._ys[i][j]
+          jj = j
 
           switch @model.line_policy
             when "interp" # and renderer.get_interpolation_hit?
@@ -165,6 +168,7 @@ export class HoverToolView extends InspectToolView
             when "next"
               rx = canvas.sx_to_vx(renderer.glyph.sxs[i][j+1])
               ry = canvas.sy_to_vy(renderer.glyph.sys[i][j+1])
+              jj = j+1
 
             when "nearest"
               d1x = renderer.glyph.sx[i][j]
@@ -179,14 +183,14 @@ export class HoverToolView extends InspectToolView
                 [sdatax, sdatay] = [d1x, d1y]
               else
                 [sdatax, sdatay] = [d2x, d2y]
-                j = j+1
+                jj = j+1
 
               data_x = renderer.glyph._x[i][j]
               data_y = renderer.glyph._y[i][j]
               rx = canvas.sx_to_vx(sdatax)
               ry = canvas.sy_to_vy(sdatay)
 
-          vars = {index: i, segment_index: j, x: x, y: y, vx: vx, vy: vy, sx: sx, sy: sy, data_x: data_x, data_y: data_y}
+          vars = {index: i, segment_index: jj, x: x, y: y, vx: vx, vy: vy, sx: sx, sy: sy, data_x: data_x, data_y: data_y}
 
           tooltip.add(rx, ry, @_render_tooltips(ds, i, vars))
 


### PR DESCRIPTION
issues: fixes #5198 

Ok this does not add any tests but the current hover tool code is basically untestable. Here is a screenshot for evidence:

<img width="656" alt="screen shot 2017-04-28 at 18 13 14" src="https://cloud.githubusercontent.com/assets/1078448/25550422/612ab6a6-2c3e-11e7-87dc-8ff724584502.png">


I'd like to make a separate issue to cleanup and refactor all the hover tool code and add tests. I am fairly certain the multiglyph double loop is doing wasted work (i.e. it loops `'i` over 1d then masks `i` to loop over 2d inside that loop)

