### PR TITLE
add gulp test:coverage

### DIFF
--- a/bokehjs/.gitignore
+++ b/bokehjs/.gitignore
@@ -1,5 +1,7 @@
 /build
 /node_modules
+/coverage
+.coverrun
 *~
 *.sw[opn]
 *.bak

--- a/bokehjs/.istanbul.yml
+++ b/bokehjs/.istanbul.yml
@@ -1,0 +1,2 @@
+instrumentation:
+    excludes: ['**/vendor/**']

--- a/bokehjs/gulp/tasks/test.coffee
+++ b/bokehjs/gulp/tasks/test.coffee
@@ -12,12 +12,23 @@ mocha = (options={}) ->
     (file) ->
       if @_files? then @_files.push(file.path) else @_files = [file.path]
     () ->
-      args = [
-        "node_modules/mocha/bin/_mocha",
-        "--compilers", "coffee:coffee-script/register",
-        "--reporter", argv.reporter ? "spec",
-        "./test/index.coffee"
-      ].concat(@_files)
+      if options.coverage? and options.coverage
+        args = [
+          "node_modules/.bin/istanbul",
+          "cover",
+          "node_modules/mocha/bin/_mocha",
+          "--",
+          "--compilers", "coffee:coffee-script/register",
+          "--reporter", argv.reporter ? "spec",
+          "./test/index.coffee"
+        ].concat(@_files)
+      else
+        args = [
+          "node_modules/mocha/bin/_mocha",
+          "--compilers", "coffee:coffee-script/register",
+          "--reporter", argv.reporter ? "spec",
+          "./test/index.coffee"
+        ].concat(@_files)
 
       if argv.debug
         args.unshift("debug")
@@ -38,6 +49,9 @@ mocha = (options={}) ->
       process.on('SIGTERM', handler)
       process.on('SIGINT',  handler)
   )
+
+gulp.task "test:coverage", ["defaults:generate"], () ->
+  gulp.src(["./test/all.coffee"]).pipe(mocha({coverage: true}))
 
 gulp.task "test", ["defaults:generate"], () ->
   gulp.src(["./test/all.coffee"]).pipe(mocha())

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -24,6 +24,7 @@
     "cheerio": "^0.19.0",
     "coffeeify": "^0.7.0",
     "del": "^1.1.1",
+    "istanbul": "^0.4.5",
     "gulp": "^3.9.0",
     "gulp-change": "^1.0.0",
     "gulp-insert": "^0.5.0",


### PR DESCRIPTION
issues: fixes #5694

I am sure there is a better way to do this but this gets this provides useful information now. This adds a new command `gulp test:coverage` which can be run locally. It adds general coverage stats to the end of the test run:

<img width="596" alt="screen shot 2017-04-28 at 22 48 39" src="https://cloud.githubusercontent.com/assets/1078448/25552637/dd064c74-2c64-11e7-9fbd-4a9695d44587.png">

And also saves a detailed HTML coverage report

<img width="1048" alt="screen shot 2017-04-28 at 22 44 28" src="https://cloud.githubusercontent.com/assets/1078448/25552642/ed99421c-2c64-11e7-936f-25ec439e749d.png">

Obviously the report would be improved if it referenced the original coffee or TS source files instead of the built JS. 