### PR TITLE
Deprecate x/y_mapper_type Plot kwargs in place of first-class Scale models

### DIFF
--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -13,6 +13,7 @@ from ..core.validation import error, warning
 from ..core.validation.errors import REQUIRED_RANGE
 from ..core.validation.warnings import (MISSING_RENDERERS, NO_DATA_RENDERERS,
                                         MALFORMED_CATEGORY_LABEL, SNAPPED_TOOLBAR_ANNOTATIONS)
+from ..util.deprecation import deprecated
 from ..util.plot_utils import _list_attr_splat, _select_helper
 from ..util.string import nice_join
 
@@ -23,6 +24,7 @@ from .grids import Grid
 from .layouts import LayoutDOM
 from .ranges import Range, FactorRange
 from .renderers import DataRenderer, DynamicImageRenderer, GlyphRenderer, Renderer, TileRenderer
+from .scales import Scale, CategoricalScale, LinearScale, LogScale
 from .sources import DataSource, ColumnDataSource
 from .tools import Tool, Toolbar, ToolEvents
 
@@ -36,16 +38,28 @@ class Plot(LayoutDOM):
             kwargs["tool_events"] = ToolEvents()
 
         if "toolbar" in kwargs and "logo" in kwargs:
-            raise ValueError("Conflicing properties set on plot: toolbar, logo.")
+            raise ValueError("Conflicting properties set on plot: toolbar, logo.")
 
         if "toolbar" in kwargs and "tools" in kwargs:
-            raise ValueError("Conflicing properties set on plot: toolbar, tools.")
+            raise ValueError("Conflicting properties set on plot: toolbar, tools.")
 
         if "toolbar" not in kwargs:
             tools = kwargs.pop('tools', [])
             logo = kwargs.pop('logo', 'normal')
 
             kwargs["toolbar"] = Toolbar(tools=tools, logo=logo)
+
+        if "x_mapper_type" in kwargs and "x_scale" in kwargs:
+            raise ValueError("Conflicting properties set on plot: x_mapper_type, x_scale.")
+
+        elif "x_mapper_type" in kwargs:
+            kwargs["x_scale"] = self._scale(kwargs.pop("x_mapper_type"))
+
+        if "y_mapper_type" in kwargs and "y_scale" in kwargs:
+            raise ValueError("Conflicting properties set on plot: y_mapper_type, y_scale")
+
+        elif "y_mapper_type" in kwargs:
+            kwargs["y_scale"] = self._scale(kwargs.pop("y_mapper_type"))
 
         super(LayoutDOM, self).__init__(**kwargs)
 
@@ -371,8 +385,41 @@ class Plot(LayoutDOM):
     The (default) data range of the vertical dimension of the plot.
     """)
 
-    x_mapper_type = Either(Auto, String, help="""
-    What kind of mapper to use to convert x-coordinates in data space
+    @classmethod
+    def _scale(cls, scale):
+        if scale == "auto":
+            return Auto
+        if scale == "categorical":
+            return CategoricalScale()
+        elif scale == "linear":
+            return LinearScale()
+        elif scale == "log":
+            return LogScale()
+        else:
+            raise ValueError("Unknown mapper_type")
+
+    @property
+    def x_mapper_type(self):
+        deprecated((0, 12, 6), "x_mapper_type", "x_scale")
+        return self.x_scale
+
+    @x_mapper_type.setter
+    def x_mapper_type(self, mapper_type):
+        deprecated((0, 12, 6), "x_mapper_type", "x_scale")
+        self.x_scale = self._scale(mapper_type)
+
+    @property
+    def y_mapper_type(self):
+        deprecated((0, 12, 6), "y_mapper_type", "y_scale")
+        return self.y_scale
+
+    @y_mapper_type.setter
+    def y_mapper_type(self, mapper_type):
+        deprecated((0, 12, 6), "y_mapper_type", "y_scale")
+        self.y_scale = self._scale(mapper_type)
+
+    x_scale = Either(Auto, Instance(Scale), help="""
+    What kind of scale to use to convert x-coordinates in data space
     into x-coordinates in screen space.
 
     Typically this can be determined automatically, but this property
@@ -380,8 +427,8 @@ class Plot(LayoutDOM):
     "seconds since epoch" instead of formatted dates.
     """)
 
-    y_mapper_type = Either(Auto, String, help="""
-    What kind of mapper to use to convert y-coordinates in data space
+    y_scale = Either(Auto, Instance(Scale), help="""
+    What kind of scale to use to convert y-coordinates in data space
     into y-coordinates in screen space.
 
     Typically this can be determined automatically, but this property

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 from six import string_types
 
 from ..core.enums import Location
-from ..core.properties import Auto, Bool, Dict, Either, Enum, Include, Instance, Int, List, Override, String
+from ..core.properties import Bool, Dict, Enum, Include, Instance, Int, List, Override, String
 from ..core.property_mixins import LineProps, FillProps
 from ..core.query import find
 from ..core.validation import error, warning
@@ -387,8 +387,8 @@ class Plot(LayoutDOM):
 
     @classmethod
     def _scale(cls, scale):
-        if scale == "auto":
-            return Auto
+        if scale == "auto" or scale is None:
+            return None
         if scale == "categorical":
             return CategoricalScale()
         elif scale == "linear":
@@ -418,22 +418,22 @@ class Plot(LayoutDOM):
         deprecated((0, 12, 6), "y_mapper_type", "y_scale")
         self.y_scale = self._scale(mapper_type)
 
-    x_scale = Either(Auto, Instance(Scale), help="""
+    x_scale = Instance(Scale, help="""
     What kind of scale to use to convert x-coordinates in data space
     into x-coordinates in screen space.
 
-    Typically this can be determined automatically, but this property
-    can be useful to, e.g., show datetime values as floating point
-    "seconds since epoch" instead of formatted dates.
+    If set to ``None``, but will infer an appropriate scale type based on
+    the default range in x-dimension. Numeric ranges will use a LinearScale
+    and FactorRanges will use a CategoricalScale.
     """)
 
-    y_scale = Either(Auto, Instance(Scale), help="""
+    y_scale = Instance(Scale, help="""
     What kind of scale to use to convert y-coordinates in data space
     into y-coordinates in screen space.
 
-    Typically this can be determined automatically, but this property
-    can be useful to, e.g., show datetime values as floating point
-    "seconds since epoch" instead of formatted dates
+    If set to ``None``, but will infer an appropriate scale type based on
+    the default range in x-dimension. Numeric ranges will use a LinearScale
+    and FactorRanges will use a CategoricalScale.
     """)
 
     extra_x_ranges = Dict(String, Instance(Range), help="""

--- a/bokeh/models/tests/test_plots.py
+++ b/bokeh/models/tests/test_plots.py
@@ -12,7 +12,6 @@ from mock import patch
 import unittest
 import pytest
 
-from bokeh.core.properties import Auto
 from bokeh.plotting import figure
 from bokeh.models import GlyphRenderer, Label, Range1d, FactorRange, Plot, LinearAxis
 from bokeh.models.scales import CategoricalScale, LinearScale, LogScale
@@ -162,25 +161,31 @@ def test_plot_with_no_title_specified_creates_an_empty_title():
     plot = Plot()
     assert plot.title.text == ""
 
+
 def test_plot__scale_classmethod():
-    assert Plot._scale("auto") == Auto
+    assert Plot._scale("auto") == None
+    assert Plot._scale(None) == None
     assert isinstance(Plot._scale("categorical"), CategoricalScale)
     assert isinstance(Plot._scale("linear"), LinearScale)
     assert isinstance(Plot._scale("log"), LogScale)
     with pytest.raises(ValueError):
         Plot._scale("malformed_type")
 
+
 def test_plot_x_mapper_type_kwarg_sets_x_scale():
     plot = Plot(x_mapper_type="linear")
     assert isinstance(plot.x_scale, LinearScale)
+
 
 def test_plot_y_mapper_type_kwarg_sets_y_scale():
     plot = Plot(y_mapper_type="log")
     assert isinstance(plot.y_scale, LogScale)
 
+
 def test_plot_raises_error_if_x_mapper_type_and_x_scale_are_set():
     with pytest.raises(ValueError):
         Plot(x_mapper_type="linear", x_scale=LinearScale())
+
 
 def test_plot_raises_error_if_y_mapper_type_and_y_scale_are_set():
     with pytest.raises(ValueError):

--- a/bokeh/models/tests/test_plots.py
+++ b/bokeh/models/tests/test_plots.py
@@ -12,8 +12,10 @@ from mock import patch
 import unittest
 import pytest
 
+from bokeh.core.properties import Auto
 from bokeh.plotting import figure
 from bokeh.models import GlyphRenderer, Label, Range1d, FactorRange, Plot, LinearAxis
+from bokeh.models.scales import CategoricalScale, LinearScale, LogScale
 from bokeh.models.tools import PanTool, Toolbar
 
 
@@ -159,3 +161,27 @@ def test_plot_raises_error_if_toolbar_and_tools_are_set():
 def test_plot_with_no_title_specified_creates_an_empty_title():
     plot = Plot()
     assert plot.title.text == ""
+
+def test_plot__scale_classmethod():
+    assert Plot._scale("auto") == Auto
+    assert isinstance(Plot._scale("categorical"), CategoricalScale)
+    assert isinstance(Plot._scale("linear"), LinearScale)
+    assert isinstance(Plot._scale("log"), LogScale)
+    with pytest.raises(ValueError):
+        Plot._scale("malformed_type")
+
+def test_plot_x_mapper_type_kwarg_sets_x_scale():
+    plot = Plot(x_mapper_type="linear")
+    assert isinstance(plot.x_scale, LinearScale)
+
+def test_plot_y_mapper_type_kwarg_sets_y_scale():
+    plot = Plot(y_mapper_type="log")
+    assert isinstance(plot.y_scale, LogScale)
+
+def test_plot_raises_error_if_x_mapper_type_and_x_scale_are_set():
+    with pytest.raises(ValueError):
+        Plot(x_mapper_type="linear", x_scale=LinearScale())
+
+def test_plot_raises_error_if_y_mapper_type_and_y_scale_are_set():
+    with pytest.raises(ValueError):
+        Plot(y_mapper_type="log", y_scale=LogScale())

--- a/bokeh/plotting/helpers.py
+++ b/bokeh/plotting/helpers.py
@@ -16,7 +16,8 @@ from ..models import (
     FactorRange, Grid, HelpTool, HoverTool, LassoSelectTool, Legend, LegendItem, LinearAxis,
     LogAxis, PanTool, ZoomInTool, ZoomOutTool, PolySelectTool, ContinuousTicker,
     SaveTool, Range, Range1d, UndoTool, RedoTool, ResetTool, ResizeTool, Tool,
-    WheelPanTool, WheelZoomTool, ColumnarDataSource, ColumnDataSource, GlyphRenderer)
+    WheelPanTool, WheelZoomTool, ColumnarDataSource, ColumnDataSource, GlyphRenderer,
+    LogScale)
 
 from ..core.properties import ColorSpec, Datetime, value, field
 from ..util.deprecation import deprecated
@@ -302,11 +303,10 @@ def _process_axis_and_grid(plot, axis_type, axis_location, minor_ticks, axis_lab
     if axiscls:
 
         if axiscls is LogAxis:
-            # TODO (bev) this mapper type hinting is ugly
             if dim == 0:
-                plot.x_mapper_type = 'log'
+                plot.x_scale = LogScale()
             elif dim == 1:
-                plot.y_mapper_type = 'log'
+                plot.y_scale = LogScale()
             else:
                 raise ValueError("received invalid dimension value: %r" % dim)
 

--- a/bokeh/plotting/tests/test_figure.py
+++ b/bokeh/plotting/tests/test_figure.py
@@ -10,6 +10,7 @@ from bokeh.models import (
     LassoSelectTool,
     Legend,
     LinearAxis,
+    LogScale,
     PanTool,
     ResetTool,
     ResizeTool,
@@ -115,11 +116,11 @@ class TestFigure(unittest.TestCase):
     def test_log_axis(self):
         p = plt.figure(x_axis_type='log')
         p.circle([1, 2, 3], [1, 2, 3])
-        self.assertEqual(p.x_mapper_type, 'log')
+        self.assertIsInstance(p.x_scale, LogScale)
 
         p = plt.figure(y_axis_type='log')
         p.circle([1, 2, 3], [1, 2, 3])
-        self.assertEqual(p.y_mapper_type, 'log')
+        self.assertIsInstance(p.y_scale, LogScale)
 
     def test_xgrid(self):
         p = plt.figure()

--- a/bokehjs/src/coffee/api/plotting.coffee
+++ b/bokehjs/src/coffee/api/plotting.coffee
@@ -306,9 +306,9 @@ export class Figure extends models.Plot
     if axiscls?
       if axiscls == models.LogAxis
         if dim == 0
-          @x_mapper_type = 'log'
+          @x_scale = new models.LogScale()
         else
-          @y_mapper_type = 'log'
+          @y_scale = new models.LogScale()
 
       axis = new axiscls()
 

--- a/bokehjs/src/coffee/api/typings/models/plots.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/plots.d.ts
@@ -55,8 +55,8 @@ declare namespace Bokeh {
   extra_x_ranges?: Map<Range>;
   extra_y_ranges?: Map<Range>;
 
-  x_mapper_type?: Auto | "log";
-  y_mapper_type?: Auto | "log";
+  x_scale?: Scale;
+  y_scale?: Scale;
 
   tool_events?: ToolEvents;
 

--- a/bokehjs/src/coffee/models/canvas/cartesian_frame.coffee
+++ b/bokehjs/src/coffee/models/canvas/cartesian_frame.coffee
@@ -45,8 +45,10 @@ export class CartesianFrame extends LayoutCanvas
   _get_scales: (scale, ranges, frame_range) ->
     scales = {}
     for name, range of ranges
-      if range.type == 'Range1d' or range.type == "DataRange1d"
-        s = if scale? then scale else new LinearScale()
+      if scale?
+        s = scale
+      else if range.type == 'Range1d' or range.type == "DataRange1d"
+        s = new LinearScale()
       else if range.type == "FactorRange"
         s = new CategoricalScale()
       else

--- a/bokehjs/src/coffee/models/canvas/cartesian_frame.coffee
+++ b/bokehjs/src/coffee/models/canvas/cartesian_frame.coffee
@@ -42,26 +42,6 @@ export class CartesianFrame extends LayoutCanvas
         ranges[name] = extra_range
     return ranges
 
-  # _get_scales: (scale_type_name, ranges, frame_range) ->
-  #   scales = {}
-  #   for name, range of ranges
-  #     if range.type == "Range1d" or range.type == "DataRange1d"
-  #       if scale_type_name == "log"
-  #         scale_type = LogScale
-  #       else
-  #         scale_type = LinearScale
-  #       range.scale_hint = scale_type_name
-  #     else if range.type == "FactorRange"
-  #       scale_type = CategoricalScale
-  #     else
-  #       logger.warn("unknown range type for range '#{name}': #{range}")
-  #       return null
-  #     scales[name] = new scale_type({
-  #       source_range: range
-  #       target_range: frame_range
-  #     })
-  #   return scales
-
   _get_scales: (scale, ranges, frame_range) ->
     scales = {}
     for name, range of ranges

--- a/bokehjs/src/coffee/models/canvas/cartesian_frame.coffee
+++ b/bokehjs/src/coffee/models/canvas/cartesian_frame.coffee
@@ -42,24 +42,43 @@ export class CartesianFrame extends LayoutCanvas
         ranges[name] = extra_range
     return ranges
 
-  _get_scales: (scale_type_name, ranges, frame_range) ->
+  # _get_scales: (scale_type_name, ranges, frame_range) ->
+  #   scales = {}
+  #   for name, range of ranges
+  #     if range.type == "Range1d" or range.type == "DataRange1d"
+  #       if scale_type_name == "log"
+  #         scale_type = LogScale
+  #       else
+  #         scale_type = LinearScale
+  #       range.scale_hint = scale_type_name
+  #     else if range.type == "FactorRange"
+  #       scale_type = CategoricalScale
+  #     else
+  #       logger.warn("unknown range type for range '#{name}': #{range}")
+  #       return null
+  #     scales[name] = new scale_type({
+  #       source_range: range
+  #       target_range: frame_range
+  #     })
+  #   return scales
+
+  _get_scales: (scale, ranges, frame_range) ->
     scales = {}
     for name, range of ranges
-      if range.type == "Range1d" or range.type == "DataRange1d"
-        if scale_type_name == "log"
-          scale_type = LogScale
-        else
-          scale_type = LinearScale
-        range.scale_hint = scale_type_name
+      if scale?
+        s = scale
+      else if range.type == 'Range1d' or range.type == "DataRange1d"
+        s = new LinearScale()
       else if range.type == "FactorRange"
-        scale_type = CategoricalScale
+        s = new CategoricalScale()
       else
         logger.warn("unknown range type for range '#{name}': #{range}")
         return null
-      scales[name] = new scale_type({
+      s.setv({
         source_range: range
         target_range: frame_range
       })
+      scales[name] = s
     return scales
 
   _configure_frame_ranges: () ->
@@ -72,8 +91,8 @@ export class CartesianFrame extends LayoutCanvas
     @_x_ranges = @_get_ranges(@x_range, @extra_x_ranges)
     @_y_ranges = @_get_ranges(@y_range, @extra_y_ranges)
 
-    @_xscales = @_get_scales(@x_mapper_type, @_x_ranges, @_h_range)
-    @_yscales = @_get_scales(@y_mapper_type, @_y_ranges, @_v_range)
+    @_xscales = @_get_scales(@x_scale, @_x_ranges, @_h_range)
+    @_yscales = @_get_scales(@y_scale, @_y_ranges, @_v_range)
 
   _update_scales: () ->
     @_configure_frame_ranges()
@@ -106,8 +125,8 @@ export class CartesianFrame extends LayoutCanvas
     extra_y_ranges: [ p.Any, {} ]
     x_range:        [ p.Instance ]
     y_range:        [ p.Instance ]
-    x_mapper_type:  [ p.String, 'auto' ]
-    y_mapper_type:  [ p.String, 'auto' ]
+    x_scale:        [ p.Instance ]
+    y_scale:        [ p.Instance ]
   }
 
   get_constraints: () ->

--- a/bokehjs/src/coffee/models/canvas/cartesian_frame.coffee
+++ b/bokehjs/src/coffee/models/canvas/cartesian_frame.coffee
@@ -45,10 +45,8 @@ export class CartesianFrame extends LayoutCanvas
   _get_scales: (scale, ranges, frame_range) ->
     scales = {}
     for name, range of ranges
-      if scale?
-        s = scale
-      else if range.type == 'Range1d' or range.type == "DataRange1d"
-        s = new LinearScale()
+      if range.type == 'Range1d' or range.type == "DataRange1d"
+        s = if scale? then scale else new LinearScale()
       else if range.type == "FactorRange"
         s = new CategoricalScale()
       else

--- a/bokehjs/src/coffee/models/plots/plot.coffee
+++ b/bokehjs/src/coffee/models/plots/plot.coffee
@@ -323,8 +323,8 @@ export class Plot extends LayoutDOM
       y_range:           [ p.Instance                         ]
       extra_y_ranges:    [ p.Any,      {}                     ] # TODO (bev)
 
-      x_mapper_type:     [ p.String,   'auto'                 ] # TODO (bev)
-      y_mapper_type:     [ p.String,   'auto'                 ] # TODO (bev)
+      x_scale:           [ p.Instance                         ]
+      y_scale:           [ p.Instance                         ]
 
       tool_events:       [ p.Instance, () -> new ToolEvents() ]
 
@@ -360,6 +360,12 @@ export class Plot extends LayoutDOM
       for tool in @toolbar.tools
         renderers = renderers.concat(tool.synthetic_renderers)
       return renderers
+    x_mapper_type: () ->
+      log.warning("x_mapper_type attr is deprecated, use x_scale")
+      @x_scale
+    y_mapper_type: () ->
+      log.warning("y_mapper_type attr is deprecated, use y_scale")
+      @y_scale
   }
 
 register_with_event(UIEvent, Plot)

--- a/bokehjs/src/coffee/models/plots/plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.coffee
@@ -671,10 +671,10 @@ export class PlotCanvas extends LayoutDOM
     @frame = new CartesianFrame({
       x_range: @plot.x_range,
       extra_x_ranges: @plot.extra_x_ranges,
-      x_mapper_type: @plot.x_mapper_type,
+      x_scale: @plot.x_scale,
       y_range: @plot.y_range,
       extra_y_ranges: @plot.extra_y_ranges,
-      y_mapper_type: @plot.y_mapper_type,
+      y_scale: @plot.y_scale
     })
 
     @above_panel = new LayoutCanvas()

--- a/bokehjs/test/models/canvas/cartesian_frame.coffee
+++ b/bokehjs/test/models/canvas/cartesian_frame.coffee
@@ -1,7 +1,12 @@
 {expect} = require "chai"
 utils = require "../../utils"
 
+{CategoricalScale} = utils.require("models/scales/categorical_scale")
+{LinearScale} = utils.require("models/scales/linear_scale")
+{LogScale} = utils.require("models/scales/log_scale")
 {CartesianFrame} = utils.require("models/canvas/cartesian_frame")
+{DataRange1d} = utils.require("models/ranges/data_range1d")
+{FactorRange} = utils.require("models/ranges/factor_range")
 {Range1d} = utils.require("models/ranges/range1d")
 {Document} = utils.require "document"
 {Variable}  = utils.require("core/layout/solver")
@@ -33,3 +38,33 @@ describe "CartesianFrame", ->
 
     expect(c.x_mappers).to.be.deep.equal c.xscales
     expect(c.y_mappers).to.be.deep.equal c.yscales
+
+  describe "_get_scales method", ->
+
+    beforeEach ->
+      @frame = new CartesianFrame({x_range: Range1d(), y_range: Range1d()})
+      @frame_range = Range1d(0, 100)
+
+    it "should return scale if defined", ->
+      scale = new LogScale()
+      ranges = {"default": new Range1d()}
+      scales = @frame._get_scales(scale, ranges, @frame_range)
+      expect(scales["default"]).to.be.instanceof(LogScale)
+
+    it "should return LinearScale as default for Range1d", ->
+      scale = undefined
+      ranges = {"default": new Range1d()}
+      scales = @frame._get_scales(scale, ranges, @frame_range)
+      expect(scales["default"]).to.be.instanceof(LinearScale)
+
+    it "should return LinearScale as default for DataRange1d", ->
+      scale = undefined
+      ranges = {"default": new DataRange1d()}
+      scales = @frame._get_scales(scale, ranges, @frame_range)
+      expect(scales["default"]).to.be.instanceof(LinearScale)
+
+    it "should return CategoricalScale as default for FactorRange", ->
+      scale = undefined
+      ranges = {"default": new FactorRange()}
+      scales = @frame._get_scales(scale, ranges, @frame_range)
+      expect(scales["default"]).to.be.instanceof(CategoricalScale)


### PR DESCRIPTION
Deprecate x/y_mapper_type Plot kwargs in place of first-class Scale models

- [ ] issues: fixes #5268
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
