### PR TITLE
Escape HTML title

### DIFF
--- a/bokeh/core/_templates/file.html
+++ b/bokeh/core/_templates/file.html
@@ -21,7 +21,7 @@ that accepts these same parameters.
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>{{ title if title else "Bokeh Plot" }}</title>
+        <title>{{ title|e if title else "Bokeh Plot" }}</title>
         {{ bokeh_css }}
         {{ bokeh_js }}
         <style>

--- a/bokeh/tests/test_embed.py
+++ b/bokeh/tests/test_embed.py
@@ -212,6 +212,11 @@ def test_file_html_provides_warning_if_no_js(mock_warn):
     )
 
 
+def test_file_html_title_is_escaped():
+    r = embed.file_html(_embed_test_plot, CDN, "&<")
+    assert "<title>&amp;&lt;</title>" in r
+
+
 class TestAutoloadStatic(unittest.TestCase):
 
     def test_return_type(self):


### PR DESCRIPTION
This changes the default Jinja template to escape the title value.

- [x] issues: fixes #6245
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
