### PR TITLE
properly check for ImageURL w, h for None

### DIFF
--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -467,28 +467,18 @@ class ImageURL(Glyph):
     The y-coordinates to locate the image anchors.
     """)
 
-    # TODO: (bev) rename to "dw" for consistency
-    w = DistanceSpec(help="""
-    The widths of the plot regions that the images will occupy.
+    w = DistanceSpec(default=None, help="""
+    The height of the plot region that the image will occupy in data space.
 
-    .. note::
-        This is not the number of pixels that an image is wide.
-        That number is fixed by the image itself.
-
-    .. note::
-        This may be renamed to "dw" in the future.
+    The default value is ``None``, in which case the image will be displayed
+    at its actual image size (regardless of the units specified here).
     """)
 
-    # TODO: (bev) rename to "dh" for consistency
-    h = DistanceSpec(help="""
-    The height of the plot region that the image will occupy.
+    h = DistanceSpec(default=None, help="""
+    The height of the plot region that the image will occupy in data space.
 
-    .. note::
-        This is not the number of pixels that an image is tall.
-        That number is fixed by the image itself.
-
-    .. note::
-        This may be renamed to "dh" in the future.
+    The default value is ``None``, in which case the image will be displayed
+    at its actual image size (regardless of the units specified here).
     """)
 
     angle = AngleSpec(default=0, help="""

--- a/bokehjs/src/coffee/models/glyphs/image_url.coffee
+++ b/bokehjs/src/coffee/models/glyphs/image_url.coffee
@@ -38,9 +38,10 @@ export class ImageURLView extends GlyphView
       img.src = @_url[i]
 
   _map_data: () ->
-    # XXX: remove this when `null` handling is improved.
-    ws = (if @_w? then @_w else NaN for x in @_x)
-    hs = (if @_h? then @_h else NaN for x in @_x)
+    # Better to check @model.w and @model.h for null since the set_data
+    # machinery will have converted @_w and @_w to lists of null
+    ws = (if @model.w? then @_w else NaN for x in @_x)
+    hs = (if @model.h? then @_h else NaN for x in @_x)
 
     switch @model.properties.w.units
       when "data" then @sw = @sdist(@renderer.xscale, @_x, ws, 'edge', @model.dilate)

--- a/bokehjs/test/models/glyphs/image_url.coffee
+++ b/bokehjs/test/models/glyphs/image_url.coffee
@@ -63,3 +63,20 @@ describe "ImageURL module", ->
       image_url_view.map_data()
       expect(image_url_view.sw).to.be.deep.equal([100])
       expect(image_url_view.sh).to.be.deep.equal([200])
+
+    it "`_map_data` should map data to NaN if w and h are null, regardless of units", ->
+      # if sw, sh are NaN, then the image width or height are used during render
+      @image_url.w = null
+      @image_url.h = null
+
+      image_url_view = create_glyph_view(@image_url)
+      image_url_view.map_data()
+      expect(image_url_view.sw).to.be.deep.equal([NaN])
+      expect(image_url_view.sh).to.be.deep.equal([NaN])
+
+      @image_url.properties.w.units = "screen"
+      @image_url.properties.h.units = "screen"
+      image_url_view = create_glyph_view(@image_url)
+      image_url_view.map_data()
+      expect(image_url_view.sw).to.be.deep.equal([NaN])
+      expect(image_url_view.sh).to.be.deep.equal([NaN])

--- a/examples/models/file/image_url.py
+++ b/examples/models/file/image_url.py
@@ -34,7 +34,7 @@ image2 = ImageURL(url="url", x="x2", y="y2", w=20, h=20, anchor="top_left")
 plot.add_glyph(source, image2)
 
 image3 = ImageURL(url=dict(value=url), x=200, y=-100, anchor="bottom_right")
-plot.add_glyph(source, image3)
+plot.add_glyph(image3)
 
 xaxis = LinearAxis()
 plot.add_layout(xaxis, 'below')


### PR DESCRIPTION
- [x] issues: fixes #6095
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

The issue was that the view properties like `@_w` are now converted to lists `[null]` when `@model.w` is `null` (or `None` on the python side). I have no opinion on whether this is reasonable (it could probably be argued either way). So this PR fixes things by checking `@model.w` directly, which is an unequivocal and always-correct source of truth in this question. 

I have also removed the note about possibly changing the property names to `dw` and `dh`. That ship has sailed. 

Finally, I changed the example to pass an empty CDS to the last "values-only" call to `ImageURL`. This is because we normally "broadcast" values to the size of the CDS. this results in the same image being rendered 5 times. The broadcasting is a reasonable thing in general. It could be simply considered a usage error to pass a CDS with data when there are not data specs with fields. (Maybe a validation warning would be advised?) Otherwise, to avoid this we would need to check for and special-case whenever a CDS has data but a glyph has all "value" data specs. 

I added a unit test to confirm that when `model.w` and `model.h` are `null` then expected `NaN` is generated for `view.sw` and `view.sh` but this is not ideal. Perhaps a strict image diff test?

<img width="648" alt="screen shot 2017-05-09 at 08 34 26" src="https://cloud.githubusercontent.com/assets/1078448/25853428/572ee332-3492-11e7-82f6-3a12209a0178.png">

