### PR TITLE
COMPAT: Avoid FutureWarning from pandas.tslib

### DIFF
--- a/bokeh/core/json_encoder.py
+++ b/bokeh/core/json_encoder.py
@@ -49,6 +49,16 @@ from ..util.serialization import transform_series, transform_array
 pd = import_optional('pandas')
 rd = import_optional("dateutil.relativedelta")
 
+if pd:
+    try:
+        # pandas >= 0.15.0
+        Timestamp = pd.Timestamp
+    except AttributeError:
+        Timestamp = pd.tslib.Timestamp
+else:
+    Timestamp = None
+
+
 _NP_EPOCH = np.datetime64(0, 'ms')
 _NP_MS_DELTA = np.timedelta64(1, 'ms')
 
@@ -70,7 +80,7 @@ class BokehJSONEncoder(json.JSONEncoder):
         '''
 
         # Pandas Timestamp
-        if pd and isinstance(obj, pd.tslib.Timestamp):
+        if pd and isinstance(obj, Timestamp):
             return obj.value / 10**6.0  #nanosecond to millisecond
         elif np.issubdtype(type(obj), np.float):
             return float(obj)

--- a/bokeh/core/tests/test_json_encoder.py
+++ b/bokeh/core/tests/test_json_encoder.py
@@ -109,7 +109,7 @@ class TestBokehJSONEncoder(unittest.TestCase):
 
     @skipIf(not is_pandas, "pandas does not work in PyPy.")
     def test_pd_timestamp(self):
-        ts = pd.tslib.Timestamp('April 28, 1948')
+        ts = pd.Timestamp('April 28, 1948')
         self.assertEqual(self.encoder.default(ts), -684115200000)
 
 class TestSerializeJson(unittest.TestCase):


### PR DESCRIPTION
pandas.tslib is deprecated and will be removed in a future version of pandas.
The only use of that is in pandas.Timestamp, which has been available in
the public API since at least pandas 0.16.

- [x] issues: fixes #6274 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

I can add a test asserting a warning isn't raised if you want.
It also looks like Bokeh *recommends* at least pandas >= 0.16.1; I was able to verify that pandas 0.16+ had Timestamp in the top-level namespace. If you prefer, I can remove the compatibility logic.