### PR TITLE
Allow datetime values for number specs by default

### DIFF
--- a/bokeh/core/json_encoder.py
+++ b/bokeh/core/json_encoder.py
@@ -9,6 +9,10 @@ In general, functions in this module convert values in the following way:
 * Datetime values (Python, Pandas, NumPy) are converted to floating point
   milliseconds since epoch.
 
+* TimeDelta values are converted to absolute floating point milliseconds.
+
+* RelativeDelta values are converted to dictionaries.
+
 * Decimal values are converted to floating point.
 
 * Sequences (Pandas Series, NumPy arrays, python sequences) that are passed
@@ -35,22 +39,17 @@ import logging
 log = logging.getLogger(__name__)
 
 import collections
-import datetime as dt
 import decimal
 import json
-import time
 
 import numpy as np
 
 from ..settings import settings
 from ..util.dependencies import import_optional
-from ..util.serialization import transform_series, transform_array
+from ..util.serialization import convert_datetime_type, is_datetime_type, transform_series, transform_array
 
 pd = import_optional('pandas')
 rd = import_optional("dateutil.relativedelta")
-
-_NP_EPOCH = np.datetime64(0, 'ms')
-_NP_MS_DELTA = np.timedelta64(1, 'ms')
 
 class BokehJSONEncoder(json.JSONEncoder):
     ''' A custom ``json.JSONEncoder`` subclass for encoding objects in
@@ -69,9 +68,11 @@ class BokehJSONEncoder(json.JSONEncoder):
 
         '''
 
-        # Pandas Timestamp
-        if pd and isinstance(obj, pd.tslib.Timestamp):
-            return obj.value / 10**6.0  #nanosecond to millisecond
+        # date/time values that get serialized as milliseconds
+        if is_datetime_type(obj):
+            return convert_datetime_type(obj)
+
+        # NumPy scalars
         elif np.issubdtype(type(obj), np.float):
             return float(obj)
         elif np.issubdtype(type(obj), np.integer):
@@ -79,38 +80,19 @@ class BokehJSONEncoder(json.JSONEncoder):
         elif np.issubdtype(type(obj), np.bool_):
             return bool(obj)
 
-        # Datetime (datetime is a subclass of date)
-        elif isinstance(obj, dt.datetime):
-            return time.mktime(obj.timetuple()) * 1000. + obj.microsecond / 1000.
-
-        # Timedelta (timedelta is class in the datetime library)
-        elif isinstance(obj, dt.timedelta):
-            return obj.total_seconds() * 1000.
-
-        # Date
-        elif isinstance(obj, dt.date):
-            return time.mktime(obj.timetuple()) * 1000.
-
-        # Numpy datetime64
-        elif isinstance(obj, np.datetime64):
-            epoch_delta = obj - _NP_EPOCH
-            return (epoch_delta / _NP_MS_DELTA)
-
-        # Time
-        elif isinstance(obj, dt.time):
-            return (obj.hour * 3600 + obj.minute * 60 + obj.second) * 1000 + obj.microsecond / 1000.
-        elif rd and isinstance(obj, rd.relativedelta):
-            return dict(years=obj.years,
-                        months=obj.months,
-                        days=obj.days,
-                        hours=obj.hours,
-                        minutes=obj.minutes,
-                        seconds=obj.seconds,
-                        microseconds=obj.microseconds)
-
-        # Decimal
+        # Decimal values
         elif isinstance(obj, decimal.Decimal):
             return float(obj)
+
+        # RelativeDelta gets serialized as a dict
+        elif rd and isinstance(obj, rd.relativedelta):
+            return dict(years=obj.years,
+                    months=obj.months,
+                    days=obj.days,
+                    hours=obj.hours,
+                    minutes=obj.minutes,
+                    seconds=obj.seconds,
+                    microseconds=obj.microseconds)
 
         else:
             return super(BokehJSONEncoder, self).default(obj)

--- a/bokeh/core/property_mixins.py
+++ b/bokeh/core/property_mixins.py
@@ -66,7 +66,7 @@ class FillProps(HasProps):
 
     """)
 
-    fill_alpha = NumberSpec(default=1.0, help="""
+    fill_alpha = NumberSpec(default=1.0, accept_datetime=False, help="""
     An alpha value to use to fill paths with.
 
     Acceptable values are floating point numbers between 0 (transparent)
@@ -95,11 +95,11 @@ class LineProps(HasProps):
 
     """)
 
-    line_width = NumberSpec(default=1, help="""
+    line_width = NumberSpec(default=1, accept_datetime=False, help="""
     Stroke width in units of pixels.
     """)
 
-    line_alpha = NumberSpec(default=1.0, help="""
+    line_alpha = NumberSpec(default=1.0, accept_datetime=False, help="""
     An alpha value to use to stroke paths with.
 
     Acceptable values are floating point numbers between 0 (transparent)
@@ -196,7 +196,7 @@ class TextProps(HasProps):
 
     """)
 
-    text_alpha = NumberSpec(default=1.0, help="""
+    text_alpha = NumberSpec(default=1.0, accept_datetime=False, help="""
     An alpha value to use to fill text with.
 
     Acceptable values are floating point numbers between 0 (transparent)

--- a/bokeh/core/tests/test_json_encoder.py
+++ b/bokeh/core/tests/test_json_encoder.py
@@ -109,7 +109,7 @@ class TestBokehJSONEncoder(unittest.TestCase):
 
     @skipIf(not is_pandas, "pandas does not work in PyPy.")
     def test_pd_timestamp(self):
-        ts = pd.tslib.Timestamp('April 28, 1948')
+        ts = pd.Timestamp('April 28, 1948')
         self.assertEqual(self.encoder.default(ts), -684115200000)
 
 class TestSerializeJson(unittest.TestCase):

--- a/bokeh/core/tests/test_json_encoder.py
+++ b/bokeh/core/tests/test_json_encoder.py
@@ -6,7 +6,6 @@ from unittest import skipIf
 from collections import deque
 import datetime as dt
 import decimal
-import time
 
 import numpy as np
 from six import string_types
@@ -180,16 +179,23 @@ class TestSerializeJson(unittest.TestCase):
         """ should convert to millis as-is
         """
 
+        DT_EPOCH = dt.datetime.utcfromtimestamp(0)
+
         a = dt.date(2016, 4, 28)
         b = dt.datetime(2016, 4, 28, 2, 20, 50)
         serialized = self.serialize({'a' : [a],
                                      'b' : [b]})
         deserialized = self.deserialize(serialized)
 
-        baseline = {u'a': [time.mktime(a.timetuple())*1000],
-                    u'b': [time.mktime(b.timetuple())*1000],
+        baseline = {u'a': [(dt.datetime(*a.timetuple()[:6]) - DT_EPOCH).total_seconds() * 1000],
+                    u'b': [(b - DT_EPOCH).total_seconds() * 1000. + b.microsecond / 1000.],
         }
         assert deserialized == baseline
+
+        # test pre-computed values too
+        assert deserialized == {
+            u'a': [1461801600000.0], u'b': [1461810050000.0]
+        }
 
     def test_builtin_timedelta_types(self):
         """ should convert time delta to a dictionary

--- a/bokeh/core/tests/test_properties.py
+++ b/bokeh/core/tests/test_properties.py
@@ -489,7 +489,7 @@ class TestNumberSpec(unittest.TestCase):
 
         f = Foo()
 
-        f.dt = datetime.datetime(2016, 5, 11)
+        f.dt = datetime.datetime(2016, 5, 11, tzinfo=None)
         self.assertEqual(f.dt, 1462942800000.0)
 
         f.dt = datetime.date(2016, 5, 12)

--- a/bokeh/core/tests/test_properties.py
+++ b/bokeh/core/tests/test_properties.py
@@ -489,24 +489,24 @@ class TestNumberSpec(unittest.TestCase):
 
         f = Foo()
 
-        f.dt = datetime.datetime(2016, 5, 11, tzinfo=None)
-        self.assertEqual(f.dt, 1462942800000.0)
+        f.dt = datetime.datetime(2016, 5, 11)
+        self.assertEqual(f.dt, 1462924800000.0)
 
-        f.dt = datetime.date(2016, 5, 12)
-        self.assertEqual(f.dt, 1463029200000.0)
+        f.dt = datetime.date(2016, 5, 11)
+        self.assertEqual(f.dt, 1462924800000.0)
 
-        f.dt = np.datetime64("2016-05-13")
-        self.assertEqual(f.dt, 1463097600000.0)
+        f.dt = np.datetime64("2016-05-11")
+        self.assertEqual(f.dt, 1462924800000.0)
 
 
         with self.assertRaises(ValueError):
             f.ndt = datetime.datetime(2016, 5, 11)
 
         with self.assertRaises(ValueError):
-            f.ndt = datetime.date(2016, 5, 12)
+            f.ndt = datetime.date(2016, 5, 11)
 
         with self.assertRaises(ValueError):
-            f.ndt = np.datetime64("2016-05-13")
+            f.ndt = np.datetime64("2016-05-11")
 
     def test_default(self):
         class Foo(HasProps):

--- a/bokeh/core/tests/test_properties.py
+++ b/bokeh/core/tests/test_properties.py
@@ -453,6 +453,61 @@ class TestNumberSpec(unittest.TestCase):
         f.x = None
         self.assertIs(Foo.__dict__["x"].serializable_value(f), None)
 
+    def tests_accepts_timedelta(self):
+        class Foo(HasProps):
+            dt = NumberSpec("dt", accept_datetime=True)
+            ndt = NumberSpec("ndt", accept_datetime=False)
+
+        f = Foo()
+
+        f.dt = datetime.timedelta(3, 54)
+        self.assertEqual(f.dt, 259254000.0)
+
+        # counts as number.Real out of the box
+        f.dt = np.timedelta64(3000, "ms")
+        self.assertEqual(f.dt, np.timedelta64(3000, "ms"))
+
+        # counts as number.Real out of the box
+        f.dt = pd.Timedelta("3000ms")
+        self.assertEqual(f.dt, 3000.0)
+
+
+        f.ndt = datetime.timedelta(3, 54)
+        self.assertEqual(f.ndt, 259254000.0)
+
+        # counts as number.Real out of the box
+        f.ndt = np.timedelta64(3000, "ms")
+        self.assertEqual(f.ndt, np.timedelta64(3000, "ms"))
+
+        f.ndt = pd.Timedelta("3000ms")
+        self.assertEqual(f.ndt, 3000.0)
+
+    def test_accepts_datetime(self):
+        class Foo(HasProps):
+            dt = NumberSpec("dt", accept_datetime=True)
+            ndt = NumberSpec("ndt", accept_datetime=False)
+
+        f = Foo()
+
+        f.dt = datetime.datetime(2016, 5, 11)
+        self.assertEqual(f.dt, 1462942800000.0)
+
+        f.dt = datetime.date(2016, 5, 12)
+        self.assertEqual(f.dt, 1463029200000.0)
+
+        f.dt = np.datetime64("2016-05-13")
+        self.assertEqual(f.dt, 1463097600000.0)
+
+
+        with self.assertRaises(ValueError):
+            f.ndt = datetime.datetime(2016, 5, 11)
+
+        with self.assertRaises(ValueError):
+            f.ndt = datetime.date(2016, 5, 12)
+
+        with self.assertRaises(ValueError):
+            f.ndt = np.datetime64("2016-05-13")
+
     def test_default(self):
         class Foo(HasProps):
             y = NumberSpec(default=12)

--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -10,13 +10,14 @@ from ..core.enums import (accept_left_right_center, AngleUnits, DeprecatedLegend
                           FontStyle, LegendClickPolicy, LegendLocation, Orientation, RenderMode,
                           SpatialUnits, TextAlign)
 from ..core.has_props import abstract
-from ..core.properties import (Angle, AngleSpec, Auto, Bool, ColorSpec, DistanceSpec, Either, Enum, Float,
-                               FontSizeSpec, Include, Instance, Int, List, NumberSpec, Override,
+from ..core.properties import (Angle, AngleSpec, Auto, Bool, ColorSpec, Datetime, DistanceSpec, Either,
+                               Enum, Float, FontSizeSpec, Include, Instance, Int, List, NumberSpec, Override,
                                Seq, String, StringSpec, Tuple, value)
 from ..core.property_mixins import FillProps, LineProps, TextProps
 from ..core.validation import error
 from ..core.validation.errors import BAD_COLUMN_NAME, NON_MATCHING_DATA_SOURCES_ON_LEGEND_ITEM_RENDERERS
 from ..model import Model
+from ..util.serialization import convert_datetime_type
 
 from .formatters import BasicTickFormatter, TickFormatter
 from .mappers import ContinuousColorMapper
@@ -402,6 +403,9 @@ class BoxAnnotation(Annotation):
 
     left = Either(Auto, NumberSpec(), default=None, help="""
     The x-coordinates of the left edge of the box annotation.
+
+    Datetime values are also accepted, but note that they are immediately
+    converted to milliseconds-since-epoch.
     """)
 
     left_units = Enum(SpatialUnits, default='data', help="""
@@ -411,6 +415,9 @@ class BoxAnnotation(Annotation):
 
     right = Either(Auto, NumberSpec(), default=None, help="""
     The x-coordinates of the right edge of the box annotation.
+
+    Datetime values are also accepted, but note that they are immediately
+    converted to milliseconds-since-epoch.
     """)
 
     right_units = Enum(SpatialUnits, default='data', help="""
@@ -420,6 +427,9 @@ class BoxAnnotation(Annotation):
 
     bottom = Either(Auto, NumberSpec(), default=None, help="""
     The y-coordinates of the bottom edge of the box annotation.
+
+    Datetime values are also accepted, but note that they are immediately
+    converted to milliseconds-since-epoch.
     """)
 
     bottom_units = Enum(SpatialUnits, default='data', help="""
@@ -429,6 +439,9 @@ class BoxAnnotation(Annotation):
 
     top = Either(Auto, NumberSpec(), default=None, help="""
     The y-coordinates of the top edge of the box annotation.
+
+    Datetime values are also accepted, but note that they are immediately
+    converted to milliseconds-since-epoch.
     """)
 
     top_units = Enum(SpatialUnits, default='data', help="""
@@ -543,7 +556,10 @@ class Label(TextAnnotation):
 
     x = Float(help="""
     The x-coordinate in screen coordinates to locate the text anchors.
-    """)
+
+    Datetime values are also accepted, but note that they are immediately
+    converted to milliseconds-since-epoch.
+    """).accepts(Datetime, convert_datetime_type)
 
     x_units = Enum(SpatialUnits, default='data', help="""
     The unit type for the x attribute. Interpreted as "data space" units
@@ -552,7 +568,10 @@ class Label(TextAnnotation):
 
     y = Float(help="""
     The y-coordinate in screen coordinates to locate the text anchors.
-    """)
+
+    Datetime values are also accepted, but note that they are immediately
+    converted to milliseconds-since-epoch.
+    """).accepts(Datetime, convert_datetime_type)
 
     y_units = Enum(SpatialUnits, default='data', help="""
     The unit type for the y attribute. Interpreted as "data space" units

--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -405,11 +405,11 @@ class ImageRGBA(Glyph):
     The y-coordinates to locate the image anchors.
     """)
 
-    rows = NumberSpec(None, help="""
+    rows = NumberSpec(None, accept_datetime=False, help="""
     The numbers of rows in the images
     """).asserts(False, lambda obj, name, value: deprecated((0, 12, 4), "ImageRGBA.rows", "2D array representation"))
 
-    cols = NumberSpec(None, help="""
+    cols = NumberSpec(None, accept_datetime=False, help="""
     The numbers of columns in the images
     """).asserts(False, lambda obj, name, value: deprecated((0, 12, 4), "ImageRGBA.cols", "2D array representation"))
 
@@ -451,7 +451,8 @@ class ImageURL(Glyph):
     # functions derived from this class
     _args = ('url', 'x', 'y', 'w', 'h', 'angle', 'global_alpha', 'dilate')
 
-    url = NumberSpec(help="""
+    # TODO (bev) Why is this a NumberSpec??
+    url = NumberSpec(accept_datetime=False, help="""
     The URLs to retrieve images from.
 
     .. note::

--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -1,4 +1,4 @@
-"""
+'''
 Functions for helping with serialization and deserialization of
 Bokeh objects.
 
@@ -7,47 +7,124 @@ performance and efficiency. The list of supported dtypes is:
 
 {binary_array_types}
 
-"""
+'''
 from __future__ import absolute_import
-
-import base64
-import math
-
-from six import iterkeys
-
-from bokeh.util.string import format_docstring
-from .dependencies import import_optional
-
-is_numpy = None
-
-try:
-    import numpy as np
-    is_numpy = True
-    BINARY_ARRAY_TYPES = set([
-        np.dtype(np.float32),
-        np.dtype(np.float64),
-        np.dtype(np.uint8),
-        np.dtype(np.int8),
-        np.dtype(np.uint16),
-        np.dtype(np.int16),
-        np.dtype(np.uint32),
-        np.dtype(np.int32),
-    ])
-except ImportError:
-    is_numpy = False
-    BINARY_ARRAY_TYPES = set()
-
-__doc__ = format_docstring(__doc__, binary_array_types="\n".join("* ``np." + str(x) + "``" for x in BINARY_ARRAY_TYPES))
-
-pd = import_optional('pandas')
 
 import logging
 log = logging.getLogger(__name__)
 
+import base64
+import datetime as dt
+import math
+import time
+
+from six import iterkeys
+
+import numpy as np
+
+from .string import format_docstring
+from .dependencies import import_optional
+
+pd = import_optional('pandas')
+
+BINARY_ARRAY_TYPES = set([
+    np.dtype(np.float32),
+    np.dtype(np.float64),
+    np.dtype(np.uint8),
+    np.dtype(np.int8),
+    np.dtype(np.uint16),
+    np.dtype(np.int16),
+    np.dtype(np.uint32),
+    np.dtype(np.int32),
+])
+
+DATETIME_TYPES = set([
+    dt.datetime,
+    dt.timedelta,
+    dt.date,
+    dt.time,
+    np.datetime64,
+    np.timedelta64
+])
+
+if pd:
+    try:
+        _pd_timestamp = pd.Timestamp
+    except AttributeError:
+        _pd_timestamp = pd.tslib.Timestamp
+    DATETIME_TYPES.add(_pd_timestamp)
+    DATETIME_TYPES.add(pd.Timedelta)
+
+NP_EPOCH = np.datetime64(0, 'ms')
+NP_MS_DELTA = np.timedelta64(1, 'ms')
+
+__doc__ = format_docstring(__doc__, binary_array_types="\n".join("* ``np." + str(x) + "``" for x in BINARY_ARRAY_TYPES))
+
 _simple_id = 1000
 
+_dt_tuple = tuple(DATETIME_TYPES)
+
+def is_datetime_type(obj):
+    ''' Whether an object is any date, datetime, or time delta type
+    recognized by Bokeh.
+
+    Arg:
+        obj (object) : the object to test
+
+    Returns:
+        bool : True if ``obj`` is a datetime type
+
+    '''
+    return isinstance(obj, _dt_tuple)
+
+def convert_datetime_type(obj):
+    ''' Convert any recognized date, datetime or time delta value to
+    floating point milliseconds
+
+    Date and Datetime values are converted to milliseconds since epoch.
+
+    TimeDeleta values are converted to absolute milliseconds.
+
+    Arg:
+        obj (object) : the object to convert
+
+    Returns:
+        float : milliseconds
+
+    '''
+    # Pandas Timestamp
+    if pd and isinstance(obj, _pd_timestamp): return obj.value / 10**6.0
+
+    # Pandas Timedelta
+    elif pd and isinstance(obj, pd.Timedelta): return obj.value / 10**6.0
+
+    # Datetime (datetime is a subclass of date)
+    elif isinstance(obj, dt.datetime):
+        return time.mktime(obj.timetuple()) * 1000. + obj.microsecond / 1000.
+
+    # Timedelta (timedelta is class in the datetime library)
+    elif isinstance(obj, dt.timedelta):
+        return obj.total_seconds() * 1000.
+
+    # Date
+    elif isinstance(obj, dt.date):
+        return time.mktime(obj.timetuple()) * 1000.
+
+    # NumPy datetime64
+    elif isinstance(obj, np.datetime64):
+        epoch_delta = obj - NP_EPOCH
+        return (epoch_delta / NP_MS_DELTA)
+
+    # Numpy timedelta64
+    elif isinstance(obj, np.timedelta64):
+        return (obj / NP_MS_DELTA)
+
+    # Time
+    elif isinstance(obj, dt.time):
+        return (obj.hour * 3600 + obj.minute * 60 + obj.second) * 1000 + obj.microsecond / 1000.
+
 def make_id():
-    """ Return a new unique ID for a Bokeh object.
+    ''' Return a new unique ID for a Bokeh object.
 
     Normally this function will return UUIDs to use for identifying Bokeh
     objects. This is especally important for Bokeh objects stored on a
@@ -55,7 +132,7 @@ def make_id():
     IDs during development, so this behavior can be overridden by
     setting the environment variable ``BOKEH_SIMPLE_IDS=yes``.
 
-    """
+    '''
     global _simple_id
 
     import uuid
@@ -69,7 +146,7 @@ def make_id():
     return str(new_id)
 
 def array_encoding_disabled(array):
-    """ Determine whether an array may be binary encoded.
+    ''' Determine whether an array may be binary encoded.
 
     The NumPy array dtypes that can be encoded are:
 
@@ -81,7 +158,7 @@ def array_encoding_disabled(array):
     Returns:
         bool
 
-    """
+    '''
 
     # disable binary encoding for non-supported dtypes
     return array.dtype not in BINARY_ARRAY_TYPES
@@ -91,7 +168,7 @@ array_encoding_disabled.__doc__ = format_docstring(array_encoding_disabled.__doc
                                                                                     for x in BINARY_ARRAY_TYPES))
 
 def transform_array(array, force_list=False):
-    """ Transform a NumPy arrays into serialized format
+    ''' Transform a NumPy arrays into serialized format
 
     Converts un-serializable dtypes and returns JSON serializable
     format
@@ -106,7 +183,7 @@ def transform_array(array, force_list=False):
     Returns:
         JSON
 
-    """
+    '''
 
     # Check for astype failures (putative Numpy < 1.7)
     try:
@@ -139,7 +216,7 @@ def transform_array(array, force_list=False):
     return serialize_array(array, force_list)
 
 def transform_array_to_list(array):
-    """ Transforms a NumPy array into a list of values
+    ''' Transforms a NumPy array into a list of values
 
     Args:
         array (np.nadarray) : the NumPy array series to transform
@@ -147,7 +224,7 @@ def transform_array_to_list(array):
     Returns:
         list or dict
 
-    """
+    '''
     if (array.dtype.kind in ('u', 'i', 'f') and (~np.isfinite(array)).any()):
         transformed = array.astype('object')
         transformed[np.isnan(array)] = 'NaN'
@@ -161,7 +238,7 @@ def transform_array_to_list(array):
     return array.tolist()
 
 def transform_series(series, force_list=False):
-    """ Transforms a Pandas series into serialized form
+    ''' Transforms a Pandas series into serialized form
 
     Args:
         series (pd.Series) : the Pandas series to transform
@@ -173,12 +250,12 @@ def transform_series(series, force_list=False):
     Returns:
         list or dict
 
-    """
+    '''
     vals = series.values
     return transform_array(vals, force_list)
 
 def serialize_array(array, force_list=False):
-    """ Transforms a NumPy array into serialized form.
+    ''' Transforms a NumPy array into serialized form.
 
     Args:
         array (np.ndarray) : the NumPy array to transform
@@ -190,7 +267,7 @@ def serialize_array(array, force_list=False):
     Returns:
         list or dict
 
-    """
+    '''
     if isinstance(array, np.ma.MaskedArray):
         array = array.filled(np.nan)  # Set masked values to nan
     if (array_encoding_disabled(array) or force_list):
@@ -199,8 +276,8 @@ def serialize_array(array, force_list=False):
         array = np.ascontiguousarray(array)
     return encode_base64_dict(array)
 
-def traverse_data(obj, is_numpy=is_numpy, use_numpy=True):
-    """ Recursively traverse an object until a flat list is found.
+def traverse_data(obj, use_numpy=True):
+    ''' Recursively traverse an object until a flat list is found.
 
     If NumPy is available, the flat list is converted to a numpy array
     and passed to transform_array() to handle ``nan``, ``inf``, and
@@ -210,13 +287,10 @@ def traverse_data(obj, is_numpy=is_numpy, use_numpy=True):
 
     Args:
         obj (list) : a list of values or lists
-        is_numpy (bool, optional): Whether NumPy is availanble
-            (default: True if NumPy is importable)
         use_numpy (bool, optional) toggle NumPy as a dependency for testing
             This argument is only useful for testing (default: True)
-    """
-    is_numpy = is_numpy and use_numpy
-    if is_numpy and all(isinstance(el, np.ndarray) for el in obj):
+    '''
+    if use_numpy and all(isinstance(el, np.ndarray) for el in obj):
         return [transform_array(el) for el in obj]
     obj_copy = []
     for item in obj:
@@ -238,7 +312,7 @@ def traverse_data(obj, is_numpy=is_numpy, use_numpy=True):
     return obj_copy
 
 def transform_column_source_data(data):
-    """ Transform ColumnSourceData data to a serialized format
+    ''' Transform ColumnSourceData data to a serialized format
 
     Args:
         data (dict) : the mapping of names to data columns to transform
@@ -246,7 +320,7 @@ def transform_column_source_data(data):
     Returns:
         JSON compatible dict
 
-    """
+    '''
     data_copy = {}
     for key in iterkeys(data):
         if pd and isinstance(data[key], (pd.Series, pd.Index)):
@@ -285,7 +359,7 @@ def encode_base64_dict(array):
     }
 
 def decode_base64_dict(data):
-    """ Decode a base64 encoded array into a NumPy array.
+    ''' Decode a base64 encoded array into a NumPy array.
 
     Args:
         data (dict) : encoded array data to decode
@@ -295,7 +369,7 @@ def decode_base64_dict(data):
     Returns:
         np.ndarray
 
-    """
+    '''
     b64 = base64.b64decode(data['__ndarray__'])
     array = np.fromstring(b64, dtype=data['dtype'])
     if len(data['shape']) > 1:

--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -16,7 +16,6 @@ log = logging.getLogger(__name__)
 import base64
 import datetime as dt
 import math
-import time
 
 from six import iterkeys
 
@@ -57,6 +56,8 @@ if pd:
 
 NP_EPOCH = np.datetime64(0, 'ms')
 NP_MS_DELTA = np.timedelta64(1, 'ms')
+
+DT_EPOCH = dt.datetime.utcfromtimestamp(0)
 
 __doc__ = format_docstring(__doc__, binary_array_types="\n".join("* ``np." + str(x) + "``" for x in BINARY_ARRAY_TYPES))
 
@@ -100,7 +101,7 @@ def convert_datetime_type(obj):
 
     # Datetime (datetime is a subclass of date)
     elif isinstance(obj, dt.datetime):
-        return time.mktime(obj.timetuple()) * 1000. + obj.microsecond / 1000.
+        return (obj - DT_EPOCH).total_seconds() * 1000. + obj.microsecond / 1000.
 
     # Timedelta (timedelta is class in the datetime library)
     elif isinstance(obj, dt.timedelta):
@@ -108,7 +109,7 @@ def convert_datetime_type(obj):
 
     # Date
     elif isinstance(obj, dt.date):
-        return time.mktime(obj.timetuple()) * 1000.
+        return (dt.datetime(*obj.timetuple()[:6]) - DT_EPOCH).total_seconds() * 1000
 
     # NumPy datetime64
     elif isinstance(obj, np.datetime64):

--- a/bokeh/util/tests/test_serialization.py
+++ b/bokeh/util/tests/test_serialization.py
@@ -51,7 +51,7 @@ def test_is_datetime_type():
     assert bus.is_datetime_type(bus._pd_timestamp(3000000))
 
 def test_convert_datetime_type():
-    assert bus.convert_datetime_type(datetime.datetime(2016, 5, 11)) == 1462942800000.0
+    assert bus.convert_datetime_type(datetime.datetime(2016, 5, 11, tzinfo=None)) == 1462942800000.0
     assert bus.convert_datetime_type(datetime.timedelta(3000)) == 259200000000.0
     assert bus.convert_datetime_type(datetime.date(2016, 5, 11)) == 1462942800000.0
     assert bus.convert_datetime_type(datetime.time(3, 54)) == 14040000.0

--- a/bokeh/util/tests/test_serialization.py
+++ b/bokeh/util/tests/test_serialization.py
@@ -51,9 +51,9 @@ def test_is_datetime_type():
     assert bus.is_datetime_type(bus._pd_timestamp(3000000))
 
 def test_convert_datetime_type():
-    assert bus.convert_datetime_type(datetime.datetime(2016, 5, 11, tzinfo=None)) == 1462942800000.0
+    assert bus.convert_datetime_type(datetime.datetime(2016, 5, 11)) == 1462924800000.0
     assert bus.convert_datetime_type(datetime.timedelta(3000)) == 259200000000.0
-    assert bus.convert_datetime_type(datetime.date(2016, 5, 11)) == 1462942800000.0
+    assert bus.convert_datetime_type(datetime.date(2016, 5, 11)) == 1462924800000.0
     assert bus.convert_datetime_type(datetime.time(3, 54)) == 14040000.0
     assert bus.convert_datetime_type(np.datetime64("2016-05-11")) == 1462924800000.0
     assert bus.convert_datetime_type(np.timedelta64(3000, 'ms')) == 3000.0

--- a/bokeh/util/tests/test_serialization.py
+++ b/bokeh/util/tests/test_serialization.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import datetime
 import base64
 
 import pytest
@@ -18,6 +19,46 @@ def test_id_with_simple_ids():
     assert bus.make_id() == "1001"
     assert bus.make_id() == "1002"
     del os.environ["BOKEH_SIMPLE_IDS"]
+
+def test_np_consts():
+    assert bus.NP_EPOCH == np.datetime64(0, 'ms')
+    assert bus.NP_MS_DELTA == np.timedelta64(1, 'ms')
+
+def test_binary_array_types():
+    assert len(bus.BINARY_ARRAY_TYPES) == 8
+    for typ in [np.dtype(np.float32),
+                np.dtype(np.float64),
+                np.dtype(np.uint8),
+                np.dtype(np.int8),
+                np.dtype(np.uint16),
+                np.dtype(np.int16),
+                np.dtype(np.uint32),
+                np.dtype(np.int32)]:
+        assert typ in bus.BINARY_ARRAY_TYPES
+
+def test_datetime_types():
+    # includes pandas types during tests
+    assert len(bus.DATETIME_TYPES) == 8
+
+def test_is_datetime_type():
+    assert bus.is_datetime_type(datetime.datetime(2016, 5, 11))
+    assert bus.is_datetime_type(datetime.timedelta(3000))
+    assert bus.is_datetime_type(datetime.date(2016, 5, 11))
+    assert bus.is_datetime_type(datetime.time(3, 54))
+    assert bus.is_datetime_type(np.datetime64("2011-05-11"))
+    assert bus.is_datetime_type(np.timedelta64(3000, 'ms'))
+    assert bus.is_datetime_type(pd.Timedelta("3000ms"))
+    assert bus.is_datetime_type(bus._pd_timestamp(3000000))
+
+def test_convert_datetime_type():
+    assert bus.convert_datetime_type(datetime.datetime(2016, 5, 11)) == 1462942800000.0
+    assert bus.convert_datetime_type(datetime.timedelta(3000)) == 259200000000.0
+    assert bus.convert_datetime_type(datetime.date(2016, 5, 11)) == 1462942800000.0
+    assert bus.convert_datetime_type(datetime.time(3, 54)) == 14040000.0
+    assert bus.convert_datetime_type(np.datetime64("2016-05-11")) == 1462924800000.0
+    assert bus.convert_datetime_type(np.timedelta64(3000, 'ms')) == 3000.0
+    assert bus.convert_datetime_type(pd.Timedelta("3000ms")) == 3000.0
+    assert bus.convert_datetime_type(bus._pd_timestamp(3000000)) == 3.0
 
 testing = [[float('nan'), 3], [float('-inf'), [float('inf')]]]
 expected = [['NaN', 3.0], ['-Infinity', ['Infinity']]]

--- a/sphinx/source/docs/releases/0.12.6.rst
+++ b/sphinx/source/docs/releases/0.12.6.rst
@@ -63,8 +63,8 @@ New signaling API
 ~~~~~~~~~~~~~~~~~
 
 Previously we used Backbone events for communication between bokehjs' objects.
-This was changed to a new type-safe API. This change mostly affects contributors
-to bokehjs and writers of extensions.
+This was changed to a new type-safe API. This change primarily affects
+contributors working on BokehJS and writers of extensions.
 
 ===================================== ==============================================
 Old                                   New
@@ -74,3 +74,14 @@ Old                                   New
 ``@listenTo(obj, "change:attr", fn)`` ``@connect(obj.properties.attr.change, fn)``
 ``obj.trigger("change", arg)``        ``obj.change.emit(arg)``
 ``obj.trigger("change:attr", arg)``   ``obj.properties.attr.change.emit(arg)``
+
+Python datetime handling
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Bokeh has not handled Python datetime values consistently with NumPy
+``datetime64``. Bokeh aims to treat all datetime values "as-is", but in some
+cases a local timezone conversion could affect Python datetime values. This
+has been corrected. In case there is code that depends on the erroneous
+behavior, please note that the new behavior is effective immediately and is
+now maintained under test to be consistent with NumPy values. See the issue
+https://github.com/bokeh/bokeh/issues/5499 for more details.


### PR DESCRIPTION
This PR adds a parameter `accept_datetime` to NumberSpec that defaults to True. When enabled, NumberSpecs will accept and immediately convert datetime values to serialized ms-since-epoch values. This allows glyphs and annotations to be positioned using datetime values.

NumberSpec was also modified to always accept and convert timedelta objects. 

This also fixes a future warning from pandas regarding `pd.tslib`

Datetime/timedelta detection and conversion was moved to `bokeh.util.serializtion` so that the code might be shared. As part of this, the handling of Python `datetime` values was corrected to match the handling of NumPy `datetime64`

- [x] issues: fixes #6274, fixes #5831 fixes #5499
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

@mattpap @canavandl I would appreciate a close review of this PR