### PR TITLE
Add plumbing for streaming and patching annoations

### DIFF
--- a/bokehjs/src/coffee/models/annotations/arrow.coffee
+++ b/bokehjs/src/coffee/models/annotations/arrow.coffee
@@ -15,13 +15,14 @@ export class ArrowView extends AnnotationView
   connect_signals: () ->
     super()
     @connect(@model.change, () => @plot_view.request_render())
-    @connect(@model.source.change, () ->
-      @set_data(@model.source)
-      @plot_view.request_render())
+    @connect(@model.source.streaming, () -> @set_data(@model.source))
+    @connect(@model.source.patching, () -> @set_data(@model.source))
+    @connect(@model.source.change, () -> @set_data(@model.source))
 
   set_data: (source) ->
     super(source)
     @visuals.warm_cache(source)
+    @plot_view.request_render()
 
   _map_data: () ->
     if @model.start_units == 'data'

--- a/bokehjs/src/coffee/models/annotations/band.coffee
+++ b/bokehjs/src/coffee/models/annotations/band.coffee
@@ -10,13 +10,14 @@ export class BandView extends AnnotationView
 
   connect_signals: () ->
     super()
-    @connect(@model.source.change, () ->
-      @set_data(@model.source)
-      @plot_view.request_render())
+    @connect(@model.source.streaming, () -> @set_data(@model.source))
+    @connect(@model.source.patching, () -> @set_data(@model.source))
+    @connect(@model.source.change, () -> @set_data(@model.source))
 
   set_data: (source) ->
     super(source)
     @visuals.warm_cache(source)
+    @plot_view.request_render()
 
   _map_data: () ->
     x_scale = @plot_view.frame.xscales[@model.x_range_name]

--- a/bokehjs/src/coffee/models/annotations/label_set.coffee
+++ b/bokehjs/src/coffee/models/annotations/label_set.coffee
@@ -22,11 +22,23 @@ export class LabelSetView extends TextAnnotationView
       @connect(@model.change, () ->
         @set_data(@model.source)
         @render())
+      @connect(@model.source.streaming, () ->
+        @set_data(@model.source)
+        @render())
+      @connect(@model.source.patching, () ->
+        @set_data(@model.source)
+        @render())
       @connect(@model.source.change, () ->
         @set_data(@model.source)
         @render())
     else
       @connect(@model.change, () ->
+        @set_data(@model.source)
+        @plot_view.request_render())
+      @connect(@model.source.streaming, () ->
+        @set_data(@model.source)
+        @plot_view.request_render())
+      @connect(@model.source.patching, () ->
         @set_data(@model.source)
         @plot_view.request_render())
       @connect(@model.source.change, () ->


### PR DESCRIPTION
 fixes #4872

Arrow, Band, and LabelSet were missing signal connections to `source.streaming` and `source.patching` necessary for these annotations to update when their data sources are streamed or patched.

This PR adds the missing signal connections. When reasonable, a `request_render` was moved to `set_data` (this is ok when there is not any CSS/dom rendering path)

Test case:

```
from random import randrange
from bokeh.io import curdoc
from bokeh.plotting import figure
from bokeh.layouts import layout
from bokeh.models import ColumnDataSource, Arrow, NormalHead

plot = figure(x_range=(0, 10), y_range=(0, 10))
source = ColumnDataSource(data={'x0': [], 'y0': [], 'x1': [], 'y1': []})
# if the plot only contains annotations it screws up range and scrolling
plot.circle(x=0, y=0)
plot.add_layout(
        Arrow(end=NormalHead(size=4), x_start='x0', y_start='y0', x_end='x1',
        y_end='y1', source=source))

def callback():
    source.stream({k: [randrange(10) for _ in range(5)] for k in ('x0', 'y0', 'x1', 'y1')})

curdoc().add_root(layout([[plot]]))
curdoc().add_periodic_callback(callback, 1000)
```

Results in:

<img width="632" alt="screen shot 2017-05-11 at 18 21 05" src="https://cloud.githubusercontent.com/assets/1078448/25975920/d0874996-3676-11e7-9183-3de9d616b7b1.png">


