### PR TITLE
update MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,7 +21,7 @@ graft sphinx
 prune sphinx/_build
 
 # Examples
-recursive-include examples *.py *.ipynb *.md
+recursive-include examples *.html *.py *.ipynb *.md
 prune examples/embed/*.html
 prune examples/models/file/*.html
 prune examples/plotting/file/*.html

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,12 +1,13 @@
 # Things to always exclude
 global-exclude .git*
-global-exclude *.ipynb_checkpoints*s
-global-exclude *.pyc
-global-exclude *.pyo
-global-exclude *js/tree_ts/*
+global-exclude .ipynb_checkpoints
+global-exclude *.py[co]
 
-# Specific files to include
-include bokeh/themes/*.yaml
+# Build
+prune bokeh/server/static/js/tree
+prune bokeh/server/static/js/tree_ts
+
+# Config
 include CHANGELOG
 include classifiers.txt
 include LICENSE.txt
@@ -23,7 +24,7 @@ graft sphinx
 prune sphinx/_build
 
 # Examples
-recursive-include examples *.html *.py *.ipynb *.md
+recursive-include examples *.html *.py *.ipynb *.md *.yaml
 prune examples/embed/*.html
 prune examples/models/file/*.html
 prune examples/plotting/file/*.html

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,21 +1,28 @@
+# Things to always exclude
 global-exclude .git*
+global-exclude .ipynb_checkpoints
+global-exclude *.pyc
+global-exclude *.pyo
+
+# Specific files to include
+include bokeh/themes/*.yaml
 include CHANGELOG
 include classifiers.txt
 include LICENSE.txt
 include setup.cfg
 include versioneer.py
 include _setup_support.py
-include bokeh/themes/*.yaml
-recursive-include examples *.py *.ipynb *.md
+
+# Tests
 recursive-include tests *.py *.ipynb *.jinja *.js *.md *.png
-prune examples/charts/.ipynb_checkpoints
-prune examples/compat/mpl/.ipynb_checkpoints
-prune examples/glyphs/.ipynb_checkpoints
-prune examples/plotting/notebook/.ipynb_checkpoints
-prune examples/charts/*.html
-prune examples/compat/mpl/*.html
-prune examples/compat/pandas/*.html
-prune examples/compat/seaborn/*.html
+
+# Docs
+graft sphinx
+prune sphinx/_build
+
+# Examples
+recursive-include examples *.py *.ipynb *.md
 prune examples/embed/*.html
-prune examples/glyphs/*.html
+prune examples/models/file/*.html
 prune examples/plotting/file/*.html
+prune examples/webgl/*.html

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,14 +1,16 @@
 # Things to always exclude
 global-exclude .git*
-global-exclude .ipynb_checkpoints
+global-exclude *.ipynb_checkpoints*s
 global-exclude *.pyc
 global-exclude *.pyo
+global-exclude *js/tree_ts/*
 
 # Specific files to include
 include bokeh/themes/*.yaml
 include CHANGELOG
 include classifiers.txt
 include LICENSE.txt
+include MANIFEST.in
 include setup.cfg
 include versioneer.py
 include _setup_support.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,11 +3,7 @@ global-exclude .git*
 global-exclude .ipynb_checkpoints
 global-exclude *.py[co]
 
-# Build
-prune bokeh/server/static/js/tree
-prune bokeh/server/static/js/tree_ts
-
-# Config
+# Top-level Config
 include CHANGELOG
 include classifiers.txt
 include LICENSE.txt
@@ -15,6 +11,10 @@ include MANIFEST.in
 include setup.cfg
 include versioneer.py
 include _setup_support.py
+
+# BokehJS Build Junk
+prune bokeh/server/static/js/tree
+prune bokeh/server/static/js/tree_ts
 
 # Tests
 recursive-include tests *.py *.ipynb *.jinja *.js *.md *.png


### PR DESCRIPTION
 issues: fixes #6295

Update `MANIFEST.in` in light of recent examples re-orgs and `bkcharts` split. 

The also changes to include the docs in the source tarball.