### PR TITLE
Replace underscore with underscore.template

### DIFF
--- a/bokehjs/gulp/tasks/scripts.ts
+++ b/bokehjs/gulp/tasks/scripts.ts
@@ -1,4 +1,3 @@
-import * as _ from "underscore"
 import * as browserify from "browserify"
 import * as gulp from "gulp"
 import * as gutil from "gulp-util"
@@ -185,7 +184,7 @@ gulp.task("scripts:bundle", ["scripts:compile"], (cb: (arg?: any) => void) => {
     const data: {[key: string]: any} = {}
     for (const name in labels) {
       const module_labels = labels[name]
-      data[name] = _.sortBy(_.values(module_labels), (mod) => mod)
+      data[name] = Object.keys(module_labels).map((key) => module_labels[key]).sort()
     }
     const modulesPath = path.join(paths.buildDir.js, "modules.json")
     fs.writeFile(modulesPath, JSON.stringify(data), () => next())

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -86,7 +86,6 @@
     "@types/run-sequence": "^0.0.29",
     "@types/del": "^2.2.32",
     "@types/resolve": "^0.0.4",
-    "@types/underscore": "^1.8.0",
     "@types/browserify": "^12.0.30",
     "@types/event-stream": "^3.3.31"
   },
@@ -121,7 +120,7 @@
     "@types/timezone-js": "^0.0.28",
     "@types/hammerjs": "^2.0.33",
 
-    "underscore": "^1.5.2",
+    "underscore.template": "^0.1.7",
     "jquery": "^2.1.1",
     "jquery-mousewheel": "^3.1.12",
     "jquery-ui": "~1.10.5",

--- a/bokehjs/src/coffee/core/util/array.ts
+++ b/bokehjs/src/coffee/core/util/array.ts
@@ -3,6 +3,8 @@
 //     (c) 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
 //     Underscore may be freely distributed under the MIT license.
 
+import {randomIn} from "./math"
+
 const slice = Array.prototype.slice
 
 export function copy<T>(array: Array<T> /*| TypedArray*/): Array<T> {
@@ -272,7 +274,7 @@ export function intersection<T>(array: Array<T>, ...arrays: Array<Array<T>>): Ar
       continue
     for (const other of arrays) {
       if (!contains(other, item))
-        continue top;
+        continue top
     }
     result.push(item)
   }
@@ -291,4 +293,18 @@ export function removeBy<T>(array: Array<T>, key: (item: T) => boolean): void {
     else
       i++
   }
+}
+
+// Shuffle a collection, using the modern version of the
+// [Fisher-Yates shuffle](http://en.wikipedia.org/wiki/Fisher–Yates_shuffle).
+export function shuffle<T>(array: T[]): T[] {
+  const length = array.length
+  const shuffled = new Array(length)
+  for (let i = 0; i < length; i++) {
+    let rand = randomIn(0, i)
+    if (rand !== i)
+      shuffled[i] = shuffled[rand]
+    shuffled[rand] = array[i]
+  }
+  return shuffled
 }

--- a/bokehjs/src/coffee/core/util/math.ts
+++ b/bokehjs/src/coffee/core/util/math.ts
@@ -26,6 +26,15 @@ export function random(): number {
   return Math.random()
 }
 
+export function randomIn(min: number, max?: number): number {
+  if (max == null) {
+    max = min
+    min = 0
+  }
+
+  return min + Math.floor(Math.random()*(max - min + 1))
+}
+
 export function atan2(start: [number, number], end: [number, number]): number {
   /*
    * Calculate the angle between a line containing start and end points (composed

--- a/bokehjs/src/coffee/core/util/object.ts
+++ b/bokehjs/src/coffee/core/util/object.ts
@@ -46,6 +46,10 @@ export function merge<T>(obj1: {[key: string] : Array<T>}, obj2: {[key: string]:
   return result
 }
 
+export function size<T>(obj: T): number {
+  return Object.keys(obj).length
+}
+
 export function isEmpty<T>(obj: T): boolean {
-  return Object.keys(obj).length === 0
+  return size(obj) === 0
 }

--- a/bokehjs/src/coffee/models/widgets/cell_formatters.coffee
+++ b/bokehjs/src/coffee/models/widgets/cell_formatters.coffee
@@ -1,5 +1,6 @@
 import * as $ from "jquery"
 import * as Numbro from "numbro"
+import * as compile_template from "underscore.template"
 
 import * as p from "core/properties"
 import {extend} from "core/util/object"
@@ -109,5 +110,5 @@ export class HTMLTemplateFormatter extends CellFormatter
       return ""
     else
       dataContext = extend({}, dataContext, {value: value})
-      compiled_template = _.template(template)
+      compiled_template = compile_template(template)
       return compiled_template(dataContext)

--- a/bokehjs/src/js/compile.coffee
+++ b/bokehjs/src/js/compile.coffee
@@ -1,4 +1,3 @@
-_ = require "underscore"
 fs = require "fs"
 path = require "path"
 ts = require "typescript"
@@ -114,7 +113,7 @@ compile_and_resolve_deps = (input) ->
     }
   })
 
-  if _.isArray(result.diagnostics) and result.diagnostics.length > 0
+  if result.diagnostics?.length > 0
     diagnostic = result.diagnostics[0]
     return reply({error: mkTypeScriptError(diagnostic)})
 

--- a/bokehjs/test/defaults.coffee
+++ b/bokehjs/test/defaults.coffee
@@ -97,7 +97,7 @@ check_matching_defaults = (name, python_defaults, coffee_defaults) ->
 
           # palettes in JS are stored as int color values
           if k == 'palette'
-            py_v = (parseInt(x, 16) for x in py_v)
+            py_v = (parseInt(x[1...], 16) for x in py_v)
 
           if js_v.length != py_v.length
             equal = false

--- a/bokehjs/test/defaults.coffee
+++ b/bokehjs/test/defaults.coffee
@@ -1,9 +1,13 @@
-_ = require "underscore"
 {expect} = require "chai"
 utils = require "./utils"
 
 core_defaults = require "./.generated_defaults/models_defaults"
 widget_defaults = require "./.generated_defaults/widgets_defaults"
+
+{isArray, isObject} = utils.require("core/util/types")
+{difference} = utils.require("core/util/array")
+{keys} = utils.require("core/util/object")
+{isEqual} = utils.require("core/util/eq")
 
 {Models} = utils.require "base"
 mixins = utils.require "core/property_mixins"
@@ -32,12 +36,12 @@ safe_stringify = (v) ->
 deep_value_to_json = (key, value, optional_parent_object) ->
   if value instanceof HasProps
     {type: value.type, attributes: value.attributes_as_json() }
-  else if _.isArray(value)
+  else if isArray(value)
     ref_array = []
     for v, i in value
       ref_array.push(deep_value_to_json(i, v, value))
     ref_array
-  else if _.isObject(value)
+  else if isObject(value)
     ref_obj = {}
     for own subkey of value
       ref_obj[subkey] = deep_value_to_json(subkey, value[subkey], value)
@@ -49,7 +53,7 @@ check_matching_defaults = (name, python_defaults, coffee_defaults) ->
   different = []
   python_missing = []
   coffee_missing = []
-  for k, v of coffee_defaults
+  for k, js_v of coffee_defaults
 
     # special case for date picker, default is "now"
     if name == 'DatePicker' and k == 'value'
@@ -65,7 +69,7 @@ check_matching_defaults = (name, python_defaults, coffee_defaults) ->
 
     # special case for selections that have a method added to them
     if k == 'selected'
-      v['0d'] = _.omit(v['0d'], 'get_view')
+      delete js_v['0d'].get_view
 
     if k == 'id'
       continue
@@ -74,41 +78,43 @@ check_matching_defaults = (name, python_defaults, coffee_defaults) ->
       py_v = python_defaults[k]
       strip_ids(py_v)
 
-      if not _.isEqual(py_v, v)
+      if not isEqual(py_v, js_v)
 
         # these two conditionals compare 'foo' and {value: 'foo'}
-        if _.isObject(v) and 'value' of v and _.isEqual(py_v, v['value'])
+        if isObject(js_v) and 'value' of js_v and isEqual(py_v, js_v['value'])
           continue
-        if _.isObject(py_v) and 'value' of py_v and _.isEqual(py_v['value'], v)
+        if isObject(py_v) and 'value' of py_v and isEqual(py_v['value'], js_v)
           continue
 
-        if _.isObject(v) and 'attributes' of v and _.isObject(py_v) and 'attributes' of py_v
-          if v['type'] == py_v['type']
-            check_matching_defaults("#{name}.#{k}", py_v['attributes'], v['attributes'])
+        if isObject(js_v) and 'attributes' of js_v and isObject(py_v) and 'attributes' of py_v
+          if js_v['type'] == py_v['type']
+            check_matching_defaults("#{name}.#{k}", py_v['attributes'], js_v['attributes'])
             continue
 
         # compare arrays of objects
-        if _.isArray(v) and _.isArray(py_v)
+        if isArray(js_v) and isArray(py_v)
           equal = true
 
           # palettes in JS are stored as int color values
           if k == 'palette'
             py_v = (parseInt(x, 16) for x in py_v)
 
-          if v.length != py_v.length
+          if js_v.length != py_v.length
             equal = false
           else
-            for i in [0...v.length]
-              if not _.isEqual(_.omit(v[i], 'id'), _.omit(py_v[i], 'id'))
+            for i in [0...js_v.length]
+              delete js_v[i].id
+              delete py_v[i].id
+              if not isEqual(js_v[i], py_v[i])
                 equal = false
                 break
 
           if equal
             continue
 
-        different.push("#{name}.#{k}: coffee defaults to #{safe_stringify(v)} but python defaults to #{safe_stringify(py_v)}")
+        different.push("#{name}.#{k}: coffee defaults to #{safe_stringify(js_v)} but python defaults to #{safe_stringify(py_v)}")
     else
-      python_missing.push("#{name}.#{k}: coffee defaults to #{safe_stringify(v)} but python has no such property")
+      python_missing.push("#{name}.#{k}: coffee defaults to #{safe_stringify(js_v)} but python has no such property")
   for k, v of python_defaults
     if k not of coffee_defaults
       coffee_missing.push("#{name}.#{k}: python defaults to #{safe_stringify(v)} but coffee has no such property")
@@ -126,10 +132,10 @@ check_matching_defaults = (name, python_defaults, coffee_defaults) ->
   different.length == 0 and python_missing.length == 0 and coffee_missing.length == 0
 
 strip_ids = (value) ->
-  if _.isArray(value)
+  if isArray(value)
     for v in value
       strip_ids(v)
-  else if _.isObject(value)
+  else if isObject(value)
     if ('id' of value)
       delete value['id']
     for k, v of value
@@ -185,7 +191,7 @@ describe "Defaults", ->
         # console.log(python_defaults)
         # console.log('coffee defaults:')
         # console.log(coffee_defaults)
-        console.log(_.difference(_.keys(python_defaults), _.keys(coffee_defaults)))
+        console.log(difference(keys(python_defaults), keys(coffee_defaults)))
         fail_count = fail_count + 1
 
     console.error("Python/Coffee matching defaults problems: #{fail_count}")

--- a/bokehjs/test/document.coffee
+++ b/bokehjs/test/document.coffee
@@ -1,9 +1,9 @@
-_ = require "underscore"
 {expect} = require "chai"
 utils = require "./utils"
 sinon = require "sinon"
 { stdoutTrap, stderrTrap } = require 'logtrap'
 
+{values, size} = utils.require("core/util/object")
 {Document, ModelChangedEvent, TitleChangedEvent, RootAddedEvent, RootRemovedEvent, DEFAULT_TITLE} = utils.require "document"
 {GE, Strength, Variable}  = utils.require "core/layout/solver"
 js_version = utils.require("version").version
@@ -334,7 +334,7 @@ describe "Document", ->
   it "can have all_models with multiple references", ->
     d = new Document()
     expect(d.roots().length).to.equal 0
-    expect(_.size(d._all_models)).to.equal 0
+    expect(size(d._all_models)).to.equal 0
 
     root1 = new SomeModel()
     root2 = new SomeModel()
@@ -344,30 +344,30 @@ describe "Document", ->
     d.add_root(root1)
     d.add_root(root2)
     expect(d.roots().length).to.equal 2
-    expect(_.size(d._all_models)).to.equal 3
+    expect(size(d._all_models)).to.equal 3
 
     root1.child = null
-    expect(_.size(d._all_models)).to.equal 3
+    expect(size(d._all_models)).to.equal 3
 
     root2.child = null
-    expect(_.size(d._all_models)).to.equal 2
+    expect(size(d._all_models)).to.equal 2
 
     root1.child = child1
-    expect(_.size(d._all_models)).to.equal 3
+    expect(size(d._all_models)).to.equal 3
 
     root2.child = child1
-    expect(_.size(d._all_models)).to.equal 3
+    expect(size(d._all_models)).to.equal 3
 
     d.remove_root(root1)
-    expect(_.size(d._all_models)).to.equal 2
+    expect(size(d._all_models)).to.equal 2
 
     d.remove_root(root2)
-    expect(_.size(d._all_models)).to.equal 0
+    expect(size(d._all_models)).to.equal 0
 
   it "can have all_models with cycles", ->
     d = new Document()
     expect(d.roots().length).to.equal 0
-    expect(_.size(d._all_models)).to.equal 0
+    expect(size(d._all_models)).to.equal 0
 
     root1 = new SomeModel()
     root2 = new SomeModel()
@@ -378,21 +378,21 @@ describe "Document", ->
     d.add_root(root1)
     d.add_root(root2)
     expect(d.roots().length).to.equal 2
-    expect(_.size(d._all_models)).to.equal 3
+    expect(size(d._all_models)).to.equal 3
 
     root1.child = null
-    expect(_.size(d._all_models)).to.equal 3
+    expect(size(d._all_models)).to.equal 3
 
     root2.child = null
-    expect(_.size(d._all_models)).to.equal 2
+    expect(size(d._all_models)).to.equal 2
 
     root1.child = child1
-    expect(_.size(d._all_models)).to.equal 3
+    expect(size(d._all_models)).to.equal 3
 
   it "can have all_models with cycles through lists", ->
     d = new Document()
     expect(d.roots().length).to.equal 0
-    expect(_.size(d._all_models)).to.equal 0
+    expect(size(d._all_models)).to.equal 0
 
     root1 = new SomeModelWithChildren()
     root2 = new SomeModelWithChildren()
@@ -403,16 +403,16 @@ describe "Document", ->
     d.add_root(root1)
     d.add_root(root2)
     expect(d.roots().length).to.equal 2
-    expect(_.size(d._all_models)).to.equal 3
+    expect(size(d._all_models)).to.equal 3
 
     root1.children = []
-    expect(_.size(d._all_models)).to.equal 3
+    expect(size(d._all_models)).to.equal 3
 
     root2.children = []
-    expect(_.size(d._all_models)).to.equal 2
+    expect(size(d._all_models)).to.equal 2
 
     root1.children = [child1]
-    expect(_.size(d._all_models)).to.equal 3
+    expect(size(d._all_models)).to.equal 3
 
   it "can notify on changes", ->
     d = new Document()
@@ -527,7 +527,7 @@ describe "Document", ->
     expect(d.title()).to.equal 'Foo'
     d.clear()
     expect(d.roots().length).to.equal 0
-    expect(_.size(d._all_models)).to.equal 0
+    expect(size(d._all_models)).to.equal 0
     # does not reset title
     expect(d.title()).to.equal 'Foo'
 
@@ -889,7 +889,7 @@ describe "Document", ->
     expect(root1.obj_prop).to.be.an.instanceof(ModelWithConstructTimeChanges)
     expect(root1.obj_prop.child).to.be.an.instanceof(AnotherModel)
     expect(Object.keys(root1.dict_of_list_prop).length).to.equal 1
-    expect(_.values(root1.dict_of_list_prop)[0].length).to.equal 1
+    expect(values(root1.dict_of_list_prop)[0].length).to.equal 1
 
   ###
   it "adds two constraints and two edit_variables on instantiation solver", ->

--- a/bokehjs/test/models/layouts/box.coffee
+++ b/bokehjs/test/models/layouts/box.coffee
@@ -1,10 +1,9 @@
-_ = require "underscore"
 {expect} = require "chai"
 utils = require "../../utils"
 sinon = require "sinon"
 
+{clone} = utils.require("core/util/object")
 {Strength, Variable}  = utils.require("core/layout/solver")
-
 {Document} = utils.require("document")
 {Box} = utils.require("models/layouts/box")
 {BoxView} = utils.require("models/layouts/box")
@@ -86,19 +85,23 @@ describe "Box", ->
       expect(constrained_variables).to.be.deep.equal @expected_constrained_variables
 
     it "should return correct constrained_variables in scale_width mode", ->
-      expected_constrained_variables = _.omit(@expected_constrained_variables, ['height'])
+      expected_constrained_variables = clone(@expected_constrained_variables)
+      delete expected_constrained_variables.height
       @box.sizing_mode = 'scale_width'
       constrained_variables = @box.get_constrained_variables()
       expect(constrained_variables).to.be.deep.equal expected_constrained_variables
 
     it "should return correct constrained_variables in scale_height mode", ->
-      expected_constrained_variables = _.omit(@expected_constrained_variables, ['width'])
+      expected_constrained_variables = clone(@expected_constrained_variables)
+      delete expected_constrained_variables.width
       @box.sizing_mode = 'scale_height'
       constrained_variables = @box.get_constrained_variables()
       expect(constrained_variables).to.be.deep.equal expected_constrained_variables
 
     it "should return correct constrained_variables in fixed mode", ->
-      expected_constrained_variables = _.omit(@expected_constrained_variables, ['height', 'width'])
+      expected_constrained_variables = clone(@expected_constrained_variables)
+      delete expected_constrained_variables.height
+      delete expected_constrained_variables.width
       @box.sizing_mode = 'fixed'
       constrained_variables = @box.get_constrained_variables()
       expect(constrained_variables).to.be.deep.equal expected_constrained_variables

--- a/bokehjs/test/models/layouts/spacer.coffee
+++ b/bokehjs/test/models/layouts/spacer.coffee
@@ -1,9 +1,8 @@
-_ = require "underscore"
 {expect} = require "chai"
 utils = require "../../utils"
 
+{clone} = utils.require("core/util/object")
 {Document} = utils.require("document")
-
 {Spacer} = utils.require("models/layouts/spacer")
 
 describe "WidgetBoxView", ->
@@ -60,14 +59,16 @@ describe "Spacer", ->
 
   it "should return correct constrained_variables in scale_width mode", ->
     # We don't return height because we're going to set it ourselves.
-    expected_constrained_variables = _.omit(@expected_constrained_variables, ['height'])
+    expected_constrained_variables = clone(@expected_constrained_variables)
+    delete expected_constrained_variables.height
     @spacer.sizing_mode = 'scale_width'
     constrained_variables = @spacer.get_constrained_variables()
     expect(constrained_variables).to.be.deep.equal expected_constrained_variables
 
   it "should return correct constrained_variables in scale_height mode", ->
     # We don't return width because we're going to set it ourselves.
-    expected_constrained_variables = _.omit(@expected_constrained_variables, ['width'])
+    expected_constrained_variables = clone(@expected_constrained_variables)
+    delete expected_constrained_variables.width
     @spacer.sizing_mode = 'scale_height'
     constrained_variables = @spacer.get_constrained_variables()
     expect(constrained_variables).to.be.deep.equal expected_constrained_variables
@@ -75,6 +76,8 @@ describe "Spacer", ->
   it "should return correct constrained_variables in fixed mode", ->
     # We don't return height or width because we're going to set them ourselves.
     @spacer.sizing_mode = 'fixed'
-    expected_constrained_variables = _.omit(@expected_constrained_variables, ['height', 'width'])
+    expected_constrained_variables = clone(@expected_constrained_variables)
+    delete expected_constrained_variables.height
+    delete expected_constrained_variables.width
     constrained_variables = @spacer.get_constrained_variables()
     expect(constrained_variables).to.be.deep.equal expected_constrained_variables

--- a/bokehjs/test/models/layouts/widget_box.coffee
+++ b/bokehjs/test/models/layouts/widget_box.coffee
@@ -1,10 +1,9 @@
-_ = require "underscore"
 {expect} = require "chai"
 utils = require "../../utils"
 sinon = require 'sinon'
 
+{clone} = utils.require("core/util/object")
 {Document} = utils.require("document")
-
 {DataRange1d} = utils.require("models/ranges/data_range1d")
 {LayoutDOM} = utils.require("models/layouts/layout_dom")
 {LayoutDOMView} = utils.require("models/layouts/layout_dom")
@@ -138,14 +137,16 @@ describe "WidgetBox", ->
 
     it "should return correct constrained_variables in scale_width mode", ->
       # We don't return height because we're going to set it ourselves.
-      expected_constrained_variables = _.omit(@expected_constrained_variables, ['height'])
+      expected_constrained_variables = clone(@expected_constrained_variables)
+      delete expected_constrained_variables.height
       @widget_box.sizing_mode = 'scale_width'
       constrained_variables = @widget_box.get_constrained_variables()
       expect(constrained_variables).to.be.deep.equal expected_constrained_variables
 
     it "should return correct constrained_variables in scale_height mode", ->
       # We don't return width because we're going to set it ourselves.
-      expected_constrained_variables = _.omit(@expected_constrained_variables, ['width'])
+      expected_constrained_variables = clone(@expected_constrained_variables)
+      delete expected_constrained_variables.width
       @widget_box.sizing_mode = 'scale_height'
       constrained_variables = @widget_box.get_constrained_variables()
       expect(constrained_variables).to.be.deep.equal expected_constrained_variables
@@ -153,7 +154,11 @@ describe "WidgetBox", ->
     it "should return correct constrained_variables in fixed mode", ->
       # We don't return height or width because we're going to set them ourselves.
       @widget_box.sizing_mode = 'fixed'
-      expected_constrained_variables = _.omit(@expected_constrained_variables, ['height', 'width', 'box_equal_size_left', 'box_equal_size_right'])
+      expected_constrained_variables = clone(@expected_constrained_variables)
+      delete expected_constrained_variables.height
+      delete expected_constrained_variables.width
+      delete expected_constrained_variables.box_equal_size_left
+      delete expected_constrained_variables.box_equal_size_right
       constrained_variables = @widget_box.get_constrained_variables()
       expect(constrained_variables).to.be.deep.equal expected_constrained_variables
 

--- a/bokehjs/test/models/plots/plot.coffee
+++ b/bokehjs/test/models/plots/plot.coffee
@@ -1,10 +1,10 @@
-_ = require "underscore"
 {expect} = require "chai"
 utils = require "../../utils"
 sinon = require 'sinon'
 
 {Document} = utils.require("document")
 
+{clone} = utils.require("core/util/object")
 {CustomJS} = utils.require("models/callbacks/customjs")
 {DataRange1d} = utils.require("models/ranges/data_range1d")
 {Range1d} = utils.require("models/ranges/range1d")
@@ -195,18 +195,24 @@ describe "Plot", ->
 
       it "should return correct constrained_variables in scale_width mode", sinon.test () ->
         @p.sizing_mode = 'scale_width'
-        expected_constrained_variables = _.omit(@expected_constrained_variables, ['height'])
+        expected_constrained_variables = clone(@expected_constrained_variables)
+        delete expected_constrained_variables.height
         constrained_variables = @p.get_constrained_variables()
         expect(constrained_variables).to.be.deep.equal expected_constrained_variables
 
       it "should return correct constrained_variables in scale_height mode", sinon.test () ->
         @p.sizing_mode = 'scale_height'
-        expected_constrained_variables = _.omit(@expected_constrained_variables, ['width'])
+        expected_constrained_variables = clone(@expected_constrained_variables)
+        delete expected_constrained_variables.width
         constrained_variables = @p.get_constrained_variables()
         expect(constrained_variables).to.be.deep.equal expected_constrained_variables
 
       it "should return correct constrained_variables in fixed mode", sinon.test () ->
         @p.sizing_mode = 'fixed'
-        expected_constrained_variables = _.omit(@expected_constrained_variables, ['height', 'width', 'box_equal_size_left', 'box_equal_size_right'])
+        expected_constrained_variables = clone(@expected_constrained_variables)
+        delete expected_constrained_variables.height
+        delete expected_constrained_variables.width
+        delete expected_constrained_variables.box_equal_size_left
+        delete expected_constrained_variables.box_equal_size_right
         constrained_variables = @p.get_constrained_variables()
         expect(constrained_variables).to.be.deep.equal expected_constrained_variables

--- a/bokehjs/test/models/tiles/tile_renderer.coffee
+++ b/bokehjs/test/models/tiles/tile_renderer.coffee
@@ -1,7 +1,7 @@
-_ = require "underscore"
 {expect} = require "chai"
 utils = require "../../utils"
 
+{shuffle} = utils.require "core/util/array"
 {TileRenderer} = utils.require "models/tiles/tile_renderer"
 {TileSource} = utils.require "models/tiles/tile_source"
 {MercatorTileSource} = utils.require "models/tiles/mercator_tile_source"
@@ -132,7 +132,7 @@ describe "tile sources", ->
         for y in [1..6] by 1
           tiles.push([x, y])
 
-      tiles = _.shuffle(tiles)
+      tiles = shuffle(tiles)
       sorted_tiles = source.sort_tiles_from_center(tiles, [1, 1, 6, 6])
 
       for i in [0..3] by 1


### PR DESCRIPTION
This removes last imports of underscore and uses underscore.template for templating and code under `core/util` otherwise.

fixes #6207
