### PR TITLE
Enabling/ Disabling re-ordering of columns in DataTable (freezing columns in place)

### DIFF
--- a/bokeh/models/widgets/tables.py
+++ b/bokeh/models/widgets/tables.py
@@ -353,7 +353,13 @@ class DataTable(TableWidget):
     sort direction. Use Ctrl + click to return to natural order. Use
     Shift + click to sort multiple columns simultaneously.
     """)
-
+    
+    reorderable = Bool(True, help="""
+    Allows the reordering of a tables's columns. To reorder a column, 
+    click and drag a table's header to the desired location in the table.
+    The columns on either side will remain in their previous order.
+    """)
+    
     editable = Bool(False, help="""
     Allows to edit table's contents. Needs cell editors to be configured on
     columns that are required to be editable.

--- a/bokeh/models/widgets/tables.py
+++ b/bokeh/models/widgets/tables.py
@@ -355,7 +355,7 @@ class DataTable(TableWidget):
     """)
     
     reorderable = Bool(True, help="""
-    Allows the reordering of a tables's columns. To reorder a column, 
+    Allows the reordering of a tables's columns. To reorder a column,
     click and drag a table's header to the desired location in the table.
     The columns on either side will remain in their previous order.
     """)

--- a/bokeh/models/widgets/tables.py
+++ b/bokeh/models/widgets/tables.py
@@ -315,10 +315,6 @@ class TableColumn(Model):
     Whether this column is sortable or not. Note that data table has
     to have sorting enabled to allow sorting in general.
     """)
-    
-    reorderable = Bool(True, help="""
-    Whether this column is reorderable or not.
-    """)
 
     default_sort = Enum("ascending", "descending", help="""
     The default sorting order. By default ``ascending`` order is used.

--- a/bokeh/models/widgets/tables.py
+++ b/bokeh/models/widgets/tables.py
@@ -315,6 +315,10 @@ class TableColumn(Model):
     Whether this column is sortable or not. Note that data table has
     to have sorting enabled to allow sorting in general.
     """)
+    
+    reorderable = Bool(True, help="""
+    Whether this column is reorderable or not.
+    """)
 
     default_sort = Enum("ascending", "descending", help="""
     The default sorting order. By default ``ascending`` order is used.

--- a/bokeh/models/widgets/tables.py
+++ b/bokeh/models/widgets/tables.py
@@ -353,13 +353,13 @@ class DataTable(TableWidget):
     sort direction. Use Ctrl + click to return to natural order. Use
     Shift + click to sort multiple columns simultaneously.
     """)
-    
+
     reorderable = Bool(True, help="""
     Allows the reordering of a tables's columns. To reorder a column,
     click and drag a table's header to the desired location in the table.
     The columns on either side will remain in their previous order.
     """)
-    
+
     editable = Bool(False, help="""
     Allows to edit table's contents. Needs cell editors to be configured on
     columns that are required to be editable.

--- a/bokehjs/src/coffee/models/widgets/data_table.coffee
+++ b/bokehjs/src/coffee/models/widgets/data_table.coffee
@@ -155,7 +155,7 @@ export class DataTableView extends WidgetView
 
     options =
       enableCellNavigation: @model.selectable != false
-      enableColumnReorder: true
+      enableColumnReorder: @model.reorderable
       forceFitColumns: @model.fit_columns
       autoHeight: @model.height == "auto"
       multiColumnSort: @model.sortable
@@ -203,6 +203,7 @@ export class DataTable extends TableWidget
       columns:             [ p.Array,  []    ]
       fit_columns:         [ p.Bool,   true  ]
       sortable:            [ p.Bool,   true  ]
+      reorderable:         [ p.Bool,   true  ]
       editable:            [ p.Bool,   false ]
       selectable:          [ p.Bool,   true  ]
       row_headers:         [ p.Bool,   true  ]


### PR DESCRIPTION
Addresses allowing fixed columns in datatable. https://github.com/bokeh/bokeh/issues/6286

Assuming no extra documentation is needed. 

If a test is needed I can do that too tomorrow.

* [x] issues: fixes #6286 
* [ ] tests added / passed
* [X] release document entry (if new feature or API change)
