### PR TITLE
Extend CDS patching to sub-elements in columns

### DIFF
--- a/bokeh/core/json_encoder.py
+++ b/bokeh/core/json_encoder.py
@@ -72,6 +72,10 @@ class BokehJSONEncoder(json.JSONEncoder):
         if is_datetime_type(obj):
             return convert_datetime_type(obj)
 
+        # slice objects
+        elif isinstance(obj, slice):
+            return dict(start=obj.start, stop=obj.stop, step=obj.step)
+
         # NumPy scalars
         elif np.issubdtype(type(obj), np.float):
             return float(obj)

--- a/bokeh/core/property/containers.py
+++ b/bokeh/core/property/containers.py
@@ -363,15 +363,20 @@ class PropertyValueDict(PropertyValueContainer, dict):
         synchronize.
 
         .. warning::
-            This function assumes the integrity of ``new_data`` has already
+            This function assumes the integrity of ``patches`` has already
             been verified.
 
         '''
+        import numpy as np
         old = self._saved_copy()
 
         for name, patch in patches.items():
             for ind, value in patch:
-                self[name][ind] = value
+                if isinstance(ind, (int, slice)):
+                    self[name][ind] = value
+                else:
+                    shape = self[name][ind[0]][ind[1:]].shape
+                    self[name][ind[0]][ind[1:]] = np.array(value, copy=False).reshape(shape)
 
         from ...server.events import ColumnsPatchedEvent
 

--- a/bokeh/core/tests/test_json_encoder.py
+++ b/bokeh/core/tests/test_json_encoder.py
@@ -106,6 +106,27 @@ class TestBokehJSONEncoder(unittest.TestCase):
         self.assertEqual(self.encoder.default(c), "rgba(16, 32, 64, 0.1)")
         self.assertIsInstance(self.encoder.default(c), string_types)
 
+    def test_slice(self):
+        c = slice(2)
+        self.assertEqual(self.encoder.default(c), dict(start=None, stop=2, step=None))
+        self.assertIsInstance(self.encoder.default(c), dict)
+
+        c = slice(0,2)
+        self.assertEqual(self.encoder.default(c), dict(start=0, stop=2, step=None))
+        self.assertIsInstance(self.encoder.default(c), dict)
+
+        c = slice(0, 10, 2)
+        self.assertEqual(self.encoder.default(c), dict(start=0, stop=10, step=2))
+        self.assertIsInstance(self.encoder.default(c), dict)
+
+        c = slice(0, None, 2)
+        self.assertEqual(self.encoder.default(c), dict(start=0, stop=None, step=2))
+        self.assertIsInstance(self.encoder.default(c), dict)
+
+        c = slice(None, None, None)
+        self.assertEqual(self.encoder.default(c), dict(start=None, stop=None, step=None))
+        self.assertIsInstance(self.encoder.default(c), dict)
+
     @skipIf(not is_pandas, "pandas does not work in PyPy.")
     def test_pd_timestamp(self):
         ts = pd.Timestamp('April 28, 1948')
@@ -208,6 +229,14 @@ class TestSerializeJson(unittest.TestCase):
     def test_deque(self):
         """Test that a deque is deserialized as a list."""
         self.assertEqual(self.serialize(deque([0, 1, 2])), '[0,1,2]')
+
+    def test_slice(self):
+        """Test that a slice is deserialized as a list."""
+        self.assertEqual(self.serialize(slice(2)), '{"start":null,"step":null,"stop":2}')
+        self.assertEqual(self.serialize(slice(0, 2)), '{"start":0,"step":null,"stop":2}')
+        self.assertEqual(self.serialize(slice(0, 10, 2)), '{"start":0,"step":2,"stop":10}')
+        self.assertEqual(self.serialize(slice(0, None, 2)), '{"start":0,"step":2,"stop":null}')
+        self.assertEqual(self.serialize(slice(None, None, None)), '{"start":null,"step":null,"stop":null}')
 
     def test_bad_kwargs(self):
         self.assertRaises(ValueError, self.serialize, [1], allow_nan=True)

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -285,11 +285,51 @@ class ColumnDataSource(ColumnarDataSource):
         the subset, instead of requiring the entire data set to be sent.
 
         This method should be passed a dictionary that maps column names to
-        lists of tuples, each of the form ``(index, new_value)``. The value
-        at the given index for that column will be updated with the new value.
+        lists of tuples that describe a patch change to apply. To replace
+        individual items in columns entirely, the tuples should be of the
+        form:
+
+        .. code-block:: python
+
+            (index, new_value)  # replace a single column value
+
+            # or
+
+            (slice, new_values) # replace several column values
+
+        Values at an index or slice will be replaced with the corresponding
+        new values.
+
+        In the case of columns whose values are other arrays or lists, (e.g.
+        image or patches glyphs), it is also possible to patch "subregions".
+        In this case the first item of the tuple should be a whose first
+        element is the index of the array item in the CDS patch, and whose
+        subsequent elements are integer indices or slices into the array item:
+
+        .. code-block:: python
+
+            # replace the entire 10th column of the 2nd array:
+
+              +------------- index of item in column data source
+              |
+              |     +------- row subindex into array item
+              |     |
+              |     |     +- column subindex into array item
+              V     V     V
+            ([2, slice(), 10], new_values)
+
+        This is roughly equivalent to indexing a three dimensional NumPy array
+        with ``arr[2, :, 10]`` The new values to patch should be supplied as a
+        **flattened one-dimensional array** of the appropriate size.
+
+        There are some limitations to the kinds of slices and data that can
+        be accepted.
+
+        * Negative start, stop, or step values will result in a ``ValueError``.
+        * ``start > stop`` will result in a ``ValueError``
 
         Args:
-            patches (dict[str, list[tuple]]) : lists of patches for each column.
+            patches (dict[str, list[tuple]]) : lists of patches for each column
 
         Returns:
             None
@@ -299,29 +339,94 @@ class ColumnDataSource(ColumnarDataSource):
 
         Example:
 
+        The following example shows how to patch entire column elements. In this case,
+
         .. code-block:: python
 
-            source = ColumnDataSource(data=dict(foo=[10, 20], bar=[100, 200]))
+            source = ColumnDataSource(data=dict(foo=[10, 20, 30], bar=[100, 200, 300]))
 
             patches = {
-                'foo' : [ (0, 1) ],
-                'bar' : [ (0, 101), (1, 201) ],
+                'foo' : [ (slice(2), [11, 12]) ],
+                'bar' : [ (0, 101), (2, 301) ],
             }
 
             source.patch(patches)
 
+        After this operation, the value of the ``source.data`` will be:
+
+        .. code-block:: python
+
+            dict(foo=[11, 22, 30], bar=[101, 200, 301])
+
         '''
+        import numpy as np
+
         extra = set(patches.keys()) - set(self.data.keys())
 
         if extra:
             raise ValueError("Can only patch existing columns (extra: %s)" % ", ".join(sorted(extra)))
 
         for name, patch in patches.items():
-            max_ind = max(x[0] for x in patch)
-            if max_ind >= len(self.data[name]):
-                raise ValueError("Out-of bounds index (%d) in patch for column: %s" % (max_ind, name))
+
+            col_len = len(self.data[name])
+
+            for ind, value in patch:
+
+                # integer index, patch single value of 1d column
+                if isinstance(ind, int):
+                    if ind > col_len or ind < 0:
+                        raise ValueError("Out-of bounds index (%d) in patch for column: %s" % (ind, name))
+
+                # slice index, patch multiple values of 1d column
+                elif isinstance(ind, slice):
+                    _check_slice(ind)
+                    if ind.stop is not None and ind.stop > col_len:
+                        raise ValueError("Out-of bounds slice index stop (%d) in patch for column: %s" % (ind.stop, name))
+
+                # multi-index, patch sub-regions of "n-d" column
+                elif isinstance(ind, (list, tuple)):
+                    if len(ind) == 0:
+                        raise ValueError("Empty (length zero) patch multi-index")
+
+                    if len(ind) == 1:
+                        raise ValueError("Patch multi-index must contain more than one subindex")
+
+                    if not isinstance(ind[0], int):
+                        raise ValueError("Initial patch sub-index may only be integer, got: %s" % ind[0])
+
+                    if ind[0] > col_len or ind[0] < 0:
+                        raise ValueError("Out-of bounds initial sub-index (%d) in patch for column: %s" % (ind, name))
+
+                    if not isinstance(self.data[name][ind[0]], np.ndarray):
+                        raise ValueError("Can only sub-patch into columns with NumPy array items")
+
+                    if len(self.data[name][ind[0]].shape) != (len(ind)-1):
+                        raise ValueError("Shape mismatch between patch slice and sliced data")
+
+                    elif isinstance(ind[0], slice):
+                        _check_slice(ind[0])
+                        if ind[0].stop is not None and ind[0].stop > col_len:
+                            raise ValueError("Out-of bounds initial slice sub-index stop (%d) in patch for column: %s" % (ind.stop, name))
+
+                    # Note: bounds of sub-indices after the first are not checked!
+                    for subind in ind[1:]:
+                        if not isinstance(subind, (int, slice)):
+                            raise ValueError("Invalid patch sub-index: %s" % subind)
+                        if isinstance(subind, slice):
+                            _check_slice(subind)
+
+                else:
+                    raise ValueError("Invalid patch index: %s" % ind)
 
         self.data._patch(self.document, self, patches, setter)
+
+def _check_slice(s):
+    if (s.start is not None and s.stop is not None and s.start > s.stop):
+        raise ValueError("Patch slices must have start < end, got %s" % s)
+    if (s.start is not None and s.start < 1) or \
+       (s.stop  is not None and s.stop < 1) or \
+       (s.step  is not None and s.step < 1):
+        raise ValueError("Patch slices must have positive (start, stop, step) values, got %s" % s)
 
 class GeoJSONDataSource(ColumnarDataSource):
     '''

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -310,23 +310,35 @@ class ColumnDataSource(ColumnarDataSource):
 
             # replace the entire 10th column of the 2nd array:
 
-              +------------- index of item in column data source
+              +----------------- index of item in column data source
               |
-              |     +------- row subindex into array item
-              |     |
-              |     |     +- column subindex into array item
-              V     V     V
-            ([2, slice(), 10], new_values)
+              |       +--------- row subindex into array item
+              |       |
+              |       |       +- column subindex into array item
+              V       V       V
+            ([2, slice(None), 10], new_values)
 
-        This is roughly equivalent to indexing a three dimensional NumPy array
-        with ``arr[2, :, 10]`` The new values to patch should be supplied as a
-        **flattened one-dimensional array** of the appropriate size.
+        Imagining a list of 2d NumPy arrays, the patch above is roughly
+        equivalent to:
+
+        .. code-block:: python
+
+            data = [arr1, arr2, ...]  # list of 2d arrays
+
+            data[2][:, 10] = new_data
 
         There are some limitations to the kinds of slices and data that can
         be accepted.
 
-        * Negative start, stop, or step values will result in a ``ValueError``.
-        * ``start > stop`` will result in a ``ValueError``
+        * Negative ``start``, ``stop``, or ``step`` values for slices will
+          result in a ``ValueError``.
+
+        * In a slice, ``start > stop`` will result in a ``ValueError``
+
+        * When patching 1d or 2d subitems, the subitems must be NumPy arrays.
+
+        * New values must be supplied as a **flattened one-dimensional array**
+          of the appropriate size.
 
         Args:
             patches (dict[str, list[tuple]]) : lists of patches for each column
@@ -357,6 +369,8 @@ class ColumnDataSource(ColumnarDataSource):
         .. code-block:: python
 
             dict(foo=[11, 22, 30], bar=[101, 200, 301])
+
+        For a more comprehensive complete example, see :bokeh-tree:`examples/howto/patch_app.py`.
 
         '''
         import numpy as np

--- a/bokehjs/src/coffee/models/glyphs/glyph.coffee
+++ b/bokehjs/src/coffee/models/glyphs/glyph.coffee
@@ -165,7 +165,7 @@ export class GlyphView extends View
 
     return result
 
-  set_data: (source) ->
+  set_data: (source, indices) ->
     data = @model.materialize_dataspecs(source)
     extend(@, data)
 
@@ -178,7 +178,7 @@ export class GlyphView extends View
     if @glglyph?
       @glglyph.set_data_changed(@_x.length)
 
-    @_set_data(source)
+    @_set_data(source, indices)
 
     @index = @_index_data()
 

--- a/bokehjs/src/coffee/models/glyphs/image_rgba.coffee
+++ b/bokehjs/src/coffee/models/glyphs/image_rgba.coffee
@@ -5,7 +5,7 @@ import {max, concat} from "core/util/array"
 export class ImageRGBAView extends XYGlyphView
 
   # TODO (bev) to improve. Currently, if only one image has changed, can
-  # pass index as "arg" to prevent full re-preocessing (useful for streaming)
+  # pass index as "arg" to prevent full re-processing (useful for streaming)
   _set_data: (source, arg) ->
     if not @image_data? or @image_data.length != @_image.length
       @image_data = new Array(@_image.length)

--- a/bokehjs/src/coffee/models/glyphs/image_rgba.coffee
+++ b/bokehjs/src/coffee/models/glyphs/image_rgba.coffee
@@ -4,9 +4,7 @@ import {max, concat} from "core/util/array"
 
 export class ImageRGBAView extends XYGlyphView
 
-  # TODO (bev) to improve. Currently, if only one image has changed, can
-  # pass index as "arg" to prevent full re-processing (useful for streaming)
-  _set_data: (source, arg) ->
+  _set_data: (source, indices) ->
     if not @image_data? or @image_data.length != @_image.length
       @image_data = new Array(@_image.length)
 
@@ -17,9 +15,8 @@ export class ImageRGBAView extends XYGlyphView
       @_height = new Array(@_image.length)
 
     for i in [0...@_image.length]
-      if arg?
-        if i != arg
-          continue
+      if indices? and indices.indexOf(i) < 0
+        continue
 
       shape = []
       if @_image_shape?

--- a/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
+++ b/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
@@ -74,7 +74,7 @@ export class GlyphRendererView extends RendererView
     @connect(@model.change, @request_render)
     @connect(@model.data_source.change, @set_data)
     @connect(@model.data_source.streaming, @set_data)
-    @connect(@model.data_source.patching, @set_data)
+    @connect(@model.data_source.patching, (indices) -> @set_data(true, indices))
     @connect(@model.data_source.select, @request_render)
     if @hover_glyph?
       @connect(@model.data_source.inspect, @request_render)
@@ -93,17 +93,16 @@ export class GlyphRendererView extends RendererView
 
   have_selection_glyphs: () -> @selection_glyph? && @nonselection_glyph?
 
-  # TODO (bev) arg is a quick-fix to allow some hinting for things like
-  # partial data updates (especially useful on expensive set_data calls
-  # for image, e.g.)
-  set_data: (request_render=true, arg) ->
+  # in case of partial updates like patching, the list of indices that actually
+  # changed may be passed as the "indices" parameter to afford any optional optimizations
+  set_data: (request_render=true, indices) ->
     t0 = Date.now()
     source = @model.data_source
 
     # TODO (bev) this is a bit clunky, need to make sure glyphs use the correct ranges when they call
     # mapping functions on the base Renderer class
     @glyph.model.setv({x_range_name: @model.x_range_name, y_range_name: @model.y_range_name}, {silent: true})
-    @glyph.set_data(source, arg)
+    @glyph.set_data(source, indices)
 
     @glyph.set_visuals(source)
     @decimated_glyph.set_visuals(source)

--- a/bokehjs/src/coffee/models/sources/column_data_source.coffee
+++ b/bokehjs/src/coffee/models/sources/column_data_source.coffee
@@ -3,7 +3,7 @@ import {HasProps} from "core/has_props"
 import * as p from "core/properties"
 import {Set} from "core/util/data_structures"
 import * as serialization from "core/util/serialization"
-import {isArray, isObject} from "core/util/types"
+import {isArray, isNumber, isObject} from "core/util/types"
 
 # exported for testing
 export concat_typed_arrays = (a, b) ->
@@ -65,7 +65,7 @@ export patch_to_column = (col, patch, shapes) ->
     # make the single index case look like the length-3 multi-index case
     if not isArray(ind)
 
-      if Number.isInteger(ind)
+      if isNumber(ind)
         value = [value]
         patched.push(ind)
       else

--- a/bokehjs/src/coffee/models/sources/column_data_source.coffee
+++ b/bokehjs/src/coffee/models/sources/column_data_source.coffee
@@ -2,7 +2,7 @@ import {ColumnarDataSource} from "./columnar_data_source"
 import {HasProps} from "core/has_props"
 import * as p from "core/properties"
 import * as serialization from "core/util/serialization"
-import {isObject} from "core/util/types"
+import {isArray, isObject} from "core/util/types"
 
 # exported for testing
 export concat_typed_arrays = (a, b) ->
@@ -49,13 +49,45 @@ export stream_to_column = (col, new_col, rollover) ->
   return concat_typed_arrays(col, tmp)
 
 # exported for testing
-export patch_to_column = (col, patch) ->
-  for i in [0...patch.length]
-    [ind, value] = patch[i]
-    col[ind] = value
+export slice = (ind, length) ->
+  if isObject(ind)
+    return [ind.start ? 0, ind.stop ? length, ind.step ? 1]
+  return [start, stop, step] = [ind, ind+1, 1]
 
+# exported for testing
+export patch_to_column = (col, patch, shapes) ->
+  for [ind, value] in patch
 
-# Datasource where the data is defined column-wise, i.e. each key in the
+    # make the single index case look like the length-3 multi-index case
+    if not isArray(ind)
+      if Number.isInteger(ind)
+        value = [value]
+      ind = [0, 0, ind]
+      shape = [1, col.length]
+      item = col
+
+    else
+      shape = shapes[ind[0]]
+      item = col[ind[0]]
+
+    # this is basically like NumPy's "newaxis", inserting an empty dimension
+    # makes length 2 and 3 multi-index cases uniform, so that the same code
+    # can handle both
+    if ind.length == 2
+      shape = [1, shape[0]]
+      ind = [ind[0], 0, ind[1]]
+
+    # now this one nested loop handles all cases
+    flat_index = 0
+    [istart, istop, istep] = slice(ind[1], shape[0])
+    [jstart, jstop, jstep] = slice(ind[2], shape[1])
+
+    for i in [istart...istop] by istep
+      for j in [jstart...jstop] by jstep
+        item[i*shape[1] + j] = value[flat_index]
+        flat_index++
+
+# Data source where the data is defined column-wise, i.e. each key in the
 # the data attribute is a column name, and its value is an array of scalars.
 # Each column should be the same length.
 export class ColumnDataSource extends ColumnarDataSource
@@ -96,6 +128,6 @@ export class ColumnDataSource extends ColumnarDataSource
   patch: (patches) ->
     data = @data
     for k, patch of patches
-      patch_to_column(data[k], patch)
+      patch_to_column(data[k], patch, @_shapes[k])
     @setv('data', data, {silent: true})
     @patching.emit()

--- a/bokehjs/src/coffee/models/sources/columnar_data_source.coffee
+++ b/bokehjs/src/coffee/models/sources/columnar_data_source.coffee
@@ -27,7 +27,7 @@ export class ColumnarDataSource extends DataSource
     @inspect = new Signal(this, "inspect")
 
     @streaming = new Signal(this, "streaming")
-    @patching = new Signal(this, "patching")
+    @patching = new Signal(this, "patching") # <number[], ColumnarDataSource>
 
   get_column: (colname) ->
     return @data[colname] ? null

--- a/bokehjs/test/models/sources/column_data_source.coffee
+++ b/bokehjs/test/models/sources/column_data_source.coffee
@@ -4,7 +4,7 @@ utils = require "../../utils"
 
 {set_log_level} = utils.require "core/logging"
 
-{ColumnDataSource, concat_typed_arrays, stream_to_column, patch_to_column} = utils.require("models/sources/column_data_source")
+{ColumnDataSource, concat_typed_arrays, stream_to_column, slice, patch_to_column} = utils.require("models/sources/column_data_source")
 
 describe "column_data_source module", ->
 
@@ -31,37 +31,270 @@ describe "column_data_source module", ->
       expect(c).to.be.instanceof Int32Array
       expect(c).to.be.deep.equal new Int32Array([1,2,3,4])
 
+  describe "slice", ->
+
+    it "should return [ind, ind+1, 1] for scalars", ->
+      expect(slice(0)).to.be.deep.equal [0, 1, 1]
+      expect(slice(10)).to.be.deep.equal [10, 11, 1]
+
+    it "should return start, stop, end for slice object", ->
+      expect(slice({start:1, stop:10, step:2})).to.be.deep.equal [1, 10, 2]
+      expect(slice({start:1, stop:10, step:2}, 5)).to.be.deep.equal [1, 10, 2]
+      expect(slice({start:1, stop:10, step:2}, 15)).to.be.deep.equal [1, 10, 2]
+
+    it "should return 0 for start when slice start is null", ->
+      expect(slice({start:null, stop:10, step:2})).to.be.deep.equal [0, 10, 2]
+      expect(slice({start:null, stop:10, step:2}, 5)).to.be.deep.equal [0, 10, 2]
+      expect(slice({start:null, stop:10, step:2}, 15)).to.be.deep.equal [0, 10, 2]
+
+    it "should return 1 for step when slice step is null", ->
+      expect(slice({start:1, stop:10, step:null})).to.be.deep.equal [1, 10, 1]
+      expect(slice({start:1, stop:10, step:null}, 5)).to.be.deep.equal [1, 10, 1]
+      expect(slice({start:1, stop:10, step:null}, 15)).to.be.deep.equal [1, 10, 1]
+
+    it "should return length for stop when slice stop is null", ->
+      expect(slice({start:1, stop:null, step:2}, 11)).to.be.deep.equal [1, 11, 2]
+
   describe "patch_to_column", ->
 
-    it "should patch Arrays to Arrays", ->
-      a = [1,2,3,4,5]
-      patch_to_column(a, [[3, 100]])
-      expect(a).to.be.instanceof Array
-      expect(a).to.be.deep.equal [1,2,3,100,5]
+    describe "with single integer index", ->
 
-    it "should patch Float32 to Float32", ->
-      a = new Float32Array([1,2,3,4,5])
-      patch_to_column(a, [[3, 100]])
-      expect(a).to.be.instanceof Float32Array
-      expect(a).to.be.deep.equal new Float32Array([1,2,3,100,5])
+      it "should patch Arrays to Arrays", ->
+        a = [1,2,3,4,5]
+        patch_to_column(a, [[3, 100]])
+        expect(a).to.be.instanceof Array
+        expect(a).to.be.deep.equal [1,2,3,100,5]
 
-    it "should patch Float64 to Float64", ->
-      a = new Float64Array([1,2,3,4,5])
-      patch_to_column(a, [[3, 100]])
-      expect(a).to.be.instanceof Float64Array
-      expect(a).to.be.deep.equal new Float64Array([1,2,3,100,5])
+        patch_to_column(a, [[2, 101]])
+        expect(a).to.be.instanceof Array
+        expect(a).to.be.deep.equal [1,2,101,100,5]
 
-    it "should patch Int32 to Int32", ->
-      a = new Int32Array([1,2,3,4,5])
-      patch_to_column(a, [[3, 100]])
-      expect(a).to.be.instanceof Int32Array
-      expect(a).to.be.deep.equal new Int32Array([1,2,3,100,5])
+      it "should patch typed Arrays to typed Arrays", ->
+        for typ in [Float32Array, Float64Array, Int32Array]
+          a = new typ([1,2,3,4,5])
+          patch_to_column(a, [[3, 100]])
+          expect(a).to.be.instanceof typ
+          expect(a).to.be.deep.equal new typ([1,2,3,100,5])
 
-    it "should handle multi-part patches", ->
-      a = [1,2,3,4,5]
-      patch_to_column(a, [[3, 100], [0, 10], [4, -1]])
-      expect(a).to.be.instanceof Array
-      expect(a).to.be.deep.equal [10,2,3,100,-1]
+          patch_to_column(a, [[2, 101]])
+          expect(a).to.be.instanceof typ
+          expect(a).to.be.deep.equal new typ([1,2,101,100,5])
+
+      it "should handle multi-part patches", ->
+        a = [1,2,3,4,5]
+        patch_to_column(a, [[3, 100], [0, 10], [4, -1]])
+        expect(a).to.be.instanceof Array
+        expect(a).to.be.deep.equal [10,2,3,100,-1]
+
+    describe "with single slice index", ->
+
+      it "should patch Arrays to Arrays", ->
+        a = [1,2,3,4,5]
+        patch_to_column(a, [[{start:2,stop:4,step:1}, [100, 101]]])
+        expect(a).to.be.instanceof Array
+        expect(a).to.be.deep.equal [1,2,100,101,5]
+
+        patch_to_column(a, [[{start:1,stop:3,step:1}, [99, 102]]])
+        expect(a).to.be.instanceof Array
+        expect(a).to.be.deep.equal [1,99,102,101,5]
+
+      it "should patch typed Arrays to typed Arrays", ->
+        for typ in [Float32Array, Float64Array, Int32Array]
+          a = new typ([1,2,3,4,5])
+          patch_to_column(a, [[{start:2,stop:4,step:1}, [100, 101]]])
+          expect(a).to.be.instanceof typ
+          expect(a).to.be.deep.equal new typ([1,2,100,101,5])
+
+          patch_to_column(a, [[{start:1,stop:3,step:1}, [99, 102]]])
+          expect(a).to.be.instanceof typ
+          expect(a).to.be.deep.equal new typ([1,99,102,101,5])
+
+      it "should handle patch indices with strides", ->
+        a = new Int32Array([1,2,3,4,5])
+        patch_to_column(a, [[{start:1,stop:5,step:2}, [100, 101]]])
+        expect(a).to.be.instanceof Int32Array
+        expect(a).to.be.deep.equal new Int32Array([1,100,3,101,5])
+
+      it "should handle multi-part patches", ->
+        a = [1,2,3,4,5]
+        patch_to_column(a, [[{start:2,stop:4,step:1}, [100, 101]], [{start:null, stop:1, step:1}, [10]], [4, -1]])
+        expect(a).to.be.instanceof Array
+        expect(a).to.be.deep.equal [10,2,100,101,-1]
+
+    describe "with multi-index for 1d subarrays", ->
+
+      it "should patch Arrays to Arrays", ->
+        a = [1,2,3,4,5]
+        b = [10, 20, -1, -2, 0, 10]
+        patch_to_column([a, b], [
+          [[0, {start:2,stop:4,step:1}], [100, 101]]
+        ], [[5], [6]])
+        expect(a).to.be.instanceof Array
+        expect(b).to.be.instanceof Array
+        expect(a).to.be.deep.equal [1,2,100,101,5]
+        expect(b).to.be.deep.equal [10, 20, -1, -2, 0, 10]
+
+        patch_to_column([a, b], [
+          [[1, {start:2,stop:4,step:1}], [100, 101]]
+        ], [[5], [6]])
+        expect(a).to.be.instanceof Array
+        expect(b).to.be.instanceof Array
+        expect(a).to.be.deep.equal [1,2,100,101,5]
+        expect(b).to.be.deep.equal [10, 20, 100, 101, 0, 10]
+
+      it "should patch typed Arrays to typed Arrays", ->
+        for typ in [Float32Array, Float64Array, Int32Array]
+          a = new typ([1,2,3,4,5])
+          b = new typ([10, 20, -1, -2, 0, 10])
+          patch_to_column([a, b], [
+            [[0, {start:2,stop:4,step:1}], [100, 101]]
+          ], [[5], [6]])
+          expect(a).to.be.instanceof typ
+          expect(b).to.be.instanceof typ
+          expect(a).to.be.deep.equal new typ([1,2,100,101,5])
+          expect(b).to.be.deep.equal new typ([10, 20, -1, -2, 0, 10])
+
+          patch_to_column([a, b], [
+            [[1, {start:2,stop:4,step:1}], [100, 101]]
+          ], [[5], [6]])
+          expect(a).to.be.instanceof typ
+          expect(b).to.be.instanceof typ
+          expect(a).to.be.deep.equal new typ([1,2,100,101,5])
+          expect(b).to.be.deep.equal new typ([10, 20, 100, 101, 0, 10])
+
+      it "should handle patch indices with strides", ->
+        a = new Int32Array([1,2,3,4,5])
+        b = new Int32Array([10, 20, -1, -2, 0, 10])
+        patch_to_column([a, b], [
+          [[0, {start:1,stop:5,step:2}], [100, 101]]
+        ], [[5], [6]])
+        expect(a).to.be.instanceof Int32Array
+        expect(b).to.be.instanceof Int32Array
+        expect(a).to.be.deep.equal new Int32Array([1,100,3,101,5])
+        expect(b).to.be.deep.equal new Int32Array([10, 20, -1, -2, 0, 10])
+
+        patch_to_column([a, b], [
+          [[1, {start:null,stop:null,step:3}], [100, 101]]
+        ], [[5], [6]])
+        expect(a).to.be.instanceof Int32Array
+        expect(b).to.be.instanceof Int32Array
+        expect(a).to.be.deep.equal new Int32Array([1,100,3,101,5])
+        expect(b).to.be.deep.equal new Int32Array([100, 20, -1, 101, 0, 10])
+
+      it "should handle multi-part patches", ->
+        a = [1,2,3,4,5]
+        b = [10, 20, -1, -2, 0, 10]
+        patch_to_column([a, b], [
+          [[0, {start:2,stop:4,step:1}], [100, 101]],
+          [[1, {start:null, stop:2, step:1}], [999, 999]],
+          [[1, 5], [6]]
+        ], [[5], [6]])
+        expect(a).to.be.instanceof Array
+        expect(b).to.be.instanceof Array
+        expect(a).to.be.deep.equal [1,2,100,101,5]
+        expect(b).to.be.deep.equal [999, 999, -1, -2, 0, 6]
+
+    describe "with multi-index for 2d subarrays", ->
+
+      it "should patch Arrays to Arrays", ->
+        a = [1,2,3,
+             4,5,6]
+        b = [10, 20,
+             -1, -2,
+              0, 10]
+        patch_to_column([a, b], [
+          [[0, {start:null,stop:null,step:null}, 2], [100, 101]]
+        ], [[2,3], [3,2]])
+        expect(a).to.be.instanceof Array
+        expect(b).to.be.instanceof Array
+        expect(a).to.be.deep.equal [1,2,100,
+                                    4,5,101]
+        expect(b).to.be.deep.equal [10, 20,
+                                    -1, -2,
+                                     0, 10]
+
+        patch_to_column([a, b], [
+          [[1, {start:0,stop:2,step:1}, {start:0,stop:1,step:1}], [100, 101]]
+        ], [[2,3], [3,2]])
+        expect(a).to.be.instanceof Array
+        expect(b).to.be.instanceof Array
+        expect(a).to.be.deep.equal [1,2,100,
+                                    4,5,101]
+        expect(b).to.be.deep.equal [100, 20,
+                                    101, -2,
+                                      0, 10]
+
+      it "should patch typed Arrays to types Arrays", ->
+        for typ in [Float32Array, Float64Array, Int32Array]
+          a = new typ([1,2,3,
+                       4,5,6])
+          b = new typ([10, 20,
+                       -1, -2,
+                        0, 10])
+          patch_to_column([a, b], [
+            [[0, {start:null,stop:null,step:null}, 2], [100, 101]]
+          ], [[2,3], [3,2]])
+          expect(a).to.be.instanceof typ
+          expect(b).to.be.instanceof typ
+          expect(a).to.be.deep.equal new typ([1,2,100,
+                                              4,5,101])
+          expect(b).to.be.deep.equal new typ([10, 20,
+                                              -1, -2,
+                                               0, 10])
+
+          patch_to_column([a, b], [
+            [[1, {start:0,stop:2,step:1}, {start:0,stop:1,step:1}], [100, 101]]
+          ], [[2,3], [3,2]])
+          expect(a).to.be.instanceof typ
+          expect(b).to.be.instanceof typ
+          expect(a).to.be.deep.equal new typ([1,2,100,
+                                              4,5,101])
+          expect(b).to.be.deep.equal new typ([100, 20,
+                                              101, -2,
+                                                0, 10])
+
+      it "should handle patch indices with strides", ->
+          a = new Int32Array([1,2,3,4,5,6])
+          b = new Int32Array([10, 20, -1, -2, 0, 10])
+          patch_to_column([a, b], [
+            [[0, {start:null,stop:null,step:1}, 2], [100, 101]]
+          ], [[2,3], [3,2]])
+          expect(a).to.be.instanceof Int32Array
+          expect(b).to.be.instanceof Int32Array
+          expect(a).to.be.deep.equal new Int32Array([1,2,100,
+                                                     4,5,101])
+          expect(b).to.be.deep.equal new Int32Array([10, 20,
+                                                     -1, -2,
+                                                      0, 10])
+
+          patch_to_column([a, b], [
+            [[1, {start:0,stop:3,step:2}, {start:0,stop:1,step:1}], [100, 101]]
+          ], [[2,3], [3,2]])
+          expect(a).to.be.instanceof Int32Array
+          expect(b).to.be.instanceof Int32Array
+          expect(a).to.be.deep.equal new Int32Array([1,2,100,
+                                                     4,5,101])
+          expect(b).to.be.deep.equal new Int32Array([100, 20,
+                                                      -1, -2,
+                                                     101, 10])
+
+      it "should handle multi-part patches", ->
+        a = [1,2,3,
+             4,5,6]
+        b = [10, 20,
+             -1, -2,
+              0, 10]
+        patch_to_column([a, b], [
+          [[0, {start:null,stop:null,step:1}, 2], [100, 101]],
+          [[1, {start:0,stop:2,step:1}, {start:0,stop:1,step:1}], [100, 101]]
+        ], [[2,3], [3,2]])
+        expect(a).to.be.instanceof Array
+        expect(b).to.be.instanceof Array
+        expect(a).to.be.deep.equal [1,2,100,
+                                    4,5,101]
+        expect(b).to.be.deep.equal [100, 20,
+                                    101, -2,
+                                      0, 10]
 
   describe "stream_to_column", ->
 

--- a/examples/app/spectrogram/waterfall.coffee
+++ b/examples/app/spectrogram/waterfall.coffee
@@ -25,7 +25,7 @@ export class WaterfallRendererView extends RendererView
     @cmap = new LinearColorMapper({'palette': @model.palette, low: 0, high: 5})
     @xscale = @plot_view.frame.xscales['default']
     @yscale = @plot_view.frame.yscales['default']
-    @max_freq = @plot_view.y_range.end
+    @max_freq = @plot_view.frame.y_range.end
 
     @connect(@model.change, @request_render)
 

--- a/examples/howto/patch_app.py
+++ b/examples/howto/patch_app.py
@@ -1,0 +1,66 @@
+# This is a Bokeh server app. To function, it must be run using the
+# Bokeh server ath the command line:
+#
+#     bokeh serve --show patch_app.py
+#
+# Running "python patch_app.py" will NOT work.
+import numpy as np
+
+from bokeh.io import curdoc
+from bokeh.layouts import gridplot
+from bokeh.plotting import figure
+from bokeh.models import ColumnDataSource
+
+# CDS with "typical" scalar elements
+x = np.random.uniform(10, size=500)
+y = np.random.uniform(10, size=500)
+color = ["navy"]*500
+color[:200] = ["firebrick"]*200
+source = ColumnDataSource(data=dict(x=x, y=y, color=color))
+
+p = figure(plot_width=400, plot_height=400)
+p.circle('x', 'y', alpha=0.6, size=8, color="color", source=source)
+
+# CDS with 1d array elements
+x = np.linspace(0, 10, 200)
+y0 = np.sin(x)
+y1 = np.cos(x)
+source1d = ColumnDataSource(data=dict(xs=[x, x], ys=[y0, y1], color=["olive", "navy"]))
+
+p1d = figure(plot_width=400, plot_height=400)
+p1d.multi_line('xs', 'ys', alpha=0.6, line_width=4, color="color", source=source1d)
+
+# CDS with 2d image elements
+N = 200
+img = np.empty((N,N), dtype=np.uint32)
+view = img.view(dtype=np.uint8).reshape((N, N, 4))
+for i in range(N):
+    for j in range(N):
+        view[i, j, :] = [int(j/N*255), int(i/N*255), 158, 255]
+source2d = ColumnDataSource(data=dict(img=[img]))
+
+p2d = figure(plot_width=400, plot_height=400, x_range=(0,10), y_range=(0,10))
+p2d.image_rgba(image='img', x=0, y=0, dw=10, dh=10, source=source2d)
+
+def update():
+
+    # update some items in the "typical" CDS column
+    s = slice(100)
+    new_x = source.data['x'][s] + np.random.uniform(-0.1, 0.1, size=100)
+    new_y = source.data['y'][s] + np.random.uniform(-0.2, 0.2, size=100)
+    source.patch({ 'x' : [(s, new_x)], 'y' : [(s, new_y)] })
+
+    # update a single point of the 1d multi-line data
+    i = np.random.randint(200)
+    new_y = source1d.data['ys'][0][i] + (0.2 * np.random.random()-0.1)
+    source1d.patch({ 'ys' : [([0, i], [new_y])]})
+
+    # update five rows of the 2d image data at a time
+    s1, s2 = slice(50, 151, 20), slice(None)
+    index = [0, s1, s2]
+    new_data = np.roll(source2d.data['img'][0][s1, s2], 2, axis=1).flatten()
+    source2d.patch({ 'img' : [(index, new_data)] })
+
+curdoc().add_periodic_callback(update, 50)
+
+curdoc().add_root(gridplot([[p, p1d, p2d]]))


### PR DESCRIPTION
This PR extends the CDS patch capability to more kinds of patch values. In particular, it can now patch sub-portions of "array" element. This is most useful for, e.g. updating data for image, patches, and multi-line glyphs.

Patches are still of the form `(index, new_data)` but now the index can be a slice, or a list of integers and slices (with correspondingly sized new data) The kinds of patches now accepted are summarized below:
```
# patch entire elements of "typical" columns
(10, 100)
(slice(2), [100, 101])

# column is "list of 1d array"
([1, 4], [6])
([0, slice(2, 4)], [100, 101])

# column is "list of 2d array"
([1, 4, slice(None)], [1, 2, 3, 4, 5])
([0, slice(2, 4), 2], [100, 101])
```

- [x] issues: fixes #6285
- [x] tests added / passed
- [x] release document entry (if new feature or API change)
