### PR TITLE
Ensure DataSpec.to_serializable returns new dict

### DIFF
--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -1485,8 +1485,8 @@ class DataSpec(Either):
         if isinstance(val, string_types):
             return dict(field=val)
 
-        # Must be dict, return as-is
-        return val
+        # Must be dict, return a new dict
+        return dict(val)
 
     def _sphinx_type(self):
         return self._sphinx_prop_link()

--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -1766,8 +1766,8 @@ class ColorSpec(DataSpec):
         if isinstance(val, string_types):
             return dict(field=val)
 
-        # Must be dict, return as-is
-        return val
+        # Must be dict, return new dict
+        return dict(val)
 
     def prepare_value(self, cls, name, value):
         # Some explanation is in order. We want to accept tuples like

--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -1702,7 +1702,7 @@ class DataDistanceSpec(NumberSpec):
         return super(DataDistanceSpec, self).prepare_value(cls, name, value)
 
     def to_serializable(self, obj, name, val):
-        d = super(ScreenDistanceSpec, self).to_serializable(obj, name, val)
+        d = super(DataDistanceSpec, self).to_serializable(obj, name, val)
         d["units"] = "data"
         return d
 

--- a/bokeh/core/tests/test_properties.py
+++ b/bokeh/core/tests/test_properties.py
@@ -1766,6 +1766,19 @@ def test_strict_dataspec_key_values():
         with pytest.raises(ValueError):
             f.x = dict(field="foo", units="junk")
 
+def test_dataspec_dict_to_serializable():
+    for typ in (NumberSpec, StringSpec, FontSizeSpec, ColorSpec, DataDistanceSpec, ScreenDistanceSpec):
+        class Foo(HasProps):
+            x = typ("x")
+        foo = Foo(x=dict(field='foo'))
+        props = foo.properties_with_values(include_defaults=False)
+        if typ is DataDistanceSpec:
+            assert props['x']['units'] == 'data'
+        elif typ is ScreenDistanceSpec:
+            assert props['x']['units'] == 'screen'
+        assert props['x']['field'] == 'foo'
+        assert props['x'] is not foo.x
+
 def test_strict_unitspec_key_values():
     class FooUnits(HasProps):
         x = DistanceSpec("x")


### PR DESCRIPTION
Fixes issue #6316 associated with ``ScreenDistanceSpec`` and ``DataDistanceSpec`` attempting to set ``units`` directly on a container, triggering a validation error. I'm still looking for a small reproducible example that could be tested but this seems to be the safer approach regardless.