### PR TITLE
Exposed initial_start and initial_end in models/Range1d. This allows …

### DIFF
--- a/bokeh/models/ranges.py
+++ b/bokeh/models/ranges.py
@@ -75,6 +75,14 @@ class Range1d(Range):
     maximum visible interval. Can be a timedelta. Note that ``bounds`` can
     impose an implicit constraint on the maximum interval as well. """)
 
+    initial_start = Either(Float, Datetime, Int, default=0, help="""
+    The default start of the range. (When user hits reset)
+    """)
+
+    initial_end = Either(Float, Datetime, Int, default=1, help="""
+    The default end of the range. (When user hits reset)
+    """)
+
     def __init__(self, *args, **kwargs):
         if args and ('start' in kwargs or 'end' in kwargs):
             raise ValueError("'start' and 'end' keywords cannot be used with positional arguments")

--- a/bokehjs/src/coffee/models/ranges/range1d.coffee
+++ b/bokehjs/src/coffee/models/ranges/range1d.coffee
@@ -10,12 +10,14 @@ export class Range1d extends Range
       bounds: [ p.Any       ] # TODO (bev)
       min_interval: [ p.Any ]
       max_interval: [ p.Any ]
+      initial_start: [p.Number, 0]
+      initial_end: [p.Number, 1]
     }
 
   _set_auto_bounds: () ->
     if @bounds == 'auto'
-      min = Math.min(@_initial_start, @_initial_end)
-      max = Math.max(@_initial_start, @_initial_end)
+      min = Math.min(@initial_start, @initial_end)
+      max = Math.max(@initial_start, @initial_end)
       @setv({bounds: [min, max]}, {silent: true})
 
   constructor: () ->
@@ -29,8 +31,8 @@ export class Range1d extends Range
   initialize: (attrs, options) ->
     super(attrs, options)
 
-    @_initial_start = @start
-    @_initial_end = @end
+    @initial_start = @start
+    @initial_end = @end
 
     @_set_auto_bounds()
 
@@ -41,7 +43,7 @@ export class Range1d extends Range
 
   reset: () ->
     @_set_auto_bounds()
-    if @start != @_initial_start or @end != @_initial_end
-      @setv({start: @_initial_start, end: @_initial_end})
+    if @start != @initial_start or @end != @initial_end
+      @setv({start: @initial_start, end: @initial_end})
     else
       @change.emit()


### PR DESCRIPTION
…the user to change the 'default' range after a graph has been created and before the user knows the range of the data that is going to be plotted

- [x] issues: fixes #6320 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
