### PR TITLE
Fix #6319: close HTTP server explicitly when closing Bokeh server

### DIFF
--- a/bokeh/server/server.py
+++ b/bokeh/server/server.py
@@ -189,6 +189,7 @@ class Server(object):
         assert not self._stopped, "Already stopped"
         self._stopped = True
         self._tornado.stop(wait)
+        self._http.stop()
 
     def run_until_shutdown(self):
         ''' Run the Bokeh Server until shutdown is requested by the user,


### PR DESCRIPTION
issues: fixes #6319 

This avoids a ResourceWarning with the HTTP server's listening socket(s).
