### PR TITLE
Adds the renderer object to cb_data

### DIFF
--- a/bokehjs/src/coffee/models/tools/inspectors/hover_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/inspectors/hover_tool.coffee
@@ -292,7 +292,7 @@ export class HoverToolView extends InspectToolView
     geometry['y'] = yscale.invert(geometry.vy)
 
     callback = @model.callback
-    [obj, data] = [callback, {index: indices, geometry: geometry}]
+    [obj, data] = [callback, {index: indices, geometry: geometry, renderer: r}]
 
     if isFunction(callback)
       callback(obj, data)


### PR DESCRIPTION
To be able to identify which renderer invoked the callback from within the JS

- [x] issues: fixes #6326 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
