### PR TITLE
Silence all change events during initialization of models

### DIFF
--- a/bokehjs/src/coffee/core/has_props.coffee
+++ b/bokehjs/src/coffee/core/has_props.coffee
@@ -101,16 +101,13 @@ export class HasProps
         throw new Error("undefined property type for #{@type}.#{name}")
       @properties[name] = new type({obj: @, attr: name, default_value: default_value})
 
-    # Bokeh specific
     this._set_after_defaults = {}
-
-    this.setv(attributes, options)
-
-    ## bokeh custom constructor code
 
     # auto generating ID
     if not attributes.id?
       @setv("id", uniqueId(), {silent: true})
+
+    this.setv(attributes, extend({silent: true}, options))
 
     # allowing us to defer initialization when loading many models
     # when loading a bunch of models, we want to do initialization as a second pass

--- a/bokehjs/src/coffee/core/has_props.coffee
+++ b/bokehjs/src/coffee/core/has_props.coffee
@@ -110,7 +110,7 @@ export class HasProps
 
     # auto generating ID
     if not attributes.id?
-      this.id = uniqueId(this.type)
+      @setv("id", uniqueId(), {silent: true})
 
     # allowing us to defer initialization when loading many models
     # when loading a bunch of models, we want to do initialization as a second pass

--- a/bokehjs/src/coffee/core/properties.coffee
+++ b/bokehjs/src/coffee/core/properties.coffee
@@ -5,6 +5,12 @@ import {valid_rgb} from "./util/color"
 import {copy} from "./util/array"
 import {isBoolean, isNumber, isString, isFunction, isArray, isObject} from "./util/types"
 
+valueToString = (value) ->
+  try
+    return JSON.stringify(value)
+  catch
+    return value.toString()
+
 #
 # Property base class
 #
@@ -110,16 +116,19 @@ export class Property # <T>
 
     @init()
 
+
+  toString: () -> "#{@name}(#{@obj}.#{@attr}, spec: #{valueToString(@spec)})"
+
 #
 # Simple Properties
 #
 
 export simple_prop = (name, pred) ->
   class Prop extends Property
-    toString: () -> "#{name}(obj: #{@obj.id}, spec: #{JSON.stringify(@spec)})"
+    name: name
     validate: (value) ->
       if not pred(value)
-        throw new Error("#{name} property '#{@attr}' given invalid value: #{JSON.stringify(value)}")
+        throw new Error("#{name} property '#{@attr}' given invalid value: #{valueToString(value)}")
 
 export class Any extends simple_prop("Any", (x) -> true)
 
@@ -154,7 +163,7 @@ export class Font extends String
 
 export enum_prop = (name, enum_values) ->
   class Enum extends simple_prop(name, (x) -> x in enum_values)
-    toString: () -> "#{name}(obj: #{@obj.id}, spec: #{JSON.stringify(@spec)})"
+    name: name
 
 export class Anchor extends enum_prop("Anchor", enums.LegendLocation)
 
@@ -210,10 +219,9 @@ export class StartEnd extends enum_prop("StartEnd", enums.StartEnd)
 #
 # Units Properties
 #
-
 export units_prop = (name, valid_units, default_units) ->
   class UnitsProp extends Number
-    toString: () -> "#{name}(obj: #{@obj.id}, spec: #{JSON.stringify(@spec)})"
+    name: name
     init: () ->
       if not @spec.units?
         @spec.units = default_units

--- a/bokehjs/src/coffee/core/signaling.ts
+++ b/bokehjs/src/coffee/core/signaling.ts
@@ -62,7 +62,7 @@ export class Signal<Args, Sender extends object> {
 
     for (const {signal, slot, context} of receivers) {
       if (signal === this) {
-        slot.call(context, args, signal!.sender)
+        slot.call(context, args, this.sender)
       }
     }
   }

--- a/bokehjs/src/coffee/core/signaling.ts
+++ b/bokehjs/src/coffee/core/signaling.ts
@@ -8,10 +8,7 @@ export type Slot<Args, Sender extends object> = ((args: Args, sender: Sender) =>
 
 export class Signal<Args, Sender extends object> {
 
-  constructor(readonly sender: Sender, readonly name: string) {
-    this.sender = sender
-    this.name = name
-  }
+  constructor(readonly sender: Sender, readonly name: string) {}
 
   connect(slot: Slot<Args, Sender>, context: object | null = null): boolean {
     if (!receiversForSender.has(this.sender)) {

--- a/bokehjs/src/coffee/core/util/string.ts
+++ b/bokehjs/src/coffee/core/util/string.ts
@@ -2,7 +2,7 @@ export function startsWith(str: string, searchString: string, position: number =
   return str.substr(position, searchString.length) == searchString
 }
 
-export function uniqueId(prefix?: string): string {
+export function uuid4(): string {
   // from ipython project
   // http://www.ietf.org/rfc/rfc4122.txt
   const s = new Array<string>(32)
@@ -13,11 +13,19 @@ export function uniqueId(prefix?: string): string {
   s[12] = "4"                                                     // bits 12-15 of the time_hi_and_version field to 0010
   s[16] = hexDigits.substr((s[16].charCodeAt(0) & 0x3) | 0x8, 1)  // bits 6-7 of the clock_seq_hi_and_reserved to 01
 
-  const uuid = s.join("")
+  return s.join("")
+}
+
+const dev = false
+let counter = 1000
+
+export function uniqueId(prefix?: string): string {
+  const id = dev ? `j${counter++}` : uuid4()
+
   if (prefix != null)
-    return `${prefix}-${uuid}`
+    return `${prefix}-${id}`
   else
-    return uuid
+    return id
 }
 
 export function escape(s: string): string {

--- a/bokehjs/src/coffee/core/view.coffee
+++ b/bokehjs/src/coffee/core/view.coffee
@@ -18,7 +18,7 @@ export class View
 
     @_parent = options.parent
 
-    @id = options.id ? uniqueId('View')
+    @id = options.id ? uniqueId()
     @initialize(options)
 
   initialize: (options) ->

--- a/bokehjs/src/coffee/document.coffee
+++ b/bokehjs/src/coffee/document.coffee
@@ -361,7 +361,7 @@ export class Document
     # this first pass removes all 'refs' replacing them with real instances
     foreach_depth_first to_update, (instance, attrs, was_new) ->
       if was_new
-        instance.setv(attrs)
+        instance.setv(attrs, {silent: true})
 
     # after removing all the refs, we can run the initialize code safely
     foreach_depth_first to_update, (instance, attrs, was_new) ->


### PR DESCRIPTION
This is a side effect of work on layout. Changes in this PR:

- [x] silence change events on init
- [x] fix double initialization bug in `Signal.constructor`
- [x] better printing of properties (to better visualize change signals)
- [x] don't include `@type` in `@id`, because `toString()` already handles this
- [x] make `uniqueId` produce simple ids in dev mode (requires setting `dev` in `core/util/string`)

fixes #6336 