### PR TITLE
Canavandl/6345 deprecate webgl attr

### DIFF
--- a/bokeh/core/enums.py
+++ b/bokeh/core/enums.py
@@ -230,7 +230,7 @@ NumeralLanguage = enumeration("be-nl", "chs", "cs", "da-dk", "de-ch", "de", "en"
                               "pt-pt", "ru", "ru-UA", "sk", "th", "tr", "uk-UA")
 
 #: Specify an output backend to render a plot area onto
-OutputBackend = enumeration("canvas", "svg")
+OutputBackend = enumeration("canvas", "svg", "webgl")
 
 #: Specify a position in the render order for a Bokeh renderer
 RenderLevel = enumeration("image", "underlay", "glyph", "annotation", "overlay")

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -278,7 +278,7 @@ def _use_gl(objs):
     from .models.plots import Plot
 
     def _needs_gl(obj):
-        return isinstance(obj, Plot) and obj.webgl
+        return isinstance(obj, Plot) and obj.output_backend == "webgl"
 
     for obj in objs:
         if isinstance(obj, Document):

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -453,6 +453,21 @@ class Plot(LayoutDOM):
         deprecated((0, 12, 6), "y_mapper_type", "y_scale")
         self.y_scale = self._scale(mapper_type)
 
+    @property
+    def webgl(self):
+        deprecated((0, 12, 6), "webgl", "output_backend")
+        return self.output_backend == "webgl"
+
+    @webgl.setter
+    def webgl(self, webgl):
+        deprecated((0, 12, 6), "webgl", "output_backend")
+        if not isinstance(webgl, bool):
+            raise ValueError('Attribute "webgl" must be a boolean')
+        if webgl is True:
+            self.output_backend = "webgl"
+        else:
+            self.output_backend = "canvas"
+
     x_scale = Instance(Scale, default=lambda: LinearScale(), help="""
     What kind of scale to use to convert x-coordinates in data space
     into x-coordinates in screen space.
@@ -691,11 +706,6 @@ class Plot(LayoutDOM):
     occurring. Once level-of-detail mode is enabled, a check is made every
     ``lod_timeout`` ms. If no interactive tool events have happened,
     level-of-detail mode is disabled.
-    """)
-
-    webgl = Bool(False, help="""
-    Whether WebGL is enabled for this plot. If True, the glyphs that
-    support this will render via WebGL instead of the 2D canvas.
     """)
 
     output_backend = Enum(OutputBackend, default="canvas", help="""

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -710,4 +710,8 @@ class Plot(LayoutDOM):
 
     output_backend = Enum(OutputBackend, default="canvas", help="""
     Specify the output backend for the plot area. Default is HTML5 Canvas.
+
+    .. note::
+        When set to ``webgl``, glyphs without a WebGL rendering implementation
+        will fall back to rendering onto 2D canvas.
     """)

--- a/bokehjs/src/coffee/api/typings/models/plots.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/plots.d.ts
@@ -74,7 +74,6 @@ declare namespace Bokeh {
   lod_interval?: Int;
   lod_timeout?: Int;
 
-  webgl?: boolean;
   hidpi?: boolean;
  }
 }

--- a/bokehjs/src/coffee/core/enums.coffee
+++ b/bokehjs/src/coffee/core/enums.coffee
@@ -24,7 +24,7 @@ export LegendLocation = [
 
 export Orientation = ["vertical", "horizontal"]
 
-export OutputBackend = ["canvas", "svg"]
+export OutputBackend = ["canvas", "svg", "webgl"]
 
 export RenderLevel = ["image", "underlay", "glyph", "annotation", "overlay"]
 

--- a/bokehjs/src/coffee/models/plots/plot.coffee
+++ b/bokehjs/src/coffee/models/plots/plot.coffee
@@ -337,7 +337,6 @@ export class Plot extends LayoutDOM
       lod_threshold:     [ p.Number,   2000                   ]
       lod_timeout:       [ p.Number,   500                    ]
 
-      webgl:             [ p.Bool,     false                  ]
       hidpi:             [ p.Bool,     true                   ]
       output_backend:    [ p.OutputBackend, "canvas"          ]
 
@@ -367,10 +366,13 @@ export class Plot extends LayoutDOM
       return renderers
     x_mapper_type: () ->
       log.warning("x_mapper_type attr is deprecated, use x_scale")
-      @x_scale
+      return @x_scale
     y_mapper_type: () ->
       log.warning("y_mapper_type attr is deprecated, use y_scale")
-      @y_scale
+      return @y_scale
+    webgl: () ->
+      log.warning("webgl attr is deprecated, use output_backend")
+      return @output_backend == "webgl"
   }
 
 register_with_event(UIEvent, Plot)

--- a/bokehjs/src/coffee/models/plots/plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.coffee
@@ -94,7 +94,7 @@ export class PlotCanvasView extends DOMView
     @canvas_view.render()
 
     # If requested, try enabling webgl
-    if @model.plot.webgl
+    if @model.plot.output_backend == "webgl"
       @init_webgl()
 
     @throttled_render = throttle((() => @force_render.emit()), 15) # TODO (bev) configurable

--- a/bokehjs/test/core/enums.coffee
+++ b/bokehjs/test/core/enums.coffee
@@ -22,6 +22,9 @@ describe "enums module", ->
   it "should have Location", ->
     expect(enums.Location).to.be.deep.equal ["above", "below", "left", "right"]
 
+  it "should have OutputBackend", ->
+    expect(enums.OutputBackend).to.be.deep.equal ["canvas", "svg", "webgl"]
+
   it "should have RenderMode", ->
     expect(enums.RenderMode).to.be.deep.equal ["canvas", "css"]
 

--- a/examples/models/file/maps_cities.py
+++ b/examples/models/file/maps_cities.py
@@ -26,7 +26,7 @@ plot = GMapPlot(
     plot_height=500,
     map_options=map_options,
     api_key=API_KEY,
-    webgl=True,
+    output_backend=True,
 )
 
 if plot.api_key == "GOOGLE_API_KEY":

--- a/examples/models/file/maps_cities.py
+++ b/examples/models/file/maps_cities.py
@@ -26,7 +26,7 @@ plot = GMapPlot(
     plot_height=500,
     map_options=map_options,
     api_key=API_KEY,
-    output_backend=True,
+    output_backend="webgl",
 )
 
 if plot.api_key == "GOOGLE_API_KEY":

--- a/examples/webgl/clustering.py
+++ b/examples/webgl/clustering.py
@@ -49,7 +49,7 @@ for dataset in (noisy_circles, noisy_moons, blobs1, blobs2):
     else:
         y_pred = algorithm.predict(X)
 
-    p = figure(webgl=True, title=algorithm.__class__.__name__,
+    p = figure(output_backend="webgl", title=algorithm.__class__.__name__,
                plot_width=PLOT_SIZE, plot_height=PLOT_SIZE)
 
     p.scatter(X[:, 0], X[:, 1], color=colors[y_pred].tolist(), alpha=0.1,)

--- a/examples/webgl/iris_blend.py
+++ b/examples/webgl/iris_blend.py
@@ -18,7 +18,7 @@ colors1 = [colormap1[x] for x in flowers['species']]
 colormap2 = {'setosa': '#0f0', 'versicolor': '#0f0', 'virginica': '#f00'}
 colors2 = [colormap2[x] for x in flowers['species']]
 
-p = figure(title = "Iris Morphology", webgl=True)
+p = figure(title = "Iris Morphology", output_backend="webgl")
 p.xaxis.axis_label = 'Petal Length'
 p.yaxis.axis_label = 'Petal Width'
 

--- a/examples/webgl/line10k.py
+++ b/examples/webgl/line10k.py
@@ -10,7 +10,7 @@ N = 10000
 x = np.linspace(0, 10*np.pi, N)
 y = np.cos(x) + np.sin(2*x+1.25) + np.random.normal(0, 0.001, (N, ))
 
-p = figure(title="A line consisting of 10k points", webgl=True)
+p = figure(title="A line consisting of 10k points", output_backend="webgl")
 
 output_file("line10k.html", title="line10k.py example")
 

--- a/examples/webgl/line_compare.py
+++ b/examples/webgl/line_compare.py
@@ -1,4 +1,4 @@
-""" Compare WebGL with canvas line.
+""" Compare WebGL, SVG with canvas line.
 
 """
 import numpy as np
@@ -7,14 +7,16 @@ from bokeh.layouts import row, column
 from bokeh.models import Slider, Dropdown, CustomJS
 from bokeh.plotting import figure, show, output_file
 
-p1 = figure(title="Canvas", webgl=False)
+p1 = figure(title="Canvas", output_backend="canvas")
 
-p2 = figure(title="WebGL", webgl=True)
+p2 = figure(title="SVG", output_backend="svg")
+
+p3 = figure(title="WebGL", output_backend="webgl")
 
 ys = 10  # yscale, to increase anisotropy
 
 lines = []
-for p in (p1, p2):
+for p in (p1, p2, p3):
 
     t = np.linspace(0, 2 * np.pi, 50)
     x = np.sin(t) * 10
@@ -75,4 +77,4 @@ sliders = column(*sliders)
 
 output_file("line_compare.html", title="line_compare.py example")
 
-show(row(sliders, p1, p2))
+show(row(sliders, p1, p2, p3))

--- a/examples/webgl/marker_compare.py
+++ b/examples/webgl/marker_compare.py
@@ -1,4 +1,4 @@
-""" Compare WebGL markers with canvas markers.
+""" Compare WebGL and SVG markers with canvas markers.
 
 This covers all markers supported by scatter. The plots are put in tabs,
 so that you can easily switch to compare positioning and appearance.
@@ -8,8 +8,8 @@ from bokeh.plotting import show, output_file, figure
 from bokeh.models.widgets import Tabs, Panel
 from bokeh.sampledata.iris import flowers
 
-def make_tab(title, marker, webgl):
-    p = figure(title=title, webgl=webgl)
+def make_tab(title, marker, backend):
+    p = figure(title=title, output_backend=backend)
     p.scatter(flowers["petal_length"], flowers["petal_width"],
               color='blue', fill_alpha=0.2, size=12, marker=marker)
     return Panel(child=p, title=title)
@@ -21,9 +21,10 @@ markers = ['asterisk', 'circle', 'square', 'diamond',
 
 tabs = []
 for marker in markers:
-    tabs.append(make_tab(marker, marker, False))
-    tabs.append(make_tab(marker + ' GL', marker, True))
+    tabs.append(make_tab(marker, marker, "canvas"))
+    tabs.append(make_tab(marker + ' SVG', marker, "svg"))
+    tabs.append(make_tab(marker + ' GL', marker, "webgl"))
 
-output_file("marker_compare.html", title="Compare regular and WebGL markers")
+output_file("marker_compare.html", title="Compare regular, SVG, and WebGL markers")
 
 show(Tabs(tabs=tabs))

--- a/examples/webgl/scatter10k.py
+++ b/examples/webgl/scatter10k.py
@@ -9,7 +9,7 @@ y = np.sin(x) + np.random.normal(0, 0.2, N)
 
 TOOLS = "pan,wheel_zoom,box_zoom,reset,save,box_select"
 
-p = figure(tools=TOOLS, webgl=True)
+p = figure(tools=TOOLS, output_backend="webgl")
 
 p.circle(x, y, alpha=0.1, nonselection_alpha=0.001)
 

--- a/sphinx/source/docs/releases/0.12.6.rst
+++ b/sphinx/source/docs/releases/0.12.6.rst
@@ -12,6 +12,13 @@ to bring interfaces and functionality up to a point that can be maintained
 long-term. We try to limit such changes as much as possible, and have a
 period of deprecation.
 
+New Deprecations
+~~~~~~~~~~~~~~~~
+
+The ``Plot.webgl`` property has been deprecated in place of
+``Plot.output_backend`` in order to avoid conflicts between WebGL and a new
+SVG backend.
+
 Deprecations removed
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/sphinx/source/docs/user_guide/webgl.rst
+++ b/sphinx/source/docs/user_guide/webgl.rst
@@ -17,12 +17,12 @@ WebGL is standardized and available in all modern browsers.
 How to enable WebGL
 -------------------
 
-To enable WebGL, set the plot's ``webgl`` property to ``True``:
+To enable WebGL, set the plot's ``output_backend`` property to ``"webgl"``:
 
 .. code-block:: python
 
-    p = Plot(webgl=True)  # for the glyph API
-    p = figure(webgl=True)  # for the plotting API
+    p = Plot(output_backend="webgl")  # for the glyph API
+    p = figure(output_backend="webgl")  # for the plotting API
 
 Support
 -------
@@ -67,8 +67,8 @@ Examples
 
     output_file("scatter10k.html", title="scatter 10k points (no WebGL)")
 
-    p = figure(webgl=False)
-    p.scatter(x,y, alpha=0.1)
+    p = figure(output_backend="webgl")
+    p.scatter(x, y, alpha=0.1)
     show(p)
 
 
@@ -86,8 +86,8 @@ Examples
 
     output_file("scatter10k.html", title="scatter 10k points (with WebGL)")
 
-    p = figure(webgl=True)
-    p.scatter(x,y, alpha=0.1)
+    p = figure(output_backend="webgl")
+    p.scatter(x, y, alpha=0.1)
     show(p)
 
 
@@ -105,6 +105,6 @@ Examples
 
     output_file("line10k.html", title="line10k.py example")
 
-    p = figure(title="A line consisting of 10k points", webgl=True)
+    p = figure(title="A line consisting of 10k points", output_backend="webgl")
     p.line(x, y, color="#22aa22", line_width=3)
     show(p)


### PR DESCRIPTION
Deprecate ``webgl`` attr in place of ``output_backend="webgl"``.

This is one to prevent conflicts between the new SVG backend and webgl.

- [x] issues: related to #6345
- [ ] tests added / passed
- [x] release document entry (if new feature or API change)
