### PR TITLE
gallery toctree path should not use os separator, always backslash

### DIFF
--- a/bokeh/sphinxext/bokeh_gallery.py
+++ b/bokeh/sphinxext/bokeh_gallery.py
@@ -42,7 +42,7 @@ class BokehGalleryDirective(BokehDirective):
             src_path = abspath(join("..", detail['path']))
             dest_path = join(dest_dir, detail['name'] + ".py")
 
-            # sphinx pickeled env works only with backslash
+            # sphinx pickled env works only with forward slash
             docname = join(env.app.config.bokeh_gallery_dir, detail['name']).replace("\\","/")
 
             try:

--- a/bokeh/sphinxext/bokeh_gallery.py
+++ b/bokeh/sphinxext/bokeh_gallery.py
@@ -41,7 +41,7 @@ class BokehGalleryDirective(BokehDirective):
         for detail in details_iter:
             src_path = abspath(join("..", detail['path']))
             dest_path = join(dest_dir, detail['name'] + ".py")
-            docname = join("docs", "gallery", detail['name'])
+            docname = join("docs", "gallery", detail['name']).replace("\\","/")
 
             try:
                 copyfile(src_path, dest_path)

--- a/bokeh/sphinxext/bokeh_gallery.py
+++ b/bokeh/sphinxext/bokeh_gallery.py
@@ -41,7 +41,9 @@ class BokehGalleryDirective(BokehDirective):
         for detail in details_iter:
             src_path = abspath(join("..", detail['path']))
             dest_path = join(dest_dir, detail['name'] + ".py")
-            docname = join("docs", "gallery", detail['name']).replace("\\","/")
+
+            # sphinx pickeled env works only with backslash
+            docname = join(env.app.config.bokeh_gallery_dir, detail['name']).replace("\\","/")
 
             try:
                 copyfile(src_path, dest_path)
@@ -66,5 +68,6 @@ def env_updated_handler(app, env):
     return getattr(env, 'gallery_updated', [])
 
 def setup(app):
+    app.add_config_value('bokeh_gallery_dir', join("docs", "gallery"), 'html')
     app.connect('env-updated', env_updated_handler)
     app.add_directive('bokeh-gallery', BokehGalleryDirective)


### PR DESCRIPTION
All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [ ] issues: fixes #6331
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
