### PR TITLE
Hack around unset document in Box's layout computations

### DIFF
--- a/bokehjs/src/coffee/models/layouts/box.coffee
+++ b/bokehjs/src/coffee/models/layouts/box.coffee
@@ -312,7 +312,12 @@ export class Box extends LayoutDOM
   # once with horizontal=true and once with horizontal=false)
   _align_inner_cell_edges_constraints: () ->
     constraints = []
-    if @ in @document.roots()
+
+    # XXX: checking for `@document?` is a temporary hack, because document isn't always
+    # attached properly. However, if document is not attached then we know it can't be
+    # a root, because otherwise add_root() would attach it. All this layout logic should
+    # be part of views instead of models and use is_root, etc.
+    if @document? and @ in @document.roots()
       flattened = @_flatten_cell_edge_variables(@_horizontal)
       for key, variables of flattened
         if variables.length > 1


### PR DESCRIPTION
I feel dirty writing code like this, but I don't see any other option, perhaps besides restoring old logic with invalidating all models every time `children` change (which isn't any better). Now I know why this code was there before. There are two proper solutions to this issue. One is fix document to attach itself to all new objects, which, to my surprise, doesn't work or at least doesn't work early enough. The other is move layout logic to views, but due to `LayoutCanvas` model and lack of `LayoutCanvasView`, it's pretty much impossible right now to do so.

fixes #6261 
