### PR TITLE
Fix regression in legend location

### DIFF
--- a/bokehjs/src/coffee/models/annotations/legend.coffee
+++ b/bokehjs/src/coffee/models/annotations/legend.coffee
@@ -88,8 +88,12 @@ export class LegendView extends AnnotationView
           y = (v_range.end + v_range.start)/2 + legend_height/2
     else if isArray(location) and location.length == 2
       [x, y] = location   # left, bottom wrt panel
-      x += h_range.start
-      y += v_range.start + legend_height
+      if panel.side?
+        x += h_range.start
+        y += v_range.end
+      else
+        x += h_range.start
+        y += v_range.start
 
     x = @plot_view.canvas.vx_to_sx(x)
     y = @plot_view.canvas.vy_to_sy(y)


### PR DESCRIPTION
All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [x] issues: fixes #6142 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

This change makes the origin for legends in the left/right panel be based on the top left corners of the left/right side panels instead of the bottom left corner. This matches the behavior from 0.12.4.