### PR TITLE
fix promblems with render pause/unpause

### DIFF
--- a/bokehjs/src/coffee/models/plots/gmap_plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/gmap_plot_canvas.coffee
@@ -17,7 +17,10 @@ load_google_api = (api_key) ->
 export class GMapPlotCanvasView extends PlotCanvasView
 
   initialize: (options) ->
+    @pause()
+
     super(options)
+
     @zoom_count = 0
 
     mo = @model.plot.map_options
@@ -31,6 +34,8 @@ export class GMapPlotCanvasView extends PlotCanvasView
       if not window._bokeh_gmaps_callback?
         load_google_api(@model.plot.api_key)
       gmaps_ready.connect(() => @request_render())
+
+    @unpause()
 
   update_range: (range_info) ->
     # RESET -------------------------
@@ -47,13 +52,14 @@ export class GMapPlotCanvasView extends PlotCanvasView
 
     # ZOOM ---------------------------
     else if range_info.factor?
-      @pause()
 
       # The zoom count decreases the sensitivity of the zoom. (We could make this user configurable)
       if @zoom_count != 10
         @zoom_count += 1
         return
       @zoom_count = 0
+
+      @pause()
 
       super(range_info)
 
@@ -166,7 +172,7 @@ export class GMapPlotCanvasView extends PlotCanvasView
     @map.setOptions({zoom: @model.plot.map_options.zoom})
     @_set_bokeh_ranges()
 
-  # this method is expected and called by PlotView.render
+  # this method is expected and called by PlotCanvasView.render
   _map_hook: (ctx, frame_box) ->
     [left, top, width, height] = frame_box
     @canvas_view.map_el.style.top    = "#{top}px"

--- a/bokehjs/src/coffee/models/plots/plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.coffee
@@ -42,21 +42,21 @@ export class PlotCanvasView extends DOMView
   view_options: () -> extend({plot_view: @, parent: @}, @options)
 
   pause: () ->
-    if not @is_paused?
-      @is_paused = 1
+    if not @_is_paused?
+      @_is_paused = 1
     else
-      @is_paused += 1
+      @_is_paused += 1
 
   unpause: (immediate=false) ->
-    @is_paused -= 1
-    if @is_paused == 0
+    @_is_paused -= 1
+    if @_is_paused == 0
       if immediate
         @render()
       else
         @request_render()
 
   request_render: () ->
-    if @is_paused? and @is_paused == 0
+    if not @is_paused
       @throttled_render()
     return
 
@@ -128,6 +128,7 @@ export class PlotCanvasView extends DOMView
 
   @getters {
     canvas_overlays: () -> @canvas_view.overlays_el
+    is_paused: () -> @_is_paused? and @_is_paused != 0
   }
 
   init_webgl: () ->
@@ -507,7 +508,7 @@ export class PlotCanvasView extends DOMView
       logger.warn('could not set initial ranges')
 
   render: () ->
-    if @is_paused? and @is_paused > 0
+    if @is_paused
       return
 
     logger.trace("PlotCanvas.render() for #{@model.id}")

--- a/bokehjs/test/models/plots/plot_canvas.coffee
+++ b/bokehjs/test/models/plots/plot_canvas.coffee
@@ -99,6 +99,48 @@ describe "PlotCanvas", ->
     for child in children
       expect(child.get_edit_variables.callCount).to.be.equal 1
 
+describe "PlotCanvasView pause", ->
+
+  afterEach ->
+    utils.unstub_canvas()
+    utils.unstub_solver()
+
+  beforeEach ->
+    utils.stub_canvas()
+    utils.stub_solver()
+    @doc = new Document()
+    @plot = new Plot({
+      x_range: new Range1d({start: 0, end: 1})
+      y_range: new Range1d({start: 0, end: 1})
+      toolbar: new Toolbar()
+      title: null
+    })
+    @plot_view = new @plot.default_view({model: @plot, parent: null})
+    @doc.add_root(@plot)
+    @plot_canvas = new PlotCanvas({plot: @plot})
+    @plot_canvas.attach_document(@doc)
+    @plot_canvas_view = new @plot_canvas.default_view({model: @plot_canvas, parent: @plot_view})
+
+  it "should start unpaused", ->
+    expect(@plot_canvas_view.is_paused).to.be.false
+
+  it "should toggle on/off in pairs", ->
+    expect(@plot_canvas_view.is_paused).to.be.false
+    @plot_canvas_view.pause()
+    expect(@plot_canvas_view.is_paused).to.be.true
+    @plot_canvas_view.unpause()
+    expect(@plot_canvas_view.is_paused).to.be.false
+
+  it "should toggle off only on last unpause with nested pairs", ->
+    expect(@plot_canvas_view.is_paused).to.be.false
+    @plot_canvas_view.pause()
+    expect(@plot_canvas_view.is_paused).to.be.true
+    @plot_canvas_view.pause()
+    expect(@plot_canvas_view.is_paused).to.be.true
+    @plot_canvas_view.unpause()
+    expect(@plot_canvas_view.is_paused).to.be.true
+    @plot_canvas_view.unpause()
+    expect(@plot_canvas_view.is_paused).to.be.false
 
 describe "PlotCanvas constraints", ->
 


### PR DESCRIPTION
issues: fixes #6328

This fixes issues with `pause` and `unpause`. These functions were being called in the `PlotCanvasView` initializer, but *not* in the subclass `GMapPlotView` initializer. This could result in calls to `request_render` too early.  Specifically wrt to gmaps, this could cause `_build_map` to be called before the plot was otherwise initialized and ready to render, which in turn results in a blank gmap. 

To fix pause/unpause for now, needed to change from simple boolean to a condition counter to keep track of "pause level", so that on pause/unpause pair nested in side another (via a function call, say) would be handled correctly. Additionally, put an explicit guard in `render` itself to prevent any renders during a pause regardless of how they were triggered. I don't think this is strictly necessary, but seems like a reasonable preventative measure. 

With this change I am unable to reproduce any issues with gmaps inside or outside of notebooks, with either inline or server resources. 

I also fixed a problem with zoom range updates that could lead to unbalanced pause/unpause. 
