### PR TITLE
Canavandl/svg headless export

### DIFF
--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -669,7 +669,6 @@ def _get_svg(obj):
     webdriver = import_required('selenium.webdriver',
                                 'To use bokeh.io.export you need selenium ' +
                                 '("conda install -c bokeh selenium" or "pip install selenium")')
-
     # assert that phantomjs is in path for webdriver
     detect_phantomjs()
 

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -665,7 +665,7 @@ def export(obj, filename=None):
 
     return os.path.abspath(filename)
 
-def _get_svg(obj):
+def _get_svgs(obj):
     webdriver = import_required('selenium.webdriver',
                                 'To use bokeh.io.export you need selenium ' +
                                 '("conda install -c bokeh selenium" or "pip install selenium")')
@@ -700,7 +700,7 @@ def export_svgs(obj, filename=None):
     ''' Export the LayoutDOM object as a PNG.
 
     If the filename is not given, it is derived from the script name
-    (e.g. ``/foo/myplot.py`` will create ``/foo/myplot.png``)
+    (e.g. ``/foo/myplot.py`` will create ``/foo/myplot.svg``)
 
     Args:
         obj (LayoutDOM object) : a Layout (Row/Column), Plot or Widget object to display
@@ -719,7 +719,7 @@ def export_svgs(obj, filename=None):
         Glyphs that are rendered via webgl won't be included in the generated PNG.
 
     '''
-    svgs = _get_svg(obj)
+    svgs = _get_svgs(obj)
 
     if len(svgs) == 0:
         logger.warn("No SVG Plots were found.")

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -710,7 +710,7 @@ def export_svgs(obj, filename=None):
             If None, infer from the filename.
 
     Returns:
-        filename (str) : the filename or list of filenames where the SVGs files
+        filenames (list(str)) : the list of filenames where the SVGs files
             are saved.
 
     .. warning::
@@ -727,6 +727,8 @@ def export_svgs(obj, filename=None):
     if filename is None:
         filename = _detect_filename("svg")
 
+    filenames = []
+
     for i, svg in enumerate(svgs):
         if i == 0:
             filename = filename
@@ -736,3 +738,7 @@ def export_svgs(obj, filename=None):
 
         with io.open(filename, mode="w", encoding="utf-8") as f:
             f.write(svg)
+
+        filenames.append(filename)
+
+    return filenames

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -682,7 +682,7 @@ def _get_svg(obj):
 
     svg_script = """
     var serialized_svgs = [];
-    var svgs = document.getElementsByTagName("svg");
+    var svgs = document.getElementsByClassName('bk-root')[0].getElementsByTagName("svg");
     for (var i = 0; i < svgs.length; i++) {
         var source = (new XMLSerializer()).serializeToString(svgs[i]);
         serialized_svgs.push(source);

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -697,7 +697,8 @@ def _get_svgs(obj):
     return svgs
 
 def export_svgs(obj, filename=None):
-    ''' Export the LayoutDOM object as a PNG.
+    ''' Export the SVG-enabled plots within a layout. Each plot will result
+    in a distinct SVG file.
 
     If the filename is not given, it is derived from the script name
     (e.g. ``/foo/myplot.py`` will create ``/foo/myplot.svg``)
@@ -709,14 +710,12 @@ def export_svgs(obj, filename=None):
             If None, infer from the filename.
 
     Returns:
-        filename (str) : the filename where the static file is saved.
+        filename (str) : the filename or list of filenames where the SVGs files
+            are saved.
 
     .. warning::
         Responsive sizing_modes may generate layouts with unexpected size and
         aspect ratios. It is recommended to use the default ``fixed`` sizing mode.
-
-    .. warning::
-        Glyphs that are rendered via webgl won't be included in the generated PNG.
 
     '''
     svgs = _get_svgs(obj)

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -601,11 +601,11 @@ def _crop_image(image, left=0, top=0, right=0, bottom=0, **kwargs):
 
 def _get_screenshot_as_png(obj):
     webdriver = import_required('selenium.webdriver',
-                                'To use bokeh.io.export you need selenium ' +
+                                'To use bokeh.io.export_png you need selenium ' +
                                 '("conda install -c bokeh selenium" or "pip install selenium")')
 
     Image = import_required('PIL.Image',
-                            'To use bokeh.io.export you need pillow ' +
+                            'To use bokeh.io.export_png you need pillow ' +
                             '("conda install pillow" or "pip install pillow")')
     # assert that phantomjs is in path for webdriver
     detect_phantomjs()
@@ -633,7 +633,7 @@ def _get_screenshot_as_png(obj):
 
     return cropped_image
 
-def export(obj, filename=None):
+def export_png(obj, filename=None):
     ''' Export the LayoutDOM object as a PNG.
 
     If the filename is not given, it is derived from the script name
@@ -667,7 +667,7 @@ def export(obj, filename=None):
 
 def _get_svgs(obj):
     webdriver = import_required('selenium.webdriver',
-                                'To use bokeh.io.export you need selenium ' +
+                                'To use bokeh.io.export_svgs you need selenium ' +
                                 '("conda install -c bokeh selenium" or "pip install selenium")')
     # assert that phantomjs is in path for webdriver
     detect_phantomjs()

--- a/bokeh/tests/test_io.py
+++ b/bokeh/tests/test_io.py
@@ -312,3 +312,23 @@ def test__get_screenshot_as_png():
     assert png.size == (2, 2)
     # a 2x2px image of transparent pixels
     assert png.tobytes() == b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+
+def test__get_svgs_no_svg_present():
+    layout = Plot(x_range=Range1d(), y_range=Range1d(),
+              plot_height=2, plot_width=2, toolbar_location=None)
+
+    svgs = io._get_svgs(layout)
+    assert svgs == []
+
+def test__get_svgs_with_svg_present():
+    layout = Plot(x_range=Range1d(), y_range=Range1d(),
+                  plot_height=2, plot_width=2, toolbar_location=None,
+                  outline_line_color=None, border_fill_color=None,
+                  background_fill_color=None, output_backend="svg")
+
+    svgs = io._get_svgs(layout)
+    assert svgs[0] == ('<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" '
+                       'width="10" height="10" style="width: 10px; height: 10px;"><defs/><g><g/><g transform="scale(1,1) '
+                       'translate(0.5,0.5)"><rect fill="#FFFFFF" stroke="none" x="0" y="0" width="10" '
+                       'height="10"/><g/><g/><g/><g/></g><g transform="scale(1,1) translate(0.5,0.5)"><rect fill="#FFFFFF" '
+                       'stroke="none" x="0" y="0" width="10" height="10"/><g/><g/><g/><g/></g></g></svg>')

--- a/sphinx/source/docs/user_guide/export.rst
+++ b/sphinx/source/docs/user_guide/export.rst
@@ -9,9 +9,10 @@ PNG Generation
 --------------
 
 Bokeh can generate RGBA-format Portable Network Graphics (PNG) images from
-layouts using the |export| function. This functionality uses a headless browser
-called WebKit to render the layout in memory and then capture a screenshot. The
-generated image will be of the same dimensions as the source layout.
+layouts using the |export_png| function. This functionality uses a headless
+browser called WebKit to render the layout in memory and then capture a
+screenshot. The generated image will be of the same dimensions as the source
+layout.
 
 In order to create a PNG with a transparent background, users should set the
 ``Plot.background_fill_color`` and ``Plot.border_fill_color`` properties to
@@ -48,9 +49,9 @@ Usage is similar to the |save| and |show| functions.
 
 .. code-block:: python
 
-    from bokeh.io import export
+    from bokeh.io import export_png
 
-    export(plot, filename="plot.png")
+    export_png(plot, filename="plot.png")
 
 .. image:: /_images/unemployment.png
 
@@ -119,7 +120,7 @@ SVG-enabled plots within a layout as distinct SVG files.
     plot.output_backend = "svg"
     export_svgs(plot, filename="plot.svg")
 
-.. image:: /_images/unemployment.png
+.. image:: /_images/unemployment.svg
 
 .. |export_svgs|     replace:: :func:`~bokeh.io.export_svgs`
 .. |export|          replace:: :func:`~bokeh.io.export`

--- a/sphinx/source/docs/user_guide/export.rst
+++ b/sphinx/source/docs/user_guide/export.rst
@@ -95,20 +95,33 @@ to ``"svg"``.
     # option two
     plot.output_backend = "svg"
 
-.. image:: /_images/unemployment.svg
-
 Exporting a SVG Image
 ~~~~~~~~~~~~~~~~~~~~~
 
-The simplest way to export a SVG plot is to install a browser bookmarklet from
-the New York Times called `SVG-Crowbar`_. When clicked, it runs a snippet of
-JavaScript and adds a prompt on the page to download the plot. It's written to
-work with Chrome and should work with Firefox in most cases.
+The simplest method to manually export a SVG plot is to install a browser
+bookmarklet from the New York Times called `SVG-Crowbar`_. When clicked, it
+runs a snippet of JavaScript and adds a prompt on the page to download the
+plot. It's written to work with Chrome and should work with Firefox in most
+cases.
 
 Alternatively, it's possible to download a SVG plot using the ``SaveTool``, but
 the toolbar isn't captured though it figures into the plot layout solver
 calculations. It's not great, but a workable option.
 
+For headless export, there's a utility function, |export_svgs|, which similar
+usage to the |save| and |show| functions. This function will download all of
+SVG-enabled plots within a layout as distinct SVG files.
+
+.. code-block:: python
+
+    from bokeh.io import export_svgs
+
+    plot.output_backend = "svg"
+    export_svgs(plot, filename="plot.svg")
+
+.. image:: /_images/unemployment.png
+
+.. |export_svgs|     replace:: :func:`~bokeh.io.export_svgs`
 .. |export|          replace:: :func:`~bokeh.io.export`
 .. |save|            replace:: :func:`~bokeh.io.save`
 .. |show|            replace:: :func:`~bokeh.io.show`

--- a/sphinx/source/docs/user_guide/export.rst
+++ b/sphinx/source/docs/user_guide/export.rst
@@ -29,7 +29,7 @@ it's suggested to use the default ``Plot.webgl=True`` attribute.
 Additional dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-In order to use the |export_png| function, users have to install some 
+In order to use the |export_png| function, users have to install some
 additional dependencies. These dependencies can be installed via conda:
 
 .. code-block:: sh

--- a/sphinx/source/docs/user_guide/export.rst
+++ b/sphinx/source/docs/user_guide/export.rst
@@ -29,8 +29,8 @@ it's suggested to use the default ``Plot.webgl=True`` attribute.
 Additional dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-In order to use the |export| function, users have to install some additional
-dependencies. These dependencies can be installed via conda:
+In order to use the |export_png| function, users have to install some 
+additional dependencies. These dependencies can be installed via conda:
 
 .. code-block:: sh
 
@@ -123,7 +123,7 @@ SVG-enabled plots within a layout as distinct SVG files.
 .. image:: /_images/unemployment.svg
 
 .. |export_svgs|     replace:: :func:`~bokeh.io.export_svgs`
-.. |export|          replace:: :func:`~bokeh.io.export`
+.. |export_png|      replace:: :func:`~bokeh.io.export`
 .. |save|            replace:: :func:`~bokeh.io.save`
 .. |show|            replace:: :func:`~bokeh.io.show`
 


### PR DESCRIPTION
- [x] issues: related #6345 
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

The main point of discussion is that I have this functionality as a separate function than ``bokeh.io.export``. Is that the correct idea? I think it is because A) users would potentially want a PNG screenshot of an SVG plot-containing layout and B) the product is different enough (a single PNG vs multiple SVGs) that I think it'd cause confusion if they were the same method. Perhaps we'd better rename ``export`` to ``export_as_png``?
