### PR TITLE
Do not over-execute range slider render

### DIFF
--- a/bokehjs/src/coffee/models/widgets/range_slider.coffee
+++ b/bokehjs/src/coffee/models/widgets/range_slider.coffee
@@ -14,7 +14,10 @@ export class RangeSliderView extends InputWidgetView
 
   initialize: (options) ->
     super(options)
-    @connect(@model.change, () -> @render())
+    @connect(@model.properties.start.change, () -> @_render())
+    @connect(@model.properties.end.change, () -> @_render())
+    @connect(@model.properties.step.change, () -> @_render())
+    @connect(@model.properties.orientation.change, () -> @_render())
     @$el.empty()
     html = @template(@model.attributes)
     @$el.html(html)
@@ -26,10 +29,10 @@ export class RangeSliderView extends InputWidgetView
       @callbackWrapper = throttle(() ->
         @model.callback?.execute(@model)
       , @model.callback_throttle)
-    @render()
+    @_render()
 
-  render: () ->
-    super()
+  _render: () ->
+    @render()
     max = @model.end
     min = @model.start
     step = @model.step or ((max - min)/50)


### PR DESCRIPTION
fixes #6123

Not 100% about this solution but it seems like a "good-enough" solution for the immediate term. It makes things usable at all (and for probably most common use cases) until broader jq refactor can take place. 

This code:
```
from bokeh.io import curdoc
from bokeh.models import RangeSlider
from bokeh.plotting import figure

slider = RangeSlider(start=0, end=10, range=(1,9), step=.1, title="Stuff")

def cb(attr, old, new):
    print(slider.range)

slider.on_change('range', cb)

curdoc().add_root(slider)
```

Behaves as expected:

<img width="1107" alt="screen shot 2017-06-04 at 11 03 25" src="https://cloud.githubusercontent.com/assets/1078448/26763284/fc4792aa-4915-11e7-81bf-3eb3a82dc759.png">

