### PR TITLE
add a toggleable property to inspectors

### DIFF
--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -90,7 +90,11 @@ class Inspection(Tool):
     ''' A base class for tools that perform "inspections", e.g. ``HoverTool``.
 
     '''
-    pass
+    toggleable = Bool(True, help="""
+    Whether an on/off toggle button should appear in the toolbar for this
+    inpection tool. If ``False``, the viewers of a plot will not be able to
+    toggle the inspector on or off using the toolbar.
+    """)
 
 @abstract
 class ToolbarBase(LayoutDOM):

--- a/bokehjs/src/coffee/models/tools/inspectors/inspect_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/inspectors/inspect_tool.coffee
@@ -1,9 +1,15 @@
+import * as p from "core/properties"
+
 import {ButtonTool, ButtonToolView} from "../button_tool"
 
 export class InspectToolView extends ButtonToolView
 
 export class InspectTool extends ButtonTool
   event_type: "move"
+
+  @define {
+    toggleable: [ p.Bool, true ]
+  }
 
   @override {
     active: true

--- a/bokehjs/src/coffee/models/tools/toolbar_base.coffee
+++ b/bokehjs/src/coffee/models/tools/toolbar_base.coffee
@@ -30,7 +30,8 @@ export class ToolbarBaseView extends LayoutDOMView
 
     buttons = @el.querySelector(".bk-button-bar-list[type='inspectors']")
     for obj in @model.inspectors
-      buttons.appendChild(new OnOffButtonView({model: obj, parent: @}).el)
+      if obj.toggleable
+        buttons.appendChild(new OnOffButtonView({model: obj, parent: @}).el)
 
     buttons = @el.querySelector(".bk-button-bar-list[type='help']")
     for obj in @model.help


### PR DESCRIPTION
 issues: fixes #6064

Until there is a better solution to consolidating multiple hover tools in toolbars, this feature at least allows users who have multiple hover tools the option of hiding some or all of the buttons in the toolbar. 