### PR TITLE
Bryanv/6398 webgl canvas regression

### DIFF
--- a/bokehjs/src/coffee/models/canvas/canvas.coffee
+++ b/bokehjs/src/coffee/models/canvas/canvas.coffee
@@ -28,7 +28,7 @@ export class CanvasView extends DOMView
     @overlays_el = @el.appendChild(div({class: "bk-canvas-overlays"}))
 
     switch @model.output_backend
-      when "canvas"
+      when "canvas", "webgl"
         @canvas_el = @el.appendChild(canvas({class: "bk-canvas"}))
         @_ctx = @canvas_el.getContext('2d')
       when "svg"


### PR DESCRIPTION
- [x] issues: fixes #6398
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

This PR fixes the missing canvas error.  On safari. some scatter examples still fail with 
```
RuntimeError: RuntimeError:OpenGL got errors (after draw): 1282
```

I believe this was an existing problem on safari, but if there are ideas to fix it I would like to fix it in this PR. 

Would also like to add tests for the canvas creation. 