### PR TITLE
extract data source correctly on line selections

### DIFF
--- a/bokehjs/src/coffee/models/tools/gestures/tap_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/gestures/tap_tool.coffee
@@ -28,9 +28,9 @@ export class TapToolView extends SelectToolView
 
       renderers_by_source = @model._computed_renderers_by_data_source()
 
-      for ds_id, renderers of renderers_by_source
+      for _, renderers of renderers_by_source
         ds = renderers[0].data_source
-        sm = renderers[0].data_source.selection_manager
+        sm = ds.selection_manager
         did_hit = sm.select(@, (@plot_view.renderer_views[r.id] for r in renderers), geometry, final, append)
 
         if did_hit and callback?

--- a/bokehjs/src/coffee/models/tools/gestures/tap_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/gestures/tap_tool.coffee
@@ -28,7 +28,8 @@ export class TapToolView extends SelectToolView
 
       renderers_by_source = @model._computed_renderers_by_data_source()
 
-      for ds, renderers of renderers_by_source
+      for ds_id, renderers of renderers_by_source
+        ds = renderers[0].data_source
         sm = renderers[0].data_source.selection_manager
         did_hit = sm.select(@, (@plot_view.renderer_views[r.id] for r in renderers), geometry, final, append)
 


### PR DESCRIPTION
issues: fixes #6400

The loop was iterating over an object indexed by data source id's and passing the id as the data source to the callback. This PR correctly grabs the actual data source.

<img width="621" alt="screen shot 2017-06-07 at 00 31 48" src="https://user-images.githubusercontent.com/1078448/26863543-d9a1c16c-4b18-11e7-80e4-e6c8d58f1235.png">

If there is any good test that is reasonable to add I'd appreciate suggestions. 