### PR TITLE
make buttons respect disabled property

### DIFF
--- a/bokeh/model.py
+++ b/bokeh/model.py
@@ -279,7 +279,7 @@ class Model(with_metaclass(MetaModel, HasProps, PropertyCallbackManager, EventCa
     help="""A mapping of event names to lists of CustomJS callbacks.
 
     Typically, rather then modifying this property directly, callbacks should be
-    added using the ``Model.js_on_event`` method:)
+    added using the ``Model.js_on_event`` method:
 
     .. code:: python
 
@@ -291,7 +291,7 @@ class Model(with_metaclass(MetaModel, HasProps, PropertyCallbackManager, EventCa
     List of events that are subscribed to by Python callbacks. This is
     the set of events that will be communicated from BokehJS back to
     Python for this model.
-     """   )
+    """)
 
     js_property_callbacks = Dict(String, List(Instance("bokeh.models.callbacks.CustomJS")), help="""
     A mapping of attribute names to lists of CustomJS callbacks, to be set up on

--- a/bokehjs/src/coffee/models/widgets/button.coffee
+++ b/bokehjs/src/coffee/models/widgets/button.coffee
@@ -3,14 +3,10 @@ import {register_with_event, ButtonClick} from "core/bokeh_events"
 
 import {AbstractButton, AbstractButtonView} from "./abstract_button"
 
-
 export class ButtonView extends AbstractButtonView
 
   change_input: () ->
-    @model.trigger_event(new ButtonClick({}))
-    @model.clicks = @model.clicks + 1
-    super()
-
+    @model.click()
 
 export class Button extends AbstractButton
   type: "Button"
@@ -19,5 +15,10 @@ export class Button extends AbstractButton
   @define {
     clicks: [ p.Number, 0 ]
   }
+
+  click: () ->
+    if not @disabled
+      @trigger_event(new ButtonClick({}))
+      @clicks += 1
 
 register_with_event(ButtonClick, Button)

--- a/bokehjs/test/models/widgets/button.coffee
+++ b/bokehjs/test/models/widgets/button.coffee
@@ -1,0 +1,33 @@
+{expect} = require "chai"
+utils = require "../../utils"
+sinon = require "sinon"
+
+{Button} = utils.require("models/widgets/button")
+{Document} = utils.require("document")
+
+describe "Button.click", ->
+
+  it "should trigger on click, if enabled", ->
+    b = new Button()
+    b.attach_document(new Document())
+
+    spy = sinon.spy(b, 'trigger_event')
+
+    expect(spy.called).to.be.false
+    expect(b.clicks).to.be.equal 0
+    b.click()
+    expect(b.clicks).to.be.equal 1
+    expect(spy.callCount).to.be.equal 1
+
+  it "should not trigger on click, if disabled", ->
+    b = new Button()
+    b.disabled = true
+    b.attach_document(new Document())
+
+    spy = sinon.spy(b, 'trigger_event')
+
+    expect(spy.called).to.be.false
+    expect(b.clicks).to.be.equal 0
+    b.click()
+    expect(b.clicks).to.be.equal 0
+    expect(spy.called).to.be.false

--- a/bokehjs/test/models/widgets/index.coffee
+++ b/bokehjs/test/models/widgets/index.coffee
@@ -1,3 +1,4 @@
+require "./button"
 require "./data_table"
 require "./paragraph"
 require "./tabs"

--- a/examples/models/server/buttons.py
+++ b/examples/models/server/buttons.py
@@ -32,8 +32,11 @@ def checkbox_button_group_handler(active):
 def radio_button_group_handler(active):
     print("radio_button_group_handler: %s" % active)
 
-button = Button(label="Button (disabled) - still has click event", button_type="primary", disabled=True)
+button = Button(label="Button (enabled) - has click event", button_type="primary")
 button.on_click(button_handler)
+
+button_disabled = Button(label="Button (disabled) - no click event", button_type="primary", disabled=True)
+button_disabled.on_click(button_handler)
 
 toggle = Toggle(label="Toggle button", button_type="success")
 toggle.on_click(toggle_handler)
@@ -58,7 +61,7 @@ checkbox_button_group.on_click(checkbox_button_group_handler)
 radio_button_group = RadioButtonGroup(labels=["Option 1", "Option 2", "Option 3"], active=0)
 radio_button_group.on_click(radio_button_group_handler)
 
-widgetBox = WidgetBox(children=[button, toggle, dropdown, split, checkbox_group, radio_group, checkbox_button_group, radio_button_group])
+widgetBox = WidgetBox(children=[button, button_disabled, toggle, dropdown, split, checkbox_group, radio_group, checkbox_button_group, radio_button_group])
 
 document = Document()
 document.add_root(widgetBox)


### PR DESCRIPTION
- [x] issues: fixes #6402
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)

ping @bokeh-dev @jlstevens This PR makes it so that buttons with `enabled=False` no longer generate click events. 

Perhaps this merits a migration note?