### PR TITLE
Fix merging of 2d selections

### DIFF
--- a/bokehjs/src/coffee/core/util/object.ts
+++ b/bokehjs/src/coffee/core/util/object.ts
@@ -33,7 +33,7 @@ export function merge<T>(obj1: {[key: string] : Array<T>}, obj2: {[key: string]:
   /*
    * Returns an object with the array values for obj1 and obj2 unioned by key.
    */
-  const result: {[key: string]: Array<T>} = Object.create(null);
+  const result: {[key: string]: Array<T>} = Object.create(Object.prototype);
 
   const keys = concat([Object.keys(obj1), Object.keys(obj2)])
 

--- a/bokehjs/test/core/selector.coffee
+++ b/bokehjs/test/core/selector.coffee
@@ -10,6 +10,11 @@ empty_selection = hittest.create_hit_test_result()
 some_1d_selection = hittest.create_1d_hit_test_result([[0, 1], [1, 2]])
 other_1d_selection = hittest.create_1d_hit_test_result([[4, 1], [5, 2]])
 
+some_2d_selection = hittest.create_hit_test_result()
+some_2d_selection['2d']['indices'] = {2: [0, 1]}
+other_2d_selection = hittest.create_hit_test_result()
+other_2d_selection['2d']['indices'] = {2: [2, 3]}
+
 describe "Selector", ->
 
   it "should be constructable", ->
@@ -32,6 +37,18 @@ describe "Selector", ->
     s.update(some_1d_selection, true, true)
     s.update(other_1d_selection, true, true)
     expect(s.indices['1d'].indices).to.be.deep.equal [0, 1, 4, 5]
+
+  it "should update 2d selections with append=false", ->
+    s = new Selector()
+    s.update(some_2d_selection, true, false)
+    s.update(other_2d_selection, true, false)
+    expect(s.indices['2d'].indices).to.be.deep.equal {2: [2, 3]}
+
+  it "should merge 2d selections with append=true", ->
+    s = new Selector()
+    s.update(some_2d_selection, true, true)
+    s.update(other_2d_selection, true, true)
+    expect(s.indices['2d'].indices).to.be.deep.equal {2: [0, 1, 2, 3]}
 
   it "should be clearable", ->
     s = new Selector()


### PR DESCRIPTION
This PR fixes the merging of 2d selections. The merge function was moved into object.ts from hittest in [PR 6202](https://github.com/bokeh/bokeh/pull/6202). Before the move, the result of merge was created by `result = {}`. When it was moved to typescript, it became `result = Object.create(null)`. But `result = {}` creates an object whose prototype is Object.prototype, so in object.ts, it should be `result = Object.create(Object.prototype)`. We need the returned object to have Object methods, like `hasOwnProperty`. 

The test "Selector should merge 2d selections with append=true" fails before the change.  

```
  1) Selector should merge 2d selections with append=true:
     TypeError: obj1.hasOwnProperty is not a function
      at Object.merge (build/js/tree/core/util/object.js:43:25)
      at HitTestResult.exports.HitTestResult.HitTestResult.update_through_union (build/js/tree/core/hittest.js:63:46)
      at Selector.exports.Selector.Selector.update (build/js/tree/core/selector.js:27:21)
      at Context.<anonymous> (test/core/selector.coffee:73:9)
```

- [x] issues: fixes #6433 
- [x] tests added / passed
