### PR TITLE
protect against exceptions when running inline code

### DIFF
--- a/bokeh/core/_templates/autoload_js.js
+++ b/bokeh/core/_templates/autoload_js.js
@@ -32,8 +32,12 @@ calls it with the rendered model.
   {% endblock %}
 
   function run_callbacks() {
-    window._bokeh_onload_callbacks.forEach(function(callback) { callback() });
-    delete window._bokeh_onload_callbacks
+    try {
+      window._bokeh_onload_callbacks.forEach(function(callback) { callback() });
+    }
+    finally {
+      delete window._bokeh_onload_callbacks
+    }
     console.info("Bokeh: all callbacks have finished");
   }
 


### PR DESCRIPTION
Without this `try/finally` if there is an exception in the the load callback then it is not deleted, and the next time output is attempted, the old callback is tried to run again, again resulting in an error. (i.e. permanently corrupting a notebook until a clear restart)