### PR TITLE
Restore workaround to properly trigger changes in source.data from data_tables

### DIFF
--- a/bokehjs/src/coffee/models/widgets/data_table.coffee
+++ b/bokehjs/src/coffee/models/widgets/data_table.coffee
@@ -99,8 +99,7 @@ export class DataTableView extends WidgetView
     @grid.invalidate()
     @grid.render()
 
-    # XXX: Workaround for `@model.source.trigger('change')` not triggering an event within python.
-    # But we still need it to trigger render updates
+    # This is only needed to call @_tell_document_about_change()
     @model.source.data = @model.source.data
     @model.source.change.emit()
 

--- a/bokehjs/src/coffee/models/widgets/data_table.coffee
+++ b/bokehjs/src/coffee/models/widgets/data_table.coffee
@@ -99,6 +99,11 @@ export class DataTableView extends WidgetView
     @grid.invalidate()
     @grid.render()
 
+    # XXX: Workaround for `@model.source.trigger('change')` not triggering an event within python.
+    # But we still need it to trigger render updates
+    @model.source.data = @model.source.data
+    @model.source.change.emit()
+
   updateSelection: () ->
     if @in_selection_update
       return

--- a/bokehjs/test/models/widgets/data_table.coffee
+++ b/bokehjs/test/models/widgets/data_table.coffee
@@ -144,7 +144,7 @@ describe "data_table module", ->
       expect(r).to.equal null
       expect(dp.source.data).to.deep.equal {index: [0,1,100,10], bar: [3.4, 1.2, 200, -10]}
 
-    it "should set fields when sorted", ->
+    it "should set items when sorted", ->
       source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
       dp = new DataProvider(source)
       fake_col = {sortAsc: true, sortCol: {field: "bar"}}


### PR DESCRIPTION
Restore workaround to properly trigger changes in source.data 
Fix typo in tests for data_table.setItem

The workaround used was restored from 260f5765b63060b60680f7f3c7e91df0a5ed637e using the new emit API.


- [x] issues: fixes #6478 
- [ ] tests added / passed

