### PR TITLE
add mark for tests needing selenium and support pytest --unmarked

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ script:
       py.test -s -m js;
     fi
   - if [[ -z "$TRAVIS_TAG" && "$GROUP" == unit ]]; then
-      py.test --rerun=5 -m 'not (examples or js or integration or quality)' --cov=bokeh --cov-config=bokeh/.coveragerc;
+      py.test --rerun=5 -m 'unit or selenium' --cov=bokeh --cov-config=bokeh/.coveragerc;
     fi
 
   # examples tests

--- a/bokeh/command/subcommands/tests/test_png.py
+++ b/bokeh/command/subcommands/tests/test_png.py
@@ -67,6 +67,7 @@ bokeh png: error: %s
 """ % (too_few)
         assert out == ""
 
+@pytest.mark.unit
 @pytest.mark.selenium
 def test_basic_script(capsys):
     def run(dirname):
@@ -81,6 +82,7 @@ def test_basic_script(capsys):
     with_directory_contents({ 'scatter.py' : basic_scatter_script },
                             run)
 
+@pytest.mark.unit
 @pytest.mark.selenium
 def test_basic_script_with_output_after(capsys):
     def run(dirname):
@@ -94,6 +96,8 @@ def test_basic_script_with_output_after(capsys):
 
     with_directory_contents({ 'scatter.py' : basic_scatter_script },
                             run)
+
+@pytest.mark.unit
 @pytest.mark.selenium
 def test_basic_script_with_output_before(capsys):
     def run(dirname):

--- a/bokeh/command/subcommands/tests/test_png.py
+++ b/bokeh/command/subcommands/tests/test_png.py
@@ -67,6 +67,7 @@ bokeh png: error: %s
 """ % (too_few)
         assert out == ""
 
+@pytest.mark.selenium
 def test_basic_script(capsys):
     def run(dirname):
         with WorkingDir(dirname):
@@ -80,6 +81,7 @@ def test_basic_script(capsys):
     with_directory_contents({ 'scatter.py' : basic_scatter_script },
                             run)
 
+@pytest.mark.selenium
 def test_basic_script_with_output_after(capsys):
     def run(dirname):
         with WorkingDir(dirname):
@@ -92,7 +94,7 @@ def test_basic_script_with_output_after(capsys):
 
     with_directory_contents({ 'scatter.py' : basic_scatter_script },
                             run)
-
+@pytest.mark.selenium
 def test_basic_script_with_output_before(capsys):
     def run(dirname):
         with WorkingDir(dirname):

--- a/bokeh/command/subcommands/tests/test_svg.py
+++ b/bokeh/command/subcommands/tests/test_svg.py
@@ -67,6 +67,7 @@ bokeh svg: error: %s
 """ % (too_few)
         assert out == ""
 
+@pytest.mark.unit
 @pytest.mark.selenium
 def test_basic_script(capsys):
     def run(dirname):
@@ -81,6 +82,7 @@ def test_basic_script(capsys):
     with_directory_contents({ 'scatter.py' : basic_svg_scatter_script },
                             run)
 
+@pytest.mark.unit
 @pytest.mark.selenium
 def test_basic_script_with_output_after(capsys):
     def run(dirname):
@@ -95,6 +97,7 @@ def test_basic_script_with_output_after(capsys):
     with_directory_contents({ 'scatter.py' : basic_svg_scatter_script },
                             run)
 
+@pytest.mark.unit
 @pytest.mark.selenium
 def test_basic_script_with_output_before(capsys):
     def run(dirname):

--- a/bokeh/command/subcommands/tests/test_svg.py
+++ b/bokeh/command/subcommands/tests/test_svg.py
@@ -67,6 +67,7 @@ bokeh svg: error: %s
 """ % (too_few)
         assert out == ""
 
+@pytest.mark.selenium
 def test_basic_script(capsys):
     def run(dirname):
         with WorkingDir(dirname):
@@ -80,6 +81,7 @@ def test_basic_script(capsys):
     with_directory_contents({ 'scatter.py' : basic_svg_scatter_script },
                             run)
 
+@pytest.mark.selenium
 def test_basic_script_with_output_after(capsys):
     def run(dirname):
         with WorkingDir(dirname):
@@ -93,6 +95,7 @@ def test_basic_script_with_output_after(capsys):
     with_directory_contents({ 'scatter.py' : basic_svg_scatter_script },
                             run)
 
+@pytest.mark.selenium
 def test_basic_script_with_output_before(capsys):
     def run(dirname):
         with WorkingDir(dirname):

--- a/bokeh/tests/test_io.py
+++ b/bokeh/tests/test_io.py
@@ -305,6 +305,7 @@ def test__crop_image():
     cropped = io._crop_image(image, **rect)
     assert cropped.size == (6,4)
 
+@pytest.mark.selenium
 def test__get_screenshot_as_png():
     layout = Plot(x_range=Range1d(), y_range=Range1d(),
                   plot_height=20, plot_width=20, toolbar_location=None,
@@ -316,6 +317,7 @@ def test__get_screenshot_as_png():
     # a 20x20px image of transparent pixels
     assert png.tobytes() == ("\x00"*1600).encode()
 
+@pytest.mark.selenium
 def test__get_screenshot_as_png_with_driver():
     layout = Plot(x_range=Range1d(), y_range=Range1d(),
                   plot_height=20, plot_width=20, toolbar_location=None,
@@ -333,6 +335,7 @@ def test__get_screenshot_as_png_with_driver():
     # a 20x20px image of transparent pixels
     assert png.tobytes() == ("\x00"*1600).encode()
 
+@pytest.mark.selenium
 def test__get_svgs_no_svg_present():
     layout = Plot(x_range=Range1d(), y_range=Range1d(),
               plot_height=20, plot_width=20, toolbar_location=None)
@@ -340,6 +343,7 @@ def test__get_svgs_no_svg_present():
     svgs = io._get_svgs(layout, None)
     assert svgs == []
 
+@pytest.mark.selenium
 def test__get_svgs_with_svg_present():
     layout = Plot(x_range=Range1d(), y_range=Range1d(),
                   plot_height=20, plot_width=20, toolbar_location=None,
@@ -351,6 +355,7 @@ def test__get_svgs_with_svg_present():
                        'width="20" height="20" style="width: 20px; height: 20px;"><defs/><g><g/><g transform="scale(1,1) '
                        'translate(0.5,0.5)"><rect fill="#FFFFFF" stroke="none" x="0" y="0" width="20" height="20"/><g/><g/><g/><g/></g></g></svg>')
 
+@pytest.mark.selenium
 def test__get_svgs_with_svg_present_with_driver():
     layout = Plot(x_range=Range1d(), y_range=Range1d(),
                   plot_height=20, plot_width=20, toolbar_location=None,

--- a/bokeh/tests/test_io.py
+++ b/bokeh/tests/test_io.py
@@ -305,6 +305,7 @@ def test__crop_image():
     cropped = io._crop_image(image, **rect)
     assert cropped.size == (6,4)
 
+@pytest.mark.unit
 @pytest.mark.selenium
 def test__get_screenshot_as_png():
     layout = Plot(x_range=Range1d(), y_range=Range1d(),
@@ -317,6 +318,7 @@ def test__get_screenshot_as_png():
     # a 20x20px image of transparent pixels
     assert png.tobytes() == ("\x00"*1600).encode()
 
+@pytest.mark.unit
 @pytest.mark.selenium
 def test__get_screenshot_as_png_with_driver():
     layout = Plot(x_range=Range1d(), y_range=Range1d(),
@@ -335,6 +337,7 @@ def test__get_screenshot_as_png_with_driver():
     # a 20x20px image of transparent pixels
     assert png.tobytes() == ("\x00"*1600).encode()
 
+@pytest.mark.unit
 @pytest.mark.selenium
 def test__get_svgs_no_svg_present():
     layout = Plot(x_range=Range1d(), y_range=Range1d(),
@@ -343,6 +346,7 @@ def test__get_svgs_no_svg_present():
     svgs = io._get_svgs(layout, None)
     assert svgs == []
 
+@pytest.mark.unit
 @pytest.mark.selenium
 def test__get_svgs_with_svg_present():
     layout = Plot(x_range=Range1d(), y_range=Range1d(),
@@ -355,6 +359,7 @@ def test__get_svgs_with_svg_present():
                        'width="20" height="20" style="width: 20px; height: 20px;"><defs/><g><g/><g transform="scale(1,1) '
                        'translate(0.5,0.5)"><rect fill="#FFFFFF" stroke="none" x="0" y="0" width="20" height="20"/><g/><g/><g/><g/></g></g></svg>')
 
+@pytest.mark.unit
 @pytest.mark.selenium
 def test__get_svgs_with_svg_present_with_driver():
     layout = Plot(x_range=Range1d(), y_range=Range1d(),

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -77,7 +77,7 @@ test:
     # jinja2 installed by bokeh
 
     # examples
-    - jupyter
+    - notebook
     - sympy
     - scikit-learn
     - networkx

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = "tests.plugins.implicit_mark"

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ markers =
     js: a javascript test
     quality: a code quality test
     selenium: a test as requiring selenium
+    unit: a python unit test (implicitly assigned for tests otherwise unmarked)
 
 [versioneer]
 # Refer to python-versioneer repository for documentation.

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,11 +19,14 @@ max-line-length = 165
 norecursedirs = build _build node_modules
 python_files = *_tests.py *_test.py test_*.py
 selenium_exclude_debug = html logs
+implicit_marker = unit
 markers =
-    integration: mark a test as an integration test - used for selenium tests
-    cross_browser: mark an integration test to run across multiple browsers (only has an effect when --driver=SauceLabs)
-    js: mark a test as a javascript test
-    examples: mark a test as an examples test
+    cross_browser: an integration test to run across multiple browsers on SauceLabs
+    examples: an examples image-diff test
+    integration: an integration test that runs on Saucelabs
+    js: a javascript test
+    quality: a code quality test
+    selenium: a test as requiring selenium
 
 [versioneer]
 # Refer to python-versioneer repository for documentation.

--- a/sphinx/source/docs/dev_guide/testing.rst
+++ b/sphinx/source/docs/dev_guide/testing.rst
@@ -17,12 +17,12 @@ level of the repository:
 
     py.test -m unit
 
-Note that this excludes unit tests that require Selenium. To execute those
-as well, run the command:
+Note that this includes unit tests that require Selenium to be installed. To
+exclude those unit tests, you can run the command:
 
 .. code-block:: sh
 
-    py.test -m "unit or selenium"
+    py.test -m "unit and not selenium"
 
 To run just the BokehJS unit tests, execute:
 

--- a/sphinx/source/docs/dev_guide/testing.rst
+++ b/sphinx/source/docs/dev_guide/testing.rst
@@ -10,14 +10,19 @@ file descriptors as some of our tests open many files to test the server.
 
     ulimit -n 1024
 
-To run just the python unit tests, run either command:
+To run all the basic python unit tests, run the following command at the top
+level of the repository:
 
 .. code-block:: sh
 
-    py.test -m 'not (js or examples or integration or quality)'
+    py.test -m unit
 
-    python -c 'import bokeh; bokeh.test()'
+Note that this excludes unit tests that require Selenium. To execute those
+as well, run the command:
 
+.. code-block:: sh
+
+    py.test -m "unit or selenium"
 
 To run just the BokehJS unit tests, execute:
 
@@ -25,7 +30,8 @@ To run just the BokehJS unit tests, execute:
 
     py.test -m js
 
-Or, in the `bokehjs` subdirectory of the source checkout.
+Alternatively, you can also navigate to the `bokehjs` subdirectory of the
+source checkout and execute:
 
 .. code-block:: sh
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,10 +6,10 @@ pytest_plugins = (
     "tests.examples.examples_report_plugin",
     "tests.integration.integration_tests_plugin",
     "tests.plugins.bokeh_server",
-    "tests.plugins.jupyter_notebook",
-    "tests.plugins.phantomjs_screenshot",
     "tests.plugins.image_diff",
+    "tests.plugins.jupyter_notebook",
     "tests.plugins.file_server",
+    "tests.plugins.phantomjs_screenshot",
 )
 
 

--- a/tests/plugins/implicit_mark.py
+++ b/tests/plugins/implicit_mark.py
@@ -1,0 +1,25 @@
+from _pytest.mark import matchmark
+
+def pytest_addoption(parser):
+    parser.addini("implicit_marker",
+                  "An implicit marker to assign to any test otherwise unmarked")
+
+def pytest_collection_modifyitems(items, config):
+    implicit_marker = config.getini("implicit_marker")
+    if not implicit_marker:
+        return
+
+    markers = []
+    for line in config.getini("markers"):
+        mark, rest = line.split(":", 1)
+        if '(' in mark:
+            mark, rest = mark.split("(", 1)
+        markers.append(mark)
+
+    all_markers = ' or '.join(markers)
+    if not all_markers:
+        return
+
+    for item in items:
+        if not matchmark(item, all_markers):
+            item.add_marker(implicit_marker)


### PR DESCRIPTION
issues: fixes #6441

Non-integration tests that require selenium can now be selected with `py.test -m selenium` This includes, e.g.some png and svg export unit tests. 

Additionally `py.test -m unit` will run all tests otherwise unmarked (i.e the basic python unit tests)