### PR TITLE
revert conda build to --no-test

### DIFF
--- a/scripts/build_upload.py
+++ b/scripts/build_upload.py
@@ -308,7 +308,7 @@ def check_cdn_creds():
 
 @build_wrapper('conda')
 def build_conda_packages():
-    run("conda build conda.recipe --quiet --build-only")
+    run("conda build conda.recipe --quiet --no-test")
 
 @build_wrapper('sdist')
 def build_sdist_packages():


### PR DESCRIPTION
`--build-only` does not leave build artifacts in `conda-bld/noarch` for whatever reason


Will test with a `0.12.7dev2`