### PR TITLE
send all datetimes to BokehJS timezone-naive

### DIFF
--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -101,7 +101,8 @@ def convert_datetime_type(obj):
 
     # Datetime (datetime is a subclass of date)
     elif isinstance(obj, dt.datetime):
-        return (obj - DT_EPOCH).total_seconds() * 1000. + obj.microsecond / 1000.
+        diff = obj.replace(tzinfo=None) - DT_EPOCH
+        return diff.total_seconds() * 1000. + obj.microsecond / 1000.
 
     # Timedelta (timedelta is class in the datetime library)
     elif isinstance(obj, dt.timedelta):

--- a/bokeh/util/tests/test_serialization.py
+++ b/bokeh/util/tests/test_serialization.py
@@ -6,6 +6,7 @@ import base64
 import pytest
 import numpy as np
 import pandas as pd
+import pytz
 
 import bokeh.util.serialization as bus
 
@@ -59,6 +60,12 @@ def test_convert_datetime_type():
     assert bus.convert_datetime_type(np.timedelta64(3000, 'ms')) == 3000.0
     assert bus.convert_datetime_type(pd.Timedelta("3000ms")) == 3000.0
     assert bus.convert_datetime_type(bus._pd_timestamp(3000000)) == 3.0
+
+def test_convert_datetime_type_with_tz():
+    # This ensures datetimes are sent to BokehJS timezone-naive
+    # see https://github.com/bokeh/bokeh/issues/6480
+    for tz in pytz.all_timezones:
+        assert bus.convert_datetime_type(datetime.datetime(2016, 5, 11, tzinfo=datetime.tzinfo(tz))) == 1462924800000.0
 
 testing = [[float('nan'), 3], [float('-inf'), [float('inf')]]]
 expected = [['NaN', 3.0], ['-Infinity', ['Infinity']]]


### PR DESCRIPTION
- [x] issues: fixes #6480
- [x] tests added / passed

The intent behind this PR is to send all datetime values to BokehJS "as-is". If a user wanted to perform timezone conversion, that could be done explicitly with a custom tick formatter. LAter perhaps we can add optional properties to specify an assumed timezone for the values, as well as a display timezome for automatic conversions when displaying. 