### PR TITLE
add mode for synthetic data if no pyaudio installed

### DIFF
--- a/examples/app/spectrogram/audio.py
+++ b/examples/app/spectrogram/audio.py
@@ -1,11 +1,6 @@
 from __future__ import print_function
 
-try:
-    import pyaudio
-except:
-    print("This demo requires pyaudio installed to function")
-    import sys
-    sys.exit(1)
+from time import sleep
 
 import numpy as np
 import scipy as sp
@@ -20,24 +15,51 @@ NUM_BINS = 16
 
 data = {'values': None}
 
-def _get_audio_data():
-    pa = pyaudio.PyAudio()
-    stream = pa.open(
-        format=pyaudio.paInt16,
-        channels=1,
-        rate=SAMPLING_RATE,
-        input=True,
-        frames_per_buffer=NUM_SAMPLES
-    )
+try:
+    import pyaudio
 
-    while True:
-        try:
-            raw_data  = np.fromstring(stream.read(NUM_SAMPLES), dtype=np.int16)
-            signal = raw_data / 32768.0
+    def update_audio_data():
+        pa = pyaudio.PyAudio()
+        stream = pa.open(
+            format=pyaudio.paInt16,
+            channels=1,
+            rate=SAMPLING_RATE,
+            input=True,
+            frames_per_buffer=NUM_SAMPLES
+        )
+
+        while True:
+            try:
+                raw_data  = np.fromstring(stream.read(NUM_SAMPLES), dtype=np.int16)
+                signal = raw_data / 32768.0
+                fft = sp.fft(signal)
+                spectrum = abs(fft)[:int(NUM_SAMPLES/2)]
+                power = spectrum**2
+                bins = simps(np.split(power, NUM_BINS))
+                data['values'] = signal, spectrum, bins
+            except:
+                continue
+
+except:
+    print()
+    print(" *** Pyaudio package not installed, using synthesized audio data ***")
+    print()
+
+    # These are basically picked out of a hat to show something vaguely interesting
+    _t = np.arange(0, NUM_SAMPLES/SAMPLING_RATE, 1.0/SAMPLING_RATE)
+    _f = 2000 + 3000*(2+np.sin(4*np.linspace(0, 2*np.pi, 500)))
+    _i = 0
+
+    def update_audio_data():
+        while True:
+            global _i
+            A = 0.3 + 0.05 * np.random.random()
+            signal = A*np.sin(2*np.pi*_f[_i]*_t + np.sin(2*np.pi*200*_t))
+
             fft = sp.fft(signal)
-            spectrum = abs(fft)[:NUM_SAMPLES/2]
+            spectrum = abs(fft)[:int(NUM_SAMPLES/2)]
             power = spectrum**2
             bins = simps(np.split(power, NUM_BINS))
             data['values'] = signal, spectrum, bins
-        except:
-            continue
+            _i = (_i + 1) % len(_f)
+            sleep(1.0/12)

--- a/examples/app/spectrogram/server_lifecycle.py
+++ b/examples/app/spectrogram/server_lifecycle.py
@@ -3,6 +3,6 @@ from threading import Thread
 import audio
 
 def on_server_loaded(server_context):
-    t = Thread(target=audio._get_audio_data, args=())
+    t = Thread(target=audio.update_audio_data, args=())
     t.setDaemon(True)
     t.start()


### PR DESCRIPTION
 issues: fixes #5628

Produces this now, when `pyaudio` is not installed:

<img width="971" alt="screen shot 2017-06-19 at 17 26 28" src="https://user-images.githubusercontent.com/1078448/27308638-58e6b44a-5515-11e7-80b0-b99c81eba79d.png">


@philippjfr if you care interested in making the fake data better or more interesting, let me know. 
