### PR TITLE
trigger set_data normally off glyph property changes

### DIFF
--- a/bokehjs/src/coffee/core/has_props.coffee
+++ b/bokehjs/src/coffee/core/has_props.coffee
@@ -90,7 +90,6 @@ export class HasProps
 
     @destroyed = new Signal(this, "destroyed")
     @change = new Signal(this, "change")
-    @propchange = new Signal(this, "propchange")
     @transformchange = new Signal(this, "transformchange")
 
     this.attributes = {}

--- a/bokehjs/src/coffee/core/properties.coffee
+++ b/bokehjs/src/coffee/core/properties.coffee
@@ -26,11 +26,7 @@ export class Property # <T>
     # Signal<T, HasProps>
     @change = new Signal(@obj, "change")
 
-    # TODO (bev) Quick fix, see https://github.com/bokeh/bokeh/pull/2684
-    @connect(@change, () =>
-      @_init()
-      @obj.propchange.emit()
-    )
+    @connect(@change, () => @_init())
 
   update: () -> @_init()
 

--- a/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
+++ b/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
@@ -72,6 +72,7 @@ export class GlyphRendererView extends RendererView
   connect_signals: () ->
     super()
     @connect(@model.change, () -> @request_render())
+    @connect(@model.glyph.change, () -> @set_data())
     @connect(@model.data_source.change, () -> @set_data())
     @connect(@model.data_source.streaming, () -> @set_data())
     @connect(@model.data_source.patching, (indices) -> @set_data(true, indices))
@@ -80,16 +81,6 @@ export class GlyphRendererView extends RendererView
       @connect(@model.data_source.inspect, () -> @request_render())
 
     @connect(@model.glyph.transformchange, () -> @set_data())
-
-    # TODO (bev) This is a quick change that  allows the plot to be
-    # update/re-rendered when properties change on the JS side. It would
-    # be better to make this more fine grained in terms of setting visuals
-    # and also could potentially be improved by making proper models out
-    # of "Spec" properties. See https://github.com/bokeh/bokeh/pull/2684
-    @connect(@model.glyph.propchange, () ->
-        @glyph.set_visuals(@model.data_source)
-        @request_render()
-    )
 
   have_selection_glyphs: () -> @selection_glyph? && @nonselection_glyph?
 


### PR DESCRIPTION
issues: fixes #6185

This removed the gorpy `propchange` signal in favor of calling `set_data` in response to standard property change events. If it's found we need an optimization we can be smarter about it (i.e. by splitting up `set_data` into different pieces, and triggering only what is necessary)
