### PR TITLE
Fix signature() utility function for Python 2.7.9

### DIFF
--- a/bokeh/util/future.py
+++ b/bokeh/util/future.py
@@ -82,8 +82,9 @@ if sys.version_info[:2] < (3, 4):
         elif isinstance(func, partial):
             sig = getargspec(func.func)
             if 'self' in sig.args: sig.args.remove('self')
-            for name in func.keywords.keys():
-                sig.args.remove(name)
+            if func.keywords is not None:
+                for name in func.keywords.keys():
+                    sig.args.remove(name)
             for val in func.args:
                 del sig.args[0]
             return sig


### PR DESCRIPTION
This fixes five unit tests that were broken under Python 2.7.9 (but not under Python 2.7.10+). No new tests were added since it was necessary to change the code to pass existing tests.

List of previously broken tests:
* `test_property_on_change_good_partial_function`
* `test_property_on_change_good_partial_method`
* `test_event_on_change_good_partial_function`
* `test_event_on_change_bad_partial_function`
* `test_event_on_change_good_partial_method`

All tests broke with the same issue:
```
bokeh/util/callback_manager.py:35: in on_event
    _check_callback(callback, ('event',), what='Event callback')
bokeh/util/callback_manager.py:12: in _check_callback
    sig = signature(callback)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

func = <functools.partial object at 0x7f8453a16cb0>

    def signature(func):
        # The modifications in this function are to make results more in line
        # with Python 3, i.e. self is not included in bound methods, supplied
        # parameters are not reported in partial, etc. This simplifies the
        # downstream code considerably.
        from inspect import getargspec, isfunction, ismethod
        from functools import partial

        if isfunction(func) or ismethod(func):
            sig = getargspec(func)
            if ismethod(func):
                sig.args.remove('self')
            return sig

        elif isinstance(func, partial):
            sig = getargspec(func.func)
            if 'self' in sig.args: sig.args.remove('self')
>           for name in func.keywords.keys():
E           AttributeError: 'NoneType' object has no attribute 'keys'

bokeh/util/future.py:85: AttributeError
```

- [o] issues: fixes #6512 
- [o] tests added / passed