### PR TITLE
export GOOGLE_API_KEY in test:docs

### DIFF
--- a/scripts/ci/test:docs
+++ b/scripts/ci/test:docs
@@ -5,5 +5,5 @@ set -x # echo commands
 
 cd sphinx
 
-GOOGLE_API_KEY=${GOOGLE_API_KEY:-"unset"}
+export GOOGLE_API_KEY=${GOOGLE_API_KEY:-"unset"}
 make SPHINXOPTS=-v all


### PR DESCRIPTION
Maybe fixes doc builds for external contributors. cc @bryevdv.