### PR TITLE
6592 webgl save

### DIFF
--- a/bokehjs/src/coffee/models/plots/plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.coffee
@@ -663,7 +663,7 @@ export class PlotCanvasView extends DOMView
       ctx.fillRect(frame_box...)
 
   save: (name) ->
-    if @model.plot.output_backend == "canvas"
+    if @model.plot.output_backend in ["canvas", "webgl"]
       canvas = @canvas_view.get_canvas_element()
       if canvas.msToBlob?
         blob = canvas.msToBlob()

--- a/bokehjs/test/size.ts
+++ b/bokehjs/test/size.ts
@@ -7,7 +7,7 @@ const build_dir = path.normalize(`${__dirname}/../build`)
 
 const LIMITS: {[key: string]: number} = {
   // js
-  "js/bokeh.min.js":           730,
+  "js/bokeh.min.js":           732,
   "js/bokeh-widgets.min.js":    90,
   "js/bokeh-tables.min.js":    200,
   "js/bokeh-api.min.js":        75,

--- a/sphinx/source/docs/user_guide/webgl.rst
+++ b/sphinx/source/docs/user_guide/webgl.rst
@@ -67,7 +67,7 @@ Examples
 
     output_file("scatter10k.html", title="scatter 10k points (no WebGL)")
 
-    p = figure(output_backend="webgl")
+    p = figure(output_backend="canvas")
     p.scatter(x, y, alpha=0.1)
     show(p)
 


### PR DESCRIPTION
Fix save tool when `output_backend= "webgl"`.
Fix webgl docs for the example without webgl.

- [x] issues: fixes #6592 
- [x] tests added / passed
