### PR TITLE
Issue6577_make stream setter accessible only in the private API

### DIFF
--- a/bokeh/document.py
+++ b/bokeh/document.py
@@ -372,7 +372,7 @@ class Document(object):
                 source = self._all_models[source_id]
                 data = event_json['data']
                 rollover = event_json['rollover']
-                source.stream(data, rollover, setter)
+                source._stream(data, rollover, setter)
             elif event_json['kind'] == 'ColumnsPatched':
                 source_id = event_json['column_source']['id']
                 if source_id not in self._all_models:

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -209,7 +209,7 @@ class ColumnDataSource(ColumnarDataSource):
             import warnings
             warnings.warn("Unable to find column '%s' in data source" % name)
 
-    def stream(self, new_data, rollover=None, setter=None):
+    def stream(self, new_data, rollover=None):
         ''' Efficiently update data source columns with new append-only data.
 
         In cases where it is necessary to update data columns in, this method
@@ -227,6 +227,58 @@ class ColumnDataSource(ColumnarDataSource):
                 from the start of the column begins to be discarded. If None,
                 then columns will continue to grow unbounded (default: None)
 
+        Returns:
+            None
+
+        Raises:
+            ValueError
+
+        Example:
+
+        .. code-block:: python
+
+            source = ColumnDataSource(data=dict(foo=[], bar=[]))
+
+            # has new, identical-length updates for all columns in source
+            new_data = {
+                'foo' : [10, 20],
+                'bar' : [100, 200],
+            }
+
+            source.stream(new_data)
+
+        '''
+        # calls internal implementation
+        self._stream(new_data, rollover)
+
+    def _stream(self, new_data, rollover=None, setter=None):
+        ''' Internal implementation to efficiently update data source columns
+        with new append-only data.   The interal implementation adds the setter
+        attribute.  [https://github.com/bokeh/bokeh/issues/6577]
+
+        In cases where it is necessary to update data columns in, this method
+        can efficiently send only the new data, instead of requiring the
+        entire data set to be re-sent.
+
+        Args:
+            new_data (dict[str, seq]) : a mapping of column names to sequences of
+                new data to append to each column.
+
+                All columns of the data source must be present in ``new_data``,
+                with identical-length append data.
+
+            rollover (int, optional) : A maximum column size, above which data
+                from the start of the column begins to be discarded. If None,
+                then columns will continue to grow unbounded (default: None)
+            setter (ClientSession or ServerSession or None, optional) :
+                This is used to prevent "boomerang" updates to Bokeh apps.
+                (default: None)
+                In the context of a Bokeh server application, incoming updates
+                to properties will be annotated with the session that is
+                doing the updating. This value is propagated through any
+                subsequent change notifications that the update triggers.
+                The session can compare the event setter to itself, and
+                suppress any updates that originate from itself.
         Returns:
             None
 

--- a/bokeh/models/tests/test_sources.py
+++ b/bokeh/models/tests/test_sources.py
@@ -119,18 +119,33 @@ class TestColumnDataSource(unittest.TestCase):
             str(cm.exception).startswith("stream(...) only supports 1d sequences, got ndarray with size (")
         )
 
-    def test_stream_good_data(self):
+    def test__stream_good_data(self):
         ds = ColumnDataSource(data=dict(a=[10], b=[20]))
         ds._document = "doc"
         stuff = {}
         mock_setter = object()
+
         def mock(*args, **kw):
             stuff['args'] = args
             stuff['kw'] = kw
         ds.data._stream = mock
-        #internal implementation of stream
+        # internal implementation of stream
         ds._stream(dict(a=[11, 12], b=[21, 22]), "foo", mock_setter)
         self.assertEqual(stuff['args'], ("doc", ds, dict(a=[11, 12], b=[21, 22]), "foo", mock_setter))
+        self.assertEqual(stuff['kw'], {})
+
+    def test_stream_good_data(self):
+        ds = ColumnDataSource(data=dict(a=[10], b=[20]))
+        ds._document = "doc"
+        stuff = {}
+
+        def mock(*args, **kw):
+            stuff['args'] = args
+            stuff['kw'] = kw
+        ds.data._stream = mock
+        # public implementation of stream
+        ds._stream(dict(a=[11, 12], b=[21, 22]), "foo")
+        self.assertEqual(stuff['args'], ("doc", ds, dict(a=[11, 12], b=[21, 22]), "foo", None))
         self.assertEqual(stuff['kw'], {})
 
     def test_patch_bad_columns(self):

--- a/bokeh/models/tests/test_sources.py
+++ b/bokeh/models/tests/test_sources.py
@@ -128,7 +128,8 @@ class TestColumnDataSource(unittest.TestCase):
             stuff['args'] = args
             stuff['kw'] = kw
         ds.data._stream = mock
-        ds.stream(dict(a=[11, 12], b=[21, 22]), "foo", mock_setter)
+        #internal implementation of stream
+        ds._stream(dict(a=[11, 12], b=[21, 22]), "foo", mock_setter)
         self.assertEqual(stuff['args'], ("doc", ds, dict(a=[11, 12], b=[21, 22]), "foo", mock_setter))
         self.assertEqual(stuff['kw'], {})
 


### PR DESCRIPTION
- [x] issues: fixes #6577 
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

Addresses issue 6577 by making the stream setter argument only accessible in a private method (_stream).

test__stream_good_data  tests the private method and 
test_stream_good_data tests the public method.

Tested on linux using 
py.test -m "unit and not selenium"
999 passed
