### PR TITLE
Fix streaming with filterable CDS

### DIFF
--- a/bokehjs/src/coffee/models/sources/cds_view.coffee
+++ b/bokehjs/src/coffee/models/sources/cds_view.coffee
@@ -29,6 +29,8 @@ export class CDSView extends Model
     )
     if @source?.streaming?
       @connect(@source.streaming, () -> @compute_indices())
+    if @source?.patching?
+      @connect(@source.patching, () -> @compute_indices())
 
   compute_indices: () ->
     indices = (filter.compute_indices(@source) for filter in @filters)

--- a/bokehjs/src/coffee/models/sources/cds_view.coffee
+++ b/bokehjs/src/coffee/models/sources/cds_view.coffee
@@ -27,6 +27,8 @@ export class CDSView extends Model
       @compute_indices()
       @change.emit()
     )
+    if @source?.streaming?
+      @connect(@source.streaming, () -> @compute_indices())
 
   compute_indices: () ->
     indices = (filter.compute_indices(@source) for filter in @filters)

--- a/bokehjs/test/models/sources/cds_view.coffee
+++ b/bokehjs/test/models/sources/cds_view.coffee
@@ -61,3 +61,12 @@ describe "CDSView", ->
     it "convert_indices_from_subset", ->
       view = new CDSView({source: cds, filters: [filter1, filter2]})
       expect(view.convert_indices_from_subset([0, 1])).to.be.deep.equal [1, 2]
+
+  it "should update its indices when its source streams new data", ->
+    cds = new ColumnDataSource({data: {x: [], y: []}})
+    new_data = {x: [1], y: [1]}
+
+    view = new CDSView({source: cds})
+    expect(view.indices).to.be.deep.equal([])
+    cds.stream(new_data)
+    expect(view.indices).to.be.deep.equal([0])

--- a/bokehjs/test/models/sources/cds_view.coffee
+++ b/bokehjs/test/models/sources/cds_view.coffee
@@ -4,6 +4,7 @@ utils = require "../../utils"
 {CDSView} = utils.require("models/sources/cds_view")
 {ColumnDataSource} = utils.require("models/sources/column_data_source")
 {Filter} = utils.require("models/filters/filter")
+{GroupFilter} = utils.require("models/filters/group_filter")
 hittest = utils.require("core/hittest")
 
 describe "CDSView", ->
@@ -69,4 +70,13 @@ describe "CDSView", ->
     view = new CDSView({source: cds})
     expect(view.indices).to.be.deep.equal([])
     cds.stream(new_data)
+    expect(view.indices).to.be.deep.equal([0])
+
+  it "should update its indices when its source patches new data", ->
+    cds = new ColumnDataSource({data: {x: ["a"], y: [1]}})
+    group_filter = new GroupFilter({column_name: "x", group: "b"})
+
+    view = new CDSView({source: cds, filters: [group_filter]})
+    expect(view.indices).to.be.deep.equal([])
+    cds.patch({"x" :[[0, "b"]]})
     expect(view.indices).to.be.deep.equal([0])


### PR DESCRIPTION
This PR fixes streaming in the presence of CDSViews. The if statement is to guard against cases where the data source of a renderer is not a columnar data source and therefore doesn't have a `streaming` signal and when there is no data source.

One thing I considered was that for each streaming event, of the CDSView and GlyphRenderer, you would want the CDSView to respond first to update its indices before the GlyphRenderer responds with its set_data. Otherwise the first streaming event would not cause a re-render of the new data. This seems to be what happens (I checked with the following script that streams new_data on a button click), but I don't know if there is a way to guarantee that one slot is called before another one? 

- [x] issues: fixes #6628 
- [x] tests added / passed

```python
from bokeh.layouts import column
from bokeh.models import ColumnDataSource
from bokeh.plotting import curdoc, figure
from bokeh.models.widgets import Button

from numpy import random

source = ColumnDataSource(dict(x=[1], y=[2]))
x_val = 2

p = figure(plot_height=500, tools="xpan,xwheel_zoom,xbox_zoom,reset", y_range=(0, 10))
p.circle(x='x', y='y', source=source)

def add_data():
    global x_val
    new_data = dict(x=[x_val], y=[random.randint(10)])
    source.stream(new_data, 300)
    x_val = x_val + 1
    
button = Button(label="Add")
button.on_click(add_data)

curdoc().add_root(column(p, button))
```