### PR TITLE
re-enable "secrets filter"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ language: generic
 sudo: false
 dist: trusty
 
-# This does not show secret variables, but only disables a filter for accidental spillage. The filter
-# is causing problems with log trunction and TravisCI support advised to turn it off for now. See the
-# issue https://github.com/bokeh/bokeh/issues/6568 for more information.
-filter_secrets: false
-
 env:
   global:
     - BOTO_CONFIG="/tmp/nowhere"


### PR DESCRIPTION
From Travis Support

> This is a follow-up to say that we believe that we have a solution in place for the truncated logs (though not yet for the colorized output). Could you try and remove `filter_secrets: false` from your configuration? Please let us know if you would encounter a truncated log again.

