### PR TITLE
update documentation for `bokeh.models.CrosshairTool`

### DIFF
--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -375,6 +375,10 @@ the current mouse position. The crosshair tool may be configured to draw
 across only one dimension by setting the ``dimensions`` property to a
 list containing ``width`` or ``height``.
 
+The crosshair tool draw dimensions may be configured by setting the 
+``dimensions`` property to a String of ``width``, ``height``, or 
+``both``.
+
 HoverTool
 ~~~~~~~~~
 

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -372,7 +372,7 @@ CrosshairTool
 
 Th crosshair tool draws a crosshair annotation over the plot, centered on
 the current mouse position. The crosshair tool draw dimensions may be
-configured by setting the ``dimensions`` property to a String of on of the
+configured by setting the ``dimensions`` property to one of the
 enumerated values ``width``, ``height``, or ``both``.
 
 HoverTool

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -371,13 +371,9 @@ CrosshairTool
 * menu icon: |crosshair_icon|
 
 Th crosshair tool draws a crosshair annotation over the plot, centered on
-the current mouse position. The crosshair tool may be configured to draw
-across only one dimension by setting the ``dimensions`` property to a
-list containing ``width`` or ``height``.
-
-The crosshair tool draw dimensions may be configured by setting the 
-``dimensions`` property to a String of ``width``, ``height``, or 
-``both``.
+the current mouse position. The crosshair tool draw dimensions may be 
+configured by setting the ``dimensions`` property to a String of on of the
+enumerated values ``width``, ``height``, or ``both``.
 
 HoverTool
 ~~~~~~~~~

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -371,7 +371,7 @@ CrosshairTool
 * menu icon: |crosshair_icon|
 
 Th crosshair tool draws a crosshair annotation over the plot, centered on
-the current mouse position. The crosshair tool draw dimensions may be 
+the current mouse position. The crosshair tool draw dimensions may be
 configured by setting the ``dimensions`` property to a String of on of the
 enumerated values ``width``, ``height``, or ``both``.
 


### PR DESCRIPTION
fixes issue #6651 : minor update to documentation to reflect expected values of `dimensions` attribute of `bokeh.models.CrosshairTool`.