### PR TITLE
Ensure provided and expected signature strings have same encoding

### DIFF
--- a/bokeh/util/session_id.py
+++ b/bokeh/util/session_id.py
@@ -17,6 +17,7 @@ import time
 from six import binary_type
 
 from bokeh.settings import settings
+from bokeh.util.string import encode_utf8
 
 # Use the system PRNG for session id generation (if possible)
 # NOTE: secure random string generation implementation is adapted
@@ -153,6 +154,7 @@ def check_session_id_signature(session_id, secret_key=settings.secret_key_bytes(
         expected_signature = _signature(base_id, secret_key)
         # hmac.compare_digest() uses a string compare algorithm that doesn't
         # short-circuit so we don't allow timing analysis
-        return hmac.compare_digest(expected_signature, provided_signature)
+        # encode_utf8 is used to ensure that strings have same encoding
+        return hmac.compare_digest(encode_utf8(expected_signature), encode_utf8(provided_signature))
     else:
         return True

--- a/bokeh/util/tests/test_session_id.py
+++ b/bokeh/util/tests/test_session_id.py
@@ -92,3 +92,9 @@ class TestSessionId(unittest.TestCase):
         key2 = generate_secret_key()
         self.assertEqual(44, len(key2))
         self.assertNotEqual(key, key2)
+
+    def test_string_encoding_does_not_affect_session_id_check(self):
+        # originates from #6653 
+        session_id = generate_session_id(signed=True, secret_key="abc")
+        self.assertTrue(check_session_id_signature(session_id, secret_key="abc", signed=True))
+        self.assertTrue(check_session_id_signature(session_id.decode('utf-8'), secret_key="abc", signed=True))

--- a/bokeh/util/tests/test_session_id.py
+++ b/bokeh/util/tests/test_session_id.py
@@ -5,6 +5,7 @@ import codecs
 import unittest
 
 import bokeh.util.session_id
+from bokeh.util.string import decode_utf8
 from bokeh.util.session_id import ( generate_session_id,
                                     generate_secret_key,
                                     check_session_id_signature,
@@ -94,7 +95,7 @@ class TestSessionId(unittest.TestCase):
         self.assertNotEqual(key, key2)
 
     def test_string_encoding_does_not_affect_session_id_check(self):
-        # originates from #6653 
+        # originates from #6653
         session_id = generate_session_id(signed=True, secret_key="abc")
         self.assertTrue(check_session_id_signature(session_id, secret_key="abc", signed=True))
-        self.assertTrue(check_session_id_signature(session_id.decode('utf-8'), secret_key="abc", signed=True))
+        self.assertTrue(check_session_id_signature(decode_utf8(session_id), secret_key="abc", signed=True))


### PR DESCRIPTION
Fixes #6653
