### PR TITLE
Fix DataTable resize regression by computing indices when source data changes

### DIFF
--- a/bokehjs/src/coffee/models/sources/cds_view.coffee
+++ b/bokehjs/src/coffee/models/sources/cds_view.coffee
@@ -31,6 +31,10 @@ export class CDSView extends Model
       @connect(@source.streaming, () -> @compute_indices())
     if @source?.patching?
       @connect(@source.patching, () -> @compute_indices())
+    if @source?
+      @connect(@source.properties.data.change, () ->
+        @compute_indices()
+      )
 
   compute_indices: () ->
     indices = (filter.compute_indices(@source) for filter in @filters)

--- a/bokehjs/test/models/sources/cds_view.coffee
+++ b/bokehjs/test/models/sources/cds_view.coffee
@@ -80,3 +80,14 @@ describe "CDSView", ->
     expect(view.indices).to.be.deep.equal([])
     cds.patch({"x" :[[0, "b"]]})
     expect(view.indices).to.be.deep.equal([0])
+
+  it "should update its indices when its source's data changes", ->
+    data1 = {x: ["a"], y: [1]}
+    data2 = {x: ["b"], y: [1]}
+    cds = new ColumnDataSource({data: data1})
+    group_filter = new GroupFilter({column_name: "x", group: "b"})
+
+    view = new CDSView({source: cds, filters: [group_filter]})
+    expect(view.indices).to.be.deep.equal([])
+    cds.data = data2
+    expect(view.indices).to.be.deep.equal([0])

--- a/examples/app/export_csv/main.py
+++ b/examples/app/export_csv/main.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 from bokeh.layouts import row, widgetbox
 from bokeh.models import ColumnDataSource, CustomJS
-from bokeh.models.widgets import Slider, Button, DataTable, TableColumn, NumberFormatter
+from bokeh.models.widgets import RangeSlider, Button, DataTable, TableColumn, NumberFormatter
 from bokeh.io import curdoc
 
 df = pd.read_csv(join(dirname(__file__), 'salary_data.csv'))
@@ -12,14 +12,14 @@ df = pd.read_csv(join(dirname(__file__), 'salary_data.csv'))
 source = ColumnDataSource(data=dict())
 
 def update():
-    current = df[df['salary'] <= slider.value].dropna()
+    current = df[(df['salary'] >= slider.value[0]) & (df['salary'] <= slider.value[1])].dropna()
     source.data = {
         'name'             : current.name,
         'salary'           : current.salary,
         'years_experience' : current.years_experience,
     }
 
-slider = Slider(title="Max Salary", start=10000, end=110000, value=50000, step=1000, format="0,0")
+slider = RangeSlider(title="Max Salary", start=10000, end=110000, value=(10000, 50000), step=1000, format="0,0")
 slider.on_change('value', lambda attr, old, new: update())
 
 button = Button(label="Download", button_type="success")

--- a/examples/app/export_csv/main.py
+++ b/examples/app/export_csv/main.py
@@ -19,7 +19,7 @@ def update():
         'years_experience' : current.years_experience,
     }
 
-slider = Slider(title="Max Salary", start=10000, end=250000, value=150000, step=1000)
+slider = Slider(title="Max Salary", start=10000, end=110000, value=50000, step=1000, format="0,0")
 slider.on_change('value', lambda attr, old, new: update())
 
 button = Button(label="Download", button_type="success")


### PR DESCRIPTION
This PR fixes the DataTable resize regression. It also updates the export_csv app, so that the range of the slider better matches the example data. 

- [x] issues: fixes #6642
- [x] tests added / passed
