### PR TITLE
Removed hard-coded zoom levels on Mercator Tile calculations

### DIFF
--- a/bokehjs/src/coffee/models/tiles/mercator_tile_source.coffee
+++ b/bokehjs/src/coffee/models/tiles/mercator_tile_source.coffee
@@ -16,7 +16,7 @@ export class MercatorTileSource extends TileSource
 
   initialize: (options) ->
     super(options)
-    @_resolutions = (@get_resolution(z) for z in [0..30])
+    @_resolutions = (@get_resolution(z) for z in [@min_zoom..@max_zoom])
 
   _computed_initial_resolution: () ->
     if @initial_resolution?


### PR DESCRIPTION
- [ ] issues: fixes #6709 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

Removed the hard coded 0 and 30 for Zoom levels during resolution calculation, and used the preconfigured min_zoom and max_zoom options, which are defaulted to 0 and 30, but are configurable when defining the tile source.