### PR TITLE
Add support for special color transparency in ColorMapper

### DIFF
--- a/bokehjs/src/coffee/core/util/color.coffee
+++ b/bokehjs/src/coffee/core/util/color.coffee
@@ -11,9 +11,12 @@ export color2hex = (color) ->
   else if svg_colors[color]?
     return svg_colors[color]
   else if color.indexOf('rgb') == 0
-    rgb = color.match(/\d+/g)
-    hex = (_component2hex(v) for v in rgb).join('')
-    return '#' + hex.slice(0, 8)  # can also be rgba
+    rgb = color.replace(/^rgba?\(|\s+|\)$/g,'').split(',')
+    hex = (_component2hex(v) for v in rgb.slice(0, 3)).join('')
+    if rgb.length == 4
+      hex = hex + _component2hex(Math.floor(parseFloat(rgb.slice(3)) * 255))
+    hex_string = '#' + hex.slice(0, 8)  # can also be rgba
+    return hex_string
   else
     return color
 

--- a/bokehjs/src/coffee/models/mappers/color_mapper.coffee
+++ b/bokehjs/src/coffee/models/mappers/color_mapper.coffee
@@ -31,7 +31,7 @@ export class ColorMapper extends Transform
         ind = i*4
         # Bitwise math in JS is limited to 31-bits, to handle 32-bit value
         # this uses regular math to compute alpha instead (see issue #6755)
-        color[ind] = parseInt((value/4278190080.0) * 255)
+        color[ind] = Math.floor((value/4278190080.0) * 255)
         color[ind+1] = (value & 0xff0000) >> 16
         color[ind+2] = (value & 0xff00) >> 8
         color[ind+3] = value & 0xff

--- a/bokehjs/src/coffee/models/mappers/color_mapper.coffee
+++ b/bokehjs/src/coffee/models/mappers/color_mapper.coffee
@@ -29,6 +29,8 @@ export class ColorMapper extends Transform
       for i in [0...data.length]
         value = values[i]
         ind = i*4
+        # Bitwise math in JS is limited to 31-bits, to handle 32-bit value
+        # this uses regular math to compute alpha instead (see issue #6755)
         color[ind] = parseInt((value/4278190080.0) * 255)
         color[ind+1] = (value & 0xff0000) >> 16
         color[ind+2] = (value & 0xff00) >> 8

--- a/bokehjs/src/coffee/models/mappers/color_mapper.coffee
+++ b/bokehjs/src/coffee/models/mappers/color_mapper.coffee
@@ -24,17 +24,17 @@ export class ColorMapper extends Transform
   v_map_screen: (data, image_glyph=false) ->
     values = @_get_values(data, @_palette, image_glyph)
     buf = new ArrayBuffer(data.length * 4)
-    color = new Uint32Array(buf)
-
     if @_little_endian
+      color = new Uint8Array(buf)
       for i in [0...data.length]
         value = values[i]
-        color[i] =
-          (0xff << 24)                   | # alpha
-          ((value & 0xff0000) >> 16)     | # blue
-          (value & 0xff00)               | # green
-          ((value & 0xff) << 16);          # red
+        ind = i*4
+        color[ind] = parseInt((value/4278190080.0) * 255)
+        color[ind+1] = (value & 0xff0000) >> 16
+        color[ind+2] = (value & 0xff00) >> 8
+        color[ind+3] = value & 0xff
     else
+      color = new Uint32Array(buf)
       for i in [0...data.length]
         value = values[i]
         color[i] = (value << 8) | 0xff     # alpha
@@ -70,6 +70,8 @@ export class ColorMapper extends Transform
       if isNumber(value)
         return value
       else
+        if value.length != 9
+          value = value + 'ff'
         return parseInt(value.slice(1), 16)
     for i in [0...palette.length]
       new_palette[i] = _convert(palette[i])

--- a/bokehjs/test/core/util/color.coffee
+++ b/bokehjs/test/core/util/color.coffee
@@ -51,7 +51,8 @@ describe "color module", ->
   it "should turn rgba() colors to tuples, overriding alpha", ->
     expect(color.color2rgba('rgba(0, 0, 0, 0)')).to.eql [0, 0, 0, 0]
     expect(color.color2rgba('rgba(0, 0, 0, 0)', 0.5)).to.eql [0, 0, 0, 0]
-    expect(color.color2rgba('rgba(255, 0, 0, 255)', 0.5)).to.eql [1, 0, 0, 1]
+    expect(color.color2rgba('rgba(255, 0, 0, 1)', 0.5)).to.eql [1, 0, 0, 1]
+    expect(color.color2rgba('rgba(255, 0, 0, 0.4)', 0.5)).to.eql [1, 0, 0, 0.4]
 
   it "should turn NaN or null to transparent color", ->
     expect(color.color2rgba(null)).to.eql [0, 0, 0, 0]

--- a/bokehjs/test/models/mappers/linear_color_mapper.coffee
+++ b/bokehjs/test/models/mappers/linear_color_mapper.coffee
@@ -16,9 +16,9 @@ describe "LinearColorMapper module", ->
         high_color: "#5F9EA0"
         })
 
-      expect(color_mapper._nan_color).to.be.equal(6266528)
-      expect(color_mapper._low_color).to.be.equal(6266528)
-      expect(color_mapper._high_color).to.be.equal(6266528)
+      expect(color_mapper._nan_color).to.be.equal(1604231423)
+      expect(color_mapper._low_color).to.be.equal(1604231423)
+      expect(color_mapper._high_color).to.be.equal(1604231423)
 
     it "If unset _low_color, _high_color should be undefined", ->
       color_mapper = new LinearColorMapper({
@@ -144,9 +144,9 @@ describe "LinearColorMapper module", ->
           low: 0
           high: 2
           palette: palette
-          low_color: "pink" # converts to 16761035
-          high_color: "orange" # converts to 16753920
+          low_color: "pink" # converts to 4290825215
+          high_color: "orange" # converts to 4289003775
         })
 
       vals = color_mapper._get_values([-1, 0, 1, 2, 3], palette, true)
-      expect(vals).to.be.deep.equal([16761035, 1, 2, 3, 16753920])
+      expect(vals).to.be.deep.equal([4290825215, 1, 2, 3, 4289003775])

--- a/bokehjs/test/models/mappers/log_color_mapper.coffee
+++ b/bokehjs/test/models/mappers/log_color_mapper.coffee
@@ -16,9 +16,9 @@ describe "LogColorMapper module", ->
         high_color: "#5F9EA0"
         })
 
-      expect(color_mapper._nan_color).to.be.equal(6266528)
-      expect(color_mapper._low_color).to.be.equal(6266528)
-      expect(color_mapper._high_color).to.be.equal(6266528)
+      expect(color_mapper._nan_color).to.be.equal(1604231423)
+      expect(color_mapper._low_color).to.be.equal(1604231423)
+      expect(color_mapper._high_color).to.be.equal(1604231423)
 
     it "If unset _low_color, _high_color should be undefined", ->
       color_mapper = new LogColorMapper({
@@ -117,9 +117,9 @@ describe "LogColorMapper module", ->
           low: 1
           high: 100
           palette: palette
-          low_color: "pink" # converts to 16761035
-          high_color: "orange" # converts to 16753920
+          low_color: "pink" # converts to 4290825215
+          high_color: "orange" # converts to 4289003775
         })
 
       vals = color_mapper._get_values([-1, 1, 10, 100, 101], palette, true)
-      expect(vals).to.be.deep.equal([16761035, 1, 2, 3, 16753920])
+      expect(vals).to.be.deep.equal([4290825215, 1, 2, 3, 4289003775])


### PR DESCRIPTION
In https://github.com/bokeh/bokeh/issues/6755 I described an issue handling transparency for special colors (e.g. nan_color, low_color and high_color) when specifying the color as an RGBA tuple. It took me a very long time to work out that bitwise math in Javascript tops out at 31-bits, which means the previous approach to bit shifting the colors no longer worked and I had to use a bit of actual math to handle the alpha value correctly. Additionally the ``color2hex`` utility was not correctly converting the alpha value to a hex value.

I have also put together a notebook demonstrating the original issue and the new behavior with the fix: https://anaconda.org/philippjfr/bokeh_alpha/notebook

Let me know what tests you think I should add and whether you have any concerns with the approach I had to take.

- [x] issues: fixes https://github.com/bokeh/bokeh/issues/6755
- [x] tests added / passed
