### PR TITLE
Added support for nbconvert preprocessors in NotebookHandler

### DIFF
--- a/bokeh/application/handlers/notebook.py
+++ b/bokeh/application/handlers/notebook.py
@@ -82,5 +82,3 @@ class NotebookHandler(CodeHandler):
             return [OptsMagicProcessor(), OutputMagicProcessor(), StripMagicsProcessor()]
         except:
             return []
-
-


### PR DESCRIPTION
This PR extends the ``NotebookHandler`` which processes``.ipynb`` files in ``bokeh serve`` to support nbconvert preprocessors. There are two main aims:

* Strip out magics from notebooks so that the bokeh server does not choke on them. This will be beneficial to all bokeh users that serve notebooks, whether or not they are using HoloViews.
* Add the HoloViews preprocessors to support holoviews magics. This will make it much easier for notebooks using holoviews to use the bokeh server with minimal modification.

Here is an example of what this enables. Given the following notebook:

![image](https://user-images.githubusercontent.com/890576/29471762-1b70e992-8449-11e7-92d6-c2e9baf05aac.png)

You can now run:

```
bokeh serve --show notebook.ipynb
```

To get:

![image](https://user-images.githubusercontent.com/890576/29471812-49ea0114-8449-11e7-8923-ab4b7f7523c1.png)

Note that the holoviews magic setting the curve to 'red' is now respected due to the preprocessors used to turn the magics into standard Python syntax. I have tried to write this code fairly defensively so that this is only applied when holoviews is available, making sure that any error backs off the the old behavior of not using any preprocessors at all.

There is a correspond PR (ioam/holoviews#1811) where I am working on further improving the HoloViews preprocessors.

## Outstanding actions

- [ ] Discuss how preprocessors might be enabled/disabled in general.
- [ ] Add the ``StripMagicsProcessor`` to bokeh so that all bokeh users can take advantage of this step without needing holoviews installed.
- [ ] Explore ways the boilerplate code in the notebook can be further reduced.
- [ ] Add new unit tests both to bokeh and holoviews.

I have marked this PR as WIP for now as I am still experimenting with the concept.
