### PR TITLE
Basic aspect ratio control

### DIFF
--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -695,7 +695,8 @@ class Plot(LayoutDOM):
 
     aspect_ratio = Either(Bool, Float, default=False, help="""
     Specify the aspect ratio behavior of the plot. Default is ``False`` which
-    means that the glyph will fill the whole plot area. ``True`` indicates that
-    the glyphs should maintain the an aspect ratio of 1. A ``Float``value can
-    also be given for arbitrary aspect_ratio control.
+    means that axis range will be set to the glyph's bounds. ``True`` indicates
+    that the axis range should maintain an aspect ratio of 1. A ``Float`` value
+    can also be given for arbitrary aspect_ratio control. Aspect ratio is
+    defined as the ratio of width over height.
     """)

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import
 
 from ..core.enums import Location, OutputBackend
-from ..core.properties import Bool, Dict, Enum, Include, Instance, Int, List, Override, String
+from ..core.properties import Bool, Dict, Enum, Include, Instance, Int, List, Override, String, Either, Float
 from ..core.property_mixins import LineProps, FillProps
 from ..core.query import find
 from ..core.validation import error, warning
@@ -691,4 +691,11 @@ class Plot(LayoutDOM):
     .. note::
         When set to ``webgl``, glyphs without a WebGL rendering implementation
         will fall back to rendering onto 2D canvas.
+    """)
+
+    aspect_ratio = Either(Bool, Float, default=False, help="""
+    Specify the aspect ratio behavior of the plot. Default is ``False`` which
+    means that the glyph will fill the whole plot area. ``True`` indicates that
+    the glyphs should maintain the an aspect ratio of 1. A ``Float``value can
+    also be given for arbitrary aspect_ratio control.
     """)

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -693,12 +693,34 @@ class Plot(LayoutDOM):
         will fall back to rendering onto 2D canvas.
     """)
 
-    aspect = Either(Auto, Float, default=None, help="""
+    match_aspect = Bool(default=False, help="""
     Specify the aspect ratio behavior of the plot. Aspect ratio is defined as
-    the physical distance relationship between a figure's width and height. It
-    is defined by the ratio of the width over the height.
+    the ratio of width over height. This property controls whether Bokeh should
+    attempt the match the (width/height) of *data space* to the (width/height)
+    in pixels of *screen space*.
 
-    Default is ``None`` which indicates no aspect ratio. ``"auto"`` indicates
-    that the plot should maintain an aspect ratio of 1. A ``Float`` value can
-    be given for arbitrary aspect ratio control.
+    Default is ``False`` which indicates that the *data* aspect ratio and the
+    *screen* aspect ratio vary independently. ``True`` indicates that the plot
+    aspect ratio of the axes will match the aspect ratio of the pixel extent
+    the axes. The end result is that a 1x1 area in data space is a square in
+    pixels, and conversely that a 1x1 pixel is a square in data units.
+
+    .. note::
+        This setting only takes effect when there are two dataranges. This
+        setting only sets the initial plot draw and subsequent resets. It is
+        possible for tools (single axis zoom, unconstrained box zoom) to
+        change the aspect ratio.
+    """)
+
+    aspect_scale = Float(default=1, help="""
+    A value to be given for increased aspect ratio control. This value is added
+    multiplicatively to the calculated value required for ``match_aspect``.
+    ``aspect_scale`` is defined as the ratio of width over height of the figure.
+
+    For example, a plot with ``aspect_scale`` value of 2 will result in a
+    square in *data units* to be drawn on the screen as a rectangle with a
+    pixel width twice as long as its pixel height.
+
+    .. note::
+        This setting only takes effect if ``match_aspect`` is set to ``True``.
     """)

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import
 
 from ..core.enums import Location, OutputBackend
-from ..core.properties import Bool, Dict, Enum, Include, Instance, Int, List, Override, String, Either, Float, Auto
+from ..core.properties import Bool, Dict, Enum, Include, Instance, Int, List, Override, String, Float
 from ..core.property_mixins import LineProps, FillProps
 from ..core.query import find
 from ..core.validation import error, warning

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import
 
 from ..core.enums import Location, OutputBackend
-from ..core.properties import Bool, Dict, Enum, Include, Instance, Int, List, Override, String, Either, Float
+from ..core.properties import Bool, Dict, Enum, Include, Instance, Int, List, Override, String, Either, Float, Auto
 from ..core.property_mixins import LineProps, FillProps
 from ..core.query import find
 from ..core.validation import error, warning
@@ -693,10 +693,12 @@ class Plot(LayoutDOM):
         will fall back to rendering onto 2D canvas.
     """)
 
-    aspect_ratio = Either(Bool, Float, default=False, help="""
-    Specify the aspect ratio behavior of the plot. Default is ``False`` which
-    means that axis range will be set to the glyph's bounds. ``True`` indicates
-    that the axis range should maintain an aspect ratio of 1. A ``Float`` value
-    can also be given for arbitrary aspect_ratio control. Aspect ratio is
-    defined as the ratio of width over height.
+    aspect = Either(Auto, Float, default=None, help="""
+    Specify the aspect ratio behavior of the plot. Aspect ratio is defined as
+    the physical distance relationship between a figure's width and height. It
+    is defined by the ratio of the width over the height.
+
+    Default is ``None`` which indicates no aspect ratio. ``"auto"`` indicates
+    that the plot should maintain an aspect ratio of 1. A ``Float`` value can
+    be given for arbitrary aspect ratio control.
     """)

--- a/bokehjs/src/coffee/models/plots/plot.coffee
+++ b/bokehjs/src/coffee/models/plots/plot.coffee
@@ -336,6 +336,8 @@ export class Plot extends LayoutDOM
       inner_height:      [ p.Number                           ]
       layout_width:      [ p.Number                           ]
       layout_height:     [ p.Number                           ]
+
+      aspect_ratio:      [ p.Any,      false                  ]
     }
 
   @override {

--- a/bokehjs/src/coffee/models/plots/plot.coffee
+++ b/bokehjs/src/coffee/models/plots/plot.coffee
@@ -337,7 +337,8 @@ export class Plot extends LayoutDOM
       layout_width:      [ p.Number                           ]
       layout_height:     [ p.Number                           ]
 
-      aspect:            [ p.Any,      null                  ]
+      match_aspect:      [ p.Bool,     false                  ]
+      aspect_scale:      [ p.Number,   1                      ]
     }
 
   @override {

--- a/bokehjs/src/coffee/models/plots/plot.coffee
+++ b/bokehjs/src/coffee/models/plots/plot.coffee
@@ -337,7 +337,7 @@ export class Plot extends LayoutDOM
       layout_width:      [ p.Number                           ]
       layout_height:     [ p.Number                           ]
 
-      aspect_ratio:      [ p.Any,      false                  ]
+      aspect:            [ p.Any,      null                  ]
     }
 
   @override {

--- a/bokehjs/src/coffee/models/plots/plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.coffee
@@ -210,9 +210,8 @@ export class PlotCanvasView extends DOMView
     follow_enabled = false
     has_bounds = false
 
-    if @model.plot.aspect? and @frame._width.value != 0 and @frame._height.value != 0
-      aspect = if @model.plot.aspect == "auto" then 1 else @model.plot.aspect
-      r = 1/aspect*(@frame._width.value/@frame._height.value)
+    if @model.plot.match_aspect != false and @frame._width.value != 0 and @frame._height.value != 0
+      r = 1/@model.plot.aspect_scale*(@frame._width.value/@frame._height.value)
 
       for k, v of bounds
         width = v.maxX - v.minX
@@ -566,7 +565,7 @@ export class PlotCanvasView extends DOMView
 
     @canvas_view.set_dims([width, height])
     @update_constraints()
-    if @model.plot.aspect? and @frame._width.value != 0 and @frame._height.value != 0
+    if @model.plot.match_aspect != false and @frame._width.value != 0 and @frame._height.value != 0
       @update_dataranges()
 
     # This allows the plot canvas to be positioned around the toolbar

--- a/bokehjs/src/coffee/models/plots/plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.coffee
@@ -212,6 +212,7 @@ export class PlotCanvasView extends DOMView
 
     if @model.plot.aspect? and @frame._width.value != 0 and @frame._height.value != 0
       aspect = if @model.plot.aspect == "auto" then 1 else @model.plot.aspect
+      r = 1/aspect*(@frame._width.value/@frame._height.value)
 
       for k, v of bounds
         width = v.maxX - v.minX

--- a/bokehjs/src/coffee/models/plots/plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.coffee
@@ -210,6 +210,32 @@ export class PlotCanvasView extends DOMView
     follow_enabled = false
     has_bounds = false
 
+    if @model.plot.aspect_ratio != false
+      aspect = if @model.plot.aspect_ratio is true then 1 else @model.plot.aspect_ratio
+      r = aspect*(@model.plot.width/@model.plot.height)
+
+      for k, v of bounds
+        width = v.maxX - v.minX
+        if width <= 0
+          width = 1.0
+
+        height = v.maxY - v.minY
+        if height <= 0
+          height = 1.0
+
+        xcenter = 0.5*(v.maxX + v.minX)
+        ycenter = 0.5*(v.maxY + v.minY)
+
+        if width < r*height
+          width = r*height
+        else
+          height = width/r
+
+        bounds[k].maxX = xcenter+0.5*width
+        bounds[k].minX = xcenter-0.5*width
+        bounds[k].maxY = ycenter+0.5*height
+        bounds[k].minY = ycenter-0.5*height
+
     for xr in values(frame.x_ranges)
       if xr instanceof DataRange1d
         bounds_to_use = if xr.scale_hint == "log" then log_bounds else bounds

--- a/bokehjs/src/coffee/models/plots/plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.coffee
@@ -210,9 +210,9 @@ export class PlotCanvasView extends DOMView
     follow_enabled = false
     has_bounds = false
 
-    if @model.plot.aspect_ratio != false
+    if @model.plot.aspect_ratio != false and @frame._width.value != 0 and @frame._height.value != 0
       aspect = if @model.plot.aspect_ratio is true then 1 else @model.plot.aspect_ratio
-      r = aspect*(@model.plot.width/@model.plot.height)
+      r = aspect*(@frame._width.value/@frame._height.value)
 
       for k, v of bounds
         width = v.maxX - v.minX
@@ -566,6 +566,7 @@ export class PlotCanvasView extends DOMView
 
     @canvas_view.set_dims([width, height])
     @update_constraints()
+    @update_dataranges()
 
     # This allows the plot canvas to be positioned around the toolbar
     @el.style.position = 'absolute'

--- a/bokehjs/src/coffee/models/plots/plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.coffee
@@ -210,9 +210,8 @@ export class PlotCanvasView extends DOMView
     follow_enabled = false
     has_bounds = false
 
-    if @model.plot.aspect_ratio != false and @frame._width.value != 0 and @frame._height.value != 0
-      aspect = if @model.plot.aspect_ratio is true then 1 else @model.plot.aspect_ratio
-      r = aspect*(@frame._width.value/@frame._height.value)
+    if @model.plot.aspect? and @frame._width.value != 0 and @frame._height.value != 0
+      aspect = if @model.plot.aspect == "auto" then 1 else @model.plot.aspect
 
       for k, v of bounds
         width = v.maxX - v.minX
@@ -566,7 +565,8 @@ export class PlotCanvasView extends DOMView
 
     @canvas_view.set_dims([width, height])
     @update_constraints()
-    @update_dataranges()
+    if @model.plot.aspect? and @frame._width.value != 0 and @frame._height.value != 0
+      @update_dataranges()
 
     # This allows the plot canvas to be positioned around the toolbar
     @el.style.position = 'absolute'


### PR DESCRIPTION
## Summary
This PR adds a simple aspect ratio control tool.

- [x] issues: fixes #474, #517
- [ ] tests 
- [ ] release document entry (if new feature or API change)

## Latest commit
This PR adds a two properties to the plot object.

`match_aspect` which indicates whether Bokeh should attempt the match the (width/height) of *data space* to the (width/height) in pixels of *screen space*.

`aspect_scale` which allows for further control of aspect control behavior by multiplying on top of the ratio calculated at `match_aspect`. This property allows the user to distort the axis at will. For example, with `aspect_scale= 2` a square in *data* units will be drawn as a rectangle with twice the *pixel* units in width than in height.

#### `match_aspect=True`
This fixes the bug shown in #6603.
![bokeh_plot 32](https://user-images.githubusercontent.com/27960786/29531839-645b31ae-8678-11e7-960c-ba3c3b612697.png)

#### `match_aspect=True, aspect_scale=2`
![bokeh_plot 47](https://user-images.githubusercontent.com/27960786/29589097-f268486c-8761-11e7-859c-b125d7812315.png)


## Explanation

Hello Bokeh team,

From my understanding the current behavior when plotting the data ranges is to use the bounds of the glyphs. The method proposed in this PR for aspect control is to instead set the data ranges values with new ones calculated based on the glyph bounds and the inherent aspect ratio of the plot. It also allows an arbitrary user defined aspect ratio. 

### A few examples:
#### Current behavior
![bokeh_plot 42](https://user-images.githubusercontent.com/27960786/29581170-82c13480-8746-11e7-8f26-b7f77ae71ecb.png)

#### New behavior with aspect ratio of 1:
![bokeh_plot 40](https://user-images.githubusercontent.com/27960786/29581229-ab0cbedc-8746-11e7-9311-47ced5276bd1.png)


#### New behavior with aspect ratio of 16/9:
![bokeh_plot 41](https://user-images.githubusercontent.com/27960786/29581189-92f8d466-8746-11e7-80f6-177e1e10aafa.png)


### What it doesn't fix
This isn't a perfect fix, since it simply uses the built in ranges for trying to maintain the aspect ratio. As described in #517, there seems to be a deeper problem with pixel per distance being different on each axis. I'm currently studying the information in those threads to see if my current solution can be improved.

### Todo
- [ ] tests 
- [ ] release document entry (if new feature or API change)

I'm assuming a new feature like this requires tests and unfortunately I haven't used mocha before, but I will do my best to get the tests done.

### Final remarks
I hope this PR is appreciated. It's always of pleasure contributing to a project like Bokeh. Feel free to dismiss this PR if you are working on something more comprehensive that also fixes issues like #6603 and #517. I've also left some more comments on specific parts about the code. I'm welcome to all suggestions or improvements. I'll be available to work some more on the PR after the weekend.

To the whole team, enjoy your weekend and thank you for such a great project.
Corey


