### PR TITLE
Support embed bokeh app in Zeppelin

### DIFF
--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -292,9 +292,6 @@ def show(obj, browser=None, new="tab", notebook_handle=False, notebook_url="loca
     return _show_with_state(obj, _state, browser, new, notebook_handle=notebook_handle)
 
 def _show_notebook_app_with_state(app, state, app_path, notebook_url):
-    if state.notebook_type == 'zeppelin':
-        raise ValueError("Zeppelin doesn't support show bokeh app.")
-
     logging.basicConfig()
     from tornado.ioloop import IOLoop
     from .server.server import Server
@@ -307,8 +304,13 @@ def _show_notebook_app_with_state(app, state, app_path, notebook_url):
     server.start()
     url = 'http://%s:%d%s' % (notebook_url.split(':')[0], server.port, app_path)
     script = server_document(url)
-
-    publish_display_data({LOAD_MIME_TYPE: {"div": script}}, metadata={LOAD_MIME_TYPE: {"server_id": server_id}})
+    if state.notebook_type == 'jupyter':
+        publish_display_data({LOAD_MIME_TYPE: {"div": script}}, metadata={LOAD_MIME_TYPE: {"server_id": server_id}})
+    elif state.notebook_type == 'zeppelin':
+        div_html = "<div class='bokeh_class' id='{divid}'>{script}</div>"
+        print('%html ' + div_html.format(script=script, divid=server_id))
+    else:
+        raise ValueError(state.notebook_type + " doesn't support to embed bokeh app.")
 
 def _show_with_state(obj, state, browser, new, notebook_handle=False):
     controller = browserlib.get_browser_controller(browser=browser)

--- a/examples/howto/server_embed/notebook_embed.ipynb
+++ b/examples/howto/server_embed/notebook_embed.ipynb
@@ -32,7 +32,9 @@
     "\n",
     "from bokeh.sampledata.sea_surface_temperature import sea_surface_temperature\n",
     "\n",
-    "output_notebook()"
+    "output_notebook()\n",
+    "# specify notebook_type as `zeppelin` if you want to embed bokeh app in Apache Zeppelin\n",
+    "# output_notebook(notebook_type='zeppelin')"
    ]
   },
   {
@@ -139,7 +141,7 @@
    },
    "outputs": [],
    "source": [
-    "show(app)"
+    "show(app, notebook_url='http://localhost:8888')"
    ]
   }
  ],

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -609,7 +609,7 @@ any or all of the following conventionally named functions:
 Embedding Bokeh Server as a Library
 -----------------------------------
 
-It can be useful to embed the Bokeh Server in a larger Tornado application, or the
+It can be useful to embed the Bokeh Server in a larger Tornado application, Zeppelin notebook or the
 Jupyter notebook, and use the already existing Tornado ``IOloop``.  Here is the
 basis of how to integrate Bokeh in such a scenario:
 


### PR DESCRIPTION

- [ ] issues: fixes #6788 
- [ ] tests added / passed, I didn't find a proper way to add unit test for this feature. I just manually verify it in Apache Zeppelin.
- [ ] release document entry (if new feature or API change)

Screenshot of my verification in Zeppelin. I run the same example of embedding bokeh app in Jupyter.
![image](https://user-images.githubusercontent.com/164491/29492623-9c1206a0-85b4-11e7-8b24-9c86d16eb11f.png)
