### PR TITLE
Revert JLab integration changes

### DIFF
--- a/bokeh/core/_templates/autoload_js.js
+++ b/bokeh/core/_templates/autoload_js.js
@@ -27,8 +27,6 @@ calls it with the rendered model.
     root._bokeh_is_loading = undefined;
   }
 
-  {% block register_mimetype %}
-  {% endblock %}
 
   {% block autoload_init %}
   {% endblock %}

--- a/bokeh/core/_templates/autoload_nb_js.js
+++ b/bokeh/core/_templates/autoload_nb_js.js
@@ -25,18 +25,13 @@
   function display_loaded() {
     if (root.Bokeh !== undefined) {
       var el = document.getElementById({{ elementid|json }});
-      el.textContent = "BokehJS " + Bokeh.version + " successfully loaded.";
+      if (el != null) {
+        el.textContent = "BokehJS " + Bokeh.version + " successfully loaded.";
+      }
     } else if (Date.now() < root._bokeh_timeout) {
       setTimeout(display_loaded, 100)
     }
   }
-
-  {%- if comms_target -%}
-  if ((root.Jupyter !== undefined) && Jupyter.notebook.kernel) {
-    comm_manager = Jupyter.notebook.kernel.comm_manager
-    comm_manager.register_target({{ comms_target|json }}, function () {});
-  }
-  {%- endif -%}
 {% endblock %}
 
 {% block run_inline_js %}

--- a/bokeh/core/_templates/autoload_nb_js.js
+++ b/bokeh/core/_templates/autoload_nb_js.js
@@ -1,120 +1,5 @@
 {% extends "autoload_js.js" %}
 
-{% block register_mimetype %}
-
-  {%- if register_mime -%}
-  var MIME_TYPE = 'application/vnd.bokehjs_exec.v0+json';
-  var CLASS_NAME = 'output_bokeh rendered_html';
-
-  /**
-   * Render data to the DOM node
-   */
-  function render(props, node) {
-    if (props.data['div'] !== undefined) {
-      var div = document.createElement("div");
-      div.innerHTML = props.data["div"];
-      node.appendChild(div);
-    }
-
-    if (props.data['script'] !== undefined) {
-      var script = document.createElement("script");
-      script.textContent = props.data["script"];
-      node.appendChild(script);
-    }
-  }
-
-  /**
-   * Handle when an output is cleared or removed
-   */
-  function handleClearOutput(event, handle) {
-    var cell = handle.cell;
-
-    var id = cell.output_area._bokeh_element_id;
-    var server_id = cell.output_area._bokeh_server_id;
-    // Clean up Bokeh references
-    if (id !== undefined) {
-      Bokeh.index[id].model.document.clear();
-      delete Bokeh.index[id];
-    }
-
-    if (server_id !== undefined) {
-      // Clean up Bokeh references
-      var cmd = "from bokeh.io import _state; print(_state.uuid_to_server['" + server_id + "'].get_sessions()[0].document.roots[0]._id)";
-      cell.notebook.kernel.execute(cmd, {
-        iopub: {
-          output: function(msg) {
-            var element_id = msg.content.text.trim();
-            Bokeh.index[element_id].model.document.clear();
-            delete Bokeh.index[element_id];
-          }
-        }
-      });
-      // Destroy server and session
-      var cmd = "from bokeh import io; io._destroy_server('" + server_id + "')";
-      cell.notebook.kernel.execute(cmd);
-    }
-  }
-
-  /**
-   * Handle when a new output is added
-   */
-  function handleAddOutput(event,  handle) {
-    var output_area = handle.output_area;
-    var output = handle.output;
-    // store reference to embed id or server id on output_area
-    if (output.metadata[MIME_TYPE] !== undefined) {
-      output_area._bokeh_element_id = output.metadata[MIME_TYPE]["id"];
-      output_area._bokeh_server_id = output.metadata[MIME_TYPE]["server_id"];
-    }
-  }
-
-  function register_renderer(notebook, OutputArea) {
-    // get OutputArea instance
-    var code_cell = notebook.get_cells().reduce(function(result, cell) { return cell.output_area ? cell : result });
-    var output_area = code_cell.output_area;
-
-    function append_mime(data, metadata, element) {
-      // create a DOM node to render to
-      var toinsert = this.create_output_subarea(
-        metadata,
-        CLASS_NAME,
-        MIME_TYPE
-      );
-      this.keyboard_manager.register_events(toinsert);
-      // Render to node
-      var props = {data: data, metadata: metadata[MIME_TYPE]};
-      render(props, toinsert[0]);
-      element.append(toinsert);
-      return toinsert
-    }
-
-    /* Handle when an output is cleared or removed */
-    output_area.events.on('clear_output.CodeCell', handleClearOutput);
-    output_area.events.on('delete.Cell', handleClearOutput);
-
-    /* Handle when a new output is added */
-    output_area.events.on('output_added.OutputArea', handleAddOutput);
-
-    /**
-     * Register the mime type and append_mime function with output_area
-     */
-    OutputArea.prototype.register_mime_type(MIME_TYPE, append_mime, {
-      /* Is output safe? */
-      safe: true,
-      /* Index of renderer in `output_area.display_order` */
-      index: 0
-    });
-  }
-
-  // register the mime type if in Jupyter Notebook environment and previously unregistered
-  var OutputArea = root.Jupyter.OutputArea;
-  if ((root.Jupyter !== undefined) && (OutputArea.prototype.mime_types().indexOf(MIME_TYPE) == -1)) {
-    register_renderer(root.Jupyter.notebook, OutputArea);
-  }
-  {%- endif -%}
-
-{% endblock %}
-
 {% block autoload_init %}
   if (typeof (root._bokeh_timeout) === "undefined" || force === true) {
     root._bokeh_timeout = Date.now() + {{ timeout|default(0)|json }};
@@ -140,13 +25,18 @@
   function display_loaded() {
     if (root.Bokeh !== undefined) {
       var el = document.getElementById({{ elementid|json }});
-      if (el != null) {
-        el.textContent = "BokehJS " + Bokeh.version + " successfully loaded.";
-      }
+      el.textContent = "BokehJS " + Bokeh.version + " successfully loaded.";
     } else if (Date.now() < root._bokeh_timeout) {
       setTimeout(display_loaded, 100)
     }
   }
+
+  {%- if comms_target -%}
+  if ((root.Jupyter !== undefined) && Jupyter.notebook.kernel) {
+    comm_manager = Jupyter.notebook.kernel.comm_manager
+    comm_manager.register_target({{ comms_target|json }}, function () {});
+  }
+  {%- endif -%}
 {% endblock %}
 
 {% block run_inline_js %}

--- a/bokeh/core/_templates/notebook_cell_observer.js
+++ b/bokeh/core/_templates/notebook_cell_observer.js
@@ -1,0 +1,30 @@
+{#
+Registers a MutationObserver that can detect deletion of cells with a
+class of 'bokeh_class'
+
+:param inner_block: Javascript block to be executed when deletion detected
+:type inner_block: str
+
+The supplied Javascript is executed with the id of the destroyed div in
+ scope as variable destroyed_id.
+
+#}
+
+var target = document.getElementById('notebook-container');
+
+var observer = new MutationObserver(function(mutations) {
+
+   for (var i = 0; i < mutations.length; i++) {
+      for (var j=0; j < mutations[i].removedNodes.length; j++) {
+        for (var k=0; k < mutations[i].removedNodes[j].childNodes.length; k++)
+          var bokeh_selector = $(mutations[i].removedNodes[j].childNodes[k]).find(".bokeh_class");
+          if (bokeh_selector) {
+            if (bokeh_selector.length > 0) {
+               var destroyed_id = bokeh_selector[0].id;
+                {{inner_block}}
+            }
+          }
+      }
+   }
+});
+observer.observe(target, { childList: true, subtree:true });

--- a/bokeh/core/state.py
+++ b/bokeh/core/state.py
@@ -44,6 +44,7 @@ class State(object):
     def __init__(self):
         self.last_comms_handle = None
         self.uuid_to_server = {} # Mapping from uuid to server instance
+        self.watching_cells = False
         self.reset()
 
     @property

--- a/bokeh/core/templates.py
+++ b/bokeh/core/templates.py
@@ -12,6 +12,7 @@
 .. bokeh-jinja:: bokeh.core.templates.NOTEBOOK_DIV
 .. bokeh-jinja:: bokeh.core.templates.PLOT_DIV
 .. bokeh-jinja:: bokeh.core.templates.SCRIPT_TAG
+.. bokeh-jinja:: bokeh.core.templates.NOTEBOOK_CELL_OBSERVER
 
 '''
 from __future__ import absolute_import
@@ -44,3 +45,5 @@ AUTOLOAD_JS = _env.get_template("autoload_js.js")
 AUTOLOAD_NB_JS = _env.get_template("autoload_nb_js.js")
 
 AUTOLOAD_TAG = _env.get_template("autoload_tag.html")
+
+NOTEBOOK_CELL_OBSERVER = _env.get_template("notebook_cell_observer.js")

--- a/bokeh/core/tests/test_state.py
+++ b/bokeh/core/tests/test_state.py
@@ -20,6 +20,7 @@ def test_creation():
     assert isinstance(s.document, Document)
     assert s.file == None
     assert s.notebook == False
+    assert s.watching_cells == False
 
 def test_default_file_resources():
     s = state.State()

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -370,7 +370,6 @@ def notebook_div(model, notebook_comms_target=None, theme=FromCurdoc):
     ))
 
     js = AUTOLOAD_NB_JS.render(
-        comms_target = notebook_comms_target,
         js_urls = [],
         css_urls = [],
         js_raw = [script],

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -26,18 +26,16 @@ import warnings
 import tempfile
 import uuid
 
-from IPython.display import publish_display_data
-
 # Bokeh imports
 from .core.state import State
 from .document import Document
-from .embed import server_document, notebook_div, notebook_content, file_html
+from .embed import server_document, notebook_div, file_html
 from .layouts import gridplot, GridSpec ; gridplot, GridSpec
 from .models import Plot
 from .resources import INLINE
 import bokeh.util.browser as browserlib  # full import needed for test mocking to work
 from .util.dependencies import import_required, detect_phantomjs
-from .util.notebook import get_comms, load_notebook, EXEC_MIME_TYPE
+from .util.notebook import get_comms, load_notebook, publish_display_data, watch_server_cells
 from .util.string import decode_utf8
 from .util.serialization import make_id
 
@@ -392,8 +390,14 @@ def show(obj, browser=None, new="tab", notebook_handle=False, notebook_url="loca
         _state.document.add_root(obj)
     return _show_with_state(obj, _state, browser, new, notebook_handle=notebook_handle)
 
+
 def _show_jupyter_app_with_state(app, state, notebook_url):
+    if not state.watching_cells:
+        watch_server_cells(_destroy_server_js)
+        state.watching_cells = True
+
     logging.basicConfig()
+    from IPython.display import HTML, display
     from tornado.ioloop import IOLoop
     from .server.server import Server
     loop = IOLoop.current()
@@ -405,8 +409,7 @@ def _show_jupyter_app_with_state(app, state, notebook_url):
     server.start()
     url = 'http://%s:%d%s' % (notebook_url.split(':')[0], server.port, "/")
     script = server_document(url)
-
-    publish_display_data({EXEC_MIME_TYPE: {"div": script}}, metadata={EXEC_MIME_TYPE: {"server_id": server_id}})
+    display(HTML(_server_cell(server, script)))
 
 def _show_with_state(obj, state, browser, new, notebook_handle=False):
     controller = browserlib.get_browser_controller(browser=browser)
@@ -433,8 +436,7 @@ def _show_file_with_state(obj, state, new, controller):
 
 def _show_jupyter_doc_with_state(obj, state, notebook_handle):
     comms_target = make_id() if notebook_handle else None
-    (script, div) = notebook_content(obj, comms_target)
-    publish_display_data({EXEC_MIME_TYPE: {"script": script, "div": div}}, metadata={EXEC_MIME_TYPE: {"id": obj._id}})
+    publish_display_data({'text/html': notebook_div(obj, comms_target)})
     if comms_target:
         handle = _CommsHandle(get_comms(comms_target), state.document,
                               state.document.to_json())
@@ -634,24 +636,38 @@ def _remove_roots(subplots):
         if sub in doc.roots:
             doc.remove_root(sub)
 
-def _destroy_server(server_id):
+def _server_cell(server, script):
+    ''' Wrap a script returned by ``autoload_server`` in a div that allows cell
+    destruction/replacement to be detected.
+
+    '''
+    divid = uuid.uuid4().hex
+    _state.uuid_to_server[divid] = server
+    div_html = "<div class='bokeh_class' id='{divid}'>{script}</div>"
+    return div_html.format(script=script, divid=divid)
+
+_destroy_server_js = """
+var cmd = "from bokeh import io; io._destroy_server('<%= destroyed_id %>')";
+var command = _.template(cmd)({destroyed_id:destroyed_id});
+Jupyter.notebook.kernel.execute(command);
+"""
+
+def _destroy_server(div_id):
     ''' Given a UUID id of a div removed or replaced in the Jupyter
     notebook, destroy the corresponding server sessions and stop it.
 
     '''
-    server = _state.uuid_to_server.get(server_id, None)
+    server = _state.uuid_to_server.get(div_id, None)
     if server is None:
-        logger.debug("No server instance found for uuid: %r" % server_id)
+        logger.debug("No server instance found for uuid: %r" % div_id)
         return
 
     try:
         for session in server.get_sessions():
             session.destroy()
-        server.stop()
-        del _state.uuid_to_server[server_id]
 
     except Exception as e:
-        logger.debug("Could not destroy server for id %r: %s" % (server_id, e))
+        logger.debug("Could not destroy server for id %r: %s" % (div_id, e))
 
 def _wait_until_render_complete(driver):
     from selenium.webdriver.support.ui import WebDriverWait

--- a/bokeh/tests/test_embed.py
+++ b/bokeh/tests/test_embed.py
@@ -111,13 +111,6 @@ class TestComponents(unittest.TestCase):
         self.maxDiff = None
         self.assertEqual(rawscript.strip(), script_content.strip())
 
-class TestNotebookContent(unittest.TestCase):
-
-    def test_return_type(self):
-        r = embed.notebook_content(_embed_test_plot)
-        self.assertTrue(isinstance(r, tuple))
-        self.assertTrue(len(r), 2)
-
 class TestNotebookDiv(unittest.TestCase):
 
     def test_return_type(self):

--- a/bokeh/tests/test_io.py
+++ b/bokeh/tests/test_io.py
@@ -253,33 +253,18 @@ class Test_ShowFileWithState(DefaultStateTester):
         self._check_func_called(mock_save, ("obj",), {"state": s})
         self._check_func_called(controller.open, ("file://savepath",), {"new": 2})
 
-class Test_ShowJupyterWithState(DefaultStateTester):
-
-    @patch('bokeh.io.get_comms')
-    @patch('bokeh.io.publish_display_data')
-    @patch('bokeh.io.notebook_content')
-    def test_no_server(self, mock_notebook_content, mock_publish_display_data, mock_get_comms):
-        mock_get_comms.return_value = "comms"
-        s = io.State()
-        mock_notebook_content.return_value = ["notebook_script", "notebook_div"]
-
-        class Obj(object):
-            _id = None
-
-        io._nb_loaded = True
-        io._show_jupyter_doc_with_state(Obj(), s, True)
-        io._nb_loaded = False
-
-        expected_args = ({'application/vnd.bokehjs_exec.v0+json': {"script": "notebook_script", "div": "notebook_div"}},)
-        expected_kwargs = {'metadata': {'application/vnd.bokehjs_exec.v0+json': {'id': None}}}
-
-        self._check_func_called(mock_publish_display_data, expected_args, expected_kwargs)
-
 class TestResetOutput(DefaultStateTester):
 
     def test(self):
         io.reset_output()
         self.assertTrue(io._state.reset.called)
+
+def test__server_cell():
+    io._state.uuid_to_server = {}
+    html = io._server_cell("server", "script123")
+    assert list(io._state.uuid_to_server.values()) == ['server']
+    assert html.startswith("<div class='bokeh_class' id='")
+    assert html.endswith("'>script123</div>")
 
 def _test_layout_added_to_root(layout_generator, children=None):
     layout = layout_generator(Plot() if children is None else children)

--- a/bokeh/util/notebook.py
+++ b/bokeh/util/notebook.py
@@ -2,12 +2,7 @@
 
 '''
 from __future__ import absolute_import
-
-from IPython.display import publish_display_data
-
-JS_MIME_TYPE   = 'application/javascript'
-LOAD_MIME_TYPE = 'application/vnd.bokehjs_load.v0+json'
-EXEC_MIME_TYPE = 'application/vnd.bokehjs_exec.v0+json'
+from bokeh.core.templates import NOTEBOOK_CELL_OBSERVER
 
 _notebook_loaded = None
 
@@ -39,14 +34,32 @@ def load_notebook(resources=None, verbose=False, hide_banner=False, load_timeout
         None
 
     '''
+    html, js = _load_notebook_html(resources, verbose, hide_banner, load_timeout)
+    if notebook_type=='jupyter':
+        publish_display_data({'text/html': html})
+        publish_display_data({'application/javascript': js})
+    else:
+        _publish_zeppelin_data(html, js)
 
+
+FINALIZE_JS = """
+document.getElementById("%s").textContent = "BokehJS is loading...";
+"""
+
+# TODO (bev) This will eventually go away
+def _publish_zeppelin_data(html, js):
+    print('%html ' + html)
+    print('%html ' + '<script type="text/javascript">' + js + "</script>")
+
+def _load_notebook_html(resources=None, verbose=False, hide_banner=False,
+                        load_timeout=5000):
     global _notebook_loaded
 
     from .. import __version__
-    from ..core.templates import NOTEBOOK_LOAD
+    from ..core.templates import AUTOLOAD_NB_JS, NOTEBOOK_LOAD
     from ..util.serialization import make_id
-    from ..resources import CDN
     from ..util.compiler import bundle_all_models
+    from ..resources import CDN
 
     if resources is None:
         resources = CDN
@@ -79,48 +92,35 @@ def load_notebook(resources=None, verbose=False, hide_banner=False, load_timeout
 
     custom_models_js = bundle_all_models()
 
-    nb_js = _loading_js(resources, element_id, custom_models_js, load_timeout, register_mime=True)
-    jl_js = _loading_js(resources, element_id, custom_models_js, load_timeout, register_mime=False)
-
-    if notebook_type=='jupyter':
-
-        if not hide_banner:
-            publish_display_data({'text/html': html})
-
-        publish_display_data({
-            JS_MIME_TYPE   : nb_js,
-            LOAD_MIME_TYPE : {"script": jl_js}
-        })
-
-    else:
-        _publish_zeppelin_data(html, jl_js)
-
-
-FINALIZE_JS = """
-document.getElementById("%s").textContent = "BokehJS is loading...";
-"""
-
-# TODO (bev) This will eventually go away
-def _publish_zeppelin_data(html, js):
-    print('%html ' + html)
-    print('%html ' + '<script type="text/javascript">' + js + "</script>")
-
-def _loading_js(resources, element_id, custom_models_js, load_timeout=5000, register_mime=True):
-
-    from ..core.templates import AUTOLOAD_NB_JS
-
     js = AUTOLOAD_NB_JS.render(
-        elementid = element_id,
-        js_urls   = resources.js_files,
-        css_urls  = resources.css_files,
-        js_raw    = resources.js_raw + [custom_models_js] + [FINALIZE_JS % element_id],
-        css_raw   = resources.css_raw_str,
-        force     = True,
-        timeout   = load_timeout,
-        register_mime = register_mime
+        elementid = '' if hide_banner else element_id,
+        js_urls  = resources.js_files,
+        css_urls = resources.css_files,
+        js_raw   = resources.js_raw + [custom_models_js] + ([] if hide_banner else [FINALIZE_JS % element_id]),
+        css_raw  = resources.css_raw_str,
+        force    = True,
+        timeout  = load_timeout
     )
 
-    return js
+    return html, js
+
+def publish_display_data(data, source='bokeh'):
+    ''' Compatibility wrapper for Jupyter ``publish_display_data``
+
+    Later versions of Jupyter remove the ``source`` (first) argument. This
+    function insulates Bokeh library code from this change.
+
+    Args:
+        source (str, optional) : the source arg for Jupyter (default: "bokeh")
+        data (dict) : the data dict to pass to ``publish_display_data``
+            Typically has the form ``{'text/html': html}``
+
+    '''
+    import IPython.core.displaypub as displaypub
+    try:
+        displaypub.publish_display_data(source, data)
+    except TypeError:
+        displaypub.publish_display_data(data)
 
 def get_comms(target_name):
     ''' Create a Jupyter comms object for a specific target, that can
@@ -135,3 +135,16 @@ def get_comms(target_name):
     '''
     from ipykernel.comm import Comm
     return Comm(target_name=target_name, data={})
+
+
+def watch_server_cells(inner_block):
+    ''' Installs a MutationObserver that detects deletion of cells using
+    io.server_cell to wrap the output.
+
+    The inner_block is a Javascript block that is executed when a server
+    cell is removed from the DOM. The id of the destroyed div is in
+    scope as the variable destroyed_id.
+    '''
+    js = NOTEBOOK_CELL_OBSERVER.render(inner_block=inner_block)
+    script = "<script type='text/javascript'>{js}</script>".format(js=js)
+    publish_display_data({'text/html': script}, source='bokeh')


### PR DESCRIPTION
This reverts commit e45e24f8e32534d64a386f5d36357bb5f351814b, reversing
changes made to c3ee83210d75ea0dbbb5ab92fe69dc4756ec2e88.

Revert "add mechanism to install external notebook display hooks (#6799)"

This reverts commit 33c2356663e5747296ac5576af74d4a1dad1b0c2.

Revert "Add mime message for jupyter lab load mime renderer (#6797)"

This reverts commit 6120d89d99d69b6f1756be6eb216b1ba1441683a.

Revert "Merge pull request #6774 from bokeh/canavandl/nb_register_mime"

This reverts commit 2788ce89fce47527d980c8ccbb83010e462023b0, reversing
changes made to e244cc4603f0bf7b50a43f2e91ddc562b93b5e0e.

Fix revert conflicts

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [ ] issues: fixes #6808 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
