### PR TITLE
Use setv to silent set data_source.inspected (not not trigger render)

### DIFF
--- a/bokehjs/src/coffee/models/graphs/graph_hit_test_policy.coffee
+++ b/bokehjs/src/coffee/models/graphs/graph_hit_test_policy.coffee
@@ -37,8 +37,8 @@ export class NodesOnly extends GraphHitTestPolicy
   do_inspection: (geometry, graph_view, final, append) ->
     @_node_selector = graph_view.model.get_selection_manager().get_or_create_inspector(graph_view.node_view.model)
     did_hit = @_do(geometry, graph_view, final, append)
-    graph_view.node_view.model.data_source.inspected = @_node_selector.indices
-    graph_view.node_view.model.data_source.inspect.emit([graph_view.node_view, {"geometry": geometry}])
+    graph_view.node_view.model.data_source.setv({inspected: @_node_selector.indices}, {silent: true})
+    graph_view.node_view.model.data_source.inspect.emit([graph_view.node_view, {geometry: geometry}])
     return did_hit
 
 
@@ -88,9 +88,9 @@ export class NodesAndLinkedEdges extends GraphHitTestPolicy
 
     did_hit = @_do(geometry, graph_view, final, append)
 
-    graph_view.node_view.model.data_source.inspected = @_node_selector.indices
-    graph_view.edge_view.model.data_source.inspected = @_edge_selector.indices
-    graph_view.node_view.model.data_source.inspect.emit([graph_view.node_view, {"geometry": geometry}])
+    graph_view.node_view.model.data_source.setv({inspected: @_node_selector.indices}, {silent: true})
+    graph_view.edge_view.model.data_source.setv({inspected: @_edge_selector.indices}, {silent: true})
+    graph_view.node_view.model.data_source.inspect.emit([graph_view.node_view, {geometry: geometry}])
 
     return did_hit
 
@@ -142,8 +142,8 @@ export class EdgesAndLinkedNodes extends GraphHitTestPolicy
 
     did_hit = @_do(geometry, graph_view, final, append)
 
-    graph_view.edge_view.model.data_source.inspected = @_edge_selector.indices
-    graph_view.node_view.model.data_source.inspected = @_node_selector.indices
-    graph_view.edge_view.model.data_source.inspect.emit([graph_view.edge_view, {'geometry': geometry}])
+    graph_view.edge_view.model.data_source.setv({inspected: @_edge_selector.indices}, {silent: true})
+    graph_view.node_view.model.data_source.setv({inspected: @_node_selector.indices}, {silent: true})
+    graph_view.edge_view.model.data_source.inspect.emit([graph_view.edge_view, {geometry: geometry}])
 
     return did_hit

--- a/bokehjs/src/coffee/models/graphs/graph_hit_test_policy.coffee
+++ b/bokehjs/src/coffee/models/graphs/graph_hit_test_policy.coffee
@@ -37,6 +37,7 @@ export class NodesOnly extends GraphHitTestPolicy
   do_inspection: (geometry, graph_view, final, append) ->
     @_node_selector = graph_view.model.get_selection_manager().get_or_create_inspector(graph_view.node_view.model)
     did_hit = @_do(geometry, graph_view, final, append)
+    # silently set inspected attr to avoid triggering data_source.change event and rerender
     graph_view.node_view.model.data_source.setv({inspected: @_node_selector.indices}, {silent: true})
     graph_view.node_view.model.data_source.inspect.emit([graph_view.node_view, {geometry: geometry}])
     return did_hit
@@ -88,6 +89,7 @@ export class NodesAndLinkedEdges extends GraphHitTestPolicy
 
     did_hit = @_do(geometry, graph_view, final, append)
 
+    # silently set inspected attr to avoid triggering data_source.change event and rerender
     graph_view.node_view.model.data_source.setv({inspected: @_node_selector.indices}, {silent: true})
     graph_view.edge_view.model.data_source.setv({inspected: @_edge_selector.indices}, {silent: true})
     graph_view.node_view.model.data_source.inspect.emit([graph_view.node_view, {geometry: geometry}])
@@ -142,6 +144,7 @@ export class EdgesAndLinkedNodes extends GraphHitTestPolicy
 
     did_hit = @_do(geometry, graph_view, final, append)
 
+    # silently set inspected attr to avoid triggering data_source.change event and rerender
     graph_view.edge_view.model.data_source.setv({inspected: @_edge_selector.indices}, {silent: true})
     graph_view.node_view.model.data_source.setv({inspected: @_node_selector.indices}, {silent: true})
     graph_view.edge_view.model.data_source.inspect.emit([graph_view.edge_view, {geometry: geometry}])

--- a/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
+++ b/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
@@ -296,6 +296,7 @@ export class GlyphRenderer extends Renderer
     else # mode == "inspect"
       inspector = @data_source.selection_manager.get_or_create_inspector(@)
       inspector.update(indices, true, false, true)
+      # silently set inspected attr to avoid triggering data_source.change event and rerender
       @data_source.setv({inspected: inspector.indices}, {silent: true})
       @data_source.inspect.emit([renderer_view, {geometry: geometry}])
 

--- a/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
+++ b/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
@@ -296,8 +296,8 @@ export class GlyphRenderer extends Renderer
     else # mode == "inspect"
       inspector = @data_source.selection_manager.get_or_create_inspector(@)
       inspector.update(indices, true, false, true)
-      @data_source.inspected = inspector.indices
-      @data_source.inspect.emit([renderer_view, {"geometry": geometry}])
+      @data_source.setv({inspected: inspector.indices}, {silent: true})
+      @data_source.inspect.emit([renderer_view, {geometry: geometry}])
 
     return not indices.is_empty()
 


### PR DESCRIPTION
Use setv to silent set data_source.inspected (not not trigger render)

- [ ] issues: fixes #6829 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
