### PR TITLE
Checks for finite values of bounds before doing the calculation for match_aspect bounds

### DIFF
--- a/bokehjs/src/coffee/models/plots/plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.coffee
@@ -212,28 +212,28 @@ export class PlotCanvasView extends DOMView
 
     if @model.plot.match_aspect != false and @frame._width.value != 0 and @frame._height.value != 0
       r = 1/@model.plot.aspect_scale*(@frame._width.value/@frame._height.value)
-
       for k, v of bounds
-        width = v.maxX - v.minX
-        if width <= 0
-          width = 1.0
+        if isFinite(v.maxX) and isFinite(v.minX) and isFinite(v.maxY) and isFinite(v.minY)
+          width = v.maxX - v.minX
+          if width <= 0
+            width = 1.0
 
-        height = v.maxY - v.minY
-        if height <= 0
-          height = 1.0
+          height = v.maxY - v.minY
+          if height <= 0
+            height = 1.0
 
-        xcenter = 0.5*(v.maxX + v.minX)
-        ycenter = 0.5*(v.maxY + v.minY)
+          xcenter = 0.5*(v.maxX + v.minX)
+          ycenter = 0.5*(v.maxY + v.minY)
 
-        if width < r*height
-          width = r*height
-        else
-          height = width/r
+          if width < r*height
+            width = r*height
+          else
+            height = width/r
 
-        bounds[k].maxX = xcenter+0.5*width
-        bounds[k].minX = xcenter-0.5*width
-        bounds[k].maxY = ycenter+0.5*height
-        bounds[k].minY = ycenter-0.5*height
+          bounds[k].maxX = xcenter+0.5*width
+          bounds[k].minX = xcenter-0.5*width
+          bounds[k].maxY = ycenter+0.5*height
+          bounds[k].minY = ycenter-0.5*height
 
     for xr in values(frame.x_ranges)
       if xr instanceof DataRange1d


### PR DESCRIPTION
# Summary
Checks for finite values of bounds before doing the calculation for `match_aspect `bounds.
- [x] issues: fixes #6851
- [ ] tests added / passed

## Explanation
When trying to plot a figure which contains a glyph without specified bounds. The default value given to these glyphs is Infinity. If you also specified the `match_aspect` for the figure, it would fail to draw the initial ranges since the computation done to to insure `match_aspect` would turn the `Infinity` values into `NaN`. This fixes the issue by checking that all values are finite before doing any calculation for the bounds. 

## Example
```
p = figure(match_aspect=True)
source = ColumnDataSource(data={'x': [], 'y': []})
p.circle(x='x', y='y', source=source)
p.circle(x=1, y=2)
```
Without the fix the ranges fail to set. However, with `match_aspect=False` the figure will set the ranges properly.