### PR TITLE
Allow supplying explicit edge paths for graphs

### DIFF
--- a/bokehjs/src/coffee/models/graphs/static_layout_provider.coffee
+++ b/bokehjs/src/coffee/models/graphs/static_layout_provider.coffee
@@ -14,6 +14,9 @@ export class StaticLayoutProvider extends LayoutProvider
     return [xs, ys]
 
   get_edge_coordinates: (edge_source) ->
+    if edge_source.data.xs? and edge_source.data.ys?
+      return [edge_source.data.xs, edge_source.data.ys]
+
     [xs, ys] = [[], []]
     starts = edge_source.data.start
     ends = edge_source.data.end

--- a/bokehjs/src/coffee/models/graphs/static_layout_provider.coffee
+++ b/bokehjs/src/coffee/models/graphs/static_layout_provider.coffee
@@ -14,19 +14,22 @@ export class StaticLayoutProvider extends LayoutProvider
     return [xs, ys]
 
   get_edge_coordinates: (edge_source) ->
-    if edge_source.data.xs? and edge_source.data.ys?
-      return [edge_source.data.xs, edge_source.data.ys]
-
     [xs, ys] = [[], []]
     starts = edge_source.data.start
     ends = edge_source.data.end
+    has_paths = edge_source.data.xs? and edge_source.data.ys?
     for i in [0...starts.length]
-      if @graph_layout[starts[i]]? and @graph_layout[ends[i]]?
-        [start, end] = [@graph_layout[starts[i]], @graph_layout[ends[i]]]
+      in_layout = @graph_layout[starts[i]]? and @graph_layout[ends[i]]?
+      if has_paths and in_layout
+        xs.push(edge_source.data.xs[i])
+        ys.push(edge_source.data.ys[i])
       else
-        [start, end] = [[NaN, NaN], [NaN, NaN]]
-      xs.push([start[0], end[0]])
-      ys.push([start[1], end[1]])
+        if in_layout
+          [start, end] = [@graph_layout[starts[i]], @graph_layout[ends[i]]]
+        else
+          [start, end] = [[NaN, NaN], [NaN, NaN]]
+        xs.push([start[0], end[0]])
+        ys.push([start[1], end[1]])
     return [xs, ys]
 
   @define {

--- a/bokehjs/test/models/graphs/static_layout_provider.coffee
+++ b/bokehjs/test/models/graphs/static_layout_provider.coffee
@@ -47,10 +47,32 @@ describe "StaticLayoutProvider", ->
         expect(xs).to.be.deep.equal([ [ -1, 0 ], [ -1, 1 ], [ -1, 0 ] ])
         expect(ys).to.be.deep.equal([ [ 0, 1 ], [ 0, 0 ], [ 0, -1 ] ])
 
+      it "should return explicit edge coords if exist", ->
+        edge_source = new ColumnDataSource()
+        edge_source.data.start = [0,0,0]
+        edge_source.data.end = [1,2,3]
+        edge_source.data.xs = [ [ -1, -0.5, 0 ], [ -1, 0, 1 ], [ -1, -0.5, 0 ] ]
+        edge_source.data.ys = [ [ 0, 0.5, 1 ], [ 0, 0, 0 ], [ 0, -0.5, -1 ] ]
+
+        [xs, ys] = @layout_provider.get_edge_coordinates(edge_source)
+        expect(xs).to.be.deep.equal([ [ -1, -0.5, 0 ], [ -1, 0, 1 ], [ -1, -0.5, 0 ] ])
+        expect(ys).to.be.deep.equal([ [ 0, 0.5, 1 ], [ 0, 0, 0 ], [ 0, -0.5, -1 ] ])
+
       it "should return NaNs if coords don't exist", ->
         edge_source = new ColumnDataSource()
         edge_source.data.start = [4,4,4]
         edge_source.data.end = [5,6,7]
+
+        [xs, ys] = @layout_provider.get_edge_coordinates(edge_source)
+        expect(xs).to.be.deep.equal([ [ NaN, NaN ], [ NaN, NaN ], [ NaN, NaN ] ])
+        expect(ys).to.be.deep.equal([ [ NaN, NaN ], [ NaN, NaN ], [ NaN, NaN ] ])
+
+      it "should not return explicit edge coords if coords don't exist", ->
+        edge_source = new ColumnDataSource()
+        edge_source.data.start = [4,4,4]
+        edge_source.data.end = [5,6,7]
+        edge_source.data.xs = [ [ -1, -0.5, 0 ], [ -1, 0, 1 ], [ -1, -0.5, 0 ] ]
+        edge_source.data.ys = [ [ 0, 0.5, 1 ], [ 0, 0, 0 ], [ 0, -0.5, -1 ] ]
 
         [xs, ys] = @layout_provider.get_edge_coordinates(edge_source)
         expect(xs).to.be.deep.equal([ [ NaN, NaN ], [ NaN, NaN ], [ NaN, NaN ] ])

--- a/sphinx/source/docs/user_guide/examples/graph_static_paths.py
+++ b/sphinx/source/docs/user_guide/examples/graph_static_paths.py
@@ -1,0 +1,49 @@
+import math
+
+from bokeh.io import show, output_file
+from bokeh.plotting import figure
+from bokeh.models import GraphRenderer, StaticLayoutProvider, Oval
+from bokeh.palettes import Spectral8
+
+N = 8
+node_indices = list(range(N))
+
+plot = figure(title="Graph Layout Demonstration", x_range=(-1.1,1.1), y_range=(-1.1,1.1),
+              tools="", toolbar_location=None)
+
+graph = GraphRenderer()
+
+graph.node_renderer.data_source.data = dict(
+    index=node_indices,
+    fill_color=Spectral8)
+graph.node_renderer.glyph = Oval(height=0.1, width=0.2, fill_color="fill_color")
+
+graph.edge_renderer.data_source.data = dict(
+    start=[0]*N,
+    end=node_indices)
+
+### start of layout code
+circ = [i*2*math.pi/8 for i in node_indices]
+x = [math.cos(i) for i in circ]
+y = [math.sin(i) for i in circ]
+graph_layout = dict(zip(node_indices, zip(x, y)))
+graph.layout_provider = StaticLayoutProvider(graph_layout=graph_layout)
+
+### Draw quadratic bezier paths
+def bezier(start, end, control, steps):
+    return (1-steps)**2*start + 2*(1-steps)*steps*control + steps**2*end
+
+xs, ys = [], []
+sx, sy = graph_layout[0]
+steps = np.linspace(0, 1, 100)
+for node_index in node_indices:
+    ex, ey = graph_layout[node_index]
+    xs.append(bezier(sx, ex, 0, steps))
+    ys.append(bezier(sy, ey, 0, steps))
+graph.edge_renderer.data_source.data['xs'] = xs
+graph.edge_renderer.data_source.data['ys'] = ys
+
+plot.renderers.append(graph)
+
+output_file("graph.html")
+show(plot)

--- a/sphinx/source/docs/user_guide/examples/graph_static_paths.py
+++ b/sphinx/source/docs/user_guide/examples/graph_static_paths.py
@@ -31,11 +31,11 @@ graph.layout_provider = StaticLayoutProvider(graph_layout=graph_layout)
 
 ### Draw quadratic bezier paths
 def bezier(start, end, control, steps):
-    return (1-steps)**2*start + 2*(1-steps)*steps*control + steps**2*end
+    return [(1-s)**2*start + 2*(1-s)*s*control + s**2*end for s in steps]
 
 xs, ys = [], []
 sx, sy = graph_layout[0]
-steps = np.linspace(0, 1, 100)
+steps = [i/100. for i in range(100)]
 for node_index in node_indices:
     ex, ey = graph_layout[node_index]
     xs.append(bezier(sx, ex, 0, steps))

--- a/sphinx/source/docs/user_guide/graph.rst
+++ b/sphinx/source/docs/user_guide/graph.rst
@@ -79,6 +79,23 @@ This example adds a provider to the above code snippet:
 .. bokeh-plot:: docs/user_guide/examples/graph_customize.py
     :source-position: above
 
+Explicit Paths
+--------------
+
+By default the :class:`~bokeh.models.graphs.StaticLayoutProvider` will
+draw straight-line paths between the supplied node positions. In order
+to supply explicit edge paths you may also supply lists of paths to
+the ``edge_renderer``
+:class:`bokeh.models.sources.ColumnDataSource`. The
+:class:`~bokeh.models.graphs.StaticLayoutProvider` will look for these
+paths on the ``"xs"`` and ``"ys"`` columns of the data source.
+
+This example extends the example from above to draw quadratic bezier
+paths between the nodes:
+
+.. bokeh-plot:: docs/user_guide/examples/graph_static_paths.py
+	:source-position: above
+
 Networkx Integration
 --------------------
 

--- a/sphinx/source/docs/user_guide/graph.rst
+++ b/sphinx/source/docs/user_guide/graph.rst
@@ -98,7 +98,7 @@ This example extends the example from above to draw quadratic bezier
 paths between the nodes:
 
 .. bokeh-plot:: docs/user_guide/examples/graph_static_paths.py
-	:source-position: above
+    :source-position: above
 
 Networkx Integration
 --------------------

--- a/sphinx/source/docs/user_guide/graph.rst
+++ b/sphinx/source/docs/user_guide/graph.rst
@@ -88,7 +88,11 @@ to supply explicit edge paths you may also supply lists of paths to
 the ``edge_renderer``
 :class:`bokeh.models.sources.ColumnDataSource`. The
 :class:`~bokeh.models.graphs.StaticLayoutProvider` will look for these
-paths on the ``"xs"`` and ``"ys"`` columns of the data source.
+paths on the ``"xs"`` and ``"ys"`` columns of the data source. Note
+that these paths should be in the same order as the ``"start"`` and
+``"end"`` points. Also note that there is no validation that they
+match up with the node positions so be extra careful when setting
+explicit paths.
 
 This example extends the example from above to draw quadratic bezier
 paths between the nodes:


### PR DESCRIPTION
When plotting a graph using the GraphRenderer and StaticLayoutProvider there is no way to supply an explicit set of paths because StaticLayoutProvider draws straight line paths from the start and end points. This PR allows supplying explicit 'xs' and 'ys' to the ``MultiLine`` CDS, which the ``StaticLayoutProvider`` will use rather than computing the straight line paths. Since the ``StaticLayoutProvider`` already expects ``start`` and ``end`` columns I think it's fine and consistent if it also looks for xs and ys, although I'd be open to respecting names set for 'xs' and 'ys' on the MultiLine glyph. Still needs tests and documentation. 

- [x] issues: fixes #6865 
- [x] tests added / passed
- [x] release document entry (if new feature or API change)
