### PR TITLE
Bryanv/6852 bar hittests

### DIFF
--- a/bokehjs/src/coffee/models/glyphs/box.coffee
+++ b/bokehjs/src/coffee/models/glyphs/box.coffee
@@ -44,6 +44,27 @@ export class BoxView extends GlyphView
     result['1d'].indices = hits
     return result
 
+  _hit_span: (geometry) ->
+
+    [vx, vy] = [geometry.vx, geometry.vy]
+
+    if geometry.direction == 'v'
+      y = @renderer.yscale.invert(vy)
+      hr = @renderer.plot_view.frame.h_range
+      minX = @renderer.xscale.invert(hr.min)
+      maxX = @renderer.xscale.invert(hr.max)
+      hits = @index.indices({ minX: minX, minY: y, maxX: maxX, maxY: y })
+    else
+      x = @renderer.xscale.invert(vx)
+      vr = @renderer.plot_view.frame.v_range
+      minY = @renderer.yscale.invert(vr.min)
+      maxY = @renderer.yscale.invert(vr.max)
+      hits = @index.indices({ minX: x, minY: minY, maxX: x, maxY: maxY })
+
+    result = hittest.create_hit_test_result()
+    result['1d'].indices = hits
+    return result
+
   draw_legend_for_index: (ctx, x0, x1, y0, y1, index) ->
     @_generic_area_legend(ctx, x0, x1, y0, y1, index)
 

--- a/bokehjs/src/coffee/models/glyphs/box.coffee
+++ b/bokehjs/src/coffee/models/glyphs/box.coffee
@@ -1,0 +1,51 @@
+import {RBush} from "core/util/spatial"
+import {Glyph, GlyphView} from "./glyph"
+import * as hittest from "core/hittest"
+import * as p from "core/properties"
+
+# Not a publicly exposed Glyph, exists to factor code for bars and quads
+
+export class BoxView extends GlyphView
+
+  _index_box: (len) ->
+    points = []
+
+    for i in [0...len]
+      [l, r, t, b] = @_lrtb(i)
+      if isNaN(l+r+t+b) or not isFinite(l+r+t+b)
+        continue
+      points.push({minX: l, minY: b, maxX: r, maxY: t, i: i})
+
+    return new RBush(points)
+
+  _render: (ctx, indices, {sleft, sright, stop, sbottom}) ->
+    for i in indices
+      if isNaN(sleft[i]+stop[i]+sright[i]+sbottom[i])
+        continue
+
+      if @visuals.fill.doit
+        @visuals.fill.set_vectorize(ctx, i)
+        ctx.fillRect(sleft[i], stop[i], sright[i]-sleft[i], sbottom[i]-stop[i])
+
+      if @visuals.line.doit
+        ctx.beginPath()
+        ctx.rect(sleft[i], stop[i], sright[i]-sleft[i], sbottom[i]-stop[i])
+        @visuals.line.set_vectorize(ctx, i)
+        ctx.stroke()
+
+  _hit_point: (geometry) ->
+    [vx, vy] = [geometry.vx, geometry.vy]
+    x = @renderer.xscale.invert(vx)
+    y = @renderer.yscale.invert(vy)
+
+    hits = @index.indices({minX: x, minY: y, maxX: x, maxY: y})
+
+    result = hittest.create_hit_test_result()
+    result['1d'].indices = hits
+    return result
+
+  draw_legend_for_index: (ctx, x0, x1, y0, y1, index) ->
+    @_generic_area_legend(ctx, x0, x1, y0, y1, index)
+
+export class Box extends Glyph
+  @mixins ['line', 'fill']

--- a/bokehjs/src/coffee/models/glyphs/hbar.coffee
+++ b/bokehjs/src/coffee/models/glyphs/hbar.coffee
@@ -72,7 +72,7 @@ export class HBar extends Glyph
   default_view: HBarView
   type: 'HBar'
 
-  @coords [['y', 'left']]
+  @coords [['left', 'y']]
   @mixins ['line', 'fill']
   @define {
     height: [ p.DistanceSpec  ]

--- a/bokehjs/src/coffee/models/glyphs/hbar.coffee
+++ b/bokehjs/src/coffee/models/glyphs/hbar.coffee
@@ -1,9 +1,19 @@
-import {RBush} from "core/util/spatial"
-import {Glyph, GlyphView} from "./glyph"
-import * as hittest from "core/hittest"
+import {Box, BoxView} from "./box"
 import * as p from "core/properties"
 
-export class HBarView extends GlyphView
+export class HBarView extends BoxView
+
+  scx: (i) -> return (@sleft[i] + @sright[i])/2
+
+  _index_data: () ->
+    return @_index_box(@_y.length)
+
+  _lrtb: (i) ->
+    l = Math.min(@_left[i], @_right[i])
+    r = Math.max(@_left[i], @_right[i])
+    t = @_y[i] + 0.5 * @_height[i]
+    b = @_y[i] - 0.5 * @_height[i]
+    return [l, r, t, b]
 
   _map_data: () ->
     vy = @renderer.yscale.v_compute(@_y)
@@ -23,57 +33,11 @@ export class HBarView extends GlyphView
       @sbottom.push(@sy[i] + @sh[i]/2)
     return null
 
-  _index_data: () ->
-    points = []
-
-    for i in [0...@_y.length]
-      l = Math.min(@_left[i], @_right[i])
-      r = Math.max(@_left[i], @_right[i])
-      t = @_y[i] + 0.5 * @_height[i]
-      b = @_y[i] - 0.5 * @_height[i]
-      if isNaN(l+r+t+b) or not isFinite(l+r+t+b)
-        continue
-      points.push({minX: l, minY: b, maxX: r, maxY: t, i: i})
-
-    return new RBush(points)
-
-  _render: (ctx, indices, {sleft, sright, stop, sbottom}) ->
-    for i in indices
-      if isNaN(sleft[i] + stop[i] + sright[i] + sbottom[i])
-        continue
-
-      if @visuals.fill.doit
-        @visuals.fill.set_vectorize(ctx, i)
-        ctx.fillRect(sleft[i], stop[i], sright[i]-sleft[i], sbottom[i]-stop[i])
-
-      if @visuals.line.doit
-        ctx.beginPath()
-        ctx.rect(sleft[i], stop[i], sright[i]-sleft[i], sbottom[i]-stop[i])
-        @visuals.line.set_vectorize(ctx, i)
-        ctx.stroke()
-
-  _hit_point: (geometry) ->
-    [vx, vy] = [geometry.vx, geometry.vy]
-    x = @renderer.xscale.invert(vx)
-    y = @renderer.yscale.invert(vy)
-
-    hits = @index.indices({minX: x, minY: y, maxX: x, maxY: y})
-
-    result = hittest.create_hit_test_result()
-    result['1d'].indices = hits
-    return result
-
-  scx: (i) -> return (@sleft[i] + @sright[i])/2
-
-  draw_legend_for_index: (ctx, x0, x1, y0, y1, index) ->
-    @_generic_area_legend(ctx, x0, x1, y0, y1, index)
-
-export class HBar extends Glyph
+export class HBar extends Box
   default_view: HBarView
   type: 'HBar'
 
   @coords [['left', 'y']]
-  @mixins ['line', 'fill']
   @define {
     height: [ p.DistanceSpec  ]
     right:  [ p.NumberSpec    ]

--- a/bokehjs/src/coffee/models/glyphs/quad.coffee
+++ b/bokehjs/src/coffee/models/glyphs/quad.coffee
@@ -1,49 +1,6 @@
-import {RBush} from "core/util/spatial"
-import {Glyph, GlyphView} from "./glyph"
-import {CategoricalScale} from "../scales/categorical_scale"
-import * as hittest from "core/hittest"
+import {Box, BoxView} from "./box"
 
-export class QuadView extends GlyphView
-
-  _index_data: () ->
-    points = []
-
-    for i in [0...@_left.length]
-      l = @_left[i]
-      r = @_right[i]
-      t = @_top[i]
-      b = @_bottom[i]
-      if isNaN(l+r+t+b) or not isFinite(l+r+t+b)
-        continue
-      points.push({minX: l, minY: b, maxX: r, maxY: t, i: i})
-
-    return new RBush(points)
-
-  _render: (ctx, indices, {sleft, sright, stop, sbottom}) ->
-    for i in indices
-      if isNaN(sleft[i]+stop[i]+sright[i]+sbottom[i])
-        continue
-
-      if @visuals.fill.doit
-        @visuals.fill.set_vectorize(ctx, i)
-        ctx.fillRect(sleft[i], stop[i], sright[i]-sleft[i], sbottom[i]-stop[i])
-
-      if @visuals.line.doit
-        ctx.beginPath()
-        ctx.rect(sleft[i], stop[i], sright[i]-sleft[i], sbottom[i]-stop[i])
-        @visuals.line.set_vectorize(ctx, i)
-        ctx.stroke()
-
-  _hit_point: (geometry) ->
-    [vx, vy] = [geometry.vx, geometry.vy]
-    x = @renderer.xscale.invert(vx)
-    y = @renderer.yscale.invert(vy)
-
-    hits = @index.indices({minX: x, minY: y, maxX: x, maxY: y})
-
-    result = hittest.create_hit_test_result()
-    result['1d'].indices = hits
-    return result
+export class QuadView extends BoxView
 
   get_anchor_point: (anchor, i, spt) ->
     left = Math.min(@sleft[i], @sright[i])
@@ -68,13 +25,18 @@ export class QuadView extends GlyphView
   scy: (i) ->
     return (@stop[i] + @sbottom[i])/2
 
-  draw_legend_for_index: (ctx, x0, x1, y0, y1, index) ->
-    @_generic_area_legend(ctx, x0, x1, y0, y1, index)
+  _index_data: () ->
+    return @_index_box(@_right.length)
 
-export class Quad extends Glyph
+  _lrtb: (i) ->
+    l = @_left[i]
+    r = @_right[i]
+    t = @_top[i]
+    b = @_bottom[i]
+    return [l, r, t, b]
+
+export class Quad extends Box
   default_view: QuadView
-
   type: 'Quad'
 
   @coords [['right', 'bottom'], ['left', 'top']]
-  @mixins ['line', 'fill']


### PR DESCRIPTION
 issues: fixes #6852

This PR fixes the point hover problem with `HBar`. This issue is that the coordinate specification was given in reverse. This is fixed in the first commit. The PR goes on to refactor bars and quads to share most implementation in a non-public `Box` base. Finally, in the third commit it adds a simple `_hit_span` so that all bars and quads now respond to `hline` and `vline` hovers.

An example is shown below (cursor was to the right of the bar, with mode `hline`)

<img width="538" alt="screen shot 2017-09-04 at 11 12 00" src="https://user-images.githubusercontent.com/1078448/30033714-70b45a94-9162-11e7-8829-3a3433631a77.png">
