### PR TITLE
add trace log level

### DIFF
--- a/bokeh/core/has_props.py
+++ b/bokeh/core/has_props.py
@@ -11,7 +11,7 @@ serializable properties.
 from __future__ import absolute_import
 
 import logging
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 import difflib
 import inspect
@@ -336,11 +336,11 @@ class HasProps(with_metaclass(MetaHasProps, object)):
 
         '''
         if name in self.properties():
-            #logger.debug("Patching attribute %s of %r", attr, patched_obj)
+            log.trace("Patching attribute %r of %r with %r", name, self, json)
             descriptor = self.lookup(name)
             descriptor.set_from_json(self, json, models, setter)
         else:
-            logger.warn("JSON had attr %r on obj %r, which is a client-only or invalid attribute that shouldn't have been sent", name, self)
+            log.warn("JSON had attr %r on obj %r, which is a client-only or invalid attribute that shouldn't have been sent", name, self)
 
     def update(self, **kwargs):
         ''' Updates the object's properties from the given keyword arguments.

--- a/bokeh/server/session.py
+++ b/bokeh/server/session.py
@@ -179,7 +179,7 @@ class ServerSession(object):
         # other and their final states will differ.
         for connection in self._subscribed_connections:
             if may_suppress and connection is self._current_patch_connection:
-                pass #log.debug("Not sending notification back to client %r for a change it requested", connection)
+                log.trace("Not sending notification back to client %r for a change it requested", connection)
             else:
                 self._pending_writes.append(connection.send_patch_document(event))
 

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -120,7 +120,8 @@ class Settings(object):
 
         '''
         level = self._get_str("PY_LOG_LEVEL", default, "debug")
-        LEVELS = {'debug': logging.DEBUG,
+        LEVELS = {'trace': logging.TRACE,
+                  'debug': logging.DEBUG,
                   'info' : logging.INFO,
                   'warn' : logging.WARNING,
                   'error': logging.ERROR,
@@ -317,6 +318,7 @@ class Settings(object):
 #:
 #:   As in the JS side, valid values are, in order of increasing severity:
 #:
+#:   - ``trace``
 #:   - ``debug``
 #:   - ``info``
 #:   - ``warn``

--- a/bokeh/util/logconfig.py
+++ b/bokeh/util/logconfig.py
@@ -22,6 +22,14 @@ import sys
 
 from ..settings import settings
 
+TRACE = 9
+logging.addLevelName(TRACE, "TRACE")
+def trace(self, message, *args, **kws):
+    if self.isEnabledFor(TRACE):
+        self._log(TRACE, message, args, **kws)
+logging.Logger.trace = trace
+logging.TRACE = TRACE
+
 level = settings.py_log_level()
 bokeh_logger = logging.getLogger('bokeh')
 root_logger = logging.getLogger()

--- a/sphinx/source/docs/dev_guide/env_vars.rst
+++ b/sphinx/source/docs/dev_guide/env_vars.rst
@@ -103,6 +103,7 @@ Accepted values are ``yes``/``no``, ``true``/``false`` or ``0``/``1``.
 The Python logging level to set
 As in the JS side, valid values are, in order of increasing severity:
 
+  - ``trace``
   - ``debug``
   - ``info``
   - ``warn``


### PR DESCRIPTION
issues: closes #6888 

This adds a `trace` log level and uncomments any commented `debug` log calls, replacing them with uncommented `trace` instead.

@bokeh/dev any comments on whether there are any downsides to monkey patching `logging` ?