### PR TITLE
Expose airport_routes data via bokeh.sampledata

### DIFF
--- a/bokeh/sampledata/__init__.py
+++ b/bokeh/sampledata/__init__.py
@@ -75,6 +75,8 @@ def download(progress=True):
         (s3, 'world_cities.zip'),
         (s3, 'airports.json'),
         (s3, 'movies.db.zip'),
+        (s3, 'airports.csv'),
+        (s3, 'routes.csv'),
     ]
 
     for base_url, file_name in files:

--- a/bokeh/sampledata/airport_routes.py
+++ b/bokeh/sampledata/airport_routes.py
@@ -1,0 +1,21 @@
+""" The data in airports.csv and routes.csv is a subset of data available from
+OpenFlights.orgs, limited to US airports. The complete data was collected on
+September 07, 2017 and is available from:
+
+.. code-block:: none
+
+    https://openflights.org/data.html
+
+"""
+from __future__ import absolute_import
+
+from bokeh.util.dependencies import import_required
+pd = import_required('pandas',
+              'airports sample data requires Pandas (http://pandas.pydata.org) to be installed')
+
+import os
+
+from . import _data_dir
+
+airports = pd.read_csv(os.path.join(_data_dir(), 'airports.csv'))
+routes = pd.read_csv(os.path.join(_data_dir(), 'routes.csv'))

--- a/bokeh/sampledata/airport_routes.py
+++ b/bokeh/sampledata/airport_routes.py
@@ -1,5 +1,5 @@
-""" The data in airports.csv and routes.csv is a subset of data available from
-OpenFlights.orgs, limited to US airports. The complete data was collected on
+""" The data in airports.csv and routes.csv is a subset (limited to US airports)
+of data available from OpenFlights.org. The complete data was collected on
 September 07, 2017 and is available from:
 
 .. code-block:: none


### PR DESCRIPTION
Expose airport_routes data via bokeh.sampledata

- [ ] issues: fixes #6902 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

Data need to be uploaded to S3 before merging.