### PR TITLE
Binary array transport

### DIFF
--- a/bokeh/client/__init__.py
+++ b/bokeh/client/__init__.py
@@ -1,4 +1,15 @@
-''' Provides client API for connecting to a Bokeh server
+''' Provides client API for connecting to a Bokeh server from a Python
+process.
+
+The primary uses for the ``bokeh.client`` are:
+
+* Implementing testing infrastructure around Bokeh applications
+* Creating and customizing specific sessions of a Bokeh application
+  running *in a Bokeh Server*, before passing them to a viewer.
+
+While it is also possible to run Bokeh application code "outside" a
+Bokeh server using ``bokeh.client``, this practice is **HIGHLY DISCOURCED**.
+
 
 '''
 from __future__ import absolute_import

--- a/bokeh/client/connection.py
+++ b/bokeh/client/connection.py
@@ -5,116 +5,32 @@ Server. Users will always want to use ``bokeh.client.session`` instead.
 from __future__ import absolute_import, print_function
 
 import logging
-
 log = logging.getLogger(__name__)
 
-from tornado import gen, locks
+from tornado import gen
 from tornado.httpclient import HTTPRequest
 from tornado.ioloop import IOLoop
 from tornado.websocket import websocket_connect, WebSocketError
-from tornado.concurrent import Future
 
 from bokeh.protocol import Protocol
 from bokeh.protocol.exceptions import MessageError, ProtocolError, ValidationError
 from bokeh.protocol.receiver import Receiver
 
-class _WebSocketClientConnectionWrapper(object):
-    ''' Used for compat across Tornado versions and to add write_lock'''
-
-    def __init__(self, socket):
-        if socket is None:
-            raise ValueError("socket must not be None")
-        self._socket = socket
-        # write_lock allows us to lock the connection to send multiple
-        # messages atomically.
-        self.write_lock = locks.Lock()
-
-    @gen.coroutine
-    def write_message(self, message, binary=False, locked=True):
-        def write_message_unlocked():
-            if self._socket.protocol is None:
-                # Tornado is maybe supposed to do this, but in fact it
-                # tries to do _socket.protocol.write_message when protocol
-                # is None and throws AttributeError or something. So avoid
-                # trying to write to the closed socket. There doesn't seem
-                # to be an obvious public function to check if the socket
-                # is closed.
-                raise WebSocketError("Connection to the server has been closed")
-
-            future = self._socket.write_message(message, binary)
-            if future is None:
-                # tornado >= 4.3 gives us a Future, simulate that
-                # with this fake Future on < 4.3
-                future = Future()
-                future.set_result(None)
-            # don't yield this future or we're blocking on ourselves!
-            raise gen.Return(future)
-
-        if locked:
-            with (yield self.write_lock.acquire()):
-                write_message_unlocked()
-        else:
-            write_message_unlocked()
-
-    def close(self, code=None, reason=None):
-        return self._socket.close(code, reason)
-
-    def read_message(self, callback=None):
-        return self._socket.read_message(callback)
+from .states import NOT_YET_CONNECTED, CONNECTED_BEFORE_ACK, CONNECTED_AFTER_ACK, DISCONNECTED, WAITING_FOR_REPLY
+from .websocket import WebSocketClientConnectionWrapper
 
 class ClientConnection(object):
     """ A Bokeh-private class used to implement ClientSession; use ClientSession to connect to the server."""
 
-    class NOT_YET_CONNECTED(object):
-        @gen.coroutine
-        def run(self, connection):
-            yield connection._connect_async()
-
-    class CONNECTED_BEFORE_ACK(object):
-        @gen.coroutine
-        def run(self, connection):
-            yield connection._wait_for_ack()
-
-    class CONNECTED_AFTER_ACK(object):
-        @gen.coroutine
-        def run(self, connection):
-            yield connection._handle_messages()
-
-    class DISCONNECTED(object):
-        @gen.coroutine
-        def run(self, connection):
-            raise gen.Return(None)
-
-    class WAITING_FOR_REPLY(object):
-        def __init__(self, reqid):
-            self._reqid = reqid
-            self._reply = None
-
-        @property
-        def reply(self):
-            return self._reply
-
-        @gen.coroutine
-        def run(self, connection):
-            message = yield connection._pop_message()
-            if message is None:
-                yield connection._transition_to_disconnected()
-            elif 'reqid' in message.header and message.header['reqid'] == self._reqid:
-                self._reply = message
-                yield connection._transition(connection.CONNECTED_AFTER_ACK())
-            else:
-                yield connection._next()
-
     def __init__(self, session, websocket_url, io_loop=None):
-        '''
-          Opens a websocket connection to the server.
+        ''' Opens a websocket connection to the server.
         '''
         self._url = websocket_url
         self._session = session
         self._protocol = Protocol("1.0")
         self._receiver = Receiver(self._protocol)
         self._socket = None
-        self._state = self.NOT_YET_CONNECTED()
+        self._state = NOT_YET_CONNECTED()
         if io_loop is None:
             # We can't use IOLoop.current because then we break
             # when running inside a notebook since ipython also uses it
@@ -135,13 +51,13 @@ class ClientConnection(object):
     @property
     def connected(self):
         """True if we've connected the websocket and exchanged initial handshake messages."""
-        return isinstance(self._state, self.CONNECTED_AFTER_ACK)
+        return isinstance(self._state, CONNECTED_AFTER_ACK)
 
     def connect(self):
         def connected_or_closed():
             # we should be looking at the same state here as the 'connected' property above, so connected
             # means both connected and that we did our initial message exchange
-            return isinstance(self._state, self.CONNECTED_AFTER_ACK) or isinstance(self._state, self.DISCONNECTED)
+            return isinstance(self._state, CONNECTED_AFTER_ACK) or isinstance(self._state, DISCONNECTED)
         self._loop_until(connected_or_closed)
 
     def close(self, why="closed"):
@@ -149,14 +65,14 @@ class ClientConnection(object):
             self._socket.close(1000, why)
 
     def loop_until_closed(self):
-        if isinstance(self._state, self.NOT_YET_CONNECTED):
+        if isinstance(self._state, NOT_YET_CONNECTED):
             # we don't use self._transition_to_disconnected here
             # because _transition is a coroutine
             self._tell_session_about_disconnect()
-            self._state = self.DISCONNECTED()
+            self._state = DISCONNECTED()
         else:
             def closed():
-                return isinstance(self._state, self.DISCONNECTED)
+                return isinstance(self._state, DISCONNECTED)
             self._loop_until(closed)
 
     @gen.coroutine
@@ -204,7 +120,7 @@ class ClientConnection(object):
         self.send_message(msg)
 
     def _send_message_wait_for_reply(self, message):
-        waiter = self.WAITING_FOR_REPLY(message.header['msgid'])
+        waiter = WAITING_FOR_REPLY(message.header['msgid'])
         self._state = waiter
 
         send_result = []
@@ -319,7 +235,7 @@ class ClientConnection(object):
     @gen.coroutine
     def _transition_to_disconnected(self):
         self._tell_session_about_disconnect()
-        yield self._transition(self.DISCONNECTED())
+        yield self._transition(DISCONNECTED())
 
     @gen.coroutine
     def _connect_async(self):
@@ -327,14 +243,14 @@ class ClientConnection(object):
         request = HTTPRequest(versioned_url)
         try:
             socket = yield websocket_connect(request)
-            self._socket = _WebSocketClientConnectionWrapper(socket)
+            self._socket = WebSocketClientConnectionWrapper(socket)
         except Exception as e:
             log.info("Failed to connect to server: %r", e)
 
         if self._socket is None:
             yield self._transition_to_disconnected()
         else:
-            yield self._transition(self.CONNECTED_BEFORE_ACK())
+            yield self._transition(CONNECTED_BEFORE_ACK())
 
 
     @gen.coroutine
@@ -342,7 +258,7 @@ class ClientConnection(object):
         message = yield self._pop_message()
         if message and message.msgtype == 'ACK':
             log.debug("Received %r", message)
-            yield self._transition(self.CONNECTED_AFTER_ACK())
+            yield self._transition(CONNECTED_AFTER_ACK())
         elif message is None:
             yield self._transition_to_disconnected()
         else:

--- a/bokeh/client/connection.py
+++ b/bokeh/client/connection.py
@@ -1,5 +1,8 @@
 ''' Implements a very low level facility for communicating with a Bokeh
-Server. Users will always want to use ``bokeh.client.session`` instead.
+Server.
+
+Users will always want to use :class:`~bokeh.client.session.ClientSession`
+instead for standard usage.
 
 '''
 from __future__ import absolute_import, print_function
@@ -20,10 +23,13 @@ from .states import NOT_YET_CONNECTED, CONNECTED_BEFORE_ACK, CONNECTED_AFTER_ACK
 from .websocket import WebSocketClientConnectionWrapper
 
 class ClientConnection(object):
-    """ A Bokeh-private class used to implement ClientSession; use ClientSession to connect to the server."""
+    ''' A Bokeh low-level class used to implement ClientSession; use ClientSession to connect to the server.
+
+    '''
 
     def __init__(self, session, websocket_url, io_loop=None):
         ''' Opens a websocket connection to the server.
+
         '''
         self._url = websocket_url
         self._session = session
@@ -42,15 +48,20 @@ class ClientConnection(object):
 
     @property
     def url(self):
+        ''' The URL of the websocket this Connection is to. '''
         return self._url
 
     @property
     def io_loop(self):
+        ''' The Tornado ``IOLoop`` this connection is using. '''
         return self._loop
 
     @property
     def connected(self):
-        """True if we've connected the websocket and exchanged initial handshake messages."""
+        ''' Whether we've connected the Websocket and have exchanged initial
+        handshake messages.
+
+        '''
         return isinstance(self._state, CONNECTED_AFTER_ACK)
 
     def connect(self):
@@ -61,10 +72,21 @@ class ClientConnection(object):
         self._loop_until(connected_or_closed)
 
     def close(self, why="closed"):
+        ''' Close the Websocket connection.
+
+        '''
         if self._socket is not None:
             self._socket.close(1000, why)
 
     def loop_until_closed(self):
+        ''' Execute a blocking loop that runs and exectutes event callbacks
+        until the connection is closed (e.g. by hitting Ctrl-C).
+
+        While this method can be used to run Bokeh application code "outside"
+        the Bokeh server, this practice is HIGHLY DISCOURAGED for any real
+        use case.
+
+        '''
         if isinstance(self._state, NOT_YET_CONNECTED):
             # we don't use self._transition_to_disconnected here
             # because _transition is a coroutine
@@ -142,10 +164,12 @@ class ClientConnection(object):
         ''' Push a document to the server, overwriting any existing server-side doc.
 
         Args:
-            document : bokeh.document.Document
-              the Document to push to the server
+            document : (Document)
+                A Document to push to the server
+
         Returns:
-             The server reply
+            The server reply
+
         '''
         msg = self._protocol.create('PUSH-DOC', document)
         reply = self._send_message_wait_for_reply(msg)
@@ -158,11 +182,14 @@ class ClientConnection(object):
 
     def pull_doc(self, document):
         ''' Pull a document from the server, overwriting the passed-in document
+
         Args:
-            document : bokeh.document.Document
+            document : (Document)
               The document to overwrite with server content.
+
         Returns:
             None
+
         '''
         msg = self._protocol.create('PULL-DOC-REQ')
         reply = self._send_message_wait_for_reply(msg)
@@ -181,24 +208,26 @@ class ClientConnection(object):
         return reply.content
 
     def request_server_info(self):
-        '''
-        Ask for information about the server.
+        ''' Ask for information about the server.
 
         Returns:
             A dictionary of server attributes.
+
         '''
         if self._server_info is None:
             self._server_info = self._send_request_server_info()
         return self._server_info
 
     def force_roundtrip(self):
-        '''
-        Force a round-trip request/reply to the server, sometimes needed to avoid race conditions.
+        ''' Force a round-trip request/reply to the server, sometimes needed to
+        avoid race conditions. Mostly useful for testing.
 
-        Outside of test suites, this method probably hurts performance and shouldn't be needed.
+        Outside of test suites, this method hurts performance and should not be
+        needed.
 
         Returns:
            None
+
         '''
         self._send_request_server_info()
 

--- a/bokeh/client/states.py
+++ b/bokeh/client/states.py
@@ -1,0 +1,50 @@
+'''
+
+'''
+from __future__ import absolute_import, print_function
+
+from tornado import gen
+
+class NOT_YET_CONNECTED(object):
+    @gen.coroutine
+    def run(self, connection):
+        yield connection._connect_async()
+
+class CONNECTED_BEFORE_ACK(object):
+    @gen.coroutine
+    def run(self, connection):
+        yield connection._wait_for_ack()
+
+class CONNECTED_AFTER_ACK(object):
+    @gen.coroutine
+    def run(self, connection):
+        yield connection._handle_messages()
+
+class DISCONNECTED(object):
+    @gen.coroutine
+    def run(self, connection):
+        raise gen.Return(None)
+
+class WAITING_FOR_REPLY(object):
+    def __init__(self, reqid):
+        self._reqid = reqid
+        self._reply = None
+
+    @property
+    def reply(self):
+        return self._reply
+
+    @property
+    def reqid(self):
+        return self._reqid
+
+    @gen.coroutine
+    def run(self, connection):
+        message = yield connection._pop_message()
+        if message is None:
+            yield connection._transition_to_disconnected()
+        elif 'reqid' in message.header and message.header['reqid'] == self.reqid:
+            self._reply = message
+            yield connection._transition(CONNECTED_AFTER_ACK())
+        else:
+            yield connection._next()

--- a/bokeh/client/states.py
+++ b/bokeh/client/states.py
@@ -1,4 +1,5 @@
-'''
+''' Provide a set of objects to represent different stages of a connection
+to a Bokeh server.
 
 '''
 from __future__ import absolute_import, print_function
@@ -6,36 +7,57 @@ from __future__ import absolute_import, print_function
 from tornado import gen
 
 class NOT_YET_CONNECTED(object):
+    ''' The ``ClientConnection`` is not yet connected.
+
+    '''
     @gen.coroutine
     def run(self, connection):
         yield connection._connect_async()
 
 class CONNECTED_BEFORE_ACK(object):
+    ''' The ``ClientConnection`` connected to a Bokeh server, but has not yet
+    received an ACK from it.
+
+    '''
     @gen.coroutine
     def run(self, connection):
         yield connection._wait_for_ack()
 
 class CONNECTED_AFTER_ACK(object):
+    ''' The ``ClientConnection`` connected to a Bokeh server, and has
+    received an ACK from it.
+
+    '''
     @gen.coroutine
     def run(self, connection):
         yield connection._handle_messages()
 
 class DISCONNECTED(object):
+    ''' The ``ClientConnection`` was connected to a Bokeh server, but is
+    now disconnected.
+
+    '''
     @gen.coroutine
     def run(self, connection):
         raise gen.Return(None)
 
 class WAITING_FOR_REPLY(object):
+    ''' The ``ClientConnection`` has sent a message to the Bokeh Server which
+    should generate a paired reply, and is waiting for the reply.
+
+    '''
     def __init__(self, reqid):
         self._reqid = reqid
         self._reply = None
 
     @property
     def reply(self):
+        ''' The reply from the server. (``None`` until the reply arrives) '''
         return self._reply
 
     @property
     def reqid(self):
+        ''' The request ID of the originating message. '''
         return self._reqid
 
     @gen.coroutine

--- a/bokeh/client/tests/test_states.py
+++ b/bokeh/client/tests/test_states.py
@@ -1,0 +1,59 @@
+from tornado import gen
+
+import bokeh.client.states as bcs
+
+class _MockConnection(object):
+    def __init__(self, to_pop=None): self._to_pop = to_pop
+
+    def _connect_async(self): raise gen.Return("_connect_async")
+    def _wait_for_ack(self): raise gen.Return("_wait_for_ack")
+    def _handle_messages(self): raise gen.Return("_handle_messages")
+    def _transition(self, arg): raise gen.Return(("_transition", arg))
+    def _transition_to_disconnected(self): raise gen.Return("_transition_to_disconnected")
+    def _next(self): raise gen.Return("_next")
+
+    @gen.coroutine
+    def _pop_message(self): raise gen.Return(self._to_pop)
+
+class _MockMessage(object):
+    header = {'reqid': 'reqid'}
+
+def test_NOT_YET_CONNECTED():
+    s = bcs.NOT_YET_CONNECTED()
+    r = s.run(_MockConnection())
+    assert r.result() == "_connect_async"
+
+def test_CONNECTED_BEFORE_ACK():
+    s = bcs.CONNECTED_BEFORE_ACK()
+    r = s.run(_MockConnection())
+    assert r.result() == "_wait_for_ack"
+
+def test_CONNECTED_AFTER_ACK():
+    s = bcs.CONNECTED_AFTER_ACK()
+    r = s.run(_MockConnection())
+    assert r.result() == "_handle_messages"
+
+def test_DISCONNECTED():
+    s = bcs.DISCONNECTED()
+    r = s.run(_MockConnection())
+    assert r.result() is None
+
+def test_WAITING_FOR_REPLY():
+    s = bcs.WAITING_FOR_REPLY("reqid")
+    assert s.reply == None
+    assert s.reqid == "reqid"
+
+    r = s.run(_MockConnection(to_pop=None))
+    assert r.result() == "_transition_to_disconnected"
+    assert s.reply is None
+
+    m = _MockMessage()
+    r = s.run(_MockConnection(to_pop=m))
+    res = r.result()
+    assert res[0] == "_transition"
+    assert isinstance(res[1], bcs.CONNECTED_AFTER_ACK)
+    assert s.reply is m
+
+    s._reqid = "nomatch"
+    r = s.run(_MockConnection(to_pop=m))
+    assert r.result() == "_next"

--- a/bokeh/client/tests/test_util.py
+++ b/bokeh/client/tests/test_util.py
@@ -1,0 +1,31 @@
+import pytest
+
+import bokeh.client.util as bcu
+
+def test_server_url_for_websocket_url_with_ws():
+    assert bcu.server_url_for_websocket_url("ws://foo.com/ws") == "http://foo.com/"
+
+def test_server_url_for_websocket_url_with_wss():
+    assert bcu.server_url_for_websocket_url("wss://foo.com/ws") == "https://foo.com/"
+
+def test_server_url_for_websocket_url_bad_proto():
+    with pytest.raises(ValueError):
+        bcu.server_url_for_websocket_url("junk://foo.com/ws")
+
+def test_server_url_for_websocket_url_bad_ending():
+    with pytest.raises(ValueError):
+        bcu.server_url_for_websocket_url("ws://foo.com/junk")
+    with pytest.raises(ValueError):
+        bcu.server_url_for_websocket_url("wss://foo.com/junk")
+
+def test_websocket_url_for_server_url_with_http():
+    assert bcu.websocket_url_for_server_url("http://foo.com") == "ws://foo.com/ws"
+    assert bcu.websocket_url_for_server_url("http://foo.com/") == "ws://foo.com/ws"
+
+def test_websocket_url_for_server_url_with_https():
+    assert bcu.websocket_url_for_server_url("https://foo.com") == "wss://foo.com/ws"
+    assert bcu.websocket_url_for_server_url("https://foo.com/") == "wss://foo.com/ws"
+
+def test_websocket_url_for_server_url_bad_proto():
+    with pytest.raises(ValueError):
+        bcu.websocket_url_for_server_url("junk://foo.com")

--- a/bokeh/client/util.py
+++ b/bokeh/client/util.py
@@ -1,9 +1,25 @@
-'''
+''' Internal utility functions used by ``bokeh.client``
 
 '''
 from __future__ import absolute_import, print_function
 
 def server_url_for_websocket_url(url):
+    ''' Convert an ``ws(s)`` URL for a Bokeh server into the appropriate
+    ``http(s)`` URL for the websocket endpoint.
+
+    Args:
+        url (str):
+            An ``ws(s)`` URL ending in ``/ws``
+
+    Returns:
+        str:
+            The corresponding ``http(s)`` URL.
+
+    Raises:
+        ValueError:
+            If the input URL is not of the proper form.
+
+    '''
     if url.startswith("ws:"):
         reprotocoled = "http" + url[2:]
     elif url.startswith("wss:"):
@@ -15,6 +31,22 @@ def server_url_for_websocket_url(url):
     return reprotocoled[:-2]
 
 def websocket_url_for_server_url(url):
+    ''' Convert an ``http(s)`` URL for a Bokeh server websocket endpoint into
+    the appropriate ``ws(s)`` URL
+
+    Args:
+        url (str):
+            An ``http(s)`` URL
+
+    Returns:
+        str:
+            The corresponding ``ws(s)`` URL ending in ``/ws``
+
+    Raises:
+        ValueError:
+            If the input URL is not of the proper form.
+
+    '''
     if url.startswith("http:"):
         reprotocoled = "ws" + url[4:]
     elif url.startswith("https:"):

--- a/bokeh/client/util.py
+++ b/bokeh/client/util.py
@@ -1,0 +1,27 @@
+'''
+
+'''
+from __future__ import absolute_import, print_function
+
+def server_url_for_websocket_url(url):
+    if url.startswith("ws:"):
+        reprotocoled = "http" + url[2:]
+    elif url.startswith("wss:"):
+        reprotocoled = "https" + url[3:]
+    else:
+        raise ValueError("URL has non-websocket protocol " + url)
+    if not reprotocoled.endswith("/ws"):
+        raise ValueError("websocket URL does not end in /ws")
+    return reprotocoled[:-2]
+
+def websocket_url_for_server_url(url):
+    if url.startswith("http:"):
+        reprotocoled = "ws" + url[4:]
+    elif url.startswith("https:"):
+        reprotocoled = "wss" + url[5:]
+    else:
+        raise ValueError("URL has unknown protocol " + url)
+    if reprotocoled.endswith("/"):
+        return reprotocoled + "ws"
+    else:
+        return reprotocoled + "/ws"

--- a/bokeh/client/websocket.py
+++ b/bokeh/client/websocket.py
@@ -1,0 +1,47 @@
+'''
+
+'''
+from __future__ import absolute_import, print_function
+
+from tornado import gen, locks
+from tornado.websocket import WebSocketError
+
+class WebSocketClientConnectionWrapper(object):
+    ''' Used for compat across Tornado versions and to add write_lock'''
+
+    def __init__(self, socket):
+        if socket is None:
+            raise ValueError("socket must not be None")
+        self._socket = socket
+        # write_lock allows us to lock the connection to send multiple
+        # messages atomically.
+        self.write_lock = locks.Lock()
+
+    @gen.coroutine
+    def write_message(self, message, binary=False, locked=True):
+        def write_message_unlocked():
+            if self._socket.protocol is None:
+                # Tornado is maybe supposed to do this, but in fact it
+                # tries to do _socket.protocol.write_message when protocol
+                # is None and throws AttributeError or something. So avoid
+                # trying to write to the closed socket. There doesn't seem
+                # to be an obvious public function to check if the socket
+                # is closed.
+                raise WebSocketError("Connection to the server has been closed")
+
+            future = self._socket.write_message(message, binary)
+
+            # don't yield this future or we're blocking on ourselves!
+            raise gen.Return(future)
+
+        if locked:
+            with (yield self.write_lock.acquire()):
+                write_message_unlocked()
+        else:
+            write_message_unlocked()
+
+    def close(self, code=None, reason=None):
+        return self._socket.close(code, reason)
+
+    def read_message(self, callback=None):
+        return self._socket.read_message(callback)

--- a/bokeh/client/websocket.py
+++ b/bokeh/client/websocket.py
@@ -1,4 +1,5 @@
-'''
+''' Provide a low-level wrapper for Tornado Websockets that adds locking
+and smooths some compatibility issues.
 
 '''
 from __future__ import absolute_import, print_function
@@ -19,6 +20,10 @@ class WebSocketClientConnectionWrapper(object):
 
     @gen.coroutine
     def write_message(self, message, binary=False, locked=True):
+        ''' Write a message to the websocket after obtaining the appropriate
+        Bokeh Document lock.
+
+        '''
         def write_message_unlocked():
             if self._socket.protocol is None:
                 # Tornado is maybe supposed to do this, but in fact it
@@ -41,7 +46,11 @@ class WebSocketClientConnectionWrapper(object):
             write_message_unlocked()
 
     def close(self, code=None, reason=None):
+        ''' Close the websocket. '''
         return self._socket.close(code, reason)
 
     def read_message(self, callback=None):
+        ''' Read a message from websocket and execute a callback.
+
+        '''
         return self._socket.read_message(callback)

--- a/bokeh/core/property/containers.py
+++ b/bokeh/core/property/containers.py
@@ -313,19 +313,7 @@ class PropertyValueColumnData(PropertyValueDict):
     # x[i] = y
     # don't wrap with notify_owner --- notifies owners explicitly
     def __setitem__(self, i, y):
-        old = self._saved_copy()
-
-        result =  super(PropertyValueDict, self).__setitem__(i, y)
-
-        from ...document.events import ColumnDataChangedEvent
-
-        # we must loop ourselves here instead of calling _notify_owners
-        # because the hint is customized for each owner separately
-        for (owner, descriptor) in self._owners:
-            hint = ColumnDataChangedEvent(owner.document, owner, cols=[i])
-            descriptor._notify_mutated(owner, old, hint=hint)
-
-        return result
+        return self.update([(i, y)])
 
     # don't wrap with notify_owner --- notifies owners explicitly
     def update(self, *args, **kwargs):

--- a/bokeh/core/property/containers.py
+++ b/bokeh/core/property/containers.py
@@ -350,7 +350,7 @@ class PropertyValueColumnData(PropertyValueDict):
         # we must loop ourselves here instead of calling _notify_owners
         # because the hint is customized for each owner separately
         for (owner, descriptor) in self._owners:
-            hint = ColumnDataChangedEvent(owner.document, owner, cols=cols)
+            hint = ColumnDataChangedEvent(owner.document, owner, cols=list(cols))
             descriptor._notify_mutated(owner, old, hint=hint)
 
         return result

--- a/bokeh/core/property/containers.py
+++ b/bokeh/core/property/containers.py
@@ -295,9 +295,65 @@ class PropertyValueDict(PropertyValueContainer, dict):
         return super(PropertyValueDict, self).update(*args, **kwargs)
 
 class PropertyValueColumnData(PropertyValueDict):
-    '''
+    ''' A property value container for ColumnData that supports change
+    notifications on mutating operations.
+
+    This property value container affords specialized code paths for
+    updating the .data dictionary for ColumnDataSource. When possible,
+    more efficient ColumnDataChangedEvent hints are generated to perform
+    the updates:
+
+    .. code-block:: python
+        x[i] = y
+        x.update
 
     '''
+
+    # x[i] = y
+    # don't wrap with notify_owner --- notifies owners explicitly
+    def __setitem__(self, i, y):
+        old = self._saved_copy()
+
+        result =  super(PropertyValueDict, self).__setitem__(i, y)
+
+        from ...document.events import ColumnDataChangedEvent
+
+        # we must loop ourselves here instead of calling _notify_owners
+        # because the hint is customized for each owner separately
+        for (owner, descriptor) in self._owners:
+            hint = ColumnDataChangedEvent(owner.document, owner, cols=[i])
+            descriptor._notify_mutated(owner, old, hint=hint)
+
+        return result
+
+    # don't wrap with notify_owner --- notifies owners explicitly
+    def update(self, *args, **kwargs):
+        old = self._saved_copy()
+
+        result = super(PropertyValueDict, self).update(*args, **kwargs)
+
+        from ...document.events import ColumnDataChangedEvent
+
+        # Grab keys to update according to  Python docstring for update([E, ]**F)
+        #
+        # If E is present and has a .keys() method, then does:  for k in E: D[k] = E[k]
+        # If E is present and lacks a .keys() method, then does:  for k, v in E: D[k] = v
+        # In either case, this is followed by: for k in F:  D[k] = F[k]
+        cols = set(kwargs.keys())
+        if len(args) == 1:
+            E = args[0]
+            if hasattr(E, 'keys'):
+                cols |= set(E.keys())
+            else:
+                cols |= { x[0] for x in E }
+
+        # we must loop ourselves here instead of calling _notify_owners
+        # because the hint is customized for each owner separately
+        for (owner, descriptor) in self._owners:
+            hint = ColumnDataChangedEvent(owner.document, owner, cols=cols)
+            descriptor._notify_mutated(owner, old, hint=hint)
+
+        return result
 
     # don't wrap with notify_owner --- notifies owners explicitly
     def _stream(self, doc, source, new_data, rollover=None, setter=None):

--- a/bokeh/core/property/containers.py
+++ b/bokeh/core/property/containers.py
@@ -304,6 +304,7 @@ class PropertyValueColumnData(PropertyValueDict):
     the updates:
 
     .. code-block:: python
+
         x[i] = y
         x.update
 

--- a/bokeh/core/property/descriptors.py
+++ b/bokeh/core/property/descriptors.py
@@ -670,22 +670,17 @@ class BasicPropertyDescriptor(PropertyDescriptor):
         default = self.instance_default(obj)
 
         if is_themed:
-            if self.name in obj._unstable_themed_values:
-                return obj._unstable_themed_values[self.name]
+            unstable_dict = obj._unstable_themed_values
+        else:
+            unstable_dict = obj._unstable_default_values
 
-            if self.property._may_have_unstable_default():
-                if isinstance(default, PropertyValueContainer):
-                    default._register_owner(obj, self)
-                obj._unstable_themed_values[self.name] = default
-            return default
-
-        if self.name in obj._unstable_default_values:
-            return obj._unstable_default_values[self.name]
+        if self.name in unstable_dict:
+            return unstable_dict[self.name]
 
         if self.property._may_have_unstable_default():
             if isinstance(default, PropertyValueContainer):
                 default._register_owner(obj, self)
-            obj._unstable_default_values[self.name] = default
+            unstable_dict[self.name] = default
 
         return default
 
@@ -735,8 +730,7 @@ class BasicPropertyDescriptor(PropertyDescriptor):
         ''' Internal implementation helper to set property values.
 
         This function handles bookkeeping around noting whether values have
-        been explicitly set, or setting up |PropertyContainer| wrappers when
-        values are containers, etc.
+        been explicitly set, etc.
 
         Args:
             obj (HasProps)
@@ -776,9 +770,9 @@ class BasicPropertyDescriptor(PropertyDescriptor):
 
         was_set = self.name in obj._property_values
 
-        # "old" is the logical old value, but it may not be
-        # the actual current attribute value if our value
-        # was mutated behind our back and we got _notify_mutated.
+        # "old" is the logical old value, but it may not be the actual current
+        # attribute value if our value was mutated behind our back and we got
+        # _notify_mutated.
         if was_set:
             old_attr_value = obj._property_values[self.name]
         else:

--- a/bokeh/core/property/descriptors.py
+++ b/bokeh/core/property/descriptors.py
@@ -253,7 +253,7 @@ class PropertyDescriptor(object):
         value = self.__get__(obj, obj.__class__)
         return self.property.serialize_value(value)
 
-    def set_from_json(self, obj, json, models, setter=None):
+    def set_from_json(self, obj, json, models=None, setter=None):
         '''Sets the value of this property from a JSON value.
 
         Args:

--- a/bokeh/core/property/tests/test_containers.py
+++ b/bokeh/core/property/tests/test_containers.py
@@ -38,33 +38,69 @@ def test_PropertyValueContainer():
 def test_PropertyValueDict_mutators(mock_notify):
     pvd = pc.PropertyValueDict(dict(foo=10, bar=20, baz=30))
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     del pvd['foo']
     assert mock_notify.called
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvd['foo'] = 11
     assert mock_notify.called
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvd.pop('foo')
     assert mock_notify.called
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvd.popitem()
     assert mock_notify.called
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvd.setdefault('baz')
     assert mock_notify.called
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvd.clear()
     assert mock_notify.called
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvd.update(bar=1)
     assert mock_notify.called
+
+@patch('bokeh.core.property.descriptors.ColumnDataPropertyDescriptor._notify_mutated')
+def test_PropertyValueColumnData___setitem__(mock_notify):
+    from bokeh.document.events import ColumnDataChangedEvent
+
+    source = ColumnDataSource(data=dict(foo=[10], bar=[20], baz=[30]))
+    pvcd = pc.PropertyValueColumnData(source.data)
+    pvcd._register_owner(source, source.lookup('data'))
+
+    mock_notify.reset_mock()
+    pvcd['foo'] = [11]
+    assert pvcd == dict(foo=[11], bar=[20], baz=[30])
+    assert mock_notify.call_count == 1
+    assert mock_notify.call_args[0] == (source, dict(foo=[10], bar=[20], baz=[30]))
+    assert 'hint' in mock_notify.call_args[1]
+    assert isinstance(mock_notify.call_args[1]['hint'], ColumnDataChangedEvent)
+    assert mock_notify.call_args[1]['hint'].column_source == source
+    assert mock_notify.call_args[1]['hint'].cols == ['foo']
+
+@patch('bokeh.core.property.descriptors.ColumnDataPropertyDescriptor._notify_mutated')
+def test_PropertyValueColumnData_update(mock_notify):
+    from bokeh.document.events import ColumnDataChangedEvent
+
+    source = ColumnDataSource(data=dict(foo=[10], bar=[20], baz=[30]))
+    pvcd = pc.PropertyValueColumnData(source.data)
+    pvcd._register_owner(source, source.lookup('data'))
+
+    mock_notify.reset_mock()
+    pvcd.update(foo=[11], bar=[21])
+    assert pvcd == dict(foo=[11], bar=[21], baz=[30])
+    assert mock_notify.call_count == 1
+    assert mock_notify.call_args[0] == (source, dict(foo=[10], bar=[20], baz=[30]))
+    assert 'hint' in mock_notify.call_args[1]
+    assert isinstance(mock_notify.call_args[1]['hint'], ColumnDataChangedEvent)
+    assert mock_notify.call_args[1]['hint'].column_source == source
+    assert sorted(mock_notify.call_args[1]['hint'].cols) == ['bar', 'foo']
 
 @patch('bokeh.core.property.containers.PropertyValueContainer._notify_owners')
 def test_PropertyValueColumnData__stream_list(mock_notify):
@@ -73,9 +109,9 @@ def test_PropertyValueColumnData__stream_list(mock_notify):
     source = ColumnDataSource(data=dict(foo=[10]))
     pvcd = pc.PropertyValueColumnData(source.data)
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvcd._stream("doc", source, dict(foo=[20]), setter="setter")
-    assert mock_notify.called_once
+    assert mock_notify.call_count == 1
     assert mock_notify.call_args[0] == ({'foo': [10, 20]},)
     assert 'hint' in mock_notify.call_args[1]
     assert isinstance(mock_notify.call_args[1]['hint'], ColumnsStreamedEvent)
@@ -89,9 +125,9 @@ def test_PropertyValueColumnData__stream_list_with_rollover(mock_notify):
     source = ColumnDataSource(data=dict(foo=[10, 20, 30]))
     pvcd = pc.PropertyValueColumnData(source.data)
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvcd._stream("doc", source, dict(foo=[40]), rollover=3, setter="setter")
-    assert mock_notify.called_once
+    assert mock_notify.call_count == 1
     assert mock_notify.call_args[0] == ({'foo': [20, 30, 40]},)
     assert 'hint' in mock_notify.call_args[1]
     assert isinstance(mock_notify.call_args[1]['hint'], ColumnsStreamedEvent)
@@ -106,9 +142,9 @@ def test_PropertyValueColumnData__stream_array(mock_notify):
     source = ColumnDataSource(data=dict(foo=np.array([10])))
     pvcd = pc.PropertyValueColumnData(source.data)
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvcd._stream("doc", source, dict(foo=[20]), setter="setter")
-    assert mock_notify.called_once
+    assert mock_notify.call_count == 1
     assert len(mock_notify.call_args[0]) == 1
     assert 'foo' in mock_notify.call_args[0][0]
     assert (mock_notify.call_args[0][0]['foo'] == np.array([10])).all()
@@ -125,9 +161,9 @@ def test_PropertyValueColumnData__stream_array_with_rollover(mock_notify):
     source = ColumnDataSource(data=dict(foo=np.array([10, 20, 30])))
     pvcd = pc.PropertyValueColumnData(source.data)
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvcd._stream("doc", source, dict(foo=[40]), rollover=3, setter="setter")
-    assert mock_notify.called_once
+    assert mock_notify.call_count == 1
     assert len(mock_notify.call_args[0]) == 1
     assert 'foo' in mock_notify.call_args[0][0]
     assert (mock_notify.call_args[0][0]['foo'] == np.array([10, 20, 30])).all()
@@ -142,9 +178,9 @@ def test_PropertyValueColumnData__patch_with_simple_indices(mock_notify):
     source = ColumnDataSource(data=dict(foo=[10, 20]))
     pvcd = pc.PropertyValueColumnData(source.data)
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvcd._patch("doc", source, dict(foo=[(1, 40)]), setter='setter')
-    assert mock_notify.called_once
+    assert mock_notify.call_count == 1
     assert mock_notify.call_args[0] == ({'foo': [10, 40]},)
     assert pvcd == dict(foo=[10, 40])
     assert 'hint' in mock_notify.call_args[1]
@@ -157,9 +193,9 @@ def test_PropertyValueColumnData__patch_with_repeated_simple_indices(mock_notify
     source = ColumnDataSource(data=dict(foo=[10, 20]))
     pvcd = pc.PropertyValueColumnData(source.data)
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvcd._patch("doc", source, dict(foo=[(1, 40), (1, 50)]), setter='setter')
-    assert mock_notify.called_once
+    assert mock_notify.call_count == 1
     assert mock_notify.call_args[0] == ({'foo': [10, 50]},)
     assert pvcd == dict(foo=[10, 50])
     assert 'hint' in mock_notify.call_args[1]
@@ -173,9 +209,9 @@ def test_PropertyValueColumnData__patch_with_slice_indices(mock_notify):
     source = ColumnDataSource(data=dict(foo=[10, 20, 30, 40, 50]))
     pvcd = pc.PropertyValueColumnData(source.data)
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvcd._patch("doc", source, dict(foo=[(slice(2), [1,2])]), setter='setter')
-    assert mock_notify.called_once
+    assert mock_notify.call_count == 1
     assert mock_notify.call_args[0] == ({'foo': [1, 2, 30, 40, 50]},)
     assert pvcd == dict(foo=[1, 2, 30, 40, 50])
     assert 'hint' in mock_notify.call_args[1]
@@ -188,9 +224,9 @@ def test_PropertyValueColumnData__patch_with_overlapping_slice_indices(mock_noti
     source = ColumnDataSource(data=dict(foo=[10, 20, 30, 40, 50]))
     pvcd = pc.PropertyValueColumnData(source.data)
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvcd._patch("doc", source, dict(foo=[(slice(2), [1,2]), (slice(1,3), [1000,2000])]), setter='setter')
-    assert mock_notify.called_once
+    assert mock_notify.call_count == 1
     assert mock_notify.call_args[0] == ({'foo': [1, 1000, 2000, 40, 50]},)
     assert pvcd == dict(foo=[1, 1000, 2000, 40, 50])
     assert 'hint' in mock_notify.call_args[1]
@@ -201,59 +237,59 @@ def test_PropertyValueColumnData__patch_with_overlapping_slice_indices(mock_noti
 def test_PropertyValueList_mutators(mock_notify):
     pvl = pc.PropertyValueList([10, 20, 30, 40, 50])
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     del pvl[2]
     assert mock_notify.called
 
     # this exercises __delslice__ on Py2 but not Py3 which just
     # uses __delitem__ and a slice index
-    mock_notify.reset()
+    mock_notify.reset_mock()
     del pvl[1:2]
     assert mock_notify.called
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvl += [888]
     assert mock_notify.called
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvl *= 2
     assert mock_notify.called
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvl[0] = 2
     assert mock_notify.called
 
     # this exercises __setslice__ on Py2 but not Py3 which just
     # uses __setitem__ and a slice index
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvl[3:1:-1] = [21, 31]
     assert mock_notify.called
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvl.append(999)
     assert mock_notify.called
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvl.extend([1000])
     assert mock_notify.called
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvl.insert(0, 100)
     assert mock_notify.called
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvl.pop()
     assert mock_notify.called
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvl.remove(100)
     assert mock_notify.called
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvl.reverse()
     assert mock_notify.called
 
-    mock_notify.reset()
+    mock_notify.reset_mock()
     pvl.sort()
     assert mock_notify.called
 

--- a/bokeh/document/events.py
+++ b/bokeh/document/events.py
@@ -210,7 +210,7 @@ class ColumnDataChangedEvent(DocumentPatchedEvent):
 
     '''
 
-    def __init__(self, document, column_source, setter=None):
+    def __init__(self, document, column_source, cols=None, setter=None):
         '''
 
         Args:
@@ -218,6 +218,10 @@ class ColumnDataChangedEvent(DocumentPatchedEvent):
                 A Bokeh document that is to be updated.
 
             column_source (ColumnDataSource) :
+
+            cols (list[str]) :
+                optional explicit list of column names to update. If None, all
+                columns will be updated (default: None)
 
             setter (ClientSession or ServerSession or None, optional) :
                 This is used to prevent "boomerang" updates to Bokeh apps.
@@ -229,6 +233,7 @@ class ColumnDataChangedEvent(DocumentPatchedEvent):
         '''
         super(ColumnDataChangedEvent, self).__init__(document, setter)
         self.column_source = column_source
+        self.cols = cols
 
     def dispatch(self, receiver):
         ''' Dispatch handling of this event to a receiver.
@@ -250,6 +255,7 @@ class ColumnDataChangedEvent(DocumentPatchedEvent):
                 'kind'          : 'ColumnDataChanged'
                 'column_source' : <reference to a CDS>
                 'new'           : <new data to steam to column_source>
+                'cols'          : <specific columns to update>
             }
 
         Args:
@@ -271,11 +277,12 @@ class ColumnDataChangedEvent(DocumentPatchedEvent):
         '''
         from ..util.serialization import transform_column_source_data
 
-        data_dict = transform_column_source_data(self.column_source.data, buffers=buffers)
+        data_dict = transform_column_source_data(self.column_source.data, buffers=buffers, cols=self.cols)
 
         return { 'kind'          : 'ColumnDataChanged',
                  'column_source' : self.column_source.ref,
-                 'new'           : data_dict}
+                 'new'           : data_dict,
+                 'cols'          : self.cols}
 
 class ColumnsStreamedEvent(DocumentPatchedEvent):
     ''' A concrete event representing efficiently streaming new data

--- a/bokeh/document/events.py
+++ b/bokeh/document/events.py
@@ -271,9 +271,11 @@ class ColumnDataChangedEvent(DocumentPatchedEvent):
         '''
         from ..util.serialization import transform_column_source_data
 
+        data_dict = transform_column_source_data(self.column_source.data, buffers=buffers)
+
         return { 'kind'          : 'ColumnDataChanged',
                  'column_source' : self.column_source.ref,
-                 'new'          : transform_column_source_data(self.column_source.data) }
+                 'new'           : data_dict}
 
 class ColumnsStreamedEvent(DocumentPatchedEvent):
     ''' A concrete event representing efficiently streaming new data

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -19,7 +19,7 @@ from warnings import warn
 import re
 
 from six import string_types
-from six.moves.urllib.parse import urlparse
+from six.moves.urllib.parse import urlparse, quote_plus
 
 from .core.templates import (
     AUTOLOAD_JS, AUTOLOAD_TAG, DOC_JS, FILE, NOTEBOOK_DIV, PLOT_DIV, SCRIPT_TAG)
@@ -616,8 +616,6 @@ def _connect_session_or_document(model=None, app_path=None, session_id=None, url
             typically not desired.
 
     '''
-    from .client.session import _encode_query_param
-
     if app_path is not None:
         deprecated((0, 12, 5), "app_path", "url", "Now pass entire app URLS in the url arguments, e.g. 'url=http://foo.com:5010/bar/myapp'")
         if not app_path.startswith("/"):
@@ -664,7 +662,7 @@ def _connect_session_or_document(model=None, app_path=None, session_id=None, url
     if arguments is not None:
         for key, value in arguments.items():
             if not key.startswith("bokeh-"):
-                src_path = src_path + "&{}={}".format(_encode_query_param(str(key)), _encode_query_param(str(value)))
+                src_path = src_path + "&{}={}".format(quote_plus(str(key)), quote_plus(str(value)))
 
     tag = AUTOLOAD_TAG.render(
         src_path = src_path,

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -45,8 +45,6 @@ from .util.serialization import make_id
 # Globals and constants
 #-----------------------------------------------------------------------------
 
-_new_param = {'tab': 2, 'window': 1}
-
 _state = State()
 
 _notebook_hooks = {}
@@ -435,7 +433,7 @@ def _show_notebook_doc_with_state(obj, state, notebook_handle):
 
 def _show_file_with_state(obj, state, new, controller):
     filename = save(obj, state=state)
-    controller.open("file://" + filename, new=_new_param[new])
+    controller.open("file://" + filename, new=browserlib.NEW_PARAM[new])
 
 def _show_jupyter_doc_with_state(obj, state, notebook_handle):
     comms_target = make_id() if notebook_handle else None

--- a/bokeh/model.py
+++ b/bokeh/model.py
@@ -540,7 +540,7 @@ class Model(with_metaclass(MetaModel, HasProps, PropertyCallbackManager, EventCa
         # this may need to be further refined in the future, if the a
         # assumption does not hold for future hinted events (e.g. the hint
         # could specify explicitly whether to do normal invalidation or not)
-        if not hint:
+        if hint is None:
             dirty = { 'count' : 0 }
             def mark_dirty(obj):
                 dirty['count'] += 1

--- a/bokeh/protocol/message.py
+++ b/bokeh/protocol/message.py
@@ -143,7 +143,7 @@ class Message(object):
 
         self._header_json = None
 
-        self._buffers.add((buf_header, buf_payload))
+        self._buffers.append((buf_header, buf_payload))
 
     def assemble_buffer(self, buf_header, buf_payload):
         ''' Add a buffer header and payload that we read from the socket.

--- a/bokeh/protocol/messages/patch_doc.py
+++ b/bokeh/protocol/messages/patch_doc.py
@@ -57,9 +57,8 @@ class patch_doc_1(Message):
 
         msg = cls(header, metadata, content)
 
-        if use_buffers:
-            for (header, payload) in buffers:
-                msg.add_buffer(header, payload)
+        for (header, payload) in buffers:
+            msg.add_buffer(header, payload)
 
         return msg
 
@@ -96,4 +95,4 @@ def process_document_events(events, use_buffers=True):
         'references' : references_json(references),
     }
 
-    return serialize_json(json), buffers
+    return serialize_json(json), buffers if use_buffers else []

--- a/bokeh/protocol/messages/patch_doc.py
+++ b/bokeh/protocol/messages/patch_doc.py
@@ -30,7 +30,7 @@ class patch_doc_1(Message):
         super(patch_doc_1, self).__init__(header, metadata, content)
 
     @classmethod
-    def create(cls, events, **metadata):
+    def create(cls, events, use_buffers=True, **metadata):
         ''' Create a ``PATCH-DOC`` message
 
         Args:
@@ -52,13 +52,14 @@ class patch_doc_1(Message):
 
         # this roundtrip is fortunate, but is needed because there are type conversions
         # in BokehJSONEncoder which keep us from easily generating non-string JSON
-        patch_json, buffers = process_document_events(events)
+        patch_json, buffers = process_document_events(events, use_buffers)
         content = loads(patch_json)
 
         msg = cls(header, metadata, content)
 
-        for (header, payload) in buffers:
-            msg.add_buffer(header, payload)
+        if use_buffers:
+            for (header, payload) in buffers:
+                msg.add_buffer(header, payload)
 
         return msg
 
@@ -68,7 +69,7 @@ class patch_doc_1(Message):
         '''
         doc.apply_json_patch(self.content, setter)
 
-def process_document_events(events):
+def process_document_events(events, use_buffers=True):
     ''' Create a JSON string describing a patch to be applied as well as
     any optional buffers.
 
@@ -84,7 +85,8 @@ def process_document_events(events):
 
     json_events = []
     references = set()
-    buffers = []
+
+    buffers = [] if use_buffers else None
 
     for event in events:
         json_events.append(event.generate(references, buffers))

--- a/bokeh/protocol/messages/tests/test_patch_doc.py
+++ b/bokeh/protocol/messages/tests/test_patch_doc.py
@@ -1,15 +1,20 @@
 from __future__ import absolute_import, print_function
 
 import unittest
+from json import loads
 
 import pytest
+
+import numpy as np
+
+from bokeh.protocol.messages.patch_doc import process_document_events
 
 import bokeh.document as document
 from bokeh.model import Model
 from bokeh.models.sources import ColumnDataSource
 from bokeh.core.properties import Int, Instance
 from bokeh.protocol import Protocol
-from bokeh.document.events import ColumnsPatchedEvent, ColumnsStreamedEvent, ModelChangedEvent, RootAddedEvent, RootRemovedEvent
+from bokeh.document.events import ColumnDataChangedEvent, ColumnsPatchedEvent, ColumnsStreamedEvent, ModelChangedEvent, RootAddedEvent, RootRemovedEvent
 
 class AnotherModelInTestPatchDoc(Model):
     bar = Int(1)
@@ -83,7 +88,7 @@ class TestPatchDocument(unittest.TestCase):
         assert other_root is not None
         new_child = AnotherModelInTestPatchDoc(bar=56)
 
-        cds = ColumnDataSource(data={'a': [0, 1, 2]})
+        cds = ColumnDataSource(data={'a': np.array([0., 1., 2.])})
         sample.add_root(cds)
 
         mock_session = object()
@@ -96,25 +101,129 @@ class TestPatchDocument(unittest.TestCase):
         event = ModelChangedEvent(sample, root, 'child', root.child, new_child, new_child)
         msg = Protocol("1.0").create("PATCH-DOC", [event])
         msg.apply_to_document(sample, mock_session)
+        self.assertEqual(msg.buffers, [])
 
         # RootAdded
         event2 = RootAddedEvent(sample, root)
         msg2 = Protocol("1.0").create("PATCH-DOC", [event2])
         msg2.apply_to_document(sample, mock_session)
+        self.assertEqual(msg2.buffers, [])
 
         # RootRemoved
         event3 = RootRemovedEvent(sample, root)
         msg3 = Protocol("1.0").create("PATCH-DOC", [event3])
         msg3.apply_to_document(sample, mock_session)
+        self.assertEqual(msg3.buffers, [])
 
         # ColumnsStreamed
         event4 = ModelChangedEvent(sample, cds, 'data', 10, None, None,
                                    hint=ColumnsStreamedEvent(sample, cds, {"a": [3]}, None, mock_session))
         msg4 = Protocol("1.0").create("PATCH-DOC", [event4])
         msg4.apply_to_document(sample, mock_session)
+        self.assertEqual(msg4.buffers, [])
 
         # ColumnsPatched
         event5 = ModelChangedEvent(sample, cds, 'data', 10, None, None,
                                    hint=ColumnsPatchedEvent(sample, cds, {"a": [(0, 11)]}))
         msg5 = Protocol("1.0").create("PATCH-DOC", [event5])
         msg5.apply_to_document(sample, mock_session)
+        self.assertEqual(msg5.buffers, [])
+
+        # ColumnDataChanged, use_buffers=False
+        event6 = ModelChangedEvent(sample, cds, 'data', {'a': np.array([0., 1.])}, None, None,
+                                   hint=ColumnDataChangedEvent(sample, cds))
+        msg6 = Protocol("1.0").create("PATCH-DOC", [event6], use_buffers=False)
+        msg6.apply_to_document(sample, mock_session)
+        self.assertEqual(msg6.buffers, [])
+
+        print(cds.data)
+        # ColumnDataChanged, use_buffers=True
+        event7 = ModelChangedEvent(sample, cds, 'data', {'a': np.array([0., 1.])}, None, None,
+                                   hint=ColumnDataChangedEvent(sample, cds))
+        msg7 = Protocol("1.0").create("PATCH-DOC", [event7])
+        # can't test apply, doc not set up to *receive* binary buffers
+        # msg7.apply_to_document(sample, mock_session)
+        self.assertEqual(len(msg7.buffers), 1)
+        buf = msg7.buffers.pop()
+        self.assertEqual(len(buf), 2)
+        self.assertTrue(isinstance(buf[0], dict))
+        self.assertTrue(list(buf[0]) == ['id'])
+
+        # reports CDS buffer *as it is* Normally events called by setter and
+        # value in local object would have been already mutated.
+        self.assertEqual(buf[1], np.array([11., 1., 2., 3]).tobytes())
+
+class _Event(object):
+    def __init__(self, refs, bufs):
+        self.refs=refs
+        self.bufs=bufs
+    def generate(self, refs, bufs):
+        refs.update(self.refs)
+        if bufs is not None:
+            bufs.extend(self.bufs)
+        return "junk"
+
+class _M(Model):
+    pass
+
+def test_process_document_events_no_refs():
+    e = _Event([], [])
+    r, bufs = process_document_events([e])
+    assert bufs == []
+    json = loads(r)
+    assert sorted(list(json)) == ['events', 'references']
+    assert len(json['references']) == 0
+    assert len(json['events']) == 1
+    assert json['events'] == ['junk']
+
+def test_process_document_events_with_refs():
+    e = _Event([_M(),_M()], [])
+    r, bufs = process_document_events([e])
+    assert bufs == []
+    json = loads(r)
+    assert sorted(list(json)) == ['events', 'references']
+    assert len(json['references']) == 2
+    assert len(json['events']) == 1
+    assert json['events'] == ['junk']
+
+def test_process_document_events_no_buffers():
+    e = _Event([], [])
+    r, bufs = process_document_events([e])
+    assert bufs == []
+    json = loads(r)
+    assert sorted(list(json)) == ['events', 'references']
+    assert len(json['references']) == 0
+    assert len(json['events']) == 1
+    assert json['events'] == ['junk']
+
+def test_process_document_events_with_buffers():
+    e = _Event([], [1,2])
+    r, bufs = process_document_events([e])
+    assert bufs == [1, 2]
+    json = loads(r)
+    assert sorted(list(json)) == ['events', 'references']
+    assert len(json['references']) == 0
+    assert len(json['events']) == 1
+    assert json['events'] == ['junk']
+
+def test_process_document_events_mixed():
+    e1 = _Event([], [1,2])
+    e2 = _Event([_M(),_M(),_M()], [3,4, 5])
+    e3 = _Event([_M(),_M()], [])
+    r, bufs = process_document_events([e1, e2, e3])
+    assert bufs == [1, 2, 3, 4, 5]
+    json = loads(r)
+    assert sorted(list(json)) == ['events', 'references']
+    assert len(json['references']) == 5
+    assert len(json['events']) == 3
+    assert json['events'] == ['junk', 'junk', 'junk']
+
+def test_process_document_events_with_buffers_and_use_buffers_false():
+    e = _Event([], [1,2])
+    r, bufs = process_document_events([e], use_buffers=False)
+    assert bufs == []
+    json = loads(r)
+    assert sorted(list(json)) == ['events', 'references']
+    assert len(json['references']) == 0
+    assert len(json['events']) == 1
+    assert json['events'] == ['junk']

--- a/bokeh/server/session.py
+++ b/bokeh/server/session.py
@@ -173,10 +173,9 @@ class ServerSession(object):
         if self._pending_writes is None:
             raise RuntimeError("_pending_writes should be non-None when we have a document lock, and we should have the lock when the document changes")
 
-        # TODO (havocp): our "change sync" protocol is flawed
-        # because if both sides change the same attribute at the
-        # same time, they will each end up with the state of the
-        # other and their final states will differ.
+        # TODO (havocp): our "change sync" protocol is flawed because if both
+        # sides change the same attribute at the same time, they will each end
+        # up with the state of the other and their final states will differ.
         for connection in self._subscribed_connections:
             if may_suppress and connection is self._current_patch_connection:
                 log.trace("Not sending notification back to client %r for a change it requested", connection)

--- a/bokeh/tests/test_client_server.py
+++ b/bokeh/tests/test_client_server.py
@@ -61,10 +61,10 @@ class TestClientServer(unittest.TestCase):
             session._connection._socket.write_message(b"xx", binary=True)
             # connection should now close on the server side
             # and the client loop should end
-            session.loop_until_closed()
+            session.loop_until_closed(suppress_warning=True)
             assert not session.connected
             session.close()
-            session.loop_until_closed()
+            session.loop_until_closed(suppress_warning=True)
             assert not session.connected
 
     def test_connect_with_prefix(self):
@@ -78,14 +78,14 @@ class TestClientServer(unittest.TestCase):
             session.connect()
             assert session.connected
             session.close()
-            session.loop_until_closed()
+            session.loop_until_closed(suppress_warning=True)
 
             session = ClientSession(io_loop = server.io_loop,
                                     websocket_url = ws_url(server))
             session.connect()
             assert not session.connected
             session.close()
-            session.loop_until_closed()
+            session.loop_until_closed(suppress_warning=True)
 
     def check_http_gets_fail(self, server):
         with (self.assertRaises(HTTPError)):
@@ -179,7 +179,7 @@ class TestClientServer(unittest.TestCase):
             assert results['bar'] == 43
 
             client_session.close()
-            client_session.loop_until_closed()
+            client_session.loop_until_closed(suppress_warning=True)
             assert not client_session.connected
 
     def test_pull_document(self):
@@ -209,7 +209,7 @@ class TestClientServer(unittest.TestCase):
             assert results['bar'] == 43
 
             client_session.close()
-            client_session.loop_until_closed()
+            client_session.loop_until_closed(suppress_warning=True)
             assert not client_session.connected
 
     def test_request_server_info(self):
@@ -230,7 +230,7 @@ class TestClientServer(unittest.TestCase):
             assert info['version_info']['server'] == __version__
 
             session.close()
-            session.loop_until_closed()
+            session.loop_until_closed(suppress_warning=True)
             assert not session.connected
 
     def test_ping(self):
@@ -257,7 +257,7 @@ class TestClientServer(unittest.TestCase):
             self.assertEqual(expected_pong + 1, connection._socket.latest_pong)
 
             session.close()
-            session.loop_until_closed()
+            session.loop_until_closed(suppress_warning=True)
             assert not session.connected
 
     def test_client_changes_go_to_server(self):
@@ -305,7 +305,7 @@ class TestClientServer(unittest.TestCase):
             assert len(server_session.document.roots) == 0
 
             client_session.close()
-            client_session.loop_until_closed()
+            client_session.loop_until_closed(suppress_warning=True)
             assert not client_session.connected
 
     def test_server_changes_go_to_client(self):
@@ -368,7 +368,7 @@ class TestClientServer(unittest.TestCase):
             assert len(client_session.document.roots) == 0
 
             client_session.close()
-            client_session.loop_until_closed()
+            client_session.loop_until_closed(suppress_warning=True)
             assert not client_session.connected
 
     @gen.coroutine
@@ -401,7 +401,7 @@ class TestClientServer(unittest.TestCase):
 
             doc.add_timeout_callback(cb, 10)
 
-            client_session.loop_until_closed()
+            client_session.loop_until_closed(suppress_warning=True)
 
             with (self.assertRaises(ValueError)) as manager:
                 doc.remove_timeout_callback(cb)
@@ -434,7 +434,7 @@ class TestClientServer(unittest.TestCase):
                                           url=url(server),
                                           io_loop=server.io_loop)
 
-            client_session.loop_until_closed()
+            client_session.loop_until_closed(suppress_warning=True)
 
             with (self.assertRaises(ValueError)) as manager:
                 doc.remove_timeout_callback(cb)
@@ -470,7 +470,7 @@ class TestClientServer(unittest.TestCase):
 
             server_session.document.add_timeout_callback(cb, 10)
 
-            client_session.loop_until_closed()
+            client_session.loop_until_closed(suppress_warning=True)
 
             with (self.assertRaises(ValueError)) as manager:
                 server_session.document.remove_timeout_callback(cb)
@@ -503,7 +503,7 @@ class TestClientServer(unittest.TestCase):
 
             doc.add_next_tick_callback(cb)
 
-            client_session.loop_until_closed()
+            client_session.loop_until_closed(suppress_warning=True)
 
             with (self.assertRaises(ValueError)) as manager:
                 doc.remove_next_tick_callback(cb)
@@ -536,7 +536,7 @@ class TestClientServer(unittest.TestCase):
                                           url=url(server),
                                           io_loop=server.io_loop)
 
-            client_session.loop_until_closed()
+            client_session.loop_until_closed(suppress_warning=True)
 
             with (self.assertRaises(ValueError)) as manager:
                 doc.remove_next_tick_callback(cb)
@@ -572,7 +572,7 @@ class TestClientServer(unittest.TestCase):
 
             server_session.document.add_next_tick_callback(cb)
 
-            client_session.loop_until_closed()
+            client_session.loop_until_closed(suppress_warning=True)
 
             with (self.assertRaises(ValueError)) as manager:
                 server_session.document.remove_next_tick_callback(cb)
@@ -605,7 +605,7 @@ class TestClientServer(unittest.TestCase):
 
             doc.add_periodic_callback(cb, 10)
 
-            client_session.loop_until_closed()
+            client_session.loop_until_closed(suppress_warning=True)
 
             doc.remove_periodic_callback(cb)
 
@@ -636,7 +636,7 @@ class TestClientServer(unittest.TestCase):
                                           url=url(server),
                                           io_loop=server.io_loop)
 
-            client_session.loop_until_closed()
+            client_session.loop_until_closed(suppress_warning=True)
 
             doc.remove_periodic_callback(cb)
 
@@ -670,7 +670,7 @@ class TestClientServer(unittest.TestCase):
 
             server_session.document.add_periodic_callback(cb, 10)
 
-            client_session.loop_until_closed()
+            client_session.loop_until_closed(suppress_warning=True)
 
             server_session.document.remove_periodic_callback(cb)
 
@@ -752,7 +752,7 @@ class TestClientServer(unittest.TestCase):
 
             session.document.on_change(client_on_change)
 
-            session.loop_until_closed()
+            session.loop_until_closed(suppress_warning=True)
 
             assert not session.connected
 
@@ -809,7 +809,7 @@ def test_client_changes_do_not_boomerang(monkeypatch):
         assert got_angry['result'] is None
 
         client_session.close()
-        client_session.loop_until_closed()
+        client_session.loop_until_closed(suppress_warning=True)
         assert not client_session.connected
         server.unlisten() # clean up so next test can run
 
@@ -860,7 +860,7 @@ def test_server_changes_do_not_boomerang(monkeypatch):
         assert got_angry['result'] is None
 
         client_session.close()
-        client_session.loop_until_closed()
+        client_session.loop_until_closed(suppress_warning=True)
         assert not client_session.connected
 
 # this test is because we do the funky serializable_value
@@ -917,7 +917,7 @@ def test_unit_spec_changes_do_not_boomerang(monkeypatch):
         change_to({ 'value' : 59, 'units' : 'screen' }, { 'value' : 30, 'units' : 'deg' })
 
         client_session.close()
-        client_session.loop_until_closed()
+        client_session.loop_until_closed(suppress_warning=True)
         assert not client_session.connected
         server.unlisten() # clean up so next test can run
 

--- a/bokeh/util/browser.py
+++ b/bokeh/util/browser.py
@@ -8,6 +8,8 @@ import webbrowser
 
 from ..settings import settings
 
+NEW_PARAM = {'tab': 2, 'window': 1}
+
 class DummyWebBrowser(object):
     ''' A "no-op" web-browser controller.
 

--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -279,7 +279,7 @@ def transform_series(series, force_list=False, buffers=None):
 
     '''
     vals = series.values
-    return transform_array(vals, forece_list=force_list, buffers=buffers)
+    return transform_array(vals, force_list=force_list, buffers=buffers)
 
 def serialize_array(array, force_list=False, buffers=None):
     ''' Transforms a NumPy array into serialized form.

--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 import base64
 import datetime as dt
 import math
+import sys
 
 import numpy as np
 
@@ -205,7 +206,6 @@ def transform_array(array, force_list=False, buffers=None):
                              dt2001.astype('datetime64[ms]').astype('int64'))
     except AttributeError as e:
         if e.args == ("'module' object has no attribute 'datetime64'",):
-            import sys
             # for compatibility with PyPy that doesn't have datetime64
             if 'PyPy' in sys.version:
                 legacy_datetime64 = False
@@ -398,6 +398,7 @@ def encode_binary_dict(array, buffers):
             '__buffer__' :  << an ID to locate the buffer >>,
             'shape'      : << array shape >>,
             'dtype'      : << dtype name >>,
+            'order'      : << byte order at origin (little or big)>>
         }
 
     Args:
@@ -420,7 +421,8 @@ def encode_binary_dict(array, buffers):
     return {
         '__buffer__'  : buffer_id,
         'shape'       : array.shape,
-        'dtype'       : array.dtype.name
+        'dtype'       : array.dtype.name,
+        'order'       : sys.byteorder
     }
 
 def encode_base64_dict(array):

--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -17,8 +17,6 @@ import base64
 import datetime as dt
 import math
 
-from six import iterkeys
-
 import numpy as np
 
 from .string import format_docstring
@@ -353,7 +351,7 @@ def traverse_data(obj, use_numpy=True, buffers=None):
             obj_copy.append(item)
     return obj_copy
 
-def transform_column_source_data(data, buffers=None):
+def transform_column_source_data(data, buffers=None, cols=None):
     ''' Transform ColumnSourceData data to a serialized format
 
     Args:
@@ -368,18 +366,25 @@ def transform_column_source_data(data, buffers=None):
             **This is an "out" parameter**. The values it contains will be
             modified in-place.
 
+        cols (list[str], optional) :
+            Optional list of subset of columns to transform. If None, all
+            columns will be transformed (default: None)
+
     Returns:
         JSON compatible dict
 
     '''
+    to_transform = set(data) if cols is None else set(cols)
+
     data_copy = {}
-    for key in iterkeys(data):
+    for key in to_transform:
         if pd and isinstance(data[key], (pd.Series, pd.Index)):
             data_copy[key] = transform_series(data[key], buffers=buffers)
         elif isinstance(data[key], np.ndarray):
             data_copy[key] = transform_array(data[key], buffers=buffers)
         else:
             data_copy[key] = traverse_data(data[key], buffers=buffers)
+
     return data_copy
 
 def encode_binary_dict(array, buffers):

--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -169,7 +169,7 @@ array_encoding_disabled.__doc__ = format_docstring(array_encoding_disabled.__doc
                                                    binary_array_types="\n    ".join("* ``np." + str(x) + "``"
                                                                                     for x in BINARY_ARRAY_TYPES))
 
-def transform_array(array, force_list=False):
+def transform_array(array, force_list=False, buffers=None):
     ''' Transform a NumPy arrays into serialized format
 
     Converts un-serializable dtypes and returns JSON serializable
@@ -181,6 +181,19 @@ def transform_array(array, force_list=False):
             This function can encode some dtypes using a binary encoding, but
             setting this argument to True will override that and cause only
             standard Python lists to be emitted. (default: False)
+
+        buffers (set, optional) :
+            If binary buffers are desired, the buffers parameter may be
+            provided, and any columns that may be sent as binary buffers
+            will be added to the set. If None, then only base64 encodinfg
+            will be used (default: None)
+
+            If force_list is True, then this value will be ignored, and
+            no buffers will be generated.
+
+            **This is an "out" parameter**. The values it contains will be
+            modified in-place.
+
 
     Returns:
         JSON
@@ -215,7 +228,7 @@ def transform_array(array, force_list=False):
     elif array.dtype.kind == 'm':
         array = array.astype('timedelta64[us]').astype('int64') / 1000.
 
-    return serialize_array(array, force_list)
+    return serialize_array(array, force_list=force_list, buffers=buffers)
 
 def transform_array_to_list(array):
     ''' Transforms a NumPy array into a list of values
@@ -239,7 +252,7 @@ def transform_array_to_list(array):
         return transformed.tolist()
     return array.tolist()
 
-def transform_series(series, force_list=False):
+def transform_series(series, force_list=False, buffers=None):
     ''' Transforms a Pandas series into serialized form
 
     Args:
@@ -249,14 +262,26 @@ def transform_series(series, force_list=False):
             setting this argument to True will override that and cause only
             standard Python lists to be emitted. (default: False)
 
+        buffers (set, optional) :
+            If binary buffers are desired, the buffers parameter may be
+            provided, and any columns that may be sent as binary buffers
+            will be added to the set. If None, then only base64 encodinfg
+            will be used (default: None)
+
+            If force_list is True, then this value will be ignored, and
+            no buffers will be generated.
+
+            **This is an "out" parameter**. The values it contains will be
+            modified in-place.
+
     Returns:
         list or dict
 
     '''
     vals = series.values
-    return transform_array(vals, force_list)
+    return transform_array(vals, forece_list=force_list, buffers=buffers)
 
-def serialize_array(array, force_list=False):
+def serialize_array(array, force_list=False, buffers=None):
     ''' Transforms a NumPy array into serialized form.
 
     Args:
@@ -265,6 +290,18 @@ def serialize_array(array, force_list=False):
             This function can encode some dtypes using a binary encoding, but
             setting this argument to True will override that and cause only
             standard Python lists to be emitted. (default: False)
+
+        buffers (set, optional) :
+            If binary buffers are desired, the buffers parameter may be
+            provided, and any columns that may be sent as binary buffers
+            will be added to the set. If None, then only base64 encodinfg
+            will be used (default: None)
+
+            If force_list is True, then this value will be ignored, and
+            no buffers will be generated.
+
+            **This is an "out" parameter**. The values it contains will be
+            modified in-place.
 
     Returns:
         list or dict
@@ -276,9 +313,12 @@ def serialize_array(array, force_list=False):
         return transform_array_to_list(array)
     if not array.flags['C_CONTIGUOUS']:
         array = np.ascontiguousarray(array)
-    return encode_base64_dict(array)
+    if buffers is None:
+        return encode_base64_dict(array)
+    else:
+        return encode_binary_dict(array, buffers)
 
-def traverse_data(obj, use_numpy=True):
+def traverse_data(obj, use_numpy=True, buffers=None):
     ''' Recursively traverse an object until a flat list is found.
 
     If NumPy is available, the flat list is converted to a numpy array
@@ -293,7 +333,7 @@ def traverse_data(obj, use_numpy=True):
             This argument is only useful for testing (default: True)
     '''
     if use_numpy and all(isinstance(el, np.ndarray) for el in obj):
-        return [transform_array(el) for el in obj]
+        return [transform_array(el, buffers=buffers) for el in obj]
     obj_copy = []
     for item in obj:
         # Check the base/common case first for performance reasons
@@ -313,11 +353,20 @@ def traverse_data(obj, use_numpy=True):
             obj_copy.append(item)
     return obj_copy
 
-def transform_column_source_data(data):
+def transform_column_source_data(data, buffers=None):
     ''' Transform ColumnSourceData data to a serialized format
 
     Args:
         data (dict) : the mapping of names to data columns to transform
+
+        buffers (set, optional) :
+            If binary buffers are desired, the buffers parameter may be
+            provided, and any columns that may be sent as binary buffers
+            will be added to the set. If None, then only base64 encodinfg
+            will be used (default: None)
+
+            **This is an "out" parameter**. The values it contains will be
+            modified in-place.
 
     Returns:
         JSON compatible dict
@@ -326,12 +375,48 @@ def transform_column_source_data(data):
     data_copy = {}
     for key in iterkeys(data):
         if pd and isinstance(data[key], (pd.Series, pd.Index)):
-            data_copy[key] = transform_series(data[key])
+            data_copy[key] = transform_series(data[key], buffers=buffers)
         elif isinstance(data[key], np.ndarray):
-            data_copy[key] = transform_array(data[key])
+            data_copy[key] = transform_array(data[key], buffers=buffers)
         else:
-            data_copy[key] = traverse_data(data[key])
+            data_copy[key] = traverse_data(data[key], buffers=buffers)
     return data_copy
+
+def encode_binary_dict(array, buffers):
+    ''' Send a numpy array as an unencoded binary buffer
+
+    The encoded format is a dict with the following structure:
+
+    .. code:: python
+
+        {
+            '__buffer__' :  << an ID to locate the buffer >>,
+            'shape'      : << array shape >>,
+            'dtype'      : << dtype name >>,
+        }
+
+    Args:
+        array (np.ndarray) : an array to encode
+
+        buffers (set) :
+            Set to add buffers to
+
+            **This is an "out" parameter**. The values it contains will be
+            modified in-place.
+
+    Returns:
+        dict
+
+    '''
+    buffer_id = make_id()
+    buf = (dict(id=buffer_id), array.tobytes())
+    buffers.append(buf)
+
+    return {
+        '__buffer__'  : buffer_id,
+        'shape'       : array.shape,
+        'dtype'       : array.dtype.name
+    }
 
 def encode_base64_dict(array):
     ''' Encode a NumPy array using base64:

--- a/bokeh/util/tests/test_browser.py
+++ b/bokeh/util/tests/test_browser.py
@@ -85,3 +85,6 @@ def test_view_args():
     assert _open_args == (('http://foo',), {'autoraise': True, 'new': 2})
 
     bub.DummyWebBrowser = db
+
+def test_NEW_PARAM():
+    assert bub.NEW_PARAM == {'tab': 2, 'window': 1}

--- a/bokeh/util/tests/test_serialization.py
+++ b/bokeh/util/tests/test_serialization.py
@@ -79,26 +79,39 @@ def test_traverse_with_numpy():
 def test_traverse_without_numpy():
     assert bus.traverse_data(testing, False) == expected
 
-def test_transform_array_force_list_default():
-    dt_ok = bus.BINARY_ARRAY_TYPES
-    for dt in dt_ok:
-        a = np.empty(shape=10, dtype=dt)
-        out = bus.transform_array(a)
-        assert isinstance(out, dict)
+@pytest.mark.parametrize('dt', bus.BINARY_ARRAY_TYPES)
+def test_transform_array_force_list_default(dt):
+    a = np.empty(shape=10, dtype=dt)
+    out = bus.transform_array(a)
+    assert isinstance(out, dict)
 
-def test_transform_array_force_list_true():
-    dt_ok = bus.BINARY_ARRAY_TYPES
-    for dt in dt_ok:
-        a = np.empty(shape=10, dtype=dt)
-        out = bus.transform_array(a, force_list=True)
-        assert isinstance(out, list)
+@pytest.mark.parametrize('dt', bus.BINARY_ARRAY_TYPES)
+def test_transform_array_force_list_default_with_buffers(dt):
+    a = np.empty(shape=10, dtype=dt)
+    bufs = []
+    out = bus.transform_array(a, buffers=bufs)
+    assert isinstance(out, dict)
+    assert len(bufs) == 1
+    assert len(bufs[0]) == 2
+    assert bufs[0][1] == a.tobytes()
+    assert 'shape' in out
+    assert out['shape'] == a.shape
+    assert 'dtype' in out
+    assert out['dtype'] == a.dtype.name
+    assert '__buffer__' in out
+
+@pytest.mark.parametrize('dt', bus.BINARY_ARRAY_TYPES)
+def test_transform_array_force_list_true(dt):
+    a = np.empty(shape=10, dtype=dt)
+    out = bus.transform_array(a, force_list=True)
+    assert isinstance(out, list)
 
 def test_transform_series_force_list_default():
-
-    # default int seems to be int64
+    # default int seems to be int64, can't be encoded!
     df = pd.Series([1, 3, 5, 6, 8])
     out = bus.transform_series(df)
     assert isinstance(out, list)
+    assert out == [1, 3, 5, 6, 8]
 
     df = pd.Series([1, 3, 5, 6, 8], dtype=np.int32)
     out = bus.transform_series(df)
@@ -111,9 +124,54 @@ def test_transform_series_force_list_default():
     df = pd.Series(np.array([np.nan, np.inf, -np.inf, 0]))
     out = bus.transform_series(df)
     assert isinstance(out, dict)
+
+def test_transform_series_force_list_default_with_buffers():
+    # default int seems to be int64, can't be converted to buffer!
+    df = pd.Series([1, 3, 5, 6, 8])
+    out = bus.transform_series(df)
+    assert isinstance(out, list)
+    assert out == [1, 3, 5, 6, 8]
+
+    df = pd.Series([1, 3, 5, 6, 8], dtype=np.int32)
+    bufs = []
+    out = bus.transform_series(df, buffers=bufs)
+    assert isinstance(out, dict)
+    assert len(bufs) == 1
+    assert len(bufs[0]) == 2
+    assert bufs[0][1] == np.array(df).tobytes()
+    assert 'shape' in out
+    assert out['shape'] == df.shape
+    assert 'dtype' in out
+    assert out['dtype'] == df.dtype.name
+    assert '__buffer__' in out
+
+    df = pd.Series([1.0, 3, 5, 6, 8])
+    bufs = []
+    out = bus.transform_series(df, buffers=bufs)
+    assert isinstance(out, dict)
+    assert len(bufs) == 1
+    assert len(bufs[0]) == 2
+    assert bufs[0][1] == np.array(df).tobytes()
+    assert 'shape' in out
+    assert out['shape'] == df.shape
+    assert 'dtype' in out
+    assert out['dtype'] == df.dtype.name
+    assert '__buffer__' in out
+
+    df = pd.Series(np.array([np.nan, np.inf, -np.inf, 0]))
+    bufs = []
+    out = bus.transform_series(df, buffers=bufs)
+    assert isinstance(out, dict)
+    assert len(bufs) == 1
+    assert len(bufs[0]) == 2
+    assert bufs[0][1] == np.array(df).tobytes()
+    assert 'shape' in out
+    assert out['shape'] == df.shape
+    assert 'dtype' in out
+    assert out['dtype'] == df.dtype.name
+    assert '__buffer__' in out
 
 def test_transform_series_force_list_true():
-
     df = pd.Series([1, 3, 5, 6, 8])
     out = bus.transform_series(df, force_list=True)
     assert isinstance(out, list)
@@ -130,12 +188,11 @@ def test_transform_series_force_list_true():
     out = bus.transform_series(df, force_list=True)
     assert isinstance(out, list)
 
-def test_transform_array_to_list():
-    dt_ok = bus.BINARY_ARRAY_TYPES
-    for dt in dt_ok:
-        a = np.empty(shape=10, dtype=dt)
-        out = bus.transform_array_to_list(a)
-        assert isinstance(out, list)
+@pytest.mark.parametrize('dt', bus.BINARY_ARRAY_TYPES)
+def test_transform_array_to_list(dt):
+    a = np.empty(shape=10, dtype=dt)
+    out = bus.transform_array_to_list(a)
+    assert isinstance(out, list)
 
 @pytest.mark.parametrize('values', [(['cat', 'dog']), ([1.2, 'apple'])])
 def test_transform_array_with_nans_to_list(values):
@@ -159,48 +216,92 @@ def test_array_encoding_disabled_by_dtype():
         a = np.empty(shape=10, dtype=dt)
         assert bus.array_encoding_disabled(a)
 
-def test_encode_base64_dict():
-    for dt in [np.float32, np.float64, np.int64]:
-        for shape in [(12,), (2, 6), (2,2,3)]:
-            a = np.arange(12, dtype=dt)
-            a.reshape(shape)
-            d = bus.encode_base64_dict(a)
+@pytest.mark.parametrize('dt', [np.float32, np.float64, np.int64])
+@pytest.mark.parametrize('shape', [(12,), (2, 6), (2,2,3)])
+def test_encode_base64_dict(dt, shape):
+    a = np.arange(12, dtype=dt)
+    a.reshape(shape)
+    d = bus.encode_base64_dict(a)
 
-            assert 'shape' in d
-            assert d['shape'] == a.shape
+    assert 'shape' in d
+    assert d['shape'] == a.shape
 
-            assert 'dtype' in d
-            assert d['dtype'] == a.dtype.name
+    assert 'dtype' in d
+    assert d['dtype'] == a.dtype.name
 
-            assert '__ndarray__' in d
-            b64 = base64.b64decode(d['__ndarray__'])
-            aa = np.fromstring(b64, dtype=d['dtype'])
-            assert np.array_equal(a, aa)
+    assert '__ndarray__' in d
+    b64 = base64.b64decode(d['__ndarray__'])
+    aa = np.fromstring(b64, dtype=d['dtype'])
+    assert np.array_equal(a, aa)
 
-def test_decode_base64_dict():
-    for dt in [np.float32, np.float64, np.int64]:
-        for shape in [(12,), (2, 6), (2,2,3)]:
-            a = np.arange(12, dtype=dt)
-            a.reshape(shape)
-            data = base64.b64encode(a).decode('utf-8')
-            d = {
-                '__ndarray__'  : data,
-                'dtype'        : a.dtype.name,
-                'shape'        : a.shape
-            }
-            aa = bus.decode_base64_dict(d)
+@pytest.mark.parametrize('dt', [np.float32, np.float64, np.int64])
+@pytest.mark.parametrize('shape', [(12,), (2, 6), (2,2,3)])
+def test_decode_base64_dict(dt, shape):
+    a = np.arange(12, dtype=dt)
+    a.reshape(shape)
+    data = base64.b64encode(a).decode('utf-8')
+    d = {
+        '__ndarray__'  : data,
+        'dtype'        : a.dtype.name,
+        'shape'        : a.shape
+    }
+    aa = bus.decode_base64_dict(d)
 
-            assert aa.shape == a.shape
+    assert aa.shape == a.shape
 
-            assert aa.dtype.name == a.dtype.name
+    assert aa.dtype.name == a.dtype.name
 
-            assert np.array_equal(a, aa)
+    assert np.array_equal(a, aa)
 
-def test_encode_decode_roundtrip():
-    for dt in [np.float32, np.float64, np.int64]:
-        for shape in [(12,), (2, 6), (2,2,3)]:
-            a = np.arange(12, dtype=dt)
-            a.reshape(shape)
-            d = bus.encode_base64_dict(a)
-            aa = bus.decode_base64_dict(d)
-            assert np.array_equal(a, aa)
+@pytest.mark.parametrize('dt', [np.float32, np.float64, np.int64])
+@pytest.mark.parametrize('shape', [(12,), (2, 6), (2,2,3)])
+def test_encode_decode_roundtrip(dt, shape):
+    a = np.arange(12, dtype=dt)
+    a.reshape(shape)
+    d = bus.encode_base64_dict(a)
+    aa = bus.decode_base64_dict(d)
+    assert np.array_equal(a, aa)
+
+
+@pytest.mark.parametrize('dt', bus.BINARY_ARRAY_TYPES)
+@pytest.mark.parametrize('shape', [(12,), (2, 6), (2,2,3)])
+def test_encode_binary_dict(dt, shape):
+    a = np.arange(12, dtype=dt)
+    a.reshape(shape)
+    bufs = []
+    d = bus.encode_binary_dict(a, buffers=bufs)
+
+    assert len(bufs) == 1
+    assert len(bufs[0]) == 2
+    assert bufs[0][1] == a.tobytes()
+    assert 'shape' in d
+    assert d['shape'] == a.shape
+
+    assert 'dtype' in d
+    assert d['dtype'] == a.dtype.name
+
+    assert '__buffer__' in d
+
+@pytest.mark.parametrize('cols', [None, [], ['a'], ['a', 'b'], ['a', 'b', 'c']])
+@pytest.mark.parametrize('dt1', [np.float32, np.float64, np.int64])
+@pytest.mark.parametrize('dt2', [np.float32, np.float64, np.int64])
+def test_transform_column_source_data_with_buffers(cols, dt1, dt2):
+    d = dict(a=[1,2,3], b=np.array([4,5,6], dtype=dt1), c=pd.Series([7,8,9], dtype=dt2))
+    bufs = []
+    out = bus.transform_column_source_data(d, buffers=bufs, cols=cols)
+    assert set(out) == (set(d) if cols is None else set(cols))
+    if 'a' in out:
+        assert out['a'] == [1,2,3]
+    for x in ['b', 'c']:
+        dt = d[x].dtype
+        if x in out:
+            if dt in bus.BINARY_ARRAY_TYPES:
+                assert isinstance(out[x], dict)
+                assert 'shape' in out[x]
+                assert out[x]['shape'] == d[x].shape
+                assert 'dtype' in out[x]
+                assert out[x]['dtype'] == d[x].dtype.name
+                assert '__buffer__' in out[x]
+            else:
+                assert isinstance(out[x], list)
+                assert out[x] == list(d[x])

--- a/bokehjs/src/coffee/client/session.coffee
+++ b/bokehjs/src/coffee/client/session.coffee
@@ -74,7 +74,7 @@ export class ClientSession
     @_connection.send(message)
 
   _handle_patch: (message) ->
-    @document.apply_json_patch(message.content, @id)
+    @document.apply_json_patch(message.content, message.buffers, @id)
 
   _handle_ok: (message) ->
     logger.trace("Unhandled OK reply to #{message.reqid()}")

--- a/bokehjs/src/coffee/core/has_props.coffee
+++ b/bokehjs/src/coffee/core/has_props.coffee
@@ -153,6 +153,7 @@ export class HasProps
   # anyone who needs to know about the change in state. The heart of the beast.
   _setv: (attrs, options) ->
     # Extract attributes and options.
+    check_eq   = options.check_eq
     silent     = options.silent
     changes    = []
     changing   = this._changing
@@ -163,7 +164,10 @@ export class HasProps
     # For each `set` attribute, update or delete the current value.
     for attr, val of attrs
       val = attrs[attr]
-      if not isEqual(current[attr], val)
+      if check_eq != false
+        if not isEqual(current[attr], val)
+          changes.push(attr)
+      else
         changes.push(attr)
       current[attr] = val
 

--- a/bokehjs/src/coffee/core/util/serialization.coffee
+++ b/bokehjs/src/coffee/core/util/serialization.coffee
@@ -1,6 +1,6 @@
 import {isArray, isObject} from "./types"
 
-ARRAY_TYPES =
+export ARRAY_TYPES =
   float32: Float32Array
   float64: Float64Array
   uint8: Uint8Array
@@ -10,7 +10,7 @@ ARRAY_TYPES =
   uint32: Uint32Array
   int32: Int32Array
 
-DTYPES = {}
+export DTYPES = {}
 for k, v of ARRAY_TYPES
     DTYPES[v.name] = k
 
@@ -21,20 +21,21 @@ buf16 = new Uint16Array(buf)
 buf8[0] = 0xAA
 buf8[1] = 0xBB
 if (buf16[0] == 0xBBAA)
-  BYTE_ORDER = "little"
+  _order = "little"
 else
-  BYTE_ORDER = "big"
+  _order = "big"
+export BYTE_ORDER = _order
 
-swap16 = (arr) ->
-  x = new Uint8Array(arr.buffer, arr.byteOffset, arr.length * 2)
+export swap16 = (a) ->
+  x = new Uint8Array(a.buffer, a.byteOffset, a.length * 2)
   for i in [0...x.length] by 2
     t = x[i]
     x[i] = x[i + 1]
     x[i + 1] = t
-    null
+  null
 
-swap32 = (arr) ->
-  x = new Uint8Array(arr.buffer, arr.byteOffset, arr.length * 4)
+export swap32 = (a) ->
+  x = new Uint8Array(a.buffer, a.byteOffset, a.length * 4)
   for i in [0...x.length] by 4
     t = x[i]
     x[i] = x[i + 3]
@@ -42,10 +43,10 @@ swap32 = (arr) ->
     t = x[i + 1]
     x[i + 1] = x[i + 2]
     x[i + 2] = t
-    null
+  null
 
-swap64 = (arr) ->
-  x = new Uint8Array(arr.buffer, arr.byteOffset, arr.length * 8)
+export swap64 = (a) ->
+  x = new Uint8Array(a.buffer, a.byteOffset, a.length * 8)
   for i in [0...x.length] by 8
     t = x[i]
     x[i] = x[i + 7];
@@ -59,9 +60,9 @@ swap64 = (arr) ->
     t = x[i + 3]
     x[i + 3] = x[i + 4]
     x[i + 4] = t
-    null
+  null
 
-_process_buffer = (spec, buffers) ->
+export process_buffer = (spec, buffers) ->
   need_swap = (spec.order != BYTE_ORDER)
   shape = spec.shape
   bytes = null
@@ -80,12 +81,20 @@ _process_buffer = (spec, buffers) ->
       swap64(arr)
   return [arr, shape]
 
-_arrayBufferToBase64 = (buffer) ->
+export process_array = (obj, buffers) ->
+  if isObject(obj) and '__ndarray__' of obj
+    return decode_base64(obj)
+  else if isObject(obj) and '__buffer__' of obj
+    return process_buffer(obj, buffers)
+  else if isArray(obj)
+    return [obj, []]
+
+export arrayBufferToBase64 = (buffer) ->
   bytes = new Uint8Array( buffer )
   binary = (String.fromCharCode(b) for b in bytes)
   return btoa( binary.join("") )
 
-_base64ToArrayBuffer = (base64) ->
+export base64ToArrayBuffer = (base64) ->
   binary_string = atob(base64)
   len = binary_string.length
   bytes = new Uint8Array( len )
@@ -94,7 +103,7 @@ _base64ToArrayBuffer = (base64) ->
   return bytes.buffer
 
 export decode_base64 = (input) ->
-  bytes = _base64ToArrayBuffer(input['__ndarray__'])
+  bytes = base64ToArrayBuffer(input['__ndarray__'])
   dtype = input['dtype']
   if dtype of ARRAY_TYPES
     array = new ARRAY_TYPES[dtype](bytes)
@@ -102,7 +111,7 @@ export decode_base64 = (input) ->
   return [array, shape]
 
 export encode_base64 = (array, shape) ->
-  b64 = _arrayBufferToBase64(array.buffer)
+  b64 = arrayBufferToBase64(array.buffer)
   dtype = DTYPES[array.constructor.name]
   data =
     __ndarray__: b64,
@@ -112,45 +121,36 @@ export encode_base64 = (array, shape) ->
 
 export decode_column_data = (data, buffers) ->
   new_data = {}
-  data_shapes = {}
+  new_shapes = {}
 
   for k, v of data
 
+    # might be array of scalars, or might be ragged array or arrays
     if isArray(v)
+
+      # v is just a regular array of scalars
+      if v.length == 0 or not (isObject(v[0]) or isArray(v[0]))
+        new_data[k] = v
+        continue
+
+      # v is a ragged array of arrays
       arrays = []
       shapes = []
-      for arr in v
-        if isObject(arr) and '__ndarray__' of arr
-          [arr, shape] = decode_base64(arr)
-          shapes.push(shape)
-          arrays.push(arr)
-        else if isObject(arr) and '__buffer__' of arr
-          [arr, shape] = _process_buffer(arr, buffers)
-          shapes.push(shape)
-          arrays.push(arr)
-        else if isArray(arr)
-          shapes.push([])
-          arrays.push(arr)
-      if shapes.length > 0
-        new_data[k] = arrays
-        data_shapes[k] = shapes
-      else
-        new_data[k] = v
+      for obj in v
+        [arr, shape] = process_array(obj, buffers)
+        arrays.push(arr)
+        shapes.push(shape)
 
-    else if isObject(v) and '__ndarray__' of v
-      [arr, shape] = decode_base64(v)
-      new_data[k] = arr
-      data_shapes[k] = shape
+      new_data[k] = arrays
+      new_shapes[k] = shapes
 
-    else if isObject(v) and '__buffer__' of v
-      [arr, shape] = _process_buffer(v, buffers)
-      new_data[k] = arr
-      data_shapes[k] = shape
-
+    # must be object or array (single array case)
     else
-      new_data[k] = v
-      data_shapes[k] = []
-  return [new_data, data_shapes]
+      [arr, shape] = process_array(v, buffers)
+      new_data[k] = arr
+      new_shapes[k] = shape
+
+  return [new_data, new_shapes]
 
 export encode_column_data = (data, shapes) ->
   new_data = {}

--- a/bokehjs/src/coffee/document.coffee
+++ b/bokehjs/src/coffee/document.coffee
@@ -618,7 +618,7 @@ export class Document
             throw new Error("Cannot stream to #{column_source_id} which is not in the document")
           column_source = @_all_models[column_source_id]
           [data, shapes] = decode_column_data(event_json['new'], buffers)
-          column_source.setv({_shapes: shapes, data: data}, {setter_id: setter_id})
+          column_source.setv({_shapes: shapes, data: data}, {setter_id: setter_id, check_eq: false})
 
         when 'ColumnsStreamed'
           column_source_id = event_json['column_source']['id']

--- a/bokehjs/src/coffee/document.coffee
+++ b/bokehjs/src/coffee/document.coffee
@@ -568,7 +568,7 @@ export class Document
       events: json_events,
       references: Document._references_json(values(references))
 
-  apply_json_patch: (patch, setter_id) ->
+  apply_json_patch: (patch, buffers, setter_id) ->
     references_json = patch['references']
     events_json = patch['events']
     references = Document._instantiate_references_json(references_json, @_all_models)
@@ -606,7 +606,7 @@ export class Document
           model_type = event_json['model']['type']
           # XXXX currently still need this first branch, some updates (initial?) go through here
           if attr == 'data' and model_type == 'ColumnDataSource'
-            [data, shapes] = decode_column_data(event_json['new'])
+            [data, shapes] = decode_column_data(event_json['new'], buffers)
             patched_obj.setv({_shapes: shapes, data: data}, {setter_id: setter_id})
           else
             value = Document._resolve_refs(event_json['new'], old_references, new_references)
@@ -617,7 +617,7 @@ export class Document
           if column_source_id not of @_all_models
             throw new Error("Cannot stream to #{column_source_id} which is not in the document")
           column_source = @_all_models[column_source_id]
-          [data, shapes] = decode_column_data(event_json['new'])
+          [data, shapes] = decode_column_data(event_json['new'], buffers)
           column_source.setv({_shapes: shapes, data: data}, {setter_id: setter_id})
 
         when 'ColumnsStreamed'

--- a/bokehjs/src/coffee/document.coffee
+++ b/bokehjs/src/coffee/document.coffee
@@ -618,6 +618,15 @@ export class Document
             throw new Error("Cannot stream to #{column_source_id} which is not in the document")
           column_source = @_all_models[column_source_id]
           [data, shapes] = decode_column_data(event_json['new'], buffers)
+
+          if event_json['cols']?
+            for k of column_source.data
+              if k not of data
+                data[k] =  column_source.data[k]
+            for k of column_source._shapes
+              if k not of shapes
+                shapes[k] = column_source._shapes[k]
+
           column_source.setv({_shapes: shapes, data: data}, {setter_id: setter_id, check_eq: false})
 
         when 'ColumnsStreamed'

--- a/bokehjs/src/coffee/embed.coffee
+++ b/bokehjs/src/coffee/embed.coffee
@@ -13,7 +13,7 @@ _handle_notebook_comms = (msg) ->
   # @ is bound to the doc
   data = JSON.parse(msg.content.data)
   if 'events' of data and 'references' of data
-    @apply_json_patch(data)
+    @apply_json_patch(data, []) # empty buffers for now
   else if 'doc' of data
     @replace_with_json(data['doc'])
   else

--- a/bokehjs/test/core/util/serialization.coffee
+++ b/bokehjs/test/core/util/serialization.coffee
@@ -1,75 +1,141 @@
 {expect} = require "chai"
 utils = require "../../utils"
 
-serialization = utils.require "core/util/serialization"
+ser = utils.require "core/util/serialization"
+{isObject} = utils.require "core/util/types"
+
+GOOD_TYPES = [
+  Float32Array, Float64Array, Uint8Array, Int8Array,
+  Uint16Array, Int16Array, Uint32Array, Int32Array
+]
 
 describe "serialization module", ->
 
-  describe "encode_typed_array", ->
+  describe "ARRAY_TYPES", ->
 
-    it "should encode Float32 arrays", ->
-      array = new Float32Array([1.1, 2.2])
-      shape = [2]
-      e = serialization.encode_base64(array, shape)
-      [d, s] = serialization.decode_base64(e)
-      expect(array).to.be.deep.equal d
-      expect(shape).to.be.deep.equal s
+    it "should map to all available typed array types", ->
+      expected  =
+        float32: Float32Array
+        float64: Float64Array
+        uint8: Uint8Array
+        int8: Int8Array
+        uint16: Uint16Array
+        int16: Int16Array
+        uint32: Uint32Array
+        int32: Int32Array
+      expect(ser.ARRAY_TYPES).to.be.deep.equal(expected)
 
-    it "should encode Float64 arrays", ->
-      array = new Float64Array([1.1, 2.2])
-      shape = [2]
-      e = serialization.encode_base64(array, shape)
-      [d, s] = serialization.decode_base64(e)
-      expect(array).to.be.deep.equal d
-      expect(shape).to.be.deep.equal s
+  describe "DTYPES", ->
 
-    it "should encode Int8 arrays", ->
-      array = new Int8Array([-1, 1])
-      shape = [2]
-      e = serialization.encode_base64(array, shape)
-      [d, s] = serialization.decode_base64(e)
-      expect(array).to.be.deep.equal d
-      expect(shape).to.be.deep.equal s
+    for typ in GOOD_TYPES
+      it "should map #{typ.name} type names to #{ser.DTYPES[typ.name]}", ->
+        expect(ser.ARRAY_TYPES[ser.DTYPES[typ.name]]).to.be.equal typ
 
-    it "should encode Uint8 arrays", ->
-      array = new Int8Array([1, 2])
-      shape = [2]
-      e = serialization.encode_base64(array, shape)
-      [d, s] = serialization.decode_base64(e)
-      expect(array).to.be.deep.equal d
-      expect(shape).to.be.deep.equal s
+  describe "BYTE_ORDER", ->
 
-    it "should encode Int16 arrays", ->
-      array = new Int16Array([-1, 1])
-      shape = [2]
-      e = serialization.encode_base64(array, shape)
-      [d, s] = serialization.decode_base64(e)
-      expect(array).to.be.deep.equal d
-      expect(shape).to.be.deep.equal s
+    it "should be big or little", ->
+      # not a great test but the best we can do for now
+      o = ser.BYTE_ORDER
+      expect(o=="big" or o=="little").to.be.true
 
-    it "should encode Uint16 arrays", ->
-      array = new Uint16Array([1, 2])
-      shape = [2]
-      e = serialization.encode_base64(array, shape)
-      [d, s] = serialization.decode_base64(e)
-      expect(array).to.be.deep.equal d
-      expect(shape).to.be.deep.equal s
+  describe "byte swap functions", ->
+    sample = [0, 1,2,3,4,5,6,7,8,9,10,12,13,14,15]
 
-    it "should encode Int32 arrays", ->
-      array = new Int32Array([-1, 1])
-      shape = [2]
-      e = serialization.encode_base64(array, shape)
-      [d, s] = serialization.decode_base64(e)
-      expect(array).to.be.deep.equal d
-      expect(shape).to.be.deep.equal s
+    it "should have swap16 that swaps 2 bytes in place", ->
+      a = new Uint8Array(4)
+      for i in [0...4]
+        a[i] = i
+      b = new Uint16Array(a.buffer)
+      expect(b.length).to.be.equal 2
+      swapped = new Uint8Array(4)
+      swapped[0] = 1
+      swapped[1] = 0
+      swapped[2] = 3
+      swapped[3] = 2
+      r = ser.swap16(b)
+      expect(r).to.be.null
+      expect(a).to.be.deep.equal swapped
 
-    it "should encode Uint32 arrays", ->
-      array = new Uint32Array([1, 2])
-      shape = [2]
-      e = serialization.encode_base64(array, shape)
-      [d, s] = serialization.decode_base64(e)
-      expect(array).to.be.deep.equal d
-      expect(shape).to.be.deep.equal s
+    it "should have swap32 that swaps 4 bytes in place", ->
+      a = new Uint8Array(8)
+      for i in [0...8]
+        a[i] = i
+      b = new Float32Array(a.buffer)
+      expect(b.length).to.be.equal 2
+      swapped = new Uint8Array(8)
+      swapped[0] = 3
+      swapped[1] = 2
+      swapped[2] = 1
+      swapped[3] = 0
+      swapped[4] = 7
+      swapped[5] = 6
+      swapped[6] = 5
+      swapped[7] = 4
+      r = ser.swap32(b)
+      expect(r).to.be.null
+      expect(a).to.be.deep.equal swapped
+
+    it "should have swap64 that swaps 8 bytes in place", ->
+      a = new Uint8Array(16)
+      for i in [0...16]
+        a[i] = i
+      b = new Float64Array(a.buffer)
+      expect(b.length).to.be.equal 2
+      swapped = new Uint8Array(16)
+      swapped[0]  = 7
+      swapped[1]  = 6
+      swapped[2]  = 5
+      swapped[3]  = 4
+      swapped[4]  = 3
+      swapped[5]  = 2
+      swapped[6]  = 1
+      swapped[7]  = 0
+      swapped[8]  = 15
+      swapped[9]  = 14
+      swapped[10] = 13
+      swapped[11] = 12
+      swapped[12] = 11
+      swapped[13] = 10
+      swapped[14] = 9
+      swapped[15] = 8
+      r = ser.swap64(b)
+      expect(r).to.be.null
+      expect(a).to.be.deep.equal swapped
+
+  describe "process_buffer function", ->
+
+  describe "process_array function", ->
+
+  describe "base64 conversion functions", ->
+
+    for typ in GOOD_TYPES
+      it "should round trip #{typ.name} buffers", ->
+        a = new Uint8Array(16)
+        for i in [0...16]
+          a[i] = i
+
+        b = new typ(a)
+        b64 = ser.arrayBufferToBase64(b.buffer)
+        expect(typeof b64).to.be.equal "string"
+        buf = ser.base64ToArrayBuffer(b64)
+        c = new typ(buf)
+        expect(c).to.be.deep.equal b
+
+  describe "encode/decode base64 functions", ->
+
+    for typ in GOOD_TYPES
+      it "should roundtrip #{typ.name} arrays", ->
+        array = new typ([1, 2])
+        shape = [2]
+        e = ser.encode_base64(array, shape)
+        expect(isObject(e)).to.be.true
+        expect(Object.keys(e).length).to.be.equal 3
+        expect(e.dtype).to.equal ser.DTYPES[typ.name]
+        expect(e.shape).to.be.deep.equal [2]
+
+        [d, s] = ser.decode_base64(e)
+        expect(array).to.be.deep.equal d
+        expect(shape).to.be.deep.equal s
 
   describe "decode_column_data", ->
 
@@ -80,8 +146,8 @@ describe "serialization module", ->
       shapes =
         x: [2]
         y: [2]
-      e = serialization.encode_column_data(data, shapes)
-      [d, s] = serialization.decode_column_data(e)
+      e = ser.encode_column_data(data, shapes)
+      [d, s] = ser.decode_column_data(e)
       expect(data).to.be.deep.equal d
       expect(shapes).to.be.deep.equal s
 
@@ -92,8 +158,8 @@ describe "serialization module", ->
       shapes =
         x: [[2], [2]]
         y: [[2], [2]]
-      e = serialization.encode_column_data(data, shapes)
-      [d, s] = serialization.decode_column_data(e)
+      e = ser.encode_column_data(data, shapes)
+      [d, s] = ser.decode_column_data(e)
       expect(data).to.be.deep.equal d
       expect(shapes).to.be.deep.equal s
 
@@ -103,7 +169,59 @@ describe "serialization module", ->
         y: [2.2, 3.3]
       shapes =
         x: [2]
-      e = serialization.encode_column_data(data, shapes)
-      [d, s] = serialization.decode_column_data(e)
+      e = ser.encode_column_data(data, shapes)
+      [d, s] = ser.decode_column_data(e)
       expect(data).to.be.deep.equal d
       expect(shapes).to.be.deep.equal s
+
+  describe "encode_column_data", ->
+
+    for typ in GOOD_TYPES
+      it "should encode #{typ.name} array columns", ->
+        data = {a : new typ([1, 2]), b: [10, 20]}
+        enc = ser.encode_column_data(data)
+        expect(enc['b']).to.be.deep.equal [10, 20]
+        expect(enc['a']).to.be.deep.equal {
+          '__ndarray__': ser.arrayBufferToBase64(data['a'].buffer),
+          'shape': undefined,
+          'dtype': ser.DTYPES[typ.name]
+        }
+
+    for typ in GOOD_TYPES
+      it "should encode ragged #{typ.name} array columns", ->
+        data = {a : [new typ([1, 2]), new typ([1, 2])], b: [10, 20]}
+        enc = ser.encode_column_data(data)
+        expect(enc['b']).to.be.deep.equal [10, 20]
+        expect(enc['a']).to.be.deep.equal [{
+          '__ndarray__': ser.arrayBufferToBase64(data['a'][0].buffer),
+          'shape': undefined,
+          'dtype': ser.DTYPES[typ.name]
+        }, {
+          '__ndarray__': ser.arrayBufferToBase64(data['a'][1].buffer),
+          'shape': undefined,
+          'dtype': ser.DTYPES[typ.name]
+        }]
+
+    for typ in GOOD_TYPES
+      it "should encode #{typ.name} array columns with shapes", ->
+        data = {a : new typ([1, 2, 3, 4]), b: [10, 20]}
+        enc = ser.encode_column_data(data, {a: [2,2]})
+        expect(enc['b']).to.be.deep.equal [10, 20]
+        expect(enc['a']).to.be.deep.equal {
+          '__ndarray__': ser.arrayBufferToBase64(data['a'].buffer),
+          'shape': [2,2],
+          'dtype': ser.DTYPES[typ.name]
+        }
+
+        data = {a : [new typ([1, 2]), new typ([1, 2])], b: [10, 20]}
+        enc = ser.encode_column_data(data, {a: [[1,2], [2, 1]]})
+        expect(enc['b']).to.be.deep.equal [10, 20]
+        expect(enc['a']).to.be.deep.equal [{
+          '__ndarray__': ser.arrayBufferToBase64(data['a'][0].buffer),
+          'shape': [1,2],
+          'dtype': ser.DTYPES[typ.name]
+        }, {
+          '__ndarray__': ser.arrayBufferToBase64(data['a'][1].buffer),
+          'shape': [2,1],
+          'dtype': ser.DTYPES[typ.name]
+        }]

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -71,6 +71,7 @@ test:
     - requests >=1.2.3
     - beautifulsoup4
     - scipy
+    - numba
     - pillow
     - boto
     - nodejs >=6.10.0

--- a/examples/app/image_blur.py
+++ b/examples/app/image_blur.py
@@ -1,0 +1,38 @@
+import numpy as np
+from numba import njit
+import scipy.misc
+
+from bokeh.io import curdoc
+from bokeh.layouts import column
+from bokeh.models import ColumnDataSource, Slider
+from bokeh.palettes import gray
+from bokeh.plotting import figure
+
+image = scipy.misc.ascent().astype(np.int32)[::-1, :]
+w, h = image.shape
+
+source = ColumnDataSource(data=dict(image=[image]))
+
+p = figure(x_range=(0, w), y_range=(0, h))
+p.image('image', x=0, y=0, dw=w, dh=h, palette=gray(256), source=source)
+
+@njit
+def blur(outimage, image, amt):
+    for i in range(amt, w-amt):
+        for j in range(amt, h-amt):
+            px = 0.
+            for iw in range(-amt//2, amt//2):
+                for jh in range(-amt//2, amt//2):
+                    px += image[i+iw, j+jh]
+            outimage[i, j] = px/(amt*amt)
+
+def update(attr, old, new):
+    out = image.copy()
+    blur(out, image, 2*new + 1)
+    source.data.update(image=[out])
+
+slider = Slider(title="Blur Factor", start=0, end=10, value=0)
+slider.on_change('value', update)
+
+curdoc().add_root(column(p, slider))
+curdoc().title = "Image Blur"

--- a/examples/app/sliders.py
+++ b/examples/app/sliders.py
@@ -40,9 +40,9 @@ plot.line('x', 'y', source=source, line_width=3, line_alpha=0.6)
 # Set up widgets
 text = TextInput(title="title", value='my sine wave')
 offset = Slider(title="offset", value=0.0, start=-5.0, end=5.0, step=0.1)
-amplitude = Slider(title="amplitude", value=1.0, start=-5.0, end=5.0)
+amplitude = Slider(title="amplitude", value=1.0, start=-5.0, end=5.0, step=0.1)
 phase = Slider(title="phase", value=0.0, start=0.0, end=2*np.pi)
-freq = Slider(title="frequency", value=1.0, start=0.1, end=5.1)
+freq = Slider(title="frequency", value=1.0, start=0.1, end=5.1, step=0.1)
 
 
 # Set up callbacks

--- a/sphinx/source/docs/reference/client.rst
+++ b/sphinx/source/docs/reference/client.rst
@@ -4,12 +4,9 @@ bokeh.client
 ============
 
 .. automodule:: bokeh.client
-  :members:
 
-.. _bokeh.client.session:
+.. toctree::
+    :maxdepth: 2
+    :glob:
 
-bokeh.client.session
---------------------
-
-.. automodule:: bokeh.client.session
-   :members:
+    client/*

--- a/sphinx/source/docs/reference/client/connection.rst
+++ b/sphinx/source/docs/reference/client/connection.rst
@@ -1,0 +1,7 @@
+.. _bokeh.client.connection:
+
+bokeh.client.connection
+-----------------------
+
+.. automodule:: bokeh.client.connection
+   :members:

--- a/sphinx/source/docs/reference/client/session.rst
+++ b/sphinx/source/docs/reference/client/session.rst
@@ -1,0 +1,7 @@
+.. _bokeh.client.session:
+
+bokeh.client.session
+--------------------
+
+.. automodule:: bokeh.client.session
+   :members:

--- a/sphinx/source/docs/reference/client/states.rst
+++ b/sphinx/source/docs/reference/client/states.rst
@@ -1,0 +1,7 @@
+.. _bokeh.client.states:
+
+bokeh.client.states
+-------------------
+
+.. automodule:: bokeh.client.states
+   :members:

--- a/sphinx/source/docs/reference/client/util.rst
+++ b/sphinx/source/docs/reference/client/util.rst
@@ -1,0 +1,7 @@
+.. _bokeh.client.util:
+
+bokeh.client.util
+-----------------
+
+.. automodule:: bokeh.client.util
+   :members:

--- a/sphinx/source/docs/reference/client/websocket.rst
+++ b/sphinx/source/docs/reference/client/websocket.rst
@@ -1,0 +1,7 @@
+.. _bokeh.client.websocket:
+
+bokeh.client.websocket
+----------------------
+
+.. automodule:: bokeh.client.websocket
+   :members:

--- a/sphinx/source/docs/releases/0.12.8.rst
+++ b/sphinx/source/docs/releases/0.12.8.rst
@@ -4,7 +4,7 @@
 Bokeh Version ``0.12.8`` is an incremental update that adds a few important
 features and fixes several bugs. Some of the highlights include:
 
-* JupyterLab integration with the `jupyterlab_bokeh` extension
+* JupyterLab integration with the `jupyterlab_bokeh`_ extension
 * Efficient binary transport for sending arrays to clients
 * Improvements to new Graph/Network capability
 
@@ -21,7 +21,7 @@ Deprecated ``bokeh.charts`` support removed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``bokeh.charts`` module, which was simply a compatibility shim to load the
-separate ``bkcharts` package, has been removed. Additionally, Bokeh itself no
+separate ``bkcharts`` package, has been removed. Additionally, Bokeh itself no
 longer lists ``bkcharts`` as a dependency. In order to continue using
 ``bkcharts`` code, the ``bkcharts`` package must be installed separately.
 
@@ -83,6 +83,7 @@ Starting with this release, Bokeh is no longer continuously tested against
 Python 3.4. Use of Bokeh with Python 3.4 will very likely still work, but
 there are no longer any guarantees backed by CI testing.
 
+.. _jupyterlab_bokeh: https://github.com/bokeh/jupyterlab_bokeh
 .. _project roadmap: https://bokehplots.com/pages/roadmap.html
 .. _strftime: http://man7.org/linux/man-pages/man3/strftime.3.html
 .. _testing section: http://bokeh.pydata.org/en/latest/docs/dev_guide/testing.html

--- a/sphinx/source/docs/releases/0.12.8.rst
+++ b/sphinx/source/docs/releases/0.12.8.rst
@@ -4,9 +4,12 @@
 Bokeh Version ``0.12.8`` is an incremental update that adds a few important
 features and fixes several bugs. Some of the highlights include:
 
+* JupyterLab integration with the `jupyterlab_bokeh` extension
+* Efficient binary transport for sending arrays to clients
+* Improvements to new Graph/Network capability
 
- Many other small bugfixes and docs additions. For full details see the
- :bokeh-tree:`CHANGELOG`.
+Many other small bugfixes and docs additions. For full details see the
+:bokeh-tree:`CHANGELOG`.
 
 Migration Guide
 ---------------
@@ -22,8 +25,8 @@ separate ``bkcharts` package, has been removed. Additionally, Bokeh itself no
 longer lists ``bkcharts`` as a dependency. In order to continue using
 ``bkcharts`` code, the ``bkcharts`` package must be installed separately.
 
-MPL compatibility removed
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Deprecated MPL compatibility removed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``bokeh.mpl`` module and all supporting code in ``bokeh.core.compat`` has
 been removed. Bokeh no longer offers or attempts any automatic MPL conversion.
@@ -64,8 +67,17 @@ The function ``bokeh.util.testing.print_versions`` has been removed
 immediately. The ``bokeh info`` command (or ``python -m bokeh info``) should be
 used instead.
 
-End of support for Python 3.4
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Refactor of ``bokeh.client`` and ``bokeh.document``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``bokeh.client`` and ``bokeh.document`` packages were refactored, to make
+maintenance and testing simpler, and to improve overall code quality. No
+commonly used or demonstrated public APIs were affected, (no example code
+required any changes). The other files that were moved or changed are not
+expected to impact user code.
+
+End of Official Support for Python 3.4
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Starting with this release, Bokeh is no longer continuously tested against
 Python 3.4. Use of Bokeh with Python 3.4 will very likely still work, but


### PR DESCRIPTION
- [x] issues: fixes #5984
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

Comments:

This PR adds support for transporting arrays as pure binary data from the server to clients, when the array type is compatible with JavaScript typed array type. The following sorts of updates to a column data source will trigger binary transport:

```
# replacing an entire data dict
source.data = dict(x=x, y=y)

# setting a single column
source.data[x] = x

# updating multiple columns
source.update(x=x, y=y)
```
Additionally, in the latter two cases, all updates now only send the columns there were actually set, instead of always sending the entire data dict (whether binary transport is available or not).

Since the many various functions involved in serialization were geared towards *returning* JSON or JSON strings, the implementation approach take was to add an optional **out-paramter** to collect binary buffers in to the functions, and to propagate it through the call chain when present. When not supplied, the default behaviour remained identical to the previous behaviour, making this approach reasonably non-intrusive. 

On the JS side, few changes were needed apart from providing an option to circumvent old/new value equality testing on ` ColumnDataChangedEvent` since it is a given that the update should take place. This results in a considerable performance improvement. 

Some limitations:

* base64 encoding still used for initial page load, hopefully can fix in a follow-on effort
* binary transport TO the server is not supported (including from python clients)
* ~~~no detection or correction for byte order is undertaken. Binary data is sent out as-is~~~

Finally, code under `bokeh.client` has been split up and refactored with additional tests added. 