### PR TITLE
js code error in documentation

### DIFF
--- a/sphinx/source/docs/user_guide/interaction/callbacks.rst
+++ b/sphinx/source/docs/user_guide/interaction/callbacks.rst
@@ -101,9 +101,8 @@ variable:
 
     callback = CustomJS(code="""
     // the event that triggered the callback is cb_obj:
-    var event = cb_obj.value;
     // The event type determines the relevant attributes
-    console.log('Tap event occured at x-position: ' + event.x)
+    console.log('Tap event occured at x-position: ' + cb_obj.x)
     """)
 
     p = figure()


### PR DESCRIPTION
Attributes are accessible directly from `cb_obj`.
Use `cb_obj.x` instead.

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [ ] issues: fixes #xxxx
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
