### PR TITLE
Bryanv/cleanups

### DIFF
--- a/bokeh/client/session.py
+++ b/bokeh/client/session.py
@@ -28,7 +28,6 @@ from six.moves.urllib.parse import quote_plus
 from ..document import Document
 from ..resources import _SessionCoordinates, DEFAULT_SERVER_HTTP_URL
 from ..util.browser import NEW_PARAM
-from ..util.deprecation import deprecated
 from ..util.session_id import generate_session_id
 from ..util.string import format_docstring
 
@@ -61,7 +60,7 @@ For information about different ways of running apps in a Bokeh server, see:
 
 BOKEH_CLIENT_APP_WARNING = "\n\n    !!!! PLEASE NOTE !!!!\n" + _BOKEH_CLIENT_APP_WARNING_BODY
 
-def push_session(document, session_id=None, url='default', app_path=None, io_loop=None):
+def push_session(document, session_id=None, url='default', io_loop=None):
     ''' Create a session by pushing the given document to the server,
     overwriting any existing server-side document.
 
@@ -100,16 +99,12 @@ def push_session(document, session_id=None, url='default', app_path=None, io_loo
             A new ClientSession connected to the server
 
     '''
-    if app_path is not None:
-        deprecated((0, 12, 5), "app_path", "url", "Now pass entire app URLS in the url arguments, e.g. 'url=http://foo.com:5010/bar/myapp''")
-        url = url + app_path
-
     coords = _SessionCoordinates(session_id=session_id, url=url)
     session = ClientSession(session_id=coords.session_id, websocket_url=websocket_url_for_server_url(coords.url), io_loop=io_loop)
     session.push(document)
     return session
 
-def pull_session(session_id=None, url='default', app_path=None, io_loop=None):
+def pull_session(session_id=None, url='default', io_loop=None):
     ''' Create a session by loading the current server-side document.
 
     ``session.document`` will be a fresh document loaded from
@@ -154,16 +149,12 @@ def pull_session(session_id=None, url='default', app_path=None, io_loop=None):
             A new ClientSession connected to the server
 
     '''
-    if app_path is not None:
-        deprecated((0, 12, 5), "app_path", "url", "Now pass entire app URLS in the url arguments, e.g. 'url=http://foo.com:5010/bar/myapp'")
-        url = url + app_path
-
     coords = _SessionCoordinates(session_id=session_id, url=url)
     session = ClientSession(session_id=session_id, websocket_url=websocket_url_for_server_url(coords.url), io_loop=io_loop)
     session.pull()
     return session
 
-def show_session(session_id=None, url='default', app_path=None, session=None, browser=None, new="tab", controller=None):
+def show_session(session_id=None, url='default', session=None, browser=None, new="tab", controller=None):
         ''' Open a browser displaying a session document.
 
         If you have a session from ``pull_session()`` or ``push_session`` you
@@ -193,11 +184,6 @@ def show_session(session_id=None, url='default', app_path=None, session=None, br
                 opens a new tab. If **new** is 'window', then opens a new window.
 
         '''
-
-        if app_path is not None:
-            deprecated((0, 12, 5), "app_path", "url", "Now pass entire app URLS in the url arguments, e.g. 'url=http://foo.com:5010/bar/myapp'")
-            url = url + app_path
-
         if session is not None:
             server_url = server_url_for_websocket_url(session._connection.url)
             session_id = session.id

--- a/bokeh/core/enums.py
+++ b/bokeh/core/enums.py
@@ -222,11 +222,6 @@ RenderLevel = enumeration("image", "underlay", "glyph", "annotation", "overlay")
 #: Specify a render mode for renderers that support both Canvas or CSS rendering
 RenderMode = enumeration("canvas", "css")
 
-# TODO (bev) Aggregation can probably be deprecated and removed
-
-#: Specify an aggregation type
-Aggregation = enumeration("sum", "mean", "count", "nunique", "median", "min", "max")
-
 #: Specify a start/end value
 StartEnd = enumeration("start", "end")
 

--- a/bokeh/core/state.py
+++ b/bokeh/core/state.py
@@ -31,6 +31,8 @@ logger = logging.getLogger(__name__)
 
 import os
 
+from six import string_types
+
 from ..document import Document
 from ..resources import Resources
 
@@ -38,9 +40,6 @@ class State(object):
     ''' Manage state related to controlling Bokeh output.
 
     '''
-
-    NOTEBOOK_TYPES = ('jupyter', 'zeppelin')
-
     def __init__(self):
         self.last_comms_handle = None
         self.uuid_to_server = {} # Mapping from uuid to server instance
@@ -91,11 +90,12 @@ class State(object):
 
     @notebook_type.setter
     def notebook_type(self, notebook_type):
-        ''' Notebook type, acceptable values are 'jupyter' and 'zeppelin'.
+        ''' Notebook type, acceptable values are 'jupyter' as well as any names
+        defined by external notebook hooks that have been installed.
 
         '''
-        if notebook_type is None or (notebook_type.lower() not in self.NOTEBOOK_TYPES):
-            raise ValueError("Unknown notebook type %r, valid notebook types are: %s" % (notebook_type, ', '.join(self.NOTEBOOK_TYPES)))
+        if notebook_type is None or not isinstance(notebook_type, string_types):
+            raise ValueError("Notebook type must be a string")
         self._notebook_type = notebook_type.lower()
 
     def _reset_keeping_doc(self):
@@ -164,7 +164,7 @@ class State(object):
             logger.info("Session output file '%s' already exists, will be overwritten." % filename)
 
     def output_notebook(self, notebook_type='jupyter'):
-        ''' Generate output in Jupyter/Zeppelin notebook cells.
+        ''' Generate output in notebook cells.
 
         Calling ``output_notebook`` not clear the effects of any other calls
         to ``output_file``, etc. It adds an additional output destination

--- a/bokeh/core/tests/test_enums.py
+++ b/bokeh/core/tests/test_enums.py
@@ -30,7 +30,6 @@ def test_enumeration_default():
 # any changes to contents of enums.py easily trackable here
 def test_enums_contents():
     assert [x for x in dir(enums) if x[0].isupper()] == [
-        'Aggregation',
         'Anchor',
         'AngleUnits',
         'ButtonType',

--- a/bokeh/core/tests/test_state.py
+++ b/bokeh/core/tests/test_state.py
@@ -57,15 +57,16 @@ def test_output_notebook_noarg():
 
 def test_output_notebook_witharg():
     s = state.State()
-    s.output_notebook(notebook_type='zeppelin')
+    s.output_notebook(notebook_type='notjup')
     assert s.notebook == True
-    assert s.notebook_type == 'zeppelin'
+    assert s.notebook_type == 'notjup'
 
 def test_output_invalid_notebook():
     s = state.State()
-    with pytest.raises(Exception) as ex:
-        s.notebook_type="invalid_notebook"
-    assert "Unknown notebook type 'invalid_notebook', valid notebook types are: jupyter, zeppelin" == str(ex.value)
+    with pytest.raises(Exception):
+        s.notebook_type=None
+    with pytest.raises(Exception):
+        s.notebook_type=10
 
 def test_reset():
     s = state.State()

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -831,33 +831,6 @@ def _standalone_docs_json_and_render_items(models):
 
     return (docs_json, render_items)
 
-# TODO this is a theory about what file_html() "should" be,
-# with a more explicit name similar to the server names below,
-# and without the jinja2 entanglement. Thus this encapsulates that
-# we use jinja2 and encapsulates the exact template variables we require.
-# Anyway, we should deprecate file_html or else drop this version,
-# most likely.
-def standalone_html_page_for_models(models, resources, title):
-    ''' Return an HTML document that renders zero or more Bokeh documents or models.
-
-    The document for each model will be embedded directly in the HTML, so the
-    resulting HTML file is standalone (does not require a server). Depending
-    on the provided resources, the HTML file may be completely self-contained
-    or may have to load JS and CSS from different files.
-
-    Args:
-        models (Model or Document) : Bokeh object to render
-            typically a Model or a Document
-        resources (Resources) : a resource configuration for BokehJS assets
-        title (str) : a title for the HTML document ``<title>`` tags or None to use the document title
-
-    Returns:
-        UTF-8 encoded HTML
-
-    '''
-    deprecated((0, 12, 5), 'bokeh.io.standalone_html_page_for_models', 'bokeh.io.file_html')
-    return file_html(models, resources, title)
-
 def server_html_page_for_models(session_id, model_ids, resources, title, template=FILE):
     render_items = []
     for modelid in model_ids:

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -325,9 +325,8 @@ def _bundle_for_objs_and_resources(objs, resources):
     return bokeh_js, bokeh_css
 
 def notebook_content(model, notebook_comms_target=None, theme=FromCurdoc):
-    ''' Return script and div that will display a Bokeh plot in a Jupyter/
-    Zeppelin Notebook. notebook_comms_target is only supported in Jupyter for
-    now.
+    ''' Return script and div that will display a Bokeh plot in a Jupyter
+    Notebook.
 
     The data for the plot is stored directly in the returned HTML.
 
@@ -374,8 +373,7 @@ def notebook_content(model, notebook_comms_target=None, theme=FromCurdoc):
 
 def notebook_div(model, notebook_comms_target=None, theme=FromCurdoc):
     ''' Return HTML for a div that will display a Bokeh plot in a
-    Jupyter/Zeppelin Notebook. notebook_comms_target is only supported
-    in Jupyter for now.
+    Jupyter Notebook.
 
     The data for the plot is stored directly in the returned HTML.
 

--- a/bokeh/embed.py
+++ b/bokeh/embed.py
@@ -616,12 +616,6 @@ def _connect_session_or_document(model=None, app_path=None, session_id=None, url
             typically not desired.
 
     '''
-    if app_path is not None:
-        deprecated((0, 12, 5), "app_path", "url", "Now pass entire app URLS in the url arguments, e.g. 'url=http://foo.com:5010/bar/myapp'")
-        if not app_path.startswith("/"):
-            app_path = "/" + app_path
-        url = url + app_path
-
     coords = _SessionCoordinates(url=url, session_id=session_id)
 
     elementid = make_id()

--- a/bokeh/io.py
+++ b/bokeh/io.py
@@ -29,7 +29,7 @@ import uuid
 # Bokeh imports
 from .core.state import State
 from .document.util import compute_patch_between_json
-from .embed import server_document, notebook_div, notebook_content, file_html
+from .embed import server_document, notebook_content, file_html
 from .layouts import gridplot, GridSpec ; gridplot, GridSpec
 from .models import Plot
 from .resources import INLINE
@@ -450,13 +450,6 @@ def _show_jupyter_doc_with_state(obj, state, notebook_handle):
                               state.document.to_json())
         state.last_comms_handle = handle
         return handle
-
-# TODO (bev) This should eventually be removed, but install a basic built-in hook for docs or now
-def _show_zeppelin_doc_with_state(obj, state, notebook_handle):
-    if notebook_handle:
-        raise ValueError("Zeppelin doesn't support notebook_handle.")
-    print("%html " + notebook_div(obj))
-    return None
 
 def save(obj, filename=None, resources=None, title=None, state=None, **kwargs):
     ''' Save an HTML file with the data for the current document.
@@ -949,7 +942,5 @@ def export_svgs(obj, filename=None, height=None, width=None, webdriver=None):
 
 def _install_notebook_hook():
     install_notebook_hook('jupyter', partial(load_notebook, notebook_type='jupyter'), _show_jupyter_doc_with_state, _show_jupyter_app_with_state, overwrite=True)
-    # TODO (bev) These should eventually be removed, but install a basic built-in hook for docs or now
-    install_notebook_hook('zeppelin', partial(load_notebook, notebook_type='zeppelin'), _show_zeppelin_doc_with_state, None, overwrite=True)
 
 _install_notebook_hook()

--- a/bokeh/model.py
+++ b/bokeh/model.py
@@ -20,7 +20,6 @@ from .themes import default as default_theme
 from .util.callback_manager import PropertyCallbackManager, EventCallbackManager
 from .util.future import with_metaclass
 from .util.serialization import make_id
-from .util.deprecation import deprecated
 from .events import Event
 
 def collect_models(*input_values):
@@ -385,15 +384,6 @@ class Model(with_metaclass(MetaModel, HasProps, PropertyCallbackManager, EventCa
 
         if event in self.properties():
             event = "change:%s" % event
-
-        from bokeh.models.sources import ColumnarDataSource
-        if isinstance(self, ColumnarDataSource):
-            if event == 'stream':
-                deprecated((0, 12, 6), "ColumnarDataSource.js_on_change('stream', ...)", "'streaming'")
-                event = 'streaming'
-            elif event == 'patch':
-                event = 'patching'
-                deprecated((0, 12, 6), "ColumnarDataSource.js_on_change('patch', ...)", "'patching'")
 
         if event not in self.js_property_callbacks:
             self.js_property_callbacks[event] = []

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -25,22 +25,25 @@ from .scales import Scale, CategoricalScale, LinearScale, LogScale
 from .sources import DataSource, ColumnDataSource
 from .tools import ResizeTool, Tool, Toolbar
 
+def _check_conflicting_kwargs(a1, a2, kwargs):
+    if a1 in kwargs and a2 in kwargs:
+        raise ValueError("Conflicting properties set on plot: %r and %r" % (a1, a2))
+
 class Plot(LayoutDOM):
     ''' Model representing a plot, containing glyphs, guides, annotations.
 
     '''
 
     def __init__(self, **kwargs):
-        if "toolbar" in kwargs and "logo" in kwargs:
-            raise ValueError("Conflicting properties set on plot: toolbar, logo.")
+        '''
 
-        if "toolbar" in kwargs and "tools" in kwargs:
-            raise ValueError("Conflicting properties set on plot: toolbar, tools.")
+        '''
+        _check_conflicting_kwargs("toolbar", "tools", kwargs)
+        _check_conflicting_kwargs("toolbar", "logo", kwargs)
 
         if "toolbar" not in kwargs:
             tools = kwargs.pop('tools', [])
             logo = kwargs.pop('logo', 'normal')
-
             kwargs["toolbar"] = Toolbar(tools=tools, logo=logo)
 
         super(LayoutDOM, self).__init__(**kwargs)

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -30,8 +30,6 @@ class Plot(LayoutDOM):
 
     '''
 
-    __deprecated_attributes__ = ["webgl", "x_mapper_type", "y_mapper_type", "tool_events"]
-
     def __init__(self, **kwargs):
         if "toolbar" in kwargs and "logo" in kwargs:
             raise ValueError("Conflicting properties set on plot: toolbar, logo.")
@@ -44,12 +42,6 @@ class Plot(LayoutDOM):
             logo = kwargs.pop('logo', 'normal')
 
             kwargs["toolbar"] = Toolbar(tools=tools, logo=logo)
-
-        if "x_mapper_type" in kwargs and "x_scale" in kwargs:
-            raise ValueError("Conflicting properties set on plot: x_mapper_type, x_scale.")
-
-        if "y_mapper_type" in kwargs and "y_scale" in kwargs:
-            raise ValueError("Conflicting properties set on plot: y_mapper_type, y_scale")
 
         super(LayoutDOM, self).__init__(**kwargs)
 
@@ -403,51 +395,6 @@ class Plot(LayoutDOM):
             return CategoricalScale()
         else:
             raise ValueError("Unknown mapper_type: %s" % scale)
-
-    @property
-    def x_mapper_type(self):
-        deprecated((0, 12, 6), "x_mapper_type", "x_scale")
-        return self.x_scale
-
-    @x_mapper_type.setter
-    def x_mapper_type(self, mapper_type):
-        deprecated((0, 12, 6), "x_mapper_type", "x_scale")
-        self.x_scale = self._scale(mapper_type)
-
-    @property
-    def y_mapper_type(self):
-        deprecated((0, 12, 6), "y_mapper_type", "y_scale")
-        return self.y_scale
-
-    @y_mapper_type.setter
-    def y_mapper_type(self, mapper_type):
-        deprecated((0, 12, 6), "y_mapper_type", "y_scale")
-        self.y_scale = self._scale(mapper_type)
-
-    @property
-    def tool_events(self):
-        deprecated((0, 12, 7), "tool_events", "bokeh.events.SelectionGeometry")
-        return None
-
-    @tool_events.setter
-    def tool_events(self, tool_events):
-        deprecated((0, 12, 7), "tool_events", "bokeh.events.SelectionGeometry")
-        pass
-
-    @property
-    def webgl(self):
-        deprecated((0, 12, 6), "webgl", "output_backend")
-        return self.output_backend == "webgl"
-
-    @webgl.setter
-    def webgl(self, webgl):
-        deprecated((0, 12, 6), "webgl", "output_backend")
-        if not isinstance(webgl, bool):
-            raise ValueError('Attribute "webgl" must be a boolean')
-        if webgl is True:
-            self.output_backend = "webgl"
-        else:
-            self.output_backend = "canvas"
 
     x_scale = Instance(Scale, default=lambda: LinearScale(), help="""
     What kind of scale to use to convert x-coordinates in data space

--- a/bokeh/models/tests/test_plots.py
+++ b/bokeh/models/tests/test_plots.py
@@ -172,26 +172,6 @@ def test_plot__scale_classmethod():
         Plot._scale("malformed_type")
 
 
-def test_plot_x_mapper_type_kwarg_sets_x_scale():
-    plot = Plot(x_mapper_type="linear")
-    assert isinstance(plot.x_scale, LinearScale)
-
-
-def test_plot_y_mapper_type_kwarg_sets_y_scale():
-    plot = Plot(y_mapper_type="log")
-    assert isinstance(plot.y_scale, LogScale)
-
-
-def test_plot_raises_error_if_x_mapper_type_and_x_scale_are_set():
-    with pytest.raises(ValueError):
-        Plot(x_mapper_type="linear", x_scale=LinearScale())
-
-
-def test_plot_raises_error_if_y_mapper_type_and_y_scale_are_set():
-    with pytest.raises(ValueError):
-        Plot(y_mapper_type="log", y_scale=LogScale())
-
-
 def test__check_required_scale_has_scales():
     plot = Plot()
     check = plot._check_required_scale()

--- a/bokeh/plotting/helpers.py
+++ b/bokeh/plotting/helpers.py
@@ -24,7 +24,6 @@ from ..models.renderers import GlyphRenderer
 from ..core.properties import ColorSpec, Datetime, value, field
 from ..transform import stack
 from ..util.dependencies import import_optional
-from ..util.deprecation import deprecated
 from ..util.string import nice_join
 
 pd = import_optional('pandas')
@@ -255,9 +254,18 @@ def _get_legend_item_label(kwargs):
 
 
 _GLYPH_SOURCE_MSG = """
-Supplying a user-defined data source AND iterable values to glyph methods is deprecated.
+Supplying a user-defined data source AND iterable values to glyph methods is
+not possibe. Either:
 
-See https://github.com/bokeh/bokeh/issues/2056 for more information.
+Pass all data directly as literals:
+
+    p.circe(x=a_list, y=an_array, ...)
+
+Or, put all data in a ColumnDataSource and pass column names:
+
+    source = ColumnDataSource(data=dict(x=a_list, y=an_array))
+    p.circe(x='x', y='x', source=source, ...)
+
 """
 
 
@@ -285,7 +293,7 @@ def _process_sequence_literals(glyphclass, kwargs, source, is_user_source):
             raise RuntimeError("Columns need to be 1D (%s is not)" % var)
 
         if is_user_source:
-            deprecated(_GLYPH_SOURCE_MSG)
+            raise RuntimeError(_GLYPH_SOURCE_MSG)
 
         source.add(val, name=var)
         kwargs[var] = var

--- a/bokeh/tests/test_embed.py
+++ b/bokeh/tests/test_embed.py
@@ -427,29 +427,6 @@ class TestAutoloadServer(unittest.TestCase):
                                'src' : src },
                              attrs)
 
-    def test_script_attrs_url_and_app_path_provided(self):
-        for path in ("/foo/bar/sliders", "/foo/bar/sliders/", "foo/bar/sliders", "foo/bar/sliders"):
-            r = embed.autoload_server(url="http://localhost:8081", app_path=path, relative_urls=True)
-            self.assertTrue('bokeh-app-path=/foo/bar/sliders' in r)
-            html = bs4.BeautifulSoup(r, "lxml")
-            scripts = html.findAll(name='script')
-            self.assertEqual(len(scripts), 1)
-            attrs = scripts[0].attrs
-            self.assertTrue(set(attrs), set([
-                'src',
-                'data-bokeh-doc-id',
-                'data-bokeh-model-id',
-                'id'
-            ]))
-            divid = attrs['id']
-            src = "%s/autoload.js?bokeh-autoload-element=%s&bokeh-app-path=/foo/bar/sliders" % \
-                  ("http://localhost:8081/foo/bar/sliders", divid)
-            self.assertDictEqual({ 'data-bokeh-doc-id' : '',
-                                   'data-bokeh-model-id' : '',
-                                   'id' : divid,
-                                   'src' : src },
-                                 attrs)
-
     def test_script_attrs_arguments_provided(self):
         r = embed.server_document(arguments=dict(foo=10))
         self.assertTrue('foo=10' in r)

--- a/bokeh/util/_plot_arg_helpers.py
+++ b/bokeh/util/_plot_arg_helpers.py
@@ -1,4 +1,7 @@
+from .deprecation import deprecated
+
 def _convert_responsive(responsive):
+    deprecated((0, 12, 10), "responsive parameter", "sizing_mode='fixed' for responsive=False or sizing_mode='scale_width' for responsive=True")
     if responsive is True:
         return 'scale_width'
     if responsive is False:

--- a/bokeh/util/notebook.py
+++ b/bokeh/util/notebook.py
@@ -1,9 +1,9 @@
-''' Functions useful for loading Bokeh code and data in Jupyter/Zeppelin notebooks.
+''' Functions useful for loading Bokeh code and data in Jupyter notebooks.
 
 '''
 from __future__ import absolute_import
 
-from ..core.templates import SCRIPT_TAG, AUTOLOAD_NB_JS
+from ..core.templates import AUTOLOAD_NB_JS
 
 HTML_MIME_TYPE = 'text/html'
 JS_MIME_TYPE   = 'application/javascript'
@@ -12,8 +12,7 @@ EXEC_MIME_TYPE = 'application/vnd.bokehjs_exec.v0+json'
 
 _notebook_loaded = None
 
-# TODO (bev) notebook_type and zeppelin bits should be removed after external zeppelin hook available
-def load_notebook(resources=None, verbose=False, hide_banner=False, load_timeout=5000, notebook_type='jupyter'):
+def load_notebook(resources=None, verbose=False, hide_banner=False, load_timeout=5000):
     ''' Prepare the IPython notebook for displaying Bokeh plots.
 
     Args:
@@ -28,9 +27,6 @@ def load_notebook(resources=None, verbose=False, hide_banner=False, load_timeout
 
         load_timeout (int, optional) :
             Timeout in milliseconds when plots assume load timed out (default: 5000)
-
-        notebook_type (string):
-            notebook_type (default: jupyter)
 
     .. warning::
         Clearing the output cell containing the published BokehJS
@@ -88,23 +84,12 @@ def load_notebook(resources=None, verbose=False, hide_banner=False, load_timeout
     nb_js = _loading_js(resources, element_id, custom_models_js, load_timeout, register_mime=True)
     jl_js = _loading_js(resources, element_id, custom_models_js, load_timeout, register_mime=False)
 
-    if notebook_type=='jupyter':
-        if not hide_banner:
-            publish_display_data({'text/html': html})
-        publish_display_data({
-            JS_MIME_TYPE   : nb_js,
-            LOAD_MIME_TYPE : jl_js
-        })
-
-    else:
-        if not hide_banner:
-            _publish_zeppelin_data(html)
-        _publish_zeppelin_data(SCRIPT_TAG.render(js_code=jl_js))
-
-# TODO (bev) This will eventually go away
-def _publish_zeppelin_data(html):
-    '''Embed html content via %html magic'''
-    print('%html ' + html)
+    if not hide_banner:
+        publish_display_data({'text/html': html})
+    publish_display_data({
+        JS_MIME_TYPE   : nb_js,
+        LOAD_MIME_TYPE : jl_js
+    })
 
 def _loading_js(resources, element_id, custom_models_js, load_timeout=5000, register_mime=True):
 

--- a/bokeh/util/platform.py
+++ b/bokeh/util/platform.py
@@ -11,13 +11,3 @@ def is_py3():
     """
     import sys
     return sys.version_info[0] == 3
-
-def is_pypy():
-    """ Test whether we are running PyPy.
-
-    Returns
-        True if we are inside PyPy, otherwise False
-
-    """
-    import platform
-    return platform.python_implementation() == "PyPy"

--- a/bokeh/util/testing.py
+++ b/bokeh/util/testing.py
@@ -100,12 +100,3 @@ def skipIfPy3(message):
     from unittest import skipIf
     from .platform import is_py3
     return skipIf(is_py3(), message)
-
-
-def skipIfPyPy(message):
-    ''' unittest decorator to skip a test for PyPy
-
-    '''
-    from unittest import skipIf
-    from .platform import is_pypy
-    return skipIf(is_pypy(), message)

--- a/examples/embed/embed_multiple_responsive.py
+++ b/examples/embed/embed_multiple_responsive.py
@@ -15,13 +15,13 @@ SCATTER_OPTIONS = dict(size=12, alpha=0.5)
 
 data = lambda: [random.choice([i for i in range(100)]) for r in range(10)]
 
-red = figure(responsive=True, tools='pan', **PLOT_OPTIONS)
+red = figure(sizing_mode='scale_width', tools='pan', **PLOT_OPTIONS)
 red.scatter(data(), data(), color="red", **SCATTER_OPTIONS)
 
-blue = figure(responsive=False, tools='pan', **PLOT_OPTIONS)
+blue = figure(sizing_mode='fixed', tools='pan', **PLOT_OPTIONS)
 blue.scatter(data(), data(), color="blue", **SCATTER_OPTIONS)
 
-green = figure(responsive=True, tools='pan', **PLOT_OPTIONS)
+green = figure(sizing_mode='scale_width', tools='pan', **PLOT_OPTIONS)
 green.scatter(data(), data(), color="green", **SCATTER_OPTIONS)
 
 ########## RENDER PLOTS ################
@@ -37,11 +37,11 @@ template = Template('''<!DOCTYPE html>
     </head>
     <body>
     <h2>Resize the window to see some plots resizing</h2>
-    <h3>Red - pan tool, responsive</h3>
+    <h3>Red - pan tool, scale_width</h3>
     {{ plot_div.red }}
-    <h3>Green - pan tool, responsive (maintains new aspect ratio)</h3>
+    <h3>Green - pan tool, scale_width</h3>
     {{ plot_div.green }}
-    <h3>Blue - pan tool, not responsive</h3>
+    <h3>Blue - pan tool, fixed/h3>
     {{ plot_div.blue }}
 
     {{ plot_script }}

--- a/sphinx/source/docs/releases/0.12.10.rst
+++ b/sphinx/source/docs/releases/0.12.10.rst
@@ -24,6 +24,7 @@ The following previous deprecations have been removed:
 * ``bokeh.io.standalone_html_page_for_models`` from ``bokeh.embed``
 * ``'patch'`` and ``'stream'`` event names (use ``'patching'`` and ``'streaming'``)
 * ``webgl``, ``x_mapper_type``, ``y_mapper_type``, and ``tool_events`` from ``Plot``
+* Glyphs methods now only accept either all sequence literals, OR all column names
 
 New Deprecations
 ~~~~~~~~~~~~~~~~

--- a/sphinx/source/docs/releases/0.12.10.rst
+++ b/sphinx/source/docs/releases/0.12.10.rst
@@ -1,0 +1,45 @@
+0.12.0 (Oct 2017)
+==================
+
+Bokeh Version ``0.12.10`` is an incremental update that adds a few important
+features and fixes several bugs. Some of the highlights include:
+
+
+
+Many other small bugfixes and docs additions. For full details see the
+:bokeh-tree:`CHANGELOG`.
+
+Migration Guide
+---------------
+
+NOTE: the 0.12.x series is the last planned release series before a version
+1.0 release. For more information see the `project roadmap`_.
+
+Deprecations Removed
+~~~~~~~~~~~~~~~~~~~~
+
+The following previous deprecations have been removed:
+
+* ``app_path`` from ``bokeh.client.session`` and ``bokeh.embed``
+* ``bokeh.io.standalone_html_page_for_models`` from ``bokeh.embed``
+* ``'patch'`` and ``'stream'`` event names (use ``'patching'`` and ``'streaming'``)
+* ``webgl``, ``x_mapper_type``, ``y_mapper_type``, and ``tool_events`` from ``Plot``
+
+New Deprecations
+~~~~~~~~~~~~~~~~
+
+The boolean ``responsive`` parameter to ``Figure`` and ``bokeh.layouts`` has
+been deprecated. The ``sizing_mode`` enum should be used instead. Use
+``sizing_mode='fixed'`` for ``responsive=True`` and
+``sizing_mode='scale_width'`` for ``responsive=False`` instead.
+
+Dead Code Removal
+~~~~~~~~~~~~~~~~~
+
+The following unused code was removed immediately:
+
+* ``Aggregation`` from ``bokeh.core.enums``
+* PyPy detection functions from ``bokeh.util``
+* Zeppelin related code (support should come from external notebook hook)
+
+.. _project roadmap: https://bokehplots.com/pages/roadmap.html

--- a/sphinx/source/docs/user_guide/styling.rst
+++ b/sphinx/source/docs/user_guide/styling.rst
@@ -209,25 +209,15 @@ values can be passed to |figure| as a convenience:
 Responsive Dimensions
 ~~~~~~~~~~~~~~~~~~~~~
 
-In addition, you can use the ``responsive`` attribute. The responsive attribute
-causes the plot to fill the container it's sitting in, and to respond to
-changes in browser size. Responsive web elements are common-place in web
-development and the ``responsive`` flag may be useful if you are trying to
-present your plot on a website where you want it to conform to a number of
-browsers. If you set the responsive flag, the ``plot_width`` and ``plot_height`` will
+For control over how the plot scales to fill its container, see the
+documentation for :ref:`bokeh.models.layouts`, in particular the
+``sizing_mode`` property of :class:`~bokeh.models.layouts.LayoutDOM`.
+
+If you set ``sizing_mode``, the ``plot_width`` and ``plot_height`` may
 immediately change when a plot is rendered to fill the container. However,
 those parameters will be used to calculate the initial aspect ratio for your
 plot, so you may want to keep them. Plots will only resize down to a minimum of
 100px (height or width) to prevent problems in displaying your plot.
-
-For more precise control over how the plot scales to fill its container,
-see the documentation for :ref:`bokeh.models.layouts`, in particular the
-``sizing_mode`` property of :class:`~bokeh.models.layouts.LayoutDOM`.
-
-.. warning::
-    This feature is known not to work when combined with HBox.
-    This is a new feature and may have other issues when used in different circumstances.
-    Please report these issues on the  `Bokeh GitHub repository`_ or the `Bokeh mailing list`_.
 
 .. _Bokeh GitHub repository: https://github.com/bokeh/bokeh
 .. _Bokeh mailing list: https://groups.google.com/a/anaconda.com/forum/#!forum/bokeh


### PR DESCRIPTION
Remove several deprecations and dead code, and add one for `responsive`. Work is outlined in individual commits. 

The only thing possibly of note:

> Glyphs methods now only accept either all sequence literals, OR all column names

i.e. mixing will trigger an error