### PR TITLE
Issue #6704: Fix hover hittest on horizontal/vertical segments

### DIFF
--- a/bokehjs/src/coffee/core/hittest.coffee
+++ b/bokehjs/src/coffee/core/hittest.coffee
@@ -73,7 +73,7 @@ export validate_bbox_coords = ([x0, x1], [y0, y1]) ->
 sqr = (x) -> x * x
 export dist_2_pts = (vx, vy, wx, wy) -> sqr(vx - wx) + sqr(vy - wy)
 
-dist_to_segment_squared = (p, v, w) ->
+export dist_to_segment_squared = (p, v, w) ->
   l2 = dist_2_pts(v.x, v.y, w.x, w.y)
   if (l2 == 0)
     return dist_2_pts(p.x, p.y, v.x, v.y)

--- a/bokehjs/src/coffee/models/glyphs/segment.coffee
+++ b/bokehjs/src/coffee/models/glyphs/segment.coffee
@@ -42,9 +42,13 @@ export class SegmentView extends GlyphView
 
     hits = []
     lw_voffset = 2 # FIXME: Use maximum of segments line_width/2 instead of magic constant 2
-    lw_sxoffset = @renderer.xscale.invert(vx-lw_voffset, true)
-    lw_syoffset = @renderer.yscale.invert(vy-lw_voffset, true)
-    candidates = @index.indices({minX: lw_sxoffset, minY: lw_syoffset, maxX: 2*x - lw_sxoffset, maxY: 2*y - lw_syoffset})
+    candidates = @index.indices({
+      minX: @renderer.xscale.invert(vx-lw_voffset, true), 
+      minY: @renderer.yscale.invert(vy-lw_voffset, true),
+      maxX: @renderer.xscale.invert(vx+lw_voffset, true),
+      maxY: @renderer.yscale.invert(vy+lw_voffset, true)
+    })
+
     for i in candidates
       threshold2 = Math.pow(Math.max(2, @visuals.line.cache_select('line_width', i) / 2), 2)
       [p0, p1] = [{x: @sx0[i], y: @sy0[i]}, {x: @sx1[i], y: @sy1[i]}]

--- a/bokehjs/src/coffee/models/glyphs/segment.coffee
+++ b/bokehjs/src/coffee/models/glyphs/segment.coffee
@@ -41,13 +41,15 @@ export class SegmentView extends GlyphView
       y: this.renderer.plot_view.canvas.vy_to_sy(vy)
 
     hits = []
-
-    candidates = @index.indices({minX: x, minY: y, maxX: x, maxY: y})
+    lw_voffset = 2 # FIXME: Use maximum of segments line_width/2 instead of magic constant 2
+    lw_sxoffset = @renderer.xscale.invert(vx-lw_voffset, true)
+    lw_syoffset = @renderer.yscale.invert(vy-lw_voffset, true)
+    candidates = @index.indices({minX: lw_sxoffset, minY: lw_syoffset, maxX: 2*x - lw_sxoffset, maxY: 2*y - lw_syoffset})
     for i in candidates
-      threshold = Math.max(2, @visuals.line.cache_select('line_width', i) / 2)
+      threshold2 = Math.pow(Math.max(2, @visuals.line.cache_select('line_width', i) / 2), 2)
       [p0, p1] = [{x: @sx0[i], y: @sy0[i]}, {x: @sx1[i], y: @sy1[i]}]
-      dist = hittest.dist_to_segment(point, p0, p1)
-      if dist < threshold
+      dist2 = hittest.dist_to_segment_squared(point, p0, p1)
+      if dist2 < threshold2
         hits.push(i)
 
     result = hittest.create_hit_test_result()

--- a/bokehjs/src/coffee/models/glyphs/segment.coffee
+++ b/bokehjs/src/coffee/models/glyphs/segment.coffee
@@ -43,7 +43,7 @@ export class SegmentView extends GlyphView
     hits = []
     lw_voffset = 2 # FIXME: Use maximum of segments line_width/2 instead of magic constant 2
     candidates = @index.indices({
-      minX: @renderer.xscale.invert(vx-lw_voffset, true), 
+      minX: @renderer.xscale.invert(vx-lw_voffset, true),
       minY: @renderer.yscale.invert(vy-lw_voffset, true),
       maxX: @renderer.xscale.invert(vx+lw_voffset, true),
       maxY: @renderer.yscale.invert(vy+lw_voffset, true)


### PR DESCRIPTION
Horizontal/vertical segments have zero bbox area and hence
are almost impossible to coincide with a point for hittest search.
Hence RBush.indices() was never returning such segments.
We now instead search rbush with a square of size 4x4 instead of a
point to find such segments as well.
Ideally, the square size should be maximum of the the line_width,
but the current state is in itself a great improvement.

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [x] issues: fixes #6704 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
