### PR TITLE
Fix typo in notebook.rst

### DIFF
--- a/sphinx/source/docs/user_guide/notebook.rst
+++ b/sphinx/source/docs/user_guide/notebook.rst
@@ -8,7 +8,7 @@ Working in the Notebook
 Inline Plots
 ------------
 
-To display Bokeh plots inline in an Jupyter/Zeppelin notebook, use the
+To display Bokeh plots inline in a Jupyter/Zeppelin notebook, use the
 |output_notebook| function from |bokeh.io| instead of (or in addition to)
 the |output_file| function we have seen previously. No other modifications
 are required. When |show| is called, the plot will be displayed inline in


### PR DESCRIPTION
There was no issue for this. Just noticed a typo in the docs. 
