### PR TITLE
stop computing unused and expensive bokeh.__base_version__

### DIFF
--- a/bokeh/__init__.py
+++ b/bokeh/__init__.py
@@ -14,7 +14,6 @@ from __future__ import absolute_import, print_function
 
 # configure Bokeh version
 from .util.version import __version__; __version__
-from .util.version import __base_version__; __base_version__
 
 # configure Bokeh logger
 from .util import logconfig

--- a/bokeh/tests/test_bokeh_init.py
+++ b/bokeh/tests/test_bokeh_init.py
@@ -4,7 +4,6 @@ def test_dir():
     import bokeh
     names = dir(bokeh)
     assert "__version__" in names
-    assert "__base_version__" in names
     assert "license" in names
     assert "sampledata" in names
 

--- a/bokeh/util/version.py
+++ b/bokeh/util/version.py
@@ -26,6 +26,3 @@ def base_version():
     import re
     VERSION_PAT = re.compile(r"^(\d+\.\d+\.\d+)((?:dev|rc).*)?")
     return VERSION_PAT.search(__version__).group(1)
-
-__base_version__ = base_version()
-del base_version

--- a/sphinx/source/docs/releases/0.12.10.rst
+++ b/sphinx/source/docs/releases/0.12.10.rst
@@ -43,4 +43,10 @@ The following unused code was removed immediately:
 * PyPy detection functions from ``bokeh.util``
 * Zeppelin related code (support should come from external notebook hook)
 
+Additionally the attribute ``bokeh.__base_version__`` was removed. Computing
+it at all times made importing Bokeh take substantial fractions of a second
+longer than necessary. It is not expected this change should affect any
+users, but if you need this value, the ``bokeh.util.version.base_version``
+function can be used.
+
 .. _project roadmap: https://bokehplots.com/pages/roadmap.html


### PR DESCRIPTION
- [x] release document entry (if new feature or API change)

This PR removes ``bokeh.__version__`` which was computed on every import of Bokeh and could take hundred of milliseconds. 

Ref: https://github.com/dask/distributed/issues/1399#issuecomment-329834414