### PR TITLE
Bryanv/hold events

### DIFF
--- a/bokeh/core/enums.py
+++ b/bokeh/core/enums.py
@@ -127,6 +127,9 @@ def enumeration(*values, **kwargs):
 
     return type("Enumeration", (Enumeration,), attrs)()
 
+#: Specify whether events should be combined or collected as-is when a Document hold is in effect
+HoldPolicy = enumeration( "combine", "collect")
+
 #: Specify whether a dimension or coordinate is latitude or longitude
 LatLon = enumeration("lat", "lon")
 

--- a/bokeh/core/tests/test_enums.py
+++ b/bokeh/core/tests/test_enums.py
@@ -41,6 +41,7 @@ def test_enums_contents():
         'Direction',
         'Enumeration',
         'FontStyle',
+        'HoldPolicy',
         'HorizontalLocation',
         'JitterRandomDistribution',
         'LatLon',

--- a/bokeh/document/document.py
+++ b/bokeh/document/document.py
@@ -26,6 +26,7 @@ import sys
 import jinja2
 from six import string_types
 
+from ..core.enums import HoldPolicy
 from ..core.json_encoder import serialize_json
 from ..core.query import find
 from ..core.templates import FILE
@@ -70,6 +71,8 @@ class Document(object):
         self._session_context = None
         self._modules = []
         self._template_variables = {}
+        self._hold = None
+        self._held_events = []
 
         # set of models subscribed to user events
         self._subscribed_models = defaultdict(set)
@@ -472,8 +475,71 @@ class Document(object):
         '''
         return self._all_models_by_name.get_one(name, "Found more than one model named '%s'" % name)
 
+    def hold(self, policy="combine"):
+        ''' Activate a document hold.
+
+        While a hold is active, no model changes will be applied, or trigger
+        callbacks. Once ``unhold`` is called, the events collected during the
+        hold will be applied according to the hold policy.
+
+        Args:
+            hold ('combine' or 'collect', optional)
+                Whether events collected during a hold should attempt to be
+                combined (default: 'combine')
+
+                When set to ``'collect'`` all events will be collected and
+                replayed in order as-is when ``unhold`` is called.
+
+                When set to ``'combine'`` Bokeh will attempt to combine
+                compatible events together. Typically, different events that
+                change the same property on the same mode can be combined.
+                For example, if the following sequence occurs:
+
+                .. code-block:: python
+
+                    doc.hold('combine')
+                    slider.value = 10
+                    slider.value = 11
+                    slider.value = 12
+
+                Then only *one* callback, for the last ``slider.value = 12``
+                will be triggered.
+
+        Returns:
+            None
+
+        .. note::
+            ``hold`` only applies to document change events, i.e. setting
+            properties on models. It does not apply to events such as
+            ``ButtonClick``, etc.
+
+        '''
+        if self._hold is not None and self._hold != policy:
+            logger.warn("hold already active with '%s', ignoring '%s'" % (self._hold, policy))
+            return
+        if policy not in HoldPolicy:
+            raise ValueError("Unknown hold policy %r" % policy)
+        self._hold = policy
+
+    def unhold(self):
+        ''' Turn off any active document hold and apply any collected events.
+
+        Returns:
+            None
+
+        '''
+        # no-op if we are already no holding
+        if self._hold is None: return
+
+        self._hold = None
+        events = list(self._held_events)
+        self._held_events = []
+
+        for event in events:
+            self._trigger_on_change(event)
+
     def on_change(self, *callbacks):
-        ''' Provide callbacks to invovke if the document or any Model reachable
+        ''' Provide callbacks to invoke if the document or any Model reachable
         from its roots changes.
 
         '''
@@ -881,6 +947,12 @@ class Document(object):
         '''
 
         '''
+        if self._hold == "collect":
+            self._held_events.append(event)
+            return
+        elif self._hold == "combine":
+            _combine_document_events(event, self._held_events)
+            return
 
         if event.callback_invoker is not None:
             self._with_self_as_curdoc(event.callback_invoker)
@@ -917,3 +989,33 @@ class Document(object):
                 return f(*args, **kwargs)
             return doc._with_self_as_curdoc(invoke)
         return wrapper
+
+
+def _combine_document_events(new_event, old_events):
+    ''' Attempt to combine a new event with a list of previous events.
+
+    The ``old_event`` will be scanned in reverse, and ``.combine(new_event)``
+    will be called on each. If a combination can be made, the function
+    will return immediately. Otherwise, ``new_event`` will be appended to
+    ``old_events``.
+
+    Args:
+        new_event (DocumentChangedEvent) :
+            The new event to attempt to combine
+
+        old_events (list[DocumentChangedEvent])
+            A list of previous events to attempt to combine new_event with
+
+            **This is an "out" parameter**. The values it contains will be
+            modified in-place.
+
+    Returns:
+        None
+
+    '''
+    for event in reversed(old_events):
+        if event.combine(new_event):
+            return
+
+    # no combination was possible
+    old_events.append(new_event)

--- a/bokeh/document/document.py
+++ b/bokeh/document/document.py
@@ -792,7 +792,7 @@ class Document(object):
             return False
         return isinstance(selector[field], string_types)
 
-    def _notify_change(self, model, attr, old, new, hint=None, setter=None):
+    def _notify_change(self, model, attr, old, new, hint=None, setter=None, callback_invoker=None):
         ''' Called by Model when it changes
 
         '''
@@ -808,7 +808,7 @@ class Document(object):
         else:
             serializable_new = None
 
-        event = ModelChangedEvent(self, model, attr, old, new, serializable_new, hint, setter)
+        event = ModelChangedEvent(self, model, attr, old, new, serializable_new, hint, setter, callback_invoker)
         self._trigger_on_change(event)
 
     def _push_all_models_freeze(self):
@@ -881,6 +881,9 @@ class Document(object):
         '''
 
         '''
+
+        if event.callback_invoker is not None:
+            self._with_self_as_curdoc(event.callback_invoker)
 
         def invoke_callbacks():
             for cb in self._callbacks.values():

--- a/bokeh/document/events.py
+++ b/bokeh/document/events.py
@@ -13,7 +13,7 @@ class DocumentChangedEvent(object):
 
     '''
 
-    def __init__(self, document, setter=None):
+    def __init__(self, document, setter=None, callback_invoker=None):
         '''
 
         Args:
@@ -31,9 +31,15 @@ class DocumentChangedEvent(object):
                 The session can compare the event setter to itself, and
                 suppress any updates that originate from itself.
 
+            callback_invoker (callable, optional) :
+                A callable that will invoke any Model callbacks that should
+                be executed in response to the change that triggered this
+                event. (default: None)
+
         '''
         self.document = document
         self.setter = setter
+        self.callback_invoker = callback_invoker
 
     def dispatch(self, receiver):
         ''' Dispatch handling of this event to a receiver.
@@ -94,7 +100,7 @@ class ModelChangedEvent(DocumentPatchedEvent):
 
     '''
 
-    def __init__(self, document, model, attr, old, new, serializable_new, hint=None, setter=None):
+    def __init__(self, document, model, attr, old, new, serializable_new, hint=None, setter=None, callback_invoker=None):
         '''
 
         Args:
@@ -130,10 +136,16 @@ class ModelChangedEvent(DocumentPatchedEvent):
                 See :class:`~bokeh.document.events.DocumentChangedEvent`
                 for more details.
 
+            callback_invoker (callable, optional) :
+                A callable that will invoke any Model callbacks that should
+                be executed in response to the change that triggered this
+                event. (default: None)
+
+
         '''
         if setter is None and isinstance(hint, (ColumnsStreamedEvent, ColumnsPatchedEvent)):
             setter = hint.setter
-        super(ModelChangedEvent, self).__init__(document, setter)
+        super(ModelChangedEvent, self).__init__(document, setter, callback_invoker)
         self.model = model
         self.attr = attr
         self.old = old
@@ -210,7 +222,7 @@ class ColumnDataChangedEvent(DocumentPatchedEvent):
 
     '''
 
-    def __init__(self, document, column_source, cols=None, setter=None):
+    def __init__(self, document, column_source, cols=None, setter=None, callback_invoker=None):
         '''
 
         Args:
@@ -230,8 +242,14 @@ class ColumnDataChangedEvent(DocumentPatchedEvent):
                 See :class:`~bokeh.document.events.DocumentChangedEvent`
                 for more details.
 
+            callback_invoker (callable, optional) :
+                A callable that will invoke any Model callbacks that should
+                be executed in response to the change that triggered this
+                event. (default: None)
+
+
         '''
-        super(ColumnDataChangedEvent, self).__init__(document, setter)
+        super(ColumnDataChangedEvent, self).__init__(document, setter, callback_invoker)
         self.column_source = column_source
         self.cols = cols
 
@@ -242,7 +260,7 @@ class ColumnDataChangedEvent(DocumentPatchedEvent):
 
         '''
         super(ColumnDataChangedEvent, self).dispatch(receiver)
-        if hasattr(receiver, '_column_data_changed)'):
+        if hasattr(receiver, '_column_data_changed'):
             receiver._column_data_changed(self)
 
     def generate(self, references, buffers):
@@ -290,7 +308,7 @@ class ColumnsStreamedEvent(DocumentPatchedEvent):
 
     '''
 
-    def __init__(self, document, column_source, data, rollover, setter=None):
+    def __init__(self, document, column_source, data, rollover, setter=None, callback_invoker=None):
         '''
 
         Args:
@@ -314,8 +332,14 @@ class ColumnsStreamedEvent(DocumentPatchedEvent):
                 See :class:`~bokeh.document.events.DocumentChangedEvent`
                 for more details.
 
+            callback_invoker (callable, optional) :
+                A callable that will invoke any Model callbacks that should
+                be executed in response to the change that triggered this
+                event. (default: None)
+
+
         '''
-        super(ColumnsStreamedEvent, self).__init__(document, setter)
+        super(ColumnsStreamedEvent, self).__init__(document, setter, callback_invoker)
         self.column_source = column_source
         self.data = data
         self.rollover = rollover
@@ -370,7 +394,7 @@ class ColumnsPatchedEvent(DocumentPatchedEvent):
 
     '''
 
-    def __init__(self, document, column_source, patches, setter=None):
+    def __init__(self, document, column_source, patches, setter=None, callback_invoker=None):
         '''
 
         Args:
@@ -389,8 +413,13 @@ class ColumnsPatchedEvent(DocumentPatchedEvent):
                 See :class:`~bokeh.document.events.DocumentChangedEvent`
                 for more details.
 
+            callback_invoker (callable, optional) :
+                A callable that will invoke any Model callbacks that should
+                be executed in response to the change that triggered this
+                event. (default: None)
+
         '''
-        super(ColumnsPatchedEvent, self).__init__(document, setter)
+        super(ColumnsPatchedEvent, self).__init__(document, setter, callback_invoker)
         self.column_source = column_source
         self.patches = patches
 
@@ -442,7 +471,7 @@ class TitleChangedEvent(DocumentPatchedEvent):
 
     '''
 
-    def __init__(self, document, title, setter=None):
+    def __init__(self, document, title, setter=None, callback_invoker=None):
         '''
 
         Args:
@@ -459,8 +488,14 @@ class TitleChangedEvent(DocumentPatchedEvent):
                 See :class:`~bokeh.document.events.DocumentChangedEvent`
                 for more details.
 
+            callback_invoker (callable, optional) :
+                A callable that will invoke any Model callbacks that should
+                be executed in response to the change that triggered this
+                event. (default: None)
+
+
         '''
-        super(TitleChangedEvent, self).__init__(document, setter)
+        super(TitleChangedEvent, self).__init__(document, setter, callback_invoker)
         self.title = title
 
     def generate(self, references, buffers):
@@ -499,7 +534,7 @@ class RootAddedEvent(DocumentPatchedEvent):
 
     '''
 
-    def __init__(self, document, model, setter=None):
+    def __init__(self, document, model, setter=None, callback_invoker=None):
         '''
 
         Args:
@@ -516,8 +551,13 @@ class RootAddedEvent(DocumentPatchedEvent):
                 See :class:`~bokeh.document.events.DocumentChangedEvent`
                 for more details.
 
+            callback_invoker (callable, optional) :
+                A callable that will invoke any Model callbacks that should
+                be executed in response to the change that triggered this
+                event. (default: None)
+
         '''
-        super(RootAddedEvent, self).__init__(document, setter)
+        super(RootAddedEvent, self).__init__(document, setter, callback_invoker)
         self.model = model
 
     def generate(self, references, buffers):
@@ -557,7 +597,7 @@ class RootRemovedEvent(DocumentPatchedEvent):
 
     '''
 
-    def __init__(self, document, model, setter=None):
+    def __init__(self, document, model, setter=None, callback_invoker=None):
         '''
 
         Args:
@@ -574,8 +614,14 @@ class RootRemovedEvent(DocumentPatchedEvent):
                 See :class:`~bokeh.document.events.DocumentChangedEvent`
                 for more details.
 
+            callback_invoker (callable, optional) :
+                A callable that will invoke any Model callbacks that should
+                be executed in response to the change that triggered this
+                event. (default: None)
+
+
         '''
-        super(RootRemovedEvent, self).__init__(document, setter)
+        super(RootRemovedEvent, self).__init__(document, setter, callback_invoker)
         self.model = model
 
     def generate(self, references, buffers):

--- a/bokeh/document/tests/test_events.py
+++ b/bokeh/document/tests/test_events.py
@@ -27,300 +27,322 @@ class FakeModel(object):
 
 # DocumentChangedEvent --------------------------------------------------------
 
-def test_DocumentChangedEvent_init():
-    e = bde.DocumentChangedEvent("doc")
-    assert e.document == "doc"
-    assert e.setter == None
-    assert e.callback_invoker == None
+class TesDocumentChangedEvent(object):
 
-    e = bde.DocumentChangedEvent("doc", "setter")
-    assert e.document == "doc"
-    assert e.setter == "setter"
-    assert e.callback_invoker == None
+    def test_init(self):
+        e = bde.DocumentChangedEvent("doc")
+        assert e.document == "doc"
+        assert e.setter == None
+        assert e.callback_invoker == None
 
-    e = bde.DocumentChangedEvent("doc", callback_invoker="invoker")
-    assert e.document == "doc"
-    assert e.setter == None
-    assert e.callback_invoker == "invoker"
+        e = bde.DocumentChangedEvent("doc", "setter")
+        assert e.document == "doc"
+        assert e.setter == "setter"
+        assert e.callback_invoker == None
 
-    e = bde.DocumentChangedEvent("doc", "setter", "invoker")
-    assert e.document == "doc"
-    assert e.setter == "setter"
-    assert e.callback_invoker == "invoker"
+        e = bde.DocumentChangedEvent("doc", callback_invoker="invoker")
+        assert e.document == "doc"
+        assert e.setter == None
+        assert e.callback_invoker == "invoker"
 
-def test_DocumentChangedEvent_dispatch():
-    e = bde.DocumentChangedEvent("doc", "setter", "invoker")
-    e.dispatch(FakeEmptyDispatcher())
-    d = FakeFullDispatcher()
-    e.dispatch(d)
-    assert d.called == ['_document_changed']
+        e = bde.DocumentChangedEvent("doc", "setter", "invoker")
+        assert e.document == "doc"
+        assert e.setter == "setter"
+        assert e.callback_invoker == "invoker"
+
+    def test_dispatch(self):
+        e = bde.DocumentChangedEvent("doc", "setter", "invoker")
+        e.dispatch(FakeEmptyDispatcher())
+        d = FakeFullDispatcher()
+        e.dispatch(d)
+        assert d.called == ['_document_changed']
 
 # DocumentPatchedEvent --------------------------------------------------------
 
-def test_DocumentPatchedEvent_init():
-    e = bde.DocumentPatchedEvent("doc", "setter", "invoker")
-    assert e.document == "doc"
-    assert e.setter == "setter"
-    assert e.callback_invoker == "invoker"
+class TestDocumentPatchedEvent(object):
 
-def test_DocumentPatchedEvent_generate():
-    e = bde.DocumentPatchedEvent("doc", "setter", "invoker")
-    with pytest.raises(NotImplementedError):
-        e.generate("refs", "bufs")
+    def test_init(self):
+        e = bde.DocumentPatchedEvent("doc", "setter", "invoker")
+        assert e.document == "doc"
+        assert e.setter == "setter"
+        assert e.callback_invoker == "invoker"
 
-def test_DocumentPatchedEvent_dispatch():
-    e = bde.DocumentPatchedEvent("doc", "setter", "invoker")
-    e.dispatch(FakeEmptyDispatcher())
-    d = FakeFullDispatcher()
-    e.dispatch(d)
-    assert d.called == ['_document_changed', '_document_patched']
+    def test_generate(self):
+        e = bde.DocumentPatchedEvent("doc", "setter", "invoker")
+        with pytest.raises(NotImplementedError):
+            e.generate("refs", "bufs")
+
+    def test_dispatch(self):
+        e = bde.DocumentPatchedEvent("doc", "setter", "invoker")
+        e.dispatch(FakeEmptyDispatcher())
+        d = FakeFullDispatcher()
+        e.dispatch(d)
+        assert d.called == ['_document_changed', '_document_patched']
 
 # ModelChangedEvent -----------------------------------------------------------
 
-def test_ModelChangedEvent_init_defaults():
-    e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew")
-    assert e.document == "doc"
-    assert e.setter == None
-    assert e.callback_invoker == None
-    e.model = "model"
-    e.attr = "attr"
-    e.old = "old"
-    e.new = "new"
-    e.snew = "snew"
-    e.hint = None
+class TestModelChangedEvent(object):
 
-def test_ModelChangedEvent_init_ignores_hint_with_setter():
-    e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew", setter="setter", hint="hint", callback_invoker="invoker")
-    assert e.document == "doc"
-    assert e.setter == "setter"
-    assert e.callback_invoker == "invoker"
-    e.model = "model"
-    e.attr = "attr"
-    e.old = "old"
-    e.new = "new"
-    e.snew = "snew"
-    e.hint = None
+    def test_init_defaults(self):
+        e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew")
+        assert e.document == "doc"
+        assert e.setter == None
+        assert e.callback_invoker == None
+        e.model = "model"
+        e.attr = "attr"
+        e.old = "old"
+        e.new = "new"
+        e.snew = "snew"
+        e.hint = None
 
-def test_ModelChangedEvent_init_uses_hint_with_no_setter():
-    e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew", hint="hint", callback_invoker="invoker")
-    assert e.document == "doc"
-    assert e.setter == None
-    assert e.callback_invoker == "invoker"
-    e.model = "model"
-    e.attr = "attr"
-    e.old = "old"
-    e.new = "new"
-    e.snew = "snew"
-    e.hint = "hint"
+    def test_init_ignores_hint_with_setter(self):
+        e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew", setter="setter", hint="hint", callback_invoker="invoker")
+        assert e.document == "doc"
+        assert e.setter == "setter"
+        assert e.callback_invoker == "invoker"
+        e.model = "model"
+        e.attr = "attr"
+        e.old = "old"
+        e.new = "new"
+        e.snew = "snew"
+        e.hint = None
 
-# TODO (bev) tests for generate
+    def test_init_uses_hint_with_no_setter(self):
+        e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew", hint="hint", callback_invoker="invoker")
+        assert e.document == "doc"
+        assert e.setter == None
+        assert e.callback_invoker == "invoker"
+        e.model = "model"
+        e.attr = "attr"
+        e.old = "old"
+        e.new = "new"
+        e.snew = "snew"
+        e.hint = "hint"
 
-def test_ModelChangedEvent_dispatch():
-    e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew")
-    e.dispatch(FakeEmptyDispatcher())
-    d = FakeFullDispatcher()
-    e.dispatch(d)
-    assert d.called == ['_document_changed', '_document_patched', '_document_model_changed']
+    # TODO (bev) tests for generate
+
+    def test_dispatch(self):
+        e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew")
+        e.dispatch(FakeEmptyDispatcher())
+        d = FakeFullDispatcher()
+        e.dispatch(d)
+        assert d.called == ['_document_changed', '_document_patched', '_document_model_changed']
 
 # ColumnDataChangedEvent ------------------------------------------------------
 
-def test_ColumnDataChangedEvent_init():
-    m = FakeModel()
-    e = bde.ColumnDataChangedEvent("doc", m, [1,2], "setter", "invoker")
-    assert e.document == "doc"
-    assert e.column_source == m
-    assert e.cols == [1,2]
-    assert e.setter == "setter"
-    assert e.callback_invoker == "invoker"
+class ColumnDataChangedEvent(object):
 
-@patch("bokeh.util.serialization.transform_column_source_data")
-def test_ColumnDataChangedEvent_generate(mock_tcds):
-    mock_tcds.return_value = "new"
-    m = FakeModel()
-    e = bde.ColumnDataChangedEvent("doc", m, [1,2], "setter", "invoker")
-    refs = dict(foo=10)
-    bufs = set()
-    r = e.generate(refs, bufs)
-    assert r == dict(kind="ColumnDataChanged", column_source="ref", new="new", cols=[1,2])
-    assert refs == dict(foo=10)
-    assert bufs == set()
+    def test_init(self):
+        m = FakeModel()
+        e = bde.ColumnDataChangedEvent("doc", m, [1,2], "setter", "invoker")
+        assert e.document == "doc"
+        assert e.column_source == m
+        assert e.cols == [1,2]
+        assert e.setter == "setter"
+        assert e.callback_invoker == "invoker"
 
-def test_ColumnDataChangedEvent_dispatch():
-    m = FakeModel()
-    e = bde.ColumnDataChangedEvent("doc", m, [1,2], "setter", "invoker")
-    e.dispatch(FakeEmptyDispatcher())
-    d = FakeFullDispatcher()
-    e.dispatch(d)
-    assert d.called == ['_document_changed', '_document_patched', '_column_data_changed']
+    @patch("bokeh.util.serialization.transform_column_source_data")
+    def test_generate(mock_tcds):
+        mock_tcds.return_value = "new"
+        m = FakeModel()
+        e = bde.ColumnDataChangedEvent("doc", m, [1,2], "setter", "invoker")
+        refs = dict(foo=10)
+        bufs = set()
+        r = e.generate(refs, bufs)
+        assert r == dict(kind="ColumnDataChanged", column_source="ref", new="new", cols=[1,2])
+        assert refs == dict(foo=10)
+        assert bufs == set()
+
+    def test_dispatch(self):
+        m = FakeModel()
+        e = bde.ColumnDataChangedEvent("doc", m, [1,2], "setter", "invoker")
+        e.dispatch(FakeEmptyDispatcher())
+        d = FakeFullDispatcher()
+        e.dispatch(d)
+        assert d.called == ['_document_changed', '_document_patched', '_column_data_changed']
 
 # ColumnsStreamedEvent --------------------------------------------------------
 
-def test_ColumnsStreamedEvent_init():
-    m = FakeModel()
-    e = bde.ColumnsStreamedEvent("doc", m, dict(foo=1), 200, "setter", "invoker")
-    assert e.document == "doc"
-    assert e.column_source == m
-    assert e.data == dict(foo=1)
-    assert e.rollover == 200
-    assert e.setter == "setter"
-    assert e.callback_invoker == "invoker"
+class ColumnsStreamedEvent(object):
 
-def test_ColumnsStreamedEvent_generate():
-    m = FakeModel()
-    e = bde.ColumnsStreamedEvent("doc", m, dict(foo=1), 200, "setter", "invoker")
-    refs = dict(foo=10)
-    bufs = set()
-    r = e.generate(refs, bufs)
-    assert r == dict(kind="ColumnsStreamed", column_source="ref", data=dict(foo=1), rollover=200)
-    assert refs == dict(foo=10)
-    assert bufs == set()
+    def test_init(self):
+        m = FakeModel()
+        e = bde.ColumnsStreamedEvent("doc", m, dict(foo=1), 200, "setter", "invoker")
+        assert e.document == "doc"
+        assert e.column_source == m
+        assert e.data == dict(foo=1)
+        assert e.rollover == 200
+        assert e.setter == "setter"
+        assert e.callback_invoker == "invoker"
 
-def test_ColumnsStreamedEvent_dispatch():
-    m = FakeModel()
-    e = bde.ColumnsStreamedEvent("doc", m, dict(foo=1), 200, "setter", "invoker")
-    e.dispatch(FakeEmptyDispatcher())
-    d = FakeFullDispatcher()
-    e.dispatch(d)
-    assert d.called == ['_document_changed', '_document_patched', '_columns_streamed']
+    def test_generate(self):
+        m = FakeModel()
+        e = bde.ColumnsStreamedEvent("doc", m, dict(foo=1), 200, "setter", "invoker")
+        refs = dict(foo=10)
+        bufs = set()
+        r = e.generate(refs, bufs)
+        assert r == dict(kind="ColumnsStreamed", column_source="ref", data=dict(foo=1), rollover=200)
+        assert refs == dict(foo=10)
+        assert bufs == set()
+
+    def test_dispatch(self):
+        m = FakeModel()
+        e = bde.ColumnsStreamedEvent("doc", m, dict(foo=1), 200, "setter", "invoker")
+        e.dispatch(FakeEmptyDispatcher())
+        d = FakeFullDispatcher()
+        e.dispatch(d)
+        assert d.called == ['_document_changed', '_document_patched', '_columns_streamed']
 
 # ColumnsPatchedEvent ---------------------------------------------------------
 
-def test_ColumnsPatchedEvent_init():
-    m = FakeModel()
-    e = bde.ColumnsPatchedEvent("doc", m, [1, 2], "setter", "invoker")
-    assert e.document == "doc"
-    assert e.column_source == m
-    assert e.patches == [1, 2]
-    assert e.setter == "setter"
-    assert e.callback_invoker == "invoker"
+class ColumnsPatchedEvent(object):
 
-def test_ColumnsPatchedEvent_generate():
-    m = FakeModel()
-    e = bde.ColumnsPatchedEvent("doc", m, [1, 2], "setter", "invoker")
-    refs = dict(foo=10)
-    bufs = set()
-    r = e.generate(refs, bufs)
-    assert r == dict(kind="ColumnsPatched", column_source="ref", patches=[1,2])
-    assert refs == dict(foo=10)
-    assert bufs == set()
+    def test_init(self):
+        m = FakeModel()
+        e = bde.ColumnsPatchedEvent("doc", m, [1, 2], "setter", "invoker")
+        assert e.document == "doc"
+        assert e.column_source == m
+        assert e.patches == [1, 2]
+        assert e.setter == "setter"
+        assert e.callback_invoker == "invoker"
 
-def test_ColumnsPatchedEvent_dispatch():
-    m = FakeModel()
-    e = bde.ColumnsPatchedEvent("doc", m, [1, 2], "setter", "invoker")
-    e.dispatch(FakeEmptyDispatcher())
-    d = FakeFullDispatcher()
-    e.dispatch(d)
-    assert d.called == ['_document_changed', '_document_patched', '_columns_patched']
+    def test_generate(self):
+        m = FakeModel()
+        e = bde.ColumnsPatchedEvent("doc", m, [1, 2], "setter", "invoker")
+        refs = dict(foo=10)
+        bufs = set()
+        r = e.generate(refs, bufs)
+        assert r == dict(kind="ColumnsPatched", column_source="ref", patches=[1,2])
+        assert refs == dict(foo=10)
+        assert bufs == set()
+
+    def test_dispatch(self):
+        m = FakeModel()
+        e = bde.ColumnsPatchedEvent("doc", m, [1, 2], "setter", "invoker")
+        e.dispatch(FakeEmptyDispatcher())
+        d = FakeFullDispatcher()
+        e.dispatch(d)
+        assert d.called == ['_document_changed', '_document_patched', '_columns_patched']
 
 # TitleChangedEvent -----------------------------------------------------------
 
-def test_TitleChangedEvent_init():
-    e = bde.TitleChangedEvent("doc", "title", "setter", "invoker")
-    assert e.document == "doc"
-    assert e.title == "title"
-    assert e.setter == "setter"
-    assert e.callback_invoker == "invoker"
+class TitleChangedEvent(object):
 
-def test_TitleChangedEvent_generate():
-    e = bde.TitleChangedEvent("doc", "title", "setter", "invoker")
-    refs = dict(foo=10)
-    bufs = set()
-    r = e.generate(refs, bufs)
-    assert r == dict(kind="TitleChanged", title="title")
-    assert refs == dict(foo=10)
-    assert bufs == set()
+    def test_init(self):
+        e = bde.TitleChangedEvent("doc", "title", "setter", "invoker")
+        assert e.document == "doc"
+        assert e.title == "title"
+        assert e.setter == "setter"
+        assert e.callback_invoker == "invoker"
 
-def test_TitleChangedEvent_dispatch():
-    e = bde.TitleChangedEvent("doc", "title", "setter", "invoker")
-    e.dispatch(FakeEmptyDispatcher())
-    d = FakeFullDispatcher()
-    e.dispatch(d)
-    assert d.called == ['_document_changed', '_document_patched']
+    def test_generate(self):
+        e = bde.TitleChangedEvent("doc", "title", "setter", "invoker")
+        refs = dict(foo=10)
+        bufs = set()
+        r = e.generate(refs, bufs)
+        assert r == dict(kind="TitleChanged", title="title")
+        assert refs == dict(foo=10)
+        assert bufs == set()
+
+    def test_dispatch(self):
+        e = bde.TitleChangedEvent("doc", "title", "setter", "invoker")
+        e.dispatch(FakeEmptyDispatcher())
+        d = FakeFullDispatcher()
+        e.dispatch(d)
+        assert d.called == ['_document_changed', '_document_patched']
 
 # RootAddedEvent --------------------------------------------------------------
 
-def test_RootAddedEvent_init():
-    m = FakeModel()
-    e = bde.RootAddedEvent("doc", m, "setter", "invoker")
-    assert e.document == "doc"
-    assert e.model == m
-    assert e.setter == "setter"
-    assert e.callback_invoker == "invoker"
+class TestRootAddedEvent(object):
 
-def test_RootAddedEvent_generate():
-    m = FakeModel()
-    e = bde.RootAddedEvent("doc", m, "setter", "invoker")
-    refs = dict(foo=10)
-    bufs = set()
-    r = e.generate(refs, bufs)
-    assert r == dict(kind="RootAdded", model="ref")
-    assert refs == dict(foo=10, ref1=1, ref2=2)
-    assert bufs == set()
+    def test_init(self):
+        m = FakeModel()
+        e = bde.RootAddedEvent("doc", m, "setter", "invoker")
+        assert e.document == "doc"
+        assert e.model == m
+        assert e.setter == "setter"
+        assert e.callback_invoker == "invoker"
 
-def test_RootAddedEvent_dispatch():
-    m = FakeModel()
-    e = bde.RootAddedEvent("doc", m, "setter", "invoker")
-    e.dispatch(FakeEmptyDispatcher())
-    d = FakeFullDispatcher()
-    e.dispatch(d)
-    assert d.called == ['_document_changed', '_document_patched']
+    def test_generate(self):
+        m = FakeModel()
+        e = bde.RootAddedEvent("doc", m, "setter", "invoker")
+        refs = dict(foo=10)
+        bufs = set()
+        r = e.generate(refs, bufs)
+        assert r == dict(kind="RootAdded", model="ref")
+        assert refs == dict(foo=10, ref1=1, ref2=2)
+        assert bufs == set()
+
+    def test_dispatch(self):
+        m = FakeModel()
+        e = bde.RootAddedEvent("doc", m, "setter", "invoker")
+        e.dispatch(FakeEmptyDispatcher())
+        d = FakeFullDispatcher()
+        e.dispatch(d)
+        assert d.called == ['_document_changed', '_document_patched']
 
 # RootRemovedEvent ------------------------------------------------------------
 
-def test_RootRemovedEvent_init():
-    m = FakeModel()
-    e = bde.RootRemovedEvent("doc", m, "setter", "invoker")
-    assert e.document == "doc"
-    assert e.model == m
-    assert e.setter == "setter"
-    assert e.callback_invoker == "invoker"
+class TestRootRemovedEvent(object):
 
-def test_RootRemovedEvent_generate():
-    m = FakeModel()
-    e = bde.RootRemovedEvent("doc", m, "setter", "invoker")
-    refs = dict(foo=10)
-    bufs = set()
-    r = e.generate(refs, bufs)
-    assert r == dict(kind="RootRemoved", model="ref")
-    assert refs == dict(foo=10)
-    assert bufs == set()
+    def test_init(self):
+        m = FakeModel()
+        e = bde.RootRemovedEvent("doc", m, "setter", "invoker")
+        assert e.document == "doc"
+        assert e.model == m
+        assert e.setter == "setter"
+        assert e.callback_invoker == "invoker"
 
-def test_RootRemovedEvent_dispatch():
-    m = FakeModel()
-    e = bde.RootRemovedEvent("doc", m, "setter", "invoker")
-    e.dispatch(FakeEmptyDispatcher())
-    d = FakeFullDispatcher()
-    e.dispatch(d)
-    assert d.called == ['_document_changed', '_document_patched']
+    def test_generate(self):
+        m = FakeModel()
+        e = bde.RootRemovedEvent("doc", m, "setter", "invoker")
+        refs = dict(foo=10)
+        bufs = set()
+        r = e.generate(refs, bufs)
+        assert r == dict(kind="RootRemoved", model="ref")
+        assert refs == dict(foo=10)
+        assert bufs == set()
+
+    def test_dispatch(self):
+        m = FakeModel()
+        e = bde.RootRemovedEvent("doc", m, "setter", "invoker")
+        e.dispatch(FakeEmptyDispatcher())
+        d = FakeFullDispatcher()
+        e.dispatch(d)
+        assert d.called == ['_document_changed', '_document_patched']
 
 # SessionCallbackAdded --------------------------------------------------------
 
-def test_SessionCallbackAdded_init():
-    e = bde.SessionCallbackAdded("doc", "callback")
-    assert e.document == "doc"
-    assert e.callback == "callback"
-    assert e.setter == None
-    assert e.callback_invoker == None
+class TestSessionCallbackAdded(object):
 
-def test_SessionCallbackAdded_dispatch():
-    e = bde.SessionCallbackAdded("doc", "callback")
-    e.dispatch(FakeEmptyDispatcher())
-    d = FakeFullDispatcher()
-    e.dispatch(d)
-    assert d.called == ['_document_changed', '_session_callback_added']
+    def test_init(self):
+        e = bde.SessionCallbackAdded("doc", "callback")
+        assert e.document == "doc"
+        assert e.callback == "callback"
+        assert e.setter == None
+        assert e.callback_invoker == None
+
+    def test_dispatch(self):
+        e = bde.SessionCallbackAdded("doc", "callback")
+        e.dispatch(FakeEmptyDispatcher())
+        d = FakeFullDispatcher()
+        e.dispatch(d)
+        assert d.called == ['_document_changed', '_session_callback_added']
 
 # SessionCallbackRemoved ------------------------------------------------------
 
-def test_SessionCallbackRemoved_init():
-    e = bde.SessionCallbackRemoved("doc", "callback")
-    assert e.document == "doc"
-    assert e.callback == "callback"
-    assert e.setter == None
-    assert e.callback_invoker == None
+class TestSessionCallbackRemoved(object):
 
-def test_SessionCallbackRemoved_dispatch():
-    e = bde.SessionCallbackRemoved("doc", "callback")
-    e.dispatch(FakeEmptyDispatcher())
-    d = FakeFullDispatcher()
-    e.dispatch(d)
-    assert d.called == ['_document_changed', '_session_callback_removed']
+    def test_init(self):
+        e = bde.SessionCallbackRemoved("doc", "callback")
+        assert e.document == "doc"
+        assert e.callback == "callback"
+        assert e.setter == None
+        assert e.callback_invoker == None
+
+    def test_dispatch(self):
+        e = bde.SessionCallbackRemoved("doc", "callback")
+        e.dispatch(FakeEmptyDispatcher())
+        d = FakeFullDispatcher()
+        e.dispatch(d)
+        assert d.called == ['_document_changed', '_session_callback_removed']

--- a/bokeh/document/tests/test_events.py
+++ b/bokeh/document/tests/test_events.py
@@ -1,0 +1,326 @@
+import pytest
+
+from mock import patch
+
+import bokeh.document.events as bde
+
+
+class FakeEmptyDispatcher(object): pass
+
+class FakeFullDispatcher(object):
+    def __init__(self):
+        self.called = []
+
+    def _document_changed(self, event):         self.called.append('_document_changed')
+    def _document_patched(self, event):         self.called.append('_document_patched')
+    def _document_model_changed(self, event):   self.called.append('_document_model_changed')
+    def _column_data_changed(self, event):      self.called.append('_column_data_changed')
+    def _columns_streamed(self, event):         self.called.append('_columns_streamed')
+    def _columns_patched(self, event):          self.called.append('_columns_patched')
+    def _session_callback_added(self, event):   self.called.append('_session_callback_added')
+    def _session_callback_removed(self, event): self.called.append('_session_callback_removed')
+
+class FakeModel(object):
+    ref = "ref"
+    data = "data"
+    def references(self): return dict(ref1=1, ref2=2)
+
+# DocumentChangedEvent --------------------------------------------------------
+
+def test_DocumentChangedEvent_init():
+    e = bde.DocumentChangedEvent("doc")
+    assert e.document == "doc"
+    assert e.setter == None
+    assert e.callback_invoker == None
+
+    e = bde.DocumentChangedEvent("doc", "setter")
+    assert e.document == "doc"
+    assert e.setter == "setter"
+    assert e.callback_invoker == None
+
+    e = bde.DocumentChangedEvent("doc", callback_invoker="invoker")
+    assert e.document == "doc"
+    assert e.setter == None
+    assert e.callback_invoker == "invoker"
+
+    e = bde.DocumentChangedEvent("doc", "setter", "invoker")
+    assert e.document == "doc"
+    assert e.setter == "setter"
+    assert e.callback_invoker == "invoker"
+
+def test_DocumentChangedEvent_dispatch():
+    e = bde.DocumentChangedEvent("doc", "setter", "invoker")
+    e.dispatch(FakeEmptyDispatcher())
+    d = FakeFullDispatcher()
+    e.dispatch(d)
+    assert d.called == ['_document_changed']
+
+# DocumentPatchedEvent --------------------------------------------------------
+
+def test_DocumentPatchedEvent_init():
+    e = bde.DocumentPatchedEvent("doc", "setter", "invoker")
+    assert e.document == "doc"
+    assert e.setter == "setter"
+    assert e.callback_invoker == "invoker"
+
+def test_DocumentPatchedEvent_generate():
+    e = bde.DocumentPatchedEvent("doc", "setter", "invoker")
+    with pytest.raises(NotImplementedError):
+        e.generate("refs", "bufs")
+
+def test_DocumentPatchedEvent_dispatch():
+    e = bde.DocumentPatchedEvent("doc", "setter", "invoker")
+    e.dispatch(FakeEmptyDispatcher())
+    d = FakeFullDispatcher()
+    e.dispatch(d)
+    assert d.called == ['_document_changed', '_document_patched']
+
+# ModelChangedEvent -----------------------------------------------------------
+
+def test_ModelChangedEvent_init_defaults():
+    e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew")
+    assert e.document == "doc"
+    assert e.setter == None
+    assert e.callback_invoker == None
+    e.model = "model"
+    e.attr = "attr"
+    e.old = "old"
+    e.new = "new"
+    e.snew = "snew"
+    e.hint = None
+
+def test_ModelChangedEvent_init_ignores_hint_with_setter():
+    e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew", setter="setter", hint="hint", callback_invoker="invoker")
+    assert e.document == "doc"
+    assert e.setter == "setter"
+    assert e.callback_invoker == "invoker"
+    e.model = "model"
+    e.attr = "attr"
+    e.old = "old"
+    e.new = "new"
+    e.snew = "snew"
+    e.hint = None
+
+def test_ModelChangedEvent_init_uses_hint_with_no_setter():
+    e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew", hint="hint", callback_invoker="invoker")
+    assert e.document == "doc"
+    assert e.setter == None
+    assert e.callback_invoker == "invoker"
+    e.model = "model"
+    e.attr = "attr"
+    e.old = "old"
+    e.new = "new"
+    e.snew = "snew"
+    e.hint = "hint"
+
+# TODO (bev) tests for generate
+
+def test_ModelChangedEvent_dispatch():
+    e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew")
+    e.dispatch(FakeEmptyDispatcher())
+    d = FakeFullDispatcher()
+    e.dispatch(d)
+    assert d.called == ['_document_changed', '_document_patched', '_document_model_changed']
+
+# ColumnDataChangedEvent ------------------------------------------------------
+
+def test_ColumnDataChangedEvent_init():
+    m = FakeModel()
+    e = bde.ColumnDataChangedEvent("doc", m, [1,2], "setter", "invoker")
+    assert e.document == "doc"
+    assert e.column_source == m
+    assert e.cols == [1,2]
+    assert e.setter == "setter"
+    assert e.callback_invoker == "invoker"
+
+@patch("bokeh.util.serialization.transform_column_source_data")
+def test_ColumnDataChangedEvent_generate(mock_tcds):
+    mock_tcds.return_value = "new"
+    m = FakeModel()
+    e = bde.ColumnDataChangedEvent("doc", m, [1,2], "setter", "invoker")
+    refs = dict(foo=10)
+    bufs = set()
+    r = e.generate(refs, bufs)
+    assert r == dict(kind="ColumnDataChanged", column_source="ref", new="new", cols=[1,2])
+    assert refs == dict(foo=10)
+    assert bufs == set()
+
+def test_ColumnDataChangedEvent_dispatch():
+    m = FakeModel()
+    e = bde.ColumnDataChangedEvent("doc", m, [1,2], "setter", "invoker")
+    e.dispatch(FakeEmptyDispatcher())
+    d = FakeFullDispatcher()
+    e.dispatch(d)
+    assert d.called == ['_document_changed', '_document_patched', '_column_data_changed']
+
+# ColumnsStreamedEvent --------------------------------------------------------
+
+def test_ColumnsStreamedEvent_init():
+    m = FakeModel()
+    e = bde.ColumnsStreamedEvent("doc", m, dict(foo=1), 200, "setter", "invoker")
+    assert e.document == "doc"
+    assert e.column_source == m
+    assert e.data == dict(foo=1)
+    assert e.rollover == 200
+    assert e.setter == "setter"
+    assert e.callback_invoker == "invoker"
+
+def test_ColumnsStreamedEvent_generate():
+    m = FakeModel()
+    e = bde.ColumnsStreamedEvent("doc", m, dict(foo=1), 200, "setter", "invoker")
+    refs = dict(foo=10)
+    bufs = set()
+    r = e.generate(refs, bufs)
+    assert r == dict(kind="ColumnsStreamed", column_source="ref", data=dict(foo=1), rollover=200)
+    assert refs == dict(foo=10)
+    assert bufs == set()
+
+def test_ColumnsStreamedEvent_dispatch():
+    m = FakeModel()
+    e = bde.ColumnsStreamedEvent("doc", m, dict(foo=1), 200, "setter", "invoker")
+    e.dispatch(FakeEmptyDispatcher())
+    d = FakeFullDispatcher()
+    e.dispatch(d)
+    assert d.called == ['_document_changed', '_document_patched', '_columns_streamed']
+
+# ColumnsPatchedEvent ---------------------------------------------------------
+
+def test_ColumnsPatchedEvent_init():
+    m = FakeModel()
+    e = bde.ColumnsPatchedEvent("doc", m, [1, 2], "setter", "invoker")
+    assert e.document == "doc"
+    assert e.column_source == m
+    assert e.patches == [1, 2]
+    assert e.setter == "setter"
+    assert e.callback_invoker == "invoker"
+
+def test_ColumnsPatchedEvent_generate():
+    m = FakeModel()
+    e = bde.ColumnsPatchedEvent("doc", m, [1, 2], "setter", "invoker")
+    refs = dict(foo=10)
+    bufs = set()
+    r = e.generate(refs, bufs)
+    assert r == dict(kind="ColumnsPatched", column_source="ref", patches=[1,2])
+    assert refs == dict(foo=10)
+    assert bufs == set()
+
+def test_ColumnsPatchedEvent_dispatch():
+    m = FakeModel()
+    e = bde.ColumnsPatchedEvent("doc", m, [1, 2], "setter", "invoker")
+    e.dispatch(FakeEmptyDispatcher())
+    d = FakeFullDispatcher()
+    e.dispatch(d)
+    assert d.called == ['_document_changed', '_document_patched', '_columns_patched']
+
+# TitleChangedEvent -----------------------------------------------------------
+
+def test_TitleChangedEvent_init():
+    e = bde.TitleChangedEvent("doc", "title", "setter", "invoker")
+    assert e.document == "doc"
+    assert e.title == "title"
+    assert e.setter == "setter"
+    assert e.callback_invoker == "invoker"
+
+def test_TitleChangedEvent_generate():
+    e = bde.TitleChangedEvent("doc", "title", "setter", "invoker")
+    refs = dict(foo=10)
+    bufs = set()
+    r = e.generate(refs, bufs)
+    assert r == dict(kind="TitleChanged", title="title")
+    assert refs == dict(foo=10)
+    assert bufs == set()
+
+def test_TitleChangedEvent_dispatch():
+    e = bde.TitleChangedEvent("doc", "title", "setter", "invoker")
+    e.dispatch(FakeEmptyDispatcher())
+    d = FakeFullDispatcher()
+    e.dispatch(d)
+    assert d.called == ['_document_changed', '_document_patched']
+
+# RootAddedEvent --------------------------------------------------------------
+
+def test_RootAddedEvent_init():
+    m = FakeModel()
+    e = bde.RootAddedEvent("doc", m, "setter", "invoker")
+    assert e.document == "doc"
+    assert e.model == m
+    assert e.setter == "setter"
+    assert e.callback_invoker == "invoker"
+
+def test_RootAddedEvent_generate():
+    m = FakeModel()
+    e = bde.RootAddedEvent("doc", m, "setter", "invoker")
+    refs = dict(foo=10)
+    bufs = set()
+    r = e.generate(refs, bufs)
+    assert r == dict(kind="RootAdded", model="ref")
+    assert refs == dict(foo=10, ref1=1, ref2=2)
+    assert bufs == set()
+
+def test_RootAddedEvent_dispatch():
+    m = FakeModel()
+    e = bde.RootAddedEvent("doc", m, "setter", "invoker")
+    e.dispatch(FakeEmptyDispatcher())
+    d = FakeFullDispatcher()
+    e.dispatch(d)
+    assert d.called == ['_document_changed', '_document_patched']
+
+# RootRemovedEvent ------------------------------------------------------------
+
+def test_RootRemovedEvent_init():
+    m = FakeModel()
+    e = bde.RootRemovedEvent("doc", m, "setter", "invoker")
+    assert e.document == "doc"
+    assert e.model == m
+    assert e.setter == "setter"
+    assert e.callback_invoker == "invoker"
+
+def test_RootRemovedEvent_generate():
+    m = FakeModel()
+    e = bde.RootRemovedEvent("doc", m, "setter", "invoker")
+    refs = dict(foo=10)
+    bufs = set()
+    r = e.generate(refs, bufs)
+    assert r == dict(kind="RootRemoved", model="ref")
+    assert refs == dict(foo=10)
+    assert bufs == set()
+
+def test_RootRemovedEvent_dispatch():
+    m = FakeModel()
+    e = bde.RootRemovedEvent("doc", m, "setter", "invoker")
+    e.dispatch(FakeEmptyDispatcher())
+    d = FakeFullDispatcher()
+    e.dispatch(d)
+    assert d.called == ['_document_changed', '_document_patched']
+
+# SessionCallbackAdded --------------------------------------------------------
+
+def test_SessionCallbackAdded_init():
+    e = bde.SessionCallbackAdded("doc", "callback")
+    assert e.document == "doc"
+    assert e.callback == "callback"
+    assert e.setter == None
+    assert e.callback_invoker == None
+
+def test_SessionCallbackAdded_dispatch():
+    e = bde.SessionCallbackAdded("doc", "callback")
+    e.dispatch(FakeEmptyDispatcher())
+    d = FakeFullDispatcher()
+    e.dispatch(d)
+    assert d.called == ['_document_changed', '_session_callback_added']
+
+# SessionCallbackRemoved ------------------------------------------------------
+
+def test_SessionCallbackRemoved_init():
+    e = bde.SessionCallbackRemoved("doc", "callback")
+    assert e.document == "doc"
+    assert e.callback == "callback"
+    assert e.setter == None
+    assert e.callback_invoker == None
+
+def test_SessionCallbackRemoved_dispatch():
+    e = bde.SessionCallbackRemoved("doc", "callback")
+    e.dispatch(FakeEmptyDispatcher())
+    d = FakeFullDispatcher()
+    e.dispatch(d)
+    assert d.called == ['_document_changed', '_session_callback_removed']

--- a/bokeh/util/callback_manager.py
+++ b/bokeh/util/callback_manager.py
@@ -115,7 +115,6 @@ class PropertyCallbackManager(object):
                 for callback in callbacks:
                     callback(attr, old, new)
         if hasattr(self, '_document') and self._document is not None:
-            self._document._notify_change(self, attr, old, new, hint, setter)
-            self._document._with_self_as_curdoc(invoke)
+            self._document._notify_change(self, attr, old, new, hint, setter, invoke)
         else:
             invoke()

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -63,6 +63,7 @@ test:
     - packaging
     - pandas
     - pytest >=3.0.2
+    - pytest-catchlog >=1.2.2
     - pytest-cov >=1.8.1
     - pytest-selenium >=1.6.0 [unix]
     - pytest-html

--- a/examples/howto/hold_app.py
+++ b/examples/howto/hold_app.py
@@ -1,0 +1,41 @@
+from bokeh.driving import repeat
+from bokeh.events import ButtonClick
+from bokeh.io import curdoc
+from bokeh.layouts import column
+from bokeh.models import Button, ColumnDataSource, Slider
+from bokeh.plotting import figure
+
+import numpy as np
+
+doc = curdoc()
+
+x = np.linspace(0, 2, 1000)
+y = 1 - (x-1)**2
+
+source = ColumnDataSource(data=dict(x=x, y=y))
+
+p  = figure(title="initial title")
+p.circle(x=1, y=list(range(0, 11)))
+p.line('x', 'y', color="orange", source=source)
+
+slider = Slider(start=0, end=10, step=0.1, value=1)
+def scb(attr, old, new):
+    source.data['y'] = new * y
+slider.on_change('value', scb)
+
+combine = Button(label="hold combine")
+combine.on_event(ButtonClick, lambda event: doc.hold("combine"))
+
+collect = Button(label="hold collect")
+collect.on_event(ButtonClick, lambda event: doc.hold("collect"))
+
+unhold = Button(label="unhold")
+unhold.on_event(ButtonClick, lambda event: doc.unhold())
+
+doc.add_root(column(p, slider, combine, collect, unhold))
+
+@repeat(np.linspace(0, 10, 100))
+def update(v):
+    slider.value = v
+
+curdoc().add_periodic_callback(update, 200)


### PR DESCRIPTION
(This is marked `WIP` but the only additions planned are examples/docs/tests)

- [x] issues: fixes #4911
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

This PR adds `hold` and `unhold` methods to `Document`  that can suppress updates/callbacks while a hold is active. There are two hold polices:

* `collect`
* `combine`

In `collect` mode, all held events are "played back" in order, as-is, when `unhold` is called. In `combine` mode, Bokeh will collapse compatible events when `unhold` is called e.g. several updates to the same `slider.value` during a hold will all be collapsed down to one update/callback corresponding to the last one. The default policy is `combine`

This PR also adds tests for `bokeh.document.events` which previously had no tests. 

@havocp @fpliger I am sure you are both busy but I have what is hopefully just a quick question of a  historical nature. Do either of you recall why the dispatch mechanism of document events "chains up" the inheritance hierarchy? e.g. consider this test:
```
def test_ModelChangedEvent_dispatch():
    e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew")
    e.dispatch(FakeEmptyDispatcher())
    d = FakeFullDispatcher()
    e.dispatch(d)
    assert d.called == ['_document_changed', '_document_patched', '_document_model_changed']
```
Dispatching to a `ModelChangedEvent` will call all the dispatch methods for all the superclasses, if they are present on the receiver. I think it might be more flexible to not "chain up". Then if on receiver dispatch method wants to chain up, it can explicitly (or not). Right now there is no choice in matter.  ~~~I don't think anything in bokeh actually relies on this, and I'd like to consider changing it to be simpler as I just described.~~~ *At least a couple of tests fail if I make this change, so leaving things as they are for now*