### PR TITLE
Correct gridplot doctext so that ncols parameter name is rendered

### DIFF
--- a/bokeh/layouts.py
+++ b/bokeh/layouts.py
@@ -301,7 +301,7 @@ def gridplot(*args, **kwargs):
             toolbar will be located, with respect to the grid. Default is
             ``above``. If set to None, no toolbar will be attached to the grid.
 
-        ncols ``Int`` (optional): Specify the number of columns you would like in your grid.
+        ncols (int, optional): Specify the number of columns you would like in your grid.
             You must only pass an un-nested list of plots (as opposed to a list of lists of plots)
             when using ncols.
 


### PR DESCRIPTION
Doctext formatting change.

- [ ] issues: fixes #6962 

(I have not yet been able to run sphinx myself due to an error running sphinx/build)