### PR TITLE
fix rendering of filtered data sources for previously broken glyphs

### DIFF
--- a/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
+++ b/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
@@ -140,7 +140,7 @@ export class GlyphRendererView extends RendererView
     # all_indices is in full data space, indices is converted to subset space
     # either by mask_data (that uses the spatial index) or manually
     indices = @glyph.mask_data(@all_indices)
-    if '' + indices == '' + @all_indices
+    if indices.length == @all_indices.length
       indices = [0...@all_indices.length]
     dtmask = Date.now() - tmask
 

--- a/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
+++ b/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
@@ -114,7 +114,7 @@ export class GlyphRendererView extends RendererView
     lod_factor = @plot_model.plot.lod_factor
     @decimated = []
     for i in [0...Math.floor(@all_indices.length/lod_factor)]
-      @decimated.push(@all_indices[i*lod_factor])
+      @decimated.push(i*lod_factor)
 
     dt = Date.now() - t0
     logger.debug("#{@glyph.model.type} GlyphRenderer (#{@model.id}): set_data finished in #{dt}ms")
@@ -137,8 +137,11 @@ export class GlyphRendererView extends RendererView
     dtmap = Date.now() - t0
 
     tmask = Date.now()
-    # all_indices and indices are in cdsview subset space
+    # all_indices is in full data space, indices is converted to subset space
+    # either by mask_data (that uses the spatial index) or manually
     indices = @glyph.mask_data(@all_indices)
+    if '' + indices == '' + @all_indices
+      indices = [0...@all_indices.length]
     dtmask = Date.now() - tmask
 
     ctx = @plot_view.canvas_view.ctx
@@ -150,10 +153,7 @@ export class GlyphRendererView extends RendererView
       selected = []
     else
       if selected['0d'].glyph
-        if @glyph instanceof LineView
-          selected = indices
-        else
-          selected = @model.view.convert_indices_from_subset(indices)
+        selected = @model.view.convert_indices_from_subset(indices)
       else if selected['1d'].indices.length > 0
         selected = selected['1d'].indices
       else
@@ -165,10 +165,7 @@ export class GlyphRendererView extends RendererView
       inspected = []
     else
       if inspected['0d'].glyph
-        if @glyph instanceof LineView
-          inspected = indices
-        else
-          inspected = @model.view.convert_indices_from_subset(indices)
+        inspected = @model.view.convert_indices_from_subset(indices)
       else if inspected['1d'].indices.length > 0
         inspected = inspected['1d'].indices
       else
@@ -194,9 +191,15 @@ export class GlyphRendererView extends RendererView
 
     if not (selected.length and @have_selection_glyphs())
         trender = Date.now()
-        glyph.render(ctx, indices, @glyph)
-        if @hover_glyph and inspected.length
-          @hover_glyph.render(ctx, inspected, @glyph)
+        if @glyph instanceof LineView
+          if @hover_glyph and inspected.length
+            @hover_glyph.render(ctx, @model.view.convert_indices_from_subset(inspected), @glyph)
+          else
+            glyph.render(ctx, @all_indices, @glyph)
+        else
+          glyph.render(ctx, indices, @glyph)
+          if @hover_glyph and inspected.length
+            @hover_glyph.render(ctx, inspected, @glyph)
         dtrender = Date.now() - trender
 
     else
@@ -209,14 +212,16 @@ export class GlyphRendererView extends RendererView
       # intersect/different selection with render mask
       selected = new Array()
       nonselected = new Array()
-      for i in indices
-        # now, selected is changed to subset space, except for Line glyph
-        if @glyph instanceof LineView
+
+      # now, selected is changed to subset space, except for Line glyph
+      if @glyph instanceof LineView
+        for i in @all_indices
           if selected_mask[i]?
             selected.push(i)
           else
             nonselected.push(i)
-        else
+      else
+        for i in indices
           if selected_mask[@all_indices[i]]?
             selected.push(i)
           else
@@ -227,7 +232,10 @@ export class GlyphRendererView extends RendererView
       nonselection_glyph.render(ctx, nonselected, @glyph)
       selection_glyph.render(ctx, selected, @glyph)
       if @hover_glyph?
-        @hover_glyph.render(ctx, inspected, @glyph)
+        if @glyph instanceof LineView
+          @hover_glyph.render(ctx, @model.view.convert_indices_from_subset(inspected), @glyph)
+        else
+          @hover_glyph.render(ctx, inspected, @glyph)
       dtrender = Date.now() - trender
 
     @last_dtrender = dtrender

--- a/bokehjs/src/coffee/models/sources/cds_view.coffee
+++ b/bokehjs/src/coffee/models/sources/cds_view.coffee
@@ -1,5 +1,6 @@
 import {Model} from "../../model"
 import * as p from "core/properties"
+import {create_hit_test_result} from "core/hittest"
 import {intersection} from "core/util/array"
 import {ColumnarDataSource} from "./columnar_data_source"
 
@@ -50,15 +51,19 @@ export class CDSView extends Model
     for i in [0...@indices.length]
       @indices_map[@indices[i]] = i
 
-  convert_selection_from_subset: (selection) ->
-    indices_1d = (@indices[i] for i in selection['1d']['indices'])
-    selection['1d']['indices'] = indices_1d
-    return selection
+  convert_selection_from_subset: (selection_subset) ->
+    selection_full = create_hit_test_result()
+    selection_full.update_through_union(selection_subset)
+    indices_1d = (@indices[i] for i in selection_subset['1d']['indices'])
+    selection_full['1d']['indices'] = indices_1d
+    return selection_full
 
-  convert_selection_to_subset: (selection) ->
-    indices_1d = (@indices_map[i] for i in selection['1d']['indices'])
-    selection['1d']['indices'] = indices_1d
-    return selection
+  convert_selection_to_subset: (selection_full) ->
+    selection_subset = create_hit_test_result()
+    selection_subset.update_through_union(selection_full)
+    indices_1d = (@indices_map[i] for i in selection_full['1d']['indices'])
+    selection_subset['1d']['indices'] = indices_1d
+    return selection_subset
 
   convert_indices_from_subset: (indices) ->
     return (@indices[i] for i in indices)

--- a/bokehjs/src/coffee/models/tools/inspectors/hover_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/inspectors/hover_tool.coffee
@@ -153,6 +153,9 @@ export class HoverToolView extends InspectToolView
     tooltip.clear()
 
     indices = renderer_view.model.get_selection_manager().inspectors[renderer_view.model.id].indices
+    if renderer_view.model instanceof GlyphRenderer
+      indices = renderer_view.model.view.convert_selection_to_subset(indices)
+
     ds = renderer_view.model.get_selection_manager().source
 
     if indices.is_empty()
@@ -284,7 +287,11 @@ export class HoverToolView extends InspectToolView
         else
           [rx, ry] = [vx, vy]
 
-        vars = {index: i, x: x, y: y, vx: vx, vy: vy, sx: sx, sy: sy, data_x: data_x, data_y: data_y}
+        if renderer_view.model instanceof GlyphRenderer
+          index = renderer_view.model.view.convert_indices_from_subset([i])[0]
+        else
+          index = i
+        vars = {index: index, x: x, y: y, vx: vx, vy: vy, sx: sx, sy: sy, data_x: data_x, data_y: data_y}
 
         tooltip.add(rx, ry, @_render_tooltips(ds, i, vars))
 


### PR DESCRIPTION
This PR fixes the rendering of glyphs that use a subset of data, through filtering with CDSView. It also fixes some bugs with the hover tool and filtered plots that were introduced with GraphRenderer work. 

The problem was at line 141 in bokehjs/src/coffee/models/renderers/glyph_renderer.coffee. I had mistakenly thought that `all_indices` was in subset space when it really is in full data space. `all_indices` contains the indices of the filtered data source (e.g. [1, 20, 45]) in the full data space. It needs to be converted to `indices` in subset space (i.e. [0, 1, 2]). This previously was working for the circle glyph, because `mask_data` using the spatial index would return the correct subset space `indices`. However, for glyphs that don't have `_mask_data`, `indices` was incorrectly in the full data space. The fix is just to convert `indices` to subset space if it wasn't converted by `mask_data`. 

I also made sure that the Line glyph was being handled properly. It needs special selected/non-selected handling ([PR where line selection rendering is improved](https://github.com/bokeh/bokeh/pull/6491)). I made it so that hovering when a line renderer has a hover_glyph displays the whole line (can be a subset using CDSView) using the hover style.

- [x] issues: fixes #6820 #6910 #6955
- [ ] tests added / passed
