### PR TITLE
allow cat cmapper factors to be pd Index

### DIFF
--- a/bokeh/models/mappers.py
+++ b/bokeh/models/mappers.py
@@ -76,7 +76,7 @@ class CategoricalColorMapper(ColorMapper):
         super(ColorMapper, self).__init__(**kwargs)
         palette = self.palette
         factors = self.factors
-        if palette and factors:
+        if palette is not None and factors is not None:
             if len(palette) < len(factors):
                 extra_factors = factors[len(palette):]
                 warnings.warn("Palette length does not match number of factors. %s will be assigned to `nan_color` %s" % (extra_factors, self.nan_color))

--- a/bokeh/models/tests/test_mappers.py
+++ b/bokeh/models/tests/test_mappers.py
@@ -48,3 +48,19 @@ def test_warning_if_categorical_color_mapper_with_short_palette(recwarn):
 def test_no_warning_if_categorical_color_mapper_with_long_palette(recwarn):
     CategoricalColorMapper(factors=["a", "b", "c"], palette=["red", "green", "orange", "blue"])
     assert len(recwarn) == 0
+
+def test_categorical_color_mapper_with_pandas_index():
+    import pandas as pd
+    from bokeh.palettes import Spectral6
+    fruits = ['Apples', 'Pears', 'Nectarines', 'Plums', 'Grapes', 'Strawberries']
+    years = ['2015', '2016', '2017']
+    data = {'2015'   : [2, 1, 4, 3, 2, 4],
+            '2016'   : [5, 3, 3, 2, 4, 6],
+            '2017'   : [3, 2, 4, 4, 5, 3]}
+
+    df = pd.DataFrame(data, index=fruits)
+    fruits = df.index
+    years = df.columns
+    m = CategoricalColorMapper(palette=Spectral6, factors=years, start=1, end=2)
+    assert list(m.factors) == list(years)
+    assert isinstance(m.factors, pd.Index)


### PR DESCRIPTION
- [x] issues: fixes #6978
- [x] tests added / passed

Solution was to make `if` tests explicitly check for `None`, otherwise array errors about using `.any` or `.all` pop up when arrays are used. 

With this change, the following code:
```
import pandas as pd
from bokeh.io import show, output_file
from bokeh.models import ColumnDataSource, FactorRange
from bokeh.plotting import figure
from bokeh.transform import factor_cmap
from bokeh.palettes import Spectral6

output_file("test.html")

fruits = ['Apples', 'Pears', 'Nectarines', 'Plums', 'Grapes', 'Strawberries']
years = ['2015', '2016', '2017']

data = {'2015'   : [2, 1, 4, 3, 2, 4],
        '2016'   : [5, 3, 3, 2, 4, 6],
        '2017'   : [3, 2, 4, 4, 5, 3]}

df = pd.DataFrame(data, index=fruits)
fruits = df.index
years = df.columns # THIS FAILED BEFORE

x = [ (fruit, year) for fruit in fruits for year in years ]
counts = sum(zip(data['2015'], data['2016'], data['2017']), ())

source = ColumnDataSource(data=dict(x=x, counts=counts))

p = figure(x_range=FactorRange(*x), plot_height=250, title="Fruit Counts by Year", toolbar_location=None, tools="")

p.vbar(x='x', top='counts', width=0.9, source=source, line_color="white", fill_color=factor_cmap('x', palette=Spectral6, factors=years, start=1, end=2))

p.y_range.start = 0
p.x_range.range_padding = 0.1
p.xaxis.major_label_orientation = 1
p.xgrid.grid_line_color = None

show(p)
```
Now yields:

<img width="584" alt="screen shot 2017-10-01 at 14 14 35" src="https://user-images.githubusercontent.com/1078448/31058073-12c9845c-a6b3-11e7-84fe-b6e1493cdecd.png">
