### PR TITLE
add Scalar versions of property mixins

### DIFF
--- a/bokeh/core/property_mixins.py
+++ b/bokeh/core/property_mixins.py
@@ -43,7 +43,7 @@ from __future__ import absolute_import
 
 from .enums import LineJoin, LineCap, FontStyle, TextAlign, TextBaseline
 from .has_props import HasProps
-from .properties import Color, ColorSpec, DashPattern, Enum, FontSizeSpec, Include, Int, Float, NumberSpec, Percent, String, value
+from .properties import Color, ColorSpec, DashPattern, Enum, FontSize, FontSizeSpec, Include, Int, Float, NumberSpec, Percent, String, value
 
 
 _color_help = """
@@ -256,7 +256,7 @@ class ScalarTextProps(HasProps):
     base_text_props = Include(BaseTextProps, use_prefix=False)
 
     # XXX not great
-    text_font_size = String("12pt")
+    text_font_size = FontSize("12pt")
 
     text_color = Color(default="#444444", help=_color_help % "fill text")
 

--- a/bokeh/core/property_mixins.py
+++ b/bokeh/core/property_mixins.py
@@ -43,7 +43,30 @@ from __future__ import absolute_import
 
 from .enums import LineJoin, LineCap, FontStyle, TextAlign, TextBaseline
 from .has_props import HasProps
-from .properties import ColorSpec, DashPattern, Enum, FontSizeSpec, Int, Float, NumberSpec, String, value
+from .properties import Color, ColorSpec, DashPattern, Enum, FontSizeSpec, Include, Int, Float, NumberSpec, Percent, String, value
+
+
+_color_help = """
+A color to use to %s with.
+
+Acceptable values are:
+
+- any of the 147 named `CSS colors`_, e.g ``'green'``, ``'indigo'``
+- an RGB(A) hex value, e.g., ``'#FF0000'``, ``'#44444444'``
+- a 3-tuple of integers (r,g,b) between 0 and 255
+- a 4-tuple of (r,g,b,a) where r,g,b are integers between 0..255 and a is between 0..1
+
+.. _CSS colors: http://www.w3schools.com/cssref/css_colornames.asp
+
+"""
+
+_alpha_help = """
+An alpha value to use to %s with.
+
+Acceptable values are floating point numbers between 0 (transparent)
+and 1 (opaque).
+
+"""
 
 class FillProps(HasProps):
     ''' Properties relevant to rendering fill regions.
@@ -52,61 +75,29 @@ class FillProps(HasProps):
 
     '''
 
-    fill_color = ColorSpec(default="gray", help="""
-    A color to use to fill paths with.
+    fill_color = ColorSpec(default="gray", help=_color_help % "fill paths")
+    fill_alpha = NumberSpec(default=1.0, accept_datetime=False, help=_alpha_help % "fill paths")
 
-    Acceptable values are:
+class ScalarFillProps(HasProps):
+    ''' Properties relevant to rendering fill regions.
 
-    - any of the 147 named `CSS colors`_, e.g ``'green'``, ``'indigo'``
-    - an RGB(A) hex value, e.g., ``'#FF0000'``, ``'#44444444'``
-    - a 3-tuple of integers (r,g,b) between 0 and 255
-    - a 4-tuple of (r,g,b,a) where r,g,b are integers between 0..255 and a is between 0..1
-
-    .. _CSS colors: http://www.w3schools.com/cssref/css_colornames.asp
-
-    """)
-
-    fill_alpha = NumberSpec(default=1.0, accept_datetime=False, help="""
-    An alpha value to use to fill paths with.
-
-    Acceptable values are floating point numbers between 0 (transparent)
-    and 1 (opaque).
-
-    """)
-
-class LineProps(HasProps):
-    ''' Properties relevant to rendering path operations.
-
-    Mirrors the BokehJS ``properties.Line`` class.
+    Mirrors the BokehJS ``properties.Fill`` class.
 
     '''
 
-    line_color = ColorSpec(default="black", help="""
-    A color to use to stroke paths with.
+    fill_color = Color(default="gray", help=_color_help)
+    fill_alpha = Percent(default=1.0, help=_alpha_help)
 
-    Acceptable values are:
 
-    - any of the 147 named `CSS colors`_, e.g ``'green'``, ``'indigo'``
-    - an RGB(A) hex value, e.g., ``'#FF0000'``, ``'#44444444'``
-    - a 3-tuple of integers (r,g,b) between 0 and 255
-    - a 4-tuple of (r,g,b,a) where r,g,b are integers between 0..255 and a is between 0..1
 
-    .. _CSS colors: http://www.w3schools.com/cssref/css_colornames.asp
 
-    """)
 
-    line_width = NumberSpec(default=1, accept_datetime=False, help="""
-    Stroke width in units of pixels.
-    """)
 
-    line_alpha = NumberSpec(default=1.0, accept_datetime=False, help="""
-    An alpha value to use to stroke paths with.
+_line_width_help = """
+Stroke width in units of pixels.
+"""
 
-    Acceptable values are floating point numbers between 0 (transparent)
-    and 1 (opaque).
-
-    """)
-
+class BaseLineProps(HasProps):
     line_join = Enum(LineJoin, help="""
     How path segments should be joined together.
 
@@ -152,24 +143,42 @@ class LineProps(HasProps):
     start from.
     """)
 
-class TextProps(HasProps):
-    ''' Properties relevant to rendering text.
+class LineProps(HasProps):
+    ''' Properties relevant to rendering path operations.
 
-    Mirrors the BokehJS ``properties.Text`` class.
-
-    .. note::
-        There is currently only support for filling text. An interface
-        to stroke the outlines of text has not yet been exposed.
+    Mirrors the BokehJS ``properties.Line`` class.
 
     '''
+
+    base_line_props = Include(BaseLineProps, use_prefix=False)
+
+    line_color = ColorSpec(default="black", help=_color_help % "stroke paths")
+    line_width = NumberSpec(default=1, accept_datetime=False, help=_line_width_help)
+    line_alpha = NumberSpec(default=1.0, accept_datetime=False, help=_alpha_help % "stroke paths")
+
+
+class ScalarLineProps(HasProps):
+    ''' Properties relevant to rendering path operations.
+
+    Mirrors the BokehJS ``properties.Line`` class.
+
+    '''
+    base_line_props = Include(BaseLineProps, use_prefix=False)
+
+    line_color = Color(default="black", help=_color_help % "stroke paths")
+    line_width = Float(default=1, help=_line_width_help)
+    line_alpha = Percent(default=1.0, help=_alpha_help % "stroke paths")
+
+
+
+
+class BaseTextProps(HasProps):
 
     text_font = String("helvetica", help="""
     Name of a font to use for rendering text, e.g., ``'times'``,
     ``'helvetica'``.
 
     """)
-
-    text_font_size = FontSizeSpec(value("12pt"))
 
     text_font_style = Enum(FontStyle, help="""
     A style to use for rendering text.
@@ -179,28 +188,6 @@ class TextProps(HasProps):
     - ``'normal'`` normal text
     - ``'italic'`` *italic text*
     - ``'bold'`` **bold text**
-
-    """)
-
-    text_color = ColorSpec(default="#444444", help="""
-    A color to use to fill text with.
-
-    Acceptable values are:
-
-    - any of the 147 named `CSS colors`_, e.g ``'green'``, ``'indigo'``
-    - an RGB(A) hex value, e.g., ``'#FF0000'``, ``'#44444444'``
-    - a 3-tuple of integers (r,g,b) between 0 and 255
-    - a 4-tuple of (r,g,b,a) where r,g,b are integers between 0..255 and a is between 0..1
-
-    .. _CSS colors: http://www.w3schools.com/cssref/css_colornames.asp
-
-    """)
-
-    text_alpha = NumberSpec(default=1.0, accept_datetime=False, help="""
-    An alpha value to use to fill text with.
-
-    Acceptable values are floating point numbers between 0 (transparent)
-    and 1 (opaque).
 
     """)
 
@@ -235,3 +222,42 @@ class TextProps(HasProps):
     a percentage of font size. The default is 120%. Setting it to 1.0, so
     100%, means no additional space will be used.
     """)
+
+
+class TextProps(HasProps):
+    ''' Properties relevant to rendering text.
+
+    Mirrors the BokehJS ``properties.Text`` class.
+
+    .. note::
+        There is currently only support for filling text. An interface
+        to stroke the outlines of text has not yet been exposed.
+
+    '''
+    base_text_props = Include(BaseTextProps, use_prefix=False)
+
+    text_font_size = FontSizeSpec(value("12pt"))
+
+    text_color = ColorSpec(default="#444444", help=_color_help % "fill text")
+
+    text_alpha = NumberSpec(default=1.0, accept_datetime=False, help=_alpha_help % "fill text")
+
+class ScalarTextProps(HasProps):
+    ''' Properties relevant to rendering text.
+
+    Mirrors the BokehJS ``properties.Text`` class.
+
+    .. note::
+        There is currently only support for filling text. An interface
+        to stroke the outlines of text has not yet been exposed.
+
+    '''
+
+    base_text_props = Include(BaseTextProps, use_prefix=False)
+
+    # XXX not great
+    text_font_size = String("12pt")
+
+    text_color = Color(default="#444444", help=_color_help % "fill text")
+
+    text_alpha = Percent(default=1.0, help=_alpha_help % "fill text")

--- a/bokeh/core/tests/test_properties.py
+++ b/bokeh/core/tests/test_properties.py
@@ -12,7 +12,7 @@ from bokeh.core.properties import (field, value,
     NumberSpec, ColorSpec, Bool, Int, Float, Complex, String,
     Regex, Seq, List, Dict, Tuple, Instance, Any, Interval, Either,
     Enum, Color, DashPattern, Size, Percent, Angle, AngleSpec, StringSpec,
-    DistanceSpec, FontSizeSpec, Override, Include, MinMaxBounds,
+    DistanceSpec, FontSize, FontSizeSpec, Override, Include, MinMaxBounds,
     DataDistanceSpec, ScreenDistanceSpec, ColumnData)
 
 from bokeh.core.property.containers import PropertyValueColumnData, PropertyValueDict, PropertyValueList
@@ -591,12 +591,12 @@ class TestFontSizeSpec(unittest.TestCase):
 
             v = '10%s' % unit
             a.x = v
-            self.assertEqual(a.x, dict(value=v))
+            self.assertEqual(a.x, v)
             self.assertEqual(a.lookup('x').serializable_value(a), dict(value=v))
 
             v = '10.2%s' % unit
             a.x = v
-            self.assertEqual(a.x, dict(value=v))
+            self.assertEqual(a.x, v)
             self.assertEqual(a.lookup('x').serializable_value(a), dict(value=v))
 
             f = '_10%s' % unit
@@ -612,12 +612,12 @@ class TestFontSizeSpec(unittest.TestCase):
         for unit in css_units.upper().split("|"):
             v = '10%s' % unit
             a.x = v
-            self.assertEqual(a.x, dict(value=v))
+            self.assertEqual(a.x, v)
             self.assertEqual(a.lookup('x').serializable_value(a), dict(value=v))
 
             v = '10.2%s' % unit
             a.x = v
-            self.assertEqual(a.x, dict(value=v))
+            self.assertEqual(a.x, v)
             self.assertEqual(a.lookup('x').serializable_value(a), dict(value=v))
 
             f = '_10%s' % unit
@@ -1192,6 +1192,7 @@ class TestProperties(unittest.TestCase):
         prop = String()
 
         self.assertTrue(prop.is_valid(None))
+
         self.assertFalse(prop.is_valid(False))
         self.assertFalse(prop.is_valid(True))
         self.assertFalse(prop.is_valid(0))
@@ -1200,10 +1201,59 @@ class TestProperties(unittest.TestCase):
         self.assertFalse(prop.is_valid(1.0))
         self.assertFalse(prop.is_valid(1.0+1.0j))
         self.assertTrue(prop.is_valid(""))
+        self.assertTrue(prop.is_valid("6"))
         self.assertFalse(prop.is_valid(()))
         self.assertFalse(prop.is_valid([]))
         self.assertFalse(prop.is_valid({}))
         self.assertFalse(prop.is_valid(Foo()))
+
+    def test_FontSize(self):
+
+        prop = FontSize()
+
+        self.assertTrue(prop.is_valid(None))
+
+        css_units = "%|em|ex|ch|ic|rem|vw|vh|vi|vb|vmin|vmax|cm|mm|q|in|pc|pt|px"
+
+        for unit in css_units.split("|"):
+            v = '10%s' % unit
+            self.assertTrue(prop.is_valid(v))
+
+            v = '10.2%s' % unit
+            self.assertTrue(prop.is_valid(v))
+
+            v = '_10%s' % unit
+            self.assertFalse(prop.is_valid(v))
+
+            v = '_10.2%s' % unit
+            self.assertFalse(prop.is_valid(v))
+
+        for unit in css_units.upper().split("|"):
+            v = '10%s' % unit
+            self.assertTrue(prop.is_valid(v))
+
+            v = '10.2%s' % unit
+            self.assertTrue(prop.is_valid(v))
+
+            v = '_10%s' % unit
+            self.assertFalse(prop.is_valid(v))
+
+            v = '_10.2%s' % unit
+            self.assertFalse(prop.is_valid(v))
+
+        self.assertFalse(prop.is_valid(False))
+        self.assertFalse(prop.is_valid(True))
+        self.assertFalse(prop.is_valid(0))
+        self.assertFalse(prop.is_valid(1))
+        self.assertFalse(prop.is_valid(0.0))
+        self.assertFalse(prop.is_valid(1.0))
+        self.assertFalse(prop.is_valid(1.0+1.0j))
+        self.assertFalse(prop.is_valid(""))
+        self.assertFalse(prop.is_valid(()))
+        self.assertFalse(prop.is_valid([]))
+        self.assertFalse(prop.is_valid({}))
+        self.assertFalse(prop.is_valid(Foo()))
+
 
     def test_Regex(self):
         with self.assertRaises(TypeError):

--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -41,7 +41,7 @@ from ..core.enums import Anchor, Direction, StepMode
 from ..core.has_props import abstract
 from ..core.properties import (AngleSpec, Bool, DistanceSpec, Enum, Float,
                                Include, Instance, Int, NumberSpec, StringSpec)
-from ..core.property_mixins import FillProps, LineProps, TextProps
+from ..core.property_mixins import FillProps, LineProps, ScalarFillProps, ScalarLineProps, TextProps
 from ..model import Model
 
 from .mappers import ColorMapper, LinearColorMapper
@@ -533,7 +533,7 @@ class Line(XYGlyph):
     The y-coordinates for the points of the line.
     """)
 
-    line_props = Include(LineProps, use_prefix=False, help="""
+    line_props = Include(ScalarLineProps, use_prefix=False, help="""
     The %s values for the line.
     """)
 
@@ -638,11 +638,11 @@ class Patch(XYGlyph):
         values in the sequence.
     """)
 
-    line_props = Include(LineProps, use_prefix=False, help="""
+    line_props = Include(ScalarLineProps, use_prefix=False, help="""
     The %s values for the patch.
     """)
 
-    fill_props = Include(FillProps, use_prefix=False, help="""
+    fill_props = Include(ScalarFillProps, use_prefix=False, help="""
     The %s values for the patch.
     """)
 


### PR DESCRIPTION
- [x] issues: fixes #5648
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)

@mattpap if you agree with this general approach, I will:

* add a real `FontSize` prop instead of `String`
* apply these scalar props other places to reduce code dupe (some annotations)
* add more tests
* general clean up 