### PR TITLE
Add "-tables" css and js includes to the docs (#6999)

### DIFF
--- a/bokeh/embed/standalone.py
+++ b/bokeh/embed/standalone.py
@@ -111,7 +111,8 @@ def components(models, wrap_script=True, wrap_plot_info=True, theme=FromCurdoc):
 
     .. note::
         The returned components assume that BokehJS resources are
-        **already loaded**.
+        **already loaded**. see :ref:`_userguide_embed_components` for an
+        important note regarding resource loading.
 
     Args:
         models (Model|list|dict|tuple) :

--- a/bokeh/embed/standalone.py
+++ b/bokeh/embed/standalone.py
@@ -109,10 +109,25 @@ def components(models, wrap_script=True, wrap_plot_info=True, theme=FromCurdoc):
 
     An example can be found in examples/embed/embed_multiple.py
 
-    .. note::
-        The returned components assume that BokehJS resources are
-        **already loaded**. see :ref:`_userguide_embed_components` for an
-        important note regarding resource loading.
+    The returned components assume that BokehJS resources are **already loaded**.
+    The html template in which they will be embedded needs to include the following
+    links and scripts tags. The widgets and tables resources are only necessary if
+    the components make use of widgets and tables.
+    
+    .. code-block:: html
+        <link
+            href="http://cdn.pydata.org/bokeh/release/bokeh-x.y.z.min.css"
+            rel="stylesheet" type="text/css">
+        <link
+            href="http://cdn.pydata.org/bokeh/release/bokeh-widgets-x.y.z.min.css"
+            rel="stylesheet" type="text/css">
+        <link
+            href="http://cdn.pydata.org/bokeh/release/bokeh-tables-x.y.z.min.css"
+            rel="stylesheet" type="text/css">
+
+        <script src="http://cdn.pydata.org/bokeh/release/bokeh-x.y.z.min.js"></script>
+        <script src="http://cdn.pydata.org/bokeh/release/bokeh-widgets-x.y.z.min.js"></script>
+        <script src="http://cdn.pydata.org/bokeh/release/bokeh-tables-x.y.z.min.js"></script>
 
     Args:
         models (Model|list|dict|tuple) :

--- a/sphinx/source/docs/installation.rst
+++ b/sphinx/source/docs/installation.rst
@@ -174,17 +174,17 @@ built into Bokeh in ``bokeh.models.widgets`` in your documents. Similarly, the
 ``"-tables"`` files are only necessary if you are using Bokeh data tables in
 your document.
 
-As a concrete example, the links for version ``0.12.7`` are:
+As a concrete example, the links for version ``0.12.9`` are:
 
-* http://cdn.pydata.org/bokeh/release/bokeh-0.12.7.min.js
-* http://cdn.pydata.org/bokeh/release/bokeh-widgets-0.12.7.min.js
-* http://cdn.pydata.org/bokeh/release/bokeh-tables-0.12.7.min.js
+* http://cdn.pydata.org/bokeh/release/bokeh-0.12.9.min.js
+* http://cdn.pydata.org/bokeh/release/bokeh-widgets-0.12.9.min.js
+* http://cdn.pydata.org/bokeh/release/bokeh-tables-0.12.9.min.js
 
 and
 
-* http://cdn.pydata.org/bokeh/release/bokeh-0.12.0.min.css
-* http://cdn.pydata.org/bokeh/release/bokeh-widgets-0.12.0.min.css
-* http://cdn.pydata.org/bokeh/release/bokeh-tables-0.12.0.min.css
+* http://cdn.pydata.org/bokeh/release/bokeh-0.12.9.min.css
+* http://cdn.pydata.org/bokeh/release/bokeh-widgets-0.12.9.min.css
+* http://cdn.pydata.org/bokeh/release/bokeh-tables-0.12.9.min.css
 
 .. note::
     For releases ``0.12.2`` and after, the BokehJS API has been branched to a separate file.

--- a/sphinx/source/docs/installation.rst
+++ b/sphinx/source/docs/installation.rst
@@ -156,11 +156,13 @@ pydata.org, under the following naming scheme::
 
     http://cdn.pydata.org/bokeh/release/bokeh-x.y.z.min.js
     http://cdn.pydata.org/bokeh/release/bokeh-widgets-x.y.z.min.js
+    http://cdn.pydata.org/bokeh/release/bokeh-tables-x.y.z.min.js
 
 for the BokehJS JavaScript files, and::
 
     http://cdn.pydata.org/bokeh/release/bokeh-x.y.z.min.css
     http://cdn.pydata.org/bokeh/release/bokeh-widgets-x.y.z.min.css
+    http://cdn.pydata.org/bokeh/release/bokeh-tables-x.y.z.min.css
 
 for the BokehJS CSS files.
 
@@ -168,17 +170,21 @@ for the BokehJS CSS files.
     The CSS must be loaded *before* the JavaScript library.
 
 The ``"-widgets"`` files are only necessary if you are using any of the widgets
-built into Bokeh in ``bokeh.models.widgets`` in your documents.
+built into Bokeh in ``bokeh.models.widgets`` in your documents. Similarly, the 
+``"-tables"`` files are only necessary if you are using Bokeh data tables in
+your document.
 
-As a concrete example, the links for version ``0.12`` are:
+As a concrete example, the links for version ``0.12.7`` are:
 
-* http://cdn.pydata.org/bokeh/release/bokeh-0.12.0.min.js
-* http://cdn.pydata.org/bokeh/release/bokeh-widgets-0.12.0.min.js
+* http://cdn.pydata.org/bokeh/release/bokeh-0.12.7.min.js
+* http://cdn.pydata.org/bokeh/release/bokeh-widgets-0.12.7.min.js
+* http://cdn.pydata.org/bokeh/release/bokeh-tables-0.12.7.min.js
 
 and
 
 * http://cdn.pydata.org/bokeh/release/bokeh-0.12.0.min.css
 * http://cdn.pydata.org/bokeh/release/bokeh-widgets-0.12.0.min.css
+* http://cdn.pydata.org/bokeh/release/bokeh-tables-0.12.0.min.css
 
 .. note::
     For releases ``0.12.2`` and after, the BokehJS API has been branched to a separate file.

--- a/sphinx/source/docs/releases/0.12.7.rst
+++ b/sphinx/source/docs/releases/0.12.7.rst
@@ -110,7 +110,7 @@ The `bokeh-widgets` bundle was split into ``bokeh-widgets`` and
 ``bokeh-tables``. This is to reduce the weight of the main widgets' bundle.
 Bokeh includes ``bokeh-tables`` automatically when necessary, so this change
 should be transparent for most users. However, users of custom templates or
-other advanced embedding scenarios (including the use of ``components`` may
+other advanced embedding scenarios (including the use of ``components``) may
 be affected. In short, if your application is responsible for loading Bokeh
 resources, then it should take care of loading the ``bokeh-tables`` as well.
 

--- a/sphinx/source/docs/releases/0.12.7.rst
+++ b/sphinx/source/docs/releases/0.12.7.rst
@@ -110,7 +110,9 @@ The `bokeh-widgets` bundle was split into ``bokeh-widgets`` and
 ``bokeh-tables``. This is to reduce the weight of the main widgets' bundle.
 Bokeh includes ``bokeh-tables`` automatically when necessary, so this change
 should be transparent for most users. However, users of custom templates or
-other advanced embedding scenarios may be affected.
+other advanced embedding scenarios (including the use of ``components`` may
+be affected. In short, if your application is responsible for loading Bokeh
+resources, then it should take care of loading the ``bokeh-tables`` as well.
 
 TapTool Callback Calling Convention
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/sphinx/source/docs/user_guide/embed.rst
+++ b/sphinx/source/docs/user_guide/embed.rst
@@ -119,24 +119,26 @@ appropriate version replacing ``x.y.z``:
     <script src="http://cdn.pydata.org/bokeh/release/bokeh-tables-x.y.z.min.js"></script>
 
 The ``"-widgets"`` files are only necessary if your document includes Bokeh widgets.
+Similarly, the ``"-tables"`` files are only necessary if you are using Bokeh data tables in
+your document.
 
-For example, to use version ``0.12.7``, including widgets support:
+For example, to use version ``0.12.9``, including widgets and tables support:
 
 .. code-block:: html
 
     <link
-        href="http://cdn.pydata.org/bokeh/release/bokeh-0.12.7.min.css"
+        href="http://cdn.pydata.org/bokeh/release/bokeh-0.12.9.min.css"
         rel="stylesheet" type="text/css">
     <link
-        href="http://cdn.pydata.org/bokeh/release/bokeh-widgets-0.12.7.min.css"
+        href="http://cdn.pydata.org/bokeh/release/bokeh-widgets-0.12.9.min.css"
         rel="stylesheet" type="text/css">
     <link
-        href="http://cdn.pydata.org/bokeh/release/bokeh-tables-0.12.7.min.css"
+        href="http://cdn.pydata.org/bokeh/release/bokeh-tables-0.12.9.min.css"
         rel="stylesheet" type="text/css">
 
-    <script src="http://cdn.pydata.org/bokeh/release/bokeh-0.12.7.min.js"></script>
-    <script src="http://cdn.pydata.org/bokeh/release/bokeh-widgets-0.12.7.min.js"></script>
-    <script src="http://cdn.pydata.org/bokeh/release/bokeh-tables-0.12.7.min.js"></script>
+    <script src="http://cdn.pydata.org/bokeh/release/bokeh-0.12.9.min.js"></script>
+    <script src="http://cdn.pydata.org/bokeh/release/bokeh-widgets-0.12.9.min.js"></script>
+    <script src="http://cdn.pydata.org/bokeh/release/bokeh-tables-0.12.9.min.js"></script>
 
 .. note::
     You must provide the closing `</script>` tag. This is required by all

--- a/sphinx/source/docs/user_guide/embed.rst
+++ b/sphinx/source/docs/user_guide/embed.rst
@@ -110,25 +110,33 @@ appropriate version replacing ``x.y.z``:
     <link
         href="http://cdn.pydata.org/bokeh/release/bokeh-widgets-x.y.z.min.css"
         rel="stylesheet" type="text/css">
+    <link
+        href="http://cdn.pydata.org/bokeh/release/bokeh-tables-x.y.z.min.css"
+        rel="stylesheet" type="text/css">
 
     <script src="http://cdn.pydata.org/bokeh/release/bokeh-x.y.z.min.js"></script>
     <script src="http://cdn.pydata.org/bokeh/release/bokeh-widgets-x.y.z.min.js"></script>
+    <script src="http://cdn.pydata.org/bokeh/release/bokeh-tables-x.y.z.min.js"></script>
 
 The ``"-widgets"`` files are only necessary if your document includes Bokeh widgets.
 
-For example, to use version ``0.12.6``, including widgets support:
+For example, to use version ``0.12.7``, including widgets support:
 
 .. code-block:: html
 
     <link
-        href="http://cdn.pydata.org/bokeh/release/bokeh-0.12.6.min.css"
+        href="http://cdn.pydata.org/bokeh/release/bokeh-0.12.7.min.css"
         rel="stylesheet" type="text/css">
     <link
-        href="http://cdn.pydata.org/bokeh/release/bokeh-widgets-0.12.6.min.css"
+        href="http://cdn.pydata.org/bokeh/release/bokeh-widgets-0.12.7.min.css"
+        rel="stylesheet" type="text/css">
+    <link
+        href="http://cdn.pydata.org/bokeh/release/bokeh-tables-0.12.7.min.css"
         rel="stylesheet" type="text/css">
 
-    <script src="http://cdn.pydata.org/bokeh/release/bokeh-0.12.6.min.js"></script>
-    <script src="http://cdn.pydata.org/bokeh/release/bokeh-widgets-0.12.6.min.js"></script>
+    <script src="http://cdn.pydata.org/bokeh/release/bokeh-0.12.7.min.js"></script>
+    <script src="http://cdn.pydata.org/bokeh/release/bokeh-widgets-0.12.7.min.js"></script>
+    <script src="http://cdn.pydata.org/bokeh/release/bokeh-tables-0.12.7.min.js"></script>
 
 .. note::
     You must provide the closing `</script>` tag. This is required by all


### PR DESCRIPTION
* add `-tables` resources in `embed.rst` and `installation.rst`
* add reference to `embed.rst` to the `components` docstring
* touch up the `0.12.7.rst` to highlight that these resources must be manually loaded in any scenario where Bokeh is not loading resources itself.

I couldn't build and check the docs yet (need a dev install) but wanted to push the PR anyway.

- [x] issues: fixes #6999 
- [ ] ~~tests added / passed~~
- [ ] ~~release document entry (if new feature or API change)~~