### PR TITLE
call formatter for major categorical ticks

### DIFF
--- a/bokehjs/src/coffee/models/axes/categorical_axis.coffee
+++ b/bokehjs/src/coffee/models/axes/categorical_axis.coffee
@@ -83,15 +83,16 @@ export class CategoricalAxisView extends AxisView
     info = []
 
     if range.levels == 1
-      info.push([ ticks.major, coords.major, @model.major_label_orientation, @visuals.major_label_text ])
+      labels = @model.formatter.doFormat(ticks.major, @)
+      info.push([ labels, coords.major, @model.major_label_orientation, @visuals.major_label_text ])
 
     else if range.levels == 2
-      labels = (x[1] for x in ticks.major)
+      labels = @model.formatter.doFormat((x[1] for x in ticks.major), @)
       info.push([ labels,     coords.major, @model.major_label_orientation, @visuals.major_label_text ])
       info.push([ ticks.tops, coords.tops,  'parallel',                     @visuals.group_text       ])
 
     else if range.levels == 3
-      labels = (x[2] for x in ticks.major)
+      labels = @model.formatter.doFormat((x[2] for x in ticks.major), @)
       mid_labels = (x[1] for x in ticks.mids)
       info.push([ labels,     coords.major, @model.major_label_orientation, @visuals.major_label_text ])
       info.push([ mid_labels, coords.mids,  'parallel',                     @visuals.subgroup_text    ])


### PR DESCRIPTION
- [x] issues: fixes #7015
- [ ] tests added / passed

A small change applies formatting to the major ticks adjacent to to the axis:

<img width="639" alt="screen shot 2017-10-09 at 13 59 14" src="https://user-images.githubusercontent.com/1078448/31353982-38908c88-acfa-11e7-9e00-2042c7bfbae3.png">

However, not in the nested case, it does *not* apply formatting to the higher level:

<img width="555" alt="screen shot 2017-10-09 at 13 58 56" src="https://user-images.githubusercontent.com/1078448/31353996-494ee970-acfa-11e7-89dd-57e306c58ca5.png">

@hiramf @hafen is this OK for now? Another change *can* produce this:

<img width="554" alt="screen shot 2017-10-09 at 13 58 39" src="https://user-images.githubusercontent.com/1078448/31354022-5d72645e-acfa-11e7-9c1a-f47e93a67667.png">

but it's not ideal &mdash; the only info available to the (one single) formatter is the local tick value, not what level it is for, or a complete compound category value. I think this is not ideal so I don't want to push it now. It might be better to have separate formatters for mid or top level ticks, or possibly there could be a way to pass more info to the formatter, so that a single formatter can intelligently switch on the category level. 

If this seems OK for the immediate issue I will figure out some tests and merge. 
