### PR TITLE
fixed URL typo in examples app & changed README URL to https

### DIFF
--- a/examples/app/movies/README.md
+++ b/examples/app/movies/README.md
@@ -1,5 +1,5 @@
 Create an interactive query and visualization dashboard for a set of
-IMDB movie data. Inspired by the [Shiny Movie Explorer](http://shiny.rstudio.com/gallery/movie-explorer.html).
+IMDB movie data. Inspired by the [Shiny Movie Explorer](https://shiny.rstudio.com/gallery/movie-explorer.html).
 
 #### Setting Up
 

--- a/examples/app/movies/description.html
+++ b/examples/app/movies/description.html
@@ -37,7 +37,7 @@ Interact with the widgets on the left to query a subset of movies to plot.
 Hover over the circles to see more information about each movie.
 </p>
 <p>
-Inspired by the <a href="hhttp://shiny.rstudio.com/gallery/movie-explorer.html">Shiny Movie Explorer</a>.
+Inspired by the <a href="https://shiny.rstudio.com/gallery/movie-explorer.html">Shiny Movie Explorer</a>.
 </p>
 <i>Information courtesy of IMDb<br>(http://www.imdb.com).<br>
 Used with permission.</i>


### PR DESCRIPTION
fixed URL typo("hhttp" -> "https") in examples app & also changed README URL to https.


- issues: None
- reso: completed 
- type: bug
- milestone: short-term

