### PR TITLE
update docs to reflect new behavior of session_context

### DIFF
--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -352,9 +352,9 @@ Accessing the HTTP Request
 When a session is created for a Bokeh application, the session context is made
 available as ``curdoc().session_context``. The most useful function of the
 session context is to make the Tornado HTTP request object available to the
-application as ``session_context.request``. The request object has a number of
-fields, such as ``arguments``, ``cookies``, ``protocol``, etc. See the
-documentation for `HTTPServerRequest`_ for full details.
+application as ``session_context.request``. Due to an incompatibility issue with
+the usage of ``--num-procs`` only the ``arguments`` attribute can be accessed.
+Attempting to access any other attribute on ``request`` will result in an error.
 
 As an example, the following code will access the request ``arguments`` to set
 a value for a variable ``N`` (perhaps controlling the number of points in a


### PR DESCRIPTION
Docs were not updated to reflect changes made to session_context in #5901. The docs reference to users having access to `request.cookies ` (and other attributes) which was removed in v0.12.5. New wording reflects the current restrictions.

Issue related to this PR is #7031.

