### PR TITLE
ensure Document modules are properly disposed of

### DIFF
--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -299,7 +299,7 @@ from os import getpid
 from ..subcommand import Subcommand
 from ..util import build_single_handler_applications, die, report_server_init_errors
 
-LOGLEVELS = ('debug', 'info', 'warning', 'error', 'critical')
+LOGLEVELS = ('trace', 'debug', 'info', 'warning', 'error', 'critical')
 SESSION_ID_MODES = ('unsigned', 'signed', 'external-signed')
 DEFAULT_LOG_FORMAT = "%(asctime)s %(message)s"
 

--- a/bokeh/command/subcommands/tests/test_serve.py
+++ b/bokeh/command/subcommands/tests/test_serve.py
@@ -24,7 +24,7 @@ def test_create():
     assert isinstance(obj, Subcommand)
 
 def test_loglevels():
-    assert scserve.LOGLEVELS == ('debug', 'info', 'warning', 'error', 'critical')
+    assert scserve.LOGLEVELS == ('trace', 'debug', 'info', 'warning', 'error', 'critical')
 
 def test_name():
     assert scserve.Serve.name == "serve"

--- a/bokeh/document/document.py
+++ b/bokeh/document/document.py
@@ -401,12 +401,43 @@ class Document(object):
             self._pop_all_models_freeze()
 
     def delete_modules(self):
-        ''' Clean up sys.modules after the session is destroyed.
+        ''' Clean up after any modules created by this Document when its session is
+        destroyed.
 
         '''
+        from gc import get_referrers
+        from types import FrameType
+
+        logger.debug("Deleting %s modules for %s" % (len(self._modules), self))
+
         for module in self._modules:
+
+            # Modules created for a Document should have three referrers at this point:
+            #
+            # - sys.modules
+            # - self._modules
+            # - a frame object
+            #
+            # This function will take care of removing these expected references.
+            #
+            # If there are any additional referrers, this probably means the module will be
+            # leaked. Here we perform a detailed check that the only referrers are expected
+            # ones. Otherwise issue an error log message with details.
+            referrers = get_referrers(module)
+            referrers = [x for x in referrers if x is not sys.modules]
+            referrers = [x for x in referrers if x is not self._modules]
+            referrers = [x for x in referrers if not isinstance(x, FrameType)]
+            if len(referrers) != 0:
+                logger.error("Module %r has extra unexpected referrers! This could indicate a serious memory leak. Extra referrers: %r" % (module, referrers))
+
+            # remove the reference from sys.modules
             if module.__name__ in sys.modules:
                 del sys.modules[module.__name__]
+
+        # remove the reference from self._modules
+        self._modules = None
+
+        # the frame reference will take care of itself
 
     @classmethod
     def from_json(cls, json):

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -230,9 +230,11 @@ class BokehTornado(TornadoApplication):
             app_context._loop = self._loop
 
         self._clients = set()
+
         self._stats_job = PeriodicCallback(self._log_stats,
                                            self._stats_log_frequency_milliseconds,
                                            io_loop=self._loop)
+
         self._cleanup_job = PeriodicCallback(self._cleanup_sessions,
                                              self._check_unused_sessions_milliseconds,
                                              io_loop=self._loop)
@@ -398,6 +400,7 @@ class BokehTornado(TornadoApplication):
 
     @gen.coroutine
     def _cleanup_sessions(self):
+        log.trace("Running session cleanup job")
         for app in self._applications.values():
             yield app._cleanup_sessions(self._unused_session_lifetime_milliseconds)
         raise gen.Return(None)


### PR DESCRIPTION
- [x] issues: fixes #7044
- [x] tests added / passed

This PR adds a detailed check in `Document.delete_modules` that saved modules only have the expected set of referrers. The method `delete_modules` is made responsible for clearing the internal list of modules so that they may be correctly reaped. Additionally some extra logging has been added to trace the session destruction codepath. 