### PR TITLE
sort the results of _mask_data so patch draw order is stable

### DIFF
--- a/bokehjs/src/coffee/models/glyphs/patches.coffee
+++ b/bokehjs/src/coffee/models/glyphs/patches.coffee
@@ -71,7 +71,10 @@ export class PatchesView extends GlyphView
     [y0, y1] = [yr.min, yr.max]
 
     bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-    return @index.indices(bbox)
+    indices = @index.indices(bbox)
+
+    # TODO (bev) this should be under test
+    return indices.sort((a, b) => a-b)
 
   _render: (ctx, indices, {sxs, sys}) ->
     # @sxss and @syss are used by _hit_point and sxc, syc


### PR DESCRIPTION
 issues: fixes #3601

I tested this with existing choropleth examples and it seems fine. 

@philippjfr I can't get HV to work at all right now, and there is no MRE in the issue, so someone else needs to confirm that it functions as desired with overlapping patches. 