### PR TITLE
ignore locked callbacks when a session is destroyed

### DIFF
--- a/bokeh/server/session.py
+++ b/bokeh/server/session.py
@@ -37,6 +37,9 @@ def _needs_document_lock(func):
         # from being discarded. This avoids potential weirdness
         # with the session vanishing in the middle of some async
         # task.
+        if self.destroyed:
+            log.debug("Ignoring locked callback on already-destroyed session.")
+            raise gen.Return(None)
         self.block_expiration()
         try:
             with (yield self._lock.acquire()):

--- a/bokeh/server/tests/test_server.py
+++ b/bokeh/server/tests/test_server.py
@@ -102,6 +102,7 @@ class HookTestHandler(Handler):
     # this has to be async too
     @gen.coroutine
     def on_session_destroyed(self, session_context):
+        # this should be no-op'd, because the session is already destroyed
         @gen.coroutine
         def shutdown_document(doc):
             doc.roots[0].hooks.append("session_destroyed")
@@ -187,13 +188,15 @@ def test__lifecycle_hooks():
     server_hook_list = server_doc.roots[0]
     assert handler.load_count == 1
     assert handler.unload_count == 1
-    assert handler.session_creation_async_value == 6
+    # this is 3 instead of 6 because locked callbacks on destroyed sessions
+    # are turned into no-ops
+    assert handler.session_creation_async_value == 3
     assert client_doc.title == "Modified"
     assert server_doc.title == "Modified"
-    # the client session doesn't see the event that adds "session_destroyed" since
-    # we shut down at that point.
+    # only the handler sees the event that adds "session_destroyed" since
+    # the session is shut down at that point.
     assert client_hook_list.hooks == ["session_created", "modify"]
-    assert server_hook_list.hooks == ["session_created", "modify", "session_destroyed"]
+    assert server_hook_list.hooks == ["session_created", "modify"]
 
 def test_prefix():
     application = Application()


### PR DESCRIPTION
- [x] issues: fixes #3538 
- [x] tests added / passed

@havocp this is a trivial change, but I'd appreciate your input. I believe the test changes reflect your intent in the original issue, but please confirm if you can. 