### PR TITLE
fix distance spec hierarchy

### DIFF
--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -1731,7 +1731,7 @@ class DistanceSpec(UnitsSpec):
             pass
         return super(DistanceSpec, self).prepare_value(cls, name, value)
 
-class ScreenDistanceSpec(NumberSpec):
+class ScreenDistanceSpec(UnitsSpec):
     ''' A |DataSpec| property that accepts numeric fixed values for screen
     distances, and also provides an associated units property that reports
     ``"screen"`` as the units.
@@ -1740,6 +1740,10 @@ class ScreenDistanceSpec(NumberSpec):
         Units are always ``"screen"``.
 
     '''
+
+    def __init__(self, default=None, help=None):
+        super(ScreenDistanceSpec, self).__init__(default=default, units_type=Enum(enums.enumeration("screen")), units_default="screen", help=help)
+
     def prepare_value(self, cls, name, value):
         try:
             if value is not None and value < 0:
@@ -1748,12 +1752,38 @@ class ScreenDistanceSpec(NumberSpec):
             pass
         return super(ScreenDistanceSpec, self).prepare_value(cls, name, value)
 
+    def make_descriptors(self, base_name):
+        ''' Return a list of ``PropertyDescriptor`` instances to install on a
+        class, in order to delegate attribute access to this property.
+
+        Unlike simpler property types, ``UnitsSpec`` returns multiple
+        descriptors to install. In particular, descriptors for the base
+        property as well as the associated units property are returned.
+
+        Args:
+            name (str) : the name of the property these descriptors are for
+
+        Returns:
+            list[PropertyDescriptor]
+
+        The descriptors returned are collected by the ``MetaHasProps``
+        metaclass and added to ``HasProps`` subclasses during class creation.
+        '''
+        units_props = self._units_type.make_descriptors("unused")
+        return [ UnitsSpecPropertyDescriptor(base_name, self, units_props[0]) ]
+
     def to_serializable(self, obj, name, val):
-        d = super(ScreenDistanceSpec, self).to_serializable(obj, name, val)
-        d["units"] = "screen"
+        d = super(UnitsSpec, self).to_serializable(obj, name, val)
+        if d is not None and 'units' not in d:
+            # d is a PropertyValueDict at this point, we need to convert it to
+            # a plain dict if we are going to modify its value, otherwise a
+            # notify_change that should not happen will be triggered
+            d = dict(d)
+            d["units"] = "screen"
         return d
 
-class DataDistanceSpec(NumberSpec):
+
+class DataDistanceSpec(UnitsSpec):
     ''' A |DataSpec| property that accepts numeric fixed values for data-space
     distances, and also provides an associated units property that reports
     ``"data"`` as the units.
@@ -1762,6 +1792,9 @@ class DataDistanceSpec(NumberSpec):
         Units are always ``"data"``.
 
     '''
+    def __init__(self, default=None, help=None):
+        super(DataDistanceSpec, self).__init__(default=default, units_type=Enum(enums.enumeration("data")), units_default="data", help=help)
+
     def prepare_value(self, cls, name, value):
         try:
             if value is not None and value < 0:
@@ -1770,9 +1803,34 @@ class DataDistanceSpec(NumberSpec):
             pass
         return super(DataDistanceSpec, self).prepare_value(cls, name, value)
 
+    def make_descriptors(self, base_name):
+        ''' Return a list of ``PropertyDescriptor`` instances to install on a
+        class, in order to delegate attribute access to this property.
+
+        Unlike simpler property types, ``UnitsSpec`` returns multiple
+        descriptors to install. In particular, descriptors for the base
+        property as well as the associated units property are returned.
+
+        Args:
+            name (str) : the name of the property these descriptors are for
+
+        Returns:
+            list[PropertyDescriptor]
+
+        The descriptors returned are collected by the ``MetaHasProps``
+        metaclass and added to ``HasProps`` subclasses during class creation.
+        '''
+        units_props = self._units_type.make_descriptors("unused")
+        return [ UnitsSpecPropertyDescriptor(base_name, self, units_props[0]) ]
+
     def to_serializable(self, obj, name, val):
-        d = super(DataDistanceSpec, self).to_serializable(obj, name, val)
-        d["units"] = "data"
+        d = super(UnitsSpec, self).to_serializable(obj, name, val)
+        if d is not None and 'units' not in d:
+            # d is a PropertyValueDict at this point, we need to convert it to
+            # a plain dict if we are going to modify its value, otherwise a
+            # notify_change that should not happen will be triggered
+            d = dict(d)
+            d["units"] = "data"
         return d
 
 class ColorSpec(DataSpec):

--- a/bokeh/core/tests/test_properties.py
+++ b/bokeh/core/tests/test_properties.py
@@ -13,7 +13,7 @@ from bokeh.core.properties import (field, value,
     Regex, Seq, List, Dict, Tuple, Instance, Any, Interval, Either,
     Enum, Color, DashPattern, Size, Percent, Angle, AngleSpec, StringSpec,
     DistanceSpec, FontSizeSpec, Override, Include, MinMaxBounds,
-    DataDistanceSpec, ScreenDistanceSpec, ColumnData)
+    DataDistanceSpec, ScreenDistanceSpec, ColumnData, UnitsSpec)
 
 from bokeh.core.property.containers import PropertyValueColumnData, PropertyValueDict, PropertyValueList
 
@@ -1769,17 +1769,34 @@ def test_strict_dataspec_key_values():
             f.x = dict(field="foo", units="junk")
 
 def test_dataspec_dict_to_serializable():
-    for typ in (NumberSpec, StringSpec, FontSizeSpec, ColorSpec, DataDistanceSpec, ScreenDistanceSpec):
+    for typ in (NumberSpec, StringSpec, FontSizeSpec, ColorSpec):
         class Foo(HasProps):
             x = typ("x")
         foo = Foo(x=dict(field='foo'))
         props = foo.properties_with_values(include_defaults=False)
-        if typ is DataDistanceSpec:
-            assert props['x']['units'] == 'data'
-        elif typ is ScreenDistanceSpec:
-            assert props['x']['units'] == 'screen'
         assert props['x']['field'] == 'foo'
         assert props['x'] is not foo.x
+
+def test_DataDistanceSpec():
+    assert issubclass(DataDistanceSpec, UnitsSpec)
+    class Foo(HasProps):
+        x = DataDistanceSpec("x")
+    foo = Foo(x=dict(field='foo'))
+    props = foo.properties_with_values(include_defaults=False)
+    assert props['x']['units'] == 'data'
+    assert props['x']['field'] == 'foo'
+    assert props['x'] is not foo.x
+
+def test_ScreenDistanceSpec():
+    assert issubclass(ScreenDistanceSpec, UnitsSpec)
+    class Foo(HasProps):
+        x = ScreenDistanceSpec("x")
+    foo = Foo(x=dict(field='foo'))
+    props = foo.properties_with_values(include_defaults=False)
+    assert props['x']['units'] == 'screen'
+    assert props['x']['field'] == 'foo'
+    assert props['x'] is not foo.x
+
 
 def test_strict_unitspec_key_values():
     class FooUnits(HasProps):


### PR DESCRIPTION
- [x] issues: fixes #6409
- [x] tests added / passed

This PR makes `ScreenDistanceSpec` and `DataDistanceSpec` properly be `UnitsSpec` subclasses. Since there is only one valid unit value, in order to keep existing semantics identical, and not avoid a useless `_units` property that can only accept one value the descriptor machinery for each was specialized. 
