### PR TITLE
factor rect hit-testing against an index out to glyph view

### DIFF
--- a/bokehjs/src/coffee/models/glyphs/box.coffee
+++ b/bokehjs/src/coffee/models/glyphs/box.coffee
@@ -33,6 +33,9 @@ export class BoxView extends GlyphView
         @visuals.line.set_vectorize(ctx, i)
         ctx.stroke()
 
+  _hit_rect: (geometry) ->
+    return @_hit_rect_against_index(geometry)
+
   _hit_point: (geometry) ->
     [vx, vy] = [geometry.vx, geometry.vy]
     x = @renderer.xscale.invert(vx)

--- a/bokehjs/src/coffee/models/glyphs/glyph.coffee
+++ b/bokehjs/src/coffee/models/glyphs/glyph.coffee
@@ -175,9 +175,9 @@ export class GlyphView extends View
   _hit_rect_against_index: (geometry) ->
     [x0, x1] = @renderer.xscale.v_invert([geometry.vx0, geometry.vx1])
     [y0, y1] = @renderer.yscale.v_invert([geometry.vy0, geometry.vy1])
-    bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
+    bb = hittest.validate_bbox_coords([x0, x1], [y0, y1])
     result = hittest.create_hit_test_result()
-    result['1d'].indices = @index.indices(bbox)
+    result['1d'].indices = @index.indices(bb)
     return result
 
   set_data: (source, indices, indices_to_update) ->

--- a/bokehjs/src/coffee/models/glyphs/glyph.coffee
+++ b/bokehjs/src/coffee/models/glyphs/glyph.coffee
@@ -1,3 +1,4 @@
+import * as hittest from "core/hittest"
 import * as p from "core/properties"
 import * as bbox from "core/util/bbox"
 import * as proj from "core/util/projections"
@@ -169,6 +170,14 @@ export class GlyphView extends View
       logger.debug("'#{geometry.type}' selection not available for #{@model.type}")
       @_nohit_warned[geometry.type] = true
 
+    return result
+
+  _hit_rect_against_index: (geometry) ->
+    [x0, x1] = @renderer.xscale.v_invert([geometry.vx0, geometry.vx1])
+    [y0, y1] = @renderer.yscale.v_invert([geometry.vy0, geometry.vy1])
+    bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
+    result = hittest.create_hit_test_result()
+    result['1d'].indices = @index.indices(bbox)
     return result
 
   set_data: (source, indices, indices_to_update) ->

--- a/bokehjs/src/coffee/models/glyphs/rect.coffee
+++ b/bokehjs/src/coffee/models/glyphs/rect.coffee
@@ -77,12 +77,7 @@ export class RectView extends XYGlyphView
       ctx.stroke()
 
   _hit_rect: (geometry) ->
-    [x0, x1] = @renderer.xscale.v_invert([geometry.vx0, geometry.vx1])
-    [y0, y1] = @renderer.yscale.v_invert([geometry.vy0, geometry.vy1])
-    bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-    result = hittest.create_hit_test_result()
-    result['1d'].indices = @index.indices(bbox)
-    return result
+    return @_hit_rect_against_index(geometry)
 
   _hit_point: (geometry) ->
     [vx, vy] = [geometry.vx, geometry.vy]

--- a/bokehjs/test/models/glyphs/rect.coffee
+++ b/bokehjs/test/models/glyphs/rect.coffee
@@ -52,6 +52,42 @@ describe "Glyph (using Rect as a concrete Glyph)", ->
 
       expect(log_bounds).to.be.deep.equal({ minX: 1, minY: 10, maxX: 3, maxY: 10 })
 
+    it "should hit test rects against an index", ->
+
+      data = {x: [20, 40, 60], y: [10, 10, 50]}
+      glyph = new Rect({
+        x: {field: "x"}
+        y: {field: "y"}
+        width: {value: 10}
+        height: {value: 20}
+      })
+
+      glyph_view = create_glyph_view(glyph, data)
+
+      scale = new LinearScale({
+        source_range: new Range1d({start: 0, end: 100})
+        target_range: new Range1d({start: 0, end: 200})
+      })
+      glyph_view.renderer.xscale = scale
+      glyph_view.renderer.yscale = scale
+      glyph_view.renderer.plot_view.frame.xscales['default'] = scale
+      glyph_view.renderer.plot_view.frame.yscales['default'] = scale
+
+      glyph_view.map_data()
+
+      # rect is XYGlyph, will only put centers in index, box glyphs will put entire box
+      geometry1 = { vx0: 0,  vy0: 0,   vx1: 40,  vy1: 20}
+      geometry2 = { vx0: 60, vy0: -10, vx1: 80,  vy1: 50}
+      geometry3 = { vx0: 0,  vy0: 150, vx1: 200, vy1: 151}
+
+      result1 = glyph_view._hit_rect_against_index(geometry1)
+      result2 = glyph_view._hit_rect_against_index(geometry2)
+      result3 = glyph_view._hit_rect_against_index(geometry3)
+
+      expect(result1['1d'].indices).to.be.deep.equal([0])
+      expect(result2['1d'].indices).to.be.deep.equal([1])
+      expect(result3['1d'].indices).to.be.deep.equal([])
+
 describe "Rect", ->
 
   describe "RectView", ->


### PR DESCRIPTION
- [x] issues: fixes #5298
- [x] tests added / passed

In the interest of remaining consistent with `rect` behaviour, and also re-using code, I have factored the rect-rect index hit testing up to glyph to also be used by `Box` subclasses. Will add test before merging. 