### PR TITLE
Bryanv/some docs

### DIFF
--- a/bokeh/embed/__init__.py
+++ b/bokeh/embed/__init__.py
@@ -33,8 +33,6 @@ from bokeh.util.api import public, internal ; public, internal
 # Public API
 #-----------------------------------------------------------------------------
 
-from .notebook import notebook_content
-
 from .server import server_document
 from .server import server_session
 
@@ -47,7 +45,6 @@ __all__ = (
     'autoload_static',
     'components',
     'file_html',
-    'notebook_content',
     'server_document',
     'server_session',
 )

--- a/bokeh/embed/notebook.py
+++ b/bokeh/embed/notebook.py
@@ -44,7 +44,11 @@ from .util import check_one_model_or_doc, div_for_render_item, find_existing_doc
 # Public API
 #-----------------------------------------------------------------------------
 
-@public((1,0,0))
+#-----------------------------------------------------------------------------
+# Internal API
+#-----------------------------------------------------------------------------
+
+@internal((1,0,0))
 def notebook_content(model, notebook_comms_target=None, theme=FromCurdoc):
     ''' Return script and div that will display a Bokeh plot in a Jupyter
     Notebook.
@@ -94,10 +98,6 @@ def notebook_content(model, notebook_comms_target=None, theme=FromCurdoc):
     div = div_for_render_item(item)
 
     return encode_utf8(script), encode_utf8(div), new_doc
-
-#-----------------------------------------------------------------------------
-# Internal API
-#-----------------------------------------------------------------------------
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/bokeh/embed/tests/test___init__.py
+++ b/bokeh/embed/tests/test___init__.py
@@ -39,7 +39,6 @@ ALL = (
     'autoload_static',
     'components',
     'file_html',
-    'notebook_content',
     'server_document',
     'server_session',
 )

--- a/bokeh/embed/tests/test_notebook.py
+++ b/bokeh/embed/tests/test_notebook.py
@@ -40,9 +40,9 @@ api = {
 
     PUBLIC: (
 
-        ( 'notebook_content', (1,0,0) ),
-
     ), INTERNAL: (
+
+        ( 'notebook_content', (1,0,0) ),
 
     )
 

--- a/bokeh/io/notebook.py
+++ b/bokeh/io/notebook.py
@@ -468,7 +468,7 @@ def show_doc(obj, state, notebook_handle):
     '''
 
     '''
-    from ..embed import notebook_content
+    from ..embed.notebook import notebook_content
     comms_target = make_id() if notebook_handle else None
     (script, div, cell_doc) = notebook_content(obj, comms_target)
 

--- a/bokeh/io/tests/test_notebook.py
+++ b/bokeh/io/tests/test_notebook.py
@@ -85,7 +85,7 @@ def test_install_notebook_hook():
 
 @patch('bokeh.io.notebook.get_comms')
 @patch('bokeh.io.notebook.publish_display_data')
-@patch('bokeh.embed.notebook_content')
+@patch('bokeh.embed.notebook.notebook_content')
 def test_show_doc_no_server(mock_notebook_content,
                             mock__publish_display_data,
                             mock_get_comms):

--- a/bokeh/models/callbacks.py
+++ b/bokeh/models/callbacks.py
@@ -32,6 +32,12 @@ class OpenURL(Callback):
 class CustomJS(Callback):
     ''' Execute a JavaScript function.
 
+    .. warning::
+        The explicit purpose of this Bokeh Model is to embed *raw JavaScript
+        code* for a browser to execute. If any part of the code is derived
+        from untrusted user inputs, then you must take appropriate care to
+        sanitize the user input prior to passing to Bokeh.
+
     '''
 
     @classmethod

--- a/bokeh/models/filters.py
+++ b/bokeh/models/filters.py
@@ -76,6 +76,12 @@ class GroupFilter(Filter):
 class CustomJSFilter(Filter):
     ''' Filter data sources with a custom defined JavaScript function.
 
+    .. warning::
+        The explicit purpose of this Bokeh Model is to embed *raw JavaScript
+        code* for a browser to execute. If any part of the code is derived
+        from untrusted user inputs, then you must take appropriate care to
+        sanitize the user input prior to passing to Bokeh.
+
     '''
 
     @classmethod

--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -242,6 +242,12 @@ class CategoricalTickFormatter(TickFormatter):
 class FuncTickFormatter(TickFormatter):
     ''' Display tick values that are formatted by a user-defined function.
 
+    .. warning::
+        The explicit purpose of this Bokeh Model is to embed *raw JavaScript
+        code* for a browser to execute. If any part of the code is derived
+        from untrusted user inputs, then you must take appropriate care to
+        sanitize the user input prior to passing to Bokeh.
+
     '''
 
     @classmethod

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -673,8 +673,13 @@ class HoverTool(Inspection):
     off by setting ``tooltips=None``.
 
     .. warning::
+        When supplying a callback or custom template, the explicit intent
+        of this Bokeh Model is to embed *raw HTML and  JavaScript code* for
+        a browser to execute. If any part of the code is derived from untrusted
+        user inputs, then you must take appropriate care to sanitize the user
+        input prior to passing to Bokeh.
 
-        Hover tool does not currently work with the following glyphs:
+    Hover tool does not currently work with the following glyphs:
 
         .. hlist::
             :columns: 3

--- a/bokeh/models/transforms.py
+++ b/bokeh/models/transforms.py
@@ -38,6 +38,12 @@ class Transform(Model):
 class CustomJSTransform(Transform):
     ''' Apply a custom defined transform to data.
 
+    .. warning::
+        The explicit purpose of this Bokeh Model is to embed *raw JavaScript
+        code* for a browser to execute. If any part of the code is derived
+        from untrusted user inputs, then you must take appropriate care to
+        sanitize the user input prior to passing to Bokeh.
+
     '''
 
     @classmethod

--- a/bokeh/models/widgets/markups.py
+++ b/bokeh/models/widgets/markups.py
@@ -1,5 +1,11 @@
 ''' Various kinds of markup (static content) widgets.
 
+.. warning::
+    The explicit purpose of these Bokeh Models is to embed *raw HTML text* for
+    a browser to execute. If any portion of the text is derived from untrusted
+    user inputs, then you must take appropriate care to sanitize the user input
+    prior to passing to Bokeh.
+
 '''
 from __future__ import absolute_import
 

--- a/sphinx/source/docs/dev_guide/documentation.rst
+++ b/sphinx/source/docs/dev_guide/documentation.rst
@@ -3,50 +3,41 @@
 Documentation
 =============
 
-We use Sphinx_ to generate our HTML documentation.
+Contributions to Bokeh will only be accepted if they contain sufficient and
+appropriate documentation support. This section outlines how to build and
+edit documentation locally, as well as describes conventions that the project
+adheres to.
+
+Helping with documentation is one of the most valuable ways to contribute to a
+project. It's also a good way to to get started and introduce yourself as a new
+contributor. The most likely way for typos or other small documentation errors
+to be resolved is for the person who notices the problem to immediately submit
+a Pull Request to with a correction. *This is always appreciated!* In
+addition quick fixes, there is also a list of `Open Docs Issues`_ on GitHub
+that anyone can look at for tasks that need help.
 
 Working on Documentation
 ------------------------
 
+Sphinx_ is used to generate HTML documentation. Due to the innate dependency
+of Bokeh on JavaScript, no other output formats are supported by the official
+build configuration. This section describes how to use Sphinx to build the
+Bokeh documentation from source.
+
 Install requirements
 ~~~~~~~~~~~~~~~~~~~~
 
-The following requirements are necessary for building Bokeh documentation:
-
-* sphinx
-* pyyaml
-* packaging
-* pygments
-
-Install these requirements::
-
-    conda install -c bokeh sphinx pyyaml packaging pygments
-
-We recommend using ``conda`` to install these requirements. Alternatively, you
-may use ``pip`` or install from the packages' source.
-
-Supported Output Formats
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-The innate dependency of Bokeh on JavaScript means that attempting other formats
-besides HTML cannot not produce good or usable results. Only HTML output is
-supported.
-
-Install the sample data
-~~~~~~~~~~~~~~~~~~~~~~~
+In order to build the docs from source, you should have followed the
+instructions in :ref:`devguide_setup`.
 
 Some of the Bokeh examples in the documentation rely on sample data that is
 not included in the Bokeh GitHub repository or released packages, due to
 their size.
 
-First, make sure that the Bokeh package is installed. Install the latest
-development version of Bokeh, if needed::
-
-    conda install -c bokeh/channel/dev bokeh
-
-
 Once Bokeh is installed, the sample data can be obtained by executing the
-following command at a Bash or Windows prompt::
+following command at a Bash or Windows prompt:
+
+.. code-block:: sh
 
     bokeh sampledata
 
@@ -56,24 +47,59 @@ download the sample data.
 Build the Documentation
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-To generate the full documentation, execute the following command from the
-``sphinx`` subdirectory of the Bokeh source's root directory:
+To generate the full documentation, first navigate to the  ``sphinx``
+subdirectory of the Bokeh source tree.
 
 .. code-block:: sh
 
     cd sphinx
-    make clean all
 
-Serve and Review the Documentation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sphinx uses the ``make`` tool to control the build process. The most common
+targets or the Bokeh makefile are:
 
-Next to start a server and automatically open the documentation in a
-browser, enter::
+``clean``
+    Remove all previously built documentation output. All outputs will
+    be generated from scratch on the next build.
 
-    make serve
+``html``
+    Build any HTML output that is not built, or needs re-building (e.g.
+    because the input source file has changed since the last build)
 
-Documentation Style Conventions
--------------------------------
+``serve``
+    Start a server to serve the docs open a web browser to display. Note
+    that due the the JavaScript files involved, starting a real server is
+    necessary to view many portions of the docs fully.
+
+For example, clean the docs build directory, run the follow command at the
+command line:
+
+.. code-block:: sh
+
+    make clean
+
+Multiple targets may be combined in a single `make` invocation. For instance,
+executing the following command will clean the docs build, generate all HTML
+docs from scratch, then open a browser to display the results:
+
+.. code-block:: sh
+
+    make clean html serve
+
+By default, built docs will load the most recent BokehJS from CDN. If you are
+making local changes to the BokehJS and wish to have the docs use your locally
+built BokehJS instead, you can set the environment variable ``BOKEH_DOCS_CDN``
+before calling ``make``:
+
+.. code-block:: sh
+
+    BOKEH_DOCS_CDN=local make clean html serv
+
+Source Code Documentation
+-------------------------
+
+Docstrings and Model help are available from a Python interpreter, but are also
+processed byt the Sphinx build to automatically generate a complete
+:ref:`refguide`.
 
 Bokeh uses some common conventions to create a consistent documentation style.
 
@@ -85,39 +111,110 @@ documentation.
 
 All docstrings are `Google Style Docstrings`_. Docstrings should generally
 begin with a verb stating what the function or method does in a short
-statement. For example, the "verb first" style is preferred::
+statement. For example, the "verb first" style is preferred:
 
-    """ Create and return a new Foo."""
+.. code-block:: python
 
-over the more verbose sentence below::
+    """ Create and return a new Foo. (GOOD)
 
-    """ This function creates and returns a new Foo. """
+    """
 
-Docstrings for functions and methods should include:
+over the more verbose sentence below:
 
-* ``Args:`` section (if any arguments are accepted)
-* ``Returns:`` section (even if the function just returns ``None``)
+.. code-block:: python
+
+    """ This function creates and returns a new Foo. (BAD)
+
+    """
+
+Docstrings for functions and methods should generally include the following
+sections:
+
+* ``Args``  (unless the function takes no arguments)
+* ``Returns`` (even if the function just returns ``None``)
 
 Short descriptions for parameters should be written in such a way that
-inserting an implicit "IS" makes a complete sentence. For example::
+inserting an implicit "IS" makes a complete sentence. For example:
 
-    title_font (str, optional) : a font used for the plot title (default: Sans)
+.. code-block:: python
+
+    title_font (str, optional) :
+        A font used for the plot title (default: Sans)
 
 can be reasonably read as "title_font IS a font used for the plot title".
 
-Document headings
-~~~~~~~~~~~~~~~~~
+A complete example might look like:
+
+.. code-block:: python
+
+    def somefunc(name, level):
+        ''' Create and return a new Foo.
+
+        Args:
+            name (str) :
+                A name for the Foo
+
+            level (int) :
+                A level for the Foo to be configured for
+
+        Returns:
+            Foo
+
+        '''
+
+Models and Properties
+~~~~~~~~~~~~~~~~~~~~~
+
+Bokeh's Model system supports its own system for providing detailed
+documentation for individual properties. These are given as a ``help``
+argument to the property type, which is interpreted as standard Sphinx
+ReST when the reference documenation is built. For example:
+
+.. code-block:: python
+
+    class DataRange(Range):
+        ''' A base class for all data range types.
+
+        '''
+
+        names = List(String, help="""
+        A list of names to query for. If set, only renderers that
+        have a matching value for their ``name`` attribute will be used
+        for autoranging.
+        """)
+
+        renderers = List(Instance(Renderer), help="""
+        An explicit list of renderers to autorange against. If unset,
+        defaults to all renderers on a plot.
+        """)
+
+
+Narrative Documentation
+-----------------------
+
+The narrative documentation consists of all the documentation that is not
+automatically generated from docstrings and Bokeh property helpstrings. This
+includes User's Guide, Quickstart, etc. The source code for these docs are
+standard Sphinx Restructure Text (ReST) files that are located under the
+``sphinx/source/docs`` subdirectory of the source tree.
+
+Section Headings
+~~~~~~~~~~~~~~~~
 
 In narrative documentation, headings help the users follow the
 key points and sections. The following outlines the headings hierarchy:
 
 .. code-block:: python
 
-    Top level (makes a top-level entry in the side-bar)
-    ===================================================
+    Top level
+    =========
+
+    This will add a "Top Level" entry in the navigation sidebar
 
     Second level
     ------------
+
+    This may add a sub-entry in the sidebar, depending on configuration.
 
     Third level
     ~~~~~~~~~~~
@@ -125,9 +222,19 @@ key points and sections. The following outlines the headings hierarchy:
     Fourth level
     ''''''''''''
 
-Note that the length of the underline should match that of the heading text.
+Note that the length of the underline *must* match that of the heading text,
+or else the Sphinx build will fail.
 
+Release Notes
+~~~~~~~~~~~~~
+
+Each release should add a new file under ``sphinx/source/docs/releases`` that
+briefly describes the changes in the release including any migration notes.
+The filename should be ``<version>.rst``, for example
+:bokeh-tree:`sphinx/source/docs/releases/0.12.7.rst`. The
+Sphinx build will automatically add this content to the list of all releases.
 
 .. _Google Style Docstrings: http://sphinxcontrib-napoleon.readthedocs.org/en/latest/example_google.html#example-google
+.. _Open Docs Issues: https://github.com/bokeh/bokeh/issues?q=is%3Aopen+is%3Aissue+label%3A%22tag%3A+component%3A+docs%22
 .. _Sphinx: http://sphinx-doc.org
 .. _Sphinx Napoleon: http://sphinxcontrib-napoleon.readthedocs.org/en/latest/index.html

--- a/sphinx/source/docs/user_guide/embed.rst
+++ b/sphinx/source/docs/user_guide/embed.rst
@@ -272,33 +272,6 @@ You can see an example by running:
 
     python /bokeh/examples/embed/embed_multiple.py
 
-.. _userguide_embed_notebook:
-
-IPython Notebook
-----------------
-
-Bokeh can also generate ``<div>`` tags suitable for inline display in the
-Jupyter notebook using the |notebook_div| function:
-
-.. code-block:: python
-
-    from bokeh.plotting import figure
-    from bokeh.embed import notebook_div
-
-    plot = figure()
-    plot.circle([1,2], [3,4])
-
-    div = notebook_div(plot)
-
-The returned div contains the same sort of ``<script>`` and ``<div>`` that
-the |components| function above returns.
-
-.. note::
-    This is a fairly low-level, explicit way to generate a Jupyter
-    notebook div. When using the |bokeh.plotting| interface, users will
-    typically call the function |output_notebook| in conjunction with
-    |show| instead.
-
 .. _userguide_embed_autoloading:
 
 Autoloading
@@ -493,4 +466,3 @@ on the server at `"some/path"`, from the document that has the plot embedded.
 .. |autoload_static| replace:: :func:`~bokeh.embed.autoload_static`
 .. |components|      replace:: :func:`~bokeh.embed.components`
 .. |file_html|       replace:: :func:`~bokeh.embed.file_html`
-.. |notebook_div|    replace:: :func:`~bokeh.embed.notebook_div`

--- a/sphinx/source/docs/user_guide/interaction/callbacks.rst
+++ b/sphinx/source/docs/user_guide/interaction/callbacks.rst
@@ -17,6 +17,12 @@ values change, or when UI or other events occur. This kind of callback can be
 used to add interesting interactions to Bokeh documents without the need to
 use a Bokeh server (but can also be used in conjunction with a Bokeh server).
 
+.. warning::
+    The explicit purpose of these callbacks is to embed *raw JavaScript
+    code* for a browser to execute. If any part of the code is derived from
+    untrusted user inputs, then you must take appropriate care to sanitize
+    the user input prior to passing to Bokeh.
+
 .. _userguide_interaction_jscallbacks_customjs:
 
 CustomJS Callbacks


### PR DESCRIPTION
- [x] issues: closes #7081, closes #1007
- [x] release document entry (if new feature or API change)

*  Removes `notebook_div` from Bokeh "Embedding" user guide. Does not replace with `notebook_content` as it is too specialized for general use.

* adds newer/better information about buiding the docs, a link to open docs issues, more information about different types of docs and where they are located, and expected conventions

* move `notebook_content` to public *dev* API

* add warnings for raw JS/HTML cases