### PR TITLE
compute rect dists more carefully

### DIFF
--- a/bokehjs/src/coffee/models/glyphs/rect.coffee
+++ b/bokehjs/src/coffee/models/glyphs/rect.coffee
@@ -137,10 +137,18 @@ export class RectView extends XYGlyphView
     vpt1 = scale.v_compute(pt1)
     sside_length = @sdist(scale, pt0, side_length, 'edge', @model.dilate)
     if dim == 0
-      vpt_corner = if vpt0[0] < vpt1[0] then vpt0 else vpt1
+      vpt_corner = vpt0
+      for i in [0...vpt0.length]
+        if vpt0[i] != vpt1[i]
+          vpt_corner = if vpt0[i] < vpt1[i] then vpt0 else vpt1
+          break
       return [sside_length, canvas.v_vx_to_sx(vpt_corner)]
     else if dim == 1
-      vpt_corner = if vpt0[0] < vpt1[0] then vpt1 else vpt0
+      vpt_corner = vpt0
+      for i in [0...vpt0.length]
+        if vpt0[i] != vpt1[i]
+          vpt_corner = if vpt0[i] < vpt1[i] then vpt1 else vpt0
+          break
       return [sside_length, canvas.v_vy_to_sy(vpt_corner)]
 
   _ddist: (dim, spts, spans) ->

--- a/bokehjs/test/models/glyphs/rect.coffee
+++ b/bokehjs/test/models/glyphs/rect.coffee
@@ -173,6 +173,21 @@ describe "Rect", ->
       expect(glyph_view.sx0).to.be.deep.equal({'0': 25})
       expect(glyph_view.sy1).to.be.deep.equal({'0': -175})
 
+    it "`_map_data` should map values for sw and sh when a height is 0", ->
+      glyph = new Rect({
+        x: {field: "x"}
+        y: {field: "y"}
+        width: {value: 10}
+        height: {field: "h"}
+      })
+      data = {x: [5], y: [5], h: [0]}
+      glyph_view = create_glyph_view(glyph, data)
+
+      @set_scales(glyph_view)
+      glyph_view.map_data()
+      expect(glyph_view.sw).to.be.deep.equal([20])
+      expect(glyph_view.sh).to.be.deep.equal([0])
+
     describe "hit-testing", ->
 
       describe "_hit_point", ->


### PR DESCRIPTION
- [x] issues: fixes #6583
- [x] tests added/passed

@clairetang6 this is your suggested function only modified to always set `vpt_corner` to something. If you have suggestions for additional/better tests please let me know (or just add them). TBH I am still not 100% clear on `sx0` and `sy1` but digging into the details will have to be another day. 
