### PR TITLE
documentation - fix version

### DIFF
--- a/sphinx/source/docs/releases/0.12.10.rst
+++ b/sphinx/source/docs/releases/0.12.10.rst
@@ -1,4 +1,4 @@
-0.12.0 (Oct 2017)
+0.12.10 (Oct 2017)
 ==================
 
 Bokeh Version ``0.12.10`` is an incremental update that adds a few important


### PR DESCRIPTION
probably a typo, `0.12.0` in document title should be `0.12.10`

- issues: fixes #7121
