### PR TITLE
Add JS script to correct element when showing plot

### DIFF
--- a/bokeh/core/_templates/autoload_nb_js.js
+++ b/bokeh/core/_templates/autoload_nb_js.js
@@ -63,7 +63,7 @@
     var toinsert = output_area.element.find(`.${CLASS_NAME.split(' ')[0]}`);
 
     if (output.metadata[EXEC_MIME_TYPE]["id"] !== undefined) {
-      toinsert[0].firstChild.textContent = output.data[JS_MIME_TYPE];
+      toinsert[toinsert.length - 1].firstChild.textContent = output.data[JS_MIME_TYPE];
       // store reference to embed id on output_area
       output_area._bokeh_element_id = output.metadata[EXEC_MIME_TYPE]["id"];
     }

--- a/bokeh/core/tests/test_templates.py
+++ b/bokeh/core/tests/test_templates.py
@@ -1,0 +1,23 @@
+import hashlib
+from os.path import abspath, join, split, pardir
+
+TOP_PATH = abspath(join(split(__file__)[0], pardir))
+
+
+def test_autoload_template_has_changed():
+    """This is not really a test but a reminder that if you change the 
+    autoload_nb_js.js template then you should make sure that insertion of
+    plots into notebooks is working as expected. In particular, this test was
+    created as part of https://github.com/bokeh/bokeh/issues/7125.
+    """
+    with open(join(TOP_PATH, '_templates/autoload_nb_js.js'), mode='rb') as f:
+        # compute a hash of the template and compare it against the
+        # last known hash
+        hash = hashlib.sha224(f.read()).hexdigest()
+        assert  hash == \
+        'dda19c5cb89b1ae6f10cdc24b052fa53738a1c31e654e5232e60ea59', \
+        """It seems that the template autoload_nb_js.js has changed. 
+        If this is voluntary and that proper testing of plots insertion 
+        in notebooks has been completed successfully, update this test
+         with this new file hash {}""".format(hash)
+

--- a/bokeh/core/tests/test_templates.py
+++ b/bokeh/core/tests/test_templates.py
@@ -1,22 +1,204 @@
-import hashlib
 from os.path import abspath, join, split, pardir
+
 
 TOP_PATH = abspath(join(split(__file__)[0], pardir))
 
+pinned_template = """{% extends "autoload_js.js" %}
 
+{% block register_mimetype %}
+
+  {%- if register_mime -%}
+  var JS_MIME_TYPE = 'application/javascript';
+  var HTML_MIME_TYPE = 'text/html';
+  var EXEC_MIME_TYPE = 'application/vnd.bokehjs_exec.v0+json';
+  var CLASS_NAME = 'output_bokeh rendered_html';
+
+  /**
+   * Render data to the DOM node
+   */
+  function render(props, node) {
+    var script = document.createElement("script");
+    node.appendChild(script);
+  }
+
+  /**
+   * Handle when an output is cleared or removed
+   */
+  function handleClearOutput(event, handle) {
+    var cell = handle.cell;
+
+    var id = cell.output_area._bokeh_element_id;
+    var server_id = cell.output_area._bokeh_server_id;
+    // Clean up Bokeh references
+    if (id !== undefined) {
+      Bokeh.index[id].model.document.clear();
+      delete Bokeh.index[id];
+    }
+
+    if (server_id !== undefined) {
+      // Clean up Bokeh references
+      var cmd = "from bokeh.io.state import curstate; print(curstate().uuid_to_server['" + server_id + "'].get_sessions()[0].document.roots[0]._id)";
+      cell.notebook.kernel.execute(cmd, {
+        iopub: {
+          output: function(msg) {
+            var element_id = msg.content.text.trim();
+            Bokeh.index[element_id].model.document.clear();
+            delete Bokeh.index[element_id];
+          }
+        }
+      });
+      // Destroy server and session
+      var cmd = "import bokeh.io.notebook as ion; ion.destroy_server('" + server_id + "')";
+      cell.notebook.kernel.execute(cmd);
+    }
+  }
+
+  /**
+   * Handle when a new output is added
+   */
+  function handleAddOutput(event, handle) {
+    var output_area = handle.output_area;
+    var output = handle.output;
+
+    // limit handleAddOutput to display_data with EXEC_MIME_TYPE content only
+    if ((output.output_type != "display_data") || (!output.data.hasOwnProperty(EXEC_MIME_TYPE))) {
+      return
+    }
+
+    var toinsert = output_area.element.find(`.${CLASS_NAME.split(' ')[0]}`);
+
+    if (output.metadata[EXEC_MIME_TYPE]["id"] !== undefined) {
+      toinsert[toinsert.length - 1].firstChild.textContent = output.data[JS_MIME_TYPE];
+      // store reference to embed id on output_area
+      output_area._bokeh_element_id = output.metadata[EXEC_MIME_TYPE]["id"];
+    }
+    if (output.metadata[EXEC_MIME_TYPE]["server_id"] !== undefined) {
+      var bk_div = document.createElement("div");
+      bk_div.innerHTML = output.data[HTML_MIME_TYPE];
+      var script_attrs = bk_div.children[0].attributes;
+      for (var i = 0; i < script_attrs.length; i++) {
+        toinsert[0].firstChild.setAttribute(script_attrs[i].name, script_attrs[i].value);
+      }
+      // store reference to server id on output_area
+      output_area._bokeh_server_id = output.metadata[EXEC_MIME_TYPE]["server_id"];
+    }
+  }
+
+  function register_renderer(events, OutputArea) {
+
+    function append_mime(data, metadata, element) {
+      // create a DOM node to render to
+      var toinsert = this.create_output_subarea(
+        metadata,
+        CLASS_NAME,
+        EXEC_MIME_TYPE
+      );
+      this.keyboard_manager.register_events(toinsert);
+      // Render to node
+      var props = {data: data, metadata: metadata[EXEC_MIME_TYPE]};
+      render(props, toinsert[0]);
+      element.append(toinsert);
+      return toinsert
+    }
+
+    /* Handle when an output is cleared or removed */
+    events.on('clear_output.CodeCell', handleClearOutput);
+    events.on('delete.Cell', handleClearOutput);
+
+    /* Handle when a new output is added */
+    events.on('output_added.OutputArea', handleAddOutput);
+
+    /**
+     * Register the mime type and append_mime function with output_area
+     */
+    OutputArea.prototype.register_mime_type(EXEC_MIME_TYPE, append_mime, {
+      /* Is output safe? */
+      safe: true,
+      /* Index of renderer in `output_area.display_order` */
+      index: 0
+    });
+  }
+
+  // register the mime type if in Jupyter Notebook environment and previously unregistered
+  if (root.Jupyter !== undefined) {
+    var events = require('base/js/events');
+    var OutputArea = require('notebook/js/outputarea').OutputArea;
+
+    if (OutputArea.prototype.mime_types().indexOf(EXEC_MIME_TYPE) == -1) {
+      register_renderer(events, OutputArea);
+    }
+  }
+  {%- endif -%}
+
+{% endblock %}
+
+{% block autoload_init %}
+  if (typeof (root._bokeh_timeout) === "undefined" || force === true) {
+    root._bokeh_timeout = Date.now() + {{ timeout|default(0)|json }};
+    root._bokeh_failed_load = false;
+  }
+
+  var NB_LOAD_WARNING = {'data': {'text/html':
+     "<div style='background-color: #fdd'>\\n"+
+     "<p>\\n"+
+     "BokehJS does not appear to have successfully loaded. If loading BokehJS from CDN, this \\n"+
+     "may be due to a slow or bad network connection. Possible fixes:\\n"+
+     "</p>\\n"+
+     "<ul>\\n"+
+     "<li>re-rerun `output_notebook()` to attempt to load from CDN again, or</li>\\n"+
+     "<li>use INLINE resources instead, as so:</li>\\n"+
+     "</ul>\\n"+
+     "<code>\\n"+
+     "from bokeh.resources import INLINE\\n"+
+     "output_notebook(resources=INLINE)\\n"+
+     "</code>\\n"+
+     "</div>"}};
+
+  function display_loaded() {
+    var el = document.getElementById({{ elementid|json }});
+    if (el != null) {
+      el.textContent = "BokehJS is loading...";
+    }
+    if (root.Bokeh !== undefined) {
+      if (el != null) {
+        el.textContent = "BokehJS " + root.Bokeh.version + " successfully loaded.";
+      }
+    } else if (Date.now() < root._bokeh_timeout) {
+      setTimeout(display_loaded, 100)
+    }
+  }
+{% endblock %}
+
+{% block run_inline_js %}
+    if ((root.Bokeh !== undefined) || (force === true)) {
+      for (var i = 0; i < inline_js.length; i++) {
+        inline_js[i].call(root, root.Bokeh);
+      }
+      {%- if elementid -%}
+      if (force === true) {
+        display_loaded();
+      }
+      {%- endif -%}
+    } else if (Date.now() < root._bokeh_timeout) {
+      setTimeout(run_inline_js, 100);
+    } else if (!root._bokeh_failed_load) {
+      console.log("Bokeh: BokehJS failed to load within specified timeout.");
+      root._bokeh_failed_load = true;
+    } else if (force !== true) {
+      var cell = $(document.getElementById({{ elementid|json }})).parents('.cell').data().cell;
+      cell.output_area.append_execute_result(NB_LOAD_WARNING)
+    }
+{% endblock %}
+"""  # noqa
 def test_autoload_template_has_changed():
     """This is not really a test but a reminder that if you change the
     autoload_nb_js.js template then you should make sure that insertion of
     plots into notebooks is working as expected. In particular, this test was
     created as part of https://github.com/bokeh/bokeh/issues/7125.
     """
-    with open(join(TOP_PATH, '_templates/autoload_nb_js.js'), mode='rb') as f:
-        # compute a hash of the template and compare it against the
-        # last known hash
-        hash = hashlib.sha224(f.read()).hexdigest()
-        assert  hash == \
-        'dda19c5cb89b1ae6f10cdc24b052fa53738a1c31e654e5232e60ea59', \
+    with open(join(TOP_PATH, '_templates/autoload_nb_js.js'), mode='r') as f:
+        assert pinned_template == f.read(), \
         """It seems that the template autoload_nb_js.js has changed.
         If this is voluntary and that proper testing of plots insertion
         in notebooks has been completed successfully, update this test
-         with this new file hash {}""".format(hash)
+        with the new file contents"""

--- a/bokeh/core/tests/test_templates.py
+++ b/bokeh/core/tests/test_templates.py
@@ -5,7 +5,7 @@ TOP_PATH = abspath(join(split(__file__)[0], pardir))
 
 
 def test_autoload_template_has_changed():
-    """This is not really a test but a reminder that if you change the 
+    """This is not really a test but a reminder that if you change the
     autoload_nb_js.js template then you should make sure that insertion of
     plots into notebooks is working as expected. In particular, this test was
     created as part of https://github.com/bokeh/bokeh/issues/7125.
@@ -16,8 +16,7 @@ def test_autoload_template_has_changed():
         hash = hashlib.sha224(f.read()).hexdigest()
         assert  hash == \
         'dda19c5cb89b1ae6f10cdc24b052fa53738a1c31e654e5232e60ea59', \
-        """It seems that the template autoload_nb_js.js has changed. 
-        If this is voluntary and that proper testing of plots insertion 
+        """It seems that the template autoload_nb_js.js has changed.
+        If this is voluntary and that proper testing of plots insertion
         in notebooks has been completed successfully, update this test
          with this new file hash {}""".format(hash)
-

--- a/bokeh/io/output.py
+++ b/bokeh/io/output.py
@@ -83,7 +83,9 @@ def output_file(filename, title="Bokeh Plot", mode="cdn", root_dir=None):
 @public((1,0,0))
 def output_notebook(resources=None, verbose=False, hide_banner=False, load_timeout=5000, notebook_type='jupyter'):
     ''' Configure the default output state to generate output in notebook cells
-    when :func:`show` is called.
+    when :func:`show` is called. Note that, :func:`show` may be called multiple
+    times in a single cell to display multiple objects in the output cell. The
+    objects will be displayed in order.
 
     Args:
         resources (Resource, optional) :

--- a/bokeh/io/showing.py
+++ b/bokeh/io/showing.py
@@ -41,6 +41,9 @@ from .state import curstate
 def show(obj, browser=None, new="tab", notebook_handle=False, notebook_url="localhost:8888"):
     ''' Immediately display a Bokeh object or application.
 
+        :func:`show` may be called multiple times in a single Jupyter notebook
+        cell to display multiple objects. The objects are displayed in order.
+
     Args:
         obj (LayoutDOM or Application) :
             A Bokeh object to display.

--- a/sphinx/source/docs/user_guide/notebook.rst
+++ b/sphinx/source/docs/user_guide/notebook.rst
@@ -18,6 +18,9 @@ the next notebook output cell. You can see a Jupyter screenshot below:
     :scale: 50 %
     :align: center
 
+Multiple plots can be displayed in a single notebook output cell by calling
+|show| multiple times in the input cell. The plots will be displayed in order.
+
 In order to embed Bokeh plots inside of JupyterLab, you need to install
 the "jupyterlab_bokeh" JupyterLab extension. This can be done by running
 the command: ``jupyter labextension install jupyterlab_bokeh``.


### PR DESCRIPTION
This PR makes it possible to correctly display multiple bokeh plots in a single jupyter notebook cell.

The array index was hard-coded as 0, meaning only first plot was properly added to notebook cell. Now, add JS script to more recently added bokeh element, so that multiple plots in the same cell will be embedded.

_I'm not sure how to add a test for this fix. I'd appreciate any help to add the appropriate tests._

- [x] issues: fixes #7125 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
