### PR TITLE
handle model=None for server_session

### DIFF
--- a/bokeh/embed/server.py
+++ b/bokeh/embed/server.py
@@ -121,8 +121,10 @@ def server_session(model, session_id, url="default", relative_urls=False, resour
         function for different or multiple page loads.
 
     Args:
-        model (Model) :
-            The object to render from the session
+        model (Model or None) :
+            The object to render from the session, or None.
+
+            If None, the entire document will be rendered.
 
         session_id (str) :
             A server session ID (default: None)
@@ -173,6 +175,7 @@ def server_session(model, session_id, url="default", relative_urls=False, resour
     app_path = _get_app_path(url)
 
     elementid = make_id()
+    modelid = "" if model is None else model._id
     src_path = _src_path(url, elementid)
 
     src_path += _process_app_path(app_path)
@@ -185,7 +188,7 @@ def server_session(model, session_id, url="default", relative_urls=False, resour
         src_path  = src_path,
         app_path  = app_path,
         elementid = elementid,
-        modelid   = model._id,
+        modelid   = modelid,
     )
 
     return encode_utf8(tag)

--- a/bokeh/embed/tests/test_server.py
+++ b/bokeh/embed/tests/test_server.py
@@ -209,6 +209,26 @@ class TestServerSession(object):
         r = bes.server_session(test_plot, session_id='fakesession', resources=None)
         assert 'resources=none' in r
 
+    def test_model_none(self):
+        r = bes.server_session(None, session_id='fakesession')
+        html = bs4.BeautifulSoup(r, "lxml")
+        scripts = html.findAll(name='script')
+        assert len(scripts) == 1
+        attrs = scripts[0].attrs
+        assert set(attrs), set([
+            'src',
+            'data-bokeh-doc-id',
+            'data-bokeh-model-id',
+            'id'
+        ])
+        divid = attrs['id']
+        src = "%s/autoload.js?bokeh-autoload-element=%s&bokeh-absolute-url=%s&bokeh-session-id=fakesession" % \
+              ("http://localhost:5006", divid, "http://localhost:5006")
+        assert attrs == { 'data-bokeh-doc-id' : '',
+                          'data-bokeh-model-id' : '',
+                          'id' : divid,
+                          'src' : src }
+
     def test_general(self, test_plot):
         r = bes.server_session(test_plot, session_id='fakesession')
         assert 'bokeh-session-id=fakesession' in r


### PR DESCRIPTION
- [x] issues: fixes #7128
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

Handling of `model=None` was broken in the `embed.py` refactor for `0.12.10`. This PR restores the capability and adds a unit test to explicitly test this use case.  

With the change so far, this code functions as expected:
```
bokeh serve sliders.py --allow-websocket-origin=localhost:8080
```

```
from flask import Flask, render_template

from bokeh.client import pull_session
from bokeh.embed import server_session

import bokeh
print(bokeh.__version__)

app = Flask(__name__)

@app.route('/', methods=['GET'])
def bkapp_page():
    session = pull_session(url="http://localhost:5006/sliders")
    script = server_session(None, session.id, url='http://localhost:5006/sliders')
    return render_template("embed.html", script=script, template="Flask")

if __name__ == '__main__':
    app.run(port=8080)
```

However, if a `session.push` is added to the flask app, the app renders but is unresponsive. I would like to resolve this issue in this PR before merging. *Update:* it appears this second problem was also present in `0.12.9`