### PR TITLE
Make slider handles updatable from arrow keys

### DIFF
--- a/bokehjs/src/coffee/models/widgets/abstract_slider.coffee
+++ b/bokehjs/src/coffee/models/widgets/abstract_slider.coffee
@@ -68,6 +68,27 @@ export class AbstractSliderView extends WidgetView
       @sliderEl.noUiSlider.on('slide',  (_, __, values) => @_slide(values))
       @sliderEl.noUiSlider.on('change', (_, __, values) => @_change(values))
 
+      # Add keyboard support
+      keypress = (e) =>
+        value = Number(@sliderEl.noUiSlider.get())
+        switch e.which
+          when 37
+            value -= step
+          when 39
+            value += step
+        pretty = @model.pretty(value)
+        logger.debug("[slider keypress] value = #{pretty}")
+        @model.value = value
+        @sliderEl.noUiSlider.set(value)
+        if @valueEl?
+          @valueEl.textContent = pretty
+        @callback_wrapper?()
+
+      handle = @sliderEl.querySelector(".#{prefix}handle")
+      handle.setAttribute('tabindex', 0)
+      handle.addEventListener('click', @focus)
+      handle.addEventListener('keydown', keypress)
+
       toggleTooltip = (i, show) =>
         handle = @sliderEl.querySelectorAll(".#{prefix}handle")[i]
         tooltip = handle.querySelector(".#{prefix}tooltip")

--- a/bokehjs/src/coffee/models/widgets/abstract_slider.coffee
+++ b/bokehjs/src/coffee/models/widgets/abstract_slider.coffee
@@ -78,7 +78,7 @@ export class AbstractSliderView extends WidgetView
             value += step
           else
             return
-            
+
         pretty = @model.pretty(value)
         logger.debug("[slider keypress] value = #{pretty}")
         @model.value = value

--- a/bokehjs/src/coffee/models/widgets/abstract_slider.coffee
+++ b/bokehjs/src/coffee/models/widgets/abstract_slider.coffee
@@ -76,6 +76,9 @@ export class AbstractSliderView extends WidgetView
             value -= step
           when 39
             value += step
+          else
+            return
+            
         pretty = @model.pretty(value)
         logger.debug("[slider keypress] value = #{pretty}")
         @model.value = value


### PR DESCRIPTION
- [x] issues: fixes #6862 

This was adapted from this [example](https://refreshless.com/nouislider/examples/#section-keyboard) in the nouislider documentation.

Tested this with the sliders example app and it works well, but I have yet to try this for sliders with multiple handles.

![image](https://i.imgur.com/0AqcuVq.gif)