### PR TITLE
note start/end of interactive periods on document

### DIFF
--- a/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
+++ b/bokehjs/src/coffee/models/renderers/glyph_renderer.coffee
@@ -175,7 +175,7 @@ export class GlyphRendererView extends RendererView
     inspected = (i for i in indices when @all_indices[i] in inspected)
 
     lod_threshold = @plot_model.plot.lod_threshold
-    if @plot_view.interactive and !glsupport and lod_threshold? and @all_indices.length > lod_threshold
+    if @model.document.interactive_duration() > 0 and !glsupport and lod_threshold? and @all_indices.length > lod_threshold
       # Render decimated during interaction if too many elements and not using GL
       indices = @decimated
       glyph = @decimated_glyph

--- a/bokehjs/src/coffee/models/tools/actions/zoom_in_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/actions/zoom_in_tool.coffee
@@ -17,7 +17,7 @@ export class ZoomInToolView extends ActionToolView
 
     @plot_view.push_state('zoom_out', {range: zoom_info})
     @plot_view.update_range(zoom_info, false, true)
-    @plot_view.interactive_timestamp = Date.now()
+    @model.document.interactive_start(@plot_model.plot)
     return null
 
 export class ZoomInTool extends ActionTool

--- a/bokehjs/src/coffee/models/tools/actions/zoom_out_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/actions/zoom_out_tool.coffee
@@ -18,7 +18,7 @@ export class ZoomOutToolView extends ActionToolView
 
     @plot_view.push_state('zoom_out', {range: zoom_info})
     @plot_view.update_range(zoom_info, false, true)
-    @plot_view.interactive_timestamp = Date.now()
+    @model.document.interactive_start(@plot_model.plot)
     return null
 
 export class ZoomOutTool extends ActionTool

--- a/bokehjs/src/coffee/models/tools/gestures/pan_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/gestures/pan_tool.coffee
@@ -17,12 +17,12 @@ export class PanToolView extends GestureToolView
         @v_axis_only = true
       if vy < vr.start or vy > vr.end
         @h_axis_only = true
-    @plot_view.interactive_timestamp = Date.now()
+    @model.document.interactive_start(@plot_model.plot)
 
   _pan: (e) ->
     # TODO (bev) get minus sign from canvas/frame
     @_update(e.deltaX, -e.deltaY)
-    @plot_view.interactive_timestamp = Date.now()
+    @model.document.interactive_start(@plot_model.plot)
 
   _pan_end: (e) ->
     @h_axis_only = false

--- a/bokehjs/src/coffee/models/tools/gestures/wheel_pan_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/gestures/wheel_pan_tool.coffee
@@ -56,7 +56,7 @@ export class WheelPanToolView extends GestureToolView
     }
     @plot_view.push_state('wheel_pan', {range: pan_info})
     @plot_view.update_range(pan_info, false, true)
-    @plot_view.interactive_timestamp = Date.now()
+    @model.document.interactive_start(@plot_model.plot)
     return null
 
 

--- a/bokehjs/src/coffee/models/tools/gestures/wheel_zoom_tool.coffee
+++ b/bokehjs/src/coffee/models/tools/gestures/wheel_zoom_tool.coffee
@@ -37,7 +37,7 @@ export class WheelZoomToolView extends GestureToolView
 
     @plot_view.push_state('wheel_zoom', {range: zoom_info})
     @plot_view.update_range(zoom_info, false, true)
-    @plot_view.interactive_timestamp = Date.now()
+    @model.document.interactive_start(@plot_model.plot)
     return null
 
 export class WheelZoomTool extends GestureTool

--- a/bokehjs/test/core/ui_events.coffee
+++ b/bokehjs/test/core/ui_events.coffee
@@ -38,18 +38,24 @@ describe "ui_events module", ->
       y_range: new Range1d({start: 0, end: 1})
       toolbar: @toolbar
     })
-    @plot_view = new @plot.default_view({model: @plot, parent: null})
     canvas.document.add_root(@plot)
+    @plot_view = new @plot.default_view({model: @plot, parent: null})
     @plot.plot_canvas.attach_document(canvas.document)
     @plot_canvas_view = new @plot.plot_canvas.default_view({ model: @plot.plot_canvas, parent: @plot_view })
     @ui_events = @plot_canvas_view.ui_event_bus
 
   describe "_trigger method", ->
 
+    afterEach ->
+      @spy_trigger.restore()
+
     beforeEach ->
       @spy_trigger = sinon.spy(@ui_events, "trigger")
 
     describe "base_type=move", ->
+
+      afterEach ->
+        @spy_cursor.restore()
 
       beforeEach ->
         @e = new Event("move")
@@ -170,6 +176,10 @@ describe "ui_events module", ->
 
     describe "base_type=scroll", ->
 
+      afterEach ->
+        @preventDefault.restore()
+        @stopPropagation.restore()
+
       beforeEach ->
         @e = new Event("scroll")
         @e.bokeh = {}
@@ -224,6 +234,7 @@ describe "ui_events module", ->
 
     afterEach ->
       @dom_stub.restore()
+      @spy.restore()
 
     beforeEach ->
       @dom_stub = sinon.stub(dom, "offset").returns({top: 0, left: 0})
@@ -266,6 +277,8 @@ describe "ui_events module", ->
 
     afterEach ->
       @dom_stub.restore()
+      @spy_plot.restore()
+      @spy_uievent.restore()
 
     beforeEach ->
       @dom_stub = sinon.stub(dom, "offset").returns({top: 0, left: 0})
@@ -319,7 +332,7 @@ describe "ui_events module", ->
 
       @ui_events._pan_start(e)
 
-      assert(@spy_plot.calledOnce)
+      assert(@spy_plot.called)
       assert(@spy_uievent.calledOnce)
 
     it "_pan method should handle pan event", ->
@@ -332,10 +345,10 @@ describe "ui_events module", ->
 
       @ui_events._pan(e)
 
-      assert(@spy_plot.calledOnce)
+      assert(@spy_plot.called)
       assert(@spy_uievent.calledOnce)
 
-    it "_pan_end method should handle pan event", ->
+    it "_pan_end method should handle pan end event", ->
       e = new Event("panend")
       e.pointerType = "mouse"
       e.srcEvent = {pageX: 100, pageY: 200}
@@ -451,7 +464,7 @@ describe "ui_events module", ->
 
       @ui_events._mouse_wheel(e)
 
-      assert(@spy_plot.calledOnce)
+      assert(@spy_plot.called)
       assert(@spy_uievent.calledOnce)
 
     # not implemented as tool method or BokehEvent

--- a/bokehjs/test/document.coffee
+++ b/bokehjs/test/document.coffee
@@ -197,6 +197,35 @@ describe "Document", ->
     d.add_root(new AnotherModel())
     expect(d.roots().length).to.equal 1
 
+  it "manages noting interactivity periods", ->
+    d = new Document()
+    expect(d._interactive_plot).to.be.null
+    expect(d._interactive_timestamp).to.be.null
+    expect(d.interactive_duration()).to.equal -1
+    stub = sinon.stub(Date, 'now')
+    stub.onCall(0).returns(10);
+    stub.onCall(1).returns(12);
+    stub.onCall(2).returns(15);
+    stub.onCall(3).returns(18);
+
+    m1 = new SomeModel()
+    m2 = new AnotherModel()
+
+    d.interactive_start(m1)  # first stub value 10
+    expect(d._interactive_plot.id).to.equal m1.id
+    expect(d._interactive_timestamp).to.be.equal 10
+    expect(d.interactive_duration()).to.be.equal 2 # second stub value 12
+
+    d.interactive_start(m2)  # third stub value 15
+    expect(d._interactive_plot.id).to.equal m1.id
+    expect(d._interactive_timestamp).to.be.equal 15
+    expect(d.interactive_duration()).to.be.equal 3 # second stub value 18
+
+    d.interactive_stop(m1)
+    expect(d._interactive_plot).to.be.null
+    expect(d._interactive_timestamp).to.be.null
+    expect(d.interactive_duration()).to.equal -1
+
   it "has working set_title", ->
     d = new Document()
     expect(d.title()).to.equal "Bokeh Application"

--- a/bokehjs/test/models/annotations/color_bar.coffee
+++ b/bokehjs/test/models/annotations/color_bar.coffee
@@ -81,6 +81,8 @@ describe "ColorBar module", ->
         describe "ColorBar.orientation = 'vertical' in plot frame", ->
 
           beforeEach ->
+            document = new Document()
+            document.add_root(@plot)
             @plot.add_layout(@color_bar)
 
           it "Should use set `width` and `height` if set", ->
@@ -116,9 +118,9 @@ describe "ColorBar module", ->
         describe "ColorBar.orientation = 'vertical' in side frame", ->
 
           beforeEach ->
-            @plot.add_layout(@color_bar, 'right')
             document = new Document()
             document.add_root(@plot)
+            @plot.add_layout(@color_bar, 'right')
 
           it "Should return height = plot.height - 2 * padding for any palette in side panel", ->
 
@@ -133,6 +135,8 @@ describe "ColorBar module", ->
         describe "ColorBar.orientation = 'horizontal'", ->
 
           beforeEach ->
+            document = new Document()
+            document.add_root(@plot)
             @color_bar.orientation = 'horizontal'
             @plot.add_layout(@color_bar)
 
@@ -170,10 +174,10 @@ describe "ColorBar module", ->
         describe "ColorBar.orientation = 'horizontal' in side frame", ->
 
           beforeEach ->
-            @color_bar.orientation = 'horizontal'
-            @plot.add_layout(@color_bar, 'below')
             document = new Document()
             document.add_root(@plot)
+            @color_bar.orientation = 'horizontal'
+            @plot.add_layout(@color_bar, 'below')
 
           it "Should return width = plot.width - 2 * padding for any palette in side panel", ->
             @color_bar.color_mapper = new LinearColorMapper({low: 1, high: 100, palette: Viridis.Viridis10})
@@ -187,6 +191,8 @@ describe "ColorBar module", ->
     describe "ColorBar.tick_info method", ->
 
       beforeEach ->
+        document = new Document()
+        document.add_root(@plot)
         @plot.add_layout(@color_bar)
         @lin_expected = new Float64Array([0, 20, 40, 60, 80, 100])
         @log_expected = new Float64Array([0, 76.70099985546604, 86.73533304426542, 92.60504167945479, 96.76966623306478, 100])
@@ -250,13 +256,14 @@ describe "ColorBar module", ->
       @_set_canvas_image_stub.restore()
 
     beforeEach ->
+      document = new Document()
+      document.add_root(@plot)
+
       @_set_canvas_image_stub = sinon.stub(ColorBarView.prototype, '_set_canvas_image')
 
       @color_bar.color_mapper = new LinearColorMapper({low: 0, high: 10, palette: Viridis.Viridis10})
 
       @plot.add_layout(@color_bar, 'right')
-      document = new Document()
-      document.add_root(@plot)
 
       @plot_canvas_view = new @plot.plot_canvas.default_view({model: @plot.plot_canvas, parent: @plot_view})
 

--- a/bokehjs/test/models/axes/axis.coffee
+++ b/bokehjs/test/models/axes/axis.coffee
@@ -93,8 +93,8 @@ describe "AxisView", ->
       toolbar: new Toolbar()
     })
     plot_view = new plot.default_view({model: plot, parent: null})
-    plot.add_layout(@axis, 'below')
     doc.add_root(plot)
+    plot.add_layout(@axis, 'below')
     plot_canvas_view = new plot.plot_canvas.default_view({model: plot.plot_canvas, parent: plot_view})
     sinon.stub(plot_canvas_view, 'update_constraints')
     @axis_view = new @axis.default_view({

--- a/bokehjs/test/models/graphs/graph_hit_test_policy.coffee
+++ b/bokehjs/test/models/graphs/graph_hit_test_policy.coffee
@@ -16,7 +16,7 @@ utils = require "../../utils"
 {GlyphRenderer} = utils.require("models/renderers/glyph_renderer")
 {GraphRenderer} = utils.require("models/renderers/graph_renderer")
 {ColumnDataSource} = utils.require("models/sources/column_data_source")
-
+{Document} = utils.require "document"
 
 describe "GraphHitTestPolicy", ->
 
@@ -27,11 +27,13 @@ describe "GraphHitTestPolicy", ->
 
   beforeEach ->
     utils.stub_canvas()
+    doc = new Document()
 
     @plot = new Plot({
        x_range: new Range1d({start: 0, end: 1})
        y_range: new Range1d({start: 0, end: 1})
     })
+    doc.add_root(@plot)
     @plot_view = new @plot.default_view({model: @plot, parent: null})
     @plot_canvas_view = new @plot.plot_canvas.default_view({model: @plot.plot_canvas, parent: @plot_view})
 


### PR DESCRIPTION
- [x] issues: fixes #5937
- [x] tests added / passed

This PR adds support for "linked" LOD by making the document centrally responsible to note the start/end/duration of interactive periods. This simplifies the code at the point of usage and allows for some simple unit tests to be added. 

With this work, LOD start/end events are only triggered on the plot that originated the interactive period. 

Here is an example script that can be used:
```
import numpy as np

from bokeh.plotting import figure, show, output_file
from bokeh.layouts import row

N = 4000
x = np.random.random(size=N) * 100
y = np.random.random(size=N) * 100
radii = np.random.random(size=N) * 1.5
colors = [
    "#%02x%02x%02x" % (int(r), int(g), 150) for r, g in zip(50+2*x, 30+2*y)
]

p0 = figure()

p0.scatter(x, y, radius=radii,
          fill_color=colors, fill_alpha=0.6,
          line_color=None)

x = np.random.random(size=N) * 100
y = np.random.random(size=N) * 100
radii = np.random.random(size=N) * 1.5
colors = [
    "#%02x%02x%02x" % (int(r), int(g), 150) for r, g in zip(50+2*x, 30+2*y)
]

p1 = figure(x_range=p0.x_range, y_range=p0.y_range)

p1.scatter(x, y, radius=radii,
          fill_color=colors, fill_alpha=0.6,
          line_color=None)

output_file("color_scatter.html", title="color_scatter.py example")

show(row(p0, p1))  # open a browser
```

There are further refinements that could be made in the future. In particular the same simple LOD threshold applies for all plots but this is not always ideal. In particular default settings do not trigger LOD on the second plot in the `vector.py` example, because the data size for the `multi_line` is small (92) even though the total number of points that make up those lines is much larger.