### PR TITLE
Update TypeScript to 2.6.1 and fix examples

### DIFF
--- a/bokehjs/examples/hover/hover.ts
+++ b/bokehjs/examples/hover/hover.ts
@@ -47,7 +47,7 @@ namespace HoverfulScatter {
     text_font_size: "5pt", text_baseline: "middle", text_align: "center"})
 
   const hover = p.toolbar.select_one(Bokeh.HoverTool)
-  hover.tooltips = (source, info) => {
+  hover.tooltips = (source: Bokeh.DataSource, info: Bokeh.HoverTooltipInfo) => {
     const ds = source as Bokeh.ColumnDataSource
     const div = document.createElement("div")
     div.style.width = "200px"

--- a/bokehjs/examples/tap/tap.ts
+++ b/bokehjs/examples/tap/tap.ts
@@ -48,7 +48,7 @@ namespace TappyScatter {
 
   const tap = p.toolbar.select_one(Bokeh.TapTool)
   tap.renderers = [circles]
-  tap.callback = (ds) => {
+  tap.callback = (ds: Bokeh.DataSource) => {
     const indices = ds.selected['1d'].indices
     if (indices.length == 1)
       console.log(`Selected index: ${indices[0]}`)

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -45,7 +45,7 @@
     "@types/through2": "^2.0.33",
     "jsdom": "^9.8.3",
     "websocket":"^1.0.22",
-    "typescript": "^2.5.3",
+    "typescript": "2.6.1",
     "tslib": "^1.6.0",
     "coffee-script": "^1.12.5",
     "detective": "^4.3.1",

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -6,7 +6,7 @@ import pytest
 import subprocess
 import signal
 
-from os.path import abspath, dirname, exists, join, split
+from os.path import dirname, exists, split
 
 from tests.plugins.utils import trace, info, fail, ok, red, warn, white
 from tests.plugins.phantomjs_screenshot import get_phantomjs_screenshot
@@ -14,8 +14,6 @@ from tests.plugins.image_diff import image_diff
 
 from bokeh.client import push_session
 from bokeh.command.util import build_single_handler_application
-
-from .utils import deal_with_output_cells
 
 @pytest.mark.examples
 def test_js_examples(js_example, example, report):
@@ -93,21 +91,6 @@ def test_server_examples(server_example, example, report, bokeh_server):
         else:
             _get_pdiff(example)
 
-
-### {{{ THIS IS BROKEN and all examples are skipped in examples.yaml
-@pytest.mark.examples
-def test_notebook_examples(notebook_example, example, jupyter_notebook, report):
-    if example.is_skip:
-        pytest.skip("skipping %s" % example.relpath)
-
-    notebook_port = pytest.config.option.notebook_port
-    url_path = join(*_get_path_parts(abspath(example.path)))
-    url = 'http://localhost:%d/notebooks/%s' % (notebook_port, url_path)
-    assert deal_with_output_cells(example.path), 'Notebook failed'
-    _assert_snapshot(example, url, 'notebook')
-    if not example.no_diff:
-        _get_pdiff(example)
-# }}}
 
 def _get_pdiff(example):
     img_path, ref_path, diff_path = example.img_path, example.ref_path, example.diff_path


### PR DESCRIPTION
Contrary to my previous understanding, "^2.6.1" means that only first number (major version) can't change. Given that TypeScript introduces breaking changes in minor versions, I locked its version to 2.6.1 and will update when new compilers are available.