### PR TITLE
Permit ColumnsStreamedEvent to accept DataFrames

### DIFF
--- a/bokeh/document/events.py
+++ b/bokeh/document/events.py
@@ -7,6 +7,10 @@ for :ref:`bokeh.events`.
 '''
 from __future__ import absolute_import
 
+from ..util.dependencies import import_optional
+
+pd = import_optional('pandas')
+
 class DocumentChangedEvent(object):
     ''' Base class for all internal events representing a change to a
     Bokeh Document.
@@ -346,7 +350,10 @@ class ColumnsStreamedEvent(DocumentPatchedEvent):
             column_source (ColumnDataSource) :
                 The data source to stream new data to.
 
-            data (dict) :
+            data (dict or DataFrame) :
+                New data to stream.
+
+                If a DataFrame, will be stored as ``{c: df[c] for c in df.columns}``
 
             rollover (int) :
                 A rollover limit. If the data source columns exceed this
@@ -365,10 +372,13 @@ class ColumnsStreamedEvent(DocumentPatchedEvent):
                 be executed in response to the change that triggered this
                 event. (default: None)
 
-
         '''
         super(ColumnsStreamedEvent, self).__init__(document, setter, callback_invoker)
         self.column_source = column_source
+
+        if pd and isinstance(data, pd.DataFrame):
+            data = {c: data[c] for c in data.columns}
+
         self.data = data
         self.rollover = rollover
 

--- a/bokeh/document/tests/test_events.py
+++ b/bokeh/document/tests/test_events.py
@@ -1,6 +1,7 @@
 import pytest
 
 from mock import patch
+import pandas as pd
 
 import bokeh.document.events as bde
 
@@ -268,6 +269,13 @@ class TestColumnsStreamedEvent(object):
         assert e.column_source is m
         assert e.data == dict(foo=1)
         assert e.rollover == 200
+
+    def test_pandas_data(self):
+        m = FakeModel()
+        df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
+        e = bde.ColumnsStreamedEvent("doc", m, df, 200, "setter", "invoker")
+        assert isinstance(e.data, dict)
+        assert e.data == {c: df[c] for c in df.columns}
 
 # ColumnsPatchedEvent ---------------------------------------------------------
 


### PR DESCRIPTION
When calling CDS stream with DataFrames, the DataFrame would make it all the way to the `ColumnsStreamedEvent`, which presented it as-is for JSON encoding. This fails because DataFrames are not directly JSON serializable.

For compartmentalization and ease of testing, the issue is resolved by teaching `ColumnsStreamedEvent` how to convert DataFrames to the appropriate serializable dict itself. Other possible solutions not pursued at this time:

* ensure `ColumnsStreamedEvent` only ever receives a dict (higher level)
* teach the Bokeh JSON encoder how to handle DataFrames (lower level)

- [x] issues: fixes #7184
- [x] tests added / passed
- [x] release document entry (if new feature or API change)
