### PR TITLE
Change css_classes property type to List

### DIFF
--- a/bokeh/models/layouts.py
+++ b/bokeh/models/layouts.py
@@ -58,10 +58,14 @@ class LayoutDOM(Model):
 
     """)
 
-    css_classes = Seq(String, help="""
+    # List in order for in-place changes to trigger changes, ref: https://github.com/bokeh/bokeh/issues/6841
+    css_classes = List(String, help="""
     A list of css class names to add to this DOM element. Note: the class names are
     simply added as-is, no other guarantees are provided.
-    """)
+
+    It is also permissible to assign from tuples, however these are adapted -- the
+    property will always contain a list.
+    """).accepts(Seq(String), lambda x: list(x))
 
 
 class Spacer(LayoutDOM):

--- a/bokeh/models/tests/test_layouts.py
+++ b/bokeh/models/tests/test_layouts.py
@@ -1,6 +1,6 @@
 import pytest
 from bokeh.plotting import Figure
-from bokeh.models.layouts import Row, Column, WidgetBox
+from bokeh.models.layouts import Row, Column, WidgetBox, LayoutDOM
 from bokeh.models.widgets import Slider
 from bokeh.models.sources import ColumnDataSource
 
@@ -76,3 +76,11 @@ def check_widget_box_children_prop(layout_callable):
 def test_WidgetBox():
     check_props(WidgetBox())
     check_widget_box_children_prop(WidgetBox)
+
+def test_LayoutDOM_css_classes():
+    m = LayoutDOM()
+    assert m.css_classes == []
+    m.css_classes = ['foo']
+    assert m.css_classes == ['foo']
+    m.css_classes = ('bar', )
+    assert m.css_classes == ['bar']

--- a/bokehjs/src/coffee/models/layouts/layout_dom.coffee
+++ b/bokehjs/src/coffee/models/layouts/layout_dom.coffee
@@ -426,5 +426,5 @@ export class LayoutDOM extends Model
       width:       [ p.Number              ]
       disabled:    [ p.Bool,       false   ]
       sizing_mode: [ p.SizingMode, "fixed" ]
-      css_classes: [ p.Array               ]
+      css_classes: [ p.Array,      []      ]
     }


### PR DESCRIPTION
In order for in place updates such as `.append` to properly trigger events, the property type must be `List` (so that `PropertyValueList` is used to wrap the value). This PR changes the type to `List`, but also adds an `accept` clause so that setting from tuples, etc. still functions.


- [x] issues: fixes #6841
- [x] tests added / passed
- [x] release document entry (if new feature or API change)
