### PR TITLE
Missing import of logger in toolbar.coffee

### DIFF
--- a/bokehjs/src/coffee/models/tools/toolbar.coffee
+++ b/bokehjs/src/coffee/models/tools/toolbar.coffee
@@ -1,5 +1,6 @@
 import * as p from "core/properties"
 import {any, sortBy} from "core/util/array"
+import {logger} from "core/logging"
 
 import {ActionTool} from "./actions/action_tool"
 import {HelpTool} from "./actions/help_tool"


### PR DESCRIPTION
Missing import of logger.
https://github.com/bokeh/bokeh/edit/master/bokehjs/src/coffee/models/tools/toolbar.coffee#L35
Error is logged if event_type does not match and therefore a Reference error was raised because of the missing import.
