### PR TITLE
Adding additional information in the multi_line() documentation

### DIFF
--- a/sphinx/source/docs/user_guide/plotting.rst
+++ b/sphinx/source/docs/user_guide/plotting.rst
@@ -92,7 +92,13 @@ accomplished with the |multi_line| glyph method:
 
 .. note::
     This glyph is unlike most other glyphs. Instead of accepting a one
-    dimensional list or array of scalar values, it accepts a "list of lists".
+    dimensional list or array of scalar values, it accepts a "list of lists"
+    for x and y positions of each line, parameters xs and ys. multi_line  
+    also expects a scalar value or a list of scalers per each line for 
+    parameters such as color, alpha, linewidth, etc. Similarily, a 
+    ColumnDataSource may be used consisting of a "list of lists" and a
+    lists of scalars where the length of the list of scalars and length of
+    lists must match.
 
 Missing Points
 ''''''''''''''


### PR DESCRIPTION
The notice was a little unclear in how to use  CDS formatted for multi_line (#7198). Adding another example source code may help as well.


- [ X] issues: fixes #7198
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
