### PR TITLE
Remove unsupported-by-IE11 template string (see #7212).

### DIFF
--- a/bokeh/core/_templates/autoload_nb_js.js
+++ b/bokeh/core/_templates/autoload_nb_js.js
@@ -60,7 +60,7 @@
       return
     }
 
-    var toinsert = output_area.element.find(`.${CLASS_NAME.split(' ')[0]}`);
+    var toinsert = output_area.element.find("." + CLASS_NAME.split(' ')[0]);
 
     if (output.metadata[EXEC_MIME_TYPE]["id"] !== undefined) {
       toinsert[0].firstChild.textContent = output.data[JS_MIME_TYPE];


### PR DESCRIPTION
Screenshot shows bokeh now successfully loading in notebook in IE11:

<img width="906" alt="screen shot 2017-11-15 at 5 14 55 pm" src="https://user-images.githubusercontent.com/1929/32850452-19a7e5d0-ca2a-11e7-9713-f4e71d0e3864.png">

- [x] issues: fixes #7212
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

I haven't yet run any other tests.