### PR TITLE
Add support for IE 11 and Edge 14 to canvas image smoothing fixups; fixes #7213.

### DIFF
--- a/bokehjs/src/coffee/core/util/canvas.coffee
+++ b/bokehjs/src/coffee/core/util/canvas.coffee
@@ -21,6 +21,7 @@ fixup_image_smoothing = (ctx) ->
     ctx.mozImageSmoothingEnabled = value
     ctx.oImageSmoothingEnabled = value
     ctx.webkitImageSmoothingEnabled = value
+    ctx.msImageSmoothingEnabled = value
   ctx.getImageSmoothingEnabled = () ->
     return ctx.imageSmoothingEnabled ? true
 


### PR DESCRIPTION
(Depends on #7220) 

IE11 screenshot:

<img width="906" alt="screen shot 2017-11-15 at 5 14 55 pm" src="https://user-images.githubusercontent.com/1929/32850557-68ac08d2-ca2a-11e7-9b15-26862bd4c5ea.png">


- [x] issues: fixes #7213 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
