### PR TITLE
Missing figure import on graph network example

### DIFF
--- a/sphinx/source/docs/user_guide/graph.rst
+++ b/sphinx/source/docs/user_guide/graph.rst
@@ -40,7 +40,7 @@ Here's a code snippet that:
 .. code-block:: python
 
     import math
-
+    from bokeh.plotting import figure
     from bokeh.models import GraphRenderer, Oval
     from bokeh.palettes import Spectral8
 


### PR DESCRIPTION
Fixes missing figure import on graph network example.

https://bokeh.pydata.org/en/latest/docs/user_guide/graph.html#edge-and-node-renderers



- [ X] issues: fixes #7240
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
