### PR TITLE
Use HTTPS to get tiles from CartoDB

### DIFF
--- a/bokeh/tests/test_tile_providers.py
+++ b/bokeh/tests/test_tile_providers.py
@@ -50,8 +50,8 @@ ALL = (
 )
 
 _CARTO_URLS = {
-    'CARTODBPOSITRON':        'http://tiles.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
-    'CARTODBPOSITRON_RETINA': 'http://tiles.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png',
+    'CARTODBPOSITRON':        'https://tiles.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
+    'CARTODBPOSITRON_RETINA': 'https://tiles.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png',
 }
 
 _STAMEN_URLS = {
@@ -63,11 +63,11 @@ _STAMEN_URLS = {
 }
 
 _STAMEN_LIC = {
-    'STAMEN_TERRAIN':          '<a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>',
-    'STAMEN_TERRAIN_RETINA':   '<a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>',
-    'STAMEN_TONER':            '<a href="http://www.openstreetmap.org/copyright">ODbL</a>',
-    'STAMEN_TONER_BACKGROUND': '<a href="http://www.openstreetmap.org/copyright">ODbL</a>',
-    'STAMEN_TONER_LABELS':     '<a href="http://www.openstreetmap.org/copyright">ODbL</a>',
+    'STAMEN_TERRAIN':          '<a href="https://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>',
+    'STAMEN_TERRAIN_RETINA':   '<a href="https://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>',
+    'STAMEN_TONER':            '<a href="https://www.openstreetmap.org/copyright">ODbL</a>',
+    'STAMEN_TONER_BACKGROUND': '<a href="https://www.openstreetmap.org/copyright">ODbL</a>',
+    'STAMEN_TONER_LABELS':     '<a href="https://www.openstreetmap.org/copyright">ODbL</a>',
 }
 
 #-----------------------------------------------------------------------------
@@ -89,9 +89,9 @@ class Test_StamenProviders(object):
     def test_attribution(self, name):
         p = getattr(bt, name)
         assert p.attribution == (
-            'Map tiles by <a href="http://stamen.com">Stamen Design</a>, '
-            'under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. '
-            'Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, '
+            'Map tiles by <a href="https://stamen.com">Stamen Design</a>, '
+            'under <a href="https://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. '
+            'Data by <a href="https://openstreetmap.org">OpenStreetMap</a>, '
             'under %s.'
         ) % _STAMEN_LIC[name]
 
@@ -113,7 +113,7 @@ class Test_CartoProviders(object):
     def test_attribution(self, name):
         p = getattr(bt, name)
         assert p.attribution == (
-            '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors,'
+            '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors,'
             '&copy; <a href="https://cartodb.com/attributions">CartoDB</a>'
         )
 

--- a/bokeh/tile_providers.py
+++ b/bokeh/tile_providers.py
@@ -15,14 +15,14 @@ Attributes:
 
         .. raw:: html
 
-            <img src="http://tiles.basemaps.cartocdn.com/light_all/14/2627/6331.png" />
+            <img src="https://tiles.basemaps.cartocdn.com/light_all/14/2627/6331.png" />
 
     CARTODBPOSITRON_RETINA
         Tile Source for CartoDB Tile Service (tiles at 'retina' resolution)
 
         .. raw:: html
 
-            <img src="http://tiles.basemaps.cartocdn.com/light_all/14/2627/6331@2x.png" />
+            <img src="https://tiles.basemaps.cartocdn.com/light_all/14/2627/6331@2x.png" />
 
     STAMEN_TERRAIN
         Tile Source for Stamen Terrain Service
@@ -109,14 +109,14 @@ import types
 class _TileProvidersModule(types.ModuleType):
 
     _CARTO_ATTRIBUTION = (
-        '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors,'
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors,'
         '&copy; <a href="https://cartodb.com/attributions">CartoDB</a>'
     )
 
     _STAMEN_ATTRIBUTION = (
-        'Map tiles by <a href="http://stamen.com">Stamen Design</a>, '
-        'under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. '
-        'Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, '
+        'Map tiles by <a href="https://stamen.com">Stamen Design</a>, '
+        'under <a href="https://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. '
+        'Data by <a href="https://openstreetmap.org">OpenStreetMap</a>, '
         'under %s.'
     )
 
@@ -124,7 +124,7 @@ class _TileProvidersModule(types.ModuleType):
     def CARTODBPOSITRON(self):
         from bokeh.models.tiles import WMTSTileSource
         return WMTSTileSource(
-            url='http://tiles.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
+            url='https://tiles.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
             attribution=self._CARTO_ATTRIBUTION
         )
 
@@ -132,7 +132,7 @@ class _TileProvidersModule(types.ModuleType):
     def CARTODBPOSITRON_RETINA(self):
         from bokeh.models.tiles import WMTSTileSource
         return WMTSTileSource(
-            url='http://tiles.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png',
+            url='https://tiles.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png',
             attribution=self._CARTO_ATTRIBUTION
         )
 
@@ -141,7 +141,7 @@ class _TileProvidersModule(types.ModuleType):
         from bokeh.models.tiles import WMTSTileSource
         return WMTSTileSource(
             url='http://tile.stamen.com/terrain/{Z}/{X}/{Y}.png',
-            attribution=self._STAMEN_ATTRIBUTION % '<a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>'
+            attribution=self._STAMEN_ATTRIBUTION % '<a href="https://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>'
         )
 
     @property
@@ -149,7 +149,7 @@ class _TileProvidersModule(types.ModuleType):
         from bokeh.models.tiles import WMTSTileSource
         return WMTSTileSource(
             url='http://tile.stamen.com/terrain/{Z}/{X}/{Y}@2x.png',
-            attribution=self._STAMEN_ATTRIBUTION % '<a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>'
+            attribution=self._STAMEN_ATTRIBUTION % '<a href="https://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>'
         )
 
     @property
@@ -157,7 +157,7 @@ class _TileProvidersModule(types.ModuleType):
         from bokeh.models.tiles import WMTSTileSource
         return WMTSTileSource(
             url='http://tile.stamen.com/toner/{Z}/{X}/{Y}.png',
-            attribution=self._STAMEN_ATTRIBUTION % '<a href="http://www.openstreetmap.org/copyright">ODbL</a>'
+            attribution=self._STAMEN_ATTRIBUTION % '<a href="https://www.openstreetmap.org/copyright">ODbL</a>'
         )
 
     @property
@@ -165,7 +165,7 @@ class _TileProvidersModule(types.ModuleType):
         from bokeh.models.tiles import WMTSTileSource
         return WMTSTileSource(
             url='http://tile.stamen.com/toner-background/{Z}/{X}/{Y}.png',
-            attribution=self._STAMEN_ATTRIBUTION % '<a href="http://www.openstreetmap.org/copyright">ODbL</a>'
+            attribution=self._STAMEN_ATTRIBUTION % '<a href="https://www.openstreetmap.org/copyright">ODbL</a>'
         )
 
     @property
@@ -173,7 +173,7 @@ class _TileProvidersModule(types.ModuleType):
         from bokeh.models.tiles import WMTSTileSource
         return WMTSTileSource(
             url='http://tile.stamen.com/toner-labels/{Z}/{X}/{Y}.png',
-            attribution=self._STAMEN_ATTRIBUTION % '<a href="http://www.openstreetmap.org/copyright">ODbL</a>'
+            attribution=self._STAMEN_ATTRIBUTION % '<a href="https://www.openstreetmap.org/copyright">ODbL</a>'
         )
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
I took the opportunity to update the URLs to https in the attributions as well.
I haven't changed the URL to the stamen tiles. They seem to be available through https but the certificate is invalid which results in browser showing an error message.

- [x] issues: fixes #3551
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
