### PR TITLE
add missing return statements to get_indices TypeScript version

### DIFF
--- a/bokehjs/src/coffee/core/util/selection.ts
+++ b/bokehjs/src/coffee/core/util/selection.ts
@@ -2,11 +2,11 @@ export function get_indices(data_source: any): any {
   const selected = data_source.selected
 
   if (selected['0d'].glyph)
-    selected['0d'].indices
+    return selected['0d'].indices
   else if (selected['1d'].indices.length > 0)
-    selected['1d'].indices
+    return selected['1d'].indices
   else if (selected['2d'].indices.length > 0)
-    selected['2d'].indices
+    return selected['2d'].indices
   else
-    []
+    return []
 }


### PR DESCRIPTION
Function always returned `undefined` due to missing `return` statements, caused `OpenURL` to fail.
