### PR TITLE
Added snap_to_zoom option for MercatorTileSource

### DIFF
--- a/bokeh/models/tiles.py
+++ b/bokeh/models/tiles.py
@@ -68,6 +68,10 @@ class MercatorTileSource(TileSource):
 
     initial_resolution = Override(default=156543.03392804097)
 
+    snap_to_zoom = Bool(default=True, help="""
+    Enables snapping of extents to the closest zoom level.
+    """)
+
     wrap_around = Bool(default=True, help="""
     Enables continuous horizontal panning by wrapping the x-axis based on
     bounds of map.

--- a/bokeh/models/tiles.py
+++ b/bokeh/models/tiles.py
@@ -68,9 +68,8 @@ class MercatorTileSource(TileSource):
 
     initial_resolution = Override(default=156543.03392804097)
 
-    snap_to_zoom = Bool(default=True, help="""
-    Enables snapping of extents to the closest zoom level.
-    """)
+    snap_to_zoom = Bool(default=False, help="""
+    Forces initial extents to snap to the closest larger zoom level.""")
 
     wrap_around = Bool(default=True, help="""
     Enables continuous horizontal panning by wrapping the x-axis based on

--- a/bokehjs/src/coffee/models/tiles/mercator_tile_source.coffee
+++ b/bokehjs/src/coffee/models/tiles/mercator_tile_source.coffee
@@ -5,7 +5,7 @@ export class MercatorTileSource extends TileSource
   type: 'MercatorTileSource'
 
   @define {
-    snap_to_zoom:       [ p.Bool,   true               ]
+    snap_to_zoom:       [ p.Bool,   false              ]
     wrap_around:        [ p.Bool,   true               ]
   }
 

--- a/bokehjs/src/coffee/models/tiles/mercator_tile_source.coffee
+++ b/bokehjs/src/coffee/models/tiles/mercator_tile_source.coffee
@@ -5,6 +5,7 @@ export class MercatorTileSource extends TileSource
   type: 'MercatorTileSource'
 
   @define {
+    snap_to_zoom:       [ p.Bool,   true               ]
     wrap_around:        [ p.Bool,   true               ]
   }
 
@@ -111,12 +112,20 @@ export class MercatorTileSource extends TileSource
       return previous
     return @_resolutions.indexOf(closest)
 
-  snap_to_zoom: (extent, height, width, level) ->
+  snap_to_zoom_level: (extent, height, width, level) ->
+    [xmin, ymin, xmax, ymax] = extent
     desired_res = @_resolutions[level]
     desired_x_delta = width * desired_res
     desired_y_delta = height * desired_res
-
-    [xmin, ymin, xmax, ymax] = extent
+    if !@snap_to_zoom
+      xscale = (xmax-xmin)/desired_x_delta
+      yscale = (ymax-ymin)/desired_y_delta
+      if xscale > yscale
+        desired_x_delta = (xmax-xmin)
+        desired_y_delta = desired_y_delta*xscale
+      else
+        desired_x_delta = desired_x_delta*yscale
+        desired_y_delta = (ymax-ymin)
     x_adjust = (desired_x_delta - (xmax - xmin)) / 2
     y_adjust = (desired_y_delta - (ymax - ymin)) / 2
 

--- a/bokehjs/src/coffee/models/tiles/tile_renderer.coffee
+++ b/bokehjs/src/coffee/models/tiles/tile_renderer.coffee
@@ -60,7 +60,7 @@ export class TileRendererView extends RendererView
   _map_data: () ->
     @initial_extent = @get_extent()
     zoom_level = @model.tile_source.get_level_by_extent(@initial_extent, @map_frame._height.value, @map_frame._width.value)
-    new_extent = @model.tile_source.snap_to_zoom(@initial_extent, @map_frame._height.value, @map_frame._width.value, zoom_level)
+    new_extent = @model.tile_source.snap_to_zoom_level(@initial_extent, @map_frame._height.value, @map_frame._width.value, zoom_level)
     @x_range.start = new_extent[0]
     @y_range.start = new_extent[1]
     @x_range.end = new_extent[2]
@@ -120,7 +120,7 @@ export class TileRendererView extends RendererView
     if @_last_height != @map_frame._height.value or @_last_width != @map_frame._width.value
       extent = @get_extent()
       zoom_level = @model.tile_source.get_level_by_extent(extent, @map_frame._height.value, @map_frame._width.value)
-      new_extent = @model.tile_source.snap_to_zoom(extent, @map_frame._height.value, @map_frame._width.value, zoom_level)
+      new_extent = @model.tile_source.snap_to_zoom_level(extent, @map_frame._height.value, @map_frame._width.value, zoom_level)
       @x_range.setv({start:new_extent[0], end: new_extent[2]})
       @y_range.setv({start:new_extent[1], end: new_extent[3]})
       @extent = new_extent

--- a/bokehjs/test/models/tiles/tile_renderer.coffee
+++ b/bokehjs/test/models/tiles/tile_renderer.coffee
@@ -277,6 +277,21 @@ describe "tile sources", ->
       source = new MercatorTileSource(tile_options)
       expect(source.is_valid_tile(-1, 1, 1)).to.be.eql(false)
 
+    it "should not snap_to_zoom_level", ->
+      bounds = source.snap_to_zoom_level(T.MERCATOR_BOUNDS, 400, 400, 2)
+      expect(bounds[0]).to.be.closeTo(T.MERCATOR_BOUNDS[0], tol)
+      expect(bounds[1]).to.be.closeTo(T.MERCATOR_BOUNDS[1], tol)
+      expect(bounds[2]).to.be.closeTo(T.MERCATOR_BOUNDS[2], tol)
+      expect(bounds[3]).to.be.closeTo(T.MERCATOR_BOUNDS[3], tol)
+
+    it "should snap_to_zoom_level", ->
+      source = new MercatorTileSource({snap_to_zoom: true})
+      bounds = source.snap_to_zoom_level(T.MERCATOR_BOUNDS, 400, 400, 2)
+      expect(bounds[0]).to.be.closeTo(-7827151.69, tol)
+      expect(bounds[1]).to.be.closeTo(-7827151.69, tol)
+      expect(bounds[2]).to.be.closeTo(7827151.69, tol)
+      expect(bounds[3]).to.be.closeTo(7827151.69, tol)
+
     it "should get best zoom level based on extent and height/width", ->
       expect(source.get_level_by_extent(T.MERCATOR_BOUNDS, 256, 256)).to.be.equal(0)
       expect(source.get_level_by_extent(T.MERCATOR_BOUNDS, 512, 512)).to.be.equal(1)

--- a/sphinx/source/docs/releases/0.12.14.rst
+++ b/sphinx/source/docs/releases/0.12.14.rst
@@ -1,7 +1,31 @@
 0.12.14 (Dec 2017)
 ==================
 
-Bokeh Version ``0.12.14`` is
+Bokeh Version ``0.12.14`` is an incremental update that adds a few
+important features and fixes several bugs. Some of the highlights
+include:
 
 
-For full details see the :bokeh-tree:`CHANGELOG`.
+Many other small bugfixes and docs additions. For full details see the
+:bokeh-tree:`CHANGELOG`.
+
+Migration Guide
+---------------
+
+NOTE: the 0.12.x series is the last planned release series before a version
+1.0 release. For more information see the `project roadmap`_.
+
+MercatorTileSource change
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+`MercatorTileSource` models previously snapped to the closest zoom
+level resulting in user supplied axis ranges to be largely
+ignored. The default behavior has now been changed from snapping to
+the closest zoom level to simply maintaining the correct aspect ratio,
+while keeping the user defined bounds contained within the axis
+ranges.
+
+The old behavior may be restored by setting enabling the `snap_to_zoom`
+property.
+
+.. _project roadmap: https://bokehplots.com/pages/roadmap.html


### PR DESCRIPTION
As discussed in https://github.com/bokeh/bokeh/issues/6655 and https://github.com/bokeh/bokeh/issues/5126, when using a map tile source the plot will snap to the nearest zoom level, which is not always desirable and often makes it very difficult to initialize the plot to a reasonable zoom range.

This PR adds an option called ``snap_to_zoom`` to the ``MercatorTileSource`` which disables this behavior and instead simply tries to maintain the appropriate aspect ratio. It does this by finding the supplied range which is closest to the next zoom level and then adjusts the other range by scaling it as a fraction of the range of the closest zoom level. In my testing this produces much better results overall, but I've left the option set to True by default to maintain backward compatibility.

Here is a before and after comparison. I've added two points to the plot which also correspond to the lower and upper bounds for each axis. As you can see the default (and current) behavior result in a suboptimal plot:

<img width="604" alt="screen shot 2017-12-07 at 7 36 43 pm" src="https://user-images.githubusercontent.com/1550771/33735022-ff03d956-db85-11e7-9e32-902ea877470c.png">

When we disable the ``snap_to_zoom`` option we can see that it still maintains the aspect but now tries to respect the extents as much as possible:

<img width="600" alt="screen shot 2017-12-07 at 7 36 34 pm" src="https://user-images.githubusercontent.com/1550771/33735090-3c972f48-db86-11e7-9a00-e0233b88feb3.png">

Before going further down this path it would be great to get your feedback @bryevdv. Personally I think this behavior is much preferable over the default behavior but I didn't want to unilaterally change default behavior. I also think this is preferable over respecting user supplied ranges even if they distort aspect because that's never a good thing to do. However we could consider allowing that by adding a ``snap_extents`` parameter instead, with 'zoom', 'aspect' and ``None`` options. 

- [x] issues: fixes #xxxx
- [x] tests added / passed
- [x] release document entry (if new feature or API change)
