### PR TITLE
Fix for themes in notebooks

### DIFF
--- a/bokeh/embed/notebook.py
+++ b/bokeh/embed/notebook.py
@@ -112,17 +112,17 @@ def _ModelInEmptyDocument(model, apply_theme=None):
     from ..document import Document
     doc = find_existing_docs([model])
 
-    if apply_theme is FromCurdoc:
-        from ..io import curdoc; curdoc
-        doc.theme = curdoc().theme
-    elif apply_theme is not None:
-        doc.theme = apply_theme
-
     model._document = None
     for ref in model.references():
         ref._document = None
     new_doc = Document()
     new_doc.add_root(model)
+
+    if apply_theme is FromCurdoc:
+        from ..io import curdoc; curdoc
+        new_doc.theme = curdoc().theme
+    elif apply_theme is not None:
+        new_doc.theme = apply_theme
 
     if settings.perform_document_validation():
         new_doc.validate()


### PR DESCRIPTION

This PR proposes a small change that seems to fix the issue described in #7319 where bokeh themes fail to apply in the notebook environment. 

I've had this diff outstanding for a while in my local copy of bokeh and I have not yet noticed any issues in other contexts (e.g bokeh server). That said, here might be other implications/issues that I am currently unaware of so maybe this simple fix isn't sufficient.