### PR TITLE
delay match_aspect adjustment

### DIFF
--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -656,6 +656,10 @@ class Plot(LayoutDOM):
         setting only sets the initial plot draw and subsequent resets. It is
         possible for tools (single axis zoom, unconstrained box zoom) to
         change the aspect ratio.
+
+    .. warning::
+        This setting is incompatible with linking dataranges across multiple
+        plots. Doing so may result in undefined behaviour.
     """)
 
     aspect_scale = Float(default=1, help="""

--- a/bokehjs/src/coffee/models/plots/plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.coffee
@@ -216,8 +216,6 @@ export class PlotCanvasView extends DOMView
     follow_enabled = false
     has_bounds = false
 
-    unioned_bounds =
-
     r = null
     if @model.plot.match_aspect != false and @frame._width.value != 0 and @frame._height.value != 0
       r = 1/@model.plot.aspect_scale*(@frame._width.value/@frame._height.value)

--- a/bokehjs/src/coffee/models/plots/plot_canvas.coffee
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.coffee
@@ -216,35 +216,16 @@ export class PlotCanvasView extends DOMView
     follow_enabled = false
     has_bounds = false
 
+    unioned_bounds =
+
+    r = null
     if @model.plot.match_aspect != false and @frame._width.value != 0 and @frame._height.value != 0
       r = 1/@model.plot.aspect_scale*(@frame._width.value/@frame._height.value)
-      for k, v of bounds
-        if isFinite(v.maxX) and isFinite(v.minX) and isFinite(v.maxY) and isFinite(v.minY)
-          width = v.maxX - v.minX
-          if width <= 0
-            width = 1.0
-
-          height = v.maxY - v.minY
-          if height <= 0
-            height = 1.0
-
-          xcenter = 0.5*(v.maxX + v.minX)
-          ycenter = 0.5*(v.maxY + v.minY)
-
-          if width < r*height
-            width = r*height
-          else
-            height = width/r
-
-          bounds[k].maxX = xcenter+0.5*width
-          bounds[k].minX = xcenter-0.5*width
-          bounds[k].maxY = ycenter+0.5*height
-          bounds[k].minY = ycenter-0.5*height
 
     for xr in values(frame.x_ranges)
       if xr instanceof DataRange1d
         bounds_to_use = if xr.scale_hint == "log" then log_bounds else bounds
-        xr.update(bounds_to_use, 0, @model.id)
+        xr.update(bounds_to_use, 0, @model.id, r)
         if xr.follow
           follow_enabled = true
       has_bounds = true if xr.bounds?
@@ -252,7 +233,7 @@ export class PlotCanvasView extends DOMView
     for yr in values(frame.y_ranges)
       if yr instanceof DataRange1d
         bounds_to_use = if yr.scale_hint == "log" then log_bounds else bounds
-        yr.update(bounds_to_use, 1, @model.id)
+        yr.update(bounds_to_use, 1, @model.id, r)
         if yr.follow
           follow_enabled = true
       has_bounds = true if yr.bounds?

--- a/bokehjs/src/coffee/models/ranges/data_range1d.ts
+++ b/bokehjs/src/coffee/models/ranges/data_range1d.ts
@@ -93,8 +93,8 @@ export class DataRange1d extends DataRange {
     return result
   }
 
-   adjust_bounds_for_aspect(bounds: Rect, r: number) : Rect {
-    let result = bbox.empty()
+   adjust_bounds_for_aspect(bounds: Rect, ratio: number): Rect {
+    const result = bbox.empty()
 
     let width = bounds.maxX - bounds.minX
     if (width <= 0) { width = 1.0 }
@@ -105,10 +105,10 @@ export class DataRange1d extends DataRange {
     const xcenter = 0.5*(bounds.maxX + bounds.minX)
     const ycenter = 0.5*(bounds.maxY + bounds.minY)
 
-    if (width < r*height) {
-      width = r*height
+    if (width < ratio*height) {
+      width = ratio*height
     } else {
-      height = width/r
+      height = width/ratio
     }
 
     result.maxX = xcenter+0.5*width
@@ -206,7 +206,7 @@ export class DataRange1d extends DataRange {
     return [start, end]
   }
 
-  update(bounds: Bounds, dimension: Dim, bounds_id: string, r: number): void {
+  update(bounds: Bounds, dimension: Dim, bounds_id: string, ratio?: number): void {
     if (this.have_updated_interactively)
       return
 
@@ -215,8 +215,8 @@ export class DataRange1d extends DataRange {
     // update the raw data bounds for all renderers we care about
     let total_bounds = this._compute_plot_bounds(renderers, bounds)
 
-    if (r != null)
-      total_bounds = this.adjust_bounds_for_aspect(total_bounds, r)
+    if (ratio != null)
+      total_bounds = this.adjust_bounds_for_aspect(total_bounds, ratio)
 
     this._plot_bounds[bounds_id] = total_bounds
 

--- a/bokehjs/test/models/ranges/data_range1d.coffee
+++ b/bokehjs/test/models/ranges/data_range1d.coffee
@@ -335,3 +335,26 @@ describe "datarange1d module", ->
       expect(spy.called).to.be.false
       r.start = 15
       expect(spy.calledOnce).to.be.true
+
+  describe "adjust_bounds_for_aspect", ->
+    it "should preserve y axis when it is larger", ->
+      r = new DataRange1d()
+
+      bds = {minX: 0, maxX: 1, minY: 0, maxY: 2}
+
+      bds = r.adjust_bounds_for_aspect(bds, 4)
+      expect(bds.minX).to.be.equal -3.5
+      expect(bds.maxX).to.be.equal 4.5
+      expect(bds.minY).to.be.equal 0
+      expect(bds.maxY).to.be.equal 2
+
+    it "should preserve x axis when it is larger", ->
+      r = new DataRange1d()
+
+      bds = {minX: 0, maxX: 8, minY: 0, maxY: 1}
+
+      bds = r.adjust_bounds_for_aspect(bds, 4)
+      expect(bds.minX).to.be.equal 0
+      expect(bds.maxX).to.be.equal 8
+      expect(bds.minY).to.be.equal -0.5
+      expect(bds.maxY).to.be.equal 1.5


### PR DESCRIPTION
The commit moves the aspect ratio adjust (for a single plot update) to after the unioned bounds are computed for the DataRange renderers. Previously the aspect correction happened on all the individual renderer bounds, before the call to update. This could result in incorrect aspect-corrected overall bounds in some situations.

Note: use of match_aspect with linked DataRange1d across multiple plots will probably yield undefined/undesirable behavior and should be considered unsupported.

- [x] issues: fixes #7218
- [x] tests added / passed
- [x] release document entry (if new feature or API change)
#