### PR TITLE
Resolve pytest --log-file conflict

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ def pytest_addoption(parser):
         "--upload", dest="upload", action="store_true", default=False, help="upload test artefacts to S3"
     )
     parser.addoption(
-        "--log-file", dest="log_file", metavar="path", action="store", default='examples.log', help="where to write the complete log"
+        "--examples-log-file", dest="log_file", metavar="path", action="store", default='examples.log', help="where to write the complete log"
     )
 
 


### PR DESCRIPTION
Recent versions of pytest fail with this error:
```
argparse.ArgumentError: argument --log-file: conflicting option string: --log-file
```

This PR changes the cusotm option added in `tests/conftest.py` to be `--examples-log-file` instead. A grep of the CI tests did not find any usage of the old `--log-file` argument (the default value is "examples.log" which is what seems to be being used).

