### PR TITLE
Fix broken generic text legend.

### DIFF
--- a/bokehjs/src/coffee/models/glyphs/text.coffee
+++ b/bokehjs/src/coffee/models/glyphs/text.coffee
@@ -47,13 +47,13 @@ export class TextView extends XYGlyphView
 
   draw_legend_for_index: (ctx, x0, x1, y0, y1, index) ->
     ctx.save()
-    @text_props.set_value(ctx)
+    @visuals.text.set_value(ctx)
     # override some features so we fit inside the legend
-    ctx.font = @text_props.font_value()
+    ctx.font = @visuals.text.font_value()
     ctx.font = ctx.font.replace(/\b[\d\.]+[\w]+\b/, '10pt')
     ctx.textAlign = "right"
     ctx.textBaseline = "middle"
-    ctx.fillText("text", x2, (y1+y2)/2)
+    ctx.fillText("text", x1, (y0+y1)/2)
     ctx.restore()
 
 export class Text extends XYGlyph

--- a/bokehjs/src/coffee/models/glyphs/text.coffee
+++ b/bokehjs/src/coffee/models/glyphs/text.coffee
@@ -46,15 +46,7 @@ export class TextView extends XYGlyphView
         ctx.restore()
 
   draw_legend_for_index: (ctx, x0, x1, y0, y1, index) ->
-    ctx.save()
-    @visuals.text.set_value(ctx)
-    # override some features so we fit inside the legend
-    ctx.font = @visuals.text.font_value()
-    ctx.font = ctx.font.replace(/\b[\d\.]+[\w]+\b/, '10pt')
-    ctx.textAlign = "right"
-    ctx.textBaseline = "middle"
-    ctx.fillText("text", x1, (y0+y1)/2)
-    ctx.restore()
+    return null
 
 export class Text extends XYGlyph
   default_view: TextView

--- a/sphinx/source/docs/releases/0.12.14.rst
+++ b/sphinx/source/docs/releases/0.12.14.rst
@@ -30,6 +30,15 @@ of updating factor ranges should work more smoothly, however there will be no
 immediate indication of problems in case "bad" factors are included accidentally
 in data other than the data points not being rendered.
 
+Change To Text Glyph Legend
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously Text Glyphs added to legends would always unconditionally render
+the word "text" as the visual symbol, which was not useful. Now, text glyphs
+render an empty space in legends. This is helpful when it is desired to use
+an interactive legend mute or hide both a primary glyph, as well as some
+associated text that goes with it. For more discssion, see :bokeh-issue:`7337`.
+
 MercatorTileSource change
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR updates `draw_legend_for_index` render empty space in legends.  The previous implementation simply rendered the word "text" unconditionally which is not useful. Now text glyphs can added to legends in combination with other glyphs in order to be able to hide or mute them together:

<img width="561" alt="screen shot 2018-01-03 at 09 23 14" src="https://user-images.githubusercontent.com/1078448/34527086-0c2a775e-f06a-11e7-94ca-ee6f5aa9ef91.png">


issues: fixes #7337



  