### PR TITLE
Fix errant scroll to end on DataTable with no selection

### DIFF
--- a/bokehjs/src/coffee/models/widgets/tables/data_table.coffee
+++ b/bokehjs/src/coffee/models/widgets/tables/data_table.coffee
@@ -129,9 +129,10 @@ export class DataTableView extends WidgetView
     # the selection is already in the viewport so that selecting from the
     # datatable itself does not re-scroll.
     cur_grid_range = @grid.getViewport()
-    if @model.scroll_to_selection and not any(permuted_indices, (i) -> cur_grid_range.top <= i <= cur_grid_range.bottom)
-      min_index = Math.max(0, Math.min.apply(null, permuted_indices) - 1)
-      @grid.scrollRowToTop(min_index)
+
+    scroll_index = @model.get_scroll_index(cur_grid_range, permuted_indices)
+    if scroll_index?
+      @grid.scrollRowToTop(scroll_index)
 
   newIndexColumn: () ->
     return {
@@ -230,3 +231,12 @@ export class DataTable extends TableWidget
   @internal {
     default_width:        [ p.Number, 600   ]
   }
+
+  get_scroll_index: (grid_range, selected_indices) ->
+    if not @scroll_to_selection or selected_indices.length == 0
+      return null
+
+    if not any(selected_indices, (i) -> grid_range.top <= i <= grid_range.bottom)
+      return Math.max(0, Math.min.apply(null, selected_indices) - 1)
+
+    return null

--- a/bokehjs/src/coffee/models/widgets/tables/data_table.coffee
+++ b/bokehjs/src/coffee/models/widgets/tables/data_table.coffee
@@ -237,6 +237,6 @@ export class DataTable extends TableWidget
       return null
 
     if not any(selected_indices, (i) -> grid_range.top <= i <= grid_range.bottom)
-      return Math.max(0, Math.min.apply(null, selected_indices) - 1)
+      return Math.max(0, Math.min(selected_indices...) - 1)
 
     return null

--- a/bokehjs/test/models/widgets/tables/data_table.coffee
+++ b/bokehjs/test/models/widgets/tables/data_table.coffee
@@ -11,6 +11,32 @@ describe "data_table module", ->
   it "should define DTINDEX_NAME", ->
     expect(DTINDEX_NAME).to.equal "__bkdt_internal_index__"
 
+  describe "DataTable class", ->
+
+    describe "get_scroll_index method", ->
+
+      it "should return null when scroll_to_selection=false", ->
+        t = new DataTable({scroll_to_selection: false})
+        expect(t.get_scroll_index({top:0, bottom:16}, [])).to.be.null
+        expect(t.get_scroll_index({top:0, bottom:16}, [10])).to.be.null
+        expect(t.get_scroll_index({top:0, bottom:16}, [18])).to.be.null
+
+      it "should return null when scroll_to_selection=true but selection is empty", ->
+        t = new DataTable({scroll_to_selection: true})
+        expect(t.get_scroll_index({top:0, bottom:16}, [])).to.be.null
+
+      it "should return null when scroll_to_selection=true but any selection is already in range", ->
+        t = new DataTable({scroll_to_selection: true})
+        expect(t.get_scroll_index({top:0, bottom:16}, [2])).to.be.null
+        expect(t.get_scroll_index({top:5, bottom:16}, [2, 10])).to.be.null
+        expect(t.get_scroll_index({top:5, bottom:16}, [2, 10, 18])).to.be.null
+
+      it "should return (min-1) when scroll_to_selection=true but no selection is in range", ->
+        t = new DataTable({scroll_to_selection: true})
+        expect(t.get_scroll_index({top:5, bottom:16}, [2])).to.be.equal 1
+        expect(t.get_scroll_index({top:5, bottom:16}, [2, 18])).to.be.equal 1
+        expect(t.get_scroll_index({top:5, bottom:16}, [18])).to.be.equal 17
+
   describe "DataProvider class", ->
 
     it "should raise an error if DTINDEX_NAME is in source", ->


### PR DESCRIPTION
This problem was caused by applying the scroll computation in the case where there was an empty selection. In this instance, the scroll index was computed using `Math.min.apply(null, [])` which is `Infinity`, resulting in a scroll to the very end. The moves the logic for computing the index in to a method on the model (with the fix for empty selections) and places it under test.

- [x] issues: fixes #7139
- [x] tests added / passed
