### PR TITLE
Correct datetime conversion when subsecond fractions are present

### DIFF
--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -101,7 +101,7 @@ def convert_datetime_type(obj):
     # Datetime (datetime is a subclass of date)
     elif isinstance(obj, dt.datetime):
         diff = obj.replace(tzinfo=None) - DT_EPOCH
-        return diff.total_seconds() * 1000. + obj.microsecond / 1000.
+        return diff.total_seconds() * 1000.
 
     # Timedelta (timedelta is class in the datetime library)
     elif isinstance(obj, dt.timedelta):

--- a/bokeh/util/tests/test_serialization.py
+++ b/bokeh/util/tests/test_serialization.py
@@ -52,6 +52,8 @@ def test_is_datetime_type():
     assert bus.is_datetime_type(bus._pd_timestamp(3000000))
 
 def test_convert_datetime_type():
+    assert bus.convert_datetime_type(datetime.datetime(2018, 1, 3, 15, 37, 59, 922452)) == 1514993879922.452
+    assert bus.convert_datetime_type(datetime.datetime(2018, 1, 3, 15, 37, 59)) == 1514993879000.0
     assert bus.convert_datetime_type(datetime.datetime(2016, 5, 11)) == 1462924800000.0
     assert bus.convert_datetime_type(datetime.timedelta(3000)) == 259200000000.0
     assert bus.convert_datetime_type(datetime.date(2016, 5, 11)) == 1462924800000.0


### PR DESCRIPTION
The existing code called `total_seconds` on a TimeDelta, as well as explicitly added `microseconds` back in. However, this resulted in a doubling of the microsecond component, since `total_seconds` already includes this portion:

https://docs.python.org/2/library/datetime.html#datetime.timedelta.total_seconds

This was never discoverd because all tests of `convert_datetime_type` on datetime values only exercised "exact date" values.

- [x] issues: fixes #6680
- [x] tests added / passed
