### PR TITLE
Connect GraphRenderer to range change events

### DIFF
--- a/bokehjs/src/coffee/models/renderers/graph_renderer.coffee
+++ b/bokehjs/src/coffee/models/renderers/graph_renderer.coffee
@@ -31,6 +31,12 @@ export class GraphRendererView extends RendererView
     @connect(@model.edge_renderer.data_source.inspect, () -> @set_data())
     @connect(@model.edge_renderer.data_source.change, () -> @set_data())
 
+    for name, rng of @plot_model.frame.x_ranges
+      @connect(rng.change, () -> @set_data())
+
+    for name, rng of @plot_model.frame.y_ranges
+      @connect(rng.change, () -> @set_data())
+
   set_data: (request_render=true) ->
     # TODO (bev) this is a bit clunky, need to make sure glyphs use the correct ranges when they call
     # mapping functions on the base Renderer class


### PR DESCRIPTION
This PR fixes a regression when zooming on plots with a GraphRenderer. As described in #7370 zooming causes the nodes to snap to the origin. By connecting the ``GraphRenderer.set_data`` method to range change events just as was done for the ``GlyphRenderer`` in #7363 the issue is resolved.

- [x] issues: fixes #7370
- [ ] tests added / passed

  