### PR TITLE
add traceback information to exception messages callbacks

### DIFF
--- a/bokeh/util/tornado.py
+++ b/bokeh/util/tornado.py
@@ -6,6 +6,8 @@ from __future__ import absolute_import, print_function
 import logging
 log = logging.getLogger(__name__)
 
+from traceback import format_exception
+
 from tornado import gen
 
 @gen.coroutine
@@ -80,7 +82,8 @@ class _AsyncPeriodic(object):
             if not self._stopped:
                 self._loop.add_future(invoke(), on_done)
             if future.exception() is not None:
-                log.error("Error thrown from periodic callback: %r", future.exception())
+                log.error("Error thrown from periodic callback:")
+                log.error("".join(format_exception(*future.exc_info())))
         self._loop.add_future(self.sleep(), on_done)
 
     def stop(self):


### PR DESCRIPTION
This came up in some other work. It's probably long overdue I wanted to get it put in immediately.  An exception in a periodic callback now yields e.g.

```
2018-01-05 17:45:40,670 Error thrown from periodic callback:
2018-01-05 17:45:40,670 Traceback (most recent call last):
  File "/Users/bryanv/anaconda/lib/python3.6/site-packages/tornado/gen.py", line 828, in callback
    result_list.append(f.result())
  File "/Users/bryanv/anaconda/lib/python3.6/site-packages/tornado/concurrent.py", line 238, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
  File "/Users/bryanv/anaconda/lib/python3.6/site-packages/tornado/gen.py", line 1069, in run
    yielded = self.gen.send(value)
  File "/Users/bryanv/work/bokeh/bokeh/server/session.py", line 51, in _needs_document_lock_wrapper
    result = yield yield_for_all_futures(func(self, *args, **kwargs))
  File "/Users/bryanv/work/bokeh/bokeh/server/session.py", line 154, in with_document_locked
    return func(*args, **kwargs)
  File "/Users/bryanv/work/bokeh/bokeh/document/document.py", line 1021, in wrapper
    return doc._with_self_as_curdoc(invoke)
  File "/Users/bryanv/work/bokeh/bokeh/document/document.py", line 1007, in _with_self_as_curdoc
    return f()
  File "/Users/bryanv/work/bokeh/bokeh/document/document.py", line 1020, in invoke
    return f(*args, **kwargs)
  File "/Users/bryanv/tmp/foo.py", line 54, in callback
    1/0
ZeroDivisionError: division by zero
```

This is useful to users but also makes certain kinds of core dev far more accessible. 