### PR TITLE
Bryanv/6681 df index streaming

### DIFF
--- a/bokeh/core/property/containers.py
+++ b/bokeh/core/property/containers.py
@@ -374,17 +374,11 @@ class PropertyValueColumnData(PropertyValueDict):
 
         import numpy as np
 
-        # pandas/issues/13918
-        if pd and isinstance(new_data, pd.DataFrame):
-            new_items = new_data.iteritems()
-        else:
-            new_items = new_data.items()
-
         # TODO (bev) Currently this reports old differently for array vs list
         # For arrays is reports the actual old value. For lists, the old value
         # is actually the already updated value. This is because the method
         # self._saved_copy() makes a shallow copy.
-        for k, v in new_items:
+        for k, v in  new_data.items():
             if isinstance(self[k], np.ndarray):
                 data = np.append(self[k], new_data[k])
                 if rollover and len(data) > rollover:

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -6,6 +6,7 @@ from ..core.has_props import abstract
 from ..core.properties import Any, Bool, ColumnData, Dict, Enum, Instance, Int, JSON, List, Seq, String
 from ..model import Model
 from ..util.dependencies import import_optional
+from ..util.serialization import convert_datetime_array
 from ..util.warnings import BokehUserWarning
 
 from .callbacks import Callback
@@ -171,7 +172,6 @@ class ColumnDataSource(ColumnarDataSource):
 
         '''
         _df = df.copy()
-        index = _df.index
         tmp_data = {c: v.values for c, v in _df.iteritems()}
 
         new_data = {}
@@ -180,15 +180,8 @@ class ColumnDataSource(ColumnarDataSource):
                 k = "_".join(k)
             new_data[k] = v
 
-        if index.name:
-            new_data[index.name] = index.values
-        elif index.names:
-            try:
-                new_data["_".join(index.names)] = index.values
-            except TypeError:
-                new_data["index"] = index.values
-        else:
-            new_data["index"] = index.values
+        index_name = ColumnDataSource._df_index_name(df)
+        new_data[index_name] = _df.index.values
         return new_data
 
     @staticmethod
@@ -207,6 +200,38 @@ class ColumnDataSource(ColumnarDataSource):
 
         '''
         return ColumnDataSource._data_from_df(group.describe())
+
+    @staticmethod
+    def _df_index_name(df):
+        ''' Return the Bokeh-appropriate column name for a DataFrame index
+
+        If there is no named index, then `"index" is returned.
+
+        If there is a single named index, then ``df.index.name`` is returned.
+
+        If there is a multi-index, and the index names are all strings, then
+        the names are joined with '_' and the result is returned, e.g. for a
+        multi-index ``['ind1', 'ind2']`` the result will be "ind1_ind2".
+        Otherwise if any index name is not a string, the fallback name "index"
+        is returned.
+
+        Args:
+            df (DataFrame) : the DataFrame to find an index name for
+
+        Returns:
+            str
+
+        '''
+        if df.index.name:
+            return df.index.name
+        elif df.index.names:
+            try:
+                return "_".join(df.index.names)
+            except TypeError:
+                return "index"
+        else:
+            return "index"
+
 
     @classmethod
     def from_df(cls, data):
@@ -392,13 +417,24 @@ class ColumnDataSource(ColumnarDataSource):
             source.stream(new_data)
 
         '''
+        needs_length_check = True
+
         if pd and isinstance(new_data, pd.Series):
             new_data = new_data.to_frame().T
+
         if pd and isinstance(new_data, pd.DataFrame):
-            newkeys = set(new_data.columns)
+            needs_length_check = False # DataFrame lengths equal by definition
+            _df = new_data
+            newkeys = set(_df.columns)
+            index_name = ColumnDataSource._df_index_name(_df)
+            newkeys.add(index_name)
+            new_data = dict(_df.iteritems())
+            new_data[index_name] = _df.index.values
         else:
             newkeys = set(new_data.keys())
+
         oldkeys = set(self.data.keys())
+
         if newkeys != oldkeys:
             missing = oldkeys - newkeys
             extra = newkeys - oldkeys
@@ -411,7 +447,7 @@ class ColumnDataSource(ColumnarDataSource):
             else:
                 raise ValueError("Must stream updates to all existing columns (extra: %s)" % ", ".join(sorted(extra)))
 
-        if not (pd and isinstance(new_data, pd.DataFrame)):
+        if needs_length_check:
             import numpy as np
 
             lengths = set()
@@ -426,6 +462,11 @@ class ColumnDataSource(ColumnarDataSource):
 
             if len(lengths) > 1:
                 raise ValueError("All streaming column updates must be the same length")
+
+        # slighgly awkward that we have to call converty_datetime_array here ourselves
+        # but the downstream code expects things to already be ms-since-epoch
+        for key in new_data:
+            new_data[key] = convert_datetime_array(new_data[key])
 
         self.data._stream(self.document, self, new_data, rollover, setter)
 

--- a/bokeh/models/tests/test_sources.py
+++ b/bokeh/models/tests/test_sources.py
@@ -171,7 +171,7 @@ class TestColumnDataSource(unittest.TestCase):
 
     skipIf(not is_pandas, "pandas not installed")
     def test__df_index_name_with_named_multi_index(self):
-        data = io.StringIO('''
+        data = io.StringIO(u'''
 Fruit,Color,Count,Price
 Apple,Red,3,$1.29
 Apple,Green,9,$0.99

--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -125,9 +125,21 @@ def convert_datetime_type(obj):
         return (obj.hour * 3600 + obj.minute * 60 + obj.second) * 1000 + obj.microsecond / 1000.
 
 def convert_datetime_array(array):
-    '''
+    ''' Convert NumPy datetime arrays to arrays to milliseconds since epoch.
+
+    Args:
+        array : (obj)
+            A NumPy array of datetime to convert
+
+            If the value passed in is not a NumPy array, it will be returned as-is.
+
+    Returns:
+        array
 
     '''
+    if not isinstance(array, np.ndarray):
+        return array
+
     try:
         dt2001 = np.datetime64('2001')
         legacy_datetime64 = (dt2001.astype('int64') ==

--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -124,6 +124,38 @@ def convert_datetime_type(obj):
     elif isinstance(obj, dt.time):
         return (obj.hour * 3600 + obj.minute * 60 + obj.second) * 1000 + obj.microsecond / 1000.
 
+def convert_datetime_array(array):
+    '''
+
+    '''
+    try:
+        dt2001 = np.datetime64('2001')
+        legacy_datetime64 = (dt2001.astype('int64') ==
+                             dt2001.astype('datetime64[ms]').astype('int64'))
+    except AttributeError as e:
+        if e.args == ("'module' object has no attribute 'datetime64'",):
+            # for compatibility with PyPy that doesn't have datetime64
+            if 'PyPy' in sys.version:
+                legacy_datetime64 = False
+                pass
+            else:
+                raise e
+        else:
+            raise e
+
+    # not quite correct, truncates to ms..
+    if array.dtype.kind == 'M':
+        if legacy_datetime64:
+            if array.dtype == np.dtype('datetime64[ns]'):
+                array = array.astype('int64') / 10**6.0
+        else:
+            array =  array.astype('datetime64[us]').astype('int64') / 1000.
+
+    elif array.dtype.kind == 'm':
+        array = array.astype('timedelta64[us]').astype('int64') / 1000.
+
+    return array
+
 def make_id():
     ''' Return a new unique ID for a Bokeh object.
 
@@ -199,32 +231,7 @@ def transform_array(array, force_list=False, buffers=None):
 
     '''
 
-    # Check for astype failures (putative Numpy < 1.7)
-    try:
-        dt2001 = np.datetime64('2001')
-        legacy_datetime64 = (dt2001.astype('int64') ==
-                             dt2001.astype('datetime64[ms]').astype('int64'))
-    except AttributeError as e:
-        if e.args == ("'module' object has no attribute 'datetime64'",):
-            # for compatibility with PyPy that doesn't have datetime64
-            if 'PyPy' in sys.version:
-                legacy_datetime64 = False
-                pass
-            else:
-                raise e
-        else:
-            raise e
-
-    # not quite correct, truncates to ms..
-    if array.dtype.kind == 'M':
-        if legacy_datetime64:
-            if array.dtype == np.dtype('datetime64[ns]'):
-                array = array.astype('int64') / 10**6.0
-        else:
-            array =  array.astype('datetime64[us]').astype('int64') / 1000.
-
-    elif array.dtype.kind == 'm':
-        array = array.astype('timedelta64[us]').astype('int64') / 1000.
+    array = convert_datetime_array(array)
 
     return serialize_array(array, force_list=force_list, buffers=buffers)
 

--- a/bokeh/util/tests/test_serialization.py
+++ b/bokeh/util/tests/test_serialization.py
@@ -63,6 +63,22 @@ def test_convert_datetime_type():
     assert bus.convert_datetime_type(pd.Timedelta("3000ms")) == 3000.0
     assert bus.convert_datetime_type(bus._pd_timestamp(3000000)) == 3.0
 
+@pytest.mark.parametrize('obj', [[1,2], (1,2), dict(), set(), 10.2, "foo"])
+def test_convert_datetime_type_array_ignores_non_array(obj):
+    assert bus.convert_datetime_array(obj) is obj
+
+def test_convert_datetime_type_array_ignores_non_datetime_array():
+    a = np.arange(0,10,100)
+    assert bus.convert_datetime_array(a) is a
+
+def test_convert_datetime_type_array():
+    a = np.array(['2018-01-03T15:37:59', '2018-01-03T15:37:59.922452', '2016-05-11'], dtype='datetime64')
+    r = bus.convert_datetime_array(a)
+    assert r[0] == 1514993879000.0
+    assert r[1] == 1514993879922.452
+    assert r[2] == 1462924800000.0
+    assert r.dtype == 'float64'
+
 def test_convert_datetime_type_with_tz():
     # This ensures datetimes are sent to BokehJS timezone-naive
     # see https://github.com/bokeh/bokeh/issues/6480


### PR DESCRIPTION
This PR allows for `CDS.stream` to accept more data frames. In particular, DataFrames with unnamed indices would previously fail, since the index would be automatically captured at CDF creation, but would *not* be captured by ``stream``.  Other notes:

* This moves all pandas processing into `CDS._stream` and makes the interface for `PropertyValueDict` always assume a plain dict of named columns (lists/arrays/series/etc). This was necessary to properly process indices, but also makes the `PropertyValueDict` simpler. However, some changes to tests were necessary.

* Although it is not new, it's worth pointing out that with the conversion to CDS, there is no guarantee that streaming a new data frame will preserve the "index-ness" of the CDS index column (see comment below in test). This was true before, but now there are more opportunities to stream from dataframes. Users who need a valid index in the CDS at all times when streaming will have to take care to construct the stream dataframe index correctly (see example below)

- [x] issues: fixes #6681
- [x] tests added / passed
- [x] release document entry (if new feature or API change)
