### PR TITLE
Handle multi-gesture tools on ProxyToolbar

### DIFF
--- a/bokehjs/src/coffee/models/tools/toolbar.coffee
+++ b/bokehjs/src/coffee/models/tools/toolbar.coffee
@@ -43,9 +43,8 @@ export class Toolbar extends ToolbarBase
             continue
 
           if multi
-            if not any(@gestures['multi'].tools, (t) => t.id == tool.id)
-              @gestures['multi'].tools = @gestures['multi'].tools.concat([tool])
-          else if not any(@gestures[et].tools, (t) => t.id == tool.id)
+            et = "multi"
+          if not any(@gestures[et].tools, (t) => t.id == tool.id)
             @gestures[et].tools = @gestures[et].tools.concat([tool])
           @connect(tool.properties.active.change, @_active_change.bind(this, tool))
 

--- a/bokehjs/src/coffee/models/tools/toolbar_box.coffee
+++ b/bokehjs/src/coffee/models/tools/toolbar_box.coffee
@@ -32,9 +32,22 @@ export class ProxyToolbar extends ToolbarBase
         if not any(@actions, (t) => t.id == tool.id)
           @actions = @actions.concat([tool])
       else if tool instanceof GestureTool
-        et = tool.event_type
-        if not any(@gestures[et].tools, (t) => t.id == tool.id)
-          @gestures[et].tools = @gestures[et].tools.concat([tool])
+        event_types = tool.event_type
+        multi = true
+        if (typeof event_types is 'string')
+          event_types = [event_types]
+          multi = false
+
+        for et in event_types
+          if et not of @gestures
+            logger.warn("Toolbar: unknown event type '#{et}' for tool:
+              #{tool.type} (#{tool.id})")
+            continue
+
+          if multi
+            et = "multi"
+          if not any(@gestures[et].tools, (t) => t.id == tool.id)
+            @gestures[et].tools = @gestures[et].tools.concat([tool])
 
   _merge_tools: () ->
     # Go through all the tools on the toolbar and replace them with

--- a/bokehjs/test/models/tools/toolbar_box.coffee
+++ b/bokehjs/test/models/tools/toolbar_box.coffee
@@ -4,10 +4,14 @@ utils = require "../../utils"
 {Document} = utils.require("document")
 
 {LayoutDOM} = utils.require("models/layouts/layout_dom")
-{ToolbarBox} = utils.require("models/tools/toolbar_box")
+{ToolbarBox, ProxyToolbar} = utils.require("models/tools/toolbar_box")
 {Toolbar} = utils.require("models/tools/toolbar")
+{ToolProxy} = utils.require("models/tools/tool_proxy")
 {ResetTool} = utils.require("models/tools/actions/reset_tool")
 {SaveTool} = utils.require("models/tools/actions/save_tool")
+{SelectTool, SelectToolView} = utils.require("models/tools/gestures/select_tool")
+{PanTool} = utils.require("models/tools/gestures/pan_tool")
+{TapTool} = utils.require("models/tools/gestures/tap_tool")
 {CrosshairTool} = utils.require("models/tools/inspectors/crosshair_tool")
 {HoverTool} = utils.require("models/tools/inspectors/hover_tool")
 
@@ -38,6 +42,15 @@ describe "ToolbarBoxView", ->
     box_view = new box.default_view({model: box, parent: null})
     expect(box_view.get_height()).to.be.null
 
+
+class MultiToolView extends SelectToolView
+
+class MultiTool extends SelectTool
+  default_view: MultiToolView
+  type: "MultiTool"
+  tool_name: "Multi Tool"
+  event_type: ["tap", "pan"]
+
 describe "ToolbarBox", ->
 
   it "should be an instance of LayoutDOM", ->
@@ -61,3 +74,20 @@ describe "ToolbarBox", ->
     box = new ToolbarBox({tools: [hover1, hover2, crosshair1, crosshair2]})
     expect(box._toolbar.inspectors.length).equal 2
   ###
+
+
+describe "ProxyToolbar", ->
+
+  describe "_init_tools method", ->
+
+    beforeEach ->
+      @multi = new MultiTool()
+      @pan = new PanTool()
+      @tap = new TapTool()
+
+    it "should have proxied multi tool in gestures", ->
+      toolbar = new ProxyToolbar({tools:[@multi, @tap, @pan]})
+      expect(toolbar.gestures['multi'].tools.length).to.be.equal(1)
+      expect(toolbar.gestures['multi'].tools[0]).to.be.an.instanceof(ToolProxy)
+      expect(toolbar.gestures['multi'].tools[0].tools.length).to.be.equal(1)
+      expect(toolbar.gestures['multi'].tools[0].tools[0]).to.be.equal(@multi)


### PR DESCRIPTION
As I described in https://github.com/bokeh/bokeh/issues/7391 while implementing support for multi-gesture tools I did not handle the initialization of a ``ProxyToolbar`` causing it to raise errors when you attempt to create a layout plot with a multi-gesture tool.

- [x] issues: fixes #7391 
- [x] tests added / passed