### PR TITLE
Added missing includes import in tile_renderer.ts

### DIFF
--- a/bokehjs/src/coffee/models/plots/plot_canvas.ts
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.ts
@@ -21,7 +21,7 @@ import * as enums from "core/enums";
 import * as p from "core/properties";
 import {throttle} from "core/util/throttle";
 import {isStrictNaN} from "core/util/types";
-import {difference, sortBy, reversed} from "core/util/array";
+import {difference, sortBy, reversed, includes} from "core/util/array";
 import {extend, values, isEmpty} from "core/util/object";
 import {update_panel_constraints, _view_sizes} from "core/layout/side_panel"
 

--- a/bokehjs/src/coffee/models/renderers/graph_renderer.ts
+++ b/bokehjs/src/coffee/models/renderers/graph_renderer.ts
@@ -4,7 +4,6 @@ import {NodesOnly} from "../graphs/graph_hit_test_policy";
 
 import * as p from "core/properties";
 import {build_views} from "core/build_views";
-import {includes} from "core/util/array";
 import {create_hit_test_result} from "core/hittest"
 
 export class GraphRendererView extends RendererView {

--- a/bokehjs/src/coffee/models/tiles/tile_renderer.ts
+++ b/bokehjs/src/coffee/models/tiles/tile_renderer.ts
@@ -4,6 +4,7 @@ import {WMTSTileSource} from "./wmts_tile_source";
 import {Renderer, RendererView} from "../renderers/renderer";
 import {div} from "core/dom";
 import * as p from "core/properties";
+import {includes} from "core/util/array";
 import {isString} from "core/util/types"
 
 export class TileRendererView extends RendererView {


### PR DESCRIPTION
As described in #7398, decaffeination introduced a usage of ``includes`` without importing it.

- [x] issues: fixes #7398
- [ ] tests added / passed
