### PR TITLE
Declare variables in widgets SelectView constant

### DIFF
--- a/bokehjs/src/coffee/models/widgets/selectbox.ts
+++ b/bokehjs/src/coffee/models/widgets/selectbox.ts
@@ -22,9 +22,9 @@ export class SelectView extends InputWidgetView {
   build_options(values): HTMLElement[] {
     return values.map((el) => {
       if (isString(el))
-        value = _label  = el
+        const value = _label = el
       else
-        [value, _label] = el
+        const [value, _label] = el
 
       const selected = this.model.value == value
       return option({selected: selected, value: value}, _label)


### PR DESCRIPTION
This fixes some variables which were not declared properly in the widget SelectView. I suspect there's a few more of these so as I discover issues I'll add more.

- [x] issues: fixes #7412
- [ ] tests added / passed