### PR TITLE
Add support for path_args and path_kwargs in bokeh server

### DIFF
--- a/bokeh/server/application_context.py
+++ b/bokeh/server/application_context.py
@@ -178,8 +178,8 @@ class ApplicationContext(object):
                                                   doc)
             # using private attr so users only have access to a read-only property
             session_context._request = _RequestProxy(handler.request)
-            session_context._path_args = handler.path_args
-            session_context._path_kwargs = handler.path_kwargs
+            session_context._path_args = [arg for arg in handler.path_args]
+            session_context._path_kwargs = dict(handler.path_kwargs)
 
             # expose the session context to the document
             # use the _attribute to set the public property .session_context

--- a/bokeh/server/views/session_handler.py
+++ b/bokeh/server/views/session_handler.py
@@ -40,6 +40,6 @@ class SessionHandler(RequestHandler):
             log.error("Session id had invalid signature: %r", session_id)
             raise HTTPError(status_code=403, reason="Invalid session ID")
 
-        session = yield self.application_context.create_session_if_needed(session_id, self.request)
+        session = yield self.application_context.create_session_if_needed(session_id, self)
 
         raise gen.Return(session)

--- a/bokeh/server/views/ws.py
+++ b/bokeh/server/views/ws.py
@@ -93,7 +93,7 @@ class WSHandler(WebSocketHandler):
     @gen.coroutine
     def _async_open(self, session_id, proto_version):
         try:
-            yield self.application_context.create_session_if_needed(session_id, self.request)
+            yield self.application_context.create_session_if_needed(session_id, self)
             session = self.application_context.get_session(session_id)
 
             protocol = Protocol(proto_version)

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -394,7 +394,7 @@ group ``graph_id``:
 
   # if the url requested is http://localhost:5006/graphs/345126,
   # graph_id should be `345126`
-  graph_id = kwargs.get('345126', '')
+  graph_id = kwargs.get('graph_id', '')
 
 .. _userguide_server_applications_callbacks:
 

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -377,6 +377,25 @@ plot):
   writing directly to ``request.connection`` is unsupported and will result in
   undefined behavior.
 
+When capturing groups are defined in regular expressions for application paths
+for a Bokeh application, you can get captured values in ``curdoc().session_context``
+via ``session_context.path_args`` and ``session_context.path_kwargs``.
+
+As an example, the following code will access the value of capturing groups
+for the ID of the graph, which is defined in the url pattern as named capturing
+group ``graph_id``:
+
+.. code-block:: python
+
+  # the url pattern of the application is defined as `/graphs/(?P<graph_id>[^/]+)
+  # and urls accepted by this pattern can be http://localhost:5006/graphs/345126
+
+  kwargs = curdoc().session_context.path_kwargs
+
+  # if the url requested is http://localhost:5006/graphs/345126,
+  # graph_id should be `345126`
+  graph_id = kwargs.get('345126', '')
+
 .. _userguide_server_applications_callbacks:
 
 Callbacks and Events


### PR DESCRIPTION
- [x] issues: fixes #7424
- [x] tests added
- [x] release document entry (if new feature or API change)

This PR adds two properties, ```path_args``` and ```path_kwargs``` to ```BokehSessionContext``` to store capturing groups in Tornado ```RequestHandler```. Test cases has been added.