### PR TITLE
Fixed regression in notebook plot embedding

### DIFF
--- a/bokehjs/src/coffee/embed.ts
+++ b/bokehjs/src/coffee/embed.ts
@@ -71,7 +71,7 @@ function _update_comms_callback(target: string, doc: Document, comm: Comm): void
 }
 
 function _init_comms(target: string, doc: Document): void {
-  if (Jupyter != null && Jupyter.notebook.kernel != null) {
+  if (typeof Jupyter !== 'undefined' && Jupyter.notebook.kernel != null) {
     logger.info(`Registering Jupyter comms for target ${target}`)
     const comm_manager = Jupyter.notebook.kernel.comm_manager
     const update_comms = (comm: Comm) => _update_comms_callback(target, doc, comm)


### PR DESCRIPTION
Simple fix for the regression described in #7439. Trying to open a notebook with embedded bokeh plots outside the notebook itself would cause it to fail to render the plots because an error occurred when trying to set up a Jupyter Comm. It now checks whether the Jupyter variable is defined.  

- [x] issues: fixes #7439 