### PR TITLE
Simplify for(;;) loops generated by decaffeinate

### DIFF
--- a/bokehjs/src/coffee/core/util/serialization.ts
+++ b/bokehjs/src/coffee/core/util/serialization.ts
@@ -119,9 +119,9 @@ export const arrayBufferToBase64 = function(buffer) {
 
 export const base64ToArrayBuffer = function(base64) {
   const binary_string = atob(base64);
-  const len = binary_string.length;
-  const bytes = new Uint8Array( len );
-  for (let i = 0, end = len, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+  const len = binary_string.length
+  const bytes = new Uint8Array(len);
+  for (let i = 0, end = len; i < end; i++) {
     bytes[i] = binary_string.charCodeAt(i);
   }
   return bytes.buffer;
@@ -196,7 +196,7 @@ export const encode_column_data = function(data, shapes) {
       v = encode_base64(v, shapes != null ? shapes[k] : undefined);
     } else if (isArray(v)) {
       const new_array = [];
-      for (let i = 0, end = v.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+      for (let i = 0, end = v.length; i < end; i++) {
         if ((v[i] != null ? v[i].buffer : undefined) instanceof ArrayBuffer) {
           new_array.push(encode_base64(v[i], __guard__(shapes != null ? shapes[k] : undefined, x => x[i])));
         } else {

--- a/bokehjs/src/coffee/models/annotations/arrow.ts
+++ b/bokehjs/src/coffee/models/annotations/arrow.ts
@@ -89,7 +89,7 @@ export class ArrowView extends AnnotationView {
     if (!this.visuals.line.doit)
       return;
 
-    for (let i = 0, end = this._x_start.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = this._x_start.length; i < end; i++) {
       this.visuals.line.set_vectorize(ctx, i);
 
       ctx.beginPath();
@@ -100,7 +100,7 @@ export class ArrowView extends AnnotationView {
   }
 
   _arrow_head(ctx, action, head, start, end) {
-    for (let i = 0, end1 = this._x_start.length, asc = 0 <= end1; asc ? i < end1 : i > end1; asc ? i++ : i--) {
+    for (let i = 0, _end = this._x_start.length; i < _end; i++) {
       // arrow head runs orthogonal to arrow body
       const angle = (Math.PI/2) + atan2([start[0][i], start[1][i]], [end[0][i], end[1][i]]);
 

--- a/bokehjs/src/coffee/models/annotations/band.ts
+++ b/bokehjs/src/coffee/models/annotations/band.ts
@@ -68,11 +68,6 @@ export class BandView extends AnnotationView {
   }
 
   render() {
-    let i;
-    let asc, end;
-    let asc1, start;
-    let asc2, end1;
-    let asc3, end2;
     if (!this.model.visible) {
       return;
     }
@@ -85,11 +80,11 @@ export class BandView extends AnnotationView {
     ctx.beginPath();
     ctx.moveTo(this._lower_sx[0], this._lower_sy[0]);
 
-    for (i = 0, end = this._lower_sx.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = this._lower_sx.length; i < end; i++) {
       ctx.lineTo(this._lower_sx[i], this._lower_sy[i]);
     }
     // iterate backwards so that the upper end is below the lower start
-    for (start = this._upper_sx.length-1, i = start, asc1 = start <= 0; asc1 ? i <= 0 : i >= 0; asc1 ? i++ : i--) {
+    for (let start = this._upper_sx.length-1, i = start; i >= 0; i--) {
       ctx.lineTo(this._upper_sx[i], this._upper_sy[i]);
     }
 
@@ -103,7 +98,7 @@ export class BandView extends AnnotationView {
     // Draw the lower band edge
     ctx.beginPath();
     ctx.moveTo(this._lower_sx[0], this._lower_sy[0]);
-    for (i = 0, end1 = this._lower_sx.length, asc2 = 0 <= end1; asc2 ? i < end1 : i > end1; asc2 ? i++ : i--) {
+    for (let i = 0, end = this._lower_sx.length; i < end; i++) {
       ctx.lineTo(this._lower_sx[i], this._lower_sy[i]);
     }
 
@@ -115,7 +110,7 @@ export class BandView extends AnnotationView {
     // Draw the upper band edge
     ctx.beginPath();
     ctx.moveTo(this._upper_sx[0], this._upper_sy[0]);
-    for (i = 0, end2 = this._upper_sx.length, asc3 = 0 <= end2; asc3 ? i < end2 : i > end2; asc3 ? i++ : i--) {
+    for (let i = 0, end = this._upper_sx.length; i < end; i++) {
       ctx.lineTo(this._upper_sx[i], this._upper_sy[i]);
     }
 

--- a/bokehjs/src/coffee/models/annotations/color_bar.ts
+++ b/bokehjs/src/coffee/models/annotations/color_bar.ts
@@ -241,7 +241,7 @@ export class ColorBarView extends AnnotationView {
     ctx.save();
     ctx.translate(x_offset, y_offset);
     this.visuals.major_tick_line.set_value(ctx);
-    for (let i = 0, end = sx.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = sx.length; i < end; i++) {
       ctx.beginPath();
       ctx.moveTo(Math.round(sx[i]+(nx*tout)), Math.round(sy[i]+(ny*tout)));
       ctx.lineTo(Math.round(sx[i]-(nx*tin)), Math.round(sy[i]-(ny*tin)));
@@ -266,7 +266,7 @@ export class ColorBarView extends AnnotationView {
     ctx.save();
     ctx.translate(x_offset, y_offset);
     this.visuals.minor_tick_line.set_value(ctx);
-    for (let i = 0, end = sx.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = sx.length; i < end; i++) {
       ctx.beginPath();
       ctx.moveTo(Math.round(sx[i]+(nx*tout)), Math.round(sy[i]+(ny*tout)));
       ctx.lineTo(Math.round(sx[i]-(nx*tin)), Math.round(sy[i]-(ny*tin)));
@@ -294,7 +294,7 @@ export class ColorBarView extends AnnotationView {
 
     ctx.save();
     ctx.translate(x_offset + x_standoff, y_offset + y_standoff);
-    for (let i = 0, end = sx.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = sx.length; i < end; i++) {
       ctx.fillText(formatted_labels[i],
                    Math.round(sx[i]+(nx*this.model.label_standoff)),
                    Math.round(sy[i]+(ny*this.model.label_standoff)));
@@ -529,7 +529,7 @@ export class ColorBar extends Annotation {
     // will not function properly in conjunction with colorbars
     const formatted_labels = this.formatter.doFormat(labels, null);
 
-    for (let i = 0, end = major_ticks.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = major_ticks.length; i < end; i++) {
       if (major_ticks[i] in this.major_label_overrides) {
         formatted_labels[i] = this.major_label_overrides[major_ticks[i]];
       }
@@ -539,9 +539,7 @@ export class ColorBar extends Annotation {
   }
 
   tick_info() {
-    let ii, scale_length;
-    let asc, end1;
-    let asc1, end2;
+    let scale_length;
     let coord;
     const image_dimensions = this._computed_image_dimensions();
     switch (this.orientation) {
@@ -570,7 +568,7 @@ export class ColorBar extends Annotation {
     const major_coords = coords.major;
     const minor_coords = coords.minor;
 
-    for (ii = 0, end1 = majors.length, asc = 0 <= end1; asc ? ii < end1 : ii > end1; asc ? ii++ : ii--) {
+    for (let ii = 0, _end = majors.length; ii < _end; ii++) {
       if ((majors[ii] < start) || (majors[ii] > end)) {
         continue;
       }
@@ -578,7 +576,7 @@ export class ColorBar extends Annotation {
       major_coords[j].push(0);
     }
 
-    for (ii = 0, end2 = minors.length, asc1 = 0 <= end2; asc1 ? ii < end2 : ii > end2; asc1 ? ii++ : ii--) {
+    for (let ii = 0, _end = minors.length; ii < _end; ii++) {
       if ((minors[ii] < start) || (minors[ii] > end)) {
         continue;
       }

--- a/bokehjs/src/coffee/models/annotations/label_set.ts
+++ b/bokehjs/src/coffee/models/annotations/label_set.ts
@@ -13,7 +13,7 @@ export class LabelSetView extends TextAnnotationView {
     this.set_data(this.model.source);
 
     if (this.model.render_mode === 'css') {
-      for (let i = 0, end = this._text.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+      for (let i = 0, end = this._text.length; i < end; i++) {
         this.title_div = div({class: 'bk-annotation-child', style: {display: "none"}});
         this.el.appendChild(this.title_div);
       }

--- a/bokehjs/src/coffee/models/annotations/poly_annotation.ts
+++ b/bokehjs/src/coffee/models/annotations/poly_annotation.ts
@@ -32,7 +32,7 @@ export class PolyAnnotationView extends AnnotationView {
     const { frame } = this.plot_view;
     ({ ctx } = this.plot_view.canvas_view);
 
-    for (let i = 0, end = xs.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = xs.length; i < end; i++) {
       let sx, sy;
       if (this.model.xs_units === 'screen')
         sx = this.model.screen ? xs[i] : frame.xview.compute(xs[i]);

--- a/bokehjs/src/coffee/models/annotations/whisker.ts
+++ b/bokehjs/src/coffee/models/annotations/whisker.ts
@@ -69,7 +69,6 @@ export class WhiskerView extends AnnotationView {
   }
 
   render() {
-    let i;
     if (!this.model.visible) {
       return;
     }
@@ -79,8 +78,7 @@ export class WhiskerView extends AnnotationView {
     const { ctx } = this.plot_view.canvas_view;
 
     if (this.visuals.line.doit) {
-      let asc, end;
-      for (i = 0, end = this._lower_sx.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+      for (let i = 0, end = this._lower_sx.length; i < end; i++) {
         this.visuals.line.set_vectorize(ctx, i);
         ctx.beginPath();
         ctx.moveTo(this._lower_sx[i], this._lower_sy[i]);
@@ -92,8 +90,7 @@ export class WhiskerView extends AnnotationView {
     const angle = this.model.dimension === "height" ? 0 : Math.PI / 2;
 
     if (this.model.lower_head != null) {
-      let asc1, end1;
-      for (i = 0, end1 = this._lower_sx.length, asc1 = 0 <= end1; asc1 ? i < end1 : i > end1; asc1 ? i++ : i--) {
+      for (let i = 0, end = this._lower_sx.length; i < end; i++) {
         ctx.save();
         ctx.translate(this._lower_sx[i], this._lower_sy[i]);
         ctx.rotate(angle + Math.PI);
@@ -103,8 +100,7 @@ export class WhiskerView extends AnnotationView {
     }
 
     if (this.model.upper_head != null) {
-      let asc2, end2;
-      for (i = 0, end2 = this._upper_sx.length, asc2 = 0 <= end2; asc2 ? i < end2 : i > end2; asc2 ? i++ : i--) {
+      for (let i = 0, end = this._upper_sx.length; i < end; i++) {
         ctx.save();
         ctx.translate(this._upper_sx[i], this._upper_sy[i]);
         ctx.rotate(angle);

--- a/bokehjs/src/coffee/models/formatters/basic_tick_formatter.ts
+++ b/bokehjs/src/coffee/models/formatters/basic_tick_formatter.ts
@@ -29,7 +29,7 @@ export class BasicTickFormatter extends TickFormatter {
   }
 
   doFormat(ticks, _axis) {
-    let i, labels;
+    let labels;
     if (ticks.length === 0) {
       return [];
     }
@@ -57,26 +57,22 @@ export class BasicTickFormatter extends TickFormatter {
     if ((precision == null) || isNumber(precision)) {
       labels = new Array(ticks.length);
       if (need_sci) {
-        let asc, end;
-        for (i = 0, end = ticks.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+        for (let i = 0, end = ticks.length; i < end; i++) {
           labels[i] = ticks[i].toExponential(precision || undefined);
         }
       } else {
-        let asc1, end1;
-        for (i = 0, end1 = ticks.length, asc1 = 0 <= end1; asc1 ? i < end1 : i > end1; asc1 ? i++ : i--) {
-          labels[i] = ticks[i].toFixed(precision || undefined).replace(
-            /(\.[0-9]*?)0+$/, "$1").replace(/\.$/, "");
+        for (let i = 0, end = ticks.length; i < end; i++) {
+          labels[i] = ticks[i].toFixed(precision || undefined).replace(/(\.[0-9]*?)0+$/, "$1").replace(/\.$/, "");
         }
       }
       return labels;
 
     } else if (precision === 'auto') {
       labels = new Array(ticks.length);
-      for (let x = this.last_precision, asc2 = this.last_precision <= 15; asc2 ? x <= 15 : x >= 15; asc2 ? x++ : x--) {
+      for (let x = this.last_precision, asc = this.last_precision <= 15; asc ? x <= 15 : x >= 15; asc ? x++ : x--) {
         let is_ok = true;
         if (need_sci) {
-          let asc3, end2;
-          for (i = 0, end2 = ticks.length, asc3 = 0 <= end2; asc3 ? i < end2 : i > end2; asc3 ? i++ : i--) {
+          for (let i = 0, end = ticks.length; i < end; i++) {
             labels[i] = ticks[i].toExponential(x);
             if (i > 0) {
               if (labels[i] === labels[i-1]) {
@@ -89,10 +85,8 @@ export class BasicTickFormatter extends TickFormatter {
             break;
           }
         } else {
-          let asc4, end3;
-          for (i = 0, end3 = ticks.length, asc4 = 0 <= end3; asc4 ? i < end3 : i > end3; asc4 ? i++ : i--) {
-            labels[i] = ticks[i].toFixed(x).replace(
-              /(\.[0-9]*?)0+$/, "$1").replace(/\.$/, "");
+          for (let i = 0, end = ticks.length; i < end; i++) {
+            labels[i] = ticks[i].toFixed(x).replace(/(\.[0-9]*?)0+$/, "$1").replace(/\.$/, "");
             if (i > 0) {
               if (labels[i] === labels[i-1]) {
                 is_ok = false;

--- a/bokehjs/src/coffee/models/formatters/datetime_tick_formatter.ts
+++ b/bokehjs/src/coffee/models/formatters/datetime_tick_formatter.ts
@@ -146,7 +146,7 @@ export class DatetimeTickFormatter extends TickFormatter {
       // If a width is provided, then we pick the most appropriate scale,
       // otherwise just use the widest format
       const good_formats = [];
-      for (let i = 0, end = widths.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+      for (let i = 0, end = widths.length; i < end; i++) {
         if ((widths[i] * ticks.length) < (fill_ratio * char_width)) {
           good_formats.push(this._width_formats[i]);
         }

--- a/bokehjs/src/coffee/models/formatters/log_tick_formatter.ts
+++ b/bokehjs/src/coffee/models/formatters/log_tick_formatter.ts
@@ -35,7 +35,7 @@ export class LogTickFormatter extends TickFormatter {
 
     let small_interval = false;
     let labels = new Array(ticks.length);
-    for (let i = 0, end = ticks.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = ticks.length; i < end; i++) {
       labels[i] = `${base}^${ Math.round(Math.log(ticks[i]) / Math.log(base)) }`;
       if ((i > 0) && (labels[i] === labels[i-1])) {
         small_interval = true;

--- a/bokehjs/src/coffee/models/formatters/mercator_tick_formatter.ts
+++ b/bokehjs/src/coffee/models/formatters/mercator_tick_formatter.ts
@@ -13,7 +13,6 @@ export class MercatorTickFormatter extends BasicTickFormatter {
   }
 
   doFormat(ticks, axis) {
-    let i, lat, lon;
     if ((this.dimension == null)) {
       throw new Error("MercatorTickFormatter.dimension not configured");
     }
@@ -25,15 +24,13 @@ export class MercatorTickFormatter extends BasicTickFormatter {
     const proj_ticks = new Array(ticks.length);
 
     if (this.dimension === "lon") {
-      let asc, end;
-      for (i = 0, end = ticks.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
-        [lon, lat] = proj4(mercator).inverse([ticks[i], axis.loc]);
+      for (let i = 0, end = ticks.length; i < end; i++) {
+        const [lon,] = proj4(mercator).inverse([ticks[i], axis.loc]);
         proj_ticks[i] = lon;
       }
     } else {
-      let asc1, end1;
-      for (i = 0, end1 = ticks.length, asc1 = 0 <= end1; asc1 ? i < end1 : i > end1; asc1 ? i++ : i--) {
-        [lon, lat] = proj4(mercator).inverse([axis.loc, ticks[i]]);
+      for (let i = 0, end = ticks.length; i < end; i++) {
+        const [, lat] = proj4(mercator).inverse([axis.loc, ticks[i]]);
         proj_ticks[i] = lat;
       }
     }

--- a/bokehjs/src/coffee/models/glyphs/bezier.ts
+++ b/bokehjs/src/coffee/models/glyphs/bezier.ts
@@ -79,7 +79,7 @@ export class BezierView extends GlyphView {
 
   _index_data() {
     const points = [];
-    for (let i = 0, end = this._x0.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = this._x0.length; i < end; i++) {
       if (isNaN(this._x0[i]+this._x1[i]+this._y0[i]+this._y1[i]+this._cx0[i]+this._cy0[i]+this._cx1[i]+this._cy1[i])) {
         continue;
       }

--- a/bokehjs/src/coffee/models/glyphs/box.ts
+++ b/bokehjs/src/coffee/models/glyphs/box.ts
@@ -10,7 +10,7 @@ export class BoxView extends GlyphView {
   _index_box(len): RBush {
     const points = [];
 
-    for (let i = 0, end = len, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = len; i < end; i++) {
       const [l, r, t, b] = this._lrtb(i);
       if (isNaN(l+r+t+b) || !isFinite(l+r+t+b)) {
         continue;

--- a/bokehjs/src/coffee/models/glyphs/circle.ts
+++ b/bokehjs/src/coffee/models/glyphs/circle.ts
@@ -76,7 +76,7 @@ export class CircleView extends XYGlyphView {
   }
 
   _hit_point(geometry) {
-    let dist, i, r2, sx0, sx1, sy0, sy1, x0, x1, y0, y1;
+    let dist, r2, sx0, sx1, sy0, sy1, x0, x1, y0, y1;
     const {sx, sy} = geometry;
     const x = this.renderer.xscale.invert(sx);
     const y = this.renderer.yscale.invert(sy);
@@ -106,7 +106,7 @@ export class CircleView extends XYGlyphView {
 
     const hits = [];
     if ((this._radius != null) && (this.model.properties.radius.units === "data")) {
-      for (i of candidates) {
+      for (const i of candidates) {
         r2 = Math.pow(this.sradius[i], 2);
         [sx0, sx1] = this.renderer.xscale.r_compute(x, this._x[i]);
         [sy0, sy1] = this.renderer.yscale.r_compute(y, this._y[i]);
@@ -116,7 +116,7 @@ export class CircleView extends XYGlyphView {
         }
       }
     } else {
-      for (i of candidates) {
+      for (const i of candidates) {
         r2 = Math.pow(this.sradius[i], 2);
         dist = Math.pow(this.sx[i]-sx, 2) + Math.pow(this.sy[i]-sy, 2);
         if (dist <= r2) {
@@ -190,7 +190,7 @@ export class CircleView extends XYGlyphView {
     const candidates = range(0, this.sx.length);
 
     const hits = [];
-    for (let i = 0, end = candidates.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = candidates.length; i < end; i++) {
       const idx = candidates[i];
       if (hittest.point_in_poly(this.sx[i], this.sy[i], sx, sy)) {
         hits.push(idx);

--- a/bokehjs/src/coffee/models/glyphs/glyph.ts
+++ b/bokehjs/src/coffee/models/glyphs/glyph.ts
@@ -134,7 +134,6 @@ export class GlyphView extends View {
 
   sdist(scale, pts, spans, pts_location = "edge", dilate = false) {
     let pt0, pt1;
-    let i;
     if (scale.source_range.v_synthetic != null) {
       pts = scale.source_range.v_synthetic(pts);
     }
@@ -142,30 +141,27 @@ export class GlyphView extends View {
     if (pts_location === 'center') {
       const halfspan = (spans.map((d) => d / 2));
       pt0 = ((() => {
-        let asc, end;
         const result = [];
-        for (i = 0, end = pts.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+        for (let i = 0, end = pts.length; i < end; i++) {
           result.push(pts[i] - halfspan[i]);
         }
         return result;
       })());
       pt1 = ((() => {
-        let asc1, end1;
-        const result1 = [];
-        for (i = 0, end1 = pts.length, asc1 = 0 <= end1; asc1 ? i < end1 : i > end1; asc1 ? i++ : i--) {
-          result1.push(pts[i] + halfspan[i]);
+        const result = [];
+        for (let i = 0, end = pts.length; i < end; i++) {
+          result.push(pts[i] + halfspan[i]);
         }
-        return result1;
+        return result;
       })());
     } else {
       pt0 = pts;
       pt1 = ((() => {
-        let asc2, end2;
-        const result2 = [];
-        for (i = 0, end2 = pt0.length, asc2 = 0 <= end2; asc2 ? i < end2 : i > end2; asc2 ? i++ : i--) {
-          result2.push(pt0[i] + spans[i]);
+        const result = [];
+        for (let i = 0, end = pt0.length; i < end; i++) {
+          result.push(pt0[i] + spans[i]);
         }
-        return result2;
+        return result;
       })());
     }
 
@@ -174,21 +170,19 @@ export class GlyphView extends View {
 
     if (dilate) {
       return ((() => {
-        let asc3, end3;
-        const result3 = [];
-        for (i = 0, end3 = spt0.length, asc3 = 0 <= end3; asc3 ? i < end3 : i > end3; asc3 ? i++ : i--) {
-          result3.push(Math.ceil(Math.abs(spt1[i] - spt0[i])));
+        const result = [];
+        for (let i = 0, end = spt0.length; i < end; i++) {
+          result.push(Math.ceil(Math.abs(spt1[i] - spt0[i])));
         }
-        return result3;
+        return result;
       })());
     } else {
       return ((() => {
-        let asc4, end4;
-        const result4 = [];
-        for (i = 0, end4 = spt0.length, asc4 = 0 <= end4; asc4 ? i < end4 : i > end4; asc4 ? i++ : i--) {
-          result4.push(Math.abs(spt1[i] - spt0[i]));
+        const result = [];
+        for (let i = 0, end = spt0.length; i < end; i++) {
+          result.push(Math.abs(spt1[i] - spt0[i]));
         }
-        return result4;
+        return result;
       })());
     }
   }
@@ -336,7 +330,7 @@ export class GlyphView extends View {
       yname = `_${yname}`;
       if (isArray(this[xname] != null ? this[xname][0] : undefined) || __guard__(this[xname] != null ? this[xname][0] : undefined, x => x.buffer) instanceof ArrayBuffer) {
         [ this[sxname], this[syname] ] = [ [], [] ];
-        for (let i = 0, end = this[xname].length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+        for (let i = 0, end = this[xname].length; i < end; i++) {
           const [sx, sy] = this.map_to_screen(this[xname][i], this[yname][i]);
           this[sxname].push(sx);
           this[syname].push(sy);

--- a/bokehjs/src/coffee/models/glyphs/hbar.ts
+++ b/bokehjs/src/coffee/models/glyphs/hbar.ts
@@ -27,7 +27,7 @@ export class HBarView extends BoxView {
     this.stop = [];
     this.sbottom = [];
     this.sh = this.sdist(this.renderer.yscale, this._y, this._height, 'center');
-    for (let i = 0, end = this.sy.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = this.sy.length; i < end; i++) {
       this.stop.push(this.sy[i] - (this.sh[i]/2));
       this.sbottom.push(this.sy[i] + (this.sh[i]/2));
     }

--- a/bokehjs/src/coffee/models/glyphs/image.ts
+++ b/bokehjs/src/coffee/models/glyphs/image.ts
@@ -32,7 +32,7 @@ export class ImageView extends XYGlyphView {
       this._height = new Array(this._image.length);
     }
 
-    for (let i = 0, end = this._image.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = this._image.length; i < end; i++) {
       let canvas, img;
       let shape = [];
       if (this._image_shape != null) {

--- a/bokehjs/src/coffee/models/glyphs/image_rgba.ts
+++ b/bokehjs/src/coffee/models/glyphs/image_rgba.ts
@@ -18,7 +18,7 @@ export class ImageRGBAView extends XYGlyphView {
       this._height = new Array(this._image.length);
     }
 
-    for (let i = 0, end = this._image.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = this._image.length; i < end; i++) {
       let buf, canvas;
       if ((indices != null) && (indices.indexOf(i) < 0)) {
         continue;
@@ -37,7 +37,7 @@ export class ImageRGBAView extends XYGlyphView {
         const flat = concat(this._image[i]);
         buf = new ArrayBuffer(flat.length * 4);
         const color = new Uint32Array(buf);
-        for (let j = 0, end1 = flat.length, asc1 = 0 <= end1; asc1 ? j < end1 : j > end1; asc1 ? j++ : j--) {
+        for (let j = 0, endj = flat.length; j < endj; j++) {
           color[j] = flat[j];
         }
         this._height[i] = this._image[i].length;

--- a/bokehjs/src/coffee/models/glyphs/image_url.ts
+++ b/bokehjs/src/coffee/models/glyphs/image_url.ts
@@ -20,7 +20,7 @@ export class ImageURLView extends GlyphView {
 
     this.retries = this._url.map((_) => retry_attempts)
 
-    for (let i = 0, end = this._url.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = this._url.length; i < end; i++) {
       if ((this._url[i] == null))
         continue;
 

--- a/bokehjs/src/coffee/models/glyphs/line.ts
+++ b/bokehjs/src/coffee/models/glyphs/line.ts
@@ -59,7 +59,7 @@ export class LineView extends XYGlyphView {
     let shortest = 9999;
     const threshold = Math.max(2, this.visuals.line.line_width.value() / 2);
 
-    for (let i = 0, end = this.sx.length-1, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = this.sx.length-1; i < end; i++) {
       const [p0, p1] = [{x: this.sx[i], y: this.sy[i]}, {x: this.sx[i+1], y: this.sy[i+1]}];
       const dist = hittest.dist_to_segment(point, p0, p1);
 
@@ -88,7 +88,7 @@ export class LineView extends XYGlyphView {
       values = this._x;
     }
 
-    for (let i = 0, end = values.length-1, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = values.length-1; i < end; i++) {
       if ((values[i]<=val && val<=values[i+1]) || (values[i+1]<=val && val<=values[i])) {
         result['0d'].glyph = this.model;
         result['0d'].get_view = () => this

--- a/bokehjs/src/coffee/models/glyphs/multi_line.ts
+++ b/bokehjs/src/coffee/models/glyphs/multi_line.ts
@@ -9,7 +9,7 @@ export class MultiLineView extends GlyphView {
 
   _index_data() {
     const points = [];
-    for (let i = 0, end = this._xs.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = this._xs.length; i < end; i++) {
       if ((this._xs[i] === null) || (this._xs[i].length === 0)) {
         continue;
       }
@@ -47,7 +47,7 @@ export class MultiLineView extends GlyphView {
       const [sx, sy] = [sxs[i], sys[i]];
 
       this.visuals.line.set_vectorize(ctx, i);
-      for (let j = 0, end = sx.length, asc = 0 <= end; asc ? j < end : j > end; asc ? j++ : j--) {
+      for (let j = 0, end = sx.length; j < end; j++) {
         if (j === 0) {
           ctx.beginPath();
           ctx.moveTo(sx[j], sy[j]);
@@ -65,17 +65,15 @@ export class MultiLineView extends GlyphView {
   }
 
   _hit_point(geometry) {
-    let asc, end;
-    let i;
     const result = hittest.create_hit_test_result();
     const point = {x: geometry.sx, y: geometry.sy};
     let shortest = 9999;
 
     const hits = {};
-    for (i = 0, end = this.sxs.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = this.sxs.length; i < end; i++) {
       const threshold = Math.max(2, this.visuals.line.cache_select('line_width', i) / 2);
       let points = null;
-      for (let j = 0, end1 = this.sxs[i].length-1, asc1 = 0 <= end1; asc1 ? j < end1 : j > end1; asc1 ? j++ : j--) {
+      for (let j = 0, endj = this.sxs[i].length-1; j < endj; j++) {
         const [p0, p1] = [{x: this.sxs[i][j], y: this.sys[i][j]}, {x: this.sxs[i][j+1], y: this.sys[i][j+1]}];
         const dist = hittest.dist_to_segment(point, p0, p1);
         if ((dist < threshold) && (dist < shortest)) {
@@ -96,8 +94,6 @@ export class MultiLineView extends GlyphView {
 
   _hit_span(geometry) {
     let val, values;
-    let asc, end;
-    let i;
     const {sx, sy} = geometry;
     const result = hittest.create_hit_test_result();
 
@@ -110,9 +106,9 @@ export class MultiLineView extends GlyphView {
     }
 
     const hits = {};
-    for (i = 0, end = values.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = values.length; i < end; i++) {
       const points = [];
-      for (let j = 0, end1 = values[i].length-1, asc1 = 0 <= end1; asc1 ? j < end1 : j > end1; asc1 ? j++ : j--) {
+      for (let j = 0, endj = values[i].length-1; j < endj; j++) {
         if (values[i][j] <= val && val <= values[i][j+1]) {
           points.push(j);
         }

--- a/bokehjs/src/coffee/models/glyphs/patch.ts
+++ b/bokehjs/src/coffee/models/glyphs/patch.ts
@@ -4,11 +4,10 @@ import {XYGlyph, XYGlyphView} from "./xy_glyph"
 export class PatchView extends XYGlyphView {
 
   _render(ctx, indices, {sx, sy}) {
-    let i;
     if (this.visuals.fill.doit) {
       this.visuals.fill.set_value(ctx);
 
-      for (i of indices) {
+      for (const i of indices) {
         if (i === 0) {
           ctx.beginPath();
           ctx.moveTo(sx[i], sy[i]);
@@ -30,7 +29,7 @@ export class PatchView extends XYGlyphView {
     if (this.visuals.line.doit) {
       this.visuals.line.set_value(ctx);
 
-      for (i of indices) {
+      for (const i of indices) {
         if (i === 0) {
           ctx.beginPath();
           ctx.moveTo(sx[i], sy[i]);

--- a/bokehjs/src/coffee/models/glyphs/patches.ts
+++ b/bokehjs/src/coffee/models/glyphs/patches.ts
@@ -25,7 +25,7 @@ export class PatchesView extends GlyphView {
     //   2: [[x31],[x32]]
     // }
     const ds = {};
-    for (let i = 0, end = nanned_qs.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = nanned_qs.length; i < end; i++) {
       ds[i] = [];
       let qs = copy(nanned_qs[i]);
       while (qs.length > 0) {
@@ -53,8 +53,8 @@ export class PatchesView extends GlyphView {
     const yss = this._build_discontinuous_object(this._ys);
 
     const points = [];
-    for (let i = 0, end = this._xs.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
-      for (let j = 0, end1 = xss[i].length, asc1 = 0 <= end1; asc1 ? j < end1 : j > end1; asc1 ? j++ : j--) {
+    for (let i = 0, end = this._xs.length; i < end; i++) {
+      for (let j = 0, endj = xss[i].length; j < endj; j++) {
         const xs = xss[i][j];
         const ys = yss[i][j];
         if (xs.length === 0) {
@@ -98,7 +98,7 @@ export class PatchesView extends GlyphView {
       if (this.visuals.fill.doit) {
         this.visuals.fill.set_vectorize(ctx, i);
 
-        for (let j = 0, end = sx.length, asc = 0 <= end; asc ? j < end : j > end; asc ? j++ : j--) {
+        for (let j = 0, end = sx.length; j < end; j++) {
           if (j === 0) {
             ctx.beginPath();
             ctx.moveTo(sx[j], sy[j]);
@@ -120,7 +120,7 @@ export class PatchesView extends GlyphView {
       if (this.visuals.line.doit) {
         this.visuals.line.set_vectorize(ctx, i);
 
-        for (let j = 0, end1 = sx.length, asc1 = 0 <= end1; asc1 ? j < end1 : j > end1; asc1 ? j++ : j--) {
+        for (let j = 0, end = sx.length; j < end; j++) {
           if (j === 0) {
             ctx.beginPath();
             ctx.moveTo(sx[j], sy[j]);
@@ -150,11 +150,11 @@ export class PatchesView extends GlyphView {
     const candidates = this.index.indices({minX: x, minY: y, maxX: x, maxY: y});
 
     const hits = [];
-    for (let i = 0, end = candidates.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = candidates.length; i < end; i++) {
       const idx = candidates[i];
       const sxs = this.renderer.sxss[idx];
       const sys = this.renderer.syss[idx];
-      for (let j = 0, end1 = sxs.length, asc1 = 0 <= end1; asc1 ? j < end1 : j > end1; asc1 ? j++ : j--) {
+      for (let j = 0, endj = sxs.length; j < endj; j++) {
         if (hittest.point_in_poly(sx, sy, sxs[j], sys[j])) {
           hits.push(idx);
         }
@@ -183,7 +183,7 @@ export class PatchesView extends GlyphView {
       // one we're in, we can use point_in_poly again
       const sxs = this.renderer.sxss[i];
       const sys = this.renderer.syss[i];
-      for (let j = 0, end = sxs.length, asc = 0 <= end; asc ? j < end : j > end; asc ? j++ : j--) {
+      for (let j = 0, end = sxs.length; j < end; j++) {
         if (hittest.point_in_poly(sx, sy, sxs[j], sys[j])) {
           return this._get_snap_coord(sxs[j]);
         }
@@ -201,7 +201,7 @@ export class PatchesView extends GlyphView {
       // one we're in, we can use point_in_poly again
       const sxs = this.renderer.sxss[i];
       const sys = this.renderer.syss[i];
-      for (let j = 0, end = sxs.length, asc = 0 <= end; asc ? j < end : j > end; asc ? j++ : j--) {
+      for (let j = 0, end = sxs.length; j < end; j++) {
         if (hittest.point_in_poly(sx, sy, sxs[j], sys[j])) {
           return this._get_snap_coord(sys[j]);
         }

--- a/bokehjs/src/coffee/models/glyphs/quadratic.ts
+++ b/bokehjs/src/coffee/models/glyphs/quadratic.ts
@@ -26,7 +26,7 @@ export class QuadraticView extends GlyphView {
 
   _index_data() {
     const points = [];
-    for (let i = 0, end = this._x0.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = this._x0.length; i < end; i++) {
       if (isNaN(this._x0[i] + this._x1[i] + this._y0[i] + this._y1[i] + this._cx[i] + this._cy[i])) {
         continue;
       }

--- a/bokehjs/src/coffee/models/glyphs/ray.ts
+++ b/bokehjs/src/coffee/models/glyphs/ray.ts
@@ -14,19 +14,17 @@ export class RayView extends XYGlyphView {
 
   _render(ctx, indices, {sx, sy, slength, _angle}) {
     if (this.visuals.line.doit) {
-
-      let i;
-      let asc, end;
       const width = this.renderer.plot_view.frame._width.value;
       const height = this.renderer.plot_view.frame._height.value;
       const inf_len = 2 * (width + height);
-      for (i = 0, end = slength.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+
+      for (let i = 0, end = slength.length; i < end; i++) {
         if (slength[i] === 0) {
           slength[i] = inf_len;
         }
       }
 
-      for (i of indices) {
+      for (const i of indices) {
         if (isNaN(sx[i]+sy[i]+_angle[i]+slength[i])) {
           continue;
         }

--- a/bokehjs/src/coffee/models/glyphs/rect.ts
+++ b/bokehjs/src/coffee/models/glyphs/rect.ts
@@ -18,15 +18,13 @@ export class RectView extends XYGlyphView {
   }
 
   _map_data() {
-    let i;
     if (this.model.properties.width.units === "data") {
       [this.sw, this.sx0] = this._map_dist_corner_for_data_side_length(this._x, this._width, this.renderer.xscale, 0);
     } else {
       this.sw = this._width;
       this.sx0 = ((() => {
-        let asc, end;
         const result = [];
-        for (i = 0, end = this.sx.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+        for (let i = 0, end = this.sx.length; i < end; i++) {
           result.push(this.sx[i] - (this.sw[i]/2));
         }
         return result;
@@ -37,28 +35,25 @@ export class RectView extends XYGlyphView {
     } else {
       this.sh = this._height;
       this.sy1 = ((() => {
-        let asc1, end1;
-        const result1 = [];
-        for (i = 0, end1 = this.sy.length, asc1 = 0 <= end1; asc1 ? i < end1 : i > end1; asc1 ? i++ : i--) {
-          result1.push(this.sy[i] - (this.sh[i]/2));
+        const result = [];
+        for (let i = 0, end = this.sy.length; i < end; i++) {
+          result.push(this.sy[i] - (this.sh[i]/2));
         }
-        return result1;
+        return result;
       })());
     }
     return this.ssemi_diag = ((() => {
-      let asc2, end2;
-      const result2 = [];
-      for (i = 0, end2 = this.sw.length, asc2 = 0 <= end2; asc2 ? i < end2 : i > end2; asc2 ? i++ : i--) {
-        result2.push(Math.sqrt((((this.sw[i]/2) * this.sw[i])/2) + (((this.sh[i]/2) * this.sh[i])/2)));
+      const result = [];
+      for (let i = 0, end = this.sw.length; i < end; i++) {
+        result.push(Math.sqrt((((this.sw[i]/2) * this.sw[i])/2) + (((this.sh[i]/2) * this.sh[i])/2)));
       }
-      return result2;
+      return result;
     })());
   }
 
   _render(ctx, indices, {sx, sy, sx0, sy1, sw, sh, _angle}) {
-    let i;
     if (this.visuals.fill.doit) {
-      for (i of indices) {
+      for (const i of indices) {
         if (isNaN(sx[i] + sy[i] + sx0[i] + sy1[i] + sw[i] + sh[i] + _angle[i])) {
           continue;
         }
@@ -81,7 +76,7 @@ export class RectView extends XYGlyphView {
     if (this.visuals.line.doit) {
       ctx.beginPath();
 
-      for (i of indices) {
+      for (const i of indices) {
 
         if (isNaN(sx[i] + sy[i] + sx0[i] + sy1[i] + sw[i] + sh[i] + _angle[i])) {
           continue;
@@ -118,23 +113,20 @@ export class RectView extends XYGlyphView {
   }
 
   _hit_point(geometry) {
-    let i;
     let {sx, sy} = geometry;
     const x = this.renderer.xscale.invert(sx);
     const y = this.renderer.yscale.invert(sy);
 
     const scenter_x = ((() => {
-      let asc, end;
       const result1 = [];
-      for (i = 0, end = this.sx0.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+      for (let i = 0, end = this.sx0.length; i < end; i++) {
         result1.push(this.sx0[i] + (this.sw[i]/2));
       }
       return result1;
     })());
     const scenter_y = ((() => {
-      let asc1, end1;
       const result2 = [];
-      for (i = 0, end1 = this.sy1.length, asc1 = 0 <= end1; asc1 ? i < end1 : i > end1; asc1 ? i++ : i--) {
+      for (let i = 0, end = this.sy1.length; i < end; i++) {
         result2.push(this.sy1[i] + (this.sh[i]/2));
       }
       return result2;
@@ -151,7 +143,7 @@ export class RectView extends XYGlyphView {
     const hits = [];
 
     const bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1]);
-    for (i of this.index.indices(bbox)) {
+    for (let i of this.index.indices(bbox)) {
       let height_in, width_in;
       if (this._angle[i]) {
         const s = Math.sin(-this._angle[i]);
@@ -179,33 +171,29 @@ export class RectView extends XYGlyphView {
 
   _map_dist_corner_for_data_side_length(coord, side_length, scale, dim) {
     let spt_corner;
-    let i;
     if (scale.source_range.synthetic != null) {
       coord = (coord.map((x) => scale.source_range.synthetic(x)));
     }
     const pt0 = ((() => {
-      let asc, end;
       const result = [];
-      for (i = 0, end = coord.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+      for (let i = 0, end = coord.length; i < end; i++) {
         result.push(Number(coord[i]) - (side_length[i]/2));
       }
       return result;
     })());
     const pt1 = ((() => {
-      let asc1, end1;
-      const result1 = [];
-      for (i = 0, end1 = coord.length, asc1 = 0 <= end1; asc1 ? i < end1 : i > end1; asc1 ? i++ : i--) {
-        result1.push(Number(coord[i]) + (side_length[i]/2));
+      const result = [];
+      for (let i = 0, end = coord.length; i < end; i++) {
+        result.push(Number(coord[i]) + (side_length[i]/2));
       }
-      return result1;
+      return result;
     })());
     const spt0 = scale.v_compute(pt0);
     const spt1 = scale.v_compute(pt1);
     const sside_length = this.sdist(scale, pt0, side_length, 'edge', this.model.dilate);
     if (dim === 0) {
-      let asc2, end2;
       spt_corner = spt0;
-      for (i = 0, end2 = spt0.length, asc2 = 0 <= end2; asc2 ? i < end2 : i > end2; asc2 ? i++ : i--) {
+      for (let i = 0, end = spt0.length; i < end; i++) {
         if (spt0[i] !== spt1[i]) {
           spt_corner = spt0[i] < spt1[i] ? spt0 : spt1;
           break;
@@ -213,9 +201,8 @@ export class RectView extends XYGlyphView {
       }
       return [sside_length, spt_corner];
     } else if (dim === 1) {
-      let asc3, end3;
       spt_corner = spt0;
-      for (i = 0, end3 = spt0.length, asc3 = 0 <= end3; asc3 ? i < end3 : i > end3; asc3 ? i++ : i--) {
+      for (let i = 0, end = spt0.length; i < end; i++) {
         if (spt0[i] !== spt1[i]) {
           spt_corner = spt0[i] < spt1[i] ? spt0 : spt1;
           break;
@@ -227,7 +214,6 @@ export class RectView extends XYGlyphView {
 
   _ddist(dim, spts, spans) {
     let scale;
-    let i;
     if (dim === 0) {
       scale = this.renderer.xscale;
     } else {
@@ -236,9 +222,8 @@ export class RectView extends XYGlyphView {
 
     const spt0 = spts;
     const spt1 = ((() => {
-      let asc, end;
       const result = [];
-      for (i = 0, end = spt0.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+      for (let i = 0, end = spt0.length; i < end; i++) {
         result.push(spt0[i] + spans[i]);
       }
       return result;
@@ -248,12 +233,11 @@ export class RectView extends XYGlyphView {
     const pt1 = scale.v_invert(spt1);
 
     return ((() => {
-      let asc1, end1;
-      const result1 = [];
-      for (i = 0, end1 = pt0.length, asc1 = 0 <= end1; asc1 ? i < end1 : i > end1; asc1 ? i++ : i--) {
-        result1.push(Math.abs(pt1[i] - pt0[i]));
+      const result = [];
+      for (let i = 0, end = pt0.length; i < end; i++) {
+        result.push(Math.abs(pt1[i] - pt0[i]));
       }
-      return result1;
+      return result;
     })());
   }
 

--- a/bokehjs/src/coffee/models/glyphs/segment.ts
+++ b/bokehjs/src/coffee/models/glyphs/segment.ts
@@ -7,7 +7,7 @@ export class SegmentView extends GlyphView {
 
   _index_data() {
     const points = [];
-    for (let i = 0, end = this._x0.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = this._x0.length; i < end; i++) {
       if (!isNaN(this._x0[i] + this._x1[i] + this._y0[i] + this._y1[i])) {
         points.push({
           minX: Math.min(this._x0[i], this._x1[i]),

--- a/bokehjs/src/coffee/models/glyphs/step.ts
+++ b/bokehjs/src/coffee/models/glyphs/step.ts
@@ -16,8 +16,7 @@ export class StepView extends XYGlyphView {
 
     ctx.moveTo(sx[0], sy[0]);
 
-    for (let i = 1, end = L, asc = 1 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
-
+    for (let i = 1, end = L; i < end; i++) {
       let x1, x2, y1, y2;
       switch (this.model.mode) {
         case "before": {

--- a/bokehjs/src/coffee/models/glyphs/vbar.ts
+++ b/bokehjs/src/coffee/models/glyphs/vbar.ts
@@ -27,7 +27,7 @@ export class VBarView extends BoxView {
     this.sleft = [];
     this.sright = [];
     this.sw = this.sdist(this.renderer.xscale, this._x, this._width, 'center');
-    for (let i = 0, end = this.sx.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = this.sx.length; i < end; i++) {
       this.sleft.push(this.sx[i] - (this.sw[i]/2));
       this.sright.push(this.sx[i] + (this.sw[i]/2));
     }

--- a/bokehjs/src/coffee/models/glyphs/webgl/base.ts
+++ b/bokehjs/src/coffee/models/glyphs/webgl/base.ts
@@ -71,7 +71,7 @@ export const line_width = function(width) {
 
 export const fill_array_with_float = function(n, val) {
     const a = new Float32Array(n);
-    for (let i = 0, end = n, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = n; i < end; i++) {
       a[i] = val;
     }
     return a;
@@ -79,8 +79,8 @@ export const fill_array_with_float = function(n, val) {
 
 export const fill_array_with_vec = function(n, m, val) {
     const a = new Float32Array(n*m);
-    for (let i = 0, end = n, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
-      for (let j = 0, end1 = m, asc1 = 0 <= end1; asc1 ? j < end1 : j > end1; asc1 ? j++ : j--) {
+    for (let i = 0, end = n; i < end; i++) {
+      for (let j = 0, endj = m; j < endj; j++) {
         a[(i*m)+j] = val[j];
       }
     }
@@ -116,7 +116,6 @@ export const attach_color = function(prog, vbo, att_name, n, visual, prefix) {
     // then use this single color for all vertices (no VBO). Otherwise we
     // create an array and upload that to the VBO, which we attahce to the prog.
     let rgba;
-    let i;
     const m = 4;
     const colorname = prefix + '_color';
     const alphaname = prefix + '_alpha';
@@ -133,14 +132,12 @@ export const attach_color = function(prog, vbo, att_name, n, visual, prefix) {
     } else {
       // Use vbo; we need an array for both the color and the alpha
       let alphas, colors;
-      let asc1, end1;
       vbo.used = true;
       // Get array of colors
       if (visual_prop_is_singular(visual, colorname)) {
         colors = ((() => {
-          let asc, end;
           const result = [];
-          for (i = 0, end = n, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+          for (let i = 0, end = n; i < end; i++) {
             result.push(visual[colorname].value());
           }
           return result;
@@ -156,9 +153,9 @@ export const attach_color = function(prog, vbo, att_name, n, visual, prefix) {
       }
       // Create array of rgbs
       const a = new Float32Array(n*m);
-      for (i = 0, end1 = n, asc1 = 0 <= end1; asc1 ? i < end1 : i > end1; asc1 ? i++ : i--) {
+      for (let i = 0, end = n; i < end; i++) {
         rgba = color2rgba(colors[i], alphas[i]);
-        for (let j = 0, end2 = m, asc2 = 0 <= end2; asc2 ? j < end2 : j > end2; asc2 ? j++ : j--) {
+        for (let j = 0, endj = m; j < endj; j++) {
           a[(i*m)+j] = rgba[j];
         }
       }

--- a/bokehjs/src/coffee/models/glyphs/webgl/line.ts
+++ b/bokehjs/src/coffee/models/glyphs/webgl/line.ts
@@ -37,9 +37,6 @@ class DashAtlas {
   make_pattern(pattern) {
     // A pattern is defined as on/off sequence of segments
     // It must be a multiple of 2
-    let i;
-    let end;
-    let asc, end1;
     if ((pattern.length > 1) && (pattern.length % 2)) {
       pattern = pattern.concat(pattern);
     }
@@ -50,7 +47,7 @@ class DashAtlas {
     }
     // Find all start and end of on-segment only
     const C: number[] = []; let c = 0;
-    for (i = 0, end = pattern.length+2; i < end; i += 2) {
+    for (let i = 0, end = pattern.length+2; i < end; i += 2) {
       const a = Math.max(0.0001, pattern[i % pattern.length]);
       const b = Math.max(0.0001, pattern[(i+1) % pattern.length]);
       C.push(c, c + a)
@@ -59,12 +56,12 @@ class DashAtlas {
     // Build pattern
     const n = this._width;
     const Z = new Float32Array(n * 4);
-    for (i = 0, end1 = n, asc = 0 <= end1; asc ? i < end1 : i > end1; asc ? i++ : i--) {
+    for (let i = 0, end = n; i < end; i++) {
       let dash_end, dash_start, dash_type;
       const x = (period * i) / (n-1);
       // get index at min - index = np.argmin(abs(C-(x)))
       let index = 0; let val_at_index = 1e16;
-      for (let j = 0, end2 = C.length, asc1 = 0 <= end2; asc1 ? j < end2 : j > end2; asc1 ? j++ : j--) {
+      for (let j = 0, endj = C.length; j < endj; j++) {
         const val = Math.abs(C[j]-x);
         if (val < val_at_index) {
            index = j; val_at_index = val;
@@ -182,24 +179,20 @@ export class LineGLGlyph extends BaseGLGlyph {
       } else {
         // Work around the limit that the indexbuffer must be uint16. We draw in chunks.
         // First collect indices in chunks
-        let chunk, i;
-        let asc, end;
-        let asc1, end1;
         indices = this.I_triangles;
         const nvertices = this.I_triangles.length;
         const chunksize = 64008;  // 65536 max. 64008 is divisible by 12
         const chunks = [];
-        for (i = 0, end = Math.ceil(nvertices/chunksize), asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+        for (let i = 0, end = Math.ceil(nvertices/chunksize); i < end; i++) {
            chunks.push([]);
         }
-        for (i = 0, end1 = indices.length, asc1 = 0 <= end1; asc1 ? i < end1 : i > end1; asc1 ? i++ : i--) {
+        for (let i = 0, end = indices.length; i < end; i++) {
           const uint16_index = indices[i] % chunksize;
-          chunk = Math.floor(indices[i] / chunksize);
+          const chunk = Math.floor(indices[i] / chunksize);
           chunks[chunk].push(uint16_index);
         }
         // Then draw each chunk
-        let asc2, end2;
-        for (chunk = 0, end2 = chunks.length, asc2 = 0 <= end2; asc2 ? chunk < end2 : chunk > end2; asc2 ? chunk++ : chunk--) {
+        for (let chunk = 0, end = chunks.length; chunk < end; chunk++) {
           const these_indices = new Uint16Array(chunks[chunk]);
           const offset = chunk * chunksize * 4;
           if (these_indices.length === 0) {
@@ -275,14 +268,7 @@ export class LineGLGlyph extends BaseGLGlyph {
       //                         ('a_texcoord', 'f4', 2) ])
 
       // Init array of implicit shape nx2
-      let i, I, T, V_angles2, V_position2, V_tangents2, V_texcoord2, Vp, Vt;
-      let asc, end;
-      let asc1, end1;
-      let asc2, end2;
-      let asc3, end3;
-      let asc4, end4;
-      let asc5, end5;
-      let asc6, end6;
+      let I, T, V_angles2, V_position2, V_tangents2, V_texcoord2, Vp, Vt;
       const n = this.nvertices;
       const _x = new Float64Array(this.glyph._x);
       const _y = new Float64Array(this.glyph._y);
@@ -294,19 +280,19 @@ export class LineGLGlyph extends BaseGLGlyph {
       const V_tangents = (Vt = new Float32Array(n*4));  // mind the 4!
 
       // Position
-      for (i = 0, end = n, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+      for (let i = 0, end = n; i < end; i++) {
         V_position[(i*2)+0] = _x[i] + this._baked_offset[0];
         V_position[(i*2)+1] = _y[i] + this._baked_offset[1];
       }
 
       // Tangents & norms (need tangents to calculate segments based on scale)
       this.tangents = (T = new Float32Array((n*2)-2));
-      for (i = 0, end1 = n-1, asc1 = 0 <= end1; asc1 ? i < end1 : i > end1; asc1 ? i++ : i--) {
+      for (let i = 0, end = n-1; i < end; i++) {
         T[(i*2)+0] = Vp[((i+1)*2)+0] - Vp[(i*2)+0];
         T[(i*2)+1] = Vp[((i+1)*2)+1] - Vp[(i*2)+1];
       }
 
-      for (i = 0, end2 = n-1, asc2 = 0 <= end2; asc2 ? i < end2 : i > end2; asc2 ? i++ : i--) {
+      for (let i = 0, end = n-1; i < end; i++) {
         // V['a_tangents'][+1:, :2] = T
         V_tangents[((i+1)*4)+0] = T[(i*2)+0];
         V_tangents[((i+1)*4)+1] = T[(i*2)+1];
@@ -324,11 +310,11 @@ export class LineGLGlyph extends BaseGLGlyph {
 
       // Angles
       const A = new Float32Array(n);
-      for (i = 0, end3 = n, asc3 = 0 <= end3; asc3 ? i < end3 : i > end3; asc3 ? i++ : i--) {
+      for (let i = 0, end = n; i < end; i++) {
         A[i] = Math.atan2((Vt[(i*4)+0]*Vt[(i*4)+3]) - (Vt[(i*4)+1]*Vt[(i*4)+2]),
                           (Vt[(i*4)+0]*Vt[(i*4)+2]) + (Vt[(i*4)+1]*Vt[(i*4)+3]));
       }
-      for (i = 0, end4 = n-1, asc4 = 0 <= end4; asc4 ? i < end4 : i > end4; asc4 ? i++ : i--) {
+      for (let i = 0, end = n-1; i < end; i++) {
         V_angles[(i*2)+0] = A[i];
         V_angles[(i*2)+1] = A[i+1];
       }
@@ -344,20 +330,19 @@ export class LineGLGlyph extends BaseGLGlyph {
       const o = 2;
       //
       // Arg, we really need an ndarray thing in JS :/
-      for (i = 0, end5 = n, asc5 = 0 <= end5; asc5 ? i < end5 : i > end5; asc5 ? i++ : i--) {  // all nodes on the line
+      for (let i = 0, end = n; i < end; i++) {  // all nodes on the line
          for (let j = 0; j < 4; j++) {  // the four quad vertices
-            var k;
-            for (k = 0; k < 2; k++) {  // xy
-              V_position2[((((i*4)+j)-o)*2)+k] = V_position[(i*2)+k];
-              V_angles2[(((i*4)+j)*2)+k] = V_angles[(i*2)+k];
+          for (let k = 0; k < 2; k++) {  // xy
+            V_position2[((((i*4)+j)-o)*2)+k] = V_position[(i*2)+k];
+            V_angles2[(((i*4)+j)*2)+k] = V_angles[(i*2)+k];
           }  // no offset
-            for (k = 0; k < 4; k++) {
-              V_tangents2[((((i*4)+j)-o)*4)+k] = V_tangents[(i*4)+k];
+          for (let k = 0; k < 4; k++) {
+            V_tangents2[((((i*4)+j)-o)*4)+k] = V_tangents[(i*4)+k];
           }
         }
       }
 
-      for (i = 0, end6 = n, asc6 = 0 <= end6; asc6 ? i <= end6 : i >= end6; asc6 ? i++ : i--) {
+      for (let i = 0, end = n; i < end; i++) {
         V_texcoord2[(((i*4)+0)*2)+0] = -1;
         V_texcoord2[(((i*4)+1)*2)+0] = -1;
         V_texcoord2[(((i*4)+2)*2)+0] = +1;
@@ -377,8 +362,7 @@ export class LineGLGlyph extends BaseGLGlyph {
       // Order of indices is such that drawing as line_strip reveals the line skeleton
       // Might have implications on culling, if we ever turn that on.
       // Order in paper was: 0 1 2 1 2 3
-      let asc7, end7;
-      for (i = 0, end7 = n, asc7 = 0 <= end7; asc7 ? i < end7 : i > end7; asc7 ? i++ : i--) {
+      for (let i = 0, end = n; i < end; i++) {
         I[(i*6)+0] = 0 + (4*i);
         I[(i*6)+1] = 1 + (4*i);
         I[(i*6)+2] = 3 + (4*i);
@@ -393,10 +377,7 @@ export class LineGLGlyph extends BaseGLGlyph {
       // scale aspect ratio in it. In the vertex shader we multiply with the
       // "isotropic part" of the scale.
 
-      let i, V_segment2;
-      let asc, end;
-      let asc1, end1;
-      let asc2, end2;
+      let V_segment2;
       const n = this.nvertices;
       const m = (4 * n) - 4;
       // Prepare arrays
@@ -405,18 +386,18 @@ export class LineGLGlyph extends BaseGLGlyph {
       const V_segment = new Float32Array(n*2);  // Elements are initialized with 0
       this.V_segment = (V_segment2 = new Float32Array(m*2));
       // Calculate vector lengths - with scale aspect ratio taken into account
-      for (i = 0, end = n-1, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+      for (let i = 0, end = n-1; i < end; i++) {
         N[i] = Math.sqrt(Math.pow(T[(i*2)+0] * sx, 2) + Math.pow(T[(i*2)+1] * sy, 2));
       }
       // Calculate Segments
       let cumsum = 0;
-      for (i = 0, end1 = n-1, asc1 = 0 <= end1; asc1 ? i < end1 : i > end1; asc1 ? i++ : i--) {
+      for (let i = 0, end = n-1; i < end; i++) {
         cumsum += N[i];
         V_segment[((i+1)*2)+0] = cumsum;
         V_segment[(i*2)+1] = cumsum;
       }
       // Upscale (same loop as in _bake())
-      for (i = 0, end2 = n, asc2 = 0 <= end2; asc2 ? i < end2 : i > end2; asc2 ? i++ : i--) {
+      for (let i = 0, end = n; i < end; i++) {
          for (let j = 0; j < 4; j++) {
             for (let k = 0; k < 2; k++) {
               V_segment2[(((i*4)+j)*2)+k] = V_segment[(i*2)+k];

--- a/bokehjs/src/coffee/models/glyphs/webgl/markers.ts
+++ b/bokehjs/src/coffee/models/glyphs/webgl/markers.ts
@@ -198,22 +198,18 @@ void main()
     } else {
       // Work around the limit that the indexbuffer must be uint16. We draw in chunks.
       // First collect indices in chunks
-      let chunk, i;
-      let asc, end;
-      let asc1, end1;
       const chunksize = 64000;  // 65536
       const chunks = [];
-      for (i = 0, end = Math.ceil(nvertices/chunksize), asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+      for (let i = 0, end = Math.ceil(nvertices/chunksize); i < end; i++) {
          chunks.push([]);
       }
-      for (i = 0, end1 = indices.length, asc1 = 0 <= end1; asc1 ? i < end1 : i > end1; asc1 ? i++ : i--) {
+      for (let i = 0, end = indices.length; i < end; i++) {
         const uint16_index = indices[i] % chunksize;
-        chunk = Math.floor(indices[i] / chunksize);
+        const chunk = Math.floor(indices[i] / chunksize);
         chunks[chunk].push(uint16_index);
       }
       // Then draw each chunk
-      let asc2, end2;
-      for (chunk = 0, end2 = chunks.length, asc2 = 0 <= end2; asc2 ? chunk < end2 : chunk > end2; asc2 ? chunk++ : chunk--) {
+      for (let chunk = 0, end = chunks.length; chunk < end; chunk++) {
         const these_indices = new Uint16Array(chunks[chunk]);
         const offset = chunk * chunksize * 4;
         if (these_indices.length === 0) {
@@ -251,7 +247,7 @@ void main()
     // The exact value for the baked_offset does not matter, as long as it brings the data to less extreme values
     const xx = new Float64Array(this.glyph._x);
     const yy = new Float64Array(this.glyph._y);
-    for (let i = 0, end = nvertices, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = nvertices; i < end; i++) {
        xx[i] += this._baked_offset[0];
        yy[i] += this._baked_offset[1];
     }

--- a/bokehjs/src/coffee/models/glyphs/xy_glyph.ts
+++ b/bokehjs/src/coffee/models/glyphs/xy_glyph.ts
@@ -7,7 +7,7 @@ export class XYGlyphView extends GlyphView {
   _index_data() {
     const points = [];
 
-    for (let i = 0, end = this._x.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = this._x.length; i < end; i++) {
       const x = this._x[i];
       const y = this._y[i];
       if (isNaN(x+y) || !isFinite(x+y)) {

--- a/bokehjs/src/coffee/models/graphs/graph_hit_test_policy.ts
+++ b/bokehjs/src/coffee/models/graphs/graph_hit_test_policy.ts
@@ -60,8 +60,6 @@ export class NodesAndLinkedEdges extends GraphHitTestPolicy {
   }
 
   _do(geometry, graph_view, final, append) {
-    let asc, end;
-    let i;
     const [node_view, edge_view] = [graph_view.node_view, graph_view.edge_view];
     const hit_test_result = node_view.glyph.hit_test(geometry);
 
@@ -74,20 +72,21 @@ export class NodesAndLinkedEdges extends GraphHitTestPolicy {
 
     const node_indices = ((() => {
       const result = [];
-      for (i of hit_test_result["1d"].indices) {         result.push(node_view.model.data_source.data.index[i]);
+      for (let i of hit_test_result["1d"].indices) {
+        result.push(node_view.model.data_source.data.index[i]);
       }
       return result;
     })());
     const edge_source = edge_view.model.data_source;
     const edge_indices = [];
-    for (i = 0, end = edge_source.data.start.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = edge_source.data.start.length; i < end; i++) {
       if (includes(node_indices, edge_source.data.start[i]) || includes(node_indices, edge_source.data.end[i])) {
         edge_indices.push(i);
       }
     }
 
     const linked_index = create_hit_test_result();
-    for (i of edge_indices) {
+    for (const i of edge_indices) {
       linked_index["2d"].indices[i] = [0];
     } //currently only supports 2-element multilines, so this is all of it
 
@@ -132,7 +131,6 @@ export class EdgesAndLinkedNodes extends GraphHitTestPolicy {
   }
 
   _do(geometry, graph_view, final, append) {
-    let i;
     const [node_view, edge_view] = [graph_view.node_view, graph_view.edge_view];
     const hit_test_result = edge_view.glyph.hit_test(geometry);
 
@@ -145,22 +143,24 @@ export class EdgesAndLinkedNodes extends GraphHitTestPolicy {
 
     const edge_indices = ((() => {
       const result = [];
-      for (i of Object.keys(hit_test_result['2d'].indices)) {         result.push(parseInt(i));
+      for (const i of Object.keys(hit_test_result['2d'].indices)) {
+        result.push(parseInt(i));
       }
       return result;
     })());
 
     const nodes = [];
-    for (i of edge_indices) {
+    for (const i of edge_indices) {
       nodes.push(edge_view.model.data_source.data.start[i]);
       nodes.push(edge_view.model.data_source.data.end[i]);
     }
 
     const node_indices = ((() => {
-      const result1 = [];
-      for (i of uniq(nodes)) {         result1.push(node_view.model.data_source.data.index.indexOf(i));
+      const result = [];
+      for (const i of uniq(nodes)) {
+        result.push(node_view.model.data_source.data.index.indexOf(i));
       }
-      return result1;
+      return result;
     })());
 
     const node_hit_test_result = create_hit_test_result();

--- a/bokehjs/src/coffee/models/graphs/static_layout_provider.ts
+++ b/bokehjs/src/coffee/models/graphs/static_layout_provider.ts
@@ -27,7 +27,7 @@ export class StaticLayoutProvider extends LayoutProvider {
     const starts = edge_source.data.start;
     const ends = edge_source.data.end;
     const has_paths = (edge_source.data.xs != null) && (edge_source.data.ys != null);
-    for (let i = 0, end1 = starts.length, asc = 0 <= end1; asc ? i < end1 : i > end1; asc ? i++ : i--) {
+    for (let i = 0, endi = starts.length; i < endi; i++) {
       const in_layout = (this.graph_layout[starts[i]] != null) && (this.graph_layout[ends[i]] != null);
       if (has_paths && in_layout) {
         xs.push(edge_source.data.xs[i]);

--- a/bokehjs/src/coffee/models/mappers/categorical_color_mapper.ts
+++ b/bokehjs/src/coffee/models/mappers/categorical_color_mapper.ts
@@ -9,7 +9,7 @@ const _equals = function(a, b) {
   if (a.length !== b.length) {
     return false;
   }
-  for (let i = 0, end = a.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+  for (let i = 0, end = a.length; i < end; i++) {
     if (a[i] !== b[i]) {
       return false;
     }

--- a/bokehjs/src/coffee/models/mappers/color_mapper.ts
+++ b/bokehjs/src/coffee/models/mappers/color_mapper.ts
@@ -26,14 +26,12 @@ export class ColorMapper extends Transform {
 
   // TODO (bev) This should not be needed, everything should use v_compute
   v_map_screen(data, image_glyph = false) {
-    let color, i, value;
     const values = this._get_values(data, this._palette, image_glyph);
     const buf = new ArrayBuffer(data.length * 4);
     if (this._little_endian) {
-      let asc, end;
-      color = new Uint8Array(buf);
-      for (i = 0, end = data.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
-        value = values[i];
+      const color = new Uint8Array(buf);
+      for (let i = 0, end = data.length; i < end; i++) {
+        const value = values[i];
         const ind = i*4;
         // Bitwise math in JS is limited to 31-bits, to handle 32-bit value
         // this uses regular math to compute alpha instead (see issue #6755)
@@ -43,10 +41,9 @@ export class ColorMapper extends Transform {
         color[ind+3] = value & 0xff;
       }
     } else {
-      let asc1, end1;
-      color = new Uint32Array(buf);
-      for (i = 0, end1 = data.length, asc1 = 0 <= end1; asc1 ? i < end1 : i > end1; asc1 ? i++ : i--) {
-        value = values[i];
+      const color = new Uint32Array(buf);
+      for (let i = 0, end = data.length; i < end; i++) {
+        const value = values[i];
         color[i] = (value << 8) | 0xff;
       }     // alpha
     }
@@ -94,7 +91,7 @@ export class ColorMapper extends Transform {
         return parseInt(value.slice(1), 16);
       }
     };
-    for (let i = 0, end = palette.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = palette.length; i < end; i++) {
       new_palette[i] = _convert(palette[i]);
     }
     return new_palette;

--- a/bokehjs/src/coffee/models/markers/marker.ts
+++ b/bokehjs/src/coffee/models/markers/marker.ts
@@ -136,7 +136,7 @@ export class MarkerView extends XYGlyphView {
     const candidates = range(0, this.sx.length);
 
     const hits = [];
-    for (let i = 0, end = candidates.length, asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = candidates.length; i < end; i++) {
       const idx = candidates[i];
       if (hittest.point_in_poly(this.sx[i], this.sy[i], sx, sy)) {
         hits.push(idx);

--- a/bokehjs/src/coffee/models/plots/plot_canvas.ts
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.ts
@@ -511,26 +511,25 @@ export class PlotCanvasView extends DOMView {
     }
 
   update_range(range_info, is_panning: boolean = false, is_scrolling: boolean = false): void {
-    let name, rng;
     this.pause();
     if ((range_info == null)) {
-      for (name in this.frame.x_ranges) {
-        rng = this.frame.x_ranges[name];
+      for (const name in this.frame.x_ranges) {
+        const rng = this.frame.x_ranges[name];
         rng.reset();
       }
-      for (name in this.frame.y_ranges) {
-        rng = this.frame.y_ranges[name];
+      for (const name in this.frame.y_ranges) {
+        const rng = this.frame.y_ranges[name];
         rng.reset();
       }
       this.update_dataranges();
     } else {
       const range_info_iter = [];
-      for (name in this.frame.x_ranges) {
-        rng = this.frame.x_ranges[name];
+      for (const name in this.frame.x_ranges) {
+        const rng = this.frame.x_ranges[name];
         range_info_iter.push([rng, range_info.xrs[name]]);
       }
-      for (name in this.frame.y_ranges) {
-        rng = this.frame.y_ranges[name];
+      for (const name in this.frame.y_ranges) {
+        const rng = this.frame.y_ranges[name];
         range_info_iter.push([rng, range_info.yrs[name]]);
       }
       if (is_scrolling) {
@@ -666,10 +665,10 @@ export class PlotCanvasView extends DOMView {
       return false;
     }
 
-    for (let _ in this.levels) {
-      const renderer_views = this.levels[_];
-      for (_ in renderer_views) {
-        const view = renderer_views[_];
+    for (const level in this.levels) {
+      const renderer_views = this.levels[level];
+      for (const id in renderer_views) {
+        const view = renderer_views[id];
         if (!view.has_finished()) {
           return false;
         }

--- a/bokehjs/src/coffee/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/coffee/models/renderers/glyph_renderer.ts
@@ -133,7 +133,7 @@ export class GlyphRendererView extends RendererView {
 
     const { lod_factor } = this.plot_model.plot;
     this.decimated = [];
-    for (let i = 0, end = Math.floor(this.all_indices.length/lod_factor), asc = 0 <= end; asc ? i < end : i > end; asc ? i++ : i--) {
+    for (let i = 0, end = Math.floor(this.all_indices.length/lod_factor); i < end; i++) {
       this.decimated.push(i*lod_factor);
     }
 
@@ -149,7 +149,6 @@ export class GlyphRendererView extends RendererView {
 
   render() {
     let dtrender, dtselect, glyph, nonselection_glyph, selection_glyph, trender;
-    let i;
     if (!this.model.visible) {
       return;
     }
@@ -185,7 +184,8 @@ export class GlyphRendererView extends RendererView {
       } else {
         selected = ((() => {
           const result = [];
-          for (i of Object.keys(selected["2d"].indices)) {             result.push(parseInt(i));
+          for (const i of Object.keys(selected["2d"].indices)) {
+            result.push(parseInt(i));
           }
           return result;
         })());
@@ -203,22 +203,24 @@ export class GlyphRendererView extends RendererView {
         inspected = inspected['1d'].indices;
       } else {
         inspected = ((() => {
-          const result1 = [];
-          for (i of Object.keys(inspected["2d"].indices)) {             result1.push(parseInt(i));
+          const result = [];
+          for (const i of Object.keys(inspected["2d"].indices)) {
+            result.push(parseInt(i));
           }
-          return result1;
+          return result;
         })());
       }
     }
 
     // inspected is transformed to subset space
     inspected = ((() => {
-      const result2 = [];
-      for (i of indices) {         if (includes(inspected, this.all_indices[i])) {
-          result2.push(i);
+      const result = [];
+      for (const i of indices) {
+        if (includes(inspected, this.all_indices[i])) {
+          result.push(i);
         }
       }
-      return result2;
+      return result;
     })());
 
     const { lod_threshold } = this.plot_model.plot;
@@ -258,7 +260,7 @@ export class GlyphRendererView extends RendererView {
       // reset the selection mask
       const tselect = Date.now();
       const selected_mask = {};
-      for (i of selected) {
+      for (const i of selected) {
         selected_mask[i] = true;
       }
 
@@ -268,7 +270,7 @@ export class GlyphRendererView extends RendererView {
 
       // now, selected is changed to subset space, except for Line glyph
       if (this.glyph instanceof LineView) {
-        for (i of this.all_indices) {
+        for (const i of this.all_indices) {
           if (selected_mask[i] != null) {
             selected.push(i);
           } else {
@@ -276,7 +278,7 @@ export class GlyphRendererView extends RendererView {
           }
         }
       } else {
-        for (i of indices) {
+        for (const i of indices) {
           if (selected_mask[this.all_indices[i]] != null) {
             selected.push(i);
           } else {

--- a/bokehjs/src/coffee/models/sources/column_data_source.ts
+++ b/bokehjs/src/coffee/models/sources/column_data_source.ts
@@ -30,10 +30,6 @@ export const stream_to_column = function(col, new_col, rollover) {
 
   // handle rollover case for typed arrays
   if ((rollover != null) && (total_len > rollover)) {
-
-    let i
-    let asc, end1
-    let asc1, end2
     const start = total_len - rollover
     const end = col.length
 
@@ -45,12 +41,12 @@ export const stream_to_column = function(col, new_col, rollover) {
     }
 
     // shift values in original col to accommodate new_col
-    for (i = start, end1 = end, asc = start <= end1; asc ? i < end1 : i > end1; asc ? i++ : i--) {
+    for (let i = start, endi = end; i < endi; i++) {
       col[i-start] = col[i]
     }
 
     // update end values in col with new_col
-    for (i = 0, end2 = new_col.length, asc1 = 0 <= end2; asc1 ? i < end2 : i > end2; asc1 ? i++ : i--) {
+    for (let i = 0, endi = new_col.length; i < endi; i++) {
       col[i+(end-start)] = new_col[i]
     }
 
@@ -111,8 +107,8 @@ export const patch_to_column = function(col, patch, shapes) {
     const [istart, istop, istep] = slice(ind[1], shape[0])
     const [jstart, jstop, jstep] = slice(ind[2], shape[1])
 
-    for (let i = istart, end = istop, step = istep, asc = step > 0; asc ? i < end : i > end; i += step) {
-      for (let j = jstart, end1 = jstop, step1 = jstep, asc1 = step1 > 0; asc1 ? j < end1 : j > end1; j += step1) {
+    for (let i = istart; i < istop; i += istep) {
+      for (let j = jstart; j < jstop; j += jstep) {
         if (patched_range) {
           patched.push(j)
         }

--- a/bokehjs/src/coffee/models/tools/gestures/tap_tool.ts
+++ b/bokehjs/src/coffee/models/tools/gestures/tap_tool.ts
@@ -39,7 +39,7 @@ export class TapToolView extends SelectToolView {
     if (this.model.behavior == "select") {
       const renderers_by_source = this._computed_renderers_by_data_source()
 
-      for(const id in renderers_by_source) {
+      for (const id in renderers_by_source) {
         const renderers = renderers_by_source[id]
         const sm = renderers[0].get_selection_manager()
         const r_views = renderers.map((r) => this.plot_view.renderer_views[r.id])

--- a/bokehjs/src/coffee/models/tools/toolbar.ts
+++ b/bokehjs/src/coffee/models/tools/toolbar.ts
@@ -30,7 +30,6 @@ export class Toolbar extends ToolbarBase {
   }
 
   _init_tools() {
-    let et;
     for (const tool of this.tools) {
       if (tool instanceof InspectTool) {
         if (!any(this.inspectors, t => t.id === tool.id)) {
@@ -52,7 +51,7 @@ export class Toolbar extends ToolbarBase {
           multi = false;
         }
 
-        for (et of event_types) {
+        for (let et of event_types) {
           if (!(et in this.gestures)) {
             logger.warn(`Toolbar: unknown event type '${et}' for tool: ${tool.type} (${tool.id})`);
             continue;
@@ -89,7 +88,7 @@ export class Toolbar extends ToolbarBase {
       }
     };
 
-    for (et in this.gestures) {
+    for (const et in this.gestures) {
       const { tools } = this.gestures[et];
       if (tools.length === 0) {
         continue;

--- a/bokehjs/src/coffee/models/tools/toolbar_base.ts
+++ b/bokehjs/src/coffee/models/tools/toolbar_base.ts
@@ -34,7 +34,7 @@ export class ToolbarBaseView extends DOMView {
   }
 
   render() {
-    let buttons, tool;
+    let buttons
     empty(this.el);
 
     this.el.classList.add("bk-toolbar");
@@ -51,20 +51,20 @@ export class ToolbarBaseView extends DOMView {
     const { gestures } = this.model;
     for (const et in gestures) {
       buttons = [];
-      for (tool of gestures[et].tools) {
+      for (const tool of gestures[et].tools) {
         buttons.push(this._tool_button_views[tool.id].el);
       }
       bars.push(buttons);
     }
 
     buttons = [];
-    for (tool of this.model.actions) {
+    for (const tool of this.model.actions) {
       buttons.push(this._tool_button_views[tool.id].el);
     }
     bars.push(buttons);
 
     buttons = [];
-    for (tool of this.model.inspectors) {
+    for (const tool of this.model.inspectors) {
       if (tool.toggleable) {
         buttons.push(this._tool_button_views[tool.id].el);
       }
@@ -72,15 +72,15 @@ export class ToolbarBaseView extends DOMView {
     bars.push(buttons);
 
     buttons = [];
-    for (tool of this.model.help) {
+    for (const tool of this.model.help) {
       buttons.push(this._tool_button_views[tool.id].el);
     }
     bars.push(buttons);
 
-    for (buttons of bars) {
-      if (buttons.length !== 0) {
-        const bar = div({class: 'bk-button-bar'}, buttons);
-        this.el.appendChild(bar);
+    for (const bar of bars) {
+      if (bar.length !== 0) {
+        const el = div({class: 'bk-button-bar'}, bar);
+        this.el.appendChild(el);
       }
     }
 

--- a/bokehjs/src/coffee/models/tools/toolbar_box.ts
+++ b/bokehjs/src/coffee/models/tools/toolbar_box.ts
@@ -74,7 +74,7 @@ export class ProxyToolbar extends ToolbarBase {
     // Go through all the tools on the toolbar and replace them with
     // a proxy e.g. PanTool, BoxSelectTool, etc.
 
-    let active, tool, tool_type, tools;
+    let active, tools;
     this._proxied_tools = [];
 
     const inspectors = {};
@@ -97,7 +97,7 @@ export class ProxyToolbar extends ToolbarBase {
       if (!(event_type in gestures)) {
         gestures[event_type] = {};
       }
-      for (tool of info.tools) {
+      for (const tool of info.tools) {
         if (!(tool.type in gestures[event_type])) {
           gestures[event_type][tool.type] = [];
         }
@@ -105,14 +105,14 @@ export class ProxyToolbar extends ToolbarBase {
       }
     }
 
-    for (tool of this.inspectors) {
+    for (const tool of this.inspectors) {
       if (!(tool.type in inspectors)) {
         inspectors[tool.type] = [];
       }
       inspectors[tool.type].push(tool);
     }
 
-    for (tool of this.actions) {
+    for (const tool of this.actions) {
       if (!(tool.type in actions)) {
         actions[tool.type] = [];
       }
@@ -128,7 +128,7 @@ export class ProxyToolbar extends ToolbarBase {
 
     for (const event_type in gestures) {
       this.gestures[event_type].tools = [];
-      for (tool_type in gestures[event_type]) {
+      for (const tool_type in gestures[event_type]) {
         tools = gestures[event_type][tool_type];
         if (tools.length > 0) {
           const proxy = make_proxy(tools);
@@ -139,7 +139,7 @@ export class ProxyToolbar extends ToolbarBase {
     }
 
     this.actions = [];
-    for (tool_type in actions) {
+    for (const tool_type in actions) {
       tools = actions[tool_type];
       if (tools.length > 0) {
         this.actions.push(make_proxy(tools));
@@ -147,7 +147,7 @@ export class ProxyToolbar extends ToolbarBase {
     }
 
     this.inspectors = [];
-    for (tool_type in inspectors) {
+    for (const tool_type in inspectors) {
       tools = inspectors[tool_type];
       if (tools.length > 0) {
         this.inspectors.push(make_proxy(tools, (active=true)));

--- a/bokehjs/src/coffee/models/transforms/interpolator.ts
+++ b/bokehjs/src/coffee/models/transforms/interpolator.ts
@@ -101,7 +101,7 @@ export class Interpolator extends Transform {
       });
     }
 
-    for (let k = 0, end = list.length, asc = 0 <= end; asc ? k < end : k > end; asc ? k++ : k--) {
+    for (let k = 0, end = list.length; k < end; k++) {
       this._x_sorted[k] = list[k].x;
       this._y_sorted[k] = list[k].y;
     }


### PR DESCRIPTION
Decaffeinate didn't have enough information to generate concise code for `for` loops. This PR cleans this up. I also made sure that every loop declares its loop counter, instead of having a function/method global.

addresses #6481