### PR TITLE
Don't set `float: left` on tabs' panels

### DIFF
--- a/bokehjs/src/less/widgets/widgets.less
+++ b/bokehjs/src/less/widgets/widgets.less
@@ -59,9 +59,6 @@
 .bk-bs-nav-tabs {
   overflow: hidden;
 }
-.bk-bs-tab-pane {
-  float: left;
-}
 
 .bk-slider {
   label {


### PR DESCRIPTION
I'm not sure why this was done, but seems unnecessary anymore and fixes the overlapping layout issue.

fixes #7443 