### PR TITLE
Enable more tslint rules and clean up code

### DIFF
--- a/bokehjs/examples/anscombe/anscombe.ts
+++ b/bokehjs/examples/anscombe/anscombe.ts
@@ -25,7 +25,7 @@ namespace Anscombe {
       "yiii" : anscombe_quartet[5],
       "xiv"  : anscombe_quartet[6],
       "yiv"  : anscombe_quartet[7],
-    }
+    },
   });
 
   const x = Bokeh.LinAlg.linspace(-0.5, 20.5, 10);

--- a/bokehjs/examples/burtin/burtin.ts
+++ b/bokehjs/examples/burtin/burtin.ts
@@ -11,7 +11,7 @@ namespace Burtin {
 
   type Gram = "negative" | "positive";
 
-  const antibiotics: Array<[string, number, number, number, Gram]> = [
+  const antibiotics: [string, number, number, number, Gram][] = [
     ["Mycobacterium tuberculosis",      800,        5,            2,        "negative"],
     ["Salmonella schottmuelleri",       10,         0.8,          0.09,     "negative"],
     ["Proteus vulgaris",                3,          0.1,          0.1,      "negative"],
@@ -31,14 +31,14 @@ namespace Burtin {
   ]
 
   interface Antibiotics {
-    index:        Array<number>;
+    index:        number[];
     length:       number;
 
-    bacteria:     Array<string>;
-    penicillin:   Array<number>;
-    streptomycin: Array<number>;
-    neomycin:     Array<number>;
-    gram:         Array<Gram>;
+    bacteria:     string[];
+    penicillin:   number[];
+    streptomycin: number[];
+    neomycin:     number[];
+    gram:         Gram[];
   }
 
   const df: Antibiotics = {
@@ -73,7 +73,7 @@ namespace Burtin {
   const a = (outer_radius - inner_radius) / (minr - maxr)
   const b = inner_radius - a * maxr
 
-  function rad(mic: Array<number>): Array<number> {
+  function rad(mic: number[]): number[] {
     return mic.map((v) => a * Math.sqrt(Math.log(v * 1E4)) + b)
   }
 

--- a/bokehjs/examples/donut/donut.ts
+++ b/bokehjs/examples/donut/donut.ts
@@ -68,7 +68,7 @@ namespace WebBrowserMarketShare {
   }
 
   const info: Bokeh.Map<BrowserInfo> = {
-    "Other": { color: "gray" }
+    "Other": { color: "gray" },
   }
 
   for (const row of read_csv_from("info")) {
@@ -94,7 +94,7 @@ namespace WebBrowserMarketShare {
       data: {
         names: item.browsers,
         shares: item.shares,
-      }
+      },
     })
 
     const end_angles = cumsum(item.shares.map(to_radians))

--- a/bokehjs/examples/donut/donut.ts
+++ b/bokehjs/examples/donut/donut.ts
@@ -24,13 +24,13 @@ namespace WebBrowserMarketShare {
   interface MonthlyShares {
     year: number
     month: string
-    browsers: Array<string>
-    shares: Array<number>
+    browsers: string[]
+    shares: number[]
   }
 
-  const data: Array<MonthlyShares> = []
+  const data: MonthlyShares[] = []
 
-  let _browsers: Array<string> = null
+  let _browsers: string[] = null
   let year: number = null
 
   for (const [head, ...tail] of read_csv_from("data")) {

--- a/bokehjs/examples/hover/hover.ts
+++ b/bokehjs/examples/hover/hover.ts
@@ -33,7 +33,7 @@ namespace HoverfulScatter {
     colors.push(plt.color(r, g, 150))
 
   const source = new Bokeh.ColumnDataSource({
-    data: {x: xx, y: yy, radius: radii, colors: colors }
+    data: {x: xx, y: yy, radius: radii, colors: colors },
   })
 
   const tools = "pan,crosshair,wheel_zoom,box_zoom,reset,hover,save"

--- a/bokehjs/examples/hover/hover.ts
+++ b/bokehjs/examples/hover/hover.ts
@@ -14,8 +14,8 @@ namespace HoverfulScatter {
   })()
 
   const M = 100
-  const xx: Array<number> = []
-  const yy: Array<number> = []
+  const xx: number[] = []
+  const yy: number[] = []
 
   for (let y = 0; y <= M; y += 4) {
     for (let x = 0; x <= M; x += 4) {
@@ -28,7 +28,7 @@ namespace HoverfulScatter {
   const indices = range(N).map((i) => i.toString())
   const radii = range(N).map((_) => random()*0.4 + 1.7)
 
-  const colors: Array<string> = []
+  const colors: string[] = []
   for (const [r, g] of zip(xx.map((x) => 50 + 2*x), yy.map((y) => 30 + 2*y)))
     colors.push(plt.color(r, g, 150))
 

--- a/bokehjs/examples/stocks/stocks.ts
+++ b/bokehjs/examples/stocks/stocks.ts
@@ -43,7 +43,7 @@ namespace Stocks {
       corp_a: [1, 4, 3, 5, 2, 3, 2, 4],
       corp_b: [4, 5, 7, 6, 8, 6, 7, 4],
       corp_c: [2, 1, 2, 1, 3, 1, 2, 3],
-    }
+    },
   });
 
   // Make source update on an interval

--- a/bokehjs/examples/tap/tap.ts
+++ b/bokehjs/examples/tap/tap.ts
@@ -14,8 +14,8 @@ namespace TappyScatter {
   })()
 
   const M = 100
-  const xx: Array<number> = []
-  const yy: Array<number> = []
+  const xx: number[] = []
+  const yy: number[] = []
 
   for (let y = 0; y <= M; y += 4) {
     for (let x = 0; x <= M; x += 4) {
@@ -28,7 +28,7 @@ namespace TappyScatter {
   const indices = range(N).map((i) => i.toString())
   const radii = range(N).map((_) => random()*0.4 + 1.7)
 
-  const colors: Array<string> = []
+  const colors: string[] = []
   for (const [r, g] of zip(xx.map((x) => 50 + 2*x), yy.map((y) => 30 + 2*y)))
     colors.push(plt.color(r, g, 150))
 

--- a/bokehjs/examples/tap/tap.ts
+++ b/bokehjs/examples/tap/tap.ts
@@ -33,7 +33,7 @@ namespace TappyScatter {
     colors.push(plt.color(r, g, 150))
 
   const source = new Bokeh.ColumnDataSource({
-    data: {x: xx, y: yy, radius: radii, colors: colors }
+    data: {x: xx, y: yy, radius: radii, colors: colors },
   })
 
   const tools = "pan,crosshair,wheel_zoom,box_zoom,reset,tap,save"

--- a/bokehjs/gulp/tasks/scripts.ts
+++ b/bokehjs/gulp/tasks/scripts.ts
@@ -88,8 +88,13 @@ gulp.task("scripts:ts", () => {
 })
 
 gulp.task("scripts:tslint", () => {
+  const srcs = [
+    join(paths.src_dir.coffee),
+    join(paths.base_dir, "test"),
+    join(paths.base_dir, "examples"),
+  ]
   return gulp
-    .src(join(paths.src_dir.coffee, "**", "*.ts"))
+    .src(srcs.map((dir) => join(dir, "**", "*.ts")))
     .pipe(tslint({formatter: "stylish", fix: argv.fix || false}))
     .pipe(tslint.report({emitError: false}))
 })

--- a/bokehjs/src/coffee/api/typings/bokeh.d.ts
+++ b/bokehjs/src/coffee/api/typings/bokeh.d.ts
@@ -1,7 +1,7 @@
 declare namespace Bokeh {
-  var version: string;
+  const version: string;
 
-  var index: Map<View<LayoutDOM>>;
+  const index: Map<View<LayoutDOM>>;
 
   class LogLevel {
    name: string;
@@ -23,13 +23,13 @@ declare namespace Bokeh {
    error: (...args: any[]) => void;
    fatal: (...args: any[]) => void;
   }
-  var logger: Logger;
+  const logger: Logger;
 
   class Settings {
     dev: boolean;
   }
 
-  var settings: Settings;
+  const settings: Settings;
 
   function sprintf(fmt: string, ...args: any[]): string;
 

--- a/bokehjs/src/coffee/api/typings/bokeh.d.ts
+++ b/bokehjs/src/coffee/api/typings/bokeh.d.ts
@@ -39,42 +39,42 @@ declare namespace Bokeh {
 
   namespace LinAlg {
     // core/util/object.ts
-    export function keys<T>(object: T): Array<string>
-    export function values<T>(object: {[key: string]: T}): Array<T>
+    export function keys<T>(object: T): string[]
+    export function values<T>(object: {[key: string]: T}): T[]
     export function extend<T, T1>(dest: T, source: T1): T & T1
-    export function extend<R>(dest: any, ...sources: Array<any>): R
+    export function extend<R>(dest: any, ...sources: any[]): R
     export function clone<T>(obj: T): T
     export function isEmpty<T>(obj: T): boolean
 
     // core/util/array.ts
-    export function copy<T>(array: Array<T>): Array<T>
-    export function concat<T>(arrays: Array<Array<T>>): Array<T>
-    export function contains<T>(array: Array<T>, value: T): boolean
-    export function nth<T>(array: Array<T>, index: number): T
-    export function zip<A, B>(As: Array<A>, Bs: Array<B>): Array<[A, B]>
-    export function unzip<A, B>(ABs: Array<[A, B]>): [Array<A>, Array<B>]
-    export function range(start: number, stop?: number, step?: number): Array<number>
-    export function linspace(start: number, stop: number, num: number): Array<number>
-    export function transpose<T>(array: Array<Array<T>>): Array<Array<T>>
-    export function sum(array: Array<number>): number
-    export function cumsum(array: Array<number>): Array<number>
-    export function min(array: Array<number>): number
-    export function minBy<T>(array: Array<T>, key: (item: T) => number): T
-    export function max(array: Array<number>): number
-    export function maxBy<T>(array: Array<T>, key: (item: T) => number): T
-    export function argmin(array: Array<number>): number
-    export function argmax(array: Array<number>): number
-    export function all<T>(array: Array<T>, predicate: (item: T) => boolean): boolean
-    export function any<T>(array: Array<T>, predicate: (item: T) => boolean): boolean
-    export function findIndex<T>(array: Array<T>, predicate: (item: T) => boolean): number
-    export function findLastIndex<T>(array: Array<T>, predicate: (item: T) => boolean): number
-    export function sortedIndex<T>(array: Array<T>, value: T): number
-    export function sortBy<T>(array: Array<T>, key: (item: T) => number): Array<T>
-    export function uniq<T>(array: Array<T>): Array<T>
-    export function uniqBy<T, U>(array: Array<T>, key: (item: T) => U): Array<T>
-    export function union<T>(...arrays: Array<Array<T>>): Array<T>
-    export function intersection<T>(array: Array<T>, ...arrays: Array<Array<T>>): Array<T>
-    export function difference<T>(array: Array<T>, ...arrays: Array<Array<T>>): Array<T>
+    export function copy<T>(array: T[]): T[]
+    export function concat<T>(arrays: T[][]): T[]
+    export function contains<T>(array: T[], value: T): boolean
+    export function nth<T>(array: T[], index: number): T
+    export function zip<A, B>(As: A[], Bs: B[]): [A, B][]
+    export function unzip<A, B>(ABs: [A, B][]): [A[], B[]]
+    export function range(start: number, stop?: number, step?: number): number[]
+    export function linspace(start: number, stop: number, num: number): number[]
+    export function transpose<T>(array: T[][]): T[][]
+    export function sum(array: number[]): number
+    export function cumsum(array: number[]): number[]
+    export function min(array: number[]): number
+    export function minBy<T>(array: T[], key: (item: T) => number): T
+    export function max(array: number[]): number
+    export function maxBy<T>(array: T[], key: (item: T) => number): T
+    export function argmin(array: number[]): number
+    export function argmax(array: number[]): number
+    export function all<T>(array: T[], predicate: (item: T) => boolean): boolean
+    export function any<T>(array: T[], predicate: (item: T) => boolean): boolean
+    export function findIndex<T>(array: T[], predicate: (item: T) => boolean): number
+    export function findLastIndex<T>(array: T[], predicate: (item: T) => boolean): number
+    export function sortedIndex<T>(array: T[], value: T): number
+    export function sortBy<T>(array: T[], key: (item: T) => number): T[]
+    export function uniq<T>(array: T[]): T[]
+    export function uniqBy<T, U>(array: T[], key: (item: T) => U): T[]
+    export function union<T>(...arrays: T[][]): T[]
+    export function intersection<T>(array: T[], ...arrays: T[][]): T[]
+    export function difference<T>(array: T[], ...arrays: T[][]): T[]
 
     // core/util/string.ts
     export function startsWith(str: string, searchString: string, position: number): boolean
@@ -87,7 +87,7 @@ declare namespace Bokeh {
     export function isString(obj: any): obj is string
     export function isStrictNaN(obj: any): obj is number
     export function isFunction(obj: any): obj is Function
-    export function isArray<T>(obj: any): obj is Array<T>
+    export function isArray<T>(obj: any): obj is T[]
     export function isObject(obj: any): obj is Object
 
     // core/util/eq.ts

--- a/bokehjs/src/coffee/api/typings/charts.d.ts
+++ b/bokehjs/src/coffee/api/typings/charts.d.ts
@@ -11,19 +11,19 @@ declare namespace Bokeh.Charts {
     end_angle?: number;
     center?: [number, number];
     treshold?: number;
-    palette?: Palette | Array<Color>;
+    palette?: Palette | Color[];
     slice_labels?: "labels" | "values" | "percentages";
   }
 
-  function pie(data: {labels: Array<string>, values: Array<number>}, opts?: IPieOpts): Plot;
+  function pie(data: {labels: string[], values: number[]}, opts?: IPieOpts): Plot;
 
   interface IBarOpts extends IChartOpts {
     stacked?: boolean;
     orientation?: "horizontal" | "vertical";
     bar_width?: number;
-    palette?: Palette | Array<Color>;
+    palette?: Palette | Color[];
     axis_number_format?: string;
   }
 
-  function bar(data: Array<Array<string | number>>, opts?: IBarOpts): Plot;
+  function bar(data: (string | number)[][], opts?: IBarOpts): Plot;
 }

--- a/bokehjs/src/coffee/api/typings/document.d.ts
+++ b/bokehjs/src/coffee/api/typings/document.d.ts
@@ -1,6 +1,6 @@
 declare namespace Bokeh {
 
-  export var Document: {
+  export const Document: {
     new(attributes?: IDocument): Document
 
     from_json_string(s: string): Document;

--- a/bokehjs/src/coffee/api/typings/document.d.ts
+++ b/bokehjs/src/coffee/api/typings/document.d.ts
@@ -8,7 +8,7 @@ declare namespace Bokeh {
   }
   export interface Document extends IDocument {
     clear(): void;
-    roots(): Array<Model>;
+    roots(): Model[];
     add_root(model: Model): void;
     remove_root(model: Model): void;
     resize(): void;

--- a/bokehjs/src/coffee/api/typings/models/annotations.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/annotations.d.ts
@@ -4,14 +4,14 @@ declare namespace Bokeh {
     level?: RenderLevel;
   }
 
-  export var LegendItem: { new(attributes?: ILegendItem, options?: ModelOpts): LegendItem };
+  export const LegendItem: { new(attributes?: ILegendItem, options?: ModelOpts): LegendItem };
   export interface LegendItem extends Model, ILegendItem {}
   export interface ILegendItem extends IModel {
     label?: Vectorized<string>;
     renderers?: GlyphRenderer[];
   }
 
-  export var Legend: { new(attributes?: ILegend, options?: ModelOpts): Legend };
+  export const Legend: { new(attributes?: ILegend, options?: ModelOpts): Legend };
   export interface Legend extends Annotation, ILegend {}
   export interface ILegend extends IAnnotation {
     location?: LegendLocation;
@@ -62,7 +62,7 @@ declare namespace Bokeh {
 
   }
 
-  export var ColorBar: { new(attributes?: IColorBar, options?: ModelOpts): ColorBar };
+  export const ColorBar: { new(attributes?: IColorBar, options?: ModelOpts): ColorBar };
   export interface ColorBar extends Annotation, IColorBar {}
   export interface IColorBar extends IAnnotation {
     location?: LegendLocation;
@@ -150,7 +150,7 @@ declare namespace Bokeh {
     // }}}
   }
 
-  export var Band: { new(attributes?: IBand, options?: ModelOpts): Band };
+  export const Band: { new(attributes?: IBand, options?: ModelOpts): Band };
   export interface Band extends Annotation, IBand {}
   export interface IBand extends IAnnotation, LineProps, FillProps {
     lower?: number[];
@@ -168,7 +168,7 @@ declare namespace Bokeh {
     y_range_name?: string;
   }
 
-  export var BoxAnnotation: { new(attributes?: IBoxAnnotation, options?: ModelOpts): BoxAnnotation };
+  export const BoxAnnotation: { new(attributes?: IBoxAnnotation, options?: ModelOpts): BoxAnnotation };
   export interface BoxAnnotation extends Annotation, IBoxAnnotation {}
   export interface IBoxAnnotation extends IAnnotation, LineProps, FillProps {
     left?: Auto | Numerical;
@@ -189,7 +189,7 @@ declare namespace Bokeh {
     render_mode?: RenderMode;
   }
 
-  export var PolyAnnotation: { new(attributes?: IPolyAnnotation, options?: ModelOpts): PolyAnnotation };
+  export const PolyAnnotation: { new(attributes?: IPolyAnnotation, options?: ModelOpts): PolyAnnotation };
   export interface PolyAnnotation extends Annotation, IPolyAnnotation {}
   export interface IPolyAnnotation extends IAnnotation, LineProps, FillProps {
     xs?: number[];
@@ -202,7 +202,7 @@ declare namespace Bokeh {
     y_range_name?: string;
   }
 
-  export var Span: { new(attributes?: ISpan, options?: ModelOpts): Span };
+  export const Span: { new(attributes?: ISpan, options?: ModelOpts): Span };
   export interface Span extends Annotation, ISpan {}
   export interface ISpan extends IAnnotation, LineProps {
     location?: number;
@@ -216,11 +216,11 @@ declare namespace Bokeh {
     render_mode?: RenderMode;
   }
 
-  export var TextAnnotation: { new(attributes?: ITextAnnotation, options?: ModelOpts): TextAnnotation };
+  export const TextAnnotation: { new(attributes?: ITextAnnotation, options?: ModelOpts): TextAnnotation };
   export interface TextAnnotation extends Annotation, ITextAnnotation {}
   export interface ITextAnnotation extends IAnnotation {}
 
-  export var Title: { new(attributes?: ITitle, options?: ModelOpts): Title };
+  export const Title: { new(attributes?: ITitle, options?: ModelOpts): Title };
   export interface Title extends TextAnnotation, ITitle {}
   export interface ITitle extends ITextAnnotation {
     text?: string;
@@ -261,11 +261,11 @@ declare namespace Bokeh {
     render_mode?: RenderMode;
   }
 
-  export var Overlay: { new(attributes?: IOverlay, options?: ModelOpts): Overlay };
+  export const Overlay: { new(attributes?: IOverlay, options?: ModelOpts): Overlay };
   export interface Overlay extends Annotation, IOverlay {}
   export interface IOverlay extends IAnnotation {}
 
-  export var Tooltip: { new(attributes?: ITooltip, options?: ModelOpts): Tooltip };
+  export const Tooltip: { new(attributes?: ITooltip, options?: ModelOpts): Tooltip };
   export interface Tooltip extends Overlay, ITooltip {}
   export interface ITooltip extends IOverlay {
     attachment?: "horizontal" | "vertical" | "left" | "right" | "above" | "below";

--- a/bokehjs/src/coffee/api/typings/models/annotations.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/annotations.d.ts
@@ -8,7 +8,7 @@ declare namespace Bokeh {
   export interface LegendItem extends Model, ILegendItem {}
   export interface ILegendItem extends IModel {
     label?: Vectorized<string>;
-    renderers?: Array<GlyphRenderer>;
+    renderers?: GlyphRenderer[];
   }
 
   export var Legend: { new(attributes?: ILegend, options?: ModelOpts): Legend };
@@ -58,7 +58,7 @@ declare namespace Bokeh {
     padding?: Int;
     spacing?: Int;
 
-    items?: Array<LegendItem>;
+    items?: LegendItem[];
 
   }
 
@@ -153,13 +153,13 @@ declare namespace Bokeh {
   export var Band: { new(attributes?: IBand, options?: ModelOpts): Band };
   export interface Band extends Annotation, IBand {}
   export interface IBand extends IAnnotation, LineProps, FillProps {
-    lower?: Array<number>;
+    lower?: number[];
     lower_units?: SpatialUnits;
 
-    upper?: Array<number>;
+    upper?: number[];
     upper_units?: SpatialUnits;
 
-    base?: Array<number>;
+    base?: number[];
     base_units?: SpatialUnits;
 
     dimension?: Dimension;
@@ -192,10 +192,10 @@ declare namespace Bokeh {
   export var PolyAnnotation: { new(attributes?: IPolyAnnotation, options?: ModelOpts): PolyAnnotation };
   export interface PolyAnnotation extends Annotation, IPolyAnnotation {}
   export interface IPolyAnnotation extends IAnnotation, LineProps, FillProps {
-    xs?: Array<number>;
+    xs?: number[];
     xs_units?: SpatialUnits;
 
-    ys?: Array<number>;
+    ys?: number[];
     ys_units?: SpatialUnits;
 
     x_range_name?: string;

--- a/bokehjs/src/coffee/api/typings/models/axes.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/axes.d.ts
@@ -69,19 +69,19 @@ declare namespace Bokeh {
   export interface ContinuousAxis extends Axis, IContinuousAxis {}
   export interface IContinuousAxis extends IAxis {}
 
-  export var LinearAxis: { new(attributes?: ILinearAxis, options?: ModelOpts): LinearAxis };
+  export const LinearAxis: { new(attributes?: ILinearAxis, options?: ModelOpts): LinearAxis };
   export interface LinearAxis extends ContinuousAxis, ILinearAxis {}
   export interface ILinearAxis extends IContinuousAxis {}
 
-  export var LogAxis: { new(attributes?: ILogAxis, options?: ModelOpts): LogAxis };
+  export const LogAxis: { new(attributes?: ILogAxis, options?: ModelOpts): LogAxis };
   export interface LogAxis extends ContinuousAxis, ILogAxis {}
   export interface ILogAxis extends IContinuousAxis {}
 
-  export var CategoricalAxis: { new(attributes?: ICategoricalAxis, options?: ModelOpts): CategoricalAxis };
+  export const CategoricalAxis: { new(attributes?: ICategoricalAxis, options?: ModelOpts): CategoricalAxis };
   export interface CategoricalAxis extends Axis, ICategoricalAxis {}
   export interface ICategoricalAxis extends IAxis {}
 
-  export var DatetimeAxis: { new(attributes?: IDatetimeAxis, options?: ModelOpts): DatetimeAxis };
+  export const DatetimeAxis: { new(attributes?: IDatetimeAxis, options?: ModelOpts): DatetimeAxis };
   export interface DatetimeAxis extends LinearAxis, IDatetimeAxis {}
   export interface IDatetimeAxis extends ILinearAxis {
     scale?: string;

--- a/bokehjs/src/coffee/api/typings/models/callbacks.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/callbacks.d.ts
@@ -2,13 +2,13 @@ declare namespace Bokeh {
   export interface Callback extends Model, ICallback {}
   export interface ICallback extends IModel {}
 
-  export var OpenURL: { new(attributes?: IOpenURL, options?: ModelOpts): OpenURL };
+  export const OpenURL: { new(attributes?: IOpenURL, options?: ModelOpts): OpenURL };
   export interface OpenURL extends Callback, IOpenURL {}
   export interface IOpenURL extends ICallback {
     url?: string;
   }
 
-  export var CustomJS: { new(attributes?: ICustomJS, options?: ModelOpts): CustomJS };
+  export const CustomJS: { new(attributes?: ICustomJS, options?: ModelOpts): CustomJS };
   export interface CustomJS extends Callback, ICustomJS {}
   export interface ICustomJS extends ICallback {
     args?: Map<Model>;

--- a/bokehjs/src/coffee/api/typings/models/formatters.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/formatters.d.ts
@@ -22,16 +22,16 @@ declare namespace Bokeh {
   export var DatetimeTickFormatter: { new(attributes?: IDatetimeTickFormatter, options?: ModelOpts): DatetimeTickFormatter };
   export interface DatetimeTickFormatter extends TickFormatter, IDatetimeTickFormatter {}
   export interface IDatetimeTickFormatter extends ITickFormatter {
-    microseconds?: Array<string>;
-    milliseconds?: Array<string>;
-    seconds?:      Array<string>;
-    minsec?:       Array<string>;
-    minutes?:      Array<string>;
-    hourmin?:      Array<string>;
-    hours?:        Array<string>;
-    days?:         Array<string>;
-    months?:       Array<string>;
-    years?:        Array<string>;
+    microseconds?: string[];
+    milliseconds?: string[];
+    seconds?:      string[];
+    minsec?:       string[];
+    minutes?:      string[];
+    hourmin?:      string[];
+    hours?:        string[];
+    days?:         string[];
+    months?:       string[];
+    years?:        string[];
   }
 
   export var FuncTickFormatter: { new(attributes?: IFuncTickFormatter, options?: ModelOpts): FuncTickFormatter };

--- a/bokehjs/src/coffee/api/typings/models/formatters.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/formatters.d.ts
@@ -2,7 +2,7 @@ declare namespace Bokeh {
   export interface TickFormatter extends Model, ITickFormatter {}
   export interface ITickFormatter extends IModel {}
 
-  export var BasicTickFormatter: { new(attributes?: IBasicTickFormatter, options?: ModelOpts): BasicTickFormatter };
+  export const BasicTickFormatter: { new(attributes?: IBasicTickFormatter, options?: ModelOpts): BasicTickFormatter };
   export interface BasicTickFormatter extends TickFormatter, IBasicTickFormatter {}
   export interface IBasicTickFormatter extends ITickFormatter {
     precision?: Auto | Int;
@@ -11,15 +11,15 @@ declare namespace Bokeh {
     power_limit_low?: Int;
   }
 
-  export var LogTickFormatter: { new(attributes?: ILogTickFormatter, options?: ModelOpts): LogTickFormatter };
+  export const LogTickFormatter: { new(attributes?: ILogTickFormatter, options?: ModelOpts): LogTickFormatter };
   export interface LogTickFormatter extends TickFormatter, ILogTickFormatter {}
   export interface ILogTickFormatter extends ITickFormatter {}
 
-  export var CategoricalTickFormatter: { new(attributes?: ICategoricalTickFormatter, options?: ModelOpts): CategoricalTickFormatter };
+  export const CategoricalTickFormatter: { new(attributes?: ICategoricalTickFormatter, options?: ModelOpts): CategoricalTickFormatter };
   export interface CategoricalTickFormatter extends TickFormatter, ICategoricalTickFormatter {}
   export interface ICategoricalTickFormatter extends ITickFormatter {}
 
-  export var DatetimeTickFormatter: { new(attributes?: IDatetimeTickFormatter, options?: ModelOpts): DatetimeTickFormatter };
+  export const DatetimeTickFormatter: { new(attributes?: IDatetimeTickFormatter, options?: ModelOpts): DatetimeTickFormatter };
   export interface DatetimeTickFormatter extends TickFormatter, IDatetimeTickFormatter {}
   export interface IDatetimeTickFormatter extends ITickFormatter {
     microseconds?: string[];
@@ -34,14 +34,14 @@ declare namespace Bokeh {
     years?:        string[];
   }
 
-  export var FuncTickFormatter: { new(attributes?: IFuncTickFormatter, options?: ModelOpts): FuncTickFormatter };
+  export const FuncTickFormatter: { new(attributes?: IFuncTickFormatter, options?: ModelOpts): FuncTickFormatter };
   export interface FuncTickFormatter extends TickFormatter, IFuncTickFormatter {}
   export interface IFuncTickFormatter extends ITickFormatter {
     args?: Map<Model>;
     code?: string;
   }
 
-  export var NumeralTickFormatter: { new(attributes?: INumeralTickFormatter, options?: ModelOpts): NumeralTickFormatter };
+  export const NumeralTickFormatter: { new(attributes?: INumeralTickFormatter, options?: ModelOpts): NumeralTickFormatter };
   export interface NumeralTickFormatter extends TickFormatter, INumeralTickFormatter {}
   export interface INumeralTickFormatter extends ITickFormatter {
     format?: string;
@@ -49,7 +49,7 @@ declare namespace Bokeh {
     rounding?: RoundingFunction;
   }
 
-  export var PrintfTickFormatter: { new(attributes?: IPrintfTickFormatter, options?: ModelOpts): PrintfTickFormatter };
+  export const PrintfTickFormatter: { new(attributes?: IPrintfTickFormatter, options?: ModelOpts): PrintfTickFormatter };
   export interface PrintfTickFormatter extends TickFormatter, IPrintfTickFormatter {}
   export interface IPrintfTickFormatter extends ITickFormatter {
     format?: string;

--- a/bokehjs/src/coffee/api/typings/models/glyphs.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/glyphs.d.ts
@@ -4,7 +4,7 @@ declare namespace Bokeh {
     visible?: boolean;
   }
 
-  export var AnnularWedge: { new(attributes?: IAnnularWedge, options?: ModelOpts): AnnularWedge };
+  export const AnnularWedge: { new(attributes?: IAnnularWedge, options?: ModelOpts): AnnularWedge };
   export interface AnnularWedge extends Glyph, IAnnularWedge {}
   export interface IAnnularWedge extends IGlyph, FillProps, LineProps {
     x?: Numerical | Categorical;
@@ -16,7 +16,7 @@ declare namespace Bokeh {
     direction?: Direction;
   }
 
-  export var Annulus: { new(attributes?: IAnnulus, options?: ModelOpts): Annulus };
+  export const Annulus: { new(attributes?: IAnnulus, options?: ModelOpts): Annulus };
   export interface Annulus extends Glyph, IAnnulus {}
   export interface IAnnulus extends IGlyph, FillProps, LineProps {
     x?: Numerical | Categorical;
@@ -25,7 +25,7 @@ declare namespace Bokeh {
     outer_radius?: Spatial;
   }
 
-  export var Arc: { new(attributes?: IArc, options?: ModelOpts): Arc };
+  export const Arc: { new(attributes?: IArc, options?: ModelOpts): Arc };
   export interface Arc extends Glyph, IArc {}
   export interface IArc extends IGlyph, LineProps {
     x?: Numerical | Categorical;
@@ -36,7 +36,7 @@ declare namespace Bokeh {
     direction?: Direction;
   }
 
-  export var Bezier: { new(attributes?: IBezier, options?: ModelOpts): Bezier };
+  export const Bezier: { new(attributes?: IBezier, options?: ModelOpts): Bezier };
   export interface Bezier extends Glyph, IBezier {}
   export interface IBezier extends IGlyph, LineProps {
     x0?: Numerical | Categorical;
@@ -49,7 +49,7 @@ declare namespace Bokeh {
     cy1?: Numerical | Categorical;
   }
 
-  export var Ellipse: { new(attributes?: IEllipse, options?: ModelOpts): Ellipse };
+  export const Ellipse: { new(attributes?: IEllipse, options?: ModelOpts): Ellipse };
   export interface Ellipse extends Glyph, IEllipse {}
   export interface IEllipse extends IGlyph, FillProps, LineProps {
     x?: Numerical | Categorical;
@@ -59,7 +59,7 @@ declare namespace Bokeh {
     angle?: Angular;
   }
 
-  export var ImageRGBA: { new(attributes?: IImageRGBA, options?: ModelOpts): ImageRGBA };
+  export const ImageRGBA: { new(attributes?: IImageRGBA, options?: ModelOpts): ImageRGBA };
   export interface ImageRGBA extends Glyph, IImageRGBA {}
   export interface IImageRGBA extends IGlyph {
     image?: Vectorized<number[]>;
@@ -72,13 +72,13 @@ declare namespace Bokeh {
     dilate?: boolean;
   }
 
-  export var Image: { new(attributes?: IImage, options?: ModelOpts): Image };
+  export const Image: { new(attributes?: IImage, options?: ModelOpts): Image };
   export interface Image extends ImageRGBA, IImage {}
   export interface IImage extends IImageRGBA {
     color_mapper?: ColorMapper;
   }
 
-  export var ImageURL: { new(attributes?: IImageURL, options?: ModelOpts): ImageURL };
+  export const ImageURL: { new(attributes?: IImageURL, options?: ModelOpts): ImageURL };
   export interface ImageURL extends Glyph, IImageURL {}
   export interface IImageURL extends IGlyph {
     url?: Vectorized<string>;
@@ -94,21 +94,21 @@ declare namespace Bokeh {
     retry_timeout?: Int;
   }
 
-  export var Line: { new(attributes?: ILine, options?: ModelOpts): Line };
+  export const Line: { new(attributes?: ILine, options?: ModelOpts): Line };
   export interface Line extends Glyph, ILine {}
   export interface ILine extends IGlyph, LineProps {
     x?: Numerical | Categorical;
     y?: Numerical | Categorical;
   }
 
-  export var MultiLine: { new(attributes?: IMultiLine, options?: ModelOpts): MultiLine };
+  export const MultiLine: { new(attributes?: IMultiLine, options?: ModelOpts): MultiLine };
   export interface MultiLine extends Glyph, IMultiLine {}
   export interface IMultiLine extends IGlyph, LineProps {
     xs?: MultiNumerical | MultiCategorical;
     ys?: MultiNumerical | MultiCategorical;
   }
 
-  export var Oval: { new(attributes?: IOval, options?: ModelOpts): Oval };
+  export const Oval: { new(attributes?: IOval, options?: ModelOpts): Oval };
   export interface Oval extends Glyph, IOval {}
   export interface IOval extends IGlyph, FillProps, LineProps {
     x?: Numerical | Categorical;
@@ -118,21 +118,21 @@ declare namespace Bokeh {
     angle?: Angular;
   }
 
-  export var Patch: { new(attributes?: IPatch, options?: ModelOpts): Patch };
+  export const Patch: { new(attributes?: IPatch, options?: ModelOpts): Patch };
   export interface Patch extends Glyph, IPatch {}
   export interface IPatch extends IGlyph, FillProps, LineProps {
     x?: Numerical | Categorical;
     y?: Numerical | Categorical;
   }
 
-  export var Patches: { new(attributes?: IPatches, options?: ModelOpts): Patches };
+  export const Patches: { new(attributes?: IPatches, options?: ModelOpts): Patches };
   export interface Patches extends Glyph, IPatches {}
   export interface IPatches extends IGlyph, LineProps, FillProps {
     xs?: MultiNumerical | MultiCategorical;
     ys?: MultiNumerical | MultiCategorical;
   }
 
-  export var Quad: { new(attributes?: IQuad, options?: ModelOpts): Quad };
+  export const Quad: { new(attributes?: IQuad, options?: ModelOpts): Quad };
   export interface Quad extends Glyph, IQuad {}
   export interface IQuad extends IGlyph, FillProps, LineProps {
     left?: Numerical | Categorical;
@@ -141,7 +141,7 @@ declare namespace Bokeh {
     top?: Numerical | Categorical;
   }
 
-  export var Quadratic: { new(attributes?: IQuadratic, options?: ModelOpts): Quadratic };
+  export const Quadratic: { new(attributes?: IQuadratic, options?: ModelOpts): Quadratic };
   export interface Quadratic extends Glyph, IQuadratic {}
   export interface IQuadratic extends IGlyph, LineProps {
     x0?: Numerical | Categorical;
@@ -152,7 +152,7 @@ declare namespace Bokeh {
     cy?: Numerical | Categorical;
   }
 
-  export var Ray: { new(attributes?: IRay, options?: ModelOpts): Ray };
+  export const Ray: { new(attributes?: IRay, options?: ModelOpts): Ray };
   export interface Ray extends Glyph, IRay {}
   export interface IRay extends IGlyph, LineProps {
     x?: Numerical | Categorical;
@@ -161,7 +161,7 @@ declare namespace Bokeh {
     angle?: Angular;
   }
 
-  export var Rect: { new(attributes?: IRect, options?: ModelOpts): Rect };
+  export const Rect: { new(attributes?: IRect, options?: ModelOpts): Rect };
   export interface Rect extends Glyph, IRect {}
   export interface IRect extends IGlyph, FillProps, LineProps {
     x?: Numerical | Categorical;
@@ -172,7 +172,7 @@ declare namespace Bokeh {
     dilate?: boolean;
   }
 
-  export var Segment: { new(attributes?: ISegment, options?: ModelOpts): Segment };
+  export const Segment: { new(attributes?: ISegment, options?: ModelOpts): Segment };
   export interface Segment extends Glyph, ISegment {}
   export interface ISegment extends IGlyph, LineProps {
     x0?: Numerical | Categorical;
@@ -181,7 +181,7 @@ declare namespace Bokeh {
     y1?: Numerical | Categorical;
   }
 
-  export var Step: { new(attributes?: IStep, options?: ModelOpts): Step };
+  export const Step: { new(attributes?: IStep, options?: ModelOpts): Step };
   export interface Step extends Glyph, IStep {}
   export interface IStep extends IGlyph, LineProps {
     x?: Numerical | Categorical;
@@ -189,7 +189,7 @@ declare namespace Bokeh {
     mode?: StepType;
   }
 
-  export var Text: { new(attributes?: IText, options?: ModelOpts): Text };
+  export const Text: { new(attributes?: IText, options?: ModelOpts): Text };
   export interface Text extends Glyph, IText {}
   export interface IText extends IGlyph, TextProps {
     x?: Numerical | Categorical;
@@ -200,7 +200,7 @@ declare namespace Bokeh {
     y_offset?: Spatial;
   }
 
-  export var Wedge: { new(attributes?: IWedge, options?: ModelOpts): Wedge };
+  export const Wedge: { new(attributes?: IWedge, options?: ModelOpts): Wedge };
   export interface Wedge extends Glyph, IWedge {}
   export interface IWedge extends IGlyph, FillProps, LineProps {
     x?: Numerical | Categorical;

--- a/bokehjs/src/coffee/api/typings/models/glyphs.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/glyphs.d.ts
@@ -62,7 +62,7 @@ declare namespace Bokeh {
   export var ImageRGBA: { new(attributes?: IImageRGBA, options?: ModelOpts): ImageRGBA };
   export interface ImageRGBA extends Glyph, IImageRGBA {}
   export interface IImageRGBA extends IGlyph {
-    image?: Vectorized<Array<number>>;
+    image?: Vectorized<number[]>;
     rows?: Vectorized<Int>;
     cols?: Vectorized<Int>;
     x?: Numerical | Categorical;

--- a/bokehjs/src/coffee/api/typings/models/grids.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/grids.d.ts
@@ -1,5 +1,5 @@
 declare namespace Bokeh {
-  export var Grid: { new(attributes?: IGrid, options?: ModelOpts): Grid };
+  export const Grid: { new(attributes?: IGrid, options?: ModelOpts): Grid };
   export interface Grid extends GuideRenderer, IGrid {}
   export interface IGrid extends IGuideRenderer {
     dimension?: Int;

--- a/bokehjs/src/coffee/api/typings/models/images.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/images.d.ts
@@ -1,5 +1,5 @@
 declare namespace Bokeh {
-  export var ImageSource: { new(attributes?: IImageSource, options?: ModelOpts): ImageSource };
+  export const ImageSource: { new(attributes?: IImageSource, options?: ModelOpts): ImageSource };
   export interface ImageSource extends Model, IImageSource {}
   export interface IImageSource extends IModel {
     url?: string;

--- a/bokehjs/src/coffee/api/typings/models/layouts.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/layouts.d.ts
@@ -7,7 +7,7 @@ declare namespace Bokeh {
     sizing_mode?: SizingMode;
   }
 
-  export var Spacer: {
+  export const Spacer: {
     new(attributes?: ISpacer, options?: ModelOpts): Spacer;
   }
   export interface Spacer extends LayoutDOM {}
@@ -18,13 +18,13 @@ declare namespace Bokeh {
     children?: LayoutDOM[];
   }
 
-  export var Row: {
+  export const Row: {
     new(attributes?: IRow, options?: ModelOpts): Row;
   }
   export interface Row extends Box {}
   export interface IRow extends IBox {}
 
-  export var Column: {
+  export const Column: {
     new(attributes?: IColumn, options?: ModelOpts): Column;
   }
   export interface Column extends Box {}

--- a/bokehjs/src/coffee/api/typings/models/layouts.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/layouts.d.ts
@@ -15,7 +15,7 @@ declare namespace Bokeh {
 
   export interface Box extends LayoutDOM, IBox {}
   export interface IBox extends ILayoutDOM {
-    children?: Array<LayoutDOM>;
+    children?: LayoutDOM[];
   }
 
   export var Row: {

--- a/bokehjs/src/coffee/api/typings/models/map_plots.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/map_plots.d.ts
@@ -13,7 +13,7 @@ declare namespace Bokeh {
   export interface MapPlot extends Plot, IMapPlot {}
   export interface IMapPlot extends IPlot {}
 
-  export var GMapPlot: { new(attributes?: IGMapPlot, options?: ModelOpts): GMapPlot };
+  export const GMapPlot: { new(attributes?: IGMapPlot, options?: ModelOpts): GMapPlot };
   export interface GMapPlot extends MapPlot, IGMapPlot {}
   export interface IGMapPlot extends IMapPlot {
     map_options?: GMapOptions;

--- a/bokehjs/src/coffee/api/typings/models/mappers.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/mappers.d.ts
@@ -1,7 +1,7 @@
 declare namespace Bokeh {
   export interface ColorMapper extends Transform, IColorMapper {}
   export interface IColorMapper extends ITransform {
-    palette?: Array<Color>;
+    palette?: Color[];
     nan_color?: Color;
   }
 
@@ -26,6 +26,6 @@ declare namespace Bokeh {
   export var CategoricalColorMapper: { new(attributes?: ICategoricalColorMapper, options?: ModelOpts): CategoricalColorMapper };
   export interface CategoricalColorMapper extends ColorMapper, ICategoricalColorMapper {}
   export interface ICategoricalColorMapper extends IColorMapper {
-    factors: Array<string> | Array<Int>;
+    factors: string[] | Int[];
   }
 }

--- a/bokehjs/src/coffee/api/typings/models/mappers.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/mappers.d.ts
@@ -5,7 +5,7 @@ declare namespace Bokeh {
     nan_color?: Color;
   }
 
-  export var LinearColorMapper: { new(attributes?: ILinearColorMapper, options?: ModelOpts): LinearColorMapper };
+  export const LinearColorMapper: { new(attributes?: ILinearColorMapper, options?: ModelOpts): LinearColorMapper };
   export interface LinearColorMapper extends ColorMapper, ILinearColorMapper {}
   export interface ILinearColorMapper extends IColorMapper {
     low?: number;
@@ -14,7 +14,7 @@ declare namespace Bokeh {
     low_color?:  Color;
   }
 
-  export var LogColorMapper: { new(attributes?: ILogColorMapper, options?: ModelOpts): LogColorMapper };
+  export const LogColorMapper: { new(attributes?: ILogColorMapper, options?: ModelOpts): LogColorMapper };
   export interface LogColorMapper extends ColorMapper, ILogColorMapper {}
   export interface ILogColorMapper extends IColorMapper {
     low?: number;
@@ -23,7 +23,7 @@ declare namespace Bokeh {
     low_color?:  Color;
   }
 
-  export var CategoricalColorMapper: { new(attributes?: ICategoricalColorMapper, options?: ModelOpts): CategoricalColorMapper };
+  export const CategoricalColorMapper: { new(attributes?: ICategoricalColorMapper, options?: ModelOpts): CategoricalColorMapper };
   export interface CategoricalColorMapper extends ColorMapper, ICategoricalColorMapper {}
   export interface ICategoricalColorMapper extends IColorMapper {
     factors: string[] | Int[];

--- a/bokehjs/src/coffee/api/typings/models/markers.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/markers.d.ts
@@ -7,58 +7,58 @@ declare namespace Bokeh {
     angle?: Angular;
   }
 
-  export var Asterisk: { new(attributes?: IAsterisk, options?: ModelOpts): Asterisk };
+  export const Asterisk: { new(attributes?: IAsterisk, options?: ModelOpts): Asterisk };
   export interface Asterisk extends Marker, IAsterisk {}
   export interface IAsterisk extends IMarker {}
 
-  export var Circle: { new(attributes?: ICircle, options?: ModelOpts): Circle };
+  export const Circle: { new(attributes?: ICircle, options?: ModelOpts): Circle };
   export interface Circle extends Marker, ICircle {}
   export interface ICircle extends IMarker {
     radius?: Spatial;
     radius_dimension?: Dimension;
   }
 
-  export var CircleCross: { new(attributes?: ICircleCross, options?: ModelOpts): CircleCross };
+  export const CircleCross: { new(attributes?: ICircleCross, options?: ModelOpts): CircleCross };
   export interface CircleCross extends Marker, ICircleCross {}
   export interface ICircleCross extends IMarker {}
 
-  export var CircleX: { new(attributes?: ICircleX, options?: ModelOpts): CircleX };
+  export const CircleX: { new(attributes?: ICircleX, options?: ModelOpts): CircleX };
   export interface CircleX extends Marker, ICircleX {}
   export interface ICircleX extends IMarker {}
 
-  export var Cross: { new(attributes?: ICross, options?: ModelOpts): Cross };
+  export const Cross: { new(attributes?: ICross, options?: ModelOpts): Cross };
   export interface Cross extends Marker, ICross {}
   export interface ICross extends IMarker {}
 
-  export var Diamond: { new(attributes?: IDiamond, options?: ModelOpts): Diamond };
+  export const Diamond: { new(attributes?: IDiamond, options?: ModelOpts): Diamond };
   export interface Diamond extends Marker, IDiamond {}
   export interface IDiamond extends IMarker {}
 
-  export var DiamondCross: { new(attributes?: IDiamondCross, options?: ModelOpts): DiamondCross };
+  export const DiamondCross: { new(attributes?: IDiamondCross, options?: ModelOpts): DiamondCross };
   export interface DiamondCross extends Marker, IDiamondCross {}
   export interface IDiamondCross extends IMarker {}
 
-  export var InvertedTriangle: { new(attributes?: IInvertedTriangle, options?: ModelOpts): InvertedTriangle };
+  export const InvertedTriangle: { new(attributes?: IInvertedTriangle, options?: ModelOpts): InvertedTriangle };
   export interface InvertedTriangle extends Marker, IInvertedTriangle {}
   export interface IInvertedTriangle extends IMarker {}
 
-  export var Square: { new(attributes?: ISquare, options?: ModelOpts): Square };
+  export const Square: { new(attributes?: ISquare, options?: ModelOpts): Square };
   export interface Square extends Marker, ISquare {}
   export interface ISquare extends IMarker {}
 
-  export var SquareCross: { new(attributes?: ISquareCross, options?: ModelOpts): SquareCross };
+  export const SquareCross: { new(attributes?: ISquareCross, options?: ModelOpts): SquareCross };
   export interface SquareCross extends Marker, ISquareCross {}
   export interface ISquareCross extends IMarker {}
 
-  export var SquareX: { new(attributes?: ISquareX, options?: ModelOpts): SquareX };
+  export const SquareX: { new(attributes?: ISquareX, options?: ModelOpts): SquareX };
   export interface SquareX extends Marker, ISquareX {}
   export interface ISquareX extends IMarker {}
 
-  export var Triangle: { new(attributes?: ITriangle, options?: ModelOpts): Triangle };
+  export const Triangle: { new(attributes?: ITriangle, options?: ModelOpts): Triangle };
   export interface Triangle extends Marker, ITriangle {}
   export interface ITriangle extends IMarker {}
 
-  export var X: { new(attributes?: IX, options?: ModelOpts): X };
+  export const X: { new(attributes?: IX, options?: ModelOpts): X };
   export interface X extends Marker, IX {}
   export interface IX extends IMarker {}
 }

--- a/bokehjs/src/coffee/api/typings/models/model.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/model.d.ts
@@ -2,13 +2,13 @@ declare namespace Bokeh {
   export interface IModel {
     id?: string;
     name?: string;
-    tags?: Array<any>;
+    tags?: any[];
   }
   export interface Model extends IModel {
-    references(): Array<Model>;
+    references(): Model[];
 
-    select<T extends Model>(type: Class<T>): Array<T>;
-    select(name: string): Array<Model>;
+    select<T extends Model>(type: Class<T>): T[];
+    select(name: string): Model[];
 
     select_one<T extends Model>(type: Class<T>): T;
     select_one(name: string): Model;

--- a/bokehjs/src/coffee/api/typings/models/plots.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/plots.d.ts
@@ -5,10 +5,10 @@ declare namespace Bokeh {
 
  export var Plot: { new(attributes?: IPlot, options?: ModelOpts): Plot };
  export interface Plot extends LayoutDOM, IPlot {
-  add_renderers(...Renderer: Array<Renderer>): void;
+  add_renderers(...Renderer: Renderer[]): void;
   add_layout(obj: Model, place?: Place): void;
   add_glyph(glyph: Glyph, source?: DataSource, attrs?: ModelOpts): GlyphRenderer;
-  add_tools(...tools: Array<Tool>): void;
+  add_tools(...tools: Tool[]): void;
  }
  export interface IPlot extends IBasePlot {
   x_range?: Range;
@@ -45,12 +45,12 @@ declare namespace Bokeh {
   border_fill_alpha?: Percent;
   // }}}
 
-  left?: Array<Renderer>;
-  right?: Array<Renderer>;
-  above?: Array<Renderer>;
-  below?: Array<Renderer>;
+  left?: Renderer[];
+  right?: Renderer[];
+  above?: Renderer[];
+  below?: Renderer[];
 
-  renderers?: Array<Renderer>;
+  renderers?: Renderer[];
 
   extra_x_ranges?: Map<Range>;
   extra_y_ranges?: Map<Range>;

--- a/bokehjs/src/coffee/api/typings/models/plots.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/plots.d.ts
@@ -3,7 +3,7 @@ declare namespace Bokeh {
   plot?: Plot;
  }
 
- export var Plot: { new(attributes?: IPlot, options?: ModelOpts): Plot };
+ export const Plot: { new(attributes?: IPlot, options?: ModelOpts): Plot };
  export interface Plot extends LayoutDOM, IPlot {
   add_renderers(...Renderer: Renderer[]): void;
   add_layout(obj: Model, place?: Place): void;

--- a/bokehjs/src/coffee/api/typings/models/ranges.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/ranges.d.ts
@@ -17,8 +17,8 @@ declare namespace Bokeh {
 
   export interface DataRange extends Range, IDataRange {}
   export interface IDataRange extends IRange {
-    names?: Array<string>;
-    renderers?: Array<Renderer>;
+    names?: string[];
+    renderers?: Renderer[];
   }
 
   export var DataRange1d: { new(attributes?: IDataRange1d, options?: ModelOpts): DataRange1d };
@@ -41,7 +41,7 @@ declare namespace Bokeh {
   export interface FactorRange extends Range, IFactorRange {}
   export interface IFactorRange extends IRange {
     offset?: number;
-    factors?: Array<string> | Array<Int>;
-    bounds?: Auto | Array<string> | Array<Int>;
+    factors?: string[] | Int[];
+    bounds?: Auto | string[] | Int[];
   }
 }

--- a/bokehjs/src/coffee/api/typings/models/ranges.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/ranges.d.ts
@@ -4,7 +4,7 @@ declare namespace Bokeh {
     callback?: Callback | ((source: this) => void);
   }
 
-  export var Range1d: {
+  export const Range1d: {
     new(attributes?: IRange1d, options?: ModelOpts): Range1d;
     (start: number, end: number): Range1d;
   }
@@ -21,7 +21,7 @@ declare namespace Bokeh {
     renderers?: Renderer[];
   }
 
-  export var DataRange1d: { new(attributes?: IDataRange1d, options?: ModelOpts): DataRange1d };
+  export const DataRange1d: { new(attributes?: IDataRange1d, options?: ModelOpts): DataRange1d };
   export interface DataRange1d extends DataRange, IDataRange1d {}
   export interface IDataRange1d extends IDataRange {
     range_padding?: number;
@@ -37,7 +37,7 @@ declare namespace Bokeh {
     default_span?: number;
   }
 
-  export var FactorRange: { new(attributes?: IFactorRange, options?: ModelOpts): FactorRange };
+  export const FactorRange: { new(attributes?: IFactorRange, options?: ModelOpts): FactorRange };
   export interface FactorRange extends Range, IFactorRange {}
   export interface IFactorRange extends IRange {
     offset?: number;

--- a/bokehjs/src/coffee/api/typings/models/renderers.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/renderers.d.ts
@@ -5,7 +5,7 @@ declare namespace Bokeh {
   export interface DataRenderer extends Renderer, IDataRenderer {}
   export interface IDataRenderer extends IRenderer {}
 
-  export var TileRenderer: { new(attributes?: ITileRenderer, options?: ModelOpts): TileRenderer };
+  export const TileRenderer: { new(attributes?: ITileRenderer, options?: ModelOpts): TileRenderer };
   export interface TileRenderer extends DataRenderer, ITileRenderer {}
   export interface ITileRenderer extends IDataRenderer {
     tile_source?: TileSource;
@@ -20,7 +20,7 @@ declare namespace Bokeh {
     render_parents?: boolean;
   }
 
-  export var GlyphRenderer: { new(attributes?: IGlyphRenderer, options?: ModelOpts): GlyphRenderer };
+  export const GlyphRenderer: { new(attributes?: IGlyphRenderer, options?: ModelOpts): GlyphRenderer };
   export interface GlyphRenderer extends Renderer, IGlyphRenderer {}
   export interface IGlyphRenderer extends IRenderer {
     data_source?: DataSource;

--- a/bokehjs/src/coffee/api/typings/models/scales.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/scales.d.ts
@@ -2,15 +2,15 @@ declare namespace Bokeh {
   export interface Scale extends Transform, IScale {}
   export interface IScale extends ITransform {}
 
-  export var LinearScale: { new(attributes?: ILinearScale, options?: ModelOpts): LinearScale };
+  export const LinearScale: { new(attributes?: ILinearScale, options?: ModelOpts): LinearScale };
   export interface LinearScale extends Scale, ILinearScale {}
   export interface ILinearScale extends IScale {}
 
-  export var LogScale: { new(attributes?: ILogScale, options?: ModelOpts): LogScale };
+  export const LogScale: { new(attributes?: ILogScale, options?: ModelOpts): LogScale };
   export interface LogScale extends Scale, ILogScale {}
   export interface ILogScale extends IScale {}
 
-  export var CategoricalScale: { new(attributes?: ICategoricalScale, options?: ModelOpts): CategoricalScale };
+  export const CategoricalScale: { new(attributes?: ICategoricalScale, options?: ModelOpts): CategoricalScale };
   export interface CategoricalScale extends Scale, ICategoricalScale {}
   export interface ICategoricalScale extends IScale {}
 }

--- a/bokehjs/src/coffee/api/typings/models/sources.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/sources.d.ts
@@ -13,7 +13,7 @@ declare namespace Bokeh {
     inspected?: Selected;
   }
 
-  export var ColumnDataSource: { new(attributes?: IColumnDataSource, options?: ModelOpts): ColumnDataSource };
+  export const ColumnDataSource: { new(attributes?: IColumnDataSource, options?: ModelOpts): ColumnDataSource };
   export interface ColumnDataSource extends ColumnarDataSource, IColumnDataSource {
     stream(new_data: Data, rollover: number): void;
   }
@@ -21,7 +21,7 @@ declare namespace Bokeh {
     data?: Data;
   }
 
-  export var GeoJSONDataSource: { new(attributes?: IGeoJSONDataSource, options?: ModelOpts): GeoJSONDataSource };
+  export const GeoJSONDataSource: { new(attributes?: IGeoJSONDataSource, options?: ModelOpts): GeoJSONDataSource };
   export interface GeoJSONDataSource extends ColumnarDataSource, IGeoJSONDataSource {}
   export interface IGeoJSONDataSource extends IColumnarDataSource {
     geojson?: JsObj;
@@ -33,7 +33,7 @@ declare namespace Bokeh {
     polling_interval?: Int;
   }
 
-  export var AjaxDataSource: { new(attributes?: IAjaxDataSource, options?: ModelOpts): AjaxDataSource };
+  export const AjaxDataSource: { new(attributes?: IAjaxDataSource, options?: ModelOpts): AjaxDataSource };
   export interface AjaxDataSource extends RemoteSource, IAjaxDataSource {}
   export interface IAjaxDataSource extends IRemoteSource {
     method?: HTTPMethod;

--- a/bokehjs/src/coffee/api/typings/models/sources.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/sources.d.ts
@@ -9,7 +9,7 @@ declare namespace Bokeh {
 
   export interface ColumnarDataSource extends DataSource, IColumnarDataSource {}
   export interface IColumnarDataSource extends IDataSource {
-    column_names?: Array<string>;
+    column_names?: string[];
     inspected?: Selected;
   }
 

--- a/bokehjs/src/coffee/api/typings/models/tickers.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/tickers.d.ts
@@ -11,14 +11,14 @@ declare namespace Bokeh {
   export var FixedTicker: { new(attributes?: IFixedTicker, options?: ModelOpts): FixedTicker };
   export interface FixedTicker extends ContinuousTicker, IFixedTicker {}
   export interface IFixedTicker extends IContinuousTicker {
-    ticks?: Array<number>;
+    ticks?: number[];
   }
 
   export var AdaptiveTicker: { new(attributes?: IAdaptiveTicker, options?: ModelOpts): AdaptiveTicker };
   export interface AdaptiveTicker extends ContinuousTicker, IAdaptiveTicker {}
   export interface IAdaptiveTicker extends IContinuousTicker {
     base?: number;
-    mantissas?: Array<number>;
+    mantissas?: number[];
     min_interval?: number;
     max_interval?: number;
   }
@@ -26,7 +26,7 @@ declare namespace Bokeh {
   export var CompositeTicker: { new(attributes?: ICompositeTicker, options?: ModelOpts): CompositeTicker };
   export interface CompositeTicker extends ContinuousTicker, ICompositeTicker {}
   export interface ICompositeTicker extends IContinuousTicker {
-    tickers?: Array<Ticker>;
+    tickers?: Ticker[];
   }
 
   export var SingleIntervalTicker: { new(attributes?: ISingleIntervalTicker, options?: ModelOpts): SingleIntervalTicker };
@@ -38,13 +38,13 @@ declare namespace Bokeh {
   export var DaysTicker: { new(attributes?: IDaysTicker, options?: ModelOpts): DaysTicker };
   export interface DaysTicker extends SingleIntervalTicker, IDaysTicker {}
   export interface IDaysTicker extends ISingleIntervalTicker {
-    days?: Array<Int>;
+    days?: Int[];
   }
 
   export var MonthsTicker: { new(attributes?: IMonthsTicker, options?: ModelOpts): MonthsTicker };
   export interface MonthsTicker extends SingleIntervalTicker, IMonthsTicker {}
   export interface IMonthsTicker extends ISingleIntervalTicker {
-    months?: Array<Int>;
+    months?: Int[];
   }
 
   export var YearsTicker: { new(attributes?: IYearsTicker, options?: ModelOpts): YearsTicker };

--- a/bokehjs/src/coffee/api/typings/models/tickers.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/tickers.d.ts
@@ -8,13 +8,13 @@ declare namespace Bokeh {
     desired_num_ticks?: Int;
   }
 
-  export var FixedTicker: { new(attributes?: IFixedTicker, options?: ModelOpts): FixedTicker };
+  export const FixedTicker: { new(attributes?: IFixedTicker, options?: ModelOpts): FixedTicker };
   export interface FixedTicker extends ContinuousTicker, IFixedTicker {}
   export interface IFixedTicker extends IContinuousTicker {
     ticks?: number[];
   }
 
-  export var AdaptiveTicker: { new(attributes?: IAdaptiveTicker, options?: ModelOpts): AdaptiveTicker };
+  export const AdaptiveTicker: { new(attributes?: IAdaptiveTicker, options?: ModelOpts): AdaptiveTicker };
   export interface AdaptiveTicker extends ContinuousTicker, IAdaptiveTicker {}
   export interface IAdaptiveTicker extends IContinuousTicker {
     base?: number;
@@ -23,47 +23,47 @@ declare namespace Bokeh {
     max_interval?: number;
   }
 
-  export var CompositeTicker: { new(attributes?: ICompositeTicker, options?: ModelOpts): CompositeTicker };
+  export const CompositeTicker: { new(attributes?: ICompositeTicker, options?: ModelOpts): CompositeTicker };
   export interface CompositeTicker extends ContinuousTicker, ICompositeTicker {}
   export interface ICompositeTicker extends IContinuousTicker {
     tickers?: Ticker[];
   }
 
-  export var SingleIntervalTicker: { new(attributes?: ISingleIntervalTicker, options?: ModelOpts): SingleIntervalTicker };
+  export const SingleIntervalTicker: { new(attributes?: ISingleIntervalTicker, options?: ModelOpts): SingleIntervalTicker };
   export interface SingleIntervalTicker extends ContinuousTicker, ISingleIntervalTicker {}
   export interface ISingleIntervalTicker extends IContinuousTicker {
     interval?: number;
   }
 
-  export var DaysTicker: { new(attributes?: IDaysTicker, options?: ModelOpts): DaysTicker };
+  export const DaysTicker: { new(attributes?: IDaysTicker, options?: ModelOpts): DaysTicker };
   export interface DaysTicker extends SingleIntervalTicker, IDaysTicker {}
   export interface IDaysTicker extends ISingleIntervalTicker {
     days?: Int[];
   }
 
-  export var MonthsTicker: { new(attributes?: IMonthsTicker, options?: ModelOpts): MonthsTicker };
+  export const MonthsTicker: { new(attributes?: IMonthsTicker, options?: ModelOpts): MonthsTicker };
   export interface MonthsTicker extends SingleIntervalTicker, IMonthsTicker {}
   export interface IMonthsTicker extends ISingleIntervalTicker {
     months?: Int[];
   }
 
-  export var YearsTicker: { new(attributes?: IYearsTicker, options?: ModelOpts): YearsTicker };
+  export const YearsTicker: { new(attributes?: IYearsTicker, options?: ModelOpts): YearsTicker };
   export interface YearsTicker extends SingleIntervalTicker, IYearsTicker {}
   export interface IYearsTicker extends ISingleIntervalTicker {}
 
-  export var BasicTicker: { new(attributes?: IBasicTicker, options?: ModelOpts): BasicTicker };
+  export const BasicTicker: { new(attributes?: IBasicTicker, options?: ModelOpts): BasicTicker };
   export interface BasicTicker extends Ticker, IBasicTicker {}
   export interface IBasicTicker extends ITicker {}
 
-  export var LogTicker: { new(attributes?: ILogTicker, options?: ModelOpts): LogTicker };
+  export const LogTicker: { new(attributes?: ILogTicker, options?: ModelOpts): LogTicker };
   export interface LogTicker extends AdaptiveTicker, ILogTicker {}
   export interface ILogTicker extends IAdaptiveTicker {}
 
-  export var CategoricalTicker: { new(attributes?: ICategoricalTicker, options?: ModelOpts): CategoricalTicker };
+  export const CategoricalTicker: { new(attributes?: ICategoricalTicker, options?: ModelOpts): CategoricalTicker };
   export interface CategoricalTicker extends Ticker, ICategoricalTicker {}
   export interface ICategoricalTicker extends ITicker {}
 
-  export var DatetimeTicker: { new(attributes?: IDatetimeTicker, options?: ModelOpts): DatetimeTicker };
+  export const DatetimeTicker: { new(attributes?: IDatetimeTicker, options?: ModelOpts): DatetimeTicker };
   export interface DatetimeTicker extends Ticker, IDatetimeTicker {}
   export interface IDatetimeTicker extends ITicker {}
 }

--- a/bokehjs/src/coffee/api/typings/models/tiles.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/tiles.d.ts
@@ -11,7 +11,7 @@ declare namespace Bokeh {
     attribution?: string;
   }
 
-  export var MercatorTileSource: { new(attributes?: IMercatorTileSource, options?: ModelOpts): MercatorTileSource };
+  export const MercatorTileSource: { new(attributes?: IMercatorTileSource, options?: ModelOpts): MercatorTileSource };
   export interface MercatorTileSource extends TileSource, IMercatorTileSource {}
   export interface IMercatorTileSource extends ITileSource {
     x_origin_offset?: number;
@@ -20,19 +20,19 @@ declare namespace Bokeh {
     wrap_around?: boolean;
   }
 
-  export var TMSTileSource: { new(attributes?: ITMSTileSource, options?: ModelOpts): TMSTileSource };
+  export const TMSTileSource: { new(attributes?: ITMSTileSource, options?: ModelOpts): TMSTileSource };
   export interface TMSTileSource extends MercatorTileSource, ITMSTileSource {}
   export interface ITMSTileSource extends IMercatorTileSource {}
 
-  export var WMTSTileSource: { new(attributes?: IWMTSTileSource, options?: ModelOpts): WMTSTileSource };
+  export const WMTSTileSource: { new(attributes?: IWMTSTileSource, options?: ModelOpts): WMTSTileSource };
   export interface WMTSTileSource extends MercatorTileSource, IWMTSTileSource {}
   export interface IWMTSTileSource extends IMercatorTileSource {}
 
-  export var QUADKEYTileSource: { new(attributes?: IQUADKEYTileSource, options?: ModelOpts): QUADKEYTileSource };
+  export const QUADKEYTileSource: { new(attributes?: IQUADKEYTileSource, options?: ModelOpts): QUADKEYTileSource };
   export interface QUADKEYTileSource extends MercatorTileSource, IQUADKEYTileSource {}
   export interface IQUADKEYTileSource extends IMercatorTileSource {}
 
-  export var BBoxTileSource: { new(attributes?: IBBoxTileSource, options?: ModelOpts): BBoxTileSource };
+  export const BBoxTileSource: { new(attributes?: IBBoxTileSource, options?: ModelOpts): BBoxTileSource };
   export interface BBoxTileSource extends MercatorTileSource, IBBoxTileSource {}
   export interface IBBoxTileSource extends IMercatorTileSource {
     use_latlon?: boolean;

--- a/bokehjs/src/coffee/api/typings/models/toolbars.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/toolbars.d.ts
@@ -2,7 +2,7 @@ declare namespace Bokeh {
   export interface ToolbarBase extends LayoutDOM, IToolbarBase {}
   export interface IToolbarBase extends ILayoutDOM {
     logo?: Logo;
-    tools?: Array<Tool>;
+    tools?: Tool[];
   }
 
   export var Toolbar: {

--- a/bokehjs/src/coffee/api/typings/models/toolbars.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/toolbars.d.ts
@@ -5,13 +5,13 @@ declare namespace Bokeh {
     tools?: Tool[];
   }
 
-  export var Toolbar: {
+  export const Toolbar: {
     new(attributes?: IToolbar, options?: ModelOpts): Toolbar;
   }
   export interface Toolbar extends ToolbarBase {}
   export interface IToolbar extends IToolbarBase {}
 
-  export var ToolbarBox: {
+  export const ToolbarBox: {
     new(attributes?: IToolbarBox, options?: ModelOpts): ToolbarBox;
   }
   export interface ToolbarBox extends ToolbarBase {}

--- a/bokehjs/src/coffee/api/typings/models/tools.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/tools.d.ts
@@ -15,57 +15,57 @@ declare namespace Bokeh {
     renderers?: Renderer[];
   }
 
-  export var PanTool: { new(attributes?: IPanTool, options?: ModelOpts): PanTool };
+  export const PanTool: { new(attributes?: IPanTool, options?: ModelOpts): PanTool };
   export interface PanTool extends Tool, IPanTool {}
   export interface IPanTool extends ITool {
     dimensions?: Dimensions;
   }
 
-  export var WheelPanTool: { new(attributes?: IWheelPanTool, options?: ModelOpts): WheelPanTool };
+  export const WheelPanTool: { new(attributes?: IWheelPanTool, options?: ModelOpts): WheelPanTool };
   export interface WheelPanTool extends Tool, IWheelPanTool {}
   export interface IWheelPanTool extends ITool {
     dimension?: Dimension;
   }
 
-  export var WheelZoomTool: { new(attributes?: IWheelZoomTool, options?: ModelOpts): WheelZoomTool };
+  export const WheelZoomTool: { new(attributes?: IWheelZoomTool, options?: ModelOpts): WheelZoomTool };
   export interface WheelZoomTool extends Tool, IWheelZoomTool {}
   export interface IWheelZoomTool extends ITool {
     dimensions?: Dimensions;
   }
 
-  export var ZoomInTool: { new(attributes?: IZoomInTool, options?: ModelOpts): ZoomInTool };
+  export const ZoomInTool: { new(attributes?: IZoomInTool, options?: ModelOpts): ZoomInTool };
   export interface ZoomInTool extends Tool, IZoomInTool {}
   export interface IZoomInTool extends ITool {
     factor?: Percent;
     dimensions?: Dimensions;
   }
 
-  export var ZoomOutTool: { new(attributes?: IZoomOutTool, options?: ModelOpts): ZoomOutTool };
+  export const ZoomOutTool: { new(attributes?: IZoomOutTool, options?: ModelOpts): ZoomOutTool };
   export interface ZoomOutTool extends Tool, IZoomOutTool {}
   export interface IZoomOutTool extends ITool {
     factor?: Percent;
     dimensions?: Dimensions;
   }
 
-  export var SaveTool: { new(attributes?: ISaveTool, options?: ModelOpts): SaveTool };
+  export const SaveTool: { new(attributes?: ISaveTool, options?: ModelOpts): SaveTool };
   export interface SaveTool extends Tool, ISaveTool {}
   export interface ISaveTool extends ITool {}
 
-  export var UndoTool: { new(attributes?: IUndoTool, options?: ModelOpts): UndoTool };
+  export const UndoTool: { new(attributes?: IUndoTool, options?: ModelOpts): UndoTool };
   export interface UndoTool extends Tool, IUndoTool {}
   export interface IUndoTool extends ITool {}
 
-  export var RedoTool: { new(attributes?: IRedoTool, options?: ModelOpts): RedoTool };
+  export const RedoTool: { new(attributes?: IRedoTool, options?: ModelOpts): RedoTool };
   export interface RedoTool extends Tool, IRedoTool {}
   export interface IRedoTool extends ITool {}
 
-  export var ResetTool: { new(attributes?: IResetTool, options?: ModelOpts): ResetTool };
+  export const ResetTool: { new(attributes?: IResetTool, options?: ModelOpts): ResetTool };
   export interface ResetTool extends Tool, IResetTool {}
   export interface IResetTool extends ITool {
 
   }
 
-  export var CrosshairTool: { new(attributes?: ICrosshairTool, options?: ModelOpts): CrosshairTool };
+  export const CrosshairTool: { new(attributes?: ICrosshairTool, options?: ModelOpts): CrosshairTool };
   export interface CrosshairTool extends InspectTool, ICrosshairTool {}
   export interface ICrosshairTool extends IInspectTool {
     dimensions?: Dimensions;
@@ -75,28 +75,28 @@ declare namespace Bokeh {
     line_alpha?: number;
   }
 
-  export var BoxZoomTool: { new(attributes?: IBoxZoomTool, options?: ModelOpts): BoxZoomTool };
+  export const BoxZoomTool: { new(attributes?: IBoxZoomTool, options?: ModelOpts): BoxZoomTool };
   export interface BoxZoomTool extends Tool, IBoxZoomTool {}
   export interface IBoxZoomTool extends ITool {}
 
-  export var BoxSelectTool: { new(attributes?: IBoxSelectTool, options?: ModelOpts): BoxSelectTool };
+  export const BoxSelectTool: { new(attributes?: IBoxSelectTool, options?: ModelOpts): BoxSelectTool };
   export interface BoxSelectTool extends SelectTool, IBoxSelectTool {}
   export interface IBoxSelectTool extends ISelectTool {
     select_every_mousemove?: boolean;
     dimensions?: Dimensions;
   }
 
-  export var LassoSelectTool: { new(attributes?: ILassoSelectTool, options?: ModelOpts): LassoSelectTool };
+  export const LassoSelectTool: { new(attributes?: ILassoSelectTool, options?: ModelOpts): LassoSelectTool };
   export interface LassoSelectTool extends SelectTool, ILassoSelectTool {}
   export interface ILassoSelectTool extends ISelectTool {
     select_every_mousemove?: boolean;
   }
 
-  export var PolySelectTool: { new(attributes?: IPolySelectTool, options?: ModelOpts): PolySelectTool };
+  export const PolySelectTool: { new(attributes?: IPolySelectTool, options?: ModelOpts): PolySelectTool };
   export interface PolySelectTool extends SelectTool, IPolySelectTool {}
   export interface IPolySelectTool extends ISelectTool {}
 
-  export var TapTool: { new(attributes?: ITapTool, options?: ModelOpts): TapTool };
+  export const TapTool: { new(attributes?: ITapTool, options?: ModelOpts): TapTool };
   export interface TapTool extends SelectTool, ITapTool {}
   export interface ITapTool extends ISelectTool {
     behavior?: "select" | "inspect";
@@ -127,7 +127,7 @@ declare namespace Bokeh {
     };
   }
 
-  export var HoverTool: { new(attributes?: IHoverTool, options?: ModelOpts): HoverTool };
+  export const HoverTool: { new(attributes?: IHoverTool, options?: ModelOpts): HoverTool };
   export interface HoverTool extends InspectTool, IHoverTool {}
   export interface IHoverTool extends IInspectTool, IHitTest {
     tooltips?: HTMLElement | [string, string][] | ((source: DataSource, info: HoverTooltipInfo) => HTMLElement);
@@ -140,7 +140,7 @@ declare namespace Bokeh {
     show_arrow?: boolean;
   }
 
-  export var HelpTool: { new(attributes?: IHelpTool, options?: ModelOpts): HelpTool };
+  export const HelpTool: { new(attributes?: IHelpTool, options?: ModelOpts): HelpTool };
   export interface HelpTool extends Tool, IHelpTool {}
   export interface IHelpTool extends ITool {
     help_tooltip?: string;

--- a/bokehjs/src/coffee/api/typings/models/tools.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/tools.d.ts
@@ -11,8 +11,8 @@ declare namespace Bokeh {
   export interface ISelectTool extends ITool, IHitTest {}
 
   export interface IHitTest {
-    names?: Array<string>;
-    renderers?: Array<Renderer>;
+    names?: string[];
+    renderers?: Renderer[];
   }
 
   export var PanTool: { new(attributes?: IPanTool, options?: ModelOpts): PanTool };
@@ -116,7 +116,7 @@ declare namespace Bokeh {
   }
 
   export interface HoverCallbackData {
-    index: Array<Int> | Array<Array<Int>>;
+    index: Int[] | Int[][];
     geometry: {
       type: "point" | "span";
       direction?: "h" | "v";
@@ -130,7 +130,7 @@ declare namespace Bokeh {
   export var HoverTool: { new(attributes?: IHoverTool, options?: ModelOpts): HoverTool };
   export interface HoverTool extends InspectTool, IHoverTool {}
   export interface IHoverTool extends IInspectTool, IHitTest {
-    tooltips?: HTMLElement | Array<[string, string]> | ((source: DataSource, info: HoverTooltipInfo) => HTMLElement);
+    tooltips?: HTMLElement | [string, string][] | ((source: DataSource, info: HoverTooltipInfo) => HTMLElement);
     callback?: Callback | ((tool: HoverTool, data: HoverCallbackData) => void);
     mode?: HoverMode;
     point_policy?: PointPolicy;

--- a/bokehjs/src/coffee/api/typings/plotting.d.ts
+++ b/bokehjs/src/coffee/api/typings/plotting.d.ts
@@ -1,10 +1,10 @@
 declare namespace Bokeh.Plotting {
-  function show(objs: Array<LayoutDOM>, target?: string | HTMLElement): Map<View<Model>>;
+  function show(objs: LayoutDOM[], target?: string | HTMLElement): Map<View<Model>>;
   function show<T extends LayoutDOM>(obj: T, target?: string | HTMLElement): View<T>;
 
   function color(r: number, g: number, b: number): string;
 
-  function gridplot(children: Array<Array<Plot>>, options?: IGridPlotOptions): Box;
+  function gridplot(children: Plot[][], options?: IGridPlotOptions): Box;
   export interface IGridPlotOptions {
     toolbar_location?: Location;
     sizing_mode?: SizingMode;
@@ -35,10 +35,10 @@ declare namespace Bokeh.Plotting {
 
   var Figure: { new(attributes?: IFigure, options?: ModelOpts): Figure };
   export interface IFigure extends IBasePlot {
-    tools?: Array<Tool | ToolType> | string;
+    tools?: (Tool | ToolType)[] | string;
 
-    x_range?: Range | [number, number] | Array<string>;
-    y_range?: Range | [number, number] | Array<string>;
+    x_range?: Range | [number, number] | string[];
+    y_range?: Range | [number, number] | string[];
 
     x_axis_type?: AxisType;
     y_axis_type?: AxisType;
@@ -136,7 +136,7 @@ declare namespace Bokeh.Plotting {
       opts?: EllipseOpts):             GlyphRenderer;
     image(
       color_mapper: ColorMapper,
-      image: ValueAttr<Array<number>>,
+      image: ValueAttr<number[]>,
       rows: ValueAttr<Int>,
       cols: ValueAttr<Int>,
       x: DataAttr,
@@ -145,7 +145,7 @@ declare namespace Bokeh.Plotting {
       dh: SpatialAttr,
       opts?: ImageOpts):            GlyphRenderer;
     image_rgba(
-      image: ValueAttr<Array<number>>,
+      image: ValueAttr<number[]>,
       rows: ValueAttr<Int>,
       cols: ValueAttr<Int>,
       x: DataAttr,
@@ -249,14 +249,14 @@ declare namespace Bokeh.Plotting {
   }
 
   //                     scalar   vector                 spec
-  type DataAttr        = number | Array<number>        | Numerical
-                 | Array<string>        | Categorical;
-  type SpatialAttr     = number | Array<number>        | Spatial;
-  type AngularAttr     = number | Array<number>        | Angular;
-  type ValueAttr<T>    = T      | Array<T>             | Vectorized<T>;
+  type DataAttr        = number | number[]        | Numerical
+                 | string[]        | Categorical;
+  type SpatialAttr     = number | number[]        | Spatial;
+  type AngularAttr     = number | number[]        | Angular;
+  type ValueAttr<T>    = T      | T[]             | Vectorized<T>;
 
-  type MultiDataAttr   =          Array<Array<number>> | MultiNumerical
-                 | Array<Array<string>> | MultiCategorical;
+  type MultiDataAttr   =          number[][] | MultiNumerical
+                 | string[][] | MultiCategorical;
 
   type ColorAttr = ValueAttr<Color>;
   type AlphaAttr = ValueAttr<Percent>;
@@ -391,7 +391,7 @@ declare namespace Bokeh.Plotting {
     dilate?: boolean;
   }
   export interface ImageRGBAAttrs extends ImageRGBAOpts {
-    image: ValueAttr<Array<number>>;
+    image: ValueAttr<number[]>;
     rows: ValueAttr<Int>;
     cols: ValueAttr<Int>;
     x: DataAttr;

--- a/bokehjs/src/coffee/api/typings/plotting.d.ts
+++ b/bokehjs/src/coffee/api/typings/plotting.d.ts
@@ -33,7 +33,7 @@ declare namespace Bokeh.Plotting {
 
   function figure(attributes?: IFigure, options?: ModelOpts): Figure;
 
-  var Figure: { new(attributes?: IFigure, options?: ModelOpts): Figure };
+  const Figure: { new(attributes?: IFigure, options?: ModelOpts): Figure };
   export interface IFigure extends IBasePlot {
     tools?: (Tool | ToolType)[] | string;
 

--- a/bokehjs/src/coffee/api/typings/selected.d.ts
+++ b/bokehjs/src/coffee/api/typings/selected.d.ts
@@ -1,8 +1,8 @@
 declare namespace Bokeh {
   // get_view() returns null or View, but View is not typed yet
-  export type Selected0d = {indices: Array<Int>, glyph?: Glyph, get_view(): any};
-  export type Selected1d = {indices: Array<Int>};
-  export type Selected2d = {indices: Array<Array<Int>>};
+  export type Selected0d = {indices: Int[], glyph?: Glyph, get_view(): any};
+  export type Selected1d = {indices: Int[]};
+  export type Selected2d = {indices: Int[][]};
 
   export type Selected = { '0d': Selected0d, '1d': Selected1d, '2d': Selected2d };
 }

--- a/bokehjs/src/coffee/api/typings/vectorization.d.ts
+++ b/bokehjs/src/coffee/api/typings/vectorization.d.ts
@@ -20,6 +20,6 @@ declare namespace Bokeh {
   export type Numerical = Vectorized<number>;
   export type Categorical = Vectorized<string>;
 
-  export type MultiNumerical = Vectorized<Array<number>>;
-  export type MultiCategorical = Vectorized<Array<string>>;
+  export type MultiNumerical = Vectorized<number[]>;
+  export type MultiCategorical = Vectorized<string[]>;
 }

--- a/bokehjs/src/coffee/core/has_props.ts
+++ b/bokehjs/src/coffee/core/has_props.ts
@@ -326,7 +326,7 @@ export abstract class HasProps extends Signalable() {
       return value.ref()
     else if (isArray(value)) {
       const ref_array: any[] = []
-      for (let i = 0; i < value.length; i++ ) {
+      for (let i = 0; i < value.length; i++) {
         const v = value[i]
         ref_array.push(HasProps._value_to_json(i.toString(), v, value))
       }

--- a/bokehjs/src/coffee/core/has_props.ts
+++ b/bokehjs/src/coffee/core/has_props.ts
@@ -71,7 +71,7 @@ export abstract class HasProps extends Signalable() {
           return value
         },
         set: function(this: HasProps, value: any): HasProps {
-          this.setv([name, value])
+          this.setv({[name]: value})
           return this
         },
         configurable: false,
@@ -154,7 +154,7 @@ export abstract class HasProps extends Signalable() {
 
     // auto generating ID
     if (attributes.id == null)
-      this.setv(["id", uniqueId()], {silent: true})
+      this.setv({id: uniqueId()}, {silent: true})
 
     this.setv(attributes, {silent: true})
 
@@ -255,14 +255,7 @@ export abstract class HasProps extends Signalable() {
     this._changing = false
   }
 
-  setv(obj: {[key: string]: any} | [string, any], options: HasProps.SetOptions = {}): void {
-    let attrs: {[key: string]: any} = {}
-    if (isArray(obj)) {
-      const [attr, value] = obj as [string, any]
-      attrs[attr] = value
-    } else
-      attrs = obj
-
+  setv(attrs: {[key: string]: any}, options: HasProps.SetOptions = {}): void {
     for (const key in attrs) {
       if (!attrs.hasOwnProperty(key))
         continue

--- a/bokehjs/src/coffee/core/properties.ts
+++ b/bokehjs/src/coffee/core/properties.ts
@@ -109,7 +109,7 @@ export class Property<T> extends Signalable() {
         attr_value = default_value(obj)
       else
         attr_value = null
-      obj.setv([attr, attr_value], {silent: true, defaults: true})
+      obj.setv({[attr]: attr_value}, {silent: true, defaults: true})
     }
 
     if (isArray(attr_value))

--- a/bokehjs/src/coffee/core/util/eq.ts
+++ b/bokehjs/src/coffee/core/util/eq.ts
@@ -8,7 +8,7 @@ import {isFunction} from "./types"
 const toString = Object.prototype.toString
 
 // Internal recursive comparison function for `isEqual`.
-function eq(a: any, b: any, aStack?: Array<any>, bStack?: Array<any>): boolean {
+function eq(a: any, b: any, aStack?: any[], bStack?: any[]): boolean {
   // Identical objects are equal. `0 === -0`, but they aren't identical.
   // See the [Harmony `egal` proposal](http://wiki.ecmascript.org/doku.php?id=harmony:egal).
   if (a === b) return a !== 0 || 1 / a === 1 / b

--- a/bokehjs/src/coffee/core/util/object.ts
+++ b/bokehjs/src/coffee/core/util/object.ts
@@ -15,7 +15,7 @@ export function values<T>(object: {[key: string]: T}): T[] {
 export function extend<T, T1>(dest: T, src: T1): T & T1;
 export function extend<T, T1, T2>(dest: T, src1: T1, src2: T2): T & T1 & T2;
 export function extend<T, T1, T2, T3>(dest: T, src1: T1, src2: T2, src3: T3): T & T1 & T2 & T3;
-export function extend<R>(dest: any, ...sources: Array<any>): R {
+export function extend<R>(dest: any, ...sources: any[]): R {
   for (const source of sources) {
     for (const key in source) {
       if (source.hasOwnProperty(key)) {

--- a/bokehjs/src/coffee/core/util/types.ts
+++ b/bokehjs/src/coffee/core/util/types.ts
@@ -29,7 +29,7 @@ export function isFunction(obj: any): obj is Function {
   return toString.call(obj) === "[object Function]"
 }
 
-export function isArray<T>(obj: any): obj is Array<T> {
+export function isArray<T>(obj: any): obj is T[] {
   return Array.isArray(obj)
 }
 

--- a/bokehjs/src/coffee/document.ts
+++ b/bokehjs/src/coffee/document.ts
@@ -816,7 +816,7 @@ export class Document {
             patched_obj.setv({_shapes: shapes, data: data}, {setter_id: setter_id})
           } else {
             const value = Document._resolve_refs(event_json.new, old_references, new_references)
-            patched_obj.setv([attr, value], {setter_id: setter_id})
+            patched_obj.setv({[attr]: value}, {setter_id: setter_id})
           }
           break
         }

--- a/bokehjs/src/coffee/models/formatters/datetime_tick_formatter.ts
+++ b/bokehjs/src/coffee/models/formatters/datetime_tick_formatter.ts
@@ -16,7 +16,7 @@ const _us = t =>
   // microsecond / millisecond tick.
   Math.round(((t / 1000) % 1) * 1000000)
 
-const _array = t => tz(t, "%Y %m %d %H %M %S").split(/\s+/).map( e => parseInt(e, 10));
+const _array = t => tz(t, "%Y %m %d %H %M %S").split(/\s+/).map(e => parseInt(e, 10));
 
 const _strftime = function(t, format) {
   if (isFunction(format)) {

--- a/bokehjs/src/coffee/models/formatters/numeral_tick_formatter.ts
+++ b/bokehjs/src/coffee/models/formatters/numeral_tick_formatter.ts
@@ -25,7 +25,7 @@ export class NumeralTickFormatter extends TickFormatter {
       case "ceil":  case "roundup":   return Math.ceil;
     } })();
 
-    const labels = ( ticks.map((tick) => Numbro.format(tick, format, language, rounding)) );
+    const labels = (ticks.map((tick) => Numbro.format(tick, format, language, rounding)));
     return labels;
   }
 }

--- a/bokehjs/src/coffee/models/formatters/printf_tick_formatter.ts
+++ b/bokehjs/src/coffee/models/formatters/printf_tick_formatter.ts
@@ -15,7 +15,7 @@ export class PrintfTickFormatter extends TickFormatter {
 
   doFormat(ticks, _axis) {
     const { format } = this;
-    const labels = ( ticks.map((tick) => sprintf(format, tick)) );
+    const labels = (ticks.map((tick) => sprintf(format, tick)));
     return labels;
   }
 }

--- a/bokehjs/src/coffee/models/layouts/layout_dom.ts
+++ b/bokehjs/src/coffee/models/layouts/layout_dom.ts
@@ -91,7 +91,7 @@ export abstract class LayoutDOMView extends DOMView {
 
       // stop on first element with sensible dimensions
       const {width, height} = measuring.getBoundingClientRect()
-      if( width != 0 && height != 0)
+      if(width != 0 && height != 0)
         return [width, height]
     }
 

--- a/bokehjs/src/coffee/models/plots/gmap_plot_canvas.ts
+++ b/bokehjs/src/coffee/models/plots/gmap_plot_canvas.ts
@@ -84,7 +84,7 @@ export class GMapPlotCanvasView extends PlotCanvasView {
 
         // Check we haven't gone out of bounds, and if we have undo the zoom
         const [proj_xstart, proj_xend,,] = this._get_projected_bounds();
-        if (( proj_xend - proj_xstart ) < 0) {
+        if ((proj_xend - proj_xstart) < 0) {
           this.map.setZoom(old_map_zoom);
         }
       }

--- a/bokehjs/src/coffee/polyfill.ts
+++ b/bokehjs/src/coffee/polyfill.ts
@@ -22,7 +22,7 @@ if (!String_proto.repeat) {
     if (this == null) {
       throw new TypeError('can\'t convert ' + this + ' to object');
     }
-    var str = '' + this;
+    let str = '' + this;
     count = +count;
     if (count != count) {
       count = 0;
@@ -43,7 +43,7 @@ if (!String_proto.repeat) {
     if (str.length * count >= 1 << 28) {
       throw new RangeError('repeat count must not overflow maximum string size');
     }
-    var rpt = '';
+    let rpt = '';
     for (;;) {
       if ((count & 1) == 1) {
         rpt += str;
@@ -94,7 +94,7 @@ if (!(Array as any).from) {
 
       // 4. If mapfn is undefined, then let mapping be false.
       const mapFn = arguments.length > 1 ? arguments[1] : void undefined;
-      var T;
+      let T;
       if (typeof mapFn !== 'undefined') {
         // 5. else
         // 5. a If IsCallable(mapfn) is false, throw a TypeError exception.
@@ -119,11 +119,10 @@ if (!(Array as any).from) {
       const A = isCallable(C) ? Object(new C(len)) : new Array(len);
 
       // 16. Let k be 0.
-      var k = 0;
+      let k = 0;
       // 17. Repeat, while k < len… (also steps a - h)
-      var kValue;
       while (k < len) {
-        kValue = items[k];
+        const kValue = items[k];
         if (mapFn) {
           A[k] = typeof T === 'undefined' ? mapFn(kValue, k) : mapFn.call(T, kValue, k);
         } else {

--- a/bokehjs/tslint.json
+++ b/bokehjs/tslint.json
@@ -16,6 +16,12 @@
         "typeLiterals": "never"
       },
       "esSpecCompliant": true
-    }]
+    }],
+    "ban-types": [true,
+      ["Number", "Use 'number' instead."],
+      ["String", "Use 'string' instead."],
+      ["Boolean", "Use 'boolean' instead."],
+      ["Array<.*>", "Use 'T[]' instead."]
+    ]
   }
 }

--- a/bokehjs/tslint.json
+++ b/bokehjs/tslint.json
@@ -25,6 +25,7 @@
     ],
     "no-construct": true,
     "no-var-keyword": true,
-    "no-string-throw": true
+    "no-string-throw": true,
+    "no-invalid-template-strings": true
   }
 }

--- a/bokehjs/tslint.json
+++ b/bokehjs/tslint.json
@@ -23,6 +23,7 @@
       ["Boolean", "Use 'boolean' instead."],
       ["Array<.*>", "Use 'T[]' instead."]
     ],
-    "no-construct": true
+    "no-construct": true,
+    "no-var-keyword": true
   }
 }

--- a/bokehjs/tslint.json
+++ b/bokehjs/tslint.json
@@ -22,6 +22,7 @@
       ["String", "Use 'string' instead."],
       ["Boolean", "Use 'boolean' instead."],
       ["Array<.*>", "Use 'T[]' instead."]
-    ]
+    ],
+    "no-construct": true
   }
 }

--- a/bokehjs/tslint.json
+++ b/bokehjs/tslint.json
@@ -24,6 +24,7 @@
       ["Array<.*>", "Use 'T[]' instead."]
     ],
     "no-construct": true,
-    "no-var-keyword": true
+    "no-var-keyword": true,
+    "no-string-throw": true
   }
 }


### PR DESCRIPTION
This PR enables a few more tslint rules for common issues (like using `Number` type instead of `number` or throwing strings instead of `new Error(...)`). 

addresses #6481 
