### PR TITLE
handle legends better with data frame sources

### DIFF
--- a/bokeh/plotting/helpers.py
+++ b/bokeh/plotting/helpers.py
@@ -246,7 +246,7 @@ def _get_legend_item_label(kwargs):
             # Do the simple thing first
             legend_item_label = value(legend)
             # But if there's a source - try and do something smart
-            if source and hasattr(source, 'column_names'):
+            if source is not None and hasattr(source, 'column_names'):
                 if legend in source.column_names:
                     legend_item_label = field(legend)
         else:
@@ -699,26 +699,30 @@ def _glyph_function(glyphclass, extra_docs=None):
 
     def func(self, **kwargs):
 
+        # Convert data source, if necesary
+        is_user_source = kwargs.get('source', None) is not None
+        if is_user_source:
+            source = kwargs['source']
+            if not isinstance(source, ColumnarDataSource):
+                try:
+                    # try converting the soruce to ColumnDataSource
+                    source = ColumnDataSource(source)
+                except ValueError as err:
+                    msg = "Failed to auto-convert {curr_type} to ColumnDataSource.\n Original error: {err}".format(
+                        curr_type=str(type(source)),
+                        err=err.message
+                    )
+                    reraise(ValueError, ValueError(msg), sys.exc_info()[2])
+
+                # update reddered_kws so that others can use the new source
+                kwargs['source'] = source
+
         # Process legend kwargs and remove legend before we get going
         legend_item_label = _get_legend_item_label(kwargs)
 
         # Need to check if user source is present before _pop_renderer_args
-        is_user_source = kwargs.get('source', None) is not None
         renderer_kws = _pop_renderer_args(kwargs)
         source = renderer_kws['data_source']
-        if not isinstance(source, ColumnarDataSource):
-            try:
-                # try converting the soruce to ColumnDataSource
-                source = ColumnDataSource(source)
-            except ValueError as err:
-                msg = "Failed to auto-convert {curr_type} to ColumnDataSource.\n Original error: {err}".format(
-                    curr_type=str(type(source)),
-                    err=err.message
-                )
-                reraise(ValueError, ValueError(msg), sys.exc_info()[2])
-
-            # update reddered_kws so that others can use the new source
-            renderer_kws['data_source'] = source
 
         # handle the main glyph, need to process literals
         glyph_ca = _pop_colors_and_alpha(glyphclass, kwargs)

--- a/bokeh/plotting/tests/test_figure.py
+++ b/bokeh/plotting/tests/test_figure.py
@@ -271,19 +271,33 @@ def p():
     return plt.figure()
 
 
-def test_glyph_label_is_legend_if_column_in_datasouurce_is_added_as_legend(p, source):
+def test_glyph_label_is_legend_if_column_in_datasource_is_added_as_legend(p, source):
     p.circle(x='x', y='y', legend='label', source=source)
     legends = p.select(Legend)
     assert len(legends) == 1
     assert legends[0].items[0].label == {'field': 'label'}
 
 
-def test_glyph_label_is_value_if_column_not_in_datasouurce_is_added_as_legend(p, source):
+def test_glyph_label_is_value_if_column_not_in_datasource_is_added_as_legend(p, source):
     p.circle(x='x', y='y', legend='milk', source=source)
     legends = p.select(Legend)
     assert len(legends) == 1
     assert legends[0].items[0].label == {'value': 'milk'}
 
+def test_glyph_label_is_legend_if_column_in_df_datasource_is_added_as_legend(p):
+    source = pd.DataFrame(data=dict(x=[1, 2, 3], y=[1, 2, 3], label=['a', 'b', 'c']))
+    p.circle(x='x', y='y', legend='label', source=source)
+    legends = p.select(Legend)
+    assert len(legends) == 1
+    assert legends[0].items[0].label == {'field': 'label'}
+
+
+def test_glyph_label_is_value_if_column_not_in_df_datasource_is_added_as_legend(p):
+    source = pd.DataFrame(data=dict(x=[1, 2, 3], y=[1, 2, 3], label=['a', 'b', 'c']))
+    p.circle(x='x', y='y', legend='milk', source=source)
+    legends = p.select(Legend)
+    assert len(legends) == 1
+    assert legends[0].items[0].label == {'value': 'milk'}
 
 def test_glyph_label_is_just_added_directly_if_not_string(p, source):
     p.circle(x='x', y='y', legend={'field': 'milk'}, source=source)
@@ -347,3 +361,16 @@ def test_compound_legend_behavior_initiated_if_labels_are_same_on_multiple_rende
     assert len(legends) == 1
     assert legends[0].items[0].renderers == [square, circle]
     assert legends[0].items[0].label == {'field': 'label'}
+
+# XXX (bev) this doesn't work yet because compound behaviour depends on renderer sources
+# matching, but passing a df means every renderer gets its own new source
+# def test_compound_legend_behavior_initiated_if_labels_are_same_on_multiple_renderers_and_are_field_with_df_source(p):
+#     source = pd.DataFrame(data=dict(x=[1, 2, 3], y=[1, 2, 3], label=['a', 'b', 'c']))
+#     # label is a field
+#     square = p.square(x='x', y='y', legend='label', source=source)
+#     circle = p.circle(x='x', y='y', legend='label', source=source)
+#     legends = p.select(Legend)
+#     assert len(legends) == 1
+#     print(legends[0].items[0].renderers)
+#     assert legends[0].items[0].renderers == [square, circle]
+#     assert legends[0].items[0].label == {'field': 'label'}

--- a/bokeh/plotting/tests/test_helpers.py
+++ b/bokeh/plotting/tests/test_helpers.py
@@ -7,10 +7,49 @@ from bokeh.models import ColumnDataSource, CDSView, Marker
 from bokeh.models.ranges import Range1d, DataRange1d, FactorRange
 from bokeh.models.scales import LinearScale, LogScale, CategoricalScale
 from bokeh.plotting import Figure
-from bokeh.plotting.helpers import (_get_legend_item_label, _get_scale,
-                                    _get_range, _stack, _graph, _glyph_function,
-                                    _RENDERER_ARGS)
+from bokeh.plotting.helpers import _get_scale,_get_range, _stack, _graph, _glyph_function, _RENDERER_ARGS
 
+import bokeh.plotting.helpers as bph
+
+class Test__get_legend_item_label(object):
+
+    def test_legend_None(self):
+        kwargs = {
+            'legend': None
+        }
+        assert bph._get_legend_item_label(kwargs) is None
+
+
+    def test_if_legend_is_something_exotic_that_it_is_passed_directly_to_label(self):
+        kwargs = {
+            'legend': {'field': 'milk'}
+        }
+        label = bph._get_legend_item_label(kwargs)
+        assert label == {'field': 'milk'}
+
+    def test_if_legend_is_a_string_but_no_source_then_label_is_set_as_value(self):
+        kwargs = {
+            'legend': 'label'
+        }
+        label = bph._get_legend_item_label(kwargs)
+        assert label == {'value': 'label'}
+
+    def test_if_legend_is_a_string_and_source_with_that_column_then_field(self):
+        kwargs = {
+            'legend': 'label',
+            'source': ColumnDataSource(dict(label=[1, 2]))
+        }
+        label = bph._get_legend_item_label(kwargs)
+        assert label == {'field': 'label'}
+
+
+    def test_if_legend_is_a_string_and_source_without_column_name_then_value(self):
+        kwargs = {
+            'legend': 'not_a_column_label',
+            'source': ColumnDataSource(dict(label=[1, 2]))
+        }
+        label = bph._get_legend_item_label(kwargs)
+        assert label == {'value': 'not_a_column_label'}
 
 def test__stack_raises_when_spec_in_kwargs():
     with pytest.raises(ValueError) as e:
@@ -124,40 +163,6 @@ def test__graph_properly_handle_edge_property_mixins():
     assert r.nonselection_glyph.line_width == 23
     assert r.hover_glyph.line_width == 23
     assert r.muted_glyph.line_width == 23
-
-# _get_legend_item_label
-def test_if_legend_is_something_exotic_that_it_is_passed_directly_to_label():
-    kwargs = {
-        'legend': {'field': 'milk'}
-    }
-    label = _get_legend_item_label(kwargs)
-    assert label == {'field': 'milk'}
-
-
-def test_if_legend_is_a_string_but_no_source_then_label_is_set_as_value():
-    kwargs = {
-        'legend': 'label'
-    }
-    label = _get_legend_item_label(kwargs)
-    assert label == {'value': 'label'}
-
-
-def test_if_legend_is_a_string_and_source_with_that_column_then_field():
-    kwargs = {
-        'legend': 'label',
-        'source': ColumnDataSource(dict(label=[1, 2]))
-    }
-    label = _get_legend_item_label(kwargs)
-    assert label == {'field': 'label'}
-
-
-def test_if_legend_is_a_string_and_source_without_column_name_then_value():
-    kwargs = {
-        'legend': 'not_a_column_label',
-        'source': ColumnDataSource(dict(label=[1, 2]))
-    }
-    label = _get_legend_item_label(kwargs)
-    assert label == {'value': 'not_a_column_label'}
 
 def test__get_scale_numeric_range_linear_axis():
     s = _get_scale(Range1d(), "linear")


### PR DESCRIPTION
- [x] issues: fixes #7400
- [x] tests added / passed

This fixes the case where passing both a legend and a DataFrame for `source` caused errors, by moving the processing of `source` up earlier (so that the legend handling code always sees only a CDS)

However, this did uncover an (unrelated) issue with DF sources and legends, namely that this case will not work as expected:
```
source = pd.DataFrame(data=dict(x=[1, 2, 3], y=[1, 2, 3], label=['a', 'b', 'c']))
square = p.square(x='x', y='y', legend='label', source=source)
circle = p.circle(x='x', y='y', legend='label', source=source)
```
The "combining" is contingent on renderers sharing a source, but in this case each renderer will have a new source, created from the DataFrame. This should be fixed, but later as part of a more general clean up. Mentioning here to document. 