### PR TITLE
Fixes for EditTools

### DIFF
--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -893,7 +893,7 @@ class EditTool(Tool):
     """)
 
 class BoxEditTool(EditTool, Drag, Tap):
-    ''' *toolbar icon*: |box_draw_icon|
+    ''' *toolbar icon*: |box_edit_icon|
 
     The BoxEditTool allows drawing, dragging and deleting ``Rect``
     glyphs on one or more renderers by editing the underlying
@@ -927,7 +927,7 @@ class BoxEditTool(EditTool, Drag, Tap):
       selection tool) then press <<backspace>> while the mouse is
       within the plot area.
 
-    .. |box_draw_icon| image:: /_images/icons/BoxEdit.png
+    .. |box_edit_icon| image:: /_images/icons/BoxEdit.png
         :height: 18pt
     '''
 

--- a/bokehjs/src/coffee/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/src/coffee/models/tools/edit/box_edit_tool.ts
@@ -158,7 +158,7 @@ export class BoxEditTool extends EditTool {
     })
   }
 
-  tool_name = "Box Draw Tool"
+  tool_name = "Box Edit Tool"
   icon = "bk-tool-icon-box-edit"
   event_type = ["tap", "pan", "move"]
   default_order = 30

--- a/bokehjs/src/coffee/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/src/coffee/models/tools/edit/box_edit_tool.ts
@@ -161,6 +161,6 @@ export class BoxEditTool extends EditTool {
   tool_name = "Box Edit Tool"
   icon = "bk-tool-icon-box-edit"
   event_type = ["tap", "pan", "move"]
-  default_order = 30
+  default_order = 1
 }
 BoxEditTool.initClass()

--- a/bokehjs/src/coffee/models/tools/edit/point_draw_tool.ts
+++ b/bokehjs/src/coffee/models/tools/edit/point_draw_tool.ts
@@ -116,6 +116,6 @@ export class PointDrawTool extends EditTool {
   tool_name = "Point Draw Tool"
   icon = "bk-tool-icon-point-draw"
   event_type = ["tap", "pan", "move"]
-  default_order = 12
+  default_order = 2
 }
 PointDrawTool.initClass()

--- a/bokehjs/src/coffee/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/src/coffee/models/tools/edit/poly_draw_tool.ts
@@ -227,6 +227,6 @@ export class PolyDrawTool extends EditTool {
   tool_name = "Polygon Draw Tool"
   icon = "bk-tool-icon-poly-draw"
   event_type = ["pan", "tap", "move"]
-  default_order = 12
+  default_order = 3
 }
 PolyDrawTool.initClass()

--- a/bokehjs/src/coffee/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/src/coffee/models/tools/edit/poly_draw_tool.ts
@@ -17,6 +17,7 @@ export class PolyDrawToolView extends EditToolView {
   _tap(e: BkEv): void {
     if (this._drawing) {
       this._draw(e, 'add');
+      this.model.renderers[0].data_source.properties.data.change.emit(undefined);
     } else {
       const append = e.srcEvent.shiftKey != null ? e.srcEvent.shiftKey : false;
       this._select_event(e, append, this.model.renderers);
@@ -37,7 +38,6 @@ export class PolyDrawToolView extends EditToolView {
       if (xkey) { ds.data[xkey].push([x, x]); }
       if (ykey) { ds.data[ykey].push([y, y]); }
       this._pad_empty_columns(ds, [xkey, ykey]);
-      ds.properties.data.change.emit(undefined);
     } else if (mode == 'edit') {
       if (xkey) {
         const xs = ds.data[xkey][ds.data[xkey].length-1];
@@ -68,7 +68,6 @@ export class PolyDrawToolView extends EditToolView {
         ys[ys.length-1] = y;
         ys.push(ny);
       }
-      ds.properties.data.change.emit(undefined);
     }
     ds.change.emit(undefined)
   }
@@ -82,6 +81,7 @@ export class PolyDrawToolView extends EditToolView {
       this._drawing = true;
       this._draw(e, 'new');
     }
+    this.model.renderers[0].data_source.properties.data.change.emit(undefined);
   }
 
   _move(e: BkEv): void {

--- a/bokehjs/src/coffee/models/tools/edit/poly_edit_tool.ts
+++ b/bokehjs/src/coffee/models/tools/edit/poly_edit_tool.ts
@@ -256,6 +256,6 @@ export class PolyEditTool extends EditTool {
   tool_name = "Poly Edit Tool"
   icon = "bk-tool-icon-poly-edit"
   event_type = ["tap", "pan", "move"]
-  default_order = 12
+  default_order = 4
 }
 PolyEditTool.initClass()

--- a/bokehjs/src/coffee/models/tools/toolbar_box.ts
+++ b/bokehjs/src/coffee/models/tools/toolbar_box.ts
@@ -164,7 +164,7 @@ export class ProxyToolbar extends ToolbarBase {
         continue;
       }
       this.gestures[et].tools = sortBy(tools, tool => tool.default_order);
-      if (!(et == 'pinch' || et == 'scroll'))
+      if (!(et == 'pinch' || et == 'scroll' || et == 'multi'))
         this.gestures[et].tools[0].active = true;
     }
   }

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -606,7 +606,7 @@ BoxEditTool
 ~~~~~~~~~~~
 
 * name: ``'box_edit'``
-* menu icon: |box_draw_icon|
+* menu icon: |box_edit_icon|
 
 The BoxEditTool allows drawing, dragging and deleting ``Rect`` glyphs
 on one or more renderers by editing the underlying
@@ -897,7 +897,7 @@ properties on |Plot| objects that control LOD behavior:
     :height: 14pt
 .. |zoom_out_icon| image:: /_images/icons/ZoomOut.png
     :height: 14pt
-.. |box_draw_icon| image:: /_images/icons/BoxEdit.png
+.. |box_edit_icon| image:: /_images/icons/BoxEdit.png
     :height: 14pt
 .. |point_draw_icon| image:: /_images/icons/PointDraw.png
     :height: 14pt


### PR DESCRIPTION
Fixes issue with PolyDrawTool not emitting event on completing a polygon/line with a double tap. Also renames remaining references to BoxDrawTool left over from a rename.

I'll leave this as a WIP until I've finished writing examples for higher level libraries, in case I find any further issues. 

- [x] issues: fixes #7470 
- [ ] tests added / passed