### PR TITLE
transform Date correctly on windows

### DIFF
--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -1071,7 +1071,7 @@ class Date(Property):
         if isinstance(value, (float,) + bokeh_integer_types):
             try:
                 value = datetime.date.fromtimestamp(value)
-            except ValueError:
+            except (ValueError, OSError):
                 value = datetime.date.fromtimestamp(value/1000)
         elif isinstance(value, string_types):
             value = dateutil.parser.parse(value).date()

--- a/bokeh/core/tests/test_properties.py
+++ b/bokeh/core/tests/test_properties.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import datetime
+import time
 import unittest
 import numpy as np
 import pandas as pd
@@ -9,7 +10,7 @@ from copy import copy
 import pytest
 
 from bokeh.core.properties import (field, value,
-    NumberSpec, ColorSpec, Bool, Int, Float, Complex, String,
+    NumberSpec, ColorSpec, Bool, Int, Float, Complex, Date, String,
     Regex, Seq, List, Dict, Tuple, Instance, Any, Interval, Either,
     Enum, Color, DashPattern, Size, Percent, Angle, AngleSpec, StringSpec,
     DistanceSpec, FontSize, FontSizeSpec, Override, Include, MinMaxBounds,
@@ -20,6 +21,17 @@ from bokeh.core.property.containers import PropertyValueColumnData, PropertyValu
 from bokeh.core.has_props import HasProps
 
 from bokeh.models import Plot
+
+class Test_Date(object):
+    def test_validate_seconds(self):
+        t = time.time()
+        d = Date()
+        assert d.transform(t) == datetime.date.today()
+
+    def test_validate_milliseconds(self):
+        t = time.time() * 1000
+        d = Date()
+        assert d.transform(t) == datetime.date.today()
 
 class Basictest(unittest.TestCase):
 


### PR DESCRIPTION
- [x] issues: fixes #7460
- [x] tests added / passed

This adds a catch for `OSError` to `Date.transform` which is the proper way to catch the exception on some platforms/versions. 

Note that `test_validate_milliseconds` was verified to fail without the associated code change, and is passing with the code change (on windows) 
