### PR TITLE
Ensured PolyEdit tool emits CDS data change event on vertex add

### DIFF
--- a/bokehjs/src/coffee/models/tools/edit/poly_edit_tool.ts
+++ b/bokehjs/src/coffee/models/tools/edit/poly_edit_tool.ts
@@ -134,7 +134,9 @@ export class PolyEditToolView extends EditToolView {
         ys.splice(index+1, 0, ny)
       }
       ds.change.emit(undefined);
-      this._selected_renderer.data_source.change.emit(undefined);
+      const selected_ds = this._selected_renderer.data_source;
+      selected_ds.change.emit(undefined);
+      selected_ds.properties.data.change.emit(undefined);
       return;
     }
     const append = e.srcEvent.shiftKey != null ? e.srcEvent.shiftKey : false;


### PR DESCRIPTION
I fixed this for the PolyDraw tool in my previous PR but somehow missed the same thing on the PolyEdit tool.

- [x] issues: fixes #7470