### PR TITLE
Resolve compilation errors around Number.isInteger

### DIFF
--- a/bokehjs/src/coffee/polyfill.ts
+++ b/bokehjs/src/coffee/polyfill.ts
@@ -9,8 +9,8 @@ if (typeof Set !== "function") {
 }
 
 // ref: https://github.com/bokeh/bokeh/issues/7373
-if (!Number.isInteger) {
-  Number.isInteger = function(value: number): boolean {
+if (!(Number as any).isInteger) {
+  (Number as any).isInteger = function(value: number): boolean {
     return typeof value === 'number' && isFinite(value) && Math.floor(value) === value;
   }
 }


### PR DESCRIPTION
The previous fix was incorrect on the type-level, because `Number.isInteger` is not a part of the standard library (es5 + es2015.collections) that we use. This isn't needed for the release.

addresses #7373, PR #7493
