### PR TITLE
Notify the user if package.json changed and `npm install` is needed

### DIFF
--- a/bokehjs/.gitignore
+++ b/bokehjs/.gitignore
@@ -10,3 +10,4 @@
 *.DS_Store
 npm-debug.log
 /test/.generated_defaults/
+/.package.json

--- a/bokehjs/gulpfile.js
+++ b/bokehjs/gulpfile.js
@@ -1,2 +1,25 @@
+const crypto = require("crypto")
+const fs = require("fs")
+
+function is_up_to_date(file) {
+  const hash_file = "." + file
+
+  if (!fs.existsSync(hash_file))
+    return false
+
+  const old_hash = fs.readFileSync(hash_file)
+
+  const new_hash = crypto.createHash("sha256")
+                         .update(fs.readFileSync(file))
+                         .digest("hex")
+
+  return old_hash == new_hash
+}
+
+if (!is_up_to_date("package.json")) {
+  console.log("package.json has changed. Run `npm install`.")
+  process.exit(1)
+}
+
 require("./ts-node").register({project: "./gulp/tsconfig.json", cache: false});
 require("./gulp");

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -114,6 +114,7 @@
     "slickgrid": "https://github.com/bokeh/SlickGrid.git#6c1327b"
   },
   "scripts": {
+    "prepare": "node ./prepare.js",
     "build": "gulp build",
     "dev-build": "gulp dev-build"
   },

--- a/bokehjs/prepare.js
+++ b/bokehjs/prepare.js
@@ -1,0 +1,12 @@
+const crypto = require("crypto")
+const fs = require("fs")
+
+function write_hash(file) {
+  const hash = crypto.createHash("sha256")
+                     .update(fs.readFileSync(file))
+                     .digest("hex")
+
+  fs.writeFileSync("." + file, hash)
+}
+
+write_hash("package.json")


### PR DESCRIPTION
For now this only notifies the user. It's not possible to run `npm install` and keep `gulp task_name` for running the build. This could be achieved in future by adding a layer above `gulp` or dropping `gulp` altogether (which I've been contemplating for some time).

fixes #7513 
