### PR TITLE
Fixed FutureWarning in json serialization of floating values

### DIFF
--- a/bokeh/core/json_encoder.py
+++ b/bokeh/core/json_encoder.py
@@ -77,7 +77,7 @@ class BokehJSONEncoder(json.JSONEncoder):
             return dict(start=obj.start, stop=obj.stop, step=obj.step)
 
         # NumPy scalars
-        elif np.issubdtype(type(obj), np.float):
+        elif np.issubdtype(type(obj), np.floating):
             return float(obj)
         elif np.issubdtype(type(obj), np.integer):
             return int(obj)


### PR DESCRIPTION
The most recent version of NumPy raises a FutureWarning during serialization because the np.issubdtype expects a scalar baseclass instead of a specific dtype. Replacing np.float with np.floating addresses this issue.

- [x] issues: fixes #7526