### PR TITLE
Add `pass_all_ticks` argument to FuncTickFormatter

### DIFF
--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -322,9 +322,11 @@ class FuncTickFormatter(TickFormatter):
     """)
 
     code = String(default="", help="""
-    A snippet of JavaScript code that reformats a single tick to the desired
-    format. The variable ``tick`` will contain the unformatted tick value and
+    A snippet of JavaScript code that reformats ticks to the desired format.
+    The variable ``tick`` will contain the unformatted tick value and
     can be expected to be present in the code snippet namespace at render time.
+    If ``pass_all_ticks`` is ``True``, ``tick`` will contain an array of ticks,
+    with array of strings expected in return.
 
     Example:
 
@@ -333,6 +335,11 @@ class FuncTickFormatter(TickFormatter):
             code = '''
             return Math.floor(tick) + " + " + (tick % 1).toFixed(2)
             '''
+    """)
+
+    pass_all_ticks = Bool(default=False, help="""
+    Whether the variable ``tick`` passed to ``code`` contains a single
+    tick at a time or an array of all ticks at once.
     """)
 
 def _DATETIME_TICK_FORMATTER_HELP(field):

--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -323,10 +323,12 @@ class FuncTickFormatter(TickFormatter):
 
     code = String(default="", help="""
     A snippet of JavaScript code that reformats ticks to the desired format.
-    The variable ``tick`` will contain the unformatted tick value and
-    can be expected to be present in the code snippet namespace at render time.
-    If ``pass_all_ticks`` is ``True``, ``tick`` will contain an array of ticks,
-    with array of strings expected in return.
+    If ``pass_all_ticks`` is ``False``, the variable ``tick`` will contain the
+    unformatted tick value and can be expected to be present in the code
+    snippet namespace at render time.
+    If ``pass_all_ticks`` is ``True``, the variable will be called ``ticks``
+    and will contain an array of ticks, with array of strings expected in
+    return.
 
     Example:
 
@@ -335,11 +337,20 @@ class FuncTickFormatter(TickFormatter):
             code = '''
             return Math.floor(tick) + " + " + (tick % 1).toFixed(2)
             '''
+
+    Equivalent example with ``pass_all_ticke=True``:
+
+        .. code-block:: javascript
+
+            code = '''
+            return ticks.map(t => Math.floor(t) + "+" + (t % 1).toFixed(2))
+            '''
     """)
 
     pass_all_ticks = Bool(default=False, help="""
-    Whether the variable ``tick`` passed to ``code`` contains a single
-    tick at a time or an array of all ticks at once.
+    Whether the ``code`` snippet is passed a single tick at a time (in a
+    variable called ``tick``), or an array of all ticks at once (in a variable
+    called ``ticks``).
     """)
 
 def _DATETIME_TICK_FORMATTER_HELP(field):

--- a/bokeh/models/tests/test_formatters.py
+++ b/bokeh/models/tests/test_formatters.py
@@ -78,3 +78,7 @@ def test_functickformatter_from_coffeescript_with_args():
         return Math.floor(slider.get("value") / 2) + tick;
         """)
     assert formatter.args == {"slider": slider}
+
+def test_functickformatter_pass_all_ticks():
+    formatter = FuncTickFormatter(code='...', pass_all_ticks=True)
+    assert formatter.pass_all_ticks

--- a/bokehjs/src/coffee/models/formatters/func_tick_formatter.ts
+++ b/bokehjs/src/coffee/models/formatters/func_tick_formatter.ts
@@ -32,7 +32,8 @@ export class FuncTickFormatter extends TickFormatter {
   }
 
   _make_func() {
-    return new Function("tick", ...Object.keys(this.args), "require", this.code);
+    const tick_arg = this.pass_all_ticks ? "ticks" : "tick";
+    return new Function(tick_arg, ...Object.keys(this.args), "require", this.code);
   }
 
   doFormat(ticks, _axis) {

--- a/bokehjs/src/coffee/models/formatters/func_tick_formatter.ts
+++ b/bokehjs/src/coffee/models/formatters/func_tick_formatter.ts
@@ -7,6 +7,7 @@ export namespace FuncTickFormatter {
   export interface Attrs extends TickFormatter.Attrs {
     args: {[key: string]: any}
     code: string
+    pass_all_ticks: boolean
   }
 
   export interface Opts extends TickFormatter.Opts {}
@@ -26,6 +27,7 @@ export class FuncTickFormatter extends TickFormatter {
     this.define({
       args: [ p.Any,     {} ], // TODO (bev) better type
       code: [ p.String,  '' ],
+      pass_all_ticks: [ p.Bool, false ],
     });
   }
 
@@ -35,7 +37,8 @@ export class FuncTickFormatter extends TickFormatter {
 
   doFormat(ticks, _axis) {
     const func = this._make_func();
-    return (ticks.map((tick) => func(tick, ...values(this.args), require)));
+    const formatter = tick => func(tick, ...values(this.args), require);
+    return this.pass_all_ticks ? formatter(ticks) : ticks.map(formatter);
   }
 }
 FuncTickFormatter.initClass();

--- a/bokehjs/test/models/formatters/func_tick_formatter.coffee
+++ b/bokehjs/test/models/formatters/func_tick_formatter.coffee
@@ -47,3 +47,11 @@ describe "func_tick_formatter module", ->
       })
       labels = formatter.doFormat([-10, -0.1, 0, 0.1, 10])
       expect(labels).to.deep.equal([5, 14.9, 15, 15.1, 25])
+
+    it "should handle array of ticks", ->
+      formatter = new FuncTickFormatter({
+        code: "return tick.map(t => t * 10)"
+        pass_all_ticks: true
+      })
+      labels = formatter.doFormat([-10, -0.1, 0, 0.1, 10])
+      expect(labels).to.deep.equal([-100, -1.0, 0, 1, 100])

--- a/bokehjs/test/models/formatters/func_tick_formatter.coffee
+++ b/bokehjs/test/models/formatters/func_tick_formatter.coffee
@@ -50,7 +50,7 @@ describe "func_tick_formatter module", ->
 
     it "should handle array of ticks", ->
       formatter = new FuncTickFormatter({
-        code: "return tick.map(t => t * 10)"
+        code: "return ticks.map(t => t * 10)"
         pass_all_ticks: true
       })
       labels = formatter.doFormat([-10, -0.1, 0, 0.1, 10])


### PR DESCRIPTION
Was unsure of the argument name. `array` seemed more explicit than `vectorized`. Open to suggestions.

- [x] issues: fixes https://github.com/bokeh/bokeh/issues/7563
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
