### PR TITLE
Issue #7474 addressed: image alpha implemented

### DIFF
--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -324,9 +324,10 @@ class Image(XYGlyph):
         if 'palette' in kwargs and 'color_mapper' in kwargs:
             raise ValueError("only one of 'palette' and 'color_mapper' may be specified")
         elif 'color_mapper' not in kwargs:
-            # Use a palette (given or default)
+            # Use a palette and alpha value (given or default)
             palette = kwargs.pop('palette', 'Greys9')
-            mapper = LinearColorMapper(palette)
+            alpha = kwargs.pop('global_alpha', 1.0)
+            mapper = LinearColorMapper(palette=palette, alpha=alpha)
             kwargs['color_mapper'] = mapper
 
         super(Image, self).__init__(**kwargs)

--- a/bokeh/models/mappers.py
+++ b/bokeh/models/mappers.py
@@ -28,9 +28,15 @@ class ColorMapper(Transform):
     Color to be used if data is NaN. Default: 'gray'
     """)
 
-    def __init__(self, palette=None, **kwargs):
+    alpha = Float(default=1.0, help="""
+    An overall opacity applied to all colors in the palette.
+    """)
+
+    def __init__(self, palette=None, alpha=None, **kwargs):
         if palette is not None:
             kwargs['palette'] = palette
+        if alpha is not None:
+            kwargs['alpha'] = alpha
         super(ColorMapper, self).__init__(**kwargs)
 
 

--- a/bokeh/models/tests/test_mappers.py
+++ b/bokeh/models/tests/test_mappers.py
@@ -13,7 +13,8 @@ def test_LinearColorMapper():
         "high",
         "low_color",
         "high_color",
-        "nan_color"],
+        "nan_color",
+        "alpha"],
     )
 
 
@@ -25,7 +26,8 @@ def test_LogColorMapper():
         "high",
         "low_color",
         "high_color",
-        "nan_color"],
+        "nan_color",
+        "alpha"],
     )
 
 
@@ -36,7 +38,8 @@ def test_CategoricalColorMapper():
         "palette",
         "start",
         "end",
-        "nan_color"],
+        "nan_color",
+        "alpha"],
     )
 
 

--- a/bokehjs/src/coffee/core/util/color.ts
+++ b/bokehjs/src/coffee/core/util/color.ts
@@ -2,7 +2,7 @@
 import * as svg_colors from "./svg_colors"
 import {includes} from "./array";
 
-const _component2hex = function(v) {
+export const component2hex = function(v) {
   let h = Number(v).toString(16);
   return h = h.length === 1 ? `0${h}` : h;
 };
@@ -15,9 +15,9 @@ export const color2hex = function(color) {
     return svg_colors[color];
   } else if (color.indexOf('rgb') === 0) {
     const rgb = color.replace(/^rgba?\(|\s+|\)$/g,'').split(',');
-    let hex = (rgb.slice(0, 3).map((v) => _component2hex(v))).join('');
+    let hex = (rgb.slice(0, 3).map((v) => component2hex(v))).join('');
     if (rgb.length === 4) {
-      hex = hex + _component2hex(Math.floor(parseFloat(rgb.slice(3)) * 255));
+      hex = hex + component2hex(Math.floor(parseFloat(rgb.slice(3)) * 255));
     }
     const hex_string = `#${hex.slice(0, 8)}`;  // can also be rgba
     return hex_string;

--- a/bokehjs/src/coffee/models/glyphs/image.ts
+++ b/bokehjs/src/coffee/models/glyphs/image.ts
@@ -159,7 +159,7 @@ export class Image extends XYGlyph {
       dw:           [ p.DistanceSpec     ],
       dh:           [ p.DistanceSpec     ],
       dilate:       [ p.Bool,      false ],
-      color_mapper: [ p.Instance,  () => new LinearColorMapper({palette: Greys9()}) ],
+      color_mapper: [ p.Instance,  () => new LinearColorMapper({palette: Greys9(), alpha: 1.0}) ],
     });
   }
 }

--- a/bokehjs/src/coffee/models/mappers/linear_color_mapper.ts
+++ b/bokehjs/src/coffee/models/mappers/linear_color_mapper.ts
@@ -38,9 +38,9 @@ export class LinearColorMapper extends ColorMapper {
 
   initialize(): void {
     super.initialize();
-    this._nan_color = this._build_palette([color2hex(this.nan_color)])[0];
-    this._high_color = (this.high_color != null) ? this._build_palette([color2hex(this.high_color)])[0] : undefined;
-    this._low_color = (this.low_color != null) ? this._build_palette([color2hex(this.low_color)])[0] : undefined;
+    this._nan_color = this._build_palette([color2hex(this.nan_color)], this.alpha)[0];
+    this._high_color = (this.high_color != null) ? this._build_palette([color2hex(this.high_color)], this.alpha)[0] : undefined;
+    this._low_color = (this.low_color != null) ? this._build_palette([color2hex(this.low_color)], this.alpha)[0] : undefined;
   }
 
   _get_values(data: number[], palette: number[], image_glyph: boolean = false): number[] {

--- a/bokehjs/src/coffee/models/mappers/log_color_mapper.ts
+++ b/bokehjs/src/coffee/models/mappers/log_color_mapper.ts
@@ -42,9 +42,9 @@ export class LogColorMapper extends ColorMapper {
 
   initialize(): void {
     super.initialize();
-    this._nan_color = this._build_palette([color2hex(this.nan_color)])[0];
-    this._high_color = (this.high_color != null) ? this._build_palette([color2hex(this.high_color)])[0] : undefined;
-    this._low_color = (this.low_color != null) ? this._build_palette([color2hex(this.low_color)])[0] : undefined;
+    this._nan_color = this._build_palette([color2hex(this.nan_color)], this.alpha)[0];
+    this._high_color = (this.high_color != null) ? this._build_palette([color2hex(this.high_color)], this.alpha)[0] : undefined;
+    this._low_color = (this.low_color != null) ? this._build_palette([color2hex(this.low_color)], this.alpha)[0] : undefined;
   }
 
   _get_values(data: number[], palette: number[], image_glyph: boolean = false): number[] {

--- a/examples/plotting/file/image_alpha.py
+++ b/examples/plotting/file/image_alpha.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+from bokeh.plotting import figure, show, output_file
+
+N = 500
+x = np.linspace(0, 10, N)
+y = np.linspace(0, 10, N)
+xx, yy = np.meshgrid(x, y)
+d = np.sin(xx)*np.cos(yy)
+d[:125, :125] = np.nan  # Set bottom left quadrant to NaNs
+
+p = figure(x_range=(0, 10), y_range=(0, 10))
+
+# Solid line to show effect of alpha
+p.line([0, 10], [0, 10], color='red', line_width=2)
+# Use global_alpha kwarg to set alpha value
+img = p.image(image=[d], x=0, y=0, dw=10, dh=10, global_alpha=0.7)
+# NaN color alpha can be set separately
+img.glyph.color_mapper.nan_color = (128, 128, 128, 0.1)
+
+output_file("image_alpha.html", title="image_alpha.py example")
+
+show(p)  # open a browser


### PR DESCRIPTION
New ColorMapper attribute 'alpha', can be assigned directly or via 'global_alpha' Image kwarg.
Example provided in image_alpha.py.

- [x] issues: fixes #7474
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
