### PR TITLE
Add support for JupyterLab comms

### DIFF
--- a/bokehjs/src/coffee/embed.ts
+++ b/bokehjs/src/coffee/embed.ts
@@ -119,9 +119,7 @@ function _init_comms(target: string, doc: Document): void {
       logger.warn(`Jupyter comms failed to register. push_notebook() will not function. (exception reported: ${e})`)
     }
   } else {
-    console.warn('Jupyter notebooks comms not available. push_notebook() will not function.'
-                 'If running JupyterLab ensure the latest jupyterlab_bokeh extension is installed.'
-				 'In an exported notebook this warning is expected.');
+    console.warn(`Jupyter notebooks comms not available. push_notebook() will not function. If running JupyterLab ensure the latest jupyterlab_bokeh extension is installed. In an exported notebook this warning is expected.`);
   }
 }
 

--- a/bokehjs/src/coffee/embed.ts
+++ b/bokehjs/src/coffee/embed.ts
@@ -56,9 +56,6 @@ declare var Jupyter: Jupyter | undefined
 
 export const kernels: {[key: string]: Kernel} = {}
 
-// Exported to allow external libraries to define custom message handlers
-export {Receiver}
-
 // Matches Bokeh CSS class selector. Setting all Bokeh parent element class names
 // with this var prevents user configurations where css styling is unset.
 export const BOKEH_ROOT = "bk-root"

--- a/bokehjs/src/coffee/embed.ts
+++ b/bokehjs/src/coffee/embed.ts
@@ -119,7 +119,9 @@ function _init_comms(target: string, doc: Document): void {
       logger.warn(`Jupyter comms failed to register. push_notebook() will not function. (exception reported: ${e})`)
     }
   } else {
-    console.warn('Jupyter notebooks comms not available. push_notebook() will not function');
+    console.warn('Jupyter notebooks comms not available. push_notebook() will not function.'
+                 'If running JupyterLab ensure the latest jupyterlab_bokeh extension is installed.'
+				 'In an exported notebook this warning is expected.');
   }
 }
 

--- a/bokehjs/src/coffee/embed.ts
+++ b/bokehjs/src/coffee/embed.ts
@@ -23,33 +23,38 @@ export interface RenderItem {
   notebook_comms_target?: any
 }
 
-declare interface CommMessage {
+export declare interface CommMessage {
   buffers: DataView[],
   content: {
     data: string
   }
 }
 
-declare interface Comm {
+export declare interface Comm {
   target_name: string
   on_msg: (msg: CommMessage) => void
   onMsg: (this: Document, receiver: Receiver, comm_msg: CommMessage) => void
 }
 
+export declare interface Kernel {
+  comm_manager: {
+    comms: {[key: string]: Promise<Comm>},
+    register_target: (target: string, fn: (comm: Comm) => void) => void,
+  },
+  _comms: {[key: string]: Promise<Comm>},
+  registerCommTarget: (target: string, fn: (comm: Comm) => void) => void,
+}
+
 declare interface Jupyter {
   notebook: {
-    kernel: undefined | {
-      comm_manager: {
-        comms: {[key: string]: Promise<Comm>},
-        register_target: (target: string, fn: (comm: Comm) => void) => void,
-      }
-    }
+    kernel: Kernel | undefined
   }
 }
 
+
 declare var Jupyter: Jupyter | undefined
 
-export const kernels: {[key: string]: any} = {}
+export const kernels: {[key: string]: Kernel} = {}
 
 // Exported to allow external libraries to define custom message handlers
 export {Receiver}

--- a/bokehjs/src/coffee/main.ts
+++ b/bokehjs/src/coffee/main.ts
@@ -5,6 +5,9 @@ export {version} from "./version"
 import * as embed from "./embed"
 export {embed}
 
+import * as protocol from "./protocol"
+export {protocol}
+
 export {logger, set_log_level} from "./core/logging"
 export {settings}              from "./core/settings"
 export {Models, index}         from "./base"

--- a/bokehjs/src/coffee/protocol/index.ts
+++ b/bokehjs/src/coffee/protocol/index.ts
@@ -1,0 +1,2 @@
+export * from "./message"
+export * from "./receiver"


### PR DESCRIPTION
This PR adds support for using ``push_notebook`` in JupyterLab when combined with https://github.com/bokeh/jupyterlab_bokeh/pull/20. The way it works is that it defines a ``Bokeh.embed.kernels`` registry which the JupyterLab extension registers kernels with on display. This allows the embed functions to register the Jupyter comm to send data from Python to JS.

I'd be happy to hear a different approach, and or make ``Bokeh.embed.kernels`` private to avoid cluttering the namespace. I've also made the ``Bokeh.embed.Receiver`` object public to allow other extensions (e.g. HoloViews) to register their own message handlers on platforms other than Jupyter.

- [x] issues: fixes #7566
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

@canavandl @bryevdv 
