### PR TITLE
Added port parameter to show_app method.  

### DIFF
--- a/bokeh/io/notebook.py
+++ b/bokeh/io/notebook.py
@@ -430,7 +430,7 @@ def publish_display_data(*args, **kw):
     return publish_display_data(*args, **kw)
 
 @dev((1,0,0))
-def show_app(app, state, notebook_url):
+def show_app(app, state, notebook_url, port=0):
     ''' Embed a Bokeh serer application in a Jupyter Notebook output cell.
 
     Args:
@@ -439,6 +439,9 @@ def show_app(app, state, notebook_url):
         state (State) :
 
         notebook_url (str) :
+
+        port (int) : the port the embedded server will listen on. By default
+        the port is 0, which results in the server listening on a random dynamic port.
 
     Returns:
         None
@@ -452,7 +455,7 @@ def show_app(app, state, notebook_url):
     loop = IOLoop.current()
 
     origin = _origin_url(notebook_url)
-    server = Server({"/": app}, io_loop=loop, port=0,  allow_websocket_origin=[origin])
+    server = Server({"/": app}, io_loop=loop, port=port,  allow_websocket_origin=[origin])
 
     server_id = uuid4().hex
     curstate().uuid_to_server[server_id] = server


### PR DESCRIPTION
Added port parameter to show_app method.  This allows the user the override the default behavior of embedded servers listening on random ports.  This is necessary to allow users to use embedded servers remotely when firewalls may restrict available ports.

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [ ] issues: fixes #7466
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
