### PR TITLE
Bryanv/7518 ajax data source endpoint undefined

### DIFF
--- a/bokehjs/src/coffee/models/sources/ajax_data_source.ts
+++ b/bokehjs/src/coffee/models/sources/ajax_data_source.ts
@@ -49,8 +49,10 @@ export class AjaxDataSource extends RemoteDataSource {
       this.initialized = true
       this.get_data(this.mode)
       if (this.polling_interval) {
-        this.interval = setInterval(this.get_data, this.polling_interval,
-                                    this.mode, this.max_size, this.if_modified)
+        this.interval = setInterval(
+          () => this.get_data(this.mode, this.max_size, this.if_modified),
+          this.polling_interval
+        )
       }
     }
   }

--- a/bokehjs/src/coffee/models/sources/ajax_data_source.ts
+++ b/bokehjs/src/coffee/models/sources/ajax_data_source.ts
@@ -58,6 +58,16 @@ export class AjaxDataSource extends RemoteDataSource {
   }
 
   get_data(mode: UpdateMode, max_size: number = 0, _if_modified: boolean = false): void {
+    const xhr = this.prepare_request()
+
+    // TODO: if_modified
+    xhr.addEventListener("load", () => this.do_load(xhr, mode, max_size))
+    xhr.addEventListener("error", () => this.do_error(xhr))
+
+    xhr.send()
+  }
+
+  prepare_request() : XMLHttpRequest {
     const xhr = new XMLHttpRequest()
     xhr.open(this.method, this.data_url, true)
     xhr.withCredentials = false
@@ -69,30 +79,32 @@ export class AjaxDataSource extends RemoteDataSource {
       xhr.setRequestHeader(name, value)
     }
 
-    // TODO: if_modified
-    xhr.addEventListener("load", () => {
-      if (xhr.status === 200) {
-        const data = JSON.parse(xhr.responseText)
-        switch (mode) {
-          case "replace": {
-            this.data = data
-            break
+    return xhr
+  }
+
+  do_load(xhr: XMLHttpRequest, mode: UpdateMode, max_size: number) : void {
+    if (xhr.status === 200) {
+      const data = JSON.parse(xhr.responseText)
+      switch (mode) {
+        case "replace": {
+          this.data = data
+          break
+        }
+        case "append": {
+          const original_data = this.data
+          for (const column of this.columns()) {
+            data[column] = original_data[column].concat(data[column]).slice(-max_size)
           }
-          case "append": {
-            const original_data = this.data
-            for (const column of this.columns()) {
-              data[column] = original_data[column].concat(data[column]).slice(-max_size)
-            }
-            this.data = data
-            break
-          }
+          this.data = data
+          break
         }
       }
-    })
-    xhr.addEventListener("error", () => {
-      logger.error(`Failed to fetch JSON from ${this.data_url} with code ${xhr.status}`)
-    })
-    xhr.send()
+    }
   }
+
+  do_error(xhr: XMLHttpRequest) : void {
+    logger.error(`Failed to fetch JSON from ${this.data_url} with code ${xhr.status}`)
+  }
+
 }
 AjaxDataSource.initClass()

--- a/bokehjs/test/models/sources/ajax_data_source.coffee
+++ b/bokehjs/test/models/sources/ajax_data_source.coffee
@@ -1,0 +1,87 @@
+{expect} = require "chai"
+utils = require "../../utils"
+
+sinon = require 'sinon'
+
+{AjaxDataSource} = utils.require("models/sources/ajax_data_source")
+
+describe "ajax_data_source module", ->
+
+  describe "AjaxDataSource", ->
+
+    beforeEach ->
+      global.XMLHttpRequest = sinon.useFakeXMLHttpRequest();
+      requests = this.requests = [];
+
+      global.XMLHttpRequest.onCreate = (xhr) ->
+        requests.push(xhr)
+
+    afterEach ->
+      global.XMLHttpRequest.restore()
+
+    describe "do_load method", ->
+
+      it "should replace", ->
+        s = new AjaxDataSource({data_url: "http://foo.com"})
+        expect(s.data).to.be.deep.equal {}
+
+        xhr = s.prepare_request()
+        xhr.respond(200, {}, '{"foo": [10, 20], "bar": [1, 2]}')
+        s.do_load(xhr, "replace", 10)
+        expect(s.data).to.be.deep.equal {"foo": [10, 20], "bar": [1, 2]}
+
+        xhr = s.prepare_request()
+        xhr.respond(200, {}, '{"foo": [100, 200], "bar": [1.1, 2.2]}')
+        s.do_load(xhr, "replace", 10)
+        expect(s.data).to.be.deep.equal {"foo": [100, 200], "bar": [1.1, 2.2]}
+
+        # max size ignored when replacing
+        xhr = s.prepare_request()
+        xhr.respond(200, {}, '{"foo": [1000, 2000], "bar": [10.1, 20.2]}')
+        s.do_load(xhr, "replace", 1)
+        expect(s.data).to.be.deep.equal {"foo": [1000, 2000], "bar": [10.1, 20.2]}
+
+      it "should append up to max_size", ->
+        s = new AjaxDataSource({data_url: "http://foo.com"})
+        expect(s.data).to.be.deep.equal {}
+
+        xhr = s.prepare_request()
+        xhr.respond(200, {}, '{"foo": [10, 20], "bar": [1, 2]}')
+        s.do_load(xhr, "append", 3)
+        expect(s.data).to.be.deep.equal {"foo": [10, 20], "bar": [1, 2]}
+
+        xhr = s.prepare_request()
+        xhr.respond(200, {}, '{"foo": [100, 200], "bar": [1.1, 2.2]}')
+        s.do_load(xhr, "append", 3)
+        expect(s.data).to.be.deep.equal {"foo": [20, 100, 200], "bar": [2, 1.1, 2.2]}
+
+    describe "prepare_request method", ->
+
+      it "should return an xhr with withCredentials = False", ->
+        s = new AjaxDataSource({data_url: "http://foo.com"})
+        xhr = s.prepare_request()
+        expect(xhr).to.be.instanceof XMLHttpRequest
+        expect(xhr.withCredentials).to.be.false
+
+      it "should return an xhr with method set from this.method", ->
+        s = new AjaxDataSource({data_url: "http://foo.com"})
+        xhr = s.prepare_request()
+        expect(xhr.method).to.be.equal 'POST'
+
+        s = new AjaxDataSource({data_url: "http://foo.com", method: "POST"})
+        xhr = s.prepare_request()
+        expect(xhr.method).to.be.equal 'POST'
+
+        s = new AjaxDataSource({data_url: "http://foo.com", method: "GET"})
+        xhr = s.prepare_request()
+        expect(xhr.method).to.be.equal 'GET'
+
+      it "should return an xhr with Content-Type header set to json", ->
+        s = new AjaxDataSource({data_url: "http://foo.com"})
+        xhr = s.prepare_request()
+        expect(xhr.requestHeaders).to.be.deep.equal {"Content-Type": "application/json"}
+
+      it "should return an xhr with additional headers set from this.http_headers", ->
+        s = new AjaxDataSource({data_url: "http://foo.com", http_headers: {foo: "bar", baz: 10}})
+        xhr = s.prepare_request()
+        expect(xhr.requestHeaders).to.be.deep.equal {"Content-Type": "application/json", foo: "bar", baz: 10}

--- a/bokehjs/test/models/sources/index.coffee
+++ b/bokehjs/test/models/sources/index.coffee
@@ -1,3 +1,4 @@
+require "./ajax_data_source"
 require "./cds_view"
 require "./column_data_source"
 require "./geojson_data_source"


### PR DESCRIPTION
- [x] issues: fixes #7518 fixes #3723
- [x] tests added / passed

This PR fixes the regression introduced in the TypeScript conversion, and also factors `AjaxDataSource` into more testable chunks