### PR TITLE
FuncTickFormatter: expose `index` and `ticks`

### DIFF
--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -326,12 +326,22 @@ class FuncTickFormatter(TickFormatter):
     format. The variable ``tick`` will contain the unformatted tick value and
     can be expected to be present in the code snippet namespace at render time.
 
+    Additionally available variables are:
+
+      * ``ticks``, an array of all axis ticks as positioned by the ticker,
+      * ``index``, the position of ``tick`` within ``ticks``, and
+      * the keys of ``args`` mapping, if any.
+
+    Finding yourself needing to cache an expensive ``ticks``-dependent
+    computation, you can store it on the ``this`` variable.
+
     Example:
 
         .. code-block:: javascript
 
             code = '''
-            return Math.floor(tick) + " + " + (tick % 1).toFixed(2)
+            this.precision = this.precision || (ticks.length > 5 ? 1 : 2);
+            return Math.floor(tick) + " + " + (tick % 1).toFixed(this.precision);
             '''
     """)
 

--- a/bokehjs/src/coffee/models/formatters/func_tick_formatter.ts
+++ b/bokehjs/src/coffee/models/formatters/func_tick_formatter.ts
@@ -30,12 +30,13 @@ export class FuncTickFormatter extends TickFormatter {
   }
 
   _make_func() {
-    return new Function("tick", ...Object.keys(this.args), "require", this.code);
+    return new Function("tick", "index", "ticks", ...Object.keys(this.args), "require", this.code);
   }
 
   doFormat(ticks, _axis) {
-    const func = this._make_func();
-    return (ticks.map((tick) => func(tick, ...values(this.args), require)));
+    const cache = {};
+    const func = this._make_func().bind(cache);
+    return ticks.map((tick, index, ticks) => func(tick, index, ticks, ...values(this.args), require));
   }
 }
 FuncTickFormatter.initClass();

--- a/bokehjs/test/models/formatters/func_tick_formatter.coffee
+++ b/bokehjs/test/models/formatters/func_tick_formatter.coffee
@@ -12,13 +12,13 @@ describe "func_tick_formatter module", ->
       expect(formatter._make_func()).to.be.an.instanceof(Function)
 
     it "should have code property as function body", ->
-      func = new Function("tick", "require", "return 10")
+      func = new Function("tick", "index", "ticks", "require", "return 10")
       expect(formatter._make_func().toString()).to.be.equal(func.toString())
 
     it "should have values as function args", ->
       rng = new Range1d()
       formatter.args = {foo: rng.ref()}
-      func = new Function("tick", "foo", "require", "return 10")
+      func = new Function("tick", "index", "ticks", "foo", "require", "return 10")
       expect(formatter._make_func().toString()).to.be.equal(func.toString())
 
   describe "doFormat method", ->
@@ -47,3 +47,12 @@ describe "func_tick_formatter module", ->
       })
       labels = formatter.doFormat([-10, -0.1, 0, 0.1, 10])
       expect(labels).to.deep.equal([5, 14.9, 15, 15.1, 25])
+
+    it "should handle array of ticks", ->
+      formatter = new FuncTickFormatter({
+        code: "this.k = this.k || (ticks.length > 3 ? 10 : 100); return tick * this.k"
+      })
+      labels = formatter.doFormat([-10, -0.1, 0, 0.1, 10])
+      expect(labels).to.deep.equal([-100, -1.0, 0, 1, 100])
+      labels = formatter.doFormat([-0.1, 0, 0.1])
+      expect(labels).to.deep.equal([-10, 0, 10])


### PR DESCRIPTION
Alternative to https://github.com/bokeh/bokeh/pull/7564.

- [x] issues: fixes https://github.com/bokeh/bokeh/issues/7563
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
