### PR TITLE
Switched from RBush to FlatBush

### DIFF
--- a/bokehjs/package-lock.json
+++ b/bokehjs/package-lock.json
@@ -2288,9 +2288,9 @@
       "dev": true
     },
     "flatbush": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/flatbush/-/flatbush-1.1.2.tgz",
-      "integrity": "sha512-WDUArrcq93+k+uc6i7kAMB6/vAHWwSQVWMnBWg/3mKLsgQMKOhUVO8LIpJ80ewgjOJWzSsCKvAbxR3/U2YdoiA=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/flatbush/-/flatbush-2.0.4.tgz",
+      "integrity": "sha512-4ve0+LFFrQ0Bs+wnU2W4pKU/kFG7Tfz1VeulbbjeaQwvJUzzqqbSiQPYLtQjghqn+IMxQN6U9LWlAP4hVCO1Sg=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/bokehjs/package-lock.json
+++ b/bokehjs/package-lock.json
@@ -2292,6 +2292,11 @@
       "integrity": "sha1-/xke3c1wiKZ1smEP/8l2vpuAdLU=",
       "dev": true
     },
+    "flatbush": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/flatbush/-/flatbush-1.1.2.tgz",
+      "integrity": "sha512-WDUArrcq93+k+uc6i7kAMB6/vAHWwSQVWMnBWg/3mKLsgQMKOhUVO8LIpJ80ewgjOJWzSsCKvAbxR3/U2YdoiA=="
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",

--- a/bokehjs/package-lock.json
+++ b/bokehjs/package-lock.json
@@ -241,11 +241,6 @@
       "integrity": "sha512-LSx7jkcXoXWB+kkfwG5zc9Okbgn51BrjLMtKwbmnqfQlCGttTnTxvDVwQanHxkK6CLKb9yEfxQ1ID6pqDpeURw==",
       "dev": true
     },
-    "@types/rbush": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rbush/-/rbush-2.0.2.tgz",
-      "integrity": "sha1-0pdWRoBJGXOrncXsOv10cEh/Uwo="
-    },
     "@types/run-sequence": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/run-sequence/-/run-sequence-0.0.29.tgz",
@@ -6408,11 +6403,6 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
-    "quickselect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.0.0.tgz",
-      "integrity": "sha1-AmMIGPmq5OyrJvAQP5jQYcF8WPM="
-    },
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
@@ -6471,14 +6461,6 @@
       "requires": {
         "randombytes": "2.0.5",
         "safe-buffer": "5.1.1"
-      }
-    },
-    "rbush": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.1.tgz",
-      "integrity": "sha1-TPrKKMMGS8DudUMaG3mZDode76k=",
-      "requires": {
-        "quickselect": "1.0.0"
       }
     },
     "read-only-stream": {

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -95,7 +95,7 @@
     "es6-set": "^0.1.5",
     "es6-promise": "3.0.2",
     "@types/es6-promise": "^0.0.33",
-    "flatbush": "^1.1.2",
+    "flatbush": "^2.0.4",
     "proj4": "<2.4",
     "@types/proj4": "^2.3.2",
     "sprintf-js": "^1.1.1",

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -95,8 +95,6 @@
     "es6-set": "^0.1.5",
     "es6-promise": "3.0.2",
     "@types/es6-promise": "^0.0.33",
-    "rbush": "^2.0.1",
-    "@types/rbush": "^2.0.2",
     "flatbush": "^1.1.2",
     "proj4": "<2.4",
     "@types/proj4": "^2.3.2",

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -97,6 +97,7 @@
     "@types/es6-promise": "^0.0.33",
     "rbush": "^2.0.1",
     "@types/rbush": "^2.0.2",
+    "flatbush": "^1.1.2",
     "proj4": "<2.4",
     "@types/proj4": "^2.3.2",
     "sprintf-js": "^1.1.1",

--- a/bokehjs/src/coffee/api/typings.d.ts
+++ b/bokehjs/src/coffee/api/typings.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="@types/rbush" />
 /// <reference types="@types/proj4" />
 /// <reference types="@types/sprintf-js" />
 /// <reference types="@types/hammerjs" />

--- a/bokehjs/src/coffee/core/hittest.ts
+++ b/bokehjs/src/coffee/core/hittest.ts
@@ -35,7 +35,7 @@ export function create_hit_test_result_from_hits(hits: [number, number][]): Sele
 }
 
 export function validate_bbox_coords([x0, x1]: [number, number], [y0, y1]: [number, number]): Rect {
-  // rbush expects x0, y0 to be min, x1, y1 max
+  // spatial index (flatbush) expects x0, y0 to be min, x1, y1 max
   if (x0 > x1) [x0, x1] = [x1, x0]
   if (y0 > y1) [y0, y1] = [y1, y0]
   return {minX: x0, minY: y0, maxX: x1, maxY: y1}

--- a/bokehjs/src/coffee/core/util/spatial.ts
+++ b/bokehjs/src/coffee/core/util/spatial.ts
@@ -1,4 +1,5 @@
-import * as rbush from "rbush"
+/// <reference types="@types/rbush" />
+import * as flatbush from "flatbush"
 
 export type Rect = {minX: number, minY: number, maxX: number, maxY: number}
 export type IndexedRect = Rect & {i: number}
@@ -10,30 +11,38 @@ export abstract class SpatialIndex {
 }
 
 export class RBush extends SpatialIndex {
-  private readonly index: rbush.RBush<IndexedRect>
+  private readonly index: any
 
   constructor(points: IndexedRect[]) {
     super()
-    this.index = rbush<IndexedRect>()
-    this.index.load(points)
+    this.index = flatbush(points.length);
+
+    for (const p of points) {
+      this.index.add(p.minX, p.minY, p.maxX, p.maxY);
+    }
+    this.index.finish();
   }
 
   get bbox(): Rect {
-    const {minX, minY, maxX, maxY} = this.index.toJSON()
-    return {minX, minY, maxX, maxY}
+    return {
+      minX: this.index._minX,
+      minY: this.index._minY,
+      maxX: this.index._maxX,
+      maxY: this.index._maxY
+    }
   }
 
-  search(rect: Rect): IndexedRect[] {
-    return this.index.search(rect)
+  search(rect: Rect): (Rect & {i: number})[] {
+    const indices = this.indices(rect);
+    const rects = new Array<(Rect & {i: number})>();
+    for (const i of indices) {
+      const data = this.index.data.slice(i*5, i*5+5);
+      rects.push({minX: data[1], minY: data[2], maxX: data[3], maxY: data[4], i});
+    }
+    return rects;
   }
 
   indices(rect: Rect): number[] {
-    const points = this.search(rect)
-    const n = points.length
-    const indices: number[] = new Array(n)
-    for (let j = 0; j < n; j++) {
-      indices[j] = points[j].i
-    }
-    return indices
+    return this.index.search(rect.minX, rect.minY, rect.maxX, rect.maxY);
   }
 }

--- a/bokehjs/src/coffee/core/util/spatial.ts
+++ b/bokehjs/src/coffee/core/util/spatial.ts
@@ -1,50 +1,45 @@
-import flatbush = require("flatbush")
+import FlatBush = require("flatbush")
+import {empty} from "./bbox"
 
 export type Rect = {minX: number, minY: number, maxX: number, maxY: number}
 export type IndexedRect = Rect & {i: number}
 
 export class SpatialIndex {
-  private readonly index = flatbush(this.points.length)
+  private readonly index: FlatBush | null = null
 
   constructor(private readonly points: IndexedRect[]) {
-    for (const p of points) {
-      const {minX, minY, maxX, maxY} = p
-      this.index.add(minX, minY, maxX, maxY)
+    if (points.length > 0) {
+      this.index = new FlatBush(points.length)
+
+      for (const p of points) {
+        const {minX, minY, maxX, maxY} = p
+        this.index.add(minX, minY, maxX, maxY)
+      }
+
+      this.index.finish()
     }
-    this.index.finish()
   }
 
   get bbox(): Rect {
-    return {
-      minX: this.index._minX,
-      minY: this.index._minY,
-      maxX: this.index._maxX,
-      maxY: this.index._maxY,
+    if (this.index == null)
+      return empty()
+    else {
+      const {minX, minY, maxX, maxY} = this.index
+      return {minX, minY, maxX, maxY}
     }
   }
 
   search(rect: Rect): IndexedRect[] {
-    const indices = this.indices(rect)
-    const {data} = this.index
-    const rects = []
-    for (const i of indices) {
-      const j = i*5
-      const minX = data[j+1]
-      const minY = data[j+2]
-      const maxX = data[j+3]
-      const maxY = data[j+4]
-      rects.push({minX, minY, maxX, maxY, i})
+    if (this.index == null)
+      return []
+    else {
+      const {minX, minY, maxX, maxY} = rect
+      const indices = this.index.search(minX, minY, maxX, maxY)
+      return indices.map((j) => this.points[j])
     }
-    return rects
   }
 
   indices(rect: Rect): number[] {
-    const points = this.search(rect)
-    const n = points.length
-    const indices: number[] = new Array(n)
-    for (let j = 0; j < n; j++) {
-      indices[j] = points[j].i
-    }
-    return indices
+    return this.search(rect).map(({i}) => i)
   }
 }

--- a/bokehjs/src/coffee/core/util/spatial.ts
+++ b/bokehjs/src/coffee/core/util/spatial.ts
@@ -1,26 +1,17 @@
-/// <reference types="@types/rbush" />
-import * as flatbush from "flatbush"
+import flatbush = require("flatbush")
 
 export type Rect = {minX: number, minY: number, maxX: number, maxY: number}
 export type IndexedRect = Rect & {i: number}
 
-export abstract class SpatialIndex {
-  abstract indices(rect: Rect): number[]
-  abstract search(rect: Rect): IndexedRect[]
-  readonly bbox: Rect
-}
+export class SpatialIndex {
+  private readonly index = flatbush(this.points.length)
 
-export class RBush extends SpatialIndex {
-  private readonly index: any
-
-  constructor(points: IndexedRect[]) {
-    super()
-    this.index = flatbush(points.length);
-
+  constructor(private readonly points: IndexedRect[]) {
     for (const p of points) {
-      this.index.add(p.minX, p.minY, p.maxX, p.maxY);
+      const {minX, minY, maxX, maxY} = p
+      this.index.add(minX, minY, maxX, maxY)
     }
-    this.index.finish();
+    this.index.finish()
   }
 
   get bbox(): Rect {
@@ -28,21 +19,32 @@ export class RBush extends SpatialIndex {
       minX: this.index._minX,
       minY: this.index._minY,
       maxX: this.index._maxX,
-      maxY: this.index._maxY
+      maxY: this.index._maxY,
     }
   }
 
-  search(rect: Rect): (Rect & {i: number})[] {
-    const indices = this.indices(rect);
-    const rects = new Array<(Rect & {i: number})>();
+  search(rect: Rect): IndexedRect[] {
+    const indices = this.indices(rect)
+    const {data} = this.index
+    const rects = []
     for (const i of indices) {
-      const data = this.index.data.slice(i*5, i*5+5);
-      rects.push({minX: data[1], minY: data[2], maxX: data[3], maxY: data[4], i});
+      const j = i*5
+      const minX = data[j+1]
+      const minY = data[j+2]
+      const maxX = data[j+3]
+      const maxY = data[j+4]
+      rects.push({minX, minY, maxX, maxY, i})
     }
-    return rects;
+    return rects
   }
 
   indices(rect: Rect): number[] {
-    return this.index.search(rect.minX, rect.minY, rect.maxX, rect.maxY);
+    const points = this.search(rect)
+    const n = points.length
+    const indices: number[] = new Array(n)
+    for (let j = 0; j < n; j++) {
+      indices[j] = points[j].i
+    }
+    return indices
   }
 }

--- a/bokehjs/src/coffee/external/flatbush.d.ts
+++ b/bokehjs/src/coffee/external/flatbush.d.ts
@@ -1,0 +1,20 @@
+declare module "flatbush" {
+
+  class FlatBush {
+    constructor(numItems: number)
+
+    add(minX: number, minY: number, maxX: number, maxY: number): void
+    finish(): void
+
+    data: Float64Array
+
+    _minX: number
+    _minY: number
+    _maxX: number
+    _maxY: number
+  }
+
+  function flatbush(numItems: number): FlatBush
+
+  export = flatbush
+}

--- a/bokehjs/src/coffee/external/flatbush.d.ts
+++ b/bokehjs/src/coffee/external/flatbush.d.ts
@@ -4,17 +4,14 @@ declare module "flatbush" {
     constructor(numItems: number)
 
     add(minX: number, minY: number, maxX: number, maxY: number): void
+    search(minX: number, minY: number, maxX: number, maxY: number, filterFn?: (i: number) => boolean): number[]
     finish(): void
 
-    data: Float64Array
-
-    _minX: number
-    _minY: number
-    _maxX: number
-    _maxY: number
+    minX: number
+    minY: number
+    maxX: number
+    maxY: number
   }
 
-  function flatbush(numItems: number): FlatBush
-
-  export = flatbush
+  export = FlatBush
 }

--- a/bokehjs/src/coffee/models/glyphs/bezier.ts
+++ b/bokehjs/src/coffee/models/glyphs/bezier.ts
@@ -3,7 +3,7 @@ import {LineMixinVector} from "core/property_mixins"
 import {Line} from "core/visuals"
 import {Arrayable} from "core/types"
 import {IBBox} from "core/util/bbox"
-import {SpatialIndex, RBush} from "core/util/spatial"
+import {SpatialIndex} from "core/util/spatial"
 import {Context2d} from "core/util/canvas"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
 import {generic_line_legend} from "./utils"
@@ -113,7 +113,7 @@ export class BezierView extends GlyphView {
       points.push({minX: x0, minY: y0, maxX: x1, maxY: y1, i})
     }
 
-    return new RBush(points)
+    return new SpatialIndex(points)
   }
 
   protected _render(ctx: Context2d, indices: number[],

--- a/bokehjs/src/coffee/models/glyphs/box.ts
+++ b/bokehjs/src/coffee/models/glyphs/box.ts
@@ -2,7 +2,7 @@ import {LineMixinVector, FillMixinVector} from "core/property_mixins"
 import {Arrayable} from "core/types"
 import {Line, Fill} from "core/visuals"
 import {IBBox} from "core/util/bbox"
-import {SpatialIndex, RBush} from "core/util/spatial"
+import {SpatialIndex} from "core/util/spatial"
 import {Context2d} from "core/util/canvas"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
 import {generic_area_legend} from "./utils"
@@ -40,7 +40,7 @@ export abstract class BoxView extends GlyphView {
       points.push({minX: l, minY: b, maxX: r, maxY: t, i})
     }
 
-    return new RBush(points)
+    return new SpatialIndex(points)
   }
 
   protected _render(ctx: Context2d, indices: number[],

--- a/bokehjs/src/coffee/models/glyphs/image_url.ts
+++ b/bokehjs/src/coffee/models/glyphs/image_url.ts
@@ -6,7 +6,7 @@ import {logger} from "core/logging"
 import * as p from "core/properties"
 import {map} from "core/util/arrayable"
 import {Context2d} from "core/util/canvas"
-import {SpatialIndex, RBush} from "core/util/spatial"
+import {SpatialIndex} from "core/util/spatial"
 
 export type CanvasImage = HTMLImageElement
 export const CanvasImage = Image
@@ -43,7 +43,7 @@ export class ImageURLView extends XYGlyphView {
   }
 
   protected _index_data(): SpatialIndex {
-    return new RBush([])
+    return new SpatialIndex([])
   }
 
   protected _set_data(): void {

--- a/bokehjs/src/coffee/models/glyphs/multi_line.ts
+++ b/bokehjs/src/coffee/models/glyphs/multi_line.ts
@@ -1,5 +1,5 @@
 import {IBBox} from "core/util/bbox"
-import {SpatialIndex, RBush} from "core/util/spatial"
+import {SpatialIndex} from "core/util/spatial"
 import {PointGeometry, SpanGeometry} from "core/geometry"
 import {NumberSpec} from "core/vectorization"
 import {LineMixinVector} from "core/property_mixins"
@@ -56,7 +56,7 @@ export class MultiLineView extends GlyphView {
       points.push({minX, minY, maxX, maxY, i})
     }
 
-    return new RBush(points)
+    return new SpatialIndex(points)
   }
 
   protected _render(ctx: Context2d, indices: number[], {sxs, sys}: MultiLineData): void {

--- a/bokehjs/src/coffee/models/glyphs/patches.ts
+++ b/bokehjs/src/coffee/models/glyphs/patches.ts
@@ -1,5 +1,5 @@
 import {IBBox} from "core/util/bbox"
-import {SpatialIndex, RBush} from "core/util/spatial"
+import {SpatialIndex} from "core/util/spatial"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
 import {generic_area_legend} from "./utils"
 import {min, max, copy, findLastIndex} from "core/util/array"
@@ -94,7 +94,7 @@ export class PatchesView extends GlyphView {
       }
     }
 
-    return new RBush(points)
+    return new SpatialIndex(points)
   }
 
   protected _mask_data(): number[] {

--- a/bokehjs/src/coffee/models/glyphs/quadratic.ts
+++ b/bokehjs/src/coffee/models/glyphs/quadratic.ts
@@ -3,7 +3,7 @@ import {LineMixinVector} from "core/property_mixins"
 import {Line} from "core/visuals"
 import {Arrayable} from "core/types"
 import {IBBox} from "core/util/bbox"
-import {SpatialIndex, RBush} from "core/util/spatial"
+import {SpatialIndex} from "core/util/spatial"
 import {Context2d} from "core/util/canvas"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
 import {generic_line_legend} from "./utils"
@@ -63,7 +63,7 @@ export class QuadraticView extends GlyphView {
       points.push({minX: x0, minY: y0, maxX: x1, maxY: y1, i})
     }
 
-    return new RBush(points)
+    return new SpatialIndex(points)
   }
 
   protected _render(ctx: Context2d, indices: number[], {sx0, sy0, sx1, sy1, scx, scy}: QuadraticData): void {

--- a/bokehjs/src/coffee/models/glyphs/segment.ts
+++ b/bokehjs/src/coffee/models/glyphs/segment.ts
@@ -5,7 +5,7 @@ import {LineMixinVector} from "core/property_mixins"
 import {Line} from "core/visuals"
 import {Arrayable} from "core/types"
 import {IBBox} from "core/util/bbox"
-import {SpatialIndex, RBush} from "core/util/spatial"
+import {SpatialIndex} from "core/util/spatial"
 import {Context2d} from "core/util/canvas"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
 import {generic_line_legend} from "./utils"
@@ -49,7 +49,7 @@ export class SegmentView extends GlyphView {
       }
     }
 
-    return new RBush(points)
+    return new SpatialIndex(points)
   }
 
   protected _render(ctx: Context2d, indices: number[], {sx0, sy0, sx1, sy1}: SegmentData): void {

--- a/bokehjs/src/coffee/models/glyphs/xy_glyph.ts
+++ b/bokehjs/src/coffee/models/glyphs/xy_glyph.ts
@@ -1,6 +1,6 @@
 import {Arrayable} from "core/types"
 import {NumberSpec} from "core/vectorization"
-import {SpatialIndex, IndexedRect, RBush} from "core/util/spatial"
+import {SpatialIndex, IndexedRect} from "core/util/spatial"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
 
 export interface XYGlyphData extends GlyphData {
@@ -30,7 +30,7 @@ export abstract class XYGlyphView extends GlyphView {
       points.push({minX: x, minY: y, maxX: x, maxY: y, i})
     }
 
-    return new RBush(points)
+    return new SpatialIndex(points)
   }
 
   scenterx(i: number): number {

--- a/bokehjs/src/coffee/tsconfig.json
+++ b/bokehjs/src/coffee/tsconfig.json
@@ -17,7 +17,7 @@
     "sourceMap": true,
     "importHelpers": true,
     "experimentalDecorators": true,
-    "types": ["hammerjs", "rbush", "googlemaps"],
+    "types": ["hammerjs", "googlemaps"],
     "baseUrl": "."
   },
   "include": ["./**/*.ts"]


### PR DESCRIPTION
As suggested in https://github.com/bokeh/bokeh/issues/7582, this PR attempts to switch out RBush for flatbush to perform the spatial indexing. As flatbush is very new is no ``@types/flatbush`` package yet, so I haven't typed everything properly yet. Before proceeding with this I'd like to find a principled way to perform some benchmarks. So far I've only seen noticeable improvements for very large number of points. 

- [x] issues: fixes #7582
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
