### PR TITLE
don't repeat base install for external PRs

### DIFF
--- a/scripts/ci/install:test
+++ b/scripts/ci/install:test
@@ -10,9 +10,6 @@ if  [[ ! -z "${TRAVIS_TAG}" ]]; then
     exit 0
 fi
 
-# do the base install
-bash scripts/ci/install
-
 # if this is an external contributor then build assets were not uploaded
 if [[ -z "${SAUCE_USERNAME}" ]]; then
     echo
@@ -21,6 +18,9 @@ if [[ -z "${SAUCE_USERNAME}" ]]; then
     bash "scripts/ci/install:build"
     bash "scripts/ci/build"
 else
+    # do the base install
+    bash scripts/ci/install
+
     pushd ${HOME}
 
     # download the pre-built Bokeh package from the build phase


### PR DESCRIPTION
The previous CI scripts would unconditionally re-install miniconda on top of an previous install, when a PR from an outside fork was made. With the latests miniconda installers this causes conda errors. This PR changes the CI scripts to only perform the base install a single time in all cases. 