### PR TITLE
rev CONDA_REQS and ignore built python files for docker images

### DIFF
--- a/docker-tools/.dockerignore
+++ b/docker-tools/.dockerignore
@@ -1,0 +1,3 @@
+__pycache__
+*.pyc
+*.pyo

--- a/docker-tools/Dockerfile-py2
+++ b/docker-tools/Dockerfile-py2
@@ -4,7 +4,7 @@ ENV PYTHON=2.7
 ENV NO_GIT_FETCH=1
 ENV PATH="/home/travis/miniconda/bin:${PATH}"
 ENV MINICONDA_FILENAME="Miniconda3-latest-Linux-x86_64.sh"
-ENV CONDA_REQS="conda=4.3.21 conda-env=2.6.0 conda-build=2.1.15"
+ENV CONDA_REQS="conda=4.4.11 conda-env=2.6.0 conda-build=3.0.27"
 
 ADD . /tmp/bokeh
 RUN chown -R travis /tmp/bokeh

--- a/docker-tools/Dockerfile-py3
+++ b/docker-tools/Dockerfile-py3
@@ -4,7 +4,7 @@ ENV PYTHON=3.6
 ENV NO_GIT_FETCH=1
 ENV PATH="/home/travis/miniconda/bin:${PATH}"
 ENV MINICONDA_FILENAME="Miniconda3-latest-Linux-x86_64.sh"
-ENV CONDA_REQS="conda=4.3.21 conda-env=2.6.0 conda-build=2.1.15"
+ENV CONDA_REQS="conda=4.4.11 conda-env=2.6.0 conda-build=3.0.27"
 
 ADD . /tmp/bokeh
 RUN chown -R travis /tmp/bokeh


### PR DESCRIPTION
Follow on to updating `CONDA_REQS` on TravisCI, this PR updates docker files to match. Additionally adds a `.dockerignore` so that any local `.pyc` files are not copied to the image (causes issues with `pytest`)