### PR TITLE
Remove opts argument from models' constructors

### DIFF
--- a/bokehjs/src/coffee/core/has_props.ts
+++ b/bokehjs/src/coffee/core/has_props.ts
@@ -19,10 +19,6 @@ export module HasProps {
     id: string
   }
 
-  export interface Opts {
-    defer_initialization?: boolean
-  }
-
   export interface SetOptions {
     check_eq?: boolean
     silent?: boolean
@@ -160,7 +156,7 @@ export abstract class HasProps extends Signalable() {
 
   protected readonly _set_after_defaults: {[key: string]: boolean} = {}
 
-  constructor(attrs: {[key: string]: any} = {}, opts: HasProps.Opts = {}) {
+  constructor(attrs: {[key: string]: any} = {}) {
     super()
 
     for (const name in this.props) {
@@ -175,13 +171,19 @@ export abstract class HasProps extends Signalable() {
     if (attrs.id == null)
       this.setv({id: uniqueId()}, {silent: true})
 
+    const deferred = attrs.__deferred__ || false
+    if (deferred) {
+      attrs = clone(attrs)
+      delete attrs.__deferred__
+    }
+
     this.setv(attrs, {silent: true})
 
     // allowing us to defer initialization when loading many models
     // when loading a bunch of models, we want to do initialization as a second pass
     // because other objects that this one depends on might not be loaded yet
 
-    if (!opts.defer_initialization)
+    if (!deferred)
       this.finalize()
   }
 

--- a/bokehjs/src/coffee/core/layout/layout_canvas.ts
+++ b/bokehjs/src/coffee/core/layout/layout_canvas.ts
@@ -9,16 +9,14 @@ export interface ViewTransform {
 
 export namespace LayoutCanvas {
   export interface Attrs extends HasProps.Attrs {}
-
-  export interface Opts extends HasProps.Opts {}
 }
 
 export interface LayoutCanvas extends LayoutCanvas.Attrs {}
 
 export abstract class LayoutCanvas extends HasProps {
 
-  constructor(attrs?: Partial<LayoutCanvas.Attrs>, opts?: LayoutCanvas.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<LayoutCanvas.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/core/layout/side_panel.ts
+++ b/bokehjs/src/coffee/core/layout/side_panel.ts
@@ -181,16 +181,14 @@ export namespace SidePanel {
   export interface Attrs extends LayoutCanvas.Attrs {
     side: Side
   }
-
-  export interface Opts extends LayoutCanvas.Opts {}
 }
 
 export interface SidePanel extends SidePanel.Attrs {}
 
 export class SidePanel extends LayoutCanvas {
 
-  constructor(attrs?: Partial<SidePanel.Attrs>, opts?: SidePanel.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<SidePanel.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/document.ts
+++ b/bokehjs/src/coffee/document.ts
@@ -450,9 +450,9 @@ export class Document {
   }
 
   static _instantiate_object(obj_id: string, obj_type: string, obj_attrs: {[key: string]: any}): HasProps {
-    const full_attrs = extend({}, obj_attrs, {id: obj_id})
+    const full_attrs = extend({}, obj_attrs, {id: obj_id, __deferred__: true})
     const model: Class<HasProps> = Models(obj_type)
-    return new model(full_attrs, {defer_initialization: true})
+    return new model(full_attrs)
   }
 
   // given a JSON representation of all models in a graph, return a

--- a/bokehjs/src/coffee/model.ts
+++ b/bokehjs/src/coffee/model.ts
@@ -15,16 +15,14 @@ export namespace Model {
     js_event_callbacks: {[key: string]: CustomJS[]}
     subscribed_events: string[]
   }
-
-  export interface Opts extends HasProps.Opts {}
 }
 
 export interface Model extends Model.Attrs {}
 
 export class Model extends HasProps {
 
-  constructor(attrs?: Partial<Model.Attrs>, opts?: Model.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Model.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/annotations/annotation.ts
+++ b/bokehjs/src/coffee/models/annotations/annotation.ts
@@ -37,8 +37,6 @@ export namespace Annotation {
   export interface Attrs extends Renderer.Attrs {
     plot: Plot
   }
-
-  export interface Opts extends Renderer.Opts {}
 }
 
 export interface Annotation extends Annotation.Attrs {
@@ -47,8 +45,8 @@ export interface Annotation extends Annotation.Attrs {
 
 export abstract class Annotation extends Renderer {
 
-  constructor(attrs?: Partial<Annotation.Attrs>, opts?: Annotation.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Annotation.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/annotations/arrow.ts
+++ b/bokehjs/src/coffee/models/annotations/arrow.ts
@@ -142,16 +142,14 @@ export namespace Arrow {
     x_range_name: string
     y_range_name: string
   }
-
-  export interface Opts extends Annotation.Opts {}
 }
 
 export interface Arrow extends Arrow.Attrs {}
 
 export class Arrow extends Annotation {
 
-  constructor(attrs?: Partial<Arrow.Attrs>, opts?: Arrow.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Arrow.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/annotations/arrow_head.ts
+++ b/bokehjs/src/coffee/models/annotations/arrow_head.ts
@@ -8,16 +8,14 @@ export namespace ArrowHead {
   export interface Attrs extends Annotation.Attrs {
     size: number
   }
-
-  export interface Opts extends Annotation.Opts {}
 }
 
 export interface ArrowHead extends ArrowHead.Attrs {}
 
 export abstract class ArrowHead extends Annotation {
 
-  constructor(attrs?: Partial<ArrowHead.Attrs>, opts?: ArrowHead.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<ArrowHead.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {
@@ -46,15 +44,14 @@ export namespace OpenHead {
 
   export interface Attrs extends ArrowHead.Attrs, Mixins {}
 
-  export interface Opts extends ArrowHead.Opts {}
 }
 
 export interface OpenHead extends OpenHead.Attrs {}
 
 export class OpenHead extends ArrowHead {
 
-  constructor(attrs?: Partial<OpenHead.Attrs>, opts?: OpenHead.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<OpenHead.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {
@@ -95,15 +92,14 @@ export namespace NormalHead {
 
   export interface Attrs extends ArrowHead.Attrs, Mixins {}
 
-  export interface Opts extends ArrowHead.Opts {}
 }
 
 export interface NormalHead extends NormalHead.Attrs {}
 
 export class NormalHead extends ArrowHead {
 
-  constructor(attrs?: Partial<NormalHead.Attrs>, opts?: NormalHead.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<NormalHead.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {
@@ -157,15 +153,14 @@ export namespace VeeHead {
 
   export interface Attrs extends ArrowHead.Attrs, Mixins {}
 
-  export interface Opts extends ArrowHead.Opts {}
 }
 
 export interface VeeHead extends VeeHead.Attrs {}
 
 export class VeeHead extends ArrowHead {
 
-  constructor(attrs?: Partial<VeeHead.Attrs>, opts?: VeeHead.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<VeeHead.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {
@@ -221,15 +216,14 @@ export namespace TeeHead {
 
   export interface Attrs extends ArrowHead.Attrs, Mixins {}
 
-  export interface Opts extends ArrowHead.Opts {}
 }
 
 export interface TeeHead extends TeeHead.Attrs {}
 
 export class TeeHead extends ArrowHead {
 
-  constructor(attrs?: Partial<TeeHead.Attrs>, opts?: TeeHead.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<TeeHead.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/annotations/band.ts
+++ b/bokehjs/src/coffee/models/annotations/band.ts
@@ -138,16 +138,14 @@ export namespace Band {
     x_range_name: string
     y_range_name: string
   }
-
-  export interface Opts extends Annotation.Opts {}
 }
 
 export interface Band extends Band.Attrs {}
 
 export class Band extends Annotation {
 
-  constructor(attrs?: Partial<Band.Attrs>, opts?: Band.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Band.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/annotations/box_annotation.ts
+++ b/bokehjs/src/coffee/models/annotations/box_annotation.ts
@@ -134,16 +134,14 @@ export namespace BoxAnnotation {
     right: number | null
     right_units: SpatialUnits
   }
-
-  export interface Opts extends Annotation.Opts {}
 }
 
 export interface BoxAnnotation extends BoxAnnotation.Attrs {}
 
 export class BoxAnnotation extends Annotation {
 
-  constructor(attrs?: Partial<BoxAnnotation.Attrs>, opts?: BoxAnnotation.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<BoxAnnotation.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/annotations/color_bar.ts
+++ b/bokehjs/src/coffee/models/annotations/color_bar.ts
@@ -455,16 +455,14 @@ export namespace ColorBar {
     minor_tick_in: number
     minor_tick_out: number
   }
-
-  export interface Opts extends Annotation.Opts {}
 }
 
 export interface ColorBar extends ColorBar.Attrs {}
 
 export class ColorBar extends Annotation {
 
-  constructor(attrs?: Partial<ColorBar.Attrs>, opts?: ColorBar.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<ColorBar.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/annotations/label.ts
+++ b/bokehjs/src/coffee/models/annotations/label.ts
@@ -93,16 +93,14 @@ export namespace Label {
     y_range_name: string
     render_mode: RenderMode
   }
-
-  export interface Opts extends TextAnnotation.Opts {}
 }
 
 export interface Label extends Label.Attrs {}
 
 export class Label extends TextAnnotation {
 
-  constructor(attrs?: Partial<Label.Attrs>, opts?: Label.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Label.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/annotations/label_set.ts
+++ b/bokehjs/src/coffee/models/annotations/label_set.ts
@@ -231,16 +231,14 @@ export namespace LabelSet {
     y_range_name: string
     render_mode: RenderMode
   }
-
-  export interface Opts extends TextAnnotation.Opts {}
 }
 
 export interface LabelSet extends LabelSet.Attrs {}
 
 export class LabelSet extends TextAnnotation {
 
-  constructor(attrs?: Partial<LabelSet.Attrs>, opts?: LabelSet.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<LabelSet.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/annotations/legend.ts
+++ b/bokehjs/src/coffee/models/annotations/legend.ts
@@ -335,16 +335,14 @@ export namespace Legend {
     items: LegendItem[]
     click_policy: LegendClickPolicy
   }
-
-  export interface Opts extends Annotation.Opts {}
 }
 
 export interface Legend extends Legend.Attrs {}
 
 export class Legend extends Annotation {
 
-  constructor(attrs?: Partial<Legend.Attrs>, opts?: Legend.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Legend.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/annotations/legend_item.ts
+++ b/bokehjs/src/coffee/models/annotations/legend_item.ts
@@ -12,16 +12,14 @@ export namespace LegendItem {
     label: StringSpec | null
     renderers: GlyphRenderer[]
   }
-
-  export interface Opts extends Model.Opts {}
 }
 
 export interface LegendItem extends LegendItem.Attrs {}
 
 export class LegendItem extends Model {
 
-  constructor(attrs?: Partial<LegendItem.Attrs>, opts?: LegendItem.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<LegendItem.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/annotations/poly_annotation.ts
+++ b/bokehjs/src/coffee/models/annotations/poly_annotation.ts
@@ -75,16 +75,14 @@ export namespace PolyAnnotation {
     y_range_name: string
     screen: boolean
   }
-
-  export interface Opts extends Annotation.Opts {}
 }
 
 export interface PolyAnnotation extends PolyAnnotation.Attrs {}
 
 export class PolyAnnotation extends Annotation {
 
-  constructor(attrs?: Partial<PolyAnnotation.Attrs>, opts?: PolyAnnotation.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<PolyAnnotation.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/annotations/span.ts
+++ b/bokehjs/src/coffee/models/annotations/span.ts
@@ -119,16 +119,14 @@ export namespace Span {
     for_hover: boolean
     computed_location: number | null
   }
-
-  export interface Opts extends Annotation.Opts {}
 }
 
 export interface Span extends Span.Attrs {}
 
 export class Span extends Annotation {
 
-  constructor(attrs?: Partial<Span.Attrs>, opts?: Span.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Span.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/annotations/text_annotation.ts
+++ b/bokehjs/src/coffee/models/annotations/text_annotation.ts
@@ -148,16 +148,14 @@ export abstract class TextAnnotationView extends AnnotationView {
 
 export namespace TextAnnotation {
   export interface Attrs extends Annotation.Attrs {}
-
-  export interface Opts extends Annotation.Opts {}
 }
 
 export interface TextAnnotation extends TextAnnotation.Attrs {}
 
 export abstract class TextAnnotation extends Annotation {
 
-  constructor(attrs?: Partial<TextAnnotation.Attrs>, opts?: TextAnnotation.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<TextAnnotation.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/annotations/title.ts
+++ b/bokehjs/src/coffee/models/annotations/title.ts
@@ -137,16 +137,14 @@ export namespace Title {
     text_align: TextAlign
     text_baseline: TextBaseline
   }
-
-  export interface Opts extends TextAnnotation.Opts {}
 }
 
 export interface Title extends Title.Attrs {}
 
 export class Title extends TextAnnotation {
 
-  constructor(attrs?: Partial<Title.Attrs>, opts?: Title.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Title.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/annotations/toolbar_panel.ts
+++ b/bokehjs/src/coffee/models/annotations/toolbar_panel.ts
@@ -55,16 +55,14 @@ export namespace ToolbarPanel {
   export interface Attrs extends Annotation.Attrs {
     toolbar: Toolbar
   }
-
-  export interface Opts extends Annotation.Opts {}
 }
 
 export interface ToolbarPanel extends ToolbarPanel.Attrs {}
 
 export class ToolbarPanel extends Annotation {
 
-  constructor(attrs?: Partial<ToolbarPanel.Attrs>, opts?: ToolbarPanel.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<ToolbarPanel.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/annotations/tooltip.ts
+++ b/bokehjs/src/coffee/models/annotations/tooltip.ts
@@ -134,16 +134,14 @@ export namespace Tooltip {
     data: [number, number, HTMLElement][]
     custom: boolean
   }
-
-  export interface Opts extends Annotation.Opts {}
 }
 
 export interface Tooltip extends Tooltip.Attrs {}
 
 export class Tooltip extends Annotation {
 
-  constructor(attrs?: Partial<Tooltip.Attrs>, opts?: Tooltip.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Tooltip.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/annotations/whisker.ts
+++ b/bokehjs/src/coffee/models/annotations/whisker.ts
@@ -130,16 +130,14 @@ export namespace Whisker {
     x_range_name: string
     y_range_name: string
   }
-
-  export interface Opts extends Annotation.Opts {}
 }
 
 export interface Whisker extends Whisker.Attrs {}
 
 export class Whisker extends Annotation {
 
-  constructor(attrs?: Partial<Whisker.Attrs>, opts?: Whisker.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Whisker.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/axes/axis.ts
+++ b/bokehjs/src/coffee/models/axes/axis.ts
@@ -389,8 +389,6 @@ export namespace Axis {
     major_label_text: Text
     axis_label_text: Text
   }
-
-  export interface Opts extends GuideRenderer.Opts {}
 }
 
 export interface Axis extends Axis.Attrs {
@@ -399,8 +397,8 @@ export interface Axis extends Axis.Attrs {
 
 export class Axis extends GuideRenderer {
 
-  constructor(attrs?: Partial<Axis.Attrs>, opts?: Axis.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Axis.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/axes/categorical_axis.ts
+++ b/bokehjs/src/coffee/models/axes/categorical_axis.ts
@@ -157,8 +157,6 @@ export namespace CategoricalAxis {
     group_text: Text,
     subgroup_text: Text,
   }
-
-  export interface Opts extends Axis.Opts {}
 }
 
 export interface CategoricalAxis extends CategoricalAxis.Attrs {}
@@ -168,8 +166,8 @@ export class CategoricalAxis extends Axis {
   ticker: CategoricalTicker
   formatter: CategoricalTickFormatter
 
-  constructor(attrs?: Partial<CategoricalAxis.Attrs>, opts?: CategoricalAxis.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<CategoricalAxis.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/axes/continuous_axis.ts
+++ b/bokehjs/src/coffee/models/axes/continuous_axis.ts
@@ -2,16 +2,14 @@ import {Axis} from "./axis"
 
 export namespace ContinuousAxis {
   export interface Attrs extends Axis.Attrs {}
-
-  export interface Opts extends Axis.Opts {}
 }
 
 export interface ContinuousAxis extends ContinuousAxis.Attrs {}
 
 export abstract class ContinuousAxis extends Axis {
 
-  constructor(attrs?: Partial<ContinuousAxis.Attrs>, opts?: ContinuousAxis.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<ContinuousAxis.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/axes/datetime_axis.ts
+++ b/bokehjs/src/coffee/models/axes/datetime_axis.ts
@@ -11,16 +11,14 @@ export namespace DatetimeAxis {
     // XXX: ticker:    DatetimeTicker
     // XXX: formatter: DatetimeTickFormatter
   }
-
-  export interface Opts extends LinearAxis.Opts {}
 }
 
 export interface DatetimeAxis extends DatetimeAxis.Attrs {}
 
 export class DatetimeAxis extends LinearAxis {
 
-  constructor(attrs?: Partial<DatetimeAxis.Attrs>, opts?: DatetimeAxis.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<DatetimeAxis.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/axes/linear_axis.ts
+++ b/bokehjs/src/coffee/models/axes/linear_axis.ts
@@ -12,8 +12,6 @@ export namespace LinearAxis {
     ticker: BasicTicker
     formatters: BasicTickFormatter
   }
-
-  export interface Opts extends ContinuousAxis.Opts {}
 }
 
 export interface LinearAxis extends LinearAxis.Attrs {}
@@ -23,8 +21,8 @@ export class LinearAxis extends ContinuousAxis {
   ticker: BasicTicker
   formatters: BasicTickFormatter
 
-  constructor(attrs?: Partial<LinearAxis.Attrs>, opts?: LinearAxis.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<LinearAxis.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/axes/log_axis.ts
+++ b/bokehjs/src/coffee/models/axes/log_axis.ts
@@ -12,8 +12,6 @@ export namespace LogAxis {
     ticker:    LogTicker
     formatter: LogTickFormatter
   }
-
-  export interface Opts extends ContinuousAxis.Opts {}
 }
 
 export interface LogAxis extends LogAxis.Attrs {}
@@ -23,8 +21,8 @@ export class LogAxis extends ContinuousAxis {
   ticker:    LogTicker
   formatter: LogTickFormatter
 
-  constructor(attrs?: Partial<LogAxis.Attrs>, opts?: LogAxis.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<LogAxis.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/callbacks/callback.ts
+++ b/bokehjs/src/coffee/models/callbacks/callback.ts
@@ -2,16 +2,14 @@ import {Model} from "../../model"
 
 export namespace Callback {
   export interface Attrs extends Model.Attrs {}
-
-  export interface Opts extends Model.Opts {}
 }
 
 export interface Callback extends Callback.Attrs {}
 
 export abstract class Callback extends Model {
 
-  constructor(attrs?: Partial<Callback.Attrs>, opts?: Callback.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Callback.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/callbacks/customjs.ts
+++ b/bokehjs/src/coffee/models/callbacks/customjs.ts
@@ -7,16 +7,14 @@ export namespace CustomJS {
     args: {[key: string]: any}
     code: string
   }
-
-  export interface Opts extends Callback.Opts {}
 }
 
 export interface CustomJS extends CustomJS.Attrs {}
 
 export class CustomJS extends Callback {
 
-  constructor(attrs?: Partial<CustomJS.Attrs>, opts?: CustomJS.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<CustomJS.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/callbacks/open_url.ts
+++ b/bokehjs/src/coffee/models/callbacks/open_url.ts
@@ -7,16 +7,14 @@ export namespace OpenURL {
   export interface Attrs extends Callback.Attrs {
     url: string
   }
-
-  export interface Opts extends Callback.Opts {}
 }
 
 export interface OpenURL extends OpenURL.Attrs {}
 
 export class OpenURL extends Callback {
 
-  constructor(attrs?: Partial<OpenURL.Attrs>, opts?: OpenURL.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<OpenURL.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/canvas/canvas.ts
+++ b/bokehjs/src/coffee/models/canvas/canvas.ts
@@ -131,16 +131,14 @@ export namespace Canvas {
     pixel_ratio: number
     output_backend: OutputBackend
   }
-
-  export interface Opts extends LayoutCanvas.Opts {}
 }
 
 export interface Canvas extends Canvas.Attrs {}
 
 export class Canvas extends LayoutCanvas {
 
-  constructor(attrs?: Partial<Canvas.Attrs>, opts?: Canvas.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Canvas.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/canvas/cartesian_frame.ts
+++ b/bokehjs/src/coffee/models/canvas/cartesian_frame.ts
@@ -23,16 +23,14 @@ export namespace CartesianFrame {
     x_scale: Scale
     y_scale: Scale
   }
-
-  export interface Opts extends LayoutCanvas.Opts {}
 }
 
 export interface CartesianFrame extends CartesianFrame.Attrs {}
 
 export class CartesianFrame extends LayoutCanvas {
 
-  constructor(attrs?: Partial<CartesianFrame.Attrs>, opts?: CartesianFrame.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<CartesianFrame.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/expressions/expression.ts
+++ b/bokehjs/src/coffee/models/expressions/expression.ts
@@ -3,16 +3,14 @@ import {Model} from "../../model"
 
 export namespace Expression {
   export interface Attrs extends Model.Attrs {}
-
-  export interface Opts extends Model.Opts {}
 }
 
 export interface Expression extends Expression.Attrs {}
 
 export abstract class Expression extends Model {
 
-  constructor(attrs?: Partial<Expression.Attrs>, opts?: Expression.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Expression.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/expressions/stack.ts
+++ b/bokehjs/src/coffee/models/expressions/stack.ts
@@ -6,16 +6,14 @@ export namespace Stack {
   export interface Attrs extends Expression.Attrs {
     fields: string[]
   }
-
-  export interface Opts extends Expression.Opts {}
 }
 
 export interface Stack extends Stack.Attrs {}
 
 export class Stack extends Expression {
 
-  constructor(attrs?: Partial<Stack.Attrs>, opts?: Stack.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Stack.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/filters/boolean_filter.ts
+++ b/bokehjs/src/coffee/models/filters/boolean_filter.ts
@@ -9,16 +9,14 @@ export namespace BooleanFilter {
   export interface Attrs extends Filter.Attrs {
     booleans: boolean[] | null
   }
-
-  export interface Opts extends Filter.Opts {}
 }
 
 export interface BooleanFilter extends BooleanFilter.Attrs {}
 
 export class BooleanFilter extends Filter {
 
-  constructor(attrs?: Partial<BooleanFilter.Attrs>, opts?: BooleanFilter.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<BooleanFilter.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/filters/customjs_filter.ts
+++ b/bokehjs/src/coffee/models/filters/customjs_filter.ts
@@ -8,16 +8,14 @@ export namespace CustomJSFilter {
     args: {[key: string]: any}
     code: string
   }
-
-  export interface Opts extends Filter.Opts {}
 }
 
 export interface CustomJSFilter extends CustomJSFilter.Attrs {}
 
 export class CustomJSFilter extends Filter {
 
-  constructor(attrs?: Partial<CustomJSFilter.Attrs>, opts?: CustomJSFilter.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<CustomJSFilter.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/filters/filter.ts
+++ b/bokehjs/src/coffee/models/filters/filter.ts
@@ -9,16 +9,14 @@ export namespace Filter {
   export interface Attrs extends Model.Attrs {
     filter: boolean[] | null
   }
-
-  export interface Opts extends Model.Opts {}
 }
 
 export interface Filter extends Filter.Attrs {}
 
 export class Filter extends Model {
 
-  constructor(attrs?: Partial<Filter.Attrs>, opts?: Filter.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Filter.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/filters/group_filter.ts
+++ b/bokehjs/src/coffee/models/filters/group_filter.ts
@@ -9,16 +9,14 @@ export namespace GroupFilter {
     column_name: string
     group: string
   }
-
-  export interface Opts extends Filter.Opts {}
 }
 
 export interface GroupFilter extends GroupFilter.Attrs {}
 
 export class GroupFilter extends Filter {
 
-  constructor(attrs?: Partial<GroupFilter.Attrs>, opts?: GroupFilter.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<GroupFilter.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/filters/index_filter.ts
+++ b/bokehjs/src/coffee/models/filters/index_filter.ts
@@ -9,16 +9,14 @@ export namespace IndexFilter {
   export interface Attrs extends Filter.Attrs {
     indices: number[] | null
   }
-
-  export interface Opts extends Filter.Opts {}
 }
 
 export interface IndexFilter extends IndexFilter.Attrs {}
 
 export class IndexFilter extends Filter {
 
-  constructor(attrs?: Partial<IndexFilter.Attrs>, opts?: IndexFilter.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<IndexFilter.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/formatters/basic_tick_formatter.ts
+++ b/bokehjs/src/coffee/models/formatters/basic_tick_formatter.ts
@@ -10,16 +10,14 @@ export namespace BasicTickFormatter {
     power_limit_high: number
     power_limit_low: number
   }
-
-  export interface Opts extends TickFormatter.Opts {}
 }
 
 export interface BasicTickFormatter extends BasicTickFormatter.Attrs {}
 
 export class BasicTickFormatter extends TickFormatter {
 
-  constructor(attrs?: Partial<BasicTickFormatter.Attrs>, opts?: BasicTickFormatter.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<BasicTickFormatter.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/formatters/categorical_tick_formatter.ts
+++ b/bokehjs/src/coffee/models/formatters/categorical_tick_formatter.ts
@@ -3,16 +3,14 @@ import {TickFormatter} from "./tick_formatter"
 
 export namespace CategoricalTickFormatter {
   export interface Attrs extends TickFormatter.Attrs {}
-
-  export interface Opts extends TickFormatter.Opts {}
 }
 
 export interface CategoricalTickFormatter extends CategoricalTickFormatter.Attrs {}
 
 export class CategoricalTickFormatter extends TickFormatter {
 
-  constructor(attrs?: Partial<CategoricalTickFormatter.Attrs>, opts?: CategoricalTickFormatter.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<CategoricalTickFormatter.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/formatters/datetime_tick_formatter.ts
+++ b/bokehjs/src/coffee/models/formatters/datetime_tick_formatter.ts
@@ -53,16 +53,14 @@ export namespace DatetimeTickFormatter {
     months: string[]
     years: string[]
   }
-
-  export interface Opts extends TickFormatter.Opts {}
 }
 
 export interface DatetimeTickFormatter extends DatetimeTickFormatter.Attrs {}
 
 export class DatetimeTickFormatter extends TickFormatter {
 
-  constructor(attrs?: Partial<DatetimeTickFormatter.Attrs>, opts?: DatetimeTickFormatter.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<DatetimeTickFormatter.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/formatters/func_tick_formatter.ts
+++ b/bokehjs/src/coffee/models/formatters/func_tick_formatter.ts
@@ -8,16 +8,14 @@ export namespace FuncTickFormatter {
     args: {[key: string]: any}
     code: string
   }
-
-  export interface Opts extends TickFormatter.Opts {}
 }
 
 export interface FuncTickFormatter extends FuncTickFormatter.Attrs {}
 
 export class FuncTickFormatter extends TickFormatter {
 
-  constructor(attrs?: Partial<FuncTickFormatter.Attrs>, opts?: FuncTickFormatter.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<FuncTickFormatter.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/formatters/log_tick_formatter.ts
+++ b/bokehjs/src/coffee/models/formatters/log_tick_formatter.ts
@@ -9,16 +9,14 @@ export namespace LogTickFormatter {
   export interface Attrs extends TickFormatter.Attrs {
     ticker: LogTicker | null
   }
-
-  export interface Opts extends TickFormatter.Opts {}
 }
 
 export interface LogTickFormatter extends LogTickFormatter.Attrs {}
 
 export class LogTickFormatter extends TickFormatter {
 
-  constructor(attrs?: Partial<LogTickFormatter.Attrs>, opts?: LogTickFormatter.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<LogTickFormatter.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/formatters/mercator_tick_formatter.ts
+++ b/bokehjs/src/coffee/models/formatters/mercator_tick_formatter.ts
@@ -8,16 +8,14 @@ export namespace MercatorTickFormatter {
   export interface Attrs extends BasicTickFormatter.Attrs {
     dimension: LatLon
   }
-
-  export interface Opts extends BasicTickFormatter.Opts {}
 }
 
 export interface MercatorTickFormatter extends MercatorTickFormatter.Attrs {}
 
 export class MercatorTickFormatter extends BasicTickFormatter {
 
-  constructor(attrs?: Partial<MercatorTickFormatter.Attrs>, opts?: MercatorTickFormatter.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<MercatorTickFormatter.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/formatters/numeral_tick_formatter.ts
+++ b/bokehjs/src/coffee/models/formatters/numeral_tick_formatter.ts
@@ -11,16 +11,14 @@ export namespace NumeralTickFormatter {
     language: string
     rounding: RoundingFunction
   }
-
-  export interface Opts extends TickFormatter.Opts {}
 }
 
 export interface NumeralTickFormatter extends NumeralTickFormatter.Attrs {}
 
 export class NumeralTickFormatter extends TickFormatter {
 
-  constructor(attrs?: Partial<NumeralTickFormatter.Attrs>, opts?: NumeralTickFormatter.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<NumeralTickFormatter.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/formatters/printf_tick_formatter.ts
+++ b/bokehjs/src/coffee/models/formatters/printf_tick_formatter.ts
@@ -8,16 +8,14 @@ export namespace PrintfTickFormatter {
   export interface Attrs extends TickFormatter.Attrs {
     format: string
   }
-
-  export interface Opts extends TickFormatter.Opts {}
 }
 
 export interface PrintfTickFormatter extends PrintfTickFormatter.Attrs {}
 
 export class PrintfTickFormatter extends TickFormatter {
 
-  constructor(attrs?: Partial<PrintfTickFormatter.Attrs>, opts?: PrintfTickFormatter.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<PrintfTickFormatter.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/formatters/tick_formatter.ts
+++ b/bokehjs/src/coffee/models/formatters/tick_formatter.ts
@@ -3,16 +3,14 @@ import {Model} from "../../model"
 
 export namespace TickFormatter {
   export interface Attrs extends Model.Attrs {}
-
-  export interface Opts extends Model.Opts {}
 }
 
 export interface TickFormatter extends TickFormatter.Attrs {}
 
 export abstract class TickFormatter extends Model {
 
-  constructor(attrs?: Partial<TickFormatter.Attrs>, opts?: TickFormatter.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<TickFormatter.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/annular_wedge.ts
+++ b/bokehjs/src/coffee/models/glyphs/annular_wedge.ts
@@ -138,16 +138,14 @@ export namespace AnnularWedge {
     start_angle: AngleSpec
     end_angle:  AngleSpec
   }
-
-  export interface Opts extends XYGlyph.Opts {}
 }
 
 export interface AnnularWedge extends AnnularWedge.Attrs {}
 
 export class AnnularWedge extends XYGlyph {
 
-  constructor(attrs?: Partial<AnnularWedge.Attrs>, opts?: AnnularWedge.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<AnnularWedge.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/annulus.ts
+++ b/bokehjs/src/coffee/models/glyphs/annulus.ts
@@ -122,16 +122,14 @@ export namespace Annulus {
     inner_radius: DistanceSpec
     outer_radius: DistanceSpec
   }
-
-  export interface Opts extends XYGlyph.Opts {}
 }
 
 export interface Annulus extends Annulus.Attrs {}
 
 export class Annulus extends XYGlyph {
 
-  constructor(attrs?: Partial<Annulus.Attrs>, opts?: Annulus.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Annulus.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/arc.ts
+++ b/bokehjs/src/coffee/models/glyphs/arc.ts
@@ -48,16 +48,14 @@ export namespace Arc {
     start_angle: AngleSpec
     end_angle: AngleSpec
   }
-
-  export interface Opts extends XYGlyph.Opts {}
 }
 
 export interface Arc extends Arc.Attrs {}
 
 export class Arc extends XYGlyph {
 
-  constructor(attrs?: Partial<Arc.Attrs>, opts?: Arc.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Arc.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/bezier.ts
+++ b/bokehjs/src/coffee/models/glyphs/bezier.ts
@@ -128,16 +128,14 @@ export namespace Bezier {
     cx1: NumberSpec
     cy1: NumberSpec
   }
-
-  export interface Opts extends Glyph.Opts {}
 }
 
 export interface Bezier extends Bezier.Attrs {}
 
 export class Bezier extends Glyph {
 
-  constructor(attrs?: Partial<Bezier.Attrs>, opts?: Bezier.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Bezier.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/box.ts
+++ b/bokehjs/src/coffee/models/glyphs/box.ts
@@ -92,16 +92,14 @@ export namespace Box {
   export interface Mixins extends LineMixinVector, FillMixinVector {}
 
   export interface Attrs extends Glyph.Attrs, Mixins {}
-
-  export interface Opts extends Glyph.Opts {}
 }
 
 export interface Box extends Box.Attrs {}
 
 export abstract class Box extends Glyph {
 
-  constructor(attrs?: Partial<Box.Attrs>, opts?: Box.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Box.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/circle.ts
+++ b/bokehjs/src/coffee/models/glyphs/circle.ts
@@ -235,16 +235,14 @@ export namespace Circle {
     radius: DistanceSpec | null
     radius_dimension: Dimension
   }
-
-  export interface Opts extends XYGlyph.Opts {}
 }
 
 export interface Circle extends Circle.Attrs {}
 
 export class Circle extends XYGlyph {
 
-  constructor(attrs?: Partial<Circle.Attrs>, opts?: Circle.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Circle.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void { // XXX: Marker

--- a/bokehjs/src/coffee/models/glyphs/ellipse.ts
+++ b/bokehjs/src/coffee/models/glyphs/ellipse.ts
@@ -89,16 +89,14 @@ export namespace Ellipse {
     width: DistanceSpec
     height: DistanceSpec
   }
-
-  export interface Opts extends XYGlyph.Opts {}
 }
 
 export interface Ellipse extends Ellipse.Attrs {}
 
 export class Ellipse extends XYGlyph {
 
-  constructor(attrs?: Partial<Ellipse.Attrs>, opts?: Ellipse.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Ellipse.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/glyph.ts
+++ b/bokehjs/src/coffee/models/glyphs/glyph.ts
@@ -360,16 +360,14 @@ export namespace Glyph {
     x_range_name: string
     y_range_name: string
   }
-
-  export interface Opts extends Model.Opts {}
 }
 
 export interface Glyph extends Glyph.Attrs {}
 
 export abstract class Glyph extends Model {
 
-  constructor(attrs?: Partial<Glyph.Attrs>, opts?: Glyph.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Glyph.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/hbar.ts
+++ b/bokehjs/src/coffee/models/glyphs/hbar.ts
@@ -44,16 +44,14 @@ export namespace HBar {
     height: DistanceSpec
     right: NumberSpec
   }
-
-  export interface Opts extends Box.Opts {}
 }
 
 export interface HBar extends HBar.Attrs {}
 
 export class HBar extends Box {
 
-  constructor(attrs?: Partial<HBar.Attrs>, opts?: HBar.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<HBar.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/image.ts
+++ b/bokehjs/src/coffee/models/glyphs/image.ts
@@ -142,16 +142,14 @@ export namespace Image {
     dilate: boolean
     color_mapper: ColorMapper
   }
-
-  export interface Opts extends XYGlyph.Opts {}
 }
 
 export interface Image extends Image.Attrs {}
 
 export class Image extends XYGlyph {
 
-  constructor(attrs?: Partial<Image.Attrs>, opts?: Image.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Image.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/image_rgba.ts
+++ b/bokehjs/src/coffee/models/glyphs/image_rgba.ts
@@ -123,16 +123,14 @@ export namespace ImageRGBA {
     dh: DistanceSpec
     dilate: boolean
   }
-
-  export interface Opts extends XYGlyph.Opts {}
 }
 
 export interface ImageRGBA extends ImageRGBA.Attrs {}
 
 export class ImageRGBA extends XYGlyph {
 
-  constructor(attrs?: Partial<ImageRGBA.Attrs>, opts?: ImageRGBA.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<ImageRGBA.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/image_url.ts
+++ b/bokehjs/src/coffee/models/glyphs/image_url.ts
@@ -183,16 +183,14 @@ export namespace ImageURL {
     retry_attempts: number
     retry_timeout: number
   }
-
-  export interface Opts extends Glyph.Opts {}
 }
 
 export interface ImageURL extends ImageURL.Attrs {}
 
 export class ImageURL extends Glyph {
 
-  constructor(attrs?: Partial<ImageURL.Attrs>, opts?: ImageURL.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<ImageURL.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/line.ts
+++ b/bokehjs/src/coffee/models/glyphs/line.ts
@@ -134,16 +134,14 @@ export namespace Line {
   export interface Mixins extends LineMixinVector {}
 
   export interface Attrs extends XYGlyph.Attrs, Mixins {}
-
-  export interface Opts extends XYGlyph.Opts {}
 }
 
 export interface Line extends Line.Attrs {}
 
 export class Line extends XYGlyph {
 
-  constructor(attrs?: Partial<Line.Attrs>, opts?: Line.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Line.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/multi_line.ts
+++ b/bokehjs/src/coffee/models/glyphs/multi_line.ts
@@ -165,16 +165,14 @@ export namespace MultiLine {
     xs: NumberSpec
     ys: NumberSpec
   }
-
-  export interface Opts extends Glyph.Opts {}
 }
 
 export interface MultiLine extends MultiLine.Attrs {}
 
 export class MultiLine extends Glyph {
 
-  constructor(attrs?: Partial<MultiLine.Attrs>, opts?: MultiLine.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<MultiLine.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/oval.ts
+++ b/bokehjs/src/coffee/models/glyphs/oval.ts
@@ -98,16 +98,14 @@ export namespace Oval {
     width: DistanceSpec
     height: DistanceSpec
   }
-
-  export interface Opts extends XYGlyph.Opts {}
 }
 
 export interface Oval extends Oval.Attrs {}
 
 export class Oval extends XYGlyph {
 
-  constructor(attrs?: Partial<Oval.Attrs>, opts?: Oval.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Oval.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/patch.ts
+++ b/bokehjs/src/coffee/models/glyphs/patch.ts
@@ -61,16 +61,14 @@ export namespace Patch {
   export interface Mixins extends LineMixinVector, FillMixinVector {}
 
   export interface Attrs extends XYGlyph.Attrs, Mixins {}
-
-  export interface Opts extends XYGlyph.Opts {}
 }
 
 export interface Patch extends Patch.Attrs {}
 
 export class Patch extends XYGlyph {
 
-  constructor(attrs?: Partial<Patch.Attrs>, opts?: Patch.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Patch.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/patches.ts
+++ b/bokehjs/src/coffee/models/glyphs/patches.ts
@@ -227,16 +227,14 @@ export namespace Patches {
     xs: NumberSpec
     ys: NumberSpec
   }
-
-  export interface Opts extends Glyph.Opts {}
 }
 
 export interface Patches extends Patches.Attrs {}
 
 export class Patches extends Glyph {
 
-  constructor(attrs?: Partial<Patches.Attrs>, opts?: Patches.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Patches.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/quad.ts
+++ b/bokehjs/src/coffee/models/glyphs/quad.ts
@@ -55,16 +55,14 @@ export namespace Quad {
     left: NumberSpec
     top: NumberSpec
   }
-
-  export interface Opts extends Box.Opts {}
 }
 
 export interface Quad extends Quad.Attrs {}
 
 export class Quad extends Box {
 
-  constructor(attrs?: Partial<Quad.Attrs>, opts?: Quad.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Quad.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/quadratic.ts
+++ b/bokehjs/src/coffee/models/glyphs/quadratic.ts
@@ -77,16 +77,14 @@ export namespace Quadratic {
     cx: NumberSpec
     cy: NumberSpec
   }
-
-  export interface Opts extends Glyph.Opts {}
 }
 
 export interface Quadratic extends Quadratic.Attrs {}
 
 export class Quadratic extends Glyph {
 
-  constructor(attrs?: Partial<Quadratic.Attrs>, opts?: Quadratic.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Quadratic.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/ray.ts
+++ b/bokehjs/src/coffee/models/glyphs/ray.ts
@@ -61,16 +61,14 @@ export namespace Ray {
     length: DistanceSpec
     angle: AngleSpec
   }
-
-  export interface Opts extends XYGlyph.Opts {}
 }
 
 export interface Ray extends Ray.Attrs {}
 
 export class Ray extends XYGlyph {
 
-  constructor(attrs?: Partial<Ray.Attrs>, opts?: Ray.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Ray.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/rect.ts
+++ b/bokehjs/src/coffee/models/glyphs/rect.ts
@@ -265,16 +265,14 @@ export namespace Rect {
     height: DistanceSpec
     dilate: boolean
   }
-
-  export interface Opts extends XYGlyph.Opts {}
 }
 
 export interface Rect extends Rect.Attrs {}
 
 export class Rect extends XYGlyph {
 
-  constructor(attrs?: Partial<Rect.Attrs>, opts?: Rect.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Rect.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/segment.ts
+++ b/bokehjs/src/coffee/models/glyphs/segment.ts
@@ -122,16 +122,14 @@ export namespace Segment {
     x1: NumberSpec
     y1: NumberSpec
   }
-
-  export interface Opts extends Glyph.Opts {}
 }
 
 export interface Segment extends Segment.Attrs {}
 
 export class Segment extends Glyph {
 
-  constructor(attrs?: Partial<Segment.Attrs>, opts?: Segment.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Segment.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/step.ts
+++ b/bokehjs/src/coffee/models/glyphs/step.ts
@@ -61,16 +61,14 @@ export namespace Step {
   export interface Attrs extends XYGlyph.Attrs, Mixins {
     mode: StepMode
   }
-
-  export interface Opts extends XYGlyph.Opts {}
 }
 
 export interface Step extends Step.Attrs {}
 
 export class Step extends XYGlyph {
 
-  constructor(attrs?: Partial<Step.Attrs>, opts?: Step.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Step.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/text.ts
+++ b/bokehjs/src/coffee/models/glyphs/text.ts
@@ -79,16 +79,14 @@ export namespace Text {
     x_offset: NumberSpec
     y_offset: NumberSpec
   }
-
-  export interface Opts extends XYGlyph.Opts {}
 }
 
 export interface Text extends Text.Attrs {}
 
 export class Text extends XYGlyph {
 
-  constructor(attrs?: Partial<Text.Attrs>, opts?: Text.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Text.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/vbar.ts
+++ b/bokehjs/src/coffee/models/glyphs/vbar.ts
@@ -44,16 +44,14 @@ export namespace VBar {
     width: DistanceSpec
     top: NumberSpec
   }
-
-  export interface Opts extends Box.Opts {}
 }
 
 export interface VBar extends VBar.Attrs {}
 
 export class VBar extends Box {
 
-  constructor(attrs?: Partial<VBar.Attrs>, opts?: VBar.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<VBar.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/wedge.ts
+++ b/bokehjs/src/coffee/models/glyphs/wedge.ts
@@ -109,16 +109,14 @@ export namespace Wedge {
     start_angle: AngleSpec
     end_angle: AngleSpec
   }
-
-  export interface Opts extends XYGlyph.Opts {}
 }
 
 export interface Wedge extends Wedge.Attrs {}
 
 export class Wedge extends XYGlyph {
 
-  constructor(attrs?: Partial<Wedge.Attrs>, opts?: Wedge.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Wedge.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/glyphs/xy_glyph.ts
+++ b/bokehjs/src/coffee/models/glyphs/xy_glyph.ts
@@ -27,16 +27,14 @@ export namespace XYGlyph {
     x: NumberSpec
     y: NumberSpec
   }
-
-  export interface Opts extends Glyph.Opts {}
 }
 
 export interface XYGlyph extends XYGlyph.Attrs {}
 
 export abstract class XYGlyph extends Glyph {
 
-  constructor(attrs?: Partial<XYGlyph.Attrs>, opts?: XYGlyph.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<XYGlyph.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/graphs/layout_provider.ts
+++ b/bokehjs/src/coffee/models/graphs/layout_provider.ts
@@ -3,16 +3,14 @@ import {ColumnarDataSource} from "../sources/columnar_data_source"
 
 export namespace LayoutProvider {
   export interface Attrs extends Model.Attrs {}
-
-  export interface Opts extends Model.Opts {}
 }
 
 export interface LayoutProvider extends LayoutProvider.Attrs {}
 
 export abstract class LayoutProvider extends Model {
 
-  constructor(attrs?: Partial<LayoutProvider.Attrs>, opts?: LayoutProvider.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<LayoutProvider.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/graphs/static_layout_provider.ts
+++ b/bokehjs/src/coffee/models/graphs/static_layout_provider.ts
@@ -6,16 +6,14 @@ export namespace StaticLayoutProvider {
   export interface Attrs extends LayoutProvider.Attrs {
     graph_layout: {[key: string]: [number, number]}
   }
-
-  export interface Opts extends LayoutProvider.Opts {}
 }
 
 export interface StaticLayoutProvider extends StaticLayoutProvider.Attrs {}
 
 export class StaticLayoutProvider extends LayoutProvider {
 
-  constructor(attrs?: Partial<StaticLayoutProvider.Attrs>, opts?: StaticLayoutProvider.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<StaticLayoutProvider.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/grids/grid.ts
+++ b/bokehjs/src/coffee/models/grids/grid.ts
@@ -124,16 +124,14 @@ export namespace Grid {
     minor_grid_line: Line
     band_fill: Fill
   }
-
-  export interface Opts extends GuideRenderer.Opts {}
 }
 
 export interface Grid extends Grid.Attrs {}
 
 export class Grid extends GuideRenderer {
 
-  constructor(attrs?: Partial<Grid.Attrs>, opts?: Grid.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Grid.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/layouts/box.ts
+++ b/bokehjs/src/coffee/models/layouts/box.ts
@@ -65,16 +65,14 @@ export namespace Box {
     children: LayoutDOM[]
     spacing: number
   }
-
-  export interface Opts extends LayoutDOM.Opts {}
 }
 
 export interface Box extends Box.Attrs {}
 
 export class Box extends LayoutDOM {
 
-  constructor(attrs?: Partial<Box.Attrs>, opts?: Box.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Box.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/layouts/column.ts
+++ b/bokehjs/src/coffee/models/layouts/column.ts
@@ -10,16 +10,14 @@ export class ColumnView extends BoxView {
 
 export namespace Column {
   export interface Attrs extends Box.Attrs {}
-
-  export interface Opts extends Box.Opts {}
 }
 
 export interface Column extends Column.Attrs {}
 
 export class Column extends Box {
 
-  constructor(attrs?: Partial<Column.Attrs>, opts?: Column.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Column.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/layouts/layout_dom.ts
+++ b/bokehjs/src/coffee/models/layouts/layout_dom.ts
@@ -356,16 +356,14 @@ export namespace LayoutDOM {
     sizing_mode: SizingMode
     css_classes: string[]
   }
-
-  export interface Opts extends Model.Opts {}
 }
 
 export interface LayoutDOM extends LayoutDOM.Attrs {}
 
 export abstract class LayoutDOM extends Model {
 
-  constructor(attrs?: Partial<LayoutDOM.Attrs>, opts?: LayoutDOM.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<LayoutDOM.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/layouts/row.ts
+++ b/bokehjs/src/coffee/models/layouts/row.ts
@@ -10,16 +10,14 @@ export class RowView extends BoxView {
 
 export namespace Row {
   export interface Attrs extends Box.Attrs {}
-
-  export interface Opts extends Box.Opts {}
 }
 
 export interface Row extends Row.Attrs {}
 
 export class Row extends Box {
 
-  constructor(attrs?: Partial<Row.Attrs>, opts?: Row.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Row.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/layouts/spacer.ts
+++ b/bokehjs/src/coffee/models/layouts/spacer.ts
@@ -29,16 +29,14 @@ export class SpacerView extends LayoutDOMView {
 
 export namespace Spacer {
   export interface Attrs extends LayoutDOM.Attrs {}
-
-  export interface Opts extends LayoutDOM.Opts {}
 }
 
 export interface Spacer extends Spacer.Attrs {}
 
 export class Spacer extends LayoutDOM {
 
-  constructor(attrs?: Partial<Spacer.Attrs>, opts?: Spacer.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Spacer.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/layouts/widget_box.ts
+++ b/bokehjs/src/coffee/models/layouts/widget_box.ts
@@ -89,16 +89,14 @@ export namespace WidgetBox {
   export interface Attrs extends LayoutDOM.Attrs {
     children: LayoutDOM[]
   }
-
-  export interface Opts extends LayoutDOM.Opts {}
 }
 
 export interface WidgetBox extends WidgetBox.Attrs {}
 
 export class WidgetBox extends LayoutDOM {
 
-  constructor(attrs?: Partial<WidgetBox.Attrs>, opts?: WidgetBox.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<WidgetBox.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/mappers/categorical_color_mapper.ts
+++ b/bokehjs/src/coffee/models/mappers/categorical_color_mapper.ts
@@ -23,16 +23,14 @@ export namespace CategoricalColorMapper {
     start: number
     end: number
   }
-
-  export interface Opts extends ColorMapper.Opts {}
 }
 
 export interface CategoricalColorMapper extends CategoricalColorMapper.Attrs {}
 
 export class CategoricalColorMapper extends ColorMapper {
 
-  constructor(attrs?: Partial<CategoricalColorMapper.Attrs>, opts?: CategoricalColorMapper.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<CategoricalColorMapper.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/mappers/color_mapper.ts
+++ b/bokehjs/src/coffee/models/mappers/color_mapper.ts
@@ -10,16 +10,14 @@ export namespace ColorMapper {
     palette: (number | string)[]
     nan_color: Color
   }
-
-  export interface Opts extends Transform.Opts {}
 }
 
 export interface ColorMapper extends ColorMapper.Attrs {}
 
 export abstract class ColorMapper extends Transform {
 
-  constructor(attrs?: Partial<ColorMapper.Attrs>, opts?: ColorMapper.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<ColorMapper.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/mappers/linear_color_mapper.ts
+++ b/bokehjs/src/coffee/models/mappers/linear_color_mapper.ts
@@ -13,16 +13,14 @@ export namespace LinearColorMapper {
     high_color: Color
     low_color: Color
   }
-
-  export interface Opts extends ColorMapper.Opts {}
 }
 
 export interface LinearColorMapper extends LinearColorMapper.Attrs {}
 
 export class LinearColorMapper extends ColorMapper {
 
-  constructor(attrs?: Partial<LinearColorMapper.Attrs>, opts?: LinearColorMapper.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<LinearColorMapper.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/mappers/log_color_mapper.ts
+++ b/bokehjs/src/coffee/models/mappers/log_color_mapper.ts
@@ -17,16 +17,14 @@ export namespace LogColorMapper {
     high_color: Color
     low_color: Color
   }
-
-  export interface Opts extends ColorMapper.Opts {}
 }
 
 export interface LogColorMapper extends LogColorMapper.Attrs {}
 
 export class LogColorMapper extends ColorMapper {
 
-  constructor(attrs?: Partial<LogColorMapper.Attrs>, opts?: LogColorMapper.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<LogColorMapper.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/markers/marker.ts
+++ b/bokehjs/src/coffee/models/markers/marker.ts
@@ -161,16 +161,14 @@ export namespace Marker {
     size: DistanceSpec
     angle: AngleSpec
   }
-
-  export interface Opts extends XYGlyph.Opts {}
 }
 
 export interface Marker extends Marker.Attrs {}
 
 export class Marker extends XYGlyph {
 
-  constructor(attrs?: Partial<Marker.Attrs>, opts?: Marker.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Marker.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/plots/gmap_plot.ts
+++ b/bokehjs/src/coffee/models/plots/gmap_plot.ts
@@ -12,16 +12,14 @@ export namespace MapOptions {
     lng: number
     zoom: number
   }
-
-  export interface Opts extends Model.Opts {}
 }
 
 export interface MapOptions extends MapOptions.Attrs {}
 
 export class MapOptions extends Model {
 
-  constructor(attrs?: Partial<MapOptions.Attrs>, opts?: MapOptions.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<MapOptions.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {
@@ -43,15 +41,14 @@ export namespace GMapOptions {
     styles: string
   }
 
-  export interface Opts extends MapOptions.Opts {}
 }
 
 export interface GMapOptions extends GMapOptions.Attrs {}
 
 export class GMapOptions extends MapOptions {
 
-  constructor(attrs?: Partial<GMapOptions.Attrs>, opts?: GMapOptions.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<GMapOptions.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {
@@ -76,15 +73,14 @@ export namespace GMapPlot {
     api_key: string
   }
 
-  export interface Opts extends Plot.Opts {}
 }
 
 export interface GMapPlot extends GMapPlot.Attrs {}
 
 export class GMapPlot extends Plot {
 
-  constructor(attrs?: Partial<GMapPlot.Attrs>, opts?: GMapPlot.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<GMapPlot.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/plots/gmap_plot_canvas.ts
+++ b/bokehjs/src/coffee/models/plots/gmap_plot_canvas.ts
@@ -250,8 +250,6 @@ export class GMapPlotCanvasView extends PlotCanvasView {
 
 export namespace GMapPlotCanvas {
   export interface Attrs extends PlotCanvas.Attrs {}
-
-  export interface Opts extends PlotCanvas.Opts {}
 }
 
 export interface GMapPlotCanvas extends GMapPlotCanvas.Attrs {}
@@ -260,8 +258,8 @@ export class GMapPlotCanvas extends PlotCanvas {
 
   plot: GMapPlot
 
-  constructor(attrs?: Partial<GMapPlotCanvas.Attrs>, opts?: GMapPlotCanvas.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<GMapPlotCanvas.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/plots/plot.ts
+++ b/bokehjs/src/coffee/models/plots/plot.ts
@@ -136,16 +136,14 @@ export namespace Plot {
     match_aspect: boolean
     aspect_scale: number
   }
-
-  export interface Opts extends LayoutDOM.Opts {}
 }
 
 export interface Plot extends Plot.Attrs {}
 
 export class Plot extends LayoutDOM {
 
-  constructor(attrs?: Partial<Plot.Attrs>, opts?: Plot.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Plot.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/plots/plot_canvas.ts
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.ts
@@ -937,8 +937,6 @@ export namespace PlotCanvas {
     canvas: Canvas
     frame: CartesianFrame
   }
-
-  export interface Opts extends LayoutDOM.Opts {}
 }
 
 export interface PlotCanvas extends PlotCanvas.Attrs {
@@ -947,8 +945,8 @@ export interface PlotCanvas extends PlotCanvas.Attrs {
 
 export class PlotCanvas extends LayoutDOM {
 
-  constructor(attrs?: Partial<PlotCanvas.Attrs>, opts?: PlotCanvas.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<PlotCanvas.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/ranges/data_range.ts
+++ b/bokehjs/src/coffee/models/ranges/data_range.ts
@@ -7,16 +7,14 @@ export namespace DataRange {
     names: string[]
     renderers: Renderer[]
   }
-
-  export interface Opts extends Range.Opts {}
 }
 
 export interface DataRange extends DataRange.Attrs {}
 
 export abstract class DataRange extends Range {
 
-  constructor(attrs?: Partial<DataRange.Attrs>, opts?: DataRange.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<DataRange.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/ranges/data_range1d.ts
+++ b/bokehjs/src/coffee/models/ranges/data_range1d.ts
@@ -27,16 +27,14 @@ export namespace DataRange1d {
 
     scale_hint: "log" | "auto"
   }
-
-  export interface Opts extends DataRange.Opts {}
 }
 
 export interface DataRange1d extends DataRange1d.Attrs {}
 
 export class DataRange1d extends DataRange {
 
-  constructor(attrs?: Partial<DataRange1d.Attrs>, opts?: DataRange1d.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<DataRange1d.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/ranges/factor_range.ts
+++ b/bokehjs/src/coffee/models/ranges/factor_range.ts
@@ -115,16 +115,14 @@ export namespace FactorRange {
     tops: string[] | undefined
     tops_groups: string[]
   }
-
-  export interface Opts extends Range.Opts {}
 }
 
 export interface FactorRange extends FactorRange.Attrs {}
 
 export class FactorRange extends Range {
 
-  constructor(attrs?: Partial<FactorRange.Attrs>, opts?: FactorRange.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<FactorRange.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/ranges/range.ts
+++ b/bokehjs/src/coffee/models/ranges/range.ts
@@ -9,16 +9,14 @@ export namespace Range {
     callback?: ((obj: Range) => void) | CustomJS // XXX: Callback
     plots: Plot[]
   }
-
-  export interface Opts extends Model.Opts {}
 }
 
 export interface Range extends Range.Attrs {}
 
 export abstract class Range extends Model {
 
-  constructor(attrs?: Partial<Range.Attrs>, opts?: Range.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Range.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/ranges/range1d.ts
+++ b/bokehjs/src/coffee/models/ranges/range1d.ts
@@ -9,16 +9,14 @@ export namespace Range1d {
     min_interval: number
     max_interval: number
   }
-
-  export interface Opts extends Range.Opts {}
 }
 
 export interface Range1d extends Range1d.Attrs {}
 
 export class Range1d extends Range {
 
-  constructor(attrs?: Partial<Range1d.Attrs>, opts?: Range1d.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Range1d.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/coffee/models/renderers/glyph_renderer.ts
@@ -378,16 +378,14 @@ export namespace GlyphRenderer {
     muted_glyph: Glyph
     muted: boolean
   }
-
-  export interface Opts extends Renderer.Opts {}
 }
 
 export interface GlyphRenderer extends GlyphRenderer.Attrs {}
 
 export class GlyphRenderer extends Renderer {
 
-  constructor(attrs?: Partial<GlyphRenderer.Attrs>, opts?: GlyphRenderer.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<GlyphRenderer.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/renderers/graph_renderer.ts
+++ b/bokehjs/src/coffee/models/renderers/graph_renderer.ts
@@ -77,7 +77,6 @@ export class GraphRendererView extends RendererView {
     this.edge_view.render();
     return this.node_view.render();
   }
-
 }
 
 export namespace GraphRenderer {
@@ -90,16 +89,14 @@ export namespace GraphRenderer {
     selection_policy: GraphHitTestPolicy
     inspection_policy: GraphHitTestPolicy
   }
-
-  export interface Opts extends Renderer.Opts {}
 }
 
 export interface GraphRenderer extends GraphRenderer.Attrs {}
 
 export class GraphRenderer extends Renderer {
 
-  constructor(attrs?: Partial<GraphRenderer.Attrs>, opts?: GraphRenderer.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<GraphRenderer.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/renderers/guide_renderer.ts
+++ b/bokehjs/src/coffee/models/renderers/guide_renderer.ts
@@ -13,16 +13,14 @@ export namespace GuideRenderer {
   }
 
   export type Visuals = Renderer.Visuals
-
-  export interface Opts extends Renderer.Opts {}
 }
 
 export interface GuideRenderer extends GuideRenderer.Attrs {}
 
 export abstract class GuideRenderer extends Renderer {
 
-  constructor(attrs?: Partial<GuideRenderer.Attrs>, opts?: GuideRenderer.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<GuideRenderer.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/renderers/renderer.ts
+++ b/bokehjs/src/coffee/models/renderers/renderer.ts
@@ -40,16 +40,14 @@ export namespace Renderer {
   }
 
   export type Visuals = visuals.Visuals
-
-  export interface Opts extends Model.Opts {}
 }
 
 export interface Renderer extends Renderer.Attrs {}
 
 export abstract class Renderer extends Model {
 
-  constructor(attrs?: Partial<Renderer.Attrs>, opts?: Renderer.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Renderer.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/scales/categorical_scale.ts
+++ b/bokehjs/src/coffee/models/scales/categorical_scale.ts
@@ -3,16 +3,14 @@ import {FactorRange} from "../ranges/factor_range"
 
 export namespace CategoricalScale {
   export interface Attrs extends LinearScale.Attrs {}
-
-  export interface Opts extends LinearScale.Opts {}
 }
 
 export interface CategoricalScale extends CategoricalScale.Attrs {}
 
 export class CategoricalScale extends LinearScale {
 
-  constructor(attrs?: Partial<CategoricalScale.Attrs>, opts?: CategoricalScale.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<CategoricalScale.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/scales/linear_scale.ts
+++ b/bokehjs/src/coffee/models/scales/linear_scale.ts
@@ -2,16 +2,14 @@ import {Scale} from "./scale"
 
 export namespace LinearScale {
   export interface Attrs extends Scale.Attrs {}
-
-  export interface Opts extends Scale.Opts {}
 }
 
 export interface LinearScale extends LinearScale.Attrs {}
 
 export class LinearScale extends Scale {
 
-  constructor(attrs?: Partial<LinearScale.Attrs>, opts?: LinearScale.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<LinearScale.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/scales/log_scale.ts
+++ b/bokehjs/src/coffee/models/scales/log_scale.ts
@@ -2,16 +2,14 @@ import {Scale} from "./scale"
 
 export namespace LogScale {
   export interface Attrs extends Scale.Attrs {}
-
-  export interface Opts extends Scale.Opts {}
 }
 
 export interface LogScale extends LogScale.Attrs {}
 
 export class LogScale extends Scale {
 
-  constructor(attrs?: Partial<LogScale.Attrs>, opts?: LogScale.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<LogScale.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/scales/scale.ts
+++ b/bokehjs/src/coffee/models/scales/scale.ts
@@ -5,16 +5,14 @@ import * as p from "core/properties"
 
 export namespace Scale {
   export interface Attrs extends Transform.Attrs {}
-
-  export interface Opts extends Transform.Opts {}
 }
 
 export interface Scale extends Scale.Attrs {}
 
 export abstract class Scale extends Transform {
 
-  constructor(attrs?: Partial<Scale.Attrs>, opts?: Scale.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Scale.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/selections/selection.ts
+++ b/bokehjs/src/coffee/models/selections/selection.ts
@@ -13,16 +13,14 @@ export namespace Selection {
     get_view: () => GlyphView | null
     multiline_indices: {[key: string]: number[]}
   }
-
-  export interface Opts extends Model.Opts {}
 }
 
 export interface Selection extends Selection.Attrs {}
 
 export class Selection extends Model {
 
-  constructor(attrs?: Partial<Selection.Attrs>, opts?: Selection.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Selection.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/sources/ajax_data_source.ts
+++ b/bokehjs/src/coffee/models/sources/ajax_data_source.ts
@@ -13,16 +13,14 @@ export namespace AjaxDataSource {
     method: HTTPMethod
     if_modified: boolean
   }
-
-  export interface Opts extends RemoteDataSource.Opts {}
 }
 
 export interface AjaxDataSource extends AjaxDataSource.Attrs {}
 
 export class AjaxDataSource extends RemoteDataSource {
 
-  constructor(attrs?: Partial<AjaxDataSource.Attrs>, opts?: AjaxDataSource.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<AjaxDataSource.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/sources/cds_view.ts
+++ b/bokehjs/src/coffee/models/sources/cds_view.ts
@@ -13,16 +13,14 @@ export namespace CDSView {
     indices: number[]
     indices_map: {[key: string]: number}
   }
-
-  export interface Opts extends Model.Opts {}
 }
 
 export interface CDSView extends CDSView.Attrs {}
 
 export class CDSView extends Model {
 
-  constructor(attrs?: Partial<CDSView.Attrs>, opts?: CDSView.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<CDSView.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/sources/column_data_source.ts
+++ b/bokehjs/src/coffee/models/sources/column_data_source.ts
@@ -128,16 +128,14 @@ export namespace ColumnDataSource {
   export interface Attrs extends ColumnarDataSource.Attrs {
     data: {[key: string]: any[]}
   }
-
-  export interface Opts extends ColumnarDataSource.Opts {}
 }
 
 export interface ColumnDataSource extends ColumnDataSource.Attrs {}
 
 export class ColumnDataSource extends ColumnarDataSource {
 
-  constructor(attrs?: Partial<ColumnDataSource.Attrs>, opts?: ColumnDataSource.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<ColumnDataSource.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/sources/columnar_data_source.ts
+++ b/bokehjs/src/coffee/models/sources/columnar_data_source.ts
@@ -21,8 +21,6 @@ export namespace ColumnarDataSource {
     inspected: Selection
     _shapes: {[key: string]: Shape | Shape[]}
   }
-
-  export interface Opts extends DataSource.Opts {}
 }
 
 export interface ColumnarDataSource extends ColumnarDataSource.Attrs {}
@@ -37,8 +35,8 @@ export abstract class ColumnarDataSource extends DataSource {
   streaming: Signal<any, this>
   patching: Signal<any, this> // <number[], ColumnarDataSource>
 
-  constructor(attrs?: Partial<ColumnarDataSource.Attrs>, opts?: ColumnarDataSource.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<ColumnarDataSource.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/sources/data_source.ts
+++ b/bokehjs/src/coffee/models/sources/data_source.ts
@@ -8,16 +8,14 @@ export namespace DataSource {
     selected: Selection
     callback: any // XXX
   }
-
-  export interface Opts extends Model.Opts {}
 }
 
 export interface DataSource extends DataSource.Attrs {}
 
 export abstract class DataSource extends Model {
 
-  constructor(attrs?: Partial<DataSource.Attrs>, opts?: DataSource.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<DataSource.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/sources/geojson_data_source.ts
+++ b/bokehjs/src/coffee/models/sources/geojson_data_source.ts
@@ -8,16 +8,14 @@ export namespace GeoJSONDataSource {
   export interface Attrs extends ColumnarDataSource.Attrs {
     geojson: any
   }
-
-  export interface Opts extends ColumnarDataSource.Opts {}
 }
 
 export interface GeoJSONDataSource extends GeoJSONDataSource.Attrs {}
 
 export class GeoJSONDataSource extends ColumnarDataSource {
 
-  constructor(attrs?: Partial<GeoJSONDataSource.Attrs>, opts?: GeoJSONDataSource.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<GeoJSONDataSource.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/sources/remote_data_source.ts
+++ b/bokehjs/src/coffee/models/sources/remote_data_source.ts
@@ -7,16 +7,14 @@ export namespace RemoteDataSource {
     data_url: string
     polling_interval: number
   }
-
-  export interface Opts extends ColumnDataSource.Opts {}
 }
 
 export interface RemoteDataSource extends RemoteDataSource.Attrs {}
 
 export abstract class RemoteDataSource extends ColumnDataSource {
 
-  constructor(attrs?: Partial<RemoteDataSource.Attrs>, opts?: RemoteDataSource.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<RemoteDataSource.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tickers/adaptive_ticker.ts
+++ b/bokehjs/src/coffee/models/tickers/adaptive_ticker.ts
@@ -23,16 +23,14 @@ export namespace AdaptiveTicker {
     min_interval: number
     max_interval: number
   }
-
-  export interface Opts extends ContinuousTicker.Opts {}
 }
 
 export interface AdaptiveTicker extends AdaptiveTicker.Attrs {}
 
 export class AdaptiveTicker extends ContinuousTicker {
 
-  constructor(attrs?: Partial<AdaptiveTicker.Attrs>, opts?: AdaptiveTicker.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<AdaptiveTicker.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tickers/basic_ticker.ts
+++ b/bokehjs/src/coffee/models/tickers/basic_ticker.ts
@@ -2,16 +2,14 @@ import {AdaptiveTicker} from "./adaptive_ticker"
 
 export namespace BasicTicker {
   export interface Attrs extends AdaptiveTicker.Attrs {}
-
-  export interface Opts extends AdaptiveTicker.Opts {}
 }
 
 export interface BasicTicker extends BasicTicker.Attrs {}
 
 export class BasicTicker extends AdaptiveTicker {
 
-  constructor(attrs?: Partial<BasicTicker.Attrs>, opts?: BasicTicker.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<BasicTicker.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tickers/categorical_ticker.ts
+++ b/bokehjs/src/coffee/models/tickers/categorical_ticker.ts
@@ -3,16 +3,14 @@ import {FactorRange, Factor} from "../ranges/factor_range"
 
 export namespace CategoricalTicker {
   export interface Attrs extends Ticker.Attrs {}
-
-  export interface Opts extends Ticker.Opts {}
 }
 
 export interface CategoricalTicker extends CategoricalTicker.Attrs {}
 
 export class CategoricalTicker extends Ticker<Factor> {
 
-  constructor(attrs?: Partial<CategoricalTicker.Attrs>, opts?: CategoricalTicker.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<CategoricalTicker.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tickers/composite_ticker.ts
+++ b/bokehjs/src/coffee/models/tickers/composite_ticker.ts
@@ -10,16 +10,14 @@ export namespace CompositeTicker {
   export interface Attrs extends ContinuousTicker.Attrs {
     tickers: ContinuousTicker[]
   }
-
-  export interface Opts extends ContinuousTicker.Opts {}
 }
 
 export interface CompositeTicker extends CompositeTicker.Attrs {}
 
 export class CompositeTicker extends ContinuousTicker {
 
-  constructor(attrs?: Partial<CompositeTicker.Attrs>, opts?: CompositeTicker.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<CompositeTicker.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tickers/continuous_ticker.ts
+++ b/bokehjs/src/coffee/models/tickers/continuous_ticker.ts
@@ -21,16 +21,14 @@ export namespace ContinuousTicker {
     num_minor_ticks: number
     desired_num_ticks: number
   }
-
-  export interface Opts extends Ticker.Opts {}
 }
 
 export interface ContinuousTicker extends ContinuousTicker.Attrs {}
 
 export abstract class ContinuousTicker extends Ticker<number> {
 
-  constructor(attrs?: Partial<ContinuousTicker.Attrs>, opts?: ContinuousTicker.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<ContinuousTicker.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tickers/datetime_ticker.ts
+++ b/bokehjs/src/coffee/models/tickers/datetime_ticker.ts
@@ -15,16 +15,14 @@ import {ONE_MILLI,ONE_SECOND,ONE_MINUTE,ONE_HOUR} from "./util"
 
 export namespace DatetimeTicker {
   export interface Attrs extends CompositeTicker.Attrs {}
-
-  export interface Opts extends CompositeTicker.Opts {}
 }
 
 export interface DatetimeTicker extends DatetimeTicker.Attrs {}
 
 export class DatetimeTicker extends CompositeTicker {
 
-  constructor(attrs?: Partial<DatetimeTicker.Attrs>, opts?: DatetimeTicker.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<DatetimeTicker.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tickers/days_ticker.ts
+++ b/bokehjs/src/coffee/models/tickers/days_ticker.ts
@@ -35,16 +35,14 @@ export namespace DaysTicker {
   export interface Attrs extends SingleIntervalTicker.Attrs {
     days: number[]
   }
-
-  export interface Opts extends SingleIntervalTicker.Opts {}
 }
 
 export interface DaysTicker extends DaysTicker.Attrs {}
 
 export class DaysTicker extends SingleIntervalTicker {
 
-  constructor(attrs?: Partial<DaysTicker.Attrs>, opts?: DaysTicker.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<DaysTicker.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tickers/fixed_ticker.ts
+++ b/bokehjs/src/coffee/models/tickers/fixed_ticker.ts
@@ -5,16 +5,14 @@ export namespace FixedTicker {
   export interface Attrs extends ContinuousTicker.Attrs {
     ticks: number[]
   }
-
-  export interface Opts extends ContinuousTicker.Opts {}
 }
 
 export interface FixedTicker extends FixedTicker.Attrs {}
 
 export class FixedTicker extends ContinuousTicker {
 
-  constructor(attrs?: Partial<FixedTicker.Attrs>, opts?: FixedTicker.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<FixedTicker.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tickers/log_ticker.ts
+++ b/bokehjs/src/coffee/models/tickers/log_ticker.ts
@@ -3,16 +3,14 @@ import {AdaptiveTicker} from "./adaptive_ticker"
 
 export namespace LogTicker {
   export interface Attrs extends AdaptiveTicker.Attrs {}
-
-  export interface Opts extends AdaptiveTicker.Opts {}
 }
 
 export interface LogTicker extends LogTicker.Attrs {}
 
 export class LogTicker extends AdaptiveTicker {
 
-  constructor(attrs?: Partial<LogTicker.Attrs>, opts?: LogTicker.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<LogTicker.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tickers/mercator_ticker.ts
+++ b/bokehjs/src/coffee/models/tickers/mercator_ticker.ts
@@ -7,16 +7,14 @@ export namespace MercatorTicker {
   export interface Attrs extends BasicTicker.Attrs {
     dimension: LatLon | null | undefined
   }
-
-  export interface Opts extends BasicTicker.Opts {}
 }
 
 export interface MercatorTicker extends MercatorTicker.Attrs {}
 
 export class MercatorTicker extends BasicTicker {
 
-  constructor(attrs?: Partial<MercatorTicker.Attrs>, opts?: MercatorTicker.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<MercatorTicker.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tickers/months_ticker.ts
+++ b/bokehjs/src/coffee/models/tickers/months_ticker.ts
@@ -32,16 +32,14 @@ export namespace MonthsTicker {
   export interface Attrs extends SingleIntervalTicker.Attrs {
     months: number[]
   }
-
-  export interface Opts extends SingleIntervalTicker.Opts {}
 }
 
 export interface MonthsTicker extends MonthsTicker.Attrs {}
 
 export class MonthsTicker extends SingleIntervalTicker {
 
-  constructor(attrs?: Partial<MonthsTicker.Attrs>, opts?: MonthsTicker.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<MonthsTicker.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tickers/single_interval_ticker.ts
+++ b/bokehjs/src/coffee/models/tickers/single_interval_ticker.ts
@@ -9,16 +9,14 @@ export namespace SingleIntervalTicker {
   export interface Attrs extends ContinuousTicker.Attrs {
     interval: number
   }
-
-  export interface Opts extends ContinuousTicker.Opts {}
 }
 
 export interface SingleIntervalTicker extends SingleIntervalTicker.Attrs {}
 
 export class SingleIntervalTicker extends ContinuousTicker {
 
-  constructor(attrs?: Partial<SingleIntervalTicker.Attrs>, opts?: SingleIntervalTicker.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<SingleIntervalTicker.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tickers/ticker.ts
+++ b/bokehjs/src/coffee/models/tickers/ticker.ts
@@ -20,16 +20,14 @@ export type TickSpec<T> = {
 
 export namespace Ticker{
   export interface Attrs extends Model.Attrs {}
-
-  export interface Opts extends Model.Opts {}
 }
 
 export interface Ticker<T> extends Ticker.Attrs {}
 
 export abstract class Ticker<T> extends Model {
 
-  constructor(attrs?: Partial<Ticker.Attrs>, opts?: Ticker.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Ticker.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tickers/years_ticker.ts
+++ b/bokehjs/src/coffee/models/tickers/years_ticker.ts
@@ -4,16 +4,14 @@ import {last_year_no_later_than, ONE_YEAR} from "./util"
 
 export namespace YearsTicker {
   export interface Attrs extends SingleIntervalTicker.Attrs {}
-
-  export interface Opts extends SingleIntervalTicker.Opts {}
 }
 
 export interface YearsTicker extends YearsTicker.Attrs {}
 
 export class YearsTicker extends SingleIntervalTicker {
 
-  constructor(attrs?: Partial<YearsTicker.Attrs>, opts?: YearsTicker.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<YearsTicker.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tiles/bbox_tile_source.ts
+++ b/bokehjs/src/coffee/models/tiles/bbox_tile_source.ts
@@ -5,16 +5,14 @@ export namespace BBoxTileSource {
   export interface Attrs extends MercatorTileSource.Attrs {
     use_latlon: boolean
   }
-
-  export interface Opts extends MercatorTileSource.Opts {}
 }
 
 export interface BBoxTileSource extends BBoxTileSource.Attrs {}
 
 export class BBoxTileSource extends MercatorTileSource {
 
-  constructor(attrs?: Partial<BBoxTileSource.Attrs>, opts?: BBoxTileSource.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<BBoxTileSource.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tiles/mercator_tile_source.ts
+++ b/bokehjs/src/coffee/models/tiles/mercator_tile_source.ts
@@ -8,16 +8,14 @@ export namespace MercatorTileSource {
     snap_to_zoom: boolean
     wrap_around: boolean
   }
-
-  export interface Opts extends TileSource.Opts {}
 }
 
 export interface MercatorTileSource extends MercatorTileSource.Attrs {}
 
 export class MercatorTileSource extends TileSource {
 
-  constructor(attrs?: Partial<MercatorTileSource.Attrs>, opts?: MercatorTileSource.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<MercatorTileSource.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tiles/quadkey_tile_source.ts
+++ b/bokehjs/src/coffee/models/tiles/quadkey_tile_source.ts
@@ -2,16 +2,14 @@ import {MercatorTileSource} from './mercator_tile_source'
 
 export namespace QUADKEYTileSource {
   export interface Attrs extends MercatorTileSource.Attrs {}
-
-  export interface Opts extends MercatorTileSource.Opts {}
 }
 
 export interface QUADKEYTileSource extends QUADKEYTileSource.Attrs {}
 
 export class QUADKEYTileSource extends MercatorTileSource {
 
-  constructor(attrs?: Partial<QUADKEYTileSource.Attrs>, opts?: QUADKEYTileSource.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<QUADKEYTileSource.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tiles/tile_renderer.ts
+++ b/bokehjs/src/coffee/models/tiles/tile_renderer.ts
@@ -372,16 +372,14 @@ export namespace TileRenderer {
     tile_source: TileSource
     render_parents: boolean
   }
-
-  export interface Opts extends Renderer.Opts {}
 }
 
 export interface TileRenderer extends TileRenderer.Attrs {}
 
 export class TileRenderer extends Renderer {
 
-  constructor(attrs?: Partial<TileRenderer.Attrs>, opts?: TileRenderer.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<TileRenderer.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tiles/tile_source.ts
+++ b/bokehjs/src/coffee/models/tiles/tile_source.ts
@@ -19,16 +19,14 @@ export namespace TileSource {
     y_origin_offset: number
     initial_resolution: number
   }
-
-  export interface Opts extends Model.Opts {}
 }
 
 export interface TileSource extends TileSource.Attrs {}
 
 export abstract class TileSource extends Model {
 
-  constructor(attrs?: Partial<TileSource.Attrs>, opts?: TileSource.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<TileSource.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tiles/tms_tile_source.ts
+++ b/bokehjs/src/coffee/models/tiles/tms_tile_source.ts
@@ -2,16 +2,14 @@ import {MercatorTileSource} from './mercator_tile_source'
 
 export namespace TMSTileSource {
   export interface Attrs extends MercatorTileSource.Attrs {}
-
-  export interface Opts extends MercatorTileSource.Opts {}
 }
 
 export interface TMSTileSource extends TMSTileSource.Attrs {}
 
 export class TMSTileSource extends MercatorTileSource {
 
-  constructor(attrs?: Partial<TMSTileSource.Attrs>, opts?: TMSTileSource.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<TMSTileSource.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tiles/wmts_tile_source.ts
+++ b/bokehjs/src/coffee/models/tiles/wmts_tile_source.ts
@@ -2,16 +2,14 @@ import {MercatorTileSource} from './mercator_tile_source'
 
 export namespace WMTSTileSource {
   export interface Attrs extends MercatorTileSource.Attrs {}
-
-  export interface Opts extends MercatorTileSource.Opts {}
 }
 
 export interface WMTSTileSource extends WMTSTileSource.Attrs {}
 
 export class WMTSTileSource extends MercatorTileSource {
 
-  constructor(attrs?: Partial<WMTSTileSource.Attrs>, opts?: WMTSTileSource.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<WMTSTileSource.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/actions/action_tool.ts
+++ b/bokehjs/src/coffee/models/tools/actions/action_tool.ts
@@ -22,16 +22,14 @@ export abstract class ActionToolView extends ButtonToolView {
 
 export namespace ActionTool {
   export interface Attrs extends ButtonTool.Attrs {}
-
-  export interface Opts extends ButtonTool.Opts {}
 }
 
 export interface ActionTool extends ActionTool.Attrs {}
 
 export abstract class ActionTool extends ButtonTool {
 
-  constructor(attrs?: Partial<ActionTool.Attrs>, opts?: ActionTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<ActionTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/actions/help_tool.ts
+++ b/bokehjs/src/coffee/models/tools/actions/help_tool.ts
@@ -14,16 +14,14 @@ export namespace HelpTool {
     help_tooltip: string
     redirect: string
   }
-
-  export interface Opts extends ActionTool.Opts {}
 }
 
 export interface HelpTool extends HelpTool.Attrs {}
 
 export class HelpTool extends ActionTool {
 
-  constructor(attrs?: Partial<HelpTool.Attrs>, opts?: HelpTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<HelpTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/actions/redo_tool.ts
+++ b/bokehjs/src/coffee/models/tools/actions/redo_tool.ts
@@ -15,16 +15,14 @@ export class RedoToolView extends ActionToolView {
 
 export namespace RedoTool {
   export interface Attrs extends ActionTool.Attrs {}
-
-  export interface Opts extends ActionTool.Opts {}
 }
 
 export interface RedoTool extends RedoTool.Attrs {}
 
 export class RedoTool extends ActionTool {
 
-  constructor(attrs?: Partial<RedoTool.Attrs>, opts?: RedoTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<RedoTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/actions/reset_tool.ts
+++ b/bokehjs/src/coffee/models/tools/actions/reset_tool.ts
@@ -14,16 +14,14 @@ export class ResetToolView extends ActionToolView {
 
 export namespace ResetTool {
   export interface Attrs extends ActionTool.Attrs {}
-
-  export interface Opts extends ActionTool.Opts {}
 }
 
 export interface ResetTool extends ResetTool.Attrs {}
 
 export class ResetTool extends ActionTool {
 
-  constructor(attrs?: Partial<ResetTool.Attrs>, opts?: ResetTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<ResetTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/actions/save_tool.ts
+++ b/bokehjs/src/coffee/models/tools/actions/save_tool.ts
@@ -10,16 +10,14 @@ export class SaveToolView extends ActionToolView {
 
 export namespace SaveTool {
   export interface Attrs extends ActionTool.Attrs {}
-
-  export interface Opts extends ActionTool.Opts {}
 }
 
 export interface SaveTool extends SaveTool.Attrs {}
 
 export class SaveTool extends ActionTool {
 
-  constructor(attrs?: Partial<SaveTool.Attrs>, opts?: SaveTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<SaveTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/actions/undo_tool.ts
+++ b/bokehjs/src/coffee/models/tools/actions/undo_tool.ts
@@ -15,16 +15,14 @@ export class UndoToolView extends ActionToolView {
 
 export namespace UndoTool {
   export interface Attrs extends ActionTool.Attrs {}
-
-  export interface Opts extends ActionTool.Opts {}
 }
 
 export interface UndoTool extends UndoTool.Attrs {}
 
 export class UndoTool extends ActionTool {
 
-  constructor(attrs?: Partial<UndoTool.Attrs>, opts?: UndoTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<UndoTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/actions/zoom_in_tool.ts
+++ b/bokehjs/src/coffee/models/tools/actions/zoom_in_tool.ts
@@ -30,16 +30,14 @@ export namespace ZoomInTool {
     factor: number
     dimensions: Dimensions
   }
-
-  export interface Opts extends ActionTool.Opts {}
 }
 
 export interface ZoomInTool extends ZoomInTool.Attrs {}
 
 export class ZoomInTool extends ActionTool {
 
-  constructor(attrs?: Partial<ZoomInTool.Attrs>, opts?: ZoomInTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<ZoomInTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/actions/zoom_out_tool.ts
+++ b/bokehjs/src/coffee/models/tools/actions/zoom_out_tool.ts
@@ -31,16 +31,14 @@ export namespace ZoomOutTool {
     factor: number
     dimensions: Dimensions
   }
-
-  export interface Opts extends ActionTool.Opts {}
 }
 
 export interface ZoomOutTool extends ZoomOutTool.Attrs {}
 
 export class ZoomOutTool extends ActionTool {
 
-  constructor(attrs?: Partial<ZoomOutTool.Attrs>, opts?: ZoomOutTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<ZoomOutTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/button_tool.ts
+++ b/bokehjs/src/coffee/models/tools/button_tool.ts
@@ -39,16 +39,14 @@ export namespace ButtonTool {
   export interface Attrs extends Tool.Attrs {
     disabled: boolean
   }
-
-  export interface Opts extends Tool.Opts {}
 }
 
 export interface ButtonTool extends ButtonTool.Attrs {}
 
 export abstract class ButtonTool extends Tool {
 
-  constructor(attrs?: Partial<ButtonTool.Attrs>, opts?: ButtonTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<ButtonTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/src/coffee/models/tools/edit/box_edit_tool.ts
@@ -135,8 +135,6 @@ export namespace BoxEditTool {
     dimensions: Dimensions
     renderers: (GlyphRenderer & HasRectCDS)[]
   }
-
-  export interface Opts extends EditTool.Opts {}
 }
 
 export interface BoxEditTool extends BoxEditTool.Attrs {}
@@ -145,8 +143,8 @@ export class BoxEditTool extends EditTool {
 
   renderers: (GlyphRenderer & HasRectCDS)[]
 
-  constructor(attrs?: Partial<BoxEditTool.Attrs>, opts?: BoxEditTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<BoxEditTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/edit/edit_tool.ts
+++ b/bokehjs/src/coffee/models/tools/edit/edit_tool.ts
@@ -132,16 +132,14 @@ export namespace EditTool {
     empty_value: any
     renderers: (GlyphRenderer & HasCDS)[]
   }
-
-  export interface Opts extends GestureTool.Opts {}
 }
 
 export interface EditTool extends EditTool.Attrs {}
 
 export abstract class EditTool extends GestureTool {
 
-  constructor(attrs?: Partial<EditTool.Attrs>, opts?: EditTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<EditTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/edit/point_draw_tool.ts
+++ b/bokehjs/src/coffee/models/tools/edit/point_draw_tool.ts
@@ -89,8 +89,6 @@ export namespace PointDrawTool {
     drag: boolean
     renderers: (GlyphRenderer & HasCDS & HasXYGlyph)[]
   }
-
-  export interface Opts extends EditTool.Opts {}
 }
 
 export interface PointDrawTool extends PointDrawTool.Attrs {}
@@ -99,8 +97,8 @@ export class PointDrawTool extends EditTool {
 
   renderers: (GlyphRenderer & HasCDS & HasXYGlyph)[]
 
-  constructor(attrs?: Partial<PointDrawTool.Attrs>, opts?: PointDrawTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<PointDrawTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/src/coffee/models/tools/edit/poly_draw_tool.ts
@@ -194,7 +194,6 @@ export class PolyDrawToolView extends EditToolView {
       this._drawing = false;
     }
   }
-
 }
 
 export namespace PolyDrawTool {
@@ -203,7 +202,6 @@ export namespace PolyDrawTool {
     renderers: (GlyphRenderer & HasCDS & HasPolyGlyph)[]
   }
 
-  export interface Opts extends EditTool.Opts {}
 }
 
 export interface PolyDrawTool extends PolyDrawTool.Attrs {}
@@ -212,8 +210,8 @@ export class PolyDrawTool extends EditTool {
 
   renderers: (GlyphRenderer & HasCDS & HasPolyGlyph)[]
 
-  constructor(attrs?: Partial<PolyDrawTool.Attrs>, opts?: PolyDrawTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<PolyDrawTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/edit/poly_edit_tool.ts
+++ b/bokehjs/src/coffee/models/tools/edit/poly_edit_tool.ts
@@ -233,8 +233,6 @@ export namespace PolyEditTool {
     vertex_renderer: (GlyphRenderer & HasCDS & HasXYGlyph)
     renderers: (GlyphRenderer & HasCDS & HasPolyGlyph)[]
   }
-
-  export interface Opts extends EditTool.Opts {}
 }
 
 export interface PolyEditTool extends PolyEditTool.Attrs {}
@@ -243,8 +241,8 @@ export class PolyEditTool extends EditTool {
 
   renderers: (GlyphRenderer & HasCDS & HasPolyGlyph)[]
 
-  constructor(attrs?: Partial<PolyEditTool.Attrs>, opts?: PolyEditTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<PolyEditTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/gestures/box_select_tool.ts
+++ b/bokehjs/src/coffee/models/tools/gestures/box_select_tool.ts
@@ -101,16 +101,14 @@ export namespace BoxSelectTool {
     callback: any // XXX
     overlay: BoxAnnotation
   }
-
-  export interface Opts extends SelectTool.Opts {}
 }
 
 export interface BoxSelectTool extends BoxSelectTool.Attrs {}
 
 export class BoxSelectTool extends SelectTool {
 
-  constructor(attrs?: Partial<BoxSelectTool.Attrs>, opts?: BoxSelectTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<BoxSelectTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/gestures/box_zoom_tool.ts
+++ b/bokehjs/src/coffee/models/tools/gestures/box_zoom_tool.ts
@@ -171,16 +171,14 @@ export namespace BoxZoomTool {
     overlay: BoxAnnotation
     match_aspect: boolean
   }
-
-  export interface Opts extends GestureTool.Opts {}
 }
 
 export interface BoxZoomTool extends BoxZoomTool.Attrs {}
 
 export class BoxZoomTool extends GestureTool {
 
-  constructor(attrs?: Partial<BoxZoomTool.Attrs>, opts?: BoxZoomTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<BoxZoomTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/gestures/gesture_tool.ts
+++ b/bokehjs/src/coffee/models/tools/gestures/gesture_tool.ts
@@ -7,16 +7,14 @@ export abstract class GestureToolView extends ButtonToolView {
 
 export namespace GestureTool {
   export interface Attrs extends ButtonTool.Attrs {}
-
-  export interface Opts extends ButtonTool.Opts {}
 }
 
 export interface GestureTool extends GestureTool.Attrs {}
 
 export abstract class GestureTool extends ButtonTool {
 
-  constructor(attrs?: Partial<GestureTool.Attrs>, opts?: GestureTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<GestureTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/gestures/lasso_select_tool.ts
+++ b/bokehjs/src/coffee/models/tools/gestures/lasso_select_tool.ts
@@ -107,16 +107,14 @@ export namespace LassoSelectTool {
     callback: any // XXX
     overlay: PolyAnnotation
   }
-
-  export interface Opts extends SelectTool.Opts {}
 }
 
 export interface LassoSelectTool extends LassoSelectTool.Attrs {}
 
 export class LassoSelectTool extends SelectTool {
 
-  constructor(attrs?: Partial<LassoSelectTool.Attrs>, opts?: LassoSelectTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<LassoSelectTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/gestures/pan_tool.ts
+++ b/bokehjs/src/coffee/models/tools/gestures/pan_tool.ts
@@ -128,16 +128,14 @@ export namespace PanTool {
   export interface Attrs extends GestureTool.Attrs {
     dimensions: Dimensions
   }
-
-  export interface Opts extends GestureTool.Opts {}
 }
 
 export interface PanTool extends PanTool.Attrs {}
 
 export class PanTool extends GestureTool {
 
-  constructor(attrs?: Partial<PanTool.Attrs>, opts?: PanTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<PanTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/gestures/poly_select_tool.ts
+++ b/bokehjs/src/coffee/models/tools/gestures/poly_select_tool.ts
@@ -101,16 +101,14 @@ export namespace PolySelectTool {
     callback: any // XXX
     overlay: PolyAnnotation
   }
-
-  export interface Opts extends SelectTool.Opts {}
 }
 
 export interface PolySelectTool extends PolySelectTool.Attrs {}
 
 export class PolySelectTool extends SelectTool {
 
-  constructor(attrs?: Partial<PolySelectTool.Attrs>, opts?: PolySelectTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<PolySelectTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/gestures/select_tool.ts
+++ b/bokehjs/src/coffee/models/tools/gestures/select_tool.ts
@@ -122,16 +122,14 @@ export namespace SelectTool {
     renderers: DataRenderer[]
     names: string[]
   }
-
-  export interface Opts extends GestureTool.Opts {}
 }
 
 export interface SelectTool extends SelectTool.Attrs {}
 
 export abstract class SelectTool extends GestureTool {
 
-  constructor(attrs?: Partial<SelectTool.Attrs>, opts?: SelectTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<SelectTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/gestures/tap_tool.ts
+++ b/bokehjs/src/coffee/models/tools/gestures/tap_tool.ts
@@ -72,16 +72,14 @@ export namespace TapTool {
     behavior: "select" | "inspect"
     callback: any // XXX
   }
-
-  export interface Opts extends SelectTool.Opts {}
 }
 
 export interface TapTool extends TapTool.Attrs {}
 
 export class TapTool extends SelectTool {
 
-  constructor(attrs?: Partial<TapTool.Attrs>, opts?: TapTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<TapTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/gestures/wheel_pan_tool.ts
+++ b/bokehjs/src/coffee/models/tools/gestures/wheel_pan_tool.ts
@@ -90,16 +90,14 @@ export namespace WheelPanTool {
     dimension: Dimension
     speed: number
   }
-
-  export interface Opts extends GestureTool.Opts {}
 }
 
 export interface WheelPanTool extends WheelPanTool.Attrs {}
 
 export class WheelPanTool extends GestureTool {
 
-  constructor(attrs?: Partial<WheelPanTool.Attrs>, opts?: WheelPanTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<WheelPanTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/gestures/wheel_zoom_tool.ts
+++ b/bokehjs/src/coffee/models/tools/gestures/wheel_zoom_tool.ts
@@ -52,16 +52,14 @@ export namespace WheelZoomTool {
     dimensions: Dimensions
     speed: number
   }
-
-  export interface Opts extends GestureTool.Opts {}
 }
 
 export interface WheelZoomTool extends WheelZoomTool.Attrs {}
 
 export class WheelZoomTool extends GestureTool {
 
-  constructor(attrs?: Partial<WheelZoomTool.Attrs>, opts?: WheelZoomTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<WheelZoomTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/inspectors/crosshair_tool.ts
+++ b/bokehjs/src/coffee/models/tools/inspectors/crosshair_tool.ts
@@ -46,16 +46,14 @@ export namespace CrosshairTool {
     render_mode: RenderMode
     spans: {width: Span, height: Span}
   }
-
-  export interface Opts extends InspectTool.Opts {}
 }
 
 export interface CrosshairTool extends CrosshairTool.Attrs {}
 
 export class CrosshairTool extends InspectTool {
 
-  constructor(attrs?: Partial<CrosshairTool.Attrs>, opts?: CrosshairTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<CrosshairTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/inspectors/hover_tool.ts
+++ b/bokehjs/src/coffee/models/tools/inspectors/hover_tool.ts
@@ -426,16 +426,14 @@ export namespace HoverTool {
     attachment: TooltipAttachment
     callback: any // XXX
   }
-
-  export interface Opts extends InspectTool.Opts {}
 }
 
 export interface HoverTool extends HoverTool.Attrs {}
 
 export class HoverTool extends InspectTool {
 
-  constructor(attrs?: Partial<HoverTool.Attrs>, opts?: HoverTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<HoverTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/inspectors/inspect_tool.ts
+++ b/bokehjs/src/coffee/models/tools/inspectors/inspect_tool.ts
@@ -11,16 +11,14 @@ export namespace InspectTool {
   export interface Attrs extends ButtonTool.Attrs {
     toggleable: boolean
   }
-
-  export interface Opts extends ButtonTool.Opts {}
 }
 
 export interface InspectTool extends InspectTool.Attrs {}
 
 export abstract class InspectTool extends ButtonTool {
 
-  constructor(attrs?: Partial<InspectTool.Attrs>, opts?: InspectTool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<InspectTool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/tool.ts
+++ b/bokehjs/src/coffee/models/tools/tool.ts
@@ -66,16 +66,14 @@ export namespace Tool {
   export interface Attrs extends Model.Attrs {
     active: boolean
   }
-
-  export interface Opts extends Model.Opts {}
 }
 
 export interface Tool extends Tool.Attrs {}
 
 export abstract class Tool extends Model {
 
-  constructor(attrs?: Partial<Tool.Attrs>, opts?: Tool.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Tool.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/tool_proxy.ts
+++ b/bokehjs/src/coffee/models/tools/tool_proxy.ts
@@ -11,16 +11,14 @@ export namespace ToolProxy {
     active: boolean
     disabled: boolean
   }
-
-  export interface Opts extends Model.Opts {}
 }
 
 export interface ToolProxy extends ToolProxy.Attrs {}
 
 export class ToolProxy extends Model {
 
-  constructor(attrs?: Partial<ToolProxy.Attrs>, opts?: ToolProxy.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<ToolProxy.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/toolbar.ts
+++ b/bokehjs/src/coffee/models/tools/toolbar.ts
@@ -24,16 +24,14 @@ export namespace Toolbar {
     active_scroll: Scroll | "auto"
     active_tap: Tap | "auto"
   }
-
-  export interface Opts extends ToolbarBase.Opts {}
 }
 
 export interface Toolbar extends Toolbar.Attrs {}
 
 export class Toolbar extends ToolbarBase {
 
-  constructor(attrs?: Partial<Toolbar.Attrs>, opts?: Toolbar.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Toolbar.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/toolbar_base.ts
+++ b/bokehjs/src/coffee/models/tools/toolbar_base.ts
@@ -92,16 +92,14 @@ export namespace ToolbarBase {
     help: Tool[]
     toolbar_location: Location
   }
-
-  export interface Opts extends Model.Opts {}
 }
 
 export interface ToolbarBase extends ToolbarBase.Attrs {}
 
 export class ToolbarBase extends Model {
 
-  constructor(attrs?: Partial<ToolbarBase.Attrs>, opts?: ToolbarBase.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<ToolbarBase.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/tools/toolbar_box.ts
+++ b/bokehjs/src/coffee/models/tools/toolbar_box.ts
@@ -17,16 +17,14 @@ import {build_views, remove_views} from "core/build_views"
 
 export namespace ProxyToolbar {
   export interface Attrs extends ToolbarBase.Attrs {}
-
-  export interface Opts extends ToolbarBase.Opts {}
 }
 
 export interface ProxyToolbar extends ProxyToolbar.Attrs {}
 
 export class ProxyToolbar extends ToolbarBase {
 
-  constructor(attrs?: Partial<ProxyToolbar.Attrs>, opts?: ProxyToolbar.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<ProxyToolbar.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {
@@ -217,15 +215,14 @@ export namespace ToolbarBox {
     toolbar_location: Location
   }
 
-  export interface Opts extends LayoutDOM.Opts {}
 }
 
 export interface ToolbarBox extends ToolbarBox.Attrs {}
 
 export class ToolbarBox extends LayoutDOM {
 
-  constructor(attrs?: Partial<ToolbarBox.Attrs>, opts?: ToolbarBox.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<ToolbarBox.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/transforms/customjs_transform.ts
+++ b/bokehjs/src/coffee/models/transforms/customjs_transform.ts
@@ -11,16 +11,14 @@ export namespace CustomJSTransform {
     func: string
     v_func: string
   }
-
-  export interface Opts extends Transform.Opts {}
 }
 
 export interface CustomJSTransform extends CustomJSTransform.Attrs {}
 
 export class CustomJSTransform extends Transform {
 
-  constructor(attrs?: Partial<CustomJSTransform.Attrs>, opts?: CustomJSTransform.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<CustomJSTransform.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/transforms/dodge.ts
+++ b/bokehjs/src/coffee/models/transforms/dodge.ts
@@ -9,16 +9,14 @@ export namespace Dodge {
     value: number
     range: Range
   }
-
-  export interface Opts extends Transform.Opts {}
 }
 
 export interface Dodge extends Dodge.Attrs {}
 
 export class Dodge extends Transform {
 
-  constructor(attrs?: Partial<Dodge.Attrs>, opts?: Dodge.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Dodge.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/transforms/interpolator.ts
+++ b/bokehjs/src/coffee/models/transforms/interpolator.ts
@@ -11,16 +11,14 @@ export namespace Interpolator {
     data: ColumnarDataSource
     clip: boolean
   }
-
-  export interface Opts extends Transform.Opts {}
 }
 
 export interface Interpolator extends Interpolator.Attrs {}
 
 export class Interpolator extends Transform {
 
-  constructor(attrs?: Partial<Interpolator.Attrs>, opts?: Interpolator.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Interpolator.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/transforms/jitter.ts
+++ b/bokehjs/src/coffee/models/transforms/jitter.ts
@@ -13,16 +13,14 @@ export namespace Jitter {
     distribution: Distribution
     range: Range
   }
-
-  export interface Opts extends Transform.Opts {}
 }
 
 export interface Jitter extends Jitter.Attrs {}
 
 export class Jitter extends Transform {
 
-  constructor(attrs?: Partial<Jitter.Attrs>, opts?: Jitter.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Jitter.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/transforms/linear_interpolator.ts
+++ b/bokehjs/src/coffee/models/transforms/linear_interpolator.ts
@@ -4,16 +4,14 @@ import {Interpolator} from "./interpolator"
 
 export namespace LinearInterpolator {
   export interface Attrs extends Interpolator.Attrs {}
-
-  export interface Opts extends Interpolator.Opts {}
 }
 
 export interface LinearInterpolator extends LinearInterpolator.Attrs {}
 
 export class LinearInterpolator extends Interpolator {
 
-  constructor(attrs?: Partial<LinearInterpolator.Attrs>, opts?: LinearInterpolator.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<LinearInterpolator.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/transforms/step_interpolator.ts
+++ b/bokehjs/src/coffee/models/transforms/step_interpolator.ts
@@ -8,16 +8,14 @@ export namespace StepInterpolator {
   export interface Attrs extends Interpolator.Attrs {
     mode: StepMode
   }
-
-  export interface Opts extends Interpolator.Opts {}
 }
 
 export interface StepInterpolator extends StepInterpolator.Attrs {}
 
 export class StepInterpolator extends Interpolator {
 
-  constructor(attrs?: Partial<StepInterpolator.Attrs>, opts?: StepInterpolator.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<StepInterpolator.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/transforms/transform.ts
+++ b/bokehjs/src/coffee/models/transforms/transform.ts
@@ -3,16 +3,14 @@ import {Model} from "../../model"
 
 export namespace Transform {
   export interface Attrs extends Model.Attrs {}
-
-  export interface Opts extends Model.Opts {}
 }
 
 export interface Transform extends Transform.Attrs {}
 
 export abstract class Transform extends Model {
 
-  constructor(attrs?: Partial<Transform.Attrs>, opts?: Transform.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Transform.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/abstract_button.ts
+++ b/bokehjs/src/coffee/models/widgets/abstract_button.ts
@@ -71,16 +71,14 @@ export namespace AbstractButton {
     button_type: ButtonType
     callback: any // XXX
   }
-
-  export interface Opts extends Widget.Opts {}
 }
 
 export interface AbstractButton extends AbstractButton.Attrs {}
 
 export abstract class AbstractButton extends Widget {
 
-  constructor(attrs?: Partial<AbstractButton.Attrs>, opts?: AbstractButton.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<AbstractButton.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/abstract_icon.ts
+++ b/bokehjs/src/coffee/models/widgets/abstract_icon.ts
@@ -6,16 +6,14 @@ export abstract class AbstractIconView extends WidgetView {
 
 export namespace AbstractIcon {
   export interface Attrs extends Widget.Attrs {}
-
-  export interface Opts extends Widget.Opts {}
 }
 
 export interface AbstractIcon extends AbstractIcon.Attrs {}
 
 export abstract class AbstractIcon extends Widget {
 
-  constructor(attrs?: Partial<AbstractIcon.Attrs>, opts?: AbstractIcon.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<AbstractIcon.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/abstract_slider.ts
+++ b/bokehjs/src/coffee/models/widgets/abstract_slider.ts
@@ -211,16 +211,14 @@ export namespace AbstractSlider {
     callback_policy: SliderCallbackPolicy
     bar_color: Color
   }
-
-  export interface Opts extends Widget.Opts {}
 }
 
 export interface AbstractSlider extends AbstractSlider.Attrs {}
 
 export abstract class AbstractSlider extends Widget {
 
-  constructor(attrs?: Partial<AbstractSlider.Attrs>, opts?: AbstractSlider.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<AbstractSlider.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/autocomplete_input.ts
+++ b/bokehjs/src/coffee/models/widgets/autocomplete_input.ts
@@ -102,16 +102,14 @@ export namespace AutocompleteInput {
   export interface Attrs extends TextInput.Attrs {
     completions: string[]
   }
-
-  export interface Opts extends TextInput.Opts {}
 }
 
 export interface AutocompleteInput extends AutocompleteInput.Attrs {}
 
 export class AutocompleteInput extends TextInput {
 
-  constructor(attrs?: Partial<AutocompleteInput.Attrs>, opts?: AutocompleteInput.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<AutocompleteInput.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/button.ts
+++ b/bokehjs/src/coffee/models/widgets/button.ts
@@ -18,16 +18,14 @@ export namespace Button {
   export interface Attrs extends AbstractButton.Attrs {
     clicks: number
   }
-
-  export interface Opts extends AbstractButton.Opts {}
 }
 
 export interface Button extends Button.Attrs {}
 
 export class Button extends AbstractButton {
 
-  constructor(attrs?: Partial<Button.Attrs>, opts?: Button.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Button.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/checkbox_button_group.ts
+++ b/bokehjs/src/coffee/models/widgets/checkbox_button_group.ts
@@ -59,16 +59,14 @@ export namespace CheckboxButtonGroup {
     button_type: ButtonType
     callback: any // XXX
   }
-
-  export interface Opts extends Widget.Opts {}
 }
 
 export interface CheckboxButtonGroup extends CheckboxButtonGroup.Attrs {}
 
 export class CheckboxButtonGroup extends Widget {
 
-  constructor(attrs?: Partial<CheckboxButtonGroup.Attrs>, opts?: CheckboxButtonGroup.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<CheckboxButtonGroup.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/checkbox_group.ts
+++ b/bokehjs/src/coffee/models/widgets/checkbox_group.ts
@@ -69,16 +69,14 @@ export namespace CheckboxGroup {
     inline: boolean
     callback: any // XXX
   }
-
-  export interface Opts extends Widget.Opts {}
 }
 
 export interface CheckboxGroup extends CheckboxGroup.Attrs {}
 
 export class CheckboxGroup extends Widget {
 
-  constructor(attrs?: Partial<CheckboxGroup.Attrs>, opts?: CheckboxGroup.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<CheckboxGroup.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/date_picker.ts
+++ b/bokehjs/src/coffee/models/widgets/date_picker.ts
@@ -93,16 +93,14 @@ export namespace DatePicker {
     min_date: string
     max_date: string
   }
-
-  export interface Opts extends InputWidget.Opts {}
 }
 
 export interface DatePicker extends DatePicker.Attrs {}
 
 export class DatePicker extends InputWidget {
 
-  constructor(attrs?: Partial<DatePicker.Attrs>, opts?: DatePicker.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<DatePicker.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/date_range_slider.ts
+++ b/bokehjs/src/coffee/models/widgets/date_range_slider.ts
@@ -22,16 +22,14 @@ export class DateRangeSliderView extends AbstractSliderView {
 
 export namespace DateRangeSlider {
   export interface Attrs extends AbstractSlider.Attrs {}
-
-  export interface Opts extends AbstractSlider.Opts {}
 }
 
 export interface DateRangeSlider extends DateRangeSlider.Attrs {}
 
 export class DateRangeSlider extends AbstractSlider {
 
-  constructor(attrs?: Partial<DateRangeSlider.Attrs>, opts?: DateRangeSlider.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<DateRangeSlider.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/date_slider.ts
+++ b/bokehjs/src/coffee/models/widgets/date_slider.ts
@@ -22,16 +22,14 @@ export class DateSliderView extends AbstractSliderView {
 
 export namespace DateSlider {
   export interface Attrs extends AbstractSlider.Attrs {}
-
-  export interface Opts extends AbstractSlider.Opts {}
 }
 
 export interface DateSlider extends DateSlider.Attrs {}
 
 export class DateSlider extends AbstractSlider {
 
-  constructor(attrs?: Partial<DateSlider.Attrs>, opts?: DateSlider.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<DateSlider.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/div.ts
+++ b/bokehjs/src/coffee/models/widgets/div.ts
@@ -21,16 +21,14 @@ export namespace Div {
   export interface Attrs extends Markup.Attrs {
     render_as_text: boolean
   }
-
-  export interface Opts extends Markup.Opts {}
 }
 
 export interface Div extends Div.Attrs {}
 
 export class Div extends Markup {
 
-  constructor(attrs?: Partial<Div.Attrs>, opts?: Div.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Div.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/dropdown.ts
+++ b/bokehjs/src/coffee/models/widgets/dropdown.ts
@@ -96,8 +96,6 @@ export namespace Dropdown {
     default_value: string
     menu: ([string, string] | null)[]
   }
-
-  export interface Opts extends AbstractButton.Opts {}
 }
 
 export interface Dropdown extends Dropdown.Attrs {
@@ -106,8 +104,8 @@ export interface Dropdown extends Dropdown.Attrs {
 
 export class Dropdown extends AbstractButton {
 
-  constructor(attrs?: Partial<Dropdown.Attrs>, opts?: Dropdown.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Dropdown.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/input_widget.ts
+++ b/bokehjs/src/coffee/models/widgets/input_widget.ts
@@ -15,16 +15,14 @@ export namespace InputWidget {
     title: string
     callback: any | null // TODO
   }
-
-  export interface Opts extends Widget.Opts {}
 }
 
 export interface InputWidget extends InputWidget.Attrs {}
 
 export class InputWidget extends Widget {
 
-  constructor(attrs?: Partial<InputWidget.Attrs>, opts?: InputWidget.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<InputWidget.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/markup.ts
+++ b/bokehjs/src/coffee/models/widgets/markup.ts
@@ -37,16 +37,14 @@ export namespace Markup {
     text: string
     style: {[key: string]: string}
   }
-
-  export interface Opts extends Widget.Opts {}
 }
 
 export interface Markup extends Markup.Attrs {}
 
 export class Markup extends Widget {
 
-  constructor(attrs?: Partial<Markup.Attrs>, opts?: Markup.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Markup.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/multiselect.ts
+++ b/bokehjs/src/coffee/models/widgets/multiselect.ts
@@ -94,16 +94,14 @@ export namespace MultiSelect {
     options: string[]
     size: number
   }
-
-  export interface Opts extends InputWidget.Opts {}
 }
 
 export interface MultiSelect extends MultiSelect.Attrs {}
 
 export class MultiSelect extends InputWidget {
 
-  constructor(attrs?: Partial<MultiSelect.Attrs>, opts?: MultiSelect.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<MultiSelect.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/panel.ts
+++ b/bokehjs/src/coffee/models/widgets/panel.ts
@@ -19,16 +19,14 @@ export namespace Panel {
     child: LayoutDOM
     closable: boolean
   }
-
-  export interface Opts extends Widget.Opts {}
 }
 
 export interface Panel extends Panel.Attrs {}
 
 export class Panel extends Widget {
 
-  constructor(attrs?: Partial<Panel.Attrs>, opts?: Panel.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Panel.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/paragraph.ts
+++ b/bokehjs/src/coffee/models/widgets/paragraph.ts
@@ -15,16 +15,14 @@ export class ParagraphView extends MarkupView {
 
 export namespace Paragraph {
   export interface Attrs extends Markup.Attrs {}
-
-  export interface Opts extends Markup.Opts {}
 }
 
 export interface Paragraph extends Paragraph.Attrs {}
 
 export class Paragraph extends Markup {
 
-  constructor(attrs?: Partial<Paragraph.Attrs>, opts?: Paragraph.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Paragraph.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/password_input.ts
+++ b/bokehjs/src/coffee/models/widgets/password_input.ts
@@ -12,16 +12,14 @@ export class PasswordInputView extends TextInputView {
 
 export namespace PasswordInput {
   export interface Attrs extends TextInput.Attrs {}
-
-  export interface Opts extends TextInput.Opts {}
 }
 
 export interface PasswordInput extends PasswordInput.Attrs {}
 
 export class PasswordInput extends TextInput {
 
-  constructor(attrs?: Partial<PasswordInput.Attrs>, opts?: PasswordInput.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<PasswordInput.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/pretext.ts
+++ b/bokehjs/src/coffee/models/widgets/pretext.ts
@@ -14,16 +14,14 @@ export class PreTextView extends MarkupView {
 
 export namespace PreText {
   export interface Attrs extends Markup.Attrs {}
-
-  export interface Opts extends Markup.Opts {}
 }
 
 export interface PreText extends PreText.Attrs {}
 
 export class PreText extends Markup {
 
-  constructor(attrs?: Partial<PreText.Attrs>, opts?: PreText.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<PreText.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/radio_button_group.ts
+++ b/bokehjs/src/coffee/models/widgets/radio_button_group.ts
@@ -63,16 +63,14 @@ export namespace RadioButtonGroup {
     button_type: ButtonType
     callback: any // XXX
   }
-
-  export interface Opts extends Widget.Opts {}
 }
 
 export interface RadioButtonGroup extends RadioButtonGroup.Attrs {}
 
 export class RadioButtonGroup extends Widget {
 
-  constructor(attrs?: Partial<RadioButtonGroup.Attrs>, opts?: RadioButtonGroup.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<RadioButtonGroup.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/radio_group.ts
+++ b/bokehjs/src/coffee/models/widgets/radio_group.ts
@@ -70,16 +70,14 @@ export namespace RadioGroup {
     inline: boolean
     callback: any // XXX
   }
-
-  export interface Opts extends Widget.Opts {}
 }
 
 export interface RadioGroup extends RadioGroup.Attrs {}
 
 export class RadioGroup extends Widget {
 
-  constructor(attrs?: Partial<RadioGroup.Attrs>, opts?: RadioGroup.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<RadioGroup.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/range_slider.ts
+++ b/bokehjs/src/coffee/models/widgets/range_slider.ts
@@ -22,16 +22,14 @@ export class RangeSliderView extends AbstractSliderView {
 
 export namespace RangeSlider {
   export interface Attrs extends AbstractSlider.Attrs {}
-
-  export interface Opts extends AbstractSlider.Opts {}
 }
 
 export interface RangeSlider extends RangeSlider.Attrs {}
 
 export class RangeSlider extends AbstractSlider {
 
-  constructor(attrs?: Partial<RangeSlider.Attrs>, opts?: RangeSlider.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<RangeSlider.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/selectbox.ts
+++ b/bokehjs/src/coffee/models/widgets/selectbox.ts
@@ -76,16 +76,14 @@ export namespace Select {
     value: string
     options: string[] | {[key: string]: string | [string, string]}
   }
-
-  export interface Opts extends InputWidget.Opts {}
 }
 
 export interface Select extends Select.Attrs {}
 
 export class Select extends InputWidget {
 
-  constructor(attrs?: Partial<Select.Attrs>, opts?: Select.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Select.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/slider.ts
+++ b/bokehjs/src/coffee/models/widgets/slider.ts
@@ -25,16 +25,14 @@ export class SliderView extends AbstractSliderView {
 
 export namespace Slider {
   export interface Attrs extends AbstractSlider.Attrs {}
-
-  export interface Opts extends AbstractSlider.Opts {}
 }
 
 export interface Slider extends Slider.Attrs {}
 
 export class Slider extends AbstractSlider {
 
-  constructor(attrs?: Partial<Slider.Attrs>, opts?: Slider.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Slider.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/tables/data_table.ts
+++ b/bokehjs/src/coffee/models/widgets/tables/data_table.ts
@@ -272,16 +272,14 @@ export namespace DataTable {
     row_headers: boolean
     scroll_to_selection: boolean
   }
-
-  export interface Opts extends TableWidget.Opts {}
 }
 
 export interface DataTable extends DataTable.Attrs {}
 
 export class DataTable extends TableWidget {
 
-  constructor(attrs?: Partial<DataTable.Attrs>, opts?: DataTable.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<DataTable.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/tables/table_column.ts
+++ b/bokehjs/src/coffee/models/widgets/tables/table_column.ts
@@ -17,16 +17,14 @@ export namespace TableColumn {
     sortable: boolean
     default_sort: "ascending" | "descending"
   }
-
-  export interface Opts extends Model.Opts {}
 }
 
 export interface TableColumn extends TableColumn.Attrs {}
 
 export class TableColumn extends Model {
 
-  constructor(attrs?: Partial<TableColumn.Attrs>, opts?: TableColumn.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<TableColumn.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/tables/table_widget.ts
+++ b/bokehjs/src/coffee/models/widgets/tables/table_widget.ts
@@ -8,16 +8,14 @@ export namespace TableWidget {
     source: ColumnarDataSource
     view: CDSView
   }
-
-  export interface Opts extends Widget.Opts {}
 }
 
 export interface TableWidget extends TableWidget.Attrs {}
 
 export class TableWidget extends Widget {
 
-  constructor(attrs?: Partial<TableWidget.Attrs>, opts?: TableWidget.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<TableWidget.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/tabs.ts
+++ b/bokehjs/src/coffee/models/widgets/tabs.ts
@@ -70,16 +70,14 @@ export namespace Tabs {
     active: number
     callback: any // XXX
   }
-
-  export interface Opts extends Widget.Opts {}
 }
 
 export interface Tabs extends Tabs.Attrs {}
 
 export class Tabs extends Widget {
 
-  constructor(attrs?: Partial<Tabs.Attrs>, opts?: Tabs.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Tabs.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/text_input.ts
+++ b/bokehjs/src/coffee/models/widgets/text_input.ts
@@ -62,16 +62,14 @@ export namespace TextInput {
     value: string
     placeholder: string
   }
-
-  export interface Opts extends InputWidget.Opts {}
 }
 
 export interface TextInput extends TextInput.Attrs {}
 
 export class TextInput extends InputWidget {
 
-  constructor(attrs?: Partial<TextInput.Attrs>, opts?: TextInput.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<TextInput.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/toggle.ts
+++ b/bokehjs/src/coffee/models/widgets/toggle.ts
@@ -22,16 +22,14 @@ export namespace Toggle {
   export interface Attrs extends AbstractButton.Attrs {
     active: boolean
   }
-
-  export interface Opts extends AbstractButton.Opts {}
 }
 
 export interface Toggle extends Toggle.Attrs {}
 
 export class Toggle extends AbstractButton {
 
-  constructor(attrs?: Partial<Toggle.Attrs>, opts?: Toggle.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Toggle.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/src/coffee/models/widgets/widget.ts
+++ b/bokehjs/src/coffee/models/widgets/widget.ts
@@ -30,16 +30,14 @@ export abstract class WidgetView extends LayoutDOMView {
 
 export namespace Widget {
   export interface Attrs extends LayoutDOM.Attrs {}
-
-  export interface Opts extends LayoutDOM.Opts {}
 }
 
 export interface Widget extends Widget.Attrs {}
 
 export abstract class Widget extends LayoutDOM {
 
-  constructor(attrs?: Partial<Widget.Attrs>, opts?: Widget.Opts) {
-    super(attrs, opts)
+  constructor(attrs?: Partial<Widget.Attrs>) {
+    super(attrs)
   }
 
   static initClass(): void {

--- a/bokehjs/test/defaults.ts
+++ b/bokehjs/test/defaults.ts
@@ -224,7 +224,7 @@ describe("Defaults", () => {
     const all_view_model_names = concat([keys(models_defaults), keys(widget_defaults)])
     for (const name of all_view_model_names) {
       const model = Models(name)
-      const instance = new model({}, {silent: true, defer_initialization: true})
+      const instance = new model({__deferred__: true})
       const attrs = instance.attributes_as_json(true, deep_value_to_json)
       strip_ids(attrs)
 


### PR DESCRIPTION
Previously we had `new Model(attrs, opts)`, now there is `new Model(attrs)`. `opts` was only used for deferred initialization. The best solution would be to have multiple constructors, but that's not supported by TypeScript. This approach seems a bit hackinsh, but at least we don't have to define `Opts` interface for all models. Also, having models configurable in general wasn't the best idea from the API design standpoint.

addresses #6481 
