### PR TITLE
fix for issue #7602: some loggers are named after __file__ instead of __name__

### DIFF
--- a/bokeh/core/validation/check.py
+++ b/bokeh/core/validation/check.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import
 
 import logging
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 def check_integrity(models):
     ''' Apply validation and integrity checks to a collection of Bokeh models.

--- a/bokeh/document/document.py
+++ b/bokeh/document/document.py
@@ -17,7 +17,7 @@ figure below:
 from __future__ import absolute_import
 
 import logging
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 from collections import defaultdict
 from json import loads

--- a/bokeh/events.py
+++ b/bokeh/events.py
@@ -49,7 +49,7 @@ event object that triggered the callback.
 from __future__ import absolute_import
 
 import logging
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 from .util.future import with_metaclass
 

--- a/bokeh/model.py
+++ b/bokeh/model.py
@@ -5,7 +5,7 @@ a Bokeh |Document|.
 from __future__ import absolute_import, print_function
 
 import logging
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 from json import loads
 from operator import itemgetter


### PR DESCRIPTION
fix for issue #7602: a few loggers are named after `__file__` instead of `__name__`