### PR TITLE
Address leaking memory

### DIFF
--- a/bokeh/command/subcommands/tests/test_serve.py
+++ b/bokeh/command/subcommands/tests/test_serve.py
@@ -132,6 +132,13 @@ def test_args():
             default=None,
         )),
 
+        ('--mem-log-frequency', dict(
+            metavar='MILLISECONDS',
+            type=int,
+            help="How often to log memory usage information",
+            default=None,
+        )),
+
         ('--use-xheaders', dict(
             action='store_true',
             help="Prefer X-headers for IP/protocol information",

--- a/bokeh/document/document.py
+++ b/bokeh/document/document.py
@@ -400,6 +400,26 @@ class Document(object):
         finally:
             self._pop_all_models_freeze()
 
+    def destroy(self, session):
+        self.remove_on_change(session)
+
+        # probably better to implement a destroy protocol on models to
+        # untangle everything, then the collect below might not be needed
+        for m in self._all_models.values():
+            m._document = None
+            del m
+
+        self._roots = []
+        self._all_models = None
+        self._all_models_by_name = None
+        self._theme = None
+        self._template = None
+        self._session_context = None
+        self.delete_modules()
+
+        import gc
+        gc.collect()
+
     def delete_modules(self):
         ''' Clean up after any modules created by this Document when its session is
         destroyed.

--- a/bokeh/server/session.py
+++ b/bokeh/server/session.py
@@ -115,9 +115,12 @@ class ServerSession(object):
 
     def destroy(self):
         self._destroyed = True
-        self._document.delete_modules()
-        self._document.remove_on_change(self)
+
+        self._document.destroy(self)
+        del self._document
+
         self._callbacks.remove_all_callbacks()
+        del self._callbacks
 
     def request_expiration(self):
         """ Used in test suite for now. Forces immediate expiration if no connections."""

--- a/bokeh/server/tests/test_server.py
+++ b/bokeh/server/tests/test_server.py
@@ -159,6 +159,11 @@ def test__lifecycle_hooks():
         server_doc = server_session.document
         assert len(server_doc.roots) == 1
 
+        # we have to capture these here for examination later, since after
+        # the session is closed, doc.roots will be emptied
+        client_hook_list = client_doc.roots[0]
+        server_hook_list = server_doc.roots[0]
+
         client_session.close()
         # expire the session quickly rather than after the
         # usual timeout
@@ -183,8 +188,6 @@ def test__lifecycle_hooks():
                              "session_destroyed",
                              "server_unloaded"]
 
-    client_hook_list = client_doc.roots[0]
-    server_hook_list = server_doc.roots[0]
     assert handler.load_count == 1
     assert handler.unload_count == 1
     # this is 3 instead of 6 because locked callbacks on destroyed sessions

--- a/bokeh/server/tests/test_session.py
+++ b/bokeh/server/tests/test_session.py
@@ -26,16 +26,12 @@ def test_subscribe():
     s.unsubscribe('connection2')
     assert s.connection_count == 0
 
-def test_destroy():
+def test_destroy_calls():
     d = Document()
     s = bss.ServerSession('some-id', d, 'ioloop')
     with mock.patch('bokeh.document.Document.delete_modules') as docdm:
-        s.destroy()
-        assert s.destroyed
+        with mock.patch('bokeh.document.Document.remove_on_change') as docroc:
+            s.destroy()
+            assert s.destroyed
+            docroc.assert_called_with(s)
         docdm.assert_called_once()
-
-    s = bss.ServerSession('some-id', d, 'ioloop')
-    with mock.patch('bokeh.document.Document.remove_on_change') as docroc:
-        s.destroy()
-        assert s.destroyed
-        docroc.assert_called_with(s)

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -18,7 +18,6 @@ from ..application import Application
 from ..resources import Resources
 from ..settings import settings
 from ..util.dependencies import import_optional
-from ..util.string import format_docstring
 
 from .application_context import ApplicationContext
 from .connection import ServerConnection
@@ -26,15 +25,15 @@ from .urls import per_app_patterns, toplevel_patterns
 from .views.root_handler import RootHandler
 from .views.static_handler import StaticHandler
 
-DEFAULT_KEEP_ALIVE_MS      = 37000  # heroku, nginx default to 60s timeout, so use less than that
+# Unfortuntely we can't yet use format_docstring to keep these automatically in sync in
+# the class docstring because Python 2 does not allow setting class.__doc__ (works with
+# Bokeh model classes because they are metaclasses)
 DEFAULT_CHECK_UNUSED_MS    = 17000
-DEFAULT_UNUSED_LIFETIME_MS = 15000
-DEFAULT_STATS_LOG_FREQ_MS  = 15000
+DEFAULT_KEEP_ALIVE_MS      = 37000  # heroku, nginx default to 60s timeout, so use less than that
 DEFAULT_MEM_LOG_FREQ_MS    = 0
+DEFAULT_STATS_LOG_FREQ_MS  = 15000
+DEFAULT_UNUSED_LIFETIME_MS = 15000
 
-# This is only needed because {} is alsp use for string formatting, so calling .format on
-# the docstring below will choke with '/' as an unrecognized key otherwise
-_DEFAULT_APP_MAP = "{ '/' : applications }"
 
 class BokehTornado(TornadoApplication):
     ''' A Tornado Application used to implement the Bokeh Server.
@@ -48,7 +47,7 @@ class BokehTornado(TornadoApplication):
 
             .. code-block:: python
 
-                applications = {DEFAULT_APP_MAP}
+                applications = { '/' : applications }
 
             When a connection comes in to a given path, the associate
             Application is used to generate a new document for the session.
@@ -92,23 +91,23 @@ class BokehTornado(TornadoApplication):
             (default: True)
 
         keep_alive_milliseconds (int, optional) :
-            Number of milliseconds between keep-alive pings (default: {DEFAULT_KEEP_ALIVE_MS})
+            Number of milliseconds between keep-alive pings (default: 37000)
 
             Pings normally required to keep the websocket open. Set to 0 to
             disable pings.
 
         check_unused_sessions_milliseconds (int, optional) :
             Number of milliseconds between checking for unused sessions
-            (default: {DEFAULT_CHECK_UNUSED_MS})
+            (default: 17000)
 
         unused_session_lifetime_milliseconds (int, optional) :
-            Number of milliseconds for unused session lifetime (default: {DEFAULT_UNUSED_LIFETIME_MS})
+            Number of milliseconds for unused session lifetime (default: 15000)
 
         stats_log_frequency_milliseconds (int, optional) :
-            Number of milliseconds between logging stats (default: {DEFAULT_STATS_LOG_FREQ_MS})
+            Number of milliseconds between logging stats (default: 15000)
 
         mem_log_frequency_milliseconds (int, optional) :
-            Number of milliseconds between logging memory information (default: {DEFAULT_MEM_LOG_FREQ_MS})
+            Number of milliseconds between logging memory information (default: 0)
 
             Enabling this feature requires the optional depenency ``psutil`` to be
             installed.
@@ -494,13 +493,3 @@ class BokehTornado(TornadoApplication):
         log.trace("Running keep alive job")
         for c in self._clients:
             c.send_ping()
-
-BokehTornado.__doc__ = format_docstring(
-    BokehTornado.__doc__,
-    DEFAULT_APP_MAP=_DEFAULT_APP_MAP,
-    DEFAULT_KEEP_ALIVE_MS=DEFAULT_KEEP_ALIVE_MS,
-    DEFAULT_CHECK_UNUSED_MS=DEFAULT_CHECK_UNUSED_MS,
-    DEFAULT_UNUSED_LIFETIME_MS=DEFAULT_UNUSED_LIFETIME_MS,
-    DEFAULT_STATS_LOG_FREQ_MS=DEFAULT_STATS_LOG_FREQ_MS,
-    DEFAULT_MEM_LOG_FREQ_MS=DEFAULT_MEM_LOG_FREQ_MS
-)


### PR DESCRIPTION
This PR adds a `destroy` method to Document, that removes several places where there might be circular references. However, this alone does not (yet) solve the problem, and a call to `gc.collect()` is required to fully release memory. A fuller solution down the road might be to implement a `destroy` protocol on all models so that they can be responsible for cleaning up any cycles.

- [x] issues: addresses #7468
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
