### PR TITLE
Datetime stream fix

### DIFF
--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -423,9 +423,8 @@ class ColumnDataSource(ColumnarDataSource):
             else:
                 raise ValueError("Must stream updates to all existing columns (extra: %s)" % ", ".join(sorted(extra)))
 
+        import numpy as np
         if needs_length_check:
-            import numpy as np
-
             lengths = set()
             arr_types = (np.ndarray, pd.Series) if pd else np.ndarray
             for k, x in new_data.items():
@@ -439,10 +438,19 @@ class ColumnDataSource(ColumnarDataSource):
             if len(lengths) > 1:
                 raise ValueError("All streaming column updates must be the same length")
 
-        # slighgly awkward that we have to call converty_datetime_array here ourselves
+        # slightly awkward that we have to call convert_datetime_array here ourselves
         # but the downstream code expects things to already be ms-since-epoch
-        for key in new_data:
-            new_data[key] = convert_datetime_array(new_data[key])
+        for key, values in new_data.items():
+            if pd and isinstance(values, (pd.Series, pd.Index)):
+                values = values.values
+            old_values = self.data[key]
+            # Apply the transformation if the new data contains datetimes
+            # but the current data has already been transformed
+            if (isinstance(values, np.ndarray) and values.dtype.kind.lower() == 'm' and
+                isinstance(old_values, np.ndarray) and old_values.dtype.kind.lower() != 'm'):
+                new_data[key] = convert_datetime_array(values)
+            else:
+                new_data[key] = values
 
         self.data._stream(self.document, self, new_data, rollover, setter)
 

--- a/bokeh/models/tests/test_sources.py
+++ b/bokeh/models/tests/test_sources.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import io
 import unittest
+import datetime as dt
 from unittest import skipIf
 import warnings
 
@@ -13,7 +14,7 @@ except ImportError as e:
     is_pandas = False
 
 from bokeh.models.sources import DataSource, ColumnDataSource
-from bokeh.util.serialization import transform_column_source_data
+from bokeh.util.serialization import transform_column_source_data, convert_datetime_array
 
 class TestColumnDataSource(unittest.TestCase):
 
@@ -220,10 +221,46 @@ Lime,Green,99,$0.39
         self.assertEqual(stuff['args'], ("doc", ds, dict(a=[11, 12], b=[21, 22]), "foo", None))
         self.assertEqual(stuff['kw'], {})
 
+    def test__stream_good_datetime64_data(self):
+        now = dt.datetime.now()
+        dates = np.array([now+dt.timedelta(i) for i in range(1, 10)], dtype='datetime64')
+        ds = ColumnDataSource(data=dict(index=dates, b=list(range(1, 10))))
+        ds._document = "doc"
+        stuff = {}
+        mock_setter = object()
+
+        def mock(*args, **kw):
+            stuff['args'] = args
+            stuff['kw'] = kw
+        ds.data._stream = mock
+        # internal implementation of stream
+        new_date = np.array([now+dt.timedelta(10)], dtype='datetime64')
+        ds._stream(dict(index=new_date, b=[10]), "foo", mock_setter)
+        self.assertTrue(np.array_equal(stuff['args'][2]['index'], new_date))
+
+    def test__stream_good_datetime64_data_transformed(self):
+        now = dt.datetime.now()
+        dates = np.array([now+dt.timedelta(i) for i in range(1, 10)], dtype='datetime64')
+        dates = convert_datetime_array(dates)
+        ds = ColumnDataSource(data=dict(index=dates, b=list(range(1, 10))))
+        ds._document = "doc"
+        stuff = {}
+        mock_setter = object()
+
+        def mock(*args, **kw):
+            stuff['args'] = args
+            stuff['kw'] = kw
+        ds.data._stream = mock
+        # internal implementation of stream
+        new_date = np.array([now+dt.timedelta(10)], dtype='datetime64')
+        ds._stream(dict(index=new_date, b=[10]), "foo", mock_setter)
+        transformed_date = convert_datetime_array(new_date)
+        self.assertTrue(np.array_equal(stuff['args'][2]['index'], transformed_date))
+
     def _assert_equal_dicts_of_arrays(self, d1, d2):
         self.assertEqual(d1.keys(), d2.keys())
         for k, v in d1.items():
-            self.assertEqual(type(v), type(d2[k]))
+            self.assertEqual(type(v), np.ndarray)
             self.assertTrue(np.array_equal(v, d2[k]))
 
     @skipIf(not is_pandas, "pandas not installed")


### PR DESCRIPTION
Fixes two regressions in datetime streaming, the first applies to attempts to stream pandas Index or Series objects, which are currently not appropriately transformed. The second deals with a difference between server and notebook streaming. When streaming data on the server the data is transformed from datetime64 types to integers, which ends up being synced. Since JS->Python is not synced in the notebook this does not occur there. To avoid this problem we only transform the data during streaming if the column it is being streamed to has also been transformed.

The two added tests cover these two conditions, one where the data has not been transformed (emulating the notebook) and one where the data has been transformed (emulating bokeh server).

- [x] issues: fixes #7587
- [x] tests added / passed
