### PR TITLE
have one unit test job use tornado 4.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,7 @@ jobs:
       env:
       - GROUP=unit
       - PYTHON=3.5
+      - TORNADO=4
 
     - install: scripts/ci/install:test
       script: scripts/ci/test

--- a/scripts/ci/install:test
+++ b/scripts/ci/install:test
@@ -35,7 +35,7 @@ else
 fi
 
 # install the pre-built Bokeh package plus all test and runtime dependencies
-conda install --yes --quiet --use-local bokeh `python scripts/deps.py run test`
+conda install --yes --quiet --use-local bokeh `python scripts/deps.py run test` tornado=${TORNADO:-5}
 
 # regrettably need to have previous JS build in the source tree
 python setup.py --install-js


### PR DESCRIPTION
- [x] issues: fixes #7483
- [x] tests added / passed

Rather than burden our already long build with a new job, this PR just makes one of the existing unit test jobs use Tornado 4.5.x