### PR TITLE
handle message send exceptions better

### DIFF
--- a/bokeh/server/views/tests/test_ws.py
+++ b/bokeh/server/views/tests/test_ws.py
@@ -1,0 +1,24 @@
+import logging
+
+import pytest
+from tornado.websocket import StreamClosedError, WebSocketClosedError
+
+from bokeh.server.views.ws import WSHandler
+
+from bokeh.util.logconfig import basicConfig
+
+# needed for caplog tests to function
+basicConfig()
+
+@pytest.mark.parametrize('exc', [StreamClosedError, WebSocketClosedError])
+def test_send_message_raises(caplog, exc):
+    class ExcMessage(object):
+        def send(self, handler):
+            raise exc()
+    assert len(caplog.records) == 0
+    with caplog.at_level(logging.WARN):
+        # fake self not great but much easier than setting up a real view
+        ret = WSHandler.send_message("self", ExcMessage())
+        assert len(caplog.records) == 1
+        assert caplog.text.endswith("Failed sending message as connection was closed\n")
+        assert ret.result() is None

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function
 
 import os
+from os.path import basename
 import time
 import pytest
 import subprocess
@@ -76,7 +77,7 @@ def test_server_examples(server_example, example, report, bokeh_server):
     for session_callback in list(doc._session_callbacks.keys()):
         doc._remove_session_callback(session_callback)
 
-    session_id = "session_id"
+    session_id = basename(example.path)
     push_session(doc, session_id=session_id)
 
     if example.no_js:


### PR DESCRIPTION
This PR handles send errors (as might happen with an early disconnect) better across Tornado versions. Also cleans up/adds some docstrings and adds a test module for `ws.py`

- [x] issues: fixes #7619
- [x] tests added / passed
