### PR TITLE
Clean up all rendering levels in PlotCanvasView.build_levels()

### DIFF
--- a/bokehjs/src/coffee/models/plots/plot_canvas.ts
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.ts
@@ -614,8 +614,10 @@ export class PlotCanvasView extends DOMView {
     const new_renderer_views = build_views(this.renderer_views, renderer_models, this.view_options()) as RendererView[]
     const renderers_to_remove = difference(old_renderers, renderer_models.map((model) => model.id))
 
-    for (const id_ of renderers_to_remove) {
-      delete this.levels.glyph[id_]
+    for (const level in this.levels) {
+      for (const id of renderers_to_remove) {
+        delete this.levels[level][id]
+      }
     }
 
     for (const view of new_renderer_views) {


### PR DESCRIPTION
~~The problem outlined in the issues is very general. Here I was able to get around it, but in the longer term, we will have to rethink document access in models and state management, especially related to models initialized in bokehjs.~~

fixes ~~#7497 (works around)~~
fixes #7476