### PR TITLE
Hover tool support for revealing values in image glyphs

### DIFF
--- a/bokehjs/src/coffee/core/util/templating.ts
+++ b/bokehjs/src/coffee/core/util/templating.ts
@@ -39,8 +39,18 @@ export function replace_placeholders(str: string, data_source: ColumnarDataSourc
       value = special_vars[name.substring(1)]
     else {
       const column = data_source.get_column(name)
-      if (column != null)
-        value = column[i]
+      let [ind, dim1, dim2, linind] = Array.isArray(i) ? i : [i, null, null, null]
+      if ((data_source._shapes[name] != undefined) && (column != null)) {
+        if (ArrayBuffer.isView(column[ind])) { // Typed arrays use the linear index
+          value = column[ind][linind]
+        }
+        else {
+          value = column[ind][dim2][dim1]
+        }
+      }
+      else if (column != null) {
+        value = column[ind]
+      }
     }
 
     let replacement = null

--- a/bokehjs/src/coffee/core/util/templating.ts
+++ b/bokehjs/src/coffee/core/util/templating.ts
@@ -25,7 +25,8 @@ function _format_number(num: string | number): string {
     return `${num}`  // get strings for categorical types
 }
 
-export function replace_placeholders(str: string, data_source: ColumnarDataSource, i: number,
+
+export function replace_placeholders(str: string, data_source: ColumnarDataSource, i : any,
     formatters: {[key: string]: "numeral" | "printf" | "datetime"} | null = null, special_vars: {[key: string]: any} = {}): string {
 
   str = str.replace(/(^|[^\$])\$(\w+)/g, (_match, prefix, name) => `${prefix}@$${name}`)

--- a/bokehjs/src/coffee/models/glyphs/image.ts
+++ b/bokehjs/src/coffee/models/glyphs/image.ts
@@ -48,6 +48,14 @@ export class ImageView extends XYGlyphView {
     }
   }
 
+  _lrtb(i) {
+    const l = this._x[i]
+    const r = l + this._dw[i]
+    const b = this._y[i]
+    const t = b + this._dh[i]
+    return [l, r, t, b]
+  }
+
   protected _set_data(): void {
     if (this.image_data == null || this.image_data.length != this._image.length)
       this.image_data = new Array(this._image.length)

--- a/bokehjs/src/coffee/models/glyphs/image.ts
+++ b/bokehjs/src/coffee/models/glyphs/image.ts
@@ -7,6 +7,7 @@ import * as p from "core/properties"
 import {max, concat} from "core/util/array"
 import {Context2d} from "core/util/canvas"
 import {Rect} from "core/util/spatial"
+import {RBush} from "core/util/spatial"
 
 // XXX: because ImageData is a global
 export interface _ImageData extends XYGlyphData {
@@ -26,7 +27,6 @@ export interface _ImageData extends XYGlyphData {
 }
 
 export interface ImageView extends _ImageData {}
-
 export class ImageView extends XYGlyphView {
   model: Image
   visuals: Image.Visuals
@@ -46,6 +46,18 @@ export class ImageView extends XYGlyphView {
       this._set_data()
       this.renderer.plot_view.request_render()
     }
+  }
+
+  _index_data(): RBush {
+    const points = [];
+    for (let i = 0, end = this._x.length; i < end; i++) {
+      const [l, r, t, b] = this._lrtb(i);
+      if (isNaN(l+r+t+b) || !isFinite(l+r+t+b)) {
+        continue;
+      }
+      points.push({minX: l, minY: b, maxX: r, maxY: t, i});
+    }
+    return new RBush(points);
   }
 
   _lrtb(i) {

--- a/bokehjs/src/coffee/models/glyphs/image.ts
+++ b/bokehjs/src/coffee/models/glyphs/image.ts
@@ -64,7 +64,7 @@ export class ImageView extends XYGlyphView {
     return new RBush(points);
   }
 
-  _lrtb(i) {
+  _lrtb(i: any) {
     const l = this._x[i]
     const r = l + this._dw[i]
     const b = this._y[i]
@@ -72,7 +72,7 @@ export class ImageView extends XYGlyphView {
     return [l, r, t, b]
   }
 
-  _image_index(index, x,y) {
+  _image_index(index : any, x: any, y : any) {
     let [l,r,t,b] = this._lrtb(index);
     let width = this._width[index]
     let height = this._height[index]
@@ -83,7 +83,7 @@ export class ImageView extends XYGlyphView {
     return [index, dim1,  dim2, (dim2 * width) + dim1]
   }
 
-  _hit_point(geometry) : Selection {
+  _hit_point(geometry: any) : Selection {
     let {sx, sy} = geometry;
     const x = this.renderer.xscale.invert(sx);
     const y = this.renderer.yscale.invert(sy);

--- a/bokehjs/src/coffee/models/selections/selection.ts
+++ b/bokehjs/src/coffee/models/selections/selection.ts
@@ -59,6 +59,7 @@ export class Selection extends Model {
                   'get_view': () => null}
     this['2d'] = {'indices': {}}
     this['1d'] = {'indices': this.indices}
+    this['im2d'] = {'indices': []}
 
     this.get_view = () => null
 
@@ -100,6 +101,7 @@ export class Selection extends Model {
       this.selected_glyphs = selection.selected_glyphs
       this.get_view = selection.get_view
       this.multiline_indices = selection.multiline_indices
+      this['im2d']['indices'] = selection['im2d']['indices']
     }
   }
 
@@ -113,7 +115,7 @@ export class Selection extends Model {
   }
 
   is_empty (): boolean {
-    return this.indices.length == 0 && this.line_indices.length == 0
+    return this.indices.length == 0 && this.line_indices.length == 0 && this['im2d']['indices'] == 0
   }
 
   update_through_union(other: Selection): void {

--- a/bokehjs/src/coffee/models/sources/cds_view.ts
+++ b/bokehjs/src/coffee/models/sources/cds_view.ts
@@ -100,6 +100,7 @@ export class CDSView extends Model {
     selection_full.update_through_union(selection_subset)
     const indices_1d = (selection_subset.indices.map((i) => this.indices[i]))
     selection_full.indices = indices_1d
+    selection_full['im2d']['indices'] = selection_subset['im2d']['indices']
     return selection_full
   }
 
@@ -108,6 +109,7 @@ export class CDSView extends Model {
     selection_subset.update_through_union(selection_full)
     const indices_1d = (selection_full.indices.map((i) => this.indices_map[i]))
     selection_subset.indices = indices_1d
+    selection_subset['im2d']['indices'] = selection_full['im2d']['indices']
     return selection_subset
   }
 

--- a/bokehjs/src/coffee/models/tools/inspectors/hover_tool.ts
+++ b/bokehjs/src/coffee/models/tools/inspectors/hover_tool.ts
@@ -359,7 +359,7 @@ export class HoverToolView extends InspectToolView {
     }
   }
 
-  _render_tooltips(ds: ColumnarDataSource, i: number, vars: any): HTMLElement {
+  _render_tooltips(ds: ColumnarDataSource, i: any, vars: any): HTMLElement {
     const tooltips = this.model.tooltips
     if (isString(tooltips)) {
       const el = div()

--- a/bokehjs/src/coffee/models/tools/inspectors/hover_tool.ts
+++ b/bokehjs/src/coffee/models/tools/inspectors/hover_tool.ts
@@ -255,6 +255,12 @@ export class HoverToolView extends InspectToolView {
       tooltip.add(rx, ry, this._render_tooltips(ds, ii, vars))
     }
 
+    for (const [ind, dim1, dim2, linind] of indices['im2d']['indices']) {
+      const vars = {index:ind, x:x, y:y, sx: sx, sy: sy}
+      let rendered = this._render_tooltips(ds, [ind, dim1, dim2, linind], vars)
+      tooltip.add(sx, sy, rendered)
+    }
+
     for (const i of indices.indices) {
       // multiglyphs set additional indices, e.g. multiline_indices for different tooltips
       if (!isEmpty(indices.multiline_indices)) {


### PR DESCRIPTION

This PR aims to address issue #3886 by showing image values using the hover tool.

Although this PR is still WIP (e.g no typing yet), it is sufficiently complete to work with this example, demonstrating hover over an image containing integers and one containing floats:

![image_hover_demo](https://user-images.githubusercontent.com/890576/37586895-9fee7b90-2b55-11e8-9624-a8c1cfa44527.gif)

## Notes:

* I have only considered getting hover information working on the JS side and have not considered how image indexing might be useful or represented syncing with Python.
* At this time, I have only added support for the special variables described [here](https://bokeh.pydata.org/en/latest/docs/user_guide/tools.html#hovertool).
* The ``_lrtb`` method is used both for finding the integer indexing and for the hit testing with ``RBush`` and was inspired by what I saw in ``quad.ts``.
* Typed arrays seem to need a linear index which I compute in the ``_hit_point`` method.
* I use ``data_source._shapes`` to find the columns that correspond to image values in `` replace_placeholders``. The alternative seems to be to get this information from the glyph at the hover tool level, but this means passing this information through several levels to get to ``replace_placeholders``.

## Outstanding items

- [ ] Updated/add typing information.
- [ ] Update docs
- [ ] Tests (though I don't know what sort of testing is recommended here)

It is likely that we will need some discussion around the representation used for image indexing and this PR should help illustrate what is required, at least in the context of implementing the (often requested!) image hover functionality.