### PR TITLE
Add support for doubletap drawing on BoxEditTool

### DIFF
--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -909,7 +909,9 @@ class BoxEditTool(EditTool, Drag, Tap):
 
     The supported actions include:
 
-    * Add box: Hold shift then click and drag anywhere on the plot.
+    * Add box: Hold shift then click and drag anywhere on the plot or
+      double tap once to start drawing, move the mouse and double tap
+      again to finish drawing.
 
     * Move box: Click and drag an existing box, the box will be
       dropped once you let go of the mouse button.

--- a/bokehjs/src/coffee/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/src/coffee/models/tools/edit/box_edit_tool.ts
@@ -17,6 +17,7 @@ export class BoxEditToolView extends EditToolView {
   _draw_basepoint: [number, number] | null
 
   _tap(ev: TapEvent): void {
+    if ((this._draw_basepoint != null) || (this._basepoint != null)) { return; }
     const append = ev.shiftKey
     this._select_event(ev, append, this.model.renderers);
   }
@@ -71,7 +72,6 @@ export class BoxEditToolView extends EditToolView {
   _update_box(ev: UIEvent, append: boolean = false, emit: boolean = false): void {
     if (this._draw_basepoint == null) { return; }
     const curpoint: [number, number] = [ev.sx, ev.sy];
-
     const frame = this.plot_model.frame;
     const dims = this.model.dimensions;
     const limits = this.model._get_dim_limits(this._draw_basepoint, curpoint, frame, dims);
@@ -101,13 +101,13 @@ export class BoxEditToolView extends EditToolView {
   }
 
   _pan_start(ev: GestureEvent): void {
-    this._select_event(ev, true, this.model.renderers);
     if (ev.shiftKey) {
       if (this._draw_basepoint != null) { return }
       this._draw_basepoint = [ev.sx, ev.sy];
       this._update_box(ev, true, false);
     } else {
       if (this._basepoint != null) { return }
+      this._select_event(ev, true, this.model.renderers);
       this._basepoint = [ev.sx, ev.sy];
     }
   }

--- a/bokehjs/test/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/test/models/tools/edit/box_edit_tool.ts
@@ -199,5 +199,28 @@ describe("BoxEditTool", () =>
       expect(testcase.data_source.data['height']).to.be.deep.equal([0.3, 0.2, 0.1, 0.3389830508474576]);
       expect(testcase.data_source.data['z']).to.be.deep.equal([null, null, null, "Test"]);
     });
+
+    it("should draw box on doubletap and move", function(): void {
+      const testcase = make_testcase();
+      const hit_test_stub = sinon.stub(testcase.glyph_view, "hit_test");
+      hit_test_stub.returns(null);
+
+      let drag_event = make_gesture_event(300, 300, true);
+      testcase.draw_tool_view._doubletap(drag_event);
+      expect(testcase.draw_tool_view._basepoint).to.be.deep.equal([300, 300]);
+      drag_event = make_gesture_event(200, 200, true);
+      testcase.draw_tool_view._move(drag_event);
+      expect(testcase.draw_tool_view._basepoint).to.be.deep.equal([300, 300]);
+      testcase.draw_tool_view._doubletap(drag_event);
+
+      expect(testcase.draw_tool_view._basepoint).to.be.equal(null);
+      expect(testcase.data_source.selected.indices).to.be.deep.equal([]);
+      expect(testcase.data_source.data['x']).to.be.deep.equal([0, 0.5, 1, -0.1327433628318584]);
+      expect(testcase.data_source.data['y']).to.be.deep.equal([0, 0.5, 1, 0.1694915254237288]);
+      expect(testcase.data_source.data['width']).to.be.deep.equal([0.1, 0.2, 0.3, 0.35398230088495575]);
+      expect(testcase.data_source.data['height']).to.be.deep.equal([0.3, 0.2, 0.1, 0.3389830508474576]);
+      expect(testcase.data_source.data['z']).to.be.deep.equal([null, null, null, "Test"]);
+    });
+
   }),
 );

--- a/bokehjs/test/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/test/models/tools/edit/box_edit_tool.ts
@@ -185,13 +185,13 @@ describe("BoxEditTool", () =>
 
       let drag_event = make_gesture_event(300, 300, true);
       testcase.draw_tool_view._pan_start(drag_event);
-      expect(testcase.draw_tool_view._basepoint).to.be.deep.equal([300, 300]);
+      expect(testcase.draw_tool_view._draw_basepoint).to.be.deep.equal([300, 300]);
       drag_event = make_gesture_event(200, 200, true);
       testcase.draw_tool_view._pan(drag_event);
-      expect(testcase.draw_tool_view._basepoint).to.be.deep.equal([300, 300]);
+      expect(testcase.draw_tool_view._draw_basepoint).to.be.deep.equal([300, 300]);
       testcase.draw_tool_view._pan_end(drag_event);
 
-      expect(testcase.draw_tool_view._basepoint).to.be.equal(null);
+      expect(testcase.draw_tool_view._draw_basepoint).to.be.equal(null);
       expect(testcase.data_source.selected.indices).to.be.deep.equal([]);
       expect(testcase.data_source.data['x']).to.be.deep.equal([0, 0.5, 1, -0.1327433628318584]);
       expect(testcase.data_source.data['y']).to.be.deep.equal([0, 0.5, 1, 0.1694915254237288]);
@@ -207,13 +207,13 @@ describe("BoxEditTool", () =>
 
       let drag_event = make_gesture_event(300, 300, true);
       testcase.draw_tool_view._doubletap(drag_event);
-      expect(testcase.draw_tool_view._basepoint).to.be.deep.equal([300, 300]);
+      expect(testcase.draw_tool_view._draw_basepoint).to.be.deep.equal([300, 300]);
       drag_event = make_gesture_event(200, 200, true);
       testcase.draw_tool_view._move(drag_event);
-      expect(testcase.draw_tool_view._basepoint).to.be.deep.equal([300, 300]);
+      expect(testcase.draw_tool_view._draw_basepoint).to.be.deep.equal([300, 300]);
       testcase.draw_tool_view._doubletap(drag_event);
 
-      expect(testcase.draw_tool_view._basepoint).to.be.equal(null);
+      expect(testcase.draw_tool_view._draw_basepoint).to.be.equal(null);
       expect(testcase.data_source.selected.indices).to.be.deep.equal([]);
       expect(testcase.data_source.data['x']).to.be.deep.equal([0, 0.5, 1, -0.1327433628318584]);
       expect(testcase.data_source.data['y']).to.be.deep.equal([0, 0.5, 1, 0.1694915254237288]);

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -637,7 +637,9 @@ showing the pressed keys. The ``BoxEditTool`` can **Add**, **Move**
 and **Delete** boxes on plots:
 
 Add box
-  Hold shift then click and drag anywhere on the plot.
+  Hold shift then click and drag anywhere on the plot or double tap
+  once to start drawing, move the mouse and double tap again to
+  finish drawing.
 
 Move box
   Click and drag an existing box, the box will be dropped once you let


### PR DESCRIPTION
This PR adds support to the ``BoxEditTool`` to draw boxes by doubletapping on the canvas, moving the mouse, and then doubletapping again to finish drawing. This makes it more consistent with the ``PolyDrawTool``, while retaining the old behavior to draw on shift+drag.

- [x] issues: fixes #7553
- [x] tests added / passed