### PR TITLE
Always clip frame in _paint_levels() despite output backend

### DIFF
--- a/bokeh/io/tests/test_export.py
+++ b/bokeh/io/tests/test_export.py
@@ -24,6 +24,7 @@ from bokeh.util.testing import verify_api ; verify_api
 from mock import patch
 from tempfile import NamedTemporaryFile
 import os
+import re
 
 # External imports
 from PIL import Image
@@ -138,36 +139,45 @@ def test_get_svgs_no_svg_present():
 @pytest.mark.unit
 @pytest.mark.selenium
 def test_get_svgs_with_svg_present():
+
+    def fix_ids(svg):
+        svg = re.sub(r'id="\w{12}"', 'id="X"', svg)
+        svg = re.sub(r'url\(#\w{12}\)', 'url(#X)', svg)
+        return svg
+
     layout = Plot(x_range=Range1d(), y_range=Range1d(),
                   plot_height=20, plot_width=20, toolbar_location=None,
                   outline_line_color=None, border_fill_color=None,
                   background_fill_color="red", output_backend="svg")
 
-    svgs = bie.get_svgs(layout)
-    assert svgs[0] == ('<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" '
-                       'width="20" height="20" style="width: 20px; height: 20px;"><defs/><g><g transform="scale(1,1) '
-                       'translate(0.5,0.5)"><rect fill="#FFFFFF" stroke="none" x="0" y="0" width="20" height="20"/>'
-                       '<rect fill="red" stroke="none" x="5" y="5" width="10" height="10"/><g/><g/><g/><g/></g></g></svg>')
-
-@pytest.mark.unit
-@pytest.mark.selenium
-def test_get_svgs_with_svg_present_with_driver():
-    layout = Plot(x_range=Range1d(), y_range=Range1d(),
-                  plot_height=20, plot_width=20, toolbar_location=None,
-                  outline_line_color=None, border_fill_color=None,
-                  background_fill_color="red", output_backend="svg")
+    svg0 = fix_ids(bie.get_svgs(layout)[0])
 
     driver = webdriver.PhantomJS(service_log_path=os.path.devnull)
+    svg1 = fix_ids(bie.get_svgs(layout)[0])
+    terminate_web_driver(driver) # Have to manually clean up the driver session
 
-    svgs = bie.get_svgs(layout)
+    svg2 = (
+        '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" '
+        'width="20" height="20" style="width: 20px; height: 20px;">'
+        '<defs>'
+            '<clipPath id="X"><path fill="none" stroke="none" d=" M 5 5 L 15 5 L 15 15 L 5 15 L 5 5 Z"/></clipPath>'
+            '<clipPath id="X"><path fill="none" stroke="none" d=" M 5 5 L 15 5 L 15 15 L 5 15 L 5 5 Z"/></clipPath>'
+        '</defs>'
+        '<g>'
+            '<g transform="scale(1,1) translate(0.5,0.5)">'
+                '<rect fill="#FFFFFF" stroke="none" x="0" y="0" width="20" height="20"/>'
+                '<rect fill="red" stroke="none" x="5" y="5" width="10" height="10"/>'
+                '<g/>'
+                '<g clip-path="url(#X)"><g/></g>'
+                '<g clip-path="url(#X)"><g/></g>'
+                '<g/>'
+            '</g>'
+        '</g>'
+        '</svg>'
+    )
 
-    # Have to manually clean up the driver session
-    terminate_web_driver(driver)
-
-    assert svgs[0] == ('<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" '
-                       'width="20" height="20" style="width: 20px; height: 20px;"><defs/><g><g transform="scale(1,1) '
-                       'translate(0.5,0.5)"><rect fill="#FFFFFF" stroke="none" x="0" y="0" width="20" height="20"/>'
-                       '<rect fill="red" stroke="none" x="5" y="5" width="10" height="10"/><g/><g/><g/><g/></g></g></svg>')
+    assert svg0 == svg2
+    assert svg1 == svg2
 
 def test_save_layout_html_resets_plot_dims():
     initial_height, initial_width = 200, 250

--- a/bokehjs/src/coffee/models/glyphs/webgl/markers.frag.ts
+++ b/bokehjs/src/coffee/models/glyphs/webgl/markers.frag.ts
@@ -70,15 +70,6 @@ float marker(vec2 P, float size)
 }
 `
 
-export const annulus = `
-float marker(vec2 P, float size)
-{
-    float r1 = length(P) - size/2.0;
-    float r2 = length(P) - size/4.0;  // half width
-    return max(r1, -r2);
-}
-`
-
 export const diamond = `
 float marker(vec2 P, float size)
 {

--- a/bokehjs/src/coffee/models/glyphs/webgl/markers.ts
+++ b/bokehjs/src/coffee/models/glyphs/webgl/markers.ts
@@ -204,7 +204,6 @@ import * as glsl from "./markers.frag"
 
 export const CircleGLGlyph           = mk_marker(glsl.circle)
 export const SquareGLGlyph           = mk_marker(glsl.square)
-export const AnnulusGLGlyph          = mk_marker(glsl.annulus)
 export const DiamondGLGlyph          = mk_marker(glsl.diamond)
 export const TriangleGLGlyph         = mk_marker(glsl.triangle)
 export const InvertedTriangleGLGlyph = mk_marker(glsl.invertedtriangle)

--- a/bokehjs/src/coffee/models/plots/plot_canvas.ts
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.ts
@@ -860,7 +860,7 @@ export class PlotCanvasView extends DOMView {
   protected _paint_levels(ctx: Context2d, levels: string[], clip_region?: FrameBox): void {
     ctx.save()
 
-    if (clip_region != null && this.model.plot.output_backend == "canvas") {
+    if (clip_region != null) {
       ctx.beginPath()
       ctx.rect.apply(ctx, clip_region)
       ctx.clip()

--- a/examples/integration/glyphs/frame_clipping_multi_backend.py
+++ b/examples/integration/glyphs/frame_clipping_multi_backend.py
@@ -1,0 +1,15 @@
+from bokeh.plotting import figure
+from bokeh.layouts import row
+from bokeh.io import save
+
+def make_figure(output_backend):
+    p = figure(plot_width=400, plot_height=400, output_backend=output_backend, title="Backend: %s" % output_backend)
+    p.circle(x=[1, 2, 3], y=[1, 2, 3], radius=0.25, color="blue", alpha=0.5)
+    p.annulus(x=[1, 2, 3], y=[1, 2, 3], inner_radius=0.1, outer_radius=0.20, color="orange")
+    return p
+
+canvas = make_figure("canvas")
+webgl  = make_figure("webgl")
+svg    = make_figure("svg")
+
+save(row(canvas, webgl, svg))


### PR DESCRIPTION
I'm not sure why clipping depended on output backed, but that definitively can't work when `webgl` and `canvas` glyphs are mixed together. In fact this also resolves clipping issues with SVG (not surprisingly).

fixes #6867
fixes #6787 