### PR TITLE
use IPython standard _repr_pretty_ method name

### DIFF
--- a/bokeh/core/has_props.py
+++ b/bokeh/core/has_props.py
@@ -646,24 +646,18 @@ class HasProps(with_metaclass(MetaHasProps, object)):
 
         '''
         IPython = import_optional('IPython')
+        cls = self.__class__
 
         if IPython:
             from IPython.lib.pretty import RepresentationPrinter
 
-        class _BokehPrettyPrinter(RepresentationPrinter):
-            def __init__(self, output, verbose=False, max_width=79, newline='\n'):
-                super(_BokehPrettyPrinter, self).__init__(output, verbose, max_width, newline)
-                self.type_pprinters[HasProps] = lambda obj, p, cycle: obj._repr_pretty(p, cycle)
-
-        if not IPython:
-            cls = self.__class__
-            raise RuntimeError("%s.%s.pretty() requires IPython" % (cls.__module__, cls.__name__))
-        else:
             stream = StringIO()
-            printer = _BokehPrettyPrinter(stream, verbose, max_width, newline)
+            printer = RepresentationPrinter(stream, verbose, max_width, newline)
             printer.pretty(self)
             printer.flush()
             return stream.getvalue()
+        else:
+            raise RuntimeError("%s.%s.pretty() requires IPython" % (cls.__module__, cls.__name__))
 
     def pprint(self, verbose=False, max_width=79, newline='\n'):
         ''' Print a "pretty" string representation of the object to stdout.
@@ -723,7 +717,7 @@ class HasProps(with_metaclass(MetaHasProps, object)):
         '''
         return self.__class__(**self._property_values)
 
-    def _repr_pretty(self, p, cycle):
+    def _repr_pretty_(self, p, cycle):
         '''
 
         '''

--- a/bokeh/model.py
+++ b/bokeh/model.py
@@ -649,7 +649,7 @@ class Model(with_metaclass(MetaModel, HasProps, PropertyCallbackManager, EventCa
 
         return html
 
-    def _repr_pretty(self, p, cycle):
+    def _repr_pretty_(self, p, cycle):
         '''
 
         '''


### PR DESCRIPTION
ensures pretty-printer is used on bokeh classes by default and simplifies logic in `.pretty()` to avoid the temporary class definition.

This has the additional benefit that the default IPython display of these objects will use your pretty-print methods. Was avoiding the default pretty-printer intentional, or a typo in the method name?

Another fix if avoiding the default pretty-printer is intentional is to register as `type_printers[cls]` for the current class, rather than `type_printers[HasProps]` only on the less specific base class.

closes #7729