### PR TITLE
make CDS.column_names a read-only property

### DIFF
--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -36,10 +36,6 @@ class ColumnarDataSource(DataSource):
 
     '''
 
-    column_names = List(String, help="""
-    An list of names for all the columns in this DataSource.
-    """)
-
     selection_policy = Instance(SelectionPolicy, help="""
     An instance of a SelectionPolicy that determines how selections are set.
     """)
@@ -132,8 +128,14 @@ class ColumnDataSource(ColumnarDataSource):
             else:
                 raise ValueError("expected a dict or pandas.DataFrame, got %s" % raw_data)
         super(ColumnDataSource, self).__init__(**kw)
-        self.column_names[:] = list(raw_data.keys())
         self.data.update(raw_data)
+
+    @property
+    def column_names(self):
+        ''' A list of the column names in this data source.
+
+        '''
+        return list(self.data)
 
     @staticmethod
     def _data_from_df(df):
@@ -243,20 +245,13 @@ class ColumnDataSource(ColumnarDataSource):
     def to_df(self):
         ''' Convert this data source to pandas dataframe.
 
-        If ``column_names`` is set, use those. Otherwise let Pandas
-        infer the column names. The ``column_names`` property can be
-        used both to order and filter the columns.
-
         Returns:
             DataFrame
 
         '''
         if not pd:
             raise RuntimeError('Pandas must be installed to convert to a Pandas Dataframe')
-        if self.column_names:
-            return pd.DataFrame(self.data, columns=self.column_names)
-        else:
-            return pd.DataFrame(self.data)
+        return pd.DataFrame(self.data)
 
     def add(self, data, name=None):
         ''' Appends a new column of data to the data source.
@@ -275,7 +270,6 @@ class ColumnDataSource(ColumnarDataSource):
             while "Series %d"%n in self.data:
                 n += 1
             name = "Series %d"%n
-        self.column_names.append(name)
         self.data[name] = data
         return name
 
@@ -294,7 +288,6 @@ class ColumnDataSource(ColumnarDataSource):
 
         '''
         try:
-            self.column_names.remove(name)
             del self.data[name]
         except (ValueError, KeyError):
             import warnings

--- a/bokehjs/src/coffee/api/typings/models/sources.d.ts
+++ b/bokehjs/src/coffee/api/typings/models/sources.d.ts
@@ -9,7 +9,6 @@ declare namespace Bokeh {
 
   export interface ColumnarDataSource extends DataSource, IColumnarDataSource {}
   export interface IColumnarDataSource extends IDataSource {
-    column_names?: string[];
     inspected?: Selected;
   }
 

--- a/bokehjs/src/coffee/models/sources/columnar_data_source.ts
+++ b/bokehjs/src/coffee/models/sources/columnar_data_source.ts
@@ -35,7 +35,7 @@ export abstract class ColumnarDataSource extends DataSource {
 
   data: {[key: string]: Arrayable}
 
-  get column_names(): String[] {
+  get column_names(): string[] {
     return keys(this.data)
   }
 

--- a/bokehjs/src/coffee/models/sources/columnar_data_source.ts
+++ b/bokehjs/src/coffee/models/sources/columnar_data_source.ts
@@ -16,7 +16,6 @@ import {SelectionPolicy, UnionRenderers} from "../selections/interaction_policy"
 
 export namespace ColumnarDataSource {
   export interface Attrs extends DataSource.Attrs {
-    column_names: string[]
     selection_policy: SelectionPolicy
     selection_manager: SelectionManager
     inspected: Selection
@@ -35,6 +34,10 @@ export abstract class ColumnarDataSource extends DataSource {
   properties: ColumnarDataSource.Props
 
   data: {[key: string]: Arrayable}
+
+  get column_names(): String[] {
+    return keys(this.data)
+  }
 
   get_array<T>(key: string): T[] {
     let column = this.data[key]
@@ -61,7 +64,6 @@ export abstract class ColumnarDataSource extends DataSource {
     this.prototype.type = 'ColumnarDataSource'
 
     this.define({
-      column_names:     [ p.Array, [] ],
       selection_policy: [ p.Instance  ],
     })
 

--- a/sphinx/source/docs/releases/0.12.16.rst
+++ b/sphinx/source/docs/releases/0.12.16.rst
@@ -24,4 +24,15 @@ To support publishing all release information on one page, the
 ``bokeh_releases``. Since this facility had no use outside building
 official Bokeh documenation, no deprecation was given.
 
+CDS ``column_names`` property
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+ColumnDataSource models had a Bokeh property ``column_names`` for specifying
+the list of column names in ``source.data``. This information was duplicative
+and had to be explicitly maintained in a fragile way. It has been replaced by
+read-only properties in both Python and JavaScript that always accurately
+report the current column names automatically. Setting ``column_names`` is
+no longer supported, however as this possibility has never been officially
+documented or demonstrated, it is not expected to affect any standard usage.
+
 .. _project roadmap: https://bokehplots.com/pages/roadmap.html


### PR DESCRIPTION
- [x] issues: fixes #6657
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

@mattpap @clairetang6 would appreciate any comments from you both. All of the existing tests of `source.column_names` pass without modification. 