### PR TITLE
Bryanv/6699 log filename

### DIFF
--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -368,6 +368,13 @@ base_serve_args = (
         default = DEFAULT_LOG_FORMAT,
         help    = "A standard Python logging format string (default: %r)" % DEFAULT_LOG_FORMAT.replace("%", "%%"),
     )),
+
+    ('--log-file', dict(
+        metavar ='LOG-FILE',
+        action  = 'store',
+        default = None,
+        help    = "A filename to write logs to, or None to write to the standard stream (default: None)",
+    )),
 )
 
 class Serve(Subcommand):
@@ -502,7 +509,7 @@ class Serve(Subcommand):
         applications = build_single_handler_applications(args.files, argvs)
 
         log_level = getattr(logging, args.log_level.upper())
-        basicConfig(level=log_level, format=args.log_format)
+        basicConfig(level=log_level, format=args.log_format, filename=args.log_file)
 
         # This should remain here until --host is removed entirely
         _fixup_deprecated_host_args(args)

--- a/bokeh/command/subcommands/tests/test_serve.py
+++ b/bokeh/command/subcommands/tests/test_serve.py
@@ -65,6 +65,13 @@ def test_args():
             help    = "A standard Python logging format string (default: %r)" % scserve.DEFAULT_LOG_FORMAT.replace("%", "%%"),
         )),
 
+        ('--log-file', dict(
+            metavar ='LOG-FILE',
+            action  = 'store',
+            default = None,
+            help    = "A filename to write logs to, or None to write to the standard stream (default: None)",
+        )),
+
         ('files', dict(
             metavar='DIRECTORY-OR-SCRIPT',
             nargs='*',


### PR DESCRIPTION
- [x] issues: fixes #6699
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

My understanding of general good guidance is to always just log to stdout and let log aggregators handle persistence. But evidently some use cases, e.g. running the server as a subprocess from Node, do not offer good options for redirections. Willing to add this option given the simplicity of implementation. 