### PR TITLE
add reset signal to plots

### DIFF
--- a/bokehjs/src/coffee/models/plots/plot.ts
+++ b/bokehjs/src/coffee/models/plots/plot.ts
@@ -2,6 +2,7 @@ import {EQ, Constraint, Variable} from "core/layout/solver"
 import {logger} from "core/logging"
 import * as visuals from "core/visuals"
 import * as p from "core/properties"
+import {Signal0} from "core/signaling"
 import {Color} from "core/types"
 import {LineJoin, LineCap} from "core/enums"
 import {Place, Location, OutputBackend} from "core/enums"
@@ -159,6 +160,8 @@ export namespace Plot {
 export interface Plot extends Plot.Attrs {}
 
 export class Plot extends LayoutDOM {
+
+  reset = new Signal0(this, "reset")
 
   properties: Plot.Props
 

--- a/bokehjs/src/coffee/models/plots/plot.ts
+++ b/bokehjs/src/coffee/models/plots/plot.ts
@@ -160,9 +160,7 @@ export namespace Plot {
 export interface Plot extends Plot.Attrs {}
 
 export class Plot extends LayoutDOM {
-
-  reset = new Signal0(this, "reset")
-
+  reset: Signal0<this>
   properties: Plot.Props
 
   constructor(attrs?: Partial<Plot.Attrs>) {
@@ -240,6 +238,8 @@ export class Plot extends LayoutDOM {
 
   initialize(): void {
     super.initialize()
+
+    this.reset = new Signal0(this, "reset")
 
     for (const xr of values(this.extra_x_ranges).concat(this.x_range)) {
       let plots = xr.plots

--- a/bokehjs/src/coffee/models/plots/plot_canvas.ts
+++ b/bokehjs/src/coffee/models/plots/plot_canvas.ts
@@ -10,6 +10,7 @@ import {ToolView} from "../tools/tool"
 import {Selection} from "../selections/selection"
 import {Plot} from "./plot"
 
+import {Reset} from "core/bokeh_events"
 import {Arrayable} from "core/types"
 import {Signal0} from "core/signaling"
 import {build_views, remove_views} from "core/build_views"
@@ -145,6 +146,13 @@ export class PlotCanvasView extends DOMView {
   request_paint(): void {
     if (!this.is_paused)
       this.throttled_paint()
+  }
+
+  reset(): void {
+    this.clear_state()
+    this.reset_range()
+    this.reset_selection()
+    this.model.plot.trigger_event(new Reset())
   }
 
   remove(): void {
@@ -645,6 +653,7 @@ export class PlotCanvasView extends DOMView {
     this.connect(this.model.plot.properties.renderers.change, () => this.build_levels())
     this.connect(this.model.plot.toolbar.properties.tools.change, () => { this.build_levels(); this.build_tools() })
     this.connect(this.model.plot.change, () => this.request_render())
+    this.connect(this.model.plot.reset, () => this.reset())
   }
 
   set_initial_range(): void {

--- a/bokehjs/src/coffee/models/tools/actions/reset_tool.ts
+++ b/bokehjs/src/coffee/models/tools/actions/reset_tool.ts
@@ -1,14 +1,10 @@
 import {ActionTool, ActionToolView} from "./action_tool"
-import {Reset} from "core/bokeh_events"
 
 export class ResetToolView extends ActionToolView {
   model: ResetTool
 
   doit(): void {
-    this.plot_view.clear_state()
-    this.plot_view.reset_range()
-    this.plot_view.reset_selection()
-    this.plot_model.plot.trigger_event(new Reset())
+    this.plot_view.reset()
   }
 }
 


### PR DESCRIPTION
- [x] issues: fixes #5071

example:

```py
from bokeh.io import show
from bokeh.layouts import column
from bokeh.models import Button, CustomJS
from bokeh.plotting import figure

p = figure(tools="reset,pan,wheel_zoom,lasso_select")
p.circle(list(range(10)), list(range(10)))

b = Button()
b.js_on_click(CustomJS(args=dict(p=p), code="""
    p.reset.emit()
"""))

show(column(p, b))
```