### PR TITLE
Silence deprecation warning from selenium.webdriver.phantomjs

### DIFF
--- a/bokeh/command/subcommands/png.py
+++ b/bokeh/command/subcommands/png.py
@@ -41,11 +41,10 @@ For all cases, it's required to explicitly add a Bokeh layout to
 from __future__ import absolute_import
 
 import io
-import os
 import sys
 import warnings
 
-from ...io.export import get_screenshot_as_png, terminate_web_driver
+from ...io.export import get_screenshot_as_png, create_webdriver, terminate_webdriver
 from ...models.plots import Plot
 from .file_output import FileOutputSubcommand
 
@@ -86,10 +85,11 @@ class PNG(FileOutputSubcommand):
         '''
 
         '''
-        import selenium.webdriver as webdriver
-        self.driver = webdriver.PhantomJS(service_log_path=os.path.devnull)
-        super(PNG, self).invoke(args)
-        terminate_web_driver(self.driver)
+        self.driver = create_webdriver()
+        try:
+            super(PNG, self).invoke(args)
+        finally:
+            terminate_webdriver(self.driver)
 
     def write_file(self, args, filename, doc):
         '''

--- a/bokeh/command/subcommands/svg.py
+++ b/bokeh/command/subcommands/svg.py
@@ -43,10 +43,9 @@ For all cases, it's required to explicitly add a Bokeh layout to
 from __future__ import absolute_import
 
 import io
-import os
 import warnings
 
-from ...io.export import get_svgs, terminate_web_driver
+from ...io.export import get_svgs, create_webdriver, terminate_webdriver
 from ...models.plots import Plot
 from ...util.string import decode_utf8
 from .file_output import FileOutputSubcommand
@@ -88,10 +87,11 @@ class SVG(FileOutputSubcommand):
         '''
 
         '''
-        import selenium.webdriver as webdriver
-        self.driver = webdriver.PhantomJS(service_log_path=os.path.devnull)
-        super(SVG, self).invoke(args)
-        terminate_web_driver(self.driver)
+        self.driver = create_webdriver()
+        try:
+            super(SVG, self).invoke(args)
+        finally:
+            terminate_webdriver(self.driver)
 
     def write_file(self, args, filename, doc):
         '''


### PR DESCRIPTION
I'm marking this as "fixes". We should open new issue for adding support for chromedriver (and firefoxdriver). With this PR we will only need to change one place in the code instead of a dozen. This also adds `try-finally` blocks to make sure `terminate_webdriver()` is actually called if failure occurs.

fixes #7510 
