### PR TITLE
Make handling of UI events more robust

### DIFF
--- a/bokehjs/src/less/main.less
+++ b/bokehjs/src/less/main.less
@@ -2,5 +2,4 @@
   position: absolute;
   display: block;
   border: 1px dashed green;
-  z-index: 100;
 }

--- a/bokehjs/src/lib/core/ui_events.ts
+++ b/bokehjs/src/lib/core/ui_events.ts
@@ -227,8 +227,13 @@ export class UIEvents {
     return this.plot_view.frame.bbox.contains(sx, sy)
   }
 
-  // XXX: srcEvent is an effect of the overall mess this method is.
-  _trigger<E extends UIEvent>(signal: UISignal<E>, e: E, srcEvent?: Event): void {
+  _trigger<E extends UIEvent>(signal: UISignal<E>, e: E, srcEvent: Event): void {
+    const {target} = srcEvent
+    const {hit_area} = this
+
+    if (target != null && target != hit_area && hit_area.contains(target as Node))
+      return
+
     this._trigger_bokeh_event(e)
 
     const gestures = this.toolbar.gestures
@@ -285,8 +290,8 @@ export class UIEvents {
         const base = is_mobile ? "pinch" : "scroll"
         const active_gesture = gestures[base].active
         if (active_gesture != null) {
-          srcEvent!.preventDefault()
-          srcEvent!.stopPropagation()
+          srcEvent.preventDefault()
+          srcEvent.stopPropagation()
           this.trigger(signal, e, active_gesture.id)
         }
         break
@@ -360,43 +365,43 @@ export class UIEvents {
     // back out delta to get original center point
     ev.sx -= e.deltaX
     ev.sy -= e.deltaY
-    this._trigger(this.pan_start, ev)
+    this._trigger(this.pan_start, ev, e.srcEvent)
   }
 
   protected _pan(e: HammerEvent): void {
-    this._trigger(this.pan, this._gesture_event(e))
+    this._trigger(this.pan, this._gesture_event(e), e.srcEvent)
   }
 
   protected _pan_end(e: HammerEvent): void {
-    this._trigger(this.pan_end, this._gesture_event(e))
+    this._trigger(this.pan_end, this._gesture_event(e), e.srcEvent)
   }
 
   protected _pinch_start(e: HammerEvent): void {
-    this._trigger(this.pinch_start, this._gesture_event(e))
+    this._trigger(this.pinch_start, this._gesture_event(e), e.srcEvent)
   }
 
   protected _pinch(e: HammerEvent): void {
-    this._trigger(this.pinch, this._gesture_event(e))
+    this._trigger(this.pinch, this._gesture_event(e), e.srcEvent)
   }
 
   protected _pinch_end(e: HammerEvent): void {
-    this._trigger(this.pinch_end, this._gesture_event(e))
+    this._trigger(this.pinch_end, this._gesture_event(e), e.srcEvent)
   }
 
   protected _rotate_start(e: HammerEvent): void {
-    this._trigger(this.rotate_start, this._gesture_event(e))
+    this._trigger(this.rotate_start, this._gesture_event(e), e.srcEvent)
   }
 
   protected _rotate(e: HammerEvent): void {
-    this._trigger(this.rotate, this._gesture_event(e))
+    this._trigger(this.rotate, this._gesture_event(e), e.srcEvent)
   }
 
   protected _rotate_end(e: HammerEvent): void {
-    this._trigger(this.rotate_end, this._gesture_event(e))
+    this._trigger(this.rotate_end, this._gesture_event(e), e.srcEvent)
   }
 
   protected _tap(e: HammerEvent): void {
-    this._trigger(this.tap, this._tap_event(e))
+    this._trigger(this.tap, this._tap_event(e), e.srcEvent)
   }
 
   protected _doubletap(e: HammerEvent): void {
@@ -407,19 +412,19 @@ export class UIEvents {
   }
 
   protected _press(e: HammerEvent): void {
-    this._trigger(this.press, this._tap_event(e))
+    this._trigger(this.press, this._tap_event(e), e.srcEvent)
   }
 
   protected _mouse_enter(e: MouseEvent): void {
-    this._trigger(this.move_enter, this._move_event(e))
+    this._trigger(this.move_enter, this._move_event(e), e)
   }
 
   protected _mouse_move(e: MouseEvent): void {
-    this._trigger(this.move, this._move_event(e))
+    this._trigger(this.move, this._move_event(e), e)
   }
 
   protected _mouse_exit(e: MouseEvent): void {
-    this._trigger(this.move_exit, this._move_event(e))
+    this._trigger(this.move_exit, this._move_event(e), e)
   }
 
   protected _mouse_wheel(e: WheelEvent): void {

--- a/bokehjs/src/lib/models/annotations/span.ts
+++ b/bokehjs/src/lib/models/annotations/span.ts
@@ -85,7 +85,6 @@ export class SpanView extends AnnotationView {
       this.el.style.left = `${sleft}px`
       this.el.style.width = `${width}px`
       this.el.style.height = `${height}px`
-      this.el.style.zIndex = "1000"
       this.el.style.backgroundColor = this.model.properties.line_color.value()
       this.el.style.opacity = this.model.properties.line_alpha.value()
       show(this.el)

--- a/bokehjs/src/lib/models/annotations/tooltip.ts
+++ b/bokehjs/src/lib/models/annotations/tooltip.ts
@@ -25,7 +25,6 @@ export class TooltipView extends AnnotationView {
     super.initialize(options)
     // TODO (bev) really probably need multiple divs
     this.plot_view.canvas_overlays.appendChild(this.el)
-    this.el.style.zIndex = "1010"
     hide(this.el)
   }
 

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -197,7 +197,7 @@ export class PlotCanvasView extends DOMView {
 
     this.throttled_paint = throttle((() => this.force_paint.emit()), 15)  // TODO (bev) configurable
 
-    this.ui_event_bus = new UIEvents(this, this.model.toolbar, this.canvas_view.el, this.model.plot)
+    this.ui_event_bus = new UIEvents(this, this.model.toolbar, this.canvas_view.events_el, this.model.plot)
 
     this.levels = {}
     for (const level of enums.RenderLevel) {

--- a/bokehjs/src/lib/models/tools/button_tool.ts
+++ b/bokehjs/src/lib/models/tools/button_tool.ts
@@ -10,11 +10,7 @@ export abstract class ButtonToolButtonView extends DOMView {
   initialize(options: any): void {
     super.initialize(options)
     this.connect(this.model.change, () => this.render())
-    this.el.addEventListener("click", (e) => {
-      e.stopPropagation()
-      e.preventDefault()
-      this._clicked()
-    })
+    this.el.addEventListener("click", () => this._clicked())
     this.render()
   }
 


### PR DESCRIPTION
So far this fixes `z-index` mess and doesn't allow propagation of events from toolbar to plot area. This makes, however, the appearance of special overlays dependent on the order of insertion of tools.

fixes #7627
