### PR TITLE
DOM: add class to safely()'s error box

### DIFF
--- a/bokehjs/src/lib/safely.ts
+++ b/bokehjs/src/lib/safely.ts
@@ -12,6 +12,7 @@ function _burst_into_flames(error: any): void {
   box.style.marginTop = "5px"
   box.style.minWidth = "200px"
   box.style.padding = "5px 5px 5px 10px"
+  box.classList.add("bokeh-error-box-into-flames")
 
   // Make button
   const button = document.createElement("span")


### PR DESCRIPTION
Allow to hide, display, or relocate error box to be useful and valuable on complicated web pages.
Basic style do not support (and not aimed to do so) webpages with navbars, relative positioning 
and so on, this integration is delegated to webpage designer through `bokeh-error-box-into-flames` 
css class.

> All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [x] issues: fixes #7802
- [ ] **no** tests added
- [ ] **no** new release document entry (if new feature or API change)
