### PR TITLE
Less strict Callback.args and improve webgl/line_compare example

### DIFF
--- a/bokeh/models/callbacks.py
+++ b/bokeh/models/callbacks.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 from types import FunctionType
 
 from ..core.has_props import abstract
-from ..core.properties import Dict, Instance, String, Bool
+from ..core.properties import Dict, String, Bool, Any
 from ..model import Model
 from ..util.dependencies import import_required
 from ..util.compiler import nodejs_compile, CompilationError
@@ -71,10 +71,10 @@ class CustomJS(Callback):
         else:
             return cls(code=compiled.code, args=args)
 
-    args = Dict(String, Instance(Model), help="""
-    A mapping of names to Bokeh plot objects. These objects are made
-    available to the callback code snippet as the values of named
-    parameters to the callback.
+    args = Dict(String, Any, help="""
+    A mapping of names to Python objects. In particular those can be bokeh's models.
+    These objects are made available to the callback's code snippet as the values of
+    named parameters to the callback.
     """)
 
     code = String(default="", help="""

--- a/bokeh/models/filters.py
+++ b/bokeh/models/filters.py
@@ -4,7 +4,7 @@ import inspect
 from textwrap import dedent
 from types import FunctionType
 
-from ..core.properties import Bool, Dict, Either, Instance, Int, Seq, String
+from ..core.properties import Bool, Dict, Either, Int, Seq, String, Any
 from ..model import Model
 from ..util.dependencies import import_required
 from ..util.compiler import nodejs_compile, CompilationError
@@ -137,10 +137,10 @@ class CustomJSFilter(Filter):
         else:
             return cls(code=compiled.code, args=args)
 
-    args = Dict(String, Instance(Model), help="""
-    A mapping of names to Bokeh plot objects. These objects are made
-    available to the callback code snippet as the values of named
-    parameters to the callback.
+    args = Dict(String, Any, help="""
+    A mapping of names to Python objects. In particular those can be bokeh's models.
+    These objects are made available to the callback's code snippet as the values of
+    named parameters to the callback.
     """)
 
     code = String(default="", help="""

--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -9,7 +9,7 @@ from types import FunctionType
 from bokeh.util.string import format_docstring
 from ..core.enums import LatLon, NumeralLanguage, RoundingFunction
 from ..core.has_props import abstract
-from ..core.properties import Auto, Bool, Dict, Either, Enum, Instance, Int, List, String
+from ..core.properties import Auto, Bool, Dict, Either, Enum, Instance, Int, List, String, Any
 from ..core.validation import error
 from ..core.validation.errors import MISSING_MERCATOR_DIMENSION
 from ..model import Model
@@ -315,10 +315,10 @@ class FuncTickFormatter(TickFormatter):
         else:
             return cls(code=compiled.code, args=args)
 
-    args = Dict(String, Instance(Model), help="""
-    A mapping of names to Bokeh plot objects. These objects are made
-    available to the formatter code snippet as the values of named
-    parameters to the callback.
+    args = Dict(String, Any, help="""
+    A mapping of names to Python objects. In particular those can be bokeh's models.
+    These objects are made available to the formatter's code snippet as the values of
+    named parameters to the callback.
     """)
 
     code = String(default="", help="""

--- a/bokeh/models/tests/test_callbacks.py
+++ b/bokeh/models/tests/test_callbacks.py
@@ -3,22 +3,21 @@ from bokeh.models import CustomJS, Slider
 
 
 def test_js_callback():
-
     slider = Slider()
 
-    cb = CustomJS(code="foo();", args={'x': slider})
+    cb = CustomJS(code="foo();", args=dict(x=slider))
     assert 'foo()' in cb.code
     assert cb.args['x'] is slider
 
-    with raises(ValueError):  # not a plot object
-        CustomJS(code="foo();", args={'x': 3})
+    cb = CustomJS(code="foo();", args=dict(x=3))
+    assert 'foo()' in cb.code
+    assert cb.args['x'] is 3
 
     with raises(AttributeError):  # kwargs not supported
         CustomJS(code="foo();", x=slider)
 
 
 def test_py_callback():
-
     slider = Slider()
     foo = None  # fool pyflakes
 
@@ -28,7 +27,8 @@ def test_py_callback():
     assert 'foo()' in cb.code
     assert cb.args['x'] is slider
 
-    with raises(ValueError):  # not a plot object
-        def cb(x=4):
-            foo()
-        CustomJS.from_py_func(cb)
+    def cb(x=4):
+        foo()
+    cb = CustomJS.from_py_func(cb)
+    assert 'foo()' in cb.code
+    assert cb.args['x'] is 4

--- a/bokeh/models/transforms.py
+++ b/bokeh/models/transforms.py
@@ -8,7 +8,7 @@ from types import FunctionType
 
 from ..core.enums import StepMode, JitterRandomDistribution
 from ..core.has_props import abstract
-from ..core.properties import Bool, Dict, Either, Enum, Float, Instance, Seq, String
+from ..core.properties import Bool, Dict, Either, Enum, Float, Instance, Seq, String, Any
 from ..model import Model
 from ..util.compiler import nodejs_compile, CompilationError
 from ..util.dependencies import import_required
@@ -162,10 +162,10 @@ class CustomJSTransform(Transform):
 
         return cls(func=compiled.code, v_func=v_compiled.code, args=args)
 
-    args = Dict(String, Instance(Model), help="""
-    A mapping of names to Bokeh plot objects. These objects are made
-    available to the callback code snippet as the values of named
-    parameters to the callback.
+    args = Dict(String, Any, help="""
+    A mapping of names to Python objects. In particular those can be bokeh's models.
+    These objects are made available to the transform' code snippet as the values of
+    named parameters to the callback.
     """)
 
     func = String(default="", help="""

--- a/examples/webgl/line_compare.py
+++ b/examples/webgl/line_compare.py
@@ -46,15 +46,12 @@ for p in (p1, p2, p3):
     lines.extend([l1, l2, l3, l4])
 
 def add_callback(widget, prop):
-    widget.callback = CustomJS(args=dict(widget=widget), code="""
-        for (var i = 0; i < %s; i++) {
-            var g = eval('line' + i).get('glyph');
-            g.set('%s', widget.get('value'));
-            window.g = g;
+    widget.callback = CustomJS(args=dict(widget=widget, lines=lines, prop=prop), code="""
+        for (var i = 0; i < lines.length; i++) {
+            var glyph = lines[i].glyph;
+            glyph[prop] = widget.value;
         }
-        """ % (len(lines), prop))
-    for i, line in enumerate(lines):
-        widget.callback.args['line%i' % i] = line
+    """)
 
 def make_slider(prop, start, end, value):
     slider = Slider(title=prop, start=start, end=end, value=value)


### PR DESCRIPTION
I'm not sure why we did insist on having `args = Dict(String, Instance(Model))`, which is very limiting. `Dict(String, Any)` allows e.g. having a list of models or a constant (instead of using Python's string formatting).

fixes #7807 