### PR TITLE
add downstream test report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,13 +60,6 @@ jobs:
       - PYTHON=2.7
       - EXTRA_CMD=--no-js
 
-#    - install: scripts/ci/install:test
-#      script: scripts/ci/test
-#      addons:
-#        sauce_connect: true
-#      env:
-#      - GROUP=integration
-
     - install: scripts/ci/install:test
       script: scripts/ci/test
       env:
@@ -100,6 +93,11 @@ jobs:
       script: scripts/ci/test
       env:
       - GROUP=codebase
+
+    - install: scripts/ci/install:test
+      script: scripts/ci/test
+      env:
+      - GROUP=downstream
 
     - install: scripts/ci/install:deploy
       stage: deploy

--- a/scripts/ci/install:downstream
+++ b/scripts/ci/install:downstream
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e # exit on error
+set -x # echo commands
+
+conda install --yes --quiet distributed

--- a/scripts/ci/test:downstream
+++ b/scripts/ci/test:downstream
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-set -e # exit on error
+# disable set -e, just run to generate a report
+#set -e # exit on error
+
 set -x # echo commands
 
 pushd `python -c "import site; print(site.getsitepackages()[0])"`
 py.test distributed/bokeh
 popd
 
-# just run to generate a report
 exit 0

--- a/scripts/ci/test:downstream
+++ b/scripts/ci/test:downstream
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e # exit on error
+set -x # echo commands
+
+pushd `python -c "import site; print(site.getsitepackages()[0])"`
+py.test distributed/bokeh
+popd
+
+# just run to generate a report
+exit 0


### PR DESCRIPTION
fixes: #7720 

For now at least this test does not fail, it only generates a report. Want to avoid a situation where one or other project is intentionally out out of sync (major revision) and then the test can't be made to pass at all in any way for some interval