### PR TITLE
fix missing python and data table updates

### DIFF
--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -950,16 +950,22 @@ class PointDrawTool(EditTool, Drag, Tap):
     ''' *toolbar icon*: |point_draw_icon|
 
     The PointDrawTool allows adding, dragging and deleting point-like
-    glyphs (of ``XYGlyph`` type) on one or more renderers by editing
-    the underlying ``ColumnDataSource`` data. Like other drawing
-    tools, the renderers that are to be edited must be supplied
-    explicitly as a list. Any newly added points will be inserted on
-    the ``ColumnDataSource`` of the first supplied renderer.
+    glyphs (of ``XYGlyph`` type) on one or more renderers by editing the
+    underlying ``ColumnDataSource`` data. Like other drawing tools, the
+    renderers that are to be edited must be supplied explicitly as a list.
+    Any newly added points will be inserted on the ``ColumnDataSource`` of
+    the first supplied renderer.
 
     The tool will automatically modify the columns on the data source
-    corresponding to the ``x`` and ``y`` values of the glyph. Any
-    additional columns in the data source will be padded with the
-    declared ``empty_value``, when adding a new point.
+    corresponding to the ``x`` and ``y`` values of the glyph. Any additional
+    columns in the data source will be padded with the given ``empty_value``
+    when adding a new point.
+
+    .. note::
+        The data source updates will trigger data change events continuously
+        throughout the edit operations on the BokehJS side. In Bokeh server
+        apps, the data source will only be synced once, when the edit operation
+        finishes.
 
     The supported actions include:
 

--- a/bokehjs/src/lib/models/tools/edit/edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/edit_tool.ts
@@ -75,7 +75,8 @@ export abstract class EditToolView extends GestureToolView {
       }
     }
     for (const renderer of renderers) {
-      renderer.data_source.change.emit();
+      renderer.data_source.change.emit()
+      renderer.data_source.properties.data.change.emit()
     }
     this._basepoint = [ev.sx, ev.sy];
   }

--- a/bokehjs/src/lib/models/tools/edit/point_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/point_draw_tool.ts
@@ -64,8 +64,12 @@ export class PointDrawToolView extends EditToolView {
     if (!this.model.drag) { return; }
     this._pan(ev);
     for (const renderer of this.model.renderers) {
-      renderer.data_source.selected.indices = [];
-      renderer.data_source.properties.data.change.emit();
+      renderer.data_source.selected.indices = []
+
+      // This is only needed to call @_tell_document_about_change()
+      renderer.data_source.data = renderer.data_source.data
+
+      renderer.data_source.properties.data.change.emit()
     }
     this._basepoint = null;
   }

--- a/bokehjs/src/lib/models/widgets/tables/data_table.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_table.ts
@@ -119,13 +119,14 @@ export class DataTableView extends WidgetView {
   connect_signals(): void {
     super.connect_signals()
     this.connect(this.model.change, () => this.render())
-    this.connect(this.model.source.properties.data.change, () => this.updateGrid())
     this.connect(this.model.source.streaming, () => this.updateGrid())
     this.connect(this.model.source.patching, () => this.updateGrid())
-    this.connect(this.model.source.change, () => this.updateSelection())
+    this.connect(this.model.source.change, () => this.updateGrid(true))
+    this.connect(this.model.source.properties.data.change, () => this.updateGrid())
+    this.connect(this.model.source.selected.change, () => this.updateSelection())
   }
 
-  updateGrid(): void {
+  updateGrid(from_source_change=false): void {
     // TODO (bev) This is to enure that CDSView indices are properly computed
     // before passing to the DataProvider. This will result in extra calls to
     // compute_indices. This "over execution" will be addressed in a more
@@ -136,9 +137,11 @@ export class DataTableView extends WidgetView {
     this.grid.invalidate()
     this.grid.render()
 
-    // This is only needed to call @_tell_document_about_change()
-    this.model.source.data = this.model.source.data
-    this.model.source.change.emit()
+    if (!from_source_change) {
+      // This is only needed to call @_tell_document_about_change()
+      this.model.source.data = this.model.source.data
+      this.model.source.change.emit()
+    }
   }
 
   updateSelection(): void {


### PR DESCRIPTION
- [x] issues: fixes #7745
- [x] issues: fixes #7597 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

This fixes both issues that got lumped into #7745

The part missing for python updates was a self-assign to `.data`, so that the doc notification machinery is invoked. The part missing for the table updates was a more explicit change signal on `.data`. Not sure why it worked before, though. Data tables have required that signal for a long time AFAICT. 

@philippjfr are there other places that the "self-assign" should go, e.g. for other tools, so that python gets updates at the appropriate times?

@mattpap any comments welcome

We do need to document that Python side updates will only happen at the end of these edit operations and not continuously throughout. 