### PR TITLE
update docs for showing apps in notebooks

### DIFF
--- a/bokeh/io/showing.py
+++ b/bokeh/io/showing.py
@@ -93,15 +93,10 @@ def show(obj, browser=None, new="tab", notebook_handle=False, notebook_url="loca
             properly. If no protocol is supplied in the URL, e.g. if it is
             of the form "localhost:8888", then "http" will be used.
 
-            It is also possible to pass ``notebook_url="*"`` to disable the
-            standard checks, so that applications will display regardless of
-            the current notebook location, however a warning will appear.
-
-            notebook_url can also be a function that takes one int for the
+            ``notebook_url`` can also be a function that takes one int for the
             bound server port.  If the port is provided, the function needs
             to generate the full public URL to the bokeh server.  If None
             is passed, the function is to generate the origin URL.
-
 
     Some parameters are only useful when certain output modes are active:
 


### PR DESCRIPTION
- [x] issues: fixes #7080
- [x] release document entry (if new feature or API change)

Updated docs to reflect that `notebook_url="*"` is not supportable, since Jupyter will not provide an API to determine the server location. 