### PR TITLE
support axes at fixed locations

### DIFF
--- a/bokeh/models/axes.py
+++ b/bokeh/models/axes.py
@@ -146,6 +146,16 @@ class Axis(GuideRenderer):
     main plot area.
     """)
 
+    fixed_location = Either(String, Float, help="""
+    Set to specify a fixed coordinate location to draw the axis. The direction
+    of ticks and major labels is determined by the side panel that the axis
+    belongs to.
+
+    .. note::
+        Axes labels are suppressed when axes are positioned at fixed locations
+        inside the central plot area.
+    """)
+
 @abstract
 class ContinuousAxis(Axis):
     ''' A base class for all numeric, non-categorical axes types.

--- a/bokeh/models/axes.py
+++ b/bokeh/models/axes.py
@@ -146,7 +146,7 @@ class Axis(GuideRenderer):
     main plot area.
     """)
 
-    fixed_location = Either(Float, String, Tuple(String, String), Tuple(String, String, String), help="""
+    fixed_location = Either(Float, String, Tuple(String, String), Tuple(String, String, String), default=None, help="""
     Set to specify a fixed coordinate location to draw the axis. The direction
     of ticks and major labels is determined by the side panel that the axis
     belongs to.

--- a/bokeh/models/axes.py
+++ b/bokeh/models/axes.py
@@ -146,7 +146,7 @@ class Axis(GuideRenderer):
     main plot area.
     """)
 
-    fixed_location = Either(String, Float, help="""
+    fixed_location = Either(Float, String, Tuple(String, String), Tuple(String, String, String), help="""
     Set to specify a fixed coordinate location to draw the axis. The direction
     of ticks and major labels is determined by the side panel that the axis
     belongs to.

--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -77,7 +77,7 @@ export class AxisView extends GuideRendererView {
     return this._tick_extent() + this._tick_label_extent() + this._axis_label_extent()
   }
 
-  get needs_clip() : boolean {
+  get needs_clip(): boolean {
     return this.model.fixed_location != null
   }
 

--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -11,7 +11,8 @@ import {Text, Line} from "core/visuals"
 import {SidePanel, Orient} from "core/layout/side_panel"
 import {Context2d} from "core/util/canvas"
 import {sum} from "core/util/array"
-import {isString, isArray} from "core/util/types"
+import {isString, isArray, isNumber} from "core/util/types"
+import {Factor, FactorRange} from "models/ranges/factor_range"
 
 const {abs, min, max} = Math
 
@@ -387,7 +388,7 @@ export namespace Axis {
     major_tick_out: number
     minor_tick_in: number
     minor_tick_out: number
-    fixed_location: any
+    fixed_location: number | Factor | null
   }
 
   export interface Props extends GuideRenderer.Props {}
@@ -604,7 +605,15 @@ export class Axis extends GuideRenderer {
 
   get loc(): number {
     if (this.fixed_location != null) {
-      return this.fixed_location
+      if (isNumber(this.fixed_location)) {
+        return this.fixed_location
+      }
+      const [, cross_range] = this.ranges
+      if (cross_range instanceof FactorRange) {
+        return cross_range.synthetic(this.fixed_location)
+      }
+      throw new Error("unexpected")
+
     }
 
     const [, cross_range] = this.ranges

--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -70,7 +70,14 @@ export class AxisView extends GuideRendererView {
   }
 
   protected _get_size(): number {
+    if (this.model.fixed_location != null) {
+      return 0
+    }
     return this._tick_extent() + this._tick_label_extent() + this._axis_label_extent()
+  }
+
+  get needs_clip() : boolean {
+    return this.model.fixed_location != null
   }
 
   // drawing sub functions -----------------------------------------------------
@@ -123,7 +130,7 @@ export class AxisView extends GuideRendererView {
   }
 
   protected _draw_axis_label(ctx: Context2d, extents: Extents, _tick_coords: TickCoords): void {
-    if (this.model.axis_label == null || this.model.axis_label.length == 0)
+    if (this.model.axis_label == null || this.model.axis_label.length == 0 || this.model.fixed_location != null)
       return
 
     let sx: number
@@ -380,6 +387,7 @@ export namespace Axis {
     major_tick_out: number
     minor_tick_in: number
     minor_tick_out: number
+    fixed_location: any
   }
 
   export interface Props extends GuideRenderer.Props {}
@@ -432,6 +440,7 @@ export class Axis extends GuideRenderer {
       major_tick_out:          [ p.Number,   6            ],
       minor_tick_in:           [ p.Number,   0            ],
       minor_tick_out:          [ p.Number,   4            ],
+      fixed_location:          [ p.Any,      null         ],
     })
 
     this.override({
@@ -594,6 +603,10 @@ export class Axis extends GuideRenderer {
   }
 
   get loc(): number {
+    if (this.fixed_location != null) {
+      return this.fixed_location
+    }
+
     const [, cross_range] = this.ranges
 
     switch (this.panel.side) {

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -852,10 +852,10 @@ export class PlotCanvasView extends DOMView {
     }
     ctx.restore()
 
-    this._paint_levels(ctx, ['image', 'underlay', 'glyph'], frame_box)
+    this._paint_levels(ctx, ['image', 'underlay', 'glyph'], frame_box, true)
     this.blit_webgl(ratio)
-    this._paint_levels(ctx, ['annotation'], frame_box)
-    this._paint_levels(ctx, ['overlay'])
+    this._paint_levels(ctx, ['annotation'], frame_box, true)
+    this._paint_levels(ctx, ['overlay'], frame_box, false)
 
     if (this._initial_state_info.range == null)
       this.set_initial_range()
@@ -868,10 +868,10 @@ export class PlotCanvasView extends DOMView {
     }
   }
 
-  protected _paint_levels(ctx: Context2d, levels: string[], clip_region?: FrameBox): void {
+  protected _paint_levels(ctx: Context2d, levels: string[], clip_region: FrameBox, global_clip: boolean): void {
     ctx.save()
 
-    if (clip_region != null) {
+    if (global_clip) {
       ctx.beginPath()
       ctx.rect.apply(ctx, clip_region)
       ctx.clip()
@@ -889,7 +889,18 @@ export class PlotCanvasView extends DOMView {
       const renderer_views = sortBy(values(this.levels[level]), sortKey)
 
       for (const renderer_view of renderer_views) {
+        if (!global_clip && renderer_view.needs_clip) {
+          ctx.save()
+          ctx.beginPath()
+          ctx.rect.apply(ctx, clip_region)
+          ctx.clip()
+        }
+
         renderer_view.render()
+
+        if (!global_clip && renderer_view.needs_clip) {
+          ctx.restore()
+        }
       }
     }
 

--- a/bokehjs/src/lib/models/renderers/renderer.ts
+++ b/bokehjs/src/lib/models/renderers/renderer.ts
@@ -35,6 +35,10 @@ export abstract class RendererView extends DOMView {
   }
 
   bbox?(): BBox
+
+  get needs_clip(): boolean {
+    return false
+  }
 }
 
 export namespace Renderer {

--- a/bokehjs/test/models/axes/axis.coffee
+++ b/bokehjs/test/models/axes/axis.coffee
@@ -8,8 +8,10 @@ sinon = require 'sinon'
 {Plot} = utils.require("models/plots/plot")
 {PlotCanvas} = utils.require("models/plots/plot_canvas")
 {PlotView} = utils.require("models/plots/plot")
+{FactorRange} = utils.require("models/ranges/factor_range")
 {Range1d} = utils.require("models/ranges/range1d")
 {SidePanel} = utils.require("core/layout/side_panel")
+{CategoricalScale} = utils.require("models/scales/categorical_scale")
 {Toolbar} = utils.require("models/tools/toolbar")
 {Document} = utils.require "document"
 
@@ -31,6 +33,43 @@ describe "Axis", ->
       major_label_overrides: {0: "zero", 4: "four", 10: "ten"}
     })
     expect(axis.compute_labels([0,2,4.0,6,8,10])).to.be.deep.equal ["zero", "2", "four", "6", "8", "ten"]
+
+  it "loc should return numeric fixed_location", ->
+    doc = new Document()
+    p = new Plot({
+      x_range: new Range1d({start: 0, end: 10})
+      y_range: new Range1d({start: 0, end: 10})
+    })
+    doc.add_root(p)
+    ticker = new BasicTicker()
+    formatter = new BasicTickFormatter()
+    axis = new Axis({
+      ticker: ticker
+      formatter: formatter
+      plot: p
+      fixed_location: 10
+    })
+    expect(axis.loc).to.equal 10
+
+  it "loc should return synthetic for categorical fixed_location", ->
+    doc = new Document()
+    p = new Plot({
+      x_range: new FactorRange({factors: ["foo", "bar"]})
+      x_scale: new CategoricalScale()
+      y_range: new Range1d({start: 0, end: 10})
+    })
+    doc.add_root(p)
+    ticker = new BasicTicker()
+    formatter = new BasicTickFormatter()
+    axis = new Axis({
+      ticker: ticker
+      formatter: formatter
+      plot: p
+      fixed_location: "foo"
+    })
+    axis.attach_document(p.document)
+    axis.add_panel('left')
+    expect(axis.loc).to.equal 0.5
 
   it "should have a SidePanel after add_panel is called", ->
     doc = new Document()
@@ -102,6 +141,13 @@ describe "AxisView", ->
       plot_view: plot_canvas_view
       parent: plot_canvas_view
     })
+
+  it "needs_clip should return the false when fixed_location null", ->
+    expect(@axis_view.needs_clip).to.be.equal false
+
+  it "needs_clip should return the false when fixed_location null", ->
+    @axis.fixed_location = 10
+    expect(@axis_view.needs_clip).to.be.equal true
 
   it "_tick_extent should return the major_tick_out property", ->
     expect(@axis_view._tick_extent()).to.be.equal @axis.major_tick_out

--- a/bokehjs/test/models/renderers/index.coffee
+++ b/bokehjs/test/models/renderers/index.coffee
@@ -1,1 +1,2 @@
 require "./glyph_renderer"
+require "./renderer"

--- a/bokehjs/test/models/renderers/renderer.coffee
+++ b/bokehjs/test/models/renderers/renderer.coffee
@@ -1,0 +1,13 @@
+{expect} = require "chai"
+utils = require "../../utils"
+
+{Renderer, RendererView} = utils.require("models/renderers/renderer")
+
+describe "RendererView", ->
+
+  describe "needs_clip", ->
+
+    it "should return false", ->
+      r = new Renderer()
+      rv = new RendererView({model: r, parent: null})
+      expect(rv.needs_clip).to.be.equal false

--- a/examples/plotting/file/fixed_axis.py
+++ b/examples/plotting/file/fixed_axis.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+from bokeh.plotting import figure, show, output_file
+
+x = np.linspace(-6, 6, 500)
+y = 8*np.sin(x)*np.sinc(x)
+
+p = figure(plot_width=800, plot_height=300, title="", tools="",
+           toolbar_location=None, match_aspect=True)
+
+p.line(x, y, color="navy", alpha=0.4, line_width=4)
+p.background_fill_color = "#efefef"
+p.xaxis.fixed_location = 0
+p.yaxis.fixed_location = 0
+
+output_file("fixed_axis.html", title="fixed_axis.py example")
+
+show(p)


### PR DESCRIPTION
- [x] issues: fixes #113
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

This implements the plan outlined in #113 and produces output such as the following:

<img width="335" alt="screen shot 2018-04-23 at 12 59 01" src="https://user-images.githubusercontent.com/1078448/39150234-7e4d283a-46f6-11e8-9f86-210fcf707183.png">

Including working with categorgical coordinates:

<img width="319" alt="screen shot 2018-04-23 at 12 59 27" src="https://user-images.githubusercontent.com/1078448/39150248-87bf9510-46f6-11e8-90eb-826ec8d4adee.png">

It's worth noting here that at least for now, axes labels are suppressed when a fixed location is provided. 

@mattpap I'd like to add some more docs and examples (and a few tests) but before going further I'd like your comments. 
