### PR TITLE
have expressions respond properly to stream/patch

### DIFF
--- a/bokeh/models/expressions.py
+++ b/bokeh/models/expressions.py
@@ -39,11 +39,9 @@ class Expression(Model):
         v_compute: (source) ->
             # compute an array of values
 
-    Note that the result of this call will be automatically saved and re-used
-    for each ``source`` that is passed in. If a ``source`` is changed, then
-    the saved value for that source is discarded, and the next call will
-    re-compute (and save) a new value. If you wish to prevent this caching, you
-    may implement ``_v_compute: (source)`` instead.
+    .. note::
+        If you wish for results to be cached per source, and updated only if
+        the source changes, implement `_v_compute: (souce)` instead.
 
     '''
     pass

--- a/bokehjs/src/lib/core/properties.ts
+++ b/bokehjs/src/lib/core/properties.ts
@@ -101,7 +101,7 @@ export class Property<T> extends Signalable() {
       if (ret == null)
         throw new Error(`attempted to retrieve property array for nonexistent field '${this.spec.field}'`)
     } else if (this.spec.expr != null) {
-      ret = this.transform(this.spec.expr._v_compute(source))
+      ret = this.transform(this.spec.expr.v_compute(source))
     } else {
       let length = source.get_length()
       if (length == null)

--- a/bokehjs/src/lib/models/expressions/expression.ts
+++ b/bokehjs/src/lib/models/expressions/expression.ts
@@ -31,18 +31,20 @@ export abstract class Expression extends Model {
     this._result = {}
   }
 
-  abstract v_compute(source: ColumnarDataSource): Arrayable
+  abstract _v_compute(source: ColumnarDataSource): Arrayable
 
-  protected _v_compute(source: ColumnarDataSource): Arrayable {
+  protected v_compute(source: ColumnarDataSource): Arrayable {
     if (this._connected[source.id] == null) {
       this.connect(source.change, () => delete this._result[source.id])
+      this.connect(source.patching, () => delete this._result[source.id])
+      this.connect(source.streaming, () => delete this._result[source.id])
       this._connected[source.id] = true
     }
 
     let result = this._result[source.id]
 
     if (result == null)
-      this._result[source.id] = result = this.v_compute(source)
+      this._result[source.id] = result = this._v_compute(source)
 
     return result
   }

--- a/bokehjs/src/lib/models/expressions/stack.ts
+++ b/bokehjs/src/lib/models/expressions/stack.ts
@@ -29,7 +29,7 @@ export class Stack extends Expression {
     })
   }
 
-  v_compute(source: ColumnarDataSource): Arrayable<number> {
+  _v_compute(source: ColumnarDataSource): Arrayable<number> {
     const result = new Float64Array(source.get_length() || 0)
     for (const f of this.fields) {
       for (let i = 0; i < source.data[f].length; i++) {

--- a/bokehjs/test/models/expressions/stack.coffee
+++ b/bokehjs/test/models/expressions/stack.coffee
@@ -45,3 +45,27 @@ describe "Stack", ->
       source.data = {foo: [10, 20, 30], bar: [0.01, 0.02, 0.03]}
       ret = s.v_compute(source)
       expect(ret).to.deep.equal new Float64Array([10.01, 20.02, 30.03])
+
+    it "should should re-compute if a source patches", ->
+      source = new ColumnDataSource({data: {foo: [1, 2, 3], bar: [0.1, 0.2, 0.3]}})
+      s = new Stack({fields: ['foo', 'bar']})
+      ret = s.v_compute(source)
+      expect(ret).to.deep.equal new Float64Array([1.1, 2.2, 3.3])
+
+      source.patch({"foo": [[1, 12]]})
+      ret = s.v_compute(source)
+      expect(ret).to.deep.equal new Float64Array([1.1, 12.2, 3.3])
+
+      source.patch({"bar": [[0, 1.1]]})
+      ret = s.v_compute(source)
+      expect(ret).to.deep.equal new Float64Array([2.1, 12.2, 3.3])
+
+    it "should should re-compute if a source streams", ->
+      source = new ColumnDataSource({data: {foo: [1, 2, 3], bar: [0.1, 0.2, 0.3]}})
+      s = new Stack({fields: ['foo', 'bar']})
+      ret = s.v_compute(source)
+      expect(ret).to.deep.equal new Float64Array([1.1, 2.2, 3.3])
+
+      source.stream({foo: [4], bar: [0.4]})
+      ret = s.v_compute(source)
+      expect(ret).to.deep.equal new Float64Array([1.1, 2.2, 3.3, 4.4])


### PR DESCRIPTION
- [x] issues: fixes #7823
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

This makes `v_compute` on the base class to do the caching, and delegate to `_v_compute`. If users make a subclass a subclass with `v_compute` it will now no longer cache. They can implement `_v_compute` if they desire that (docs updated accordingly). This is definitely more sensible. 