### PR TITLE
Proof of concept contributed module: ion.RangeSlider

### DIFF
--- a/bokeh/models/widgets/contrib/ionRangeSlider/__init__.py
+++ b/bokeh/models/widgets/contrib/ionRangeSlider/__init__.py
@@ -1,0 +1,1 @@
+from .main import *

--- a/bokeh/models/widgets/contrib/ionRangeSlider/main.py
+++ b/bokeh/models/widgets/contrib/ionRangeSlider/main.py
@@ -1,0 +1,90 @@
+#from bokeh.core.properties import (Float, Instance, Tuple, Bool, Enum,
+#                                   List, String, Any)
+import os
+
+from IPython import embed
+
+from bokeh.core.properties import Bool, Float, String, Enum, Tuple, Instance, Color, List, Any
+from bokeh.core.enums import SliderCallbackPolicy, enumeration
+from bokeh.models.widgets import Div
+from bokeh.models.callbacks import Callback
+from bokeh.util.compiler import TypeScript
+from bokeh.models import Widget
+from bokeh.models.widgets import AbstractSlider
+
+class IonRangeSlider(AbstractSlider):
+    # The special class attribute ``__implementation__`` should contain a string
+    # of JavaScript (or CoffeeScript) code that implements the JavaScript side
+    # of the custom extension model or a string name of a JavaScript (or
+    # CoffeeScript) file with the implementation.
+
+    #with open(os.path.join(os.path.dirname(__file__), '../bokeh-ion-rangesliderjs/src/ion_range_slider.ts')) as file_:
+    #    implementation = file_.readlines()
+    #__implementation__ = TypeScript(''.join(implementation))
+    __javascript__ = ["https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js",
+                      "https://cdnjs.cloudflare.com/ajax/libs/ion-rangeslider/2.1.4/js/ion.rangeSlider.js"]
+    __css__ = ["https://cdnjs.cloudflare.com/ajax/libs/normalize/4.2.0/normalize.css",
+               "https://cdnjs.cloudflare.com/ajax/libs/ion-rangeslider/2.1.4/css/ion.rangeSlider.css",
+               "https://cdnjs.cloudflare.com/ajax/libs/ion-rangeslider/2.1.4/css/ion.rangeSlider.skinFlat.min.css",
+               "https://cdnjs.cloudflare.com/ajax/libs/ion-rangeslider/2.1.4/img/sprite-skin-flat.png"]
+
+    # Below are all the "properties" for this model. Bokeh properties are
+    # class attributes that define the fields (and their types) that can be
+    # communicated automatically between Python and the browser. Properties
+    # also support type validation. More information about properties in
+    # can be found here:
+    #
+    #    http://bokeh.pydata.org/en/latest/docs/reference/core.html#bokeh-core-properties
+
+    start = Float(default=0, help="""
+    The minimum allowable value.
+    """)
+
+    end = Float(default=1, help="""
+    The maximum allowable value.
+    """)
+
+    value = Tuple(Float, Float, default = [0, 1], help="""
+    Initial or selected range.
+    """)
+
+    step = Float(default=0.1, help="""
+    The step between consecutive values.
+    """)
+
+    #format = String(default="0[.]00") Ignored right now
+
+    #bar_color = Color(default="#e6e6e6", help=""" """) Overwritten default
+
+    slider_type = Enum(enumeration('single', 'double'), default='single', help="""
+    Choose slider type, could be single - for one handle, or double for
+    two handles.
+    """)
+
+    values = List(Any, help="""
+    Set up your own array of possible slider values. They could be numbers
+    or strings. The following attributes are ignored if you supply values:
+    min, max and step.
+    """)
+
+    grid = Bool(default=True, help="""
+    Show the grid beneath the slider.
+    """)
+
+    prettify_enabled = Bool(default=True, help="""
+    Improve readability of long numbers. 10000000 -> 10 000 000
+    """)
+
+    prettify = Instance(Callback, help="""
+    Set up your own prettify function. Can be anything. For example, you can
+    set up unix time as slider values and than transform them to cool looking
+    dates.
+    """)
+
+    force_edges = Bool(default=False, help="""
+    Slider will be always inside it's container.
+    """)
+
+    prefix = String(default="", help="""
+    Set prefix for values. Will be set up right before the number: $100
+    """)

--- a/bokeh/models/widgets/contrib/ionRangeSlider/main.py
+++ b/bokeh/models/widgets/contrib/ionRangeSlider/main.py
@@ -44,7 +44,7 @@ class IonRangeSlider(AbstractSlider):
     The maximum allowable value.
     """)
 
-    value = Tuple(Float, Float, default = [0, 1], help="""
+    value = Tuple(Any, Any, default = [0, 1], help="""
     Initial or selected range.
     """)
 

--- a/bokehjs/src/lib/models/widgets/abstract_slider.ts
+++ b/bokehjs/src/lib/models/widgets/abstract_slider.ts
@@ -20,7 +20,7 @@ export interface SliderSpec {
 export abstract class AbstractSliderView extends WidgetView {
   model: AbstractSlider
 
-  protected sliderEl: noUiSlider.Instance
+  protected sliderEl: any // To allow for extention for IonRangeSlider
   protected titleEl: HTMLElement
   protected valueEl: HTMLElement
   protected callback_wrapper?: () => void

--- a/bokehjs/src/lib/models/widgets/contrib/index.ts
+++ b/bokehjs/src/lib/models/widgets/contrib/index.ts
@@ -1,0 +1,1 @@
+export * from "./ionRangeSlider"

--- a/bokehjs/src/lib/models/widgets/contrib/ionRangeSlider/ion_range_slider.ts
+++ b/bokehjs/src/lib/models/widgets/contrib/ionRangeSlider/ion_range_slider.ts
@@ -1,11 +1,11 @@
 import $ = require('jquery')
-import {IonRangeSliderOptions, IonRangeSliderEvent} from "ion-rangeslider"
+import {IonRangeSliderOptions} from "ion-rangeslider"
 
 import {throttle} from "core/util/callback"
 // The "core/properties" module has all the property types
 import * as p from "core/properties"
 import {div, input, label} from "core/dom"
-import {logger} from "core/logging"
+//import {logger} from "core/logging"
 
 // We will subclass in JavaScript from the same class that was subclassed
 // from in Python
@@ -16,7 +16,7 @@ import {AbstractSlider, AbstractSliderView, SliderSpec} from "models/widgets/abs
 export class IonRangeSliderView extends AbstractSliderView {
   model: IonRangeSlider
 
-  protected sliderEl: null
+  protected sliderEl: HTMLElement
   protected titleEl: HTMLElement
   protected valueEl: HTMLElement
   protected value_type: string
@@ -32,7 +32,7 @@ export class IonRangeSliderView extends AbstractSliderView {
   }
 
   protected _calc_from(values: string[] | string): string[] | number[] {
-    var parsed_values: number[] | string[]
+    var parsed_values: number[] | string[] = Array()
 
     if (!(values instanceof Array)) {
       switch(this.value_type) {
@@ -99,8 +99,6 @@ export class IonRangeSliderView extends AbstractSliderView {
     }
     //
     // Set up parameters
-    const prefix = 'bk-ionRange-'
-
     const {start, end, value, step} = this._calc_to()
 
     //let tooltips: boolean | any[] // XXX
@@ -122,7 +120,6 @@ export class IonRangeSliderView extends AbstractSliderView {
 
       var opts: IonRangeSliderOptions = {
         type: this.model.slider_type,
-        cssPrefix: prefix,
       }
       if (this.model.values instanceof Array) {
         // If 'this.model.values' is provided, 'from' and 'to' are the indexes in the 'values' array.
@@ -267,12 +264,17 @@ export class IonRangeSlider extends AbstractSlider {
       force_edges:       [ p.Bool,        false        ],
       prefix:            [ p.String,      ""           ],
     })
+
+    this.override({
+      bar_color: '#ed5565',
+      start: 0,
+      end: 1,
+      value: [0, 1],
+      step: 0.1,
+      show_value: false,
+      title: ''
+    })
   }
-  start = 0
-  end   = 1
-  value = [0, 1]
-  step = 0.1
-  bar_color = null
 
   protected _formatter(value: number, _format: string): string {
     return `${value}`

--- a/bokehjs/src/lib/models/widgets/contrib/ionRangeSlider/ion_range_slider.ts
+++ b/bokehjs/src/lib/models/widgets/contrib/ionRangeSlider/ion_range_slider.ts
@@ -1,0 +1,271 @@
+//jQuery(input).ionRangeSlider(opts)
+import $ = require('jquery')
+//import "ion-rangeslider"
+import {IonRangeSliderOptions, IonRangeSliderEvent} from "ion-rangeslider"
+
+import {throttle} from "core/util/callback"
+// The "core/properties" module has all the property types
+import * as p from "core/properties"
+import {div, input, label} from "core/dom"
+import {logger} from "core/logging"
+
+// We will subclass in JavaScript from the same class that was subclassed
+// from in Python
+import {Widget} from "models/widgets/widget"
+import {AbstractSlider, AbstractSliderView, SliderSpec} from "models/widgets/abstract_slider"
+
+
+export class IonRangeSliderView extends AbstractSliderView {
+  model: IonRangeSlider
+
+    //protected sliderEl: any
+    //protected titleEl: HTMLElement
+    //protected valueEl: HTMLElement
+    //protected callback_wrapper?: () => void
+
+  protected _calc_to(): SliderSpec {
+    return {
+      start: this.model.start,
+      end: this.model.end,
+      value: this.model.value,
+      step: this.model.step,
+    }
+  }
+
+  protected _calc_from(values: number[]): number[] {
+    if (!(values instanceof Array))
+      values = [values, values]
+    return values
+  }
+
+  initialize(options: any): void {
+    super.initialize(options)
+    logger.info('Initialize function called, rendering..')
+    this.render()
+  }
+
+  render(): void {
+    logger.info(`[ionRangeSlider] Start rendering`)
+    logger.info(this.model)
+    if (this.model.format) {
+      logger.warn('[ionRangeSlider] Option format currently ignored')
+    }
+    if (this.sliderEl == null) {
+      logger.info(`[ionRangeSlider] am I here?`)
+      // XXX: temporary workaround for _render_css()
+      this._render_classes() // XXX: because no super()
+
+      // LayoutDOMView sets up lots of helpful things, but
+      // it's render method is not suitable for widgets - who
+      // should provide their own.
+      if (this.model.height != null)
+        this.el.style.height = `${this.model.height}px`
+      if (this.model.width != null)
+        this.el.style.width = `${this.model.width}px`
+    }
+
+    logger.info(`[ionRangeSlider] Setting callback`)
+    if (this.model.callback != null) {
+      logger.info('[ionRangeSlider] Callback non-zero')
+      const callback = () => this.model.callback.execute(this.model)
+
+      switch (this.model.callback_policy) {
+        case 'continuous': {
+          this.callback_wrapper = callback
+          break
+        }
+        case 'throttle': {
+          this.callback_wrapper = throttle(callback, this.model.callback_throttle)
+          break
+        }
+      }
+    }
+    //
+    // Set up parameters
+    const prefix = 'bk-ionRange-'
+
+    const {start, end, value, step} = this._calc_to()
+
+    //logger.info(`[ionRangeSlider] Setting tooltips`)
+    //let tooltips: boolean | any[] // XXX
+    //if (this.model.tooltips) {
+    //  const formatter = {
+    //    to: (value: number): string => this.model.pretty(value),
+    //  }
+
+    //  tooltips = repeat(formatter, value.length)
+    //} else
+    //  tooltips = false
+
+    this.el.classList.add("bk-slider")
+    console.log(this.sliderEl)
+    console.log(this.model.values)
+    console.log(this.model.values instanceof Array)
+    if (this.sliderEl == null) {
+      this.sliderEl = input({type: "text", class: "slider", id: this.model.id})
+      //this.sliderEl = input({type: "text", class: "slider", id: 'blerger'})
+      this.el.appendChild(this.sliderEl) // XXX: bad typings; no cssPrefix
+
+
+      console.log('[ionRangeSlider] initializing external class')
+      var opts: IonRangeSliderOptions = {
+        type: this.model.slider_type,
+        cssPrefix: prefix,
+      }
+      if (this.model.values instanceof Array) {
+        opts.values = this.model.values
+      } else {
+        opts.min  = start
+        opts.max  = end
+        opts.from = value[0]
+        opts.to   = value[1]
+        opts.step = step
+      }
+      opts.grid = this.model.grid
+      opts.prettify_enabled = this.model.prettify_enabled
+      opts.prettify = this.model.prettify
+      opts.force_edges = this.model.force_edges
+      opts.prefix = this.model.prefix
+      console.log(this.model.disabled)
+      opts.disable = this.model.disabled
+
+      $(this.sliderEl).ionRangeSlider(opts);
+      console.log('prop')
+      console.log($(this.sliderEl).prop('value'))
+      $(this.sliderEl).on('change', (data) => this._slide(data)) // ~= slide
+      $(this.el).on('finish', (data) => this._change(data)) // ~= change
+
+      console.log('[ionRangeSlider] Setting color')
+      $(this.el).find('.irs-bar').css('background', this.model.bar_color)
+      $(this.el).find('.irs-bar-edge').css('background', this.model.bar_color)
+      $(this.el).find('.irs-single').css('background', this.model.bar_color)
+
+      if (this.callback_wrapper != null)
+          this.callback_wrapper()
+
+
+      if (this.titleEl != null)
+        this.el.removeChild(this.titleEl)
+      if (this.valueEl != null)
+        this.el.removeChild(this.valueEl)
+
+      if (this.model.title != null) {
+        if (this.model.title.length != 0) {
+          this.titleEl = label({}, `${this.model.title}:`)
+          this.el.insertBefore(this.titleEl, this.sliderEl)
+        }
+
+        if (this.model.show_value) {
+          const pretty = value.map((v) => this.model.pretty(v)).join(" .. ")
+          this.valueEl = div({class: "bk-slider-value"}, pretty)
+          this.el.insertBefore(this.valueEl, this.sliderEl)
+        }
+      } //endif: this.model.title != null
+    } //endif: this.sliderEl == null
+  } //function: render
+
+  protected _slide(data): void {
+    console.log('sliding!')
+    console.log($(this.sliderEl))
+    const ion_value = $(this.sliderEl).prop('value')
+    console.log(ion_value)
+    const value = this._calc_from(ion_value)
+    console.log(value)
+    this.model.value = value
+    if (this.callback_wrapper != null)
+      this.callback_wrapper()
+  }
+
+  protected _change(data): void {
+    const ion_value = $(this.sliderEl).prop('value')
+    const value = this._calc_from(ion_value)
+    this.model.value = value
+    switch (this.model.callback_policy) {
+      case 'mouseup':
+      case 'throttle': {
+        if (this.model.callback != null)
+          this.model.callback.execute(this.model)
+        break
+      }
+    }
+  }
+} //namespace: IonRangeSliderView
+
+      //    opts = {
+      //      onChange: this.slide,
+      //      onFinish: this.slidestop,
+      //    }
+      //
+      //    this.model.range = range
+      //    this.$el.find( "////{ this.model.id }" ).val( range.join(' - '))
+      //    this.$el.find('.bk-slider-parent').height(this.model.height)
+      //
+      //
+      //  slidestop: (data) =>
+      //    if this.model.callback_policy == 'mouseup' or this.model.callback_policy == 'throttle'
+      //      this.model.callback?.execute(this.model)
+      //
+      //  slide: (data) =>
+      //    range = [data.from, data.to]
+      //    value = range.join(' - ')
+      //    this.$el.find( "////{ this.model.id }" ).val( value )
+      //    this.model.range = range
+      //    if this.callbackWrapper then this.callbackWrapper()
+      //
+      //  prettify: (data) =>
+      //    this.model.prettify?.execute(data)
+
+export namespace IonRangeSlider {
+  export interface Attrs extends Widget.Attrs {
+    slider_type:       string
+    values:            any
+    grid:              boolean
+    prettify_enabled:  boolean
+    prettify:          any
+    force_edges:       boolean
+    prefix:            string
+  }
+
+  export interface Props extends Widget.Props {}
+}
+
+export interface IonRangeSlider extends IonRangeSlider.Attrs {}
+
+export class IonRangeSlider extends AbstractSlider {
+
+  properties: IonRangeSlider.Props
+
+  constructor(attrs?: Partial<IonRangeSlider.Attrs>) {
+    super(attrs)
+  }
+
+  static initClass(): void {
+    this.prototype.type = "IonRangeSlider"
+    this.prototype.default_view = IonRangeSliderView
+
+    this.define({
+      slider_type:       [ p.String,      "single"     ],
+      values:            [ p.Any,                      ],
+      grid:              [ p.Bool,        true         ],
+      prettify_enabled:  [ p.Bool,        true         ],
+      prettify:          [ p.Any,         null         ],
+      force_edges:       [ p.Bool,        false        ],
+      prefix:            [ p.String,      ""           ],
+    })
+  }
+  start = 0
+  end   = 1
+  value = [0, 1]
+  step = 0.1
+  bar_color = ''
+
+  protected _formatter(value: number, _format: string): string {
+    return `${value}`
+  }
+
+  pretty(value: number): string {
+    return this._formatter(value, this.format)
+  }
+}
+
+IonRangeSlider.initClass()

--- a/bokehjs/src/lib/models/widgets/contrib/main.ts
+++ b/bokehjs/src/lib/models/widgets/contrib/main.ts
@@ -1,0 +1,5 @@
+import * as IonRangeSlider from "./index"
+export {IonRangeSlider}
+
+import {register_models} from "../../../base"
+register_models(IonRangeSlider as any)

--- a/examples/models/file/ion_range_sliders_playground.py
+++ b/examples/models/file/ion_range_sliders_playground.py
@@ -15,7 +15,7 @@ from bokeh.util.browser import view
 from bokeh.models.layouts import Row, Column, WidgetBox
 from bokeh.models.widgets import Div
 from bokeh.models.callbacks import CustomJS
-from bokeh_ion_rangeslider import *
+from bokeh.models.contrib.IonRangeSlider import *
 
 slider = IonRangeSlider(title="Numerical", value=[50, 10000], start=0, end=96, step=5)
 duo_slider = IonRangeSlider(slider_type='double', title="Numerical", value=[50, 10000], start=0, end=96, step=5)

--- a/examples/models/file/ion_range_sliders_playground.py
+++ b/examples/models/file/ion_range_sliders_playground.py
@@ -7,17 +7,18 @@ sys.path.append('..')
 
 from IPython import embed
 
-from bokeh.io import show, save
+from bokeh.io import show, save, curdoc
 from bokeh.document import Document
 from bokeh.embed import file_html
 from bokeh.resources import INLINE
 from bokeh.util.browser import view
 from bokeh.models.layouts import Row, Column, WidgetBox
 from bokeh.models.widgets import Div
-from bokeh.models.widgets.contrib.ionRangeSlider import IonRangeSlider
 from bokeh.models.callbacks import CustomJS
+from bokeh_ion_rangeslider import *
 
 slider = IonRangeSlider(title="Numerical", value=[50, 10000], start=0, end=96, step=5)
+duo_slider = IonRangeSlider(slider_type='double', title="Numerical", value=[50, 10000], start=0, end=96, step=5)
 
 disabled_slider = IonRangeSlider(title="Disabled", value=[50, 50], start=0, end=96, step=5, disabled=True)
 
@@ -26,6 +27,15 @@ range_slider = IonRangeSlider(title="Numerical range", value=[30, 70], start=0, 
 only_value_slider = IonRangeSlider(value=[50, 50], start=0, end=96, step=5)
 
 no_title_slider = IonRangeSlider(title=None, value=[50, 50], start=0, end=96, step=5)
+
+round = CustomJS(code="""
+         var f = cb_obj
+         f = Number(f.toPrecision(2))
+         return f
+     """)
+
+prettified_slider = IonRangeSlider(title=None, values=[1, 2, 3.141592, 1000000], start=0, end=96, step=5, prettify=round)
+string_slider = IonRangeSlider(title=None, values=['apple', 'banana', 'cherry', 'kiwi'], value=('banana', 'banana'), prettify=round)
 
 def color_picker():
     def color_slider(title, color):
@@ -38,12 +48,8 @@ def color_picker():
     div = Div(width=100, height=100, style=dict(backgroundColor="rgb(127, 127, 127"))
 
     cb = CustomJS(args=dict(red=red, green=green, blue=blue, div=div), code="""
-        console.log('setting color!')
         var color = "rgb(" + red.value[0] + ", " + green.value[0] + ", " + blue.value[0] + ")";
-        console.log(color)
         div.style = {backgroundColor: color};
-        console.log('setting color!')
-        console.log(div)
     """)
 
     red.callback   = cb
@@ -56,25 +62,59 @@ def color_picker():
         WidgetBox(width=50, children=[blue]),
         div,
     ])
-round = CustomJS(code="""
-         var f = cb_obj
-         f = Number(f.toPrecision(2))
-         return f
-     """)
+
+def color_picker_python():
+    def color_slider(title, color):
+        return IonRangeSlider(title=title, show_value=False, height=300, value=[127, 127], start=0, end=255, step=1, orientation="vertical", bar_color=color, grid=False)
+
+    red   = color_slider("R", "red")
+    green = color_slider("G", "green")
+    blue  = color_slider("B", "blue")
+
+    div = Div(width=100, height=100, style=dict(backgroundColor="rgb(127, 127, 127"))
+
+    cb = CustomJS(args=dict(red=red, green=green, blue=blue, div=div), code="""
+        var color = "rgb(" + red.value[0] + ", " + green.value[0] + ", " + blue.value[0] + ")";
+        div.style = {backgroundColor: color};
+    """)
+    def callback(attr, old, new):
+        #color = slider._property_values['bar_color']
+        div.style['backgroundColor'] = 'rgb({:d},{:d},{:d})'.format(red.value[0], green.value[0], blue.value[0])
+        return
+
+    red.on_change('value', callback)
+    green.on_change('value', callback)
+    blue.on_change('value', callback)
+
+    return Column(children=[
+        Div(text="Only works with 'bokeh serve'"),
+        Row(children=[
+            WidgetBox(width=50, children=[red]),
+            WidgetBox(width=50, children=[green]),
+            WidgetBox(width=50, children=[blue]),
+            div,
+        ])
+    ])
 test_slider = IonRangeSlider(slider_type='double', start=0, end=77, values=[1,2,3.123123,40.1234], prettify=round)
 
 sliders = Row(children=[
     Column(children=[
         slider,
+        duo_slider,
         disabled_slider,
         range_slider,
         only_value_slider,
         no_title_slider,
+        prettified_slider,
+        string_slider
     ]),
-    color_picker(),
+   Column(children=[
+        color_picker(),
+        color_picker_python(),
+    ])
 ])
 
-doc = Document()
+doc = curdoc()
 doc.add_root(sliders)
 save(doc)
 

--- a/examples/models/file/ion_range_sliders_playground.py
+++ b/examples/models/file/ion_range_sliders_playground.py
@@ -1,0 +1,87 @@
+from __future__ import print_function
+
+#from datetime import date
+import os
+import sys
+sys.path.append('..')
+
+from IPython import embed
+
+from bokeh.io import show, save
+from bokeh.document import Document
+from bokeh.embed import file_html
+from bokeh.resources import INLINE
+from bokeh.util.browser import view
+from bokeh.models.layouts import Row, Column, WidgetBox
+from bokeh.models.widgets import Div
+from bokeh.models.widgets.contrib.ionRangeSlider import IonRangeSlider
+from bokeh.models.callbacks import CustomJS
+
+slider = IonRangeSlider(title="Numerical", value=[50, 10000], start=0, end=96, step=5)
+
+disabled_slider = IonRangeSlider(title="Disabled", value=[50, 50], start=0, end=96, step=5, disabled=True)
+
+range_slider = IonRangeSlider(title="Numerical range", value=[30, 70], start=0, end=100, step=0.5)
+
+only_value_slider = IonRangeSlider(value=[50, 50], start=0, end=96, step=5)
+
+no_title_slider = IonRangeSlider(title=None, value=[50, 50], start=0, end=96, step=5)
+
+def color_picker():
+    def color_slider(title, color):
+        return IonRangeSlider(title=title, show_value=False, height=300, value=[127, 127], start=0, end=255, step=1, orientation="vertical", bar_color=color, grid=False)
+
+    red   = color_slider("R", "red")
+    green = color_slider("G", "green")
+    blue  = color_slider("B", "blue")
+
+    div = Div(width=100, height=100, style=dict(backgroundColor="rgb(127, 127, 127"))
+
+    cb = CustomJS(args=dict(red=red, green=green, blue=blue, div=div), code="""
+        console.log('setting color!')
+        var color = "rgb(" + red.value[0] + ", " + green.value[0] + ", " + blue.value[0] + ")";
+        console.log(color)
+        div.style = {backgroundColor: color};
+        console.log('setting color!')
+        console.log(div)
+    """)
+
+    red.callback   = cb
+    green.callback = cb
+    blue.callback  = cb
+
+    return Row(children=[
+        WidgetBox(width=50, children=[red]),
+        WidgetBox(width=50, children=[green]),
+        WidgetBox(width=50, children=[blue]),
+        div,
+    ])
+round = CustomJS(code="""
+         var f = cb_obj
+         f = Number(f.toPrecision(2))
+         return f
+     """)
+test_slider = IonRangeSlider(slider_type='double', start=0, end=77, values=[1,2,3.123123,40.1234], prettify=round)
+
+sliders = Row(children=[
+    Column(children=[
+        slider,
+        disabled_slider,
+        range_slider,
+        only_value_slider,
+        no_title_slider,
+    ]),
+    color_picker(),
+])
+
+doc = Document()
+doc.add_root(sliders)
+save(doc)
+
+#if __name__ == "__main__":
+#    doc.validate()
+#    filename = "ion_range_sliders.html"
+#    with open(filename, "w") as f:
+#        f.write(file_html(doc, INLINE, "ion_range_sliders"))
+#    print("Wrote %s" % filename)
+#    view(filename)


### PR DESCRIPTION
Based on:
https://github.com/bokeh/bokeh/issues/7852
https://github.com/Karel-van-de-Plassche/bokeh-ion-rangeslider

Related to:
https://github.com/bokeh/bokeh/issues/7853
https://github.com/bokeh/bokeh/issues/7852

To do:
- [ ] issues: fixes #7853 and #7852 
- [ ] Approve folder structure [by: @mattpap]
- [ ] Decide how to handle dependencies (`jquery` + `ion-rangeslider` + `@types/jquery` + `@types/ion-rangeslider`)
- [ ] Decide to split this into RangeSlider and SingleSlider, right now this is set by 'slider_type` attribute. [by @mattpap or @bryevdv ]
- [ ] Tests passed
- [ ] Add tests
- [ ] release document entry (if new feature or API change)

Fix bugs:
- [ ] `Uncaught Error: Model 'IonRangeSlider' does not exist. This could be due to a widget
                     or a custom model not being registered before first usage.`
- [ ] Dependency collision between `es6-promise` and `jquery` `@types`
- [ ] Python callbacks not working

Fixed in external repo (not in this pull request)
- Prettify CustomJS function