### PR TITLE
make grid bands handle ends correctly

### DIFF
--- a/bokehjs/src/lib/models/grids/grid.ts
+++ b/bokehjs/src/lib/models/grids/grid.ts
@@ -229,6 +229,14 @@ export class Grid extends GuideRenderer {
     const cmax = cross_range.max
 
     const coords: [number[][], number[][]] = [[], []]
+
+    if (!exclude_ends) {
+      if (ticks[0] != min)
+        ticks.splice(0, 0, min)
+      if (ticks[ticks.length-1] != max)
+        ticks.push(max)
+    }
+
     for (let ii = 0; ii < ticks.length; ii++) {
       if ((ticks[ii] == min || ticks[ii] == max) && exclude_ends)
         continue

--- a/bokehjs/test/models/grids/grid.coffee
+++ b/bokehjs/test/models/grids/grid.coffee
@@ -84,3 +84,51 @@ it "use user bounds when set'", ->
     })
 
     expect(grid.computed_bounds()).to.be.deep.equal [1, 9]
+
+  it "should return major grid_coords without ends by default", ->
+    doc = new Document()
+    p = new Plot({
+      x_range: new Range1d({start: 0.1, end: 9.9})
+      y_range: new Range1d({start: 0.1, end: 9.9})
+    })
+    doc.add_root(p)
+    ticker = new BasicTicker()
+    formatter = new BasicTickFormatter()
+    axis = new Axis({
+      ticker: ticker
+      formatter: formatter
+      plot: p
+    })
+    axis.attach_document(p.document)
+    p.add_layout(axis, 'below')
+    grid = new Grid({
+      ticker: ticker
+      plot: p
+    })
+
+    expect(grid.grid_coords('major')).to.be.deep.equal [[[2,2], [4,4], [6,6], [8,8]], [[0.1,9.9], [0.1,9.9], [0.1,9.9], [0.1,9.9]]]
+
+    it "should return major grid_coords with ends when asked", ->
+    doc = new Document()
+    p = new Plot({
+      x_range: new Range1d({start: 0.1, end: 9.9})
+      y_range: new Range1d({start: 0.1, end: 9.9})
+    })
+    doc.add_root(p)
+    ticker = new BasicTicker()
+    formatter = new BasicTickFormatter()
+    axis = new Axis({
+      ticker: ticker
+      formatter: formatter
+      plot: p
+    })
+    axis.attach_document(p.document)
+    p.add_layout(axis, 'below')
+    grid = new Grid({
+      ticker: ticker
+      plot: p
+    })
+
+    expect(grid.grid_coords('major', false)).to.be.deep.equal [
+      [[0.1,0.1], [2,2], [4,4], [6,6], [8,8], [9.9,9.9]], [[0.1,9.9], [0.1,9.9], [0.1,9.9], [0.1,9.9], [0.1,9.9], [0.1,9.9]]
+     ]


### PR DESCRIPTION
- [x] issues: fixes #6698
- [x] tests added / passed

Does not fix the flickering issue, going to punt on that. But makes sure the ends are always alternating from the first full band:

<img width="362" alt="screen shot 2018-05-08 at 21 53 09" src="https://user-images.githubusercontent.com/1078448/39796296-9288b948-530a-11e8-8a01-a67a6d974dcb.png">
