### PR TITLE
Image hover documentation and tests

### DIFF
--- a/bokehjs/test/core/util/templating.ts
+++ b/bokehjs/test/core/util/templating.ts
@@ -113,6 +113,13 @@ describe("templating module", () => {
 
     const source = new ColumnDataSource({data: {foo: [10, 1.002], bar: ["a", "<div>b</div>"], baz: [1492890671885, 1290460671885]}})
 
+    const imsource = new ColumnDataSource({data:
+                                           {arrs: [[[0, 10, 20], [30, 40, 50]]],
+                                            floats: [[0.,1.,2.,3.,4.,5.]],
+                                            labels: ['test label']}})
+    const imindex1 = {index: 0, dim1: 2, dim2: 1, flat_index: 5}
+    const imindex2 = {index: 0, dim1: 1, dim2: 0, flat_index: 1}
+
     it("should return $ values from special_vars", () => {
       const v = tmpl.get_value("$x", source, 0, {"x": 99999})
       expect(v).to.be.equal(99999)
@@ -134,6 +141,31 @@ describe("templating module", () => {
       const v2 = tmpl.get_value("foo", source, 1, {})
       expect(v2).to.be.equal(1.002)
     })
+
+    it("should index flat typed array format for images", () => {
+      const v1 = tmpl.get_value("floats", imsource, imindex1, {})
+      expect(v1).to.be.equal(5)
+
+      const v2 = tmpl.get_value("floats", imsource, imindex2, {})
+      expect(v2).to.be.equal(1)
+    })
+
+    it("should index array of arrays format for images", () => {
+      const v1 = tmpl.get_value("arrs", imsource, imindex1, {})
+      expect(v1).to.be.equal(50)
+
+      const v2 = tmpl.get_value("arrs", imsource, imindex2, {})
+      expect(v2).to.be.equal(10)
+    })
+
+    it("should index scalar data format for images", () => {
+      const v1 = tmpl.get_value("labels", imsource, imindex1, {})
+      expect(v1).to.be.equal('test label')
+
+      const v2 = tmpl.get_value("labels", imsource, imindex2, {})
+      expect(v2).to.be.equal('test label')
+    })
+
   })
 
   describe("replace_placeholders", () => {

--- a/examples/plotting/file/image.py
+++ b/examples/plotting/file/image.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from bokeh.plotting import figure, show, output_file
+from bokeh.models import HoverTool
 
 N = 500
 x = np.linspace(0, 10, N)
@@ -8,7 +9,8 @@ y = np.linspace(0, 10, N)
 xx, yy = np.meshgrid(x, y)
 d = np.sin(xx)*np.cos(yy)
 
-p = figure(x_range=(0, 10), y_range=(0, 10))
+p = figure(x_range=(0, 10), y_range=(0, 10),
+           tools=[HoverTool(tooltips=[("x", "$x"), ("y", "$y"), ("value", "@image")])])
 
 # must give a vector of image data for image parameter
 p.image(image=[d], x=0, y=0, dw=10, dh=10, palette="Spectral11")

--- a/sphinx/docserver.py
+++ b/sphinx/docserver.py
@@ -2,9 +2,11 @@ from __future__ import print_function
 
 import flask
 import os
+import sys
 import threading
 import time
 import webbrowser
+import tornado
 
 from tornado.wsgi import WSGIContainer
 from tornado.httpserver import HTTPServer
@@ -58,6 +60,10 @@ def ui():
         pass
 
 if __name__ == "__main__":
+
+    if tornado.version_info[0] == 4:
+        print('docserver.py script requires tornado 5 or higher')
+        sys.exit(1)
 
     print("\nStarting Bokeh plot server on port %d..." % PORT)
     print("Visit http://localhost:%d/en/latest/index.html to see plots\n" % PORT)

--- a/sphinx/source/docs/user_guide/examples/tools_hover_tooltips_image.py
+++ b/sphinx/source/docs/user_guide/examples/tools_hover_tooltips_image.py
@@ -4,14 +4,13 @@ from bokeh.models import HoverTool
 
 output_file("tools_hover_tooltip_image.html")
 
-img1 = np.array([np.linspace(0, 10, 200)]*20)
-img2 = np.array([np.linspace(0, 10, 10)]*20)
-img3 = np.random.rand(25, 10) > 0.5
+ramp = np.array([np.linspace(0, 10, 200)]*20)
+steps = np.array([np.linspace(0, 10, 10)]*20)
+bitmask = np.random.rand(25, 10) > 0.5
 
-
-data = dict(image=[img1, img2, img3],
-            pattern=['smooth ramp', 'steps', 'bit mask'],
-            tenfold=[img1*10, img2*10, img3*10],
+data = dict(image=[ramp, steps, bitmask],
+            squared=[ramp**2, steps**2, bitmask**2],
+            pattern=['smooth ramp', 'steps', 'bitmask'],
             x=[0, 0, 25],
             y=[5, 20, 5],
             dw=[20,  20, 10],
@@ -20,11 +19,11 @@ data = dict(image=[img1, img2, img3],
 cds = ColumnDataSource(data=data)
 hover = HoverTool(tooltips=[
     ('index', "$index"),
+    ('pattern', '@pattern'),
     ("x", "$x"),
     ("y", "$y"),
-    ('pattern', '@pattern'),
-    ('10x', '@tenfold'),
-    ("value", "@image")], )
+    ("value", "@image"),
+    ('squared', '@squared')], )
 
 p = figure( x_range=(0, 35), y_range=(0, 35), tools=[hover, 'wheel_zoom'])
 p.image(source=cds, image='image', x='x', y='y', dw='dw', dh='dh', palette="Inferno256")

--- a/sphinx/source/docs/user_guide/examples/tools_hover_tooltips_image.py
+++ b/sphinx/source/docs/user_guide/examples/tools_hover_tooltips_image.py
@@ -1,0 +1,31 @@
+import numpy as np
+from bokeh.plotting import figure, output_file, show, ColumnDataSource
+from bokeh.models import HoverTool
+
+output_file("tools_hover_tooltip_image.html")
+
+img1 = np.array([np.linspace(0, 10, 200)]*20)
+img2 = np.array([np.linspace(0, 10, 10)]*20)
+img3 = np.random.rand(25, 10) > 0.5
+
+
+data = dict(image=[img1, img2, img3],
+            pattern=['smooth ramp', 'steps', 'bit mask'],
+            tenfold=[img1*10, img2*10, img3*10],
+            x=[0, 0, 25],
+            y=[5, 20, 5],
+            dw=[20,  20, 10],
+            dh=[10,  10, 25])
+
+cds = ColumnDataSource(data=data)
+hover = HoverTool(tooltips=[
+    ('index', "$index"),
+    ("x", "$x"),
+    ("y", "$y"),
+    ('pattern', '@pattern'),
+    ('10x', '@tenfold'),
+    ("value", "@image")], )
+
+p = figure( x_range=(0, 35), y_range=(0, 35), tools=[hover, 'wheel_zoom'])
+p.image(source=cds, image='image', x='x', y='y', dw='dw', dh='dh', palette="Inferno256")
+show(p)

--- a/sphinx/source/docs/user_guide/plotting.rst
+++ b/sphinx/source/docs/user_guide/plotting.rst
@@ -258,6 +258,12 @@ raw RGBA data using |image_rgba|:
 .. bokeh-plot:: docs/user_guide/examples/plotting_image.py
     :source-position: above
 
+The hover tool allows interactive inspection of the values specified at
+any chosen pixel. For more information on how to enable hover with
+images, please consult the hover tool section of the :ref:`tools user
+guide <userguide_tools_inspectors>`.
+
+
 .. _userguide_plotting_segments_rays:
 
 Segments and Rays

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -566,6 +566,21 @@ to specify a custom formatter that can display derived quantities in the
 tooltip.
 
 
+Image Hover
+'''''''''''
+
+The hover tool can be used to inspect image glyphs which may contain
+layers of data in the corresponding ``ColumnDataSource``:
+
+
+.. bokeh-plot:: docs/user_guide/examples/tools_hover_tooltips_image.py
+    :source-position: above
+
+In this example, three image patterns are defined named ``ramp``,
+``steps`` and ``bitmask``. The hover tooltip shows the index of the
+image, the name of the pattern, the ``x`` and ``y`` position of the
+cursor as well as the corresponding value and value squared.
+
 .. _custom_hover_tooltip:
 
 Custom Tooltip

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -561,6 +561,10 @@ over the plot below:
 .. bokeh-plot:: docs/user_guide/examples/tools_hover_tooltip_formatting.py
     :source-position: none
 
+Using the |CustomJSHover| model, it is also possible to use JavaScript
+to specify a custom formatter that can display derived quantities in the
+tooltip.
+
 
 .. _custom_hover_tooltip:
 
@@ -858,6 +862,7 @@ properties on |Plot| objects that control LOD behavior:
 .. |figure| replace:: :func:`~bokeh.plotting.figure`
 
 .. |HoverTool| replace:: :class:`~bokeh.models.tools.HoverTool`
+.. |CustomJSHover| replace:: :class:`~bokeh.models.tools.CustomJSHover` 
 
 .. |NumeralTickFormatter| replace:: :class:`~bokeh.models.formatters.NumeralTickFormatter`
 .. |DatetimeTickFormatter| replace:: :class:`~bokeh.models.formatters.DatetimeTickFormatter`

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -877,7 +877,7 @@ properties on |Plot| objects that control LOD behavior:
 .. |figure| replace:: :func:`~bokeh.plotting.figure`
 
 .. |HoverTool| replace:: :class:`~bokeh.models.tools.HoverTool`
-.. |CustomJSHover| replace:: :class:`~bokeh.models.tools.CustomJSHover` 
+.. |CustomJSHover| replace:: :class:`~bokeh.models.tools.CustomJSHover`
 
 .. |NumeralTickFormatter| replace:: :class:`~bokeh.models.formatters.NumeralTickFormatter`
 .. |DatetimeTickFormatter| replace:: :class:`~bokeh.models.formatters.DatetimeTickFormatter`


### PR DESCRIPTION

This PR follows on from #7651 to add an example, an entry in the user guide, other miscellaneous documentation (e.g a pointer from the image glyph section) and unit tests.

In the first commit a new ``tools_hover_tooltips_image.py`` example is added which looks like this:

<img src="https://user-images.githubusercontent.com/890576/39835969-cf3fe040-53c9-11e8-9df7-3b215c73b661.png" width="50%"></img>

I'm open to suggestions on how to improve this example. In particular, @bryevdv suggested that the bit mask would look better if the two colors contrasted less.