### PR TITLE
Don't use encode_utf8(), keep unicode and encode when writing

### DIFF
--- a/bokeh/command/subcommands/file_output.py
+++ b/bokeh/command/subcommands/file_output.py
@@ -7,8 +7,6 @@ from abc import abstractmethod
 import argparse
 import io
 
-from bokeh.util.string import decode_utf8
-
 from ..subcommand import Subcommand
 from ..util import build_single_handler_applications, die
 
@@ -129,10 +127,10 @@ class FileOutputSubcommand(Subcommand):
         '''
         contents = self.file_contents(args, doc)
         if filename == '-':
-            print(decode_utf8(contents))
+            print(contents)
         else:
             with io.open(filename, "w", encoding="utf-8") as file:
-                file.write(decode_utf8(contents))
+                file.write(contents)
         self.after_write_file(args, filename, doc)
 
     # can be overridden optionally

--- a/bokeh/command/subcommands/svg.py
+++ b/bokeh/command/subcommands/svg.py
@@ -47,7 +47,6 @@ import warnings
 
 from ...io.export import get_svgs, create_webdriver, terminate_webdriver
 from ...models.plots import Plot
-from ...util.string import decode_utf8
 from .file_output import FileOutputSubcommand
 
 class SVG(FileOutputSubcommand):
@@ -100,7 +99,7 @@ class SVG(FileOutputSubcommand):
         contents = self.file_contents(args, doc)
         for i, svg in enumerate(contents):
             if filename == '-':
-                print(decode_utf8(svg))
+                print(svg)
             else:
                 if i == 0:
                     filename = filename
@@ -108,7 +107,7 @@ class SVG(FileOutputSubcommand):
                     idx = filename.find(".svg")
                     filename = filename[:idx] + "_{}".format(i) + filename[idx:]
                 with io.open(filename, "w", encoding="utf-8") as f:
-                    f.write(decode_utf8(svg))
+                    f.write(svg)
             self.after_write_file(args, filename, doc)
 
     def file_contents(self, args, doc):

--- a/bokeh/embed/notebook.py
+++ b/bokeh/embed/notebook.py
@@ -30,7 +30,6 @@ from contextlib import contextmanager
 from ..core.templates import DOC_NB_JS
 from ..core.json_encoder import serialize_json
 from ..settings import settings
-from ..util.string import encode_utf8
 from .util import FromCurdoc
 from .util import check_one_model_or_doc, div_for_render_item, find_existing_docs, standalone_docs_json_and_render_items
 
@@ -94,7 +93,7 @@ def notebook_content(model, notebook_comms_target=None, theme=FromCurdoc):
 
     div = div_for_render_item(item)
 
-    return encode_utf8(script), encode_utf8(div), new_doc
+    return script, div, new_doc
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/bokeh/embed/server.py
+++ b/bokeh/embed/server.py
@@ -30,7 +30,7 @@ from six.moves.urllib.parse import urlparse, quote_plus
 from ..core.templates import AUTOLOAD_TAG, FILE
 from ..resources import DEFAULT_SERVER_HTTP_URL
 from ..util.serialization import make_id
-from ..util.string import encode_utf8, format_docstring
+from ..util.string import format_docstring
 from .bundle import bundle_for_objs_and_resources
 from .util import html_page_for_render_items
 
@@ -101,7 +101,7 @@ def server_document(url="default", relative_urls=False, resources="default", arg
         elementid = elementid,
     )
 
-    return encode_utf8(tag)
+    return tag
 
 def server_session(model=None, session_id=None, url="default", relative_urls=False, resources="default", arguments=None):
     ''' Return a script tag that embeds content from a specific existing session on
@@ -190,7 +190,7 @@ def server_session(model=None, session_id=None, url="default", relative_urls=Fal
         modelid   = modelid,
     )
 
-    return encode_utf8(tag)
+    return tag
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/embed/standalone.py
+++ b/bokeh/embed/standalone.py
@@ -33,7 +33,6 @@ from ..document.document import DEFAULT_TITLE, Document
 from ..model import Model
 from ..settings import settings
 from ..util.compiler import bundle_all_models
-from ..util.string import encode_utf8
 from .bundle import bundle_for_objs_and_resources
 from .util import FromCurdoc
 from .util import (check_models_or_docs, check_one_model_or_doc, div_for_render_item, find_existing_docs, html_page_for_render_items,
@@ -97,7 +96,7 @@ def autoload_static(model, resources, script_path):
         docid = item.get('docid', ''),
     )
 
-    return encode_utf8(js), encode_utf8(tag)
+    return js, tag
 
 def components(models, wrap_script=True, wrap_plot_info=True, theme=FromCurdoc):
     ''' Return HTML components to embed a Bokeh plot. The data for the plot is
@@ -158,7 +157,7 @@ def components(models, wrap_script=True, wrap_plot_info=True, theme=FromCurdoc):
             instance of the ``Theme`` class.
 
     Returns:
-        UTF-8 encoded *(script, div[s])* or *(raw_script, plot_info[s])*
+        *(script, div[s])* or *(raw_script, plot_info[s])*
 
     Examples:
 
@@ -214,7 +213,6 @@ def components(models, wrap_script=True, wrap_plot_info=True, theme=FromCurdoc):
     script += script_for_render_items(docs_json, render_items)
     if wrap_script:
         script = wrap_in_script_tag(script)
-    script = encode_utf8(script)
 
     if wrap_plot_info:
         results = list(div_for_render_item(item) for item in render_items)
@@ -270,7 +268,7 @@ def file_html(models,
             instance of the ``Theme`` class.
 
     Returns:
-        UTF-8 encoded HTML
+        HTML
 
     '''
     models = check_models_or_docs(models)

--- a/bokeh/embed/tests/test_server.py
+++ b/bokeh/embed/tests/test_server.py
@@ -146,10 +146,6 @@ class TestServerDocument(object):
 
 class TestServerSession(object):
 
-    def test_return_type(self, test_plot):
-        r = bes.server_session(test_plot, session_id='fakesession')
-        assert isinstance(r, str)
-
     def test_script_attrs_session_id_provided(self, test_plot):
         r = bes.server_session(test_plot, session_id='fakesession')
         assert 'bokeh-session-id=fakesession' in r

--- a/bokeh/embed/tests/test_standalone.py
+++ b/bokeh/embed/tests/test_standalone.py
@@ -32,7 +32,6 @@ from bokeh.io import curdoc
 from bokeh.model import Model
 from bokeh.plotting import figure
 from bokeh.resources import CDN, JSResources, CSSResources
-from bokeh.util.string import encode_utf8
 
 # Module under test
 import bokeh.embed.standalone as bes
@@ -151,10 +150,6 @@ class Test_components(object):
         assert div.attrs['class'] == ['bk-plotdiv']
         assert div.text == ''
 
-    def test_script_is_utf8_encoded(self, test_plot):
-        script, div = bes.components(test_plot)
-        assert isinstance(script, str)
-
     @patch('bokeh.embed.util.make_id', new_callable=lambda: stable_id)
     def test_output_is_without_script_tag_when_wrap_script_is_false(self, mock_make_id, test_plot):
         script, div = bes.components(test_plot)
@@ -169,44 +164,12 @@ class Test_components(object):
         #self.maxDiff = None
         #assert rawscript.strip() == script_content.strip()
 
-class Test_file_html(object):
-
-    def test_return_type(self, test_plot):
-
-        class fake_template:
-            def __init__(self, tester, user_template_variables=None):
-                self.tester = tester
-                self.template_variables = {
-                    "title",
-                    "bokeh_js",
-                    "bokeh_css",
-                    "plot_script",
-                    "plot_div"
-                }
-                if user_template_variables is not None:
-                    self.template_variables.update(user_template_variables)
-
-            def render(self, template_variables):
-                assert self.template_variables.issubset(set(template_variables.keys()))
-                return "template result"
-
-        r = bes.file_html(test_plot, CDN, "title")
-        assert isinstance(r, str)
-
-        r = bes.file_html(test_plot, CDN, "title", fake_template(self))
-        assert isinstance(r, str)
-
-        r = bes.file_html(test_plot, CDN, "title",
-                            fake_template(self, {"test_var"}),
-                            {"test_var": "test"})
-        assert isinstance(r, str)
-
     @patch('bokeh.embed.bundle.warn')
     def test_file_html_handles_js_only_resources(self, mock_warn, test_plot):
         js_resources = JSResources(mode="relative", components=["bokeh"])
         template = Template("<head>{{ bokeh_js }}</head><body></body>")
         output = bes.file_html(test_plot, (js_resources, None), "title", template=template)
-        html = encode_utf8("<head>%s</head><body></body>" % js_resources.render_js())
+        html = "<head>%s</head><body></body>" % js_resources.render_js()
         assert output == html
 
     @patch('bokeh.embed.bundle.warn')
@@ -222,7 +185,7 @@ class Test_file_html(object):
         css_resources = CSSResources(mode="relative", components=["bokeh"])
         template = Template("<head>{{ bokeh_css }}</head><body></body>")
         output = bes.file_html(test_plot, (None, css_resources), "title", template=template)
-        html = encode_utf8("<head>%s</head><body></body>" % css_resources.render_css())
+        html = "<head>%s</head><body></body>" % css_resources.render_css()
         assert output == html
 
     @patch('bokeh.embed.bundle.warn')

--- a/bokeh/embed/util.py
+++ b/bokeh/embed/util.py
@@ -35,7 +35,7 @@ from ..model import Model
 from ..settings import settings
 from ..util.compiler import bundle_all_models
 from ..util.serialization import make_id
-from ..util.string import encode_utf8, indent
+from ..util.string import indent
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -150,8 +150,7 @@ def html_page_for_render_items(bundle, docs_json, render_items, title,
         plot_div = "\n".join(div_for_render_item(item) for item in render_items)
     ))
 
-    html = template.render(template_variables_full)
-    return encode_utf8(html)
+    return template.render(template_variables_full)
 
 def script_for_render_items(docs_json_or_id, render_items, app_path=None, absolute_url=None):
     '''

--- a/bokeh/io/export.py
+++ b/bokeh/io/export.py
@@ -36,7 +36,6 @@ from tempfile import mkstemp
 from ..embed import file_html
 from ..resources import INLINE
 from ..util.dependencies import import_required, detect_phantomjs
-from ..util.string import decode_utf8
 from .util import default_filename
 
 #-----------------------------------------------------------------------------

--- a/bokeh/io/export.py
+++ b/bokeh/io/export.py
@@ -13,7 +13,7 @@
 # Boilerplate
 #-----------------------------------------------------------------------------
 from __future__ import absolute_import, division, print_function, unicode_literals
-from six import raise_from, b
+from six import raise_from
 
 import logging
 log = logging.getLogger(__name__)
@@ -173,7 +173,7 @@ def get_screenshot_as_png(obj, driver=None, **kwargs):
     with _tmp_html() as tmp:
         html = get_layout_html(obj, **kwargs)
         with io.open(tmp.path, mode="w", encoding="utf-8") as file:
-            file.write(decode_utf8(html))
+            file.write(html)
 
         web_driver = driver if driver is not None else create_webdriver()
 
@@ -204,8 +204,8 @@ def get_svgs(obj, driver=None, **kwargs):
     '''
     with _tmp_html() as tmp:
         html = get_layout_html(obj, **kwargs)
-        with io.open(tmp.path, mode="wb") as file:
-            file.write(b(html))
+        with io.open(tmp.path, mode="w", encoding="utf-8") as file:
+            file.write(html)
 
         web_driver = driver if driver is not None else create_webdriver()
 

--- a/bokeh/io/saving.py
+++ b/bokeh/io/saving.py
@@ -30,7 +30,6 @@ from warnings import warn
 
 # Bokeh imports
 from ..settings import settings
-from ..util.string import decode_utf8
 from .state import curstate
 from .util import default_filename
 
@@ -145,7 +144,7 @@ def _save_helper(obj, filename, resources, title):
     html = file_html(obj, resources, title=title)
 
     with io.open(filename, mode="w", encoding="utf-8") as f:
-        f.write(decode_utf8(html))
+        f.write(html)
 
 #-----------------------------------------------------------------------------
 # Code

--- a/bokeh/protocol/tests/test_receiver.py
+++ b/bokeh/protocol/tests/test_receiver.py
@@ -4,7 +4,6 @@ import pytest
 
 from bokeh.protocol import receiver, Protocol
 from bokeh.protocol.exceptions import ValidationError
-from bokeh.util.string import decode_utf8
 
 _proto = Protocol("1.0")
 
@@ -15,13 +14,13 @@ def test_validation_success():
     msg = _proto.create('ACK')
     r = receiver.Receiver(_proto)
 
-    partial = r.consume(decode_utf8(msg.header_json)).result()
+    partial = r.consume(msg.header_json).result()
     assert partial is None
 
-    partial = r.consume(decode_utf8(msg.metadata_json)).result()
+    partial = r.consume(msg.metadata_json).result()
     assert partial is None
 
-    partial = r.consume(decode_utf8(msg.content_json)).result()
+    partial = r.consume(msg.content_json).result()
     assert partial is not None
     assert partial.msgtype == msg.msgtype
     assert partial.header == msg.header
@@ -31,16 +30,16 @@ def test_validation_success():
 def test_validation_success_with_one_buffer():
     r = receiver.Receiver(_proto)
 
-    partial = r.consume(decode_utf8('{"msgtype": "PATCH-DOC", "msgid": "10", "num_buffers":1}')).result()
+    partial = r.consume(b'{"msgtype": "PATCH-DOC", "msgid": "10", "num_buffers":1}').result()
     assert partial is None
 
-    partial = r.consume(decode_utf8('{}')).result()
+    partial = r.consume(b'{}').result()
     assert partial is None
 
-    partial = r.consume(decode_utf8('{"bar": 10}')).result()
+    partial = r.consume(b'{"bar": 10}').result()
     assert partial is None
 
-    partial = r.consume(decode_utf8('header')).result()
+    partial = r.consume(b'header').result()
     assert partial is None
 
     partial = r.consume(b'payload').result()
@@ -55,12 +54,12 @@ def test_multiple_validation_success_with_multiple_buffers():
     r = receiver.Receiver(_proto)
 
     for N in range(10):
-        partial = r.consume(decode_utf8('{"msgtype": "PATCH-DOC", "msgid": "10", "num_buffers":%d}' % N)).result()
-        partial = r.consume(decode_utf8('{}')).result()
-        partial = r.consume(decode_utf8('{"bar": 10}')).result()
+        partial = r.consume(b'{"msgtype": "PATCH-DOC", "msgid": "10", "num_buffers":%d}' % N).result()
+        partial = r.consume(b'{}').result()
+        partial = r.consume(b'{"bar": 10}').result()
 
         for i in range(N):
-            partial = r.consume(decode_utf8('header%d'% i )).result()
+            partial = r.consume(b'header%d' % i).result()
             partial = r.consume(b'payload%d' % i).result()
 
         assert partial is not None
@@ -79,33 +78,33 @@ def test_binary_header_raises_error():
 def test_binary_metadata_raises_error():
     r = receiver.Receiver(_proto)
 
-    r.consume(decode_utf8('header'))
+    r.consume(b'header')
     with pytest.raises(ValidationError):
         r.consume(b'metadata').result()
 
 def test_binary_content_raises_error():
     r = receiver.Receiver(_proto)
 
-    r.consume(decode_utf8('header'))
-    r.consume(decode_utf8('metadata'))
+    r.consume(b'header')
+    r.consume(b'metadata')
     with pytest.raises(ValidationError):
         r.consume(b'content').result()
 
 def test_binary_payload_header_raises_error():
     r = receiver.Receiver(_proto)
 
-    r.consume(decode_utf8('{"msgtype": "PATCH-DOC", "msgid": "10", "num_buffers":1}'))
-    r.consume(decode_utf8('{}'))
-    r.consume(decode_utf8('{}'))
+    r.consume(b'{"msgtype": "PATCH-DOC", "msgid": "10", "num_buffers":1}')
+    r.consume(b'{}')
+    r.consume(b'{}')
     with pytest.raises(ValidationError):
         r.consume(b'buf_header').result()
 
 def test_text_payload_buffer_raises_error():
     r = receiver.Receiver(_proto)
 
-    r.consume(decode_utf8('{"msgtype": "PATCH-DOC", "msgid": "10", "num_buffers":1}'))
-    r.consume(decode_utf8('{}'))
-    r.consume(decode_utf8('{}'))
-    r.consume(decode_utf8('buf_header')).result()
+    r.consume(b'{"msgtype": "PATCH-DOC", "msgid": "10", "num_buffers":1}')
+    r.consume(b'{}')
+    r.consume(b'{}')
+    r.consume(b'buf_header').result()
     with pytest.raises(ValidationError):
-        r.consume(decode_utf8('buf_payload')).result()
+        r.consume(b'buf_payload').result()

--- a/bokeh/server/views/autoload_js_handler.py
+++ b/bokeh/server/views/autoload_js_handler.py
@@ -10,7 +10,6 @@ from six.moves.urllib.parse import urlparse
 from tornado import gen
 
 from bokeh.core.templates import AUTOLOAD_JS
-from bokeh.util.string import encode_utf8
 from bokeh.util.compiler import bundle_all_models
 from bokeh.embed.standalone import script_for_render_items
 
@@ -60,4 +59,4 @@ class AutoloadJsHandler(SessionHandler):
         )
 
         self.set_header("Content-Type", 'application/javascript')
-        self.write(encode_utf8(js))
+        self.write(js)

--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -84,7 +84,6 @@ from ..document import Document
 from ..embed import autoload_static
 from ..resources import Resources
 from ..settings import settings
-from ..util.string import decode_utf8
 from .example_handler import ExampleHandler
 from .templates import PLOT_PAGE
 
@@ -257,8 +256,8 @@ class BokehPlotDirective(Directive):
             # handle examples external to the docs source, e.g. gallery examples
             else:
                 app.debug("[bokeh-plot] handling external example in %r: %s", env.docname, self.arguments[0])
-                source = open(self.arguments[0]).read()
-                source = decode_utf8(source)
+                with io.open(self.arguments[0], "r", encoding="utf-8") as f:
+                    source = f.read()
                 docname = env.docname.replace("/", "-")
                 js_name = "bokeh-plot-%s-external-%s.js" % (docname, uuid4().hex)
                 (script, js, js_path, source) = _process_script(source, self.arguments[0], env, js_name, env.config.bokeh_plot_use_relative_paths)

--- a/bokeh/util/session_id.py
+++ b/bokeh/util/session_id.py
@@ -17,7 +17,6 @@ import time
 from six import binary_type
 
 from bokeh.settings import settings
-from bokeh.util.string import encode_utf8
 
 # Use the system PRNG for session id generation (if possible)
 # NOTE: secure random string generation implementation is adapted
@@ -154,7 +153,6 @@ def check_session_id_signature(session_id, secret_key=settings.secret_key_bytes(
         expected_signature = _signature(base_id, secret_key)
         # hmac.compare_digest() uses a string compare algorithm that doesn't
         # short-circuit so we don't allow timing analysis
-        # encode_utf8 is used to ensure that strings have same encoding
-        return hmac.compare_digest(encode_utf8(expected_signature), encode_utf8(provided_signature))
+        return hmac.compare_digest(expected_signature.encode("utf-8"), provided_signature.encode("utf-8"))
     else:
         return True

--- a/bokeh/util/string.py
+++ b/bokeh/util/string.py
@@ -5,36 +5,6 @@ from __future__ import absolute_import
 
 import re
 
-def encode_utf8(u):
-    ''' Encode a UTF-8 string to a sequence of bytes.
-
-    Args:
-        u (str) : the string to encode
-
-    Returns:
-        bytes
-
-    '''
-    import sys
-    if sys.version_info[0] == 2:
-        u = u.encode('utf-8')
-    return u
-
-def decode_utf8(u):
-    ''' Decode a sequence of bytes to a UTF-8 string
-
-    Args:
-        u (str) : the bytes to decode
-
-    Returns:
-        UTF-8 string
-
-    '''
-    import sys
-    if sys.version_info[0] == 2:
-        u = u.decode('utf-8')
-    return u
-
 def indent(text, n=2, ch=" "):
     ''' Indent all the lines in a given block of text by a specified ammount.
 

--- a/bokeh/util/tests/test_session_id.py
+++ b/bokeh/util/tests/test_session_id.py
@@ -5,7 +5,6 @@ import codecs
 import unittest
 
 import bokeh.util.session_id
-from bokeh.util.string import decode_utf8
 from bokeh.util.session_id import ( generate_session_id,
                                     generate_secret_key,
                                     check_session_id_signature,
@@ -98,4 +97,4 @@ class TestSessionId(unittest.TestCase):
         # originates from #6653
         session_id = generate_session_id(signed=True, secret_key="abc")
         self.assertTrue(check_session_id_signature(session_id, secret_key="abc", signed=True))
-        self.assertTrue(check_session_id_signature(decode_utf8(session_id), secret_key="abc", signed=True))
+        self.assertTrue(check_session_id_signature(session_id.decode("utf-8"), secret_key="abc", signed=True))

--- a/examples/app/stocks/download_sample_data.py
+++ b/examples/app/stocks/download_sample_data.py
@@ -1,7 +1,7 @@
 import os
+import io
 from six.moves import urllib
 import zipfile
-from bokeh.util.string import encode_utf8
 
 
 def extract_hosted_zip(data_url, save_dir, exclude_term=None):
@@ -53,8 +53,8 @@ def extract_zip(zip_name, exclude_term=None):
 
                 # read file from zip, then write to new directory
                 data = z.read(zip_file)
-                with open(dest_file, 'wb') as f:
-                    f.write(encode_utf8(data))
+                with io.open(dest_file, 'w', encoding="utf-8") as f:
+                    f.write(data)
 
     except zipfile.error as e:
         print("Bad zipfile (%r): %s" % (zip_name, e))

--- a/examples/embed/simple/simple.py
+++ b/examples/embed/simple/simple.py
@@ -17,7 +17,6 @@ import flask
 from bokeh.embed import components
 from bokeh.plotting import figure
 from bokeh.resources import INLINE
-from bokeh.util.string import encode_utf8
 
 app = flask.Flask(__name__)
 
@@ -67,7 +66,7 @@ def polynomial():
         _from=_from,
         to=to
     )
-    return encode_utf8(html)
+    return html
 
 if __name__ == "__main__":
     print(__doc__)


### PR DESCRIPTION
This is a bit excessive to fix #7885, however, I was curious how badly I will break bokeh when I remove all `encode_utf8()` calls. The only case where I needed to add `.encode("utf-8")` (in both 2 and 3) was when comparing HMAC. Otherwise it's sufficient to make sure files are open with `io.open(..., "w", encoding="utf-8")`. Lets see if tests are all green (I verified unit tests locally). This is a breaking change, I didn't update docstrings, etc. Some removed tests could be updated and restored.

fixes #7901 
