### PR TITLE
Fixes #3596: Warn on generating static HTML with Python callbacks

### DIFF
--- a/bokeh/embed/standalone.py
+++ b/bokeh/embed/standalone.py
@@ -28,7 +28,6 @@ import re
 # External imports
 
 # Bokeh imports
-from ..model import collect_models
 from ..core.templates import AUTOLOAD_JS, AUTOLOAD_TAG, FILE
 from ..document.document import DEFAULT_TITLE, Document
 from ..model import Model

--- a/bokeh/embed/standalone.py
+++ b/bokeh/embed/standalone.py
@@ -28,6 +28,7 @@ import re
 # External imports
 
 # Bokeh imports
+from ..model import collect_models
 from ..core.templates import AUTOLOAD_JS, AUTOLOAD_TAG, FILE
 from ..document.document import DEFAULT_TITLE, Document
 from ..model import Model
@@ -274,6 +275,10 @@ def file_html(models,
 
     '''
     models = check_models_or_docs(models)
+    for model in collect_models(models):
+        if len(model._callbacks) > 0 or len(model._event_callbacks) > 0:
+            log.warn(' Python callback in static document. Use CustomJS instead.')
+            break
 
     with _ModelInDocument(models, apply_theme=theme):
         (docs_json, render_items) = standalone_docs_json_and_render_items(models)

--- a/bokeh/embed/standalone.py
+++ b/bokeh/embed/standalone.py
@@ -275,10 +275,6 @@ def file_html(models,
 
     '''
     models = check_models_or_docs(models)
-    for model in collect_models(models):
-        if len(model._callbacks) > 0 or len(model._event_callbacks) > 0:
-            log.warn(' Python callback in static document. Use CustomJS instead.')
-            break
 
     with _ModelInDocument(models, apply_theme=theme):
         (docs_json, render_items) = standalone_docs_json_and_render_items(models)

--- a/bokeh/embed/tests/test_util.py
+++ b/bokeh/embed/tests/test_util.py
@@ -23,6 +23,8 @@ import pytest ; pytest
 
 # Bokeh imports
 from bokeh.model import Model
+from bokeh.core.properties import Int, String, Instance, List
+from bokeh.document.document import Document
 
 # Module under test
 import bokeh.embed.util as beu
@@ -30,6 +32,49 @@ import bokeh.embed.util as beu
 #-----------------------------------------------------------------------------
 # Setup
 #-----------------------------------------------------------------------------
+# Taken from test_callback_manager.py
+class _GoodPropertyCallback(object):
+
+    def __init__(self):
+        self.last_name = None
+        self.last_old = None
+        self.last_new = None
+
+    def __call__(self, name, old, new):
+        self.method(name, old, new)
+
+    def method(self, name, old, new):
+        self.last_name = name
+        self.last_old = old
+        self.last_new = new
+
+    def partially_good(self, name, old, new, newer):
+        pass
+
+    def just_fine(self, name, old, new, extra='default'):
+        pass
+
+class _GoodEventCallback(object):
+
+    def __init__(self):
+        self.last_name = None
+        self.last_old = None
+        self.last_new = None
+
+    def __call__(self, event):
+        self.method(event)
+
+    def method(self, event):
+        self.event = event
+
+    def partially_good(self, arg, event):
+        pass
+
+# Taken from test_model
+class SomeModel(Model):
+    a = Int(12)
+    b = String("hello")
+    c = List(Int, [1, 2, 3])
 
 #-----------------------------------------------------------------------------
 # General API
@@ -81,7 +126,14 @@ class Test_script_for_render_items(object):
     pass
 
 class Test_standalone_docs_json_and_render_items(object):
-    pass
+    def test_log_warning_if_python_property_callback(self):
+        d = Document()
+        m1 = SomeModel()
+        c1 = _GoodPropertyCallback()
+        d.add_root(m1)
+
+        m1.on_change('name', c1)
+        beu.standalone_docs_json_and_render_items(m1)
 
 class Test_wrap_in_onload(object):
 

--- a/bokeh/embed/tests/test_util.py
+++ b/bokeh/embed/tests/test_util.py
@@ -27,6 +27,7 @@ from bokeh.model import Model
 from bokeh.core.properties import Int, String, List
 from bokeh.document.document import Document
 from bokeh.util.logconfig import basicConfig
+from bokeh.events import Tap
 
 # Module under test
 import bokeh.embed.util as beu
@@ -152,7 +153,7 @@ class Test_standalone_docs_json_and_render_items(object):
         c1 = _GoodEventCallback()
         d.add_root(m1)
 
-        m1.on_event('tap', c1)
+        m1.on_event(Tap, c1)
         assert len(m1._event_callbacks) != 0
 
         with caplog.at_level(logging.WARN):

--- a/bokeh/embed/tests/test_util.py
+++ b/bokeh/embed/tests/test_util.py
@@ -24,7 +24,7 @@ import logging
 
 # Bokeh imports
 from bokeh.model import Model
-from bokeh.core.properties import Int, String, Instance, List
+from bokeh.core.properties import Int, String, List
 from bokeh.document.document import Document
 from bokeh.util.logconfig import basicConfig
 
@@ -76,7 +76,7 @@ class _GoodEventCallback(object):
         pass
 
 # Taken from test_model
-class SomeModel(Model):
+class EmbedTestUtilModel(Model):
     a = Int(12)
     b = String("hello")
     c = List(Int, [1, 2, 3])
@@ -134,7 +134,7 @@ class Test_standalone_docs_json_and_render_items(object):
 
     def test_log_warning_if_python_property_callback(self, caplog):
         d = Document()
-        m1 = SomeModel()
+        m1 = EmbedTestUtilModel()
         c1 = _GoodPropertyCallback()
         d.add_root(m1)
 
@@ -148,7 +148,7 @@ class Test_standalone_docs_json_and_render_items(object):
 
     def test_log_warning_if_python_event_callback(self, caplog):
         d = Document()
-        m1 = SomeModel()
+        m1 = EmbedTestUtilModel()
         c1 = _GoodEventCallback()
         d.add_root(m1)
 


### PR DESCRIPTION
Thought the safest way to check this is on static HTML generation. Does not warn when generating JSON though, but don't think it is needed. You can test this functionality with this snippet:

``` python
from bokeh.io import curdoc, show
from bokeh.plotting import figure
from bokeh.models.widgets import Button
from bokeh.models import CustomJS
from bokeh.layouts import column
from bokeh.events import ButtonClick

from IPython import embed

# Create plot and buttons
plot = figure(plot_height=400, plot_width=400)
click_button = Button()
change_button = Button()
event_button = Button()
change_js_button = Button()
event_js_button = Button()

# Define callbacks
def handler(*args):
    print('Clicked!')

def handler2(attr, old, new):
    print('Clicked!')

js_handler = CustomJS(code='console.log("JS:Click")')

# Connect callbacks
click_button.on_click(handler)
change_button.on_change('clicks', handler2)
event_button.on_event(ButtonClick, handler)
change_js_button.js_on_click(js_handler)
event_js_button.js_on_event(ButtonClick, js_handler)

# Add to layout. Run with `bokeh serve` for no warnings, or run with python or `bokeh html` for warnings
layout = column(plot, click_button, change_button, event_button, change_js_button, event_js_button)
curdoc().add_root(layout)
show(layout)
```

- [x] issues: fixes #3596
- [x] tests added / passed

Was not sure where and if to put a test for this, not very familiar with selinium, but looking into it.