### PR TITLE
Made tile attributions less distracting

### DIFF
--- a/bokehjs/src/less/main.less
+++ b/bokehjs/src/less/main.less
@@ -3,3 +3,7 @@
   display: block;
   border: 1px dashed green;
 }
+
+.bk-tile-attribution a {
+  color: black;
+}

--- a/bokehjs/src/lib/models/tiles/tile_renderer.ts
+++ b/bokehjs/src/lib/models/tiles/tile_renderer.ts
@@ -100,9 +100,10 @@ export class TileRendererView extends RendererView {
             right: `${right}px`,
             'max-width': `${max_width}px`,
             padding: "2px",
-            'background-color': 'rgba(255,255,255,0.8)',
-            'font-size': '9pt',
+            'background-color': 'rgba(255,255,255,0.5)',
+            'font-size': '7pt',
             'font-family': 'sans-serif',
+            'line-height': '1.05',
           },
         })
 

--- a/bokehjs/src/lib/models/tiles/tile_renderer.ts
+++ b/bokehjs/src/lib/models/tiles/tile_renderer.ts
@@ -85,10 +85,10 @@ export class TileRendererView extends RendererView {
   }
 
   protected _add_attribution(): void {
-    const { attribution } = this.model.tile_source
+    const {attribution} = this.model.tile_source
 
-    if (isString(attribution) && (attribution.length > 0)) {
-      if ((this.attributionEl == null)) {
+    if (isString(attribution) && attribution.length > 0) {
+      if (this.attributionEl == null) {
         const right = this.plot_model.canvas._right.value - this.plot_model.frame._right.value
         const bottom = this.plot_model.canvas._bottom.value - this.plot_model.frame._bottom.value
         const max_width = this.map_frame._width.value
@@ -98,12 +98,15 @@ export class TileRendererView extends RendererView {
             position: "absolute",
             bottom: `${bottom}px`,
             right: `${right}px`,
-            'max-width': `${max_width}px`,
+            'max-width': `${max_width - 4 /*padding*/}px`,
             padding: "2px",
             'background-color': 'rgba(255,255,255,0.5)',
             'font-size': '7pt',
             'font-family': 'sans-serif',
             'line-height': '1.05',
+            'white-space': 'nowrap',
+            overflow: 'hidden',
+            'text-overflow': 'ellipsis',
           },
         })
 
@@ -112,6 +115,7 @@ export class TileRendererView extends RendererView {
       }
 
       this.attributionEl.innerHTML = attribution
+      this.attributionEl.title = this.attributionEl.textContent!.replace(/\s*\n\s*/g, " ")
     }
   }
 


### PR DESCRIPTION
As described in https://github.com/bokeh/bokeh/issues/7908, the attribution text for tile sources is currently quite distractingly large, particularly for small plots:

![image](https://user-images.githubusercontent.com/1695496/40151049-2d1c8e6a-5943-11e8-8d0c-682a41d0a883.png)

After applying this PR, the text should still be readable, but is less distracting:

![image](https://user-images.githubusercontent.com/1695496/40150898-18a69512-5942-11e8-9872-aef8c2e25509.png)

Open issue: Is there a way to avoid coloring the link text blue?  It's very difficult to read in certain cases (see the black and white Stamen example above), and it's hard to make a background color that works well for both black and bright blue text when combined with various elements that might be in the map tiles.  I can see how to change any CSS elements that apply to the general text here, but not for link anchors.


