### PR TITLE
Bryanv/usability

### DIFF
--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -22,7 +22,7 @@ from .ranges import Range, FactorRange, DataRange1d, Range1d
 from .renderers import GlyphRenderer, Renderer, TileRenderer
 from .scales import Scale, CategoricalScale, LinearScale, LogScale
 from .sources import DataSource, ColumnDataSource
-from .tools import Tool, Toolbar
+from .tools import Tool, Toolbar, HoverTool
 
 def _check_conflicting_kwargs(a1, a2, kwargs):
     if a1 in kwargs and a2 in kwargs:
@@ -160,6 +160,14 @@ class Plot(LayoutDOM):
         '''
         legends = [obj for obj in self.renderers if isinstance(obj, Legend)]
         return _list_attr_splat(legends)
+
+    @property
+    def hover(self):
+        ''' Splattable list of :class:`~bokeh.models.tools.HoverTool` objects.
+
+        '''
+        hovers = [obj for obj in self.tools if isinstance(obj, HoverTool)]
+        return _list_attr_splat(hovers)
 
     def _grid(self, dimension):
         grid = [obj for obj in self.renderers if isinstance(obj, Grid) and obj.dimension==dimension]

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -647,6 +647,7 @@ class CustomJSHover(Model):
     * ``data_x`` data-space x-coordinate of the hovered glyph
     * ``data_y`` data-space y-coordinate of the hovered glyph
     * ``indices`` column indices of all currently hovered glyphs
+    * ``name`` value of the ``name`` property of the hovered glyph renderer
 
     If the hover is over a "multi" glyph such as ``Patches`` or ``MultiLine``
     then a ``segment_index`` key will also be present.
@@ -895,7 +896,8 @@ class HoverTool(Inspection):
 
     Field names starting with "$" are special, known fields:
 
-    :$index: index of selected point in the data source
+    :$index: index of hovered point in the data source
+    :$name: value of the ``name`` property of the hovered glyph renderer
     :$x: x-coordinate under the cursor in data space
     :$y: y-coordinate under the cursor in data space
     :$sx: x-coordinate under the cursor in screen (canvas) space
@@ -914,6 +916,13 @@ class HoverTool(Inspection):
     Note that if a column name contains spaces, the it must be supplied by
     surrounding it in curly braces, e.g. ``@{adjusted close}`` will display
     values from a column named ``"adjusted close"``.
+
+    Sometimes (especially with stacked charts) it is desirable to allow the
+    name of the column be specified indirectly. The field name ``@$name`` is
+    distinguished in that it will look up the ``name`` field on the hovered
+    glyph renderer, and use that value as the column name. For instance, if
+    a user hovers with the name ``"US East"``, then ``@$name`` is equivalent to
+    ``@{US East}``.
 
     By default, values for fields (e.g. ``@foo``) are displayed in a basic
     numeric format. However it is possible to control the formatting of values

--- a/bokeh/plotting/figure.py
+++ b/bokeh/plotting/figure.py
@@ -822,6 +822,10 @@ Examples:
             stackers (seq[str]) : a list of data source field names to stack
                 successively for ``left`` and ``right`` bar coordinates.
 
+                Additionally, the ``name`` of the renderer will be set to
+                the value of each successive stacker (this is useful with the
+                special hover variable ``$name``)
+
         Any additional keyword arguments are passed to each call to ``hbar``.
         If a keyword value is a list or tuple, then each call will get one
         value from the sequence.
@@ -843,8 +847,8 @@ Examples:
 
             .. code-block:: python
 
-                p.hbar(bottom=stack(),       top=stack('2016'),         x=10, width=0.9, color='blue', source=source)
-                p.hbar(bottom=stack('2016'), top=stack('2016', '2017'), x=10, width=0.9, color='red', source=source)
+                p.hbar(bottom=stack(),       top=stack('2016'),         x=10, width=0.9, color='blue', source=source, name='2016')
+                p.hbar(bottom=stack('2016'), top=stack('2016', '2017'), x=10, width=0.9, color='red',  source=source, name='2017')
 
         '''
         result = []
@@ -859,6 +863,10 @@ Examples:
         Args:
             stackers (seq[str]) : a list of data source field names to stack
                 successively for ``left`` and ``right`` bar coordinates.
+
+                Additionally, the ``name`` of the renderer will be set to
+                the value of each successive stacker (this is useful with the
+                special hover variable ``$name``)
 
         Any additional keyword arguments are passed to each call to ``vbar``.
         If a keyword value is a list or tuple, then each call will get one
@@ -881,8 +889,8 @@ Examples:
 
             .. code-block:: python
 
-                p.vbar(bottom=stack(),       top=stack('2016'),         x=10, width=0.9, color='blue', source=source)
-                p.vbar(bottom=stack('2016'), top=stack('2016', '2017'), x=10, width=0.9, color='red', source=source)
+                p.vbar(bottom=stack(),       top=stack('2016'),         x=10, width=0.9, color='blue', source=source, name='2016')
+                p.vbar(bottom=stack('2016'), top=stack('2016', '2017'), x=10, width=0.9, color='red',  source=source, name='2017')
 
 
         '''

--- a/bokeh/plotting/figure.py
+++ b/bokeh/plotting/figure.py
@@ -5,7 +5,7 @@ logger = logging.getLogger(__name__)
 
 from six import string_types
 
-from ..core.properties import Any, Auto, Either, Enum, Int, Seq, Instance, String
+from ..core.properties import Any, Auto, Either, Enum, Int, List, Seq, Instance, String, Tuple
 from ..core.enums import HorizontalLocation, VerticalLocation
 from ..models import ColumnDataSource, Plot, Title, Tool, GraphRenderer
 from ..models import glyphs, markers
@@ -83,6 +83,10 @@ class FigureOptions(Options):
     The type of the y-axis.
     """)
 
+    tooltips = Either(String, List(Tuple(String, String)), help="""
+
+    """)
+
 class Figure(Plot):
     ''' A subclass of :class:`~bokeh.models.plots.Plot` that simplifies plot
     creation with default axes, grids, tools, etc.
@@ -144,7 +148,7 @@ class Figure(Plot):
         _process_axis_and_grid(self, opts.x_axis_type, opts.x_axis_location, opts.x_minor_ticks, opts.x_axis_label, self.x_range, 0)
         _process_axis_and_grid(self, opts.y_axis_type, opts.y_axis_location, opts.y_minor_ticks, opts.y_axis_label, self.y_range, 1)
 
-        tool_objs, tool_map = _process_tools_arg(self, opts.tools)
+        tool_objs, tool_map = _process_tools_arg(self, opts.tools, opts.tooltips)
         self.add_tools(*tool_objs)
         _process_active_tools(self.toolbar, tool_map, opts.active_drag, opts.active_inspect, opts.active_scroll, opts.active_tap)
 

--- a/bokeh/plotting/figure.py
+++ b/bokeh/plotting/figure.py
@@ -84,7 +84,12 @@ class FigureOptions(Options):
     """)
 
     tooltips = Either(String, List(Tuple(String, String)), help="""
-
+    An optional argument to configure tooltips for the Figure. This argument
+    accepts the same values as the ``HoverTool.tooltips`` property. If a hover
+    tool is specified in the ``tools`` argument, this value will override that
+    hover tools ``tooltips`` value. If no hover tool is specified in the
+    ``tools`` argument, then passing tooltips here will cause one to be created
+    and added.
     """)
 
 class Figure(Plot):

--- a/bokeh/plotting/helpers.py
+++ b/bokeh/plotting/helpers.py
@@ -490,7 +490,7 @@ def _process_axis_and_grid(plot, axis_type, axis_location, minor_ticks, axis_lab
             getattr(plot, axis_location).append(axis)
 
 
-def _process_tools_arg(plot, tools):
+def _process_tools_arg(plot, tools, tooltips=None):
     """ Adds tools to the plot object
 
     Args:
@@ -498,6 +498,8 @@ def _process_tools_arg(plot, tools):
         tools (seq[Tool or str]|str): list of tool types or string listing the
             tool names. Those are converted using the _tool_from_string
             function. I.e.: `wheel_zoom,box_zoom,reset`.
+        tooltips (string or seq[tuple[str, str]], optional):
+            tooltips to use to configure a HoverTool
 
     Returns:
         list of Tools objects added to plot, map of supplied string names to tools
@@ -533,6 +535,14 @@ def _process_tools_arg(plot, tools):
 
     if repeated_tools:
         warnings.warn("%s are being repeated" % ",".join(repeated_tools))
+
+    if tooltips is not None:
+        for tool_obj in tool_objs:
+            if isinstance(tool_obj, HoverTool):
+                tool_obj.tooltips = tooltips
+                break
+        else:
+            tool_objs.append(HoverTool(tooltips=tooltips))
 
     return tool_objs, tool_map
 

--- a/bokeh/plotting/helpers.py
+++ b/bokeh/plotting/helpers.py
@@ -51,7 +51,7 @@ def _stack(stackers, spec0, spec1, **kw):
     _kw = []
 
     for i, val in enumerate(stackers):
-        d  = {}
+        d  = {'name': val}
         s0 = list(s1)
         s1.append(val)
 

--- a/bokeh/plotting/tests/test_helpers.py
+++ b/bokeh/plotting/tests/test_helpers.py
@@ -81,7 +81,7 @@ def test__stack_broadcast_with_no_kwargs():
     kws = _stack(stackers, 'start', 'end')
     assert len(kws) == len(stackers)
     for i, kw in enumerate(kws):
-        assert set(['start', 'end']) == set(kw.keys())
+        assert set(['start', 'end', 'name']) == set(kw.keys())
         assert list(kw['start']['expr'].fields) == stackers[:i]
         assert list(kw['end']['expr'].fields) == stackers[:(i+1)]
 
@@ -90,22 +90,49 @@ def test__stack_broadcast_with_scalar_kwargs():
     kws = _stack(stackers, 'start', 'end', foo=10, bar="baz")
     assert len(kws) == len(stackers)
     for i, kw in enumerate(kws):
-        assert set(['start', 'end', 'foo', 'bar']) == set(kw.keys())
+        assert set(['start', 'end', 'foo', 'bar', 'name']) == set(kw.keys())
         assert list(kw['start']['expr'].fields) == stackers[:i]
         assert list(kw['end']['expr'].fields) == stackers[:(i+1)]
         assert kw['foo'] == 10
         assert kw['bar'] == "baz"
+        assert kw['name'] == stackers[i]
 
 def test__stack_broadcast_with_list_kwargs():
     stackers = ['a', 'b', 'c', 'd']
     kws = _stack(stackers, 'start', 'end', foo=[10, 20, 30, 40], bar="baz")
     assert len(kws) == len(stackers)
     for i, kw in enumerate(kws):
-        assert set(['start', 'end', 'foo', 'bar']) == set(kw.keys())
+        assert set(['start', 'end', 'foo', 'bar', 'name']) == set(kw.keys())
         assert list(kw['start']['expr'].fields) == stackers[:i]
         assert list(kw['end']['expr'].fields) == stackers[:(i+1)]
         assert kw['foo'] == [10, 20, 30, 40][i]
         assert kw['bar'] == "baz"
+        assert kw['name'] == stackers[i]
+
+def test__stack_broadcast_name_scalar_overrides():
+    stackers = ['a', 'b', 'c', 'd']
+    kws = _stack(stackers, 'start', 'end', foo=[10, 20, 30, 40], bar="baz", name="name")
+    assert len(kws) == len(stackers)
+    for i, kw in enumerate(kws):
+        assert set(['start', 'end', 'foo', 'bar', 'name']) == set(kw.keys())
+        assert list(kw['start']['expr'].fields) == stackers[:i]
+        assert list(kw['end']['expr'].fields) == stackers[:(i+1)]
+        assert kw['foo'] == [10, 20, 30, 40][i]
+        assert kw['bar'] == "baz"
+        assert kw['name'] == "name"
+
+def test__stack_broadcast_name_list_overrides():
+    names = ["aa", "bb", "cc", "dd"]
+    stackers = ['a', 'b', 'c', 'd']
+    kws = _stack(stackers, 'start', 'end', foo=[10, 20, 30, 40], bar="baz", name=names)
+    assert len(kws) == len(stackers)
+    for i, kw in enumerate(kws):
+        assert set(['start', 'end', 'foo', 'bar', 'name']) == set(kw.keys())
+        assert list(kw['start']['expr'].fields) == stackers[:i]
+        assert list(kw['end']['expr'].fields) == stackers[:(i+1)]
+        assert kw['foo'] == [10, 20, 30, 40][i]
+        assert kw['bar'] == "baz"
+        assert kw['name'] == names[i]
 
 def test__graph_will_convert_dataframes_to_sources():
     node_source = pd.DataFrame(data=dict(foo=[]))

--- a/bokehjs/src/lib/core/util/templating.ts
+++ b/bokehjs/src/lib/core/util/templating.ts
@@ -119,6 +119,9 @@ export function replace_placeholders(str: string, data_source: ColumnarDataSourc
   // this extracts the $x, @x, @{x} without any trailing {format}
   const raw_spec = str.replace(/(?:^|[^@])([@|\$](?:\w+|{[^{}]+}))(?:{[^{}]+})?/g, (_match, raw_spec, _format) => `${raw_spec}`)
 
+  // this handles the special case @$name, replacing it with an @var corresponding to special_vars.name
+  str = str.replace(/@\$name/g, (_match) => `@{${special_vars.name}}`)
+
   // this prepends special vars with "@", e.g "$x" becomes "@$x", so subsequent processing is simpler
   str = str.replace(/(^|[^\$])\$(\w+)/g, (_match, prefix, name) => `${prefix}@$${name}`)
 

--- a/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
+++ b/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
@@ -240,7 +240,19 @@ export class HoverToolView extends InspectToolView {
         }
       }
 
-      const vars = {index: ii, x: x, y: y, sx: sx, sy: sy, data_x: data_x, data_y: data_y, rx: rx, ry: ry, indices: indices.line_indices}
+      const vars = {
+        index: ii,
+        x:       x,
+        y:       y,
+        sx:      sx,
+        sy:      sy,
+        data_x:  data_x,
+        data_y:  data_y,
+        rx:      rx,
+        ry:      ry,
+        indices: indices.line_indices,
+        name:    renderer_view.model.name,
+      }
       tooltip.add(rx, ry, this._render_tooltips(ds, ii, vars))
     }
 
@@ -291,7 +303,18 @@ export class HoverToolView extends InspectToolView {
           else
             index = i
 
-          const vars = {index: index, segment_index: jj, x: x, y: y, sx: sx, sy: sy, data_x: data_x, data_y: data_y, indices: indices.multiline_indices}
+          const vars = {
+            index:         index,
+            segment_index: jj,
+            x:             x,
+            y:             y,
+            sx:            sx,
+            sy:            sy,
+            data_x:        data_x,
+            data_y:        data_y,
+            indices:       indices.multiline_indices,
+            name:          renderer_view.model.name,
+          }
           tooltip.add(rx, ry, this._render_tooltips(ds, index, vars))
         }
       } else {
@@ -319,7 +342,17 @@ export class HoverToolView extends InspectToolView {
         else
           index = i
 
-        const vars = {index: index, x: x, y: y, sx: sx, sy: sy, data_x: data_x, data_y: data_y, indices: indices.indices}
+        const vars = {
+          index:   index,
+          x:       x,
+          y:       y,
+          sx:      sx,
+          sy:      sy,
+          data_x:  data_x,
+          data_y:  data_y,
+          indices: indices.indices,
+          name:    renderer_view.model.name,
+        }
         tooltip.add(rx, ry, this._render_tooltips(ds, index, vars))
       }
     }

--- a/bokehjs/test/core/util/templating.ts
+++ b/bokehjs/test/core/util/templating.ts
@@ -269,5 +269,10 @@ describe("templating module", () => {
       const s = tmpl.replace_placeholders("stuff $foo @foo @foo @foo{(0.000 %)} @baz{%F %T}", source, 0, {"baz": "datetime"}, {"foo": "special"})
       expect(s).to.be.equal("stuff special 10 10 1000.000 % 2017-04-22 19:51:11")
     })
+
+    it("should handle special @$name case by using special_vars.name as the column", () => {
+      const s = tmpl.replace_placeholders("stuff @$name", source, 0, {}, {"name": "foo"})
+      expect(s).to.be.equal("stuff 10")
+    })
   })
 })

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -84,7 +84,7 @@ test:
     - scikit-learn
     - networkx
     - icalendar
-    - flask
+    - flask >=1.0
     - pscript
     - pyshp
 

--- a/examples/app/gapminder/main.py
+++ b/examples/app/gapminder/main.py
@@ -4,10 +4,8 @@ import pandas as pd
 from bokeh.core.properties import field
 from bokeh.io import curdoc
 from bokeh.layouts import layout
-from bokeh.models import (
-    ColumnDataSource, HoverTool, SingleIntervalTicker, Slider, Button, Label,
-    CategoricalColorMapper,
-)
+from bokeh.models import (ColumnDataSource, HoverTool, SingleIntervalTicker,
+                          Slider, Button, Label, CategoricalColorMapper)
 from bokeh.palettes import Spectral6
 from bokeh.plotting import figure
 

--- a/examples/app/movies/main.py
+++ b/examples/app/movies/main.py
@@ -6,7 +6,7 @@ import sqlite3 as sql
 
 from bokeh.plotting import figure
 from bokeh.layouts import layout, widgetbox
-from bokeh.models import ColumnDataSource, HoverTool, Div
+from bokeh.models import ColumnDataSource, Div
 from bokeh.models.widgets import Slider, Select, TextInput
 from bokeh.io import curdoc
 from bokeh.sampledata.movies_data import movie_path
@@ -52,13 +52,13 @@ y_axis = Select(title="Y Axis", options=sorted(axis_map.keys()), value="Number o
 # Create Column Data Source that will be used by the plot
 source = ColumnDataSource(data=dict(x=[], y=[], color=[], title=[], year=[], revenue=[], alpha=[]))
 
-hover = HoverTool(tooltips=[
+TOOLTIPS=[
     ("Title", "@title"),
     ("Year", "@year"),
     ("$", "@revenue")
-])
+]
 
-p = figure(plot_height=600, plot_width=700, title="", toolbar_location=None, tools=[hover])
+p = figure(plot_height=600, plot_width=700, title="", toolbar_location=None, tooltips=TOOLTIPS)
 p.circle(x="x", y="y", source=source, size=7, color="color", line_color=None, fill_alpha="alpha")
 
 

--- a/examples/plotting/file/airports_map.py
+++ b/examples/plotting/file/airports_map.py
@@ -1,32 +1,27 @@
 from __future__ import print_function
 
 from bokeh.layouts import row
-from bokeh.models import (
-    Range1d, WMTSTileSource, ColumnDataSource, HoverTool,
-)
-from bokeh.plotting import figure, show, output_file
+from bokeh.models import Range1d, WMTSTileSource
+from bokeh.plotting import figure, show
 from bokeh.sampledata.airports import data as airports
 from bokeh.tile_providers import CARTODBPOSITRON
 
-points_source = ColumnDataSource(airports)
 title = "US Airports: Field Elevation > 1500m"
 
-def plot(tile_source, filename):
-    output_file(filename, title=title)
+def plot(tile_source):
 
     # set to roughly extent of points
     x_range = Range1d(start=airports['x'].min() - 10000, end=airports['x'].max() + 10000, bounds=None)
     y_range = Range1d(start=airports['y'].min() - 10000, end=airports['y'].max() + 10000, bounds=None)
 
     # create plot and add tools
-    p = figure(tools='wheel_zoom,pan', x_range=x_range, y_range=y_range, title=title)
+    p = figure(tools='hover,wheel_zoom,pan', x_range=x_range, y_range=y_range, title=title,
+               tooltips=[("Name", "@name"), ("Elevation", "@elevation (m)")])
     p.axis.visible = False
-    hover_tool = HoverTool(tooltips=[("Name", "@name"), ("Elevation", "@elevation (m)")])
-    p.add_tools(hover_tool)
     p.add_tile(tile_source)
 
     # create point glyphs
-    p.circle(x='x', y='y', size=9, fill_color="#F46B42", line_color="#D2C4C1", line_width=1.5, source=points_source)
+    p.circle(x='x', y='y', size=9, fill_color="#F46B42", line_color="#D2C4C1", line_width=1.5, source=airports)
     return p
 
 # create a tile source
@@ -40,7 +35,7 @@ tile_options['attribution'] = """
     """
 mq_tile_source = WMTSTileSource(**tile_options)
 
-carto = plot(CARTODBPOSITRON, 'airports_map_cartodb.html')
-mq = plot(mq_tile_source, 'airports_map.html')
+carto = plot(CARTODBPOSITRON)
+mq = plot(mq_tile_source)
 
 show(row([carto, mq]))

--- a/examples/plotting/file/bar_pandas_groupby_colormapped.py
+++ b/examples/plotting/file/bar_pandas_groupby_colormapped.py
@@ -1,5 +1,4 @@
 from bokeh.io import show, output_file
-from bokeh.models import ColumnDataSource
 from bokeh.palettes import Spectral5
 from bokeh.plotting import figure
 from bokeh.sampledata.autompg import autompg as df
@@ -10,14 +9,12 @@ output_file("bar_pandas_groupby_colormapped.html")
 df.cyl = df.cyl.astype(str)
 group = df.groupby('cyl')
 
-source = ColumnDataSource(group)
-
 cyl_cmap = factor_cmap('cyl', palette=Spectral5, factors=sorted(df.cyl.unique()))
 
 p = figure(plot_height=350, x_range=group, title="MPG by # Cylinders",
            toolbar_location=None, tools="")
 
-p.vbar(x='cyl', top='mpg_mean', width=1, source=source,
+p.vbar(x='cyl', top='mpg_mean', width=1, source=group,
        line_color=cyl_cmap, fill_color=cyl_cmap)
 
 p.y_range.start = 0

--- a/examples/plotting/file/bar_pandas_groupby_nested.py
+++ b/examples/plotting/file/bar_pandas_groupby_nested.py
@@ -1,5 +1,4 @@
 from bokeh.io import show, output_file
-from bokeh.models import ColumnDataSource, HoverTool
 from bokeh.plotting import figure
 from bokeh.palettes import Spectral5
 from bokeh.sampledata.autompg import autompg_clean as df
@@ -12,13 +11,12 @@ df.yr = df.yr.astype(str)
 
 group = df.groupby(('cyl', 'mfr'))
 
-source = ColumnDataSource(group)
 index_cmap = factor_cmap('cyl_mfr', palette=Spectral5, factors=sorted(df.cyl.unique()), end=1)
 
 p = figure(plot_width=800, plot_height=300, title="Mean MPG by # Cylinders and Manufacturer",
-           x_range=group, toolbar_location=None, tools="")
+           x_range=group, toolbar_location=None, tooltips=[("MPG", "@mpg_mean"), ("Cyl, Mfr", "@cyl_mfr")])
 
-p.vbar(x='cyl_mfr', top='mpg_mean', width=1, source=source,
+p.vbar(x='cyl_mfr', top='mpg_mean', width=1, source=group,
        line_color="white", fill_color=index_cmap, )
 
 p.y_range.start = 0
@@ -27,7 +25,5 @@ p.xgrid.grid_line_color = None
 p.xaxis.axis_label = "Manufacturer grouped by # Cylinders"
 p.xaxis.major_label_orientation = 1.2
 p.outline_line_color = None
-
-p.add_tools(HoverTool(tooltips=[("MPG", "@mpg_mean"), ("Cyl, Mfr", "@cyl_mfr")]))
 
 show(p)

--- a/examples/plotting/file/bar_stacked.py
+++ b/examples/plotting/file/bar_stacked.py
@@ -1,6 +1,6 @@
 from bokeh.core.properties import value
 from bokeh.io import show, output_file
-from bokeh.models import ColumnDataSource, HoverTool
+from bokeh.models import HoverTool
 from bokeh.plotting import figure
 
 output_file("bar_stacked.html")
@@ -14,13 +14,11 @@ data = {'fruits' : fruits,
         '2016'   : [5, 3, 4, 2, 4, 6],
         '2017'   : [3, 2, 4, 4, 5, 3]}
 
-source = ColumnDataSource(data=data)
-
 p = figure(x_range=fruits, plot_height=350, title="Fruit Counts by Year",
            toolbar_location=None, tools="")
 
-renderers = p.vbar_stack(years, x='fruits', width=0.9, color=colors, source=source,
-                         legend=[value(x) for x in years], name=years)
+renderers = p.vbar_stack(years, x='fruits', width=0.9, color=colors, source=data,
+                         legend=[value(x) for x in years])
 
 for r in renderers:
     year = r.name

--- a/examples/plotting/file/bar_stacked.py
+++ b/examples/plotting/file/bar_stacked.py
@@ -1,9 +1,8 @@
 from bokeh.core.properties import value
 from bokeh.io import show, output_file
-from bokeh.models import HoverTool
 from bokeh.plotting import figure
 
-output_file("bar_stacked.html")
+output_file("stacked.html")
 
 fruits = ['Apples', 'Pears', 'Nectarines', 'Plums', 'Grapes', 'Strawberries']
 years = ["2015", "2016", "2017"]
@@ -14,19 +13,11 @@ data = {'fruits' : fruits,
         '2016'   : [5, 3, 4, 2, 4, 6],
         '2017'   : [3, 2, 4, 4, 5, 3]}
 
-p = figure(x_range=fruits, plot_height=350, title="Fruit Counts by Year",
-           toolbar_location=None, tools="")
+p = figure(x_range=fruits, plot_height=250, title="Fruit Counts by Year",
+           toolbar_location=None, tools="hover", tooltips="$name @fruits: @$name")
 
-renderers = p.vbar_stack(years, x='fruits', width=0.9, color=colors, source=data,
-                         legend=[value(x) for x in years])
-
-for r in renderers:
-    year = r.name
-    hover = HoverTool(tooltips=[
-        ("%s total" % year, "@%s" % year),
-        ("index", "$index")
-    ], renderers=[r])
-    p.add_tools(hover)
+p.vbar_stack(years, x='fruits', width=0.9, color=colors, source=data,
+             legend=[value(x) for x in years])
 
 p.y_range.start = 0
 p.x_range.range_padding = 0.1

--- a/examples/plotting/file/color_sliders.py
+++ b/examples/plotting/file/color_sliders.py
@@ -2,7 +2,7 @@ import colorsys
 import yaml
 
 from bokeh.layouts import column, row, widgetbox
-from bokeh.models import ColumnDataSource, HoverTool, CustomJS, Slider
+from bokeh.models import ColumnDataSource, CustomJS, Slider
 from bokeh.plotting import figure, output_file, show, curdoc
 from bokeh.themes import Theme
 
@@ -109,7 +109,7 @@ color_range1 = p2.rect(x='x', y='y', width=1, height=10,
                        color='crcolor', source=crsource)
 
 # set up hover tool to show color hex code and sample swatch
-p2.select_one(HoverTool).tooltips = [
+p2.hover.tooltips = [
     ('color', '$color[hex, rgb, swatch]:crcolor'),
     ('RGB levels', '@RGBs')
 ]

--- a/examples/plotting/file/custom_tooltip.py
+++ b/examples/plotting/file/custom_tooltip.py
@@ -1,6 +1,5 @@
 import pandas as pd
 
-from bokeh.models import HoverTool, ColumnDataSource
 from bokeh.plotting import figure, show
 from bokeh.sampledata.periodic_table import elements
 
@@ -19,32 +18,29 @@ colormap = {
     "transition metal"     : "#e08e79",
 }
 
-source = ColumnDataSource(
-    data=dict(
-        atomic_number=elements["atomic number"],
-        sym=elements["symbol"],
-        name=elements["name"],
-        atomic_mass = pd.to_numeric(elements['atomic mass'], errors="coerce"),
-        density=elements['density'],
-        metal=[x.title() for x in elements["metal"]],
-        type_color=[colormap[x] for x in elements["metal"]]
-    )
+data=dict(
+    atomic_number=elements["atomic number"],
+    sym=elements["symbol"],
+    name=elements["name"],
+    atomic_mass = pd.to_numeric(elements['atomic mass'], errors="coerce"),
+    density=elements['density'],
+    metal=[x.title() for x in elements["metal"]],
+    type_color=[colormap[x] for x in elements["metal"]]
 )
 
 mass_format = '{0.00}'
 
-hover = HoverTool(tooltips="""
+TOOLTIPS = """
     <div style="width: 62px; height: 62px; opacity: .8; padding: 5px; background-color: @type_color;>
     <h1 style="margin: 0; font-size: 12px;"> @atomic_number </h1>
     <h1 style="margin: 0; font-size: 24px;"><strong> @sym </strong></h1>
     <p style=" margin: 0; font-size: 8px;"><strong> @name </strong></p>
     <p style="margin: 0; font-size: 8px;"> @atomic_mass{mass_format} </p>
     </div>
-    """.format(mass_format=mass_format)
-)
+""".format(mass_format=mass_format)
 
-p = figure(plot_width=900, plot_height=450, tools=[hover], title='Densities by Atomic Mass')
-p.circle('atomic_mass', 'density', size=12, source=source, color='type_color',
+p = figure(plot_width=900, plot_height=450, tooltips=TOOLTIPS, title='Densities by Atomic Mass')
+p.circle('atomic_mass', 'density', size=12, source=data, color='type_color',
          line_color="black", legend='metal', fill_alpha=0.9)
 
 p.xaxis.axis_label= 'Atomic Mass'

--- a/examples/plotting/file/elements.py
+++ b/examples/plotting/file/elements.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from bokeh.models import ColumnDataSource, LabelSet, HoverTool
+from bokeh.models import ColumnDataSource, LabelSet
 from bokeh.plotting import figure, show, output_file
 from bokeh.sampledata.periodic_table import elements
 
@@ -20,21 +20,20 @@ melting_point_inds = [int(10*(x-low)/(high-low)) for x in melting_points] #gives
 elements['melting_colors'] = [palette[i] for i in melting_point_inds]
 
 TITLE = "Density vs Atomic Weight of Elements (colored by melting point)"
-tools = "pan,wheel_zoom,box_zoom,reset,save".split(',')
-hover = HoverTool(tooltips=[
+TOOLS = "hover,pan,wheel_zoom,box_zoom,reset,save"
+
+p = figure(tools=TOOLS, toolbar_location="above", logo="grey", plot_width=1200, title=TITLE)
+p.background_fill_color = "#dddddd"
+p.xaxis.axis_label = "atomic weight (amu)"
+p.yaxis.axis_label = "density (g/cm^3)"
+p.grid.grid_line_color = "white"
+p.hover.tooltips = [
     ("name", "@name"),
     ("symbol:", "@symbol"),
     ("density", "@density"),
     ("atomic weight", "@{atomic mass}"),
     ("melting point", "@{melting point}")
-])
-tools.append(hover)
-
-p = figure(tools=tools, toolbar_location="above", logo="grey", plot_width=1200, title=TITLE)
-p.background_fill_color = "#dddddd"
-p.xaxis.axis_label = "atomic weight (amu)"
-p.yaxis.axis_label = "density (g/cm^3)"
-p.grid.grid_line_color = "white"
+]
 
 source = ColumnDataSource(elements)
 

--- a/examples/plotting/file/geojson_points.py
+++ b/examples/plotting/file/geojson_points.py
@@ -1,16 +1,12 @@
 from bokeh.io import output_file, show
-from bokeh.models import GeoJSONDataSource, HoverTool
+from bokeh.models import GeoJSONDataSource
 from bokeh.plotting import figure
 from bokeh.sampledata.sample_geojson import geojson
 
-p = figure()
+p = figure(tooltips=[("Organisation Name", "@OrganisationName")])
 
 p.circle(x='x', y='y', line_color=None, fill_alpha=0.8, size=20,
          source=GeoJSONDataSource(geojson=geojson))
-
-p.add_tools(HoverTool(tooltips=[
-    ("Organisation Name", "@OrganisationName")
-]))
 
 output_file("geojson_points.html", title="GeoJSON Points")
 

--- a/examples/plotting/file/hexbin.py
+++ b/examples/plotting/file/hexbin.py
@@ -16,10 +16,10 @@ r, bins = p.hexbin(x, y, size=0.5, hover_color="pink", hover_alpha=0.8)
 
 p.circle(x, y, color="white", size=1)
 
-hover = HoverTool(tooltips=[("count", "@c"), ("(q,r)", "(@q, @r)")],
-                  mode="mouse", point_policy="follow_mouse", renderers=[r])
-
-p.add_tools(hover)
+p.add_tools(HoverTool(
+    tooltips=[("count", "@c"), ("(q,r)", "(@q, @r)")],
+    mode="mouse", point_policy="follow_mouse", renderers=[r]
+))
 
 output_file("hexbin.html")
 

--- a/examples/plotting/file/hover.py
+++ b/examples/plotting/file/hover.py
@@ -2,10 +2,18 @@ import itertools
 
 import numpy as np
 
-from bokeh.plotting import ColumnDataSource, figure, show, output_file
-from bokeh.models import HoverTool
+from bokeh.plotting import figure, show, output_file
 
 TOOLS="crosshair,pan,wheel_zoom,box_zoom,reset,hover,save"
+
+TOOLTIPS = [
+    ("index", "$index"),
+    ("(x,y)", "($x, $y)"),
+    ("radius", "@radius"),
+    ("fill color", "$color[hex, swatch]:colors"),
+    ("foo", "@foo"),
+    ("bar", "@bar"),
+]
 
 xx, yy = np.meshgrid(range(0,101,4), range(0,101,4))
 x = xx.flatten()
@@ -17,31 +25,22 @@ colors = [
     "#%02x%02x%02x" % (int(r), int(g), 150) for r, g in zip(50+2*x, 30+2*y)
 ]
 
-source = ColumnDataSource(data=dict(
+data=dict(
     x=x,
     y=y,
     radius=radii,
     colors=colors,
     foo=list(itertools.permutations("abcdef"))[:N],
     bar=np.random.normal(size=N),
-))
+)
 
-p = figure(title="Hoverful Scatter", tools=TOOLS)
+p = figure(title="Hoverful Scatter", tools=TOOLS, tooltips=TOOLTIPS)
 
-p.circle(x='x', y='y', radius='radius', source=source,
+p.circle(x='x', y='y', radius='radius', source=data,
          fill_color='colors', fill_alpha=0.6, line_color=None)
 
 p.text(x, y, text=inds, alpha=0.5, text_font_size="5pt",
        text_baseline="middle", text_align="center")
-
-hover = p.select_one(HoverTool).tooltips = [
-    ("index", "$index"),
-    ("(x,y)", "($x, $y)"),
-    ("radius", "@radius"),
-    ("fill color", "$color[hex, swatch]:colors"),
-    ("foo", "@foo"),
-    ("bar", "@bar"),
-]
 
 output_file("hover.html", title="hover.py example")
 

--- a/examples/plotting/file/image.py
+++ b/examples/plotting/file/image.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 from bokeh.plotting import figure, show, output_file
-from bokeh.models import HoverTool
 
 N = 500
 x = np.linspace(0, 10, N)
@@ -10,7 +9,7 @@ xx, yy = np.meshgrid(x, y)
 d = np.sin(xx)*np.cos(yy)
 
 p = figure(x_range=(0, 10), y_range=(0, 10),
-           tools=[HoverTool(tooltips=[("x", "$x"), ("y", "$y"), ("value", "@image")])])
+           tooltips=[("x", "$x"), ("y", "$y"), ("value", "@image")])
 
 # must give a vector of image data for image parameter
 p.image(image=[d], x=0, y=0, dw=10, dh=10, palette="Spectral11")

--- a/examples/plotting/file/les_mis.py
+++ b/examples/plotting/file/les_mis.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 from bokeh.plotting import figure, show, output_file
-from bokeh.models import HoverTool, ColumnDataSource
 from bokeh.sampledata.les_mis import data
 
 nodes = data['nodes']
@@ -32,17 +31,18 @@ for i, node1 in enumerate(nodes):
         else:
             color.append('lightgrey')
 
-source = ColumnDataSource(data=dict(
+data=dict(
     xname=xname,
     yname=yname,
     colors=color,
     alphas=alpha,
     count=counts.flatten(),
-))
+)
 
 p = figure(title="Les Mis Occurrences",
            x_axis_location="above", tools="hover,save",
-           x_range=list(reversed(names)), y_range=names)
+           x_range=list(reversed(names)), y_range=names,
+           tooltips = [('names', '@yname, @xname'), ('count', '@count')])
 
 p.plot_width = 800
 p.plot_height = 800
@@ -53,14 +53,9 @@ p.axis.major_label_text_font_size = "5pt"
 p.axis.major_label_standoff = 0
 p.xaxis.major_label_orientation = np.pi/3
 
-p.rect('xname', 'yname', 0.9, 0.9, source=source,
+p.rect('xname', 'yname', 0.9, 0.9, source=data,
        color='colors', alpha='alphas', line_color=None,
        hover_line_color='black', hover_color='colors')
-
-p.select_one(HoverTool).tooltips = [
-    ('names', '@yname, @xname'),
-    ('count', '@count'),
-]
 
 output_file("les_mis.html", title="les_mis.py example")
 

--- a/examples/plotting/file/multi_line.py
+++ b/examples/plotting/file/multi_line.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from scipy.stats import norm
 
 from bokeh.plotting import show, figure
-from bokeh.models import ColumnDataSource, HoverTool, TapTool
+from bokeh.models import HoverTool, TapTool
 from bokeh.layouts import gridplot
 from bokeh.palettes import Viridis6
 
@@ -23,8 +23,6 @@ for scale, mz in [(1.0, 83), (0.9, 55), (0.6, 98), (0.4, 43), (0.2, 39), (0.12, 
 
 mass_spec['color'] = Viridis6
 
-source = ColumnDataSource(mass_spec)
-
 figure_opts = dict(plot_width=450, plot_height=300)
 hover_opts = dict(
     tooltips=[('MZ', '@MZ_tip'), ('Rel Intensity', '@Intensity_tip')],
@@ -34,7 +32,7 @@ hover_opts = dict(
 line_opts = dict(
     line_width=5, line_color='color', line_alpha=0.6,
     hover_line_color='color', hover_line_alpha=1.0,
-    source=source
+    source=mass_spec
 )
 
 rt_plot = figure(tools=[HoverTool(**hover_opts), TapTool()], **figure_opts)

--- a/examples/plotting/file/periodic.py
+++ b/examples/plotting/file/periodic.py
@@ -1,5 +1,4 @@
 from bokeh.io import output_file, show
-from bokeh.models import ColumnDataSource, HoverTool
 from bokeh.plotting import figure
 from bokeh.sampledata.periodic_table import elements
 from bokeh.transform import dodge, factor_cmap
@@ -28,16 +27,23 @@ cmap = {
     "transition metal"     : "#599d7A",
 }
 
-source = ColumnDataSource(df)
+TOOLTIPS = [
+    ("Name", "@name"),
+    ("Atomic number", "@{atomic number}"),
+    ("Atomic mass", "@{atomic mass}"),
+    ("Type", "@metal"),
+    ("CPK color", "$color[hex, swatch]:CPK"),
+    ("Electronic configuration", "@{electronic configuration}"),
+]
 
 p = figure(title="Periodic Table (omitting LA and AC Series)", plot_width=1000, plot_height=450,
-           tools="", toolbar_location=None,
-           x_range=groups, y_range=list(reversed(periods)))
+           x_range=groups, y_range=list(reversed(periods)),
+           tools="hover", toolbar_location=None, tooltips=TOOLTIPS)
 
-p.rect("group", "period", 0.95, 0.95, source=source, fill_alpha=0.6, legend="metal",
+p.rect("group", "period", 0.95, 0.95, source=df, fill_alpha=0.6, legend="metal",
        color=factor_cmap('metal', palette=list(cmap.values()), factors=list(cmap.keys())))
 
-text_props = {"source": source, "text_align": "left", "text_baseline": "middle"}
+text_props = {"source": df, "text_align": "left", "text_baseline": "middle"}
 
 x = dodge("group", -0.4, range=p.x_range)
 
@@ -54,15 +60,6 @@ r = p.text(x=x, y=dodge("period", -0.2, range=p.y_range), text="atomic mass", **
 r.glyph.text_font_size="5pt"
 
 p.text(x=["3", "3"], y=["VI", "VII"], text=["LA", "AC"], text_align="center", text_baseline="middle")
-
-p.add_tools(HoverTool(tooltips = [
-    ("Name", "@name"),
-    ("Atomic number", "@{atomic number}"),
-    ("Atomic mass", "@{atomic mass}"),
-    ("Type", "@metal"),
-    ("CPK color", "$color[hex, swatch]:CPK"),
-    ("Electronic configuration", "@{electronic configuration}"),
-]))
 
 p.outline_line_color = None
 p.grid.grid_line_color = None

--- a/examples/plotting/file/texas.py
+++ b/examples/plotting/file/texas.py
@@ -1,9 +1,5 @@
 from bokeh.io import show
-from bokeh.models import (
-    ColumnDataSource,
-    HoverTool,
-    LogColorMapper
-)
+from bokeh.models import LogColorMapper
 from bokeh.palettes import Viridis6 as palette
 from bokeh.plotting import figure
 
@@ -23,31 +19,26 @@ county_names = [county['name'] for county in counties.values()]
 county_rates = [unemployment[county_id] for county_id in counties]
 color_mapper = LogColorMapper(palette=palette)
 
-source = ColumnDataSource(data=dict(
+data=dict(
     x=county_xs,
     y=county_ys,
     name=county_names,
     rate=county_rates,
-))
+)
 
 TOOLS = "pan,wheel_zoom,reset,hover,save"
 
 p = figure(
     title="Texas Unemployment, 2009", tools=TOOLS,
-    x_axis_location=None, y_axis_location=None
-)
+    x_axis_location=None, y_axis_location=None,
+    tooltips=[
+        ("Name", "@name"), ("Unemployment rate)", "@rate%"), ("(Long, Lat)", "($x, $y)")
+    ])
 p.grid.grid_line_color = None
+p.hover.point_policy = "follow_mouse"
 
-p.patches('x', 'y', source=source,
+p.patches('x', 'y', source=data,
           fill_color={'field': 'rate', 'transform': color_mapper},
           fill_alpha=0.7, line_color="white", line_width=0.5)
-
-hover = p.select_one(HoverTool)
-hover.point_policy = "follow_mouse"
-hover.tooltips = [
-    ("Name", "@name"),
-    ("Unemployment rate)", "@rate%"),
-    ("(Long, Lat)", "($x, $y)"),
-]
 
 show(p)

--- a/examples/plotting/file/unemployment.py
+++ b/examples/plotting/file/unemployment.py
@@ -2,14 +2,7 @@ from math import pi
 import pandas as pd
 
 from bokeh.io import show
-from bokeh.models import (
-    ColumnDataSource,
-    HoverTool,
-    LinearColorMapper,
-    BasicTicker,
-    PrintfTickFormatter,
-    ColorBar,
-)
+from bokeh.models import LinearColorMapper, BasicTicker, PrintfTickFormatter, ColorBar
 from bokeh.plotting import figure
 from bokeh.sampledata.unemployment1948 import data
 
@@ -28,14 +21,13 @@ df = pd.DataFrame(data.stack(), columns=['rate']).reset_index()
 colors = ["#75968f", "#a5bab7", "#c9d9d3", "#e2e2e2", "#dfccce", "#ddb7b1", "#cc7878", "#933b41", "#550b1d"]
 mapper = LinearColorMapper(palette=colors, low=df.rate.min(), high=df.rate.max())
 
-source = ColumnDataSource(df)
-
 TOOLS = "hover,save,pan,box_zoom,reset,wheel_zoom"
 
 p = figure(title="US Unemployment ({0} - {1})".format(years[0], years[-1]),
            x_range=years, y_range=list(reversed(months)),
            x_axis_location="above", plot_width=900, plot_height=400,
-           tools=TOOLS, toolbar_location='below')
+           tools=TOOLS, toolbar_location='below',
+           tooltips=[('date', '@Month @Year'), ('rate', '@rate%')])
 
 p.grid.grid_line_color = None
 p.axis.axis_line_color = None
@@ -45,7 +37,7 @@ p.axis.major_label_standoff = 0
 p.xaxis.major_label_orientation = pi / 3
 
 p.rect(x="Year", y="Month", width=1, height=1,
-       source=source,
+       source=df,
        fill_color={'field': 'rate', 'transform': mapper},
        line_color=None)
 
@@ -54,10 +46,5 @@ color_bar = ColorBar(color_mapper=mapper, major_label_text_font_size="5pt",
                      formatter=PrintfTickFormatter(format="%d%%"),
                      label_standoff=6, border_line_color=None, location=(0, 0))
 p.add_layout(color_bar, 'right')
-
-p.select_one(HoverTool).tooltips = [
-     ('date', '@Month @Year'),
-     ('rate', '@rate%'),
-]
 
 show(p)      # show the plot

--- a/sphinx/docserver.py
+++ b/sphinx/docserver.py
@@ -14,7 +14,7 @@ from tornado.ioloop import IOLoop
 
 _basedir = os.path.join("..", os.path.dirname(__file__))
 
-app = flask.Flask(__name__, static_path="/unused")
+app = flask.Flask(__name__, static_folder="/unused")
 PORT=5009
 http_server = HTTPServer(WSGIContainer(app))
 

--- a/sphinx/source/docs/releases/0.13.0.rst
+++ b/sphinx/source/docs/releases/0.13.0.rst
@@ -4,7 +4,7 @@
 Bokeh Version ``0.13.0`` is an incremental update that adds a few
 new features and fixes several bugs. Some of the highlights include:
 
-*
+* Improved hover tool fields for common stacked bar plot cases
 
 And several other bug fixes and docs additions. For full details see the
 :bokeh-tree:`CHANGELOG`.
@@ -12,25 +12,33 @@ And several other bug fixes and docs additions. For full details see the
 Migration Guide
 ---------------
 
-NOTE: the 0.13.x series is the last release series before a version
+NOTE: the 0.13.x series is a final series of small releases leading to a
 1.0 release. For more information see the `project roadmap`_.
 
-Deprecations Removed
-~~~~~~~~~~~~~~~~~~~~
+New Hover fields
+~~~~~~~~~~~~~~~~
 
-The following functions, arguments, or features have were previously deprecated
-with warnings and instructions for new usage, and have now been permanently
-removed:
+Two new hover tooltip fields are now available:
 
-*
+* ``$name`` will preint the value of the ``name`` property of a glyph that
+  is being hovered over.
 
-bokehjs' build changes
-~~~~~~~~~~~~~~~~~~~~~~
+* ``@$name`` will look up values from a column like a normal ``@`` field,
+  but will use ``$name`` as the name of the column.
 
-Previously we used gulp as the build system for bokehjs. This was replaced with
-an in-house solution. Now the build is run with ``node make build`` instead of
-``gulp build``. Task names remained unchanged. If you want preserve the old
-workflow, e.g. to aid ``git bisect``, the create an alias for ``node make``,
+Both of these are espeically useful in conjunction with stacked bar plots.
+
+BokehJS Build
+~~~~~~~~~~~~~
+
+The ``gulp`` tool was previously used as the build system for BokehJS. This
+has been replaced with a smaller and simpler build script. This greatly
+reduced the number of dependencies required to build BokehJS and a completely
+clean NPM package security audit was obtained as a side effect.
+
+To build now, run the commandf ``node make build`` instead of ``gulp build``.
+Task names remained unchanged. If you want preserve the old workflow, e.g. to
+aid ``git bisect``, it is suggested to create an alias for ``node make``,
 e.g. in bash this would be ``alias gulp='node make'``.
 
 .. _project roadmap: https://bokehplots.com/pages/roadmap.html

--- a/sphinx/source/docs/user_guide/categorical.rst
+++ b/sphinx/source/docs/user_guide/categorical.rst
@@ -192,13 +192,44 @@ stacked bar chart that is split by positive and negative values:
 Hover Tools
 '''''''''''
 
-Sometimes when stacking bars, it's desirable to have a different hover tool
-for each layer in the stack. The ``hbar_stack`` and ``vbar_stack`` functions
-return a list of all the renderers created (one for each stack). These can
-be used to customize different hover tools as shown below
+For stacked bar plots, Bokeh provides some special hover variables that are
+useful for common cases.
+
+When stacking bars, Bokeh automatically sets the ``name`` property for each
+layer in the stack to be the value of the stack column for that layer. This
+name value is accessible to hover tools via the ``$name`` special variable.
+
+Additionally, the hover variable ``@$name`` can be used to look up values from
+the stack column for each layer. For instance, if a user hovers over a stack
+glyph with the name ``"US East"``, then ``@$name`` is equivalent to
+``@{US East}``.
+
+The example below demonstrates both of these hover variables:
 
 .. bokeh-plot:: docs/user_guide/examples/categorical_bar_stacked_hover.py
     :source-position: above
+
+Note that it is also possible to override the value of ``name`` by passing it
+manually to ``vbar_stack`` and ``hbar_stack``. In this case, ``$@name`` will
+look up the column names provided by the user.
+
+It may also sometimes be desirable to have a different hover tool for each
+layer in the stack. For such cases, the ``hbar_stack`` and ``vbar_stack``
+functions return a list of all the renderers created (one for each stack).
+These can be used to customize different hover tools for each layer:
+
+.. code-block:: python
+
+    renderers = p.vbar_stack(years, x='fruits', width=0.9, color=colors, source=source,
+                             legend=[value(x) for x in years], name=years)
+
+    for r in renderers:
+        year = r.name
+        hover = HoverTool(tooltips=[
+            ("%s total" % year, "@%s" % year),
+            ("index", "$index")
+        ], renderers=[r])
+        p.add_tools(hover)
 
 .. _userguide_categorical_bars_mixed:
 

--- a/sphinx/source/docs/user_guide/examples/categorical_bar_pandas_groupby_nested.py
+++ b/sphinx/source/docs/user_guide/examples/categorical_bar_pandas_groupby_nested.py
@@ -1,24 +1,22 @@
 from bokeh.io import show, output_file
-from bokeh.models import ColumnDataSource, HoverTool
 from bokeh.plotting import figure
 from bokeh.palettes import Spectral5
 from bokeh.sampledata.autompg import autompg_clean as df
 from bokeh.transform import factor_cmap
 
-output_file("bars.html")
+output_file("bar_pandas_groupby_nested.html")
 
 df.cyl = df.cyl.astype(str)
 df.yr = df.yr.astype(str)
 
 group = df.groupby(('cyl', 'mfr'))
 
-source = ColumnDataSource(group)
 index_cmap = factor_cmap('cyl_mfr', palette=Spectral5, factors=sorted(df.cyl.unique()), end=1)
 
 p = figure(plot_width=800, plot_height=300, title="Mean MPG by # Cylinders and Manufacturer",
-           x_range=group, toolbar_location=None, tools="")
+           x_range=group, toolbar_location=None, tooltips=[("MPG", "@mpg_mean"), ("Cyl, Mfr", "@cyl_mfr")])
 
-p.vbar(x='cyl_mfr', top='mpg_mean', width=1, source=source,
+p.vbar(x='cyl_mfr', top='mpg_mean', width=1, source=group,
        line_color="white", fill_color=index_cmap, )
 
 p.y_range.start = 0
@@ -27,7 +25,5 @@ p.xgrid.grid_line_color = None
 p.xaxis.axis_label = "Manufacturer grouped by # Cylinders"
 p.xaxis.major_label_orientation = 1.2
 p.outline_line_color = None
-
-p.add_tools(HoverTool(tooltips=[("MPG", "@mpg_mean"), ("Cyl, Mfr", "@cyl_mfr")]))
 
 show(p)

--- a/sphinx/source/docs/user_guide/examples/categorical_bar_stacked.py
+++ b/sphinx/source/docs/user_guide/examples/categorical_bar_stacked.py
@@ -1,6 +1,5 @@
 from bokeh.core.properties import value
 from bokeh.io import show, output_file
-from bokeh.models import ColumnDataSource
 from bokeh.plotting import figure
 
 output_file("stacked.html")
@@ -14,12 +13,10 @@ data = {'fruits' : fruits,
         '2016'   : [5, 3, 4, 2, 4, 6],
         '2017'   : [3, 2, 4, 4, 5, 3]}
 
-source = ColumnDataSource(data=data)
-
 p = figure(x_range=fruits, plot_height=250, title="Fruit Counts by Year",
            toolbar_location=None, tools="")
 
-p.vbar_stack(years, x='fruits', width=0.9, color=colors, source=source,
+p.vbar_stack(years, x='fruits', width=0.9, color=colors, source=data,
              legend=[value(x) for x in years])
 
 p.y_range.start = 0

--- a/sphinx/source/docs/user_guide/examples/categorical_bar_stacked_hover.py
+++ b/sphinx/source/docs/user_guide/examples/categorical_bar_stacked_hover.py
@@ -1,9 +1,8 @@
 from bokeh.core.properties import value
 from bokeh.io import show, output_file
-from bokeh.models import ColumnDataSource, HoverTool
 from bokeh.plotting import figure
 
-output_file("bar_stacked.html")
+output_file("stacked.html")
 
 fruits = ['Apples', 'Pears', 'Nectarines', 'Plums', 'Grapes', 'Strawberries']
 years = ["2015", "2016", "2017"]
@@ -14,21 +13,11 @@ data = {'fruits' : fruits,
         '2016'   : [5, 3, 4, 2, 4, 6],
         '2017'   : [3, 2, 4, 4, 5, 3]}
 
-source = ColumnDataSource(data=data)
+p = figure(x_range=fruits, plot_height=250, title="Fruit Counts by Year",
+           toolbar_location=None, tools="hover", tooltips="$name @fruits: @$name")
 
-p = figure(x_range=fruits, plot_height=350, title="Fruit Counts by Year",
-           toolbar_location=None, tools="")
-
-renderers = p.vbar_stack(years, x='fruits', width=0.9, color=colors, source=source,
-                         legend=[value(x) for x in years], name=years)
-
-for r in renderers:
-    year = r.name
-    hover = HoverTool(tooltips=[
-        ("%s total" % year, "@%s" % year),
-        ("index", "$index")
-    ], renderers=[r])
-    p.add_tools(hover)
+p.vbar_stack(years, x='fruits', width=0.9, color=colors, source=data,
+             legend=[value(x) for x in years])
 
 p.y_range.start = 0
 p.x_range.range_padding = 0.1

--- a/sphinx/source/docs/user_guide/examples/categorical_heatmap_periodic.py
+++ b/sphinx/source/docs/user_guide/examples/categorical_heatmap_periodic.py
@@ -1,5 +1,5 @@
 from bokeh.io import output_file, show
-from bokeh.models import ColumnDataSource, HoverTool
+from bokeh.models import ColumnDataSource
 from bokeh.plotting import figure
 from bokeh.sampledata.periodic_table import elements
 from bokeh.transform import dodge, factor_cmap
@@ -31,7 +31,7 @@ cmap = {
 source = ColumnDataSource(df)
 
 p = figure(plot_width=900, plot_height=500, title="Periodic Table (omitting LA and AC Series)",
-           x_range=groups, y_range=list(reversed(periods)), toolbar_location=None, tools="")
+           x_range=groups, y_range=list(reversed(periods)), toolbar_location=None, tools="hover")
 
 p.rect("group", "period", 0.95, 0.95, source=source, fill_alpha=0.6, legend="metal",
        color=factor_cmap('metal', palette=list(cmap.values()), factors=list(cmap.keys())))
@@ -54,14 +54,14 @@ r.glyph.text_font_size="5pt"
 
 p.text(x=["3", "3"], y=["VI", "VII"], text=["LA", "AC"], text_align="center", text_baseline="middle")
 
-p.add_tools(HoverTool(tooltips = [
+p.hover.tooltips = [
     ("Name", "@name"),
     ("Atomic number", "@{atomic number}"),
     ("Atomic mass", "@{atomic mass}"),
     ("Type", "@metal"),
     ("CPK color", "$color[hex, swatch]:CPK"),
     ("Electronic configuration", "@{electronic configuration}"),
-]))
+]
 
 p.outline_line_color = None
 p.grid.grid_line_color = None

--- a/sphinx/source/docs/user_guide/examples/tools_hover_custom_tooltip.py
+++ b/sphinx/source/docs/user_guide/examples/tools_hover_custom_tooltip.py
@@ -1,5 +1,4 @@
 from bokeh.plotting import figure, output_file, show, ColumnDataSource
-from bokeh.models import HoverTool
 
 output_file("toolbar.html")
 
@@ -23,7 +22,7 @@ source = ColumnDataSource(data=dict(
     ]
 ))
 
-hover = HoverTool( tooltips="""
+TOOLTIPS = """
     <div>
         <div>
             <img
@@ -44,10 +43,9 @@ hover = HoverTool( tooltips="""
             <span style="font-size: 10px; color: #696;">($x, $y)</span>
         </div>
     </div>
-    """
-)
+"""
 
-p = figure(plot_width=400, plot_height=400, tools=[hover],
+p = figure(plot_width=400, plot_height=400, tooltips=TOOLTIPS,
            title="Mouse over the dots")
 
 p.circle('x', 'y', size=20, source=source)

--- a/sphinx/source/docs/user_guide/examples/tools_hover_tooltips.py
+++ b/sphinx/source/docs/user_guide/examples/tools_hover_tooltips.py
@@ -1,5 +1,4 @@
 from bokeh.plotting import figure, output_file, show, ColumnDataSource
-from bokeh.models import HoverTool
 
 output_file("toolbar.html")
 
@@ -9,13 +8,13 @@ source = ColumnDataSource(data=dict(
     desc=['A', 'b', 'C', 'd', 'E'],
 ))
 
-hover = HoverTool(tooltips=[
+TOOLTIPS = [
     ("index", "$index"),
     ("(x,y)", "($x, $y)"),
     ("desc", "@desc"),
-])
+]
 
-p = figure(plot_width=400, plot_height=400, tools=[hover],
+p = figure(plot_width=400, plot_height=400, tooltips=TOOLTIPS,
            title="Mouse over the dots")
 
 p.circle('x', 'y', size=20, source=source)

--- a/sphinx/source/docs/user_guide/examples/tools_hover_tooltips_image.py
+++ b/sphinx/source/docs/user_guide/examples/tools_hover_tooltips_image.py
@@ -1,6 +1,5 @@
 import numpy as np
-from bokeh.plotting import figure, output_file, show, ColumnDataSource
-from bokeh.models import HoverTool
+from bokeh.plotting import figure, output_file, show
 
 output_file("tools_hover_tooltip_image.html")
 
@@ -16,15 +15,16 @@ data = dict(image=[ramp, steps, bitmask],
             dw=[20,  20, 10],
             dh=[10,  10, 25])
 
-cds = ColumnDataSource(data=data)
-hover = HoverTool(tooltips=[
+TOOLTIPS = [
     ('index', "$index"),
     ('pattern', '@pattern'),
     ("x", "$x"),
     ("y", "$y"),
     ("value", "@image"),
-    ('squared', '@squared')], )
+    ('squared', '@squared')
+]
 
-p = figure( x_range=(0, 35), y_range=(0, 35), tools=[hover, 'wheel_zoom'])
-p.image(source=cds, image='image', x='x', y='y', dw='dw', dh='dh', palette="Inferno256")
+p = figure( x_range=(0, 35), y_range=(0, 35), tools='hover,wheel_zoom', tooltips=TOOLTIPS)
+p.image(source=data, image='image', x='x', y='y', dw='dw', dh='dh', palette="Inferno256")
+
 show(p)

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -432,6 +432,8 @@ in data or screen space. These special fields are listed here:
 
 :``$index``:
     index of selected point in the data source
+:``$name``:
+    value of the ``name`` property of the hovered glyph renderer
 :``$x``:
     x-coordinate under the cursor in data space
 :``$y``:
@@ -440,6 +442,8 @@ in data or screen space. These special fields are listed here:
     x-coordinate under the cursor in screen (canvas) space
 :``$sy``:
     y-coordinate under the cursor in screen (canvas) space
+:``$name``:
+    The ``name`` property of the glyph that is hovered over
 :``$color``:
     colors from a data source, with the syntax: ``$color[options]:field_name``.
     The available options are: ``hex`` (to display the color as a hex value),
@@ -455,8 +459,15 @@ Note that if a column name contains spaces, the it must be supplied by
 surrounding it in curly braces, e.g. ``@{adjusted close}`` will display values
 from a column named ``"adjusted close"``.
 
-Here is a complete example of how to configure and use the hover tool with
-a default tooltip:
+Sometimes (especially with stacked charts) it is desirable to allow the
+name of the column be specified indirectly. The field name ``@$name`` is
+distinguished in that it will look up the ``name`` field on the hovered
+glyph renderer, and use that value as the column name. For instance, if
+a user hovers with the name ``"US East"``, then ``@$name`` is equivalent to
+``@{US East}``.
+
+Here is a complete example of how to configure and use the hover tool by setting
+the ``tooltips`` argument to ``figure``:
 
 .. bokeh-plot:: docs/user_guide/examples/tools_hover_tooltips.py
     :source-position: above
@@ -533,8 +544,8 @@ Note that format specifications are also compatible with column names that
 have spaces. For example ```@{adjusted close}{($ 0.00 a)}`` applies a format
 to a column named "adjusted close".
 
-The example code below shows configuring a ``HoverTool`` with different
-formatters for different fields:
+The example code below shows explicitly configuring a ``HoverTool`` with
+different formatters for different fields:
 
 .. code-block:: python
 
@@ -571,7 +582,6 @@ Image Hover
 
 The hover tool can be used to inspect image glyphs which may contain
 layers of data in the corresponding ``ColumnDataSource``:
-
 
 .. bokeh-plot:: docs/user_guide/examples/tools_hover_tooltips_image.py
     :source-position: above


### PR DESCRIPTION
@pzwang suggested trying to get more in the "user mind" this PR is an attempt to make some common things easier than they currently are. In particular:

* add `$name` special variable to shoe glyph renderer `name`
* adds `tooltips` convenience arg to `Figure`
* adds `Plot.hover` accessor

all of which make simple hover tool cases much easier to get up and running. Also update various examples to pass dataframes or dicts directly as `source` where possible.  

I'd like to try and solve at least one more issue, which is there is not a good way to add a single hover tool to a `vbar_stack` etc that covers the stacked quantities. 

cc @mattpap for any early thoughts. 

- [x] tests added / passed
- [x] release document entry (if new feature or API change)


