### PR TITLE
Ensured the PolyDraw tool correctly handles typed array paths

### DIFF
--- a/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
@@ -1,6 +1,7 @@
 import {Keys} from "core/dom"
 import {UIEvent, GestureEvent, TapEvent, MoveEvent, KeyEvent} from "core/ui_events"
 import * as p from "core/properties"
+import {isArray} from "core/util/types"
 import {MultiLine} from "../../glyphs/multi_line"
 import {Patches} from "../../glyphs/patches"
 import {GlyphRenderer} from "../../renderers/glyph_renderer"
@@ -50,16 +51,24 @@ export class PolyDrawToolView extends EditToolView {
     } else if (mode == 'add') {
       if (xkey) {
         const xidx = ds.data[xkey].length-1;
-        const xs = ds.get_array<number[]>(xkey)[xidx]
+        let xs = ds.get_array<number[]>(xkey)[xidx]
         const nx = xs[xs.length-1];
         xs[xs.length-1] = x;
+        if (!isArray(xs)) {
+          xs = Array.from(xs)
+          ds.data[xkey][xidx] = xs;
+        }
         xs.push(nx);
       }
       if (ykey) {
         const yidx = ds.data[ykey].length-1;
-        const ys = ds.get_array<number[]>(ykey)[yidx]
+        let ys = ds.get_array<number[]>(ykey)[yidx]
         const ny = ys[ys.length-1];
         ys[ys.length-1] = y;
+        if (!isArray(ys)) {
+          ys = Array.from(ys)
+          ds.data[ykey][yidx] = ys;
+        }
         ys.push(ny);
       }
     }

--- a/bokehjs/test/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/test/models/tools/edit/poly_draw_tool.ts
@@ -195,6 +195,25 @@ describe("PolyDrawTool", (): void => {
       expect(testcase.data_source.data['ys']).to.be.deep.equal(ydata);
     });
 
+    it("should draw patch despite typed array data", function(): void {
+      const testcase = make_testcase();
+      const hit_test_stub = sinon.stub(testcase.glyph_view, "hit_test");
+
+      hit_test_stub.returns(null);
+      testcase.draw_tool_view._doubletap(make_tap_event(300, 300));
+      testcase.data_source.data['xs'][2] = Float64Array.from(testcase.data_source.data['xs'][2])
+      testcase.data_source.data['ys'][2] = Float64Array.from(testcase.data_source.data['ys'][2])
+      testcase.draw_tool_view._tap(make_tap_event(250, 250));
+      testcase.draw_tool_view._doubletap(make_tap_event(200, 200));
+
+      const new_xs = [0.04424778761061947, -0.13274336283185842, -0.30973451327433627];
+      const new_ys = [-0, 0.1694915254237288, 0.3389830508474576];
+      const xdata = [[0, 0.5, 1], [0, 0.5, 1], new_xs];
+      const ydata = [[0, -0.5, -1], [0, -0.5, -1], new_ys];
+      expect(testcase.data_source.data['xs']).to.be.deep.equal(xdata);
+      expect(testcase.data_source.data['ys']).to.be.deep.equal(ydata);
+    });
+
     it("should end draw patch on escape", function(): void {
       const testcase = make_testcase();
       const hit_test_stub = sinon.stub(testcase.glyph_view, "hit_test");


### PR DESCRIPTION
Small fix to allow the PolyDraw tool to edit a data source containing typed array paths, which have been added after starting to edit the data source when the arrays are usually converted.

- [x] issues: fixes https://github.com/bokeh/bokeh/issues/7953
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
