### PR TITLE
add option to set websocket_max_message_size

### DIFF
--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -306,6 +306,7 @@ from bokeh.application import Application
 from bokeh.resources import DEFAULT_SERVER_PORT
 from bokeh.util.logconfig import basicConfig
 from bokeh.util.string import nice_join, format_docstring
+from bokeh.server.tornado import DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES
 from bokeh.settings import settings
 
 from os import getpid
@@ -477,7 +478,7 @@ class Serve(Subcommand):
             action='store',
             help="Set the Tornado websocket_max_message_size value (defaults "
                  "to 20MB) NOTE: This setting has effect ONLY for Tornado>=4.5",
-            default=20*10124*1024,
+            default=DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES,
             type=int,
         )),
 

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -467,10 +467,20 @@ class Serve(Subcommand):
             metavar='N',
             action='store',
             help="Number of worker processes for an app. Default to one. Using "
-                 "0 will autodetect number of cores",
+                 "0 will autodetect number of cores (defaults to 1)",
             default=1,
             type=int,
         )),
+
+        ('--websocket-max-message-size', dict(
+            metavar='BYTES',
+            action='store',
+            help="Set the Tornado websocket_max_message_size value (defaults "
+                 "to 20MB) NOTE: This setting has effect ONLY for Tornado>=4.5",
+            default=20*10124*1024,
+            type=int,
+        )),
+
     )
 
 
@@ -520,6 +530,7 @@ class Serve(Subcommand):
                                                               'stats_log_frequency_milliseconds',
                                                               'mem_log_frequency_milliseconds',
                                                               'use_xheaders',
+                                                              'websocket_max_message_size',
                                                             ]
                           if getattr(args, key, None) is not None }
 

--- a/bokeh/command/subcommands/tests/test_serve.py
+++ b/bokeh/command/subcommands/tests/test_serve.py
@@ -6,6 +6,7 @@ import re
 import socket
 import subprocess
 import sys
+from time import sleep
 
 import pytest
 import requests
@@ -177,7 +178,7 @@ def test_args():
             action='store',
             help="Set the Tornado websocket_max_message_size value (defaults "
                  "to 20MB) NOTE: This setting has effect ONLY for Tornado>=4.5",
-            default=20*10124*1024,
+            default=20*1024*1024,
             type=int,
         )),
     )
@@ -234,15 +235,17 @@ def test_port_not_available():
 
 @pytest.mark.skipif(six.PY2, reason="Travis bug causes bad file descriptor")
 def test_actual_port_printed_out():
+    from fcntl import fcntl, F_GETFL, F_SETFL
+    from os import O_NONBLOCK, read
+    pat = re.compile(r'Bokeh app running at: http://localhost:(\d+)')
+    m = None
     with run_bokeh_serve(["--port", "0"]) as p:
-        pat = re.compile(r'Bokeh app running at: http://localhost:(\d+)')
-        while True:
-            line = p.stdout.readline()
-            print("child stdout>", line)
-            m = pat.search(line.decode())
-            if m is not None:
-                break
-        else:
+        flags = fcntl(p.stdout, F_GETFL)
+        fcntl(p.stdout, F_SETFL, flags | O_NONBLOCK)
+        sleep(2)
+        o = read(p.stdout.fileno(), 100*1024)
+        m = pat.search(o.decode())
+        if m is None:
             pytest.fail("no matching log line in process output")
         port = int(m.group(1))
         assert port > 0
@@ -251,13 +254,10 @@ def test_actual_port_printed_out():
 
 @pytest.mark.skipif(six.PY2, reason="Travis bug causes bad file descriptor")
 def test_websocket_max_message_size_printed_out():
+    pat = re.compile(r'Torndado websocket_max_message_size set to 12345')
     with run_bokeh_serve(["--websocket-max-message-size", "12345"]) as p:
-        pat = re.compile(r'Setting Torndado websocket_max_message_size to 12345')
-        while True:
-            line = p.stdout.readline()
-            print("child stdout>", line)
-            m = pat.search(line.decode())
-            if m is not None:
-                break
-        else:
-            pytest.fail("no matching log line in process output")
+        sleep(2)
+    o, e = p.communicate()
+    m = pat.search(o.decode())
+    if m is None:
+        pytest.fail("no matching log line in process output")

--- a/bokeh/server/server.py
+++ b/bokeh/server/server.py
@@ -78,6 +78,12 @@ class _ServerOpts(Options):
     ``X-Scheme``, ``X-Forwarded-Proto`` headers (if they are provided).
     """)
 
+    websocket_max_message_size = Int(default=20*1024*104, help="""
+    Set the Tornado ``websocket_max_message_size`` value.
+
+    NOTE: This setting has effect ONLY for Tornado>=4.5
+    """)
+
 
 class BaseServer(object):
     ''' Explicitly coordinate the level Tornado components required to run a
@@ -391,7 +397,11 @@ class Server(BaseServer):
 
         extra_websocket_origins = create_hosts_whitelist(opts.allow_websocket_origin, self.port)
         try:
-            tornado_app = BokehTornado(applications, extra_websocket_origins=extra_websocket_origins, prefix=self.prefix, **kwargs)
+            tornado_app = BokehTornado(applications,
+                                       extra_websocket_origins=extra_websocket_origins,
+                                       prefix=self.prefix,
+                                       websocket_max_message_size_bytes=opts.websocket_max_message_size,
+                                       **kwargs)
 
             http_server = HTTPServer(tornado_app, **http_server_kwargs)
 

--- a/bokeh/server/server.py
+++ b/bokeh/server/server.py
@@ -32,7 +32,7 @@ from ..resources import DEFAULT_SERVER_PORT
 from ..util.options import Options
 
 from .util import bind_sockets, create_hosts_whitelist
-from .tornado import BokehTornado
+from .tornado import BokehTornado, DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES
 
 # This class itself is intentionally undocumented (it is used to generate
 # documentation elsewhere)
@@ -78,7 +78,7 @@ class _ServerOpts(Options):
     ``X-Scheme``, ``X-Forwarded-Proto`` headers (if they are provided).
     """)
 
-    websocket_max_message_size = Int(default=20*1024*104, help="""
+    websocket_max_message_size = Int(default=DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES, help="""
     Set the Tornado ``websocket_max_message_size`` value.
 
     NOTE: This setting has effect ONLY for Tornado>=4.5

--- a/bokeh/server/tests/test_tornado.py
+++ b/bokeh/server/tests/test_tornado.py
@@ -60,6 +60,11 @@ def test_prefix():
         with ManagedServerLoop(application, prefix=prefix) as server:
             assert server._tornado.prefix == "/foo"
 
+def test_websocket_max_message_size_bytes():
+    app = Application()
+    t = tornado.BokehTornado({"/": app}, websocket_max_message_size_bytes=12345)
+    assert t.settings['websocket_max_message_size'] == 12345
+
 def test_websocket_origins():
     application = Application()
     with ManagedServerLoop(application) as server:

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -209,7 +209,9 @@ class BokehTornado(TornadoApplication):
         if websocket_max_message_size_bytes <= 0:
             raise ValueError("websocket_max_message_size_bytes must be postitive")
         elif websocket_max_message_size_bytes != DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES:
-            log.info("Setting Torndado websocket_max_message_size to %d", websocket_max_message_size_bytes)
+            log.info("Torndado websocket_max_message_size set to %d bytes (%0.2f MB)",
+                     websocket_max_message_size_bytes,
+                     websocket_max_message_size_bytes/1024.0**2)
 
         if extra_websocket_origins is None:
             self._websocket_origins = set()

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -28,11 +28,12 @@ from .views.static_handler import StaticHandler
 # Unfortuntely we can't yet use format_docstring to keep these automatically in sync in
 # the class docstring because Python 2 does not allow setting class.__doc__ (works with
 # Bokeh model classes because they are metaclasses)
-DEFAULT_CHECK_UNUSED_MS    = 17000
-DEFAULT_KEEP_ALIVE_MS      = 37000  # heroku, nginx default to 60s timeout, so use less than that
-DEFAULT_MEM_LOG_FREQ_MS    = 0
-DEFAULT_STATS_LOG_FREQ_MS  = 15000
-DEFAULT_UNUSED_LIFETIME_MS = 15000
+DEFAULT_CHECK_UNUSED_MS                  = 17000
+DEFAULT_KEEP_ALIVE_MS                    = 37000  # heroku, nginx default to 60s timeout, so use less than that
+DEFAULT_MEM_LOG_FREQ_MS                  = 0
+DEFAULT_STATS_LOG_FREQ_MS                = 15000
+DEFAULT_UNUSED_LIFETIME_MS               = 15000
+DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES = 20*1024*1024
 
 
 class BokehTornado(TornadoApplication):
@@ -124,6 +125,12 @@ class BokehTornado(TornadoApplication):
             If there are multiple Bokeh applications configured, this option
             has no effect.
 
+        websocket_max_message_size_bytes (int, optional):
+            Set the Tornado ``websocket_max_message_size`` value.
+            (default: 20*1024*1024)
+
+            NOTE: This setting has effect ONLY for Tornado>=4.5
+
     Any additional keyword arguments are passed to ``tornado.web.Application``.
     '''
 
@@ -142,6 +149,7 @@ class BokehTornado(TornadoApplication):
                  mem_log_frequency_milliseconds=DEFAULT_MEM_LOG_FREQ_MS,
                  use_index=True,
                  redirect_root=True,
+                 websocket_max_message_size_bytes=DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES,
                  **kwargs):
 
         # This will be set when initialize is called
@@ -197,6 +205,11 @@ class BokehTornado(TornadoApplication):
             elif mem_log_frequency_milliseconds != DEFAULT_MEM_LOG_FREQ_MS:
                 log.info("Log memory usage every %d milliseconds", mem_log_frequency_milliseconds)
         self._mem_log_frequency_milliseconds = mem_log_frequency_milliseconds
+
+        if websocket_max_message_size_bytes <= 0:
+            raise ValueError("websocket_max_message_size_bytes must be postitive")
+        elif websocket_max_message_size_bytes != DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES:
+            log.info("Setting Torndado websocket_max_message_size to %d", websocket_max_message_size_bytes)
 
         if extra_websocket_origins is None:
             self._websocket_origins = set()
@@ -260,7 +273,9 @@ class BokehTornado(TornadoApplication):
         for line in pformat(all_patterns, width=60).split("\n"):
             log.debug("  " + line)
 
-        super(BokehTornado, self).__init__(all_patterns, **kwargs)
+        super(BokehTornado, self).__init__(all_patterns,
+                                           websocket_max_message_size=websocket_max_message_size_bytes,
+                                           **kwargs)
 
     def initialize(self, io_loop):
         ''' Start a Bokeh Server Tornado Application on a given Tornado IOLoop.

--- a/sphinx/source/docs/releases/0.13.0.rst
+++ b/sphinx/source/docs/releases/0.13.0.rst
@@ -15,6 +15,13 @@ Migration Guide
 NOTE: the 0.13.x series is a final series of small releases leading to a
 1.0 release. For more information see the `project roadmap`_.
 
+Max Websocket Message Size
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A new command line option ``--websocket-max-message-size`` for the Bokeh
+server can be used to configure the Tornado ``websocket_max_message_size``
+option. The default value is 20mb.
+
 New Hover fields
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
- [x] issues: fixes #7374
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

I was going to raise the min Tornado version to 4.5 but @bdarnell advised that earlier versions will just silently ignore the value rather than error out, so I have merely documented this fact. 

The tests 