### PR TITLE
Changed default line_join from miter to bevel

### DIFF
--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -467,7 +467,7 @@ class Serve(Subcommand):
         ('--num-procs', dict(
             metavar='N',
             action='store',
-            help="Number of worker processes for an app. Default to one. Using "
+            help="Number of worker processes for an app. Using "
                  "0 will autodetect number of cores (defaults to 1)",
             default=1,
             type=int,

--- a/bokeh/command/subcommands/tests/test_serve.py
+++ b/bokeh/command/subcommands/tests/test_serve.py
@@ -167,7 +167,7 @@ def test_args():
         ('--num-procs', dict(
              metavar='N',
              action='store',
-             help="Number of worker processes for an app. Default to one. Using "
+             help="Number of worker processes for an app. Using "
                   "0 will autodetect number of cores (defaults to 1)",
              default=1,
              type=int,

--- a/bokeh/core/property_mixins.py
+++ b/bokeh/core/property_mixins.py
@@ -98,7 +98,7 @@ Stroke width in units of pixels.
 """
 
 class BaseLineProps(HasProps):
-    line_join = Enum(LineJoin, help="""
+    line_join = Enum(LineJoin, default='bevel', help="""
     How path segments should be joined together.
 
     Acceptable values are:

--- a/bokeh/models/tests/utils/property_utils.py
+++ b/bokeh/models/tests/utils/property_utils.py
@@ -33,7 +33,7 @@ def check_line_properties(model, prefix="", line_color=Color.black, line_width=1
     assert getattr(model, prefix + "line_color") == line_color
     assert getattr(model, prefix + "line_width") == line_width
     assert getattr(model, prefix + "line_alpha") == line_alpha
-    assert getattr(model, prefix + "line_join") == LineJoin.miter
+    assert getattr(model, prefix + "line_join") == LineJoin.bevel
     assert getattr(model, prefix + "line_cap") == LineCap.butt
     assert getattr(model, prefix + "line_dash") == []
     assert getattr(model, prefix + "line_dash_offset") == 0

--- a/bokehjs/src/lib/core/property_mixins.ts
+++ b/bokehjs/src/lib/core/property_mixins.ts
@@ -70,7 +70,7 @@ const _line_mixin = {
   line_color:       [ p.ColorSpec,  'black'   ],
   line_width:       [ p.NumberSpec, 1         ],
   line_alpha:       [ p.NumberSpec, 1.0       ],
-  line_join:        [ p.LineJoin,   'miter'   ],
+  line_join:        [ p.LineJoin,   'bevel'   ],
   line_cap:         [ p.LineCap,    'butt'    ],
   line_dash:        [ p.Array,      []        ],
   line_dash_offset: [ p.Number,     0         ],

--- a/sphinx/source/docs/releases/0.13.0.rst
+++ b/sphinx/source/docs/releases/0.13.0.rst
@@ -20,7 +20,8 @@ Max Websocket Message Size
 
 A new command line option ``--websocket-max-message-size`` for the Bokeh
 server can be used to configure the Tornado ``websocket_max_message_size``
-option. The default value is 20mb.
+option. The default value is now 20mb, an increase from the previous
+10mb implicit default.
 
 New Hover fields
 ~~~~~~~~~~~~~~~~

--- a/sphinx/source/docs/releases/0.13.0.rst
+++ b/sphinx/source/docs/releases/0.13.0.rst
@@ -48,4 +48,13 @@ Task names remained unchanged. If you want preserve the old workflow, e.g. to
 aid ``git bisect``, it is suggested to create an alias for ``node make``,
 e.g. in bash this would be ``alias gulp='node make'``.
 
+Deprecations and Compatibility
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The default ``line_join`` style has been changed from ``miter`` to ``bevel``,
+to avoid exaggerating corners where connected lines meet at a sharp angle.
+The HTML Canvas ``miterLimit`` property is meant to prevent such issues,
+but it does not appear to be respected by current browsers.
+
+
 .. _project roadmap: https://bokehplots.com/pages/roadmap.html

--- a/sphinx/source/docs/releases/0.13.0.rst
+++ b/sphinx/source/docs/releases/0.13.0.rst
@@ -48,8 +48,8 @@ Task names remained unchanged. If you want preserve the old workflow, e.g. to
 aid ``git bisect``, it is suggested to create an alias for ``node make``,
 e.g. in bash this would be ``alias gulp='node make'``.
 
-Deprecations and Compatibility
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Line Join Default
+~~~~~~~~~~~~~~~~~
 
 The default ``line_join`` style has been changed from ``miter`` to ``bevel``,
 to avoid exaggerating corners where connected lines meet at a sharp angle.


### PR DESCRIPTION
- [x] issues: fixes #7951
- [x] release document entry (if new feature or API change)

In every case where I can detect a difference from the current value, the change is an improvement.  E.g. from a [TriMesh example](https://holoviews.org/reference/elements/bokeh/TriMesh.html), before:
![image](https://user-images.githubusercontent.com/1695496/40948169-5b043768-682c-11e8-8200-21275ea03279.png)
and after:
![image](https://user-images.githubusercontent.com/1695496/40948180-698b325a-682c-11e8-9aec-1507d47b70e5.png)
(see all the spurious corners along the top edge of the image above, and how they disappear on the bottom image.)
Thanks to @bryevdv for the code.