### PR TITLE
Using mappers documentation update

### DIFF
--- a/sphinx/source/docs/user_guide/examples/styling_linear_mappers.py
+++ b/sphinx/source/docs/user_guide/examples/styling_linear_mappers.py
@@ -1,8 +1,6 @@
 from bokeh.plotting import figure, show, output_file
-from bokeh.models import Band, ColumnDataSource, ColorBar
+from bokeh.models import ColumnDataSource, ColorBar
 from bokeh.palettes import Spectral6
-import pandas as pd
-import numpy as np
 from bokeh.transform import linear_cmap
 
 output_file("styling_linear_mappers.html", title="styling_linear_mappers.py example")

--- a/sphinx/source/docs/user_guide/examples/styling_linear_mappers.py
+++ b/sphinx/source/docs/user_guide/examples/styling_linear_mappers.py
@@ -1,0 +1,31 @@
+from bokeh.plotting import figure, show, output_file
+from bokeh.models import Band, ColumnDataSource
+from bokeh.palettes import Spectral6
+import pandas as pd
+import numpy as np
+from bokeh.transform import linear_cmap
+
+output_file("styling_linear_mappers.html", title="styling_linear_mappers.py example")
+
+# Create some random data
+x = np.random.random(1000) * 2 + 5
+y = np.random.normal(size=1000) * 2 + 5
+
+df = pd.DataFrame(data=dict(x=x, y=y)).sort_values(by="x")
+
+mapper = linear_cmap(field_name='y' #Use the field name of the column source
+                    ,palette=Spectral6
+                    ,low=df.y.min()
+                    ,high=df.y.max()
+                    )
+
+source = ColumnDataSource(df.reset_index())
+
+p = figure(plot_width=400, plot_height=400)
+
+p.scatter(x='x', y='y', line_color=mapper,color=mapper, fill_alpha=1, size=4, source=source)
+
+p.title.text = "Linear Color Map Based on Y"
+
+
+show(p)

--- a/sphinx/source/docs/user_guide/examples/styling_linear_mappers.py
+++ b/sphinx/source/docs/user_guide/examples/styling_linear_mappers.py
@@ -1,5 +1,5 @@
 from bokeh.plotting import figure, show, output_file
-from bokeh.models import Band, ColumnDataSource
+from bokeh.models import Band, ColumnDataSource, ColorBar
 from bokeh.palettes import Spectral6
 import pandas as pd
 import numpy as np
@@ -7,25 +7,20 @@ from bokeh.transform import linear_cmap
 
 output_file("styling_linear_mappers.html", title="styling_linear_mappers.py example")
 
-# Create some random data
-x = np.random.random(1000) * 2 + 5
-y = np.random.normal(size=1000) * 2 + 5
+x = [1,2,3,4,5,7,8,9,10]
+y = [1,2,3,4,5,7,8,9,10]
 
-df = pd.DataFrame(data=dict(x=x, y=y)).sort_values(by="x")
+#Use the field name of the column source
+mapper = linear_cmap(field_name='y', palette=Spectral6 ,low=min(y) ,high=max(y))
 
-mapper = linear_cmap(field_name='y' #Use the field name of the column source
-                    ,palette=Spectral6
-                    ,low=df.y.min()
-                    ,high=df.y.max()
-                    )
+source = ColumnDataSource(dict(x=x,y=y))
 
-source = ColumnDataSource(df.reset_index())
+p = figure(plot_width=300, plot_height=300, title="Linear Color Map Based on Y")
 
-p = figure(plot_width=400, plot_height=400)
+p.circle(x='x', y='y', line_color=mapper,color=mapper, fill_alpha=1, size=12, source=source)
 
-p.scatter(x='x', y='y', line_color=mapper,color=mapper, fill_alpha=1, size=4, source=source)
+color_bar = ColorBar(color_mapper=mapper['transform'], width=8,  location=(0,0))
 
-p.title.text = "Linear Color Map Based on Y"
-
+p.add_layout(color_bar, 'right')
 
 show(p)

--- a/sphinx/source/docs/user_guide/styling.rst
+++ b/sphinx/source/docs/user_guide/styling.rst
@@ -25,6 +25,35 @@ All of the standard palettes included in bokeh can be found at
 :ref:`bokeh.palettes`. Custom palettes can be made by creating sequences of
 RGB(A) hex strings.
 
+.. _userguide_styling_using_mappers:
+
+Using Mappers
+--------------
+
+Color Mappers allow you to encode some data sequence into a palette of colors based on the value in that sequence. 
+The mappers are then set as the ``color`` attribute on marker objects. Bokeh includes several types of mappers to encode colors:
+
+* ``bokeh.transform.factor_cmap``: Maps colors to specific categorical elements see :ref:`userguide_categorical` for more detail. 
+* ``bokeh.transform.linear_cmap``: Maps a range of numeric values across the available colors from high to low. For example, a range of `[0,99]` given the colors `['red', 'green', 'blue']` would be mapped as follows::
+
+        x < 0  : 'red'     # values < low are clamped
+    0 >= x < 33 : 'red'
+    33 >= x < 66 : 'green'
+    66 >= x < 99 : 'blue'
+    99 >= x      : 'blue'    # values > high are clamped
+
+
+* ``bokeh.transform.log_cmap``: Similar to ``linear_cmap`` but uses a natual log scale to map the colors. 
+
+These mapper functions return a `DataSpec` property that can be passed to the color attribute of the glyph as follows: 
+
+
+.. bokeh-plot:: docs/user_guide/examples/styling_linear_mappers.py
+    :source-position: above
+
+
+
+
 .. _userguide_styling_visual_properties:
 
 Visual Properties
@@ -562,7 +591,7 @@ documentation in the :ref:`refguide`.
 The |FuncTickFormatter| allows arbitrary tick formatting to be performed by
 supplying a JavaScript snippet as the ``code`` property. For convenience,
 there are also ``from_py_func`` and ``from_coffeescript`` class methods
-that can convert a python function or coffeescript snippet into JavaScript
+that can convert a python function or CoffeeScript snippet into JavaScript
 automatically. In all cases, the variable ``tick`` will contain the unformatted
 tick value and can be expected to be present in the snippet or function
 namespace at render time. The example below demonstrates configuring a

--- a/sphinx/source/docs/user_guide/styling.rst
+++ b/sphinx/source/docs/user_guide/styling.rst
@@ -44,8 +44,8 @@ The mappers are then set as the ``color`` attribute on marker objects. Bokeh inc
 
 
 * ``bokeh.transform.log_cmap``: Similar to ``linear_cmap`` but uses a natual log scale to map the colors. 
-
-These mapper functions return a `DataSpec` property that can be passed to the color attribute of the glyph as follows: 
+ 
+These mapper functions return a ``DataSpec`` property that can be passed to the color attribute of the glyph. The returned dataspec includes a ``bokeh.transform`` which can be accessed to use the mapper in another context such as to create a ``ColorBar`` as in the example below: 
 
 
 .. bokeh-plot:: docs/user_guide/examples/styling_linear_mappers.py

--- a/sphinx/source/docs/user_guide/styling.rst
+++ b/sphinx/source/docs/user_guide/styling.rst
@@ -32,7 +32,7 @@ Using Mappers
 
 Color Mappers allow you to encode some data sequence into a palette of colors based on the value in that sequence. The mappers are then set as the ``color`` attribute on marker objects. Bokeh includes several types of mappers to encode colors:
 
-* ``bokeh.transform.factor_cmap``: Maps colors to specific categorical elements see :ref:`userguide_categorical` for more detail. 
+* ``bokeh.transform.factor_cmap``: Maps colors to specific categorical elements see :ref:`userguide_categorical` for more detail.
 * ``bokeh.transform.linear_cmap``: Maps a range of numeric values across the available colors from high to low. For example, a range of `[0,99]` given the colors `['red', 'green', 'blue']` would be mapped as follows::
 
         x < 0  : 'red'     # values < low are clamped
@@ -41,9 +41,9 @@ Color Mappers allow you to encode some data sequence into a palette of colors ba
     66 >= x < 99 : 'blue'
     99 >= x      : 'blue'    # values > high are clamped
 
-* ``bokeh.transform.log_cmap``: Similar to ``linear_cmap`` but uses a natual log scale to map the colors. 
- 
-These mapper functions return a ``DataSpec`` property that can be passed to the color attribute of the glyph. The returned dataspec includes a ``bokeh.transform`` which can be accessed to use the mapper in another context such as to create a ``ColorBar`` as in the example below: 
+* ``bokeh.transform.log_cmap``: Similar to ``linear_cmap`` but uses a natual log scale to map the colors.
+
+These mapper functions return a ``DataSpec`` property that can be passed to the color attribute of the glyph. The returned dataspec includes a ``bokeh.transform`` which can be accessed to use the mapper in another context such as to create a ``ColorBar`` as in the example below:
 
 .. bokeh-plot:: docs/user_guide/examples/styling_linear_mappers.py
     :source-position: above

--- a/sphinx/source/docs/user_guide/styling.rst
+++ b/sphinx/source/docs/user_guide/styling.rst
@@ -30,8 +30,7 @@ RGB(A) hex strings.
 Using Mappers
 --------------
 
-Color Mappers allow you to encode some data sequence into a palette of colors based on the value in that sequence. 
-The mappers are then set as the ``color`` attribute on marker objects. Bokeh includes several types of mappers to encode colors:
+Color Mappers allow you to encode some data sequence into a palette of colors based on the value in that sequence. The mappers are then set as the ``color`` attribute on marker objects. Bokeh includes several types of mappers to encode colors:
 
 * ``bokeh.transform.factor_cmap``: Maps colors to specific categorical elements see :ref:`userguide_categorical` for more detail. 
 * ``bokeh.transform.linear_cmap``: Maps a range of numeric values across the available colors from high to low. For example, a range of `[0,99]` given the colors `['red', 'green', 'blue']` would be mapped as follows::
@@ -42,17 +41,12 @@ The mappers are then set as the ``color`` attribute on marker objects. Bokeh inc
     66 >= x < 99 : 'blue'
     99 >= x      : 'blue'    # values > high are clamped
 
-
 * ``bokeh.transform.log_cmap``: Similar to ``linear_cmap`` but uses a natual log scale to map the colors. 
  
 These mapper functions return a ``DataSpec`` property that can be passed to the color attribute of the glyph. The returned dataspec includes a ``bokeh.transform`` which can be accessed to use the mapper in another context such as to create a ``ColorBar`` as in the example below: 
 
-
 .. bokeh-plot:: docs/user_guide/examples/styling_linear_mappers.py
     :source-position: above
-
-
-
 
 .. _userguide_styling_visual_properties:
 


### PR DESCRIPTION
fixes:  #7995

This is an update to the "Styling Visual Attributes page" to document the use of the mappers along with an example. 

A picture of the page (built locally) is attached here as well if folks just want to provide feedback on the text. 

This includes an example where 10 circles are drawn with an diverging color palette based on the y-axis. This pairs nicely with "Using Palettes" the first entry on the page. 

thanks



<img width="1427" alt="using mappers documentation" src="https://user-images.githubusercontent.com/20745904/41443991-14f000b0-700e-11e8-84c5-a6e4215db3fd.png">
