### PR TITLE
Bryanv/7985 gmap pos args

### DIFF
--- a/bokeh/plotting/gmap.py
+++ b/bokeh/plotting/gmap.py
@@ -65,6 +65,15 @@ class GMap(GMapPlot):
     ''' A subclass of :class:`~bokeh.models.plots.Plot` that simplifies plot
     creation with default axes, grids, tools, etc.
 
+    Args:
+        google_api_key (str):
+            Google requires an API key be supplied for maps to function. See:
+
+            https://developers.google.com/maps/documentation/javascript/get-api-key
+
+        map_options: (GMapOptions)
+            Configuration specific to a Google Map
+
     In addition to all the Bokeh model property attributes documented below,
     the ``Figure`` initializer also accepts the following options, which can
     help simplify configuration:
@@ -77,7 +86,7 @@ class GMap(GMapPlot):
     __subtype__ = "GMap"
     __view_model__ = "GMapPlot"
 
-    def __init__(self, google_api_key, map_options, **kw):
+    def __init__(self, **kw):
 
         if 'plot_width' in kw and 'width' in kw:
             raise ValueError("Figure called with both 'plot_width' and 'width' supplied, supply only one")
@@ -94,8 +103,7 @@ class GMap(GMapPlot):
         if isinstance(title, string_types):
             kw['title'] = Title(text=title)
 
-        super(GMap, self).__init__(api_key=google_api_key, map_options=map_options,
-                                   x_range=Range1d(), y_range=Range1d(), **kw)
+        super(GMap, self).__init__(x_range=Range1d(), y_range=Range1d(), **kw)
 
         xf = MercatorTickFormatter(dimension="lon")
         xt = MercatorTicker(dimension="lon")
@@ -203,4 +211,4 @@ def gmap(google_api_key, map_options, **kwargs):
 
     '''
 
-    return GMap(google_api_key, map_options, **kwargs)
+    return GMap(api_key=google_api_key, map_options=map_options, **kwargs)

--- a/bokeh/tests/test_model.py
+++ b/bokeh/tests/test_model.py
@@ -164,3 +164,14 @@ def test_model_js_on_change_ignores_dupe_callbacks():
     m = SomeModel()
     m.js_on_change('foo', cb, cb)
     assert m.js_property_callbacks == {"foo": [cb]}
+
+from bokeh.models import * # NOQA
+from bokeh.plotting import * # NOQA
+def test_all_builtin_models_default_constructible():
+    bad = []
+    for name, cls in Model.__class__.model_class_reverse_map.items():
+        try:
+            cls()
+        except:
+            bad.append(name)
+        assert bad == []


### PR DESCRIPTION
This problem stemmed from the Bokeh `bokeh.plotting.gmap.GMap` model not being default constructible. Generally speaking all Bokeh models need to be default constructible. This PR also adds a test to assert that.  

- [x] issues: fixes #7985
- [x] tests added / passed
