### PR TITLE
Fix hit testing issues for wedge and annular wedge

### DIFF
--- a/bokehjs/src/lib/core/util/math.ts
+++ b/bokehjs/src/lib/core/util/math.ts
@@ -1,3 +1,5 @@
+const enum Direction {clock, anticlock}
+
 export function angle_norm(angle: number): number {
   while (angle < 0) {
     angle += 2*Math.PI
@@ -12,12 +14,11 @@ export function angle_dist(lhs: number, rhs: number): number {
   return Math.abs(angle_norm(lhs-rhs))
 }
 
-export function angle_between(mid: number, lhs: number, rhs: number, direction: 1 | 0): boolean {
-  // 1 = anticlock, 0 = clock
+export function angle_between(mid: number, lhs: number, rhs: number, direction: Direction): boolean {
   const norm_mid = angle_norm(mid)
   const d = angle_dist(lhs, rhs)
   const cond = angle_dist(lhs, norm_mid) <= d && angle_dist(norm_mid, rhs) <= d
-  if (direction == 1)
+  if (direction == Direction.anticlock)
     return !cond
   else
     return cond

--- a/bokehjs/src/lib/core/util/math.ts
+++ b/bokehjs/src/lib/core/util/math.ts
@@ -12,14 +12,15 @@ export function angle_dist(lhs: number, rhs: number): number {
   return Math.abs(angle_norm(lhs-rhs))
 }
 
-export function angle_between(mid: number, lhs: number, rhs: number, direction: "anticlock" | "clock"): boolean {
+export function angle_between(mid: number, lhs: number, rhs: number, direction: 1 | 0): boolean {
+  // 1 = anticlock, 0 = clock
   const norm_mid = angle_norm(mid)
   const d = angle_dist(lhs, rhs)
   const cond = angle_dist(lhs, norm_mid) <= d && angle_dist(norm_mid, rhs) <= d
-  if (direction == "anticlock")
-    return cond
-  else
+  if (direction == 1)
     return !cond
+  else
+    return cond
 }
 
 export function random(): number {

--- a/bokehjs/src/lib/models/glyphs/wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/wedge.ts
@@ -66,21 +66,22 @@ export class WedgeView extends XYGlyphView {
     const x = this.renderer.xscale.invert(sx);
     const y = this.renderer.yscale.invert(sy);
 
-    // check radius first
+    // check diameter first
+    const max_diameter = 2 * this.max_radius
     if (this.model.properties.radius.units === "data") {
-      x0 = x - this.max_radius;
-      x1 = x + this.max_radius;
+      x0 = x - max_diameter;
+      x1 = x + max_diameter;
 
-      y0 = y - this.max_radius;
-      y1 = y + this.max_radius;
+      y0 = y - max_diameter;
+      y1 = y + max_diameter;
 
     } else {
-      sx0 = sx - this.max_radius;
-      sx1 = sx + this.max_radius;
+      sx0 = sx - max_diameter;
+      sx1 = sx + max_diameter;
       [x0, x1] = this.renderer.xscale.r_invert(sx0, sx1);
 
-      sy0 = sy - this.max_radius;
-      sy1 = sy + this.max_radius;
+      sy0 = sy - max_diameter;
+      sy1 = sy + max_diameter;
       [y0, y1] = this.renderer.yscale.r_invert(sy0, sy1);
     }
 

--- a/bokehjs/src/lib/models/glyphs/wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/wedge.ts
@@ -113,6 +113,20 @@ export class WedgeView extends XYGlyphView {
   draw_legend_for_index(ctx: Context2d, bbox: IBBox, index: number): void {
     generic_area_legend(this.visuals, ctx, bbox, index);
   }
+
+  private _scenterxy(i: number): {x: number, y: number} {
+    const r = this.sradius[i] / 2;
+    const a = (this._start_angle[i] + this._end_angle[i]) / 2;
+    return {x: this.sx[i] + (r * Math.cos(a)), y: this.sy[i] + (r * Math.sin(a))};
+  }
+
+  scenterx(i: number): number {
+    return this._scenterxy(i).x
+  }
+
+  scentery(i: number): number {
+    return this._scenterxy(i).y
+  }
 }
 
 export namespace Wedge {

--- a/bokehjs/test/core/util/math.ts
+++ b/bokehjs/test/core/util/math.ts
@@ -16,8 +16,8 @@ describe("math module", () => {
   })
 
   it("should return true if `mid` angle between `lhs` and `rhs`", () => {
-    expect(math.angle_between(0, -1, 1, "anticlock")).to.be.equal(false)
-    expect(math.angle_between(0, -1, 1, "clock")).to.be.equal(true)
+    expect(math.angle_between(0, -1, 1, 1)).to.be.equal(true)
+    expect(math.angle_between(0, -1, 1, 0)).to.be.equal(false)
   })
 
   it("should return the arctangent between 2 (x,y) points", () => {


### PR DESCRIPTION
Corrects the issues discussed in #7428 and #2080. Namely the incorrect behaviour when the direction is set to clock, and also improving hover tool tip display position for wedge glyphs.

Might be some changing required depending on the exact intention of using angle_between.

- [X] issues: fixes #7428 and #2080
