### PR TITLE
Added workaround when initializing CDS with column named index

### DIFF
--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -159,6 +159,11 @@ class ColumnDataSource(ColumnarDataSource):
             new_data[k] = v
 
         index_name = ColumnDataSource._df_index_name(df)
+        if index_name in new_data:
+            old_index_name = index_name
+            index_name = old_index_name + '_index'
+            warnings.warn('Column named %s. Renaming index to %s' %
+                          (old_index_name, index_name))
         new_data[index_name] = _df.index.values
         return new_data
 


### PR DESCRIPTION
Was not 100% sure of the course of action here. I think that the user expects the column name to be the same, and cares less about the specific name of the index. Which is why I opted to adjust the index name, and not the column name. The warning should help either way for this edge case.

- [x] issues: fixes #6770
- [ ] tests added / passed
