### PR TITLE
bokeh server: reference leak fix

### DIFF
--- a/bokeh/document/document.py
+++ b/bokeh/document/document.py
@@ -1006,9 +1006,11 @@ class Document(object):
             else:
                 callback_objs = [callback_obj]
                 self._session_callbacks.remove(callback_obj)
-                for cb_objs in self._callback_objs_by_callable[originator].values():
+                for cb, cb_objs in list(self._callback_objs_by_callable[originator].items()):
                     try:
                         cb_objs.remove(callback_obj)
+                        if not cb_objs:
+                            del self._callback_objs_by_callable[originator][cb]
                     except KeyError:
                         pass
         except KeyError:

--- a/bokeh/util/tornado.py
+++ b/bokeh/util/tornado.py
@@ -167,20 +167,20 @@ class _CallbackGroup(object):
         return remover
 
     def _execute_remover(self, callback_id, removers):
-            try:
-                with self._removers_lock:
-                    if callable(callback_id):
-                        remover = self._create_deprecated_remover(callback_id, removers)
-                    else:
-                        remover = removers.pop(callback_id)
-                        for cb_ids in self._get_removers_ids_by_callable(removers).values():
-                            try:
-                                cb_ids.remove(callback_id)
-                            except KeyError:
-                                pass
-            except KeyError:
-                raise ValueError("Removing a callback twice (or after it's already been run)")
-            remover()
+        try:
+            with self._removers_lock:
+                if callable(callback_id):
+                    remover = self._create_deprecated_remover(callback_id, removers)
+                else:
+                    remover = removers.pop(callback_id)
+                    for cb_ids in self._get_removers_ids_by_callable(removers).values():
+                        try:
+                            cb_ids.remove(callback_id)
+                        except KeyError:
+                            pass
+        except KeyError:
+            raise ValueError("Removing a callback twice (or after it's already been run)")
+        remover()
 
     def add_next_tick_callback(self, callback, callback_id=None):
         """ Adds a callback to be run on the next tick.

--- a/bokeh/util/tornado.py
+++ b/bokeh/util/tornado.py
@@ -173,9 +173,11 @@ class _CallbackGroup(object):
                     remover = self._create_deprecated_remover(callback_id, removers)
                 else:
                     remover = removers.pop(callback_id)
-                    for cb_ids in self._get_removers_ids_by_callable(removers).values():
+                    for cb, cb_ids in list(self._get_removers_ids_by_callable(removers).items()):
                         try:
                             cb_ids.remove(callback_id)
+                            if not cb_ids:
+                                del self._get_removers_ids_by_callable(removers)[cb]
                         except KeyError:
                             pass
         except KeyError:


### PR DESCRIPTION
The #7992 issue originates from the fact that `_callback_objs_by_callable` in document.py and `_next_tick_removers_by_callable` etc. in tornado.py are retaining references, as dictionary keys, to callable objects (and their wrapped versions, correspondingly), passed to `add_next_tick_callback` etc. document methods. I guess, the intention was to group multiple next tick or timeout callbacks for the same callback function in `defaultdict(set)`s. Though, the wrapped callbacks of the same callback function are already different objects and "won't stack" in `_next_tick_removers_by_callable`, while passing different callback functions will aggregate in both location, thus doubling the captured reference count.

This PR is fixing it by removing the `key, value` pairs completely, once the `value` is an empty set. This is, probably, the least invasive way to fix the issue, though, not the most performant. Arguably, a simple dict `{callback_obj: callback}` in document.py and `{callback_id: wrapped_callback}` in tornado.py might be better, and can also eliminate the separation between different types of document callbacks in different dictionaries(?). Not sure about the latter in a view of deprecated ways of adding/removing callbacks.

Maybe a couple of tests should be added to verify that the bokeh server doesn't hold (directly and indirectly) any refs to callback functions after their execution.

- [x] issues: fixes #7992 
- [ ] tests added / passed
