### PR TITLE
Make Bokeh work in frozen scripts

### DIFF
--- a/bokeh/core/templates.py
+++ b/bokeh/core/templates.py
@@ -16,12 +16,22 @@ models in various ways.
 
 '''
 from __future__ import absolute_import
-
 import json
+from jinja2 import Environment, Markup, FileSystemLoader, PackageLoader
+import sys
+import os
 
-from jinja2 import Environment, PackageLoader, Markup
+def get_env():
+    ''' Get the correct Jinja2 Environment, also for frozen scripts.
+    '''
+    if getattr(sys, 'frozen', False):
+        templates_path = os.path.join(sys._MEIPASS, '_templates')
+        return Environment(loader=FileSystemLoader(templates_path))
+    else:
+        return Environment(loader=PackageLoader('bokeh.core', '_templates'))
 
-_env = Environment(loader=PackageLoader('bokeh.core', '_templates'))
+
+_env = get_env()
 _env.filters['json'] = lambda obj: Markup(json.dumps(obj))
 
 JS_RESOURCES = _env.get_template("js_resources.html")


### PR DESCRIPTION
This PR fixes a bug concerning the interaction between Bokeh and PyInstaller by using Jinja2's `FileSystemLoader` instead of `PackageLoader` (which is currently not supported by PyInstaller), and adjusting the path to the `_templates` folder. It should also fix issues with other freezing tools (like py2exe in #799). However, PyInstaller is probably the most widely used freezing tool and is still actively maintained (unlike e.g. py2exe, whose last release is almost four years old).

Since the changes are in an `if getattr(sys, 'frozen', False)` block (as described in the [PyInstaller documentation](http://pyinstaller.readthedocs.io/en/stable/runtime-information.html)), this PR shouldn't break anything for the "live" use.

PyInstaller itself does not copy the `bokeh/core/_templates` folder (which contains files to be loaded by `bokeh/core/templates.py`). When a bundled app starts up, the bootloader stores the absolute path to the bundle folder in `sys._MEIPASS` – and this is where I tell Jinja2 to look for the `_templates` folder.

If you now freeze the script with PyInstaller, the `_templates` folder must be explicitly copied with `--add-data _templates:_templates` (or in the `.spec` file), but that's something the PyInstaller people should mention in their documentation (if my PR is merged, I can get this going).

I'm not sure how to test this (for continuous integration). Creating a bundled app and check if it works seems to be a bit too much for this, well, pretty special use case?

The changes are tested locally on my machine with Bokeh 0.12.16 and PyInstaller 3.3.1 on Ubuntu 18.04 and Python 3.6.5. This is the minimal example that worked:

```python
from bokeh.plotting import figure, output_file, show

# prepare some data
x = [1, 2, 3, 4, 5]
y = [6, 7, 2, 4, 5]

# output to static HTML file
output_file("lines.html", title="line plot example")

# create a new plot with a title and axis labels
p = figure(title="simple line example", x_axis_label='x', y_axis_label='y')

# add a line renderer with legend and line thickness
p.line(x, y, legend="Temp.", line_width=2)

# show the results
show(p)
```

If there is anything else I can do, let me know!