### PR TITLE
test with minimal packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,7 @@ jobs:
       - GROUP=unit
       - PYTHON=3.5
       - TORNADO=4
+      - MINIMAL=1
 
     - install: scripts/ci/install:test
       script: scripts/ci/test

--- a/bokeh/core/property/tests/test_bases.py
+++ b/bokeh/core/property/tests/test_bases.py
@@ -2,9 +2,9 @@ from mock import patch
 import pytest
 
 import numpy as np
-import pandas as pd
 
 from bokeh.core.has_props import HasProps
+from bokeh.util.testing import pd ; pd
 
 import bokeh.core.property.bases as pb
 
@@ -115,7 +115,7 @@ def test_property_matches_non_dict_containers_with_array_false(capsys):
     out, err = capsys.readouterr()
     assert err == ""
 
-def test_property_matches_dicts_with_series_values(capsys):
+def test_property_matches_dicts_with_series_values(capsys, pd):
     p = pb.Property()
     d1 = pd.DataFrame(dict(foo=np.arange(10)))
     d2 = pd.DataFrame(dict(foo=np.arange(10)))
@@ -132,7 +132,7 @@ def test_property_matches_dicts_with_series_values(capsys):
     out, err = capsys.readouterr()
     assert err == ""
 
-def test_property_matches_dicts_with_index_values(capsys):
+def test_property_matches_dicts_with_index_values(capsys, pd):
     p = pb.Property()
     d1 = pd.DataFrame(dict(foo=np.arange(10)))
     d2 = pd.DataFrame(dict(foo=np.arange(10)))

--- a/bokeh/core/tests/test_properties.py
+++ b/bokeh/core/tests/test_properties.py
@@ -2,9 +2,7 @@ from __future__ import absolute_import
 
 import datetime
 import time
-import unittest
 import numpy as np
-import pandas as pd
 from copy import copy
 
 import pytest
@@ -21,6 +19,8 @@ from bokeh.core.property.containers import PropertyValueColumnData, PropertyValu
 from bokeh.core.has_props import HasProps
 
 from bokeh.models import Plot
+
+from bokeh.util.testing import pd ; pd
 
 SPECS = (NumberSpec, ColorSpec, AngleSpec, StringSpec, DistanceSpec, FontSizeSpec, DataDistanceSpec, ScreenDistanceSpec)
 
@@ -304,7 +304,7 @@ class Test_Date(object):
         d = Date()
         assert d.transform(t) == datetime.date.today()
 
-class Basictest(unittest.TestCase):
+class Basictest(object):
 
     def test_simple_class(self):
         class Foo(HasProps):
@@ -315,36 +315,36 @@ class Basictest(unittest.TestCase):
             s = String(None)
 
         f = Foo()
-        self.assertEqual(f.x, 12)
-        self.assertEqual(f.y, "hello")
-        self.assert_(np.array_equal(np.array([1, 2, 3]), f.z))
-        self.assertEqual(f.s, None)
+        assert f.x == 12
+        assert f.y == "hello"
+        assert np.array_equal(np.array([1, 2, 3]), f.z)
+        assert f.s is None
 
 
-        self.assertEqual(set(["x", "y", "z", "zz", "s"]), f.properties())
+        assert set(["x", "y", "z", "zz", "s"]) == f.properties()
         with_defaults = f.properties_with_values(include_defaults=True)
-        self.assertDictEqual(dict(x=12, y="hello", z=[1,2,3], zz={}, s=None), with_defaults)
+        assert dict(x=12, y="hello", z=[1,2,3], zz={}, s=None) == with_defaults
         without_defaults = f.properties_with_values(include_defaults=False)
-        self.assertDictEqual(dict(), without_defaults)
+        assert dict() == without_defaults
 
         f.x = 18
-        self.assertEqual(f.x, 18)
+        assert f.x == 18
 
         f.y = "bar"
-        self.assertEqual(f.y, "bar")
+        assert f.y == "bar"
 
         without_defaults = f.properties_with_values(include_defaults=False)
-        self.assertDictEqual(dict(x=18, y="bar"), without_defaults)
+        assert dict(x=18, y="bar") == without_defaults
 
         f.z[0] = 100
 
         without_defaults = f.properties_with_values(include_defaults=False)
-        self.assertDictEqual(dict(x=18, y="bar", z=[100,2,3]), without_defaults)
+        assert dict(x=18, y="bar", z=[100,2,3]) == without_defaults
 
         f.zz = {'a': 10}
 
         without_defaults = f.properties_with_values(include_defaults=False)
-        self.assertDictEqual(dict(x=18, y="bar", z=[100,2,3], zz={'a': 10}), without_defaults)
+        assert dict(x=18, y="bar", z=[100,2,3], zz={'a': 10}) == without_defaults
 
     def test_enum(self):
         class Foo(HasProps):
@@ -352,19 +352,19 @@ class Basictest(unittest.TestCase):
             y = Enum("small", "medium", "large", default="large")
 
         f = Foo()
-        self.assertEqual(f.x, "blue")
-        self.assertEqual(f.y, "large")
+        assert f.x == "blue"
+        assert f.y == "large"
 
         f.x = "red"
-        self.assertEqual(f.x, "red")
+        assert f.x == "red"
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             f.x = "yellow"
 
         f.y = "small"
-        self.assertEqual(f.y, "small")
+        assert f.y == "small"
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             f.y = "yellow"
 
     def test_inheritance(self):
@@ -376,8 +376,8 @@ class Basictest(unittest.TestCase):
             z = Float(3.14)
 
         c = Child()
-        self.assertEqual(frozenset(['x', 'y', 'z']), frozenset(c.properties()))
-        self.assertEqual(c.y, "hello")
+        assert frozenset(['x', 'y', 'z']) == frozenset(c.properties())
+        assert c.y == "hello"
 
     def test_set(self):
         class Foo(HasProps):
@@ -386,14 +386,14 @@ class Basictest(unittest.TestCase):
             z = String("blah")
 
         f = Foo()
-        self.assertEqual(f.x, 12)
-        self.assertEqual(f.y, "red")
-        self.assertEqual(f.z, "blah")
+        assert f.x == 12
+        assert f.y == "red"
+        assert f.z == "blah"
         f.update(**dict(x=20, y="green", z="hello"))
-        self.assertEqual(f.x, 20)
-        self.assertEqual(f.y, "green")
-        self.assertEqual(f.z, "hello")
-        with self.assertRaises(ValueError):
+        assert f.x == 20
+        assert f.y == "green"
+        assert f.z == "hello"
+        with pytest.raises(ValueError):
             f.update(y="orange")
 
     def test_no_parens(self):
@@ -401,9 +401,9 @@ class Basictest(unittest.TestCase):
             x = Int
             y = Int()
         f = Foo()
-        self.assertEqual(f.x, f.y)
+        assert f.x == f.y
         f.x = 13
-        self.assertEqual(f.x, 13)
+        assert f.x == 13
 
     def test_accurate_properties_sets(self):
         class Base(HasProps):
@@ -422,53 +422,36 @@ class Basictest(unittest.TestCase):
             sub_child = Instance(HasProps)
 
         b = Base()
-        self.assertEqual(set(["child"]),
-                         b.properties_with_refs())
-        self.assertEqual(set(["container"]),
-                         b.properties_containers())
-        self.assertEqual(set(["num", "container", "child"]),
-                         b.properties())
-        self.assertEqual(set(["num", "container", "child"]),
-                         b.properties(with_bases=True))
-        self.assertEqual(set(["num", "container", "child"]),
-                         b.properties(with_bases=False))
+        assert set(["child"]) == b.properties_with_refs()
+        assert set(["container"]) == b.properties_containers()
+        assert set(["num", "container", "child"]) == b.properties()
+        assert set(["num", "container", "child"]) == b.properties(with_bases=True)
+        assert set(["num", "container", "child"]) == b.properties(with_bases=False)
 
         m = Mixin()
-        self.assertEqual(set(["mixin_child"]),
-                         m.properties_with_refs())
-        self.assertEqual(set(["mixin_container"]),
-                         m.properties_containers())
-        self.assertEqual(set(["mixin_num", "mixin_container", "mixin_child"]),
-                         m.properties())
-        self.assertEqual(set(["mixin_num", "mixin_container", "mixin_child"]),
-                         m.properties(with_bases=True))
-        self.assertEqual(set(["mixin_num", "mixin_container", "mixin_child"]),
-                         m.properties(with_bases=False))
+        assert set(["mixin_child"]) == m.properties_with_refs()
+        assert set(["mixin_container"]) == m.properties_containers()
+        assert set(["mixin_num", "mixin_container", "mixin_child"]) == m.properties()
+        assert set(["mixin_num", "mixin_container", "mixin_child"]) == m.properties(with_bases=True)
+        assert set(["mixin_num", "mixin_container", "mixin_child"]) == m.properties(with_bases=False)
 
         s = Sub()
-        self.assertEqual(set(["child", "sub_child", "mixin_child"]),
-                         s.properties_with_refs())
-        self.assertEqual(set(["container", "sub_container", "mixin_container"]),
-                         s.properties_containers())
-        self.assertEqual(set(["num", "container", "child",
-                              "mixin_num", "mixin_container", "mixin_child",
-                              "sub_num", "sub_container", "sub_child"]),
-                         s.properties())
-        self.assertEqual(set(["num", "container", "child",
-                              "mixin_num", "mixin_container", "mixin_child",
-                              "sub_num", "sub_container", "sub_child"]),
-                         s.properties(with_bases=True))
-        self.assertEqual(set(["sub_num", "sub_container", "sub_child"]),
-                         s.properties(with_bases=False))
+        assert set(["child", "sub_child", "mixin_child"]) == s.properties_with_refs()
+        assert set(["container", "sub_container", "mixin_container"]) == s.properties_containers()
+        assert set(["num", "container", "child", "mixin_num", "mixin_container", "mixin_child", "sub_num", "sub_container", "sub_child"]) == s.properties()
+        assert set(
+            ["num", "container", "child", "mixin_num", "mixin_container", "mixin_child", "sub_num", "sub_container", "sub_child"]
+        ) == s.properties(with_bases=True)
+        assert set(["sub_num", "sub_container", "sub_child"]) == s.properties(with_bases=False)
 
         # verify caching
-        self.assertIs(s.properties_with_refs(), s.properties_with_refs())
-        self.assertIs(s.properties_containers(), s.properties_containers())
-        self.assertIs(s.properties(), s.properties())
-        self.assertIs(s.properties(with_bases=True), s.properties(with_bases=True))
+        assert s.properties_with_refs() is s.properties_with_refs()
+        assert s.properties_containers() is s.properties_containers()
+        assert s.properties() is s.properties()
+        assert s.properties(with_bases=True) is s.properties(with_bases=True)
         # this one isn't cached because we store it as a list __properties__ and wrap it
         # in a new set every time
-        #self.assertIs(s.properties(with_bases=False), s.properties(with_bases=False))
+        #assert s.properties(with_bases=False) is s.properties(with_bases=False)
 
     def test_accurate_dataspecs(self):
         class Base(HasProps):
@@ -485,16 +468,13 @@ class Basictest(unittest.TestCase):
         mixin = Mixin()
         sub = Sub()
 
-        self.assertEqual(set(["num"]), base.dataspecs())
-        self.assertEqual(set(["mixin_num"]), mixin.dataspecs())
-        self.assertEqual(set(["num", "mixin_num", "sub_num"]), sub.dataspecs())
+        assert set(["num"]) == base.dataspecs()
+        assert set(["mixin_num"]) == mixin.dataspecs()
+        assert set(["num", "mixin_num", "sub_num"]) == sub.dataspecs()
 
-        self.assertDictEqual(dict(num=base.lookup("num")), base.dataspecs_with_props())
-        self.assertDictEqual(dict(mixin_num=mixin.lookup("mixin_num")), mixin.dataspecs_with_props())
-        self.assertDictEqual(dict(num=sub.lookup("num"),
-                                  mixin_num=sub.lookup("mixin_num"),
-                                  sub_num=sub.lookup("sub_num")),
-                             sub.dataspecs_with_props())
+        assert dict(num=base.lookup("num")) ==  base.dataspecs_with_props()
+        assert dict(mixin_num=mixin.lookup("mixin_num")) == mixin.dataspecs_with_props()
+        assert dict(num=sub.lookup("num"), mixin_num=sub.lookup("mixin_num"), sub_num=sub.lookup("sub_num")) == sub.dataspecs_with_props()
 
     def test_not_serialized(self):
         class NotSerialized(HasProps):
@@ -502,28 +482,28 @@ class Basictest(unittest.TestCase):
             y = String("hello")
 
         o = NotSerialized()
-        self.assertEqual(o.x, 12)
-        self.assertEqual(o.y, 'hello')
+        assert o.x == 12
+        assert o.y == 'hello'
 
         # non-serialized props are still in the list of props
-        self.assertTrue('x' in o.properties())
-        self.assertTrue('y' in o.properties())
+        assert 'x' in o.properties()
+        assert 'y' in o.properties()
 
         # but they aren't in the dict of props with values, since their
         # values are not important (already included in other values,
         # as with the _units properties)
-        self.assertTrue('x' not in o.properties_with_values(include_defaults=True))
-        self.assertTrue('y' in o.properties_with_values(include_defaults=True))
-        self.assertTrue('x' not in o.properties_with_values(include_defaults=False))
-        self.assertTrue('y' not in o.properties_with_values(include_defaults=False))
+        assert 'x' not in o.properties_with_values(include_defaults=True)
+        assert 'y' in o.properties_with_values(include_defaults=True)
+        assert 'x' not in o.properties_with_values(include_defaults=False)
+        assert 'y' not in o.properties_with_values(include_defaults=False)
 
         o.x = 42
         o.y = 'world'
 
-        self.assertTrue('x' not in o.properties_with_values(include_defaults=True))
-        self.assertTrue('y' in o.properties_with_values(include_defaults=True))
-        self.assertTrue('x' not in o.properties_with_values(include_defaults=False))
-        self.assertTrue('y' in o.properties_with_values(include_defaults=False))
+        assert 'x' not in o.properties_with_values(include_defaults=True)
+        assert 'y' in o.properties_with_values(include_defaults=True)
+        assert 'x' not in o.properties_with_values(include_defaults=False)
+        assert 'y' in o.properties_with_values(include_defaults=False)
 
     def test_readonly(self):
         class Readonly(HasProps):
@@ -532,32 +512,32 @@ class Basictest(unittest.TestCase):
             z = String("hello")
 
         o = Readonly()
-        self.assertEqual(o.x, 12)
-        self.assertEqual(o.y, None)
-        self.assertEqual(o.z, 'hello')
+        assert o.x == 12
+        assert o.y == None
+        assert o.z == 'hello'
 
         # readonly props are still in the list of props
-        self.assertTrue('x' in o.properties())
-        self.assertTrue('y' in o.properties())
-        self.assertTrue('z' in o.properties())
+        assert 'x' in o.properties()
+        assert 'y' in o.properties()
+        assert 'z' in o.properties()
 
         # but they aren't in the dict of props with values
-        self.assertTrue('x' not in o.properties_with_values(include_defaults=True))
-        self.assertTrue('y' not in o.properties_with_values(include_defaults=True))
-        self.assertTrue('z' in o.properties_with_values(include_defaults=True))
-        self.assertTrue('x' not in o.properties_with_values(include_defaults=False))
-        self.assertTrue('y' not in o.properties_with_values(include_defaults=False))
-        self.assertTrue('z' not in o.properties_with_values(include_defaults=False))
+        assert 'x' not in o.properties_with_values(include_defaults=True)
+        assert 'y' not in o.properties_with_values(include_defaults=True)
+        assert 'z' in o.properties_with_values(include_defaults=True)
+        assert 'x' not in o.properties_with_values(include_defaults=False)
+        assert 'y' not in o.properties_with_values(include_defaults=False)
+        assert 'z' not in o.properties_with_values(include_defaults=False)
 
-        with self.assertRaises(RuntimeError):
+        with pytest.raises(RuntimeError):
             o.x = 7
-        with self.assertRaises(RuntimeError):
+        with pytest.raises(RuntimeError):
             o.y = 7
         o.z = "xyz"
 
-        self.assertEqual(o.x, 12)
-        self.assertEqual(o.y, None)
-        self.assertEqual(o.z, 'xyz')
+        assert o.x == 12
+        assert o.y == None
+        assert o.z == 'xyz'
 
     def test_include_defaults(self):
         class IncludeDefaultsTest(HasProps):
@@ -565,21 +545,21 @@ class Basictest(unittest.TestCase):
             y = String("hello")
 
         o = IncludeDefaultsTest()
-        self.assertEqual(o.x, 12)
-        self.assertEqual(o.y, 'hello')
+        assert o.x == 12
+        assert o.y == 'hello'
 
-        self.assertTrue('x' in o.properties_with_values(include_defaults=True))
-        self.assertTrue('y' in o.properties_with_values(include_defaults=True))
-        self.assertTrue('x' not in o.properties_with_values(include_defaults=False))
-        self.assertTrue('y' not in o.properties_with_values(include_defaults=False))
+        assert 'x' in o.properties_with_values(include_defaults=True)
+        assert 'y' in o.properties_with_values(include_defaults=True)
+        assert 'x' not in o.properties_with_values(include_defaults=False)
+        assert 'y' not in o.properties_with_values(include_defaults=False)
 
         o.x = 42
         o.y = 'world'
 
-        self.assertTrue('x' in o.properties_with_values(include_defaults=True))
-        self.assertTrue('y' in o.properties_with_values(include_defaults=True))
-        self.assertTrue('x' in o.properties_with_values(include_defaults=False))
-        self.assertTrue('y' in o.properties_with_values(include_defaults=False))
+        assert 'x' in o.properties_with_values(include_defaults=True)
+        assert 'y' in o.properties_with_values(include_defaults=True)
+        assert 'x' in o.properties_with_values(include_defaults=False)
+        assert 'y' in o.properties_with_values(include_defaults=False)
 
     def test_include_defaults_with_kwargs(self):
         class IncludeDefaultsKwargsTest(HasProps):
@@ -587,13 +567,13 @@ class Basictest(unittest.TestCase):
             y = String("hello")
 
         o = IncludeDefaultsKwargsTest(x=14, y="world")
-        self.assertEqual(o.x, 14)
-        self.assertEqual(o.y, 'world')
+        assert o.x == 14
+        assert o.y == 'world'
 
-        self.assertTrue('x' in o.properties_with_values(include_defaults=True))
-        self.assertTrue('y' in o.properties_with_values(include_defaults=True))
-        self.assertTrue('x' in o.properties_with_values(include_defaults=False))
-        self.assertTrue('y' in o.properties_with_values(include_defaults=False))
+        assert 'x' in o.properties_with_values(include_defaults=True)
+        assert 'y' in o.properties_with_values(include_defaults=True)
+        assert 'x' in o.properties_with_values(include_defaults=False)
+        assert 'y' in o.properties_with_values(include_defaults=False)
 
     def test_include_defaults_set_to_same(self):
         class IncludeDefaultsSetToSameTest(HasProps):
@@ -602,19 +582,19 @@ class Basictest(unittest.TestCase):
 
         o = IncludeDefaultsSetToSameTest()
 
-        self.assertTrue('x' in o.properties_with_values(include_defaults=True))
-        self.assertTrue('y' in o.properties_with_values(include_defaults=True))
-        self.assertTrue('x' not in o.properties_with_values(include_defaults=False))
-        self.assertTrue('y' not in o.properties_with_values(include_defaults=False))
+        assert 'x' in o.properties_with_values(include_defaults=True)
+        assert 'y' in o.properties_with_values(include_defaults=True)
+        assert 'x' not in o.properties_with_values(include_defaults=False)
+        assert 'y' not in o.properties_with_values(include_defaults=False)
 
         # this should no-op
         o.x = 12
         o.y = "hello"
 
-        self.assertTrue('x' in o.properties_with_values(include_defaults=True))
-        self.assertTrue('y' in o.properties_with_values(include_defaults=True))
-        self.assertTrue('x' not in o.properties_with_values(include_defaults=False))
-        self.assertTrue('y' not in o.properties_with_values(include_defaults=False))
+        assert 'x' in o.properties_with_values(include_defaults=True)
+        assert 'y' in o.properties_with_values(include_defaults=True)
+        assert 'x' not in o.properties_with_values(include_defaults=False)
+        assert 'y' not in o.properties_with_values(include_defaults=False)
 
     def test_override_defaults(self):
         class FooBase(HasProps):
@@ -633,17 +613,17 @@ class Basictest(unittest.TestCase):
         f_sub = FooSub()
         f_sub_sub = FooSubSub()
 
-        self.assertEqual(f_base.x, 12)
-        self.assertEqual(f_sub.x, 14)
-        self.assertEqual(f_sub_sub.x, 16)
+        assert f_base.x == 12
+        assert f_sub.x == 14
+        assert f_sub_sub.x == 16
 
-        self.assertEqual(12, f_base.properties_with_values(include_defaults=True)['x'])
-        self.assertEqual(14, f_sub.properties_with_values(include_defaults=True)['x'])
-        self.assertEqual(16, f_sub_sub.properties_with_values(include_defaults=True)['x'])
+        assert 12 == f_base.properties_with_values(include_defaults=True)['x']
+        assert 14 == f_sub.properties_with_values(include_defaults=True)['x']
+        assert 16 == f_sub_sub.properties_with_values(include_defaults=True)['x']
 
-        self.assertFalse('x' in f_base.properties_with_values(include_defaults=False))
-        self.assertFalse('x' in f_sub.properties_with_values(include_defaults=False))
-        self.assertFalse('x' in f_sub_sub.properties_with_values(include_defaults=False))
+        assert 'x' not in f_base.properties_with_values(include_defaults=False)
+        assert 'x' not in f_sub.properties_with_values(include_defaults=False)
+        assert 'x' not in f_sub_sub.properties_with_values(include_defaults=False)
 
     def test_include_delegate(self):
         class IsDelegate(HasProps):
@@ -663,39 +643,39 @@ class Basictest(unittest.TestCase):
             y = Override(default="world") # override the Include changing just the default
 
         o = IncludesDelegateWithoutPrefix()
-        self.assertEqual(o.x, 12)
-        self.assertEqual(o.y, 42)
-        self.assertFalse(hasattr(o, 'z'))
+        assert o.x == 12
+        assert o.y == 42
+        assert not hasattr(o, 'z')
 
-        self.assertTrue('x' in o.properties_with_values(include_defaults=True))
-        self.assertTrue('y' in o.properties_with_values(include_defaults=True))
-        self.assertTrue('x' not in o.properties_with_values(include_defaults=False))
-        self.assertTrue('y' not in o.properties_with_values(include_defaults=False))
+        assert 'x' in o.properties_with_values(include_defaults=True)
+        assert 'y' in o.properties_with_values(include_defaults=True)
+        assert 'x' not in o.properties_with_values(include_defaults=False)
+        assert 'y' not in o.properties_with_values(include_defaults=False)
 
         o = IncludesDelegateWithoutPrefixUsingOverride()
-        self.assertEqual(o.x, 12)
-        self.assertEqual(o.y, 'world')
-        self.assertFalse(hasattr(o, 'z'))
+        assert o.x == 12
+        assert o.y == 'world'
+        assert not hasattr(o, 'z')
 
-        self.assertTrue('x' in o.properties_with_values(include_defaults=True))
-        self.assertTrue('y' in o.properties_with_values(include_defaults=True))
-        self.assertTrue('x' not in o.properties_with_values(include_defaults=False))
-        self.assertTrue('y' not in o.properties_with_values(include_defaults=False))
+        assert 'x' in o.properties_with_values(include_defaults=True)
+        assert 'y' in o.properties_with_values(include_defaults=True)
+        assert 'x' not in o.properties_with_values(include_defaults=False)
+        assert 'y' not in o.properties_with_values(include_defaults=False)
 
         o2 = IncludesDelegateWithPrefix()
-        self.assertEqual(o2.z_x, 12)
-        self.assertEqual(o2.z_y, 57)
-        self.assertFalse(hasattr(o2, 'z'))
-        self.assertFalse(hasattr(o2, 'x'))
-        self.assertFalse(hasattr(o2, 'y'))
+        assert o2.z_x == 12
+        assert o2.z_y == 57
+        assert not hasattr(o2, 'z')
+        assert not hasattr(o2, 'x')
+        assert not hasattr(o2, 'y')
 
-        self.assertFalse('z' in o2.properties_with_values(include_defaults=True))
-        self.assertFalse('x' in o2.properties_with_values(include_defaults=True))
-        self.assertFalse('y' in o2.properties_with_values(include_defaults=True))
-        self.assertTrue('z_x' in o2.properties_with_values(include_defaults=True))
-        self.assertTrue('z_y' in o2.properties_with_values(include_defaults=True))
-        self.assertTrue('z_x' not in o2.properties_with_values(include_defaults=False))
-        self.assertTrue('z_y' not in o2.properties_with_values(include_defaults=False))
+        assert 'z' not in o2.properties_with_values(include_defaults=True)
+        assert 'x' not in o2.properties_with_values(include_defaults=True)
+        assert 'y' not in o2.properties_with_values(include_defaults=True)
+        assert 'z_x' in o2.properties_with_values(include_defaults=True)
+        assert 'z_y' in o2.properties_with_values(include_defaults=True)
+        assert 'z_x' not in o2.properties_with_values(include_defaults=False)
+        assert 'z_y' not in o2.properties_with_values(include_defaults=False)
 
     # def test_kwargs_init(self):
     #     class Foo(HasProps):
@@ -703,40 +683,40 @@ class Basictest(unittest.TestCase):
     #         y = Int
     #         z = Float
     #     f = Foo(x = "hello", y = 14)
-    #     self.assertEqual(f.x, "hello")
-    #     self.assertEqual(f.y, 14)
+    #     assert f.x == "hello"
+    #     assert f.y == 14
 
-    #     with self.assertRaises(TypeError):
+    #     with pytest.raises(TypeError):
     #         # This should raise a TypeError: object.__init__() takes no parameters
     #         g = Foo(z = 3.14, q = "blah")
 
-class TestNumberSpec(unittest.TestCase):
+class TestNumberSpec(object):
 
     def test_field(self):
         class Foo(HasProps):
             x = NumberSpec("xfield")
         f = Foo()
-        self.assertEqual(f.x, "xfield")
-        self.assertDictEqual(Foo.__dict__["x"].serializable_value(f), {"field": "xfield"})
+        assert f.x == "xfield"
+        assert Foo.__dict__["x"].serializable_value(f) == {"field": "xfield"}
         f.x = "my_x"
-        self.assertEqual(f.x, "my_x")
-        self.assertDictEqual(Foo.__dict__["x"].serializable_value(f), {"field": "my_x"})
+        assert f.x == "my_x"
+        assert Foo.__dict__["x"].serializable_value(f) == {"field": "my_x"}
 
     def test_value(self):
         class Foo(HasProps):
             x = NumberSpec("xfield")
         f = Foo()
-        self.assertEqual(f.x, "xfield")
+        assert f.x, "xfield"
         f.x = 12
-        self.assertEqual(f.x, 12)
-        self.assertDictEqual(Foo.__dict__["x"].serializable_value(f), {"value": 12})
+        assert f.x == 12
+        assert Foo.__dict__["x"].serializable_value(f) == {"value": 12}
         f.x = 15
-        self.assertEqual(f.x, 15)
-        self.assertDictEqual(Foo.__dict__["x"].serializable_value(f), {"value": 15})
+        assert f.x == 15
+        assert Foo.__dict__["x"].serializable_value(f) == {"value": 15}
         f.x = dict(value=32)
-        self.assertDictEqual(Foo.__dict__["x"].serializable_value(f), {"value": 32})
+        assert Foo.__dict__["x"].serializable_value(f) == {"value": 32}
         f.x = None
-        self.assertIs(Foo.__dict__["x"].serializable_value(f), None)
+        assert Foo.__dict__["x"].serializable_value(f) is None
 
     def tests_accepts_timedelta(self):
         class Foo(HasProps):
@@ -746,26 +726,33 @@ class TestNumberSpec(unittest.TestCase):
         f = Foo()
 
         f.dt = datetime.timedelta(3, 54)
-        self.assertEqual(f.dt, 259254000.0)
+        assert f.dt == 259254000.0
 
         # counts as number.Real out of the box
         f.dt = np.timedelta64(3000, "ms")
-        self.assertEqual(f.dt, np.timedelta64(3000, "ms"))
-
-        # counts as number.Real out of the box
-        f.dt = pd.Timedelta("3000ms")
-        self.assertEqual(f.dt, 3000.0)
-
+        assert f.dt == np.timedelta64(3000, "ms")
 
         f.ndt = datetime.timedelta(3, 54)
-        self.assertEqual(f.ndt, 259254000.0)
+        assert f.ndt == 259254000.0
 
         # counts as number.Real out of the box
         f.ndt = np.timedelta64(3000, "ms")
-        self.assertEqual(f.ndt, np.timedelta64(3000, "ms"))
+        assert f.ndt == np.timedelta64(3000, "ms")
+
+
+    def tests_accepts_timedelta_with_pandas(self, pd):
+        class Foo(HasProps):
+            dt = NumberSpec("dt", accept_datetime=True)
+            ndt = NumberSpec("ndt", accept_datetime=False)
+
+        f = Foo()
+
+        # counts as number.Real out of the box
+        f.dt = pd.Timedelta("3000ms")
+        assert f.dt == 3000.0
 
         f.ndt = pd.Timedelta("3000ms")
-        self.assertEqual(f.ndt, 3000.0)
+        assert f.ndt == 3000.0
 
     def test_accepts_datetime(self):
         class Foo(HasProps):
@@ -775,36 +762,36 @@ class TestNumberSpec(unittest.TestCase):
         f = Foo()
 
         f.dt = datetime.datetime(2016, 5, 11)
-        self.assertEqual(f.dt, 1462924800000.0)
+        assert f.dt == 1462924800000.0
 
         f.dt = datetime.date(2016, 5, 11)
-        self.assertEqual(f.dt, 1462924800000.0)
+        assert f.dt == 1462924800000.0
 
         f.dt = np.datetime64("2016-05-11")
-        self.assertEqual(f.dt, 1462924800000.0)
+        assert f.dt == 1462924800000.0
 
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             f.ndt = datetime.datetime(2016, 5, 11)
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             f.ndt = datetime.date(2016, 5, 11)
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             f.ndt = np.datetime64("2016-05-11")
 
     def test_default(self):
         class Foo(HasProps):
             y = NumberSpec(default=12)
         f = Foo()
-        self.assertEqual(f.y, 12)
-        self.assertDictEqual(Foo.__dict__["y"].serializable_value(f), {"value": 12})
+        assert f.y == 12
+        assert Foo.__dict__["y"].serializable_value(f) == {"value": 12}
         f.y = "y1"
-        self.assertEqual(f.y, "y1")
+        assert f.y == "y1"
         # Once we set a concrete value, the default is ignored, because it is unused
         f.y = 32
-        self.assertEqual(f.y, 32)
-        self.assertDictEqual(Foo.__dict__["y"].serializable_value(f), {"value": 32})
+        assert f.y == 32
+        assert Foo.__dict__["y"].serializable_value(f) == {"value": 32}
 
     def test_multiple_instances(self):
         class Foo(HasProps):
@@ -814,13 +801,13 @@ class TestNumberSpec(unittest.TestCase):
         b = Foo()
         a.x = 13
         b.x = 14
-        self.assertEqual(a.x, 13)
-        self.assertEqual(b.x, 14)
-        self.assertDictEqual(Foo.__dict__["x"].serializable_value(a), {"value": 13})
-        self.assertDictEqual(Foo.__dict__["x"].serializable_value(b), {"value": 14})
+        assert a.x == 13
+        assert b.x == 14
+        assert Foo.__dict__["x"].serializable_value(a) == {"value": 13}
+        assert Foo.__dict__["x"].serializable_value(b) == {"value": 14}
         b.x = {"field": "x3"}
-        self.assertDictEqual(Foo.__dict__["x"].serializable_value(a), {"value": 13})
-        self.assertDictEqual(Foo.__dict__["x"].serializable_value(b), {"field": "x3"})
+        assert Foo.__dict__["x"].serializable_value(a) == {"value": 13}
+        assert Foo.__dict__["x"].serializable_value(b) == {"field": "x3"}
 
     def test_autocreate_no_parens(self):
         class Foo(HasProps):
@@ -828,9 +815,9 @@ class TestNumberSpec(unittest.TestCase):
 
         a = Foo()
 
-        self.assertIs(a.x, None)
+        assert a.x is None
         a.x = 14
-        self.assertEqual(a.x, 14)
+        assert a.x == 14
 
     def test_set_from_json_keeps_mode(self):
         class Foo(HasProps):
@@ -838,29 +825,29 @@ class TestNumberSpec(unittest.TestCase):
 
         a = Foo()
 
-        self.assertIs(a.x, None)
+        assert a.x is None
 
         # set as a value
         a.x = 14
-        self.assertEqual(a.x, 14)
+        assert a.x == 14
         # set_from_json keeps the previous dict-ness or lack thereof
         a.set_from_json('x', dict(value=16))
-        self.assertEqual(a.x, 16)
+        assert a.x == 16
         # but regular assignment overwrites the previous dict-ness
         a.x = dict(value=17)
-        self.assertDictEqual(a.x, dict(value=17))
+        assert a.x == dict(value=17)
 
         # set as a field
         a.x = "bar"
-        self.assertEqual(a.x, "bar")
+        assert a.x == "bar"
         # set_from_json keeps the previous dict-ness or lack thereof
         a.set_from_json('x', dict(field="foo"))
-        self.assertEqual(a.x, "foo")
+        assert a.x == "foo"
         # but regular assignment overwrites the previous dict-ness
         a.x = dict(field="baz")
-        self.assertDictEqual(a.x, dict(field="baz"))
+        assert a.x == dict(field="baz")
 
-class TestFontSizeSpec(unittest.TestCase):
+class TestFontSizeSpec(object):
     def test_font_size_from_string(self):
         class Foo(HasProps):
             x = FontSizeSpec(default=None)
@@ -868,50 +855,50 @@ class TestFontSizeSpec(unittest.TestCase):
         css_units = "%|em|ex|ch|ic|rem|vw|vh|vi|vb|vmin|vmax|cm|mm|q|in|pc|pt|px"
 
         a = Foo()
-        self.assertIs(a.x, None)
+        assert a.x is None
 
         for unit in css_units.split("|"):
 
             v = '10%s' % unit
             a.x = v
-            self.assertEqual(a.x, v)
-            self.assertEqual(a.lookup('x').serializable_value(a), dict(value=v))
+            assert a.x == v
+            assert a.lookup('x').serializable_value(a) == dict(value=v)
 
             v = '10.2%s' % unit
             a.x = v
-            self.assertEqual(a.x, v)
-            self.assertEqual(a.lookup('x').serializable_value(a), dict(value=v))
+            assert a.x == v
+            assert a.lookup('x').serializable_value(a) == dict(value=v)
 
             f = '_10%s' % unit
             a.x = f
-            self.assertEqual(a.x, f)
-            self.assertEqual(a.lookup('x').serializable_value(a), dict(field=f))
+            assert a.x == f
+            assert a.lookup('x').serializable_value(a) == dict(field=f)
 
             f = '_10.2%s' % unit
             a.x = f
-            self.assertEqual(a.x, f)
-            self.assertEqual(a.lookup('x').serializable_value(a), dict(field=f))
+            assert a.x == f
+            assert a.lookup('x').serializable_value(a) == dict(field=f)
 
         for unit in css_units.upper().split("|"):
             v = '10%s' % unit
             a.x = v
-            self.assertEqual(a.x, v)
-            self.assertEqual(a.lookup('x').serializable_value(a), dict(value=v))
+            assert a.x == v
+            assert a.lookup('x').serializable_value(a) == dict(value=v)
 
             v = '10.2%s' % unit
             a.x = v
-            self.assertEqual(a.x, v)
-            self.assertEqual(a.lookup('x').serializable_value(a), dict(value=v))
+            assert a.x == v
+            assert a.lookup('x').serializable_value(a) == dict(value=v)
 
             f = '_10%s' % unit
             a.x = f
-            self.assertEqual(a.x, f)
-            self.assertEqual(a.lookup('x').serializable_value(a), dict(field=f))
+            assert a.x == f
+            assert a.lookup('x').serializable_value(a) == dict(field=f)
 
             f = '_10.2%s' % unit
             a.x = f
-            self.assertEqual(a.x, f)
-            self.assertEqual(a.lookup('x').serializable_value(a), dict(field=f))
+            assert a.x == f
+            assert a.lookup('x').serializable_value(a) == dict(field=f)
 
     def test_bad_font_size_values(self):
         class Foo(HasProps):
@@ -919,13 +906,13 @@ class TestFontSizeSpec(unittest.TestCase):
 
         a = Foo()
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             a.x = "6"
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             a.x = 6
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             a.x = ""
 
     def test_fields(self):
@@ -935,29 +922,29 @@ class TestFontSizeSpec(unittest.TestCase):
         a = Foo()
 
         a.x = "_120"
-        self.assertEqual(a.x, "_120")
+        assert a.x == "_120"
 
         a.x = dict(field="_120")
-        self.assertEqual(a.x, dict(field="_120"))
+        assert a.x == dict(field="_120")
 
         a.x = "foo"
-        self.assertEqual(a.x, "foo")
+        assert a.x == "foo"
 
         a.x = dict(field="foo")
-        self.assertEqual(a.x, dict(field="foo"))
+        assert a.x == dict(field="foo")
 
-class TestAngleSpec(unittest.TestCase):
+class TestAngleSpec(object):
     def test_default_none(self):
         class Foo(HasProps):
             x = AngleSpec(None)
 
         a = Foo()
 
-        self.assertIs(a.x, None)
-        self.assertEqual(a.x_units, 'rad')
+        assert a.x is None
+        assert a.x_units == 'rad'
         a.x = 14
-        self.assertEqual(a.x, 14)
-        self.assertEqual(a.x_units, 'rad')
+        assert a.x == 14
+        assert a.x_units == 'rad'
 
     def test_autocreate_no_parens(self):
         class Foo(HasProps):
@@ -965,11 +952,11 @@ class TestAngleSpec(unittest.TestCase):
 
         a = Foo()
 
-        self.assertIs(a.x, None)
-        self.assertEqual(a.x_units, 'rad')
+        assert a.x is None
+        assert a.x_units == 'rad'
         a.x = 14
-        self.assertEqual(a.x, 14)
-        self.assertEqual(a.x_units, 'rad')
+        assert a.x == 14
+        assert a.x_units == 'rad'
 
     def test_default_value(self):
         class Foo(HasProps):
@@ -977,8 +964,8 @@ class TestAngleSpec(unittest.TestCase):
 
         a = Foo()
 
-        self.assertEqual(a.x, 14)
-        self.assertEqual(a.x_units, 'rad')
+        assert a.x == 14
+        assert a.x_units == 'rad'
 
     def test_setting_dict_sets_units(self):
         class Foo(HasProps):
@@ -986,12 +973,12 @@ class TestAngleSpec(unittest.TestCase):
 
         a = Foo()
 
-        self.assertEqual(a.x, 14)
-        self.assertEqual(a.x_units, 'rad')
+        assert a.x == 14
+        assert a.x_units == 'rad'
 
         a.x = { 'value' : 180, 'units' : 'deg' }
-        self.assertDictEqual(a.x, { 'value' : 180 })
-        self.assertEqual(a.x_units, 'deg')
+        assert a.x == { 'value' : 180 }
+        assert a.x_units == 'deg'
 
     def test_setting_json_sets_units_keeps_dictness(self):
         class Foo(HasProps):
@@ -999,12 +986,12 @@ class TestAngleSpec(unittest.TestCase):
 
         a = Foo()
 
-        self.assertEqual(a.x, 14)
-        self.assertEqual(a.x_units, 'rad')
+        assert a.x == 14
+        assert a.x_units == 'rad'
 
         a.set_from_json('x', { 'value' : 180, 'units' : 'deg' })
-        self.assertEqual(a.x, 180)
-        self.assertEqual(a.x_units, 'deg')
+        assert a.x == 180
+        assert a.x_units == 'deg'
 
     def test_setting_dict_does_not_modify_original_dict(self):
         class Foo(HasProps):
@@ -1012,31 +999,31 @@ class TestAngleSpec(unittest.TestCase):
 
         a = Foo()
 
-        self.assertEqual(a.x, 14)
-        self.assertEqual(a.x_units, 'rad')
+        assert a.x == 14
+        assert a.x_units == 'rad'
 
         new_value = { 'value' : 180, 'units' : 'deg' }
         new_value_copy = copy(new_value)
-        self.assertDictEqual(new_value_copy, new_value)
+        assert new_value_copy == new_value
 
         a.x = new_value
-        self.assertDictEqual(a.x, { 'value' : 180 })
-        self.assertEqual(a.x_units, 'deg')
+        assert a.x == { 'value' : 180 }
+        assert a.x_units == 'deg'
 
-        self.assertDictEqual(new_value_copy, new_value)
+        assert new_value_copy == new_value
 
-class TestDistanceSpec(unittest.TestCase):
+class TestDistanceSpec(object):
     def test_default_none(self):
         class Foo(HasProps):
             x = DistanceSpec(None)
 
         a = Foo()
 
-        self.assertIs(a.x, None)
-        self.assertEqual(a.x_units, 'data')
+        assert a.x is None
+        assert a.x_units == 'data'
         a.x = 14
-        self.assertEqual(a.x, 14)
-        self.assertEqual(a.x_units, 'data')
+        assert a.x == 14
+        assert a.x_units == 'data'
 
     def test_autocreate_no_parens(self):
         class Foo(HasProps):
@@ -1044,11 +1031,11 @@ class TestDistanceSpec(unittest.TestCase):
 
         a = Foo()
 
-        self.assertIs(a.x, None)
-        self.assertEqual(a.x_units, 'data')
+        assert a.x is None
+        assert a.x_units == 'data'
         a.x = 14
-        self.assertEqual(a.x, 14)
-        self.assertEqual(a.x_units, 'data')
+        assert a.x == 14
+        assert a.x_units == 'data'
 
     def test_default_value(self):
         class Foo(HasProps):
@@ -1056,48 +1043,48 @@ class TestDistanceSpec(unittest.TestCase):
 
         a = Foo()
 
-        self.assertEqual(a.x, 14)
-        self.assertEqual(a.x_units, 'data')
+        assert a.x == 14
+        assert a.x_units == 'data'
 
-class TestColorSpec(unittest.TestCase):
+class TestColorSpec(object):
 
     def test_field(self):
         class Foo(HasProps):
             col = ColorSpec("colorfield")
         desc = Foo.__dict__["col"]
         f = Foo()
-        self.assertEqual(f.col, "colorfield")
-        self.assertDictEqual(desc.serializable_value(f), {"field": "colorfield"})
+        assert f.col == "colorfield"
+        assert desc.serializable_value(f) == {"field": "colorfield"}
         f.col = "myfield"
-        self.assertEqual(f.col, "myfield")
-        self.assertDictEqual(desc.serializable_value(f), {"field": "myfield"})
+        assert f.col == "myfield"
+        assert desc.serializable_value(f) == {"field": "myfield"}
 
     def test_field_default(self):
         class Foo(HasProps):
             col = ColorSpec(default="red")
         desc = Foo.__dict__["col"]
         f = Foo()
-        self.assertEqual(f.col, "red")
-        self.assertDictEqual(desc.serializable_value(f), {"value": "red"})
+        assert f.col == "red"
+        assert desc.serializable_value(f) == {"value": "red"}
         f.col = "myfield"
-        self.assertEqual(f.col, "myfield")
-        self.assertDictEqual(desc.serializable_value(f), {"field": "myfield"})
+        assert f.col == "myfield"
+        assert desc.serializable_value(f) == {"field": "myfield"}
 
     def test_default_tuple(self):
         class Foo(HasProps):
             col = ColorSpec(default=(128, 255, 124))
         desc = Foo.__dict__["col"]
         f = Foo()
-        self.assertEqual(f.col, (128, 255, 124))
-        self.assertDictEqual(desc.serializable_value(f), {"value": "rgb(128, 255, 124)"})
+        assert f.col == (128, 255, 124)
+        assert desc.serializable_value(f) == {"value": "rgb(128, 255, 124)"}
 
     def test_fixed_value(self):
         class Foo(HasProps):
             col = ColorSpec("gray")
         desc = Foo.__dict__["col"]
         f = Foo()
-        self.assertEqual(f.col, "gray")
-        self.assertDictEqual(desc.serializable_value(f), {"value": "gray"})
+        assert f.col == "gray"
+        assert desc.serializable_value(f) == {"value": "gray"}
 
     def test_named_value(self):
         class Foo(HasProps):
@@ -1106,11 +1093,11 @@ class TestColorSpec(unittest.TestCase):
         f = Foo()
 
         f.col = "red"
-        self.assertEqual(f.col, "red")
-        self.assertDictEqual(desc.serializable_value(f), {"value": "red"})
+        assert f.col == "red"
+        assert desc.serializable_value(f) == {"value": "red"}
         f.col = "forestgreen"
-        self.assertEqual(f.col, "forestgreen")
-        self.assertDictEqual(desc.serializable_value(f), {"value": "forestgreen"})
+        assert f.col == "forestgreen"
+        assert desc.serializable_value(f) == {"value": "forestgreen"}
 
     def test_case_insensitive_named_value(self):
         class Foo(HasProps):
@@ -1119,11 +1106,11 @@ class TestColorSpec(unittest.TestCase):
         f = Foo()
 
         f.col = "RED"
-        self.assertEqual(f.col, "RED")
-        self.assertDictEqual(desc.serializable_value(f), {"value": "RED"})
+        assert f.col == "RED"
+        assert desc.serializable_value(f) == {"value": "RED"}
         f.col = "ForestGreen"
-        self.assertEqual(f.col, "ForestGreen")
-        self.assertDictEqual(desc.serializable_value(f), {"value": "ForestGreen"})
+        assert f.col == "ForestGreen"
+        assert desc.serializable_value(f) == {"value": "ForestGreen"}
 
     def test_named_value_set_none(self):
         class Foo(HasProps):
@@ -1131,14 +1118,14 @@ class TestColorSpec(unittest.TestCase):
         desc = Foo.__dict__["col"]
         f = Foo()
         f.col = None
-        self.assertDictEqual(desc.serializable_value(f), {"value": None})
+        assert desc.serializable_value(f) == {"value": None}
 
     def test_named_value_unset(self):
         class Foo(HasProps):
             col = ColorSpec("colorfield")
         desc = Foo.__dict__["col"]
         f = Foo()
-        self.assertDictEqual(desc.serializable_value(f), {"field": "colorfield"})
+        assert desc.serializable_value(f) == {"field": "colorfield"}
 
     def test_named_color_overriding_default(self):
         class Foo(HasProps):
@@ -1146,11 +1133,11 @@ class TestColorSpec(unittest.TestCase):
         desc = Foo.__dict__["col"]
         f = Foo()
         f.col = "forestgreen"
-        self.assertEqual(f.col, "forestgreen")
-        self.assertDictEqual(desc.serializable_value(f), {"value": "forestgreen"})
+        assert f.col == "forestgreen"
+        assert desc.serializable_value(f) == {"value": "forestgreen"}
         f.col = "myfield"
-        self.assertEqual(f.col, "myfield")
-        self.assertDictEqual(desc.serializable_value(f), {"field": "myfield"})
+        assert f.col == "myfield"
+        assert desc.serializable_value(f) == {"field": "myfield"}
 
     def test_hex_value(self):
         class Foo(HasProps):
@@ -1158,11 +1145,11 @@ class TestColorSpec(unittest.TestCase):
         desc = Foo.__dict__["col"]
         f = Foo()
         f.col = "#FF004A"
-        self.assertEqual(f.col, "#FF004A")
-        self.assertDictEqual(desc.serializable_value(f), {"value": "#FF004A"})
+        assert f.col == "#FF004A"
+        assert desc.serializable_value(f) == {"value": "#FF004A"}
         f.col = "myfield"
-        self.assertEqual(f.col, "myfield")
-        self.assertDictEqual(desc.serializable_value(f), {"field": "myfield"})
+        assert f.col == "myfield"
+        assert desc.serializable_value(f) == {"field": "myfield"}
 
     def test_tuple_value(self):
         class Foo(HasProps):
@@ -1170,14 +1157,14 @@ class TestColorSpec(unittest.TestCase):
         desc = Foo.__dict__["col"]
         f = Foo()
         f.col = (128, 200, 255)
-        self.assertEqual(f.col, (128, 200, 255))
-        self.assertDictEqual(desc.serializable_value(f), {"value": "rgb(128, 200, 255)"})
+        assert f.col == (128, 200, 255)
+        assert desc.serializable_value(f) == {"value": "rgb(128, 200, 255)"}
         f.col = "myfield"
-        self.assertEqual(f.col, "myfield")
-        self.assertDictEqual(desc.serializable_value(f), {"field": "myfield"})
+        assert f.col == "myfield"
+        assert desc.serializable_value(f) == {"field": "myfield"}
         f.col = (100, 150, 200, 0.5)
-        self.assertEqual(f.col, (100, 150, 200, 0.5))
-        self.assertDictEqual(desc.serializable_value(f), {"value": "rgba(100, 150, 200, 0.5)"})
+        assert f.col == (100, 150, 200, 0.5)
+        assert desc.serializable_value(f) == {"value": "rgba(100, 150, 200, 0.5)"}
 
     def test_set_dict(self):
         class Foo(HasProps):
@@ -1185,30 +1172,30 @@ class TestColorSpec(unittest.TestCase):
         desc = Foo.__dict__["col"]
         f = Foo()
         f.col = {"field": "myfield"}
-        self.assertDictEqual(f.col, {"field": "myfield"})
+        assert f.col == {"field": "myfield"}
 
         f.col = "field2"
-        self.assertEqual(f.col, "field2")
-        self.assertDictEqual(desc.serializable_value(f), {"field": "field2"})
+        assert f.col == "field2"
+        assert desc.serializable_value(f) == {"field": "field2"}
 
-class TestDashPattern(unittest.TestCase):
+class TestDashPattern(object):
 
     def test_named(self):
         class Foo(HasProps):
             pat = DashPattern
         f = Foo()
 
-        self.assertEqual(f.pat, [])
+        assert f.pat == []
         f.pat = "solid"
-        self.assertEqual(f.pat, [])
+        assert f.pat == []
         f.pat = "dashed"
-        self.assertEqual(f.pat, [6])
+        assert f.pat == [6]
         f.pat = "dotted"
-        self.assertEqual(f.pat, [2, 4])
+        assert f.pat == [2, 4]
         f.pat = "dotdash"
-        self.assertEqual(f.pat, [2, 4, 6, 4])
+        assert f.pat == [2, 4, 6, 4]
         f.pat = "dashdot"
-        self.assertEqual(f.pat, [6, 4, 2, 4])
+        assert f.pat == [6, 4, 2, 4]
 
     def test_string(self):
         class Foo(HasProps):
@@ -1216,15 +1203,15 @@ class TestDashPattern(unittest.TestCase):
         f = Foo()
 
         f.pat = ""
-        self.assertEqual(f.pat, [])
+        assert f.pat == []
         f.pat = "2"
-        self.assertEqual(f.pat, [2])
+        assert f.pat == [2]
         f.pat = "2 4"
-        self.assertEqual(f.pat, [2, 4])
+        assert f.pat == [2, 4]
         f.pat = "2 4 6"
-        self.assertEqual(f.pat, [2, 4, 6])
+        assert f.pat == [2, 4, 6]
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             f.pat = "abc 6"
 
     def test_list(self):
@@ -1233,17 +1220,17 @@ class TestDashPattern(unittest.TestCase):
         f = Foo()
 
         f.pat = ()
-        self.assertEqual(f.pat, ())
+        assert f.pat == ()
         f.pat = (2,)
-        self.assertEqual(f.pat, (2,))
+        assert f.pat == (2,)
         f.pat = (2, 4)
-        self.assertEqual(f.pat, (2, 4))
+        assert f.pat == (2, 4)
         f.pat = (2, 4, 6)
-        self.assertEqual(f.pat, (2, 4, 6))
+        assert f.pat == (2, 4, 6)
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             f.pat = (2, 4.2)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             f.pat = (2, "a")
 
     def test_invalid(self):
@@ -1251,11 +1238,11 @@ class TestDashPattern(unittest.TestCase):
             pat = DashPattern
         f = Foo()
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             f.pat = 10
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             f.pat = 10.1
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             f.pat = {}
 
 
@@ -1268,418 +1255,424 @@ class Bar(HasProps):
 class Baz(HasProps):
     pass
 
-class TestProperties(unittest.TestCase):
+class TestProperties(object):
 
     def test_Any(self):
         prop = Any()
 
-        self.assertTrue(prop.is_valid(None))
-        self.assertTrue(prop.is_valid(False))
-        self.assertTrue(prop.is_valid(True))
-        self.assertTrue(prop.is_valid(0))
-        self.assertTrue(prop.is_valid(1))
-        self.assertTrue(prop.is_valid(0.0))
-        self.assertTrue(prop.is_valid(1.0))
-        self.assertTrue(prop.is_valid(1.0+1.0j))
-        self.assertTrue(prop.is_valid(""))
-        self.assertTrue(prop.is_valid(()))
-        self.assertTrue(prop.is_valid([]))
-        self.assertTrue(prop.is_valid({}))
-        self.assertTrue(prop.is_valid(Foo()))
+        assert prop.is_valid(None)
+        assert prop.is_valid(False)
+        assert prop.is_valid(True)
+        assert prop.is_valid(0)
+        assert prop.is_valid(1)
+        assert prop.is_valid(0.0)
+        assert prop.is_valid(1.0)
+        assert prop.is_valid(1.0+1.0j)
+        assert prop.is_valid("")
+        assert prop.is_valid(())
+        assert prop.is_valid([])
+        assert prop.is_valid({})
+        assert prop.is_valid(Foo())
 
     def test_Bool(self):
         prop = Bool()
 
-        self.assertTrue(prop.is_valid(None))
-        self.assertTrue(prop.is_valid(False))
-        self.assertTrue(prop.is_valid(True))
-        self.assertFalse(prop.is_valid(0))
-        self.assertFalse(prop.is_valid(1))
-        self.assertFalse(prop.is_valid(0.0))
-        self.assertFalse(prop.is_valid(1.0))
-        self.assertFalse(prop.is_valid(1.0+1.0j))
-        self.assertFalse(prop.is_valid(""))
-        self.assertFalse(prop.is_valid(()))
-        self.assertFalse(prop.is_valid([]))
-        self.assertFalse(prop.is_valid({}))
-        self.assertFalse(prop.is_valid(Foo()))
+        assert prop.is_valid(None)
+        assert prop.is_valid(False)
+        assert prop.is_valid(True)
+        assert not prop.is_valid(0)
+        assert not prop.is_valid(1)
+        assert not prop.is_valid(0.0)
+        assert not prop.is_valid(1.0)
+        assert not prop.is_valid(1.0+1.0j)
+        assert not prop.is_valid("")
+        assert not prop.is_valid(())
+        assert not prop.is_valid([])
+        assert not prop.is_valid({})
+        assert not prop.is_valid(Foo())
 
-        self.assertTrue(prop.is_valid(np.bool8(False)))
-        self.assertTrue(prop.is_valid(np.bool8(True)))
-        self.assertFalse(prop.is_valid(np.int8(0)))
-        self.assertFalse(prop.is_valid(np.int8(1)))
-        self.assertFalse(prop.is_valid(np.int16(0)))
-        self.assertFalse(prop.is_valid(np.int16(1)))
-        self.assertFalse(prop.is_valid(np.int32(0)))
-        self.assertFalse(prop.is_valid(np.int32(1)))
-        self.assertFalse(prop.is_valid(np.int64(0)))
-        self.assertFalse(prop.is_valid(np.int64(1)))
-        self.assertFalse(prop.is_valid(np.uint8(0)))
-        self.assertFalse(prop.is_valid(np.uint8(1)))
-        self.assertFalse(prop.is_valid(np.uint16(0)))
-        self.assertFalse(prop.is_valid(np.uint16(1)))
-        self.assertFalse(prop.is_valid(np.uint32(0)))
-        self.assertFalse(prop.is_valid(np.uint32(1)))
-        self.assertFalse(prop.is_valid(np.uint64(0)))
-        self.assertFalse(prop.is_valid(np.uint64(1)))
-        self.assertFalse(prop.is_valid(np.float16(0)))
-        self.assertFalse(prop.is_valid(np.float16(1)))
-        self.assertFalse(prop.is_valid(np.float32(0)))
-        self.assertFalse(prop.is_valid(np.float32(1)))
-        self.assertFalse(prop.is_valid(np.float64(0)))
-        self.assertFalse(prop.is_valid(np.float64(1)))
-        self.assertFalse(prop.is_valid(np.complex64(1.0+1.0j)))
-        self.assertFalse(prop.is_valid(np.complex128(1.0+1.0j)))
+        assert prop.is_valid(np.bool8(False))
+        assert prop.is_valid(np.bool8(True))
+        assert not prop.is_valid(np.int8(0))
+        assert not prop.is_valid(np.int8(1))
+        assert not prop.is_valid(np.int16(0))
+        assert not prop.is_valid(np.int16(1))
+        assert not prop.is_valid(np.int32(0))
+        assert not prop.is_valid(np.int32(1))
+        assert not prop.is_valid(np.int64(0))
+        assert not prop.is_valid(np.int64(1))
+        assert not prop.is_valid(np.uint8(0))
+        assert not prop.is_valid(np.uint8(1))
+        assert not prop.is_valid(np.uint16(0))
+        assert not prop.is_valid(np.uint16(1))
+        assert not prop.is_valid(np.uint32(0))
+        assert not prop.is_valid(np.uint32(1))
+        assert not prop.is_valid(np.uint64(0))
+        assert not prop.is_valid(np.uint64(1))
+        assert not prop.is_valid(np.float16(0))
+        assert not prop.is_valid(np.float16(1))
+        assert not prop.is_valid(np.float32(0))
+        assert not prop.is_valid(np.float32(1))
+        assert not prop.is_valid(np.float64(0))
+        assert not prop.is_valid(np.float64(1))
+        assert not prop.is_valid(np.complex64(1.0+1.0j))
+        assert not prop.is_valid(np.complex128(1.0+1.0j))
         if hasattr(np, "complex256"):
-            self.assertFalse(prop.is_valid(np.complex256(1.0+1.0j)))
+            assert not prop.is_valid(np.complex256(1.0+1.0j))
 
     def test_Int(self):
         prop = Int()
 
-        self.assertTrue(prop.is_valid(None))
-        # TODO: self.assertFalse(prop.is_valid(False))
-        # TODO: self.assertFalse(prop.is_valid(True))
-        self.assertTrue(prop.is_valid(0))
-        self.assertTrue(prop.is_valid(1))
-        self.assertFalse(prop.is_valid(0.0))
-        self.assertFalse(prop.is_valid(1.0))
-        self.assertFalse(prop.is_valid(1.0+1.0j))
-        self.assertFalse(prop.is_valid(""))
-        self.assertFalse(prop.is_valid(()))
-        self.assertFalse(prop.is_valid([]))
-        self.assertFalse(prop.is_valid({}))
-        self.assertFalse(prop.is_valid(Foo()))
+        assert prop.is_valid(None)
+        # TODO: assert not prop.is_valid(False)
+        # TODO: assert not prop.is_valid(True)
+        assert prop.is_valid(0)
+        assert prop.is_valid(1)
+        assert not prop.is_valid(0.0)
+        assert not prop.is_valid(1.0)
+        assert not prop.is_valid(1.0+1.0j)
+        assert not prop.is_valid("")
+        assert not prop.is_valid(())
+        assert not prop.is_valid([])
+        assert not prop.is_valid({})
+        assert not prop.is_valid(Foo())
 
-        # TODO: self.assertFalse(prop.is_valid(np.bool8(False)))
-        # TODO: self.assertFalse(prop.is_valid(np.bool8(True)))
-        self.assertTrue(prop.is_valid(np.int8(0)))
-        self.assertTrue(prop.is_valid(np.int8(1)))
-        self.assertTrue(prop.is_valid(np.int16(0)))
-        self.assertTrue(prop.is_valid(np.int16(1)))
-        self.assertTrue(prop.is_valid(np.int32(0)))
-        self.assertTrue(prop.is_valid(np.int32(1)))
-        self.assertTrue(prop.is_valid(np.int64(0)))
-        self.assertTrue(prop.is_valid(np.int64(1)))
-        self.assertTrue(prop.is_valid(np.uint8(0)))
-        self.assertTrue(prop.is_valid(np.uint8(1)))
-        self.assertTrue(prop.is_valid(np.uint16(0)))
-        self.assertTrue(prop.is_valid(np.uint16(1)))
-        self.assertTrue(prop.is_valid(np.uint32(0)))
-        self.assertTrue(prop.is_valid(np.uint32(1)))
-        self.assertTrue(prop.is_valid(np.uint64(0)))
-        self.assertTrue(prop.is_valid(np.uint64(1)))
-        self.assertFalse(prop.is_valid(np.float16(0)))
-        self.assertFalse(prop.is_valid(np.float16(1)))
-        self.assertFalse(prop.is_valid(np.float32(0)))
-        self.assertFalse(prop.is_valid(np.float32(1)))
-        self.assertFalse(prop.is_valid(np.float64(0)))
-        self.assertFalse(prop.is_valid(np.float64(1)))
-        self.assertFalse(prop.is_valid(np.complex64(1.0+1.0j)))
-        self.assertFalse(prop.is_valid(np.complex128(1.0+1.0j)))
+        # TODO: assert not prop.is_valid(np.bool8(False))
+        # TODO: assert not prop.is_valid(np.bool8(True))
+        assert prop.is_valid(np.int8(0))
+        assert prop.is_valid(np.int8(1))
+        assert prop.is_valid(np.int16(0))
+        assert prop.is_valid(np.int16(1))
+        assert prop.is_valid(np.int32(0))
+        assert prop.is_valid(np.int32(1))
+        assert prop.is_valid(np.int64(0))
+        assert prop.is_valid(np.int64(1))
+        assert prop.is_valid(np.uint8(0))
+        assert prop.is_valid(np.uint8(1))
+        assert prop.is_valid(np.uint16(0))
+        assert prop.is_valid(np.uint16(1))
+        assert prop.is_valid(np.uint32(0))
+        assert prop.is_valid(np.uint32(1))
+        assert prop.is_valid(np.uint64(0))
+        assert prop.is_valid(np.uint64(1))
+        assert not prop.is_valid(np.float16(0))
+        assert not prop.is_valid(np.float16(1))
+        assert not prop.is_valid(np.float32(0))
+        assert not prop.is_valid(np.float32(1))
+        assert not prop.is_valid(np.float64(0))
+        assert not prop.is_valid(np.float64(1))
+        assert not prop.is_valid(np.complex64(1.0+1.0j))
+        assert not prop.is_valid(np.complex128(1.0+1.0j))
         if hasattr(np, "complex256"):
-            self.assertFalse(prop.is_valid(np.complex256(1.0+1.0j)))
+            assert not prop.is_valid(np.complex256(1.0+1.0j))
 
     def test_Float(self):
         prop = Float()
 
-        self.assertTrue(prop.is_valid(None))
-        # TODO: self.assertFalse(prop.is_valid(False))
-        # TODO: self.assertFalse(prop.is_valid(True))
-        self.assertTrue(prop.is_valid(0))
-        self.assertTrue(prop.is_valid(1))
-        self.assertTrue(prop.is_valid(0.0))
-        self.assertTrue(prop.is_valid(1.0))
-        self.assertFalse(prop.is_valid(1.0+1.0j))
-        self.assertFalse(prop.is_valid(""))
-        self.assertFalse(prop.is_valid(()))
-        self.assertFalse(prop.is_valid([]))
-        self.assertFalse(prop.is_valid({}))
-        self.assertFalse(prop.is_valid(Foo()))
+        assert prop.is_valid(None)
+        # TODO: assert not prop.is_valid(False)
+        # TODO: assert not prop.is_valid(True)
+        assert prop.is_valid(0)
+        assert prop.is_valid(1)
+        assert prop.is_valid(0.0)
+        assert prop.is_valid(1.0)
+        assert not prop.is_valid(1.0+1.0j)
+        assert not prop.is_valid("")
+        assert not prop.is_valid(())
+        assert not prop.is_valid([])
+        assert not prop.is_valid({})
+        assert not prop.is_valid(Foo())
 
-        # TODO: self.assertFalse(prop.is_valid(np.bool8(False)))
-        # TODO: self.assertFalse(prop.is_valid(np.bool8(True)))
-        self.assertTrue(prop.is_valid(np.int8(0)))
-        self.assertTrue(prop.is_valid(np.int8(1)))
-        self.assertTrue(prop.is_valid(np.int16(0)))
-        self.assertTrue(prop.is_valid(np.int16(1)))
-        self.assertTrue(prop.is_valid(np.int32(0)))
-        self.assertTrue(prop.is_valid(np.int32(1)))
-        self.assertTrue(prop.is_valid(np.int64(0)))
-        self.assertTrue(prop.is_valid(np.int64(1)))
-        self.assertTrue(prop.is_valid(np.uint8(0)))
-        self.assertTrue(prop.is_valid(np.uint8(1)))
-        self.assertTrue(prop.is_valid(np.uint16(0)))
-        self.assertTrue(prop.is_valid(np.uint16(1)))
-        self.assertTrue(prop.is_valid(np.uint32(0)))
-        self.assertTrue(prop.is_valid(np.uint32(1)))
-        self.assertTrue(prop.is_valid(np.uint64(0)))
-        self.assertTrue(prop.is_valid(np.uint64(1)))
-        self.assertTrue(prop.is_valid(np.float16(0)))
-        self.assertTrue(prop.is_valid(np.float16(1)))
-        self.assertTrue(prop.is_valid(np.float32(0)))
-        self.assertTrue(prop.is_valid(np.float32(1)))
-        self.assertTrue(prop.is_valid(np.float64(0)))
-        self.assertTrue(prop.is_valid(np.float64(1)))
-        self.assertFalse(prop.is_valid(np.complex64(1.0+1.0j)))
-        self.assertFalse(prop.is_valid(np.complex128(1.0+1.0j)))
+        # TODO: assert not prop.is_valid(np.bool8(False))
+        # TODO: assert not prop.is_valid(np.bool8(True))
+        assert prop.is_valid(np.int8(0))
+        assert prop.is_valid(np.int8(1))
+        assert prop.is_valid(np.int16(0))
+        assert prop.is_valid(np.int16(1))
+        assert prop.is_valid(np.int32(0))
+        assert prop.is_valid(np.int32(1))
+        assert prop.is_valid(np.int64(0))
+        assert prop.is_valid(np.int64(1))
+        assert prop.is_valid(np.uint8(0))
+        assert prop.is_valid(np.uint8(1))
+        assert prop.is_valid(np.uint16(0))
+        assert prop.is_valid(np.uint16(1))
+        assert prop.is_valid(np.uint32(0))
+        assert prop.is_valid(np.uint32(1))
+        assert prop.is_valid(np.uint64(0))
+        assert prop.is_valid(np.uint64(1))
+        assert prop.is_valid(np.float16(0))
+        assert prop.is_valid(np.float16(1))
+        assert prop.is_valid(np.float32(0))
+        assert prop.is_valid(np.float32(1))
+        assert prop.is_valid(np.float64(0))
+        assert prop.is_valid(np.float64(1))
+        assert not prop.is_valid(np.complex64(1.0+1.0j))
+        assert not prop.is_valid(np.complex128(1.0+1.0j))
         if hasattr(np, "complex256"):
-            self.assertFalse(prop.is_valid(np.complex256(1.0+1.0j)))
+            assert not prop.is_valid(np.complex256(1.0+1.0j))
 
     def test_Complex(self):
         prop = Complex()
 
-        self.assertTrue(prop.is_valid(None))
-        # TODO: self.assertFalse(prop.is_valid(False))
-        # TODO: self.assertFalse(prop.is_valid(True))
-        self.assertTrue(prop.is_valid(0))
-        self.assertTrue(prop.is_valid(1))
-        self.assertTrue(prop.is_valid(0.0))
-        self.assertTrue(prop.is_valid(1.0))
-        self.assertTrue(prop.is_valid(1.0+1.0j))
-        self.assertFalse(prop.is_valid(""))
-        self.assertFalse(prop.is_valid(()))
-        self.assertFalse(prop.is_valid([]))
-        self.assertFalse(prop.is_valid({}))
-        self.assertFalse(prop.is_valid(Foo()))
+        assert prop.is_valid(None)
+        # TODO: assert not prop.is_valid(False)
+        # TODO: assert not prop.is_valid(True)
+        assert prop.is_valid(0)
+        assert prop.is_valid(1)
+        assert prop.is_valid(0.0)
+        assert prop.is_valid(1.0)
+        assert prop.is_valid(1.0+1.0j)
+        assert not prop.is_valid("")
+        assert not prop.is_valid(())
+        assert not prop.is_valid([])
+        assert not prop.is_valid({})
+        assert not prop.is_valid(Foo())
 
-        # TODO: self.assertFalse(prop.is_valid(np.bool8(False)))
-        # TODO: self.assertFalse(prop.is_valid(np.bool8(True)))
-        self.assertTrue(prop.is_valid(np.int8(0)))
-        self.assertTrue(prop.is_valid(np.int8(1)))
-        self.assertTrue(prop.is_valid(np.int16(0)))
-        self.assertTrue(prop.is_valid(np.int16(1)))
-        self.assertTrue(prop.is_valid(np.int32(0)))
-        self.assertTrue(prop.is_valid(np.int32(1)))
-        self.assertTrue(prop.is_valid(np.int64(0)))
-        self.assertTrue(prop.is_valid(np.int64(1)))
-        self.assertTrue(prop.is_valid(np.uint8(0)))
-        self.assertTrue(prop.is_valid(np.uint8(1)))
-        self.assertTrue(prop.is_valid(np.uint16(0)))
-        self.assertTrue(prop.is_valid(np.uint16(1)))
-        self.assertTrue(prop.is_valid(np.uint32(0)))
-        self.assertTrue(prop.is_valid(np.uint32(1)))
-        self.assertTrue(prop.is_valid(np.uint64(0)))
-        self.assertTrue(prop.is_valid(np.uint64(1)))
-        self.assertTrue(prop.is_valid(np.float16(0)))
-        self.assertTrue(prop.is_valid(np.float16(1)))
-        self.assertTrue(prop.is_valid(np.float32(0)))
-        self.assertTrue(prop.is_valid(np.float32(1)))
-        self.assertTrue(prop.is_valid(np.float64(0)))
-        self.assertTrue(prop.is_valid(np.float64(1)))
-        self.assertTrue(prop.is_valid(np.complex64(1.0+1.0j)))
-        self.assertTrue(prop.is_valid(np.complex128(1.0+1.0j)))
+        # TODO: assert not prop.is_valid(np.bool8(False))
+        # TODO: assert not prop.is_valid(np.bool8(True))
+        assert prop.is_valid(np.int8(0))
+        assert prop.is_valid(np.int8(1))
+        assert prop.is_valid(np.int16(0))
+        assert prop.is_valid(np.int16(1))
+        assert prop.is_valid(np.int32(0))
+        assert prop.is_valid(np.int32(1))
+        assert prop.is_valid(np.int64(0))
+        assert prop.is_valid(np.int64(1))
+        assert prop.is_valid(np.uint8(0))
+        assert prop.is_valid(np.uint8(1))
+        assert prop.is_valid(np.uint16(0))
+        assert prop.is_valid(np.uint16(1))
+        assert prop.is_valid(np.uint32(0))
+        assert prop.is_valid(np.uint32(1))
+        assert prop.is_valid(np.uint64(0))
+        assert prop.is_valid(np.uint64(1))
+        assert prop.is_valid(np.float16(0))
+        assert prop.is_valid(np.float16(1))
+        assert prop.is_valid(np.float32(0))
+        assert prop.is_valid(np.float32(1))
+        assert prop.is_valid(np.float64(0))
+        assert prop.is_valid(np.float64(1))
+        assert prop.is_valid(np.complex64(1.0+1.0j))
+        assert prop.is_valid(np.complex128(1.0+1.0j))
         if hasattr(np, "complex256"):
-            self.assertTrue(prop.is_valid(np.complex256(1.0+1.0j)))
+            assert prop.is_valid(np.complex256(1.0+1.0j))
 
     def test_String(self):
         prop = String()
 
-        self.assertTrue(prop.is_valid(None))
+        assert prop.is_valid(None)
 
-        self.assertFalse(prop.is_valid(False))
-        self.assertFalse(prop.is_valid(True))
-        self.assertFalse(prop.is_valid(0))
-        self.assertFalse(prop.is_valid(1))
-        self.assertFalse(prop.is_valid(0.0))
-        self.assertFalse(prop.is_valid(1.0))
-        self.assertFalse(prop.is_valid(1.0+1.0j))
-        self.assertTrue(prop.is_valid(""))
-        self.assertTrue(prop.is_valid("6"))
-        self.assertFalse(prop.is_valid(()))
-        self.assertFalse(prop.is_valid([]))
-        self.assertFalse(prop.is_valid({}))
-        self.assertFalse(prop.is_valid(Foo()))
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
+        assert not prop.is_valid(0)
+        assert not prop.is_valid(1)
+        assert not prop.is_valid(0.0)
+        assert not prop.is_valid(1.0)
+        assert not prop.is_valid(1.0+1.0j)
+        assert prop.is_valid("")
+        assert prop.is_valid("6")
+        assert not prop.is_valid(())
+        assert not prop.is_valid([])
+        assert not prop.is_valid({})
+        assert not prop.is_valid(Foo())
 
     def test_FontSize(self):
 
         prop = FontSize()
 
-        self.assertTrue(prop.is_valid(None))
+        assert prop.is_valid(None)
 
         css_units = "%|em|ex|ch|ic|rem|vw|vh|vi|vb|vmin|vmax|cm|mm|q|in|pc|pt|px"
 
         for unit in css_units.split("|"):
             v = '10%s' % unit
-            self.assertTrue(prop.is_valid(v))
+            assert prop.is_valid(v)
 
             v = '10.2%s' % unit
-            self.assertTrue(prop.is_valid(v))
+            assert prop.is_valid(v)
 
             v = '_10%s' % unit
-            self.assertFalse(prop.is_valid(v))
+            assert not prop.is_valid(v)
 
             v = '_10.2%s' % unit
-            self.assertFalse(prop.is_valid(v))
+            assert not prop.is_valid(v)
 
         for unit in css_units.upper().split("|"):
             v = '10%s' % unit
-            self.assertTrue(prop.is_valid(v))
+            assert prop.is_valid(v)
 
             v = '10.2%s' % unit
-            self.assertTrue(prop.is_valid(v))
+            assert prop.is_valid(v)
 
             v = '_10%s' % unit
-            self.assertFalse(prop.is_valid(v))
+            assert not prop.is_valid(v)
 
             v = '_10.2%s' % unit
-            self.assertFalse(prop.is_valid(v))
+            assert not prop.is_valid(v)
 
-        self.assertFalse(prop.is_valid(False))
-        self.assertFalse(prop.is_valid(True))
-        self.assertFalse(prop.is_valid(0))
-        self.assertFalse(prop.is_valid(1))
-        self.assertFalse(prop.is_valid(0.0))
-        self.assertFalse(prop.is_valid(1.0))
-        self.assertFalse(prop.is_valid(1.0+1.0j))
-        self.assertFalse(prop.is_valid(""))
-        self.assertFalse(prop.is_valid(()))
-        self.assertFalse(prop.is_valid([]))
-        self.assertFalse(prop.is_valid({}))
-        self.assertFalse(prop.is_valid(Foo()))
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
+        assert not prop.is_valid(0)
+        assert not prop.is_valid(1)
+        assert not prop.is_valid(0.0)
+        assert not prop.is_valid(1.0)
+        assert not prop.is_valid(1.0+1.0j)
+        assert not prop.is_valid("")
+        assert not prop.is_valid(())
+        assert not prop.is_valid([])
+        assert not prop.is_valid({})
+        assert not prop.is_valid(Foo())
 
 
     def test_Regex(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             prop = Regex()
 
         prop = Regex("^x*$")
 
-        self.assertTrue(prop.is_valid(None))
-        self.assertFalse(prop.is_valid(False))
-        self.assertFalse(prop.is_valid(True))
-        self.assertFalse(prop.is_valid(0))
-        self.assertFalse(prop.is_valid(1))
-        self.assertFalse(prop.is_valid(0.0))
-        self.assertFalse(prop.is_valid(1.0))
-        self.assertFalse(prop.is_valid(1.0+1.0j))
-        self.assertTrue(prop.is_valid(""))
-        self.assertFalse(prop.is_valid(()))
-        self.assertFalse(prop.is_valid([]))
-        self.assertFalse(prop.is_valid({}))
-        self.assertFalse(prop.is_valid(Foo()))
+        assert prop.is_valid(None)
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
+        assert not prop.is_valid(0)
+        assert not prop.is_valid(1)
+        assert not prop.is_valid(0.0)
+        assert not prop.is_valid(1.0)
+        assert not prop.is_valid(1.0+1.0j)
+        assert prop.is_valid("")
+        assert not prop.is_valid(())
+        assert not prop.is_valid([])
+        assert not prop.is_valid({})
+        assert not prop.is_valid(Foo())
 
     def test_Seq(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             prop = Seq()
 
         prop = Seq(Int)
 
-        self.assertTrue(prop.is_valid(None))
-        self.assertFalse(prop.is_valid(False))
-        self.assertFalse(prop.is_valid(True))
-        self.assertFalse(prop.is_valid(0))
-        self.assertFalse(prop.is_valid(1))
-        self.assertFalse(prop.is_valid(0.0))
-        self.assertFalse(prop.is_valid(1.0))
-        self.assertFalse(prop.is_valid(1.0+1.0j))
-        self.assertFalse(prop.is_valid(""))
-        self.assertTrue(prop.is_valid(()))
-        self.assertTrue(prop.is_valid([]))
-        self.assertTrue(prop.is_valid(np.array([])))
-        self.assertFalse(prop.is_valid(set([])))
-        self.assertFalse(prop.is_valid({}))
-        self.assertTrue(prop.is_valid((1, 2)))
-        self.assertTrue(prop.is_valid([1, 2]))
-        self.assertTrue(prop.is_valid(np.array([1, 2])))
-        self.assertFalse(prop.is_valid({1, 2}))
-        self.assertFalse(prop.is_valid({1: 2}))
-        self.assertFalse(prop.is_valid(Foo()))
+        assert prop.is_valid(None)
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
+        assert not prop.is_valid(0)
+        assert not prop.is_valid(1)
+        assert not prop.is_valid(0.0)
+        assert not prop.is_valid(1.0)
+        assert not prop.is_valid(1.0+1.0j)
+        assert not prop.is_valid("")
+        assert prop.is_valid(())
+        assert prop.is_valid([])
+        assert prop.is_valid(np.array([]))
+        assert not prop.is_valid(set([]))
+        assert not prop.is_valid({})
+        assert prop.is_valid((1, 2))
+        assert prop.is_valid([1, 2])
+        assert prop.is_valid(np.array([1, 2]))
+        assert not prop.is_valid({1, 2})
+        assert not prop.is_valid({1: 2})
+        assert not prop.is_valid(Foo())
+
+    def test_Seq_with_pandas(self, pd):
+        with pytest.raises(TypeError):
+            prop = Seq()
+
+        prop = Seq(Int)
 
         df = pd.DataFrame([1, 2])
-        self.assertTrue(prop.is_valid(df.index))
-        self.assertTrue(prop.is_valid(df.iloc[0]))
+        assert prop.is_valid(df.index)
+        assert prop.is_valid(df.iloc[0])
 
     def test_List(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             prop = List()
 
         prop = List(Int)
 
-        self.assertTrue(prop.is_valid(None))
-        self.assertFalse(prop.is_valid(False))
-        self.assertFalse(prop.is_valid(True))
-        self.assertFalse(prop.is_valid(0))
-        self.assertFalse(prop.is_valid(1))
-        self.assertFalse(prop.is_valid(0.0))
-        self.assertFalse(prop.is_valid(1.0))
-        self.assertFalse(prop.is_valid(1.0+1.0j))
-        self.assertFalse(prop.is_valid(""))
-        self.assertFalse(prop.is_valid(()))
-        self.assertTrue(prop.is_valid([]))
-        self.assertFalse(prop.is_valid({}))
-        self.assertFalse(prop.is_valid(Foo()))
+        assert prop.is_valid(None)
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
+        assert not prop.is_valid(0)
+        assert not prop.is_valid(1)
+        assert not prop.is_valid(0.0)
+        assert not prop.is_valid(1.0)
+        assert not prop.is_valid(1.0+1.0j)
+        assert not prop.is_valid("")
+        assert not prop.is_valid(())
+        assert prop.is_valid([])
+        assert not prop.is_valid({})
+        assert not prop.is_valid(Foo())
 
     def test_Dict(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             prop = Dict()
 
         prop = Dict(String, List(Int))
 
-        self.assertTrue(prop.is_valid(None))
-        self.assertFalse(prop.is_valid(False))
-        self.assertFalse(prop.is_valid(True))
-        self.assertFalse(prop.is_valid(0))
-        self.assertFalse(prop.is_valid(1))
-        self.assertFalse(prop.is_valid(0.0))
-        self.assertFalse(prop.is_valid(1.0))
-        self.assertFalse(prop.is_valid(1.0+1.0j))
-        self.assertFalse(prop.is_valid(""))
-        self.assertFalse(prop.is_valid(()))
-        self.assertFalse(prop.is_valid([]))
-        self.assertTrue(prop.is_valid({}))
-        self.assertFalse(prop.is_valid(Foo()))
+        assert prop.is_valid(None)
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
+        assert not prop.is_valid(0)
+        assert not prop.is_valid(1)
+        assert not prop.is_valid(0.0)
+        assert not prop.is_valid(1.0)
+        assert not prop.is_valid(1.0+1.0j)
+        assert not prop.is_valid("")
+        assert not prop.is_valid(())
+        assert not prop.is_valid([])
+        assert prop.is_valid({})
+        assert not prop.is_valid(Foo())
 
     def test_Tuple(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             prop = Tuple()
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             prop = Tuple(Int)
 
         prop = Tuple(Int, String, List(Int))
 
-        self.assertTrue(prop.is_valid(None))
-        self.assertFalse(prop.is_valid(False))
-        self.assertFalse(prop.is_valid(True))
-        self.assertFalse(prop.is_valid(0))
-        self.assertFalse(prop.is_valid(1))
-        self.assertFalse(prop.is_valid(0.0))
-        self.assertFalse(prop.is_valid(1.0))
-        self.assertFalse(prop.is_valid(1.0+1.0j))
-        self.assertFalse(prop.is_valid(""))
-        self.assertFalse(prop.is_valid(()))
-        self.assertFalse(prop.is_valid([]))
-        self.assertFalse(prop.is_valid({}))
-        self.assertFalse(prop.is_valid(Foo()))
+        assert prop.is_valid(None)
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
+        assert not prop.is_valid(0)
+        assert not prop.is_valid(1)
+        assert not prop.is_valid(0.0)
+        assert not prop.is_valid(1.0)
+        assert not prop.is_valid(1.0+1.0j)
+        assert not prop.is_valid("")
+        assert not prop.is_valid(())
+        assert not prop.is_valid([])
+        assert not prop.is_valid({})
+        assert not prop.is_valid(Foo())
 
-        self.assertTrue(prop.is_valid((1, "", [1, 2, 3])))
-        self.assertFalse(prop.is_valid((1.0, "", [1, 2, 3])))
-        self.assertFalse(prop.is_valid((1, True, [1, 2, 3])))
-        self.assertFalse(prop.is_valid((1, "", (1, 2, 3))))
-        self.assertFalse(prop.is_valid((1, "", [1, 2, "xyz"])))
+        assert prop.is_valid((1, "", [1, 2, 3]))
+        assert not prop.is_valid((1.0, "", [1, 2, 3]))
+        assert not prop.is_valid((1, True, [1, 2, 3]))
+        assert not prop.is_valid((1, "", (1, 2, 3)))
+        assert not prop.is_valid((1, "", [1, 2, "xyz"]))
 
     def test_Instance(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             prop = Instance()
 
         prop = Instance(Foo)
 
-        self.assertTrue(prop.is_valid(None))
-        self.assertFalse(prop.is_valid(False))
-        self.assertFalse(prop.is_valid(True))
-        self.assertFalse(prop.is_valid(0))
-        self.assertFalse(prop.is_valid(1))
-        self.assertFalse(prop.is_valid(0.0))
-        self.assertFalse(prop.is_valid(1.0))
-        self.assertFalse(prop.is_valid(1.0+1.0j))
-        self.assertFalse(prop.is_valid(""))
-        self.assertFalse(prop.is_valid(()))
-        self.assertFalse(prop.is_valid([]))
-        self.assertFalse(prop.is_valid({}))
-        self.assertTrue(prop.is_valid(Foo()))
+        assert prop.is_valid(None)
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
+        assert not prop.is_valid(0)
+        assert not prop.is_valid(1)
+        assert not prop.is_valid(0.0)
+        assert not prop.is_valid(1.0)
+        assert not prop.is_valid(1.0+1.0j)
+        assert not prop.is_valid("")
+        assert not prop.is_valid(())
+        assert not prop.is_valid([])
+        assert not prop.is_valid({})
+        assert prop.is_valid(Foo())
 
-        self.assertFalse(prop.is_valid(Bar()))
-        self.assertFalse(prop.is_valid(Baz()))
+        assert not prop.is_valid(Bar())
+        assert not prop.is_valid(Baz())
 
     def test_Instance_from_json(self):
         class MapOptions(HasProps):
@@ -1689,314 +1682,314 @@ class TestProperties(unittest.TestCase):
 
         v1 = Instance(MapOptions).from_json(dict(lat=1, lng=2))
         v2 = MapOptions(lat=1, lng=2)
-        self.assertTrue(v1.equals(v2))
+        assert v1.equals(v2)
 
     def test_Interval(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             prop = Interval()
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             prop = Interval(Int, 0.0, 1.0)
 
         prop = Interval(Int, 0, 255)
 
-        self.assertTrue(prop.is_valid(None))
-        # TODO: self.assertFalse(prop.is_valid(False))
-        # TODO: self.assertFalse(prop.is_valid(True))
-        self.assertTrue(prop.is_valid(0))
-        self.assertTrue(prop.is_valid(1))
-        self.assertFalse(prop.is_valid(0.0))
-        self.assertFalse(prop.is_valid(1.0))
-        self.assertFalse(prop.is_valid(1.0+1.0j))
-        self.assertFalse(prop.is_valid(""))
-        self.assertFalse(prop.is_valid(()))
-        self.assertFalse(prop.is_valid([]))
-        self.assertFalse(prop.is_valid({}))
-        self.assertFalse(prop.is_valid(Foo()))
+        assert prop.is_valid(None)
+        # TODO: assert not prop.is_valid(False)
+        # TODO: assert not prop.is_valid(True)
+        assert prop.is_valid(0)
+        assert prop.is_valid(1)
+        assert not prop.is_valid(0.0)
+        assert not prop.is_valid(1.0)
+        assert not prop.is_valid(1.0+1.0j)
+        assert not prop.is_valid("")
+        assert not prop.is_valid(())
+        assert not prop.is_valid([])
+        assert not prop.is_valid({})
+        assert not prop.is_valid(Foo())
 
-        self.assertTrue(prop.is_valid(127))
-        self.assertFalse(prop.is_valid(-1))
-        self.assertFalse(prop.is_valid(256))
+        assert prop.is_valid(127)
+        assert not prop.is_valid(-1)
+        assert not prop.is_valid(256)
 
         prop = Interval(Float, 0.0, 1.0)
 
-        self.assertTrue(prop.is_valid(None))
-        # TODO: self.assertFalse(prop.is_valid(False))
-        # TODO: self.assertFalse(prop.is_valid(True))
-        self.assertTrue(prop.is_valid(0))
-        self.assertTrue(prop.is_valid(1))
-        self.assertTrue(prop.is_valid(0.0))
-        self.assertTrue(prop.is_valid(1.0))
-        self.assertFalse(prop.is_valid(1.0+1.0j))
-        self.assertFalse(prop.is_valid(""))
-        self.assertFalse(prop.is_valid(()))
-        self.assertFalse(prop.is_valid([]))
-        self.assertFalse(prop.is_valid({}))
-        self.assertFalse(prop.is_valid(Foo()))
+        assert prop.is_valid(None)
+        # TODO: assert not prop.is_valid(False)
+        # TODO: assert not prop.is_valid(True)
+        assert prop.is_valid(0)
+        assert prop.is_valid(1)
+        assert prop.is_valid(0.0)
+        assert prop.is_valid(1.0)
+        assert not prop.is_valid(1.0+1.0j)
+        assert not prop.is_valid("")
+        assert not prop.is_valid(())
+        assert not prop.is_valid([])
+        assert not prop.is_valid({})
+        assert not prop.is_valid(Foo())
 
-        self.assertTrue(prop.is_valid(0.5))
-        self.assertFalse(prop.is_valid(-0.001))
-        self.assertFalse(prop.is_valid( 1.001))
+        assert prop.is_valid(0.5)
+        assert not prop.is_valid(-0.001)
+        assert not prop.is_valid( 1.001)
 
     def test_Either(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             prop = Either()
 
         prop = Either(Interval(Int, 0, 100), Regex("^x*$"), List(Int))
 
-        self.assertTrue(prop.is_valid(None))
-        # TODO: self.assertFalse(prop.is_valid(False))
-        # TODO: self.assertFalse(prop.is_valid(True))
-        self.assertTrue(prop.is_valid(0))
-        self.assertTrue(prop.is_valid(1))
-        self.assertFalse(prop.is_valid(0.0))
-        self.assertFalse(prop.is_valid(1.0))
-        self.assertFalse(prop.is_valid(1.0+1.0j))
-        self.assertTrue(prop.is_valid(""))
-        self.assertFalse(prop.is_valid(()))
-        self.assertTrue(prop.is_valid([]))
-        self.assertFalse(prop.is_valid({}))
-        self.assertFalse(prop.is_valid(Foo()))
+        assert prop.is_valid(None)
+        # TODO: assert not prop.is_valid(False)
+        # TODO: assert not prop.is_valid(True)
+        assert prop.is_valid(0)
+        assert prop.is_valid(1)
+        assert not prop.is_valid(0.0)
+        assert not prop.is_valid(1.0)
+        assert not prop.is_valid(1.0+1.0j)
+        assert prop.is_valid("")
+        assert not prop.is_valid(())
+        assert prop.is_valid([])
+        assert not prop.is_valid({})
+        assert not prop.is_valid(Foo())
 
-        self.assertTrue(prop.is_valid(100))
-        self.assertFalse(prop.is_valid(-100))
-        self.assertTrue(prop.is_valid("xxx"))
-        self.assertFalse(prop.is_valid("yyy"))
-        self.assertTrue(prop.is_valid([1, 2, 3]))
-        self.assertFalse(prop.is_valid([1, 2, ""]))
+        assert prop.is_valid(100)
+        assert not prop.is_valid(-100)
+        assert prop.is_valid("xxx")
+        assert not prop.is_valid("yyy")
+        assert prop.is_valid([1, 2, 3])
+        assert not prop.is_valid([1, 2, ""])
 
     def test_Enum(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             prop = Enum()
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             prop = Enum("red", "green", 1)
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             prop = Enum("red", "green", "red")
 
         prop = Enum("red", "green", "blue")
 
-        self.assertTrue(prop.is_valid(None))
-        self.assertFalse(prop.is_valid(False))
-        self.assertFalse(prop.is_valid(True))
-        self.assertFalse(prop.is_valid(0))
-        self.assertFalse(prop.is_valid(1))
-        self.assertFalse(prop.is_valid(0.0))
-        self.assertFalse(prop.is_valid(1.0))
-        self.assertFalse(prop.is_valid(1.0+1.0j))
-        self.assertFalse(prop.is_valid(""))
-        self.assertFalse(prop.is_valid(()))
-        self.assertFalse(prop.is_valid([]))
-        self.assertFalse(prop.is_valid({}))
-        self.assertFalse(prop.is_valid(Foo()))
+        assert prop.is_valid(None)
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
+        assert not prop.is_valid(0)
+        assert not prop.is_valid(1)
+        assert not prop.is_valid(0.0)
+        assert not prop.is_valid(1.0)
+        assert not prop.is_valid(1.0+1.0j)
+        assert not prop.is_valid("")
+        assert not prop.is_valid(())
+        assert not prop.is_valid([])
+        assert not prop.is_valid({})
+        assert not prop.is_valid(Foo())
 
-        self.assertTrue(prop.is_valid("red"))
-        self.assertTrue(prop.is_valid("green"))
-        self.assertTrue(prop.is_valid("blue"))
+        assert prop.is_valid("red")
+        assert prop.is_valid("green")
+        assert prop.is_valid("blue")
 
-        self.assertFalse(prop.is_valid("RED"))
-        self.assertFalse(prop.is_valid("GREEN"))
-        self.assertFalse(prop.is_valid("BLUE"))
+        assert not prop.is_valid("RED")
+        assert not prop.is_valid("GREEN")
+        assert not prop.is_valid("BLUE")
 
-        self.assertFalse(prop.is_valid(" red"))
-        self.assertFalse(prop.is_valid(" green"))
-        self.assertFalse(prop.is_valid(" blue"))
+        assert not prop.is_valid(" red")
+        assert not prop.is_valid(" green")
+        assert not prop.is_valid(" blue")
 
         from bokeh.core.enums import LineJoin
         prop = Enum(LineJoin)
 
-        self.assertTrue(prop.is_valid(None))
-        self.assertFalse(prop.is_valid(False))
-        self.assertFalse(prop.is_valid(True))
-        self.assertFalse(prop.is_valid(0))
-        self.assertFalse(prop.is_valid(1))
-        self.assertFalse(prop.is_valid(0.0))
-        self.assertFalse(prop.is_valid(1.0))
-        self.assertFalse(prop.is_valid(1.0+1.0j))
-        self.assertFalse(prop.is_valid(""))
-        self.assertFalse(prop.is_valid(()))
-        self.assertFalse(prop.is_valid([]))
-        self.assertFalse(prop.is_valid({}))
-        self.assertFalse(prop.is_valid(Foo()))
+        assert prop.is_valid(None)
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
+        assert not prop.is_valid(0)
+        assert not prop.is_valid(1)
+        assert not prop.is_valid(0.0)
+        assert not prop.is_valid(1.0)
+        assert not prop.is_valid(1.0+1.0j)
+        assert not prop.is_valid("")
+        assert not prop.is_valid(())
+        assert not prop.is_valid([])
+        assert not prop.is_valid({})
+        assert not prop.is_valid(Foo())
 
-        self.assertTrue(prop.is_valid("miter"))
-        self.assertTrue(prop.is_valid("round"))
-        self.assertTrue(prop.is_valid("bevel"))
+        assert prop.is_valid("miter")
+        assert prop.is_valid("round")
+        assert prop.is_valid("bevel")
 
-        self.assertFalse(prop.is_valid("MITER"))
-        self.assertFalse(prop.is_valid("ROUND"))
-        self.assertFalse(prop.is_valid("BEVEL"))
+        assert not prop.is_valid("MITER")
+        assert not prop.is_valid("ROUND")
+        assert not prop.is_valid("BEVEL")
 
-        self.assertFalse(prop.is_valid(" miter"))
-        self.assertFalse(prop.is_valid(" round"))
-        self.assertFalse(prop.is_valid(" bevel"))
+        assert not prop.is_valid(" miter")
+        assert not prop.is_valid(" round")
+        assert not prop.is_valid(" bevel")
 
         from bokeh.core.enums import NamedColor
         prop = Enum(NamedColor)
 
-        self.assertTrue(prop.is_valid("red"))
-        self.assertTrue(prop.is_valid("Red"))
-        self.assertTrue(prop.is_valid("RED"))
+        assert prop.is_valid("red")
+        assert prop.is_valid("Red")
+        assert prop.is_valid("RED")
 
     def test_Color(self):
         prop = Color()
 
-        self.assertTrue(prop.is_valid(None))
-        self.assertFalse(prop.is_valid(False))
-        self.assertFalse(prop.is_valid(True))
-        self.assertFalse(prop.is_valid(0))
-        self.assertFalse(prop.is_valid(1))
-        self.assertFalse(prop.is_valid(0.0))
-        self.assertFalse(prop.is_valid(1.0))
-        self.assertFalse(prop.is_valid(1.0+1.0j))
-        self.assertFalse(prop.is_valid(""))
-        self.assertFalse(prop.is_valid(()))
-        self.assertFalse(prop.is_valid([]))
-        self.assertFalse(prop.is_valid({}))
-        self.assertFalse(prop.is_valid(Foo()))
+        assert prop.is_valid(None)
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
+        assert not prop.is_valid(0)
+        assert not prop.is_valid(1)
+        assert not prop.is_valid(0.0)
+        assert not prop.is_valid(1.0)
+        assert not prop.is_valid(1.0+1.0j)
+        assert not prop.is_valid("")
+        assert not prop.is_valid(())
+        assert not prop.is_valid([])
+        assert not prop.is_valid({})
+        assert not prop.is_valid(Foo())
 
-        self.assertTrue(prop.is_valid((0, 127, 255)))
-        self.assertFalse(prop.is_valid((0, -127, 255)))
-        self.assertFalse(prop.is_valid((0, 127)))
-        self.assertFalse(prop.is_valid((0, 127, 1.0)))
-        self.assertFalse(prop.is_valid((0, 127, 255, 255)))
-        self.assertTrue(prop.is_valid((0, 127, 255, 1.0)))
+        assert prop.is_valid((0, 127, 255))
+        assert not prop.is_valid((0, -127, 255))
+        assert not prop.is_valid((0, 127))
+        assert not prop.is_valid((0, 127, 1.0))
+        assert not prop.is_valid((0, 127, 255, 255))
+        assert prop.is_valid((0, 127, 255, 1.0))
 
-        self.assertTrue(prop.is_valid("#00aaff"))
-        self.assertTrue(prop.is_valid("#00AAFF"))
-        self.assertTrue(prop.is_valid("#00AaFf"))
-        self.assertFalse(prop.is_valid("00aaff"))
-        self.assertFalse(prop.is_valid("00AAFF"))
-        self.assertFalse(prop.is_valid("00AaFf"))
-        self.assertFalse(prop.is_valid("#00AaFg"))
-        self.assertFalse(prop.is_valid("#00AaFff"))
+        assert prop.is_valid("#00aaff")
+        assert prop.is_valid("#00AAFF")
+        assert prop.is_valid("#00AaFf")
+        assert not prop.is_valid("00aaff")
+        assert not prop.is_valid("00AAFF")
+        assert not prop.is_valid("00AaFf")
+        assert not prop.is_valid("#00AaFg")
+        assert not prop.is_valid("#00AaFff")
 
-        self.assertTrue(prop.is_valid("blue"))
-        self.assertTrue(prop.is_valid("BLUE"))
-        self.assertFalse(prop.is_valid("foobar"))
+        assert prop.is_valid("blue")
+        assert prop.is_valid("BLUE")
+        assert not prop.is_valid("foobar")
 
-        self.assertEqual(prop.transform((0, 127, 255)), "rgb(0, 127, 255)")
-        self.assertEqual(prop.transform((0, 127, 255, 0.1)), "rgba(0, 127, 255, 0.1)")
+        assert prop.transform((0, 127, 255)), "rgb(0, 127, 255)"
+        assert prop.transform((0, 127, 255, 0.1)), "rgba(0, 127, 255, 0.1)"
 
     def test_DashPattern(self):
         prop = DashPattern()
 
-        self.assertTrue(prop.is_valid(None))
-        self.assertFalse(prop.is_valid(False))
-        self.assertFalse(prop.is_valid(True))
-        self.assertFalse(prop.is_valid(0))
-        self.assertFalse(prop.is_valid(1))
-        self.assertFalse(prop.is_valid(0.0))
-        self.assertFalse(prop.is_valid(1.0))
-        self.assertFalse(prop.is_valid(1.0+1.0j))
-        self.assertTrue(prop.is_valid(""))
-        self.assertTrue(prop.is_valid(()))
-        self.assertTrue(prop.is_valid([]))
-        self.assertFalse(prop.is_valid({}))
-        self.assertFalse(prop.is_valid(Foo()))
+        assert prop.is_valid(None)
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
+        assert not prop.is_valid(0)
+        assert not prop.is_valid(1)
+        assert not prop.is_valid(0.0)
+        assert not prop.is_valid(1.0)
+        assert not prop.is_valid(1.0+1.0j)
+        assert prop.is_valid("")
+        assert prop.is_valid(())
+        assert prop.is_valid([])
+        assert not prop.is_valid({})
+        assert not prop.is_valid(Foo())
 
-        self.assertTrue(prop.is_valid("solid"))
-        self.assertTrue(prop.is_valid("dashed"))
-        self.assertTrue(prop.is_valid("dotted"))
-        self.assertTrue(prop.is_valid("dotdash"))
-        self.assertTrue(prop.is_valid("dashdot"))
-        self.assertFalse(prop.is_valid("DASHDOT"))
+        assert prop.is_valid("solid")
+        assert prop.is_valid("dashed")
+        assert prop.is_valid("dotted")
+        assert prop.is_valid("dotdash")
+        assert prop.is_valid("dashdot")
+        assert not prop.is_valid("DASHDOT")
 
-        self.assertTrue(prop.is_valid([1, 2, 3]))
-        self.assertFalse(prop.is_valid([1, 2, 3.0]))
+        assert prop.is_valid([1, 2, 3])
+        assert not prop.is_valid([1, 2, 3.0])
 
-        self.assertTrue(prop.is_valid("1 2 3"))
-        self.assertFalse(prop.is_valid("1 2 x"))
+        assert prop.is_valid("1 2 3")
+        assert not prop.is_valid("1 2 x")
 
     def test_Size(self):
         prop = Size()
 
-        self.assertTrue(prop.is_valid(None))
-        # TODO: self.assertFalse(prop.is_valid(False))
-        # TODO: self.assertFalse(prop.is_valid(True))
-        self.assertTrue(prop.is_valid(0))
-        self.assertTrue(prop.is_valid(1))
-        self.assertTrue(prop.is_valid(0.0))
-        self.assertTrue(prop.is_valid(1.0))
-        self.assertFalse(prop.is_valid(1.0+1.0j))
-        self.assertFalse(prop.is_valid(""))
-        self.assertFalse(prop.is_valid(()))
-        self.assertFalse(prop.is_valid([]))
-        self.assertFalse(prop.is_valid({}))
-        self.assertFalse(prop.is_valid(Foo()))
+        assert prop.is_valid(None)
+        # TODO: assert not prop.is_valid(False)
+        # TODO: assert not prop.is_valid(True)
+        assert prop.is_valid(0)
+        assert prop.is_valid(1)
+        assert prop.is_valid(0.0)
+        assert prop.is_valid(1.0)
+        assert not prop.is_valid(1.0+1.0j)
+        assert not prop.is_valid("")
+        assert not prop.is_valid(())
+        assert not prop.is_valid([])
+        assert not prop.is_valid({})
+        assert not prop.is_valid(Foo())
 
-        self.assertTrue(prop.is_valid(100))
-        self.assertTrue(prop.is_valid(100.1))
-        self.assertFalse(prop.is_valid(-100))
-        self.assertFalse(prop.is_valid(-0.001))
+        assert prop.is_valid(100)
+        assert prop.is_valid(100.1)
+        assert not prop.is_valid(-100)
+        assert not prop.is_valid(-0.001)
 
     def test_Percent(self):
         prop = Percent()
 
-        self.assertTrue(prop.is_valid(None))
-        # TODO: self.assertFalse(prop.is_valid(False))
-        # TODO: self.assertFalse(prop.is_valid(True))
-        self.assertTrue(prop.is_valid(0))
-        self.assertTrue(prop.is_valid(1))
-        self.assertTrue(prop.is_valid(0.0))
-        self.assertTrue(prop.is_valid(1.0))
-        self.assertFalse(prop.is_valid(1.0+1.0j))
-        self.assertFalse(prop.is_valid(""))
-        self.assertFalse(prop.is_valid(()))
-        self.assertFalse(prop.is_valid([]))
-        self.assertFalse(prop.is_valid({}))
-        self.assertFalse(prop.is_valid(Foo()))
+        assert prop.is_valid(None)
+        # TODO: assert not prop.is_valid(False)
+        # TODO: assert not prop.is_valid(True)
+        assert prop.is_valid(0)
+        assert prop.is_valid(1)
+        assert prop.is_valid(0.0)
+        assert prop.is_valid(1.0)
+        assert not prop.is_valid(1.0+1.0j)
+        assert not prop.is_valid("")
+        assert not prop.is_valid(())
+        assert not prop.is_valid([])
+        assert not prop.is_valid({})
+        assert not prop.is_valid(Foo())
 
-        self.assertTrue(prop.is_valid(0.5))
-        self.assertFalse(prop.is_valid(-0.001))
-        self.assertFalse(prop.is_valid( 1.001))
+        assert prop.is_valid(0.5)
+        assert not prop.is_valid(-0.001)
+        assert not prop.is_valid( 1.001)
 
     def test_Angle(self):
         prop = Angle()
 
-        self.assertTrue(prop.is_valid(None))
-        # TODO: self.assertFalse(prop.is_valid(False))
-        # TODO: self.assertFalse(prop.is_valid(True))
-        self.assertTrue(prop.is_valid(0))
-        self.assertTrue(prop.is_valid(1))
-        self.assertTrue(prop.is_valid(0.0))
-        self.assertTrue(prop.is_valid(1.0))
-        self.assertFalse(prop.is_valid(1.0+1.0j))
-        self.assertFalse(prop.is_valid(""))
-        self.assertFalse(prop.is_valid(()))
-        self.assertFalse(prop.is_valid([]))
-        self.assertFalse(prop.is_valid({}))
-        self.assertFalse(prop.is_valid(Foo()))
+        assert prop.is_valid(None)
+        # TODO: assert not prop.is_valid(False)
+        # TODO: assert not prop.is_valid(True)
+        assert prop.is_valid(0)
+        assert prop.is_valid(1)
+        assert prop.is_valid(0.0)
+        assert prop.is_valid(1.0)
+        assert not prop.is_valid(1.0+1.0j)
+        assert not prop.is_valid("")
+        assert not prop.is_valid(())
+        assert not prop.is_valid([])
+        assert not prop.is_valid({})
+        assert not prop.is_valid(Foo())
 
     def test_MinMaxBounds_with_no_datetime(self):
         prop = MinMaxBounds(accept_datetime=False)
 
         # Valid values
-        self.assertTrue(prop.is_valid('auto'))
-        self.assertTrue(prop.is_valid(None))
-        self.assertTrue(prop.is_valid((12, 13)))
-        self.assertTrue(prop.is_valid((-32, -13)))
-        self.assertTrue(prop.is_valid((12.1, 13.1)))
-        self.assertTrue(prop.is_valid((None, 13.1)))
-        self.assertTrue(prop.is_valid((-22, None)))
+        assert prop.is_valid('auto')
+        assert prop.is_valid(None)
+        assert prop.is_valid((12, 13))
+        assert prop.is_valid((-32, -13))
+        assert prop.is_valid((12.1, 13.1))
+        assert prop.is_valid((None, 13.1))
+        assert prop.is_valid((-22, None))
 
         # Invalid values
-        self.assertFalse(prop.is_valid('string'))
-        self.assertFalse(prop.is_valid(12))
-        self.assertFalse(prop.is_valid(('a', 'b')))
-        self.assertFalse(prop.is_valid((13, 12)))
-        self.assertFalse(prop.is_valid((13.1, 12.2)))
-        self.assertFalse(prop.is_valid((datetime.date(2012, 10, 1), datetime.date(2012, 12, 2))))
+        assert not prop.is_valid('string')
+        assert not prop.is_valid(12)
+        assert not prop.is_valid(('a', 'b'))
+        assert not prop.is_valid((13, 12))
+        assert not prop.is_valid((13.1, 12.2))
+        assert not prop.is_valid((datetime.date(2012, 10, 1), datetime.date(2012, 12, 2)))
 
     def test_MinMaxBounds_with_datetime(self):
         prop = MinMaxBounds(accept_datetime=True)
 
         # Valid values
-        self.assertTrue(prop.is_valid((datetime.date(2012, 10, 1), datetime.date(2012, 12, 2))))
+        assert prop.is_valid((datetime.date(2012, 10, 1), datetime.date(2012, 12, 2)))
 
         # Invalid values
-        self.assertFalse(prop.is_valid((datetime.date(2012, 10, 1), 22)))
+        assert not prop.is_valid((datetime.date(2012, 10, 1), 22))
 
 def test_HasProps_equals():
     class Foo(HasProps):

--- a/bokeh/core/tests/test_properties.py
+++ b/bokeh/core/tests/test_properties.py
@@ -706,7 +706,7 @@ class TestNumberSpec(object):
         class Foo(HasProps):
             x = NumberSpec("xfield")
         f = Foo()
-        assert f.x, "xfield"
+        assert f.x == "xfield"
         f.x = 12
         assert f.x == 12
         assert Foo.__dict__["x"].serializable_value(f) == {"value": 12}
@@ -1869,8 +1869,8 @@ class TestProperties(object):
         assert prop.is_valid("BLUE")
         assert not prop.is_valid("foobar")
 
-        assert prop.transform((0, 127, 255)), "rgb(0, 127, 255)"
-        assert prop.transform((0, 127, 255, 0.1)), "rgba(0, 127, 255, 0.1)"
+        assert prop.transform((0, 127, 255)) == "rgb(0, 127, 255)"
+        assert prop.transform((0, 127, 255, 0.1)) == "rgba(0, 127, 255, 0.1)"
 
     def test_DashPattern(self):
         prop = DashPattern()

--- a/bokeh/document/tests/test_document.py
+++ b/bokeh/document/tests/test_document.py
@@ -5,7 +5,6 @@ import pytest
 from mock import patch
 
 import logging
-import unittest
 
 from copy import copy
 
@@ -129,7 +128,7 @@ class Test_Document_delete_modules(object):
         assert 'junkjunkjunk' not in sys.modules
         assert d._modules is None
 
-class TestDocument(unittest.TestCase):
+class TestDocument(object):
 
     def test_empty(self):
         d = document.Document()
@@ -863,39 +862,39 @@ class TestDocument(unittest.TestCase):
                 expected = copy(new_value)
                 if 'units' not in expected:
                     expected['units'] = root1.foo_units
-                self.assertDictEqual(expected, root1.lookup('foo').serializable_value(root1))
+                assert expected == root1.lookup('foo').serializable_value(root1)
             else:
-                self.assertEqual(new_value, root1.foo)
+                assert new_value == root1.foo
         patch_test(57)
-        self.assertEqual('data', root1.foo_units)
+        assert 'data' == root1.foo_units
         patch_test(dict(value=58))
-        self.assertEqual('data', root1.foo_units)
+        assert 'data' == root1.foo_units
         patch_test(dict(value=58, units='screen'))
-        self.assertEqual('screen', root1.foo_units)
+        assert 'screen' == root1.foo_units
         patch_test(dict(value=59, units='screen'))
-        self.assertEqual('screen', root1.foo_units)
+        assert 'screen' == root1.foo_units
         patch_test(dict(value=59, units='data'))
-        self.assertEqual('data', root1.foo_units)
+        assert 'data' == root1.foo_units
         patch_test(dict(value=60, units='data'))
-        self.assertEqual('data', root1.foo_units)
+        assert 'data' == root1.foo_units
         patch_test(dict(value=60, units='data'))
-        self.assertEqual('data', root1.foo_units)
+        assert 'data' == root1.foo_units
         patch_test(61)
-        self.assertEqual('data', root1.foo_units)
+        assert 'data' == root1.foo_units
         root1.foo = "a_string" # so "woot" gets set as a string
         patch_test("woot")
-        self.assertEqual('data', root1.foo_units)
+        assert 'data' == root1.foo_units
         patch_test(dict(field="woot2"))
-        self.assertEqual('data', root1.foo_units)
+        assert 'data' == root1.foo_units
         patch_test(dict(field="woot2", units='screen'))
-        self.assertEqual('screen', root1.foo_units)
+        assert 'screen' == root1.foo_units
         patch_test(dict(field="woot3"))
-        self.assertEqual('screen', root1.foo_units)
+        assert 'screen' == root1.foo_units
         patch_test(dict(value=70))
-        self.assertEqual('screen', root1.foo_units)
+        assert 'screen' == root1.foo_units
         root1.foo = 123 # so 71 gets set as a number
         patch_test(71)
-        self.assertEqual('screen', root1.foo_units)
+        assert 'screen' == root1.foo_units
 
     def test_patch_reference_property(self):
         d = document.Document()

--- a/bokeh/document/tests/test_events.py
+++ b/bokeh/document/tests/test_events.py
@@ -1,7 +1,8 @@
 import pytest
 
 from mock import patch
-import pandas as pd
+
+from bokeh.util.testing import pd ; pd
 
 import bokeh.document.events as bde
 
@@ -270,7 +271,7 @@ class TestColumnsStreamedEvent(object):
         assert e.data == dict(foo=1)
         assert e.rollover == 200
 
-    def test_pandas_data(self):
+    def test_pandas_data(self, pd):
         m = FakeModel()
         df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
         e = bde.ColumnsStreamedEvent("doc", m, df, 200, "setter", "invoker")

--- a/bokeh/models/tests/test_mappers.py
+++ b/bokeh/models/tests/test_mappers.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 
+from bokeh.palettes import Spectral6
+from bokeh.util.testing import pd ; pd
+
 from bokeh.models.mappers import LinearColorMapper, LogColorMapper, CategoricalColorMapper
 
 from .utils.property_utils import check_properties_existence
@@ -49,9 +52,7 @@ def test_no_warning_if_categorical_color_mapper_with_long_palette(recwarn):
     CategoricalColorMapper(factors=["a", "b", "c"], palette=["red", "green", "orange", "blue"])
     assert len(recwarn) == 0
 
-def test_categorical_color_mapper_with_pandas_index():
-    import pandas as pd
-    from bokeh.palettes import Spectral6
+def test_categorical_color_mapper_with_pandas_index(pd):
     fruits = ['Apples', 'Pears', 'Nectarines', 'Plums', 'Grapes', 'Strawberries']
     years = ['2015', '2016', '2017']
     data = {'2015'   : [2, 1, 4, 3, 2, 4],

--- a/bokeh/models/tests/test_plots.py
+++ b/bokeh/models/tests/test_plots.py
@@ -9,7 +9,6 @@
 from __future__ import absolute_import
 
 from mock import patch
-import unittest
 import pytest
 
 from bokeh.plotting import figure
@@ -19,54 +18,45 @@ from bokeh.models.scales import CategoricalScale, LinearScale, LogScale
 from bokeh.models.tools import PanTool, Toolbar
 
 
-class TestPlotSelect(unittest.TestCase):
+class TestPlotSelect(object):
 
-    def setUp(self):
+    def setup_method(self):
         self._plot = figure(tools='pan')
         self._plot.circle([1,2,3], [3,2,1], name='foo')
 
     @patch('bokeh.models.plots.find')
     def test_string_arg(self, mock_find):
         self._plot.select('foo')
-        self.assertTrue(mock_find.called)
-        self.assertEqual(mock_find.call_args[0][1], dict(name='foo'))
+        assert mock_find.called
+        assert mock_find.call_args[0][1] == dict(name='foo')
 
     @patch('bokeh.models.plots.find')
     def test_type_arg(self, mock_find):
         self._plot.select(PanTool)
-        self.assertTrue(mock_find.called)
-        self.assertEqual(mock_find.call_args[0][1], dict(type=PanTool))
+        assert mock_find.called
+        assert mock_find.call_args[0][1] == dict(type=PanTool)
 
     @patch('bokeh.models.plots.find')
     def test_kwargs(self, mock_find):
         kw = dict(name='foo', type=GlyphRenderer)
         self._plot.select(**kw)
-        self.assertTrue(mock_find.called)
-        self.assertEqual(mock_find.call_args[0][1], kw)
+        assert mock_find.called
+        assert mock_find.call_args[0][1] == kw
 
     def test_too_many_args(self):
-        with self.assertRaises(TypeError) as cm:
+        with pytest.raises(TypeError) as cm:
             self._plot.select('foo', 'bar')
-        self.assertEqual(
-            'select accepts at most ONE positional argument.',
-            str(cm.exception)
-        )
+            assert 'select accepts at most ONE positional argument.' == str(cm.exception)
 
     def test_no_input(self):
-        with self.assertRaises(TypeError) as cm:
+        with pytest.raises(TypeError) as cm:
             self._plot.select()
-        self.assertEqual(
-            'select requires EITHER a positional argument, OR keyword arguments.',
-            str(cm.exception)
-        )
+            assert 'select requires EITHER a positional argument, OR keyword arguments.' == str(cm.exception)
 
     def test_arg_and_kwarg(self):
-        with self.assertRaises(TypeError) as cm:
+        with pytest.raises(TypeError) as cm:
             self._plot.select('foo', type=PanTool)
-        self.assertEqual(
-            'select accepts EITHER a positional argument, OR keyword arguments (not both).',
-            str(cm.exception)
-        )
+            assert 'select accepts EITHER a positional argument, OR keyword arguments (not both).' == str(cm.exception)
 
 
 def test_plot_add_layout_raises_error_if_not_render():
@@ -105,10 +95,10 @@ class BaseTwinAxis(object):
     """Base class for testing extra ranges"""
 
     def verify_axis(self, axis_name):
-        plot = Plot()  # no need for setUp()
+        plot = Plot()
         range_obj = getattr(plot, 'extra_{}_ranges'.format(axis_name))
         range_obj['foo_range'] = self.get_range_instance()
-        self.assertTrue(range_obj['foo_range'])
+        assert range_obj['foo_range']
 
     def test_x_range(self):
         self.verify_axis('x')
@@ -121,7 +111,7 @@ class BaseTwinAxis(object):
         raise NotImplementedError
 
 
-class TestCategoricalTwinAxis(BaseTwinAxis, unittest.TestCase):
+class TestCategoricalTwinAxis(BaseTwinAxis, object):
     """Test whether extra x and y ranges can be categorical"""
 
     @staticmethod
@@ -129,7 +119,7 @@ class TestCategoricalTwinAxis(BaseTwinAxis, unittest.TestCase):
         return FactorRange('foo', 'bar')
 
 
-class TestLinearTwinAxis(BaseTwinAxis, unittest.TestCase):
+class TestLinearTwinAxis(BaseTwinAxis, object):
     """Test whether extra x and y ranges can be Range1d"""
 
     @staticmethod

--- a/bokeh/models/tests/test_sources.py
+++ b/bokeh/models/tests/test_sources.py
@@ -1,177 +1,163 @@
 from __future__ import absolute_import
 
 import io
-import unittest
 import datetime as dt
-from unittest import skipIf
 import warnings
 
+import pytest
+
 import numpy as np
-try:
-    import pandas as pd
-    is_pandas = True
-except ImportError as e:
-    is_pandas = False
 
 from bokeh.models.sources import DataSource, ColumnDataSource
 from bokeh.util.serialization import transform_column_source_data, convert_datetime_array
+from bokeh.util.testing import pd ; pd
 
-class TestColumnDataSource(unittest.TestCase):
+class TestColumnDataSource(object):
 
     def test_basic(self):
         ds = ColumnDataSource()
-        self.assertTrue(isinstance(ds, DataSource))
+        assert isinstance(ds, DataSource)
 
     def test_init_dict_arg(self):
         data = dict(a=[1], b=[2])
         ds = ColumnDataSource(data)
-        self.assertEquals(ds.data, data)
-        self.assertEquals(set(ds.column_names), set(data.keys()))
+        assert ds.data == data
+        assert set(ds.column_names) == set(data.keys())
 
     def test_init_dict_data_kwarg(self):
         data = dict(a=[1], b=[2])
         ds = ColumnDataSource(data=data)
-        self.assertEquals(ds.data, data)
-        self.assertEquals(set(ds.column_names), set(data.keys()))
+        assert ds.data == data
+        assert set(ds.column_names) == set(data.keys())
 
-    @skipIf(not is_pandas, "pandas not installed")
-    def test_init_dataframe_arg(self):
+    def test_init_dataframe_arg(self, pd):
         data = dict(a=[1, 2], b=[2, 3])
         df = pd.DataFrame(data)
         ds = ColumnDataSource(df)
-        self.assertTrue(set(df.columns).issubset(set(ds.column_names)))
+        assert set(df.columns).issubset(set(ds.column_names))
         for key in data.keys():
-            self.assertIsInstance(ds.data[key], np.ndarray)
-            self.assertEquals(list(df[key]), list(ds.data[key]))
-        self.assertIsInstance(ds.data['index'], np.ndarray)
-        self.assertEquals([0, 1], list(ds.data['index']))
-        self.assertEqual(set(ds.column_names) - set(df.columns), set(["index"]))
+            assert isinstance(ds.data[key], np.ndarray)
+            assert list(df[key]) == list(ds.data[key])
+        assert isinstance(ds.data['index'], np.ndarray)
+        assert [0, 1] == list(ds.data['index'])
+        assert set(ds.column_names) - set(df.columns) == set(["index"])
 
-    @skipIf(not is_pandas, "pandas not installed")
-    def test_init_dataframe_data_kwarg(self):
+    def test_init_dataframe_data_kwarg(self, pd):
         data = dict(a=[1, 2], b=[2, 3])
         df = pd.DataFrame(data)
         ds = ColumnDataSource(data=df)
-        self.assertTrue(set(df.columns).issubset(set(ds.column_names)))
+        assert set(df.columns).issubset(set(ds.column_names))
         for key in data.keys():
-            self.assertIsInstance(ds.data[key], np.ndarray)
-            self.assertEquals(list(df[key]), list(ds.data[key]))
-        self.assertIsInstance(ds.data['index'], np.ndarray)
-        self.assertEquals([0, 1], list(ds.data['index']))
-        self.assertEqual(set(ds.column_names) - set(df.columns), set(["index"]))
+            assert isinstance(ds.data[key], np.ndarray)
+            assert list(df[key]) == list(ds.data[key])
+        assert isinstance(ds.data['index'], np.ndarray)
+        assert [0, 1] == list(ds.data['index'])
+        assert set(ds.column_names) - set(df.columns) == set(["index"])
 
-    @skipIf(not is_pandas, "pandas not installed")
-    def test_init_groupby_arg(self):
+    def test_init_groupby_arg(self, pd):
         from bokeh.sampledata.autompg import autompg as df
         group = df.groupby(('origin', 'cyl'))
         ds = ColumnDataSource(group)
         s = group.describe()
-        self.assertTrue(len(ds.column_names)) == 41
-        self.assertIsInstance(ds.data['origin_cyl'], np.ndarray)
+        assert len(ds.column_names) == 49
+        assert isinstance(ds.data['origin_cyl'], np.ndarray)
         for key in s.columns.values:
             k2 = "_".join(key)
-            self.assertIsInstance(ds.data[k2], np.ndarray)
-            self.assertEquals(list(s[key]), list(ds.data[k2]))
+            assert isinstance(ds.data[k2], np.ndarray)
+            assert list(s[key]) == list(ds.data[k2])
 
-    @skipIf(not is_pandas, "pandas not installed")
-    def test_init_groupby_data_kwarg(self):
+    def test_init_groupby_data_kwarg(self, pd):
         from bokeh.sampledata.autompg import autompg as df
         group = df.groupby(('origin', 'cyl'))
         ds = ColumnDataSource(data=group)
         s = group.describe()
-        self.assertTrue(len(ds.column_names)) == 41
-        self.assertIsInstance(ds.data['origin_cyl'], np.ndarray)
+        assert len(ds.column_names) == 49
+        assert isinstance(ds.data['origin_cyl'], np.ndarray)
         for key in s.columns.values:
             k2 = "_".join(key)
-            self.assertIsInstance(ds.data[k2], np.ndarray)
-            self.assertEquals(list(s[key]), list(ds.data[k2]))
+            assert isinstance(ds.data[k2], np.ndarray)
+            assert list(s[key]) == list(ds.data[k2])
 
-    @skipIf(not is_pandas, "pandas not installed")
-    def test_init_groupby_with_None_subindex_name(self):
+    def test_init_groupby_with_None_subindex_name(self, pd):
         df = pd.DataFrame({"A": [1, 2, 3, 4] * 2, "B": [10, 20, 30, 40] * 2, "C": range(8)})
         group = df.groupby(['A', [10, 20, 30, 40] * 2])
         ds = ColumnDataSource(data=group)
         s = group.describe()
-        self.assertTrue(len(ds.column_names)) == 41
-        self.assertIsInstance(ds.data['index'], np.ndarray)
+        assert len(ds.column_names) == 17
+        assert isinstance(ds.data['index'], np.ndarray)
         for key in s.columns.values:
             k2 = "_".join(key)
-            self.assertIsInstance(ds.data[k2], np.ndarray)
-            self.assertEquals(list(s[key]), list(ds.data[k2]))
+            assert isinstance(ds.data[k2], np.ndarray)
+            assert list(s[key]) == list(ds.data[k2])
 
     def test_add_with_name(self):
         ds = ColumnDataSource()
         name = ds.add([1,2,3], name="foo")
-        self.assertEquals(name, "foo")
+        assert name == "foo"
         name = ds.add([4,5,6], name="bar")
-        self.assertEquals(name, "bar")
+        assert name == "bar"
 
     def test_add_without_name(self):
         ds = ColumnDataSource()
         name = ds.add([1,2,3])
-        self.assertEquals(name, "Series 0")
+        assert name == "Series 0"
         name = ds.add([4,5,6])
-        self.assertEquals(name, "Series 1")
+        assert name == "Series 1"
 
     def test_add_with_and_without_name(self):
         ds = ColumnDataSource()
         name = ds.add([1,2,3], "foo")
-        self.assertEquals(name, "foo")
+        assert name == "foo"
         name = ds.add([4,5,6])
-        self.assertEquals(name, "Series 1")
+        assert name == "Series 1"
 
     def test_remove_exists(self):
         ds = ColumnDataSource()
         name = ds.add([1,2,3], "foo")
         assert name
         ds.remove("foo")
-        self.assertEquals(ds.column_names, [])
+        assert ds.column_names == []
 
     def test_remove_exists2(self):
         with warnings.catch_warnings(record=True) as w:
             ds = ColumnDataSource()
             ds.remove("foo")
-            self.assertEquals(ds.column_names, [])
-            self.assertEquals(len(w), 1)
-            self.assertEquals(w[0].category, UserWarning)
-            self.assertEquals(str(w[0].message), "Unable to find column 'foo' in data source")
+            assert ds.column_names == []
+            assert len(w) == 1
+            assert w[0].category == UserWarning
+            assert str(w[0].message) == "Unable to find column 'foo' in data source"
 
     def test_stream_bad_data(self):
         ds = ColumnDataSource(data=dict(a=[10], b=[20]))
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as cm:
             ds.stream(dict())
-        self.assertEqual(str(cm.exception), "Must stream updates to all existing columns (missing: a, b)")
-        with self.assertRaises(ValueError) as cm:
+            assert str(cm.exception) == "Must stream updates to all existing columns (missing: a, b)"
+        with pytest.raises(ValueError) as cm:
             ds.stream(dict(a=[10]))
-        self.assertEqual(str(cm.exception), "Must stream updates to all existing columns (missing: b)")
-        with self.assertRaises(ValueError) as cm:
+            assert str(cm.exception) == "Must stream updates to all existing columns (missing: b)"
+        with pytest.raises(ValueError) as cm:
             ds.stream(dict(a=[10], b=[10], x=[10]))
-        self.assertEqual(str(cm.exception), "Must stream updates to all existing columns (extra: x)")
-        with self.assertRaises(ValueError) as cm:
+            assert str(cm.exception) == "Must stream updates to all existing columns (extra: x)"
+        with pytest.raises(ValueError) as cm:
             ds.stream(dict(a=[10], x=[10]))
-        self.assertEqual(str(cm.exception), "Must stream updates to all existing columns (missing: b, extra: x)")
-        with self.assertRaises(ValueError) as cm:
+            assert str(cm.exception) == "Must stream updates to all existing columns (missing: b, extra: x)"
+        with pytest.raises(ValueError) as cm:
             ds.stream(dict(a=[10], b=[10, 20]))
-        self.assertEqual(str(cm.exception), "All streaming column updates must be the same length")
+            assert str(cm.exception) == "All streaming column updates must be the same length"
 
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as cm:
             ds.stream(dict(a=[10], b=np.ones((1,1))))
-        self.assertTrue(
-            str(cm.exception).startswith("stream(...) only supports 1d sequences, got ndarray with size (")
-        )
+            assert str(cm.exception).startswith("stream(...) only supports 1d sequences, got ndarray with size (")
 
-    @skipIf(not is_pandas, "pandas not installed")
-    def test__df_index_name_with_named_index(self):
+    def test__df_index_name_with_named_index(self, pd):
         df = pd.DataFrame(dict(a=[10], b=[20], c=[30])).set_index('c')
         assert ColumnDataSource._df_index_name(df) == "c"
 
-    @skipIf(not is_pandas, "pandas not installed")
-    def test__df_index_name_with_unnamed_index(self):
+    def test__df_index_name_with_unnamed_index(self, pd):
         df = pd.DataFrame(dict(a=[10], b=[20], c=[30]))
         assert ColumnDataSource._df_index_name(df) == "index"
 
-    @skipIf(not is_pandas, "pandas not installed")
-    def test__df_index_name_with_named_multi_index(self):
+    def test__df_index_name_with_named_multi_index(self, pd):
         data = io.StringIO(u'''
 Fruit,Color,Count,Price
 Apple,Red,3,$1.29
@@ -184,8 +170,7 @@ Lime,Green,99,$0.39
         assert df.index.names == ['Fruit', 'Color']
         assert ColumnDataSource._df_index_name(df) == "Fruit_Color"
 
-    @skipIf(not is_pandas, "pandas not installed")
-    def test__df_index_name_with_unnamed_multi_index(self):
+    def test__df_index_name_with_unnamed_multi_index(self, pd):
         arrays = [np.array(['bar', 'bar', 'baz', 'baz', 'foo', 'foo', 'qux', 'qux']),
                   np.array(['one', 'two', 'one', 'two', 'one', 'two', 'one', 'two'])]
         df = pd.DataFrame(np.random.randn(8, 4), index=arrays)
@@ -204,8 +189,8 @@ Lime,Green,99,$0.39
         ds.data._stream = mock
         # internal implementation of stream
         ds._stream(dict(a=[11, 12], b=[21, 22]), "foo", mock_setter)
-        self.assertEqual(stuff['args'], ("doc", ds, dict(a=[11, 12], b=[21, 22]), "foo", mock_setter))
-        self.assertEqual(stuff['kw'], {})
+        assert stuff['args'] == ("doc", ds, dict(a=[11, 12], b=[21, 22]), "foo", mock_setter)
+        assert stuff['kw'] == {}
 
     def test_stream_good_data(self):
         ds = ColumnDataSource(data=dict(a=[10], b=[20]))
@@ -218,8 +203,8 @@ Lime,Green,99,$0.39
         ds.data._stream = mock
         # public implementation of stream
         ds._stream(dict(a=[11, 12], b=[21, 22]), "foo")
-        self.assertEqual(stuff['args'], ("doc", ds, dict(a=[11, 12], b=[21, 22]), "foo", None))
-        self.assertEqual(stuff['kw'], {})
+        assert stuff['args'] == ("doc", ds, dict(a=[11, 12], b=[21, 22]), "foo", None)
+        assert stuff['kw'] == {}
 
     def test__stream_good_datetime64_data(self):
         now = dt.datetime.now()
@@ -236,7 +221,7 @@ Lime,Green,99,$0.39
         # internal implementation of stream
         new_date = np.array([now+dt.timedelta(10)], dtype='datetime64')
         ds._stream(dict(index=new_date, b=[10]), "foo", mock_setter)
-        self.assertTrue(np.array_equal(stuff['args'][2]['index'], new_date))
+        assert np.array_equal(stuff['args'][2]['index'], new_date)
 
     def test__stream_good_datetime64_data_transformed(self):
         now = dt.datetime.now()
@@ -255,10 +240,9 @@ Lime,Green,99,$0.39
         new_date = np.array([now+dt.timedelta(10)], dtype='datetime64')
         ds._stream(dict(index=new_date, b=[10]), "foo", mock_setter)
         transformed_date = convert_datetime_array(new_date)
-        self.assertTrue(np.array_equal(stuff['args'][2]['index'], transformed_date))
+        assert np.array_equal(stuff['args'][2]['index'], transformed_date)
 
-    @skipIf(not is_pandas, "pandas not installed")
-    def test__stream_good_df_with_date_index_data(self):
+    def test__stream_good_df_with_date_index_data(self, pd):
         df = pd.DataFrame(
             index=pd.date_range('now', periods=30, freq='T'),
             columns=['A'],
@@ -279,11 +263,10 @@ Lime,Green,99,$0.39
             data=np.random.standard_normal(30)
         )
         ds._stream(new_df, "foo", mock_setter)
-        self.assertTrue(np.array_equal(stuff['args'][2]['index'], new_df.index.values))
-        self.assertTrue(np.array_equal(stuff['args'][2]['A'], new_df.A.values))
+        assert np.array_equal(stuff['args'][2]['index'], new_df.index.values)
+        assert np.array_equal(stuff['args'][2]['A'], new_df.A.values)
 
-    @skipIf(not is_pandas, "pandas not installed")
-    def test__stream_good_dict_of_index_and_series_data(self):
+    def test__stream_good_dict_of_index_and_series_data(self, pd):
         df = pd.DataFrame(
             index=pd.date_range('now', periods=30, freq='T'),
             columns=['A'],
@@ -304,11 +287,10 @@ Lime,Green,99,$0.39
             data=np.random.standard_normal(30)
         )
         ds._stream({'index': new_df.index, 'A': new_df.A}, "foo", mock_setter)
-        self.assertTrue(np.array_equal(stuff['args'][2]['index'], new_df.index.values))
-        self.assertTrue(np.array_equal(stuff['args'][2]['A'], new_df.A.values))
+        assert np.array_equal(stuff['args'][2]['index'], new_df.index.values)
+        assert np.array_equal(stuff['args'][2]['A'], new_df.A.values)
 
-    @skipIf(not is_pandas, "pandas not installed")
-    def test__stream_good_dict_of_index_and_series_data_transformed(self):
+    def test__stream_good_dict_of_index_and_series_data_transformed(self, pd):
         df = pd.DataFrame(
             index=pd.date_range('now', periods=30, freq='T'),
             columns=['A'],
@@ -330,18 +312,16 @@ Lime,Green,99,$0.39
             data=np.random.standard_normal(30)
         )
         ds._stream({'index': new_df.index, 'A': new_df.A}, "foo", mock_setter)
-        self.assertTrue(np.array_equal(stuff['args'][2]['index'],
-                                       convert_datetime_array(new_df.index.values)))
-        self.assertTrue(np.array_equal(stuff['args'][2]['A'], new_df.A.values))
+        assert np.array_equal(stuff['args'][2]['index'], convert_datetime_array(new_df.index.values))
+        assert np.array_equal(stuff['args'][2]['A'], new_df.A.values)
 
     def _assert_equal_dicts_of_arrays(self, d1, d2):
-        self.assertEqual(d1.keys(), d2.keys())
+        assert d1.keys() == d2.keys()
         for k, v in d1.items():
-            self.assertEqual(type(v), np.ndarray)
-            self.assertTrue(np.array_equal(v, d2[k]))
+            assert type(v) == np.ndarray
+            assert np.array_equal(v, d2[k])
 
-    @skipIf(not is_pandas, "pandas not installed")
-    def test_stream_dict_to_ds_created_from_df(self):
+    def test_stream_dict_to_ds_created_from_df(self, pd):
         data = pd.DataFrame(dict(a=[10], b=[20], c=[30])).set_index('c')
         ds = ColumnDataSource(data)
         ds._document = "doc"
@@ -366,22 +346,22 @@ Lime,Green,99,$0.39
                         b=np.array([21, 22]),
                         c=pd.Series([31, 32])), 7)
 
-        self.assertEqual(len(stream_stuff['args']), 5)
+        assert len(stream_stuff['args']) == 5
         expected_stream_args = ("doc", ds, dict(a=[11, 12],
                                                 b=np.array([21, 22]),
                                                 c=pd.Series([31, 32])), 7, None)
         for i, (arg, ex_arg) in enumerate(zip(stream_stuff['args'],
                                               expected_stream_args)):
             if i == 2:
-                self.assertEqual(arg['a'], ex_arg['a'])
+                assert arg['a'] == ex_arg['a']
                 del arg['a'], ex_arg['a']
                 self._assert_equal_dicts_of_arrays(arg, ex_arg)
             else:
-                self.assertEqual(arg, ex_arg)
+                assert arg == ex_arg
 
-        self.assertEqual(stream_stuff['kwargs'], {})
+        assert stream_stuff['kwargs'] == {}
 
-        self.assertEqual(len(notify_owners_stuff['args']), 1)
+        assert len(notify_owners_stuff['args']) == 1
         self._assert_equal_dicts_of_arrays(notify_owners_stuff['args'][0],
                                            dict(a=np.array([10]),
                                                 b=np.array([20]),
@@ -392,8 +372,7 @@ Lime,Green,99,$0.39
                                                 b=np.array([20, 21, 22]),
                                                 c=np.array([30, 31, 32])))
 
-    @skipIf(not is_pandas, "pandas not installed")
-    def test_stream_series_to_ds_created_from_df(self):
+    def test_stream_series_to_ds_created_from_df(self, pd):
         data = pd.DataFrame(dict(a=[10], b=[20], c=[30]))
         ds = ColumnDataSource(data)
         ds._document = "doc"
@@ -418,7 +397,7 @@ Lime,Green,99,$0.39
 
         ds._stream(pd.Series([11, 21, 31], index=list('abc')), 7)
 
-        self.assertEqual(len(stream_stuff['args']), 5)
+        assert len(stream_stuff['args']) == 5
         expected_df = pd.DataFrame(dict(a=np.array([11]),
                                                 b=np.array([21]),
                                                 c=np.array([31])))
@@ -429,11 +408,11 @@ Lime,Green,99,$0.39
             if i == 2:
                 self._assert_equal_dicts_of_arrays(arg, ex_arg)
             else:
-                self.assertEqual(arg, ex_arg)
+                assert arg == ex_arg
 
-        self.assertEqual(stream_stuff['kwargs'], {})
+        assert stream_stuff['kwargs'] == {}
 
-        self.assertEqual(len(notify_owners_stuff['args']), 1)
+        assert len(notify_owners_stuff['args']) == 1
         self._assert_equal_dicts_of_arrays(notify_owners_stuff['args'][0],
                                            dict(a=np.array([10]),
                                                 b=np.array([20]),
@@ -446,8 +425,7 @@ Lime,Green,99,$0.39
                                                 c=np.array([30, 31]),
                                                 index=np.array([0, 0])))
 
-    @skipIf(not is_pandas, "pandas not installed")
-    def test_stream_df_to_ds_created_from_df_named_index(self):
+    def test_stream_df_to_ds_created_from_df_named_index(self, pd):
         data = pd.DataFrame(dict(a=[10], b=[20], c=[30])).set_index('c')
         ds = ColumnDataSource(data)
         ds._document = "doc"
@@ -474,22 +452,22 @@ Lime,Green,99,$0.39
                                      b=[21, 22],
                                      c=[31, 32])).set_index('c'), 7)
 
-        self.assertEqual(len(stream_stuff['args']), 5)
+        assert len(stream_stuff['args']) == 5
         expected_steam_data = dict(a=np.array([11, 12]),
                                    b=np.array([21, 22]),
                                    c=np.array([31, 32]))
         expected_args = ("doc", ds, expected_steam_data, 7, None)
         for i, (arg, ex_arg) in enumerate(zip(stream_stuff['args'], expected_args)):
             if i == 2:
-                self.assertEqual(arg.keys(), ex_arg.keys())
+                assert arg.keys() == ex_arg.keys()
                 for k, v in arg.items():
-                    self.assertTrue(np.array_equal(v, ex_arg[k]))
+                    assert np.array_equal(v, ex_arg[k])
             else:
-                self.assertEqual(stream_stuff['args'][i], expected_args[i])
+                assert stream_stuff['args'][i] == expected_args[i]
 
-        self.assertEqual(stream_stuff['kwargs'], {})
+        assert stream_stuff['kwargs'] == {}
 
-        self.assertEqual(len(notify_owners_stuff['args']), 1)
+        assert len(notify_owners_stuff['args']) == 1
         self._assert_equal_dicts_of_arrays(notify_owners_stuff['args'][0],
                                            dict(a=np.array([10]),
                                                 b=np.array([20]),
@@ -500,8 +478,7 @@ Lime,Green,99,$0.39
                                                 b=np.array([20, 21, 22]),
                                                 c=np.array([30, 31, 32])))
 
-    @skipIf(not is_pandas, "pandas not installed")
-    def test_stream_df_to_ds_created_from_df_default_index(self):
+    def test_stream_df_to_ds_created_from_df_default_index(self, pd):
         data = pd.DataFrame(dict(a=[10], b=[20], c=[30]))
         ds = ColumnDataSource(data)
         ds._document = "doc"
@@ -528,7 +505,7 @@ Lime,Green,99,$0.39
                                      b=[21, 22],
                                      c=[31, 32])), 7)
 
-        self.assertEqual(len(stream_stuff['args']), 5)
+        assert len(stream_stuff['args']) == 5
         expected_df = pd.DataFrame(dict(a=np.array([11, 12]),
                                         b=np.array([21, 22]),
                                         c=np.array([31, 32])))
@@ -538,13 +515,13 @@ Lime,Green,99,$0.39
         for i, (arg, ex_arg) in enumerate(zip(stream_stuff['args'], expected_args)):
             if i == 2:
                 for k, v in arg.items():
-                    self.assertTrue(np.array_equal(v, ex_arg[k]))
+                    assert np.array_equal(v, ex_arg[k])
             else:
-                self.assertEqual(stream_stuff['args'][i], expected_args[i])
+                assert stream_stuff['args'][i] == expected_args[i]
 
-        self.assertEqual(stream_stuff['kwargs'], {})
+        assert stream_stuff['kwargs'] == {}
 
-        self.assertEqual(len(notify_owners_stuff['args']), 1)
+        assert len(notify_owners_stuff['args']) == 1
         self._assert_equal_dicts_of_arrays(notify_owners_stuff['args'][0],
                                            dict(a=np.array([10]),
                                                 b=np.array([20]),
@@ -559,19 +536,19 @@ Lime,Green,99,$0.39
 
     def test_patch_bad_columns(self):
         ds = ColumnDataSource(data=dict(a=[10, 11], b=[20, 21]))
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as cm:
             ds.patch(dict(c=[(0, 100)]))
-        self.assertEqual(str(cm.exception), "Can only patch existing columns (extra: c)")
-        with self.assertRaises(ValueError) as cm:
+            assert str(cm.exception) == "Can only patch existing columns (extra: c)"
+        with pytest.raises(ValueError) as cm:
             ds.patch(dict(a=[(0,100)], c=[(0, 100)], d=[(0, 100)]))
-        self.assertEqual(str(cm.exception), "Can only patch existing columns (extra: c, d)")
+            assert str(cm.exception) == "Can only patch existing columns (extra: c, d)"
 
 
     def test_patch_bad_simple_indices(self):
         ds = ColumnDataSource(data=dict(a=[10, 11], b=[20, 21]))
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as cm:
             ds.patch(dict(a=[(3, 100)]))
-        self.assertEqual(str(cm.exception), "Out-of bounds index (3) in patch for column: a")
+            assert str(cm.exception) == "Out-of bounds index (3) in patch for column: a"
 
     def test_patch_good_simple_indices(self):
         ds = ColumnDataSource(data=dict(a=[10, 11], b=[20, 21]))
@@ -583,29 +560,29 @@ Lime,Green,99,$0.39
             stuff['kw'] = kw
         ds.data._patch = mock
         ds.patch(dict(a=[(0,100), (1,101)], b=[(0,200)]), mock_setter)
-        self.assertEqual(stuff['args'], ("doc", ds, dict(a=[(0,100), (1,101)], b=[(0,200)]), mock_setter))
-        self.assertEqual(stuff['kw'], {})
+        assert stuff['args'] == ("doc", ds, dict(a=[(0,100), (1,101)], b=[(0,200)]), mock_setter)
+        assert stuff['kw'] == {}
 
     def test_patch_bad_slice_indices(self):
         ds = ColumnDataSource(data=dict(a=[10, 11, 12, 13, 14, 15], b=[20, 21, 22, 23, 24, 25]))
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError) as cm:
             ds.patch(dict(a=[(slice(10), list(range(10)))]))
-        self.assertEqual(str(cm.exception), "Out-of bounds slice index stop (10) in patch for column: a")
-        with self.assertRaises(ValueError) as cm:
+            assert str(cm.exception) == "Out-of bounds slice index stop (10) in patch for column: a"
+        with pytest.raises(ValueError) as cm:
             ds.patch(dict(a=[(slice(10, 1), list(range(10)))]))
-        self.assertEqual(str(cm.exception), "Patch slices must have start < end, got slice(10, 1, None)")
-        with self.assertRaises(ValueError) as cm:
+            assert str(cm.exception) == "Patch slices must have start < end, got slice(10, 1, None)"
+        with pytest.raises(ValueError) as cm:
             ds.patch(dict(a=[(slice(None, 10, -1), list(range(10)))]))
-        self.assertEqual(str(cm.exception), "Patch slices must have non-negative (start, stop, step) values, got slice(None, 10, -1)")
-        with self.assertRaises(ValueError) as cm:
+            assert str(cm.exception) == "Patch slices must have non-negative (start, stop, step) values, got slice(None, 10, -1)"
+        with pytest.raises(ValueError) as cm:
             ds.patch(dict(a=[(slice(10, 1, 1), list(range(10)))]))
-        self.assertEqual(str(cm.exception), "Patch slices must have start < end, got slice(10, 1, 1)")
-        with self.assertRaises(ValueError) as cm:
+            assert str(cm.exception) == "Patch slices must have start < end, got slice(10, 1, 1)"
+        with pytest.raises(ValueError) as cm:
             ds.patch(dict(a=[(slice(10, 1, -1), list(range(10)))]))
-        self.assertEqual(str(cm.exception), "Patch slices must have start < end, got slice(10, 1, -1)")
-        with self.assertRaises(ValueError) as cm:
+            assert str(cm.exception) == "Patch slices must have start < end, got slice(10, 1, -1)"
+        with pytest.raises(ValueError) as cm:
             ds.patch(dict(a=[(slice(1, 10, -1), list(range(10)))]))
-        self.assertEqual(str(cm.exception), "Patch slices must have non-negative (start, stop, step) values, got slice(1, 10, -1)")
+            assert str(cm.exception) == "Patch slices must have non-negative (start, stop, step) values, got slice(1, 10, -1)"
 
 
     def test_patch_good_slice_indices(self):
@@ -618,78 +595,73 @@ Lime,Green,99,$0.39
             stuff['kw'] = kw
         ds.data._patch = mock
         ds.patch(dict(a=[(slice(2), [100, 101]), (slice(3, 5), [100, 101])], b=[(slice(0, None, 2), [100, 101, 102])]), mock_setter)
-        self.assertEqual(stuff['args'],
-            ("doc", ds, dict(a=[(slice(2), [100, 101]), (slice(3, 5), [100, 101])], b=[(slice(0, None, 2), [100, 101, 102])]), mock_setter)
-        )
-        self.assertEqual(stuff['kw'], {})
+        assert stuff['args'] == ("doc", ds, dict(a=[(slice(2), [100, 101]), (slice(3, 5), [100, 101])], b=[(slice(0, None, 2), [100, 101, 102])]), mock_setter)
+        assert stuff['kw'] == {}
 
     def test_data_column_lengths(self):
         # TODO: use this when soft=False
         #
-        #with self.assertRaises(ValueError):
+        #with pytest.raises(ValueError):
         #    ColumnDataSource(data=dict(a=[10, 11], b=[20, 21, 22]))
         #
         #ds = ColumnDataSource()
-        #with self.assertRaises(ValueError):
+        #with pytest.raises(ValueError):
         #    ds.data = dict(a=[10, 11], b=[20, 21, 22])
         #
         #ds = ColumnDataSource(data=dict(a=[10, 11]))
-        #with self.assertRaises(ValueError):
+        #with pytest.raises(ValueError):
         #    ds.data["b"] = [20, 21, 22]
         #
         #ds = ColumnDataSource(data=dict(a=[10, 11], b=[20, 21]))
-        #with self.assertRaises(ValueError):
+        #with pytest.raises(ValueError):
         #    ds.data.update(dict(a=[10, 11, 12]))
 
         with warnings.catch_warnings(record=True) as warns:
             ColumnDataSource(data=dict(a=[10, 11], b=[20, 21, 22]))
-            self.assertEquals(len(warns), 1)
-            self.assertEquals(str(warns[0].message), "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 2), ('b', 3)")
+            assert len(warns) == 1
+            assert str(warns[0].message) == "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 2), ('b', 3)"
 
         ds = ColumnDataSource()
         with warnings.catch_warnings(record=True) as warns:
             ds.data = dict(a=[10, 11], b=[20, 21, 22])
-            self.assertEquals(len(warns), 1)
-            self.assertEquals(str(warns[0].message), "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 2), ('b', 3)")
+            assert len(warns) == 1
+            assert str(warns[0].message) == "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 2), ('b', 3)"
 
         ds = ColumnDataSource(data=dict(a=[10, 11]))
         with warnings.catch_warnings(record=True) as warns:
             ds.data["b"] = [20, 21, 22]
-            self.assertEquals(len(warns), 1)
-            self.assertEquals(str(warns[0].message), "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 2), ('b', 3)")
+            assert len(warns) == 1
+            assert str(warns[0].message) == "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 2), ('b', 3)"
 
         ds = ColumnDataSource(data=dict(a=[10, 11], b=[20, 21]))
         with warnings.catch_warnings(record=True) as warns:
             ds.data.update(dict(a=[10, 11, 12]))
-            self.assertEquals(len(warns), 1)
-            self.assertEquals(str(warns[0].message), "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 3), ('b', 2)")
+            assert len(warns) == 1
+            assert str(warns[0].message) == "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 3), ('b', 2)"
 
     def test_set_data_from_json_list(self):
         ds = ColumnDataSource()
         data = {"foo": [1, 2, 3]}
         ds.set_from_json('data', data)
-        self.assertEquals(ds.data, data)
+        assert ds.data == data
 
     def test_set_data_from_json_base64(self):
         ds = ColumnDataSource()
         data = {"foo": np.arange(3)}
         json = transform_column_source_data(data)
         ds.set_from_json('data', json)
-        self.assertTrue(np.array_equal(ds.data["foo"], data["foo"]))
+        assert np.array_equal(ds.data["foo"], data["foo"])
 
     def test_set_data_from_json_nested_base64(self):
         ds = ColumnDataSource()
         data = {"foo": [[np.arange(3)]]}
         json = transform_column_source_data(data)
         ds.set_from_json('data', json)
-        self.assertTrue(np.array_equal(ds.data["foo"], data["foo"]))
+        assert np.array_equal(ds.data["foo"], data["foo"])
 
     def test_set_data_from_json_nested_base64_and_list(self):
         ds = ColumnDataSource()
         data = {"foo": [np.arange(3), [1, 2, 3]]}
         json = transform_column_source_data(data)
         ds.set_from_json('data', json)
-        self.assertTrue(np.array_equal(ds.data["foo"], data["foo"]))
-
-if __name__ == "__main__":
-    unittest.main()
+        assert np.array_equal(ds.data["foo"], data["foo"])

--- a/bokeh/plotting/tests/test_figure.py
+++ b/bokeh/plotting/tests/test_figure.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
-import unittest
 import pytest
-import pandas as pd
 
 from bokeh.core.properties import value
 from bokeh.models import (
@@ -15,165 +13,171 @@ from bokeh.models import (
     ResetTool,
     Title,
 )
+from bokeh.util.testing import pd; pd
 
 import bokeh.plotting as plt
 
-
-
-class TestFigure(unittest.TestCase):
+class TestFigure(object):
 
     def test_basic(self):
         p = plt.figure()
         q = plt.figure()
         q.circle([1, 2, 3], [1, 2, 3])
-        self.assertNotEqual(p, q)
+        assert p != q
+
         r = plt.figure()
-        self.assertNotEqual(p, r)
-        self.assertNotEqual(q, r)
+        assert p != r
+        assert q != r
+
         p = plt.figure(width=100, height=120)
-        self.assertEqual(p.plot_width, 100)
-        self.assertEqual(p.plot_height, 120)
+        assert p.plot_width == 100
+        assert p.plot_height == 120
+
         p = plt.figure(plot_width=100, plot_height=120)
-        self.assertEqual(p.plot_width, 100)
-        self.assertEqual(p.plot_height, 120)
-        self.assertRaises(ValueError, plt.figure, plot_width=100, width=120)
-        self.assertRaises(ValueError, plt.figure, plot_height=100, height=120)
+        assert p.plot_width == 100
+        assert p.plot_height == 120
+
+        with pytest.raises(ValueError):
+            plt.figure(plot_width=100, width=120)
+
+        with pytest.raises(ValueError):
+            plt.figure(plot_height=100, height=120)
 
     def test_xaxis(self):
         p = plt.figure()
         p.circle([1, 2, 3], [1, 2, 3])
-        self.assertEqual(len(p.xaxis), 1)
+        assert len(p.xaxis) == 1
 
         expected = set(p.xaxis)
 
         ax = LinearAxis()
         expected.add(ax)
         p.above.append(ax)
-        self.assertEqual(set(p.xaxis), expected)
+        assert set(p.xaxis) == expected
 
         ax2 = LinearAxis()
         expected.add(ax2)
         p.above.append(ax2)
-        self.assertEqual(set(p.xaxis), expected)
+        assert set(p.xaxis) == expected
 
         p.left.append(LinearAxis())
-        self.assertEqual(set(p.xaxis), expected)
+        assert set(p.xaxis) == expected
 
         p.right.append(LinearAxis())
-        self.assertEqual(set(p.xaxis), expected)
+        assert set(p.xaxis) == expected
 
     def test_yaxis(self):
         p = plt.figure()
         p.circle([1, 2, 3], [1, 2, 3])
-        self.assertEqual(len(p.yaxis), 1)
+        assert len(p.yaxis) == 1
 
         expected = set(p.yaxis)
 
         ax = LinearAxis()
         expected.add(ax)
         p.right.append(ax)
-        self.assertEqual(set(p.yaxis), expected)
+        assert set(p.yaxis) == expected
 
         ax2 = LinearAxis()
         expected.add(ax2)
         p.right.append(ax2)
-        self.assertEqual(set(p.yaxis), expected)
+        assert set(p.yaxis) == expected
 
         p.above.append(LinearAxis())
-        self.assertEqual(set(p.yaxis), expected)
+        assert set(p.yaxis) == expected
 
         p.below.append(LinearAxis())
-        self.assertEqual(set(p.yaxis), expected)
+        assert set(p.yaxis) == expected
 
     def test_axis(self):
         p = plt.figure()
         p.circle([1, 2, 3], [1, 2, 3])
-        self.assertEqual(len(p.axis), 2)
+        assert len(p.axis) == 2
 
         expected = set(p.axis)
 
         ax = LinearAxis()
         expected.add(ax)
         p.above.append(ax)
-        self.assertEqual(set(p.axis), expected)
+        assert set(p.axis) == expected
 
         ax2 = LinearAxis()
         expected.add(ax2)
         p.below.append(ax2)
-        self.assertEqual(set(p.axis), expected)
+        assert set(p.axis) == expected
 
         ax3 = LinearAxis()
         expected.add(ax3)
         p.left.append(ax3)
-        self.assertEqual(set(p.axis), expected)
+        assert set(p.axis) == expected
 
         ax4 = LinearAxis()
         expected.add(ax4)
         p.right.append(ax4)
-        self.assertEqual(set(p.axis), expected)
+        assert set(p.axis) == expected
 
     def test_log_axis(self):
         p = plt.figure(x_axis_type='log')
         p.circle([1, 2, 3], [1, 2, 3])
-        self.assertIsInstance(p.x_scale, LogScale)
+        assert isinstance(p.x_scale, LogScale)
 
         p = plt.figure(y_axis_type='log')
         p.circle([1, 2, 3], [1, 2, 3])
-        self.assertIsInstance(p.y_scale, LogScale)
+        assert isinstance(p.y_scale, LogScale)
 
     def test_xgrid(self):
         p = plt.figure()
         p.circle([1, 2, 3], [1, 2, 3])
-        self.assertEqual(len(p.xgrid), 1)
-        self.assertEqual(p.xgrid[0].dimension, 0)
+        assert len(p.xgrid) == 1
+        assert p.xgrid[0].dimension == 0
 
     def test_ygrid(self):
         p = plt.figure()
         p.circle([1, 2, 3], [1, 2, 3])
-        self.assertEqual(len(p.ygrid), 1)
-        self.assertEqual(p.ygrid[0].dimension, 1)
+        assert len(p.ygrid) == 1
+        assert p.ygrid[0].dimension == 1
 
     def test_grid(self):
         p = plt.figure()
         p.circle([1, 2, 3], [1, 2, 3])
-        self.assertEqual(len(p.grid), 2)
+        assert len(p.grid) == 2
 
     def test_tools(self):
         TOOLS = "pan,box_zoom,reset,lasso_select"
         fig = plt.figure(tools=TOOLS)
         expected = [PanTool, BoxZoomTool, ResetTool, LassoSelectTool]
 
-        self.assertEqual(len(fig.tools), len(expected))
+        assert len(fig.tools) == len(expected)
         for i, _type in enumerate(expected):
-            self.assertIsInstance(fig.tools[i], _type)
+            assert isinstance(fig.tools[i], _type)
 
     def test_plot_fill_props(self):
         p = plt.figure(background_fill_color='red',
                        background_fill_alpha=0.5,
                        border_fill_color='blue',
                        border_fill_alpha=0.8)
-        self.assertEqual(p.background_fill_color, 'red')
-        self.assertEqual(p.background_fill_alpha, 0.5)
-        self.assertEqual(p.border_fill_color, 'blue')
-        self.assertEqual(p.border_fill_alpha, 0.8)
+        assert p.background_fill_color == 'red'
+        assert p.background_fill_alpha == 0.5
+        assert p.border_fill_color == 'blue'
+        assert p.border_fill_alpha == 0.8
 
         p.background_fill_color = 'green'
         p.border_fill_color = 'yellow'
-        self.assertEqual(p.background_fill_color, 'green')
-        self.assertEqual(p.border_fill_color, 'yellow')
+        assert p.background_fill_color == 'green'
+        assert p.border_fill_color == 'yellow'
 
     def test_columnsource_auto_conversion_from_dict(self):
         p = plt.figure()
         dct = {'x': [1, 2, 3], 'y': [2, 3, 4]}
         p.circle(x='x', y='y', source=dct)
 
-    def test_columnsource_auto_conversion_from_pandas(self):
+    def test_columnsource_auto_conversion_from_pandas(self, pd):
         p = plt.figure()
         df = pd.DataFrame({'x': [1, 2, 3], 'y': [2, 3, 4]})
         p.circle(x='x', y='y', source=df)
 
 
-class TestMarkers(unittest.TestCase):
+class TestMarkers(object):
 
     def check_each_color_input(self, rgbs, func):
         """Runs assertions for each rgb provided with the given function."""
@@ -184,19 +188,21 @@ class TestMarkers(unittest.TestCase):
     def color_only_checks(self, p, rgb):
         """Helper method for checks specific to color= input."""
         p.circle([1, 2, 3], [1, 2, 3], color=rgb)
-        self.assertTupleEqual(p.renderers[-1].glyph.line_color, rgb)
-        self.assertTupleEqual(p.renderers[-1].glyph.fill_color, rgb)
+        assert p.renderers[-1].glyph.line_color == rgb
+        assert p.renderers[-1].glyph.fill_color == rgb
 
         # rgb should always be an integer by the time it is added to property
-        [self.assertIsInstance(v, int) for v in p.renderers[-1].glyph.line_color[0:3]]
-        [self.assertIsInstance(v, int) for v in p.renderers[-1].glyph.fill_color[0:3]]
+        for v in p.renderers[-1].glyph.line_color[0:3]:
+            assert isinstance(v, int)
+            assert isinstance(v, int)
 
     def line_color_input_checks(self, p, rgb):
         """Helper method for checks specific to line_color= only input."""
         p.circle([1, 2, 3], [1, 2, 3], line_color=rgb)
-        self.assertTupleEqual(p.renderers[-1].glyph.line_color, rgb)
+        assert p.renderers[-1].glyph.line_color == rgb
         # should always be an integer by the time it is added to property
-        [self.assertIsInstance(v, int) for v in p.renderers[-1].glyph.line_color[0:3]]
+        for v in p.renderers[-1].glyph.line_color[0:3]:
+            assert isinstance(v, int)
 
     def test_mixed_inputs(self):
         """Helper method to test mixed global and specific color args."""
@@ -209,19 +215,19 @@ class TestMarkers(unittest.TestCase):
 
         # color/line_color
         p.circle([1, 2, 3], [1, 2, 3], color=rgb, line_color=rgb_other)
-        self.assertTupleEqual(p.renderers[-1].glyph.fill_color, rgb)
-        self.assertTupleEqual(p.renderers[-1].glyph.line_color, rgb_other)
+        assert p.renderers[-1].glyph.fill_color == rgb
+        assert p.renderers[-1].glyph.line_color == rgb_other
 
         # color/fill_color
         p.circle([1, 2, 3], [1, 2, 3], color=rgb, fill_color=rgb_other)
-        self.assertTupleEqual(p.renderers[-1].glyph.line_color, rgb)
-        self.assertTupleEqual(p.renderers[-1].glyph.fill_color, rgb_other)
+        assert p.renderers[-1].glyph.line_color == rgb
+        assert p.renderers[-1].glyph.fill_color == rgb_other
 
         # alpha/line_alpha
         p.circle([1, 2, 3], [1, 2, 3], color=rgb, alpha=alpha1,
                  line_alpha=alpha2)
-        self.assertEqual(p.renderers[-1].glyph.line_alpha, alpha2)
-        self.assertEqual(p.renderers[-1].glyph.fill_alpha, alpha1)
+        assert p.renderers[-1].glyph.line_alpha == alpha2
+        assert p.renderers[-1].glyph.fill_alpha == alpha1
 
     def test_color_input_float(self):
         """Test input of rgb with float values."""
@@ -238,8 +244,8 @@ class TestMarkers(unittest.TestCase):
     def test_render_level(self):
         p = plt.figure()
         p.circle([1, 2, 3], [1, 2, 3], level="underlay")
-        self.assertEqual(p.renderers[-1].level, "underlay")
-        with self.assertRaises(ValueError):
+        assert p.renderers[-1].level == "underlay"
+        with pytest.raises(ValueError):
             p.circle([1, 2, 3], [1, 2, 3], level="bad_input")
 
 
@@ -320,7 +326,7 @@ def test_glyph_label_is_value_if_column_not_in_datasource_is_added_as_legend(p, 
     assert len(legends) == 1
     assert legends[0].items[0].label == {'value': 'milk'}
 
-def test_glyph_label_is_legend_if_column_in_df_datasource_is_added_as_legend(p):
+def test_glyph_label_is_legend_if_column_in_df_datasource_is_added_as_legend(p, pd):
     source = pd.DataFrame(data=dict(x=[1, 2, 3], y=[1, 2, 3], label=['a', 'b', 'c']))
     p.circle(x='x', y='y', legend='label', source=source)
     legends = p.select(Legend)
@@ -328,7 +334,7 @@ def test_glyph_label_is_legend_if_column_in_df_datasource_is_added_as_legend(p):
     assert legends[0].items[0].label == {'field': 'label'}
 
 
-def test_glyph_label_is_value_if_column_not_in_df_datasource_is_added_as_legend(p):
+def test_glyph_label_is_value_if_column_not_in_df_datasource_is_added_as_legend(p, pd):
     source = pd.DataFrame(data=dict(x=[1, 2, 3], y=[1, 2, 3], label=['a', 'b', 'c']))
     p.circle(x='x', y='y', legend='milk', source=source)
     legends = p.select(Legend)
@@ -400,7 +406,7 @@ def test_compound_legend_behavior_initiated_if_labels_are_same_on_multiple_rende
 
 # XXX (bev) this doesn't work yet because compound behaviour depends on renderer sources
 # matching, but passing a df means every renderer gets its own new source
-# def test_compound_legend_behavior_initiated_if_labels_are_same_on_multiple_renderers_and_are_field_with_df_source(p):
+# def test_compound_legend_behavior_initiated_if_labels_are_same_on_multiple_renderers_and_are_field_with_df_source(p, pd):
 #     source = pd.DataFrame(data=dict(x=[1, 2, 3], y=[1, 2, 3], label=['a', 'b', 'c']))
 #     # label is a field
 #     square = p.square(x='x', y='y', legend='label', source=source)

--- a/bokeh/plotting/tests/test_helpers.py
+++ b/bokeh/plotting/tests/test_helpers.py
@@ -1,13 +1,7 @@
 import datetime
 from mock import mock
-from unittest import skipIf
 
 import numpy as np
-try:
-    import pandas as pd
-    is_pandas = True
-except ImportError as e:
-    is_pandas = False
 import pytest
 
 from bokeh.models import ColumnDataSource, CDSView, Marker
@@ -16,6 +10,7 @@ from bokeh.models.ranges import Range1d, DataRange1d, FactorRange
 from bokeh.models.scales import LinearScale, LogScale, CategoricalScale
 from bokeh.plotting import Figure
 from bokeh.plotting.helpers import _get_scale,_get_range, _stack, _graph, _glyph_function, _RENDERER_ARGS, _get_axis_class
+from bokeh.util.testing import pd; pd
 
 import bokeh.plotting.helpers as bph
 
@@ -140,8 +135,7 @@ def test__stack_broadcast_name_list_overrides():
         assert kw['bar'] == "baz"
         assert kw['name'] == names[i]
 
-@skipIf(not is_pandas, "pandas not installed")
-def test__graph_will_convert_dataframes_to_sources():
+def test__graph_will_convert_dataframes_to_sources(pd):
     node_source = pd.DataFrame(data=dict(foo=[]))
     edge_source = pd.DataFrame(data=dict(start=[], end=[], bar=[]))
 
@@ -297,15 +291,13 @@ def test__get_range_with_ndarray_factors():
     assert isinstance(r, FactorRange)
     assert r.factors == list(f)
 
-@skipIf(not is_pandas, "pandas not installed")
-def test__get_range_with_series():
+def test__get_range_with_series(pd):
     r = _get_range(pd.Series([20, 30]))
     assert isinstance(r, Range1d)
     assert r.start == 20
     assert r.end == 30
 
-@skipIf(not is_pandas, "pandas not installed")
-def test__get_range_with_too_long_series():
+def test__get_range_with_too_long_series(pd):
     with pytest.raises(ValueError):
         _get_range(pd.Series([20, 30, 40]))
 
@@ -328,7 +320,7 @@ def test__get_range_with_float_bounds():
     assert r.start == 1.2
     assert r.end == 10
 
-def test_get_range_with_pandas_group():
+def test_get_range_with_pandas_group(pd):
     from bokeh.sampledata.iris import flowers
     g = flowers.groupby('species')
     r = _get_range(g)

--- a/bokeh/protocol/messages/tests/test_patch_doc.py
+++ b/bokeh/protocol/messages/tests/test_patch_doc.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, print_function
 
-import unittest
 from json import loads
 
 import pytest
@@ -23,7 +22,7 @@ class SomeModelInTestPatchDoc(Model):
     foo = Int(2)
     child = Instance(Model)
 
-class TestPatchDocument(unittest.TestCase):
+class TestPatchDocument(object):
 
     def _sample_doc(self):
         doc = document.Document()
@@ -101,40 +100,40 @@ class TestPatchDocument(unittest.TestCase):
         event = ModelChangedEvent(sample, root, 'child', root.child, new_child, new_child)
         msg = Protocol("1.0").create("PATCH-DOC", [event])
         msg.apply_to_document(sample, mock_session)
-        self.assertEqual(msg.buffers, [])
+        assert msg.buffers == []
 
         # RootAdded
         event2 = RootAddedEvent(sample, root)
         msg2 = Protocol("1.0").create("PATCH-DOC", [event2])
         msg2.apply_to_document(sample, mock_session)
-        self.assertEqual(msg2.buffers, [])
+        assert msg2.buffers == []
 
         # RootRemoved
         event3 = RootRemovedEvent(sample, root)
         msg3 = Protocol("1.0").create("PATCH-DOC", [event3])
         msg3.apply_to_document(sample, mock_session)
-        self.assertEqual(msg3.buffers, [])
+        assert msg3.buffers == []
 
         # ColumnsStreamed
         event4 = ModelChangedEvent(sample, cds, 'data', 10, None, None,
                                    hint=ColumnsStreamedEvent(sample, cds, {"a": [3]}, None, mock_session))
         msg4 = Protocol("1.0").create("PATCH-DOC", [event4])
         msg4.apply_to_document(sample, mock_session)
-        self.assertEqual(msg4.buffers, [])
+        assert msg4.buffers == []
 
         # ColumnsPatched
         event5 = ModelChangedEvent(sample, cds, 'data', 10, None, None,
                                    hint=ColumnsPatchedEvent(sample, cds, {"a": [(0, 11)]}))
         msg5 = Protocol("1.0").create("PATCH-DOC", [event5])
         msg5.apply_to_document(sample, mock_session)
-        self.assertEqual(msg5.buffers, [])
+        assert msg5.buffers == []
 
         # ColumnDataChanged, use_buffers=False
         event6 = ModelChangedEvent(sample, cds, 'data', {'a': np.array([0., 1.])}, None, None,
                                    hint=ColumnDataChangedEvent(sample, cds))
         msg6 = Protocol("1.0").create("PATCH-DOC", [event6], use_buffers=False)
         msg6.apply_to_document(sample, mock_session)
-        self.assertEqual(msg6.buffers, [])
+        assert msg6.buffers == []
 
         print(cds.data)
         # ColumnDataChanged, use_buffers=True
@@ -143,15 +142,15 @@ class TestPatchDocument(unittest.TestCase):
         msg7 = Protocol("1.0").create("PATCH-DOC", [event7])
         # can't test apply, doc not set up to *receive* binary buffers
         # msg7.apply_to_document(sample, mock_session)
-        self.assertEqual(len(msg7.buffers), 1)
+        assert len(msg7.buffers) == 1
         buf = msg7.buffers.pop()
-        self.assertEqual(len(buf), 2)
-        self.assertTrue(isinstance(buf[0], dict))
-        self.assertTrue(list(buf[0]) == ['id'])
+        assert len(buf) == 2
+        assert isinstance(buf[0], dict)
+        assert list(buf[0]) == ['id']
 
         # reports CDS buffer *as it is* Normally events called by setter and
         # value in local object would have been already mutated.
-        self.assertEqual(buf[1], np.array([11., 1., 2., 3]).tobytes())
+        assert buf[1] == np.array([11., 1., 2., 3]).tobytes()
 
 class _Event(object):
     def __init__(self, refs, bufs):

--- a/bokeh/protocol/messages/tests/test_pull_doc.py
+++ b/bokeh/protocol/messages/tests/test_pull_doc.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, print_function
 
-import unittest
-
 import bokeh.document as document
 from bokeh.model import Model
 from bokeh.core.properties import Int, Instance
@@ -14,7 +12,7 @@ class SomeModelInTestPullDoc(Model):
     foo = Int(2)
     child = Instance(Model)
 
-class TestPullDocument(unittest.TestCase):
+class TestPullDocument(object):
 
     def _sample_doc(self):
         doc = document.Document()

--- a/bokeh/protocol/messages/tests/test_push_doc.py
+++ b/bokeh/protocol/messages/tests/test_push_doc.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, print_function
 
-import unittest
-
 import bokeh.document as document
 from bokeh.model import Model
 from bokeh.core.properties import Int, Instance
@@ -14,7 +12,7 @@ class SomeModelInTestPushDoc(Model):
     foo = Int(2)
     child = Instance(Model)
 
-class TestPushDocument(unittest.TestCase):
+class TestPushDocument(object):
 
     def _sample_doc(self):
         doc = document.Document()

--- a/bokeh/sampledata/tests/test_airport_routes.py
+++ b/bokeh/sampledata/tests/test_airport_routes.py
@@ -20,10 +20,9 @@ import pytest ; pytest
 # Standard library imports
 
 # External imports
-import pandas as pd
 
 # Bokeh imports
-from bokeh.util.testing import verify_all
+from bokeh.util.testing import pd, verify_all ; pd
 
 # Module under test
 #import bokeh.sampledata.airport_routes as bsa
@@ -44,14 +43,14 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.airport_routes", ALL))
 
 @pytest.mark.sampledata
-def test_airports():
+def test_airports(pd):
     import bokeh.sampledata.airport_routes as bsa
     assert isinstance(bsa.airports, pd.DataFrame)
 
     # don't check detail for external data
 
 @pytest.mark.sampledata
-def test_routes():
+def test_routes(pd):
     import bokeh.sampledata.airport_routes as bsa
     assert isinstance(bsa.routes, pd.DataFrame)
 

--- a/bokeh/sampledata/tests/test_airports.py
+++ b/bokeh/sampledata/tests/test_airports.py
@@ -20,10 +20,9 @@ import pytest ; pytest
 # Standard library imports
 
 # External imports
-import pandas as pd
 
 # Bokeh imports
-from bokeh.util.testing import verify_all
+from bokeh.util.testing import pd, verify_all ; pd
 
 # Module under test
 #import bokeh.sampledata.airports as bsa
@@ -43,7 +42,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.airports", ALL))
 
 @pytest.mark.sampledata
-def test_data():
+def test_data(pd):
     import bokeh.sampledata.airports as bsa
     assert isinstance(bsa.data, pd.DataFrame)
 

--- a/bokeh/sampledata/tests/test_autompg.py
+++ b/bokeh/sampledata/tests/test_autompg.py
@@ -20,10 +20,9 @@ import pytest ; pytest
 # Standard library imports
 
 # External imports
-import pandas as pd
 
 # Bokeh imports
-from bokeh.util.testing import verify_all
+from bokeh.util.testing import pd, verify_all ; pd
 
 # Module under test
 #import bokeh.sampledata.autompg as bsa
@@ -44,7 +43,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.autompg", ALL))
 
 @pytest.mark.sampledata
-def test_autompg():
+def test_autompg(pd):
     import bokeh.sampledata.autompg as bsa
     assert isinstance(bsa.autompg, pd.DataFrame)
 
@@ -53,7 +52,7 @@ def test_autompg():
     assert all(x in [1,2,3] for x in bsa.autompg.origin)
 
 @pytest.mark.sampledata
-def test_autompg_clean():
+def test_autompg_clean(pd):
     import bokeh.sampledata.autompg as bsa
     assert isinstance(bsa.autompg_clean, pd.DataFrame)
 

--- a/bokeh/sampledata/tests/test_autompg2.py
+++ b/bokeh/sampledata/tests/test_autompg2.py
@@ -20,10 +20,9 @@ import pytest ; pytest
 # Standard library imports
 
 # External imports
-import pandas as pd
 
 # Bokeh imports
-from bokeh.util.testing import verify_all
+from bokeh.util.testing import pd, verify_all ; pd
 
 # Module under test
 #import bokeh.sampledata.autompg2 as bsa
@@ -43,7 +42,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.autompg2", ALL))
 
 @pytest.mark.sampledata
-def test_autompg2():
+def test_autompg2(pd):
     import bokeh.sampledata.autompg2 as bsa
     assert isinstance(bsa.autompg2, pd.DataFrame)
 

--- a/bokeh/sampledata/tests/test_browsers.py
+++ b/bokeh/sampledata/tests/test_browsers.py
@@ -20,10 +20,9 @@ import pytest ; pytest
 # Standard library imports
 
 # External imports
-import pandas as pd
 
 # Bokeh imports
-from bokeh.util.testing import verify_all
+from bokeh.util.testing import pd, verify_all ; pd
 
 # Module under test
 #import bokeh.sampledata.browsers as bsb
@@ -44,7 +43,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.browsers", ALL))
 
 @pytest.mark.sampledata
-def test_browsers_nov_2013():
+def test_browsers_nov_2013(pd):
     import bokeh.sampledata.browsers as bsb
     assert isinstance(bsb.browsers_nov_2013, pd.DataFrame)
 

--- a/bokeh/sampledata/tests/test_commits.py
+++ b/bokeh/sampledata/tests/test_commits.py
@@ -20,10 +20,9 @@ import pytest ; pytest
 # Standard library imports
 
 # External imports
-import pandas as pd
 
 # Bokeh imports
-from bokeh.util.testing import verify_all
+from bokeh.util.testing import pd, verify_all ; pd
 
 # Module under test
 #import bokeh.sampledata.commits as bsc
@@ -43,7 +42,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.commits", ALL))
 
 @pytest.mark.sampledata
-def test_data():
+def test_data(pd):
     import bokeh.sampledata.commits as bsc
     assert isinstance(bsc.data, pd.DataFrame)
 

--- a/bokeh/sampledata/tests/test_daylight.py
+++ b/bokeh/sampledata/tests/test_daylight.py
@@ -20,10 +20,9 @@ import pytest ; pytest
 # Standard library imports
 
 # External imports
-import pandas as pd
 
 # Bokeh imports
-from bokeh.util.testing import verify_all
+from bokeh.util.testing import pd, verify_all ; pd
 
 # Module under test
 #import bokeh.sampledata.daylight as bsd
@@ -43,7 +42,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.daylight", ALL))
 
 @pytest.mark.sampledata
-def test_daylight_warsaw_2013():
+def test_daylight_warsaw_2013(pd):
     import bokeh.sampledata.daylight as bsd
     assert isinstance(bsd.daylight_warsaw_2013, pd.DataFrame)
 

--- a/bokeh/sampledata/tests/test_degrees.py
+++ b/bokeh/sampledata/tests/test_degrees.py
@@ -20,10 +20,9 @@ import pytest ; pytest
 # Standard library imports
 
 # External imports
-import pandas as pd
 
 # Bokeh imports
-from bokeh.util.testing import verify_all
+from bokeh.util.testing import pd, verify_all ; pd
 
 # Module under test
 #import bokeh.sampledata.degrees as bsd
@@ -43,7 +42,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.degrees", ALL))
 
 @pytest.mark.sampledata
-def test_data():
+def test_data(pd):
     import bokeh.sampledata.degrees as bsd
     assert isinstance(bsd.data, pd.DataFrame)
 

--- a/bokeh/sampledata/tests/test_gapminder.py
+++ b/bokeh/sampledata/tests/test_gapminder.py
@@ -20,10 +20,9 @@ import pytest ; pytest
 # Standard library imports
 
 # External imports
-import pandas as pd
 
 # Bokeh imports
-from bokeh.util.testing import verify_all
+from bokeh.util.testing import pd, verify_all ; pd
 
 # Module under test
 #import bokeh.sampledata.gapminder as bsg
@@ -47,7 +46,7 @@ Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.gapminder", A
 
 @pytest.mark.sampledata
 @pytest.mark.parametrize('name', ['fertility', 'life_expectancy', 'population', 'regions'])
-def test_data(name):
+def test_data(pd, name):
     import bokeh.sampledata.gapminder as bsg
     data = getattr(bsg, name)
     assert isinstance(data, pd.DataFrame)

--- a/bokeh/sampledata/tests/test_glucose.py
+++ b/bokeh/sampledata/tests/test_glucose.py
@@ -20,10 +20,9 @@ import pytest ; pytest
 # Standard library imports
 
 # External imports
-import pandas as pd
 
 # Bokeh imports
-from bokeh.util.testing import verify_all
+from bokeh.util.testing import pd, verify_all ; pd
 
 # Module under test
 #import bokeh.sampledata.glucose as bsg
@@ -43,7 +42,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.glucose", ALL))
 
 @pytest.mark.sampledata
-def test_data():
+def test_data(pd):
     import bokeh.sampledata.glucose as bsg
     assert isinstance(bsg.data, pd.DataFrame)
 

--- a/bokeh/sampledata/tests/test_iris.py
+++ b/bokeh/sampledata/tests/test_iris.py
@@ -20,10 +20,9 @@ import pytest ; pytest
 # Standard library imports
 
 # External imports
-import pandas as pd
 
 # Bokeh imports
-from bokeh.util.testing import verify_all
+from bokeh.util.testing import pd, verify_all ; pd
 
 # Module under test
 #import bokeh.sampledata.iris as bsi
@@ -43,7 +42,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.iris", ALL))
 
 @pytest.mark.sampledata
-def test_flowers():
+def test_flowers(pd):
     import bokeh.sampledata.iris as bsi
     assert isinstance(bsi.flowers, pd.DataFrame)
 

--- a/bokeh/sampledata/tests/test_mtb.py
+++ b/bokeh/sampledata/tests/test_mtb.py
@@ -20,10 +20,9 @@ import pytest ; pytest
 # Standard library imports
 
 # External imports
-import pandas as pd
 
 # Bokeh imports
-from bokeh.util.testing import verify_all
+from bokeh.util.testing import pd, verify_all ; pd
 
 # Module under test
 #import bokeh.sampledata.mtb as bsm
@@ -43,7 +42,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.mtb", ALL))
 
 @pytest.mark.sampledata
-def test_obiszow_mtb_xcm():
+def test_obiszow_mtb_xcm(pd):
     import bokeh.sampledata.mtb as bsm
     assert isinstance(bsm.obiszow_mtb_xcm, pd.DataFrame)
 

--- a/bokeh/sampledata/tests/test_perceptions.py
+++ b/bokeh/sampledata/tests/test_perceptions.py
@@ -20,10 +20,9 @@ import pytest ; pytest
 # Standard library imports
 
 # External imports
-import pandas as pd
 
 # Bokeh imports
-from bokeh.util.testing import verify_all
+from bokeh.util.testing import pd, verify_all ; pd
 
 # Module under test
 #import bokeh.sampledata.perceptions as bsp
@@ -44,7 +43,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.perceptions", ALL))
 
 @pytest.mark.sampledata
-def test_numberly():
+def test_numberly(pd):
     import bokeh.sampledata.perceptions as bsp
     assert isinstance(bsp.numberly, pd.DataFrame)
 
@@ -52,7 +51,7 @@ def test_numberly():
     assert len(bsp.numberly) == 46
 
 @pytest.mark.sampledata
-def test_probly():
+def test_probly(pd):
     import bokeh.sampledata.perceptions as bsp
     assert isinstance(bsp.probly, pd.DataFrame)
 

--- a/bokeh/sampledata/tests/test_periodic_table.py
+++ b/bokeh/sampledata/tests/test_periodic_table.py
@@ -20,10 +20,9 @@ import pytest ; pytest
 # Standard library imports
 
 # External imports
-import pandas as pd
 
 # Bokeh imports
-from bokeh.util.testing import verify_all
+from bokeh.util.testing import pd, verify_all ; pd
 
 # Module under test
 #import bokeh.sampledata.periodic_table as bsp
@@ -43,7 +42,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.periodic_table", ALL))
 
 @pytest.mark.sampledata
-def test_elements():
+def test_elements(pd):
     import bokeh.sampledata.periodic_table as bsp
     assert isinstance(bsp.elements, pd.DataFrame)
 

--- a/bokeh/sampledata/tests/test_population.py
+++ b/bokeh/sampledata/tests/test_population.py
@@ -20,10 +20,9 @@ import pytest ; pytest
 # Standard library imports
 
 # External imports
-import pandas as pd
 
 # Bokeh imports
-from bokeh.util.testing import verify_all
+from bokeh.util.testing import pd, verify_all ; pd
 
 # Module under test
 #import bokeh.sampledata.population as bsp
@@ -43,7 +42,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.population", ALL))
 
 @pytest.mark.sampledata
-def test_data():
+def test_data(pd):
     import bokeh.sampledata.population as bsp
     assert isinstance(bsp.data, pd.DataFrame)
 

--- a/bokeh/sampledata/tests/test_sea_surface_temperature.py
+++ b/bokeh/sampledata/tests/test_sea_surface_temperature.py
@@ -20,10 +20,9 @@ import pytest ; pytest
 # Standard library imports
 
 # External imports
-import pandas as pd
 
 # Bokeh imports
-from bokeh.util.testing import verify_all
+from bokeh.util.testing import pd, verify_all ; pd
 
 # Module under test
 #import bokeh.sampledata.sea_surface_temperature as bss
@@ -43,7 +42,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.sea_surface_temperature", ALL))
 
 @pytest.mark.sampledata
-def test_sea_surface_temperature():
+def test_sea_surface_temperature(pd):
     import bokeh.sampledata.sea_surface_temperature as bss
     assert isinstance(bss.sea_surface_temperature, pd.DataFrame)
 

--- a/bokeh/sampledata/tests/test_sprint.py
+++ b/bokeh/sampledata/tests/test_sprint.py
@@ -20,10 +20,9 @@ import pytest ; pytest
 # Standard library imports
 
 # External imports
-import pandas as pd
 
 # Bokeh imports
-from bokeh.util.testing import verify_all
+from bokeh.util.testing import pd, verify_all ; pd
 
 # Module under test
 #import bokeh.sampledata.sprint as bss
@@ -43,7 +42,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.sprint", ALL))
 
 @pytest.mark.sampledata
-def test_sprint():
+def test_sprint(pd):
     import bokeh.sampledata.sprint as bss
     assert isinstance(bss.sprint, pd.DataFrame)
 

--- a/bokeh/sampledata/tests/test_unemployment1948.py
+++ b/bokeh/sampledata/tests/test_unemployment1948.py
@@ -20,10 +20,9 @@ import pytest ; pytest
 # Standard library imports
 
 # External imports
-import pandas as pd
 
 # Bokeh imports
-from bokeh.util.testing import verify_all
+from bokeh.util.testing import pd, verify_all ; pd
 
 # Module under test
 #import bokeh.sampledata.unemployment1948 as bsu
@@ -43,7 +42,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.unemployment1948", ALL))
 
 @pytest.mark.sampledata
-def test_data():
+def test_data(pd):
     import bokeh.sampledata.unemployment1948 as bsu
     assert isinstance(bsu.data, pd.DataFrame)
 

--- a/bokeh/sampledata/tests/test_us_marriages_divorces.py
+++ b/bokeh/sampledata/tests/test_us_marriages_divorces.py
@@ -20,10 +20,9 @@ import pytest ; pytest
 # Standard library imports
 
 # External imports
-import pandas as pd
 
 # Bokeh imports
-from bokeh.util.testing import verify_all
+from bokeh.util.testing import pd, verify_all ; pd
 
 # Module under test
 #import bokeh.sampledata.us_marriages_divorces as bsu
@@ -43,7 +42,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.us_marriages_divorces", ALL))
 
 @pytest.mark.sampledata
-def test_data():
+def test_data(pd):
     import bokeh.sampledata.us_marriages_divorces as bsu
     assert isinstance(bsu.data, pd.DataFrame)
 

--- a/bokeh/sampledata/tests/test_world_cities.py
+++ b/bokeh/sampledata/tests/test_world_cities.py
@@ -20,10 +20,9 @@ import pytest ; pytest
 # Standard library imports
 
 # External imports
-import pandas as pd
 
 # Bokeh imports
-from bokeh.util.testing import verify_all
+from bokeh.util.testing import pd, verify_all ; pd
 
 # Module under test
 #import bokeh.sampledata.world_cities as bsw
@@ -43,7 +42,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.world_cities", ALL))
 
 @pytest.mark.sampledata
-def test_data():
+def test_data(pd):
     import bokeh.sampledata.world_cities as bsw
     assert isinstance(bsw.data, pd.DataFrame)
 

--- a/bokeh/server/tests/test_callbacks.py
+++ b/bokeh/server/tests/test_callbacks.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, print_function
 
-import unittest
 from concurrent.futures import ThreadPoolExecutor
 from itertools import repeat
 
@@ -49,59 +48,59 @@ class LoopAndGroup(object):
     def __enter__(self):
         return self
 
-class TestCallbackGroup(unittest.TestCase):
+class TestCallbackGroup(object):
     def test_next_tick_runs(self):
         with (LoopAndGroup()) as ctx:
             func = _make_invocation_counter(ctx.io_loop)
-            self.assertEqual(0, len(ctx.group._next_tick_callback_removers))
+            assert 0 == len(ctx.group._next_tick_callback_removers)
             ctx.group.add_next_tick_callback(func)
-            self.assertEqual(1, len(ctx.group._next_tick_callback_removers))
-        self.assertEqual(1, func.count())
+            assert 1 == len(ctx.group._next_tick_callback_removers)
+        assert 1 == func.count()
         # check for leaks
-        self.assertEqual(0, len(ctx.group._next_tick_callback_removers))
+        assert 0 == len(ctx.group._next_tick_callback_removers)
 
     def test_timeout_runs(self):
         with (LoopAndGroup()) as ctx:
             func = _make_invocation_counter(ctx.io_loop)
-            self.assertEqual(0, len(ctx.group._timeout_callback_removers))
+            assert 0 == len(ctx.group._timeout_callback_removers)
             ctx.group.add_timeout_callback(func, timeout_milliseconds=1)
-            self.assertEqual(1, len(ctx.group._timeout_callback_removers))
-        self.assertEqual(1, func.count())
+            assert 1 == len(ctx.group._timeout_callback_removers)
+        assert 1 == func.count()
         # check for leaks
-        self.assertEqual(0, len(ctx.group._timeout_callback_removers))
+        assert 0 == len(ctx.group._timeout_callback_removers)
 
     def test_periodic_runs(self):
         with (LoopAndGroup()) as ctx:
             func = _make_invocation_counter(ctx.io_loop, stop_after=5)
-            self.assertEqual(0, len(ctx.group._periodic_callback_removers))
+            assert 0 == len(ctx.group._periodic_callback_removers)
             cb_id = ctx.group.add_periodic_callback(func, period_milliseconds=1)
-            self.assertEqual(1, len(ctx.group._periodic_callback_removers))
-        self.assertEqual(5, func.count())
+            assert 1 == len(ctx.group._periodic_callback_removers)
+        assert 5 == func.count()
         # check for leaks... periodic doesn't self-remove though
-        self.assertEqual(1, len(ctx.group._periodic_callback_removers))
+        assert 1 == len(ctx.group._periodic_callback_removers)
         ctx.group.remove_periodic_callback(cb_id)
-        self.assertEqual(0, len(ctx.group._periodic_callback_removers))
+        assert 0 == len(ctx.group._periodic_callback_removers)
 
     def test_next_tick_does_not_run_if_removed_immediately(self):
         with (LoopAndGroup(quit_after=15)) as ctx:
             func = _make_invocation_counter(ctx.io_loop)
             cb_id = ctx.group.add_next_tick_callback(func)
             ctx.group.remove_next_tick_callback(cb_id)
-        self.assertEqual(0, func.count())
+        assert 0 == func.count()
 
     def test_timeout_does_not_run_if_removed_immediately(self):
         with (LoopAndGroup(quit_after=15)) as ctx:
             func = _make_invocation_counter(ctx.io_loop)
             cb_id = ctx.group.add_timeout_callback(func, timeout_milliseconds=1)
             ctx.group.remove_timeout_callback(cb_id)
-        self.assertEqual(0, func.count())
+        assert 0 == func.count()
 
     def test_periodic_does_not_run_if_removed_immediately(self):
         with (LoopAndGroup(quit_after=15)) as ctx:
             func = _make_invocation_counter(ctx.io_loop, stop_after=5)
             cb_id = ctx.group.add_periodic_callback(func, period_milliseconds=1)
             ctx.group.remove_periodic_callback(cb_id)
-        self.assertEqual(0, func.count())
+        assert 0 == func.count()
 
     def test_same_callback_as_all_three_types(self):
         with (LoopAndGroup()) as ctx:
@@ -110,28 +109,28 @@ class TestCallbackGroup(unittest.TestCase):
             ctx.group.add_periodic_callback(func, period_milliseconds=2)
             ctx.group.add_timeout_callback(func, timeout_milliseconds=1)
             ctx.group.add_next_tick_callback(func)
-        self.assertEqual(5, func.count())
+        assert 5 == func.count()
 
     def test_adding_next_tick_twice(self):
         with (LoopAndGroup()) as ctx:
             func = _make_invocation_counter(ctx.io_loop, stop_after=2)
             ctx.group.add_next_tick_callback(func)
             ctx.group.add_next_tick_callback(func)
-        self.assertEqual(2, func.count())
+        assert 2 == func.count()
 
     def test_adding_timeout_twice(self):
         with (LoopAndGroup()) as ctx:
             func = _make_invocation_counter(ctx.io_loop, stop_after=2)
             ctx.group.add_timeout_callback(func, timeout_milliseconds=1)
             ctx.group.add_timeout_callback(func, timeout_milliseconds=2)
-        self.assertEqual(2, func.count())
+        assert 2 == func.count()
 
     def test_adding_periodic_twice(self):
         with (LoopAndGroup()) as ctx:
             func = _make_invocation_counter(ctx.io_loop, stop_after=2)
             ctx.group.add_periodic_callback(func, period_milliseconds=3)
             ctx.group.add_periodic_callback(func, period_milliseconds=2)
-        self.assertEqual(2, func.count())
+        assert 2 == func.count()
 
     def test_remove_all_callbacks(self):
         with (LoopAndGroup(quit_after=15)) as ctx:
@@ -144,37 +143,37 @@ class TestCallbackGroup(unittest.TestCase):
             ctx.group.add_periodic_callback(func, period_milliseconds=2)
             ctx.group.add_timeout_callback(func, timeout_milliseconds=1)
             ctx.group.add_next_tick_callback(func)
-        self.assertEqual(0, func.count())
+        assert 0 == func.count()
 
     def test_removing_next_tick_twice(self):
         with (LoopAndGroup(quit_after=15)) as ctx:
             func = _make_invocation_counter(ctx.io_loop)
             cb_id = ctx.group.add_next_tick_callback(func)
             ctx.group.remove_next_tick_callback(cb_id)
-            with (self.assertRaises(ValueError)) as manager:
+            with pytest.raises(ValueError) as exc:
                 ctx.group.remove_next_tick_callback(cb_id)
-        self.assertEqual(0, func.count())
-        self.assertTrue("twice" in repr(manager.exception))
+        assert 0 == func.count()
+        assert "twice" in repr(exc.value)
 
     def test_removing_timeout_twice(self):
         with (LoopAndGroup(quit_after=15)) as ctx:
             func = _make_invocation_counter(ctx.io_loop)
             cb_id = ctx.group.add_timeout_callback(func, timeout_milliseconds=1)
             ctx.group.remove_timeout_callback(cb_id)
-            with (self.assertRaises(ValueError)) as manager:
+            with pytest.raises(ValueError) as exc:
                 ctx.group.remove_timeout_callback(cb_id)
-        self.assertEqual(0, func.count())
-        self.assertTrue("twice" in repr(manager.exception))
+        assert 0 == func.count()
+        assert "twice" in repr(exc.value)
 
     def test_removing_periodic_twice(self):
         with (LoopAndGroup(quit_after=15)) as ctx:
             func = _make_invocation_counter(ctx.io_loop, stop_after=5)
             cb_id = ctx.group.add_periodic_callback(func, period_milliseconds=1)
             ctx.group.remove_periodic_callback(cb_id)
-            with (self.assertRaises(ValueError)) as manager:
+            with pytest.raises(ValueError) as exc:
                 ctx.group.remove_periodic_callback(cb_id)
-        self.assertEqual(0, func.count())
-        self.assertTrue("twice" in repr(manager.exception))
+        assert 0 == func.count()
+        assert "twice" in repr(exc.value)
 
     def test_adding_next_tick_from_another_thread(self):
         # The test has probabilistic nature - there's a slight change it'll give a false negative
@@ -183,7 +182,7 @@ class TestCallbackGroup(unittest.TestCase):
             func = _make_invocation_counter(ctx.io_loop, stop_after=n)
             tpe = ThreadPoolExecutor(n)
             list(tpe.map(ctx.group.add_next_tick_callback, repeat(func, n)))
-        self.assertEqual(n, func.count())
+        assert n == func.count()
 
     def test_deprecated_remove_next_tick_callback(self):
         with LoopAndGroup(quit_after=15) as ctx:
@@ -191,7 +190,7 @@ class TestCallbackGroup(unittest.TestCase):
             ctx.group.add_next_tick_callback(func)
             with pytest.warns(BokehDeprecationWarning):
                 ctx.group.remove_next_tick_callback(func)
-        self.assertEqual(0, func.count())
+        assert 0 == func.count()
 
     def test_deprecated_remove_periodic_callback(self):
         with LoopAndGroup(quit_after=15) as ctx:
@@ -199,7 +198,7 @@ class TestCallbackGroup(unittest.TestCase):
             ctx.group.add_periodic_callback(func, 1)
             with pytest.warns(BokehDeprecationWarning):
                 ctx.group.remove_periodic_callback(func)
-        self.assertEqual(0, func.count())
+        assert 0 == func.count()
 
     def test_deprecated_remove_timeout_callback(self):
         with LoopAndGroup(quit_after=15) as ctx:
@@ -207,4 +206,4 @@ class TestCallbackGroup(unittest.TestCase):
             ctx.group.add_timeout_callback(func, 1)
             with pytest.warns(BokehDeprecationWarning):
                 ctx.group.remove_timeout_callback(func)
-        self.assertEqual(0, func.count())
+        assert 0 == func.count()

--- a/bokeh/tests/test_client_server.py
+++ b/bokeh/tests/test_client_server.py
@@ -609,7 +609,7 @@ class TestClientServer(object):
 
             doc.remove_periodic_callback(cb_id)
 
-            assert dict(a=0, b=1, c=2, d=3, e=4), result.values
+            assert dict(a=0, b=1, c=2, d=3, e=4) == result.values
 
     def test_client_session_periodic_async_added_before_push(self):
         application = Application()

--- a/bokeh/tests/test_client_server.py
+++ b/bokeh/tests/test_client_server.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function
 
 from mock import patch
-import unittest
+import pytest
 
 import logging
 import bokeh.document as document
@@ -35,7 +35,7 @@ class UnitsSpecModel(Model):
 
 logging.basicConfig(level=logging.DEBUG)
 
-class TestClientServer(unittest.TestCase):
+class TestClientServer(object):
 
     def test_minimal_connect_and_disconnect(self):
         application = Application()
@@ -88,13 +88,13 @@ class TestClientServer(unittest.TestCase):
             session.loop_until_closed(suppress_warning=True)
 
     def check_http_gets_fail(self, server):
-        with (self.assertRaises(HTTPError)):
+        with pytest.raises(HTTPError):
             http_get(server.io_loop, url(server))
-        with (self.assertRaises(HTTPError)):
+        with pytest.raises(HTTPError):
             http_get(server.io_loop, url(server) + "autoload.js?bokeh-autoload-element=foo")
 
     def check_connect_session_fails(self, server, origin):
-        with (self.assertRaises(HTTPError)):
+        with pytest.raises(HTTPError):
             websocket_open(server.io_loop,
                            ws_url(server)+"?bokeh-protocol-version=1.0&bokeh-session-id=foo",
                            origin=origin)
@@ -248,13 +248,13 @@ class TestClientServer(unittest.TestCase):
             server._tornado._keep_alive() # send ping
             session.force_roundtrip()
 
-            self.assertEqual(expected_pong, connection._socket.latest_pong)
+            assert expected_pong == connection._socket.latest_pong
 
             # check that each ping increments by 1
             server._tornado._keep_alive()
             session.force_roundtrip()
 
-            self.assertEqual(expected_pong + 1, connection._socket.latest_pong)
+            assert (expected_pong + 1) == connection._socket.latest_pong
 
             session.close()
             session.loop_until_closed(suppress_warning=True)
@@ -403,11 +403,11 @@ class TestClientServer(unittest.TestCase):
 
             client_session.loop_until_closed(suppress_warning=True)
 
-            with (self.assertRaises(ValueError)) as manager:
+            with pytest.raises(ValueError) as exc:
                 doc.remove_timeout_callback(cb_id)
-            self.assertTrue('already removed' in repr(manager.exception))
+            assert 'already removed' in repr(exc.value)
 
-            self.assertDictEqual(dict(a=0, b=1, c=2, d=3, e=4), result.values)
+            assert dict(a=0, b=1, c=2, d=3, e=4) == result.values
 
     def test_client_session_timeout_async_added_before_push(self):
         application = Application()
@@ -436,11 +436,11 @@ class TestClientServer(unittest.TestCase):
 
             client_session.loop_until_closed(suppress_warning=True)
 
-            with (self.assertRaises(ValueError)) as manager:
+            with pytest.raises(ValueError) as exc:
                 doc.remove_timeout_callback(cb_id)
-            self.assertTrue('already removed' in repr(manager.exception))
+            assert 'already removed' in repr(exc.value)
 
-            self.assertDictEqual(dict(a=0, b=1, c=2, d=3, e=4), result.values)
+            assert dict(a=0, b=1, c=2, d=3, e=4) == result.values
 
     def test_server_session_timeout_async(self):
         application = Application()
@@ -472,11 +472,11 @@ class TestClientServer(unittest.TestCase):
 
             client_session.loop_until_closed(suppress_warning=True)
 
-            with (self.assertRaises(ValueError)) as manager:
+            with pytest.raises(ValueError) as exc:
                 server_session.document.remove_timeout_callback(cb_id)
-            self.assertTrue('already removed' in repr(manager.exception))
+            assert 'already removed' in repr(exc.value)
 
-            self.assertDictEqual(dict(a=0, b=1, c=2, d=3, e=4), result.values)
+            assert dict(a=0, b=1, c=2, d=3, e=4) == result.values
 
     def test_client_session_next_tick_async(self):
         application = Application()
@@ -505,11 +505,11 @@ class TestClientServer(unittest.TestCase):
 
             client_session.loop_until_closed(suppress_warning=True)
 
-            with (self.assertRaises(ValueError)) as manager:
+            with pytest.raises(ValueError) as exc:
                 doc.remove_next_tick_callback(cb_id)
-            self.assertTrue('already removed' in repr(manager.exception))
+            assert 'already removed' in repr(exc.value)
 
-            self.assertDictEqual(dict(a=0, b=1, c=2, d=3, e=4), result.values)
+            assert dict(a=0, b=1, c=2, d=3, e=4) == result.values
 
     def test_client_session_next_tick_async_added_before_push(self):
         application = Application()
@@ -538,11 +538,11 @@ class TestClientServer(unittest.TestCase):
 
             client_session.loop_until_closed(suppress_warning=True)
 
-            with (self.assertRaises(ValueError)) as manager:
+            with pytest.raises(ValueError) as exc:
                 doc.remove_next_tick_callback(cb_id)
-            self.assertTrue('already removed' in repr(manager.exception))
+            assert 'already removed' in repr(exc.value)
 
-            self.assertDictEqual(dict(a=0, b=1, c=2, d=3, e=4), result.values)
+            assert dict(a=0, b=1, c=2, d=3, e=4) == result.values
 
     def test_server_session_next_tick_async(self):
         application = Application()
@@ -574,11 +574,11 @@ class TestClientServer(unittest.TestCase):
 
             client_session.loop_until_closed(suppress_warning=True)
 
-            with (self.assertRaises(ValueError)) as manager:
+            with pytest.raises(ValueError) as exc:
                 server_session.document.remove_next_tick_callback(cb_id)
-            self.assertTrue('already removed' in repr(manager.exception))
+            assert 'already removed' in repr(exc.value)
 
-            self.assertDictEqual(dict(a=0, b=1, c=2, d=3, e=4), result.values)
+            assert dict(a=0, b=1, c=2, d=3, e=4) == result.values
 
     def test_client_session_periodic_async(self):
         application = Application()
@@ -609,7 +609,7 @@ class TestClientServer(unittest.TestCase):
 
             doc.remove_periodic_callback(cb_id)
 
-            self.assertDictEqual(dict(a=0, b=1, c=2, d=3, e=4), result.values)
+            assert dict(a=0, b=1, c=2, d=3, e=4), result.values
 
     def test_client_session_periodic_async_added_before_push(self):
         application = Application()
@@ -640,7 +640,7 @@ class TestClientServer(unittest.TestCase):
 
             doc.remove_periodic_callback(cb_id)
 
-            self.assertDictEqual(dict(a=0, b=1, c=2, d=3, e=4), result.values)
+            assert dict(a=0, b=1, c=2, d=3, e=4) == result.values
 
     def test_server_session_periodic_async(self):
         application = Application()
@@ -674,7 +674,7 @@ class TestClientServer(unittest.TestCase):
 
             server_session.document.remove_periodic_callback(cb_id)
 
-            self.assertDictEqual(dict(a=0, b=1, c=2, d=3, e=4), result.values)
+            assert dict(a=0, b=1, c=2, d=3, e=4) == result.values
 
     def test_lots_of_concurrent_messages(self):
         application = Application()
@@ -765,8 +765,6 @@ class TestClientServer(unittest.TestCase):
             assert result['server_connection_count'] == 1
             assert result['server_close_code'] is None
 
-# This isn't in the unittest.TestCase because per-test fixtures
-# don't work there (see note at bottom of https://pytest.org/latest/unittest.html#unittest-testcase)
 def test_client_changes_do_not_boomerang(monkeypatch):
     application = Application()
     with ManagedServerLoop(application) as server:
@@ -813,8 +811,6 @@ def test_client_changes_do_not_boomerang(monkeypatch):
         assert not client_session.connected
         server.unlisten() # clean up so next test can run
 
-# This isn't in the unittest.TestCase because per-test fixtures
-# don't work there (see note at bottom of https://pytest.org/latest/unittest.html#unittest-testcase)
 def test_server_changes_do_not_boomerang(monkeypatch):
     application = Application()
     with ManagedServerLoop(application) as server:

--- a/bokeh/tests/test_objects.py
+++ b/bokeh/tests/test_objects.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import
-import unittest
 
-from six.moves import xrange
 import copy
+
+import pytest
+from six.moves import xrange
+
 from bokeh.core.properties import List, String, Instance, Dict, Any, Int
 from bokeh.model import Model
 from bokeh.core.property.containers import PropertyValueList, PropertyValueDict
@@ -58,14 +60,14 @@ def large_plot(n):
     return col, objects
 
 
-class TestMetaModel(unittest.TestCase):
+class TestMetaModel(object):
 
-    def setUp(self):
+    def setup_method(self):
         from bokeh.model import MetaModel
         self.metamodel = MetaModel
         self.old_map = copy.copy(self.metamodel.model_class_reverse_map)
 
-    def tearDown(self):
+    def teardown_method(self):
         self.metamodel.model_class_reverse_map = self.old_map
 
     def mkclass(self):
@@ -75,24 +77,26 @@ class TestMetaModel(unittest.TestCase):
 
     def test_metaclassing(self):
         tclass = self.mkclass()
-        self.assertTrue(hasattr(tclass, '__view_model__'))
-        self.assertRaises(Warning, self.mkclass)
+        assert hasattr(tclass, '__view_model__')
+        with pytest.raises(Warning):
+            self.mkclass()
 
     def test_get_class(self):
         from bokeh.model import get_class
         self.mkclass()
         tclass = get_class('Test_Class')
-        self.assertTrue(hasattr(tclass, 'foo'))
-        self.assertRaises(KeyError, get_class, 'Imaginary_Class')
+        assert hasattr(tclass, 'foo')
+        with pytest.raises(KeyError):
+            get_class('Imaginary_Class')
 
 class DeepModel(Model):
     child = Instance(Model)
 
-class TestCollectModels(unittest.TestCase):
+class TestCollectModels(object):
 
     def test_references_large(self):
         root, objects = large_plot(10)
-        self.assertEqual(set(root.references()), objects)
+        assert set(root.references()) == objects
 
     def test_references_deep(self):
         root = DeepModel()
@@ -106,16 +110,16 @@ class TestCollectModels(unittest.TestCase):
             objects.add(model)
             parent.child = model
             parent = model
-        self.assertEqual(set(root.references()), objects)
+        assert set(root.references()) == objects
 
 class SomeModelToJson(Model):
     child = Instance(Model)
     foo = Int()
     bar = String()
 
-class TestModel(unittest.TestCase):
+class TestModel(object):
 
-    def setUp(self):
+    def setup_method(self):
         from bokeh.models import Model
 
         self.pObjectClass = Model
@@ -123,22 +127,20 @@ class TestModel(unittest.TestCase):
 
     def test_init(self):
         testObject = self.pObjectClass(id='test_id')
-        self.assertEqual(testObject._id, 'test_id')
+        assert testObject._id == 'test_id'
 
         testObject2 = self.pObjectClass()
-        self.assertIsNot(testObject2._id, None)
+        assert testObject2._id is not None
 
-        self.assertEqual(set(["name", "tags", "js_property_callbacks",
-                              "subscribed_events", "js_event_callbacks"]),
-                         testObject.properties())
-        self.assertDictEqual(dict(name=None, tags=[], js_property_callbacks={},
-                                  js_event_callbacks={}, subscribed_events=[]),
-                             testObject.properties_with_values(include_defaults=True))
-        self.assertDictEqual(dict(), testObject.properties_with_values(include_defaults=False))
+        assert set(["name", "tags", "js_property_callbacks", "subscribed_events", "js_event_callbacks"]) == testObject.properties()
+        assert dict(
+            name=None, tags=[], js_property_callbacks={}, js_event_callbacks={}, subscribed_events=[]
+        ) == testObject.properties_with_values(include_defaults=True)
+        assert dict() == testObject.properties_with_values(include_defaults=False)
 
     def test_ref(self):
         testObject = self.pObjectClass(id='test_id')
-        self.assertEqual({'type': 'Model', 'id': 'test_id'}, testObject.ref)
+        assert {'type': 'Model', 'id': 'test_id'} == testObject.ref
 
     def test_references_by_ref_by_value(self):
         from bokeh.core.has_props import HasProps
@@ -171,8 +173,8 @@ class TestModel(unittest.TestCase):
         x1 = X1(y=y, z1=z1)
         x2 = X2(y=y, z2=z2)
 
-        self.assertEqual(x1.references(), {t1, y, t2,     x1})
-        self.assertEqual(x2.references(), {t1, y, t2, z2, x2})
+        assert x1.references() == {t1, y, t2,     x1}
+        assert x2.references() == {t1, y, t2, z2, x2}
 
     def test_references_in_containers(self):
         from bokeh.core.properties import Int, String, Instance, List, Tuple, Dict
@@ -195,7 +197,7 @@ class TestModel(unittest.TestCase):
         u1, u2, u3, u4, u5 = U(a=1), U(a=2), U(a=3), U(a=4), U(a=5)
         v = V(u1=u1, u2=[u2], u3=(3, u3), u4={"4": u4}, u5={"5": [u5]})
 
-        self.assertEqual(v.references(), set([v, u1, u2, u3, u4, u5]))
+        assert v.references() == set([v, u1, u2, u3, u4, u5])
 
     def test_to_json(self):
         child_obj = SomeModelToJson(foo=57, bar="hello")
@@ -203,7 +205,7 @@ class TestModel(unittest.TestCase):
                               foo=42, bar="world")
         json = obj.to_json(include_defaults=True)
         json_string = obj.to_json_string(include_defaults=True)
-        self.assertEqual({ "child" : { "id" : child_obj._id, "type" : "SomeModelToJson" },
+        assert { "child" : { "id" : child_obj._id, "type" : "SomeModelToJson" },
                            "id" : obj._id,
                            "name" : None,
                            "tags" : [],
@@ -211,75 +213,72 @@ class TestModel(unittest.TestCase):
                            "js_event_callbacks" : {},
                            "subscribed_events" : [],
                            "foo" : 42,
-                           "bar" : "world" },
-                         json)
-        self.assertEqual(('{"bar":"world",' +
-                          '"child":{"id":"%s","type":"SomeModelToJson"},' +
-                          '"foo":42,"id":"%s","js_event_callbacks":{},"js_property_callbacks":{},' +
-                          '"name":null,"subscribed_events":[],"tags":[]}') %
-                         (child_obj._id, obj._id),
-                         json_string)
+                           "bar" : "world" } == json
+        assert ('{"bar":"world",' +
+                '"child":{"id":"%s","type":"SomeModelToJson"},' +
+                '"foo":42,"id":"%s","js_event_callbacks":{},"js_property_callbacks":{},' +
+                '"name":null,"subscribed_events":[],"tags":[]}') % (child_obj._id, obj._id) == json_string
 
     def test_no_units_in_json(self):
         from bokeh.models import AnnularWedge
         obj = AnnularWedge()
         json = obj.to_json(include_defaults=True)
-        self.assertTrue('start_angle' in json)
-        self.assertTrue('start_angle_units' not in json)
-        self.assertTrue('outer_radius' in json)
-        self.assertTrue('outer_radius_units' not in json)
+        assert 'start_angle' in json
+        assert 'start_angle_units' not in json
+        assert 'outer_radius' in json
+        assert 'outer_radius_units' not in json
 
     def test_dataspec_field_in_json(self):
         from bokeh.models import AnnularWedge
         obj = AnnularWedge()
         obj.start_angle = "fieldname"
         json = obj.to_json(include_defaults=True)
-        self.assertTrue('start_angle' in json)
-        self.assertTrue('start_angle_units' not in json)
-        self.assertDictEqual(dict(units='rad', field='fieldname'), json['start_angle'])
+        assert 'start_angle' in json
+        assert 'start_angle_units' not in json
+        assert dict(units='rad', field='fieldname'), json['start_angle']
 
     def test_dataspec_value_in_json(self):
         from bokeh.models import AnnularWedge
         obj = AnnularWedge()
         obj.start_angle = 60
         json = obj.to_json(include_defaults=True)
-        self.assertTrue('start_angle' in json)
-        self.assertTrue('start_angle_units' not in json)
-        self.assertDictEqual(dict(units='rad', value=60), json['start_angle'])
+        assert 'start_angle' in json
+        assert 'start_angle_units' not in json
+        assert dict(units='rad', value=60) == json['start_angle']
 
     def test_list_default(self):
         class HasListDefault(Model):
             value = List(String, default=["hello"])
         obj = HasListDefault()
-        self.assertEqual(obj.value, obj.value)
+        assert obj.value == obj.value
 
         # 'value' should not be included because we haven't modified it
-        self.assertFalse('value' in obj.properties_with_values(include_defaults=False))
+        assert 'value' not in obj.properties_with_values(include_defaults=False)
         # (but should be in include_defaults=True)
-        self.assertTrue('value' in obj.properties_with_values(include_defaults=True))
+        assert 'value' in obj.properties_with_values(include_defaults=True)
 
         obj.value.append("world")
 
         # 'value' should now be included
-        self.assertTrue('value' in obj.properties_with_values(include_defaults=False))
+        assert 'value' in obj.properties_with_values(include_defaults=False)
 
     def test_dict_default(self):
         class HasDictDefault(Model):
             value = Dict(String, Int, default=dict(hello=42))
         obj = HasDictDefault()
-        self.assertDictEqual(obj.value, obj.value)
-        self.assertDictEqual(dict(hello=42), obj.value)
+        assert obj.value == obj.value
+        assert dict(hello=42) == obj.value
 
         # 'value' should not be included because we haven't modified it
-        self.assertFalse('value' in obj.properties_with_values(include_defaults=False))
+        assert 'value' not in obj.properties_with_values(include_defaults=False)
         # (but should be in include_defaults=True)
-        self.assertTrue('value' in obj.properties_with_values(include_defaults=True))
+        assert 'value' in obj.properties_with_values(include_defaults=True)
 
         obj.value['world'] = 57
 
         # 'value' should now be included
-        self.assertTrue('value' in obj.properties_with_values(include_defaults=False))
-        self.assertDictEqual(dict(hello=42, world=57), obj.value)
+        assert 'value' in obj.properties_with_values(include_defaults=False)
+        assert dict(hello=42, world=57), obj.value
 
     def test_func_default_with_counter(self):
         counter = dict(value=0)
@@ -290,24 +289,24 @@ class TestModel(unittest.TestCase):
             value = Int(default=next_value)
         obj1 = HasFuncDefaultInt()
         obj2 = HasFuncDefaultInt()
-        self.assertEqual(obj1.value+1, obj2.value)
+        assert obj1.value+1 == obj2.value
 
         # 'value' is a default, but it gets included as a
         # non-default because it's unstable.
-        self.assertTrue('value' in obj1.properties_with_values(include_defaults=False))
+        assert 'value' in obj1.properties_with_values(include_defaults=False)
 
     def test_func_default_with_model(self):
         class HasFuncDefaultModel(Model):
             child = Instance(Model, lambda: Model())
         obj1 = HasFuncDefaultModel()
         obj2 = HasFuncDefaultModel()
-        self.assertNotEqual(obj1.child._id, obj2.child._id)
+        assert obj1.child._id != obj2.child._id
 
         # 'child' is a default, but it gets included as a
         # non-default because it's unstable.
-        self.assertTrue('child' in obj1.properties_with_values(include_defaults=False))
+        assert 'child' in obj1.properties_with_values(include_defaults=False)
 
-class TestContainerMutation(unittest.TestCase):
+class TestContainerMutation(object):
 
     def _check_mutation(self, obj, attr, mutator, expected_event_old, expected_event_new):
         result = dict(calls=[])
@@ -316,16 +315,16 @@ class TestContainerMutation(unittest.TestCase):
         obj.on_change(attr, record_trigger)
         try:
             actual_old = getattr(obj, attr)
-            self.assertEqual(expected_event_old, actual_old)
+            assert expected_event_old == actual_old
             mutator(actual_old)
-            self.assertEqual(expected_event_new, getattr(obj, attr))
+            assert expected_event_new == getattr(obj, attr)
         finally:
             obj.remove_on_change(attr, record_trigger)
-        self.assertEqual(1, len(result['calls']))
+        assert 1 == len(result['calls'])
         call = result['calls'][0]
-        self.assertEqual(attr, call[0])
-        self.assertEqual(expected_event_old, call[1])
-        self.assertEqual(expected_event_new, call[2])
+        assert attr == call[0]
+        assert expected_event_old == call[1]
+        assert expected_event_new == call[2]
 
 
 class HasListProp(Model):
@@ -337,34 +336,34 @@ class TestListMutation(TestContainerMutation):
 
     def test_whether_included_in_props_with_values(self):
         obj = HasListProp()
-        self.assertFalse('foo' in obj.properties_with_values(include_defaults=False))
-        self.assertTrue('foo' in obj.properties_with_values(include_defaults=True))
+        assert 'foo' not in obj.properties_with_values(include_defaults=False)
+        assert 'foo' in obj.properties_with_values(include_defaults=True)
         # simply reading the property creates a new wrapper, so be
         # sure that doesn't count as replacing the default
         foo = obj.foo
-        self.assertEqual(foo, foo) # this is to calm down flake's unused var warning
-        self.assertFalse('foo' in obj.properties_with_values(include_defaults=False))
-        self.assertTrue('foo' in obj.properties_with_values(include_defaults=True))
+        assert foo == foo # this is to calm down flake's unused var warning
+        assert 'foo' not in obj.properties_with_values(include_defaults=False)
+        assert 'foo' in obj.properties_with_values(include_defaults=True)
         # but changing the list should count as replacing the default
         obj.foo.append("hello")
-        self.assertTrue('foo' in obj.properties_with_values(include_defaults=False))
-        self.assertTrue('foo' in obj.properties_with_values(include_defaults=True))
+        assert 'foo' in obj.properties_with_values(include_defaults=False)
+        assert 'foo' in obj.properties_with_values(include_defaults=True)
 
     def test_assignment_maintains_owners(self):
         obj = HasListProp()
         old_list = obj.foo
-        self.assertTrue(isinstance(old_list, PropertyValueList))
-        self.assertEqual(1, len(old_list._owners))
+        assert isinstance(old_list, PropertyValueList)
+        assert 1 == len(old_list._owners)
         obj.foo = ["a"]
         new_list = obj.foo
-        self.assertTrue(isinstance(new_list, PropertyValueList))
-        self.assertIsNot(old_list, new_list)
-        self.assertEqual(0, len(old_list._owners))
-        self.assertEqual(1, len(new_list._owners))
+        assert isinstance(new_list, PropertyValueList)
+        assert old_list is not new_list
+        assert 0 == len(old_list._owners)
+        assert 1 == len(new_list._owners)
 
     def test_list_delitem(self):
         obj = HasListProp(foo=["a", "b", "c"])
-        self.assertTrue(isinstance(obj.foo, PropertyValueList))
+        assert isinstance(obj.foo, PropertyValueList)
         def mutate(x):
             del x[1]
         self._check_mutation(obj, 'foo', mutate,
@@ -373,7 +372,7 @@ class TestListMutation(TestContainerMutation):
 
     def test_list_delslice(self):
         obj = HasListProp(foo=["a", "b", "c", "d"])
-        self.assertTrue(isinstance(obj.foo, PropertyValueList))
+        assert isinstance(obj.foo, PropertyValueList)
         def mutate(x):
             del x[1:3]
         self._check_mutation(obj, 'foo', mutate,
@@ -382,7 +381,7 @@ class TestListMutation(TestContainerMutation):
 
     def test_list_iadd(self):
         obj = HasListProp(foo=["a"])
-        self.assertTrue(isinstance(obj.foo, PropertyValueList))
+        assert isinstance(obj.foo, PropertyValueList)
         def mutate(x):
             x += ["b"]
         self._check_mutation(obj, 'foo', mutate,
@@ -391,7 +390,7 @@ class TestListMutation(TestContainerMutation):
 
     def test_list_imul(self):
         obj = HasListProp(foo=["a"])
-        self.assertTrue(isinstance(obj.foo, PropertyValueList))
+        assert isinstance(obj.foo, PropertyValueList)
         def mutate(x):
             x *= 3
         self._check_mutation(obj, 'foo', mutate,
@@ -400,7 +399,7 @@ class TestListMutation(TestContainerMutation):
 
     def test_list_setitem(self):
         obj = HasListProp(foo=["a"])
-        self.assertTrue(isinstance(obj.foo, PropertyValueList))
+        assert isinstance(obj.foo, PropertyValueList)
         def mutate(x):
             x[0] = "b"
         self._check_mutation(obj, 'foo', mutate,
@@ -409,7 +408,7 @@ class TestListMutation(TestContainerMutation):
 
     def test_list_setslice(self):
         obj = HasListProp(foo=["a", "b", "c", "d"])
-        self.assertTrue(isinstance(obj.foo, PropertyValueList))
+        assert isinstance(obj.foo, PropertyValueList)
         def mutate(x):
             x[1:3] = ["x"]
         self._check_mutation(obj, 'foo', mutate,
@@ -418,45 +417,45 @@ class TestListMutation(TestContainerMutation):
 
     def test_list_append(self):
         obj = HasListProp()
-        self.assertTrue(isinstance(obj.foo, PropertyValueList))
+        assert isinstance(obj.foo, PropertyValueList)
         self._check_mutation(obj, 'foo', lambda x: x.append("bar"), [], ["bar"])
 
     def test_list_extend(self):
         obj = HasListProp()
-        self.assertTrue(isinstance(obj.foo, PropertyValueList))
+        assert isinstance(obj.foo, PropertyValueList)
         self._check_mutation(obj, 'foo', lambda x: x.extend(["x", "y"]), [], ["x", "y"])
 
     def test_list_insert(self):
         obj = HasListProp(foo=["a", "b"])
-        self.assertTrue(isinstance(obj.foo, PropertyValueList))
+        assert isinstance(obj.foo, PropertyValueList)
         self._check_mutation(obj, 'foo', lambda x: x.insert(1, "x"),
                              ["a", "b"],
                              ["a", "x", "b"])
 
     def test_list_pop(self):
         obj = HasListProp(foo=["a", "b"])
-        self.assertTrue(isinstance(obj.foo, PropertyValueList))
+        assert isinstance(obj.foo, PropertyValueList)
         self._check_mutation(obj, 'foo', lambda x: x.pop(),
                              ["a", "b"],
                              ["a"])
 
     def test_list_remove(self):
         obj = HasListProp(foo=["a", "b"])
-        self.assertTrue(isinstance(obj.foo, PropertyValueList))
+        assert isinstance(obj.foo, PropertyValueList)
         self._check_mutation(obj, 'foo', lambda x: x.remove("b"),
                              ["a", "b"],
                              ["a"])
 
     def test_list_reverse(self):
         obj = HasListProp(foo=["a", "b"])
-        self.assertTrue(isinstance(obj.foo, PropertyValueList))
+        assert isinstance(obj.foo, PropertyValueList)
         self._check_mutation(obj, 'foo', lambda x: x.reverse(),
                              ["a", "b"],
                              ["b", "a"])
 
     def test_list_sort(self):
         obj = HasListProp(foo=["b", "a"])
-        self.assertTrue(isinstance(obj.foo, PropertyValueList))
+        assert isinstance(obj.foo, PropertyValueList)
         self._check_mutation(obj, 'foo', lambda x: x.sort(),
                              ["b", "a"],
                              ["a", "b"])
@@ -476,34 +475,34 @@ class TestDictMutation(TestContainerMutation):
 
     def test_whether_included_in_props_with_values(self):
         obj = HasStringDictProp()
-        self.assertFalse('foo' in obj.properties_with_values(include_defaults=False))
-        self.assertTrue('foo' in obj.properties_with_values(include_defaults=True))
+        assert 'foo' not in obj.properties_with_values(include_defaults=False)
+        assert 'foo' in obj.properties_with_values(include_defaults=True)
         # simply reading the property creates a new wrapper, so be
         # sure that doesn't count as replacing the default
         foo = obj.foo
-        self.assertEqual(foo, foo) # this is to calm down flake's unused var warning
-        self.assertFalse('foo' in obj.properties_with_values(include_defaults=False))
-        self.assertTrue('foo' in obj.properties_with_values(include_defaults=True))
+        assert foo == foo # this is to calm down flake's unused var warning
+        assert 'foo' not in obj.properties_with_values(include_defaults=False)
+        assert 'foo' in obj.properties_with_values(include_defaults=True)
         # but changing the dict should count as replacing the default
         obj.foo['bar'] = 42
-        self.assertTrue('foo' in obj.properties_with_values(include_defaults=False))
-        self.assertTrue('foo' in obj.properties_with_values(include_defaults=True))
+        assert 'foo' in obj.properties_with_values(include_defaults=False)
+        assert 'foo' in obj.properties_with_values(include_defaults=True)
 
     def test_assignment_maintains_owners(self):
         obj = HasStringDictProp()
         old_dict = obj.foo
-        self.assertTrue(isinstance(old_dict, PropertyValueDict))
-        self.assertEqual(1, len(old_dict._owners))
+        assert isinstance(old_dict, PropertyValueDict)
+        assert 1 == len(old_dict._owners)
         obj.foo = dict(a=1)
         new_dict = obj.foo
-        self.assertTrue(isinstance(new_dict, PropertyValueDict))
-        self.assertIsNot(old_dict, new_dict)
-        self.assertEqual(0, len(old_dict._owners))
-        self.assertEqual(1, len(new_dict._owners))
+        assert isinstance(new_dict, PropertyValueDict)
+        assert old_dict is not new_dict
+        assert 0 == len(old_dict._owners)
+        assert 1 == len(new_dict._owners)
 
     def test_dict_delitem_string(self):
         obj = HasStringDictProp(foo=dict(a=1, b=2, c=3))
-        self.assertTrue(isinstance(obj.foo, PropertyValueDict))
+        assert isinstance(obj.foo, PropertyValueDict)
         def mutate(x):
             del x['b']
         self._check_mutation(obj, 'foo', mutate,
@@ -512,7 +511,7 @@ class TestDictMutation(TestContainerMutation):
 
     def test_dict_delitem_int(self):
         obj = HasIntDictProp(foo={ 1 : "a", 2 : "b", 3 : "c" })
-        self.assertTrue(isinstance(obj.foo, PropertyValueDict))
+        assert isinstance(obj.foo, PropertyValueDict)
         def mutate(x):
             del x[1]
         self._check_mutation(obj, 'foo', mutate,
@@ -521,7 +520,7 @@ class TestDictMutation(TestContainerMutation):
 
     def test_dict_setitem_string(self):
         obj = HasStringDictProp(foo=dict(a=1, b=2, c=3))
-        self.assertTrue(isinstance(obj.foo, PropertyValueDict))
+        assert isinstance(obj.foo, PropertyValueDict)
         def mutate(x):
             x['b'] = 42
         self._check_mutation(obj, 'foo', mutate,
@@ -530,7 +529,7 @@ class TestDictMutation(TestContainerMutation):
 
     def test_dict_setitem_int(self):
         obj = HasIntDictProp(foo={ 1 : "a", 2 : "b", 3 : "c" })
-        self.assertTrue(isinstance(obj.foo, PropertyValueDict))
+        assert isinstance(obj.foo, PropertyValueDict)
         def mutate(x):
             x[2] = "bar"
         self._check_mutation(obj, 'foo', mutate,
@@ -539,7 +538,7 @@ class TestDictMutation(TestContainerMutation):
 
     def test_dict_clear(self):
         obj = HasStringDictProp(foo=dict(a=1, b=2, c=3))
-        self.assertTrue(isinstance(obj.foo, PropertyValueDict))
+        assert isinstance(obj.foo, PropertyValueDict)
         def mutate(x):
             x.clear()
         self._check_mutation(obj, 'foo', mutate,
@@ -548,7 +547,7 @@ class TestDictMutation(TestContainerMutation):
 
     def test_dict_pop(self):
         obj = HasStringDictProp(foo=dict(a=1, b=2, c=3))
-        self.assertTrue(isinstance(obj.foo, PropertyValueDict))
+        assert isinstance(obj.foo, PropertyValueDict)
         def mutate(x):
             x.pop('b')
         self._check_mutation(obj, 'foo', mutate,
@@ -557,24 +556,24 @@ class TestDictMutation(TestContainerMutation):
 
     def test_dict_pop_default_works(self):
         obj = HasStringDictProp(foo=dict(a=1, b=2, c=3))
-        self.assertTrue(isinstance(obj.foo, PropertyValueDict))
-        self.assertEqual(42, obj.foo.pop('z', 42))
+        assert isinstance(obj.foo, PropertyValueDict)
+        assert 42 == obj.foo.pop('z', 42)
 
     def test_dict_popitem_works(self):
         obj = HasStringDictProp(foo=dict(a=1, b=2, c=3))
-        self.assertTrue(isinstance(obj.foo, PropertyValueDict))
+        assert isinstance(obj.foo, PropertyValueDict)
         i = obj.foo.popitem()
-        self.assertTrue(i == ('a', 1) or i == ('b', 2) or i == ('c', 3))
+        assert i == ('a', 1) or i == ('b', 2) or i == ('c', 3)
         # we don't _check_mutation since the end value is nondeterministic
 
     def test_dict_setdefault(self):
         obj = HasStringDictProp(foo=dict(a=1, b=2, c=3))
-        self.assertTrue(isinstance(obj.foo, PropertyValueDict))
+        assert isinstance(obj.foo, PropertyValueDict)
         def mutate(x):
             b = x.setdefault('b', 43)
-            self.assertEqual(2, b)
+            assert 2 == b
             z = x.setdefault('z', 44)
-            self.assertEqual(44, z)
+            assert 44 == z
 
         self._check_mutation(obj, 'foo', mutate,
                              dict(a=1, b=2, c=3),
@@ -582,12 +581,9 @@ class TestDictMutation(TestContainerMutation):
 
     def test_dict_update(self):
         obj = HasStringDictProp(foo=dict(a=1, b=2, c=3))
-        self.assertTrue(isinstance(obj.foo, PropertyValueDict))
+        assert isinstance(obj.foo, PropertyValueDict)
         def mutate(x):
             x.update(dict(b=7, c=8))
         self._check_mutation(obj, 'foo', mutate,
                              dict(a=1, b=2, c=3),
                              dict(a=1, b=7, c=8))
-
-if __name__ == "__main__":
-    unittest.main()

--- a/bokeh/tests/test_objects.py
+++ b/bokeh/tests/test_objects.py
@@ -235,7 +235,7 @@ class TestModel(object):
         json = obj.to_json(include_defaults=True)
         assert 'start_angle' in json
         assert 'start_angle_units' not in json
-        assert dict(units='rad', field='fieldname'), json['start_angle']
+        assert dict(units='rad', field='fieldname') == json['start_angle']
 
     def test_dataspec_value_in_json(self):
         from bokeh.models import AnnularWedge
@@ -278,7 +278,7 @@ class TestModel(object):
 
         # 'value' should now be included
         assert 'value' in obj.properties_with_values(include_defaults=False)
-        assert dict(hello=42, world=57), obj.value
+        assert dict(hello=42, world=57) == obj.value
 
     def test_func_default_with_counter(self):
         counter = dict(value=0)

--- a/bokeh/tests/test_resources.py
+++ b/bokeh/tests/test_resources.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 
-import unittest
-
 import os
+
+import pytest
 
 import bokeh.resources as resources
 from bokeh.models import Model
@@ -51,101 +51,108 @@ def test_inline_css_resources():
     assert r.messages == []
 
 
-class TestResources(unittest.TestCase):
+class TestResources(object):
 
     def test_basic(self):
         r = resources.Resources()
-        self.assertEqual(r.mode, "inline")
+        assert r.mode == "inline"
 
     def test_log_level(self):
         r = resources.Resources()
         for level in LOG_LEVELS:
             r.log_level = level
-            self.assertEqual(r.log_level, level)
+            assert r.log_level == level
             if not r.dev:
-                self.assertEqual(r.js_raw[-1], 'Bokeh.set_log_level("%s");' % level)
-        self.assertRaises(ValueError, setattr, r, "log_level", "foo")
+                assert r.js_raw[-1] == 'Bokeh.set_log_level("%s");' % level
+        with pytest.raises(ValueError):
+            setattr(r, "log_level", "foo")
 
     def test_module_attrs(self):
-        self.assertEqual(resources.CDN.mode, "cdn")
-        self.assertEqual(resources.INLINE.mode, "inline")
+        assert resources.CDN.mode == "cdn"
+        assert resources.INLINE.mode == "inline"
 
     def test_inline(self):
         r = resources.Resources(mode="inline")
-        self.assertEqual(r.mode, "inline")
-        self.assertEqual(r.dev, False)
+        assert r.mode == "inline"
+        assert r.dev == False
 
-        self.assertEqual(len(r.js_raw), 5)
-        self.assertEqual(r.js_raw[-1], DEFAULT_LOG_JS_RAW)
-        self.assertEqual(len(r.css_raw), 3)
-        self.assertEqual(r.messages, [])
+        assert len(r.js_raw) == 5
+        assert r.js_raw[-1] == DEFAULT_LOG_JS_RAW
+        assert len(r.css_raw) == 3
+        assert r.messages == []
 
     def test_get_cdn_urls(self):
         dev_version = "0.0.1dev2"
         result = _get_cdn_urls(version=dev_version)
         url = result['urls'](["bokeh"], 'js')[0]
-        self.assertIn('bokeh/dev', url)
+        assert 'bokeh/dev' in url
 
     def test_cdn(self):
         resources.__version__ = "1.0"
         r = resources.Resources(mode="cdn", version="1.0")
-        self.assertEqual(r.mode, "cdn")
-        self.assertEqual(r.dev, False)
+        assert r.mode == "cdn"
+        assert r.dev == False
 
-        self.assertEqual(r.js_raw, [DEFAULT_LOG_JS_RAW])
-        self.assertEqual(r.css_raw, [])
-        self.assertEqual(r.messages, [])
+        assert r.js_raw == [DEFAULT_LOG_JS_RAW]
+        assert r.css_raw == []
+        assert r.messages == []
 
         resources.__version__ = "1.0-1-abc"
         r = resources.Resources(mode="cdn", version="1.0")
-        self.assertEqual(r.messages, [
-            {'text': "Requesting CDN BokehJS version '1.0' from Bokeh development version '1.0-1-abc'. This configuration is unsupported and may not work!",
+        assert r.messages == [{
+            'text': "Requesting CDN BokehJS version '1.0' from Bokeh development version '1.0-1-abc'. This configuration is unsupported and may not work!",
             'type': 'warn'}
-        ])
+        ]
 
     def test_server_default(self):
         r = resources.Resources(mode="server")
-        self.assertEqual(r.mode, "server")
-        self.assertEqual(r.dev, False)
+        assert r.mode == "server"
+        assert r.dev == False
 
-        self.assertEqual(r.js_raw, [DEFAULT_LOG_JS_RAW])
-        self.assertEqual(r.css_raw, [])
-        self.assertEqual(r.messages, [])
-        self.assertEqual(r.js_files, ['http://localhost:5006/static/js/bokeh.min.js',
-                                      'http://localhost:5006/static/js/bokeh-widgets.min.js',
-                                      'http://localhost:5006/static/js/bokeh-tables.min.js',
-                                      'http://localhost:5006/static/js/bokeh-gl.min.js'])
-        self.assertEqual(r.css_files, ['http://localhost:5006/static/css/bokeh.min.css',
-                                       'http://localhost:5006/static/css/bokeh-widgets.min.css',
-                                       'http://localhost:5006/static/css/bokeh-tables.min.css'])
+        assert r.js_raw == [DEFAULT_LOG_JS_RAW]
+        assert r.css_raw == []
+        assert r.messages == []
+
+        assert r.js_files == ['http://localhost:5006/static/js/bokeh.min.js',
+                              'http://localhost:5006/static/js/bokeh-widgets.min.js',
+                              'http://localhost:5006/static/js/bokeh-tables.min.js',
+                              'http://localhost:5006/static/js/bokeh-gl.min.js']
+
+        assert r.css_files == ['http://localhost:5006/static/css/bokeh.min.css',
+                               'http://localhost:5006/static/css/bokeh-widgets.min.css',
+                               'http://localhost:5006/static/css/bokeh-tables.min.css']
 
     def test_server_root_url(self):
         r = resources.Resources(mode="server", root_url="http://foo/")
 
-        self.assertEqual(r.js_raw, [DEFAULT_LOG_JS_RAW])
-        self.assertEqual(r.css_raw, [])
-        self.assertEqual(r.messages, [])
-        self.assertEqual(r.js_files, ['http://foo/static/js/bokeh.min.js',
-                                      'http://foo/static/js/bokeh-widgets.min.js',
-                                      'http://foo/static/js/bokeh-tables.min.js',
-                                      'http://foo/static/js/bokeh-gl.min.js'])
-        self.assertEqual(r.css_files, ['http://foo/static/css/bokeh.min.css',
-                                       'http://foo/static/css/bokeh-widgets.min.css',
-                                       'http://foo/static/css/bokeh-tables.min.css'])
+        assert r.js_raw == [DEFAULT_LOG_JS_RAW]
+        assert r.css_raw == []
+        assert r.messages == []
+
+        assert r.js_files == ['http://foo/static/js/bokeh.min.js',
+                              'http://foo/static/js/bokeh-widgets.min.js',
+                              'http://foo/static/js/bokeh-tables.min.js',
+                              'http://foo/static/js/bokeh-gl.min.js']
+
+        assert r.css_files == ['http://foo/static/css/bokeh.min.css',
+                               'http://foo/static/css/bokeh-widgets.min.css',
+                               'http://foo/static/css/bokeh-tables.min.css']
 
     def test_server_root_url_empty(self):
         r = resources.Resources(mode="server", root_url="")
 
-        self.assertEqual(r.js_raw, [DEFAULT_LOG_JS_RAW])
-        self.assertEqual(r.css_raw, [])
-        self.assertEqual(r.messages, [])
-        self.assertEqual(r.js_files, ['static/js/bokeh.min.js',
-                                      'static/js/bokeh-widgets.min.js',
-                                      'static/js/bokeh-tables.min.js',
-                                      'static/js/bokeh-gl.min.js'])
-        self.assertEqual(r.css_files, ['static/css/bokeh.min.css',
-                                       'static/css/bokeh-widgets.min.css',
-                                       'static/css/bokeh-tables.min.css'])
+        assert r.js_raw == [DEFAULT_LOG_JS_RAW]
+        assert r.css_raw == []
+        assert r.messages == []
+
+        assert r.js_files == ['static/js/bokeh.min.js',
+                              'static/js/bokeh-widgets.min.js',
+                              'static/js/bokeh-tables.min.js',
+                              'static/js/bokeh-gl.min.js']
+
+        assert r.css_files == ['static/css/bokeh.min.css',
+                               'static/css/bokeh-widgets.min.css',
+                               'static/css/bokeh-tables.min.css']
 
 
     def test_server_with_versioner(self):
@@ -155,76 +162,81 @@ class TestResources(unittest.TestCase):
         r = resources.Resources(mode="server", root_url="http://foo/",
                                 path_versioner=versioner)
 
-        self.assertEqual(r.js_files, ['http://foo/static/js/bokeh.min.js?v=VERSIONED',
-                                      'http://foo/static/js/bokeh-widgets.min.js?v=VERSIONED',
-                                      'http://foo/static/js/bokeh-tables.min.js?v=VERSIONED',
-                                      'http://foo/static/js/bokeh-gl.min.js?v=VERSIONED'])
-        self.assertEqual(r.css_files, ['http://foo/static/css/bokeh.min.css?v=VERSIONED',
-                                       'http://foo/static/css/bokeh-widgets.min.css?v=VERSIONED',
-                                       'http://foo/static/css/bokeh-tables.min.css?v=VERSIONED'])
+        assert r.js_files == ['http://foo/static/js/bokeh.min.js?v=VERSIONED',
+                              'http://foo/static/js/bokeh-widgets.min.js?v=VERSIONED',
+                              'http://foo/static/js/bokeh-tables.min.js?v=VERSIONED',
+                              'http://foo/static/js/bokeh-gl.min.js?v=VERSIONED']
+
+        assert r.css_files == ['http://foo/static/css/bokeh.min.css?v=VERSIONED',
+                               'http://foo/static/css/bokeh-widgets.min.css?v=VERSIONED',
+                               'http://foo/static/css/bokeh-tables.min.css?v=VERSIONED']
 
     def test_server_dev(self):
         r = resources.Resources(mode="server-dev")
-        self.assertEqual(r.mode, "server")
-        self.assertEqual(r.dev, True)
+        assert r.mode == "server"
+        assert r.dev == True
 
-        self.assertEqual(len(r.js_raw), 2)
-        self.assertEqual(r.css_raw, [])
-        self.assertEqual(r.messages, [])
+        assert len(r.js_raw) == 2
+        assert r.css_raw == []
+        assert r.messages == []
 
         r = resources.Resources(mode="server-dev", root_url="http://foo/")
 
-        self.assertEqual(r.js_raw, [DEFAULT_LOG_JS_RAW, "Bokeh.settings.dev = true"])
-        self.assertEqual(r.css_raw, [])
-        self.assertEqual(r.messages, [])
+        assert r.js_raw == [DEFAULT_LOG_JS_RAW, "Bokeh.settings.dev = true"]
+        assert r.css_raw == []
+        assert r.messages == []
 
     def test_relative(self):
         r = resources.Resources(mode="relative")
-        self.assertEqual(r.mode, "relative")
-        self.assertEqual(r.dev, False)
+        assert r.mode == "relative"
+        assert r.dev == False
 
-        self.assertEqual(r.js_raw, [DEFAULT_LOG_JS_RAW])
-        self.assertEqual(r.css_raw, [])
-        self.assertEqual(r.messages, [])
+        assert r.js_raw == [DEFAULT_LOG_JS_RAW]
+        assert r.css_raw == []
+        assert r.messages == []
 
     def test_relative_dev(self):
         r = resources.Resources(mode="relative-dev")
-        self.assertEqual(r.mode, "relative")
-        self.assertEqual(r.dev, True)
+        assert r.mode == "relative"
+        assert r.dev == True
 
-        self.assertEqual(r.js_raw, [DEFAULT_LOG_JS_RAW, "Bokeh.settings.dev = true"])
-        self.assertEqual(r.css_raw, [])
-        self.assertEqual(r.messages, [])
+        assert r.js_raw == [DEFAULT_LOG_JS_RAW, "Bokeh.settings.dev = true"]
+        assert r.css_raw == []
+        assert r.messages == []
 
     def test_absolute(self):
         r = resources.Resources(mode="absolute")
-        self.assertEqual(r.mode, "absolute")
-        self.assertEqual(r.dev, False)
+        assert r.mode == "absolute"
+        assert r.dev == False
 
-        self.assertEqual(r.js_raw, [DEFAULT_LOG_JS_RAW])
-        self.assertEqual(r.css_raw, [])
-        self.assertEqual(r.messages, [])
+        assert r.js_raw == [DEFAULT_LOG_JS_RAW]
+        assert r.css_raw == []
+        assert r.messages == []
 
     def test_absolute_dev(self):
         r = resources.Resources(mode="absolute-dev")
-        self.assertEqual(r.mode, "absolute")
-        self.assertEqual(r.dev, True)
+        assert r.mode == "absolute"
+        assert r.dev == True
 
-        self.assertEqual(r.js_raw, [DEFAULT_LOG_JS_RAW, "Bokeh.settings.dev = true"])
-        self.assertEqual(r.css_raw, [])
-        self.assertEqual(r.messages, [])
+        assert r.js_raw == [DEFAULT_LOG_JS_RAW, "Bokeh.settings.dev = true"]
+        assert r.css_raw == []
+        assert r.messages == []
 
     def test_argument_checks(self):
-        self.assertRaises(ValueError, resources.Resources, "foo")
+        with pytest.raises(ValueError):
+            resources.Resources("foo")
 
         for mode in ("inline", "cdn", "server", "server-dev", "absolute", "absolute-dev"):
-            self.assertRaises(ValueError, resources.Resources, mode, root_dir="foo")
+            with pytest.raises(ValueError):
+                resources.Resources(mode, root_dir="foo")
 
         for mode in ("inline", "server", "server-dev", "relative", "relative-dev", "absolute", "absolute-dev"):
-            self.assertRaises(ValueError, resources.Resources, mode, version="foo")
+            with pytest.raises(ValueError):
+                resources.Resources(mode, version="foo")
 
         for mode in ("inline", "cdn", "relative", "relative-dev", "absolute", "absolute-dev"):
-            self.assertRaises(ValueError, resources.Resources, mode, root_url="foo")
+            with pytest.raises(ValueError):
+                resources.Resources(mode, root_url="foo")
 
 
 ## Test external resources

--- a/bokeh/tests/test_server.py
+++ b/bokeh/tests/test_server.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, print_function
 
-import unittest
-
 import logging
 from bokeh.server.server import Server
 from bokeh.application import Application
@@ -11,7 +9,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 # test_client_server.py is the test for the main functionality
 # of the server, here we're testing some properties in isolation
-class TestServer(unittest.TestCase):
+class TestServer(object):
     def test_port(self):
         loop = IOLoop()
         loop.make_current()

--- a/bokeh/tests/test_widgets.py
+++ b/bokeh/tests/test_widgets.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import unittest
 import inspect
 
 
@@ -16,29 +15,29 @@ def get_prop_set(class_object):
     return class_properties
 
 
-class TestPanel(unittest.TestCase):
+class TestPanel(object):
 
-    def setUp(self):
+    def setup_method(self):
         from bokeh.models.widgets.panels import Panel
         self.panelCls = Panel
 
     def test_expectedprops(self):
         expected_properties = set(['title', 'child', 'closable'])
         actual_properties = get_prop_set(self.panelCls)
-        self.assertTrue(expected_properties.issubset(actual_properties))
+        assert expected_properties.issubset(actual_properties)
 
     def test_prop_defaults(self):
         p1 = self.panelCls()
         p2 = self.panelCls()
-        self.assertEqual(p1.title, "")
-        self.assertEqual(p2.title, "")
-        self.assertEqual(p1.child, None)
-        self.assertFalse(p1.closable)
+        assert p1.title == ""
+        assert p2.title == ""
+        assert p1.child == None
+        assert not p1.closable
 
 
-class TestTabs(unittest.TestCase):
+class TestTabs(object):
 
-    def setUp(self):
+    def setup_method(self):
         from bokeh.models.widgets.panels import Tabs, Panel
         self.tabsCls = Tabs
         self.panelCls = Panel
@@ -46,13 +45,9 @@ class TestTabs(unittest.TestCase):
     def test_expected_props(self):
         expected_properties = set(['tabs', 'active'])
         actual_properties = get_prop_set(self.tabsCls)
-        self.assertTrue(expected_properties.issubset(actual_properties))
+        assert expected_properties.issubset(actual_properties)
 
     def test_props_defaults(self):
         tab = self.tabsCls()
-        self.assertEqual(tab.tabs, [])
-        self.assertEqual(tab.active, 0)
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert tab.tabs == []
+        assert tab.active == 0

--- a/bokeh/util/testing.py
+++ b/bokeh/util/testing.py
@@ -13,6 +13,14 @@ import tempfile
 import pytest
 from six import string_types
 
+from .dependencies import import_optional
+
+@pytest.fixture
+def pd():
+    pandas = import_optional('pandas')
+    if pandas is None: pytest.skip('pandas is not installed')
+    return pandas
+
 def verify_all(module, ALL):
 
     class Test___all__(object):

--- a/bokeh/util/tests/test_hex.py
+++ b/bokeh/util/tests/test_hex.py
@@ -23,6 +23,7 @@ import pytest ; pytest
 import numpy as np
 
 # Bokeh imports
+from bokeh.util.testing import pd ; pd
 
 # Module under test
 import bokeh.util.hex as buh
@@ -87,7 +88,9 @@ class Test_cartesian_to_axial(object):
 
 class Test_hexbin(object):
 
-    def test_gaussian_pointytop(self):
+    # hexbin requires pandas
+
+    def test_gaussian_pointytop(self, pd):
         bins = buh.hexbin(x, y, 2)
         assert list(bins.q) == [0,0,1,1,1,2,2]
         assert list(bins.r) == [-1,0,-2,-1,0,-2,-1]
@@ -95,7 +98,7 @@ class Test_hexbin(object):
 
         assert bins.equals(buh.hexbin(x, y, 2, "pointytop"))
 
-    def test_gaussian_flattop(self):
+    def test_gaussian_flattop(self, pd):
         bins = buh.hexbin(x, y, 2, "flattop")
         assert list(bins.q) == [0, 0, 1, 1, 1, 2]
         assert list(bins.r) == [-1, 0, -2, -1, 0, -2]

--- a/bokeh/util/tests/test_session_id.py
+++ b/bokeh/util/tests/test_session_id.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import base64
 import codecs
-import unittest
 
 import bokeh.util.session_id
 from bokeh.util.string import decode_utf8
@@ -29,12 +28,12 @@ def _base64_decode(encoded):
 def _base64_decode_utf8(encoded):
     return codecs.decode(_base64_decode(encoded), 'utf-8')
 
-class TestSessionId(unittest.TestCase):
+class TestSessionId(object):
     def test_base64_roundtrip(self):
         for s in [ "", "a", "ab", "abc", "abcd", "abcde", "abcdef", "abcdefg",
                    "abcdefgh", "abcdefghi",
                    "abcdefghijklmnopqrstuvwxyz" ]:
-            self.assertEqual(s, _base64_decode_utf8(_base64_encode(s)))
+            assert s == _base64_decode_utf8(_base64_encode(s))
 
     def test_reseed_if_needed(self):
         # we have to set a seed in order to be able to get state
@@ -42,60 +41,60 @@ class TestSessionId(unittest.TestCase):
         state = random.getstate()
         _reseed_if_needed(using_sysrandom=True, secret_key=None)
         # did NOT reseed
-        self.assertEqual(state, random.getstate())
+        assert state == random.getstate()
         # monkeypatch
         saved = bokeh.util.session_id.random
         try:
             bokeh.util.session_id.random = random
             _reseed_if_needed(using_sysrandom=False, secret_key="abc")
             # DID reseed
-            self.assertNotEqual(state, random.getstate())
+            assert state != random.getstate()
         finally:
             bokeh.util.session_id.random = saved
 
     def test_signature(self):
         sig = _signature("xyz", secret_key="abc")
         with_same_key = _signature("xyz", secret_key="abc")
-        self.assertEqual(sig, with_same_key)
+        assert sig == with_same_key
         with_different_key = _signature("xyz", secret_key="qrs")
-        self.assertNotEqual(sig, with_different_key)
+        assert sig != with_different_key
 
     def test_generate_unsigned(self):
         session_id = generate_session_id(signed=False)
-        self.assertEqual(44, len(session_id))
+        assert 44 == len(session_id)
         another_session_id = generate_session_id(signed=False)
-        self.assertEqual(44, len(another_session_id))
+        assert 44 == len(another_session_id)
 
-        self.assertNotEqual(session_id, another_session_id)
+        assert session_id != another_session_id
 
     def test_generate_signed(self):
         session_id = generate_session_id(signed=True, secret_key="abc")
-        self.assertTrue('-' in session_id)
-        self.assertTrue(check_session_id_signature(session_id, secret_key="abc", signed=True))
-        self.assertFalse(check_session_id_signature(session_id, secret_key="qrs", signed=True))
+        assert '-' in session_id
+        assert check_session_id_signature(session_id, secret_key="abc", signed=True)
+        assert not check_session_id_signature(session_id, secret_key="qrs", signed=True)
 
     def test_check_signature_of_unsigned(self):
         session_id = generate_session_id(signed=False, secret_key="abc") # secret shouldn't be used
-        self.assertFalse(check_session_id_signature(session_id, secret_key="abc", signed=True))
+        assert not check_session_id_signature(session_id, secret_key="abc", signed=True)
 
     def test_check_signature_of_empty_string(self):
-        self.assertFalse(check_session_id_signature("", secret_key="abc", signed=True))
+        assert not check_session_id_signature("", secret_key="abc", signed=True)
 
     def test_check_signature_of_junk_with_hyphen_in_it(self):
-        self.assertFalse(check_session_id_signature("foo-bar-baz", secret_key="abc", signed=True))
+        assert not check_session_id_signature("foo-bar-baz", secret_key="abc", signed=True)
 
     def test_check_signature_with_signing_disabled(self):
-        self.assertTrue(check_session_id_signature("gobbledygook", secret_key="abc", signed=False))
+        assert check_session_id_signature("gobbledygook", secret_key="abc", signed=False)
 
     def test_generate_secret_key(self):
         key = generate_secret_key()
-        self.assertEqual(44, len(key))
+        assert 44 == len(key)
         key2 = generate_secret_key()
-        self.assertEqual(44, len(key2))
-        self.assertNotEqual(key, key2)
+        assert 44 == len(key2)
+        assert key != key2
 
     def test_string_encoding_does_not_affect_session_id_check(self):
         # originates from #6653
         session_id = generate_session_id(signed=True, secret_key="abc")
-        self.assertTrue(check_session_id_signature(session_id, secret_key="abc", signed=True))
-        self.assertTrue(check_session_id_signature(decode_utf8(session_id), secret_key="abc", signed=True))
+        assert check_session_id_signature(session_id, secret_key="abc", signed=True)
+        assert check_session_id_signature(decode_utf8(session_id), secret_key="abc", signed=True)

--- a/scripts/ci/install:unit
+++ b/scripts/ci/install:unit
@@ -7,3 +7,7 @@ set -x # echo commands
 pushd bokehjs
 npm install --no-save --no-progress phantomjs
 popd
+
+if  [[ ! -z "${MINIMAL}" ]]; then
+    conda remove --yes --quiet pandas scipy notebook scikit-learn sympy flask
+fi

--- a/scripts/ci/test:unit
+++ b/scripts/ci/test:unit
@@ -3,6 +3,13 @@
 set -e # exit on error
 set -x # echo commands
 
-py.test -m 'unit'                   \
+# sampledata depends on pandas, skip if we are testing with minimal deps
+if  [[ ! -z "${MINIMAL}" ]]; then
+    selector='unit and not sampledata'
+else
+    selector='unit'
+fi
+
+py.test -m "$selector"              \
     --cov=bokeh                     \
     --cov-config=bokeh/.coveragerc

--- a/tests/test_bokehjs.py
+++ b/tests/test_bokehjs.py
@@ -2,11 +2,10 @@ from __future__ import print_function
 
 import os
 import pytest
-import unittest
 import subprocess
 
 @pytest.mark.js
-class TestBokehJS(unittest.TestCase):
+class TestBokehJS(object):
 
     def test_bokehjs(self):
         os.chdir('bokehjs')
@@ -17,6 +16,3 @@ class TestBokehJS(unittest.TestCase):
         print(msg)
         if proc.returncode != 0:
             assert False
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
This adds a `MINIMAL=1` flag to one unit test build that results in these dependencies being uninstalled:

> pandas scipy notebook scikit-learn sympy flask

As a side effect, all reliance on `unittest.TestCase` has been removed, all tests are "pytest" style. As a further result, all use of pandas in unit tests can now be moderated through a `pd` pytest fixture that will automatically skip a test if pandas is not installed, with one exception: The modules in `bokeh.sampledata` heavily depend on pandas and throw a runtime exception stating to install pandas even on just an import . To deal with this the unit test script adds `"and not sampledata"` when `MINIMAL` is set.

- [x] issues: fixes #2596
- [x] tests added / passed
