### PR TITLE
handle Pandas PeriodIndex and Timedelta properly

### DIFF
--- a/bokeh/core/json_encoder.py
+++ b/bokeh/core/json_encoder.py
@@ -46,7 +46,7 @@ import numpy as np
 
 from ..settings import settings
 from ..util.dependencies import import_optional
-from ..util.serialization import convert_datetime_type, is_datetime_type, transform_series, transform_array
+from ..util.serialization import convert_datetime_type, convert_timedelta_type, is_datetime_type, is_timedelta_type, transform_series, transform_array
 
 pd = import_optional('pandas')
 rd = import_optional("dateutil.relativedelta")
@@ -71,6 +71,9 @@ class BokehJSONEncoder(json.JSONEncoder):
         # date/time values that get serialized as milliseconds
         if is_datetime_type(obj):
             return convert_datetime_type(obj)
+
+        if is_timedelta_type(obj):
+            return convert_timedelta_type(obj)
 
         # slice objects
         elif isinstance(obj, slice):

--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -874,12 +874,14 @@ class MinMaxBounds(Either):
             types = (
                 Auto,
                 Tuple(Float, Float),
+                Tuple(TimeDelta, TimeDelta),
                 Tuple(Datetime, Datetime),
             )
         else:
             types = (
                 Auto,
                 Tuple(Float, Float),
+                Tuple(TimeDelta, TimeDelta),
             )
         super(MinMaxBounds, self).__init__(*types, default=default, help=help)
 
@@ -1603,8 +1605,12 @@ class NumberSpec(DataSpec):
     ''' A |DataSpec| property that accepts numeric and datetime fixed values.
 
     By default, date and datetime values are immediately converted to
-    milliseconds since epoch. It it possible to disable processing of datetime
+    milliseconds since epoch. It is possible to disable processing of datetime
     values by passing ``accept_datetime=False``.
+
+    By default, timedelta values are immediately converted to absolute
+    milliseconds.  It is possible to disable processing of timedelta
+    values by passing ``accept_timedelta=False``
 
     Timedelta values are interpreted as absolute milliseconds.
 
@@ -1615,9 +1621,10 @@ class NumberSpec(DataSpec):
         m.location = "foo" # field
 
     '''
-    def __init__(self, default=None, help=None, key_type=_ExprFieldValueTransform, accept_datetime=True):
+    def __init__(self, default=None, help=None, key_type=_ExprFieldValueTransform, accept_datetime=True, accept_timedelta=True):
         super(NumberSpec, self).__init__(key_type, Float, default=default, help=help)
-        self.accepts(TimeDelta, convert_timedelta_type)
+        if accept_timedelta:
+            self.accepts(TimeDelta, convert_timedelta_type)
         if accept_datetime:
             self.accepts(Datetime, convert_datetime_type)
 

--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -106,7 +106,7 @@ from six import string_types, iteritems
 
 from .. import colors
 from ..util.dependencies import import_optional
-from ..util.serialization import convert_datetime_type, decode_base64_dict, transform_column_source_data
+from ..util.serialization import convert_datetime_type, convert_timedelta_type, decode_base64_dict, transform_column_source_data
 from ..util.string import nice_join, format_docstring
 
 from .property.bases import ContainerProperty, DeserializationError, ParameterizedProperty, Property, PrimitiveProperty
@@ -1617,7 +1617,7 @@ class NumberSpec(DataSpec):
     '''
     def __init__(self, default=None, help=None, key_type=_ExprFieldValueTransform, accept_datetime=True):
         super(NumberSpec, self).__init__(key_type, Float, default=default, help=help)
-        self.accepts(TimeDelta, convert_datetime_type)
+        self.accepts(TimeDelta, convert_timedelta_type)
         if accept_datetime:
             self.accepts(Datetime, convert_datetime_type)
 

--- a/bokeh/core/property_mixins.py
+++ b/bokeh/core/property_mixins.py
@@ -76,7 +76,7 @@ class FillProps(HasProps):
     '''
 
     fill_color = ColorSpec(default="gray", help=_color_help % "fill paths")
-    fill_alpha = NumberSpec(default=1.0, accept_datetime=False, help=_alpha_help % "fill paths")
+    fill_alpha = NumberSpec(default=1.0, accept_datetime=False, accept_timedelta=False, help=_alpha_help % "fill paths")
 
 class ScalarFillProps(HasProps):
     ''' Properties relevant to rendering fill regions.
@@ -153,8 +153,8 @@ class LineProps(HasProps):
     base_line_props = Include(BaseLineProps, use_prefix=False)
 
     line_color = ColorSpec(default="black", help=_color_help % "stroke paths")
-    line_width = NumberSpec(default=1, accept_datetime=False, help=_line_width_help)
-    line_alpha = NumberSpec(default=1.0, accept_datetime=False, help=_alpha_help % "stroke paths")
+    line_width = NumberSpec(default=1, accept_datetime=False, accept_timedelta=False, help=_line_width_help)
+    line_alpha = NumberSpec(default=1.0, accept_datetime=False, accept_timedelta=False, help=_alpha_help % "stroke paths")
 
 
 class ScalarLineProps(HasProps):
@@ -240,7 +240,7 @@ class TextProps(HasProps):
 
     text_color = ColorSpec(default="#444444", help=_color_help % "fill text")
 
-    text_alpha = NumberSpec(default=1.0, accept_datetime=False, help=_alpha_help % "fill text")
+    text_alpha = NumberSpec(default=1.0, accept_datetime=False, accept_timedelta=False, help=_alpha_help % "fill text")
 
 class ScalarTextProps(HasProps):
     ''' Properties relevant to rendering text.

--- a/bokeh/core/tests/test_json_encoder.py
+++ b/bokeh/core/tests/test_json_encoder.py
@@ -212,6 +212,23 @@ class TestSerializeJson(object):
         deserialized = self.deserialize(serialized)
         assert deserialized == delta.total_seconds() * 1000
 
+    def test_numpy_timedelta_types(self):
+        delta = np.timedelta64(3000, 'ms')
+        serialized = self.serialize(delta)
+        deserialized = self.deserialize(serialized)
+        assert deserialized == 3000
+
+        delta = np.timedelta64(3000, 's')
+        serialized = self.serialize(delta)
+        deserialized = self.deserialize(serialized)
+        assert deserialized == 3000000
+
+    def test_pandas_timedelta_types(self, pd):
+        delta = pd.Timedelta("3000ms")
+        serialized = self.serialize(delta)
+        deserialized = self.deserialize(serialized)
+        assert deserialized == 3000
+
     def test_deque(self):
         """Test that a deque is deserialized as a list."""
         assert self.serialize(deque([0, 1, 2])) == '[0,1,2]'

--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -513,8 +513,7 @@ class ImageURL(XYGlyph):
     # functions derived from this class
     _args = ('url', 'x', 'y', 'w', 'h', 'angle', 'global_alpha', 'dilate')
 
-    # TODO (bev) Why is this a NumberSpec??
-    url = NumberSpec(accept_datetime=False, help="""
+    url = StringSpec(default=None, help="""
     The URLs to retrieve images from.
 
     .. note::

--- a/bokeh/models/ranges.py
+++ b/bokeh/models/ranges.py
@@ -42,20 +42,20 @@ class Range1d(Range):
 
     '''
 
-    start = Either(Float, Datetime, Int, default=0, help="""
+    start = Either(Float, Datetime, Int, TimeDelta, default=0, help="""
     The start of the range.
     """)
 
-    end = Either(Float, Datetime, Int, default=1, help="""
+    end = Either(Float, Datetime, Int, TimeDelta, default=1, help="""
     The end of the range.
     """)
 
-    reset_start = Either(Float, Datetime, Int, default=None, help="""
+    reset_start = Either(Float, Datetime, Int, TimeDelta, default=None, help="""
     The start of the range to apply after reset. If set to ``None`` defaults
     to the ``start`` value during initialization.
     """)
 
-    reset_end = Either(Float, Datetime, Int, default=None, help="""
+    reset_end = Either(Float, Datetime, Int, TimeDelta, default=None, help="""
     The end of the range to apply when resetting. If set to ``None`` defaults
     to the ``end`` value during initialization.
     """)

--- a/bokeh/models/ranges.py
+++ b/bokeh/models/ranges.py
@@ -9,7 +9,7 @@ from collections import Counter
 
 from ..core.enums import PaddingUnits, StartEnd
 from ..core.has_props import abstract
-from ..core.properties import (Bool, Datetime, Either, Enum, Float, Instance, Int,
+from ..core.properties import (Bool, Datetime, Either, Enum, Float, Instance,
                                List, MinMaxBounds, Seq, String, TimeDelta, Tuple)
 from ..core.validation import error
 from ..core.validation.errors import DUPLICATE_FACTORS
@@ -42,20 +42,20 @@ class Range1d(Range):
 
     '''
 
-    start = Either(Float, Datetime, Int, TimeDelta, default=0, help="""
+    start = Either(Float, Datetime, TimeDelta, default=0, help="""
     The start of the range.
     """)
 
-    end = Either(Float, Datetime, Int, TimeDelta, default=1, help="""
+    end = Either(Float, Datetime, TimeDelta, default=1, help="""
     The end of the range.
     """)
 
-    reset_start = Either(Float, Datetime, Int, TimeDelta, default=None, help="""
+    reset_start = Either(Float, Datetime, TimeDelta, default=None, help="""
     The start of the range to apply after reset. If set to ``None`` defaults
     to the ``start`` value during initialization.
     """)
 
-    reset_end = Either(Float, Datetime, Int, TimeDelta, default=None, help="""
+    reset_end = Either(Float, Datetime, TimeDelta, default=None, help="""
     The end of the range to apply when resetting. If set to ``None`` defaults
     to the ``end`` value during initialization.
     """)
@@ -79,12 +79,12 @@ class Range1d(Range):
         Range1d(start=0, end=1, bounds=(0, None))  # Maximum is unbounded, minimum bounded to 0
     """)
 
-    min_interval = Either(Float, TimeDelta, Int, default=None, help="""
+    min_interval = Either(Float, TimeDelta, default=None, help="""
     The level that the range is allowed to zoom in, expressed as the
     minimum visible interval. If set to ``None`` (default), the minimum
     interval is not bound. Can be a timedelta. """)
 
-    max_interval = Either(Float, TimeDelta, Int, default=None, help="""
+    max_interval = Either(Float, TimeDelta, default=None, help="""
     The level that the range is allowed to zoom out, expressed as the
     maximum visible interval. Can be a timedelta. Note that ``bounds`` can
     impose an implicit constraint on the maximum interval as well. """)
@@ -126,7 +126,7 @@ class DataRange1d(DataRange):
 
     '''
 
-    range_padding = Float(default=0.1, help="""
+    range_padding = Either(Float, TimeDelta, default=0.1, help="""
     How much padding to add around the computed data bounds.
 
     When ``range_padding_units`` is set to ``"percent"``, the span of the
@@ -141,17 +141,17 @@ class DataRange1d(DataRange):
     as an absolute quantity. (default: ``"percent"``)
     """)
 
-    start = Float(help="""
+    start = Either(Float, Datetime, TimeDelta, help="""
     An explicitly supplied range start. If provided, will override
     automatically computed start value.
     """)
 
-    end = Float(help="""
+    end = Either(Float, Datetime, TimeDelta, help="""
     An explicitly supplied range end. If provided, will override
     automatically computed end value.
     """)
 
-    bounds = MinMaxBounds(accept_datetime=False, default=None, help="""
+    bounds = MinMaxBounds(accept_datetime=True, default=None, help="""
     The bounds that the range is allowed to go to. Typically used to prevent
     the user from panning/zooming/etc away from the data.
 
@@ -168,12 +168,12 @@ class DataRange1d(DataRange):
     ``max`` to ``None`` e.g. ``DataRange1d(bounds=(None, 12))``
     """)
 
-    min_interval = Float(default=None, help="""
+    min_interval = Either(Float, TimeDelta, default=None, help="""
     The level that the range is allowed to zoom in, expressed as the
     minimum visible interval. If set to ``None`` (default), the minimum
     interval is not bound.""")
 
-    max_interval = Float(default=None, help="""
+    max_interval = Either(Float, TimeDelta, default=None, help="""
     The level that the range is allowed to zoom out, expressed as the
     maximum visible interval. Note that ``bounds`` can impose an
     implicit constraint on the maximum interval as well.""")
@@ -202,7 +202,7 @@ class DataRange1d(DataRange):
     ``None``.
     """)
 
-    follow_interval = Float(default=None, help="""
+    follow_interval = Either(Float, TimeDelta, default=None, help="""
     If ``follow`` is set to ``"start"`` or ``"end"`` then the range will
     always be constrained to that::
 
@@ -212,7 +212,7 @@ class DataRange1d(DataRange):
 
     """)
 
-    default_span = Float(default=2.0, help="""
+    default_span = Either(Float, TimeDelta, default=2.0, help="""
     A default width for the interval, in case ``start`` is equal to ``end``
     (if used with a log axis, default_span is in powers of 10).
     """)

--- a/bokeh/models/tests/test_ranges.py
+++ b/bokeh/models/tests/test_ranges.py
@@ -115,6 +115,30 @@ class Test_DataRange1d(object):
         assert datarange1d.end is None
         assert datarange1d.bounds is None
 
+    def test_init_with_timedelta(self):
+        datarange1d = DataRange1d(start=-dt.timedelta(seconds=5), end=dt.timedelta(seconds=3))
+        assert datarange1d.start == -dt.timedelta(seconds=5)
+        assert datarange1d.end == dt.timedelta(seconds=3)
+        assert datarange1d.bounds is None
+
+    def test_init_with_datetime(self):
+        datarange1d = DataRange1d(start=dt.datetime(2016, 4, 28, 2, 20, 50), end=dt.datetime(2017, 4, 28, 2, 20, 50))
+        assert datarange1d.start == dt.datetime(2016, 4, 28, 2, 20, 50)
+        assert datarange1d.end == dt.datetime(2017, 4, 28, 2, 20, 50)
+        assert datarange1d.bounds is None
+
+    def test_init_with_float(self):
+        datarange1d = DataRange1d(start=-1.0, end=3.0)
+        assert datarange1d.start == -1.0
+        assert datarange1d.end == 3.0
+        assert datarange1d.bounds is None
+
+    def test_init_with_int(self):
+        datarange1d = DataRange1d(start=-1, end=3)
+        assert datarange1d.start == -1
+        assert datarange1d.end == 3
+        assert datarange1d.bounds is None
+
     def test_init_with_follow_sets_bounds_to_none(self):
         datarange1d = DataRange1d(follow="start")
         assert datarange1d.follow == "start"

--- a/bokeh/models/tests/test_ranges.py
+++ b/bokeh/models/tests/test_ranges.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import datetime as dt
+
 import mock
 import pytest
 
@@ -22,6 +24,30 @@ class Test_Range1d(object):
             "min_interval",
             "max_interval"],
         )
+
+    def test_init_with_timedelta(self):
+        range1d = Range1d(start=-dt.timedelta(seconds=5), end=dt.timedelta(seconds=3))
+        assert range1d.start == -dt.timedelta(seconds=5)
+        assert range1d.end == dt.timedelta(seconds=3)
+        assert range1d.bounds is None
+
+    def test_init_with_datetime(self):
+        range1d = Range1d(start=dt.datetime(2016, 4, 28, 2, 20, 50), end=dt.datetime(2017, 4, 28, 2, 20, 50))
+        assert range1d.start == dt.datetime(2016, 4, 28, 2, 20, 50)
+        assert range1d.end == dt.datetime(2017, 4, 28, 2, 20, 50)
+        assert range1d.bounds is None
+
+    def test_init_with_float(self):
+        range1d = Range1d(start=-1.0, end=3.0)
+        assert range1d.start == -1.0
+        assert range1d.end == 3.0
+        assert range1d.bounds is None
+
+    def test_init_with_int(self):
+        range1d = Range1d(start=-1, end=3)
+        assert range1d.start == -1
+        assert range1d.end == 3
+        assert range1d.bounds is None
 
     def test_init_with_positional_arguments(self):
         range1d = Range1d(1, 2)

--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -38,14 +38,11 @@ BINARY_ARRAY_TYPES = set([
     np.dtype(np.int32),
 ])
 
-# TODO (bev) properly, timedelta values should not be considered datetime types
 DATETIME_TYPES = set([
     dt.datetime,
-    dt.timedelta,
     dt.date,
     dt.time,
     np.datetime64,
-    np.timedelta64
 ])
 
 if pd:
@@ -69,8 +66,8 @@ _simple_id = 1000
 _dt_tuple = tuple(DATETIME_TYPES)
 
 def is_datetime_type(obj):
-    ''' Whether an object is any date, datetime, or time delta type
-    recognized by Bokeh.
+    ''' Whether an object is any date, time, or datetime type recognized by
+    Bokeh.
 
     Arg:
         obj (object) : the object to test
@@ -81,13 +78,37 @@ def is_datetime_type(obj):
     '''
     return isinstance(obj, _dt_tuple)
 
+def is_timedelta_type(obj):
+    ''' Whether an object is any timedelta type recognized by Bokeh.
+
+    Arg:
+        obj (object) : the object to test
+
+    Returns:
+        bool : True if ``obj`` is a timedelta type
+
+    '''
+    return isinstance(obj, (dt.timedelta, np.timedelta64))
+
+def convert_timedelta_type(obj):
+    ''' Convert any recognized timedelta value to floating point absolute
+    milliseconds.
+
+    Arg:
+        obj (object) : the object to convert
+
+    Returns:
+        float : milliseconds
+
+    '''
+    if isinstance(obj, dt.timedelta):
+        return obj.total_seconds() * 1000.
+    elif isinstance(obj, np.timedelta64):
+        return (obj / NP_MS_DELTA)
+
 def convert_datetime_type(obj):
-    ''' Convert any recognized date, datetime or time delta value to
-    floating point milliseconds
-
-    Date and Datetime values are converted to milliseconds since epoch.
-
-    TimeDeleta values are converted to absolute milliseconds.
+    ''' Convert any recognized date, time, or datetime value to floating point
+    milliseconds since epoch.
 
     Arg:
         obj (object) : the object to convert
@@ -111,10 +132,6 @@ def convert_datetime_type(obj):
         diff = obj.replace(tzinfo=None) - DT_EPOCH
         return diff.total_seconds() * 1000.
 
-    # Timedelta (timedelta is class in the datetime library)
-    elif isinstance(obj, dt.timedelta):
-        return obj.total_seconds() * 1000.
-
     # Date
     elif isinstance(obj, dt.date):
         return (dt.datetime(*obj.timetuple()[:6]) - DT_EPOCH).total_seconds() * 1000
@@ -123,10 +140,6 @@ def convert_datetime_type(obj):
     elif isinstance(obj, np.datetime64):
         epoch_delta = obj - NP_EPOCH
         return (epoch_delta / NP_MS_DELTA)
-
-    # Numpy timedelta64
-    elif isinstance(obj, np.timedelta64):
-        return (obj / NP_MS_DELTA)
 
     # Time
     elif isinstance(obj, dt.time):

--- a/bokeh/util/tests/test_serialization.py
+++ b/bokeh/util/tests/test_serialization.py
@@ -43,19 +43,22 @@ def test_datetime_types(pd):
     if pd is None:
         assert len(bus.DATETIME_TYPES) == 6
     else:
-        assert len(bus.DATETIME_TYPES) == 8
+        assert len(bus.DATETIME_TYPES) == 9
 
-def test_is_datetime_type(pd):
+def test_is_datetime_type_non_pandas_types():
     assert bus.is_datetime_type(datetime.datetime(2016, 5, 11))
     assert bus.is_datetime_type(datetime.timedelta(3000))
     assert bus.is_datetime_type(datetime.date(2016, 5, 11))
     assert bus.is_datetime_type(datetime.time(3, 54))
     assert bus.is_datetime_type(np.datetime64("2011-05-11"))
     assert bus.is_datetime_type(np.timedelta64(3000, 'ms'))
+
+def test_is_datetime_type_pandas_types(pd):
     assert bus.is_datetime_type(pd.Timedelta("3000ms"))
     assert bus.is_datetime_type(bus._pd_timestamp(3000000))
+    assert bus.is_datetime_type(pd.Period('1900', 'A-DEC'))
 
-def test_convert_datetime_type(pd):
+def test_convert_datetime_type_non_pandas_types():
     assert bus.convert_datetime_type(datetime.datetime(2018, 1, 3, 15, 37, 59, 922452)) == 1514993879922.452
     assert bus.convert_datetime_type(datetime.datetime(2018, 1, 3, 15, 37, 59)) == 1514993879000.0
     assert bus.convert_datetime_type(datetime.datetime(2016, 5, 11)) == 1462924800000.0
@@ -64,8 +67,12 @@ def test_convert_datetime_type(pd):
     assert bus.convert_datetime_type(datetime.time(3, 54)) == 14040000.0
     assert bus.convert_datetime_type(np.datetime64("2016-05-11")) == 1462924800000.0
     assert bus.convert_datetime_type(np.timedelta64(3000, 'ms')) == 3000.0
+
+def test_convert_datetime_type_pandas_types(pd):
     assert bus.convert_datetime_type(pd.Timedelta("3000ms")) == 3000.0
     assert bus.convert_datetime_type(bus._pd_timestamp(3000000)) == 3.0
+    assert bus.convert_datetime_type(pd.Period('1900', 'A-DEC')) == -2208988800000.0
+    assert bus.convert_datetime_type(pd.Period('1900', 'A-DEC')) == bus.convert_datetime_type(np.datetime64("1900-01-01"))
 
 @pytest.mark.parametrize('obj', [[1,2], (1,2), dict(), set(), 10.2, "foo"])
 @pytest.mark.unit
@@ -164,6 +171,8 @@ def test_transform_series_force_list_default_with_buffers(pd):
     assert isinstance(out, dict)
     assert len(bufs) == 1
     assert len(bufs[0]) == 2
+    assert isinstance(bufs[0][0], dict)
+    assert list(bufs[0][0]) == ["id"]
     assert bufs[0][1] == np.array(df).tobytes()
     assert 'shape' in out
     assert out['shape'] == df.shape
@@ -177,6 +186,8 @@ def test_transform_series_force_list_default_with_buffers(pd):
     assert isinstance(out, dict)
     assert len(bufs) == 1
     assert len(bufs[0]) == 2
+    assert isinstance(bufs[0][0], dict)
+    assert list(bufs[0][0]) == ["id"]
     assert bufs[0][1] == np.array(df).tobytes()
     assert 'shape' in out
     assert out['shape'] == df.shape
@@ -190,12 +201,63 @@ def test_transform_series_force_list_default_with_buffers(pd):
     assert isinstance(out, dict)
     assert len(bufs) == 1
     assert len(bufs[0]) == 2
+    assert isinstance(bufs[0][0], dict)
+    assert list(bufs[0][0]) == ["id"]
     assert bufs[0][1] == np.array(df).tobytes()
     assert 'shape' in out
     assert out['shape'] == df.shape
     assert 'dtype' in out
     assert out['dtype'] == df.dtype.name
     assert '__buffer__' in out
+
+    # PeriodIndex
+    df = pd.period_range('1900-01-01','2000-01-01', freq='A')
+    bufs = []
+    out = bus.transform_series(df, buffers=bufs)
+    assert isinstance(out, dict)
+    assert len(bufs) == 1
+    assert len(bufs[0]) == 2
+    assert isinstance(bufs[0][0], dict)
+    assert list(bufs[0][0]) == ["id"]
+    assert bufs[0][1] == bus.convert_datetime_array(df.to_timestamp().values).tobytes()
+    assert 'shape' in out
+    assert out['shape'] == df.shape
+    assert 'dtype' in out
+    assert out['dtype'] == 'float64'
+    assert '__buffer__' in out
+
+    # DatetimeIndex
+    df = pd.period_range('1900-01-01','2000-01-01', freq='A').to_timestamp()
+    bufs = []
+    out = bus.transform_series(df, buffers=bufs)
+    assert isinstance(out, dict)
+    assert len(bufs) == 1
+    assert len(bufs[0]) == 2
+    assert isinstance(bufs[0][0], dict)
+    assert list(bufs[0][0]) == ["id"]
+    assert bufs[0][1] == bus.convert_datetime_array(df.values).tobytes()
+    assert 'shape' in out
+    assert out['shape'] == df.shape
+    assert 'dtype' in out
+    assert out['dtype'] == 'float64'
+    assert '__buffer__' in out
+
+    # TimeDeltaIndex
+    df = pd.to_timedelta(np.arange(5), unit='s')
+    bufs = []
+    out = bus.transform_series(df, buffers=bufs)
+    assert isinstance(out, dict)
+    assert len(bufs) == 1
+    assert len(bufs[0]) == 2
+    assert isinstance(bufs[0][0], dict)
+    assert list(bufs[0][0]) == ["id"]
+    assert bufs[0][1] == bus.convert_datetime_array(df.values).tobytes()
+    assert 'shape' in out
+    assert out['shape'] == df.shape
+    assert 'dtype' in out
+    assert out['dtype'] == 'float64'
+    assert '__buffer__' in out
+
 
 def test_transform_series_force_list_true(pd):
     df = pd.Series([1, 3, 5, 6, 8])

--- a/bokeh/util/tests/test_serialization.py
+++ b/bokeh/util/tests/test_serialization.py
@@ -41,20 +41,31 @@ def test_binary_array_types():
 
 def test_datetime_types(pd):
     if pd is None:
-        assert len(bus.DATETIME_TYPES) == 6
+        assert len(bus.DATETIME_TYPES) == 4
     else:
-        assert len(bus.DATETIME_TYPES) == 9
+        assert len(bus.DATETIME_TYPES) == 7
+
+def test_is_timedelta_type_non_pandas_types():
+    assert bus.is_timedelta_type(datetime.timedelta(3000))
+    assert bus.is_timedelta_type(np.timedelta64(3000, 'ms'))
+
+def test_is_timedelta_type_pandas_types(pd):
+    assert bus.is_timedelta_type(pd.Timedelta("3000ms"))
+
+def test_convert_timedelta_type_non_pandas_types():
+    assert bus.convert_timedelta_type(datetime.timedelta(3000)) == 259200000000.0
+    assert bus.convert_timedelta_type(np.timedelta64(3000, 'ms')) == 3000.
+
+def test_convert_timedelta_type_pandas_types(pd):
+    assert bus.convert_timedelta_type(pd.Timedelta("3000ms")) == 3000.0
 
 def test_is_datetime_type_non_pandas_types():
     assert bus.is_datetime_type(datetime.datetime(2016, 5, 11))
-    assert bus.is_datetime_type(datetime.timedelta(3000))
     assert bus.is_datetime_type(datetime.date(2016, 5, 11))
     assert bus.is_datetime_type(datetime.time(3, 54))
     assert bus.is_datetime_type(np.datetime64("2011-05-11"))
-    assert bus.is_datetime_type(np.timedelta64(3000, 'ms'))
 
 def test_is_datetime_type_pandas_types(pd):
-    assert bus.is_datetime_type(pd.Timedelta("3000ms"))
     assert bus.is_datetime_type(bus._pd_timestamp(3000000))
     assert bus.is_datetime_type(pd.Period('1900', 'A-DEC'))
 
@@ -62,14 +73,11 @@ def test_convert_datetime_type_non_pandas_types():
     assert bus.convert_datetime_type(datetime.datetime(2018, 1, 3, 15, 37, 59, 922452)) == 1514993879922.452
     assert bus.convert_datetime_type(datetime.datetime(2018, 1, 3, 15, 37, 59)) == 1514993879000.0
     assert bus.convert_datetime_type(datetime.datetime(2016, 5, 11)) == 1462924800000.0
-    assert bus.convert_datetime_type(datetime.timedelta(3000)) == 259200000000.0
     assert bus.convert_datetime_type(datetime.date(2016, 5, 11)) == 1462924800000.0
     assert bus.convert_datetime_type(datetime.time(3, 54)) == 14040000.0
     assert bus.convert_datetime_type(np.datetime64("2016-05-11")) == 1462924800000.0
-    assert bus.convert_datetime_type(np.timedelta64(3000, 'ms')) == 3000.0
 
 def test_convert_datetime_type_pandas_types(pd):
-    assert bus.convert_datetime_type(pd.Timedelta("3000ms")) == 3000.0
     assert bus.convert_datetime_type(bus._pd_timestamp(3000000)) == 3.0
     assert bus.convert_datetime_type(pd.Period('1900', 'A-DEC')) == -2208988800000.0
     assert bus.convert_datetime_type(pd.Period('1900', 'A-DEC')) == bus.convert_datetime_type(np.datetime64("1900-01-01"))


### PR DESCRIPTION
- [x] issues: fixes #2266 fixes #5426
- [x] tests added / passed

Noticed quite a bit of silliness in working on those two issues, so added some other cleanup. This PR:

* adds proper handling for Pandas `Period` and `PeriodIndex`, also making sure the binary protocol is used for Pandas series when it should be

* clarifies internally that time delta values are not datetimes

* allows Range1d to accept time delta values

* allows DataRange1d to also accept datetimes and time delta values (cannot think of any reason they should not)

* fixes the bizarre `url = NumberSpec` type on `ImageURL`

Thanks to @miccoli for discussion and prompting