### PR TITLE
Added x and y values to the geometries property of cb_data when tapto…

### DIFF
--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -394,6 +394,13 @@ class TapTool(Tap):
     its ``.source`` attribute and the selection geometry as its
     ``.geometries`` attribute.
 
+    The ``.geometries`` attribute has 5 members.
+    ``.type`` is the geometry type, which always a ``.point`` for a tap event.
+    ``.sx`` and ``.sy`` are the screen X and Y coordinates where the tap occurred.
+    ``.x`` and ``.y`` are the converted data coordinates for the item that has
+    been selected. The ``.x`` and ``.y`` values are based on the axis assiged
+    to that glyph.
+
     .. note::
         This callback does *not* execute on every tap, only when a glyphs is
         "hit". If you would like to execute a callback on every mouse tap,

--- a/bokehjs/src/lib/models/tools/gestures/tap_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/tap_tool.ts
@@ -2,7 +2,7 @@ import {SelectTool, SelectToolView} from "./select_tool"
 import * as p from "core/properties"
 import {TapEvent} from "core/ui_events"
 import {isFunction} from "core/util/types"
-import {Geometry, PointGeometry} from "core/geometry"
+import {PointGeometry} from "core/geometry"
 import {DataSource} from "../../sources/data_source"
 
 export class TapToolView extends SelectToolView {
@@ -22,14 +22,6 @@ export class TapToolView extends SelectToolView {
   _select(geometry: PointGeometry, final: boolean, append: boolean): void {
     const callback = this.model.callback
 
-    const cb_data: {
-      geometries: Geometry,
-      source: DataSource | null,
-    } = {
-      geometries: geometry,
-      source: null,
-    }
-
     if (this.model.behavior == "select") {
       const renderers_by_source = this._computed_renderers_by_data_source()
 
@@ -40,7 +32,16 @@ export class TapToolView extends SelectToolView {
         const did_hit = sm.select(r_views, geometry, final, append)
 
         if (did_hit && callback != null) {
-          cb_data.source = sm.source
+          const frame = this.plot_model.frame
+          const xscale = frame.xscales[renderers[0].x_range_name]
+          const yscale = frame.yscales[renderers[0].y_range_name]
+          const x = xscale.invert(geometry.sx)
+          const y = yscale.invert(geometry.sy)
+          const g = {...geometry, x, y}
+          const cb_data: {
+              geometries: { type: "point", sx: number, sy: number, x: number, y: number }
+              source: DataSource | null,
+          } = { geometries: g, source: sm.source }
           if (isFunction(callback))
             callback(this, cb_data)
           else
@@ -56,7 +57,16 @@ export class TapToolView extends SelectToolView {
         const did_hit = sm.inspect(this.plot_view.renderer_views[r.id], geometry)
 
         if (did_hit && callback != null) {
-          cb_data.source = sm.source
+          const frame = this.plot_model.frame
+          const xscale = frame.xscales[r.x_range_name]
+          const yscale = frame.yscales[r.y_range_name]
+          const x = xscale.invert(geometry.sx)
+          const y = yscale.invert(geometry.sy)
+          const g = {...geometry, x, y}
+          const cb_data: {
+              geometries: { type: "point", sx: number, sy: number, x: number, y: number }
+              source: DataSource | null,
+          } = { geometries: g, source: sm.source }
           if (isFunction(callback))
             callback(this, cb_data)
           else


### PR DESCRIPTION
Addes two additional variables to the cb_data.geometries object when a callback is called from the taptool.

x, and y provide values for the calculated data values for the x and y screen coordinates sx and sy

- [x] issues: fixes #8013 
- [x] tests added / passed
- [x] release document entry (if new feature or API change)
