### PR TITLE
improved support for pyinstaller

### DIFF
--- a/bokeh/core/templates.py
+++ b/bokeh/core/templates.py
@@ -25,7 +25,7 @@ def get_env():
     ''' Get the correct Jinja2 Environment, also for frozen scripts.
     '''
     if getattr(sys, 'frozen', False):
-        templates_path = os.path.join(sys._MEIPASS, '_templates')
+        templates_path = os.path.join(sys._MEIPASS, 'bokeh', 'core', '_templates')
         return Environment(loader=FileSystemLoader(templates_path))
     else:
         return Environment(loader=PackageLoader('bokeh.core', '_templates'))


### PR DESCRIPTION
A better treatment for freezing bokeh with pyinstaller.

The `_templates` dir should better stay in its original subdirectory than in the project root as implemented in #8008, as it better fits pyinstaller directory layout: as documented [here](https://pythonhosted.org/PyInstaller/hooks.html), `collect_data_files()` as opposed to `--add-data` doesn't support the destination path.

See my [PR3607](https://github.com/pyinstaller/pyinstaller/pull/3607) with the associated pyinstaller hook file which uses the new _templates location.