### PR TITLE
format Bokeh warnings more nicely

### DIFF
--- a/bokeh/__init__.py
+++ b/bokeh/__init__.py
@@ -60,10 +60,21 @@ from . import sampledata; sampledata
 from .util import logconfig
 del logconfig
 
-# Configure warnings to always show, despite Python's active efforts to hide them from users.
+# Configure warnings to always show nice mssages, despite Python's active
+# efforts to hide them from users.
 import warnings
 from .util.warnings import BokehDeprecationWarning, BokehUserWarning
 warnings.simplefilter('always', BokehDeprecationWarning)
 warnings.simplefilter('always', BokehUserWarning)
+
+original_formatwarning = warnings.formatwarning
+def _formatwarning(message, category, filename, lineno, line=None):
+    from .util.warnings import BokehDeprecationWarning, BokehUserWarning
+    if category not in (BokehDeprecationWarning, BokehUserWarning):
+        return original_formatwarning(message, category, filename, lineno, line)
+    return "%s: %s\n" % (category.__name__, message)
+warnings.formatwarning = _formatwarning
+
+del _formatwarning
 del BokehDeprecationWarning, BokehUserWarning
 del warnings

--- a/bokeh/tests/test___init__.py
+++ b/bokeh/tests/test___init__.py
@@ -20,12 +20,14 @@ import pytest ; pytest
 # Standard library imports
 from os.path import dirname, join
 from shutil import copy
+import warnings
 
 # External imports
 from six import string_types
 
 # Bokeh imports
 from bokeh.util.testing import verify_all
+from bokeh.util.warnings import BokehDeprecationWarning, BokehUserWarning
 
 # Module under test
 import bokeh as b
@@ -95,3 +97,17 @@ def test_license(capsys):
     b.license()
     out, err = capsys.readouterr()
     assert out == _LICENSE
+
+class TestWarnings(object):
+    @pytest.mark.parametrize('cat', (BokehDeprecationWarning, BokehUserWarning))
+    def test_bokeh_custom(self, cat):
+        r = warnings.formatwarning("message", cat, "line", "lineno")
+        assert r == "%s: %s\n" %(cat.__name__, "message")
+
+    def test_general_default(self):
+        r = warnings.formatwarning("message", RuntimeWarning, "line", "lineno")
+        assert r == "line:lineno: RuntimeWarning: message\n"
+
+    def test_filters(self):
+        assert ('always', None, BokehUserWarning, None, 0) in warnings.filters
+        assert ('always', None, BokehDeprecationWarning, None, 0) in warnings.filters


### PR DESCRIPTION
- [x] issues: fixes #6362
- [x] tests added / passed

With this change, (Bokeh) warnings are now streamlined:
```
In [5]: from bokeh.models import ColumnDataSource; source = ColumnDataSource(data=dict(a=[1], b=[1,2]))
BokehUserWarning: ColumnDataSource's columns must be of the same length. Current lengths: ('a', 1), ('b', 2)
```
The rationale for dropping the line and lineno is that warnings are typically emitted deep in Bokeh library code, which is not helpful, and also often as part of validation, so that raising the stacklevel is also not useful or practical. 

Non-Bokeh warnings should continue to function as normal. 