### PR TITLE
add validation on extra range names

### DIFF
--- a/bokeh/core/validation/errors.py
+++ b/bokeh/core/validation/errors.py
@@ -66,7 +66,10 @@ validation checks.
     The RangeTool must have at least one of x_range or y_range configured
 
 1019 *(DUPLICATE_FACTORS)*
-    FactorRange must specicy a unique list of categorical factors for an axis.
+    FactorRange must specify a unique list of categorical factors for an axis.
+
+1020 *(BAD_EXTRA_RANGE_NAME)*
+    An extra range name is configued with a name that does not correspond to any range.
 
 9999 *(EXT)*
     Indicates that a custom error check has failed.
@@ -86,13 +89,14 @@ codes = {
     1010: ("CDSVIEW_SOURCE_DOESNT_MATCH",                        "CDSView used by Glyph renderer must have a source that matches the Glyph renderer's data source"),
     1011: ("MALFORMED_GRAPH_SOURCE",                             "The GraphSource is incorrectly configured"),
     1012: ("INCOMPATIBLE_MAP_RANGE_TYPE",                        "Map plots can only support Range1d types, not data ranges"),
-    1013: ("INCOMPATIBLE_POINT_DRAW_RENDERER",                   "PointDrawTool renderers may only reference XYGlyph models."),
+    1013: ("INCOMPATIBLE_POINT_DRAW_RENDERER",                   "PointDrawTool renderers may only reference XYGlyph models"),
     1014: ("INCOMPATIBLE_BOX_EDIT_RENDERER",                     "BoxEditTool renderers may only reference Rect glyph models"),
-    1015: ("INCOMPATIBLE_POLY_DRAW_RENDERER",                    "PolyDrawTool renderers may only reference MultiLine and Patches glyph models."),
+    1015: ("INCOMPATIBLE_POLY_DRAW_RENDERER",                    "PolyDrawTool renderers may only reference MultiLine and Patches glyph models"),
     1016: ("INCOMPATIBLE_POLY_EDIT_RENDERER",                    "PolyEditTool renderers may only reference MultiLine and Patches glyph models"),
     1017: ("INCOMPATIBLE_POLY_EDIT_VERTEX_RENDERER",             "PolyEditTool vertex_renderer may only reference XYGlyph models"),
     1018: ("NO_RANGE_TOOL_RANGES",                               "RangeTool must have at least one of x_range or y_range configured"),
     1019: ("DUPLICATE_FACTORS",                                  "FactorRange must specicy a unique list of categorical factors for an axis"),
+    1020: ("BAD_EXTRA_RANGE_NAME",                               "An extra range name is configued with a name that does not correspond to any range"),
     9999: ("EXT",                                                "Custom extension reports error"),
 }
 

--- a/bokeh/models/tests/test_sources.py
+++ b/bokeh/models/tests/test_sources.py
@@ -618,26 +618,26 @@ Lime,Green,99,$0.39
 
         with warnings.catch_warnings(record=True) as warns:
             ColumnDataSource(data=dict(a=[10, 11], b=[20, 21, 22]))
-            assert len(warns) == 1
-            assert str(warns[0].message) == "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 2), ('b', 3)"
+        assert len(warns) == 1
+        assert str(warns[0].message) == "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 2), ('b', 3)"
 
         ds = ColumnDataSource()
         with warnings.catch_warnings(record=True) as warns:
             ds.data = dict(a=[10, 11], b=[20, 21, 22])
-            assert len(warns) == 1
-            assert str(warns[0].message) == "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 2), ('b', 3)"
+        assert len(warns) == 1
+        assert str(warns[0].message) == "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 2), ('b', 3)"
 
         ds = ColumnDataSource(data=dict(a=[10, 11]))
         with warnings.catch_warnings(record=True) as warns:
             ds.data["b"] = [20, 21, 22]
-            assert len(warns) == 1
-            assert str(warns[0].message) == "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 2), ('b', 3)"
+        assert len(warns) == 1
+        assert str(warns[0].message) == "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 2), ('b', 3)"
 
         ds = ColumnDataSource(data=dict(a=[10, 11], b=[20, 21]))
         with warnings.catch_warnings(record=True) as warns:
             ds.data.update(dict(a=[10, 11, 12]))
-            assert len(warns) == 1
-            assert str(warns[0].message) == "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 3), ('b', 2)"
+        assert len(warns) == 1
+        assert str(warns[0].message) == "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 3), ('b', 2)"
 
     def test_set_data_from_json_list(self):
         ds = ColumnDataSource()


### PR DESCRIPTION
- [x] issues: fixes #7320
- [x] tests added / passed

Also cleans up some other minor test and formatting issues. 

Generates this sort of error:
```
In [7]: p = figure()

In [8]: p.xaxis.x_range_name = "junk"

In [9]: check_integrity([p])
ERROR:bokeh.core.validation.check:E-1020 (BAD_EXTRA_RANGE_NAME): An extra range name is configued with a name that does not correspond to any range: x_range_name='junk' [LinearAxis(id='db4bc5d5-79cf-4d64-89c2-39b7db443848', ...)]```