### PR TITLE
fix annulus hit testing with screen units

### DIFF
--- a/bokehjs/src/lib/models/glyphs/annulus.ts
+++ b/bokehjs/src/lib/models/glyphs/annulus.ts
@@ -84,12 +84,25 @@ export class AnnulusView extends XYGlyphView {
   protected _hit_point(geometry: PointGeometry): Selection {
     const {sx, sy} = geometry
     const x = this.renderer.xscale.invert(sx)
-    const x0 = x - this.max_outer_radius
-    const x1 = x + this.max_outer_radius
-
     const y = this.renderer.yscale.invert(sy)
-    const y0 = y - this.max_outer_radius
-    const y1 = y + this.max_outer_radius
+
+    let x0: number, y0: number
+    let x1: number, y1: number
+    if (this.model.properties.outer_radius.units == "data") {
+      x0 = x - this.max_outer_radius;
+      x1 = x + this.max_outer_radius;
+
+      y0 = y - this.max_outer_radius;
+      y1 = y + this.max_outer_radius;
+    } else {
+      const sx0 = sx - this.max_outer_radius;
+      const sx1 = sx + this.max_outer_radius;
+      [x0, x1] = this.renderer.xscale.r_invert(sx0, sx1);
+
+      const sy0 = sy - this.max_outer_radius;
+      const sy1 = sy + this.max_outer_radius;
+      [y0, y1] = this.renderer.yscale.r_invert(sy0, sy1);
+    }
 
     const hits: [number, number][] = []
 


### PR DESCRIPTION
Corrects annulus hit testing where outer diameter is specified in screen units. 

Coincidently I noticed you can specify an annulus with an inner diameter greater than the outer diameter, in that case hover fails.

- [X] issues: fixes #2022
- [] tests passed

