### PR TITLE
clamp bar endpoints to viewport

### DIFF
--- a/bokehjs/src/lib/models/glyphs/box.ts
+++ b/bokehjs/src/lib/models/glyphs/box.ts
@@ -63,6 +63,20 @@ export abstract class BoxView extends GlyphView {
     }
   }
 
+  // We need to clamp the endpoints inside the viewport, because various browser canvas
+  // implementations have issues drawing rects with enpoints far outside the viewport
+  protected _clamp_viewport(): void {
+    const hr = this.renderer.plot_view.frame.bbox.h_range
+    const vr = this.renderer.plot_view.frame.bbox.v_range
+    const n = this.stop.length
+    for (let i = 0; i < n; i++) {
+      this.stop[i] = Math.max(this.stop[i], vr.start)
+      this.sbottom[i] = Math.min(this.sbottom[i], vr.end)
+      this.sleft[i] = Math.max(this.sleft[i], hr.start)
+      this.sright[i] = Math.min(this.sright[i], hr.end)
+    }
+  }
+
   protected _hit_rect(geometry: RectGeometry): Selection {
     return this._hit_rect_against_index(geometry)
   }

--- a/bokehjs/src/lib/models/glyphs/hbar.ts
+++ b/bokehjs/src/lib/models/glyphs/hbar.ts
@@ -59,6 +59,8 @@ export class HBarView extends BoxView {
       this.stop[i] = this.sy[i] - this.sh[i]/2
       this.sbottom[i] = this.sy[i] + this.sh[i]/2
     }
+
+    this._clamp_viewport()
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/vbar.ts
+++ b/bokehjs/src/lib/models/glyphs/vbar.ts
@@ -59,6 +59,8 @@ export class VBarView extends BoxView {
       this.sleft[i] = this.sx[i] - this.sw[i]/2
       this.sright[i] = this.sx[i] + this.sw[i]/2
     }
+
+    this._clamp_viewport()
   }
 }
 


### PR DESCRIPTION
- [x] issues: fixes #8060
- [ ] tests added / passed

OP code now generates:

<img width="603" alt="screen shot 2018-07-09 at 12 29 57" src="https://user-images.githubusercontent.com/1078448/42471791-e3848f36-8373-11e8-99ef-4e3454d88adc.png">

Tested manually with `hbar`. Need to verify hover, etc is not impacted. Also need to add at minimum, unit tests for the viewport clamp function, but would like to add some selenium tests on travis directly. 
