### PR TITLE
Ensure BoxDrawTool does not draw when tool inactive

### DIFF
--- a/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
@@ -82,6 +82,7 @@ export class BoxEditToolView extends EditToolView {
   }
 
   _doubletap(ev: TapEvent): void {
+    if (!this.model.active) { return; }
     if (this._draw_basepoint != null) {
       this._update_box(ev, false, true)
       this._draw_basepoint = null;

--- a/bokehjs/test/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/test/models/tools/edit/box_edit_tool.ts
@@ -212,5 +212,13 @@ describe("BoxEditTool", () =>
       expect(testcase.data_source.data['z']).to.be.deep.equal([null, null, null, "Test"]);
     });
 
+    it("should not draw box on doubletap when tool inactive", function(): void {
+      const testcase = make_testcase();
+      testcase.draw_tool_view.model.active = false;
+
+      let drag_event = make_gesture_event(300, 300, true);
+      testcase.draw_tool_view._doubletap(drag_event);
+      expect(testcase.draw_tool_view._draw_basepoint).to.be.equal(undefined);
+    });
   }),
 );

--- a/bokehjs/test/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/test/models/tools/edit/poly_draw_tool.ts
@@ -241,5 +241,14 @@ describe("PolyDrawTool", (): void => {
 
       expect(testcase.data_source.data['z']).to.be.deep.equal([null, null, "Test"]);
     });
+
+    it("should not draw poly on doubletap when tool inactive", function(): void {
+      const testcase = make_testcase();
+      testcase.draw_tool_view.model.active = false;
+
+      let drag_event = make_gesture_event(300, 300, true);
+      testcase.draw_tool_view._doubletap(drag_event);
+      expect(testcase.draw_tool_view._drawing).to.be.equal(false);
+    });
   })
 });


### PR DESCRIPTION
This PR adds a simple check to ensure the BoxEditTool does not draw when the tool is inactive. Also adds unit tests to avoid regressions.

- [x] issues: fixes https://github.com/bokeh/bokeh/issues/8075
- [x] tests added / passed