### PR TITLE
Fixes #6770. Flatten pandas columns and index explicitly on CDS creation

### DIFF
--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -65,10 +65,15 @@ class ColumnDataSource(ColumnarDataSource):
           source = ColumnDataSource(df)
 
       In this case the CDS will have columns corresponding to the columns of
-      the ``DataFrame``. If the ``DataFrame`` has a named index column, then
-      CDS will also have a column with this name. However, if the index name
-      (or any subname of a ``MultiIndex``) is ``None``, then the CDS will have
-      a column generically named ``index`` for the index.
+      the ``DataFrame``. If the ``DataFrame`` columns have multiple levels,
+      they will be flattend using an underscore (e.g. level_0_col_level_1_col).
+      The index of the DataFrame will be flattened to an ``Index`` of tuples
+      if it's a ``MultiIndex``, and then reset using ``reset_index``. The result
+      will be a column with the same name if the index was named, or
+      level_0_name_level_1_name if it was a named ``MultiIndex``. If the
+      ``Index`` did not have a name or the ``MultiIndex`` name could not be
+      flattened/determined, the ``reset_index`` function will name the index column
+      ``index``, or ``level_0`` if the name ``index`` is not available.
 
     * A Pandas ``GroupBy`` object
 

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -158,7 +158,11 @@ class ColumnDataSource(ColumnarDataSource):
 
         # Flatten columns
         if isinstance(df.columns, pd.MultiIndex):
-            _df.columns = ['_'.join(col) for col in _df.columns.values]
+            try:
+                _df.columns = ['_'.join(col) for col in _df.columns.values]
+            except TypeError:
+                raise TypeError('Could not flatten MultiIndex columns. '
+                                'use string column names or flatten manually')
         # Flatten index
         index_name = ColumnDataSource._df_index_name(df)
         if index_name == 'index':

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -150,16 +150,24 @@ class ColumnDataSource(ColumnarDataSource):
 
         '''
         _df = df.copy()
+
+        # Flatten columns
+        if isinstance(df.columns, pd.MultiIndex):
+            _df.columns = ['_'.join(col) for col in _df.columns.values]
+        # Flatten index
+        index_name = ColumnDataSource._df_index_name(df)
+        if index_name == 'index':
+            _df.index = pd.Index(_df.index.values)
+        else:
+            _df.index = pd.Index(_df.index.values, name=index_name)
+        _df.reset_index(inplace=True)
+
         tmp_data = {c: v.values for c, v in _df.iteritems()}
 
         new_data = {}
         for k, v in tmp_data.items():
-            if isinstance(k, tuple):
-                k = "_".join(k)
             new_data[k] = v
 
-        index_name = ColumnDataSource._df_index_name(df)
-        new_data[index_name] = _df.index.values
         return new_data
 
     @staticmethod

--- a/bokeh/models/tests/test_sources.py
+++ b/bokeh/models/tests/test_sources.py
@@ -65,6 +65,18 @@ class TestColumnDataSource(object):
         assert [0, 1] == list(ds.data['level_0'])
         assert set(ds.column_names) - set(df.columns) == set(["level_0"])
 
+    def test_init_dataframe_nonstring_named_column(self, pd):
+        data = {1: [1, 2], 2: [2, 3]}
+        df = pd.DataFrame(data)
+        with pytest.raises(ValueError, match=r'expected an element of.*') as cm:
+            ColumnDataSource(data=df)
+
+    def test_init_dataframe_nonstring_named_multicolumn(self, pd):
+        data = {(1, 2): [1, 2], (2, 3): [2, 3]}
+        df = pd.DataFrame(data)
+        with pytest.raises(TypeError, match=r'Could not flatten.*') as cm:
+            ColumnDataSource(data=df)
+
     def test_init_groupby_arg(self, pd):
         from bokeh.sampledata.autompg import autompg as df
         group = df.groupby(by=['origin', 'cyl'])

--- a/bokeh/models/tests/test_sources.py
+++ b/bokeh/models/tests/test_sources.py
@@ -68,13 +68,13 @@ class TestColumnDataSource(object):
     def test_init_dataframe_nonstring_named_column(self, pd):
         data = {1: [1, 2], 2: [2, 3]}
         df = pd.DataFrame(data)
-        with pytest.raises(ValueError, match=r'expected an element of.*') as cm:
+        with pytest.raises(ValueError, match=r'expected an element of.*'):
             ColumnDataSource(data=df)
 
     def test_init_dataframe_nonstring_named_multicolumn(self, pd):
         data = {(1, 2): [1, 2], (2, 3): [2, 3]}
         df = pd.DataFrame(data)
-        with pytest.raises(TypeError, match=r'Could not flatten.*') as cm:
+        with pytest.raises(TypeError, match=r'Could not flatten.*'):
             ColumnDataSource(data=df)
 
     def test_init_groupby_arg(self, pd):

--- a/bokeh/models/tests/test_sources.py
+++ b/bokeh/models/tests/test_sources.py
@@ -53,6 +53,18 @@ class TestColumnDataSource(object):
         assert [0, 1] == list(ds.data['index'])
         assert set(ds.column_names) - set(df.columns) == set(["index"])
 
+    def test_init_dataframe_index_named_column(self, pd):
+        data = dict(a=[1, 2], b=[2, 3], index=[4, 5])
+        df = pd.DataFrame(data)
+        ds = ColumnDataSource(data=df)
+        assert set(df.columns).issubset(set(ds.column_names))
+        for key in data.keys():
+            assert isinstance(ds.data[key], np.ndarray)
+            assert list(df[key]) == list(ds.data[key])
+        assert isinstance(ds.data['level_0'], np.ndarray)
+        assert [0, 1] == list(ds.data['level_0'])
+        assert set(ds.column_names) - set(df.columns) == set(["level_0"])
+
     def test_init_groupby_arg(self, pd):
         from bokeh.sampledata.autompg import autompg as df
         group = df.groupby(by=['origin', 'cyl'])


### PR DESCRIPTION
Both df.index and df.columns can be a pd.MultiIndex. Bokeh
expects a 'flat' table. This change uses the pandas API to
flatten, solving some issues with naming + being more consistent
with pandas

Supersedes https://github.com/bokeh/bokeh/pull/8002

- [x] issues: fixes #6770
- [x] tests added / passed
- [x] release document entry (if new feature or API change)
