### PR TITLE
Add CustomAction toolbar action

### DIFF
--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -94,14 +94,17 @@ from __future__ import absolute_import, print_function
 import logging
 logger = logging.getLogger(__name__)
 
+import base64
 import collections
 from copy import copy
 import datetime
 import dateutil.parser
 from importlib import import_module
+from io import BytesIO
 import numbers
 import re
 
+import PIL.Image
 from six import string_types, iteritems
 
 from .. import colors
@@ -789,6 +792,52 @@ class Auto(Enum):
     def _sphinx_type(self):
         return self._sphinx_prop_link()
 
+class Image(Property):
+    ''' Accept image file types, e.g PNG, JPEG, TIFF, etc.
+
+    This property can be configured with:
+
+    * A string filename to be loaded with ``PIL.Image.open``
+    * An RGB(A) NumPy array, will be converted to PNG
+    * A ``PIL.Image.Image`` object
+
+    In all cases, the image data is serialized as a Base64 encoded string.
+
+    '''
+
+    def validate(self, value, detail=True):
+        import numpy as np
+
+        valid = False
+
+        if value is None or isinstance(value, (string_types, PIL.Image.Image)):
+            valid = True
+
+        if isinstance(value, np.ndarray):
+            valid = value.dtype == "uint8" and len(value.shape) == 3 and value.shape[2] in (3, 4)
+
+        if not valid:
+            msg = "" if not detail else "invalid value: %r; allowed values are string filenames, PIL.Image.Image instances, or RGB(A) NumPy arrays" % value
+            raise ValueError(msg)
+
+    def transform(self, value):
+        if value is None:
+            return None
+
+        import numpy as np
+        if isinstance(value, np.ndarray):
+            value = PIL.Image.fromarray(value)
+
+        if isinstance(value, string_types):
+            value = PIL.Image.open(value)
+
+        if isinstance(value, PIL.Image.Image):
+            out = BytesIO()
+            value.save(out, value.format or "PNG")
+            return base64.b64encode(out.getvalue()).decode('ascii')
+
+        raise ValueError("Could not transform %r" % value)
+
 class RGB(Property):
     ''' Accept colors.RGB values.
 
@@ -856,7 +905,6 @@ class Color(Either):
 
     def _sphinx_type(self):
         return self._sphinx_prop_link()
-
 
 class MinMaxBounds(Either):
     ''' Accept (min, max) bounds tuples for use with Ranges.

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -28,7 +28,7 @@ from ..core.enums import (Anchor, Dimension, Dimensions, Location,
                           TooltipFieldFormatter, TooltipAttachment)
 from ..core.has_props import abstract
 from ..core.properties import (
-    Auto, Bool, Color, Date, Datetime, Dict, Either, Enum, Int, Float,
+    Auto, Bool, Color, Date, Datetime, Dict, Either, Enum, Image, Int, Float,
     Percent, Instance, List, Seq, String, Tuple
 )
 from ..util.compiler import nodejs_compile, CompilationError
@@ -307,6 +307,36 @@ class WheelZoomTool(Scroll):
     speed = Float(default=1/600, help="""
     Speed at which the wheel zooms. Default is 1/600. Optimal range is between
     0.001 and 0.09. High values will be clipped. Speed may very between browsers.
+    """)
+
+class CustomAction(Action):
+    ''' Execute a custom action, e.g. ``CustomJS`` callback when a toolbar
+    icon is activated.
+
+    Example:
+
+        .. code-block:: python
+
+            tool = CustomAction(icon="icon.png",
+                                callback=CustomJS(code='alert("foo")'))
+
+            plot.add_tools(tool)
+
+    '''
+
+    action_tooltip = String(default="Perform a Custom Action", help="""
+    Tooltip displayed when hovering over the custom action icon.
+    """)
+
+    callback = Instance(Callback, help="""
+    A Bokeh callback to execute when the custom action icon is activated.
+    """)
+
+    icon = Image(help="""
+    An icon to display in the toolbar.
+
+    The icon can provided as a string filename for an image, a PIL ``Image``
+    object, or an RGB(A) NumPy array.
     """)
 
 class SaveTool(Action):

--- a/bokehjs/src/lib/models/tools/actions/custom_action.ts
+++ b/bokehjs/src/lib/models/tools/actions/custom_action.ts
@@ -1,0 +1,66 @@
+import {ActionTool, ActionToolView, ActionToolButtonView} from "./action_tool"
+import * as p from "core/properties"
+import {isFunction} from "core/util/types"
+
+export class CustomActionButtonView extends ActionToolButtonView {
+  model: CustomAction
+
+  css_classes(): string[] {
+    return super.css_classes().concat("bk-toolbar-button-custom-action")
+  }
+
+}
+
+export class CustomActionView extends ActionToolView {
+  model: CustomAction
+
+  doit(): void {
+    const callback = this.model.callback
+    if (isFunction(callback))
+      callback(this, {})
+    else
+      callback.execute(this, {})
+    }
+}
+
+export namespace CustomAction {
+  export interface Attrs extends ActionTool.Attrs {
+    action_tooltip: string
+    callback: any // XXX
+    icon: string
+  }
+
+  export interface Props extends ActionTool.Props {}
+}
+
+export interface CustomAction extends CustomAction.Attrs {}
+
+export class CustomAction extends ActionTool {
+
+  properties: CustomAction.Props
+
+  constructor(attrs?: Partial<CustomAction.Attrs>) {
+    super(attrs)
+  }
+
+  static initClass(): void {
+    this.prototype.type = "CustomAction"
+    this.prototype.default_view = CustomActionView
+
+    this.define({
+      action_tooltip: [ p.String, 'Perform a Custom Action'],
+      callback:       [ p.Any                              ], // TODO: p.Either(p.Instance(Callback), p.Function) ]
+      icon:           [ p.String,                          ],
+    })
+  }
+
+  tool_name = "Custom Action"
+
+  button_view = CustomActionButtonView
+
+  get tooltip(): string {
+    return this.action_tooltip
+  }
+}
+
+CustomAction.initClass()

--- a/bokehjs/src/lib/models/tools/button_tool.ts
+++ b/bokehjs/src/lib/models/tools/button_tool.ts
@@ -3,6 +3,7 @@ import {DOMView} from "core/dom_view"
 import {Tool, ToolView} from "./tool"
 import {empty} from "core/dom"
 import * as p from "core/properties"
+import {isString} from "core/util/types"
 
 export abstract class ButtonToolButtonView extends DOMView {
   model: ButtonTool
@@ -20,7 +21,12 @@ export abstract class ButtonToolButtonView extends DOMView {
 
   render(): void {
     empty(this.el)
-    this.el.classList.add(this.model.icon)
+    if (isString(this.model.icon)) {
+      if (this.model.icon.startsWith("bk-tool-icon-"))
+        this.el.classList.add(this.model.icon)
+      else
+        this.el.style.backgroundImage = "url('data:image/png;base64," + this.model.icon + "')"
+    }
     this.el.title = this.model.tooltip
   }
 
@@ -53,7 +59,7 @@ export abstract class ButtonTool extends Tool {
     this.prototype.type = "ButtonTool"
 
     this.internal({
-      disabled: [ p.Boolean, false ],
+      disabled:    [ p.Boolean,    false ],
     })
   }
 

--- a/bokehjs/src/lib/models/tools/index.ts
+++ b/bokehjs/src/lib/models/tools/index.ts
@@ -1,4 +1,5 @@
 export {ActionTool}        from "./actions/action_tool"
+export {CustomAction}      from "./actions/custom_action"
 export {HelpTool}          from "./actions/help_tool"
 export {RedoTool}          from "./actions/redo_tool"
 export {ResetTool}         from "./actions/reset_tool"

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ REQUIRES = [
     'python-dateutil >=2.1',
     'Jinja2 >=2.7',
     'numpy >=1.7.1',
+    'pillow >= 4.0',
     'packaging >=16.8',
     'tornado >=4.3',
 ]

--- a/sphinx/source/docs/releases/1.0.0.rst
+++ b/sphinx/source/docs/releases/1.0.0.rst
@@ -12,6 +12,11 @@ And several other bug fixes and docs additions. For full details see the
 Migration Guide
 ---------------
 
+New Dependencies
+~~~~~~~~~~~~~~~~
+
+"Pillow>=4.0" has been added to the list of Bokeh runtime dependencies.
+
 Pretty printing functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This is a slight diversion, but I intend to use this targetable toolbar button that executes callback code as a simple and standard means to inject JS code into selenium tests. Additionally, it seems like quite a useful feature for users in its own right. 

This PR also adds an `Image` property, that can be set from RGB(A) NumPy arrays, PIL image objects, or from filenames of images in disk. The transformed value is always a Base64 `data\image` string. In this way the icon for the toolbar tool may be set to an arbitrary choice by the user. 

This requires adding Pillow as a dependency, however Pillow is easily obtainable. Additionally, there was Gitter discussion about adding PNG, TIFF, etc. image glyphs, and Pillow will be needed for that work as well. 
