### PR TITLE
REF: Use .loc instead of .ix in examples

### DIFF
--- a/examples/howto/layouts/words_and_plots.py
+++ b/examples/howto/layouts/words_and_plots.py
@@ -47,8 +47,8 @@ def scatter():
 
 
 def hover_plot():
-    x = data.ix['2010-10-06'].index.to_series()
-    y = data.ix['2010-10-06']['glucose']
+    x = data.loc['2010-10-06'].index.to_series()
+    y = data.loc['2010-10-06']['glucose']
     p = figure(
         plot_width=800, plot_height=400, x_axis_type="datetime",
         tools="", toolbar_location=None, title='Hover over points'

--- a/examples/plotting/file/hover_glyph.py
+++ b/examples/plotting/file/hover_glyph.py
@@ -2,8 +2,8 @@ from bokeh.models import HoverTool
 from bokeh.plotting import figure, output_file, show
 from bokeh.sampledata.glucose import data
 
-x = data.ix['2010-10-06'].index.to_series()
-y = data.ix['2010-10-06']['glucose']
+x = data.loc['2010-10-06'].index.to_series()
+y = data.loc['2010-10-06']['glucose']
 
 # Basic plot setup
 p = figure(plot_width=800, plot_height=400, x_axis_type="datetime",

--- a/sphinx/source/docs/user_guide/examples/plotting_box_annotation.py
+++ b/sphinx/source/docs/user_guide/examples/plotting_box_annotation.py
@@ -7,7 +7,7 @@ output_file("box_annotation.html", title="box_annotation.py example")
 TOOLS = "pan,wheel_zoom,box_zoom,reset,save"
 
 #reduce data size
-data = data.ix['2010-10-06':'2010-10-13']
+data = data.loc['2010-10-06':'2010-10-13']
 
 p = figure(x_axis_type="datetime", tools=TOOLS)
 

--- a/sphinx/source/docs/user_guide/examples/styling_glyph_hover.py
+++ b/sphinx/source/docs/user_guide/examples/styling_glyph_hover.py
@@ -4,7 +4,7 @@ from bokeh.sampledata.glucose import data
 
 output_file("styling_hover.html")
 
-subset = data.ix['2010-10-06']
+subset = data.loc['2010-10-06']
 
 x, y = subset.index.to_series(), subset['glucose']
 


### PR DESCRIPTION
In continuation to #8104 and #8105

