### PR TITLE
Allow ability to overwrite existing glyphs in drawing tools

### DIFF
--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -1251,6 +1251,11 @@ class BoxEditTool(EditTool, Drag, Tap):
     the vertical dimension can be controlled.
     """)
 
+    overwrite = Bool(default=False, help="""
+    Whether the tool should overwrite the existing box, if there is one,
+    or whether it should add a new box on every draw event (the default).
+    """)
+
     @error(INCOMPATIBLE_BOX_EDIT_RENDERER)
     def _check_compatible_renderers(self):
         incompatible_renderers = []
@@ -1348,6 +1353,11 @@ class PolyDrawTool(EditTool, Drag, Tap):
     drag = Bool(default=True, help="""
     Enables dragging of existing patches and multi-lines on pan events.""")
 
+    overwrite = Bool(default=False, help="""
+    Whether the tool should overwrite the existing box, if there is one,
+    or whether it should add a new box on every draw event (the default).
+    """)
+    
     @error(INCOMPATIBLE_POLY_DRAW_RENDERER)
     def _check_compatible_renderers(self):
         incompatible_renderers = []

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -1254,7 +1254,8 @@ class BoxEditTool(EditTool, Drag, Tap):
     num_objects = Int(default=0, help="""
     Defines a limit on the number of boxes that can be drawn. By
     default there is no limit on the number of objects, but if enabled
-    the oldest drawn box will be overwritten when the limit is reached.
+    the oldest drawn box will be dropped to make space for the new box
+    being added.
     """)
 
     @error(INCOMPATIBLE_BOX_EDIT_RENDERER)
@@ -1311,7 +1312,8 @@ class PointDrawTool(EditTool, Drag, Tap):
     num_objects = Int(default=0, help="""
     Defines a limit on the number of points that can be drawn. By
     default there is no limit on the number of objects, but if enabled
-    the oldest drawn point will be overwritten when the limit is reached.
+    the oldest drawn point will be dropped to make space for the new
+    point.
     """)
 
     @error(INCOMPATIBLE_POINT_DRAW_RENDERER)
@@ -1364,7 +1366,7 @@ class PolyDrawTool(EditTool, Drag, Tap):
     Defines a limit on the number of patches or multi-lines that can
     be drawn. By default there is no limit on the number of objects,
     but if enabled the oldest drawn patch or multi-line will be
-    overwritten when the limit is reached.
+    dropped to make space for the new patch or multi-line.
     """)
 
     @error(INCOMPATIBLE_POLY_DRAW_RENDERER)

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -1308,6 +1308,12 @@ class PointDrawTool(EditTool, Drag, Tap):
     drag = Bool(default=True, help="""
     Enables dragging of existing points on pan events.""")
 
+    num_objects = Int(default=0, help="""
+    Defines a limit on the number of points that can be drawn. By
+    default there is no limit on the number of objects, but if enabled
+    the oldest drawn point will be overwritten when the limit is reached.
+    """)
+
     @error(INCOMPATIBLE_POINT_DRAW_RENDERER)
     def _check_compatible_renderers(self):
         incompatible_renderers = []

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -1251,9 +1251,10 @@ class BoxEditTool(EditTool, Drag, Tap):
     the vertical dimension can be controlled.
     """)
 
-    overwrite = Bool(default=False, help="""
-    Whether the tool should overwrite the existing box, if there is one,
-    or whether it should add a new box on every draw event (the default).
+    num_objects = Int(default=0, help="""
+    Defines a limit on the number of boxes that can be drawn. By
+    default there is no limit on the number of objects, but if enabled
+    the oldest drawn box will be overwritten when the limit is reached.
     """)
 
     @error(INCOMPATIBLE_BOX_EDIT_RENDERER)
@@ -1353,11 +1354,13 @@ class PolyDrawTool(EditTool, Drag, Tap):
     drag = Bool(default=True, help="""
     Enables dragging of existing patches and multi-lines on pan events.""")
 
-    overwrite = Bool(default=False, help="""
-    Whether the tool should overwrite the existing box, if there is one,
-    or whether it should add a new box on every draw event (the default).
+    num_objects = Int(default=0, help="""
+    Defines a limit on the number of patches or multi-lines that can
+    be drawn. By default there is no limit on the number of objects,
+    but if enabled the oldest drawn patch or multi-line will be
+    overwritten when the limit is reached.
     """)
-    
+
     @error(INCOMPATIBLE_POLY_DRAW_RENDERER)
     def _check_compatible_renderers(self):
         incompatible_renderers = []

--- a/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
@@ -93,7 +93,7 @@ export class BoxEditToolView extends EditToolView {
     } else {
       this._draw_basepoint = [ev.sx, ev.sy];
       this._select_event(ev, true, this.model.renderers);
-      this._update_box(ev, true, false);
+      this._update_box(ev, !this.model.overwrite, false);
     }
   }
 
@@ -105,7 +105,7 @@ export class BoxEditToolView extends EditToolView {
     if (ev.shiftKey) {
       if (this._draw_basepoint != null) { return }
       this._draw_basepoint = [ev.sx, ev.sy];
-      this._update_box(ev, true, false);
+      this._update_box(ev, !this.model.overwrite, false);
     } else {
       if (this._basepoint != null) { return }
       this._select_event(ev, true, this.model.renderers);
@@ -141,6 +141,7 @@ export namespace BoxEditTool {
   export interface Attrs extends EditTool.Attrs {
     dimensions: Dimensions
     renderers: (GlyphRenderer & HasRectCDS)[]
+    overwrite: boolean
   }
 
   export interface Props extends EditTool.Props {}
@@ -164,6 +165,7 @@ export class BoxEditTool extends EditTool {
 
     this.define({
       dimensions: [ p.Dimensions, "both" ],
+      overwrite: [ p.Bool, false ]
     })
   }
 

--- a/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
@@ -147,7 +147,7 @@ export class BoxEditToolView extends EditToolView {
 export namespace BoxEditTool {
   export interface Attrs extends EditTool.Attrs {
     dimensions: Dimensions
-    num_objects: Number
+    num_objects: number
     renderers: (GlyphRenderer & HasRectCDS)[]
   }
 

--- a/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
@@ -51,6 +51,13 @@ export class BoxEditToolView extends EditToolView {
     const [xkey, ykey] = [glyph.x.field, glyph.y.field];
     const [wkey, hkey] = [glyph.width.field, glyph.height.field];
     if (append) {
+      if (this.model.num_objects &&
+          ((xkey && ds.get_array(xkey).length >= this.model.num_objects) ||
+           (ykey && ds.get_array(ykey).length >= this.model.num_objects))) {
+        for (const column of ds.columns()) {
+          ds.get_array(column).splice(0, 1)
+        }
+      }
       if (xkey) ds.get_array(xkey).push(x)
       if (ykey) ds.get_array(ykey).push(y)
       if (wkey) ds.get_array(wkey).push(w)
@@ -93,7 +100,7 @@ export class BoxEditToolView extends EditToolView {
     } else {
       this._draw_basepoint = [ev.sx, ev.sy];
       this._select_event(ev, true, this.model.renderers);
-      this._update_box(ev, !this.model.overwrite, false);
+      this._update_box(ev, true, false);
     }
   }
 
@@ -105,7 +112,7 @@ export class BoxEditToolView extends EditToolView {
     if (ev.shiftKey) {
       if (this._draw_basepoint != null) { return }
       this._draw_basepoint = [ev.sx, ev.sy];
-      this._update_box(ev, !this.model.overwrite, false);
+      this._update_box(ev, true, false);
     } else {
       if (this._basepoint != null) { return }
       this._select_event(ev, true, this.model.renderers);
@@ -140,8 +147,8 @@ export class BoxEditToolView extends EditToolView {
 export namespace BoxEditTool {
   export interface Attrs extends EditTool.Attrs {
     dimensions: Dimensions
+    num_objects: Number
     renderers: (GlyphRenderer & HasRectCDS)[]
-    overwrite: boolean
   }
 
   export interface Props extends EditTool.Props {}
@@ -165,7 +172,7 @@ export class BoxEditTool extends EditTool {
 
     this.define({
       dimensions: [ p.Dimensions, "both" ],
-      overwrite: [ p.Bool, false ]
+      num_objects: [ p.Int, 0 ]
     })
   }
 

--- a/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
@@ -51,7 +51,7 @@ export class BoxEditToolView extends EditToolView {
     const [xkey, ykey] = [glyph.x.field, glyph.y.field];
     const [wkey, hkey] = [glyph.width.field, glyph.height.field];
     if (append) {
-      this._pop_glyphs(ds, this.model.num_objects, xkey, ykey)
+      this._pop_glyphs(ds, this.model.num_objects)
       if (xkey) ds.get_array(xkey).push(x)
       if (ykey) ds.get_array(ykey).push(y)
       if (wkey) ds.get_array(wkey).push(w)

--- a/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
@@ -51,13 +51,7 @@ export class BoxEditToolView extends EditToolView {
     const [xkey, ykey] = [glyph.x.field, glyph.y.field];
     const [wkey, hkey] = [glyph.width.field, glyph.height.field];
     if (append) {
-      if (this.model.num_objects &&
-          ((xkey && ds.get_array(xkey).length >= this.model.num_objects) ||
-           (ykey && ds.get_array(ykey).length >= this.model.num_objects))) {
-        for (const column of ds.columns()) {
-          ds.get_array(column).splice(0, 1)
-        }
-      }
+      this._pop_glyphs(ds, this.model.num_objects, xkey, ykey)
       if (xkey) ds.get_array(xkey).push(x)
       if (ykey) ds.get_array(ykey).push(y)
       if (wkey) ds.get_array(wkey).push(w)

--- a/bokehjs/src/lib/models/tools/edit/edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/edit_tool.ts
@@ -1,7 +1,8 @@
 import * as p from "core/properties"
-import {UIEvent, MoveEvent} from "core/ui_events"
 import {PointGeometry} from "core/geometry"
+import {UIEvent, MoveEvent} from "core/ui_events"
 import {includes} from "core/util/array"
+import {isArray} from "core/util/types"
 import {XYGlyph} from "../../glyphs/xy_glyph"
 import {ColumnarDataSource} from "../../sources/columnar_data_source"
 import {GlyphRenderer} from "../../renderers/glyph_renderer"
@@ -53,14 +54,21 @@ export abstract class EditToolView extends GestureToolView {
     cds.selection_manager.clear();
   }
 
-  _pop_glyphs(cds: ColumnarDataSource, num_objects: number, xkey: string | null, ykey: string | null) {
+  _pop_glyphs(cds: ColumnarDataSource, num_objects: number) {
     // Pops rows in the CDS until only num_objects are left
-    while (num_objects &&
-           ((xkey && cds.get_array(xkey).length >= num_objects) ||
-            (ykey && cds.get_array(ykey).length >= num_objects))) {
-      for (const column of cds.columns()) {
-        cds.get_array(column).splice(0, 1)
+    const columns = cds.columns()
+    if (!num_objects || !columns.length)
+      return
+    for (const column of columns) {
+      let array = cds.get_array(column)
+      const drop = array.length-num_objects+1
+      if (drop < 1)
+        continue
+      if (!isArray(array)) {
+        array = Array.from(array)
+        cds.data[column] = array;
       }
+      array.splice(0, drop)
     }
   }
 

--- a/bokehjs/src/lib/models/tools/edit/edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/edit_tool.ts
@@ -53,6 +53,17 @@ export abstract class EditToolView extends GestureToolView {
     cds.selection_manager.clear();
   }
 
+  _pop_glyphs(cds: ColumnarDataSource, num_objects: number, xkey: string | null, ykey: string | null) {
+    // Pops rows in the CDS until only num_objects are left
+    while (num_objects &&
+           ((xkey && cds.get_array(xkey).length >= num_objects) ||
+            (ykey && cds.get_array(ykey).length >= num_objects))) {
+      for (const column of cds.columns()) {
+        cds.get_array(column).splice(0, 1)
+      }
+    }
+  }
+
   _drag_points(ev: UIEvent, renderers: (GlyphRenderer & HasXYGlyph)[]): void {
     if (this._basepoint == null) { return; };
     const [bx, by] = this._basepoint;

--- a/bokehjs/src/lib/models/tools/edit/point_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/point_draw_tool.ts
@@ -25,6 +25,14 @@ export class PointDrawToolView extends EditToolView {
     const [xkey, ykey] = [glyph.x.field, glyph.y.field];
     const [x, y] = point;
 
+    if (this.model.num_objects &&
+        ((xkey && ds.get_array(xkey).length >= this.model.num_objects) ||
+         (ykey && ds.get_array(ykey).length >= this.model.num_objects))) {
+      for (const column of ds.columns()) {
+        ds.get_array(column).splice(0, 1)
+      }
+    }
+
     if (xkey) ds.get_array(xkey).push(x)
     if (ykey) ds.get_array(ykey).push(y)
 
@@ -79,6 +87,7 @@ export namespace PointDrawTool {
   export interface Attrs extends EditTool.Attrs {
     add: boolean
     drag: boolean
+    num_objects: number
     renderers: (GlyphRenderer & HasXYGlyph)[]
   }
 
@@ -104,6 +113,7 @@ export class PointDrawTool extends EditTool {
     this.define({
       add:  [ p.Bool, true ],
       drag: [ p.Bool, true ],
+      num_objects: [ p.Int, 0 ],
     })
   }
 

--- a/bokehjs/src/lib/models/tools/edit/point_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/point_draw_tool.ts
@@ -25,7 +25,7 @@ export class PointDrawToolView extends EditToolView {
     const [xkey, ykey] = [glyph.x.field, glyph.y.field];
     const [x, y] = point;
 
-    this._pop_glyphs(ds, this.model.num_objects, xkey, ykey)
+    this._pop_glyphs(ds, this.model.num_objects)
     if (xkey) ds.get_array(xkey).push(x)
     if (ykey) ds.get_array(ykey).push(y)
     this._pad_empty_columns(ds, [xkey, ykey]);

--- a/bokehjs/src/lib/models/tools/edit/point_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/point_draw_tool.ts
@@ -25,17 +25,9 @@ export class PointDrawToolView extends EditToolView {
     const [xkey, ykey] = [glyph.x.field, glyph.y.field];
     const [x, y] = point;
 
-    if (this.model.num_objects &&
-        ((xkey && ds.get_array(xkey).length >= this.model.num_objects) ||
-         (ykey && ds.get_array(ykey).length >= this.model.num_objects))) {
-      for (const column of ds.columns()) {
-        ds.get_array(column).splice(0, 1)
-      }
-    }
-
+    this._pop_glyphs(ds, this.model.num_objects, xkey, ykey)
     if (xkey) ds.get_array(xkey).push(x)
     if (ykey) ds.get_array(ykey).push(y)
-
     this._pad_empty_columns(ds, [xkey, ykey]);
 
     ds.change.emit();

--- a/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
@@ -36,9 +36,20 @@ export class PolyDrawToolView extends EditToolView {
     const glyph: any = renderer.glyph;
     const [xkey, ykey] = [glyph.xs.field, glyph.ys.field];
     if (mode == 'new') {
-      if (xkey) ds.get_array(xkey).push([x, x])
-      if (ykey) ds.get_array(ykey).push([y, y])
-      this._pad_empty_columns(ds, [xkey, ykey]);
+      if (this.model.overwrite && ((xkey && ds.get_array(xkey).length) || (ykey && ds.get_array(ykey).length))) {
+        if (xkey) {
+          const xarr = ds.get_array(xkey)
+          xarr[xarr.length-1] = [x, x]
+        }
+        if (ykey) {
+          const yarr = ds.get_array(ykey)
+          yarr[yarr.length-1] = [y, y]
+        }
+      } else {
+        if (xkey) ds.get_array(xkey).push([x, x])
+        if (ykey) ds.get_array(ykey).push([y, y])
+        this._pad_empty_columns(ds, [xkey, ykey]);
+      }
     } else if (mode == 'edit') {
       if (xkey) {
         const xs = ds.data[xkey][ds.data[xkey].length-1];
@@ -194,6 +205,7 @@ export class PolyDrawToolView extends EditToolView {
 export namespace PolyDrawTool {
   export interface Attrs extends EditTool.Attrs {
     drag: boolean
+    overwrite: boolean
     renderers: (GlyphRenderer & HasPolyGlyph)[]
   }
 
@@ -219,6 +231,7 @@ export class PolyDrawTool extends EditTool {
 
     this.define({
       drag: [ p.Bool, true ],
+      overwrite: [ p.Bool, false]
     })
   }
 

--- a/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
@@ -201,8 +201,8 @@ export class PolyDrawToolView extends EditToolView {
 export namespace PolyDrawTool {
   export interface Attrs extends EditTool.Attrs {
     drag: boolean
-    num_objects: Number
     renderers: (GlyphRenderer & HasPolyGlyph)[]
+    num_objects: number
   }
 
   export interface Props extends EditTool.Props {}
@@ -227,7 +227,7 @@ export class PolyDrawTool extends EditTool {
 
     this.define({
       drag: [ p.Bool, true ],
-      num_objects: [ p.Int, null ]
+      num_objects: [ p.Int, 0 ],
     })
   }
 

--- a/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
@@ -36,20 +36,16 @@ export class PolyDrawToolView extends EditToolView {
     const glyph: any = renderer.glyph;
     const [xkey, ykey] = [glyph.xs.field, glyph.ys.field];
     if (mode == 'new') {
-      if (this.model.overwrite && ((xkey && ds.get_array(xkey).length) || (ykey && ds.get_array(ykey).length))) {
-        if (xkey) {
-          const xarr = ds.get_array(xkey)
-          xarr[xarr.length-1] = [x, x]
+      if (this.model.num_objects &&
+          ((xkey && ds.get_array(xkey).length >= this.model.num_objects) ||
+           (ykey && ds.get_array(ykey).length >= this.model.num_objects))) {
+        for (const column of ds.columns()) {
+          ds.get_array(column).splice(0, 1)
         }
-        if (ykey) {
-          const yarr = ds.get_array(ykey)
-          yarr[yarr.length-1] = [y, y]
-        }
-      } else {
-        if (xkey) ds.get_array(xkey).push([x, x])
-        if (ykey) ds.get_array(ykey).push([y, y])
-        this._pad_empty_columns(ds, [xkey, ykey]);
       }
+      if (xkey) ds.get_array(xkey).push([x, x])
+      if (ykey) ds.get_array(ykey).push([y, y])
+      this._pad_empty_columns(ds, [xkey, ykey]);
     } else if (mode == 'edit') {
       if (xkey) {
         const xs = ds.data[xkey][ds.data[xkey].length-1];
@@ -205,7 +201,7 @@ export class PolyDrawToolView extends EditToolView {
 export namespace PolyDrawTool {
   export interface Attrs extends EditTool.Attrs {
     drag: boolean
-    overwrite: boolean
+    num_objects: Number
     renderers: (GlyphRenderer & HasPolyGlyph)[]
   }
 
@@ -231,7 +227,7 @@ export class PolyDrawTool extends EditTool {
 
     this.define({
       drag: [ p.Bool, true ],
-      overwrite: [ p.Bool, false]
+      num_objects: [ p.Int, null ]
     })
   }
 

--- a/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
@@ -36,7 +36,7 @@ export class PolyDrawToolView extends EditToolView {
     const glyph: any = renderer.glyph;
     const [xkey, ykey] = [glyph.xs.field, glyph.ys.field];
     if (mode == 'new') {
-      this._pop_glyphs(ds, this.model.num_objects, xkey, ykey)
+      this._pop_glyphs(ds, this.model.num_objects)
       if (xkey) ds.get_array(xkey).push([x, x])
       if (ykey) ds.get_array(ykey).push([y, y])
       this._pad_empty_columns(ds, [xkey, ykey]);

--- a/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
@@ -36,13 +36,7 @@ export class PolyDrawToolView extends EditToolView {
     const glyph: any = renderer.glyph;
     const [xkey, ykey] = [glyph.xs.field, glyph.ys.field];
     if (mode == 'new') {
-      if (this.model.num_objects &&
-          ((xkey && ds.get_array(xkey).length >= this.model.num_objects) ||
-           (ykey && ds.get_array(ykey).length >= this.model.num_objects))) {
-        for (const column of ds.columns()) {
-          ds.get_array(column).splice(0, 1)
-        }
-      }
+      this._pop_glyphs(ds, this.model.num_objects, xkey, ykey)
       if (xkey) ds.get_array(xkey).push([x, x])
       if (ykey) ds.get_array(ykey).push([y, y])
       this._pad_empty_columns(ds, [xkey, ykey]);

--- a/bokehjs/test/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/test/models/tools/edit/box_edit_tool.ts
@@ -190,6 +190,29 @@ describe("BoxEditTool", () =>
       expect(testcase.data_source.data['z']).to.be.deep.equal([null, null, null, "Test"]);
     });
 
+    it("should draw and pop box on pan", function(): void {
+      const testcase = make_testcase();
+      testcase.draw_tool_view.model.num_objects = 3;
+      const hit_test_stub = sinon.stub(testcase.glyph_view, "hit_test");
+      hit_test_stub.returns(null);
+
+      let drag_event = make_gesture_event(300, 300, true);
+      testcase.draw_tool_view._pan_start(drag_event);
+      expect(testcase.draw_tool_view._draw_basepoint).to.be.deep.equal([300, 300]);
+      drag_event = make_gesture_event(200, 200, true);
+      testcase.draw_tool_view._pan(drag_event);
+      expect(testcase.draw_tool_view._draw_basepoint).to.be.deep.equal([300, 300]);
+      testcase.draw_tool_view._pan_end(drag_event);
+
+      expect(testcase.draw_tool_view._draw_basepoint).to.be.equal(null);
+      expect(testcase.data_source.selected.indices).to.be.deep.equal([]);
+      expect(testcase.data_source.data['x']).to.be.deep.equal([0.5, 1, -0.1327433628318584]);
+      expect(testcase.data_source.data['y']).to.be.deep.equal([0.5, 1, 0.1694915254237288]);
+      expect(testcase.data_source.data['width']).to.be.deep.equal([0.2, 0.3, 0.35398230088495575]);
+      expect(testcase.data_source.data['height']).to.be.deep.equal([0.2, 0.1, 0.3389830508474576]);
+      expect(testcase.data_source.data['z']).to.be.deep.equal([null, null, "Test"]);
+    });
+
     it("should draw box on doubletap and move", function(): void {
       const testcase = make_testcase();
       const hit_test_stub = sinon.stub(testcase.glyph_view, "hit_test");

--- a/bokehjs/test/models/tools/edit/point_draw_tool.ts
+++ b/bokehjs/test/models/tools/edit/point_draw_tool.ts
@@ -112,6 +112,20 @@ describe("PointDrawTool", (): void => {
       expect(testcase.data_source.data['y']).to.be.deep.equal([0, 0.5, 1, 0.3389830508474576]);
     });
 
+    it("should add and pop point on tap", function() {
+      const testcase = make_testcase();
+      testcase.draw_tool_view.model.num_objects = 3
+      const hit_test_stub = sinon.stub(testcase.glyph_view, "hit_test");
+
+      hit_test_stub.returns(null);
+      const tap_event = make_tap_event(300, 200);
+      testcase.draw_tool_view._tap(tap_event);
+
+      expect(testcase.data_source.selected.indices).to.be.deep.equal([]);
+      expect(testcase.data_source.data['x']).to.be.deep.equal([0.5, 1, 0.04424778761061947]);
+      expect(testcase.data_source.data['y']).to.be.deep.equal([0.5, 1, 0.3389830508474576]);
+    });
+
     it("should insert empty_value on other columns", function() {
       const testcase = make_testcase();
       const hit_test_stub = sinon.stub(testcase.glyph_view, "hit_test");

--- a/bokehjs/test/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/test/models/tools/edit/poly_draw_tool.ts
@@ -155,7 +155,6 @@ describe("PolyDrawTool", (): void => {
       expect(testcase.data_source.data['ys']).to.be.deep.equal(ydata);
     });
 
-
     it("should drag previously selected patch on pan", function(): void {
       const testcase = make_testcase();
       const hit_test_stub = sinon.stub(testcase.glyph_view, "hit_test");
@@ -177,7 +176,6 @@ describe("PolyDrawTool", (): void => {
       expect(testcase.data_source.data['ys']).to.be.deep.equal(ydata);
     });
 
-
     it("should draw patch on doubletap", function(): void {
       const testcase = make_testcase();
       const hit_test_stub = sinon.stub(testcase.glyph_view, "hit_test");
@@ -191,6 +189,24 @@ describe("PolyDrawTool", (): void => {
       const new_ys = [-0, 0.1694915254237288, 0.3389830508474576];
       const xdata = [[0, 0.5, 1], [0, 0.5, 1], new_xs];
       const ydata = [[0, -0.5, -1], [0, -0.5, -1], new_ys];
+      expect(testcase.data_source.data['xs']).to.be.deep.equal(xdata);
+      expect(testcase.data_source.data['ys']).to.be.deep.equal(ydata);
+    });
+
+    it("should draw and pop patch on doubletap", function(): void {
+      const testcase = make_testcase();
+      testcase.draw_tool_view.model.num_objects = 2
+      const hit_test_stub = sinon.stub(testcase.glyph_view, "hit_test");
+
+      hit_test_stub.returns(null);
+      testcase.draw_tool_view._doubletap(make_tap_event(300, 300));
+      testcase.draw_tool_view._tap(make_tap_event(250, 250));
+      testcase.draw_tool_view._doubletap(make_tap_event(200, 200));
+
+      const new_xs = [0.04424778761061947, -0.13274336283185842, -0.30973451327433627];
+      const new_ys = [-0, 0.1694915254237288, 0.3389830508474576];
+      const xdata = [[0, 0.5, 1], new_xs];
+      const ydata = [[0, -0.5, -1], new_ys];
       expect(testcase.data_source.data['xs']).to.be.deep.equal(xdata);
       expect(testcase.data_source.data['ys']).to.be.deep.equal(ydata);
     });

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -655,6 +655,12 @@ with the declared ``empty_value``, when adding a new box. When drawing
 a new box the data will always be added to the ``ColumnDataSource`` on
 the first supplied renderer.
 
+It is also often useful to limit the number of elements that can be
+drawn, e.g. when specifying a specific number of regions of interest.
+Using the ``num_objects`` property we can set such a limit, ensuring
+that when it is reached the least recently drawn box is removed and
+replaced with a new one.
+
 .. raw:: html
 
     <img src="http://bokeh.pydata.org/static/box_edit_keyboard_optimized.gif"
@@ -718,6 +724,11 @@ additional columns in the data source will be padded with the declared
 be inserted on the ``ColumnDataSource`` of the first supplied
 renderer.
 
+It is also often useful to limit the number of elements that can be
+drawn.  Using the ``num_objects`` property we can set such a limit,
+ensuring that when it is reached the least recently drawn point is
+removed and replaced with a new one.
+
 .. raw:: html
 
     <img src="http://bokeh.pydata.org/static/point_draw_keyboard_optimized.gif"
@@ -772,6 +783,12 @@ additional columns in the data source will be padded with the declared
 ``empty_value``, when adding a new point. Any newly added patch or
 multi-line will be inserted on the ``ColumnDataSource`` of the first
 supplied renderer.
+
+It is also often useful to limit the number of elements that can be
+drawn, e.g. when specifying a specific number of regions of interest.
+Using the ``num_objects`` property we can set such a limit, ensuring
+that when it is reached the least recently drawn patch or multi-line
+is removed and replaced with a new one.
 
 .. raw:: html
 

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -657,9 +657,9 @@ the first supplied renderer.
 
 It is also often useful to limit the number of elements that can be
 drawn, e.g. when specifying a specific number of regions of interest.
-Using the ``num_objects`` property we can set such a limit, ensuring
-that when it is reached the least recently drawn box is removed and
-replaced with a new one.
+Using the ``num_objects`` property we can ensure that once the limit
+has been reached the oldest box will be popped off the queue to make
+space for the new box being added.
 
 .. raw:: html
 
@@ -725,9 +725,9 @@ be inserted on the ``ColumnDataSource`` of the first supplied
 renderer.
 
 It is also often useful to limit the number of elements that can be
-drawn.  Using the ``num_objects`` property we can set such a limit,
-ensuring that when it is reached the least recently drawn point is
-removed and replaced with a new one.
+drawn.  Using the ``num_objects`` property we can ensure that once the
+limit has been reached the oldest point will be popped off the queue
+to make space for the new point being added.
 
 .. raw:: html
 
@@ -786,9 +786,9 @@ supplied renderer.
 
 It is also often useful to limit the number of elements that can be
 drawn, e.g. when specifying a specific number of regions of interest.
-Using the ``num_objects`` property we can set such a limit, ensuring
-that when it is reached the least recently drawn patch or multi-line
-is removed and replaced with a new one.
+Using the ``num_objects`` property we can ensure that once the limit
+has been reached the oldest patch/multi-line will be popped off the
+queue to make space for the new patch/multi-line being added.
 
 .. raw:: html
 


### PR DESCRIPTION
This PR addresses a feature requested from the existing drawing tools, which is to overwrite the last drawn glyph. This is useful when you only want to draw a single box or polygon.

The spelling to enable this behavior is to set the new property ``overwrite=True``, suggestions for alternative spelling would be welcome (@jbednar?).

- [x] issues: fixes https://github.com/bokeh/bokeh/issues/7987
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
