### PR TITLE
Add tilt option to GMapOptions

### DIFF
--- a/bokeh/models/map_plots.py
+++ b/bokeh/models/map_plots.py
@@ -76,6 +76,16 @@ class GMapOptions(MapOptions):
 
     """)
 
+    tilt = Int(default=45, help="""
+    `Tilt`_ angle of the map. The only allowed values are 0 and 45.
+    Only has an effect on 'satellite' and 'hybrid' map types.
+    A value of 0 causes the map to always use a 0 degree overhead view.
+    A value of 45 causes the tilt angle to switch to 45 imagery if available.
+
+    .. _Tilt: https://developers.google.com/maps/documentation/javascript/reference/3/map#MapOptions.tilt
+
+    """)
+
 class GMapPlot(MapPlot):
     ''' A Bokeh Plot with a `Google Map`_ displayed underneath.
 

--- a/bokehjs/src/lib/models/plots/gmap_plot.ts
+++ b/bokehjs/src/lib/models/plots/gmap_plot.ts
@@ -47,12 +47,14 @@ export namespace GMapOptions {
     map_type: string
     scale_control: boolean
     styles: string
+    tilt: number
   }
 
   export interface Props extends MapOptions.Props {
     map_type: p.Property<string>
     scale_control: p.Property<boolean>
     styles: p.Property<string>
+    tilt: p.Property<number>
   }
 }
 
@@ -73,6 +75,7 @@ export class GMapOptions extends MapOptions {
       map_type:      [ p.String, "roadmap" ],
       scale_control: [ p.Bool,   false     ],
       styles:        [ p.String            ],
+      tilt:          [ p.Int,    45        ],
     })
   }
 }

--- a/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
@@ -126,6 +126,7 @@ export class GMapPlotCanvasView extends PlotCanvasView {
       disableDefaultUI: true,
       mapTypeId: this.map_types[mo.map_type],
       scaleControl: mo.scale_control,
+      tilt: mo.tilt,
     }
 
     if (mo.styles != null)
@@ -150,6 +151,7 @@ export class GMapPlotCanvasView extends PlotCanvasView {
     this.connect(this.model.plot.map_options.properties.zoom.change, () => this._update_zoom())
     this.connect(this.model.plot.map_options.properties.map_type.change, () => this._update_map_type())
     this.connect(this.model.plot.map_options.properties.scale_control.change, () => this._update_scale_control())
+    this.connect(this.model.plot.map_options.properties.tilt.change, () => this._update_tilt())
   }
 
   protected _render_finished(): void {
@@ -199,6 +201,10 @@ export class GMapPlotCanvasView extends PlotCanvasView {
 
   protected _update_scale_control(): void {
     this.map.setOptions({scaleControl: this.model.plot.map_options.scale_control })
+  }
+
+  protected _update_tilt(): void {
+    this.map.setOptions({tilt: this.model.plot.map_options.tilt })
   }
 
   protected _update_options(): void {


### PR DESCRIPTION
Relevant Google Groups discussion: https://groups.google.com/a/continuum.io/forum/#!msg/bokeh/Ko66-4PbhNc/0TEpR3S1CQAJ

I am trying to add support for the `tilt` option for GMapPlot.

Without knowing exactly what I'm doing I have added the `tilt` option analogous to the `scale_control` option.

There are two open issues:
1) I don't see how my added option is ever sent to the API, so I doubt this will actually have any effect yet. Please help me understand how this should work.
2) In the current state, using a non default tilt parameter (i.e. `tilt=0`) breaks the plot with the following error:
```
Uncaught Error: property GMapOptions.tilt wasn't declared
    at t.u.setv (bokeh-1.0.0dev4.min.js:31)
    at t.u [as constructor] (bokeh-1.0.0dev4.min.js:31)
    at t.i [as constructor] (bokeh-1.0.0dev4.min.js:31)
    at t [as constructor] (bokeh-1.0.0dev4.min.js:31)
    at new t (bokeh-1.0.0dev4.min.js:31)
    at Function.P._instantiate_object (bokeh-1.0.0dev4.min.js:31)
    at Function.P._instantiate_references_json (bokeh-1.0.0dev4.min.js:31)
    at Function.P.from_json (bokeh-1.0.0dev4.min.js:31)
    at bokeh-1.0.0dev4.min.js:31
    at bokeh-1.0.0dev4.min.js:31
```

After having made the changes in this commit, I ran
```
python setup.py develop --build-js
```

Running `python -m bokeh info` outputs:
```Python version      :  2.7.12 (default, Nov 19 2016, 06:48:10) 
IPython version     :  5.4.1
Bokeh version       :  1.0.0dev4-1-g9d7e3ea-dirty
BokehJS static path :  /home/nicolas/src/bokeh/bokeh/server/static
node.js version     :  v8.11.3
npm version         :  6.3.0
```
So I believe to have set up my development environment correctly.

Thank you for your help!