### PR TITLE
Ensure draw/edit tools sync data on bokeh server

### DIFF
--- a/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
@@ -67,6 +67,7 @@ export class BoxEditToolView extends EditToolView {
     ds.change.emit();
     if (emit) {
       ds.properties.data.change.emit();
+      ds.data = ds.data;
     }
   }
 
@@ -90,6 +91,7 @@ export class BoxEditToolView extends EditToolView {
       for (const renderer of this.model.renderers) {
         renderer.data_source.selected.indices = [];
         renderer.data_source.properties.data.change.emit();
+        renderer.data_source.data = renderer.data_source.data;
       }
     } else {
       this._draw_basepoint = [ev.sx, ev.sy];
@@ -134,6 +136,7 @@ export class BoxEditToolView extends EditToolView {
     for (const renderer of this.model.renderers) {
       renderer.data_source.selected.indices = [];
       renderer.data_source.properties.data.change.emit();
+      renderer.data_source.data = renderer.data_source.data;
     }
   }
 }

--- a/bokehjs/src/lib/models/tools/edit/edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/edit_tool.ts
@@ -49,7 +49,7 @@ export abstract class EditToolView extends GestureToolView {
         values.splice(ind-index, 1);
       }
     }
-    cds.change.emit();
+    cds.data = cds.data;
     cds.properties.data.change.emit();
     cds.selection_manager.clear();
   }
@@ -94,8 +94,8 @@ export abstract class EditToolView extends GestureToolView {
       }
     }
     for (const renderer of renderers) {
-      renderer.data_source.change.emit()
       renderer.data_source.properties.data.change.emit()
+      renderer.data_source.data = renderer.data_source.data
     }
     this._basepoint = [ev.sx, ev.sy];
   }

--- a/bokehjs/src/lib/models/tools/edit/point_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/point_draw_tool.ts
@@ -30,7 +30,7 @@ export class PointDrawToolView extends EditToolView {
     if (ykey) ds.get_array(ykey).push(y)
     this._pad_empty_columns(ds, [xkey, ykey]);
 
-    ds.change.emit();
+    ds.data = ds.data;
     ds.properties.data.change.emit();
   }
 

--- a/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
@@ -17,8 +17,10 @@ export class PolyDrawToolView extends EditToolView {
 
   _tap(ev: TapEvent): void {
     if (this._drawing) {
+      const cds = this.model.renderers[0].data_source;
       this._draw(ev, 'add');
-      this.model.renderers[0].data_source.properties.data.change.emit();
+      cds.properties.data.change.emit()
+      cds.data = cds.data;
     } else {
       const append = ev.shiftKey
       this._select_event(ev, append, this.model.renderers);
@@ -78,6 +80,7 @@ export class PolyDrawToolView extends EditToolView {
 
   _doubletap(ev: TapEvent): void {
     if (!this.model.active) { return; }
+    const cds = this.model.renderers[0].data_source
     if (this._drawing) {
       this._drawing = false;
       this._draw(ev, 'edit');
@@ -85,7 +88,8 @@ export class PolyDrawToolView extends EditToolView {
       this._drawing = true;
       this._draw(ev, 'new');
     }
-    this.model.renderers[0].data_source.properties.data.change.emit();
+    cds.properties.data.change.emit();
+    cds.data = cds.data;
   }
 
   _move(ev: MoveEvent): void {
@@ -109,8 +113,8 @@ export class PolyDrawToolView extends EditToolView {
       const ys = ds.get_array<number[]>(ykey)[yidx];
       ys.splice(ys.length-1, 1)
     }
-    ds.change.emit()
     ds.properties.data.change.emit();
+    ds.data = ds.data
   }
 
   _keyup(ev: KeyEvent): void {
@@ -180,6 +184,7 @@ export class PolyDrawToolView extends EditToolView {
     for (const renderer of this.model.renderers) {
       renderer.data_source.selected.indices = [];
       renderer.data_source.properties.data.change.emit();
+      renderer.data_source.data = renderer.data_source.data;
     }
     this._basepoint = null;
   }

--- a/bokehjs/src/lib/models/tools/edit/poly_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_edit_tool.ts
@@ -78,7 +78,7 @@ export class PolyEditToolView extends EditToolView {
     point_ds.selected.indices = [];
     this._selected_renderer = renderer;
     point_ds.change.emit();
-    point_ds.properties.data.change.emit();
+    point_ds.data = point_ds.data;
   }
 
   _move(ev: MoveEvent): void {
@@ -125,7 +125,7 @@ export class PolyEditToolView extends EditToolView {
       }
       ds.change.emit();
       const selected_ds = this._selected_renderer.data_source;
-      selected_ds.change.emit();
+      selected_ds.data = selected_ds.data
       selected_ds.properties.data.change.emit();
       return;
     }
@@ -145,7 +145,7 @@ export class PolyEditToolView extends EditToolView {
     if (xkey) ds.get_array(xkey).splice(index, 1)
     if (ykey) ds.get_array(ykey).splice(index, 1)
     if (emit) {
-      ds.change.emit();
+      ds.data = ds.data;
       ds.properties.data.change.emit();
     }
   }
@@ -209,9 +209,9 @@ export class PolyEditToolView extends EditToolView {
     if (xkey) ds.data[xkey] = []
     if (ykey) ds.data[ykey] = []
     ds.selection_manager.clear();
-    ds.change.emit();
-    this._selected_renderer.data_source.change.emit();
+    ds.data = ds.data;
     ds.properties.data.change.emit();
+    this._selected_renderer.data_source.data = this._selected_renderer.data_source.data;
     this._selected_renderer.data_source.properties.data.change.emit();
     this._selected_renderer = null;
   }


### PR DESCRIPTION
This PR ensures that the drawing/editing tools trigger server side events by explicitly setting the data when necessary. I'll also add some selenium tests to this PR to avoid regressions.

- [x] issues: fixes https://github.com/bokeh/bokeh/issues/8032
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
