### PR TITLE
initial work to support server selenium tests

### DIFF
--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -1,0 +1,92 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2017, Anaconda, Inc. All rights reserved.
+#
+# Powered by the Bokeh Development Team.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import pytest ; pytest
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+
+# External imports
+
+# Bokeh imports
+from bokeh.layouts import column
+from bokeh.models import Button, Circle, ColumnDataSource, CustomAction, CustomJS, Plot, Range1d, Toggle
+from bokeh._testing.util.selenium import RECORD
+
+#-----------------------------------------------------------------------------
+# Tests
+#-----------------------------------------------------------------------------
+
+pytest_plugins = (
+    "bokeh._testing.plugins.bokeh",
+)
+
+
+@pytest.mark.integration
+@pytest.mark.selenium
+class Test_Datatable(object):
+
+    def test_button_round_trips(self, bokeh_server_page):
+
+        def modify_doc(doc):
+            source = ColumnDataSource(dict(x=[1, 2], y=[1, 1]))
+            plot = Plot(plot_height=400, plot_width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
+            plot.add_glyph(source, Circle(x='x', y='y', size=20))
+            plot.add_tools(CustomAction(callback=CustomJS(args=dict(s=source), code=RECORD("data", "s.data"))))
+            button = Button(css_classes=['foo'])
+            def cb(): source.data=dict(x=[10, 20], y=[10, 10])
+            button.on_click(cb)
+            doc.add_root(column(button, plot))
+
+        page = bokeh_server_page(modify_doc)
+
+        button = page.driver.find_element_by_class_name('foo')
+        button.click()
+
+        custom = page.driver.find_element_by_class_name("bk-toolbar-button-custom-action")
+        custom.click()
+
+        results = page.results
+        assert results ==  {'data': {'x': [10, 20], 'y': [10, 10]}}
+
+        # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
+        #assert page.has_no_console_errors()
+
+    def test_toggle_round_trips2(self, bokeh_server_page):
+
+        def modify_doc(doc):
+            source = ColumnDataSource(dict(x=[1, 2], y=[1, 1]))
+            plot = Plot(plot_height=400, plot_width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
+            plot.add_glyph(source, Circle(x='x', y='y', size=20))
+            plot.add_tools(CustomAction(callback=CustomJS(args=dict(s=source), code=RECORD("data", "s.data"))))
+            button = Toggle(css_classes=['foo'])
+            def cb(value): source.data=dict(x=[100, 20], y=[10, 10])
+            button.on_click(cb)
+            doc.add_root(column(button, plot))
+
+        page = bokeh_server_page(modify_doc)
+
+        button = page.driver.find_element_by_class_name('foo')
+        button.click()
+
+        custom = page.driver.find_element_by_class_name("bk-toolbar-button-custom-action")
+        custom.click()
+
+        results = page.results
+        assert results ==  {'data': {'x': [100, 20], 'y': [10, 10]}}
+
+        # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
+        #assert page.has_no_console_errors()


### PR DESCRIPTION
This is an initial stab at a workflow for adding selenium tests for bokeh server apps. Some things will probably change, but this is enough to support other currently ongoing work.

Some questions (to be addressed in later PRs):

* should server tests e.g. for widgets, be located with all the other widget tests? Or should the be segregated? If so, in what sort of layout

* Should `single_plot_page` etc jsut be made to support server apps out of the box? Or should `bokeh_server_page` remain distinct?

Also note the workarounds for https://github.com/bokeh/bokeh/issues/7970 that should be removed when that issue is resolved. 

cc @philippjfr 