### PR TITLE
Add context manager and decorator to control property validation

### DIFF
--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -2157,10 +2157,10 @@ class validate(object):
     Example:
         .. code-block:: python
 
-             with validate(False):  # do no validate while within this block
-                 pass
+            with validate(False):  # do no validate while within this block
+                pass
 
-             validate(False)  # don't validate ever
+            validate(False)  # don't validate ever
 
     See Also:
         :func:`~bokeh.core.property.bases.validation_on`: check the state of validation
@@ -2173,7 +2173,7 @@ class validate(object):
         Property._should_validate = value
 
     def __enter__(self):
-        return
+        pass
 
     def __exit__(self, typ, value, traceback):
         Property._should_validate = self.old
@@ -2187,7 +2187,7 @@ def without_property_validation(input_function):
 
             @without_property_validation
             def update(attr, old, new):
-                # do stuff without validation
+                # do things without validation
 
     See Also:
         :class:`~bokeh.core.properties.validate`: context mangager for more fine-grained control

--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -81,12 +81,25 @@ Helpers
 .. autofunction:: field
 .. autofunction:: value
 
-
 Special Properties
 ------------------
 
 .. autoclass:: Include
 .. autoclass:: Override
+
+Validation Control
+------------------
+
+By default, Bokeh properties perform type validation on values. This helps to
+ensure the consistency of any data exchanged between Python and JavaScript, as
+well as provide detailed and immediate feedback to users if they attempt to
+set values of the wrong type. However, these type checks incur some overhead.
+In some cases it may be desirable to turn off validation in specific places,
+or even entirely, in order to boost performance. The following API is available
+to control when type validation occurs.
+
+.. autoclass:: validate
+.. autofunction:: without_property_validation
 
 '''
 from __future__ import absolute_import, print_function
@@ -99,6 +112,7 @@ import collections
 from copy import copy
 import datetime
 import dateutil.parser
+from functools import wraps
 from importlib import import_module
 from io import BytesIO
 import numbers
@@ -2128,6 +2142,62 @@ class Include(PropertyDescriptorFactory):
 
         return descriptors
 
+#------------------------------------------------------------------------------
+# Validation Control
+#------------------------------------------------------------------------------
+
+class validate(object):
+    ''' Control validation of bokeh properties
+
+    This can be used as a context manager, or as a normal callable
+
+    Args:
+        value (bool) : Whether validation should occur or not
+
+    Example:
+        .. code-block:: python
+
+             with validate(False):  # do no validate while within this block
+                 pass
+
+             validate(False)  # don't validate ever
+
+    See Also:
+        :func:`~bokeh.core.property.bases.validation_on`: check the state of validation
+
+        :func:`~bokeh.core.properties.without_property_validation`: function decorator
+
+    '''
+    def __init__(self, value):
+        self.old = Property._should_validate
+        Property._should_validate = value
+
+    def __enter__(self):
+        return
+
+    def __exit__(self, typ, value, traceback):
+        Property._should_validate = self.old
+
+
+def without_property_validation(input_function):
+    ''' Turn off property validation during update callbacks
+
+    Example:
+        .. code-block:: python
+
+            @without_property_validation
+            def update(attr, old, new):
+                # do stuff without validation
+
+    See Also:
+        :class:`~bokeh.core.properties.validate`: context mangager for more fine-grained control
+
+    '''
+    @wraps(input_function)
+    def func(*args, **kwargs):
+        with validate(False):
+            return input_function(*args, **kwargs)
+    return func
 
 # Everything below is just to update the module docstring
 _all_props = set(x for x in globals().values() if isinstance(x, type) and issubclass(x, Property))

--- a/bokeh/core/property/bases.py
+++ b/bokeh/core/property/bases.py
@@ -26,8 +26,6 @@ from .descriptors import BasicPropertyDescriptor
 
 pd = import_optional('pandas')
 
-_global_validate = [True]
-
 class DeserializationError(Exception):
     pass
 
@@ -438,47 +436,51 @@ class validate(object):
 
     This can be used as a context manager, or as a normal callable
 
-    Examples
-    --------
-    >>> with validate(False):  # do no validate while within this block
-    ...     pass
+    Example:
+        .. code-block:: python
 
-    >>> validate(False)  # don't validate ever
+             with validate(False):  # do no validate while within this block
+                 pass
 
-    See Also
-    --------
-    validation_on: check the state of validation
-    without_property_validation: function decorator
+             validate(False)  # don't validate ever
+
+    See Also:
+        validation_on: check the state of validation
+        without_property_validation: function decorator
     """
+    _global_value = True
+
     def __init__(self, value):
-        self.old = _global_validate[0]
-        _global_validate[0] = value
+        self.old = validate._global_value
+        validate._global_value = value
 
     def __enter__(self):
         return
 
     def __exit__(self, typ, value, traceback):
-        _global_validate[0] = self.old
+        validate._global_value = self.old
 
 
 def validation_on():
     """ Check if property validation is currently active """
-    return _global_validate[0]
+    return validate._global_value
 
 
 def without_property_validation(func):
     """ Turn off property validation during update calls
 
-        @without_property_validation
-        def update(attr, old, new):
-            # do stuff without validation
+    Example:
+        .. code-block:: python
 
-    See Also
-    --------
-    validate: context mangager for more fine-grained control
+            @without_property_validation
+            def update(attr, old, new):
+                # do stuff without validation
+
+    See Also:
+        validate: context mangager for more fine-grained control
     """
-    @functools.wraps(func)
-    def _(*args, **kwargs):
+    @functools.wraps(input_function)
+    def func(*args, **kwargs):
         with validate(False):
-            return func(*args, **kwargs)
+            return input_function(*args, **kwargs)
     return _

--- a/bokeh/core/property/bases.py
+++ b/bokeh/core/property/bases.py
@@ -13,7 +13,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 from copy import copy
-import functools
 import types
 
 from six import string_types
@@ -53,6 +52,9 @@ class Property(PropertyDescriptorFactory):
             (default: False)
 
     '''
+
+    # This class attribute is controlled by external helper API for validation
+    _should_validate = True
 
     def __init__(self, default=None, help=None, serialized=True, readonly=False):
         # This is how the descriptor is created in the class declaration.
@@ -431,57 +433,11 @@ class ContainerProperty(ParameterizedProperty):
         # all containers are mutable, so the default can be modified
         return True
 
-
-class validate(object):
-    """ Control validation of bokeh properties
-
-    This can be used as a context manager, or as a normal callable
-
-    Example:
-        .. code-block:: python
-
-             with validate(False):  # do no validate while within this block
-                 pass
-
-             validate(False)  # don't validate ever
-
-    See Also:
-        validation_on: check the state of validation
-        without_property_validation: function decorator
-    """
-    _global_value = True
-
-    def __init__(self, value):
-        self.old = validate._global_value
-        validate._global_value = value
-
-    def __enter__(self):
-        return
-
-    def __exit__(self, typ, value, traceback):
-        validate._global_value = self.old
-
-
 def validation_on():
-    """ Check if property validation is currently active """
-    return validate._global_value
+    ''' Check if property validation is currently active
 
+    Returns:
+        bool
 
-def without_property_validation(input_function):
-    """ Turn off property validation during update calls
-
-    Example:
-        .. code-block:: python
-
-            @without_property_validation
-            def update(attr, old, new):
-                # do stuff without validation
-
-    See Also:
-        validate: context mangager for more fine-grained control
-    """
-    @functools.wraps(input_function)
-    def func(*args, **kwargs):
-        with validate(False):
-            return input_function(*args, **kwargs)
-    return func
+    '''
+    return Property._should_validate

--- a/bokeh/core/property/bases.py
+++ b/bokeh/core/property/bases.py
@@ -13,6 +13,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 from copy import copy
+import functools
 import types
 
 from six import string_types
@@ -466,7 +467,7 @@ def validation_on():
     return validate._global_value
 
 
-def without_property_validation(func):
+def without_property_validation(input_function):
     """ Turn off property validation during update calls
 
     Example:
@@ -483,4 +484,4 @@ def without_property_validation(func):
     def func(*args, **kwargs):
         with validate(False):
             return input_function(*args, **kwargs)
-    return _
+    return func

--- a/bokeh/core/property/tests/test_bases.py
+++ b/bokeh/core/property/tests/test_bases.py
@@ -148,31 +148,8 @@ def test_property_matches_dicts_with_index_values(capsys, pd):
     out, err = capsys.readouterr()
     assert err == ""
 
-
-def test_validate():
+def test_validation_on():
+    assert pb.Property._should_validate == True
     assert pb.validation_on()
-    with pb.validate(False):
-        assert not pb.validation_on()
-    assert pb.validation_on()
-
-    with pb.validate(False):
-        assert not pb.validation_on()
-        with pb.validate(True):
-            assert pb.validation_on()
-        assert not pb.validation_on()
-    assert pb.validation_on()
-
-    pb.validate(False)
+    pb.Property._should_validate = False
     assert not pb.validation_on()
-    pb.validate(True)
-    assert pb.validation_on()
-
-
-def test_without_property_validation():
-    @pb.without_property_validation
-    def f():
-        assert not pb.validation_on()
-
-    assert pb.validation_on()
-    f()
-    assert pb.validation_on()

--- a/bokeh/core/property/tests/test_bases.py
+++ b/bokeh/core/property/tests/test_bases.py
@@ -147,3 +147,22 @@ def test_property_matches_dicts_with_index_values(capsys, pd):
     assert p.matches(d1.index, 10) is False
     out, err = capsys.readouterr()
     assert err == ""
+
+
+def test_validate():
+    assert pb.validation_on()
+    with pb.validate(False):
+        assert not pb.validation_on()
+    assert pb.validation_on()
+
+    with pb.validate(False):
+        assert not pb.validation_on()
+        with pb.validate(True):
+            assert pb.validation_on()
+        assert not pb.validation_on()
+    assert pb.validation_on()
+
+    pb.validate(False)
+    assert not pb.validation_on()
+    pb.validate(True)
+    assert pb.validation_on()

--- a/bokeh/core/property/tests/test_bases.py
+++ b/bokeh/core/property/tests/test_bases.py
@@ -157,4 +157,3 @@ def test_validation_on():
 
     pb.Property._should_validate = True
     assert pb.validation_on()
-

--- a/bokeh/core/property/tests/test_bases.py
+++ b/bokeh/core/property/tests/test_bases.py
@@ -166,3 +166,13 @@ def test_validate():
     assert not pb.validation_on()
     pb.validate(True)
     assert pb.validation_on()
+
+
+def test_without_property_validation():
+    @pb.without_property_validation
+    def f():
+        assert not pb.validation_on()
+
+    assert pb.validation_on()
+    f()
+    assert pb.validation_on()

--- a/bokeh/core/property/tests/test_bases.py
+++ b/bokeh/core/property/tests/test_bases.py
@@ -151,5 +151,10 @@ def test_property_matches_dicts_with_index_values(capsys, pd):
 def test_validation_on():
     assert pb.Property._should_validate == True
     assert pb.validation_on()
+
     pb.Property._should_validate = False
     assert not pb.validation_on()
+
+    pb.Property._should_validate = True
+    assert pb.validation_on()
+

--- a/bokeh/core/tests/test_properties.py
+++ b/bokeh/core/tests/test_properties.py
@@ -17,14 +17,45 @@ from bokeh.core.properties import (field, value,
     DistanceSpec, FontSize, FontSizeSpec, Override, Include, MinMaxBounds,
     DataDistanceSpec, ScreenDistanceSpec, ColumnData, UnitsSpec, Image)
 
+from bokeh.core.property.bases import validation_on
 from bokeh.core.property.containers import PropertyValueColumnData, PropertyValueDict, PropertyValueList
 
 from bokeh.core.has_props import HasProps
 
 from bokeh.models import Plot
 
+import bokeh.core.properties as bcp
 
 SPECS = (NumberSpec, ColorSpec, AngleSpec, StringSpec, DistanceSpec, FontSizeSpec, DataDistanceSpec, ScreenDistanceSpec)
+
+class TestValidationControl(object):
+    def test_validate(self):
+        assert validation_on()
+        with bcp.validate(False):
+            assert not validation_on()
+        assert validation_on()
+
+        with bcp.validate(False):
+            assert not validation_on()
+            with bcp.validate(True):
+                assert validation_on()
+            assert not validation_on()
+        assert validation_on()
+
+        bcp.validate(False)
+        assert not validation_on()
+        bcp.validate(True)
+        assert validation_on()
+
+
+    def test_without_property_validation(self):
+        @bcp.without_property_validation
+        def f():
+            assert not validation_on()
+
+        assert validation_on()
+        f()
+        assert validation_on()
 
 class TestValidateDetailDefault(object):
 


### PR DESCRIPTION
This allows users to control whether or not they want validate checks when
updating properties.

Examples
--------

    with validate(False):
        ...

or

    @without_property_validation
    def update(attr, old, new):
        ...

Fixes #8138

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [x] issues: fixes #8138
- [x] tests added / passed
- [x] release document entry (if new feature or API change)
