### PR TITLE
Jsnsross/8142 span datetime

### DIFF
--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -849,6 +849,9 @@ class Span(Annotation):
 
     location = Float(help="""
     The location of the span, along ``dimension``.
+
+    Datetime values are also accepted, but note that they are immediately
+    converted to milliseconds-since-epoch.
     """).accepts(Datetime, convert_datetime_type)
 
     location_units = Enum(SpatialUnits, default='data', help="""

--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -849,7 +849,7 @@ class Span(Annotation):
 
     location = Float(help="""
     The location of the span, along ``dimension``.
-    """)
+    """).accepts(Datetime, convert_datetime_type)
 
     location_units = Enum(SpatialUnits, default='data', help="""
     The unit type for the location attribute. Interpreted as "data space"

--- a/bokeh/models/tests/test_annotations.py
+++ b/bokeh/models/tests/test_annotations.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 import mock
-
+import pandas as pd
 from bokeh.core.properties import field, value
 from bokeh.core.validation import check_integrity
 from bokeh.models.annotations import (
@@ -340,6 +340,15 @@ def test_Span():
         "render_mode"
     ], LINE)
 
+def test_Span_accepts_datetime_location():
+    obj = Span(location = pd.to_datetime('2018-8-7'))
+    assert obj.location == 1533600000000.0
+
+def test_Label_accepts_datetime_location():
+    obj = Label(x = pd.to_datetime('2018-8-7'),
+                y = pd.to_datetime('2018-8-7'))
+    assert obj.x == 1533600000000.0
+    assert obj.y == 1533600000000.0
 
 def test_Title():
     title = Title()

--- a/bokeh/models/tests/test_annotations.py
+++ b/bokeh/models/tests/test_annotations.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 import mock
-import pandas as pd
+from datetime import datetime
+
 from bokeh.core.properties import field, value
 from bokeh.core.validation import check_integrity
 from bokeh.models.annotations import (
@@ -253,9 +254,9 @@ def test_Label():
         prefix('border_', LINE),
         prefix('background_', FILL))
 
-def test_Label_accepts_datetime_location():
-    obj = Label(x = pd.to_datetime('2018-8-7'),
-                y = pd.to_datetime('2018-8-7'))
+def test_Label_accepts_datetime_xy():
+    obj = Label(x = datetime(2018,8,7,0,0),
+                y = datetime(2018,8,7,0,0))
     assert obj.x == 1533600000000.0
     assert obj.y == 1533600000000.0
 
@@ -346,7 +347,7 @@ def test_Span():
     ], LINE)
 
 def test_Span_accepts_datetime_location():
-    obj = Span(location = pd.to_datetime('2018-8-7'))
+    obj = Span(location = datetime(2018,8,7,0,0))
     assert obj.location == 1533600000000.0
 
 def test_Title():

--- a/bokeh/models/tests/test_annotations.py
+++ b/bokeh/models/tests/test_annotations.py
@@ -253,6 +253,11 @@ def test_Label():
         prefix('border_', LINE),
         prefix('background_', FILL))
 
+def test_Label_accepts_datetime_location():
+    obj = Label(x = pd.to_datetime('2018-8-7'),
+                y = pd.to_datetime('2018-8-7'))
+    assert obj.x == 1533600000000.0
+    assert obj.y == 1533600000000.0
 
 def test_LabelSet():
     label_set = LabelSet()
@@ -343,12 +348,6 @@ def test_Span():
 def test_Span_accepts_datetime_location():
     obj = Span(location = pd.to_datetime('2018-8-7'))
     assert obj.location == 1533600000000.0
-
-def test_Label_accepts_datetime_location():
-    obj = Label(x = pd.to_datetime('2018-8-7'),
-                y = pd.to_datetime('2018-8-7'))
-    assert obj.x == 1533600000000.0
-    assert obj.y == 1533600000000.0
 
 def test_Title():
     title = Title()


### PR DESCRIPTION
- [x] issues: fixes #8142 
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)

resolved issue with Span not accepting a datetime by copying formulation used for x and y arguments in Label. Also added tests for Span.location and Label.x / Label.y to ensure that datetime is properly being converted to milliseconds-since-epoch