### PR TITLE
Define {css,js}_resources blocks in the correct order

### DIFF
--- a/bokeh/core/_templates/file.html
+++ b/bokeh/core/_templates/file.html
@@ -26,10 +26,10 @@ that accepts these same parameters.
       <title>{% block title %}{{ title | e if title else "Bokeh Plot" }}{% endblock %}</title>
       {% block preamble %}{% endblock %}
       {% block resources %}
-        {% block js_resources %}
+        {% block css_resources %}
           {{ bokeh_css | indent(8) if bokeh_css }}
         {% endblock %}
-        {% block css_resources %}
+        {% block js_resources %}
           {{ bokeh_js | indent(8) if bokeh_js }}
         {% endblock %}
       {% endblock %}


### PR DESCRIPTION
fixes #8160 
