### PR TITLE
Ensure TileRenderer renders despite aspect changes

### DIFF
--- a/bokehjs/src/lib/models/tiles/tile_renderer.ts
+++ b/bokehjs/src/lib/models/tiles/tile_renderer.ts
@@ -182,7 +182,7 @@ export class TileRendererView extends RendererView {
     this._tiles.push(tile)
   }
 
-  protected _enforce_aspect_ratio(): boolean {
+  protected _enforce_aspect_ratio(): void {
     // brute force way of handling resize or sizing_mode event -------------------------------------------------------------
     if ((this._last_height !== this.map_frame._height.value) || (this._last_width !== this.map_frame._width.value)) {
       const extent = this.get_extent()
@@ -193,9 +193,7 @@ export class TileRendererView extends RendererView {
       this.extent = new_extent
       this._last_height = this.map_frame._height.value
       this._last_width = this.map_frame._width.value
-      return true
     }
-    return false
   }
 
   has_finished(): boolean {
@@ -223,9 +221,7 @@ export class TileRendererView extends RendererView {
       this.map_initialized = true
     }
 
-    if (this._enforce_aspect_ratio()) {
-      return
-    }
+    this._enforce_aspect_ratio()
 
     this._update()
     if (this.prefetch_timer != null) {


### PR DESCRIPTION
Having the TileRenderer skip rendering when the aspect changes caused visible flicker, which can be quite annoying. I suspect the tile is re-rendered immediately anyway because the aspect code will cause ranges to change but avoiding flicker should take priority over the small savings achieved by skipping rendering here.

- [x] issues: fixes https://github.com/bokeh/bokeh/issues/7378
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
