### PR TITLE
Bryanv/8179 show accumulation

### DIFF
--- a/bokeh/embed/elements.py
+++ b/bokeh/embed/elements.py
@@ -1,0 +1,164 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2017, Anaconda, Inc. All rights reserved.
+#
+# Powered by the Bokeh Development Team.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+''' Generate various HTML elements from Bokeh render items.
+
+'''
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+log = logging.getLogger(__name__)
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+
+# External imports
+from six import string_types
+
+# Bokeh imports
+from ..core.json_encoder import serialize_json
+from ..core.templates import _env, DOC_JS, FILE, MACROS, PLOT_DIV
+from ..document.document import DEFAULT_TITLE
+from ..settings import settings
+from ..util.compiler import bundle_all_models
+from ..util.serialization import make_id
+from ..util.string import encode_utf8, escape
+from .wrappers import wrap_in_onload, wrap_in_safely, wrap_in_script_tag
+
+#-----------------------------------------------------------------------------
+# Globals and constants
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
+def div_for_render_item(item):
+    ''' Render an HTML div for a Bokeh render item.
+
+    Args:
+        item (RenderItem):
+            the item to create a div for
+
+    Returns:
+        str
+
+    '''
+    return PLOT_DIV.render(doc=item, macros=MACROS)
+
+def html_page_for_render_items(bundle, docs_json, render_items, title, template=None, template_variables={}):
+    ''' Render an HTML page from a template and Bokeh render items.
+
+    Args:
+        bundle (tuple):
+            a tuple containing (bokehjs, bokehcss)
+
+        docs_json (JSON-like):
+            Serialized Bokeh Documen t
+
+        render_items (RenderItems)
+            Specific items to render from the document and where
+
+        title (str or None)
+            A title for the HTML page. If None, DEFAULT_TITLE is used
+
+        template (str or Template or None, optional) :
+            A Template to be used for the HTML page. If None, FILE is used.
+
+        template_variables (dict, optional):
+            Any Additional variables to pass to the template
+
+    Returns:
+        str
+
+    '''
+    if title is None:
+        title = DEFAULT_TITLE
+
+    bokeh_js, bokeh_css = bundle
+
+    json_id = make_id()
+    json = escape(serialize_json(docs_json), quote=False)
+    json = wrap_in_script_tag(json, "application/json", json_id)
+
+    script = bundle_all_models()
+    script += script_for_render_items(json_id, render_items)
+    script = wrap_in_script_tag(script)
+
+    context = template_variables.copy()
+
+    context.update(dict(
+        title = title,
+        bokeh_js = bokeh_js,
+        bokeh_css = bokeh_css,
+        plot_script = json + script,
+        docs = render_items,
+        base = FILE,
+        macros = MACROS,
+    ))
+
+    if len(render_items) == 1:
+        context["doc"] = context["docs"][0]
+        context["roots"] = context["doc"].roots
+
+    # XXX: backwards compatibility, remove for 1.0
+    context["plot_div"] = "\n".join(div_for_render_item(item) for item in render_items)
+
+    if template is None:
+        template = FILE
+    elif isinstance(template, string_types):
+        template = _env.from_string("{% extends base %}\n" + template)
+
+    html = template.render(context)
+    return encode_utf8(html)
+
+def script_for_render_items(docs_json_or_id, render_items, app_path=None, absolute_url=None):
+    '''
+
+    '''
+    if isinstance(docs_json_or_id, string_types):
+        docs_json = "document.getElementById('%s').textContent" % docs_json_or_id
+    else:
+        # XXX: encodes &, <, > and ', but not ". This is because " is used a lot in JSON,
+        # and encoding it would significantly increase size of generated files. Doing so
+        # is safe, because " in strings was already encoded by JSON, and the semi-encoded
+        # JSON string is included in JavaScript in single quotes.
+        docs_json = serialize_json(docs_json_or_id, pretty=False) # JSON string
+        docs_json = escape(docs_json, quote=("'",))               # make HTML-safe
+        docs_json = docs_json.replace("\\", "\\\\")               # double encode escapes
+        docs_json =  "'" + docs_json + "'"                        # JS string
+
+    js = DOC_JS.render(
+        docs_json=docs_json,
+        render_items=serialize_json([ item.to_json() for item in render_items ], pretty=False),
+        app_path=app_path,
+        absolute_url=absolute_url,
+    )
+
+    if not settings.dev:
+        js = wrap_in_safely(js)
+
+    return wrap_in_onload(js)
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------

--- a/bokeh/embed/notebook.py
+++ b/bokeh/embed/notebook.py
@@ -28,9 +28,10 @@ log = logging.getLogger(__name__)
 # Bokeh imports
 from ..core.templates import DOC_NB_JS
 from ..core.json_encoder import serialize_json
+from ..model import Model
 from ..util.string import encode_utf8
 from .util import FromCurdoc
-from .util import OutputDocumentFor, check_one_model_or_doc, div_for_render_item, standalone_docs_json_and_render_items
+from .util import OutputDocumentFor, div_for_render_item, standalone_docs_json_and_render_items
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -72,11 +73,12 @@ def notebook_content(model, notebook_comms_target=None, theme=FromCurdoc):
 
     '''
 
-    model = check_one_model_or_doc(model)
+    if not isinstance(model, Model):
+        raise ValueError("notebook_content expects a single Model instance")
 
     # Comms handling relies on the fact that the new_doc returned here
     # has models with the same IDs as they were started with
-    with OutputDocumentFor(model, apply_theme=theme, always_new=True) as new_doc:
+    with OutputDocumentFor([model], apply_theme=theme, always_new=True) as new_doc:
         (docs_json, [render_item]) = standalone_docs_json_and_render_items([model])
 
     div = div_for_render_item(render_item)

--- a/bokeh/embed/notebook.py
+++ b/bokeh/embed/notebook.py
@@ -30,8 +30,8 @@ from ..core.templates import DOC_NB_JS
 from ..core.json_encoder import serialize_json
 from ..model import Model
 from ..util.string import encode_utf8
-from .util import FromCurdoc
-from .util import OutputDocumentFor, div_for_render_item, standalone_docs_json_and_render_items
+from .elements import div_for_render_item
+from .util import FromCurdoc, OutputDocumentFor, standalone_docs_json_and_render_items
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/bokeh/embed/notebook.py
+++ b/bokeh/embed/notebook.py
@@ -22,17 +22,15 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from contextlib import contextmanager
 
 # External imports
 
 # Bokeh imports
 from ..core.templates import DOC_NB_JS
 from ..core.json_encoder import serialize_json
-from ..settings import settings
 from ..util.string import encode_utf8
 from .util import FromCurdoc
-from .util import check_one_model_or_doc, div_for_render_item, find_existing_docs, standalone_docs_json_and_render_items
+from .util import OutputDocumentFor, check_one_model_or_doc, div_for_render_item, standalone_docs_json_and_render_items
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -78,7 +76,7 @@ def notebook_content(model, notebook_comms_target=None, theme=FromCurdoc):
 
     # Comms handling relies on the fact that the new_doc returned here
     # has models with the same IDs as they were started with
-    with _ModelInEmptyDocument(model, apply_theme=theme) as new_doc:
+    with OutputDocumentFor(model, apply_theme=theme, always_new=True) as new_doc:
         (docs_json, [render_item]) = standalone_docs_json_and_render_items([model])
 
     div = div_for_render_item(render_item)
@@ -97,36 +95,6 @@ def notebook_content(model, notebook_comms_target=None, theme=FromCurdoc):
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------
-
-@contextmanager
-def _ModelInEmptyDocument(model, apply_theme=None):
-
-    # Note: Comms handling relies on the fact that the new_doc returned
-    # has models with the same IDs as they were started with
-
-    from ..document import Document
-    doc = find_existing_docs([model])
-
-    model._document = None
-    for ref in model.references():
-        ref._document = None
-    new_doc = Document()
-    new_doc.add_root(model)
-
-    if apply_theme is FromCurdoc:
-        from ..io import curdoc; curdoc
-        new_doc.theme = curdoc().theme
-    elif apply_theme is not None:
-        new_doc.theme = apply_theme
-
-    if settings.perform_document_validation():
-        new_doc.validate()
-
-    yield new_doc
-
-    model._document = doc
-    for ref in model.references():
-        ref._document = doc
 
 #-----------------------------------------------------------------------------
 # Code

--- a/bokeh/embed/server.py
+++ b/bokeh/embed/server.py
@@ -32,7 +32,8 @@ from ..resources import DEFAULT_SERVER_HTTP_URL
 from ..util.serialization import make_id
 from ..util.string import encode_utf8, format_docstring
 from .bundle import bundle_for_objs_and_resources
-from .util import RenderItem, html_page_for_render_items
+from .elements import html_page_for_render_items
+from .util import RenderItem
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/bokeh/embed/standalone.py
+++ b/bokeh/embed/standalone.py
@@ -34,10 +34,9 @@ from ..model import Model
 from ..util.compiler import bundle_all_models
 from ..util.string import encode_utf8
 from .bundle import bundle_for_objs_and_resources
-from .util import FromCurdoc
-from .util import (OutputDocumentFor, html_page_for_render_items,
-                   script_for_render_items, standalone_docs_json_and_render_items,
-                   wrap_in_onload, wrap_in_script_tag)
+from .elements import html_page_for_render_items, script_for_render_items
+from .util import FromCurdoc, OutputDocumentFor, standalone_docs_json_and_render_items
+from .wrappers import wrap_in_onload, wrap_in_script_tag
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/bokeh/embed/tests/test_elements.py
+++ b/bokeh/embed/tests/test_elements.py
@@ -1,0 +1,56 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2017, Anaconda, Inc. All rights reserved.
+#
+# Powered by the Bokeh Development Team.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import pytest ; pytest
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+
+# External imports
+
+# Bokeh imports
+from bokeh.embed.util import RenderItem
+
+# Module under test
+import bokeh.embed.elements as bee
+
+#-----------------------------------------------------------------------------
+# Setup
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
+class Test_div_for_render_item(object):
+
+    def test_render(self):
+        render_item = RenderItem(docid="doc123", elementid="foo123")
+        assert bee.div_for_render_item(render_item).strip() == """<div class="bk-root" id="foo123"></div>"""
+
+class Test_html_page_for_render_items(object):
+    pass
+
+class Test_script_for_render_items(object):
+    pass
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------

--- a/bokeh/embed/tests/test_notebook.py
+++ b/bokeh/embed/tests/test_notebook.py
@@ -18,17 +18,16 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from mock import patch
 
 # External imports
 
 # Bokeh imports
-#from bokeh.core.templates import DOC_NB_JS, PLOT_DIV
 #from bokeh.core.json_encoder import serialize_json
+#from bokeh.core.templates import DOC_NB_JS, PLOT_DIV
+#from bokeh.embed.util import RenderItem
 
 # Module under test
-import bokeh.embed.notebook as ben
-#from bokeh.embed.util import RenderItem
+#import bokeh.embed.notebook as ben
 
 #-----------------------------------------------------------------------------
 # Setup
@@ -87,18 +86,3 @@ class Test_notebook_content(object):
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------
-
-class Test__ModelInEmptyDocument(object):
-
-    @patch('bokeh.document.document.check_integrity')
-    def test_validates_document_by_default(self, check_integrity, test_plot):
-        with ben._ModelInEmptyDocument(test_plot):
-            pass
-        assert check_integrity.called
-
-    @patch('bokeh.document.document.check_integrity')
-    def test_doesnt_validate_document_due_to_env_var(self, check_integrity, monkeypatch, test_plot):
-        monkeypatch.setenv("BOKEH_VALIDATE_DOC", "false")
-        with ben._ModelInEmptyDocument(test_plot):
-            pass
-        assert not check_integrity.called

--- a/bokeh/embed/tests/test_util.py
+++ b/bokeh/embed/tests/test_util.py
@@ -21,13 +21,16 @@ import pytest ; pytest
 import logging
 
 # External imports
+from mock import patch
 
 # Bokeh imports
-from bokeh.model import Model
-from bokeh.core.properties import Int, String, List
+from bokeh.core.properties import Instance, Int, String, List
 from bokeh.document.document import Document
-from bokeh.util.logconfig import basicConfig
+from bokeh.io import curdoc
 from bokeh.events import Tap
+from bokeh.model import Model
+from bokeh.themes import Theme
+from bokeh.util.logconfig import basicConfig
 
 # Module under test
 import bokeh.embed.util as beu
@@ -37,6 +40,16 @@ import bokeh.embed.util as beu
 #-----------------------------------------------------------------------------
 # needed for caplog tests to function
 basicConfig()
+
+@pytest.fixture
+def test_plot():
+    from bokeh.plotting import figure
+    test_plot = figure()
+    test_plot.circle([1, 2], [2, 3])
+    return test_plot
+
+class SomeModelInTestObjects(Model):
+    child = Instance(Model)
 
 # Taken from test_callback_manager.py
 class _GoodPropertyCallback(object):
@@ -95,6 +108,429 @@ class Test_FromCurdoc(object):
     def test_type(self):
         assert isinstance(beu.FromCurdoc, type)
 
+_ODFERR = "OutputDocumentFor expects a Model, a Document, or a sequence of Models"
+
+class Test_OutputDocumentFor_general(object):
+
+    def test_error_on_empty_list(self):
+        with pytest.raises(ValueError) as e:
+            with beu.OutputDocumentFor([]):
+                pass
+        assert str(e).endswith(_ODFERR)
+
+    def test_error_on_mixed_list(self):
+        p = Model()
+        d = Document()
+        orig_theme = d.theme
+        with pytest.raises(ValueError) as e:
+            with beu.OutputDocumentFor([p, d]):
+                pass
+        assert str(e).endswith(_ODFERR)
+        assert d.theme is orig_theme
+
+    @pytest.mark.parametrize('v', [10, -0,3, "foo", True])
+    def test_error_on_wrong_types(self, v):
+        with pytest.raises(ValueError) as e:
+            with beu.OutputDocumentFor(v):
+                pass
+        assert str(e).endswith(_ODFERR)
+
+    def test_with_doc_in_child_raises_error(self):
+        doc = Document()
+        p1 = Model()
+        p2 = SomeModelInTestObjects(child=Model())
+        doc.add_root(p2.child)
+        assert p1.document is None
+        assert p2.document is None
+        assert p2.child.document is doc
+        with pytest.raises(RuntimeError) as e:
+            with beu.OutputDocumentFor([p1, p2]):
+                pass
+        assert "already in a doc" in str(e)
+
+    @patch('bokeh.document.document.check_integrity')
+    def test_validates_document_by_default(self, check_integrity, test_plot):
+        with beu.OutputDocumentFor([test_plot]):
+            pass
+        assert check_integrity.called
+
+    @patch('bokeh.document.document.check_integrity')
+    def test_doesnt_validate_doc_due_to_env_var(self, check_integrity, monkeypatch, test_plot):
+        monkeypatch.setenv("BOKEH_VALIDATE_DOC", "false")
+        with beu.OutputDocumentFor([test_plot]):
+            pass
+        assert not check_integrity.called
+
+class Test_OutputDocumentFor_default_apply_theme(object):
+
+    def test_single_document(self):
+        # should use existing doc in with-block
+        p = Model()
+        d = Document()
+        orig_theme = d.theme
+        d.add_root(p)
+        with beu.OutputDocumentFor(d) as doc:
+            assert doc is d
+            assert d.theme is orig_theme
+        assert d.theme is orig_theme
+
+    def test_single_model_with_document(self):
+        # should use existing doc in with-block
+        p = Model()
+        d = Document()
+        orig_theme = d.theme
+        d.add_root(p)
+        with beu.OutputDocumentFor([p]):
+            assert p.document is d
+            assert d.theme is orig_theme
+        assert p.document is d
+        assert d.theme is orig_theme
+
+    def test_single_model_with_no_document(self):
+        p = Model()
+        assert p.document is None
+        with beu.OutputDocumentFor([p]):
+            assert p.document is not None
+        assert p.document is not None
+
+    def test_list_of_model_with_no_documents(self):
+        # should create new (permanent) doc for inputs
+        p1 = Model()
+        p2 = Model()
+        assert p1.document is None
+        assert p2.document is None
+        with beu.OutputDocumentFor([p1, p2]):
+            assert p1.document is not None
+            assert p2.document is not None
+            assert p1.document is p2.document
+            new_doc = p1.document
+            new_theme = p1.document.theme
+        assert p1.document is new_doc
+        assert p1.document is p2.document
+        assert p1.document.theme is new_theme
+
+    def test_list_of_model_same_as_roots(self):
+        # should use existing doc in with-block
+        p1 = Model()
+        p2 = Model()
+        d = Document()
+        orig_theme = d.theme
+        d.add_root(p1)
+        d.add_root(p2)
+        with beu.OutputDocumentFor([p1, p2]):
+            assert p1.document is d
+            assert p2.document is d
+            assert d.theme is orig_theme
+        assert p1.document is d
+        assert p2.document is d
+        assert d.theme is orig_theme
+
+    def test_list_of_model_same_as_roots_with_always_new(self):
+        # should use new temp doc for everything inside with-block
+        p1 = Model()
+        p2 = Model()
+        d = Document()
+        orig_theme = d.theme
+        d.add_root(p1)
+        d.add_root(p2)
+        with beu.OutputDocumentFor([p1, p2], always_new=True):
+            assert p1.document is not d
+            assert p2.document is not d
+            assert p1.document is p2.document
+            assert p2.document.theme is orig_theme
+        assert p1.document is d
+        assert p2.document is d
+        assert d.theme is orig_theme
+
+    def test_list_of_model_subset_roots(self):
+        # should use new temp doc for subset inside with-block
+        p1 = Model()
+        p2 = Model()
+        d = Document()
+        orig_theme = d.theme
+        d.add_root(p1)
+        d.add_root(p2)
+        with beu.OutputDocumentFor([p1]):
+            assert p1.document is not d
+            assert p2.document is d
+            assert p1.document.theme is orig_theme
+            assert p2.document.theme is orig_theme
+        assert p1.document is d
+        assert p2.document is d
+        assert d.theme is orig_theme
+
+    def test_list_of_models_different_docs(self):
+        # should use new temp doc for eveything inside with-block
+        d = Document()
+        orig_theme = d.theme
+        p1 = Model()
+        p2 = Model()
+        d.add_root(p2)
+        assert p1.document is None
+        assert p2.document is not None
+        with beu.OutputDocumentFor([p1, p2]):
+            assert p1.document is not None
+            assert p2.document is not None
+            assert p1.document is not d
+            assert p2.document is not d
+            assert p1.document == p2.document
+            assert p1.document.theme is orig_theme
+        assert p1.document is None
+        assert p2.document is not None
+        assert p2.document.theme is orig_theme
+
+class Test_OutputDocumentFor_custom_apply_theme(object):
+
+    def test_single_document(self):
+        # should use existing doc in with-block
+        p = Model()
+        d = Document()
+        orig_theme = d.theme
+        d.add_root(p)
+        with beu.OutputDocumentFor(d, apply_theme=Theme(json={})) as doc:
+            assert doc is d
+            assert d.theme is not orig_theme
+        assert d.theme is orig_theme
+
+    def test_single_model_with_document(self):
+        # should use existing doc in with-block
+        p = Model()
+        d = Document()
+        orig_theme = d.theme
+        d.add_root(p)
+        with beu.OutputDocumentFor([p], apply_theme=Theme(json={})):
+            assert p.document is d
+            assert d.theme is not orig_theme
+        assert p.document is d
+        assert d.theme is orig_theme
+
+    def test_single_model_with_no_document(self):
+        p = Model()
+        assert p.document is None
+        with beu.OutputDocumentFor([p], apply_theme=Theme(json={})):
+            assert p.document is not None
+            new_theme = p.document.theme
+        assert p.document is not None
+        assert p.document.theme is not new_theme
+
+    def test_list_of_model_with_no_documents(self):
+        # should create new (permanent) doc for inputs
+        p1 = Model()
+        p2 = Model()
+        assert p1.document is None
+        assert p2.document is None
+        with beu.OutputDocumentFor([p1, p2], apply_theme=Theme(json={})):
+            assert p1.document is not None
+            assert p2.document is not None
+            assert p1.document is p2.document
+            new_doc = p1.document
+            new_theme = p1.document.theme
+        assert p1.document is new_doc
+        assert p2.document is new_doc
+        assert p1.document is p2.document
+        # should restore to default theme after with-block
+        assert p1.document.theme is not new_theme
+
+    def test_list_of_model_same_as_roots(self):
+        # should use existing doc in with-block
+        p1 = Model()
+        p2 = Model()
+        d = Document()
+        orig_theme = d.theme
+        d.add_root(p1)
+        d.add_root(p2)
+        with beu.OutputDocumentFor([p1, p2], apply_theme=Theme(json={})):
+            assert p1.document is d
+            assert p2.document is d
+            assert d.theme is not orig_theme
+        assert p1.document is d
+        assert p2.document is d
+        assert d.theme is orig_theme
+
+    def test_list_of_model_same_as_roots_with_always_new(self):
+        # should use new temp doc for everything inside with-block
+        p1 = Model()
+        p2 = Model()
+        d = Document()
+        orig_theme = d.theme
+        d.add_root(p1)
+        d.add_root(p2)
+        with beu.OutputDocumentFor([p1, p2], always_new=True, apply_theme=Theme(json={})):
+            assert p1.document is not d
+            assert p2.document is not d
+            assert p1.document is p2.document
+            assert p2.document.theme is not orig_theme
+        assert p1.document is d
+        assert p2.document is d
+        assert d.theme is orig_theme
+
+    def test_list_of_model_subset_roots(self):
+        # should use new temp doc for subset inside with-block
+        p1 = Model()
+        p2 = Model()
+        d = Document()
+        orig_theme = d.theme
+        d.add_root(p1)
+        d.add_root(p2)
+        with beu.OutputDocumentFor([p1], apply_theme=Theme(json={})):
+            assert p1.document is not d
+            assert p2.document is d
+            assert p1.document.theme is not orig_theme
+            assert p2.document.theme is orig_theme
+        assert p1.document is d
+        assert p2.document is d
+        assert d.theme is orig_theme
+
+    def test_list_of_models_different_docs(self):
+        # should use new temp doc for eveything inside with-block
+        d = Document()
+        orig_theme = d.theme
+        p1 = Model()
+        p2 = Model()
+        d.add_root(p2)
+        assert p1.document is None
+        assert p2.document is not None
+        with beu.OutputDocumentFor([p1, p2], apply_theme=Theme(json={})):
+            assert p1.document is not None
+            assert p2.document is not None
+            assert p1.document is not d
+            assert p2.document is not d
+            assert p1.document == p2.document
+            assert p1.document.theme is not orig_theme
+        assert p1.document is None
+        assert p2.document is not None
+        assert p2.document.theme is orig_theme
+
+class Test_OutputDocumentFor_FromCurdoc_apply_theme(object):
+
+    def setup_method(self):
+        self.orig_theme = curdoc().theme
+        curdoc().theme = Theme(json={})
+
+    def teardown_method(self):
+        curdoc().theme = self.orig_theme
+
+    def test_single_document(self):
+        # should use existing doc in with-block
+        p = Model()
+        d = Document()
+        orig_theme = d.theme
+        d.add_root(p)
+        with beu.OutputDocumentFor(d, apply_theme=beu.FromCurdoc) as doc:
+            assert doc is d
+            assert d.theme is curdoc().theme
+        assert d.theme is orig_theme
+
+    def test_single_model_with_document(self):
+        # should use existing doc in with-block
+        p = Model()
+        d = Document()
+        orig_theme = d.theme
+        d.add_root(p)
+        with beu.OutputDocumentFor([p], apply_theme=beu.FromCurdoc):
+            assert p.document is d
+            assert d.theme is curdoc().theme
+        assert p.document is d
+        assert d.theme is orig_theme
+
+    def test_single_model_with_no_document(self):
+        p = Model()
+        assert p.document is None
+        with beu.OutputDocumentFor([p], apply_theme=beu.FromCurdoc):
+            assert p.document is not None
+            assert p.document.theme is curdoc().theme
+            new_doc = p.document
+        assert p.document is new_doc
+        assert p.document.theme is not curdoc().theme
+
+    def test_list_of_model_with_no_documents(self):
+        # should create new (permanent) doc for inputs
+        p1 = Model()
+        p2 = Model()
+        assert p1.document is None
+        assert p2.document is None
+        with beu.OutputDocumentFor([p1, p2], apply_theme=beu.FromCurdoc):
+            assert p1.document is not None
+            assert p2.document is not None
+            assert p1.document is p2.document
+            new_doc = p1.document
+            assert p1.document.theme is curdoc().theme
+        assert p1.document is new_doc
+        assert p2.document is new_doc
+        assert p1.document is p2.document
+        # should restore to default theme after with-block
+        assert p1.document.theme is not curdoc().theme
+
+    def test_list_of_model_same_as_roots(self):
+        # should use existing doc in with-block
+        p1 = Model()
+        p2 = Model()
+        d = Document()
+        orig_theme = d.theme
+        d.add_root(p1)
+        d.add_root(p2)
+        with beu.OutputDocumentFor([p1, p2], apply_theme=beu.FromCurdoc):
+            assert p1.document is d
+            assert p2.document is d
+            assert d.theme is curdoc().theme
+        assert p1.document is d
+        assert p2.document is d
+        assert d.theme is orig_theme
+
+    def test_list_of_model_same_as_roots_with_always_new(self):
+        # should use new temp doc for everything inside with-block
+        p1 = Model()
+        p2 = Model()
+        d = Document()
+        orig_theme = d.theme
+        d.add_root(p1)
+        d.add_root(p2)
+        with beu.OutputDocumentFor([p1, p2], always_new=True, apply_theme=beu.FromCurdoc):
+            assert p1.document is not d
+            assert p2.document is not d
+            assert p1.document is p2.document
+            assert p2.document.theme is curdoc().theme
+        assert p1.document is d
+        assert p2.document is d
+        assert d.theme is orig_theme
+
+    def test_list_of_model_subset_roots(self):
+        # should use new temp doc for subset inside with-block
+        p1 = Model()
+        p2 = Model()
+        d = Document()
+        orig_theme = d.theme
+        d.add_root(p1)
+        d.add_root(p2)
+        with beu.OutputDocumentFor([p1], apply_theme=beu.FromCurdoc):
+            assert p1.document is not d
+            assert p2.document is d
+            assert p1.document.theme is curdoc().theme
+            assert p2.document.theme is orig_theme
+        assert p1.document is d
+        assert p2.document is d
+        assert d.theme is orig_theme
+
+    def test_list_of_models_different_docs(self):
+        # should use new temp doc for eveything inside with-block
+        d = Document()
+        orig_theme = d.theme
+        p1 = Model()
+        p2 = Model()
+        d.add_root(p2)
+        assert p1.document is None
+        assert p2.document is not None
+        with beu.OutputDocumentFor([p1, p2], apply_theme=beu.FromCurdoc):
+            assert p1.document is not None
+            assert p2.document is not None
+            assert p1.document is not d
+            assert p2.document is not d
+            assert p1.document == p2.document
+            assert p1.document.theme is curdoc().theme
+        assert p1.document is None
+        assert p2.document is not None
+        assert p2.document.theme is orig_theme
+
 class Test_check_models_or_docs(object):
     pass
 
@@ -119,9 +555,6 @@ class Test_div_for_render_item(object):
     def test_render(self):
         render_item = beu.RenderItem(docid="doc123", elementid="foo123")
         assert beu.div_for_render_item(render_item).strip() == """<div class="bk-root" id="foo123"></div>"""
-
-class Test_find_existing_docs(object):
-    pass
 
 class Test_html_page_for_render_items(object):
     pass

--- a/bokeh/embed/tests/test_util.py
+++ b/bokeh/embed/tests/test_util.py
@@ -108,7 +108,7 @@ class Test_FromCurdoc(object):
     def test_type(self):
         assert isinstance(beu.FromCurdoc, type)
 
-_ODFERR = "OutputDocumentFor expects a Model, a Document, or a sequence of Models"
+_ODFERR = "OutputDocumentFor expects a sequence of Models"
 
 class Test_OutputDocumentFor_general(object):
 
@@ -146,7 +146,7 @@ class Test_OutputDocumentFor_general(object):
         with pytest.raises(RuntimeError) as e:
             with beu.OutputDocumentFor([p1, p2]):
                 pass
-        assert "already in a doc" in str(e)
+            assert "already in a doc" in str(e)
 
     @patch('bokeh.document.document.check_integrity')
     def test_validates_document_by_default(self, check_integrity, test_plot):
@@ -162,17 +162,6 @@ class Test_OutputDocumentFor_general(object):
         assert not check_integrity.called
 
 class Test_OutputDocumentFor_default_apply_theme(object):
-
-    def test_single_document(self):
-        # should use existing doc in with-block
-        p = Model()
-        d = Document()
-        orig_theme = d.theme
-        d.add_root(p)
-        with beu.OutputDocumentFor(d) as doc:
-            assert doc is d
-            assert d.theme is orig_theme
-        assert d.theme is orig_theme
 
     def test_single_model_with_document(self):
         # should use existing doc in with-block
@@ -280,17 +269,6 @@ class Test_OutputDocumentFor_default_apply_theme(object):
         assert p2.document.theme is orig_theme
 
 class Test_OutputDocumentFor_custom_apply_theme(object):
-
-    def test_single_document(self):
-        # should use existing doc in with-block
-        p = Model()
-        d = Document()
-        orig_theme = d.theme
-        d.add_root(p)
-        with beu.OutputDocumentFor(d, apply_theme=Theme(json={})) as doc:
-            assert doc is d
-            assert d.theme is not orig_theme
-        assert d.theme is orig_theme
 
     def test_single_model_with_document(self):
         # should use existing doc in with-block
@@ -410,17 +388,6 @@ class Test_OutputDocumentFor_FromCurdoc_apply_theme(object):
     def teardown_method(self):
         curdoc().theme = self.orig_theme
 
-    def test_single_document(self):
-        # should use existing doc in with-block
-        p = Model()
-        d = Document()
-        orig_theme = d.theme
-        d.add_root(p)
-        with beu.OutputDocumentFor(d, apply_theme=beu.FromCurdoc) as doc:
-            assert doc is d
-            assert d.theme is curdoc().theme
-        assert d.theme is orig_theme
-
     def test_single_model_with_document(self):
         # should use existing doc in with-block
         p = Model()
@@ -530,25 +497,6 @@ class Test_OutputDocumentFor_FromCurdoc_apply_theme(object):
         assert p1.document is None
         assert p2.document is not None
         assert p2.document.theme is orig_theme
-
-class Test_check_models_or_docs(object):
-    pass
-
-class Test_check_one_model_or_doc(object):
-
-    def test_succeed_with_one_model(self):
-        m = Model()
-        assert beu.check_one_model_or_doc(m) is m
-
-    def test_fails_with_multiple_models(self):
-        m1 = Model()
-        m2 = Model()
-        with pytest.raises(ValueError):
-            beu.check_one_model_or_doc([m1, m2])
-        with pytest.raises(ValueError):
-            beu.check_one_model_or_doc((m1, m2))
-        with pytest.raises(ValueError):
-            beu.check_one_model_or_doc(dict(m1=m1, m2=m2))
 
 class Test_div_for_render_item(object):
 

--- a/bokeh/embed/tests/test_util.py
+++ b/bokeh/embed/tests/test_util.py
@@ -498,18 +498,6 @@ class Test_OutputDocumentFor_FromCurdoc_apply_theme(object):
         assert p2.document is not None
         assert p2.document.theme is orig_theme
 
-class Test_div_for_render_item(object):
-
-    def test_render(self):
-        render_item = beu.RenderItem(docid="doc123", elementid="foo123")
-        assert beu.div_for_render_item(render_item).strip() == """<div class="bk-root" id="foo123"></div>"""
-
-class Test_html_page_for_render_items(object):
-    pass
-
-class Test_script_for_render_items(object):
-    pass
-
 class Test_standalone_docs_json_and_render_items(object):
 
     def test_log_warning_if_python_property_callback(self, caplog):
@@ -540,57 +528,6 @@ class Test_standalone_docs_json_and_render_items(object):
             assert len(caplog.records) == 1
             assert caplog.text != ''
 
-class Test_wrap_in_onload(object):
-
-    def test_render(self):
-        assert beu.wrap_in_onload("code\nmorecode") == """\
-(function() {
-  var fn = function() {
-    code
-    morecode
-  };
-  if (document.readyState != "loading") fn();
-  else document.addEventListener("DOMContentLoaded", fn);
-})();\
-"""
-
-class Test_wrap_in_safely(object):
-
-    def test_render(self):
-        assert beu.wrap_in_safely("code\nmorecode") == """\
-Bokeh.safely(function() {
-  code
-  morecode
-});\
-"""
-
-class Test_wrap_in_script_tag(object):
-
-    def test_render(self):
-        assert beu.wrap_in_script_tag("code\nmorecode") == """
-<script type="text/javascript">
-  code
-  morecode
-</script>\
-"""
-
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------
-
-def test__ONLOAD():
-    assert beu._ONLOAD == """\
-(function() {
-  var fn = function() {
-%(code)s
-  };
-  if (document.readyState != "loading") fn();
-  else document.addEventListener("DOMContentLoaded", fn);
-})();\
-"""
-
-def test__SAFELY():
-    assert beu._SAFELY == """\
-Bokeh.safely(function() {
-%(code)s
-});"""\

--- a/bokeh/embed/tests/test_wrappers.py
+++ b/bokeh/embed/tests/test_wrappers.py
@@ -1,0 +1,94 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2017, Anaconda, Inc. All rights reserved.
+#
+# Powered by the Bokeh Development Team.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import pytest ; pytest
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+
+# External imports
+
+# Bokeh imports
+
+# Module under test
+import bokeh.embed.wrappers as bew
+
+#-----------------------------------------------------------------------------
+# Setup
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
+class Test_wrap_in_onload(object):
+
+    def test_render(self):
+        assert bew.wrap_in_onload("code\nmorecode") == """\
+(function() {
+  var fn = function() {
+    code
+    morecode
+  };
+  if (document.readyState != "loading") fn();
+  else document.addEventListener("DOMContentLoaded", fn);
+})();\
+"""
+
+class Test_wrap_in_safely(object):
+
+    def test_render(self):
+        assert bew.wrap_in_safely("code\nmorecode") == """\
+Bokeh.safely(function() {
+  code
+  morecode
+});\
+"""
+
+class Test_wrap_in_script_tag(object):
+
+    def test_render(self):
+        assert bew.wrap_in_script_tag("code\nmorecode") == """
+<script type="text/javascript">
+  code
+  morecode
+</script>\
+"""
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+def test__ONLOAD():
+    assert bew._ONLOAD == """\
+(function() {
+  var fn = function() {
+%(code)s
+  };
+  if (document.readyState != "loading") fn();
+  else document.addEventListener("DOMContentLoaded", fn);
+})();\
+"""
+
+def test__SAFELY():
+    assert bew._SAFELY == """\
+Bokeh.safely(function() {
+%(code)s
+});"""\

--- a/bokeh/embed/util.py
+++ b/bokeh/embed/util.py
@@ -36,7 +36,7 @@ from ..model import Model, collect_models
 from ..settings import settings
 from ..util.compiler import bundle_all_models
 from ..util.serialization import make_id
-from ..util.string import encode_utf8, indent
+from ..util.string import encode_utf8, escape, indent
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -436,24 +436,6 @@ def wrap_in_script_tag(js, type="text/javascript", id=None):
 
     '''
     return SCRIPT_TAG.render(js_code=indent(js, 2), type=type, id=id)
-
-# based on `html` stdlib module (3.2+)
-def escape(s, quote=("'", '"')):
-    """
-    Replace special characters "&", "<" and ">" to HTML-safe sequences.
-    If the optional flag quote is true (the default), the quotation mark
-    characters, both double quote (") and single quote (') characters are also
-    translated.
-    """
-    s = s.replace("&", "&amp;")
-    s = s.replace("<", "&lt;")
-    s = s.replace(">", "&gt;")
-    if quote:
-        if '"' in quote:
-            s = s.replace('"', "&quot;")
-        if "'" in quote:
-            s = s.replace("'", "&#x27;")
-    return s
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/bokeh/embed/wrappers.py
+++ b/bokeh/embed/wrappers.py
@@ -1,0 +1,84 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2017, Anaconda, Inc. All rights reserved.
+#
+# Powered by the Bokeh Development Team.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+'''
+
+'''
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+log = logging.getLogger(__name__)
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+
+# External imports
+
+# Bokeh imports
+from ..core.templates import SCRIPT_TAG
+from ..util.string import indent
+
+#-----------------------------------------------------------------------------
+# Globals and constants
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
+def wrap_in_onload(code):
+    '''
+
+    '''
+    return _ONLOAD % dict(code=indent(code, 4))
+
+def wrap_in_safely(code):
+    '''
+
+    '''
+    return _SAFELY % dict(code=indent(code, 2))
+
+def wrap_in_script_tag(js, type="text/javascript", id=None):
+    '''
+
+    '''
+    return SCRIPT_TAG.render(js_code=indent(js, 2), type=type, id=id)
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+_ONLOAD = """\
+(function() {
+  var fn = function() {
+%(code)s
+  };
+  if (document.readyState != "loading") fn();
+  else document.addEventListener("DOMContentLoaded", fn);
+})();\
+"""
+
+_SAFELY = """\
+Bokeh.safely(function() {
+%(code)s
+});\
+"""
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------

--- a/bokeh/io/notebook.py
+++ b/bokeh/io/notebook.py
@@ -488,6 +488,9 @@ def show_doc(obj, state, notebook_handle):
     '''
 
     '''
+    if obj not in state.document.roots:
+        state.document.add_root(obj)
+
     from ..embed.notebook import notebook_content
     comms_target = make_id() if notebook_handle else None
     (script, div, cell_doc) = notebook_content(obj, comms_target)

--- a/bokeh/io/showing.py
+++ b/bokeh/io/showing.py
@@ -132,8 +132,6 @@ def show(obj, browser=None, new="tab", notebook_handle=False, notebook_url="loca
     if is_application or callable(obj):
         return run_notebook_hook(state.notebook_type, 'app', obj, state, notebook_url)
 
-    if obj not in state.document.roots:
-        state.document.add_root(obj)
     return _show_with_state(obj, state, browser, new, notebook_handle=notebook_handle)
 
 #-----------------------------------------------------------------------------

--- a/bokeh/io/tests/test_notebook.py
+++ b/bokeh/io/tests/test_notebook.py
@@ -63,6 +63,7 @@ def test_show_doc_no_server(mock_notebook_content,
 
     class Obj(object):
         _id = None
+        def references(self): return []
 
     assert mock__publish_display_data.call_count == 0
     binb.show_doc(Obj(), s, True)

--- a/bokeh/io/tests/test_showing.py
+++ b/bokeh/io/tests/test_showing.py
@@ -50,7 +50,7 @@ def test_show_with_default_args(mock__show_with_state):
     assert mock__show_with_state.call_count == 1
     assert mock__show_with_state.call_args[0] == (p, curstate(), None, "tab")
     assert mock__show_with_state.call_args[1] == {'notebook_handle': False}
-    assert p in curdoc().roots
+    assert curdoc().roots == []
 
 @patch('bokeh.io.showing._show_with_state')
 def test_show_with_explicit_args(mock__show_with_state):
@@ -61,7 +61,7 @@ def test_show_with_explicit_args(mock__show_with_state):
     assert mock__show_with_state.call_count == 1
     assert mock__show_with_state.call_args[0] == (p, curstate(), "browser", "new")
     assert mock__show_with_state.call_args[1] == {'notebook_handle': True}
-    assert p in curdoc().roots
+    assert curdoc().roots == []
 
 @patch('bokeh.io.showing.run_notebook_hook')
 def test_show_with_app(mock_run_notebook_hook):
@@ -76,22 +76,15 @@ def test_show_with_app(mock_run_notebook_hook):
     assert mock_run_notebook_hook.call_args[1] == {}
 
 @patch('bokeh.io.showing._show_with_state')
-def test_show_adds_obj_to_document_if_not_already_there(m):
+def test_show_doesn_not_adds_obj_to_curdoc(m):
     curstate().reset()
     assert curstate().document.roots == []
     p = Plot()
     bis.show(p)
-    assert p in curstate().document.roots
-
-@patch('bokeh.io.showing._show_with_state')
-def test_show_doesnt_duplicate_if_already_there(m):
-    curstate().reset()
     assert curstate().document.roots == []
     p = Plot()
     bis.show(p)
-    assert curstate().document.roots == [p]
-    bis.show(p)
-    assert curstate().document.roots == [p]
+    assert curstate().document.roots == []
 
 @pytest.mark.parametrize('obj', [1, 2.3, None, "str", GlyphRenderer()])
 @pytest.mark.unit

--- a/bokeh/model.py
+++ b/bokeh/model.py
@@ -216,6 +216,7 @@ class Model(with_metaclass(MetaModel, HasProps, PropertyCallbackManager, EventCa
     def __init__(self, **kwargs):
         self._id = kwargs.pop("id", make_id())
         self._document = None
+        self._temp_document = None
         super(Model, self).__init__(**kwargs)
         default_theme.apply_to_model(self)
 
@@ -307,6 +308,8 @@ class Model(with_metaclass(MetaModel, HasProps, PropertyCallbackManager, EventCa
         ''' The |Document| this model is attached to (can be ``None``)
 
         '''
+        if self._temp_document is not None:
+            return self._temp_document
         return self._document
 
     @property

--- a/bokeh/server/views/autoload_js_handler.py
+++ b/bokeh/server/views/autoload_js_handler.py
@@ -12,7 +12,7 @@ from tornado import gen
 from bokeh.core.templates import AUTOLOAD_JS
 from bokeh.util.string import encode_utf8
 from bokeh.util.compiler import bundle_all_models
-from bokeh.embed.standalone import script_for_render_items
+from bokeh.embed.elements import script_for_render_items
 from bokeh.embed.util import RenderItem
 
 from .session_handler import SessionHandler

--- a/bokeh/util/string.py
+++ b/bokeh/util/string.py
@@ -35,6 +35,33 @@ def decode_utf8(u):
         u = u.decode('utf-8')
     return u
 
+# based on `html` stdlib module (3.2+)
+def escape(s, quote=("'", '"')):
+    ''' Perform HTML-safe escaping.
+
+    Replaces special characters "&", "<" and ">" to HTML-safe sequences, and
+    optionally translates quote characters.
+
+    Args:
+        s (str): a string to escape
+
+        quote (seq[str], optional) : which quote characters to replace
+            (default: ("'", '"'))
+
+    Returns:
+        str
+
+    '''
+    s = s.replace("&", "&amp;")
+    s = s.replace("<", "&lt;")
+    s = s.replace(">", "&gt;")
+    if quote:
+        if '"' in quote:
+            s = s.replace('"', "&quot;")
+        if "'" in quote:
+            s = s.replace("'", "&#x27;")
+    return s
+
 def indent(text, n=2, ch=" "):
     ''' Indent all the lines in a given block of text by a specified ammount.
 

--- a/bokeh/util/tests/test_string.py
+++ b/bokeh/util/tests/test_string.py
@@ -2,6 +2,32 @@ from __future__ import absolute_import
 
 import bokeh.util.string as bus
 
+class Test_escape(object):
+
+    def test_default_quote(self):
+        assert bus.escape("foo'bar") == "foo&#x27;bar"
+        assert bus.escape('foo"bar') == "foo&quot;bar"
+
+    def test_quote_False(self):
+        assert bus.escape("foo'bar", quote=False) == "foo'bar"
+        assert bus.escape('foo"bar', quote=False) == 'foo"bar'
+
+    def test_quote_custom(self):
+        assert bus.escape("foo'bar", quote=('"'),) == "foo'bar"
+        assert bus.escape("foo'bar", quote=("'"),) == "foo&#x27;bar"
+
+        assert bus.escape('foo"bar', quote=("'"),) == 'foo"bar'
+        assert bus.escape('foo"bar', quote=('"'),) == "foo&quot;bar"
+
+    def test_amp(self):
+        assert bus.escape("foo&bar") == "foo&amp;bar"
+
+    def test_lt(self):
+        assert bus.escape("foo<bar") == "foo&lt;bar"
+
+    def test_gt(self):
+        assert bus.escape("foo>bar") == "foo&gt;bar"
+
 class Test_format_doctring(object):
     def test_no_argument(self):
         doc__ = "hello world"
@@ -32,8 +58,6 @@ class Test_indent(object):
 
     def test_with_ch(self):
         assert bus.indent(self.TEXT, ch="-") == "--some text\n--to indent\n--  goes here"
-
-
 
 def test_snakify():
     assert bus.snakify("MyClassName") == "my_class_name"

--- a/tests/integration/widgets/test_div.py
+++ b/tests/integration/widgets/test_div.py
@@ -22,8 +22,8 @@ import pytest ; pytest
 # External imports
 
 # Bokeh imports
-from bokeh.embed.util import escape
 from bokeh.models import Div
+from bokeh.util.string import escape
 
 #-----------------------------------------------------------------------------
 # Tests

--- a/tests/integration/widgets/test_paragraph.py
+++ b/tests/integration/widgets/test_paragraph.py
@@ -22,8 +22,8 @@ import pytest ; pytest
 # External imports
 
 # Bokeh imports
-from bokeh.embed.util import escape
 from bokeh.models import Paragraph
+from bokeh.util.string import escape
 
 #-----------------------------------------------------------------------------
 # Tests

--- a/tests/integration/widgets/test_pretext.py
+++ b/tests/integration/widgets/test_pretext.py
@@ -22,8 +22,8 @@ import pytest ; pytest
 # External imports
 
 # Bokeh imports
-from bokeh.embed.util import escape
 from bokeh.models import PreText
+from bokeh.util.string import escape
 
 #-----------------------------------------------------------------------------
 # Tests


### PR DESCRIPTION
- [x] issues: fixes #8179
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

This PR makes the following changes:

* `show` only adds content to `curdoc` when showing in the notebook. It is necessary in the notebook that *all* output be in the same global document, but this is not necessary or especially useful for typical usage outside the notebook. 

* Consolidates ill-specified and undocumented `_ModelInDocument` and `_ModelInEmptyDocument` into a documented context manager `OutputDocumentFor` that is comprehensively tested.

The old context managers seemed to try to handle cases that do no seem important. e.g. mixing documents and models together, making their behaviour overly complicated. 

`OutputDocumentFor` tries to just re-use an existing document where possible. If there is no existing document, it will create one, and make it the permanent new document (i.e. it will call `add_root` on them). If there are too many documents, or if we only want to consider a *subset of roots*.  then `OutputDocumentFor` creates a "temp doc" that effectively re-homes the models, to use inside the with-block

The last bit is what could be considered bit kludgy. Specifically, because the "temp" doc is not completely initialized, but is useful enough to use for the serialization cases we currently have. The *implementation* could be perhaps improved with a better internal API. Or perhaps the "temp doc" concept could be explicitly realized in a new type. Comments here are welcome. 

However, I believe the outward facing *behaviour* of `OutputDocumentFor` is fairly close to what it needs to be. I'd like to come to explicit agreement on this point. Then as long as those behaviours are fully codified in tests we can improve implementation now or later. 

cc @mattpap 

One thing to note also is that `OutputDocumentFor` is somewhat faster now, and especially with validation turned off, only takes on the order of miroseconds on my latptop. 