### PR TITLE
Bryanv/5231 json embeds

### DIFF
--- a/bokeh/embed/__init__.py
+++ b/bokeh/embed/__init__.py
@@ -37,11 +37,13 @@ from .server import server_session
 from .standalone import autoload_static
 from .standalone import components
 from .standalone import file_html
+from .standalone import json_item
 
 __all__ = (
     'autoload_static',
     'components',
     'file_html',
+    'json_item',
     'server_document',
     'server_session',
 )

--- a/bokeh/embed/__init__.py
+++ b/bokeh/embed/__init__.py
@@ -5,7 +5,15 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-'''
+''' Provide functions for embedding Bokeh standalone and server content in
+web pages.
+
+.. autofunction:: autoload_static
+.. autofunction:: components
+.. autofunction:: file_html
+.. autofunction:: json_item
+.. autofunction:: server_document
+.. autofunction:: server_session
 
 '''
 

--- a/bokeh/embed/standalone.py
+++ b/bokeh/embed/standalone.py
@@ -303,8 +303,62 @@ def file_html(models,
         return html_page_for_render_items(bundle, docs_json, render_items, title=title,
                                           template=template, template_variables=template_variables)
 
-def json_item(model, target, theme=FromCurdoc):
-    '''
+def json_item(model, target=None, theme=FromCurdoc):
+    ''' Return a JSON block that can be used to embed standalone Bokeh conent.
+
+    Args:
+        model (Model) :
+            The Bokeh object to embed
+
+        target (string, optional)
+            A div id to embd the model into. If None, the target id must
+            be supplied in the JavaScript call.
+
+        theme (Theme, optional) :
+            Defaults to the ``Theme`` instance in the current document.
+            Setting this to ``None`` uses the default theme or the theme
+            already specified in the document. Any other value must be an
+            instance of the ``Theme`` class.
+
+    Returns:
+        JSON-like
+
+    This function returns a JSON block that can be consumed by the BokehJS
+    function ``Bokeh.embed.embed_item``. As an example, a Flask endpoint for
+    ``/plot`` might return the following content to embed a Bokeh plot into
+    a div with id *"myplot"*:
+
+    .. code-block:: python
+
+        @app.route('/plot')
+        def plot():
+            p = make_plot('petal_width', 'petal_length')
+            return json.dumps(json_item(p, "myplot"))
+
+    Then a web page can retrieve this JSON and embed the plot by calling
+    ``Bokeh.embed.embed_item``:
+
+    .. code-block:: html
+
+        <script>
+        fetch('/plot')
+            .then(function(response) { return response.json(); })
+            .then(function(item) { Bokeh.embed.embed_item(item); })
+        </script>
+
+    Alternatively, if is more convenient to suppluy the target div id directly
+    in the page source, that is also possible. If `target_id` is omitted in the
+    call to this function:
+
+    .. code-block:: python
+
+        return json.dumps(json_item(p))
+
+    Then the value passed to ``embed_item`` is used:
+
+    .. code-block:: javascript
+
+        Bokeh.embed.embed_item(item, "myplot");
 
     '''
     with OutputDocumentFor([model], apply_theme=theme) as doc:

--- a/bokeh/embed/standalone.py
+++ b/bokeh/embed/standalone.py
@@ -35,7 +35,7 @@ from ..util.compiler import bundle_all_models
 from ..util.string import encode_utf8
 from .bundle import bundle_for_objs_and_resources
 from .elements import html_page_for_render_items, script_for_render_items
-from .util import FromCurdoc, OutputDocumentFor, standalone_docs_json_and_render_items
+from .util import FromCurdoc, OutputDocumentFor, standalone_docs_json, standalone_docs_json_and_render_items
 from .wrappers import wrap_in_onload, wrap_in_script_tag
 
 #-----------------------------------------------------------------------------
@@ -302,6 +302,24 @@ def file_html(models,
         bundle = bundle_for_objs_and_resources([doc], resources)
         return html_page_for_render_items(bundle, docs_json, render_items, title=title,
                                           template=template, template_variables=template_variables)
+
+def json_item(model, target, theme=FromCurdoc):
+    '''
+
+    '''
+    with OutputDocumentFor([model], apply_theme=theme) as doc:
+        doc.title = ""
+        docs_json = standalone_docs_json([model])
+
+    doc = list(docs_json.values())[0]
+    root_id = doc['roots']['root_ids'][0]
+
+    return {
+        'target_id' : target,
+        'root_id'   : root_id,
+        'doc'       : doc,
+    }
+
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/embed/tests/test___init__.py
+++ b/bokeh/embed/tests/test___init__.py
@@ -35,6 +35,7 @@ ALL = (
     'autoload_static',
     'components',
     'file_html',
+    'json_item',
     'server_document',
     'server_session',
 )

--- a/bokeh/embed/tests/test_standalone.py
+++ b/bokeh/embed/tests/test_standalone.py
@@ -60,8 +60,7 @@ class Test_autoload_static(object):
         r = bes.autoload_static(test_plot, CDN, "some/path")
         assert len(r) == 2
 
-    @patch('bokeh.embed.util.make_id', new_callable=lambda: stable_id)
-    def test_script_attrs(self, mock_make_id, test_plot):
+    def test_script_attrs(self, test_plot):
         js, tag = bes.autoload_static(test_plot, CDN, "some/path")
         html = bs4.BeautifulSoup(tag, "lxml")
         scripts = html.findAll(name='script')
@@ -95,7 +94,7 @@ class Test_components(object):
         assert isinstance(divs, dict)
         assert all(isinstance(x, string_types) for x in divs.keys())
 
-    @patch('bokeh.embed.util.make_id', new_callable=lambda: stable_id)
+    @patch('bokeh.embed.util.uuid.uuid4', new_callable=lambda: stable_id)
     def test_plot_dict_returned_when_wrap_plot_info_is_false(self, mock_make_id):
         doc = Document()
         plot1 = figure()
@@ -141,8 +140,7 @@ class Test_components(object):
         script, div = bes.components(test_plot)
         assert isinstance(script, str)
 
-    @patch('bokeh.embed.util.make_id', new_callable=lambda: stable_id)
-    def test_output_is_without_script_tag_when_wrap_script_is_false(self, mock_make_id, test_plot):
+    def test_output_is_without_script_tag_when_wrap_script_is_false(self, test_plot):
         script, div = bes.components(test_plot)
         html = bs4.BeautifulSoup(script, "lxml")
         scripts = html.findAll(name='script')

--- a/bokeh/embed/tests/test_standalone.py
+++ b/bokeh/embed/tests/test_standalone.py
@@ -94,7 +94,7 @@ class Test_components(object):
         assert isinstance(divs, dict)
         assert all(isinstance(x, string_types) for x in divs.keys())
 
-    @patch('bokeh.embed.util.uuid.uuid4', new_callable=lambda: stable_id)
+    @patch('bokeh.embed.util.make_globally_unique_id', new_callable=lambda: stable_id)
     def test_plot_dict_returned_when_wrap_plot_info_is_false(self, mock_make_id):
         doc = Document()
         plot1 = figure()

--- a/bokeh/embed/tests/test_standalone.py
+++ b/bokeh/embed/tests/test_standalone.py
@@ -27,6 +27,7 @@ from six import string_types
 
 # Bokeh imports
 from bokeh.document import Document
+from bokeh.embed.util import standalone_docs_json
 from bokeh.io import curdoc
 from bokeh.plotting import figure
 from bokeh.resources import CDN, JSResources, CSSResources
@@ -239,6 +240,41 @@ class Test_file_html(object):
 
         # this is a very coarse test but it will do
         assert "bokeh-widgets" not in out
+
+class Test_json_item(object):
+
+    def test_with_target_id(self, test_plot):
+        out = bes.json_item(test_plot, target="foo")
+        assert out['target_id'] == "foo"
+
+    def test_without_target_id(self, test_plot):
+        out = bes.json_item(test_plot)
+        assert out['target_id'] == None
+
+    def test_doc_json(self, test_plot):
+        out = bes.json_item(test_plot, target="foo")
+        expected = list(standalone_docs_json([test_plot]).values())[0]
+        assert out['doc'] == expected
+
+    def test_doc_title(self, test_plot):
+        out = bes.json_item(test_plot, target="foo")
+        assert out['doc']['title'] == ""
+
+    def test_root_id(self, test_plot):
+        out = bes.json_item(test_plot, target="foo")
+        assert out['doc']['roots']['root_ids'][0] == out['root_id']
+
+    @patch('bokeh.embed.standalone.OutputDocumentFor')
+    def test_apply_theme(self, mock_OFD, test_plot):
+        # the subsequent call inside ODF will fail since the model was never
+        # added to a document. Ignoring that since we just want to make sure
+        # ODF is called with the expected theme arg.
+        try:
+            bes.json_item(test_plot, theme="foo")
+        except ValueError:
+            pass
+        mock_OFD.assert_called_once_with([test_plot], apply_theme="foo")
+
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/embed/util.py
+++ b/bokeh/embed/util.py
@@ -24,6 +24,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 from collections import Sequence, OrderedDict
 from contextlib import contextmanager
+import uuid
 
 # External imports
 
@@ -31,7 +32,6 @@ from contextlib import contextmanager
 from ..document.document import Document
 from ..model import Model, collect_models
 from ..settings import settings
-from ..util.serialization import make_id
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -160,7 +160,7 @@ class RenderItem(object):
         if roots is None:
             roots = OrderedDict()
         elif isinstance(roots, list):
-            roots = OrderedDict([ (root, make_id()) for root in roots ])
+            roots = OrderedDict([ (root, str(uuid.uuid4())) for root in roots ])
 
         self.docid = docid
         self.sessionid = sessionid
@@ -233,6 +233,13 @@ class RenderRoots(object):
     def to_json(self):
         return OrderedDict([ (root._id, elementid) for root, elementid in self._roots.items() ])
 
+def standalone_docs_json(models):
+    '''
+
+    '''
+    docs_json, render_items = standalone_docs_json_and_render_items(models)
+    return docs_json
+
 def standalone_docs_json_and_render_items(models, suppress_callback_warning=False):
     '''
 
@@ -259,15 +266,15 @@ def standalone_docs_json_and_render_items(models, suppress_callback_warning=Fals
                 raise ValueError("to render a model as HTML it must be part of a document")
 
         if doc not in docs:
-            docs[doc] = (make_id(), OrderedDict())
+            docs[doc] = (str(uuid.uuid4()), OrderedDict())
 
         (docid, roots) = docs[doc]
 
         if model is not None:
-            roots[model] = make_id()
+            roots[model] = str(uuid.uuid4())
         else:
             for model in doc.roots:
-                roots[model] = make_id()
+                roots[model] = str(uuid.uuid4())
 
     docs_json = {}
     for doc, (docid, _) in docs.items():

--- a/bokeh/embed/util.py
+++ b/bokeh/embed/util.py
@@ -263,7 +263,7 @@ def standalone_docs_json_and_render_items(models, suppress_callback_warning=Fals
             doc = model.document
 
             if doc is None:
-                raise ValueError("to render a model as HTML it must be part of a document")
+                raise ValueError("A Bokeh Model must be part of a Document to render as standalone content")
 
         if doc not in docs:
             docs[doc] = (make_globally_unique_id(), OrderedDict())

--- a/bokeh/embed/util.py
+++ b/bokeh/embed/util.py
@@ -24,7 +24,6 @@ log = logging.getLogger(__name__)
 # Standard library imports
 from collections import Sequence, OrderedDict
 from contextlib import contextmanager
-import uuid
 
 # External imports
 
@@ -32,6 +31,7 @@ import uuid
 from ..document.document import Document
 from ..model import Model, collect_models
 from ..settings import settings
+from ..util.serialization import make_globally_unique_id
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -160,7 +160,7 @@ class RenderItem(object):
         if roots is None:
             roots = OrderedDict()
         elif isinstance(roots, list):
-            roots = OrderedDict([ (root, str(uuid.uuid4())) for root in roots ])
+            roots = OrderedDict([ (root, make_globally_unique_id()) for root in roots ])
 
         self.docid = docid
         self.sessionid = sessionid
@@ -266,15 +266,15 @@ def standalone_docs_json_and_render_items(models, suppress_callback_warning=Fals
                 raise ValueError("to render a model as HTML it must be part of a document")
 
         if doc not in docs:
-            docs[doc] = (str(uuid.uuid4()), OrderedDict())
+            docs[doc] = (make_globally_unique_id(), OrderedDict())
 
         (docid, roots) = docs[doc]
 
         if model is not None:
-            roots[model] = str(uuid.uuid4())
+            roots[model] = make_globally_unique_id()
         else:
             for model in doc.roots:
-                roots[model] = str(uuid.uuid4())
+                roots[model] = make_globally_unique_id()
 
     docs_json = {}
     for doc, (docid, _) in docs.items():

--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -202,8 +202,8 @@ def make_id():
 
     Normally this function will return simple monotonically increasing integer
     IDs (as strings) for identifying Bokeh ojects within a Document. However,
-    if it is desirable to have UUIDs for every object, this behavior can be
-    overridden by setting the environment variable ``BOKEH_SIMPLE_IDS=no``.
+    if it is desirable to have globally unique for every object, this behavior
+    can be overridden by setting the environment variable ``BOKEH_SIMPLE_IDS=no``.
 
     Returns:
         str
@@ -216,7 +216,19 @@ def make_id():
             _simple_id += 1
             return str(_simple_id)
     else:
-        return str(uuid.uuid4())
+        return make_globally_unique_id()
+
+def make_globally_unique_id():
+    ''' Return a globally unique UUID.
+
+    Some situtations, e.g. id'ing dynamincally created Divs in HTML documents,
+    always require globally unique IDs.
+
+    Returns:
+        str
+
+    '''
+    return str(uuid.uuid4())
 
 def array_encoding_disabled(array):
     ''' Determine whether an array may be binary encoded.

--- a/bokeh/util/tests/test_serialization.py
+++ b/bokeh/util/tests/test_serialization.py
@@ -1,7 +1,11 @@
 from __future__ import absolute_import
 
-import datetime
 import base64
+import datetime
+import os
+from random import random
+from threading import Thread
+import time
 
 import pytest
 import numpy as np
@@ -10,17 +14,41 @@ import pytz
 
 import bokeh.util.serialization as bus
 
+class Test_make_id(object):
 
-def test_id():
-    assert len(bus.make_id()) == 36
-    assert isinstance(bus.make_id(), str)
+    def test_default(self):
+        bus._simple_id = 999
+        assert bus.make_id() == "1000"
+        assert bus.make_id() == "1001"
+        assert bus.make_id() == "1002"
 
-def test_id_with_simple_ids():
-    import os
-    os.environ["BOKEH_SIMPLE_IDS"] = "yes"
-    assert bus.make_id() == "1001"
-    assert bus.make_id() == "1002"
-    del os.environ["BOKEH_SIMPLE_IDS"]
+    def test_simple_ids_yes(self):
+        bus._simple_id = 999
+        os.environ["BOKEH_SIMPLE_IDS"] = "yes"
+        assert bus.make_id() == "1000"
+        assert bus.make_id() == "1001"
+        assert bus.make_id() == "1002"
+
+    def test_simple_ids_no(self):
+        os.environ["BOKEH_SIMPLE_IDS"] = "no"
+        assert len(bus.make_id()) == 36
+        assert isinstance(bus.make_id(), str)
+        del os.environ["BOKEH_SIMPLE_IDS"]
+
+    def test_threads(self):
+        bus._simple_id = 999
+        outputs = []
+        threads = []
+        def func():
+            for i in range(10):
+                time.sleep(random()/100)
+                outputs.append(bus.make_id())
+        for i in range(100):
+            threads.append(Thread(target=func))
+        for t in threads: t.start()
+        for t in threads: t.join()
+        outputs.append(bus.make_id())
+        assert outputs == [str(x) for x in range(1000, 2001)]
 
 def test_np_consts():
     assert bus.NP_EPOCH == np.datetime64(0, 'ms')

--- a/bokeh/util/tests/test_serialization.py
+++ b/bokeh/util/tests/test_serialization.py
@@ -3,9 +3,6 @@ from __future__ import absolute_import
 import base64
 import datetime
 import os
-from random import random
-from threading import Thread
-import time
 
 import pytest
 import numpy as np
@@ -35,20 +32,10 @@ class Test_make_id(object):
         assert isinstance(bus.make_id(), str)
         del os.environ["BOKEH_SIMPLE_IDS"]
 
-    def test_threads(self):
-        bus._simple_id = 999
-        outputs = []
-        threads = []
-        def func():
-            for i in range(10):
-                time.sleep(random()/100)
-                outputs.append(bus.make_id())
-        for i in range(100):
-            threads.append(Thread(target=func))
-        for t in threads: t.start()
-        for t in threads: t.join()
-        outputs.append(bus.make_id())
-        assert outputs == [str(x) for x in range(1000, 2001)]
+class Test_make_globally_unique_id(object):
+    def test_basic(self):
+        assert len(bus.make_globally_unique_id()) == 36
+        assert isinstance(bus.make_globally_unique_id(), str)
 
 def test_np_consts():
     assert bus.NP_EPOCH == np.datetime64(0, 'ms')

--- a/bokehjs/src/lib/document.ts
+++ b/bokehjs/src/lib/document.ts
@@ -698,6 +698,7 @@ export class Document {
     const root_ids = this._roots.map((r) => r.id)
     const root_references = values(this._all_models)
     return {
+      version: js_version,
       title: this._title,
       roots: {
         root_ids: root_ids,

--- a/bokehjs/src/lib/embed/index.ts
+++ b/bokehjs/src/lib/embed/index.ts
@@ -15,7 +15,7 @@ export {add_document_from_session} from "./server"
 export {embed_items_notebook, kernels} from "./notebook"
 export {BOKEH_ROOT, inject_css, inject_raw_css} from "./dom"
 
-type JsonItem = {doc: DocJson, root_id: string, target_id: string}
+export type JsonItem = {doc: DocJson, root_id: string, target_id: string}
 interface Roots {[index: string]: string}
 
 export function embed_item(item: JsonItem) {
@@ -23,8 +23,7 @@ export function embed_item(item: JsonItem) {
   const doc_id = uuid4()
   docs_json[doc_id] = item.doc
 
-  const roots: Roots = {}
-  roots[item.root_id] = item.target_id
+  const roots: Roots = {[item.root_id]: item.target_id}
   const render_item: RenderItem = { roots: roots, docid: doc_id }
 
   defer(() => _embed_items(docs_json, [render_item]))

--- a/bokehjs/src/lib/embed/index.ts
+++ b/bokehjs/src/lib/embed/index.ts
@@ -1,7 +1,7 @@
-import {Document} from "../document"
+import {Document, DocJson} from "../document"
 import {logger} from "../core/logging"
 import {defer} from "../core/util/callback"
-import {unescape} from "../core/util/string"
+import {unescape, uuid4} from "../core/util/string"
 import {isString} from "../core/util/types"
 
 import {DocsJson, RenderItem} from "./json"
@@ -14,6 +14,21 @@ export {add_document_standalone} from "./standalone"
 export {add_document_from_session} from "./server"
 export {embed_items_notebook, kernels} from "./notebook"
 export {BOKEH_ROOT, inject_css, inject_raw_css} from "./dom"
+
+type JsonItem = {doc: DocJson, root_id: string, target_id: string}
+interface Roots {[index: string]: string}
+
+export function embed_item(item: JsonItem) {
+  const docs_json: DocsJson = {}
+  const doc_id = uuid4()
+  docs_json[doc_id] = item.doc
+
+  const roots: Roots = {}
+  roots[item.root_id] = item.target_id
+  const render_item: RenderItem = { roots: roots, docid: doc_id }
+
+  defer(() => _embed_items(docs_json, [render_item]))
+}
 
 // TODO (bev) this is currently clunky. Standalone embeds only provide
 // the first two args, whereas server provide the app_app, and *may* prove and

--- a/bokehjs/src/lib/embed/index.ts
+++ b/bokehjs/src/lib/embed/index.ts
@@ -18,12 +18,14 @@ export {BOKEH_ROOT, inject_css, inject_raw_css} from "./dom"
 export type JsonItem = {doc: DocJson, root_id: string, target_id: string}
 interface Roots {[index: string]: string}
 
-export function embed_item(item: JsonItem) {
+export function embed_item(item: JsonItem, target_id?: string) {
   const docs_json: DocsJson = {}
   const doc_id = uuid4()
   docs_json[doc_id] = item.doc
 
-  const roots: Roots = {[item.root_id]: item.target_id}
+  if (target_id == null)
+    target_id = item.target_id
+  const roots: Roots = {[item.root_id]: target_id}
   const render_item: RenderItem = { roots: roots, docid: doc_id }
 
   defer(() => _embed_items(docs_json, [render_item]))

--- a/examples.yaml
+++ b/examples.yaml
@@ -17,7 +17,7 @@
 - path: "examples/howto/layouts"
 
 - path: "examples/embed"
-  skip: ["arguments", "autoload_static.py", "custom_server", "server_session", "simple"]
+  skip: ["arguments", "autoload_static.py", "custom_server", "json_item.py", "server_session", "simple"]
 
 - path: "examples/app"
   type: server

--- a/examples/embed/json_item.py
+++ b/examples/embed/json_item.py
@@ -1,0 +1,63 @@
+from __future__ import print_function
+import json
+
+from bokeh.embed import json_item
+from bokeh.plotting import figure
+from bokeh.sampledata.iris import flowers
+
+from flask import Flask
+from jinja2 import Template
+
+app = Flask(__name__)
+
+page = Template("""
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link href="http://localhost:5006/static/css/bokeh.css" rel="stylesheet" type="text/css">
+  <script src="http://localhost:5006/static/js/bokeh.js"></script>
+</head>
+
+<body>
+  <div id="myplot"></div>
+  <div id="myplot2"></div>
+  <script>
+  fetch('/plot')
+    .then(function(response) { return response.json(); })
+    .then(function(item) { Bokeh.embed.embed_item(item); })
+  </script>
+  <script>
+  fetch('/plot2')
+    .then(function(response) { return response.json(); })
+    .then(function(item) { Bokeh.embed.embed_item(item, "myplot2"); })
+  </script>
+</body>
+""")
+
+colormap = {'setosa': 'red', 'versicolor': 'green', 'virginica': 'blue'}
+colors = [colormap[x] for x in flowers['species']]
+
+def make_plot(x, y):
+    p = figure(title = "Iris Morphology", sizing_mode="fixed")
+    p.xaxis.axis_label = x
+    p.yaxis.axis_label = y
+    p.circle(flowers[x], flowers[y], color=colors, fill_alpha=0.2, size=10)
+    return p
+
+@app.route('/')
+def root():
+    return page.render()
+
+@app.route('/plot')
+def plot():
+    p = make_plot('petal_width', 'petal_length')
+    return json.dumps(json_item(p, "myplot"))
+
+@app.route('/plot2')
+def plot2():
+    p = make_plot('sepal_width', 'sepal_length')
+    return json.dumps(json_item(p))
+
+if __name__ == '__main__':
+    print("\n\n *** Run 'bokeh static --port 5006` in a separate window ***\n\n")
+    app.run()

--- a/sphinx/source/docs/releases/1.0.0.rst
+++ b/sphinx/source/docs/releases/1.0.0.rst
@@ -28,6 +28,18 @@ making it unusable. As a result, both ``pprint`` and ``pretty`` methods have
 been removed. A "pretty" HTML repr still functions in Jupyter notebooks. This
 change is not expected to affect any normal usage.
 
+Bokeh Object IDs
+~~~~~~~~~~~~~~~~
+
+Previously Bokeh generated unique UUIDs for every Bokeh object. Starting with
+this release, Bokeh generates simple increasing integer IDs by default. You can
+set the environment variable ``BOKEH_SIMPLE_IDS=no`` to restore the previous
+behavior. The generation of simple IDs is faster than UUIDs, otherwise this
+change is not expected to affect any normal usage. However, if you are creating
+Bokeh objects for a single Document in separate processes, i.e. by using the
+``multiprocessing`` module, then you will want to turn off simple IDs. (This
+is expected to be a rare and unusual usage.)
+
 ``bokeh.util.plot_utils``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/sphinx/source/docs/user_guide/embed.rst
+++ b/sphinx/source/docs/user_guide/embed.rst
@@ -61,6 +61,71 @@ the |bokeh.plotting| interface in a script or Jupyter notebook, users will
 typically call the function |output_file| in conjunction with |show| or
 |save| instead.
 
+.. _userguide_embed_json_items:
+
+JSON Items
+~~~~~~~~~~
+
+Bokeh can also supply a block of JSON that can be easily consumed by a BokehJS
+to render standalone Bokeh content in a specifed div. The |json_item| function
+accepts a Bokeh Model (e.g. a Plot), and optionally a target ID that identifies
+a div to render into:
+
+.. code-block:: python
+
+        p = figure()
+        p.circle(x, y)
+
+        item_text = json.dumps(json_item(p, "myplot"))
+
+This output can be used by the ``Bokeh.embed.embed_item`` function on a webpage:
+
+.. code-block:: javascript
+
+    item = JSON.parse(item_text);
+    Bokeh.embed.embed_item(item);
+
+In this situation, the Bokeh plot will render itself into a div with the id
+*"myplot"*.
+
+It is also possible to omit the target id when calling |json_item|
+
+.. code-block:: python
+
+        p = figure()
+        p.circle(x, y)
+
+        item_text = json.dumps(json_item(p)) # no target_id given
+
+Then the target id can be controlled on teh JavaScript side:
+
+.. code-block:: javascript
+
+    item = JSON.parse(item_text);
+    Bokeh.embed.embed_item(item, "myplot");
+
+As a more complete example, it a Flask server may be configured to serve Bokeh
+JSON items from a */plot* endpoint:
+
+.. code-block:: python
+
+    @app.route('/plot')
+    def plot():
+        p = make_plot('petal_width', 'petal_length')
+        return json.dumps(json_item(p, "myplot"))
+
+Then the corresponding code on the page might look like:
+
+.. code-block:: html
+
+    <script>
+    fetch('/plot')
+        .then(function(response) { return response.json(); })
+        .then(function(item) { Bokeh.embed.embed_item(item); })
+    </script>
+
+A full example can be found a :bokeh-tree:`examples/embed/json_item.py`.
+
 .. _userguide_embed_standalone_components:
 
 Components
@@ -517,5 +582,6 @@ The full template, with all the sections that can be overridden, is given here:
 .. |autoload_static| replace:: :func:`~bokeh.embed.autoload_static`
 .. |components|      replace:: :func:`~bokeh.embed.components`
 .. |file_html|       replace:: :func:`~bokeh.embed.file_html`
+.. |json_item|       replace:: :func:`~bokeh.embed.json_item`
 .. |server_document| replace:: :func:`~bokeh.embed.server_document`
 .. |server_session|  replace:: :func:`~bokeh.embed.server_session`

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -76,8 +76,10 @@ def test_server_examples(server_example, example, report, bokeh_server):
     if example.is_skip:
         pytest.skip("skipping %s" % example.relpath)
 
+    os.environ['BOKEH_SIMPLE_IDS'] = 'no'
     app = build_single_handler_application(example.path)
     doc = app.create_document()
+    del os.environ['BOKEH_SIMPLE_IDS']
 
     # remove all next-tick, periodic, and timeout callbacks
     for session_callback in doc.session_callbacks:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -9,6 +9,8 @@ import signal
 
 from os.path import dirname, exists, split
 
+import six
+
 from bokeh.server.callbacks import NextTickCallback, PeriodicCallback, TimeoutCallback
 from bokeh._testing.util.images import image_diff
 from bokeh._testing.util.screenshot import get_screenshot
@@ -76,10 +78,12 @@ def test_server_examples(server_example, example, report, bokeh_server):
     if example.is_skip:
         pytest.skip("skipping %s" % example.relpath)
 
-    os.environ['BOKEH_SIMPLE_IDS'] = 'no'
+    # mitigate some weird interaction isolated to simple ids, py2.7,
+    # "push_session" server usage, and TravisCI
+    if six.PY2: os.environ['BOKEH_SIMPLE_IDS'] = 'no'
     app = build_single_handler_application(example.path)
     doc = app.create_document()
-    del os.environ['BOKEH_SIMPLE_IDS']
+    if six.PY2: del os.environ['BOKEH_SIMPLE_IDS']
 
     # remove all next-tick, periodic, and timeout callbacks
     for session_callback in doc.session_callbacks:


### PR DESCRIPTION
- [x] issues: fixes #5231
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

So far this PR adds the ability to make a simple JSON export of a Bokeh root model from Python and then embed it in JS using `Bokeh.embed.embed_item` (see example below). Notes:

* It is not yet possible to export JSON from a JS doc and also pass that to `embed_item`. It seems that `to_json` includes a lot of layout related attrs that are not present in the python export and this confuses re-constitution of the document. I think #8085 may solve this issue since layout is moved off of models there. 

* currently the target ID is specified in `json_item(p, "myplot")` and them embedded with `embed_item(item)` on the JS side. But maybe the converse is better for specifying the target? e.g `json_item(p)` on the export side with the target specified in JS `embed_item(item, "myplot")`

* currently can only export a single root this way, perhaps would be good to be able to embed multiple roots at once but open to not-doing that now as long as a reasonable pathway later is not precluded. 

This PR also switches to simple IDs by default. 