### PR TITLE
Using 'utf-8' codec to open python 3 scripts in bokeh app

### DIFF
--- a/bokeh/application/handlers/script.py
+++ b/bokeh/application/handlers/script.py
@@ -49,6 +49,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 
 # External imports
+import six
 
 # Bokeh imports
 from .code import CodeHandler
@@ -81,8 +82,12 @@ class ScriptHandler(CodeHandler):
             raise ValueError('Must pass a filename to ScriptHandler')
         filename = kwargs['filename']
 
-        with open(filename, 'r') as f:
-            kwargs['source'] = f.read()
+        if six.PY3:
+            with open(filename, 'r', encoding='utf-8') as f:
+                kwargs['source'] = f.read()
+        else:
+            with open(filename, 'r') as f:
+                kwargs['source'] = f.read()
 
         super(ScriptHandler, self).__init__(*args, **kwargs)
 

--- a/bokeh/application/handlers/script.py
+++ b/bokeh/application/handlers/script.py
@@ -88,6 +88,7 @@ class ScriptHandler(CodeHandler):
         # - default encoding used by Python 3 `open` statement
         #   is not 'utf-8' on Windows platform,
         # - Python 3 `open` ignores le `coding` comment line.
+        # See https://github.com/bokeh/bokeh/pull/8202 for details.
         if six.PY3:
             with open(filename, 'r', encoding='utf-8') as f:
                 kwargs['source'] = f.read()

--- a/bokeh/application/handlers/script.py
+++ b/bokeh/application/handlers/script.py
@@ -82,6 +82,12 @@ class ScriptHandler(CodeHandler):
             raise ValueError('Must pass a filename to ScriptHandler')
         filename = kwargs['filename']
 
+        # For Python 3, encoding must be set to utf-8 because:
+        # - when specifying an encoding in `io.open`, it doesn't
+        #   work with Python 2,
+        # - default encoding used by Python 3 `open` statement
+        #   is not 'utf-8' on Windows platform,
+        # - Python 3 `open` ignores le `coding` comment line.
         if six.PY3:
             with open(filename, 'r', encoding='utf-8') as f:
                 kwargs['source'] = f.read()


### PR DESCRIPTION
Using 'utf-8' codec to open python 3 scripts in bokeh app.

- [x] issues: fixes #682 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
