### PR TITLE
handle vline/hline hover in corner cases

### DIFF
--- a/bokehjs/src/lib/models/glyphs/line.ts
+++ b/bokehjs/src/lib/models/glyphs/line.ts
@@ -1,5 +1,5 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
-import {generic_line_legend} from "./utils"
+import {generic_line_legend, line_interpolation} from "./utils"
 import {PointGeometry, SpanGeometry} from "core/geometry"
 import {LineMixinVector} from "core/property_mixins"
 import {Arrayable} from "core/types"
@@ -113,26 +113,8 @@ export class LineView extends XYGlyphView {
   }
 
   get_interpolation_hit(i: number, geometry: PointGeometry | SpanGeometry): [number, number] {
-    const {sx, sy} = geometry
     const [x2, y2, x3, y3] = [this._x[i], this._y[i], this._x[i+1], this._y[i+1]]
-
-    let x0: number, x1: number
-    let y0: number, y1: number
-    if (geometry.type == 'point') {
-      ;[y0, y1] = this.renderer.yscale.r_invert(sy-1, sy+1)
-      ;[x0, x1] = this.renderer.xscale.r_invert(sx-1, sx+1)
-    } else {
-      if (geometry.direction == 'v') {
-        ;[y0, y1] = this.renderer.yscale.r_invert(sy, sy)
-        ;[x0, x1] = [x2, x3]
-      } else {
-        ;[x0, x1] = this.renderer.xscale.r_invert(sx, sx)
-        ;[y0, y1] = [y2, y3]
-      }
-    }
-
-    const {x, y} = hittest.check_2_segments_intersect(x0, y0, x1, y1, x2, y2, x3, y3)
-    return [x!, y!] // XXX: null is not handled at use sites
+    return line_interpolation(this.renderer, geometry, x2, y2, x3, y3)
   }
 
   draw_legend_for_index(ctx: Context2d, bbox: IBBox, index: number): void {

--- a/bokehjs/src/lib/models/glyphs/multi_line.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_line.ts
@@ -11,7 +11,7 @@ import {min, max} from "core/util/array"
 import {isStrictNaN} from "core/util/types"
 import {Context2d} from "core/util/canvas"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
-import {generic_line_legend} from "./utils"
+import {generic_line_legend, line_interpolation} from "./utils"
 import {Selection} from "../selections/selection"
 
 export interface MultiLineData extends GlyphData {
@@ -140,29 +140,8 @@ export class MultiLineView extends GlyphView {
   }
 
   get_interpolation_hit(i: number, point_i: number, geometry: PointGeometry | SpanGeometry): [number, number] {
-    const {sx, sy} = geometry
-    const x2 = this._xs[i][point_i]
-    const y2 = this._ys[i][point_i]
-    const x3 = this._xs[i][point_i+1]
-    const y3 = this._ys[i][point_i+1]
-
-    let x0: number, x1: number
-    let y0: number, y1: number
-    if (geometry.type == 'point') {
-      ;[y0, y1] = this.renderer.yscale.r_invert(sy-1, sy+1)
-      ;[x0, x1] = this.renderer.xscale.r_invert(sx-1, sx+1)
-    } else {
-      if (geometry.direction == 'v') {
-        ;[y0, y1] = this.renderer.yscale.r_invert(sy, sy)
-        ;[x0, x1] = [x2, x3]
-      } else {
-        ;[x0, x1] = this.renderer.xscale.r_invert(sx, sx)
-        ;[y0, y1] = [y2, y3]
-      }
-    }
-
-    const {x, y} = hittest.check_2_segments_intersect(x0, y0, x1, y1, x2, y2, x3, y3)
-    return [x!, y!] // XXX: null is not handled at use sites
+    const [x2, y2, x3, y3] = [this._xs[i][point_i], this._ys[i][point_i], this._xs[i][point_i+1], this._ys[i][point_i+1]]
+    return line_interpolation(this.renderer, geometry, x2, y2, x3, y3)
   }
 
   draw_legend_for_index(ctx: Context2d, bbox: IBBox, index: number): void {

--- a/bokehjs/src/lib/models/glyphs/utils.ts
+++ b/bokehjs/src/lib/models/glyphs/utils.ts
@@ -1,6 +1,9 @@
 import {Visuals, Line, Fill} from "core/visuals"
 import {Context2d} from "core/util/canvas"
 import {IBBox} from "core/util/bbox"
+import {PointGeometry, SpanGeometry} from "core/geometry"
+import * as hittest from "core/hittest"
+import {GlyphRendererView} from "../renderers/glyph_renderer"
 
 export function generic_line_legend(visuals: Visuals & {line: Line}, ctx: Context2d, {x0, x1, y0, y1}: IBBox, index: number): void {
   ctx.save()
@@ -37,4 +40,28 @@ export function generic_area_legend(visuals: {line: Line, fill: Fill}, ctx: Cont
     visuals.line.set_vectorize(ctx, index)
     ctx.stroke()
   }
+}
+
+export function line_interpolation(renderer: GlyphRendererView, geometry: PointGeometry | SpanGeometry, x2: number, y2: number, x3: number, y3: number): [number, number] {
+  const {sx, sy} = geometry
+  let x0: number, x1: number
+  let y0: number, y1: number
+
+  if (geometry.type == 'point') {
+    // The +/- adjustments here are to dilate the hit point into a virtual "segment" to use below
+    ;[y0, y1] = renderer.yscale.r_invert(sy-1, sy+1)
+    ;[x0, x1] = renderer.xscale.r_invert(sx-1, sx+1)
+  } else {
+    // The +/- adjustments here are to handle cases such as purely horizontal or vertical lines
+    if (geometry.direction == 'v') {
+      ;[y0, y1] = renderer.yscale.r_invert(sy, sy)
+      ;[x0, x1] = [Math.min(x2-1, x3-1), Math.max(x2+1, x3+1)]
+    } else {
+      ;[x0, x1] = renderer.xscale.r_invert(sx, sx)
+      ;[y0, y1] = [Math.min(y2-1, y3-1), Math.max(y2+1, y3+1)]
+    }
+  }
+
+  const {x, y} = hittest.check_2_segments_intersect(x0, y0, x1, y1, x2, y2, x3, y3)
+  return [x!, y!] // XXX: null is not handled at use sites
 }


### PR DESCRIPTION
- [x] issues: fixes #8198

ensures the vline/hline segments completely envelope the target line in the transverse direction (even if the line is vertical or horizontal)

<img width="595" alt="screen shot 2018-09-04 at 14 58 01" src="https://user-images.githubusercontent.com/1078448/45060073-4b7c1f80-b053-11e8-8d90-6a9b14f403c6.png">
