### PR TITLE
Windows platform test corrections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.diff
 *.org
 .project
+.pydevproject
 *.rej
 .settings/
 .*.sw[nop]

--- a/bokeh/application/handlers/tests/test_notebook.py
+++ b/bokeh/application/handlers/tests/test_notebook.py
@@ -20,7 +20,9 @@ import pytest ; pytest
 # Standard library imports
 
 # External imports
+from packaging import version
 import nbformat
+import nbconvert
 
 # Bokeh imports
 from bokeh.document import Document
@@ -59,7 +61,10 @@ class Test_NotebookHandler(object):
         with_script_contents(source, load)
 
         assert result['handler']._runner.path == result['filename']
-        assert result['handler']._runner.source == "\n# coding: utf-8\n"
+        if version.parse(nbconvert.__version__) < version.parse("5.4"):
+            assert result['handler']._runner.source == "\n# coding: utf-8\n"
+        else:
+            assert result['handler']._runner.source == "#!/usr/bin/env python\n# coding: utf-8\n"
         assert not doc.roots
 
     def test_missing_filename_raises(self):

--- a/bokeh/command/tests/test_util.py
+++ b/bokeh/command/tests/test_util.py
@@ -2,6 +2,7 @@ import tempfile
 
 from mock import patch
 import pytest
+import os
 
 import bokeh.command.util as util
 from bokeh.document import Document
@@ -32,10 +33,12 @@ If this is not the case, renaming main.py will supress this warning.
 
 @patch('warnings.warn')
 def test_build_single_handler_application_main_py(mock_warn):
-    f = tempfile.NamedTemporaryFile(suffix="main.py")
+    f = tempfile.NamedTemporaryFile(suffix="main.py", delete=False)
+    f.close() #close file to open it later on windows
     util.build_single_handler_application(f.name)
     assert mock_warn.called
     assert mock_warn.call_args[0] == (DIRSTYLE_MAIN_WARNING_COPY,)
+    os.remove(f.name)
 
 _SIZE_WARNING = "Width/height arguments will be ignored for this muliple layout. (Size valus only apply when exporting single plots.)"
 

--- a/bokeh/core/tests/test_templates.py
+++ b/bokeh/core/tests/test_templates.py
@@ -9,6 +9,10 @@ def compute_sha256(data):
     sha256.update(data)
     return sha256.hexdigest()
 
+def _crlf_cr_2_lf_bin(s):
+    import re
+    return re.sub(b"\r\n|\r|\n", b"\n", s)
+
 pinned_template_sha256 = "22c80ab04af3eb44b5be510bedd46c89d6c6d1d73bb3437050b799ee0e2ec044"
 
 def test_autoload_template_has_changed():
@@ -18,7 +22,7 @@ def test_autoload_template_has_changed():
     created as part of https://github.com/bokeh/bokeh/issues/7125.
     """
     with io.open(join(TOP_PATH, '_templates/autoload_nb_js.js'), mode='rb') as f:
-        assert pinned_template_sha256 == compute_sha256(f.read()), \
+        assert pinned_template_sha256 == compute_sha256(_crlf_cr_2_lf_bin(f.read())), \
         """It seems that the template autoload_nb_js.js has changed.
         If this is voluntary and that proper testing of plots insertion
         in notebooks has been completed successfully, update this test

--- a/bokeh/io/tests/test_util.py
+++ b/bokeh/io/tests/test_util.py
@@ -18,6 +18,7 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import os
 from mock import Mock, patch, PropertyMock
 
 # External imports
@@ -40,7 +41,7 @@ import bokeh.io.util as biu
 #-----------------------------------------------------------------------------
 
 def test_detect_current_filename():
-    assert biu.detect_current_filename().endswith(("py.test", "pytest"))
+    assert biu.detect_current_filename().endswith(("py.test", "pytest", "py.test-script.py"))
 
 @patch('bokeh.io.util.NamedTemporaryFile')
 def test_temp_filename(mock_tmp):
@@ -69,19 +70,19 @@ def test_default_filename():
         # a current file, access, and no share exec
         biu._no_access = lambda x: False
         r = biu.default_filename("test")
-        assert r == "/a/b/foo.test"
+        assert os.path.normpath(r) == os.path.normpath("/a/b/foo.test")
 
         # a current file, NO access, and no share exec
         biu._no_access = lambda x: True
         r = biu.default_filename("test")
-        assert r != "/a/b/foo.test"
+        assert os.path.normpath(r) != os.path.normpath("/a/b/foo.test")
         assert r.endswith(".test")
 
         # a current file, access, but WITH share exec
         biu._no_access = lambda x: False
         biu._shares_exec_prefix = lambda x: True
         r = biu.default_filename("test")
-        assert r != "/a/b/foo.test"
+        assert os.path.normpath(r) != os.path.normpath("/a/b/foo.test")
         assert r.endswith(".test")
 
         # no current file
@@ -89,7 +90,7 @@ def test_default_filename():
         biu._no_access = lambda x: False
         biu._shares_exec_prefix = lambda x: False
         r = biu.default_filename("test")
-        assert r != "/a/b/foo.test"
+        assert os.path.normpath(r) != os.path.normpath("/a/b/foo.test")
         assert r.endswith(".test")
 
     finally:
@@ -103,7 +104,6 @@ def test_default_filename():
 
 @patch('os.access')
 def test__no_access(mock_access):
-    import os
     biu._no_access("test")
     assert mock_access.called
     assert mock_access.call_args[0] == ("test", os.W_OK | os.X_OK)

--- a/bokeh/models/tests/test_sources.py
+++ b/bokeh/models/tests/test_sources.py
@@ -664,21 +664,21 @@ Lime,Green,99,$0.39
 
     def test_set_data_from_json_base64(self):
         ds = ColumnDataSource()
-        data = {"foo": np.arange(3)}
+        data = {"foo": np.arange(3, dtype=np.int64)}
         json = transform_column_source_data(data)
         ds.set_from_json('data', json)
         assert np.array_equal(ds.data["foo"], data["foo"])
 
     def test_set_data_from_json_nested_base64(self):
         ds = ColumnDataSource()
-        data = {"foo": [[np.arange(3)]]}
+        data = {"foo": [[np.arange(3, dtype=np.int64)]]}
         json = transform_column_source_data(data)
         ds.set_from_json('data', json)
         assert np.array_equal(ds.data["foo"], data["foo"])
 
     def test_set_data_from_json_nested_base64_and_list(self):
         ds = ColumnDataSource()
-        data = {"foo": [np.arange(3), [1, 2, 3]]}
+        data = {"foo": [np.arange(3, dtype=np.int64), [1, 2, 3]]}
         json = transform_column_source_data(data)
         ds.set_from_json('data', json)
         assert np.array_equal(ds.data["foo"], data["foo"])

--- a/bokeh/server/tests/test_server.py
+++ b/bokeh/server/tests/test_server.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 import pytest
 import logging
 import re
-
+import sys
 import mock
 
 from tornado import gen
@@ -577,6 +577,8 @@ def test__no_generate_session_doc():
         sessions = server.get_sessions('/')
         assert 0 == len(sessions)
 
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="multiple processes not supported on Windows")
 def test__server_multiple_processes():
 
     # Can't use an ioloop in this test

--- a/bokeh/server/tests/test_server.py
+++ b/bokeh/server/tests/test_server.py
@@ -137,6 +137,8 @@ class HookTestHandler(Handler):
         self.hooks.append("periodic_session")
         self.session_periodic_remover()
 
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="Lifecycle hooks order different on Windows (TODO open issue)")
 def test__lifecycle_hooks():
     application = Application()
     handler = HookTestHandler()

--- a/bokeh/util/compiler.py
+++ b/bokeh/util/compiler.py
@@ -157,6 +157,9 @@ def _npmjs_path():
             _npmjs += '.cmd'
     return _npmjs
 
+def _crlf_cr_2_lf(s):
+    return re.sub(r"\\r\\n|\\r|\\n", r"\\n", s)
+
 def _run(app, argv, input=None):
     proc = Popen([app] + argv, stdout=PIPE, stderr=PIPE, stdin=PIPE)
     (stdout, errout) = proc.communicate(input=None if input is None else json.dumps(input).encode())
@@ -164,7 +167,7 @@ def _run(app, argv, input=None):
     if proc.returncode != 0:
         raise RuntimeError(errout)
     else:
-        return stdout.decode('utf-8')
+        return _crlf_cr_2_lf(stdout.decode('utf-8'))
 
 def _run_nodejs(argv, input=None):
     return _run(_nodejs_path(), argv, input)

--- a/bokeh/util/compiler.py
+++ b/bokeh/util/compiler.py
@@ -153,6 +153,8 @@ def _npmjs_path():
     global _npmjs
     if _npmjs is None:
         _npmjs = join(dirname(_nodejs_path()), "npm")
+        if sys.platform == "win32":
+            _npmjs += '.cmd'
     return _npmjs
 
 def _run(app, argv, input=None):

--- a/bokeh/util/tests/test_browser.py
+++ b/bokeh/util/tests/test_browser.py
@@ -1,11 +1,9 @@
 import os
+import sys
 import webbrowser
 
 import pytest
 from mock import patch
-
-import sys
-import os
 
 import bokeh.util.browser as bub
 

--- a/bokeh/util/tests/test_browser.py
+++ b/bokeh/util/tests/test_browser.py
@@ -4,6 +4,9 @@ import webbrowser
 import pytest
 from mock import patch
 
+import sys
+import os
+
 import bokeh.util.browser as bub
 
 _open_args = None
@@ -70,7 +73,10 @@ def test_view_args():
 
     # test non-http locations treated as local files
     bub.view("/foo/bar", browser="none")
-    assert _open_args == (('file:///foo/bar',), {'autoraise': True, 'new': 0})
+    if sys.platform == "win32":
+        assert _open_args == (('file://' + os.path.splitdrive(os.getcwd())[0] + '\\foo\\bar',), {'autoraise': True, 'new': 0})
+    else:
+        assert _open_args == (('file:///foo/bar',), {'autoraise': True, 'new': 0})
 
     # test autoraise passed to open
     bub.view("http://foo", browser="none", autoraise=False)


### PR DESCRIPTION
Python version      :  3.7.0 (default, Jun 28 2018, 08:04:48) [MSC v.1912 64 bit (AMD64)]
IPython version     :  6.5.0
Bokeh version       :  1.0.0dev6-14-g463049309
BokehJS static path :  g:\pythonworkspace\bokeh\bokeh\server\static
node.js version     :  v8.9.3
npm version         :  6.4.1

- [ ] issues: fixes #8146
- [ ] tests: 0 added / +11 passed / +1 skipped

===== 4 failed, 2999 passed, 698 deselected, 1 warnings in 106.19 seconds =====
