### PR TITLE
Added unit/integration tests for python3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,19 @@ jobs:
       script: scripts/ci/test
       env:
       - GROUP=integration
+      - PYTHON=3.7
+
+    - install: scripts/ci/install.test
+      script: scripts/ci/test
+      env:
+      - GROUP=integration
       - PYTHON=3.6
+
+    - install: scripts/ci/install.test
+      script: scripts/ci/test
+      env:
+      - GROUP=unit
+      - PYTHON=3.7
 
     - install: scripts/ci/install.test
       script: scripts/ci/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,12 +75,6 @@ jobs:
       script: scripts/ci/test
       env:
       - GROUP=integration
-      - PYTHON=3.7
-
-    - install: scripts/ci/install.test
-      script: scripts/ci/test
-      env:
-      - GROUP=integration
       - PYTHON=3.6
 
     - install: scripts/ci/install.test


### PR DESCRIPTION
See title. Not sure if python3.7 support is premature at this point, but I found some functions failing that worked in python3.6, so this is the first step in testing compatibility.