### PR TITLE
support specifying representative point from legend items

### DIFF
--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -81,6 +81,18 @@ class LegendItem(Model):
     then all data_sources of renderers must be the same.
     """)
 
+    index = Int(default=None, help="""
+    The column data index to use for drawing the representative items.
+
+    If None (the default), then Bokeh will automatically choose an index to
+    use. If the label does not refer to a data column name, this is typically
+    the first data point in the data source. Otherwise, if the label does
+    refer to a column name, the legend will have "groupby" behavior, and will
+    choose and display representative points from every "group" in the column.
+
+    If set to a number, Bokeh will use that numbner as the index in all cases.
+    """)
+
     @error(NON_MATCHING_DATA_SOURCES_ON_LEGEND_ITEM_RENDERERS)
     def _check_data_sources_on_renderers(self):
         if self.label and 'field' in self.label:

--- a/bokehjs/src/lib/models/annotations/legend.ts
+++ b/bokehjs/src/lib/models/annotations/legend.ts
@@ -258,7 +258,7 @@ export class LegendView extends AnnotationView {
         ctx.fillText(label, x2 + label_standoff, y1 + this.max_label_height/2.0)
         for (const r of item.renderers) {
           const view = this.plot_view.renderer_views[r.id] as GlyphRendererView
-          view.draw_legend(ctx, x1, x2, y1, y2, field, label)
+          view.draw_legend(ctx, x1, x2, y1, y2, field, label, item.index)
         }
 
         if (!active) {

--- a/bokehjs/src/lib/models/annotations/legend_item.ts
+++ b/bokehjs/src/lib/models/annotations/legend_item.ts
@@ -10,6 +10,7 @@ export namespace LegendItem {
   export interface Attrs extends Model.Attrs {
     label: StringSpec | null
     renderers: GlyphRenderer[]
+    index: number | null
   }
 
   export interface Props extends Model.Props {}
@@ -31,6 +32,7 @@ export class LegendItem extends Model {
     this.define({
       label:     [ p.StringSpec, null ],
       renderers: [ p.Array,      []   ],
+      index:     [ p.Number,     null ],
     })
   }
 

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -345,8 +345,9 @@ export class GlyphRendererView extends RendererView {
     return ctx.restore()
   }
 
-  draw_legend(ctx: Context2d, x0: number, x1: number, y0: number, y1: number, field: string | null, label: string): void {
-    const index = this.model.get_reference_point(field, label)
+  draw_legend(ctx: Context2d, x0: number, x1: number, y0: number, y1: number, field: string | null, label: string, index: number | null): void {
+    if (index == null)
+      index = this.model.get_reference_point(field, label)
     this.glyph.draw_legend_for_index(ctx, {x0, x1, y0, y1}, index)
   }
 

--- a/examples/plotting/file/multi_legend.py
+++ b/examples/plotting/file/multi_legend.py
@@ -1,0 +1,16 @@
+from bokeh.plotting import figure, output_file, show
+from bokeh.models import Legend, LegendItem
+
+p = figure()
+r = p.multi_line([[1,2,3], [1,2,3]], [[1,3,2], [3,4,3]],
+                 color=["orange", "red"], line_width=4)
+
+legend = Legend(items=[
+    LegendItem(label="orange", renderers=[r], index=0),
+    LegendItem(label="red", renderers=[r], index=1),
+])
+p.add_layout(legend)
+
+output_file("multi_legend.html")
+
+show(p)

--- a/sphinx/source/docs/user_guide/annotations.rst
+++ b/sphinx/source/docs/user_guide/annotations.rst
@@ -9,7 +9,7 @@ supplemental information to their visualizations.
 .. _userguide_plotting_titles:
 
 Titles
-~~~~~~
+------
 
 |Title| annotations allow descriptive text to be rendered around the edges
 of a plot.
@@ -60,7 +60,7 @@ visually overlap in way that is not desirable.
 .. _userguide_plotting_legends:
 
 Legends
-~~~~~~~
+-------
 
 It is possible to create |Legend| annotations easily by specifying a legend
 argument to the glyph methods, when creating a plot.
@@ -71,6 +71,9 @@ argument to the glyph methods, when creating a plot.
 
 .. bokeh-plot:: docs/user_guide/examples/plotting_legends.py
     :source-position: above
+
+Automatic Grouping
+~~~~~~~~~~~~~~~~~~
 
 It is also possible to create multiple legend items for the same glyph when
 if needed by passing a legend that is the column of the column data source.
@@ -85,6 +88,21 @@ example. Alternatively, you can not specify any legend argument, and manually
 build a :class:`~bokeh.models.annotations.Legend` by hand. You can see an
 example of this in :bokeh-tree:`examples/models/file/legends.py`:
 
+Explicit Index
+~~~~~~~~~~~~~~
+
+Other times, it may be useful to expicitly tell Bokeh which index into a
+ColumnDataSource should be used when drawing a legend item. In particuar,
+if you want to draw multiple legend items for "multi" glyphs such as
+``MultiLine`` or ``Patches``. This is accomplished by specifying an ``index``
+for the legend item as shown below.
+
+.. bokeh-plot:: docs/user_guide/examples/plotting_legends_multi_index.py
+    :source-position: above
+
+Interactive Legends
+~~~~~~~~~~~~~~~~~~~
+
 It's also possible to configure legends to be interactive, so that clicking
 or tapping on legend entries affects the corresponding glyph visibility. See
 the :ref:`userguide_interaction_legends` section of the User's Guide for more
@@ -98,7 +116,7 @@ information and examples.
 .. _userguide_plotting_color_bars:
 
 Color Bars
-~~~~~~~~~~
+----------
 
 A |ColorBar| can be created using a |ColorMapper| instance, which
 contains a color palette. Both on- and off-plot color bars are
@@ -115,7 +133,7 @@ supported; the desired location can be specified when adding the
 .. _userguide_plotting_arrows:
 
 Arrows
-~~~~~~
+------
 
 |Arrow| annotations can be used to connect glyphs and label annotations or
 to simply highlight plot regions. Arrows are compound annotations, meaning
@@ -149,7 +167,7 @@ and the fill properties control the interior of the arrow head (if applicable).
 .. _userguide_plotting_bands:
 
 Bands
-~~~~~
+-----
 
 A |Band| will create a dimensionally-linked "stripe", either located in data
 or screen coordinates. One common use for the Band annotation is to indicate
@@ -161,7 +179,7 @@ uncertainty related to a series of measurements.
 .. _userguide_plotting_box_annotations:
 
 Box Annotations
-~~~~~~~~~~~~~~~
+---------------
 
 A |BoxAnnotation| can be linked to either data or screen coordinates in order
 to emphasize specific plot regions. By default, box annotation dimensions (e.g.
@@ -174,7 +192,7 @@ plot area.
 .. _userguide_plotting_labels:
 
 Labels
-~~~~~~
+------
 
 Labels are text elements that can be used to annotate either glyphs or plot
 regions.
@@ -215,7 +233,7 @@ The following example illustrates the use of both:
 .. _userguide_plotting_slope:
 
 Slopes
-~~~~~~
+------
 
 |Slope| annotations are lines which may be sloped and extend to the
 edge of the plot area.
@@ -226,7 +244,7 @@ edge of the plot area.
 .. _userguide_plotting_spans:
 
 Spans
-~~~~~
+-----
 
 |Span| annotations are lines that have a single dimension (width or height)
 and extend to the edge of the plot area.
@@ -237,7 +255,7 @@ and extend to the edge of the plot area.
 .. _userguide_plotting_whiskers:
 
 Whiskers
-~~~~~~~~
+--------
 
 A |Whisker| will create a dimensionally-linked "stem", either located in data
 or screen coordinates. Indicating error or uncertainty for measurements at a

--- a/sphinx/source/docs/user_guide/examples/plotting_legends_multi_index.py
+++ b/sphinx/source/docs/user_guide/examples/plotting_legends_multi_index.py
@@ -1,0 +1,14 @@
+from bokeh.plotting import figure, show
+from bokeh.models import Legend, LegendItem
+
+p = figure()
+r = p.multi_line([[1,2,3], [1,2,3]], [[1,3,2], [3,4,3]],
+                 color=["orange", "red"], line_width=4)
+
+legend = Legend(items=[
+    LegendItem(label="orange", renderers=[r], index=0),
+    LegendItem(label="red", renderers=[r], index=1),
+])
+p.add_layout(legend)
+
+show(p)


### PR DESCRIPTION
- [x] release document entry (if new feature or API change)

This was raised on Gitter and falls under the category of low hanging but valuable fruit. This PR allows users to specify an explicit `index` on legend items, so that e.g. annotating each line in a multi_line is possible. With a little more follow-on work, #2603 would be within reach. Later work might also add a convenience API to `multi_line` and `patches` to make creating the legend items less manual. 

Unfortunately I can't think of a good direct test for this with the current view architecture, but I have added an expample that will show up under image diff tests. 

```
from bokeh.plotting import figure, output_file, show
from bokeh.models import Legend, LegendItem

p = figure()
r = p.multi_line([[1,2,3], [1,2,3]], [[1,3,2], [3,4,3]],
                 color=["orange", "red"], line_width=4)

legend = Legend(items=[
    LegendItem(label="orange", renderers=[r], index=0),
    LegendItem(label="red", renderers=[r], index=1),
])
p.add_layout(legend)

output_file("multi_legend.html")

show(p)
```

<img width="523" alt="screen shot 2018-09-06 at 11 41 10" src="https://user-images.githubusercontent.com/1078448/45178136-c8310a00-b1c9-11e8-8548-255c4c5cab2a.png">
