### PR TITLE
don't report unversioned python in deps.py output

### DIFF
--- a/scripts/deps.py
+++ b/scripts/deps.py
@@ -27,6 +27,9 @@ spec = []
 for name in sys.argv[1:]:
     spec += section[name]
 
+# bare python unpins python version causing upgrade to latest
+if 'python' in spec: spec.remove('python')
+
 deps = ""
 deps += " ".join(s for s in spec)
 deps = deps.replace(' >=', '>=')  # conda syntax doesn't allow spaces b/w pkg name and version spec


### PR DESCRIPTION
Build is currently failing due to an apparent python 3.7 issue, which has uncovered that the current method of installation will always use the most recent python, instead of what is explicitly specified and intended. 

The issue is having an unversioned "python" in the conda install line:

<img width="730" alt="screen shot 2018-09-06 at 14 05 33" src="https://user-images.githubusercontent.com/1078448/45185117-fb7d9400-b1dd-11e8-8b7d-1c6811caee87.png">

This PR addresses that by removing "python" if it is present (it has to remain in the recipe, so our only option is to filter it out)