### PR TITLE
remove dead testing code

### DIFF
--- a/bokeh/_testing/plugins/log_file.py
+++ b/bokeh/_testing/plugins/log_file.py
@@ -38,11 +38,9 @@ import pytest
 
 @pytest.yield_fixture(scope="session")
 def log_file(request):
-    is_slave = hasattr(request.config, 'slaveinput')
-    if not is_slave:
-        with open(request.config.option.log_file, 'w') as f:
-            # Clean-out any existing log-file
-            f.write("")
+    with open(request.config.option.log_file, 'w') as f:
+        # Clean-out any existing log-file
+        f.write("")
     with open(pytest.config.option.log_file, 'a') as f:
         yield f
 


### PR DESCRIPTION
This PR initially set about to ensure we used humane naming throughout, but as it turns out the small amount of relevant code is actually no longer needed at all and can just be removed altogether. 
