### PR TITLE
use np.frombuffer instead of deprecated np.fromstring

### DIFF
--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -513,7 +513,7 @@ def decode_base64_dict(data):
 
     '''
     b64 = base64.b64decode(data['__ndarray__'])
-    array = np.fromstring(b64, dtype=data['dtype'])
+    array = np.frombuffer(b64, dtype=data['dtype'])
     if len(data['shape']) > 1:
         array = array.reshape(data['shape'])
     return array

--- a/bokeh/util/tests/test_serialization.py
+++ b/bokeh/util/tests/test_serialization.py
@@ -331,7 +331,7 @@ def test_encode_base64_dict(dt, shape):
 
     assert '__ndarray__' in d
     b64 = base64.b64decode(d['__ndarray__'])
-    aa = np.fromstring(b64, dtype=d['dtype'])
+    aa = np.frombuffer(b64, dtype=d['dtype'])
     assert np.array_equal(a, aa)
 
 @pytest.mark.parametrize('dt', [np.float32, np.float64, np.int64])


### PR DESCRIPTION
Not sure why this:

> C:\projects\bokeh\bokeh\util\serialization.py:516: DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead
1911  array = np.fromstring(b64, dtype=data['dtype'])

is only showing up on tentative windows builds on Appveyor (see #8213) but might as well fix it up now. `np.frombuffer` appears in the NumPy 1.7.x docs:

https://docs.scipy.org/doc/numpy-1.7.0/reference/generated/numpy.frombuffer.html

so there should be no need to change our `REQUIRES`