### PR TITLE
Bryanv/8232 frombuffer writeonly

### DIFF
--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -513,7 +513,7 @@ def decode_base64_dict(data):
 
     '''
     b64 = base64.b64decode(data['__ndarray__'])
-    array = np.frombuffer(b64, dtype=data['dtype'])
+    array = np.copy(np.frombuffer(b64, dtype=data['dtype']))
     if len(data['shape']) > 1:
         array = array.reshape(data['shape'])
     return array

--- a/bokeh/util/tests/test_serialization.py
+++ b/bokeh/util/tests/test_serialization.py
@@ -354,6 +354,8 @@ def test_decode_base64_dict(dt, shape):
 
     assert np.array_equal(a, aa)
 
+    assert aa.flags['WRITEABLE']
+
 @pytest.mark.parametrize('dt', [np.float32, np.float64, np.int64])
 @pytest.mark.parametrize('shape', [(12,), (2, 6), (2,2,3)])
 @pytest.mark.unit


### PR DESCRIPTION
Issue was change from `np.fromstring` to `np.frombuffer` The latter creates a non-writeable view which does not work with `patch`. Since `fromstring` was previously making a new array, the simple solution of adding an `np.copy` call should have similar performance. It's possible in the future we could defer copying until/unless it is needed (COW)

This also fixes an issue where exceptions in python 3 Bokeh apps were not printing tracebacks correctly. 

- [x] issues: fixes #8232
- [x] tests added / passed
