### PR TITLE
add clear method to CDS

### DIFF
--- a/bokehjs/src/lib/api/plotting.ts
+++ b/bokehjs/src/lib/api/plotting.ts
@@ -501,8 +501,8 @@ export class Figure extends Plot {
     if (legend != null) {
       if (isString(legend)) {
         legend_item_label = { value: legend }
-        if ((source != null) && (source.column_names != null)) {
-          if (includes(source.column_names, legend)) {
+        if ((source != null) && (source.columns() != null)) {
+          if (includes(source.columns(), legend)) {
             legend_item_label = { field: legend }
           }
         }

--- a/bokehjs/src/lib/core/util/serialization.ts
+++ b/bokehjs/src/lib/core/util/serialization.ts
@@ -128,7 +128,7 @@ export function process_array(obj: NDArray | BufferSpec | Arrayable, buffers: [a
     return decode_base64(obj)
   else if (isObject(obj) && '__buffer__' in obj)
     return process_buffer(obj, buffers)
-  else if (isArray(obj))
+  else if (isArray(obj) || isTypedArray(obj))
     return [obj, []]
   else
     return undefined as never

--- a/bokehjs/src/lib/models/sources/columnar_data_source.ts
+++ b/bokehjs/src/lib/models/sources/columnar_data_source.ts
@@ -35,10 +35,6 @@ export abstract class ColumnarDataSource extends DataSource {
 
   data: {[key: string]: Arrayable}
 
-  get column_names(): string[] {
-    return keys(this.data)
-  }
-
   get_array<T>(key: string): T[] {
     let column = this.data[key]
 
@@ -119,6 +115,14 @@ export abstract class ColumnarDataSource extends DataSource {
     const length = this.get_length()
     return range(0, length != null ? length : 1)
     //TODO: returns [0] when no data, should it?
+  }
+
+  clear(): void {
+    const empty: {[key: string]: Arrayable} = {}
+    for (const col of this.columns()) {
+      empty[col] = new (<any>this.data[col].constructor)
+    }
+    this.data = empty
   }
 }
 ColumnarDataSource.initClass()

--- a/bokehjs/test/core/util/serialization.ts
+++ b/bokehjs/test/core/util/serialization.ts
@@ -251,4 +251,18 @@ describe("serialization module", () => {
       })
     }
   })
+
+  describe("process_array", () => {
+    it("should return arrays as-is", () => {
+      const arr = [1, 2, 3.4]
+      expect(ser.process_array(arr, [])).to.be.deep.equal([ arr, [] ])
+    })
+
+    it("should return typed arrays as-is", () => {
+      for (const typ of GOOD_TYPES) {
+        const arr = new typ([1, 2, 3.4])
+        expect(ser.process_array(arr, [])).to.be.deep.equal([ arr, [] ])
+      }
+    })
+  })
 })

--- a/bokehjs/test/models/sources/column_data_source.coffee
+++ b/bokehjs/test/models/sources/column_data_source.coffee
@@ -4,6 +4,7 @@
 {Set} = require("core/util/data_structures")
 {set_log_level} = require "core/logging"
 
+{keys} = require("core/util/object")
 {ColumnDataSource, stream_to_column, slice, patch_to_column} = require("models/sources/column_data_source")
 
 describe "column_data_source module", ->
@@ -521,3 +522,35 @@ describe "column_data_source module", ->
       r = new ColumnDataSource({data: {foo: [1], bar: [1,2], baz: [1]}})
       out = stderrTrap -> r.get_length()
       expect(out).to.be.equal "[bokeh] data source has columns of inconsistent lengths\n"
+
+  describe "columns method", ->
+
+    it "should report .data.keys", ->
+      r = new ColumnDataSource({data: {foo: [10, 20], bar:[10, 20]}})
+      expect(r.columns()).to.be.deep.equal keys(r.data)
+
+    it "should update if columns update", ->
+      r = new ColumnDataSource({data: {foo: [10, 20], bar:[10, 20]}})
+      r.data.baz = [11, 21]
+      expect(r.columns()).to.be.deep.equal keys(r.data)
+
+  describe "clear method", ->
+
+    it "should clear plain arrys to plain arrays", ->
+      r = new ColumnDataSource({data: {foo: [10, 20], bar:[10, 20]}})
+      r.clear()
+      expect(r.data).to.be.deep.equal {foo: [], bar:[]}
+
+    it "should clear typed arrays to typed arrays", ->
+      for typ in [Float32Array, Float64Array, Int32Array]
+        r = new ColumnDataSource({data: {foo: [10, 20], bar: new typ([1,2])}})
+        r.clear()
+        expect(r.data).to.be.deep.equal {foo: [], bar: new typ([])}
+
+    it "should clear columns added later", ->
+      for typ in [Float32Array, Float64Array, Int32Array]
+        r = new ColumnDataSource({data: {foo: [10, 20]}})
+        r.data.bar = [100, 200]
+        r.data.baz = new typ([1,2])
+        r.clear()
+        expect(r.data).to.be.deep.equal {foo: [], bar: [], baz: new typ([])}


### PR DESCRIPTION
This PR adds a `clear` method to BokehJS CDS. Additionally:

* removes duplicative `column_names` property (use `columns()` consistently)
* fixes a bug preventing direct init of CDS from typed arrays

- [x] issues: fixes #7990
- [x] tests added / passed
