### PR TITLE
project coords for segment glyphs on gmaps

### DIFF
--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -218,12 +218,20 @@ export abstract class GlyphView extends View {
     const self = this as any
     extend(self, data)
 
+    // TODO (bev) Should really probably delegate computing projected
+    // coordinates to glyphs, instead of centralizing here in one place.
     if (this.renderer.plot_view.model.use_map) {
       if (self._x != null)
         [self._x, self._y] = proj.project_xy(self._x, self._y)
 
       if (self._xs != null)
         [self._xs, self._ys] = proj.project_xsys(self._xs, self._ys)
+
+      if (self._x0 != null)
+        [self._x0, self._y0] = proj.project_xy(self._x0, self._y0)
+
+      if (self._x1 != null)
+        [self._x1, self._y1] = proj.project_xy(self._x1, self._y1)
     }
 
     // if we have any coordinates that are categorical, convert them to


### PR DESCRIPTION
- [x] issues: fixes #7974 

Test code:
```
from bokeh.io import show
from bokeh.models import GMapOptions, ColumnDataSource
from bokeh.plotting import figure, gmap

map_options = GMapOptions(lat=37.76, lng=-121.9, map_type="roadmap", zoom=11)
plot = gmap(google_api_key="AIzaSyAM1OHVm6Yr_i54Kt01mylfxyNxQdxmxHQ", map_options=map_options)

source = ColumnDataSource( data = dict(
    y=[ 37.762260 ],
    x=[-121.96226],
    ym01=[37.762290 ],
    xm01=[-121.86189 ],
))

plot.segment(x0="x", y0="y", x1="xm01", y1="ym01",line_color="green", line_width=2, source=source)
plot.circle(x=[-121.96226, -121.86189], y=[37.762260, 37.762290], size=8)

show(plot)
```

Result:

<img width="604" alt="screen shot 2018-09-12 at 13 15 27" src="https://user-images.githubusercontent.com/1078448/45451385-c4046100-b68f-11e8-8531-e19016450117.png">
