### PR TITLE
Add DocumentLifeCycleHandler and Document.on_session_destroyed

### DIFF
--- a/bokeh/application/handlers/document_lifecycle.py
+++ b/bokeh/application/handlers/document_lifecycle.py
@@ -15,9 +15,6 @@ on the Document.
 #-----------------------------------------------------------------------------
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import logging
-log = logging.getLogger(__name__)
-
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
@@ -42,11 +39,13 @@ class DocumentLifeCycleHandler(Handler):
 
     '''
 
+    safe_to_fork = True
+
     # Public methods ----------------------------------------------------------
 
     def modify_document(self, doc):
         pass
-    
+
     def on_session_destroyed(self, session_context):
         '''
         Calls any on_session_destroyed callbacks defined on the Document

--- a/bokeh/application/handlers/document_lifecycle.py
+++ b/bokeh/application/handlers/document_lifecycle.py
@@ -1,0 +1,68 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2017, Anaconda, Inc. All rights reserved.
+#
+# Powered by the Bokeh Development Team.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+''' Bokeh Application Handler to execute on_session_destroyed callbacks defined
+on the Document.
+
+'''
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+log = logging.getLogger(__name__)
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+
+# External imports
+
+# Bokeh imports
+from .handler import Handler
+
+#-----------------------------------------------------------------------------
+# Globals and constants
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+class DocumentLifeCycleHandler(Handler):
+    ''' Calls on_session_destroyed callbacks defined on the Document.
+
+    '''
+
+    # Public methods ----------------------------------------------------------
+
+    def modify_document(self, doc):
+        pass
+    
+    def on_session_destroyed(self, session_context):
+        '''
+        Calls any on_session_destroyed callbacks defined on the Document
+        '''
+        doc = session_context._document
+        for callback in doc._session_destroyed_callbacks:
+            callback(doc)
+
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------

--- a/bokeh/application/handlers/document_lifecycle.py
+++ b/bokeh/application/handlers/document_lifecycle.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-# Copyright (c) 2012 - 2017, Anaconda, Inc. All rights reserved.
+# Copyright (c) 2012 - 2018, Anaconda, Inc. All rights reserved.
 #
 # Powered by the Bokeh Development Team.
 #
@@ -15,6 +15,9 @@ on the Document.
 #-----------------------------------------------------------------------------
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import logging
+log = logging.getLogger(__name__)
+
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
@@ -24,7 +27,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 # External imports
 
 # Bokeh imports
-from .handler import Handler
+from .lifecycle import LifecycleHandler
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -34,25 +37,14 @@ from .handler import Handler
 # General API
 #-----------------------------------------------------------------------------
 
-class DocumentLifeCycleHandler(Handler):
+class DocumentLifecycleHandler(LifecycleHandler):
     ''' Calls on_session_destroyed callbacks defined on the Document.
 
     '''
 
-    safe_to_fork = True
-
-    # Public methods ----------------------------------------------------------
-
-    def modify_document(self, doc):
-        pass
-
-    def on_session_destroyed(self, session_context):
-        '''
-        Calls any on_session_destroyed callbacks defined on the Document
-        '''
-        doc = session_context._document
-        for callback in doc._session_destroyed_callbacks:
-            callback(doc)
+    def __init__(self, *args, **kwargs):
+        super(DocumentLifecycleHandler, self).__init__(*args, **kwargs)
+        self._on_session_destroyed = _on_session_destroyed
 
 #-----------------------------------------------------------------------------
 # Dev API
@@ -61,6 +53,13 @@ class DocumentLifeCycleHandler(Handler):
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------
+
+def _on_session_destroyed(session_context):
+    '''
+    Calls any on_session_destroyed callbacks defined on the Document
+    '''
+    for callback in session_context._document._session_destroyed_callbacks:
+        callback(session_context)
 
 #-----------------------------------------------------------------------------
 # Code

--- a/bokeh/application/handlers/lifecycle.py
+++ b/bokeh/application/handlers/lifecycle.py
@@ -23,14 +23,10 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-import codecs
-import os
 
 # External imports
 
 # Bokeh imports
-from ...util.callback_manager import _check_callback
-from .code_runner import CodeRunner
 from .handler import Handler
 
 #-----------------------------------------------------------------------------

--- a/bokeh/application/handlers/lifecycle.py
+++ b/bokeh/application/handlers/lifecycle.py
@@ -1,0 +1,134 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2018, Anaconda, Inc. All rights reserved.
+#
+# Powered by the Bokeh Development Team.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+''' Bokeh Application Handler to look for Bokeh server lifecycle callbacks
+in a specified Python module.
+
+'''
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+log = logging.getLogger(__name__)
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+import codecs
+import os
+
+# External imports
+
+# Bokeh imports
+from ...util.callback_manager import _check_callback
+from .code_runner import CodeRunner
+from .handler import Handler
+
+#-----------------------------------------------------------------------------
+# Globals and constants
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+class LifecycleHandler(Handler):
+    ''' Load a script which contains server lifecycle callbacks.
+
+    '''
+
+    def __init__(self, *args, **kwargs):
+        super(LifecycleHandler, self).__init__(*args, **kwargs)
+        self._on_server_loaded = _do_nothing
+        self._on_server_unloaded = _do_nothing
+        self._on_session_created = _do_nothing
+        self._on_session_destroyed = _do_nothing
+        self.safe_to_fork = True
+
+    # Properties --------------------------------------------------------------
+
+    # Public methods ----------------------------------------------------------
+
+    def modify_document(self, doc):
+        ''' This handler does not make any modifications to the Document.
+
+        Args:
+            doc (Document) : A Bokeh Document to update in-place
+
+                *This handler does not modify the document*
+
+        Returns:
+            None
+
+        '''
+        # we could support a modify_document function, might be weird though.
+        pass
+
+    def on_server_loaded(self, server_context):
+        ''' Execute `on_server_unloaded`` from the configured module (if
+        it is defined) when the server is first started.
+
+        Args:
+            server_context (ServerContext) :
+
+        '''
+        return self._on_server_loaded(server_context)
+
+    def on_server_unloaded(self, server_context):
+        ''' Execute ``on_server_unloaded`` from the configured module (if
+        it is defined) when the server cleanly exits. (Before stopping the
+        server's ``IOLoop``.)
+
+        Args:
+            server_context (ServerContext) :
+
+        .. warning::
+            In practice this code may not run, since servers are often killed
+            by a signal.
+
+        '''
+        return self._on_server_unloaded(server_context)
+
+    def on_session_created(self, session_context):
+        ''' Execute ``on_session_created`` from the configured module (if
+        it is defined) when a new session is created.
+
+        Args:
+            session_context (SessionContext) :
+
+        '''
+        return self._on_session_created(session_context)
+
+    def on_session_destroyed(self, session_context):
+        ''' Execute ``on_session_destroyed`` from the configured module (if
+        it is defined) when a new session is destroyed.
+
+        Args:
+            session_context (SessionContext) :
+
+        '''
+        return self._on_session_destroyed(session_context)
+
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+def _do_nothing(ignored):
+    pass
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------

--- a/bokeh/application/handlers/server_lifecycle.py
+++ b/bokeh/application/handlers/server_lifecycle.py
@@ -31,7 +31,7 @@ import os
 # Bokeh imports
 from ...util.callback_manager import _check_callback
 from .code_runner import CodeRunner
-from .handler import Handler
+from .lifecycle import LifecycleHandler
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -41,7 +41,7 @@ from .handler import Handler
 # General API
 #-----------------------------------------------------------------------------
 
-class ServerLifecycleHandler(Handler):
+class ServerLifecycleHandler(LifecycleHandler):
     ''' Load a script which contains server lifecycle callbacks.
 
     '''
@@ -66,11 +66,6 @@ class ServerLifecycleHandler(Handler):
         source = codecs.open(filename, 'r', 'UTF-8').read()
 
         self._runner = CodeRunner(source, filename, argv)
-
-        self._on_server_loaded = _do_nothing
-        self._on_server_unloaded = _do_nothing
-        self._on_session_created = _do_nothing
-        self._on_session_destroyed = _do_nothing
 
         if not self._runner.failed:
             # unlike ScriptHandler, we only load the module one time
@@ -119,66 +114,6 @@ class ServerLifecycleHandler(Handler):
 
     # Public methods ----------------------------------------------------------
 
-    def modify_document(self, doc):
-        ''' This handler does not make any modifications to the Document.
-
-        Args:
-            doc (Document) : A Bokeh Document to update in-place
-
-                *This handler does not modify the document*
-
-        Returns:
-            None
-
-        '''
-        # we could support a modify_document function, might be weird though.
-        pass
-
-    def on_server_loaded(self, server_context):
-        ''' Execute `on_server_unloaded`` from the configured module (if
-        it is defined) when the server is first started.
-
-        Args:
-            server_context (ServerContext) :
-
-        '''
-        return self._on_server_loaded(server_context)
-
-    def on_server_unloaded(self, server_context):
-        ''' Execute ``on_server_unloaded`` from the configured module (if
-        it is defined) when the server cleanly exits. (Before stopping the
-        server's ``IOLoop``.)
-
-        Args:
-            server_context (ServerContext) :
-
-        .. warning::
-            In practice this code may not run, since servers are often killed
-            by a signal.
-
-        '''
-        return self._on_server_unloaded(server_context)
-
-    def on_session_created(self, session_context):
-        ''' Execute ``on_session_created`` from the configured module (if
-        it is defined) when a new session is created.
-
-        Args:
-            session_context (SessionContext) :
-
-        '''
-        return self._on_session_created(session_context)
-
-    def on_session_destroyed(self, session_context):
-        ''' Execute ``on_session_destroyed`` from the configured module (if
-        it is defined) when a new session is destroyed.
-
-        Args:
-            session_context (SessionContext) :
-
-        '''
-        return self._on_session_destroyed(session_context)
-
     def url_path(self):
         ''' The last path component for the basename of the path to the
         callback module.
@@ -197,9 +132,6 @@ class ServerLifecycleHandler(Handler):
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------
-
-def _do_nothing(ignored):
-    pass
 
 #-----------------------------------------------------------------------------
 # Code

--- a/bokeh/application/handlers/tests/test_document_lifecycle.py
+++ b/bokeh/application/handlers/tests/test_document_lifecycle.py
@@ -1,0 +1,94 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2017, Anaconda, Inc. All rights reserved.
+#
+# Powered by the Bokeh Development Team.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import pytest ; pytest
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+
+# External imports
+
+# Bokeh imports
+from bokeh.document import Document
+
+# Module under test
+import bokeh.application.handlers.document_lifecycle as bahd
+
+#-----------------------------------------------------------------------------
+# Setup
+#-----------------------------------------------------------------------------
+
+class MockSessionContext(object):
+    def __init__(self, doc):
+        self._document = doc
+        self.status = None
+        self.counter = 0
+
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+class Test_DocumentLifecycleHandler(object):
+
+    def test_document_bad_on_session_destroyed_signature(self):
+        doc = Document()
+
+        def destroy(a, b):
+            pass
+
+        with pytest.raises(ValueError):
+            doc.on_session_destroyed(destroy)
+
+    def test_document_on_session_destroyed(self):
+        doc = Document()
+        handler = bahd.DocumentLifecycleHandler()
+
+        def destroy(session_context):
+            assert doc is session_context._document
+            session_context.status = 'Destroyed'
+
+        doc.on_session_destroyed(destroy)
+
+        session_context = MockSessionContext(doc)
+        handler.on_session_destroyed(session_context)
+        assert session_context.status == 'Destroyed'
+
+    def test_document_on_session_destroyed_calls_multiple(self):
+        doc = Document()
+
+        def increment(session_context):
+            session_context.counter += 1
+
+        doc.on_session_destroyed(increment)
+
+        def increment_by_two(session_context):
+            session_context.counter += 2
+
+        doc.on_session_destroyed(increment_by_two)
+
+        handler = bahd.DocumentLifecycleHandler()
+        session_context = MockSessionContext(doc)
+        handler.on_session_destroyed(session_context)
+        assert session_context.counter == 3, 'DocumentLifecycleHandler did not call all callbacks'
+

--- a/bokeh/application/handlers/tests/test_document_lifecycle.py
+++ b/bokeh/application/handlers/tests/test_document_lifecycle.py
@@ -91,4 +91,3 @@ class Test_DocumentLifecycleHandler(object):
         session_context = MockSessionContext(doc)
         handler.on_session_destroyed(session_context)
         assert session_context.counter == 3, 'DocumentLifecycleHandler did not call all callbacks'
-

--- a/bokeh/document/document.py
+++ b/bokeh/document/document.py
@@ -68,6 +68,7 @@ class Document(object):
         self._all_models_by_name = MultiValuedDict()
         self._all_former_model_ids = set()
         self._callbacks = {}
+        self._session_destroyed_callbacks = {}
         self._session_callbacks = set()
         self._session_context = None
         self._modules = []
@@ -622,6 +623,15 @@ class Document(object):
     def on_change_dispatch_to(self, receiver):
         if not receiver in self._callbacks:
             self._callbacks[receiver] = lambda event: event.dispatch(receiver)
+
+    def on_session_destroyed(self, *callbacks):
+        ''' Provide callbacks to invoke when the session serving the Document
+        is destroyed
+
+        '''
+        for callback in callbacks:
+            _check_callback(callback, ('document',))
+            self._session_destroyed_callbacks[callback] = callback
 
     def remove_next_tick_callback(self, callback_obj):
         ''' Remove a callback added earlier with ``add_next_tick_callback``.

--- a/bokeh/document/document.py
+++ b/bokeh/document/document.py
@@ -630,7 +630,7 @@ class Document(object):
 
         '''
         for callback in callbacks:
-            _check_callback(callback, ('document',))
+            _check_callback(callback, ('session_context',))
             self._session_destroyed_callbacks[callback] = callback
 
     def remove_next_tick_callback(self, callback_obj):

--- a/bokeh/server/server.py
+++ b/bokeh/server/server.py
@@ -360,7 +360,7 @@ class Server(BaseServer):
         log.info("Starting Bokeh server version %s (running on Tornado %s)" % (__version__, tornado.version))
 
         from bokeh.application.handlers.function import FunctionHandler
-        from bokeh.application.handlers.document_lifecycle import DocumentLifeCycleHandler
+        from bokeh.application.handlers.document_lifecycle import DocumentLifecycleHandler
 
         if callable(applications):
             applications = Application(FunctionHandler(applications))
@@ -371,7 +371,9 @@ class Server(BaseServer):
         for k, v in list(applications.items()):
             if callable(v):
                 applications[k] = Application(FunctionHandler(v))
-            applications[k].add(DocumentLifeCycleHandler())
+            if all(not isinstance(handler, DocumentLifecycleHandler)
+                   for handler in applications[k]._handlers):
+                applications[k].add(DocumentLifecycleHandler())
 
         opts = _ServerOpts(kwargs)
         self._port = opts.port

--- a/bokeh/server/server.py
+++ b/bokeh/server/server.py
@@ -360,6 +360,7 @@ class Server(BaseServer):
         log.info("Starting Bokeh server version %s (running on Tornado %s)" % (__version__, tornado.version))
 
         from bokeh.application.handlers.function import FunctionHandler
+        from bokeh.application.handlers.document_lifecycle import DocumentLifeCycleHandler
 
         if callable(applications):
             applications = Application(FunctionHandler(applications))
@@ -370,6 +371,7 @@ class Server(BaseServer):
         for k, v in list(applications.items()):
             if callable(v):
                 applications[k] = Application(FunctionHandler(v))
+            applications[k].add(DocumentLifeCycleHandler())
 
         opts = _ServerOpts(kwargs)
         self._port = opts.port

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -610,13 +610,13 @@ it with the ``Document.on_session_destroyed`` method:
 
 .. code-block:: python
 
-	doc = Document()
+    doc = Document()
 
     def cleanup_session(session_context):
         ''' This function is called when a session is closed. '''
         pass
 
-	doc.on_session_destroyed(cleanup_session)
+    doc.on_session_destroyed(cleanup_session)
 
 .. _userguide_server_embedding:
 

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -601,6 +601,23 @@ any or all of the following conventionally named functions:
         ''' If present, this function is called when a session is closed. '''
         pass
 
+Additionally, ``on_session_destroyed`` lifecycle hooks may also be defined
+directly on the ``Document`` being served. Since the task of cleaning up after
+a user closes a session is common, e.g. to shut down a database connection,
+this provides an easy route to performing such actions without bundling
+a separate file. To declare such a callback define a function and register
+it with the ``Document.on_session_destroyed`` method:
+
+.. code-block:: python
+
+	doc = Document()
+
+    def cleanup_session(session_context):
+        ''' This function is called when a session is closed. '''
+        pass
+
+	doc.on_session_destroyed(cleanup_session)
+
 .. _userguide_server_embedding:
 
 Embedding Bokeh Server as a Library


### PR DESCRIPTION
As described in #8247 this adds a way to define ``on_session_destroyed`` callbacks on the Document which are executed by a ``DocumentLifeCycleHandler`` which is added to all ``Application`` instances by default.

Two things that need to be decided before I'm happy with this:

* Naming of the `DocumentLifeCycleHandler`
* Who is responsible for adding the `DocumentLifeCycleHandler`, currently the `Server` adds this handler to all applications (at minimum it might want to check whether the application already has such a handler)

Once these items have been decided I'll add some tests and add a bit about this in the server docs.

- [x] issues: fixes #8247
- [x] tests added / passed
- [x] release document entry (if new feature or API change)
