### PR TITLE
add missing embed tempate

### DIFF
--- a/examples/embed/server_session/templates/embed.html
+++ b/examples/embed/server_session/templates/embed.html
@@ -1,0 +1,18 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Embedding a Bokeh Server With {{ framework }}</title>
+</head>
+
+<body>
+  <div>
+    This Bokeh app below served by a Bokeh server that has been embedded
+    in another web app framework. For more information see the section
+    <a  target="_blank" href="https://bokeh.pydata.org/en/latest/docs/user_guide/server.html#embedding-bokeh-server-as-a-library">Embedding Bokeh Server as a Library</a>
+    in the User's Guide.
+  </div>
+  {{ script|safe }}
+</body>
+</html>


### PR DESCRIPTION
- [x] issues: fixes #8257

`.html` files are git ignored under `examples` to prevent accidentally committing example output to the repo, but that cuts the opposite direction when adding HTML files is intended. 
