### PR TITLE
suppress callback warning on image export

### DIFF
--- a/bokeh/embed/standalone.py
+++ b/bokeh/embed/standalone.py
@@ -245,7 +245,8 @@ def file_html(models,
               title=None,
               template=FILE,
               template_variables={},
-              theme=FromCurdoc):
+              theme=FromCurdoc,
+              suppress_callback_warning=False):
     ''' Return an HTML document that embeds Bokeh Model or Document objects.
 
     The data for the plot is stored directly in the returned HTML, with
@@ -256,11 +257,14 @@ def file_html(models,
         models (Model or Document or seq[Model]) : Bokeh object or objects to render
             typically a Model or Document
 
-        resources (Resources or tuple(JSResources or None, CSSResources or None)) : i
+        resources (Resources or tuple(JSResources or None, CSSResources or None)) :
             A resource configuration for Bokeh JS & CSS assets.
 
-        title (str, optional) : a title for the HTML document ``<title>`` tags or None. (default: None)
-            If None, attempt to automatically find the Document title from the given plot objects.
+        title (str, optional) :
+            A title for the HTML document ``<title>`` tags or None. (default: None)
+
+            If None, attempt to automatically find the Document title from the given
+            plot objects.
 
         template (Template, optional) : HTML document template (default: FILE)
             A Jinja2 Template, see bokeh.core.templates.FILE for the required
@@ -276,6 +280,12 @@ def file_html(models,
             already specified in the document. Any other value must be an
             instance of the ``Theme`` class.
 
+        suppress_callback_warning (bool, optional) :
+            Normally generating standalone HTML from a Bokeh Document that has
+            Python callbacks will result in a warning stating that the callbacks
+            cannot function. However, this warning can be suppressed by setting
+            this value to True (default: False)
+
     Returns:
         UTF-8 encoded HTML
 
@@ -287,7 +297,7 @@ def file_html(models,
         models = models.roots
 
     with OutputDocumentFor(models, apply_theme=theme) as doc:
-        (docs_json, render_items) = standalone_docs_json_and_render_items(models)
+        (docs_json, render_items) = standalone_docs_json_and_render_items(models, suppress_callback_warning=suppress_callback_warning)
         title = _title_from_models(models, title)
         bundle = bundle_for_objs_and_resources([doc], resources)
         return html_page_for_render_items(bundle, docs_json, render_items, title=title,

--- a/bokeh/embed/tests/test_util.py
+++ b/bokeh/embed/tests/test_util.py
@@ -528,6 +528,25 @@ class Test_standalone_docs_json_and_render_items(object):
             assert len(caplog.records) == 1
             assert caplog.text != ''
 
+    def test_suppress_warnings(self, caplog):
+        d = Document()
+        m1 = EmbedTestUtilModel()
+        c1 = _GoodPropertyCallback()
+        c2 = _GoodEventCallback()
+        d.add_root(m1)
+
+        m1.on_change('name', c1)
+        assert len(m1._callbacks) != 0
+
+        m1.on_event(Tap, c2)
+        assert len(m1._event_callbacks) != 0
+
+        with caplog.at_level(logging.WARN):
+            beu.standalone_docs_json_and_render_items(m1, suppress_callback_warning=True)
+            assert len(caplog.records) == 0
+            assert caplog.text == ''
+
+
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------

--- a/bokeh/embed/util.py
+++ b/bokeh/embed/util.py
@@ -93,7 +93,7 @@ def OutputDocumentFor(objs, apply_theme=None, always_new=False):
 
             If None, use whatever theme is on the document that is found or created
 
-            If FromCurdox, use curdoc().theme, restoring any previous theme afterwards
+            If FromCurdoc, use curdoc().theme, restoring any previous theme afterwards
 
             If a Theme instance, use that theme, restoring any previous theme afterwards
 
@@ -233,7 +233,7 @@ class RenderRoots(object):
     def to_json(self):
         return OrderedDict([ (root._id, elementid) for root, elementid in self._roots.items() ])
 
-def standalone_docs_json_and_render_items(models):
+def standalone_docs_json_and_render_items(models, suppress_callback_warning=False):
     '''
 
     '''
@@ -243,7 +243,7 @@ def standalone_docs_json_and_render_items(models):
     if not (isinstance(models, Sequence) and all(isinstance(x, (Model, Document)) for x in models)):
         raise ValueError("Expected a Model, Document, or Sequence of Models or Documents")
 
-    if submodel_has_python_callbacks(models):
+    if submodel_has_python_callbacks(models) and not suppress_callback_warning:
         log.warn(_CALLBACKS_WARNING)
 
     docs = {}

--- a/bokeh/io/export.py
+++ b/bokeh/io/export.py
@@ -239,7 +239,7 @@ def get_layout_html(obj, resources=INLINE, **kwargs):
             obj.plot_width = kwargs.get('width', old_width)
 
     try:
-        html = file_html(obj, resources, title="")
+        html = file_html(obj, resources, title="", suppress_callback_warning=True)
     finally:
         if resize:
             obj.plot_height = old_height


### PR DESCRIPTION
- [x] issues: fixes #8020
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

I would have preferred to find a way to do this without adding another paramete to `file_html` but that would require a larger refactor. 