### PR TITLE
warn on setting  attributes on empty splattable legend lists

### DIFF
--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -3,6 +3,8 @@
 '''
 from __future__ import absolute_import
 
+import warnings
+
 from six import string_types
 
 from ..core.enums import Location, OutputBackend
@@ -41,6 +43,17 @@ class _list_attr_splat(list):
         else:
             return dir(self)
 
+_LEGEND_EMPTY_WARNING = """
+You are attemptings to set `plot.legend.%s` on a plot that has zero legends added, this will have no effect.
+
+Before legend properties can be set, you must add a Legend explicitly, or call a glyph method with the 'legend' parameter set.
+"""
+
+class _legend_attr_splat(_list_attr_splat):
+    def __setattr__(self, attr, value):
+        if not len(self):
+            warnings.warn(_LEGEND_EMPTY_WARNING % attr)
+        return super(_legend_attr_splat, self).__setattr__(attr, value)
 
 def _select_helper(args, kwargs):
     """ Allow flexible selector syntax.
@@ -202,7 +215,7 @@ class Plot(LayoutDOM):
 
         '''
         legends = [obj for obj in self.renderers if isinstance(obj, Legend)]
-        return _list_attr_splat(legends)
+        return _legend_attr_splat(legends)
 
     @property
     def hover(self):

--- a/bokeh/models/tests/test_plots.py
+++ b/bokeh/models/tests/test_plots.py
@@ -19,6 +19,32 @@ from bokeh.models.ranges import FactorRange, DataRange1d, Range1d
 from bokeh.models.scales import CategoricalScale, LinearScale, LogScale
 from bokeh.models.tools import PanTool
 
+import bokeh.models.plots as bmp
+
+_LEGEND_EMPTY_WARNING = """
+You are attemptings to set `plot.legend.location` on a plot that has zero legends added, this will have no effect.
+
+Before legend properties can be set, you must add a Legend explicitly, or call a glyph method with the 'legend' parameter set.
+"""
+
+class TestPlotLegendProperty(object):
+
+    def test_basic(self):
+        plot = figure(tools='')
+        x = plot.legend
+        assert isinstance(x, bmp._list_attr_splat)
+        assert len(x) == 0
+        plot.circle([1,2], [3,4], legend="foo")
+        x = plot.legend
+        assert isinstance(x, bmp._list_attr_splat)
+        assert len(x) == 1
+
+    def test_warnign(self):
+        plot = figure(tools='')
+        with pytest.warns(UserWarning) as warns:
+            plot.legend.location = "above"
+            assert len(warns) == 1
+            assert warns[0].message.args[0] == _LEGEND_EMPTY_WARNING
 
 class TestPlotSelect(object):
 


### PR DESCRIPTION
- [x] issues: fixes #5632
- [x] tests added / passed

This PR is narrow, it only adds a warning setting attributes on empty `p.legend`. It is far less common to not have axes or grids when using `bokeh.plotting` and I have never seen any reports of similar confusion happening with `p.axis`, etc. But legends are only created on demand so it is much easier to get in a situation trying to set `p.legend.location` before any legend exists. 