### PR TITLE
Remove global event listeners when deleting views to prevent memory leaks

### DIFF
--- a/bokehjs/src/lib/core/ui_events.ts
+++ b/bokehjs/src/lib/core/ui_events.ts
@@ -83,6 +83,34 @@ export class UIEvents {
               readonly hit_area: HTMLElement,
               readonly plot: Plot) {
     this._configure_hammerjs()
+    
+    // Mouse & keyboard events not handled through hammerjs
+
+    // We can 'add and forget' these event listeners because this.hit_area is a DOM element
+    // that will be thrown away when the view is removed
+    this.hit_area.addEventListener("mousemove", (e) => this._mouse_move(e))
+    this.hit_area.addEventListener("mouseenter", (e) => this._mouse_enter(e))
+    this.hit_area.addEventListener("mouseleave", (e) => this._mouse_exit(e))
+    this.hit_area.addEventListener("wheel", (e) => this._mouse_wheel(e))
+
+    // But we MUST remove listeners registered on document or we'll leak memory: register
+    // 'this' as the listener (it implements the event listener interface, i.e. handleEvent)
+    // instead of an anonymous function so we can easily refer back to it for removing
+    document.addEventListener("keydown", this)
+    document.addEventListener("keyup", this)
+  }
+
+  destroy(): void {
+    this.hammer.destroy()
+    document.removeEventListener("keydown", this)
+    document.removeEventListener("keyup", this)
+  }
+
+  handleEvent(e: KeyboardEvent): void {
+    if (e.type == "keydown")
+      this._key_down(e)
+    else if (e.type == "keyup")
+      this._key_up(e)
   }
 
   protected _configure_hammerjs(): void {
@@ -109,17 +137,8 @@ export class UIEvents {
     this.hammer.on('rotatestart', (e) => this._rotate_start(e))
     this.hammer.on('rotate', (e) => this._rotate(e))
     this.hammer.on('rotateend', (e) => this._rotate_end(e))
-
-    this.hit_area.addEventListener("mousemove", (e) => this._mouse_move(e))
-    this.hit_area.addEventListener("mouseenter", (e) => this._mouse_enter(e))
-    this.hit_area.addEventListener("mouseleave", (e) => this._mouse_exit(e))
-
-    this.hit_area.addEventListener("wheel", (e) => this._mouse_wheel(e))
-
-    document.addEventListener("keydown", (e) => this._key_down(e))
-    document.addEventListener("keyup", (e) => this._key_up(e))
   }
-
+  
   register_tool(tool_view: ToolView): void {
     const et = tool_view.model.event_type
 

--- a/bokehjs/src/lib/core/ui_events.ts
+++ b/bokehjs/src/lib/core/ui_events.ts
@@ -83,7 +83,7 @@ export class UIEvents {
               readonly hit_area: HTMLElement,
               readonly plot: Plot) {
     this._configure_hammerjs()
-    
+
     // Mouse & keyboard events not handled through hammerjs
 
     // We can 'add and forget' these event listeners because this.hit_area is a DOM element
@@ -138,7 +138,7 @@ export class UIEvents {
     this.hammer.on('rotate', (e) => this._rotate(e))
     this.hammer.on('rotateend', (e) => this._rotate_end(e))
   }
-  
+
   register_tool(tool_view: ToolView): void {
     const et = tool_view.model.event_type
 

--- a/bokehjs/src/lib/models/layouts/layout_dom.ts
+++ b/bokehjs/src/lib/models/layouts/layout_dom.ts
@@ -242,10 +242,19 @@ export abstract class LayoutDOMView extends DOMView {
     super.connect_signals()
 
     if (this.is_root)
-      window.addEventListener("resize", () => this.resize())
+      window.addEventListener("resize", this)
 
     // XXX: this.connect(this.model.change, () => this.layout())
     this.connect(this.model.properties.sizing_mode.change, () => this.layout())
+  }
+
+  handleEvent(): void {
+    this.resize()
+  }
+
+  disconnect_signals(): void {
+    super.disconnect_signals()
+    window.removeEventListener("resize", this)
   }
 
   _render_classes(): void {

--- a/bokehjs/src/lib/models/layouts/layout_dom.ts
+++ b/bokehjs/src/lib/models/layouts/layout_dom.ts
@@ -253,8 +253,8 @@ export abstract class LayoutDOMView extends DOMView {
   }
 
   disconnect_signals(): void {
-    super.disconnect_signals()
     window.removeEventListener("resize", this)
+    super.disconnect_signals()
   }
 
   _render_classes(): void {

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -156,6 +156,7 @@ export class PlotCanvasView extends DOMView {
   }
 
   remove(): void {
+    this.ui_event_bus.destroy()
     remove_views(this.renderer_views)
     remove_views(this.tool_views)
     this.canvas_view.remove()


### PR DESCRIPTION
As promised in the [memory leak issue discussion](https://github.com/bokeh/bokeh/issues/5355), here is a PR for properly removing event listeners registered by BokehJS views on **window** and **document** global objects.
Because they constitute an active reference to the view, these listeners prevent garbage collection of most (all ?) of a Bokeh document's memory footprint after it has been entirely removed from the DOM.

I don't know what kind of testing is expected from such a PR. All I can say is these changes don't evidently break bokehjs' behavior and now re-running again and again the same cell in Jupyter Notebook shows the memory still increasing short-term, but being properly garbage-collected afterwards.

- [x] issues: fixes #5355 
- [ ] tests added / passed