### PR TITLE
Fix {css,js}_resources block mismatch

### DIFF
--- a/sphinx/source/docs/user_guide/embed.rst
+++ b/sphinx/source/docs/user_guide/embed.rst
@@ -477,10 +477,10 @@ The full template, with all the sections that can be overridden, is given here:
         <title>{% block title %}{{ title | e if title else "Bokeh Plot" }}{% endblock %}</title>
         {% block preamble %}{% endblock %}
         {% block resources %}
-            {% block js_resources %}
+            {% block css_resources %}
             {{ bokeh_css | indent(8) if bokeh_css }}
             {% endblock %}
-            {% block css_resources %}
+            {% block js_resources %}
             {{ bokeh_js | indent(8) if bokeh_js }}
             {% endblock %}
         {% endblock %}


### PR DESCRIPTION
Issue #8160 stated that there was a mismatch in `{css,js}_ressources` both in `file.html` template and documentation.
PR #8161 fixed only the mismatch in `file.html` template.

This PR fixes the mismatch in the documentation.

Have a nice day!

fixes #8160