### PR TITLE
Add computed_icon getter to ToolProxy

### DIFF
--- a/bokehjs/src/lib/models/tools/tool_proxy.ts
+++ b/bokehjs/src/lib/models/tools/tool_proxy.ts
@@ -63,6 +63,10 @@ export class ToolProxy extends Model {
     return this.tools[0].computed_icon
   }
 
+  get computed_icon(): string {
+    return this.icon
+  }
+
   initialize(): void {
     super.initialize()
     this.do = new Signal0(this, "do")

--- a/bokehjs/test/models/tools/toolbar_box.coffee
+++ b/bokehjs/test/models/tools/toolbar_box.coffee
@@ -47,6 +47,7 @@ class MultiToolView extends SelectToolView
 class MultiTool extends SelectTool
   default_view: MultiToolView
   type: "MultiTool"
+  icon: "Multi Tool"
   tool_name: "Multi Tool"
   event_type: ["tap", "pan"]
 
@@ -88,5 +89,6 @@ describe "ProxyToolbar", ->
       toolbar = new ProxyToolbar({tools:[@multi, @tap, @pan]})
       expect(toolbar.gestures['multi'].tools.length).to.be.equal(1)
       expect(toolbar.gestures['multi'].tools[0]).to.be.an.instanceof(ToolProxy)
+      expect(toolbar.gestures['multi'].tools[0].computed_icon).to.be.equal('Multi Tool')
       expect(toolbar.gestures['multi'].tools[0].tools.length).to.be.equal(1)
       expect(toolbar.gestures['multi'].tools[0].tools[0]).to.be.equal(@multi)


### PR DESCRIPTION
Fixes missing icons on merged toolbars which use ToolProxy.

- [x] issues: fixes #8282 
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
