### PR TITLE
add minor ticks "minor_ticks=" option in FixedTicker

### DIFF
--- a/bokeh/models/tickers.py
+++ b/bokeh/models/tickers.py
@@ -40,8 +40,10 @@ class ContinuousTicker(Ticker):
 
 class FixedTicker(ContinuousTicker):
     ''' Generate ticks at fixed, explicitly supplied locations.
+
     .. note::
         The ``desired_num_ticks`` property is ignored by this Ticker.
+
     '''
 
     ticks = Seq(Float, default=[], help="""

--- a/bokeh/models/tickers.py
+++ b/bokeh/models/tickers.py
@@ -47,8 +47,8 @@ class FixedTicker(ContinuousTicker):
     ticks = Seq(Float, default=[], help="""
     List of major tick locations.
     """)
-	
-	minor_ticks = Seq(Float, default=[], help="""
+
+    minor_ticks = Seq(Float, default=[], help="""
     List of minor tick locations.
     """)
 

--- a/bokeh/models/tickers.py
+++ b/bokeh/models/tickers.py
@@ -40,14 +40,16 @@ class ContinuousTicker(Ticker):
 
 class FixedTicker(ContinuousTicker):
     ''' Generate ticks at fixed, explicitly supplied locations.
-
     .. note::
         The ``desired_num_ticks`` property is ignored by this Ticker.
-
     '''
 
     ticks = Seq(Float, default=[], help="""
-    List of tick locations.
+    List of major tick locations.
+    """)
+	
+	minor_ticks = Seq(Float, default=[], help="""
+    List of minor tick locations.
     """)
 
 class AdaptiveTicker(ContinuousTicker):

--- a/bokehjs/src/lib/models/tickers/fixed_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/fixed_ticker.ts
@@ -5,6 +5,7 @@ import * as p from "core/properties"
 export namespace FixedTicker {
   export interface Attrs extends ContinuousTicker.Attrs {
     ticks: number[]
+    minor_ticks: number[]
   }
 
   export interface Props extends ContinuousTicker.Props {}
@@ -25,13 +26,14 @@ export class FixedTicker extends ContinuousTicker {
 
     this.define({
       ticks: [ p.Array, [] ],
+      minor_ticks: [ p.Array, [] ],
     })
   }
 
   get_ticks_no_defaults(_data_low: number, _data_high: number, _cross_loc: any, _desired_n_ticks: number): TickSpec<number> {
     return {
       major: this.ticks,
-      minor: [],
+      minor: this.minor_ticks,
     }
   }
 


### PR DESCRIPTION
This PR attempts to add an optional minor_ticks option for FixedTicker. 

Subsequently, one should be able to pass FixedTicker a list of minor tick values analogous to how one would pass a list of major tick values. 
```python
p.axis.ticker = FixedTicker(ticks=[0, 5, 10], minor_ticks=[1,2,3,4, 6,7,8,9])
```
past behavior should still work because `minor_ticks=[]` by default

I am new to typescript, so please doublecheck the work! Not sure where else to update (e.g. in [tests](https://github.com/bokeh/bokeh/blob/master/bokehjs/test/models/tickers/fixed_ticker.ts) or in docs)

- [ ] issues: fixes #8295
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

## Tested example for reproducibility
```python
import numpy as np

from bokeh.io import show, output_file, output_notebook
from bokeh.plotting import figure
from bokeh.models.tickers import FixedTicker

#data (will not be plotted!)
major_data = [0.1, 1, 10, 100]
minor_data = [0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9] + [2, 3, 4, 5, 6, 7, 8, 9] + [20, 30, 40, 50, 60, 70, 80, 90]

#original data will be viewed in log10 space
minor_ticks = np.log10(minor_data).tolist()
major_ticks = np.log10(major_data).tolist()
major_data_labels = ["10⁻¹", "10⁰", "10¹", "10²"]

#workaround to handle whole number floats being treated differently in override process
    #https://github.com/bokeh/bokeh/issues/8166
major_ticks_converted = [int(item)  if float(item).is_integer()  else item  for item in major_ticks]

major_label_overrides = dict(zip(major_ticks_converted, major_data_labels))
```
#### Default behavior
```python
p = figure(x_range=(-2,3))
p.circle(x=[-1,0,1,2,2], y=[1,1,1,1,1.5])

#p.axis.ticker = major_ticks  #to verify shorthand compatibility
p.xaxis.ticker = FixedTicker(ticks=major_ticks)
p.xaxis.major_label_overrides = major_label_overrides
 
#output_notebook()
output_file('FixedTicker_default.html')
show(p)
```
![image](https://user-images.githubusercontent.com/20694664/46326958-516f0d00-c5cd-11e8-882b-93fbca33c249.png)


#### New behavior after recompiling bokehjs and activating with `BOKEH_RESOURCES=inline`
```python
p = figure(x_range=(-2,3))
p.circle(x=[-1,0,1,2,2], y=[1,1,1,1,1.5])

p.xaxis.ticker = FixedTicker(ticks=major_ticks, minor_ticks=minor_ticks)
p.xaxis.major_label_overrides = major_label_overrides

#output_notebook()
output_file('FixedTicker_new.html')
show(p)
```
![image](https://user-images.githubusercontent.com/20694664/46326900-f4735700-c5cc-11e8-8f9c-2ef9fbd0372b.png)
