### PR TITLE
use standard args for gridplot

### DIFF
--- a/bokeh/layouts.py
+++ b/bokeh/layouts.py
@@ -231,7 +231,7 @@ def layout(*args, **kwargs):
     # Make the grid
     return _create_grid(children, sizing_mode)
 
-def gridplot(*args, sizing_mode='fixed',  toolbar_location='above', ncols=None,
+def gridplot(children, sizing_mode='fixed',  toolbar_location='above', ncols=None,
              plot_width=None, plot_height=None, toolbar_options=None, merge_tools=True):
     ''' Create a grid of plots rendered on separate canvases.
 
@@ -299,7 +299,7 @@ def gridplot(*args, sizing_mode='fixed',  toolbar_location='above', ncols=None,
         if not hasattr(Location, toolbar_location):
             raise ValueError("Invalid value of toolbar_location: %s" % toolbar_location)
 
-    children = _handle_children(*args)
+    children = _handle_children(children=children)
     if ncols:
         if any(isinstance(child, list) for child in children):
             raise ValueError("Cannot provide a nested list when using ncols")

--- a/bokeh/layouts.py
+++ b/bokeh/layouts.py
@@ -231,9 +231,12 @@ def layout(*args, **kwargs):
     # Make the grid
     return _create_grid(children, sizing_mode)
 
-def gridplot(*args, **kwargs):
-    """ Create a grid of plots rendered on separate canvases. ``gridplot`` builds a single toolbar
-    for all the plots in the grid. ``gridplot`` is designed to layout a set of plots. For general
+def gridplot(*args, sizing_mode='fixed',  toolbar_location='above', ncols=None,
+             plot_width=None, plot_height=None, toolbar_options=None, merge_tools=True):
+    ''' Create a grid of plots rendered on separate canvases.
+
+    The ``gridplot`` function builds a single toolbar for all the plots in the
+    grid. ``gridplot`` is designed to layout a set of plots. For general
     grid layout, use the :func:`~bokeh.layouts.layout` function.
 
     Args:
@@ -285,15 +288,9 @@ def gridplot(*args, **kwargs):
                 toolbar_options=dict(logo='gray')
             )
 
-    """
-    toolbar_location = kwargs.get('toolbar_location', 'above')
-    sizing_mode = kwargs.get('sizing_mode', 'fixed')
-    children = kwargs.get('children')
-    toolbar_options = kwargs.get('toolbar_options', {})
-    plot_width = kwargs.get('plot_width')
-    plot_height = kwargs.get('plot_height')
-    ncols = kwargs.get('ncols')
-    merge_tools = kwargs.get('merge_tools', True)
+    '''
+    if toolbar_options is None:
+        toolbar_options = {}
 
     # Integrity checks & set-up
     _verify_sizing_mode(sizing_mode)
@@ -302,7 +299,7 @@ def gridplot(*args, **kwargs):
         if not hasattr(Location, toolbar_location):
             raise ValueError("Invalid value of toolbar_location: %s" % toolbar_location)
 
-    children = _handle_children(*args, children=children)
+    children = _handle_children(*args)
     if ncols:
         if any(isinstance(child, list) for child in children):
             raise ValueError("Cannot provide a nested list when using ncols")

--- a/examples/plotting/file/histogram.py
+++ b/examples/plotting/file/histogram.py
@@ -104,4 +104,4 @@ p4.yaxis.axis_label = 'Pr(x)'
 
 output_file('histogram.html', title="histogram.py example")
 
-show(gridplot(p1,p2,p3,p4, ncols=2, plot_width=400, plot_height=400, toolbar_location=None))
+show(gridplot([p1,p2,p3,p4], ncols=2, plot_width=400, plot_height=400, toolbar_location=None))

--- a/examples/plotting/file/legend.py
+++ b/examples/plotting/file/legend.py
@@ -26,4 +26,4 @@ p2.line(x, 3*y, legend="3*sin(x)", line_color="green")
 
 output_file("legend.html", title="legend.py example")
 
-show(gridplot(p1, p2, ncols=2, plot_width=400, plot_height=400))  # open a browser
+show(gridplot([p1, p2], ncols=2, plot_width=400, plot_height=400))  # open a browser

--- a/examples/plotting/file/rect.py
+++ b/examples/plotting/file/rect.py
@@ -23,4 +23,4 @@ p3.rect(x, y, 0.1, 0.1, alpha=0.5, color="navy", angle=-np.pi/6)
 
 output_file("rect.html", title="rect.py example")
 
-show(gridplot(p1, p2, p3, ncols=2, plot_width=400, plot_height=400))
+show(gridplot([p1, p2, p3], ncols=2, plot_width=400, plot_height=400))


### PR DESCRIPTION
This PR removes unnecessary arbitrary arg/kwarg processing in `gridplot` in favor of standard Python optional args 

- [x] issues: fixes #8273
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

Now get for unknown arg:

```
TypeError: gridplot() got an unexpected keyword argument 'n_cols'
```