### PR TITLE
Small build tasks

### DIFF
--- a/scripts/ci/install
+++ b/scripts/ci/install
@@ -21,7 +21,6 @@ fi
 
 # if emergency, temporary package pins are necessary, they can go here
 PINNED_PKGS=$(cat <<EOF
-pillow <=5.1
 EOF
 )
 mkdir -p $HOME/miniconda/conda-meta

--- a/tests/integration/widgets/test_password_input.py
+++ b/tests/integration/widgets/test_password_input.py
@@ -90,6 +90,8 @@ class Test_PasswordInput(object):
 
         assert page.has_no_console_errors()
 
+    # XXX (bev) always works locally but fails intermittently (often) on TravisCI
+    @pytest.mark.skip
     def test_server_on_change_no_round_trip_without_enter_or_click(self, bokeh_server_page):
         page = bokeh_server_page(modify_doc)
 

--- a/tests/integration/widgets/test_text_input.py
+++ b/tests/integration/widgets/test_text_input.py
@@ -90,7 +90,7 @@ class Test_TextInput(object):
 
         assert page.has_no_console_errors()
 
-    # XXX (bev) alwasy works locally but fails intermittently (often) on TravisCI
+    # XXX (bev) always works locally but fails intermittently (often) on TravisCI
     @pytest.mark.skip
     def test_server_on_change_no_round_trip_without_enter_or_click(self, bokeh_server_page):
         page = bokeh_server_page(modify_doc)


### PR DESCRIPTION
This PR removes the package pin for Pillow now that Pillow 5.3 is available, and also disables a flaky integration test. 
