### PR TITLE
Bryanv/reduce import code

### DIFF
--- a/bokeh/core/templates.py
+++ b/bokeh/core/templates.py
@@ -17,19 +17,20 @@ models in various ways.
 '''
 from __future__ import absolute_import
 import json
-from jinja2 import Environment, Markup, FileSystemLoader, PackageLoader
+from os.path import dirname, join
 import sys
-import os
+
+from jinja2 import Environment, Markup, FileSystemLoader
 
 def get_env():
     ''' Get the correct Jinja2 Environment, also for frozen scripts.
     '''
     if getattr(sys, 'frozen', False):
-        templates_path = os.path.join(sys._MEIPASS, 'bokeh', 'core', '_templates')
+        templates_path = join(sys._MEIPASS, 'bokeh', 'core', '_templates')
         return Environment(loader=FileSystemLoader(templates_path))
     else:
-        return Environment(loader=PackageLoader('bokeh.core', '_templates'))
-
+        templates_path = join(dirname(__file__), '_templates')
+        return Environment(loader=FileSystemLoader(templates_path))
 
 _env = get_env()
 _env.filters['json'] = lambda obj: Markup(json.dumps(obj))

--- a/bokeh/plotting/figure.py
+++ b/bokeh/plotting/figure.py
@@ -12,7 +12,6 @@ from ..models import glyphs as _glyphs
 from ..models import markers as _markers
 from ..models.tools import Drag, Inspection, Scroll, Tap
 from ..util.options import Options
-from ..util.string import format_docstring
 from ..transform import linear_cmap
 from .helpers import (
     _get_range, _get_scale, _process_axis_and_grid, _process_tools_arg,
@@ -94,7 +93,9 @@ class FigureOptions(Options):
     """)
 
 class Figure(Plot):
-    ''' A subclass of :class:`~bokeh.models.plots.Plot` that simplifies plot
+    ''' Create a new Figure for plotting.
+
+    A subclass of :class:`~bokeh.models.plots.Plot` that simplifies plot
     creation with default axes, grids, tools, etc.
 
     Figure objects have many glyph methods that can be used to draw
@@ -103,7 +104,49 @@ class Figure(Plot):
     .. hlist::
         :columns: 3
 
-{glyph_methods}
+        * :func:`~bokeh.plotting.figure.Figure.annular_wedge`
+        * :func:`~bokeh.plotting.figure.Figure.annulus`
+        * :func:`~bokeh.plotting.figure.Figure.arc`
+        * :func:`~bokeh.plotting.figure.Figure.asterisk`
+        * :func:`~bokeh.plotting.figure.Figure.bezier`
+        * :func:`~bokeh.plotting.figure.Figure.circle`
+        * :func:`~bokeh.plotting.figure.Figure.circle_cross`
+        * :func:`~bokeh.plotting.figure.Figure.circle_x`
+        * :func:`~bokeh.plotting.figure.Figure.cross`
+        * :func:`~bokeh.plotting.figure.Figure.dash`
+        * :func:`~bokeh.plotting.figure.Figure.diamond`
+        * :func:`~bokeh.plotting.figure.Figure.diamond_cross`
+        * :func:`~bokeh.plotting.figure.Figure.ellipse`
+        * :func:`~bokeh.plotting.figure.Figure.hbar`
+        * :func:`~bokeh.plotting.figure.Figure.hex`
+        * :func:`~bokeh.plotting.figure.Figure.hex_tile`
+        * :func:`~bokeh.plotting.figure.Figure.image`
+        * :func:`~bokeh.plotting.figure.Figure.image_rgba`
+        * :func:`~bokeh.plotting.figure.Figure.image_url`
+        * :func:`~bokeh.plotting.figure.Figure.inverted_triangle`
+        * :func:`~bokeh.plotting.figure.Figure.line`
+        * :func:`~bokeh.plotting.figure.Figure.multi_line`
+        * :func:`~bokeh.plotting.figure.Figure.oval`
+        * :func:`~bokeh.plotting.figure.Figure.patch`
+        * :func:`~bokeh.plotting.figure.Figure.patches`
+        * :func:`~bokeh.plotting.figure.Figure.quad`
+        * :func:`~bokeh.plotting.figure.Figure.quadratic`
+        * :func:`~bokeh.plotting.figure.Figure.ray`
+        * :func:`~bokeh.plotting.figure.Figure.rect`
+        * :func:`~bokeh.plotting.figure.Figure.segment`
+        * :func:`~bokeh.plotting.figure.Figure.square`
+        * :func:`~bokeh.plotting.figure.Figure.square_cross`
+        * :func:`~bokeh.plotting.figure.Figure.square_x`
+        * :func:`~bokeh.plotting.figure.Figure.step`
+        * :func:`~bokeh.plotting.figure.Figure.text`
+        * :func:`~bokeh.plotting.figure.Figure.triangle`
+        * :func:`~bokeh.plotting.figure.Figure.vbar`
+        * :func:`~bokeh.plotting.figure.Figure.wedge`
+        * :func:`~bokeh.plotting.figure.Figure.x`
+
+    As well as a scatter function that can be parameterized by marker type:
+
+    * :func:`~bokeh.plotting.figure.Figure.scatter`
 
     There are also two specialized methods for stacking bars:
 
@@ -114,9 +157,8 @@ class Figure(Plot):
 
     * :func:`~bokeh.plotting.figure.Figure.hexbin`
 
-    In addition to all the Bokeh model property attributes documented below,
-    the ``Figure`` initializer also accepts the following options, which can
-    help simplify configuration:
+    In addition to all the ``Figure`` property attributes, the following
+    options are also accepted:
 
     .. bokeh-options:: FigureOptions
         :module: bokeh.plotting.figure
@@ -957,38 +999,8 @@ Examples:
         return graph_renderer
 
 def figure(**kwargs):
-    ''' Create a new :class:`~bokeh.plotting.figure.Figure` for plotting.
-
-    Figure objects have many glyph methods that can be used to draw
-    vectorized graphical glyphs:
-
-    .. hlist::
-        :columns: 3
-
-{glyph_methods}
-
-    There are also two specialized methods for stacking bars:
-
-    * :func:`~bokeh.plotting.figure.Figure.hbar_stack`
-    * :func:`~bokeh.plotting.figure.Figure.vbar_stack`
-
-    And one specialized method for making simple hexbin plots:
-
-    * :func:`~bokeh.plotting.figure.Figure.hexbin`
-
-    In addition to the standard :class:`~bokeh.plotting.figure.Figure`
-    property values (e.g. ``plot_width`` or ``sizing_mode``) the following
-    additional options can be passed as well:
-
-    .. bokeh-options:: FigureOptions
-        :module: bokeh.plotting.figure
-
-    Returns:
-       Figure
-
-    '''
-
     return Figure(**kwargs)
+figure.__doc__ = Figure.__doc__
 
 _MARKER_SHORTCUTS = {
     "*"  : "asterisk",
@@ -1013,8 +1025,3 @@ def markers():
 
 _color_fields = set(["color", "fill_color", "line_color"])
 _alpha_fields = set(["alpha", "fill_alpha", "line_alpha"])
-
-_gms = sorted(x for x in dir(Figure) if getattr(getattr(Figure, x), 'glyph_method', False))
-_gms = "\n".join("        * :func:`~bokeh.plotting.figure.Figure.%s`" % x for x in _gms)
-Figure.__doc__ = format_docstring(Figure.__doc__, glyph_methods=_gms)
-figure.__doc__ = format_docstring(figure.__doc__, glyph_methods=_gms)

--- a/bokeh/util/sampledata.py
+++ b/bokeh/util/sampledata.py
@@ -21,18 +21,18 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# NOTE: since downloading sampledata is not a common occurrnce, non-stdlib
+# imports are generally deferrered in this module
+
 # Standard library imports
 from os import mkdir, remove
 from os.path import abspath, dirname, exists, expanduser, isdir, isfile, join, splitext
 from sys import stdout
-from zipfile import ZipFile
 
 # External imports
 import six
-from six.moves.urllib.request import urlopen
 
 # Bokeh imports
-from .dependencies import import_required
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -87,6 +87,7 @@ def external_csv(module, name, **kw):
     '''
 
     '''
+    from .dependencies import import_required
     pd = import_required('pandas', '%s sample data requires Pandas (http://pandas.pydata.org) to be installed' % module)
     return pd.read_csv(external_path(name), **kw)
 
@@ -133,6 +134,7 @@ def package_csv(module, name, **kw):
     '''
 
     '''
+    from .dependencies import import_required
     pd = import_required('pandas', '%s sample data requires Pandas (http://pandas.pydata.org) to be installed' % module)
     return pd.read_csv(package_path(name), **kw)
 
@@ -184,6 +186,12 @@ def _download_file(base_url, filename, data_dir, progress=True):
     '''
 
     '''
+    # These is actually a somewhat expensive imports that added ~5% to overall
+    # typical bokeh import times. Since downloading sampledata is not a common
+    # action, we defer them to inside this function.
+    from six.moves.urllib.request import urlopen
+    from zipfile import ZipFile
+
     file_url = join(base_url, filename)
     file_path = join(data_dir, filename)
 


### PR DESCRIPTION
This PR claims some low hanging fruit for reducing Bokeh import times:

* Don't use `PackageLoader` for loading Bokeh Jinja templates (required `pkg_resources` import is very expensive)

* defer non-stdlib imports in sampledata modules (downloading sampledata is rare usage)

* reduce some dynamic docstring manipulations

All told this shaves ~200ms off `import bokeh.plotting` on my laptop. The results using:
```
python3.7 -X importtime -c "import bokeh.plotting" 2> bokeh3.log
tuna bokeh3.log
``` 
are:

<img width="1238" alt="screen shot 2018-10-05 at 15 16 30" src="https://user-images.githubusercontent.com/1078448/46562596-a94d9280-c8b1-11e8-9062-d80670a12813.png">

About half of that ~600ms appears to be NumPy and Pandas, which is borne out by this very rough timing:

```
In [1]: import pandas, numpy

In [2]:

In [2]: %time import bokeh.plotting
CPU times: user 190 ms, sys: 40.8 ms, total: 231 ms
Wall time: 309 ms
```

It's worth noting that 60-70 ms for computing `bokeh.__version__` disappears in real release packages where the version string is hardcoded. 

We can't do much about the NumPy/Pandas burden, but there are still some things we can do to reduce things on our end later:

* defer loading default temlate yaml files until requested (this will take a little more work/care)
* remove more dynamic module code (e.g dynamic glyph method construction)
* defer loading Jinja templates until needed
* move submodules of `bokeh.models` to `bokeh._modules` so that individual models can be imported internally without importing everything in `bokeh.models.__init__.py`

I would estimate ~150ms (relative reference on this laptop) is probably a floor for `import bokeh.plotting`