### PR TITLE
Only deduplicate some tool types

### DIFF
--- a/bokehjs/src/lib/models/tools/toolbar_box.ts
+++ b/bokehjs/src/lib/models/tools/toolbar_box.ts
@@ -145,7 +145,7 @@ export class ProxyToolbar extends ToolbarBase {
         const tools = gestures[event_type][tool_type]
 
         if (tools.length > 0) {
-          if (event_type == 'multi') {
+          if (event_type == 'multi' || tool_type == "CustomAction") {
             for (const tool of tools) {
               const proxy = make_proxy([tool])
               gesture.tools.push(proxy as any)

--- a/bokehjs/src/lib/models/tools/toolbar_box.ts
+++ b/bokehjs/src/lib/models/tools/toolbar_box.ts
@@ -145,9 +145,17 @@ export class ProxyToolbar extends ToolbarBase {
         const tools = gestures[event_type][tool_type]
 
         if (tools.length > 0) {
-          const proxy = make_proxy(tools)
-          gesture.tools.push(proxy as any)
-          this.connect(proxy.properties.active.change, this._active_change.bind(this, proxy))
+          if (event_type == 'multi') {
+            for (const tool of tools) {
+              const proxy = make_proxy([tool])
+              gesture.tools.push(proxy as any)
+              this.connect(proxy.properties.active.change, this._active_change.bind(this, proxy))
+            }
+          } else {
+            const proxy = make_proxy(tools)
+            gesture.tools.push(proxy as any)
+            this.connect(proxy.properties.active.change, this._active_change.bind(this, proxy))
+          }
         }
       }
     }

--- a/bokehjs/src/lib/models/tools/toolbar_box.ts
+++ b/bokehjs/src/lib/models/tools/toolbar_box.ts
@@ -145,7 +145,7 @@ export class ProxyToolbar extends ToolbarBase {
         const tools = gestures[event_type][tool_type]
 
         if (tools.length > 0) {
-          if (event_type == 'multi' || tool_type == "CustomAction") {
+          if (event_type == 'multi') {
             for (const tool of tools) {
               const proxy = make_proxy([tool])
               gesture.tools.push(proxy as any)
@@ -164,8 +164,12 @@ export class ProxyToolbar extends ToolbarBase {
     for (const tool_type in actions) {
       const tools = actions[tool_type]
 
-      if (tools.length > 0)
+      if (tool_type == 'CustomAction') {
+        for (const tool of tools)
+          this.actions.push(make_proxy([tool]) as any)
+      } else if (tools.length > 0) {
         this.actions.push(make_proxy(tools) as any) // XXX
+      }
     }
 
     this.inspectors = []

--- a/bokehjs/test/models/tools/toolbar_box.coffee
+++ b/bokehjs/test/models/tools/toolbar_box.coffee
@@ -6,8 +6,11 @@
 {ToolbarBox, ProxyToolbar} = require("models/tools/toolbar_box")
 {Toolbar} = require("models/tools/toolbar")
 {ToolProxy} = require("models/tools/tool_proxy")
+{CustomAction} = require("models/tools/actions/custom_action")
 {ResetTool} = require("models/tools/actions/reset_tool")
 {SaveTool} = require("models/tools/actions/save_tool")
+{BoxEditTool} = require("models/tools/edit/box_edit_tool")
+{PointDrawTool} = require("models/tools/edit/point_draw_tool")
 {SelectTool, SelectToolView} = require("models/tools/gestures/select_tool")
 {PanTool} = require("models/tools/gestures/pan_tool")
 {TapTool} = require("models/tools/gestures/tap_tool")
@@ -57,24 +60,6 @@ describe "ToolbarBox", ->
     box = new ToolbarBox()
     expect(box).to.be.an.instanceof(LayoutDOM)
 
-  ### TODO
-  it "should correctly merge multiple actions", ->
-    reset1 = new ResetTool()
-    reset2 = new ResetTool()
-    save1 = new SaveTool()
-    save2 = new SaveTool()
-    box = new ToolbarBox({tools: [reset1, reset2, save1, save2]})
-    expect(box._toolbar.actions.length).equal 2
-
-  it "should correctly merge multiple inspectors", ->
-    hover1 = new HoverTool()
-    hover2 = new HoverTool()
-    crosshair1 = new CrosshairTool()
-    crosshair2 = new CrosshairTool()
-    box = new ToolbarBox({tools: [hover1, hover2, crosshair1, crosshair2]})
-    expect(box._toolbar.inspectors.length).equal 2
-  ###
-
 
 describe "ProxyToolbar", ->
 
@@ -92,3 +77,37 @@ describe "ProxyToolbar", ->
       expect(toolbar.gestures['multi'].tools[0].computed_icon).to.be.equal('Multi Tool')
       expect(toolbar.gestures['multi'].tools[0].tools.length).to.be.equal(1)
       expect(toolbar.gestures['multi'].tools[0].tools[0]).to.be.equal(@multi)
+
+  describe "_merge_tools method", ->
+
+    it "should correctly merge multiple actions", ->
+      reset1 = new ResetTool()
+      reset2 = new ResetTool()
+      save1 = new SaveTool()
+      save2 = new SaveTool()
+      proxy_toolbar = new ProxyToolbar({tools: [reset1, reset2, save1, save2]})
+      expect(proxy_toolbar.actions.length).equal 2
+
+    it "should correctly merge multiple inspectors", ->
+      hover1 = new HoverTool()
+      hover2 = new HoverTool()
+      crosshair1 = new CrosshairTool()
+      crosshair2 = new CrosshairTool()
+      proxy_toolbar = new ProxyToolbar({tools: [hover1, hover2, crosshair1, crosshair2]})
+      expect(proxy_toolbar.inspectors.length).equal 2
+
+    it "should avoid merge of multiple multi-gesture tools", ->
+      pointdraw = new PointDrawTool()
+      boxedit1 = new BoxEditTool()
+      boxedit2 = new BoxEditTool()
+      proxy_toolbar = new ProxyToolbar({tools: [pointdraw, boxedit1, boxedit2]})
+      expect(proxy_toolbar.gestures.multi.tools.length).equal 3
+
+    it "should avoid merge of multiple CustomAction tools", ->
+      reset1 = new ResetTool()
+      reset2 = new ResetTool()
+      custom_action1 = new CustomAction()
+      custom_action2 = new CustomAction()
+      proxy_toolbar = new ProxyToolbar({tools: [reset1, reset2, custom_action1, custom_action2]})
+      console.log(proxy_toolbar.actions)
+      expect(proxy_toolbar.actions.length).equal 3

--- a/bokehjs/test/models/tools/toolbar_box.coffee
+++ b/bokehjs/test/models/tools/toolbar_box.coffee
@@ -109,5 +109,4 @@ describe "ProxyToolbar", ->
       custom_action1 = new CustomAction()
       custom_action2 = new CustomAction()
       proxy_toolbar = new ProxyToolbar({tools: [reset1, reset2, custom_action1, custom_action2]})
-      console.log(proxy_toolbar.actions)
       expect(proxy_toolbar.actions.length).equal 3


### PR DESCRIPTION
Bokeh helpfully supports the option of deduplicating tools in a layout by creating tool proxies for any tool type that is added more than once. This is appropriate for tool types such as pan/zoom/save/help etc. but not for others such as the drawing tools.

For now this PR explicitly skips multi-gesture tools which is the ``event_type`` used by the drawing tools and ``CustomAction`` tools. This may not be the best approach and/or may not cover all the tool types that should be skipped during deduplication. 

I don't think you will generally want multiple navigation tools (BoxZoomTool, PanTool, WheelZoomTool, WheelPanTool, ZoomInTool), select tools (BoxSelectTool, LassoSelectTool, PolySelectTool , TapTool), inspection tools (HoverTool, CrosshairTool), or action tools (SaveTool, UndoTool, RedoTool, ResetTool). The only other tool I can imagine wanting multiple entries for is the ``CustomActionTool`` since each instance can trigger a different action and can have a different tooltip and icon.

Therefore the current check I'm doing to skip deduplication is ``(event_type == 'multi' || tool_type == "CustomAction")``. If someone can suggest a more principled way of determining which tools not to deduplicate I'd be happy to hear it.

- [x] issues: fixes #8074
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
