### PR TITLE
Add adapter property to AjaxDataSource

### DIFF
--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -29,8 +29,8 @@ class DataSource(Model):
     A callback to run in the browser whenever the selection is changed.
 
     .. note:
-        This property left for backwards compatibility, but may be deprecated
-        in future. Prefer ``source.selected.js_on_change(...)`` for new code.
+        This property is left for backwards compatibility, but may be deprecated
+        in the future. Prefer ``source.selected.js_on_change(...)`` for new code.
     """)
 
 @abstract
@@ -720,9 +720,9 @@ class AjaxDataSource(RemoteSource):
     A JavaScript callback to adapt raw JSON responses to Bokeh ColumnDataSource
     format.
 
-    If provided, this callback is executes imediately after the JSON data is
+    If provided, this callback is executes immediately after the JSON data is
     received, but before apprending or replacing data in the data source. The
-    CustomJS callback will receiece the AjaxDataSource as ``cb_obj`` and will
+    CustomJS callback will receive the AjaxDataSource as ``cb_obj`` and will
     receive the raw JSON response as ``cb_data.response``. The callback code
     should return a ``data`` object suitable for a Bokeh ColumnDataSource (i.e.
     a mapping of string column names to arrays of data).

--- a/bokehjs/src/lib/models/tools/toolbar_base.ts
+++ b/bokehjs/src/lib/models/tools/toolbar_base.ts
@@ -24,7 +24,6 @@ export class ToolbarBaseView extends DOMView {
     super.initialize(options)
     this._tool_button_views = {}
     this._build_tool_button_views()
-    debugger
   }
 
   connect_signals(): void {

--- a/bokehjs/src/lib/models/tools/toolbar_base.ts
+++ b/bokehjs/src/lib/models/tools/toolbar_base.ts
@@ -24,6 +24,7 @@ export class ToolbarBaseView extends DOMView {
     super.initialize(options)
     this._tool_button_views = {}
     this._build_tool_button_views()
+    debugger
   }
 
   connect_signals(): void {

--- a/bokehjs/test/models/sources/ajax_data_source.coffee
+++ b/bokehjs/test/models/sources/ajax_data_source.coffee
@@ -2,7 +2,7 @@
 
 sinon = require 'sinon'
 
-{CustomJS} = require("models/callbacks/CustomJS")
+{CustomJS} = require("models/callbacks/customjs")
 {AjaxDataSource} = require("models/sources/ajax_data_source")
 
 describe "ajax_data_source module", ->

--- a/examples/howto/ajax_source.py
+++ b/examples/howto/ajax_source.py
@@ -1,17 +1,24 @@
 import numpy as np
-from datetime import timedelta
-from functools import update_wrapper, wraps
-from math import sin
-from random import random
-from six import string_types
+from flask import Flask, jsonify, make_response, request
 
-from bokeh.plotting import figure, show, output_file
-from bokeh.models.sources import AjaxDataSource
+from bokeh.plotting import figure, show
+from bokeh.models import AjaxDataSource, CustomJS
 
-output_file("ajax_source.html", title="ajax_source.py example")
+# Bokeh related code
+
+adapter = CustomJS(code="""
+    const result = {x: [], y: []}
+    const pts = cb_data.response.points
+    for (i=0; i<pts.length; i++) {
+        result.x.push(pts[i][0])
+        result.y.push(pts[i][1])
+    }
+    return result
+""")
 
 source = AjaxDataSource(data_url='http://localhost:5050/data',
-                        polling_interval=100)
+                        polling_interval=100, adapter=adapter)
+
 p = figure(plot_height=300, plot_width=800, background_fill_color="lightgrey",
            title="Streaming Noisy sin(x) via Ajax")
 p.circle('x', 'y', source=source)
@@ -19,88 +26,34 @@ p.circle('x', 'y', source=source)
 p.x_range.follow = "end"
 p.x_range.follow_interval = 10
 
-try:
-    from flask import Flask, jsonify, make_response, request, current_app
-except ImportError:
-    raise ImportError("You need Flask to run this example!")
-
-show(p)
-
-#########################################################
-# Flask server related
-#
-# The following code has no relation to bokeh and it's only
-# purpose is to serve data to the AjaxDataSource instantiated
-# previously. Flask just happens to be one of the python
-# web frameworks that makes it's easy and concise to do so
-#########################################################
-
-
-def crossdomain(origin=None, methods=None, headers=None,
-                max_age=21600, attach_to_all=True,
-                automatic_options=True):
-    """
-    Decorator to set crossdomain configuration on a Flask view
-
-    For more details about it refer to:
-
-    http://flask.pocoo.org/snippets/56/
-    """
-    if methods is not None:
-        methods = ', '.join(sorted(x.upper() for x in methods))
-
-    if headers is not None and not isinstance(headers, string_types):
-        headers = ', '.join(x.upper() for x in headers)
-
-    if not isinstance(origin, string_types):
-        origin = ', '.join(origin)
-
-    if isinstance(max_age, timedelta):
-        max_age = max_age.total_seconds()
-
-    def get_methods():
-        options_resp = current_app.make_default_options_response()
-        return options_resp.headers['allow']
-
-    def decorator(f):
-        @wraps(f)
-        def wrapped_function(*args, **kwargs):
-            if automatic_options and request.method == 'OPTIONS':
-                resp = current_app.make_default_options_response()
-            else:
-                resp = make_response(f(*args, **kwargs))
-            if not attach_to_all and request.method != 'OPTIONS':
-                return resp
-
-            h = resp.headers
-
-            h['Access-Control-Allow-Origin'] = origin
-            h['Access-Control-Allow-Methods'] = get_methods()
-            h['Access-Control-Max-Age'] = str(max_age)
-            requested_headers = request.headers.get(
-                'Access-Control-Request-Headers'
-            )
-            if headers is not None:
-                h['Access-Control-Allow-Headers'] = headers
-            elif requested_headers:
-                h['Access-Control-Allow-Headers'] = requested_headers
-            return resp
-        f.provide_automatic_options = False
-        return update_wrapper(wrapped_function, f)
-
-    return decorator
+# Flask related code
 
 app = Flask(__name__)
 
+def crossdomain(f):
+    def wrapped_function(*args, **kwargs):
+        resp = make_response(f(*args, **kwargs))
+        h = resp.headers
+        h['Access-Control-Allow-Origin'] = '*'
+        h['Access-Control-Allow-Methods'] = "GET, OPTIONS, POST"
+        h['Access-Control-Max-Age'] = str(21600)
+        requested_headers = request.headers.get('Access-Control-Request-Headers')
+        if requested_headers:
+            h['Access-Control-Allow-Headers'] = requested_headers
+        return resp
+    return wrapped_function
+
 x = list(np.arange(0, 6, 0.1))
-y = [sin(xx) + random() for xx in x]
+y = list(np.sin(x) + np.random.random(len(x)))
 
 @app.route('/data', methods=['GET', 'OPTIONS', 'POST'])
-@crossdomain(origin="*", methods=['GET', 'POST'], headers=None)
-def hello_world():
+@crossdomain
+def data():
     x.append(x[-1]+0.1)
-    y.append(sin(x[-1])+random())
-    return jsonify(x=x[-500:], y=y[-500:])
+    y.append(np.sin(x[-1])+np.random.random())
+    return jsonify(points=list(zip(x,y)))
 
-if __name__ == "__main__":
-    app.run(port=5050)
+# show and run
+
+show(p)
+app.run(port=5050)


### PR DESCRIPTION
This small PR adds an `adapter` property to `AjaxDataSource` that accepts a `customJS` that will convert any arbitrary JSON response into Bokeh CDS data format. The `ajax_source.py` is updated and simplified to demonstrate this new fearture. 