### PR TITLE
load themes from python modules instead of json files

### DIFF
--- a/bokeh/document/document.py
+++ b/bokeh/document/document.py
@@ -148,7 +148,7 @@ class Document(object):
         if self._theme is theme:
             return
 
-        if isinstance(theme, str):
+        if isinstance(theme, string_types):
             try:
                 self._theme = built_in_themes[theme]
             except KeyError:
@@ -159,7 +159,7 @@ class Document(object):
         elif isinstance(theme, Theme):
             self._theme = theme
         else:
-            raise ValueError("Theme must be a str or an instance of the Theme class")
+            raise ValueError("Theme must be a string or an instance of the Theme class")
 
         for model in self._all_models.values():
             self._theme.apply_to_model(model)

--- a/bokeh/themes/__init__.py
+++ b/bokeh/themes/__init__.py
@@ -7,6 +7,65 @@
 #-----------------------------------------------------------------------------
 ''' Provide access to built-in themes:
 
+CALIBER
+~~~~~~~
+
+.. bokeh-plot::
+
+    from bokeh.plotting import figure, output_file, show
+    from bokeh.themes import built_in_themes
+    from bokeh.io import curdoc
+
+    x = [1, 2, 3, 4, 5]
+    y = [6, 7, 6, 4, 5]
+
+    output_file("caliber.html")
+    curdoc().theme = 'caliber'
+    p = figure(title='caliber', plot_width=300, plot_height=300)
+    p.line(x, y)
+    show(p)
+
+DARK_MINIMAL
+~~~~~~~~~~~~
+
+.. bokeh-plot::
+
+    from bokeh.plotting import figure, output_file, show
+    from bokeh.themes import built_in_themes
+    from bokeh.io import curdoc
+
+    x = [1, 2, 3, 4, 5]
+    y = [6, 7, 6, 4, 5]
+
+    output_file("dark_minimal.html")
+    curdoc().theme = 'dark_minimal'
+    p = figure(title='dark_minimal', plot_width=300, plot_height=300)
+    p.line(x, y)
+    show(p)
+
+
+LIGHT_MINIMAL
+~~~~~~~~~~~~~
+
+.. bokeh-plot::
+
+    from bokeh.plotting import figure, output_file, show
+    from bokeh.themes import built_in_themes
+    from bokeh.io import curdoc
+
+    x = [1, 2, 3, 4, 5]
+    y = [6, 7, 6, 4, 5]
+
+    output_file("light_minimal.html")
+    curdoc().theme = 'light_minimal'
+    p = figure(title='light_minimal', plot_width=300, plot_height=300)
+    p.line(x, y)
+    show(p)
+
+as well as the ``Theme`` class that can be used to create new Themes.
+
+.. autoclass:: Theme
+
 '''
 from __future__ import absolute_import, division, print_function, unicode_literals
 

--- a/bokeh/themes/__init__.py
+++ b/bokeh/themes/__init__.py
@@ -1,24 +1,67 @@
-''' Provides API for loading themes
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2017, Anaconda, Inc. All rights reserved.
+#
+# Powered by the Bokeh Development Team.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+''' Provide access to built-in themes:
 
 '''
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function, unicode_literals
 
-from os.path import dirname, realpath, join
+import logging
+log = logging.getLogger(__name__)
 
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+
+# External imports
+
+# Bokeh imports
+from . import _caliber, _dark_minimal, _light_minimal
 from .theme import Theme
 
-_THIS_DIR = dirname(realpath(__file__))
-_FP_FMT = join(_THIS_DIR, '{0}.json')
+#-----------------------------------------------------------------------------
+# Globals and constants
+#-----------------------------------------------------------------------------
 
+__all__ = (
+    'CALIBER',
+    'DARK_MINIMAL',
+    'LIGHT_MINIMAL',
+    'Theme',
+    'built_in_themes',
+    'default',
+)
+
+CALIBER       = 'caliber'
 LIGHT_MINIMAL = 'light_minimal'
-DARK_MINIMAL = 'dark_minimal'
-CALIBER = 'caliber'
+DARK_MINIMAL  = 'dark_minimal'
 
 default = Theme(json={})
+
 built_in_themes = {
-    LIGHT_MINIMAL: Theme(filename=_FP_FMT.format(LIGHT_MINIMAL)),
-    DARK_MINIMAL: Theme(filename=_FP_FMT.format(DARK_MINIMAL)),
-    CALIBER: Theme(filename=_FP_FMT.format(CALIBER))
+    CALIBER       : Theme(json=_caliber.json),
+    DARK_MINIMAL  : Theme(json=_dark_minimal.json),
+    LIGHT_MINIMAL : Theme(json=_caliber.json),
 }
 
-del dirname, realpath, join
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Code
+#----------------------------------------------------------------------------

--- a/bokeh/themes/_caliber.py
+++ b/bokeh/themes/_caliber.py
@@ -1,4 +1,12 @@
-{
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2017, Anaconda, Inc. All rights reserved.
+#
+# Powered by the Bokeh Development Team.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+json = {
     "attrs": {
         "Axis": {
             "major_tick_in": 0,

--- a/bokeh/themes/_dark_minimal.py
+++ b/bokeh/themes/_dark_minimal.py
@@ -1,4 +1,12 @@
-{
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2017, Anaconda, Inc. All rights reserved.
+#
+# Powered by the Bokeh Development Team.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+json = {
     "attrs": {
         "Figure" : {
             "background_fill_color": "#20262B",

--- a/bokeh/themes/_light_minimal.py
+++ b/bokeh/themes/_light_minimal.py
@@ -1,4 +1,12 @@
-{
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2017, Anaconda, Inc. All rights reserved.
+#
+# Powered by the Bokeh Development Team.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+json = {
     "attrs": {
         "Axis": {
             "major_tick_line_alpha": 0,

--- a/bokeh/themes/theme.py
+++ b/bokeh/themes/theme.py
@@ -1,17 +1,50 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2017, Anaconda, Inc. All rights reserved.
+#
+# Powered by the Bokeh Development Team.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
 ''' Provide a ``Theme`` class for specifying new default values for Bokeh
 :class:`~bokeh.model.Model` properties.
 
 '''
-from __future__ import absolute_import, print_function
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import absolute_import, division, print_function, unicode_literals
 
+import logging
+log = logging.getLogger(__name__)
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
 import yaml
 
+# External imports
+
+# Bokeh imports
 from ..core.has_props import HasProps
+
+#-----------------------------------------------------------------------------
+# Globals and constants
+#-----------------------------------------------------------------------------
+
+__all__ = (
+    'Theme',
+)
 
 # whenever we cache that there's nothing themed for a class, we
 # use this same dict instance, so we don't have a zillion empty
 # dicts in our caches.
 _empty_dict = dict()
+
+#-----------------------------------------------------------------------------
+# General API
+#----------------------------------------------------------------------------
 
 # Note: in DirectoryHandler and in general we assume this is an
 # immutable object, because we share it among sessions and we
@@ -209,3 +242,15 @@ class Theme(object):
         # the dict.
         if len(_empty_dict) > 0:
             raise RuntimeError("Somebody put stuff in _empty_dict")
+
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Code
+#----------------------------------------------------------------------------

--- a/bokeh/themes/theme.py
+++ b/bokeh/themes/theme.py
@@ -46,6 +46,10 @@ _empty_dict = dict()
 # General API
 #----------------------------------------------------------------------------
 
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
 # Note: in DirectoryHandler and in general we assume this is an
 # immutable object, because we share it among sessions and we
 # don't monitor it for changes. If you make this mutable by adding
@@ -115,53 +119,6 @@ class Theme(object):
                     'text_color': 'white'
                 }
             }
-
-    Built-in-Themes:
-
-        .. bokeh-plot::
-
-            from bokeh.plotting import figure, output_file, show
-            from bokeh.themes import built_in_themes
-            from bokeh.io import curdoc
-
-            x = [1, 2, 3, 4, 5]
-            y = [6, 7, 6, 4, 5]
-
-            output_file("dark_minimal.html")
-            curdoc().theme = 'dark_minimal'
-            p = figure(title='dark_minimal', plot_width=300, plot_height=300)
-            p.line(x, y)
-            show(p)
-
-        .. bokeh-plot::
-
-            from bokeh.plotting import figure, output_file, show
-            from bokeh.themes import built_in_themes
-            from bokeh.io import curdoc
-
-            x = [1, 2, 3, 4, 5]
-            y = [6, 7, 6, 4, 5]
-
-            output_file("light_minimal.html")
-            curdoc().theme = 'light_minimal'
-            p = figure(title='light_minimal', plot_width=300, plot_height=300)
-            p.line(x, y)
-            show(p)
-
-        .. bokeh-plot::
-
-            from bokeh.plotting import figure, output_file, show
-            from bokeh.themes import built_in_themes
-            from bokeh.io import curdoc
-
-            x = [1, 2, 3, 4, 5]
-            y = [6, 7, 6, 4, 5]
-
-            output_file("caliber.html")
-            curdoc().theme = 'caliber'
-            p = figure(title='caliber', plot_width=300, plot_height=300)
-            p.line(x, y)
-            show(p)
 
     '''
     def __init__(self, filename=None, json=None):
@@ -242,10 +199,6 @@ class Theme(object):
         # the dict.
         if len(_empty_dict) > 0:
             raise RuntimeError("Somebody put stuff in _empty_dict")
-
-#-----------------------------------------------------------------------------
-# Dev API
-#-----------------------------------------------------------------------------
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/scripts/ci/install
+++ b/scripts/ci/install
@@ -22,6 +22,7 @@ fi
 # if emergency, temporary package pins are necessary, they can go here
 PINNED_PKGS=$(cat <<EOF
 EOF
+sphinx=1.7
 )
 mkdir -p $HOME/miniconda/conda-meta
 echo -e "$PINNED_PKGS" > $HOME/miniconda/conda-meta/pinned

--- a/sphinx/source/docs/reference/themes.rst
+++ b/sphinx/source/docs/reference/themes.rst
@@ -4,12 +4,3 @@ bokeh.themes
 ============
 
 .. automodule:: bokeh.themes
-  :members:
-
-.. _bokeh.themes.theme:
-
-bokeh.themes.theme
-------------------
-
-.. automodule:: bokeh.themes.theme
-  :members:


### PR DESCRIPTION
This PR moves the YAML theme definitions into strings in python modules, rather than external files. This is to support better integration with "freeze" tools like cx_freeze and pyinstaller. As a side effect it probably shaves a small amount off general import times 

This PR also pins sphinx to 1.7 as it was noticed 1.8 results in broken static image links. 