### PR TITLE
replace log.warn with log.warning

### DIFF
--- a/bokeh/application/handlers/directory.py
+++ b/bokeh/application/handlers/directory.py
@@ -97,7 +97,7 @@ class DirectoryHandler(Handler):
         main_py = join(src_path, 'main.py')
         main_ipy = join(src_path, 'main.ipynb')
         if exists(main_py) and exists(main_ipy):
-            log.warn("Found both 'main.py' and 'main.ipynb' in %s, using 'main.py'" % (src_path))
+            log.warning("Found both 'main.py' and 'main.ipynb' in %s, using 'main.py'" % (src_path))
             main = main_py
         elif exists(main_py):
             main = main_py

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -614,7 +614,7 @@ class Serve(Subcommand):
         def add_optional_autoreload_files(file_list):
             for filen in file_list:
                 if os.path.isdir(filen):
-                    log.warn("Cannot watch directory " + filen)
+                    log.warning("Cannot watch directory " + filen)
                     continue
                 log.info("Watching: " + filen)
                 watch(filen)

--- a/bokeh/core/has_props.py
+++ b/bokeh/core/has_props.py
@@ -324,7 +324,7 @@ class HasProps(with_metaclass(MetaHasProps, object)):
             descriptor = self.lookup(name)
             descriptor.set_from_json(self, json, models, setter)
         else:
-            log.warn("JSON had attr %r on obj %r, which is a client-only or invalid attribute that shouldn't have been sent", name, self)
+            log.warning("JSON had attr %r on obj %r, which is a client-only or invalid attribute that shouldn't have been sent", name, self)
 
     def update(self, **kwargs):
         ''' Updates the object's properties from the given keyword arguments.

--- a/bokeh/embed/util.py
+++ b/bokeh/embed/util.py
@@ -251,7 +251,7 @@ def standalone_docs_json_and_render_items(models, suppress_callback_warning=Fals
         raise ValueError("Expected a Model, Document, or Sequence of Models or Documents")
 
     if submodel_has_python_callbacks(models) and not suppress_callback_warning:
-        log.warn(_CALLBACKS_WARNING)
+        log.warning(_CALLBACKS_WARNING)
 
     docs = {}
     for model_or_doc in models:

--- a/bokeh/io/export.py
+++ b/bokeh/io/export.py
@@ -121,7 +121,7 @@ def export_svgs(obj, filename=None, height=None, width=None, webdriver=None):
     svgs = get_svgs(obj, height=height, width=width, driver=webdriver)
 
     if len(svgs) == 0:
-        log.warn("No SVG Plots were found.")
+        log.warning("No SVG Plots were found.")
         return
 
     if filename is None:
@@ -273,14 +273,14 @@ def wait_until_render_complete(driver):
     try:
         WebDriverWait(driver, 5, poll_frequency=0.1).until(is_bokeh_render_complete)
     except TimeoutException:
-        log.warn("The webdriver raised a TimeoutException while waiting for \
+        log.warning("The webdriver raised a TimeoutException while waiting for \
                      a 'bokeh:idle' event to signify that the layout has rendered. \
                      Something may have gone wrong.")
     finally:
         browser_logs = driver.get_log('browser')
         severe_errors = [l for l in browser_logs if l.get('level') == 'SEVERE']
         if len(severe_errors) > 0:
-            log.warn("There were severe browser errors that may have affected your export: {}".format(severe_errors))
+            log.warning("There were severe browser errors that may have affected your export: {}".format(severe_errors))
 
 def create_webdriver():
     with warnings.catch_warnings():

--- a/bokeh/server/contexts.py
+++ b/bokeh/server/contexts.py
@@ -231,7 +231,7 @@ class ApplicationContext(object):
                 del self._session_contexts[session.id]
                 log.trace("Session %r was successfully discarded", session.id)
             else:
-                log.warn("Session %r was scheduled to discard but came back to life", session.id)
+                log.warning("Session %r was scheduled to discard but came back to life", session.id)
         yield session.with_document_locked(do_discard)
 
         # session lifecycle hooks are supposed to be called outside the document lock,

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -199,7 +199,7 @@ class BokehTornado(TornadoApplication):
             raise ValueError("mem_log_frequency_milliseconds must be >= 0")
         elif mem_log_frequency_milliseconds > 0:
             if import_optional('psutil') is None:
-                log.warn("Memory logging requested, but is disabled. Optional dependency 'psutil' is missing. "
+                log.warning("Memory logging requested, but is disabled. Optional dependency 'psutil' is missing. "
                          "Try 'pip install psutil' or 'conda install psutil'")
                 mem_log_frequency_milliseconds = 0
             elif mem_log_frequency_milliseconds != DEFAULT_MEM_LOG_FREQ_MS:

--- a/bokeh/server/views/ws.py
+++ b/bokeh/server/views/ws.py
@@ -221,7 +221,7 @@ class WSHandler(WebSocketHandler):
             yield message.send(self)
         except (WebSocketClosedError, StreamClosedError): # Tornado 4.x may raise StreamClosedError
             # on_close() is / will be called anyway
-            log.warn("Failed sending message as connection was closed")
+            log.warning("Failed sending message as connection was closed")
         raise gen.Return(None)
 
     @gen.coroutine


### PR DESCRIPTION
Noticed in test output that `log.warn` is deprecated. This PR replaces all instances with `log.warning` as indicated. 