### PR TITLE
Allow loading cached compiled models using hook

### DIFF
--- a/bokeh/util/compiler.py
+++ b/bokeh/util/compiler.py
@@ -364,18 +364,20 @@ class CustomModel(object):
     def module(self):
         return "custom/%s" % snakify(self.full_name)
 
-def _model_cache_no_op(implementation):
+def _model_cache_no_op(model, implementation):
     """Return cached compiled implementation"""
     return None
 
 _CACHING_IMPLEMENTATION = _model_cache_no_op
 
 def get_cache_hook():
-    '''Returns the current cache hook used to look up the compiled code given an Implementation'''
+    '''Returns the current cache hook used to look up the compiled
+       code given the CustomModel and Implementation'''
     return _CACHING_IMPLEMENTATION
 
 def set_cache_hook(hook):
-    '''Sets a compiled model cache hook used to look up the compiled code given an Implementation'''
+    '''Sets a compiled model cache hook used to look up the compiled
+       code given the CustomModel and Implementation'''
     global _CACHING_IMPLEMENTATION
     _CACHING_IMPLEMENTATION = hook
 
@@ -408,7 +410,7 @@ def _compile_models(custom_models):
 
     for model in ordered_models:
         impl = model.implementation
-        compiled = _CACHING_IMPLEMENTATION(impl)
+        compiled = _CACHING_IMPLEMENTATION(model, impl)
         if compiled is None:
             compiled = nodejs_compile(impl.code, lang=impl.lang, file=impl.file)
 

--- a/bokeh/util/compiler.py
+++ b/bokeh/util/compiler.py
@@ -378,9 +378,20 @@ def _get_custom_models(models):
         return None
     return custom_models
 
-def _get_cached_implementation(implementation):
+def _model_cache_no_op(implementation):
     """Return cached compiled implementation"""
     return None
+
+_CACHING_IMPLEMENTATION = _model_cache_no_op
+
+def get_cache_hook():
+    '''Returns the current cache hook used to look up the compiled code given an Implementation'''
+    return _CACHING_IMPLEMENTATION
+
+def set_cache_hook(hook):
+    '''Sets a compiled model cache hook used to look up the compiled code given an Implementation'''
+    global _CACHING_IMPLEMENTATION
+    _CACHING_IMPLEMENTATION = hook
 
 def _compile_models(models):
     """Returns the compiled implementation of supplied `models`. """
@@ -401,7 +412,7 @@ def _compile_models(models):
 
     for model in ordered_models:
         impl = model.implementation
-        compiled = _get_cached_implementation(impl)
+        compiled = _CACHING_IMPLEMENTATION(impl)
         if compiled is None:
             compiled = nodejs_compile(impl.code, lang=impl.lang, file=impl.file)
 


### PR DESCRIPTION
Simplified implementation for loading cached compiled models until we settle on a public API. Works by allowing users to set a cache hook which should return the compiled code given the uncompiled implementation. Offers public methods to get and set this hook, available as:

```
bokeh.util.compiler.get_cache_hook
bokeh.util.compiler.set_cache_hook
```

Also splits the compilation code a bit so that it is easier for an external library to pre-compile a model and load it in the cache hook it registers.

- [x] issues: fixes #5345
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
