### PR TITLE
Add log1p option to LogScale

### DIFF
--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -438,7 +438,9 @@ class Plot(LayoutDOM):
         if scale in ["auto", "linear"]:
             return LinearScale()
         elif scale == "log":
-            return LogScale()
+            return LogScale(log_type='log')
+        elif scale == "log1p":
+            return LogScale(log_type='log1p')
         if scale == "categorical":
             return CategoricalScale()
         else:

--- a/bokeh/models/scales.py
+++ b/bokeh/models/scales.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 
 from ..core.has_props import abstract
+from ..core.properties import String
 from .transforms import Transform
 
 @abstract
@@ -40,7 +41,21 @@ class LogScale(Scale):
     '''
 
     '''
-    pass
+
+    log_type = String(help="""
+    An optional value specifying the type of log. Value values are:
+
+        log (default value)
+        log1p
+
+    """)
+    def __init__(self, *arg, **kw):
+        print(" in LogScale __init__:", kw)
+        super(LogScale, self).__init__(*arg, **kw)
+        if "log_type" in kw:
+            self.log_type = kw['log_type']
+        else:
+            self.log_type = 'log'
 
 class CategoricalScale(LinearScale):
     '''

--- a/bokeh/models/tests/test_plots.py
+++ b/bokeh/models/tests/test_plots.py
@@ -239,6 +239,7 @@ def test_plot__scale_classmethod():
     assert isinstance(Plot._scale("auto"), LinearScale)
     assert isinstance(Plot._scale("linear"), LinearScale)
     assert isinstance(Plot._scale("log"), LogScale)
+    assert isinstance(Plot._scale("log1p"), LogScale)
     assert isinstance(Plot._scale("categorical"), CategoricalScale)
     with pytest.raises(ValueError):
         Plot._scale("malformed_type")

--- a/bokeh/plotting/figure.py
+++ b/bokeh/plotting/figure.py
@@ -75,11 +75,11 @@ class FigureOptions(Options):
     Which tap tool should initially be active.
     """)
 
-    x_axis_type = Either(Auto, Enum("linear", "log", "datetime", "mercator"), default="auto", help="""
+    x_axis_type = Either(Auto, Enum("linear", "log", "log1p", "datetime", "mercator"), default="auto", help="""
     The type of the x-axis.
     """)
 
-    y_axis_type = Either(Auto, Enum("linear", "log", "datetime", "mercator"), default="auto", help="""
+    y_axis_type = Either(Auto, Enum("linear", "log", "log1p", "datetime", "mercator"), default="auto", help="""
     The type of the y-axis.
     """)
 

--- a/bokeh/plotting/helpers.py
+++ b/bokeh/plotting/helpers.py
@@ -363,7 +363,9 @@ def _get_scale(range_input, axis_type):
     if isinstance(range_input, (DataRange1d, Range1d)) and axis_type in ["linear", "datetime", "mercator", "auto", None]:
         return LinearScale()
     elif isinstance(range_input, (DataRange1d, Range1d)) and axis_type == "log":
-        return LogScale()
+        return LogScale(log_type = "log")
+    elif isinstance(range_input, (DataRange1d, Range1d)) and axis_type == "log1p":
+        return LogScale(log_type = "log1p")
     elif isinstance(range_input, FactorRange):
         return CategoricalScale()
     else:
@@ -375,7 +377,7 @@ def _get_axis_class(axis_type, range_input, dim):
         return None, {}
     elif axis_type == "linear":
         return LinearAxis, {}
-    elif axis_type == "log":
+    elif (axis_type == "log" or axis_type == "log1p"):
         return LogAxis, {}
     elif axis_type == "datetime":
         return DatetimeAxis, {}

--- a/bokehjs/src/lib/models/scales/log_scale.ts
+++ b/bokehjs/src/lib/models/scales/log_scale.ts
@@ -1,8 +1,12 @@
 import {Scale} from "./scale"
 import {Arrayable} from "core/types"
 
+import * as p from "core/properties"
+
 export namespace LogScale {
-  export interface Attrs extends Scale.Attrs {}
+  export interface Attrs extends Scale.Attrs {
+    log_type: String
+  }
 
   export interface Props extends Scale.Props {}
 }
@@ -19,6 +23,20 @@ export class LogScale extends Scale {
 
   static initClass(): void {
     this.prototype.type = "LogScale"
+    this.internal({
+      log_type: [ p.String ],
+    })
+  }
+
+  calculate_log(x: number): number {
+    let value: number
+    console.log(`log_type: ${this.log_type}`)
+    if (this.log_type == 'log1p')
+      value = Math.log1p(x)
+    else
+      value = Math.log(x)
+
+    return value
   }
 
   compute(x: number): number {
@@ -28,7 +46,7 @@ export class LogScale extends Scale {
     if (inter_factor == 0)
       value = 0
     else {
-      const _x = (Math.log(x) - inter_offset) / inter_factor
+      const _x = (this.calculate_log(x) - inter_offset) / inter_factor
       if (isFinite(_x))
         value = _x*factor + offset
       else
@@ -48,7 +66,7 @@ export class LogScale extends Scale {
         result[i] = 0
     } else {
       for (let i = 0; i < xs.length; i++) {
-        const _x = (Math.log(xs[i]) - inter_offset) / inter_factor
+        const _x = (this.calculate_log(xs[i]) - inter_offset) / inter_factor
         let value: number
         if (isFinite(_x))
           value = _x*factor + offset
@@ -85,7 +103,7 @@ export class LogScale extends Scale {
       if (start == 0)
         [start, end] = [1, 10]
       else {
-        const log_val = Math.log(start) / Math.log(10)
+        const log_val = this.calculate_log(start) / Math.log(10)
         start = Math.pow(10, Math.floor(log_val))
 
         if (Math.ceil(log_val) != Math.floor(log_val))
@@ -110,11 +128,11 @@ export class LogScale extends Scale {
     let inter_factor: number
     let inter_offset: number
     if (start == 0) {
-      inter_factor = Math.log(end)
+      inter_factor = this.calculate_log(end)
       inter_offset = 0
     } else {
-      inter_factor = Math.log(end) - Math.log(start)
-      inter_offset = Math.log(start)
+      inter_factor = this.calculate_log(end) - this.calculate_log(start)
+      inter_offset = this.calculate_log(start)
     }
 
     const factor = screen_range


### PR DESCRIPTION
Add option to `LogScale` to use `math.log1p` for situations where there is a zero value. Ex. A histogram with empty bins.

- [x] issues: fixes #6536
- [ ] tests added / passed

![image](https://user-images.githubusercontent.com/7515105/47177867-46132580-d2df-11e8-8e14-8f26c0875291.png)
