### PR TITLE
Bryanv/8348 better glyph source msg

### DIFF
--- a/bokeh/plotting/tests/test_figure.py
+++ b/bokeh/plotting/tests/test_figure.py
@@ -184,6 +184,17 @@ class TestFigure(object):
         df = pd.DataFrame({'x': [1, 2, 3], 'y': [2, 3, 4]})
         p.circle(x='x', y='y', source=df)
 
+    def test_glyph_method_errors_on_sequence_literals_with_source(self):
+        p = bpf.figure()
+        source = ColumnDataSource({'x': [1, 2, 3], 'y': [2, 3, 4]})
+
+        with pytest.raises(RuntimeError, match=r"Expected y to reference fields in the supplied data source."):
+            p.circle(x='x', y=[1,2,3], source=source)
+        with pytest.raises(RuntimeError, match=r"Expected y and line_color to reference fields in the supplied data source."):
+            p.circle(x='x', y=[1,2,3], line_color=["red", "green", "blue"], source=source)
+        with pytest.raises(RuntimeError, match=r"Expected y, fill_color and line_color to reference fields in the supplied data source."):
+            p.circle(x='x', y=[1,2,3], color=["red", "green", "blue"], source=source)
+
 class TestMarkers(object):
 
     @pytest.mark.parametrize('marker', list(MarkerType))

--- a/bokeh/plotting/tests/test_figure.py
+++ b/bokeh/plotting/tests/test_figure.py
@@ -1,4 +1,7 @@
 from __future__ import absolute_import
+
+import re
+
 import pytest
 
 from bokeh.core.enums import MarkerType
@@ -192,8 +195,11 @@ class TestFigure(object):
             p.circle(x='x', y=[1,2,3], source=source)
         with pytest.raises(RuntimeError, match=r"Expected y and line_color to reference fields in the supplied data source."):
             p.circle(x='x', y=[1,2,3], line_color=["red", "green", "blue"], source=source)
-        with pytest.raises(RuntimeError, match=r"Expected y, fill_color and line_color to reference fields in the supplied data source."):
+        with pytest.raises(RuntimeError) as e:
             p.circle(x='x', y=[1,2,3], color=["red", "green", "blue"], source=source)
+        m = re.search (r"Expected y, (.+) and (.+) to reference fields in the supplied data source.", str(e.value))
+        assert m is not None
+        assert set(m.groups()) == set(["fill_color", "line_color"])
 
 class TestMarkers(object):
 

--- a/bokeh/util/string.py
+++ b/bokeh/util/string.py
@@ -79,13 +79,15 @@ def indent(text, n=2, ch=" "):
     padding = ch * n
     return "\n".join(padding+line for line in text.split("\n"))
 
-def nice_join(seq, sep=", "):
+def nice_join(seq, sep=", ", conjuction="or"):
     ''' Join together sequences of strings into English-friendly phrases using
     the conjunction ``or`` when appropriate.
 
     Args:
         seq (seq[str]) : a sequence of strings to nicely join
         sep (str, optional) : a sequence delimiter to use (default: ", ")
+        conjunction (str or None, optional) : a conjuction to use for the last
+            two items, or None to reproduce basic join behaviour (default: "or")
 
     Returns:
         a joined string
@@ -97,10 +99,10 @@ def nice_join(seq, sep=", "):
     '''
     seq = [str(x) for x in seq]
 
-    if len(seq) <= 1:
+    if len(seq) <= 1 or conjuction is None:
         return sep.join(seq)
     else:
-        return "%s or %s" % (sep.join(seq[:-1]), seq[-1])
+        return "%s %s %s" % (sep.join(seq[:-1]), conjuction, seq[-1])
 
 def snakify(name, sep='_'):
     ''' Convert CamelCase to snake_case. '''

--- a/bokeh/util/tests/test_string.py
+++ b/bokeh/util/tests/test_string.py
@@ -59,6 +59,32 @@ class Test_indent(object):
     def test_with_ch(self):
         assert bus.indent(self.TEXT, ch="-") == "--some text\n--to indent\n--  goes here"
 
+class Test_nice_join(object):
+
+    def test_default(self):
+        assert bus.nice_join(["one"]) == "one"
+        assert bus.nice_join(["one", "two"]) == "one or two"
+        assert bus.nice_join(["one", "two", "three"]) == "one, two or three"
+        assert bus.nice_join(["one", "two", "three", "four"]) == "one, two, three or four"
+
+    def test_string_conjunction(self):
+        assert bus.nice_join(["one"], conjuction="and") == "one"
+        assert bus.nice_join(["one", "two"], conjuction="and") == "one and two"
+        assert bus.nice_join(["one", "two", "three"], conjuction="and") == "one, two and three"
+        assert bus.nice_join(["one", "two", "three", "four"], conjuction="and") == "one, two, three and four"
+
+    def test_None_conjunction(self):
+        assert bus.nice_join(["one"], conjuction=None) == "one"
+        assert bus.nice_join(["one", "two"], conjuction=None) == "one, two"
+        assert bus.nice_join(["one", "two", "three"], conjuction=None) == "one, two, three"
+        assert bus.nice_join(["one", "two", "three", "four"], conjuction=None) == "one, two, three, four"
+
+    def test_sep(self):
+        assert bus.nice_join(["one"], sep='; ') == "one"
+        assert bus.nice_join(["one", "two"], sep='; ') == "one or two"
+        assert bus.nice_join(["one", "two", "three"], sep='; ') == "one; two or three"
+        assert bus.nice_join(["one", "two", "three", "four"], sep="; ") == "one; two; three or four"
+
 def test_snakify():
     assert bus.snakify("MyClassName") == "my_class_name"
     assert bus.snakify("My1Class23Name456") == "my1_class23_name456"


### PR DESCRIPTION

- [x] issues: fixes #8348
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

cc @syhooper @jbednar @philippjfr 

Note one small thing, if a literal is passed fo the convenience param `"color"` then the error expands that and lists the actual property names instead:

> Expected y, fill_color and line_color to reference fields in the supplied data source.

I don't think that could be improved without adding a fair amount of complexity. 