### PR TITLE
Improved handling of DocumentLifeCycleHandler callbacks

### DIFF
--- a/bokeh/application/handlers/document_lifecycle.py
+++ b/bokeh/application/handlers/document_lifecycle.py
@@ -62,14 +62,23 @@ def _on_session_destroyed(session_context):
     '''
     Calls any on_session_destroyed callbacks defined on the Document
     '''
-    for callback in session_context._document._session_destroyed_callbacks:
+    callbacks = list(session_context._document._session_destroyed_callbacks)
+    session_context._document._session_destroyed_callbacks = {}
+    for callback in callbacks:
         try:
             callback(session_context)
         except Exception as e:
             log.warn('DocumentLifeCycleHandler on_session_destroyed '
-                     'callback failed on %s callback with following error: %s'
+                     'callback %s failed with following error: %s'
                      % (callback, e))
-    session_context._document._session_destroyed_callbacks = {}
+    if callbacks:
+        # If any session callbacks were defined garbage collect after
+        # deleting all references
+        del callback
+        del callbacks
+
+        import gc
+        gc.collect()
 
 #-----------------------------------------------------------------------------
 # Code

--- a/bokeh/application/handlers/document_lifecycle.py
+++ b/bokeh/application/handlers/document_lifecycle.py
@@ -62,8 +62,8 @@ def _on_session_destroyed(session_context):
     '''
     Calls any on_session_destroyed callbacks defined on the Document
     '''
-    callbacks = list(session_context._document._session_destroyed_callbacks)
-    session_context._document._session_destroyed_callbacks = {}
+    callbacks = session_context._document.session_destroyed_callbacks
+    session_context._document.session_destroyed_callbacks = {}
     for callback in callbacks:
         try:
             callback(session_context)

--- a/bokeh/application/handlers/document_lifecycle.py
+++ b/bokeh/application/handlers/document_lifecycle.py
@@ -72,8 +72,7 @@ def _on_session_destroyed(session_context):
                      'callback %s failed with following error: %s'
                      % (callback, e))
     if callbacks:
-        # If any session callbacks were defined garbage collect after
-        # deleting all references
+        # If any session callbacks were defined garbage collect after deleting all references
         del callback
         del callbacks
 

--- a/bokeh/application/handlers/document_lifecycle.py
+++ b/bokeh/application/handlers/document_lifecycle.py
@@ -63,7 +63,7 @@ def _on_session_destroyed(session_context):
     Calls any on_session_destroyed callbacks defined on the Document
     '''
     callbacks = session_context._document.session_destroyed_callbacks
-    session_context._document.session_destroyed_callbacks = {}
+    session_context._document.session_destroyed_callbacks = set()
     for callback in callbacks:
         try:
             callback(session_context)

--- a/bokeh/application/handlers/document_lifecycle.py
+++ b/bokeh/application/handlers/document_lifecycle.py
@@ -63,7 +63,13 @@ def _on_session_destroyed(session_context):
     Calls any on_session_destroyed callbacks defined on the Document
     '''
     for callback in session_context._document._session_destroyed_callbacks:
-        callback(session_context)
+        try:
+            callback(session_context)
+        except Exception as e:
+            log.warn('DocumentLifeCycleHandler on_session_destroyed '
+                     'callback failed on %s callback with following error: %s'
+                     % (callback, e))
+    session_context._document._session_destroyed_callbacks = {}
 
 #-----------------------------------------------------------------------------
 # Code

--- a/bokeh/application/handlers/tests/test_document_lifecycle.py
+++ b/bokeh/application/handlers/tests/test_document_lifecycle.py
@@ -75,7 +75,7 @@ class Test_DocumentLifecycleHandler(object):
         session_context = MockSessionContext(doc)
         handler.on_session_destroyed(session_context)
         assert session_context.status == 'Destroyed'
-        assert session_context._document._session_destroyed_callbacks == {}
+        assert session_context._document.session_destroyed_callbacks == []
 
     def test_document_on_session_destroyed_calls_multiple(self):
         doc = Document()

--- a/bokeh/application/handlers/tests/test_document_lifecycle.py
+++ b/bokeh/application/handlers/tests/test_document_lifecycle.py
@@ -75,7 +75,7 @@ class Test_DocumentLifecycleHandler(object):
         session_context = MockSessionContext(doc)
         handler.on_session_destroyed(session_context)
         assert session_context.status == 'Destroyed'
-        assert session_context._document.session_destroyed_callbacks == []
+        assert session_context._document.session_destroyed_callbacks == set()
 
     def test_document_on_session_destroyed_calls_multiple(self):
         doc = Document()

--- a/bokeh/application/handlers/tests/test_document_lifecycle.py
+++ b/bokeh/application/handlers/tests/test_document_lifecycle.py
@@ -75,6 +75,7 @@ class Test_DocumentLifecycleHandler(object):
         session_context = MockSessionContext(doc)
         handler.on_session_destroyed(session_context)
         assert session_context.status == 'Destroyed'
+        assert session_context._document._session_destroyed_callbacks == {}
 
     def test_document_on_session_destroyed_calls_multiple(self):
         doc = Document()

--- a/bokeh/document/document.py
+++ b/bokeh/document/document.py
@@ -101,7 +101,7 @@ class Document(object):
         self._all_models_by_name = MultiValuedDict()
         self._all_former_model_ids = set()
         self._callbacks = {}
-        self._session_destroyed_callbacks = {}
+        self._session_destroyed_callbacks = set()
         self._session_callbacks = set()
         self._session_context = None
         self._modules = []
@@ -137,7 +137,7 @@ class Document(object):
         ''' A list of all the on_session_destroyed callbacks on this document.
 
         '''
-        return list(self._session_destroyed_callbacks)
+        return self._session_destroyed_callbacks
 
     @session_destroyed_callbacks.setter
     def session_destroyed_callbacks(self, callbacks):
@@ -675,7 +675,7 @@ class Document(object):
         '''
         for callback in callbacks:
             _check_callback(callback, ('session_context',))
-            self._session_destroyed_callbacks[callback] = callback
+            self._session_destroyed_callbacks.add(callback)
 
     def remove_next_tick_callback(self, callback_obj):
         ''' Remove a callback added earlier with ``add_next_tick_callback``.

--- a/bokeh/document/document.py
+++ b/bokeh/document/document.py
@@ -133,6 +133,17 @@ class Document(object):
         return list(self._session_callbacks)
 
     @property
+    def session_destroyed_callbacks(self):
+        ''' A list of all the on_session_destroyed callbacks on this document.
+
+        '''
+        return list(self._session_destroyed_callbacks)
+
+    @session_destroyed_callbacks.setter
+    def session_destroyed_callbacks(self, callbacks):
+        self._session_destroyed_callbacks = callbacks
+
+    @property
     def session_context(self):
         ''' The ``SessionContext`` for this document.
 


### PR DESCRIPTION
Handles exceptions in Document.on_session_destroyed callbacks and discards them once they have been processed.

- [x] issues: fixes #8367
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
