### PR TITLE
Make BokehJS prop.spec Private

### DIFF
--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -520,7 +520,7 @@ export abstract class HasProps extends Signalable() {
       // store under the canonical field name, e.g. _image_shape, even if the column name is "foo"
       if (prop.spec.field != null && prop.spec.field in source._shapes)
         data[`_${name}_shape`] = source._shapes[prop.spec.field]
-      if (prop instanceof p.Distance)
+      if (prop instanceof p.DistanceSpec)
         data[`max_${name}`] = max(data[`_${name}`])
     }
     return data

--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -204,7 +204,7 @@ export abstract class HasProps extends Signalable() {
     for (const name in this.properties) {
       const prop = this.properties[name]
       prop.update()
-      if (prop.spec.transform != null)
+      if (prop.dataspec && prop.spec.transform != null)
         this.connect(prop.spec.transform.change, () => this.transformchange.emit())
     }
 

--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -512,7 +512,7 @@ export abstract class HasProps extends Signalable() {
       if (!prop.dataspec)
         continue
       // this skips optional properties like radius for circles
-      if (prop.optional && prop.spec.value == null && !(name in this._set_after_defaults))
+      if (prop.optional && prop.value_optional() == null && !(name in this._set_after_defaults))
         continue
 
       data[`_${name}`] = prop.array(source)

--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -204,8 +204,13 @@ export abstract class HasProps extends Signalable() {
     for (const name in this.properties) {
       const prop = this.properties[name]
       prop.update()
-      if (prop.dataspec && prop.spec.transform != null)
-        this.connect(prop.spec.transform.change, () => this.transformchange.emit())
+
+      if (!prop.dataspec)
+        continue
+
+      const transform = prop.get_transform()
+      if (transform != null)
+        this.connect(transform.change, () => this.transformchange.emit())
     }
 
     this.initialize()
@@ -511,6 +516,7 @@ export abstract class HasProps extends Signalable() {
       const prop = this.properties[name]
       if (!prop.dataspec)
         continue
+
       // this skips optional properties like radius for circles
       if (prop.optional && prop.value_optional() == null && !(name in this._set_after_defaults))
         continue
@@ -518,8 +524,9 @@ export abstract class HasProps extends Signalable() {
       data[`_${name}`] = prop.array(source)
       // the shapes are indexed by the column name, but when we materialize the dataspec, we should
       // store under the canonical field name, e.g. _image_shape, even if the column name is "foo"
-      if (prop.spec.field != null && prop.spec.field in source._shapes)
-        data[`_${name}_shape`] = source._shapes[prop.spec.field]
+      const field = prop.get_field()
+      if (field != null && field in source._shapes)
+        data[`_${name}_shape`] = source._shapes[field]
       if (prop instanceof p.DistanceSpec)
         data[`max_${name}`] = max(data[`_${name}`])
     }

--- a/bokehjs/src/lib/core/properties.ts
+++ b/bokehjs/src/lib/core/properties.ts
@@ -182,6 +182,7 @@ export const Int = Number
 export class Percent extends simple_prop("Number", (x) => (isNumber(x) || isBoolean(x)) && 0 <= x && x <= 1.0) {}
 
 export class String extends simple_prop("String", isString) {}
+export const FontSize = String
 
 // TODO (bev) don't think this exists python side
 export class Font extends String {}

--- a/bokehjs/src/lib/core/properties.ts
+++ b/bokehjs/src/lib/core/properties.ts
@@ -287,8 +287,6 @@ export class Angle extends units_prop("Angle", enums.AngleUnits, "rad") {
   }
 }
 
-export class Distance extends units_prop("Distance", enums.SpatialUnits, "data") {}
-
 //
 // DataSpec properties
 //
@@ -299,7 +297,7 @@ AngleSpec.prototype.dataspec = true
 export class ColorSpec extends Color {}
 ColorSpec.prototype.dataspec = true
 
-export class DistanceSpec extends Distance {}
+export class DistanceSpec extends units_prop("DistanceSpec", enums.SpatialUnits, "data") {}
 DistanceSpec.prototype.dataspec = true
 
 export class FontSizeSpec extends String {}

--- a/bokehjs/src/lib/core/properties.ts
+++ b/bokehjs/src/lib/core/properties.ts
@@ -177,6 +177,8 @@ export class Instance extends simple_prop("Instance", (x) => x.properties != nul
 export class Number extends simple_prop("Number", (x) => isNumber(x) || isBoolean(x)) {}
 export const Int = Number
 
+export class Angle extends Number {}
+
 // TODO extend Number instead of copying it's predicate
 //class Percent extends Number("Percent", (x) -> 0 <= x <= 1.0)
 export class Percent extends simple_prop("Number", (x) => (isNumber(x) || isBoolean(x)) && 0 <= x && x <= 1.0) {}
@@ -279,21 +281,18 @@ export function units_prop<Units>(name: string, valid_units: Units[], default_un
   }
 }
 
-export class Angle extends units_prop("Angle", enums.AngleUnits, "rad") {
+//
+// DataSpec properties
+//
+
+export class AngleSpec extends units_prop("AngleSpec", enums.AngleUnits, "rad") {
   transform(values: Arrayable): Arrayable {
     if (this.spec.units == "deg")
       values = map(values, (x: number) => x * Math.PI/180.0)
     values = map(values, (x: number) => -x)
     return super.transform(values)
   }
-}
-
-//
-// DataSpec properties
-//
-
-export class AngleSpec extends Angle {}
-AngleSpec.prototype.dataspec = true
+}AngleSpec.prototype.dataspec = true
 
 export class ColorSpec extends Color {}
 ColorSpec.prototype.dataspec = true

--- a/bokehjs/src/lib/core/properties.ts
+++ b/bokehjs/src/lib/core/properties.ts
@@ -279,10 +279,10 @@ export class StartEnd extends enum_prop("StartEnd", enums.StartEnd) {}
 export function units_prop<Units>(name: string, valid_units: Units[], default_units: any) {
   return class extends Number {
     init(): void {
-      if (this.spec.units == null)
-        this.spec.units = default_units
+      if (this.units == null)
+        this.units = default_units
 
-      const units = this.spec.units
+      const units = this.units
       if (!includes(valid_units, units))
         throw new Error(`${name} units must be one of ${valid_units}, given invalid value: ${units}`)
     }
@@ -303,7 +303,7 @@ export function units_prop<Units>(name: string, valid_units: Units[], default_un
 
 export class AngleSpec extends units_prop("AngleSpec", enums.AngleUnits, "rad") {
   transform(values: Arrayable): Arrayable {
-    if (this.spec.units == "deg")
+    if (this.units == "deg")
       values = map(values, (x: number) => x * Math.PI/180.0)
     values = map(values, (x: number) => -x)
     return super.transform(values)

--- a/bokehjs/src/lib/core/properties.ts
+++ b/bokehjs/src/lib/core/properties.ts
@@ -81,9 +81,10 @@ export class Property<T> extends Signalable() {
       return this.transform([this.obj.getv(this.attr)])[0]
     }
 
-    if (this.spec.value === undefined)
+    const value = this.spec.value
+    if (value === undefined)
      return undefined
-    let ret = this.transform([this.spec.value])[0]
+    let ret = this.transform([value])[0]
     if (this.spec.transform != null && do_spec_transform)
       ret = this.spec.transform.compute(ret)
     return ret
@@ -150,8 +151,9 @@ export class Property<T> extends Signalable() {
       if (this.spec.field != null && !isString(this.spec.field))
         throw new Error(`field value for dataspec property '${attr}' is not a string`)
 
-      if (this.spec.value != null)
-        this.validate(this.spec.value)
+      const value = this.value_optional()
+      if (value != null)
+        this.validate(value)
     }
 
     this.init()

--- a/bokehjs/src/lib/core/properties.ts
+++ b/bokehjs/src/lib/core/properties.ts
@@ -75,14 +75,24 @@ export class Property<T> extends Signalable() {
 
   // ----- property accessors
 
-  value(do_spec_transform: boolean = true): any {
+  // this function will return undefined without error if there is no value defined
+  value_optional(do_spec_transform: boolean = true): any {
     if (this.spec.value === undefined)
-      throw new Error("attempted to retrieve property value for property without value specification")
+     return undefined
     let ret = this.transform([this.spec.value])[0]
     if (this.spec.transform != null && do_spec_transform)
       ret = this.spec.transform.compute(ret)
     return ret
   }
+
+  // this function will raise an error if there is no value defined
+  value(do_spec_transform: boolean = true): any {
+    const ret = this.value_optional(do_spec_transform)
+    if (ret === undefined)
+      throw new Error(`attempted to retrieve property value for '${this.attr}' which has no value specification`)
+    return ret
+  }
+
 
   array(source: ColumnarDataSource): any[] {
     if (!this.dataspec)

--- a/bokehjs/src/lib/core/properties.ts
+++ b/bokehjs/src/lib/core/properties.ts
@@ -32,7 +32,7 @@ export function isSpec(obj: any): boolean {
 
 export class Property<T> extends Signalable() {
 
-  spec: {
+  _spec: {
     value?: any
     field?: string
     expr?: any
@@ -81,7 +81,7 @@ export class Property<T> extends Signalable() {
       return this.transform([this.obj.getv(this.attr)])[0]
     }
 
-    const value = this.spec.value
+    const value = this._spec.value
     if (value === undefined)
      return undefined
 
@@ -135,19 +135,19 @@ export class Property<T> extends Signalable() {
   get_expr(): any {
     if (!this.dataspec)
       throw new Error("attempted to retrieve dataspec expr for non-dataspec property")
-    return this.spec.expr
+    return this._spec.expr
   }
 
   get_field(): any {
     if (!this.dataspec)
       throw new Error("attempted to retrieve dataspec field for non-dataspec property")
-    return this.spec.field
+    return this._spec.field
   }
 
   get_transform(): any {
     if (!this.dataspec)
       throw new Error("attempted to retrieve dataspec transform for non-dataspec property")
-    return this.spec.transform
+    return this._spec.transform
   }
 
   // ----- private methods
@@ -168,11 +168,11 @@ export class Property<T> extends Signalable() {
 
     if (this.dataspec) {
       if (isArray(attr_value))
-        this.spec = {value: attr_value}
+        this._spec = {value: attr_value}
       else if (isSpec(attr_value))
-        this.spec = attr_value
+        this._spec = attr_value
       else
-        this.spec = {value: attr_value}
+        this._spec = {value: attr_value}
 
       const field = this.get_field()
       if (field != null && !isString(field))
@@ -188,7 +188,7 @@ export class Property<T> extends Signalable() {
 
   toString(): string {
     /*${this.name}*/
-    return `Prop(${this.obj}.${this.attr}, spec: ${valueToString(this.spec)})`
+    return `Prop(${this.obj}.${this.attr}, spec: ${valueToString(this._spec)})`
   }
 }
 
@@ -317,11 +317,11 @@ export function units_prop<Units>(name: string, valid_units: Units[], default_un
     }
 
     get units(): Units {
-      return this.spec.units as Units
+      return this._spec.units as Units
     }
 
     set units(units: Units) {
-      this.spec.units = units
+      this._spec.units = units
     }
   }
 }

--- a/bokehjs/src/lib/core/util/serialization.ts
+++ b/bokehjs/src/lib/core/util/serialization.ts
@@ -99,18 +99,18 @@ export interface BufferSpec {
   shape: Shape
 }
 
-export function process_buffer(spec: BufferSpec, buffers: [any, any][]): [TypedArray, Shape] {
-  const need_swap = spec.order !== BYTE_ORDER
-  const {shape} = spec
+export function process_buffer(specification: BufferSpec, buffers: [any, any][]): [TypedArray, Shape] {
+  const need_swap = specification.order !== BYTE_ORDER
+  const {shape} = specification
   let bytes = null
   for (const buf of buffers) {
     const header = JSON.parse(buf[0])
-    if (header.id === spec.__buffer__) {
+    if (header.id === specification.__buffer__) {
       bytes = buf[1]
       break
     }
   }
-  const arr = new (ARRAY_TYPES[spec.dtype])(bytes)
+  const arr = new (ARRAY_TYPES[specification.dtype])(bytes)
   if (need_swap) {
     if (arr.BYTES_PER_ELEMENT === 2) {
       swap16(arr)

--- a/bokehjs/src/lib/core/visuals.ts
+++ b/bokehjs/src/lib/core/visuals.ts
@@ -30,8 +30,8 @@ export abstract class ContextProperties {
   warm_cache(source?: ColumnarDataSource): void {
     for (const attr of this.attrs) {
       const prop = this.obj.properties[this.prefix + attr]
-      if (prop.spec.value !== undefined) // TODO (bev) better test?
-        this.cache[attr] = prop.spec.value
+      if (!prop.dataspec)
+        this.cache[attr] = prop.value()
       else if (source != null)
         this.cache[attr + "_array"] = prop.array(source)
       else
@@ -42,8 +42,8 @@ export abstract class ContextProperties {
   cache_select(attr: string, i: number): any {
     const prop = this.obj.properties[this.prefix + attr]
     let value: any
-    if (prop.spec.value !== undefined) // TODO (bev) better test?
-      this.cache[attr] = value = prop.spec.value
+    if (!prop.dataspec)
+      this.cache[attr] = prop.value()
     else
       this.cache[attr] = value = this.cache[attr + "_array"][i]
     return value

--- a/bokehjs/src/lib/core/visuals.ts
+++ b/bokehjs/src/lib/core/visuals.ts
@@ -222,8 +222,8 @@ Text.prototype.do_attr = "text_color"
 export class Visuals {
 
   constructor(model: HasProps) {
-    for (const spec of model.mixins) {
-      const [name, prefix=""] = spec.split(":")
+    for (const mixin of model.mixins) {
+      const [name, prefix=""] = mixin.split(":")
       let cls: Class<ContextProperties>
       switch (name) {
         case "line": cls = Line; break

--- a/bokehjs/src/lib/core/visuals.ts
+++ b/bokehjs/src/lib/core/visuals.ts
@@ -43,7 +43,7 @@ export abstract class ContextProperties {
     const prop = this.obj.properties[this.prefix + attr]
     let value: any
     if (!prop.dataspec)
-      this.cache[attr] = prop.value()
+      this.cache[attr] = value = prop.value()
     else
       this.cache[attr] = value = this.cache[attr + "_array"][i]
     return value

--- a/bokehjs/src/lib/core/visuals.ts
+++ b/bokehjs/src/lib/core/visuals.ts
@@ -20,8 +20,8 @@ export abstract class ContextProperties {
   all_indices: number[]
 
   constructor(readonly obj: HasProps, readonly prefix: string = "") {
-    const do_spec = obj.properties[prefix + this.do_attr].spec
-    this.doit = do_spec.value !== null // XXX: can't be `undefined`, see TODOs below.
+    const prop = obj.properties[prefix + this.do_attr]
+    this.doit = prop.value_optional() !== null // could possibly be undefined
 
     for (const attr of this.attrs)
       (this as any)[attr] = obj.properties[prefix + attr]

--- a/bokehjs/src/lib/models/glyphs/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/circle.ts
@@ -33,8 +33,8 @@ export class CircleView extends XYGlyphView {
     // XXX: Order is important here: size is always present (at least
     // a default), but radius is only present if a user specifies it.
     if (this._radius != null) {
-      if (this.model.properties.radius.spec.units == "data") {
-        const rd = this.model.properties.radius_dimension.spec.value
+      if (this.model.properties.radius.units == "data") {
+        const rd = this.model.properties.radius_dimension.value()
         switch (rd) {
           case "x": {
             this.sradius = this.sdist(this.renderer.xscale, this._x, this._radius)

--- a/bokehjs/src/lib/models/glyphs/webgl/base.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/base.ts
@@ -103,9 +103,7 @@ export function fill_array_with_vec(n: number, m: number, val: Arrayable<number>
 }
 
 export function visual_prop_is_singular(visual: any, propname: string): boolean {
-  // This touches the internals of the visual, so we limit use in this function
-  // See renderer.ts:cache_select() for similar code
-  return visual[propname].spec.value !== undefined
+  return visual[propname].value_optional() !== undefined
 }
 
 export function attach_float(prog: Program, vbo: VertexBuffer & {used?: boolean}, att_name: string, n: number, visual: any, name: string): void {

--- a/bokehjs/src/lib/models/widgets/abstract_slider.ts
+++ b/bokehjs/src/lib/models/widgets/abstract_slider.ts
@@ -97,8 +97,8 @@ export abstract class AbstractSliderView extends WidgetView {
 
       // Add keyboard support
       const keypress = (e: KeyboardEvent): void => {
-        const spec = this._calc_to()
-        let value = spec.value[0]
+        const current = this._calc_to()
+        let value = current.value[0]
         switch (e.which) {
           case 37: {
             value = Math.max(value - step, start)

--- a/bokehjs/test/core/properties.coffee
+++ b/bokehjs/test/core/properties.coffee
@@ -157,7 +157,27 @@ describe "properties module", ->
         fn = ->
           prop = new properties.Property(new SomeHasProps(spec_field_only), 'a')
           prop.value()
-        expect(fn).to.throw Error, "attempted to retrieve property value for property without value specification"
+        expect(fn).to.throw Error, "attempted to retrieve property value for 'a' which has no value specification"
+
+    describe "value_optional", ->
+      it "should return a value if there is a value spec", ->
+        prop = new properties.Property(new SomeHasProps(fixed), 'a')
+        expect(prop.value_optional()).to.be.equal 1
+        prop = new properties.Property(new SomeHasProps(spec_value), 'a')
+        expect(prop.value_optional()).to.be.equal 2
+
+      it "should return a transformed value if there is a value spec with transform", ->
+        prop = new properties.Property(new SomeHasProps(spec_value_trans), 'a')
+        expect(prop.value_optional()).to.be.equal 3
+
+      it "should allow a fixed null value", ->
+        prop = new properties.Property(new SomeHasProps(spec_value_null), 'a')
+        expect(prop.value_optional()).to.be.equal null
+
+      it "should return undefined", ->
+        prop = new properties.Property(new SomeHasProps(spec_field_only), 'a')
+        expect(prop.value_optional()).to.be.equal undefined
+
 
     describe "array", ->
 

--- a/bokehjs/test/core/properties.coffee
+++ b/bokehjs/test/core/properties.coffee
@@ -334,31 +334,19 @@ describe "properties module", ->
       prop = new properties.Angle(new SomeHasProps(a: {value: 10}), 'a')
       expect(prop).to.be.instanceof properties.Number
 
-    describe "units", ->
-      it "should default to rad units", ->
+    describe "transform", ->
+      it "should be Property.transform", ->
         prop = new properties.Angle(new SomeHasProps(a: {value: 10}), 'a')
-        expect(prop.spec.units).to.be.equal "rad"
+        expect(prop.transform).to.be.equal properties.Property.prototype.transform
 
-      it "should accept deg units", ->
-        prop = new properties.Angle(new SomeHasProps(a: {value: 10, units:"deg"}), 'a')
-        expect(prop.spec.units).to.be.equal "deg"
-
-      it "should accept rad units", ->
-        prop = new properties.Angle(new SomeHasProps(a: {value: 10, units:"rad"}), 'a')
-        expect(prop.spec.units).to.be.equal "rad"
-
-      it "should throw an Error on bad units", ->
-        fn = ->
-          prop = new properties.Angle(new SomeHasProps(a: {value: 10, units:"bad"}), 'a')
-        expect(fn).to.throw Error, "Angle units must be one of deg,rad, given invalid value: bad"
-
+  describe "AngleSpec", ->
     describe "transform", ->
       it "should multiply radians by -1", ->
-        prop = new properties.Angle(new SomeHasProps(a: {value: 10, units: "rad"}), 'a')
+        prop = new properties.AngleSpec(new SomeHasProps(a: {value: 10, units: "rad"}), 'a')
         expect(prop.transform([-10, 0, 10, 20])).to.be.deep.equal [10, -0, -10, -20]
 
       it "should convert degrees to -1 * radians", ->
-        prop = new properties.Angle(new SomeHasProps(a: {value: 10, units: "deg"}), 'a')
+        prop = new properties.AngleSpec(new SomeHasProps(a: {value: 10, units: "deg"}), 'a')
         expect(prop.transform([-180, 0, 180])).to.be.deep.equal [Math.PI, -0, -Math.PI]
 
   describe "Array", ->

--- a/bokehjs/test/core/properties.coffee
+++ b/bokehjs/test/core/properties.coffee
@@ -542,15 +542,15 @@ describe "properties module", ->
     describe "units", ->
       it "should default to data units", ->
         prop = new properties.DistanceSpec(new SomeHasProps(a: {value: 10}), 'a')
-        expect(prop.spec.units).to.be.equal "data"
+        expect(prop.units).to.be.equal "data"
 
       it "should accept screen units", ->
         prop = new properties.DistanceSpec(new SomeHasProps(a: {value: 10, units:"screen"}), 'a')
-        expect(prop.spec.units).to.be.equal "screen"
+        expect(prop.units).to.be.equal "screen"
 
       it "should accept data units", ->
         prop = new properties.DistanceSpec(new SomeHasProps(a: {value: 10, units:"data"}), 'a')
-        expect(prop.spec.units).to.be.equal "data"
+        expect(prop.units).to.be.equal "data"
 
       it "should throw an Error on bad units", ->
         fn = ->

--- a/bokehjs/test/core/properties.coffee
+++ b/bokehjs/test/core/properties.coffee
@@ -149,13 +149,13 @@ describe "properties module", ->
 
       it "should set a spec for object attr values", ->
         p = new DataSpecProperty(new SomeHasProps(a: {field: "foo"}), 'a')
-        expect(p.spec).to.be.deep.equal {field: "foo"}
+        expect(p._spec).to.be.deep.equal {field: "foo"}
         p = new DataSpecProperty(new SomeHasProps(a: {value: "foo"}), 'a')
-        expect(p.spec).to.be.deep.equal {value: "foo"}
+        expect(p._spec).to.be.deep.equal {value: "foo"}
 
       it "should set a value spec for non-object attr values", ->
         p = new DataSpecProperty(new SomeHasProps(a: 10), 'a')
-        expect(p.spec).to.be.deep.equal {value: 10}
+        expect(p._spec).to.be.deep.equal {value: 10}
 
     describe "value", ->
       it "should return a value if there is a value spec", ->
@@ -331,7 +331,7 @@ describe "properties module", ->
         obj = new SomeSpecHasProps(a: {value: 10})
         prop = obj.properties.a
         obj.a = {value: 20}
-        expect(prop.spec).to.be.deep.equal {value: 20}
+        expect(prop._spec).to.be.deep.equal {value: 20}
 
   describe "Anchor", ->
     prop = new properties.Anchor(new SomeHasProps(a: {value: "top_left"}), 'a')

--- a/bokehjs/test/core/properties.coffee
+++ b/bokehjs/test/core/properties.coffee
@@ -506,33 +506,33 @@ describe "properties module", ->
         result = prop.transform ["clock", "anticlock"]
         expect(result).to.be.deep.equal new Uint8Array [0, 1]
 
-  describe "Distance", ->
+  describe "DistanceSpec", ->
 
     it "should be an instance of Number", ->
-      prop = new properties.Distance(new SomeHasProps(a: {value: 10}), 'a')
+      prop = new properties.DistanceSpec(new SomeHasProps(a: {value: 10}), 'a')
       expect(prop).to.be.instanceof properties.Number
 
     describe "units", ->
       it "should default to data units", ->
-        prop = new properties.Distance(new SomeHasProps(a: {value: 10}), 'a')
+        prop = new properties.DistanceSpec(new SomeHasProps(a: {value: 10}), 'a')
         expect(prop.spec.units).to.be.equal "data"
 
       it "should accept screen units", ->
-        prop = new properties.Distance(new SomeHasProps(a: {value: 10, units:"screen"}), 'a')
+        prop = new properties.DistanceSpec(new SomeHasProps(a: {value: 10, units:"screen"}), 'a')
         expect(prop.spec.units).to.be.equal "screen"
 
       it "should accept data units", ->
-        prop = new properties.Distance(new SomeHasProps(a: {value: 10, units:"data"}), 'a')
+        prop = new properties.DistanceSpec(new SomeHasProps(a: {value: 10, units:"data"}), 'a')
         expect(prop.spec.units).to.be.equal "data"
 
       it "should throw an Error on bad units", ->
         fn = ->
-          prop = new properties.Distance(new SomeHasProps(a: {value: 10, units:"bad"}), 'a')
-        expect(fn).to.throw Error, "Distance units must be one of screen,data, given invalid value: bad"
+          prop = new properties.DistanceSpec(new SomeHasProps(a: {value: 10, units:"bad"}), 'a')
+        expect(fn).to.throw Error, "DistanceSpec units must be one of screen,data, given invalid value: bad"
 
     describe "transform", ->
       it "should be Property.transform", ->
-        prop = new properties.Distance(new SomeHasProps(a: {value: 10}), 'a')
+        prop = new properties.DistanceSpec(new SomeHasProps(a: {value: 10}), 'a')
         expect(prop.transform).to.be.equal properties.Property.prototype.transform
 
   describe "Font", ->
@@ -810,7 +810,6 @@ describe "properties module", ->
       expect("Color" of properties).to.be.true
       expect("Dimension" of properties).to.be.true
       expect("Direction" of properties).to.be.true
-      expect("Distance" of properties).to.be.true
       expect("Font" of properties).to.be.true
       expect("FontStyle" of properties).to.be.true
       expect("Instance" of properties).to.be.true

--- a/examples/models/file/donut.py
+++ b/examples/models/file/donut.py
@@ -61,7 +61,7 @@ for browser, start_angle, end_angle in zip(browsers, start_angles, end_angles):
     end = angles.tolist() + [end_angle]
     start = [start_angle] + end[:-1]
     base_color = colors[browser]
-    fill = [ base_color.lighten(i*0.05) for i in range(len(versions) + 1) ]
+    fill = [ base_color.lighten(i*0.05).to_hex() for i in range(len(versions) + 1) ]
     # extra empty string accounts for all versions with share < 0.5 together
     text = [ number if share >= 1 else "" for number, share in zip(versions.VersionNumber, versions.Share) ] + [""]
     x, y = polar_to_cartesian(1.25, start, end)
@@ -72,19 +72,8 @@ for browser, start_angle, end_angle in zip(browsers, start_angles, end_angles):
         line_color="white", line_width=2, fill_color="fill")
     plot.add_glyph(source, glyph)
 
-
     text_angle = [(start[i]+end[i])/2 for i in range(len(start))]
     text_angle = [angle + pi if pi/2 < angle < 3*pi/2 else angle for angle in text_angle]
-
-    if first and text:
-        text.insert(0, '(version)')
-        offset = pi / 48
-        text_angle.insert(0, text_angle[0] - offset)
-        start.insert(0, start[0] - offset)
-        end.insert(0, end[0] - offset)
-        x, y = polar_to_cartesian(1.25, start, end)
-        first = False
-
 
     text_source = ColumnDataSource(dict(text=text, x=x, y=y, angle=text_angle))
     glyph = Text(x="x", y="y", text="text", angle="angle",

--- a/sphinx/source/docs/releases/1.0.1.rst
+++ b/sphinx/source/docs/releases/1.0.1.rst
@@ -1,0 +1,26 @@
+1.0.1 (December 2018)
+=====================
+
+Bokeh Version ``1.0.1``
+
+Some of the highlights include:
+
+
+And several other bug fixes and docs additions. For full details see the
+:bokeh-tree:`CHANGELOG`.
+
+.. migration_101
+
+Migration Guide
+---------------
+
+.. migration_101_bokehjs
+
+BokehJS issues
+~~~~~~~~~~~~~~
+
+The ``spec`` attribute of BokehJS model properties has been made private. It
+is not expected than any users ever had cause to attempt to use this very
+low-level internal attribute, and this change is intended to fully clarify
+that this data structure is not suitable for general usage. See
+:bokeh-pull:`8370` for full information.


### PR DESCRIPTION
- [x] issues: fixes #8356
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)

This PR addresses #8356, however after a brief closer look it became evident that with a little more work than the one-line fix, some serious tech debt around BokehJS properties could be paid down. 

This PR:

* makes the `spec` field on `Property` be private, i.e. `prop._spec`
* restricts all direct access to `_spec` to inside `properties.ts`
* ensures that only actual "DataSpec" properties (i.e. only those with `prop.dataspec = True`) have a `._spec` present
* some cosmetic variable renames to aid with confirming `spec` not used outside `properties.ts`

Some new methods provide uniform access to the fields inside `_spec`. These first four only work on DataSpec properties and will raise an error on non-dataspecs:

* `get_expr()` -- access a dataspec expression
* `get_field()` -- access a dataspec field
* `get_transform()` -- access a dataspec transform
* `array(...)` -- return CDS array for field (unchanged from existing)

These last two work uniformly on any property dataspec or nor:

* `value_optional()` -- return undefined if no value set
* `value()` -- raise error if no value set (unchanged from existing)

I don't think the naming is ideal, but `transform` already refers to the "intrinsic" transform a property can have, and I do not want to rename `value` to `get_value` e.g. because that breaks compatibility on something that might possibly reasonably be used by users [1]

This PR is currently WIP. further tasks:

* [ ] release notes
* [ ] more tests (explicit test for #8356 and others)
* [ ] convert test to TS

---

[1] Note that this is a "breaking" change to BokehJS, but does not contravene the ***Specific Commitment for BokehJS*** made in the announcement (all existing CustomJS examples and BokehJS models and properties  and events will stay compatible) Direct usage of `.spec` is not something we can reasonably support (and I have no reason to believe *anyone* has tried to use this)

cc @bokeh/core 