### PR TITLE
Color property now accepts css rgb(a) strings

### DIFF
--- a/bokeh/core/property/color.py
+++ b/bokeh/core/property/color.py
@@ -100,6 +100,11 @@ class Color(Either):
     def __init__(self, default=None, help=None):
         types = (Enum(enums.NamedColor),
                  Regex("^#[0-9a-fA-F]{6}$"),
+                 Regex("^rgba\(((25[0-5]|2[0-4]\d|1\d{1,2}|\d\d?)\s*,"
+                       "\s*?){2}(25[0-5]|2[0-4]\d|1\d{1,2}|\d\d?)\s*,"
+                       "\s*([01]\.?\d*?)\)"),
+                 Regex("^rgb\(((25[0-5]|2[0-4]\d|1\d{1,2}|\d\d?)\s*,"
+                       "\s*?){2}(25[0-5]|2[0-4]\d|1\d{1,2}|\d\d?)\s*?\)"),
                  Tuple(Byte, Byte, Byte),
                  Tuple(Byte, Byte, Byte, Percent),
                  RGB)

--- a/bokeh/core/property/tests/test_color.py
+++ b/bokeh/core/property/tests/test_color.py
@@ -58,6 +58,10 @@ class Test_Color(object):
         assert prop.is_valid("blue")
         assert prop.is_valid("BLUE")
 
+        assert prop.is_valid('rgb(10, 20, 30)')
+        assert prop.is_valid('rgba(10, 20, 30, 1)')
+        assert prop.is_valid('rgba(10, 20, 30, 0.5)')
+
         assert prop.is_valid(RGB(10, 20, 30))
 
     def test_invalid(self):
@@ -80,6 +84,22 @@ class Test_Color(object):
         assert not prop.is_valid((0, 127))
         assert not prop.is_valid((0, 127, 1.0))
         assert not prop.is_valid((0, 127, 255, 255))
+
+        assert not prop.is_valid('(0, 127, 255)')
+        assert not prop.is_valid('rgb(0, -127, 255)')
+        assert not prop.is_valid('rgb(0, 127)')
+        assert not prop.is_valid('rgb(0, 127, 1.0)')
+        assert not prop.is_valid('rgb(256, 1, 1)')
+        assert not prop.is_valid('rgb(256, 1, 1, 1.0)')
+
+        assert not prop.is_valid('(10, 20, 30')
+        assert not prop.is_valid('rgba(10, 20, 30')
+        assert not prop.is_valid('rgba(10, 20, 30)')
+        assert not prop.is_valid('rgba(10, 20, 30,)')
+        assert not prop.is_valid('rgba(10, 20)')
+        assert not prop.is_valid('rgba(10, 20, 256, 1)')
+        assert not prop.is_valid('rgba(10, 20, 256, 10)')
+        assert not prop.is_valid('rgba(10, 20, 30, 50)')
 
         assert not prop.is_valid("00aaff")
         assert not prop.is_valid("00AAFF")


### PR DESCRIPTION
Fairly heavy-weight regex that allows the Color property to accept rgb(a) strings like:

```python
'rgb(10, 20, 30)'
'rgba(10, 20, 30, 1)'
'rgba(10, 20, 30, 0.5)'
```

Includes checks for bounds of both RGB and A values. Fixes the bug I observed in #4096, https://github.com/ioam/holoviews/issues/2777 and https://github.com/ioam/holoviews/issues/3107.

Would of course be happy to replace it with something simpler, e.g. a combined regex:

```
rgba?\(((25[0-5]|2[0-4]\d|1\d{1,2}|\d\d?)\s*,\s*?){2}(25[0-5]|2[0-4]\d|1\d{1,2}|\d\d?)\s*,?\s*([01]\.?\d*?)?\)
```

but that would not error on ``rgba(0, 0, 0)`` and ``rgb(0, 0, 0, 0.5)``, but apparently even github renders those correctly, so maybe that's not an issue.

- [x] issues: fixes #4096
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
