### PR TITLE
pass _angle value when rendering legends for EllipseOval

### DIFF
--- a/bokehjs/src/lib/models/glyphs/ellipse_oval.ts
+++ b/bokehjs/src/lib/models/glyphs/ellipse_oval.ts
@@ -122,7 +122,7 @@ export abstract class EllipseOvalView extends CenterRotatableView  {
       sh[index] = d
     }
 
-    this._render(ctx, [index], {sx, sy, sw, sh} as any) // XXX
+    this._render(ctx, [index], {sx, sy, sw, sh, _angle: [0]} as any) // XXX
   }
 
   protected _bounds({minX, maxX, minY, maxY}: Rect): Rect {


### PR DESCRIPTION
- [x] issues: fixes #8375

Not sure how we can currently test this effectively, absent view-models, but open to suggestion. Otherwise I'd like to embark on a plan of moving view logic into testable view models in 2019. 
