### PR TITLE
Allow OutputDocumentFor to handle children with docs

### DIFF
--- a/bokeh/embed/tests/test_util.py
+++ b/bokeh/embed/tests/test_util.py
@@ -136,7 +136,7 @@ class Test_OutputDocumentFor_general(object):
                 pass
         assert str(e).endswith(_ODFERR)
 
-    def test_with_doc_in_child_raises_error(self):
+    def test_with_doc_in_child_sets_temp_doc(self):
         doc = Document()
         p1 = Model()
         p2 = SomeModelInTestObjects(child=Model())
@@ -144,10 +144,14 @@ class Test_OutputDocumentFor_general(object):
         assert p1.document is None
         assert p2.document is None
         assert p2.child.document is doc
-        with pytest.raises(RuntimeError) as e:
-            with beu.OutputDocumentFor([p1, p2]):
-                pass
-            assert "already in a doc" in str(e)
+        with beu.OutputDocumentFor([p1, p2]) as d:
+            assert d is not doc
+            assert p1.document is d
+            assert p2.document is d
+            assert p2.child.document is d
+        assert p1.document is None
+        assert p2.document is None
+        assert p2.child.document is doc
 
     @patch('bokeh.document.document.check_integrity')
     def test_validates_document_by_default(self, check_integrity, test_plot):
@@ -609,3 +613,172 @@ class Test_standalone_docs_json(object):
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------
+
+class Test__compute_current_docs(object):
+
+    def test_no_docs(self):
+        p1 = Model()
+        p2 = Model()
+        res = beu._compute_current_docs([p1, p2])
+        assert res == set([None])
+
+    def test_top_level_same_doc(self):
+        d = Document()
+        p1 = Model()
+        p2 = Model()
+        d.add_root(p1)
+        d.add_root(p2)
+        res = beu._compute_current_docs([p1, p2])
+        assert res == set([d])
+
+    def test_top_level_different_doc(self):
+        d1 = Document()
+        d2 = Document()
+        p1 = Model()
+        p2 = Model()
+        d1.add_root(p1)
+        d2.add_root(p2)
+        res = beu._compute_current_docs([p1, p2])
+        assert res == set([d1, d2])
+
+
+    def test_child_docs(self):
+        d = Document()
+        p1 = Model()
+        p2 = SomeModelInTestObjects(child=Model())
+        d.add_root(p2.child)
+        res = beu._compute_current_docs([p1, p2])
+        assert res == set([None, d])
+
+
+        d2 = Document()
+        d2.add_root(p1)
+        res = beu._compute_current_docs([p1, p2])
+        assert res == set([None, d, d2])
+
+
+class Test__create_temp_doc(object):
+
+    def test_no_docs(self):
+        p1 = Model()
+        p2 = Model()
+        beu._create_temp_doc([p1, p2])
+        assert isinstance(p1.document, Document)
+        assert isinstance(p2.document, Document)
+
+    def test_top_level_same_doc(self):
+        d = Document()
+        p1 = Model()
+        p2 = Model()
+        d.add_root(p1)
+        d.add_root(p2)
+        beu._create_temp_doc([p1, p2])
+        assert isinstance(p1.document, Document)
+        assert p1.document is not d
+        assert isinstance(p2.document, Document)
+        assert p2.document is not d
+
+        assert p2.document == p1.document
+
+    def test_top_level_different_doc(self):
+        d1 = Document()
+        d2 = Document()
+        p1 = Model()
+        p2 = Model()
+        d1.add_root(p1)
+        d2.add_root(p2)
+        beu._create_temp_doc([p1, p2])
+        assert isinstance(p1.document, Document)
+        assert p1.document is not d1
+        assert isinstance(p2.document, Document)
+        assert p2.document is not d2
+
+        assert p2.document == p1.document
+
+    def test_child_docs(self):
+        d = Document()
+        p1 = Model()
+        p2 = SomeModelInTestObjects(child=Model())
+        d.add_root(p2.child)
+        beu._create_temp_doc([p1, p2])
+
+        assert isinstance(p1.document, Document)
+        assert p1.document is not d
+        assert isinstance(p2.document, Document)
+        assert p2.document is not d
+        assert isinstance(p2.child.document, Document)
+        assert p2.child.document is not d
+
+        assert p2.document == p1.document
+        assert p2.document == p2.child.document
+
+class Test__dispose_temp_doc(object):
+
+    def test_no_docs(self):
+        p1 = Model()
+        p2 = Model()
+        beu._dispose_temp_doc([p1, p2])
+        assert p1.document is None
+        assert p2.document is None
+
+    def test_with_docs(self):
+        d1 = Document()
+        d2 = Document()
+        p1 = Model()
+        d1.add_root(p1)
+        p2 = SomeModelInTestObjects(child=Model())
+        d2.add_root(p2.child)
+        beu._create_temp_doc([p1, p2])
+        beu._dispose_temp_doc([p1, p2])
+        assert p1.document is d1
+        assert p2.document is None
+        assert p2.child.document is d2
+
+    def test_with_temp_docs(self):
+        p1 = Model()
+        p2 = Model()
+        beu._create_temp_doc([p1, p2])
+        beu._dispose_temp_doc([p1, p2])
+        assert p1.document is None
+        assert p2.document is None
+
+class Test__set_temp_theme(object):
+    def test_apply_None(self):
+        d = Document()
+        orig = d.theme
+        beu._set_temp_theme(d, None)
+        assert d._old_theme is orig
+        assert d.theme is orig
+
+    def test_apply_theme(self):
+        t = Theme(json={})
+        d = Document()
+        orig = d.theme
+        beu._set_temp_theme(d, t)
+        assert d._old_theme is orig
+        assert d.theme is t
+
+    def test_apply_from_curdoc(self):
+        t = Theme(json={})
+        curdoc().theme = t
+        d = Document()
+        orig = d.theme
+        beu._set_temp_theme(d, beu.FromCurdoc)
+        assert d._old_theme is orig
+        assert d.theme is t
+
+class Test__unset_temp_theme(object):
+    def test_basic(self):
+        t = Theme(json={})
+        d = Document()
+        d._old_theme = t
+        beu._unset_temp_theme(d)
+        assert d.theme is t
+        assert not hasattr(d, "_old_theme")
+
+    def test_no_old_theme(self):
+        d = Document()
+        orig = d.theme
+        beu._unset_temp_theme(d)
+        assert d.theme is orig
+        assert not hasattr(d, "_old_theme")

--- a/bokeh/embed/util.py
+++ b/bokeh/embed/util.py
@@ -113,7 +113,7 @@ def OutputDocumentFor(objs, apply_theme=None, always_new=False):
 
     def finish(): pass
 
-    docs = set(x.document for x in objs)
+    docs = _compute_current_docs(objs)
 
     # handle a single shared document, or missing document
     if len(docs) == 1:
@@ -317,6 +317,14 @@ be used. For more information on building and running Bokeh applications, see:
     http://bokeh.pydata.org/en/latest/docs/user_guide/server.html
 """
 
+def _compute_current_docs(objs):
+    docs = set()
+    for obj in objs:
+        docs.add(obj.document)
+        for ref in obj.references():
+            docs.add(ref.document)
+    return docs
+
 def _create_temp_doc(models):
     doc = Document()
     for m in models:
@@ -343,6 +351,8 @@ def _set_temp_theme(doc, apply_theme):
         doc.theme = apply_theme
 
 def _unset_temp_theme(doc):
+    if not hasattr(doc, "_old_theme"):
+        return
     doc.theme = doc._old_theme
     del doc._old_theme
 


### PR DESCRIPTION
- [x] issues: fixes #8362
- [x] tests added / passed

### Acceptable change argument:

This PR fixes #8362 by allowing the dev API context manager `OutputDocumentFor` to correctly handle cases where children models have different models that documents roots (specifically a case where a child model has a document, but its root parents have None). Prior to this PR, this situation was **explicitly** an error condition. This change is deemed acceptable, because this PR only *relaxes the condition*, i.e. all previous situations are still handled exactly as before with no change, but new acceptable cases (which *should* be acceptable) are now possible. 

In practice, almost no users will use `OutputDocumentFor` directly, and of those very few, arguably any that do would expect the behavor in this PR. The practical outcome is simply that cases that currently fail, that should succeed (i.e. #8363), will now succeed. 

Additionally, defensive code was added to the private function `_unset_temp_theme`. Specifically, it is now idempotent. Previously it would fall over if called repeatedly, or called on a document that had not previously been acted on by `_create_temp_doc`. This restriction seems unnecessary, and as the function is private, any change is acceptable. 

cc @bokeh/core re: change argument

