### PR TITLE
Bokeh export csv example now discovers column heading names

### DIFF
--- a/examples/app/export_csv/download.js
+++ b/examples/app/export_csv/download.js
@@ -1,12 +1,12 @@
 function table_to_csv(data_table) {
-    var columns = Object.keys(data_table)
-    var nrows = data_table[columns[0]].length
-    var lines = [columns.join(',')]
+    const columns = Object.keys(data_table)
+    const nrows = data_table[columns[0]].length
+    const lines = [columns.join(',')]
 
     for (var i = 0; i < nrows; i++) {
         var row = [];
         for (var j = 0; j < columns.length; j++) {
-            var column = columns[j]
+            const column = columns[j]
             row.push(data_table[column][i].toString())
         }
         lines.push(row.join(','))
@@ -16,16 +16,16 @@ function table_to_csv(data_table) {
 }
 
 
-var data = source.data
-var filetext = table_to_csv(data)
-var filename = 'data_result.csv'
-var blob = new Blob([filetext], { type: 'text/csv;charset=utf-8;' })
+const data = source.data
+const filename = 'data_result.csv'
+filetext = table_to_csv(data)
+const blob = new Blob([filetext], { type: 'text/csv;charset=utf-8;' })
 
 //addresses IE
 if (navigator.msSaveBlob) {
     navigator.msSaveBlob(blob, filename)
 } else {
-    var link = document.createElement('a')
+    const link = document.createElement('a')
     link.href = URL.createObjectURL(blob)
     link.download = filename
     link.target = '_blank'

--- a/examples/app/export_csv/download.js
+++ b/examples/app/export_csv/download.js
@@ -1,35 +1,35 @@
 function table_to_csv(data_table) {
     var columns = Object.keys(data_table)
     var nrows = data_table[columns[0]].length
-    var lines = [columns.join(',')];
+    var lines = [columns.join(',')]
 
     for (var i = 0; i < nrows; i++) {
         var row = [];
         for (var j = 0; j < columns.length; j++) {
-            var column = columns[j];
-            row.push(data_table[column][i].toString());
+            var column = columns[j]
+            row.push(data_table[column][i].toString())
         }
-        lines.push(row.join(','));
+        lines.push(row.join(','))
     }
-    filetext = lines.join('\n').concat('\n');
+    filetext = lines.join('\n').concat('\n')
     return filetext
 }
 
 
-var data = source.data;
-var filetext = table_to_csv(data);
-var filename = 'data_result.csv';
-var blob = new Blob([filetext], { type: 'text/csv;charset=utf-8;' });
+var data = source.data
+var filetext = table_to_csv(data)
+var filename = 'data_result.csv'
+var blob = new Blob([filetext], { type: 'text/csv;charset=utf-8;' })
 
 //addresses IE
 if (navigator.msSaveBlob) {
-    navigator.msSaveBlob(blob, filename);
+    navigator.msSaveBlob(blob, filename)
 } else {
-    var link = document.createElement("a");
+    var link = document.createElement("a")
     link = document.createElement('a')
-    link.href = URL.createObjectURL(blob);
+    link.href = URL.createObjectURL(blob)
     link.download = filename
-    link.target = "_blank";
-    link.style.visibility = 'hidden';
+    link.target = "_blank"
+    link.style.visibility = 'hidden'
     link.dispatchEvent(new MouseEvent('click'))
 }

--- a/examples/app/export_csv/download.js
+++ b/examples/app/export_csv/download.js
@@ -3,9 +3,9 @@ function table_to_csv(data_table) {
     const nrows = data_table[columns[0]].length
     const lines = [columns.join(',')]
 
-    for (var i = 0; i < nrows; i++) {
-        var row = [];
-        for (var j = 0; j < columns.length; j++) {
+    for (let i = 0; i < nrows; i++) {
+        let row = [];
+        for (let j = 0; j < columns.length; j++) {
             const column = columns[j]
             row.push(data_table[column][i].toString())
         }

--- a/examples/app/export_csv/download.js
+++ b/examples/app/export_csv/download.js
@@ -25,10 +25,10 @@ var blob = new Blob([filetext], { type: 'text/csv;charset=utf-8;' })
 if (navigator.msSaveBlob) {
     navigator.msSaveBlob(blob, filename)
 } else {
-    var link = document.createElement("a")
+    var link = document.createElement('a')
     link.href = URL.createObjectURL(blob)
     link.download = filename
-    link.target = "_blank"
+    link.target = '_blank'
     link.style.visibility = 'hidden'
     link.dispatchEvent(new MouseEvent('click'))
 }

--- a/examples/app/export_csv/download.js
+++ b/examples/app/export_csv/download.js
@@ -1,13 +1,13 @@
-function table_to_csv(data_table) {
-    const columns = Object.keys(data_table)
-    const nrows = data_table[columns[0]].length
+function table_to_csv(source) {
+    const columns = Object.keys(source.data)
+    const nrows = source.get_length()
     const lines = [columns.join(',')]
 
     for (let i = 0; i < nrows; i++) {
         let row = [];
         for (let j = 0; j < columns.length; j++) {
             const column = columns[j]
-            row.push(data_table[column][i].toString())
+            row.push(source.data[column][i].toString())
         }
         lines.push(row.join(','))
     }
@@ -17,7 +17,7 @@ function table_to_csv(data_table) {
 
 
 const filename = 'data_result.csv'
-filetext = table_to_csv(source.data)
+filetext = table_to_csv(source)
 const blob = new Blob([filetext], { type: 'text/csv;charset=utf-8;' })
 
 //addresses IE

--- a/examples/app/export_csv/download.js
+++ b/examples/app/export_csv/download.js
@@ -26,7 +26,6 @@ if (navigator.msSaveBlob) {
     navigator.msSaveBlob(blob, filename)
 } else {
     var link = document.createElement("a")
-    link = document.createElement('a')
     link.href = URL.createObjectURL(blob)
     link.download = filename
     link.target = "_blank"

--- a/examples/app/export_csv/download.js
+++ b/examples/app/export_csv/download.js
@@ -11,8 +11,7 @@ function table_to_csv(source) {
         }
         lines.push(row.join(','))
     }
-    filetext = lines.join('\n').concat('\n')
-    return filetext
+    return lines.join('\n').concat('\n')
 }
 
 

--- a/examples/app/export_csv/download.js
+++ b/examples/app/export_csv/download.js
@@ -1,14 +1,23 @@
-var data = source.data;
-var filetext = 'name,income,years_experience\n';
-for (var i = 0; i < data['name'].length; i++) {
-    var currRow = [data['name'][i].toString(),
-                   data['salary'][i].toString(),
-                   data['years_experience'][i].toString().concat('\n')];
+function table_to_csv(data_table) {
+    var columns = Object.keys(data_table)
+    var nrows = data_table[columns[0]].length
+    var lines = [columns.join(',')];
 
-    var joined = currRow.join();
-    filetext = filetext.concat(joined);
+    for (var i = 0; i < nrows; i++) {
+        var row = [];
+        for (var j = 0; j < columns.length; j++) {
+            var column = columns[j];
+            row.push(data_table[column][i].toString());
+        }
+        lines.push(row.join(','));
+    }
+    filetext = lines.join('\n').concat('\n');
+    return filetext
 }
 
+
+var data = source.data;
+var filetext = table_to_csv(data);
 var filename = 'data_result.csv';
 var blob = new Blob([filetext], { type: 'text/csv;charset=utf-8;' });
 

--- a/examples/app/export_csv/download.js
+++ b/examples/app/export_csv/download.js
@@ -16,9 +16,8 @@ function table_to_csv(data_table) {
 }
 
 
-const data = source.data
 const filename = 'data_result.csv'
-filetext = table_to_csv(data)
+filetext = table_to_csv(source.data)
 const blob = new Blob([filetext], { type: 'text/csv;charset=utf-8;' })
 
 //addresses IE


### PR DESCRIPTION
Export csv now discovers column heading names in data table before downloading csv file.

@jni went to some effort to work out how we could do this for datatables with arbitrary numbers of columns and column headings. It's a very neat solution.

- [x] issues: fixes https://github.com/bokeh/bokeh/issues/8379
- [ ] tests added / passed (not necessary, no new functionality added)
- [ ] release document entry (not necessary, not a new feature)
