### PR TITLE
Bryanv/8362 new temp doc for export

### DIFF
--- a/bokeh/embed/standalone.py
+++ b/bokeh/embed/standalone.py
@@ -246,7 +246,8 @@ def file_html(models,
               template=FILE,
               template_variables={},
               theme=FromCurdoc,
-              suppress_callback_warning=False):
+              suppress_callback_warning=False,
+              _always_new=False):
     ''' Return an HTML document that embeds Bokeh Model or Document objects.
 
     The data for the plot is stored directly in the returned HTML, with
@@ -296,7 +297,7 @@ def file_html(models,
     if isinstance(models, Document):
         models = models.roots
 
-    with OutputDocumentFor(models, apply_theme=theme) as doc:
+    with OutputDocumentFor(models, apply_theme=theme, always_new=_always_new) as doc:
         (docs_json, render_items) = standalone_docs_json_and_render_items(models, suppress_callback_warning=suppress_callback_warning)
         title = _title_from_models(models, title)
         bundle = bundle_for_objs_and_resources([doc], resources)

--- a/bokeh/embed/tests/test_util.py
+++ b/bokeh/embed/tests/test_util.py
@@ -609,3 +609,129 @@ class Test_standalone_docs_json(object):
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------
+
+class Test__create_temp_doc(object):
+
+    def test_no_docs(self):
+        p1 = Model()
+        p2 = Model()
+        beu._create_temp_doc([p1, p2])
+        assert isinstance(p1.document, Document)
+        assert isinstance(p2.document, Document)
+
+    def test_top_level_same_doc(self):
+        d = Document()
+        p1 = Model()
+        p2 = Model()
+        d.add_root(p1)
+        d.add_root(p2)
+        beu._create_temp_doc([p1, p2])
+        assert isinstance(p1.document, Document)
+        assert p1.document is not d
+        assert isinstance(p2.document, Document)
+        assert p2.document is not d
+
+        assert p2.document == p1.document
+
+    def test_top_level_different_doc(self):
+        d1 = Document()
+        d2 = Document()
+        p1 = Model()
+        p2 = Model()
+        d1.add_root(p1)
+        d2.add_root(p2)
+        beu._create_temp_doc([p1, p2])
+        assert isinstance(p1.document, Document)
+        assert p1.document is not d1
+        assert isinstance(p2.document, Document)
+        assert p2.document is not d2
+
+        assert p2.document == p1.document
+
+    def test_child_docs(self):
+        d = Document()
+        p1 = Model()
+        p2 = SomeModelInTestObjects(child=Model())
+        d.add_root(p2.child)
+        beu._create_temp_doc([p1, p2])
+
+        assert isinstance(p1.document, Document)
+        assert p1.document is not d
+        assert isinstance(p2.document, Document)
+        assert p2.document is not d
+        assert isinstance(p2.child.document, Document)
+        assert p2.child.document is not d
+
+        assert p2.document == p1.document
+        assert p2.document == p2.child.document
+
+class Test__dispose_temp_doc(object):
+
+    def test_no_docs(self):
+        p1 = Model()
+        p2 = Model()
+        beu._dispose_temp_doc([p1, p2])
+        assert p1.document is None
+        assert p2.document is None
+
+    def test_with_docs(self):
+        d1 = Document()
+        d2 = Document()
+        p1 = Model()
+        d1.add_root(p1)
+        p2 = SomeModelInTestObjects(child=Model())
+        d2.add_root(p2.child)
+        beu._create_temp_doc([p1, p2])
+        beu._dispose_temp_doc([p1, p2])
+        assert p1.document is d1
+        assert p2.document is None
+        assert p2.child.document is d2
+
+    def test_with_temp_docs(self):
+        p1 = Model()
+        p2 = Model()
+        beu._create_temp_doc([p1, p2])
+        beu._dispose_temp_doc([p1, p2])
+        assert p1.document is None
+        assert p2.document is None
+
+class Test__set_temp_theme(object):
+    def test_apply_None(self):
+        d = Document()
+        orig = d.theme
+        beu._set_temp_theme(d, None)
+        assert d._old_theme is orig
+        assert d.theme is orig
+
+    def test_apply_theme(self):
+        t = Theme(json={})
+        d = Document()
+        orig = d.theme
+        beu._set_temp_theme(d, t)
+        assert d._old_theme is orig
+        assert d.theme is t
+
+    def test_apply_from_curdoc(self):
+        t = Theme(json={})
+        curdoc().theme = t
+        d = Document()
+        orig = d.theme
+        beu._set_temp_theme(d, beu.FromCurdoc)
+        assert d._old_theme is orig
+        assert d.theme is t
+
+class Test__unset_temp_theme(object):
+    def test_basic(self):
+        t = Theme(json={})
+        d = Document()
+        d._old_theme = t
+        beu._unset_temp_theme(d)
+        assert d.theme is t
+        assert not hasattr(d, "_old_theme")
+
+    def test_no_old_theme(self):
+        d = Document()
+        orig = d.theme
+        beu._unset_temp_theme(d)
+        assert d.theme is orig
+        assert not hasattr(d, "_old_theme")

--- a/bokeh/embed/util.py
+++ b/bokeh/embed/util.py
@@ -114,31 +114,37 @@ def OutputDocumentFor(objs, apply_theme=None, always_new=False):
     def finish(): pass
 
     docs = set(x.document for x in objs)
+    if None in docs: docs.remove(None)
 
-    # handle a single shared document, or missing document
-    if len(docs) == 1:
-        doc = docs.pop()
+    if always_new:
+        def finish(): # NOQA
+            _dispose_temp_doc(objs)
+        doc = _create_temp_doc(objs)
 
-        # if there is no document, make one to use
-        if doc is None:
+    else:
+        if len(docs) == 0:
             doc = Document()
             for model in objs:
                 doc.add_root(model)
 
-        # we are not using all the roots, make a quick clone for outputting purposes
-        elif set(objs) != set(doc.roots) or always_new:
+        # handle a single shared document
+        elif len(docs) == 1:
+            doc = docs.pop()
+
+            # we are not using all the roots, make a quick clone for outputting purposes
+            if set(objs) != set(doc.roots):
+                def finish(): # NOQA
+                    _dispose_temp_doc(objs)
+                doc = _create_temp_doc(objs)
+
+            # we are using all the roots of a single doc, just use doc as-is
+            pass
+
+        # models have mixed docs, just make a quick clone
+        else:
             def finish(): # NOQA
                 _dispose_temp_doc(objs)
             doc = _create_temp_doc(objs)
-
-        # we are using all the roots of a single doc, just use doc as-is
-        pass
-
-    # models have mixed docs, just make a quick clone
-    else:
-        def finish(): # NOQA
-            _dispose_temp_doc(objs)
-        doc = _create_temp_doc(objs)
 
     if settings.perform_document_validation():
         doc.validate()

--- a/bokeh/embed/util.py
+++ b/bokeh/embed/util.py
@@ -343,6 +343,8 @@ def _set_temp_theme(doc, apply_theme):
         doc.theme = apply_theme
 
 def _unset_temp_theme(doc):
+    if not hasattr(doc, "_old_theme"):
+        return
     doc.theme = doc._old_theme
     del doc._old_theme
 

--- a/bokeh/io/export.py
+++ b/bokeh/io/export.py
@@ -254,7 +254,7 @@ def get_layout_html(obj, resources=INLINE, **kwargs):
             obj.plot_width = kwargs.get('width', old_width)
 
     try:
-        html = file_html(obj, resources, title="", suppress_callback_warning=True)
+        html = file_html(obj, resources, title="", suppress_callback_warning=True, _always_new=True)
     finally:
         if resize:
             obj.plot_height = old_height

--- a/bokeh/io/tests/test_export.py
+++ b/bokeh/io/tests/test_export.py
@@ -26,6 +26,7 @@ import re
 from PIL import Image
 
 # Bokeh imports
+from bokeh.layouts import row
 from bokeh.models.plots import Plot
 from bokeh.models.ranges import Range1d
 from bokeh.io.webdriver import webdriver_control, terminate_webdriver
@@ -169,6 +170,22 @@ def test_get_layout_html_resets_plot_dims():
 
     assert layout.plot_height == initial_height
     assert layout.plot_width == initial_width
+
+def test_layout_html_on_child_first():
+    p = Plot(x_range=Range1d(), y_range=Range1d())
+
+    bie.get_layout_html(p, height=100, width=100)
+
+    layout = row(p)
+    bie.get_layout_html(layout)
+
+def test_layout_html_on_parent_first():
+    p = Plot(x_range=Range1d(), y_range=Range1d())
+
+    layout = row(p)
+    bie.get_layout_html(layout)
+
+    bie.get_layout_html(p, height=100, width=100)
 
 #-----------------------------------------------------------------------------
 # Private API


### PR DESCRIPTION
- [x] issues: fixes #xxxx
- [x] tests added / passed

This is a simpler PR for #8362 that forces all export functions to set `aways_new=True` when generating their file output. This alleviates the problem of exporting a child of some layout before showing the layout causing a "multiple document" error, but does no change any semantics of `OutputDocumentFor` (not even just by expanding acceptable usage) and does not cause a costly references traversal. 