### PR TITLE
Skip rendering legend glyph for empty scatter

### DIFF
--- a/bokehjs/src/lib/models/markers/scatter.ts
+++ b/bokehjs/src/lib/models/markers/scatter.ts
@@ -16,7 +16,7 @@ export class ScatterView extends MarkerView {
 
   protected _render(ctx: Context2d, indices: number[], {sx, sy, _size, _angle, _marker}: ScatterData): void {
     for (const i of indices) {
-      if (isNaN(sx[i] + sy[i] + _size[i] + _angle[i]))
+      if (isNaN(sx[i] + sy[i] + _size[i] + _angle[i]) || _marker[i] == null)
         continue
 
       const r = _size[i]/2


### PR DESCRIPTION
This skips rendering the legend glyph entry if the scatter glyph is empty. Alternatively we could simply default to a circle but that may be misleading and the legend does update if you subsequently set or stream data to the scatter.

Here is an image of a plot with two scatter glyphs each with empty data:

![screen shot 2018-11-10 at 9 23 22 pm](https://user-images.githubusercontent.com/1550771/48306279-ef3feb00-e52e-11e8-847a-8031c09e670c.png)

and then I set some data:

![screen shot 2018-11-10 at 9 23 30 pm](https://user-images.githubusercontent.com/1550771/48306320-f535cc00-e52e-11e8-8503-0dd538618b62.png)

Not sure what the best way is to test actual rendering of plots.

- [x] issues: fixes #8395
- [ ] tests added / passed
