### PR TITLE
Update server.rst: wrong apache module name

### DIFF
--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -919,7 +919,7 @@ configuration:
 .. code-block:: sh
 
     a2enmod proxy
-    a2enmod http_proxy
+    a2enmod proxy_http
     a2enmod proxy_wstunnel
     apache2ctl restart
 


### PR DESCRIPTION
In section about Apache reverse proxy there was a wrong module name: `http_proxy` changed to `proxy_http`.


- [x] issues: fixes #8425 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
