### PR TITLE
Clean up .gitignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,113 +1,42 @@
-# Editor temporary/working/backup files #
-#########################################
-.#*
-[#]*#
-*~
-*$
-*.bak
-*.diff
-*.org
-.project
-.pydevproject
-*.rej
-.settings/
-.*.sw[nop]
-.sw[nop]
-*.tmp
-*.coverage.*
-**/screenshots/current*
-**/screenshots/diff*
-
-# Compiled source #
-###################
-*.a
-*.com
-*.class
-*.dll
-*.exe
-*.o
 *.py[ocd]
-*.so
 
-# Packages #
-############
-# it's better to unpack these files and commit the raw source
-# git has its own built in compression methods
-*.7z
-*.bz2
-*.bzip2
-*.dmg
-*.gz
-*.iso
-*.jar
-*.rar
-*.tar
-*.tbz2
-*.tgz
-*.zip
-
-# Python files #
-################
 # setup.py working directory
 /build
+
 # sphinx build directory
 /_build
+
 # setup.py dist directory
 /dist
 /doc/build
 /doc/cdoc/build
 /MANIFEST
+
 # Egg metadata
-*.egg-info
-# The shelf plugin uses this dir
-./.shelf
+/*.egg-info
+
 # coverage reports
-.coverage
+/.coverage
+
 # ipython files
 **/.ipynb_checkpoints
-# tests/examples reports
+
+# tests/examples
 report.html
+examples.log
 
-# Logs and databases #
-######################
-*.log
-*.sql
-*.sqlite
+# conda build
+/linux-64
+/osx-64
+/win-64
 
-# Patches #
-###########
-*.patch
-*.diff
+# pytest
+/.cache/
+/.pytest_cache/
 
-# OS generated files #
-######################
-.DS_Store*
-.VolumeIcon.icns
-.fseventsd
-Icon?
-.gdb_history
-ehthumbs.db
-Thumbs.db
-
-# Things specific to this project #
-###################################
-webplot.py
-redis.db
-bokehpids.json
-bokeh.data.*
-bokeh.server.*
-bokeh.sets.*
-remotedata
-target/
-/.idea/
-/.c9/
-
-osx-64
-linux-64
-win-64
-
-/record.txt
+# auto-generated
 /bokeh/LICENSE.txt
+
+# ???
+/record.txt
 /examples/refs
-.cache/
-.pytest_cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,12 @@
 *.py[ocd]
 
-# setup.py working directory
+# setup.py things
 /build
+/dist
+/MANIFEST
 
 # sphinx build directory
-/_build
-
-# setup.py dist directory
-/dist
-/doc/build
-/doc/cdoc/build
-/MANIFEST
+/sphinx/build
 
 # Egg metadata
 /*.egg-info
@@ -24,6 +20,7 @@
 # tests/examples
 report.html
 examples.log
+/examples/custom/font-awesome/package-lock.json
 
 # conda build
 /linux-64
@@ -37,6 +34,29 @@ examples.log
 # auto-generated
 /bokeh/LICENSE.txt
 
-# ???
-/record.txt
-/examples/refs
+# dev files
+*.patch
+*.diff
+*.rej
+
+# common editor cruft
+.#*
+[#]*#
+*~
+*$
+*.bak
+.project
+.pydevproject
+.*.sw[nop]
+.sw[nop]
+*.tmp
+
+# compressed / binary files
+*.bz2
+*.bzip2
+*.dmg
+*.gz
+*.iso
+*.tar
+*.tgz
+*.zip


### PR DESCRIPTION
My goal is to have `.gitignore` files reduced to the bare minimum. Anything that's not project related (so e.g. editor/IDE temporary files) should be configured locally by the user. All entries (or groups of entries) must have an annotation why we ignore or what generate those (a good example is `.cache/`). If entries are specific to a subdirectory, they should be moved to a specific `.gitignore` file.

fixes #8433 