### PR TITLE
Fix text_align in table cell formatters

### DIFF
--- a/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
@@ -79,6 +79,8 @@ export class StringFormatter extends CellFormatter {
     if (text_color != null)
       text.style.color = text_color
 
+    text.style.display = "block"
+
     return text.outerHTML
   }
 }

--- a/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
@@ -3,7 +3,7 @@ import compile_template = require("underscore.template")
 import tz = require("timezone")
 
 import * as p from "core/properties"
-import {span, i} from "core/dom"
+import {div, i} from "core/dom"
 import {Color} from "core/types"
 import {FontStyle, TextAlign, RoundingFunction} from "core/enums"
 import {isString} from "core/util/types"
@@ -64,7 +64,7 @@ export class StringFormatter extends CellFormatter {
   doFormat(_row: any, _cell: any, value: any, _columnDef: any, _dataContext: any): string {
     const {font_style, text_align, text_color} = this
 
-    const text = span({}, value == null ? "" : `${value}`)
+    const text = div({}, value == null ? "" : `${value}`)
     switch (font_style) {
       case "bold":
         text.style.fontWeight = "bold"
@@ -78,8 +78,6 @@ export class StringFormatter extends CellFormatter {
       text.style.textAlign = text_align
     if (text_color != null)
       text.style.color = text_color
-
-    text.style.display = "block"
 
     return text.outerHTML
   }

--- a/examples/app/dash/main.py
+++ b/examples/app/dash/main.py
@@ -6,7 +6,8 @@ import pandas as pd
 
 from bokeh.io import curdoc
 from bokeh.layouts import column
-from bokeh.models import ColumnDataSource, DataTable, RangeTool, TableColumn
+from bokeh.models import ColumnDataSource, DataTable, RangeTool, TableColumn, \
+                         NumberFormatter, StringFormatter
 from bokeh.palettes import Spectral11
 from bokeh.plotting import figure
 from bokeh.transform import cumsum
@@ -92,8 +93,10 @@ curdoc().add_root(platform)
 source = ColumnDataSource(data=mpg[:6])
 columns = [
     TableColumn(field="cyl", title="Counts"),
-    TableColumn(field="cty", title="Uniques"),
-    TableColumn(field="hwy", title="Rating"),
+    TableColumn(field="cty", title="Uniques",
+                formatter=StringFormatter(text_align="center")),
+    TableColumn(field="hwy", title="Rating",
+                formatter=NumberFormatter(text_align="right")),
 ]
 table = DataTable(source=source, columns=columns, height=210, width=330, name="table", sizing_mode="scale_both")
 

--- a/examples/integration/widgets/data_table_customization.py
+++ b/examples/integration/widgets/data_table_customization.py
@@ -1,5 +1,5 @@
 from bokeh.io import save
-from bokeh.models import ColumnDataSource
+from bokeh.models import ColumnDataSource, NumberFormatter, StringFormatter
 from bokeh.models.widgets import DataTable, TableColumn, HTMLTemplateFormatter
 
 from bokeh.sampledata.periodic_table import elements
@@ -14,8 +14,10 @@ html_image_template = """
 </a>
 """
 columns = [
-    TableColumn(field='atomic number', title='Atomic Number'),
-    TableColumn(field='symbol', title='Symbol'),
+    TableColumn(field='atomic number', title='Atomic Number',
+                formatter=NumberFormatter(text_align="right")),
+    TableColumn(field='symbol', title='Symbol',
+                formatter=StringFormatter(text_align="center")),
     TableColumn(field='name', title='Name',
                 formatter=HTMLTemplateFormatter(template=html_font_template)),
     TableColumn(field='name_lower', title='Image',


### PR DESCRIPTION
The text_align attribute of table cell text's span is set but does not take effect because it does not fill the container width of table cell's div.  This trivial fix is in the base StringFormatter which also addresses NumberFormatter, allowing numeric columns/cells to be defined with proper right-alignment.
- [x] issues: fixes #5721
