### PR TITLE
Add min/max radius dimensions

### DIFF
--- a/bokeh/models/markers.py
+++ b/bokeh/models/markers.py
@@ -155,12 +155,15 @@ class Circle(Marker):
 
     """)
 
-    radius_dimension = Enum(enumeration('x', 'y'), help="""
+    radius_dimension = Enum(enumeration('x', 'y', 'max', 'min'), help="""
     What dimension to measure circle radii along.
 
     When the data space aspect ratio is not 1-1, then the size of the drawn
     circles depends on what direction is used to measure the "distance" of
     the radius. This property allows that direction to be controlled.
+
+    Setting this dimension to 'max' will calculate the radius on both the x
+    and y dimensions and use the maximum of the two, 'min' selects the minimum.
     """)
 
 class CircleCross(Marker):

--- a/bokehjs/src/lib/models/glyphs/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/circle.ts
@@ -45,14 +45,16 @@ export class CircleView extends XYGlyphView {
             break
           }
           case "max": {
-            let sradius_x = this.sdist(this.renderer.xscale, this._x, this._radius)
-            let sradius_y = this.sdist(this.renderer.yscale, this._y, this._radius)
+            const sradius_x = this.sdist(this.renderer.xscale, this._x, this._radius)
+            const sradius_y = this.sdist(this.renderer.yscale, this._y, this._radius)
             this.sradius = map(sradius_x, (s, i) => Math.max(s, sradius_y[i]))
+            break
           }
           case "min": {
-            let sradius_x = this.sdist(this.renderer.xscale, this._x, this._radius)
-            let sradius_y = this.sdist(this.renderer.yscale, this._y, this._radius)
+            const sradius_x = this.sdist(this.renderer.xscale, this._x, this._radius)
+            const sradius_y = this.sdist(this.renderer.yscale, this._y, this._radius)
             this.sradius = map(sradius_x, (s, i) => Math.min(s, sradius_y[i]))
+            break
           }
         }
       } else {

--- a/bokehjs/src/lib/models/glyphs/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/circle.ts
@@ -44,6 +44,16 @@ export class CircleView extends XYGlyphView {
             this.sradius = this.sdist(this.renderer.yscale, this._y, this._radius)
             break
           }
+          case "max": {
+            let sradius_x = this.sdist(this.renderer.xscale, this._x, this._radius)
+            let sradius_y = this.sdist(this.renderer.yscale, this._y, this._radius)
+            this.sradius = map(sradius_x, (s, i) => Math.max(s, sradius_y[i]))
+          }
+          case "min": {
+            let sradius_x = this.sdist(this.renderer.xscale, this._x, this._radius)
+            let sradius_y = this.sdist(this.renderer.yscale, this._y, this._radius)
+            this.sradius = map(sradius_x, (s, i) => Math.min(s, sradius_y[i]))
+          }
         }
       } else {
         this.sradius = this._radius
@@ -257,14 +267,14 @@ export namespace Circle {
     angle: AngleSpec
     size: DistanceSpec
     radius: DistanceSpec | null
-    radius_dimension: "x" | "y"
+    radius_dimension: "x" | "y" | "max" | "min"
   }
 
   export interface Props extends XYGlyph.Props {
     angle: p.AngleSpec
     size: p.DistanceSpec
     radius: p.DistanceSpec
-    radius_dimension: p.Property<"x" | "y">
+    radius_dimension: p.Property<"x" | "y" | "max" | "min">
   }
 
   export interface Visuals extends XYGlyph.Visuals {


### PR DESCRIPTION
Fixes: #626

This PR completes the functionality proposed in #626 which was partially addressed in commit ee8de73.

**Description:**
This PR adds two additional dimensions to radius_dimension, 'min' and 'max'

'min' dynamically selects either the x and y dimension off which to calculate the radius value, choosing whichever results in a smaller size, while 'max' does the same thing but chooses the maximum.