### PR TITLE
Add support for multiline axis labels

### DIFF
--- a/bokeh/models/axes.py
+++ b/bokeh/models/axes.py
@@ -108,9 +108,9 @@ class Axis(GuideRenderer):
     The %s of the major tick labels.
     """)
 
-    major_label_text_align = Override(default="center")
+    major_label_text_align = Override(default=None) # poor man's "auto"
 
-    major_label_text_baseline = Override(default="alphabetic")
+    major_label_text_baseline = Override(default=None) # poor man's "auto"
 
     major_label_text_font_size = Override(default={'value': "8pt"})
 

--- a/bokehjs/src/lib/core/layout/side_panel.ts
+++ b/bokehjs/src/lib/core/layout/side_panel.ts
@@ -271,7 +271,7 @@ export class SidePanel extends LayoutCanvas {
     return this.side == "left" || this.side == "right"
   }
 
-  apply_label_text_heuristics(ctx: CanvasRenderingContext2D, orient: TextOrient | number): void {
+  get_label_text_heuristics(orient: TextOrient | number): {baseline: CanvasTextBaseline, align: CanvasTextAlign} {
     const side = this.side
 
     let baseline: CanvasTextBaseline
@@ -293,8 +293,7 @@ export class SidePanel extends LayoutCanvas {
       }
     }
 
-    ctx.textBaseline = baseline
-    ctx.textAlign = align
+    return {baseline, align}
   }
 
   get_label_angle_heuristic(orient: Orient): number {

--- a/bokehjs/test/core/layout/side_panel.ts
+++ b/bokehjs/test/core/layout/side_panel.ts
@@ -12,20 +12,18 @@ import {Range1d} from "models/ranges/range1d"
 
 describe("SidePanel", () => {
 
-  describe("apply_location_heuristics", () => {
+  describe("get_label_text_heuristics", () => {
 
     it("should calculate appropriate axis_label text properties based on location", () => {
       const p1 = new SidePanel({side: 'left'})
-      const ctx1 = {} as any
-      p1.apply_label_text_heuristics(ctx1, 'parallel')
-      expect(ctx1.textBaseline).to.be.equal("alphabetic")
-      expect(ctx1.textAlign).to.be.equal("center")
+      const r1 = p1.get_label_text_heuristics('parallel')
+      expect(r1.baseline).to.be.equal("alphabetic")
+      expect(r1.align).to.be.equal("center")
 
       const p2 = new SidePanel({side: 'below'})
-      const ctx2 = {} as any
-      p2.apply_label_text_heuristics(ctx2, Math.PI/2)
-      expect(ctx2.textBaseline).to.be.equal("middle")
-      expect(ctx2.textAlign).to.be.equal("right")
+      const r2 = p2.get_label_text_heuristics(Math.PI/2)
+      expect(r2.baseline).to.be.equal("middle")
+      expect(r2.align).to.be.equal("right")
     })
   })
 

--- a/bokehjs/test/index.coffee
+++ b/bokehjs/test/index.coffee
@@ -1,3 +1,5 @@
+sinon = require("sinon")
+
 # XXX: Patch jsdom/utils before importing main jsdom. Otherwise
 #      HTMLCanvasElement will detect no canvas and make tests
 #      fail with "unable to obtain 2D rendering context".
@@ -48,3 +50,8 @@ global.Event = global.window.Event
 global.Image = global.window.Image
 global.atob = require "atob"
 global.btoa = require "btoa"
+
+# Stub get_text_height(), because jsdom doesn't allow for computing any real HTML element
+# metrics, like a normal web browser would do. APIs are just stubs and usually return 0.
+core_util_text = require("core/util/text")
+sinon.stub(core_util_text, "get_text_height", () -> {height: 15, ascent: 10, descent: 5})

--- a/bokehjs/test/models/annotations/color_bar.coffee
+++ b/bokehjs/test/models/annotations/color_bar.coffee
@@ -12,16 +12,10 @@ sinon = require 'sinon'
 {Plot} = require("models/plots/plot")
 {Range1d} = require("models/ranges/range1d")
 {Document} = require "document"
-bokeh_text  = require("core/util/text")
 
 describe "ColorBar module", ->
 
-  afterEach ->
-    bokeh_text.get_text_height.restore()
-
   beforeEach ->
-    sinon.stub(bokeh_text, "get_text_height", () -> {height: 15, ascent: 10, descent: 5})
-
     @plot = new Plot({
        x_range: new Range1d({start: 0, end: 1})
        y_range: new Range1d({start: 0, end: 1})

--- a/bokehjs/test/models/axes/axis.ts
+++ b/bokehjs/test/models/axes/axis.ts
@@ -148,8 +148,7 @@ describe("AxisView", () => {
 
   it("_axis_label_extent should be greater than the font_size", () => {
     const {axis_view} = build({axis_label: 'Left axis label'})
-    expect(axis_view._axis_label_extent()).to.be.above(0)
-    expect(axis_view._axis_label_extent()).to.be.below(10)
+    expect(axis_view._axis_label_extent()).to.be.equal(23) // assuming get_text_height() stub
   })
 
   it("_axis_label_extent should be 0 if axis_label is null", () => {

--- a/examples/integration/axes/multiline_axis_labels.py
+++ b/examples/integration/axes/multiline_axis_labels.py
@@ -1,0 +1,31 @@
+from __future__ import absolute_import
+
+from bokeh.plotting import figure, save
+from bokeh.models import CategoricalAxis
+
+f1 = "foo\n1234567\nXYZT"
+f2 = "barrrrrr\nsome long text on this line\n1234567890 xyz\nuvw uvw uvw uvw"
+f3 = "baz-100000000"
+
+factors = [f1, f2, f3]
+x = [f1, f1, f1, f2, f2, f2, f3, f3, f3]
+y = [f1, f2, f3, f1, f2, f3, f1, f2, f3]
+
+colors = [
+    "#0B486B", "#79BD9A", "#CFF09E",
+    "#79BD9A", "#0B486B", "#79BD9A",
+    "#CFF09E", "#79BD9A", "#0B486B"
+]
+
+plot = figure(title="Multiline categorical axis labels", toolbar_location=None,
+              x_range=factors, y_range=factors,
+              x_axis_type=None, y_axis_type=None)
+
+plot.add_layout(CategoricalAxis(), "left")
+plot.add_layout(CategoricalAxis(), "right")
+plot.add_layout(CategoricalAxis(), "above")
+plot.add_layout(CategoricalAxis(), "below")
+
+plot.rect(x, y, color=colors, width=1, height=1)
+
+save(plot)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/27475/48651741-91167a80-e9fc-11e8-9d41-7de0c799c26b.png)

At this point align and baseline can be configured (overriding the heuristic), but label positioning will be wrong. It would be nice to fix this here, but this will conflict greatly with the layout PR, so I suppose I will do it later. Also, baseline isn't exactly correct in this setup and I will need to introduce vertical align instead.

fixes #8169