### PR TITLE
Spelling and formatting fixes in docs

### DIFF
--- a/sphinx/source/docs/contribute.rst
+++ b/sphinx/source/docs/contribute.rst
@@ -32,7 +32,7 @@ new contributors.
 Specific areas we could use help and expertise with:
 
 * Support for mobile and touch platforms
-* Maintainance of RBokeh and other language bindings
+* Maintenance of RBokeh and other language bindings
 * Windows support and testing
 * Visual design and styling
 * WebGL performance optimization

--- a/sphinx/source/docs/dev_guide/documentation.rst
+++ b/sphinx/source/docs/dev_guide/documentation.rst
@@ -67,7 +67,7 @@ targets or the Bokeh makefile are:
 
 ``serve``
     Start a server to serve the docs open a web browser to display. Note
-    that due the the JavaScript files involved, starting a real server is
+    that due to the JavaScript files involved, starting a real server is
     necessary to view many portions of the docs fully.
 
 For example, clean the docs build directory, run the follow command at the
@@ -168,7 +168,7 @@ Models and Properties
 Bokeh's Model system supports its own system for providing detailed
 documentation for individual properties. These are given as a ``help``
 argument to the property type, which is interpreted as standard Sphinx
-ReST when the reference documenation is built. For example:
+ReST when the reference documentation is built. For example:
 
 .. code-block:: python
 

--- a/sphinx/source/docs/dev_guide/env_vars.rst
+++ b/sphinx/source/docs/dev_guide/env_vars.rst
@@ -65,7 +65,7 @@ locally or deployed to the docs site).
 ``BOKEH_DOCS_VERSION``
 ~~~~~~~~~~~~~~~~~~~~~~
 What version of Bokeh to show when building sphinx docs locally. Useful if it
-is necessay to re-deploy old docs with hotfixes.
+is necessary to re-deploy old docs with hotfixes.
 
 ``BOKEH_DOCS_CSS_SERVER``
 -------------------------

--- a/sphinx/source/docs/dev_guide/server.rst
+++ b/sphinx/source/docs/dev_guide/server.rst
@@ -34,7 +34,7 @@ Applications are represented by the ``Application`` class. This class is
 contains list of ``Handler`` instances and optional metadata. Handlers
 can be created in lots of ways; from JSON files, from Python functions, from
 Python files, and perhaps many more ways in the future.  The optional metadata
-is available as a json blob via the ``/metadata`` endpoint.  For example,
+is available as a JSON blob via the ``/metadata`` endpoint.  For example,
 creating a ``Application`` instance with::
 
     Application(metadata=dict(hi="hi", there="there"))

--- a/sphinx/source/docs/dev_guide/setup.rst
+++ b/sphinx/source/docs/dev_guide/setup.rst
@@ -36,7 +36,7 @@ Conda
 ~~~~~
 
 Developing Bokeh requires installing some software packages that are not
-Python packages (e.g. Selenium, nodejs, etc.). To make this more manageable,
+Python packages (e.g. Selenium, NodeJS, etc.). To make this more manageable,
 core developers rely heavily on the `conda package manager`_ for the free
 `Anaconda`_ Python distribution. However, ``conda`` can also install
 non-Python package dependencies, which helps streamline Bokeh development

--- a/sphinx/source/docs/installation.rst
+++ b/sphinx/source/docs/installation.rst
@@ -15,7 +15,7 @@ Supported Platforms
 ===================
 
 Bokeh is officially supported (and continuously tested) on CPython versions 2.7
-and 3.5+ only. Other Python versions or implementations may function, possiblly
+and 3.5+ only. Other Python versions or implementations may function, possibly
 limited capacity, but no guarantees or support is provided.
 
 .. _install_required:

--- a/sphinx/source/docs/user_guide.rst
+++ b/sphinx/source/docs/user_guide.rst
@@ -65,7 +65,7 @@ topic:
     in a variety of ways.
 
 :ref:`userguide_cli`
-    Use Bokeh's capabilites from the command line with the ``bokeh``
+    Use Bokeh's capabilities from the command line with the ``bokeh``
     command.
 
 :ref:`userguide_extensions`

--- a/sphinx/source/docs/user_guide/annotations.rst
+++ b/sphinx/source/docs/user_guide/annotations.rst
@@ -91,8 +91,8 @@ example of this in :bokeh-tree:`examples/models/file/legends.py`:
 Explicit Index
 ~~~~~~~~~~~~~~
 
-Other times, it may be useful to expicitly tell Bokeh which index into a
-ColumnDataSource should be used when drawing a legend item. In particuar,
+Other times, it may be useful to explicitly tell Bokeh which index into a
+``ColumnDataSource`` should be used when drawing a legend item. In particular,
 if you want to draw multiple legend items for "multi" glyphs such as
 ``MultiLine`` or ``Patches``. This is accomplished by specifying an ``index``
 for the legend item as shown below.

--- a/sphinx/source/docs/user_guide/bokehjs.rst
+++ b/sphinx/source/docs/user_guide/bokehjs.rst
@@ -9,8 +9,8 @@ and event handling in a browser. The Bokeh Python library, and libraries for
 :ref:`userguide_quickstart_other_languages` such as R, Scala, and Julia, are
 primarily a means to interact with BokehJS conveniently at a high level,
 without needing to explicitly worry about JavaScript or web development.
-However, BokehJS hasits own API, and it is possible to do pure JavaScript
-development using BokehJSdirectly. Additionally, :ref:`userguide_extensions`
+However, BokehJS has its own API, and it is possible to do pure JavaScript
+development using BokehJS directly. Additionally, :ref:`userguide_extensions`
 with custom models typically requires interacting with BokehJS directly as well.
 
 .. warning::
@@ -36,7 +36,7 @@ answering questions about BokehJS models, even though it is presented
 from a Python perspective.
 
 Unlike the hierarchical organization of the Python library, all of the
-JavaScript models are all in one flat ``Bokeh`` module.  Typically any
+JavaScript models are all in one flat ``Bokeh`` module. Typically any
 Python ``ClassName`` is available as ``Bokeh.ClassName`` from JavaScript.
 The complete list of models available from JavaScript can be seen at
 :bokeh-tree:`bokehjs/src/lib/api/models.ts`.
@@ -298,8 +298,8 @@ the following optional keys:
 :``palette``: *Palette | Array<Color>* --- a named palette, or list of colors to colormap the values
 :``axis_number_format``: *string* --- a format string to use for axis ticks
 
-By default, plots created ``Bokeh.Charts.bar`` automatically add a toroltip
-and hover policy. Here is some example code that demonstrates the ``ba``
+By default, plots created ``Bokeh.Charts.bar`` automatically add a tooltip
+and hover policy. Here is some example code that demonstrates the ``bar``
 function, with the plot it generates shown below:
 
 .. code-block:: javascript

--- a/sphinx/source/docs/user_guide/categorical.rst
+++ b/sphinx/source/docs/user_guide/categorical.rst
@@ -71,7 +71,7 @@ Since Bokeh displays bars in the order the factors are given for the range,
 "sorting" bars in a bar plot is identical to sorting the factors for the range.
 
 In the example below the fruit factors are sorted in increasing order according
-to their corresponing counts, causing the bars to be sorted:
+to their corresponding counts, causing the bars to be sorted:
 
 .. bokeh-plot:: docs/user_guide/examples/categorical_bar_sorted.py
     :source-position: above

--- a/sphinx/source/docs/user_guide/data.rst
+++ b/sphinx/source/docs/user_guide/data.rst
@@ -27,7 +27,7 @@ to the ``circle`` plotting method (see :ref:`userguide_plotting` for more exampl
 
 When you pass in data like this, Bokeh works behind the scenes to make a
 |ColumnDataSource| for you. But learning to create and use the |ColumnDataSource|
-will enable you access more advanced capabilites, such as streaming data,
+will enable you access more advanced capabilities, such as streaming data,
 sharing data between plots, and filtering data.
 
 ColumnDataSource
@@ -110,8 +110,8 @@ Pandas GroupBy
 
 If a ``GroupBy`` object is used, the CDS will have columns corresponding to the result of
 calling ``group.describe()``. The ``describe`` method generates columns for statistical measures
-such as ``mean`` and ``count`` for all the non-grouped orginal columns. The resulting ``DataFrame``
-has ``MultiIndex`` columns with the original column name and the columputed measure, so it
+such as ``mean`` and ``count`` for all the non-grouped original columns. The resulting ``DataFrame``
+has ``MultiIndex`` columns with the original column name and the computed measure, so it
 will be flattened using the aforementioned scheme. For example, if a
 ``DataFrame`` has columns ``'year'`` and ``'mpg'``. Then passing ``df.groupby('year')``
 to a CDS will result in columns such as ``'mpg_mean'``
@@ -220,7 +220,7 @@ CustomJSTransform
 ~~~~~~~~~~~~~~~~~
 
 In addition to built-in transforms above, there is also a ``CustomJSTransform``
-that allows for specifying arbitary JavaScript code to perform a tranform step
+that allows for specifying arbitrary JavaScript code to perform a transform step
 on ColumnDataSource data. Typically, the ``v_func`` (for "vectorized" function)
 is provided. (Less commonly a scalar equivalent ``func`` may also be needed).
 The ``v_func`` code should expect an array of inputs in the variable ``xs``, and
@@ -359,12 +359,12 @@ AjaxDataSource
 Bokeh server applications make it simple to update and stream data to data
 sources, but sometimes it is desirable to have similar functionality in
 standalone documents. The :class:`~bokeh.models.sources.AjaxDataSource`
-provides this cabability.
+provides this capability.
 
-The ``AjaxDataSource`` is configured with a URL to a REST endoint and a
+The ``AjaxDataSource`` is configured with a URL to a REST endpoint and a
 polling interval. In the browser, the data source will request data from the
 endpoint at the specified interval and update the data locally. Existing
-data may either be replaced entirely, or appened to (up to a configurable
+data may either be replaced entirely, or appended to (up to a configurable
 ``max_size``). The endpoint that is supplied should return a JSON dict that
 matches the standard ``ColumnDataSource`` format:
 

--- a/sphinx/source/docs/user_guide/embed.rst
+++ b/sphinx/source/docs/user_guide/embed.rst
@@ -67,7 +67,7 @@ JSON Items
 ~~~~~~~~~~
 
 Bokeh can also supply a block of JSON that can be easily consumed by a BokehJS
-to render standalone Bokeh content in a specifed div. The |json_item| function
+to render standalone Bokeh content in a specified div. The |json_item| function
 accepts a Bokeh Model (e.g. a Plot), and optionally a target ID that identifies
 a div to render into:
 
@@ -97,7 +97,7 @@ It is also possible to omit the target id when calling |json_item|
 
         item_text = json.dumps(json_item(p)) # no target_id given
 
-Then the target id can be controlled on teh JavaScript side:
+Then the target id can be controlled on the JavaScript side:
 
 .. code-block:: javascript
 
@@ -363,8 +363,8 @@ Autoload Scripts
 
 A final way to embed standalone documents is the |autoload_static| function.
 This function with provide a  ``<script>`` tag that will replace itself with
-a Bokeh plot, wherever the tag happens to be located. The script will also check f
-or BokehJS and load it, if necessary. Using this function it is possible to
+a Bokeh plot, wherever the tag happens to be located. The script will also check
+for BokehJS and load it, if necessary. Using this function it is possible to
 embed a plot by placing this script tag alone in your document.
 
 This function takes a Bokeh model (e.g. a plot) that you want to display, a
@@ -494,8 +494,8 @@ Standard template
 -----------------
 
 Bokeh also provides a standard Jinja template that can be useful for quickly
-embedding differnet document roots flexibly by extending the "base" template.
-This is especially useful for embedding individal components of a Bokeh app
+embedding different document roots flexibly by extending the "base" template.
+This is especially useful for embedding individual components of a Bokeh app
 in a non-Bokeh layout (e.g. Bootstrap, etc.).
 
 Below is a minimal example. Assuming that the application creates two roots

--- a/sphinx/source/docs/user_guide/extensions.rst
+++ b/sphinx/source/docs/user_guide/extensions.rst
@@ -197,7 +197,7 @@ the know extensions ``.coffee``, ``.js``, or ``.ts`` then the it is interpreted
 as a filename. The corresponding file is opened and its contents are compiled
 appropriately according to the file extension.
 
-Othewise, if the implementation is inline in the class, the language for the
+Otherwise, if the implementation is inline in the class, the language for the
 source code may be explicitly provided by using the classes ``CoffeeScript``,
 ``JavaScript``, or ``TypeScript``, e.g.
 
@@ -215,7 +215,7 @@ Supplying External Resources
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As part of implementing a custom model in Bokeh, there may be the need to
-include third-party javascript libraries or css resources. Bokeh supports
+include third-party Javascript libraries or CSS resources. Bokeh supports
 supplying external resources through the Python class attributes
 ``__javascript__`` and ``__css__`` of custom models.
 
@@ -223,15 +223,15 @@ Including the URL paths to external resources will causes Bokeh to add
 the resources to the html document head, causing the Javascript library to be
 available in the global namespace and the custom CSS styling to be applied.
 
-One example is including the JS and CSS files for `KaTex`_ (a
-Javascript-based typesetting library that supports LaTex) in order to create
-a ``LaTexLabel`` custom model.
+One example is including the JS and CSS files for `KaTeX`_ (a
+Javascript-based typesetting library that supports LaTeX) in order to create
+a ``LatexLabel`` custom model.
 
 .. code-block:: python
 
     class LatexLabel(Label):
         """A subclass of the Bokeh built-in `Label` that supports rendering
-        LaTex using the KaTex typesetting library.
+        LaTeX using the KaTeX typesetting library.
         """
         __javascript__ = "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.js"
         __css__ = "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.css"
@@ -239,7 +239,7 @@ a ``LaTexLabel`` custom model.
         # do something here
         """
 
-See the LaTex example in the extensions gallery below to see the full
+See the LaTeX example in the extensions gallery below to see the full
 implementation and resulting output.
 
 .. _userguide_extensions_structure_server_integration:
@@ -289,11 +289,11 @@ and improvements to this section for future users.
     a Bokeh custom extension.
 
 :ref:`userguide_extensions_examples_latex`
-    Include a third-party JavaScript library in order to render LaTex.
+    Include a third-party JavaScript library in order to render LaTeX.
 
 :ref:`userguide_extensions_examples_widget`
     Include a third-party JavaScript library in an extension widget.
 
 .. _CoffeeScript: http://coffeescript.org
-.. _KaTex: https://khan.github.io/KaTeX/
+.. _KaTeX: https://khan.github.io/KaTeX/
 .. _TypeScript: https://www.typescriptlang.org/

--- a/sphinx/source/docs/user_guide/extensions_gallery/latex.rst
+++ b/sphinx/source/docs/user_guide/extensions_gallery/latex.rst
@@ -3,10 +3,10 @@
 Creating Latex Labels
 ---------------------
 
-This example shows how to create a custom ``LaTexLabel`` class that uses a
-third party Javascript library, `KaTex`_, in order to render LaTex onto the plot.
+This example shows how to create a custom ``LatexLabel`` class that uses a
+third party Javascript library, `KaTeX`_, in order to render LaTeX onto the plot.
 
 .. bokeh-plot:: docs/user_guide/examples/extensions_example_latex.py
     :source-position: below
 
-.. _KaTex: https://khan.github.io/KaTeX/
+.. _KaTeX: https://khan.github.io/KaTeX/

--- a/sphinx/source/docs/user_guide/extensions_gallery/widget.rst
+++ b/sphinx/source/docs/user_guide/extensions_gallery/widget.rst
@@ -16,7 +16,7 @@ Python script:
 .. literalinclude:: ../examples/extensions_example_widget.py
    :language: python
 
-Coffeescript for ion range slider:
+CoffeeScript for ion range slider:
 
 .. literalinclude:: ../examples/extensions_ion_range_slider.coffee
    :language: coffee

--- a/sphinx/source/docs/user_guide/interaction/callbacks.rst
+++ b/sphinx/source/docs/user_guide/interaction/callbacks.rst
@@ -108,7 +108,7 @@ variable:
     callback = CustomJS(code="""
     // the event that triggered the callback is cb_obj:
     // The event type determines the relevant attributes
-    console.log('Tap event occured at x-position: ' + cb_obj.x)
+    console.log('Tap event occurred at x-position: ' + cb_obj.x)
     """)
 
     p = figure()
@@ -195,7 +195,7 @@ a line through that value.
 CustomJS for Hover
 ''''''''''''''''''
 
-The HoverTool has a callback which comes with two pieces of built-in data: the
+The ``HoverTool`` has a callback which comes with two pieces of built-in data: the
 `index`, and the `geometry`. The `index` is the indices of any points that the
 hover tool is over.
 
@@ -206,7 +206,7 @@ CustomJS for Range Update
 '''''''''''''''''''''''''
 
 With Bokeh, ranges have a callback attribute that accept a Callback instance
-and execute javascript code on range updates that are triggered by tool
+and execute Javascript code on range updates that are triggered by tool
 interactions such as a box zoom, wheel scroll or pan.
 
 .. bokeh-plot:: docs/user_guide/examples/interaction_callbacks_for_range_update.py

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -208,7 +208,7 @@ Notice that we have not specified an output or connection method anywhere in
 this code. It is a simple script that creates and updates objects. The
 flexibility of the ``bokeh`` command line tool means that we can defer
 output options until the end. We could, e.g., run ``bokeh json myapp.py`` to
-get a JSON serialized version of the the application. But in this case,
+get a JSON serialized version of the application. But in this case,
 we would like to run the app on a Bokeh server, so we execute:
 
 .. code-block:: sh
@@ -274,7 +274,7 @@ The full set of files that Bokeh server knows about is:
 
 The optional components are
 
-* A ``server_lifecycle.py`` file that allows optional callbacks to be triggered at different stages of application creation, as descriped in :ref:`userguide_server_applications_lifecycle`.
+* A ``server_lifecycle.py`` file that allows optional callbacks to be triggered at different stages of application creation, as described in :ref:`userguide_server_applications_lifecycle`.
 
 * A ``static`` subdirectory that can be used to serve static resources associated with this application.
 
@@ -542,7 +542,7 @@ locked session callback on a different update rate.
     def locked_update(i):
         source.stream(dict(x=[source.data['x'][-1]+1], y=[i], color=["blue"]))
 
-    # this unclocked callback will not prevent other session callbacks from
+    # this unlocked callback will not prevent other session callbacks from
     # executing while it is in flight
     @gen.coroutine
     @without_document_lock
@@ -717,6 +717,7 @@ with it. To share it with other people who are able to install the required
 python stack, we can share the application with them, and let them run it locally
 themselves in the same manner. However, we might also want to deploy the application
 in a way that other people can access it as a service:
+
 * without having to install all of the prerequisites
 * without needing to have the source code
 * like any other webpage
@@ -771,7 +772,7 @@ Bokeh server were running on the local machine.
 
 The second, slightly more complicated case occurs when there is a gateway
 between the server and the local machine.  In that situation a reverse tunnel
-must be estabished from the server to the gateway. Additionally the tunnel
+must be established from the server to the gateway. Additionally the tunnel
 from the local machine will also point to the gateway.
 
 Issue the following commands on the **remote host** where the Bokeh server
@@ -822,7 +823,7 @@ Nginx
 '''''
 
 One very common HTTP and reverse-proxying server is Nginx. A sample
-server confuguration block is shown below:
+server configuration block is shown below:
 
 .. code-block:: nginx
 
@@ -877,7 +878,7 @@ to a global static directory during your deployment process. See
 Apache
 ''''''
 
-Another common HTTP server and proxy is Apache. Here is sample confuguration
+Another common HTTP server and proxy is Apache. Here is sample configuration
 for running a Bokeh server behind Apache:
 
 .. code-block:: apache


### PR DESCRIPTION
Fixes various typo/spelling/formatting mistakes in the documentation. Other than fixing things as I read through, I mostly used a spellchecker to find mistakes, so there may be more I missed.

- [ ] issues: addresses #8448 
