### PR TITLE
Documentation cleanup

### DIFF
--- a/bokeh/application/application.py
+++ b/bokeh/application/application.py
@@ -78,7 +78,7 @@ class Application(object):
                 The URL is taken from the first one only.
 
         Keyword Args:
-            metadata (dict): abitrary user-supplied JSON data to make available
+            metadata (dict): arbitrary user-supplied JSON data to make available
                 with the application.
 
                 The server will provide a URL ``http://applicationurl/metadata``
@@ -251,7 +251,7 @@ class ServerContext(with_metaclass(ABCMeta)):
 
     @abstractproperty
     def sessions(self):
-        ''' SessionContext instances belonging to this application.
+        ''' ``SessionContext`` instances belonging to this application.
 
         *Subclasses must implement this method.*
 

--- a/bokeh/application/handlers/directory.py
+++ b/bokeh/application/handlers/directory.py
@@ -6,7 +6,7 @@
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 '''  Provide a Bokeh Application Handler to build up documents by running
-the code from ``main.py`` or `main.ipynb`` files in specified directories.
+the code from ``main.py`` or ``main.ipynb`` files in specified directories.
 
 The directory may also optionally contain:
 

--- a/bokeh/application/handlers/handler.py
+++ b/bokeh/application/handlers/handler.py
@@ -193,7 +193,7 @@ class Handler(object):
             return self._static
 
     def url_path(self):
-        ''' Returs a default URL path, if applicable.
+        ''' Returns a default URL path, if applicable.
 
         Handlers subclasses may optionally implement this method, to inform
         the Bokeh application what URL it should be installed at.

--- a/bokeh/client/connection.py
+++ b/bokeh/client/connection.py
@@ -59,7 +59,7 @@ __all__ = (
 #-----------------------------------------------------------------------------
 
 class ClientConnection(object):
-    ''' A Bokeh low-level class used to implement ClientSession; use ClientSession to connect to the server.
+    ''' A Bokeh low-level class used to implement ``ClientSession``; use ``ClientSession`` to connect to the server.
 
     '''
 
@@ -133,7 +133,7 @@ class ClientConnection(object):
         self._send_request_server_info()
 
     def loop_until_closed(self):
-        ''' Execute a blocking loop that runs and exectutes event callbacks
+        ''' Execute a blocking loop that runs and executes event callbacks
         until the connection is closed (e.g. by hitting Ctrl-C).
 
         While this method can be used to run Bokeh application code "outside"

--- a/bokeh/client/session.py
+++ b/bokeh/client/session.py
@@ -108,7 +108,7 @@ def pull_session(session_id=None, url='default', io_loop=None, arguments=None):
                 can also be `"default"` which will connect to the default app URL
 
         io_loop (``tornado.ioloop.IOLoop``, optional) :
-            The IOLoop to use for the websocket
+            The ``IOLoop`` to use for the websocket
 
         arguments (dict[str, str], optional) :
             A dictionary of key/values to be passed as HTTP request arguments
@@ -120,7 +120,7 @@ def pull_session(session_id=None, url='default', io_loop=None, arguments=None):
 
     Returns:
         ClientSession :
-            A new ClientSession connected to the server
+            A new ``ClientSession`` connected to the server
 
     '''
 
@@ -222,12 +222,12 @@ class ClientSession(object):
     ''' Represents a websocket connection to a server-side session.
 
     Each server session stores a Document, which is kept in sync with the
-    corresponding Document for this ClientSession instance. Udates on either
-    side of the connection will automatically propagate to the other side, as
-    long as the connectiion is open.
+    corresponding Document for this ``ClientSession`` instance. Updates on
+    either side of the connection will automatically propagate to the other
+    side, as long as the connection is open.
 
     ClientSession objects can (and usually should) be used as a context manager
-    so that the sesssion is properly closed:
+    so that the session is properly closed:
 
     .. code-block:: python
 
@@ -236,7 +236,7 @@ class ClientSession(object):
             script = server_session(session_id=mysession.id, url=app_url)
             return render_template("embed.html", script=script, template="Flask")
 
-    If you do not use ClientSesssion in this way, it is up to you to ensure
+    If you do not use ``ClientSession`` in this way, it is up to you to ensure
     that ``session.close()`` is called.
 
     '''
@@ -340,7 +340,7 @@ class ClientSession(object):
         self._connection.force_roundtrip()
 
     def loop_until_closed(self, suppress_warning=False):
-        ''' Execute a blocking loop that runs and exectutes event callbacks
+        ''' Execute a blocking loop that runs and executes event callbacks
         until the connection is closed (e.g. by hitting Ctrl-C).
 
         While this method can be used to run Bokeh application code "outside"
@@ -495,7 +495,7 @@ The use of `session.loop_until_closed` and `push_session` to run Bokeh
 application code outside a Bokeh server is **HIGHLY DISCOURAGED** for any real
 use.
 
-Running application code outside a Bokeh server with bokeh.client in this way
+Running application code outside a Bokeh server with ``bokeh.client`` in this way
 has (and always will have) several intrinsic drawbacks:
 
 * Fast binary array transport is NOT available! Base64 fallback is much slower
@@ -503,7 +503,7 @@ has (and always will have) several intrinsic drawbacks:
 * Server *and* client process must be running at ALL TIMES for callbacks to work
 * App code run outside the Bokeh server is NOT SCALABLE behind a load balancer
 
-The bokeh.client API is recommended to use ONLY for testing, or for customizing
+The ``bokeh.client`` API is recommended to use ONLY for testing, or for customizing
 individual sessions running in a full Bokeh server, before passing on to viewers.
 
 For information about different ways of running apps in a Bokeh server, see:

--- a/bokeh/client/websocket.py
+++ b/bokeh/client/websocket.py
@@ -47,7 +47,7 @@ __all__ = (
 #-----------------------------------------------------------------------------
 
 class WebSocketClientConnectionWrapper(object):
-    ''' Used for compat across Tornado versions and to add write_lock'''
+    ''' Used for compatibility across Tornado versions and to add write_lock'''
 
     def __init__(self, socket):
         if socket is None:

--- a/bokeh/colors/color.py
+++ b/bokeh/colors/color.py
@@ -56,7 +56,7 @@ class Color(object):
             value (float) :
                 A number to clamp.
 
-            maxiumum (float, optional) :
+            maximum (float, optional) :
                 A max bound to to clamp to. If None, there is no upper bound,
                 and values are only clamped to be non-negative. (default: None)
 

--- a/bokeh/core/enums.py
+++ b/bokeh/core/enums.py
@@ -212,7 +212,7 @@ def enumeration(*values, **kwargs):
 
     return type(str("Enumeration"), (Enumeration,), attrs)()
 
-#: Specify an achor position on a box/frame
+#: Specify an anchor position on a box/frame
 Anchor = enumeration(
     "top_left",    "top_center",    "top_right",
     "center_left", "center",        "center_right",

--- a/bokeh/core/has_props.py
+++ b/bokeh/core/has_props.py
@@ -475,7 +475,7 @@ class HasProps(with_metaclass(MetaHasProps, object)):
         properties defined on any parent classes.
 
         Returns:
-            set[str] : names of DataSpec properties
+            set[str] : names of ``DataSpec`` properties
 
         '''
         return set(cls.dataspecs_with_props().keys())

--- a/bokeh/core/json_encoder.py
+++ b/bokeh/core/json_encoder.py
@@ -220,7 +220,7 @@ class BokehJSONEncoder(json.JSONEncoder):
             return super(BokehJSONEncoder, self).default(obj)
 
     def default(self, obj):
-        ''' The required ``default`` method for JSONEncoder subclasses.
+        ''' The required ``default`` method for ``JSONEncoder`` subclasses.
 
         Args:
             obj (obj) :

--- a/bokeh/core/property/bases.py
+++ b/bokeh/core/property/bases.py
@@ -384,7 +384,7 @@ class Property(PropertyDescriptorFactory):
         Args:
             fn (callable) :
                 A function accepting ``(obj, value)`` that returns True if the value
-                passes the assertion, or False othwise
+                passes the assertion, or False otherwise.
 
             msg_or_fn (str or callable) :
                 A message to print in case the assertion fails, or a function

--- a/bokeh/core/property/descriptor_factory.py
+++ b/bokeh/core/property/descriptor_factory.py
@@ -83,7 +83,7 @@ __all__ = (
 class PropertyDescriptorFactory(object):
     ''' Base class for all Bokeh properties.
 
-    A Bokeh property really consist of two parts: the familar "property"
+    A Bokeh property really consist of two parts: the familiar "property"
     portion, such as ``Int``, ``String``, etc., as well as an associated
     Python descriptor that delegates attribute access (e.g. ``range.start``)
     to the property instance.

--- a/bokeh/core/property/descriptors.py
+++ b/bokeh/core/property/descriptors.py
@@ -13,7 +13,7 @@ descriptor protocol to provide easy-to-use, declarative, type-based
 class properties that can automatically validate and serialize their
 values, as well as help provide sophisticated documentation.
 
-A Bokeh property really consist of two parts: a familar "property"
+A Bokeh property really consist of two parts: a familiar "property"
 portion, such as ``Int``, ``String``, etc., as well as an associated
 Python descriptor that delegates attribute access to the property instance.
 
@@ -436,7 +436,7 @@ class PropertyDescriptor(object):
         raise NotImplementedError("Implement _internal_set()")
 
 class BasicPropertyDescriptor(PropertyDescriptor):
-    ''' A PropertyDescriptor for basic Bokeh properties (e.g, ``Int``,
+    ''' A ``PropertyDescriptor`` for basic Bokeh properties (e.g, ``Int``,
     ``String``, ``Float``, etc.) with simple get/set and serialization
     behavior.
 
@@ -917,7 +917,7 @@ class BasicPropertyDescriptor(PropertyDescriptor):
 
 
 class ColumnDataPropertyDescriptor(BasicPropertyDescriptor):
-    ''' A PropertyDescriptor specialized to handling ``ColumnData`` properties.
+    ''' A ``PropertyDescriptor`` specialized to handling ``ColumnData`` properties.
 
     '''
 
@@ -974,7 +974,7 @@ class ColumnDataPropertyDescriptor(BasicPropertyDescriptor):
         self._internal_set(obj, value, hint=hint, setter=setter)
 
 class DataSpecPropertyDescriptor(BasicPropertyDescriptor):
-    ''' A PropertyDescriptor for Bokeh |DataSpec| properties that serialize to
+    ''' A ``PropertyDescriptor`` for Bokeh |DataSpec| properties that serialize to
     field/value dictionaries.
 
     '''
@@ -1029,7 +1029,7 @@ class DataSpecPropertyDescriptor(BasicPropertyDescriptor):
         super(DataSpecPropertyDescriptor, self).set_from_json(obj, json, models, setter)
 
 class UnitsSpecPropertyDescriptor(DataSpecPropertyDescriptor):
-    ''' A PropertyDecscriptor for Bokeh |UnitsSpec| properties that contribute
+    ''' A ``PropertyDecscriptor`` for Bokeh |UnitsSpec| properties that contribute
     associated ``_units`` properties automatically as a side effect.
 
     '''

--- a/bokeh/core/validation/decorators.py
+++ b/bokeh/core/validation/decorators.py
@@ -101,7 +101,7 @@ def error(code_or_name):
     Returns:
         callable : decorator for Bokeh model methods
 
-    The function that is decoratate should have a name that starts with
+    The function that is decorated should have a name that starts with
     ``_check``, and return a string message in case a bad condition is
     detected, and ``None`` if no bad condition is detected.
 
@@ -141,7 +141,7 @@ def warning(code_or_name):
     Returns:
         callable : decorator for Bokeh model methods
 
-    The function that is decoratate should have a name that starts with
+    The function that is decorated should have a name that starts with
     ``_check``, and return a string message in case a bad condition is
     detected, and ``None`` if no bad condition is detected.
 

--- a/bokeh/core/validation/errors.py
+++ b/bokeh/core/validation/errors.py
@@ -45,7 +45,7 @@ validation checks.
     dimension (will result in blank plot).
 
 1010 *(CDSVIEW_SOURCE_DOESNT_MATCH)*
-    A |GlyphRenderer| has a CDSView whose source doesn't match the GlyphRenderer's
+    A |GlyphRenderer| has a ``CDSView`` whose source doesn't match the ``GlyphRenderer``'s
     data source.
 
 1011 *(MALFORMED_GRAPH_SOURCE)*
@@ -55,31 +55,31 @@ validation checks.
     Map plots can only support ``Range1d`` types, not data ranges.
 
 1013 *(INCOMPATIBLE_POINT_DRAW_RENDERER)*
-    The PointDrawTool renderers may only reference XYGlyph models.
+    The ``PointDrawTool`` renderers may only reference ``XYGlyph`` models.
 
 1014 *(INCOMPATIBLE_BOX_EDIT_RENDERER)*
-    The BoxEditTool renderers may only reference Rect glyph models.
+    The ``BoxEditTool`` renderers may only reference ``Rect`` glyph models.
 
 1015 *(INCOMPATIBLE_POLY_DRAW_RENDERER)*
-    The PolyDrawTool renderers may only reference MultiLine and Patches glyph models.
+    The ``PolyDrawTool`` renderers may only reference ``MultiLine`` and ``Patches`` glyph models.
 
 1016 *(INCOMPATIBLE_POLY_EDIT_RENDERER)*
-    The PolyEditTool renderers may only reference MultiLine and Patches glyph models.
+    The ``PolyEditTool`` renderers may only reference ``MultiLine`` and ``Patches`` glyph models.
 
 1017 *(INCOMPATIBLE_POLY_EDIT_VERTEX_RENDERER)*
-    The PolyEditTool vertex_renderer may only reference XYGlyph models.
+    The ``PolyEditTool`` vertex_renderer may only reference ``XYGlyph`` models.
 
 1018 *(NO_RANGE_TOOL_RANGES)*
-    The RangeTool must have at least one of x_range or y_range configured
+    The ``RangeTool`` must have at least one of ``x_range`` or ``y_range`` configured
 
 1019 *(DUPLICATE_FACTORS)*
-    FactorRange must specify a unique list of categorical factors for an axis.
+    ``FactorRange`` must specify a unique list of categorical factors for an axis.
 
 1020 *(BAD_EXTRA_RANGE_NAME)*
-    An extra range name is configued with a name that does not correspond to any range.
+    An extra range name is configured with a name that does not correspond to any range.
 
 1021 *(EQUAL_SLIDER_START_END)*
-    noUiSlider most have a nonequal start and end.
+    ``noUiSlider`` most have a nonequal start and end.
 
 9999 *(EXT)*
     Indicates that a custom error check has failed.

--- a/bokeh/embed/standalone.py
+++ b/bokeh/embed/standalone.py
@@ -313,14 +313,14 @@ def file_html(models,
                                           template=template, template_variables=template_variables)
 
 def json_item(model, target=None, theme=FromCurdoc):
-    ''' Return a JSON block that can be used to embed standalone Bokeh conent.
+    ''' Return a JSON block that can be used to embed standalone Bokeh content.
 
     Args:
         model (Model) :
             The Bokeh object to embed
 
         target (string, optional)
-            A div id to embd the model into. If None, the target id must
+            A div id to embed the model into. If None, the target id must
             be supplied in the JavaScript call.
 
         theme (Theme, optional) :
@@ -355,7 +355,7 @@ def json_item(model, target=None, theme=FromCurdoc):
             .then(function(item) { Bokeh.embed.embed_item(item); })
         </script>
 
-    Alternatively, if is more convenient to suppluy the target div id directly
+    Alternatively, if is more convenient to supply the target div id directly
     in the page source, that is also possible. If `target_id` is omitted in the
     call to this function:
 

--- a/bokeh/events.py
+++ b/bokeh/events.py
@@ -198,7 +198,7 @@ class ButtonClick(Event):
         super(ButtonClick, self).__init__(model=model)
 
 class PlotEvent(Event):
-    ''' PlotEvent is the base class for all events applicable to Plot models.
+    ''' The base class for all events applicable to Plot models.
 
     '''
 
@@ -251,7 +251,7 @@ class SelectionGeometry(PlotEvent):
         super(SelectionGeometry, self).__init__(model=model)
 
 class Reset(PlotEvent):
-    ''' Announce a button click event on a plot ResetTool.
+    ''' Announce a button click event on a plot ``ResetTool``.
 
     '''
     event_name = "reset"
@@ -379,8 +379,8 @@ class MouseWheel(PointEvent):
 
     .. note::
         By default, Bokeh plots do not prevent default scroll events unless a
-        WheelZoomTool or WheelPanTool is active. This may change in future
-        releases.
+        ``WheelZoomTool`` or ``WheelPanTool`` is active. This may change in
+        future releases.
 
     '''
     event_name = 'wheel'

--- a/bokeh/io/export.py
+++ b/bokeh/io/export.py
@@ -58,7 +58,7 @@ __all__ = (
 #-----------------------------------------------------------------------------
 
 def export_png(obj, filename=None, height=None, width=None, webdriver=None):
-    ''' Export the LayoutDOM object or document as a PNG.
+    ''' Export the ``LayoutDOM`` object or document as a PNG.
 
     If the filename is not given, it is derived from the script name
     (e.g. ``/foo/myplot.py`` will create ``/foo/myplot.png``)
@@ -120,8 +120,8 @@ def export_svgs(obj, filename=None, height=None, width=None, webdriver=None):
             to export the image.
 
     Returns:
-        filenames (list(str)) : the list of filenames where the SVGs files
-            are saved.
+        filenames (list(str)) : the list of filenames where the SVGs files are
+        saved.
 
     .. warning::
         Responsive sizing_modes may generate layouts with unexpected size and
@@ -172,7 +172,7 @@ def create_webdriver():
     return webdriver_control.create()
 
 def get_screenshot_as_png(obj, driver=None, **kwargs):
-    ''' Get a screenshot of a LayoutDOM object.
+    ''' Get a screenshot of a ``LayoutDOM`` object.
 
     Args:
         obj (LayoutDOM or Document) : a Layout (Row/Column), Plot or Widget

--- a/bokeh/io/output.py
+++ b/bokeh/io/output.py
@@ -47,7 +47,7 @@ def output_file(filename, title="Bokeh Plot", mode="cdn", root_dir=None):
     '''Configure the default output state to generate output saved
     to a file when :func:`show` is called.
 
-    Does not change the current Document from curdoc(). File and notebook
+    Does not change the current ``Document`` from ``curdoc()``. File and notebook
     output may be active at the same time, so e.g., this does not clear the
     effects of ``output_notebook()``.
 

--- a/bokeh/io/showing.py
+++ b/bokeh/io/showing.py
@@ -63,8 +63,8 @@ def show(obj, browser=None, new="tab", notebook_handle=False, notebook_url="loca
 
             In a Jupyter notebook, a Bokeh application or callable may also
             be passed. A callable will be turned into an Application using a
-            FunctionHandler. The application will be run and displayed inline
-            in the associated notebook output cell.
+            ``FunctionHandler``. The application will be run and displayed
+            inline in the associated notebook output cell.
 
         browser (str, optional) :
             Specify the browser to use to open output files(default: None)

--- a/bokeh/io/state.py
+++ b/bokeh/io/state.py
@@ -155,7 +155,7 @@ class State(object):
             root_dir (str, optional) : root dir to use for absolute resources
                 (default: None)
 
-                This value is ignored for other resource types, e.g. ``INLINE`` or``CDN``.
+                This value is ignored for other resource types, e.g. ``INLINE`` or ``CDN``.
 
         .. warning::
             The specified output file will be overwritten on every save, e.g.,

--- a/bokeh/model.py
+++ b/bokeh/model.py
@@ -301,7 +301,7 @@ class Model(with_metaclass(MetaModel, HasProps, PropertyCallbackManager, EventCa
         [GlyphRenderer(id='1de4c3df-a83d-480a-899b-fb263d3d5dd9', ...)]
 
     Or simply a convenient way to attach any necessary metadata to a model
-    that can be accessed by CustomJS callbacks, etc.
+    that can be accessed by ``CustomJS`` callbacks, etc.
 
     .. note::
         No uniqueness guarantees or other conditions are enforced on any tags
@@ -312,14 +312,14 @@ class Model(with_metaclass(MetaModel, HasProps, PropertyCallbackManager, EventCa
 
     js_event_callbacks = Dict(String, List(Instance("bokeh.models.callbacks.CustomJS")),
     help="""
-    A mapping of event names to lists of CustomJS callbacks.
+    A mapping of event names to lists of ``CustomJS`` callbacks.
 
     Typically, rather then modifying this property directly, callbacks should be
     added using the ``Model.js_on_event`` method:
 
     .. code:: python
 
-        callback = CustomJS(code="console.log('tap event occured')")
+        callback = CustomJS(code="console.log('tap event occurred')")
         plot.js_on_event('tap', callback)
     """)
 
@@ -330,7 +330,7 @@ class Model(with_metaclass(MetaModel, HasProps, PropertyCallbackManager, EventCa
     """)
 
     js_property_callbacks = Dict(String, List(Instance("bokeh.models.callbacks.CustomJS")), help="""
-    A mapping of attribute names to lists of CustomJS callbacks, to be set up on
+    A mapping of attribute names to lists of ``CustomJS`` callbacks, to be set up on
     BokehJS side when the document is created.
 
     Typically, rather then modifying this property directly, callbacks should be
@@ -398,7 +398,7 @@ class Model(with_metaclass(MetaModel, HasProps, PropertyCallbackManager, EventCa
 
 
     def js_on_change(self, event, *callbacks):
-        ''' Attach a CustomJS callback to an arbitrary BokehJS model event.
+        ''' Attach a ``CustomJS`` callback to an arbitrary BokehJS model event.
 
         On the BokehJS side, change events for model properties have the
         form ``"change:property_name"``. As a convenience, if the event name
@@ -531,7 +531,7 @@ class Model(with_metaclass(MetaModel, HasProps, PropertyCallbackManager, EventCa
         need to separately have the full attributes of those
         other objects.
 
-        There's no corresponding from_json() because to
+        There's no corresponding ``from_json()`` because to
         deserialize an object is normally done in the context of a
         Document (since the Document can resolve references).
 
@@ -553,7 +553,7 @@ class Model(with_metaclass(MetaModel, HasProps, PropertyCallbackManager, EventCa
         will need to separately have the full attributes of those
         other objects.
 
-        There's no corresponding from_json_string() because to
+        There's no corresponding ``from_json_string()`` because to
         deserialize an object is normally done in the context of a
         Document (since the Document can resolve references).
 
@@ -580,7 +580,7 @@ class Model(with_metaclass(MetaModel, HasProps, PropertyCallbackManager, EventCa
         # The explicit assumption here is that hinted events do not need to
         # go through all the same invalidation steps. Currently this is the
         # case for ColumnsStreamedEvent and ColumnsPatchedEvent. However,
-        # this may need to be further refined in the future, if the a
+        # this may need to be further refined in the future, if the
         # assumption does not hold for future hinted events (e.g. the hint
         # could specify explicitly whether to do normal invalidation or not)
         if hint is None:
@@ -635,7 +635,7 @@ class Model(with_metaclass(MetaModel, HasProps, PropertyCallbackManager, EventCa
         That's what "json like" means.
 
         This method should be considered "private" or "protected",
-        for use internal to Bokeh; use to_json() instead because
+        for use internal to Bokeh; use ``to_json()`` instead because
         it gives you only plain JSON-compatible types.
 
         Args:

--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -44,8 +44,8 @@ class TextAnnotation(Annotation):
     '''
 
     render_mode = Enum(RenderMode, default="canvas", help="""
-    Specifies whether the text is rendered as a canvas element or as an
-    css element overlaid on the canvas. The default mode is "canvas".
+    Specifies whether the text is rendered as a canvas element or as a
+    CSS element overlaid on the canvas. The default mode is "canvas".
 
     .. note::
         The CSS labels won't be present in the output using the "save" tool.
@@ -90,7 +90,7 @@ class LegendItem(Model):
     refer to a column name, the legend will have "groupby" behavior, and will
     choose and display representative points from every "group" in the column.
 
-    If set to a number, Bokeh will use that numbner as the index in all cases.
+    If set to a number, Bokeh will use that number as the index in all cases.
     """)
 
     @error(NON_MATCHING_DATA_SOURCES_ON_LEGEND_ITEM_RENDERERS)
@@ -193,7 +193,7 @@ class Legend(Annotation):
     """)
 
     spacing = Int(3, help="""
-    Amount of spacing (in pixles) between legend entries.
+    Amount of spacing (in pixels) between legend entries.
     """)
 
     items = List(Instance(LegendItem), help="""
@@ -278,7 +278,7 @@ class ColorBar(Annotation):
     """)
 
     formatter = Instance(TickFormatter, default=lambda: BasicTickFormatter(), help="""
-    A TickFormatter to use for formatting the visual appearance of ticks.
+    A ``TickFormatter`` to use for formatting the visual appearance of ticks.
     """)
 
     major_label_overrides = Dict(Either(Float, String), String, default={}, help="""
@@ -290,8 +290,8 @@ class ColorBar(Annotation):
     A continuous color mapper containing a color palette to render.
 
     .. warning::
-        If the `low` and `high` attributes of the ColorMapper aren't set, ticks
-        and tick labels won't be rendered. Additionally, if a LogTicker is
+        If the `low` and `high` attributes of the ``ColorMapper`` aren't set, ticks
+        and tick labels won't be rendered. Additionally, if a ``LogTicker`` is
         passed to the `ticker` argument and either or both of the logarithms
         of `low` and `high` values of the color_mapper are non-numeric
         (i.e. `low=0`), the tick and tick labels won't be rendered.
@@ -395,7 +395,7 @@ class Arrow(Annotation):
     """)
 
     start = Instance('.models.arrow_heads.ArrowHead', default=None, help="""
-    Instance of ArrowHead.
+    Instance of ``ArrowHead``.
     """)
 
     x_end = NumberSpec(help="""
@@ -412,7 +412,7 @@ class Arrow(Annotation):
     """)
 
     end = Instance('.models.arrow_heads.ArrowHead', default=_DEFAULT_ARROW, help="""
-    Instance of ArrowHead.
+    Instance of ``ArrowHead``.
     """)
 
     body_props = Include(LineProps, use_prefix=False, help="""
@@ -532,7 +532,7 @@ class Band(Annotation):
     """)
 
     upper = DistanceSpec(help="""
-    The coordinations of the upper portion of the filled area band.
+    The coordinates of the upper portion of the filled area band.
     """)
 
     base = DistanceSpec(help="""
@@ -707,7 +707,7 @@ class LabelSet(TextAnnotation):
     """)
 
     x_units = Enum(SpatialUnits, default='data', help="""
-    The unit type for the xs attribute. Interpreted as "data space" units
+    The unit type for the ``xs`` attribute. Interpreted as "data space" units
     by default.
     """)
 
@@ -716,7 +716,7 @@ class LabelSet(TextAnnotation):
     """)
 
     y_units = Enum(SpatialUnits, default='data', help="""
-    The unit type for the ys attribute. Interpreted as "data space" units
+    The unit type for the ``ys`` attribute. Interpreted as "data space" units
     by default.
     """)
 
@@ -788,7 +788,7 @@ class PolyAnnotation(Annotation):
     """)
 
     xs_units = Enum(SpatialUnits, default='data', help="""
-    The unit type for the xs attribute. Interpreted as "data space" units
+    The unit type for the ``xs`` attribute. Interpreted as "data space" units
     by default.
     """)
 
@@ -797,7 +797,7 @@ class PolyAnnotation(Annotation):
     """)
 
     ys_units = Enum(SpatialUnits, default='data', help="""
-    The unit type for the ys attribute. Interpreted as "data space" units
+    The unit type for the ``ys`` attribute. Interpreted as "data space" units
     by default.
     """)
 
@@ -887,8 +887,8 @@ class Span(Annotation):
     """)
 
     render_mode = Enum(RenderMode, default="canvas", help="""
-    Specifies whether the span is rendered as a canvas element or as an
-    css element overlaid on the canvas. The default mode is "canvas".
+    Specifies whether the span is rendered as a canvas element or as a
+    CSS element overlaid on the canvas. The default mode is "canvas".
 
     .. warning::
         The line_dash and line_dash_offset attributes aren't supported if
@@ -910,11 +910,11 @@ class Title(TextAnnotation):
     """)
 
     vertical_align = Enum(VerticalAlign, default='bottom', help="""
-    Aligment of the text in its enclosing space, *across* the direction of the text.
+    Alignment of the text in its enclosing space, *across* the direction of the text.
     """)
 
     align = Enum(TextAlign, default='left', help="""
-    Aligment of the text in its enclosing space, *along* the direction of the text.
+    Alignment of the text in its enclosing space, *along* the direction of the text.
     """)
 
     offset = Float(default=0, help="""
@@ -1020,15 +1020,15 @@ class Whisker(Annotation):
     """)
 
     lower_head = Instance('.models.arrow_heads.ArrowHead', default=_DEFAULT_TEE, help="""
-    Instance of ArrowHead.
+    Instance of ``ArrowHead``.
     """)
 
     upper = DistanceSpec(help="""
-    The coordinations of the upper end of the whiskers.
+    The coordinates of the upper end of the whiskers.
     """)
 
     upper_head = Instance('.models.arrow_heads.ArrowHead', default=_DEFAULT_TEE, help="""
-    Instance of ArrowHead.
+    Instance of ``ArrowHead``.
     """)
 
     base = DistanceSpec(help="""

--- a/bokeh/models/axes.py
+++ b/bokeh/models/axes.py
@@ -63,7 +63,7 @@ class Axis(GuideRenderer):
     """).accepts(Seq(Float), lambda ticks: FixedTicker(ticks=ticks))
 
     formatter = Instance(TickFormatter, help="""
-    A TickFormatter to use for formatting the visual appearance
+    A ``TickFormatter`` to use for formatting the visual appearance
     of ticks.
     """)
 
@@ -185,7 +185,7 @@ class CategoricalAxis(Axis):
     ''' An axis that displays ticks and labels for categorical ranges.
 
     The ``CategoricalAxis`` can handle factor ranges with up to two levels of
-    nesting, including drawing a seperator line between top-level groups of
+    nesting, including drawing a separator line between top-level groups of
     factors.
 
     '''
@@ -246,7 +246,7 @@ class CategoricalAxis(Axis):
     subgroup_text_font_style = Override(default="bold")
 
 class DatetimeAxis(LinearAxis):
-    ''' An LinearAxis that picks nice numbers for tick locations on
+    ''' A ``LinearAxis`` that picks nice numbers for tick locations on
     a datetime scale. Configured with a ``DatetimeTickFormatter`` by
     default.
 

--- a/bokeh/models/callbacks.py
+++ b/bokeh/models/callbacks.py
@@ -42,7 +42,7 @@ class CustomJS(Callback):
 
     @classmethod
     def from_py_func(cls, func):
-        """ Create a CustomJS instance from a Python function. The
+        """ Create a ``CustomJS`` instance from a Python function. The
         function is translated to JavaScript using PScript.
         """
         if not isinstance(func, FunctionType):
@@ -83,7 +83,7 @@ class CustomJS(Callback):
     ``args`` are available as parameters that the code can use. Additionally,
     a ``cb_obj`` parameter contains the object that triggered the callback
     and an optional ``cb_data`` parameter that contains any tool-specific data
-    (i.e. mouse coordinates and hovered glyph indices for the HoverTool).
+    (i.e. mouse coordinates and hovered glyph indices for the ``HoverTool``).
 
     .. note:: Use ``CustomJS.from_coffeescript()`` for CoffeeScript source code.
 

--- a/bokeh/models/expressions.py
+++ b/bokeh/models/expressions.py
@@ -34,7 +34,7 @@ class Expression(Model):
 
     JavaScript implementations should implement the following methods:
 
-    .. code-block: coffeescript
+    .. code-block:: coffeescript
 
         v_compute: (source) ->
             # compute an array of values

--- a/bokeh/models/expressions.py
+++ b/bokeh/models/expressions.py
@@ -40,8 +40,8 @@ class Expression(Model):
             # compute an array of values
 
     .. note::
-        If you wish for results to be cached per source, and updated only if
-        the source changes, implement `_v_compute: (souce)` instead.
+        If you wish for results to be cached per source and updated only if
+        the source changes, implement ``_v_compute: (source)`` instead.
 
     '''
     pass
@@ -53,7 +53,7 @@ class CumSum(Expression):
     '''
 
     field = String(help="""
-    The name of a ColumnDataSource column to cumulatively sum for new values.
+    The name of a ``ColumnDataSource`` column to cumulatively sum for new values.
     """)
 
     include_zero = Bool(default=False, help="""

--- a/bokeh/models/filters.py
+++ b/bokeh/models/filters.py
@@ -11,7 +11,7 @@ from ..util.compiler import nodejs_compile, CompilationError
 
 class Filter(Model):
     ''' A Filter model represents a filtering operation that returns a row-wise subset of
-    data when applied to a ColumnDataSource.
+    data when applied to a ``ColumnDataSource``.
     '''
 
     filter = Either(Seq(Int), Seq(Bool), help="""
@@ -25,7 +25,7 @@ class Filter(Model):
         super(Filter, self).__init__(**kw)
 
 class IndexFilter(Filter):
-    ''' An IndexFilter filters data by returning the subset of data at a given set of indices.
+    ''' An ``IndexFilter`` filters data by returning the subset of data at a given set of indices.
     '''
 
     indices = Seq(Int, help="""
@@ -39,7 +39,7 @@ class IndexFilter(Filter):
         super(IndexFilter, self).__init__(**kw)
 
 class BooleanFilter(Filter):
-    ''' A BooleanFilter filters data by returning the subset of data corresponding to indices
+    ''' A ``BooleanFilter`` filters data by returning the subset of data corresponding to indices
     where the values of the booleans array is True.
     '''
 
@@ -54,7 +54,7 @@ class BooleanFilter(Filter):
         super(BooleanFilter, self).__init__(**kw)
 
 class GroupFilter(Filter):
-    ''' A GroupFilter represents the rows of a ColumnDataSource where the values of the categorical
+    ''' A ``GroupFilter`` represents the rows of a ``ColumnDataSource`` where the values of the categorical
     column column_name match the group variable.
     '''
 
@@ -86,11 +86,11 @@ class CustomJSFilter(Filter):
 
     @classmethod
     def from_py_func(cls, func):
-        ''' Create a CustomJSFilter instance from a Python function. The
-        fucntion is translated to JavaScript using PScript.
+        ''' Create a ``CustomJSFilter`` instance from a Python function. The
+        function is translated to JavaScript using PScript.
 
         The ``func`` function namespace will contain the variable ``source``
-        at render time. This will be the data source associated with the CDSView
+        at render time. This will be the data source associated with the ``CDSView``
         that this filter is added to.
         '''
         if not isinstance(func, FunctionType):
@@ -122,13 +122,13 @@ class CustomJSFilter(Filter):
 
     @classmethod
     def from_coffeescript(cls, code, args={}):
-        ''' Create a CustomJSFilter instance from CoffeeScript snippets.
+        ''' Create a ``CustomJSFilter`` instance from CoffeeScript snippets.
         The function bodies are translated to JavaScript functions using node
         and therefore require return statements.
 
         The ``code`` function namespace will contain the variable ``source``
-        at render time. This will be the data source associated with the CDSView
-        that this filter is added to.
+        at render time. This will be the data source associated with the
+        ``CDSView`` that this filter is added to.
         '''
 
         compiled = nodejs_compile(code, lang="coffeescript", file="???")
@@ -147,7 +147,7 @@ class CustomJSFilter(Filter):
     A snippet of JavaScript code to filter data contained in a columnar data source.
     The code is made into the body of a function, and all of of the named objects in
     ``args`` are available as parameters that the code can use. The variable
-    ``source`` will contain the data source that is associated with the CDSView this
+    ``source`` will contain the data source that is associated with the ``CDSView`` this
     filter is added to.
 
     The code should either return the indices of the subset or an array of booleans

--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -55,7 +55,7 @@ class BasicTickFormatter(TickFormatter):
     """)
 
 class MercatorTickFormatter(BasicTickFormatter):
-    ''' TickFormatter for values in WebMercator units.
+    ''' A ``TickFormatter`` for values in WebMercator units.
 
     Some map plot types internally use WebMercator to describe coordinates,
     plot bounds, etc. These units are not very human-friendly. This tick
@@ -77,7 +77,7 @@ class MercatorTickFormatter(BasicTickFormatter):
     should be `"lat"``.
 
     In order to prevent hard to debug errors, there is no default value for
-    dimension. Using an un-configured MercatorTickFormatter will result in
+    dimension. Using an un-configured ``MercatorTickFormatter`` will result in
     a validation error and a JavaScript console error.
     """)
 
@@ -252,7 +252,7 @@ class FuncTickFormatter(TickFormatter):
 
     @classmethod
     def from_py_func(cls, func):
-        ''' Create a FuncTickFormatter instance from a Python function. The
+        ''' Create a ``FuncTickFormatter`` instance from a Python function. The
         function is translated to JavaScript using PScript. The variable
         ``tick`` will contain the unformatted tick value and can be expected to
         be present in the function namespace at render time.
@@ -267,7 +267,7 @@ class FuncTickFormatter(TickFormatter):
             """
 
         The python function must have no positional arguments. It's
-        possible to pass Bokeh models (e.g. a ColumnDataSource) as keyword
+        possible to pass Bokeh models (e.g. a ``ColumnDataSource``) as keyword
         arguments to the function.
 
         '''

--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -628,7 +628,7 @@ class MultiLine(Glyph):
     """)
 
 class MultiPolygons(Glyph):
-    ''' Render several MultiPolygons.
+    ''' Render several MultiPolygon.
 
     Modeled on geoJSON - the data for the ``MultiPolygons`` glyph is
     different in that the vector of values is not a vector of scalars.
@@ -645,18 +645,18 @@ class MultiPolygons(Glyph):
     The x-coordinates for all the patches, given as a nested list.
 
     .. note::
-        Each item in MultiPolygons represents one MultiPolygon and each
-        MultiPolygon is comprised of n Polygons. Each Polygon is made of
-        one exterior ring optionally followed by m interior rings (holes).
+        Each item in ``MultiPolygons`` represents one MultiPolygon and each
+        MultiPolygon is comprised of ``n`` Polygons. Each Polygon is made of
+        one exterior ring optionally followed by ``m`` interior rings (holes).
     """)
 
     ys = NumberSpec(help="""
     The y-coordinates for all the patches, given as a "list of lists".
 
     .. note::
-        Each item in MultiPolygons represents one MultiPolygon and each
-        MultiPolygon is comprised of n Polygons. Each Polygon is made of
-        one exterior ring optionally followed by m interior rings (holes).
+        Each item in ``MultiPolygons`` represents one MultiPolygon and each
+        MultiPolygon is comprised of ``n`` Polygons. Each Polygon is made of
+        one exterior ring optionally followed by ``m`` interior rings (holes).
     """)
 
     line_props = Include(LineProps, use_prefix=False, help="""

--- a/bokeh/models/graphs.py
+++ b/bokeh/models/graphs.py
@@ -34,7 +34,7 @@ class StaticLayoutProvider(LayoutProvider):
 
 def from_networkx(graph, layout_function, **kwargs):
         '''
-        Generate a GraphRenderer from a networkx.Graph object and networkx
+        Generate a ``GraphRenderer`` from a ``networkx.Graph`` object and networkx
         layout function. Any keyword arguments will be passed to the
         layout function.
 
@@ -131,7 +131,7 @@ class GraphHitTestPolicy(Model):
 
 class NodesOnly(GraphHitTestPolicy):
     '''
-    With the NodesOnly policy, only graph nodes are able to be selected and
+    With the ``NodesOnly`` policy, only graph nodes are able to be selected and
     inspected. There is no selection or inspection of graph edges.
 
     '''
@@ -140,7 +140,7 @@ class NodesOnly(GraphHitTestPolicy):
 
 class NodesAndLinkedEdges(GraphHitTestPolicy):
     '''
-    With the NodesAndLinkedEdges policy, inspection or selection of graph
+    With the ``NodesAndLinkedEdges`` policy, inspection or selection of graph
     nodes will result in the inspection or selection of the node and of the
     linked graph edges. There is no direct selection or inspection of graph
     edges.
@@ -151,7 +151,7 @@ class NodesAndLinkedEdges(GraphHitTestPolicy):
 
 class EdgesAndLinkedNodes(GraphHitTestPolicy):
     '''
-    With the EdgesAndLinkedNodes policy, inspection or selection of graph
+    With the ``EdgesAndLinkedNodes`` policy, inspection or selection of graph
     edges will result in the inspection or selection of the edge and of the
     linked graph nodes. There is no direct selection or inspection of graph
     nodes.

--- a/bokeh/models/layouts.py
+++ b/bokeh/models/layouts.py
@@ -60,7 +60,7 @@ class LayoutDOM(Model):
 
     # List in order for in-place changes to trigger changes, ref: https://github.com/bokeh/bokeh/issues/6841
     css_classes = List(String, help="""
-    A list of css class names to add to this DOM element. Note: the class names are
+    A list of CSS class names to add to this DOM element. Note: the class names are
     simply added as-is, no other guarantees are provided.
 
     It is also permissible to assign from tuples, however these are adapted -- the

--- a/bokeh/models/map_plots.py
+++ b/bokeh/models/map_plots.py
@@ -53,12 +53,12 @@ class MapPlot(Plot):
             return "%s.y_range" % str(self)
 
 class GMapOptions(MapOptions):
-    ''' Options for GMapPlot objects.
+    ''' Options for ``GMapPlot`` objects.
 
     '''
 
     map_type = Enum(MapType, default="roadmap", help="""
-    The `map type`_ to use for the GMapPlot.
+    The `map type`_ to use for the ``GMapPlot``.
 
     .. _map type: https://developers.google.com/maps/documentation/javascript/reference#MapTypeId
 
@@ -69,7 +69,7 @@ class GMapOptions(MapOptions):
     """)
 
     styles = JSON(help="""
-    A JSON array of `map styles`_ to use for the GMapPlot. Many example styles can
+    A JSON array of `map styles`_ to use for the ``GMapPlot``. Many example styles can
     `be found here`_.
 
     .. _map styles: https://developers.google.com/maps/documentation/javascript/reference#MapTypeStyle

--- a/bokeh/models/mappers.py
+++ b/bokeh/models/mappers.py
@@ -174,7 +174,7 @@ class LogColorMapper(ContinuousColorMapper):
        20.09 >= x         : 'blue'    # values > high are clamped
 
     .. warning::
-        The LogColorMapper only works for images with scalar values that are
+        The ``LogColorMapper`` only works for images with scalar values that are
         non-negative.
 
     '''

--- a/bokeh/models/markers.py
+++ b/bokeh/models/markers.py
@@ -116,7 +116,7 @@ class Scatter(Marker):
 
     marker = MarkerSpec(default="circle", help="""
     Which marker to render. This can be the name of any built in marker,
-    e.g. "circle", or a reference to a data column containinh such names.
+    e.g. "circle", or a reference to a data column containing such names.
     """)
 
     __example__ = "examples/reference/models/Scatter.py"

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -340,7 +340,7 @@ class Plot(LayoutDOM):
         return g
 
     def add_tile(self, tile_source, **kw):
-        ''' Adds new TileRenderer into the Plot.renderers
+        ''' Adds new ``TileRenderer`` into ``Plot.renderers``
 
         Args:
             tile_source (TileSource) : a tile source instance which contain tileset configuration

--- a/bokeh/models/ranges.py
+++ b/bokeh/models/ranges.py
@@ -75,8 +75,11 @@ class Range1d(Range):
 
     Examples:
 
+    .. code-block:: python
+
         Range1d(0, 1, bounds='auto')  # Auto-bounded to 0 and 1 (Default behavior)
         Range1d(start=0, end=1, bounds=(0, None))  # Maximum is unbounded, minimum bounded to 0
+
     """)
 
     min_interval = Either(Float, TimeDelta, default=None, help="""
@@ -270,7 +273,7 @@ class FactorRange(Range):
     Factors may have 1, 2, or 3 levels. For 1-level factors, each factor is
     simply a string. For example:
 
-    .. code-block: python
+    .. code-block:: python
 
         FactorRange(factors=["sales", "marketing", "engineering"])
 

--- a/bokeh/models/ranges.py
+++ b/bokeh/models/ranges.py
@@ -82,11 +82,11 @@ class Range1d(Range):
     min_interval = Either(Float, TimeDelta, default=None, help="""
     The level that the range is allowed to zoom in, expressed as the
     minimum visible interval. If set to ``None`` (default), the minimum
-    interval is not bound. Can be a timedelta. """)
+    interval is not bound. Can be a ``TimeDelta``. """)
 
     max_interval = Either(Float, TimeDelta, default=None, help="""
     The level that the range is allowed to zoom out, expressed as the
-    maximum visible interval. Can be a timedelta. Note that ``bounds`` can
+    maximum visible interval. Can be a ``TimeDelta``. Note that ``bounds`` can
     impose an implicit constraint on the maximum interval as well. """)
 
     def __init__(self, *args, **kwargs):
@@ -159,7 +159,7 @@ class DataRange1d(DataRange):
 
     By default, the bounds will be None, allowing your plot to pan/zoom as far
     as you want. If bounds are 'auto' they will be computed to be the same as
-    the start and end of the DataRange1d.
+    the start and end of the ``DataRange1d``.
 
     Bounds are provided as a tuple of ``(min, max)`` so regardless of whether
     your range is increasing or decreasing, the first item should be the
@@ -327,7 +327,7 @@ class FactorRange(Range):
         FactorRange(factors=[["foo", "1'], ["foo", "2'], ["bar", "1"]])
 
     The top level groups correspond to ``"foo"` and ``"bar"``, and the
-    group padding will be applied between the factors``["foo", "2']`` and
+    group padding will be applied between the factors ``["foo", "2']`` and
     ``["bar", "1"]``
     """)
 
@@ -377,7 +377,7 @@ class FactorRange(Range):
 
     By default, the bounds will be None, allowing your plot to pan/zoom as far
     as you want. If bounds are 'auto' they will be computed to be the same as
-    the start and end of the FactorRange.
+    the start and end of the ``FactorRange``.
     """)
 
     min_interval = Float(default=None, help="""

--- a/bokeh/models/renderers.py
+++ b/bokeh/models/renderers.py
@@ -158,7 +158,7 @@ class GlyphRenderer(DataRenderer):
 
     hover_glyph = Instance(Glyph, help="""
     An optional glyph used for inspected points, e.g., those that are
-    being hovered over by a HoverTool.
+    being hovered over by a ``HoverTool``.
     """)
 
     muted_glyph = Instance(Glyph, help="""
@@ -207,27 +207,27 @@ class GraphRenderer(DataRenderer):
     """)
 
     layout_provider = Instance(LayoutProvider, help="""
-    An instance of a LayoutProvider that supplies the layout of the network
+    An instance of a ``LayoutProvider`` that supplies the layout of the network
     graph in cartesian space.
     """)
 
     node_renderer = Instance(GlyphRenderer, default=_DEFAULT_NODE_RENDERER, help="""
-    Instance of a GlyphRenderer containing an XYGlyph that will be rendered
+    Instance of a ``GlyphRenderer`` containing an ``XYGlyph`` that will be rendered
     as the graph nodes.
     """)
 
     edge_renderer = Instance(GlyphRenderer, default=_DEFAULT_EDGE_RENDERER, help="""
-    Instance of a GlyphRenderer containing an MultiLine Glyph that will be
+    Instance of a ``GlyphRenderer`` containing an ``MultiLine`` Glyph that will be
     rendered as the graph edges.
     """)
 
     selection_policy = Instance(GraphHitTestPolicy, default=lambda: NodesOnly(), help="""
-    An instance of a GraphHitTestPolicy that provides the logic for selection
+    An instance of a ``GraphHitTestPolicy`` that provides the logic for selection
     of graph components.
     """)
 
     inspection_policy = Instance(GraphHitTestPolicy, default=lambda: NodesOnly(), help="""
-    An instance of a GraphHitTestPolicy that provides the logic for inspection
+    An instance of a ``GraphHitTestPolicy`` that provides the logic for inspection
     of graph components.
     """)
 

--- a/bokeh/models/scales.py
+++ b/bokeh/models/scales.py
@@ -13,7 +13,7 @@ class Scale(Transform):
 
     JavaScript implementations should implement the following methods:
 
-    .. code-block: coffeescript
+    .. code-block:: coffeescript
 
         compute: (x) ->
             # compute the transform of a single value

--- a/bokeh/models/selections.py
+++ b/bokeh/models/selections.py
@@ -4,11 +4,11 @@ from ..model import Model
 
 class Selection(Model):
     '''
-    A Selection represents a portion of the data in a DataSource, which
+    A Selection represents a portion of the data in a ``DataSource``, which
     can be visually manipulated in a plot.
 
     Selections are typically created by selecting points in a plot with
-    a SelectTool, but can also be programmatically specified.
+    a ``SelectTool``, but can also be programmatically specified.
 
     '''
 

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -22,7 +22,7 @@ class DataSource(Model):
     '''
 
     selected = Instance(Selection, default=lambda: Selection(), help="""
-    A Selection that indicates selected indices on this DataSource.
+    A Selection that indicates selected indices on this ``DataSource``.
     """)
 
     callback = Instance(Callback, help="""
@@ -41,7 +41,7 @@ class ColumnarDataSource(DataSource):
     '''
 
     selection_policy = Instance(SelectionPolicy, default=lambda: UnionRenderers(), help="""
-    An instance of a SelectionPolicy that determines how selections are set.
+    An instance of a ``SelectionPolicy`` that determines how selections are set.
     """)
 
 class ColumnDataSource(ColumnarDataSource):
@@ -50,7 +50,7 @@ class ColumnDataSource(ColumnarDataSource):
     The ``ColumnDataSource`` is a fundamental data structure of Bokeh. Most
     plots, data tables, etc. will be driven by a ``ColumnDataSource``.
 
-    If the ColumnDataSource initializer is called with a single argument that
+    If the ``ColumnDataSource`` initializer is called with a single argument that
     can be any of the following:
 
     * A Python ``dict`` that maps string names to sequences of values, e.g.
@@ -75,8 +75,8 @@ class ColumnDataSource(ColumnarDataSource):
 
       In this case the CDS will have columns corresponding to the columns of
       the ``DataFrame``. If the ``DataFrame`` columns have multiple levels,
-      they will be flattend using an underscore (e.g. level_0_col_level_1_col).
-      The index of the DataFrame will be flattened to an ``Index`` of tuples
+      they will be flattened using an underscore (e.g. level_0_col_level_1_col).
+      The index of the ``DataFrame`` will be flattened to an ``Index`` of tuples
       if it's a ``MultiIndex``, and then reset using ``reset_index``. The result
       will be a column with the same name if the index was named, or
       level_0_name_level_1_name if it was a named ``MultiIndex``. If the
@@ -93,7 +93,7 @@ class ColumnDataSource(ColumnarDataSource):
       In this case the CDS will have columns corresponding to the result of
       calling ``group.describe()``. The ``describe`` method generates columns
       for statistical measures such as ``mean`` and ``count`` for all the
-      non-grouped orginal columns. The CDS columns are formed by joining
+      non-grouped original columns. The CDS columns are formed by joining
       original column names with the computed measure. For example, if a
       ``DataFrame`` has columns ``'year'`` and ``'mpg'``. Then passing
       ``df.groupby('year')`` to a CDS will result in columns such as
@@ -125,7 +125,7 @@ class ColumnDataSource(ColumnarDataSource):
 
     def __init__(self, *args, **kw):
         ''' If called with a single argument that is a dict or
-        pandas.DataFrame, treat that implicitly as the "data" attribute.
+        ``pandas.DataFrame``, treat that implicitly as the "data" attribute.
 
         '''
         if len(args) == 1 and "data" not in kw:
@@ -153,7 +153,7 @@ class ColumnDataSource(ColumnarDataSource):
 
     @staticmethod
     def _data_from_df(df):
-        ''' Create a ``dict`` of columns from a Pandas DataFrame,
+        ''' Create a ``dict`` of columns from a Pandas ``DataFrame``,
         suitable for creating a ColumnDataSource.
 
         Args:
@@ -190,8 +190,8 @@ class ColumnDataSource(ColumnarDataSource):
 
     @staticmethod
     def _data_from_groupby(group):
-        ''' Create a ``dict`` of columns from a Pandas GroupBy,
-        suitable for creating a ColumnDataSource.
+        ''' Create a ``dict`` of columns from a Pandas ``GroupBy``,
+        suitable for creating a ``ColumnDataSource``.
 
         The data generated is the result of running ``describe``
         on the group.
@@ -207,7 +207,7 @@ class ColumnDataSource(ColumnarDataSource):
 
     @staticmethod
     def _df_index_name(df):
-        ''' Return the Bokeh-appropriate column name for a DataFrame index
+        ''' Return the Bokeh-appropriate column name for a ``DataFrame`` index
 
         If there is no named index, then `"index" is returned.
 
@@ -220,7 +220,7 @@ class ColumnDataSource(ColumnarDataSource):
         is returned.
 
         Args:
-            df (DataFrame) : the DataFrame to find an index name for
+            df (DataFrame) : the ``DataFrame`` to find an index name for
 
         Returns:
             str
@@ -239,8 +239,8 @@ class ColumnDataSource(ColumnarDataSource):
 
     @classmethod
     def from_df(cls, data):
-        ''' Create a ``dict`` of columns from a Pandas DataFrame,
-        suitable for creating a ColumnDataSource.
+        ''' Create a ``dict`` of columns from a Pandas ``DataFrame``,
+        suitable for creating a ``ColumnDataSource``.
 
         Args:
             data (DataFrame) : data to convert
@@ -253,8 +253,8 @@ class ColumnDataSource(ColumnarDataSource):
 
     @classmethod
     def from_groupby(cls, data):
-        ''' Create a ``dict`` of columns from a Pandas GroupBy,
-        suitable for creating a ColumnDataSource.
+        ''' Create a ``dict`` of columns from a Pandas ``GroupBy``,
+        suitable for creating a ``ColumnDataSource``.
 
         The data generated is the result of running ``describe``
         on the group.
@@ -269,7 +269,7 @@ class ColumnDataSource(ColumnarDataSource):
         return cls._data_from_df(data.describe())
 
     def to_df(self):
-        ''' Convert this data source to pandas dataframe.
+        ''' Convert this data source to pandas ``DataFrame``.
 
         Returns:
             DataFrame
@@ -363,7 +363,7 @@ class ColumnDataSource(ColumnarDataSource):
 
     def _stream(self, new_data, rollover=None, setter=None):
         ''' Internal implementation to efficiently update data source columns
-        with new append-only data.   The interal implementation adds the setter
+        with new append-only data. The internal implementation adds the setter
         attribute.  [https://github.com/bokeh/bokeh/issues/6577]
 
         In cases where it is necessary to update data columns in, this method
@@ -477,7 +477,7 @@ class ColumnDataSource(ColumnarDataSource):
         ''' Efficiently update data source columns at specific locations
 
         If it is only necessary to update a small subset of data in a
-        ColumnDataSource, this method can be used to efficiently update only
+        ``ColumnDataSource``, this method can be used to efficiently update only
         the subset, instead of requiring the entire data set to be sent.
 
         This method should be passed a dictionary that maps column names to
@@ -639,7 +639,7 @@ def _check_slice(s):
         raise ValueError("Patch slices must have non-negative (start, stop, step) values, got %s" % s)
 
 class CDSView(Model):
-    ''' A view into a ColumnDataSource that represents a row-wise subset.
+    ''' A view into a ``ColumnDataSource`` that represents a row-wise subset.
 
     '''
 
@@ -648,7 +648,7 @@ class CDSView(Model):
     """)
 
     source = Instance(ColumnarDataSource, help="""
-    The ColumnDataSource associated with this view. Used to determine
+    The ``ColumnDataSource`` associated with this view. Used to determine
     the length of the columns.
     """)
 
@@ -658,8 +658,9 @@ class GeoJSONDataSource(ColumnarDataSource):
     '''
 
     geojson = JSON(help="""
-    GeoJSON that contains features for plotting. Currently GeoJSONDataSource can
-    only process a FeatureCollection or GeometryCollection.
+    GeoJSON that contains features for plotting. Currently
+    ``GeoJSONDataSource`` can only process a ``FeatureCollection`` or
+    ``GeometryCollection``.
     """)
 
 @abstract
@@ -682,7 +683,7 @@ class RemoteSource(ColumnDataSource):
 
 class AjaxDataSource(RemoteSource):
     ''' A data source that can populate columns by making Ajax calls to REST
-    enpoints.
+    endpoints.
 
     The ``AjaxDataSource`` can be especially useful if you want to make a
     standalone document (i.e. not backed by the Bokeh server) that can still
@@ -699,7 +700,7 @@ class AjaxDataSource(RemoteSource):
             'y' : [9, 3, 2, ...]
         }
 
-    Alternatively, if the REST API returns a different format, a CustomJS
+    Alternatively, if the REST API returns a different format, a ``CustomJS``
     callback can be provided to convert the REST response into Bokeh format,
     via the ``adapter`` property of this data source.
 
@@ -708,7 +709,7 @@ class AjaxDataSource(RemoteSource):
     '''
 
     method = Enum('POST', 'GET', help="""
-    Specifiy the the HTTP method to use for the Ajax request (GET or POST)
+    Specify the HTTP method to use for the Ajax request (GET or POST)
     """)
 
     mode = Enum("replace", "append", help="""
@@ -717,15 +718,15 @@ class AjaxDataSource(RemoteSource):
     """)
 
     adapter = Instance(CustomJS, help="""
-    A JavaScript callback to adapt raw JSON responses to Bokeh ColumnDataSource
+    A JavaScript callback to adapt raw JSON responses to Bokeh ``ColumnDataSource``
     format.
 
     If provided, this callback is executes immediately after the JSON data is
     received, but before appending or replacing data in the data source. The
-    CustomJS callback will receive the AjaxDataSource as ``cb_obj`` and will
-    receive the raw JSON response as ``cb_data.response``. The callback code
-    should return a ``data`` object suitable for a Bokeh ColumnDataSource (i.e.
-    a mapping of string column names to arrays of data).
+    ``CustomJS`` callback will receive the ``AjaxDataSource`` as ``cb_obj`` and
+    will receive the raw JSON response as ``cb_data.response``. The callback
+    code should return a ``data`` object suitable for a Bokeh ``ColumnDataSource``
+    (i.e.  a mapping of string column names to arrays of data).
     """)
 
     max_size = Int(help="""

--- a/bokeh/models/tickers.py
+++ b/bokeh/models/tickers.py
@@ -168,7 +168,7 @@ class MercatorTicker(BasicTicker):
     should be `"lat"``.
 
     In order to prevent hard to debug errors, there is no default value for
-    dimension. Using an un-configured MercatorTicker will result in a
+    dimension. Using an un-configured ``MercatorTicker`` will result in a
     validation error and a JavaScript console error.
     """)
 

--- a/bokeh/models/tiles.py
+++ b/bokeh/models/tiles.py
@@ -56,7 +56,7 @@ class TileSource(Model):
     """)
 
 class MercatorTileSource(TileSource):
-    ''' A base class for Mercator tile services (e.g.``WMTSTileSource``).
+    ''' A base class for Mercator tile services (e.g. ``WMTSTileSource``).
 
     '''
 
@@ -82,19 +82,19 @@ class MercatorTileSource(TileSource):
     """)
 
 class TMSTileSource(MercatorTileSource):
-    ''' The TMSTileSource contains tile config info and provides urls for
-    tiles based on a templated url e.g. ``http://your.tms.server.host/{Z}/{X}/{Y}.png``.
-    The defining feature of TMS is the tile-origin in located at the bottom-left.
+    ''' Contains tile config info and provides urls for tiles based on a
+    templated url e.g. ``http://your.tms.server.host/{Z}/{X}/{Y}.png``. The
+    defining feature of TMS is the tile-origin in located at the bottom-left.
 
-    The TMSTileSource can also be helpful in implementing tile renderers for
+    ``TMSTileSource`` can also be helpful in implementing tile renderers for
     custom tile sets, including non-spatial datasets.
 
     '''
     pass
 
 class WMTSTileSource(MercatorTileSource):
-    ''' The ``WMTSTileSource`` behaves much like ``TMSTileSource`` but has its
-    tile-origin in the top-left.
+    ''' Behaves much like ``TMSTileSource`` but has its tile-origin in the
+    top-left.
 
     This is the most common used tile source for web mapping applications.
     Such companies as Google, MapQuest, Stamen, Esri, and OpenStreetMap provide
@@ -104,19 +104,20 @@ class WMTSTileSource(MercatorTileSource):
     pass
 
 class QUADKEYTileSource(MercatorTileSource):
-    ''' The QUADKEYTileSource has the same tile origin as the WMTSTileSource
-    but requests tiles using a `quadkey` argument instead of X, Y, Z e.g. ``http://your.quadkey.tile.host/{Q}.png``
+    ''' Has the same tile origin as the ``WMTSTileSource`` but requests tiles using
+    a `quadkey` argument instead of X, Y, Z e.g.
+    ``http://your.quadkey.tile.host/{Q}.png``
 
     '''
     pass
 
 class BBoxTileSource(MercatorTileSource):
-    ''' The BBoxTileSource has the same default tile origin as the
-    WMTSTileSource but requested tiles use a ``{XMIN}``, ``{YMIN}``,
-    ``{XMAX}``, ``{YMAX}`` e.g. ``http://your.custom.tile.service?bbox={XMIN},{YMIN},{XMAX},{YMAX}``.
+    ''' Has the same default tile origin as the ``WMTSTileSource`` but requested
+    tiles use a ``{XMIN}``, ``{YMIN}``, ``{XMAX}``, ``{YMAX}`` e.g.
+    ``http://your.custom.tile.service?bbox={XMIN},{YMIN},{XMAX},{YMAX}``.
 
     '''
 
     use_latlon = Bool(default=False, help="""
-    Flag which indicates option to output {XMIN},{YMIN},{XMAX},{YMAX} in meters or latitude and longitude.
+    Flag which indicates option to output ``{XMIN}``, ``{YMIN}``, ``{XMAX}``, ``{YMAX}`` in meters or latitude and longitude.
     """)

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -97,7 +97,7 @@ class Inspection(Gesture):
     '''
     toggleable = Bool(True, help="""
     Whether an on/off toggle button should appear in the toolbar for this
-    inpection tool. If ``False``, the viewers of a plot will not be able to
+    inspection tool. If ``False``, the viewers of a plot will not be able to
     toggle the inspector on or off using the toolbar.
     """)
 
@@ -410,7 +410,7 @@ class TapTool(Tap):
     This tool can be configured to either make selections or inspections
     on associated data sources. The difference is that selection changes
     propagate across bokeh and other components (e.g. selection glyph)
-    will be notified. Inspecions don't act like this, so it's useful to
+    will be notified. Inspections don't act like this, so it's useful to
     configure `callback` when setting `behavior='inspect'`.
     """)
 
@@ -433,7 +433,7 @@ class TapTool(Tap):
     ``.type`` is the geometry type, which always a ``.point`` for a tap event.
     ``.sx`` and ``.sy`` are the screen X and Y coordinates where the tap occurred.
     ``.x`` and ``.y`` are the converted data coordinates for the item that has
-    been selected. The ``.x`` and ``.y`` values are based on the axis assiged
+    been selected. The ``.x`` and ``.y`` values are based on the axis assigned
     to that glyph.
 
     .. note::
@@ -637,8 +637,8 @@ class BoxSelectTool(Drag):
 
     callback = Instance(Callback, help="""
     A callback to run in the browser on completion of drawing a selection box.
-    The cb_data parameter that is available to the Callback code will contain
-    one BoxSelectTool-specific field:
+    The ``cb_data`` parameter that is available to the Callback code will contain
+    one ``BoxSelectTool``-specific field:
 
     :geometry: object containing the coordinates of the selection box
     """)
@@ -703,8 +703,8 @@ class LassoSelectTool(Drag):
 
     callback = Instance(Callback, help="""
     A callback to run in the browser on every selection of a lasso area.
-    The cb_data parameter that is available to the Callback code will contain
-    one LassoSelectTool-specific field:
+    The ``cb_data`` parameter that is available to the Callback code will contain
+    one ``LassoSelectTool``-specific field:
 
     :geometry: object containing the coordinates of the lasso area
     """)
@@ -748,7 +748,7 @@ class PolySelectTool(Tap):
 
     callback = Instance(Callback, help="""
     A callback to run in the browser on completion of drawing a polygon.
-    The cb_data parameter that is available to the Callback code will contain
+    The ``cb_data`` parameter that is available to the Callback code will contain
     one PolySelectTool-specific field:
 
     :geometry: object containing the coordinates of the polygon
@@ -812,11 +812,11 @@ class CustomJSHover(Model):
 
     @classmethod
     def from_py_func(cls, code):
-        ''' Create a CustomJSHover instance from a Python functions. The
+        ''' Create a ``CustomJSHover`` instance from a Python functions. The
         function is translated to JavaScript using PScript.
 
         The python functions must have no positional arguments. It's
-        possible to pass Bokeh models (e.g. a ColumnDataSource) as keyword
+        possible to pass Bokeh models (e.g. a ``ColumnDataSource``) as keyword
         arguments to the functions.
 
         The ``code`` function namespace will contain the variable ``value``
@@ -956,7 +956,7 @@ class HoverTool(Inspection):
             ("total", "@total{$0,0.00}"
         ]
 
-    You can also supply a ``Callback`` to the HoverTool, to build custom
+    You can also supply a ``Callback`` to the ``HoverTool``, to build custom
     interactions on hover. In this case you may want to turn the tooltips
     off by setting ``tooltips=None``.
 
@@ -1001,8 +1001,8 @@ class HoverTool(Inspection):
 
     callback = Instance(Callback, help="""
     A callback to run in the browser whenever the input's value changes. The
-    cb_data parameter that is available to the Callback code will contain two
-    HoverTool specific fields:
+    ``cb_data`` parameter that is available to the Callback code will contain two
+    ``HoverTool`` specific fields:
 
     :index: object containing the indices of the hovered points in the data source
     :geometry: object containing the coordinates of the hover cursor
@@ -1198,7 +1198,7 @@ class EditTool(Gesture):
 
     empty_value = Either(Bool, Int, Float, Date, Datetime, Color, help="""
     Defines the value to insert on non-coordinate columns when a new
-    glyph is inserted into the ColumnDataSource columns, e.g. when a
+    glyph is inserted into the ``ColumnDataSource`` columns, e.g. when a
     circle glyph defines 'x', 'y' and 'color' columns, adding a new
     point will add the x and y-coordinates to 'x' and 'y' columns and
     the color column will be filled with the defined empty value.
@@ -1219,12 +1219,11 @@ class EditTool(Gesture):
 class BoxEditTool(EditTool, Drag, Tap):
     ''' *toolbar icon*: |box_edit_icon|
 
-    The BoxEditTool allows drawing, dragging and deleting ``Rect``
-    glyphs on one or more renderers by editing the underlying
-    ``ColumnDataSource`` data. Like other drawing tools, the renderers
-    that are to be edited must be supplied explicitly as a list. When
-    drawing a new box the data will always be added to the
-    ``ColumnDataSource`` on the first supplied renderer.
+    Allows drawing, dragging and deleting ``Rect`` glyphs on one or more
+    renderers by editing the underlying ``ColumnDataSource`` data. Like other
+    drawing tools, the renderers that are to be edited must be supplied
+    explicitly as a list. When drawing a new box the data will always be added
+    to the ``ColumnDataSource`` on the first supplied renderer.
 
     The tool will automatically modify the columns on the data source
     corresponding to the ``x``, ``y``, ``width`` and ``height`` values
@@ -1347,7 +1346,7 @@ class PolyDrawTool(EditTool, Drag, Tap):
 
     The PolyDrawTool allows drawing, selecting and deleting
     ``Patches`` and ``MultiLine`` glyphs on one or more renderers by
-    editing the underlying ColumnDataSource data. Like other drawing
+    editing the underlying ``ColumnDataSource`` data. Like other drawing
     tools, the renderers that are to be edited must be supplied
     explicitly as a list.
 
@@ -1357,7 +1356,7 @@ class PolyDrawTool(EditTool, Drag, Tap):
     declared ``empty_value``, when adding a new point.
 
     If a ``vertex_renderer`` with an point-like glyph is supplied the
-    PolyDrawTool will use it to display the vertices of the
+    ``PolyDrawTool`` will use it to display the vertices of the
     multi-lines/patches on all supplied renderers. This also enables
     the ability to snap to existing vertices while drawing.
 
@@ -1415,9 +1414,8 @@ class PolyDrawTool(EditTool, Drag, Tap):
 class FreehandDrawTool(EditTool, Drag, Tap):
     ''' *toolbar icon*: |freehand_draw_icon|
 
-    The FreehandDrawTool allows freehand drawing of ``Patches`` and
-    ``MultiLine`` glyphs. The glyph to draw may be defined via the
-    ``renderers`` property.
+    Allows freehand drawing of ``Patches`` and ``MultiLine`` glyphs. The glyph
+    to draw may be defined via the ``renderers`` property.
 
     The tool will automatically modify the columns on the data source
     corresponding to the ``xs`` and ``ys`` values of the glyph. Any

--- a/bokeh/models/transforms.py
+++ b/bokeh/models/transforms.py
@@ -48,11 +48,11 @@ class CustomJSTransform(Transform):
 
     @classmethod
     def from_py_func(cls, func, v_func):
-        ''' Create a CustomJSTransform instance from a pair of Python
+        ''' Create a ``CustomJSTransform`` instance from a pair of Python
         functions. The function is translated to JavaScript using PScript.
 
         The python functions must have no positional arguments. It's
-        possible to pass Bokeh models (e.g. a ColumnDataSource) as keyword
+        possible to pass Bokeh models (e.g. a ``ColumnDataSource``) as keyword
         arguments to the functions.
 
         The ``func`` function namespace will contain the variable ``x`` (the
@@ -125,7 +125,7 @@ class CustomJSTransform(Transform):
 
     @classmethod
     def from_coffeescript(cls, func, v_func, args={}):
-        ''' Create a CustomJSTransform instance from a pair of CoffeeScript
+        ''' Create a ``CustomJSTransform`` instance from a pair of CoffeeScript
         snippets. The function bodies are translated to JavaScript functions
         using node and therefore require return statements.
 
@@ -257,7 +257,7 @@ class Interpolator(Transform):
     between specified (x, y) pairs of data.  As an example, if two control
     point pairs were provided to the interpolator, a linear interpolaction
     at a specific value of 'x' would result in the value of 'y' which existed
-    on the line conneting the two control points.
+    on the line connecting the two control points.
 
     The control point pairs for the interpolators can be specified through either
 
@@ -267,7 +267,7 @@ class Interpolator(Transform):
 
         interp = Interpolator(x=[1, 2, 3, 4, 5], y=[2, 5, 10, 12, 16])
 
-    * or a pair of columns defined in a `ColumnDataSource` object:
+    * or a pair of columns defined in a ``ColumnDataSource`` object:
 
     .. code-block: python
 
@@ -275,13 +275,13 @@ class Interpolator(Transform):
 
 
     This is the base class and is not intended to end use.  Please see the
-    documentation for the final derived classes (Jitter, LineraInterpolator,
-    StepInterpolator) for mor information on their specific methods of
+    documentation for the final derived classes (``Jitter``, ``LineraInterpolator``,
+    ``StepInterpolator``) for more information on their specific methods of
     interpolation.
 
     '''
     x = Either(String, Seq(Float), help="""
-    Independant coordiante denoting the location of a point.
+    Independent coordinate denoting the location of a point.
     """)
 
     y = Either(String, Seq(Float), help="""

--- a/bokeh/models/transforms.py
+++ b/bokeh/models/transforms.py
@@ -23,7 +23,7 @@ class Transform(Model):
 
     JavaScript implementations should implement the following methods:
 
-    .. code-block: coffeescript
+    .. code-block:: coffeescript
 
         compute: (x) ->
             # compute the transform of a single value
@@ -263,13 +263,13 @@ class Interpolator(Transform):
 
     * A literal sequence of values:
 
-    .. code-block: python
+    .. code-block:: python
 
         interp = Interpolator(x=[1, 2, 3, 4, 5], y=[2, 5, 10, 12, 16])
 
     * or a pair of columns defined in a ``ColumnDataSource`` object:
 
-    .. code-block: python
+    .. code-block:: python
 
         interp = Interpolator(x="year", y="earnings", data=jewlery_prices))
 

--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -42,8 +42,9 @@ class TextInput(InputWidget):
     """)
 
     callback = Instance(Callback, help="""
-    A callback to run in the browser whenever the user unfocuses the TextInput
-    widget by hitting Enter or clicking outside of the text box area.
+    A callback to run in the browser whenever the user unfocuses the
+    ``TextInput`` widget by hitting Enter or clicking outside of the text box
+    area.
     """)
 
     placeholder = String(default="", help="""
@@ -53,11 +54,11 @@ class TextInput(InputWidget):
 
 class PasswordInput(TextInput):
     ''' Single-line password input widget.
-        Note: Despite PasswordInput inheriting from TextInput the password
-        cannot be inspected on the field ``value``. Also, note that this field
-        functionally just hides the input on the browser, transmiting safely a
-        password as a callback, e.g., to the a bokeh server would require
-        some secure connection.
+        Note: Despite ``PasswordInput`` inheriting from ``TextInput`` the
+        password cannot be inspected on the field ``value``. Also, note that
+        this field functionally just hides the input on the browser,
+        transmitting safely a password as a callback, e.g., to a bokeh
+        server would require some secure connection.
 
     '''
 

--- a/bokeh/models/widgets/sliders.py
+++ b/bokeh/models/widgets/sliders.py
@@ -50,7 +50,7 @@ class AbstractSlider(Widget):
     """)
 
     callback_throttle = Float(default=200, help="""
-    Number of millseconds to pause between callback calls as the slider is moved.
+    Number of milliseconds to pause between callback calls as the slider is moved.
     """)
 
     callback_policy = Enum(SliderCallbackPolicy, default="throttle", help="""

--- a/bokeh/models/widgets/tables.py
+++ b/bokeh/models/widgets/tables.py
@@ -527,7 +527,7 @@ class DataTable(TableWidget):
     """)
 
     reorderable = Bool(True, help="""
-    Allows the reordering of a tables's columns. To reorder a column,
+    Allows the reordering of a table's columns. To reorder a column,
     click and drag a table's header to the desired location in the table.
     The columns on either side will remain in their previous order.
     """)

--- a/bokeh/palettes.py
+++ b/bokeh/palettes.py
@@ -130,7 +130,7 @@ attributes ``d3``, ``mpl``, and ``colorblind`` that have dictionaries
 corresponding to the those groups of palettes.
 
 Finally, all palettes are collected in the ``all_palettes`` palettes
-module attrubute, and the "small" palettes (i.e. excluding the ones with 256
+module attribute, and the "small" palettes (i.e. excluding the ones with 256
 colors) are collected and in a ``small_palettes`` attribute.
 
 Built-in Palettes

--- a/bokeh/plotting/figure.py
+++ b/bokeh/plotting/figure.py
@@ -816,22 +816,22 @@ Examples:
         so that hexagonal tiles are all regular (i.e. not "stretched") in
         screen space.
 
-        For more sophisicated use-cases, e.g. weighted binning or individually
+        For more sophisticated use-cases, e.g. weighted binning or individually
         scaling hex tiles, use :func:`hex_tile` directly, or consider a higher
         level library such as HoloViews.
 
         Args:
             x (array[float]) :
-                A NumPy array of x-coordinates to bin into haxagonal tiles.
+                A NumPy array of x-coordinates to bin into hexagonal tiles.
 
             y (array[float]) :
-                A NumPy array of y-coordinates to bin into haxagonal tiles
+                A NumPy array of y-coordinates to bin into hexagonal tiles
 
             size (float) :
                 The size of the hexagonal tiling to use. The size is defined as
                 distance from the center of a hexagon to a corner.
 
-                In case the apsect scaling is not 1-1, then specifically `size`
+                In case the aspect scaling is not 1-1, then specifically `size`
                 is the distance from the center to the "top" corner with the
                 `"pointytop"` orientation, and the distance from the center to
                 a "side" corner with the "flattop" orientation.
@@ -859,7 +859,7 @@ Examples:
 
                 When working with a plot with ``aspect_scale != 1``, this
                 parameter can be set to match the plot, in order to draw
-                regular hexagons (insted of "stretched" ones).
+                regular hexagons (instead of "stretched" ones).
 
                 This is roughly equivalent to binning in "screen space", and
                 it may be better to use axis-aligned rectangular bins when
@@ -870,7 +870,7 @@ Examples:
         Returns
             (Glyphrender, DataFrame)
                 A tuple with the ``HexTile`` renderer generated to display the
-                binning, and a Pandas DataFrame with columns ``q``, ``r``,
+                binning, and a Pandas ``DataFrame`` with columns ``q``, ``r``,
                 and ``count``, where ``q`` and ``r`` are `axial coordinates`_
                 for a tile, and ``count`` is the associated bin count.
 
@@ -1010,7 +1010,7 @@ Examples:
                 for the graph edges. An attempt will be made to convert the object to
                 :class:`~bokeh.models.sources.ColumnDataSource` if needed. If none is supplied, one is created
                 for the user automatically.
-            layout_provider (:class:`~bokeh.models.graphs.LayoutProvider`) : a LayoutProvider instance to
+            layout_provider (:class:`~bokeh.models.graphs.LayoutProvider`) : a ``LayoutProvider`` instance to
                 provide the graph coordinates in Cartesian space.
             **kwargs: :ref:`userguide_styling_line_properties` and :ref:`userguide_styling_fill_properties`
         '''

--- a/bokeh/protocol/receiver.py
+++ b/bokeh/protocol/receiver.py
@@ -62,7 +62,7 @@ class Receiver(object):
 
         Args:
             protocol (Protocol) :
-                A Bokeh protocol object to use to assemble colleted message
+                A Bokeh protocol object to use to assemble collected message
                 fragments.
         '''
         self._protocol = protocol

--- a/bokeh/protocol/versions.py
+++ b/bokeh/protocol/versions.py
@@ -1,4 +1,4 @@
-''' Provide definitions for Bokeh WebSocket prototol versions.
+''' Provide definitions for Bokeh WebSocket protocol versions.
 
 A *protocol specification* is a sequence of tuples of the form:
 

--- a/bokeh/server/callbacks.py
+++ b/bokeh/server/callbacks.py
@@ -46,7 +46,7 @@ class SessionCallback(object):
         raise NotImplementedError("_copy_with_changed_callback")
 
 class NextTickCallback(SessionCallback):
-    ''' Represent a callback to execute on the next IOLoop "tick".
+    ''' Represent a callback to execute on the next ``IOLoop`` "tick".
 
     '''
     def __init__(self, document, callback, id=None):
@@ -67,7 +67,7 @@ class NextTickCallback(SessionCallback):
         return NextTickCallback(self._document, new_callback, self._id)
 
 class PeriodicCallback(SessionCallback):
-    ''' Represent a callback to execute periodically on the IOLoop at a
+    ''' Represent a callback to execute periodically on the ``IOLoop`` at a
     specified periodic time interval.
 
     '''
@@ -100,7 +100,7 @@ class PeriodicCallback(SessionCallback):
         return PeriodicCallback(self._document, new_callback, self._period, self._id)
 
 class TimeoutCallback(SessionCallback):
-    ''' Represent a callback to execute once on the IOLoop after a specifeed
+    ''' Represent a callback to execute once on the ``IOLoop`` after a specified
     time interval passes.
 
     '''

--- a/bokeh/server/contexts.py
+++ b/bokeh/server/contexts.py
@@ -97,8 +97,8 @@ class BokehSessionContext(SessionContext):
 
 
 class ApplicationContext(object):
-    ''' Server-side holder for bokeh.application.Application plus any associated data.
-        This holds data that's global to all sessions, while ServerSession holds
+    ''' Server-side holder for ``bokeh.application.Application`` plus any associated data.
+        This holds data that's global to all sessions, while ``ServerSession`` holds
         data specific to an "instance" of the application.
     '''
 

--- a/bokeh/server/server.py
+++ b/bokeh/server/server.py
@@ -331,7 +331,8 @@ class Server(BaseServer):
                 path "/" automatically.
 
                 As a convenience, a callable may also be provided, in which
-                an Application will be created for it using FunctionHandler.
+                an Application will be created for it using
+                ``FunctionHandler``.
 
             io_loop (IOLoop, optional) :
                 An explicit Tornado ``IOLoop`` to run Bokeh Server code on. If

--- a/bokeh/server/session.py
+++ b/bokeh/server/session.py
@@ -135,11 +135,11 @@ class ServerSession(object):
         self._expiration_blocked_count -= 1
 
     def subscribe(self, connection):
-        """This should only be called by ServerConnection.subscribe_session or our book-keeping will be broken"""
+        """This should only be called by ``ServerConnection.subscribe_session`` or our book-keeping will be broken"""
         self._subscribed_connections.add(connection)
 
     def unsubscribe(self, connection):
-        """This should only be called by ServerConnection.unsubscribe_session or our book-keeping will be broken"""
+        """This should only be called by ``ServerConnection.unsubscribe_session`` or our book-keeping will be broken"""
         self._subscribed_connections.discard(connection)
         self._last_unsubscribe_time = current_time()
 

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -110,7 +110,7 @@ class BokehTornado(TornadoApplication):
         mem_log_frequency_milliseconds (int, optional) :
             Number of milliseconds between logging memory information (default: 0)
 
-            Enabling this feature requires the optional depenency ``psutil`` to be
+            Enabling this feature requires the optional dependency ``psutil`` to be
             installed.
 
         use_index (bool, optional) :

--- a/bokeh/server/util.py
+++ b/bokeh/server/util.py
@@ -139,7 +139,7 @@ def match_host(host, pattern):
             wildcards for ip address octets or ports.
 
     This function will return ``True`` if the hostname matches the pattern,
-    including any widcards. If the pattern contains a port, the host string
+    including any wildcards. If the pattern contains a port, the host string
     must also contain a matching port.
 
     Returns:

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -30,10 +30,11 @@ A global settings object that other parts of Bokeh can refer to.
   - ``BOKEH_RESOURCES=absolute-dev``
   - ``BOKEH_SIMPLE_IDS=true``
 
- Accepted values are ``yes``/``no``, ``true``/``false`` or ``0``/``1``.
+  Accepted values are ``yes``/``no``, ``true``/``false`` or ``0``/``1``.
 
-``BOKEH_DOCS_CDN`` --- What version of BokehJS to use when building sphinx
-  `~bokeh.resources.Resources` class reference for full details.
+``BOKEH_DOCS_CDN`` --- What version of BokehJS to use when building sphinx.
+
+  See :ref:`bokeh.resources` module reference for full details.
 
 ``BOKEH_DOCS_VERSION`` --- What version of Bokeh to show when building sphinx docs locally.
 

--- a/bokeh/transform.py
+++ b/bokeh/transform.py
@@ -131,7 +131,7 @@ def factor_mark(field_name, markers, factors, start=0, end=None):
 
     .. note::
         This transform is primarily only useful with ``scatter``, which
-        can be paremeterized by glyph type.
+        can be parameterized by glyph type.
 
     Args:
         field_name (str) : a field name to configure ``DataSpec`` with
@@ -163,7 +163,7 @@ def jitter(field_name, width, mean=0, distribution="uniform", range=None):
     Args:
         field_name (str) : a field name to configure ``DataSpec`` with
 
-        width (float) : the width of the random distribition to apply
+        width (float) : the width of the random distribution to apply
 
         mean (float, optional) : an offset to apply (default: 0)
 

--- a/bokeh/util/compiler.py
+++ b/bokeh/util/compiler.py
@@ -94,7 +94,7 @@ class AttrDict(dict):
         return self[key]
 
 class CompilationError(RuntimeError):
-    ''' A RuntimeError subclass for reporting JS compilation errors.
+    ''' A ``RuntimeError`` subclass for reporting JS compilation errors.
 
     '''
     def __init__(self, error):
@@ -217,7 +217,7 @@ class Inline(Implementation):
         self.file = file
 
 class CoffeeScript(Inline):
-    ''' An implementation for a Bokeh custom model in CoffeeSript.
+    ''' An implementation for a Bokeh custom model in CoffeeScript.
 
     Example:
 
@@ -241,7 +241,7 @@ class CoffeeScript(Inline):
         return "coffeescript"
 
 class TypeScript(Inline):
-    ''' An implementation for a Bokeh custom model in TypeSript
+    ''' An implementation for a Bokeh custom model in TypeScript
 
     Example:
 

--- a/bokeh/util/hex.py
+++ b/bokeh/util/hex.py
@@ -5,7 +5,7 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-''' Functions useful for dealing with hexacognal tilings.
+''' Functions useful for dealing with hexagonal tilings.
 
 For more information on the concepts employed here, see this informative page
 
@@ -46,7 +46,7 @@ def axial_to_cartesian(q, r, size, orientation, aspect_scale=1):
     tiles centers.
 
     This function can be useful for positioning other Bokeh glyphs with
-    cartesian coordinates in relationto a hex tiling.
+    cartesian coordinates in relation to a hex tiling.
 
     This function was adapted from:
 
@@ -147,8 +147,8 @@ def cartesian_to_axial(x, y, size, orientation, aspect_scale=1):
 def hexbin(x, y, size, orientation="pointytop", aspect_scale=1):
     ''' Perform an equal-weight binning of data points into hexagonal tiles.
 
-    For more sophiscticated use cases, e.g. weighted binning or scaling
-    individual tiles proprtional to some other quantity, consider using
+    For more sophisticated use cases, e.g. weighted binning or scaling
+    individual tiles proportional to some other quantity, consider using
     HoloViews.
 
     Args:
@@ -174,7 +174,7 @@ def hexbin(x, y, size, orientation="pointytop", aspect_scale=1):
 
             When working with a plot with ``aspect_scale != 1``, this
             parameter can be set to match the plot, in order to draw
-            regular hexagons (insted of "stretched" ones).
+            regular hexagons (instead of "stretched" ones).
 
             This is roughly equivalent to binning in "screen space", and
             it may be better to use axis-aligned rectangular bins when

--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -201,7 +201,7 @@ def make_id():
     ''' Return a new unique ID for a Bokeh object.
 
     Normally this function will return simple monotonically increasing integer
-    IDs (as strings) for identifying Bokeh ojects within a Document. However,
+    IDs (as strings) for identifying Bokeh objects within a Document. However,
     if it is desirable to have globally unique for every object, this behavior
     can be overridden by setting the environment variable ``BOKEH_SIMPLE_IDS=no``.
 
@@ -221,7 +221,7 @@ def make_id():
 def make_globally_unique_id():
     ''' Return a globally unique UUID.
 
-    Some situtations, e.g. id'ing dynamincally created Divs in HTML documents,
+    Some situtations, e.g. id'ing dynamically created Divs in HTML documents,
     always require globally unique IDs.
 
     Returns:
@@ -268,7 +268,7 @@ def transform_array(array, force_list=False, buffers=None):
         buffers (set, optional) :
             If binary buffers are desired, the buffers parameter may be
             provided, and any columns that may be sent as binary buffers
-            will be added to the set. If None, then only base64 encodinfg
+            will be added to the set. If None, then only base64 encoding
             will be used (default: None)
 
             If force_list is True, then this value will be ignored, and
@@ -322,7 +322,7 @@ def transform_series(series, force_list=False, buffers=None):
         buffers (set, optional) :
             If binary buffers are desired, the buffers parameter may be
             provided, and any columns that may be sent as binary buffers
-            will be added to the set. If None, then only base64 encodinfg
+            will be added to the set. If None, then only base64 encoding
             will be used (default: None)
 
             If force_list is True, then this value will be ignored, and
@@ -356,7 +356,7 @@ def serialize_array(array, force_list=False, buffers=None):
         buffers (set, optional) :
             If binary buffers are desired, the buffers parameter may be
             provided, and any columns that may be sent as binary buffers
-            will be added to the set. If None, then only base64 encodinfg
+            will be added to the set. If None, then only base64 encoding
             will be used (default: None)
 
             If force_list is True, then this value will be ignored, and
@@ -416,7 +416,7 @@ def traverse_data(obj, use_numpy=True, buffers=None):
     return obj_copy
 
 def transform_column_source_data(data, buffers=None, cols=None):
-    ''' Transform ColumnSourceData data to a serialized format
+    ''' Transform ``ColumnSourceData`` data to a serialized format
 
     Args:
         data (dict) : the mapping of names to data columns to transform
@@ -424,7 +424,7 @@ def transform_column_source_data(data, buffers=None, cols=None):
         buffers (set, optional) :
             If binary buffers are desired, the buffers parameter may be
             provided, and any columns that may be sent as binary buffers
-            will be added to the set. If None, then only base64 encodinfg
+            will be added to the set. If None, then only base64 encoding
             will be used (default: None)
 
             **This is an "out" parameter**. The values it contains will be

--- a/bokeh/util/string.py
+++ b/bokeh/util/string.py
@@ -63,7 +63,7 @@ def escape(s, quote=("'", '"')):
     return s
 
 def indent(text, n=2, ch=" "):
-    ''' Indent all the lines in a given block of text by a specified ammount.
+    ''' Indent all the lines in a given block of text by a specified amount.
 
     Args:
         text (str) :

--- a/bokeh/util/version.py
+++ b/bokeh/util/version.py
@@ -11,7 +11,7 @@ Attributes:
 
 Functions:
     base_version:
-        Reurn the base version string, without any "dev", "rc" or local build
+        Return the base version string, without any "dev", "rc" or local build
         information appended.
 
 .. _versioneer: https://github.com/warner/python-versioneer

--- a/sphinx/source/docs/dev_guide/documentation.rst
+++ b/sphinx/source/docs/dev_guide/documentation.rst
@@ -13,7 +13,7 @@ project. It's also a good way to to get started and introduce yourself as a new
 contributor. The most likely way for typos or other small documentation errors
 to be resolved is for the person who notices the problem to immediately submit
 a Pull Request to with a correction. *This is always appreciated!* In
-addition quick fixes, there is also a list of `Open Docs Issues`_ on GitHub
+addition to quick fixes, there is also a list of `Open Docs Issues`_ on GitHub
 that anyone can look at for tasks that need help.
 
 Working on Documentation

--- a/sphinx/source/docs/reference/models.rst
+++ b/sphinx/source/docs/reference/models.rst
@@ -5,7 +5,7 @@ bokeh.models
 
 .. automodule:: bokeh.models
 
-These models are accumulatd into :class:`~bokeh.document.Document` instances,
+These models are accumulated into :class:`~bokeh.document.Document` instances,
 which can be serialized and sent to clients (typically browsers) for display
 or use there.
 


### PR DESCRIPTION
I'm glad Bokeh is really well documented, but there's a lot more documentation than I thought!

This fixes lots of typos and places where classes/code were referenced without using double backticks. A few docstring rewordings to make them "verb first" style. Some minor formatting fixes too.

Also fixed some formatting typos where `.. code-block::` was used with one colon instead of two. It would be nice if Sphinx/rst would error when that happens, instead of silently displaying nothing.

- [ ] issues: addresses #8448 
