### PR TITLE
Update callback lasso example  #8393

### DIFF
--- a/sphinx/source/docs/user_guide/examples/interaction_callbacks_for_selections.py
+++ b/sphinx/source/docs/user_guide/examples/interaction_callbacks_for_selections.py
@@ -18,9 +18,9 @@ p2 = figure(plot_width=400, plot_height=400, x_range=(0, 1), y_range=(0, 1),
             tools="", title="Watch Here")
 p2.circle('x', 'y', source=s2, alpha=0.6)
 
-s1.callback = CustomJS(args=dict(s2=s2), code="""
-        var inds = cb_obj.selected.indices;
-        var d1 = cb_obj.data;
+s1.selected.js_on_change('indices', CustomJS(args=dict(s1=s1, s2=s2), code="""
+        var inds = cb_obj.indices;
+        var d1 = s1.data;
         var d2 = s2.data;
         d2['x'] = []
         d2['y'] = []
@@ -30,6 +30,7 @@ s1.callback = CustomJS(args=dict(s2=s2), code="""
         }
         s2.change.emit();
     """)
+)
 
 layout = row(p1, p2)
 


### PR DESCRIPTION
Fixes #8393. Updates interaction callback example (lasso select) in documentation to make it work with new version of bokeh (1.0.1). Thank you @philippjfr for pointing/adding solution. 
 Ref: https://github.com/bokeh/bokeh/issues/8393

- [X] issues: fixes #8393 

I tested example with bokeh 1.0.1 and it produced expected results:

<img width="806" alt="screen shot 2018-11-28 at 10 24 35 am" src="https://user-images.githubusercontent.com/7328852/49142516-3ed93180-f2f9-11e8-8ebf-ccd82e396511.png">

