### PR TITLE
Update lasso example documentation (#8393)

### DIFF
--- a/sphinx/source/docs/user_guide/examples/interaction_callbacks_for_selections.py
+++ b/sphinx/source/docs/user_guide/examples/interaction_callbacks_for_selections.py
@@ -18,9 +18,9 @@ p2 = figure(plot_width=400, plot_height=400, x_range=(0, 1), y_range=(0, 1),
             tools="", title="Watch Here")
 p2.circle('x', 'y', source=s2, alpha=0.6)
 
-s1.callback = CustomJS(args=dict(s2=s2), code="""
-        var inds = cb_obj.selected.indices;
-        var d1 = cb_obj.data;
+s1.selected.js_on_change('indices', CustomJS(args=dict(s1=s1, s2=s2), code="""
+        var inds = cb_obj.indices;
+        var d1 = s1.data;
         var d2 = s2.data;
         d2['x'] = []
         d2['y'] = []
@@ -30,6 +30,7 @@ s1.callback = CustomJS(args=dict(s2=s2), code="""
         }
         s2.change.emit();
     """)
+)
 
 layout = row(p1, p2)
 


### PR DESCRIPTION
Updates documentation example of lasso selection to make it work
with bokeh version 1.0.1. Thank you @philippjfr for pointing to/adding solution.
Ref: https://github.com/bokeh/bokeh/issues/8393

Tested new example and produces expected figure:

<img width="825" alt="screen shot 2018-11-28 at 11 03 36 pm" src="https://user-images.githubusercontent.com/7328852/49186026-afb53380-f363-11e8-931e-ac82f247840f.png">

- [x] issues: fixes #8393 
