### PR TITLE
DOC: remove extra "to execute" from embed

### DIFF
--- a/sphinx/source/docs/user_guide/embed.rst
+++ b/sphinx/source/docs/user_guide/embed.rst
@@ -16,7 +16,7 @@ First, a reminder of the distinction between standalone documents and apps:
 :ref:`userguide_embed_apps`
     These are Bokeh documents that are backed by a Bokeh Server. In addition
     to all the features of standalone documents, it is also possible to connect
-    events and tools to real Python callbacks, to execute that execute in the
+    events and tools to real Python callbacks, that execute in the
     Bokeh server. See :ref:`userguide_server` for more information about
     creating and running Bokeh apps.
 


### PR DESCRIPTION
in the introductory paragraphs of ["Embedding Plots and Apps"](https://bokeh.pydata.org/en/latest/docs/user_guide/embed.html#embedding-plots-and-apps) on the distinction between bokeh apps and standallone HTML, IMHO the text reads better if "to execute that execute" is changed to just "that execute":

>These are Bokeh documents that are backed by a Bokeh Server. In addition to all the features of standalone documents, it is also possible to connect events and tools to real Python callbacks, ~to execute~ that execute in the Bokeh server.

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [ ] issues: fixes #xxxx
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
