### PR TITLE
update sampledata bucket URL

### DIFF
--- a/bokeh/util/sampledata.py
+++ b/bokeh/util/sampledata.py
@@ -53,7 +53,7 @@ def download(progress=True):
     data_dir = external_data_dir(create=True)
     print("Using data directory: %s" % data_dir)
 
-    s3 = 'https://s3.amazonaws.com/bokeh_data/'
+    s3 = 'https://bokeh-sampledata.s3.amazonaws.com'
     files = [
         (s3, 'CGM.csv'),
         (s3, 'US_Counties.zip'),

--- a/bokeh/util/sampledata.py
+++ b/bokeh/util/sampledata.py
@@ -31,6 +31,7 @@ from sys import stdout
 
 # External imports
 import six
+from six.moves.urllib_parse import urljoin
 
 # Bokeh imports
 
@@ -193,7 +194,7 @@ def _download_file(base_url, filename, data_dir, progress=True):
     from six.moves.urllib.request import urlopen
     from zipfile import ZipFile
 
-    file_url = join(base_url, filename)
+    file_url = urljoin(base_url, filename)
     file_path = join(data_dir, filename)
 
     url = urlopen(file_url)


### PR DESCRIPTION
This changes the S3 bucket to use one under the control of the Bokeh AWS account. 

I had hoped to make a new bucket, rename the old `bokeh_data` bucket , then change the new bucket name to `bokeh_data`, so that the URL would not be different. However, this is no longer possible. AWS has restricted the namespace for buckets, new bucket names may no longer contain underscores at all. 

I have not changed or deleted the old bucket, and have no plans to, but cannot guarantee it will exist in perpetuity.