### PR TITLE
Disable show_vertices when PolyDrawTool inactive

### DIFF
--- a/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
@@ -80,6 +80,7 @@ export class PolyDrawToolView extends PolyToolView {
   }
 
   _show_vertices(): void {
+    if (!this.model.active ) { return }
     const xs: number[] = []
     const ys: number[] = []
     for (let i=0; i<this.model.renderers.length; i++) {


### PR DESCRIPTION
Straightforward fix the PolyDrawTool simply checks whether it is actually active before drawing vertices.

- [x] issues: fixes #8493
- [ ] tests added / passed
