### PR TITLE
move BokehJS license details to bokehjs/LICENSE

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -26,25 +26,3 @@ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 THE POSSIBILITY OF SUCH DAMAGE.
-
-
-
-
-The BokehJS client library bundles many third party JavaScript libraries. The
-complete set of unique licenses found in BokehJS packages is listed here:
-
-* Apache-2.0
-* AFLv2.1
-* BSD-2-Clause
-* BSD-3-Clause
-* ISC
-* MIT
-* Unlicense
-* WTFPL
-
-A detailed list of specific package licenses may be obtained by executing the
-following commands in the "bokehjs" subdirectory:
-
-    $ npm install
-
-    $ npx license-checker --production --csv

--- a/bokeh/tests/test___init__.py
+++ b/bokeh/tests/test___init__.py
@@ -72,28 +72,6 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 THE POSSIBILITY OF SUCH DAMAGE.
 
-
-
-
-The BokehJS client library bundles many third party JavaScript libraries. The
-complete set of unique licenses found in BokehJS packages is listed here:
-
-* Apache-2.0
-* AFLv2.1
-* BSD-2-Clause
-* BSD-3-Clause
-* ISC
-* MIT
-* Unlicense
-* WTFPL
-
-A detailed list of specific package licenses may be obtained by executing the
-following commands in the "bokehjs" subdirectory:
-
-    $ npm install
-
-    $ npx license-checker --production --csv
-
 """
 
 #-----------------------------------------------------------------------------

--- a/bokehjs/LICENSE
+++ b/bokehjs/LICENSE
@@ -26,3 +26,25 @@ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+
+The BokehJS client library bundles many third party JavaScript libraries. The
+complete set of unique licenses found in BokehJS packages is listed here:
+
+* Apache-2.0
+* AFLv2.1
+* BSD-2-Clause
+* BSD-3-Clause
+* ISC
+* MIT
+* Unlicense
+* WTFPL
+
+A detailed list of specific package licenses may be obtained by executing the
+following commands in the "bokehjs" subdirectory:
+
+    $ npm install
+
+    $ npx license-checker --production --csv

--- a/tests/codebase/test_js_license_set.py
+++ b/tests/codebase/test_js_license_set.py
@@ -29,7 +29,7 @@ from subprocess import PIPE, Popen
 # Tests
 #-----------------------------------------------------------------------------
 
-# If this list changes, then LICENSE.txt should be updated accordingly
+# If this list changes, then bokehjs/LICENSE should be updated accordingly
 LICENSES = [
     'Apache-2.0',
     'AFLv2.1',
@@ -44,7 +44,7 @@ LICENSES = [
 @pytest.mark.codebase
 def test_js_license_set():
     ''' If the current set of JS licenses changes, they should be noted in
-    the LICENSE.txt file.
+    the bokehjs/LICENSE file.
 
     '''
     os.chdir('bokehjs')


### PR DESCRIPTION
Moves the declaration of vendored JS libraries to the `bokehjs/LICENSE` file, which makes more sense. 


cc @dwt FYI for your reference