### PR TITLE
Enable copy paste for datatables

### DIFF
--- a/bokeh/_testing/util/selenium.py
+++ b/bokeh/_testing/util/selenium.py
@@ -123,6 +123,40 @@ def enter_text_in_cell(driver, cell, text):
     actions.send_keys(text + Keys.ENTER)
     actions.perform()
 
+def enter_text_in_cell_with_click_enter(driver, cell, text):
+    actions = ActionChains(driver)
+    actions.move_to_element(cell)
+    actions.click()
+    actions.send_keys(Keys.ENTER + text + Keys.ENTER)
+    actions.perform()
+
+def copy_table_rows(driver, rows):
+    actions = ActionChains(driver)
+    row = get_table_row(driver, rows[0])
+    actions.move_to_element(row)
+    actions.click()
+    actions.key_down(Keys.SHIFT)
+    for r in rows[1:]:
+        row = get_table_row(driver, r)
+        actions.move_to_element(row)
+        actions.click()
+    actions.key_up(Keys.SHIFT)
+    actions.key_down(Keys.CONTROL)
+    actions.send_keys(Keys.INSERT)
+    actions.key_up(Keys.CONTROL)
+    #actions.send_keys(Keys.CONTROL, 'c')
+    actions.perform()
+
+def paste_values(driver, el=None):
+    actions = ActionChains(driver)
+    if el:
+        actions.move_to_element(el)
+    actions.key_down(Keys.SHIFT)
+    actions.send_keys(Keys.INSERT)
+    actions.key_up(Keys.SHIFT)
+      #actions.send_keys(Keys.CONTROL, 'v')
+    actions.perform()
+
 def get_table_column_cells(driver, col):
     result = []
     grid = driver.find_element_by_css_selector('.grid-canvas')
@@ -147,6 +181,9 @@ def get_table_selected_rows(driver):
 
 def get_table_cell(driver, row, col):
     return driver.find_element_by_css_selector('.grid-canvas .slick-row:nth-child(%d) .r%d' % (row, col))
+
+def get_page_element(driver, element_selector):
+    return driver.find_element_by_css_selector(element_selector)
 
 def shift_click(driver, element):
     actions = ActionChains(driver)

--- a/bokehjs/package-lock.json
+++ b/bokehjs/package-lock.json
@@ -1933,6 +1933,43 @@
       "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
       "dev": true
     },
+    "patch-package": {
+      "version": "5.1.1",
+      "resolved": "http://registry.npmjs.org/patch-package/-/patch-package-5.1.1.tgz",
+      "integrity": "sha512-bO+vfFGgTVTtv89kXWGEMIPnrYhhhMtbOnJKStfIhNWUxperVjlI++1ixksi0YPCMPGuFy9W3zsKHxIITV2r2A==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "cross-spawn": "^5.1.0",
+        "fs-extra": "^4.0.1",
+        "minimist": "^1.2.0",
+        "rimraf": "^2.6.1",
+        "slash": "^1.0.0",
+        "tmp": "^0.0.31",
+        "update-notifier": "^2.2.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -2274,8 +2311,8 @@
       "dev": true
     },
     "slickgrid": {
-      "version": "git+https://github.com/bokeh/SlickGrid.git#6c1327bbf85128d6cccce82436bfcccfe6b33afc",
-      "from": "git+https://github.com/bokeh/SlickGrid.git#6c1327b",
+      "version": "git+https://github.com/bokeh/SlickGrid.git#d1bd9fa7d66b8e281812c2e98941880d867a5896",
+      "from": "git+https://github.com/bokeh/SlickGrid.git#d1bd9fa7",
       "requires": {
         "jquery": ">=1.8.0",
         "jquery-ui": ">=1.8.0"

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -81,7 +81,7 @@
     "pikaday": "^1.7.0",
     "proj4": "<2.4",
     "request": "^2.88.0",
-    "slickgrid": "https://github.com/bokeh/SlickGrid.git#6c1327b",
+    "slickgrid": "https://github.com/bokeh/SlickGrid.git#d1bd9fa7",
     "spawn-sync": "^2.0.0",
     "sprintf-js": "^1.1.1",
     "timezone": "^1.0.6",

--- a/bokehjs/src/lib/models/widgets/tables/data_table.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_table.ts
@@ -3,9 +3,11 @@ type SlickGrid = typeof SlickGrid
 
 const {RowSelectionModel} = require("slickgrid/plugins/slick.rowselectionmodel")
 const {CheckboxSelectColumn} = require("slickgrid/plugins/slick.checkboxselectcolumn")
+const {CellExternalCopyManager} = require("slickgrid/plugins/slick.cellexternalcopymanager")
 
 import * as p from "core/properties"
 import {uniqueId} from "core/util/string"
+import {isString} from "core/util/types"
 import {any, range} from "core/util/array"
 import {keys} from "core/util/object"
 import {logger} from "core/logging"
@@ -254,6 +256,20 @@ export class DataTableView extends WidgetView {
       this.grid.setSelectionModel(new RowSelectionModel({selectActiveRow: checkboxSelector == null}))
       if (checkboxSelector != null)
         this.grid.registerPlugin(checkboxSelector)
+
+      const pluginOptions = {
+        dataItemColumnValueExtractor: function(val: Item, col: TableColumn) {
+          // As defined in this file, Item can contain any type values
+          let value: any = val[col.field]
+          if (isString(value)) {
+            value = value.replace(/\n/g, "\\n")
+          }
+          return value
+        },
+        includeHeaderWhenCopying: false,
+      }
+
+      this.grid.registerPlugin(new CellExternalCopyManager(pluginOptions))
 
       this.grid.onSelectedRowsChanged.subscribe((_event: any, args: any) => {
         if (this._in_selection_update) {

--- a/tests/codebase/test_code_quality.py
+++ b/tests/codebase/test_code_quality.py
@@ -81,7 +81,8 @@ def use_tab_rule(fname):
 
 exclude_paths = ("CHANGELOG",)
 
-exclude_exts = (".png", ".jpg", ".pxm", ".ico", ".ics", ".gz", ".gif", ".enc", ".svg", ".xml", ".shp", ".dbf", ".shx", "otf", ".eot", ".ttf", ".woff", ".woff2")
+exclude_exts = (".patch", ".png", ".jpg", ".pxm", ".ico", ".ics", ".gz", ".gif", ".enc", ".svg", ".xml", ".shp",
+                ".dbf", ".shx", "otf", ".eot", ".ttf", ".woff", ".woff2")
 
 exclude_dirs = ("sphinx/draw.io",)
 

--- a/tests/integration/widgets/tables/test_cell_editors.py
+++ b/tests/integration/widgets/tables/test_cell_editors.py
@@ -23,7 +23,7 @@ import pytest ; pytest
 
 # Bokeh imports
 from bokeh.models import ColumnDataSource, CustomJS, DataTable, IntEditor, NumberEditor, StringEditor, TableColumn
-from bokeh._testing.util.selenium import enter_text_in_cell, get_table_cell, RECORD
+from bokeh._testing.util.selenium import enter_text_in_cell, enter_text_in_cell_with_click_enter, get_table_cell, RECORD
 
 #-----------------------------------------------------------------------------
 # Tests
@@ -298,6 +298,27 @@ class Test_StringEditor(Test_CellEditor_Base):
         # Now double click, enter the text new value and <enter>
         cell = get_table_cell(page.driver, 1, 1)
         enter_text_in_cell(page.driver, cell, "baz")
+
+        # Click row 2 (which triggers callback again so we can inspect the data)
+        cell = get_table_cell(page.driver, 2, 1)
+        cell.click()
+        results = page.results
+        assert results['values'] == ["baz", "bar"]
+
+        assert page.has_no_console_errors()
+
+    def test_editing_updates_source_with_click_enter(self, bokeh_model_page):
+        page = bokeh_model_page(self.table)
+
+        # Click row 1 (which triggers the selection callback)
+        cell = get_table_cell(page.driver, 1, 1)
+        cell.click()
+        results = page.results
+        assert results['values'] == self.values
+
+        # Now double click, enter the text new value and <enter>
+        cell = get_table_cell(page.driver, 1, 1)
+        enter_text_in_cell_with_click_enter(page.driver, cell, "baz")
 
         # Click row 2 (which triggers callback again so we can inspect the data)
         cell = get_table_cell(page.driver, 2, 1)

--- a/tests/integration/widgets/test_copy_paste.py
+++ b/tests/integration/widgets/test_copy_paste.py
@@ -1,0 +1,72 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2017, Anaconda, Inc. All rights reserved.
+#
+# Powered by the Bokeh Development Team.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import pytest ; pytest
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+
+from time import sleep
+
+# External imports
+
+# Bokeh imports
+from bokeh.layouts import column
+from bokeh.models import ColumnDataSource, DataTable, TableColumn
+from bokeh._testing.util.selenium import copy_table_rows, paste_values
+from bokeh._testing.util.selenium import get_page_element, enter_text_in_cell_with_click_enter
+from bokeh.models.widgets import Div
+
+#-----------------------------------------------------------------------------
+# Tests
+#-----------------------------------------------------------------------------
+
+pytest_plugins = (
+    "bokeh._testing.plugins.bokeh",
+)
+
+@pytest.mark.integration
+@pytest.mark.selenium
+class Test_CopyPaste(object):
+
+    def test_copy_paste_to_textarea(self, bokeh_model_page):
+        source = ColumnDataSource(dict(x=[1, 2], y=[1, 1]))
+        columns = [TableColumn(field='x', title='x'), TableColumn(field='y', title='y')]
+        table = DataTable(source=source, columns=columns, editable=False, width=600)
+        text_area = Div(text='<textarea id="T1"></textarea>')
+
+        page = bokeh_model_page(column(table, text_area))
+
+        # Use reversed order to get the correct order
+        copy_table_rows(page.driver, [2, 1])
+
+        # Copy is a little slow
+        sleep(0.1)
+
+        element = get_page_element(page.driver, '#T1')
+
+        # Selenium doesn't paste until we write something to the element first
+        # textarea works like a cell
+        enter_text_in_cell_with_click_enter(page.driver, element, 'PASTED:')
+
+        paste_values(page.driver, element)
+
+        result = element.get_attribute('value')
+
+        # The textarea now contains the content in the datatable
+        assert result == '\nPASTED:\n0\t1\t1\n1\t2\t1\n'
+
+        assert page.has_no_console_errors()


### PR DESCRIPTION
Use slickgrid external copy paste manager to add copy paste support for bokeh datatables.

- [x] issues: fixes #7762
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
