### PR TITLE
Preprocessor to strip out IPython magics from notebooks

### DIFF
--- a/bokeh/application/handlers/notebook.py
+++ b/bokeh/application/handlers/notebook.py
@@ -92,12 +92,12 @@ class NotebookHandler(CodeHandler):
                 Given the source of a cell, filter out all cell and line magics.
                 """
                 filtered=[]
-                for num, line in enumerate(source.splitlines()):
+                for line in source.splitlines():
                     if self._magic_pattern.match(line) is None:
                         filtered.append(line)
                     else:
-                        msg = 'Stripping out IPython magic detected on line {num} of cell {cell}: {line}' #%r' % line
-                        message = msg.format(num=num, cell=self._cell_counter, line=repr(line))
+                        msg = 'Stripping out IPython magic detected in code cell {cell}: {line}' #%r' % line
+                        message = msg.format(cell=self._cell_counter, line=repr(line))
                         log.warn(message)
                 return '\n'.join(filtered)
 

--- a/bokeh/application/handlers/notebook.py
+++ b/bokeh/application/handlers/notebook.py
@@ -85,7 +85,7 @@ class NotebookHandler(CodeHandler):
             """
 
 
-            _magic_pattern = re.compile('^\s*%+\w\w')
+            _magic_pattern = re.compile('^\s*%+\w\w+($|(\s+))')
 
             def strip_magics(self, source):
                 """

--- a/bokeh/application/handlers/notebook.py
+++ b/bokeh/application/handlers/notebook.py
@@ -84,8 +84,7 @@ class NotebookHandler(CodeHandler):
             out all magics (i.e IPython specific syntax).
             """
 
-
-            _magic_pattern = re.compile('^\s*%+\w\w+($|(\s+))')
+            _magic_pattern = re.compile('^\s*(?P<magic>%+\w\w+)($|(\s+))')
 
             def strip_magics(self, source):
                 """
@@ -93,11 +92,12 @@ class NotebookHandler(CodeHandler):
                 """
                 filtered=[]
                 for line in source.splitlines():
-                    if self._magic_pattern.match(line) is None:
+                    match = self._magic_pattern.match(line)
+                    if match is None:
                         filtered.append(line)
                     else:
-                        msg = 'Stripping out IPython magic detected in code cell {cell}: {line}' #%r' % line
-                        message = msg.format(cell=self._cell_counter, line=repr(line))
+                        msg = 'Stripping out IPython magic {magic} detected in code cell {cell}'
+                        message = msg.format(cell=self._cell_counter, magic=match.group('magic'))
                         log.warn(message)
                 return '\n'.join(filtered)
 

--- a/bokeh/application/handlers/notebook.py
+++ b/bokeh/application/handlers/notebook.py
@@ -92,20 +92,23 @@ class NotebookHandler(CodeHandler):
                 Given the source of a cell, filter out all cell and line magics.
                 """
                 filtered=[]
-                for line in source.splitlines():
+                for num, line in enumerate(source.splitlines()):
                     if self._magic_pattern.match(line) is None:
                         filtered.append(line)
                     else:
-                        msg = 'Stripping out IPython magic detected on line: %r' % line
-                        log.warn(msg)
+                        msg = 'Stripping out IPython magic detected on line {num} of cell {cell}: {line}' #%r' % line
+                        message = msg.format(num=num, cell=self._cell_counter, line=repr(line))
+                        log.warn(message)
                 return '\n'.join(filtered)
 
             def preprocess_cell(self, cell, resources, index):
                 if cell['cell_type'] == 'code':
+                    self._cell_counter += 1
                     cell['source'] = self.strip_magics(cell['source'])
                 return cell, resources
 
             def __call__(self, nb, resources):
+                self._cell_counter = 1
                 return self.preprocess(nb,resources)
 
         preprocessors=[StripMagicsProcessor()]

--- a/bokeh/application/handlers/notebook.py
+++ b/bokeh/application/handlers/notebook.py
@@ -95,6 +95,9 @@ class NotebookHandler(CodeHandler):
                 for line in source.splitlines():
                     if self._magic_pattern.match(line) is None:
                         filtered.append(line)
+                    else:
+                        msg = 'Stripping out IPython magic detected on line: %r' % line
+                        log.warn(msg)
                 return '\n'.join(filtered)
 
             def preprocess_cell(self, cell, resources, index):

--- a/bokeh/application/handlers/notebook.py
+++ b/bokeh/application/handlers/notebook.py
@@ -96,7 +96,7 @@ class NotebookHandler(CodeHandler):
                     if match is None:
                         filtered.append(line)
                     else:
-                        msg = 'Stripping out IPython magic {magic} detected in code cell {cell}'
+                        msg = 'Stripping out IPython magic {magic} in code cell {cell}'
                         message = msg.format(cell=self._cell_counter, magic=match.group('magic'))
                         log.warn(message)
                 return '\n'.join(filtered)

--- a/bokeh/application/handlers/notebook.py
+++ b/bokeh/application/handlers/notebook.py
@@ -84,7 +84,7 @@ class NotebookHandler(CodeHandler):
             out all magics (i.e IPython specific syntax).
             """
 
-            _magic_pattern = re.compile('^\s*(?P<magic>%+\w\w+)($|(\s+))')
+            _magic_pattern = re.compile('^\s*(?P<magic>%%\w\w+)($|(\s+))')
 
             def strip_magics(self, source):
                 """
@@ -122,6 +122,7 @@ class NotebookHandler(CodeHandler):
                 exporter.register_preprocessor(preprocessor)
 
             source, _ = exporter.from_notebook_node(nb)
+            source = source.replace('get_ipython().run_line_magic', '')
             kwargs['source'] = source
 
         super(NotebookHandler, self).__init__(*args, **kwargs)

--- a/bokeh/application/handlers/notebook.py
+++ b/bokeh/application/handlers/notebook.py
@@ -22,6 +22,7 @@ notebook code is executed, the Document being modified will be available as
 #-----------------------------------------------------------------------------
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import re
 import logging
 log = logging.getLogger(__name__)
 
@@ -83,13 +84,16 @@ class NotebookHandler(CodeHandler):
             out all magics (i.e IPython specific syntax).
             """
 
+
+            _magic_pattern = re.compile('^\s*%+\w\w')
+
             def strip_magics(self, source):
                 """
                 Given the source of a cell, filter out all cell and line magics.
                 """
                 filtered=[]
                 for line in source.splitlines():
-                    if not line.startswith('%'):
+                    if self._magic_pattern.match(line) is None:
                         filtered.append(line)
                 return '\n'.join(filtered)
 

--- a/bokeh/application/handlers/notebook.py
+++ b/bokeh/application/handlers/notebook.py
@@ -108,7 +108,7 @@ class NotebookHandler(CodeHandler):
                 return cell, resources
 
             def __call__(self, nb, resources):
-                self._cell_counter = 1
+                self._cell_counter = 0
                 return self.preprocess(nb,resources)
 
         preprocessors=[StripMagicsProcessor()]

--- a/bokeh/application/handlers/tests/test_notebook.py
+++ b/bokeh/application/handlers/tests/test_notebook.py
@@ -20,9 +20,11 @@ import pytest ; pytest
 # Standard library imports
 
 # External imports
+import six
 from packaging import version
 import nbformat
 import nbconvert
+
 
 # Bokeh imports
 from bokeh.document import Document
@@ -55,6 +57,7 @@ class Test_NotebookHandler(object):
 
     # Public methods ----------------------------------------------------------
 
+    @pytest.mark.skipif(six.PY2, reason="this test doesn't work on Python 2 due to unicode literals")
     def test_runner_strips_line_magics(self):
         doc = Document()
         source = nbformat.v4.new_notebook()
@@ -66,6 +69,7 @@ class Test_NotebookHandler(object):
 
         with_script_contents(source, load)
 
+    @pytest.mark.skipif(six.PY2, reason="this test doesn't work on Python 2 due to unicode literals")
     def test_runner_strips_cell_magics(self):
         doc = Document()
         source = nbformat.v4.new_notebook()

--- a/bokeh/application/handlers/tests/test_notebook.py
+++ b/bokeh/application/handlers/tests/test_notebook.py
@@ -55,6 +55,29 @@ class Test_NotebookHandler(object):
 
     # Public methods ----------------------------------------------------------
 
+    def test_runner_strips_line_magics(self):
+        doc = Document()
+        source = nbformat.v4.new_notebook()
+        source.cells.append(nbformat.v4.new_code_cell('%time'))
+        def load(filename):
+            handler = bahn.NotebookHandler(filename=filename)
+            handler.modify_document(doc)
+            assert handler._runner.failed == False
+
+        with_script_contents(source, load)
+
+    def test_runner_strips_cell_magics(self):
+        doc = Document()
+        source = nbformat.v4.new_notebook()
+        code = '%%timeit\n1+1'
+        source.cells.append(nbformat.v4.new_code_cell(code))
+        def load(filename):
+            handler = bahn.NotebookHandler(filename=filename)
+            handler.modify_document(doc)
+            assert handler._runner.failed == False
+
+        with_script_contents(source, load)
+
     def test_runner_uses_source_from_filename(self):
         doc = Document()
         source = nbformat.v4.new_notebook()


### PR DESCRIPTION
First cut at addressing #8513.

Using this tiny notebook called 'Test.ipynb':

![image](https://user-images.githubusercontent.com/890576/50702593-f824d880-1016-11e9-9b22-394be0b685c6.png)

On master, running `bokeh serve --show Test.ipynb` gives you:

![image](https://user-images.githubusercontent.com/890576/50702486-b300a680-1016-11e9-88d4-4f1881356a46.png)

With this PR:

![image](https://user-images.githubusercontent.com/890576/50702565-e3e0db80-1016-11e9-9581-3de677b50ac8.png)

Right now this is a first cut. Things to think about:

- [ ] Is this the best way to detect magics? Probably not as a line of valid Python could start with a  bare `%` e.g an expression in parentheses or an expression using `\` to break across lines. Checking for an alphanumeric identifier immediately after `%` doesn't really help as this is valid Python too:

   ```python
   foo = 2
   4 \
   %foo
   ```

  I suppose we could make an explicit blacklist of the most common magics to be safe?

- [ ] Should we warn when magics are detected? (probably)
- [ ] Avoid inlining the `StripMagicsProcessor` class (currently done to use bokeh's approach to importing `nbconvert` inline).
