### PR TITLE
use only yaml.safe_load

### DIFF
--- a/bokeh/_testing/util/examples.py
+++ b/bokeh/_testing/util/examples.py
@@ -263,7 +263,7 @@ def collect_examples(config_path):
     list_of_examples = []
 
     with open(config_path, "r") as f:
-        examples = yaml.load(f.read())
+        examples = yaml.safe_load(f.read())
 
     for example in examples:
         path = example["path"]

--- a/bokeh/themes/theme.py
+++ b/bokeh/themes/theme.py
@@ -128,7 +128,7 @@ class Theme(object):
         if filename is not None:
             f = open(filename)
             try:
-                json = yaml.load(f)
+                json = yaml.safe_load(f)
                 # empty docs result in None rather than {}, fix it.
                 if json is None:
                     json = {}

--- a/bokeh/util/sampledata.py
+++ b/bokeh/util/sampledata.py
@@ -106,7 +106,7 @@ def external_data_dir(create=False):
     data_dir = join(bokeh_dir, "data")
 
     try:
-        config = yaml.load(open(join(bokeh_dir, 'config')))
+        config = yaml.safe_load(open(join(bokeh_dir, 'config')))
         data_dir = expanduser(config['sampledata_dir'])
     except (IOError, TypeError):
         pass


### PR DESCRIPTION
- [x] issues: fixes #8541

Replaces all usage of `yaml.load` with `yaml.safe_load`

Checked codebase:

```
~/work/bokeh/bokeh bryanv/8541_yaml_safe_load
(base) ❯ grip yaml |grep load
  266 :         examples = yaml.safe_load(f.read())
  131 :                 json = yaml.safe_load(f)
  109 :         config = yaml.safe_load(open(join(bokeh_dir, 'config')))
```
If there was anything else like `from yaml import load` it would show up in the above output. 