### PR TITLE
Simple approach to replacing line and cell magics

### DIFF
--- a/bokeh/application/handlers/notebook.py
+++ b/bokeh/application/handlers/notebook.py
@@ -81,7 +81,10 @@ class NotebookHandler(CodeHandler):
             nb = nbformat.read(f, nbformat.NO_CONVERT)
             exporter = nbconvert.PythonExporter()
             source, _ = exporter.from_notebook_node(nb)
-            kwargs['source'] = source
+
+        source = source.replace('get_ipython().run_cell_magic', '')
+        source = source.replace('get_ipython().run_line_magic', '')
+        kwargs['source'] = source
 
         super(NotebookHandler, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION

This PR is a simpler and safer alternative to #8539 - it lets nbconvert try to convert the magics and *then* removes `run_cell_magic` and `run_line_magic` calls.

Current it doesn't issue warnings but warnings are now less important now that false positives are far more unlikely.