### PR TITLE
Safer alternative fix for unicode notebook issue in Python 2

### DIFF
--- a/bokeh/application/handlers/notebook.py
+++ b/bokeh/application/handlers/notebook.py
@@ -124,8 +124,9 @@ class NotebookHandler(CodeHandler):
             source, _ = exporter.from_notebook_node(nb)
             source = source.replace('get_ipython().run_line_magic', '')
             source = source.replace('get_ipython().magic', '')
-            if sys.version_info.major == 2:
-                source = source.replace('# coding: utf-8','')
+
+            if sys.version_info.major == 2 and isinstance(source, unicode): # NOQA
+                source = source.encode('utf-8')
             kwargs['source'] = source
 
         super(NotebookHandler, self).__init__(*args, **kwargs)

--- a/bokeh/application/handlers/tests/test_notebook.py
+++ b/bokeh/application/handlers/tests/test_notebook.py
@@ -96,9 +96,6 @@ class Test_NotebookHandler(object):
         else:
             expected_source = "#!/usr/bin/env python\n# coding: utf-8\n"
 
-        if sys.version_info.major == 2:
-            expected_source = expected_source.replace('# coding: utf-8','')
-
         assert result['handler']._runner.source == expected_source
         assert not doc.roots
 

--- a/bokeh/application/handlers/tests/test_notebook.py
+++ b/bokeh/application/handlers/tests/test_notebook.py
@@ -12,7 +12,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import pytest ; pytest
 
-import sys
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
@@ -23,7 +22,6 @@ import sys
 from packaging import version
 import nbformat
 import nbconvert
-
 
 # Bokeh imports
 from bokeh.document import Document


### PR DESCRIPTION

This PR is an alternative fix to the one implemented in #8555. Based on a suggestion from @philippjfr, it seems like it might be best to always encode to utf8 as nbconvert is templated to always use that encoding.