### PR TITLE
Ensure compilation of custom model works with bokehjs compiled on win

### DIFF
--- a/bokeh/util/compiler.py
+++ b/bokeh/util/compiler.py
@@ -296,7 +296,7 @@ def bundle_models(models):
 
     def read_json(name):
         with io.open(join(bokehjs_dir, "js", name + ".json"), encoding="utf-8") as f:
-            return json.loads(f.read())
+            return [mod.replace('\\','/') for mod in json.loads(f.read())]
 
     bundles = ["bokeh", "bokeh-api", "bokeh-widgets", "bokeh-tables", "bokeh-gl"]
     known_modules = set(sum([ read_json(name) for name in bundles ], []))

--- a/bokeh/util/compiler.py
+++ b/bokeh/util/compiler.py
@@ -296,7 +296,7 @@ def bundle_models(models):
 
     def read_json(name):
         with io.open(join(bokehjs_dir, "js", name + ".json"), encoding="utf-8") as f:
-            return [mod.replace('\\','/') for mod in json.loads(f.read())]
+            return json.loads(f.read())
 
     bundles = ["bokeh", "bokeh-api", "bokeh-widgets", "bokeh-tables", "bokeh-gl"]
     known_modules = set(sum([ read_json(name) for name in bundles ], []))

--- a/bokeh/util/tests/test_compiler.py
+++ b/bokeh/util/tests/test_compiler.py
@@ -17,6 +17,9 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import os
+import io
+import json
 from mock import patch
 
 # External imports
@@ -168,6 +171,12 @@ def test_FromFile(mock_open):
 
 def test_exts():
     assert buc.exts == (".coffee", ".ts", ".js", ".css", ".less")
+    
+def test_jsons():
+    for file in os.listdir(os.path.join(buc.bokehjs_dir, "js")):
+        if file.endswith('.json'):
+            with io.open(os.path.join(buc.bokehjs_dir, "js", file), encoding="utf-8") as f:
+                assert all(['\\' not in mod for mod in json.loads(f.read())])
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokehjs/make/linker.ts
+++ b/bokehjs/make/linker.ts
@@ -328,7 +328,7 @@ export class Module {
     for (const base of this.linker.bases) {
       const path = relative(base, this.file)
       if (!path.startsWith("..")) {
-        return path.replace(/\.js$/, "").replace(new RegExp(/\\/, 'g'), "/")
+        return path.replace(/\.js$/, "").replace(/\\/g, "/")
       }
     }
 

--- a/bokehjs/make/linker.ts
+++ b/bokehjs/make/linker.ts
@@ -328,7 +328,7 @@ export class Module {
     for (const base of this.linker.bases) {
       const path = relative(base, this.file)
       if (!path.startsWith("..")) {
-        return path.replace(/\.js$/, "")
+        return path.replace(/\.js$/, "").replace(new RegExp(/\\/, 'g'), "/")
       }
     }
 


### PR DESCRIPTION
If windows compile bokehjs => the path separator in bokeh.json is `\\` instead of `/`
Then when a custom module extension with lines like :
`import * as p from "core/properties"` 
is compiled it failed because available module in bokeh.json is `core\\properties`
