### PR TITLE
Possible typo in documentation for bokeh.client.session. 

### DIFF
--- a/bokeh/client/session.py
+++ b/bokeh/client/session.py
@@ -230,13 +230,13 @@ class ClientSession(object):
 
     .. code-block:: python
 
-        with pull_session(url=app_url) as session:
+        with pull_session(url=app_url) as mysession:
             # customize session here
             script = server_session(session_id=mysession.id, url=app_url)
             return render_template("embed.html", script=script, template="Flask")
 
     If you do not use ``ClientSession`` in this way, it is up to you to ensure
-    that ``session.close()`` is called.
+    that ``mysession.close()`` is called.
 
     '''
 


### PR DESCRIPTION
In [documentation for bokeh.client.session](https://bokeh.pydata.org/en/latest/docs/reference/client/session.html) under ClientSession object, mysession and session objects should maybe be the same?

```
with pull_session(url=app_url) as session:
    # customize session here
    script = server_session(session_id=mysession.id, url=app_url)
    return render_template("embed.html", script=script, template="Flask")
```
