### PR TITLE
pin conda versions with CONDA_REQS on appveyor too

### DIFF
--- a/scripts/ci/appveyor/install.ps1
+++ b/scripts/ci/appveyor/install.ps1
@@ -4,7 +4,7 @@ function install() {
     conda config --add channels bokeh
     conda config --add channels conda-forge
     conda config --get channels
-    conda update -q conda
+    conda install --yes --quiet $Env:CONDA_REQS
     conda install jinja2 pyyaml
     conda install $(python scripts/deps.py build).split() |  % {"""$_"""}
 }


### PR DESCRIPTION
Conda 4.6.1 is causing issues on Appveyor (https://github.com/appveyor/ci/issues/2822)