### PR TITLE
#8589 Fixes docstring typo in patch method of sources.py

### DIFF
--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -606,7 +606,7 @@ class ColumnDataSource(ColumnarDataSource):
 
         .. code-block:: python
 
-            dict(foo=[11, 22, 30], bar=[101, 200, 301])
+            dict(foo=[11, 12, 30], bar=[101, 200, 301])
 
         For a more comprehensive complete example, see :bokeh-tree:`examples/howto/patch_app.py`.
 


### PR DESCRIPTION
Fixed a docstring typo as raised in #8589 