### PR TITLE
Refactor tile_providers to handle multiple documents more intuitively…

### DIFF
--- a/bokeh/tests/test_tile_providers.py
+++ b/bokeh/tests/test_tile_providers.py
@@ -40,7 +40,7 @@ ALL = (
     'STAMEN_TONER_BACKGROUND',
     'STAMEN_TONER_LABELS',
     'get_provider',
-    'Provider'
+    'ThirdParty'
 )
 
 _CARTO_URLS = {
@@ -133,13 +133,21 @@ class Test_CartoProviders(object):
 class Test_GetProvider(object):
 
     def test_get_provider(self, name):
-        assert name in bt.Provider.__members__
-        enum_member = bt.Provider.__members__[name]
+        assert name in bt.ThirdParty
+        enum_member = getattr(bt.ThirdParty, name)
         p1 = bt.get_provider(enum_member)
         p2 = bt.get_provider(name)
         assert isinstance(p1, WMTSTileSource)
         assert isinstance(p2, WMTSTileSource)
         assert p1 is not p2
+
+        with pytest.deprecated_call():
+            # This will not return a WMTSTileSource in bokeh 2.0.0!
+            default_instance = getattr(bt, name)
+        new_instance = bt.get_provider(default_instance)
+        assert default_instance is not new_instance
+        assert default_instance.url == new_instance.url
+        assert default_instance.attribution == new_instance.attribution
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/tests/test_tile_providers.py
+++ b/bokeh/tests/test_tile_providers.py
@@ -40,7 +40,7 @@ ALL = (
     'STAMEN_TONER_BACKGROUND',
     'STAMEN_TONER_LABELS',
     'get_provider',
-    'ThirdParty'
+    'Vendors'
 )
 
 _CARTO_URLS = {
@@ -86,6 +86,8 @@ class Test_StamenProviders(object):
     def test_attribution(self, name):
         with pytest.deprecated_call():
             p = getattr(bt, name)
+
+        print(p.attribution)
         assert p.attribution == (
             'Map tiles by <a href="https://stamen.com">Stamen Design</a>, '
             'under <a href="https://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. '
@@ -126,15 +128,16 @@ class Test_CartoProviders(object):
             p2 = getattr(bt, name)
         assert p1 is not p2
 
-@pytest.mark.parametrize('name', ['CARTODBPOSITRON', 'CARTODBPOSITRON_RETINA', 'STAMEN_TERRAIN',
-                                  'STAMEN_TERRAIN_RETINA', 'STAMEN_TONER', 'STAMEN_TONER_BACKGROUND',
-                                  'STAMEN_TONER_LABELS',])
+
 @pytest.mark.unit
 class Test_GetProvider(object):
 
+    @pytest.mark.parametrize('name', ['CARTODBPOSITRON', 'CARTODBPOSITRON_RETINA', 'STAMEN_TERRAIN',
+                                      'STAMEN_TERRAIN_RETINA', 'STAMEN_TONER', 'STAMEN_TONER_BACKGROUND',
+                                      'STAMEN_TONER_LABELS', ])
     def test_get_provider(self, name):
-        assert name in bt.ThirdParty
-        enum_member = getattr(bt.ThirdParty, name)
+        assert name in bt.Vendors
+        enum_member = getattr(bt.Vendors, name)
         p1 = bt.get_provider(enum_member)
         p2 = bt.get_provider(name)
         p3 = bt.get_provider(name.lower())
@@ -154,6 +157,11 @@ class Test_GetProvider(object):
         assert default_instance is not new_instance
         assert default_instance.url == new_instance.url
         assert default_instance.attribution == new_instance.attribution
+
+    def test_unknown_vendor(self):
+        with pytest.raises(ValueError):
+            bt.get_provider("This is not a valid tile vendor")
+
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/tests/test_tile_providers.py
+++ b/bokeh/tests/test_tile_providers.py
@@ -137,9 +137,15 @@ class Test_GetProvider(object):
         enum_member = getattr(bt.ThirdParty, name)
         p1 = bt.get_provider(enum_member)
         p2 = bt.get_provider(name)
+        p3 = bt.get_provider(name.lower())
         assert isinstance(p1, WMTSTileSource)
         assert isinstance(p2, WMTSTileSource)
+        assert isinstance(p3, WMTSTileSource)
         assert p1 is not p2
+        assert p2 is not p3
+        assert p1 is not p3
+        assert p1.url == p2.url == p3.url
+        assert p1.attribution == p2.attribution == p3.attribution
 
         with pytest.deprecated_call():
             # This will not return a WMTSTileSource in bokeh 2.0.0!

--- a/bokeh/tests/test_tile_providers.py
+++ b/bokeh/tests/test_tile_providers.py
@@ -39,6 +39,8 @@ ALL = (
     'STAMEN_TONER',
     'STAMEN_TONER_BACKGROUND',
     'STAMEN_TONER_LABELS',
+    'get_provider',
+    'Provider'
 )
 
 _CARTO_URLS = {
@@ -72,15 +74,18 @@ Test___all__ = verify_all(bt, ALL)
 @pytest.mark.unit
 class Test_StamenProviders(object):
     def test_type(self, name):
-        p = getattr(bt, name)
+        with pytest.deprecated_call():
+            p = getattr(bt, name)
         assert isinstance(p, WMTSTileSource)
 
     def test_url(self, name):
-        p = getattr(bt, name)
+        with pytest.deprecated_call():
+            p = getattr(bt, name)
         assert p.url == _STAMEN_URLS[name]
 
     def test_attribution(self, name):
-        p = getattr(bt, name)
+        with pytest.deprecated_call():
+            p = getattr(bt, name)
         assert p.attribution == (
             'Map tiles by <a href="https://stamen.com">Stamen Design</a>, '
             'under <a href="https://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. '
@@ -89,31 +94,51 @@ class Test_StamenProviders(object):
         ) % _STAMEN_LIC[name]
 
     def test_copies(self, name):
-        p1 = getattr(bt, name)
-        p2 = getattr(bt, name)
+        with pytest.deprecated_call():
+            p1 = getattr(bt, name)
+            p2 = getattr(bt, name)
         assert p1 is not p2
 
 @pytest.mark.parametrize('name', ['CARTODBPOSITRON', 'CARTODBPOSITRON_RETINA'])
 @pytest.mark.unit
 class Test_CartoProviders(object):
     def test_type(self, name):
-        p = getattr(bt, name)
+        with pytest.deprecated_call():
+            p = getattr(bt, name)
         assert isinstance(p, WMTSTileSource)
 
     def test_url(self, name):
-        p = getattr(bt, name)
+        with pytest.deprecated_call():
+            p = getattr(bt, name)
         assert p.url == _CARTO_URLS[name]
 
     def test_attribution(self, name):
-        p = getattr(bt, name)
+        with pytest.deprecated_call():
+            p = getattr(bt, name)
         assert p.attribution == (
             '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors,'
             '&copy; <a href="https://cartodb.com/attributions">CartoDB</a>'
         )
 
     def test_copies(self, name):
-        p1 = getattr(bt, name)
-        p2 = getattr(bt, name)
+        with pytest.deprecated_call():
+            p1 = getattr(bt, name)
+            p2 = getattr(bt, name)
+        assert p1 is not p2
+
+@pytest.mark.parametrize('name', ['CARTODBPOSITRON', 'CARTODBPOSITRON_RETINA', 'STAMEN_TERRAIN',
+                                  'STAMEN_TERRAIN_RETINA', 'STAMEN_TONER', 'STAMEN_TONER_BACKGROUND',
+                                  'STAMEN_TONER_LABELS',])
+@pytest.mark.unit
+class Test_GetProvider(object):
+
+    def test_get_provider(self, name):
+        assert name in bt.Provider.__members__
+        enum_member = bt.Provider.__members__[name]
+        p1 = bt.get_provider(enum_member)
+        p2 = bt.get_provider(name)
+        assert isinstance(p1, WMTSTileSource)
+        assert isinstance(p2, WMTSTileSource)
         assert p1 is not p2
 
 #-----------------------------------------------------------------------------

--- a/bokeh/tile_providers.py
+++ b/bokeh/tile_providers.py
@@ -1,48 +1,50 @@
-# -----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
 # Copyright (c) 2012 - 2019, Anaconda, Inc., and Bokeh Contributors.
 # All rights reserved.
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
-# -----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
 ''' Pre-configured tile sources for common third party tile services.
 
 
 Attributes:
 
-    Provider
-        Enum listing all available tile services
+    ThirdParty
+        Enum listing all available preconfigured tiling services
 
     get_provider
-        Use this function to retrieve any tile provider.
+        Use this function to retrieve an instance of a predefined tile provider.
 
         Args:
-            provider_name (Union[str, Provider])
+            provider_name (Union[str, ThirdParty])
                 Name of the tile provider to supply.
-                Use tile_providers.Provider enum, or the name of a provider as string
+                Use tile_providers.ThirdParty enum, or the name of a provider as string
+                
 
         Returns:
             WMTSTileProviderSource: The desired tile provider instance
 
         Raises:
             ValueError, if the provider can not be found
+            ValueError, if the attribution for that provider can not be found
 
 
         Example:
 
-        .. code-block:: python
+            .. code-block:: python
 
-                >>> from bokeh.tile_providers import get_provider, Provider
-                >>> get_provider(Provider.CARTODBPOSITRON)
-                <class 'bokeh.models.tiles.WMTSTileSource'>
-                >>> get_provider('CARTODBPOSITRON')
-                <class 'bokeh.models.tiles.WMTSTileSource'>
+                    >>> from bokeh.tile_providers import get_provider, ThirdParty
+                    >>> get_provider(ThirdParty.CARTODBPOSITRON)
+                    <class 'bokeh.models.tiles.WMTSTileSource'>
+                    >>> get_provider('CARTODBPOSITRON')
+                    <class 'bokeh.models.tiles.WMTSTileSource'>
 
 
     CARTODBPOSITRON
         Tile Source for CartoDB Tile Service
 
         Warns:
-            BokehDeprecationWarning: Deprecated in bokeh 2.0.0. Use get_provider instead
+            BokehDeprecationWarning: Deprecated in bokeh 1.1.0. Use get_provider instead
 
         .. raw:: html
 
@@ -52,7 +54,7 @@ Attributes:
         Tile Source for CartoDB Tile Service (tiles at 'retina' resolution)
 
         Warns:
-            BokehDeprecationWarning: Deprecated in bokeh 2.0.0. Use get_provider instead
+            BokehDeprecationWarning: Deprecated in bokeh 1.1.0. Use get_provider instead
 
         .. raw:: html
 
@@ -62,7 +64,7 @@ Attributes:
         Tile Source for Stamen Terrain Service
 
         Warns:
-            BokehDeprecationWarning: Deprecated in bokeh 2.0.0. Use get_provider instead
+            BokehDeprecationWarning: Deprecated in bokeh 1.1.0. Use get_provider instead
 
         .. raw:: html
 
@@ -72,7 +74,7 @@ Attributes:
         Tile Source for Stamen Terrain Service
 
         Warns:
-            BokehDeprecationWarning: Deprecated in bokeh 2.0.0. Use get_provider instead
+            BokehDeprecationWarning: Deprecated in bokeh 1.1.0. Use get_provider instead
 
         .. raw:: html
 
@@ -82,7 +84,7 @@ Attributes:
         Tile Source for Stamen Toner Service
 
         Warns:
-            BokehDeprecationWarning: Deprecated in bokeh 2.0.0. Use get_provider instead
+            BokehDeprecationWarning: Deprecated in bokeh 1.1.0. Use get_provider instead
 
         .. raw:: html
 
@@ -92,7 +94,7 @@ Attributes:
         Tile Source for Stamen Toner Background Service which does not include labels
 
         Warns:
-            BokehDeprecationWarning: Deprecated in bokeh 2.0.0. Use get_provider instead
+            BokehDeprecationWarning: Deprecated in bokeh 1.1.0. Use get_provider instead
 
         .. raw:: html
 
@@ -102,7 +104,7 @@ Attributes:
         Tile Source for Stamen Toner Service which includes only labels
 
         Warns:
-            BokehDeprecationWarning: Deprecated in bokeh 2.0.0. Use get_provider instead
+            BokehDeprecationWarning: Deprecated in bokeh 1.1.0. Use get_provider instead
 
         .. raw:: html
 
@@ -115,46 +117,46 @@ Additional information available at:
 
 '''
 
-# -----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
 # Boilerplate
-# -----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
 
 log = logging.getLogger(__name__)
 
-# -----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
 # Imports
-# -----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
 
 # Standard library imports
 import sys
 import types
-from enum import Enum
 
 # External imports
 
 # Bokeh imports
+from bokeh.core.enums import enumeration
 
 
-# -----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
 # Globals and constants
-# -----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
 
 # __all__ defined at the bottom on the class module
 
-# -----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
 # General API
-# -----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
 
-# -----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
 # Dev API
-# -----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
 
-# -----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
 # Private API
-# -----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
 
 class _TileProvidersModule(types.ModuleType):
     _CARTO_ATTRIBUTION = (
@@ -169,45 +171,48 @@ class _TileProvidersModule(types.ModuleType):
         'under %s.'
     )
 
-    class Provider(Enum):
-        CARTODBPOSITRON = 'https://tiles.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png'
-        CARTODBPOSITRON_RETINA = 'https://tiles.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png'
-        STAMEN_TERRAIN = 'http://tile.stamen.com/terrain/{Z}/{X}/{Y}.png'
-        STAMEN_TERRAIN_RETINA = 'http://tile.stamen.com/terrain/{Z}/{X}/{Y}@2x.png'
-        STAMEN_TONER = 'http://tile.stamen.com/toner/{Z}/{X}/{Y}.png'
-        STAMEN_TONER_BACKGROUND = 'http://tile.stamen.com/toner-background/{Z}/{X}/{Y}.png'
-        STAMEN_TONER_LABELS = 'http://tile.stamen.com/toner-labels/{Z}/{X}/{Y}.png'
+    _SERVICE_URLS = dict(
+        CARTODBPOSITRON='https://tiles.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
+        CARTODBPOSITRON_RETINA='https://tiles.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png',
+        STAMEN_TERRAIN='http://tile.stamen.com/terrain/{Z}/{X}/{Y}.png',
+        STAMEN_TERRAIN_RETINA='http://tile.stamen.com/terrain/{Z}/{X}/{Y}@2x.png',
+        STAMEN_TONER='http://tile.stamen.com/toner/{Z}/{X}/{Y}.png',
+        STAMEN_TONER_BACKGROUND='http://tile.stamen.com/toner-background/{Z}/{X}/{Y}.png',
+        STAMEN_TONER_LABELS='http://tile.stamen.com/toner-labels/{Z}/{X}/{Y}.png',
+    )
 
-    def get_provider(self, provider_name):
-        if not isinstance(provider_name, _TileProvidersModule.Provider):
-            try:
-                provider_name = _TileProvidersModule.Provider.__members__[provider_name.upper()]
-            except KeyError as e:
-                raise ValueError('Unknown tile provider {0}'.format(provider_name)) from e
-        provider = self._make_tile_provider(selected_provider=provider_name)
-        return provider
-
+    ThirdParty = enumeration('CARTODBPOSITRON', 'CARTODBPOSITRON_RETINA',
+                             'STAMEN_TERRAIN', 'STAMEN_TERRAIN_RETINA', 'STAMEN_TONER',
+                             'STAMEN_TONER_BACKGROUND', 'STAMEN_TONER_LABELS',
+                             case_sensitive=True)
+    
     @staticmethod
-    def _make_tile_provider(selected_provider):
-        url = selected_provider.value
-        if selected_provider.name.startswith('CARTO'):
+    def get_provider(provider_name):
+        from bokeh.models.tiles import WMTSTileSource
+
+        if isinstance(provider_name, WMTSTileSource):
+            # This allows `get_provider(CARTODBPOSITRON)` to work
+            return WMTSTileSource(url=provider_name.url, attribution=provider_name.attribution)
+
+        if provider_name not in _TileProvidersModule.ThirdParty:
+            raise ValueError('Unknown tile provider {0}'.format(provider_name))
+
+        selected_provider = provider_name.upper()
+        url = _TileProvidersModule._SERVICE_URLS[selected_provider]
+        if selected_provider.startswith('CARTO'):
             attribution = _TileProvidersModule._CARTO_ATTRIBUTION
-        elif selected_provider.name.startswith('STAMEN'):
+        elif selected_provider.startswith('STAMEN'):
             attribution = _TileProvidersModule._STAMEN_ATTRIBUTION
         else:
             raise ValueError('Can not retrieve attribution for {0}'.format(selected_provider))
-        from bokeh.models.tiles import WMTSTileSource
-        return WMTSTileSource(
-            url=url,
-            attribution=attribution
-        )
+        return WMTSTileSource(url=url, attribution=attribution)
 
     # Properties --------------------------------------------------------------
 
     @property
     def CARTODBPOSITRON(self):
         from bokeh.util.deprecation import deprecated
-        deprecated(since_or_msg=(2, 0, 0), old='CARTODBPOSITRON', new='get_provider(Provider.CARTODBPOSITRON)')
+        deprecated(since_or_msg=(1, 1, 0), old='CARTODBPOSITRON', new='get_provider(ThirdParty.CARTODBPOSITRON)')
         from bokeh.models.tiles import WMTSTileSource
         return WMTSTileSource(
             url='https://tiles.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
@@ -217,7 +222,8 @@ class _TileProvidersModule(types.ModuleType):
     @property
     def CARTODBPOSITRON_RETINA(self):
         from bokeh.util.deprecation import deprecated
-        deprecated(since_or_msg=(2, 0, 0), old='CARTODBPOSITRON_RETINA', new='get_provider(Provider.CARTODBPOSITRON_RETINA)')
+        deprecated(since_or_msg=(1, 1, 0), old='CARTODBPOSITRON_RETINA',
+                   new='get_provider(ThirdParty.CARTODBPOSITRON_RETINA)')
         from bokeh.models.tiles import WMTSTileSource
         return WMTSTileSource(
             url='https://tiles.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png',
@@ -227,7 +233,7 @@ class _TileProvidersModule(types.ModuleType):
     @property
     def STAMEN_TERRAIN(self):
         from bokeh.util.deprecation import deprecated
-        deprecated(since_or_msg=(2, 0, 0), old='STAMEN_TERRAIN', new='get_provider(Provider.STAMEN_TERRAIN)')
+        deprecated(since_or_msg=(1, 1, 0), old='STAMEN_TERRAIN', new='get_provider(ThirdParty.STAMEN_TERRAIN)')
         from bokeh.models.tiles import WMTSTileSource
         return WMTSTileSource(
             url='http://tile.stamen.com/terrain/{Z}/{X}/{Y}.png',
@@ -237,7 +243,8 @@ class _TileProvidersModule(types.ModuleType):
     @property
     def STAMEN_TERRAIN_RETINA(self):
         from bokeh.util.deprecation import deprecated
-        deprecated(since_or_msg=(2, 0, 0), old='STAMEN_TERRAIN_RETINA', new='get_provider(provider.STAMEN_TERRAIN_RETINA)')
+        deprecated(since_or_msg=(1, 1, 0), old='STAMEN_TERRAIN_RETINA',
+                   new='get_provider(provider.STAMEN_TERRAIN_RETINA)')
         from bokeh.models.tiles import WMTSTileSource
         return WMTSTileSource(
             url='http://tile.stamen.com/terrain/{Z}/{X}/{Y}@2x.png',
@@ -247,7 +254,7 @@ class _TileProvidersModule(types.ModuleType):
     @property
     def STAMEN_TONER(self):
         from bokeh.util.deprecation import deprecated
-        deprecated(since_or_msg=(2, 0, 0), old='STAMEN_TONER', new='get_provider(Provider.STAMEN_TONER)')
+        deprecated(since_or_msg=(1, 1, 0), old='STAMEN_TONER', new='get_provider(ThirdParty.STAMEN_TONER)')
         from bokeh.models.tiles import WMTSTileSource
         return WMTSTileSource(
             url='http://tile.stamen.com/toner/{Z}/{X}/{Y}.png',
@@ -257,7 +264,8 @@ class _TileProvidersModule(types.ModuleType):
     @property
     def STAMEN_TONER_BACKGROUND(self):
         from bokeh.util.deprecation import deprecated
-        deprecated(since_or_msg=(2, 0, 0), old='STAMEN_TONER_BACKGROUND', new='get_provider(Provider.STAMEN_TONER_BACKGROUND)')
+        deprecated(since_or_msg=(1, 1, 0), old='STAMEN_TONER_BACKGROUND',
+                   new='get_provider(ThirdParty.STAMEN_TONER_BACKGROUND)')
         from bokeh.models.tiles import WMTSTileSource
         return WMTSTileSource(
             url='http://tile.stamen.com/toner-background/{Z}/{X}/{Y}.png',
@@ -267,7 +275,7 @@ class _TileProvidersModule(types.ModuleType):
     @property
     def STAMEN_TONER_LABELS(self):
         from bokeh.util.deprecation import deprecated
-        deprecated(since_or_msg=(2, 0, 0), old='STAMEN_TONER_LABELS', new='get_provider(Provider.STAMEN_TONER_LABELS)')
+        deprecated(since_or_msg=(1, 1, 0), old='STAMEN_TONER_LABELS', new='get_provider(ThirdParty.STAMEN_TONER_LABELS)')
         from bokeh.models.tiles import WMTSTileSource
         return WMTSTileSource(
             url='http://tile.stamen.com/toner-labels/{Z}/{X}/{Y}.png',
@@ -275,9 +283,9 @@ class _TileProvidersModule(types.ModuleType):
         )
 
 
-# -----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
 # Code
-# -----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
 
 _mod = _TileProvidersModule(str('bokeh.tile_providers'))
 _mod.__doc__ = __doc__
@@ -290,7 +298,7 @@ _mod.__all__ = (
     'STAMEN_TONER_BACKGROUND',
     'STAMEN_TONER_LABELS',
     'get_provider',
-    'Provider'
+    'ThirdParty'
 )
 sys.modules['bokeh.tile_providers'] = _mod
 del _mod, sys, types

--- a/bokeh/tile_providers.py
+++ b/bokeh/tile_providers.py
@@ -19,7 +19,6 @@ Attributes:
             provider_name (Union[str, Vendors])
                 Name of the tile provider to supply.
                 Use tile_providers.Vendors enum, or the name of a provider as string
-                
 
         Returns:
             WMTSTileProviderSource: The desired tile provider instance
@@ -204,7 +203,7 @@ class _TileProvidersModule(types.ModuleType):
                           'STAMEN_TERRAIN', 'STAMEN_TERRAIN_RETINA', 'STAMEN_TONER',
                           'STAMEN_TONER_BACKGROUND', 'STAMEN_TONER_LABELS',
                           case_sensitive=True)
-    
+
     def get_provider(self, provider_name):
         from bokeh.models.tiles import WMTSTileSource
 

--- a/bokeh/tile_providers.py
+++ b/bokeh/tile_providers.py
@@ -1,16 +1,48 @@
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Copyright (c) 2012 - 2019, Anaconda, Inc., and Bokeh Contributors.
 # All rights reserved.
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 ''' Pre-configured tile sources for common third party tile services.
 
 
 Attributes:
 
+    Provider
+        Enum listing all available tile services
+
+    get_provider
+        Use this function to retrieve any tile provider.
+
+        Args:
+            provider_name (Union[str, Provider])
+                Name of the tile provider to supply.
+                Use tile_providers.Provider enum, or the name of a provider as string
+
+        Returns:
+            WMTSTileProviderSource: The desired tile provider instance
+
+        Raises:
+            ValueError, if the provider can not be found
+
+
+        Example:
+
+        .. code-block:: python
+
+                >>> from bokeh.tile_providers import get_provider, Provider
+                >>> get_provider(Provider.CARTODBPOSITRON)
+                <class 'bokeh.models.tiles.WMTSTileSource'>
+                >>> get_provider('CARTODBPOSITRON')
+                <class 'bokeh.models.tiles.WMTSTileSource'>
+
+
     CARTODBPOSITRON
         Tile Source for CartoDB Tile Service
+
+        Warns:
+            BokehDeprecationWarning: Deprecated in bokeh 2.0.0. Use get_provider instead
 
         .. raw:: html
 
@@ -19,12 +51,18 @@ Attributes:
     CARTODBPOSITRON_RETINA
         Tile Source for CartoDB Tile Service (tiles at 'retina' resolution)
 
+        Warns:
+            BokehDeprecationWarning: Deprecated in bokeh 2.0.0. Use get_provider instead
+
         .. raw:: html
 
             <img src="https://tiles.basemaps.cartocdn.com/light_all/14/2627/6331@2x.png" />
 
     STAMEN_TERRAIN
         Tile Source for Stamen Terrain Service
+
+        Warns:
+            BokehDeprecationWarning: Deprecated in bokeh 2.0.0. Use get_provider instead
 
         .. raw:: html
 
@@ -33,12 +71,18 @@ Attributes:
     STAMEN_TERRAIN_RETINA
         Tile Source for Stamen Terrain Service
 
+        Warns:
+            BokehDeprecationWarning: Deprecated in bokeh 2.0.0. Use get_provider instead
+
         .. raw:: html
 
             <img src="http://c.tile.stamen.com/terrain/14/2627/6331@2x.png" />
 
     STAMEN_TONER
         Tile Source for Stamen Toner Service
+
+        Warns:
+            BokehDeprecationWarning: Deprecated in bokeh 2.0.0. Use get_provider instead
 
         .. raw:: html
 
@@ -47,12 +91,18 @@ Attributes:
     STAMEN_TONER_BACKGROUND
         Tile Source for Stamen Toner Background Service which does not include labels
 
+        Warns:
+            BokehDeprecationWarning: Deprecated in bokeh 2.0.0. Use get_provider instead
+
         .. raw:: html
 
             <img src="http://c.tile.stamen.com/toner-background/14/2627/6331.png" />
 
     STAMEN_TONER_LABELS
         Tile Source for Stamen Toner Service which includes only labels
+
+        Warns:
+            BokehDeprecationWarning: Deprecated in bokeh 2.0.0. Use get_provider instead
 
         .. raw:: html
 
@@ -65,46 +115,48 @@ Additional information available at:
 
 '''
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Boilerplate
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
+
 log = logging.getLogger(__name__)
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Imports
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 # Standard library imports
 import sys
 import types
+from enum import Enum
 
 # External imports
 
 # Bokeh imports
 
-#-----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
 # Globals and constants
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 # __all__ defined at the bottom on the class module
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # General API
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Dev API
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Private API
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 class _TileProvidersModule(types.ModuleType):
-
     _CARTO_ATTRIBUTION = (
         '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors,'
         '&copy; <a href="https://cartodb.com/attributions">CartoDB</a>'
@@ -117,10 +169,45 @@ class _TileProvidersModule(types.ModuleType):
         'under %s.'
     )
 
+    class Provider(Enum):
+        CARTODBPOSITRON = 'https://tiles.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png'
+        CARTODBPOSITRON_RETINA = 'https://tiles.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png'
+        STAMEN_TERRAIN = 'http://tile.stamen.com/terrain/{Z}/{X}/{Y}.png'
+        STAMEN_TERRAIN_RETINA = 'http://tile.stamen.com/terrain/{Z}/{X}/{Y}@2x.png'
+        STAMEN_TONER = 'http://tile.stamen.com/toner/{Z}/{X}/{Y}.png'
+        STAMEN_TONER_BACKGROUND = 'http://tile.stamen.com/toner-background/{Z}/{X}/{Y}.png'
+        STAMEN_TONER_LABELS = 'http://tile.stamen.com/toner-labels/{Z}/{X}/{Y}.png'
+
+    def get_provider(self, provider_name):
+        if not isinstance(provider_name, _TileProvidersModule.Provider):
+            try:
+                provider_name = _TileProvidersModule.Provider.__members__[provider_name.upper()]
+            except KeyError as e:
+                raise ValueError('Unknown tile provider {0}'.format(provider_name)) from e
+        provider = self._make_tile_provider(selected_provider=provider_name)
+        return provider
+
+    @staticmethod
+    def _make_tile_provider(selected_provider):
+        url = selected_provider.value
+        if selected_provider.name.startswith('CARTO'):
+            attribution = _TileProvidersModule._CARTO_ATTRIBUTION
+        elif selected_provider.name.startswith('STAMEN'):
+            attribution = _TileProvidersModule._STAMEN_ATTRIBUTION
+        else:
+            raise ValueError('Can not retrieve attribution for {0}'.format(selected_provider))
+        from bokeh.models.tiles import WMTSTileSource
+        return WMTSTileSource(
+            url=url,
+            attribution=attribution
+        )
+
     # Properties --------------------------------------------------------------
 
     @property
     def CARTODBPOSITRON(self):
+        from bokeh.util.deprecation import deprecated
+        deprecated(since_or_msg=(2, 0, 0), old='CARTODBPOSITRON', new='get_provider(Provider.CARTODBPOSITRON)')
         from bokeh.models.tiles import WMTSTileSource
         return WMTSTileSource(
             url='https://tiles.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
@@ -129,6 +216,8 @@ class _TileProvidersModule(types.ModuleType):
 
     @property
     def CARTODBPOSITRON_RETINA(self):
+        from bokeh.util.deprecation import deprecated
+        deprecated(since_or_msg=(2, 0, 0), old='CARTODBPOSITRON_RETINA', new='get_provider(Provider.CARTODBPOSITRON_RETINA)')
         from bokeh.models.tiles import WMTSTileSource
         return WMTSTileSource(
             url='https://tiles.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png',
@@ -137,6 +226,8 @@ class _TileProvidersModule(types.ModuleType):
 
     @property
     def STAMEN_TERRAIN(self):
+        from bokeh.util.deprecation import deprecated
+        deprecated(since_or_msg=(2, 0, 0), old='STAMEN_TERRAIN', new='get_provider(Provider.STAMEN_TERRAIN)')
         from bokeh.models.tiles import WMTSTileSource
         return WMTSTileSource(
             url='http://tile.stamen.com/terrain/{Z}/{X}/{Y}.png',
@@ -145,6 +236,8 @@ class _TileProvidersModule(types.ModuleType):
 
     @property
     def STAMEN_TERRAIN_RETINA(self):
+        from bokeh.util.deprecation import deprecated
+        deprecated(since_or_msg=(2, 0, 0), old='STAMEN_TERRAIN_RETINA', new='get_provider(provider.STAMEN_TERRAIN_RETINA)')
         from bokeh.models.tiles import WMTSTileSource
         return WMTSTileSource(
             url='http://tile.stamen.com/terrain/{Z}/{X}/{Y}@2x.png',
@@ -153,6 +246,8 @@ class _TileProvidersModule(types.ModuleType):
 
     @property
     def STAMEN_TONER(self):
+        from bokeh.util.deprecation import deprecated
+        deprecated(since_or_msg=(2, 0, 0), old='STAMEN_TONER', new='get_provider(Provider.STAMEN_TONER)')
         from bokeh.models.tiles import WMTSTileSource
         return WMTSTileSource(
             url='http://tile.stamen.com/toner/{Z}/{X}/{Y}.png',
@@ -161,6 +256,8 @@ class _TileProvidersModule(types.ModuleType):
 
     @property
     def STAMEN_TONER_BACKGROUND(self):
+        from bokeh.util.deprecation import deprecated
+        deprecated(since_or_msg=(2, 0, 0), old='STAMEN_TONER_BACKGROUND', new='get_provider(Provider.STAMEN_TONER_BACKGROUND)')
         from bokeh.models.tiles import WMTSTileSource
         return WMTSTileSource(
             url='http://tile.stamen.com/toner-background/{Z}/{X}/{Y}.png',
@@ -169,15 +266,18 @@ class _TileProvidersModule(types.ModuleType):
 
     @property
     def STAMEN_TONER_LABELS(self):
+        from bokeh.util.deprecation import deprecated
+        deprecated(since_or_msg=(2, 0, 0), old='STAMEN_TONER_LABELS', new='get_provider(Provider.STAMEN_TONER_LABELS)')
         from bokeh.models.tiles import WMTSTileSource
         return WMTSTileSource(
             url='http://tile.stamen.com/toner-labels/{Z}/{X}/{Y}.png',
             attribution=self._STAMEN_ATTRIBUTION % '<a href="https://www.openstreetmap.org/copyright">ODbL</a>'
         )
 
-#-----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
 # Code
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 _mod = _TileProvidersModule(str('bokeh.tile_providers'))
 _mod.__doc__ = __doc__
@@ -189,6 +289,8 @@ _mod.__all__ = (
     'STAMEN_TONER',
     'STAMEN_TONER_BACKGROUND',
     'STAMEN_TONER_LABELS',
+    'get_provider',
+    'Provider'
 )
 sys.modules['bokeh.tile_providers'] = _mod
 del _mod, sys, types

--- a/bokeh/tile_providers.py
+++ b/bokeh/tile_providers.py
@@ -194,10 +194,11 @@ class _TileProvidersModule(types.ModuleType):
             # This allows `get_provider(CARTODBPOSITRON)` to work
             return WMTSTileSource(url=provider_name.url, attribution=provider_name.attribution)
 
-        if provider_name not in _TileProvidersModule.ThirdParty:
+        selected_provider = provider_name.upper()
+
+        if selected_provider not in _TileProvidersModule.ThirdParty:
             raise ValueError('Unknown tile provider {0}'.format(provider_name))
 
-        selected_provider = provider_name.upper()
         url = _TileProvidersModule._SERVICE_URLS[selected_provider]
         if selected_provider.startswith('CARTO'):
             attribution = _TileProvidersModule._CARTO_ATTRIBUTION

--- a/examples/integration/tiles/tile_smoothing.py
+++ b/examples/integration/tiles/tile_smoothing.py
@@ -1,6 +1,6 @@
 from bokeh.layouts import column
 from bokeh.plotting import figure, show, output_file
-from bokeh.tile_providers import CARTODBPOSITRON
+from bokeh.tile_providers import get_provider, Provider
 
 output_file("tile_smoothing.html")
 
@@ -14,9 +14,10 @@ p2.x_range = p1.x_range
 p2.y_range = p1.y_range
 
 # Add smoothed tiles (the default)
-r1 = p1.add_tile(CARTODBPOSITRON)
+tile_provider = get_provider(Provider.CARTODBPOSITRON)
+r1 = p1.add_tile(tile_provider)
 
 # Add non-smoothed tile
-r2 = p2.add_tile(CARTODBPOSITRON, smoothing=False)
+r2 = p2.add_tile(tile_provider, smoothing=False)
 
 show(column(p1, p2))

--- a/examples/integration/tiles/tile_smoothing.py
+++ b/examples/integration/tiles/tile_smoothing.py
@@ -1,6 +1,6 @@
 from bokeh.layouts import column
 from bokeh.plotting import figure, show, output_file
-from bokeh.tile_providers import get_provider, Provider
+from bokeh.tile_providers import get_provider, ThirdParty
 
 output_file("tile_smoothing.html")
 
@@ -14,7 +14,7 @@ p2.x_range = p1.x_range
 p2.y_range = p1.y_range
 
 # Add smoothed tiles (the default)
-tile_provider = get_provider(Provider.CARTODBPOSITRON)
+tile_provider = get_provider(ThirdParty.CARTODBPOSITRON)
 r1 = p1.add_tile(tile_provider)
 
 # Add non-smoothed tile

--- a/examples/integration/tiles/tile_smoothing.py
+++ b/examples/integration/tiles/tile_smoothing.py
@@ -1,6 +1,6 @@
 from bokeh.layouts import column
 from bokeh.plotting import figure, show, output_file
-from bokeh.tile_providers import get_provider, ThirdParty
+from bokeh.tile_providers import get_provider, Vendors
 
 output_file("tile_smoothing.html")
 
@@ -14,7 +14,7 @@ p2.x_range = p1.x_range
 p2.y_range = p1.y_range
 
 # Add smoothed tiles (the default)
-tile_provider = get_provider(ThirdParty.CARTODBPOSITRON)
+tile_provider = get_provider(Vendors.CARTODBPOSITRON)
 r1 = p1.add_tile(tile_provider)
 
 # Add non-smoothed tile

--- a/examples/plotting/file/tile_source.py
+++ b/examples/plotting/file/tile_source.py
@@ -1,11 +1,11 @@
 from bokeh.plotting import figure, show, output_file
-from bokeh.tile_providers import get_provider, ThirdParty
+from bokeh.tile_providers import get_provider, Vendors
 
 output_file("tile_source.html")
 
 # create plot and add tools
 p = figure(x_range=(-2000000, 2000000), y_range=(1000000, 7000000),
            x_axis_type="mercator", y_axis_type="mercator")
-p.add_tile(get_provider(ThirdParty.CARTODBPOSITRON))
+p.add_tile(get_provider(Vendors.CARTODBPOSITRON))
 
 show(p)

--- a/examples/plotting/file/tile_source.py
+++ b/examples/plotting/file/tile_source.py
@@ -1,11 +1,11 @@
 from bokeh.plotting import figure, show, output_file
-from bokeh.tile_providers import get_provider, Provider
+from bokeh.tile_providers import get_provider, ThirdParty
 
 output_file("tile_source.html")
 
 # create plot and add tools
 p = figure(x_range=(-2000000, 2000000), y_range=(1000000, 7000000),
            x_axis_type="mercator", y_axis_type="mercator")
-p.add_tile(get_provider(Provider.CARTODBPOSITRON))
+p.add_tile(get_provider(ThirdParty.CARTODBPOSITRON))
 
 show(p)

--- a/examples/plotting/file/tile_source.py
+++ b/examples/plotting/file/tile_source.py
@@ -1,11 +1,11 @@
 from bokeh.plotting import figure, show, output_file
-from bokeh.tile_providers import CARTODBPOSITRON
+from bokeh.tile_providers import get_provider, Provider
 
 output_file("tile_source.html")
 
 # create plot and add tools
 p = figure(x_range=(-2000000, 2000000), y_range=(1000000, 7000000),
            x_axis_type="mercator", y_axis_type="mercator")
-p.add_tile(CARTODBPOSITRON)
+p.add_tile(get_provider(Provider.CARTODBPOSITRON))
 
 show(p)


### PR DESCRIPTION
Deprecate functionality to retrieve tile providers as already instanciated objectes,
which was confusing for multiple document use-cases.
Instead, add a new function `get_provider` that returns a provider and is thus more clear.


 -   Implement get_provider. It accepts the provider name as a string (case does not matter), or an
    element of a new enum Provider. This function creates the tile provider accordingly and returns the new instance of it. 
 -   Issue deprecations in the existing properties for the providers
 -  Update the test cases to assert the deprecation warning, and add a new testcase that tests `get_provider`. (The functionality of the other test cases is not duplicated, so that has to be done when the real deprecation happens).
 -   Update the docstring of tile_providers
 -   Update all examples (that I could find).

Example snippets:

```python
from bokeh.tile_providers import CARTODBPOSITRON

# Works, but raises BokehDeprecationWarning:
# "BokehDeprecationWarning: CARTODBPOSITRON was deprecated in Bokeh 2.0.0 and will be removed, use get_provider(Provider.CARTODBPOSITRON) instead."

from bokeh.tile_providers import get_provider, Provider

# Use the new enum for tile types
p1 = get_provider(Provider.CARTODBPOSITRON)

# Also works with string names (upper and lower case)
p2 = get_provider("CARTODBPOSITRON")

# Also works by passing in the "old" provider. Not sure about this feature
p3 = get_provider(CARTODBPOSITRON)
```

There are a few things which I am not sure about:

-    Whether I used the right deprecation protocol (I used bokeh.util.deprecation.deprecated)
-    Whether I found all examples
-    Whether the docstring is what you expect/the right format. I am not sure how to document the enum values
-    Whether I found all examples

Please let me know if anything is not what you expected/should be changed!

- [x] issues: fixes #8566 
- [x] tests added / passed: Yes
- [ ] release document entry (if new feature or API change): Not sure where to add
