### PR TITLE
Invalidate TileSource cache on property changes

### DIFF
--- a/bokehjs/src/lib/models/tiles/tile_renderer.ts
+++ b/bokehjs/src/lib/models/tiles/tile_renderer.ts
@@ -52,6 +52,7 @@ export class TileRendererView extends RendererView {
   connect_signals(): void {
     super.connect_signals()
     this.connect(this.model.change, () => this.request_render())
+    this.connect(this.model.tile_source.change, () => this.request_render())
   }
 
   get_extent(): Extent {

--- a/bokehjs/src/lib/models/tiles/tile_source.ts
+++ b/bokehjs/src/lib/models/tiles/tile_source.ts
@@ -20,7 +20,17 @@ export namespace TileSource {
     initial_resolution: number
   }
 
-  export interface Props extends Model.Props {}
+  export interface Props extends Model.Props {
+    url: p.Property<string>
+    tile_size: p.Property<number>
+    max_zoom: p.Property<number>
+    min_zoom: p.Property<number>
+    extra_url_vars: p.Property<{[key: string]: string}>
+    attribution: p.Property<string>
+    x_origin_offset: p.Property<number>
+    y_origin_offset: p.Property<number>
+    initial_resolution: p.Property<number>
+  }
 }
 
 export interface TileSource extends TileSource.Attrs {}
@@ -60,6 +70,11 @@ export abstract class TileSource extends Model {
     this._normalize_case()
   }
 
+  connect_signals(): void {
+    super.connect_signals()
+    this.connect(this.change, () => this._clear_cache())
+  }
+
   string_lookup_replace(str: string, lookup: {[key: string]: string}): string {
     let result_str = str
     for (const key in lookup) {
@@ -83,6 +98,10 @@ export abstract class TileSource extends Model {
       .replace('{xmax}','{XMAX}')
       .replace('{ymax}','{YMAX}')
     this.url = url
+  }
+
+  protected _clear_cache(): void {
+    this.tiles = {}
   }
 
   tile_xyz_to_key(x: number, y: number, z: number): string {

--- a/bokehjs/test/models/tiles/tile_renderer.coffee
+++ b/bokehjs/test/models/tiles/tile_renderer.coffee
@@ -131,6 +131,15 @@ describe "tile sources", ->
         expect(t[0]).to.be.within(3, 4)
         expect(t[1]).to.be.within(3, 4)
 
+    it "should invalidate cache on property change", ->
+      tile_options =
+        url : 'http://mock/{x}/{y}/{z}.png'
+      tile_source = new TileSource(tile_options)
+      tile = {tile_coords: [0, 1, 2]}
+      tile_source.tiles['mock_key'] = tile
+      tile_source.url = 'http://mock/{x}/{y}/{z}.png'
+      expect(tile_source.tiles).to.be.empty
+
   describe "tms tile source", ->
     url = 'http://c.tiles.mapbox.com/v3/examples.map-szwdot65/{Z}/{X}/{Y}.png'
     source = new TMSTileSource({url: url})


### PR DESCRIPTION
Upgrades ``TileSource`` attributes to properties and add events to clear cache and rerender when a property changes. Let me know if my assumption that attributes need to be properties to trigger model change events is wrong.

![geoviews_tilesources_small](https://user-images.githubusercontent.com/1550771/51953927-2fc84a00-2436-11e9-81fe-57596653c509.gif)

- [x] issues: fixes #8164
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
