### PR TITLE
Fix CDS callback property callbacks

### DIFF
--- a/bokehjs/src/lib/models/sources/data_source.ts
+++ b/bokehjs/src/lib/models/sources/data_source.ts
@@ -36,7 +36,7 @@ export abstract class DataSource extends Model {
 
   connect_signals(): void {
     super.connect_signals()
-    this.connect(this.properties.selected.change, () => {
+    this.connect(this.selected.change, () => {
       const {callback} = this
       if (callback != null) {
         if (isFunction(callback))

--- a/sphinx/source/docs/user_guide/examples/interaction_callbacks_for_selections_lasso_mean.py
+++ b/sphinx/source/docs/user_guide/examples/interaction_callbacks_for_selections_lasso_mean.py
@@ -15,27 +15,27 @@ p.circle('x', 'y', color='color', size=8, source=s, alpha=0.4)
 s2 = ColumnDataSource(data=dict(x=[0, 1], ym=[0.5, 0.5]))
 p.line(x='x', y='ym', color="orange", line_width=5, alpha=0.6, source=s2)
 
-s.callback = CustomJS(args=dict(s2=s2), code="""
-        var inds = cb_obj.selected.indices;
-        var d = cb_obj.data;
-        var ym = 0
+s.selected.js_on_change('indices', CustomJS(args=dict(s=s, s2=s2), code="""
+    const inds = s.selected.indices;
+    const d = s.data;
+    var ym = 0
 
-        if (inds.length == 0)
-            return;
+    if (inds.length == 0)
+        return;
 
-        for (var i = 0; i < d['color'].length; i++) {
-            d['color'][i] = "navy"
-        }
-        for (var i = 0; i < inds.length; i++) {
-            d['color'][inds[i]] = "firebrick"
-            ym += d['y'][inds[i]]
-        }
+    for (var i = 0; i < d['color'].length; i++) {
+        d['color'][i] = "navy"
+    }
+    for (var i = 0; i < inds.length; i++) {
+        d['color'][inds[i]] = "firebrick"
+        ym += d['y'][inds[i]]
+    }
 
-        ym /= inds.length
-        s2.data['ym'] = [ym, ym]
+    ym /= inds.length
+    s2.data['ym'] = [ym, ym]
 
-        cb_obj.change.emit();
-        s2.change.emit();
-    """)
+    s.change.emit();
+    s2.change.emit();
+"""))
 
 show(p)

--- a/tests/integration/models/test_sources.py
+++ b/tests/integration/models/test_sources.py
@@ -24,8 +24,9 @@ import pytest ; pytest
 # Bokeh imports
 from bokeh.layouts import column
 from bokeh.models import (
-    Button, ColumnDataSource, CustomAction, CustomJS, Plot, Range1d,
+    Button, ColumnDataSource, CustomAction, CustomJS, Plot, Range1d, TapTool
 )
+from bokeh.plotting import figure
 from bokeh._testing.util.selenium import RECORD
 
 #-----------------------------------------------------------------------------
@@ -137,3 +138,21 @@ class Test_ColumnDataSource(object):
 
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         #assert page.has_no_console_errors()
+
+    # XXX callback property to be deprecated for 2.0
+    def test_selection_triggers_callback_property_callback(self, single_plot_page):
+        plot = figure(height=800, width=1000, tools='')
+        r = plot.rect(x=[1, 2], y=[1, 1], width=1, height=1)
+        plot.add_tools(TapTool())
+
+        r.data_source.callback = CustomJS(code=RECORD("indices", "cb_obj.selected.indices"))
+
+        page = single_plot_page(plot)
+
+        page.click_canvas_at_position(400, 500)
+        assert page.results["indices"] == [0]
+
+        page.click_canvas_at_position(600, 300)
+        assert page.results["indices"] == [1]
+
+        assert page.has_no_console_errors()


### PR DESCRIPTION
The signals were set up to trigger when the `selected` model itself change (i.e. if it was replaced wholesale). This updates to watch changes on properties of the `Selection` (e.g. `indices`) This does not handle the case if a selection is in fact wholesale replaced but I would consider that unsupported and would support making the selection model read only in future releases. 

- [x] issues: fixes #xxxx
- [x] tests added / passed
- [x] release document entry (if new feature or API change)
