### PR TITLE
remove python 3.5 from matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
         - google-chrome-stable --no-sandbox --headless --hide-scrollbars --remote-debugging-port=9222 &
       env:
       - GROUP=examples
-      - PYTHON=3.5
+      - PYTHON=3.6
 
     - install: scripts/ci/install.test
       script: scripts/ci/test
@@ -96,7 +96,7 @@ jobs:
       script: scripts/ci/test
       env:
       - GROUP=unit
-      - PYTHON=3.5
+      - PYTHON=3.6
       - TORNADO=4
       - MINIMAL=1
 


### PR DESCRIPTION
In order to update to the latest conda and conda-build we would need to drop Python 3.5 from our test matrix. This PR is to prove out that things will indeed work, and have a discussion about whether to actually do it. 

I am personally not happy about how aggressively conda has dropped support for Python 3.4 and 3.5 but here we are. I am +0 on this change. FWIW builds do seem to go faster which is certainly a benefit to devs. 

@bokeh/dev thoughts?
