### PR TITLE
use test env for running CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ notifications:
 
 before_install:
   - export PATH="$HOME/miniconda/bin:$PATH"
+  - export PATH="$HOME/miniconda/envs/testenv/bin:$PATH"
   - export PATH="$HOME/build/bokeh/bokeh/bokehjs/node_modules/phantomjs-prebuilt/lib/phantom/bin:$PATH"
   - export PATH="$HOME/bin:$PATH"
   - export TRAVIS_COMMIT_MSG="$(git log --format=%B --no-merges -n 1)"

--- a/scripts/ci/install
+++ b/scripts/ci/install
@@ -26,10 +26,17 @@ EOF
 mkdir -p $HOME/miniconda/conda-meta
 echo -e "$PINNED_PKGS" > $HOME/miniconda/conda-meta/pinned
 
-# install conda packages
-conda install --yes --quiet python=${PYTHON} ${CONDA_REQS}
+# install conda packages in root env
+conda install --yes --quiet ${CONDA_REQS}
 
 # set default conda channels
 conda config --set auto_update_conda off
 conda config --append channels bokeh
 conda config --get channels
+
+# create and activate test env
+conda create -n testenv --yes --quiet python=${PYTHON} pyyaml jinja2
+
+# conda init / activate unfortunately do not work on TravisCI so this path
+# is added in .travis.yml
+# export PATH=${HOME}/miniconda/envs/testenv/bin:${PATH}

--- a/scripts/ci/install.build
+++ b/scripts/ci/install.build
@@ -15,7 +15,7 @@ bash scripts/ci/install
 
 # install build time dependencies
 BUILD_DEPS=`python scripts/deps.py build`
-conda install --yes --quiet ${BUILD_DEPS}
+conda install -n testenv --yes --quiet ${BUILD_DEPS}
 
 npm install -g npm
 

--- a/scripts/ci/install.downstream
+++ b/scripts/ci/install.downstream
@@ -3,5 +3,5 @@
 set -e # exit on error
 set -x # echo commands
 
-conda install --yes --quiet distributed
-conda install --yes --quiet -c pyviz/label/dev holoviews nose
+conda install -n testenv --yes --quiet distributed
+conda install -n testenv --yes --quiet -c pyviz/label/dev holoviews nose

--- a/scripts/ci/install.test
+++ b/scripts/ci/install.test
@@ -35,7 +35,7 @@ else
 fi
 
 # install the pre-built Bokeh package plus all test and runtime dependencies
-conda install --yes --quiet --use-local bokeh `python scripts/deps.py run test` tornado=${TORNADO:-5}
+conda install -n testenv --yes --quiet --use-local bokeh `python scripts/deps.py run test` tornado=${TORNADO:-5}
 
 npm install -g npm
 

--- a/scripts/ci/install.unit
+++ b/scripts/ci/install.unit
@@ -9,5 +9,5 @@ npm install --no-save --no-progress phantomjs
 popd
 
 if  [[ ! -z "${MINIMAL}" ]]; then
-    conda remove --yes --quiet --no-pin pandas scipy notebook scikit-learn sympy flask
+    conda remove -n testenv --yes --quiet --no-pin pandas scipy notebook scikit-learn sympy flask
 fi


### PR DESCRIPTION
This PR attempts to update conda and conda-build but also preserve Python 3.5 jobs, but switching to a dedicated non-root env for testing during install. 
