### PR TITLE
force a layout rebuild on active tab changes

### DIFF
--- a/bokehjs/src/lib/models/layouts/tabs.ts
+++ b/bokehjs/src/lib/models/layouts/tabs.ts
@@ -102,6 +102,10 @@ export class TabsView extends LayoutDOMView {
       hide(child_view.el)
 
     show(child_views[i].el)
+
+    // this is to ensure hidden tabs re-layout correctly, see:
+    // https://github.com/bokeh/bokeh/issues/8614
+    this.rebuild()
   }
 }
 


### PR DESCRIPTION
- [x] issues: fixes #8614
- [ ] tests added / passed

@mattpap if you have a better/more efficient solution I'm happy to defer but otherwise this seems reasonable (and limited in scope) in order to ensure correct behaviour. 