### PR TITLE
add --index option to specify site index template

### DIFF
--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -480,6 +480,13 @@ class Serve(Subcommand):
             help    = "One of: %s" % nice_join(SESSION_ID_MODES),
         )),
 
+        ('--index', dict(
+            metavar='INDEX',
+            action  = 'store',
+            default = None,
+            help    = 'Path to a template to use for the site index',
+        )),
+
         ('--disable-index', dict(
             action = 'store_true',
             help    = 'Do not use the default index on the root path',
@@ -564,6 +571,7 @@ class Serve(Subcommand):
                                                               'allow_websocket_origin',
                                                               'num_procs',
                                                               'prefix',
+                                                              'index',
                                                               'keep_alive_milliseconds',
                                                               'check_unused_sessions_milliseconds',
                                                               'unused_session_lifetime_milliseconds',

--- a/bokeh/command/subcommands/tests/test_serve.py
+++ b/bokeh/command/subcommands/tests/test_serve.py
@@ -182,6 +182,13 @@ def test_args():
             help    = "One of: %s" % nice_join(scserve.SESSION_ID_MODES),
         )),
 
+        ('--index', dict(
+            metavar='INDEX',
+            action  = 'store',
+            default = None,
+            help    = 'Path to a template to use for the site index',
+        )),
+
         ('--disable-index', dict(
             action = 'store_true',
             help    = 'Do not use the default index on the root path',

--- a/bokeh/server/server.py
+++ b/bokeh/server/server.py
@@ -364,6 +364,7 @@ class Server(BaseServer):
         self._port = opts.port
         self._address = opts.address
         self._prefix = opts.prefix
+        self._index = opts.index
 
         if opts.num_procs != 1:
             assert all(app.safe_to_fork for app in applications.values()), (
@@ -389,6 +390,7 @@ class Server(BaseServer):
             tornado_app = BokehTornado(applications,
                                        extra_websocket_origins=extra_websocket_origins,
                                        prefix=self.prefix,
+                                       index=self.index,
                                        websocket_max_message_size_bytes=opts.websocket_max_message_size,
                                        **kwargs)
 
@@ -407,6 +409,13 @@ class Server(BaseServer):
             io_loop = IOLoop.current()
 
         super(Server, self).__init__(io_loop, tornado_app, http_server)
+
+    @property
+    def index(self):
+        ''' A path to a Jinja2 template to use for index at "/"
+
+        '''
+        return self._index
 
     @property
     def prefix(self):
@@ -462,6 +471,10 @@ class _ServerOpts(Options):
 
     prefix = String(default="", help="""
     A URL prefix to use for all Bokeh server paths.
+    """)
+
+    index = String(default=None, help="""
+    A path to a Jinja2 template to use for the index "/"
     """)
 
     allow_websocket_origin = List(String, default=None, help="""

--- a/bokeh/server/tests/test_server.py
+++ b/bokeh/server/tests/test_server.py
@@ -172,6 +172,14 @@ def test_prefix():
     with ManagedServerLoop(application, prefix="foo") as server:
         assert server.prefix == "foo"
 
+def test_index():
+    application = Application()
+    with ManagedServerLoop(application) as server:
+        assert server.index is None
+
+    with ManagedServerLoop(application, index="foo") as server:
+        assert server.index == "foo"
+
 def test_get_sessions():
     application = Application()
     with ManagedServerLoop(application) as server:

--- a/bokeh/server/tests/test_tornado.py
+++ b/bokeh/server/tests/test_tornado.py
@@ -80,6 +80,14 @@ def test_default_resources():
         assert r.root_url == "/foo/bar/"
         assert r.path_versioner == StaticHandler.append_version
 
+def test_index():
+    application = Application()
+    with ManagedServerLoop(application) as server:
+        assert server._tornado.index is None
+
+    with ManagedServerLoop(application, index='foo') as server:
+        assert server._tornado.index == "foo"
+
 def test_prefix():
     application = Application()
     with ManagedServerLoop(application) as server:

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -145,6 +145,11 @@ class BokehTornado(TornadoApplication):
             Whether to generate an index of running apps in the ``RootHandler``
             (default: True)
 
+        index (str, optional) :
+            Path to a Jinja2 template to serve as the index for "/" if use_index
+            is True. If None, the basic built in app index template is used.
+            (default: None)
+
         redirect_root (bool, optional) :
             When there is only a single running application, whether to
             redirect requests to ``"/"`` to that application automatically
@@ -178,6 +183,7 @@ class BokehTornado(TornadoApplication):
                  use_index=True,
                  redirect_root=True,
                  websocket_max_message_size_bytes=DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES,
+                 index=None,
                  **kwargs):
 
         # This will be set when initialize is called
@@ -193,6 +199,8 @@ class BokehTornado(TornadoApplication):
             prefix = "/" + prefix
 
         self._prefix = prefix
+
+        self._index = index
 
         if keep_alive_milliseconds < 0:
             # 0 means "disable"
@@ -292,6 +300,7 @@ class BokehTornado(TornadoApplication):
                 if use_index:
                     data = {"applications": self._applications,
                             "prefix": self._prefix,
+                            "index": self._index,
                             "use_redirect": redirect_root}
                     prefixed_pat = (self._prefix + p[0],) + p[1:] + (data,)
                     all_patterns.append(prefixed_pat)
@@ -343,6 +352,13 @@ class BokehTornado(TornadoApplication):
 
         '''
         return set(self._applications)
+
+    @property
+    def index(self):
+        ''' Path to a Jinja2 template to serve as the index "/"
+
+        '''
+        return self._index
 
     @property
     def io_loop(self):

--- a/bokeh/server/views/root_handler.py
+++ b/bokeh/server/views/root_handler.py
@@ -53,6 +53,7 @@ class RootHandler(RequestHandler):
     def initialize(self, *args, **kw):
         self.applications = kw["applications"]
         self.prefix = kw["prefix"]
+        self.index = kw["index"]
         self.use_redirect = kw["use_redirect"]
 
     @gen.coroutine
@@ -63,7 +64,8 @@ class RootHandler(RequestHandler):
             redirect_to = prefix + app_names[0]
             self.redirect(redirect_to)
         else:
-            self.render("app_index.html", prefix=prefix, items=sorted(self.applications.keys()))
+            index = "app_index.html" if self.index is None else self.index
+            self.render(index, prefix=prefix, items=sorted(self.applications.keys()))
 
 #-----------------------------------------------------------------------------
 # Private API


### PR DESCRIPTION
This is a useful little feature in and of itself, but specifically I need it to set up a new demo site on Elastic Beanstalk without having to run nginx separately. 
