### PR TITLE
Bryanv/sphinxext

### DIFF
--- a/bokeh/core/has_props.py
+++ b/bokeh/core/has_props.py
@@ -656,12 +656,13 @@ _ABSTRACT_ADMONITION = '''
 
 '''
 
+# The "../../" is needed for bokeh-plot to construct the correct path to examples
 _EXAMPLE_TEMPLATE = '''
 
     Example
     -------
 
-    .. bokeh-plot:: ../%(path)s
+    .. bokeh-plot:: ../../%(path)s
         :source-position: below
 
 '''

--- a/bokeh/sphinxext/_templates/gallery_detail.rst
+++ b/bokeh/sphinxext/_templates/gallery_detail.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+.. index::
+   single: examples; {{ filename }}
+
+{{ filename }}
+{{ '-' * filename|length }}
+
+.. bokeh-plot:: {{ source_path }}
+    :source-position: below

--- a/bokeh/sphinxext/_templates/jinja_detail.rst
+++ b/bokeh/sphinxext/_templates/jinja_detail.rst
@@ -1,6 +1,7 @@
 .. data:: {{ name }}
     :module: {{ module }}
     :annotation: = {{ objrepr }}
+    {% if noindex %}:noindex:{% endif %}
 
     {% if doc %}{{ doc|indent(4) }}{% endif %}
 

--- a/bokeh/sphinxext/bokeh_autodoc.py
+++ b/bokeh/sphinxext/bokeh_autodoc.py
@@ -4,13 +4,18 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-""" Integrate Bokeh extensions into Sphinx autodoc.
+''' Integrate Bokeh extensions into Sphinx autodoc.
 
-Ensures that autodoc directives such as ``autoclass`` automatically
-use Bokeh-specific directives (e.g., ``bokeh-prop`` and ``bokeh-model``)
-when appropriate.
+Ensures that autodoc directives such as ``autoclass`` automatically make use of
+Bokeh-specific directives when appropriate. The following Bokeh extensions are
+configured:
 
-"""
+* :ref:`bokeh.sphinxext.bokeh_color`
+* :ref:`bokeh.sphinxext.bokeh_enum`
+* :ref:`bokeh.sphinxext.bokeh_model`
+* :ref:`bokeh.sphinxext.bokeh_prop`
+
+'''
 
 #-----------------------------------------------------------------------------
 # Boilerplate
@@ -94,6 +99,7 @@ class ModelDocumenter(ClassDocumenter):
         return isinstance(member, class_types) and issubclass(member, Model)
 
 def setup(app):
+    ''' Required Sphinx extension setup function. '''
     app.add_autodocumenter(ColorDocumenter)
     app.add_autodocumenter(EnumDocumenter)
     app.add_autodocumenter(PropDocumenter)

--- a/bokeh/sphinxext/bokeh_autodoc.py
+++ b/bokeh/sphinxext/bokeh_autodoc.py
@@ -70,6 +70,12 @@ class ColorDocumenter(ModuleLevelDocumenter):
     def can_document_member(cls, member, membername, isattr, parent):
         return isinstance(member, Color)
 
+    # We don't need/want anything from the actual NamedColor class
+    def add_content(self, more_content, no_docstring=False):
+        pass
+    def get_object_members(self, want_all):
+        return False, []
+
 class EnumDocumenter(ModuleLevelDocumenter):
     directivetype = 'bokeh-enum'
     objtype = 'enum'

--- a/bokeh/sphinxext/bokeh_color.py
+++ b/bokeh/sphinxext/bokeh_color.py
@@ -4,14 +4,22 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-""" Document Bokeh color objects.
+''' Document Bokeh named colors.
 
-The ``bokeh-color`` directive generates a color swatch for named colors
-in the ``bokeh.colors`` module:
+The ``bokeh-color`` directive accepts a named color as its argument:
+
+.. code-block:: rest
 
     .. bokeh-color:: aliceblue
 
-"""
+and generates a labeled color swatch as output.
+
+    .. bokeh-color:: aliceblue
+
+The ``bokeh-color`` direction may be used explicitly, but it can also be used
+in conjunction with the :ref:`bokeh.sphinxext.bokeh_autodoc` extension.
+
+'''
 
 #-----------------------------------------------------------------------------
 # Boilerplate
@@ -29,6 +37,7 @@ log = logging.getLogger(__name__)
 
 # External imports
 from docutils import nodes
+from docutils.parsers.rst.directives import unchanged
 
 # Bokeh imports
 from bokeh.colors import named
@@ -55,12 +64,13 @@ __all__ = (
 
 class BokehColorDirective(BokehDirective):
 
-    has_content = True
+    has_content = False
     required_arguments = 1
-    optional_arguments = 2
+    option_spec = {
+        'module': unchanged,
+    }
 
     def run(self):
-
         color = self.arguments[0]
 
         html = COLOR_DETAIL.render(color=getattr(named, color).to_css(), text=color)
@@ -68,6 +78,7 @@ class BokehColorDirective(BokehDirective):
         return [node]
 
 def setup(app):
+    ''' Required Sphinx extension setup function. '''
     app.add_directive_to_domain('py', 'bokeh-color', BokehColorDirective)
 
 #-----------------------------------------------------------------------------

--- a/bokeh/sphinxext/bokeh_directive.py
+++ b/bokeh/sphinxext/bokeh_directive.py
@@ -4,7 +4,7 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-'''
+''' Provide a base class and useful functions for Bokeh Sphinx directives.
 
 '''
 
@@ -41,7 +41,7 @@ py_sig_re = re.compile(
     r'''^ ([\w.]*\.)?            # class name(s)
           (\w+)  \s*             # thing name
           (?: \((.*)\)           # optional: arguments
-           (?:\s* -> \s* (.*))?  #           return annotation
+           (?:\s* -> \s* (.*))?  # return annotation
           )? $                   # and nothing more
           ''', re.VERBOSE)
 

--- a/bokeh/sphinxext/bokeh_enum.py
+++ b/bokeh/sphinxext/bokeh_enum.py
@@ -4,32 +4,42 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-""" Thoroughly document Bokeh enumerations
+''' Thoroughly document Bokeh enumerations
 
-The ``bokeh-enum`` directive generates useful type information
-for the enumeration, including all the allowable values. If the
-number of values is large, the full list is put in a collapsible
-code block.
+The ``bokeh-enum`` directive generates useful documentation for enumerations,
+including all the allowable values. If the number of values is large, the full
+list is put in a collapsible code block.
 
-This directive takes the name of a Bokeh enum variable and the
-module to find the value as an argument::
+This directive takes the name of a Bokeh enum variable as the argument and the
+module name as an option. An optional description may be added as content:
+
+.. code-block:: rest
 
     .. bokeh-enum:: baz
         :module: bokeh.sphinxext.sample
+
+        Specify a baz style
 
 Examples
 --------
 
-For the following definition of ``bokeh.sphinxext.sample.Bar``::
-
-    baz = enumeration("a", "b", "c")
-
-the above usage yields the output:
+The directive above will generate the following output:
 
     .. bokeh-enum:: baz
         :module: bokeh.sphinxext.sample
 
-"""
+        Specify a baz style
+
+Although ``bokeh-enum`` may be used explicitly, it is more often convenient in
+conjunction with the :ref:`bokeh.sphinxext.bokeh_autodoc` extension. Together,
+the same output above will be generated directly from the following code:
+
+.. code-block:: python
+
+    #: Specify a baz style
+    baz = enumeration("a", "b", "c")
+
+'''
 
 #-----------------------------------------------------------------------------
 # Boilerplate
@@ -49,7 +59,6 @@ import textwrap
 
 # External imports
 from docutils.parsers.rst.directives import unchanged
-
 from sphinx.errors import SphinxError
 
 # Bokeh imports
@@ -63,7 +72,6 @@ from .templates import ENUM_DETAIL
 __all__ = (
     'BokehEnumDirective',
     'setup',
-    'wrapper',
 )
 
 #-----------------------------------------------------------------------------
@@ -74,21 +82,16 @@ __all__ = (
 # Dev API
 #-----------------------------------------------------------------------------
 
-wrapper = textwrap.TextWrapper(subsequent_indent='    ')
-
 class BokehEnumDirective(BokehDirective):
 
     has_content = True
     required_arguments = 1
-    optional_arguments = 2
-
     option_spec = {
         'module': unchanged,
         'noindex': lambda x: True, # directives.flag weirdly returns None
     }
 
     def run(self):
-
         name = self.arguments[0]
 
         try:
@@ -101,7 +104,7 @@ class BokehEnumDirective(BokehDirective):
         fullrepr = repr(enum)
         if len(fullrepr) > 180:
             shortrepr = fullrepr[:40] + " .... " + fullrepr[-40:]
-            fullrepr = wrapper.wrap(fullrepr)
+            fullrepr = _wrapper.wrap(fullrepr)
         else:
             shortrepr = fullrepr
             fullrepr = None
@@ -118,11 +121,14 @@ class BokehEnumDirective(BokehDirective):
         return self._parse(rst_text, "<bokeh-enum>")
 
 def setup(app):
+    ''' Required Sphinx extension setup function. '''
     app.add_directive_to_domain('py', 'bokeh-enum', BokehEnumDirective)
 
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------
+
+_wrapper = textwrap.TextWrapper(subsequent_indent='    ')
 
 #-----------------------------------------------------------------------------
 # Code

--- a/bokeh/sphinxext/bokeh_github.py
+++ b/bokeh/sphinxext/bokeh_github.py
@@ -6,8 +6,8 @@
 #-----------------------------------------------------------------------------
 ''' Simplify linking to Bokeh Github resources.
 
-This module proved four new roles that can be uses to easily link
-to various resources in the Bokeh Github repository:
+This module proved four new roles that can be uses to easily link to various
+resources in the Bokeh Github repository:
 
 ``:bokeh-commit:`` : link to a specific commit
 
@@ -20,7 +20,9 @@ to various resources in the Bokeh Github repository:
 Examples
 --------
 
-The following code::
+The following code:
+
+.. code-block:: rest
 
     The repo history shows that :bokeh-commit:`bf19bcb` was made in
     in :bokeh-pull:`1698`, which closed :bokeh-issue:`1694`. This included
@@ -58,10 +60,7 @@ from docutils.parsers.rst.roles import set_classes
 # Globals and constants
 #-----------------------------------------------------------------------------
 
-BOKEH_GH = "https://github.com/bokeh/bokeh"
-
 __all__ = (
-    'BOKEH_GH',
     'bokeh_commit',
     'bokeh_issue',
     'bokeh_pull',
@@ -145,7 +144,6 @@ def bokeh_tree(name, rawtext, text, lineno, inliner, options=None, content=None)
         All of the examples are located in the :bokeh-tree:`examples`
         subdirectory of your Bokeh checkout.
 
-
     Returns 2 part tuple containing list of nodes to insert into the
     document and a list of system messages.  Both are allowed to be
     empty.
@@ -157,14 +155,14 @@ def bokeh_tree(name, rawtext, text, lineno, inliner, options=None, content=None)
     if '-' in tag:
         tag = 'master'
 
-    url = "%s/tree/%s/%s" % (BOKEH_GH, tag, text)
+    url = "%s/tree/%s/%s" % (_BOKEH_GH, tag, text)
     options = options or {}
     set_classes(options)
-    node = nodes.reference(
-        rawtext, text, refuri=url, **options)
+    node = nodes.reference(rawtext, text, refuri=url, **options)
     return [node], []
 
 def setup(app):
+    ''' Required Sphinx extension setup function. '''
     app.add_role('bokeh-commit', bokeh_commit)
     app.add_role('bokeh-issue', bokeh_issue)
     app.add_role('bokeh-pull', bokeh_pull)
@@ -173,6 +171,8 @@ def setup(app):
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------
+
+_BOKEH_GH = "https://github.com/bokeh/bokeh"
 
 def _make_gh_link_node(app, rawtext, role, kind, api_type, id, options=None):
     ''' Return a link to a Bokeh Github resource.
@@ -187,7 +187,7 @@ def _make_gh_link_node(app, rawtext, role, kind, api_type, id, options=None):
         options (dict) : options dictionary passed to role function
 
     '''
-    url = "%s/%s/%s" % (BOKEH_GH, api_type, id)
+    url = "%s/%s/%s" % (_BOKEH_GH, api_type, id)
     options = options or {}
     set_classes(options)
     node = nodes.reference(

--- a/bokeh/sphinxext/bokeh_model.py
+++ b/bokeh/sphinxext/bokeh_model.py
@@ -4,15 +4,16 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-""" Thoroughly document Bokeh model classes.
+''' Thoroughly document Bokeh model classes.
 
-The ``bokeh-model`` directive will automatically document
-all the attributes (including Bokeh properties) of a Bokeh
-model class. A JSON prototype showing all the possible
-JSON fields will also be generated.
+The ``bokeh-model`` directive will automatically document all the attributes
+(including Bokeh properties) of a Bokeh Model subclass. A JSON prototype showing
+all the possible JSON fields will also be generated.
 
-This directive takes the path to a Bokeh model class as an
-argument::
+This directive takes the name of a Bokeh model class as an argument and its
+module as an option:
+
+.. code-block:: rest
 
     .. bokeh-model:: Foo
         :module: bokeh.sphinxext.sample
@@ -20,10 +21,12 @@ argument::
 Examples
 --------
 
-For the following definition of ``bokeh.sphinxext.sample.Foo``::
+For the following definition of ``bokeh.sphinxext.sample.Foo``:
+
+.. code-block:: python
 
     class Foo(Model):
-        ''' This is a Foo model. '''
+        """ This is a Foo model. """
         index = Either(Auto, Enum('abc', 'def', 'xzy'), help="doc for index")
         value = Tuple(Float, Float, help="doc for value")
 
@@ -33,7 +36,10 @@ the above usage yields the output:
     .. bokeh-model:: Foo
         :module: bokeh.sphinxext.sample
 
-"""
+The ``bokeh-model`` direction may be used explicitly, but it can also be used
+in conjunction with the :ref:`bokeh.sphinxext.bokeh_autodoc` extension.
+
+'''
 
 #-----------------------------------------------------------------------------
 # Boilerplate
@@ -82,8 +88,7 @@ class BokehModelDirective(BokehDirective):
 
     has_content = True
     required_arguments = 1
-    optional_arguments = 2
-
+    optional_arguments = 1
     option_spec = {
         'module': unchanged
     }
@@ -128,6 +133,7 @@ class BokehModelDirective(BokehDirective):
         return self._parse(rst_text, "<bokeh-model>")
 
 def setup(app):
+    ''' Required Sphinx extension setup function. '''
     app.add_directive_to_domain('py', 'bokeh-model', BokehModelDirective)
 
 #-----------------------------------------------------------------------------

--- a/bokeh/sphinxext/bokeh_options.py
+++ b/bokeh/sphinxext/bokeh_options.py
@@ -4,14 +4,15 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-""" Thoroughly document Bokeh options classes.
+''' Thoroughly document Bokeh options classes.
 
-The ``bokeh-options`` directive will automatically document
-all the properties) of a Bokeh Options class.
+The ``bokeh-options`` directive will automatically document all the properties
+of a Bokeh Options class under a heading of "Keyword Args".
 
+This directive takes the name of a Bokeh Options subclass as the argument, and
+its module as an option:
 
-This directive takes the path to a Bokeh model class as an
-argument::
+.. code-block:: rest
 
     .. bokeh-options:: Opts
         :module: bokeh.sphinxext.sample
@@ -19,21 +20,22 @@ argument::
 Examples
 --------
 
-For the following definition of ``bokeh.sphinxext.sample.Opts``::
+For the following definition of ``bokeh.sphinxext.sample.Opts``:
+
+.. code-block:: python
 
     class Opts(Options):
-        ''' This is an Options class '''
+        """ This is an Options class """
 
         host = String(default="localhost", help="a host to connect to")
-        port = Int(default="5890", help="a port to connect to")
-
+        port = Int(default=5890, help="a port to connect to")
 
 the above usage yields the output:
 
     .. bokeh-options:: Opts
         :module: bokeh.sphinxext.sample
 
-"""
+'''
 
 #-----------------------------------------------------------------------------
 # Boilerplate
@@ -82,8 +84,7 @@ class BokehOptionsDirective(BokehDirective):
 
     has_content = True
     required_arguments = 1
-    optional_arguments = 2
-
+    optional_arguments = 1
     option_spec = {
         'module': unchanged
     }
@@ -127,6 +128,7 @@ class BokehOptionsDirective(BokehDirective):
         return self._parse(rst_text, "<bokeh-options>")
 
 def setup(app):
+    ''' Required Sphinx extension setup function. '''
     app.add_directive_to_domain('py', 'bokeh-options', BokehOptionsDirective)
 
 #-----------------------------------------------------------------------------

--- a/bokeh/sphinxext/bokeh_palette.py
+++ b/bokeh/sphinxext/bokeh_palette.py
@@ -115,9 +115,7 @@ def bokeh_palette(name, rawtext, text, lineno, inliner, options=None, content=No
     return [node], []
 
 def setup(app):
-    ''' Required setup function for Sphinx extensions.
-
-    '''
+    ''' Required Sphinx extension setup function. '''
     app.add_role('bokeh-palette', bokeh_palette)
 
 #-----------------------------------------------------------------------------

--- a/bokeh/sphinxext/bokeh_palette_group.py
+++ b/bokeh/sphinxext/bokeh_palette_group.py
@@ -4,7 +4,7 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-""" Generate visual representations of palettes in Bokeh palette groups.
+''' Generate visual representations of palettes in Bokeh palette groups.
 
 The ``bokeh.palettes`` modules expose attributes such as ``mpl``, ``brewer``,
 and ``d3`` that provide groups of palettes. The ``bokeh-palette-group``
@@ -21,7 +21,7 @@ Generates the output:
 
     .. bokeh-palette-group:: mpl
 
-"""
+'''
 
 #-----------------------------------------------------------------------------
 # Boilerplate
@@ -54,9 +54,7 @@ from .templates import PALETTE_GROUP_DETAIL
 __all__ = (
     'bokeh_palette_group',
     'BokehPaletteGroupDirective',
-    'CSS',
     'html_visit_bokeh_palette_group',
-    'JS',
     'setup',
 )
 
@@ -67,15 +65,6 @@ __all__ = (
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------
-
-CSS = """
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
-"""
-
-JS = """
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
-"""
 
 class bokeh_palette_group(nodes.General, nodes.Element):
     pass
@@ -92,7 +81,7 @@ class BokehPaletteGroupDirective(Directive):
         return [node]
 
 def html_visit_bokeh_palette_group(self, node):
-    self.body.append(CSS)
+    self.body.append(_BOOTSTRAP_CSS)
     self.body.append('<div class="container-fluid"><div class="row">"')
     group = getattr(bp, node['group'], None)
     if not isinstance(group, dict):
@@ -105,16 +94,26 @@ def html_visit_bokeh_palette_group(self, node):
         html = PALETTE_GROUP_DETAIL.render(name=name, numbers=numbers, palettes=palettes)
         self.body.append(html)
     self.body.append('</div></div>')
-    self.body.append(JS)
+    self.body.append(_BOOTSTRAP_JS)
     raise nodes.SkipNode
 
 def setup(app):
+    ''' Required Sphinx extension setup function. '''
     app.add_node(bokeh_palette_group, html=(html_visit_bokeh_palette_group, None))
     app.add_directive('bokeh-palette-group', BokehPaletteGroupDirective)
 
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------
+
+_BOOTSTRAP_CSS = """
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+"""
+
+_BOOTSTRAP_JS = """
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+"""
 
 #-----------------------------------------------------------------------------
 # Code

--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -4,7 +4,7 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-""" Include Bokeh plots in Sphinx HTML documentation.
+''' Include Bokeh plots in Sphinx HTML documentation.
 
 For other output types, the placeholder text ``[graph]`` will
 be generated.
@@ -69,7 +69,8 @@ The inline example code above produces the following output:
 
     show(p)
 
-"""
+'''
+
 
 #-----------------------------------------------------------------------------
 # Boilerplate
@@ -85,7 +86,6 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-import ast
 from os import getenv
 from os.path import basename, dirname, join
 import re
@@ -93,7 +93,7 @@ from uuid import uuid4
 
 # External imports
 from docutils import nodes
-from docutils.parsers.rst import Directive, Parser
+from docutils.parsers.rst import Directive
 from docutils.parsers.rst.directives import choice, flag
 
 from sphinx.errors import SphinxError
@@ -108,80 +108,19 @@ from ..resources import Resources
 from ..settings import settings
 from ..util.string import decode_utf8
 from .example_handler import ExampleHandler
-from .templates import PLOT_PAGE
 
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
 
-docs_cdn = settings.docs_cdn()
-
 __all__ = (
-    'PlotScriptError',
-    'PlotScriptParser',
     'BokehPlotDirective',
-    'env_before_read_docs',
-    'builder_inited',
-    'html_page_context',
-    'build_finished',
-    'env_purge_doc',
     'setup',
 )
 
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
-
-class PlotScriptError(SphinxError):
-    """ Error during script parsing. """
-
-    category = 'PlotScript error'
-
-class PlotScriptParser(Parser):
-    """ This Parser recognizes .py files in the Sphinx source tree,
-    assuming that they contain bokeh examples
-
-    Note: it is important that the .py files are parsed first. This is
-    accomplished by reordering the doc names in the env_before_read_docs callback
-
-    """
-
-    supported = ('python',)
-
-    def parse(self, source, document):
-        """ Parse ``source``, write results to ``document``.
-
-        """
-        # This is lame, but seems to be required for python 2
-        source = CODING.sub("", source)
-
-        env = document.settings.env
-        filename = env.doc2path(env.docname) # e.g. full path to docs/user_guide/examples/layout_vertical
-
-        # This code splits the source into two parts: the docstring (or None if
-        # there is not one), and the remaining source code after
-        m = ast.parse(source)
-        docstring = ast.get_docstring(m)
-        if docstring is not None:
-            lines = source.split("\n")
-            lineno = m.body[0].lineno # assumes docstring is m.body[0]
-            source = "\n".join(lines[lineno:])
-
-        js_name = "bokeh-plot-%s.js" % uuid4().hex
-
-        (script, js, js_path, source) = _process_script(source, filename, env, js_name, env.config.bokeh_plot_use_relative_paths)
-
-        env.bokeh_plot_files[env.docname] = (script, js, js_path, source)
-
-        rst = PLOT_PAGE.render(source=source,
-                               filename=basename(filename),
-                               docstring=docstring,
-                               script=script)
-
-        document['bokeh_plot_include_bokehjs'] = True
-
-        # can't use super, Sphinx Parser classes don't inherit object
-        Parser.parse(self, rst, document)
 
 class BokehPlotDirective(Directive):
 
@@ -201,43 +140,24 @@ class BokehPlotDirective(Directive):
         if self.arguments and self.content:
             raise SphinxError("bokeh-plot:: directive can't have both args and content")
 
-        # process inline examples here
+        # need docname not to look like a path
+        docname = env.docname.replace("/", "-")
+
         if self.content:
             log.debug("[bokeh-plot] handling inline example in %r", env.docname)
+            path = env.bokeh_plot_auxdir  # code runner just needs any real path
             source = '\n'.join(self.content)
-            # need docname not to look like a path
-            docname = env.docname.replace("/", "-")
-            js_name = "bokeh-plot-%s-inline-%s.js" % (docname, uuid4().hex)
-            # the code runner just needs a real path to cd to, this will do
-            path = join(env.bokeh_plot_auxdir, js_name)
-
-            (script, js, js_path, source) = _process_script(source, path, env, js_name, env.config.bokeh_plot_use_relative_paths)
-            if(env.config.bokeh_plot_use_relative_paths):
-                script = script.replace('$REL_PATH$', _get_file_depth_string(env.docname) + 'scripts')
-            env.bokeh_plot_files[js_name] = (script, js, js_path, source)
-
-        # process example files here
         else:
-            example_path = self.arguments[0][:-3]  # remove the ".py"
+            log.debug("[bokeh-plot] handling external example in %r: %s", env.docname, self.arguments[0])
+            path = self.arguments[0]
+            if not path.startswith("/"):
+                path = join(env.app.srcdir, path)
+            source = decode_utf8(open(path).read())
 
-            # if it's an "internal" example, the python parser has already handled it
-            if example_path in env.bokeh_plot_files:
-                log.debug("[bokeh-plot] handling internal example in %r: %s", env.docname, self.arguments[0])
-                (script, js, js_path, source) = env.bokeh_plot_files[example_path]
-                if(env.config.bokeh_plot_use_relative_paths):
-                    script = script.replace('$REL_PATH$', _get_file_depth_string(env.docname) + 'scripts')
+        js_name = "bokeh-plot-%s-external-%s.js" % (uuid4().hex, docname)
 
-            # handle examples external to the docs source, e.g. gallery examples
-            else:
-                log.debug("[bokeh-plot] handling external example in %r: %s", env.docname, self.arguments[0])
-                source = open(self.arguments[0]).read()
-                source = decode_utf8(source)
-                docname = env.docname.replace("/", "-")
-                js_name = "bokeh-plot-%s-external-%s.js" % (docname, uuid4().hex)
-                (script, js, js_path, source) = _process_script(source, self.arguments[0], env, js_name, env.config.bokeh_plot_use_relative_paths)
-                if(env.config.bokeh_plot_use_relative_paths):
-                    script = script.replace('$REL_PATH$', _get_file_depth_string(env.docname) + 'scripts')
-                env.bokeh_plot_files[js_name] = (script, js, js_path, source)
+        (script, js, js_path, source) = _process_script(source, path, env, js_name)
+        env.bokeh_plot_files[js_name] = (script, js, js_path, source, dirname(env.docname))
 
         # use the source file name to construct a friendly target_id
         target_id = "%s.%s" % (env.docname, basename(js_path))
@@ -262,15 +182,6 @@ class BokehPlotDirective(Directive):
 # Dev API
 #-----------------------------------------------------------------------------
 
-def env_before_read_docs(app, env, docnames):
-    # sort to make sure the custom Python file parser gets to process any plot
-    # scripts first, since it will save the plot output for use later.
-    docnames.sort(key=lambda x: 0 if env.doc2path(x).endswith(".py") else 1)
-    for name in [x for x in docnames if env.doc2path(x).endswith(".py")]:
-        if not name.startswith(tuple(env.app.config.bokeh_plot_pyfile_include_dirs)):
-            env.found_docs.remove(name)
-            docnames.remove(name)
-
 def builder_inited(app):
     app.env.bokeh_plot_auxdir = join(app.env.doctreedir, 'bokeh_plot')
     ensuredir(app.env.bokeh_plot_auxdir) # sphinx/_build/doctrees/bokeh_plot
@@ -278,56 +189,38 @@ def builder_inited(app):
     if not hasattr(app.env, 'bokeh_plot_files'):
         app.env.bokeh_plot_files = {}
 
-def html_page_context(app, pagename, templatename, context, doctree):
-    """ Add BokehJS to pages that contain plots.
-
-    """
-    if doctree and doctree.get('bokeh_plot_include_bokehjs'):
-        context['bokeh_css_files'] = resources.css_files
-        context['bokeh_js_files'] = resources.js_files
-
 def build_finished(app, exception):
     files = set()
 
-    for (script, js, js_path, source) in app.env.bokeh_plot_files.values():
-        files.add(js_path)
+    for (script, js, js_path, source, docpath) in app.env.bokeh_plot_files.values():
+        files.add((js_path, docpath))
 
     files_iter = status_iterator(sorted(files),
                                  'copying bokeh-plot files... ',
                                  'brown',
                                  len(files),
-                                 stringify_func=lambda x: basename(x))
+                                 app.verbosity,
+                                 stringify_func=lambda x: basename(x[0]))
 
-    for file in files_iter:
-        target = join(app.builder.outdir, "scripts", basename(file))
+    for (file, docpath) in files_iter:
+        target = join(app.builder.outdir, docpath, basename(file))
         ensuredir(dirname(target))
         try:
             copyfile(file, target)
         except OSError as e:
             raise SphinxError('cannot copy local file %r, reason: %s' % (file, e))
 
-def env_purge_doc(app, env, docname):
-    """ Remove local files for a given document.
-
-    """
-    if docname in env.bokeh_plot_files:
-        del env.bokeh_plot_files[docname]
-
 def setup(app):
-    """ sphinx config variable to scan .py files in provided directories only """
+    ''' Required Sphinx extension setup function. '''
+
+    # These two are deprecated and no longer have any effect, to be removed 2.0
     app.add_config_value('bokeh_plot_pyfile_include_dirs', [], 'html')
     app.add_config_value('bokeh_plot_use_relative_paths', False, 'html')
-    app.add_config_value('bokeh_missing_google_api_key_ok', True, 'html')
-
-    app.add_source_parser('.py', PlotScriptParser)
 
     app.add_directive('bokeh-plot', BokehPlotDirective)
-
-    app.connect('env-before-read-docs', env_before_read_docs)
-    app.connect('builder-inited',       builder_inited)
-    app.connect('html-page-context',    html_page_context)
-    app.connect('build-finished',       build_finished)
-    app.connect('env-purge-doc',        env_purge_doc)
+    app.add_config_value('bokeh_missing_google_api_key_ok', True, 'html')
+    app.connect('builder-inited', builder_inited)
+    app.connect('build-finished', build_finished)
 
 #-----------------------------------------------------------------------------
 # Private API
@@ -358,36 +251,21 @@ def _process_script(source, filename, env, js_name, use_relative_paths=False):
     d = Document()
     c.modify_document(d)
     if c.error:
-        raise PlotScriptError(c.error_detail)
-
-    script_path = None
-    if(use_relative_paths):
-        script_path = join("$REL_PATH$", js_name)
-    else:
-        script_path = join("/scripts", js_name)
+        raise RuntimeError(c.error_detail)
 
     js_path = join(env.bokeh_plot_auxdir, js_name)
-    js, script = autoload_static(d.roots[0], resources, script_path)
+    js, script = autoload_static(d.roots[0], resources, js_name)
 
     with open(js_path, "w") as f:
         f.write(js)
 
     return (script, js, js_path, source)
 
-def _get_file_depth_string(docname):
-    """Get relative path string of file containing directive"""
-    pre_path = ''
-
-    depth = docname.count('/')
-    if depth is None:
-        pre_path = ''
-    else:
-        pre_path = ''.join(['../'] * depth)
-    return pre_path
-
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
+
+docs_cdn = settings.docs_cdn()
 
 # if BOKEH_DOCS_CDN is unset just use default CDN resources
 if docs_cdn is None:

--- a/bokeh/sphinxext/bokeh_prop.py
+++ b/bokeh/sphinxext/bokeh_prop.py
@@ -4,15 +4,16 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-""" Thoroughly document Bokeh property attributes.
+''' Thoroughly document Bokeh property attributes.
 
-The ``bokeh-prop`` directive generates useful type information
-for the property attribute, including cross links to the relevant
-property types. Additionally, any per-attribute docstrings are
-also displayed.
+The ``bokeh-prop`` directive generates documentation for Bokeh model properties,
+including cross links to the relevant property types. Additionally, any
+per-attribute help strings are also displayed.
 
-This directive takes the path to an attribute on a Bokeh
-model class as an argument::
+This directive takes the name *(class.attr)* of a Bokeh property as its
+argument and the module as an option:
+
+.. code-block:: rest
 
     .. bokeh-prop:: Bar.thing
         :module: bokeh.sphinxext.sample
@@ -20,10 +21,12 @@ model class as an argument::
 Examples
 --------
 
-For the following definition of ``bokeh.sphinxext.sample.Bar``::
+For the following definition of ``bokeh.sphinxext.sample.Bar``:
+
+.. code-block:: python
 
     class Bar(Model):
-        ''' This is a Bar model. '''
+        """ This is a Bar model. """
         thing = List(Int, help="doc for thing")
 
 the above usage yields the output:
@@ -31,7 +34,11 @@ the above usage yields the output:
     .. bokeh-prop:: Bar.thing
         :module: bokeh.sphinxext.sample
 
-"""
+
+The ``bokeh-prop`` direction may be used explicitly, but it can also be used
+in conjunction with the :ref:`bokeh.sphinxext.bokeh_autodoc` extension.
+
+'''
 
 #-----------------------------------------------------------------------------
 # Boilerplate
@@ -79,8 +86,7 @@ class BokehPropDirective(BokehDirective):
 
     has_content = True
     required_arguments = 1
-    optional_arguments = 2
-
+    optional_arguments = 1
     option_spec = {
         'module': unchanged
     }
@@ -115,6 +121,7 @@ class BokehPropDirective(BokehDirective):
         return self._parse(rst_text, "<bokeh-prop>")
 
 def setup(app):
+    ''' Required Sphinx extension setup function. '''
     app.add_directive_to_domain('py', 'bokeh-prop', BokehPropDirective)
 
 #-----------------------------------------------------------------------------

--- a/bokeh/sphinxext/bokeh_releases.py
+++ b/bokeh/sphinxext/bokeh_releases.py
@@ -9,7 +9,7 @@
 This directive collect all the release notes files in the ``docs/releases``
 subdirectory, and includes them in *reverse version order*. Typical usage:
 
-.. code-block:: rst
+.. code-block:: rest
 
     :tocdepth: 1
 
@@ -83,6 +83,7 @@ class BokehReleases(BokehDirective):
         return rst
 
 def setup(app):
+    ''' Required Sphinx extension setup function. '''
     app.add_directive('bokeh-releases', BokehReleases)
 
 #-----------------------------------------------------------------------------

--- a/bokeh/sphinxext/bokeh_sitemap.py
+++ b/bokeh/sphinxext/bokeh_sitemap.py
@@ -4,7 +4,7 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-""" Generate a ``sitemap.txt`` to aid with search indexing.
+''' Generate a ``sitemap.txt`` to aid with search indexing.
 
 ``sitemap.txt`` is a plain text list of all the pages in the docs site.
 Each URL is listed on a line in the text file. It is machine readable
@@ -14,7 +14,7 @@ All that is required to generate the sitemap is to list this module
 ``bokeh.sphinxext.sitemap`` in the list of extensions in the Sphinx
 configuration file ``conf.py``.
 
-"""
+'''
 
 #-----------------------------------------------------------------------------
 # Boilerplate
@@ -56,23 +56,24 @@ __all__ = (
 #-----------------------------------------------------------------------------
 
 def html_page_context(app, pagename, templatename, context, doctree):
-    """ Collect page names for the sitemap as HTML pages are built.
+    ''' Collect page names for the sitemap as HTML pages are built.
 
-    """
+    '''
     site = context['SITEMAP_BASE_URL']
     version = context['version']
     app.sitemap_links.add(site + version + '/' + pagename + ".html")
 
 def build_finished(app, exception):
-    """ Generate a ``sitemap.txt`` from the collected HTML page links.
+    ''' Generate a ``sitemap.txt`` from the collected HTML page links.
 
-    """
+    '''
     filename = join(app.outdir, "sitemap.txt")
 
     links_iter = status_iterator(sorted(app.sitemap_links),
                                  'adding links to sitemap... ',
                                  'brown',
-                                 len(app.sitemap_links))
+                                 len(app.sitemap_links),
+                                 app.verbosity)
 
     try:
         with open(filename, 'w') as f:
@@ -82,6 +83,7 @@ def build_finished(app, exception):
         raise SphinxError('cannot write sitemap.txt, reason: %s' % e)
 
 def setup(app):
+    ''' Required Sphinx extension setup function. '''
     app.connect('html-page-context', html_page_context)
     app.connect('build-finished',    build_finished)
     app.sitemap_links = set()

--- a/bokeh/sphinxext/collapsible_code_block.py
+++ b/bokeh/sphinxext/collapsible_code_block.py
@@ -4,10 +4,11 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-""" Display code blocks in collapsible sections when outputting
-to HTML.
+''' Display code blocks in collapsible sections when outputting to HTML.
 
-This directive takes a heading to use for the collapsible code block::
+This directive takes a heading to use for the collapsible code block:
+
+.. code-block:: rest
 
     .. collapsible-code-block:: python
         :heading: Some Code
@@ -35,7 +36,7 @@ The inline example code above produces the following output:
 
     print("Hello, Bokeh!")
 
-"""
+'''
 
 #-----------------------------------------------------------------------------
 # Boilerplate
@@ -96,7 +97,7 @@ class CollapsibleCodeBlock(CodeBlock):
         rst_source = self.state_machine.node.document['source']
         rst_filename = basename(rst_source)
 
-        target_id = "%s.ccb-%d" % (rst_filename, env.new_serialno('bokeh-plot'))
+        target_id = "%s.ccb-%d" % (rst_filename, env.new_serialno('ccb'))
         target_id = target_id.replace(".", "-")
         target_node = nodes.target('', '', ids=[target_id])
 
@@ -122,6 +123,7 @@ def html_depart_collapsible_code_block(self, node):
     self.body.append(CCB_EPILOGUE.render())
 
 def setup(app):
+    ''' Required Sphinx extension setup function. '''
     app.add_node(
         collapsible_code_block,
         html=(

--- a/bokeh/sphinxext/example_handler.py
+++ b/bokeh/sphinxext/example_handler.py
@@ -4,6 +4,9 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
+'''
+
+'''
 
 #-----------------------------------------------------------------------------
 # Boilerplate
@@ -45,7 +48,7 @@ __all__ = (
 
 class ExampleHandler(Handler):
     """ A stripped-down handler similar to CodeHandler but that does
-    some appropriate monkeypatching to
+    some appropriate monkeypatching.
 
     """
 

--- a/bokeh/sphinxext/sample.py
+++ b/bokeh/sphinxext/sample.py
@@ -24,7 +24,8 @@ log = logging.getLogger(__name__)
 # Bokeh imports
 from bokeh.model import Model
 from bokeh.core.enums import enumeration
-from bokeh.core.properties import Auto, Either, Enum, Float, Int, List, Tuple
+from bokeh.core.properties import Auto, Either, Enum, Float, Int, List, String, Tuple
+from bokeh.util.options import Options
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -34,6 +35,7 @@ __all__ = (
     'Bar',
     'baz',
     'Foo',
+    'Opts',
 )
 
 #-----------------------------------------------------------------------------
@@ -55,6 +57,12 @@ class Bar(Model):
 
 #: This is an enumeration
 baz = enumeration("a", "b", "c")
+
+class Opts(Options):
+    """ This is an Options class """
+
+    host = String(default="localhost", help="a host to connect to")
+    port = Int(default=5890, help="a port to connect to")
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/sample.py
+++ b/bokeh/sphinxext/sample.py
@@ -4,6 +4,10 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
+''' This modules simply provides some sample code for the documentation of
+``bokeh.sphinxext`` itself.
+
+'''
 
 #-----------------------------------------------------------------------------
 # Boilerplate

--- a/bokeh/sphinxext/templates.py
+++ b/bokeh/sphinxext/templates.py
@@ -4,6 +4,9 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
+'''
+
+'''
 
 #-----------------------------------------------------------------------------
 # Boilerplate
@@ -18,9 +21,10 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from os.path import dirname, join
 
 # External imports
-from jinja2 import Environment, PackageLoader
+from jinja2 import Environment, FileSystemLoader
 
 # Bokeh imports
 
@@ -47,7 +51,9 @@ __all__ = (
 # Private API
 #-----------------------------------------------------------------------------
 
-_env = Environment(loader=PackageLoader('bokeh.sphinxext', '_templates'))
+_templates_path = join(dirname(__file__), '_templates')
+
+_env = Environment(loader=FileSystemLoader(_templates_path))
 
 #-----------------------------------------------------------------------------
 # General API

--- a/bokeh/sphinxext/templates.py
+++ b/bokeh/sphinxext/templates.py
@@ -70,7 +70,8 @@ COLOR_DETAIL = _env.get_template("color_detail.html")
 
 ENUM_DETAIL = _env.get_template("enum_detail.rst")
 
-GALLERY_PAGE = _env.get_template("gallery_page.rst")
+GALLERY_PAGE   = _env.get_template("gallery_page.rst")
+GALLERY_DETAIL = _env.get_template("gallery_detail.rst")
 
 JINJA_DETAIL = _env.get_template("jinja_detail.rst")
 

--- a/sphinx/.gitignore
+++ b/sphinx/.gitignore
@@ -1,3 +1,3 @@
-_build
+build
 source/docs/gallery/*
 *.html

--- a/sphinx/Makefile
+++ b/sphinx/Makefile
@@ -1,17 +1,11 @@
 # Makefile for Sphinx documentation
-#
 
 # You can set these variables from the command line.
-SPHINXBUILD   = sphinx-build
-PAPER         =
-BUILDDIR      = _build
+SPHINXBUILD = sphinx-build
+BUILDDIR    = build
 
 # Internal variables.
-PAPEROPT_a4     = -D latex_paper_size=a4
-PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source -W
-# the i18n builder cannot share the environment and doctrees with the others
-I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+ALLSPHINXOPTS = -d $(BUILDDIR)/doctrees $(SPHINXOPTS) source -W
 
 .PHONY: help clean html serve
 

--- a/sphinx/docserver.py
+++ b/sphinx/docserver.py
@@ -28,12 +28,12 @@ def welcome():
 @app.route('/en/latest/<path:filename>')
 def send_pic(filename):
     return flask.send_from_directory(
-        os.path.join(_basedir,"sphinx/_build/html/"), filename)
+        os.path.join(_basedir,"sphinx/build/html/"), filename)
 
 @app.route('/scripts/<path:filename>')
 def send_script(filename):
     return flask.send_from_directory(
-        os.path.join(_basedir,"sphinx/_build/html/scripts/"), filename)
+        os.path.join(_basedir,"sphinx/build/html/scripts/"), filename)
 
 def open_browser():
     # Child process

--- a/sphinx/docserver.py
+++ b/sphinx/docserver.py
@@ -30,11 +30,6 @@ def send_pic(filename):
     return flask.send_from_directory(
         os.path.join(_basedir,"sphinx/build/html/"), filename)
 
-@app.route('/scripts/<path:filename>')
-def send_script(filename):
-    return flask.send_from_directory(
-        os.path.join(_basedir,"sphinx/build/html/scripts/"), filename)
-
 def open_browser():
     # Child process
     time.sleep(0.5)

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -22,7 +22,7 @@ from os.path import abspath, dirname, join
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '1.7'
+needs_sphinx = '1.8'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -270,7 +270,7 @@ texinfo_documents = [
 
 # intersphinx settings
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/', None),
+    'python': ('https://docs.python.org/3/', None),
     'pandas': ('http://pandas.pydata.org/pandas-docs/stable/', None),
-    'numpy': ('http://docs.scipy.org/doc/numpy/', None)
+    'numpy': ('https://docs.scipy.org/doc/numpy/', None)
 }

--- a/sphinx/source/docs/gallery.json
+++ b/sphinx/source/docs/gallery.json
@@ -1,7 +1,7 @@
 {
     "details": [
         { "path": "examples/plotting/file/iris.py",                            "name": "iris"                           },
-        { "path": "examples/plotting/file/ridgeplot.py",                       "name": "ridgeplot"                        },
+        { "path": "examples/plotting/file/ridgeplot.py",                       "name": "ridgeplot"                      },
         { "path": "examples/plotting/file/hexbin.py",                          "name": "hexbin"                         },
         { "path": "examples/plotting/file/hex_tile.py",                        "name": "hex_tile"                       },
         { "path": "examples/plotting/file/bar_colormapped.py",                 "name": "bar_colormapped"                },
@@ -43,7 +43,7 @@
         { "path": "examples/plotting/file/markers.py",                         "name": "markers"                        },
         { "path": "examples/plotting/file/burtin.py",                          "name": "burtin"                         },
         { "path": "examples/plotting/file/bar_basic.py",                       "name": "bar_basic"                      },
-        { "path": "examples/plotting/file/stacked_area.py",                    "name": "stacked_area"                         },
+        { "path": "examples/plotting/file/stacked_area.py",                    "name": "stacked_area"                   },
         { "path": "examples/plotting/file/elements.py",                        "name": "elements"                       },
         { "path": "examples/plotting/file/boxplot.py",                         "name": "boxplot"                        },
         { "path": "examples/plotting/file/logplot.py",                         "name": "logaxis"                        }

--- a/sphinx/source/docs/reference/sphinxext.rst
+++ b/sphinx/source/docs/reference/sphinxext.rst
@@ -16,6 +16,13 @@ bokeh_autodoc
 
 .. automodule:: bokeh.sphinxext.bokeh_autodoc
 
+.. _bokeh.sphinxext.bokeh_color:
+
+bokeh_color
+-----------
+
+.. automodule:: bokeh.sphinxext.bokeh_color
+
 .. _bokeh.sphinxext.bokeh_enum:
 
 bokeh_enum
@@ -75,7 +82,7 @@ bokeh_prop
 .. _bokeh.sphinxext.bokeh_releases:
 
 bokeh_releases
--------------------
+--------------
 
 .. automodule:: bokeh.sphinxext.bokeh_releases
 

--- a/sphinx/source/docs/reference/sphinxext.rst
+++ b/sphinx/source/docs/reference/sphinxext.rst
@@ -44,6 +44,13 @@ bokeh_github
 
 .. automodule:: bokeh.sphinxext.bokeh_github
 
+.. _bokeh.sphinxext.bokeh_jinja:
+
+bokeh_jinja
+-----------
+
+.. automodule:: bokeh.sphinxext.bokeh_jinja
+
 .. _bokeh.sphinxext.bokeh_model:
 
 bokeh_model

--- a/sphinx/source/docs/reference/sphinxext.rst
+++ b/sphinx/source/docs/reference/sphinxext.rst
@@ -58,6 +58,13 @@ bokeh_model
 
 .. automodule:: bokeh.sphinxext.bokeh_model
 
+.. _bokeh.sphinxext.bokeh_options:
+
+bokeh_options
+-------------
+
+.. automodule:: bokeh.sphinxext.bokeh_options
+
 .. _bokeh.sphinxext.bokeh_palette:
 
 bokeh_palette

--- a/sphinx/source/docs/releases/1.1.0.rst
+++ b/sphinx/source/docs/releases/1.1.0.rst
@@ -3,9 +3,12 @@
 
 Bokeh Version ``1.1.0`` (January 2019) primarily
 
+.. _release-1-1-0-migration:
 
 Migration Guide
 ---------------
+
+.. _release-1-1-0-new:
 
 New in 1.1
 ~~~~~~~~~~
@@ -22,6 +25,8 @@ See :ref:`userguide_interaction_linked_properties` for more information.
 The ``Slider.value_as_date`` method was added to conveniently retrieve Slider
 values as date objects when appropriate.
 
+.. _release-1-1-0-deprecations:
+
 Deprecations
 ~~~~~~~~~~~~
 
@@ -37,3 +42,23 @@ removed in a future 2.0 release:
 
 * Support for "transpiling" Python code to JavaScript. All ``from_py_func``
   methods will be removed. Use JavaScript or Typescript instead.
+
+Changes to bokeh.sphinxext
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In order to support a longer term goal of moving Bokeh docs to `ReadTheDocs`_,
+some changes to the ``bokeh-plot`` Sphinx directive were necessary. These are:
+
+* Plot script files are now always placed immediately adjacent to the document
+  they are for, and loaded using relative URLs.
+
+* The config values ``bokeh_plot_pyfile_include_dirs`` and
+  ``bokeh_plot_use_relative_paths`` are no longer needed. Setting them will have
+  no effect (but will not break existing builds). These config values will be
+  removed in a future 2.0 release.
+
+We believe that there are very few users of ``bokeh.sphinxext`` outside the
+project itself, and that these changes will not cause any breakage for any of
+those users. However, please reach out for support if any unforseen issues arise.
+
+.. _ReadTheDocs: https://readthedocs.org


### PR DESCRIPTION
- [x] issues: fixes #5955
- [x] release document entry (if new feature or API change)

This PR closes #5955 and makes `bokeh-plot` scripts always be located adjacent to the document they are for, and always be loaded with relative links. This is a first step in supporting a longer term goal of hosting Bokeh docs on ReadTheDocs.  Also in this PR:

* Both `bokeh-gallery` and `bokeh-plot` were simplified: The custom Sphinx parser for python files was  removed. The gallery plugin simply generates `.rst` files with the appropriate `bokeh-plot` directives at build start. The plot plugin always handles python files at the same time (on `run` for a document). 

* Subjectively, the build seems to run somewhat more quickly as a result. As a guess this is due to not parsing the AST manually

* Adds some sections missing from the refguide

* General cleanup and consistency across the entire `sphinxext` package. 

@mattpap I'd like to merge this and cut a 1.1dev5 release tomorrow to ensure there are no end-to-end issues. 