### PR TITLE
Connect CDSView.source's slots after late initialization

### DIFF
--- a/bokehjs/src/lib/models/sources/cds_view.ts
+++ b/bokehjs/src/lib/models/sources/cds_view.ts
@@ -46,38 +46,47 @@ export class CDSView extends Model {
 
   connect_signals(): void {
     super.connect_signals()
+
     this.connect(this.properties.filters.change, () => {
       this.compute_indices()
       this.change.emit()
     })
-    if (this.source != null) {
-      if (this.source.change != null)
-        this.connect(this.source.change, () => this.compute_indices())
-      if (this.source.streaming != null)
-        this.connect(this.source.streaming, () => this.compute_indices())
-      if (this.source.patching != null)
-        this.connect(this.source.patching, () => this.compute_indices())
+
+    const connect_listeners = () => {
+      const fn = () => this.compute_indices()
+
+      if (this.source != null) {
+        this.connect(this.source.change, fn)
+
+        if (this.source instanceof ColumnarDataSource) {
+          this.connect(this.source.streaming, fn)
+          this.connect(this.source.patching, fn)
+        }
+      }
+    }
+
+    let initialized = this.source != null
+
+    if (initialized)
+      connect_listeners()
+    else {
+      this.connect(this.properties.source.change, () => {
+        if (!initialized) {
+          connect_listeners()
+          initialized = true
+        }
+      })
     }
   }
 
   compute_indices(): void {
-    let indices = (this.filters.map((filter) => filter.compute_indices(this.source)))
-    indices = ((() => {
-      const result = []
-      for (const inds of indices) {
-        if (inds != null) {
-          result.push(inds)
-        }
-      }
-      return result
-    })())
-    if (indices.length > 0) {
+    const indices = this.filters.map((filter) => filter.compute_indices(this.source))
+                                .filter((indices) => indices != null)
+
+    if (indices.length > 0)
       this.indices = intersection.apply(this, indices)
-    } else {
-      if (this.source instanceof ColumnarDataSource) {
-        this.indices = this.source.get_indices()
-      }
-    }
+    else if (this.source instanceof ColumnarDataSource)
+      this.indices = this.source.get_indices()
 
     this.indices_map_to_subset()
   }
@@ -92,7 +101,7 @@ export class CDSView extends Model {
   convert_selection_from_subset(selection_subset: Selection): Selection {
     const selection_full = new Selection()
     selection_full.update_through_union(selection_subset)
-    const indices_1d = (selection_subset.indices.map((i) => this.indices[i]))
+    const indices_1d = selection_subset.indices.map((i) => this.indices[i])
     selection_full.indices = indices_1d
     selection_full.image_indices = selection_subset.image_indices
     return selection_full
@@ -101,7 +110,7 @@ export class CDSView extends Model {
   convert_selection_to_subset(selection_full: Selection): Selection {
     const selection_subset = new Selection()
     selection_subset.update_through_union(selection_full)
-    const indices_1d = (selection_full.indices.map((i) => this.indices_map[i]))
+    const indices_1d = selection_full.indices.map((i) => this.indices_map[i])
     selection_subset.indices = indices_1d
     selection_subset.image_indices = selection_full.image_indices
     return selection_subset


### PR DESCRIPTION
This fixes the particular case of `CDSView.source`. The issue will be fixed completely in #8597.

fixes #8686
