### PR TITLE
Compute content size with subpixel precision

### DIFF
--- a/bokehjs/src/lib/core/dom.ts
+++ b/bokehjs/src/lib/core/dom.ts
@@ -213,14 +213,14 @@ export function outer_size(el: HTMLElement): Size {
 }
 
 export function content_size(el: HTMLElement): Size {
+  const {left, top} = el.getBoundingClientRect()
   const {padding} = extents(el)
-  const left = Math.ceil(padding.left)
-  const top = Math.ceil(padding.top)
   let width = 0
   let height = 0
   for (const child of children(el)) {
-    width = Math.max(width, child.offsetLeft - left + child.offsetWidth)
-    height = Math.max(height, child.offsetTop - top + child.offsetHeight)
+    const rect = child.getBoundingClientRect()
+    width = Math.max(width, Math.ceil(rect.left - left - padding.left + rect.width))
+    height = Math.max(height, Math.ceil(rect.top - top - padding.top + rect.height))
   }
   return {width, height}
 }

--- a/tests/baselines/examples/plotting/file/css_classes
+++ b/tests/baselines/examples/plotting/file/css_classes
@@ -1,4 +1,4 @@
-Column bbox=[0, 0, 310, 455]
+Column bbox=[0, 0, 310, 463]
   Paragraph bbox=[5, 5, 300, 38]
-  Div bbox=[5, 53, 272, 184]
-  Div bbox=[5, 247, 296, 203]
+  Div bbox=[5, 53, 276, 188]
+  Div bbox=[5, 251, 300, 207]


### PR DESCRIPTION
@philippjfr, can you try this out? This should resolve issue with unnecessary wrapping.

fixes #8654 