### PR TITLE
Change Whisker and Band parameters to UnitSpec

### DIFF
--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -30,7 +30,7 @@ from ..core.enums import (AngleUnits, Dimension, FontStyle, LegendClickPolicy, L
                           Orientation, RenderMode, SpatialUnits, VerticalAlign, TextAlign,
                           TooltipAttachment)
 from ..core.has_props import abstract
-from ..core.properties import (Angle, AngleSpec, Auto, Bool, ColorSpec, Datetime, Dict, DistanceSpec, Either,
+from ..core.properties import (Angle, AngleSpec, Auto, Bool, ColorSpec, Datetime, Dict, Either,
                                Enum, Float, FontSizeSpec, Include, Instance, Int, List, NumberSpec, Override,
                                Seq, String, StringSpec, Tuple, UnitsSpec, value)
 from ..core.property_mixins import FillProps, LineProps, TextProps

--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -32,7 +32,7 @@ from ..core.enums import (AngleUnits, Dimension, FontStyle, LegendClickPolicy, L
 from ..core.has_props import abstract
 from ..core.properties import (Angle, AngleSpec, Auto, Bool, ColorSpec, Datetime, Dict, DistanceSpec, Either,
                                Enum, Float, FontSizeSpec, Include, Instance, Int, List, NumberSpec, Override,
-                               Seq, String, StringSpec, Tuple, value)
+                               Seq, String, StringSpec, Tuple, UnitsSpec, value)
 from ..core.property_mixins import FillProps, LineProps, TextProps
 from ..core.validation import error
 from ..core.validation.errors import BAD_COLUMN_NAME, NON_MATCHING_DATA_SOURCES_ON_LEGEND_ITEM_RENDERERS
@@ -579,16 +579,15 @@ class Band(Annotation):
     ''' Render a filled area band along a dimension.
 
     '''
-
-    lower = DistanceSpec(help="""
+    lower = UnitsSpec(default=None, units_type=Enum(SpatialUnits), units_default="data", help="""
     The coordinates of the lower portion of the filled area band.
     """)
 
-    upper = DistanceSpec(help="""
+    upper = UnitsSpec(default=None, units_type=Enum(SpatialUnits), units_default="data", help="""
     The coordinates of the upper portion of the filled area band.
     """)
 
-    base = DistanceSpec(help="""
+    base = UnitsSpec(default=None, units_type=Enum(SpatialUnits), units_default="data", help="""
     The orthogonal coordinates of the upper and lower values.
     """)
 
@@ -1063,7 +1062,7 @@ class Whisker(Annotation):
 
     '''
 
-    lower = DistanceSpec(help="""
+    lower = UnitsSpec(default=None, units_type=Enum(SpatialUnits), units_default="data", help="""
     The coordinates of the lower end of the whiskers.
     """)
 
@@ -1071,7 +1070,7 @@ class Whisker(Annotation):
     Instance of ``ArrowHead``.
     """)
 
-    upper = DistanceSpec(help="""
+    upper = UnitsSpec(default=None, units_type=Enum(SpatialUnits), units_default="data", help="""
     The coordinates of the upper end of the whiskers.
     """)
 
@@ -1079,7 +1078,7 @@ class Whisker(Annotation):
     Instance of ``ArrowHead``.
     """)
 
-    base = DistanceSpec(help="""
+    base = UnitsSpec(default=None, units_type=Enum(SpatialUnits), units_default="data", help="""
     The orthogonal coordinates of the upper and lower values.
     """)
 

--- a/bokeh/models/tests/test_annotations.py
+++ b/bokeh/models/tests/test_annotations.py
@@ -430,6 +430,15 @@ def test_Whisker():
         "y_range_name"],
         LINE)
 
+def test_Whisker_and_Band_accept_negative_values():
+    whisker = Whisker(base=-1., lower=-1.5, upper=-0.5)
+    assert whisker.base == -1.
+    assert whisker.lower == -1.5
+    assert whisker.upper == -0.5
+    band = Band(base=-1., lower=-1.5, upper=-0.5)
+    assert band.base == -1.
+    assert band.lower == -1.5
+    assert band.upper == -0.5
 
 def test_can_add_multiple_glyph_renderers_to_legend_item():
     legend_item = LegendItem()


### PR DESCRIPTION
- [x] issues: fixes #8484
- [x] tests added / passed

I've changed the specs of `base`, `lower` and `upper` to a less restrictive `UnitSpec` as `DistanceSpec` did not permit negative values for these parameters. I'm not sure whether it would make sense to create a new spec class explicitly for this.