### PR TITLE
Stops the directory handler from bailing inappropriately.

### DIFF
--- a/bokeh/application/handlers/directory.py
+++ b/bokeh/application/handlers/directory.py
@@ -176,7 +176,7 @@ class DirectoryHandler(Handler):
         if they are found.
 
         '''
-        if self.failed:
+        if self._lifecycle_handler.failed:
             return
         # Note: we do NOT copy self._theme, which assumes the Theme
         # class is immutable (has no setters)


### PR DESCRIPTION
At the start of it's modify_doc, the directory handler checked it's `failed` property and returned immediately if it was true. The `failed` property checked the `failed` properties of the embedded `_main_handler` and `_lifecycle_handler`. Checking `_main_handler.failed` and bailing immediately meant that any failure in the user's script would never be cleared, and the bokeh server would have to be restarted. Now we only check `_lifecycle_handler.failed`, which we do want to bail on.

fixes #8577 

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [ ] issues: fixes #xxxx
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
