### PR TITLE
Make warnings configurable

### DIFF
--- a/bokeh/colors/util.py
+++ b/bokeh/colors/util.py
@@ -74,7 +74,7 @@ class _ColorGroupMeta(type):
 
     def __getattr__(self, v):
         from . import named
-        if v is not "_colors" and v in self._colors:
+        if v != "_colors" and v in self._colors:
             return getattr(named, v.lower())
         return super(_ColorGroupMeta, self).__getattr__(v)
 

--- a/bokeh/core/tests/test_validation.py
+++ b/bokeh/core/tests/test_validation.py
@@ -153,6 +153,43 @@ def test_silence_with_bad_input_and_check_warn(mock_warn, mock_error):
     assert not mock_error.called
     assert mock_warn.called
 
+@patch('bokeh.core.validation.check.log.error')
+@patch('bokeh.core.validation.check.log.warning')
+def test_silence_warning_already_in_silencers_is_ok(mock_warn, mock_error):
+    from bokeh.core.validation.warnings import EXT
+    m = Mod(foo=-10)
+    try:
+        silencers0= v.silence(EXT)  # turn the warning off
+        silencers1 = v.silence(EXT)  # do it a second time - no-op
+        assert len(silencers0) == 1
+        assert silencers0 == silencers1  # silencers is same as before
+
+        v.check_integrity([m])
+        assert not mock_error.called
+        assert not mock_warn.called
+    finally:
+        v.silence(EXT, False)  # turn the warning back on
+        v.check_integrity([m])
+        assert not mock_error.called
+        assert mock_warn.called
+
+@patch('bokeh.core.validation.check.log.error')
+@patch('bokeh.core.validation.check.log.warning')
+def test_silence_remove_warning_that_is_not_in_silencers_is_ok(mock_warn, mock_error):
+    from bokeh.core.validation.warnings import EXT
+    m = Mod(foo=-10)
+
+    silencers0 = v.silence(EXT)  # turn the warning off
+    assert len(silencers0) == 1
+
+    silencers1 = v.silence(EXT, False)  # turn the warning back on
+    silencers2 = v.silence(EXT, False)  # do it a second time - no-op
+    assert len(silencers1) == 0
+    assert silencers1 == silencers2
+
+    v.check_integrity([m])
+    assert not mock_error.called
+    assert mock_warn.called
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------

--- a/bokeh/core/tests/test_validation.py
+++ b/bokeh/core/tests/test_validation.py
@@ -126,6 +126,32 @@ def test_check_warn(mock_warn, mock_error):
     assert not mock_error.called
     assert mock_warn.called
 
+@patch('bokeh.core.validation.check.log.error')
+@patch('bokeh.core.validation.check.log.warning')
+def test_silence_and_check_warn(mock_warn, mock_error):
+    m = Mod(foo=-10)
+    try:
+        v.silence('EXT:W')  # turn the warning off
+        v.check_integrity([m])
+        assert not mock_error.called
+        assert not mock_warn.called
+    finally:
+        v.silence('EXT:W', False)  # turn the warning back on
+        v.check_integrity([m])
+        assert not mock_error.called
+        assert mock_warn.called
+
+@patch('bokeh.core.validation.check.log.error')
+@patch('bokeh.core.validation.check.log.warning')
+def test_silence_with_bad_name_and_check_warn(mock_warn, mock_error):
+    m = Mod(foo=-10)
+    with pytest.raises(ValueError, match=('Input to silence should be '
+                                          'name of warning - not code')):
+        v.silence(9999)
+    v.check_integrity([m])
+    assert not mock_error.called
+    assert mock_warn.called
+
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------

--- a/bokeh/core/tests/test_validation.py
+++ b/bokeh/core/tests/test_validation.py
@@ -146,9 +146,8 @@ def test_silence_and_check_warn(mock_warn, mock_error):
 @patch('bokeh.core.validation.check.log.warning')
 def test_silence_with_bad_input_and_check_warn(mock_warn, mock_error):
     m = Mod(foo=-10)
-    with pytest.raises(ValueError, match=("Input to silence should be a "
-                                          "warning object - not of type "
-                                          "<class 'str'>")):
+    with pytest.raises(ValueError, match=('Input to silence should be a '
+                                          'warning object')):
         v.silence('EXT:W')
     v.check_integrity([m])
     assert not mock_error.called

--- a/bokeh/core/tests/test_validation.py
+++ b/bokeh/core/tests/test_validation.py
@@ -129,25 +129,27 @@ def test_check_warn(mock_warn, mock_error):
 @patch('bokeh.core.validation.check.log.error')
 @patch('bokeh.core.validation.check.log.warning')
 def test_silence_and_check_warn(mock_warn, mock_error):
+    from bokeh.core.validation.warnings import EXT
     m = Mod(foo=-10)
     try:
-        v.silence('EXT:W')  # turn the warning off
+        v.silence(EXT)  # turn the warning off
         v.check_integrity([m])
         assert not mock_error.called
         assert not mock_warn.called
     finally:
-        v.silence('EXT:W', False)  # turn the warning back on
+        v.silence(EXT, False)  # turn the warning back on
         v.check_integrity([m])
         assert not mock_error.called
         assert mock_warn.called
 
 @patch('bokeh.core.validation.check.log.error')
 @patch('bokeh.core.validation.check.log.warning')
-def test_silence_with_bad_name_and_check_warn(mock_warn, mock_error):
+def test_silence_with_bad_input_and_check_warn(mock_warn, mock_error):
     m = Mod(foo=-10)
-    with pytest.raises(ValueError, match=('Input to silence should be '
-                                          'name of warning - not code')):
-        v.silence(9999)
+    with pytest.raises(ValueError, match=("Input to silence should be a "
+                                          "warning object - not of type "
+                                          "<class 'str'>")):
+        v.silence('EXT:W')
     v.check_integrity([m])
     assert not mock_error.called
     assert mock_warn.called

--- a/bokeh/core/validation/__init__.py
+++ b/bokeh/core/validation/__init__.py
@@ -22,6 +22,18 @@ To assist with diagnosing potential problems, Bokeh performs a validation step
 when outputting a visualization for display. This module contains error and
 warning codes as well as helper functions for defining validation checks.
 
+One use case for warnings is to loudly point users in the right direction
+when they accidentally do something that they probably didn't mean to do - this
+is the case for EMPTY_LAYOUT for instance. Since warnings don't necessarily
+indicate misuse, they are configurable. To silence a warning, use the silence
+function provided.
+
+.. code-block:: python
+
+    >>> from bokeh.core.validation import silence
+    >>> from bokeh.core.validation.warnings import EMPTY_LAYOUT
+    >>> silence(EMPTY_LAYOUT, True)
+
 '''
 
 #-----------------------------------------------------------------------------

--- a/bokeh/core/validation/__init__.py
+++ b/bokeh/core/validation/__init__.py
@@ -41,7 +41,7 @@ log = logging.getLogger(__name__)
 # External imports
 
 # Bokeh imports
-from .check import check_integrity
+from .check import check_integrity, silence
 from .decorators import error, warning
 
 #-----------------------------------------------------------------------------

--- a/bokeh/core/validation/check.py
+++ b/bokeh/core/validation/check.py
@@ -48,7 +48,7 @@ def silence(name, silence=True):
         silence (bool) : Whether or not to silence the warning
 
     Returns:
-        set conatining names of silenced warnings
+        A set containing the names of all silenced warnings
 
     This function adds or removes names from a set of silencers which
     is refered to when running ``check_integrity``. If a warning with a particular

--- a/bokeh/core/validation/check.py
+++ b/bokeh/core/validation/check.py
@@ -29,14 +29,49 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
+__silencers__ = set()
 
 __all__ = (
     'check_integrity',
+    'silence'
 )
 
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
+
+def silence(name, silence=True):
+    ''' Silence named warning on all Bokeh models.
+
+    Args:
+        name (str) : Names of warnings to silence
+        silence (bool) : Whether or not to silence the warning
+
+    Returns:
+        set conatining names of silenced warnings
+
+    This function adds or removes names from a set of silencers which
+    is refered to when running ``check_integrity``. If a warning with a particular
+    name is added to the silencers - then it will never be raised.
+
+    .. code-block:: python
+
+        >>> silence('EMPTY_LAYOUT', True)
+        {'EMPTY_LAYOUT'}
+
+        >>> empty_row = Row
+
+        >>> check_integrity([empty_row])
+
+    '''
+    if isinstance(name, int):
+        raise ValueError('Input to silence should be name of warning - not code')
+    if silence:
+        __silencers__.add(name)
+    else:
+        __silencers__.remove(name)
+    return __silencers__
+
 
 def check_integrity(models):
     ''' Apply validation and integrity checks to a collection of Bokeh models.
@@ -75,7 +110,9 @@ def check_integrity(models):
         log.error("E-%d (%s): %s: %s" % msg)
 
     for msg in sorted(messages['warning']):
-        log.warning("W-%d (%s): %s: %s" % msg)
+        code, name, desc, obj = msg
+        if name not in __silencers__:
+            log.warning("W-%d (%s): %s: %s" % msg)
 
     # This will be turned on in a future release
     # if len(messages['error']) or (len(messages['warning']) and settings.strict()):

--- a/bokeh/core/validation/check.py
+++ b/bokeh/core/validation/check.py
@@ -74,7 +74,7 @@ def silence(warning, silence=True):
                          '- not of type {}'.format(type(warning)))
     if silence:
         __silencers__.add(warning)
-    else:
+    elif warning in __silencers__:
         __silencers__.remove(warning)
     return __silencers__
 

--- a/bokeh/core/validation/check.py
+++ b/bokeh/core/validation/check.py
@@ -41,10 +41,10 @@ __all__ = (
 #-----------------------------------------------------------------------------
 
 def silence(warning, silence=True):
-    ''' Silence warning on all Bokeh models.
+    ''' Silence a particular warning on all Bokeh models.
 
     Args:
-        warning (Warning) : Warning to silence
+        warning (Warning) : Bokeh warning to silence
         silence (bool) : Whether or not to silence the warning
 
     Returns:
@@ -55,13 +55,18 @@ def silence(warning, silence=True):
     is added to the silencers - then it will never be raised.
 
     .. code-block:: python
+
         >>> from bokeh.core.validation.warnings import EMPTY_LAYOUT
-        >>> silence(EMPTY_LAYOUT, True)
+        >>> bokeh.core.validation.silence(EMPTY_LAYOUT, True)
         {1002}
 
-        >>> empty_row = Row
+    To turn a warning back on use the same method but with the silence
+    argument set to false
 
-        >>> check_integrity([empty_row])
+    .. code-block:: python
+
+        >>> bokeh.core.validation.silence(EMPTY_LAYOUT, False)
+        set()
 
     '''
     if not isinstance(warning, int):

--- a/bokeh/core/validation/check.py
+++ b/bokeh/core/validation/check.py
@@ -40,36 +40,37 @@ __all__ = (
 # General API
 #-----------------------------------------------------------------------------
 
-def silence(name, silence=True):
-    ''' Silence named warning on all Bokeh models.
+def silence(warning, silence=True):
+    ''' Silence warning on all Bokeh models.
 
     Args:
-        name (str) : Names of warnings to silence
+        warning (Warning) : Warning to silence
         silence (bool) : Whether or not to silence the warning
 
     Returns:
-        A set containing the names of all silenced warnings
+        A set containing the all silenced warnings
 
-    This function adds or removes names from a set of silencers which
-    is refered to when running ``check_integrity``. If a warning with a particular
-    name is added to the silencers - then it will never be raised.
+    This function adds or removes warnings from a set of silencers which
+    is refered to when running ``check_integrity``. If a warning
+    is added to the silencers - then it will never be raised.
 
     .. code-block:: python
-
-        >>> silence('EMPTY_LAYOUT', True)
-        {'EMPTY_LAYOUT'}
+        >>> from bokeh.core.validation.warnings import EMPTY_LAYOUT
+        >>> silence(EMPTY_LAYOUT, True)
+        {1002}
 
         >>> empty_row = Row
 
         >>> check_integrity([empty_row])
 
     '''
-    if isinstance(name, int):
-        raise ValueError('Input to silence should be name of warning - not code')
+    if not isinstance(warning, int):
+        raise ValueError('Input to silence should be a warning object '
+                         '- not of type {}'.format(type(warning)))
     if silence:
-        __silencers__.add(name)
+        __silencers__.add(warning)
     else:
-        __silencers__.remove(name)
+        __silencers__.remove(warning)
     return __silencers__
 
 
@@ -111,7 +112,7 @@ def check_integrity(models):
 
     for msg in sorted(messages['warning']):
         code, name, desc, obj = msg
-        if name not in __silencers__:
+        if code not in __silencers__:
             log.warning("W-%d (%s): %s: %s" % msg)
 
     # This will be turned on in a future release

--- a/bokeh/models/tests/test_callbacks.py
+++ b/bokeh/models/tests/test_callbacks.py
@@ -44,7 +44,7 @@ def test_js_callback():
 
     cb = CustomJS(code="foo();", args=dict(x=3))
     assert 'foo()' in cb.code
-    assert cb.args['x'] is 3
+    assert cb.args['x'] == 3
 
     with raises(AttributeError):  # kwargs not supported
         CustomJS(code="foo();", x=slider)
@@ -64,7 +64,7 @@ def test_py_callback():
         foo()
     cb = CustomJS.from_py_func(cb)
     assert 'foo()' in cb.code
-    assert cb.args['x'] is 4
+    assert cb.args['x'] == 4
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/tests/test_transform.py
+++ b/bokeh/tests/test_transform.py
@@ -101,7 +101,7 @@ class Test_factor_cmap(object):
         assert t['transform'].palette == ["red", "green"]
         assert t['transform'].factors == ["foo", "bar"]
         assert t['transform'].start == 1
-        assert t['transform'].end is 2
+        assert t['transform'].end == 2
         assert t['transform'].nan_color == "pink"
 
     def test_defaults(self):

--- a/sphinx/source/docs/reference/core/validation.rst
+++ b/sphinx/source/docs/reference/core/validation.rst
@@ -33,6 +33,8 @@ of Bokeh models, or mark methods on Models as warning or error checks.
 
 .. autofunction:: bokeh.core.validation.check.check_integrity
 
+.. autofunction:: bokeh.core.validation.check.silence
+
 .. autofunction:: bokeh.core.validation.decorators.error
 
 .. autofunction:: bokeh.core.validation.decorators.warning


### PR DESCRIPTION
Implementing configurable warning silencer as suggested by @bryevdv: https://github.com/bokeh/bokeh/issues/8725#issuecomment-470586707.

- [x] issues: fixes #8725
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)

## To try it

```python
import bokeh
from bokeh.layouts import row
from bokeh.io import output_notebook, show

output_notebook(verbose=True)
# create an empty layout object
empty_row = row([])

# turn the warning off
bokeh.core.validation.silence('EMPTY_LAYOUT')
# see that there is no warning
show(empty_row) 

# turn the warning back on
bokeh.core.validation.silence('EMPTY_LAYOUT', False)
# see that there is a warning
show(empty_row)
```

## Screenshot of use case
<img width="730" alt="Screen Shot 2019-03-11 at 1 46 18 PM" src="https://user-images.githubusercontent.com/4806877/54146513-7ed6a700-4406-11e9-9f9f-1022602c1bc5.png">
