### PR TITLE
Refactored continuous color mappers with .scan and .cmap

### DIFF
--- a/bokehjs/src/lib/models/mappers/continuous_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/continuous_color_mapper.ts
@@ -46,7 +46,7 @@ export abstract class ContinuousColorMapper extends ColorMapper {
 
       if (isNaN(d))
         values[i] = nan_color
-      else 
+      else
         values[i] = this.cmap(d, palette, low_color, high_color, scan_data)
     }
   }

--- a/bokehjs/src/lib/models/mappers/continuous_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/continuous_color_mapper.ts
@@ -33,7 +33,7 @@ export abstract class ContinuousColorMapper extends ColorMapper {
     })
   }
 
-  protected abstract scan<T>(data: Arrayable<number>, palette: Arrayable<T>) : any
+  protected abstract scan<T>(data: Arrayable<number>, palette: Arrayable<T>): unknown
 
   protected _v_compute<T>(data: Arrayable<number>, values: Arrayable<T>,
     palette: Arrayable<T>, colors: {nan_color: T, low_color?: T, high_color?: T}): void {

--- a/bokehjs/src/lib/models/mappers/continuous_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/continuous_color_mapper.ts
@@ -45,10 +45,9 @@ export abstract class ContinuousColorMapper extends ColorMapper {
     for (let i = 0, end = data.length; i < end; i++) {
       const d = data[i]
 
-      if (isNaN(d)) {
+      if (isNaN(d))
         values[i] = nan_color
-        continue
-      }
+      else 
         values[i] = this.cmap(d, palette, low_color, high_color, scan_data)
     }
   }

--- a/bokehjs/src/lib/models/mappers/continuous_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/continuous_color_mapper.ts
@@ -33,6 +33,26 @@ export abstract class ContinuousColorMapper extends ColorMapper {
     })
   }
 
+  protected abstract scan<T>(data: Arrayable<number>, palette: Arrayable<T>) : any
+
+
+  protected _v_compute<T>(data: Arrayable<number>, values: Arrayable<T>,
+    palette: Arrayable<T>, colors: {nan_color: T, low_color?: T, high_color?: T}): void {
+
+    const {nan_color, low_color, high_color} = colors
+    const scan_data = this.scan(data, palette)
+
+    for (let i = 0, end = data.length; i < end; i++) {
+      const d = data[i]
+
+      if (isNaN(d)) {
+        values[i] = nan_color
+        continue
+      }
+        values[i] = this.cmap(d, palette, low_color, high_color, scan_data)
+    }
+  }
+
   protected _colors<T>(conv: (c: Color) => T): {nan_color: T, low_color?: T, high_color?: T} {
     return {
       ...super._colors(conv),
@@ -40,8 +60,7 @@ export abstract class ContinuousColorMapper extends ColorMapper {
       high_color: this.high_color != null ? conv(this.high_color) : undefined,
     }
   }
+  protected abstract cmap<T>(d : number,  palette: Arrayable<T>,  low_color: T, high_color: T, scan_data: any) : any
 
-  protected abstract _v_compute<T>(data: Arrayable<number>, values: Arrayable<T>,
-    palette: Arrayable<T>, colors: {nan_color: T, low_color?: T, high_color?: T}): void
 }
 ContinuousColorMapper.initClass()

--- a/bokehjs/src/lib/models/mappers/continuous_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/continuous_color_mapper.ts
@@ -35,7 +35,6 @@ export abstract class ContinuousColorMapper extends ColorMapper {
 
   protected abstract scan<T>(data: Arrayable<number>, palette: Arrayable<T>) : any
 
-
   protected _v_compute<T>(data: Arrayable<number>, values: Arrayable<T>,
     palette: Arrayable<T>, colors: {nan_color: T, low_color?: T, high_color?: T}): void {
 

--- a/bokehjs/src/lib/models/mappers/linear_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/linear_color_mapper.ts
@@ -16,7 +16,6 @@ export interface LinearScanData {
   normed_interval: number
 }
 
-
 export interface LinearColorMapper extends LinearColorMapper.Attrs {}
 
 export class LinearColorMapper extends ContinuousColorMapper {
@@ -37,9 +36,7 @@ export class LinearColorMapper extends ContinuousColorMapper {
     const norm_factor = 1 / (high - low)
     const normed_interval = 1 / palette.length
  
-    return {high:high, low:low,
-            norm_factor:norm_factor,
-            normed_interval:normed_interval}
+    return {high, low, norm_factor, normed_interval}
   }
   
   protected cmap<T>(d : number,  palette: Arrayable<T>,  low_color: T,

--- a/bokehjs/src/lib/models/mappers/linear_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/linear_color_mapper.ts
@@ -9,6 +9,14 @@ export namespace LinearColorMapper {
   export type Props = ContinuousColorMapper.Props
 }
 
+export interface LinearScanData {
+  high: number
+  low: number
+  norm_factor: number
+  normed_interval: number
+}
+
+
 export interface LinearColorMapper extends LinearColorMapper.Attrs {}
 
 export class LinearColorMapper extends ContinuousColorMapper {
@@ -22,42 +30,36 @@ export class LinearColorMapper extends ContinuousColorMapper {
     this.prototype.type = "LinearColorMapper"
   }
 
-  protected _v_compute<T>(data: Arrayable<number>, values: Arrayable<T>,
-      palette: Arrayable<T>, colors: {nan_color: T, low_color?: T, high_color?: T}): void {
-    const {nan_color, low_color, high_color} = colors
-
+    protected scan<T>(data: Arrayable<number>, palette: Arrayable<T>) : LinearScanData {
     const low = this.low != null ? this.low : min(data)
     const high = this.high != null ? this.high : max(data)
-    const max_key = palette.length - 1
-
+ 
     const norm_factor = 1 / (high - low)
     const normed_interval = 1 / palette.length
-
-    for (let i = 0, end = data.length; i < end; i++) {
-      const d = data[i]
-
-      if (isNaN(d)) {
-        values[i] = nan_color
-        continue
-      }
-
-      // This handles the edge case where d == high, since the code below maps
-      // values exactly equal to high to palette.length, which is greater than
-      // max_key
-      if (d == high) {
-        values[i] = palette[max_key]
-        continue
-      }
-
-      const normed_d = (d - low) * norm_factor
-      const key = Math.floor(normed_d / normed_interval)
-      if (key < 0)
-        values[i] = low_color != null ? low_color : palette[0]
-      else if (key > max_key)
-        values[i] = high_color != null ? high_color : palette[max_key]
-      else
-        values[i] = palette[key]
+ 
+    return {high:high, low:low,
+            norm_factor:norm_factor,
+            normed_interval:normed_interval}
+  }
+  
+  protected cmap<T>(d : number,  palette: Arrayable<T>,  low_color: T,
+                    high_color: T, scan_data: LinearScanData) : T {
+    // This handles the edge case where d == high, since the code below maps
+    // values exactly equal to high to palette.length, which is greater than
+    // max_key
+    const max_key = palette.length - 1
+    if (d == scan_data.high) {
+      return palette[max_key]
     }
+ 
+    const normed_d = (d - scan_data.low) * scan_data.norm_factor
+    const key = Math.floor(normed_d / scan_data.normed_interval)
+    if (key < 0)
+      return low_color != null ? low_color : palette[0]
+    else if (key > max_key)
+      return high_color != null ? high_color : palette[max_key]
+    else
+      return palette[key]
   }
 }
 LinearColorMapper.initClass()

--- a/bokehjs/src/lib/models/mappers/linear_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/linear_color_mapper.ts
@@ -32,13 +32,13 @@ export class LinearColorMapper extends ContinuousColorMapper {
     protected scan<T>(data: Arrayable<number>, palette: Arrayable<T>) : LinearScanData {
     const low = this.low != null ? this.low : min(data)
     const high = this.high != null ? this.high : max(data)
- 
+
     const norm_factor = 1 / (high - low)
     const normed_interval = 1 / palette.length
- 
+
     return {high, low, norm_factor, normed_interval}
   }
-  
+
   protected cmap<T>(d : number,  palette: Arrayable<T>,  low_color: T,
                     high_color: T, scan_data: LinearScanData) : T {
     // This handles the edge case where d == high, since the code below maps
@@ -48,7 +48,7 @@ export class LinearColorMapper extends ContinuousColorMapper {
     if (d == scan_data.high) {
       return palette[max_key]
     }
- 
+
     const normed_d = (d - scan_data.low) * scan_data.norm_factor
     const key = Math.floor(normed_d / scan_data.normed_interval)
     if (key < 0)

--- a/bokehjs/src/lib/models/mappers/log_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/log_color_mapper.ts
@@ -43,21 +43,18 @@ export class LogColorMapper extends ContinuousColorMapper {
 
   protected cmap<T>(d : number,  palette: Arrayable<T>,  low_color: T,
                     high_color: T, scan_data: LogScanData) : T {
-    // This handles the edge case where d == high, since the code below maps
-    // values exactly equal to high to palette.length, which is greater than
-    // max_key
     const max_key = palette.length - 1
 
     if (d > scan_data.high) {
       return high_color != null ? high_color : palette[max_key]
     }
-    if (d == scan_data.high) {
+    // This handles the edge case where d == high, since the code below maps
+    // values exactly equal to high to palette.length, which is greater than
+    // max_key
+    if (d == scan_data.high)
       return palette[max_key]
-    }
-
-    if (d < scan_data.low) {
+    else if(d < scan_data.low)
       return low_color != null ? low_color : palette[0]
-    }
 
      // Get the key
      const log = log1p(d) - log1p(scan_data.low)  // subtract the low offset
@@ -65,7 +62,8 @@ export class LogColorMapper extends ContinuousColorMapper {
 
      // Deal with upper bound
      if (key > max_key) {
-       key = max_key }
+       key = max_key
+     }
 
      return palette[key]
   }

--- a/bokehjs/src/lib/models/mappers/log_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/log_color_mapper.ts
@@ -33,6 +33,7 @@ export class LogColorMapper extends ContinuousColorMapper {
   }
 
   protected scan<T>(data: Arrayable<number>, palette: Arrayable<T>) : LogScanData {
+    const n = palette.length
     const low = this.low != null ? this.low : min(data)
     const high = this.high != null ? this.high : max(data)
     const scale = n / (log1p(high) - log1p(low))  // subtract the low offset

--- a/bokehjs/src/lib/models/mappers/log_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/log_color_mapper.ts
@@ -7,13 +7,11 @@ import * as p from "core/properties"
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log1p.
 const log1p = Math.log1p != null ? Math.log1p : (x: number) => Math.log(1 + x)
 
-
 export interface LogScanData {
   high: number
   low: number
   scale: number
 }
-
 
 export namespace LogColorMapper {
   export type Attrs = p.AttrsOf<Props>
@@ -35,12 +33,11 @@ export class LogColorMapper extends ContinuousColorMapper {
   }
 
   protected scan<T>(data: Arrayable<number>, palette: Arrayable<T>) : LogScanData {
-    let n = palette.length
     const low = this.low != null ? this.low : min(data)
     const high = this.high != null ? this.high : max(data)
     const scale = n / (log1p(high) - log1p(low))  // subtract the low offset
         
-    return {high:high, low:low, scale:scale}
+    return {high, low, scale}
   }
 
   protected cmap<T>(d : number,  palette: Arrayable<T>,  low_color: T,
@@ -53,7 +50,7 @@ export class LogColorMapper extends ContinuousColorMapper {
     if (d > scan_data.high) {
       return high_color != null ? high_color : palette[max_key]
     }
-    else if (d == scan_data.high) {
+    if (d == scan_data.high) {
       return palette[max_key]
     }
      

--- a/bokehjs/src/lib/models/mappers/log_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/log_color_mapper.ts
@@ -52,14 +52,14 @@ export class LogColorMapper extends ContinuousColorMapper {
 
     if (d > scan_data.high) {
       return high_color != null ? high_color : palette[max_key]
-     }
-     else if (d == scan_data.high) {
-       return palette[max_key]
-     }
+    }
+    else if (d == scan_data.high) {
+      return palette[max_key]
+    }
      
-     if (d < scan_data.low) {
-       return low_color != null ? low_color : palette[0]
-     }
+    if (d < scan_data.low) {
+      return low_color != null ? low_color : palette[0]
+    }
      
      // Get the key
      const log = log1p(d) - log1p(scan_data.low)  // subtract the low offset

--- a/bokehjs/src/lib/models/mappers/log_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/log_color_mapper.ts
@@ -37,7 +37,7 @@ export class LogColorMapper extends ContinuousColorMapper {
     const low = this.low != null ? this.low : min(data)
     const high = this.high != null ? this.high : max(data)
     const scale = n / (log1p(high) - log1p(low))  // subtract the low offset
-        
+
     return {high, low, scale}
   }
 
@@ -54,19 +54,19 @@ export class LogColorMapper extends ContinuousColorMapper {
     if (d == scan_data.high) {
       return palette[max_key]
     }
-     
+
     if (d < scan_data.low) {
       return low_color != null ? low_color : palette[0]
     }
-     
+
      // Get the key
      const log = log1p(d) - log1p(scan_data.low)  // subtract the low offset
      let key = Math.floor(log * scan_data.scale)
-     
+
      // Deal with upper bound
      if (key > max_key) {
        key = max_key }
-     
+
      return palette[key]
   }
 }

--- a/bokehjs/src/lib/models/mappers/log_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/log_color_mapper.ts
@@ -7,6 +7,14 @@ import * as p from "core/properties"
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log1p.
 const log1p = Math.log1p != null ? Math.log1p : (x: number) => Math.log(1 + x)
 
+
+export interface LogScanData {
+  high: number
+  low: number
+  scale: number
+}
+
+
 export namespace LogColorMapper {
   export type Attrs = p.AttrsOf<Props>
 
@@ -26,53 +34,43 @@ export class LogColorMapper extends ContinuousColorMapper {
     this.prototype.type = "LogColorMapper"
   }
 
-  protected _v_compute<T>(data: Arrayable<number>, values: Arrayable<T>,
-      palette: Arrayable<T>, colors: {nan_color: T, low_color?: T, high_color?: T}): void {
-    const {nan_color, low_color, high_color} = colors
-
-    const n = palette.length
+  protected scan<T>(data: Arrayable<number>, palette: Arrayable<T>) : LogScanData {
+    let n = palette.length
     const low = this.low != null ? this.low : min(data)
     const high = this.high != null ? this.high : max(data)
     const scale = n / (log1p(high) - log1p(low))  // subtract the low offset
+        
+    return {high:high, low:low, scale:scale}
+  }
+
+  protected cmap<T>(d : number,  palette: Arrayable<T>,  low_color: T,
+                    high_color: T, scan_data: LogScanData) : T {
+    // This handles the edge case where d == high, since the code below maps
+    // values exactly equal to high to palette.length, which is greater than
+    // max_key
     const max_key = palette.length - 1
 
-    for (let i = 0, end = data.length; i < end; i++) {
-      const d = data[i]
-
-      // Check NaN
-      if (isNaN(d)) {
-        values[i] = nan_color
-        continue
-      }
-
-      if (d > high) {
-        values[i] = high_color != null ? high_color : palette[max_key]
-        continue
-      }
-
-      // This handles the edge case where d == high, since the code below maps
-      // values exactly equal to high to palette.length, which is greater than
-      // max_key
-      if (d == high) {
-        values[i] = palette[max_key]
-        continue
-      }
-
-      if (d < low) {
-        values[i] = low_color != null ? low_color : palette[0]
-        continue
-      }
-
-      // Get the key
-      const log = log1p(d) - log1p(low)  // subtract the low offset
-      let key = Math.floor(log * scale)
-
-      // Deal with upper bound
-      if (key > max_key)
-        key = max_key
-
-      values[i] = palette[key]
-    }
+    if (d > scan_data.high) {
+      return high_color != null ? high_color : palette[max_key]
+     }
+     else if (d == scan_data.high) {
+       return palette[max_key]
+     }
+     
+     if (d < scan_data.low) {
+       return low_color != null ? low_color : palette[0]
+     }
+     
+     // Get the key
+     const log = log1p(d) - log1p(scan_data.low)  // subtract the low offset
+     let key = Math.floor(log * scan_data.scale)
+     
+     // Deal with upper bound
+     if (key > max_key) {
+       key = max_key }
+     
+     return palette[key]
   }
 }
+
 LogColorMapper.initClass()


### PR DESCRIPTION
This PR implements a refactor of continuous colormappers that I think makes the structure of the code clearer and will make it easier to add new colormappers to Bokeh (addressing https://github.com/pyviz/datashader/issues/609). I will submit another PR based off of this one shortly adding these new colormappers, starting with a cubic colormapper. Working on colormappers will also let me address https://github.com/bokeh/bokeh/issues/8724.

The core insight here is that that all continuous colormappers do at least two scans of the data 1) an initial scan to collect information about the data being colormapped - this can be as simple as finding the min/max of the data 2) a loop over the data that actually applies the colormapping based on the value being colormapped and the information collected in step 1.

These two steps are implemented by a `scan` method which does the initial collection of the information needed to do the colormapping and a `cmap` method which uses this information to colormap a specific value.

Other than making things clearer, one of the advantages of splitting the color mapping process into two methods is that you'll be able to implement new colormappers just by implementing a new `scan` method while inheriting a generic `cmap`method from a base class. This isn't demonstrated in this PR but will be demonstrated in the follow up PR that adds new colormappers.

This PR keeps the existing core machinery of both the linear and log color mappers intact. In the next PR it will be possible to use a more generic approach throughout.

