### PR TITLE
make angle_between strict

### DIFF
--- a/bokehjs/src/lib/core/util/math.ts
+++ b/bokehjs/src/lib/core/util/math.ts
@@ -15,13 +15,12 @@ export function angle_dist(lhs: number, rhs: number): number {
 }
 
 export function angle_between(mid: number, lhs: number, rhs: number, direction: Direction): boolean {
-  const norm_mid = angle_norm(mid)
   const d = angle_dist(lhs, rhs)
+  if (d == 0)
+    return false
+  const norm_mid = angle_norm(mid)
   const cond = angle_dist(lhs, norm_mid) <= d && angle_dist(norm_mid, rhs) <= d
-  if (direction == Direction.anticlock)
-    return !cond
-  else
-    return cond
+  return (direction == Direction.clock) ? cond : !cond
 }
 
 export function random(): number {

--- a/bokehjs/test/core/util/math.ts
+++ b/bokehjs/test/core/util/math.ts
@@ -4,42 +4,67 @@ import * as math from "core/util/math"
 
 describe("math module", () => {
 
-  it("should return angle normalized between 0 and 2*Math.PI inclusive", () => {
-    expect(math.angle_norm(3*Math.PI)).to.be.closeTo(Math.PI, 0.000001)
-    expect(math.angle_norm(-3*Math.PI)).to.be.closeTo(Math.PI, 0.000001)
-    expect(math.angle_norm(0)).to.be.closeTo(0, 0.000001)
+  describe("angle_norm", () => {
+
+    it("should return angle normalized between 0 and 2*Math.PI inclusive", () => {
+      expect(math.angle_norm(3*Math.PI)).to.be.closeTo(Math.PI, 0.000001)
+      expect(math.angle_norm(-3*Math.PI)).to.be.closeTo(Math.PI, 0.000001)
+      expect(math.angle_norm(0)).to.be.closeTo(0, 0.000001)
+    })
+
   })
 
-  it("should return the distance between two angles as a positive radian", () => {
-    expect(math.angle_dist(2.5*Math.PI, -2.5*Math.PI)).to.be.closeTo(Math.PI, 0.000001)
-    expect(math.angle_dist(-2.5*Math.PI, 2.5*Math.PI)).to.be.closeTo(Math.PI, 0.000001)
+  describe("angle_dist", () => {
+
+    it("should return the distance between two angles as a positive radian", () => {
+      expect(math.angle_dist(2.5*Math.PI, -2.5*Math.PI)).to.be.closeTo(Math.PI, 0.000001)
+      expect(math.angle_dist(-2.5*Math.PI, 2.5*Math.PI)).to.be.closeTo(Math.PI, 0.000001)
+    })
+
   })
 
-  it("should return true if `mid` angle between `lhs` and `rhs`", () => {
-    expect(math.angle_between(0, -1, 1, 1)).to.be.equal(true)
-    expect(math.angle_between(0, -1, 1, 0)).to.be.equal(false)
+  describe("angle_between", () => {
+
+    it("should return true if `mid` angle strictly between `lhs` and `rhs`", () => {
+      expect(math.angle_between(0, -1, 1, 1)).to.be.equal(true)
+      expect(math.angle_between(0, -1, 1, 0)).to.be.equal(false)
+    })
+
+    it("should return false if `mid` == `lhs` == `rhs`", () => {
+      expect(math.angle_between(10, 10, 10, 1)).to.be.equal(false)
+      expect(math.angle_between(10, 10, 10, 0)).to.be.equal(false)
+    })
+
   })
 
-  it("should return the arctangent between 2 (x,y) points", () => {
-    expect(math.atan2([0,0],[0,1])).to.be.closeTo(Math.PI/2, 0.0000001) // vertical up
-    expect(math.atan2([0,0],[0,-1])).to.be.closeTo(-Math.PI/2, 0.0000001) // vertical down
-    expect(math.atan2([0,0],[1,0])).to.be.closeTo(0, 0.0000001) // horizontal right
-    expect(math.atan2([0,0],[-1,0])).to.be.closeTo(Math.PI, 0.0000001) // horizontal left
-    expect(math.atan2([1,1],[2,2])).to.be.closeTo(Math.PI/4, 0.0000001)
+  describe("atan2", () => {
+
+    it("should return the arctangent between 2 (x,y) points", () => {
+      expect(math.atan2([0,0],[0,1])).to.be.closeTo(Math.PI/2, 0.0000001) // vertical up
+      expect(math.atan2([0,0],[0,-1])).to.be.closeTo(-Math.PI/2, 0.0000001) // vertical down
+      expect(math.atan2([0,0],[1,0])).to.be.closeTo(0, 0.0000001) // horizontal right
+      expect(math.atan2([0,0],[-1,0])).to.be.closeTo(Math.PI, 0.0000001) // horizontal left
+      expect(math.atan2([1,1],[2,2])).to.be.closeTo(Math.PI/4, 0.0000001)
+    })
+
   })
 
-  it("should clamp between min and max values", () => {
-    expect(math.clamp(0, -1, 1)).to.be.equal(0)
-    expect(math.clamp(1, -1, 1)).to.be.equal(1)
-    expect(math.clamp(2, -1, 1)).to.be.equal(1)
-    expect(math.clamp(-1, -1, 1)).to.be.equal(-1)
-    expect(math.clamp(-2, -1, 1)).to.be.equal(-1)
+  describe("clamp", () => {
 
-    expect(math.clamp(0, 1, 2)).to.be.equal(1)
-    expect(math.clamp(1, 1, 2)).to.be.equal(1)
-    expect(math.clamp(-1, 1, 2)).to.be.equal(1)
-    expect(math.clamp(1.5, 1, 2)).to.be.equal(1.5)
-    expect(math.clamp(2, 1, 2)).to.be.equal(2)
-    expect(math.clamp(3, 1, 2)).to.be.equal(2)
+    it("should clamp between min and max values", () => {
+      expect(math.clamp(0, -1, 1)).to.be.equal(0)
+      expect(math.clamp(1, -1, 1)).to.be.equal(1)
+      expect(math.clamp(2, -1, 1)).to.be.equal(1)
+      expect(math.clamp(-1, -1, 1)).to.be.equal(-1)
+      expect(math.clamp(-2, -1, 1)).to.be.equal(-1)
+
+      expect(math.clamp(0, 1, 2)).to.be.equal(1)
+      expect(math.clamp(1, 1, 2)).to.be.equal(1)
+      expect(math.clamp(-1, 1, 2)).to.be.equal(1)
+      expect(math.clamp(1.5, 1, 2)).to.be.equal(1.5)
+      expect(math.clamp(2, 1, 2)).to.be.equal(2)
+      expect(math.clamp(3, 1, 2)).to.be.equal(2)
+    })
+
   })
 })


### PR DESCRIPTION
- [x] issues: fixes #8742
- [x] tests added / passed

This PR addresses #8742 by making `angle_between` be strict, i.e. it will return false if the `start` and `end` angles are identical. 

New result of MRE with this change:

<img width="623" alt="Screen Shot 2019-03-16 at 12 39 42 PM" src="https://user-images.githubusercontent.com/1078448/54480771-cdf75000-47e9-11e9-944d-a01faa667aa3.png">

For reference, as of this PR, `angle_between` is only used in the `wedge` and `annular_wedge` glyphs:

```
❯ grin angle_between
./core/util/math.ts:
   17 : export function angle_between(mid: number, lhs: number, rhs: number, direction: Direction): boolean {
./models/glyphs/annular_wedge.ts:
    9 : import {angle_between} from "core/util/math"
  127 :       if (angle_between(-angle, -this._start_angle[i], -this._end_angle[i], direction)) {
./models/glyphs/wedge.ts:
   10 : import {angle_between} from "core/util/math"
  104 :       if (angle_between(-angle, -this._start_angle[i], -this._end_angle[i], direction)) {
```
