### PR TITLE
Specialize visuals 'doit' getters

### DIFF
--- a/bokehjs/src/lib/core/visuals.ts
+++ b/bokehjs/src/lib/core/visuals.ts
@@ -12,18 +12,15 @@ export abstract class ContextProperties {
 
   // prototype {
   attrs: string[]
-  do_attr: string
   // }
 
   readonly cache: {[key: string]: any} = {}
-  readonly doit: boolean
+
+  abstract get doit(): boolean
 
   all_indices: number[]
 
   constructor(readonly obj: HasProps, readonly prefix: string = "") {
-    const do_spec = obj.properties[prefix + this.do_attr].spec
-    this.doit = do_spec.value !== null // XXX: can't be `undefined`, see TODOs below.
-
     for (const attr of this.attrs)
       (this as any)[attr] = obj.properties[prefix + attr]
   }
@@ -80,6 +77,12 @@ export class Line extends ContextProperties {
     ctx.setLineDashOffset(this.line_dash_offset.value())
   }
 
+  get doit(): boolean {
+    return !(this.line_color.value() === null ||
+             this.line_alpha.value() == 0     ||
+             this.line_width.value() == 0)
+  }
+
   protected _set_vectorize(ctx: Context2d, i: number): void {
     this.cache_select("line_color", i)
     if (ctx.strokeStyle !== this.cache.line_color)
@@ -117,7 +120,6 @@ export class Line extends ContextProperties {
 }
 
 Line.prototype.attrs = Object.keys(mixins.line())
-Line.prototype.do_attr = "line_color"
 
 export class Fill extends ContextProperties {
 
@@ -127,6 +129,11 @@ export class Fill extends ContextProperties {
   set_value(ctx: Context2d): void {
     ctx.fillStyle   = this.fill_color.value()
     ctx.globalAlpha = this.fill_alpha.value()
+  }
+
+  get doit(): boolean {
+    return !(this.fill_color.value() === null ||
+             this.fill_alpha.value() == 0)
   }
 
   protected _set_vectorize(ctx: Context2d, i: number): void {
@@ -146,7 +153,6 @@ export class Fill extends ContextProperties {
 }
 
 Fill.prototype.attrs = Object.keys(mixins.fill())
-Fill.prototype.do_attr =  "fill_color"
 
 export class Text extends ContextProperties {
 
@@ -194,6 +200,11 @@ export class Text extends ContextProperties {
     ctx.textBaseline = this.text_baseline.value()
   }
 
+  get doit(): boolean {
+    return !(this.text_color.value() === null ||
+             this.text_alpha.value() == 0)
+  }
+
   protected _set_vectorize(ctx: Context2d, i: number): void {
     this.cache_select("font", i)
     if (ctx.font !== this.cache.font)
@@ -218,7 +229,6 @@ export class Text extends ContextProperties {
 }
 
 Text.prototype.attrs = Object.keys(mixins.text())
-Text.prototype.do_attr = "text_color"
 
 export class Visuals {
 

--- a/bokehjs/src/lib/core/visuals.ts
+++ b/bokehjs/src/lib/core/visuals.ts
@@ -78,9 +78,9 @@ export class Line extends ContextProperties {
   }
 
   get doit(): boolean {
-    return !(this.line_color.value() === null ||
-             this.line_alpha.value() == 0     ||
-             this.line_width.value() == 0)
+    return !(this.line_color.spec.value === null ||
+             this.line_alpha.spec.value == 0     ||
+             this.line_width.spec.value == 0)
   }
 
   protected _set_vectorize(ctx: Context2d, i: number): void {
@@ -132,8 +132,8 @@ export class Fill extends ContextProperties {
   }
 
   get doit(): boolean {
-    return !(this.fill_color.value() === null ||
-             this.fill_alpha.value() == 0)
+    return !(this.fill_color.spec.value === null ||
+             this.fill_alpha.spec.value == 0)
   }
 
   protected _set_vectorize(ctx: Context2d, i: number): void {
@@ -201,8 +201,8 @@ export class Text extends ContextProperties {
   }
 
   get doit(): boolean {
-    return !(this.text_color.value() === null ||
-             this.text_alpha.value() == 0)
+    return !(this.text_color.spec.value === null ||
+             this.text_alpha.spec.value == 0)
   }
 
   protected _set_vectorize(ctx: Context2d, i: number): void {

--- a/bokehjs/test/core/visuals.ts
+++ b/bokehjs/test/core/visuals.ts
@@ -10,6 +10,23 @@ import * as text_glyph from "models/glyphs/text"
 
 describe("Fill", () => {
 
+  describe("set_value", () => {
+    for (const [attr, spec, value] of [
+      ['fillStyle', 'fill_color', 'red'],
+      ['globalAlpha', 'fill_alpha', 0.5],
+    ]) {
+      it(`should set canvas context ${attr} value from ${spec} spec value`, () =>{
+        const ctx = {} as any
+        const attrs = {} as any
+        attrs[spec] = {value}
+        const model = new Circle(attrs)
+        const fill = new Fill(model)
+        fill.set_value(ctx)
+        expect(ctx[attr]).to.be.equal(value)
+      })
+    }
+  })
+
   describe("doit", () => {
     it("should be false if fill_color is null", () => {
       const attrs = {fill_alpha: {value: 1}, fill_color: {value: null}}
@@ -35,6 +52,32 @@ describe("Fill", () => {
 
 describe("Line", () => {
 
+  describe("set_value", () => {
+    for (const [attr, spec, value] of [
+      ['strokeStyle', 'line_color', 'red'],
+      ['globalAlpha', 'line_alpha', 0.5],
+      ['lineWidth', 'line_width', 2],
+      ['lineJoin', 'line_join', 'miter'],
+      ['lineCap', 'line_cap', 'butt'],
+      ['lineDashOffset', 'line_dash_offset', 2],
+
+      // TS complains destructuring this, just test (redundantly) by hand below
+      //['lineDash', 'line_dash', [1,2]],
+    ]) {
+      it(`should set canvas context ${attr} value from ${spec} spec value`, () =>{
+        const ctx = {} as any
+        ctx.setLineDash = function (x: number) { ctx.lineDash = x }
+        ctx.setLineDashOffset = function (x: number) { ctx.lineDashOffset = x }
+        const attrs = {line_dash: [1,2]} as any
+        attrs[spec] = {value}
+        const model = new Circle(attrs)
+        const line = new Line(model)
+        line.set_value(ctx)
+        expect(ctx[attr]).to.be.equal(value)
+        expect(ctx.lineDash).to.be.deep.equal([1,2])
+      })
+    }
+  })
   describe("doit", () => {
     it("should be false if line_color is null", () => {
       const attrs = {line_alpha: {value: 1}, line_color: {value: null}, line_width: {value: 1}}
@@ -66,6 +109,26 @@ describe("Line", () => {
 
 describe("Text", () => {
 
+  describe("set_value", () => {
+    for (const [attr, spec, value] of [
+      // "font" handled below
+      ['fillStyle',    'text_color', 'red'],
+      ['globalAlpha',  'text_alpha', '0.5'],
+      ['textAlign',    'text_align', 'center'],
+      ['textBaseline', 'text_baseline', 'bottom'],
+    ]) {
+      it(`should set canvas context ${attr} value from ${spec} spec value`, () =>{
+        const ctx = {} as any
+        const attrs = {text_font: 'times', text_font_size: "12pt", text_font_style: "bold"} as any
+        attrs[spec] = {value}
+        const model = new text_glyph.Text(attrs)
+        const text = new Text(model)
+        text.set_value(ctx)
+        expect(ctx[attr]).to.be.equal(value)
+        expect(ctx.font).to.be.equal("bold 12pt times")
+      })
+    }
+  })
   describe("doit", () => {
     it("should be false if text_color is null", () => {
       const attrs = {text_alpha: {value: 1}, text_color: {value: null}}

--- a/bokehjs/test/core/visuals.ts
+++ b/bokehjs/test/core/visuals.ts
@@ -1,11 +1,93 @@
 import {expect} from "chai"
 import {create_glyph_renderer_view} from "../models/glyphs/glyph_utils"
 
-import {Visuals, Fill} from "core/visuals"
+import {Fill, Line, Text, Visuals} from "core/visuals"
 import {ColumnDataSource} from "models/sources/column_data_source"
 import {CDSView} from "models/sources/cds_view"
 import {IndexFilter} from "models/filters/index_filter"
 import {Circle, CircleView} from "models/glyphs/circle"
+import * as text_glyph from "models/glyphs/text"
+
+describe("Fill", () => {
+
+  describe("doit", () => {
+    it("should be false if fill_color is null", () => {
+      const attrs = {fill_alpha: {value: 1}, fill_color: {value: null}}
+      const model = new Circle(attrs)
+      const fill = new Fill(model)
+      expect(fill.doit).to.be.false
+    })
+    it("should be false if fill_alpha is 0", () => {
+      const attrs = {fill_alpha: {value: 0}, fill_color: {value: "red"}}
+      const model = new Circle(attrs)
+      const fill = new Fill(model)
+      expect(fill.doit).to.be.false
+    })
+    it("should be true otherwise", () => {
+      const attrs = {fill_alpha: {value: 1}, fill_color: {value: "red"}}
+      const model = new Circle(attrs)
+      const fill = new Fill(model)
+      expect(fill.doit).to.be.true
+    })
+  })
+
+})
+
+describe("Line", () => {
+
+  describe("doit", () => {
+    it("should be false if line_color is null", () => {
+      const attrs = {line_alpha: {value: 1}, line_color: {value: null}, line_width: {value: 1}}
+      const model = new Circle(attrs)
+      const line = new Line(model)
+      expect(line.doit).to.be.false
+    })
+    it("should be false if line_width is 0", () => {
+      const attrs = {line_alpha: {value: 1}, line_color: {value: "red"}, line_width: {value: 0}}
+      const model = new Circle(attrs)
+      const line = new Line(model)
+      expect(line.doit).to.be.false
+    })
+    it("should be false if line_alpha is 0", () => {
+      const attrs = {line_alpha: {value: 0}, line_color: {value: "red"}, line_width: {value: 1}}
+      const model = new Circle(attrs)
+      const line = new Line(model)
+      expect(line.doit).to.be.false
+    })
+    it("should be true otherwise", () => {
+      const attrs = {line_alpha: {value: 1}, line_color: {value: "red"}, line_width: {value: 1}}
+      const model = new Circle(attrs)
+      const line = new Line(model)
+      expect(line.doit).to.be.true
+    })
+  })
+
+})
+
+describe("Text", () => {
+
+  describe("doit", () => {
+    it("should be false if text_color is null", () => {
+      const attrs = {text_alpha: {value: 1}, text_color: {value: null}}
+      const model = new text_glyph.Text(attrs)
+      const text = new Text(model)
+      expect(text.doit).to.be.false
+    })
+    it("should be false if text_alpha is 0", () => {
+      const attrs = {text_alpha: {value: 0}, text_color: {value: "red"}}
+      const model = new text_glyph.Text(attrs)
+      const text = new Text(model)
+      expect(text.doit).to.be.false
+    })
+    it("should be true otherwise", () => {
+      const attrs = {text_alpha: {value: 1}, text_color: {value: "red"}}
+      const model = new text_glyph.Text(attrs)
+      const text = new Text(model)
+      expect(text.doit).to.be.true
+    })
+  })
+
+})
 
 describe("Visuals", () => {
 
@@ -55,5 +137,6 @@ describe("Visuals", () => {
       (renderer_view.glyph as CircleView).visuals.fill.set_vectorize(ctx, 1)
       expect(ctx.globalAlpha).to.be.equal(1)
     })
+
   })
 })


### PR DESCRIPTION
- [x] issues: fixes #8746
- [x] tests added / passed

This PR generalizes the notion of whether a "visual" should be drawn or not. Currentlty only a single attribute (typically color, e.g. `fill_color`) is checked against `null` to determine whether canvas operations should be skipped or not. This removes the generic code that checks the single configured attribute, with an abstract `doit` property getter on the base, that is specialized for each visual subclass. New behavior is summarized below:

* fill: skip if color is null, or alpha is 0
* line: skip if color is null, or alpha or width is 0
* text: skip if color is null, or alpha is 0

The new code is more explicit and seems to be an improvement from a maintenance POV as well. 

Also it was noticed that the visual classes have almost no tests, despite being very low level and in use in many places. I have added tests to cover the new functionality, as well as some other basic tests.

New MRE output with this PR:

<img width="420" alt="Screen Shot 2019-03-16 at 8 02 42 PM" src="https://user-images.githubusercontent.com/1078448/54484600-4fb99e80-4827-11e9-8d5a-814d40aa4ff2.png">
