### PR TITLE
Added workaround for amd load in notebook

### DIFF
--- a/bokeh/core/_templates/autoload_js.js
+++ b/bokeh/core/_templates/autoload_js.js
@@ -61,16 +61,24 @@ calls it with the rendered model.
     console.debug("Bokeh: BokehJS not loaded, scheduling load and callback at", now());
     root._bokeh_is_loading = css_urls.length + js_urls.length;
 
+    var _define = window.define;
+
     function on_load() {
       root._bokeh_is_loading--;
       if (root._bokeh_is_loading === 0) {
         console.debug("Bokeh: all BokehJS libraries/stylesheets loaded");
+        if (window.requirejs) {
+          window.define = _define;
+        }
         run_callbacks()
       }
     }
 
     function on_error() {
       console.error("failed to load " + url);
+      if (window.requirejs) {
+        window.define = _define;
+      }
     }
 
     for (var i = 0; i < css_urls.length; i++) {
@@ -85,6 +93,9 @@ calls it with the rendered model.
       document.body.appendChild(element);
     }
 
+    if (window.requirejs && js_urls.length) {
+      window.define = undefined
+    }
     for (var i = 0; i < js_urls.length; i++) {
       var url = js_urls[i];
       var element = document.createElement('script');


### PR DESCRIPTION
This is hacky but very simple fix for https://github.com/bokeh/bokeh/issues/5227. It works well both in the classic notebook and when exporting a notebook using nbconvert. Setting ``window.define = undefined`` is definitely a hack but it is considerably simpler than it would be for us to leverage ``requirejs`` correctly in the notebook and works in all scenarios I have tested. That said I will defer to @mattpap's judgement on this since this does have the potential to break code that does rely on define being defined.

- [x] issues: fixes #5227
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
