### PR TITLE
compute image bounds correctly

### DIFF
--- a/bokehjs/src/lib/core/util/templating.ts
+++ b/bokehjs/src/lib/core/util/templating.ts
@@ -7,7 +7,7 @@ import {escape} from "./string"
 import {isNumber, isString, isArray, isTypedArray} from "./types"
 
 import {ColumnarDataSource} from "models/sources/columnar_data_source"
-import {ImageIndex} from "../../models/glyphs/image"
+import {ImageIndex} from "../../models/glyphs/image_base"
 import {CustomJSHover} from 'models/tools/inspectors/customjs_hover'
 
 export function sprintf(format: string, ...args: unknown[]): string {

--- a/bokehjs/src/lib/models/glyphs/image.ts
+++ b/bokehjs/src/lib/models/glyphs/image.ts
@@ -1,4 +1,4 @@
-import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
+import {ImageBase, ImageBaseView, ImageDataBase} from "./image_base"
 import {ColorMapper} from "../mappers/color_mapper"
 import {LinearColorMapper} from "../mappers/linear_color_mapper"
 import {Class} from "core/class"
@@ -6,26 +6,12 @@ import {Arrayable} from "core/types"
 import * as p from "core/properties"
 import {concat} from "core/util/array"
 import {Context2d} from "core/util/canvas"
-import {SpatialIndex} from "core/util/spatial"
 import * as hittest from "core/hittest"
 import {Selection} from "../selections/selection"
 import {PointGeometry} from "core/geometry"
+import { ImageRGBAData } from './image_rgba'
 
-// XXX: because ImageData is a global
-export interface _ImageData extends XYGlyphData {
-  image_data: Arrayable<HTMLCanvasElement>
-
-  _image: Arrayable<Arrayable<number> | number[][]>
-  _dw: Arrayable<number>
-  _dh: Arrayable<number>
-
-  _image_shape?: Arrayable<[number, number]>
-
-  sw: Arrayable<number>
-  sh: Arrayable<number>
-}
-
-export interface ImageView extends _ImageData {}
+export interface ImageView extends ImageDataBase {}
 
 export interface ImageIndex {
   index: number
@@ -34,7 +20,7 @@ export interface ImageIndex {
   flat_index: number
 }
 
-export class ImageView extends XYGlyphView {
+export class ImageView extends ImageBaseView {
   model: Image
   visuals: Image.Visuals
 
@@ -53,32 +39,6 @@ export class ImageView extends XYGlyphView {
       this._set_data()
       this.renderer.plot_view.request_render()
     }
-  }
-
-  _index_data(): SpatialIndex {
-    const points = []
-    for (let i = 0, end = this._x.length; i < end; i++) {
-      const [l, r, t, b] = this._lrtb(i)
-      if (isNaN(l + r + t + b) || !isFinite(l + r + t + b)) {
-        continue
-      }
-      points.push({minX: l, minY: b, maxX: r, maxY: t, i})
-    }
-    return new SpatialIndex(points)
-  }
-
-  _lrtb(i: number) : [number, number, number, number]{
-    const xr = this.renderer.xscale.source_range
-    const x1 = this._x[i]
-    const x2 = xr.is_reversed ? x1 - this._dw[i] : x1 + this._dw[i]
-
-    const yr = this.renderer.yscale.source_range
-    const y1 = this._y[i]
-    const y2 = yr.is_reversed ? y1 - this._dh[i] : y1 + this._dh[i]
-
-    const [l,r] = x1 < x2 ? [x1,x2] : [x2,x1]
-    const [b,t] = y1 < y2 ? [y1,y2] : [y2,y1]
-    return [l, r, t, b]
   }
 
   _image_index(index : number, x: number, y : number) : ImageIndex {
@@ -110,14 +70,7 @@ export class ImageView extends XYGlyphView {
   }
 
   protected _set_data(): void {
-    if (this.image_data == null || this.image_data.length != this._image.length)
-      this.image_data = new Array(this._image.length)
-
-    if (this._width == null || this._width.length != this._image.length)
-      this._width = new Array(this._image.length)
-
-    if (this._height == null || this._height.length != this._image.length)
-      this._height = new Array(this._image.length)
+    this._set_width_heigh_data()
 
     const cmap = this.model.color_mapper.rgba_mapper
 
@@ -135,51 +88,13 @@ export class ImageView extends XYGlyphView {
         this._width[i] = _image[0].length
       }
 
-      const _image_data = this.image_data[i]
-      let canvas: HTMLCanvasElement
-      if (_image_data != null && _image_data.width == this._width[i] &&
-                                 _image_data.height == this._height[i])
-        canvas = _image_data
-      else {
-        canvas = document.createElement('canvas')
-        canvas.width = this._width[i]
-        canvas.height = this._height[i]
-      }
-
-      const ctx = canvas.getContext('2d')!
-      const image_data = ctx.getImageData(0, 0, this._width[i], this._height[i])
       const buf8 = cmap.v_compute(img)
-      image_data.data.set(buf8)
-      ctx.putImageData(image_data, 0, 0)
-      this.image_data[i] = canvas
+      this._set_image_data_from_buffer(i, buf8)
+
     }
   }
 
-  protected _map_data(): void {
-    switch (this.model.properties.dw.units) {
-      case "data": {
-        this.sw = this.sdist(this.renderer.xscale, this._x, this._dw, 'edge', this.model.dilate)
-        break
-      }
-      case "screen": {
-        this.sw = this._dw
-        break
-      }
-    }
-
-    switch (this.model.properties.dh.units) {
-      case "data": {
-        this.sh = this.sdist(this.renderer.yscale, this._y, this._dh, 'edge', this.model.dilate)
-        break
-      }
-      case "screen": {
-        this.sh = this._dh
-        break
-      }
-    }
-  }
-
-  protected _render(ctx: Context2d, indices: number[], {image_data, sx, sy, sw, sh}: _ImageData): void {
+  protected _render(ctx: Context2d, indices: number[], {image_data, sx, sy, sw, sh}: ImageRGBAData): void {
     const old_smoothing = ctx.getImageSmoothingEnabled()
     ctx.setImageSmoothingEnabled(false)
 
@@ -213,7 +128,7 @@ const Greys9 = () => ["#000000", "#252525", "#525252", "#737373", "#969696", "#b
 export namespace Image {
   export type Attrs = p.AttrsOf<Props>
 
-  export type Props = XYGlyph.Props & {
+  export type Props = ImageBase.Props & {
     image: p.NumberSpec
     dw: p.DistanceSpec
     dh: p.DistanceSpec
@@ -222,12 +137,12 @@ export namespace Image {
     color_mapper: p.Property<ColorMapper>
   }
 
-  export type Visuals = XYGlyph.Visuals
+  export type Visuals = ImageBase.Visuals
 }
 
 export interface Image extends Image.Attrs {}
 
-export class Image extends XYGlyph {
+export class Image extends ImageBase {
   properties: Image.Props
   default_view: Class<ImageView>
 
@@ -240,11 +155,6 @@ export class Image extends XYGlyph {
     this.prototype.default_view = ImageView
 
     this.define<Image.Props>({
-      image:        [ p.NumberSpec       ], // TODO (bev) array spec?
-      dw:           [ p.DistanceSpec     ],
-      dh:           [ p.DistanceSpec     ],
-      dilate:       [ p.Boolean,   false ],
-      global_alpha: [ p.Number,    1.0   ],
       color_mapper: [ p.Instance,  () => new LinearColorMapper({palette: Greys9()}) ],
     })
   }

--- a/bokehjs/src/lib/models/glyphs/image.ts
+++ b/bokehjs/src/lib/models/glyphs/image.ts
@@ -2,9 +2,9 @@ import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {ColorMapper} from "../mappers/color_mapper"
 import {LinearColorMapper} from "../mappers/linear_color_mapper"
 import {Class} from "core/class"
-import {Arrayable, Rect} from "core/types"
+import {Arrayable} from "core/types"
 import * as p from "core/properties"
-import {max, concat} from "core/util/array"
+import {concat} from "core/util/array"
 import {Context2d} from "core/util/canvas"
 import {SpatialIndex} from "core/util/spatial"
 import * as hittest from "core/hittest"
@@ -23,9 +23,6 @@ export interface _ImageData extends XYGlyphData {
 
   sw: Arrayable<number>
   sh: Arrayable<number>
-
-  max_dw: number
-  max_dh: number
 }
 
 export interface ImageView extends _ImageData {}
@@ -155,14 +152,6 @@ export class ImageView extends XYGlyphView {
       image_data.data.set(buf8)
       ctx.putImageData(image_data, 0, 0)
       this.image_data[i] = canvas
-
-      this.max_dw = 0
-      if (this.model.properties.dw.units == "data")
-        this.max_dw = max(this._dw)
-
-      this.max_dh = 0
-      if (this.model.properties.dh.units == "data")
-        this.max_dh = max(this._dh)
     }
   }
 
@@ -215,13 +204,6 @@ export class ImageView extends XYGlyphView {
     }
 
     ctx.setImageSmoothingEnabled(old_smoothing)
-  }
-
-  bounds(): Rect {
-    const {bbox} = this.index
-    bbox.maxX += this.max_dw
-    bbox.maxY += this.max_dh
-    return bbox
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/image.ts
+++ b/bokehjs/src/lib/models/glyphs/image.ts
@@ -6,19 +6,10 @@ import {Arrayable} from "core/types"
 import * as p from "core/properties"
 import {concat} from "core/util/array"
 import {Context2d} from "core/util/canvas"
-import * as hittest from "core/hittest"
-import {Selection} from "../selections/selection"
-import {PointGeometry} from "core/geometry"
-import { ImageRGBAData } from './image_rgba'
 
-export interface ImageView extends ImageDataBase {}
+export interface ImageData extends ImageDataBase {}
 
-export interface ImageIndex {
-  index: number
-  dim1: number
-  dim2: number
-  flat_index: number
-}
+export interface ImageView extends ImageData {}
 
 export class ImageView extends ImageBaseView {
   model: Image
@@ -39,34 +30,6 @@ export class ImageView extends ImageBaseView {
       this._set_data()
       this.renderer.plot_view.request_render()
     }
-  }
-
-  _image_index(index : number, x: number, y : number) : ImageIndex {
-    const [l,r,t,b] = this._lrtb(index)
-    const width = this._width[index]
-    const height = this._height[index]
-    const dx = (r - l) / width
-    const dy = (t - b) / height
-    const dim1 = Math.floor((x - l) / dx)
-    const dim2 = Math.floor((y - b) / dy)
-    return {index, dim1, dim2, flat_index: dim2*width + dim1}
-  }
-
-  _hit_point(geometry: PointGeometry) : Selection {
-    const {sx, sy} = geometry
-    const x = this.renderer.xscale.invert(sx)
-    const y = this.renderer.yscale.invert(sy)
-    const bbox = hittest.validate_bbox_coords([x, x], [y, y])
-    const candidates = this.index.indices(bbox)
-    const result = hittest.create_empty_hit_test_result()
-
-    result.image_indices = []
-    for (const index of candidates) {
-      if ((sx != Infinity) && (sy != Infinity)) {
-        result.image_indices.push(this._image_index(index, x,y))
-      }
-    }
-    return result
   }
 
   protected _set_data(): void {
@@ -94,7 +57,7 @@ export class ImageView extends ImageBaseView {
     }
   }
 
-  protected _render(ctx: Context2d, indices: number[], {image_data, sx, sy, sw, sh}: ImageRGBAData): void {
+  protected _render(ctx: Context2d, indices: number[], {image_data, sx, sy, sw, sh}: ImageData): void {
     const old_smoothing = ctx.getImageSmoothingEnabled()
     ctx.setImageSmoothingEnabled(false)
 

--- a/bokehjs/src/lib/models/glyphs/image_base.ts
+++ b/bokehjs/src/lib/models/glyphs/image_base.ts
@@ -1,0 +1,159 @@
+import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
+import {Arrayable} from "core/types"
+import * as p from "core/properties"
+import {Context2d} from "core/util/canvas"
+import {SpatialIndex} from "core/util/spatial"
+
+export interface ImageDataBase extends XYGlyphData {
+  image_data: Arrayable<HTMLCanvasElement>
+
+  _image: Arrayable<Arrayable<number> | number[][]>
+  _dw: Arrayable<number>
+  _dh: Arrayable<number>
+
+  _image_shape?: Arrayable<[number, number]>
+
+  sw: Arrayable<number>
+  sh: Arrayable<number>
+}
+
+export interface ImageBaseView extends ImageDataBase {}
+
+export interface ImageIndex {
+  index: number
+  dim1: number
+  dim2: number
+  flat_index: number
+}
+
+export class ImageBaseView extends XYGlyphView {
+  model: ImageBase
+  visuals: ImageBase.Visuals
+
+  protected _width: Arrayable<number>
+  protected _height: Arrayable<number>
+
+  protected _render(_ctx: Context2d, _indices: number[], _data: ImageDataBase): void {}
+
+  _index_data(): SpatialIndex {
+    const points = []
+    for (let i = 0, end = this._x.length; i < end; i++) {
+      const [l, r, t, b] = this._lrtb(i)
+      if (isNaN(l + r + t + b) || !isFinite(l + r + t + b)) {
+        continue
+      }
+      points.push({minX: l, minY: b, maxX: r, maxY: t, i})
+    }
+    return new SpatialIndex(points)
+  }
+
+  _lrtb(i: number) : [number, number, number, number]{
+    const xr = this.renderer.xscale.source_range
+    const x1 = this._x[i]
+    const x2 = xr.is_reversed ? x1 - this._dw[i] : x1 + this._dw[i]
+
+    const yr = this.renderer.yscale.source_range
+    const y1 = this._y[i]
+    const y2 = yr.is_reversed ? y1 - this._dh[i] : y1 + this._dh[i]
+
+    const [l,r] = x1 < x2 ? [x1,x2] : [x2,x1]
+    const [b,t] = y1 < y2 ? [y1,y2] : [y2,y1]
+    return [l, r, t, b]
+  }
+
+  protected _set_width_heigh_data(): void {
+    if (this.image_data == null || this.image_data.length != this._image.length)
+      this.image_data = new Array(this._image.length)
+
+    if (this._width == null || this._width.length != this._image.length)
+      this._width = new Array(this._image.length)
+
+    if (this._height == null || this._height.length != this._image.length)
+      this._height = new Array(this._image.length)
+  }
+
+  protected _get_or_create_canvas(i: number): HTMLCanvasElement {
+    const _image_data = this.image_data[i]
+    if (_image_data != null && _image_data.width == this._width[i] &&
+                               _image_data.height == this._height[i])
+      return _image_data
+    else {
+      const canvas = document.createElement('canvas')
+      canvas.width = this._width[i]
+      canvas.height = this._height[i]
+      return canvas
+    }
+  }
+
+  protected _set_image_data_from_buffer(i: number, buf8: Uint8Array): void {
+    const canvas = this._get_or_create_canvas(i)
+    const ctx = canvas.getContext('2d')!
+    const image_data = ctx.getImageData(0, 0, this._width[i], this._height[i])
+    image_data.data.set(buf8)
+    ctx.putImageData(image_data, 0, 0)
+    this.image_data[i] = canvas
+  }
+
+  protected _map_data(): void {
+    switch (this.model.properties.dw.units) {
+      case "data": {
+        this.sw = this.sdist(this.renderer.xscale, this._x, this._dw, 'edge', this.model.dilate)
+        break
+      }
+      case "screen": {
+        this.sw = this._dw
+        break
+      }
+    }
+
+    switch (this.model.properties.dh.units) {
+      case "data": {
+        this.sh = this.sdist(this.renderer.yscale, this._y, this._dh, 'edge', this.model.dilate)
+        break
+      }
+      case "screen": {
+        this.sh = this._dh
+        break
+      }
+    }
+  }
+
+}
+
+export namespace ImageBase {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = XYGlyph.Props & {
+    image: p.NumberSpec
+    dw: p.DistanceSpec
+    dh: p.DistanceSpec
+    global_alpha: p.Property<number>
+    dilate: p.Property<boolean>
+  }
+
+  export type Visuals = XYGlyph.Visuals
+}
+
+export interface ImageBase extends ImageBase.Attrs {}
+
+export class ImageBase extends XYGlyph {
+  properties: ImageBase.Props
+
+  constructor(attrs?: Partial<ImageBase.Attrs>) {
+    super(attrs)
+  }
+
+  static initClass(): void {
+    this.prototype.type = 'ImageBase'
+    this.prototype.default_view = ImageBaseView
+
+    this.define<ImageBase.Props>({
+      image:        [ p.NumberSpec       ], // TODO (bev) array spec?
+      dw:           [ p.DistanceSpec     ],
+      dh:           [ p.DistanceSpec     ],
+      dilate:       [ p.Boolean,   false ],
+      global_alpha: [ p.Number,    1.0   ],
+    })
+  }
+}
+ImageBase.initClass()

--- a/bokehjs/src/lib/models/glyphs/image_rgba.ts
+++ b/bokehjs/src/lib/models/glyphs/image_rgba.ts
@@ -1,8 +1,8 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
-import {Arrayable, TypedArray, Rect} from "core/types"
+import {Arrayable, TypedArray} from "core/types"
 import {Class} from "core/class"
 import * as p from "core/properties"
-import {max, concat} from "core/util/array"
+import {concat} from "core/util/array"
 import {Context2d} from "core/util/canvas"
 
 export interface ImageRGBAData extends XYGlyphData {
@@ -16,9 +16,6 @@ export interface ImageRGBAData extends XYGlyphData {
 
   sw: Arrayable<number>
   sh: Arrayable<number>
-
-  max_dw: number
-  max_dh: number
 }
 
 export interface ImageRGBAView extends ImageRGBAData {}
@@ -84,14 +81,6 @@ export class ImageRGBAView extends XYGlyphView {
       image_data.data.set(buf8)
       ctx.putImageData(image_data, 0, 0)
       this.image_data[i] = canvas
-
-      this.max_dw = 0
-      if (this.model.properties.dw.units == "data")
-        this.max_dw = max(this._dw)
-
-      this.max_dh = 0
-      if (this.model.properties.dh.units == "data")
-        this.max_dh = max(this._dh)
     }
   }
 
@@ -141,13 +130,6 @@ export class ImageRGBAView extends XYGlyphView {
     }
 
     ctx.setImageSmoothingEnabled(old_smoothing)
-  }
-
-  bounds(): Rect {
-    const {bbox} = this.index
-    bbox.maxX += this.max_dw
-    bbox.maxY += this.max_dh
-    return bbox
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/image_rgba.ts
+++ b/bokehjs/src/lib/models/glyphs/image_rgba.ts
@@ -1,26 +1,15 @@
-import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
+import {ImageBase, ImageBaseView, ImageDataBase} from "./image_base"
 import {Arrayable, TypedArray} from "core/types"
 import {Class} from "core/class"
 import * as p from "core/properties"
 import {concat} from "core/util/array"
 import {Context2d} from "core/util/canvas"
 
-export interface ImageRGBAData extends XYGlyphData {
-  image_data: Arrayable<HTMLCanvasElement>
-
-  _image: Arrayable<TypedArray | number[][]>
-  _dw: Arrayable<number>
-  _dh: Arrayable<number>
-
-  _image_shape?: Arrayable<[number, number]>
-
-  sw: Arrayable<number>
-  sh: Arrayable<number>
-}
+export interface ImageRGBAData extends ImageDataBase {}
 
 export interface ImageRGBAView extends ImageRGBAData {}
 
-export class ImageRGBAView extends XYGlyphView {
+export class ImageRGBAView extends ImageBaseView {
   model: ImageRGBA
   visuals: ImageRGBA.Visuals
 
@@ -33,14 +22,7 @@ export class ImageRGBAView extends XYGlyphView {
   }
 
   protected _set_data(indices: number[] | null): void {
-    if (this.image_data == null || this.image_data.length != this._image.length)
-      this.image_data = new Array(this._image.length)
-
-    if (this._width == null || this._width.length != this._image.length)
-      this._width = new Array(this._image.length)
-
-    if (this._height == null || this._height.length != this._image.length)
-      this._height = new Array(this._image.length)
+    this._set_width_heigh_data()
 
     for (let i = 0, end = this._image.length; i < end; i++) {
       if (indices != null && indices.indexOf(i) < 0)
@@ -64,47 +46,9 @@ export class ImageRGBAView extends XYGlyphView {
         this._width[i] = _image[0].length
       }
 
-      const _image_data = this.image_data[i]
-      let canvas: HTMLCanvasElement
-      if (_image_data != null && _image_data.width == this._width[i] &&
-                                 _image_data.height == this._height[i])
-        canvas = _image_data
-      else {
-        canvas = document.createElement('canvas')
-        canvas.width = this._width[i]
-        canvas.height = this._height[i]
-      }
-
-      const ctx = canvas.getContext('2d')!
-      const image_data = ctx.getImageData(0, 0, this._width[i], this._height[i])
       const buf8 = new Uint8Array(buf)
-      image_data.data.set(buf8)
-      ctx.putImageData(image_data, 0, 0)
-      this.image_data[i] = canvas
-    }
-  }
+      this._set_image_data_from_buffer(i, buf8)
 
-  protected _map_data(): void {
-    switch (this.model.properties.dw.units) {
-      case "data": {
-        this.sw = this.sdist(this.renderer.xscale, this._x, this._dw, "edge", this.model.dilate)
-        break
-      }
-      case "screen": {
-        this.sw = this._dw
-        break
-      }
-    }
-
-    switch (this.model.properties.dh.units) {
-      case "data": {
-        this.sh = this.sdist(this.renderer.yscale, this._y, this._dh, "edge", this.model.dilate)
-        break
-      }
-      case "screen": {
-        this.sh = this._dh
-        break
-      }
     }
   }
 
@@ -136,7 +80,7 @@ export class ImageRGBAView extends XYGlyphView {
 export namespace ImageRGBA {
   export type Attrs = p.AttrsOf<Props>
 
-  export type Props = XYGlyph.Props & {
+  export type Props = ImageBase.Props & {
     image: p.NumberSpec
     dw: p.DistanceSpec
     dh: p.DistanceSpec
@@ -144,12 +88,12 @@ export namespace ImageRGBA {
     dilate: p.Property<boolean>
   }
 
-  export type Visuals = XYGlyph.Visuals
+  export type Visuals = ImageBase.Visuals
 }
 
 export interface ImageRGBA extends ImageRGBA.Attrs {}
 
-export class ImageRGBA extends XYGlyph {
+export class ImageRGBA extends ImageBase {
   properties: ImageRGBA.Props
   default_view: Class<ImageRGBAView>
 
@@ -160,14 +104,6 @@ export class ImageRGBA extends XYGlyph {
   static initClass(): void {
     this.prototype.type = 'ImageRGBA'
     this.prototype.default_view = ImageRGBAView
-
-    this.define<ImageRGBA.Props>({
-      image:        [ p.NumberSpec         ], // TODO (bev) array spec?
-      dw:           [ p.DistanceSpec       ],
-      dh:           [ p.DistanceSpec       ],
-      global_alpha: [ p.Number,      1.0   ],
-      dilate:       [ p.Boolean,     false ],
-    })
   }
 }
 ImageRGBA.initClass()

--- a/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
+++ b/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
@@ -18,7 +18,7 @@ import {build_views, remove_views} from "core/build_views"
 import {HoverMode, PointPolicy, LinePolicy, Anchor, TooltipAttachment} from "core/enums"
 import {Geometry, PointGeometry, SpanGeometry} from "core/geometry"
 import {ColumnarDataSource} from "../../sources/columnar_data_source"
-import {ImageIndex} from "../../glyphs/image"
+import {ImageIndex} from "../../glyphs/image_base"
 
 export function _nearest_line_hit(i: number, geometry: Geometry,
     sx: number, sy: number, dx: number[], dy: number[]): [[number, number], number] {

--- a/examples/plotting/file/image.py
+++ b/examples/plotting/file/image.py
@@ -8,8 +8,8 @@ y = np.linspace(0, 10, N)
 xx, yy = np.meshgrid(x, y)
 d = np.sin(xx)*np.cos(yy)
 
-p = figure(x_range=(0, 10), y_range=(0, 10),
-           tooltips=[("x", "$x"), ("y", "$y"), ("value", "@image")])
+p = figure(tooltips=[("x", "$x"), ("y", "$y"), ("value", "@image")])
+p.x_range.range_padding = p.y_range.range_padding = 0
 
 # must give a vector of image data for image parameter
 p.image(image=[d], x=0, y=0, dw=10, dh=10, palette="Spectral11")

--- a/examples/plotting/file/image_rgba.py
+++ b/examples/plotting/file/image_rgba.py
@@ -14,7 +14,7 @@ for i in range(N):
         view[i, j, 2] = int(j/N*255)
         view[i, j, 3] = 255
 
-p = figure()
+p = figure(tooltips=[("x", "$x"), ("y", "$y"), ("value", "@image")])
 p.x_range.range_padding = p.y_range.range_padding = 0
 
 # must give a vector of images

--- a/examples/plotting/file/image_rgba.py
+++ b/examples/plotting/file/image_rgba.py
@@ -14,7 +14,8 @@ for i in range(N):
         view[i, j, 2] = int(j/N*255)
         view[i, j, 3] = 255
 
-p = figure(x_range=(0,10), y_range=(0,10))
+p = figure()
+p.x_range.range_padding = p.y_range.range_padding = 0
 
 # must give a vector of images
 p.image_rgba(image=[img], x=0, y=0, dw=10, dh=10)


### PR DESCRIPTION
- [x] issues: fixes #8770 fixes #8668
- [x] tests added / passed

As far as I can tell, this has been broken forever, possibly since the image glyphs were created. This PR removes the code that modifies the default bounds based on the spatial index, since these are already correct as-is. 

It might be nice to add some image or integration tests to verify this change. We could also update some of the gallery examples to not set ranges explicitly (but they would need to set `range_padding`  to 0 instead). 

Finally, I don't think things will behave well with `dw_units` or `dh_units` set to "screen" but things are clearly currently already broken in that case, by inspection. I would support deprecation being able to set units on these for 2.0 cc @bokeh/dev 