### PR TITLE
correcting validation for BAD_EXTRA_RANGE_NAME (#8723)

### DIFF
--- a/bokeh/model.py
+++ b/bokeh/model.py
@@ -68,8 +68,12 @@ def collect_filtered_models(discard, *input_values):
     collecting all nested ``Models`` on the go.
 
     Args:
-        discard (Callable[[Model], bool])
-            a callable returning whether to continue down the object's references
+        *discard (Callable[[Model], bool])
+            a callable which accepts a *Model* instance as its single argument
+            and returns a boolean stating whether to discard the instance. The
+            latter means that the instance will not be added to collected
+            models nor will its references be explored.
+
         *input_values (Model)
             Bokeh models to collect other models from
 
@@ -82,17 +86,9 @@ def collect_filtered_models(discard, *input_values):
     collected = []
     queued = []
 
-    queue_one = None
-    if discard is None:
-        def _visitor(obj):
-            if obj.id not in ids:
-                queued.append(obj)
-        queue_one = _visitor
-    else:
-        def _filteredvistor(obj):
-            if obj.id not in ids and not discard(obj):
-                queued.append(obj)
-        queue_one = _filteredvistor
+    def queue_one(obj):
+        if obj.id not in ids and not (callable(discard) and discard(obj)):
+            queued.append(obj)
 
     for value in input_values:
         _visit_value_and_its_immediate_references(value, queue_one)

--- a/bokeh/model.py
+++ b/bokeh/model.py
@@ -59,6 +59,53 @@ __all__ = (
 # Dev API
 #-----------------------------------------------------------------------------
 
+def collect_filtered_models(discard, *input_values):
+    ''' Collect a duplicate-free list of all other Bokeh models referred to by
+    this model, or by any of its references, etc, unless filtered-out by the
+    provided callable.
+
+    Iterate over ``input_values`` and descend through their structure
+    collecting all nested ``Models`` on the go.
+
+    Args:
+        discard (Callable[[Model], bool])
+            a callable returning whether to continue down the object's references
+        *input_values (Model)
+            Bokeh models to collect other models from
+
+    Returns:
+        None
+
+    '''
+
+    ids = set([])
+    collected = []
+    queued = []
+
+    queue_one = None
+    if discard is None:
+        def _visitor(obj):
+            if obj.id not in ids:
+                queued.append(obj)
+        queue_one = _visitor
+    else:
+        def _filteredvistor(obj):
+            if obj.id not in ids and not discard(obj):
+                queued.append(obj)
+        queue_one = _filteredvistor
+
+    for value in input_values:
+        _visit_value_and_its_immediate_references(value, queue_one)
+
+    while queued:
+        obj = queued.pop(0)
+        if obj.id not in ids:
+            ids.add(obj.id)
+            collected.append(obj)
+            _visit_immediate_value_references(obj, queue_one)
+
+    return collected
+
 def collect_models(*input_values):
     ''' Collect a duplicate-free list of all other Bokeh models referred to by
     this model, or by any of its references, etc.
@@ -75,26 +122,7 @@ def collect_models(*input_values):
         list[Model] : all models reachable from this one.
 
     '''
-
-    ids = set([])
-    collected = []
-    queued = []
-
-    def queue_one(obj):
-        if obj.id not in ids:
-            queued.append(obj)
-
-    for value in input_values:
-        _visit_value_and_its_immediate_references(value, queue_one)
-
-    while queued:
-        obj = queued.pop(0)
-        if obj.id not in ids:
-            ids.add(obj.id)
-            collected.append(obj)
-            _visit_immediate_value_references(obj, queue_one)
-
-    return collected
+    return collect_filtered_models(None, *input_values)
 
 def get_class(view_model_name):
     ''' Look up a Bokeh model class, given its view model name.

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -34,7 +34,7 @@ from ..core.query import find
 from ..core.validation import error, warning
 from ..core.validation.errors import BAD_EXTRA_RANGE_NAME, REQUIRED_RANGE, REQUIRED_SCALE, INCOMPATIBLE_SCALE_AND_RANGE
 from ..core.validation.warnings import MISSING_RENDERERS, FIXED_SIZING_MODE, FIXED_WIDTH_POLICY, FIXED_HEIGHT_POLICY
-from ..model import Model
+from ..model import Model, collect_filtered_models
 from ..util.deprecation import deprecated
 from ..util.string import nice_join
 
@@ -368,8 +368,9 @@ class Plot(LayoutDOM):
 
     @error(BAD_EXTRA_RANGE_NAME)
     def _check_bad_extra_range_name(self):
-        msg = ""
-        for ref in self.references():
+        msg  = ""
+        filt = lambda x: x is not self and isinstance(x, Plot)
+        for ref in collect_filtered_models(filt, self):
             prop_names = ref.properties()
             bad = []
             if 'x_range_name' in prop_names and 'y_range_name' in prop_names:


### PR DESCRIPTION
- [ x] issues: fixes #8723 
- [ x] tests added / passed: added to test_bad_extra_range_name in models/tests/test_plots
- [ ] release document entry (if new feature or API change)


Most significant change is a modified version of bokeh.model.collect_models. The new collect_filtered_models gets to reject a object *and* discontinue exploration of its children depending on a test function provided in the tests. The old collect_models now calls on the new function.