### PR TITLE
Fixes trying to index dict_keys

### DIFF
--- a/bokeh/application/application.py
+++ b/bokeh/application/application.py
@@ -100,7 +100,7 @@ class Application(object):
         metadata = kwargs.pop('metadata', None)
         if kwargs:
             raise TypeError("Invalid keyword argument: %s" %
-                kwargs.keys()[0])
+                list(kwargs.keys())[0])
         self._static_path = None
         self._handlers = []
         self._metadata = metadata


### PR DESCRIPTION
This pull request fixes a small bug in application.py, causing the application to crash with a cryptic error, by trying to index `kwargs.keys()`.

It is probably a leftover from Python 2 times.