### PR TITLE
Upgrade to TypeScript 3.4

### DIFF
--- a/bokehjs/make/prelude.ts
+++ b/bokehjs/make/prelude.ts
@@ -28,6 +28,10 @@ ${license}
       if (name === "bokehjs")
         return entry;
 
+      var prefix = "@bokehjs/"
+      if (name.slice(0, prefix.length) === prefix)
+        name = name.slice(prefix.length)
+
       var alias = aliases[name]
       if (alias != null)
         return alias;

--- a/bokehjs/make/tasks/all.ts
+++ b/bokehjs/make/tasks/all.ts
@@ -1,0 +1,3 @@
+import {task} from "../task"
+
+task("all", ["build", "examples", "test"])

--- a/bokehjs/make/tasks/index.ts
+++ b/bokehjs/make/tasks/index.ts
@@ -1,3 +1,4 @@
+import "./all"
 import "./build"
 import "./clean"
 import "./compiler"

--- a/bokehjs/package-lock.json
+++ b/bokehjs/package-lock.json
@@ -2562,9 +2562,9 @@
       }
     },
     "typescript": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3.tgz",
-      "integrity": "sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.1.tgz",
+      "integrity": "sha512-3NSMb2VzDQm8oBTLH6Nj55VVtUEpe/rgkIzMir0qVoLyjDZlnMBva0U6vDiV3IH+sl/Yu6oP5QwsAQtHPmDd2Q==",
       "dev": true
     },
     "uglify-js": {

--- a/bokehjs/package-lock.json
+++ b/bokehjs/package-lock.json
@@ -195,9 +195,9 @@
       "dev": true
     },
     "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
@@ -843,9 +843,9 @@
       }
     },
     "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "estraverse": {
@@ -1324,9 +1324,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -37,7 +37,7 @@
     "yargs": "^13.2.2",
     "jsdom": "^9.8.3",
     "websocket": "^1.0.28",
-    "typescript": "3.3.3",
+    "typescript": "3.4.1",
     "tslint": "^5.13.1",
     "tsconfig-paths": "^3.8.0",
     "coffeescript": "^2.3.2",

--- a/bokehjs/test/models/glyphs/glyph_utils.ts
+++ b/bokehjs/test/models/glyphs/glyph_utils.ts
@@ -35,7 +35,7 @@ import {HasProps} from "@bokehjs/core/has_props"
 export type ViewType<T extends HasProps> = InstanceType<T["default_view"]>
 
 export function create_glyph_view<G extends Glyph>(glyph: G, data: {[key: string]: Arrayable} = {}): ViewType<G> {
-  return create_glyph_renderer_view(glyph, data).glyph /* glyph_view */ as ViewType<G>
+  return create_glyph_renderer_view(glyph, data).glyph /* glyph_view */ as unknown as ViewType<G> // XXX: investigate this
 }
 
 export type AxisType = "linear" | "log" | "categorical"


### PR DESCRIPTION
Upgrades the compiler, fixes `npm audit` complaints and resolves an issue with bokehjs integration tests after PR #8782.