### PR TITLE
Fix range tool interaction issues

### DIFF
--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -263,7 +263,7 @@ class PanTool(Drag):
 
 DEFAULT_RANGE_OVERLAY = lambda: BoxAnnotation(
     level="overlay",
-    render_mode="css",
+    render_mode="canvas",
     fill_color="lightgrey",
     fill_alpha=0.5,
     line_color="black",

--- a/bokehjs/src/lib/models/tools/gestures/range_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/range_tool.ts
@@ -63,6 +63,28 @@ export function compute_value(value: number, scale: Scale, sdelta: number, range
   return value
 }
 
+export function compute_end_side(end: number, range: Range, side: Side): Side {
+  if (end > range.start) {
+    range.end = end
+    return side
+  } else {
+    range.end = range.start
+    range.start = end
+    return flip_side(side)
+  }
+}
+
+export function compute_start_side(start: number, range: Range, side: Side): Side {
+  if (start < range.end ) {
+    range.start = start
+    return side
+  } else {
+    range.start = range.end
+    range.end = start
+    return flip_side(side)
+  }
+}
+
 export function update_range(range: Range1d, scale: Scale, delta: number, plot_range: Range): void {
   const [sstart, send] = scale.r_compute(range.start, range.end)
   const [start, end] = scale.r_invert(sstart+delta, send+delta)
@@ -155,22 +177,10 @@ export class RangeToolView extends GestureToolView {
         update_range(xr, xscale, new_dx, frame.x_range)
       else if (this.side == Side.Left) {
         const start = compute_value(xr.start, xscale, new_dx, frame.x_range)
-        if (start < xr.end )
-          xr.start = start
-        else {
-          xr.start = xr.end
-          xr.end = start
-          this.side = flip_side(this.side)
-        }
+        this.side = compute_start_side(start, xr, this.side)
       } else if (this.side == Side.Right) {
         const end = compute_value(xr.end, xscale, new_dx, frame.x_range)
-        if (end > xr.start)
-          xr.end = end
-        else {
-          xr.end = xr.start
-          xr.start = end
-          this.side = flip_side(this.side)
-        }
+        this.side = compute_end_side(end, xr, this.side)
       }
     }
 
@@ -180,23 +190,11 @@ export class RangeToolView extends GestureToolView {
       else if (this.side == Side.Bottom) {
         yr.start = compute_value(yr.start, yscale, new_dy, frame.y_range)
         const start = compute_value(yr.start, yscale, new_dy, frame.y_range)
-        if (start < yr.end )
-          yr.start = start
-        else {
-          yr.start = yr.end
-          yr.end = start
-          this.side = flip_side(this.side)
-        }
+        this.side = compute_start_side(start, yr, this.side)
       } else if (this.side == Side.Top) {
         yr.end = compute_value(yr.end, yscale, new_dy, frame.y_range)
         const end = compute_value(yr.end, yscale, new_dy, frame.y_range)
-        if (end > yr.start)
-          yr.end = end
-        else {
-          yr.end = yr.start
-          yr.start = end
-          this.side = flip_side(this.side)
-        }
+        this.side = compute_end_side(end, yr, this.side)
       }
     }
 

--- a/bokehjs/src/lib/models/tools/gestures/range_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/range_tool.ts
@@ -7,7 +7,17 @@ import {logger} from "core/logging"
 import * as p from "core/properties"
 import {GestureTool, GestureToolView} from "./gesture_tool"
 
-const enum Side { None, Left, Right, LeftRight, Bottom, Top, BottomTop, LeftRightBottomTop }
+export const enum Side { None, Left, Right, LeftRight, Bottom, Top, BottomTop, LeftRightBottomTop }
+
+export function flip_side(side: Side): Side {
+  switch (side) {
+    case Side.Left:   return Side.Right
+    case Side.Right:  return Side.Left
+    case Side.Bottom: return Side.Top
+    case Side.Top:    return Side.Bottom
+    default:          return side
+  }
+}
 
 // TODO (bev) This would be better directly with BoxAnnotation, but hard
 // to test on a view. Move when "View Models" are implemented
@@ -60,7 +70,7 @@ export function update_range(range: Range1d, scale: Scale, delta: number, plot_r
   const initial_sides_inside = sides_inside(range.start, range.end, plot_range)
   const final_sides_inside = sides_inside(start, end, plot_range)
 
-  // Allow the update as long as the number of sides in-bounds
+  // Allow the update as long as the number of sides in-bounds does not decrease
   if (final_sides_inside >= initial_sides_inside) {
     range.start = start
     range.end = end
@@ -150,7 +160,7 @@ export class RangeToolView extends GestureToolView {
         else {
           xr.start = xr.end
           xr.end = start
-          this.side = Side.Right
+          this.side = flip_side(this.side)
         }
       } else if (this.side == Side.Right) {
         const end = compute_value(xr.end, xscale, new_dx, frame.x_range)
@@ -159,7 +169,7 @@ export class RangeToolView extends GestureToolView {
         else {
           xr.end = xr.start
           xr.start = end
-          this.side = Side.Left
+          this.side = flip_side(this.side)
         }
       }
     }
@@ -175,7 +185,7 @@ export class RangeToolView extends GestureToolView {
         else {
           yr.start = yr.end
           yr.end = start
-          this.side = Side.Top
+          this.side = flip_side(this.side)
         }
       } else if (this.side == Side.Top) {
         yr.end = compute_value(yr.end, yscale, new_dy, frame.y_range)
@@ -185,7 +195,7 @@ export class RangeToolView extends GestureToolView {
         else {
           yr.end = yr.start
           yr.start = end
-          this.side = Side.Bottom
+          this.side = flip_side(this.side)
         }
       }
     }

--- a/bokehjs/test/models/tools/gestures/range_tool.ts
+++ b/bokehjs/test/models/tools/gestures/range_tool.ts
@@ -1,6 +1,6 @@
 import {expect} from "chai"
 
-import {compute_value, is_near, is_inside, update_range, RangeTool} from "@bokehjs/models/tools/gestures/range_tool"
+import {compute_value, flip_side, is_near, is_inside, update_range, RangeTool, Side} from "@bokehjs/models/tools/gestures/range_tool"
 import {Range1d} from "@bokehjs/models/ranges/range1d"
 import {LinearScale} from "@bokehjs/models/scales/linear_scale"
 
@@ -14,6 +14,27 @@ describe("range_tool module", () => {
       target_range: new Range1d(target),
     })
   }
+
+  describe("flpp_side", () => {
+    it("should flip left to right", () => {
+      expect(flip_side(Side.Left)).to.equal(Side.Right)
+    })
+    it("should flip right to left", () => {
+      expect(flip_side(Side.Right)).to.equal(Side.Left)
+    })
+    it("should flip top to bottom", () => {
+      expect(flip_side(Side.Top)).to.equal(Side.Bottom)
+    })
+    it("should flip bottom to top", () => {
+      expect(flip_side(Side.Bottom)).to.equal(Side.Top)
+    })
+    it("should all others to themselves", () => {
+      expect(flip_side(Side.None)).to.equal(Side.None)
+      expect(flip_side(Side.BottomTop)).to.equal(Side.BottomTop)
+      expect(flip_side(Side.LeftRightBottomTop)).to.equal(Side.LeftRightBottomTop)
+    })
+
+  })
 
   describe("is_near", () => {
     const scale = generate_scale()

--- a/bokehjs/test/models/tools/gestures/range_tool.ts
+++ b/bokehjs/test/models/tools/gestures/range_tool.ts
@@ -1,6 +1,6 @@
 import {expect} from "chai"
 
-import {compute_value, flip_side, is_near, is_inside, update_range, RangeTool, Side} from "@bokehjs/models/tools/gestures/range_tool"
+import {compute_value, flip_side, is_near, is_inside, update_range, RangeTool, Side, compute_end_side, compute_start_side} from "@bokehjs/models/tools/gestures/range_tool"
 import {Range1d} from "@bokehjs/models/ranges/range1d"
 import {LinearScale} from "@bokehjs/models/scales/linear_scale"
 
@@ -15,7 +15,7 @@ describe("range_tool module", () => {
     })
   }
 
-  describe("flpp_side", () => {
+  describe("flip_side", () => {
     it("should flip left to right", () => {
       expect(flip_side(Side.Left)).to.equal(Side.Right)
     })
@@ -33,7 +33,6 @@ describe("range_tool module", () => {
       expect(flip_side(Side.BottomTop)).to.equal(Side.BottomTop)
       expect(flip_side(Side.LeftRightBottomTop)).to.equal(Side.LeftRightBottomTop)
     })
-
   })
 
   describe("is_near", () => {
@@ -123,6 +122,44 @@ describe("range_tool module", () => {
       const r2 = compute_value(5, scale, -50, range)
       expect(r2).to.be.equal(0)
     })
+  })
+
+  describe("compute_start_side", () => {
+    it("should not flip if new start < end", () => {
+      const r = new Range1d({start: 0, end: 1})
+      const side = compute_start_side(0.5, r, Side.Top)
+      expect(r.start).to.be.equal(0.5)
+      expect(r.end).to.be.equal(1)
+      expect(side).to.be.equal(Side.Top)
+    })
+
+    it("should flip if new start >= end", () => {
+      const r = new Range1d({start: 0, end: 1})
+      const side = compute_start_side(1.5, r, Side.Top)
+      expect(r.end).to.be.equal(1.5)
+      expect(r.start).to.be.equal(1)
+      expect(side).to.be.equal(Side.Bottom)
+    })
+
+  })
+
+  describe("compute_end_side", () => {
+    it("should not flip if new end > start", () => {
+      const r = new Range1d({start: 0, end: 1})
+      const side = compute_end_side(1.5, r, Side.Top)
+      expect(r.start).to.be.equal(0)
+      expect(r.end).to.be.equal(1.5)
+      expect(side).to.be.equal(Side.Top)
+    })
+
+    it("should flip if new end <= start", () => {
+      const r = new Range1d({start: 0, end: 1})
+      const side = compute_end_side(-0.5, r, Side.Top)
+      expect(r.start).to.be.equal(-0.5)
+      expect(r.end).to.be.equal(0)
+      expect(side).to.be.equal(Side.Bottom)
+    })
+
   })
 
   describe("update_range", () => {

--- a/examples/plotting/file/range_tool.py
+++ b/examples/plotting/file/range_tool.py
@@ -9,7 +9,7 @@ from bokeh.sampledata.stocks import AAPL
 dates = np.array(AAPL['date'], dtype=np.datetime64)
 source = ColumnDataSource(data=dict(date=dates, close=AAPL['adj_close']))
 
-p = figure(plot_height=300, plot_width=800, tools="", toolbar_location=None,
+p = figure(plot_height=300, plot_width=800, tools="xpan", toolbar_location=None,
            x_axis_type="datetime", x_axis_location="above",
            background_fill_color="#efefef", x_range=(dates[1500], dates[2500]))
 

--- a/tests/integration/tools/test_range_tool.py
+++ b/tests/integration/tools/test_range_tool.py
@@ -1,0 +1,300 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2017, Anaconda, Inc. All rights reserved.
+#
+# Powered by the Bokeh Development Team.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import pytest ; pytest
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+
+# External imports
+
+# Bokeh imports
+from bokeh.models import ColumnDataSource, CustomAction, CustomJS, Plot, Range1d, Rect, RangeTool
+from bokeh._testing.util.selenium import RECORD
+
+#-----------------------------------------------------------------------------
+# Tests
+#-----------------------------------------------------------------------------
+
+# TODO (bev) Add tests with y_range
+# TODO (bev) Add tests with both x_range and y_range
+
+pytest_plugins = (
+    "bokeh._testing.plugins.bokeh",
+)
+
+def _make_plot():
+    source = ColumnDataSource(dict(x=[1, 2], y=[1, 1]))
+    r = Range1d(start=0.4, end=0.6)
+    plot = Plot(plot_height=400, plot_width=1100, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
+    plot.add_glyph(source, Rect(x='x', y='y', width=0.9, height=0.9))
+    tool = RangeTool(x_range=r)
+    plot.add_tools(tool)
+    plot.min_border_right = 100
+    code = RECORD("start", "t.x_range.start") + RECORD("end", "t.x_range.end")
+    plot.add_tools(CustomAction(callback=CustomJS(args=dict(t=tool), code=code)))
+    plot.toolbar_sticky = False
+    return plot
+
+@pytest.mark.integration
+@pytest.mark.selenium
+class Test_RangeTool(object):
+
+    def test_selected_by_default(self, single_plot_page):
+        plot = _make_plot()
+
+        page = single_plot_page(plot)
+
+        target = 'range'
+        button = page.get_toolbar_button(target)
+        assert 'active' in button.get_attribute('class')
+
+        assert page.has_no_console_errors()
+
+    def test_can_be_deselected_and_selected(self, single_plot_page):
+        plot = _make_plot()
+
+        page = single_plot_page(plot)
+
+        target = 'range'
+
+        # Check is active
+        button = page.get_toolbar_button(target)
+        assert 'active' in button.get_attribute('class')
+
+        # Click and check is not active
+        button = page.get_toolbar_button(target)
+        button.click()
+        assert 'active' not in button.get_attribute('class')
+
+        # Click again and check is active
+        button = page.get_toolbar_button(target)
+        button.click()
+        assert 'active' in button.get_attribute('class')
+
+        assert page.has_no_console_errors()
+
+    def test_center_pan_has_no_effect_when_deselected(self, single_plot_page):
+        plot = _make_plot()
+
+        page = single_plot_page(plot)
+
+        target = 'range'
+        button = page.get_toolbar_button(target)
+        button.click()
+
+        page.drag_canvas_at_position(500, 200, 100, 0)
+
+        page.click_custom_action()
+
+        results = page.results
+        assert results['start'] == 0.4
+        assert results['end'] == 0.6
+
+        assert page.has_no_console_errors()
+
+    def test_center_pan_updates_range_when_selected(self, single_plot_page):
+        plot = _make_plot()
+
+        page = single_plot_page(plot)
+
+        page.drag_canvas_at_position(500, 200, 100, 0)
+
+        page.click_custom_action()
+
+        results = page.results
+        assert results['start'] == 0.5
+        assert results['end'] == 0.7
+
+        page.drag_canvas_at_position(600, 200, -300, 0)
+
+        page.click_custom_action()
+
+        results = page.results
+        assert results['start'] == 0.2
+        assert results['end'] == 0.4
+
+        assert page.has_no_console_errors()
+
+    def test_center_pan_with_right_side_outside(self, single_plot_page):
+        plot = _make_plot()
+        plot.tools[0].x_range.end = 1.1
+
+        page = single_plot_page(plot)
+
+        page.drag_canvas_at_position(500, 200, 100, 0)
+
+        page.click_custom_action()
+
+        results = page.results
+        assert results['start'] == 0.5
+        assert results['end'] == 1.2
+
+        page.drag_canvas_at_position(600, 200, -300, 0)
+
+        page.click_custom_action()
+
+        results = page.results
+        assert results['start'] == 0.2
+        assert results['end'] == 0.9
+
+        assert page.has_no_console_errors()
+
+    def test_center_pan_with_left_side_outside(self, single_plot_page):
+        plot = _make_plot()
+        plot.tools[0].x_range.start = -0.1
+
+        page = single_plot_page(plot)
+
+        page.drag_canvas_at_position(500, 200, -100, 0)
+
+        page.click_custom_action()
+
+        results = page.results
+        assert results['start'] == -0.2
+        assert results['end'] == 0.5
+
+        page.drag_canvas_at_position(400, 200, 300, 0)
+
+        page.click_custom_action()
+
+        results = page.results
+        assert results['start'] == 0.1
+        assert results['end'] == 0.8
+
+        assert page.has_no_console_errors()
+
+    def test_left_edge_drag_updates_start(self, single_plot_page):
+        plot = _make_plot()
+
+        page = single_plot_page(plot)
+
+        page.drag_canvas_at_position(400, 200, 100, 0)
+
+        page.click_custom_action()
+
+        results = page.results
+        assert results['start'] == 0.5
+        assert results['end'] == 0.6
+
+        page.drag_canvas_at_position(500, 200, -300, 0)
+
+        page.click_custom_action()
+
+        results = page.results
+        assert results['start'] == 0.2
+        assert results['end'] == 0.6
+
+    def test_left_edge_drag_can_flip(self, single_plot_page):
+        plot = _make_plot()
+
+        page = single_plot_page(plot)
+
+        page.drag_canvas_at_position(400, 200, 300, 0)
+
+        page.click_custom_action()
+
+        results = page.results
+        assert results['start'] == 0.6
+        assert results['end'] == 0.7
+
+    def test_left_edge_drag_with_right_edge_outside(self, single_plot_page):
+        plot = _make_plot()
+        plot.tools[0].x_range.end = 1.1
+
+        page = single_plot_page(plot)
+
+        page.drag_canvas_at_position(400, 200, 300, 0)
+
+        page.click_custom_action()
+
+        results = page.results
+        assert results['start'] == 0.7
+        assert results['end'] == 1.1
+
+    def test_right_edge_drag_updates_end(self, single_plot_page):
+        plot = _make_plot()
+
+        page = single_plot_page(plot)
+
+        page.drag_canvas_at_position(600, 200, 100, 0)
+
+        page.click_custom_action()
+
+        results = page.results
+        assert results['start'] == 0.4
+        assert results['end'] == 0.7
+
+        page.drag_canvas_at_position(700, 200, -200, 0)
+
+        page.click_custom_action()
+
+        results = page.results
+        assert results['start'] == 0.4
+        assert results['end'] == 0.5
+
+    def test_right_edge_drag_can_flip(self, single_plot_page):
+        plot = _make_plot()
+
+        page = single_plot_page(plot)
+
+        page.drag_canvas_at_position(600, 200, -300, 0)
+
+        page.click_custom_action()
+
+        results = page.results
+        assert results['start'] == 0.3
+        assert results['end'] == 0.4
+
+    def test_right_edge_drag_with_left_edge_outside(self, single_plot_page):
+        plot = _make_plot()
+        plot.tools[0].x_range.start = -0.1
+
+        page = single_plot_page(plot)
+
+        page.drag_canvas_at_position(600, 200, -300, 0)
+
+        page.click_custom_action()
+
+        results = page.results
+        assert results['start'] == -0.1
+        assert results['end'] == 0.3
+
+
+    # TODO (bev) This test is broken due to some dumb reason with tooling
+    @pytest.mark.skip
+    def test_center_pan_stops_at_plot_range_limit(self, single_plot_page):
+        plot = _make_plot()
+
+        page = single_plot_page(plot)
+
+        page.drag_canvas_at_position(500, 200, 300, 0)
+
+        page.click_custom_action()
+
+        results = page.results
+        assert results['start'] == 0.7
+        assert results['end'] == 0.9
+
+        page.drag_canvas_at_position(800, 200, 150, 0)
+
+        page.click_custom_action()
+
+        results = page.results
+        assert results['start'] == 0.8
+        assert results['end'] == 1
+
+        assert page.has_no_console_errors()


### PR DESCRIPTION
This is WIP, intend to add both unit and integration tests, as well as refactor complicated and duplicated code in *range_tool.ts*.

- [x] issues: fixes #8793
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

* dragging the box will function if one side of the range is out of bounds
* dragging one side over the other will automatically flip the range
* box annotation is clipped wnen a side is out of bounds

![ScreenFlow](https://user-images.githubusercontent.com/1078448/55295361-0b9ad200-53c1-11e9-8312-0da6969a884c.gif)



