### PR TITLE
Replace log1p by log in LogColorMapper

### DIFF
--- a/bokehjs/src/lib/models/mappers/log_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/log_color_mapper.ts
@@ -3,10 +3,6 @@ import {Arrayable} from "core/types"
 import {min, max} from "core/util/arrayable"
 import * as p from "core/properties"
 
-// Math.log1p() is not supported by any version of IE, so let's use a polyfill based on
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log1p.
-const log1p = Math.log1p != null ? Math.log1p : (x: number) => Math.log(1 + x)
-
 export namespace LogColorMapper {
   export type Attrs = p.AttrsOf<Props>
 
@@ -33,7 +29,7 @@ export class LogColorMapper extends ContinuousColorMapper {
     const n = palette.length
     const low = this.low != null ? this.low : min(data)
     const high = this.high != null ? this.high : max(data)
-    const scale = n / (log1p(high) - log1p(low))  // subtract the low offset
+    const scale = n / (Math.log(high) - Math.log(low))  // subtract the low offset
     const max_key = palette.length - 1
 
     for (let i = 0, end = data.length; i < end; i++) {
@@ -64,7 +60,7 @@ export class LogColorMapper extends ContinuousColorMapper {
       }
 
       // Get the key
-      const log = log1p(d) - log1p(low)  // subtract the low offset
+      const log = Math.log(d) - Math.log(low)  // subtract the low offset
       let key = Math.floor(log * scale)
 
       // Deal with upper bound

--- a/bokehjs/test/models/mappers/log_color_mapper.ts
+++ b/bokehjs/test/models/mappers/log_color_mapper.ts
@@ -17,13 +17,6 @@ describe("LogColorMapper module", () => {
       expect([buf8_1[0], buf8_1[1], buf8_1[2], buf8_1[3]]).to.be.deep.equal([254, 224, 139, 255])
     })
 
-    it("Should correctly handle zero values", () => {
-      const palette = ["#3288bd", "#abdda4", "#fee08b"]
-      const color_mapper = new LogColorMapper({low: 0, high: 10, palette})
-
-      const buf8 = color_mapper.rgba_mapper.v_compute([0])
-      expect([buf8[0], buf8[1], buf8[2], buf8[3]]).to.be.deep.equal([50, 136, 189, 255])
-    })
   })
 
   describe("LogColorMapper.v_compute method", () => {


### PR DESCRIPTION
Fixes #8724.

LogColorMapper would (for now) use plain old `Math.log`, which means it is consistent with LogTicker etc. and the current documentation. At least for the time being people won't unwittingly create plainly wrong colormaps anymore.

Long-term, I think @jlstevens' #8743 and #8765 would be much better suited to address issues such as scales blowing up when outliers near zero are present.

Before:
![plot_log1p](https://user-images.githubusercontent.com/38992106/55980362-4d9a0280-5c62-11e9-9abb-a7cb4e6169d9.png)

After:
![plot_log](https://user-images.githubusercontent.com/38992106/55980370-54c11080-5c62-11e9-91c2-d5e82e56a081.png)

```
import numpy as np

from bokeh.io import show
from bokeh.models import ColorBar, LogTicker
from bokeh.models.sources import ColumnDataSource
from bokeh.models.mappers import LinearColorMapper, LogColorMapper
from bokeh.palettes import Viridis6, Viridis3
from bokeh.plotting import figure

x = np.linspace(1e-4, 1e-1, num=2500)
y = np.random.normal(size=2500) * 2 + 5
source = ColumnDataSource(dict(x=x, y1=y, y2=y - 10))

log_mapper = LogColorMapper(palette=Viridis3, low=1e-4, high=1e-1)

p = figure(x_axis_type='linear', toolbar_location='above')
opts = dict(x='x', line_color=None, source=source)
p.circle(y='y1', fill_color={'field': 'x', 'transform': log_mapper}, legend="Log mapper", **opts)

colorbar = ColorBar(color_mapper=log_mapper, location=(0,0), orientation='horizontal', padding=0)

p.add_layout(colorbar, 'below')

show(p)

from bokeh.io import export_png

export_png(p, filename="plot.png")
```