### PR TITLE
Fix the exports when using Firefox as a webdriver.

### DIFF
--- a/bokeh/io/export.py
+++ b/bokeh/io/export.py
@@ -306,7 +306,7 @@ def wait_until_render_complete(driver):
             if len(messages) > 0:
                 log.warning("There were browser warnings and/or errors that may have affected your export")
                 for message in messages:
-                log.warning(message)
+                    log.warning(message)
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/bokeh/io/export.py
+++ b/bokeh/io/export.py
@@ -274,6 +274,7 @@ def wait_until_render_complete(driver):
     '''
     from selenium.webdriver.support.ui import WebDriverWait
     from selenium.common.exceptions import TimeoutException
+    from selenium.webdriver import Firefox
 
     def is_bokeh_loaded(driver):
         return driver.execute_script('''
@@ -298,11 +299,13 @@ def wait_until_render_complete(driver):
                     "a 'bokeh:idle' event to signify that the layout has rendered. "
                     "Something may have gone wrong.")
     finally:
-        browser_logs = driver.get_log('browser')
-        messages = [ l.get("message") for l in browser_logs if l.get('level') in ['WARNING', 'ERROR', 'SEVERE'] ]
-        if len(messages) > 0:
-            log.warning("There were browser warnings and/or errors that may have affected your export")
-            for message in messages:
+        # Firefox webdriver does not currently support logs
+        if not isinstance(driver, Firefox):
+            browser_logs = driver.get_log('browser')
+            messages = [ l.get("message") for l in browser_logs if l.get('level') in ['WARNING', 'ERROR', 'SEVERE'] ]
+            if len(messages) > 0:
+                log.warning("There were browser warnings and/or errors that may have affected your export")
+                for message in messages:
                 log.warning(message)
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION

- [x] issues: fixes #8853
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

This PR enables Firefox to be used as a webdriver by disabling logs. 

It can then be used like this:
```
from selenium.webdriver import Firefox, FirefoxOptions
options = FirefoxOptions()
options.headless = True
webdriver = Firefox(options=options)
export_png(item, path, webdriver=webdriver)
```

It _may_ be a starting point to fix this issue: https://github.com/bokeh/bokeh/issues/8176