### PR TITLE
Create README to explain server_embed usage

### DIFF
--- a/examples/howto/server_embed/README.md
+++ b/examples/howto/server_embed/README.md
@@ -1,0 +1,11 @@
+- `flask_embed.py` rename to _main.py_, run with `python main.py`, and open http://127.0.0.1:8000/ in a web browser.
+- `flask_gunicorn_embed.py` a UNIX environment is required to run this script.
+- `notebook_embed.ipynb` requires [Jupyter Notebook](https://jupyter.org/).
+- `standalone_embed.py` rename to _main.py_ and run with `python main.py`. On Windows, the `num_procs=4` argument must
+be removed from the Server initialisation call on line 34.
+- `tornado_embed.py` rename to _main.py_ and run with `python main.py`. On Windows, the `num_procs=4` argument must be
+removed from the Server initialisation call on line 47. Note: the `static/` end point is reserved for Bokeh resources,
+as specified in [bokeh.server.urls](https://bokeh.pydata.org/en/latest/docs/reference/server/urls.html). In order to
+make your own end point for static resources, add the following to the `extra_patterns` argument, replacing `DIR` with
+the desired directory
+`(r'/DIR/(.*)', StaticFileHandler, {'path': os.path.normpath(os.path.dirname(__file__) + '/DIR')})`.

--- a/examples/howto/server_embed/README.md
+++ b/examples/howto/server_embed/README.md
@@ -1,11 +1,12 @@
-- `flask_embed.py` rename to _main.py_, run with `python main.py`, and open http://127.0.0.1:8000/ in a web browser.
+- `flask_embed.py` run with `python flask_embed.py` and open http://127.0.0.1:8000/ in a web browser.
 - `flask_gunicorn_embed.py` a UNIX environment is required to run this script.
 - `notebook_embed.ipynb` requires [Jupyter Notebook](https://jupyter.org/).
-- `standalone_embed.py` rename to _main.py_ and run with `python main.py`. On Windows, the `num_procs=4` argument must
-be removed from the Server initialisation call on line 34.
-- `tornado_embed.py` rename to _main.py_ and run with `python main.py`. On Windows, the `num_procs=4` argument must be
-removed from the Server initialisation call on line 47. Note: the `static/` end point is reserved for Bokeh resources,
-as specified in [bokeh.server.urls](https://bokeh.pydata.org/en/latest/docs/reference/server/urls.html). In order to
-make your own end point for static resources, add the following to the `extra_patterns` argument, replacing `DIR` with
-the desired directory
-`(r'/DIR/(.*)', StaticFileHandler, {'path': os.path.normpath(os.path.dirname(__file__) + '/DIR')})`.
+- `standalone_embed.py` run with `python standalone_embed.py`.
+On Windows, the `num_procs=4` argument must be removed from the Server initialisation call on line 34.
+- `tornado_embed.py` run with `python tornado_embed.py`.
+On Windows, the `num_procs=4` argument must be removed from the Server initialisation call on line 47.
+Note: the `static/` end point is reserved for Bokeh resources, as specified in
+[bokeh.server.urls](https://bokeh.pydata.org/en/latest/docs/reference/server/urls.html). In order to
+make your own end point for static resources, add the following to the `extra_patterns` argument,
+replacing `DIR` with the desired directory.
+`(r'/DIR/(.*)', StaticFileHandler, {'path': os.path.normpath(os.path.dirname(__file__) + '/DIR')})`

--- a/examples/howto/server_embed/README.md
+++ b/examples/howto/server_embed/README.md
@@ -5,8 +5,3 @@
 On Windows, the `num_procs=4` argument must be removed from the Server initialisation call on line 34.
 - `tornado_embed.py` run with `python tornado_embed.py`.
 On Windows, the `num_procs=4` argument must be removed from the Server initialisation call on line 47.
-Note: the `static/` end point is reserved for Bokeh resources, as specified in
-[bokeh.server.urls](https://bokeh.pydata.org/en/latest/docs/reference/server/urls.html). In order to
-make your own end point for static resources, add the following to the `extra_patterns` argument,
-replacing `DIR` with the desired directory.
-`(r'/DIR/(.*)', StaticFileHandler, {'path': os.path.normpath(os.path.dirname(__file__) + '/DIR')})`

--- a/examples/howto/server_embed/tornado_embed.py
+++ b/examples/howto/server_embed/tornado_embed.py
@@ -44,6 +44,10 @@ def modify_doc(doc):
 # Setting num_procs here means we can't touch the IOLoop before now, we must
 # let Server handle that. If you need to explicitly handle IOLoops then you
 # will need to use the lower level BaseServer class.
+# The `static/` end point is reserved for Bokeh resources, as specified in
+# bokeh.server.urls. In order to make your own end point for static resources,
+# add the following to the `extra_patterns` argument, replacing `DIR` with the desired directory.
+# (r'/DIR/(.*)', StaticFileHandler, {'path': os.path.normpath(os.path.dirname(__file__) + '/DIR')})
 server = Server({'/bkapp': modify_doc}, num_procs=4, extra_patterns=[('/', IndexHandler)])
 server.start()
 


### PR DESCRIPTION
The examples in server_embed have requirements that may not be apparent to new users. This README should help avoid confusion.