### PR TITLE
#8889 fixed, removed unnecessary clause

### DIFF
--- a/bokehjs/src/lib/models/glyphs/image_url.ts
+++ b/bokehjs/src/lib/models/glyphs/image_url.ts
@@ -158,9 +158,6 @@ export class ImageURLView extends XYGlyphView {
       if (isNaN(sx[i] + sy[i] + _angle[i]))
         continue
 
-      if (this.retries[i] == -1)
-        continue
-
       const img = image[i]
 
       if (img == null) {


### PR DESCRIPTION
This pull request contains an easy fix to issue #8889. 
I removed the error causing if statement, since the image will be tested to not be null 
before rendering anyway. 

- [x] issues: fixes #8889
- [x] tests: passed (As far as I can tell)
