### PR TITLE
Ensure that js_property_callbacks can be updated

### DIFF
--- a/bokeh/model.py
+++ b/bokeh/model.py
@@ -538,12 +538,14 @@ class Model(with_metaclass(MetaModel, HasProps, PropertyCallbackManager, EventCa
         if event in self.properties():
             event = "change:%s" % event
 
+        old = {k: [cb for cb in cbs] for k, cbs in self.js_property_callbacks.items()}
         if event not in self.js_property_callbacks:
             self.js_property_callbacks[event] = []
         for callback in callbacks:
             if callback in self.js_property_callbacks[event]:
                 continue
             self.js_property_callbacks[event].append(callback)
+        self.trigger('js_property_callbacks', old, self.js_property_callbacks)
 
     def layout(self, side, plot):
         '''

--- a/bokehjs/src/lib/core/signaling.ts
+++ b/bokehjs/src/lib/core/signaling.ts
@@ -171,7 +171,7 @@ export function Signalable<C extends Constructor>(Base?: C) {
       connect<Args, Sender extends object>(signal: Signal<Args, Sender>, slot: Slot<Args, Sender>): boolean {
         return signal.connect(slot, this)
       }
-	  disconnect<Args, Sender extends object>(signal: Signal<Args, Sender>, slot: Slot<Args, Sender>): boolean {
+      disconnect<Args, Sender extends object>(signal: Signal<Args, Sender>, slot: Slot<Args, Sender>): boolean {
         return signal.disconnect(slot, this)
       }
     }

--- a/bokehjs/src/lib/core/signaling.ts
+++ b/bokehjs/src/lib/core/signaling.ts
@@ -162,11 +162,17 @@ export function Signalable<C extends Constructor>(Base?: C) {
       connect<Args, Sender extends object>(signal: Signal<Args, Sender>, slot: Slot<Args, Sender>): boolean {
         return signal.connect(slot, this)
       }
+      disconnect<Args, Sender extends object>(signal: Signal<Args, Sender>, slot: Slot<Args, Sender>): boolean {
+        return signal.disconnect(slot, this)
+      }
     }
   } else {
     return class implements ISignalable {
       connect<Args, Sender extends object>(signal: Signal<Args, Sender>, slot: Slot<Args, Sender>): boolean {
         return signal.connect(slot, this)
+      }
+	  disconnect<Args, Sender extends object>(signal: Signal<Args, Sender>, slot: Slot<Args, Sender>): boolean {
+        return signal.disconnect(slot, this)
       }
     }
   }
@@ -175,6 +181,9 @@ export function Signalable<C extends Constructor>(Base?: C) {
 export namespace _Signalable {
   export function connect<Args, Sender extends object>(this: object, signal: Signal<Args, Sender>, slot: Slot<Args, Sender>): boolean {
     return signal.connect(slot, this)
+  }
+  export function disconnect<Args, Sender extends object>(this: object, signal: Signal<Args, Sender>, slot: Slot<Args, Sender>): boolean {
+    return signal.disconnect(slot, this)
   }
 }
 

--- a/bokehjs/src/lib/model.ts
+++ b/bokehjs/src/lib/model.ts
@@ -43,15 +43,8 @@ export class Model extends HasProps {
   connect_signals(): void {
     super.connect_signals()
 
-    for (const base_evt in this.js_property_callbacks) {
-      const callbacks = this.js_property_callbacks[base_evt]
-      const [evt, attr=null] = base_evt.split(':')
-      for (const cb of callbacks) {
-        const signal = attr != null ? (this.properties as any)[attr][evt] : (this as any)[evt]
-        this.connect(signal, () => cb.execute(this))
-      }
-    }
-
+    this._update_property_callbacks()
+    this.connect(this.properties.js_property_callbacks.change, () => this._update_property_callbacks())
     this.connect(this.properties.js_event_callbacks.change, () => this._update_event_callbacks())
     this.connect(this.properties.subscribed_events.change, () => this._update_event_callbacks())
   }
@@ -78,6 +71,18 @@ export class Model extends HasProps {
       return
     }
     this.document.event_manager.subscribed_models.add(this.id)
+  }
+
+  protected _update_property_callbacks(): void {
+    for (const base_evt in this.js_property_callbacks) {
+      const callbacks = this.js_property_callbacks[base_evt]
+      const [evt, attr=null] = base_evt.split(':')
+      for (const cb of callbacks) {
+        console.log(cb)
+        const signal = attr != null ? (this.properties as any)[attr][evt] : (this as any)[evt]
+        this.connect(signal, () => cb.execute(this))
+      }
+    }
   }
 
   protected _doc_attached(): void {

--- a/bokehjs/src/lib/model.ts
+++ b/bokehjs/src/lib/model.ts
@@ -84,7 +84,7 @@ export class Model extends HasProps {
       }
     }
     this._js_callbacks = {};
-	for (const base_evt in this.js_property_callbacks) {
+    for (const base_evt in this.js_property_callbacks) {
       const callbacks = this.js_property_callbacks[base_evt]
       const [evt, attr=null] = base_evt.split(':')
       this._js_callbacks[base_evt] = []

--- a/bokehjs/src/lib/model.ts
+++ b/bokehjs/src/lib/model.ts
@@ -83,7 +83,7 @@ export class Model extends HasProps {
         this.disconnect(signal, cb)
       }
     }
-    this._js_callbacks = {};
+    this._js_callbacks = {}
     for (const base_evt in this.js_property_callbacks) {
       const callbacks = this.js_property_callbacks[base_evt]
       const [evt, attr=null] = base_evt.split(':')

--- a/bokehjs/src/lib/model.ts
+++ b/bokehjs/src/lib/model.ts
@@ -23,7 +23,7 @@ export interface Model extends Model.Attrs {}
 
 export class Model extends HasProps {
   properties: Model.Props
-  private _js_callbacks: {[key: string]: any[]}
+  private _js_callbacks: {[key: string]: (() => void)[]}
 
   constructor(attrs?: Partial<Model.Attrs>) {
     super(attrs)
@@ -75,25 +75,26 @@ export class Model extends HasProps {
   }
 
   protected _update_property_callbacks(): void {
-    for (const base_evt in this._js_callbacks) {
-      const callbacks = this._js_callbacks[base_evt]
-      const [evt, attr=null] = base_evt.split(':')
-      for (const cb of callbacks) {
-        const signal = attr != null ? (this.properties as any)[attr][evt] : (this as any)[evt]
+    const signal_for = (event: string) => {
+      const [evt, attr=null] = event.split(":")
+      return attr != null ? (this.properties as any)[attr][evt] : (this as any)[evt]
+    }
+
+    for (const event in this._js_callbacks) {
+      const callbacks = this._js_callbacks[event]
+      const signal = signal_for(event)
+      for (const cb of callbacks)
         this.disconnect(signal, cb)
-      }
     }
     this._js_callbacks = {}
-    for (const base_evt in this.js_property_callbacks) {
-      const callbacks = this.js_property_callbacks[base_evt]
-      const [evt, attr=null] = base_evt.split(':')
-      this._js_callbacks[base_evt] = []
-      for (const cb of callbacks) {
-        const signal = attr != null ? (this.properties as any)[attr][evt] : (this as any)[evt]
-        const cb_wrapper = () => cb.execute(this)
-        this.connect(signal, cb_wrapper)
-        this._js_callbacks[base_evt].push(cb_wrapper)
-      }
+
+    for (const event in this.js_property_callbacks) {
+      const callbacks = this.js_property_callbacks[event]
+      const wrappers = callbacks.map((cb) => () => cb.execute(this))
+      this._js_callbacks[event] = wrappers
+      const signal = signal_for(event)
+      for (const cb of wrappers)
+        this.connect(signal, cb)
     }
   }
 


### PR DESCRIPTION
This PR ensures that when ``js_on_change`` is called a ``ModelChangedEvent`` is triggered and the callbacks are updated on the frontend. The main problem I'm currently facing is that I haven't yet figured out how to disconnect previous callbacks since at least in theory callbacks could be deleted as well as added. If we don't expect them ever to be deleted we could also simply keep track of callbacks that have been connected and skip them the second.

- [x] issues: fixes #8895
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
