### PR TITLE
pass layout kwargs to underlying objects

### DIFF
--- a/bokeh/layouts.py
+++ b/bokeh/layouts.py
@@ -219,7 +219,7 @@ def layout(*args, **kwargs):
     children = _handle_children(*args, children=children)
 
     # Make the grid
-    return _create_grid(children, sizing_mode)
+    return _create_grid(children, sizing_mode, **kwargs)
 
 def gridplot(children, sizing_mode=None, toolbar_location='above', ncols=None,
              plot_width=None, plot_height=None, toolbar_options=None, merge_tools=True):
@@ -590,7 +590,7 @@ def _handle_children(*args, **kwargs):
     return children
 
 
-def _create_grid(iterable, sizing_mode, layer=0):
+def _create_grid(iterable, sizing_mode, layer=0, **kwargs):
     """Recursively create grid from input lists."""
     return_list = []
     for item in iterable:
@@ -606,8 +606,8 @@ def _create_grid(iterable, sizing_mode, layer=0):
                 Tried to insert: %s of type %s""" % (item, type(item))
             )
     if layer % 2 == 0:
-        return column(children=return_list, sizing_mode=sizing_mode)
-    return row(children=return_list, sizing_mode=sizing_mode)
+        return column(children=return_list, sizing_mode=sizing_mode, **kwargs)
+    return row(children=return_list, sizing_mode=sizing_mode, **kwargs)
 
 
 def _chunks(l, ncols):

--- a/bokeh/tests/test_layouts.py
+++ b/bokeh/tests/test_layouts.py
@@ -85,6 +85,14 @@ def test_layout_simple():
         assert isinstance(r, Row)
 
 
+def test_layout_kwargs():
+    p1, p2, p3, p4 = figure(), figure(), figure(), figure()
+
+    grid = layout([[p1, p2], [p3, p4]], sizing_mode='fixed', name='simple')
+
+    assert grid.name == 'simple'
+
+
 def test_layout_nested():
     p1, p2, p3, p4, p5, p6 = figure(), figure(), figure(), figure(), figure(), figure()
 


### PR DESCRIPTION
This PR passes the `kwargs` given to `layout()` down to the underlying `row()` or `column()` calls in `bokeh.layouts`.  This fixes the behavior described in #8903.

- [x] issues: fixes #8903
- [x] tests added / passed
