### PR TITLE
add value_throttled property to sliders

### DIFF
--- a/bokeh/models/widgets/sliders.py
+++ b/bokeh/models/widgets/sliders.py
@@ -80,6 +80,8 @@ class AbstractSlider(Widget):
 
     callback = Instance(Callback, help="""
     A callback to run in the browser whenever the current Slider value changes.
+
+    DEPRECATED: use .js_on_change or .on_change with "value" or "value_throttled"
     """)
 
     callback_throttle = Float(default=200, help="""
@@ -87,7 +89,9 @@ class AbstractSlider(Widget):
     """)
 
     callback_policy = Enum(SliderCallbackPolicy, default="throttle", help="""
-    When the callback is initiated. This parameter can take on only one of three options:
+    When the value_throttled property is updated.
+
+    This parameter can take on only one of three options:
 
     * "continuous": the callback will be executed immediately for each movement of the slider
     * "throttle": the callback will be executed at most every ``callback_throttle`` milliseconds.
@@ -95,8 +99,7 @@ class AbstractSlider(Widget):
 
     The "mouseup" policy is intended for scenarios in which the callback is expensive in time.
 
-    .. warning::
-        Callback policy currently apply to JS callbacks
+    Both Python and JS callbacks on "value_throttled" will respect this policy setting.
     """)
 
     bar_color = Color(default="#e6e6e6", help="""
@@ -127,6 +130,10 @@ class Slider(AbstractSlider):
     Initial or selected value.
     """)
 
+    value_throttled = Float(help="""
+    Initial or selected value, throttled according to callback_policy.
+    """)
+
     step = Float(default=1, help="""
     The step between consecutive values.
     """)
@@ -138,6 +145,10 @@ class RangeSlider(AbstractSlider):
 
     value = Tuple(Float, Float, help="""
     Initial or selected range.
+    """)
+
+    value_throttled = Tuple(Float, Float, help="""
+    Initial or selected value, throttled according to callback_policy.
     """)
 
     start = Float(help="""
@@ -159,6 +170,10 @@ class DateSlider(AbstractSlider):
 
     value = Date(help="""
     Initial or selected value.
+    """)
+
+    value_throttled = Date(help="""
+    Initial or selected value, throttled according to callback_policy.
     """)
 
     start = Date(help="""
@@ -221,6 +236,10 @@ class DateRangeSlider(AbstractSlider):
 
     value = Tuple(Date, Date, help="""
     Initial or selected range.
+    """)
+
+    value_throttled = Tuple(Date, Date, help="""
+    Initial or selected value, throttled according to callback_policy.
     """)
 
     start = Date(help="""

--- a/bokehjs/src/lib/models/widgets/abstract_slider.ts
+++ b/bokehjs/src/lib/models/widgets/abstract_slider.ts
@@ -62,21 +62,23 @@ export abstract class AbstractSliderView extends ControlView {
 
   protected _init_callback(): void {
     const {callback} = this.model
-    if (callback != null) {
-      const fn = () => callback.execute(this.model)
+    const fn = () => {
+      if (callback != null)
+        callback.execute(this.model)
+      this.model.value_throttled = this.model.value
+    }
 
-      switch (this.model.callback_policy) {
-        case 'continuous': {
-          this.callback_wrapper = fn
-          break
-        }
-        case 'throttle': {
-          this.callback_wrapper = throttle(fn, this.model.callback_throttle)
-          break
-        }
-        default:
-          this.callback_wrapper = undefined
+    switch (this.model.callback_policy) {
+      case 'continuous': {
+        this.callback_wrapper = fn
+        break
       }
+      case 'throttle': {
+        this.callback_wrapper = throttle(fn, this.model.callback_throttle)
+        break
+      }
+      default:
+        this.callback_wrapper = undefined
     }
   }
 
@@ -208,6 +210,7 @@ export abstract class AbstractSliderView extends ControlView {
 
   protected _change(values: number[]): void {
     this.model.value = this._calc_from(values)
+    this.model.value_throttled = this.model.value
     switch (this.model.callback_policy) {
       case 'mouseup':
       case 'throttle': {
@@ -228,6 +231,7 @@ export namespace AbstractSlider {
     start: p.Property<any> // XXX
     end: p.Property<any> // XXX
     value: p.Property<any> // XXX
+    value_throttled: p.Property<any> // XXX
     step: p.Property<number>
     format: p.Property<string>
     direction: p.Property<"ltr" | "rtl">
@@ -257,6 +261,7 @@ export abstract class AbstractSlider extends Control {
       start:             [ p.Any                                ],
       end:               [ p.Any                                ],
       value:             [ p.Any                                ],
+      value_throttled:   [ p.Any                                ],
       step:              [ p.Number,               1            ],
       format:            [ p.String                             ],
       direction:         [ p.Any,                  "ltr"        ],

--- a/examples/app/clustering/main.py
+++ b/examples/app/clustering/main.py
@@ -131,6 +131,7 @@ dataset_select = Select(value='Noisy Circles',
                         options=datasets_names)
 
 samples_slider = Slider(title="Number of samples",
+                        callback_policy="mouseup",
                         value=1500.0,
                         start=1000.0,
                         end=3000.0,
@@ -138,6 +139,7 @@ samples_slider = Slider(title="Number of samples",
                         width=400)
 
 clusters_slider = Slider(title="Number of clusters",
+                         callback_policy="mouseup",
                          value=2.0,
                          start=2.0,
                          end=10.0,
@@ -173,10 +175,10 @@ def update_samples_or_dataset(attrname, old, new):
     source.data = dict(colors=colors, x=X[:, 0], y=X[:, 1])
 
 algorithm_select.on_change('value', update_algorithm_or_clusters)
-clusters_slider.on_change('value', update_algorithm_or_clusters)
+clusters_slider.on_change('value_throttled', update_algorithm_or_clusters)
 
 dataset_select.on_change('value', update_samples_or_dataset)
-samples_slider.on_change('value', update_samples_or_dataset)
+samples_slider.on_change('value_throttled', update_samples_or_dataset)
 
 # set up layout
 selects = row(dataset_select, algorithm_select, width=420)

--- a/examples/howto/layouts/dashboard.py
+++ b/examples/howto/layouts/dashboard.py
@@ -42,31 +42,30 @@ def slider():
         title="Sliders example")
     plot.line('x', 'y', source=source, line_width=3, line_alpha=0.6)
 
-    callback = CustomJS(args=dict(source=source), code="""
-        var data = source.data;
-        var A = amp.value;
-        var k = freq.value;
-        var phi = phase.value;
-        var B = offset.value;
-        var x = data['x']
-        var y = data['y']
+    amp_slider = Slider(start=0.1, end=10, value=1, step=.1, title="Amplitude")
+    freq_slider = Slider(start=0.1, end=10, value=1, step=.1, title="Frequency")
+    phase_slider = Slider(start=0, end=6.4, value=0, step=.1, title="Phase")
+    offset_slider = Slider(start=-5, end=5, value=0, step=.1, title="Offset")
+
+    callback = CustomJS(args=dict(source=source, amp=amp_slider, freq=freq_slider, phase=phase_slider, offset=offset_slider),
+                        code="""
+        const data = source.data;
+        const A = amp.value;
+        const k = freq.value;
+        const phi = phase.value;
+        const B = offset.value;
+        const x = data['x']
+        const y = data['y']
         for (var i = 0; i < x.length; i++) {
             y[i] = B + A*Math.sin(k*x[i]+phi);
         }
         source.change.emit();
     """)
 
-    amp_slider = Slider(start=0.1, end=10, value=1, step=.1, title="Amplitude", callback=callback, callback_policy='mouseup')
-    callback.args["amp"] = amp_slider
-
-    freq_slider = Slider(start=0.1, end=10, value=1, step=.1, title="Frequency", callback=callback)
-    callback.args["freq"] = freq_slider
-
-    phase_slider = Slider(start=0, end=6.4, value=0, step=.1, title="Phase", callback=callback)
-    callback.args["phase"] = phase_slider
-
-    offset_slider = Slider(start=-5, end=5, value=0, step=.1, title="Offset", callback=callback)
-    callback.args["offset"] = offset_slider
+    amp_slider.js_on_change('value', callback)
+    freq_slider.js_on_change('value', callback)
+    phase_slider.js_on_change('value', callback)
+    offset_slider.js_on_change('value', callback)
 
     widgets = column(amp_slider, freq_slider, phase_slider, offset_slider)
     return [widgets, plot]

--- a/examples/plotting/file/color_sliders.py
+++ b/examples/plotting/file/color_sliders.py
@@ -50,45 +50,40 @@ p1.text(0, 0, text='color', text_color='text_color',
         alpha=0.6667, text_font_size='36pt', text_baseline='middle',
         text_align='center', source=source)
 
+red_slider = Slider(title="R", start=0, end=255, value=255, step=1)
+green_slider = Slider(title="G", start=0, end=255, value=255, step=1)
+blue_slider = Slider(title="B", start=0, end=255, value=255, step=1)
+
 # the callback function to update the color of the block and associated label text
 # NOTE: the JS functions for converting RGB to hex are taken from the excellent answer
 # by Tim Down at http://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
-callback = CustomJS(args=dict(source=source), code="""
+callback = CustomJS(args=dict(source=source, red=red_slider, blue=blue_slider, green=green_slider), code="""
     function componentToHex(c) {
-        var hex = c.toString(16);
-        return hex.length == 1 ? "0" + hex : hex;
+        var hex = c.toString(16)
+        return hex.length == 1 ? "0" + hex : hex
     }
     function rgbToHex(r, g, b) {
-        return "#" + componentToHex(r) + componentToHex(g) + componentToHex(b);
+        return "#" + componentToHex(r) + componentToHex(g) + componentToHex(b)
     }
     function toInt(v) {
-       return v | 0;
+       return v | 0
     }
-    var data = source.data;
-    var color = data['color'];
-    var text_color = data['text_color'];
-    var R = toInt(red_slider.value);
-    var G = toInt(green_slider.value);
-    var B = toInt(blue_slider.value);
-    color[0] = rgbToHex(R, G, B);
-    text_color[0] = '#ffffff';
+    const color = source.data['color']
+    const text_color = source.data['text_color']
+    const R = toInt(red.value)
+    const G = toInt(green.value)
+    const B = toInt(blue.value)
+    color[0] = rgbToHex(R, G, B)
+    text_color[0] = '#ffffff'
     if ((R > 127) || (G > 127) || (B > 127)) {
-        text_color[0] = '#000000';
+        text_color[0] = '#000000'
     }
-    source.change.emit();
+    source.change.emit()
 """)
 
-# create slider tool objects with a callback to control the RGB levels for first plot
-SLIDER_ARGS = dict(start=0, end=255, value=255, step=1, callback=callback)
-
-red_slider = Slider(title="R", **SLIDER_ARGS)
-callback.args['red_slider'] = red_slider
-
-green_slider = Slider(title="G", **SLIDER_ARGS)
-callback.args['green_slider'] = green_slider
-
-blue_slider = Slider(title="B", **SLIDER_ARGS)
-callback.args['blue_slider'] = blue_slider
+red_slider.js_on_change('value', callback)
+blue_slider.js_on_change('value', callback)
+green_slider.js_on_change('value', callback)
 
 # plot 2: create a color spectrum with a hover-over tool to inspect hex codes
 

--- a/examples/plotting/file/slider.py
+++ b/examples/plotting/file/slider.py
@@ -13,35 +13,30 @@ plot = figure(y_range=(-10, 10), plot_width=400, plot_height=400)
 
 plot.line('x', 'y', source=source, line_width=3, line_alpha=0.6)
 
-callback = CustomJS(args=dict(source=source), code="""
-    var data = source.data;
-    var A = amp.value;
-    var k = freq.value;
-    var phi = phase.value;
-    var B = offset.value;
-    var x = data['x']
-    var y = data['y']
+amp_slider = Slider(start=0.1, end=10, value=1, step=.1, title="Amplitude")
+freq_slider = Slider(start=0.1, end=10, value=1, step=.1, title="Frequency")
+phase_slider = Slider(start=0, end=6.4, value=0, step=.1, title="Phase")
+offset_slider = Slider(start=-5, end=5, value=0, step=.1, title="Offset")
+
+callback = CustomJS(args=dict(source=source, amp=amp_slider, freq=freq_slider, phase=phase_slider, offset=offset_slider),
+                    code="""
+    const data = source.data;
+    const A = amp.value;
+    const k = freq.value;
+    const phi = phase.value;
+    const B = offset.value;
+    const x = data['x']
+    const y = data['y']
     for (var i = 0; i < x.length; i++) {
         y[i] = B + A*Math.sin(k*x[i]+phi);
     }
     source.change.emit();
 """)
 
-amp_slider = Slider(start=0.1, end=10, value=1, step=.1,
-                    title="Amplitude", callback=callback)
-callback.args["amp"] = amp_slider
-
-freq_slider = Slider(start=0.1, end=10, value=1, step=.1,
-                     title="Frequency", callback=callback)
-callback.args["freq"] = freq_slider
-
-phase_slider = Slider(start=0, end=6.4, value=0, step=.1,
-                      title="Phase", callback=callback)
-callback.args["phase"] = phase_slider
-
-offset_slider = Slider(start=-5, end=5, value=0, step=.1,
-                       title="Offset", callback=callback)
-callback.args["offset"] = offset_slider
+amp_slider.js_on_change('value', callback)
+freq_slider.js_on_change('value', callback)
+phase_slider.js_on_change('value', callback)
+offset_slider.js_on_change('value', callback)
 
 layout = row(
     plot,

--- a/examples/plotting/file/slider_callback_policy.py
+++ b/examples/plotting/file/slider_callback_policy.py
@@ -2,41 +2,22 @@ from bokeh.io import output_file, show
 from bokeh.layouts import column
 from bokeh.models import CustomJS, Slider, Div
 
-# NOTE: the JS functions to forvide the format code for strings is found the answer
-# from the user fearphage at http://stackoverflow.com/questions/610406/javascript-equivalent-to-printf-string-format
-callback = CustomJS(code="""
-    var s1 = slider1.value;
-    var s2 = slider2.value;
-    var s3 = slider3.value;
-
-    if (!String.prototype.format) {
-      String.prototype.format = function() {
-        var args = arguments;
-        return this.replace(/{(\d+)}/g, function(match, number) {
-          return typeof args[number] != 'undefined'
-            ? args[number]
-            : match
-          ;
-        });
-      };
-    }
-
-    para.text = "<h1>Slider Values</h1><p>Slider 1: {0}<p>Slider 2: {1}<p>Slider 3: {2}".format(s1, s2, s3);
-""")
-
 para = Div(text="<h1>Slider Values:</h1><p>Slider 1: 0<p>Slider 2: 0<p>Slider 3: 0")
 
 s1 = Slider(title="Slider 1 (Continuous)", start=0, end=1000, value=0, step=1,
-            callback=callback, callback_policy="continuous")
+            callback_policy="continuous")
 s2 = Slider(title="Slider 2 (Throttle)", start=0, end=1000, value=0, step=1,
-            callback=callback, callback_policy="throttle", callback_throttle=1000)
+            callback_policy="throttle", callback_throttle=1000)
 s3 = Slider(title="Slider 3 (Mouse Up)", start=0, end=1000, value=0, step=1,
-            callback=callback, callback_policy="mouseup")
+            callback_policy="mouseup")
 
-callback.args['para'] = para
-callback.args['slider1'] = s1
-callback.args['slider2'] = s2
-callback.args['slider3'] = s3
+callback = CustomJS(args=dict(para=para, s1=s1, s2=s2, s3=s3), code="""
+    para.text = "<h1>Slider Values</h1><p>Slider 1: " + s1.value  + "<p>Slider 2: " + s2.value + "<p>Slider 3: " + s3.value
+""")
+
+s1.js_on_change('value_throttled', callback)
+s2.js_on_change('value_throttled', callback)
+s3.js_on_change('value_throttled', callback)
 
 output_file('slider_callback_policy.html')
 

--- a/sphinx/source/docs/user_guide/examples/extensions_example_widget.py
+++ b/sphinx/source/docs/user_guide/examples/extensions_example_widget.py
@@ -108,9 +108,11 @@ callback_ion = CustomJS(args=dict(source=source), code="""
     """)
 
 
-slider = Slider(start=0, end=5, step=0.1, value=1, title="Bokeh Slider - Power", callback=callback_single)
+slider = Slider(start=0, end=5, step=0.1, value=1, title="Bokeh Slider - Power")
+slider.js_on_change('value', callback_single)
+
 ion_range_slider = IonRangeSlider(start=0.01, end=0.99, step=0.01, range=(min(x), max(x)),
-    title='Ion Range Slider - Range', callback=callback_ion, callback_policy='continuous')
+    title='Ion Range Slider - Range', callback_policy='continuous', callback=callback_ion)
 
 layout = column(plot, slider, ion_range_slider)
 show(layout)

--- a/sphinx/source/docs/user_guide/examples/interaction_callbacks_for_widgets.py
+++ b/sphinx/source/docs/user_guide/examples/interaction_callbacks_for_widgets.py
@@ -23,7 +23,8 @@ callback = CustomJS(args=dict(source=source), code="""
         source.change.emit();
     """)
 
-slider = Slider(start=0.1, end=4, value=1, step=.1, title="power", callback=callback)
+slider = Slider(start=0.1, end=4, value=1, step=.1, title="power")
+slider.js_on_change('value', callback)
 
 layout = column(slider, plot)
 


### PR DESCRIPTION
- [x] issues: fixes #4540
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

This adds `value_throttled` to sliders, which obeys the callback policy for both JS and Python callbacks. Examples are updated to use this where appropriate, and additionally all slider examples are updated to use `value` or `value_throttled` for callbacks instead of the deprecated `callback` property. 