### PR TITLE
remove vestigal plot symmetry options

### DIFF
--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -35,7 +35,6 @@ from ..core.validation import error, warning
 from ..core.validation.errors import BAD_EXTRA_RANGE_NAME, REQUIRED_RANGE, REQUIRED_SCALE, INCOMPATIBLE_SCALE_AND_RANGE
 from ..core.validation.warnings import MISSING_RENDERERS, FIXED_SIZING_MODE, FIXED_WIDTH_POLICY, FIXED_HEIGHT_POLICY
 from ..model import Model, collect_filtered_models
-from ..util.deprecation import deprecated
 from ..util.string import nice_join
 
 from .annotations import Legend, Title
@@ -616,23 +615,6 @@ class Plot(LayoutDOM):
     to the same value. If an individual border property is explicitly set,
     it will override ``min_border``.
     """)
-
-
-    @property
-    def h_symmetry(self):
-        deprecated("h_symmetry has been non-functional since before Bokeh 1.0 and will be removed at Bokeh 2.0")
-
-    @h_symmetry.setter
-    def h_symmetry(self, _):
-        deprecated("h_symmetry has been non-functional since before Bokeh 1.0 and will be removed at Bokeh 2.0")
-
-    @property
-    def v_symmetry(self):
-        deprecated("v_symmetry has been non-functional since before Bokeh 1.0 and will be removed at Bokeh 2.0")
-
-    @v_symmetry.setter
-    def v_symmetry(self, _):
-        deprecated("v_symmetry has been non-functional since before Bokeh 1.0 and will be removed at Bokeh 2.0")
 
     lod_factor = Int(10, help="""
     Decimation factor to use when applying level-of-detail decimation.

--- a/sphinx/source/docs/releases/2.0.0.rst
+++ b/sphinx/source/docs/releases/2.0.0.rst
@@ -1,0 +1,22 @@
+.. _release-2-0-0:
+
+2.0.0
+=====
+
+Bokeh Version ``2.0.0`` (XXXX 2019) is a major milestone of the Bokeh project.
+
+
+
+And several other bug fixes and docs additions. For full details see the
+:bokeh-tree:`CHANGELOG`.
+
+.. _release-2-0-0-migration:
+
+`Migration Guide <releases.html#release-2-0-0-migration>`__
+-----------------------------------------------------------
+
+Plot Symmetry Properties
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The deprecated vestigal properties ``Plot.h_symmetry`` and ``Plot.v_symmetry``
+have been removed. These properties were non-functional for many releases.


### PR DESCRIPTION
Picking a small issue to get started. This is mostly to prove out running CI on the long-running `landing-2.0` branch.

- [x] issues: fixes #8936
- [x] release document entry (if new feature or API change)
