### PR TITLE
Make Tornado 5 the minimum version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ jobs:
       env:
       - GROUP=unit
       - PYTHON=3.5
-      - TORNADO=4
+      - TORNADO=5
       - MINIMAL=1
 
     - install: scripts/ci/install.test

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -509,8 +509,7 @@ class Serve(Subcommand):
         ('--websocket-max-message-size', dict(
             metavar='BYTES',
             action='store',
-            help="Set the Tornado websocket_max_message_size value (defaults "
-                 "to 20MB) NOTE: This setting has effect ONLY for Tornado>=4.5",
+            help="Set the Tornado websocket_max_message_size value (defaults to 20MB)",
             default=DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES,
             type=int,
         )),

--- a/bokeh/command/subcommands/tests/test_serve.py
+++ b/bokeh/command/subcommands/tests/test_serve.py
@@ -211,8 +211,7 @@ def test_args():
          ('--websocket-max-message-size', dict(
             metavar='BYTES',
             action='store',
-            help="Set the Tornado websocket_max_message_size value (defaults "
-                 "to 20MB) NOTE: This setting has effect ONLY for Tornado>=4.5",
+            help="Set the Tornado websocket_max_message_size value (defaults to 20MB)",
             default=20*1024*1024,
             type=int,
         )),

--- a/bokeh/server/server.py
+++ b/bokeh/server/server.py
@@ -494,8 +494,6 @@ class _ServerOpts(Options):
 
     websocket_max_message_size = Int(default=DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES, help="""
     Set the Tornado ``websocket_max_message_size`` value.
-
-    NOTE: This setting has effect ONLY for Tornado>=4.5
     """)
 
 #-----------------------------------------------------------------------------

--- a/bokeh/server/tests/test_server.py
+++ b/bokeh/server/tests/test_server.py
@@ -670,7 +670,7 @@ def test__server_multiple_processes():
 
 def test__existing_ioloop_with_multiple_processes_exception():
     application = Application()
-    ioloop_instance = IOLoop.instance() ; ioloop_instance # silence flake8
+    ioloop_current = IOLoop.current() ; ioloop_current # silence flake8
     with pytest.raises(RuntimeError):
         with ManagedServerLoop(application, num_procs=3):
             pass

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -162,8 +162,6 @@ class BokehTornado(TornadoApplication):
             Set the Tornado ``websocket_max_message_size`` value.
             (default: 20*1024*1024)
 
-            NOTE: This setting has effect ONLY for Tornado>=4.5
-
     Any additional keyword arguments are passed to ``tornado.web.Application``.
     '''
 

--- a/bokeh/server/views/tests/test_ws.py
+++ b/bokeh/server/views/tests/test_ws.py
@@ -20,8 +20,7 @@ import pytest ; pytest
 import logging
 
 # External imports
-import six
-from tornado.websocket import StreamClosedError, WebSocketClosedError
+from tornado.websocket import WebSocketClosedError
 
 # Bokeh imports
 from bokeh.util.logconfig import basicConfig
@@ -40,13 +39,11 @@ basicConfig()
 # General API
 #-----------------------------------------------------------------------------
 
-@pytest.mark.skipif(six.PY2, reason="this test doesn't work on Python 2 due to 'fake self' hack.")
-@pytest.mark.parametrize('exc', [StreamClosedError, WebSocketClosedError])
 @pytest.mark.unit
-def test_send_message_raises(caplog, exc):
+def test_send_message_raises(caplog):
     class ExcMessage(object):
         def send(self, handler):
-            raise exc()
+            raise WebSocketClosedError()
     assert len(caplog.records) == 0
     with caplog.at_level(logging.WARN):
         # fake self not great but much easier than setting up a real view

--- a/bokeh/server/views/ws.py
+++ b/bokeh/server/views/ws.py
@@ -27,7 +27,7 @@ import codecs
 from six.moves.urllib.parse import urlparse
 
 from tornado import gen, locks
-from tornado.websocket import StreamClosedError, WebSocketHandler, WebSocketClosedError
+from tornado.websocket import WebSocketHandler, WebSocketClosedError
 
 
 # Bokeh imports
@@ -251,7 +251,7 @@ class WSHandler(WebSocketHandler):
             if _message_test_port is not None:
                 _message_test_port.sent.append(message)
             yield message.send(self)
-        except (WebSocketClosedError, StreamClosedError): # Tornado 4.x may raise StreamClosedError
+        except WebSocketClosedError:
             # on_close() is / will be called anyway
             log.warning("Failed sending message as connection was closed")
         raise gen.Return(None)

--- a/bokeh/util/tornado.py
+++ b/bokeh/util/tornado.py
@@ -105,24 +105,16 @@ class _AsyncPeriodic(object):
         self._started = True
 
         def invoke():
-            # important to start the sleep before starting callback
-            # so any initial time spent in callback "counts against"
-            # the period.
+            # important to start the sleep before starting callback so any initial
+            # time spent in callback "counts against" the period.
             sleep_future = self.sleep()
             result = self._func()
 
-            # This is needed for Tornado >= 4.5 where convert_yielded will no
-            # longer raise BadYieldError on None
             if result is None:
                 return sleep_future
 
-            try:
-                callback_future = gen.convert_yielded(result)
-            except gen.BadYieldError:
-                # result is not a yieldable thing
-                return sleep_future
-            else:
-                return gen.multi([sleep_future, callback_future])
+            callback_future = gen.convert_yielded(result)
+            return gen.multi([sleep_future, callback_future])
 
         def on_done(future):
             if not self._stopped:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - pyyaml
     - setuptools
     - six
-    - tornado >=4.3
+    - tornado >=5
     - yaml
 
   run:

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ REQUIRES = [
     'numpy >=1.7.1',
     'pillow >=4.0',
     'packaging >=16.8',
-    'tornado >=4.3',
+    'tornado >=5',
 ]
 
 # handle the compat difference for futures (meta.yaml handles differently)

--- a/sphinx/docserver.py
+++ b/sphinx/docserver.py
@@ -40,7 +40,7 @@ data = {}
 def serve_http():
     data['ioloop'] = IOLoop()
     http_server.listen(PORT)
-    IOLoop.instance().start()
+    IOLoop.current().start()
 
 def shutdown_server():
     ioloop = data['ioloop']

--- a/sphinx/source/docs/releases/2.0.0.rst
+++ b/sphinx/source/docs/releases/2.0.0.rst
@@ -15,6 +15,11 @@ And several other bug fixes and docs additions. For full details see the
 `Migration Guide <releases.html#release-2-0-0-migration>`__
 -----------------------------------------------------------
 
+Minimum Tornado Version
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The Bokeh server now requires Tornado 5.0 or higher.
+
 Plot Symmetry Properties
 ~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
- [x] issues: fixes #8935
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

cc @bokeh/core I'd like to check with folks before just merging this one. By the time the 2.0 landing branch is merge, Tornado 5.0 will be ~18 months old. I am definitely strongly +1 on making 5.x the new minimum version as it integrates very naturally with `asyncio` which I suspect will be valuable to more users over a fairly short time span. 