### PR TITLE
Clean up Rect and its validation in spatial indexing

### DIFF
--- a/bokehjs/src/lib/core/dom.ts
+++ b/bokehjs/src/lib/core/dom.ts
@@ -236,8 +236,8 @@ export function content_size(el: HTMLElement): Size {
 export function position(el: HTMLElement, box: Box, margin?: Extents): void {
   const {style} = el
 
-  style.left   = `${box.left}px`
-  style.top    = `${box.top}px`
+  style.left   = `${box.x}px`
+  style.top    = `${box.y}px`
   style.width  = `${box.width}px`
   style.height = `${box.height}px`
 

--- a/bokehjs/src/lib/core/hittest.ts
+++ b/bokehjs/src/lib/core/hittest.ts
@@ -1,4 +1,3 @@
-import {Rect} from "./types"
 import {sort_by} from "./util/array"
 import {Selection} from "../models/selections/selection"
 
@@ -41,13 +40,6 @@ export function create_hit_test_result_from_hits(hits: [number, number][]): Sele
   const result = new Selection()
   result.indices = sort_by(hits, ([_i, dist]) => dist).map(([i, _dist]) => i)
   return result
-}
-
-export function validate_bbox_coords([x0, x1]: [number, number], [y0, y1]: [number, number]): Rect {
-  // spatial index (flatbush) expects x0, y0 to be min, x1, y1 max
-  if (x0 > x1) [x0, x1] = [x1, x0]
-  if (y0 > y1) [y0, y1] = [y1, y0]
-  return {minX: x0, minY: y0, maxX: x1, maxY: y1}
 }
 
 function sqr(x: number): number {

--- a/bokehjs/src/lib/core/types.ts
+++ b/bokehjs/src/lib/core/types.ts
@@ -29,20 +29,13 @@ export type Size = {
 }
 
 export type Box = {
-  left: number
-  top: number
+  x: number
+  y: number
   width: number
   height: number
 }
 
 export type Rect = {
-  minX: number
-  minY: number
-  maxX: number
-  maxY: number
-}
-
-export type Area = {
   x0: number
   y0: number
   x1: number

--- a/bokehjs/src/lib/core/util/bbox.ts
+++ b/bokehjs/src/lib/core/util/bbox.ts
@@ -1,40 +1,40 @@
-import {Arrayable, Rect, Box, Area, Interval} from "../types"
+import {Arrayable, Rect, Box, Interval} from "../types"
 
 const {min, max} = Math
 
 export function empty(): Rect {
   return {
-    minX:  Infinity,
-    minY:  Infinity,
-    maxX: -Infinity,
-    maxY: -Infinity,
+    x0:  Infinity,
+    y0:  Infinity,
+    x1: -Infinity,
+    y1: -Infinity,
   }
 }
 
 export function positive_x(): Rect {
   return {
-    minX:  Number.MIN_VALUE,
-    minY: -Infinity,
-    maxX:  Infinity,
-    maxY:  Infinity,
+    x0:  Number.MIN_VALUE,
+    y0: -Infinity,
+    x1:  Infinity,
+    y1:  Infinity,
   }
 }
 
 export function positive_y(): Rect {
   return {
-    minX: -Infinity,
-    minY:  Number.MIN_VALUE,
-    maxX:  Infinity,
-    maxY:  Infinity,
+    x0: -Infinity,
+    y0:  Number.MIN_VALUE,
+    x1:  Infinity,
+    y1:  Infinity,
   }
 }
 
 export function union(a: Rect, b: Rect): Rect {
   return {
-    minX: min(a.minX, b.minX),
-    maxX: max(a.maxX, b.maxX),
-    minY: min(a.minY, b.minY),
-    maxY: max(a.maxY, b.maxY),
+    x0: min(a.x0, b.x0),
+    x1: max(a.x1, b.x1),
+    y0: min(a.y0, b.y0),
+    y1: max(a.y1, b.y1),
   }
 }
 
@@ -56,21 +56,21 @@ export interface CoordinateTransform {
   v_compute: (vv: Arrayable<number>) => Arrayable<number>
 }
 
-export class BBox implements Area {
+export class BBox implements Rect {
 
   readonly x0: number
   readonly y0: number
   readonly x1: number
   readonly y1: number
 
-  constructor(box?: Area | Box | Position) {
+  constructor(box?: Rect | Box | Position) {
     if (box == null) {
       this.x0 = 0
       this.y0 = 0
       this.x1 = 0
       this.y1 = 0
     } else if ('x0' in box) {
-      const {x0, y0, x1, y1} = box as Area
+      const {x0, y0, x1, y1} = box as Rect
       if (!(x0 <= x1 && y0 <= y1))
         throw new Error(`invalid bbox {x0: ${x0}, y0: ${y0}, x1: ${x1}, y1: ${y1}}`)
       this.x0 = x0
@@ -78,13 +78,13 @@ export class BBox implements Area {
       this.x1 = x1
       this.y1 = y1
     } else if ("x" in box) {
-      const {left, top, width, height} = box as Box
+      const {x, y, width, height} = box as Box
       if (!(width >= 0 && height >= 0))
-        throw new Error(`invalid bbox {left: ${left}, top: ${top}, width: ${width}, height: ${height}}`)
-      this.x0 = left
-      this.y0 = top
-      this.x1 = left + width
-      this.y1 = top + height
+        throw new Error(`invalid bbox {x: ${x}, y: ${y}, width: ${width}, height: ${height}}`)
+      this.x0 = x
+      this.y0 = y
+      this.x1 = x + width
+      this.y1 = y + height
     } else {
       let left: number, right: number
       let top: number, bottom: number
@@ -137,11 +137,6 @@ export class BBox implements Area {
     return `BBox({left: ${this.left}, top: ${this.top}, width: ${this.width}, height: ${this.height}})`
   }
 
-  get minX(): number { return this.x0 }
-  get minY(): number { return this.y0 }
-  get maxX(): number { return this.x1 }
-  get maxY(): number { return this.y1 }
-
   get left(): number { return this.x0 }
   get top(): number { return this.y0 }
   get right(): number { return this.x1 }
@@ -155,7 +150,8 @@ export class BBox implements Area {
   get width(): number { return this.x1 - this.x0 }
   get height(): number { return this.y1 - this.y0 }
 
-  get rect(): Box { return {left: this.left, top: this.top, width: this.width, height: this.height} }
+  get rect(): Rect { return {x0: this.x0, y0: this.y0, x1: this.x1, y1: this.y1} }
+  get box(): Box { return {x: this.x, y: this.y, width: this.width, height: this.height} }
 
   get h_range(): Interval { return {start: this.x0, end: this.x1} }
   get v_range(): Interval { return {start: this.y0, end: this.y1} }
@@ -185,7 +181,7 @@ export class BBox implements Area {
     return [x, y]
   }
 
-  union(that: Area): BBox {
+  union(that: Rect): BBox {
     return new BBox({
       x0: min(this.x0, that.x0),
       y0: min(this.y0, that.y0),
@@ -194,7 +190,7 @@ export class BBox implements Area {
     })
   }
 
-  equals(that: Area): boolean {
+  equals(that: Rect): boolean {
     return this.x0 == that.x0 && this.y0 == that.y0 && this.x1 == that.x1 && this.y1 == that.y1
   }
 

--- a/bokehjs/src/lib/core/util/spatial.ts
+++ b/bokehjs/src/lib/core/util/spatial.ts
@@ -13,8 +13,8 @@ export class SpatialIndex {
       this.index = new FlatBush(points.length)
 
       for (const p of points) {
-        const {minX, minY, maxX, maxY} = p
-        this.index.add(minX, minY, maxX, maxY)
+        const {x0, y0, x1, y1} = p
+        this.index.add(x0, y0, x1, y1)
       }
 
       this.index.finish()
@@ -22,12 +22,12 @@ export class SpatialIndex {
   }
 
   protected _normalize(rect: Rect): Rect {
-    let {minX, minY, maxX, maxY} = rect
-    if (minX > maxX)
-      [minX, maxX] = [maxX, minX]
-    if (minY > maxY)
-      [minY, maxY] = [maxY, minY]
-    return {minX, minY, maxX, maxY}
+    let {x0, y0, x1, y1} = rect
+    if (x0 > x1)
+      [x0, x1] = [x1, x0]
+    if (y0 > y1)
+      [y0, y1] = [y1, y0]
+    return {x0, y0, x1, y1}
   }
 
   get bbox(): Rect {
@@ -35,7 +35,7 @@ export class SpatialIndex {
       return empty()
     else {
       const {minX, minY, maxX, maxY} = this.index
-      return {minX, minY, maxX, maxY}
+      return {x0: minX, y0: minY, x1: maxX, y1: maxY}
     }
   }
 
@@ -43,8 +43,8 @@ export class SpatialIndex {
     if (this.index == null)
       return []
     else {
-      const {minX, minY, maxX, maxY} = this._normalize(rect)
-      const indices = this.index.search(minX, minY, maxX, maxY)
+      const {x0, y0, x1, y1} = this._normalize(rect)
+      const indices = this.index.search(x0, y0, x1, y1)
       return indices.map((j) => this.points[j])
     }
   }

--- a/bokehjs/src/lib/models/annotations/annotation.ts
+++ b/bokehjs/src/lib/models/annotations/annotation.ts
@@ -58,7 +58,7 @@ export abstract class AnnotationView extends RendererView {
 
   serializable_state(): {[key: string]: unknown} {
     const state = super.serializable_state()
-    return this.layout == null ? state : {...state, bbox: this.layout.bbox.rect}
+    return this.layout == null ? state : {...state, bbox: this.layout.bbox.box}
   }
 }
 

--- a/bokehjs/src/lib/models/annotations/arrow.ts
+++ b/bokehjs/src/lib/models/annotations/arrow.ts
@@ -83,7 +83,7 @@ export class ArrowView extends AnnotationView {
     // Next we call .clip on all the arrow heads, inside an initial canvas sized
     // rect, to create an "inverted" clip region for the arrow heads
     ctx.beginPath()
-    const {left: x, top: y, width, height} = this.plot_view.layout.bbox.rect
+    const {x, y, width, height} = this.plot_view.layout.bbox
     ctx.rect(x, y, width, height)
     if (this.model.end != null)
       this._arrow_head(ctx, "clip", this.model.end, start, end)

--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -499,7 +499,7 @@ export class AxisView extends GuideRendererView {
   serializable_state(): {[key: string]: unknown} {
     return {
       ...super.serializable_state(),
-      bbox: this.layout.bbox.rect,
+      bbox: this.layout.bbox.box,
     }
   }
 }

--- a/bokehjs/src/lib/models/glyphs/annular_wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/annular_wedge.ts
@@ -2,7 +2,7 @@ import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {generic_area_legend} from "./utils"
 import {PointGeometry} from "core/geometry"
 import {LineVector, FillVector} from "core/property_mixins"
-import {Arrayable, Area} from "core/types"
+import {Arrayable, Rect} from "core/types"
 import {Line, Fill} from "core/visuals"
 import * as hittest from "core/hittest"
 import * as p from "core/properties"
@@ -108,8 +108,7 @@ export class AnnularWedgeView extends XYGlyphView {
 
     const candidates = []
 
-    const bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-    for (const i of this.index.indices(bbox)) {
+    for (const i of this.index.indices({x0, x1, y0, y1})) {
       const or2 = Math.pow(this.souter_radius[i], 2)
       const ir2 = Math.pow(this.sinner_radius[i], 2)
       const [sx0, sx1] = this.renderer.xscale.r_compute(x, this._x[i])
@@ -132,7 +131,7 @@ export class AnnularWedgeView extends XYGlyphView {
     return hittest.create_hit_test_result_from_hits(hits)
   }
 
-  draw_legend_for_index(ctx: Context2d, bbox: Area, index: number): void {
+  draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
     generic_area_legend(this.visuals, ctx, bbox, index)
   }
 

--- a/bokehjs/src/lib/models/glyphs/annulus.ts
+++ b/bokehjs/src/lib/models/glyphs/annulus.ts
@@ -1,5 +1,5 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
-import {Arrayable, Area} from "core/types"
+import {Arrayable, Rect} from "core/types"
 import {PointGeometry} from "core/geometry"
 import {LineVector, FillVector} from "core/property_mixins"
 import {Line, Fill} from "core/visuals"
@@ -104,8 +104,7 @@ export class AnnulusView extends XYGlyphView {
 
     const hits: [number, number][] = []
 
-    const bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-    for (const i of this.index.indices(bbox)) {
+    for (const i of this.index.indices({x0, x1, y0, y1})) {
       const or2 = Math.pow(this.souter_radius[i], 2)
       const ir2 = Math.pow(this.sinner_radius[i], 2)
       const [sx0, sx1] = this.renderer.xscale.r_compute(x, this._x[i])
@@ -118,7 +117,7 @@ export class AnnulusView extends XYGlyphView {
     return hittest.create_hit_test_result_from_hits(hits)
   }
 
-  draw_legend_for_index(ctx: Context2d, {x0, y0, x1, y1}: Area, index: number): void {
+  draw_legend_for_index(ctx: Context2d, {x0, y0, x1, y1}: Rect, index: number): void {
     const len = index + 1
 
     const sx: number[] = new Array(len)

--- a/bokehjs/src/lib/models/glyphs/arc.ts
+++ b/bokehjs/src/lib/models/glyphs/arc.ts
@@ -2,7 +2,7 @@ import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {generic_line_legend} from "./utils"
 import {LineVector} from "core/property_mixins"
 import {Line} from "core/visuals"
-import {Arrayable, Area} from "core/types"
+import {Arrayable, Rect} from "core/types"
 import {Direction} from "core/enums"
 import * as p from "core/properties"
 import {Context2d} from "core/util/canvas"
@@ -48,7 +48,7 @@ export class ArcView extends XYGlyphView {
     }
   }
 
-  draw_legend_for_index(ctx: Context2d, bbox: Area, index: number): void {
+  draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
     generic_line_legend(this.visuals, ctx, bbox, index)
   }
 }

--- a/bokehjs/src/lib/models/glyphs/area.ts
+++ b/bokehjs/src/lib/models/glyphs/area.ts
@@ -2,7 +2,7 @@ import {Glyph, GlyphView, GlyphData} from "./glyph"
 import {generic_area_legend} from "./utils"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
 import {Fill, Hatch} from "core/visuals"
-import {Area as BBoxArea } from "core/types"
+import {Rect} from "core/types"
 import {Context2d} from "core/util/canvas"
 import * as p from "core/properties"
 
@@ -14,7 +14,7 @@ export abstract class AreaView extends GlyphView {
   model:Area
   visuals: Area.Visuals
 
-  draw_legend_for_index(ctx: Context2d, bbox: BBoxArea, index: number): void {
+  draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
     generic_area_legend(this.visuals, ctx, bbox, index)
   }
 }

--- a/bokehjs/src/lib/models/glyphs/bezier.ts
+++ b/bokehjs/src/lib/models/glyphs/bezier.ts
@@ -1,6 +1,6 @@
 import {LineVector} from "core/property_mixins"
 import {Line} from "core/visuals"
-import {Arrayable, Area} from "core/types"
+import {Arrayable, Rect} from "core/types"
 import {SpatialIndex} from "core/util/spatial"
 import {Context2d} from "core/util/canvas"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
@@ -109,7 +109,7 @@ export class BezierView extends GlyphView {
 
       const [x0, y0, x1, y1] = _cbb(this._x0[i],  this._y0[i],  this._x1[i],  this._y1[i],
                                     this._cx0[i], this._cy0[i], this._cx1[i], this._cy1[i])
-      points.push({minX: x0, minY: y0, maxX: x1, maxY: y1, i})
+      points.push({x0, y0, x1, y1, i})
     }
 
     return new SpatialIndex(points)
@@ -132,7 +132,7 @@ export class BezierView extends GlyphView {
     }
   }
 
-  draw_legend_for_index(ctx: Context2d, bbox: Area, index: number): void {
+  draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
     generic_line_legend(this.visuals, ctx, bbox, index)
   }
 

--- a/bokehjs/src/lib/models/glyphs/box.ts
+++ b/bokehjs/src/lib/models/glyphs/box.ts
@@ -1,5 +1,5 @@
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
-import {Arrayable, Area} from "core/types"
+import {Arrayable, Rect} from "core/types"
 import {Line, Fill, Hatch} from "core/visuals"
 import {SpatialIndex} from "core/util/spatial"
 import {Context2d} from "core/util/canvas"
@@ -38,10 +38,10 @@ export abstract class BoxView extends GlyphView {
       if (isNaN(l + r + t + b) || !isFinite(l + r + t + b))
         continue
       points.push({
-        minX: Math.min(l, r),
-        minY: Math.min(t, b),
-        maxX: Math.max(r, l),
-        maxY: Math.max(t, b),
+        x0: Math.min(l, r),
+        y0: Math.min(t, b),
+        x1: Math.max(r, l),
+        y1: Math.max(t, b),
         i,
       })
     }
@@ -103,7 +103,7 @@ export abstract class BoxView extends GlyphView {
     const x = this.renderer.xscale.invert(sx)
     const y = this.renderer.yscale.invert(sy)
 
-    const hits = this.index.indices({minX: x, minY: y, maxX: x, maxY: y})
+    const hits = this.index.indices({x0: x, y0: y, x1: x, y1: y})
 
     const result = hittest.create_empty_hit_test_result()
     result.indices = hits
@@ -117,13 +117,13 @@ export abstract class BoxView extends GlyphView {
     if (geometry.direction == 'v') {
       const y = this.renderer.yscale.invert(sy)
       const hr = this.renderer.plot_view.frame.bbox.h_range
-      const [minX, maxX] = this.renderer.xscale.r_invert(hr.start, hr.end)
-      hits = this.index.indices({minX, minY: y, maxX, maxY: y})
+      const [x0, x1] = this.renderer.xscale.r_invert(hr.start, hr.end)
+      hits = this.index.indices({x0, y0: y, x1, y1: y})
     } else {
       const x = this.renderer.xscale.invert(sx)
       const vr = this.renderer.plot_view.frame.bbox.v_range
-      const [minY, maxY] = this.renderer.yscale.r_invert(vr.start, vr.end)
-      hits = this.index.indices({minX: x, minY, maxX: x, maxY})
+      const [y0, y1] = this.renderer.yscale.r_invert(vr.start, vr.end)
+      hits = this.index.indices({x0: x, y0, x1: x, y1})
     }
 
     const result = hittest.create_empty_hit_test_result()
@@ -131,7 +131,7 @@ export abstract class BoxView extends GlyphView {
     return result
   }
 
-  draw_legend_for_index(ctx: Context2d, bbox: Area, index: number): void {
+  draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
     generic_area_legend(this.visuals, ctx, bbox, index)
   }
 }

--- a/bokehjs/src/lib/models/glyphs/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/circle.ts
@@ -2,7 +2,7 @@ import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {PointGeometry, SpanGeometry, RectGeometry, PolyGeometry} from "core/geometry"
 import {LineVector, FillVector} from "core/property_mixins"
 import {Line, Fill} from "core/visuals"
-import {Arrayable, Area} from "core/types"
+import {Arrayable, Rect} from "core/types"
 import {RadiusDimension} from "core/enums"
 import * as hittest from "core/hittest"
 import * as p from "core/properties"
@@ -91,8 +91,7 @@ export class CircleView extends XYGlyphView {
       ;[y0, y1] = this.renderer.yscale.r_invert(sy0, sy1)
     }
 
-    const bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-    return this.index.indices(bbox)
+    return this.index.indices({x0, x1, y0, y1})
   }
 
   protected _render(ctx: Context2d, indices: number[], {sx, sy, sradius}: CircleData): void {
@@ -141,8 +140,7 @@ export class CircleView extends XYGlyphView {
       ;[y0, y1] = [Math.min(y0, y1), Math.max(y0, y1)]
     }
 
-    const bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-    const candidates = this.index.indices(bbox)
+    const candidates = this.index.indices({x0, x1, y0, y1})
 
     const hits: [number, number][] = []
     if ((this._radius != null) && (this.model.properties.radius.units == "data")) {
@@ -169,22 +167,22 @@ export class CircleView extends XYGlyphView {
   }
 
   protected _hit_span(geometry: SpanGeometry): Selection {
-      let ms, x0, x1, y0, y1
       const {sx, sy} = geometry
-      const {minX, minY, maxX, maxY} = this.bounds()
+      const bounds = this.bounds()
       const result = hittest.create_empty_hit_test_result()
 
+      let x0, x1, y0, y1
       if (geometry.direction == 'h') {
         // use circle bounds instead of current pointer y coordinates
         let sx0, sx1
-        y0 = minY
-        y1 = maxY
+        y0 = bounds.y0
+        y1 = bounds.y1
         if (this._radius != null && this.model.properties.radius.units == "data") {
           sx0 = sx - this.max_radius
           sx1 = sx + this.max_radius
           ;[x0, x1] = this.renderer.xscale.r_invert(sx0, sx1)
         } else {
-          ms = this.max_size/2
+          const ms = this.max_size/2
           sx0 = sx - ms
           sx1 = sx + ms
           ;[x0, x1] = this.renderer.xscale.r_invert(sx0, sx1)
@@ -192,22 +190,21 @@ export class CircleView extends XYGlyphView {
       } else {
         // use circle bounds instead of current pointer x coordinates
         let sy0, sy1
-        x0 = minX
-        x1 = maxX
+        x0 = bounds.x0
+        x1 = bounds.x1
         if (this._radius != null && this.model.properties.radius.units == "data") {
           sy0 = sy - this.max_radius
           sy1 = sy + this.max_radius
           ;[y0, y1] = this.renderer.yscale.r_invert(sy0, sy1)
         } else {
-          ms = this.max_size/2
+          const ms = this.max_size/2
           sy0 = sy - ms
           sy1 = sy + ms
           ;[y0, y1] = this.renderer.yscale.r_invert(sy0, sy1)
         }
       }
 
-      const bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-      const hits = this.index.indices(bbox)
+      const hits = this.index.indices({x0, x1, y0, y1})
 
       result.indices = hits
       return result
@@ -217,9 +214,8 @@ export class CircleView extends XYGlyphView {
     const {sx0, sx1, sy0, sy1} = geometry
     const [x0, x1] = this.renderer.xscale.r_invert(sx0, sx1)
     const [y0, y1] = this.renderer.yscale.r_invert(sy0, sy1)
-    const bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
     const result = hittest.create_empty_hit_test_result()
-    result.indices = this.index.indices(bbox)
+    result.indices = this.index.indices({x0, x1, y0, y1})
     return result
   }
 
@@ -244,7 +240,7 @@ export class CircleView extends XYGlyphView {
 
   // circle does not inherit from marker (since it also accepts radius) so we
   // must supply a draw_legend for it  here
-  draw_legend_for_index(ctx: Context2d, {x0, y0, x1, y1}: Area, index: number): void {
+  draw_legend_for_index(ctx: Context2d, {x0, y0, x1, y1}: Rect, index: number): void {
     // using objects like this seems a little wonky, since the keys are coerced to
     // stings, but it works
     const len = index + 1

--- a/bokehjs/src/lib/models/glyphs/ellipse_oval.ts
+++ b/bokehjs/src/lib/models/glyphs/ellipse_oval.ts
@@ -2,7 +2,7 @@ import {CenterRotatable, CenterRotatableView, CenterRotatableData} from "./cente
 import {PointGeometry} from "core/geometry"
 import {LineVector, FillVector} from "core/property_mixins"
 import * as hittest from "core/hittest"
-import {Area, Rect} from "core/types"
+import {Rect} from "core/types"
 import {Context2d} from "core/util/canvas"
 import {Selection} from "../selections/selection"
 import * as p from "core/properties"
@@ -83,8 +83,7 @@ export abstract class EllipseOvalView extends CenterRotatableView  {
       ;[y0, y1] = this.renderer.yscale.r_invert(sy0, sy1)
     }
 
-    const bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-    const candidates = this.index.indices(bbox)
+    const candidates = this.index.indices({x0, x1, y0, y1})
     const hits: [number, number][] = []
 
     for (const i of candidates) {
@@ -100,7 +99,7 @@ export abstract class EllipseOvalView extends CenterRotatableView  {
     return hittest.create_hit_test_result_from_hits(hits)
   }
 
-  draw_legend_for_index(ctx: Context2d, {x0, y0, x1, y1}: Area, index: number): void {
+  draw_legend_for_index(ctx: Context2d, {x0, y0, x1, y1}: Rect, index: number): void {
     const len = index + 1
 
     const sx: number[] = new Array(len)
@@ -124,12 +123,12 @@ export abstract class EllipseOvalView extends CenterRotatableView  {
     this._render(ctx, [index], {sx, sy, sw, sh, _angle: [0]} as any) // XXX
   }
 
-  protected _bounds({minX, maxX, minY, maxY}: Rect): Rect {
+  protected _bounds({x0, x1, y0, y1}: Rect): Rect {
     return {
-      minX: minX - this.max_w2,
-      maxX: maxX + this.max_w2,
-      minY: minY - this.max_h2,
-      maxY: maxY + this.max_h2,
+      x0: x0 - this.max_w2,
+      x1: x1 + this.max_w2,
+      y0: y0 - this.max_h2,
+      y1: y1 + this.max_h2,
     }
   }
 }

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -9,7 +9,7 @@ import {View} from "core/view"
 import {Model} from "../../model"
 import {Anchor} from "core/enums"
 import {logger} from "core/logging"
-import {Arrayable, Area, Rect} from "core/types"
+import {Arrayable, Rect} from "core/types"
 import {map} from "core/util/arrayable"
 import {extend} from "core/util/object"
 import {isArray, isTypedArray} from "core/util/types"
@@ -113,18 +113,18 @@ export abstract class GlyphView extends View {
 
     const positive_x_bbs = this.index.search(bbox.positive_x())
     for (const x of positive_x_bbs) {
-      if (x.minX < bb.minX)
-        bb.minX = x.minX
-      if (x.maxX > bb.maxX)
-        bb.maxX = x.maxX
+      if (x.x0 < bb.x0)
+        bb.x0 = x.x0
+      if (x.x1 > bb.x1)
+        bb.x1 = x.x1
     }
 
     const positive_y_bbs = this.index.search(bbox.positive_y())
     for (const y of positive_y_bbs) {
-      if (y.minY < bb.minY)
-        bb.minY = y.minY
-      if (y.maxY > bb.maxY)
-        bb.maxY = y.maxY
+      if (y.y0 < bb.y0)
+        bb.y0 = y.y0
+      if (y.y1 > bb.y1)
+        bb.y1 = y.y1
     }
 
     return this._bounds(bb)
@@ -176,7 +176,7 @@ export abstract class GlyphView extends View {
       return map(spt0, (_, i) => Math.abs(spt1[i] - spt0[i]))
   }
 
-  draw_legend_for_index(_ctx: Context2d, _bbox: Area, _index: number): void {}
+  draw_legend_for_index(_ctx: Context2d, _bbox: Rect, _index: number): void {}
 
   hit_test(geometry: Geometry): hittest.HitTestResult {
     let result = null
@@ -196,9 +196,8 @@ export abstract class GlyphView extends View {
     const {sx0, sx1, sy0, sy1} = geometry
     const [x0, x1] = this.renderer.xscale.r_invert(sx0, sx1)
     const [y0, y1] = this.renderer.yscale.r_invert(sy0, sy1)
-    const bb = hittest.validate_bbox_coords([x0, x1], [y0, y1])
     const result = hittest.create_empty_hit_test_result()
-    result.indices = this.index.indices(bb)
+    result.indices = this.index.indices({x0, x1, y0, y1})
     return result
   }
 

--- a/bokehjs/src/lib/models/glyphs/harea.ts
+++ b/bokehjs/src/lib/models/glyphs/harea.ts
@@ -31,7 +31,7 @@ export class HAreaView extends AreaView {
       if (isNaN(x1 + x2 + y) || !isFinite(x1 + x2 + y))
         continue
 
-      points.push({minX: Math.min(x1, x2), minY: y, maxX: Math.max(x1, x2), maxY: y, i})
+      points.push({x0: Math.min(x1, x2), y0: y, x1: Math.max(x1, x2), y1: y, i})
     }
 
     return new SpatialIndex(points)

--- a/bokehjs/src/lib/models/glyphs/hex_tile.ts
+++ b/bokehjs/src/lib/models/glyphs/hex_tile.ts
@@ -4,7 +4,7 @@ import {PointGeometry, RectGeometry, SpanGeometry} from "core/geometry"
 import * as hittest from "core/hittest"
 import * as p from "core/properties"
 import {LineVector, FillVector} from "core/property_mixins"
-import {Arrayable, Area} from "core/types"
+import {Arrayable, Rect} from "core/types"
 import {Context2d} from "core/util/canvas"
 import {SpatialIndex} from "core/util/spatial"
 import {Line, Fill} from "core/visuals"
@@ -27,11 +27,6 @@ export interface HexTileData extends GlyphData {
 
   svx: number[]
   svy: number[]
-
-  minX: number
-  maxX: number
-  minY: number
-  maxY: number
 
   ssize: number
 }
@@ -84,7 +79,7 @@ export class HexTileView extends GlyphView {
       const y = this._y[i]
       if (isNaN(x+y) || !isFinite(x+y))
         continue
-      points.push({minX: x-xsize, minY: y-ysize, maxX: x+xsize, maxY: y+ysize, i})
+      points.push({x0: x-xsize, y0: y-ysize, x1: x+xsize, y1: y+ysize, i})
     }
     return new SpatialIndex(points)
   }
@@ -158,7 +153,7 @@ export class HexTileView extends GlyphView {
     const x = this.renderer.xscale.invert(sx)
     const y = this.renderer.yscale.invert(sy)
 
-    const candidates = this.index.indices({minX: x, minY: y, maxX: x, maxY: y})
+    const candidates = this.index.indices({x0: x, y0: y, x1: x, y1: y})
 
     const hits = []
     for (const i of candidates) {
@@ -181,13 +176,13 @@ export class HexTileView extends GlyphView {
     if (geometry.direction == 'v') {
       const y = this.renderer.yscale.invert(sy)
       const hr = this.renderer.plot_view.frame.bbox.h_range
-      const [minX, maxX] = this.renderer.xscale.r_invert(hr.start, hr.end)
-      hits = this.index.indices({minX, minY: y, maxX, maxY: y})
+      const [x0, x1] = this.renderer.xscale.r_invert(hr.start, hr.end)
+      hits = this.index.indices({x0, y0: y, x1, y1: y})
     } else {
       const x = this.renderer.xscale.invert(sx)
       const vr = this.renderer.plot_view.frame.bbox.v_range
-      const [minY, maxY] = this.renderer.yscale.r_invert(vr.start, vr.end)
-      hits = this.index.indices({minX: x, minY, maxX: x, maxY})
+      const [y0, y1] = this.renderer.yscale.r_invert(vr.start, vr.end)
+      hits = this.index.indices({x0: x, y0, x1: x, y1})
     }
 
     const result = hittest.create_empty_hit_test_result()
@@ -199,13 +194,12 @@ export class HexTileView extends GlyphView {
     const {sx0, sx1, sy0, sy1} = geometry
     const [x0, x1] = this.renderer.xscale.r_invert(sx0, sx1)
     const [y0, y1] = this.renderer.yscale.r_invert(sy0, sy1)
-    const bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
     const result = hittest.create_empty_hit_test_result()
-    result.indices = this.index.indices(bbox)
+    result.indices = this.index.indices({x0, x1, y0, y1})
     return result
   }
 
-  draw_legend_for_index(ctx: Context2d, bbox: Area, index: number): void {
+  draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
     generic_area_legend(this.visuals, ctx, bbox, index)
   }
 

--- a/bokehjs/src/lib/models/glyphs/image_base.ts
+++ b/bokehjs/src/lib/models/glyphs/image_base.ts
@@ -38,7 +38,7 @@ export class ImageBaseView extends XYGlyphView {
       if (isNaN(l + r + t + b) || !isFinite(l + r + t + b)) {
         continue
       }
-      points.push({minX: l, minY: b, maxX: r, maxY: t, i})
+      points.push({x0: l, y0: b, x1: r, y1: t, i})
     }
     return new SpatialIndex(points)
   }
@@ -129,8 +129,7 @@ export class ImageBaseView extends XYGlyphView {
     const {sx, sy} = geometry
     const x = this.renderer.xscale.invert(sx)
     const y = this.renderer.yscale.invert(sy)
-    const bbox = hittest.validate_bbox_coords([x, x], [y, y])
-    const candidates = this.index.indices(bbox)
+    const candidates = this.index.indices({x0: x, x1: x, y0: y, y1: y})
     const result = hittest.create_empty_hit_test_result()
 
     result.image_indices = []

--- a/bokehjs/src/lib/models/glyphs/image_url.ts
+++ b/bokehjs/src/lib/models/glyphs/image_url.ts
@@ -100,12 +100,12 @@ export class ImageURLView extends XYGlyphView {
         ys[n + i] = this._y[i] + this._h[i]
     }
 
-    const minX = min(xs)
-    const maxX = max(xs)
-    const minY = min(ys)
-    const maxY = max(ys)
+    const x0 = min(xs)
+    const x1 = max(xs)
+    const y0 = min(ys)
+    const y1 = max(ys)
 
-    this._bounds_rect = {minX, maxX, minY, maxY}
+    this._bounds_rect = {x0, x1, y0, y1}
   }
 
   has_finished(): boolean {

--- a/bokehjs/src/lib/models/glyphs/line.ts
+++ b/bokehjs/src/lib/models/glyphs/line.ts
@@ -2,7 +2,7 @@ import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {generic_line_legend, line_interpolation} from "./utils"
 import {PointGeometry, SpanGeometry} from "core/geometry"
 import {LineVector} from "core/property_mixins"
-import {Arrayable, Area} from "core/types"
+import {Arrayable, Rect} from "core/types"
 import * as visuals from "core/visuals"
 import * as hittest from "core/hittest"
 import {Context2d} from "core/util/canvas"
@@ -117,7 +117,7 @@ export class LineView extends XYGlyphView {
     return line_interpolation(this.renderer, geometry, x2, y2, x3, y3)
   }
 
-  draw_legend_for_index(ctx: Context2d, bbox: Area, index: number): void {
+  draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
     generic_line_legend(this.visuals, ctx, bbox, index)
   }
 }

--- a/bokehjs/src/lib/models/glyphs/multi_line.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_line.ts
@@ -2,7 +2,7 @@ import {SpatialIndex} from "core/util/spatial"
 import {PointGeometry, SpanGeometry} from "core/geometry"
 import {LineVector} from "core/property_mixins"
 import {Line} from "core/visuals"
-import {Arrayable, Area} from "core/types"
+import {Arrayable, Rect} from "core/types"
 import * as hittest from "core/hittest"
 import * as p from "core/properties"
 import {keys} from "core/util/object"
@@ -49,10 +49,10 @@ export class MultiLineView extends GlyphView {
           ys.push(y)
       }
 
-      const [minX, maxX] = [min(xs), max(xs)]
-      const [minY, maxY] = [min(ys), max(ys)]
+      const [x0, x1] = [min(xs), max(xs)]
+      const [y0, y1] = [min(ys), max(ys)]
 
-      points.push({minX, minY, maxX, maxY, i})
+      points.push({x0, y0, x1, y1, i})
     }
 
     return new SpatialIndex(points)
@@ -143,7 +143,7 @@ export class MultiLineView extends GlyphView {
     return line_interpolation(this.renderer, geometry, x2, y2, x3, y3)
   }
 
-  draw_legend_for_index(ctx: Context2d, bbox: Area, index: number): void {
+  draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
     generic_line_legend(this.visuals, ctx, bbox, index)
   }
 

--- a/bokehjs/src/lib/models/glyphs/multi_polygons.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_polygons.ts
@@ -3,7 +3,7 @@ import {Glyph, GlyphView, GlyphData} from "./glyph"
 import {generic_area_legend} from "./utils"
 import {min, max} from "core/util/array"
 import {sum} from "core/util/arrayable"
-import {Arrayable, Area} from "core/types"
+import {Arrayable, Rect} from "core/types"
 import {PointGeometry} from "core/geometry"
 import {Context2d} from "core/util/canvas"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
@@ -39,13 +39,7 @@ export class MultiPolygonsView extends GlyphView {
         if (xs.length == 0)
           continue
 
-        points.push({
-          minX: min(xs),
-          minY: min(ys),
-          maxX: max(xs),
-          maxY: max(ys),
-          i,
-        })
+        points.push({x0: min(xs), y0: min(ys), x1: max(xs), y1: max(ys), i})
       }
     }
     this.hole_index = this._index_hole_data()  // should this be set here?
@@ -65,13 +59,7 @@ export class MultiPolygonsView extends GlyphView {
             if (xs.length == 0)
               continue
 
-            points.push({
-              minX: min(xs),
-              minY: min(ys),
-              maxX: max(xs),
-              maxY: max(ys),
-              i,
-            })
+            points.push({x0: min(xs), y0: min(ys), x1: max(xs), y1: max(ys), i})
           }
         }
       }
@@ -86,8 +74,7 @@ export class MultiPolygonsView extends GlyphView {
     const yr = this.renderer.plot_view.frame.y_ranges.default
     const [y0, y1] = [yr.min, yr.max]
 
-    const bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-    const indices = this.index.indices(bbox)
+    const indices = this.index.indices({x0, x1, y0, y1})
 
     // TODO this is probably needed in patches as well so that we don't draw glyphs multiple times
     return indices.sort((a, b) => a - b).filter((value, index, array) => {
@@ -146,8 +133,8 @@ export class MultiPolygonsView extends GlyphView {
     const x = this.renderer.xscale.invert(sx)
     const y = this.renderer.yscale.invert(sy)
 
-    const candidates = this.index.indices({minX: x, minY: y, maxX: x, maxY: y})
-    const hole_candidates = this.hole_index.indices({minX: x, minY: y, maxX: x, maxY: y})
+    const candidates = this.index.indices({x0: x, y0: y, x1: x, y1: y})
+    const hole_candidates = this.hole_index.indices({x0: x, y0: y, x1: x, y1: y})
 
     const hits = []
     for (let i = 0, end = candidates.length; i < end; i++) {
@@ -261,7 +248,7 @@ export class MultiPolygonsView extends GlyphView {
     }
   }
 
-  draw_legend_for_index(ctx: Context2d, bbox: Area, index: number): void {
+  draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
     generic_area_legend(this.visuals, ctx, bbox, index)
   }
 }

--- a/bokehjs/src/lib/models/glyphs/patch.ts
+++ b/bokehjs/src/lib/models/glyphs/patch.ts
@@ -2,7 +2,7 @@ import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {generic_area_legend} from "./utils"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
 import {Line, Fill, Hatch} from "core/visuals"
-import {Arrayable, Area} from "core/types"
+import {Arrayable, Rect} from "core/types"
 import {Context2d} from "core/util/canvas"
 import * as p from "core/properties"
 
@@ -45,7 +45,7 @@ export class PatchView extends XYGlyphView {
     }
   }
 
-  draw_legend_for_index(ctx: Context2d, bbox: Area, index: number): void {
+  draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
     generic_area_legend(this.visuals, ctx, bbox, index)
   }
 }

--- a/bokehjs/src/lib/models/glyphs/patches.ts
+++ b/bokehjs/src/lib/models/glyphs/patches.ts
@@ -4,7 +4,7 @@ import {generic_area_legend} from "./utils"
 import {min, max, copy, find_last_index} from "core/util/array"
 import {sum} from "core/util/arrayable"
 import {isStrictNaN} from "core/util/types"
-import {Arrayable, Area} from "core/types"
+import {Arrayable, Rect} from "core/types"
 import {PointGeometry} from "core/geometry"
 import {Context2d} from "core/util/canvas"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
@@ -82,13 +82,7 @@ export class PatchesView extends GlyphView {
         if (xs.length == 0)
           continue
 
-        points.push({
-          minX: min(xs),
-          minY: min(ys),
-          maxX: max(xs),
-          maxY: max(ys),
-          i,
-        })
+        points.push({x0: min(xs), y0: min(ys), x1: max(xs), y1: max(ys), i})
       }
     }
 
@@ -102,8 +96,7 @@ export class PatchesView extends GlyphView {
     const yr = this.renderer.plot_view.frame.y_ranges.default
     const [y0, y1] = [yr.min, yr.max]
 
-    const bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-    const indices = this.index.indices(bbox)
+    const indices = this.index.indices({x0, x1, y0, y1})
 
     // TODO (bev) this should be under test
     return indices.sort((a, b) => a - b)
@@ -156,7 +149,7 @@ export class PatchesView extends GlyphView {
     const x = this.renderer.xscale.invert(sx)
     const y = this.renderer.yscale.invert(sy)
 
-    const candidates = this.index.indices({minX: x, minY: y, maxX: x, maxY: y})
+    const candidates = this.index.indices({x0: x, y0: y, x1: x, y1: y})
 
     const hits = []
     for (let i = 0, end = candidates.length; i < end; i++) {
@@ -215,7 +208,7 @@ export class PatchesView extends GlyphView {
     throw new Error("unreachable code")
   }
 
-  draw_legend_for_index(ctx: Context2d, bbox: Area, index: number): void {
+  draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
     generic_area_legend(this.visuals, ctx, bbox, index)
   }
 }

--- a/bokehjs/src/lib/models/glyphs/quadratic.ts
+++ b/bokehjs/src/lib/models/glyphs/quadratic.ts
@@ -1,6 +1,6 @@
 import {LineVector} from "core/property_mixins"
 import {Line} from "core/visuals"
-import {Arrayable, Area} from "core/types"
+import {Arrayable, Rect} from "core/types"
 import {SpatialIndex} from "core/util/spatial"
 import {Context2d} from "core/util/canvas"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
@@ -59,7 +59,7 @@ export class QuadraticView extends GlyphView {
       const [x0, x1] = _qbb(this._x0[i], this._cx[i], this._x1[i])
       const [y0, y1] = _qbb(this._y0[i], this._cy[i], this._y1[i])
 
-      points.push({minX: x0, minY: y0, maxX: x1, maxY: y1, i})
+      points.push({x0, y0, x1, y1, i})
     }
 
     return new SpatialIndex(points)
@@ -81,7 +81,7 @@ export class QuadraticView extends GlyphView {
     }
   }
 
-  draw_legend_for_index(ctx: Context2d, bbox: Area, index: number): void {
+  draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
     generic_line_legend(this.visuals, ctx, bbox, index)
   }
 

--- a/bokehjs/src/lib/models/glyphs/ray.ts
+++ b/bokehjs/src/lib/models/glyphs/ray.ts
@@ -2,7 +2,7 @@ import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {generic_line_legend} from "./utils"
 import {LineVector} from "core/property_mixins"
 import {Line} from "core/visuals"
-import {Arrayable, Area} from "core/types"
+import {Arrayable, Rect} from "core/types"
 import {Class} from "core/class"
 import * as p from "core/properties"
 import {Context2d} from "core/util/canvas"
@@ -58,7 +58,7 @@ export class RayView extends XYGlyphView {
     }
   }
 
-  draw_legend_for_index(ctx: Context2d, bbox: Area, index: number): void {
+  draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
     generic_line_legend(this.visuals, ctx, bbox, index)
   }
 }

--- a/bokehjs/src/lib/models/glyphs/rect.ts
+++ b/bokehjs/src/lib/models/glyphs/rect.ts
@@ -2,7 +2,7 @@ import {CenterRotatable, CenterRotatableView, CenterRotatableData} from "./cente
 import {generic_area_legend} from "./utils"
 import {PointGeometry, RectGeometry} from "core/geometry"
 import {LineVector, FillVector} from "core/property_mixins"
-import {Arrayable, Area} from "core/types"
+import {Arrayable} from "core/types"
 import {Class} from "core/class"
 import * as types from "core/types"
 import * as hittest from "core/hittest"
@@ -144,8 +144,7 @@ export class RectView extends CenterRotatableView {
 
     const hits = []
 
-    const bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-    for (const i of this.index.indices(bbox)) {
+    for (const i of this.index.indices({x0, x1, y0, y1})) {
       let height_in: boolean, width_in: boolean
       if (this._angle[i]) {
         const s = Math.sin(-this._angle[i])
@@ -218,16 +217,16 @@ export class RectView extends CenterRotatableView {
     return ddist
   }
 
-  draw_legend_for_index(ctx: Context2d, bbox: Area, index: number): void {
+  draw_legend_for_index(ctx: Context2d, bbox: types.Rect, index: number): void {
     generic_area_legend(this.visuals, ctx, bbox, index)
   }
 
-  protected _bounds({minX, maxX, minY, maxY}: types.Rect): types.Rect {
+  protected _bounds({x0, x1, y0, y1}: types.Rect): types.Rect {
     return {
-      minX: minX - this.max_w2,
-      maxX: maxX + this.max_w2,
-      minY: minY - this.max_h2,
-      maxY: maxY + this.max_h2,
+      x0: x0 - this.max_w2,
+      x1: x1 + this.max_w2,
+      y0: y0 - this.max_h2,
+      y1: y1 + this.max_h2,
     }
   }
 }

--- a/bokehjs/src/lib/models/glyphs/segment.ts
+++ b/bokehjs/src/lib/models/glyphs/segment.ts
@@ -3,7 +3,7 @@ import * as hittest from "core/hittest"
 import * as p from "core/properties"
 import {LineVector} from "core/property_mixins"
 import {Line} from "core/visuals"
-import {Arrayable, Area} from "core/types"
+import {Arrayable, Rect} from "core/types"
 import {SpatialIndex} from "core/util/spatial"
 import {Context2d} from "core/util/canvas"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
@@ -39,10 +39,10 @@ export class SegmentView extends GlyphView {
 
       if (!isNaN(x0 + x1 + y0 + y1)) {
         points.push({
-          minX: Math.min(x0, x1),
-          minY: Math.min(y0, y1),
-          maxX: Math.max(x0, x1),
-          maxY: Math.max(y0, y1),
+          x0: Math.min(x0, x1),
+          y0: Math.min(y0, y1),
+          x1: Math.max(x0, x1),
+          y1: Math.max(y0, y1),
           i,
         })
       }
@@ -74,9 +74,9 @@ export class SegmentView extends GlyphView {
     const hits = []
     const lw_voffset = 2 // FIXME: Use maximum of segments line_width/2 instead of magic constant 2
 
-    const [minX, maxX] = this.renderer.xscale.r_invert(sx-lw_voffset, sx+lw_voffset)
-    const [minY, maxY] = this.renderer.yscale.r_invert(sy-lw_voffset, sy+lw_voffset)
-    const candidates = this.index.indices({minX, minY, maxX, maxY})
+    const [x0, x1] = this.renderer.xscale.r_invert(sx-lw_voffset, sx+lw_voffset)
+    const [y0, y1] = this.renderer.yscale.r_invert(sy-lw_voffset, sy+lw_voffset)
+    const candidates = this.index.indices({x0, y0, x1, y1})
 
     for (const i of candidates) {
       const threshold2 = Math.pow(Math.max(2, this.visuals.line.cache_select('line_width', i) / 2), 2)
@@ -109,9 +109,9 @@ export class SegmentView extends GlyphView {
 
     const hits = []
 
-    const [minX, maxX] = this.renderer.xscale.r_invert(hr.start, hr.end)
-    const [minY, maxY] = this.renderer.yscale.r_invert(vr.start, vr.end)
-    const candidates = this.index.indices({minX, minY, maxX, maxY})
+    const [x0, x1] = this.renderer.xscale.r_invert(hr.start, hr.end)
+    const [y0, y1] = this.renderer.yscale.r_invert(vr.start, vr.end)
+    const candidates = this.index.indices({x0, y0, x1, y1})
 
     for (const i of candidates) {
       if ((v0[i] <= val && val <= v1[i]) || (v1[i] <= val && val <= v0[i]))
@@ -131,7 +131,7 @@ export class SegmentView extends GlyphView {
     return (this.sy0[i] + this.sy1[i])/2
   }
 
-  draw_legend_for_index(ctx: Context2d, bbox: Area, index: number): void {
+  draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
     generic_line_legend(this.visuals, ctx, bbox, index)
   }
 }

--- a/bokehjs/src/lib/models/glyphs/step.ts
+++ b/bokehjs/src/lib/models/glyphs/step.ts
@@ -3,7 +3,7 @@ import {generic_line_legend} from "./utils"
 import {LineVector} from "core/property_mixins"
 import {Line} from "core/visuals"
 import * as p from "core/properties"
-import {Area} from "core/types"
+import {Rect} from "core/types"
 import {StepMode} from "core/enums"
 import {Context2d} from "core/util/canvas"
 
@@ -83,7 +83,7 @@ export class StepView extends XYGlyphView {
     ctx.stroke()
   }
 
-  draw_legend_for_index(ctx: Context2d, bbox: Area, index: number): void {
+  draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
     generic_line_legend(this.visuals, ctx, bbox, index)
   }
 }

--- a/bokehjs/src/lib/models/glyphs/utils.ts
+++ b/bokehjs/src/lib/models/glyphs/utils.ts
@@ -1,11 +1,11 @@
 import {Visuals, Line, Fill, Hatch} from "core/visuals"
 import {Context2d} from "core/util/canvas"
-import {Area} from "core/types"
+import {Rect} from "core/types"
 import {PointGeometry, SpanGeometry} from "core/geometry"
 import * as hittest from "core/hittest"
 import {GlyphRendererView} from "../renderers/glyph_renderer"
 
-export function generic_line_legend(visuals: Visuals & {line: Line}, ctx: Context2d, {x0, x1, y0, y1}: Area, index: number): void {
+export function generic_line_legend(visuals: Visuals & {line: Line}, ctx: Context2d, {x0, x1, y0, y1}: Rect, index: number): void {
   ctx.save()
   ctx.beginPath()
   ctx.moveTo(x0, (y0 + y1) /2)
@@ -17,7 +17,7 @@ export function generic_line_legend(visuals: Visuals & {line: Line}, ctx: Contex
   ctx.restore()
 }
 
-export function generic_area_legend(visuals: {line?: Line, fill: Fill, hatch?: Hatch}, ctx: Context2d, {x0, x1, y0, y1}: Area, index: number): void {
+export function generic_area_legend(visuals: {line?: Line, fill: Fill, hatch?: Hatch}, ctx: Context2d, {x0, x1, y0, y1}: Rect, index: number): void {
   const w = Math.abs(x1 - x0)
   const dw = w*0.1
   const h = Math.abs(y1 - y0)

--- a/bokehjs/src/lib/models/glyphs/varea.ts
+++ b/bokehjs/src/lib/models/glyphs/varea.ts
@@ -31,7 +31,7 @@ export class VAreaView extends AreaView {
       if (isNaN(x + y1 + y2) || !isFinite(x + y1 + y2))
         continue
 
-      points.push({minX: x, minY: Math.min(y1, y2), maxX: x, maxY: Math.max(y1, y2), i})
+      points.push({x0: x, y0: Math.min(y1, y2), x1: x, y1: Math.max(y1, y2), i})
     }
 
     return new SpatialIndex(points)

--- a/bokehjs/src/lib/models/glyphs/wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/wedge.ts
@@ -3,7 +3,7 @@ import {generic_area_legend} from "./utils"
 import {PointGeometry} from "core/geometry"
 import {LineVector, FillVector} from "core/property_mixins"
 import {Line, Fill} from "core/visuals"
-import {Arrayable, Area} from "core/types"
+import {Arrayable, Rect} from "core/types"
 import {Direction} from "core/enums"
 import * as hittest from "core/hittest"
 import * as p from "core/properties"
@@ -85,8 +85,7 @@ export class WedgeView extends XYGlyphView {
 
     const candidates = []
 
-    const bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-    for (const i of this.index.indices(bbox)) {
+    for (const i of this.index.indices({x0, x1, y0, y1})) {
       const r2 = Math.pow(this.sradius[i], 2)
       ;[sx0, sx1] = this.renderer.xscale.r_compute(x, this._x[i])
       ;[sy0, sy1] = this.renderer.yscale.r_compute(y, this._y[i])
@@ -109,7 +108,7 @@ export class WedgeView extends XYGlyphView {
     return hittest.create_hit_test_result_from_hits(hits)
   }
 
-  draw_legend_for_index(ctx: Context2d, bbox: Area, index: number): void {
+  draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
     generic_area_legend(this.visuals, ctx, bbox, index)
   }
 

--- a/bokehjs/src/lib/models/glyphs/xy_glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/xy_glyph.ts
@@ -27,7 +27,7 @@ export abstract class XYGlyphView extends GlyphView {
       if (isNaN(x + y) || !isFinite(x + y))
         continue
 
-      points.push({minX: x, minY: y, maxX: x, maxY: y, i})
+      points.push({x0: x, y0: y, x1: x, y1: y, i})
     }
 
     return new SpatialIndex(points)

--- a/bokehjs/src/lib/models/layouts/layout_dom.ts
+++ b/bokehjs/src/lib/models/layouts/layout_dom.ts
@@ -359,7 +359,7 @@ export abstract class LayoutDOMView extends DOMView {
   serializable_state(): {[key: string]: unknown} {
     return {
       ...super.serializable_state(),
-      bbox: this.layout.bbox.rect,
+      bbox: this.layout.bbox.box,
       children: this.child_views.map((child) => child.serializable_state()),
     }
   }

--- a/bokehjs/src/lib/models/markers/marker.ts
+++ b/bokehjs/src/lib/models/markers/marker.ts
@@ -3,7 +3,7 @@ import {XYGlyph, XYGlyphView, XYGlyphData} from "../glyphs/xy_glyph"
 import {PointGeometry, SpanGeometry, RectGeometry, PolyGeometry} from "core/geometry"
 import {LineVector, FillVector} from "core/property_mixins"
 import {Line, Fill} from "core/visuals"
-import {Arrayable, Area} from "core/types"
+import {Arrayable, Rect} from "core/types"
 import * as hittest from "core/hittest"
 import * as p from "core/properties"
 import {range} from "core/util/array"
@@ -60,8 +60,7 @@ export abstract class MarkerView extends XYGlyphView {
     const sy1 = vr.end + this.max_size
     const [y0, y1] = this.renderer.yscale.r_invert(sy0, sy1)
 
-    const bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-    return this.index.indices(bbox)
+    return this.index.indices({x0, x1, y0, y1})
   }
 
   protected _hit_point(geometry: PointGeometry): Selection {
@@ -75,8 +74,7 @@ export abstract class MarkerView extends XYGlyphView {
     const sy1 = sy + this.max_size
     const [y0, y1] = this.renderer.yscale.r_invert(sy0, sy1)
 
-    const bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-    const candidates = this.index.indices(bbox)
+    const candidates = this.index.indices({x0, x1, y0, y1})
 
     const hits: [number, number][] = []
     for (const i of candidates) {
@@ -91,29 +89,26 @@ export abstract class MarkerView extends XYGlyphView {
 
   protected _hit_span(geometry: SpanGeometry): Selection {
     const {sx, sy} = geometry
-    const {minX, minY, maxX, maxY} = this.bounds()
+    const bounds = this.bounds()
+    const ms = this.max_size/2
     const result = hittest.create_empty_hit_test_result()
 
-    let x0: number, x1: number
-    let y0: number, y1: number
+    let x0, x1, y0, y1
     if (geometry.direction == 'h') {
-      y0 = minY
-      y1 = maxY
-      const ms = this.max_size/2
+      y0 = bounds.y0
+      y1 = bounds.y1
       const sx0 = sx - ms
       const sx1 = sx + ms
       ;[x0, x1] = this.renderer.xscale.r_invert(sx0, sx1)
     } else {
-      x0 = minX
-      x1 = maxX
-      const ms = this.max_size/2
+      x0 = bounds.x0
+      x1 = bounds.x1
       const sy0 = sy - ms
       const sy1 = sy + ms
       ;[y0, y1] = this.renderer.yscale.r_invert(sy0, sy1)
     }
 
-    const bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
-    const hits = this.index.indices(bbox)
+    const hits = this.index.indices({x0, x1, y0, y1})
 
     result.indices = hits
     return result
@@ -123,9 +118,8 @@ export abstract class MarkerView extends XYGlyphView {
     const {sx0, sx1, sy0, sy1} = geometry
     const [x0, x1] = this.renderer.xscale.r_invert(sx0, sx1)
     const [y0, y1] = this.renderer.yscale.r_invert(sy0, sy1)
-    const bbox = hittest.validate_bbox_coords([x0, x1], [y0, y1])
     const result = hittest.create_empty_hit_test_result()
-    result.indices = this.index.indices(bbox)
+    result.indices = this.index.indices({x0, x1, y0, y1})
     return result
   }
 
@@ -146,7 +140,7 @@ export abstract class MarkerView extends XYGlyphView {
     return result
   }
 
-  draw_legend_for_index(ctx: Context2d, {x0, x1, y0, y1}: Area, index: number): void {
+  draw_legend_for_index(ctx: Context2d, {x0, x1, y0, y1}: Rect, index: number): void {
     // using objects like this seems a little wonky, since the keys are coerced to
     // stings, but it works
     const len = index + 1

--- a/bokehjs/src/lib/models/markers/scatter.ts
+++ b/bokehjs/src/lib/models/markers/scatter.ts
@@ -1,7 +1,7 @@
 import {Marker, MarkerView, MarkerData} from "./marker"
 import {marker_funcs} from "./defs"
 import {MarkerType} from "core/enums"
-import {Arrayable, Area} from "core/types"
+import {Arrayable, Rect} from "core/types"
 import * as p from "core/properties"
 import {Context2d} from "core/util/canvas"
 
@@ -36,7 +36,7 @@ export class ScatterView extends MarkerView {
     }
   }
 
-  draw_legend_for_index(ctx: Context2d, {x0, x1, y0, y1}: Area, index: number): void {
+  draw_legend_for_index(ctx: Context2d, {x0, x1, y0, y1}: Rect, index: number): void {
     // using objects like this seems a little wonky, since the keys are coerced to
     // stings, but it works
     const len = index + 1

--- a/bokehjs/src/lib/models/ranges/data_range1d.ts
+++ b/bokehjs/src/lib/models/ranges/data_range1d.ts
@@ -125,14 +125,14 @@ export class DataRange1d extends DataRange {
    adjust_bounds_for_aspect(bounds: Rect, ratio: number): Rect {
     const result = bbox.empty()
 
-    let width = bounds.maxX - bounds.minX
+    let width = bounds.x1 - bounds.x0
     if (width <= 0) { width = 1.0 }
 
-    let height = bounds.maxY - bounds.minY
+    let height = bounds.y1 - bounds.y0
     if (height <= 0) { height = 1.0 }
 
-    const xcenter = 0.5*(bounds.maxX + bounds.minX)
-    const ycenter = 0.5*(bounds.maxY + bounds.minY)
+    const xcenter = 0.5*(bounds.x1 + bounds.x0)
+    const ycenter = 0.5*(bounds.y1 + bounds.y0)
 
     if (width < ratio*height) {
       width = ratio*height
@@ -140,10 +140,10 @@ export class DataRange1d extends DataRange {
       height = width/ratio
     }
 
-    result.maxX = xcenter+0.5*width
-    result.minX = xcenter-0.5*width
-    result.maxY = ycenter+0.5*height
-    result.minY = ycenter-0.5*height
+    result.x1 = xcenter+0.5*width
+    result.x0 = xcenter-0.5*width
+    result.y1 = ycenter+0.5*height
+    result.y0 = ycenter-0.5*height
 
     return result
   }
@@ -157,9 +157,9 @@ export class DataRange1d extends DataRange {
 
     let min, max: number
     if (dimension == 0)
-      [min, max] = [overall.minX, overall.maxX]
+      [min, max] = [overall.x0, overall.x1]
     else
-      [min, max] = [overall.minY, overall.maxY]
+      [min, max] = [overall.y0, overall.y1]
 
     return [min, max]
   }

--- a/bokehjs/test/core/util/bbox.ts
+++ b/bokehjs/test/core/util/bbox.ts
@@ -5,27 +5,27 @@ import * as bbox from "@bokehjs/core/util/bbox"
 describe("bbox module", () => {
   describe("empty", () => {
     it("should be an unbounded box", () => {
-      expect(bbox.empty()).to.deep.equal({minX: Infinity, minY: Infinity, maxX: -Infinity, maxY:-Infinity})
+      expect(bbox.empty()).to.deep.equal({x0: Infinity, y0: Infinity, x1: -Infinity, y1:-Infinity})
     })
   })
 
   describe("positive_x", () => {
     it("should be box covering the area where x is positive", () => {
-      expect(bbox.positive_x()).to.deep.equal({minX: Number.MIN_VALUE, minY: -Infinity, maxX: Infinity, maxY: Infinity})
+      expect(bbox.positive_x()).to.deep.equal({x0: Number.MIN_VALUE, y0: -Infinity, x1: Infinity, y1: Infinity})
     })
   })
 
   describe("positive_y", () => {
     it("should be box covering the area where y is positive", () => {
-      expect(bbox.positive_y()).to.deep.equal({minX: -Infinity, minY: Number.MIN_VALUE, maxX: Infinity, maxY: Infinity})
+      expect(bbox.positive_y()).to.deep.equal({x0: -Infinity, y0: Number.MIN_VALUE, x1: Infinity, y1: Infinity})
     })
   })
 
   describe("union", () => {
     const empty    = bbox.empty()
-    const outside  = {minX: 0, maxX: 10, minY:  0, maxY: 10}
-    const inside   = {minX: 4, maxX:  5, minY:  4, maxY: 5 }
-    const overlaps = {minX:-5, maxX:  5, minY: -5, maxY: 5 }
+    const outside  = {x0: 0, x1: 10, y0:  0, y1: 10}
+    const inside   = {x0: 4, x1:  5, y0:  4, y1: 5 }
+    const overlaps = {x0:-5, x1:  5, y0: -5, y1: 5 }
 
     it("should return empty when inputs are empty", () => {
       expect(bbox.union(empty, empty)).to.deep.equal(empty)
@@ -42,13 +42,13 @@ describe("bbox module", () => {
     })
 
     it("should return the envelope of overlapping bboxes", () => {
-      expect(bbox.union(overlaps, outside)).to.deep.equal({minX: -5, maxX: 10, minY: -5, maxY: 10})
-      expect(bbox.union(outside, overlaps)).to.deep.equal({minX: -5, maxX: 10, minY: -5, maxY: 10})
+      expect(bbox.union(overlaps, outside)).to.deep.equal({x0: -5, x1: 10, y0: -5, y1: 10})
+      expect(bbox.union(outside, overlaps)).to.deep.equal({x0: -5, x1: 10, y0: -5, y1: 10})
     })
 
     it("should return the envelope of disjoint bboxes", () => {
-      expect(bbox.union(overlaps, outside)).to.deep.equal({minX: -5, maxX: 10, minY: -5, maxY: 10})
-      expect(bbox.union(outside, overlaps)).to.deep.equal({minX: -5, maxX: 10, minY: -5, maxY: 10})
+      expect(bbox.union(overlaps, outside)).to.deep.equal({x0: -5, x1: 10, y0: -5, y1: 10})
+      expect(bbox.union(outside, overlaps)).to.deep.equal({x0: -5, x1: 10, y0: -5, y1: 10})
     })
   })
 })

--- a/bokehjs/test/devtools.ts
+++ b/bokehjs/test/devtools.ts
@@ -44,8 +44,8 @@ function timeout(ms: number): Promise<void> {
   })
 }
 
-type BBox = {left: number, top: number, width: number, height: number}
-type State = {type: string, bbox?: BBox, children?: State[]}
+type Box = {x: number, y: number, width: number, height: number}
+type State = {type: string, bbox?: Box, children?: State[]}
 
 function create_baseline(items: State[]): string {
   let baseline = ""
@@ -55,8 +55,8 @@ function create_baseline(items: State[]): string {
       baseline += `${"  ".repeat(level)}${type}`
 
       if (bbox != null) {
-        const {left, top, width, height} = bbox
-        baseline += ` bbox=[${left}, ${top}, ${width}, ${height}]`
+        const {x, y, width, height} = bbox
+        baseline += ` bbox=[${x}, ${y}, ${width}, ${height}]`
       }
 
       baseline += "\n"

--- a/bokehjs/test/models/glyphs/rect.ts
+++ b/bokehjs/test/models/glyphs/rect.ts
@@ -31,7 +31,7 @@ describe("Glyph (using Rect as a concrete Glyph)", () => {
       const glyph_view = create_glyph_view(glyph, data)
       const bounds = glyph_view.bounds()
 
-      expect(bounds).to.be.deep.equal({ minX: 1, minY: -20, maxX: 4, maxY: 30 })
+      expect(bounds).to.be.deep.equal({ x0: 1, y0: -20, x1: 4, y1: 30 })
     })
 
     it("should calculate log bounds based on data values > 0", () => {
@@ -39,7 +39,7 @@ describe("Glyph (using Rect as a concrete Glyph)", () => {
       const glyph_view = create_glyph_view(glyph, data)
       const log_bounds = glyph_view.log_bounds()
 
-      expect(log_bounds).to.be.deep.equal({ minX: 1, minY: 10, maxX: 4, maxY: 30 })
+      expect(log_bounds).to.be.deep.equal({ x0: 1, y0: 10, x1: 4, y1: 30 })
     })
 
     it("should calculate log bounds when NaNs are present", () => {
@@ -47,7 +47,7 @@ describe("Glyph (using Rect as a concrete Glyph)", () => {
       const glyph_view = create_glyph_view(glyph, data)
       const log_bounds = glyph_view.log_bounds()
 
-      expect(log_bounds).to.be.deep.equal({ minX: 1, minY: 10, maxX: 3, maxY: 10 })
+      expect(log_bounds).to.be.deep.equal({ x0: 1, y0: 10, x1: 3, y1: 10 })
     })
 
     it("should hit test rects against an index", () => {
@@ -99,7 +99,7 @@ describe("Rect", () => {
       const glyph_view = create_glyph_view(glyph, data)
       const bounds = glyph_view.bounds()
 
-      expect(bounds).to.be.deep.equal({ minX: -5, minY: -10, maxX: 8, maxY: 13 })
+      expect(bounds).to.be.deep.equal({ x0: -5, y0: -10, x1: 8, y1: 13 })
     })
 
     it("should calculate log bounds based on data including width and height", () => {
@@ -107,7 +107,7 @@ describe("Rect", () => {
       const glyph_view = create_glyph_view(glyph, data)
       const log_bounds = glyph_view.log_bounds()
 
-      expect(log_bounds).to.be.deep.equal({ minX: -4, minY: -9, maxX: 8, maxY: 13 })
+      expect(log_bounds).to.be.deep.equal({ x0: -4, y0: -9, x1: 8, y1: 13 })
     })
 
     it("`_map_data` should correctly map data if width and height units are 'data'", () => {

--- a/bokehjs/test/models/ranges/data_range1d.ts
+++ b/bokehjs/test/models/ranges/data_range1d.ts
@@ -253,7 +253,7 @@ describe("datarange1d module", () => {
     it("should compute max/min for dimension of a single plot_bounds", () => {
       const r = new DataRange1d()
       const bds = {
-        1: {minX: 0, maxX: 10, minY: 5, maxY:6},
+        1: {x0: 0, x1: 10, y0: 5, y1:6},
       }
       expect(r._compute_min_max(bds, 0)).to.be.deep.equal([0, 10])
       expect(r._compute_min_max(bds, 1)).to.be.deep.equal([5, 6])
@@ -262,16 +262,16 @@ describe("datarange1d module", () => {
     it("should compute max/min for dimension of multiple plot_bounds", () => {
       const r = new DataRange1d()
       const bds0 = {
-        1: {minX: 0, maxX: 10, minY: 5, maxY: 6},
-        2: {minX: 0, maxX: 15, minY: 5.5, maxY: 5.6},
+        1: {x0: 0, x1: 10, y0: 5, y1: 6},
+        2: {x0: 0, x1: 15, y0: 5.5, y1: 5.6},
       }
       expect(r._compute_min_max(bds0, 0)).to.be.deep.equal([0, 15])
       expect(r._compute_min_max(bds0, 1)).to.be.deep.equal([5, 6])
 
       const bds1 = {
-        1: {minX: 0, maxX: 10, minY: 5, maxY: 6},
-        2: {minX: 0, maxX: 15, minY: 5.5, maxY: 5.6},
-        3: {minX: -10, maxX: 15, minY: 0, maxY: 2},
+        1: {x0: 0, x1: 10, y0: 5, y1: 6},
+        2: {x0: 0, x1: 15, y0: 5.5, y1: 5.6},
+        3: {x0: -10, x1: 15, y0: 0, y1: 2},
       }
       expect(r._compute_min_max(bds1, 0)).to.be.deep.equal([-10, 15])
       expect(r._compute_min_max(bds1, 1)).to.be.deep.equal([0, 6])
@@ -287,13 +287,13 @@ describe("datarange1d module", () => {
       const g2 = new GlyphRenderer({id: "2"})
 
       const bds = {
-        1: {minX: 0, maxX: 10, minY: 5, maxY: 6},
-        2: {minX: 0, maxX: 15, minY: 5.5, maxY: 5.6},
-        3: {minX: -10, maxX: 15, minY: 0, maxY: 2},
+        1: {x0: 0, x1: 10, y0: 5, y1: 6},
+        2: {x0: 0, x1: 15, y0: 5.5, y1: 5.6},
+        3: {x0: -10, x1: 15, y0: 0, y1: 2},
       }
 
-      expect(r._compute_plot_bounds([g1], bds)).to.be.deep.equal({minX: 0, maxX: 10, minY: 5, maxY: 6})
-      expect(r._compute_plot_bounds([g1, g2], bds)).to.be.deep.equal({minX: 0, maxX: 15, minY: 5, maxY: 6})
+      expect(r._compute_plot_bounds([g1], bds)).to.be.deep.equal({x0: 0, x1: 10, y0: 5, y1: 6})
+      expect(r._compute_plot_bounds([g1, g2], bds)).to.be.deep.equal({x0: 0, x1: 15, y0: 5, y1: 6})
     })
   })
 
@@ -305,7 +305,7 @@ describe("datarange1d module", () => {
       const r = new DataRange1d({plots: [p]})
 
       const bds = {
-        id: {minX: -10, maxX: -6, minY: 5, maxY: 6},
+        id: {x0: -10, x1: -6, y0: 5, y1: 6},
       }
 
       r.update(bds, 0, "id")
@@ -318,7 +318,7 @@ describe("datarange1d module", () => {
       const r = new DataRange1d({scale_hint: "log", plots: [p]})
 
       const bds = {
-        id: {minX: Infinity, maxX: -Infinity, minY: 5, maxY: 6},
+        id: {x0: Infinity, x1: -Infinity, y0: 5, y1: 6},
       }
 
       r.update(bds, 0, "id")
@@ -342,22 +342,22 @@ describe("datarange1d module", () => {
   describe("adjust_bounds_for_aspect", () => {
     it("should preserve y axis when it is larger", () => {
       const r = new DataRange1d()
-      const bds = r.adjust_bounds_for_aspect({minX: 0, maxX: 1, minY: 0, maxY: 2}, 4)
+      const bds = r.adjust_bounds_for_aspect({x0: 0, x1: 1, y0: 0, y1: 2}, 4)
 
-      expect(bds.minX).to.be.equal(-3.5)
-      expect(bds.maxX).to.be.equal(4.5)
-      expect(bds.minY).to.be.equal(0)
-      expect(bds.maxY).to.be.equal(2)
+      expect(bds.x0).to.be.equal(-3.5)
+      expect(bds.x1).to.be.equal(4.5)
+      expect(bds.y0).to.be.equal(0)
+      expect(bds.y1).to.be.equal(2)
     })
 
     it("should preserve x axis when it is larger", () => {
       const r = new DataRange1d()
-      const bds = r.adjust_bounds_for_aspect({minX: 0, maxX: 8, minY: 0, maxY: 1}, 4)
+      const bds = r.adjust_bounds_for_aspect({x0: 0, x1: 8, y0: 0, y1: 1}, 4)
 
-      expect(bds.minX).to.be.equal(0)
-      expect(bds.maxX).to.be.equal(8)
-      expect(bds.minY).to.be.equal(-0.5)
-      expect(bds.maxY).to.be.equal(1.5)
+      expect(bds.x0).to.be.equal(0)
+      expect(bds.x1).to.be.equal(8)
+      expect(bds.y0).to.be.equal(-0.5)
+      expect(bds.y1).to.be.equal(1.5)
     })
   })
 })

--- a/examples/custom/gears/gear.ts
+++ b/examples/custom/gears/gear.ts
@@ -2,7 +2,7 @@ import {XYGlyph, XYGlyphView, XYGlyphData} from "models/glyphs/xy_glyph"
 import {generic_area_legend} from "models/glyphs/utils"
 import {isString} from "core/util/types"
 import {Context2d} from "core/util/canvas"
-import {Arrayable, Area} from "core/types"
+import {Arrayable, Rect} from "core/types"
 import {LineVector, FillVector} from "core/property_mixins"
 import {Line, Fill} from "core/visuals"
 import * as p from "core/properties"
@@ -141,7 +141,7 @@ export class GearView extends XYGlyphView {
     }
   }
 
-  draw_legend_for_index(ctx: Context2d, bbox: Area, index: number): void {
+  draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
     generic_area_legend(this.visuals, ctx, bbox, index)
   }
 }

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -129,7 +129,7 @@ def _create_baseline(items):
             line = "%s%s" % ("  "*level, type)
 
             if bbox is not None:
-                line += " bbox=[%s, %s, %s, %s]" % (bbox["left"], bbox["top"], bbox["width"], bbox["height"])
+                line += " bbox=[%s, %s, %s, %s]" % (bbox["x"], bbox["y"], bbox["width"], bbox["height"])
 
             line += "\n"
 


### PR DESCRIPTION
Previously `Rect` was defined as `{minX, maxX, minY, maxY}`, which was what rbush/flatbush uses. Now it's defined as `{x0, x1, y0, y1}`, which better aligns with the rest of bokehjs. Besides this, I removed unnecessary calls to `validate_bbox_coords()`, because `SpatialIndex` does normalization anyway.