### PR TITLE
remove legacy datetime check

### DIFF
--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -207,28 +207,9 @@ def convert_datetime_array(array):
     if not isinstance(array, np.ndarray):
         return array
 
-    try:
-        dt2001 = np.datetime64('2001')
-        legacy_datetime64 = (dt2001.astype('int64') ==
-                             dt2001.astype('datetime64[ms]').astype('int64'))
-    except AttributeError as e:
-        if e.args == ("'module' object has no attribute 'datetime64'",):
-            # for compatibility with PyPy that doesn't have datetime64
-            if 'PyPy' in sys.version:
-                legacy_datetime64 = False
-                pass
-            else:
-                raise e
-        else:
-            raise e
-
     # not quite correct, truncates to ms..
     if array.dtype.kind == 'M':
-        if legacy_datetime64:
-            if array.dtype == np.dtype('datetime64[ns]'):
-                array = array.astype('int64') / 10**6.0
-        else:
-            array =  array.astype('datetime64[us]').astype('int64') / 1000.
+        array =  array.astype('datetime64[us]').astype('int64') / 1000.
 
     elif array.dtype.kind == 'm':
         array = array.astype('timedelta64[us]').astype('int64') / 1000.


### PR DESCRIPTION
- [x] issues: fixes #8956

This check only applied to Numpy < 1.7 and that's already our min
