### PR TITLE
don't call show in tests

### DIFF
--- a/bokeh/util/tests/test_compiler.py
+++ b/bokeh/util/tests/test_compiler.py
@@ -180,7 +180,7 @@ def test_jsons():
                 assert all(['\\' not in mod for mod in json.loads(f.read())])
 
 def test_inline_extension():
-    from bokeh.io import show
+    from bokeh.io import save
     from bokeh.models import TickFormatter
     from bokeh.plotting import figure
     from bokeh.util.compiler import TypeScript
@@ -221,7 +221,7 @@ def test_inline_extension():
     p = figure()
     p.circle([1, 2, 3, 4, 6], [5, 7, 3, 2, 4])
     p.xaxis.formatter = TestFormatter()
-    show(p)
+    save(p)
 
 #-----------------------------------------------------------------------------
 # Dev API


### PR DESCRIPTION
Calling `show` in a test opens a browser tab on test run which is super annoying. Confirmed `save` failed when it should and passes when it should.