### PR TITLE
Restrict CDS property changes

### DIFF
--- a/bokeh/core/property/bases.py
+++ b/bokeh/core/property/bases.py
@@ -90,9 +90,12 @@ class Property(PropertyDescriptorFactory):
     # This class attribute is controlled by external helper API for validation
     _should_validate = True
 
-    def __init__(self, default=None, help=None, serialized=True, readonly=False):
+    def __init__(self, default=None, help=None, serialized=None, readonly=False):
         # This is how the descriptor is created in the class declaration.
-        self._serialized = False if readonly else serialized
+        if serialized is None:
+            self._serialized = False if readonly else True
+        else:
+            self._serialized = serialized
         self._readonly = readonly
         self._default = default
         self.__doc__ = help

--- a/bokeh/core/property/descriptors.py
+++ b/bokeh/core/property/descriptors.py
@@ -93,7 +93,7 @@ from copy import copy
 # External imports
 
 # Bokeh imports
-from .wrappers import PropertyValueContainer
+from .wrappers import PropertyValueColumnData, PropertyValueContainer
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -912,6 +912,14 @@ class BasicPropertyDescriptor(PropertyDescriptor):
             obj.trigger(self.name, old, value, hint, setter)
 
 
+_CDS_SET_FROM_CDS_ERROR = """
+ColumnDataSource.data properties may only be set from plain Python dicts,
+not other ColumnDataSource.data values.
+
+If you need to copy set from one CDS to another, make a shallow copy by
+calling dict: s1.data = dict(s2.data)
+"""
+
 class ColumnDataPropertyDescriptor(BasicPropertyDescriptor):
     ''' A ``PropertyDescriptor`` specialized to handling ``ColumnData`` properties.
 
@@ -959,6 +967,9 @@ class ColumnDataPropertyDescriptor(BasicPropertyDescriptor):
 
         if self.property._readonly:
             raise RuntimeError("%s.%s is a readonly property" % (obj.__class__.__name__, self.name))
+
+        if isinstance(value, PropertyValueColumnData):
+            raise ValueError(_CDS_SET_FROM_CDS_ERROR)
 
         from ...document.events import ColumnDataChangedEvent
 

--- a/bokeh/core/property/instance.py
+++ b/bokeh/core/property/instance.py
@@ -50,7 +50,7 @@ class Instance(Property):
             (default: False)
 
     '''
-    def __init__(self, instance_type, default=None, help=None, readonly=False):
+    def __init__(self, instance_type, default=None, help=None, readonly=False, serialized=True):
         if not isinstance(instance_type, (type, str)):
             raise ValueError("expected a type or string, got %s" % instance_type)
 
@@ -60,7 +60,7 @@ class Instance(Property):
 
         self._instance_type = instance_type
 
-        super().__init__(default=default, help=help, readonly=readonly)
+        super().__init__(default=default, help=help, readonly=readonly, serialized=True)
 
     def __str__(self):
         return "%s(%s)" % (self.__class__.__name__, self.instance_type.__name__)

--- a/bokeh/core/property/instance.py
+++ b/bokeh/core/property/instance.py
@@ -44,10 +44,13 @@ __all__ = (
 class Instance(Property):
     ''' Accept values that are instances of |HasProps|.
 
-
+    Args:
+        readonly (bool, optional) :
+            Whether attributes created from this property are read-only.
+            (default: False)
 
     '''
-    def __init__(self, instance_type, default=None, help=None):
+    def __init__(self, instance_type, default=None, help=None, readonly=False):
         if not isinstance(instance_type, (type, str)):
             raise ValueError("expected a type or string, got %s" % instance_type)
 
@@ -57,7 +60,7 @@ class Instance(Property):
 
         self._instance_type = instance_type
 
-        super().__init__(default=default, help=help)
+        super().__init__(default=default, help=help, readonly=readonly)
 
     def __str__(self):
         return "%s(%s)" % (self.__class__.__name__, self.instance_type.__name__)

--- a/bokeh/core/property/tests/test_bases.py
+++ b/bokeh/core/property/tests/test_bases.py
@@ -43,156 +43,174 @@ ALL = (
 # General API
 #-----------------------------------------------------------------------------
 
-@patch('bokeh.core.property.bases.Property.validate')
-def test_is_valid_supresses_validation_detail(mock_validate):
-    p = bcpb.Property()
-    p.is_valid(None)
-    assert mock_validate.called
-    assert mock_validate.call_args[0] == (None, False)
+class TestProperty(object):
 
-def test_property_assert_bools():
-    hp = HasProps()
-    p = bcpb.Property()
+    @patch('bokeh.core.property.bases.Property.validate')
+    def test_is_valid_supresses_validation_detail(self, mock_validate):
+        p = bcpb.Property()
+        p.is_valid(None)
+        assert mock_validate.called
+        assert mock_validate.call_args[0] == (None, False)
 
-    p.asserts(True, "true")
-    assert p.prepare_value(hp, "foo", 10) == 10
+    def test_serialized_default(self):
+        p = bcpb.Property()
+        assert p.serialized == True
+        assert p.readonly == False
 
-    p.asserts(False, "false")
-    with pytest.raises(ValueError) as e:
-        p.prepare_value(hp, "foo", 10)
-        assert str(e) == "false"
+        # readonly=True sets serialized=False if unspecified
+        p = bcpb.Property(readonly=True)
+        assert p.serialized == False
+        assert p.readonly == True
 
-def test_property_assert_functions():
-    hp = HasProps()
-    p = bcpb.Property()
+        # explicit serialized value always respected
+        p = bcpb.Property(readonly=True, serialized=True)
+        assert p.serialized == True
+        assert p.readonly == True
 
-    p.asserts(lambda obj, value: True, "true")
-    p.asserts(lambda obj, value: obj is hp, "true")
-    p.asserts(lambda obj, value: value==10, "true")
-    assert p.prepare_value(hp, "foo", 10) == 10
 
-    p.asserts(lambda obj, value: False, "false")
-    with pytest.raises(ValueError) as e:
-        p.prepare_value(hp, "foo", 10)
-        assert str(e) == "false"
+    def test_assert_bools(self):
+        hp = HasProps()
+        p = bcpb.Property()
 
-def test_property_assert_msg_funcs():
-    hp = HasProps()
-    p = bcpb.Property()
+        p.asserts(True, "true")
+        assert p.prepare_value(hp, "foo", 10) == 10
 
-    def raise_(ex):
-        raise ex
+        p.asserts(False, "false")
+        with pytest.raises(ValueError) as e:
+                p.prepare_value(hp, "foo", 10)
+                assert str(e) == "false"
 
-    p.asserts(False, lambda obj, name, value: raise_(ValueError("bad %s %s %s" % (hp==obj, name, value))))
+    def test_assert_functions(self):
+        hp = HasProps()
+        p = bcpb.Property()
 
-    with pytest.raises(ValueError) as e:
-        p.prepare_value(hp, "foo", 10)
-        assert str(e) == "bad True name, 10"
+        p.asserts(lambda obj, value: True, "true")
+        p.asserts(lambda obj, value: obj is hp, "true")
+        p.asserts(lambda obj, value: value==10, "true")
+        assert p.prepare_value(hp, "foo", 10) == 10
 
-def test_property_matches_basic_types(capsys):
-    p = bcpb.Property()
-    for x in [1, 1.2, "a", np.arange(4), None, False, True, {}, []]:
-        assert p.matches(x, x) is True
-        assert p.matches(x, "junk") is False
-    out, err = capsys.readouterr()
-    assert err == ""
+        p.asserts(lambda obj, value: False, "false")
+        with pytest.raises(ValueError) as e:
+                p.prepare_value(hp, "foo", 10)
+                assert str(e) == "false"
 
-def test_property_matches_compatible_arrays(capsys):
-    p = bcpb.Property()
-    a = np.arange(5)
-    b = np.arange(5)
-    assert p.matches(a, b) is True
-    assert p.matches(a, b+1) is False
-    for x in [1, 1.2, "a", np.arange(4), None, False]:
-        assert p.matches(a, x) is False
-        assert p.matches(x, b) is False
-    out, err = capsys.readouterr()
-    assert err == ""
+    def test_assert_msg_funcs(self):
+        hp = HasProps()
+        p = bcpb.Property()
 
-def test_property_matches_incompatible_arrays(capsys):
-    p = bcpb.Property()
-    a = np.arange(5)
-    b = np.arange(5).astype(str)
-    assert p.matches(a, b) is False
-    out, err = capsys.readouterr()
-    # no way to suppress FutureWarning in this case
-    # assert err == ""
+        def raise_(ex):
+                raise ex
 
-def test_property_matches_dicts_with_array_values(capsys):
-    p = bcpb.Property()
-    d1 = dict(foo=np.arange(10))
-    d2 = dict(foo=np.arange(10))
+        p.asserts(False, lambda obj, name, value: raise_(ValueError("bad %s %s %s" % (hp==obj, name, value))))
 
-    assert p.matches(d1, d1) is True
-    assert p.matches(d1, d2) is True
+        with pytest.raises(ValueError) as e:
+                p.prepare_value(hp, "foo", 10)
+                assert str(e) == "bad True name, 10"
 
-    # XXX not sure if this is preferable to have match, or not
-    assert p.matches(d1, dict(foo=list(range(10)))) is True
+    def test_matches_basic_types(self, capsys):
+        p = bcpb.Property()
+        for x in [1, 1.2, "a", np.arange(4), None, False, True, {}, []]:
+                assert p.matches(x, x) is True
+                assert p.matches(x, "junk") is False
+        out, err = capsys.readouterr()
+        assert err == ""
 
-    assert p.matches(d1, dict(foo=np.arange(11))) is False
-    assert p.matches(d1, dict(bar=np.arange(10))) is False
-    assert p.matches(d1, dict(bar=10)) is False
-    out, err = capsys.readouterr()
-    assert err == ""
+    def test_matches_compatible_arrays(self, capsys):
+        p = bcpb.Property()
+        a = np.arange(5)
+        b = np.arange(5)
+        assert p.matches(a, b) is True
+        assert p.matches(a, b+1) is False
+        for x in [1, 1.2, "a", np.arange(4), None, False]:
+                assert p.matches(a, x) is False
+                assert p.matches(x, b) is False
+        out, err = capsys.readouterr()
+        assert err == ""
 
-def test_property_matches_non_dict_containers_with_array_false(capsys):
-    p = bcpb.Property()
-    d1 = [np.arange(10)]
-    d2 = [np.arange(10)]
-    assert p.matches(d1, d1) is True  # because object identity
-    assert p.matches(d1, d2) is False
+    def test_matches_incompatible_arrays(self, capsys):
+        p = bcpb.Property()
+        a = np.arange(5)
+        b = np.arange(5).astype(str)
+        assert p.matches(a, b) is False
+        out, err = capsys.readouterr()
+        # no way to suppress FutureWarning in this case
+        # assert err == ""
 
-    t1 = (np.arange(10),)
-    t2 = (np.arange(10),)
-    assert p.matches(t1, t1) is True  # because object identity
-    assert p.matches(t1, t2) is False
+    def test_matches_dicts_with_array_values(self, capsys):
+        p = bcpb.Property()
+        d1 = dict(foo=np.arange(10))
+        d2 = dict(foo=np.arange(10))
 
-    out, err = capsys.readouterr()
-    assert err == ""
+        assert p.matches(d1, d1) is True
+        assert p.matches(d1, d2) is True
 
-def test_property_matches_dicts_with_series_values(capsys, pd):
-    p = bcpb.Property()
-    d1 = pd.DataFrame(dict(foo=np.arange(10)))
-    d2 = pd.DataFrame(dict(foo=np.arange(10)))
+        # XXX not sure if this is preferable to have match, or not
+        assert p.matches(d1, dict(foo=list(range(10)))) is True
 
-    assert p.matches(d1.foo, d1.foo) is True
-    assert p.matches(d1.foo, d2.foo) is True
+        assert p.matches(d1, dict(foo=np.arange(11))) is False
+        assert p.matches(d1, dict(bar=np.arange(10))) is False
+        assert p.matches(d1, dict(bar=10)) is False
+        out, err = capsys.readouterr()
+        assert err == ""
 
-    # XXX not sure if this is preferable to have match, or not
-    assert p.matches(d1.foo, (range(10))) is True
+    def test_matches_non_dict_containers_with_array_false(self, capsys):
+        p = bcpb.Property()
+        d1 = [np.arange(10)]
+        d2 = [np.arange(10)]
+        assert p.matches(d1, d1) is True  # because object identity
+        assert p.matches(d1, d2) is False
 
-    assert p.matches(d1.foo, np.arange(11)) is False
-    assert p.matches(d1.foo, np.arange(10)+1) is False
-    assert p.matches(d1.foo, 10) is False
-    out, err = capsys.readouterr()
-    assert err == ""
+        t1 = (np.arange(10),)
+        t2 = (np.arange(10),)
+        assert p.matches(t1, t1) is True  # because object identity
+        assert p.matches(t1, t2) is False
 
-def test_property_matches_dicts_with_index_values(capsys, pd):
-    p = bcpb.Property()
-    d1 = pd.DataFrame(dict(foo=np.arange(10)))
-    d2 = pd.DataFrame(dict(foo=np.arange(10)))
+        out, err = capsys.readouterr()
+        assert err == ""
 
-    assert p.matches(d1.index, d1.index) is True
-    assert p.matches(d1.index, d2.index) is True
+    def test_matches_dicts_with_series_values(self, capsys, pd):
+        p = bcpb.Property()
+        d1 = pd.DataFrame(dict(foo=np.arange(10)))
+        d2 = pd.DataFrame(dict(foo=np.arange(10)))
 
-    # XXX not sure if this is preferable to have match, or not
-    assert p.matches(d1.index, list(range(10))) is True
+        assert p.matches(d1.foo, d1.foo) is True
+        assert p.matches(d1.foo, d2.foo) is True
 
-    assert p.matches(d1.index, np.arange(11)) is False
-    assert p.matches(d1.index, np.arange(10)+1) is False
-    assert p.matches(d1.index, 10) is False
-    out, err = capsys.readouterr()
-    assert err == ""
+        # XXX not sure if this is preferable to have match, or not
+        assert p.matches(d1.foo, (range(10))) is True
 
-def test_validation_on():
-    assert bcpb.Property._should_validate == True
-    assert bcpb.validation_on()
+        assert p.matches(d1.foo, np.arange(11)) is False
+        assert p.matches(d1.foo, np.arange(10)+1) is False
+        assert p.matches(d1.foo, 10) is False
+        out, err = capsys.readouterr()
+        assert err == ""
 
-    bcpb.Property._should_validate = False
-    assert not bcpb.validation_on()
+    def test_matches_dicts_with_index_values(self, capsys, pd):
+        p = bcpb.Property()
+        d1 = pd.DataFrame(dict(foo=np.arange(10)))
+        d2 = pd.DataFrame(dict(foo=np.arange(10)))
 
-    bcpb.Property._should_validate = True
-    assert bcpb.validation_on()
+        assert p.matches(d1.index, d1.index) is True
+        assert p.matches(d1.index, d2.index) is True
+
+        # XXX not sure if this is preferable to have match, or not
+        assert p.matches(d1.index, list(range(10))) is True
+
+        assert p.matches(d1.index, np.arange(11)) is False
+        assert p.matches(d1.index, np.arange(10)+1) is False
+        assert p.matches(d1.index, 10) is False
+        out, err = capsys.readouterr()
+        assert err == ""
+
+    def test_validation_on(self):
+        assert bcpb.Property._should_validate == True
+        assert bcpb.validation_on()
+
+        bcpb.Property._should_validate = False
+        assert not bcpb.validation_on()
+
+        bcpb.Property._should_validate = True
+        assert bcpb.validation_on()
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/core/property/tests/test_instance.py
+++ b/bokeh/core/property/tests/test_instance.py
@@ -45,6 +45,14 @@ class Test_Instance(object):
         with pytest.raises(TypeError):
             bcpi.Instance()
 
+    def test_serialized(self):
+        prop = bcpi.Instance(_TestModel)
+        assert prop.serialized == True
+
+    def test_readonly(self):
+        prop = bcpi.Instance(_TestModel)
+        assert prop.readonly == False
+
     def test_valid(self):
         prop = bcpi.Instance(_TestModel)
 

--- a/bokeh/models/graphs.py
+++ b/bokeh/models/graphs.py
@@ -17,7 +17,6 @@
 from ..core.has_props import abstract
 from ..core.properties import Any, Dict, Either, Int, Seq, String
 from ..model import Model
-from ..models.sources import ColumnDataSource
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -146,12 +145,9 @@ def from_networkx(graph, layout_function, **kwargs):
         edge_dict['start'] = [x[0] for x in graph.edges()]
         edge_dict['end'] = [x[1] for x in graph.edges()]
 
-        node_source = ColumnDataSource(data=node_dict)
-        edge_source = ColumnDataSource(data=edge_dict)
-
         graph_renderer = GraphRenderer()
-        graph_renderer.node_renderer.data_source = node_source
-        graph_renderer.edge_renderer.data_source = edge_source
+        graph_renderer.node_renderer.data_source.data = node_dict
+        graph_renderer.edge_renderer.data_source.data = edge_dict
 
         if callable(layout_function):
             graph_layout = layout_function(graph, **kwargs)

--- a/bokeh/models/graphs.py
+++ b/bokeh/models/graphs.py
@@ -150,8 +150,8 @@ def from_networkx(graph, layout_function, **kwargs):
         edge_source = ColumnDataSource(data=edge_dict)
 
         graph_renderer = GraphRenderer()
-        graph_renderer.node_renderer.data_source.data = node_source.data
-        graph_renderer.edge_renderer.data_source.data = edge_source.data
+        graph_renderer.node_renderer.data_source = node_source
+        graph_renderer.edge_renderer.data_source = edge_source
 
         if callable(layout_function):
             graph_layout = layout_function(graph, **kwargs)

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -59,7 +59,7 @@ class DataSource(Model):
 
     '''
 
-    selected = Instance(Selection, default=lambda: Selection(), help="""
+    selected = Instance(Selection, default=lambda: Selection(), readonly=True, help="""
     A Selection that indicates selected indices on this ``DataSource``.
     """)
 

--- a/bokeh/models/tests/test_sources.py
+++ b/bokeh/models/tests/test_sources.py
@@ -50,6 +50,11 @@ class TestColumnDataSource(object):
             ds.selected = Selection()
             assert str(e).endswith("ColumnDataSource.selected is a readonly property")
 
+    def test_selected_serialized(self):
+        ds = bms.ColumnDataSource()
+        prop = ds.lookup('selected')
+        assert prop.serialized == True
+
     def test_init_dict_arg(self):
         data = dict(a=[1], b=[2])
         ds = bms.ColumnDataSource(data)

--- a/bokeh/models/tests/test_sources.py
+++ b/bokeh/models/tests/test_sources.py
@@ -23,10 +23,11 @@ import warnings
 import numpy as np
 
 # Bokeh imports
+from bokeh.models.sources import Selection
 from bokeh.util.serialization import transform_column_source_data, convert_datetime_array
 
 # Module under test
-from bokeh.models.sources import DataSource, ColumnDataSource
+import bokeh.models.sources as bms
 
 #-----------------------------------------------------------------------------
 # Setup
@@ -39,25 +40,32 @@ from bokeh.models.sources import DataSource, ColumnDataSource
 class TestColumnDataSource(object):
 
     def test_basic(self):
-        ds = ColumnDataSource()
-        assert isinstance(ds, DataSource)
+        ds = bms.ColumnDataSource()
+        assert isinstance(ds, bms.DataSource)
+        assert isinstance(ds.selected, Selection)
+
+    def test_selected_is_readonly(self):
+        ds = bms.ColumnDataSource()
+        with pytest.raises(RuntimeError) as e:
+            ds.selected = Selection()
+            assert str(e).endswith("ColumnDataSource.selected is a readonly property")
 
     def test_init_dict_arg(self):
         data = dict(a=[1], b=[2])
-        ds = ColumnDataSource(data)
+        ds = bms.ColumnDataSource(data)
         assert ds.data == data
         assert set(ds.column_names) == set(data.keys())
 
     def test_init_dict_data_kwarg(self):
         data = dict(a=[1], b=[2])
-        ds = ColumnDataSource(data=data)
+        ds = bms.ColumnDataSource(data=data)
         assert ds.data == data
         assert set(ds.column_names) == set(data.keys())
 
     def test_init_dataframe_arg(self, pd):
         data = dict(a=[1, 2], b=[2, 3])
         df = pd.DataFrame(data)
-        ds = ColumnDataSource(df)
+        ds = bms.ColumnDataSource(df)
         assert set(df.columns).issubset(set(ds.column_names))
         for key in data.keys():
             assert isinstance(ds.data[key], np.ndarray)
@@ -69,7 +77,7 @@ class TestColumnDataSource(object):
     def test_init_dataframe_data_kwarg(self, pd):
         data = dict(a=[1, 2], b=[2, 3])
         df = pd.DataFrame(data)
-        ds = ColumnDataSource(data=df)
+        ds = bms.ColumnDataSource(data=df)
         assert set(df.columns).issubset(set(ds.column_names))
         for key in data.keys():
             assert isinstance(ds.data[key], np.ndarray)
@@ -81,7 +89,7 @@ class TestColumnDataSource(object):
     def test_init_dataframe_index_named_column(self, pd):
         data = dict(a=[1, 2], b=[2, 3], index=[4, 5])
         df = pd.DataFrame(data)
-        ds = ColumnDataSource(data=df)
+        ds = bms.ColumnDataSource(data=df)
         assert set(df.columns).issubset(set(ds.column_names))
         for key in data.keys():
             assert isinstance(ds.data[key], np.ndarray)
@@ -94,7 +102,7 @@ class TestColumnDataSource(object):
         columns = pd.CategoricalIndex(['a', 'b'])
         data = [[0,2], [1,3]]
         df = pd.DataFrame(columns=columns, data=data)
-        ds = ColumnDataSource(data=df)
+        ds = bms.ColumnDataSource(data=df)
         assert set(df.columns).issubset(set(ds.column_names))
         for key in columns:
             assert isinstance(ds.data[key], np.ndarray)
@@ -107,18 +115,18 @@ class TestColumnDataSource(object):
         data = {1: [1, 2], 2: [2, 3]}
         df = pd.DataFrame(data)
         with pytest.raises(ValueError, match=r'expected an element of.*'):
-            ColumnDataSource(data=df)
+            bms.ColumnDataSource(data=df)
 
     def test_init_dataframe_nonstring_named_multicolumn(self, pd):
         data = {(1, 2): [1, 2], (2, 3): [2, 3]}
         df = pd.DataFrame(data)
         with pytest.raises(TypeError, match=r'Could not flatten.*'):
-            ColumnDataSource(data=df)
+            bms.ColumnDataSource(data=df)
 
     def test_init_groupby_arg(self, pd):
         from bokeh.sampledata.autompg import autompg as df
         group = df.groupby(by=['origin', 'cyl'])
-        ds = ColumnDataSource(group)
+        ds = bms.ColumnDataSource(group)
         s = group.describe()
         assert len(ds.column_names) == 49
         assert isinstance(ds.data['origin_cyl'], np.ndarray)
@@ -130,7 +138,7 @@ class TestColumnDataSource(object):
     def test_init_groupby_data_kwarg(self, pd):
         from bokeh.sampledata.autompg import autompg as df
         group = df.groupby(by=['origin', 'cyl'])
-        ds = ColumnDataSource(data=group)
+        ds = bms.ColumnDataSource(data=group)
         s = group.describe()
         assert len(ds.column_names) == 49
         assert isinstance(ds.data['origin_cyl'], np.ndarray)
@@ -142,7 +150,7 @@ class TestColumnDataSource(object):
     def test_init_groupby_with_None_subindex_name(self, pd):
         df = pd.DataFrame({"A": [1, 2, 3, 4] * 2, "B": [10, 20, 30, 40] * 2, "C": range(8)})
         group = df.groupby(['A', [10, 20, 30, 40] * 2])
-        ds = ColumnDataSource(data=group)
+        ds = bms.ColumnDataSource(data=group)
         s = group.describe()
         assert len(ds.column_names) == 17
         assert isinstance(ds.data['index'], np.ndarray)
@@ -153,36 +161,36 @@ class TestColumnDataSource(object):
 
     def test_init_propertyvaluecolumndata_copy(self):
         data = dict(a=[1], b=[2])
-        cd = ColumnDataSource(data).data
-        ds = ColumnDataSource(data=cd)
+        cd = bms.ColumnDataSource(data).data
+        ds = bms.ColumnDataSource(data=cd)
         assert ds.data == cd
         assert id(ds.data) != id(cd)
         ds.data['a'][0] = 2
         assert cd['a'][0] == 2
 
     def test_add_with_name(self):
-        ds = ColumnDataSource()
+        ds = bms.ColumnDataSource()
         name = ds.add([1,2,3], name="foo")
         assert name == "foo"
         name = ds.add([4,5,6], name="bar")
         assert name == "bar"
 
     def test_add_without_name(self):
-        ds = ColumnDataSource()
+        ds = bms.ColumnDataSource()
         name = ds.add([1,2,3])
         assert name == "Series 0"
         name = ds.add([4,5,6])
         assert name == "Series 1"
 
     def test_add_with_and_without_name(self):
-        ds = ColumnDataSource()
+        ds = bms.ColumnDataSource()
         name = ds.add([1,2,3], "foo")
         assert name == "foo"
         name = ds.add([4,5,6])
         assert name == "Series 1"
 
     def test_remove_exists(self):
-        ds = ColumnDataSource()
+        ds = bms.ColumnDataSource()
         name = ds.add([1,2,3], "foo")
         assert name
         ds.remove("foo")
@@ -190,7 +198,7 @@ class TestColumnDataSource(object):
 
     def test_remove_exists2(self):
         with warnings.catch_warnings(record=True) as w:
-            ds = ColumnDataSource()
+            ds = bms.ColumnDataSource()
             ds.remove("foo")
             assert ds.column_names == []
             assert len(w) == 1
@@ -198,7 +206,7 @@ class TestColumnDataSource(object):
             assert str(w[0].message) == "Unable to find column 'foo' in data source"
 
     def test_stream_bad_data(self):
-        ds = ColumnDataSource(data=dict(a=[10], b=[20]))
+        ds = bms.ColumnDataSource(data=dict(a=[10], b=[20]))
         with pytest.raises(ValueError, match=r"Must stream updates to all existing columns \(missing: a, b\)"):
             ds.stream(dict())
         with pytest.raises(ValueError, match=r"Must stream updates to all existing columns \(missing: b\)"):
@@ -215,11 +223,11 @@ class TestColumnDataSource(object):
 
     def test__df_index_name_with_named_index(self, pd):
         df = pd.DataFrame(dict(a=[10], b=[20], c=[30])).set_index('c')
-        assert ColumnDataSource._df_index_name(df) == "c"
+        assert bms.ColumnDataSource._df_index_name(df) == "c"
 
     def test__df_index_name_with_unnamed_index(self, pd):
         df = pd.DataFrame(dict(a=[10], b=[20], c=[30]))
-        assert ColumnDataSource._df_index_name(df) == "index"
+        assert bms.ColumnDataSource._df_index_name(df) == "index"
 
     def test__df_index_name_with_named_multi_index(self, pd):
         data = io.StringIO(u'''
@@ -232,17 +240,17 @@ Lime,Green,99,$0.39
 ''')
         df = pd.read_csv(data).set_index(['Fruit', 'Color'])
         assert df.index.names == ['Fruit', 'Color']
-        assert ColumnDataSource._df_index_name(df) == "Fruit_Color"
+        assert bms.ColumnDataSource._df_index_name(df) == "Fruit_Color"
 
     def test__df_index_name_with_unnamed_multi_index(self, pd):
         arrays = [np.array(['bar', 'bar', 'baz', 'baz', 'foo', 'foo', 'qux', 'qux']),
                   np.array(['one', 'two', 'one', 'two', 'one', 'two', 'one', 'two'])]
         df = pd.DataFrame(np.random.randn(8, 4), index=arrays)
         assert df.index.names == [None, None]
-        assert ColumnDataSource._df_index_name(df) == "index"
+        assert bms.ColumnDataSource._df_index_name(df) == "index"
 
     def test__stream_good_data(self):
-        ds = ColumnDataSource(data=dict(a=[10], b=[20]))
+        ds = bms.ColumnDataSource(data=dict(a=[10], b=[20]))
         ds._document = "doc"
         stuff = {}
         mock_setter = object()
@@ -257,7 +265,7 @@ Lime,Green,99,$0.39
         assert stuff['kw'] == {}
 
     def test_stream_good_data(self):
-        ds = ColumnDataSource(data=dict(a=[10], b=[20]))
+        ds = bms.ColumnDataSource(data=dict(a=[10], b=[20]))
         ds._document = "doc"
         stuff = {}
 
@@ -273,7 +281,7 @@ Lime,Green,99,$0.39
     def test__stream_good_datetime64_data(self):
         now = dt.datetime.now()
         dates = np.array([now+dt.timedelta(i) for i in range(1, 10)], dtype='datetime64')
-        ds = ColumnDataSource(data=dict(index=dates, b=list(range(1, 10))))
+        ds = bms.ColumnDataSource(data=dict(index=dates, b=list(range(1, 10))))
         ds._document = "doc"
         stuff = {}
         mock_setter = object()
@@ -291,7 +299,7 @@ Lime,Green,99,$0.39
         now = dt.datetime.now()
         dates = np.array([now+dt.timedelta(i) for i in range(1, 10)], dtype='datetime64')
         dates = convert_datetime_array(dates)
-        ds = ColumnDataSource(data=dict(index=dates, b=list(range(1, 10))))
+        ds = bms.ColumnDataSource(data=dict(index=dates, b=list(range(1, 10))))
         ds._document = "doc"
         stuff = {}
         mock_setter = object()
@@ -312,7 +320,7 @@ Lime,Green,99,$0.39
             columns=['A'],
             data=np.cumsum(np.random.standard_normal(30), axis=0)
         )
-        ds = ColumnDataSource(data=df)
+        ds = bms.ColumnDataSource(data=df)
         ds._document = "doc"
         stuff = {}
         mock_setter = object()
@@ -336,7 +344,7 @@ Lime,Green,99,$0.39
             columns=['A'],
             data=np.cumsum(np.random.standard_normal(30), axis=0)
         )
-        ds = ColumnDataSource(data=df)
+        ds = bms.ColumnDataSource(data=df)
         ds._document = "doc"
         stuff = {}
         mock_setter = object()
@@ -360,7 +368,7 @@ Lime,Green,99,$0.39
             columns=['A'],
             data=np.cumsum(np.random.standard_normal(30), axis=0)
         )
-        ds = ColumnDataSource(data={'index': convert_datetime_array(df.index.values),
+        ds = bms.ColumnDataSource(data={'index': convert_datetime_array(df.index.values),
                                     'A': df.A})
         ds._document = "doc"
         stuff = {}
@@ -387,7 +395,7 @@ Lime,Green,99,$0.39
 
     def test_stream_dict_to_ds_created_from_df(self, pd):
         data = pd.DataFrame(dict(a=[10], b=[20], c=[30])).set_index('c')
-        ds = ColumnDataSource(data)
+        ds = bms.ColumnDataSource(data)
         ds._document = "doc"
 
         notify_owners_stuff = {}
@@ -438,7 +446,7 @@ Lime,Green,99,$0.39
 
     def test_stream_series_to_ds_created_from_df(self, pd):
         data = pd.DataFrame(dict(a=[10], b=[20], c=[30]))
-        ds = ColumnDataSource(data)
+        ds = bms.ColumnDataSource(data)
         ds._document = "doc"
 
         notify_owners_stuff = {}
@@ -491,7 +499,7 @@ Lime,Green,99,$0.39
 
     def test_stream_df_to_ds_created_from_df_named_index(self, pd):
         data = pd.DataFrame(dict(a=[10], b=[20], c=[30])).set_index('c')
-        ds = ColumnDataSource(data)
+        ds = bms.ColumnDataSource(data)
         ds._document = "doc"
 
         notify_owners_stuff = {}
@@ -544,7 +552,7 @@ Lime,Green,99,$0.39
 
     def test_stream_df_to_ds_created_from_df_default_index(self, pd):
         data = pd.DataFrame(dict(a=[10], b=[20], c=[30]))
-        ds = ColumnDataSource(data)
+        ds = bms.ColumnDataSource(data)
         ds._document = "doc"
 
         notify_owners_stuff = {}
@@ -599,7 +607,7 @@ Lime,Green,99,$0.39
                                                 index=np.array([0, 0, 1])))
 
     def test_patch_bad_columns(self):
-        ds = ColumnDataSource(data=dict(a=[10, 11], b=[20, 21]))
+        ds = bms.ColumnDataSource(data=dict(a=[10, 11], b=[20, 21]))
         with pytest.raises(ValueError, match=r"Can only patch existing columns \(extra: c\)"):
             ds.patch(dict(c=[(0, 100)]))
         with pytest.raises(ValueError, match=r"Can only patch existing columns \(extra: c, d\)"):
@@ -607,12 +615,12 @@ Lime,Green,99,$0.39
 
 
     def test_patch_bad_simple_indices(self):
-        ds = ColumnDataSource(data=dict(a=[10, 11], b=[20, 21]))
+        ds = bms.ColumnDataSource(data=dict(a=[10, 11], b=[20, 21]))
         with pytest.raises(ValueError, match=r"Out-of bounds index \(3\) in patch for column: a"):
             ds.patch(dict(a=[(3, 100)]))
 
     def test_patch_good_simple_indices(self):
-        ds = ColumnDataSource(data=dict(a=[10, 11], b=[20, 21]))
+        ds = bms.ColumnDataSource(data=dict(a=[10, 11], b=[20, 21]))
         ds._document = "doc"
         stuff = {}
         mock_setter = object()
@@ -625,7 +633,7 @@ Lime,Green,99,$0.39
         assert stuff['kw'] == {}
 
     def test_patch_bad_slice_indices(self):
-        ds = ColumnDataSource(data=dict(a=[10, 11, 12, 13, 14, 15], b=[20, 21, 22, 23, 24, 25]))
+        ds = bms.ColumnDataSource(data=dict(a=[10, 11, 12, 13, 14, 15], b=[20, 21, 22, 23, 24, 25]))
         with pytest.raises(ValueError, match=r"Out-of bounds slice index stop \(10\) in patch for column: a"):
             ds.patch(dict(a=[(slice(10), list(range(10)))]))
         with pytest.raises(ValueError, match=r"Patch slices must have start < end, got slice\(10, 1, None\)"):
@@ -641,7 +649,7 @@ Lime,Green,99,$0.39
 
 
     def test_patch_good_slice_indices(self):
-        ds = ColumnDataSource(data=dict(a=[10, 11, 12, 13, 14, 15], b=[20, 21, 22, 23, 24, 25]))
+        ds = bms.ColumnDataSource(data=dict(a=[10, 11, 12, 13, 14, 15], b=[20, 21, 22, 23, 24, 25]))
         ds._document = "doc"
         stuff = {}
         mock_setter = object()
@@ -657,65 +665,65 @@ Lime,Green,99,$0.39
         # TODO: use this when soft=False
         #
         #with pytest.raises(ValueError):
-        #    ColumnDataSource(data=dict(a=[10, 11], b=[20, 21, 22]))
+        #    bms.ColumnDataSource(data=dict(a=[10, 11], b=[20, 21, 22]))
         #
-        #ds = ColumnDataSource()
+        #ds = bms.ColumnDataSource()
         #with pytest.raises(ValueError):
         #    ds.data = dict(a=[10, 11], b=[20, 21, 22])
         #
-        #ds = ColumnDataSource(data=dict(a=[10, 11]))
+        #ds = bms.ColumnDataSource(data=dict(a=[10, 11]))
         #with pytest.raises(ValueError):
         #    ds.data["b"] = [20, 21, 22]
         #
-        #ds = ColumnDataSource(data=dict(a=[10, 11], b=[20, 21]))
+        #ds = bms.ColumnDataSource(data=dict(a=[10, 11], b=[20, 21]))
         #with pytest.raises(ValueError):
         #    ds.data.update(dict(a=[10, 11, 12]))
 
         with warnings.catch_warnings(record=True) as warns:
-            ColumnDataSource(data=dict(a=[10, 11], b=[20, 21, 22]))
+            bms.ColumnDataSource(data=dict(a=[10, 11], b=[20, 21, 22]))
         assert len(warns) == 1
         assert str(warns[0].message) == "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 2), ('b', 3)"
 
-        ds = ColumnDataSource()
+        ds = bms.ColumnDataSource()
         with warnings.catch_warnings(record=True) as warns:
             ds.data = dict(a=[10, 11], b=[20, 21, 22])
         assert len(warns) == 1
         assert str(warns[0].message) == "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 2), ('b', 3)"
 
-        ds = ColumnDataSource(data=dict(a=[10, 11]))
+        ds = bms.ColumnDataSource(data=dict(a=[10, 11]))
         with warnings.catch_warnings(record=True) as warns:
             ds.data["b"] = [20, 21, 22]
         assert len(warns) == 1
         assert str(warns[0].message) == "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 2), ('b', 3)"
 
-        ds = ColumnDataSource(data=dict(a=[10, 11], b=[20, 21]))
+        ds = bms.ColumnDataSource(data=dict(a=[10, 11], b=[20, 21]))
         with warnings.catch_warnings(record=True) as warns:
             ds.data.update(dict(a=[10, 11, 12]))
         assert len(warns) == 1
         assert str(warns[0].message) == "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 3), ('b', 2)"
 
     def test_set_data_from_json_list(self):
-        ds = ColumnDataSource()
+        ds = bms.ColumnDataSource()
         data = {"foo": [1, 2, 3]}
         ds.set_from_json('data', data)
         assert ds.data == data
 
     def test_set_data_from_json_base64(self):
-        ds = ColumnDataSource()
+        ds = bms.ColumnDataSource()
         data = {"foo": np.arange(3, dtype=np.int64)}
         json = transform_column_source_data(data)
         ds.set_from_json('data', json)
         assert np.array_equal(ds.data["foo"], data["foo"])
 
     def test_set_data_from_json_nested_base64(self):
-        ds = ColumnDataSource()
+        ds = bms.ColumnDataSource()
         data = {"foo": [[np.arange(3, dtype=np.int64)]]}
         json = transform_column_source_data(data)
         ds.set_from_json('data', json)
         assert np.array_equal(ds.data["foo"], data["foo"])
 
     def test_set_data_from_json_nested_base64_and_list(self):
-        ds = ColumnDataSource()
+        ds = bms.ColumnDataSource()
         data = {"foo": [np.arange(3, dtype=np.int64), [1, 2, 3]]}
         json = transform_column_source_data(data)
         ds.set_from_json('data', json)

--- a/examples/integration/glyphs/selection_nonselection.py
+++ b/examples/integration/glyphs/selection_nonselection.py
@@ -1,6 +1,5 @@
 from bokeh.io import save
 from bokeh.plotting import figure
-from bokeh.models import Selection
 
 p = figure(x_range=(0, 6), y_range=(0, 7), width=600, height=600, toolbar_location=None)
 
@@ -12,7 +11,7 @@ def mkglyph(x, y, selection):
         selection_color='red',
         selection_alpha=0.2,
         nonselection_color='black')
-    r.data_source.selected = Selection(indices=selection)
+    r.data_source.selected.indices=selection
     return r
 
 mkglyph([1, 2, 3, 4, 5], [1, 2, 3, 4, 5], selection=[1, 3, 4])

--- a/examples/integration/widgets/data_table_preselection.py
+++ b/examples/integration/widgets/data_table_preselection.py
@@ -1,9 +1,9 @@
 from bokeh.io import save
-from bokeh.models import ColumnDataSource, DataTable, TableColumn, Selection
+from bokeh.models import ColumnDataSource, DataTable, TableColumn
 
 data = dict(x=list(range(10)))
-selected = Selection(indices=[1, 2])
-source = ColumnDataSource(data=data, selected=selected)
+source = ColumnDataSource(data=data)
+source.selected.indices = [1, 2]
 columns = [TableColumn(field="x", title="X")]
 data_table = DataTable(source=source, columns=columns)
 

--- a/sphinx/source/docs/releases/2.0.0.rst
+++ b/sphinx/source/docs/releases/2.0.0.rst
@@ -32,6 +32,15 @@ The ``use_strict`` property has been removed from all models that it had been
 on previously. All JavaScript code, e.g. for ``CustomJS`` will always be rendered
 with ``"use_strict"`` added.
 
+ColumnDataSource Properties
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``ColumnDataSource.selected`` property is now read-only.
+
+The ``ColumnDataSource.data`` property can only be set from plain Python dicts.
+Attempting to set from another CDS, i.e ``s1.data = s2.data``, will raise an
+error.
+
 Plot Symmetry Properties
 ~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
`s.selected` is now read only

`s1.data = s2.data` now throws an error