### PR TITLE
more explicit hover formatter specs

### DIFF
--- a/bokehjs/src/lib/core/util/templating.ts
+++ b/bokehjs/src/lib/core/util/templating.ts
@@ -44,18 +44,15 @@ export function basic_formatter(value: unknown, _format: string, _special_vars: 
     return `${value}`  // get strings for categorical types
 }
 
-export function get_formatter(name: string, raw_spec: string, format?: string, formatters?: Formatters): FormatterFunc {
+export function get_formatter(raw_spec: string, format?: string, formatters?: Formatters): FormatterFunc {
   // no format, use default built in formatter
   if (format == null)
     return basic_formatter
 
   // format spec in the formatters dict, use that
-  if (formatters != null && (name in formatters || raw_spec in formatters)) {
+  if (formatters != null && raw_spec in formatters) {
 
-    // some day (Bokeh 2.0) we can get rid of the check for name, and just check the raw spec
-    // keep it now for compatibility but do not demonstrate it anywhere
-    const key: string = raw_spec in formatters ? raw_spec : name
-    const formatter = formatters[key]
+    const formatter = formatters[raw_spec]
 
     if (isString(formatter)) {
       if (formatter in DEFAULT_FORMATTERS)
@@ -74,15 +71,14 @@ export function get_formatter(name: string, raw_spec: string, format?: string, f
 
 }
 
-export function get_value(name: string, data_source: ColumnarDataSource, i: Index, special_vars: Vars) {
-
-  if (name[0] == "$") {
-    if (name.substring(1) in special_vars)
-      return special_vars[name.substring(1)]
+function  _get_special_value(name: string, special_vars: Vars) {
+    if (name in special_vars)
+      return special_vars[name]
     else
-      throw new Error(`Unknown special variable '${name}'`)
-  }
+      throw new Error(`Unknown special variable '\$${name}'`)
+}
 
+function  _get_column_value(name: string, data_source: ColumnarDataSource, i: Index) {
   const column = data_source.get_column(name)
 
   // missing column
@@ -107,34 +103,43 @@ export function get_value(name: string, data_source: ColumnarDataSource, i: Inde
     return data // inspect per-image scalar data
 }
 
-export function replace_placeholders(str: string, data_source: ColumnarDataSource, i: Index, formatters?: Formatters, special_vars: Vars = {}): string {
+export function get_value(raw_name: string, data_source: ColumnarDataSource, i: Index, special_vars: Vars) {
 
-  // this extracts the $x, @x, @{x} without any trailing {format}
-  const raw_spec = str.replace(/(?:^|[^@])([@|\$](?:\w+|{[^{}]+}))(?:{[^{}]+})?/g, (_match, raw_spec, _format) => `${raw_spec}`)
+  if (raw_name[0] == "$") {
+    const name = raw_name.substring(1)
+    return _get_special_value(name, special_vars)
+  } else {
+    const name = raw_name.substring(1).replace(/[{}]/g, "")
+    return _get_column_value(name, data_source, i)
+  }
+}
+
+export function replace_placeholders(str: string, data_source: ColumnarDataSource, i: Index, formatters?: Formatters, special_vars: Vars = {}): string {
 
   // this handles the special case @$name, replacing it with an @var corresponding to special_vars.name
   str = str.replace(/@\$name/g, (_match) => `@{${special_vars.name}}`)
 
-  // this prepends special vars with "@", e.g "$x" becomes "@$x", so subsequent processing is simpler
-  str = str.replace(/(^|[^\$])\$(\w+)/g, (_match, prefix, name) => `${prefix}@$${name}`)
-
-  str = str.replace(/(^|[^@])@(?:(\$?\w+)|{([^{}]+)})(?:{([^{}]+)})?/g, (_match, prefix, name, long_name, format) => {
-
-    name = long_name != null ? long_name : name
-
-    const value = get_value(name, data_source, i, special_vars)
+  //
+  // (?:\$\w+) - special vars: $x
+  // (?:@\w+) - simple names: @foo
+  // (?:@{(?:[^{}]+)})) - full names: @{one two}
+  //
+  // (?:{([^{}]+)})? - (optional) format for all of the above: @foo{fmt}
+  //
+  str = str.replace(/((?:\$\w+)|(?:@\w+)|(?:@{(?:[^{}]+)}))(?:{([^{}]+)})?/g, (_match, spec, format) => {
+    const value = get_value(spec, data_source, i, special_vars)
 
     // missing value, return ???
     if (value == null)
-      return `${prefix}${escape("???")}`
+      return `${escape("???")}`
 
     // 'safe' format, return the value as-is
     if (format == 'safe')
-     return `${prefix}${value}`
+     return `${value}`
 
     // format and escape everything else
-    const formatter = get_formatter(name, raw_spec, format, formatters)
-    return `${prefix}${escape(formatter(value, format, special_vars))}`
+    const formatter = get_formatter(spec, format, formatters)
+    return `${escape(formatter(value, format, special_vars))}`
   })
 
   return str

--- a/bokehjs/test/core/util/templating.ts
+++ b/bokehjs/test/core/util/templating.ts
@@ -64,48 +64,32 @@ describe("templating module", () => {
   describe("get_formatter", () => {
 
     it("should return basic_formatter for null format", () => {
-      const f = tmpl.get_formatter("x", "@x")
+      const f = tmpl.get_formatter("@x")
       expect(f).to.be.equal(tmpl.basic_formatter)
     })
 
     it("should return numeral formatter for specs not in formatters dict", () => {
-      const f = tmpl.get_formatter("x", "@x", "$0.00")
+      const f = tmpl.get_formatter("@x", "$0.00")
       expect(f).to.be.equal(tmpl.DEFAULT_FORMATTERS.numeral)
     })
 
     it("should return formatter from formatters dict when raw_spec is in formatters", () => {
-      const f1 = tmpl.get_formatter("x", "@x", "$0.00", {"@x": "numeral"})
+      const f1 = tmpl.get_formatter("@x", "$0.00", {"@x": "numeral"})
       expect(f1).to.be.equal(tmpl.DEFAULT_FORMATTERS.numeral)
 
-      const f2 = tmpl.get_formatter("x", "@x", "%5.3f mu", {"@x": "printf"})
+      const f2 = tmpl.get_formatter("@x", "%5.3f mu", {"@x": "printf"})
       expect(f2).to.be.equal(tmpl.DEFAULT_FORMATTERS.printf)
 
-      const f3 = tmpl.get_formatter("x", "@x", "%m/%d/%Y", {"@x": "datetime"})
+      const f3 = tmpl.get_formatter("@x", "%m/%d/%Y", {"@x": "datetime"})
       expect(f3).to.be.equal(tmpl.DEFAULT_FORMATTERS.datetime)
 
       const custom = new CustomJSHover({code:"return format + ' ' + special_vars.special + ' ' + value"})
-      const f4 = tmpl.get_formatter("x", "@x", "custom", {"@x": custom})
-      expect(f4(3.123, "custom", {special: 10})).to.be.equal("custom 10 3.123")
-    })
-
-    // this should be removed ~Bokeh 2.0
-    it("should return formatter from formatters dict when name is in formatters", () => {
-      const f1 = tmpl.get_formatter("x", "@x", "$0.00", {x: "numeral"})
-      expect(f1).to.be.equal(tmpl.DEFAULT_FORMATTERS.numeral)
-
-      const f2 = tmpl.get_formatter("x", "@x", "%5.3f mu", {x: "printf"})
-      expect(f2).to.be.equal(tmpl.DEFAULT_FORMATTERS.printf)
-
-      const f3 = tmpl.get_formatter("x", "@x", "%m/%d/%Y", {x: "datetime"})
-      expect(f3).to.be.equal(tmpl.DEFAULT_FORMATTERS.datetime)
-
-      const custom = new CustomJSHover({code:"return format + ' ' + special_vars.special + ' ' + value"})
-      const f4 = tmpl.get_formatter("x", "@x", "custom", {x: custom})
+      const f4 = tmpl.get_formatter("@x", "custom", {"@x": custom})
       expect(f4(3.123, "custom", {special: 10})).to.be.equal("custom 10 3.123")
     })
 
     it("should throw an error on unknown formatter type", () => {
-      expect(() => tmpl.get_formatter("x", "@x", "%5.3f mu", {x: "junk" as any})).to.throw(Error)
+      expect(() => tmpl.get_formatter("@x", "%5.3f mu", {"@x": "junk" as any})).to.throw(Error)
     })
   })
 
@@ -135,34 +119,34 @@ describe("templating module", () => {
     })
 
     it("should return integer indices from columns", () => {
-      const v1 = tmpl.get_value("foo", source, 0, {})
+      const v1 = tmpl.get_value("@foo", source, 0, {})
       expect(v1).to.be.equal(10)
 
-      const v2 = tmpl.get_value("foo", source, 1, {})
+      const v2 = tmpl.get_value("@foo", source, 1, {})
       expect(v2).to.be.equal(1.002)
     })
 
     it("should index flat typed array format for images", () => {
-      const v1 = tmpl.get_value("floats", imsource, imindex1, {})
+      const v1 = tmpl.get_value("@floats", imsource, imindex1, {})
       expect(v1).to.be.equal(5)
 
-      const v2 = tmpl.get_value("floats", imsource, imindex2, {})
+      const v2 = tmpl.get_value("@floats", imsource, imindex2, {})
       expect(v2).to.be.equal(1)
     })
 
     it("should index array of arrays format for images", () => {
-      const v1 = tmpl.get_value("arrs", imsource, imindex1, {})
+      const v1 = tmpl.get_value("@arrs", imsource, imindex1, {})
       expect(v1).to.be.equal(50)
 
-      const v2 = tmpl.get_value("arrs", imsource, imindex2, {})
+      const v2 = tmpl.get_value("@arrs", imsource, imindex2, {})
       expect(v2).to.be.equal(10)
     })
 
     it("should index scalar data format for images", () => {
-      const v1 = tmpl.get_value("labels", imsource, imindex1, {})
+      const v1 = tmpl.get_value("@labels", imsource, imindex1, {})
       expect(v1).to.be.equal('test label')
 
-      const v2 = tmpl.get_value("labels", imsource, imindex2, {})
+      const v2 = tmpl.get_value("@labels", imsource, imindex2, {})
       expect(v2).to.be.equal('test label')
     })
 
@@ -214,7 +198,7 @@ describe("templating module", () => {
     })
 
     it("should throw an error on unrecognized formatters", () => {
-      const fn = () => tmpl.replace_placeholders("stuff @foo{(0.000 %)}", source, 0, {foo: "junk" as any})
+      const fn = () => tmpl.replace_placeholders("stuff @foo{(0.000 %)}", source, 0, {"@foo": "junk" as any})
       expect(fn).to.throw(Error)
     })
 
@@ -229,34 +213,34 @@ describe("templating module", () => {
 
     it("should use the numeral formatter if specified", () => {
       // just picking a random and uniquely numbro format to test with
-      const s1 = tmpl.replace_placeholders("stuff @foo{(0.000 %)}", source, 0, {foo: "numeral"})
+      const s1 = tmpl.replace_placeholders("stuff @foo{(0.000 %)}", source, 0, {"@foo": "numeral"})
       expect(s1).to.be.equal("stuff 1000.000 %")
 
-      const s2 = tmpl.replace_placeholders("stuff @foo{(0.000 %)}", source, 1, {foo: "numeral"})
+      const s2 = tmpl.replace_placeholders("stuff @foo{(0.000 %)}", source, 1, {"@foo": "numeral"})
       expect(s2).to.be.equal("stuff 100.200 %")
     })
 
     it("should use a customjs hover formatter if specified", () => {
       const custom = new CustomJSHover({code:"return format + ' ' + special_vars.special + ' ' + value"})
-      const s = tmpl.replace_placeholders("stuff @foo{custom}", source, 0, {foo: custom}, {special: "vars"})
+      const s = tmpl.replace_placeholders("stuff @foo{custom}", source, 0, {"@foo": custom}, {special: "vars"})
       expect(s).to.be.equal("stuff custom vars 10")
     })
 
     it("should replace field names with tz formatted values with datetime formatter", () => {
       // just picking a random and uniquely tz format to test with
-      const s1 = tmpl.replace_placeholders("stuff @baz{%F %T}", source, 0, {baz: "datetime"})
+      const s1 = tmpl.replace_placeholders("stuff @baz{%F %T}", source, 0, {"@baz": "datetime"})
       expect(s1).to.be.equal("stuff 2017-04-22 19:51:11")
 
-      const s2 = tmpl.replace_placeholders("stuff @baz{%F %T}", source, 1, {baz: "datetime"})
+      const s2 = tmpl.replace_placeholders("stuff @baz{%F %T}", source, 1, {"@baz": "datetime"})
       expect(s2).to.be.equal("stuff 2010-11-22 21:17:51")
     })
 
     it("should replace field names with Sprintf formatted values with printf formatter", () => {
       // just picking a random and uniquely Sprintf formats to test with
-      const s1 = tmpl.replace_placeholders("stuff @foo{%x}", source, 0, {foo: "printf"})
+      const s1 = tmpl.replace_placeholders("stuff @foo{%x}", source, 0, {"@foo": "printf"})
       expect(s1).to.be.equal("stuff a")
 
-      const s2 = tmpl.replace_placeholders("stuff @foo{%0.4f}", source, 1, {foo: "printf"})
+      const s2 = tmpl.replace_placeholders("stuff @foo{%0.4f}", source, 1, {"@foo": "printf"})
       expect(s2).to.be.equal("stuff 1.0020")
     })
 
@@ -266,7 +250,7 @@ describe("templating module", () => {
     })
 
     it("should replace combinations and duplicates", () => {
-      const s = tmpl.replace_placeholders("stuff $foo @foo @foo @foo{(0.000 %)} @baz{%F %T}", source, 0, {baz: "datetime"}, {foo: "special"})
+      const s = tmpl.replace_placeholders("stuff $foo @foo @foo @foo{(0.000 %)} @baz{%F %T}", source, 0, {"@baz": "datetime"}, {foo: "special"})
       expect(s).to.be.equal("stuff special 10 10 1000.000 % 2017-04-22 19:51:11")
     })
 

--- a/examples/plotting/file/customjs_hover.py
+++ b/examples/plotting/file/customjs_hover.py
@@ -22,13 +22,13 @@ code = """
 
 p.add_tools(HoverTool(
     tooltips=[
-        ( 'lon',   '@x{custom}' ),
-        ( 'lat',   '@y{custom}' ),
+        ( 'lon', '$x{custom}' ),
+        ( 'lat', '$y{custom}' ),
     ],
 
     formatters={
-        'x' : CustomJSHover(code=code % 0),
-        'y' : CustomJSHover(code=code % 1),
+        '$x' : CustomJSHover(code=code % 0),
+        '$y' : CustomJSHover(code=code % 1),
     }
 ))
 

--- a/sphinx/source/docs/releases/2.0.0.rst
+++ b/sphinx/source/docs/releases/2.0.0.rst
@@ -5,8 +5,6 @@
 
 Bokeh Version ``2.0.0`` (XXXX 2019) is a major milestone of the Bokeh project.
 
-
-
 And several other bug fixes and docs additions. For full details see the
 :bokeh-tree:`CHANGELOG`.
 
@@ -24,6 +22,26 @@ Minimum Tornado Version
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 The Bokeh server now requires Tornado 5.0 or higher.
+
+HoverTool Formatters Specification
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously, the ``formatters`` property accepted a CDS column name. For example
+a formatter for a tooltip for ``"@foo`` could be specied with just ``"foo"``:
+
+.. code-block:: python
+
+    hover_tool.formatters = { "foo": "datetime"}   # BAD
+
+Now, the full matching tooltip specification, including the ``"@"``, should
+be used:
+
+.. code-block:: python
+
+    hover_tool.formatters = { "@foo": "datetime"}   # GOOD
+
+This allows tooltip formatters to be used uniformly with both columns, as well
+as "special variables", e.g. ``"$x"``.
 
 Bokeh Sphinx Extension
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/sphinx/source/docs/user_guide/examples/tools_hover_tooltip_formatting.py
+++ b/sphinx/source/docs/user_guide/examples/tools_hover_tooltip_formatting.py
@@ -34,9 +34,9 @@ p.add_tools(HoverTool(
     ],
 
     formatters={
-        'date'      : 'datetime', # use 'datetime' formatter for 'date' field
-        'adj close' : 'printf',   # use 'printf' formatter for 'adj close' field
-                                  # use default 'numeral' formatter for other fields
+        '@date'        : 'datetime', # use 'datetime' formatter for '@date' field
+        '@{adj close}' : 'printf',   # use 'printf' formatter for '@{adj close}' field
+                                     # use default 'numeral' formatter for other fields
     },
 
     # display a tooltip whenever the cursor is vertically in line with a glyph

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -529,13 +529,19 @@ strings:
     |PrintfTickFormatter| reference documentation for complete details.
 
 These are supplied by configuring the ``formatters`` property of a hover
-tool. This property maps column names to format schemes. For example, to
-use the ``"datetime"`` scheme for formatting a column ``"close date"``,
+tool. This property maps tooltip variables to format schemes. For example, to
+use the ``"datetime"`` scheme for formatting a column ``"@{close date}"``,
 set the value:
 
 .. code-block:: python
 
-    hover_tool.formatters = { "close date": "datetime"}
+    hover_tool.formatters = { "@{close date}": "datetime"}
+
+Formatters may also be supplied for "special variables" such as ``"$x"``:
+
+.. code-block:: python
+
+    hover_tool.formatters = { "$x": "datetime"}
 
 If no formatter is specified for a column name, the default ``"numeral"``
 formatter is assumed.
@@ -557,9 +563,9 @@ different formatters for different fields:
         ],
 
         formatters={
-            'date'      : 'datetime', # use 'datetime' formatter for 'date' field
-            'adj close' : 'printf',   # use 'printf' formatter for 'adj close' field
-                                      # use default 'numeral' formatter for other fields
+            '@date'        : 'datetime', # use 'datetime' formatter for '@date' field
+            '@{adj close}' : 'printf',   # use 'printf' formatter for '@{adj close}' field
+                                         # use default 'numeral' formatter for other fields
         },
 
         # display a tooltip whenever the cursor is vertically in line with a glyph


### PR DESCRIPTION
This PR changes the specification format for hover formatters to require the keys in the `formatters` dict to strictly match the format from the tooltips, including any `@` or `$` prefix:

```
hover.tooltips = "@foo{%s}   @{foo bar}{0.00}   $x{%F}"
hover.formatters = {
    "@foo"       : "printf",
    "@{foo bar}" : "numeral",
    "$x"         : "datetime",
}
```
Previously, just a column name e.g. "foo" was expected. 

This change means that formatting specification can now apply uniformly to "special variables" such as "$x" and also reduces confusion by making it clear that the column and special variable names are what formatters apply to. (There were several support requests due to attempting to match up labels instead)

This PR also simplifies and corrects some broken logic int he templating code. 