### PR TITLE
rev nwmatcher version

### DIFF
--- a/bokehjs/package-lock.json
+++ b/bokehjs/package-lock.json
@@ -1605,7 +1605,7 @@
       "dependencies": {
         "commander": {
           "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
@@ -1730,9 +1730,9 @@
       "from": "git+https://github.com/bokeh/numbro.git#e1b6c52"
     },
     "nwmatcher": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
-      "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
+      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
       "dev": true
     },
     "oauth-sign": {

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "license-checker": "^25.0.1",
+    "nwmatcher": ">=1.4.4",
     "semver": "^5.6.0",
     "toposort": "^2.0.2",
     "chai": "^4.2.0",


### PR DESCRIPTION
This PR stipulates `nwmatcher >= 1.4.4` to address GH reported vulnerability. 

Note that this package is only used for development, and does not impact normal user usage. 