### PR TITLE
Toggle tooltip only when it is enabled in Slider

### DIFF
--- a/bokehjs/src/lib/models/widgets/abstract_slider.ts
+++ b/bokehjs/src/lib/models/widgets/abstract_slider.ts
@@ -185,7 +185,7 @@ abstract class AbstractBaseSliderView extends ControlView {
       this._set_keypress_handles()
 
       const toggleTooltip = (i: number, show: boolean): void => {
-        if (!tooltips) 
+        if (!tooltips)
           return
         const handle = this.slider_el.querySelectorAll(`.${prefix}handle`)[i]
         const tooltip = handle.querySelector<HTMLElement>(`.${prefix}tooltip`)!

--- a/bokehjs/src/lib/models/widgets/abstract_slider.ts
+++ b/bokehjs/src/lib/models/widgets/abstract_slider.ts
@@ -185,7 +185,8 @@ abstract class AbstractBaseSliderView extends ControlView {
       this._set_keypress_handles()
 
       const toggleTooltip = (i: number, show: boolean): void => {
-        if (!tooltips) return;
+        if (!tooltips) 
+          return
         const handle = this.slider_el.querySelectorAll(`.${prefix}handle`)[i]
         const tooltip = handle.querySelector<HTMLElement>(`.${prefix}tooltip`)!
         tooltip.style.display = show ? 'block' : ''

--- a/bokehjs/src/lib/models/widgets/abstract_slider.ts
+++ b/bokehjs/src/lib/models/widgets/abstract_slider.ts
@@ -185,6 +185,7 @@ abstract class AbstractBaseSliderView extends ControlView {
       this._set_keypress_handles()
 
       const toggleTooltip = (i: number, show: boolean): void => {
+        if (!tooltips) return;
         const handle = this.slider_el.querySelectorAll(`.${prefix}handle`)[i]
         const tooltip = handle.querySelector<HTMLElement>(`.${prefix}tooltip`)!
         tooltip.style.display = show ? 'block' : ''


### PR DESCRIPTION
We don't want the `toggleTooltip` happening when tooltip is set to `false`.
This solves errors with accessing style attribute of a `null`.

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [x] issues: fixes #9022
- [n/a] tests added / passed
- [n/a] release document entry (if new feature or API change)
