### PR TITLE
New event listener for TextInput

### DIFF
--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -97,7 +97,13 @@ class TextInput(InputWidget):
     """)
 
     placeholder = String(default="", help="""
-    Placeholder for empty input field
+    Placeholder for empty input field.
+    """)
+    
+    wait_commit = Bool(default=True, help="""
+    Run the callback once the user commits the value in the ``TextInput``
+    (i.e. by pressing Enter or clicking outside the text box area). If False, 
+    the callback is executed everytime the value changes (i.e. as text is being typed).
     """)
 
 

--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -99,10 +99,10 @@ class TextInput(InputWidget):
     placeholder = String(default="", help="""
     Placeholder for empty input field.
     """)
-    
+
     wait_commit = Bool(default=True, help="""
     Run the callback once the user commits the value in the ``TextInput``
-    (i.e. by pressing Enter or clicking outside the text box area). If False, 
+    (i.e. by pressing Enter or clicking outside the text box area). If False,
     the callback is executed everytime the value changes (i.e. as text is being typed).
     """)
 

--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -90,20 +90,20 @@ class TextInput(InputWidget):
     Initial or entered text value.
     """)
 
+    value_input = String(default="", help="""
+    Initial or entered text value that triggers a callback whenever the value changes.
+    """)
+
     callback = Instance(Callback, help="""
     A callback to run in the browser whenever the user unfocuses the
     ``TextInput`` widget by hitting Enter or clicking outside of the text box
     area.
+
+    DEPRECATED: use .js_on_change or .on_change with "value" or "value_input"
     """)
 
     placeholder = String(default="", help="""
     Placeholder for empty input field.
-    """)
-
-    wait_commit = Bool(default=True, help="""
-    Run the callback once the user commits the value in the ``TextInput``
-    (i.e. by pressing Enter or clicking outside the text box area). If False,
-    the callback is executed everytime the value changes (i.e. as text is being typed).
     """)
 
 

--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 
 # Bokeh imports
 from ...core.has_props import abstract
-from ...core.properties import Date, Either, Float, Instance, Int, List, String, Tuple, Dict, ColorHex, Bool
+from ...core.properties import Date, Either, Float, Instance, Int, List, String, Tuple, Dict, ColorHex
 
 from ..callbacks import Callback
 

--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 
 # Bokeh imports
 from ...core.has_props import abstract
-from ...core.properties import Date, Either, Float, Instance, Int, List, String, Tuple, Dict, ColorHex
+from ...core.properties import Date, Either, Float, Instance, Int, List, String, Tuple, Dict, ColorHex, Bool
 
 from ..callbacks import Callback
 

--- a/bokehjs/src/lib/models/widgets/text_input.ts
+++ b/bokehjs/src/lib/models/widgets/text_input.ts
@@ -16,7 +16,6 @@ export class TextInputView extends InputWidgetView {
     this.connect(this.model.properties.value.change, () => this.input_el.value = this.model.value)
     this.connect(this.model.properties.disabled.change, () => this.input_el.disabled = this.model.disabled)
     this.connect(this.model.properties.placeholder.change, () => this.input_el.placeholder = this.model.placeholder)
-    this.connect(this.model.properties.wait_commit.change, () => this.input_el.wait_commit = this.model.wait_commit)
   }
 
   render(): void {
@@ -29,7 +28,6 @@ export class TextInputView extends InputWidgetView {
       value: this.model.value,
       disabled: this.model.disabled,
       placeholder: this.model.placeholder,
-      wait_commit: this.model.wait_commit
     })
     if (this.model.wait_commit) {
         this.input_el.addEventListener("change", () => this.change_input())
@@ -70,7 +68,7 @@ export class TextInput extends InputWidget {
     this.define<TextInput.Props>({
       value:       [ p.String, "" ],
       placeholder: [ p.String, "" ],
-      wait_commit:  [ p.Boolean, true ],
+      wait_commit: [ p.Boolean, true ],
     })
   }
 }

--- a/bokehjs/src/lib/models/widgets/text_input.ts
+++ b/bokehjs/src/lib/models/widgets/text_input.ts
@@ -14,6 +14,7 @@ export class TextInputView extends InputWidgetView {
     super.connect_signals()
     this.connect(this.model.properties.name.change, () => this.input_el.name = this.model.name || "")
     this.connect(this.model.properties.value.change, () => this.input_el.value = this.model.value)
+    this.connect(this.model.properties.value_input.change, () => this.input_el.value = this.model.value_input)
     this.connect(this.model.properties.disabled.change, () => this.input_el.disabled = this.model.disabled)
     this.connect(this.model.properties.placeholder.change, () => this.input_el.placeholder = this.model.placeholder)
   }
@@ -29,16 +30,18 @@ export class TextInputView extends InputWidgetView {
       disabled: this.model.disabled,
       placeholder: this.model.placeholder,
     })
-    if (this.model.wait_commit) {
-        this.input_el.addEventListener("change", () => this.change_input())
-    } else {
-        this.input_el.addEventListener("input", () => this.change_input())
-    }
+    this.input_el.addEventListener("change", () => this.change_input_onchange())
+    this.input_el.addEventListener("input",  () => this.change_input_oninput())
     this.group_el.appendChild(this.input_el)
   }
 
-  change_input(): void {
+  change_input_onchange(): void {
     this.model.value = this.input_el.value
+    super.change_input()
+  }
+
+  change_input_oninput(): void {
+    this.model.value_input = this.input_el.value
     super.change_input()
   }
 }
@@ -48,8 +51,8 @@ export namespace TextInput {
 
   export type Props = InputWidget.Props & {
     value: p.Property<string>
+    value_input: p.Property<string>
     placeholder: p.Property<string>
-    wait_commit: p.Property<boolean>
   }
 }
 
@@ -67,8 +70,8 @@ export class TextInput extends InputWidget {
 
     this.define<TextInput.Props>({
       value:       [ p.String, "" ],
+      value_input: [ p.String, "" ],
       placeholder: [ p.String, "" ],
-      wait_commit: [ p.Boolean, true ],
     })
   }
 }

--- a/bokehjs/src/lib/models/widgets/text_input.ts
+++ b/bokehjs/src/lib/models/widgets/text_input.ts
@@ -30,18 +30,20 @@ export class TextInputView extends InputWidgetView {
       disabled: this.model.disabled,
       placeholder: this.model.placeholder,
     })
-    this.input_el.addEventListener("change", () => this.change_input_onchange())
-    this.input_el.addEventListener("input",  () => this.change_input_oninput())
+    this.input_el.addEventListener("change", (e: any) => this.change_input(e))
+    this.input_el.addEventListener("input",  (e: any) => this.change_input(e))
     this.group_el.appendChild(this.input_el)
   }
 
-  change_input_onchange(): void {
-    this.model.value = this.input_el.value
-    super.change_input()
-  }
-
-  change_input_oninput(): void {
-    this.model.value_input = this.input_el.value
+  change_input(event?: any): void {
+    if (typeof event !== undefined) {
+      const eventType = event.type;
+      if (eventType == "change") {
+        this.model.value = this.input_el.value
+      } else if (eventType == "input") {
+        this.model.value_input = this.input_el.value
+      }
+    }
     super.change_input()
   }
 }

--- a/bokehjs/src/lib/models/widgets/text_input.ts
+++ b/bokehjs/src/lib/models/widgets/text_input.ts
@@ -37,7 +37,7 @@ export class TextInputView extends InputWidgetView {
 
   change_input(event?: any): void {
     if (typeof event !== undefined) {
-      const eventType = event.type;
+      const eventType = event.type
       if (eventType == "change") {
         this.model.value = this.input_el.value
       } else if (eventType == "input") {

--- a/bokehjs/src/lib/models/widgets/text_input.ts
+++ b/bokehjs/src/lib/models/widgets/text_input.ts
@@ -30,20 +30,18 @@ export class TextInputView extends InputWidgetView {
       disabled: this.model.disabled,
       placeholder: this.model.placeholder,
     })
-    this.input_el.addEventListener("change", (e: any) => this.change_input(e))
-    this.input_el.addEventListener("input",  (e: any) => this.change_input(e))
+    this.input_el.addEventListener("change", () => this.change_input())
+    this.input_el.addEventListener("input",  () => this.change_input_oninput())
     this.group_el.appendChild(this.input_el)
   }
 
-  change_input(event?: any): void {
-    if (typeof event !== undefined) {
-      const eventType = event.type
-      if (eventType == "change") {
-        this.model.value = this.input_el.value
-      } else if (eventType == "input") {
-        this.model.value_input = this.input_el.value
-      }
-    }
+  change_input(): void {
+    this.model.value = this.input_el.value
+    super.change_input()
+  }
+
+  change_input_oninput(): void {
+    this.model.value_input = this.input_el.value
     super.change_input()
   }
 }

--- a/bokehjs/src/lib/models/widgets/text_input.ts
+++ b/bokehjs/src/lib/models/widgets/text_input.ts
@@ -16,6 +16,7 @@ export class TextInputView extends InputWidgetView {
     this.connect(this.model.properties.value.change, () => this.input_el.value = this.model.value)
     this.connect(this.model.properties.disabled.change, () => this.input_el.disabled = this.model.disabled)
     this.connect(this.model.properties.placeholder.change, () => this.input_el.placeholder = this.model.placeholder)
+    this.connect(this.model.properties.wait_commit.change, () => this.input_el.wait_commit = this.model.wait_commit)
   }
 
   render(): void {
@@ -28,8 +29,13 @@ export class TextInputView extends InputWidgetView {
       value: this.model.value,
       disabled: this.model.disabled,
       placeholder: this.model.placeholder,
+      wait_commit: this.model.wait_commit
     })
-    this.input_el.addEventListener("change", () => this.change_input())
+    if (this.model.wait_commit) {
+        this.input_el.addEventListener("change", () => this.change_input())
+    } else {
+        this.input_el.addEventListener("input", () => this.change_input())
+    }
     this.group_el.appendChild(this.input_el)
   }
 
@@ -45,6 +51,7 @@ export namespace TextInput {
   export type Props = InputWidget.Props & {
     value: p.Property<string>
     placeholder: p.Property<string>
+    wait_commit: p.Property<boolean>
   }
 }
 
@@ -63,6 +70,7 @@ export class TextInput extends InputWidget {
     this.define<TextInput.Props>({
       value:       [ p.String, "" ],
       placeholder: [ p.String, "" ],
+      wait_commit:  [ p.Boolean, true ],
     })
   }
 }


### PR DESCRIPTION
Adds the possibility to use the "input" event for the TextInput event listener. The "change" event is still default, and the "input" event is accessible by setting the new variable "wait_commit" as False.

- [ ] issues: fixes #8676
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
