### PR TITLE
allow source.data set from pandas types

### DIFF
--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -140,6 +140,12 @@ Special Properties
 .. autoclass:: Include
 .. autoclass:: Override
 
+Validation-only Properties
+--------------------------
+
+.. autoclass:: PandasDataFrame
+.. autoclass:: PandasGroupBy
+
 Validation Control
 ------------------
 
@@ -217,6 +223,8 @@ __all__ = (
     'MinMaxBounds',
     'NumberSpec',
     'Override',
+    'PandasDataFrame',
+    'PandasGroupBy',
     'Percent',
     'RGB',
     'Regex',
@@ -296,6 +304,9 @@ from .property.numeric import Percent; Percent
 from .property.numeric import Size; Size
 
 from .property.override import Override ; Override
+
+from .property.pandas import PandasDataFrame ; PandasDataFrame
+from .property.pandas import PandasGroupBy ; PandasGroupBy
 
 from .property.primitive import Bool; Bool
 from .property.primitive import Complex; Complex

--- a/bokeh/core/property/pandas.py
+++ b/bokeh/core/property/pandas.py
@@ -1,0 +1,90 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2019, Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+''' Provide (optional) Pandas properties.
+
+'''
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+log = logging.getLogger(__name__)
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+from ...util.dependencies import import_optional
+from .bases import Property
+
+# External imports
+
+# Bokeh imports
+
+#-----------------------------------------------------------------------------
+# Globals and constants
+#-----------------------------------------------------------------------------
+
+pd = import_optional('pandas')
+
+__all__ = (
+    'PandasDataFrame',
+    'PandasGroupBy',
+)
+
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+class PandasDataFrame(Property):
+    ''' Accept Pandas DataFrame values.
+
+    This property only exists to support type validation, e.g. for "accepts"
+    clauses. It is not serializable itself, and is not useful to add to
+    Bokeh models directly.
+
+    '''
+    def validate(self, value, detail=True):
+        super(PandasDataFrame, self).validate(value, detail)
+
+        if pd and isinstance(value, pd.DataFrame):
+            return
+
+        msg = "" if not detail else "expected Pandas DataFrame, got %r" % value
+        raise ValueError(msg)
+
+class PandasGroupBy(Property):
+    ''' Accept Pandas DataFrame values.
+
+    This property only exists to support type validation, e.g. for "accepts"
+    clauses. It is not serializable itself, and is not useful to add to
+    Bokeh models directly.
+
+    '''
+    def validate(self, value, detail=True):
+        super(PandasGroupBy, self).validate(value, detail)
+
+        if pd and isinstance(value, pd.core.groupby.GroupBy):
+            return
+
+        msg = "" if not detail else "expected Pandas GroupBy, got %r" % value
+        raise ValueError(msg)
+
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------

--- a/bokeh/core/property/tests/test_pandas.py
+++ b/bokeh/core/property/tests/test_pandas.py
@@ -1,0 +1,87 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2019, Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import pytest ; pytest
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+
+# External imports
+
+# Bokeh imports
+from . import _TestHasProps, _TestModel
+from bokeh._testing.util.api import verify_all
+
+# Module under test
+import bokeh.core.property.pandas as bcpp
+
+#-----------------------------------------------------------------------------
+# Setup
+#-----------------------------------------------------------------------------
+
+ALL = (
+    'PandasDataFrame',
+    'PandasGroupBy',
+)
+
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+class Test_PandasDataFrame(object):
+
+    def test_valid(self, pd):
+        prop = bcpp.PandasDataFrame()
+        assert prop.is_valid(pd.DataFrame())
+
+    def test_invalid(self):
+        prop = bcpp.PandasDataFrame()
+        assert not prop.is_valid(None)
+        assert not prop.is_valid(1.0+1.0j)
+        assert not prop.is_valid(())
+        assert not prop.is_valid([])
+        assert not prop.is_valid({})
+        assert not prop.is_valid(_TestHasProps())
+        assert not prop.is_valid(_TestModel())
+
+class Test_PandasGroupBy(object):
+
+    def test_valid(self, pd):
+        prop = bcpp.PandasGroupBy()
+        assert prop.is_valid(pd.core.groupby.GroupBy(pd.DataFrame()))
+
+    def test_invalid(self):
+        prop = bcpp.PandasGroupBy()
+        assert not prop.is_valid(None)
+        assert not prop.is_valid(1.0+1.0j)
+        assert not prop.is_valid(())
+        assert not prop.is_valid([])
+        assert not prop.is_valid({})
+        assert not prop.is_valid(_TestHasProps())
+        assert not prop.is_valid(_TestModel())
+
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------
+
+Test___all__ = verify_all(bcpp, ALL)

--- a/bokeh/core/tests/test_properties.py
+++ b/bokeh/core/tests/test_properties.py
@@ -74,6 +74,8 @@ ALL = (
     'MinMaxBounds',
     'NumberSpec',
     'Override',
+    'PandasDataFrame',
+    'PandasGroupBy',
     'Percent',
     'RGB',
     'Regex',

--- a/bokeh/models/tests/test_sources.py
+++ b/bokeh/models/tests/test_sources.py
@@ -68,6 +68,20 @@ class TestColumnDataSource(object):
         assert [0, 1] == list(ds.data['index'])
         assert set(ds.column_names) - set(df.columns) == set(["index"])
 
+    def test_data_accepts_dataframe_arg(self, pd):
+        data = dict(a=[1, 2], b=[2, 3])
+        df = pd.DataFrame(data)
+        ds = ColumnDataSource()
+        assert ds.data == {}
+        ds.data = df
+        assert set(df.columns).issubset(set(ds.column_names))
+        for key in data.keys():
+            assert isinstance(ds.data[key], np.ndarray)
+            assert list(df[key]) == list(ds.data[key])
+        assert isinstance(ds.data['index'], np.ndarray)
+        assert [0, 1] == list(ds.data['index'])
+        assert set(ds.column_names) - set(df.columns) == set(["index"])
+
     def test_init_dataframe_data_kwarg(self, pd):
         data = dict(a=[1, 2], b=[2, 3])
         df = pd.DataFrame(data)
@@ -92,11 +106,40 @@ class TestColumnDataSource(object):
         assert [0, 1] == list(ds.data['level_0'])
         assert set(ds.column_names) - set(df.columns) == set(["level_0"])
 
+    def test_data_accepts_dataframe_index_named_column(self, pd):
+        data = dict(a=[1, 2], b=[2, 3], index=[4, 5])
+        df = pd.DataFrame(data)
+        ds = ColumnDataSource()
+        assert ds.data == {}
+        ds.data = df
+        assert set(df.columns).issubset(set(ds.column_names))
+        for key in data.keys():
+            assert isinstance(ds.data[key], np.ndarray)
+            assert list(df[key]) == list(ds.data[key])
+        assert isinstance(ds.data['level_0'], np.ndarray)
+        assert [0, 1] == list(ds.data['level_0'])
+        assert set(ds.column_names) - set(df.columns) == set(["level_0"])
+
     def test_init_dataframe_column_categoricalindex(self, pd):
         columns = pd.CategoricalIndex(['a', 'b'])
         data = [[0,2], [1,3]]
         df = pd.DataFrame(columns=columns, data=data)
         ds = ColumnDataSource(data=df)
+        assert set(df.columns).issubset(set(ds.column_names))
+        for key in columns:
+            assert isinstance(ds.data[key], np.ndarray)
+            assert list(df[key]) == list(ds.data[key])
+        assert isinstance(ds.data['index'], np.ndarray)
+        assert [0, 1] == list(ds.data['index'])
+        assert set(ds.column_names) - set(df.columns) == set(["index"])
+
+    def test_data_accepts_dataframe_column_categoricalindex(self, pd):
+        columns = pd.CategoricalIndex(['a', 'b'])
+        data = [[0,2], [1,3]]
+        df = pd.DataFrame(columns=columns, data=data)
+        ds = ColumnDataSource()
+        assert ds.data == {}
+        ds.data = df
         assert set(df.columns).issubset(set(ds.column_names))
         for key in columns:
             assert isinstance(ds.data[key], np.ndarray)
@@ -129,6 +172,20 @@ class TestColumnDataSource(object):
             assert isinstance(ds.data[k2], np.ndarray)
             assert list(s[key]) == list(ds.data[k2])
 
+    def test_data_accepts_groupby_arg(self, pd):
+        from bokeh.sampledata.autompg import autompg as df
+        group = df.groupby(by=['origin', 'cyl'])
+        ds = ColumnDataSource()
+        assert ds.data == {}
+        ds.data = group
+        s = group.describe()
+        assert len(ds.column_names) == 49
+        assert isinstance(ds.data['origin_cyl'], np.ndarray)
+        for key in s.columns.values:
+            k2 = "_".join(key)
+            assert isinstance(ds.data[k2], np.ndarray)
+            assert list(s[key]) == list(ds.data[k2])
+
     def test_init_groupby_data_kwarg(self, pd):
         from bokeh.sampledata.autompg import autompg as df
         group = df.groupby(by=['origin', 'cyl'])
@@ -145,6 +202,20 @@ class TestColumnDataSource(object):
         df = pd.DataFrame({"A": [1, 2, 3, 4] * 2, "B": [10, 20, 30, 40] * 2, "C": range(8)})
         group = df.groupby(['A', [10, 20, 30, 40] * 2])
         ds = ColumnDataSource(data=group)
+        s = group.describe()
+        assert len(ds.column_names) == 17
+        assert isinstance(ds.data['index'], np.ndarray)
+        for key in s.columns.values:
+            k2 = "_".join(key)
+            assert isinstance(ds.data[k2], np.ndarray)
+            assert list(s[key]) == list(ds.data[k2])
+
+    def test_data_accepts_groupby_with_None_subindex_name(self, pd):
+        df = pd.DataFrame({"A": [1, 2, 3, 4] * 2, "B": [10, 20, 30, 40] * 2, "C": range(8)})
+        group = df.groupby(['A', [10, 20, 30, 40] * 2])
+        ds = ColumnDataSource()
+        assert ds.data == {}
+        ds.data = group
         s = group.describe()
         assert len(ds.column_names) == 17
         assert isinstance(ds.data['index'], np.ndarray)

--- a/examples/app/population.py
+++ b/examples/app/population.py
@@ -64,8 +64,7 @@ year = Select(title="Year:", value="2010", options=years)
 location = Select(title="Location:", value="World", options=locations)
 
 def update():
-    age =  df[(df.Location == location.value) & (df.Year == int(year.value))]
-    ages.data = ColumnDataSource.from_df(age)
+    ages.data = df[(df.Location == location.value) & (df.Year == int(year.value))]
 
     pop = df[df.Location == location.value].groupby(df.Year).Value.sum()
     new_known = pop[pop.index <= 2010]

--- a/examples/app/stocks/main.py
+++ b/examples/app/stocks/main.py
@@ -107,11 +107,12 @@ def ticker2_change(attrname, old, new):
 def update(selected=None):
     t1, t2 = ticker1.value, ticker2.value
 
-    data = get_data(t1, t2)
-    source.data = source.from_df(data[['t1', 't2', 't1_returns', 't2_returns']])
-    source_static.data = source.data
+    df = get_data(t1, t2)
+    data = df[['t1', 't2', 't1_returns', 't2_returns']]
+    source.data = data
+    source_static.data = data
 
-    update_stats(data, t1, t2)
+    update_stats(df, t1, t2)
 
     corr.title.text = '%s returns vs. %s returns' % (t1, t2)
     ts1.title.text, ts2.title.text = t1, t2


### PR DESCRIPTION
- [x] issues: fixes #9052
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

@mattpap it occurred to me that we could possibly tighten up the pandas "properties" more by making them specialized to raise errors if they were actually added to models. But I think the documentation is sufficient, unless you have a strenuous objection. 