### PR TITLE
fix table selection issues

### DIFF
--- a/bokeh/_testing/util/selenium.py
+++ b/bokeh/_testing/util/selenium.py
@@ -144,14 +144,18 @@ def hover_element(driver, element):
     hover = ActionChains(driver).move_to_element(element)
     hover.perform()
 
-def enter_text_in_element(driver, element, text, click=1, enter=True):
+def enter_text_in_element(driver, element, text, click=1, enter=True, mod=None):
     actions = ActionChains(driver)
     actions.move_to_element(element)
     if click == 1: actions.click()
     elif click == 2: actions.double_click()
     if enter:
         text += Keys.ENTER
+    if mod:
+        actions.key_down(mod)
     actions.send_keys(text)
+    if mod:
+        actions.key_up(mod)
     actions.perform()
 
 def enter_text_in_cell(driver, cell, text):

--- a/bokehjs/src/lib/models/widgets/tables/cell_editors.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_editors.ts
@@ -40,7 +40,7 @@ export abstract class CellEditorView extends DOMView {
 
   render(): void {
     super.render()
-    this.args.container.appendChild(this.el)
+    this.args.container.append(this.el)
     this.el.appendChild(this.inputEl)
     this.renderEditor()
     this.disableNavigation()

--- a/bokehjs/src/lib/models/widgets/tables/data_table.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_table.ts
@@ -157,7 +157,7 @@ export class DataTableView extends WidgetView {
 
     const {selected} = this.model.source
 
-    const permuted_indices = selected.indices.map((x: number) => this.data.index.indexOf(x))
+    const permuted_indices = selected.indices.map((x: number) => this.data.index.indexOf(x)).sort()
 
     this._in_selection_update = true
     this.grid.setSelectedRows(permuted_indices)
@@ -274,7 +274,6 @@ export class DataTableView extends WidgetView {
         if (this._in_selection_update) {
           return
         }
-
         this.model.source.selected.indices = args.rows.map((i: number) => this.data.index[i])
       })
 

--- a/tests/integration/widgets/tables/test_copy_paste.py
+++ b/tests/integration/widgets/tables/test_copy_paste.py
@@ -60,15 +60,15 @@ class Test_DataTableCopyPaste(object):
         row = get_table_row(page.driver, 2)
         row.click()
 
-        enter_text_in_element(page.driver, row, Keys.CONTROL+ Keys.INSERT, click=0, enter=False)
+        enter_text_in_element(page.driver, row, Keys.INSERT, mod=Keys.CONTROL, click=0, enter=False)
 
         input_el = page.driver.find_element_by_css_selector('.foo')
-        enter_text_in_element(page.driver, input_el, Keys.CONTROL + "v", enter=False)
+        enter_text_in_element(page.driver, input_el, Keys.INSERT, mod=Keys.SHIFT, enter=False)
         sleep(1)
         enter_text_in_element(page.driver, input_el, "")
 
         results = page.results
 
-        assert results['value'] == 'testing junk'
+        assert results['value'] == '1\t2\t1\tbar'
 
         assert page.has_no_console_errors()

--- a/tests/integration/widgets/tables/test_copy_paste.py
+++ b/tests/integration/widgets/tables/test_copy_paste.py
@@ -25,8 +25,8 @@ from selenium.webdriver.common.keys import Keys
 
 # Bokeh imports
 from bokeh.layouts import column
-from bokeh.models import ColumnDataSource, CustomJS, DataTable, Plot, TableColumn, TextInput
-from bokeh._testing.util.selenium import enter_text_in_element, get_table_row, RECORD
+from bokeh.models import ColumnDataSource, CustomJS, DataTable, TableColumn, TextAreaInput, TextInput
+from bokeh._testing.util.selenium import enter_text_in_element, get_table_row, RECORD, shift_click
 
 #-----------------------------------------------------------------------------
 # Tests
@@ -40,9 +40,7 @@ pytest_plugins = (
 @pytest.mark.selenium
 class Test_DataTableCopyPaste(object):
 
-    def test_single_row_copy(self, single_plot_page):
-        plot = Plot(height=100, width=100)
-
+    def test_single_row_copy(self, bokeh_model_page):
         data = {'x': [1,2,3,4], 'y': [1, 1, 1, 1], 'd': ['foo', 'bar', 'baz', 'quux']}
         source = ColumnDataSource(data)
         table = DataTable(columns=[
@@ -54,7 +52,7 @@ class Test_DataTableCopyPaste(object):
         text_input = TextInput(css_classes=["foo"])
         text_input.js_on_change('value', CustomJS(code=RECORD("value", "cb_obj.value")))
 
-        page = single_plot_page(column(plot, table, text_input))
+        page = bokeh_model_page(column(table, text_input))
 
         # select the third row
         row = get_table_row(page.driver, 2)
@@ -64,11 +62,76 @@ class Test_DataTableCopyPaste(object):
 
         input_el = page.driver.find_element_by_css_selector('.foo')
         enter_text_in_element(page.driver, input_el, Keys.INSERT, mod=Keys.SHIFT, enter=False)
-        sleep(1)
         enter_text_in_element(page.driver, input_el, "")
 
+        sleep(0.5)
         results = page.results
 
         assert results['value'] == '1\t2\t1\tbar'
+
+        assert page.has_no_console_errors()
+
+    def test_single_row_copy_with_zero(self, bokeh_model_page):
+        data = {'x': [1,2,3,4], 'y': [0, 0, 0, 0], 'd': ['foo', 'bar', 'baz', 'quux']}
+        source = ColumnDataSource(data)
+        table = DataTable(columns=[
+            TableColumn(field="x", title="x"),
+            TableColumn(field="y", title="y"),
+            TableColumn(field="d", title="d"),
+        ], source=source)
+
+        text_input = TextAreaInput(css_classes=["foo"])
+        text_input.js_on_change('value', CustomJS(code=RECORD("value", "cb_obj.value")))
+
+        page = bokeh_model_page(column(table, text_input))
+
+        # select the third row
+        row = get_table_row(page.driver, 2)
+        row.click()
+
+        enter_text_in_element(page.driver, row, Keys.INSERT, mod=Keys.CONTROL, click=0, enter=False)
+
+        input_el = page.driver.find_element_by_css_selector('.foo')
+        enter_text_in_element(page.driver, input_el, Keys.INSERT, mod=Keys.SHIFT, enter=False)
+        #enter_text_in_element(page.driver, input_el, "")
+
+        sleep(0.5)
+        results = page.results
+
+        assert results['value'] == '1\t2\t0\tbar\n'
+
+        assert page.has_no_console_errors()
+
+    def test_multi_row_copy(self, bokeh_model_page):
+        data = {'x': [1,2,3,4], 'y': [0, 1, 2, 3], 'd': ['foo', 'bar', 'baz', 'quux']}
+        source = ColumnDataSource(data)
+        table = DataTable(columns=[
+            TableColumn(field="x", title="x"),
+            TableColumn(field="y", title="y"),
+            TableColumn(field="d", title="d"),
+        ], source=source)
+
+        text_input = TextAreaInput(css_classes=["foo"])
+        text_input.js_on_change('value', CustomJS(code=RECORD("value", "cb_obj.value")))
+
+        page = bokeh_model_page(column(table, text_input))
+
+        # select the third row
+        row = get_table_row(page.driver, 1)
+        row.click()
+
+        row = get_table_row(page.driver, 3)
+        shift_click(page.driver, row)
+
+        enter_text_in_element(page.driver, row, Keys.INSERT, mod=Keys.CONTROL, click=0, enter=False)
+
+        input_el = page.driver.find_element_by_css_selector('.foo')
+        enter_text_in_element(page.driver, input_el, Keys.INSERT, mod=Keys.SHIFT, enter=False)
+        #enter_text_in_element(page.driver, input_el, "")
+
+        sleep(0.5)
+        results = page.results
+
+        assert results['value'] == '0\t1\t0\tfoo\n1\t2\t1\tbar\n2\t3\t2\tbaz\n'
 
         assert page.has_no_console_errors()

--- a/tests/integration/widgets/tables/test_copy_paste.py
+++ b/tests/integration/widgets/tables/test_copy_paste.py
@@ -1,0 +1,74 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2017, Anaconda, Inc. All rights reserved.
+#
+# Powered by the Bokeh Development Team.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import pytest ; pytest
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+from time import sleep
+
+# External imports
+from selenium.webdriver.common.keys import Keys
+
+# Bokeh imports
+from bokeh.layouts import column
+from bokeh.models import ColumnDataSource, CustomJS, DataTable, Plot, TableColumn, TextInput
+from bokeh._testing.util.selenium import enter_text_in_element, get_table_row, RECORD
+
+#-----------------------------------------------------------------------------
+# Tests
+#-----------------------------------------------------------------------------
+
+pytest_plugins = (
+    "bokeh._testing.plugins.bokeh",
+)
+
+@pytest.mark.integration
+@pytest.mark.selenium
+class Test_DataTableCopyPaste(object):
+
+    def test_single_row_copy(self, single_plot_page):
+        plot = Plot(height=100, width=100)
+
+        data = {'x': [1,2,3,4], 'y': [1, 1, 1, 1], 'd': ['foo', 'bar', 'baz', 'quux']}
+        source = ColumnDataSource(data)
+        table = DataTable(columns=[
+            TableColumn(field="x", title="x"),
+            TableColumn(field="y", title="y"),
+            TableColumn(field="d", title="d"),
+        ], source=source)
+
+        text_input = TextInput(css_classes=["foo"])
+        text_input.js_on_change('value', CustomJS(code=RECORD("value", "cb_obj.value")))
+
+        page = single_plot_page(column(plot, table, text_input))
+
+        # select the third row
+        row = get_table_row(page.driver, 2)
+        row.click()
+
+        enter_text_in_element(page.driver, row, Keys.CONTROL+ Keys.INSERT, click=0, enter=False)
+
+        input_el = page.driver.find_element_by_css_selector('.foo')
+        enter_text_in_element(page.driver, input_el, Keys.CONTROL + "v", enter=False)
+        sleep(1)
+        enter_text_in_element(page.driver, input_el, "")
+
+        results = page.results
+
+        assert results['value'] == 'testing junk'
+
+        assert page.has_no_console_errors()


### PR DESCRIPTION
- [x] issues: fixes #8921
- [x] issues: fixes #8923
- [x] tests added / passed

Tests coming tomorrow. The issues here:

* permuted indices can end up re-ordered from row order, they just need to be sorted so that the rows that are selected are copied out in order

* `container` is a jQ object, `appendChild` does not exist (use `append`)