### PR TITLE
use sampledata.bokeh.org CDN

### DIFF
--- a/bokeh/util/sampledata.py
+++ b/bokeh/util/sampledata.py
@@ -53,7 +53,8 @@ def download(progress=True):
     data_dir = external_data_dir(create=True)
     print("Using data directory: %s" % data_dir)
 
-    s3 = 'https://bokeh-sampledata.s3.amazonaws.com'
+    # HTTP requests are cheaper for us, and there is nothing private to protect
+    s3 = 'http://sampledata.bokeh.org'
     files = [
         (s3, 'CGM.csv'),
         (s3, 'US_Counties.zip'),


### PR DESCRIPTION
This PR changes the sampledata download URL to point at a new CDN distribution at http://sampledata.bokeh.org  This should be both faster as well as cheap for the project (a large chunk of S3 egress is for running `bokeh sampledata` on CI jobs)

Note that HTTP is used in stead of HTTPS because HTTP requests are cheaper on cloudfront and there is no reason AFAIK that it should matter (no data to protect, apps running, or javascript)