### PR TITLE
exclude landing-2.0 issues from changelog for now

### DIFF
--- a/scripts/issues.py
+++ b/scripts/issues.py
@@ -119,12 +119,17 @@ def closed_issue(issue, after=None):
             return True
     return False
 
+def landing20(issue):
+    """Returns True iff this issue is marked landing-2.0."""
+    labels = issue.get('labels', [])
+    return any(label['name'] == 'landing-2.0' for label in labels)
 
 def relevent_issue(issue, after):
     """Returns True iff this issue is something we should show in the changelog."""
     return (closed_issue(issue, after) and
             issue_completed(issue) and
-            issue_section(issue))
+            issue_section(issue) and
+            not landing20(issue))
 
 
 def relevant_issues(issues, after):


### PR DESCRIPTION
Our automation is not really set up to handle long-running parallel dev branches like `landing-2.0`. This PR excludes issues and PRs with that tag from `CHANGELOG` generation. Right before 2.0 we will need to explicitly *add* them (even overriding the `-p <tag>` option) and then after 2.0 restore things to their original state. 