### PR TITLE
extend FileInput with more attributes.

### DIFF
--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -87,8 +87,17 @@ class FileInput(Widget):
 
     '''
 
-    file = String(default="", readonly=True, help="""
+    value = String(default="", readonly=True, help="""
     A base64-encoded string of the contents of the selected file.
+    """)
+
+    mime_type = String(default="", readonly=True, help="""
+    The mime type of the selected file.
+    """)
+
+    filename = String(default="", readonly=True, help="""
+    The filename of the selected file.
+    The file path is not included as browsers do not allow access to it.
     """)
 
     accept = String(default="", help="""

--- a/bokehjs/src/lib/models/widgets/file_input.ts
+++ b/bokehjs/src/lib/models/widgets/file_input.ts
@@ -34,11 +34,11 @@ export class FileInputView extends WidgetView {
   }
 
   file(e: any): void {
-    var file = e.target.result
-    var file_arr = file.split(",")
+    const file = e.target.result
+    const file_arr = file.split(",")
 
-    var content = file_arr[1]
-    var header = file_arr[0].split(":")[1].split(";")[0]
+    const content = file_arr[1]
+    const header = file_arr[0].split(":")[1].split(";")[0]
 
     this.model.value = content
     this.model.mime_type = header

--- a/bokehjs/src/lib/models/widgets/file_input.ts
+++ b/bokehjs/src/lib/models/widgets/file_input.ts
@@ -28,19 +28,30 @@ export class FileInputView extends WidgetView {
 
   load_file(e: any): void {
     const reader = new FileReader()
+    this.model.filename = e.target.files[0].name
     reader.onload = (e) => this.file(e)
     reader.readAsDataURL(e.target.files[0])
   }
 
   file(e: any): void {
-    this.model.file = e.target.result
+    var file = e.target.result
+    var file_arr = file.split(",")
+
+    var content = file_arr[1]
+    var header = file_arr[0].split(":")[1].split(";")[0]
+
+    this.model.value = content
+    this.model.mime_type = header
+
   }
 }
 
 export namespace FileInput {
   export type Attrs = p.AttrsOf<Props>
   export type Props = Widget.Props & {
-    file: p.Property<string>
+    value: p.Property<string>
+    mime_type: p.Property<string>
+    filename: p.Property<string>
     accept: p.Property<string>
   }
 }
@@ -60,8 +71,10 @@ export abstract class FileInput extends Widget {
     this.prototype.default_view = FileInputView
 
     this.define<FileInput.Props>({
-      file:   [ p.String, '' ],
-      accept: [ p.String, '' ],
+      value:     [ p.String, '' ],
+      mime_type: [ p.String, '' ],
+      filename:  [ p.String, '' ],
+      accept:    [ p.String, '' ],
     })
   }
 }

--- a/examples/plotting/file/file_input.py
+++ b/examples/plotting/file/file_input.py
@@ -1,5 +1,3 @@
-
-
 from bokeh.plotting import show, output_file
 from bokeh.models import FileInput, Div, CustomJS
 from bokeh.layouts import column

--- a/examples/plotting/file/file_input.py
+++ b/examples/plotting/file/file_input.py
@@ -5,7 +5,7 @@ from bokeh.layouts import column
 
 # Set up widgets
 file_input = FileInput(accept=".csv,.json")
-para = Div(text=f"<h1>FileInput Values:</h1><p>filename:<p>b64 value:")
+para = Div(text="<h1>FileInput Values:</h1><p>filename:<p>b64 value:")
 
 # Create CustomJS callback to display file_input attributes on change
 callback = CustomJS(args=dict(para=para, file_input=file_input), code="""

--- a/examples/plotting/file/file_input.py
+++ b/examples/plotting/file/file_input.py
@@ -1,0 +1,23 @@
+
+
+from bokeh.plotting import show, output_file
+from bokeh.models import FileInput, Div, CustomJS
+from bokeh.layouts import column
+
+
+# Set up widgets
+file_input = FileInput(accept=".csv,.json")
+para = Div(text=f"<h1>FileInput Values:</h1><p>filename:<p>b64 value:")
+
+# Create CustomJS callback to display file_input attributes on change
+callback = CustomJS(args=dict(para=para, file_input=file_input), code="""
+    para.text = "<h1>FileInput Values:</h1><p>filename: " + file_input.filename  + "<p>b64 value: " + file_input.value
+""")
+
+# Attach callback to FileInput widget
+file_input.js_on_change('change', callback)
+
+
+output_file("file_input.html")
+
+show(column(file_input, para))

--- a/tests/baselines/examples/plotting/file/file_input
+++ b/tests/baselines/examples/plotting/file/file_input
@@ -1,0 +1,3 @@
+Column bbox=[0, 0, 310, 180]
+  FileInput bbox=[5, 5, 300, 21]
+  Div bbox=[5, 36, 212, 139]


### PR DESCRIPTION
Replaces the `file` attribute in the FileInput widget with separate `value` and `mime_type` attributes. Also adds a `filename` attribute.

- [x] issues: fixes #9099
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
