### PR TITLE
Remove Dev Build installation instructions

### DIFF
--- a/sphinx/source/docs/installation.rst
+++ b/sphinx/source/docs/installation.rst
@@ -178,39 +178,6 @@ from its TypeScript sources. Some additional toolchain support is required.
 Please consult the :ref:`devguide_setup` section of the :ref:`devguide` for
 detailed instructions.
 
-.. _install_devbuild:
-
-Developer Builds
-----------------
-
-An easier way to obtain the most recent Bokeh updates without having to worry
-about building Bokeh yourself is to install a developer build. Developer builds
-are not published on any particular schedule but often come out a few times a
-month or more.
-
-These builds are made available on the "bokeh" channel of `anaconda.org`_. If
-you are using Anaconda, you can install with conda by issuing the command from a
-Bash or Windows command prompt:
-
-.. code-block:: sh
-
-    conda install -c bokeh/channel/dev bokeh
-
-Alternatively you can install with pip from a Bash or Windows command prompt:
-
-.. code-block:: sh
-
-    pip install --pre -i https://pypi.anaconda.org/bokeh/channel/dev/simple bokeh --extra-index-url https://pypi.python.org/simple/
-
-We attempt to make sure the developer builds are relatively stable, however please
-be aware they they are not tested as rigorously as standard releases. Any problems
-or issues reported on the GitHub issue tracker are appreciated.
-
-.. warning::
-    **BokehJS resources for developer builds are not guaranteed to be
-    permanently available**. You should never use any artifacts made by a
-    developer build "in production".
-
 .. _install_bokehjs:
 
 BokehJS


### PR DESCRIPTION
It is evidently impossible to adequately convey the ephemeral nature and absence of any guarantees around dev build resources, which can lead to confusion and problems for users. Additionally, looking back, the actual benefit from making public announcements of dev builds (in terms of actionable feedback received from the public at large) has been negligible over the years. This PR removes public-facing instructions for installing from the `bokeh/dev` channel, and in the future no announcements will be made when dev builds or rcs are published to it. 