### PR TITLE
compute runtime deps correctly

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - python
     - python-dateutil
     - pyyaml
+    - ripgrep
     - setuptools
     - six
     - tornado >=4.3

--- a/scripts/ci/build
+++ b/scripts/ci/build
@@ -16,7 +16,7 @@ node make build
 popd
 
 # build a noarch conda package for Bokeh using the just-built BokehJS
-conda build conda.recipe --quiet --no-test --no-anaconda-upload
+conda build conda.recipe --quiet --no-test --no-anaconda-upload --no-verify
 
 # if this is an external contributor then the uploads below will fail
 if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then

--- a/scripts/ci/install
+++ b/scripts/ci/install
@@ -11,7 +11,7 @@ fi
 wget -qO- "https://raw.githubusercontent.com/travis-ci/artifacts/master/install" |bash
 
 # install Miniconda
-PYTHON="${PYTHON:-3.6}"
+PYTHON="${PYTHON:-3.7}"
 MINICONDA_FILENAME=Miniconda${PYTHON:0:1}-latest-Linux-x86_64.sh
 if  [ "${NO_INSTALL_CONDA}" != "1" ]; then
     wget -nv "http://repo.continuum.io/miniconda/${MINICONDA_FILENAME}"

--- a/scripts/deps.py
+++ b/scripts/deps.py
@@ -12,6 +12,8 @@ def load_setup_py_data():
 
     def _setup(**kw): data.update(kw)
     setuptools.setup = _setup
+    setup_src = open("setup.py").read()
+    exec(setup_src)
     return data
 
 meta_src = jinja2.Template(open("conda.recipe/meta.yaml").read())

--- a/scripts/deps.py
+++ b/scripts/deps.py
@@ -6,6 +6,7 @@ import yaml
 
 def load_setup_py_data():
     import os
+    from os.path import abspath, dirname, join
     import setuptools
     os.environ['CONDA_BUILD_STATE'] = 'RENDER'
     data = {}
@@ -13,6 +14,7 @@ def load_setup_py_data():
     def _setup(**kw): data.update(kw)
     setuptools.setup = _setup
     setup_src = open("setup.py").read()
+    sys.path.append(abspath(join(dirname(__file__), "..")))
     exec(setup_src)
     return data
 

--- a/scripts/deps.py
+++ b/scripts/deps.py
@@ -1,21 +1,21 @@
-import sys
+import os
+from os.path import abspath, dirname, join
 import platform
+import sys
+
 import jinja2
+import setuptools
 import yaml
 
+data = {}
+setup_src = open("setup.py").read()
+os.environ['CONDA_BUILD_STATE'] = 'RENDER'
+def _setup(**kw): data.update(kw)
+setuptools.setup = _setup
+sys.path.append(abspath(join(dirname(__file__), "..")))
+exec(setup_src)
 
 def load_setup_py_data():
-    import os
-    from os.path import abspath, dirname, join
-    import setuptools
-    os.environ['CONDA_BUILD_STATE'] = 'RENDER'
-    data = {}
-
-    def _setup(**kw): data.update(kw)
-    setuptools.setup = _setup
-    setup_src = open("setup.py").read()
-    sys.path.append(abspath(join(dirname(__file__), "..")))
-    exec(setup_src)
     return data
 
 meta_src = jinja2.Template(open("conda.recipe/meta.yaml").read())


### PR DESCRIPTION
`deps.py run` was not actually returning runtime dependencies from `setup.py` This was exposed in `landing-2.0` where "pillow? was moved from test to runtime deps. It was no longer getting installed and tests were failing on PIL imports. (It's possible recent pyyaml and conda-build revs changed something that worked previously)

Also bumps default Python version, if unspecified, to 3.7 (e.g. build phase)