### PR TITLE
Use BokehJS from CDN when the commit is tagged

### DIFF
--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -287,7 +287,7 @@ def _get_current_commit():
     )
     return result.stdout.decode('utf8').strip()
 
-def is_tagged_version():
+def git_tagged_version():
     commit = _get_current_commit()
     print('Bokeh commit: {commit}'.format(commit=commit))
     result = subprocess.run(
@@ -296,13 +296,14 @@ def is_tagged_version():
     )
     tagged = result.stdout.decode('utf8').strip()
     print('Bokeh tagged version: {tagged}'.format(tagged=tagged))
-    return bool(tagged)
+    return tagged
 
 if os.environ.get('READTHEDOCS') == 'True':
     readthedocs_version = os.environ.get('READTHEDOCS_VERSION')
-    if is_tagged_version():
+    tagged_version = git_tagged_version()
+    if tagged_version:
         # Use Bokeh Resources from CDN
-        os.environ['BOKEH_DOCS_CDN'] = readthedocs_version
+        os.environ['BOKEH_DOCS_CDN'] = tagged_version
     else:
         # Use Bokeh Resources from Read the Docs
         os.environ['BOKEH_DOCS_CDN'] = 'test:{readthedocs_version}'.format(


### PR DESCRIPTION
Get the name of the version from the git tag instead of using Read the
Docs version's name.

This fixes the problem when the commit is a tagged and Read the Docs
is building `latest` version for example. With this commit, we are
setting the CDN version to use as the tag name instead of the Read the
Docs version's name, which is the correct name.