### PR TITLE
Convert _pop_colors_and_alpha to _pop_visuals

### DIFF
--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -485,7 +485,7 @@ class Image(XYGlyph):
 
     # a canonical order for positional args that can be used for any
     # functions derived from this class
-    _args = ('image', 'x', 'y', 'dw', 'dh', 'global_alpha', 'dilate')
+    _args = ('image', 'x', 'y', 'dw', 'dh', 'dilate')
 
     # a hook to specify any additional kwargs handled by an initializer
     _extra_kws = {
@@ -554,7 +554,7 @@ class ImageRGBA(XYGlyph):
 
     # a canonical order for positional args that can be used for any
     # functions derived from this class
-    _args = ('image', 'x', 'y', 'dw', 'dh', 'global_alpha', 'dilate')
+    _args = ('image', 'x', 'y', 'dw', 'dh', 'dilate')
 
     image = NumberSpec(help="""
     The arrays of RGBA data for the images.
@@ -609,7 +609,7 @@ class ImageURL(XYGlyph):
 
     # a canonical order for positional args that can be used for any
     # functions derived from this class
-    _args = ('url', 'x', 'y', 'w', 'h', 'angle', 'global_alpha', 'dilate')
+    _args = ('url', 'x', 'y', 'w', 'h', 'angle', 'dilate')
 
     url = StringSpec(default=None, help="""
     The URLs to retrieve images from.

--- a/bokeh/plotting/helpers.py
+++ b/bokeh/plotting/helpers.py
@@ -332,7 +332,7 @@ def _pop_visuals(glyphclass, props, prefix="", defaults={}, trait_defaults={}):
     trait_defaults.setdefault('color', get_default_color())
     trait_defaults.setdefault('alpha', 1.0)
 
-    result = dict()
+    result, traits = dict(), set()
     for pname in filter(is_visual, glyphclass.properties()):
         _, trait = split_feature_trait(pname)
         if prefix+pname in props:
@@ -343,6 +343,9 @@ def _pop_visuals(glyphclass, props, prefix="", defaults={}, trait_defaults={}):
             result[pname] = defaults[pname]
         elif trait in trait_defaults:
             result[pname] = trait_defaults[trait]
+        traits.add(trait)
+    for trait in traits:
+        props.pop(prefix+trait, None)
 
     return result
 

--- a/bokeh/plotting/helpers.py
+++ b/bokeh/plotting/helpers.py
@@ -187,42 +187,44 @@ def _graph(node_source, edge_source, **kwargs):
             raise ValueError(msg).with_traceback(sys.exc_info()[2])
 
     ## node stuff
+    node_ca = _pop_visuals(Circle, kwargs, prefix="node_")
+
     if any(x.startswith('node_selection_') for x in kwargs):
-        snode_ca = _pop_visuals(Circle, kwargs, prefix="node_selection_")
+        snode_ca = _pop_visuals(Circle, kwargs, prefix="node_selection_", defaults=node_ca)
     else:
         snode_ca = None
 
     if any(x.startswith('node_hover_') for x in kwargs):
-        hnode_ca = _pop_visuals(Circle, kwargs, prefix="node_hover_")
+        hnode_ca = _pop_visuals(Circle, kwargs, prefix="node_hover_", defaults=node_ca)
     else:
         hnode_ca = None
 
     if any(x.startswith('node_muted_') for x in kwargs):
-        mnode_ca = _pop_visuals(Circle, kwargs, prefix="node_muted_")
+        mnode_ca = _pop_visuals(Circle, kwargs, prefix="node_muted_", defaults=node_ca)
     else:
         mnode_ca = None
 
-    nsnode_ca = _pop_visuals(Circle, kwargs, prefix="node_nonselection_")
-    node_ca = _pop_visuals(Circle, kwargs, prefix="node_")
+    nsnode_ca = _pop_visuals(Circle, kwargs, prefix="node_nonselection_", defaults=node_ca)
 
     ## edge stuff
+    edge_ca = _pop_visuals(MultiLine, kwargs, prefix="edge_")
+
     if any(x.startswith('edge_selection_') for x in kwargs):
-        sedge_ca = _pop_visuals(MultiLine, kwargs, prefix="edge_selection_")
+        sedge_ca = _pop_visuals(MultiLine, kwargs, prefix="edge_selection_", defaults=edge_ca)
     else:
         sedge_ca = None
 
     if any(x.startswith('edge_hover_') for x in kwargs):
-        hedge_ca = _pop_visuals(MultiLine, kwargs, prefix="edge_hover_")
+        hedge_ca = _pop_visuals(MultiLine, kwargs, prefix="edge_hover_", defaults=edge_ca)
     else:
         hedge_ca = None
 
     if any(x.startswith('edge_muted_') for x in kwargs):
-        medge_ca = _pop_visuals(MultiLine, kwargs, prefix="edge_muted_")
+        medge_ca = _pop_visuals(MultiLine, kwargs, prefix="edge_muted_", defaults=edge_ca)
     else:
         medge_ca = None
 
-    nsedge_ca = _pop_visuals(MultiLine, kwargs, prefix="edge_nonselection_")
-    edge_ca = _pop_visuals(MultiLine, kwargs, prefix="edge_")
+    nsedge_ca = _pop_visuals(MultiLine, kwargs, prefix="edge_nonselection_", defaults=edge_ca)
 
     ## node stuff
     node_kwargs = {k.lstrip('node_'): v for k, v in kwargs.copy().items() if k.lstrip('node_') in Circle.properties()}
@@ -327,7 +329,7 @@ def _pop_visuals(glyphclass, props, prefix="", defaults={}, trait_defaults={}):
     def is_visual(ft):
         """Whether a feature trait name is visual"""
         feature, trait = split_feature_trait(ft)
-        return feature in ('line', 'fill', 'text') and trait is not None
+        return feature in ('line', 'fill', 'text', 'global') and trait is not None
 
     defaults = defaults.copy()
     defaults.setdefault('text_color', 'black')
@@ -920,10 +922,6 @@ def _glyph_function(glyphclass, extra_docs=None):
         # Need to check if user source is present before _pop_renderer_args
         renderer_kws = _pop_renderer_args(kwargs)
         source = renderer_kws['data_source']
-
-        # Assign global_alpha from alpha if glyph type is an image
-        if 'alpha' in kwargs and glyphclass.__name__ in ('Image', 'ImageRGBA', 'ImageURL'):
-            kwargs['global_alpha'] = kwargs['alpha']
 
         # handle the main glyph, need to process literals
         glyph_ca = _pop_visuals(glyphclass, kwargs)

--- a/bokehjs/src/lib/api/plotting.ts
+++ b/bokehjs/src/lib/api/plotting.ts
@@ -660,13 +660,15 @@ export class Figure extends Plot {
         if (props.includes(prefix+pname)) {
             result[pname] = props[prefix+pname]
             delete props[prefix+pname] }
-        else if (props.includes(prefix+trait)) {
+        else if (!cls.props.includes(trait) && props.includes(prefix+trait)) {
             result[pname] = props[prefix+trait] }
         else if (defaults.includes(pname)) {
             result[pname] = defaults[pname] }
         else if (trait_defaults.includes(trait)) {
             result[pname] = trait_defaults[trait] }
-        traits.add(trait)
+        if !cls.props.includes(trait) {
+          traits.add(trait)
+        }
       }
     }
     for (const trait of traits) {

--- a/bokehjs/src/lib/api/plotting.ts
+++ b/bokehjs/src/lib/api/plotting.ts
@@ -640,16 +640,16 @@ export class Figure extends Plot {
     }
     const _is_visual = function(ft: string): boolean {
       [feature, trait] = _split_feature_trait(ft)
-      return (feature in ['line', 'fill', 'text']) && (trait != null)
+      return ['line', 'fill', 'text'].includes(feature) && (trait != null)
     }
 
     const defaults : Attrs = {...defaults}
-    if ( !('text_color' in defaults) ) {
+    if ( !defaults.includes('text_color') ) {
       defaults['text_color'] = 'black' }
     const trait_defaults : Attrs = {...trait_defaults}
-    if ( !('color' in trait_defaults) ) {
+    if ( !trait_defaults.includes('color') ) {
       trait_defaults['color'] = _default_color }
-    if ( !('alpha' in trait_defaults) ){
+    if ( !trait_defaults.includes('alpha') ){
       trait_defaults['alpha'] = _default_alpha }
 
     const result: Attrs = {}
@@ -657,14 +657,14 @@ export class Figure extends Plot {
     for (pname in cls.properties) {
       if (_is_visual(pname)) {
         [_, trait] = _split_feature_trait(pname)
-        if (prefix+pname in props) {
+        if (props.includes(prefix+pname)) {
             result[pname] = props[prefix+pname]
             delete props[prefix+pname] }
-        else if (prefix+trait in props) {
+        else if (props.includes(prefix+trait)) {
             result[pname] = props[prefix+trait] }
-        else if (pname in defaults) {
+        else if (defaults.includes(pname)) {
             result[pname] = defaults[pname] }
-        else if (trait in trait_defaults) {
+        else if (trait_defaults.includes(trait)) {
             result[pname] = trait_defaults[trait] }
         traits.add(trait)
       }

--- a/bokehjs/src/lib/api/plotting.ts
+++ b/bokehjs/src/lib/api/plotting.ts
@@ -633,40 +633,42 @@ export class Figure extends Plot {
   _pop_visuals(cls: Class<HasProps>, props: Attrs, prefix: string = "",
                         defaults: Attrs = {}, trait_defaults: Attrs = {}): Attrs {
 
-    const _split_feature_trait = function(ft: string): string {
-      ft = ft.split('_', 2)
-      if (ft.length==2) { return ft }
-      else { return ft.concat([null]) }
+    const _split_feature_trait = function(ft: string): Array<string|null> {
+      const fta: Array<string|null> = ft.split('_', 2)
+      if (fta.length==2) { return fta }
+      else { return fta.concat([null]) }
     }
     const _is_visual = function(ft: string): boolean {
+      let feature, trait
       [feature, trait] = _split_feature_trait(ft)
-      return ['line', 'fill', 'text'].includes(feature) && (trait != null)
+      return includes(['line', 'fill', 'text'], feature) && (trait != null)
     }
 
-    const defaults : Attrs = {...defaults}
-    if ( !defaults.includes('text_color') ) {
+    defaults = {...defaults}
+    if ( !includes(defaults, 'text_color') ) {
       defaults['text_color'] = 'black' }
-    const trait_defaults : Attrs = {...trait_defaults}
-    if ( !trait_defaults.includes('color') ) {
+    trait_defaults = {...trait_defaults}
+    if ( !includes(trait_defaults, 'color') ) {
       trait_defaults['color'] = _default_color }
-    if ( !trait_defaults.includes('alpha') ){
+    if ( !includes(trait_defaults, 'alpha') ){
       trait_defaults['alpha'] = _default_alpha }
 
     const result: Attrs = {}
-    traits = new Set()
-    for (pname in cls.properties) {
+    const traits = new Set()
+    for (const pname in cls.properties) {
+      let _, trait
       if (_is_visual(pname)) {
         [_, trait] = _split_feature_trait(pname)
-        if (props.includes(prefix+pname)) {
+        if (includes(props, prefix+pname)) {
             result[pname] = props[prefix+pname]
             delete props[prefix+pname] }
-        else if (!cls.props.includes(trait) && props.includes(prefix+trait)) {
+        else if (!includes(cls.props, trait) && includes(props, prefix+trait)) {
             result[pname] = props[prefix+trait] }
-        else if (defaults.includes(pname)) {
+        else if (includes(defaults, pname)) {
             result[pname] = defaults[pname] }
-        else if (trait_defaults.includes(trait)) {
+        else if (includes(trait_defaults, trait)) {
             result[pname] = trait_defaults[trait] }
-        if !cls.props.includes(trait) {
+        if !includes(cls.props, trait) {
           traits.add(trait)
         }
       }


### PR DESCRIPTION
Ni! This PR replaces `_pop_colors_and_alpha` with a new function `_pop_visuals` that works on all visuals in a more generic fashion. Details are documented in the code. As discussed in issue #8893, changes in property inheritance behavior should be noted in the release. In particular, visuals for a non prefixed glyph now serve as base for their prefixed counterparts (`hover_line_color` defaults to `line_color` if that is set), and aliases now work for all property traits ('selection_{y}' is an alias for 'selection_{x}_{y}' for any (x, y) where x is a visual feature).

Implemented and tested in `/bokeh/plotting/helpers.py`.
Implemented and not tested in `bokehjs/src/lib/api/plotting.ts`.

- [x] issues: fixes #8893, #4820
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

@bryevdv