### PR TITLE
Add support for typescript-eslint

### DIFF
--- a/bokehjs/eslint.json
+++ b/bokehjs/eslint.json
@@ -14,6 +14,7 @@
   "plugins": ["@typescript-eslint"],
   "extends": [],
   "rules": {
-    "comma-spacing": ["error", {"before": false, "after": true}]
+    "comma-spacing": ["error", {"before": false, "after": true}],
+    "comma-dangle": ["error", "always-multiline"]
   }
 }

--- a/bokehjs/eslint.json
+++ b/bokehjs/eslint.json
@@ -14,5 +14,6 @@
   "plugins": ["@typescript-eslint"],
   "extends": [],
   "rules": {
+    "comma-spacing": ["error", {"before": false, "after": true}]
   }
 }

--- a/bokehjs/eslint.json
+++ b/bokehjs/eslint.json
@@ -1,0 +1,18 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": [
+      "./make/tsconfig.json",
+      "./src/lib/tsconfig.json",
+      "./src/compiler/tsconfig.json",
+      "./test/tsconfig.json",
+      "./examples/tsconfig.json"
+    ],
+    "tsconfigRootDir": ".",
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": [],
+  "rules": {
+  }
+}

--- a/bokehjs/eslint.json
+++ b/bokehjs/eslint.json
@@ -15,6 +15,7 @@
   "extends": [],
   "rules": {
     "comma-spacing": ["error", {"before": false, "after": true}],
-    "comma-dangle": ["error", "always-multiline"]
+    "comma-dangle": ["error", "always-multiline"],
+    "@typescript-eslint/type-annotation-spacing": ["error"]
   }
 }

--- a/bokehjs/examples/burtin/burtin.ts
+++ b/bokehjs/examples/burtin/burtin.ts
@@ -54,7 +54,7 @@ export namespace Burtin {
   const drug_color = {
     Penicillin:   "#0d3362",
     Streptomycin: "#c64737",
-    Neomycin:     "black"  ,
+    Neomycin:     "black",
   }
 
   const gram_color = {

--- a/bokehjs/examples/charts/charts.ts
+++ b/bokehjs/examples/charts/charts.ts
@@ -14,12 +14,12 @@ export namespace Charts {
   const p14 = Bokeh.Charts.pie(pie_data, {inner_radius: 0.2, palette: "Oranges9", slice_labels: "percentages"})
 
   const bar_data = [
-    ['City'              , '2010 Population' , '2000 Population'],
-    ['New York City, NY' , 8175000           , 8008000          ],
-    ['Los Angeles, CA'   , 3792000           , 3694000          ],
-    ['Chicago, IL'       , 2695000           , 2896000          ],
-    ['Houston, TX'       , 2099000           , 1953000          ],
-    ['Philadelphia, PA'  , 1526000           , 1517000          ],
+    ['City',              '2010 Population', '2000 Population'],
+    ['New York City, NY', 8175000,           8008000          ],
+    ['Los Angeles, CA',   3792000,           3694000          ],
+    ['Chicago, IL',       2695000,           2896000          ],
+    ['Houston, TX',       2099000,           1953000          ],
+    ['Philadelphia, PA',  1526000,           1517000          ],
   ]
 
   const p21 = Bokeh.Charts.bar(bar_data, {axis_number_format: "0.[00]a"})

--- a/bokehjs/examples/stocks/stocks.ts
+++ b/bokehjs/examples/stocks/stocks.ts
@@ -25,7 +25,7 @@ export namespace Stocks {
     plot.add_layout(new Bokeh.Grid({ticker: yaxis.ticker, dimension: 1}))
 
     // Add a line for each entry in the source
-    const colors = ['#aa0000','#00aa00', '#0000aa', '#aaaa00', '#aa00aa', '#00aaaa']
+    const colors = ['#aa0000', '#00aa00', '#0000aa', '#aaaa00', '#aa00aa', '#00aaaa']
     let i = -1
     for (const key in source.data) {
       if (key != 't') {

--- a/bokehjs/make/tasks/compiler.ts
+++ b/bokehjs/make/tasks/compiler.ts
@@ -22,7 +22,7 @@ task("compiler:build", ["compiler:ts"], async () => {
   const ignores = ["babel-core", "@babel/core"] // XXX: remove together with coffeescript
   const builtins = true
   const minify = false
-  const cache = join(build_dir.js, "compiler-cache.json")
+  const cache = argv.cache !== false ? join(build_dir.js, "compiler-cache.json") : undefined
 
   const linker = new Linker({entries, bases, ignores, builtins, minify, cache})
   const [bundle] = linker.link()

--- a/bokehjs/make/tasks/lint.ts
+++ b/bokehjs/make/tasks/lint.ts
@@ -1,24 +1,46 @@
 import {argv} from "yargs"
 import {join} from "path"
 
-import {Linter, Configuration} from "tslint"
+import * as ts from "tslint"
+import * as es from "eslint"
 
 import {task, log} from "../task"
 import * as paths from "../paths"
 
-function lint(dir: string): void {
+function eslint(dir: string): void {
+  const engine = new es.CLIEngine({
+    configFile: "./eslint.json",
+    extensions: [".ts"],
+    fix: argv.fix === true,
+  })
+
+  const report = engine.executeOnFiles([dir])
+
+  if (report.errorCount != 0) {
+    const formatter = engine.getFormatter()
+    const output = formatter(report.results)
+
+    for (const line of output.trim().split("\n"))
+      log(line)
+
+    if (argv.emitError)
+      process.exit(1)
+  }
+}
+
+function tslint(dir: string): void {
   const options = {
     rulesDirectory: join(paths.base_dir, "tslint", "rules"),
     formatter: "stylish",
-    fix: (argv.fix as boolean | undefined) || false,
+    fix: argv.fix === true,
   }
 
-  const program = Linter.createProgram(join(dir, "tsconfig.json"))
-  const linter = new Linter(options, program)
-  const files = Linter.getFileNames(program)
+  const program = ts.Linter.createProgram(join(dir, "tsconfig.json"))
+  const linter = new ts.Linter(options, program)
+  const files = ts.Linter.getFileNames(program)
 
   for (const file of files) {
-    const config = Configuration.findConfiguration("./tslint.json", file).results
+    const config = ts.Configuration.findConfiguration("./tslint.json", file).results
     const contents = program.getSourceFile(file)!.getFullText()
     linter.lint(file, contents, config)
   }
@@ -34,20 +56,20 @@ function lint(dir: string): void {
   }
 }
 
-task("tslint:make", async () => {
-  lint(paths.make_dir)
-})
+task("eslint:make", async () => eslint(paths.make_dir))
+task("eslint:lib", async () => eslint(paths.src_dir.lib))
+task("eslint:compiler", async () => eslint(paths.src_dir.compiler))
+task("eslint:test", async () => eslint(paths.src_dir.test))
+task("eslint:examples", async () => eslint(paths.src_dir.examples))
 
-task("tslint:lib", async () => {
-  lint(paths.src_dir.lib)
-})
+task("eslint", ["eslint:make", "eslint:lib", "eslint:compiler", "eslint:test", "eslint:examples"])
 
-task("tslint:test", async () => {
-  lint(paths.src_dir.test)
-})
+task("tslint:make", async () => tslint(paths.make_dir))
+task("tslint:lib", async () => tslint(paths.src_dir.lib))
+task("tslint:compiler", async () => tslint(paths.src_dir.compiler))
+task("tslint:test", async () => tslint(paths.src_dir.test))
+task("tslint:examples", async () => tslint(paths.src_dir.examples))
 
-task("tslint:examples", async () => {
-  lint(paths.src_dir.examples)
-})
+task("tslint", ["tslint:make", "tslint:lib", "tslint:compiler", "tslint:test", "tslint:examples"])
 
-task("tslint", ["tslint:make", "tslint:lib", "tslint:test", "tslint:examples"])
+task("lint", ["eslint", "tslint"])

--- a/bokehjs/make/tasks/scripts.ts
+++ b/bokehjs/make/tasks/scripts.ts
@@ -25,7 +25,7 @@ task("scripts:bundle", ["scripts:compile"], async () => {
   const linker = new Linker({
     entries: packages.map((pkg) => pkg.main),
     bases: [paths.build_dir.lib, "./node_modules"],
-    cache: join(paths.build_dir.js, "cache.json"),
+    cache: argv.cache !== false ? join(paths.build_dir.js, "cache.json") : undefined,
   })
 
   const bundles = linker.link()

--- a/bokehjs/package-lock.json
+++ b/bokehjs/package-lock.json
@@ -51,6 +51,12 @@
       "integrity": "sha512-laiDIXqqthjJlyAMYAXOtN3N8+UlbM+KvZi4BaY5ZOekmVkBs/UxfK5O0HWeJVG2eW8F+Mu2ww13fTX+kY1FlQ==",
       "dev": true
     },
+    "@types/eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
+      "dev": true
+    },
     "@types/geojson": {
       "version": "7946.0.6",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.6.tgz",
@@ -76,6 +82,12 @@
       "requires": {
         "@types/sizzle": "*"
       }
+    },
+    "@types/json-schema": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
+      "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
+      "dev": true
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -153,6 +165,71 @@
       "integrity": "sha512-sCZy4SxP9rN2w30Hlmg5dtdRwgYQfYRiLo9usw8X9cxlf+H4FqM1xX7+sNH7NNKVdbXMJWqva7iyy+fxh/V7fA==",
       "dev": true
     },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.13.0.tgz",
+      "integrity": "sha512-WQHCozMnuNADiqMtsNzp96FNox5sOVpU8Xt4meaT4em8lOG1SrOv92/mUbEHQVh90sldKSfcOc/I0FOb/14G1g==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "1.13.0",
+        "eslint-utils": "^1.3.1",
+        "functional-red-black-tree": "^1.0.1",
+        "regexpp": "^2.0.1",
+        "tsutils": "^3.7.0"
+      },
+      "dependencies": {
+        "tsutils": {
+          "version": "3.17.1",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+          "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
+      "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/typescript-estree": "1.13.0",
+        "eslint-scope": "^4.0.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.13.0.tgz",
+      "integrity": "sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==",
+      "dev": true,
+      "requires": {
+        "@types/eslint-visitor-keys": "^1.0.0",
+        "@typescript-eslint/experimental-utils": "1.13.0",
+        "@typescript-eslint/typescript-estree": "1.13.0",
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
+      "integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
+      "dev": true,
+      "requires": {
+        "lodash.unescape": "4.0.1",
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true
+        }
+      }
+    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -166,9 +243,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-      "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
+      "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
       "dev": true
     },
     "acorn-globals": {
@@ -178,7 +255,21 @@
       "dev": true,
       "requires": {
         "acorn": "^4.0.4"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "4.0.13",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+          "dev": true
+        }
       }
+    },
+    "acorn-jsx": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+      "dev": true
     },
     "ajv": {
       "version": "5.5.2",
@@ -198,6 +289,12 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true,
       "optional": true
+    },
+    "ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -291,6 +388,12 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
+    },
     "async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
@@ -377,6 +480,12 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
     "camelcase": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
@@ -427,6 +536,12 @@
         "supports-color": "^5.3.0"
       }
     },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -442,6 +557,21 @@
         "commander": "2.11.x",
         "ws": "^6.1.0"
       }
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
     },
     "cliui": {
       "version": "4.1.0",
@@ -716,6 +846,15 @@
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -855,11 +994,167 @@
         }
       }
     },
+    "eslint": {
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
+      "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.9.1",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^4.0.3",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^5.0.1",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.2.2",
+        "js-yaml": "^3.13.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.11",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^5.5.1",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
+      "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+      "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^6.0.7",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
+          "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+          "dev": true
+        }
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
     },
     "estraverse": {
       "version": "4.2.0",
@@ -903,6 +1198,28 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
+      }
+    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -927,6 +1244,24 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
+    },
     "find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -934,6 +1269,17 @@
       "dev": true,
       "requires": {
         "locate-path": "^3.0.0"
+      }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
       }
     },
     "flatbush": {
@@ -948,6 +1294,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/flatqueue/-/flatqueue-1.1.0.tgz",
       "integrity": "sha512-N95K6UfbI1wg6iOg3ItYrL3d3kNN6Fe0+dsp6sbTBg9/3dqR5KiTaMdfxG2dz2ITKAWCSYCvjf69xpA6760Zfw=="
+    },
+    "flatted": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -979,6 +1331,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
     "get-func-name": {
@@ -1018,6 +1376,12 @@
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
     },
     "globby": {
       "version": "6.1.0",
@@ -1133,12 +1497,34 @@
       "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
       "dev": true
     },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
     "image-size": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
       "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
       "dev": true,
       "optional": true
+    },
+    "import-fresh": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+      "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -1155,6 +1541,44 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
+    },
+    "inquirer": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
+      "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.12",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
     },
     "invert-kv": {
       "version": "2.0.0",
@@ -1191,6 +1615,12 @@
       "requires": {
         "path-is-inside": "^1.0.1"
       }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -1367,6 +1797,14 @@
         "whatwg-encoding": "^1.0.1",
         "whatwg-url": "^4.3.0",
         "xml-name-validator": "^2.0.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "4.0.13",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+          "dev": true
+        }
       }
     },
     "json-parse-better-errors": {
@@ -1385,6 +1823,12 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "json-stringify-safe": {
@@ -1490,10 +1934,22 @@
         "path-exists": "^3.0.0"
       }
     },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
+      "dev": true
+    },
+    "lodash.unescape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
       "dev": true
     },
     "logtrap": {
@@ -1670,10 +2126,22 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
     },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
     "nan": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
       "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "neo-async": {
@@ -1769,6 +2237,15 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
       }
     },
     "optimist": {
@@ -1890,6 +2367,15 @@
       "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
       "dev": true
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "parse5": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
@@ -1967,6 +2453,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "proj4": {
@@ -2062,6 +2554,12 @@
         "once": "^1.3.0"
       }
     },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
     "request": {
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
@@ -2123,6 +2621,22 @@
         "path-parse": "^1.0.6"
       }
     },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -2130,6 +2644,24 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -2206,6 +2738,17 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
     },
     "slickgrid": {
       "version": "git+https://github.com/bokeh/SlickGrid.git#8e993bfe1e4c16c6115bbad2ee1b4476d2136675",
@@ -2390,6 +2933,12 @@
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -2404,6 +2953,70 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
       "dev": true
+    },
+    "table": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.5.tgz",
+      "integrity": "sha512-oGa2Hl7CQjfoaogtrOHEJroOcYILTx7BZWLGsJIlzoWmB2zmguhNfPJZsWPKYek/MgCxfco54gEi31d1uN2hFA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
     },
     "terser": {
       "version": "3.17.0",
@@ -2424,10 +3037,31 @@
         }
       }
     },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
     "timezone": {
       "version": "1.0.22",
       "resolved": "https://registry.npmjs.org/timezone/-/timezone-1.0.22.tgz",
       "integrity": "sha512-xDkfblPtNhzU0fYm5FhWNzqECX2mzvpBgd+Pf5F8yAQmbxeWL4+6f496iGqdu0WllF7TxSlE6mmRH4uFnACVuQ=="
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
     },
     "toposort": {
       "version": "2.0.2",
@@ -2604,6 +3238,23 @@
       "resolved": "https://registry.npmjs.org/underscore.template/-/underscore.template-0.1.7.tgz",
       "integrity": "sha1-MBPg6hgXVjBvFgnpWcr7xyKts+k="
     },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        }
+      }
+    },
     "util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
@@ -2774,6 +3425,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "ws": {
       "version": "6.2.0",

--- a/bokehjs/package-lock.json
+++ b/bokehjs/package-lock.json
@@ -51,10 +51,26 @@
       "integrity": "sha512-laiDIXqqthjJlyAMYAXOtN3N8+UlbM+KvZi4BaY5ZOekmVkBs/UxfK5O0HWeJVG2eW8F+Mu2ww13fTX+kY1FlQ==",
       "dev": true
     },
+    "@types/eslint": {
+      "version": "4.16.8",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-4.16.8.tgz",
+      "integrity": "sha512-n0ZvaIpPeBxproRvV+tZoCHRxIoNAk+k+XMvQefKgx3qM3IundoogQBAwiNEnqW0GDP1j1ATe5lFy9xxutFAHg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
+      "dev": true
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
     "@types/geojson": {

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -65,7 +65,11 @@
     "@types/hammerjs": "^2.0.36",
     "@types/nouislider": "^9.0.4",
     "@types/proj4": "^2.3.2",
-    "@types/sprintf-js": "^1.1.2"
+    "@types/sprintf-js": "^1.1.2",
+    "eslint": "^5.16.0",
+    "acorn": "^6.2.1",
+    "@typescript-eslint/eslint-plugin": "^1.13.0",
+    "@typescript-eslint/parser": "^1.13.0"
   },
   "dependencies": {
     "tslib": "^1.9.3",

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -66,6 +66,7 @@
     "@types/nouislider": "^9.0.4",
     "@types/proj4": "^2.3.2",
     "@types/sprintf-js": "^1.1.2",
+    "@types/eslint": "^4.16.8",
     "eslint": "^5.16.0",
     "acorn": "^6.2.1",
     "@typescript-eslint/eslint-plugin": "^1.13.0",

--- a/bokehjs/src/compiler/compile.ts
+++ b/bokehjs/src/compiler/compile.ts
@@ -6,7 +6,7 @@ import * as lesscss from "less"
 import {compiler_host, parse_tsconfig, default_transformers, compile_files, report_diagnostics, TSOutput, Inputs, Outputs, Path} from "./compiler"
 import * as transforms from "./transforms"
 
-import tsconfig_json from "./tsconfig"
+import * as tsconfig_json from "./tsconfig.ext.json"
 
 export function compile_typescript(base_dir: string, inputs: Inputs, bokehjs_dir: string): {outputs?: Outputs} & TSOutput {
   const preconfigure: ts.CompilerOptions = {

--- a/bokehjs/src/compiler/main.ts
+++ b/bokehjs/src/compiler/main.ts
@@ -27,7 +27,7 @@ function reply(data: unknown): void {
   process.stdout.write("\n")
 }
 
-import tsconfig_json from "./tsconfig"
+import * as tsconfig_json from "./tsconfig.ext.json"
 
 async function build() {
   const base_dir =  argv.baseDir as string

--- a/bokehjs/src/compiler/transforms.ts
+++ b/bokehjs/src/compiler/transforms.ts
@@ -241,7 +241,7 @@ export function add_json_export() {
         const left = ts.createPropertyAccess(ts.createIdentifier("module"), "exports")
         const right = statement.expression
         const assign = ts.createStatement(ts.createAssignment(left, right))
-        return ts.updateSourceFileNode(root, [statement, assign])
+        return ts.updateSourceFileNode(root, [assign])
       }
     }
 

--- a/bokehjs/src/compiler/tsconfig.ext.json
+++ b/bokehjs/src/compiler/tsconfig.ext.json
@@ -1,4 +1,4 @@
-const tsconfig = {
+{
   "compilerOptions": {
     "noImplicitAny": true,
     "noImplicitThis": true,
@@ -23,9 +23,7 @@ const tsconfig = {
     "target": "ES5",
     "lib": ["es2015", "dom"],
     "baseUrl": ".",
-    "outDir": "./dist",
+    "outDir": "./dist"
   },
-  "include": ["./**/*.ts"],
+  "include": ["./**/*.ts"]
 }
-
-export default tsconfig

--- a/bokehjs/src/lib/api/plotting.ts
+++ b/bokehjs/src/lib/api/plotting.ts
@@ -415,7 +415,7 @@ export class Figure extends Plot {
     ys: MultiPolygonsArgs["ys"],
     args?: Partial<MultiPolygonsArgs>): GlyphRenderer
   multi_polygons(...args: unknown[]): GlyphRenderer {
-    return this._glyph(models.MultiPolygons,"xs,ys", args)
+    return this._glyph(models.MultiPolygons, "xs,ys", args)
   }
 
   oval(args: Partial<OvalArgs>): GlyphRenderer

--- a/bokehjs/src/lib/core/ui_events.ts
+++ b/bokehjs/src/lib/core/ui_events.ts
@@ -60,28 +60,28 @@ export type UISignal<E> = Signal<{id: string | null, e: E}, UIEvents>
 
 export class UIEvents implements EventListenerObject {
 
-  readonly pan_start    : UISignal<GestureEvent> = new Signal(this, 'pan:start')
-  readonly pan          : UISignal<GestureEvent> = new Signal(this, 'pan')
-  readonly pan_end      : UISignal<GestureEvent> = new Signal(this, 'pan:end')
-  readonly pinch_start  : UISignal<GestureEvent> = new Signal(this, 'pinch:start')
-  readonly pinch        : UISignal<GestureEvent> = new Signal(this, 'pinch')
-  readonly pinch_end    : UISignal<GestureEvent> = new Signal(this, 'pinch:end')
-  readonly rotate_start : UISignal<GestureEvent> = new Signal(this, 'rotate:start')
-  readonly rotate       : UISignal<GestureEvent> = new Signal(this, 'rotate')
-  readonly rotate_end   : UISignal<GestureEvent> = new Signal(this, 'rotate:end')
+  readonly pan_start:    UISignal<GestureEvent> = new Signal(this, 'pan:start')
+  readonly pan:          UISignal<GestureEvent> = new Signal(this, 'pan')
+  readonly pan_end:      UISignal<GestureEvent> = new Signal(this, 'pan:end')
+  readonly pinch_start:  UISignal<GestureEvent> = new Signal(this, 'pinch:start')
+  readonly pinch:        UISignal<GestureEvent> = new Signal(this, 'pinch')
+  readonly pinch_end:    UISignal<GestureEvent> = new Signal(this, 'pinch:end')
+  readonly rotate_start: UISignal<GestureEvent> = new Signal(this, 'rotate:start')
+  readonly rotate:       UISignal<GestureEvent> = new Signal(this, 'rotate')
+  readonly rotate_end:   UISignal<GestureEvent> = new Signal(this, 'rotate:end')
 
-  readonly tap          : UISignal<TapEvent>     = new Signal(this, 'tap')
-  readonly doubletap    : UISignal<TapEvent>     = new Signal(this, 'doubletap')
-  readonly press        : UISignal<TapEvent>     = new Signal(this, 'press')
+  readonly tap:          UISignal<TapEvent>     = new Signal(this, 'tap')
+  readonly doubletap:    UISignal<TapEvent>     = new Signal(this, 'doubletap')
+  readonly press:        UISignal<TapEvent>     = new Signal(this, 'press')
 
-  readonly move_enter   : UISignal<MoveEvent>    = new Signal(this, 'move:enter')
-  readonly move         : UISignal<MoveEvent>    = new Signal(this, 'move')
-  readonly move_exit    : UISignal<MoveEvent>    = new Signal(this, 'move:exit')
+  readonly move_enter:   UISignal<MoveEvent>    = new Signal(this, 'move:enter')
+  readonly move:         UISignal<MoveEvent>    = new Signal(this, 'move')
+  readonly move_exit:    UISignal<MoveEvent>    = new Signal(this, 'move:exit')
 
-  readonly scroll       : UISignal<ScrollEvent>  = new Signal(this, 'scroll')
+  readonly scroll:       UISignal<ScrollEvent>  = new Signal(this, 'scroll')
 
-  readonly keydown      : UISignal<KeyEvent>     = new Signal(this, 'keydown')
-  readonly keyup        : UISignal<KeyEvent>     = new Signal(this, 'keyup')
+  readonly keydown:      UISignal<KeyEvent>     = new Signal(this, 'keydown')
+  readonly keyup:        UISignal<KeyEvent>     = new Signal(this, 'keyup')
 
   private readonly hammer = new Hammer(this.hit_area, {touchAction: 'auto'})
 

--- a/bokehjs/src/lib/core/util/color.ts
+++ b/bokehjs/src/lib/core/util/color.ts
@@ -24,7 +24,7 @@ export function color2hex(color: string): string {
   else if (is_svg_color(color))
     return svg_colors[color]
   else if (color.indexOf('rgb') == 0) {
-    const rgb = color.replace(/^rgba?\(|\s+|\)$/g,'').split(',')
+    const rgb = color.replace(/^rgba?\(|\s+|\)$/g, '').split(',')
     let hex = rgb.slice(0, 3).map(_component2hex).join('')
     if (rgb.length == 4)
       hex += _component2hex(Math.floor(parseFloat(rgb[3]) * 255))

--- a/bokehjs/src/lib/core/util/object.ts
+++ b/bokehjs/src/lib/core/util/object.ts
@@ -21,7 +21,7 @@ export function clone<T extends object>(obj: T): T {
   return extend({}, obj) // XXX: can't use {...obj} due to https://github.com/Microsoft/TypeScript/issues/14409
 }
 
-export function merge<T>(obj1: {[key: string] : T[]}, obj2: {[key: string]: T[]}): {[key: string]: T[]} {
+export function merge<T>(obj1: {[key: string]: T[]}, obj2: {[key: string]: T[]}): {[key: string]: T[]} {
   /*
    * Returns an object with the array values for obj1 and obj2 unioned by key.
    */

--- a/bokehjs/src/lib/core/util/templating.ts
+++ b/bokehjs/src/lib/core/util/templating.ts
@@ -64,7 +64,7 @@ export function get_formatter(name: string, raw_spec: string, format?: string, f
         throw new Error(`Unknown tooltip field formatter type '${formatter}'`)
     }
 
-    return function(value: unknown, format: string, special_vars: Vars) : string {
+    return function(value: unknown, format: string, special_vars: Vars): string {
       return formatter.format(value, format, special_vars)
     }
   }

--- a/bokehjs/src/lib/core/visuals.ts
+++ b/bokehjs/src/lib/core/visuals.ts
@@ -37,7 +37,7 @@ function _get_canvas(size: number): HTMLCanvasElement {
 }
 
 export type Color = string
-function create_hatch_canvas(hatch_pattern: mixins.HatchPattern, hatch_color: Color, hatch_scale: number, hatch_weight:number ): HTMLCanvasElement {
+function create_hatch_canvas(hatch_pattern: mixins.HatchPattern, hatch_color: Color, hatch_scale: number, hatch_weight: number ): HTMLCanvasElement {
     const h = hatch_scale
     const h2 = h / 2
     const h4 = h2 / 2
@@ -359,7 +359,7 @@ export class Hatch extends ContextProperties {
     return value
   }
 
-  private _try_defer(defer_func: () => void):void {
+  private _try_defer(defer_func: () => void): void {
     const {hatch_pattern, hatch_extra} = this.cache
     if (hatch_extra != null && hatch_extra.hasOwnProperty(hatch_pattern) ) {
       const custom = hatch_extra[hatch_pattern]

--- a/bokehjs/src/lib/core/visuals.ts
+++ b/bokehjs/src/lib/core/visuals.ts
@@ -8,19 +8,19 @@ import {LineJoin, LineCap, FontStyle, TextAlign, TextBaseline} from "./enums"
 import {HasProps} from "./has_props"
 import {ColumnarDataSource} from "models/sources/columnar_data_source"
 
-function _horz(ctx: Context2d , h: number, h2: number): void {
+function _horz(ctx: Context2d, h: number, h2: number): void {
   ctx.moveTo(0, h2+0.5)
   ctx.lineTo(h, h2+0.5)
   ctx.stroke()
 }
 
-function _vert(ctx: Context2d , h: number, h2: number): void {
+function _vert(ctx: Context2d, h: number, h2: number): void {
   ctx.moveTo(h2+0.5, 0)
   ctx.lineTo(h2+0.5, h)
   ctx.stroke()
 }
 
-function _x(ctx: Context2d , h: number): void {
+function _x(ctx: Context2d, h: number): void {
   ctx.moveTo(0, h)
   ctx.lineTo(h, 0)
   ctx.stroke()

--- a/bokehjs/src/lib/document/document.ts
+++ b/bokehjs/src/lib/document/document.ts
@@ -432,7 +432,7 @@ export class Document {
         }
       }
       for (const k in items) {
-        const [instance,,] = items[k]
+        const [instance,, ] = items[k]
         foreach_value(instance)
       }
     }

--- a/bokehjs/src/lib/models/annotations/arrow.ts
+++ b/bokehjs/src/lib/models/annotations/arrow.ts
@@ -168,12 +168,12 @@ export class Arrow extends Annotation {
     this.mixins(['line'])
 
     this.define<Arrow.Props>({
-      x_start:      [ p.NumberSpec,                          ],
-      y_start:      [ p.NumberSpec,                          ],
+      x_start:      [ p.NumberSpec                           ],
+      y_start:      [ p.NumberSpec                           ],
       start_units:  [ p.SpatialUnits, 'data'                 ],
       start:        [ p.Instance,     null                   ],
-      x_end:        [ p.NumberSpec,                          ],
-      y_end:        [ p.NumberSpec,                          ],
+      x_end:        [ p.NumberSpec                           ],
+      y_end:        [ p.NumberSpec                           ],
       end_units:    [ p.SpatialUnits, 'data'                 ],
       end:          [ p.Instance,     () => new OpenHead({}) ],
       source:       [ p.Instance                             ],

--- a/bokehjs/src/lib/models/annotations/box_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/box_annotation.ts
@@ -121,7 +121,7 @@ export class BoxAnnotationView extends AnnotationView {
     ctx.restore()
   }
 
-  interactive_bbox() : BBox {
+  interactive_bbox(): BBox {
     const tol = this.model.properties.line_width.value() + EDGE_TOLERANCE
     return new BBox({
       x0: this.sleft-tol,

--- a/bokehjs/src/lib/models/annotations/color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/color_bar.ts
@@ -633,7 +633,7 @@ export class ColorBar extends Annotation {
     this.define<ColorBar.Props>({
       location:                [ p.Any,         'top_right' ],
       orientation:             [ p.Orientation, 'vertical'  ],
-      title:                   [ p.String,                  ],
+      title:                   [ p.String                   ],
       title_standoff:          [ p.Number,      2           ],
       width:                   [ p.Any,         'auto'      ],
       height:                  [ p.Any,         'auto'      ],

--- a/bokehjs/src/lib/models/annotations/label.ts
+++ b/bokehjs/src/lib/models/annotations/label.ts
@@ -97,11 +97,11 @@ export class Label extends TextAnnotation {
     this.mixins(['text', 'line:border_', 'fill:background_'])
 
     this.define<Label.Props>({
-      x:            [ p.Number,                      ],
+      x:            [ p.Number                       ],
       x_units:      [ p.SpatialUnits, 'data'         ],
-      y:            [ p.Number,                      ],
+      y:            [ p.Number                       ],
       y_units:      [ p.SpatialUnits, 'data'         ],
-      text:         [ p.String,                      ],
+      text:         [ p.String                       ],
       angle:        [ p.Angle,       0               ],
       angle_units:  [ p.AngleUnits,  'rad'           ],
       x_offset:     [ p.Number,      0               ],

--- a/bokehjs/src/lib/models/annotations/legend.ts
+++ b/bokehjs/src/lib/models/annotations/legend.ts
@@ -378,7 +378,7 @@ export class Legend extends Annotation {
     this.define<Legend.Props>({
       orientation:      [ p.Orientation,    'vertical'  ],
       location:         [ p.Any,            'top_right' ], // TODO (bev)
-      title:            [ p.String,                     ],
+      title:            [ p.String                      ],
       title_standoff:   [ p.Number,         5           ],
       label_standoff:   [ p.Number,         5           ],
       glyph_height:     [ p.Number,         20          ],

--- a/bokehjs/src/lib/models/annotations/title.ts
+++ b/bokehjs/src/lib/models/annotations/title.ts
@@ -147,7 +147,7 @@ export class Title extends TextAnnotation {
     this.mixins(['line:border_', 'fill:background_'])
 
     this.define<Title.Props>({
-      text:            [ p.String,                    ],
+      text:            [ p.String                     ],
       text_font:       [ p.Font,          'helvetica' ],
       text_font_size:  [ p.FontSizeSpec,  '10pt'      ],
       text_font_style: [ p.FontStyle,     'bold'      ],

--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -382,7 +382,7 @@ export class AxisView extends GuideRendererView {
   }
 
   get computed_bounds(): [number, number] {
-    const [range,] = this.ranges
+    const [range, ] = this.ranges
 
     const user_bounds = this.model.bounds // XXX: ? 'auto'
     const range_bounds: [number, number] = [range.min, range.max]
@@ -412,7 +412,7 @@ export class AxisView extends GuideRendererView {
   get rule_coords(): Coords {
     const i = this.dimension
     const j = (i + 1) % 2
-    const [range,] = this.ranges
+    const [range, ] = this.ranges
     const [start, end] = this.computed_bounds
 
     const xs: number[] = new Array(2)
@@ -433,7 +433,7 @@ export class AxisView extends GuideRendererView {
   get tick_coords(): TickCoords {
     const i = this.dimension
     const j = (i + 1) % 2
-    const [range,] = this.ranges
+    const [range, ] = this.ranges
     const [start, end] = this.computed_bounds
 
     const ticks = this.model.ticker.get_ticks(start, end, range, this.loc, {})

--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -382,7 +382,7 @@ export class AxisView extends GuideRendererView {
   }
 
   get computed_bounds(): [number, number] {
-    const [range, ] = this.ranges
+    const [range] = this.ranges
 
     const user_bounds = this.model.bounds // XXX: ? 'auto'
     const range_bounds: [number, number] = [range.min, range.max]
@@ -412,7 +412,7 @@ export class AxisView extends GuideRendererView {
   get rule_coords(): Coords {
     const i = this.dimension
     const j = (i + 1) % 2
-    const [range, ] = this.ranges
+    const [range] = this.ranges
     const [start, end] = this.computed_bounds
 
     const xs: number[] = new Array(2)
@@ -433,7 +433,7 @@ export class AxisView extends GuideRendererView {
   get tick_coords(): TickCoords {
     const i = this.dimension
     const j = (i + 1) % 2
-    const [range, ] = this.ranges
+    const [range] = this.ranges
     const [start, end] = this.computed_bounds
 
     const ticks = this.model.ticker.get_ticks(start, end, range, this.loc, {})

--- a/bokehjs/src/lib/models/axes/categorical_axis.ts
+++ b/bokehjs/src/lib/models/axes/categorical_axis.ts
@@ -25,7 +25,7 @@ export class CategoricalAxisView extends AxisView {
   }
 
   protected _draw_group_separators(ctx: Context2d, _extents: Extents, _tick_coords: TickCoords): void {
-    const [range, ] = (this.ranges as any) as [FactorRange, FactorRange]
+    const [range] = (this.ranges as any) as [FactorRange, FactorRange]
     const [start, end] = this.computed_bounds
 
     if (!range.tops || range.tops.length < 2 || !this.visuals.separator_line.doit)
@@ -83,7 +83,7 @@ export class CategoricalAxisView extends AxisView {
   }
 
   protected _get_factor_info(): [string[], Coords, Orient | number, visuals.Text][] {
-    const [range, ] = (this.ranges as any) as [FactorRange, FactorRange]
+    const [range] = (this.ranges as any) as [FactorRange, FactorRange]
     const [start, end] = this.computed_bounds
     const loc = this.loc
 
@@ -117,7 +117,7 @@ export class CategoricalAxisView extends AxisView {
   get tick_coords(): CategoricalTickCoords {
     const i = this.dimension
     const j = (i + 1) % 2
-    const [range, ] = (this.ranges as any) as [FactorRange, FactorRange]
+    const [range] = (this.ranges as any) as [FactorRange, FactorRange]
     const [start, end] = this.computed_bounds
 
     const ticks = this.model.ticker.get_ticks(start, end, range, this.loc, {})

--- a/bokehjs/src/lib/models/axes/categorical_axis.ts
+++ b/bokehjs/src/lib/models/axes/categorical_axis.ts
@@ -25,7 +25,7 @@ export class CategoricalAxisView extends AxisView {
   }
 
   protected _draw_group_separators(ctx: Context2d, _extents: Extents, _tick_coords: TickCoords): void {
-    const [range,] = (this.ranges as any) as [FactorRange, FactorRange]
+    const [range, ] = (this.ranges as any) as [FactorRange, FactorRange]
     const [start, end] = this.computed_bounds
 
     if (!range.tops || range.tops.length < 2 || !this.visuals.separator_line.doit)
@@ -83,7 +83,7 @@ export class CategoricalAxisView extends AxisView {
   }
 
   protected _get_factor_info(): [string[], Coords, Orient | number, visuals.Text][] {
-    const [range,] = (this.ranges as any) as [FactorRange, FactorRange]
+    const [range, ] = (this.ranges as any) as [FactorRange, FactorRange]
     const [start, end] = this.computed_bounds
     const loc = this.loc
 
@@ -117,7 +117,7 @@ export class CategoricalAxisView extends AxisView {
   get tick_coords(): CategoricalTickCoords {
     const i = this.dimension
     const j = (i + 1) % 2
-    const [range,] = (this.ranges as any) as [FactorRange, FactorRange]
+    const [range, ] = (this.ranges as any) as [FactorRange, FactorRange]
     const [start, end] = this.computed_bounds
 
     const ticks = this.model.ticker.get_ticks(start, end, range, this.loc, {})

--- a/bokehjs/src/lib/models/formatters/mercator_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/mercator_tick_formatter.ts
@@ -38,7 +38,7 @@ export class MercatorTickFormatter extends BasicTickFormatter {
 
     if (this.dimension == "lon") {
       for (let i = 0; i < n; i++) {
-        const [lon, ] = wgs84_mercator.inverse([ticks[i], opts.loc])
+        const [lon] = wgs84_mercator.inverse([ticks[i], opts.loc])
         proj_ticks[i] = lon
       }
     } else {

--- a/bokehjs/src/lib/models/formatters/mercator_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/mercator_tick_formatter.ts
@@ -38,7 +38,7 @@ export class MercatorTickFormatter extends BasicTickFormatter {
 
     if (this.dimension == "lon") {
       for (let i = 0; i < n; i++) {
-        const [lon,] = wgs84_mercator.inverse([ticks[i], opts.loc])
+        const [lon, ] = wgs84_mercator.inverse([ticks[i], opts.loc])
         proj_ticks[i] = lon
       }
     } else {

--- a/bokehjs/src/lib/models/glyphs/area.ts
+++ b/bokehjs/src/lib/models/glyphs/area.ts
@@ -11,7 +11,7 @@ export interface AreaData extends GlyphData {}
 export interface AreaView extends AreaData {}
 
 export abstract class AreaView extends GlyphView {
-  model:Area
+  model: Area
   visuals: Area.Visuals
 
   draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {

--- a/bokehjs/src/lib/models/glyphs/harea.ts
+++ b/bokehjs/src/lib/models/glyphs/harea.ts
@@ -20,7 +20,7 @@ export interface HAreaData extends AreaData {
 export interface HAreaView extends HAreaData {}
 
 export class HAreaView extends AreaView {
-  model:HArea
+  model: HArea
   visuals: HArea.Visuals
 
   protected _index_data(): SpatialIndex {

--- a/bokehjs/src/lib/models/glyphs/image_base.ts
+++ b/bokehjs/src/lib/models/glyphs/image_base.ts
@@ -52,8 +52,8 @@ export class ImageBaseView extends XYGlyphView {
     const y1 = this._y[i]
     const y2 = yr.is_reversed ? y1 - this._dh[i] : y1 + this._dh[i]
 
-    const [l,r] = x1 < x2 ? [x1,x2] : [x2,x1]
-    const [b,t] = y1 < y2 ? [y1,y2] : [y2,y1]
+    const [l, r] = x1 < x2 ? [x1, x2] : [x2, x1]
+    const [b, t] = y1 < y2 ? [y1, y2] : [y2, y1]
     return [l, r, t, b]
   }
 
@@ -115,7 +115,7 @@ export class ImageBaseView extends XYGlyphView {
   }
 
   _image_index(index : number, x: number, y : number) : ImageIndex {
-    const [l,r,t,b] = this._lrtb(index)
+    const [l, r, t, b] = this._lrtb(index)
     const width = this._width[index]
     const height = this._height[index]
     const dx = (r - l) / width
@@ -135,7 +135,7 @@ export class ImageBaseView extends XYGlyphView {
     result.image_indices = []
     for (const index of candidates) {
       if ((sx != Infinity) && (sy != Infinity)) {
-        result.image_indices.push(this._image_index(index, x,y))
+        result.image_indices.push(this._image_index(index, x, y))
       }
     }
     return result

--- a/bokehjs/src/lib/models/glyphs/image_base.ts
+++ b/bokehjs/src/lib/models/glyphs/image_base.ts
@@ -43,7 +43,7 @@ export class ImageBaseView extends XYGlyphView {
     return new SpatialIndex(points)
   }
 
-  _lrtb(i: number) : [number, number, number, number]{
+  _lrtb(i: number): [number, number, number, number]{
     const xr = this.renderer.xscale.source_range
     const x1 = this._x[i]
     const x2 = xr.is_reversed ? x1 - this._dw[i] : x1 + this._dw[i]
@@ -114,7 +114,7 @@ export class ImageBaseView extends XYGlyphView {
     }
   }
 
-  _image_index(index : number, x: number, y : number) : ImageIndex {
+  _image_index(index: number, x: number, y: number): ImageIndex {
     const [l, r, t, b] = this._lrtb(index)
     const width = this._width[index]
     const height = this._height[index]
@@ -125,7 +125,7 @@ export class ImageBaseView extends XYGlyphView {
     return {index, dim1, dim2, flat_index: dim2*width + dim1}
   }
 
-  _hit_point(geometry: PointGeometry) : Selection {
+  _hit_point(geometry: PointGeometry): Selection {
     const {sx, sy} = geometry
     const x = this.renderer.xscale.invert(sx)
     const y = this.renderer.yscale.invert(sy)

--- a/bokehjs/src/lib/models/glyphs/image_url.ts
+++ b/bokehjs/src/lib/models/glyphs/image_url.ts
@@ -176,14 +176,14 @@ export class ImageURLView extends XYGlyphView {
 
   protected _final_sx_sy(anchor: Anchor, sx: number, sy: number, sw: number, sh: number): [number, number] {
     switch (anchor) {
-      case 'top_left':      return [sx         , sy         ]
+      case 'top_left':      return [sx, sy         ]
       case 'top_center':    return [sx - (sw/2), sy         ]
-      case 'top_right':     return [sx - sw    , sy         ]
-      case 'center_right':  return [sx - sw    , sy - (sh/2)]
-      case 'bottom_right':  return [sx - sw    , sy - sh    ]
+      case 'top_right':     return [sx - sw, sy         ]
+      case 'center_right':  return [sx - sw, sy - (sh/2)]
+      case 'bottom_right':  return [sx - sw, sy - sh    ]
       case 'bottom_center': return [sx - (sw/2), sy - sh    ]
-      case 'bottom_left':   return [sx         , sy - sh    ]
-      case 'center_left':   return [sx         , sy - (sh/2)]
+      case 'bottom_left':   return [sx, sy - sh    ]
+      case 'center_left':   return [sx, sy - (sh/2)]
       case 'center':        return [sx - (sw/2), sy - (sh/2)]
     }
   }

--- a/bokehjs/src/lib/models/glyphs/text.ts
+++ b/bokehjs/src/lib/models/glyphs/text.ts
@@ -128,7 +128,7 @@ export class TextView extends XYGlyphView {
     return result
   }
 
-  private _scenterxy(i: number): {x:number, y:number} {
+  private _scenterxy(i: number): {x: number, y: number} {
     const sx0 = this._sxs[i][0][0]
     const sy0 = this._sys[i][0][0]
     const sxc = (this._sxs[i][0][2] + sx0) / 2

--- a/bokehjs/src/lib/models/glyphs/varea.ts
+++ b/bokehjs/src/lib/models/glyphs/varea.ts
@@ -20,7 +20,7 @@ export interface VAreaData extends AreaData {
 export interface VAreaView extends VAreaData {}
 
 export class VAreaView extends AreaView {
-  model:VArea
+  model: VArea
   visuals: VArea.Visuals
 
   protected _index_data(): SpatialIndex {

--- a/bokehjs/src/lib/models/glyphs/webgl/base.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/base.ts
@@ -138,7 +138,7 @@ export function attach_color(prog: Program, vbo: VertexBuffer & {used?: boolean}
   if (!visual.doit) {
     // Don't draw (draw transparent)
     vbo.used = false
-    prog.set_attribute(att_name, 'vec4', [0,0,0,0])
+    prog.set_attribute(att_name, 'vec4', [0, 0, 0, 0])
   } else if (visual_prop_is_singular(visual, colorname) && visual_prop_is_singular(visual, alphaname)) {
     // Nice and simple; both color and alpha are singular
     vbo.used = false

--- a/bokehjs/src/lib/models/grids/grid.ts
+++ b/bokehjs/src/lib/models/grids/grid.ts
@@ -99,7 +99,7 @@ export class GridView extends GuideRendererView {
   }
 
   computed_bounds(): [number, number] {
-    const [range, ] = this.ranges()
+    const [range] = this.ranges()
 
     const user_bounds = this.model.bounds
     const range_bounds = [range.min, range.max]

--- a/bokehjs/src/lib/models/grids/grid.ts
+++ b/bokehjs/src/lib/models/grids/grid.ts
@@ -99,7 +99,7 @@ export class GridView extends GuideRendererView {
   }
 
   computed_bounds(): [number, number] {
-    const [range,] = this.ranges()
+    const [range, ] = this.ranges()
 
     const user_bounds = this.model.bounds
     const range_bounds = [range.min, range.max]

--- a/bokehjs/src/lib/models/layouts/grid_box.ts
+++ b/bokehjs/src/lib/models/layouts/grid_box.ts
@@ -12,7 +12,7 @@ export class GridBoxView extends LayoutDOMView {
   }
 
   get child_models(): LayoutDOM[] {
-    return this.model.children.map(([child, ]) => child)
+    return this.model.children.map(([child]) => child)
   }
 
   _update_layout(): void {

--- a/bokehjs/src/lib/models/layouts/grid_box.ts
+++ b/bokehjs/src/lib/models/layouts/grid_box.ts
@@ -12,7 +12,7 @@ export class GridBoxView extends LayoutDOMView {
   }
 
   get child_models(): LayoutDOM[] {
-    return this.model.children.map(([child,]) => child)
+    return this.model.children.map(([child, ]) => child)
   }
 
   _update_layout(): void {

--- a/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
@@ -100,7 +100,7 @@ export class GMapPlotView extends PlotView {
         this.map.setZoom(new_map_zoom)
 
         // Check we haven't gone out of bounds, and if we have undo the zoom
-        const [proj_xstart, proj_xend,,] = this._get_projected_bounds()
+        const [proj_xstart, proj_xend,, ] = this._get_projected_bounds()
         if (proj_xend - proj_xstart < 0) {
           this.map.setZoom(old_map_zoom)
         }

--- a/bokehjs/src/lib/models/ranges/data_range1d.ts
+++ b/bokehjs/src/lib/models/ranges/data_range1d.ts
@@ -44,7 +44,7 @@ export class DataRange1d extends DataRange {
       range_padding:       [ p.Number,       0.1       ],
       range_padding_units: [ p.PaddingUnits, "percent" ],
       flipped:             [ p.Boolean,      false     ],
-      follow:              [ p.StartEnd,               ],
+      follow:              [ p.StartEnd                ],
       follow_interval:     [ p.Number                  ],
       default_span:        [ p.Number,       2         ],
     })

--- a/bokehjs/src/lib/models/ranges/factor_range.ts
+++ b/bokehjs/src/lib/models/ranges/factor_range.ts
@@ -98,7 +98,7 @@ export function map_three_levels(factors: L3Factor[],
     for (const f1 of submids_order)
       mids_order.push([f0, f1])
     total_subpad += subpad
-    const subtot = sum(tops[f0].map(([f1, ]) => submap[f1].value))
+    const subtot = sum(tops[f0].map(([f1]) => submap[f1].value))
     mapping[f0] = {value: subtot/n, mapping: submap}
     suboffset += n + outer_pad + subpad
   }

--- a/bokehjs/src/lib/models/ranges/factor_range.ts
+++ b/bokehjs/src/lib/models/ranges/factor_range.ts
@@ -98,7 +98,7 @@ export function map_three_levels(factors: L3Factor[],
     for (const f1 of submids_order)
       mids_order.push([f0, f1])
     total_subpad += subpad
-    const subtot = sum(tops[f0].map(([f1,]) => submap[f1].value))
+    const subtot = sum(tops[f0].map(([f1, ]) => submap[f1].value))
     mapping[f0] = {value: subtot/n, mapping: submap}
     suboffset += n + outer_pad + subpad
   }

--- a/bokehjs/src/lib/models/textures/image_url_texture.ts
+++ b/bokehjs/src/lib/models/textures/image_url_texture.ts
@@ -40,7 +40,7 @@ export abstract class ImageURLTexture extends Texture {
     }
   }
 
-  onload(defer_func: () => void) : void {
+  onload(defer_func: () => void): void {
     if (this.image.complete) {
       defer_func()
     } else {

--- a/bokehjs/src/lib/models/textures/texture.ts
+++ b/bokehjs/src/lib/models/textures/texture.ts
@@ -28,7 +28,7 @@ export abstract class Texture extends Model {
 
   abstract get_pattern(color: any, alpha: number, scale: number, weight: number):  (ctx: Context2d) => CanvasPattern | null
 
-  onload(defer_func: () => void) : void {
+  onload(defer_func: () => void): void {
     defer_func()
   }
 

--- a/bokehjs/src/lib/models/tickers/datetime_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/datetime_ticker.ts
@@ -6,7 +6,7 @@ import {CompositeTicker} from "./composite_ticker"
 import {DaysTicker} from "./days_ticker"
 import {MonthsTicker} from "./months_ticker"
 import {YearsTicker} from "./years_ticker"
-import {ONE_MILLI,ONE_SECOND,ONE_MINUTE,ONE_HOUR} from "./util"
+import {ONE_MILLI, ONE_SECOND, ONE_MINUTE, ONE_HOUR} from "./util"
 
 // This is a decent ticker for time data (in milliseconds).
 // It could certainly be improved:

--- a/bokehjs/src/lib/models/tickers/days_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/days_ticker.ts
@@ -1,6 +1,6 @@
 import {TickSpec} from "./ticker"
 import {SingleIntervalTicker} from "./single_interval_ticker"
-import {copy_date,last_month_no_later_than,ONE_DAY} from "./util"
+import {copy_date, last_month_no_later_than, ONE_DAY} from "./util"
 import * as p from "core/properties"
 import {concat} from "core/util/array"
 

--- a/bokehjs/src/lib/models/tiles/tile_renderer.ts
+++ b/bokehjs/src/lib/models/tiles/tile_renderer.ts
@@ -284,7 +284,7 @@ export class TileRendererView extends DataRendererView {
     const zoom_level = this.model.tile_source.get_level_by_extent(extent, h, w)
     const tiles = this.model.tile_source.get_tiles_by_extent(extent, zoom_level)
     for (let t = 0, end = Math.min(10, tiles.length); t < end; t++) {
-      const [x, y, z,] = tiles[t]
+      const [x, y, z, ] = tiles[t]
       const children = this.model.tile_source.children_by_tile_xyz(x, y, z)
       for (const c of children) {
         const [cx, cy, cz, cbounds] = c
@@ -341,7 +341,7 @@ export class TileRendererView extends DataRendererView {
     const children = []
 
     for (const t of tiles) {
-      const [x, y, z,] = t
+      const [x, y, z, ] = t
       const key = tile_source.tile_xyz_to_key(x, y, z)
       const tile = tile_source.tiles[key] as TileData
       if (tile != null && tile.loaded) {

--- a/bokehjs/src/lib/models/tiles/tile_renderer.ts
+++ b/bokehjs/src/lib/models/tiles/tile_renderer.ts
@@ -284,7 +284,7 @@ export class TileRendererView extends DataRendererView {
     const zoom_level = this.model.tile_source.get_level_by_extent(extent, h, w)
     const tiles = this.model.tile_source.get_tiles_by_extent(extent, zoom_level)
     for (let t = 0, end = Math.min(10, tiles.length); t < end; t++) {
-      const [x, y, z, ] = tiles[t]
+      const [x, y, z] = tiles[t]
       const children = this.model.tile_source.children_by_tile_xyz(x, y, z)
       for (const c of children) {
         const [cx, cy, cz, cbounds] = c
@@ -341,7 +341,7 @@ export class TileRendererView extends DataRendererView {
     const children = []
 
     for (const t of tiles) {
-      const [x, y, z, ] = t
+      const [x, y, z] = t
       const key = tile_source.tile_xyz_to_key(x, y, z)
       const tile = tile_source.tiles[key] as TileData
       if (tile != null && tile.loaded) {

--- a/bokehjs/src/lib/models/tiles/tile_source.ts
+++ b/bokehjs/src/lib/models/tiles/tile_source.ts
@@ -76,14 +76,14 @@ export abstract class TileSource extends Model {
      * Note: should probably be refactored into subclasses.
      */
     const url = this.url
-      .replace('{x}','{X}')
-      .replace('{y}','{Y}')
-      .replace('{z}','{Z}')
-      .replace('{q}','{Q}')
-      .replace('{xmin}','{XMIN}')
-      .replace('{ymin}','{YMIN}')
-      .replace('{xmax}','{XMAX}')
-      .replace('{ymax}','{YMAX}')
+      .replace('{x}', '{X}')
+      .replace('{y}', '{Y}')
+      .replace('{z}', '{Z}')
+      .replace('{q}', '{Q}')
+      .replace('{xmin}', '{XMIN}')
+      .replace('{ymin}', '{YMIN}')
+      .replace('{xmax}', '{XMAX}')
+      .replace('{ymax}', '{YMAX}')
     this.url = url
   }
 

--- a/bokehjs/src/lib/models/tools/actions/custom_action.ts
+++ b/bokehjs/src/lib/models/tools/actions/custom_action.ts
@@ -45,7 +45,7 @@ export class CustomAction extends ActionTool {
     this.define<CustomAction.Props>({
       action_tooltip: [ p.String, 'Perform a Custom Action'],
       callback:       [ p.Any                              ], // TODO: p.Either(p.Instance(Callback), p.Function) ]
-      icon:           [ p.String,                          ],
+      icon:           [ p.String                           ],
     })
   }
 

--- a/bokehjs/src/lib/models/tools/edit/edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/edit_tool.ts
@@ -160,9 +160,9 @@ export abstract class EditTool extends GestureTool {
 
   static initClass(): void {
     this.define<EditTool.Props>({
-      custom_icon:    [ p.String,   ],
-      custom_tooltip: [ p.String,   ],
-      empty_value:    [ p.Any,      ],
+      custom_icon:    [ p.String    ],
+      custom_tooltip: [ p.String    ],
+      empty_value:    [ p.Any       ],
       renderers:      [ p.Array, [] ],
     })
   }

--- a/bokehjs/src/lib/models/tools/gestures/box_zoom_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/box_zoom_tool.ts
@@ -25,7 +25,7 @@ export class BoxZoomToolView extends GestureToolView {
     let vh = Math.abs(base_point[1]-curpoint[1])
 
     const va = vh == 0 ? 0 : vw/vh
-    const [xmod,] = va >= a ? [1, va/a] : [a/va, 1]
+    const [xmod, ] = va >= a ? [1, va/a] : [a/va, 1]
 
     // OK the code blocks below merit some explanation. They do:
     //

--- a/bokehjs/src/lib/models/tools/gestures/box_zoom_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/box_zoom_tool.ts
@@ -25,7 +25,7 @@ export class BoxZoomToolView extends GestureToolView {
     let vh = Math.abs(base_point[1]-curpoint[1])
 
     const va = vh == 0 ? 0 : vw/vh
-    const [xmod, ] = va >= a ? [1, va/a] : [a/va, 1]
+    const [xmod] = va >= a ? [1, va/a] : [a/va, 1]
 
     // OK the code blocks below merit some explanation. They do:
     //

--- a/bokehjs/src/lib/models/transforms/jitter.ts
+++ b/bokehjs/src/lib/models/transforms/jitter.ts
@@ -30,8 +30,8 @@ export class Jitter extends Transform {
 
   static initClass(): void {
     this.define<Jitter.Props>({
-      mean:         [ p.Number      , 0        ],
-      width:        [ p.Number      , 1        ],
+      mean:         [ p.Number, 0        ],
+      width:        [ p.Number, 1        ],
       distribution: [ p.Distribution, 'uniform'],
       range:        [ p.Instance               ],
     })

--- a/bokehjs/src/lib/models/widgets/dropdown.ts
+++ b/bokehjs/src/lib/models/widgets/dropdown.ts
@@ -138,8 +138,8 @@ export class Dropdown extends AbstractButton {
     this.define<Dropdown.Props>({
       split:         [ p.Boolean, false ],
       menu:          [ p.Array,   []    ],
-      value:         [ p.String,        ], // deprecated
-      default_value: [ p.String,        ], // deprecated
+      value:         [ p.String         ], // deprecated
+      default_value: [ p.String         ], // deprecated
     })
 
     this.override({

--- a/bokehjs/src/lib/models/widgets/radio_group.ts
+++ b/bokehjs/src/lib/models/widgets/radio_group.ts
@@ -65,7 +65,7 @@ export class RadioGroup extends InputGroup {
     this.prototype.default_view = RadioGroupView
 
     this.define<RadioGroup.Props>({
-      active:   [ p.Number,        ],
+      active:   [ p.Number         ],
       labels:   [ p.Array,   []    ],
       inline:   [ p.Boolean, false ],
       callback: [ p.Any            ],

--- a/bokehjs/src/lib/models/widgets/spinner.ts
+++ b/bokehjs/src/lib/models/widgets/spinner.ts
@@ -6,7 +6,7 @@ import {bk_input} from "styles/widgets/inputs"
 
 const {abs, floor, log10} = Math
 
-function _get_sig_dig(num: number) : number {
+function _get_sig_dig(num: number): number {
   let x = abs(Number(String(num).replace(".", ""))) // remove decimal and make positive
   if (x == 0) return 0
   while (x != 0 && (x % 10 == 0)) x /= 10 // kill the 0s at the end of n

--- a/bokehjs/src/lib/models/widgets/tables/data_table.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_table.ts
@@ -346,7 +346,7 @@ export class DataTable extends TableWidget {
   }
 
   update_sort_columns(sortCols: any): null {
-    this._sort_columns=sortCols.map((x:any) => ({field:x.sortCol.field,sortAsc:x.sortAsc}))
+    this._sort_columns=sortCols.map((x:any) => ({field:x.sortCol.field, sortAsc:x.sortAsc}))
     return null
   }
 

--- a/bokehjs/src/lib/models/widgets/tables/data_table.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_table.ts
@@ -346,7 +346,7 @@ export class DataTable extends TableWidget {
   }
 
   update_sort_columns(sortCols: any): null {
-    this._sort_columns=sortCols.map((x:any) => ({field:x.sortCol.field, sortAsc:x.sortAsc}))
+    this._sort_columns=sortCols.map((x: any) => ({field:x.sortCol.field, sortAsc:x.sortAsc}))
     return null
   }
 

--- a/bokehjs/test/core/enums.ts
+++ b/bokehjs/test/core/enums.ts
@@ -47,7 +47,7 @@ describe("enums module", () => {
   it("should have HatchPatternType", () => {
     expect(enums.HatchPatternType).to.be.deep.equal([
       'blank', 'dot', 'ring', 'horizontal_line', 'vertical_line', 'cross', 'horizontal_dash',
-      'vertical_dash', 'spiral' , 'right_diagonal_line', 'left_diagonal_line', 'diagonal_cross',
+      'vertical_dash', 'spiral', 'right_diagonal_line', 'left_diagonal_line', 'diagonal_cross',
       'right_diagonal_dash', 'left_diagonal_dash', 'horizontal_wave', 'vertical_wave', 'criss_cross',
       ' ', '.', 'o', '-', '|', '+', '"', ':', '@', '/', '\\', 'x', ',', '`', 'v', '>', '*',
     ])

--- a/bokehjs/test/core/hittest.ts
+++ b/bokehjs/test/core/hittest.ts
@@ -11,7 +11,7 @@ describe("hittest module", () => {
   })
 
   it("should return false if (x,y) point is outside a polygon, true if inside", () => {
-    expect(hittest.point_in_poly(1.5, 5, [1,2,2,1], [4,5,8,9])).to.be.equal(true)
-    expect(hittest.point_in_poly(1.01, 4, [1,2,2,1], [4,5,8,9])).to.be.equal(false)
+    expect(hittest.point_in_poly(1.5, 5, [1, 2, 2, 1], [4, 5, 8, 9])).to.be.equal(true)
+    expect(hittest.point_in_poly(1.01, 4, [1, 2, 2, 1], [4, 5, 8, 9])).to.be.equal(false)
   })
 })

--- a/bokehjs/test/core/properties.ts
+++ b/bokehjs/test/core/properties.ts
@@ -195,7 +195,7 @@ describe("properties module", () => {
     describe("array", () => {
 
       it("should return an array if there is a value spec", () => {
-        const source = new ColumnDataSource({data: {foo: [0,1,2,3,10]}})
+        const source = new ColumnDataSource({data: {foo: [0, 1, 2, 3, 10]}})
         const p1 = new DataSpecProperty(new SomeSpecHasProps(fixed), 'a')
         const arr1 = p1.array(source)
         expect(arr1).to.be.instanceof(Array)
@@ -218,7 +218,7 @@ describe("properties module", () => {
       })
 
       it("should return an array if there is a valid expr spec", () => {
-        const source = new ColumnDataSource({data: {foo: [0,1,2,3,10]}})
+        const source = new ColumnDataSource({data: {foo: [0, 1, 2, 3, 10]}})
         const prop = new DataSpecProperty(new SomeSpecHasProps(spec_expr), 'a')
         const arr = prop.array(source)
         expect(arr).to.be.instanceof(Array)
@@ -231,7 +231,7 @@ describe("properties module", () => {
       })
 
       it("should return an array if there is a valid field spec", () => {
-        const source = new ColumnDataSource({data: {foo: [0,1,2,3,10]}})
+        const source = new ColumnDataSource({data: {foo: [0, 1, 2, 3, 10]}})
         const prop = new DataSpecProperty(new SomeSpecHasProps(spec_field), 'a')
         const arr = prop.array(source)
         expect(arr).to.be.instanceof(Array)
@@ -244,7 +244,7 @@ describe("properties module", () => {
       })
 
       it("should return an array if there is a valid field spec named 'field'", () => {
-        const source = new ColumnDataSource({data: {field: [0,1,2,3,10]}})
+        const source = new ColumnDataSource({data: {field: [0, 1, 2, 3, 10]}})
         const prop = new DataSpecProperty(new SomeSpecHasProps({a: {field: 'field'}, b: 30}), 'a')
         const arr = prop.array(source)
         expect(arr).to.be.instanceof(Array)
@@ -266,7 +266,7 @@ describe("properties module", () => {
       })
 
       it("should apply a spec transform to a field", () => {
-        const source = new ColumnDataSource({data: {foo: [0,1,2,3,10]}})
+        const source = new ColumnDataSource({data: {foo: [0, 1, 2, 3, 10]}})
         const prop = new DataSpecProperty(new SomeSpecHasProps(spec_field_trans), 'a')
         const arr = prop.array(source)
         expect(arr).to.be.instanceof(Array)
@@ -279,7 +279,7 @@ describe("properties module", () => {
       })
 
       it("should apply a spec transform to a value array", () => {
-        const source = new ColumnDataSource({data: {foo: [0,1,2,3,10]}})
+        const source = new ColumnDataSource({data: {foo: [0, 1, 2, 3, 10]}})
         const prop = new DataSpecProperty(new SomeSpecHasProps(spec_value_trans), 'a')
         const arr = prop.array(source)
         expect(arr).to.be.instanceof(Array)
@@ -377,7 +377,7 @@ describe("properties module", () => {
 
     describe("validate", () => {
       it("should return undefined on any input", () => {
-        for (const x of [true, null, undefined, 10, 10.2, "foo", [1,2,3], {}, new SomeHasProps()])
+        for (const x of [true, null, undefined, 10, 10.2, "foo", [1, 2, 3], {}, new SomeHasProps()])
           expect(prop.validate(x)).to.be.undefined
       })
     })
@@ -423,8 +423,8 @@ describe("properties module", () => {
     describe("validate", () => {
       it("should return undefined on array input", () => {
         expect(prop.validate([])).to.be.undefined
-        expect(prop.validate([1,2,3])).to.be.undefined
-        expect(prop.validate(new Float64Array([1,2,3]))).to.be.undefined
+        expect(prop.validate([1, 2, 3])).to.be.undefined
+        expect(prop.validate(new Float64Array([1, 2, 3]))).to.be.undefined
       })
 
       it("should throw an Error on non-array input", () => {

--- a/bokehjs/test/core/ui_events.ts
+++ b/bokehjs/test/core/ui_events.ts
@@ -374,7 +374,7 @@ describe("ui_events module", () => {
     it("_pan_start method should handle panstart event", () => {
       const e: any = new Event("panstart") // XXX: not a hammerjs event
       e.pointerType = "mouse"
-      e.srcEvent = {pageX: 100, pageY: 200, preventDefault() : void {
+      e.srcEvent = {pageX: 100, pageY: 200, preventDefault(): void {
         assert.ok(true, 'preventDefault ref')
       }}
 
@@ -390,7 +390,7 @@ describe("ui_events module", () => {
     it("_pan method should handle pan event", () => {
       const e: any = new Event("pan") // XXX: not a hammerjs event
       e.pointerType = "mouse"
-      e.srcEvent = {pageX: 100, pageY: 200, preventDefault() : void {
+      e.srcEvent = {pageX: 100, pageY: 200, preventDefault(): void {
         assert.ok(true, 'preventDefault ref')
       }}
 
@@ -406,7 +406,7 @@ describe("ui_events module", () => {
     it("_pan_end method should handle pan end event", () => {
       const e: any = new Event("panend") // XXX: not a hammerjs event
       e.pointerType = "mouse"
-      e.srcEvent = {pageX: 100, pageY: 200, preventDefault() : void {
+      e.srcEvent = {pageX: 100, pageY: 200, preventDefault(): void {
         assert.ok(true, 'preventDefault ref')
       }}
 
@@ -556,7 +556,7 @@ describe("ui_events module", () => {
 
       const etap: any = new Event("tap") // XXX: not a hammerjs event
       etap.pointerType = "mouse"
-      etap.srcEvent = {pageX: 100, pageY: 200, preventDefault() : void {
+      etap.srcEvent = {pageX: 100, pageY: 200, preventDefault(): void {
         assert.ok(true, 'preventDefault ref')
       }}
 
@@ -565,7 +565,7 @@ describe("ui_events module", () => {
 
       const epan: any = new Event("pan") // XXX: not a hammerjs event
       epan.pointerType = "mouse"
-      epan.srcEvent = {pageX: 100, pageY: 200, preventDefault() : void {
+      epan.srcEvent = {pageX: 100, pageY: 200, preventDefault(): void {
         assert.ok(true, 'preventDefault ref')
       }}
       ANY_ui_events._pan(epan)

--- a/bokehjs/test/core/util/math.ts
+++ b/bokehjs/test/core/util/math.ts
@@ -40,11 +40,11 @@ describe("math module", () => {
   describe("atan2", () => {
 
     it("should return the arctangent between 2 (x,y) points", () => {
-      expect(math.atan2([0,0],[0,1])).to.be.closeTo(Math.PI/2, 0.0000001) // vertical up
-      expect(math.atan2([0,0],[0,-1])).to.be.closeTo(-Math.PI/2, 0.0000001) // vertical down
-      expect(math.atan2([0,0],[1,0])).to.be.closeTo(0, 0.0000001) // horizontal right
-      expect(math.atan2([0,0],[-1,0])).to.be.closeTo(Math.PI, 0.0000001) // horizontal left
-      expect(math.atan2([1,1],[2,2])).to.be.closeTo(Math.PI/4, 0.0000001)
+      expect(math.atan2([0, 0], [0, 1])).to.be.closeTo(Math.PI/2, 0.0000001) // vertical up
+      expect(math.atan2([0, 0], [0, -1])).to.be.closeTo(-Math.PI/2, 0.0000001) // vertical down
+      expect(math.atan2([0, 0], [1, 0])).to.be.closeTo(0, 0.0000001) // horizontal right
+      expect(math.atan2([0, 0], [-1, 0])).to.be.closeTo(Math.PI, 0.0000001) // horizontal left
+      expect(math.atan2([1, 1], [2, 2])).to.be.closeTo(Math.PI/4, 0.0000001)
     })
 
   })

--- a/bokehjs/test/core/util/serialization.ts
+++ b/bokehjs/test/core/util/serialization.ts
@@ -259,7 +259,7 @@ describe("serialization module", () => {
     for (const typ of GOOD_TYPES) {
       it(`should encode ${typ.name} array columns with shapes`, () => {
         const data1 = {a: new typ([1, 2, 3, 4]), b: [10, 20]}
-        const enc1 = ser.encode_column_data(data1, {a: [2,2]})
+        const enc1 = ser.encode_column_data(data1, {a: [2, 2]})
         expect(enc1.b).to.be.deep.equal([10, 20])
         expect(enc1.a).to.be.deep.equal({
           __ndarray__: ser.arrayBufferToBase64(data1.a.buffer),
@@ -268,7 +268,7 @@ describe("serialization module", () => {
         })
 
         const data2 = {a: [new typ([1, 2]), new typ([1, 2])], b: [10, 20]}
-        const enc2 = ser.encode_column_data(data2, {a: [[1,2], [2, 1]]})
+        const enc2 = ser.encode_column_data(data2, {a: [[1, 2], [2, 1]]})
         expect(enc2.b).to.be.deep.equal([10, 20])
         expect(enc2.a).to.be.deep.equal([{
           __ndarray__: ser.arrayBufferToBase64(data2.a[0].buffer),

--- a/bokehjs/test/core/util/templating.ts
+++ b/bokehjs/test/core/util/templating.ts
@@ -115,7 +115,7 @@ describe("templating module", () => {
 
     const imsource = new ColumnDataSource({data:
                                            {arrs: [[[0, 10, 20], [30, 40, 50]]],
-                                            floats: [[0.,1.,2.,3.,4.,5.]],
+                                            floats: [[0., 1., 2., 3., 4., 5.]],
                                             labels: ['test label']}})
     const imindex1 = {index: 0, dim1: 2, dim2: 1, flat_index: 5}
     const imindex2 = {index: 0, dim1: 1, dim2: 0, flat_index: 1}

--- a/bokehjs/test/core/visuals.ts
+++ b/bokehjs/test/core/visuals.ts
@@ -68,13 +68,13 @@ describe("Line", () => {
         const ctx = {} as any
         ctx.setLineDash = function (x: number) { ctx.lineDash = x }
         ctx.setLineDashOffset = function (x: number) { ctx.lineDashOffset = x }
-        const attrs = {line_dash: [1,2]} as any
+        const attrs = {line_dash: [1, 2]} as any
         attrs[spec] = {value}
         const model = new Circle(attrs)
         const line = new Line(model)
         line.set_value(ctx)
         expect(ctx[attr]).to.be.equal(value)
-        expect(ctx.lineDash).to.be.deep.equal([1,2])
+        expect(ctx.lineDash).to.be.deep.equal([1, 2])
       })
     }
   })

--- a/bokehjs/test/document/events.ts
+++ b/bokehjs/test/document/events.ts
@@ -48,12 +48,12 @@ describe("events module", () => {
     it("should generate json", () => {
       const d = new Document()
       const m = new TestModel()
-      const evt = new events.ColumnsPatchedEvent(d, m.ref(), {foo: [[1,2]]})
+      const evt = new events.ColumnsPatchedEvent(d, m.ref(), {foo: [[1, 2]]})
       const json = evt.json(EMPTY_REFS)
       expect(json).to.be.deep.equal({
         kind: "ColumnsPatched",
         column_source: m.ref(),
-        patches: {foo: [[1,2]]},
+        patches: {foo: [[1, 2]]},
       })
     })
   })
@@ -62,12 +62,12 @@ describe("events module", () => {
     it("should generate json with rollover", () => {
       const d = new Document()
       const m = new TestModel()
-      const evt = new events.ColumnsStreamedEvent(d, m.ref(), {foo: [1,2], bar: [3,4]}, 10)
+      const evt = new events.ColumnsStreamedEvent(d, m.ref(), {foo: [1, 2], bar: [3, 4]}, 10)
       const json = evt.json(EMPTY_REFS)
       expect(json).to.be.deep.equal({
         kind: "ColumnsStreamed",
         column_source: m.ref(),
-        data: {foo: [1,2], bar: [3,4]},
+        data: {foo: [1, 2], bar: [3, 4]},
         rollover: 10,
       })
     })
@@ -75,12 +75,12 @@ describe("events module", () => {
     it("should generate json without rollover", () => {
       const d = new Document()
       const m = new TestModel()
-      const evt = new events.ColumnsStreamedEvent(d, m.ref(), {foo: [1,2], bar: [3,4]})
+      const evt = new events.ColumnsStreamedEvent(d, m.ref(), {foo: [1, 2], bar: [3, 4]})
       const json = evt.json(EMPTY_REFS)
       expect(json).to.be.deep.equal({
         kind: "ColumnsStreamed",
         column_source: m.ref(),
-        data: {foo: [1,2], bar: [3,4]},
+        data: {foo: [1, 2], bar: [3, 4]},
         rollover: undefined,
       })
     })
@@ -131,13 +131,13 @@ describe("events module", () => {
     it("should delegate generating json to a hint", () =>{
       const d = new Document()
       const m = new TestModel()
-      const hint = new events.ColumnsStreamedEvent(d, m.ref(), {foo: [1,2], bar: [3,4]})
+      const hint = new events.ColumnsStreamedEvent(d, m.ref(), {foo: [1, 2], bar: [3, 4]})
       const evt = new events.ModelChangedEvent(d, m, "foo", 1, 2, undefined, hint)
       const json = evt.json(EMPTY_REFS)
       expect(json).to.be.deep.equal({
         kind: "ColumnsStreamed",
         column_source: m.ref(),
-        data: {foo: [1,2], bar: [3,4]},
+        data: {foo: [1, 2], bar: [3, 4]},
         rollover: undefined,
       })
     })

--- a/bokehjs/test/models/axes/axis.ts
+++ b/bokehjs/test/models/axes/axis.ts
@@ -27,7 +27,7 @@ describe("Axis", () => {
     const plot_view = new plot.default_view({model: plot, parent: null}).build()
     const axis_view = plot_view.renderer_views[axis.id] as AxisView
 
-    expect(axis_view.compute_labels([0,2,4.0,6,8,10])).to.be.deep.equal(["zero", "2", "four", "6", "8", "ten"])
+    expect(axis_view.compute_labels([0, 2, 4.0, 6, 8, 10])).to.be.deep.equal(["zero", "2", "four", "6", "8", "ten"])
   })
 
   it("loc should return numeric fixed_location", () => {

--- a/bokehjs/test/models/formatters/func_tick_formatter.ts
+++ b/bokehjs/test/models/formatters/func_tick_formatter.ts
@@ -46,7 +46,7 @@ describe("func_tick_formatter module", () => {
         use_strict: true,
       })
       const labels = formatter.doFormat([0, 0, 0], {loc: 0})
-      expect(labels).to.be.deep.equal([3,3,3])
+      expect(labels).to.be.deep.equal([3, 3, 3])
     })
 
     it("should handle args appropriately", () => {

--- a/bokehjs/test/models/glyphs/ray.ts
+++ b/bokehjs/test/models/glyphs/ray.ts
@@ -17,7 +17,7 @@ describe("Ray", () => {
     })
 
     it("`_map_data` should correctly map data if length units are 'data'", () => {
-      for (const angle of [0,1,2,3]) {
+      for (const angle of [0, 1, 2, 3]) {
         const data = {x: [1], y: [2], angle: [angle], length: [10]}
         const glyph_view = create_glyph_view(glyph, data)
 
@@ -30,7 +30,7 @@ describe("Ray", () => {
     })
 
     it("`_map_data` should correctly map data if length units are 'screen'", () => {
-      for (const angle of [0,1,2,3]) {
+      for (const angle of [0, 1, 2, 3]) {
         const data = {x: [1], y: [2], angle: [angle], length: [10]}
         const glyph_view = create_glyph_view(glyph, data)
 
@@ -43,7 +43,7 @@ describe("Ray", () => {
     })
 
     it("`_map_data` should correctly map data if length units are 'data' and scale is reversed", () => {
-      for (const angle of [0,1,2,3]) {
+      for (const angle of [0, 1, 2, 3]) {
         const data = {x: [1], y: [2], angle: [angle], length: [10]}
         const glyph_view = create_glyph_view(glyph, data)
 
@@ -56,7 +56,7 @@ describe("Ray", () => {
     })
 
     it("`_map_data` should correctly map data if length units are 'screen' and scale is reversed", () => {
-      for (const angle of [0,1,2,3]) {
+      for (const angle of [0, 1, 2, 3]) {
         const data = {x: [1], y: [2], angle: [angle], length: [10]}
         const glyph_view = create_glyph_view(glyph, data)
 

--- a/bokehjs/test/models/graphs/static_layout_provider.ts
+++ b/bokehjs/test/models/graphs/static_layout_provider.ts
@@ -26,16 +26,16 @@ describe("StaticLayoutProvider", () => {
 
       it("should return node coords if exist", () => {
         const node_source = new ColumnDataSource()
-        node_source.data.index = [0,1,2,3]
+        node_source.data.index = [0, 1, 2, 3]
 
         const [xs, ys] = layout_provider.get_node_coordinates(node_source)
-        expect(xs).to.be.deep.equal([-1,0,1,0])
-        expect(ys).to.be.deep.equal([0,1,0,-1])
+        expect(xs).to.be.deep.equal([-1, 0, 1, 0])
+        expect(ys).to.be.deep.equal([0, 1, 0, -1])
       })
 
       it("should return NaNs if coords don't exist", () => {
         const node_source = new ColumnDataSource()
-        node_source.data.index = [4,5,6]
+        node_source.data.index = [4, 5, 6]
 
         const [xs, ys] = layout_provider.get_node_coordinates(node_source)
         expect(xs).to.be.deep.equal([NaN, NaN, NaN])
@@ -47,8 +47,8 @@ describe("StaticLayoutProvider", () => {
 
       it("should return edge coords if exist", () => {
         const edge_source = new ColumnDataSource()
-        edge_source.data.start = [0,0,0]
-        edge_source.data.end = [1,2,3]
+        edge_source.data.start = [0, 0, 0]
+        edge_source.data.end = [1, 2, 3]
 
         const [xs, ys] = layout_provider.get_edge_coordinates(edge_source)
         expect(xs).to.be.deep.equal([ [ -1, 0 ], [ -1, 1 ], [ -1, 0 ] ])
@@ -57,8 +57,8 @@ describe("StaticLayoutProvider", () => {
 
       it("should return explicit edge coords if exist", () => {
         const edge_source = new ColumnDataSource()
-        edge_source.data.start = [0,0,0]
-        edge_source.data.end = [1,2,3]
+        edge_source.data.start = [0, 0, 0]
+        edge_source.data.end = [1, 2, 3]
         edge_source.data.xs = [ [ -1, -0.5, 0 ], [ -1, 0, 1 ], [ -1, -0.5, 0 ] ]
         edge_source.data.ys = [ [ 0, 0.5, 1 ], [ 0, 0, 0 ], [ 0, -0.5, -1 ] ]
 
@@ -69,8 +69,8 @@ describe("StaticLayoutProvider", () => {
 
       it("should return NaNs if coords don't exist", () => {
         const edge_source = new ColumnDataSource()
-        edge_source.data.start = [4,4,4]
-        edge_source.data.end = [5,6,7]
+        edge_source.data.start = [4, 4, 4]
+        edge_source.data.end = [5, 6, 7]
 
         const [xs, ys] = layout_provider.get_edge_coordinates(edge_source)
         expect(xs).to.be.deep.equal([ [ NaN, NaN ], [ NaN, NaN ], [ NaN, NaN ] ])
@@ -79,8 +79,8 @@ describe("StaticLayoutProvider", () => {
 
       it("should not return explicit edge coords if coords don't exist", () => {
         const edge_source = new ColumnDataSource()
-        edge_source.data.start = [4,4,4]
-        edge_source.data.end = [5,6,7]
+        edge_source.data.start = [4, 4, 4]
+        edge_source.data.end = [5, 6, 7]
         edge_source.data.xs = [ [ -1, -0.5, 0 ], [ -1, 0, 1 ], [ -1, -0.5, 0 ] ]
         edge_source.data.ys = [ [ 0, 0.5, 1 ], [ 0, 0, 0 ], [ 0, -0.5, -1 ] ]
 

--- a/bokehjs/test/models/grids/grid.ts
+++ b/bokehjs/test/models/grids/grid.ts
@@ -75,7 +75,7 @@ describe("Grid", () => {
     const grid_view = plot_view.renderer_views[grid.id] as GridView
 
     expect(grid_view.grid_coords('major')).to.be.deep.equal([
-      [[2,2],      [4,4],      [6,6],      [8,8]     ],
+      [[2, 2],     [4, 4],     [6, 6],     [8, 8]    ],
       [[0.1, 9.9], [0.1, 9.9], [0.1, 9.9], [0.1, 9.9]],
     ])
   })

--- a/bokehjs/test/models/ranges/factor_range.ts
+++ b/bokehjs/test/models/ranges/factor_range.ts
@@ -219,7 +219,7 @@ describe("factor_range module", () => {
         const r4 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4']], 0, 0, 1)
         expect(r4[0]).to.deep.equal({
           a: {value: 2.5, mapping: {1: {value: 1.5}, 2: {value: 2.5}, 3: {value: 3.5}}},
-          b: {value: 5  , mapping: {1: {value: 4.5}, 4: {value: 5.5}}},
+          b: {value: 5, mapping: {1: {value: 4.5}, 4: {value: 5.5}}},
         })
         expect(r4[1]).to.deep.equal(['a', 'b'])
         expect(r4[2]).to.be.equal(0)
@@ -227,7 +227,7 @@ describe("factor_range module", () => {
         const r5 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4'], ['c', '0']], 0, 0, 1)
         expect(r5[0]).to.deep.equal({
           a: {value: 2.5, mapping: {1: {value: 1.5}, 2: {value: 2.5}, 3: {value: 3.5}}},
-          b: {value: 5  , mapping: {1: {value: 4.5}, 4: {value: 5.5}}},
+          b: {value: 5, mapping: {1: {value: 4.5}, 4: {value: 5.5}}},
           c: {value: 6.5, mapping: {0: {value: 6.5}}},
         })
         expect(r5[1]).to.deep.equal(['a', 'b', 'c'])
@@ -318,15 +318,15 @@ describe("factor_range module", () => {
         const r4 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4']], 2, 0, 1)
         expect(r4[0]).to.deep.equal({
           a: {value: 2.5, mapping: {1: {value: 1.5}, 2: {value: 2.5}, 3: {value: 3.5}}},
-          b: {value: 7  , mapping: {1: {value: 6.5}, 4: {value: 7.5}}},
+          b: {value: 7, mapping: {1: {value: 6.5}, 4: {value: 7.5}}},
         })
         expect(r4[1]).to.deep.equal(['a', 'b'])
         expect(r4[2]).to.be.equal(2)
 
         const r5 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4'], ['c', '0']], 2, 0, 1)
         expect(r5[0]).to.deep.equal({
-          a: {value: 2.5 , mapping: {1: {value:  1.5}, 2: {value: 2.5}, 3: {value: 3.5}}},
-          b: {value: 7   , mapping: {1: {value:  6.5}, 4: {value: 7.5}}},
+          a: {value: 2.5, mapping: {1: {value:  1.5}, 2: {value: 2.5}, 3: {value: 3.5}}},
+          b: {value: 7, mapping: {1: {value:  6.5}, 4: {value: 7.5}}},
           c: {value: 10.5, mapping: {0: {value: 10.5}}},
         })
         expect(r5[1]).to.deep.equal(['a', 'b', 'c'])

--- a/bokehjs/test/models/scales/categorical_scale.ts
+++ b/bokehjs/test/models/scales/categorical_scale.ts
@@ -158,19 +158,19 @@ describe("categorical_scale module", () => {
         const scale = mkscale()
 
         const values0 = scale.v_compute([
-          ['foo',-0.6], ['foo',-0.5], ['foo',-0.2], ['foo',-0.1], ['foo',0.0], ['foo',0.1], ['foo',0.2], ['foo',0.5], ['foo',0.6],
+          ['foo', -0.6], ['foo', -0.5], ['foo', -0.2], ['foo', -0.1], ['foo', 0.0], ['foo', 0.1], ['foo', 0.2], ['foo', 0.5], ['foo', 0.6],
         ])
-        expect(values0).to.deep.equal(new Float64Array([18,20,26,28,30,32,34,40,42]))
+        expect(values0).to.deep.equal(new Float64Array([18, 20, 26, 28, 30, 32, 34, 40, 42]))
 
         const values1 = scale.v_compute([
-          ['bar',-0.6], ['bar',-0.5], ['bar',-0.2], ['bar',-0.1], ['bar',0.0], ['bar',0.1], ['bar',0.2], ['bar',0.5], ['bar',0.6],
+          ['bar', -0.6], ['bar', -0.5], ['bar', -0.2], ['bar', -0.1], ['bar', 0.0], ['bar', 0.1], ['bar', 0.2], ['bar', 0.5], ['bar', 0.6],
         ])
-        expect(values1).to.deep.equal(new Float64Array([38,40,46,48,50,52,54,60,62]))
+        expect(values1).to.deep.equal(new Float64Array([38, 40, 46, 48, 50, 52, 54, 60, 62]))
 
         const values2 = scale.v_compute([
-          ['baz',-0.6], ['baz',-0.5], ['baz',-0.2], ['baz',-0.1], ['baz',0.0], ['baz',0.1], ['baz',0.2], ['baz',0.5], ['baz',0.6],
+          ['baz', -0.6], ['baz', -0.5], ['baz', -0.2], ['baz', -0.1], ['baz', 0.0], ['baz', 0.1], ['baz', 0.2], ['baz', 0.5], ['baz', 0.6],
         ])
-        expect(values2).to.deep.equal(new Float64Array([58,60,66,68,70,72,74,80,82]))
+        expect(values2).to.deep.equal(new Float64Array([58, 60, 66, 68, 70, 72, 74, 80, 82]))
       })
     })
   })

--- a/bokehjs/test/models/scales/linear_scale.ts
+++ b/bokehjs/test/models/scales/linear_scale.ts
@@ -28,11 +28,11 @@ describe("linear_scale module", () => {
     })
 
     it("should vector map values linearly", () => {
-      expect(scale.v_compute([-1,0,5,10,11])).to.be.deep.equal(new Float64Array([14,20,50,80,86]))
+      expect(scale.v_compute([-1, 0, 5, 10, 11])).to.be.deep.equal(new Float64Array([14, 20, 50, 80, 86]))
     })
 
     it("should map to a Float64Array", () => {
-      expect(scale.v_compute([-1,0,5,10,11])).to.be.instanceof(Float64Array)
+      expect(scale.v_compute([-1, 0, 5, 10, 11])).to.be.instanceof(Float64Array)
     })
 
     it("should inverse map values linearly", () => {
@@ -44,11 +44,11 @@ describe("linear_scale module", () => {
     })
 
     it("should vector in inverse map values linearly", () => {
-      expect(scale.v_invert([14,20,50,80,86])).to.be.deep.equal(new Float64Array([-1,0,5,10,11]))
+      expect(scale.v_invert([14, 20, 50, 80, 86])).to.be.deep.equal(new Float64Array([-1, 0, 5, 10, 11]))
     })
 
     it("should inverse map to a Float64Array", () => {
-      expect(scale.v_invert([-1,0,5,10,11])).to.be.instanceof(Float64Array)
+      expect(scale.v_invert([-1, 0, 5, 10, 11])).to.be.instanceof(Float64Array)
     })
   })
 })

--- a/bokehjs/test/models/scales/log_scale.ts
+++ b/bokehjs/test/models/scales/log_scale.ts
@@ -57,12 +57,12 @@ describe("LogScale module", () => {
 
     it("should vector map values logly", () => {
       const scale = mkscale()
-      expect(scale.v_compute([1,10,100,10000])).to.be.deep.equal(new Float64Array([10, 35, 60, 110]))
+      expect(scale.v_compute([1, 10, 100, 10000])).to.be.deep.equal(new Float64Array([10, 35, 60, 110]))
     })
 
     it("should map to a Float64Array", () => {
       const scale = mkscale()
-      expect(scale.v_compute([-1,0,5,10,11])).to.be.instanceof(Float64Array)
+      expect(scale.v_compute([-1, 0, 5, 10, 11])).to.be.instanceof(Float64Array)
     })
   })
 

--- a/bokehjs/test/models/sources/column_data_source.ts
+++ b/bokehjs/test/models/sources/column_data_source.ts
@@ -44,159 +44,159 @@ describe("column_data_source module", () => {
     describe("with single integer index", () => {
 
       it("should patch Arrays to Arrays", () => {
-        const a = [1,2,3,4,5]
+        const a = [1, 2, 3, 4, 5]
         patch_to_column(a, [[3, 100]], [])
         expect(a).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([1,2,3,100,5])
+        expect(a).to.be.deep.equal([1, 2, 3, 100, 5])
 
         patch_to_column(a, [[2, 101]], [])
         expect(a).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([1,2,101,100,5])
+        expect(a).to.be.deep.equal([1, 2, 101, 100, 5])
       })
 
       it("should patch typed Arrays to typed Arrays", () => {
         for (const typ of [Float32Array, Float64Array, Int32Array]) {
-          const a = new typ([1,2,3,4,5])
+          const a = new typ([1, 2, 3, 4, 5])
           patch_to_column(a, [[3, 100]], [])
           expect(a).to.be.instanceof(typ)
-          expect(a).to.be.deep.equal(new typ([1,2,3,100,5]))
+          expect(a).to.be.deep.equal(new typ([1, 2, 3, 100, 5]))
 
           patch_to_column(a, [[2, 101]], [])
           expect(a).to.be.instanceof(typ)
-          expect(a).to.be.deep.equal(new typ([1,2,101,100,5]))
+          expect(a).to.be.deep.equal(new typ([1, 2, 101, 100, 5]))
         }
       })
 
       it("should handle multi-part patches", () => {
-        const a = [1,2,3,4,5]
+        const a = [1, 2, 3, 4, 5]
         patch_to_column(a, [[3, 100], [0, 10], [4, -1]], [])
         expect(a).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([10,2,3,100,-1])
+        expect(a).to.be.deep.equal([10, 2, 3, 100, -1])
       })
 
       it("should return a Set of the patched indices", () => {
-        const a = [1,2,3,4,5]
+        const a = [1, 2, 3, 4, 5]
         const s = patch_to_column(a, [[3, 100], [0, 10], [4, -1]], [])
         expect(s).to.be.instanceof(Set)
-        expect(s.diff(new Set([0,3,4])).values).to.be.deep.equal([])
+        expect(s.diff(new Set([0, 3, 4])).values).to.be.deep.equal([])
       })
     })
 
     describe("with single slice index", () => {
 
       it("should patch Arrays to Arrays", () => {
-        const a = [1,2,3,4,5]
-        patch_to_column(a, [[{start:2,stop:4,step:1}, [100, 101]]], [])
+        const a = [1, 2, 3, 4, 5]
+        patch_to_column(a, [[{start:2, stop:4, step:1}, [100, 101]]], [])
         expect(a).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([1,2,100,101,5])
+        expect(a).to.be.deep.equal([1, 2, 100, 101, 5])
 
-        patch_to_column(a, [[{start:1,stop:3,step:1}, [99, 102]]], [])
+        patch_to_column(a, [[{start:1, stop:3, step:1}, [99, 102]]], [])
         expect(a).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([1,99,102,101,5])
+        expect(a).to.be.deep.equal([1, 99, 102, 101, 5])
       })
 
       it("should patch typed Arrays to typed Arrays", () => {
         for (const typ of [Float32Array, Float64Array, Int32Array]) {
-          const a = new typ([1,2,3,4,5])
-          patch_to_column(a, [[{start:2,stop:4,step:1}, [100, 101]]], [])
+          const a = new typ([1, 2, 3, 4, 5])
+          patch_to_column(a, [[{start:2, stop:4, step:1}, [100, 101]]], [])
           expect(a).to.be.instanceof(typ)
-          expect(a).to.be.deep.equal(new typ([1,2,100,101,5]))
+          expect(a).to.be.deep.equal(new typ([1, 2, 100, 101, 5]))
 
-          patch_to_column(a, [[{start:1,stop:3,step:1}, [99, 102]]], [])
+          patch_to_column(a, [[{start:1, stop:3, step:1}, [99, 102]]], [])
           expect(a).to.be.instanceof(typ)
-          expect(a).to.be.deep.equal(new typ([1,99,102,101,5]))
+          expect(a).to.be.deep.equal(new typ([1, 99, 102, 101, 5]))
         }
       })
 
       it("should handle patch indices with strides", () => {
-        const a = new Int32Array([1,2,3,4,5])
-        patch_to_column(a, [[{start:1,stop:5,step:2}, [100, 101]]], [])
+        const a = new Int32Array([1, 2, 3, 4, 5])
+        patch_to_column(a, [[{start:1, stop:5, step:2}, [100, 101]]], [])
         expect(a).to.be.instanceof(Int32Array)
-        expect(a).to.be.deep.equal(new Int32Array([1,100,3,101,5]))
+        expect(a).to.be.deep.equal(new Int32Array([1, 100, 3, 101, 5]))
       })
 
       it("should handle multi-part patches", () => {
-        const a = [1,2,3,4,5]
-        patch_to_column(a, [[{start:2,stop:4,step:1}, [100, 101]], [{stop:1, step:1}, [10]], [4, -1]], [])
+        const a = [1, 2, 3, 4, 5]
+        patch_to_column(a, [[{start:2, stop:4, step:1}, [100, 101]], [{stop:1, step:1}, [10]], [4, -1]], [])
         expect(a).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([10,2,100,101,-1])
+        expect(a).to.be.deep.equal([10, 2, 100, 101, -1])
       })
 
       it("should return a Set of the patched indices", () => {
-        const a = [1,2,3,4,5]
-        const s = patch_to_column(a, [[{start:2,stop:4,step:1}, [100, 101]], [{stop:1, step:1}, [10]], [4, -1]], [])
+        const a = [1, 2, 3, 4, 5]
+        const s = patch_to_column(a, [[{start:2, stop:4, step:1}, [100, 101]], [{stop:1, step:1}, [10]], [4, -1]], [])
         expect(s).to.be.instanceof(Set)
-        expect(s.diff(new Set([0,2,3,4])).values).to.be.deep.equal([])
+        expect(s.diff(new Set([0, 2, 3, 4])).values).to.be.deep.equal([])
       })
     })
 
     describe("with multi-index for 1d subarrays", () => {
 
       it("should patch Arrays to Arrays", () => {
-        const a = [1,2,3,4,5]
+        const a = [1, 2, 3, 4, 5]
         const b = [10, 20, -1, -2, 0, 10]
-        const c = [1,2,3,4]
+        const c = [1, 2, 3, 4]
         patch_to_column([a, b, c], [
-          [[0, {start:2,stop:4,step:1}], [100, 101]],
+          [[0, {start:2, stop:4, step:1}], [100, 101]],
         ], [[5], [6], [4]])
         expect(a).to.be.instanceof(Array)
         expect(b).to.be.instanceof(Array)
         expect(c).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([1,2,100,101,5])
+        expect(a).to.be.deep.equal([1, 2, 100, 101, 5])
         expect(b).to.be.deep.equal([10, 20, -1, -2, 0, 10])
-        expect(c).to.be.deep.equal([1,2,3,4])
+        expect(c).to.be.deep.equal([1, 2, 3, 4])
 
         patch_to_column([a, b, c], [
-          [[1, {start:2,stop:4,step:1}], [100, 101]],
+          [[1, {start:2, stop:4, step:1}], [100, 101]],
         ], [[5], [6], [4]])
         expect(a).to.be.instanceof(Array)
         expect(b).to.be.instanceof(Array)
         expect(c).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([1,2,100,101,5])
+        expect(a).to.be.deep.equal([1, 2, 100, 101, 5])
         expect(b).to.be.deep.equal([10, 20, 100, 101, 0, 10])
-        expect(c).to.be.deep.equal([1,2,3,4])
+        expect(c).to.be.deep.equal([1, 2, 3, 4])
       })
 
       it("should patch typed Arrays to typed Arrays", () => {
         for (const typ of [Float32Array, Float64Array, Int32Array]) {
-          const a = new typ([1,2,3,4,5])
+          const a = new typ([1, 2, 3, 4, 5])
           const b = new typ([10, 20, -1, -2, 0, 10])
-          const c = new typ([1,2,3,4])
+          const c = new typ([1, 2, 3, 4])
           patch_to_column([a, b, c], [
-            [[0, {start:2,stop:4,step:1}], [100, 101]],
+            [[0, {start:2, stop:4, step:1}], [100, 101]],
           ], [[5], [6], [4]])
           expect(a).to.be.instanceof(typ)
           expect(b).to.be.instanceof(typ)
           expect(c).to.be.instanceof(typ)
-          expect(a).to.be.deep.equal(new typ([1,2,100,101,5]))
+          expect(a).to.be.deep.equal(new typ([1, 2, 100, 101, 5]))
           expect(b).to.be.deep.equal(new typ([10, 20, -1, -2, 0, 10]))
-          expect(c).to.be.deep.equal(new typ([1,2,3,4]))
+          expect(c).to.be.deep.equal(new typ([1, 2, 3, 4]))
 
           patch_to_column([a, b, c], [
-            [[1, {start:2,stop:4,step:1}], [100, 101]],
+            [[1, {start:2, stop:4, step:1}], [100, 101]],
           ], [[5], [6], [4]])
           expect(a).to.be.instanceof(typ)
           expect(b).to.be.instanceof(typ)
           expect(c).to.be.instanceof(typ)
-          expect(a).to.be.deep.equal(new typ([1,2,100,101,5]))
+          expect(a).to.be.deep.equal(new typ([1, 2, 100, 101, 5]))
           expect(b).to.be.deep.equal(new typ([10, 20, 100, 101, 0, 10]))
-          expect(c).to.be.deep.equal(new typ([1,2,3,4]))
+          expect(c).to.be.deep.equal(new typ([1, 2, 3, 4]))
         }
       })
 
       it("should handle patch indices with strides", () => {
-        const a = new Int32Array([1,2,3,4,5])
+        const a = new Int32Array([1, 2, 3, 4, 5])
         const b = new Int32Array([10, 20, -1, -2, 0, 10])
-        const c = new Int32Array([1,2,3,4])
-        patch_to_column([a, b,c], [
-          [[0, {start:1,stop:5,step:2}], [100, 101]],
+        const c = new Int32Array([1, 2, 3, 4])
+        patch_to_column([a, b, c], [
+          [[0, {start:1, stop:5, step:2}], [100, 101]],
         ], [[5], [6], [4]])
         expect(a).to.be.instanceof(Int32Array)
         expect(b).to.be.instanceof(Int32Array)
         expect(c).to.be.instanceof(Int32Array)
-        expect(a).to.be.deep.equal(new Int32Array([1,100,3,101,5]))
+        expect(a).to.be.deep.equal(new Int32Array([1, 100, 3, 101, 5]))
         expect(b).to.be.deep.equal(new Int32Array([10, 20, -1, -2, 0, 10]))
-        expect(c).to.be.deep.equal(new Int32Array([1,2,3,4]))
+        expect(c).to.be.deep.equal(new Int32Array([1, 2, 3, 4]))
 
         patch_to_column([a, b, c], [
           [[1, {step:3}], [100, 101]],
@@ -204,147 +204,147 @@ describe("column_data_source module", () => {
         expect(a).to.be.instanceof(Int32Array)
         expect(b).to.be.instanceof(Int32Array)
         expect(c).to.be.instanceof(Int32Array)
-        expect(a).to.be.deep.equal(new Int32Array([1,100,3,101,5]))
+        expect(a).to.be.deep.equal(new Int32Array([1, 100, 3, 101, 5]))
         expect(b).to.be.deep.equal(new Int32Array([100, 20, -1, 101, 0, 10]))
-        expect(c).to.be.deep.equal(new Int32Array([1,2,3,4]))
+        expect(c).to.be.deep.equal(new Int32Array([1, 2, 3, 4]))
       })
 
       it("should handle multi-part patches", () => {
-        const a = [1,2,3,4,5]
+        const a = [1, 2, 3, 4, 5]
         const b = [10, 20, -1, -2, 0, 10]
-        const c = [1,2,3,4]
+        const c = [1, 2, 3, 4]
         patch_to_column([a, b, c], [
-          [[0, {start:2,stop:4,step:1}], [100, 101]],
+          [[0, {start:2, stop:4, step:1}], [100, 101]],
           [[1, {stop:2, step:1}], [999, 999]],
           [[1, 5], [6]],
         ], [[5], [6], [4]])
         expect(a).to.be.instanceof(Array)
         expect(b).to.be.instanceof(Array)
         expect(c).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([1,2,100,101,5])
+        expect(a).to.be.deep.equal([1, 2, 100, 101, 5])
         expect(b).to.be.deep.equal([999, 999, -1, -2, 0, 6])
-        expect(c).to.be.deep.equal([1,2,3,4])
+        expect(c).to.be.deep.equal([1, 2, 3, 4])
       })
 
       it("should return a Set of the patched indices", () => {
-        const a = [1,2,3,4,5]
+        const a = [1, 2, 3, 4, 5]
         const b = [10, 20, -1, -2, 0, 10]
-        const c = [1,2,3,4]
+        const c = [1, 2, 3, 4]
         const s = patch_to_column([a, b, c], [
-          [[0, {start:2,stop:4,step:1}], [100, 101]],
+          [[0, {start:2, stop:4, step:1}], [100, 101]],
           [[1, {stop:2, step:1}], [999, 999]],
           [[1, 5], [6]],
         ], [[5], [6], [4]])
         expect(s).to.be.instanceof(Set)
-        expect(s.diff(new Set([0,1])).values).to.be.deep.equal([])
+        expect(s.diff(new Set([0, 1])).values).to.be.deep.equal([])
       })
     })
 
     describe("with multi-index for 2d subarrays", () => {
 
       it("should patch Arrays to Arrays", () => {
-        const a = [1,2,3, 4,5,6]
+        const a = [1, 2, 3, 4, 5, 6]
         const b = [10, 20, -1, -2, 0, 10]
-        const c = [1,2]
-        patch_to_column([a, b, c], [[[0, {}, 2], [100, 101]]], [[2,3], [3,2], [1,2]])
+        const c = [1, 2]
+        patch_to_column([a, b, c], [[[0, {}, 2], [100, 101]]], [[2, 3], [3, 2], [1, 2]])
         expect(a).to.be.instanceof(Array)
         expect(b).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([1,2,100, 4,5,101])
+        expect(a).to.be.deep.equal([1, 2, 100, 4, 5, 101])
         expect(b).to.be.deep.equal([10, 20, -1, -2, 0, 10])
-        expect(c).to.be.deep.equal([1,2])
+        expect(c).to.be.deep.equal([1, 2])
 
         patch_to_column([a, b, c], [
-          [[1, {start:0,stop:2,step:1}, {start:0,stop:1,step:1}], [100, 101]],
-        ], [[2,3], [3,2], [1,2]])
+          [[1, {start:0, stop:2, step:1}, {start:0, stop:1, step:1}], [100, 101]],
+        ], [[2, 3], [3, 2], [1, 2]])
         expect(a).to.be.instanceof(Array)
         expect(b).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([1,2,100, 4,5,101])
+        expect(a).to.be.deep.equal([1, 2, 100, 4, 5, 101])
         expect(b).to.be.deep.equal([100, 20, 101, -2, 0, 10])
-        expect(c).to.be.deep.equal([1,2])
+        expect(c).to.be.deep.equal([1, 2])
       })
 
       it("should patch typed Arrays to types Arrays", () => {
         for (const typ of [Float32Array, Float64Array, Int32Array]) {
-          const a = new typ([1,2,3,
-                       4,5,6])
+          const a = new typ([1, 2, 3,
+                       4, 5, 6])
           const b = new typ([10, 20,
                        -1, -2,
                         0, 10])
-          const c = new typ([1,2])
+          const c = new typ([1, 2])
           patch_to_column([a, b, c], [
             [[0, {}, 2], [100, 101]],
-          ], [[2,3], [3,2], [1,2]])
+          ], [[2, 3], [3, 2], [1, 2]])
           expect(a).to.be.instanceof(typ)
           expect(b).to.be.instanceof(typ)
           expect(c).to.be.instanceof(typ)
-          expect(a).to.be.deep.equal(new typ([1,2,100, 4,5,101]))
+          expect(a).to.be.deep.equal(new typ([1, 2, 100, 4, 5, 101]))
           expect(b).to.be.deep.equal(new typ([10, 20, -1, -2, 0, 10]))
-          expect(c).to.be.deep.equal(new typ([1,2]))
+          expect(c).to.be.deep.equal(new typ([1, 2]))
 
           patch_to_column([a, b, c], [
-            [[1, {start:0,stop:2,step:1}, {start:0,stop:1,step:1}], [100, 101]],
-          ], [[2,3], [3,2], [1,2]])
+            [[1, {start:0, stop:2, step:1}, {start:0, stop:1, step:1}], [100, 101]],
+          ], [[2, 3], [3, 2], [1, 2]])
           expect(a).to.be.instanceof(typ)
           expect(b).to.be.instanceof(typ)
           expect(c).to.be.instanceof(typ)
-          expect(a).to.be.deep.equal(new typ([1,2,100, 4,5,101]))
+          expect(a).to.be.deep.equal(new typ([1, 2, 100, 4, 5, 101]))
           expect(b).to.be.deep.equal(new typ([100, 20, 101, -2, 0, 10]))
-          expect(c).to.be.deep.equal(new typ([1,2]))
+          expect(c).to.be.deep.equal(new typ([1, 2]))
         }
       })
 
       it("should handle patch indices with strides", () => {
-        const a = new Int32Array([1,2,3,4,5,6])
+        const a = new Int32Array([1, 2, 3, 4, 5, 6])
         const b = new Int32Array([10, 20, -1, -2, 0, 10])
-        const c = new Int32Array([1,2])
+        const c = new Int32Array([1, 2])
         patch_to_column([a, b, c], [
           [[0, {step:1}, 2], [100, 101]],
-        ], [[2,3], [3,2], [1,2]])
+        ], [[2, 3], [3, 2], [1, 2]])
         expect(a).to.be.instanceof(Int32Array)
         expect(b).to.be.instanceof(Int32Array)
         expect(c).to.be.instanceof(Int32Array)
-        expect(a).to.be.deep.equal(new Int32Array([1,2,100, 4,5,101]))
+        expect(a).to.be.deep.equal(new Int32Array([1, 2, 100, 4, 5, 101]))
         expect(b).to.be.deep.equal(new Int32Array([10, 20, -1, -2, 0, 10]))
-        expect(c).to.be.deep.equal(new Int32Array([1,2]))
+        expect(c).to.be.deep.equal(new Int32Array([1, 2]))
 
         patch_to_column([a, b, c], [
-          [[1, {start:0,stop:3,step:2}, {start:0,stop:1,step:1}], [100, 101]],
-        ], [[2,3], [3,2], [1,2]])
+          [[1, {start:0, stop:3, step:2}, {start:0, stop:1, step:1}], [100, 101]],
+        ], [[2, 3], [3, 2], [1, 2]])
         expect(a).to.be.instanceof(Int32Array)
         expect(b).to.be.instanceof(Int32Array)
         expect(c).to.be.instanceof(Int32Array)
-        expect(c).to.be.deep.equal(new Int32Array([1,2]))
-        expect(a).to.be.deep.equal(new Int32Array([1,2,100, 4,5,101]))
+        expect(c).to.be.deep.equal(new Int32Array([1, 2]))
+        expect(a).to.be.deep.equal(new Int32Array([1, 2, 100, 4, 5, 101]))
         expect(b).to.be.deep.equal(new Int32Array([100, 20, -1, -2, 101, 10]))
-        expect(c).to.be.deep.equal(new Int32Array([1,2]))
+        expect(c).to.be.deep.equal(new Int32Array([1, 2]))
       })
 
       it("should handle multi-part patches", () => {
-        const a = [1,2,3, 4,5,6]
+        const a = [1, 2, 3, 4, 5, 6]
         const b = [10, 20, -1, -2, 0, 10]
-        const c = [1,2]
+        const c = [1, 2]
         patch_to_column([a, b, c], [
           [[0, {step:1}, 2], [100, 101]],
-          [[1, {start:0,stop:2,step:1}, {start:0,stop:1,step:1}], [100, 101]],
-        ], [[2,3], [3,2], [1,2]])
+          [[1, {start:0, stop:2, step:1}, {start:0, stop:1, step:1}], [100, 101]],
+        ], [[2, 3], [3, 2], [1, 2]])
         expect(a).to.be.instanceof(Array)
         expect(b).to.be.instanceof(Array)
         expect(c).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([1,2,100, 4,5,101])
+        expect(a).to.be.deep.equal([1, 2, 100, 4, 5, 101])
         expect(b).to.be.deep.equal([100, 20, 101, -2, 0, 10])
         expect(c).to.be.deep.equal([1, 2])
       })
 
       it("should return a Set of the patched indices", () => {
-        const a = [1,2,3, 4,5,6]
+        const a = [1, 2, 3, 4, 5, 6]
         const b = [10, 20, -1, -2, 0, 10]
-        const c = [1,2]
+        const c = [1, 2]
         const s = patch_to_column([a, b, c], [
           [[0, {step:1}, 2], [100, 101]],
-          [[1, {start:0,stop:2,step:1}, {start:0,stop:1,step:1}], [100, 101]],
-        ], [[2,3], [3,2], [1,2]])
+          [[1, {start:0, stop:2, step:1}, {start:0, stop:1, step:1}], [100, 101]],
+        ], [[2, 3], [3, 2], [1, 2]])
         expect(s).to.be.instanceof(Set)
-        expect(s.diff(new Set([0,1])).values).to.be.deep.equal([])
+        expect(s.diff(new Set([0, 1])).values).to.be.deep.equal([])
       })
     })
   })
@@ -352,103 +352,103 @@ describe("column_data_source module", () => {
   describe("stream_to_column", () => {
 
     it("should stream Arrays to Arrays", () => {
-      const a = [1,2,3,4,5]
+      const a = [1, 2, 3, 4, 5]
       const r = stream_to_column(a, [100, 200])
       expect(r).to.be.instanceof(Array)
-      expect(r).to.be.deep.equal([1,2,3,4,5,100,200])
+      expect(r).to.be.deep.equal([1, 2, 3, 4, 5, 100, 200])
     })
 
     it("should stream Arrays to Arrays with rollover", () => {
-      const a0 = [1,2,3,4,5]
+      const a0 = [1, 2, 3, 4, 5]
       const r0 = stream_to_column(a0, [100, 200, 300], 5)
       expect(r0).to.be.instanceof(Array)
-      expect(r0).to.be.deep.equal([4,5,100,200,300])
+      expect(r0).to.be.deep.equal([4, 5, 100, 200, 300])
 
-      const a1 = [1,2,3,4,5]
+      const a1 = [1, 2, 3, 4, 5]
       const r1 = stream_to_column(a1, [100, 200, 300], 6)
       expect(r1).to.be.instanceof(Array)
-      expect(r1).to.be.deep.equal([3,4,5,100,200,300])
+      expect(r1).to.be.deep.equal([3, 4, 5, 100, 200, 300])
     })
 
     it("should stream Float32 to Float32", () => {
-      const a = new Float32Array([1,2,3,4,5])
+      const a = new Float32Array([1, 2, 3, 4, 5])
       const r = stream_to_column(a, [100, 200])
       expect(r).to.be.instanceof(Float32Array)
-      expect(r).to.be.deep.equal(new Float32Array([1,2,3,4,5,100,200]))
+      expect(r).to.be.deep.equal(new Float32Array([1, 2, 3, 4, 5, 100, 200]))
     })
 
     it("should stream Float32 to Float32 with rollover", () => {
       // test when col is already at rollover len
-      const a0 = new Float32Array([1,2,3,4,5])
+      const a0 = new Float32Array([1, 2, 3, 4, 5])
       const r0 = stream_to_column(a0, [100, 200, 300], 5)
       expect(r0).to.be.instanceof(Float32Array)
-      expect(r0).to.be.deep.equal(new Float32Array([4,5,100,200,300]))
+      expect(r0).to.be.deep.equal(new Float32Array([4, 5, 100, 200, 300]))
 
       // test when col is not at rollover len but will exceed
-      const a1 = new Float32Array([1,2,3,4,5])
+      const a1 = new Float32Array([1, 2, 3, 4, 5])
       const r1 = stream_to_column(a1, [100, 200, 300], 6)
       expect(r1).to.be.instanceof(Float32Array)
-      expect(r1).to.be.deep.equal(new Float32Array([3,4,5,100,200,300]))
+      expect(r1).to.be.deep.equal(new Float32Array([3, 4, 5, 100, 200, 300]))
 
       // test when col is not at rollover len and will not exceed
-      const a2 = new Float32Array([1,2,3,4,5])
+      const a2 = new Float32Array([1, 2, 3, 4, 5])
       const r2 = stream_to_column(a2, [100, 200, 300], 10)
       expect(r2).to.be.instanceof(Float32Array)
-      expect(r2).to.be.deep.equal(new Float32Array([1,2,3,4,5,100,200,300]))
+      expect(r2).to.be.deep.equal(new Float32Array([1, 2, 3, 4, 5, 100, 200, 300]))
     })
 
     it("should stream Float64 to Float64", () => {
-      const a = new Float64Array([1,2,3,4,5])
+      const a = new Float64Array([1, 2, 3, 4, 5])
       const r = stream_to_column(a, [100, 200])
       expect(r).to.be.instanceof(Float64Array)
-      expect(r).to.be.deep.equal(new Float64Array([1,2,3,4,5,100,200]))
+      expect(r).to.be.deep.equal(new Float64Array([1, 2, 3, 4, 5, 100, 200]))
     })
 
     it("should stream Float64 to Float64 with rollover", () => {
       // test when col is already at rollover len
-      const a0 = new Float64Array([1,2,3,4,5])
+      const a0 = new Float64Array([1, 2, 3, 4, 5])
       const r0 = stream_to_column(a0, [100, 200, 300], 5)
       expect(r0).to.be.instanceof(Float64Array)
-      expect(r0).to.be.deep.equal(new Float64Array([4,5,100,200,300]))
+      expect(r0).to.be.deep.equal(new Float64Array([4, 5, 100, 200, 300]))
 
       // test when col is not at rollover len but will exceed
-      const a1 = new Float64Array([1,2,3,4,5])
+      const a1 = new Float64Array([1, 2, 3, 4, 5])
       const r1 = stream_to_column(a1, [100, 200, 300], 6)
       expect(r1).to.be.instanceof(Float64Array)
-      expect(r1).to.be.deep.equal(new Float64Array([3,4,5,100,200,300]))
+      expect(r1).to.be.deep.equal(new Float64Array([3, 4, 5, 100, 200, 300]))
 
       // test when col is not at rollover len and will not exceed
-      const a2 = new Float64Array([1,2,3,4,5])
+      const a2 = new Float64Array([1, 2, 3, 4, 5])
       const r2 = stream_to_column(a2, [100, 200, 300], 10)
       expect(r2).to.be.instanceof(Float64Array)
-      expect(r2).to.be.deep.equal(new Float64Array([1,2,3,4,5,100,200,300]))
+      expect(r2).to.be.deep.equal(new Float64Array([1, 2, 3, 4, 5, 100, 200, 300]))
     })
 
     it("should stream Int32 to Int32", () => {
-      const a = new Int32Array([1,2,3,4,5])
+      const a = new Int32Array([1, 2, 3, 4, 5])
       const r = stream_to_column(a, [100, 200])
       expect(r).to.be.instanceof(Int32Array)
-      expect(r).to.be.deep.equal(new Int32Array([1,2,3,4,5,100,200]))
+      expect(r).to.be.deep.equal(new Int32Array([1, 2, 3, 4, 5, 100, 200]))
     })
 
     it("should stream Int32 to Int32 with rollover", () => {
       // test when col is already at rollover len
-      const a0 = new Int32Array([1,2,3,4,5])
+      const a0 = new Int32Array([1, 2, 3, 4, 5])
       const r0 = stream_to_column(a0, [100, 200, 300], 5)
       expect(r0).to.be.instanceof(Int32Array)
-      expect(r0).to.be.deep.equal(new Int32Array([4,5,100,200,300]))
+      expect(r0).to.be.deep.equal(new Int32Array([4, 5, 100, 200, 300]))
 
       // test when col is not at rollover len but will exceed
-      const a1 = new Int32Array([1,2,3,4,5])
+      const a1 = new Int32Array([1, 2, 3, 4, 5])
       const r1 = stream_to_column(a1, [100, 200, 300], 6)
       expect(r1).to.be.instanceof(Int32Array)
-      expect(r1).to.be.deep.equal(new Int32Array([3,4,5,100,200,300]))
+      expect(r1).to.be.deep.equal(new Int32Array([3, 4, 5, 100, 200, 300]))
 
       // test when col is not at rollover len and will not exceed
-      const a2 = new Int32Array([1,2,3,4,5])
+      const a2 = new Int32Array([1, 2, 3, 4, 5])
       const r2 = stream_to_column(a2, [100, 200, 300], 10)
       expect(r2).to.be.instanceof(Int32Array)
-      expect(r2).to.be.deep.equal(new Int32Array([1,2,3,4,5,100,200,300]))
+      expect(r2).to.be.deep.equal(new Int32Array([1, 2, 3, 4, 5, 100, 200, 300]))
     })
   })
 
@@ -538,11 +538,11 @@ describe("column_data_source module", () => {
 
     it("should alert if column lengths are inconsistent", () => {
       set_log_level("info")
-      const r0 = new ColumnDataSource({data: {foo: [1], bar: [1,2]}})
+      const r0 = new ColumnDataSource({data: {foo: [1], bar: [1, 2]}})
       const out0 = stderrTrap(() => r0.get_length())
       expect(out0).to.be.equal("[bokeh] data source has columns of inconsistent lengths\n")
 
-      const r1 = new ColumnDataSource({data: {foo: [1], bar: [1,2], baz: [1]}})
+      const r1 = new ColumnDataSource({data: {foo: [1], bar: [1, 2], baz: [1]}})
       const out1 = stderrTrap(() => r1.get_length())
       expect(out1).to.be.equal("[bokeh] data source has columns of inconsistent lengths\n")
     })
@@ -572,7 +572,7 @@ describe("column_data_source module", () => {
 
     it("should clear typed arrays to typed arrays", () => {
       for (const typ of [Float32Array, Float64Array, Int32Array]) {
-        const r = new ColumnDataSource({data: {foo: [10, 20], bar: new typ([1,2])}})
+        const r = new ColumnDataSource({data: {foo: [10, 20], bar: new typ([1, 2])}})
         r.clear()
         expect(r.data).to.be.deep.equal({foo: [], bar: new typ([])})
       }
@@ -582,7 +582,7 @@ describe("column_data_source module", () => {
       for (const typ of [Float32Array, Float64Array, Int32Array]) {
         const r = new ColumnDataSource({data: {foo: [10, 20]}})
         r.data.bar = [100, 200]
-        r.data.baz = new typ([1,2])
+        r.data.baz = new typ([1, 2])
         r.clear()
         expect(r.data).to.be.deep.equal({foo: [], bar: [], baz: new typ([])})
       }

--- a/bokehjs/test/models/tickers/adaptive_ticker.ts
+++ b/bokehjs/test/models/tickers/adaptive_ticker.ts
@@ -25,31 +25,31 @@ describe("AdaptiveTicker Model", () => {
   describe("AdaptiveTicker get_interval method", () => {
 
     it("should use the '1' mantissa", () => {
-      const ticker = new AdaptiveTicker({mantissas: [1,2,5], base: 10})
+      const ticker = new AdaptiveTicker({mantissas: [1, 2, 5], base: 10})
       const interval = ticker.get_interval(0, 1000, 10)
       expect(interval).to.be.equal(100)
     })
 
     it("should use the '2' matissa", () => {
-      const ticker = new AdaptiveTicker({mantissas: [1,2,5], base: 10})
+      const ticker = new AdaptiveTicker({mantissas: [1, 2, 5], base: 10})
       const interval = ticker.get_interval(0, 1000, 5)
       expect(interval).to.be.equal(200)
     })
 
     it("should use the '5' matissa", () => {
-      const ticker = new AdaptiveTicker({mantissas: [1,2,5], base: 10})
+      const ticker = new AdaptiveTicker({mantissas: [1, 2, 5], base: 10})
       const interval = ticker.get_interval(0, 1000, 2)
       expect(interval).to.be.equal(500)
     })
 
     it("should use the min_interval", () => {
-      const ticker = new AdaptiveTicker({mantissas: [1,2,5], base: 10, min_interval: 250})
+      const ticker = new AdaptiveTicker({mantissas: [1, 2, 5], base: 10, min_interval: 250})
       const interval = ticker.get_interval(0, 1000, 10)
       expect(interval).to.be.equal(250)
     })
 
     it("should use the max_interval", () => {
-      const ticker = new AdaptiveTicker({mantissas: [1,2,5], base: 10, max_interval: 50})
+      const ticker = new AdaptiveTicker({mantissas: [1, 2, 5], base: 10, max_interval: 50})
       const interval = ticker.get_interval(0, 1000, 10)
       expect(interval).to.be.equal(50)
     })

--- a/bokehjs/test/models/tickers/days_ticker.ts
+++ b/bokehjs/test/models/tickers/days_ticker.ts
@@ -11,7 +11,7 @@ describe("DaysTicker Model", () => {
   })
 
   it("should configure an interval of (diff)*ONE_DAY with a multiple days", () => {
-    const ticker = new DaysTicker({days: [0,3,6,9]})
+    const ticker = new DaysTicker({days: [0, 3, 6, 9]})
     expect(ticker.interval).to.be.equal(3*ONE_DAY)
   })
 

--- a/bokehjs/test/models/tickers/months_ticker.ts
+++ b/bokehjs/test/models/tickers/months_ticker.ts
@@ -11,7 +11,7 @@ describe("MonthsTicker Model", () => {
   })
 
   it("should configure an interval of (diff)*ONE_MONTH with a multiple months", () => {
-    const ticker = new MonthsTicker({months: [0,3,6,9]})
+    const ticker = new MonthsTicker({months: [0, 3, 6, 9]})
     expect(ticker.interval).to.be.equal(3*ONE_MONTH)
   })
 

--- a/bokehjs/test/models/tiles/tile_renderer.ts
+++ b/bokehjs/test/models/tiles/tile_renderer.ts
@@ -85,13 +85,13 @@ describe("tile sources", () => {
     const source = new AbstractTileSource(tile_options)
 
     it("should convert tile xyz into a tile key", () => {
-      const k = source.tile_xyz_to_key(1,1,1)
+      const k = source.tile_xyz_to_key(1, 1, 1)
       expect(k).to.be.equal("1:1:1")
     })
 
     it("should convert tile key to tile xyz", () => {
       const xyz = source.key_to_tile_xyz('1:1:1')
-      expect(xyz).to.be.eql([1,1,1])
+      expect(xyz).to.be.eql([1, 1, 1])
     })
 
     it("should successfully set x_origin_offset and y_origin_offset", () => {
@@ -119,7 +119,7 @@ describe("tile sources", () => {
       const expect_url = 'http://test_value/test_value2/0/0/0.png'
       expect(tile_source.extra_url_vars).to.have.any.keys('test_key')
       expect(tile_source.extra_url_vars).to.have.any.keys('test_key2')
-      expect(tile_source.get_image_url(0,0,0)).to.be.equal(expect_url)
+      expect(tile_source.get_image_url(0, 0, 0)).to.be.equal(expect_url)
     })
 
     it("should handle case-insensitive url parameters (template url)", () => {
@@ -129,13 +129,13 @@ describe("tile sources", () => {
         url: 'http://mock/{x}/{y}/{z}.png',
       }
       const tile_source0 = new AbstractTileSource(tile_options0)
-      expect(tile_source0.get_image_url(0,0,0)).to.be.equal(expect_url)
+      expect(tile_source0.get_image_url(0, 0, 0)).to.be.equal(expect_url)
 
       const tile_options1 = {
         url: 'http://mock/{X}/{Y}/{Z}.png',
       }
       const tile_source1 = new AbstractTileSource(tile_options1)
-      expect(tile_source1.get_image_url(0,0,0)).to.be.equal(expect_url)
+      expect(tile_source1.get_image_url(0, 0, 0)).to.be.equal(expect_url)
     })
 
     it("should return tiles in ascending distance from center tile", () => {
@@ -270,7 +270,7 @@ describe("tile sources", () => {
     it("should handle case-insensitive url parameters (template url)", () => {
       const tile_options0 = {url: 'http://mock?bbox={xmin},{ymin},{xmax},{ymax}'}
       const tile_source0 = new BBoxTileSource(tile_options0)
-      const url0 = tile_source0.get_image_url(0,0,0)
+      const url0 = tile_source0.get_image_url(0, 0, 0)
       expect(url0.indexOf('{xmin}')).to.be.equal(-1)
       expect(url0.indexOf('{ymin}')).to.be.equal(-1)
       expect(url0.indexOf('{xmax}')).to.be.equal(-1)
@@ -278,7 +278,7 @@ describe("tile sources", () => {
 
       const tile_options1 = {url: 'http://mock?bbox={XMIN},{YMIN},{XMAX},{YMAX}'}
       const tile_source1 = new BBoxTileSource(tile_options1)
-      const url1 = tile_source1.get_image_url(0,0,0)
+      const url1 = tile_source1.get_image_url(0, 0, 0)
       expect(url1.indexOf('{XMIN}')).to.be.equal(-1)
       expect(url1.indexOf('{YMIN}')).to.be.equal(-1)
       expect(url1.indexOf('{XMAX}')).to.be.equal(-1)
@@ -302,18 +302,18 @@ describe("tile sources", () => {
 
     it("should convert cache key into tile x,y,z", () => {
       const source = new MercatorTileSource()
-      expect(source.key_to_tile_xyz("1:1:1")).to.be.eql([1,1,1])
+      expect(source.key_to_tile_xyz("1:1:1")).to.be.eql([1, 1, 1])
     })
 
     it("should successfully wrap around (x-axis) for normalized tile coordinates", () => {
       const source = new MercatorTileSource()
-      expect(source.normalize_xyz(-1, 1, 2)).to.be.eql([3,1,2])
+      expect(source.normalize_xyz(-1, 1, 2)).to.be.eql([3, 1, 2])
     })
 
     it("should successfully get closest parent tile by xyz", () => {
       const source = new MercatorTileSource()
-      source.tiles[source.tile_xyz_to_key(0,1,1)] = {tile_coords: [0, 0, 0]}
-      expect(source.get_closest_parent_by_tile_xyz(0, 3, 2)).to.be.eql([0,1,1])
+      source.tiles[source.tile_xyz_to_key(0, 1, 1)] = {tile_coords: [0, 0, 0]}
+      expect(source.get_closest_parent_by_tile_xyz(0, 3, 2)).to.be.eql([0, 1, 1])
     })
 
     it("should verify whether tile xyz's are valid", () => {
@@ -365,8 +365,8 @@ describe("tile sources", () => {
 
     it("should convert pixel x/y to tile x/y", () => {
       const source = new MercatorTileSource()
-      expect(source.pixels_to_tile(1, 1)).to.be.eql([0,0])
-      expect(source.pixels_to_tile(0, 0)).to.be.eql([0,0])
+      expect(source.pixels_to_tile(1, 1)).to.be.eql([0, 0])
+      expect(source.pixels_to_tile(0, 0)).to.be.eql([0, 0])
     })
 
     it("should convert pixel x/y to meters x/y", () => {

--- a/bokehjs/test/models/transforms/customjs_transform.ts
+++ b/bokehjs/test/models/transforms/customjs_transform.ts
@@ -105,7 +105,7 @@ for (var i = 0; i < xs.length; i++) {
 return new_xs\
 `
       const r = new CustomJSTransform({v_func, use_strict: true})
-      expect(r.v_compute([1,2,3])).to.be.deep.equal(new Array(11,12,13))
+      expect(r.v_compute([1, 2, 3])).to.be.deep.equal(new Array(11, 12, 13))
     })
 
     it("should properly transform an array of values using an arg property", () => {
@@ -118,7 +118,7 @@ return new_xs\
 `
       const rng = new Range1d({start: 11, end: 21})
       const r = new CustomJSTransform({args: {foo: rng}, v_func, use_strict: true})
-      expect(r.v_compute([1,2,3])).to.be.deep.equal(new Array(12,13,14))
+      expect(r.v_compute([1, 2, 3])).to.be.deep.equal(new Array(12, 13, 14))
     })
   })
 })

--- a/bokehjs/test/models/transforms/linear_interpolator.ts
+++ b/bokehjs/test/models/transforms/linear_interpolator.ts
@@ -40,7 +40,7 @@ describe("linear_interpolator_transform module", () => {
     })
 
     it("should map to a Float64Array", () => {
-      expect(transform.v_compute([-1,0,5,10,11])).to.be.instanceof(Float64Array)
+      expect(transform.v_compute([-1, 0, 5, 10, 11])).to.be.instanceof(Float64Array)
     })
   })
 
@@ -62,7 +62,7 @@ describe("linear_interpolator_transform module", () => {
     })
 
     it("should map to a Float64Array", () => {
-      expect(transform.v_compute([-1,0,5,10,11])).to.be.instanceof(Float64Array)
+      expect(transform.v_compute([-1, 0, 5, 10, 11])).to.be.instanceof(Float64Array)
     })
   })
 })

--- a/bokehjs/test/models/transforms/step_interpolator.ts
+++ b/bokehjs/test/models/transforms/step_interpolator.ts
@@ -42,7 +42,7 @@ describe("step_interpolator_transform module", () => {
       })
 
       it("should map to a Float64Array", () => {
-        expect(transform.v_compute([-1,0,5,10,11])).to.be.instanceof(Float64Array)
+        expect(transform.v_compute([-1, 0, 5, 10, 11])).to.be.instanceof(Float64Array)
       })
     })
 
@@ -58,7 +58,7 @@ describe("step_interpolator_transform module", () => {
       })
 
       it("should map to a Float64Array", () => {
-        expect(transform.v_compute([-1,0,5,10,11])).to.be.instanceof(Float64Array)
+        expect(transform.v_compute([-1, 0, 5, 10, 11])).to.be.instanceof(Float64Array)
       })
     })
 
@@ -74,7 +74,7 @@ describe("step_interpolator_transform module", () => {
       })
 
       it("should map to a Float64Array", () => {
-        expect(transform.v_compute([-1,0,5,10,11])).to.be.instanceof(Float64Array)
+        expect(transform.v_compute([-1, 0, 5, 10, 11])).to.be.instanceof(Float64Array)
       })
     })
   })
@@ -99,7 +99,7 @@ describe("step_interpolator_transform module", () => {
       })
 
       it("should map to a Float64Array", () => {
-        expect(transform.v_compute([-1,0,5,10,11])).to.be.instanceof(Float64Array)
+        expect(transform.v_compute([-1, 0, 5, 10, 11])).to.be.instanceof(Float64Array)
       })
     })
 
@@ -115,7 +115,7 @@ describe("step_interpolator_transform module", () => {
       })
 
       it("should map to a Float64Array", () => {
-        expect(transform.v_compute([-1,0,5,10,11])).to.be.instanceof(Float64Array)
+        expect(transform.v_compute([-1, 0, 5, 10, 11])).to.be.instanceof(Float64Array)
       })
     })
 
@@ -131,7 +131,7 @@ describe("step_interpolator_transform module", () => {
       })
 
       it("should map to a Float64Array", () => {
-        expect(transform.v_compute([-1,0,5,10,11])).to.be.instanceof(Float64Array)
+        expect(transform.v_compute([-1, 0, 5, 10, 11])).to.be.instanceof(Float64Array)
       })
     })
   })

--- a/bokehjs/test/models/widgets/checkbox_button_group.ts
+++ b/bokehjs/test/models/widgets/checkbox_button_group.ts
@@ -12,14 +12,14 @@ describe("CheckboxButtonGroup", () => {
       const g = new CheckboxButtonGroup({active: [0, 2]})
       const view = new g.default_view({model: g, parent: null}).build()
       view.change_active(1)
-      expect(g.active).to.deep.equal([0,1,2])
+      expect(g.active).to.deep.equal([0, 1, 2])
     })
 
     it("should remove arg from active if is present", () => {
       const g = new CheckboxButtonGroup({active: [0, 1, 2]})
       const view = new g.default_view({model: g, parent: null}).build()
       view.change_active(1)
-      expect(g.active).to.deep.equal([0,2])
+      expect(g.active).to.deep.equal([0, 2])
       view.change_active(2)
       expect(g.active).to.deep.equal([0])
     })

--- a/bokehjs/test/models/widgets/tables/data_table.ts
+++ b/bokehjs/test/models/widgets/tables/data_table.ts
@@ -48,27 +48,27 @@ describe("data_table module", () => {
   describe("DataProvider class", () => {
 
     it("should raise an error if DTINDEX_NAME is in source", () => {
-      const bad = new ColumnDataSource({data: {__bkdt_internal_index__: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      const bad = new ColumnDataSource({data: {__bkdt_internal_index__: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
       const view = new CDSView({source: bad})
       expect(() => new TableDataProvider(bad, view)).to.throw(Error)
     })
 
     it("should construct an internal index", () => {
-      const source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      const source = new ColumnDataSource({data: {index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
       const view = new CDSView({source})
       const dp = new TableDataProvider(source, view)
-      expect(dp.index).to.deep.equal([0,1,2,3])
+      expect(dp.index).to.deep.equal([0, 1, 2, 3])
     })
 
     it("should report the data source length", () => {
-      const source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      const source = new ColumnDataSource({data: {index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
       const view = new CDSView({source})
       const dp = new TableDataProvider(source, view)
       expect(dp.getLength()).to.equal(4)
     })
 
     it("should return items when unsorted", () => {
-      const source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      const source = new ColumnDataSource({data: {index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
       const view = new CDSView({source})
       const dp = new TableDataProvider(source, view)
 
@@ -79,7 +79,7 @@ describe("data_table module", () => {
     })
 
     it("should return items when sorted", () => {
-      const source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      const source = new ColumnDataSource({data: {index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
       const view = new CDSView({source})
       const dp = new TableDataProvider(source, view)
       const fake_col = {sortAsc: true, sortCol: {field: "bar"}}
@@ -92,7 +92,7 @@ describe("data_table module", () => {
     })
 
     it("should return fields when unsorted", () => {
-      const source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      const source = new ColumnDataSource({data: {index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
       const view = new CDSView({source})
       const dp = new TableDataProvider(source, view)
 
@@ -113,7 +113,7 @@ describe("data_table module", () => {
     })
 
     it("should return fields when sorted", () => {
-      const source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      const source = new ColumnDataSource({data: {index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
       const view = new CDSView({source})
       const dp = new TableDataProvider(source, view)
 
@@ -137,7 +137,7 @@ describe("data_table module", () => {
     })
 
     it("should get all records", () => {
-      const source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      const source = new ColumnDataSource({data: {index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
       const view = new CDSView({source})
       const dp = new TableDataProvider(source, view)
       expect(dp.getRecords()).to.deep.equal(range(0, dp.getLength()).map((i) => dp.getItem(i)))
@@ -148,48 +148,48 @@ describe("data_table module", () => {
     })
 
     it("should re-order only the index when sorted", () => {
-      const source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      const source = new ColumnDataSource({data: {index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
       const view = new CDSView({source})
       const dp = new TableDataProvider(source, view)
-      expect(dp.index).to.deep.equal([0,1,2,3])
+      expect(dp.index).to.deep.equal([0, 1, 2, 3])
 
       const fake_col = {sortAsc: true, sortCol: {field: "bar"}}
       dp.sort([fake_col])
-      expect(dp.index).to.deep.equal([3,2,1,0])
-      expect(dp.source.data).to.deep.equal({index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]})
+      expect(dp.index).to.deep.equal([3, 2, 1, 0])
+      expect(dp.source.data).to.deep.equal({index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]})
     })
 
     it("should return null metadata", () => {
-      const source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      const source = new ColumnDataSource({data: {index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
       const view = new CDSView({source})
       const dp = new TableDataProvider(source, view)
       expect(dp.getItemMetadata(0)).to.be.null
     })
 
     it("should set fields when unsorted", () => {
-      const source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      const source = new ColumnDataSource({data: {index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
       const view = new CDSView({source})
       const dp = new TableDataProvider(source, view)
 
       dp.setField(0, "index", 10.1)
-      expect(dp.source.data).to.deep.equal({index: [10.1,1,2,10], bar: [3.4, 1.2, 0, -10]})
+      expect(dp.source.data).to.deep.equal({index: [10.1, 1, 2, 10], bar: [3.4, 1.2, 0, -10]})
 
       dp.setField(2, "bar", 100)
-      expect(dp.source.data).to.deep.equal({index: [10.1,1,2,10], bar: [3.4, 1.2, 100, -10]})
+      expect(dp.source.data).to.deep.equal({index: [10.1, 1, 2, 10], bar: [3.4, 1.2, 100, -10]})
     })
 
     it("should set fields when sorted", () => {
-      const source = new ColumnDataSource({data: {index: [0,1,2,10], bar: [3.4, 1.2, 0, -10]}})
+      const source = new ColumnDataSource({data: {index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
       const view = new CDSView({source})
       const dp = new TableDataProvider(source, view)
       const fake_col = {sortAsc: true, sortCol: {field: "bar"}}
       dp.sort([fake_col])
 
       dp.setField(0, "index", 10.1)
-      expect(dp.source.data).to.deep.equal({index: [0,1,2,10.1], bar: [3.4, 1.2, 0, -10]})
+      expect(dp.source.data).to.deep.equal({index: [0, 1, 2, 10.1], bar: [3.4, 1.2, 0, -10]})
 
       dp.setField(2, "bar", 100)
-      expect(dp.source.data).to.deep.equal({index: [0,1,2,10.1], bar: [3.4, 100, 0, -10]})
+      expect(dp.source.data).to.deep.equal({index: [0, 1, 2, 10.1], bar: [3.4, 100, 0, -10]})
     })
 
   })

--- a/bokehjs/test/protocol/message.ts
+++ b/bokehjs/test/protocol/message.ts
@@ -34,9 +34,9 @@ describe("protocol/message module", () => {
 
       it("should append a new buffer", () => {
         m.assemble_buffer({msgid: "1"}, 2)
-        expect(m.buffers).to.be.deep.equal([[{msgid: "1"},2]])
+        expect(m.buffers).to.be.deep.equal([[{msgid: "1"}, 2]])
         m.assemble_buffer({msgid: "3"}, 4)
-        expect(m.buffers).to.be.deep.equal([[{msgid: "1"},2], [{msgid: "3"},4]])
+        expect(m.buffers).to.be.deep.equal([[{msgid: "1"}, 2], [{msgid: "3"}, 4]])
       })
 
       it("should raise an error if num_buffers is exceeded", () => {

--- a/scripts/ci/test.codebase
+++ b/scripts/ci/test.codebase
@@ -8,7 +8,7 @@ node make scripts:compile --emit-error
 
 node make test:compile --emit-error
 
-node make tslint --emit-error
+node make lint --emit-error
 popd
 
 py.test -m sampledata


### PR DESCRIPTION
Adds support for eslint (and typescript-eslint). One can use `node make eslint` to run the linter, but the preferred command is `node make lint`, which runs both `eslint` and `tslint`. I enabled a few stylistic rules (tslint doesn't have those) for testing.

fixes #9155 
