### PR TITLE
Add SSL termination and revamped settings system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ jobs:
         - google-chrome-stable --no-sandbox --headless --hide-scrollbars --remote-debugging-port=9222 &
       env:
       - GROUP=examples
-      - PYTHON=3.7
+      - PYTHON=3.7.2
 
     - install: scripts/ci/install.test
       script: scripts/ci/test
@@ -93,7 +93,7 @@ jobs:
       script: scripts/ci/test
       env:
       - GROUP=unit
-      - PYTHON=3.7
+      - PYTHON=3.7.2
 
     - install: scripts/ci/install.test
       script: scripts/ci/test

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -83,27 +83,8 @@ Otherwise, You can see an index of all running applications at the server root:
 This index can be disabled with the ``--disable-index`` option, and the redirect
 behavior can be disabled with the ``--disable-index-redirect`` option.
 
-Network Configuration
-~~~~~~~~~~~~~~~~~~~~~
-
-To control the port that the Bokeh server listens on, use the ``--port``
-argument:
-
-.. code-block:: sh
-
-    bokeh serve app_script.py --port 8080
-
-To listen on an arbitrary port, pass ``0`` as the port number.  The actual
-port number will be logged at startup.
-
-Similarly, a specific network address can be specified with the
-``--address`` argument. For example:
-
-.. code-block:: sh
-
-    bokeh serve app_script.py --address 0.0.0.0
-
-will have the Bokeh server listen all available network addresses.
+Application Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Bokeh server can fork the underlying tornado server into multiprocess.  This is
 useful when trying to handle multiple connections especially in the context of
@@ -118,19 +99,6 @@ processes
 Note that due to limitations inherent in Tornado, Windows does not support
 ``--num-procs`` values greater than one! In this case consider running multiple
 Bokeh server instances behind a load balancer.
-
-By default, cross site connections to the Bokeh server websocket are not
-allowed. You can enable websocket connections originating from additional
-hosts by specifying them with the ``BOKEH_ALLOW_WS_ORIGIN`` environment variable
-or the ``--allow-websocket-origin`` option:
-
-.. code-block:: sh
-
-    bokeh serve app_script.py --allow-websocket-origin foo.com:8081
-
-It is possible to specify multiple allowed websocket origins by adding
-the ``--allow-websocket-origin`` option multiple times and to provide a
-comma separated list of hosts to ``BOKEH_ALLOW_WS_ORIGIN``
 
 The Bokeh server can also add an optional prefix to all URL paths.
 This can often be useful in conjunction with "reverse proxy" setups.
@@ -155,6 +123,171 @@ To configure this feature, set the ``--keep-alive`` option:
 The value is specified in milliseconds. The default keep-alive interval
 is 37 seconds. Give a value of 0 to disable keep-alive pings.
 
+Network Configuration
+~~~~~~~~~~~~~~~~~~~~~
+
+To control the port that the Bokeh server listens on, use the ``--port``
+argument:
+
+.. code-block:: sh
+
+    bokeh serve app_script.py --port 8080
+
+To listen on an arbitrary port, pass ``0`` as the port number.  The actual
+port number will be logged at startup.
+
+Similarly, a specific network address can be specified with the
+``--address`` argument. For example:
+
+.. code-block:: sh
+
+    bokeh serve app_script.py --address 0.0.0.0
+
+will have the Bokeh server listen all available network addresses.
+
+By default, cross site connections to the Bokeh server websocket are not
+allowed. You can enable websocket connections originating from additional
+hosts by specifying them with the ``BOKEH_ALLOW_WS_ORIGIN`` environment variable
+or the ``--allow-websocket-origin`` option:
+
+.. code-block:: sh
+
+    bokeh serve app_script.py --allow-websocket-origin foo.com:8081
+
+It is possible to specify multiple allowed websocket origins by adding
+the ``--allow-websocket-origin`` option multiple times and to provide a
+comma separated list of hosts to ``BOKEH_ALLOW_WS_ORIGIN``
+
+To have the Bokeh server override the remote IP and URI scheme/protocol for
+all requests with ``X-Real-Ip``, ``X-Forwarded-For``, ``X-Scheme``,
+``X-Forwarded-Proto``  headers (if they are provided), set the
+``--use-xheaders`` option:
+
+.. code-block:: sh
+
+    bokeh serve app_script.py --use-xheaders
+
+This is typically needed when running a Bokeh server behind a reverse proxy
+that is SSL-terminated.
+
+.. warning::
+    It is not advised to set this option on a Bokeh server directly facing
+    the Internet.
+
+A Bokeh server can also terminate SSL connections directly by specifying the
+path to a single file in PEM format containing the certificate as well as any
+number of CA certificates needed to establish the certificate’s authenticity:
+
+.. code-block:: sh
+
+    bokeh serve --ssl-certfile /path/to/cert.pem
+
+Alternatively, the path may also be supplied by setting the environment
+variable ``BOKEH_SSL_CERTFILE``.
+
+If the private key is stored separately, its location may be supplied by
+setting the ``-ssl-keyfile`` command line argument, or by setting the
+``BOKEH_SSL_KEYFILE`` evironment variable. If a password is required for the
+private key, it should be supplied by setting the ``BOKEH_SSL_PASSWORD``
+environment variable.
+
+Session ID Options
+~~~~~~~~~~~~~~~~~~
+
+Typically, each browser tab connected to a Bokeh server will have its own
+session ID. When the server generates an ID, it will make it cryptographically
+unguessable. This keeps users from accessing one another's sessions.
+
+To control who can use a Bokeh application, the server can sign session IDs
+with a secret key and reject "made up" session names. There are three modes,
+controlled by the ``--session-ids`` argument:
+
+.. code-block:: sh
+
+    bokeh serve app_script.py --session-ids signed
+
+The available modes are: {SESSION_ID_MODES}
+
+In ``unsigned`` mode, the server will accept any session ID provided to it in
+the URL. For example, ``http://localhost/app_script?bokeh-session-id=foo`` will
+create a session ``foo``. In ``unsigned`` mode, if the session ID isn't
+provided with ``?bokeh-session-id=`` in the URL, the server will still generate
+a cryptographically-unguessable ID. However, the server allows clients to
+create guessable or deliberately-shared sessions if they want to.
+
+``unsigned`` mode is most useful when the server is running locally for
+development, for example you can have multiple processes access a fixed session
+name such as ``default``. ``unsigned`` mode is also convenient because there's
+no need to generate or configure a secret key.
+
+In ``signed`` mode, the session ID must be in a special format and signed with
+a secret key. Attempts to use the application with an invalid session ID will
+fail, but if no ``?bokeh-session-id=`` parameter is provided, the server will
+generate a fresh, signed session ID. The result of ``signed`` mode is that only
+secure session IDs are allowed but anyone can connect to the server.
+
+In ``external-signed`` mode, the session ID must be signed but the server
+itself won't generate a session ID; the ``?bokeh-session-id=`` parameter will
+be required. To use this mode, an external process (such as another web app)
+would use the function ``bokeh.util.session_id.generate_session_id()`` to
+create valid session IDs. The external process and the Bokeh server must share
+the same ``BOKEH_SECRET_KEY`` environment variable.
+
+``external-signed`` mode is useful if you want another process to authenticate
+access to the Bokeh server. If someone is permitted to use a Bokeh application,
+you would generate a session ID for them, then redirect them to the Bokeh
+server with that valid session ID. If you don't generate a session ID for
+someone, then they can't load the app from the Bokeh server.
+
+In both ``signed`` and ``external-signed`` mode, the secret key must be kept
+secret; anyone with the key can generate a valid session ID.
+
+The secret key should be set in a ``BOKEH_SECRET_KEY`` environment variable and
+should be a cryptographically random string with at least 256 bits (32 bytes)
+of entropy. The ``bokeh secret`` command can generate new secret keys.
+
+Session Expiration Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To configure how often to check for unused sessions. set the
+``--check-unused-sessions`` option:
+
+.. code-block:: sh
+
+    bokeh serve app_script.py --check-unused-sessions 10000
+
+The value is specified in milliseconds. The default interval for checking for
+unused sessions is 17 seconds. Only positive integer values are accepted.
+
+To configure how often unused sessions last. set the
+``--unused-session-lifetime`` option:
+
+.. code-block:: sh
+
+    bokeh serve app_script.py --unused-session-lifetime 60000
+
+The value is specified in milliseconds. The default lifetime interval for
+unused sessions is 15 seconds. Only positive integer values are accepted.
+
+Diagnostic Options
+~~~~~~~~~~~~~~~~~~
+
+The logging level can be controlled by the ``--log-level`` argument:
+
+.. code-block:: sh
+
+    bokeh serve app_script.py --log-level debug
+
+The available log levels are: {LOGLEVELS}
+
+The log format can be controlled by the ``--log-format`` argument:
+
+.. code-block:: sh
+
+    bokeh serve app_script.py --log-format "%(levelname)s: %(message)s"
+
+The default log format is ``"{DEFAULT_LOG_FORMAT}"``
+
 To control how often statistic logs are written, set the
 ``--stats-log-frequency`` option:
 
@@ -175,132 +308,6 @@ set the ``--mem-log-frequency`` option:
 
 The value is specified in milliseconds. The default interval for
 logging stats is 0 (disabled). Only positive integer values are accepted.
-
-To have the Bokeh server override the remote IP and URI scheme/protocol for
-all requests with ``X-Real-Ip``, ``X-Forwarded-For``, ``X-Scheme``,
-``X-Forwarded-Proto``  headers (if they are provided), set the
-``--use-xheaders`` option:
-
-.. code-block:: sh
-
-    bokeh serve app_script.py --use-xheaders
-
-This is typically needed when running a Bokeh server behind a reverse proxy
-that is SSL-terminated.
-
-.. warning::
-    It is not advised to set this option on a Bokeh server directly facing
-    the Internet.
-
-Session ID Options
-~~~~~~~~~~~~~~~~~~
-
-Typically, each browser tab connected to a Bokeh server will have
-its own session ID. When the server generates an ID, it will make
-it cryptographically unguessable. This keeps users from accessing
-one another's sessions.
-
-To control who can use a Bokeh application, the server can sign
-sessions with a secret key and reject "made up" session
-names. There are three modes, controlled by the ``--session-ids``
-argument:
-
-.. code-block:: sh
-
-    bokeh serve app_script.py --session-ids signed
-
-The available modes are: {SESSION_ID_MODES}
-
-In ``unsigned`` mode, the server will accept any session ID
-provided to it in the URL. For example,
-``http://localhost/app_script?bokeh-session-id=foo`` will create a
-session ``foo``. In ``unsigned`` mode, if the session ID isn't
-provided with ``?bokeh-session-id=`` in the URL, the server will
-still generate a cryptographically-unguessable ID. However, the
-server allows clients to create guessable or deliberately-shared
-sessions if they want to.
-
-``unsigned`` mode is most useful when the server is running
-locally for development, for example you can have multiple
-processes access a fixed session name such as
-``default``. ``unsigned`` mode is also convenient because there's
-no need to generate or configure a secret key.
-
-In ``signed`` mode, the session ID must be in a special format and
-signed with a secret key. Attempts to use the application with an
-invalid session ID will fail, but if no ``?bokeh-session-id=``
-parameter is provided, the server will generate a fresh, signed
-session ID. The result of ``signed`` mode is that only secure
-session IDs are allowed but anyone can connect to the server.
-
-In ``external-signed`` mode, the session ID must be signed but the
-server itself won't generate a session ID; the
-``?bokeh-session-id=`` parameter will be required. To use this
-mode, you would need some sort of external process (such as
-another web app) which would use the
-``bokeh.util.session_id.generate_session_id()`` function to create
-valid session IDs. The external process and the Bokeh server must
-share the same ``BOKEH_SECRET_KEY`` environment variable.
-
-``external-signed`` mode is useful if you want another process to
-authenticate access to the Bokeh server; if someone is permitted
-to use the Bokeh application, you would generate a session ID for
-them, then redirect them to the Bokeh server with that valid
-session ID. If you don't generate a session ID for someone, then
-they can't load the app from the Bokeh server.
-
-In both ``signed`` and ``external-signed`` mode, the secret key
-must be kept secret; anyone with the key can generate a valid
-session ID.
-
-The secret key should be set in a ``BOKEH_SECRET_KEY`` environment
-variable and should be a cryptographically random string with at
-least 256 bits (32 bytes) of entropy.  You can generate a new
-secret key with the ``bokeh secret`` command.
-
-Session Expiration Options
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-To configure how often to check for unused sessions. set the
---check-unused-sessions option:
-
-.. code-block:: sh
-
-    bokeh serve app_script.py --check-unused-sessions 10000
-
-The value is specified in milliseconds. The default interval for
-checking for unused sessions is 17 seconds. Only positive integer
-values are accepted.
-
-To configure how often unused sessions last. set the
---unused-session-lifetime option:
-
-.. code-block:: sh
-
-    bokeh serve app_script.py --unused-session-lifetime 60000
-
-The value is specified in milliseconds. The default lifetime interval
-for unused sessions is 15 seconds. Only positive integer values are
-accepted.
-
-Logging Options
-~~~~~~~~~~~~~~~
-
-The logging level can be controlled by the ``--log-level`` argument:
-
-.. code-block:: sh
-
-    bokeh serve app_script.py --log-level debug
-
-The available log levels are: {LOGLEVELS}
-
-The log format can be controlled by the ``--log-format`` argument:
-
-.. code-block:: sh
-
-    bokeh serve app_script.py --log-format "%(levelname)s: %(message)s"
-
-The default log format is ``"{DEFAULT_LOG_FORMAT}"``
 
 '''
 
@@ -361,8 +368,8 @@ base_serve_args = (
     ('--log-level', dict(
         metavar = 'LOG-LEVEL',
         action  = 'store',
-        default = 'info',
-        choices = LOGLEVELS,
+        default = None,
+        choices = LOGLEVELS + (None,),
         help    = "One of: %s" % nice_join(LOGLEVELS),
     )),
 
@@ -379,6 +386,14 @@ base_serve_args = (
         default = None,
         help    = "A filename to write logs to, or None to write to the standard stream (default: None)",
     )),
+
+    ('--use-config', dict(
+        metavar='CONFIG',
+        type=str,
+        help="Use a YAML config file for settings",
+        default=None,
+    )),
+
 )
 
 __all__ = (
@@ -411,7 +426,7 @@ class Serve(Subcommand):
             metavar='COMMAND-LINE-ARGS',
             nargs=argparse.REMAINDER,
             help="Command line arguments remaining to passed on to the application handler. "
-                 "NOTE: if this argument precedes DIRECTORY-OR-SCRIPT then some other argument, e.g "
+                 "NOTE: if this argument precedes DIRECTORY-OR-SCRIPT then some other argument, e.g. "
                  "--show, must be placed before the directory or script. ",
         )),
 
@@ -493,6 +508,20 @@ class Serve(Subcommand):
             help="Prefer X-headers for IP/protocol information",
         )),
 
+        ('--ssl-certfile', dict(
+            metavar='CERTFILE',
+            action  = 'store',
+            default = None,
+            help    = 'Absolute path to a certificate file for SSL termination',
+        )),
+
+        ('--ssl-keyfile', dict(
+            metavar='KEYFILE',
+            action  = 'store',
+            default = None,
+            help    = 'Absolute path to a private key file for SSL termination',
+        )),
+
         ('--session-ids', dict(
             metavar='MODE',
             action  = 'store',
@@ -541,6 +570,13 @@ class Serve(Subcommand):
         '''
 
         '''
+        log_level = settings.py_log_level(args.log_level)
+        basicConfig(format=args.log_format, filename=args.log_file)
+        logging.getLogger('bokeh').setLevel(log_level)
+
+        if args.use_config is not None:
+            log.info("Using override config file: {}".format(args.use_config))
+            settings.load_config(args.use_config)
 
         # protect this import inside a function so that "bokeh info" can work
         # even if Tornado is not installed
@@ -548,9 +584,6 @@ class Serve(Subcommand):
 
         argvs = { f : args.args for f in args.files}
         applications = build_single_handler_applications(args.files, argvs)
-
-        log_level = getattr(logging, args.log_level.upper())
-        basicConfig(level=log_level, format=args.log_format, filename=args.log_file)
 
         if len(applications) == 0:
             # create an empty application by default
@@ -590,6 +623,9 @@ class Serve(Subcommand):
 
         server_kwargs['sign_sessions'] = settings.sign_sessions()
         server_kwargs['secret_key'] = settings.secret_key_bytes()
+        server_kwargs['ssl_certfile'] = settings.ssl_certfile(getattr(args, 'ssl_certfile', None))
+        server_kwargs['ssl_keyfile'] = settings.ssl_keyfile(getattr(args, 'ssl_keyfile', None))
+        server_kwargs['ssl_password'] = settings.ssl_password()
         server_kwargs['generate_session_ids'] = True
         if args.session_ids is None:
             # no --session-ids means use the env vars

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -176,7 +176,7 @@ that is SSL-terminated.
 
 A Bokeh server can also terminate SSL connections directly by specifying the
 path to a single file in PEM format containing the certificate as well as any
-number of CA certificates needed to establish the certificate’s authenticity:
+number of CA certificates needed to establish the certificate's authenticity:
 
 .. code-block:: sh
 

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -570,8 +570,14 @@ class Serve(Subcommand):
         '''
 
         '''
-        log_level = settings.py_log_level(args.log_level)
         basicConfig(format=args.log_format, filename=args.log_file)
+
+        # This is a bit of a fudge. We want the default log level for non-server
+        # cases to be None, i.e. don't set a log level. But for the server we
+        # do want to set the log level to INFO if nothing else overrides that.
+        log_level = settings.py_log_level(args.log_level)
+        if log_level is None:
+            log_level = logging.INFO
         logging.getLogger('bokeh').setLevel(log_level)
 
         if args.use_config is not None:

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -186,7 +186,7 @@ Alternatively, the path may also be supplied by setting the environment
 variable ``BOKEH_SSL_CERTFILE``.
 
 If the private key is stored separately, its location may be supplied by
-setting the ``-ssl-keyfile`` command line argument, or by setting the
+setting the ``--ssl-keyfile`` command line argument, or by setting the
 ``BOKEH_SSL_KEYFILE`` evironment variable. If a password is required for the
 private key, it should be supplied by setting the ``BOKEH_SSL_PASSWORD``
 environment variable.
@@ -573,7 +573,7 @@ class Serve(Subcommand):
         basicConfig(format=args.log_format, filename=args.log_file)
 
         # This is a bit of a fudge. We want the default log level for non-server
-        # cases to be None, i.e. don't set a log level. But for the server we
+        # cases to be None, i.e. we don't set a log level. But for the server we
         # do want to set the log level to INFO if nothing else overrides that.
         log_level = settings.py_log_level(args.log_level)
         if log_level is None:

--- a/bokeh/command/subcommands/tests/test_serve.py
+++ b/bokeh/command/subcommands/tests/test_serve.py
@@ -83,8 +83,8 @@ def test_args():
         ('--log-level', dict(
             metavar = 'LOG-LEVEL',
             action  = 'store',
-            default = 'info',
-            choices = scserve.LOGLEVELS,
+            default = None,
+            choices = scserve.LOGLEVELS + (None,),
             help    = "One of: %s" % nice_join(scserve.LOGLEVELS),
         )),
 
@@ -102,6 +102,13 @@ def test_args():
             help    = "A filename to write logs to, or None to write to the standard stream (default: None)",
         )),
 
+        ('--use-config', dict(
+            metavar='CONFIG',
+            type=str,
+            help="Use a YAML config file for settings",
+            default=None,
+        )),
+
         ('files', dict(
             metavar='DIRECTORY-OR-SCRIPT',
             nargs='*',
@@ -113,7 +120,7 @@ def test_args():
             metavar='COMMAND-LINE-ARGS',
             nargs=argparse.REMAINDER,
             help="Command line arguments remaining to passed on to the application handler. "
-                 "NOTE: if this argument precedes DIRECTORY-OR-SCRIPT then some other argument, e.g "
+                 "NOTE: if this argument precedes DIRECTORY-OR-SCRIPT then some other argument, e.g. "
                  "--show, must be placed before the directory or script. ",
         )),
 
@@ -193,6 +200,20 @@ def test_args():
         ('--use-xheaders', dict(
             action='store_true',
             help="Prefer X-headers for IP/protocol information",
+        )),
+
+        ('--ssl-certfile', dict(
+            metavar='CERTFILE',
+            action  = 'store',
+            default = None,
+            help    = 'Absolute path to a certificate file for SSL termination',
+        )),
+
+        ('--ssl-keyfile', dict(
+            metavar='KEYFILE',
+            action  = 'store',
+            default = None,
+            help    = 'Absolute path to a private key file for SSL termination',
         )),
 
         ('--session-ids', dict(

--- a/bokeh/core/json_encoder.py
+++ b/bokeh/core/json_encoder.py
@@ -147,8 +147,7 @@ def serialize_json(obj, pretty=None, indent=None, **kwargs):
         if name in kwargs:
             raise ValueError("The value of %r is computed internally, overriding is not permissable." % name)
 
-    if pretty is None:
-        pretty = settings.pretty(False)
+    pretty = settings.pretty(pretty)
 
     if pretty:
         separators=(",", ": ")

--- a/bokeh/io/notebook.py
+++ b/bokeh/io/notebook.py
@@ -374,12 +374,13 @@ def load_notebook(resources=None, verbose=False, hide_banner=False, load_timeout
 
     from .. import __version__
     from ..core.templates import NOTEBOOK_LOAD
+    from ..resources import Resources
+    from ..settings import settings
     from ..util.serialization import make_id
-    from ..resources import CDN
     from ..util.compiler import bundle_all_models
 
     if resources is None:
-        resources = CDN
+        resources = Resources(mode=settings.resources())
 
     if not hide_banner:
 

--- a/bokeh/io/output.py
+++ b/bokeh/io/output.py
@@ -42,7 +42,7 @@ __all__ = (
 # General API
 #-----------------------------------------------------------------------------
 
-def output_file(filename, title="Bokeh Plot", mode="cdn", root_dir=None):
+def output_file(filename, title="Bokeh Plot", mode=None, root_dir=None):
     '''Configure the default output state to generate output saved
     to a file when :func:`show` is called.
 

--- a/bokeh/io/saving.py
+++ b/bokeh/io/saving.py
@@ -125,8 +125,8 @@ def _get_save_resources(state, resources, suppress_warning):
     if not suppress_warning:
         warn("save() called but no resources were supplied and output_file(...) was never called, defaulting to resources.CDN")
 
-    from ..resources import CDN
-    return CDN
+    from ..resources import Resources
+    return Resources(mode=settings.resources())
 
 def _get_save_title(state, title, suppress_warning):
     if title is not None:

--- a/bokeh/io/state.py
+++ b/bokeh/io/state.py
@@ -132,7 +132,7 @@ class State(object):
 
     # Public methods ----------------------------------------------------------
 
-    def output_file(self, filename, title="Bokeh Plot", mode="cdn", root_dir=None):
+    def output_file(self, filename, title="Bokeh Plot", mode=None, root_dir=None):
         ''' Configure output to a standalone HTML file.
 
         Calling ``output_file`` not clear the effects of any other calls to

--- a/bokeh/io/tests/test_output.py
+++ b/bokeh/io/tests/test_output.py
@@ -40,7 +40,7 @@ class Test_output_file(object):
 
     @patch('bokeh.io.state.State.output_file')
     def test_no_args(self, mock_output_file):
-        default_kwargs = dict(title="Bokeh Plot", mode="cdn", root_dir=None)
+        default_kwargs = dict(title="Bokeh Plot", mode=None, root_dir=None)
         bio.output_file("foo.html")
         assert mock_output_file.call_count == 1
         assert mock_output_file.call_args[0] == ("foo.html",)

--- a/bokeh/io/tests/test_saving.py
+++ b/bokeh/io/tests/test_saving.py
@@ -67,10 +67,9 @@ def test__get_save_args_default_resources():
 
 @patch('bokeh.io.saving.warn')
 def test__get_save_args_missing_resources(mock_warn):
-    from bokeh.resources import CDN
     curstate().reset()
     filename, resources, title = bis._get_save_args(curstate(), "filename", None, "title")
-    assert resources == CDN
+    assert resources.mode == "cdn"
     assert mock_warn.call_count == 1
     assert mock_warn.call_args[0] == (
         "save() called but no resources were supplied and output_file(...) was never called, defaulting to resources.CDN",

--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -67,8 +67,9 @@ class BaseResources(object):
     _default_root_dir = "."
     _default_root_url = DEFAULT_SERVER_HTTP_URL
 
-    def __init__(self, mode='inline', version=None, root_dir=None,
-                 minified=True, log_level="info", root_url=None,
+    # TOOD (bev) remove inline default for 2.0
+    def __init__(self, mode="inline", version=None, root_dir=None,
+                 minified=None, log_level=None, root_url=None,
                  path_versioner=None, components=None):
 
         self._components = components

--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -67,8 +67,7 @@ class BaseResources(object):
     _default_root_dir = "."
     _default_root_url = DEFAULT_SERVER_HTTP_URL
 
-    # TOOD (bev) remove inline default for 2.0
-    def __init__(self, mode="inline", version=None, root_dir=None,
+    def __init__(self, mode=None, version=None, root_dir=None,
                  minified=None, log_level=None, root_url=None,
                  path_versioner=None, components=None):
 

--- a/bokeh/server/server.py
+++ b/bokeh/server/server.py
@@ -383,6 +383,13 @@ class Server(BaseServer):
             http_server_kwargs = {}
         http_server_kwargs.setdefault('xheaders', opts.use_xheaders)
 
+        if opts.ssl_certfile:
+            log.info("Configuring for SSL termination")
+            import ssl
+            context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+            context.load_cert_chain(certfile=opts.ssl_certfile, keyfile=opts.ssl_keyfile, password=opts.ssl_password)
+            http_server_kwargs['ssl_options'] = context
+
         sockets, self._port = bind_sockets(self.address, self.port)
 
         extra_websocket_origins = create_hosts_whitelist(opts.allow_websocket_origin, self.port)
@@ -490,6 +497,18 @@ class _ServerOpts(Options):
     Whether to have the Bokeh server override the remote IP and URI scheme
     and protocol for all requests with ``X-Real-Ip``, ``X-Forwarded-For``,
     ``X-Scheme``, ``X-Forwarded-Proto`` headers (if they are provided).
+    """)
+
+    ssl_certfile = String(default=None, help="""
+
+    """)
+
+    ssl_keyfile = String(default=None, help="""
+
+    """)
+
+    ssl_password = String(default=None, help="""
+
     """)
 
     websocket_max_message_size = Int(default=DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES, help="""

--- a/bokeh/server/server.py
+++ b/bokeh/server/server.py
@@ -500,15 +500,15 @@ class _ServerOpts(Options):
     """)
 
     ssl_certfile = String(default=None, help="""
-
+    The path to a certificate file for SSL termination.
     """)
 
     ssl_keyfile = String(default=None, help="""
-
+    The path to a private key file for SSL termination.
     """)
 
     ssl_password = String(default=None, help="""
-
+    A password to decrypt the SSL keyfile, if necessary.
     """)
 
     websocket_max_message_size = Int(default=DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES, help="""

--- a/bokeh/server/tests/test_server.py
+++ b/bokeh/server/tests/test_server.py
@@ -20,10 +20,11 @@ import pytest ; pytest
 from datetime import timedelta
 import logging
 import re
+import ssl
 import sys
-import mock
 
 # External imports
+import mock
 from tornado import gen
 from tornado.ioloop import PeriodicCallback, IOLoop
 from tornado.httpclient import HTTPError
@@ -271,6 +272,22 @@ def test_use_xheaders():
     application = Application()
     with ManagedServerLoop(application, use_xheaders=True) as server:
         assert server._http.xheaders == True
+
+def test_ssl_args_plumbing():
+    with mock.patch.object(ssl, 'SSLContext'):
+        s = server.Server({}, port=0, ssl_certfile="foo")
+        assert s._http.ssl_options.load_cert_chain.call_args[0] == ()
+        assert s._http.ssl_options.load_cert_chain.call_args[1] == dict(certfile='foo', keyfile=None, password=None)
+
+    with mock.patch.object(ssl, 'SSLContext'):
+        s = server.Server({}, port=0, ssl_certfile="foo", ssl_keyfile="baz")
+        assert s._http.ssl_options.load_cert_chain.call_args[0] == ()
+        assert s._http.ssl_options.load_cert_chain.call_args[1] == dict(certfile='foo', keyfile="baz", password=None)
+
+    with mock.patch.object(ssl, 'SSLContext'):
+        s = server.Server({}, port=0, ssl_certfile="foo", ssl_keyfile="baz", ssl_password="bar")
+        assert s._http.ssl_options.load_cert_chain.call_args[0] == ()
+        assert s._http.ssl_options.load_cert_chain.call_args[1] == dict(certfile='foo', keyfile="baz", password="bar")
 
 # This test just maintains basic creation and setup, detailed functionality
 # is exercised by Server tests above

--- a/bokeh/server/tests/test_server.py
+++ b/bokeh/server/tests/test_server.py
@@ -275,19 +275,19 @@ def test_use_xheaders():
 
 def test_ssl_args_plumbing():
     with mock.patch.object(ssl, 'SSLContext'):
-        s = server.Server({}, port=0, ssl_certfile="foo")
-        assert s._http.ssl_options.load_cert_chain.call_args[0] == ()
-        assert s._http.ssl_options.load_cert_chain.call_args[1] == dict(certfile='foo', keyfile=None, password=None)
+        with ManagedServerLoop({}, ssl_certfile="foo") as server:
+            assert server._http.ssl_options.load_cert_chain.call_args[0] == ()
+            assert server._http.ssl_options.load_cert_chain.call_args[1] == dict(certfile='foo', keyfile=None, password=None)
 
     with mock.patch.object(ssl, 'SSLContext'):
-        s = server.Server({}, port=0, ssl_certfile="foo", ssl_keyfile="baz")
-        assert s._http.ssl_options.load_cert_chain.call_args[0] == ()
-        assert s._http.ssl_options.load_cert_chain.call_args[1] == dict(certfile='foo', keyfile="baz", password=None)
+        with ManagedServerLoop({}, ssl_certfile="foo", ssl_keyfile="baz") as server:
+            assert server._http.ssl_options.load_cert_chain.call_args[0] == ()
+            assert server._http.ssl_options.load_cert_chain.call_args[1] == dict(certfile='foo', keyfile="baz", password=None)
 
     with mock.patch.object(ssl, 'SSLContext'):
-        s = server.Server({}, port=0, ssl_certfile="foo", ssl_keyfile="baz", ssl_password="bar")
-        assert s._http.ssl_options.load_cert_chain.call_args[0] == ()
-        assert s._http.ssl_options.load_cert_chain.call_args[1] == dict(certfile='foo', keyfile="baz", password="bar")
+        with ManagedServerLoop({}, ssl_certfile="foo", ssl_keyfile="baz", ssl_password="bar") as server:
+            assert server._http.ssl_options.load_cert_chain.call_args[0] == ()
+            assert server._http.ssl_options.load_cert_chain.call_args[1] == dict(certfile='foo', keyfile="baz", password="bar")
 
 # This test just maintains basic creation and setup, detailed functionality
 # is exercised by Server tests above

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -413,7 +413,7 @@ class Settings(object):
     will build docs that use BokehJS version ``1.4.0rc1`` from CDN.
     """)
 
-    docs_version = PrioritizedSetting("docs_version", "BOKEH_DOCS_CDN", help="""
+    docs_version = PrioritizedSetting("docs_version", "BOKEH_DOCS_CDN", default=None, help="""
     The Bokeh version to stipulate when building the docs.
 
     This setting is necessary to re-deploy existing versions of docs with new

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -502,7 +502,7 @@ class Settings(object):
     Whether JSON strings should be pretty-printed.
     """)
 
-    py_log_level = PrioritizedSetting("py_log_level", "BOKEH_PY_LOG_LEVEL", default="info", dev_default="debug", convert=convert_logging, help="""
+    py_log_level = PrioritizedSetting("py_log_level", "BOKEH_PY_LOG_LEVEL", default="none", dev_default="debug", convert=convert_logging, help="""
     The log level for Python Bokeh code.
 
     Valid values are, in order of increasing severity:

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -7,118 +7,68 @@
 ''' Control global configuration options with environment variables.
 A global settings object that other parts of Bokeh can refer to.
 
-``BOKEH_ALLOW_WS_ORIGIN`` --- List of websocket origins allowed to access bokeh.
+immediately supplied values
+    These are values that are passed to the setting:
 
-  Comma separated list of domains that need to access bokeh websocket interface.
-  This can also be provided using the --allow-websocket-origin parameter.
+    .. code-block:: python
 
-  Note: This option overrides the --allow-websocket-origin flag
+        settings.minified(minified_val)
 
-``BOKEH_BROWSER`` --- What browser to use when opening plots.
+    If ``minified_val`` is not None, then it will be returned, as-is.
+    Otherwise, if None is passed, then the setting will continute to look
+    down the search order for a value. This is useful for passing optional
+    function paramters that are None by default. If the parameter is passed
+    to the function, then it will take precedence.
 
-  Valid values are any of the browser names understood by the python
-  standard library webbrowser_ module.
+previously user-set values
+    If the value is set explicity in code:
 
-``BOKEH_DEV`` --- Whether to use development mode.
+    .. code-block:: python
 
-  This uses absolute paths to development (non-minified) BokehJS components,
-  sets logging to ``debug``, makes generated HTML and JSON human-readable,
-  etc.
+        settings.minified = False
 
-  This is a meta variable equivalent to the following environment variables:
+    Then this value will take precedence over other sources. Applications
+    may use this ability to set values supplied on the command line, so that
+    they take precedence over environment variables.
 
-  - ``BOKEH_BROWSER=none``
-  - ``BOKEH_LOG_LEVEL=debug``
-  - ``BOKEH_MINIFIED=false``
-  - ``BOKEH_PRETTY=true``
-  - ``BOKEH_PY_LOG_LEVEL=debug``
-  - ``BOKEH_RESOURCES=absolute-dev``
+user-specified config override file
+    Values from a YAML configuration file that is explicitly loaded:
 
-  Accepted values are ``yes``/``no``, ``true``/``false`` or ``0``/``1``.
+    .. code-block:: python
 
-  .. note::
-    When running server and notebook examples, the ``BOKEH_RESOURCES``
-    setting that ``BOKEH_DEV`` sets will cause rendering problems.
+        settings.load_config("/path/to/bokeh.yaml)
 
-    We recommend manually setting ``BOKEH_RESOURCES`` to ``server``
-    for server work, and ``inline`` for notebooks (other
-    :class:`~bokeh.resources.Resources` settings may also work)
+    Any values from ``bokeh.yaml`` will take precedence over the sources
+    below. Applications may offer command line arguments to load such a
+    file. e.g. ``bokeh serve --use-config myconf.yaml``
 
-``BOKEH_DOCS_CDN`` --- What version of BokehJS to use when building sphinx.
+environment variable
+    Values found in the associated environment variables:
 
-  See :ref:`bokeh.resources` module reference for full details.
+    .. code-block:: sh
 
-``BOKEH_DOCS_VERSION`` --- What version of Bokeh to show when building sphinx docs locally.
+        BOKEH_MINIFIED=no bokeh serve app.py
 
-  Useful for re-deployment purposes.
+    * local user config file
 
-  Set to ``"local"`` to use a locally built dev version of BokehJS.
+    Bokeh will look for a YAML configuration file in the current user's
+    home directory ``${HOME}/.bokeh/bokeh.yaml``.
 
-  .. note::
-      This variable is only used when building documentation from the
-      development version.
+global system configuration (not yet implemented)
+    Future support is planned to load Bokeh settings from global system
+    configurations.
 
-``BOKEH_LOG_LEVEL`` --- The BokehJS console logging level to use.
+implicit defaults
+    These are default values defined by the setting declarations. There are
+    regular defaults, as well as "dev" defaults that are used when the
+    environment variable ``BOKEH_DEV=yes`` is set.
 
-  Valid values are, in order of increasing severity:
+If no value is obtained after searching all of these locations, then a
+RuntimeError will be raised.
 
-  - ``trace``
-  - ``debug``
-  - ``info``
-  - ``warn``
-  - ``error``
-  - ``fatal``
+.. bokeh-settings:: settings
+    :module: bokeh.settings
 
-  The default logging level is ``info``.
-
-  .. note::
-      When running server examples, it is the value of this
-      ``BOKEH_LOG_LEVEL`` that is set for the server that matters.
-
-``BOKEH_MINIFIED`` --- Whether to emit minified JavaScript for ``bokeh.js``.
-
-  Accepted values are ``yes``/``no``, ``true``/``false`` or ``0``/``1``.
-
-``BOKEH_PRETTY`` --- Whether to emit "pretty printed" JSON.
-
-  Accepted values are ``yes``/``no``, ``true``/``false`` or ``0``/``1``.
-
-``BOKEH_PY_LOG_LEVEL`` --- The Python logging level to set.
-
-  As in the JS side, valid values are, in order of increasing severity:
-
-  - ``trace``
-  - ``debug``
-  - ``info``
-  - ``warn``
-  - ``error``
-  - ``fatal``
-  - ``none``
-
-  The default logging level is ``none``.
-
-``BOKEH_RESOURCES`` --- What kind of BokehJS resources to configure.
-
-  For example:  ``inline``, ``cdn``, ``server``. See the
-  :class:`~bokeh.core.resources.Resources` class reference for full details.
-
-``BOKEH_ROOTDIR`` --- Root directory to use with ``relative`` resources.
-
-  See the :class:`~bokeh.resources.Resources` class reference for full
-  details.
-
-``BOKEH_SIMPLE_IDS`` --- Whether to generate human-friendly object IDs.
-
-  Accepted values are ``yes``/``no``, ``true``/``false`` or ``0``/``1``.
-  Normally Bokeh generates UUIDs for object identifiers. Setting this variable
-  to an affirmative value will result in more friendly simple numeric IDs
-  counting up from 1000.
-
-``BOKEH_VERSION`` --- What version of BokehJS to use with ``cdn`` resources.
-
-  See the :class:`~bokeh.resources.Resources` class reference for full details.
-
-.. _webbrowser: https://docs.python.org/2/library/webbrowser.html
 '''
 
 #-----------------------------------------------------------------------------
@@ -136,18 +86,21 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import codecs
 import os
-from os.path import join, abspath, isdir
+from os.path import abspath, expanduser, join
 
 # External imports
+import yaml
 
 # Bokeh imports
-from .util.paths import ROOT_DIR, bokehjsdir
+from .util.paths import bokehjsdir
 
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
 
-# __all__ defined at the bottom on the class module
+__all__ = (
+    'settings',
+)
 
 #-----------------------------------------------------------------------------
 # General API
@@ -157,160 +110,473 @@ from .util.paths import ROOT_DIR, bokehjsdir
 # Dev API
 #-----------------------------------------------------------------------------
 
-#-----------------------------------------------------------------------------
-# Private API
-#-----------------------------------------------------------------------------
+def convert_str(value):
+    ''' Return a string as-is
+    '''
+    return value
 
-class _Settings(object):
-    ''' A class to collect global, overridable Bokeh configuration settings.
+def convert_bool(value):
+    ''' Convert a string to True or False
+
+    If a boolean is passed in, it is returned as-is. Otherwise the function
+    maps the following strings, ignoring case:
+
+    * "yes", "1", "on" -> True
+    * "no", "0", "off" -> False
+
+    Args:
+        value (str):
+            A string value to convert to bool
+
+    Returns:
+        bool
+
+    Raises:
+        ValueError
+
+    '''
+    if value in (True, False):
+        return value
+
+    val = value.lower()
+    if val in ["yes", "1", "on", "true", "True"]:
+        return True
+    if val in ["no", "0", "off", "false", "False"]:
+        return False
+
+    raise ValueError("Cannot convert {} to boolean value".format(value))
+
+def convert_str_seq(value):
+    ''' Convert a string to a lit of strings
+
+    If a list or tuple is passed in, it is returned as-is.
+
+    Args:
+        value (str) :
+            A string to convert to a list of strings
+
+    Returns
+        list[str]
+
+    '''
+    if isinstance(value, (list, tuple)):
+        return value
+
+    try:
+        return value.split(",")
+    except:
+        raise ValueError("Cannot convert {} to list value".format(value))
+
+_log_levels = {
+    "CRITICAL" : logging.CRITICAL,
+    "ERROR"    : logging.ERROR,
+    "WARNING"  : logging.WARNING,
+    "INFO"     : logging.INFO,
+    "DEBUG"    : logging.DEBUG,
+    "TRACE"    : 9,  # Custom level hard-coded to avoid circular import
+    "NONE"     : None,
+}
+
+def convert_logging(value):
+    '''Convert a string to a Python logging level
+
+    If a log level is passed in, it is returned as-is. Otherwise the function
+    understands the following strings, ignoring case:
+
+    * "critical"
+    * "error"
+    * "warning"
+    * "info"
+    * "debug"
+    * "trace"
+    * "none"
+
+    Args:
+        value (str):
+            A string value to convert to a logging level
+
+    Returns:
+        int or None
+
+    Raises:
+        ValueError
+
+    '''
+    if value in set(_log_levels.values()):
+        return value
+
+    value = value.upper()
+    if value in _log_levels:
+        return _log_levels[value]
+
+    raise ValueError("Cannot convert {} to log level, valid values are: {}".format(value, ", ".join(_log_levels)))
+
+_default_convert = lambda x: x
+
+class _Unset: pass
+
+def is_dev():
+    return convert_bool(os.environ.get("BOKEH_DEV", False))
+
+class PrioritizedSetting(object):
+    ''' Return a value for a global setting according to configuration precedence.
+
+    The following methods are searched in order for the setting:
+
+    6. immediately supplied values
+    5. previously user-set values (e.g. set from command line)
+    4. user-specified config override file
+    3. environment variable
+    2. local user config file
+    1. global system config file (not yet implemented)
+    0. implicit defaults
+
+    Ref: https://stackoverflow.com/a/11077282/3406693
+
+    If a value cannot be determined, a ValueError is raised.
+
+    The ``env_var`` argument specifies the name of an environment to check for
+    setting values, e.g. ``"BOKEH_LOG_LEVEL"``.
+
+    The optional ``default`` argument specified an implicit default value for
+    the setting that is returned if no other methods provide a value.
+
+    A ``convert`` agument may be provided to convert values before they are
+    returned. For instance to concert log levels in environment variables
+    to ``logging`` module values.
+    '''
+
+    def __init__(self, name, env_var=None, default=_Unset, dev_default=_Unset, convert=None, help=""):
+        self._convert = convert if convert else _default_convert
+        self._default = default
+        self._dev_default = dev_default
+        self._env_var = env_var
+        self._help = help
+        self._name = name
+        self._parent = None
+        self._user_value = _Unset
+
+    def __call__(self, value=None):
+        '''Return the setting value according to the standard precedence.
+
+        Args:
+            value (any, optional):
+                An optional immediate value. If not None, the value will
+                be converted, then returned.
+
+        Returns:
+            str or int or float
+
+        Raises:
+            RuntimeError
+        '''
+
+        # 6. immediate values
+        if value is not None:
+            return self._convert(value)
+
+        # 5. previously user-set value
+        if self._user_value is not _Unset:
+            return self._convert(self._user_value)
+
+        # 4. user-named config file
+        if self._parent and self._name in self._parent.config_override:
+            return self._convert(self._parent.config_override[self._name])
+
+        # 3. environment variable
+        if self._env_var and self._env_var in os.environ:
+            return self._convert(os.environ[self._env_var])
+
+        # 2. local config file
+        if self._parent and self._name in self._parent.config_user:
+            return self._convert(self._parent.config_user[self._name])
+
+        # 1. global config file
+        if self._parent and self._name in self._parent.config_system:
+            return self._convert(self._parent.config_system[self._name])
+
+        # 0. implicit defaults
+        if is_dev() and self._dev_default is not _Unset:
+            return self._convert(self._dev_default)
+        if self._default is not _Unset:
+            return self._convert(self._default)
+
+        raise RuntimeError("No configured value found for setting %r" % self._name)
+
+    def __get__(self, instance, owner):
+        return self
+
+    def __set__(self, instance, value):
+        self.set_value(value)
+
+    def set_value(self, value):
+        ''' Specify a value for this setting programmatically.
+
+        A value set this way takes precedence over all other methods except
+        immediate values.
+
+        Args:
+            value (str or int or float):
+                A user-set value for this setting
+
+        Returns:
+            None
+        '''
+        self._user_value = value
+
+    def unset_value(self):
+        ''' Unset the previous user value such that the priority is reset.
+
+        '''
+        self._user_value = _Unset
+
+    @property
+    def env_var(self):
+        return self._env_var
+
+    @property
+    def default(self):
+        return self._default
+
+    @property
+    def dev_default(self):
+        return self._dev_default
+
+_config_user_locations = (
+    join(expanduser("~"), ".bokeh", "bokeh.yaml"),
+)
+
+_config_system_locations = ()
+
+class Settings(object):
+    '''
 
     '''
 
-    _prefix = "BOKEH_"
-    debugjs = False
+    def __init__(self):
+        self._config_override = {}
+        self._config_user = self._try_load_config(_config_user_locations)
+        self._config_system = {} # TODO (bev)
 
-    # Properties --------------------------------------------------------------
-
-    @property
-    def _environ(self):
-        return os.environ
-
-    def _get(self, key, default=None):
-        return self._environ.get(self._prefix + key, default)
+        for x in self.__class__.__dict__.values():
+            if isinstance(x, PrioritizedSetting):
+                x._parent = self
 
     @property
-    def _is_dev(self):
-        return self._get_bool("DEV", False)
+    def config_system(self):
+        return dict(self._config_system)
+
+    @property
+    def config_user(self):
+        return dict(self._config_user)
+
+    @property
+    def config_override(self):
+        return dict(self._config_override)
 
     @property
     def dev(self):
-        return self._is_dev
+        return is_dev()
 
-    # Public methods ----------------------------------------------------------
+    allowed_ws_origin = PrioritizedSetting("allowed_ws_origin", "BOKEH_ALLOW_WS_ORIGIN", default=[], convert=convert_str_seq, help="""
+    A comma-separated list of allowed websocket origins for Bokeh server applications.
+    """)
 
-    def _dev_or_default(self, default, dev):
-        return dev if dev is not None and self._is_dev else default
+    browser = PrioritizedSetting("browser", "BOKEH_BROWSER", default=None, dev_default="none", help="""
+    The default browser that Bokeh should use to show documents with.
 
-    def _get_str(self, key, default, dev=None):
-        return self._get(key, self._dev_or_default(default, dev))
+    Valid values are any of the browser names understood by the python
+    standard library webbrowser_ module.
 
-    def _get_int(self, key, default, dev=None):
-        return int(self._get(key, self._dev_or_default(default, dev)))
+    .. _webbrowser: https://docs.python.org/2/library/webbrowser.html
+    """)
 
-    def _get_bool(self, key, default, dev=None):
-        value = self._get(key)
+    docs_cdn = PrioritizedSetting("docs_cdn", "BOKEH_DOCS_CDN", default=None, help="""
+    The version of BokehJS that should be use for loading CDN resources when
+    building the docs.
 
-        if value is None:
-            value = self._dev_or_default(default, dev)
-        elif value.lower() in ["true", "yes", "on", "1"]:
-            value = True
-        elif value.lower() in ["false", "no", "off", "0"]:
-            value = False
-        else:
-            raise ValueError("invalid value %r for boolean property %s%s" % (value, self._prefix, key))
+    To build and display the docs using a locally built BokehJS, use ``local``.
+    For example:
 
-        return value
+    .. code-block:: sh
 
-    def _get_list(self, key, default, dev=None):
-        value = self._get(key)
+        BOKEH_DOCS_CDN=local make clean serve
 
-        if value is None:
-            value = self._dev_or_default(default, dev)
-        else:
-            value = self._get(key, self._dev_or_default(default, dev)).split(',')
+    Will build a fresh copy of the docs using the locally built BokehJS and open
+    a new browser tab to view them.
 
-        return value
+    Otherwise, the value is interpreted a version for CDN. For example:
 
-    def browser(self, default=None):
-        ''' Set the default browser that Bokeh should use to show documents
-        with.
+    .. code-block:: sh
+
+        BOKEH_DOCS_CDN=1.4.0rc1 make clean
+
+    will build docs that use BokehJS version ``1.4.0rc1`` from CDN.
+    """)
+
+    docs_version = PrioritizedSetting("docs_version", "BOKEH_DOCS_CDN", help="""
+    The Bokeh version to stipulate when building the docs.
+
+    This setting is necessary to re-deploy existing versions of docs with new
+    fixes or changes.
+    """)
+
+    ignore_filename = PrioritizedSetting("ignore_filename", "BOKEH_IGNORE_FILENAME", default=False, convert=convert_bool, help="""
+    Whether to ignore the current script filename when saving Bokeh content.
+    """)
+
+    log_level = PrioritizedSetting("log_level", "BOKEH_LOG_LEVEL", default="info", dev_default="debug", help="""
+    Set the log level for JavaScript BokehJS code.
+
+    Valid values are, in order of increasing severity:
+
+    - ``trace``
+    - ``debug``
+    - ``info``
+    - ``warn``
+    - ``error``
+    - ``fatal``
+
+    """)
+
+    minified = PrioritizedSetting("minified", "BOKEH_MINIFIED", convert=convert_bool, default=True, dev_default=False, help="""
+    Whether Bokeh should use minified BokehJS resources.
+    """)
+
+    nodejs_path = PrioritizedSetting("nodejs_path", "BOKEH_NODEJS_PATH", default=None, help="""
+    Path to the Node executable.
+
+    NodeJS is an optional dependency that is required for PNG and SVG export,
+    and for compiling custom extensions. Bokeh will try to automatically locate
+    an installed Node executable. Use this environment variable to override the
+    location Bokeh finds, or to point to a non-standard location.
+    """)
+
+    perform_document_validation = PrioritizedSetting("validate_doc", "BOKEH_VALIDATE_DOC", convert=convert_bool, default=True, help="""
+    whether Bokeh should perform validation checks on documents.
+
+    Setting this value to False may afford a small performance improvement.
+    """)
+
+    phantomjs_path = PrioritizedSetting("phantomjs_path", "BOKEH_PHANTOMJS_PATH", default=None, help="""
+    Path to the PhantomJS executable.
+
+    PhantomJS is an optional dependency that is required for PNG and SVG export.
+    Bokeh will try to automatically locate an installed PhantomJS executable.
+    Use this environment variable to override the location Bokeh finds, or to
+    point to a non-standard location.
+    """)
+
+    pretty = PrioritizedSetting("pretty", "BOKEH_PRETTY", default=False, dev_default=True, help="""
+    Whether JSON strings should be pretty-printed.
+    """)
+
+    py_log_level = PrioritizedSetting("py_log_level", "BOKEH_PY_LOG_LEVEL", default="info", dev_default="debug", convert=convert_logging, help="""
+    The log level for Python Bokeh code.
+
+    Valid values are, in order of increasing severity:
+
+    - ``trace``
+    - ``debug``
+    - ``info``
+    - ``warn``
+    - ``error``
+    - ``fatal``
+    - ``none``
+
+    """)
+
+    resources = PrioritizedSetting("resources", "BOKEH_RESOURCES", default="cdn", dev_default="absolute-dev", help="""
+    What kind of BokehJS resources to configure, e.g ``inline`` or ``cdn``
+
+    See the :class:`~bokeh.resources.Resources` class reference for full details.
+    """)
+
+    rootdir = PrioritizedSetting("rootdir", "BOKEH_ROOTDIR", default=None, help="""
+    Root directory to use with ``relative`` resources
+
+    See the :class:`~bokeh.resources.Resources` class reference for full details.
+    """)
+
+    secret_key = PrioritizedSetting("secret_key", "BOKEH_SECRET_KEY", default=None, help="""
+    A long, cryptographically-random secret unique to a Bokeh deployment.
+    """)
+
+    sign_sessions = PrioritizedSetting("sign_sessions", "BOKEH_SIGN_SESSIONS", default=False, help="""
+    Whether the Boeh server should only allow sessions signed with a secret key.
+
+    If True, ``BOKEH_SECRET_KEY`` must also be set.
+    """)
+
+    simple_ids = PrioritizedSetting("simple_ids", "BOKEH_SIMPLE_IDS", default=True, convert=convert_bool, help="""
+    Whether Bokeh should use simple integers for model IDs (starting at 1000).
+
+    If False, Bokeh will use UUIDs for object identifiers. This might be needed,
+    e.g., if mulitple processes are contributing to a single Bokeh Document.
+    """)
+
+    ssl_certfile = PrioritizedSetting("ssl_certfile", "BOKEH_SSL_CERTFILE", default=None, help="""
+    The path to a certificate file for SSL termination.
+    """)
+
+    ssl_keyfile = PrioritizedSetting("ssl_keyfile", "BOKEH_SSL_KEYFILE", default=None, help="""
+    The path to a private key file for SSL termination.
+    """)
+
+    ssl_password = PrioritizedSetting("ssl_password", "BOKEH_SSL_PASSWORD", default=None, help="""
+    A password to decrypt the BOKEH_SSL_KEYFILE
+    """)
+
+    strict = PrioritizedSetting("strict", "BOKEH_STRICT", convert=convert_bool, help="""
+    Whether validation checks should be strict (i.e. raise errors).
+    """)
+
+    version = PrioritizedSetting("version", "BOKEH_VERSION", default=None, help="""
+    What version of BokehJS to use with CDN resources.
+
+    See the :class:`~bokeh.resources.Resources` class reference for full details.
+    """)
+
+    # Non-settings methods
+
+    def bokehjsdir(self):
+        ''' The location of the BokehJS source tree.
 
         '''
-        return self._get_str("BROWSER", default, "none")
+        return bokehjsdir(self.dev)
 
-    def resources(self, default=None):
-        ''' Set (override) the type of resources that Bokeh should use when
-        outputting documents.
-
-        '''
-        return self._get_str("RESOURCES", default, "absolute-dev")
-
-    def rootdir(self, default=None):
-        ''' Set the root directory for "relative" resources.
+    def css_files(self):
+        ''' The CSS files in the BokehJS directory.
 
         '''
-        return self._get_str("ROOTDIR", default)
+        js_files = []
+        for root, dirnames, files in os.walk(self.bokehjsdir()):
+            for fname in files:
+                if fname.endswith(".css"):
+                    js_files.append(join(root, fname))
+        return js_files
 
-    def version(self, default=None):
-        ''' Set (override) the standard reported Bokeh version.
-
-        '''
-        return self._get_str("VERSION", default)
-
-    def docs_cdn(self, default=None):
-        ''' Set the version of BokehJS should use for CDN resources when
-        building the docs.
+    def js_files(self):
+        ''' The JS files in the BokehJS directory.
 
         '''
-        return self._get_str("DOCS_CDN", default)
+        js_files = []
+        for root, dirnames, files in os.walk(self.bokehjsdir()):
+            for fname in files:
+                if fname.endswith(".js"):
+                    js_files.append(join(root, fname))
+        return js_files
 
-    def docs_version(self, default=None):
-        ''' Set the version to use for building the docs.
+    def load_config(self, location):
+        ''' Load a user-specified override config file.
 
-        '''
-        return self._get_str("DOCS_VERSION", default)
-
-    def minified(self, default=None):
-        ''' Set whether Bokeh should use minified BokehJS resources.
-
-        '''
-        return self._get_bool("MINIFIED", default, False)
-
-    def log_level(self, default=None):
-        ''' Set the log level for JavaScript BokehJS code.
+        The file should be a YAML format with ``key: value`` lines.
 
         '''
-        return self._get_str("LOG_LEVEL", default, "debug")
-
-    def py_log_level(self, default='none'):
-        ''' Set the log level for python Bokeh code.
-
-        '''
-        level = self._get_str("PY_LOG_LEVEL", default, "debug")
-        LEVELS = {'trace': logging.TRACE,
-                  'debug': logging.DEBUG,
-                  'info' : logging.INFO,
-                  'warn' : logging.WARNING,
-                  'error': logging.ERROR,
-                  'fatal': logging.CRITICAL,
-                  'none' : None}
-        return LEVELS[level]
-
-    def pretty(self, default=None):
-        ''' Set whether JSON strings should be pretty-printed.
-
-        '''
-        return self._get_bool("PRETTY", default, True)
-
-    def simple_ids(self, default=None):
-        ''' Set whether Bokeh should generate simple numeric model IDs.
-
-        '''
-        return self._get_bool("SIMPLE_IDS", default, True)
-
-    def strict(self, default=None):
-        ''' Set whether validation should be performed strictly.
-
-        '''
-        return self._get_bool("STRICT", default, False)
-
-    def secret_key(self, default=None):
-        ''' Set the secret key.
-
-        Should be a long, cryptographically-random secret unique the
-        Bokeh deployment.
-        '''
-        return self._get_str("SECRET_KEY", default)
+        try:
+            self._config_override = yaml.load(open(abspath(location)), Loader=yaml.SafeLoader)
+        except Exception:
+            raise RuntimeError("Could not load Bokeh config file: {}".format(location))
 
     def secret_key_bytes(self):
         ''' Return the secret_key, converted to bytes and cached.
@@ -324,83 +590,23 @@ class _Settings(object):
                 self._secret_key_bytes = codecs.encode(key, "utf-8")
         return self._secret_key_bytes
 
-    def sign_sessions(self, default=False):
-        ''' Set whether the server should only allow sessions signed with
-        our secret key.
+    def _try_load_config(self, locations):
+        for location in locations:
+            try:
+                return yaml.load(open(location), Loader=yaml.SafeLoader)
+            except:
+                pass
+        return {}
 
-        If True, BOKEH_SECRET_KEY must also be set.
-
-        '''
-        return self._get_bool("SIGN_SESSIONS", default)
-
-    def perform_document_validation(self, default=True):
-        ''' Set whether Bokeh should perform validation checks on documents.
-
-        '''
-        return self._get_bool("VALIDATE_DOC", default)
-
-    # Server settings go here:
-
-    def bokehjssrcdir(self):
-        ''' The absolute path of the BokehJS source code in the installed
-        Bokeh source tree.
-
-        '''
-        if self._is_dev or self.debugjs:
-            bokehjssrcdir = abspath(join(ROOT_DIR, '..', 'bokehjs', 'src'))
-
-            if isdir(bokehjssrcdir):
-                return bokehjssrcdir
-
-        return None
-
-    def bokehjsdir(self):
-        '''
-
-        '''
-        return bokehjsdir(self._is_dev or self.debugjs)
-
-    def js_files(self):
-        ''' The JS files in the BokehJS directory.
-
-        '''
-        bokehjsdir = self.bokehjsdir()
-        js_files = []
-        for root, dirnames, files in os.walk(bokehjsdir):
-            for fname in files:
-                if fname.endswith(".js"):
-                    js_files.append(join(root, fname))
-        return js_files
-
-    def css_files(self):
-        ''' The CSS files in the BokehJS directory.
-
-        '''
-        bokehjsdir = self.bokehjsdir()
-        js_files = []
-        for root, dirnames, files in os.walk(bokehjsdir):
-            for fname in files:
-                if fname.endswith(".css"):
-                    js_files.append(join(root, fname))
-        return js_files
-
-    def nodejs_path(self, default=None):
-        return self._get_str("NODEJS_PATH", default)
-
-    def phantomjs_path(self, default=None):
-        return self._get_str("PHANTOMJS_PATH", default)
-
-    def ignore_filename(self):
-        return self._get_bool("IGNORE_FILENAME", False)
-
-    def allowed_ws_origin(self, default=None):
-        return self._get_list("ALLOW_WS_ORIGIN", default)
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
 
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
 
-settings = _Settings()
+settings = Settings()
 
 if settings.secret_key() is not None:
     if len(settings.secret_key()) < 32:
@@ -409,8 +615,4 @@ if settings.secret_key() is not None:
 
 if settings.sign_sessions() and settings.secret_key() is None:
     import warnings
-    warnings.warn("BOKEH_SECRET_KEY must be set if BOKEH_SIGN_SESSIONS is set to true")
-
-__all__ = (
-  'settings',
-)
+    warnings.warn("BOKEH_SECRET_KEY must be set if BOKEH_SIGN_SESSIONS is set to True")

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -555,7 +555,7 @@ class Settings(object):
     """)
 
     ssl_password = PrioritizedSetting("ssl_password", "BOKEH_SSL_PASSWORD", default=None, help="""
-    A password to decrypt the BOKEH_SSL_KEYFILE
+     A password to decrypt the SSL keyfile, if necessary.
     """)
 
     strict = PrioritizedSetting("strict", "BOKEH_STRICT", convert=convert_bool, help="""

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -7,6 +7,8 @@
 ''' Control global configuration options with environment variables.
 A global settings object that other parts of Bokeh can refer to.
 
+Setting values are always looked up in the following prescribed order:
+
 immediately supplied values
     These are values that are passed to the setting:
 
@@ -65,8 +67,25 @@ implicit defaults
 If no value is obtained after searching all of these locations, then a
 RuntimeError will be raised.
 
+Defined Settings
+~~~~~~~~~~~~~~~~
+
+Settings are accessible on the ``bokeh.settings.settings`` instance, via
+accessor methods. For instance:
+
+.. code-block::
+
+    settings.minified()
+
+Bokeh provides the following defined settings:
+
 .. bokeh-settings:: settings
     :module: bokeh.settings
+
+Additionally, there are a few methods on the ``settings`` object:
+
+.. autoclass:: Settings
+    :members:
 
 '''
 
@@ -210,8 +229,6 @@ def convert_logging(value):
 
     raise ValueError("Cannot convert {} to log level, valid values are: {}".format(value, ", ".join(_log_levels)))
 
-_default_convert = lambda x: x
-
 class _Unset: pass
 
 def is_dev():
@@ -246,7 +263,7 @@ class PrioritizedSetting(object):
     '''
 
     def __init__(self, name, env_var=None, default=_Unset, dev_default=_Unset, convert=None, help=""):
-        self._convert = convert if convert else _default_convert
+        self._convert = convert if convert else convert_str
         self._default = default
         self._dev_default = dev_default
         self._env_var = env_var
@@ -340,6 +357,21 @@ class PrioritizedSetting(object):
     @property
     def dev_default(self):
         return self._dev_default
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def help(self):
+        return self._help
+
+    @property
+    def convert_type(self):
+        if self._convert is convert_str: return "String"
+        if self._convert is convert_bool: return "Bool"
+        if self._convert is convert_logging: return "Log Level"
+        if self._convert is convert_str_seq: return "List[String]"
 
 _config_user_locations = (
     join(expanduser("~"), ".bokeh", "bokeh.yaml"),

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -49,8 +49,7 @@ environment variable
 
         BOKEH_MINIFIED=no bokeh serve app.py
 
-    * local user config file
-
+local user config file
     Bokeh will look for a YAML configuration file in the current user's
     home directory ``${HOME}/.bokeh/bokeh.yaml``.
 

--- a/bokeh/sphinxext/_templates/settings_detail.rst
+++ b/bokeh/sphinxext/_templates/settings_detail.rst
@@ -1,0 +1,12 @@
+{% for setting in settings %}
+
+.. data:: {{ setting['_name'] }}
+    :annotation: = {{ setting['_env_var'] }}
+
+{{ setting['_help']|indent(4) }}
+
+{% endfor %}
+
+
+. autoclass:: {{ module_name }}.Settings
+    :members:

--- a/bokeh/sphinxext/_templates/settings_detail.rst
+++ b/bokeh/sphinxext/_templates/settings_detail.rst
@@ -1,12 +1,13 @@
 {% for setting in settings %}
 
-.. data:: {{ setting['_name'] }}
-    :annotation: = {{ setting['_env_var'] }}
+.. data:: {{ setting['name'] }}
+    :annotation:
 
-{{ setting['_help']|indent(4) }}
+    * **Type**: {{ setting['type'] }}
+    * **Env var**: ``{{ setting['env_var'] }}``
+    * **Default**: {{ setting['default'] }}
+    * **Dev Default**: {{ setting['dev_default'] }}
+
+    {{ setting['help']|indent(4) }}
 
 {% endfor %}
-
-
-. autoclass:: {{ module_name }}.Settings
-    :members:

--- a/bokeh/sphinxext/bokeh_settings.py
+++ b/bokeh/sphinxext/bokeh_settings.py
@@ -1,0 +1,111 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2019, Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+''' Thoroughly document Bokeh settings.
+
+The ``bokeh-model`` directive will automatically document all the attributes
+(including Bokeh PrioritizedSettings) of an object.
+
+This directive takes the name of a module attribute
+
+.. code-block:: rest
+
+    .. bokeh-settings:: settings
+        :module: bokeh.settings
+
+'''
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+log = logging.getLogger(__name__)
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+import importlib
+
+# External imports
+from docutils.parsers.rst.directives import unchanged
+
+from sphinx.errors import SphinxError
+
+# Bokeh imports
+from ..settings import PrioritizedSetting
+from .bokeh_directive import BokehDirective, py_sig_re
+from .templates import SETTINGS_DETAIL
+
+#-----------------------------------------------------------------------------
+# Globals and constants
+#-----------------------------------------------------------------------------
+
+__all__ = (
+    'BokehSettingsDirective',
+    'setup',
+)
+
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
+class BokehSettingsDirective(BokehDirective):
+
+    has_content = True
+    required_arguments = 1
+    optional_arguments = 1
+    option_spec = {
+        'module': unchanged
+    }
+
+    def run(self):
+        sig = " ".join(self.arguments)
+
+        m = py_sig_re.match(sig)
+        if m is None:
+            raise SphinxError("Unable to parse signature for bokeh-model: %r" % sig)
+        name_prefix, obj_name, arglist, retann = m.groups()
+
+        module_name = self.options['module']
+
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError:
+            raise SphinxError("Unable to generate reference docs for %s, couldn't import module '%s'" % (obj_name, module_name))
+
+        obj = getattr(module, obj_name, None)
+        if obj is None:
+            raise SphinxError("Unable to generate reference docs for %s, no model '%s' in %s" % (obj_name, obj_name, module_name))
+
+        settings = [x.__dict__ for x in obj.__class__.__dict__.values() if isinstance(x, PrioritizedSetting)]
+
+        rst_text = SETTINGS_DETAIL.render(
+            name=obj_name,
+            module_name=module_name,
+            settings=settings
+        )
+
+        return self._parse(rst_text, "<bokeh-settings>")
+
+def setup(app):
+    ''' Required Sphinx extension setup function. '''
+    app.add_directive_to_domain('py', 'bokeh-settings', BokehSettingsDirective)
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------

--- a/bokeh/sphinxext/templates.py
+++ b/bokeh/sphinxext/templates.py
@@ -96,6 +96,8 @@ PLOT_PAGE = _env.get_template("plot_page.rst")
 
 PROP_DETAIL = _env.get_template("prop_detail.rst")
 
+SETTINGS_DETAIL = _env.get_template("settings_detail.rst")
+
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------

--- a/bokeh/tests/test_resources.py
+++ b/bokeh/tests/test_resources.py
@@ -46,9 +46,9 @@ DEFAULT_LOG_JS_RAW = 'Bokeh.set_log_level("info");'
 
 ## Test JSResources
 
-def test_js_resources_default_mode_is_inline():
+def test_js_resources_default_mode_is_cdn():
     r = resources.JSResources()
-    assert r.mode == "inline"
+    assert r.mode == "cdn"
 
 
 def test_js_resources_inline_has_no_css_resources():
@@ -64,9 +64,9 @@ def test_js_resources_inline_has_no_css_resources():
 
 ## Test CSSResources
 
-def test_css_resources_default_mode_is_inline():
+def test_css_resources_default_mode_is_cdn():
     r = resources.CSSResources()
-    assert r.mode == "inline"
+    assert r.mode == "cdn"
 
 
 def test_inline_css_resources():
@@ -83,7 +83,7 @@ class TestResources(object):
 
     def test_basic(self):
         r = resources.Resources()
-        assert r.mode == "inline"
+        assert r.mode == "cdn"
 
     def test_log_level(self):
         r = resources.Resources()

--- a/bokeh/tests/test_settings.py
+++ b/bokeh/tests/test_settings.py
@@ -44,30 +44,242 @@ logging.basicConfig(level=logging.DEBUG)
 
 Test___all__ = verify_all(bs, ALL)
 
+_expected_settings = (
+    'allowed_ws_origin',
+    'browser',
+    'docs_cdn',
+    'docs_version',
+    'ignore_filename',
+    'log_level',
+    'minified',
+    'nodejs_path',
+    'perform_document_validation',
+    'phantomjs_path',
+    'pretty',
+    'py_log_level',
+    'resources',
+    'rootdir',
+    'secret_key',
+    'sign_sessions',
+    'simple_ids',
+    'ssl_certfile',
+    'ssl_keyfile',
+    'ssl_password',
+    'strict',
+    'version',
+)
+
+class TestSettings(object):
+
+    def test_standard_settings(self):
+        settings = [k for k,v in bs.settings.__class__.__dict__.items() if isinstance(v, bs.PrioritizedSetting)]
+        assert set(settings) == set(_expected_settings)
+
+    @pytest.mark.parametrize("name", _expected_settings)
+    def test_prefix(self, name):
+        ps = getattr(bs.settings, name)
+        assert ps.env_var.startswith("BOKEH_")
+
+    @pytest.mark.parametrize("name", _expected_settings)
+    def test_parent(self, name):
+        ps = getattr(bs.settings, name)
+        assert ps._parent == bs.settings
+
+    def test_types(self):
+        assert bs.settings.ignore_filename._convert == bs.convert_bool
+        assert bs.settings.minified._convert == bs.convert_bool
+        assert bs.settings.perform_document_validation._convert == bs.convert_bool
+        assert bs.settings.simple_ids._convert == bs.convert_bool
+        assert bs.settings.strict._convert == bs.convert_bool
+
+        assert bs.settings.py_log_level._convert == bs.convert_logging
+
+        assert bs.settings.allowed_ws_origin._convert == bs.convert_str_seq
+
+        default_typed = set(_expected_settings) - set([
+            'ignore_filename',
+            'minified',
+            'perform_document_validation',
+            'simple_ids',
+            'strict',
+            'py_log_level',
+            'allowed_ws_origin'
+        ])
+        for name in default_typed:
+            ps = getattr(bs.settings, name)
+            assert ps._convert == bs._default_convert
+
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------
 
+class TestConverters(object):
+    @pytest.mark.parametrize("value", ["Yes", "YES", "yes", "1", "ON", "on", "true", "True", True])
+    def test_convert_bool(self, value):
+        assert bs.convert_bool(value)
+
+    @pytest.mark.parametrize("value", ["No", "NO", "no", "0", "OFF", "off", "false", "False", False])
+    def test_convert_bool_false(self, value):
+        assert not bs.convert_bool(value)
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_convert_bool_identity(self, value):
+        assert bs.convert_bool(value) == value
+
+    def test_convert_bool_bad(self):
+        with pytest.raises(ValueError):
+            bs.convert_bool("junk")
+
+    @pytest.mark.parametrize("value", ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"])
+    def test_convert_logging_good(self, value):
+        assert bs.convert_logging(value) == getattr(logging, value)
+
+        # check lowercase works too
+        assert bs.convert_logging(value.lower()) == getattr(logging, value)
+
+    def test_convert_logging_none(self):
+        assert bs.convert_logging("NONE") == None
+
+        # check lowercase works
+        assert bs.convert_logging("none") == None
+
+        # check value works
+        assert bs.convert_logging(None) == None
+
+    @pytest.mark.parametrize("value", ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"])
+    def test_convert_logging_identity(self, value):
+        level = getattr(logging, value)
+        assert bs.convert_logging(level) == level
+
+    def test_convert_logging_bad(self):
+        with pytest.raises(ValueError):
+            bs.convert_logging("junk")
+
+class TestPrioritizedSetting(object):
+    def test_env_var_property(self):
+        ps = bs.PrioritizedSetting("foo", env_var="BOKEH_FOO")
+        assert ps.env_var == "BOKEH_FOO"
+
+    def test_everything_unset_raises(self):
+        ps = bs.PrioritizedSetting("foo")
+        with pytest.raises(RuntimeError):
+            ps()
+
+    def test_implict_default(self):
+        ps = bs.PrioritizedSetting("foo", default=10)
+        assert ps() == 10
+
+    def test_implict_default_converts(self):
+        ps = bs.PrioritizedSetting("foo", convert=int, default="10")
+        assert ps() == 10
+
+    def test_default(self):
+        ps = bs.PrioritizedSetting("foo", env_var="BOKEH_FOO", default=10)
+        assert ps.default == 10
+        assert ps() == 10
+
+    def test_dev_default(self):
+        ps = bs.PrioritizedSetting("foo", env_var="BOKEH_FOO", default=10, dev_default=20)
+        assert ps.dev_default == 20
+        os.environ['BOKEH_DEV'] = "yes"
+        assert ps() == 20
+        del os.environ['BOKEH_DEV']
+
+    def test_env_var(self):
+        os.environ["BOKEH_FOO"] = "30"
+        ps = bs.PrioritizedSetting("foo", env_var="BOKEH_FOO")
+        assert ps.env_var == "BOKEH_FOO"
+        assert ps() == "30"
+        del os.environ["BOKEH_FOO"]
+
+    def test_env_var_converts(self):
+        os.environ["BOKEH_FOO"] = "30"
+        ps = bs.PrioritizedSetting("foo", convert=int, env_var="BOKEH_FOO")
+        assert ps() == 30
+        del os.environ["BOKEH_FOO"]
+
+    def test_user_set(self):
+        ps = bs.PrioritizedSetting("foo")
+        ps.set_value(40)
+        assert ps() == 40
+
+    def test_user_unset(self):
+        ps = bs.PrioritizedSetting("foo", default=2)
+        ps.set_value(40)
+        assert ps() == 40
+        ps.unset_value()
+        assert ps() == 2
+
+    def test_user_set_converts(self):
+        ps = bs.PrioritizedSetting("foo", convert=int)
+        ps.set_value("40")
+        assert ps() == 40
+
+    def test_immediate(self):
+        ps = bs.PrioritizedSetting("foo")
+        assert ps(50) == 50
+
+    def test_immediate_converts(self):
+        ps = bs.PrioritizedSetting("foo", convert=int)
+        assert ps("50") == 50
+
+    def test_precedence(self):
+        class FakeSettings(object):
+            config_override = {}
+            config_user = {}
+            config_system = {}
+
+        ps = bs.PrioritizedSetting("foo", env_var="BOKEH_FOO", convert=int, default=0, dev_default=5)
+        ps._parent = FakeSettings
+
+        # 0. implicit default
+        assert ps() == 0
+
+        # 0. implicit default (DEV)
+        os.environ['BOKEH_DEV'] = "yes"
+        assert ps() == 5
+        del os.environ['BOKEH_DEV']
+
+        # 1. global config file
+        FakeSettings.config_system['foo'] = 10
+        assert ps() == 10
+
+        # 2. local config file
+        FakeSettings.config_user['foo'] = 20
+        assert ps() == 20
+
+        # 3. environment variable
+        os.environ["BOKEH_FOO"] = "30"
+        assert ps() == 30
+
+        # 4. override config file
+        FakeSettings.config_override['foo'] = 40
+        assert ps() == 40
+
+        # 5. previously user-set value
+        ps.set_value(50)
+        assert ps() == 50
+
+        # 6. immediate values
+        assert ps(60) == 60
+
+        del os.environ["BOKEH_FOO"]
+
+    def test_descriptors(self):
+        class FakeSettings(object):
+            foo = bs.PrioritizedSetting("foo", env_var="BOKEH_FOO")
+            bar = bs.PrioritizedSetting("bar", env_var="BOKEH_BAR", default=10)
+
+        s = FakeSettings()
+        assert s.foo is FakeSettings.foo
+
+        assert s.bar() == 10
+        s.bar = 20
+        assert s.bar() == 20
+
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------
-
-class Test__get_list(object):
-    def test_single(self):
-        os.environ["BOKEH_FOO"] = "foo"
-        result = bs.settings._get_list("FOO", None)
-        assert result == ["foo"]
-        del os.environ["BOKEH_FOO"]
-
-    def test_multiple(self):
-        os.environ["BOKEH_FOO"] = "foo,bar,foobar"
-        result = bs.settings._get_list("FOO", None)
-        assert result == ["foo", "bar", "foobar"]
-        del os.environ["BOKEH_FOO"]
-
-    def test_default(self):
-        result = bs.settings._get_list("FOO", None)
-        assert result is None
 
 #-----------------------------------------------------------------------------
 # Code

--- a/bokeh/tests/test_settings.py
+++ b/bokeh/tests/test_settings.py
@@ -86,15 +86,15 @@ class TestSettings(object):
         assert ps._parent == bs.settings
 
     def test_types(self):
-        assert bs.settings.ignore_filename._convert == bs.convert_bool
-        assert bs.settings.minified._convert == bs.convert_bool
-        assert bs.settings.perform_document_validation._convert == bs.convert_bool
-        assert bs.settings.simple_ids._convert == bs.convert_bool
-        assert bs.settings.strict._convert == bs.convert_bool
+        assert bs.settings.ignore_filename.convert_type == "Bool"
+        assert bs.settings.minified.convert_type == "Bool"
+        assert bs.settings.perform_document_validation.convert_type == "Bool"
+        assert bs.settings.simple_ids.convert_type == "Bool"
+        assert bs.settings.strict.convert_type == "Bool"
 
-        assert bs.settings.py_log_level._convert == bs.convert_logging
+        assert bs.settings.py_log_level.convert_type == "Log Level"
 
-        assert bs.settings.allowed_ws_origin._convert == bs.convert_str_seq
+        assert bs.settings.allowed_ws_origin.convert_type == "List[String]"
 
         default_typed = set(_expected_settings) - set([
             'ignore_filename',
@@ -107,7 +107,7 @@ class TestSettings(object):
         ])
         for name in default_typed:
             ps = getattr(bs.settings, name)
-            assert ps._convert == bs._default_convert
+            assert ps.convert_type == "String"
 
 #-----------------------------------------------------------------------------
 # Dev API
@@ -172,6 +172,14 @@ class TestPrioritizedSetting(object):
     def test_implict_default_converts(self):
         ps = bs.PrioritizedSetting("foo", convert=int, default="10")
         assert ps() == 10
+
+    def test_help(self):
+        ps = bs.PrioritizedSetting("foo", env_var="BOKEH_FOO", default=10, help="bar")
+        assert ps.help == "bar"
+
+    def test_name(self):
+        ps = bs.PrioritizedSetting("foo", env_var="BOKEH_FOO", default=10)
+        assert ps.name == "foo"
 
     def test_default(self):
         ps = bs.PrioritizedSetting("foo", env_var="BOKEH_FOO", default=10)

--- a/bokeh/util/browser.py
+++ b/bokeh/util/browser.py
@@ -65,10 +65,6 @@ def get_browser_controller(browser=None):
             the ``webbrowser`` standard library module. In the value is
             ``None`` then a system default is used.
 
-    .. note::
-        If the environment variable ``BOKEH_BROWSER`` is set, it will take
-        precedence.
-
     Returns:
         controller : a web browser controller
 

--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -251,7 +251,7 @@ def make_id():
     '''
     global _simple_id
 
-    if settings.simple_ids(True):
+    if settings.simple_ids():
         with _simple_id_lock:
             _simple_id += 1
             return str(_simple_id)

--- a/bokeh/util/tests/test_browser.py
+++ b/bokeh/util/tests/test_browser.py
@@ -64,15 +64,12 @@ def test_get_browser_controller_value(mock_get):
 def test_get_browser_controller_dummy_with_env(mock_get):
     os.environ['BOKEH_BROWSER'] = "bar"
     bub.get_browser_controller('none')
-    assert mock_get.called
-    assert mock_get.call_args[0] == ("bar",)
-    assert mock_get.call_args[1] == {}
     del os.environ['BOKEH_BROWSER']
 
 @patch('webbrowser.get')
 def test_get_browser_controller_None_with_env(mock_get):
     os.environ['BOKEH_BROWSER'] = "bar"
-    bub.get_browser_controller(None)
+    bub.get_browser_controller()
     assert mock_get.called
     assert mock_get.call_args[0] == ("bar",)
     assert mock_get.call_args[1] == {}
@@ -83,7 +80,7 @@ def test_get_browser_controller_value_with_env(mock_get):
     os.environ['BOKEH_BROWSER'] = "bar"
     bub.get_browser_controller('foo')
     assert mock_get.called
-    assert mock_get.call_args[0] == ("bar",)
+    assert mock_get.call_args[0] == ("foo",)
     assert mock_get.call_args[1] == {}
     del os.environ['BOKEH_BROWSER']
 

--- a/scripts/ci/install
+++ b/scripts/ci/install
@@ -11,7 +11,7 @@ fi
 wget -qO- "https://raw.githubusercontent.com/travis-ci/artifacts/master/install" |bash
 
 # install Miniconda
-PYTHON="${PYTHON:-3.7}"
+PYTHON="${PYTHON:-3.7.2}" # XXXX pin to 3.7.2 for now: https://github.com/ContinuumIO/anaconda-issues/issues/11196
 MINICONDA_FILENAME=Miniconda${PYTHON:0:1}-latest-Linux-x86_64.sh
 if  [ "${NO_INSTALL_CONDA}" != "1" ]; then
     wget -nv "http://repo.continuum.io/miniconda/${MINICONDA_FILENAME}"

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -45,6 +45,7 @@ extensions = [
     'bokeh.sphinxext.bokeh_plot',
     'bokeh.sphinxext.bokeh_prop',
     'bokeh.sphinxext.bokeh_releases',
+    'bokeh.sphinxext.bokeh_settings',
     'bokeh.sphinxext.bokeh_sitemap',
     'bokeh.sphinxext.bokehjs_content',
     'bokeh.sphinxext.collapsible_code_block',

--- a/sphinx/source/docs/dev_guide/env_vars.rst
+++ b/sphinx/source/docs/dev_guide/env_vars.rst
@@ -3,30 +3,13 @@
 Environment Variables
 =====================
 
-There are several environment variables that can be useful for developers:
+Most of the environment variables that can be set to affect Bokeh operation
+are described in the :ref:`bokeh.settings` reference guide. In addition to
+those, there is a ``BOKEH_DEV`` environment variable that may be useful to
+set for local development.
 
-``BOKEH_ALLOW_WS_ORIGIN``
--------------------------
-List of websocket origins allowed to access bokeh.
-Comma separated list of domains that need to access bokeh websocket interface.
-This can also be provided using the --allow-websocket-origin parameter.
-
-Note: This option overrides the --allow-websocket-origin flag
-
-``BOKEH_BROWSER``
------------------
-What browser to use when opening plots
-Valid values are any of the browser names understood by the python
-standard library webbrowser_ module.
-
-``BOKEH_DEV``
---------------
-Whether to use development mode
-This uses absolute paths to development (non-minified) BokehJS components,
-sets logging to ``debug``, makes generated HTML and JSON human-readable,
-etc.
-
-This is a meta variable equivalent to the following environment variables:
+Setting ``BOKEH_DEV=true`` is equivalent to setting all of the following
+individually:
 
 - ``BOKEH_BROWSER=none``
 - ``BOKEH_LOG_LEVEL=debug``
@@ -35,7 +18,8 @@ This is a meta variable equivalent to the following environment variables:
 - ``BOKEH_PY_LOG_LEVEL=debug``
 - ``BOKEH_RESOURCES=absolute-dev``
 
-Accepted values are ``yes``/``no``, ``true``/``false`` or ``0``/``1``.
+In general this ensure local, unminified BokehJS resources are used, ups the
+default log levels, and makes generated HTML and JSON more human-readable
 
 .. note::
     When running server and notebook examples, the ``BOKEH_RESOURCES``
@@ -44,116 +28,3 @@ Accepted values are ``yes``/``no``, ``true``/``false`` or ``0``/``1``.
     We recommend manually setting ``BOKEH_RESOURCES`` to ``server``
     for server work, and ``inline`` for notebooks (other
     :class:`~bokeh.resources.Resources` settings may also work)
-
-``BOKEH_DOCS_CDN``
---------------------
-What version of BokehJS to use when building sphinx docs.
-
-To build and display the docs using a locally built BokehJS, set to ``local``.
-For example:
-
-.. code-block:: sh
-
-    BOKEH_DOCS_CDN=local make clean serve
-
-Will build a fresh copy of the docs using the locally built BokehJS and open
-a new browser tab to view hem.
-
-To build test docs to deploy to a one-off location on the docs site, set to
-``test:<location>``. For example:
-
-.. code-block:: sh
-
-    BOKEH_DOCS_CDN=test:newthing make clean
-
-will build docs that can be deployed with ``fab deploy:newthing``.
-
-Otherwise, the value is interpreted a version for CDN:
-
-.. code-block:: sh
-
-    BOKEH_DOCS_CDN=0.12.7rc1 make clean
-
-will build docs that use BokehJS version ``0.12.7rc1`` from CDN (whether viewed
-locally or deployed to the docs site).
-
-``BOKEH_DOCS_VERSION``
-~~~~~~~~~~~~~~~~~~~~~~
-What version of Bokeh to show when building sphinx docs locally. Useful if it
-is necessary to re-deploy old docs with hotfixes.
-
-``BOKEH_LOG_LEVEL``
--------------------
-The BokehJS console logging level to use Valid values are, in order of increasing severity:
-
-  - ``trace``
-  - ``debug``
-  - ``info``
-  - ``warn``
-  - ``error``
-  - ``fatal``
-
-The default logging level is ``info``.
-
-.. note::
-    When running server examples, it is the value of this
-    ``BOKEH_LOG_LEVEL`` that is set for the server that matters.
-
-``BOKEH_MINIFIED``
--------------------
-Whether to emit minified JavaScript for ``bokeh.js``
-Accepted values are ``yes``/``no``, ``true``/``false`` or ``0``/``1``.
-
-``BOKEH_PRETTY``
------------------
-Whether to emit "pretty printed" JSON
-Accepted values are ``yes``/``no``, ``true``/``false`` or ``0``/``1``.
-
-``BOKEH_PY_LOG_LEVEL``
------------------------
-The Python logging level to set
-As in the JS side, valid values are, in order of increasing severity:
-
-  - ``trace``
-  - ``debug``
-  - ``info``
-  - ``warn``
-  - ``error``
-  - ``fatal``
-  - ``none``
-
-The default logging level is ``none``.
-
-``BOKEH_RESOURCES``
---------------------
-What kind of BokehJS resources to configure
-For example:  ``inline``, ``cdn``, ``server``. See the
-:class:`~bokeh.resources.Resources` class reference for full details.
-
-``BOKEH_ROOTDIR``
-------------------
-Root directory to use with ``relative`` resources
-See the :class:`~bokeh.resources.Resources` class reference for full
-details.
-
-``BOKEH_SIMPLE_IDS``
------------------------
-Whether to generate human-friendly object IDs
-Accepted values are ``yes``/``no``, ``true``/``false`` or ``0``/``1``.
-Normally Bokeh generates UUIDs for object identifiers. Setting this variable
-to an affirmative value will result in more friendly simple numeric IDs
-counting up from 1000.
-
-``BOKEH_VALIDATE_DOC``
------------------------
-Whether to perform a validation check on the document before outputting.
-Accepted values are ``yes``/``no``, ``true``/``false`` or ``0``/``1``.
-Setting this variable to a negative value for a document that is known to be
-correctly configured may yield performance improvements.
-
-``BOKEH_VERSION``
------------------
-What version of BokehJS to use with ``cdn`` resources
-See the :class:`~bokeh.resources.Resources` class reference for full details.
-
-.. _webbrowser: https://docs.python.org/2/library/webbrowser.html

--- a/sphinx/source/docs/reference/settings.rst
+++ b/sphinx/source/docs/reference/settings.rst
@@ -4,4 +4,3 @@ bokeh.settings
 ==============
 
 .. automodule:: bokeh.settings
-  :members:

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -811,6 +811,33 @@ local machine.
     and wish to contribute your knowledge here, please
     contact us on https://discourse.bokeh.org
 
+.. _userguide_server_deployment_ssl:
+
+SSL Termination
+~~~~~~~~~~~~~~~
+
+A Bokeh server can be configure to terminate SSL connections (i.e. to service
+secure HTTPS and WSS sessions) directly. At a minimum, the ``--ssl-certfile``
+argument must be supplied. The value must be the path to a single file in PEM
+format containing the certificate as well as any number of CA certificates
+needed to establish the certificate's authenticity:
+
+.. code-block:: sh
+
+    bokeh serve --ssl-certfile /path/to/cert.pem
+
+The path to the certificate file may also be supplied by setting the environment
+variable ``BOKEH_SSL_CERTFILE``.
+
+If the private key is stored separately, its location may be supplied by
+setting the ``--ssl-keyfile`` command line argument, or by setting the
+``BOKEH_SSL_KEYFILE`` evironment variable. If a password is required for the
+private key, it should be supplied by setting the ``BOKEH_SSL_PASSWORD``
+environment variable.
+
+Alternativey, you may wish to run a Boekh server behind a proxy, and have the
+proxy terminate SSL. That scenario is described in the next section.
+
 .. _userguide_server_deplyoment_proxy:
 
 Basic Reverse Proxy Setup


### PR DESCRIPTION
This one went a bit afield. I finally got fed up with the existing `bokeh.settings` and inconsistencies in settings preference order, that I redid the whole thing so that:

* the order for checking settings is documented and consistent 
* settings can be auto-documented 
* support for settings config files

There's still work to do (for 2.0 to make sure this new settings system is applied consistently and that there are conventions about who has responsibility for what. 

- [x] issues: fixes #9139
- [x] tests added / passed
- [x] release document entry (if new feature or API change)