### PR TITLE
Enable more eslint rules

### DIFF
--- a/bokehjs/eslint.json
+++ b/bokehjs/eslint.json
@@ -29,6 +29,7 @@
     }],
     "comma-spacing": ["error", {"before": false, "after": true}],
     "comma-dangle": ["error", "always-multiline"],
-    "@typescript-eslint/type-annotation-spacing": ["error"]
+    "@typescript-eslint/type-annotation-spacing": ["error"],
+    "no-floating-decimal": ["error"]
   }
 }

--- a/bokehjs/eslint.json
+++ b/bokehjs/eslint.json
@@ -32,6 +32,11 @@
     "comma-dangle": ["error", "always-multiline"],
     "no-trailing-spaces": ["error"],
     "@typescript-eslint/type-annotation-spacing": ["error"],
-    "no-floating-decimal": ["error"]
+    "no-floating-decimal": ["error"],
+    "space-before-function-paren": ["error", {
+      "anonymous": "never",
+      "named": "never",
+      "asyncArrow": "always"
+    }]
   }
 }

--- a/bokehjs/eslint.json
+++ b/bokehjs/eslint.json
@@ -14,6 +14,7 @@
   "plugins": ["@typescript-eslint"],
   "extends": [],
   "rules": {
+    "semi": ["error", "never"],
     "indent": ["error", 2, {
       "SwitchCase": 1,
       "outerIIFEBody": 1,

--- a/bokehjs/eslint.json
+++ b/bokehjs/eslint.json
@@ -27,6 +27,7 @@
       "FunctionExpression": {"body": 1, "parameters": "off"},
       "ignoredNodes": ["ConditionalExpression"]
     }],
+    "brace-style": ["error", "1tbs", {"allowSingleLine": true}],
     "comma-spacing": ["error", {"before": false, "after": true}],
     "comma-dangle": ["error", "always-multiline"],
     "@typescript-eslint/type-annotation-spacing": ["error"],

--- a/bokehjs/eslint.json
+++ b/bokehjs/eslint.json
@@ -37,6 +37,7 @@
       "anonymous": "never",
       "named": "never",
       "asyncArrow": "always"
-    }]
+    }],
+    "space-in-parens": ["error", "never"]
   }
 }

--- a/bokehjs/eslint.json
+++ b/bokehjs/eslint.json
@@ -30,6 +30,7 @@
     "brace-style": ["error", "1tbs", {"allowSingleLine": true}],
     "comma-spacing": ["error", {"before": false, "after": true}],
     "comma-dangle": ["error", "always-multiline"],
+    "no-trailing-spaces": ["error"],
     "@typescript-eslint/type-annotation-spacing": ["error"],
     "no-floating-decimal": ["error"]
   }

--- a/bokehjs/eslint.json
+++ b/bokehjs/eslint.json
@@ -14,6 +14,18 @@
   "plugins": ["@typescript-eslint"],
   "extends": [],
   "rules": {
+    "indent": ["error", 2, {
+      "SwitchCase": 1,
+      "outerIIFEBody": 1,
+      "ArrayExpression": "first",
+      "ObjectExpression": "first",
+      "ImportDeclaration": "first",
+      "VariableDeclarator": "first",
+      "CallExpression": {"arguments": "first"},
+      "FunctionDeclaration": {"body": 1, "parameters": "off"},
+      "FunctionExpression": {"body": 1, "parameters": "off"},
+      "ignoredNodes": ["ConditionalExpression"]
+    }],
     "comma-spacing": ["error", {"before": false, "after": true}],
     "comma-dangle": ["error", "always-multiline"],
     "@typescript-eslint/type-annotation-spacing": ["error"]

--- a/bokehjs/examples/burtin/burtin.ts
+++ b/bokehjs/examples/burtin/burtin.ts
@@ -96,17 +96,17 @@ export namespace Burtin {
 
   // small wedges
   p.annular_wedge(0, 0, inner_radius, rad(df.penicillin),
-          angles.map((angle) => -big_angle+angle+5*small_angle),
-          angles.map((angle) => -big_angle+angle+6*small_angle),
-          {color: drug_color.Penicillin})
+                  angles.map((angle) => -big_angle+angle+5*small_angle),
+                  angles.map((angle) => -big_angle+angle+6*small_angle),
+                  {color: drug_color.Penicillin})
   p.annular_wedge(0, 0, inner_radius, rad(df.streptomycin),
-          angles.map((angle) => -big_angle+angle+3*small_angle),
-          angles.map((angle) => -big_angle+angle+4*small_angle),
-          {color: drug_color.Streptomycin})
+                  angles.map((angle) => -big_angle+angle+3*small_angle),
+                  angles.map((angle) => -big_angle+angle+4*small_angle),
+                  {color: drug_color.Streptomycin})
   p.annular_wedge(0, 0, inner_radius, rad(df.neomycin),
-          angles.map((angle) => -big_angle+angle+1*small_angle),
-          angles.map((angle) => -big_angle+angle+2*small_angle),
-          {color: drug_color.Neomycin})
+                  angles.map((angle) => -big_angle+angle+1*small_angle),
+                  angles.map((angle) => -big_angle+angle+2*small_angle),
+                  {color: drug_color.Neomycin})
 
   // circular axes and lables
   const labels = range(-3, 4).map((v) => 10**v)
@@ -114,30 +114,30 @@ export namespace Burtin {
 
   p.circle(0, 0, {radius: radii, fill_color: null, line_color: "white"})
   p.text(0, radii.slice(0, -1), labels.slice(0, -1).map((label) => label.toString()),
-     {text_font_size: "8pt", text_align: "center", text_baseline: "middle"})
+         {text_font_size: "8pt", text_align: "center", text_baseline: "middle"})
 
   // radial axes
   p.annular_wedge(0, 0, inner_radius-10, outer_radius+10,
-          angles.map((angle) => -big_angle+angle),
-          angles.map((angle) => -big_angle+angle),
-          {color: "black"})
+                  angles.map((angle) => -big_angle+angle),
+                  angles.map((angle) => -big_angle+angle),
+                  {color: "black"})
 
   // bacteria labels
   const xr = angles.map((angle) => radii[0]*Math.cos(-big_angle/2 + angle))
   const yr = angles.map((angle) => radii[0]*Math.sin(-big_angle/2 + angle))
   const label_angle = angles.map((angle) => -big_angle/2 + angle)
-               .map((angle) => (angle < -Math.PI/2) ? angle + Math.PI : angle)
+    .map((angle) => (angle < -Math.PI/2) ? angle + Math.PI : angle)
   p.text(xr, yr, df.bacteria, {angle: label_angle,
-     text_font_size: "9pt", text_align: "center", text_baseline: "middle"})
+                               text_font_size: "9pt", text_align: "center", text_baseline: "middle"})
 
   // OK, these hand drawn legends are pretty clunky, will be improved in future release
   p.circle([-40, -40], [-370, -390], {color: values(gram_color), radius: 5})
   p.text([-30, -30], [-370, -390], Object.keys(gram_color).map((gram) => `Gram-${gram}`),
-     {text_font_size: "7pt", text_align: "left", text_baseline: "middle"})
+         {text_font_size: "7pt", text_align: "left", text_baseline: "middle"})
 
   p.rect([-40, -40, -40], [18, 0, -18], 30, 13, {color: values(drug_color)})
   p.text([-15, -15, -15], [18, 0, -18], Object.keys(drug_color),
-     {text_font_size: "9pt", text_align: "left", text_baseline: "middle"})
+         {text_font_size: "9pt", text_align: "left", text_baseline: "middle"})
 
   plt.show(p)
 }

--- a/bokehjs/examples/burtin/burtin.ts
+++ b/bokehjs/examples/burtin/burtin.ts
@@ -67,7 +67,7 @@ export namespace Burtin {
   const inner_radius = 90
   const outer_radius = 300 - 10
 
-  const minr = Math.sqrt(Math.log(.001 * 1E4))
+  const minr = Math.sqrt(Math.log(0.001 * 1E4))
   const maxr = Math.sqrt(Math.log(1000 * 1E4))
   const a = (outer_radius - inner_radius) / (minr - maxr)
   const b = inner_radius - a * maxr

--- a/bokehjs/examples/donut/donut.ts
+++ b/bokehjs/examples/donut/donut.ts
@@ -17,10 +17,11 @@ export namespace WebBrowserMarketShare {
 
   function read_csv_from(id: string) {
     const text = document.getElementById(id)!.innerHTML
-    return text.split("\n")
-         .map((line) => line.trim())
-         .filter((line) => line.length > 0)
-         .map((line) => line.split(/, /).map((val) => val.trim()))
+    return text
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .map((line) => line.split(/, /).map((val) => val.trim()))
   }
 
   interface MonthlyShares {
@@ -101,8 +102,8 @@ export namespace WebBrowserMarketShare {
     const colors = item.browsers.map((name) => info[name].color)
 
     fig.wedge({x: 0, y: 0, radius: 1.5, source,
-         start_angle: start_angles, end_angle: end_angles,
-         line_color: "white", line_width: 1, fill_color: colors})
+               start_angle: start_angles, end_angle: end_angles,
+               line_color: "white", line_width: 1, fill_color: colors})
 
     const icons = item.browsers.map((name) => info[name].icon)
     const [x0, y0] = unzip(half_angles.map((angle) => to_cartesian(1.7, angle)))

--- a/bokehjs/examples/hierarchical/hierarchical.ts
+++ b/bokehjs/examples/hierarchical/hierarchical.ts
@@ -22,7 +22,7 @@ export namespace Hierarchical {
   const counts = concat(zip(data["2015"], data["2016"], data["2017"])) // like an hstack
 
   const p = figure({x_range: new FactorRange({factors: x, range_padding: 0.1}),
-    plot_height: 250, toolbar_location: null, title: "Fruit Counts by Year"})
+                    plot_height: 250, toolbar_location: null, title: "Fruit Counts by Year"})
   p.vbar({x, top: counts, width: 0.9})
 
   p.xaxis.map((axis) => axis.major_label_orientation = 1)

--- a/bokehjs/examples/hover/hover.ts
+++ b/bokehjs/examples/hover/hover.ts
@@ -36,11 +36,13 @@ export namespace HoverfulScatter {
 
   const p = plt.figure({title: "Hoverful Scatter", tools})
 
-  p.circle({field: "x"}, {field: "y"}, {source, radius: radii,
-    fill_color: colors, fill_alpha: 0.6, line_color: null})
+  p.circle({field: "x"}, {field: "y"}, {
+    source, radius: radii, fill_color: colors, fill_alpha: 0.6, line_color: null,
+  })
 
-  p.text({field: "x"}, {field: "y"}, indices, {source, alpha: 0.5,
-    text_font_size: "5pt", text_baseline: "middle", text_align: "center"})
+  p.text({field: "x"}, {field: "y"}, indices, {
+    source, alpha: 0.5, text_font_size: "5pt", text_baseline: "middle", text_align: "center",
+  })
 
   const hover = p.toolbar.select_one(Bokeh.HoverTool)
   hover!.tooltips = (source, info) => {

--- a/bokehjs/examples/stocks/stocks.ts
+++ b/bokehjs/examples/stocks/stocks.ts
@@ -31,7 +31,7 @@ export namespace Stocks {
       if (key != 't') {
         i += 1
         plot.line({field: 't'}, {field: key},
-             {source, legend: key, line_color: colors[i%6], line_width: 2})
+                  {source, legend: key, line_color: colors[i%6], line_width: 2})
       }
     }
 

--- a/bokehjs/examples/tap/tap.ts
+++ b/bokehjs/examples/tap/tap.ts
@@ -36,11 +36,13 @@ export namespace TappyScatter {
 
   const p = plt.figure({title: "Tappy Scatter", tools})
 
-  const circles = p.circle({field: "x"}, {field: "y"}, {source, radius: radii,
-              fill_color: colors, fill_alpha: 0.6, line_color: null})
+  const circles = p.circle({field: "x"}, {field: "y"}, {
+    source, radius: radii, fill_color: colors, fill_alpha: 0.6, line_color: null,
+  })
 
-  p.text({field: "x"}, {field: "y"}, indices, {source, alpha: 0.5,
-     text_font_size: "5pt", text_baseline: "middle", text_align: "center"})
+  p.text({field: "x"}, {field: "y"}, indices, {
+    source, alpha: 0.5, text_font_size: "5pt", text_baseline: "middle", text_align: "center",
+  })
 
   const tap = p.toolbar.select_one(Bokeh.TapTool)
   tap!.renderers = [circles]

--- a/bokehjs/make/tasks/lint.ts
+++ b/bokehjs/make/tasks/lint.ts
@@ -15,6 +15,7 @@ function eslint(dir: string): void {
   })
 
   const report = engine.executeOnFiles([dir])
+  es.CLIEngine.outputFixes(report)
 
   if (report.errorCount != 0) {
     const formatter = engine.getFormatter()

--- a/bokehjs/make/tasks/scripts.ts
+++ b/bokehjs/make/tasks/scripts.ts
@@ -36,8 +36,9 @@ task("scripts:bundle", ["scripts:compile"], async () => {
   const min_js = (js: string) => rename(js, {ext: '.min.js'})
 
   function bundle(minified: boolean, outputs: string[]) {
-    bundles.map((bundle) => bundle.assemble(minified))
-           .map((artifact, i) => artifact.write(outputs[i]))
+    bundles
+      .map((bundle) => bundle.assemble(minified))
+      .map((artifact, i) => artifact.write(outputs[i]))
   }
 
   bundle(false, outputs)

--- a/bokehjs/src/compiler/main.ts
+++ b/bokehjs/src/compiler/main.ts
@@ -8,19 +8,19 @@ import {compile_files, read_tsconfig, parse_tsconfig, is_failed, default_transfo
 import {compile_and_resolve_deps} from "./compile"
 import {Linker} from "./linker"
 
-  async function read_stdin() {
-    const stdin = process.stdin
+async function read_stdin() {
+  const stdin = process.stdin
 
-    stdin.setEncoding("utf-8")
-    stdin.resume()
+  stdin.setEncoding("utf-8")
+  stdin.resume()
 
-    let data = ""
-    for await (const chunk of stdin) {
-      data += chunk
-    }
-
-    return data
+  let data = ""
+  for await (const chunk of stdin) {
+    data += chunk
   }
+
+  return data
+}
 
 function reply(data: unknown): void {
   process.stdout.write(JSON.stringify(data))
@@ -80,8 +80,9 @@ async function build() {
   const min_js = (js: string) => rename(js, {ext: '.min.js'})
 
   function bundle(minified: boolean, outputs: string[]) {
-    bundles.map((bundle) => bundle.assemble(minified))
-           .map((artifact, i) => artifact.write(outputs[i]))
+    bundles
+      .map((bundle) => bundle.assemble(minified))
+      .map((artifact, i) => artifact.write(outputs[i]))
   }
 
   bundle(false, outputs)

--- a/bokehjs/src/compiler/sys.ts
+++ b/bokehjs/src/compiler/sys.ts
@@ -2,7 +2,7 @@ import * as ts from "typescript"
 import {parse, format, normalize} from "path"
 
 export function scan(path: string,
-    extensions?: readonly string[], exclude?: readonly string[], include?: readonly string[], depth?: number): string[] {
+                     extensions?: readonly string[], exclude?: readonly string[], include?: readonly string[], depth?: number): string[] {
   return ts.sys.readDirectory(path, extensions, exclude, include, depth).map((p) => normalize(p))
 }
 

--- a/bokehjs/src/lib/api/charts.ts
+++ b/bokehjs/src/lib/api/charts.ts
@@ -311,7 +311,7 @@ export function bar(data: BarChartData, opts: BarChartOpts = {}): Plot {
   }
 
   if (orientation == "vertical") {
-     [xdr, ydr] = [ydr, xdr]
+    [xdr, ydr] = [ydr, xdr]
     ;[xaxis, yaxis] = [yaxis, xaxis]
     ;[xscale, yscale] = [yscale, xscale]
 

--- a/bokehjs/src/lib/client/connection.ts
+++ b/bokehjs/src/lib/client/connection.ts
@@ -89,9 +89,9 @@ export class ClientConnection {
       /*
       if (this.closed_permanently) {
       */
-        if (!this.closed_permanently)
-          logger.info(`Websocket connection ${this._number} disconnected, will not attempt to reconnect`)
-        return
+      if (!this.closed_permanently)
+        logger.info(`Websocket connection ${this._number} disconnected, will not attempt to reconnect`)
+      return
       /*
       } else {
         logger.debug(`Attempting to reconnect websocket ${this._number}`)
@@ -296,7 +296,8 @@ export class ClientConnection {
 // getting a session; session.close() works too once you have a session.
 export function pull_session(url?: string, session_id?: string, args_string?: string): Promise<ClientSession> {
   const promise = new Promise<ClientSession>((resolve, reject) => {
-    const connection = new ClientConnection(url, session_id, args_string,
+    const connection = new ClientConnection(
+      url, session_id, args_string,
       (session) => {
         try {
           resolve(session)

--- a/bokehjs/src/lib/core/bokeh_events.ts
+++ b/bokehjs/src/lib/core/bokeh_events.ts
@@ -87,10 +87,10 @@ export abstract class PointEvent extends UIEvent {
 @event("pan")
 export class Pan extends PointEvent {
 
+  /* TODO: direction: -1 | 1 */
   constructor(readonly sx: number, readonly sy: number,
               readonly x: number, readonly y: number,
-              readonly delta_x: number, readonly delta_y: number,
-              /*readonly direction: -1 | 1*/) {
+              readonly delta_x: number, readonly delta_y: number) {
     super(sx, sy, x, y)
   }
 

--- a/bokehjs/src/lib/core/dom.ts
+++ b/bokehjs/src/lib/core/dom.ts
@@ -4,70 +4,70 @@ import {Size, Box, Extents} from "./types"
 export type HTMLAttrs = {[name: string]: any}
 export type HTMLChild = string | HTMLElement | (string | HTMLElement)[]
 
-const _createElement = <T extends keyof HTMLElementTagNameMap>(tag: T) =>
-    (attrs: HTMLAttrs = {}, ...children: HTMLChild[]): HTMLElementTagNameMap[T] => {
+const _createElement = <T extends keyof HTMLElementTagNameMap>(tag: T) => {
+  return (attrs: HTMLAttrs = {}, ...children: HTMLChild[]): HTMLElementTagNameMap[T] => {
+    const element = document.createElement(tag)
+    element.classList.add("bk")
 
-  const element = document.createElement(tag)
-  element.classList.add("bk")
+    for (const attr in attrs) {
+      let value = attrs[attr]
 
-  for (const attr in attrs) {
-    let value = attrs[attr]
+      if (value == null || isBoolean(value) && !value)
+        continue
 
-    if (value == null || isBoolean(value) && !value)
-      continue
+      if (attr === "class") {
+        if (isString(value))
+          value = value.split(/\s+/)
 
-    if (attr === "class") {
-      if (isString(value))
-        value = value.split(/\s+/)
+        if (isArray(value)) {
+          for (const cls of (value as string[])) {
+            if (cls != null)
+              element.classList.add(cls)
+          }
+          continue
+        }
+      }
 
-      if (isArray(value)) {
-        for (const cls of (value as string[])) {
-          if (cls != null)
-            element.classList.add(cls)
+      if (attr === "style" && isPlainObject(value)) {
+        for (const prop in value) {
+          (element.style as any)[prop] = value[prop]
         }
         continue
       }
-    }
 
-    if (attr === "style" && isPlainObject(value)) {
-      for (const prop in value) {
-        (element.style as any)[prop] = value[prop]
+      if (attr === "data" && isPlainObject(value)) {
+        for (const key in value) {
+          element.dataset[key] = value[key] as string | undefined // XXX: attrs needs a better type
+        }
+        continue
       }
-      continue
+
+      element.setAttribute(attr, value)
     }
 
-    if (attr === "data" && isPlainObject(value)) {
-      for (const key in value) {
-        element.dataset[key] = value[key] as string | undefined // XXX: attrs needs a better type
-      }
-      continue
+    function append(child: HTMLElement | string) {
+      if (child instanceof HTMLElement)
+        element.appendChild(child)
+      else if (isString(child))
+        element.appendChild(document.createTextNode(child))
+      else if (child != null && child !== false)
+        throw new Error(`expected an HTMLElement, string, false or null, got ${JSON.stringify(child)}`)
     }
 
-    element.setAttribute(attr, value)
-  }
+    for (const child of children) {
+      if (isArray(child)) {
+        for (const _child of child)
+          append(_child)
+      } else
+        append(child)
+    }
 
-  function append(child: HTMLElement | string) {
-    if (child instanceof HTMLElement)
-      element.appendChild(child)
-    else if (isString(child))
-      element.appendChild(document.createTextNode(child))
-    else if (child != null && child !== false)
-      throw new Error(`expected an HTMLElement, string, false or null, got ${JSON.stringify(child)}`)
+    return element
   }
-
-  for (const child of children) {
-    if (isArray(child)) {
-      for (const _child of child)
-        append(_child)
-    } else
-      append(child)
-  }
-
-  return element
 }
 
-export function createElement<T extends keyof HTMLElementTagNameMap>(tag: T,
-     attrs: HTMLAttrs, ...children: HTMLChild[]): HTMLElementTagNameMap[T] {
+export function createElement<T extends keyof HTMLElementTagNameMap>(
+    tag: T, attrs: HTMLAttrs, ...children: HTMLChild[]): HTMLElementTagNameMap[T] {
   return _createElement(tag)(attrs, ...children)
 }
 

--- a/bokehjs/src/lib/core/layout/layoutable.ts
+++ b/bokehjs/src/lib/core/layout/layoutable.ts
@@ -292,8 +292,9 @@ export abstract class ContentLayoutable extends Layoutable {
   protected _measure(viewport: Sizeable): SizeHint {
     const content_size = this._content_size()
 
-    const bounds = viewport.bounded_to(this.sizing.size)
-                           .bounded_to(content_size)
+    const bounds = viewport
+      .bounded_to(this.sizing.size)
+      .bounded_to(content_size)
 
     const width = (() => {
       switch (this.sizing.width_policy) {

--- a/bokehjs/src/lib/core/util/canvas.ts
+++ b/bokehjs/src/lib/core/util/canvas.ts
@@ -80,8 +80,8 @@ function fixup_ellipse(ctx: any): void {
 
     ctx.moveTo(-rx, 0) // start point of first curve
     ctx.bezierCurveTo(-rx,  ry * c, -rx * c,  ry, 0,  ry)
-    ctx.bezierCurveTo( rx * c,  ry,  rx,  ry * c,  rx, 0)
-    ctx.bezierCurveTo( rx, -ry * c,  rx * c, -ry, 0, -ry)
+    ctx.bezierCurveTo(rx * c,  ry,  rx,  ry * c,  rx, 0)
+    ctx.bezierCurveTo(rx, -ry * c,  rx * c, -ry, 0, -ry)
     ctx.bezierCurveTo(-rx * c, -ry, -rx, -ry * c, -rx, 0)
 
     ctx.rotate(-rotation)

--- a/bokehjs/src/lib/core/util/serialization.ts
+++ b/bokehjs/src/lib/core/util/serialization.ts
@@ -202,8 +202,8 @@ function decode_traverse_data(v: any, buffers: [any, any][]): [Arrayable, any] {
   const shapes: Shape[] = []
 
   for (const obj of v) {
-    const [arr, shape] = isArray(obj) ? decode_traverse_data(obj, buffers) :
-                                        process_array(obj as NDArray, buffers)
+    const [arr, shape] = isArray(obj) ? decode_traverse_data(obj, buffers)
+                                      : process_array(obj as NDArray, buffers)
     arrays.push(arr)
     shapes.push(shape)
   }

--- a/bokehjs/src/lib/core/util/templating.ts
+++ b/bokehjs/src/lib/core/util/templating.ts
@@ -130,7 +130,7 @@ export function replace_placeholders(str: string, data_source: ColumnarDataSourc
 
     // 'safe' format, return the value as-is
     if (format == 'safe')
-     return `${prefix}${value}`
+      return `${prefix}${value}`
 
     // format and escape everything else
     const formatter = get_formatter(name, raw_spec, format, formatters)

--- a/bokehjs/src/lib/core/visuals.ts
+++ b/bokehjs/src/lib/core/visuals.ts
@@ -38,148 +38,148 @@ function _get_canvas(size: number): HTMLCanvasElement {
 
 export type Color = string
 function create_hatch_canvas(hatch_pattern: mixins.HatchPattern, hatch_color: Color, hatch_scale: number, hatch_weight: number ): HTMLCanvasElement {
-    const h = hatch_scale
-    const h2 = h / 2
-    const h4 = h2 / 2
+  const h = hatch_scale
+  const h2 = h / 2
+  const h4 = h2 / 2
 
-    const canvas = _get_canvas(hatch_scale)
+  const canvas = _get_canvas(hatch_scale)
 
-    const ctx = canvas.getContext("2d")! as Context2d
-    ctx.strokeStyle = hatch_color
-    ctx.lineCap="square"
-    ctx.fillStyle = hatch_color
-    ctx.lineWidth = hatch_weight
+  const ctx = canvas.getContext("2d")! as Context2d
+  ctx.strokeStyle = hatch_color
+  ctx.lineCap="square"
+  ctx.fillStyle = hatch_color
+  ctx.lineWidth = hatch_weight
 
-    switch (hatch_pattern) {
-      // we should not need these if code conditions on hatch.doit, but
-      // include them here just for completeness
-      case " ":
-      case "blank":
-        break
+  switch (hatch_pattern) {
+    // we should not need these if code conditions on hatch.doit, but
+    // include them here just for completeness
+    case " ":
+    case "blank":
+      break
 
-      case ".":
-      case "dot":
-        ctx.arc(h2, h2, h2/2, 0, 2 * Math.PI, true)
-        ctx.fill()
-        break
+    case ".":
+    case "dot":
+      ctx.arc(h2, h2, h2/2, 0, 2 * Math.PI, true)
+      ctx.fill()
+      break
 
-      case "o":
-      case "ring":
-        ctx.arc(h2, h2, h2/2, 0, 2 * Math.PI, true)
-        ctx.stroke()
-        break
+    case "o":
+    case "ring":
+      ctx.arc(h2, h2, h2/2, 0, 2 * Math.PI, true)
+      ctx.stroke()
+      break
 
-      case "-":
-      case "horizontal_line":
-        _horz(ctx, h, h2)
-        break
+    case "-":
+    case "horizontal_line":
+      _horz(ctx, h, h2)
+      break
 
-      case "|":
-      case "vertical_line":
-        _vert(ctx, h, h2)
-        break
+    case "|":
+    case "vertical_line":
+      _vert(ctx, h, h2)
+      break
 
-      case "+":
-      case "cross":
-        _horz(ctx, h, h2)
-        _vert(ctx, h, h2)
-        break
+    case "+":
+    case "cross":
+      _horz(ctx, h, h2)
+      _vert(ctx, h, h2)
+      break
 
-      case "\"":
-      case "horizontal_dash":
-        _horz(ctx, h2, h2)
-        break
+    case "\"":
+    case "horizontal_dash":
+      _horz(ctx, h2, h2)
+      break
 
-      case ":":
-      case "vertical_dash":
-        _vert(ctx, h2, h2)
-        break
+    case ":":
+    case "vertical_dash":
+      _vert(ctx, h2, h2)
+      break
 
-      case "@":
-      case "spiral":
-        const h30 = h/30
-        ctx.moveTo(h2, h2)
-        for (let i = 0; i < 360; i++) {
-          const angle = 0.1 * i
-          const x = h2 + (h30 * angle) * Math.cos(angle)
-          const y = h2 + (h30 * angle) * Math.sin(angle)
-          ctx.lineTo(x, y)
-        }
-        ctx.stroke()
-        break
+    case "@":
+    case "spiral":
+      const h30 = h/30
+      ctx.moveTo(h2, h2)
+      for (let i = 0; i < 360; i++) {
+        const angle = 0.1 * i
+        const x = h2 + (h30 * angle) * Math.cos(angle)
+        const y = h2 + (h30 * angle) * Math.sin(angle)
+        ctx.lineTo(x, y)
+      }
+      ctx.stroke()
+      break
 
-      case "/":
-      case "right_diagonal_line":
-        ctx.moveTo(-h4+0.5, h)
-        ctx.lineTo(h4+0.5, 0)
-        ctx.stroke()
-        ctx.moveTo(h4+0.5, h)
-        ctx.lineTo(3*h4+0.5, 0)
-        ctx.stroke()
-        ctx.moveTo(3*h4+0.5, h)
-        ctx.lineTo(5*h4+0.5, 0)
-        ctx.stroke()
-        ctx.stroke()
-        break
+    case "/":
+    case "right_diagonal_line":
+      ctx.moveTo(-h4+0.5, h)
+      ctx.lineTo(h4+0.5, 0)
+      ctx.stroke()
+      ctx.moveTo(h4+0.5, h)
+      ctx.lineTo(3*h4+0.5, 0)
+      ctx.stroke()
+      ctx.moveTo(3*h4+0.5, h)
+      ctx.lineTo(5*h4+0.5, 0)
+      ctx.stroke()
+      ctx.stroke()
+      break
 
-        case "\\":
-        case "left_diagonal_line":
-        ctx.moveTo(h4+0.5, h)
-        ctx.lineTo(-h4+0.5, 0)
-        ctx.stroke()
-        ctx.moveTo(3*h4+0.5, h)
-        ctx.lineTo(h4+0.5, 0)
-        ctx.stroke()
-        ctx.moveTo(5*h4+0.5, h)
-        ctx.lineTo(3*h4+0.5, 0)
-        ctx.stroke()
-        ctx.stroke()
-        break
+    case "\\":
+    case "left_diagonal_line":
+      ctx.moveTo(h4+0.5, h)
+      ctx.lineTo(-h4+0.5, 0)
+      ctx.stroke()
+      ctx.moveTo(3*h4+0.5, h)
+      ctx.lineTo(h4+0.5, 0)
+      ctx.stroke()
+      ctx.moveTo(5*h4+0.5, h)
+      ctx.lineTo(3*h4+0.5, 0)
+      ctx.stroke()
+      ctx.stroke()
+      break
 
-      case "x":
-      case "diagonal_cross":
-        _x(ctx, h)
-        break
+    case "x":
+    case "diagonal_cross":
+      _x(ctx, h)
+      break
 
-      case ",":
-      case "right_diagonal_dash":
-        ctx.moveTo(h4+0.5, 3*h4+0.5)
-        ctx.lineTo(3*h4+0.5, h4+0.5)
-        ctx.stroke()
-        break
+    case ",":
+    case "right_diagonal_dash":
+      ctx.moveTo(h4+0.5, 3*h4+0.5)
+      ctx.lineTo(3*h4+0.5, h4+0.5)
+      ctx.stroke()
+      break
 
-      case "`":
-      case "left_diagonal_dash":
-        ctx.moveTo(h4+0.5, h4+0.5)
-        ctx.lineTo(3*h4+0.5, 3*h4+0.5)
-        ctx.stroke()
-        break
+    case "`":
+    case "left_diagonal_dash":
+      ctx.moveTo(h4+0.5, h4+0.5)
+      ctx.lineTo(3*h4+0.5, 3*h4+0.5)
+      ctx.stroke()
+      break
 
-      case "v":
-      case "horizontal_wave":
-        ctx.moveTo(0, h4)
-        ctx.lineTo(h2, 3*h4)
-        ctx.lineTo(h, h4)
-        ctx.stroke()
-        break
+    case "v":
+    case "horizontal_wave":
+      ctx.moveTo(0, h4)
+      ctx.lineTo(h2, 3*h4)
+      ctx.lineTo(h, h4)
+      ctx.stroke()
+      break
 
-      case ">":
-      case "vertical_wave":
-        ctx.moveTo(h4, 0)
-        ctx.lineTo(3*h4, h2)
-        ctx.lineTo(h4, h)
-        ctx.stroke()
-        break
+    case ">":
+    case "vertical_wave":
+      ctx.moveTo(h4, 0)
+      ctx.lineTo(3*h4, h2)
+      ctx.lineTo(h4, h)
+      ctx.stroke()
+      break
 
-      case "*":
-      case "criss_cross":
-        _x(ctx, h)
-        _horz(ctx, h, h2)
-        _vert(ctx, h, h2)
-        break
-    }
+    case "*":
+    case "criss_cross":
+      _x(ctx, h)
+      _horz(ctx, h, h2)
+      _vert(ctx, h, h2)
+      break
+  }
 
-    return canvas
+  return canvas
 }
 
 export abstract class ContextProperties {

--- a/bokehjs/src/lib/core/visuals.ts
+++ b/bokehjs/src/lib/core/visuals.ts
@@ -37,7 +37,7 @@ function _get_canvas(size: number): HTMLCanvasElement {
 }
 
 export type Color = string
-function create_hatch_canvas(hatch_pattern: mixins.HatchPattern, hatch_color: Color, hatch_scale: number, hatch_weight: number ): HTMLCanvasElement {
+function create_hatch_canvas(hatch_pattern: mixins.HatchPattern, hatch_color: Color, hatch_scale: number, hatch_weight: number): HTMLCanvasElement {
   const h = hatch_scale
   const h2 = h / 2
   const h4 = h2 / 2
@@ -344,7 +344,7 @@ export class Hatch extends ContextProperties {
       this.cache_select("hatch_pattern", i)
       this.cache_select("hatch_weight", i)
       const {hatch_color, hatch_scale, hatch_pattern, hatch_weight, hatch_extra} = this.cache
-      if (hatch_extra != null && hatch_extra.hasOwnProperty(hatch_pattern) ) {
+      if (hatch_extra != null && hatch_extra.hasOwnProperty(hatch_pattern)) {
         const custom = hatch_extra[hatch_pattern]
         this.cache.pattern = custom.get_pattern(hatch_color, hatch_scale, hatch_weight)
       } else {
@@ -361,7 +361,7 @@ export class Hatch extends ContextProperties {
 
   private _try_defer(defer_func: () => void): void {
     const {hatch_pattern, hatch_extra} = this.cache
-    if (hatch_extra != null && hatch_extra.hasOwnProperty(hatch_pattern) ) {
+    if (hatch_extra != null && hatch_extra.hasOwnProperty(hatch_pattern)) {
       const custom = hatch_extra[hatch_pattern]
       custom.onload(defer_func)
     }

--- a/bokehjs/src/lib/models/annotations/legend.ts
+++ b/bokehjs/src/lib/models/annotations/legend.ts
@@ -255,11 +255,13 @@ export class LegendView extends AnnotationView {
       if (labels.length == 0)
         continue
 
-      const active = (() => { switch (this.model.click_policy) {
-        case "none": return true
-        case "hide": return every(item.renderers, r => r.visible)
-        case "mute": return every(item.renderers, r => !r.muted)
-      } })()
+      const active = (() => {
+        switch (this.model.click_policy) {
+          case "none": return true
+          case "hide": return every(item.renderers, r => r.visible)
+          case "mute": return every(item.renderers, r => !r.muted)
+        }
+      })()
 
       for (const label of labels) {
         const x1 = bbox.x + xoffset

--- a/bokehjs/src/lib/models/annotations/legend_item.ts
+++ b/bokehjs/src/lib/models/annotations/legend_item.ts
@@ -72,7 +72,7 @@ export class LegendItem extends Model {
     super.initialize()
     this.legend = null
     this.connect(this.change,
-      () => { if (this.legend != null) this.legend.item_change.emit() })
+                 () => { if (this.legend != null) this.legend.item_change.emit() })
 
     // Validate data_sources match
     const data_source_validation = this._check_data_sources_on_renderers()

--- a/bokehjs/src/lib/models/annotations/tooltip.ts
+++ b/bokehjs/src/lib/models/annotations/tooltip.ts
@@ -59,7 +59,7 @@ export class TooltipView extends AnnotationView {
 
     for (const [sx, sy, content] of data) {
       if (this.model.inner_only && !frame.bbox.contains(sx, sy))
-          continue
+        continue
 
       const tip = div({}, content)
       this.el.appendChild(tip)

--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -214,7 +214,7 @@ export class AxisView extends GuideRendererView {
     let xoff, yoff: number
 
     if (units == "screen") {
-       [sxs, sys] = coords
+      [sxs, sys] = coords
       ;[xoff, yoff] = [0, 0]
     } else {
       const [dxs, dys] = coords

--- a/bokehjs/src/lib/models/axes/categorical_axis.ts
+++ b/bokehjs/src/lib/models/axes/categorical_axis.ts
@@ -132,13 +132,15 @@ export class CategoricalAxisView extends AxisView {
     coords.major[i] = ticks.major as any
     coords.major[j] = ticks.major.map((_x) => this.loc)
 
-    if (range.levels == 3)
+    if (range.levels == 3) {
       coords.mids[i] = ticks.mids as any
       coords.mids[j] = ticks.mids.map((_x) => this.loc)
+    }
 
-    if (range.levels > 1)
+    if (range.levels > 1) {
       coords.tops[i] = ticks.tops as any
       coords.tops[j] = ticks.tops.map((_x) => this.loc)
+    }
 
     return coords
   }

--- a/bokehjs/src/lib/models/glyphs/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/circle.ts
@@ -167,48 +167,48 @@ export class CircleView extends XYGlyphView {
   }
 
   protected _hit_span(geometry: SpanGeometry): Selection {
-      const {sx, sy} = geometry
-      const bounds = this.bounds()
-      const result = hittest.create_empty_hit_test_result()
+    const {sx, sy} = geometry
+    const bounds = this.bounds()
+    const result = hittest.create_empty_hit_test_result()
 
-      let x0, x1, y0, y1
-      if (geometry.direction == 'h') {
-        // use circle bounds instead of current pointer y coordinates
-        let sx0, sx1
-        y0 = bounds.y0
-        y1 = bounds.y1
-        if (this._radius != null && this.model.properties.radius.units == "data") {
-          sx0 = sx - this.max_radius
-          sx1 = sx + this.max_radius
-          ;[x0, x1] = this.renderer.xscale.r_invert(sx0, sx1)
-        } else {
-          const ms = this.max_size/2
-          sx0 = sx - ms
-          sx1 = sx + ms
-          ;[x0, x1] = this.renderer.xscale.r_invert(sx0, sx1)
-        }
+    let x0, x1, y0, y1
+    if (geometry.direction == 'h') {
+      // use circle bounds instead of current pointer y coordinates
+      let sx0, sx1
+      y0 = bounds.y0
+      y1 = bounds.y1
+      if (this._radius != null && this.model.properties.radius.units == "data") {
+        sx0 = sx - this.max_radius
+        sx1 = sx + this.max_radius
+        ;[x0, x1] = this.renderer.xscale.r_invert(sx0, sx1)
       } else {
-        // use circle bounds instead of current pointer x coordinates
-        let sy0, sy1
-        x0 = bounds.x0
-        x1 = bounds.x1
-        if (this._radius != null && this.model.properties.radius.units == "data") {
-          sy0 = sy - this.max_radius
-          sy1 = sy + this.max_radius
-          ;[y0, y1] = this.renderer.yscale.r_invert(sy0, sy1)
-        } else {
-          const ms = this.max_size/2
-          sy0 = sy - ms
-          sy1 = sy + ms
-          ;[y0, y1] = this.renderer.yscale.r_invert(sy0, sy1)
-        }
+        const ms = this.max_size/2
+        sx0 = sx - ms
+        sx1 = sx + ms
+        ;[x0, x1] = this.renderer.xscale.r_invert(sx0, sx1)
       }
-
-      const hits = this.index.indices({x0, x1, y0, y1})
-
-      result.indices = hits
-      return result
+    } else {
+      // use circle bounds instead of current pointer x coordinates
+      let sy0, sy1
+      x0 = bounds.x0
+      x1 = bounds.x1
+      if (this._radius != null && this.model.properties.radius.units == "data") {
+        sy0 = sy - this.max_radius
+        sy1 = sy + this.max_radius
+        ;[y0, y1] = this.renderer.yscale.r_invert(sy0, sy1)
+      } else {
+        const ms = this.max_size/2
+        sy0 = sy - ms
+        sy1 = sy + ms
+        ;[y0, y1] = this.renderer.yscale.r_invert(sy0, sy1)
+      }
     }
+
+    const hits = this.index.indices({x0, x1, y0, y1})
+
+    result.indices = hits
+    return result
+  }
 
   protected _hit_rect(geometry: RectGeometry): Selection {
     const {sx0, sx1, sy0, sy1} = geometry

--- a/bokehjs/src/lib/models/glyphs/ellipse_oval.ts
+++ b/bokehjs/src/lib/models/glyphs/ellipse_oval.ts
@@ -39,24 +39,24 @@ export abstract class EllipseOvalView extends CenterRotatableView  {
   }
 
   protected _render(ctx: Context2d, indices: number[], {sx, sy, sw, sh, _angle}: EllipseOvalData): void {
-     for (const i of indices) {
-       if (isNaN(sx[i] + sy[i] + sw[i] + sh[i] + _angle[i]))
-         continue
+    for (const i of indices) {
+      if (isNaN(sx[i] + sy[i] + sw[i] + sh[i] + _angle[i]))
+        continue
 
-       ctx.beginPath()
-       ctx.ellipse(sx[i], sy[i], sw[i]/2.0, sh[i]/2.0, _angle[i], 0, 2 * Math.PI)
+      ctx.beginPath()
+      ctx.ellipse(sx[i], sy[i], sw[i]/2.0, sh[i]/2.0, _angle[i], 0, 2 * Math.PI)
 
-       if (this.visuals.fill.doit) {
-         this.visuals.fill.set_vectorize(ctx, i)
-         ctx.fill()
-       }
+      if (this.visuals.fill.doit) {
+        this.visuals.fill.set_vectorize(ctx, i)
+        ctx.fill()
+      }
 
-       if (this.visuals.line.doit) {
-         this.visuals.line.set_vectorize(ctx, i)
-         ctx.stroke()
-       }
-     }
-   }
+      if (this.visuals.line.doit) {
+        this.visuals.line.set_vectorize(ctx, i)
+        ctx.stroke()
+      }
+    }
+  }
 
   protected _hit_point(geometry: PointGeometry): Selection {
     let x0, x1, y0, y1, cond, dist, sx0, sx1, sy0, sy1
@@ -89,7 +89,7 @@ export abstract class EllipseOvalView extends CenterRotatableView  {
     for (const i of candidates) {
       cond = hittest.point_in_ellipse(sx, sy, this._angle[i], this.sh[i]/2, this.sw[i]/2, this.sx[i], this.sy[i])
       if (cond) {
-         [sx0, sx1] = this.renderer.xscale.r_compute(x, this._x[i])
+        [sx0, sx1] = this.renderer.xscale.r_compute(x, this._x[i])
         ;[sy0, sy1] = this.renderer.yscale.r_compute(y, this._y[i])
         dist = Math.pow(sx0-sx1, 2) + Math.pow(sy0-sy1, 2)
         hits.push([i, dist])

--- a/bokehjs/src/lib/models/glyphs/hex_tile.ts
+++ b/bokehjs/src/lib/models/glyphs/hex_tile.ts
@@ -87,7 +87,7 @@ export class HexTileView extends GlyphView {
   // overriding map_data instead of _map_data because the default automatic mappings
   // for other glyphs (with cartesian coordinates) is not useful
   map_data(): void {
-     [this.sx, this.sy] = this.map_to_screen(this._x, this._y)
+    [this.sx, this.sy] = this.map_to_screen(this._x, this._y)
     ;[this.svx, this.svy] = this._get_unscaled_vertices()
   }
 

--- a/bokehjs/src/lib/models/glyphs/multi_polygons.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_polygons.ts
@@ -206,8 +206,8 @@ export class MultiPolygonsView extends GlyphView {
       const sxs = this.sxs[i]
       const sys = this.sys[i]
       for (let j = 0, end = sxs.length; j < end; j++) {
-      if (hittest.point_in_poly(sx, sy, (sxs[j][0] as number[]), (sys[j][0] as number[])))
-        return this._get_snap_coord(sys[j][0])
+        if (hittest.point_in_poly(sx, sy, (sxs[j][0] as number[]), (sys[j][0] as number[])))
+          return this._get_snap_coord(sys[j][0])
       }
     }
 

--- a/bokehjs/src/lib/models/glyphs/multi_polygons.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_polygons.ts
@@ -51,7 +51,7 @@ export class MultiPolygonsView extends GlyphView {
     const points = []
     for (let i = 0, end = this._xs.length; i < end; i++) {
       for (let j = 0, endj = this._xs[i].length; j < endj; j++) {
-        if (this._xs[i][j].length > 1 ) {
+        if (this._xs[i][j].length > 1) {
           for (let k = 1, endk = this._xs[i][j].length; k < endk; k++) {
             const xs = this._xs[i][j][k]  // only use holes
             const ys = this._ys[i][j][k]  // only use holes

--- a/bokehjs/src/lib/models/glyphs/step.ts
+++ b/bokehjs/src/lib/models/glyphs/step.ts
@@ -33,12 +33,12 @@ export class StepView extends XYGlyphView {
       let y1: number, y2: number
       switch (this.model.mode) {
         case "before": {
-           [x1, y1] = [sx[i-1], sy[i]]
+          [x1, y1] = [sx[i-1], sy[i]]
           ;[x2, y2] = [sx[i],   sy[i]]
           break
         }
         case "after": {
-           [x1, y1] = [sx[i], sy[i-1]]
+          [x1, y1] = [sx[i], sy[i-1]]
           ;[x2, y2] = [sx[i], sy[i]  ]
           break
         }

--- a/bokehjs/src/lib/models/glyphs/utils.ts
+++ b/bokehjs/src/lib/models/glyphs/utils.ts
@@ -54,15 +54,15 @@ export function line_interpolation(renderer: GlyphRendererView, geometry: PointG
 
   if (geometry.type == 'point') {
     // The +/- adjustments here are to dilate the hit point into a virtual "segment" to use below
-     [y0, y1] = renderer.yscale.r_invert(sy-1, sy+1)
+    [y0, y1] = renderer.yscale.r_invert(sy-1, sy+1)
     ;[x0, x1] = renderer.xscale.r_invert(sx-1, sx+1)
   } else {
     // The +/- adjustments here are to handle cases such as purely horizontal or vertical lines
     if (geometry.direction == 'v') {
-       [y0, y1] = renderer.yscale.r_invert(sy, sy)
+      [y0, y1] = renderer.yscale.r_invert(sy, sy)
       ;[x0, x1] = [Math.min(x2-1, x3-1), Math.max(x2+1, x3+1)]
     } else {
-       [x0, x1] = renderer.xscale.r_invert(sx, sx)
+      [x0, x1] = renderer.xscale.r_invert(sx, sx)
       ;[y0, y1] = [Math.min(y2-1, y3-1), Math.max(y2+1, y3+1)]
     }
   }

--- a/bokehjs/src/lib/models/glyphs/webgl/line.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/line.ts
@@ -46,7 +46,7 @@ class DashAtlas {
     // Period is sum of elements
     let period = 0
     for (const v of pattern) {
-       period += v
+      period += v
     }
     // Find all start and end of on-segment only
     const C: number[] = []
@@ -68,8 +68,8 @@ class DashAtlas {
       for (let j = 0, endj = C.length; j < endj; j++) {
         const val = Math.abs(C[j]-x)
         if (val < val_at_index) {
-           index = j; val_at_index = val
-         }
+          index = j; val_at_index = val
+        }
       }
       if ((index % 2) === 0) {
         dash_type = (x <= C[index]) ? +1 : 0
@@ -211,7 +211,7 @@ export class LineGLGlyph extends BaseGLGlyph {
       const chunksize = 64008  // 65536 max. 64008 is divisible by 12
       const chunks: number[][] = []
       for (let i = 0, end = Math.ceil(nvertices/chunksize); i < end; i++) {
-         chunks.push([])
+        chunks.push([])
       }
       for (let i = 0, end = indices.length; i < end; i++) {
         const uint16_index = indices[i] % chunksize
@@ -357,7 +357,7 @@ export class LineGLGlyph extends BaseGLGlyph {
     //
     // Arg, we really need an ndarray thing in JS :/
     for (let i = 0, end = n; i < end; i++) {  // all nodes on the line
-       for (let j = 0; j < 4; j++) {  // the four quad vertices
+      for (let j = 0; j < 4; j++) {  // the four quad vertices
         for (let k = 0; k < 2; k++) {  // xy
           V_position2[((((i*4)+j)-o)*2)+k] = V_position[(i*2)+k]
           V_angles2[(((i*4)+j)*2)+k] = V_angles[(i*2)+k]

--- a/bokehjs/src/lib/models/glyphs/webgl/markers.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/markers.ts
@@ -108,8 +108,8 @@ export abstract class MarkerGLGlyph extends BaseGLGlyph {
       // next renderer update.
       const ua = window.navigator.userAgent
       if ((ua.indexOf("MSIE ") + ua.indexOf("Trident/") + ua.indexOf("Edge/")) > 0) {
-         logger.warn('WebGL warning: IE is known to produce 1px sprites whith selections.')
-       }
+        logger.warn('WebGL warning: IE is known to produce 1px sprites whith selections.')
+      }
       this.index_buffer.set_size(indices.length*2)
       this.index_buffer.set_data(0, new Uint16Array(indices))
       this.prog.draw(this.gl.POINTS, this.index_buffer)
@@ -119,7 +119,7 @@ export abstract class MarkerGLGlyph extends BaseGLGlyph {
       const chunksize = 64000  // 65536
       const chunks: number[][] = []
       for (let i = 0, end = Math.ceil(nvertices/chunksize); i < end; i++) {
-         chunks.push([])
+        chunks.push([])
       }
       for (let i = 0, end = indices.length; i < end; i++) {
         const uint16_index = indices[i] % chunksize
@@ -166,8 +166,8 @@ export abstract class MarkerGLGlyph extends BaseGLGlyph {
     const xx = new Float64Array(this.glyph._x)
     const yy = new Float64Array(this.glyph._y)
     for (let i = 0, end = nvertices; i < end; i++) {
-       xx[i] += this._baked_offset[0]
-       yy[i] += this._baked_offset[1]
+      xx[i] += this._baked_offset[0]
+      yy[i] += this._baked_offset[1]
     }
     this.vbo_x.set_data(0, new Float32Array(xx))
     this.vbo_y.set_data(0, new Float32Array(yy))

--- a/bokehjs/src/lib/models/markers/defs.ts
+++ b/bokehjs/src/lib/models/markers/defs.ts
@@ -8,21 +8,21 @@ const SQ3 = Math.sqrt(3)
 
 function _one_line(ctx: Context2d, r: number): void {
   ctx.moveTo(-r,  0)
-  ctx.lineTo( r,  0)
+  ctx.lineTo(r,  0)
 }
 
 function _one_x(ctx: Context2d, r: number): void {
   ctx.moveTo(-r,  r)
-  ctx.lineTo( r, -r)
+  ctx.lineTo(r, -r)
   ctx.moveTo(-r, -r)
-  ctx.lineTo( r,  r)
+  ctx.lineTo(r,  r)
 }
 
 function _one_cross(ctx: Context2d, r: number): void {
-  ctx.moveTo( 0,  r)
-  ctx.lineTo( 0, -r)
+  ctx.moveTo(0,  r)
+  ctx.lineTo(0, -r)
   ctx.moveTo(-r,  0)
-  ctx.lineTo( r,  0)
+  ctx.lineTo(r,  0)
 }
 
 function _one_diamond(ctx: Context2d, r: number): void {
@@ -37,12 +37,12 @@ function _one_hex(ctx: Context2d, r: number): void {
   const r2 = r/2
   const h = SQ3*r2
 
-  ctx.moveTo( r,   0)
-  ctx.lineTo( r2, -h)
+  ctx.moveTo(r,   0)
+  ctx.lineTo(r2, -h)
   ctx.lineTo(-r2, -h)
   ctx.lineTo(-r,   0)
   ctx.lineTo(-r2,  h)
-  ctx.lineTo( r2,  h)
+  ctx.lineTo(r2,  h)
   ctx.closePath()
 }
 

--- a/bokehjs/src/lib/models/ranges/data_range1d.ts
+++ b/bokehjs/src/lib/models/ranges/data_range1d.ts
@@ -120,7 +120,7 @@ export class DataRange1d extends DataRange {
     return result
   }
 
-   adjust_bounds_for_aspect(bounds: Rect, ratio: number): Rect {
+  adjust_bounds_for_aspect(bounds: Rect, ratio: number): Rect {
     const result = bbox.empty()
 
     let width = bounds.x1 - bounds.x0

--- a/bokehjs/src/lib/models/renderers/graph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/graph_renderer.ts
@@ -25,8 +25,11 @@ export class GraphRendererView extends DataRendererView {
     this.yscale = this.plot_view.frame.yscales.default
 
     this._renderer_views = {}
-    ;[this.node_view, this.edge_view] = build_views(this._renderer_views,
-      [this.model.node_renderer, this.model.edge_renderer], {parent: this.parent}) as [GlyphRendererView, GlyphRendererView]
+
+    ;[this.node_view, this.edge_view] = build_views(this._renderer_views, [
+      this.model.node_renderer,
+      this.model.edge_renderer,
+    ], {parent: this.parent}) as [GlyphRendererView, GlyphRendererView]
 
     this.set_data()
   }

--- a/bokehjs/src/lib/models/selections/selection.ts
+++ b/bokehjs/src/lib/models/selections/selection.ts
@@ -102,7 +102,7 @@ export class Selection extends Model {
     }
   }
 
-  clear (): void {
+  clear(): void {
     this.final = true
     this.indices = []
     this.line_indices = []
@@ -111,7 +111,7 @@ export class Selection extends Model {
     this.selected_glyphs = []
   }
 
-  is_empty (): boolean {
+  is_empty(): boolean {
     return this.indices.length == 0 && this.line_indices.length == 0 && this.image_indices.length == 0
   }
 

--- a/bokehjs/src/lib/models/sources/cds_view.ts
+++ b/bokehjs/src/lib/models/sources/cds_view.ts
@@ -78,8 +78,9 @@ export class CDSView extends Model {
   }
 
   compute_indices(): void {
-    const indices = this.filters.map((filter) => filter.compute_indices(this.source))
-                                .filter((indices) => indices != null)
+    const indices = this.filters
+      .map((filter) => filter.compute_indices(this.source))
+      .filter((indices) => indices != null)
 
     if (indices.length > 0)
       this.indices = intersection.apply(this, indices)

--- a/bokehjs/src/lib/models/tickers/continuous_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/continuous_ticker.ts
@@ -70,9 +70,9 @@ export abstract class ContinuousTicker extends Ticker<number> {
       factors = []
     else
       factors = range(start_factor, end_factor + 1)
-    const ticks =
-      factors.map((factor) => factor*interval)
-             .filter((tick) => data_low <= tick && tick <= data_high)
+    const ticks = factors
+      .map((factor) => factor*interval)
+      .filter((tick) => data_low <= tick && tick <= data_high)
     const num_minor_ticks = this.num_minor_ticks
     const minor_ticks = []
     if (num_minor_ticks > 0 && ticks.length > 0) {

--- a/bokehjs/src/lib/models/tiles/bbox_tile_source.ts
+++ b/bokehjs/src/lib/models/tiles/bbox_tile_source.ts
@@ -33,10 +33,11 @@ export class BBoxTileSource extends MercatorTileSource {
     else
       [xmin, ymin, xmax, ymax] = this.get_tile_meter_bounds(x, y, z)
 
-    return image_url.replace("{XMIN}", xmin.toString())
-                    .replace("{YMIN}", ymin.toString())
-                    .replace("{XMAX}", xmax.toString())
-                    .replace("{YMAX}", ymax.toString())
+    return image_url
+      .replace("{XMIN}", xmin.toString())
+      .replace("{YMIN}", ymin.toString())
+      .replace("{XMAX}", xmax.toString())
+      .replace("{YMAX}", ymax.toString())
   }
 }
 BBoxTileSource.initClass()

--- a/bokehjs/src/lib/models/tiles/tile_source.ts
+++ b/bokehjs/src/lib/models/tiles/tile_source.ts
@@ -113,9 +113,10 @@ export abstract class TileSource extends Model {
 
   get_image_url(x: number, y: number, z: number): string {
     const image_url = this.string_lookup_replace(this.url, this.extra_url_vars)
-    return image_url.replace("{X}", x.toString())
-                    .replace('{Y}', y.toString())
-                    .replace("{Z}", z.toString())
+    return image_url
+      .replace("{X}", x.toString())
+      .replace('{Y}', y.toString())
+      .replace("{Z}", z.toString())
   }
 
   abstract tile_xyz_to_quadkey(x: number, y: number, z: number): string

--- a/bokehjs/src/lib/models/tiles/tms_tile_source.ts
+++ b/bokehjs/src/lib/models/tiles/tms_tile_source.ts
@@ -18,8 +18,9 @@ export class TMSTileSource extends MercatorTileSource {
 
   get_image_url(x: number, y: number, z: number): string {
     const image_url = this.string_lookup_replace(this.url, this.extra_url_vars)
-    return image_url.replace("{X}", x.toString())
-                    .replace('{Y}', y.toString())
-                    .replace("{Z}", z.toString())
+    return image_url
+      .replace("{X}", x.toString())
+      .replace('{Y}', y.toString())
+      .replace("{Z}", z.toString())
   }
 }

--- a/bokehjs/src/lib/models/tiles/wmts_tile_source.ts
+++ b/bokehjs/src/lib/models/tiles/wmts_tile_source.ts
@@ -19,8 +19,9 @@ export class WMTSTileSource extends MercatorTileSource {
   get_image_url(x: number, y: number, z: number): string {
     const image_url = this.string_lookup_replace(this.url, this.extra_url_vars)
     const [wx, wy, wz] = this.tms_to_wmts(x, y, z)
-    return image_url.replace("{X}", wx.toString())
-                    .replace('{Y}', wy.toString())
-                    .replace("{Z}", wz.toString())
+    return image_url
+      .replace("{X}", wx.toString())
+      .replace("{Y}", wy.toString())
+      .replace("{Z}", wz.toString())
   }
 }

--- a/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
@@ -49,7 +49,7 @@ export class BoxEditToolView extends EditToolView {
     const yscale = frame.yscales[renderer.y_range_name]
     const [x0, x1] = xscale.r_invert(sx0, sx1)
     const [y0, y1] = yscale.r_invert(sy0, sy1)
-    const [x, y] = [(x0+x1)/2., (y0+y1)/2.]
+    const [x, y] = [(x0+x1)/2, (y0+y1)/2]
     const [w, h] = [x1-x0, y1-y0]
     const [xkey, ykey] = [glyph.x.field, glyph.y.field]
     const [wkey, hkey] = [glyph.width.field, glyph.height.field]

--- a/bokehjs/src/lib/models/tools/edit/freehand_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/freehand_draw_tool.ts
@@ -65,7 +65,7 @@ export class FreehandDrawToolView extends EditToolView {
     this._select_event(ev, ev.shiftKey, this.model.renderers)
   }
 
- _keyup(ev: KeyEvent): void {
+  _keyup(ev: KeyEvent): void {
     if (!this.model.active || !this._mouse_in_frame)
       return
     for (const renderer of this.model.renderers) {

--- a/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
@@ -80,7 +80,7 @@ export class PolyDrawToolView extends PolyToolView {
   }
 
   _show_vertices(): void {
-    if (!this.model.active ) { return }
+    if (!this.model.active) { return }
     const xs: number[] = []
     const ys: number[] = []
     for (let i=0; i<this.model.renderers.length; i++) {

--- a/bokehjs/src/lib/models/tools/gestures/range_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/range_tool.ts
@@ -250,11 +250,11 @@ export class RangeTool extends GestureTool {
     this.prototype.default_view = RangeToolView
 
     this.define<RangeTool.Props>({
-        x_range:       [ p.Instance, null                  ],
-        x_interaction: [ p.Boolean,  true                  ],
-        y_range:       [ p.Instance, null                  ],
-        y_interaction: [ p.Boolean,  true                  ],
-        overlay:       [ p.Instance, DEFAULT_RANGE_OVERLAY ],
+      x_range:       [ p.Instance, null                  ],
+      x_interaction: [ p.Boolean,  true                  ],
+      y_range:       [ p.Instance, null                  ],
+      y_interaction: [ p.Boolean,  true                  ],
+      overlay:       [ p.Instance, DEFAULT_RANGE_OVERLAY ],
     })
 
   }

--- a/bokehjs/src/lib/models/tools/gestures/range_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/range_tool.ts
@@ -76,7 +76,7 @@ export function compute_end_side(end: number, range: Range, side: Side): Side {
 }
 
 export function compute_start_side(start: number, range: Range, side: Side): Side {
-  if (start < range.end ) {
+  if (start < range.end) {
     range.start = start
     return side
   } else {

--- a/bokehjs/src/lib/models/tools/toolbar_base.ts
+++ b/bokehjs/src/lib/models/tools/toolbar_base.ts
@@ -227,7 +227,7 @@ export class ToolbarBase extends Model {
 
   protected _init_tools(): void {
     // The only purpose of this function is to avoid unnecessary property churning.
-    const tools_changed = function (old_tools: Tool[], new_tools: Tool[]) {
+    const tools_changed = function(old_tools: Tool[], new_tools: Tool[]) {
       if (old_tools.length != new_tools.length) {
         return true
       }

--- a/bokehjs/src/lib/models/widgets/abstract_slider.ts
+++ b/bokehjs/src/lib/models/widgets/abstract_slider.ts
@@ -104,9 +104,8 @@ abstract class AbstractBaseSliderView extends ControlView {
 
   protected _set_bar_color(): void {
     if (!this.model.disabled) {
-      this.slider_el.querySelector<HTMLElement>(`.${prefix}connect`)!
-                    .style
-                    .backgroundColor = this.model.bar_color
+      const connect_el = this.slider_el.querySelector<HTMLElement>(`.${prefix}connect`)!
+      connect_el.style.backgroundColor = this.model.bar_color
     }
   }
 

--- a/bokehjs/src/lib/models/widgets/tables/cell_editors.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_editors.ts
@@ -518,12 +518,14 @@ export class DateEditorView extends CellEditorView {
     return super.position()
   }
 
-  getValue(): any {}
+  getValue(): any {
     //return @$datepicker.datepicker("getDate").getTime()
+  }
 
-  setValue(_val: any): void {}
-}
+  setValue(_val: any): void {
     //@$datepicker.datepicker("setDate", new Date(val))
+  }
+}
 
 export namespace DateEditor {
   export type Attrs = p.AttrsOf<Props>

--- a/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
@@ -177,7 +177,7 @@ export class DateFormatter extends CellFormatter {
     })
   }
 
-   getFormat(): string | undefined {
+  getFormat(): string | undefined {
     // using definitions provided here: https://api.jqueryui.com/datepicker/
     // except not implementing TICKS
     switch (this.format) {

--- a/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
@@ -112,11 +112,13 @@ export class NumberFormatter extends StringFormatter {
 
   doFormat(row: any, cell: any, value: any, columnDef: any, dataContext: any): string {
     const {format, language} = this
-    const rounding = (() => { switch (this.rounding) {
-      case "round": case "nearest":   return Math.round
-      case "floor": case "rounddown": return Math.floor
-      case "ceil":  case "roundup":   return Math.ceil
-    } })()
+    const rounding = (() => {
+      switch (this.rounding) {
+        case "round": case "nearest":   return Math.round
+        case "floor": case "rounddown": return Math.floor
+        case "ceil":  case "roundup":   return Math.ceil
+      }
+    })()
     value = Numbro.format(value, format, language, rounding)
     return super.doFormat(row, cell, value, columnDef, dataContext)
   }

--- a/bokehjs/src/lib/models/widgets/tables/data_cube.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_cube.ts
@@ -218,7 +218,7 @@ export class DataCubeProvider extends TableDataProvider {
     return item instanceof Group
       ? item as Item
       : Object.keys(data)
-          .reduce((o, c) => ({...o, [c]: data[c][item as number]}), {[DTINDEX_NAME]: item})
+        .reduce((o, c) => ({...o, [c]: data[c][item as number]}), {[DTINDEX_NAME]: item})
   }
 
   getItemMetadata(i: number): RowMetadata<Item> {

--- a/bokehjs/src/lib/models/widgets/tables/data_table.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_table.ts
@@ -245,7 +245,7 @@ export class DataTableView extends WidgetView {
         this._hide_header()
       }
       this.model.update_sort_columns(columns)
-   })
+    })
 
     if (this.model.selectable !== false) {
       this.grid.setSelectionModel(new RowSelectionModel({selectActiveRow: checkboxSelector == null}))

--- a/bokehjs/src/lib/polyfill.ts
+++ b/bokehjs/src/lib/polyfill.ts
@@ -66,19 +66,19 @@ if (typeof String.prototype.repeat === "undefined") {
 
 // Production steps of ECMA-262, Edition 6, 22.1.2.1
 if (typeof Array.from === "undefined") {
-  Array.from = (function () {
+  Array.from = (function() {
     const toStr = Object.prototype.toString
-    const isCallable = function (fn: any) {
+    const isCallable = function(fn: any) {
       return typeof fn === 'function' || toStr.call(fn) === '[object Function]'
     }
-    const toInteger = function (value: any) {
+    const toInteger = function(value: any) {
       const number = Number(value)
       if (isNaN(number)) { return 0 }
       if (number === 0 || !isFinite(number)) { return number }
       return (number > 0 ? 1 : -1) * Math.floor(Math.abs(number))
     }
     const maxSafeInteger = Math.pow(2, 53) - 1
-    const toLength = function (value: any) {
+    const toLength = function(value: any) {
       const len = toInteger(value)
       return Math.min(Math.max(len, 0), maxSafeInteger)
     }

--- a/bokehjs/test/client/connection.ts
+++ b/bokehjs/test/client/connection.ts
@@ -177,7 +177,7 @@ describe("ClientSession", function() {
             },
           )
         },
-       )
+      )
     })
     return expect(promise).eventually.to.equal("OK")
   })

--- a/bokehjs/test/core/properties.ts
+++ b/bokehjs/test/core/properties.ts
@@ -184,10 +184,10 @@ describe("properties module", () => {
       })
 
       it("should throw an Error otherwise", () => {
-       function fn(): void {
+        function fn(): void {
           const prop = new MyProperty(new SomeHasProps(spec_field_only), 'a')
           prop.value()
-       }
+        }
         expect(fn).to.throw(Error, "attempted to retrieve property value for property without value specification")
       })
     })
@@ -291,48 +291,48 @@ describe("properties module", () => {
         expect(arr[4]).to.be.equal(6)
       })
 
-    describe("init", () => {
-      it("should return nothing by default", () => {
-        const prop = new MyProperty(new SomeHasProps({a: {value: "foo"}}), 'a')
-        expect(prop.init()).to.be.undefined
-      })
-    })
-
-    describe("transform", () => {
-      it("should be the identity", () => {
-        expect(p.Property.prototype.transform(10)).to.be.equal(10)
-        expect(p.Property.prototype.transform("foo")).to.be.equal("foo")
-        expect(p.Property.prototype.transform(null)).to.be.null
+      describe("init", () => {
+        it("should return nothing by default", () => {
+          const prop = new MyProperty(new SomeHasProps({a: {value: "foo"}}), 'a')
+          expect(prop.init()).to.be.undefined
+        })
       })
 
-      it("should return the same type as passed", () => {
-        const r1 = p.Number.prototype.transform([10, 20, 30])
-        expect(r1).to.be.deep.equal([10, 20, 30])
-        const r2 = p.Number.prototype.transform(new Float64Array([10, 20, 30]))
-        expect(r2).to.be.deep.equal(new Float64Array([10, 20, 30]))
-      })
-    })
+      describe("transform", () => {
+        it("should be the identity", () => {
+          expect(p.Property.prototype.transform(10)).to.be.equal(10)
+          expect(p.Property.prototype.transform("foo")).to.be.equal("foo")
+          expect(p.Property.prototype.transform(null)).to.be.null
+        })
 
-    describe("validate", () => {
-      it("should return nothing by default", () => {
-        const prop = new MyProperty(new SomeHasProps({a: {value: "foo"}}), 'a')
-        expect(prop.validate(undefined)).to.be.undefined
-        expect(prop.validate(10)).to.be.undefined
-        expect(prop.validate("foo")).to.be.undefined
-        expect(prop.validate(null)).to.be.undefined
+        it("should return the same type as passed", () => {
+          const r1 = p.Number.prototype.transform([10, 20, 30])
+          expect(r1).to.be.deep.equal([10, 20, 30])
+          const r2 = p.Number.prototype.transform(new Float64Array([10, 20, 30]))
+          expect(r2).to.be.deep.equal(new Float64Array([10, 20, 30]))
+        })
       })
-    })
 
-    describe("changing the property attribute value", () => {
-      it("should trigger change on the property", () => {
-        const obj = new SomeHasProps({a: {value: "foo"}})
-        const prop = obj.properties.a
-        const stuff = {called: false}
-        prop.change.connect(function fn(): void { stuff.called = true})
-        obj.a = {value: "bar"}
-        expect(stuff.called).to.be.true
+      describe("validate", () => {
+        it("should return nothing by default", () => {
+          const prop = new MyProperty(new SomeHasProps({a: {value: "foo"}}), 'a')
+          expect(prop.validate(undefined)).to.be.undefined
+          expect(prop.validate(10)).to.be.undefined
+          expect(prop.validate("foo")).to.be.undefined
+          expect(prop.validate(null)).to.be.undefined
+        })
       })
-    })
+
+      describe("changing the property attribute value", () => {
+        it("should trigger change on the property", () => {
+          const obj = new SomeHasProps({a: {value: "foo"}})
+          const prop = obj.properties.a
+          const stuff = {called: false}
+          prop.change.connect(function fn(): void { stuff.called = true})
+          obj.a = {value: "bar"}
+          expect(stuff.called).to.be.true
+        })
+      })
 
       it("should update the spec", () => {
         const obj = new SomeHasProps({a: {value: "foo"}})

--- a/bokehjs/test/core/util/templating.ts
+++ b/bokehjs/test/core/util/templating.ts
@@ -116,7 +116,7 @@ describe("templating module", () => {
     const imsource = new ColumnDataSource({
       data: {
         arrs: [[[0, 10, 20], [30, 40, 50]]],
-        floats: [[0., 1., 2., 3., 4., 5.]],
+        floats: [[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]],
         labels: ['test label'],
       },
     })

--- a/bokehjs/test/core/util/templating.ts
+++ b/bokehjs/test/core/util/templating.ts
@@ -113,10 +113,13 @@ describe("templating module", () => {
 
     const source = new ColumnDataSource({data: {foo: [10, 1.002], bar: ["a", "<div>b</div>"], baz: [1492890671885, 1290460671885]}})
 
-    const imsource = new ColumnDataSource({data:
-                                           {arrs: [[[0, 10, 20], [30, 40, 50]]],
-                                            floats: [[0., 1., 2., 3., 4., 5.]],
-                                            labels: ['test label']}})
+    const imsource = new ColumnDataSource({
+      data: {
+        arrs: [[[0, 10, 20], [30, 40, 50]]],
+        floats: [[0., 1., 2., 3., 4., 5.]],
+        labels: ['test label'],
+      },
+    })
     const imindex1 = {index: 0, dim1: 2, dim2: 1, flat_index: 5}
     const imindex2 = {index: 0, dim1: 1, dim2: 0, flat_index: 1}
 

--- a/bokehjs/test/core/visuals.ts
+++ b/bokehjs/test/core/visuals.ts
@@ -66,8 +66,8 @@ describe("Line", () => {
     ]) {
       it(`should set canvas context ${attr} value from ${spec} spec value`, () =>{
         const ctx = {} as any
-        ctx.setLineDash = function (x: number) { ctx.lineDash = x }
-        ctx.setLineDashOffset = function (x: number) { ctx.lineDashOffset = x }
+        ctx.setLineDash = function(x: number) { ctx.lineDash = x }
+        ctx.setLineDashOffset = function(x: number) { ctx.lineDashOffset = x }
         const attrs = {line_dash: [1, 2]} as any
         attrs[spec] = {value}
         const model = new Circle(attrs)

--- a/bokehjs/test/document/document.ts
+++ b/bokehjs/test/document/document.ts
@@ -175,7 +175,7 @@ describe("Document", () => {
 
   beforeEach(() => {
     date_stub = sinon.stub(Date, 'now')
-    date_stub.onCall(0).returns( 5)
+    date_stub.onCall(0).returns(5)
     date_stub.onCall(1).returns(10)
     date_stub.onCall(2).returns(12)
     date_stub.onCall(3).returns(15)

--- a/bokehjs/test/integration.ts
+++ b/bokehjs/test/integration.ts
@@ -37,14 +37,14 @@ const spacer =
    width: number | null, height: number | null,
    min_width?: number, min_height?: number,
    max_width?: number, max_height?: number) => (color: Color): Spacer => {
-  return new Spacer({
-    width_policy, height_policy,
-    width, height,
-    min_width, min_height,
-    max_width, max_height,
-    background: color,
-  })
-}
+    return new Spacer({
+      width_policy, height_policy,
+      width, height,
+      min_width, min_height,
+      max_width, max_height,
+      background: color,
+    })
+  }
 
 describe("Row", () => {
   it("should allow to expand when child policy is max", async () => {

--- a/bokehjs/test/models/annotations/color_bar.ts
+++ b/bokehjs/test/models/annotations/color_bar.ts
@@ -15,12 +15,12 @@ import * as text from "@bokehjs/core/util/text"
 
 function color_bar_view(attrs: Partial<ColorBar.Attrs>, place: Place = "center"): ColorBarView {
   const plot = new Plot({
-     x_range: new Range1d({start: 0, end: 1}),
-     y_range: new Range1d({start: 0, end: 1}),
-     frame_width: 500,
-     frame_height: 500,
-     width_policy: "min",
-     height_policy: "min",
+    x_range: new Range1d({start: 0, end: 1}),
+    y_range: new Range1d({start: 0, end: 1}),
+    frame_width: 500,
+    frame_height: 500,
+    width_policy: "min",
+    height_policy: "min",
   })
 
   const color_bar = new ColorBar(attrs)

--- a/bokehjs/test/models/callbacks/customjs.ts
+++ b/bokehjs/test/models/callbacks/customjs.ts
@@ -71,8 +71,8 @@ describe("customjs module", () => {
   describe("execute method", () => {
 
     it("should execute the code and return the result", () => {
-       const r = new CustomJS({code: "return 10", use_strict: true})
-       expect(r.execute('foo')).to.be.equal(10)
+      const r = new CustomJS({code: "return 10", use_strict: true})
+      expect(r.execute('foo')).to.be.equal(10)
     })
 
     it("should execute the code with args parameters passed", () => {
@@ -100,9 +100,9 @@ describe("customjs module", () => {
       // the definition order of keys in a JS object, though it
       // is reliable in some JS runtimes
       const r = new CustomJS({args: {
-          foo4: "foo4", foo5: "foo5", foo6: "foo6",
-          foo1: "foo1", foo2: "foo2", foo3: "foo3",
-        }, code: "return foo1 + foo2 + foo3 + foo4 + foo5 + foo6", use_strict: true})
+        foo4: "foo4", foo5: "foo5", foo6: "foo6",
+        foo1: "foo1", foo2: "foo2", foo3: "foo3",
+      }, code: "return foo1 + foo2 + foo3 + foo4 + foo5 + foo6", use_strict: true})
       expect(r.execute({})).to.be.equal("foo1foo2foo3foo4foo5foo6")
     })
   })

--- a/bokehjs/test/models/graphs/graph_hit_test_policy.ts
+++ b/bokehjs/test/models/graphs/graph_hit_test_policy.ts
@@ -40,8 +40,8 @@ describe("GraphHitTestPolicy", () => {
     const doc = new Document()
 
     const plot = new Plot({
-       x_range: new Range1d({start: 0, end: 1}),
-       y_range: new Range1d({start: 0, end: 1}),
+      x_range: new Range1d({start: 0, end: 1}),
+      y_range: new Range1d({start: 0, end: 1}),
     })
     doc.add_root(plot)
     const plot_view = new plot.default_view({model: plot, parent: null}).build()

--- a/bokehjs/test/models/graphs/graph_hit_test_policy.ts
+++ b/bokehjs/test/models/graphs/graph_hit_test_policy.ts
@@ -227,7 +227,7 @@ describe("GraphHitTestPolicy", () => {
         const policy = new EdgesAndLinkedNodes()
         policy.do_selection(hit_test_result, gr, true, false)
 
-        expect(node_source.selected.indices).to.be.deep.equal( [0, 2] )
+        expect(node_source.selected.indices).to.be.deep.equal([0, 2])
       })
     })
 
@@ -253,7 +253,7 @@ describe("GraphHitTestPolicy", () => {
         const did_hit = policy.do_inspection(hit_test_result, {type: "point", sx: 0, sy: 0}, gv, true, false)
 
         expect(did_hit).to.be.true
-        expect(node_source.inspected.indices).to.be.deep.equal( [0, 2] )
+        expect(node_source.inspected.indices).to.be.deep.equal([0, 2])
       })
     })
   })

--- a/bokehjs/test/models/plots/plot.ts
+++ b/bokehjs/test/models/plots/plot.ts
@@ -33,31 +33,31 @@ describe("lib.models.plots.plot", () => {
 
   describe("PlotView", () => {
 
-      it("should perform standard reset actions by default", () => {
-        const view = new_plot_view()
-        const spy_state = sinon.spy(view, 'clear_state')
-        const spy_range = sinon.spy(view, 'reset_range')
-        const spy_selection = sinon.spy(view, 'reset_selection')
-        const spy_event = sinon.spy(view.model, 'trigger_event')
-        view.reset()
-        expect(spy_state.called).to.be.true
-        expect(spy_range.called).to.be.true
-        expect(spy_selection.called).to.be.true
-        expect(spy_event.called).to.be.true
-      })
+    it("should perform standard reset actions by default", () => {
+      const view = new_plot_view()
+      const spy_state = sinon.spy(view, 'clear_state')
+      const spy_range = sinon.spy(view, 'reset_range')
+      const spy_selection = sinon.spy(view, 'reset_selection')
+      const spy_event = sinon.spy(view.model, 'trigger_event')
+      view.reset()
+      expect(spy_state.called).to.be.true
+      expect(spy_range.called).to.be.true
+      expect(spy_selection.called).to.be.true
+      expect(spy_event.called).to.be.true
+    })
 
-      it("should skip standard reset actions for event_only policy", () => {
-        const view = new_plot_view({reset_policy: "event_only"})
-        const spy_state = sinon.spy(view, 'clear_state')
-        const spy_range = sinon.spy(view, 'reset_range')
-        const spy_selection = sinon.spy(view, 'reset_selection')
-        const spy_event = sinon.spy(view.model, 'trigger_event')
-        view.reset()
-        expect(spy_state.called).to.be.false
-        expect(spy_range.called).to.be.false
-        expect(spy_selection.called).to.be.false
-        expect(spy_event.called).to.be.true
-      })
+    it("should skip standard reset actions for event_only policy", () => {
+      const view = new_plot_view({reset_policy: "event_only"})
+      const spy_state = sinon.spy(view, 'clear_state')
+      const spy_range = sinon.spy(view, 'reset_range')
+      const spy_selection = sinon.spy(view, 'reset_selection')
+      const spy_event = sinon.spy(view.model, 'trigger_event')
+      view.reset()
+      expect(spy_state.called).to.be.false
+      expect(spy_range.called).to.be.false
+      expect(spy_selection.called).to.be.false
+      expect(spy_event.called).to.be.true
+    })
 
     it("layout should set element style correctly", () => {
       const view = new_plot_view({width: 425, height: 658})

--- a/bokehjs/test/models/ranges/factor_range.ts
+++ b/bokehjs/test/models/ranges/factor_range.ts
@@ -93,44 +93,44 @@ describe("factor_range module", () => {
         expect(r3[1]).to.be.equal(0)
       })
 
-     describe("with positive padding", () => {
+      describe("with positive padding", () => {
 
-      it("should evenly map a list of factors, padded, starting at 0.5 (with no offset by default)", () => {
-        const r0 = map_one_level(['a'], 0.5)
-        expect(r0[0]).to.deep.equal({a: {value: 0.5}})
-        expect(r0[1]).to.be.equal(0)
+        it("should evenly map a list of factors, padded, starting at 0.5 (with no offset by default)", () => {
+          const r0 = map_one_level(['a'], 0.5)
+          expect(r0[0]).to.deep.equal({a: {value: 0.5}})
+          expect(r0[1]).to.be.equal(0)
 
-        const r1 = map_one_level(['a', 'b'], 0.5)
-        expect(r1[0]).to.deep.equal({a: {value: 0.5}, b: {value: 2}})
-        expect(r1[1]).to.be.equal(0.5)
+          const r1 = map_one_level(['a', 'b'], 0.5)
+          expect(r1[0]).to.deep.equal({a: {value: 0.5}, b: {value: 2}})
+          expect(r1[1]).to.be.equal(0.5)
 
-        const r2 = map_one_level(['a', 'b', 'c'], 0.5)
-        expect(r2[0]).to.deep.equal({a: {value: 0.5}, b: {value: 2}, c: {value: 3.5}})
-        expect(r2[1]).to.be.equal(1)
+          const r2 = map_one_level(['a', 'b', 'c'], 0.5)
+          expect(r2[0]).to.deep.equal({a: {value: 0.5}, b: {value: 2}, c: {value: 3.5}})
+          expect(r2[1]).to.be.equal(1)
 
-        const r3 = map_one_level(['a', 'b', 'c', 'd'], 0.5)
-        expect(r3[0]).to.deep.equal({a: {value: 0.5}, b: {value: 2}, c: {value: 3.5}, d: {value: 5}})
-        expect(r3[1]).to.be.equal(1.5)
+          const r3 = map_one_level(['a', 'b', 'c', 'd'], 0.5)
+          expect(r3[0]).to.deep.equal({a: {value: 0.5}, b: {value: 2}, c: {value: 3.5}, d: {value: 5}})
+          expect(r3[1]).to.be.equal(1.5)
+        })
+
+        it("should also apply an offset if provided", () => {
+          const r0 = map_one_level(['a'], 0.5, 1)
+          expect(r0[0]).to.deep.equal({a: {value: 1.5}})
+          expect(r0[1]).to.be.equal(0)
+
+          const r1 = map_one_level(['a', 'b'], 0.5, 1)
+          expect(r1[0]).to.deep.equal({a: {value: 1.5}, b: {value: 3}})
+          expect(r1[1]).to.be.equal(0.5)
+
+          const r2 = map_one_level(['a', 'b', 'c'], 0.5, 1)
+          expect(r2[0]).to.deep.equal({a: {value: 1.5}, b: {value: 3}, c: {value: 4.5}})
+          expect(r2[1]).to.be.equal(1)
+
+          const r3 = map_one_level(['a', 'b', 'c', 'd'], 0.5, 1)
+          expect(r3[0]).to.deep.equal({a: {value: 1.5}, b: {value: 3}, c: {value: 4.5}, d: {value: 6}})
+          expect(r3[1]).to.be.equal(1.5)
+        })
       })
-
-      it("should also apply an offset if provided", () => {
-        const r0 = map_one_level(['a'], 0.5, 1)
-        expect(r0[0]).to.deep.equal({a: {value: 1.5}})
-        expect(r0[1]).to.be.equal(0)
-
-        const r1 = map_one_level(['a', 'b'], 0.5, 1)
-        expect(r1[0]).to.deep.equal({a: {value: 1.5}, b: {value: 3}})
-        expect(r1[1]).to.be.equal(0.5)
-
-        const r2 = map_one_level(['a', 'b', 'c'], 0.5, 1)
-        expect(r2[0]).to.deep.equal({a: {value: 1.5}, b: {value: 3}, c: {value: 4.5}})
-        expect(r2[1]).to.be.equal(1)
-
-        const r3 = map_one_level(['a', 'b', 'c', 'd'], 0.5, 1)
-        expect(r3[0]).to.deep.equal({a: {value: 1.5}, b: {value: 3}, c: {value: 4.5}, d: {value: 6}})
-        expect(r3[1]).to.be.equal(1.5)
-      })
-     })
     })
   })
 

--- a/bokehjs/test/models/sources/column_data_source.ts
+++ b/bokehjs/test/models/sources/column_data_source.ts
@@ -266,10 +266,10 @@ describe("column_data_source module", () => {
       it("should patch typed Arrays to types Arrays", () => {
         for (const typ of [Float32Array, Float64Array, Int32Array]) {
           const a = new typ([1, 2, 3,
-                       4, 5, 6])
+                             4, 5, 6])
           const b = new typ([10, 20,
-                       -1, -2,
-                        0, 10])
+                             -1, -2,
+                             0, 10])
           const c = new typ([1, 2])
           patch_to_column([a, b, c], [
             [[0, {}, 2], [100, 101]],

--- a/bokehjs/test/models/tools/inspectors/customjs_hover.ts
+++ b/bokehjs/test/models/tools/inspectors/customjs_hover.ts
@@ -74,8 +74,8 @@ describe("customjs module", () => {
   describe("format method", () => {
 
     it("should execute the code and return the result", () => {
-       const r = new CustomJSHover({code: "return format + ' ' + value + ' ' + 10"})
-       expect(r.format(0, "custom", {})).to.be.equal("custom 0 10")
+      const r = new CustomJSHover({code: "return format + ' ' + value + ' ' + 10"})
+      expect(r.format(0, "custom", {})).to.be.equal("custom 0 10")
     })
 
     it("should execute the code with args parameters passed", () => {

--- a/bokehjs/test/models/transforms/dodge.ts
+++ b/bokehjs/test/models/transforms/dodge.ts
@@ -9,7 +9,7 @@ describe("Dodge transform module", () => {
     const transform = new Dodge({value: -0.5})
 
     it("should add value to data", () => {
-      const vals = [-10, -2.5, 0, .2, .5, 10]
+      const vals = [-10, -2.5, 0, 0.2, 0.5, 10]
       const rets = transform.v_compute(vals)
       expect(rets).to.deep.equal(new Float64Array([-10.5, -3, -0.5, -0.3, 0, 9.5]))
     })

--- a/bokehjs/test/models/widgets/checkbox_button_group.ts
+++ b/bokehjs/test/models/widgets/checkbox_button_group.ts
@@ -8,7 +8,7 @@ describe("CheckboxButtonGroup", () => {
 
   describe("change_active", () => {
 
-    it( "should add arg to active if not present", () => {
+    it("should add arg to active if not present", () => {
       const g = new CheckboxButtonGroup({active: [0, 2]})
       const view = new g.default_view({model: g, parent: null}).build()
       view.change_active(1)


### PR DESCRIPTION
Enables the following rules:
- [x] `indent`
- [x] `semi`
- [x] `no-floating-decimal`
- [x] `brace-style`
- [x] `no-trailing-spaces`
- [x] `space-before-function-paren`
- [x] `space-in-parens`
