### PR TITLE
Automatically insert class init code

### DIFF
--- a/bokehjs/src/compiler/compiler.ts
+++ b/bokehjs/src/compiler/compiler.ts
@@ -107,6 +107,9 @@ export function default_transformers(options: ts.CompilerOptions, css_dir?: Path
   const insert_class_name = transforms.insert_class_name()
   transformers.before.push(insert_class_name)
 
+  const add_init_class = transforms.add_init_class()
+  transformers.before.push(add_init_class)
+
   const base = options.baseUrl
   if (base != null) {
     const relativize_modules = transforms.relativize_modules((file, module_path) => {

--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -45,7 +45,7 @@ export abstract class HasProps extends Signalable() {
   set type(name: string) { this.constructor.__name__ = name }
   get type(): string     { return this.constructor.__name__ }
 
-  static initClass(): void {
+  static init_HasProps(): void {
     this.prototype.props = {}
     this.prototype.mixins = []
 
@@ -534,4 +534,3 @@ export abstract class HasProps extends Signalable() {
     return data
   }
 }
-HasProps.initClass()

--- a/bokehjs/src/lib/core/selection_manager.ts
+++ b/bokehjs/src/lib/core/selection_manager.ts
@@ -25,7 +25,7 @@ export class SelectionManager extends HasProps {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_SelectionManager(): void {
     this.internal({
       source: [ p.Any ],
     })
@@ -92,4 +92,3 @@ export class SelectionManager extends HasProps {
     return this.inspectors[rmodel.id]
   }
 }
-SelectionManager.initClass()

--- a/bokehjs/src/lib/model.ts
+++ b/bokehjs/src/lib/model.ts
@@ -29,7 +29,7 @@ export class Model extends HasProps {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Model(): void {
     this.define<Model.Props>({
       tags:                  [ p.Array, [] ],
       name:                  [ p.String    ],
@@ -122,4 +122,3 @@ export class Model extends HasProps {
     }
   }
 }
-Model.initClass()

--- a/bokehjs/src/lib/models/annotations/annotation.ts
+++ b/bokehjs/src/lib/models/annotations/annotation.ts
@@ -79,10 +79,9 @@ export abstract class Annotation extends Renderer {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Annotation(): void {
     this.override({
       level: 'annotation',
     })
   }
 }
-Annotation.initClass()

--- a/bokehjs/src/lib/models/annotations/arrow.ts
+++ b/bokehjs/src/lib/models/annotations/arrow.ts
@@ -162,7 +162,7 @@ export class Arrow extends Annotation {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Arrow(): void {
     this.prototype.default_view = ArrowView
 
     this.mixins(['line'])
@@ -182,4 +182,3 @@ export class Arrow extends Annotation {
     })
   }
 }
-Arrow.initClass()

--- a/bokehjs/src/lib/models/annotations/arrow_head.ts
+++ b/bokehjs/src/lib/models/annotations/arrow_head.ts
@@ -21,7 +21,7 @@ export abstract class ArrowHead extends Annotation {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_ArrowHead(): void {
     this.define<ArrowHead.Props>({
       size: [ p.Number, 25 ],
     })
@@ -38,7 +38,6 @@ export abstract class ArrowHead extends Annotation {
 
   abstract clip(ctx: Context2d, i: number): void // This method should not begin or close a path
 }
-ArrowHead.initClass()
 
 export namespace OpenHead {
   export type Attrs = p.AttrsOf<Props>
@@ -55,7 +54,7 @@ export class OpenHead extends ArrowHead {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_OpenHead(): void {
     this.mixins(['line'])
   }
 
@@ -84,7 +83,6 @@ export class OpenHead extends ArrowHead {
     }
   }
 }
-OpenHead.initClass()
 
 export namespace NormalHead {
   export type Attrs = p.AttrsOf<Props>
@@ -101,7 +99,7 @@ export class NormalHead extends ArrowHead {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_NormalHead(): void {
     this.mixins(['line', 'fill'])
 
     this.override({
@@ -143,7 +141,6 @@ export class NormalHead extends ArrowHead {
     ctx.closePath()
   }
 }
-NormalHead.initClass()
 
 export namespace VeeHead {
   export type Attrs = p.AttrsOf<Props>
@@ -160,7 +157,7 @@ export class VeeHead extends ArrowHead {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_VeeHead(): void {
     this.mixins(['line', 'fill'])
 
     this.override({
@@ -204,7 +201,6 @@ export class VeeHead extends ArrowHead {
     ctx.closePath()
   }
 }
-VeeHead.initClass()
 
 export namespace TeeHead {
   export type Attrs = p.AttrsOf<Props>
@@ -221,7 +217,7 @@ export class TeeHead extends ArrowHead {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_TeeHead(): void {
     this.mixins(['line'])
   }
 
@@ -239,4 +235,3 @@ export class TeeHead extends ArrowHead {
 
   clip(_ctx: Context2d, _i: number): void {}
 }
-TeeHead.initClass()

--- a/bokehjs/src/lib/models/annotations/band.ts
+++ b/bokehjs/src/lib/models/annotations/band.ts
@@ -163,7 +163,7 @@ export class Band extends Annotation {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Band(): void {
     this.prototype.default_view = BandView
 
     this.mixins(['line', 'fill'])
@@ -186,4 +186,3 @@ export class Band extends Annotation {
     })
   }
 }
-Band.initClass()

--- a/bokehjs/src/lib/models/annotations/box_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/box_annotation.ts
@@ -184,7 +184,7 @@ export class BoxAnnotation extends Annotation {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_BoxAnnotation(): void {
     this.prototype.default_view = BoxAnnotationView
 
     this.mixins(['line', 'fill'])
@@ -230,4 +230,3 @@ export class BoxAnnotation extends Annotation {
     this.data_update.emit()
   }
 }
-BoxAnnotation.initClass()

--- a/bokehjs/src/lib/models/annotations/color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/color_bar.ts
@@ -617,7 +617,7 @@ export class ColorBar extends Annotation {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_ColorBar(): void {
     this.prototype.default_view = ColorBarView
 
     this.mixins([
@@ -666,4 +666,3 @@ export class ColorBar extends Annotation {
     })
   }
 }
-ColorBar.initClass()

--- a/bokehjs/src/lib/models/annotations/label.ts
+++ b/bokehjs/src/lib/models/annotations/label.ts
@@ -91,7 +91,7 @@ export class Label extends TextAnnotation {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Label(): void {
     this.prototype.default_view = LabelView
 
     this.mixins(['text', 'line:border_', 'fill:background_'])
@@ -116,4 +116,3 @@ export class Label extends TextAnnotation {
     })
   }
 }
-Label.initClass()

--- a/bokehjs/src/lib/models/annotations/label_set.ts
+++ b/bokehjs/src/lib/models/annotations/label_set.ts
@@ -229,7 +229,7 @@ export class LabelSet extends TextAnnotation {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_LabelSet(): void {
     this.prototype.default_view = LabelSetView
 
     this.mixins(['text', 'line:border_', 'fill:background_'])
@@ -254,4 +254,3 @@ export class LabelSet extends TextAnnotation {
     })
   }
 }
-LabelSet.initClass()

--- a/bokehjs/src/lib/models/annotations/legend.ts
+++ b/bokehjs/src/lib/models/annotations/legend.ts
@@ -366,7 +366,7 @@ export class Legend extends Annotation {
     this.item_change = new Signal0(this, "item_change")
   }
 
-  static initClass(): void {
+  static init_Legend(): void {
     this.prototype.default_view = LegendView
 
     this.mixins([
@@ -418,4 +418,3 @@ export class Legend extends Annotation {
     return legend_names
   }
 }
-Legend.initClass()

--- a/bokehjs/src/lib/models/annotations/legend_item.ts
+++ b/bokehjs/src/lib/models/annotations/legend_item.ts
@@ -28,7 +28,7 @@ export class LegendItem extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_LegendItem(): void {
     this.define<LegendItem.Props>({
       label:     [ p.StringSpec, null ],
       renderers: [ p.Array,      []   ],
@@ -117,4 +117,3 @@ export class LegendItem extends Model {
     return []
   }
 }
-LegendItem.initClass()

--- a/bokehjs/src/lib/models/annotations/poly_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/poly_annotation.ts
@@ -94,7 +94,7 @@ export class PolyAnnotation extends Annotation {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_PolyAnnotation(): void {
     this.prototype.default_view = PolyAnnotationView
 
     this.mixins(['line', 'fill'])
@@ -130,4 +130,3 @@ export class PolyAnnotation extends Annotation {
     this.data_update.emit()
   }
 }
-PolyAnnotation.initClass()

--- a/bokehjs/src/lib/models/annotations/slope.ts
+++ b/bokehjs/src/lib/models/annotations/slope.ts
@@ -86,7 +86,7 @@ export class Slope extends Annotation {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Slope(): void {
     this.prototype.default_view = SlopeView
 
     this.mixins(['line'])
@@ -104,4 +104,3 @@ export class Slope extends Annotation {
 
   }
 }
-Slope.initClass()

--- a/bokehjs/src/lib/models/annotations/span.ts
+++ b/bokehjs/src/lib/models/annotations/span.ts
@@ -132,7 +132,7 @@ export class Span extends Annotation {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Span(): void {
     this.prototype.default_view = SpanView
 
     this.mixins(['line'])
@@ -156,4 +156,3 @@ export class Span extends Annotation {
     })
   }
 }
-Span.initClass()

--- a/bokehjs/src/lib/models/annotations/text_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/text_annotation.ts
@@ -163,10 +163,9 @@ export abstract class TextAnnotation extends Annotation {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_TextAnnotation(): void {
     this.define<TextAnnotation.Props>({
       render_mode: [ p.RenderMode, "canvas" ],
     })
   }
 }
-TextAnnotation.initClass()

--- a/bokehjs/src/lib/models/annotations/title.ts
+++ b/bokehjs/src/lib/models/annotations/title.ts
@@ -141,7 +141,7 @@ export class Title extends TextAnnotation {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Title(): void {
     this.prototype.default_view = TitleView
 
     this.mixins(['line:border_', 'fill:background_'])
@@ -169,4 +169,3 @@ export class Title extends TextAnnotation {
     })
   }
 }
-Title.initClass()

--- a/bokehjs/src/lib/models/annotations/toolbar_panel.ts
+++ b/bokehjs/src/lib/models/annotations/toolbar_panel.ts
@@ -73,7 +73,7 @@ export class ToolbarPanel extends Annotation {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_ToolbarPanel(): void {
     this.prototype.default_view = ToolbarPanelView
 
     this.define<ToolbarPanel.Props>({
@@ -81,4 +81,3 @@ export class ToolbarPanel extends Annotation {
     })
   }
 }
-ToolbarPanel.initClass()

--- a/bokehjs/src/lib/models/annotations/tooltip.ts
+++ b/bokehjs/src/lib/models/annotations/tooltip.ts
@@ -141,7 +141,7 @@ export class Tooltip extends Annotation {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Tooltip(): void {
     this.prototype.default_view = TooltipView
 
     this.define<Tooltip.Props>({
@@ -168,4 +168,3 @@ export class Tooltip extends Annotation {
     this.data = this.data.concat([[sx, sy, content]])
   }
 }
-Tooltip.initClass()

--- a/bokehjs/src/lib/models/annotations/whisker.ts
+++ b/bokehjs/src/lib/models/annotations/whisker.ts
@@ -155,7 +155,7 @@ export class Whisker extends Annotation {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Whisker(): void {
     this.prototype.default_view = WhiskerView
 
     this.mixins(['line'])
@@ -177,4 +177,3 @@ export class Whisker extends Annotation {
     })
   }
 }
-Whisker.initClass()

--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -549,7 +549,7 @@ export class Axis extends GuideRenderer {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Axis(): void {
     this.prototype.default_view = AxisView
 
     this.mixins([
@@ -593,4 +593,3 @@ export class Axis extends GuideRenderer {
     })
   }
 }
-Axis.initClass()

--- a/bokehjs/src/lib/models/axes/categorical_axis.ts
+++ b/bokehjs/src/lib/models/axes/categorical_axis.ts
@@ -178,7 +178,7 @@ export class CategoricalAxis extends Axis {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_CategoricalAxis(): void {
     this.prototype.default_view = CategoricalAxisView
 
     this.mixins([
@@ -205,4 +205,3 @@ export class CategoricalAxis extends Axis {
     })
   }
 }
-CategoricalAxis.initClass()

--- a/bokehjs/src/lib/models/axes/datetime_axis.ts
+++ b/bokehjs/src/lib/models/axes/datetime_axis.ts
@@ -25,7 +25,7 @@ export class DatetimeAxis extends LinearAxis {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_DatetimeAxis(): void {
     this.prototype.default_view = DatetimeAxisView
 
     this.override({
@@ -34,4 +34,3 @@ export class DatetimeAxis extends LinearAxis {
     })
   }
 }
-DatetimeAxis.initClass()

--- a/bokehjs/src/lib/models/axes/linear_axis.ts
+++ b/bokehjs/src/lib/models/axes/linear_axis.ts
@@ -29,7 +29,7 @@ export class LinearAxis extends ContinuousAxis {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_LinearAxis(): void {
     this.prototype.default_view = LinearAxisView
 
     this.override({
@@ -38,4 +38,3 @@ export class LinearAxis extends ContinuousAxis {
     })
   }
 }
-LinearAxis.initClass()

--- a/bokehjs/src/lib/models/axes/log_axis.ts
+++ b/bokehjs/src/lib/models/axes/log_axis.ts
@@ -29,7 +29,7 @@ export class LogAxis extends ContinuousAxis {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_LogAxis(): void {
     this.prototype.default_view = LogAxisView
 
     this.override({
@@ -38,4 +38,3 @@ export class LogAxis extends ContinuousAxis {
     })
   }
 }
-LogAxis.initClass()

--- a/bokehjs/src/lib/models/axes/mercator_axis.ts
+++ b/bokehjs/src/lib/models/axes/mercator_axis.ts
@@ -29,7 +29,7 @@ export class MercatorAxis extends LinearAxis {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_MercatorAxis(): void {
     this.prototype.default_view = MercatorAxisView
 
     this.override({
@@ -38,4 +38,3 @@ export class MercatorAxis extends LinearAxis {
     })
   }
 }
-MercatorAxis.initClass()

--- a/bokehjs/src/lib/models/callbacks/customjs.ts
+++ b/bokehjs/src/lib/models/callbacks/customjs.ts
@@ -22,7 +22,7 @@ export class CustomJS extends Callback {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_CustomJS(): void {
     this.define<CustomJS.Props>({
       args:       [ p.Any,     {}    ], // TODO (bev) better type
       code:       [ p.String,  ''    ],
@@ -47,4 +47,3 @@ export class CustomJS extends Callback {
     return this.func.apply(cb_obj, this.values.concat(cb_obj, cb_data, require, {}))
   }
 }
-CustomJS.initClass()

--- a/bokehjs/src/lib/models/callbacks/open_url.ts
+++ b/bokehjs/src/lib/models/callbacks/open_url.ts
@@ -21,7 +21,7 @@ export class OpenURL extends Callback {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_OpenURL(): void {
     this.define<OpenURL.Props>({
       url: [ p.String, 'http://' ],
       same_tab: [ p.Boolean, false ],
@@ -48,4 +48,3 @@ export class OpenURL extends Callback {
     // TODO: multiline_indices: {[key: string]: number[]}
   }
 }
-OpenURL.initClass()

--- a/bokehjs/src/lib/models/canvas/canvas.ts
+++ b/bokehjs/src/lib/models/canvas/canvas.ts
@@ -129,7 +129,7 @@ export class Canvas extends HasProps {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Canvas(): void {
     this.prototype.default_view = CanvasView
 
     this.internal({
@@ -140,4 +140,3 @@ export class Canvas extends HasProps {
     })
   }
 }
-Canvas.initClass()

--- a/bokehjs/src/lib/models/expressions/cumsum.ts
+++ b/bokehjs/src/lib/models/expressions/cumsum.ts
@@ -21,7 +21,7 @@ export class CumSum extends Expression {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_CumSum(): void {
     this.define<CumSum.Props>({
       field:        [ p.String         ],
       include_zero: [ p.Boolean, false ],
@@ -39,4 +39,3 @@ export class CumSum extends Expression {
     return result
   }
 }
-CumSum.initClass()

--- a/bokehjs/src/lib/models/expressions/stack.ts
+++ b/bokehjs/src/lib/models/expressions/stack.ts
@@ -20,7 +20,7 @@ export class Stack extends Expression {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Stack(): void {
     this.define<Stack.Props>({
       fields: [ p.Array, [] ],
     })
@@ -37,4 +37,3 @@ export class Stack extends Expression {
     return result
   }
 }
-Stack.initClass()

--- a/bokehjs/src/lib/models/filters/boolean_filter.ts
+++ b/bokehjs/src/lib/models/filters/boolean_filter.ts
@@ -22,7 +22,7 @@ export class BooleanFilter extends Filter {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_BooleanFilter(): void {
     this.define<BooleanFilter.Props>({
       booleans: [ p.Array, null ],
     })
@@ -49,4 +49,3 @@ export class BooleanFilter extends Filter {
     }
   }
 }
-BooleanFilter.initClass()

--- a/bokehjs/src/lib/models/filters/customjs_filter.ts
+++ b/bokehjs/src/lib/models/filters/customjs_filter.ts
@@ -23,7 +23,7 @@ export class CustomJSFilter extends Filter {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_CustomJSFilter(): void {
     this.define<CustomJSFilter.Props>({
       args:       [ p.Any,     {}    ], // TODO (bev) better type
       code:       [ p.String,  ''    ],
@@ -49,4 +49,3 @@ export class CustomJSFilter extends Filter {
     return super.compute_indices(source)
   }
 }
-CustomJSFilter.initClass()

--- a/bokehjs/src/lib/models/filters/filter.ts
+++ b/bokehjs/src/lib/models/filters/filter.ts
@@ -22,7 +22,7 @@ export class Filter extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Filter(): void {
     this.define<Filter.Props>({
       filter: [ p.Array, null ],
     })
@@ -45,4 +45,3 @@ export class Filter extends Model {
     }
   }
 }
-Filter.initClass()

--- a/bokehjs/src/lib/models/filters/group_filter.ts
+++ b/bokehjs/src/lib/models/filters/group_filter.ts
@@ -22,7 +22,7 @@ export class GroupFilter extends Filter {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_GroupFilter(): void {
     this.define<GroupFilter.Props>({
       column_name: [ p.String  ],
       group:       [ p.String  ],
@@ -45,4 +45,3 @@ export class GroupFilter extends Filter {
     }
   }
 }
-GroupFilter.initClass()

--- a/bokehjs/src/lib/models/filters/index_filter.ts
+++ b/bokehjs/src/lib/models/filters/index_filter.ts
@@ -22,7 +22,7 @@ export class IndexFilter extends Filter {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_IndexFilter(): void {
     this.define<IndexFilter.Props>({
       indices: [ p.Array, null ],
     })
@@ -42,4 +42,3 @@ export class IndexFilter extends Filter {
     }
   }
 }
-IndexFilter.initClass()

--- a/bokehjs/src/lib/models/formatters/basic_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/basic_tick_formatter.ts
@@ -22,7 +22,7 @@ export class BasicTickFormatter extends TickFormatter {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_BasicTickFormatter(): void {
     this.define<BasicTickFormatter.Props>({
       precision:        [ p.Any,     'auto' ], // TODO (bev) better
       use_scientific:   [ p.Boolean, true   ],
@@ -115,4 +115,3 @@ export class BasicTickFormatter extends TickFormatter {
     return labels
   }
 }
-BasicTickFormatter.initClass()

--- a/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
@@ -74,7 +74,7 @@ export class DatetimeTickFormatter extends TickFormatter {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_DatetimeTickFormatter(): void {
     this.define<DatetimeTickFormatter.Props>({
       microseconds: [ p.Array, ['%fus'] ],
       milliseconds: [ p.Array, ['%3Nms', '%S.%3Ns'] ],
@@ -242,4 +242,3 @@ export class DatetimeTickFormatter extends TickFormatter {
     return labels
   }
 }
-DatetimeTickFormatter.initClass()

--- a/bokehjs/src/lib/models/formatters/func_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/func_tick_formatter.ts
@@ -22,7 +22,7 @@ export class FuncTickFormatter extends TickFormatter {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_FuncTickFormatter(): void {
     this.define<FuncTickFormatter.Props>({
       args:       [ p.Any,     {}    ], // TODO (bev) better type
       code:       [ p.String,  ''    ],
@@ -49,4 +49,3 @@ export class FuncTickFormatter extends TickFormatter {
     return ticks.map((tick, index, ticks) => func(tick, index, ticks, ...this.values, require, {}))
   }
 }
-FuncTickFormatter.initClass()

--- a/bokehjs/src/lib/models/formatters/log_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/log_tick_formatter.ts
@@ -21,7 +21,7 @@ export class LogTickFormatter extends TickFormatter {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_LogTickFormatter(): void {
     this.define<LogTickFormatter.Props>({
       ticker: [ p.Instance, null ],
     })
@@ -58,4 +58,3 @@ export class LogTickFormatter extends TickFormatter {
       return labels
   }
 }
-LogTickFormatter.initClass()

--- a/bokehjs/src/lib/models/formatters/mercator_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/mercator_tick_formatter.ts
@@ -20,7 +20,7 @@ export class MercatorTickFormatter extends BasicTickFormatter {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_MercatorTickFormatter(): void {
     this.define<MercatorTickFormatter.Props>({
       dimension: [ p.LatLon ],
     })
@@ -51,4 +51,3 @@ export class MercatorTickFormatter extends BasicTickFormatter {
     return super.doFormat(proj_ticks, opts)
   }
 }
-MercatorTickFormatter.initClass()

--- a/bokehjs/src/lib/models/formatters/numeral_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/numeral_tick_formatter.ts
@@ -23,7 +23,7 @@ export class NumeralTickFormatter extends TickFormatter {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_NumeralTickFormatter(): void {
     this.define<NumeralTickFormatter.Props>({
       // TODO (bev) all of these could be tightened up
       format:   [ p.String,           '0,0'   ],
@@ -51,4 +51,3 @@ export class NumeralTickFormatter extends TickFormatter {
     return ticks.map((tick) => Numbro.format(tick, format, language, _rounding_fn))
   }
 }
-NumeralTickFormatter.initClass()

--- a/bokehjs/src/lib/models/formatters/printf_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/printf_tick_formatter.ts
@@ -19,7 +19,7 @@ export class PrintfTickFormatter extends TickFormatter {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_PrintfTickFormatter(): void {
     this.define<PrintfTickFormatter.Props>({
       format: [ p.String, '%s' ],
     })
@@ -29,4 +29,3 @@ export class PrintfTickFormatter extends TickFormatter {
     return ticks.map((tick) => sprintf(this.format, tick))
   }
 }
-PrintfTickFormatter.initClass()

--- a/bokehjs/src/lib/models/glyphs/annular_wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/annular_wedge.ts
@@ -173,7 +173,7 @@ export class AnnularWedge extends XYGlyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_AnnularWedge(): void {
     this.prototype.default_view = AnnularWedgeView
 
     this.mixins(['line', 'fill'])
@@ -186,4 +186,3 @@ export class AnnularWedge extends XYGlyph {
     })
   }
 }
-AnnularWedge.initClass()

--- a/bokehjs/src/lib/models/glyphs/annulus.ts
+++ b/bokehjs/src/lib/models/glyphs/annulus.ts
@@ -156,7 +156,7 @@ export class Annulus extends XYGlyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Annulus(): void {
     this.prototype.default_view = AnnulusView
 
     this.mixins(['line', 'fill'])
@@ -166,4 +166,3 @@ export class Annulus extends XYGlyph {
     })
   }
 }
-Annulus.initClass()

--- a/bokehjs/src/lib/models/glyphs/arc.ts
+++ b/bokehjs/src/lib/models/glyphs/arc.ts
@@ -75,7 +75,7 @@ export class Arc extends XYGlyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Arc(): void {
     this.prototype.default_view = ArcView
 
     this.mixins(['line'])
@@ -87,4 +87,3 @@ export class Arc extends XYGlyph {
     })
   }
 }
-Arc.initClass()

--- a/bokehjs/src/lib/models/glyphs/area.ts
+++ b/bokehjs/src/lib/models/glyphs/area.ts
@@ -36,8 +36,7 @@ export class Area extends Glyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Area(): void {
     this.mixins(['fill', 'hatch'])
   }
 }
-Area.initClass()

--- a/bokehjs/src/lib/models/glyphs/bezier.ts
+++ b/bokehjs/src/lib/models/glyphs/bezier.ts
@@ -171,11 +171,10 @@ export class Bezier extends Glyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Bezier(): void {
     this.prototype.default_view = BezierView
 
     this.coords([['x0', 'y0'], ['x1', 'y1'], ['cx0', 'cy0'], ['cx1', 'cy1']])
     this.mixins(['line'])
   }
 }
-Bezier.initClass()

--- a/bokehjs/src/lib/models/glyphs/box.ts
+++ b/bokehjs/src/lib/models/glyphs/box.ts
@@ -174,8 +174,7 @@ export abstract class Box extends Glyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Box(): void {
     this.mixins(['line', 'fill', 'hatch'])
   }
 }
-Box.initClass()

--- a/bokehjs/src/lib/models/glyphs/center_rotatable.ts
+++ b/bokehjs/src/lib/models/glyphs/center_rotatable.ts
@@ -47,7 +47,7 @@ export abstract class CenterRotatable extends XYGlyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_CenterRotatable(): void {
     this.mixins(['line', 'fill'])
     this.define<CenterRotatable.Props>({
       angle:  [ p.AngleSpec,   0     ],
@@ -57,4 +57,3 @@ export abstract class CenterRotatable extends XYGlyph {
 
   }
 }
-CenterRotatable.initClass()

--- a/bokehjs/src/lib/models/glyphs/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/circle.ts
@@ -279,7 +279,7 @@ export class Circle extends XYGlyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Circle(): void {
     this.prototype.default_view = CircleView
 
     this.mixins(['line', 'fill'])
@@ -296,4 +296,3 @@ export class Circle extends XYGlyph {
     this.properties.radius.optional = true
   }
 }
-Circle.initClass()

--- a/bokehjs/src/lib/models/glyphs/ellipse.ts
+++ b/bokehjs/src/lib/models/glyphs/ellipse.ts
@@ -28,8 +28,7 @@ export class Ellipse extends EllipseOval {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Ellipse(): void {
     this.prototype.default_view = EllipseView
   }
 }
-Ellipse.initClass()

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -352,7 +352,7 @@ export abstract class Glyph extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Glyph(): void {
     this.prototype._coords = []
 
     this.internal({
@@ -374,4 +374,3 @@ export abstract class Glyph extends Model {
     this.define<Glyph.Props>(result)
   }
 }
-Glyph.initClass()

--- a/bokehjs/src/lib/models/glyphs/harea.ts
+++ b/bokehjs/src/lib/models/glyphs/harea.ts
@@ -122,7 +122,7 @@ export class HArea extends Area {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_HArea(): void {
     this.prototype.default_view = HAreaView
 
     this.define<HArea.Props>({
@@ -132,4 +132,3 @@ export class HArea extends Area {
     })
   }
 }
-HArea.initClass()

--- a/bokehjs/src/lib/models/glyphs/hbar.ts
+++ b/bokehjs/src/lib/models/glyphs/hbar.ts
@@ -85,7 +85,7 @@ export class HBar extends Box {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_HBar(): void {
     this.prototype.default_view = HBarView
 
     this.coords([['left', 'y']])
@@ -96,4 +96,3 @@ export class HBar extends Box {
     this.override({ left: 0 })
   }
 }
-HBar.initClass()

--- a/bokehjs/src/lib/models/glyphs/hex_tile.ts
+++ b/bokehjs/src/lib/models/glyphs/hex_tile.ts
@@ -229,7 +229,7 @@ export class HexTile extends Glyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_HexTile(): void {
     this.prototype.default_view = HexTileView
 
     this.coords([['r', 'q']])
@@ -243,4 +243,3 @@ export class HexTile extends Glyph {
     this.override({ line_color: null })
   }
 }
-HexTile.initClass()

--- a/bokehjs/src/lib/models/glyphs/image.ts
+++ b/bokehjs/src/lib/models/glyphs/image.ts
@@ -113,7 +113,7 @@ export class Image extends ImageBase {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Image(): void {
     this.prototype.default_view = ImageView
 
     this.define<Image.Props>({
@@ -121,4 +121,3 @@ export class Image extends ImageBase {
     })
   }
 }
-Image.initClass()

--- a/bokehjs/src/lib/models/glyphs/image_base.ts
+++ b/bokehjs/src/lib/models/glyphs/image_base.ts
@@ -166,7 +166,7 @@ export class ImageBase extends XYGlyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_ImageBase(): void {
     this.prototype.default_view = ImageBaseView
 
     this.define<ImageBase.Props>({
@@ -178,4 +178,3 @@ export class ImageBase extends XYGlyph {
     })
   }
 }
-ImageBase.initClass()

--- a/bokehjs/src/lib/models/glyphs/image_rgba.ts
+++ b/bokehjs/src/lib/models/glyphs/image_rgba.ts
@@ -101,8 +101,7 @@ export class ImageRGBA extends ImageBase {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_ImageRGBA(): void {
     this.prototype.default_view = ImageRGBAView
   }
 }
-ImageRGBA.initClass()

--- a/bokehjs/src/lib/models/glyphs/image_url.ts
+++ b/bokehjs/src/lib/models/glyphs/image_url.ts
@@ -246,7 +246,7 @@ export class ImageURL extends XYGlyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_ImageURL(): void {
     this.prototype.default_view = ImageURLView
 
     this.define<ImageURL.Props>({
@@ -262,4 +262,3 @@ export class ImageURL extends XYGlyph {
     })
   }
 }
-ImageURL.initClass()

--- a/bokehjs/src/lib/models/glyphs/line.ts
+++ b/bokehjs/src/lib/models/glyphs/line.ts
@@ -139,10 +139,9 @@ export class Line extends XYGlyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Line(): void {
     this.prototype.default_view = LineView
 
     this.mixins(['line'])
   }
 }
-Line.initClass()

--- a/bokehjs/src/lib/models/glyphs/multi_line.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_line.ts
@@ -176,11 +176,10 @@ export class MultiLine extends Glyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_MultiLine(): void {
     this.prototype.default_view = MultiLineView
 
     this.coords([['xs', 'ys']])
     this.mixins(['line'])
   }
 }
-MultiLine.initClass()

--- a/bokehjs/src/lib/models/glyphs/multi_polygons.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_polygons.ts
@@ -273,11 +273,10 @@ export class MultiPolygons extends Glyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_MultiPolygons(): void {
     this.prototype.default_view = MultiPolygonsView
 
     this.coords([['xs', 'ys']])
     this.mixins(['line', 'fill', 'hatch'])
   }
 }
-MultiPolygons.initClass()

--- a/bokehjs/src/lib/models/glyphs/oval.ts
+++ b/bokehjs/src/lib/models/glyphs/oval.ts
@@ -49,8 +49,7 @@ export class Oval extends EllipseOval {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Oval(): void {
     this.prototype.default_view = OvalView
   }
 }
-Oval.initClass()

--- a/bokehjs/src/lib/models/glyphs/patch.ts
+++ b/bokehjs/src/lib/models/glyphs/patch.ts
@@ -82,10 +82,9 @@ export class Patch extends XYGlyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Patch(): void {
     this.prototype.default_view = PatchView
 
     this.mixins(['line', 'fill', 'hatch'])
   }
 }
-Patch.initClass()

--- a/bokehjs/src/lib/models/glyphs/patches.ts
+++ b/bokehjs/src/lib/models/glyphs/patches.ts
@@ -233,11 +233,10 @@ export class Patches extends Glyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Patches(): void {
     this.prototype.default_view = PatchesView
 
     this.coords([['xs', 'ys']])
     this.mixins(['line', 'fill', 'hatch'])
   }
 }
-Patches.initClass()

--- a/bokehjs/src/lib/models/glyphs/quad.ts
+++ b/bokehjs/src/lib/models/glyphs/quad.ts
@@ -64,10 +64,9 @@ export class Quad extends Box {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Quad(): void {
     this.prototype.default_view = QuadView
 
     this.coords([['right', 'bottom'], ['left', 'top']])
   }
 }
-Quad.initClass()

--- a/bokehjs/src/lib/models/glyphs/quadratic.ts
+++ b/bokehjs/src/lib/models/glyphs/quadratic.ts
@@ -118,11 +118,10 @@ export class Quadratic extends Glyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Quadratic(): void {
     this.prototype.default_view = QuadraticView
 
     this.coords([['x0', 'y0'], ['x1', 'y1'], ['cx', 'cy']])
     this.mixins(['line'])
   }
 }
-Quadratic.initClass()

--- a/bokehjs/src/lib/models/glyphs/ray.ts
+++ b/bokehjs/src/lib/models/glyphs/ray.ts
@@ -84,7 +84,7 @@ export class Ray extends XYGlyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Ray(): void {
     this.prototype.default_view = RayView
 
     this.mixins(['line'])
@@ -94,4 +94,3 @@ export class Ray extends XYGlyph {
     })
   }
 }
-Ray.initClass()

--- a/bokehjs/src/lib/models/glyphs/rect.ts
+++ b/bokehjs/src/lib/models/glyphs/rect.ts
@@ -251,11 +251,10 @@ export class Rect extends CenterRotatable {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Rect(): void {
     this.prototype.default_view = RectView
     this.define<Rect.Props>({
       dilate: [ p.Boolean, false ],
     })
   }
 }
-Rect.initClass()

--- a/bokehjs/src/lib/models/glyphs/segment.ts
+++ b/bokehjs/src/lib/models/glyphs/segment.ts
@@ -158,11 +158,10 @@ export class Segment extends Glyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Segment(): void {
     this.prototype.default_view = SegmentView
 
     this.coords([['x0', 'y0'], ['x1', 'y1']])
     this.mixins(['line'])
   }
 }
-Segment.initClass()

--- a/bokehjs/src/lib/models/glyphs/step.ts
+++ b/bokehjs/src/lib/models/glyphs/step.ts
@@ -107,7 +107,7 @@ export class Step extends XYGlyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Step(): void {
     this.prototype.default_view = StepView
 
     this.mixins(['line'])
@@ -116,4 +116,3 @@ export class Step extends XYGlyph {
     })
   }
 }
-Step.initClass()

--- a/bokehjs/src/lib/models/glyphs/text.ts
+++ b/bokehjs/src/lib/models/glyphs/text.ts
@@ -168,7 +168,7 @@ export class Text extends XYGlyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Text(): void {
     this.prototype.default_view = TextView
 
     this.mixins(['text'])
@@ -180,4 +180,3 @@ export class Text extends XYGlyph {
     })
   }
 }
-Text.initClass()

--- a/bokehjs/src/lib/models/glyphs/varea.ts
+++ b/bokehjs/src/lib/models/glyphs/varea.ts
@@ -122,7 +122,7 @@ export class VArea extends Area {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_VArea(): void {
     this.prototype.default_view = VAreaView
 
     this.define<VArea.Props>({
@@ -132,4 +132,3 @@ export class VArea extends Area {
     })
   }
 }
-VArea.initClass()

--- a/bokehjs/src/lib/models/glyphs/vbar.ts
+++ b/bokehjs/src/lib/models/glyphs/vbar.ts
@@ -85,7 +85,7 @@ export class VBar extends Box {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_VBar(): void {
     this.prototype.default_view = VBarView
 
     this.coords([['x', 'bottom']])
@@ -98,4 +98,3 @@ export class VBar extends Box {
     })
   }
 }
-VBar.initClass()

--- a/bokehjs/src/lib/models/glyphs/wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/wedge.ts
@@ -149,7 +149,7 @@ export class Wedge extends XYGlyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Wedge(): void {
     this.prototype.default_view = WedgeView
 
     this.mixins(['line', 'fill'])
@@ -161,4 +161,3 @@ export class Wedge extends XYGlyph {
     })
   }
 }
-Wedge.initClass()

--- a/bokehjs/src/lib/models/glyphs/xy_glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/xy_glyph.ts
@@ -63,8 +63,7 @@ export abstract class XYGlyph extends Glyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_XYGlyph(): void {
     this.coords([['x', 'y']])
   }
 }
-XYGlyph.initClass()

--- a/bokehjs/src/lib/models/graphs/static_layout_provider.ts
+++ b/bokehjs/src/lib/models/graphs/static_layout_provider.ts
@@ -19,7 +19,7 @@ export class StaticLayoutProvider extends LayoutProvider {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_StaticLayoutProvider(): void {
     this.define<StaticLayoutProvider.Props>({
       graph_layout: [ p.Any, {} ],
     })
@@ -62,4 +62,3 @@ export class StaticLayoutProvider extends LayoutProvider {
     return [xs, ys]
   }
 }
-StaticLayoutProvider.initClass()

--- a/bokehjs/src/lib/models/grids/grid.ts
+++ b/bokehjs/src/lib/models/grids/grid.ts
@@ -215,7 +215,7 @@ export class Grid extends GuideRenderer {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Grid(): void {
     this.prototype.default_view = GridView
 
     this.mixins(['line:grid_', 'line:minor_grid_', 'fill:band_', 'hatch:band_'])
@@ -237,4 +237,3 @@ export class Grid extends GuideRenderer {
     })
   }
 }
-Grid.initClass()

--- a/bokehjs/src/lib/models/layouts/box.ts
+++ b/bokehjs/src/lib/models/layouts/box.ts
@@ -34,11 +34,10 @@ export abstract class Box extends LayoutDOM {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Box(): void {
     this.define<Box.Props>({
       children: [ p.Array,  [] ],
       spacing:  [ p.Number, 0  ],
     })
   }
 }
-Box.initClass()

--- a/bokehjs/src/lib/models/layouts/column.ts
+++ b/bokehjs/src/lib/models/layouts/column.ts
@@ -31,7 +31,7 @@ export class Column extends Box {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Column(): void {
     this.prototype.default_view = ColumnView
 
     this.define<Column.Props>({
@@ -39,4 +39,3 @@ export class Column extends Box {
     })
   }
 }
-Column.initClass()

--- a/bokehjs/src/lib/models/layouts/grid_box.ts
+++ b/bokehjs/src/lib/models/layouts/grid_box.ts
@@ -50,7 +50,7 @@ export class GridBox extends LayoutDOM {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_GridBox(): void {
     this.prototype.default_view = GridBoxView
 
     this.define<GridBox.Props>({
@@ -61,4 +61,3 @@ export class GridBox extends LayoutDOM {
     })
   }
 }
-GridBox.initClass()

--- a/bokehjs/src/lib/models/layouts/layout_dom.ts
+++ b/bokehjs/src/lib/models/layouts/layout_dom.ts
@@ -399,7 +399,7 @@ export abstract class LayoutDOM extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_LayoutDOM(): void {
     this.define<LayoutDOM.Props>({
       width:         [ p.Number,     null         ],
       height:        [ p.Number,     null         ],
@@ -420,4 +420,3 @@ export abstract class LayoutDOM extends Model {
     })
   }
 }
-LayoutDOM.initClass()

--- a/bokehjs/src/lib/models/layouts/row.ts
+++ b/bokehjs/src/lib/models/layouts/row.ts
@@ -31,7 +31,7 @@ export class Row extends Box {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Row(): void {
     this.prototype.default_view = RowView
 
     this.define<Row.Props>({
@@ -39,4 +39,3 @@ export class Row extends Box {
     })
   }
 }
-Row.initClass()

--- a/bokehjs/src/lib/models/layouts/spacer.ts
+++ b/bokehjs/src/lib/models/layouts/spacer.ts
@@ -30,8 +30,7 @@ export class Spacer extends LayoutDOM {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Spacer(): void {
     this.prototype.default_view = SpacerView
   }
 }
-Spacer.initClass()

--- a/bokehjs/src/lib/models/layouts/tabs.ts
+++ b/bokehjs/src/lib/models/layouts/tabs.ts
@@ -244,7 +244,7 @@ export class Tabs extends LayoutDOM {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Tabs(): void {
     this.prototype.default_view = TabsView
 
     this.define<Tabs.Props>({
@@ -255,7 +255,6 @@ export class Tabs extends LayoutDOM {
     })
   }
 }
-Tabs.initClass()
 
 export namespace Panel {
   export type Attrs = p.AttrsOf<Props>
@@ -276,7 +275,7 @@ export class Panel extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Panel(): void {
     this.define<Panel.Props>({
       title:    [ p.String,  ""    ],
       child:    [ p.Instance       ],
@@ -284,4 +283,3 @@ export class Panel extends Model {
     })
   }
 }
-Panel.initClass()

--- a/bokehjs/src/lib/models/layouts/widget_box.ts
+++ b/bokehjs/src/lib/models/layouts/widget_box.ts
@@ -20,8 +20,7 @@ export class WidgetBox extends Column {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_WidgetBox(): void {
     this.prototype.default_view = WidgetBoxView
   }
 }
-WidgetBox.initClass()

--- a/bokehjs/src/lib/models/mappers/categorical_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/categorical_color_mapper.ts
@@ -20,7 +20,7 @@ export class CategoricalColorMapper extends ColorMapper {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_CategoricalColorMapper(): void {
     this.define<CategoricalColorMapper.Props>({
       factors: [ p.Array     ],
       start:   [ p.Number, 0 ],
@@ -33,4 +33,3 @@ export class CategoricalColorMapper extends ColorMapper {
     cat_v_compute(data, this.factors, palette, values, this.start, this.end, nan_color)
   }
 }
-CategoricalColorMapper.initClass()

--- a/bokehjs/src/lib/models/mappers/categorical_marker_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/categorical_marker_mapper.ts
@@ -24,7 +24,7 @@ export class CategoricalMarkerMapper extends Mapper<string> {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_CategoricalMarkerMapper(): void {
     this.define<CategoricalMarkerMapper.Props>({
       factors:       [ p.Array                ],
       markers:       [ p.Array                ],
@@ -40,4 +40,3 @@ export class CategoricalMarkerMapper extends Mapper<string> {
     return values
   }
 }
-CategoricalMarkerMapper.initClass()

--- a/bokehjs/src/lib/models/mappers/categorical_pattern_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/categorical_pattern_mapper.ts
@@ -24,7 +24,7 @@ export class CategoricalPatternMapper extends Mapper<string> {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_CategoricalPatternMapper(): void {
     this.define<CategoricalPatternMapper.Props>({
       factors:       [ p.Array                 ],
       patterns:      [ p.Array                 ],
@@ -40,4 +40,3 @@ export class CategoricalPatternMapper extends Mapper<string> {
     return values
   }
 }
-CategoricalPatternMapper.initClass()

--- a/bokehjs/src/lib/models/mappers/color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/color_mapper.ts
@@ -56,7 +56,7 @@ export abstract class ColorMapper extends Mapper<Color> {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_ColorMapper(): void {
     this.define<ColorMapper.Props>({
       palette:   [ p.Any           ], // TODO (bev)
       nan_color: [ p.Color, "gray" ],
@@ -89,4 +89,3 @@ export abstract class ColorMapper extends Mapper<Color> {
   protected abstract _v_compute<T>(xs: ArrayableOf<number | Factor>, values: Arrayable<T>,
                                    palette: Arrayable<T>, colors: {nan_color: T}): void
 }
-ColorMapper.initClass()

--- a/bokehjs/src/lib/models/mappers/continuous_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/continuous_color_mapper.ts
@@ -22,7 +22,7 @@ export abstract class ContinuousColorMapper extends ColorMapper {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_ContinuousColorMapper(): void {
     this.define<ContinuousColorMapper.Props>({
       high:       [ p.Number ],
       low:        [ p.Number ],
@@ -42,4 +42,3 @@ export abstract class ContinuousColorMapper extends ColorMapper {
   protected abstract _v_compute<T>(data: Arrayable<number>, values: Arrayable<T>,
     palette: Arrayable<T>, colors: {nan_color: T, low_color?: T, high_color?: T}): void
 }
-ContinuousColorMapper.initClass()

--- a/bokehjs/src/lib/models/markers/marker.ts
+++ b/bokehjs/src/lib/models/markers/marker.ts
@@ -179,7 +179,7 @@ export abstract class Marker extends XYGlyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Marker(): void {
     this.mixins(['line', 'fill'])
     this.define<Marker.Props>({
       size:  [ p.DistanceSpec, { units: "screen", value: 4 } ],
@@ -187,4 +187,3 @@ export abstract class Marker extends XYGlyph {
     })
   }
 }
-Marker.initClass()

--- a/bokehjs/src/lib/models/markers/scatter.ts
+++ b/bokehjs/src/lib/models/markers/scatter.ts
@@ -75,11 +75,10 @@ export class Scatter extends Marker {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Scatter(): void {
     this.prototype.default_view = ScatterView
     this.define<Scatter.Props>({
       marker: [ p.MarkerSpec, {value: "circle"} ],
     })
   }
 }
-Scatter.initClass()

--- a/bokehjs/src/lib/models/plots/gmap_plot.ts
+++ b/bokehjs/src/lib/models/plots/gmap_plot.ts
@@ -27,7 +27,7 @@ export class MapOptions extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_MapOptions(): void {
     this.define<MapOptions.Props>({
       lat:  [ p.Number     ],
       lng:  [ p.Number     ],
@@ -35,7 +35,6 @@ export class MapOptions extends Model {
     })
   }
 }
-MapOptions.initClass()
 
 export namespace GMapOptions {
   export type Attrs = p.AttrsOf<Props>
@@ -57,7 +56,7 @@ export class GMapOptions extends MapOptions {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_GMapOptions(): void {
     this.define<GMapOptions.Props>({
       map_type:      [ p.String,  "roadmap" ],
       scale_control: [ p.Boolean, false     ],
@@ -66,7 +65,6 @@ export class GMapOptions extends MapOptions {
     })
   }
 }
-GMapOptions.initClass()
 
 export namespace GMapPlot {
   export type Attrs = p.AttrsOf<Props>
@@ -89,7 +87,7 @@ export class GMapPlot extends Plot {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_GMapPlot(): void {
     this.prototype.default_view = GMapPlotView
 
     // This seems to be necessary so that everything can initialize.
@@ -113,4 +111,3 @@ export class GMapPlot extends Plot {
       logger.error("api_key is required. See https://developers.google.com/maps/documentation/javascript/get-api-key for more information on how to obtain your own.")
   }
 }
-GMapPlot.initClass()

--- a/bokehjs/src/lib/models/plots/plot.ts
+++ b/bokehjs/src/lib/models/plots/plot.ts
@@ -111,7 +111,7 @@ export class Plot extends LayoutDOM {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Plot(): void {
     this.prototype.default_view = PlotView
 
     this.mixins(["line:outline_", "fill:background_", "fill:border_"])
@@ -252,4 +252,3 @@ export class Plot extends LayoutDOM {
     return concat([above, below, left, right])
   }
 }
-Plot.initClass()

--- a/bokehjs/src/lib/models/ranges/data_range.ts
+++ b/bokehjs/src/lib/models/ranges/data_range.ts
@@ -20,11 +20,10 @@ export abstract class DataRange extends Range {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_DataRange(): void {
     this.define<DataRange.Props>({
       names:     [ p.Array, [] ],
       renderers: [ p.Array, [] ],
     })
   }
 }
-DataRange.initClass()

--- a/bokehjs/src/lib/models/ranges/data_range1d.ts
+++ b/bokehjs/src/lib/models/ranges/data_range1d.ts
@@ -37,7 +37,7 @@ export class DataRange1d extends DataRange {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_DataRange1d(): void {
     this.define<DataRange1d.Props>({
       start:               [ p.Number                  ],
       end:                 [ p.Number                  ],
@@ -298,4 +298,3 @@ export class DataRange1d extends DataRange {
     this.change.emit()
   }
 }
-DataRange1d.initClass()

--- a/bokehjs/src/lib/models/ranges/factor_range.ts
+++ b/bokehjs/src/lib/models/ranges/factor_range.ts
@@ -135,7 +135,7 @@ export class FactorRange extends Range {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_FactorRange(): void {
     this.define<FactorRange.Props>({
       factors:             [ p.Array,        []        ],
       factor_padding:      [ p.Number,       0         ],
@@ -264,4 +264,3 @@ export class FactorRange extends Range {
       this.setv({bounds: [start, end]}, {silent: true})
   }
 }
-FactorRange.initClass()

--- a/bokehjs/src/lib/models/ranges/range.ts
+++ b/bokehjs/src/lib/models/ranges/range.ts
@@ -25,7 +25,7 @@ export abstract class Range extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Range(): void {
     this.define<Range.Props>({
       callback:     [ p.Any ], // TODO: p.Either(p.Instance(Callback), p.Function)
       bounds:       [ p.Any ], // TODO (bev)
@@ -65,4 +65,3 @@ export abstract class Range extends Model {
     return this.start > this.end
   }
 }
-Range.initClass()

--- a/bokehjs/src/lib/models/ranges/range1d.ts
+++ b/bokehjs/src/lib/models/ranges/range1d.ts
@@ -21,7 +21,7 @@ export class Range1d extends Range {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Range1d(): void {
     this.define<Range1d.Props>({
       start:  [ p.Number, 0 ],
       end:    [ p.Number, 1 ],
@@ -65,4 +65,3 @@ export class Range1d extends Range {
       this.change.emit()
   }
 }
-Range1d.initClass()

--- a/bokehjs/src/lib/models/renderers/data_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/data_renderer.ts
@@ -27,7 +27,7 @@ export abstract class DataRenderer extends Renderer {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_DataRenderer(): void {
     this.define<DataRenderer.Props>({
       x_range_name: [ p.String, 'default' ],
       y_range_name: [ p.String, 'default' ],
@@ -40,4 +40,3 @@ export abstract class DataRenderer extends Renderer {
 
   abstract get_selection_manager(): SelectionManager
 }
-DataRenderer.initClass()

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -393,7 +393,7 @@ export class GlyphRenderer extends DataRenderer {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_GlyphRenderer(): void {
     this.prototype.default_view = GlyphRendererView
 
     this.define<GlyphRenderer.Props>({
@@ -434,4 +434,3 @@ export class GlyphRenderer extends DataRenderer {
     return this.data_source.selection_manager
   }
 }
-GlyphRenderer.initClass()

--- a/bokehjs/src/lib/models/renderers/graph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/graph_renderer.ts
@@ -107,7 +107,7 @@ export class GraphRenderer extends DataRenderer {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_GraphRenderer(): void {
     this.prototype.default_view = GraphRendererView
 
     this.define<GraphRenderer.Props>({
@@ -123,4 +123,3 @@ export class GraphRenderer extends DataRenderer {
     return this.node_renderer.data_source.selection_manager
   }
 }
-GraphRenderer.initClass()

--- a/bokehjs/src/lib/models/renderers/guide_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/guide_renderer.ts
@@ -23,10 +23,9 @@ export abstract class GuideRenderer extends Renderer {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_GuideRenderer(): void {
     this.override({
       level: "overlay",
     })
   }
 }
-GuideRenderer.initClass()

--- a/bokehjs/src/lib/models/renderers/renderer.ts
+++ b/bokehjs/src/lib/models/renderers/renderer.ts
@@ -74,11 +74,10 @@ export abstract class Renderer extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Renderer(): void {
     this.define<Renderer.Props>({
       level: [ p.RenderLevel ],
       visible: [ p.Boolean, true ],
     })
   }
 }
-Renderer.initClass()

--- a/bokehjs/src/lib/models/scales/scale.ts
+++ b/bokehjs/src/lib/models/scales/scale.ts
@@ -22,7 +22,7 @@ export abstract class Scale extends Transform {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Scale(): void {
     this.internal({
       source_range: [ p.Any ],
       target_range: [ p.Any ], // p.Instance(Range1d)
@@ -51,4 +51,3 @@ export abstract class Scale extends Transform {
       return [this.invert(sx0), this.invert(sx1)]
   }
 }
-Scale.initClass()

--- a/bokehjs/src/lib/models/selections/selection.ts
+++ b/bokehjs/src/lib/models/selections/selection.ts
@@ -38,7 +38,7 @@ export class Selection extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Selection(): void {
     this.define<Selection.Props>({
       indices:           [ p.Array,   [] ],
       line_indices:      [ p.Array,   [] ],
@@ -134,4 +134,3 @@ export class Selection extends Model {
     this.multiline_indices = merge(other.multiline_indices, this.multiline_indices)
   }
 }
-Selection.initClass()

--- a/bokehjs/src/lib/models/sources/ajax_data_source.ts
+++ b/bokehjs/src/lib/models/sources/ajax_data_source.ts
@@ -23,7 +23,7 @@ export class AjaxDataSource extends RemoteDataSource {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_AjaxDataSource(): void {
     this.define<AjaxDataSource.Props>({
       content_type: [ p.String,     'application/json' ],
       http_headers: [ p.Any,         {}                ],
@@ -88,4 +88,3 @@ export class AjaxDataSource extends RemoteDataSource {
     logger.error(`Failed to fetch JSON from ${this.data_url} with code ${xhr.status}`)
   }
 }
-AjaxDataSource.initClass()

--- a/bokehjs/src/lib/models/sources/cds_view.ts
+++ b/bokehjs/src/lib/models/sources/cds_view.ts
@@ -25,7 +25,7 @@ export class CDSView extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_CDSView(): void {
     this.define<CDSView.Props>({
       filters: [ p.Array, [] ],
       source:  [ p.Instance  ],
@@ -119,4 +119,3 @@ export class CDSView extends Model {
     return indices.map((i) => this.indices[i])
   }
 }
-CDSView.initClass()

--- a/bokehjs/src/lib/models/sources/column_data_source.ts
+++ b/bokehjs/src/lib/models/sources/column_data_source.ts
@@ -156,7 +156,7 @@ export class ColumnDataSource extends ColumnarDataSource {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_ColumnDataSource(): void {
     this.define<ColumnDataSource.Props>({
       data: [ p.Any, {} ],
     })
@@ -218,4 +218,3 @@ export class ColumnDataSource extends ColumnarDataSource {
     }
   }
 }
-ColumnDataSource.initClass()

--- a/bokehjs/src/lib/models/sources/columnar_data_source.ts
+++ b/bokehjs/src/lib/models/sources/columnar_data_source.ts
@@ -54,7 +54,7 @@ export abstract class ColumnarDataSource extends DataSource {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_ColumnarDataSource(): void {
     this.define<ColumnarDataSource.Props>({
       selection_policy: [ p.Instance, () => new UnionRenderers() ],
     })
@@ -121,4 +121,3 @@ export abstract class ColumnarDataSource extends DataSource {
     this.data = empty
   }
 }
-ColumnarDataSource.initClass()

--- a/bokehjs/src/lib/models/sources/data_source.ts
+++ b/bokehjs/src/lib/models/sources/data_source.ts
@@ -21,7 +21,7 @@ export abstract class DataSource extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_DataSource(): void {
     this.define<DataSource.Props>({
       selected: [ p.Instance, () => new Selection() ], // TODO (bev)
       callback: [ p.Any                             ], // TODO: p.Either(p.Instance(Callback), p.Function) ]
@@ -38,4 +38,3 @@ export abstract class DataSource extends Model {
 
   setup?(): void
 }
-DataSource.initClass()

--- a/bokehjs/src/lib/models/sources/geojson_data_source.ts
+++ b/bokehjs/src/lib/models/sources/geojson_data_source.ts
@@ -38,7 +38,7 @@ export class GeoJSONDataSource extends ColumnarDataSource {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_GeoJSONDataSource(): void {
     this.define<GeoJSONDataSource.Props>({
       geojson: [ p.Any ], // TODO (bev)
     })
@@ -225,4 +225,3 @@ export class GeoJSONDataSource extends ColumnarDataSource {
     return data
   }
 }
-GeoJSONDataSource.initClass()

--- a/bokehjs/src/lib/models/sources/remote_data_source.ts
+++ b/bokehjs/src/lib/models/sources/remote_data_source.ts
@@ -32,10 +32,9 @@ export abstract class RemoteDataSource extends WebDataSource {
     this.setup()
   }
 
-  static initClass(): void {
+  static init_RemoteDataSource(): void {
     this.define<RemoteDataSource.Props>({
       polling_interval: [ p.Number ],
     })
   }
 }
-RemoteDataSource.initClass()

--- a/bokehjs/src/lib/models/sources/web_data_source.ts
+++ b/bokehjs/src/lib/models/sources/web_data_source.ts
@@ -65,7 +65,7 @@ export abstract class WebDataSource extends ColumnDataSource {
     }
   }
 
-  static initClass(): void {
+  static init_WebDataSource(): void {
     this.define<WebDataSource.Props>({
       mode:             [ p.UpdateMode, 'replace' ],
       max_size:         [ p.Number                ],
@@ -74,4 +74,3 @@ export abstract class WebDataSource extends ColumnDataSource {
     })
   }
 }
-WebDataSource.initClass()

--- a/bokehjs/src/lib/models/textures/canvas_texture.ts
+++ b/bokehjs/src/lib/models/textures/canvas_texture.ts
@@ -20,7 +20,7 @@ export abstract class CanvasTexture extends Texture {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_CanvasTexture(): void {
     this.define<CanvasTexture.Props>({
       code: [ p.String ],
     })
@@ -43,4 +43,3 @@ export abstract class CanvasTexture extends Texture {
   }
 
 }
-CanvasTexture.initClass()

--- a/bokehjs/src/lib/models/textures/image_url_texture.ts
+++ b/bokehjs/src/lib/models/textures/image_url_texture.ts
@@ -19,7 +19,7 @@ export abstract class ImageURLTexture extends Texture {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_ImageURLTexture(): void {
     this.define<ImageURLTexture.Props>({
       url: [ p.String ],
     })
@@ -53,4 +53,3 @@ export abstract class ImageURLTexture extends Texture {
   private image: HTMLImageElement
 
 }
-ImageURLTexture.initClass()

--- a/bokehjs/src/lib/models/textures/texture.ts
+++ b/bokehjs/src/lib/models/textures/texture.ts
@@ -20,7 +20,7 @@ export abstract class Texture extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Texture(): void {
     this.define<Texture.Props>({
       repetition: [ p.TextureRepetition, "repeat" ],
     })
@@ -33,4 +33,3 @@ export abstract class Texture extends Model {
   }
 
 }
-Texture.initClass()

--- a/bokehjs/src/lib/models/tickers/adaptive_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/adaptive_ticker.ts
@@ -36,7 +36,7 @@ export class AdaptiveTicker extends ContinuousTicker {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_AdaptiveTicker(): void {
     this.define<AdaptiveTicker.Props>({
       base:         [ p.Number, 10.0      ],
       mantissas:    [ p.Array,  [1, 2, 5] ],
@@ -88,4 +88,3 @@ export class AdaptiveTicker extends ContinuousTicker {
     return clamp(interval, this.get_min_interval(), this.get_max_interval())
   }
 }
-AdaptiveTicker.initClass()

--- a/bokehjs/src/lib/models/tickers/composite_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/composite_ticker.ts
@@ -24,7 +24,7 @@ export class CompositeTicker extends ContinuousTicker {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_CompositeTicker(): void {
     this.define<CompositeTicker.Props>({
       tickers: [p.Array, [] ],
     })
@@ -90,4 +90,3 @@ export class CompositeTicker extends ContinuousTicker {
     return best_ticker.get_ticks_no_defaults(data_low, data_high, cross_loc, desired_n_ticks)
   }
 }
-CompositeTicker.initClass()

--- a/bokehjs/src/lib/models/tickers/continuous_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/continuous_ticker.ts
@@ -34,7 +34,7 @@ export abstract class ContinuousTicker extends Ticker<number> {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_ContinuousTicker(): void {
     this.define<ContinuousTicker.Props>({
       num_minor_ticks:   [ p.Number, 5 ],
       desired_num_ticks: [ p.Number, 6 ],
@@ -117,4 +117,3 @@ export abstract class ContinuousTicker extends Ticker<number> {
     return data_range / desired_n_ticks
   }
 }
-ContinuousTicker.initClass()

--- a/bokehjs/src/lib/models/tickers/datetime_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/datetime_ticker.ts
@@ -29,7 +29,7 @@ export class DatetimeTicker extends CompositeTicker {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_DatetimeTicker(): void {
     this.override({
       num_minor_ticks: 0,
       tickers: () => [
@@ -78,4 +78,3 @@ export class DatetimeTicker extends CompositeTicker {
     })
   }
 }
-DatetimeTicker.initClass()

--- a/bokehjs/src/lib/models/tickers/days_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/days_ticker.ts
@@ -49,7 +49,7 @@ export class DaysTicker extends SingleIntervalTicker {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_DaysTicker(): void {
     this.define<DaysTicker.Props>({
       days: [ p.Array, [] ],
     })
@@ -105,4 +105,3 @@ export class DaysTicker extends SingleIntervalTicker {
     }
   }
 }
-DaysTicker.initClass()

--- a/bokehjs/src/lib/models/tickers/fixed_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/fixed_ticker.ts
@@ -20,7 +20,7 @@ export class FixedTicker extends ContinuousTicker {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_FixedTicker(): void {
     this.define<FixedTicker.Props>({
       ticks: [ p.Array, [] ],
       minor_ticks: [ p.Array, [] ],
@@ -43,4 +43,3 @@ export class FixedTicker extends ContinuousTicker {
   max_interval: number = 0
   //
 }
-FixedTicker.initClass()

--- a/bokehjs/src/lib/models/tickers/log_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/log_ticker.ts
@@ -18,7 +18,7 @@ export class LogTicker extends AdaptiveTicker {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_LogTicker(): void {
     this.override({
       mantissas: [1, 5],
     })
@@ -89,4 +89,3 @@ export class LogTicker extends AdaptiveTicker {
     }
   }
 }
-LogTicker.initClass()

--- a/bokehjs/src/lib/models/tickers/mercator_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/mercator_ticker.ts
@@ -21,7 +21,7 @@ export class MercatorTicker extends BasicTicker {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_MercatorTicker(): void {
     this.define<MercatorTicker.Props>({
       dimension: [ p.LatLon ],
     })
@@ -79,4 +79,3 @@ export class MercatorTicker extends BasicTicker {
     return {major, minor}
   }
 }
-MercatorTicker.initClass()

--- a/bokehjs/src/lib/models/tickers/months_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/months_ticker.ts
@@ -46,7 +46,7 @@ export class MonthsTicker extends SingleIntervalTicker {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_MonthsTicker(): void {
     this.define<MonthsTicker.Props>({
       months: [ p.Array, [] ],
     })
@@ -84,4 +84,3 @@ export class MonthsTicker extends SingleIntervalTicker {
     }
   }
 }
-MonthsTicker.initClass()

--- a/bokehjs/src/lib/models/tickers/single_interval_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/single_interval_ticker.ts
@@ -22,7 +22,7 @@ export class SingleIntervalTicker extends ContinuousTicker {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_SingleIntervalTicker(): void {
     this.define<SingleIntervalTicker.Props>({
       interval: [ p.Number ],
     })
@@ -40,4 +40,3 @@ export class SingleIntervalTicker extends ContinuousTicker {
     return this.interval
   }
 }
-SingleIntervalTicker.initClass()

--- a/bokehjs/src/lib/models/tiles/bbox_tile_source.ts
+++ b/bokehjs/src/lib/models/tiles/bbox_tile_source.ts
@@ -18,7 +18,7 @@ export class BBoxTileSource extends MercatorTileSource {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_BBoxTileSource(): void {
     this.define<BBoxTileSource.Props>({
       use_latlon: [ p.Boolean, false ],
     })
@@ -40,4 +40,3 @@ export class BBoxTileSource extends MercatorTileSource {
       .replace("{YMAX}", ymax.toString())
   }
 }
-BBoxTileSource.initClass()

--- a/bokehjs/src/lib/models/tiles/mercator_tile_source.ts
+++ b/bokehjs/src/lib/models/tiles/mercator_tile_source.ts
@@ -21,7 +21,7 @@ export class MercatorTileSource extends TileSource {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_MercatorTileSource(): void {
     this.define<MercatorTileSource.Props>({
       snap_to_zoom: [ p.Boolean, false ],
       wrap_around:  [ p.Boolean, true  ],
@@ -312,4 +312,3 @@ export class MercatorTileSource extends TileSource {
     return Math.floor(x / Math.pow(2, z))
   }
 }
-MercatorTileSource.initClass()

--- a/bokehjs/src/lib/models/tiles/tile_renderer.ts
+++ b/bokehjs/src/lib/models/tiles/tile_renderer.ts
@@ -406,7 +406,7 @@ export class TileRenderer extends DataRenderer {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_TileRenderer(): void {
     this.prototype.default_view = TileRendererView
 
     this.define<TileRenderer.Props>({
@@ -426,4 +426,3 @@ export class TileRenderer extends DataRenderer {
     return this._selection_manager
   }
 }
-TileRenderer.initClass()

--- a/bokehjs/src/lib/models/tiles/tile_source.ts
+++ b/bokehjs/src/lib/models/tiles/tile_source.ts
@@ -32,7 +32,7 @@ export abstract class TileSource extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_TileSource(): void {
     this.define<TileSource.Props>({
       url:                [ p.String, ''  ],
       tile_size:          [ p.Number, 256 ],
@@ -135,4 +135,3 @@ export abstract class TileSource extends Model {
 
   abstract normalize_xyz(x: number, y: number, z: number): [number, number, number]
 }
-TileSource.initClass()

--- a/bokehjs/src/lib/models/tools/actions/custom_action.ts
+++ b/bokehjs/src/lib/models/tools/actions/custom_action.ts
@@ -39,7 +39,7 @@ export class CustomAction extends ActionTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_CustomAction(): void {
     this.prototype.default_view = CustomActionView
 
     this.define<CustomAction.Props>({
@@ -57,4 +57,3 @@ export class CustomAction extends ActionTool {
     return this.action_tooltip
   }
 }
-CustomAction.initClass()

--- a/bokehjs/src/lib/models/tools/actions/help_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/help_tool.ts
@@ -28,7 +28,7 @@ export class HelpTool extends ActionTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_HelpTool(): void {
     this.prototype.default_view = HelpToolView
 
     this.define<HelpTool.Props>({
@@ -44,4 +44,3 @@ export class HelpTool extends ActionTool {
     return this.help_tooltip
   }
 }
-HelpTool.initClass()

--- a/bokehjs/src/lib/models/tools/actions/redo_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/redo_tool.ts
@@ -30,7 +30,7 @@ export class RedoTool extends ActionTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_RedoTool(): void {
     this.prototype.default_view = RedoToolView
 
     this.override({
@@ -41,4 +41,3 @@ export class RedoTool extends ActionTool {
   tool_name = "Redo"
   icon = bk_tool_icon_redo
 }
-RedoTool.initClass()

--- a/bokehjs/src/lib/models/tools/actions/reset_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/reset_tool.ts
@@ -25,11 +25,10 @@ export class ResetTool extends ActionTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_ResetTool(): void {
     this.prototype.default_view = ResetToolView
   }
 
   tool_name = "Reset"
   icon = bk_tool_icon_reset
 }
-ResetTool.initClass()

--- a/bokehjs/src/lib/models/tools/actions/save_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/save_tool.ts
@@ -25,11 +25,10 @@ export class SaveTool extends ActionTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_SaveTool(): void {
     this.prototype.default_view = SaveToolView
   }
 
   tool_name = "Save"
   icon = bk_tool_icon_save
 }
-SaveTool.initClass()

--- a/bokehjs/src/lib/models/tools/actions/undo_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/undo_tool.ts
@@ -30,7 +30,7 @@ export class UndoTool extends ActionTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_UndoTool(): void {
     this.prototype.default_view = UndoToolView
 
     this.override({
@@ -41,4 +41,3 @@ export class UndoTool extends ActionTool {
   tool_name = "Undo"
   icon = bk_tool_icon_undo
 }
-UndoTool.initClass()

--- a/bokehjs/src/lib/models/tools/actions/zoom_in_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_in_tool.ts
@@ -43,7 +43,7 @@ export class ZoomInTool extends ActionTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_ZoomInTool(): void {
     this.prototype.default_view = ZoomInToolView
 
     this.define<ZoomInTool.Props>({
@@ -59,4 +59,3 @@ export class ZoomInTool extends ActionTool {
     return this._get_dim_tooltip(this.tool_name, this.dimensions)
   }
 }
-ZoomInTool.initClass()

--- a/bokehjs/src/lib/models/tools/actions/zoom_out_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_out_tool.ts
@@ -44,7 +44,7 @@ export class ZoomOutTool extends ActionTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_ZoomOutTool(): void {
     this.prototype.default_view = ZoomOutToolView
 
     this.define<ZoomOutTool.Props>({
@@ -60,4 +60,3 @@ export class ZoomOutTool extends ActionTool {
     return this._get_dim_tooltip(this.tool_name, this.dimensions)
   }
 }
-ZoomOutTool.initClass()

--- a/bokehjs/src/lib/models/tools/button_tool.ts
+++ b/bokehjs/src/lib/models/tools/button_tool.ts
@@ -57,7 +57,7 @@ export abstract class ButtonTool extends Tool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_ButtonTool(): void {
     this.internal({
       disabled:    [ p.Boolean,    false ],
     })
@@ -77,4 +77,3 @@ export abstract class ButtonTool extends Tool {
     return this.icon
   }
 }
-ButtonTool.initClass()

--- a/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
@@ -159,7 +159,7 @@ export class BoxEditTool extends EditTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_BoxEditTool(): void {
     this.prototype.default_view = BoxEditToolView
 
     this.define<BoxEditTool.Props>({
@@ -173,4 +173,3 @@ export class BoxEditTool extends EditTool {
   event_type = ["tap" as "tap", "pan" as "pan", "move" as "move"]
   default_order = 1
 }
-BoxEditTool.initClass()

--- a/bokehjs/src/lib/models/tools/edit/edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/edit_tool.ts
@@ -158,7 +158,7 @@ export abstract class EditTool extends GestureTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_EditTool(): void {
     this.define<EditTool.Props>({
       custom_icon:    [ p.String    ],
       custom_tooltip: [ p.String    ],
@@ -175,4 +175,3 @@ export abstract class EditTool extends GestureTool {
     return this.custom_icon || this.icon
   }
 }
-EditTool.initClass()

--- a/bokehjs/src/lib/models/tools/edit/freehand_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/freehand_draw_tool.ts
@@ -95,7 +95,7 @@ export class FreehandDrawTool extends EditTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_FreehandDrawTool(): void {
     this.prototype.default_view = FreehandDrawToolView
 
     this.define<FreehandDrawTool.Props>({
@@ -107,4 +107,3 @@ export class FreehandDrawTool extends EditTool {
   event_type = ["pan" as "pan", "tap" as "tap"]
   default_order = 3
 }
-FreehandDrawTool.initClass()

--- a/bokehjs/src/lib/models/tools/edit/point_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/point_draw_tool.ts
@@ -93,7 +93,7 @@ export class PointDrawTool extends EditTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_PointDrawTool(): void {
     this.prototype.default_view = PointDrawToolView
 
     this.define<PointDrawTool.Props>({
@@ -108,4 +108,3 @@ export class PointDrawTool extends EditTool {
   event_type = ["tap" as "tap", "pan" as "pan", "move" as "move"]
   default_order = 2
 }
-PointDrawTool.initClass()

--- a/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
@@ -253,7 +253,7 @@ export class PolyDrawTool extends PolyTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_PolyDrawTool(): void {
     this.prototype.default_view = PolyDrawToolView
 
     this.define<PolyDrawTool.Props>({
@@ -267,4 +267,3 @@ export class PolyDrawTool extends PolyTool {
   event_type = ["pan" as "pan", "tap" as "tap", "move" as "move"]
   default_order = 3
 }
-PolyDrawTool.initClass()

--- a/bokehjs/src/lib/models/tools/edit/poly_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_edit_tool.ts
@@ -239,7 +239,7 @@ export class PolyEditTool extends PolyTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_PolyEditTool(): void {
     this.prototype.default_view = PolyEditToolView
   }
 
@@ -248,4 +248,3 @@ export class PolyEditTool extends PolyTool {
   event_type = ["tap" as "tap", "pan" as "pan", "move" as "move"]
   default_order = 4
 }
-PolyEditTool.initClass()

--- a/bokehjs/src/lib/models/tools/edit/poly_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_tool.ts
@@ -79,7 +79,7 @@ export class PolyTool extends EditTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_PolyTool(): void {
     this.prototype.default_view = PolyToolView
 
     this.define<PolyTool.Props>({
@@ -87,4 +87,3 @@ export class PolyTool extends EditTool {
     })
   }
 }
-PolyTool.initClass()

--- a/bokehjs/src/lib/models/tools/gestures/box_select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/box_select_tool.ts
@@ -124,7 +124,7 @@ export class BoxSelectTool extends SelectTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_BoxSelectTool(): void {
     this.prototype.default_view = BoxSelectToolView
 
     this.define<BoxSelectTool.Props>({
@@ -145,4 +145,3 @@ export class BoxSelectTool extends SelectTool {
     return this._get_dim_tooltip(this.tool_name, this.dimensions)
   }
 }
-BoxSelectTool.initClass()

--- a/bokehjs/src/lib/models/tools/gestures/box_zoom_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/box_zoom_tool.ts
@@ -188,7 +188,7 @@ export class BoxZoomTool extends GestureTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_BoxZoomTool(): void {
     this.prototype.default_view = BoxZoomToolView
 
     this.define<BoxZoomTool.Props>({
@@ -208,4 +208,3 @@ export class BoxZoomTool extends GestureTool {
     return this._get_dim_tooltip(this.tool_name, this.dimensions)
   }
 }
-BoxZoomTool.initClass()

--- a/bokehjs/src/lib/models/tools/gestures/lasso_select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/lasso_select_tool.ts
@@ -123,7 +123,7 @@ export class LassoSelectTool extends SelectTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_LassoSelectTool(): void {
     this.prototype.default_view = LassoSelectToolView
 
     this.define<LassoSelectTool.Props>({
@@ -138,4 +138,3 @@ export class LassoSelectTool extends SelectTool {
   event_type = "pan" as "pan"
   default_order = 12
 }
-LassoSelectTool.initClass()

--- a/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
@@ -136,7 +136,7 @@ export class PanTool extends GestureTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_PanTool(): void {
     this.prototype.default_view = PanToolView
 
     this.define<PanTool.Props>({
@@ -160,4 +160,3 @@ export class PanTool extends GestureTool {
     }
   }
 }
-PanTool.initClass()

--- a/bokehjs/src/lib/models/tools/gestures/poly_select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/poly_select_tool.ts
@@ -118,7 +118,7 @@ export class PolySelectTool extends SelectTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_PolySelectTool(): void {
     this.prototype.default_view = PolySelectToolView
 
     this.define<PolySelectTool.Props>({
@@ -132,4 +132,3 @@ export class PolySelectTool extends SelectTool {
   event_type = "tap" as "tap"
   default_order = 11
 }
-PolySelectTool.initClass()

--- a/bokehjs/src/lib/models/tools/gestures/range_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/range_tool.ts
@@ -246,7 +246,7 @@ export class RangeTool extends GestureTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_RangeTool(): void {
     this.prototype.default_view = RangeToolView
 
     this.define<RangeTool.Props>({
@@ -297,4 +297,3 @@ export class RangeTool extends GestureTool {
   event_type = "pan" as "pan"
   default_order = 1
 }
-RangeTool.initClass()

--- a/bokehjs/src/lib/models/tools/gestures/select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/select_tool.ts
@@ -124,11 +124,10 @@ export abstract class SelectTool extends GestureTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_SelectTool(): void {
     this.define<SelectTool.Props>({
       renderers: [ p.Any,   'auto' ],
       names:     [ p.Array, []     ],
     })
   }
 }
-SelectTool.initClass()

--- a/bokehjs/src/lib/models/tools/gestures/tap_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/tap_tool.ts
@@ -82,7 +82,7 @@ export class TapTool extends SelectTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_TapTool(): void {
     this.prototype.default_view = TapToolView
 
     this.define<TapTool.Props>({
@@ -96,4 +96,3 @@ export class TapTool extends SelectTool {
   event_type = "tap" as "tap"
   default_order = 10
 }
-TapTool.initClass()

--- a/bokehjs/src/lib/models/tools/gestures/wheel_pan_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/wheel_pan_tool.ts
@@ -100,7 +100,7 @@ export class WheelPanTool extends GestureTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_WheelPanTool(): void {
     this.prototype.default_view = WheelPanToolView
 
     this.define<WheelPanTool.Props>({
@@ -121,4 +121,3 @@ export class WheelPanTool extends GestureTool {
     return this._get_dim_tooltip(this.tool_name, this.dimension)
   }
 }
-WheelPanTool.initClass()

--- a/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
@@ -72,7 +72,7 @@ export class WheelZoomTool extends GestureTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_WheelZoomTool(): void {
     this.prototype.default_view = WheelZoomToolView
 
     this.define<WheelZoomTool.Props>({
@@ -93,4 +93,3 @@ export class WheelZoomTool extends GestureTool {
     return this._get_dim_tooltip(this.tool_name, this.dimensions)
   }
 }
-WheelZoomTool.initClass()

--- a/bokehjs/src/lib/models/tools/inspectors/crosshair_tool.ts
+++ b/bokehjs/src/lib/models/tools/inspectors/crosshair_tool.ts
@@ -60,7 +60,7 @@ export class CrosshairTool extends InspectTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_CrosshairTool(): void {
     this.prototype.default_view = CrosshairToolView
 
     this.define<CrosshairTool.Props>({
@@ -113,4 +113,3 @@ export class CrosshairTool extends InspectTool {
     }
   }
 }
-CrosshairTool.initClass()

--- a/bokehjs/src/lib/models/tools/inspectors/customjs_hover.ts
+++ b/bokehjs/src/lib/models/tools/inspectors/customjs_hover.ts
@@ -23,7 +23,7 @@ export class CustomJSHover extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_CustomJSHover(): void {
     this.define<CustomJSHover.Props>({
       args: [ p.Any,    {} ], // TODO (bev) better type
       code: [ p.String, "" ],
@@ -46,4 +46,3 @@ export class CustomJSHover extends Model {
   }
 
 }
-CustomJSHover.initClass()

--- a/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
+++ b/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
@@ -447,7 +447,7 @@ export class HoverTool extends InspectTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_HoverTool(): void {
     this.prototype.default_view = HoverToolView
 
     this.define<HoverTool.Props>({
@@ -472,4 +472,3 @@ export class HoverTool extends InspectTool {
   tool_name = "Hover"
   icon = bk_tool_icon_hover
 }
-HoverTool.initClass()

--- a/bokehjs/src/lib/models/tools/inspectors/inspect_tool.ts
+++ b/bokehjs/src/lib/models/tools/inspectors/inspect_tool.ts
@@ -24,7 +24,7 @@ export abstract class InspectTool extends ButtonTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_InspectTool(): void {
     this.prototype.button_view = OnOffButtonView
 
     this.define<InspectTool.Props>({
@@ -38,4 +38,3 @@ export abstract class InspectTool extends ButtonTool {
 
   event_type = "move" as "move"
 }
-InspectTool.initClass()

--- a/bokehjs/src/lib/models/tools/tool.ts
+++ b/bokehjs/src/lib/models/tools/tool.ts
@@ -81,7 +81,7 @@ export abstract class Tool extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Tool(): void {
     this.internal({
       active: [ p.Boolean, false ],
     })
@@ -127,4 +127,3 @@ export abstract class Tool extends Model {
     return [sxlim, sylim]
   }
 }
-Tool.initClass()

--- a/bokehjs/src/lib/models/tools/tool_proxy.ts
+++ b/bokehjs/src/lib/models/tools/tool_proxy.ts
@@ -25,7 +25,7 @@ export class ToolProxy extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_ToolProxy(): void {
     this.define<ToolProxy.Props>({
       tools:    [ p.Array,   []    ],
       active:   [ p.Boolean, false ],
@@ -96,4 +96,3 @@ export class ToolProxy extends Model {
   }
   */
 }
-ToolProxy.initClass()

--- a/bokehjs/src/lib/models/tools/toolbar.ts
+++ b/bokehjs/src/lib/models/tools/toolbar.ts
@@ -55,7 +55,7 @@ export class Toolbar extends ToolbarBase {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Toolbar(): void {
     this.prototype.default_view = ToolbarBaseView
 
     this.define<Toolbar.Props>({
@@ -140,4 +140,3 @@ export class Toolbar extends ToolbarBase {
     }
   }
 }
-Toolbar.initClass()

--- a/bokehjs/src/lib/models/tools/toolbar_base.ts
+++ b/bokehjs/src/lib/models/tools/toolbar_base.ts
@@ -38,7 +38,7 @@ export class ToolbarViewModel extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_ToolbarViewModel(): void {
     this.define<ToolbarViewModel.Props>({
       _visible: [ p.Any,     null  ],
       autohide: [ p.Boolean, false ],
@@ -49,7 +49,6 @@ export class ToolbarViewModel extends Model {
     return (!this.autohide) ? true : (this._visible == null) ? false : this._visible
   }
 }
-ToolbarViewModel.initClass()
 
 export class ToolbarBaseView extends DOMView {
   model: ToolbarBase
@@ -200,7 +199,7 @@ export class ToolbarBase extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_ToolbarBase(): void {
     this.prototype.default_view = ToolbarBaseView
 
     this.define<ToolbarBase.Props>({
@@ -306,4 +305,3 @@ export class ToolbarBase extends Model {
     }
   }
 }
-ToolbarBase.initClass()

--- a/bokehjs/src/lib/models/tools/toolbar_box.ts
+++ b/bokehjs/src/lib/models/tools/toolbar_box.ts
@@ -192,7 +192,7 @@ export class ToolbarBox extends LayoutDOM {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_ToolbarBox(): void {
     this.prototype.default_view = ToolbarBoxView
 
     this.define<ToolbarBox.Props>({
@@ -201,4 +201,3 @@ export class ToolbarBox extends LayoutDOM {
     })
   }
 }
-ToolbarBox.initClass()

--- a/bokehjs/src/lib/models/transforms/customjs_transform.ts
+++ b/bokehjs/src/lib/models/transforms/customjs_transform.ts
@@ -24,7 +24,7 @@ export class CustomJSTransform extends Transform {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_CustomJSTransform(): void {
     this.define<CustomJSTransform.Props>({
       args:       [ p.Any,    {}     ], // TODO (bev) better type
       func:       [ p.String, ""     ],
@@ -62,4 +62,3 @@ export class CustomJSTransform extends Transform {
     return this.vector_transform(...this.values, xs, require, {})
   }
 }
-CustomJSTransform.initClass()

--- a/bokehjs/src/lib/models/transforms/dodge.ts
+++ b/bokehjs/src/lib/models/transforms/dodge.ts
@@ -23,7 +23,7 @@ export class Dodge extends Transform {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Dodge(): void {
     this.define<Dodge.Props>({
       value: [ p.Number,  0 ],
       range: [ p.Instance   ],
@@ -61,4 +61,3 @@ export class Dodge extends Transform {
     return x + this.value
   }
 }
-Dodge.initClass()

--- a/bokehjs/src/lib/models/transforms/interpolator.ts
+++ b/bokehjs/src/lib/models/transforms/interpolator.ts
@@ -25,7 +25,7 @@ export abstract class Interpolator extends Transform {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Interpolator(): void {
     this.define<Interpolator.Props>({
       x:    [ p.Any           ],
       y:    [ p.Any           ],
@@ -102,4 +102,3 @@ export abstract class Interpolator extends Transform {
     this._sorted_dirty = false
   }
 }
-Interpolator.initClass()

--- a/bokehjs/src/lib/models/transforms/jitter.ts
+++ b/bokehjs/src/lib/models/transforms/jitter.ts
@@ -28,7 +28,7 @@ export class Jitter extends Transform {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Jitter(): void {
     this.define<Jitter.Props>({
       mean:         [ p.Number, 0        ],
       width:        [ p.Number, 1        ],
@@ -80,4 +80,3 @@ export class Jitter extends Transform {
     }
   }
 }
-Jitter.initClass()

--- a/bokehjs/src/lib/models/transforms/step_interpolator.ts
+++ b/bokehjs/src/lib/models/transforms/step_interpolator.ts
@@ -20,7 +20,7 @@ export class StepInterpolator extends Interpolator {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_StepInterpolator(): void {
     this.define<StepInterpolator.Props>({
       mode: [ p.StepMode, "after"],
     })
@@ -62,4 +62,3 @@ export class StepInterpolator extends Interpolator {
     return ind != -1 ? this._y_sorted[ind] : NaN
   }
 }
-StepInterpolator.initClass()

--- a/bokehjs/src/lib/models/widgets/abstract_button.ts
+++ b/bokehjs/src/lib/models/widgets/abstract_button.ts
@@ -84,7 +84,7 @@ export abstract class AbstractButton extends Control {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_AbstractButton(): void {
     this.define<AbstractButton.Props>({
       label:       [ p.String,     "Button"  ],
       icon:        [ p.Instance              ],
@@ -93,4 +93,3 @@ export abstract class AbstractButton extends Control {
     })
   }
 }
-AbstractButton.initClass()

--- a/bokehjs/src/lib/models/widgets/abstract_slider.ts
+++ b/bokehjs/src/lib/models/widgets/abstract_slider.ts
@@ -316,7 +316,7 @@ export abstract class AbstractSlider extends Control {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_AbstractSlider(): void {
     this.define<AbstractSlider.Props>({
       title:             [ p.String,               ""           ],
       show_value:        [ p.Boolean,              true         ],
@@ -346,4 +346,3 @@ export abstract class AbstractSlider extends Control {
     return this._formatter(value, this.format)
   }
 }
-AbstractSlider.initClass()

--- a/bokehjs/src/lib/models/widgets/autocomplete_input.ts
+++ b/bokehjs/src/lib/models/widgets/autocomplete_input.ts
@@ -167,7 +167,7 @@ export class AutocompleteInput extends TextInput {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_AutocompleteInput(): void {
     this.prototype.default_view = AutocompleteInputView
 
     this.define<AutocompleteInput.Props>({
@@ -176,4 +176,3 @@ export class AutocompleteInput extends TextInput {
     })
   }
 }
-AutocompleteInput.initClass()

--- a/bokehjs/src/lib/models/widgets/button.ts
+++ b/bokehjs/src/lib/models/widgets/button.ts
@@ -30,7 +30,7 @@ export class Button extends AbstractButton {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Button(): void {
     this.prototype.default_view = ButtonView
 
     this.define<Button.Props>({
@@ -42,4 +42,3 @@ export class Button extends AbstractButton {
     })
   }
 }
-Button.initClass()

--- a/bokehjs/src/lib/models/widgets/button_group.ts
+++ b/bokehjs/src/lib/models/widgets/button_group.ts
@@ -65,7 +65,7 @@ export abstract class ButtonGroup extends Control {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_ButtonGroup(): void {
     this.define<ButtonGroup.Props>({
       labels:      [ p.Array,      []        ],
       button_type: [ p.ButtonType, "default" ],
@@ -73,4 +73,3 @@ export abstract class ButtonGroup extends Control {
     })
   }
 }
-ButtonGroup.initClass()

--- a/bokehjs/src/lib/models/widgets/checkbox_button_group.ts
+++ b/bokehjs/src/lib/models/widgets/checkbox_button_group.ts
@@ -50,7 +50,7 @@ export class CheckboxButtonGroup extends ButtonGroup {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_CheckboxButtonGroup(): void {
     this.prototype.default_view = CheckboxButtonGroupView
 
     this.define<CheckboxButtonGroup.Props>({
@@ -58,4 +58,3 @@ export class CheckboxButtonGroup extends ButtonGroup {
     })
   }
 }
-CheckboxButtonGroup.initClass()

--- a/bokehjs/src/lib/models/widgets/checkbox_group.ts
+++ b/bokehjs/src/lib/models/widgets/checkbox_group.ts
@@ -65,7 +65,7 @@ export class CheckboxGroup extends InputGroup {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_CheckboxGroup(): void {
     this.prototype.default_view = CheckboxGroupView
 
     this.define<CheckboxGroup.Props>({
@@ -76,4 +76,3 @@ export class CheckboxGroup extends InputGroup {
     })
   }
 }
-CheckboxGroup.initClass()

--- a/bokehjs/src/lib/models/widgets/color_picker.ts
+++ b/bokehjs/src/lib/models/widgets/color_picker.ts
@@ -54,7 +54,7 @@ export class ColorPicker extends InputWidget {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_ColorPicker(): void {
     this.prototype.default_view = ColorPickerView
 
     this.define<ColorPicker.Props>({
@@ -62,4 +62,3 @@ export class ColorPicker extends InputWidget {
     })
   }
 }
-ColorPicker.initClass()

--- a/bokehjs/src/lib/models/widgets/date_picker.ts
+++ b/bokehjs/src/lib/models/widgets/date_picker.ts
@@ -112,7 +112,7 @@ export class DatePicker extends InputWidget {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_DatePicker(): void {
     this.prototype.default_view = DatePickerView
 
     this.define<DatePicker.Props>({
@@ -123,4 +123,3 @@ export class DatePicker extends InputWidget {
     })
   }
 }
-DatePicker.initClass()

--- a/bokehjs/src/lib/models/widgets/date_range_slider.ts
+++ b/bokehjs/src/lib/models/widgets/date_range_slider.ts
@@ -22,7 +22,7 @@ export class DateRangeSlider extends AbstractSlider {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_DateRangeSlider(): void {
     this.prototype.default_view = DateRangeSliderView
 
     this.override({
@@ -37,4 +37,3 @@ export class DateRangeSlider extends AbstractSlider {
     return tz(value, format)
   }
 }
-DateRangeSlider.initClass()

--- a/bokehjs/src/lib/models/widgets/date_slider.ts
+++ b/bokehjs/src/lib/models/widgets/date_slider.ts
@@ -22,7 +22,7 @@ export class DateSlider extends AbstractSlider {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_DateSlider(): void {
     this.prototype.default_view = DateSliderView
 
     this.override({
@@ -37,4 +37,3 @@ export class DateSlider extends AbstractSlider {
     return tz(value, format)
   }
 }
-DateSlider.initClass()

--- a/bokehjs/src/lib/models/widgets/div.ts
+++ b/bokehjs/src/lib/models/widgets/div.ts
@@ -30,7 +30,7 @@ export class Div extends Markup {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Div(): void {
     this.prototype.default_view = DivView
 
     this.define<Div.Props>({
@@ -38,4 +38,3 @@ export class Div extends Markup {
     })
   }
 }
-Div.initClass()

--- a/bokehjs/src/lib/models/widgets/dropdown.ts
+++ b/bokehjs/src/lib/models/widgets/dropdown.ts
@@ -132,7 +132,7 @@ export class Dropdown extends AbstractButton {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Dropdown(): void {
     this.prototype.default_view = DropdownView
 
     this.define<Dropdown.Props>({
@@ -151,4 +151,3 @@ export class Dropdown extends AbstractButton {
     return this.split || this.default_value != null
   }
 }
-Dropdown.initClass()

--- a/bokehjs/src/lib/models/widgets/file_input.ts
+++ b/bokehjs/src/lib/models/widgets/file_input.ts
@@ -66,7 +66,7 @@ export abstract class FileInput extends Widget {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_FileInput(): void {
     this.prototype.type = "FileInput"
     this.prototype.default_view = FileInputView
 
@@ -78,5 +78,3 @@ export abstract class FileInput extends Widget {
     })
   }
 }
-
-FileInput.initClass()

--- a/bokehjs/src/lib/models/widgets/input_widget.ts
+++ b/bokehjs/src/lib/models/widgets/input_widget.ts
@@ -53,11 +53,10 @@ export abstract class InputWidget extends Control {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_InputWidget(): void {
     this.define<InputWidget.Props>({
       title:    [ p.String, "" ],
       callback: [ p.Any        ],
     })
   }
 }
-InputWidget.initClass()

--- a/bokehjs/src/lib/models/widgets/markup.ts
+++ b/bokehjs/src/lib/models/widgets/markup.ts
@@ -49,11 +49,10 @@ export abstract class Markup extends Widget {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Markup(): void {
     this.define<Markup.Props>({
       text:  [ p.String, '' ],
       style: [ p.Any,    {} ],
     })
   }
 }
-Markup.initClass()

--- a/bokehjs/src/lib/models/widgets/multiselect.ts
+++ b/bokehjs/src/lib/models/widgets/multiselect.ts
@@ -97,7 +97,7 @@ export class MultiSelect extends InputWidget {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_MultiSelect(): void {
     this.prototype.default_view = MultiSelectView
 
     this.define<MultiSelect.Props>({
@@ -107,4 +107,3 @@ export class MultiSelect extends InputWidget {
     })
   }
 }
-MultiSelect.initClass()

--- a/bokehjs/src/lib/models/widgets/paragraph.ts
+++ b/bokehjs/src/lib/models/widgets/paragraph.ts
@@ -28,8 +28,7 @@ export class Paragraph extends Markup {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Paragraph(): void {
     this.prototype.default_view = ParagraphView
   }
 }
-Paragraph.initClass()

--- a/bokehjs/src/lib/models/widgets/password_input.ts
+++ b/bokehjs/src/lib/models/widgets/password_input.ts
@@ -25,8 +25,7 @@ export class PasswordInput extends TextInput {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_PasswordInput(): void {
     this.prototype.default_view = PasswordInputView
   }
 }
-PasswordInput.initClass()

--- a/bokehjs/src/lib/models/widgets/pretext.ts
+++ b/bokehjs/src/lib/models/widgets/pretext.ts
@@ -27,8 +27,7 @@ export class PreText extends Markup {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_PreText(): void {
     this.prototype.default_view = PreTextView
   }
 }
-PreText.initClass()

--- a/bokehjs/src/lib/models/widgets/radio_button_group.ts
+++ b/bokehjs/src/lib/models/widgets/radio_button_group.ts
@@ -45,7 +45,7 @@ export class RadioButtonGroup extends ButtonGroup {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_RadioButtonGroup(): void {
     this.prototype.default_view = RadioButtonGroupView
 
     this.define<RadioButtonGroup.Props>({
@@ -53,4 +53,3 @@ export class RadioButtonGroup extends ButtonGroup {
     })
   }
 }
-RadioButtonGroup.initClass()

--- a/bokehjs/src/lib/models/widgets/radio_group.ts
+++ b/bokehjs/src/lib/models/widgets/radio_group.ts
@@ -61,7 +61,7 @@ export class RadioGroup extends InputGroup {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_RadioGroup(): void {
     this.prototype.default_view = RadioGroupView
 
     this.define<RadioGroup.Props>({
@@ -72,4 +72,3 @@ export class RadioGroup extends InputGroup {
     })
   }
 }
-RadioGroup.initClass()

--- a/bokehjs/src/lib/models/widgets/range_slider.ts
+++ b/bokehjs/src/lib/models/widgets/range_slider.ts
@@ -22,7 +22,7 @@ export class RangeSlider extends AbstractSlider {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_RangeSlider(): void {
     this.prototype.default_view = RangeSliderView
 
     this.override({
@@ -37,4 +37,3 @@ export class RangeSlider extends AbstractSlider {
     return numbro.format(value, format)
   }
 }
-RangeSlider.initClass()

--- a/bokehjs/src/lib/models/widgets/selectbox.ts
+++ b/bokehjs/src/lib/models/widgets/selectbox.ts
@@ -80,7 +80,7 @@ export class Select extends InputWidget {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Select(): void {
     this.prototype.default_view = SelectView
 
     this.define<Select.Props>({
@@ -89,4 +89,3 @@ export class Select extends InputWidget {
     })
   }
 }
-Select.initClass()

--- a/bokehjs/src/lib/models/widgets/slider.ts
+++ b/bokehjs/src/lib/models/widgets/slider.ts
@@ -22,7 +22,7 @@ export class Slider extends AbstractSlider {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Slider(): void {
     this.prototype.default_view = SliderView
 
     this.override({
@@ -37,4 +37,3 @@ export class Slider extends AbstractSlider {
     return numbro.format(value, format)
   }
 }
-Slider.initClass()

--- a/bokehjs/src/lib/models/widgets/spinner.ts
+++ b/bokehjs/src/lib/models/widgets/spinner.ts
@@ -97,7 +97,7 @@ export class Spinner extends InputWidget {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Spinner(): void {
     this.prototype.default_view = SpinnerView
 
     this.define<Spinner.Props>({
@@ -108,4 +108,3 @@ export class Spinner extends InputWidget {
     })
   }
 }
-Spinner.initClass()

--- a/bokehjs/src/lib/models/widgets/tables/cell_editors.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_editors.ts
@@ -176,14 +176,13 @@ export interface StringEditor extends StringEditor.Attrs {}
 export class StringEditor extends CellEditor {
   properties: StringEditor.Props
 
-  static initClass(): void {
+  static init_StringEditor(): void {
     this.prototype.default_view = StringEditorView
     this.define<StringEditor.Props>({
       completions: [ p.Array, [] ],
     })
   }
 }
-StringEditor.initClass()
 
 export class TextEditorView extends CellEditorView {
   model: TextEditor
@@ -206,11 +205,10 @@ export interface TextEditor extends TextEditor.Attrs {}
 export class TextEditor extends CellEditor {
   properties: TextEditor.Props
 
-  static initClass(): void {
+  static init_TextEditor(): void {
     this.prototype.default_view = TextEditorView
   }
 }
-TextEditor.initClass()
 
 export class SelectEditorView extends CellEditorView {
   model: SelectEditor
@@ -242,14 +240,13 @@ export interface SelectEditor extends SelectEditor.Attrs {}
 export class SelectEditor extends CellEditor {
   properties: SelectEditor.Props
 
-  static initClass(): void {
+  static init_SelectEditor(): void {
     this.prototype.default_view = SelectEditorView
     this.define<SelectEditor.Props>({
       options: [ p.Array, [] ],
     })
   }
 }
-SelectEditor.initClass()
 
 export class PercentEditorView extends CellEditorView {
   model: PercentEditor
@@ -272,11 +269,10 @@ export interface PercentEditor extends PercentEditor.Attrs {}
 export class PercentEditor extends CellEditor {
   properties: PercentEditor.Props
 
-  static initClass(): void {
+  static init_PercentEditor(): void {
     this.prototype.default_view = PercentEditorView
   }
 }
-PercentEditor.initClass()
 
 export class CheckboxEditorView extends CellEditorView {
   model: CheckboxEditor
@@ -312,11 +308,10 @@ export interface CheckboxEditor extends CheckboxEditor.Attrs {}
 export class CheckboxEditor extends CellEditor {
   properties: CheckboxEditor.Props
 
-  static initClass(): void {
+  static init_CheckboxEditor(): void {
     this.prototype.default_view = CheckboxEditorView
   }
 }
-CheckboxEditor.initClass()
 
 export class IntEditorView extends CellEditorView {
   model: IntEditor
@@ -369,14 +364,13 @@ export interface IntEditor extends IntEditor.Attrs {}
 export class IntEditor extends CellEditor {
   properties: IntEditor.Props
 
-  static initClass(): void {
+  static init_IntEditor(): void {
     this.prototype.default_view = IntEditorView
     this.define<IntEditor.Props>({
       step: [ p.Number, 1 ],
     })
   }
 }
-IntEditor.initClass()
 
 export class NumberEditorView extends CellEditorView {
   model: NumberEditor
@@ -429,14 +423,13 @@ export interface NumberEditor extends NumberEditor.Attrs {}
 export class NumberEditor extends CellEditor {
   properties: NumberEditor.Props
 
-  static initClass(): void {
+  static init_NumberEditor(): void {
     this.prototype.default_view = NumberEditorView
     this.define<NumberEditor.Props>({
       step: [ p.Number, 0.01 ],
     })
   }
 }
-NumberEditor.initClass()
 
 export class TimeEditorView extends CellEditorView {
   model: TimeEditor
@@ -459,11 +452,10 @@ export interface TimeEditor extends TimeEditor.Attrs {}
 export class TimeEditor extends CellEditor {
   properties: TimeEditor.Props
 
-  static initClass(): void {
+  static init_TimeEditor(): void {
     this.prototype.default_view = TimeEditorView
   }
 }
-TimeEditor.initClass()
 
 export class DateEditorView extends CellEditorView {
   model: DateEditor
@@ -538,8 +530,7 @@ export interface DateEditor extends DateEditor.Attrs {}
 export class DateEditor extends CellEditor {
   properties: DateEditor.Props
 
-  static initClass(): void {
+  static init_DateEditor(): void {
     this.prototype.default_view = DateEditorView
   }
 }
-DateEditor.initClass()

--- a/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
@@ -51,7 +51,7 @@ export class StringFormatter extends CellFormatter {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_StringFormatter(): void {
     this.define<StringFormatter.Props>({
       font_style: [ p.FontStyle, "normal" ],
       text_align: [ p.TextAlign, "left"   ],
@@ -80,7 +80,6 @@ export class StringFormatter extends CellFormatter {
     return text.outerHTML
   }
 }
-StringFormatter.initClass()
 
 export namespace NumberFormatter {
   export type Attrs = p.AttrsOf<Props>
@@ -101,7 +100,7 @@ export class NumberFormatter extends StringFormatter {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_NumberFormatter(): void {
 
     this.define<NumberFormatter.Props>({
       format:   [ p.String,           '0,0'   ], // TODO (bev)
@@ -123,7 +122,6 @@ export class NumberFormatter extends StringFormatter {
     return super.doFormat(row, cell, value, columnDef, dataContext)
   }
 }
-NumberFormatter.initClass()
 
 export namespace BooleanFormatter {
   export type Attrs = p.AttrsOf<Props>
@@ -142,7 +140,7 @@ export class BooleanFormatter extends CellFormatter {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_BooleanFormatter(): void {
 
     this.define<BooleanFormatter.Props>({
       icon: [ p.String, 'check' ],
@@ -153,7 +151,6 @@ export class BooleanFormatter extends CellFormatter {
     return !!value ? i({class: this.icon}).outerHTML : ""
   }
 }
-BooleanFormatter.initClass()
 
 export namespace DateFormatter {
   export type Attrs = p.AttrsOf<Props>
@@ -172,7 +169,7 @@ export class DateFormatter extends CellFormatter {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_DateFormatter(): void {
 
     this.define<DateFormatter.Props>({
       format: [ p.String, 'ISO-8601' ],
@@ -212,7 +209,6 @@ export class DateFormatter extends CellFormatter {
     return super.doFormat(row, cell, date, columnDef, dataContext)
   }
 }
-DateFormatter.initClass()
 
 export namespace HTMLTemplateFormatter {
   export type Attrs = p.AttrsOf<Props>
@@ -231,7 +227,7 @@ export class HTMLTemplateFormatter extends CellFormatter {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_HTMLTemplateFormatter(): void {
 
     this.define<HTMLTemplateFormatter.Props>({
       template: [ p.String, '<%= value %>' ],
@@ -249,4 +245,3 @@ export class HTMLTemplateFormatter extends CellFormatter {
     }
   }
 }
-HTMLTemplateFormatter.initClass()

--- a/bokehjs/src/lib/models/widgets/tables/data_cube.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_cube.ts
@@ -75,7 +75,7 @@ export class GroupingInfo extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_GroupingInfo(): void {
     this.prototype.type = 'GroupingInfo'
 
     this.define<GroupingInfo.Props>({
@@ -91,7 +91,6 @@ export class GroupingInfo extends Model {
     }
   }
 }
-GroupingInfo.initClass()
 
 export class DataCubeProvider extends TableDataProvider {
 
@@ -328,7 +327,7 @@ export class DataCube extends DataTable {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_DataCube(): void {
     this.prototype.type = 'DataCube'
     this.prototype.default_view = DataCubeView
 
@@ -338,4 +337,3 @@ export class DataCube extends DataTable {
     })
   }
 }
-DataCube.initClass()

--- a/bokehjs/src/lib/models/widgets/tables/data_table.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_table.ts
@@ -321,7 +321,7 @@ export class DataTable extends TableWidget {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_DataTable(): void {
     this.prototype.default_view = DataTableView
 
     this.define<DataTable.Props>({
@@ -361,4 +361,3 @@ export class DataTable extends TableWidget {
     return null
   }
 }
-DataTable.initClass()

--- a/bokehjs/src/lib/models/widgets/tables/row_aggregators.ts
+++ b/bokehjs/src/lib/models/widgets/tables/row_aggregators.ts
@@ -23,7 +23,7 @@ export abstract class RowAggregator extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_RowAggregator(): void {
     this.prototype.type = 'RowAggregator'
     this.define<RowAggregator.Props>({
       field_: [ p.String, '' ],
@@ -34,13 +34,12 @@ export abstract class RowAggregator extends Model {
   abstract accumulate(item: { [key: string]: any }): void
   abstract storeResult(totals: GroupTotals<number>): void
 }
-RowAggregator.initClass()
 
 const avg = new Avg()
 export class AvgAggregator extends RowAggregator {
   readonly key = 'avg'
 
-  static initClass(): void {
+  static init_AvgAggregator(): void {
     this.prototype.type = 'AvgAggregator'
   }
 
@@ -48,13 +47,12 @@ export class AvgAggregator extends RowAggregator {
   accumulate = avg.accumulate
   storeResult = avg.storeResult
 }
-AvgAggregator.initClass()
 
 const min = new Min()
 export class MinAggregator extends RowAggregator {
   readonly key = 'min'
 
-  static initClass(): void {
+  static init_MinAggregator(): void {
     this.prototype.type = 'MinAggregator'
   }
 
@@ -62,13 +60,12 @@ export class MinAggregator extends RowAggregator {
   accumulate = min.accumulate
   storeResult = min.storeResult
 }
-MinAggregator.initClass()
 
 const max = new Max()
 export class MaxAggregator extends RowAggregator {
   readonly key = 'max'
 
-  static initClass(): void {
+  static init_MaxAggregator(): void {
     this.prototype.type = 'MaxAggregator'
   }
 
@@ -76,13 +73,12 @@ export class MaxAggregator extends RowAggregator {
   accumulate = max.accumulate
   storeResult = max.storeResult
 }
-MaxAggregator.initClass()
 
 const sum = new Sum()
 export class SumAggregator extends RowAggregator {
   readonly key = 'sum'
 
-  static initClass(): void {
+  static init_SumAggregator(): void {
     this.prototype.type = 'SumAggregator'
   }
 
@@ -90,4 +86,3 @@ export class SumAggregator extends RowAggregator {
   accumulate = sum.accumulate
   storeResult = sum.storeResult
 }
-SumAggregator.initClass()

--- a/bokehjs/src/lib/models/widgets/tables/table_column.ts
+++ b/bokehjs/src/lib/models/widgets/tables/table_column.ts
@@ -33,7 +33,7 @@ export class TableColumn extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_TableColumn(): void {
     this.define<TableColumn.Props>({
       field:        [ p.String                                ],
       title:        [ p.String                                ],
@@ -59,4 +59,3 @@ export class TableColumn extends Model {
     }
   }
 }
-TableColumn.initClass()

--- a/bokehjs/src/lib/models/widgets/tables/table_widget.ts
+++ b/bokehjs/src/lib/models/widgets/tables/table_widget.ts
@@ -21,7 +21,7 @@ export class TableWidget extends Widget {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_TableWidget(): void {
     this.define<TableWidget.Props>({
       source: [ p.Instance ],
       view:   [ p.Instance, () => new CDSView() ],
@@ -37,4 +37,3 @@ export class TableWidget extends Widget {
     }
   }
 }
-TableWidget.initClass()

--- a/bokehjs/src/lib/models/widgets/text_input.ts
+++ b/bokehjs/src/lib/models/widgets/text_input.ts
@@ -65,7 +65,7 @@ export class TextInput extends InputWidget {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_TextInput(): void {
     this.prototype.default_view = TextInputView
 
     this.define<TextInput.Props>({
@@ -75,4 +75,3 @@ export class TextInput extends InputWidget {
     })
   }
 }
-TextInput.initClass()

--- a/bokehjs/src/lib/models/widgets/textarea_input.ts
+++ b/bokehjs/src/lib/models/widgets/textarea_input.ts
@@ -64,7 +64,7 @@ export class TextAreaInput extends TextInput {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_TextAreaInput(): void {
     this.prototype.default_view = TextAreaInputView
 
     this.define<TextAreaInput.Props>({
@@ -74,4 +74,3 @@ export class TextAreaInput extends TextInput {
     })
   }
 }
-TextAreaInput.initClass()

--- a/bokehjs/src/lib/models/widgets/toggle.ts
+++ b/bokehjs/src/lib/models/widgets/toggle.ts
@@ -44,7 +44,7 @@ export class Toggle extends AbstractButton {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Toggle(): void {
     this.prototype.default_view = ToggleView
 
     this.define<Toggle.Props>({
@@ -56,4 +56,3 @@ export class Toggle extends AbstractButton {
     })
   }
 }
-Toggle.initClass()

--- a/bokehjs/src/lib/models/widgets/widget.ts
+++ b/bokehjs/src/lib/models/widgets/widget.ts
@@ -51,7 +51,7 @@ export abstract class Widget extends HTMLBox {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Widget(): void {
     this.define<Widget.Props>({
       orientation:  [ p.Orientation, "horizontal" ],
       default_size: [ p.Number,      300          ],
@@ -62,4 +62,3 @@ export abstract class Widget extends HTMLBox {
     })
   }
 }
-Widget.initClass()

--- a/bokehjs/test/document/document.ts
+++ b/bokehjs/test/document/document.ts
@@ -27,13 +27,12 @@ class AnotherModel extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_AnotherModel(): void {
     this.define<AnotherModel.Props>({
       bar: [ p.Number, 1 ],
     })
   }
 }
-AnotherModel.initClass()
 
 Models.register('AnotherModel', AnotherModel)
 
@@ -54,7 +53,7 @@ class SomeModel extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_SomeModel(): void {
 
     this.define<SomeModel.Props>({
       foo:   [ p.Number, 2 ],
@@ -62,7 +61,6 @@ class SomeModel extends Model {
     })
   }
 }
-SomeModel.initClass()
 
 Models.register('SomeModel', SomeModel)
 
@@ -82,14 +80,13 @@ class SomeModelWithChildren extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_SomeModelWithChildren(): void {
 
     this.define<SomeModelWithChildren.Props>({
       children: [ p.Array, [] ],
     })
   }
 }
-SomeModelWithChildren.initClass()
 
 Models.register('SomeModelWithChildren', SomeModelWithChildren)
 
@@ -116,7 +113,7 @@ class ModelWithConstructTimeChanges extends Model {
     this.child = new AnotherModel()
   }
 
-  static initClass(): void {
+  static init_ModelWithConstructTimeChanges(): void {
 
     this.define<ModelWithConstructTimeChanges.Props>({
       foo:   [ p.Number, 2 ],
@@ -124,7 +121,6 @@ class ModelWithConstructTimeChanges extends Model {
     })
   }
 }
-ModelWithConstructTimeChanges.initClass()
 
 Models.register('ModelWithConstructTimeChanges', ModelWithConstructTimeChanges)
 
@@ -155,7 +151,7 @@ class ComplicatedModelWithConstructTimeChanges extends Model {
     this.dict_of_list_prop = { foo: [new AnotherModel()] }
   }
 
-  static initClass(): void {
+  static init_ComplicatedModelWithConstructTimeChanges(): void {
 
     this.define<ComplicatedModelWithConstructTimeChanges.Props>({
       list_prop:         [ p.Array ],
@@ -165,7 +161,6 @@ class ComplicatedModelWithConstructTimeChanges extends Model {
     })
   }
 }
-ComplicatedModelWithConstructTimeChanges.initClass()
 
 Models.register('ComplicatedModelWithConstructTimeChanges', ComplicatedModelWithConstructTimeChanges)
 

--- a/bokehjs/test/document/events.ts
+++ b/bokehjs/test/document/events.ts
@@ -24,13 +24,12 @@ class TestModelWithRefs extends HasProps {
 
   foo: any
 
-  static initClass(): void {
+  static init_TestModelWithRefs(): void {
     this.define<any>({
       foo: [ p.Any, [] ],
     })
   }
 }
-TestModelWithRefs.initClass()
 
 describe("events module", () => {
 

--- a/bokehjs/test/model.ts
+++ b/bokehjs/test/model.ts
@@ -11,7 +11,7 @@ class SomeModel extends Model {
   bar: string
   baz: number
 
-  static initClass(): void {
+  static init_SomeModel(): void {
     this.define<any>({
       foo: [ p.Number, 2 ],
       bar: [ p.String    ],
@@ -19,7 +19,6 @@ class SomeModel extends Model {
     })
   }
 }
-SomeModel.initClass()
 
 describe("Model objects", () => {
 

--- a/examples/app/spectrogram/waterfall.ts
+++ b/examples/app/spectrogram/waterfall.ts
@@ -128,7 +128,7 @@ export class WaterfallRenderer extends Renderer {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_WaterfallRenderer(): void {
     this.prototype.default_view = WaterfallRendererView
 
     this.define<WaterfallRenderer.Props>({
@@ -144,4 +144,3 @@ export class WaterfallRenderer extends Renderer {
     })
   }
 }
-WaterfallRenderer.initClass()

--- a/examples/app/surface3d/surface3d.ts
+++ b/examples/app/surface3d/surface3d.ts
@@ -121,7 +121,7 @@ export class Surface3d extends HTMLBox {
   // typos, which would prohibit serialization/deserialization of this model.
   static __name__ = "Surface3d"
 
-  static initClass(): void {
+  static init_Surface3d(): void {
     // This is usually boilerplate. In some cases there may not be a view.
     this.prototype.default_view = Surface3dView
 
@@ -139,4 +139,3 @@ export class Surface3d extends HTMLBox {
     })
   }
 }
-Surface3d.initClass()

--- a/examples/custom/custom_tool.py
+++ b/examples/custom/custom_tool.py
@@ -63,7 +63,7 @@ export class DrawTool extends GestureTool {
   event_type = "pan" as "pan"
   default_order = 12
 
-  static initClass(): void {
+  static init_DrawTool(): void {
     this.prototype.default_view = DrawToolView
 
     this.define<DrawTool.Props>({
@@ -71,7 +71,6 @@ export class DrawTool extends GestureTool {
     })
   }
 }
-DrawTool.initClass()
 """
 
 class DrawTool(Tool):

--- a/examples/custom/font-awesome/fontawesome_icon.ts
+++ b/examples/custom/font-awesome/fontawesome_icon.ts
@@ -49,7 +49,7 @@ export class FontAwesomeIcon extends AbstractIcon {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_FontAwesomeIcon(): void {
     this.prototype.default_view = FontAwesomeIconView
 
     this.define<FontAwesomeIcon.Props>({
@@ -60,4 +60,3 @@ export class FontAwesomeIcon extends AbstractIcon {
     })
   }
 }
-FontAwesomeIcon.initClass()

--- a/examples/custom/gears/gear.ts
+++ b/examples/custom/gears/gear.ts
@@ -170,7 +170,7 @@ export class Gear extends XYGlyph {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Gear(): void {
     this.prototype.default_view = GearView
 
     this.mixins(['line', 'fill'])
@@ -184,4 +184,3 @@ export class Gear extends XYGlyph {
     })
   }
 }
-Gear.initClass()

--- a/examples/custom/parallel_plot/parallel_reset.ts
+++ b/examples/custom/parallel_plot/parallel_reset.ts
@@ -24,11 +24,10 @@ export class ParallelResetTool extends ActionTool {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_ParallelResetTool(): void {
     this.prototype.default_view = ParallelResetToolView
   }
 
   tool_name = "Reset Zoom"
   icon = "bk-tool-icon-reset"
 }
-ParallelResetTool.initClass()

--- a/examples/custom/parallel_plot/parallel_selection_tool.ts
+++ b/examples/custom/parallel_plot/parallel_selection_tool.ts
@@ -362,7 +362,7 @@ export interface ParallelSelectionTool extends ParallelSelectionTool.Attrs {}
 export class ParallelSelectionTool extends BoxSelectTool {
   properties: ParallelSelectionTool.Props
 
-  static initClass(): void {
+  static init_ParallelSelectionTool(): void {
     this.prototype.default_view = ParallelSelectionView
 
     this.define<ParallelSelectionTool.Props>({
@@ -376,4 +376,3 @@ export class ParallelSelectionTool extends BoxSelectTool {
   //override event_type property define in BoxSelectTool
   event_type: any = ["tap" as "tap", "pan" as "pan", "move" as "move"]
 }
-ParallelSelectionTool.initClass()

--- a/examples/models/file/custom.py
+++ b/examples/models/file/custom.py
@@ -67,7 +67,7 @@ export interface MyPlot extends MyPlot.Attrs {
 export class MyPlot extends Plot {
   properties: MyPlot.Props
 
-  static initClass(): void {
+  static init_MyPlot(): void {
     this.prototype.default_view = MyPlotView
 
     this.define<MyPlot.Props>({
@@ -82,7 +82,6 @@ export class MyPlot extends Plot {
     })
   }
 }
-MyPlot.initClass()
 """)
 
     gradient_angle = Float(default=0)

--- a/examples/models/file/latex_extension.py
+++ b/examples/models/file/latex_extension.py
@@ -65,11 +65,10 @@ export class LatexLabelView extends LabelView {
 }
 
 export class LatexLabel extends Label {
-  static initClass(): void {
+  static init_LatexLabel(): void {
     this.prototype.default_view = LatexLabelView
   }
 }
-LatexLabel.initClass()
 """)
 
 p = figure(title="LaTex Extension Demonstration", plot_width=800, plot_height=350,

--- a/examples/models/file/popup.ts
+++ b/examples/models/file/popup.ts
@@ -21,7 +21,7 @@ export class Popup extends Model {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Popup(): void {
     this.define<Popup.Props>({
       message: [ p.String, "" ]
     })
@@ -34,4 +34,3 @@ export class Popup extends Model {
     }
   }
 }
-Popup.initClass()

--- a/sphinx/source/docs/user_guide/examples/extensions_example_latex.py
+++ b/sphinx/source/docs/user_guide/examples/extensions_example_latex.py
@@ -70,11 +70,10 @@ export class LatexLabel extends Label {
     super(attrs)
   }
 
-  static initClass() {
+  static init_LatexLabel() {
     this.prototype.default_view = LatexLabelView
   }
 }
-LatexLabel.initClass()
 """
 
 

--- a/sphinx/source/docs/user_guide/examples/extensions_example_tool.py
+++ b/sphinx/source/docs/user_guide/examples/extensions_example_tool.py
@@ -63,7 +63,7 @@ export class DrawTool extends GestureTool {
   event_type = "pan" as "pan"
   default_order = 12
 
-  static initClass(): void {
+  static init_DrawTool(): void {
     this.prototype.default_view = DrawToolView
 
     this.define<DrawTool.Props>({
@@ -71,7 +71,6 @@ export class DrawTool extends GestureTool {
     })
   }
 }
-DrawTool.initClass()
 """
 
 

--- a/sphinx/source/docs/user_guide/examples/extensions_example_wrapping.py
+++ b/sphinx/source/docs/user_guide/examples/extensions_example_wrapping.py
@@ -142,7 +142,7 @@ export class Surface3d extends LayoutDOM {
   // typos, which would prohibit serialization/deserialization of this model.
   static __name__ = "Surface3d"
 
-  static initClass() {
+  static init_Surface3d() {
     // This is usually boilerplate. In some cases there may not be a view.
     this.prototype.default_view = Surface3dView
 
@@ -159,7 +159,6 @@ export class Surface3d extends LayoutDOM {
     })
   }
 }
-Surface3d.initClass()
 """
 
 # This custom extension model will have a DOM view that should layout-able in

--- a/sphinx/source/docs/user_guide/examples/extensions_ion_range_slider.ts
+++ b/sphinx/source/docs/user_guide/examples/extensions_ion_range_slider.ts
@@ -129,7 +129,7 @@ export class IonRangeSlider extends InputWidget {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_IonRangeSlider(): void {
     // If there is an associated view, this is boilerplate.
     this.prototype.default_view = IonRangeSliderView
 
@@ -149,4 +149,3 @@ export class IonRangeSlider extends InputWidget {
     })
   }
 }
-IonRangeSlider.initClass()

--- a/sphinx/source/docs/user_guide/examples/extensions_putting_together_ts.py
+++ b/sphinx/source/docs/user_guide/examples/extensions_putting_together_ts.py
@@ -60,7 +60,7 @@ export class Custom extends HTMLBox {
     super(attrs)
   }
 
-  static initClass(): void {
+  static init_Custom(): void {
     // If there is an associated view, this is typically boilerplate.
     this.prototype.default_view = CustomView
 
@@ -79,7 +79,6 @@ export class Custom extends HTMLBox {
     })
   }
 }
-Custom.initClass()
 """
 
 from bokeh.util.compiler import TypeScript

--- a/sphinx/source/docs/user_guide/extensions.rst
+++ b/sphinx/source/docs/user_guide/extensions.rst
@@ -127,7 +127,7 @@ extensions in the next section.
       // typos, which would prohibit serialization/deserialization of this model.
       static __name__ = "Surface3d"
 
-      static initClass(): void {
+      static init_Custom(): void {
         // If there is an associated view, this is typically boilerplate.
         this.prototype.default_view = CustomView
 
@@ -142,7 +142,6 @@ extensions in the next section.
         })
       }
     }
-    Custom.initClass()
 
 .. _userguide_extensions_structure_putting_together:
 


### PR DESCRIPTION
This change is backwards compatible. Nothing changes from users' perspective and one can still use the old syntax.

fixes #9170 
