### PR TITLE
ensure null values in geoJSON are rendered as NaNs in the data source

### DIFF
--- a/bokehjs/src/lib/models/sources/geojson_data_source.ts
+++ b/bokehjs/src/lib/models/sources/geojson_data_source.ts
@@ -31,6 +31,10 @@ export namespace GeoJSONDataSource {
 
 export interface GeoJSONDataSource extends GeoJSONDataSource.Attrs {}
 
+function orNaN(v: number | undefined): number {
+  return v != null ? v : NaN
+}
+
 export class GeoJSONDataSource extends ColumnarDataSource {
   properties: GeoJSONDataSource.Props
 
@@ -75,15 +79,12 @@ export class GeoJSONDataSource extends ColumnarDataSource {
     for (const property in properties) {
       if (!data.hasOwnProperty(property))
         data[property] = this._get_new_nan_array(item_count)
-      data[property][i] = properties[property]
+      // orNaN necessary here to prevent null values from ending up in the column
+      data[property][i] = orNaN(properties[property])
     }
   }
 
   private _add_geometry(geometry: GeoItem, data: GeoData, i: number): void {
-
-    function orNaN(v: number | undefined) {
-      return v != null ? v : NaN
-    }
 
     function flatten(acc: Position[], item: Position[]) {
       return acc.concat([[NaN, NaN, NaN]]).concat(item)

--- a/bokehjs/test/models/sources/geojson_data_source.ts
+++ b/bokehjs/test/models/sources/geojson_data_source.ts
@@ -217,10 +217,25 @@ describe("geojson_data_source module", () => {
           }
        ]
     }`
-    const geo = new GeoJSONDataSource({geojson})
 
     it("should add the properties to the data", () => {
+      const geo = new GeoJSONDataSource({geojson})
       const expected_data = {x: [102], y: [33], z: [NaN], xs: [[]], ys: [[]], zs: [[]], color: ["pink"], value: [33]}
+      expect(geo.data).to.be.deep.equal(expected_data)
+    })
+
+    it("should convert null property values to NaN", () => {
+      const geojson = `{
+        "type": "FeatureCollection",
+        "features": [
+            { "type": "Feature",
+              "geometry": {"type": "Point", "coordinates": [102, 33]},
+              "properties": {"color": "pink", "value": null}
+            }
+        ]
+      }`
+      const geo = new GeoJSONDataSource({geojson})
+      const expected_data = {x: [102], y: [33], z: [NaN], xs: [[]], ys: [[]], zs: [[]], color: ["pink"], value: [NaN]}
       expect(geo.data).to.be.deep.equal(expected_data)
     })
   })


### PR DESCRIPTION
- [x] issues: fixes #9174
- [x] tests added / passed

OP test code
```
import geopandas as gpd
import numpy as np
from bokeh.palettes import Reds
from bokeh.models import GeoJSONDataSource, LinearColorMapper
from bokeh.plotting import figure, show

geodf = gpd.read_file("provinces.geojson")
geodf.loc[6, 'index'] = np.nan
print(geodf)
color_mapper = LinearColorMapper(palette=Reds[9][::-1], nan_color='black')

p = figure()
geo_source = GeoJSONDataSource(geojson=geodf.to_json())
p.patches('xs', 'ys', fill_alpha=1,
              fill_color={'field': 'index', 'transform': color_mapper},
              line_color='white', line_width=0.5,
              source=geo_source)

show(p)
```
Now produces:

<img width="428" alt="Screen Shot 2019-08-22 at 12 36 18 PM" src="https://user-images.githubusercontent.com/1078448/63544205-77e5b180-c4d9-11e9-8a77-90a0cef150ba.png">
