### PR TITLE
Pin GMaps API at version 3.36

### DIFF
--- a/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
@@ -17,7 +17,7 @@ const load_google_api = function(api_key: string): void {
 
   const script = document.createElement('script')
   script.type = 'text/javascript'
-  script.src = `https://maps.googleapis.com/maps/api/js?key=${api_key}&callback=_bokeh_gmaps_callback`
+  script.src = `https://maps.googleapis.com/maps/api/js?v=3.36&key=${api_key}&callback=_bokeh_gmaps_callback`
   document.body.appendChild(script)
 }
 


### PR DESCRIPTION
Versions 3.37+ don't work reliably in older browsers like IE or phantomjs.

fixes #9185 