### PR TITLE
handle angle between 0, 2pi correctly

### DIFF
--- a/bokehjs/src/lib/core/util/math.ts
+++ b/bokehjs/src/lib/core/util/math.ts
@@ -1,7 +1,10 @@
 const enum Direction {clock, anticlock}
 
 export function angle_norm(angle: number): number {
-  while (angle < 0) {
+  if (angle == 0) {
+    return 0
+  }
+  while (angle <= 0) {
     angle += 2*Math.PI
   }
   while (angle > 2*Math.PI) {
@@ -11,13 +14,15 @@ export function angle_norm(angle: number): number {
 }
 
 export function angle_dist(lhs: number, rhs: number): number {
-  return Math.abs(angle_norm(lhs-rhs))
+  return angle_norm(lhs-rhs)
 }
 
 export function angle_between(mid: number, lhs: number, rhs: number, direction: Direction): boolean {
   const d = angle_dist(lhs, rhs)
   if (d == 0)
     return false
+  if (d == 2*Math.PI)
+    return true
   const norm_mid = angle_norm(mid)
   const cond = angle_dist(lhs, norm_mid) <= d && angle_dist(norm_mid, rhs) <= d
   return (direction == Direction.clock) ? cond : !cond

--- a/bokehjs/test/core/util/math.ts
+++ b/bokehjs/test/core/util/math.ts
@@ -6,10 +6,18 @@ describe("math module", () => {
 
   describe("angle_norm", () => {
 
+    it("should return 0 for 0", () => {
+      expect(math.angle_norm(0)).to.be.equal(0)
+
+    })
+
     it("should return angle normalized between 0 and 2*Math.PI inclusive", () => {
       expect(math.angle_norm(3*Math.PI)).to.be.closeTo(Math.PI, 0.000001)
       expect(math.angle_norm(-3*Math.PI)).to.be.closeTo(Math.PI, 0.000001)
-      expect(math.angle_norm(0)).to.be.closeTo(0, 0.000001)
+    })
+
+    it("should return 2*Math.PI for -2*Math.PI", () => {
+      expect(math.angle_norm(2*Math.PI)).to.be.closeTo(2*Math.PI, 0.000001)
     })
 
   })
@@ -19,6 +27,11 @@ describe("math module", () => {
     it("should return the distance between two angles as a positive radian", () => {
       expect(math.angle_dist(2.5*Math.PI, -2.5*Math.PI)).to.be.closeTo(Math.PI, 0.000001)
       expect(math.angle_dist(-2.5*Math.PI, 2.5*Math.PI)).to.be.closeTo(Math.PI, 0.000001)
+    })
+
+    it("should return 2*Math.PI for  full range", () => {
+      expect(math.angle_dist(0, 2*Math.PI)).to.be.closeTo(2*Math.PI, 0.000001)
+      expect(math.angle_dist(2*Math.PI, 0)).to.be.closeTo(2*Math.PI, 0.000001)
     })
 
   })
@@ -33,6 +46,22 @@ describe("math module", () => {
     it("should return false if `mid` == `lhs` == `rhs`", () => {
       expect(math.angle_between(10, 10, 10, 1)).to.be.equal(false)
       expect(math.angle_between(10, 10, 10, 0)).to.be.equal(false)
+    })
+
+    it("should return false if `lhs` == `rhs` == 0", () => {
+      expect(math.angle_between(0, 0, 0, 0)).to.be.equal(false)
+      expect(math.angle_between(1, 0, 0, 0)).to.be.equal(false)
+      expect(math.angle_between(-1, 0, 0, 0)).to.be.equal(false)
+      expect(math.angle_between(0, 0, 0, 1)).to.be.equal(false)
+      expect(math.angle_between(1, 0, 0, 1)).to.be.equal(false)
+      expect(math.angle_between(-1, 0, 0, 1)).to.be.equal(false)
+    })
+
+    it("should return true if angle dist is 2_Math.PI", () => {
+      expect(math.angle_between(1, 0, 2*Math.PI, 0)).to.be.equal(true)
+      expect(math.angle_between(-1, 0, 2*Math.PI, 0)).to.be.equal(true)
+      expect(math.angle_between(1, 0, 2*Math.PI, 1)).to.be.equal(true)
+      expect(math.angle_between(-1, 0, 2*Math.PI, 1)).to.be.equal(true)
     })
 
   })


### PR DESCRIPTION
This PR makes sure that `angle_norm` only returns 0 for initial angle=0, and 2pi for any positive or negative multiples. Additionally d=2pi is special cased in `angle_between` since the direction is degenerate in that case. 

- [x] issues: fixes #9152
- [x] tests added / passed

Results of OP example as well as current GH repo example:


<img width="469" alt="Screen Shot 2019-08-24 at 7 40 05 PM" src="https://user-images.githubusercontent.com/1078448/63644877-681bc800-c6a7-11e9-94fd-fd6a9cac5d90.png">
<img width="419" alt="Screen Shot 2019-08-24 at 7 40 13 PM" src="https://user-images.githubusercontent.com/1078448/63644878-681bc800-c6a7-11e9-95a3-6ff47080a6e1.png">




