### PR TITLE
Pillow is already a bokeh dependency

### DIFF
--- a/sphinx/source/docs/user_guide/export.rst
+++ b/sphinx/source/docs/user_guide/export.rst
@@ -11,7 +11,7 @@ additional dependencies. These dependencies can be installed via conda:
 
 .. code-block:: sh
 
-    conda install selenium phantomjs pillow
+    conda install selenium phantomjs
 
 Alternatively, you can install phantomjs from npm via
 


### PR DESCRIPTION
I think the "additional dependency" `pillow` should be removed from this section because it is already a bokeh dependency