### PR TITLE
Fix typos in docs, comments, etc

### DIFF
--- a/bokeh/application/handlers/code_runner.py
+++ b/bokeh/application/handlers/code_runner.py
@@ -167,7 +167,7 @@ class CodeRunner(object):
 
         '''
         try:
-            # Simulate the sys.path behaviour decribed here:
+            # Simulate the sys.path behaviour described here:
             #
             # https://docs.python.org/2/library/sys.html#sys.path
             _cwd = os.getcwd()

--- a/bokeh/client/session.py
+++ b/bokeh/client/session.py
@@ -340,7 +340,7 @@ class ClientSession(object):
 
         While this method can be used to run Bokeh application code "outside"
         the Bokeh server, this practice is HIGHLY DISCOURAGED for any real
-        use case. This function is intented to facilitate testing ONLY.
+        use case. This function is intended to facilitate testing ONLY.
 
         '''
 

--- a/bokeh/command/tests/test_util.py
+++ b/bokeh/command/tests/test_util.py
@@ -69,7 +69,7 @@ call "bokeh serve" on the directory instead. For example:
 
     bokeh serve my_app_dir/
 
-If this is not the case, renaming main.py will supress this warning.
+If this is not the case, renaming main.py will suppress this warning.
 """
 
 @patch('warnings.warn')

--- a/bokeh/command/util.py
+++ b/bokeh/command/util.py
@@ -71,7 +71,7 @@ call "bokeh serve" on the directory instead. For example:
 
     bokeh serve my_app_dir/
 
-If this is not the case, renaming main.py will supress this warning.
+If this is not the case, renaming main.py will suppress this warning.
 """
 
 def build_single_handler_application(path, argv=None):

--- a/bokeh/core/enums.py
+++ b/bokeh/core/enums.py
@@ -200,7 +200,7 @@ def enumeration(*values, **kwargs):
             Whether validation should consider case or not (default: True)
 
         quote (bool, optional):
-            Whther values should be quoted in the string representations
+            Whether values should be quoted in the string representations
             (default: False)
 
     Raises:

--- a/bokeh/core/json_encoder.py
+++ b/bokeh/core/json_encoder.py
@@ -145,7 +145,7 @@ def serialize_json(obj, pretty=None, indent=None, **kwargs):
     # these args to json.dumps are computed internally and should not be passed along
     for name in ['allow_nan', 'separators', 'sort_keys']:
         if name in kwargs:
-            raise ValueError("The value of %r is computed internally, overriding is not permissable." % name)
+            raise ValueError("The value of %r is computed internally, overriding is not permissible." % name)
 
     pretty = settings.pretty(pretty)
 

--- a/bokeh/core/property/dataspec.py
+++ b/bokeh/core/property/dataspec.py
@@ -140,7 +140,7 @@ class DataSpec(Either):
         glyph.x = { 'value': 10, 'transform': Jitter(width=0.4) }
 
     Note that ``DataSpec`` is not normally useful on its own. Typically,
-    a model will define properties using one of the sublclasses such
+    a model will define properties using one of the subclasses such
     as :class:`~bokeh.core.properties.NumberSpec` or
     :class:`~bokeh.core.properties.ColorSpec`. For example, a Bokeh
     model with ``x``, ``y`` and ``color`` properties that can handle

--- a/bokeh/document/document.py
+++ b/bokeh/document/document.py
@@ -759,7 +759,7 @@ class Document(object):
             None
 
         Raises:
-            ValueError, if the callback was never added or has alraedy been run or removed
+            ValueError, if the callback was never added or has already been run or removed
 
         '''
         self._remove_session_callback(callback_obj, self.add_timeout_callback)

--- a/bokeh/io/state.py
+++ b/bokeh/io/state.py
@@ -16,7 +16,7 @@ Generating output for Bokeh plots requires coordinating several things:
 
 :class:`~bokeh.document.Document`
     Groups together Bokeh models that may be shared between plots (e.g.,
-    range or data source objects) into one common strucure.
+    range or data source objects) into one common structure.
 
 :class:`~bokeh.resources.Resources`
     Control how JavaScript and CSS for the client library BokehJS are

--- a/bokeh/models/layouts.py
+++ b/bokeh/models/layouts.py
@@ -148,7 +148,7 @@ class LayoutDOM(Model):
 
     ``"fit"``
         Use component's preferred height (if set) and allow to fit into the available
-        vertical space withing the minimum and maximum height bounds (if set). Component's
+        vertical space within the minimum and maximum height bounds (if set). Component's
         height neither will be aggressively minimized nor maximized.
 
     ``"min"``

--- a/bokeh/plotting/figure.py
+++ b/bokeh/plotting/figure.py
@@ -781,7 +781,7 @@ Examples:
         .. note::
             When passing ``marker="circle"`` it is also possible to supply a
             ``radius`` value in data-space units. When configuring marker type
-            from a data source column, *all* markers incuding circles may only
+            from a data source column, *all* markers including circles may only
             be configured with ``size`` in screen units.
 
         '''

--- a/bokeh/plotting/helpers.py
+++ b/bokeh/plotting/helpers.py
@@ -796,7 +796,7 @@ def _glyph_function(glyphclass, extra_docs=None):
 
     def func(self, **kwargs):
 
-        # Convert data source, if necesary
+        # Convert data source, if necessary
         is_user_source = kwargs.get('source', None) is not None
         if is_user_source:
             source = kwargs['source']

--- a/bokeh/sampledata/les_mis.py
+++ b/bokeh/sampledata/les_mis.py
@@ -4,7 +4,7 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-''' Provide JSON data for co-occurence of characters in Les Miserables.
+''' Provide JSON data for co-occurrence of characters in Les Miserables.
 
 '''
 

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -243,7 +243,7 @@ class BokehTornado(TornadoApplication):
         self._mem_log_frequency_milliseconds = mem_log_frequency_milliseconds
 
         if websocket_max_message_size_bytes <= 0:
-            raise ValueError("websocket_max_message_size_bytes must be postitive")
+            raise ValueError("websocket_max_message_size_bytes must be positive")
         elif websocket_max_message_size_bytes != DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES:
             log.info("Torndado websocket_max_message_size set to %d bytes (%0.2f MB)",
                      websocket_max_message_size_bytes,

--- a/bokehjs/src/lib/core/util/refs.ts
+++ b/bokehjs/src/lib/core/util/refs.ts
@@ -29,7 +29,7 @@ export function create_ref(obj: HasProps): Ref {
 // Determine whether an object has the proper format of a Bokeh reference
 //
 // @param arg [Object] the object to test
-// @return [bool] whether the object is a refererence
+// @return [bool] whether the object is a reference
 //
 // @note this function does not check that the id and types are valid,
 //   only that the format is correct (all required keys are present)

--- a/bokehjs/src/lib/models/annotations/label.ts
+++ b/bokehjs/src/lib/models/annotations/label.ts
@@ -29,7 +29,7 @@ export class LabelView extends TextAnnotationView {
     if (!this.model.visible)
       return
 
-    // Here because AngleSpec does units tranform and label doesn't support specs
+    // Here because AngleSpec does units transform and label doesn't support specs
     let angle: number
     switch (this.model.angle_units) {
       case "rad": {

--- a/bokehjs/src/lib/models/glyphs/webgl/markers.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/markers.ts
@@ -175,7 +175,7 @@ export abstract class MarkerGLGlyph extends BaseGLGlyph {
     if (this.glyph._angle != null) {
       this.vbo_a.set_data(0, new Float32Array(this.glyph._angle))
     }
-    // Radius is special; some markes allow radius in data-coords instead of screen coords
+    // Radius is special; some markers allow radius in data-coords instead of screen coords
     // @radius tells us that radius is in units, sradius is the pre-calculated screen radius
     if (this.glyph instanceof CircleView && this.glyph._radius != null)
       this.vbo_s.set_data(0, new Float32Array(map(this.glyph.sradius, (s) => s*2)))

--- a/bokehjs/src/lib/models/tickers/fixed_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/fixed_ticker.ts
@@ -34,7 +34,7 @@ export class FixedTicker extends ContinuousTicker {
     }
   }
 
-  // XXX: whatever, because FixedTicker needs to fullfill the interface somehow
+  // XXX: whatever, because FixedTicker needs to fulfill the interface somehow
   get_interval(_data_low: number, _data_high: number, _desired_n_ticks: number): number {
     return 0
   }

--- a/bokehjs/src/lib/models/tools/tool.ts
+++ b/bokehjs/src/lib/models/tools/tool.ts
@@ -94,7 +94,7 @@ export abstract class Tool extends Model {
   }
 
   // utility function to return a tool name, modified
-  // by the active dimenions. Used by tools that have dimensions
+  // by the active dimensions. Used by tools that have dimensions
   protected _get_dim_tooltip(name: string, dims: Dimensions): string {
     switch (dims) {
       case "width":  return `${name} (x-axis)`

--- a/sphinx/source/docs/dev_guide/server.rst
+++ b/sphinx/source/docs/dev_guide/server.rst
@@ -83,7 +83,7 @@ Summarizing the object graph:
   - has 1 path used to identify it in URLs
   - has 1 ``ServerContext`` representing the aspects of
     the server visible to application code
-  - has N ``ServerSesssion``
+  - has N ``ServerSession``
 
    - has 1 session ID which is a string naming the session
    - has 1 ``Document`` representing the session state
@@ -332,7 +332,7 @@ Some Current Protocol Caveats
    over binary websocket frames.  However, NumPy arrays of
    dtype ``float32``, ``float64`` and integer types smaller than ``int32``
    are base64 encoded in content frame to avoid performance
-   limitations of naiive JSON string searliazation.
+   limitations of naiive JSON string serialization.
    JavaScript's lack of native 64-bit integer support precludes
    them from inclusion in this optimization.
    The base64 encoding should be entirely transparent to all

--- a/sphinx/source/docs/dev_guide/setup.rst
+++ b/sphinx/source/docs/dev_guide/setup.rst
@@ -140,7 +140,7 @@ command at your command prompt to install all the required packages:
 
         conda install $(python scripts/deps.py build run test).split() | where {$_}
 
-* Winows (DOS Command Prompt)
+* Windows (DOS Command Prompt)
 
     .. code-block:: sh
 

--- a/sphinx/source/docs/releases/0.12.15.rst
+++ b/sphinx/source/docs/releases/0.12.15.rst
@@ -72,7 +72,7 @@ hit testing of image glyphs.
 
 All code should update to use these new properties. For now *read only*
 access to things like ``selected['1d'].indicies`` will continue to function
-as before for compatibility. However, programmtically *setting* selections
+as before for compatibility. However, programmatically *setting* selections
 must now go through the mode properties, i.e. ``.indices``, ``.line_indices``,
 etc.
 

--- a/sphinx/source/docs/releases/0.12.5.rst
+++ b/sphinx/source/docs/releases/0.12.5.rst
@@ -45,7 +45,7 @@ period of deprecation.
 New Deprecations
 ~~~~~~~~~~~~~~~~
 
-**MPL COMPATIBLITY IS DEPRECATED**
+**MPL COMPATIBILITY IS DEPRECATED**
 
 Bokeh's MPL compatibility was implemented using a third-party library that
 only exposes a small fraction of all Matplotlib functionality, and is

--- a/sphinx/source/docs/releases/1.1.0.rst
+++ b/sphinx/source/docs/releases/1.1.0.rst
@@ -47,7 +47,7 @@ removed in a future 2.0 release:
 * Support for CoffeeScript in ``CustomJS`` or custom extensions. Use JavaScript
   or Typescript instead.
 
-* Support for ``ClientSession.loop_until_closed``. This function is intented
+* Support for ``ClientSession.loop_until_closed``. This function is intended
   to support testing only, and will be removed from the public API. Bokeh
   applications should be run directly on a Bokeh server.
 
@@ -70,6 +70,6 @@ some changes to the ``bokeh-plot`` Sphinx directive were necessary. These are:
 
 We believe that there are very few users of ``bokeh.sphinxext`` outside the
 project itself, and that these changes will not cause any breakage for any of
-those users. However, please reach out for support if any unforseen issues arise.
+those users. However, please reach out for support if any unforeseen issues arise.
 
 .. _ReadTheDocs: https://readthedocs.org

--- a/sphinx/source/docs/user_guide/categorical.rst
+++ b/sphinx/source/docs/user_guide/categorical.rst
@@ -254,7 +254,7 @@ offset for each different call to ``vbar``:
 Stacked and Grouped
 ~~~~~~~~~~~~~~~~~~~
 
-The above techiques for stacking and grouping may also be used together to
+The above techniques for stacking and grouping may also be used together to
 crate a stacked, grouped bar plot.
 
 Continuing the example above with bars grouped by quarter, we might stack each
@@ -377,7 +377,7 @@ We've seen above how categorical locations can be modified by operations like
 *dodge* and *jitter*.  It is also possible to supply an offset to a categorical
 location explicitly. This is done by adding a numeric value to the end of a
 category, e.g. ``["Jan", 0.2]`` is the category "Jan" offset by a value of 0.2.
-For hierachical categories, the value is added at the end of the existing
+For hierarchical categories, the value is added at the end of the existing
 list, e.g. ``["West", "Sales", -0,2]``. Any numeric value at the end of a
 list of categories is always interpreted as an offset.
 

--- a/sphinx/source/docs/user_guide/plotting.rst
+++ b/sphinx/source/docs/user_guide/plotting.rst
@@ -96,7 +96,7 @@ accomplished with the |multi_line| glyph method:
     dimensional list or array of scalar values, it accepts a "list of lists"
     for x and y positions of each line, parameters xs and ys. multi_line
     also expects a scalar value or a list of scalers per each line for
-    parameters such as color, alpha, linewidth, etc. Similarily, a
+    parameters such as color, alpha, linewidth, etc. Similarly, a
     ColumnDataSource may be used consisting of a "list of lists" and a
     lists of scalars where the length of the list of scalars and length of
     lists must match.
@@ -258,7 +258,7 @@ This can be accomplished with the |patches| glyph method:
     dimensional list or array of scalar values, it accepts a "list of lists"
     for x and y positions of each patch, parameters xs and ys. patches
     also expects a scalar value or a list of scalers per each patch for
-    parameters such as color, alpha, linewidth, etc. Similarily, a
+    parameters such as color, alpha, linewidth, etc. Similarly, a
     ColumnDataSource may be used consisting of a "list of lists" and a
     lists of scalars where the length of the list of scalars and length of
     lists must match.
@@ -293,7 +293,7 @@ holes inside each polygon.
     list of x and y positions for the exterior and holes composing each
     polygon. MultiPolygons also expects a scalar value or a list of scalers
     per each item for parameters such as color, alpha, linewidth, etc.
-    Similarily, one can use a ColumnDataSource consisting of a 3 times nested
+    Similarly, one can use a ColumnDataSource consisting of a 3 times nested
     list and a list of scalars where the length of the list of scalars and
     length of the top level list must match.
 

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -653,7 +653,7 @@ can be found in the examples directory:
 
 Also note that most every command line argument for ``bokeh serve`` has a
 corresponding keyword argument to ``Server``. For instance setting the
---allow-sebsocket-orgin`` command line argument is equivalent to passing
+--allow-sebsocket-origin`` command line argument is equivalent to passing
 ``allow_websocket_origin`` as a parameter.
 
 .. _userguide_server_bokeh_client:
@@ -1124,8 +1124,8 @@ Websocket Origin
 ''''''''''''''''
 
 When an HTTP request is made to the Bokeh server, it immediately returns a
-script that will initiate a webocket connection, and all subsequent
-commumication happens over the webocket. To reduce the risk of cross-site
+script that will initiate a websocket connection, and all subsequent
+commumication happens over the websocket. To reduce the risk of cross-site
 misuse, the bokeh server will only initiate websocket connections from
 origins that are explicitly whitelisted. Requests with Origin headers that
 do not match the whitelist will generate HTTP 403 error responses.
@@ -1157,7 +1157,7 @@ instance, we typically want to restict the Bokeh server to honoring *only*
 requests that originate from our ``acme.com`` page, so that other pages cannot
 embed our Bokeh app without our knowledge.
 
-This can be accomplished  by setting the ``--allow-sebsocket-orgin`` command
+This can be accomplished  by setting the ``--allow-sebsocket-origin`` command
 line argument:
 
 .. code-block:: sh
@@ -1174,7 +1174,7 @@ origin than  ``acme.com``, and the Bokeh server will reject them.
     determined and knowledgeble attacker can spoof Origin headers.
 
 If multiple allowed origins are required, then multiple instances of
-``--allow-sebsocket-orgin`` can be passed on the command line.
+``--allow-sebsocket-origin`` can be passed on the command line.
 
 It is also possible to configure a Bokeh server to allow any and all connections
 Regardless of origin:


### PR DESCRIPTION
Fixed some typos in docs, comments, string literals, etc.