### PR TITLE
Outdated sentence removed from docs

### DIFF
--- a/sphinx/source/docs/user_guide/export.rst
+++ b/sphinx/source/docs/user_guide/export.rst
@@ -41,9 +41,7 @@ Limitations
 ~~~~~~~~~~~
 
 Responsive sizing_modes may generate layouts with unexpected size and aspect
-ratios. It is recommended to use the default ``fixed`` sizing mode. Also,
-glyphs that are rendered via webgl won't be included in the generated PNG, so
-it's suggested to use the default ``Plot.webgl=True`` attribute.
+ratios. It is recommended to use the default ``fixed`` sizing mode.
 
 Example usage
 ~~~~~~~~~~~~~


### PR DESCRIPTION
The sentence seems outdated because the new notation is `output_backend = 'webgl'` and saving plots as PNG with `output_backend = 'canvas'` works well.
