### PR TITLE
Fixed image hover value on inverted axes

### DIFF
--- a/bokehjs/src/lib/models/glyphs/image_base.ts
+++ b/bokehjs/src/lib/models/glyphs/image_base.ts
@@ -120,8 +120,12 @@ export class ImageBaseView extends XYGlyphView {
     const height = this._height[index]
     const dx = (r - l) / width
     const dy = (t - b) / height
-    const dim1 = Math.floor((x - l) / dx)
-    const dim2 = Math.floor((y - b) / dy)
+    let dim1 = Math.floor((x - l) / dx)
+    let dim2 = Math.floor((y - b) / dy)
+    if (this.renderer.xscale.source_range.is_reversed)
+      dim1 = width-dim1-1
+    if (this.renderer.yscale.source_range.is_reversed)
+      dim2 = height-dim2-1
     return {index, dim1, dim2, flat_index: dim2*width + dim1}
   }
 


### PR DESCRIPTION
This ensures that the `ImageIndex` generated by hover correctly inverts the indexes when the axis range is inverted. The initial attempt at fixing this (https://github.com/bokeh/bokeh/pull/8031/) did not invert the index.

<img width="514" alt="Screen Shot 2019-10-01 at 1 00 33 PM" src="https://user-images.githubusercontent.com/1550771/65956817-93829700-e44b-11e9-8b6d-4e0eea23291c.png">

- [x] issues: fixes #8778
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
