### PR TITLE
fix structure issues in palette docs

### DIFF
--- a/bokeh/sphinxext/_templates/palette_group_detail.html
+++ b/bokeh/sphinxext/_templates/palette_group_detail.html
@@ -1,7 +1,7 @@
 <div class="row-eq-height col-md-6" style="min-height: 300px;">
     <table>
       <tr>
-        <th colspan="8"> <h2>{{ name }}</h2> </th>
+        <th colspan="8"> <h4>{{ name }}</h4> </th>
       </tr>
 
       {% for number in numbers %}

--- a/sphinx/source/docs/reference/palettes.rst
+++ b/sphinx/source/docs/reference/palettes.rst
@@ -4,4 +4,3 @@ bokeh.palettes
 ==============
 
 .. automodule:: bokeh.palettes
-  :members:


### PR DESCRIPTION
This PR fixes two issues with the `bokeh.palettes` documentation pages:

* palette names were at `<h2>` which put them above the enclosing `<h3>` section headers. They are now `<h4>` which will play much better with the upcoming search crawler

* Functions entries were duplicated at the bottom due to `:members:` (we explicitly call autofunction earlier) This has been removed
