### PR TITLE
Invalidate assets in folder and subfolders

### DIFF
--- a/scripts/build_upload.py
+++ b/scripts/build_upload.py
@@ -387,11 +387,11 @@ def upload_docs():
 
     if V(CONFIG.version).is_prerelease:
         run(sync_cmd % "dev")
-        run(invalidate_cmd % "/en/dev")
+        run(invalidate_cmd % '"/en/dev*"')
     else:
         run(sync_cmd % CONFIG.version)
         run(sync_cmd % "latest")
-        paths =  "/en/latest /versions.json" % CONFIG.version
+        paths = '"/en/latest*" /versions.json'
         run(invalidate_cmd % paths)
     cd("..")
 


### PR DESCRIPTION
All assets with the path prefix in Amazon Cloudfront
CDN are invalidated in its cache.

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [ ] issues: fixes #9264 
- [ ] ~tests added / passed~
- [ ] ~release document entry (if new feature or API change)~
