### PR TITLE
Improve error message if import of channels fails.

### DIFF
--- a/bokeh/server/django/__init__.py
+++ b/bokeh/server/django/__init__.py
@@ -6,7 +6,8 @@ if six.PY2:
 from bokeh.util.dependencies import import_required
 
 import_required("django", "django is required by bokeh.server.django")
-import_required("channels", "channels is required by bokeh.server.django")
+import_required("channels", "The package channels is required by bokeh.server.django. "
+                            "and must be installed'")
 
 from .apps import DjangoBokehConfig
 default_app_config = "bokeh.server.django.DjangoBokehConfig"


### PR DESCRIPTION
Currently channels in only availeble on pip, but not conda.
Thus the conda install mentioned in the developer guide will not install it.
To run pytest -m codebase (mentioned in the developer guide) to be added as
git pre-commit hook will fail, giving first-time-contributers a bad experience

Point the users to install it via pip instead

- [x] issues: fixes #9274
- [x] tests added / passed
- [x] release document entry (if new feature or API change)
