### PR TITLE
Consistently use https protcol for cdn.pydata.org URLs

### DIFF
--- a/bokeh/embed/standalone.py
+++ b/bokeh/embed/standalone.py
@@ -114,9 +114,9 @@ def components(models, wrap_script=True, wrap_plot_info=True, theme=FromCurdoc):
 
     .. code-block:: html
 
-        <script src="http://cdn.pydata.org/bokeh/release/bokeh-x.y.z.min.js"></script>
-        <script src="http://cdn.pydata.org/bokeh/release/bokeh-widgets-x.y.z.min.js"></script>
-        <script src="http://cdn.pydata.org/bokeh/release/bokeh-tables-x.y.z.min.js"></script>
+        <script src="https://cdn.pydata.org/bokeh/release/bokeh-x.y.z.min.js"></script>
+        <script src="https://cdn.pydata.org/bokeh/release/bokeh-widgets-x.y.z.min.js"></script>
+        <script src="https://cdn.pydata.org/bokeh/release/bokeh-tables-x.y.z.min.js"></script>
 
     Note that in Jupyter Notebooks, it is not possible to use components and show in
     the same notebook cell.

--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -236,7 +236,7 @@ class JSResources(BaseResources):
     The following **mode** values are available for configuring a Resource object:
 
     * ``'inline'`` configure to provide entire Bokeh JS and CSS inline
-    * ``'cdn'`` configure to load Bokeh JS and CSS from ``http://cdn.pydata.org``
+    * ``'cdn'`` configure to load Bokeh JS and CSS from ``https://cdn.pydata.org``
     * ``'server'`` configure to load from a Bokeh Server
     * ``'server-dev'`` same as ``server`` but supports non-minified assets
     * ``'relative'`` configure to load relative to the given directory
@@ -308,7 +308,7 @@ class CSSResources(BaseResources):
     The following **mode** values are available for configuring a Resource object:
 
     * ``'inline'`` configure to provide entire BokehJS code and CSS inline
-    * ``'cdn'`` configure to load Bokeh CSS from ``http://cdn.pydata.org``
+    * ``'cdn'`` configure to load Bokeh CSS from ``https://cdn.pydata.org``
     * ``'server'`` configure to load from a Bokeh Server
     * ``'server-dev'`` same as ``server`` but supports non-minified CSS
     * ``'relative'`` configure to load relative to the given directory
@@ -377,7 +377,7 @@ class Resources(JSResources, CSSResources):
     The following **mode** values are available for configuring a Resource object:
 
     * ``'inline'`` configure to provide entire Bokeh JS and CSS inline
-    * ``'cdn'`` configure to load Bokeh JS and CSS from ``http://cdn.pydata.org``
+    * ``'cdn'`` configure to load Bokeh JS and CSS from ``https://cdn.pydata.org``
     * ``'server'`` configure to load from a Bokeh Server
     * ``'server-dev'`` same as ``server`` but supports non-minified assets
     * ``'relative'`` configure to load relative to the given directory

--- a/sphinx/source/docs/installation.rst
+++ b/sphinx/source/docs/installation.rst
@@ -188,10 +188,10 @@ versions of BokehJS are available for download from CDN at pydata.org, under
 the following naming scheme::
 
     # Javascript files
-    http://cdn.pydata.org/bokeh/release/bokeh-x.y.z.min.js
-    http://cdn.pydata.org/bokeh/release/bokeh-widgets-x.y.z.min.js
-    http://cdn.pydata.org/bokeh/release/bokeh-tables-x.y.z.min.js
-    http://cdn.pydata.org/bokeh/release/bokeh-api-x.y.z.min.js
+    https://cdn.pydata.org/bokeh/release/bokeh-x.y.z.min.js
+    https://cdn.pydata.org/bokeh/release/bokeh-widgets-x.y.z.min.js
+    https://cdn.pydata.org/bokeh/release/bokeh-tables-x.y.z.min.js
+    https://cdn.pydata.org/bokeh/release/bokeh-api-x.y.z.min.js
 
 The ``"-widgets"`` files are only necessary if you are using any of the widgets
 built into Bokeh in ``bokeh.models.widgets`` in your documents. Similarly, the
@@ -201,10 +201,10 @@ and must be loaded *after* the core BokehJS library.
 
 As a concrete example, the links for version ``1.0.0`` are:
 
-* http://cdn.pydata.org/bokeh/release/bokeh-1.0.0.min.js
-* http://cdn.pydata.org/bokeh/release/bokeh-widgets-1.0.0.min.js
-* http://cdn.pydata.org/bokeh/release/bokeh-tables-1.0.0.min.js
-* http://cdn.pydata.org/bokeh/release/bokeh-api-1.0.0.min.js
+* https://cdn.pydata.org/bokeh/release/bokeh-1.0.0.min.js
+* https://cdn.pydata.org/bokeh/release/bokeh-widgets-1.0.0.min.js
+* https://cdn.pydata.org/bokeh/release/bokeh-tables-1.0.0.min.js
+* https://cdn.pydata.org/bokeh/release/bokeh-api-1.0.0.min.js
 
 .. _Anaconda Python Distribution: http://anaconda.com/anaconda
 .. _anaconda.org: http://anaconda.org

--- a/sphinx/source/docs/user_guide/embed.rst
+++ b/sphinx/source/docs/user_guide/embed.rst
@@ -315,7 +315,7 @@ Then inserting the script and div elements into this boilerplate:
             <meta charset="utf-8">
             <title>Bokeh Scatter Plots</title>
 
-            <script type="text/javascript" src="http://cdn.pydata.org/bokeh/release/bokeh-1.1.0.min.js"></script>
+            <script src="https://cdn.pydata.org/bokeh/release/bokeh-1.1.0.min.js"></script>
 
             <!-- COPY/PASTE SCRIPT HERE -->
 

--- a/sphinx/source/docs/user_guide/quickstart.rst
+++ b/sphinx/source/docs/user_guide/quickstart.rst
@@ -281,7 +281,7 @@ Resources
 
 To generate plots, the client library BokehJS JavaScript and CSS code must
 be loaded into the browser. By default, the |output_file| function will
-load BokehJS from http://cdn.pydata.org . However, you can also configure Bokeh
+load BokehJS from https://cdn.pydata.org . However, you can also configure Bokeh
 to generate static HTML files with BokehJS resources embedded directly inside,
 by passing the argument ``mode="inline"`` to the |output_file| function.
 


### PR DESCRIPTION
Most browsers will not load http scripts from https pages. A few links were already using https, but some were not. http://cdn.pydata.org redirects to https://cdn.pydata.org so the loaded scripts will be the same.