### PR TITLE
9403: added BasicNumberFormatter as DataTable CellFormatter to suppor…

### DIFF
--- a/bokeh/models/widgets/tables.py
+++ b/bokeh/models/widgets/tables.py
@@ -40,6 +40,7 @@ from .widget import Widget
 
 __all__ = (
     'AvgAggregator',
+    'BasicNumberFormatter',
     'BooleanFormatter',
     'CellFormatter',
     'CellEditor',
@@ -111,6 +112,30 @@ class StringFormatter(CellFormatter):
     text_color = Color(help="""
     An optional text color. See :class:`bokeh.core.properties.Color` for
     details.
+    """)
+
+class BasicNumberFormatter(StringFormatter):
+    ''' Display numeric values from continuous ranges as "basic numbers",
+    using scientific notation when appropriate by default.
+    '''
+    precision = Int(10, help="""
+    How many digits of precision to display.
+    """)
+
+    use_scientific = Bool(True, help="""
+    Whether to ever display scientific notation. If ``True``, then
+    when to use scientific notation is controlled by ``power_limit_low``
+    and ``power_limit_high``.
+    """)
+
+    power_limit_high = Int(5, help="""
+    Limit the use of scientific notation to when::
+        log(x) >= power_limit_high
+    """)
+
+    power_limit_low = Int(-3, help="""
+    Limit the use of scientific notation to when::
+        log(x) <= power_limit_low
     """)
 
 class NumberFormatter(StringFormatter):

--- a/bokeh/models/widgets/tables.py
+++ b/bokeh/models/widgets/tables.py
@@ -40,7 +40,6 @@ from .widget import Widget
 
 __all__ = (
     'AvgAggregator',
-    'BasicNumberFormatter',
     'BooleanFormatter',
     'CellFormatter',
     'CellEditor',
@@ -57,6 +56,7 @@ __all__ = (
     'NumberEditor',
     'NumberFormatter',
     'PercentEditor',
+    'ScientificFormatter',
     'SelectEditor',
     'StringEditor',
     'StringFormatter',
@@ -114,18 +114,12 @@ class StringFormatter(CellFormatter):
     details.
     """)
 
-class BasicNumberFormatter(StringFormatter):
+class ScientificFormatter(StringFormatter):
     ''' Display numeric values from continuous ranges as "basic numbers",
     using scientific notation when appropriate by default.
     '''
     precision = Int(10, help="""
     How many digits of precision to display.
-    """)
-
-    use_scientific = Bool(True, help="""
-    Whether to ever display scientific notation. If ``True``, then
-    when to use scientific notation is controlled by ``power_limit_low``
-    and ``power_limit_high``.
     """)
 
     power_limit_high = Int(5, help="""

--- a/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
@@ -131,7 +131,7 @@ export abstract class BasicNumberFormatter extends StringFormatter {
         precision = 1
       }
       if (need_sci) {
-          value = value.toExponential(precision || undefined)
+        value = value.toExponential(precision || undefined)
       } else {
         value = value.toFixed(precision || undefined).replace(/(\.[0-9]*?)0+$/, "$1").replace(/\.$/, "")
       }

--- a/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
@@ -6,7 +6,7 @@ import * as p from "core/properties"
 import {div, i} from "core/dom"
 import {Color} from "core/types"
 import {FontStyle, TextAlign, RoundingFunction} from "core/enums"
-import {isNumber, isString} from "core/util/types"
+import {isString} from "core/util/types"
 import {Model} from "../../../model"
 
 export namespace CellFormatter {
@@ -85,7 +85,7 @@ export namespace ScientificFormatter {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = StringFormatter.Props & {
-    precision: p.Property<number | 10>
+    precision: p.Property<number>
     power_limit_high: p.Property<number>
     power_limit_low: p.Property<number>
   }
@@ -102,7 +102,7 @@ export abstract class ScientificFormatter extends StringFormatter {
 
   static init_ScientificFormatter(): void {
     this.define<ScientificFormatter.Props>({
-      precision:        [ p.Any,     10     ],
+      precision:        [ p.Number,  10     ],
       power_limit_high: [ p.Number,  5      ],
       power_limit_low:  [ p.Number,  -3     ],
     })
@@ -117,20 +117,18 @@ export abstract class ScientificFormatter extends StringFormatter {
   }
 
   doFormat(row: any, cell: any, value: any, columnDef: any, dataContext: any): string {
-    let need_sci = value >= this.scientific_limit_high || value <= this.scientific_limit_low
+    const need_sci = value <= this.scientific_limit_low || value >= this.scientific_limit_high
     let precision = this.precision
 
-    if (precision == null || isNumber(precision)) {
-      // toExponential does not handle precision values < 0 correctly
-      if (precision < 1) {
-        precision = 1
-      }
+    // toExponential does not handle precision values < 0 correctly
+    if (precision < 1) {
+      precision = 1
+    }
 
-      if (need_sci) {
-        value = value.toExponential(precision || undefined)
-      } else {
-        value = value.toFixed(precision || undefined).replace(/(\.[0-9]*?)0+$/, "$1").replace(/\.$/, "")
-      }
+    if (need_sci) {
+      value = value.toExponential(precision)
+    } else {
+      value = value.toFixed(precision).replace(/(\.[0-9]*?)0+$/, "$1").replace(/\.$/, "")
     }
 
     // add StringFormatter formatting

--- a/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
@@ -81,30 +81,28 @@ export class StringFormatter extends CellFormatter {
   }
 }
 
-export namespace BasicNumberFormatter {
+export namespace ScientificFormatter {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = StringFormatter.Props & {
     precision: p.Property<number | 10>
-    use_scientific: p.Property<boolean>
     power_limit_high: p.Property<number>
     power_limit_low: p.Property<number>
   }
 }
 
-export interface BasicNumberFormatter extends BasicNumberFormatter.Attrs {}
+export interface ScientificFormatter extends ScientificFormatter.Attrs {}
 
-export abstract class BasicNumberFormatter extends StringFormatter {
-  properties: BasicNumberFormatter.Props
+export abstract class ScientificFormatter extends StringFormatter {
+  properties: ScientificFormatter.Props
 
-  constructor(attrs?: Partial<BasicNumberFormatter.Attrs>) {
+  constructor(attrs?: Partial<ScientificFormatter.Attrs>) {
     super(attrs)
   }
 
-  static init_BasicNumberFormatter(): void {
-    this.define<BasicNumberFormatter.Props>({
+  static init_ScientificFormatter(): void {
+    this.define<ScientificFormatter.Props>({
       precision:        [ p.Any,     10     ],
-      use_scientific:   [ p.Boolean, true   ],
       power_limit_high: [ p.Number,  5      ],
       power_limit_low:  [ p.Number,  -3     ],
     })
@@ -119,17 +117,15 @@ export abstract class BasicNumberFormatter extends StringFormatter {
   }
 
   doFormat(row: any, cell: any, value: any, columnDef: any, dataContext: any): string {
-    let need_sci = false
-    if (this.use_scientific) {
-      need_sci = value >= this.scientific_limit_high || value <= this.scientific_limit_low
-    }
-
+    let need_sci = value >= this.scientific_limit_high || value <= this.scientific_limit_low
     let precision = this.precision
+
     if (precision == null || isNumber(precision)) {
       // toExponential does not handle precision values < 0 correctly
       if (precision < 1) {
         precision = 1
       }
+
       if (need_sci) {
         value = value.toExponential(precision || undefined)
       } else {

--- a/bokehjs/test/size.ts
+++ b/bokehjs/test/size.ts
@@ -15,7 +15,7 @@ const LIMITS: {[key: string]: number} = {
   // es6
   "js/bokeh-es6.min.js":         640,
   "js/bokeh-widgets-es6.min.js":  90,
-  "js/bokeh-tables-es6.min.js":  250,
+  "js/bokeh-tables-es6.min.js":  270,
   "js/bokeh-api-es6.min.js":      90,
   "js/bokeh-gl-es6.min.js":       70,
   // css


### PR DESCRIPTION
…t scientific notation with precision settings

- [x] issues: fixes #9403
- [ ] tests added / passed:
- [x] release document entry (if new feature or API change)

Notes:
* I used the same style as BasicTickFormatter, but without the ticks handling and Auto precision determination as that is not needed for single values
* toExponential does not handle precision values <1 despite the Bokeh documentation saying it could handle 0. Precision values for this BasicNumberFormatter implementation <1 are now handled as if 1 was passed @bryevdv: any idea on why toExponential does not handle precision=0? should providing a negative value raise an error instead, and if yes, how? Most ideally there would be a Bokeh type PosInt (0, 1, 2, 3, ...) that does validation automatically
* BasicNumberFormatter derives from StringFormatter so that one can use coloring and fonts
* I used the commit Hook and fixed the errors that were related to my code, but it seems there are additional errors that seemed unrelated. Could be that they are due to using Windows? (e.g. something about a file not found and something about icalendar)
* I did not add unit tests, not sure how to do so for this functionality as I did not see any existing unit tests for the other CellFormatters

Tested with:
```py
from bokeh.models import ColumnDataSource
from bokeh.models.widgets.tables import (
    DataTable, TableColumn, IntEditor, NumberFormatter, BasicNumberFormatter
)
from bokeh.io import curdoc
import copy

dict1 = {
    'x': list(range(10)),
    'y': [1.234**n/10**n for n in list(range(10))],
    'z': [1.234**n*10**n for n in list(range(10))],
}

source = ColumnDataSource(data=dict1)

columns = [
    TableColumn(field="x", title="x"),
    TableColumn(field="y", title="y"),
    TableColumn(field="z", title="NumberFormatter", formatter=NumberFormatter(format="0.00[00]")),
    TableColumn(field="z", title="BNF", formatter=BasicNumberFormatter()),
    TableColumn(field="z", title="BNF False", formatter=BasicNumberFormatter(use_scientific=False)),
    TableColumn(field="z", title="BNF 2", formatter=BasicNumberFormatter(precision=2)),
    TableColumn(field="z", title="BNF 0", formatter=BasicNumberFormatter(precision=0)),
    TableColumn(field="z", title="BNF 3 red", formatter=BasicNumberFormatter(precision=3,text_color='red'))
]

data_table = DataTable(
    source=source,
    columns=columns,
    width=800,
    reorderable=False,
)

curdoc().add_root(data_table)
```

Result:
![image](https://user-images.githubusercontent.com/7702207/67277658-94956a00-f4c7-11e9-8987-8a5d18be16bb.png)