### PR TITLE
Switch to geckodriver/firefox in bokeh.io

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -570,7 +570,6 @@ jobs:
         run: |
           pushd bokehjs
           npm install -g npm
-          npm install -g phantomjs-prebuilt
           npm ci --no-progress
           popd
           python setup.py --install-js

--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -122,6 +122,7 @@ jobs:
         run: |
           conda config --set auto_update_conda off
           conda config --append channels bokeh
+          conda config --append channels conda-forge
           conda config --get channels
           conda install --yes --quiet $CONDA_REQS
 
@@ -210,6 +211,7 @@ jobs:
         run: |
           conda config --set auto_update_conda off
           conda config --append channels bokeh
+          conda config --append channels conda-forge
           conda config --get channels
           conda install --yes --quiet $CONDA_REQS
 
@@ -329,6 +331,7 @@ jobs:
         run: |
           conda config --set auto_update_conda off
           conda config --append channels bokeh
+          conda config --append channels conda-forge
           conda config --get channels
           conda install --yes --quiet $CONDA_REQS
 
@@ -420,6 +423,7 @@ jobs:
         run: |
           conda config --set auto_update_conda off
           conda config --append channels bokeh
+          conda config --append channels conda-forge
           conda config --get channels
           conda install --yes --quiet $CONDA_REQS
 
@@ -630,6 +634,7 @@ jobs:
         run: |
           conda config --set auto_update_conda off
           conda config --append channels bokeh
+          conda config --append channels conda-forge
           conda config --get channels
           conda install --yes --quiet $CONDA_REQS
 
@@ -718,6 +723,7 @@ jobs:
         run: |
           conda config --set auto_update_conda off
           conda config --append channels bokeh
+          conda config --append channels conda-forge
           conda config --get channels
           conda install --yes --quiet $CONDA_REQS
 
@@ -816,6 +822,7 @@ jobs:
         run: |
           conda config --set auto_update_conda off
           conda config --append channels bokeh
+          conda config --append channels conda-forge
           conda config --get channels
           conda install --yes --quiet $CONDA_REQS
 

--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -491,6 +491,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       max-parallel: 6
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/bokeh/command/subcommands/png.py
+++ b/bokeh/command/subcommands/png.py
@@ -61,7 +61,8 @@ from argparse import Namespace
 
 # Bokeh imports
 from ...document import Document
-from ...io.export import create_webdriver, get_screenshot_as_png, terminate_webdriver
+from ...io.export import get_screenshot_as_png
+from ...io.webdriver import webdriver_control
 from ..util import set_single_plot_width_height
 from .file_output import FileOutputSubcommand
 
@@ -114,11 +115,11 @@ class PNG(FileOutputSubcommand):
         '''
 
         '''
-        self.driver = create_webdriver()
+        self.driver = webdriver_control.create()
         try:
             super().invoke(args)
         finally:
-            terminate_webdriver(self.driver)
+            webdriver_control.terminate(self.driver)
 
     def write_file(self, args: Namespace, filename: str, doc: Document) -> None:
         '''

--- a/bokeh/command/subcommands/png.py
+++ b/bokeh/command/subcommands/png.py
@@ -56,7 +56,6 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import io
-import sys
 from argparse import Namespace
 
 # Bokeh imports
@@ -120,18 +119,6 @@ class PNG(FileOutputSubcommand):
             super().invoke(args)
         finally:
             webdriver_control.terminate(self.driver)
-
-    def write_file(self, args: Namespace, filename: str, doc: Document) -> None:
-        '''
-
-        '''
-        contents = self.file_contents(args, doc)
-        if filename == '-':
-            sys.stdout.buffer.write(contents)
-        else:
-            with io.open(filename, "w+b") as f:
-                f.write(contents)
-        self.after_write_file(args, filename, doc)
 
     def file_contents(self, args: Namespace, doc: Document) -> bytes:
         '''

--- a/bokeh/command/subcommands/svg.py
+++ b/bokeh/command/subcommands/svg.py
@@ -59,7 +59,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import argparse
-import io
+from typing import List
 
 # Bokeh imports
 from ...document import Document
@@ -123,23 +123,7 @@ class SVG(FileOutputSubcommand):
         finally:
             webdriver_control.terminate(self.driver)
 
-    def write_file(self, args: argparse.Namespace, filename: str, doc: Document) -> None:
-        '''
-
-        '''
-        contents = self.file_contents(args, doc)
-        for i, svg in enumerate(contents):
-            if filename == '-':
-                print(svg)
-            else:
-                if i > 0:
-                    idx = filename.find(".svg")
-                    filename = filename[:idx] + "_{}".format(i) + filename[idx:]
-                with io.open(filename, "w", encoding="utf-8") as f:
-                    f.write(svg)
-            self.after_write_file(args, filename, doc)
-
-    def file_contents(self, args: argparse.Namespace, doc: Document) -> bytes:
+    def file_contents(self, args: argparse.Namespace, doc: Document) -> List[str]:
         '''
 
         '''

--- a/bokeh/command/subcommands/svg.py
+++ b/bokeh/command/subcommands/svg.py
@@ -63,7 +63,8 @@ import io
 
 # Bokeh imports
 from ...document import Document
-from ...io.export import create_webdriver, get_svgs, terminate_webdriver
+from ...io.export import get_svgs
+from ...io.webdriver import webdriver_control
 from ..util import set_single_plot_width_height
 from .file_output import FileOutputSubcommand
 
@@ -116,11 +117,11 @@ class SVG(FileOutputSubcommand):
         '''
 
         '''
-        self.driver = create_webdriver()
+        self.driver = webdriver_control.create()
         try:
             super().invoke(args)
         finally:
-            terminate_webdriver(self.driver)
+            webdriver_control.terminate(self.driver)
 
     def write_file(self, args: argparse.Namespace, filename: str, doc: Document) -> None:
         '''

--- a/bokeh/core/validation/__init__.py
+++ b/bokeh/core/validation/__init__.py
@@ -47,7 +47,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Bokeh imports
-from .check import check_integrity, silence
+from .check import check_integrity, silence, silenced
 from .decorators import error, warning
 
 #-----------------------------------------------------------------------------

--- a/bokeh/core/validation/check.py
+++ b/bokeh/core/validation/check.py
@@ -18,21 +18,27 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+import contextlib
+from typing import Set
+
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
-__silencers__ = set()
+
+__silencers__: Set[int] = set()
 
 __all__ = (
     'check_integrity',
-    'silence'
+    'silence',
+    'silenced',
 )
 
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
 
-def silence(warning, silence=True):
+def silence(warning: int, silence: bool = True) -> Set[int]:
     ''' Silence a particular warning on all Bokeh models.
 
     Args:
@@ -70,6 +76,13 @@ def silence(warning, silence=True):
         __silencers__.remove(warning)
     return __silencers__
 
+@contextlib.contextmanager
+def silenced(warning: int) -> None:
+    silence(warning, True)
+    try:
+        yield
+    finally:
+        silence(warning, False)
 
 def check_integrity(models):
     ''' Apply validation and integrity checks to a collection of Bokeh models.

--- a/bokeh/embed/standalone.py
+++ b/bokeh/embed/standalone.py
@@ -243,7 +243,7 @@ def components(models: Union[ModelLike, ModelLikeCollection], wrap_script: bool 
 def file_html(models: Union[Model, Document, Sequence[Model]],
               resources: Union[Resources, Tuple[JSResources, CSSResources]],
               title: Optional[str] = None,
-              template: Template = FILE,
+              template: Union[Template, str] = FILE,
               template_variables: Dict[str, Any] = {},
               theme: ThemeLike = FromCurdoc,
               suppress_callback_warning: bool = False,

--- a/bokeh/io/export.py
+++ b/bokeh/io/export.py
@@ -30,7 +30,7 @@ from PIL import Image
 
 # Bokeh imports
 from ..embed import file_html
-from ..resources import INLINE_LEGACY
+from ..resources import INLINE
 from .util import default_filename
 from .webdriver import WebDriver, webdriver_control
 
@@ -213,7 +213,7 @@ def get_svgs(obj, driver=None, timeout=5, **kwargs) -> bytes:
 
     return svgs
 
-def get_layout_html(obj, resources=INLINE_LEGACY, **kwargs):
+def get_layout_html(obj, resources=INLINE, **kwargs):
     '''
 
     '''

--- a/bokeh/io/export.py
+++ b/bokeh/io/export.py
@@ -32,20 +32,18 @@ from PIL import Image
 from ..embed import file_html
 from ..resources import INLINE_LEGACY
 from .util import default_filename
+from .webdriver import webdriver_control
 
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
 
 __all__ = (
-    'create_webdriver',
     'export_png',
     'export_svgs',
     'get_layout_html',
     'get_screenshot_as_png',
     'get_svgs',
-    'terminate_webdriver',
-    'webdriver_control',
 )
 
 #-----------------------------------------------------------------------------
@@ -159,23 +157,9 @@ def export_svgs(obj, filename=None, height=None, width=None, webdriver=None, tim
 
     return filenames
 
-# this is part of the API for this module
-from .webdriver import terminate_webdriver ; terminate_webdriver
-from .webdriver import webdriver_control ; webdriver_control
-
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------
-
-def create_webdriver():
-    ''' Create a new webdriver.
-
-    .. note ::
-        Here for compatibility. Prefer methods on the webdriver_control
-        object.
-
-    '''
-    return webdriver_control.create()
 
 def get_screenshot_as_png(obj, driver=None, timeout=5, **kwargs):
     ''' Get a screenshot of a ``LayoutDOM`` object.
@@ -208,9 +192,6 @@ def get_screenshot_as_png(obj, driver=None, timeout=5, **kwargs):
 
         web_driver.get("file:///" + tmp.path)
         web_driver.maximize_window()
-
-        ## resize for PhantomJS compat
-        web_driver.execute_script("document.body.style.width = '100%';")
 
         wait_until_render_complete(web_driver, timeout)
 

--- a/bokeh/io/export.py
+++ b/bokeh/io/export.py
@@ -240,8 +240,16 @@ def get_layout_html(obj, resources=INLINE_LEGACY, **kwargs):
             obj.plot_height = kwargs.get('height', old_height)
             obj.plot_width = kwargs.get('width', old_width)
 
+    template = r"""\
+    {% block postamble %}
+    <style>
+        body { margin: 0; }
+    </style>
+    {% endblock %}
+    """
+
     try:
-        html = file_html(obj, resources, title="", suppress_callback_warning=True, _always_new=True)
+        html = file_html(obj, resources, title="", template=template, suppress_callback_warning=True, _always_new=True)
     finally:
         if resize:
             obj.plot_height = old_height

--- a/bokeh/io/export.py
+++ b/bokeh/io/export.py
@@ -326,12 +326,13 @@ def _maximize_viewport(web_driver: WebDriver) -> Tuple[int, int]:
     calculate_window_size = """\
         const [width, height] = arguments
         return [
-            window.outerWidth - window.innerWidth + width,
-            window.outerHeight - window.innerHeight + height,
+            // XXX: outer{Width,Height} can be 0 in headless mode under certain window managers
+            Math.max(0, window.outerWidth - window.innerWidth) + width,
+            Math.max(0, window.outerHeight - window.innerHeight) + height,
         ]
     """
     [width, height] = web_driver.execute_script(calculate_window_size, *viewport_size)
-    eps = 100 # XXX: can't set window size exactly in some window managers, crop it to size later
+    eps = 100 # XXX: can't set window size exactly in certain window managers, crop it to size later
     web_driver.set_window_size(width + eps, height + eps)
     return viewport_size
 

--- a/bokeh/io/export.py
+++ b/bokeh/io/export.py
@@ -24,13 +24,14 @@ import os
 import warnings
 from os.path import abspath
 from tempfile import mkstemp
+from typing import Optional, Tuple
 
 # External imports
 from PIL import Image
 
 # Bokeh imports
 from ..embed import file_html
-from ..resources import INLINE
+from ..resources import INLINE, Resources
 from .util import default_filename
 from .webdriver import WebDriver, webdriver_control
 
@@ -161,7 +162,8 @@ def export_svgs(obj, filename=None, height=None, width=None, webdriver=None, tim
 # Dev API
 #-----------------------------------------------------------------------------
 
-def get_screenshot_as_png(obj, driver=None, timeout=5, **kwargs):
+def get_screenshot_as_png(obj, driver=None, timeout=5, *,
+        resources: Resources = INLINE, width: Optional[int] = None, height: Optional[int] = None) -> Image:
     ''' Get a screenshot of a ``LayoutDOM`` object.
 
     Args:
@@ -184,7 +186,7 @@ def get_screenshot_as_png(obj, driver=None, timeout=5, **kwargs):
 
     '''
     with _tmp_html() as tmp:
-        html = get_layout_html(obj, **kwargs)
+        html = get_layout_html(obj, resources=resources, width=width, height=height)
         with io.open(tmp.path, mode="w", encoding="utf-8") as file:
             file.write(html)
 
@@ -192,10 +194,10 @@ def get_screenshot_as_png(obj, driver=None, timeout=5, **kwargs):
         web_driver.maximize_window()
         web_driver.get("file:///" + tmp.path)
         wait_until_render_complete(web_driver, timeout)
-        _maximize_viewport(web_driver)
+        [width, height] = _maximize_viewport(web_driver)
         png = web_driver.get_screenshot_as_png()
 
-    return Image.open(io.BytesIO(png)).convert("RGBA")
+    return Image.open(io.BytesIO(png)).convert("RGBA").crop((0, 0, width, height))
 
 def get_svgs(obj, driver=None, timeout=5, **kwargs) -> bytes:
     '''
@@ -213,30 +215,37 @@ def get_svgs(obj, driver=None, timeout=5, **kwargs) -> bytes:
 
     return svgs
 
-def get_layout_html(obj, resources=INLINE, **kwargs):
+def get_layout_html(obj, *, resources: Resources = INLINE, width: Optional[int] = None, height: Optional[int] = None) -> str:
     '''
 
     '''
     resize = False
-    if kwargs.get('height') is not None or kwargs.get('width') is not None:
+    if height is not None or width is not None:
         # Defer this import, it is expensive
         from ..models.plots import Plot
         if not isinstance(obj, Plot):
             warnings.warn("Export method called with height or width kwargs on a non-Plot layout. The size values will be ignored.")
         else:
             resize = True
-            old_height = obj.plot_height
+
             old_width = obj.plot_width
-            obj.plot_height = kwargs.get('height', old_height)
-            obj.plot_width = kwargs.get('width', old_width)
+            old_height = obj.plot_height
+
+            if width is not None:
+                obj.plot_width = width
+            if height is not None:
+                obj.plot_height = height
 
     template = r"""\
     {% block preamble %}
     <style>
         html, body {
-            margin: 0;
+            box-sizing: border-box;
             width: 100%;
             height: 100%;
+            margin: 0;
+            border: 0;
+            padding: 0;
             overflow: hidden;
         }
     </style>
@@ -247,8 +256,8 @@ def get_layout_html(obj, resources=INLINE, **kwargs):
         html = file_html(obj, resources, title="", template=template, suppress_callback_warning=True, _always_new=True)
     finally:
         if resize:
-            obj.plot_height = old_height
             obj.plot_width = old_width
+            obj.plot_height = old_height
 
     return html
 
@@ -290,24 +299,34 @@ def wait_until_render_complete(driver, timeout):
 
 def _log_console(driver):
     levels = {'WARNING', 'ERROR', 'SEVERE'}
-    logs = driver.get_log('browser')
+    try:
+        logs = driver.get_log('browser')
+    except Exception:
+        return
     messages = [ log.get("message") for log in logs if log.get('level') in levels ]
     if len(messages) > 0:
         log.warning("There were browser warnings and/or errors that may have affected your export")
         for message in messages:
             log.warning(message)
 
-def _maximize_viewport(web_driver: WebDriver) -> None:
-    calculate_window_size = """\
+def _maximize_viewport(web_driver: WebDriver) -> Tuple[int, int]:
+    calculate_viewport_size = """\
         const root = document.getElementsByClassName("bk-root")[0]
         const {width, height} = root.children[0].getBoundingClientRect()
+        return [width, height]
+    """
+    viewport_size = web_driver.execute_script(calculate_viewport_size)
+    calculate_window_size = """\
+        const [width, height] = arguments
         return [
             window.outerWidth - window.innerWidth + width,
             window.outerHeight - window.innerHeight + height,
         ]
     """
-    [width, height] = web_driver.execute_script(calculate_window_size)
-    web_driver.set_window_size(width, height)
+    [width, height] = web_driver.execute_script(calculate_window_size, *viewport_size)
+    eps = 100 # XXX: can't set window size exactly in some window managers, crop it to size later
+    web_driver.set_window_size(width + eps, height + eps)
+    return viewport_size
 
 _SVG_SCRIPT = """
 var serialized_svgs = [];

--- a/bokeh/io/export.py
+++ b/bokeh/io/export.py
@@ -195,7 +195,7 @@ def get_screenshot_as_png(obj, driver=None, timeout=5, **kwargs):
         _maximize_viewport(web_driver)
         png = web_driver.get_screenshot_as_png()
 
-    return Image.open(io.BytesIO(png))
+    return Image.open(io.BytesIO(png)).convert("RGBA")
 
 def get_svgs(obj, driver=None, timeout=5, **kwargs) -> bytes:
     '''

--- a/bokeh/io/util.py
+++ b/bokeh/io/util.py
@@ -23,6 +23,7 @@ import os
 import sys
 from os.path import basename, dirname, join, splitext
 from tempfile import NamedTemporaryFile
+from typing import Optional
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -42,7 +43,7 @@ __all__ = (
 # Dev API
 #-----------------------------------------------------------------------------
 
-def default_filename(ext):
+def default_filename(ext: str) -> str:
     ''' Generate a default filename with a given extension, attempting to use
     the filename of the currently running process, if possible.
 
@@ -76,7 +77,7 @@ def default_filename(ext):
     name, _ = splitext(basename(filename))
     return join(basedir, name + "." + ext)
 
-def detect_current_filename():
+def detect_current_filename() -> Optional[str]:
     ''' Attempt to return the filename of the currently running Python process
 
     Returns None if the filename cannot be detected.
@@ -85,17 +86,18 @@ def detect_current_filename():
 
     filename = None
     frame = inspect.currentframe()
-    try:
-        while frame.f_back and frame.f_globals.get('name') != '__main__':
-            frame = frame.f_back
+    if frame is not None:
+        try:
+            while frame.f_back and frame.f_globals.get('name') != '__main__':
+                frame = frame.f_back
 
-        filename = frame.f_globals.get('__file__')
-    finally:
-        del frame
+            filename = frame.f_globals.get('__file__')
+        finally:
+            del frame
 
     return filename
 
-def temp_filename(ext):
+def temp_filename(ext: str) -> str:
     ''' Generate a temporary, writable filename with the given extension
 
     '''
@@ -105,18 +107,19 @@ def temp_filename(ext):
 # Private API
 #-----------------------------------------------------------------------------
 
-def _no_access(basedir):
+def _no_access(basedir: str) -> bool:
     ''' Return True if the given base dir is not accessible or writeable
 
     '''
     return not os.access(basedir, os.W_OK | os.X_OK)
 
-def _shares_exec_prefix(basedir):
+def _shares_exec_prefix(basedir: str) -> bool:
     ''' Whether a give base directory is on the system exex prefix
 
     '''
-    prefix = sys.exec_prefix
-    return (prefix is not None and basedir.startswith(prefix))
+    # XXX: exec_prefix has type str so why the check?
+    prefix: Optional[str] = sys.exec_prefix
+    return prefix is not None and basedir.startswith(prefix)
 
 #-----------------------------------------------------------------------------
 # Code

--- a/bokeh/io/webdriver.py
+++ b/bokeh/io/webdriver.py
@@ -58,7 +58,7 @@ __all__ = (
 def create_firefox_webdriver() -> WebDriver:
     options = webdriver.firefox.options.Options()
     options.add_argument("--headless")
-    return webdriver.Firefox(options=options, log_path=devnull)
+    return webdriver.Firefox(options=options, service_log_path=devnull)
 
 def create_chromium_webdriver() -> WebDriver:
     options = webdriver.chrome.options.Options()

--- a/bokeh/io/webdriver.py
+++ b/bokeh/io/webdriver.py
@@ -63,6 +63,7 @@ def create_firefox_webdriver() -> WebDriver:
 def create_chromium_webdriver() -> WebDriver:
     options = webdriver.chrome.options.Options()
     options.add_argument("--headless")
+    options.add_argument("--hide-scrollbars")
     return webdriver.Chrome(options=options)
 
 #-----------------------------------------------------------------------------
@@ -103,7 +104,7 @@ class _WebdriverState(object):
 
     current: Optional[WebDriver]
 
-    def __init__(self, reuse: bool = True, kind: Optional[DriverKind] = None):
+    def __init__(self, *, reuse: bool = True, kind: Optional[DriverKind] = None):
         self.reuse = reuse
         self.current = None
 
@@ -116,7 +117,7 @@ class _WebdriverState(object):
                 self.kind = "firefox"
             else:
                 raise RuntimeError("Neither firefox/geckodriver nor chromium-browser/chromedriver are available on system PATH. " \
-                                   "You can install the former with 'conda install -c conda-forge firefox geckodriver'")
+                                   "You can install the former with 'conda install -c conda-forge firefox geckodriver'.")
 
     @staticmethod
     def terminate(driver: WebDriver) -> None:
@@ -134,13 +135,14 @@ class _WebdriverState(object):
             self.current = self.create()
         return self.current
 
-    def create(self) -> WebDriver:
-        if self.kind == "firefox":
+    def create(self, kind: Optional[DriverKind] = None) -> WebDriver:
+        driver_kind = kind or self.kind
+        if driver_kind == "firefox":
             return create_firefox_webdriver()
-        elif self.kind == "chromium":
+        elif driver_kind == "chromium":
             return create_chromium_webdriver()
         else:
-            raise ValueError(f"Unknown webdriver kind {self.kind}")
+            raise ValueError(f"Unknown webdriver kind {driver_kind}")
 
     @property
     def reuse(self) -> bool:

--- a/bokeh/io/webdriver.py
+++ b/bokeh/io/webdriver.py
@@ -77,7 +77,7 @@ def _detect(executable: str) -> Optional[str]:
 
     try:
         proc = Popen([path, "--version"], stdout=PIPE, stderr=PIPE)
-        (stdout, stderr) = proc.communicate()
+        proc.communicate()
         if proc.returncode != 0:
             return None
     except OSError:

--- a/bokeh/io/webdriver.py
+++ b/bokeh/io/webdriver.py
@@ -89,7 +89,8 @@ def _is_available(executable: str) -> bool:
     return _detect(executable) is not None
 
 def _has_firefox() -> bool:
-    return _is_available("firefox") and _is_available("geckodriver")
+    names = ["firefox-bin", "firefox"]
+    return any(_is_available(name) for name in names) and _is_available("geckodriver")
 
 def _has_chromium() -> bool:
     names = ["chromium-browser", "chromium", "chrome", "google-chrome", "Google Chrome"]

--- a/bokeh/io/webdriver.py
+++ b/bokeh/io/webdriver.py
@@ -22,7 +22,6 @@ log = logging.getLogger(__name__)
 import atexit
 import shutil
 from os.path import devnull
-from subprocess import PIPE, Popen
 from typing import Any, Optional
 
 # External imports
@@ -71,19 +70,7 @@ def create_chromium_webdriver() -> WebDriver:
 #-----------------------------------------------------------------------------
 
 def _detect(executable: str) -> Optional[str]:
-    path = shutil.which(executable)
-    if path is None:
-        return None
-
-    try:
-        proc = Popen([path, "--version"], stdout=PIPE, stderr=PIPE)
-        proc.communicate()
-        if proc.returncode != 0:
-            return None
-    except OSError:
-        return None
-
-    return path
+    return shutil.which(executable)
 
 def _is_available(executable: str) -> bool:
     return _detect(executable) is not None

--- a/bokeh/io/webdriver.py
+++ b/bokeh/io/webdriver.py
@@ -92,7 +92,8 @@ def _has_firefox() -> bool:
     return _is_available("firefox") and _is_available("geckodriver")
 
 def _has_chromium() -> bool:
-    return _is_available("chromium-browser") and _is_available("chromedriver")
+    names = ["chromium-browser", "chromium", "chrome", "google-chrome", "Google Chrome"]
+    return any(_is_available(name) for name in names) and _is_available("chromedriver")
 
 class _WebdriverState(object):
     '''

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -537,15 +537,6 @@ class Settings(object):
     Setting this value to False may afford a small performance improvement.
     """)
 
-    phantomjs_path = PrioritizedSetting("phantomjs_path", "BOKEH_PHANTOMJS_PATH", default=None, help="""
-    Path to the PhantomJS executable.
-
-    PhantomJS is an optional dependency that is required for PNG and SVG export.
-    Bokeh will try to automatically locate an installed PhantomJS executable.
-    Use this environment variable to override the location Bokeh finds, or to
-    point to a non-standard location.
-    """)
-
     pretty = PrioritizedSetting("pretty", "BOKEH_PRETTY", default=False, dev_default=True, help="""
     Whether JSON strings should be pretty-printed.
     """)

--- a/bokeh/util/dependencies.py
+++ b/bokeh/util/dependencies.py
@@ -19,17 +19,9 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-import shutil
 from importlib import import_module
-from subprocess import PIPE, Popen
 from types import ModuleType
 from typing import Optional
-
-# External imports
-from packaging.version import Version as V
-
-# Bokeh imports
-from ..settings import settings
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -38,7 +30,6 @@ from ..settings import settings
 __all__ = (
     'import_optional',
     'import_required',
-    'detect_phantomjs',
 )
 
 #-----------------------------------------------------------------------------
@@ -88,42 +79,6 @@ def import_required(mod_name: str, error_msg: str) -> ModuleType:
         return import_module(mod_name)
     except ImportError as e:
         raise RuntimeError(error_msg) from e
-
-
-def detect_phantomjs(version: str = '2.1') -> str:
-    ''' Detect if PhantomJS is avaiable in PATH, at a minimum version.
-
-    Args:
-        version (str, optional) :
-            Required minimum version for PhantomJS (mostly for testing)
-
-    Returns:
-        str, path to PhantomJS
-
-    '''
-    if settings.phantomjs_path() is not None:
-        phantomjs_path = settings.phantomjs_path()
-    else:
-        phantomjs_path = shutil.which("phantomjs") or "phantomjs"
-
-    try:
-        proc = Popen([phantomjs_path, "--version"], stdout=PIPE, stderr=PIPE, stdin=PIPE)
-        proc.wait()
-        out = proc.communicate()
-
-        if len(out[1]) > 0:
-            raise RuntimeError('Error encountered in PhantomJS detection: %r' % out[1].decode('utf8'))
-
-        required = V(version)
-        installed = V(out[0].decode('utf8'))
-        if installed < required:
-            raise RuntimeError('PhantomJS version to old. Version>=%s required, installed: %s' % (required, installed))
-
-    except OSError:
-        raise RuntimeError('PhantomJS is not present in PATH or BOKEH_PHANTOMJS_PATH. Try "conda install phantomjs" or \
-            "npm install -g phantomjs-prebuilt"')
-
-    return phantomjs_path
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -476,9 +476,11 @@ export class PlotView extends LayoutDOMView {
       ctx.drawImage(webgl.canvas, 0, 0)
       // Set back hidpi transform
       ctx.save()
-      const ratio = this.canvas.pixel_ratio
-      ctx.scale(ratio, ratio)
-      ctx.translate(0.5, 0.5)
+      if (this.model.hidpi) {
+        const ratio = this.canvas.pixel_ratio
+        ctx.scale(ratio, ratio)
+        ctx.translate(0.5, 0.5)
+      }
     }
   }
 
@@ -1002,8 +1004,10 @@ export class PlotView extends LayoutDOMView {
 
     // Set hidpi-transform
     ctx.save()   // Save default state, do *after* getting ratio, cause setting canvas.width resets transforms
-    ctx.scale(ratio, ratio)
-    ctx.translate(0.5, 0.5)
+    if (this.model.hidpi) {
+      ctx.scale(ratio, ratio)
+      ctx.translate(0.5, 0.5)
+    }
 
     const frame_box: FrameBox = [
       this.frame._left.value,

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -57,8 +57,10 @@ test:
     - boto
     - colorama
     - coverage
+    - firefox
     - flake8
     - flaky
+    - geckodriver
     - ipython
     - isort >=4.3.21
     - lxml

--- a/setup.cfg
+++ b/setup.cfg
@@ -154,7 +154,7 @@ disallow_untyped_calls = False
 
 [mypy-bokeh.io.export]
 ignore_errors = False
-disallow-any-unimported = False
+disallow_any_unimported = False
 
 [mypy-bokeh.io.util]
 ignore_errors = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -151,3 +151,6 @@ ignore_errors = False
 [mypy-bokeh.command.*]
 ignore_errors = False
 disallow_untyped_calls = False
+
+[mypy-bokeh.util.webdriver]
+ignore_errors = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -152,5 +152,12 @@ ignore_errors = False
 ignore_errors = False
 disallow_untyped_calls = False
 
+[mypy-bokeh.io.export]
+ignore_errors = False
+disallow-any-unimported = False
+
+[mypy-bokeh.io.util]
+ignore_errors = False
+
 [mypy-bokeh.util.webdriver]
 ignore_errors = False

--- a/sphinx/source/docs/dev_guide/setup.rst
+++ b/sphinx/source/docs/dev_guide/setup.rst
@@ -196,13 +196,6 @@ to install all of BokehJS JavaScript dependencies:
 This command will install the necessary packages into the ``node_modules``
 subdirectory.
 
-PhantomJS
-~~~~~~~~~
-
-PhantomJS is currently required to exercise some capabilities under test. It
-is available via Conda for some platforms. For other platforms, it may be
-installed via npm with: ``npm install -g phantomjs``.
-
 ----
 
 Typically, these instructions only need to be followed once, when you are

--- a/sphinx/source/docs/dev_guide/testing.rst
+++ b/sphinx/source/docs/dev_guide/testing.rst
@@ -133,7 +133,7 @@ can view at ``examples.log`` in the same directory that you the tests
 were run from.
 
 .. warning::
-    Server examples do get run, but phantomJS cannot currently capture
+    Server examples do get run, but selenium cannot currently capture
     the output, so they are always blank in the test results
 
 Integration tests

--- a/sphinx/source/docs/installation.rst
+++ b/sphinx/source/docs/installation.rst
@@ -70,7 +70,7 @@ Pandas
 psutil
     Necessary to enable detailed memory logging in the Bokeh server.
 
-Selenium, PhantomJS
+Selenium, GeckoDriver, Firefox
     Necessary for :ref:`userguide_export` to PNG and SVG images.
 
 Sphinx

--- a/sphinx/source/docs/user_guide/export.rst
+++ b/sphinx/source/docs/user_guide/export.rst
@@ -6,21 +6,18 @@ Exporting Plots
 Additional dependencies
 -----------------------
 
-In order to use the |export| functions, users have to install some
-additional dependencies. These dependencies can be installed via conda:
+In order to use the |export| functions, users may have to install additional
+dependencies. These dependencies can be installed via conda:
 
 .. code-block:: sh
 
-    conda install selenium phantomjs
+    conda install selenium geckodriver firefox
 
-Alternatively, you can install phantomjs from npm via
-
-.. code-block:: sh
-
-    npm install -g phantomjs-prebuilt
-
-Note that the minimum compatible version of PhantomJS is 2.1, regardless of
-how it is installed.
+Alternatively one can use ``chromedriver`` and ``chromium`` browser (or one of
+its variants). Typically at least one compatible browser will be available on
+modern systems, thus installing a web browser may not be necessary. Bokeh will
+search for available browsers (and drivers) and use what's available, unless
+configured otherwise.
 
 .. _userguide_export_png:
 

--- a/tests/integration/tools/test_freehand_draw_tool.py
+++ b/tests/integration/tools/test_freehand_draw_tool.py
@@ -18,6 +18,9 @@ import pytest ; pytest
 # Standard library imports
 import time
 
+# External imports
+from flaky import flaky
+
 # Bokeh imports
 from bokeh._testing.util.compare import cds_data_almost_equal
 from bokeh._testing.util.selenium import RECORD
@@ -138,6 +141,7 @@ class Test_FreehandDrawTool(object):
 
         assert page.has_no_console_errors()
 
+    @flaky(max_runs=10)
     def test_freehand_draw_syncs_to_server(self, bokeh_server_page) -> None:
         expected = {'xs': [[1.6216216216216217, 2.027027027027027, 2.027027027027027, 2.027027027027027]],
                     'ys': [[1.5, 1.125, 1.125, 1.125]]}
@@ -149,6 +153,7 @@ class Test_FreehandDrawTool(object):
 
         assert page.results == {"matches": "True"}
 
+    @flaky(max_runs=10)
     def test_line_delete_syncs_to_server(self, bokeh_server_page) -> None:
         expected = {'xs': [], 'ys': []}
 

--- a/tests/unit/bokeh/command/subcommands/test_svg.py
+++ b/tests/unit/bokeh/command/subcommands/test_svg.py
@@ -189,7 +189,7 @@ def test_basic_script_with_multiple_svg_plots(capsys) -> None:
         assert err == ""
         assert out == ""
 
-        assert set(["scatter.svg", "scatter_1.svg", "scatter.py"]) == set(os.listdir(dirname))
+        assert set(["scatter_0.svg", "scatter_1.svg", "scatter.py"]) == set(os.listdir(dirname))
 
     with_directory_contents({ 'scatter.py' : multi_svg_scatter_script },
                             run)

--- a/tests/unit/bokeh/io/test_export.py
+++ b/tests/unit/bokeh/io/test_export.py
@@ -41,8 +41,10 @@ import bokeh.io.export as bie # isort:skip
 @pytest.fixture(scope="module", params=["chromium", "firefox"])
 def webdriver(request):
     driver = webdriver_control.create(request.param)
-    yield driver
-    webdriver_control.terminate(driver)
+    try:
+        yield driver
+    finally:
+        webdriver_control.terminate(driver)
 
 #-----------------------------------------------------------------------------
 # General API

--- a/tests/unit/bokeh/io/test_export.py
+++ b/tests/unit/bokeh/io/test_export.py
@@ -22,7 +22,7 @@ from mock import patch
 from PIL import Image
 
 # Bokeh imports
-from bokeh.io.webdriver import terminate_webdriver, webdriver_control
+from bokeh.io.webdriver import webdriver_control
 from bokeh.layouts import row
 from bokeh.models import ColumnDataSource, Plot, Range1d, Rect
 from bokeh.plotting import figure
@@ -39,7 +39,7 @@ import bokeh.io.export as bie # isort:skip
 def webdriver():
     driver = webdriver_control.create()
     yield driver
-    terminate_webdriver(driver)
+    webdriver_control.terminate(driver)
 
 #-----------------------------------------------------------------------------
 # General API

--- a/tests/unit/bokeh/io/test_export.py
+++ b/tests/unit/bokeh/io/test_export.py
@@ -71,7 +71,10 @@ def test_get_screenshot_as_png(webdriver, dimensions: Tuple[int, int]) -> None:
 
     # a WxHpx image of white pixels
     assert png.size == (width, height)
-    assert png.tobytes() == b"\xff\xff\xff\xff"*width*height
+
+    data = png.tobytes()
+    assert len(data) == 4*width*height
+    assert data == b"\xff\xff\xff\xff"*width*height
 
 @pytest.mark.unit
 @pytest.mark.selenium

--- a/tests/unit/bokeh/io/test_export.py
+++ b/tests/unit/bokeh/io/test_export.py
@@ -23,6 +23,8 @@ from mock import patch
 from PIL import Image
 
 # Bokeh imports
+from bokeh.core.validation import silenced
+from bokeh.core.validation.warnings import MISSING_RENDERERS
 from bokeh.io.webdriver import webdriver_control
 from bokeh.layouts import row
 from bokeh.models import ColumnDataSource, Plot, Range1d, Rect
@@ -64,7 +66,8 @@ def test_get_screenshot_as_png(webdriver, dimensions: Tuple[int, int]) -> None:
                   toolbar_location=None,
                   outline_line_color=None, background_fill_color=None, border_fill_color=None)
 
-    png = bie.get_screenshot_as_png(layout, web_driver=webdriver)
+    with silenced(MISSING_RENDERERS):
+        png = bie.get_screenshot_as_png(layout, web_driver=webdriver)
 
     # a WxHpx image of white pixels
     assert png.size == (width, height)
@@ -107,7 +110,9 @@ def test_get_screenshot_as_png_with_glyph(webdriver, dimensions: Tuple[int, int]
 def test_get_screenshot_as_png_with_unicode_minified(webdriver) -> None:
     p = figure(title="유니 코드 지원을위한 작은 테스트")
 
-    png = bie.get_screenshot_as_png(p, driver=webdriver, resources=Resources(mode="inline", minified=True, legacy=True))
+    with silenced(MISSING_RENDERERS):
+        png = bie.get_screenshot_as_png(p, driver=webdriver, resources=Resources(mode="inline", minified=True, legacy=True))
+
     assert len(png.tobytes()) > 0
 
 @pytest.mark.unit
@@ -115,7 +120,9 @@ def test_get_screenshot_as_png_with_unicode_minified(webdriver) -> None:
 def test_get_screenshot_as_png_with_unicode_unminified(webdriver) -> None:
     p = figure(title="유니 코드 지원을위한 작은 테스트")
 
-    png = bie.get_screenshot_as_png(p, driver=webdriver, resources=Resources(mode="inline", minified=False, legacy=True))
+    with silenced(MISSING_RENDERERS):
+        png = bie.get_screenshot_as_png(p, driver=webdriver, resources=Resources(mode="inline", minified=False, legacy=True))
+
     assert len(png.tobytes()) > 0
 
 @pytest.mark.unit
@@ -124,7 +131,9 @@ def test_get_svgs_no_svg_present() -> None:
     layout = Plot(x_range=Range1d(), y_range=Range1d(),
               plot_height=20, plot_width=20, toolbar_location=None)
 
-    svgs = bie.get_svgs(layout)
+    with silenced(MISSING_RENDERERS):
+        svgs = bie.get_svgs(layout)
+
     assert svgs == []
 
 @pytest.mark.unit
@@ -141,8 +150,9 @@ def test_get_svgs_with_svg_present(webdriver) -> None:
                   outline_line_color=None, border_fill_color=None,
                   background_fill_color="red", output_backend="svg")
 
-    svg0 = fix_ids(bie.get_svgs(layout, driver=webdriver)[0])
-    svg1 = fix_ids(bie.get_svgs(layout, driver=webdriver)[0])
+    with silenced(MISSING_RENDERERS):
+        svg0 = fix_ids(bie.get_svgs(layout, driver=webdriver)[0])
+        svg1 = fix_ids(bie.get_svgs(layout, driver=webdriver)[0])
 
     svg2 = (
         '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" '
@@ -167,7 +177,8 @@ def test_get_layout_html_resets_plot_dims() -> None:
     layout = Plot(x_range=Range1d(), y_range=Range1d(),
                   plot_height=initial_height, plot_width=initial_width)
 
-    bie.get_layout_html(layout, height=100, width=100)
+    with silenced(MISSING_RENDERERS):
+        bie.get_layout_html(layout, height=100, width=100)
 
     assert layout.plot_height == initial_height
     assert layout.plot_width == initial_width
@@ -175,18 +186,22 @@ def test_get_layout_html_resets_plot_dims() -> None:
 def test_layout_html_on_child_first() -> None:
     p = Plot(x_range=Range1d(), y_range=Range1d())
 
-    bie.get_layout_html(p, height=100, width=100)
+    with silenced(MISSING_RENDERERS):
+        bie.get_layout_html(p, height=100, width=100)
 
-    layout = row(p)
-    bie.get_layout_html(layout)
+    with silenced(MISSING_RENDERERS):
+        layout = row(p)
+        bie.get_layout_html(layout)
 
 def test_layout_html_on_parent_first() -> None:
     p = Plot(x_range=Range1d(), y_range=Range1d())
 
-    layout = row(p)
-    bie.get_layout_html(layout)
+    with silenced(MISSING_RENDERERS):
+        layout = row(p)
+        bie.get_layout_html(layout)
 
-    bie.get_layout_html(p, height=100, width=100)
+    with silenced(MISSING_RENDERERS):
+        bie.get_layout_html(p, height=100, width=100)
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/tests/unit/bokeh/io/test_export.py
+++ b/tests/unit/bokeh/io/test_export.py
@@ -116,7 +116,7 @@ def test_get_screenshot_as_png_with_unicode_minified(webdriver) -> None:
     p = figure(title="유니 코드 지원을위한 작은 테스트")
 
     with silenced(MISSING_RENDERERS):
-        png = bie.get_screenshot_as_png(p, driver=webdriver, resources=Resources(mode="inline", minified=True, legacy=True))
+        png = bie.get_screenshot_as_png(p, driver=webdriver, resources=Resources(mode="inline", minified=True))
 
     assert len(png.tobytes()) > 0
 
@@ -126,7 +126,7 @@ def test_get_screenshot_as_png_with_unicode_unminified(webdriver) -> None:
     p = figure(title="유니 코드 지원을위한 작은 테스트")
 
     with silenced(MISSING_RENDERERS):
-        png = bie.get_screenshot_as_png(p, driver=webdriver, resources=Resources(mode="inline", minified=False, legacy=True))
+        png = bie.get_screenshot_as_png(p, driver=webdriver, resources=Resources(mode="inline", minified=False))
 
     assert len(png.tobytes()) > 0
 

--- a/tests/unit/bokeh/io/test_export.py
+++ b/tests/unit/bokeh/io/test_export.py
@@ -18,10 +18,6 @@ import pytest ; pytest
 import re
 from typing import Tuple
 
-# External imports
-from mock import patch
-from PIL import Image
-
 # Bokeh imports
 from bokeh.core.validation import silenced
 from bokeh.core.validation.warnings import MISSING_RENDERERS
@@ -56,46 +52,46 @@ def webdriver(request):
 
 @pytest.mark.unit
 @pytest.mark.selenium
-@pytest.mark.parametrize("dimensions", [(4, 4), (14, 14), (44, 44), (144, 144), (444, 444), (1444, 1444)])
+@pytest.mark.parametrize("dimensions", [(14, 14), (44, 44), (144, 144), (444, 444), (1444, 1444)])
 def test_get_screenshot_as_png(webdriver, dimensions: Tuple[int, int]) -> None:
     width, height = dimensions
-    border = 2
+    border = 5
 
     layout = Plot(x_range=Range1d(), y_range=Range1d(),
                   plot_height=width, plot_width=height,
                   min_border=border,
                   hidpi=False,
                   toolbar_location=None,
-                  outline_line_color=None, background_fill_color=None, border_fill_color=None)
+                  outline_line_color=None, background_fill_color="#00ff00", border_fill_color="#00ff00")
 
     with silenced(MISSING_RENDERERS):
-        png = bie.get_screenshot_as_png(layout, web_driver=webdriver)
+        png = bie.get_screenshot_as_png(layout, driver=webdriver)
 
     # a WxHpx image of white pixels
     assert png.size == (width, height)
 
     data = png.tobytes()
     assert len(data) == 4*width*height
-    assert data == b"\xff\xff\xff\xff"*width*height
+    assert data == b"\x00\xff\x00\xff"*width*height
 
 @pytest.mark.unit
 @pytest.mark.selenium
-@pytest.mark.parametrize("dimensions", [(4, 4), (14, 14), (44, 44), (144, 144), (444, 444), (1444, 1444)])
+@pytest.mark.parametrize("dimensions", [(14, 14), (44, 44), (144, 144), (444, 444), (1444, 1444)])
 def test_get_screenshot_as_png_with_glyph(webdriver, dimensions: Tuple[int, int]) -> None:
     width, height = dimensions
-    border = 2
+    border = 5
 
     layout = Plot(x_range=Range1d(-1, 1), y_range=Range1d(-1, 1),
                   plot_height=width, plot_width=height,
                   toolbar_location=None,
                   min_border=border,
                   hidpi=False,
-                  outline_line_color=None, background_fill_color=None, border_fill_color=None)
-    glyph = Rect(x="x", y="y", width=2, height=2, fill_color="red", line_color="red")
+                  outline_line_color=None, background_fill_color="#00ff00", border_fill_color="#00ff00")
+    glyph = Rect(x="x", y="y", width=2, height=2, fill_color="#ff0000", line_color="#ff0000")
     source = ColumnDataSource(data=dict(x=[0], y=[0]))
     layout.add_glyph(source, glyph)
 
-    png = bie.get_screenshot_as_png(layout, web_dirver=webdriver)
+    png = bie.get_screenshot_as_png(layout, driver=webdriver)
     assert png.size == (width, height)
 
     data = png.tobytes()
@@ -108,7 +104,8 @@ def test_get_screenshot_as_png_with_glyph(webdriver, dimensions: Tuple[int, int]
             count += 1
 
     w, h, b = width, height, border
-    assert count == w*h - 2*b*(w + h) + 4*b**2
+    expected_count = w*h - 2*b*(w + h) + 4*b**2
+    assert count == expected_count
 
 @pytest.mark.unit
 @pytest.mark.selenium

--- a/tests/unit/bokeh/io/test_export.py
+++ b/tests/unit/bokeh/io/test_export.py
@@ -72,7 +72,9 @@ def test_get_screenshot_as_png(webdriver, dimensions: Tuple[int, int]) -> None:
 
     data = png.tobytes()
     assert len(data) == 4*width*height
-    assert data == b"\x00\xff\x00\xff"*width*height
+    assert (data == b"\x00\xff\x00\xff"*width*height or
+            data == b"\x2e\xff\x05\xff"*width*height)   # XXX: Chrome on MacOS
+
 
 @pytest.mark.unit
 @pytest.mark.selenium
@@ -100,7 +102,9 @@ def test_get_screenshot_as_png_with_glyph(webdriver, dimensions: Tuple[int, int]
     # count red pixels in center area
     count = 0
     for x in range(width*height):
-        if data[x*4:x*4+4] == b"\xff\x00\x00\xff":
+        pixel = data[x*4:x*4+4]
+        if pixel == b"\xff\x00\x00\xff" or \
+           pixel == b"\xfc\x00\x06\xff":     # XXX: Chrome on MacOS
             count += 1
 
     w, h, b = width, height, border

--- a/tests/unit/bokeh/io/test_webdriver.py
+++ b/tests/unit/bokeh/io/test_webdriver.py
@@ -52,7 +52,7 @@ class Test_webdriver_control(object):
         # so create a new instance only to check default values
         wc = biw._WebdriverState()
         assert wc.reuse == True
-        assert wc.kind == "firefox"
+        assert wc.kind == "chromium"
         assert wc.current is None
 
     def test_get_with_reuse(self) -> None:

--- a/tests/unit/bokeh/io/test_webdriver.py
+++ b/tests/unit/bokeh/io/test_webdriver.py
@@ -15,7 +15,8 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # External imports
-import selenium.webdriver.phantomjs.webdriver
+import selenium.webdriver.chrome.webdriver
+import selenium.webdriver.firefox.webdriver
 
 # Module under test
 import bokeh.io.webdriver as biw # isort:skip
@@ -32,18 +33,17 @@ import bokeh.io.webdriver as biw # isort:skip
 # Dev API
 #-----------------------------------------------------------------------------
 
-def test_create_phantomjs_webdriver() -> None:
-    d = biw.create_phantomjs_webdriver()
-    assert isinstance(d, selenium.webdriver.phantomjs.webdriver.WebDriver)
+def test_create_firefox_webdriver() -> None:
+    d = biw.create_firefox_webdriver()
+    assert isinstance(d, selenium.webdriver.firefox.webdriver.WebDriver)
 
-def test_terminate_webdriver() -> None:
-    d = biw.create_phantomjs_webdriver()
-    assert d.service.process is not None
-    biw.terminate_webdriver(d)
-    assert d.service.process is None
+def test_create_chromium_webdriver() -> None:
+    d = biw.create_chromium_webdriver()
+    assert isinstance(d, selenium.webdriver.chrome.webdriver.WebDriver)
 
 _driver_map = {
-    'phantomjs': selenium.webdriver.phantomjs.webdriver.WebDriver,
+    'firefox': selenium.webdriver.firefox.webdriver.WebDriver,
+    'chromium': selenium.webdriver.chrome.webdriver.WebDriver,
 }
 
 class Test_webdriver_control(object):
@@ -52,7 +52,7 @@ class Test_webdriver_control(object):
         # so create a new instance only to check default values
         wc = biw._WebdriverState()
         assert wc.reuse == True
-        assert wc.kind == "phantomjs"
+        assert wc.kind == "firefox"
         assert wc.current is None
 
     def test_get_with_reuse(self) -> None:
@@ -83,7 +83,7 @@ class Test_webdriver_control(object):
         biw.webdriver_control.reuse = True
         biw.webdriver_control.reset()
 
-    @pytest.mark.parametrize('kind', ['phantomjs'])
+    @pytest.mark.parametrize('kind', ['firefox', 'chromium'])
     def test_create(self, kind) -> None:
         biw.webdriver_control.kind = kind
         assert biw.webdriver_control.kind == kind

--- a/tests/unit/bokeh/test_settings.py
+++ b/tests/unit/bokeh/test_settings.py
@@ -53,7 +53,6 @@ _expected_settings = (
     'minified',
     'nodejs_path',
     'perform_document_validation',
-    'phantomjs_path',
     'pretty',
     'py_log_level',
     'resources',

--- a/tests/unit/bokeh/util/test_dependencies.py
+++ b/tests/unit/bokeh/util/test_dependencies.py
@@ -25,24 +25,6 @@ import bokeh.util.dependencies as dep # isort:skip
 # General API
 #-----------------------------------------------------------------------------
 
-class Test_detect_phantomjs(object):
-
-    def test_detect_phantomjs_success(self) -> None:
-        assert dep.detect_phantomjs() is not None
-
-    def test_detect_phantomjs_bad_path(self, monkeypatch) -> None:
-        monkeypatch.setenv("BOKEH_PHANTOMJS_PATH", "bad_path")
-        with pytest.raises(RuntimeError):
-            dep.detect_phantomjs()
-
-    def test_detect_phantomjs_bad_version(self) -> None:
-        with pytest.raises(RuntimeError) as e:
-            dep.detect_phantomjs('10.1')
-        assert str(e.value).endswith("PhantomJS version to old. Version>=10.1 required, installed: 2.1.1")
-
-    def test_detect_phantomjs_default_required_version(self) -> None:
-        assert dep.detect_phantomjs.__defaults__ == ('2.1',)
-
 class Test_import_optional(object):
 
     def test_success(self) -> None:


### PR DESCRIPTION
This adds support for geckodriver/firefox and chromedriver/chromium, and removes support for obsolete phantomjs. The former pair is now the default, primarily because both geckodriver and firefox are available from conda-forge, so installation process is straightforward. The later pair can be used alternatively. I plan to add support for auto-detection of available drivers and headless browsers, and make bokeh use what's available, so that we don't force users to install new web browsers needlessly. Especially because there should be a viable browser available on modern systems. 