### PR TITLE
Officially support Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,12 @@ jobs:
       script: scripts/ci/test
       env:
       - GROUP=unit
+      - PYTHON=3.8
+
+    - install: scripts/ci/install.test
+      script: scripts/ci/test
+      env:
+      - GROUP=unit
       - PYTHON=3.7
 
     - install: scripts/ci/install.test

--- a/scripts/ci/install
+++ b/scripts/ci/install
@@ -32,6 +32,7 @@ conda install --yes --quiet ${CONDA_REQS}
 # set default conda channels
 conda config --set auto_update_conda off
 conda config --append channels bokeh
+conda config --append channels conda-forge
 conda config --get channels
 
 # create and activate test env

--- a/scripts/ci/test
+++ b/scripts/ci/test
@@ -10,7 +10,7 @@ if  [[ ! -z "${TRAVIS_TAG}" ]]; then
     exit 0
 fi
 
-[[ "$(python --version | cut -d' ' -f2)" == "${PYTHON:-3.7}"* ]]
+[[ "$(python --version |& cut -d' ' -f2)" == "${PYTHON:-3.7}"* ]]
 
 bokeh info
 

--- a/scripts/ci/test
+++ b/scripts/ci/test
@@ -10,6 +10,8 @@ if  [[ ! -z "${TRAVIS_TAG}" ]]; then
     exit 0
 fi
 
+[[ "$(python --version | cut -d' ' -f2)" == "${PYTHON:-3.7}"* ]]
+
 bokeh info
 
 bash "scripts/ci/test.${GROUP}"

--- a/scripts/deps.py
+++ b/scripts/deps.py
@@ -37,7 +37,7 @@ specs = [ spec for spec in specs if spec.split(" ")[0] != "python" ]
 
 # add double quotes to specs for windows, fixes #9065
 if "windows" in platform.platform().lower():
-    specs = ['"{}"'.format(spec) for spec in specs]
+    specs = [f'"{spec}"' for spec in specs]
 
 deps = ""
 deps += " ".join(specs)

--- a/scripts/deps.py
+++ b/scripts/deps.py
@@ -28,19 +28,19 @@ section = {
     "test"   : meta_src["test"]["requires"],
 }
 
-spec = []
+specs = []
 for name in sys.argv[1:]:
-    spec += section[name]
+    specs += section[name]
 
 # bare python unpins python version causing upgrade to latest
-if 'python' in spec: spec.remove('python')
+specs = [ spec for spec in specs if spec.split(" ")[0] != "python" ]
 
 # add double quotes to specs for windows, fixes #9065
 if "windows" in platform.platform().lower():
-    spec = ['"{}"'.format(s) for s in spec]
+    specs = ['"{}"'.format(spec) for spec in specs]
 
 deps = ""
-deps += " ".join(s for s in spec)
+deps += " ".join(specs)
 deps = deps.replace(' >=', '>=')  # conda syntax doesn't allow spaces b/w pkg name and version spec
 deps = deps.replace(' <', '<')
 deps = deps.replace(' [unix]', ' ')


### PR DESCRIPTION
Python 3.8 feedstock was finally merged. For now I just added support for unit testing on 3.8.