### PR TITLE
Resolve all dependencies of an extension

### DIFF
--- a/bokeh/embed/bundle.py
+++ b/bokeh/embed/bundle.py
@@ -191,6 +191,26 @@ def bundle_for_objs_and_resources(objs, resources):
 # Private API
 #-----------------------------------------------------------------------------
 
+def _query_extensions(objs, query):
+    names = set()
+
+    for obj in _all_objs(objs):
+        if hasattr(obj, "__implementation__"):
+            continue
+        name = obj.__view_module__.split(".")[0]
+        if name == "bokeh":
+            continue
+        if name in names:
+            continue
+        names.add(name)
+
+        for model in Model.model_class_reverse_map.values():
+            if model.__module__.startswith(name):
+                if query(model):
+                    return True
+
+    return False
+
 def _bundle_extensions(objs, resources):
     names = set()
     extensions = []
@@ -271,7 +291,7 @@ def _use_tables(objs):
 
     '''
     from ..models.widgets import TableWidget
-    return _any(objs, lambda obj: isinstance(obj, TableWidget))
+    return _any(objs, lambda obj: isinstance(obj, TableWidget)) or _ext_use_tables(objs)
 
 def _use_widgets(objs):
     ''' Whether a collection of Bokeh objects contains a any Widget
@@ -284,7 +304,15 @@ def _use_widgets(objs):
 
     '''
     from ..models.widgets import Widget
-    return _any(objs, lambda obj: isinstance(obj, Widget))
+    return _any(objs, lambda obj: isinstance(obj, Widget)) or _ext_use_widgets(objs)
+
+def _ext_use_tables(objs):
+    from ..models.widgets import TableWidget
+    return _query_extensions(objs, lambda cls: issubclass(cls, TableWidget))
+
+def _ext_use_widgets(objs):
+    from ..models.widgets import Widget
+    return _query_extensions(objs, lambda cls: issubclass(cls, Widget))
 
 #-----------------------------------------------------------------------------
 # Code


### PR DESCRIPTION
This is a quick fix that affects only new-style extensions. Proper solutions include allowing lazy module loading in bokehjs and redesign of resource management with extension (among other things) in mind, both which I intend to do for 2.0.

fixes #9343 
