### PR TITLE
9064 - static typing - bokeh.util.hex.py

### DIFF
--- a/bokeh/util/hex.py
+++ b/bokeh/util/hex.py
@@ -23,6 +23,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from typing import Tuple, Any
 
 # External imports
 import numpy as np
@@ -44,7 +45,7 @@ __all__ = (
 # General API
 #-----------------------------------------------------------------------------
 
-def axial_to_cartesian(q, r, size, orientation, aspect_scale=1):
+def axial_to_cartesian(q: Any, r: Any, size: float, orientation: str, aspect_scale: float = 1) -> Tuple[Any, Any]:
     ''' Map axial *(q,r)* coordinates to cartesian *(x,y)* coordinates of
     tiles centers.
 
@@ -95,7 +96,7 @@ def axial_to_cartesian(q, r, size, orientation, aspect_scale=1):
 
     return (x, y)
 
-def cartesian_to_axial(x, y, size, orientation, aspect_scale=1):
+def cartesian_to_axial(x: Any, y: Any, size: float, orientation: str, aspect_scale: float = 1) -> Tuple[Any, Any]:
     ''' Map Cartesion *(x,y)* points to axial *(q,r)* coordinates of enclosing
     tiles.
 
@@ -147,7 +148,7 @@ def cartesian_to_axial(x, y, size, orientation, aspect_scale=1):
 
     return _round_hex(q, r)
 
-def hexbin(x, y, size, orientation="pointytop", aspect_scale=1):
+def hexbin(x: Any, y: Any, size: float, orientation: str = "pointytop", aspect_scale: float = 1) -> Any:
     ''' Perform an equal-weight binning of data points into hexagonal tiles.
 
     For more sophisticated use cases, e.g. weighted binning or scaling
@@ -194,11 +195,12 @@ def hexbin(x, y, size, orientation="pointytop", aspect_scale=1):
         Hex binning only functions on linear scales, i.e. not on log plots.
 
     '''
-    pd = import_required('pandas','hexbin requires pandas to be installed')
+    pd: Any = import_required('pandas','hexbin requires pandas to be installed')
 
     q, r = cartesian_to_axial(x, y, size, orientation, aspect_scale=aspect_scale)
 
     df = pd.DataFrame(dict(r=r, q=q))
+
     return df.groupby(['q', 'r']).size().reset_index(name='counts')
 
 #-----------------------------------------------------------------------------
@@ -209,7 +211,7 @@ def hexbin(x, y, size, orientation="pointytop", aspect_scale=1):
 # Private API
 #-----------------------------------------------------------------------------
 
-def _round_hex(q, r):
+def _round_hex(q: Any, r: Any) -> Tuple[Any, Any]:
     ''' Round floating point axial hex coordinates to integer *(q,r)*
     coordinates.
 

--- a/bokeh/util/hex.py
+++ b/bokeh/util/hex.py
@@ -23,10 +23,14 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import Tuple, Any
+from typing import Any, Tuple, TYPE_CHECKING
+from typing_extensions import Literal
 
 # External imports
 import numpy as np
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 # Bokeh imports
 from .dependencies import import_required
@@ -41,11 +45,14 @@ __all__ = (
     'hexbin',
 )
 
+Orientation = Literal["pointytop", "flattop"]
+
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
 
-def axial_to_cartesian(q: Any, r: Any, size: float, orientation: str, aspect_scale: float = 1) -> Tuple[Any, Any]:
+def axial_to_cartesian(q: np.array[float], r: np.array[float], size: float,
+        orientation: Orientation, aspect_scale: float = 1) -> Tuple[np.array[int], np.array[int]]:
     ''' Map axial *(q,r)* coordinates to cartesian *(x,y)* coordinates of
     tiles centers.
 
@@ -71,8 +78,7 @@ def axial_to_cartesian(q: Any, r: Any, size: float, orientation: str, aspect_sca
             to a side corner for "flattop" orientation.
 
         orientation (str) :
-            Whether the hex tile orientation should be "pointytop" or
-            "flattop".
+            Whether the hex tile orientation should be "pointytop" or "flattop".
 
         aspect_scale (float, optional) :
             Scale the hexagons in the "cross" dimension.
@@ -96,7 +102,8 @@ def axial_to_cartesian(q: Any, r: Any, size: float, orientation: str, aspect_sca
 
     return (x, y)
 
-def cartesian_to_axial(x: Any, y: Any, size: float, orientation: str, aspect_scale: float = 1) -> Tuple[Any, Any]:
+def cartesian_to_axial(x: np.array[float], y: np.array[float], size: float,
+        orientation: Orientation, aspect_scale: float = 1) -> Tuple[np.array[int], np.array[int]]:
     ''' Map Cartesion *(x,y)* points to axial *(q,r)* coordinates of enclosing
     tiles.
 
@@ -119,8 +126,7 @@ def cartesian_to_axial(x: Any, y: Any, size: float, orientation: str, aspect_sca
             to a side corner for "flattop" orientation.
 
         orientation (str) :
-            Whether the hex tile orientation should be "pointytop" or
-            "flattop".
+            Whether the hex tile orientation should be "pointytop" or "flattop".
 
         aspect_scale (float, optional) :
             Scale the hexagons in the "cross" dimension.
@@ -148,7 +154,8 @@ def cartesian_to_axial(x: Any, y: Any, size: float, orientation: str, aspect_sca
 
     return _round_hex(q, r)
 
-def hexbin(x: Any, y: Any, size: float, orientation: str = "pointytop", aspect_scale: float = 1) -> Any:
+def hexbin(x: np.array[float], y: np.array[float], size: float,
+        orientation: Orientation = "pointytop", aspect_scale: float = 1) -> "pd.DataFrame":
     ''' Perform an equal-weight binning of data points into hexagonal tiles.
 
     For more sophisticated use cases, e.g. weighted binning or scaling
@@ -195,7 +202,7 @@ def hexbin(x: Any, y: Any, size: float, orientation: str = "pointytop", aspect_s
         Hex binning only functions on linear scales, i.e. not on log plots.
 
     '''
-    pd: Any = import_required('pandas','hexbin requires pandas to be installed')
+    pd: Any = import_required('pandas', 'hexbin requires pandas to be installed')
 
     q, r = cartesian_to_axial(x, y, size, orientation, aspect_scale=aspect_scale)
 
@@ -211,7 +218,7 @@ def hexbin(x: Any, y: Any, size: float, orientation: str = "pointytop", aspect_s
 # Private API
 #-----------------------------------------------------------------------------
 
-def _round_hex(q: Any, r: Any) -> Tuple[Any, Any]:
+def _round_hex(q: np.array[float], r: np.array[float]) -> Tuple[np.array[int], np.array[int]]:
     ''' Round floating point axial hex coordinates to integer *(q,r)*
     coordinates.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,3 +78,6 @@ ignore_errors = False
 
 [mypy-bokeh.util.deprecation]
 ignore_errors = False
+
+[mypy-bokeh.util.hex]
+ignore_errors = False


### PR DESCRIPTION
bokeh.util.hex.py: added mypy typing to function inputs and return values. A lot of "Any" due to no numpy type stubs

setup.cfg: reference the module for mypy testing

- [x] issues: addresses #9064
- [ ] tests added / passed
N/A - use mypy to test
- [ ] release document entry (if new feature or API change)
