### PR TITLE
Add missing typing_extensions dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ REQUIRES = [
     'pillow >=4.0',
     'packaging >=16.8',
     'tornado >=5',
+    'typing_extensions >=3.7.4',
 ]
 
 # if this is just conda-build skimming information, skip all this actual work


### PR DESCRIPTION
This is necessary to support some advanced types that were introduced after Python 3.6. This dependency was supposed to be added in an earlier PR, but somehow got removed. CI doesn't fail, because `mypy` incidentally installs this package as well.