### PR TITLE
Remove last Python 2 compatibility bits

### DIFF
--- a/bokeh/client/session.py
+++ b/bokeh/client/session.py
@@ -41,7 +41,6 @@ from ..document import Document
 from ..resources import _SessionCoordinates, DEFAULT_SERVER_HTTP_URL
 from ..util.browser import NEW_PARAM
 from ..util.session_id import generate_session_id
-from ..util.string import format_docstring
 from .util import server_url_for_websocket_url, websocket_url_for_server_url
 
 #-----------------------------------------------------------------------------
@@ -481,5 +480,3 @@ class ClientSession(object):
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
-
-__doc__ = format_docstring(__doc__)

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -849,7 +849,6 @@ class Serve(Subcommand):
 # Code
 #-----------------------------------------------------------------------------
 
-
 __doc__ = format_docstring(__doc__,
     DEFAULT_PORT=DEFAULT_SERVER_PORT,
     LOGLEVELS=nice_join(LOGLEVELS),

--- a/bokeh/embed/server.py
+++ b/bokeh/embed/server.py
@@ -27,7 +27,6 @@ from urllib.parse import quote_plus, urlparse
 from ..core.templates import AUTOLOAD_TAG, FILE
 from ..resources import DEFAULT_SERVER_HTTP_URL
 from ..util.serialization import make_id
-from ..util.string import format_docstring
 from .bundle import bundle_for_objs_and_resources
 from .elements import html_page_for_render_items
 from .util import RenderItem
@@ -47,7 +46,7 @@ __all__ = (
 #-----------------------------------------------------------------------------
 
 def server_document(url="default", relative_urls=False, resources="default", arguments=None):
-    ''' Return a script tag that embeds content from a Bokeh server.
+    f''' Return a script tag that embeds content from a Bokeh server.
 
     Bokeh apps embedded using these methods will NOT set the browser window title.
 
@@ -108,7 +107,7 @@ def server_document(url="default", relative_urls=False, resources="default", arg
     return tag
 
 def server_session(model=None, session_id=None, url="default", relative_urls=False, resources="default"):
-    ''' Return a script tag that embeds content from a specific existing session on
+    f''' Return a script tag that embeds content from a specific existing session on
     a Bokeh server.
 
     This function is typically only useful for serving from a a specific session
@@ -363,6 +362,3 @@ def _src_path(url, elementid):
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
-
-server_document.__doc__ = format_docstring(server_document.__doc__, DEFAULT_SERVER_HTTP_URL=DEFAULT_SERVER_HTTP_URL)
-server_session.__doc__ = format_docstring(server_session.__doc__, DEFAULT_SERVER_HTTP_URL=DEFAULT_SERVER_HTTP_URL)

--- a/bokeh/server/auth_provider.py
+++ b/bokeh/server/auth_provider.py
@@ -36,7 +36,6 @@ __all__ = (
 # General API
 #-----------------------------------------------------------------------------
 
-# TODO (bev) make this an ABC but wait until Bokeh 2 / drop Python 2.7
 class AuthProvider(object):
     ''' Abstract base class for implementing authorization hooks.
 

--- a/bokeh/server/django/__init__.py
+++ b/bokeh/server/django/__init__.py
@@ -1,13 +1,7 @@
-import six
-
-if six.PY2:
-    raise ImportError("bokeh.server.django requires Python 3.x")
-
 from bokeh.util.dependencies import import_required
 
 import_required("django", "django is required by bokeh.server.django")
-import_required("channels", "The package channels is required by bokeh.server.django. "
-                            "and must be installed'")
+import_required("channels", "The package channels is required by bokeh.server.django and must be installed")
 
 from .apps import DjangoBokehConfig
 default_app_config = "bokeh.server.django.DjangoBokehConfig"

--- a/bokeh/server/django/consumers.py
+++ b/bokeh/server/django/consumers.py
@@ -262,7 +262,7 @@ class WSConsumer(AsyncWebsocketConsumer, ConsumerHelper):
 # Private API
 #-----------------------------------------------------------------------------
 
-# TODO: remove this when Python 2.x is dropped
+# TODO: remove this when coroutines are dropped
 class AsyncServerConnection(ServerConnection):
 
     async def send_patch_document(self, event):

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -45,9 +45,6 @@ from .views.static_handler import StaticHandler
 # Globals and constants
 #-----------------------------------------------------------------------------
 
-# Unfortunately we can't yet use format_docstring to keep these automatically in sync in
-# the class docstring because Python 2 does not allow setting class.__doc__ (works with
-# Bokeh model classes because they are metaclasses)
 DEFAULT_CHECK_UNUSED_MS                  = 17000
 DEFAULT_KEEP_ALIVE_MS                    = 37000  # heroku, nginx default to 60s timeout, so use less than that
 DEFAULT_MEM_LOG_FREQ_MS                  = 0
@@ -64,7 +61,7 @@ __all__ = (
 #-----------------------------------------------------------------------------
 
 class BokehTornado(TornadoApplication):
-    ''' A Tornado Application used to implement the Bokeh Server.
+    f''' A Tornado Application used to implement the Bokeh Server.
 
     Args:
         applications (dict[str,Application] or Application) :
@@ -75,7 +72,7 @@ class BokehTornado(TornadoApplication):
 
             .. code-block:: python
 
-                applications = { '/' : applications }
+                applications = {{ '/' : applications }}
 
             When a connection comes in to a given path, the associate
             Application is used to generate a new document for the session.
@@ -119,23 +116,27 @@ class BokehTornado(TornadoApplication):
             (default: True)
 
         keep_alive_milliseconds (int, optional) :
-            Number of milliseconds between keep-alive pings (default: 37000)
+            Number of milliseconds between keep-alive pings
+            (default: {DEFAULT_KEEP_ALIVE_MS})
 
             Pings normally required to keep the websocket open. Set to 0 to
             disable pings.
 
         check_unused_sessions_milliseconds (int, optional) :
             Number of milliseconds between checking for unused sessions
-            (default: 17000)
+            (default: {DEFAULT_CHECK_UNUSED_MS})
 
         unused_session_lifetime_milliseconds (int, optional) :
-            Number of milliseconds for unused session lifetime (default: 15000)
+            Number of milliseconds for unused session lifetime
+            (default: {DEFAULT_UNUSED_LIFETIME_MS})
 
         stats_log_frequency_milliseconds (int, optional) :
-            Number of milliseconds between logging stats (default: 15000)
+            Number of milliseconds between logging stats
+            (default: {DEFAULT_STATS_LOG_FREQ_MS})
 
         mem_log_frequency_milliseconds (int, optional) :
-            Number of milliseconds between logging memory information (default: 0)
+            Number of milliseconds between logging memory information
+            (default: {DEFAULT_MEM_LOG_FREQ_MS})
 
             Enabling this feature requires the optional dependency ``psutil`` to be
             installed.
@@ -159,7 +160,7 @@ class BokehTornado(TornadoApplication):
 
         websocket_max_message_size_bytes (int, optional):
             Set the Tornado ``websocket_max_message_size`` value.
-            (default: 20*1024*1024)
+            (default: {DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES})
 
             NOTE: This setting has effect ONLY for Tornado>=4.5
 

--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -86,7 +86,6 @@ log = logging.getLogger(__name__)
 # Standard library imports
 from os import getenv
 from os.path import basename, dirname, join
-import re
 from uuid import uuid4
 
 # External imports
@@ -221,9 +220,6 @@ def setup(app):
 #-----------------------------------------------------------------------------
 
 def _process_script(source, filename, env, js_name, use_relative_paths=False):
-    # This is lame, but seems to be required for python 2
-    source = CODING.sub("", source)
-
     # Explicitly make sure old extensions are not included until a better
     # automatic mechanism is available
     Model._clear_extensions()
@@ -259,4 +255,3 @@ def _process_script(source, filename, env, js_name, use_relative_paths=False):
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
-CODING = re.compile(r"^# -\*- coding: (.*) -\*-$", re.M)

--- a/bokeh/util/dependencies.py
+++ b/bokeh/util/dependencies.py
@@ -104,11 +104,7 @@ def detect_phantomjs(version: str = '2.1') -> str:
     if settings.phantomjs_path() is not None:
         phantomjs_path = settings.phantomjs_path()
     else:
-        if hasattr(shutil, "which"):
-            phantomjs_path = shutil.which("phantomjs") or "phantomjs"
-        else:
-            # Python 2 relies on Environment variable in PATH - attempt to use as follows
-            phantomjs_path = "phantomjs"
+        phantomjs_path = shutil.which("phantomjs") or "phantomjs"
 
     try:
         proc = Popen([phantomjs_path, "--version"], stdout=PIPE, stderr=PIPE)

--- a/examples/app/gapminder/main.py
+++ b/examples/app/gapminder/main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pandas as pd
 
 from bokeh.io import curdoc

--- a/examples/app/stocks/main.py
+++ b/examples/app/stocks/main.py
@@ -18,19 +18,7 @@ at your command prompt. Then navigate to the URL
 .. _README: https://github.com/bokeh/bokeh/blob/master/examples/app/stocks/README.md
 
 '''
-try:
-    from functools import lru_cache
-except ImportError:
-    # Python 2 does stdlib does not have lru_cache so let's just
-    # create a dummy decorator to avoid crashing
-    print ("WARNING: Cache for this example is available on Python 3 only.")
-    def lru_cache():
-        def dec(f):
-            def _(*args, **kws):
-                return f(*args, **kws)
-            return _
-        return dec
-
+from functools import lru_cache
 from os.path import dirname, join
 
 import pandas as pd

--- a/examples/embed/arguments/bokeh_server.py
+++ b/examples/embed/arguments/bokeh_server.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 '''This example demonstrates embedding an autoloaded Bokeh server
 into a simple Flask application, and passing arguments to Bokeh.

--- a/examples/models/file/trail.py
+++ b/examples/models/file/trail.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from math import sin, cos, atan2, sqrt, radians
 
 import numpy as np

--- a/examples/plotting/file/histogram.py
+++ b/examples/plotting/file/histogram.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import numpy as np
 import scipy.special
 

--- a/examples/plotting/file/us_marriages_divorces_hover.py
+++ b/examples/plotting/file/us_marriages_divorces_hover.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 from bokeh.models import ColumnDataSource, NumeralTickFormatter, SingleIntervalTicker
 from bokeh.plotting import figure, show, output_file
 from bokeh.sampledata.us_marriages_divorces import data

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from bokeh import __version__
 
 # -- General configuration -----------------------------------------------------

--- a/tests/unit/bokeh/io/test_export.py
+++ b/tests/unit/bokeh/io/test_export.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #-----------------------------------------------------------------------------
 # Copyright (c) 2012 - 2019, Anaconda, Inc., and Bokeh Contributors.
 # All rights reserved.

--- a/tests/unit/bokeh/io/test_webdriver.py
+++ b/tests/unit/bokeh/io/test_webdriver.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #-----------------------------------------------------------------------------
 # Copyright (c) 2012 - 2019, Anaconda, Inc., and Bokeh Contributors.
 # All rights reserved.

--- a/tests/unit/bokeh/test_ext.py
+++ b/tests/unit/bokeh/test_ext.py
@@ -67,13 +67,11 @@ def test_ext_commands(tmpdir):
 # Private API
 #-----------------------------------------------------------------------------
 
-# TODO: restore when support for Python 2.x is removed
-#def _entries(path):
-#    return sorted(os.scandir(path), key=lambda entry: entry.name)
+def _entries(path):
+    return sorted(os.scandir(path), key=lambda entry: entry.name)
 
 def _names(path):
-    #return [ entry.name for entry in _entries(path) ]
-    return sorted(os.listdir(path))
+    return [ entry.name for entry in _entries(path) ]
 
 #-----------------------------------------------------------------------------
 # Code


### PR DESCRIPTION
Removing some last Python 2 bits. What remains to change is:

- `bokeh/colors/util.py`
    When Python2 support is dropped, this will no longer be necessary.
- `bokeh/server/auth_provider.py`
   TODO (bev) make this an ABC but wait until Bokeh 2 / drop Python 2.7

Those can be addressed in separate PRs, especially that I'm not sure what to do about both cases. I suppose use `Enum` in the former. However, the later is not a good candidate for using abstract classes, given the choice of implementation of different methods.

addresses #8666