### PR TITLE
Add PYI for bokeh.palettes

### DIFF
--- a/bokeh/palettes.pyi
+++ b/bokeh/palettes.pyi
@@ -1,0 +1,536 @@
+from typing import List, Dict
+
+Palette = List[str]
+PaletteCollection = Dict[int, Palette]
+PaletteMap = Dict[str, PaletteCollection]
+
+YlGn3: Palette
+YlGn4: Palette
+YlGn5: Palette
+YlGn6: Palette
+YlGn7: Palette
+YlGn8: Palette
+YlGn9: Palette
+
+YlGnBu3: Palette
+YlGnBu4: Palette
+YlGnBu5: Palette
+YlGnBu6: Palette
+YlGnBu7: Palette
+YlGnBu8: Palette
+YlGnBu9: Palette
+
+GnBu3: Palette
+GnBu4: Palette
+GnBu5: Palette
+GnBu6: Palette
+GnBu7: Palette
+GnBu8: Palette
+GnBu9: Palette
+
+BuGn3: Palette
+BuGn4: Palette
+BuGn5: Palette
+BuGn6: Palette
+BuGn7: Palette
+BuGn8: Palette
+BuGn9: Palette
+
+PuBuGn3: Palette
+PuBuGn4: Palette
+PuBuGn5: Palette
+PuBuGn6: Palette
+PuBuGn7: Palette
+PuBuGn8: Palette
+PuBuGn9: Palette
+
+PuBu3: Palette
+PuBu4: Palette
+PuBu5: Palette
+PuBu6: Palette
+PuBu7: Palette
+PuBu8: Palette
+PuBu9: Palette
+
+BuPu3: Palette
+BuPu4: Palette
+BuPu5: Palette
+BuPu6: Palette
+BuPu7: Palette
+BuPu8: Palette
+BuPu9: Palette
+
+RdPu3: Palette
+RdPu4: Palette
+RdPu5: Palette
+RdPu6: Palette
+RdPu7: Palette
+RdPu8: Palette
+RdPu9: Palette
+
+PuRd3: Palette
+PuRd4: Palette
+PuRd5: Palette
+PuRd6: Palette
+PuRd7: Palette
+PuRd8: Palette
+PuRd9: Palette
+
+OrRd3: Palette
+OrRd4: Palette
+OrRd5: Palette
+OrRd6: Palette
+OrRd7: Palette
+OrRd8: Palette
+OrRd9: Palette
+
+YlOrRd3: Palette
+YlOrRd4: Palette
+YlOrRd5: Palette
+YlOrRd6: Palette
+YlOrRd7: Palette
+YlOrRd8: Palette
+YlOrRd9: Palette
+
+YlOrBr3: Palette
+YlOrBr4: Palette
+YlOrBr5: Palette
+YlOrBr6: Palette
+YlOrBr7: Palette
+YlOrBr8: Palette
+YlOrBr9: Palette
+
+Purples3: Palette
+Purples4: Palette
+Purples5: Palette
+Purples6: Palette
+Purples7: Palette
+Purples8: Palette
+Purples9: Palette
+Purples256: Palette
+
+Blues3: Palette
+Blues4: Palette
+Blues5: Palette
+Blues6: Palette
+Blues7: Palette
+Blues8: Palette
+Blues9: Palette
+Blues256: Palette
+
+Greens3: Palette
+Greens4: Palette
+Greens5: Palette
+Greens6: Palette
+Greens7: Palette
+Greens8: Palette
+Greens9: Palette
+Greens256: Palette
+
+Oranges3: Palette
+Oranges4: Palette
+Oranges5: Palette
+Oranges6: Palette
+Oranges7: Palette
+Oranges8: Palette
+Oranges9: Palette
+Oranges256: Palette
+
+Reds3: Palette
+Reds4: Palette
+Reds5: Palette
+Reds6: Palette
+Reds7: Palette
+Reds8: Palette
+Reds9: Palette
+Reds256: Palette
+
+Greys3: Palette
+Greys4: Palette
+Greys5: Palette
+Greys6: Palette
+Greys7: Palette
+Greys8: Palette
+Greys9: Palette
+Greys10: Palette
+Greys11: Palette
+Greys256: Palette
+
+PuOr3: Palette
+PuOr4: Palette
+PuOr5: Palette
+PuOr6: Palette
+PuOr7: Palette
+PuOr8: Palette
+PuOr9: Palette
+PuOr10: Palette
+PuOr11: Palette
+
+BrBG3: Palette
+BrBG4: Palette
+BrBG5: Palette
+BrBG6: Palette
+BrBG7: Palette
+BrBG8: Palette
+BrBG9: Palette
+BrBG10: Palette
+BrBG11: Palette
+
+PRGn3: Palette
+PRGn4: Palette
+PRGn5: Palette
+PRGn6: Palette
+PRGn7: Palette
+PRGn8: Palette
+PRGn9: Palette
+PRGn10: Palette
+PRGn11: Palette
+
+PiYG3: Palette
+PiYG4: Palette
+PiYG5: Palette
+PiYG6: Palette
+PiYG7: Palette
+PiYG8: Palette
+PiYG9: Palette
+PiYG10: Palette
+PiYG11: Palette
+
+RdBu3: Palette
+RdBu4: Palette
+RdBu5: Palette
+RdBu6: Palette
+RdBu7: Palette
+RdBu8: Palette
+RdBu9: Palette
+RdBu10: Palette
+RdBu11: Palette
+
+RdGy3: Palette
+RdGy4: Palette
+RdGy5: Palette
+RdGy6: Palette
+RdGy7: Palette
+RdGy8: Palette
+RdGy9: Palette
+RdGy10: Palette
+RdGy11: Palette
+
+RdYlBu3: Palette
+RdYlBu4: Palette
+RdYlBu5: Palette
+RdYlBu6: Palette
+RdYlBu7: Palette
+RdYlBu8: Palette
+RdYlBu9: Palette
+RdYlBu10: Palette
+RdYlBu11: Palette
+
+Spectral3: Palette
+Spectral4: Palette
+Spectral5: Palette
+Spectral6: Palette
+Spectral7: Palette
+Spectral8: Palette
+Spectral9: Palette
+Spectral10: Palette
+Spectral11: Palette
+
+RdYlGn3: Palette
+RdYlGn4: Palette
+RdYlGn5: Palette
+RdYlGn6: Palette
+RdYlGn7: Palette
+RdYlGn8: Palette
+RdYlGn9: Palette
+RdYlGn10: Palette
+RdYlGn11: Palette
+
+# http://colorbrewer2.org/?type=qualitative&scheme=Accent&n=8
+Accent3: Palette
+Accent4: Palette
+Accent5: Palette
+Accent6: Palette
+Accent7: Palette
+Accent8: Palette
+
+# http://colorbrewer2.org/?type=qualitative&scheme=Dark2&n=8
+Dark2_3: Palette
+Dark2_4: Palette
+Dark2_5: Palette
+Dark2_6: Palette
+Dark2_7: Palette
+Dark2_8: Palette
+
+# http://colorbrewer2.org/?type=qualitative&scheme=Paired&n=12
+Paired3: Palette
+Paired4: Palette
+Paired5: Palette
+Paired6: Palette
+Paired7: Palette
+Paired8: Palette
+Paired9: Palette
+Paired10: Palette
+Paired11: Palette
+Paired12: Palette
+
+# http://colorbrewer2.org/?type=qualitative&scheme=Pastel1&n=9
+Pastel1_3: Palette
+Pastel1_4: Palette
+Pastel1_5: Palette
+Pastel1_6: Palette
+Pastel1_7: Palette
+Pastel1_8: Palette
+Pastel1_9: Palette
+
+# http://colorbrewer2.org/?type=qualitative&scheme=Pastel2&n=8
+Pastel2_3: Palette
+Pastel2_4: Palette
+Pastel2_5: Palette
+Pastel2_6: Palette
+Pastel2_7: Palette
+Pastel2_8: Palette
+
+# http://colorbrewer2.org/?type=qualitative&scheme=Set1&n=9
+Set1_3: Palette
+Set1_4: Palette
+Set1_5: Palette
+Set1_6: Palette
+Set1_7: Palette
+Set1_8: Palette
+Set1_9: Palette
+
+# http://colorbrewer2.org/?type=qualitative&scheme=Set2&n=8
+Set2_3: Palette
+Set2_4: Palette
+Set2_5: Palette
+Set2_6: Palette
+Set2_7: Palette
+Set2_8: Palette
+
+# http://colorbrewer2.org/?type=qualitative&scheme=Set3&n=12
+Set3_3: Palette
+Set3_4: Palette
+Set3_5: Palette
+Set3_6: Palette
+Set3_7: Palette
+Set3_8: Palette
+Set3_9: Palette
+Set3_10: Palette
+Set3_11: Palette
+Set3_12: Palette
+
+Inferno3: Palette
+Inferno4: Palette
+Inferno5: Palette
+Inferno6: Palette
+Inferno7: Palette
+Inferno8: Palette
+Inferno9: Palette
+Inferno10: Palette
+Inferno11: Palette
+Inferno256: Palette
+
+Magma3: Palette
+Magma4: Palette
+Magma5: Palette
+Magma6: Palette
+Magma7: Palette
+Magma8: Palette
+Magma9: Palette
+Magma10: Palette
+Magma11: Palette
+Magma256: Palette
+
+Plasma3: Palette
+Plasma4: Palette
+Plasma5: Palette
+Plasma6: Palette
+Plasma7: Palette
+Plasma8: Palette
+Plasma9: Palette
+Plasma10: Palette
+Plasma11: Palette
+Plasma256: Palette
+
+Viridis3: Palette
+Viridis4: Palette
+Viridis5: Palette
+Viridis6: Palette
+Viridis7: Palette
+Viridis8: Palette
+Viridis9: Palette
+Viridis10: Palette
+Viridis11: Palette
+Viridis256: Palette
+
+Cividis3: Palette
+Cividis4: Palette
+Cividis5: Palette
+Cividis6: Palette
+Cividis7: Palette
+Cividis8: Palette
+Cividis9: Palette
+Cividis10: Palette
+Cividis11: Palette
+Cividis256: Palette
+
+Turbo3: Palette
+Turbo4: Palette
+Turbo5: Palette
+Turbo6: Palette
+Turbo7: Palette
+Turbo8: Palette
+Turbo9: Palette
+Turbo10: Palette
+Turbo11: Palette
+Turbo256: Palette
+
+Category10_3: Palette
+Category10_4: Palette
+Category10_5: Palette
+Category10_6: Palette
+Category10_7: Palette
+Category10_8: Palette
+Category10_9: Palette
+Category10_10: Palette
+
+Category20_3: Palette
+Category20_4: Palette
+Category20_5: Palette
+Category20_6: Palette
+Category20_7: Palette
+Category20_8: Palette
+Category20_9: Palette
+Category20_10: Palette
+Category20_11: Palette
+Category20_12: Palette
+Category20_13: Palette
+Category20_14: Palette
+Category20_15: Palette
+Category20_16: Palette
+Category20_17: Palette
+Category20_18: Palette
+Category20_19: Palette
+Category20_20: Palette
+
+Category20b_3: Palette
+Category20b_4: Palette
+Category20b_5: Palette
+Category20b_6: Palette
+Category20b_7: Palette
+Category20b_8: Palette
+Category20b_9: Palette
+Category20b_10: Palette
+Category20b_11: Palette
+Category20b_12: Palette
+Category20b_13: Palette
+Category20b_14: Palette
+Category20b_15: Palette
+Category20b_16: Palette
+Category20b_17: Palette
+Category20b_18: Palette
+Category20b_19: Palette
+Category20b_20: Palette
+
+Category20c_3: Palette
+Category20c_4: Palette
+Category20c_5: Palette
+Category20c_6: Palette
+Category20c_7: Palette
+Category20c_8: Palette
+Category20c_9: Palette
+Category20c_10: Palette
+Category20c_11: Palette
+Category20c_12: Palette
+Category20c_13: Palette
+Category20c_14: Palette
+Category20c_15: Palette
+Category20c_16: Palette
+Category20c_17: Palette
+Category20c_18: Palette
+Category20c_19: Palette
+Category20c_20: Palette
+
+# colorblind friendly palette from http://jfly.iam.u-tokyo.ac.jp/color/
+Colorblind3: Palette
+Colorblind4: Palette
+Colorblind5: Palette
+Colorblind6: Palette
+Colorblind7: Palette
+Colorblind8: Palette
+
+YlGn: PaletteCollection
+YlGnBu: PaletteCollection
+GnBu: PaletteCollection
+BuGn: PaletteCollection
+PuBuGn: PaletteCollection
+PuBu: PaletteCollection
+BuPu: PaletteCollection
+RdPu: PaletteCollection
+PuRd: PaletteCollection
+OrRd: PaletteCollection
+YlOrRd: PaletteCollection
+YlOrBr: PaletteCollection
+Purples: PaletteCollection
+Blues: PaletteCollection
+Greens: PaletteCollection
+Oranges: PaletteCollection
+Reds: PaletteCollection
+Greys: PaletteCollection
+PuOr: PaletteCollection
+BrBG: PaletteCollection
+PRGn: PaletteCollection
+PiYG: PaletteCollection
+RdBu: PaletteCollection
+RdGy: PaletteCollection
+RdYlBu: PaletteCollection
+Spectral: PaletteCollection
+RdYlGn: PaletteCollection
+Accent: PaletteCollection
+Dark2: PaletteCollection
+Paired: PaletteCollection
+Pastel1: PaletteCollection
+Pastel2: PaletteCollection
+Set1: PaletteCollection
+Set2: PaletteCollection
+Set3: PaletteCollection
+Magma: PaletteCollection
+Inferno: PaletteCollection
+Plasma: PaletteCollection
+Viridis: PaletteCollection
+Cividis: PaletteCollection
+Turbo: PaletteCollection
+Category10: PaletteCollection
+Category20: PaletteCollection
+Category20b: PaletteCollection
+Category20c: PaletteCollection
+Colorblind: PaletteCollection
+
+brewer: PaletteMap
+d3: PaletteMap
+mpl: PaletteMap
+colorblind: PaletteMap
+all_palettes: PaletteMap
+small_palettes: PaletteMap
+
+def linear_palette(palette: Palette, n: int) -> Palette:
+    ...
+def diverging_palette(palette1: Palette, palette2: Palette, n: int, midpoint: float) -> Palette:
+    ...
+def magma(n: int) -> Palette:
+    ...
+def inferno(n: int) -> Palette:
+    ...
+def plasma(n: int) -> Palette:
+    ...
+def viridis(n: int) -> Palette:
+    ...
+def cividis(n: int) -> Palette:
+    ...
+def turbo(n: int) -> Palette:
+    ...
+def grey(n: int) -> Palette:
+    ...
+def gray(n: int) -> Palette:
+    ...


### PR DESCRIPTION
This is counter proposal to PR #9383. This allows to help IDEs to understand the module hack that `bokeh.palettes` uses. This allows to us to keep mutable data structures with copy on access. I tested this in vscode (with vscode-python extension) and pycharm (community edition), and both are able to resolve all palettes, collections, etc. with correct type information.

fixes #9248 
