### PR TITLE
Include step in the list of glyphs that HoverTool does not work with

### DIFF
--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -965,6 +965,7 @@ class HoverTool(Inspection):
             * patch
             * quadratic
             * ray
+            * step
             * text
 
     .. |hover_icon| image:: /_images/icons/Hover.png


### PR DESCRIPTION
Small change to documentation to reflect that issue #7419 is still open