### PR TITLE
Replace metaclasses with `__init_subclass__`

### DIFF
--- a/bokeh/core/has_props.py
+++ b/bokeh/core/has_props.py
@@ -27,7 +27,6 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import difflib
-import inspect
 from warnings import warn
 
 # External imports
@@ -201,7 +200,7 @@ def accumulate_from_superclasses(cls, propname):
     # classes, and the cache must be separate for each class
     if cachename not in cls.__dict__:
         s = set()
-        for c in inspect.getmro(cls):
+        for c in cls.__mro__:
             if issubclass(c, HasProps) and hasattr(c, propname):
                 base = getattr(c, propname)
                 s.update(base)
@@ -224,7 +223,7 @@ def accumulate_dict_from_superclasses(cls, propname):
     # classes, and the cache must be separate for each class
     if cachename not in cls.__dict__:
         d = dict()
-        for c in inspect.getmro(cls):
+        for c in cls.__mro__:
             if issubclass(c, HasProps) and hasattr(c, propname):
                 base = getattr(c, propname)
                 for k,v in base.items():

--- a/bokeh/sphinxext/bokeh_model.py
+++ b/bokeh/sphinxext/bokeh_model.py
@@ -62,7 +62,7 @@ from docutils.parsers.rst.directives import unchanged
 from sphinx.errors import SphinxError
 
 # Bokeh imports
-from ..model import MetaModel
+from ..model import Model
 from ..util.warnings import BokehDeprecationWarning
 from .bokeh_directive import BokehDirective, py_sig_re
 from .templates import MODEL_DETAIL
@@ -112,8 +112,8 @@ class BokehModelDirective(BokehDirective):
         if model is None:
             raise SphinxError("Unable to generate reference docs for %s, no model '%s' in %s" % (model_name, model_name, module_name))
 
-        if type(model) != MetaModel:
-            raise SphinxError("Unable to generate reference docs for %s, model '%s' is not of type MetaModel" % (model_name, model_name))
+        if not issubclass(model, Model):
+            raise SphinxError("Unable to generate reference docs for %s, model '%s' is a subclass of Model" % (model_name, model_name))
 
         # We may need to instantiate deprecated objects as part of documenting
         # them in the reference guide. Suppress any warnings here to keep the

--- a/bokehjs/test/model.ts
+++ b/bokehjs/test/model.ts
@@ -23,7 +23,7 @@ class SomeModel extends Model {
 describe("Model objects", () => {
 
   describe("default creation", () => {
-    const m = new Model()
+    const m = new SomeModel()
 
     it("should have null name", () => {
       expect(m.name).to.be.null

--- a/scripts/spec.py
+++ b/scripts/spec.py
@@ -10,7 +10,7 @@ def _proto(obj, defaults=False):
     return json.dumps(obj.to_json(defaults), sort_keys=True, indent=None)
 
 data = {}
-for name, m in sorted(Model.__class__.model_class_reverse_map.items()):
+for name, m in sorted(Model.model_class_reverse_map.items()):
     item = {
         'name'  : name,
         'bases' : [base.__module__ + '.' + base.__name__ for base in m.__bases__],

--- a/sphinx/source/docs/reference/model.rst
+++ b/sphinx/source/docs/reference/model.rst
@@ -9,7 +9,7 @@ bokeh.model
 .. automodule:: bokeh.model
   :members:
 
-    .. autoclass: MetaModel
+    .. autoclass: Model
 
         .. autodata:: model_class_reverse_map
             :annotation: = {}

--- a/tests/unit/bokeh/embed/test_util__embed.py
+++ b/tests/unit/bokeh/embed/test_util__embed.py
@@ -44,7 +44,10 @@ def test_plot():
     test_plot.circle([1, 2], [2, 3])
     return test_plot
 
-class SomeModelInTestObjects(Model):
+class SomeModel(Model):
+    some = Int
+
+class OtherModel(Model):
     child = Instance(Model)
 
 # Taken from test_callback_manager.py
@@ -115,7 +118,7 @@ class Test_OutputDocumentFor_general(object):
         assert str(e.value).endswith(_ODFERR)
 
     def test_error_on_mixed_list(self):
-        p = Model()
+        p = SomeModel()
         d = Document()
         orig_theme = d.theme
         with pytest.raises(ValueError) as e:
@@ -133,8 +136,8 @@ class Test_OutputDocumentFor_general(object):
 
     def test_with_doc_in_child_raises_error(self):
         doc = Document()
-        p1 = Model()
-        p2 = SomeModelInTestObjects(child=Model())
+        p1 = SomeModel()
+        p2 = OtherModel(child=SomeModel())
         doc.add_root(p2.child)
         assert p1.document is None
         assert p2.document is None
@@ -161,7 +164,7 @@ class Test_OutputDocumentFor_default_apply_theme(object):
 
     def test_single_model_with_document(self):
         # should use existing doc in with-block
-        p = Model()
+        p = SomeModel()
         d = Document()
         orig_theme = d.theme
         d.add_root(p)
@@ -172,7 +175,7 @@ class Test_OutputDocumentFor_default_apply_theme(object):
         assert d.theme is orig_theme
 
     def test_single_model_with_no_document(self):
-        p = Model()
+        p = SomeModel()
         assert p.document is None
         with beu.OutputDocumentFor([p]):
             assert p.document is not None
@@ -180,8 +183,8 @@ class Test_OutputDocumentFor_default_apply_theme(object):
 
     def test_list_of_model_with_no_documents(self):
         # should create new (permanent) doc for inputs
-        p1 = Model()
-        p2 = Model()
+        p1 = SomeModel()
+        p2 = SomeModel()
         assert p1.document is None
         assert p2.document is None
         with beu.OutputDocumentFor([p1, p2]):
@@ -196,8 +199,8 @@ class Test_OutputDocumentFor_default_apply_theme(object):
 
     def test_list_of_model_same_as_roots(self):
         # should use existing doc in with-block
-        p1 = Model()
-        p2 = Model()
+        p1 = SomeModel()
+        p2 = SomeModel()
         d = Document()
         orig_theme = d.theme
         d.add_root(p1)
@@ -212,8 +215,8 @@ class Test_OutputDocumentFor_default_apply_theme(object):
 
     def test_list_of_model_same_as_roots_with_always_new(self):
         # should use new temp doc for everything inside with-block
-        p1 = Model()
-        p2 = Model()
+        p1 = SomeModel()
+        p2 = SomeModel()
         d = Document()
         orig_theme = d.theme
         d.add_root(p1)
@@ -229,8 +232,8 @@ class Test_OutputDocumentFor_default_apply_theme(object):
 
     def test_list_of_model_subset_roots(self):
         # should use new temp doc for subset inside with-block
-        p1 = Model()
-        p2 = Model()
+        p1 = SomeModel()
+        p2 = SomeModel()
         d = Document()
         orig_theme = d.theme
         d.add_root(p1)
@@ -248,8 +251,8 @@ class Test_OutputDocumentFor_default_apply_theme(object):
         # should use new temp doc for eveything inside with-block
         d = Document()
         orig_theme = d.theme
-        p1 = Model()
-        p2 = Model()
+        p1 = SomeModel()
+        p2 = SomeModel()
         d.add_root(p2)
         assert p1.document is None
         assert p2.document is not None
@@ -268,7 +271,7 @@ class Test_OutputDocumentFor_custom_apply_theme(object):
 
     def test_single_model_with_document(self):
         # should use existing doc in with-block
-        p = Model()
+        p = SomeModel()
         d = Document()
         orig_theme = d.theme
         d.add_root(p)
@@ -279,7 +282,7 @@ class Test_OutputDocumentFor_custom_apply_theme(object):
         assert d.theme is orig_theme
 
     def test_single_model_with_no_document(self):
-        p = Model()
+        p = SomeModel()
         assert p.document is None
         with beu.OutputDocumentFor([p], apply_theme=Theme(json={})):
             assert p.document is not None
@@ -289,8 +292,8 @@ class Test_OutputDocumentFor_custom_apply_theme(object):
 
     def test_list_of_model_with_no_documents(self):
         # should create new (permanent) doc for inputs
-        p1 = Model()
-        p2 = Model()
+        p1 = SomeModel()
+        p2 = SomeModel()
         assert p1.document is None
         assert p2.document is None
         with beu.OutputDocumentFor([p1, p2], apply_theme=Theme(json={})):
@@ -307,8 +310,8 @@ class Test_OutputDocumentFor_custom_apply_theme(object):
 
     def test_list_of_model_same_as_roots(self):
         # should use existing doc in with-block
-        p1 = Model()
-        p2 = Model()
+        p1 = SomeModel()
+        p2 = SomeModel()
         d = Document()
         orig_theme = d.theme
         d.add_root(p1)
@@ -323,8 +326,8 @@ class Test_OutputDocumentFor_custom_apply_theme(object):
 
     def test_list_of_model_same_as_roots_with_always_new(self):
         # should use new temp doc for everything inside with-block
-        p1 = Model()
-        p2 = Model()
+        p1 = SomeModel()
+        p2 = SomeModel()
         d = Document()
         orig_theme = d.theme
         d.add_root(p1)
@@ -340,8 +343,8 @@ class Test_OutputDocumentFor_custom_apply_theme(object):
 
     def test_list_of_model_subset_roots(self):
         # should use new temp doc for subset inside with-block
-        p1 = Model()
-        p2 = Model()
+        p1 = SomeModel()
+        p2 = SomeModel()
         d = Document()
         orig_theme = d.theme
         d.add_root(p1)
@@ -359,8 +362,8 @@ class Test_OutputDocumentFor_custom_apply_theme(object):
         # should use new temp doc for eveything inside with-block
         d = Document()
         orig_theme = d.theme
-        p1 = Model()
-        p2 = Model()
+        p1 = SomeModel()
+        p2 = SomeModel()
         d.add_root(p2)
         assert p1.document is None
         assert p2.document is not None
@@ -386,7 +389,7 @@ class Test_OutputDocumentFor_FromCurdoc_apply_theme(object):
 
     def test_single_model_with_document(self):
         # should use existing doc in with-block
-        p = Model()
+        p = SomeModel()
         d = Document()
         orig_theme = d.theme
         d.add_root(p)
@@ -397,7 +400,7 @@ class Test_OutputDocumentFor_FromCurdoc_apply_theme(object):
         assert d.theme is orig_theme
 
     def test_single_model_with_no_document(self):
-        p = Model()
+        p = SomeModel()
         assert p.document is None
         with beu.OutputDocumentFor([p], apply_theme=beu.FromCurdoc):
             assert p.document is not None
@@ -408,8 +411,8 @@ class Test_OutputDocumentFor_FromCurdoc_apply_theme(object):
 
     def test_list_of_model_with_no_documents(self):
         # should create new (permanent) doc for inputs
-        p1 = Model()
-        p2 = Model()
+        p1 = SomeModel()
+        p2 = SomeModel()
         assert p1.document is None
         assert p2.document is None
         with beu.OutputDocumentFor([p1, p2], apply_theme=beu.FromCurdoc):
@@ -426,8 +429,8 @@ class Test_OutputDocumentFor_FromCurdoc_apply_theme(object):
 
     def test_list_of_model_same_as_roots(self):
         # should use existing doc in with-block
-        p1 = Model()
-        p2 = Model()
+        p1 = SomeModel()
+        p2 = SomeModel()
         d = Document()
         orig_theme = d.theme
         d.add_root(p1)
@@ -442,8 +445,8 @@ class Test_OutputDocumentFor_FromCurdoc_apply_theme(object):
 
     def test_list_of_model_same_as_roots_with_always_new(self):
         # should use new temp doc for everything inside with-block
-        p1 = Model()
-        p2 = Model()
+        p1 = SomeModel()
+        p2 = SomeModel()
         d = Document()
         orig_theme = d.theme
         d.add_root(p1)
@@ -459,8 +462,8 @@ class Test_OutputDocumentFor_FromCurdoc_apply_theme(object):
 
     def test_list_of_model_subset_roots(self):
         # should use new temp doc for subset inside with-block
-        p1 = Model()
-        p2 = Model()
+        p1 = SomeModel()
+        p2 = SomeModel()
         d = Document()
         orig_theme = d.theme
         d.add_root(p1)
@@ -478,8 +481,8 @@ class Test_OutputDocumentFor_FromCurdoc_apply_theme(object):
         # should use new temp doc for eveything inside with-block
         d = Document()
         orig_theme = d.theme
-        p1 = Model()
-        p2 = Model()
+        p1 = SomeModel()
+        p2 = SomeModel()
         d.add_root(p2)
         assert p1.document is None
         assert p2.document is not None
@@ -497,7 +500,7 @@ class Test_OutputDocumentFor_FromCurdoc_apply_theme(object):
 class Test_standalone_docs_json_and_render_items(object):
 
     def test_passing_model(self):
-        p1 = Model()
+        p1 = SomeModel()
         d = Document()
         d.add_root(p1)
         docs_json, render_items = beu.standalone_docs_json_and_render_items([p1])
@@ -506,11 +509,11 @@ class Test_standalone_docs_json_and_render_items(object):
         assert doc['version'] == __version__
         assert len(doc['roots']['root_ids']) == 1
         assert len(doc['roots']['references']) == 1
-        assert doc['roots']['references'] == [{'attributes': {}, 'id': str(p1.id), 'type': 'Model'}]
+        assert doc['roots']['references'] == [{'attributes': {}, 'id': str(p1.id), 'type': 'test_util__embed.SomeModel'}]
         assert len(render_items) == 1
 
     def test_passing_doc(self):
-        p1 = Model()
+        p1 = SomeModel()
         d = Document()
         d.add_root(p1)
         docs_json, render_items = beu.standalone_docs_json_and_render_items([d])
@@ -519,11 +522,11 @@ class Test_standalone_docs_json_and_render_items(object):
         assert doc['version'] == __version__
         assert len(doc['roots']['root_ids']) == 1
         assert len(doc['roots']['references']) == 1
-        assert doc['roots']['references'] == [{'attributes': {}, 'id': str(p1.id), 'type': 'Model'}]
+        assert doc['roots']['references'] == [{'attributes': {}, 'id': str(p1.id), 'type': 'test_util__embed.SomeModel'}]
         assert len(render_items) == 1
 
     def test_exception_for_missing_doc(self):
-        p1 = Model()
+        p1 = SomeModel()
         with pytest.raises(ValueError) as e:
             beu.standalone_docs_json_and_render_items([p1])
         assert str(e.value) == "A Bokeh Model must be part of a Document to render as standalone content"
@@ -578,8 +581,8 @@ class Test_standalone_docs_json(object):
 
     @patch('bokeh.embed.util.standalone_docs_json_and_render_items')
     def test_delgation(self, mock_sdjari):
-        p1 = Model()
-        p2 = Model()
+        p1 = SomeModel()
+        p2 = SomeModel()
         d = Document()
         d.add_root(p1)
         d.add_root(p2)
@@ -592,8 +595,8 @@ class Test_standalone_docs_json(object):
         mock_sdjari.assert_called_once_with([p1, p2])
 
     def test_output(self):
-        p1 = Model()
-        p2 = Model()
+        p1 = SomeModel()
+        p2 = SomeModel()
         d = Document()
         d.add_root(p1)
         d.add_root(p2)
@@ -608,16 +611,16 @@ class Test_standalone_docs_json(object):
 class Test__create_temp_doc(object):
 
     def test_no_docs(self):
-        p1 = Model()
-        p2 = Model()
+        p1 = SomeModel()
+        p2 = SomeModel()
         beu._create_temp_doc([p1, p2])
         assert isinstance(p1.document, Document)
         assert isinstance(p2.document, Document)
 
     def test_top_level_same_doc(self):
         d = Document()
-        p1 = Model()
-        p2 = Model()
+        p1 = SomeModel()
+        p2 = SomeModel()
         d.add_root(p1)
         d.add_root(p2)
         beu._create_temp_doc([p1, p2])
@@ -631,8 +634,8 @@ class Test__create_temp_doc(object):
     def test_top_level_different_doc(self):
         d1 = Document()
         d2 = Document()
-        p1 = Model()
-        p2 = Model()
+        p1 = SomeModel()
+        p2 = SomeModel()
         d1.add_root(p1)
         d2.add_root(p2)
         beu._create_temp_doc([p1, p2])
@@ -645,8 +648,8 @@ class Test__create_temp_doc(object):
 
     def test_child_docs(self):
         d = Document()
-        p1 = Model()
-        p2 = SomeModelInTestObjects(child=Model())
+        p1 = SomeModel()
+        p2 = OtherModel(child=SomeModel())
         d.add_root(p2.child)
         beu._create_temp_doc([p1, p2])
 
@@ -663,8 +666,8 @@ class Test__create_temp_doc(object):
 class Test__dispose_temp_doc(object):
 
     def test_no_docs(self):
-        p1 = Model()
-        p2 = Model()
+        p1 = SomeModel()
+        p2 = SomeModel()
         beu._dispose_temp_doc([p1, p2])
         assert p1.document is None
         assert p2.document is None
@@ -672,9 +675,9 @@ class Test__dispose_temp_doc(object):
     def test_with_docs(self):
         d1 = Document()
         d2 = Document()
-        p1 = Model()
+        p1 = SomeModel()
         d1.add_root(p1)
-        p2 = SomeModelInTestObjects(child=Model())
+        p2 = OtherModel(child=SomeModel())
         d2.add_root(p2.child)
         beu._create_temp_doc([p1, p2])
         beu._dispose_temp_doc([p1, p2])
@@ -683,8 +686,8 @@ class Test__dispose_temp_doc(object):
         assert p2.child.document is d2
 
     def test_with_temp_docs(self):
-        p1 = Model()
-        p2 = Model()
+        p1 = SomeModel()
+        p2 = SomeModel()
         beu._create_temp_doc([p1, p2])
         beu._dispose_temp_doc([p1, p2])
         assert p1.document is None

--- a/tests/unit/bokeh/test_model.py
+++ b/tests/unit/bokeh/test_model.py
@@ -131,7 +131,7 @@ from bokeh.models import * # NOQA
 from bokeh.plotting import * # NOQA
 def test_all_builtin_models_default_constructible():
     bad = []
-    for name, cls in Model.__class__.model_class_reverse_map.items():
+    for name, cls in Model.model_class_reverse_map.items():
         try:
             cls()
         except:

--- a/tests/unit/bokeh/test_resources.py
+++ b/tests/unit/bokeh/test_resources.py
@@ -253,7 +253,7 @@ class TestResources(object):
 
 def test_external_js_and_css_resource_embedding():
     """ This test method has to be at the end of the test modules because
-    subclassing a Model causes the CustomModel to be added as a MetaModel and
+    subclassing a Model causes the CustomModel to be added as a Model and
     messes up the Resources state for the other tests.
     """
 

--- a/tests/unit/bokeh/test_themes.py
+++ b/tests/unit/bokeh/test_themes.py
@@ -37,6 +37,9 @@ from bokeh.themes import Theme, built_in_themes, DARK_MINIMAL, LIGHT_MINIMAL
 # General API
 #-----------------------------------------------------------------------------
 
+class SomeModel(Model):
+    some = Int
+
 class ThemedModel(Model):
     number = Int(42)
     string = String("hello")
@@ -273,28 +276,28 @@ class TestThemes(object):
         assert 0 == len(doc.theme._line_defaults)
 
     def test_setting_built_in_theme_obj(self):
-        obj = Model()
+        obj = SomeModel()
         doc = Document()
         doc.add_root(obj)
         doc.theme = built_in_themes[LIGHT_MINIMAL]
         assert "#5B5B5B" == doc.theme._json['attrs']['ColorBar']['title_text_color']
 
     def test_setting_built_in_theme_str(self):
-        obj = Model()
+        obj = SomeModel()
         doc = Document()
         doc.add_root(obj)
         doc.theme = DARK_MINIMAL
         assert "#20262B" == doc.theme._json['attrs']['Figure']['background_fill_color']
 
     def test_setting_built_in_theme_missing(self):
-        obj = Model()
+        obj = SomeModel()
         doc = Document()
         doc.add_root(obj)
         with pytest.raises(ValueError):
             doc.theme = 'some_theme_i_guess'
 
     def test_setting_built_in_theme_error(self):
-        obj = Model()
+        obj = SomeModel()
         doc = Document()
         doc.add_root(obj)
         with pytest.raises(ValueError):


### PR DESCRIPTION
This PR drops `_MetaEvent` and `MetaModel`. I will work on `HasPropsMeta` separately as it's a bigger chunk of work.

addresses #8666