### PR TITLE
9064 bokeh.command typing

### DIFF
--- a/bokeh/command/bootstrap.py
+++ b/bokeh/command/bootstrap.py
@@ -43,6 +43,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import sys
 import argparse
+from typing import Any, Optional, Sequence, Tuple
 
 # External imports
 
@@ -53,6 +54,7 @@ from bokeh.settings import settings
 
 from .util import die
 from . import subcommands
+from .subcommand import Subcommand
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -65,8 +67,8 @@ __all__ = (
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
-
-def main(argv):
+# TODO - struggling to resolve argv mypy typing. is nested tuple of ((arg_name, arg_dict), ...) not Sequence[str]
+def main(argv) -> None:
     ''' Execute the Bokeh command.
 
     Args:
@@ -90,7 +92,7 @@ def main(argv):
 
     '''
     if len(argv) == 1:
-        die("ERROR: Must specify subcommand, one of: %s" % nice_join(x.name for x in subcommands.all))
+        die("ERROR: Must specify subcommand, one of: %s" % nice_join([x.name for x in subcommands.all]))
 
     parser = argparse.ArgumentParser(
         prog=argv[0],

--- a/bokeh/command/subcommand.py
+++ b/bokeh/command/subcommand.py
@@ -21,6 +21,8 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from abc import ABCMeta, abstractmethod
+from argparse import ArgumentParser, Namespace
+from typing import Union
 
 # External imports
 
@@ -92,7 +94,11 @@ class Subcommand(metaclass=ABCMeta):
 
     '''
 
-    def __init__(self, parser):
+    # initialize empty placeholder class attributes for static typing purposes
+    name: str = ""
+    help: str = ""
+
+    def __init__(self, parser: ArgumentParser) -> None:
         ''' Initialize the subcommand with its parser
 
         Args:
@@ -113,13 +119,18 @@ class Subcommand(metaclass=ABCMeta):
             self.parser.add_argument(*flags, **arg[1])
 
     @abstractmethod
-    def invoke(self, args):
+    def invoke(self, args: Namespace) -> Union[bool, None]:
         ''' Takes over main program flow to perform the subcommand.
 
         *This method must be implemented by subclasses.*
+        subclassed overwritten methods return different types:
+        bool: Build
+        None: FileOutput (subclassed by HTML, SVG and JSON. PNG overwrites FileOutput.invoke method), Info, Init, \
+                Sampledata, Secret, Serve, Static
+
 
         Args:
-            args (seq) : command line arguments for the subcommand to parse
+            args (argparse.Namespace) : command line arguments for the subcommand to parse
 
         Raises:
             NotImplementedError

--- a/bokeh/command/subcommands/__init__.py
+++ b/bokeh/command/subcommands/__init__.py
@@ -19,8 +19,14 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from typing import List, Type, TYPE_CHECKING
 
 # External imports
+# necessary workaround to perform import only when running mypy typechecking
+# see https://mypy.readthedocs.io/en/latest/common_issues.html#import-cycles
+if TYPE_CHECKING:
+    from ..subcommand import Subcommand
+
 
 # Bokeh imports
 
@@ -44,12 +50,12 @@ __all__ = (
 # Private API
 #-----------------------------------------------------------------------------
 
-def _collect():
+def _collect() -> List[Type[Subcommand]]:
     from importlib import import_module
     from os import listdir
     from os.path import dirname
     from ..subcommand import Subcommand
-
+    # reference type by module as fully
     results = []
 
     for file in listdir(dirname(__file__)):
@@ -63,6 +69,9 @@ def _collect():
         for name in dir(mod):
             attr = getattr(mod, name)
             if isinstance(attr, type) and issubclass(attr, Subcommand):
+                # TODO - typing added empty string "name" attribute to Subcommand, below check may now fail
+                # could instead use below commented if-check
+                # if attr: continue  # use truthy value of non-empty string
                 if not hasattr(attr, 'name'): continue # excludes abstract bases
                 results.append(attr)
 

--- a/bokeh/command/subcommands/build.py
+++ b/bokeh/command/subcommands/build.py
@@ -17,6 +17,8 @@
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from argparse import Namespace
+from typing import Sequence
 
 # External imports
 
@@ -64,7 +66,7 @@ class Build(Subcommand):
         )),
     )
 
-    def invoke(self, args):
+    def invoke(self, args: Namespace) -> bool:
         return build(args.base_dir, rebuild=args.rebuild, debug=args.debug)
 
 #-----------------------------------------------------------------------------

--- a/bokeh/command/subcommands/html.py
+++ b/bokeh/command/subcommands/html.py
@@ -67,6 +67,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from argparse import Namespace
 
 # External imports
 
@@ -75,6 +76,7 @@ from bokeh.resources import Resources
 from bokeh.embed import file_html
 
 from .file_output import FileOutputSubcommand
+from ...document import Document
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -113,7 +115,7 @@ class HTML(FileOutputSubcommand):
 
     ) + FileOutputSubcommand.other_args()
 
-    def after_write_file(self, args, filename, doc):
+    def after_write_file(self, args: Namespace, filename: str, doc: Document) -> None:
         '''
 
         '''
@@ -121,7 +123,7 @@ class HTML(FileOutputSubcommand):
             from bokeh.util.browser import view
             view(filename)
 
-    def file_contents(self, args, doc):
+    def file_contents(self, args: Namespace, doc: Document) -> str:
         '''
 
         '''

--- a/bokeh/command/subcommands/info.py
+++ b/bokeh/command/subcommands/info.py
@@ -50,7 +50,9 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from argparse import Namespace
 import sys
+from typing import Any, Optional
 
 # External imports
 
@@ -74,10 +76,12 @@ __all__ = (
 # Private API
 #-----------------------------------------------------------------------------
 
-def _version(modname, attr):
+def _version(modname: str, attr: str) -> Optional[Any]:
     mod = import_optional(modname)
     if mod:
         return getattr(mod, attr)
+    else:  # explicit None return for mypy typing
+        return None
 
 #-----------------------------------------------------------------------------
 # General API
@@ -102,7 +106,7 @@ class Info(Subcommand):
 
     )
 
-    def invoke(self, args):
+    def invoke(self, args: Namespace) -> None:
         '''
 
         '''

--- a/bokeh/command/subcommands/init.py
+++ b/bokeh/command/subcommands/init.py
@@ -17,6 +17,7 @@
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from argparse import Namespace
 
 # External imports
 
@@ -68,9 +69,9 @@ class Init(Subcommand):
         )),
     )
 
-    def invoke(self, args):
+    def invoke(self, args: Namespace) -> bool:
         return init(args.base_dir, interactive=args.interactive,
-            bokehjs_version=args.bokehjs_version, debug=args.debug)
+                    bokehjs_version=args.bokehjs_version, debug=args.debug)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/command/subcommands/json.py
+++ b/bokeh/command/subcommands/json.py
@@ -46,11 +46,13 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from argparse import Namespace
 
 # External imports
 
 # Bokeh imports
 from .file_output import FileOutputSubcommand
+from ...document import Document
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -90,7 +92,7 @@ class JSON(FileOutputSubcommand):
 
     ) + FileOutputSubcommand.other_args()
 
-    def file_contents(self, args, doc):
+    def file_contents(self, args: Namespace, doc: Document) -> str:
         '''
 
         '''

--- a/bokeh/command/subcommands/png.py
+++ b/bokeh/command/subcommands/png.py
@@ -57,6 +57,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import io
 import sys
+from argparse import Namespace
 
 # External imports
 
@@ -64,6 +65,7 @@ import sys
 from ...io.export import get_screenshot_as_png, create_webdriver, terminate_webdriver
 from ..util import set_single_plot_width_height
 from .file_output import FileOutputSubcommand
+from ...document import Document
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -110,7 +112,7 @@ class PNG(FileOutputSubcommand):
 
     ) + FileOutputSubcommand.other_args()
 
-    def invoke(self, args):
+    def invoke(self, args: Namespace) -> None:
         '''
 
         '''
@@ -120,7 +122,7 @@ class PNG(FileOutputSubcommand):
         finally:
             terminate_webdriver(self.driver)
 
-    def write_file(self, args, filename, doc):
+    def write_file(self, args: Namespace, filename: str, doc: Document) -> None:
         '''
 
         '''
@@ -132,7 +134,7 @@ class PNG(FileOutputSubcommand):
                 f.write(contents)
         self.after_write_file(args, filename, doc)
 
-    def file_contents(self, args, doc):
+    def file_contents(self, args: Namespace, doc: Document) -> bytes:
         '''
 
         '''

--- a/bokeh/command/subcommands/sampledata.py
+++ b/bokeh/command/subcommands/sampledata.py
@@ -35,6 +35,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from argparse import Namespace
 
 # External imports
 
@@ -68,7 +69,7 @@ class Sampledata(Subcommand):
     args = (
     )
 
-    def invoke(self, args):
+    def invoke(self, args: Namespace) -> None:
         '''
 
         '''

--- a/bokeh/command/subcommands/secret.py
+++ b/bokeh/command/subcommands/secret.py
@@ -34,6 +34,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from argparse import Namespace
 
 # External imports
 
@@ -67,7 +68,7 @@ class Secret(Subcommand):
     args = (
     )
 
-    def invoke(self, args):
+    def invoke(self, args: Namespace) -> None:
         '''
 
         '''

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -412,6 +412,7 @@ import argparse
 from fnmatch import fnmatch
 import os
 from glob import glob
+from typing import List, Optional
 
 # External imports
 from tornado.autoreload import watch
@@ -455,7 +456,7 @@ base_serve_args = (
         metavar = 'LOG-LEVEL',
         action  = 'store',
         default = None,
-        choices = LOGLEVELS + (None,),
+        choices = LOGLEVELS + ("None", ),
         help    = "One of: %s" % nice_join(LOGLEVELS),
     )),
 
@@ -679,7 +680,7 @@ class Serve(Subcommand):
         )),
     )
 
-    def invoke(self, args):
+    def invoke(self, args: argparse.Namespace) -> None:
         '''
 
         '''
@@ -783,7 +784,7 @@ class Serve(Subcommand):
         server_kwargs['redirect_root'] = not args.disable_index_redirect
         server_kwargs['autoreload'] = args.dev is not None
 
-        def find_autoreload_targets(app_path):
+        def find_autoreload_targets(app_path: str) -> None:
             path = os.path.abspath(app_path)
             if not os.path.isdir(path):
                 return
@@ -796,7 +797,7 @@ class Serve(Subcommand):
                         log.info("Watching: " + os.path.join(path, name))
                         watch(os.path.join(path, name))
 
-        def add_optional_autoreload_files(file_list):
+        def add_optional_autoreload_files(file_list: List[str]) -> None:
             for filen in file_list:
                 if os.path.isdir(filen):
                     log.warning("Cannot watch directory " + filen)
@@ -820,7 +821,7 @@ class Serve(Subcommand):
             if args.show:
 
                 # we have to defer opening in browser until we start up the server
-                def show_callback():
+                def show_callback() -> None:
                     for route in applications.keys():
                         server.show(route)
 
@@ -849,8 +850,10 @@ class Serve(Subcommand):
 # Code
 #-----------------------------------------------------------------------------
 
-
-__doc__ = format_docstring(__doc__,
+# TODO - fails mypy typechecking with "error: Incompatible types in assignment (expression has type "Optional[str]", variable has type "str")"
+# __doc__ is str and format_docstring() expects Optional[str]
+__doc__ = format_docstring(
+    __doc__,
     DEFAULT_PORT=DEFAULT_SERVER_PORT,
     LOGLEVELS=nice_join(LOGLEVELS),
     SESSION_ID_MODES=nice_join(SESSION_ID_MODES),

--- a/bokeh/command/subcommands/static.py
+++ b/bokeh/command/subcommands/static.py
@@ -16,6 +16,8 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from argparse import Namespace
+from typing import Dict
 
 # External imports
 
@@ -26,7 +28,7 @@ from bokeh.settings import settings
 from ..subcommand import Subcommand
 from ..util import report_server_init_errors
 from .serve import base_serve_args
-
+from ...application import Application
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -50,7 +52,7 @@ class Static(Subcommand):
 
     args = base_serve_args
 
-    def invoke(self, args):
+    def invoke(self, args: Namespace) -> None:
         '''
 
         '''
@@ -72,7 +74,7 @@ class Static(Subcommand):
         # even if Tornado is not installed
         from bokeh.server.server import Server
 
-        applications = {}
+        applications: Dict[str, Application] = {}
 
         _allowed_keys = ['port', 'address']
         server_kwargs = { key: getattr(args, key) for key in _allowed_keys if getattr(args, key, None) is not None }

--- a/bokeh/command/subcommands/svg.py
+++ b/bokeh/command/subcommands/svg.py
@@ -58,6 +58,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import argparse
 import io
 
 # External imports
@@ -68,6 +69,7 @@ from ...io.export import get_svgs, create_webdriver, terminate_webdriver
 from ..util import set_single_plot_width_height
 
 from .file_output import FileOutputSubcommand
+from ...document import Document
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -114,7 +116,7 @@ class SVG(FileOutputSubcommand):
 
     ) + FileOutputSubcommand.other_args()
 
-    def invoke(self, args):
+    def invoke(self, args: argparse.Namespace) -> None:
         '''
 
         '''
@@ -124,7 +126,7 @@ class SVG(FileOutputSubcommand):
         finally:
             terminate_webdriver(self.driver)
 
-    def write_file(self, args, filename, doc):
+    def write_file(self, args: argparse.Namespace, filename: str, doc: Document) -> None:
         '''
 
         '''
@@ -142,7 +144,7 @@ class SVG(FileOutputSubcommand):
                     f.write(svg)
             self.after_write_file(args, filename, doc)
 
-    def file_contents(self, args, doc):
+    def file_contents(self, args: argparse.Namespace, doc: Document) -> bytes:
         '''
 
         '''

--- a/bokeh/command/util.py
+++ b/bokeh/command/util.py
@@ -22,13 +22,15 @@ import contextlib
 import errno
 import os
 import sys
+from typing import Any, Dict, Generator, Union, List, Sequence
 import warnings
 
 # External imports
 
 # Bokeh imports
 from bokeh.application import Application
-from bokeh.application.handlers import ScriptHandler, DirectoryHandler, NotebookHandler
+from bokeh.document import Document
+from bokeh.application.handlers import ScriptHandler, DirectoryHandler, NotebookHandler, Handler
 from bokeh.models.plots import Plot
 
 #-----------------------------------------------------------------------------
@@ -47,7 +49,7 @@ __all__ = (
 # General API
 #-----------------------------------------------------------------------------
 
-def die(message, status=1):
+def die(message: str, status: int = 1) -> None:
     ''' Print an error message and exit.
 
     This function will call ``sys.exit`` with the given ``status`` and the
@@ -72,7 +74,7 @@ call "bokeh serve" on the directory instead. For example:
 If this is not the case, renaming main.py will suppress this warning.
 """
 
-def build_single_handler_application(path, argv=None):
+def build_single_handler_application(path: str, argv: Sequence[str] = None) -> Application:
     ''' Return a Bokeh application built using a single handler for a script,
     notebook, or directory.
 
@@ -111,6 +113,7 @@ def build_single_handler_application(path, argv=None):
     '''
     argv = argv or []
     path = os.path.abspath(path)
+    handler: Handler
 
     # There are certainly race conditions here if the file/directory is deleted
     # in between the isdir/isfile tests and subsequent code. But it would be a
@@ -136,7 +139,7 @@ def build_single_handler_application(path, argv=None):
 
     return application
 
-def build_single_handler_applications(paths, argvs=None):
+def build_single_handler_applications(paths: List[str], argvs: Dict[str, List[str]] = None) -> Dict[str, Application]:
     ''' Return a dictionary mapping routes to Bokeh applications built using
     single handlers, for specified files or directories.
 
@@ -158,7 +161,7 @@ def build_single_handler_applications(paths, argvs=None):
         RuntimeError
 
     '''
-    applications = {}
+    applications: Dict[str, Application] = {}
     argvs = argvs or {}
 
     for path in paths:
@@ -176,7 +179,7 @@ def build_single_handler_applications(paths, argvs=None):
 
 
 @contextlib.contextmanager
-def report_server_init_errors(address=None, port=None, **kwargs):
+def report_server_init_errors(address: str = None, port: int = None, **kwargs: Any) -> Generator:
     ''' A context manager to help print more informative error messages when a
     ``Server`` cannot be started due to a network problem.
 
@@ -209,13 +212,16 @@ def report_server_init_errors(address=None, port=None, **kwargs):
             log.critical("Cannot start Bokeh server [%s]: %r", codename, e)
         sys.exit(1)
 
-def set_single_plot_width_height(doc, width, height):
+def set_single_plot_width_height(doc: Document, width: int, height: int) -> None:
     if width is not None or height is not None:
         layout = doc.roots
         if len(layout) != 1 or not isinstance(layout[0], Plot):
             warnings.warn("Width/height arguments will be ignored for this muliple layout. (Size valus only apply when exporting single plots.)")
         else:
             plot = layout[0]
+            # TODO - fails mypy check
+            # unsure how to handle with typing. width is int base type and class property getter is typing.Int
+            # plot.plot_width  = width if width is not None else plot.plot_width  # doesnt solve problem
             plot.plot_height = height or plot.plot_height
             plot.plot_width  = width or plot.plot_width
 

--- a/bokeh/ext.py
+++ b/bokeh/ext.py
@@ -14,8 +14,10 @@
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from os import PathLike
 from os.path import join
 from subprocess import Popen
+from typing import List
 
 # External imports
 
@@ -34,9 +36,8 @@ __all__ = ["init", "build"]
 # General API
 #-----------------------------------------------------------------------------
 
-# TODO: def init(base_dir: pathlib.Path, *, interactive: bool = False,
-#                development: bool = False, debug: bool = False) -> bool
-def init(base_dir, interactive=False, bokehjs_version=None, debug=False):
+def init(base_dir: PathLike, *, interactive: bool = False,
+         bokehjs_version: str = None, debug: bool = False) -> bool:
     """
     Initialize a directory as a new bokeh extension.
 
@@ -61,8 +62,8 @@ def init(base_dir, interactive=False, bokehjs_version=None, debug=False):
     proc = _run_command("init", base_dir, args, debug)
     return proc.returncode == 0
 
-# TODO: def init(base_dir: pathlib.Path, *, rebuild: bool = False, debug: bool = False) -> bool
-def build(base_dir, rebuild=False, debug=False):
+
+def build(base_dir: PathLike, *, rebuild: bool = False, debug: bool = False) -> bool:
     """
     Build a bokeh extension in the given directory.
 
@@ -91,7 +92,7 @@ def build(base_dir, rebuild=False, debug=False):
 # Private API
 #-----------------------------------------------------------------------------
 
-def _run_command(command, base_dir, args, debug=False):
+def _run_command(command: str, base_dir: PathLike, args: List[str], debug: bool = False) -> Popen:
     bokehjs_dir = settings.bokehjsdir()
 
     if debug:

--- a/bokeh/util/hex.py
+++ b/bokeh/util/hex.py
@@ -23,6 +23,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from typing import Tuple, Any
 
 # External imports
 import numpy as np
@@ -44,7 +45,7 @@ __all__ = (
 # General API
 #-----------------------------------------------------------------------------
 
-def axial_to_cartesian(q, r, size, orientation, aspect_scale=1):
+def axial_to_cartesian(q: Any, r: Any, size: float, orientation: str, aspect_scale: float = 1) -> Tuple[Any, Any]:
     ''' Map axial *(q,r)* coordinates to cartesian *(x,y)* coordinates of
     tiles centers.
 
@@ -95,7 +96,7 @@ def axial_to_cartesian(q, r, size, orientation, aspect_scale=1):
 
     return (x, y)
 
-def cartesian_to_axial(x, y, size, orientation, aspect_scale=1):
+def cartesian_to_axial(x: Any, y: Any, size: float, orientation: str, aspect_scale: float = 1) -> Tuple[Any, Any]:
     ''' Map Cartesion *(x,y)* points to axial *(q,r)* coordinates of enclosing
     tiles.
 
@@ -147,7 +148,7 @@ def cartesian_to_axial(x, y, size, orientation, aspect_scale=1):
 
     return _round_hex(q, r)
 
-def hexbin(x, y, size, orientation="pointytop", aspect_scale=1):
+def hexbin(x: Any, y: Any, size: float, orientation: str = "pointytop", aspect_scale: float = 1) -> Any:
     ''' Perform an equal-weight binning of data points into hexagonal tiles.
 
     For more sophisticated use cases, e.g. weighted binning or scaling
@@ -194,11 +195,12 @@ def hexbin(x, y, size, orientation="pointytop", aspect_scale=1):
         Hex binning only functions on linear scales, i.e. not on log plots.
 
     '''
-    pd = import_required('pandas','hexbin requires pandas to be installed')
+    pd: Any = import_required('pandas','hexbin requires pandas to be installed')
 
     q, r = cartesian_to_axial(x, y, size, orientation, aspect_scale=aspect_scale)
 
     df = pd.DataFrame(dict(r=r, q=q))
+
     return df.groupby(['q', 'r']).size().reset_index(name='counts')
 
 #-----------------------------------------------------------------------------
@@ -209,7 +211,7 @@ def hexbin(x, y, size, orientation="pointytop", aspect_scale=1):
 # Private API
 #-----------------------------------------------------------------------------
 
-def _round_hex(q, r):
+def _round_hex(q: Any, r: Any) -> Tuple[Any, Any]:
     ''' Round floating point axial hex coordinates to integer *(q,r)*
     coordinates.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,3 +75,6 @@ ignore_errors = False
 
 [mypy-bokeh.util.sampledata]
 ignore_errors = False
+
+[mypy-bokeh.util.hex]
+ignore_errors = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,3 +81,6 @@ ignore_errors = False
 
 [mypy-bokeh.ext]
 ignore_errors = False
+
+[mypy-bokeh.command.*]
+ignore_errors = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,3 +78,6 @@ ignore_errors = False
 
 [mypy-bokeh.util.hex]
 ignore_errors = False
+
+[mypy-bokeh.ext]
+ignore_errors = False


### PR DESCRIPTION
added mypy typing to function inputs and return values for command package. specific module comments and difficulties below

setup.cfg: reference the package for mypy testing

# subcommand/
[x] __init__.py
bokeh.command.subcommands._collect()
# TODO - added an empty string "name" attribute to Subcommand class, the if-check may now fail
if not hasattr(attr, 'name'): continue # excludes abstract bases

Unsure if should initialise with None instead of empty string. Attributes are not really Optional when subclassed
https://mypy.readthedocs.io/en/latest/kinds_of_types.html#optional-types-and-the-none-type
name: Optional[str] = None
help: Optional[str] = None

[X] serve.py
- found that paths are still string at this point and NOT PathLike
- bokeh.util.string.format_docstring fails typechecking, expects an Optional[str] arg and __doc__ is str

[X] svg.py
assumed below selenium executed JS will return bytes and not bytearray
bokeh.command.subcommands.svg.SVG.file_contents()
_SVG_SCRIPT = """
var serialized_svgs = [];
var svgs = document.getElementsByClassName('bk-root')[0].getElementsByTagName("svg");
for (var i = 0; i < svgs.length; i++) {
    var source = (new XMLSerializer()).serializeToString(svgs[i]);
    serialized_svgs.push(source);
};
return serialized_svgs
"""

# command/
[X] bootstrap.py
- bokeh.command.bootstrap.main(): struggling to resolve argv mypy typing. is nested tuple of [(arg_name, arg_dict)] not Sequence[str]
[X] subcommand.py
- added empty class attributes "name" and "help". could impact hasattr() checks elsewhere

[X] util.py
bokeh.command.util.set_single_plot_width_height()
issue of conditionally assigning int native and Int bokeh type to same variable.
could use class properties and getters/setter methods on the Would need to set it on the Plot object: bokeh/models/plots.py:495 https://www.python-course.eu/python3_properties.php


- [X ] issues: fixes #9064 
- [ ] tests added / passed
N/A - mypy tests
- [ ] release document entry (if new feature or API change)
N/A
