### PR TITLE
Update FUNDING.yml

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,8 +1,8 @@
 # These are supported funding model platforms
 
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+github: [numfocus]
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-custom: https://numfocus.salsalabs.org/donate-to-bokeh/index.html
+custom: https://numfocus.org/donate-to-bokeh


### PR DESCRIPTION
add NumFOCUS github sponsors button (recurring donations only)

This feature is launching today at GitHub Universe!

Also gave the numfocus.org hosted campaign for Bokeh, in case it helps people feel more secure/legit about the donation link.

cc @bryevdv