### PR TITLE
Update to cdn.bokeh.org

### DIFF
--- a/bokeh/embed/standalone.py
+++ b/bokeh/embed/standalone.py
@@ -119,9 +119,9 @@ def components(models: Union[ModelLike, ModelLikeCollection], wrap_script: bool 
 
     .. code-block:: html
 
-        <script src="https://cdn.pydata.org/bokeh/release/bokeh-x.y.z.min.js"></script>
-        <script src="https://cdn.pydata.org/bokeh/release/bokeh-widgets-x.y.z.min.js"></script>
-        <script src="https://cdn.pydata.org/bokeh/release/bokeh-tables-x.y.z.min.js"></script>
+        <script src="https://cdn.bokeh.org/bokeh/release/bokeh-x.y.z.min.js"></script>
+        <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-x.y.z.min.js"></script>
+        <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-x.y.z.min.js"></script>
 
     Note that in Jupyter Notebooks, it is not possible to use components and show in
     the same notebook cell.

--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -233,7 +233,7 @@ class JSResources(BaseResources):
     The following **mode** values are available for configuring a Resource object:
 
     * ``'inline'`` configure to provide entire Bokeh JS and CSS inline
-    * ``'cdn'`` configure to load Bokeh JS and CSS from ``https://cdn.pydata.org``
+    * ``'cdn'`` configure to load Bokeh JS and CSS from ``https://cdn.bokeh.org``
     * ``'server'`` configure to load from a Bokeh Server
     * ``'server-dev'`` same as ``server`` but supports non-minified assets
     * ``'relative'`` configure to load relative to the given directory
@@ -305,7 +305,7 @@ class CSSResources(BaseResources):
     The following **mode** values are available for configuring a Resource object:
 
     * ``'inline'`` configure to provide entire BokehJS code and CSS inline
-    * ``'cdn'`` configure to load Bokeh CSS from ``https://cdn.pydata.org``
+    * ``'cdn'`` configure to load Bokeh CSS from ``https://cdn.bokeh.org``
     * ``'server'`` configure to load from a Bokeh Server
     * ``'server-dev'`` same as ``server`` but supports non-minified CSS
     * ``'relative'`` configure to load relative to the given directory
@@ -374,7 +374,7 @@ class Resources(JSResources, CSSResources):
     The following **mode** values are available for configuring a Resource object:
 
     * ``'inline'`` configure to provide entire Bokeh JS and CSS inline
-    * ``'cdn'`` configure to load Bokeh JS and CSS from ``https://cdn.pydata.org``
+    * ``'cdn'`` configure to load Bokeh JS and CSS from ``https://cdn.bokeh.org``
     * ``'server'`` configure to load from a Bokeh Server
     * ``'server-dev'`` same as ``server`` but supports non-minified assets
     * ``'relative'`` configure to load relative to the given directory
@@ -449,7 +449,7 @@ class _SessionCoordinates(object):
 _DEV_PAT = re.compile(r"^(\d)+\.(\d)+\.(\d)+(dev|rc)")
 
 def _cdn_base_url():
-    return "https://cdn.pydata.org"
+    return "https://cdn.bokeh.org"
 
 
 def _get_cdn_urls(version=None, minified=True):


### PR DESCRIPTION
I'm at a bit of a loss, I really thought this had already been done. Not a huge deal, but annoying. Definitely would have preferred to have the last py2 release pulling from the actual `cdn.bokeh.org` location rather than using the redirect from `cdn.pydata.org` in perpetuity. 
