### PR TITLE
allow grids to delegate ticking to an axis

### DIFF
--- a/bokeh/models/axes.py
+++ b/bokeh/models/axes.py
@@ -308,7 +308,7 @@ class MercatorAxis(LinearAxis):
         super().__init__(**kw)
 
         # Just being careful. It would be defeat the purpose for anyone to actually
-        # configure this axis with differnet kinds of tickers or formatters.
+        # configure this axis with different kinds of tickers or formatters.
         if isinstance(self.ticker, MercatorTicker):
             self.ticker.dimension = dimension
         if isinstance(self.formatter, MercatorTickFormatter):

--- a/bokeh/models/grids.py
+++ b/bokeh/models/grids.py
@@ -73,10 +73,15 @@ class Grid(GuideRenderer):
     rendering a grid on the plot. If unset, use the default y-range.
     """)
 
-    ticker = Either(Instance(Ticker), Instance(Axis), help="""
-    The Ticker to use for computing locations for the Grid lines. May also be
-    configured with an Axis, in which case the Grid will delegate the ticking
-    to that Axis instance.
+    axis = Instance(Axis, help="""
+    An Axis to delegate ticking to. If the ticker property is None, then the
+    Grid will use the ticker on the specified axis for computing where to draw
+    grid lines. Otherwise, it ticker is not None, it will take precedence over
+    any Axis.
+    """)
+
+    ticker = Instance(Ticker, help="""
+    A Ticker to use for computing locations for the Grid lines.
     """).accepts(Seq(Float), lambda ticks: FixedTicker(ticks=ticks))
 
     grid_props = Include(ScalarLineProps, help="""

--- a/bokeh/models/grids.py
+++ b/bokeh/models/grids.py
@@ -26,6 +26,7 @@ log = logging.getLogger(__name__)
 from ..core.properties import Auto, Either, Float, Include, Instance, Int, Override, Seq, String, Tuple
 from ..core.property_mixins import ScalarFillProps, ScalarHatchProps, ScalarLineProps
 
+from .axes import Axis
 from .renderers import GuideRenderer
 from .tickers import FixedTicker, Ticker
 
@@ -63,19 +64,19 @@ class Grid(GuideRenderer):
     # a path, ranges in both dimensions will matter.
 
     x_range_name = String('default', help="""
-    A particular (named) x-range to use for computing screen
-    locations when rendering a grid on the plot. If unset, use the
-    default x-range.
+    A particular (named) x-range to use for computing screen locations when
+    rendering a grid on the plot. If unset, use the default x-range.
     """)
 
     y_range_name = String('default', help="""
-    A particular (named) y-range to use for computing screen
-    locations when rendering a grid on the plot. If unset, use the
-    default y-range.
+    A particular (named) y-range to use for computing screen locations when
+    rendering a grid on the plot. If unset, use the default y-range.
     """)
 
-    ticker = Instance(Ticker, help="""
-    The Ticker to use for computing locations for the Grid lines.
+    ticker = Either(Instance(Ticker), Instance(Axis), help="""
+    The Ticker to use for computing locations for the Grid lines. May also be
+    configured with an Axis, in which case the Grid will delegate the ticking
+    to that Axis instance.
     """).accepts(Seq(Float), lambda ticks: FixedTicker(ticks=ticks))
 
     grid_props = Include(ScalarLineProps, help="""

--- a/bokeh/plotting/helpers.py
+++ b/bokeh/plotting/helpers.py
@@ -630,7 +630,7 @@ def _process_axis_and_grid(plot, axis_type, axis_location, minor_ticks, axis_lab
         if axis_label:
             axis.axis_label = axis_label
 
-        grid = Grid(dimension=dim, ticker=axis)
+        grid = Grid(dimension=dim, axis=axis)
         plot.add_layout(grid, "center")
 
         if axis_location is not None:

--- a/bokeh/plotting/helpers.py
+++ b/bokeh/plotting/helpers.py
@@ -630,7 +630,7 @@ def _process_axis_and_grid(plot, axis_type, axis_location, minor_ticks, axis_lab
         if axis_label:
             axis.axis_label = axis_label
 
-        grid = Grid(dimension=dim, ticker=axis.ticker)
+        grid = Grid(dimension=dim, ticker=axis)
         plot.add_layout(grid, "center")
 
         if axis_location is not None:

--- a/bokehjs/src/lib/models/grids/grid.ts
+++ b/bokehjs/src/lib/models/grids/grid.ts
@@ -154,8 +154,6 @@ export class GridView extends GuideRendererView {
     const cmin = cross_range.min
     const cmax = cross_range.max
 
-
-
     if (!exclude_ends) {
       if (ticks[0] != min)
         ticks.splice(0, 0, min)

--- a/bokehjs/src/lib/models/grids/grid.ts
+++ b/bokehjs/src/lib/models/grids/grid.ts
@@ -1,3 +1,4 @@
+import {Axis} from "../axes"
 import {GuideRenderer, GuideRendererView} from "../renderers/guide_renderer"
 import {Range} from "../ranges/range"
 import {Ticker} from "../tickers/ticker"
@@ -138,7 +139,7 @@ export class GridView extends GuideRendererView {
     // currently only support "straight line" grids, this should be OK for now. If
     // we ever want to support "curved" grids, e.g. for some projections, we may
     // have to communicate more than just a single cross location.
-    const ticks = this.model.ticker.get_ticks(start, end, range, cross_range.min, {})[location]
+    const ticks = this.model.get_ticker().get_ticks(start, end, range, cross_range.min, {})[location]
 
     const min = range.min
     const max = range.max
@@ -181,7 +182,7 @@ export namespace Grid {
   export type Props = GuideRenderer.Props & {
     bounds: p.Property<[number, number] | "auto">
     dimension: p.Property<0 | 1>
-    ticker: p.Property<Ticker<any>>
+    ticker: p.Property<Ticker<any> | Axis>
     x_range_name: p.Property<string>
     y_range_name: p.Property<string>
   } & mixins.GridLine
@@ -227,4 +228,12 @@ export class Grid extends GuideRenderer {
       minor_grid_line_color: null,
     })
   }
+
+  get_ticker(): Ticker<any> {
+    if (this.ticker instanceof Ticker) {
+      return this.ticker
+    }
+    return this.ticker.ticker
+  }
+
 }

--- a/bokehjs/src/lib/models/grids/grid.ts
+++ b/bokehjs/src/lib/models/grids/grid.ts
@@ -135,11 +135,18 @@ export class GridView extends GuideRendererView {
     let [start, end] = this.computed_bounds();
     [start, end] = [Math.min(start, end), Math.max(start, end)]
 
+    const coords: [number[][], number[][]] = [[], []]
+
     // TODO: (bev) using cross_range.min for cross_loc is a bit of a cheat. Since we
     // currently only support "straight line" grids, this should be OK for now. If
     // we ever want to support "curved" grids, e.g. for some projections, we may
     // have to communicate more than just a single cross location.
-    const ticks = this.model.get_ticker().get_ticks(start, end, range, cross_range.min, {})[location]
+    const ticker = this.model.get_ticker()
+    if (ticker == null) {
+      return coords
+    }
+
+    const ticks = ticker.get_ticks(start, end, range, cross_range.min, {})[location]
 
     const min = range.min
     const max = range.max
@@ -147,7 +154,7 @@ export class GridView extends GuideRendererView {
     const cmin = cross_range.min
     const cmax = cross_range.max
 
-    const coords: [number[][], number[][]] = [[], []]
+
 
     if (!exclude_ends) {
       if (ticks[0] != min)
@@ -182,7 +189,8 @@ export namespace Grid {
   export type Props = GuideRenderer.Props & {
     bounds: p.Property<[number, number] | "auto">
     dimension: p.Property<0 | 1>
-    ticker: p.Property<Ticker<any> | Axis>
+    axis: p.Property<Axis>
+    ticker: p.Property<Ticker<any>>
     x_range_name: p.Property<string>
     y_range_name: p.Property<string>
   } & mixins.GridLine
@@ -215,6 +223,7 @@ export class Grid extends GuideRenderer {
     this.define<Grid.Props>({
       bounds:       [ p.Any,     'auto'    ], // TODO (bev)
       dimension:    [ p.Any,     0         ],
+      axis:         [ p.Instance           ],
       ticker:       [ p.Instance           ],
       x_range_name: [ p.String,  'default' ],
       y_range_name: [ p.String,  'default' ],
@@ -229,11 +238,14 @@ export class Grid extends GuideRenderer {
     })
   }
 
-  get_ticker(): Ticker<any> {
-    if (this.ticker instanceof Ticker) {
+  get_ticker(): Ticker<any> | null {
+    if (this.ticker != null) {
       return this.ticker
     }
-    return this.ticker.ticker
+    if (this.axis != null) {
+      return this.axis.ticker
+    }
+    return null
   }
 
 }

--- a/bokehjs/test/models/grids/grid.ts
+++ b/bokehjs/test/models/grids/grid.ts
@@ -3,6 +3,7 @@ import {expect} from "chai"
 import {Axis} from "@bokehjs/models/axes/axis"
 import {BasicTicker} from "@bokehjs/models/tickers/basic_ticker"
 import {BasicTickFormatter} from "@bokehjs/models/formatters/basic_tick_formatter"
+import {FixedTicker} from "@bokehjs/models/tickers/fixed_ticker"
 import {Grid, GridView} from "@bokehjs/models/grids/grid"
 import {Plot} from "@bokehjs/models/plots/plot"
 import {Range1d} from "@bokehjs/models/ranges/range1d"
@@ -100,7 +101,7 @@ describe("Grid", () => {
     ])
   })
 
-  it("should delegage to an Axis ticker", () => {
+  it("should delegate to an Axis ticker", () => {
     const plot = new Plot({
       x_range: new Range1d({start: 0.1, end: 9.9}),
       y_range: new Range1d({start: 0.1, end: 9.9}),
@@ -109,7 +110,7 @@ describe("Grid", () => {
     const formatter = new BasicTickFormatter()
     const axis = new Axis({ticker, formatter})
     plot.add_layout(axis, 'below')
-    const grid = new Grid({ticker: axis})
+    const grid = new Grid({axis: axis})
     plot.add_layout(grid, 'center')
     const plot_view = new plot.default_view({model: plot, parent: null}).build()
     const grid_view = plot_view.renderer_views[grid.id] as GridView
@@ -119,5 +120,29 @@ describe("Grid", () => {
       [[0.1, 9.9], [0.1, 9.9], [0.1, 9.9], [0.1, 9.9], [0.1, 9.9], [0.1, 9.9]],
     ])
   })
+
+  it("should prefer an explicit ticker to an Axis ticker", () => {
+    const plot = new Plot({
+      x_range: new Range1d({start: 0.1, end: 9.9}),
+      y_range: new Range1d({start: 0.1, end: 9.9}),
+    })
+
+    const axis_ticker = new FixedTicker({ticks: [1,2,3,4]})
+    const formatter = new BasicTickFormatter()
+    const axis = new Axis({ticker: axis_ticker, formatter})
+
+    plot.add_layout(axis, 'below')
+    const ticker = new BasicTicker()
+    const grid = new Grid({axis, ticker})
+    plot.add_layout(grid, 'center')
+    const plot_view = new plot.default_view({model: plot, parent: null}).build()
+    const grid_view = plot_view.renderer_views[grid.id] as GridView
+
+    expect(grid_view.grid_coords('major', false)).to.be.deep.equal([
+      [[0.1, 0.1], [2, 2],     [4, 4],     [6, 6],     [8, 8],     [9.9, 9.9]],
+      [[0.1, 9.9], [0.1, 9.9], [0.1, 9.9], [0.1, 9.9], [0.1, 9.9], [0.1, 9.9]],
+    ])
+  })
+
 
 })

--- a/bokehjs/test/models/grids/grid.ts
+++ b/bokehjs/test/models/grids/grid.ts
@@ -127,7 +127,7 @@ describe("Grid", () => {
       y_range: new Range1d({start: 0.1, end: 9.9}),
     })
 
-    const axis_ticker = new FixedTicker({ticks: [1,2,3,4]})
+    const axis_ticker = new FixedTicker({ticks: [1, 2, 3, 4]})
     const formatter = new BasicTickFormatter()
     const axis = new Axis({ticker: axis_ticker, formatter})
 

--- a/bokehjs/test/models/grids/grid.ts
+++ b/bokehjs/test/models/grids/grid.ts
@@ -110,7 +110,7 @@ describe("Grid", () => {
     const formatter = new BasicTickFormatter()
     const axis = new Axis({ticker, formatter})
     plot.add_layout(axis, 'below')
-    const grid = new Grid({axis: axis})
+    const grid = new Grid({axis})
     plot.add_layout(grid, 'center')
     const plot_view = new plot.default_view({model: plot, parent: null}).build()
     const grid_view = plot_view.renderer_views[grid.id] as GridView
@@ -143,6 +143,5 @@ describe("Grid", () => {
       [[0.1, 9.9], [0.1, 9.9], [0.1, 9.9], [0.1, 9.9], [0.1, 9.9], [0.1, 9.9]],
     ])
   })
-
 
 })

--- a/bokehjs/test/models/grids/grid.ts
+++ b/bokehjs/test/models/grids/grid.ts
@@ -99,4 +99,25 @@ describe("Grid", () => {
       [[0.1, 9.9], [0.1, 9.9], [0.1, 9.9], [0.1, 9.9], [0.1, 9.9], [0.1, 9.9]],
     ])
   })
+
+  it("should delegage to an Axis ticker", () => {
+    const plot = new Plot({
+      x_range: new Range1d({start: 0.1, end: 9.9}),
+      y_range: new Range1d({start: 0.1, end: 9.9}),
+    })
+    const ticker = new BasicTicker()
+    const formatter = new BasicTickFormatter()
+    const axis = new Axis({ticker, formatter})
+    plot.add_layout(axis, 'below')
+    const grid = new Grid({ticker: axis})
+    plot.add_layout(grid, 'center')
+    const plot_view = new plot.default_view({model: plot, parent: null}).build()
+    const grid_view = plot_view.renderer_views[grid.id] as GridView
+
+    expect(grid_view.grid_coords('major', false)).to.be.deep.equal([
+      [[0.1, 0.1], [2, 2],     [4, 4],     [6, 6],     [8, 8],     [9.9, 9.9]],
+      [[0.1, 9.9], [0.1, 9.9], [0.1, 9.9], [0.1, 9.9], [0.1, 9.9], [0.1, 9.9]],
+    ])
+  })
+
 })

--- a/tests/unit/bokeh/models/test_grids.py
+++ b/tests/unit/bokeh/models/test_grids.py
@@ -19,7 +19,7 @@ import pytest ; pytest
 # External imports
 
 # Bokeh imports
-from bokeh.models import FixedTicker
+from bokeh.models import FixedTicker, LinearAxis
 
 # Module under test
 import bokeh.models.grids as bmg
@@ -41,6 +41,14 @@ def test_ticker_accepts_number_sequences():
     g.ticker = [-10, 0, 10, 20.7]
     assert isinstance(g.ticker, FixedTicker)
     assert g.ticker.ticks == [-10, 0, 10, 20.7]
+
+def test_ticker_accepts_axis():
+    g = bmg.Grid(ticker=LinearAxis())
+    assert isinstance(g.ticker, LinearAxis)
+
+    g = bmg.Grid()
+    g.ticker = LinearAxis()
+    assert isinstance(g.ticker, LinearAxis)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/models/test_grids.py
+++ b/tests/unit/bokeh/models/test_grids.py
@@ -43,12 +43,12 @@ def test_ticker_accepts_number_sequences():
     assert g.ticker.ticks == [-10, 0, 10, 20.7]
 
 def test_ticker_accepts_axis():
-    g = bmg.Grid(ticker=LinearAxis())
-    assert isinstance(g.ticker, LinearAxis)
+    g = bmg.Grid(axis=LinearAxis())
+    assert isinstance(g.axis, LinearAxis)
 
     g = bmg.Grid()
-    g.ticker = LinearAxis()
-    assert isinstance(g.ticker, LinearAxis)
+    g.axis = LinearAxis()
+    assert isinstance(g.axis, LinearAxis)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/plotting/test_figure.py
+++ b/tests/unit/bokeh/plotting/test_figure.py
@@ -147,8 +147,11 @@ class TestFigure(object):
 
     def test_grid_tickers(self):
         p = bpf.figure()
-        assert p.xgrid[0].ticker == p.xaxis[0]
-        assert p.ygrid[0].ticker == p.yaxis[0]
+        assert p.xgrid[0].axis == p.xaxis[0]
+        assert p.xgrid[0].ticker is None
+
+        assert p.ygrid[0].axis == p.yaxis[0]
+        assert p.ygrid[0].ticker is None
 
     def test_xgrid(self):
         p = bpf.figure()

--- a/tests/unit/bokeh/plotting/test_figure.py
+++ b/tests/unit/bokeh/plotting/test_figure.py
@@ -145,6 +145,11 @@ class TestFigure(object):
         p.circle([1, 2, 3], [1, 2, 3])
         assert isinstance(p.y_scale, LogScale)
 
+    def test_grid_tickers(self):
+        p = bpf.figure()
+        assert p.xgrid[0].ticker == p.xaxis[0]
+        assert p.ygrid[0].ticker == p.yaxis[0]
+
     def test_xgrid(self):
         p = bpf.figure()
         p.circle([1, 2, 3], [1, 2, 3])


### PR DESCRIPTION
- [x] issues: fixes #8561
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

After adding this line to the `iris.py` example:

    p.xaxis.ticker = [1,3,7]

The output is:

<img width="415" alt="Screen Shot 2019-11-15 at 6 23 40 PM" src="https://user-images.githubusercontent.com/1078448/68986543-3c573c80-07d5-11ea-8603-f44c7741909c.png">

Also confirmed explicitly setting a ticker on the grids works to take precedence. Not sure if there are any other docs or explicit examples needed. 
