### PR TITLE
remove errant pscript dep

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -84,7 +84,6 @@ test:
     - networkx
     - notebook
     - opencv
-    - pscript
     - pyshp
     - scikit-learn
     - sympy


### PR DESCRIPTION
Guess this got overlooked when the python transpilation code was removed. 