### PR TITLE
Update .coveragerc

### DIFF
--- a/scripts/ci/test.unit
+++ b/scripts/ci/test.unit
@@ -12,7 +12,7 @@ fi
 
 # don't run from the top level dir, make sure tests run on installed package
 pushd tests
-py.test -m "$selector"              \
+py.test -m "$selector" tests        \
     --cov=bokeh                     \
     --cov-config=.coveragerc
 popd

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -1,2 +1,2 @@
 [run]
-omit = *_testing/*, *sphinxext/*, */_version.py
+omit = *_testing/*, *sampledata/*, *sphinxext/*, */_version.py


### PR DESCRIPTION
- [x] issues: fixes #9421

This should remove the sampledata dirs from the unit test coverage reports (sampledata is covered by a separate set of tests outside the unit test run so it should not be included in unit test restults) but I am not yet sure about the double counting repo vs package