### PR TITLE
Temp disable windows builds for GH CI

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         node_version: [10, 12]
         python_version: [3.7]
-        os: [windows-latest, macos-latest]
+        os: [macos-latest]
 
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
This PR disables the windows builds for now. I expect there are lots of changes that we will want to make to these configurations but I would like to get a stable, green master first and foremost, then fix issues in follow-on PRs.

cc @ammarnajjar 
