### PR TITLE
docs: correct the gh-actions badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@
          alt="Current TravisCI build status" />
     </a>
     <a href="https://github.com/bokeh/bokeh/actions">
-    <img src="https://github.com/bokeh/bokeh/workflows/.github/workflows/bokeh-ci.yml/badge.svg"
+    <img src="https://github.com/bokeh/bokeh/workflows/GitHub-CI/badge.svg"
          alt="Current github actions build status" />
     </a>
   </td>


### PR DESCRIPTION
It is documented [here](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository), but it seems like using the absolute path to the action yml file did not work, but using the workflow name instead works:

before:
![image](https://user-images.githubusercontent.com/7128635/69468473-9f744080-0d8c-11ea-9eb7-91fcf58bdfc1.png)


after:
![image](https://user-images.githubusercontent.com/7128635/69468481-aac76c00-0d8c-11ea-89e9-338b019885c6.png)
