### PR TITLE
force trigger gh-actions on pull_request

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -1,6 +1,6 @@
 name: GitHub-CI
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -1,6 +1,6 @@
 name: GitHub-CI
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         python_version: [3.7]
-        os: [windows-latest,macos-latest]
+        os: [windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
Forcing triggers on push and on pull_request.

**but** to be aware the default type of PR  activity triggers are only (opened, synchronize, or reopened).

there are other PR activities available which are disabled by default:

- assigned
- unassigned
- labeled
- unlabeled
- edited
- closed
- ready_for_review
- locked
- unlocked
- review_requested
- review_request_removed

in order to enable them, we need to do that specifically => [docs](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#pull-request-event-pull_request)

please advise