### PR TITLE
palettes docs can assume jq and bs

### DIFF
--- a/bokeh/sphinxext/bokeh_palette_group.py
+++ b/bokeh/sphinxext/bokeh_palette_group.py
@@ -21,6 +21,11 @@ Generates the output:
 
     .. bokeh-palette-group:: mpl
 
+.. note::
+   This extension assumes both Bootstrap and JQuery are present (which is the
+   case for the Bokeh documentation theme). If using this theme outside the
+   Bokeh documentation, be sure to include those resources by hand.
+
 '''
 
 #-----------------------------------------------------------------------------
@@ -75,8 +80,9 @@ class BokehPaletteGroupDirective(Directive):
         node['group'] = self.arguments[0]
         return [node]
 
+# NOTE: This extension now *assumes* both Bootstrap and JQuery are present
+# (which is now the case for the Bokeh docs theme).
 def html_visit_bokeh_palette_group(self, node):
-    self.body.append(_BOOTSTRAP_CSS)
     self.body.append('<div class="container-fluid"><div class="row">"')
     group = getattr(bp, node['group'], None)
     if not isinstance(group, dict):
@@ -89,7 +95,6 @@ def html_visit_bokeh_palette_group(self, node):
         html = PALETTE_GROUP_DETAIL.render(name=name, numbers=numbers, palettes=palettes)
         self.body.append(html)
     self.body.append('</div></div>')
-    self.body.append(_BOOTSTRAP_JS)
     raise nodes.SkipNode
 
 def setup(app):
@@ -100,15 +105,6 @@ def setup(app):
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------
-
-_BOOTSTRAP_CSS = """
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
-"""
-
-_BOOTSTRAP_JS = """
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
-"""
 
 #-----------------------------------------------------------------------------
 # Code


### PR DESCRIPTION
- [x] issues: fixes #9457
- [x] release document entry (if new feature or API change)

Sphinx extension for palette groups should just assume and use JQ and Bootstrap from the theme (in particular the docutils.js for search requires an ancient JQ version)