### PR TITLE
don't include Examples dir in conda pkg

### DIFF
--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -1,8 +1,2 @@
 python setup.py --quiet install --build-js --single-version-externally-managed --record=record.txt
 if errorlevel 1 exit 1
-
-mkdir %PREFIX%\Examples
-if errorlevel 1 exit 1
-
-copy /Y examples %PREFIX%\Examples\bokeh
-if errorlevel 1 exit 1

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -2,8 +2,5 @@
 
 $PYTHON setup.py --quiet install --install-js --single-version-externally-managed --record=record.txt
 
-mkdir $PREFIX/Examples
-cp -r examples $PREFIX/Examples/bokeh
-
 cd $PREFIX
 echo $PREFIX


### PR DESCRIPTION
Including an `Examples` directory in a conda package was due to an ancient anaconda env idea that supposed many packages would want to include examples. Though the feature still "works" it was never actually publicized or encouraged, and looking at a current set of Anaconda envs, not a single other package adds anything to Examples besides Bokeh. I think we can safely stop bothering with this, make our packages slightly smaller and our builds slightly faster. 
