### PR TITLE
Mark flask_gunicorn_embed.py worker thread as a daemon.

### DIFF
--- a/examples/howto/server_embed/flask_gunicorn_embed.py
+++ b/examples/howto/server_embed/flask_gunicorn_embed.py
@@ -78,4 +78,6 @@ def bk_worker():
     server.start()
     server.io_loop.start()
 
-Thread(target=bk_worker).start()
+t = Thread(target=bk_worker)
+t.daemon = True
+t.start()


### PR DESCRIPTION
Fixes #9476 seen when trying to stop gunicorn via Ctrl-C.

- [x] issues: fixes #9476
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
