### PR TITLE
pin ipython max version

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -59,6 +59,7 @@ test:
     - coverage
     - flake8
     - flaky
+    - ipython <=7.9.0
     - isort >=4.3.21
     - lxml
     - mock


### PR DESCRIPTION
pins ipython to 7.9 

cc @mattpap