### PR TITLE
More SRI hash work

### DIFF
--- a/bokeh/util/version.py
+++ b/bokeh/util/version.py
@@ -20,6 +20,9 @@ Functions:
         Return the base version string, without any "dev", "rc" or local build
         information appended.
 
+    is_full_release:
+        Return whether the current installed version is a full release.
+
 .. _versioneer: https://github.com/warner/python-versioneer
 
 '''
@@ -43,6 +46,7 @@ from .._version import get_versions
 
 __all__ = (
     'base_version',
+    'is_full_release',
 )
 
 #-----------------------------------------------------------------------------
@@ -52,12 +56,10 @@ __all__ = (
 def base_version() -> str:
     return _base_version_helper(__version__)
 
-def _base_version_helper(version: str) -> str:
+def is_full_release() -> bool:
     import re
-    VERSION_PAT = re.compile(r"^(\d+\.\d+\.\d+)((?:dev|rc).*)?")
-    match = VERSION_PAT.search(version)
-    assert match is not None
-    return match.group(1)
+    VERSION_PAT = re.compile(r"^(\d+\.\d+\.\d+)$")
+    return bool(VERSION_PAT.match(__version__))
 
 #-----------------------------------------------------------------------------
 # Dev API
@@ -66,6 +68,13 @@ def _base_version_helper(version: str) -> str:
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------
+
+def _base_version_helper(version: str) -> str:
+    import re
+    VERSION_PAT = re.compile(r"^(\d+\.\d+\.\d+)((?:dev|rc).*)?")
+    match = VERSION_PAT.search(version)
+    assert match is not None
+    return match.group(1)
 
 #-----------------------------------------------------------------------------
 # Code

--- a/scripts/sri.py
+++ b/scripts/sri.py
@@ -1,0 +1,80 @@
+import json
+import re
+import sys
+from collections import OrderedDict
+from distutils.version import StrictVersion
+from glob import glob
+from os.path import abspath, basename, dirname, join
+from subprocess import PIPE, Popen
+
+TOP = abspath(join(dirname(__file__), ".."))
+
+VERSION = re.compile(r"^(\d+\.\d+\.\d+)$")
+
+
+def compute_single_hash(path):
+    assert path.endswith(".js")
+
+    digest = f"openssl dgst -sha384 -binary {path}".split()
+    p1 = Popen(digest, stdout=PIPE)
+
+    b64 = "openssl base64 -A".split()
+    p2 = Popen(b64, stdin=p1.stdout, stdout=PIPE)
+
+    out, _ = p2.communicate()
+    return out.decode("utf-8").strip()
+
+
+def compute_hashes_for_paths(paths, version):
+    hashes = []
+    for path in paths:
+        name, suffix = basename(path).split(".", 1)
+        filename = f"{name}-{version}.{suffix}"
+        sri_hash = compute_single_hash(path)
+        hashes.append((filename, sri_hash))
+    return dict(sorted(hashes))
+
+
+def get_current_package_json():
+    tmp = json.load(open(join(TOP, "bokeh", "_sri.json")))
+    results = OrderedDict(
+        (key, dict(val))
+        for key, val in sorted(
+            tmp.items(), key=lambda item: StrictVersion(item[0]), reverse=True
+        )
+    )
+    return results
+
+
+def write_package_json(data):
+    with open(join(TOP, "bokeh", "_sri.json"), "w") as f:
+        f.write(json.dumps(data, indent=2))
+        f.write("\n")
+
+
+def update_package(version):
+    current = get_current_package_json()
+
+    assert (
+        version not in current
+    ), f"Version {version} already exists in the hash data file"
+
+    paths = glob(join(TOP, "bokeh/server/static/js/bokeh*.js"))
+    hashes = compute_hashes_for_paths(paths, version)
+
+    new = {version: hashes}
+    new.update(current)
+
+    write_package_json(new)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: python sri.py <new-version>")
+        sys.exit(1)
+
+    version = sys.argv[1]
+
+    assert VERSION.match(version), f"{version!r} is not a valid Bokeh release version string"
+
+    update_package(version)

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -70,7 +70,7 @@ bokeh_plot_pyfile_include_dirs = ['docs']
 
 intersphinx_mapping = {
     'python' : ('https://docs.python.org/3/', None),
-    'pandas' : ('http://pandas.pydata.org/pandas-docs/stable/', None),
+    'pandas' : ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'numpy'  : ('https://docs.scipy.org/doc/numpy/', None)
 }
 

--- a/tests/unit/bokeh/util/test_version.py
+++ b/tests/unit/bokeh/util/test_version.py
@@ -14,6 +14,9 @@ import pytest ; pytest
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+import re
+
 # External imports
 import mock
 
@@ -27,6 +30,8 @@ import bokeh.util.version as buv # isort:skip
 # Setup
 #-----------------------------------------------------------------------------
 
+VERSION_PAT = re.compile(r"^(\d+\.\d+\.\d+)$")
+
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
@@ -38,10 +43,25 @@ class Test___version__(object):
         assert buv.__version__ == get_versions()['version']
 
 class Test_base_version(object):
+
     def test_returns_helper(self):
         with mock.patch('bokeh.util.version._base_version_helper') as helper:
             buv.base_version()
             assert helper.called
+
+class Test_is_full_release(object):
+
+    def test_actual(self):
+        assert buv.is_full_release() == bool(VERSION_PAT.match(buv.__version__))
+
+    def test_mock_full(self, monkeypatch):
+        monkeypatch.setattr(buv, '__version__', "1.5.0")
+        assert buv.is_full_release()
+
+    @pytest.mark.parametrize('v', ("1.2.3dev2", "1.4.5rc3", "junk"))
+    def test_mock_not_full(self, monkeypatch, v):
+        monkeypatch.setattr(buv, '__version__', v)
+        assert not buv.is_full_release()
 
 #-----------------------------------------------------------------------------
 # Dev API


### PR DESCRIPTION
Addresses #8397 

- [x] tests added / passed
- [x] release document entry (if new feature or API change)

This PR does some more incremental work towards supporting SRI hashes for BokehJS.  Primarily:

* adds a `verify_sri_hashes` func that can be used with full-release packges to verify that computed SRI hashes match the hash manifest

* adds an`sri.py` script that can update the hash manifest (takes care to preserve ordering) 

*incidentally, adds an `is_full_release` predicate in `bokeh.util.version`

cc @mattpap @jakirkham @tommycarstensen 
