### PR TITLE
Fix WebGL rendering on high DPI displays

### DIFF
--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -434,9 +434,10 @@ export class PlotView extends LayoutDOMView {
     const {webgl} = this.canvas_view
     if (webgl != null) {
       // Sync canvas size
-      const {width, height} = this.layout.bbox
-      webgl.canvas.width = width
-      webgl.canvas.height = height
+      const {width, height} = this.canvas_view.bbox
+      const {pixel_ratio} = this.canvas_view.model
+      webgl.canvas.width = pixel_ratio*width
+      webgl.canvas.height = pixel_ratio*height
       const {gl} = webgl
       // Clipping
       gl.enable(gl.SCISSOR_TEST)


### PR DESCRIPTION
For now without tests, because there is no good way to test this at the moment. However, it's possible to use device emulation mode in chrome's devtools to test this with various pixel ratios. This requires some additional work on bokehjs' integration testing framework.

fixes #9483 
