### PR TITLE
Pivot is not a supported app anymore

### DIFF
--- a/examples/app/README.md
+++ b/examples/app/README.md
@@ -62,12 +62,6 @@ The demos container here are:
     <td>A simulated streaming <a href=https://en.wikipedia.org/wiki/Open-high-low-close_chart>OHLC chart</a> with <a href=https://en.wikipedia.org/wiki/MACD>MACD indicator</a> and selectable moving averages using periodic callbacks and the efficient streaming API</td>
   </tr>
 
-  <tr><td colspan="2">pivot</td></tr>
-  <tr>
-    <td><a href="https://github.com/bokeh/bokeh/tree/master/examples/app/pivot"><img src="https://docs.bokeh.org/static/pivot_t.png" width=400></img></a></td>
-    <td>A tool for creating pivot charts from CSVs.</td>
-  </tr>
-
   <tr><td colspan="2">selection_histogram</td></tr>
   <tr>
     <td><a href="https://github.com/bokeh/bokeh/tree/master/examples/app/selection_histogram.py"><img src="https://docs.bokeh.org/static/selection_histogram_t.png" width=400></img></a></td>


### PR DESCRIPTION
remove the pivot from the readme since it's not a supported example anymore

- [x] issues: fixes #9519
- [x] tests added / passed
- [x] release document entry (if new feature or API change)
