### PR TITLE
don't duplicate helpool

### DIFF
--- a/bokehjs/src/lib/models/tools/toolbar_base.ts
+++ b/bokehjs/src/lib/models/tools/toolbar_base.ts
@@ -131,7 +131,6 @@ export class ToolbarBaseView extends DOMView {
 
     bars.push(this.model.actions.map(el))
     bars.push(this.model.inspectors.filter((tool) => tool.toggleable).map(el))
-    bars.push(this.model.help.map(el))
 
     for (const bar of bars) {
       if (bar.length !== 0) {


### PR DESCRIPTION
- [x] issues: fixes #9474

This removes the `HelpTool` from a special privileged position next to the logo and just makes it behave as a normal action tool, which I am 100% fine with. 

Could not see a good way to test as we are not set up to test Bokeh views at all, really. 

<img width="622" alt="Screen Shot 2020-01-03 at 2 57 44 PM" src="https://user-images.githubusercontent.com/1078448/71754074-966d9900-2e39-11ea-97ee-4fe604ba3690.png">

