### PR TITLE
Add FullscreenTool

### DIFF
--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -456,6 +456,17 @@ class ResetTool(Action):
 
     pass
 
+class FullscreenTool(Action):
+    ''' *toolbar icon*: |fullscreen_icon|
+
+    The fullscreen tool is an action, when toggled the plot the tool is attached
+    to is fullscreened. Not that if the plot is inside an <iframe> you will need
+    to add a allowfullscreen attribute (+ webkitallowfullscreen and mozallowfullscreen)
+
+    .. |fullscreen_icon| image:: /_images/icons/Fullscreen.png
+        :height: 18pt
+    '''
+
 class TapTool(Tap):
     ''' *toolbar icon*: |tap_icon|
 

--- a/bokehjs/package-lock.json
+++ b/bokehjs/package-lock.json
@@ -147,13 +147,13 @@
     "@types/combine-source-map": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@types/combine-source-map/-/combine-source-map-0.8.1.tgz",
-      "integrity": "sha512-WhZUni7/6qV3qSLs+2BHWYeisnde3tpoUrkOYN0BmcTHyw0X+xREYC03DATYQTfC1pCdmzGCS2LbTm61V+OS0Q==",
+      "integrity": "sha1-SEr5ki72z5rPLbGNh++rtzdk2ZQ=",
       "dev": true
     },
     "@types/convert-source-map": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@types/convert-source-map/-/convert-source-map-1.5.1.tgz",
-      "integrity": "sha512-laiDIXqqthjJlyAMYAXOtN3N8+UlbM+KvZi4BaY5ZOekmVkBs/UxfK5O0HWeJVG2eW8F+Mu2ww13fTX+kY1FlQ==",
+      "integrity": "sha1-1NGA3WrcXLaK2ZvVbgPWN4gfRhY=",
       "dev": true
     },
     "@types/eslint": {
@@ -2141,7 +2141,7 @@
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
       "dev": true,
       "optional": true
     },
@@ -2452,7 +2452,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -2578,7 +2578,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -2754,6 +2754,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "screenfull": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.0.0.tgz",
+      "integrity": "sha512-yShzhaIoE9OtOhWVyBBffA6V98CDCoyHTsp8228blmqYy1Z5bddzE/4FPiJKlr8DVR4VBiiUyfPzIQPIYDkeMA=="
     },
     "semver": {
       "version": "6.3.0",

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -72,6 +72,7 @@
     "es6-map": "^0.1.5",
     "es6-set": "^0.1.5",
     "flatbush": "^3.1.1",
+    "screenfull": "^5.0.0",
     "gloo2": "https://github.com/bokeh/gloo2.git#b41bd5d",
     "hammerjs": "^2.0.4",
     "nouislider": "^10.0.0",

--- a/bokehjs/src/lib/models/tools/actions/fullscreen_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/fullscreen_tool.ts
@@ -1,0 +1,37 @@
+import {logger} from "core/logging"
+import * as p from "core/properties"
+import {ActionTool, ActionToolView} from "models/tools/actions/action_tool"
+import screenfull from "screenfull"
+
+export class FullscreenToolView extends ActionToolView {
+  model: FullscreenTool
+
+  doit(): void {
+    if (screenfull.isEnabled)
+      screenfull.toggle((this.root as any).el);
+    else
+      logger.warn('Could not toggle fullscreen on, ensure the allowfullscreen attribute is set.')
+  }
+}
+
+export namespace FullscreenTool {
+  export type Attrs = p.AttrsOf<Props>
+  export type Props = ActionTool.Props
+}
+
+export interface FullscreenTool extends FullscreenTool.Attrs {}
+
+export class FullscreenTool extends ActionTool {
+  properties: FullscreenTool.Props
+
+  constructor(attrs?: Partial<FullscreenTool.Attrs>) {
+    super(attrs)
+  }
+
+  static init_FullscreenTool(): void {
+    this.prototype.default_view = FullscreenToolView
+  }
+
+  tool_name = "Fullscreen"
+  icon = "bk-tool-icon-reset"
+}

--- a/bokehjs/src/lib/models/tools/index.ts
+++ b/bokehjs/src/lib/models/tools/index.ts
@@ -1,5 +1,6 @@
 export {ActionTool}        from "./actions/action_tool"
 export {CustomAction}      from "./actions/custom_action"
+export {FullscreenTool}    from "./actions/fullscreen_tool"
 export {HelpTool}          from "./actions/help_tool"
 export {RedoTool}          from "./actions/redo_tool"
 export {ResetTool}         from "./actions/reset_tool"


### PR DESCRIPTION
Adds a FullscreenTool which maximizes the root view. Might want to make that configurable and allow just fullscreening the specific subplot (although I'd have to test that).

- [x] issues: fixes #3598
- [ ] Add icon
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
