### PR TITLE
fix circular import between glyphs and markers

### DIFF
--- a/bokeh/models/glyph.py
+++ b/bokeh/models/glyph.py
@@ -1,0 +1,75 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2019, Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+''' Display a variety of visual shapes whose attributes can be associated
+with data columns from ``ColumnDataSources``.
+
+All these glyphs share a minimal common interface through their base class
+``Glyph``:
+
+.. autoclass:: Glyph
+    :members:
+
+'''
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+import logging # isort:skip
+log = logging.getLogger(__name__)
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Bokeh imports
+from ..core.has_props import abstract
+from ..model import Model
+
+#-----------------------------------------------------------------------------
+# Globals and constants
+#-----------------------------------------------------------------------------
+
+__all__ = (
+    'ConnectedXYGlyph',
+    'Glyph',
+    'XYGlyph',
+)
+
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+@abstract
+class Glyph(Model):
+    ''' Base class for all glyph models.
+
+    '''
+
+@abstract
+class XYGlyph(Glyph):
+    ''' Base class of glyphs with `x` and `y` coordinate attributes.
+
+    '''
+
+@abstract
+class ConnectedXYGlyph(XYGlyph):
+    ''' Base class of glyphs with `x` and `y` coordinate attributes and
+    a connected topology.
+
+    '''
+
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------

--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -57,7 +57,6 @@ log = logging.getLogger(__name__)
 
 # Bokeh imports
 from ..core.enums import Anchor, Direction, StepMode
-from ..core.has_props import abstract
 from ..core.properties import (
     AngleSpec,
     Bool,
@@ -81,7 +80,7 @@ from ..core.property_mixins import (
     ScalarLineProps,
     TextProps,
 )
-from ..model import Model
+from .glyph import ConnectedXYGlyph, Glyph, XYGlyph
 from .mappers import ColorMapper, LinearColorMapper
 
 #-----------------------------------------------------------------------------
@@ -93,6 +92,7 @@ __all__ = (
     'Annulus',
     'Arc',
     'Bezier',
+    'ConnectedXYGlyph',
     'Ellipse',
     'Glyph',
     'HArea',
@@ -123,25 +123,6 @@ __all__ = (
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
-
-@abstract
-class Glyph(Model):
-    ''' Base class for all glyph models.
-
-    '''
-
-@abstract
-class XYGlyph(Glyph):
-    ''' Base class of glyphs with `x` and `y` coordinate attributes.
-
-    '''
-
-@abstract
-class ConnectedXYGlyph(XYGlyph):
-    ''' Base class of glyphs with `x` and `y` coordinate attributes and
-    a connected topology.
-
-    '''
 
 class AnnularWedge(XYGlyph):
     ''' Render annular wedges.

--- a/bokeh/models/markers.py
+++ b/bokeh/models/markers.py
@@ -60,7 +60,7 @@ from ..core.properties import (
     ScreenDistanceSpec,
 )
 from ..core.property_mixins import FillProps, LineProps
-from .glyphs import XYGlyph
+from .glyph import XYGlyph
 
 #-----------------------------------------------------------------------------
 # Globals and constants


### PR DESCRIPTION
This attempts to fix a fragile potential circular import situation between `bokeh.models.glyphs` and `bokeh.models.markers`. 

This was reported by LGTM, but I have definitely run in to problems on numerous occasions where a seemingly innocuous change suddenly results in tests failing with "Duplicate Model definition". So in truth, this probably does not go far enough. We should  possibly restructure the repo layout, and codify best practices, e.g. 

* move all the actual implementations to `bokeh._models.xyz`
* in those modules, avoid importing from other model modules at the top level except for base classes
* generally, internally only import from `bokeh._models`
* tests only import from public `bokeh.models`

We could provide stub `bokeh.models.ranges` that just import from `bokeh._models.ranges`, etc. and if desired, those could then be easily explicitly deprecated. Maybe that's v3 to v4 territory tho.

We would also need to figure out how to structure our reference documentation 
