### PR TITLE
test on python 3.8

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -525,6 +525,7 @@ jobs:
             echo "::add-path::$HOME/miniconda3/Scripts"
           else
             echo "::add-path::$HOME/miniconda3/bin"
+            echo "::add-path::$HOME/miniconda3/envs/test/bin"
           fi
 
       - name: Configure conda
@@ -561,8 +562,8 @@ jobs:
       - name: Install conda packages
         shell: bash
         run: |
-          conda install --yes --quiet python=${{ matrix.python-version }} jinja2 pyyaml
-          conda install --yes --quiet --use-local bokeh `python scripts/deps.py run test` python=${{ matrix.python-version }}
+          conda create -n test --yes --quiet python=${{ matrix.python-version }} jinja2 pyyaml
+          conda install -n test --yes --quiet --use-local bokeh `python scripts/deps.py run test` python=${{ matrix.python-version }}
 
       - name: Cache node modules
         uses: actions/cache@v1
@@ -594,7 +595,7 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ runner.os }}" = "Windows" ]]; then
-            source activate base
+            source activate test
           fi
           py.test -m unit --cov=bokeh --cov-config=.coveragerc --color=yes tests
 

--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -1,6 +1,10 @@
 name: GitHub-CI
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
 
@@ -491,7 +495,7 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v2-beta

--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Configure conda
         shell: bash
         env:
-          CONDA_REQS: "conda=4.7.12 conda-build=3.18.10 conda-verify=3.4.2 ripgrep=0.10.0 jinja2"
+          CONDA_REQS: "conda=4.8.1 conda-build=3.18.10 conda-verify=3.4.2 ripgrep=0.10.0 jinja2"
         run: |
           conda config --set auto_update_conda off
           conda config --append channels bokeh
@@ -118,7 +118,7 @@ jobs:
       - name: Configure conda
         shell: bash
         env:
-          CONDA_REQS: "conda=4.7.12 conda-build=3.18.10 conda-verify=3.4.2 ripgrep=0.10.0 jinja2"
+          CONDA_REQS: "conda=4.8.1 conda-build=3.18.10 conda-verify=3.4.2 ripgrep=0.10.0 jinja2"
         run: |
           conda config --set auto_update_conda off
           conda config --append channels bokeh
@@ -206,7 +206,7 @@ jobs:
       - name: Configure conda
         shell: bash
         env:
-          CONDA_REQS: "conda=4.7.12 conda-build=3.18.10 conda-verify=3.4.2 ripgrep=0.10.0 jinja2"
+          CONDA_REQS: "conda=4.8.1 conda-build=3.18.10 conda-verify=3.4.2 ripgrep=0.10.0 jinja2"
         run: |
           conda config --set auto_update_conda off
           conda config --append channels bokeh
@@ -325,7 +325,7 @@ jobs:
       - name: Configure conda
         shell: bash
         env:
-          CONDA_REQS: "conda=4.7.12 conda-build=3.18.10 conda-verify=3.4.2 ripgrep=0.10.0 jinja2"
+          CONDA_REQS: "conda=4.8.1 conda-build=3.18.10 conda-verify=3.4.2 ripgrep=0.10.0 jinja2"
         run: |
           conda config --set auto_update_conda off
           conda config --append channels bokeh
@@ -421,7 +421,7 @@ jobs:
       - name: Configure conda
         shell: bash
         env:
-          CONDA_REQS: "conda=4.7.12 conda-build=3.18.10 conda-verify=3.4.2 ripgrep=0.10.0 jinja2"
+          CONDA_REQS: "conda=4.8.1 conda-build=3.18.10 conda-verify=3.4.2 ripgrep=0.10.0 jinja2"
         run: |
           conda config --set auto_update_conda off
           conda config --append channels bokeh
@@ -530,7 +530,7 @@ jobs:
       - name: Configure conda
         shell: bash
         env:
-          CONDA_REQS: "conda=4.7.12 conda-build=3.18.10 conda-verify=3.4.2 jinja2"
+          CONDA_REQS: "conda=4.8.1 conda-build=3.18.10 conda-verify=3.4.2 jinja2"
         run: |
           conda config --set auto_update_conda off
           conda config --append channels bokeh
@@ -627,7 +627,7 @@ jobs:
       - name: Configure conda
         shell: bash
         env:
-          CONDA_REQS: "conda=4.7.12 conda-build=3.18.10 conda-verify=3.4.2 ripgrep=0.10.0 jinja2"
+          CONDA_REQS: "conda=4.8.1 conda-build=3.18.10 conda-verify=3.4.2 ripgrep=0.10.0 jinja2"
         run: |
           conda config --set auto_update_conda off
           conda config --append channels bokeh
@@ -715,7 +715,7 @@ jobs:
       - name: Configure conda
         shell: bash
         env:
-          CONDA_REQS: "conda=4.7.12 conda-build=3.18.10 conda-verify=3.4.2 ripgrep=0.10.0 jinja2"
+          CONDA_REQS: "conda=4.8.1 conda-build=3.18.10 conda-verify=3.4.2 ripgrep=0.10.0 jinja2"
         run: |
           conda config --set auto_update_conda off
           conda config --append channels bokeh
@@ -813,7 +813,7 @@ jobs:
       - name: Configure conda
         shell: bash
         env:
-          CONDA_REQS: "conda=4.7.12 conda-build=3.18.10 conda-verify=3.4.2 ripgrep=0.10.0 jinja2"
+          CONDA_REQS: "conda=4.8.1 conda-build=3.18.10 conda-verify=3.4.2 ripgrep=0.10.0 jinja2"
         run: |
           conda config --set auto_update_conda off
           conda config --append channels bokeh

--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -560,7 +560,7 @@ jobs:
         shell: bash
         run: |
           conda install --yes --quiet python=${{ matrix.python-version }} jinja2 pyyaml
-          conda install --yes --quiet --use-local bokeh `python scripts/deps.py run test`
+          conda install --yes --quiet --use-local bokeh `python scripts/deps.py run test` python=${{ matrix.python-version }}
 
       - name: Cache node modules
         uses: actions/cache@v1

--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -534,6 +534,8 @@ jobs:
         run: |
           conda config --set auto_update_conda off
           conda config --append channels bokeh
+          # XXX (bev) note C-F just for unit tests
+          conda config --append channels conda-forge
           conda config --get channels
           conda install --yes --quiet $CONDA_REQS
 

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -601,6 +601,6 @@ BokehTornado.__doc__ = format_docstring(
 )
 
 # See https://github.com/bokeh/bokeh/issues/9507
-if sys.platform == 'win32':
+if sys.platform == 'win32' and sys.version_info[:3] >= (3, 8, 0):
     import asyncio
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -20,6 +20,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import os
+import sys
 from pprint import pformat
 from urllib.parse import urljoin
 
@@ -598,3 +599,8 @@ BokehTornado.__doc__ = format_docstring(
     DEFAULT_UNUSED_LIFETIME_MS=DEFAULT_UNUSED_LIFETIME_MS,
     DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES=DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES,
 )
+
+# See https://github.com/bokeh/bokeh/issues/9507
+if sys.platform == 'win32':
+    import asyncio
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())


### PR DESCRIPTION
* issues: fixes #9507 

This PR adds unit test builds for Python 3.8 and should also run the CI workflow on pushes to master. 

Also addresses a real failure on win/py38