### PR TITLE
Allow to publish dev bokehjs packages

### DIFF
--- a/bokehjs/package-lock.json
+++ b/bokehjs/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "bokehjs",
-  "version": "2.0.0dev5",
+  "name": "@bokeh/bokehjs",
+  "version": "2.0.0-dev.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -490,7 +490,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -799,6 +800,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -938,7 +940,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "devtools-protocol": {
       "version": "0.0.719693",
@@ -1353,7 +1356,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "fast-deep-equal": {
       "version": "2.0.1",
@@ -1929,7 +1933,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -2149,13 +2154,15 @@
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
       "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "mime-types": {
       "version": "2.1.24",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
       "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "mime-db": "1.40.0"
       }
@@ -3245,7 +3252,8 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "type": {
       "version": "1.2.0",

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "bokehjs",
-  "version": "2.0.0dev5",
+  "name": "@bokeh/bokehjs",
+  "version": "2.0.0-dev.5",
   "description": "Interactive, novel data visualization",
   "keywords": [
     "bokeh",
@@ -20,6 +20,12 @@
     "node": ">=10.13",
     "npm": ">=6.0"
   },
+  "files": [
+    "build/js/bokeh*.min.js",
+    "build/js/legacy/bokeh*.min.js",
+    "build/js/lib/**/*.js",
+    "build/js/types/**/*.d.ts"
+  ],
   "devDependencies": {
     "semver": "^6.3.0",
     "toposort": "^2.0.2",

--- a/bokehjs/src/lib/document/document.ts
+++ b/bokehjs/src/lib/document/document.ts
@@ -610,10 +610,14 @@ export class Document {
   static from_json(json: DocJson): Document {
     logger.debug("Creating Document from JSON")
 
+    function pyify(version: string) {
+      return version.replace(/-(dev|rc)\./, "$1")
+    }
+
     const py_version = json.version! // XXX!
     const is_dev = py_version.indexOf('+') !== -1 || py_version.indexOf('-') !== -1
     const versions_string = `Library versions: JS (${js_version}) / Python (${py_version})`
-    if (!is_dev && js_version !== py_version) {
+    if (!is_dev && pyify(js_version) != py_version) {
       logger.warn("JS/Python version mismatch")
       logger.warn(versions_string)
     } else

--- a/bokehjs/src/lib/version.ts
+++ b/bokehjs/src/lib/version.ts
@@ -1,1 +1,1 @@
-export const version = '2.0.0dev5'
+export const version = '2.0.0-dev.5'

--- a/bokehjs/test/unit/document/document.ts
+++ b/bokehjs/test/unit/document/document.ts
@@ -619,7 +619,8 @@ describe("Document", () => {
     try {
       const json = d.to_json_string()
       const parsed = JSON.parse(json)
-      parsed.version = `${js_version}`
+      const py_version = js_version.replace(/-(dev|rc)\./, "$1")
+      parsed.version = `${py_version}`
       const out0 = trap(() => Document.from_json_string(JSON.stringify(parsed)))
       expect(out0.warn).to.be.equal("")
 
@@ -627,23 +628,23 @@ describe("Document", () => {
       const out1 = trap(() => Document.from_json_string(JSON.stringify(parsed)))
       expect(out1.warn).to.be.equal(`[bokeh] JS/Python version mismatch\n[bokeh] Library versions: JS (${js_version}) / Python (${parsed.version})\n`)
 
-      parsed.version = `${js_version}rc123`
+      parsed.version = `${py_version}rc123`
       const out2 = trap(() => Document.from_json_string(JSON.stringify(parsed)))
       expect(out2.warn).to.be.equal(`[bokeh] JS/Python version mismatch\n[bokeh] Library versions: JS (${js_version}) / Python (${parsed.version})\n`)
 
-      parsed.version = `${js_version}dev123`
+      parsed.version = `${py_version}dev123`
       const out3 = trap(() => Document.from_json_string(JSON.stringify(parsed)))
       expect(out3.warn).to.be.equal(`[bokeh] JS/Python version mismatch\n[bokeh] Library versions: JS (${js_version}) / Python (${parsed.version})\n`)
 
-      parsed.version = `${js_version}-foo`
+      parsed.version = `${py_version}-foo`
       const out4 = trap(() => Document.from_json_string(JSON.stringify(parsed)))
       expect(out4.warn).to.be.equal("")
 
-      parsed.version = `${js_version}rc123-foo`
+      parsed.version = `${py_version}rc123-foo`
       const out5 = trap(() => Document.from_json_string(JSON.stringify(parsed)))
       expect(out5.warn).to.be.equal("")
 
-      parsed.version = `${js_version}dev123-bar`
+      parsed.version = `${py_version}dev123-bar`
       const out6 = trap(() => Document.from_json_string(JSON.stringify(parsed)))
       expect(out6.warn).to.be.equal("")
     } finally {

--- a/scripts/deps.py
+++ b/scripts/deps.py
@@ -30,8 +30,9 @@ section = {
     "test"   : meta_src["test"]["requires"],
 }
 
+args = sys.argv[1:] or ["build", "deploy", "run", "test"]
 spec = []
-for name in sys.argv[1:]:
+for name in args:
     spec += section[name]
 
 # bare python unpins python version causing upgrade to latest


### PR DESCRIPTION
This changes the dev version format in bokehjs package, to match npm's requirements (e.g. `2.0.1-dev5` -> `2.0.1-dev.5`). It's unfortunate, but this is how it works. I've been using this pattern in `jupyter_bokeh` and `ipywidgets_bokeh`. I also switched package name from `bokehjs` to `@bokeh/bokehjs`. This isn't strictly necessary at this point, but it's useful to start using this pattern.
