### PR TITLE
Add -> None to all test_ functions

### DIFF
--- a/tests/codebase/test_code_quality.py
+++ b/tests/codebase/test_code_quality.py
@@ -26,7 +26,7 @@ from os.path import abspath, basename, join, relpath, split, splitext
 #-----------------------------------------------------------------------------
 
 @pytest.mark.codebase
-def test_code_quality():
+def test_code_quality() -> None:
     ''' Applies a collection of general codebase style and quality rules to
     every file inm the repository. Unless specifically excepted:
 

--- a/tests/codebase/test_flake8.py
+++ b/tests/codebase/test_flake8.py
@@ -27,7 +27,7 @@ from . import TOP_PATH
 #-----------------------------------------------------------------------------
 
 @pytest.mark.codebase
-def test_flake8():
+def test_flake8() -> None:
     ''' Assures that the Python codebase passes configured Flake8 checks
 
     '''

--- a/tests/codebase/test_isort.py
+++ b/tests/codebase/test_isort.py
@@ -27,7 +27,7 @@ from . import TOP_PATH
 #-----------------------------------------------------------------------------
 
 @pytest.mark.codebase
-def test_isort():
+def test_isort() -> None:
     ''' Assures that the Python codebase passes configured Flake8 checks
 
     '''

--- a/tests/codebase/test_js_license_set.py
+++ b/tests/codebase/test_js_license_set.py
@@ -36,7 +36,7 @@ LICENSES = [
 ]
 
 @pytest.mark.codebase
-def test_js_license_set():
+def test_js_license_set() -> None:
     ''' If the current set of JS licenses changes, they should be noted in
     the bokehjs/LICENSE file.
 

--- a/tests/codebase/test_no_client_server_common.py
+++ b/tests/codebase/test_no_client_server_common.py
@@ -35,7 +35,7 @@ BASIC_IMPORTS = [
 #-----------------------------------------------------------------------------
 
 @pytest.mark.codebase
-def test_no_client_server_common():
+def test_no_client_server_common() -> None:
     ''' Basic usage of Bokeh should not result in any client/server code being
     imported. This test ensures that importing basic modules does not bring in
     bokeh.client or bokeh.server.

--- a/tests/codebase/test_no_ipython_common.py
+++ b/tests/codebase/test_no_ipython_common.py
@@ -34,7 +34,7 @@ BASIC_IMPORTS = [
 ]
 
 @pytest.mark.codebase
-def test_no_ipython_common():
+def test_no_ipython_common() -> None:
     ''' Basic usage of Bokeh should not result in any IPython code being
     imported. This test ensures that importing basic modules does not bring in
     IPython.

--- a/tests/codebase/test_no_request_host.py
+++ b/tests/codebase/test_no_request_host.py
@@ -28,7 +28,7 @@ from . import TOP_PATH
 #-----------------------------------------------------------------------------
 
 @pytest.mark.codebase
-def test_no_request_host():
+def test_no_request_host() -> None:
     ''' It is not safe for the Bokeh codebase to use request.host in any way.
     This test ensures "request.host" does not appear in any file.
 

--- a/tests/codebase/test_no_tornado_common.py
+++ b/tests/codebase/test_no_tornado_common.py
@@ -32,7 +32,7 @@ BASIC_IMPORTS = [
 ]
 
 @pytest.mark.codebase
-def test_no_tornado_common():
+def test_no_tornado_common() -> None:
     ''' Basic usage of Bokeh should not result in any Tornado code being
     imported. This test ensures that importing basic modules does not bring in
     Tornado.

--- a/tests/codebase/test_python_execution_with_OO.py
+++ b/tests/codebase/test_python_execution_with_OO.py
@@ -30,7 +30,7 @@ from . import TOP_PATH
 blacklist = {}
 
 @pytest.mark.codebase
-def test_python_execution_with_OO():
+def test_python_execution_with_OO() -> None:
     ''' Running python with -OO will discard docstrings (__doc__ is None)
     which can cause problems if docstrings are naively formatted.
 

--- a/tests/codebase/test_windows_reserved_filenames.py
+++ b/tests/codebase/test_windows_reserved_filenames.py
@@ -24,7 +24,7 @@ from os.path import join, splitext
 #-----------------------------------------------------------------------------
 
 @pytest.mark.codebase
-def test_windows_reserved_filenames():
+def test_windows_reserved_filenames() -> None:
     ''' Certain seemingly innocuous filenames like "aux.js" will cause
     Windows packages to fail spectacularly. This test ensures those reserved
     names are not present in the codebase.

--- a/tests/integration/embed/test_json_item.py
+++ b/tests/integration/embed/test_json_item.py
@@ -54,7 +54,7 @@ PAGE = Template("""
 @pytest.mark.selenium
 class Test_json_item(object):
 
-    def test_bkroot_added_to_target(self, driver, test_file_path_and_url):
+    def test_bkroot_added_to_target(self, driver, test_file_path_and_url) -> None:
         p = Plot()
         html = PAGE.render(item=json.dumps(json_item(p)), resources=INLINE.render())
 

--- a/tests/integration/models/test_datarange1d.py
+++ b/tests/integration/models/test_datarange1d.py
@@ -51,7 +51,7 @@ def _make_plot(**kw):
 @pytest.mark.selenium
 class Test_DataRange1d(object):
 
-    def test_includes_hidden_glyphs_by_default(self, single_plot_page):
+    def test_includes_hidden_glyphs_by_default(self, single_plot_page) -> None:
         plot, glyph = _make_plot()
 
         page = single_plot_page(plot)
@@ -64,7 +64,7 @@ class Test_DataRange1d(object):
 
         assert page.has_no_console_errors()
 
-    def test_includes_hidden_glyphs_when_asked(self, single_plot_page):
+    def test_includes_hidden_glyphs_when_asked(self, single_plot_page) -> None:
         plot, glyph = _make_plot(only_visible=False)
 
         page = single_plot_page(plot)
@@ -77,7 +77,7 @@ class Test_DataRange1d(object):
 
         assert page.has_no_console_errors()
 
-    def test_excludes_hidden_glyphs_when_asked(self, single_plot_page):
+    def test_excludes_hidden_glyphs_when_asked(self, single_plot_page) -> None:
         plot, glyph = _make_plot(only_visible=True)
 
         page = single_plot_page(plot)
@@ -91,7 +91,7 @@ class Test_DataRange1d(object):
         assert page.has_no_console_errors()
 
 
-    def test_updates_when_visibility_is_toggled(self, single_plot_page):
+    def test_updates_when_visibility_is_toggled(self, single_plot_page) -> None:
         source = ColumnDataSource(dict(x=[1, 2], y1=[0, 1], y2=[10,11]))
         plot = Plot(plot_height=400, plot_width=400, x_range=DataRange1d(), y_range=DataRange1d(only_visible=True), min_border=0)
         plot.add_glyph(source, Circle(x='x', y='y1'))

--- a/tests/integration/models/test_plot.py
+++ b/tests/integration/models/test_plot.py
@@ -34,7 +34,7 @@ pytest_plugins = (
 @pytest.mark.selenium
 class Test_Plot(object):
 
-    def test_inner_dims_trigger_on_dynamic_add(self, bokeh_server_page):
+    def test_inner_dims_trigger_on_dynamic_add(self, bokeh_server_page) -> None:
 
         data = {}
         def modify_doc(doc):

--- a/tests/integration/models/test_sources.py
+++ b/tests/integration/models/test_sources.py
@@ -42,7 +42,7 @@ def is_cds_data_streamed(evt):
 @pytest.mark.selenium
 class Test_ColumnDataSource(object):
 
-    def test_client_source_patch_sends_patch_event(self, bokeh_server_page):
+    def test_client_source_patch_sends_patch_event(self, bokeh_server_page) -> None:
         data = {'x': [1,2,3,4], 'y': [10,20,30,40]}
         source = ColumnDataSource(data)
         def modify_doc(doc):
@@ -86,7 +86,7 @@ class Test_ColumnDataSource(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         #assert page.has_no_console_errors()
 
-    def test_client_source_stream_sends_patch_event(self, bokeh_server_page):
+    def test_client_source_stream_sends_patch_event(self, bokeh_server_page) -> None:
         data = {'x': [1,2,3,4], 'y': [10,20,30,40]}
         source = ColumnDataSource(data)
         def modify_doc(doc):

--- a/tests/integration/tools/test_box_edit_tool.py
+++ b/tests/integration/tools/test_box_edit_tool.py
@@ -79,7 +79,7 @@ def _make_server_plot(expected, num_objects=0):
 @pytest.mark.selenium
 class Test_BoxEditTool(object):
 
-    def test_selected_by_default(self, single_plot_page):
+    def test_selected_by_default(self, single_plot_page) -> None:
         plot = _make_plot('both')
 
         page = single_plot_page(plot)
@@ -89,7 +89,7 @@ class Test_BoxEditTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_can_be_deselected_and_selected(self, single_plot_page):
+    def test_can_be_deselected_and_selected(self, single_plot_page) -> None:
         plot = _make_plot('both')
 
         page = single_plot_page(plot)
@@ -110,7 +110,7 @@ class Test_BoxEditTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_double_click_triggers_draw(self, single_plot_page):
+    def test_double_click_triggers_draw(self, single_plot_page) -> None:
         plot = _make_plot('both')
 
         page = single_plot_page(plot)
@@ -130,7 +130,7 @@ class Test_BoxEditTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_shift_drag_triggers_draw(self, single_plot_page):
+    def test_shift_drag_triggers_draw(self, single_plot_page) -> None:
         plot = _make_plot('both')
 
         page = single_plot_page(plot)
@@ -147,7 +147,7 @@ class Test_BoxEditTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_drag_moves_box(self, single_plot_page):
+    def test_drag_moves_box(self, single_plot_page) -> None:
         plot = _make_plot('both')
 
         page = single_plot_page(plot)
@@ -169,7 +169,7 @@ class Test_BoxEditTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_backspace_deletes_drawn_box(self, single_plot_page):
+    def test_backspace_deletes_drawn_box(self, single_plot_page) -> None:
         plot = _make_plot('both', num_objects=2)
 
         page = single_plot_page(plot)
@@ -191,7 +191,7 @@ class Test_BoxEditTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_num_objects_limits_drawn_boxes(self, single_plot_page):
+    def test_num_objects_limits_drawn_boxes(self, single_plot_page) -> None:
         plot = _make_plot('both', num_objects=2)
 
         page = single_plot_page(plot)
@@ -209,7 +209,7 @@ class Test_BoxEditTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_box_draw_syncs_to_server(self, bokeh_server_page):
+    def test_box_draw_syncs_to_server(self, bokeh_server_page) -> None:
         expected = {"x": [1, 2, 1.2162162162162162],
                     "y": [1, 1, 1.875],
                     "width": [0.5, 0.5, 0.8108108108108109],
@@ -226,7 +226,7 @@ class Test_BoxEditTool(object):
         page.click_custom_action()
         assert page.results == {"matches": "True"}
 
-    def test_box_drag_syncs_to_server(self, bokeh_server_page):
+    def test_box_drag_syncs_to_server(self, bokeh_server_page) -> None:
         expected = {"x": [1, 2, 1.6216216216216217],
                     "y": [1, 1, 1.5000000000000002],
                     "width": [0.5, 0.5, 0.8108108108108109],
@@ -246,7 +246,7 @@ class Test_BoxEditTool(object):
         page.click_custom_action()
         assert page.results == {"matches": "True"}
 
-    def test_box_delete_syncs_to_server(self, bokeh_server_page):
+    def test_box_delete_syncs_to_server(self, bokeh_server_page) -> None:
         expected = {"x": [2], "y": [1],
                     "width": [0.5], "height": [0.5]}
 

--- a/tests/integration/tools/test_box_zoom_tool.py
+++ b/tests/integration/tools/test_box_zoom_tool.py
@@ -53,7 +53,7 @@ def _make_plot(tool):
 @pytest.mark.selenium
 class Test_BoxZoomTool(object):
 
-    def test_deselected_by_default_with_pan_tool(self, single_plot_page):
+    def test_deselected_by_default_with_pan_tool(self, single_plot_page) -> None:
         plot = _make_plot(BoxZoomTool())
         plot.add_tools(PanTool())
 
@@ -64,7 +64,7 @@ class Test_BoxZoomTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_selected_by_default_without_pan_tool(self, single_plot_page):
+    def test_selected_by_default_without_pan_tool(self, single_plot_page) -> None:
         plot = _make_plot(BoxZoomTool())
 
         page = single_plot_page(plot)
@@ -74,7 +74,7 @@ class Test_BoxZoomTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_can_be_selected_and_deselected(self, single_plot_page):
+    def test_can_be_selected_and_deselected(self, single_plot_page) -> None:
         plot = _make_plot(BoxZoomTool())
         plot.add_tools(PanTool())
 
@@ -97,7 +97,7 @@ class Test_BoxZoomTool(object):
         assert page.has_no_console_errors()
 
     @pytest.mark.parametrize('dim', ['both', 'width', 'height'])
-    def test_box_zoom_has_no_effect_when_deslected(self, dim, single_plot_page):
+    def test_box_zoom_has_no_effect_when_deslected(self, dim, single_plot_page) -> None:
         plot = _make_plot(BoxZoomTool(dimensions=dim))
 
         page = single_plot_page(plot)
@@ -117,7 +117,7 @@ class Test_BoxZoomTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_box_zoom_with_corner_origin(self, single_plot_page):
+    def test_box_zoom_with_corner_origin(self, single_plot_page) -> None:
         plot = _make_plot(BoxZoomTool())
 
         page = single_plot_page(plot)
@@ -134,7 +134,7 @@ class Test_BoxZoomTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_box_zoom_with_center_origin(self, single_plot_page):
+    def test_box_zoom_with_center_origin(self, single_plot_page) -> None:
         plot = _make_plot(BoxZoomTool(origin="center"))
 
         page = single_plot_page(plot)
@@ -149,7 +149,7 @@ class Test_BoxZoomTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_box_zoom_with_center_origin_clips_to_range(self, single_plot_page):
+    def test_box_zoom_with_center_origin_clips_to_range(self, single_plot_page) -> None:
         plot = _make_plot(BoxZoomTool(origin="center"))
 
         page = single_plot_page(plot)
@@ -166,7 +166,7 @@ class Test_BoxZoomTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_box_zoom_width_updates_only_xrange(self, single_plot_page):
+    def test_box_zoom_width_updates_only_xrange(self, single_plot_page) -> None:
         plot = _make_plot(BoxZoomTool(dimensions="width"))
 
         page = single_plot_page(plot)
@@ -183,7 +183,7 @@ class Test_BoxZoomTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_box_zoom_width_clips_to_xrange(self, single_plot_page):
+    def test_box_zoom_width_clips_to_xrange(self, single_plot_page) -> None:
         plot = _make_plot(BoxZoomTool(dimensions="width"))
 
         page = single_plot_page(plot)
@@ -200,7 +200,7 @@ class Test_BoxZoomTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_box_zoom_height_updates_only_yrange(self, single_plot_page):
+    def test_box_zoom_height_updates_only_yrange(self, single_plot_page) -> None:
         plot = _make_plot(BoxZoomTool(dimensions="height"))
 
         page = single_plot_page(plot)
@@ -217,7 +217,7 @@ class Test_BoxZoomTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_box_zoom_height_clips_to_yrange(self, single_plot_page):
+    def test_box_zoom_height_clips_to_yrange(self, single_plot_page) -> None:
         plot = _make_plot(BoxZoomTool(dimensions="height"))
 
         page = single_plot_page(plot)
@@ -234,7 +234,7 @@ class Test_BoxZoomTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_box_zoom_can_match_aspect(self, single_plot_page):
+    def test_box_zoom_can_match_aspect(self, single_plot_page) -> None:
         plot = _make_plot(BoxZoomTool(match_aspect=True))
         plot.x_range.end = 2
 

--- a/tests/integration/tools/test_custom_action.py
+++ b/tests/integration/tools/test_custom_action.py
@@ -32,7 +32,7 @@ pytest_plugins = (
 @pytest.mark.selenium
 class Test_CustomAction(object):
 
-    def test_tap_triggers_callback(self, single_plot_page):
+    def test_tap_triggers_callback(self, single_plot_page) -> None:
         plot = figure(height=800, width=1000, tools='')
         plot.rect(x=[1, 2], y=[1, 1], width=1, height=1)
         plot.add_tools(CustomAction(callback=CustomJS(code=RECORD("activated", "true"))))

--- a/tests/integration/tools/test_freehand_draw_tool.py
+++ b/tests/integration/tools/test_freehand_draw_tool.py
@@ -76,7 +76,7 @@ def _make_server_plot(expected, num_objects=0):
 @pytest.mark.selenium
 class Test_FreehandDrawTool(object):
 
-    def test_selected_by_default(self, single_plot_page):
+    def test_selected_by_default(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -86,7 +86,7 @@ class Test_FreehandDrawTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_can_be_deselected_and_selected(self, single_plot_page):
+    def test_can_be_deselected_and_selected(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -107,7 +107,7 @@ class Test_FreehandDrawTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_drag_triggers_draw(self, single_plot_page):
+    def test_drag_triggers_draw(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -122,7 +122,7 @@ class Test_FreehandDrawTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_num_object_limits_lines(self, single_plot_page):
+    def test_num_object_limits_lines(self, single_plot_page) -> None:
         plot = _make_plot(num_objects=1)
 
         page = single_plot_page(plot)
@@ -138,7 +138,7 @@ class Test_FreehandDrawTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_freehand_draw_syncs_to_server(self, bokeh_server_page):
+    def test_freehand_draw_syncs_to_server(self, bokeh_server_page) -> None:
         expected = {'xs': [[1.6216216216216217, 2.027027027027027, 2.027027027027027, 2.027027027027027]],
                     'ys': [[1.5, 1.125, 1.125, 1.125]]}
 
@@ -149,7 +149,7 @@ class Test_FreehandDrawTool(object):
 
         assert page.results == {"matches": "True"}
 
-    def test_line_delete_syncs_to_server(self, bokeh_server_page):
+    def test_line_delete_syncs_to_server(self, bokeh_server_page) -> None:
         expected = {'xs': [], 'ys': []}
 
         page = bokeh_server_page(_make_server_plot(expected))

--- a/tests/integration/tools/test_pan_tool.py
+++ b/tests/integration/tools/test_pan_tool.py
@@ -55,7 +55,7 @@ _css = dict(both='pan', width='xpan', height='ypan')
 class Test_PanTool(object):
 
     @pytest.mark.parametrize('dim', ['both', 'width', 'height'])
-    def test_selected_by_default(self, dim, single_plot_page):
+    def test_selected_by_default(self, dim, single_plot_page) -> None:
         plot = _make_plot(dim)
 
         page = single_plot_page(plot)
@@ -68,7 +68,7 @@ class Test_PanTool(object):
         assert page.has_no_console_errors()
 
     @pytest.mark.parametrize('dim', ['both', 'width', 'height'])
-    def test_can_be_deselected_and_selected(self, dim, single_plot_page):
+    def test_can_be_deselected_and_selected(self, dim, single_plot_page) -> None:
         plot = _make_plot(dim)
 
         page = single_plot_page(plot)
@@ -92,7 +92,7 @@ class Test_PanTool(object):
         assert page.has_no_console_errors()
 
     @pytest.mark.parametrize('dim', ['both', 'width', 'height'])
-    def test_pan_has_no_effect_when_deslected(self, dim, single_plot_page):
+    def test_pan_has_no_effect_when_deslected(self, dim, single_plot_page) -> None:
         plot = _make_plot(dim)
 
         page = single_plot_page(plot)
@@ -114,7 +114,7 @@ class Test_PanTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_pan_updates_both_ranges(self, single_plot_page):
+    def test_pan_updates_both_ranges(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -131,7 +131,7 @@ class Test_PanTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_xpan_upates_only_xrange(self, single_plot_page):
+    def test_xpan_upates_only_xrange(self, single_plot_page) -> None:
         plot = _make_plot('width')
 
         page = single_plot_page(plot)
@@ -148,7 +148,7 @@ class Test_PanTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_ypan_updates_only_yrange(self, single_plot_page):
+    def test_ypan_updates_only_yrange(self, single_plot_page) -> None:
         plot = _make_plot('height')
 
         page = single_plot_page(plot)

--- a/tests/integration/tools/test_point_draw_tool.py
+++ b/tests/integration/tools/test_point_draw_tool.py
@@ -76,7 +76,7 @@ def _make_server_plot(expected):
 @pytest.mark.selenium
 class Test_PointDrawTool(object):
 
-    def test_selected_by_default(self, single_plot_page):
+    def test_selected_by_default(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -86,7 +86,7 @@ class Test_PointDrawTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_can_be_deselected_and_selected(self, single_plot_page):
+    def test_can_be_deselected_and_selected(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -107,7 +107,7 @@ class Test_PointDrawTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_click_triggers_draw(self, single_plot_page):
+    def test_click_triggers_draw(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -123,7 +123,7 @@ class Test_PointDrawTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_click_does_not_trigger_draw(self, single_plot_page):
+    def test_click_does_not_trigger_draw(self, single_plot_page) -> None:
         plot = _make_plot(add=False)
 
         page = single_plot_page(plot)
@@ -138,7 +138,7 @@ class Test_PointDrawTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_drag_moves_point(self, single_plot_page):
+    def test_drag_moves_point(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -155,7 +155,7 @@ class Test_PointDrawTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_drag_does_not_move_point(self, single_plot_page):
+    def test_drag_does_not_move_point(self, single_plot_page) -> None:
         plot = _make_plot(drag=False)
 
         page = single_plot_page(plot)
@@ -172,7 +172,7 @@ class Test_PointDrawTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_num_object_limits_points(self, single_plot_page):
+    def test_num_object_limits_points(self, single_plot_page) -> None:
         plot = _make_plot(num_objects=2)
 
         page = single_plot_page(plot)
@@ -188,7 +188,7 @@ class Test_PointDrawTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_point_draw_syncs_to_server(self, bokeh_server_page):
+    def test_point_draw_syncs_to_server(self, bokeh_server_page) -> None:
         expected = {"x": [1, 2, 1.6216216216216217],
                     "y": [1, 1, 1.5]}
 
@@ -200,7 +200,7 @@ class Test_PointDrawTool(object):
         page.click_custom_action()
         assert page.results == {"matches": "True"}
 
-    def test_point_drag_syncs_to_server(self, bokeh_server_page):
+    def test_point_drag_syncs_to_server(self, bokeh_server_page) -> None:
         expected = {"x": [1, 2, 2.1891891891891895],
                     "y": [1, 1, 1.1024999999999998]}
 
@@ -213,7 +213,7 @@ class Test_PointDrawTool(object):
         page.click_custom_action()
         assert page.results == {"matches": "True"}
 
-    def test_point_delete_syncs_to_server(self, bokeh_server_page):
+    def test_point_delete_syncs_to_server(self, bokeh_server_page) -> None:
         expected = {"x": [1, 2],
                     "y": [1, 1]}
 

--- a/tests/integration/tools/test_poly_draw_tool.py
+++ b/tests/integration/tools/test_poly_draw_tool.py
@@ -81,7 +81,7 @@ def _make_server_plot(expected):
 @pytest.mark.selenium
 class Test_PolyDrawTool(object):
 
-    def test_selected_by_default(self, single_plot_page):
+    def test_selected_by_default(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -91,7 +91,7 @@ class Test_PolyDrawTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_can_be_deselected_and_selected(self, single_plot_page):
+    def test_can_be_deselected_and_selected(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -112,7 +112,7 @@ class Test_PolyDrawTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_double_click_triggers_draw(self, single_plot_page):
+    def test_double_click_triggers_draw(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -129,7 +129,7 @@ class Test_PolyDrawTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_click_snaps_to_vertex(self, single_plot_page):
+    def test_click_snaps_to_vertex(self, single_plot_page) -> None:
         plot = _make_plot(vertices=True)
 
         page = single_plot_page(plot)
@@ -148,7 +148,7 @@ class Test_PolyDrawTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_drag_moves_multi_line(self, single_plot_page):
+    def test_drag_moves_multi_line(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -166,7 +166,7 @@ class Test_PolyDrawTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_drag_does_not_move_multi_line(self, single_plot_page):
+    def test_drag_does_not_move_multi_line(self, single_plot_page) -> None:
         plot = _make_plot(drag=False)
 
         page = single_plot_page(plot)
@@ -184,7 +184,7 @@ class Test_PolyDrawTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_num_object_limits_multi_lines(self, single_plot_page):
+    def test_num_object_limits_multi_lines(self, single_plot_page) -> None:
         plot = _make_plot(num_objects=1)
 
         page = single_plot_page(plot)
@@ -202,7 +202,7 @@ class Test_PolyDrawTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_poly_draw_syncs_to_server(self, bokeh_server_page):
+    def test_poly_draw_syncs_to_server(self, bokeh_server_page) -> None:
         expected = {"xs": [[1, 2], [1.6216216216216217, 2.4324324324324325]],
                     "ys": [[1, 1], [1.5, 0.75]]}
 
@@ -218,7 +218,7 @@ class Test_PolyDrawTool(object):
 
     # TODO (bev) Fix up after GH CI switch
     @pytest.mark.skip
-    def test_poly_drag_syncs_to_server(self, bokeh_server_page):
+    def test_poly_drag_syncs_to_server(self, bokeh_server_page) -> None:
         expected = {"xs": [[1, 2], [2.1891891891891895, 3]],
                     "ys": [[1, 1], [1.125, 0.375]]}
 
@@ -233,7 +233,7 @@ class Test_PolyDrawTool(object):
         page.click_custom_action()
         assert page.results == {"matches": "True"}
 
-    def test_poly_delete_syncs_to_server(self, bokeh_server_page):
+    def test_poly_delete_syncs_to_server(self, bokeh_server_page) -> None:
         expected = {"xs": [[1, 2]],
                     "ys": [[1, 1]]}
 

--- a/tests/integration/tools/test_poly_edit_tool.py
+++ b/tests/integration/tools/test_poly_edit_tool.py
@@ -246,7 +246,7 @@ class Test_PolyEditTool(object):
 
     # TODO (bev) Fix up after GH CI switch
     @pytest.mark.skip
-    def test_poly_delete_syncs_to_server(self, bokeh_server_page):
+    def test_poly_delete_syncs_to_server(self, bokeh_server_page) -> None:
         expected = {"xs": [[1, 2], [1.6, 2.027027027027027]],
                     "ys": [[1, 1], [1.5, 1.8749999999999998]]}
         page = bokeh_server_page(_make_server_plot(expected))

--- a/tests/integration/tools/test_range_tool.py
+++ b/tests/integration/tools/test_range_tool.py
@@ -55,7 +55,7 @@ def _make_plot():
 @pytest.mark.selenium
 class Test_RangeTool(object):
 
-    def test_selected_by_default(self, single_plot_page):
+    def test_selected_by_default(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -66,7 +66,7 @@ class Test_RangeTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_can_be_deselected_and_selected(self, single_plot_page):
+    def test_can_be_deselected_and_selected(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -89,7 +89,7 @@ class Test_RangeTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_center_pan_has_no_effect_when_deselected(self, single_plot_page):
+    def test_center_pan_has_no_effect_when_deselected(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -108,7 +108,7 @@ class Test_RangeTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_center_pan_updates_range_when_selected(self, single_plot_page):
+    def test_center_pan_updates_range_when_selected(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -131,7 +131,7 @@ class Test_RangeTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_center_pan_with_right_side_outside(self, single_plot_page):
+    def test_center_pan_with_right_side_outside(self, single_plot_page) -> None:
         plot = _make_plot()
         plot.tools[0].x_range.end = 1.1
 
@@ -155,7 +155,7 @@ class Test_RangeTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_center_pan_with_left_side_outside(self, single_plot_page):
+    def test_center_pan_with_left_side_outside(self, single_plot_page) -> None:
         plot = _make_plot()
         plot.tools[0].x_range.start = -0.1
 
@@ -179,7 +179,7 @@ class Test_RangeTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_left_edge_drag_updates_start(self, single_plot_page):
+    def test_left_edge_drag_updates_start(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -200,7 +200,7 @@ class Test_RangeTool(object):
         assert results['start'] == 0.2
         assert results['end'] == 0.6
 
-    def test_left_edge_drag_can_flip(self, single_plot_page):
+    def test_left_edge_drag_can_flip(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -213,7 +213,7 @@ class Test_RangeTool(object):
         assert results['start'] == 0.6
         assert results['end'] == 0.7
 
-    def test_left_edge_drag_with_right_edge_outside(self, single_plot_page):
+    def test_left_edge_drag_with_right_edge_outside(self, single_plot_page) -> None:
         plot = _make_plot()
         plot.tools[0].x_range.end = 1.1
 
@@ -227,7 +227,7 @@ class Test_RangeTool(object):
         assert results['start'] == 0.7
         assert results['end'] == 1.1
 
-    def test_right_edge_drag_updates_end(self, single_plot_page):
+    def test_right_edge_drag_updates_end(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -248,7 +248,7 @@ class Test_RangeTool(object):
         assert results['start'] == 0.4
         assert results['end'] == 0.5
 
-    def test_right_edge_drag_can_flip(self, single_plot_page):
+    def test_right_edge_drag_can_flip(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -261,7 +261,7 @@ class Test_RangeTool(object):
         assert results['start'] == 0.3
         assert results['end'] == 0.4
 
-    def test_right_edge_drag_with_left_edge_outside(self, single_plot_page):
+    def test_right_edge_drag_with_left_edge_outside(self, single_plot_page) -> None:
         plot = _make_plot()
         plot.tools[0].x_range.start = -0.1
 
@@ -278,7 +278,7 @@ class Test_RangeTool(object):
 
     # TODO (bev) This test is broken due to some dumb reason with tooling
     @pytest.mark.skip
-    def test_center_pan_stops_at_plot_range_limit(self, single_plot_page):
+    def test_center_pan_stops_at_plot_range_limit(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)

--- a/tests/integration/tools/test_reset_tool.py
+++ b/tests/integration/tools/test_reset_tool.py
@@ -54,7 +54,7 @@ def _make_plot():
 @pytest.mark.selenium
 class Test_ResetTool(object):
 
-    def test_deselected_by_default(self, single_plot_page):
+    def test_deselected_by_default(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -64,7 +64,7 @@ class Test_ResetTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_clicking_resets_range(self, single_plot_page):
+    def test_clicking_resets_range(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -95,7 +95,7 @@ class Test_ResetTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_clicking_resets_selection(self, single_plot_page):
+    def test_clicking_resets_selection(self, single_plot_page) -> None:
         source = ColumnDataSource(dict(x=[1, 2], y=[1, 1]))
         source.selected.indices = [0]
         source.selected.line_indices = [0]

--- a/tests/integration/tools/test_tap_tool.py
+++ b/tests/integration/tools/test_tap_tool.py
@@ -37,7 +37,7 @@ pytest_plugins = (
 @pytest.mark.selenium
 class Test_TapTool(object):
 
-    def test_tap_triggers_no_callback_without_hit(self, single_plot_page):
+    def test_tap_triggers_no_callback_without_hit(self, single_plot_page) -> None:
         plot = figure(height=800, width=1000, tools='')
         plot.rect(x=[1, 2], y=[1, 1], width=1, height=1)
         plot.add_tools(TapTool(callback=CustomJS(code=RECORD("indices", "cb_data.source.selected.indices"))))
@@ -52,7 +52,7 @@ class Test_TapTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_tap_triggers_callback_with_indices(self, single_plot_page):
+    def test_tap_triggers_callback_with_indices(self, single_plot_page) -> None:
         plot = figure(height=800, width=1000, tools='')
         plot.rect(x=[1, 2], y=[1, 1], width=1, height=1)
         plot.add_tools(TapTool(callback=CustomJS(code=RECORD("indices", "cb_data.source.selected.indices"))))
@@ -67,7 +67,7 @@ class Test_TapTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_tap_reports_all_indices_on_overlap(self, single_plot_page):
+    def test_tap_reports_all_indices_on_overlap(self, single_plot_page) -> None:
         plot = figure(height=800, width=1000, tools='')
         plot.rect(x=[1, 1], y=[1, 1], width=1, height=1)
         plot.add_tools(TapTool(callback=CustomJS(code=RECORD("indices", "cb_data.source.selected.indices"))))

--- a/tests/integration/tools/test_toolbar_autohide.py
+++ b/tests/integration/tools/test_toolbar_autohide.py
@@ -33,7 +33,7 @@ pytest_plugins = (
 @pytest.mark.selenium
 class Test_Toobar_Autohide(object):
 
-    def test_toolbar_is_visible_by_default_and_stays_visible(self, single_plot_page):
+    def test_toolbar_is_visible_by_default_and_stays_visible(self, single_plot_page) -> None:
         plot = figure(height=800, width=1000)
         plot.rect(x=[1, 2], y=[1, 1], width=1, height=1)
 
@@ -53,7 +53,7 @@ class Test_Toobar_Autohide(object):
 
         assert page.has_no_console_errors()
 
-    def test_toolbar_with_autohide_becomes_visible_when_cursor_is_over_plot(self, single_plot_page):
+    def test_toolbar_with_autohide_becomes_visible_when_cursor_is_over_plot(self, single_plot_page) -> None:
         plot = figure(height=800, width=1000)
         plot.toolbar.autohide = True
         plot.rect(x=[1, 2], y=[1, 1], width=1, height=1)

--- a/tests/integration/tools/test_wheel_zoom_tool.py
+++ b/tests/integration/tools/test_wheel_zoom_tool.py
@@ -52,7 +52,7 @@ def _make_plot(dimensions="both"):
 @pytest.mark.selenium
 class Test_WheelZoomTool(object):
 
-    def test_deselected_by_default(self, single_plot_page):
+    def test_deselected_by_default(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -62,7 +62,7 @@ class Test_WheelZoomTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_can_be_selected_and_deselected(self, single_plot_page):
+    def test_can_be_selected_and_deselected(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -83,7 +83,7 @@ class Test_WheelZoomTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_zoom_out(self, single_plot_page):
+    def test_zoom_out(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -115,7 +115,7 @@ class Test_WheelZoomTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_zoom_in(self, single_plot_page):
+    def test_zoom_in(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -147,7 +147,7 @@ class Test_WheelZoomTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_xwheel_zoom(self, single_plot_page):
+    def test_xwheel_zoom(self, single_plot_page) -> None:
         plot = _make_plot(dimensions="width")
 
         page = single_plot_page(plot)
@@ -189,7 +189,7 @@ class Test_WheelZoomTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_ywheel_zoom(self, single_plot_page):
+    def test_ywheel_zoom(self, single_plot_page) -> None:
         plot = _make_plot(dimensions="height")
 
         page = single_plot_page(plot)

--- a/tests/integration/tools/test_zoom_in_tool.py
+++ b/tests/integration/tools/test_zoom_in_tool.py
@@ -52,7 +52,7 @@ def _make_plot():
 @pytest.mark.selenium
 class Test_ZoomInTool(object):
 
-    def test_deselected_by_default(self, single_plot_page):
+    def test_deselected_by_default(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -62,7 +62,7 @@ class Test_ZoomInTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_clicking_zooms_in(self, single_plot_page):
+    def test_clicking_zooms_in(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)

--- a/tests/integration/tools/test_zoom_out_tool.py
+++ b/tests/integration/tools/test_zoom_out_tool.py
@@ -52,7 +52,7 @@ def _make_plot():
 @pytest.mark.selenium
 class Test_ZoomOutTool(object):
 
-    def test_deselected_by_default(self, single_plot_page):
+    def test_deselected_by_default(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -62,7 +62,7 @@ class Test_ZoomOutTool(object):
 
         assert page.has_no_console_errors()
 
-    def test_clicking_zooms_out(self, single_plot_page):
+    def test_clicking_zooms_out(self, single_plot_page) -> None:
         plot = _make_plot()
 
         page = single_plot_page(plot)

--- a/tests/integration/widgets/tables/test_cell_editors.py
+++ b/tests/integration/widgets/tables/test_cell_editors.py
@@ -58,7 +58,7 @@ class Test_CellEditor_Base(object):
 #     values = [True, False]
 #     editor = CheckboxEditor
 
-#     def test_editing_does_not_update_source_on_noneditable_table(self, bokeh_model_page):
+#     def test_editing_does_not_update_source_on_noneditable_table(self, bokeh_model_page) -> None:
 #         self.table.editable = False
 #         page = bokeh_model_page(self.table)
 
@@ -80,7 +80,7 @@ class Test_CellEditor_Base(object):
 
 #         assert page.has_no_console_errors()
 
-#     def test_editing_updates_source(self, bokeh_model_page):
+#     def test_editing_updates_source(self, bokeh_model_page) -> None:
 #         page = bokeh_model_page(self.table)
 
 #         # Click row 1 (which triggers the selection callback)
@@ -106,7 +106,7 @@ class Test_IntEditor(Test_CellEditor_Base):
     values = [1, 2]
     editor = IntEditor
 
-    def test_editing_does_not_update_source_on_noneditable_table(self, bokeh_model_page):
+    def test_editing_does_not_update_source_on_noneditable_table(self, bokeh_model_page) -> None:
         self.table.editable = False
         page = bokeh_model_page(self.table)
 
@@ -129,7 +129,7 @@ class Test_IntEditor(Test_CellEditor_Base):
         assert page.has_no_console_errors()
 
     @pytest.mark.parametrize('bad', ["1.1", "text"])
-    def test_editing_does_not_update_source_on_bad_values(self, bad, bokeh_model_page):
+    def test_editing_does_not_update_source_on_bad_values(self, bad, bokeh_model_page) -> None:
         self.table.editable = False
         page = bokeh_model_page(self.table)
 
@@ -151,7 +151,7 @@ class Test_IntEditor(Test_CellEditor_Base):
 
         assert page.has_no_console_errors()
 
-    def test_editing_updates_source(self, bokeh_model_page):
+    def test_editing_updates_source(self, bokeh_model_page) -> None:
         page = bokeh_model_page(self.table)
 
         # Click row 1 (which triggers the selection callback)
@@ -177,7 +177,7 @@ class Test_NumberEditor(Test_CellEditor_Base):
     values = [1.1, 2.2]
     editor = NumberEditor
 
-    def test_editing_does_not_update_source_on_noneditable_table(self, bokeh_model_page):
+    def test_editing_does_not_update_source_on_noneditable_table(self, bokeh_model_page) -> None:
         self.table.editable = False
         page = bokeh_model_page(self.table)
 
@@ -200,7 +200,7 @@ class Test_NumberEditor(Test_CellEditor_Base):
         assert page.has_no_console_errors()
 
     @pytest.mark.parametrize('bad', ["text"])
-    def test_editing_does_not_update_source_on_bad_values(self, bad, bokeh_model_page):
+    def test_editing_does_not_update_source_on_bad_values(self, bad, bokeh_model_page) -> None:
         self.table.editable = False
         page = bokeh_model_page(self.table)
 
@@ -222,7 +222,7 @@ class Test_NumberEditor(Test_CellEditor_Base):
 
         assert page.has_no_console_errors()
 
-    def test_editing_updates_source(self, bokeh_model_page):
+    def test_editing_updates_source(self, bokeh_model_page) -> None:
         page = bokeh_model_page(self.table)
 
         # Click row 1 (which triggers the selection callback)
@@ -248,7 +248,7 @@ class Test_StringEditor(Test_CellEditor_Base):
     values = ["foo", "bar"]
     editor = StringEditor
 
-    def test_editing_does_not_update_source_on_noneditable_table(self, bokeh_model_page):
+    def test_editing_does_not_update_source_on_noneditable_table(self, bokeh_model_page) -> None:
         self.table.editable = False
         page = bokeh_model_page(self.table)
 
@@ -271,7 +271,7 @@ class Test_StringEditor(Test_CellEditor_Base):
         assert page.has_no_console_errors()
 
     @pytest.mark.parametrize('bad', ["1", "1.1", "-1"])
-    def test_editing_does_not_update_source_on_bad_values(self, bad, bokeh_model_page):
+    def test_editing_does_not_update_source_on_bad_values(self, bad, bokeh_model_page) -> None:
         self.table.editable = False
         page = bokeh_model_page(self.table)
 
@@ -293,7 +293,7 @@ class Test_StringEditor(Test_CellEditor_Base):
 
         assert page.has_no_console_errors()
 
-    def test_editing_updates_source(self, bokeh_model_page):
+    def test_editing_updates_source(self, bokeh_model_page) -> None:
         page = bokeh_model_page(self.table)
 
         # Click row 1 (which triggers the selection callback)
@@ -314,7 +314,7 @@ class Test_StringEditor(Test_CellEditor_Base):
 
         assert page.has_no_console_errors()
 
-    def test_editing_updates_source_with_click_enter(self, bokeh_model_page):
+    def test_editing_updates_source_with_click_enter(self, bokeh_model_page) -> None:
         page = bokeh_model_page(self.table)
 
         # Click row 1 (which triggers the selection callback)
@@ -341,7 +341,7 @@ class Test_StringEditor(Test_CellEditor_Base):
 #     values = [0.1, 0.2]
 #     editor = PercentEditor
 
-#     def test_editing_does_not_update_source_on_noneditable_table(self, bokeh_model_page):
+#     def test_editing_does_not_update_source_on_noneditable_table(self, bokeh_model_page) -> None:
 #         self.table.editable = False
 #         page = bokeh_model_page(self.table)
 
@@ -364,7 +364,7 @@ class Test_StringEditor(Test_CellEditor_Base):
 #         assert page.has_no_console_errors()
 
 #     @pytest.mark.parametrize('bad', ["-1", "-0.5", "1.1", "2", "text"])
-#     def test_editing_does_not_update_source_on_bad_values(self, bad, bokeh_model_page):
+#     def test_editing_does_not_update_source_on_bad_values(self, bad, bokeh_model_page) -> None:
 #         self.table.editable = False
 #         page = bokeh_model_page(self.table)
 
@@ -386,7 +386,7 @@ class Test_StringEditor(Test_CellEditor_Base):
 
 #         assert page.has_no_console_errors()
 
-#     def test_editing_updates_source(self, bokeh_model_page):
+#     def test_editing_updates_source(self, bokeh_model_page) -> None:
 #         page = bokeh_model_page(self.table)
 
 #         # click row 1 (which triggers the selection callback)

--- a/tests/integration/widgets/tables/test_copy_paste.py
+++ b/tests/integration/widgets/tables/test_copy_paste.py
@@ -43,7 +43,7 @@ pytest_plugins = (
 @pytest.mark.selenium
 class Test_DataTableCopyPaste(object):
 
-    def test_single_row_copy(self, bokeh_model_page):
+    def test_single_row_copy(self, bokeh_model_page) -> None:
         data = {'x': [1,2,3,4], 'y': [1,1,1,1], 'd': ['foo', 'bar', 'baz', 'quux']}
         source = ColumnDataSource(data)
         table = DataTable(columns=[
@@ -73,7 +73,7 @@ class Test_DataTableCopyPaste(object):
 
         assert page.has_no_console_errors()
 
-    def test_single_row_copy_with_zero(self, bokeh_model_page):
+    def test_single_row_copy_with_zero(self, bokeh_model_page) -> None:
         data = {'x': [1,2,3,4], 'y': [0,0,0,0], 'd': ['foo', 'bar', 'baz', 'quux']}
         source = ColumnDataSource(data)
         table = DataTable(columns=[
@@ -103,7 +103,7 @@ class Test_DataTableCopyPaste(object):
 
         assert page.has_no_console_errors()
 
-    def test_multi_row_copy(self, bokeh_model_page):
+    def test_multi_row_copy(self, bokeh_model_page) -> None:
         data = {'x': [1,2,3,4], 'y': [0,1,2,3], 'd': ['foo', 'bar', 'baz', 'quux']}
         source = ColumnDataSource(data)
         table = DataTable(columns=[

--- a/tests/integration/widgets/tables/test_data_table.py
+++ b/tests/integration/widgets/tables/test_data_table.py
@@ -44,7 +44,7 @@ class Test_CellEditor_Base(object):
 @pytest.mark.selenium
 class Test_DataTable(object):
 
-    def test_row_highlights_reflect_no_initial_selection(self, bokeh_model_page):
+    def test_row_highlights_reflect_no_initial_selection(self, bokeh_model_page) -> None:
 
         source = ColumnDataSource({'values': [1, 2]})
         column = TableColumn(field='values', title='values')
@@ -60,7 +60,7 @@ class Test_DataTable(object):
 
         assert page.has_no_console_errors()
 
-    def test_row_highlights_reflect_initial_selection(self, bokeh_model_page):
+    def test_row_highlights_reflect_initial_selection(self, bokeh_model_page) -> None:
 
         source = ColumnDataSource({'values': [1, 2]})
         source.selected.indices = [1]
@@ -77,7 +77,7 @@ class Test_DataTable(object):
 
         assert page.has_no_console_errors()
 
-    def test_row_highlights_reflect_ui_selection(self, bokeh_model_page):
+    def test_row_highlights_reflect_ui_selection(self, bokeh_model_page) -> None:
 
         source = ColumnDataSource({'values': [1, 2]})
         column = TableColumn(field='values', title='values')
@@ -102,7 +102,7 @@ class Test_DataTable(object):
 
         assert page.has_no_console_errors()
 
-    def test_row_highlights_reflect_js_selection(self, bokeh_model_page):
+    def test_row_highlights_reflect_js_selection(self, bokeh_model_page) -> None:
 
         source = ColumnDataSource({'values': [1, 2]})
         col = TableColumn(field='values', title='values')

--- a/tests/integration/widgets/tables/test_sortable.py
+++ b/tests/integration/widgets/tables/test_sortable.py
@@ -31,7 +31,7 @@ pytest_plugins = (
 @pytest.mark.selenium
 class Test_DataTableSortable(object):
 
-    def test_columns_sortable(self, bokeh_model_page):
+    def test_columns_sortable(self, bokeh_model_page) -> None:
         data = {'x': [1,2,3,4], 'y': [4, 3, 2, 1], 'd': ['foo', 'bar', 'baz', 'quux']}
         source = ColumnDataSource(data)
         table = DataTable(columns=[
@@ -57,7 +57,7 @@ class Test_DataTableSortable(object):
 
         assert page.has_no_console_errors()
 
-    def test_click_nonsortable(self, bokeh_model_page):
+    def test_click_nonsortable(self, bokeh_model_page) -> None:
         data = {'x': [1,2,3,4], 'y': [4, 3, 2, 1], 'd': ['foo', 'bar', 'baz', 'quux']}
         source = ColumnDataSource(data)
         table = DataTable(columns=[
@@ -81,7 +81,7 @@ class Test_DataTableSortable(object):
 
         assert page.has_no_console_errors()
 
-    def test_click_sortable(self, bokeh_model_page):
+    def test_click_sortable(self, bokeh_model_page) -> None:
         data = {'x': [1,2,3,4], 'y': [4, 3, 2, 1], 'd': ['foo', 'bar', 'baz', 'quux']}
         source = ColumnDataSource(data)
         table = DataTable(columns=[
@@ -112,7 +112,7 @@ class Test_DataTableSortable(object):
 
         assert page.has_no_console_errors()
 
-    def test_table_unsortable(self, bokeh_model_page):
+    def test_table_unsortable(self, bokeh_model_page) -> None:
         data = {'x': [1,2,3,4], 'y': [4, 3, 2, 1], 'd': ['foo', 'bar', 'baz', 'quux']}
         source = ColumnDataSource(data)
         table = DataTable(columns=[

--- a/tests/integration/widgets/tables/test_source_updates.py
+++ b/tests/integration/widgets/tables/test_source_updates.py
@@ -68,7 +68,7 @@ def has_cds_data_patches(msgs):
 @pytest.mark.selenium
 class Test_DataTableSource(object):
 
-    def test_server_source_patch_does_not_duplicate_data_update_event(self, bokeh_server_page):
+    def test_server_source_patch_does_not_duplicate_data_update_event(self, bokeh_server_page) -> None:
         def modify_doc(doc):
             data = {'x': [1,2,3,4], 'y': [10,20,30,40]}
             source = ColumnDataSource(data)
@@ -122,7 +122,7 @@ class Test_DataTableSource(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         #assert page.has_no_console_errors()
 
-    def test_server_source_stream_does_not_duplicate_data_update_event(self, bokeh_server_page):
+    def test_server_source_stream_does_not_duplicate_data_update_event(self, bokeh_server_page) -> None:
         def modify_doc(doc):
             data = {'x': [1,2,3,4], 'y': [10,20,30,40]}
             source = ColumnDataSource(data)
@@ -176,7 +176,7 @@ class Test_DataTableSource(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         #assert page.has_no_console_errors()
 
-    def test_server_source_update_does_not_duplicate_data_update_event(self, bokeh_server_page):
+    def test_server_source_update_does_not_duplicate_data_update_event(self, bokeh_server_page) -> None:
         def modify_doc(doc):
             data = {'x': [1,2,3,4], 'y': [10,20,30,40]}
             source = ColumnDataSource(data)
@@ -230,7 +230,7 @@ class Test_DataTableSource(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         #assert page.has_no_console_errors()
 
-    def test_server_edit_does_not_duplicate_data_update_event(self, bokeh_server_page):
+    def test_server_edit_does_not_duplicate_data_update_event(self, bokeh_server_page) -> None:
         def modify_doc(doc):
             data = {'x': [1,2,3,4], 'y': [10,20,30,40]}
             source = ColumnDataSource(data)
@@ -279,7 +279,7 @@ class Test_DataTableSource(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         #assert page.has_no_console_errors()
 
-    def test_server_basic_selection(self, bokeh_server_page):
+    def test_server_basic_selection(self, bokeh_server_page) -> None:
         data = {'x': [1,2,3,4,5,6], 'y': [60,50,40,30,20,10]}
         source = ColumnDataSource(data)
 
@@ -329,7 +329,7 @@ class Test_DataTableSource(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         #assert page.has_no_console_errors()
 
-    def test_server_basic_mulitselection(self, bokeh_server_page):
+    def test_server_basic_mulitselection(self, bokeh_server_page) -> None:
         data = {'x': [1,2,3,4,5,6], 'y': [60,50,40,30,20,10]}
         source = ColumnDataSource(data)
 
@@ -382,7 +382,7 @@ class Test_DataTableSource(object):
         #assert page.has_no_console_errors()
 
     @flaky(max_runs=5)
-    def test_server_sorted_after_data_update(self, bokeh_server_page):
+    def test_server_sorted_after_data_update(self, bokeh_server_page) -> None:
         data = {'x': [1,2,5,6], 'y': [60,50,20,10]}
         source = ColumnDataSource(data)
 
@@ -439,7 +439,7 @@ class Test_DataTableSource(object):
         #assert page.has_no_console_errors()
 
     @pytest.mark.skip
-    def test_server_sorted_after_patch(self, bokeh_server_page):
+    def test_server_sorted_after_patch(self, bokeh_server_page) -> None:
         data = {'x': [1,2,5,6], 'y': [60,50,20,10]}
         source = ColumnDataSource(data)
 
@@ -496,7 +496,7 @@ class Test_DataTableSource(object):
         #assert page.has_no_console_errors()
 
     @pytest.mark.skip
-    def test_server_sorted_after_stream(self, bokeh_server_page):
+    def test_server_sorted_after_stream(self, bokeh_server_page) -> None:
         data = {'x': [1,2,5,6], 'y': [60,50,20,10]}
         source = ColumnDataSource(data)
 
@@ -553,7 +553,7 @@ class Test_DataTableSource(object):
         #assert page.has_no_console_errors()
 
     @pytest.mark.skip
-    def test_server_sorted_after_edit(self, bokeh_server_page):
+    def test_server_sorted_after_edit(self, bokeh_server_page) -> None:
         data = {'x': [1,2,5,6], 'y': [60,50,20,10]}
         source = ColumnDataSource(data)
 
@@ -605,7 +605,7 @@ class Test_DataTableSource(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         #assert page.has_no_console_errors()
 
-    def test_server_source_updated_after_edit(self, bokeh_server_page):
+    def test_server_source_updated_after_edit(self, bokeh_server_page) -> None:
         data = {'x': [1,2,5,6], 'y': [60,50,20,10]}
         source = ColumnDataSource(data)
 
@@ -647,7 +647,7 @@ class Test_DataTableSource(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         #assert page.has_no_console_errors()
 
-    def test_server_source_callback_triggered_after_edit(self, bokeh_server_page):
+    def test_server_source_callback_triggered_after_edit(self, bokeh_server_page) -> None:
         data = {'x': [1,2,5,6], 'y': [60,50,20,10]}
         source = ColumnDataSource(data)
 
@@ -680,7 +680,7 @@ class Test_DataTableSource(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         #assert page.has_no_console_errors()
 
-    def test_glyph_selection_updates_table(self, single_plot_page):
+    def test_glyph_selection_updates_table(self, single_plot_page) -> None:
         plot = Plot(height=800, width=1000)
 
         data = {'x': [1,2,3,4], 'y': [1, 1, 1, 1]}

--- a/tests/integration/widgets/test_autocomplete_input.py
+++ b/tests/integration/widgets/test_autocomplete_input.py
@@ -58,7 +58,7 @@ def modify_doc(doc):
 @pytest.mark.selenium
 class Test_AutocompleteInput(object):
 
-    def test_displays_text_input(self, bokeh_model_page):
+    def test_displays_text_input(self, bokeh_model_page) -> None:
         text_input = AutocompleteInput(css_classes=["foo"], completions = ["100001", "12344556", "12344557", "3194567289", "209374209374"])
 
         page = bokeh_model_page(text_input)
@@ -68,7 +68,7 @@ class Test_AutocompleteInput(object):
 
         assert page.has_no_console_errors()
 
-    def test_displays_title(self, bokeh_model_page):
+    def test_displays_title(self, bokeh_model_page) -> None:
         text_input = AutocompleteInput(title="title", css_classes=["foo"], completions = ["100001", "12344556", "12344557", "3194567289", "209374209374"])
 
         page = bokeh_model_page(text_input)
@@ -81,7 +81,7 @@ class Test_AutocompleteInput(object):
 
         assert page.has_no_console_errors()
 
-    def test_displays_menu(self, bokeh_model_page):
+    def test_displays_menu(self, bokeh_model_page) -> None:
         text_input = AutocompleteInput(title="title", css_classes=["foo"], completions = ["100001", "12344556", "12344557", "3194567289", "209374209374"])
 
         page = bokeh_model_page(text_input)
@@ -124,7 +124,7 @@ class Test_AutocompleteInput(object):
 
         assert page.has_no_console_errors()
 
-    def test_min_characters(self, bokeh_model_page):
+    def test_min_characters(self, bokeh_model_page) -> None:
         text_input = AutocompleteInput(title="title", css_classes=["foo"],
                                        completions = ["100001", "12344556", "12344557", "3194567289", "209374209374"],
                                        min_characters=1)
@@ -150,7 +150,7 @@ class Test_AutocompleteInput(object):
         assert "bk-active" not in items[1].get_attribute('class')
         assert "bk-active" not in items[2].get_attribute('class')
 
-    def test_arrow_cannot_escape_menu(self, bokeh_model_page):
+    def test_arrow_cannot_escape_menu(self, bokeh_model_page) -> None:
         text_input = AutocompleteInput(title="title", css_classes=["foo"], completions = ["100001", "12344556", "12344557", "3194567289", "209374209374"])
 
         page = bokeh_model_page(text_input)
@@ -207,7 +207,7 @@ class Test_AutocompleteInput(object):
 
         assert page.has_no_console_errors()
 
-    def test_mouse_hover(self, bokeh_model_page):
+    def test_mouse_hover(self, bokeh_model_page) -> None:
         text_input = AutocompleteInput(title="title", css_classes=["foo"], completions = ["100001", "12344556", "12344557", "3194567289", "209374209374"])
 
         page = bokeh_model_page(text_input)
@@ -238,7 +238,7 @@ class Test_AutocompleteInput(object):
         assert "bk-active" in items[1].get_attribute('class')
 
     @flaky(max_runs=10)
-    def test_server_on_change_no_round_trip_without_enter_or_click(self, bokeh_server_page):
+    def test_server_on_change_no_round_trip_without_enter_or_click(self, bokeh_server_page) -> None:
         page = bokeh_server_page(modify_doc)
 
         el = page.driver.find_element_by_css_selector('.foo input')
@@ -255,7 +255,7 @@ class Test_AutocompleteInput(object):
     #@flaky(max_runs=10)
     # TODO (bev) Fix up after GH CI switch
     @pytest.mark.skip
-    def test_server_on_change_round_trip_full_entry(self, bokeh_server_page):
+    def test_server_on_change_round_trip_full_entry(self, bokeh_server_page) -> None:
         page = bokeh_server_page(modify_doc)
 
         # double click to highlight and overwrite old text
@@ -286,7 +286,7 @@ class Test_AutocompleteInput(object):
     #@flaky(max_runs=10)
     # TODO (bev) Fix up after GH CI switch
     @pytest.mark.skip
-    def test_server_on_change_round_trip_partial_entry(self, bokeh_server_page):
+    def test_server_on_change_round_trip_partial_entry(self, bokeh_server_page) -> None:
         page = bokeh_server_page(modify_doc)
 
         # double click to highlight and overwrite old text
@@ -317,7 +317,7 @@ class Test_AutocompleteInput(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         #assert page.has_no_console_errors()
 
-    def test_server_on_change_round_trip_menu_entry(self, bokeh_server_page):
+    def test_server_on_change_round_trip_menu_entry(self, bokeh_server_page) -> None:
         page = bokeh_server_page(modify_doc)
 
         # double click to highlight and overwrite old text

--- a/tests/integration/widgets/test_button.py
+++ b/tests/integration/widgets/test_button.py
@@ -41,7 +41,7 @@ pytest_plugins = (
 @pytest.mark.selenium
 class Test_Button(object):
 
-    def test_displays_label(self, bokeh_model_page):
+    def test_displays_label(self, bokeh_model_page) -> None:
         button = Button(label="label", css_classes=["foo"])
 
         page = bokeh_model_page(button)
@@ -50,7 +50,7 @@ class Test_Button(object):
         assert button.text == "label"
 
     @pytest.mark.parametrize('typ', list(ButtonType))
-    def test_displays_button_type(self, typ, bokeh_model_page):
+    def test_displays_button_type(self, typ, bokeh_model_page) -> None:
         button = Button(button_type=typ, css_classes=["foo"])
 
         page = bokeh_model_page(button)
@@ -58,7 +58,7 @@ class Test_Button(object):
         button = page.driver.find_element_by_css_selector('.foo .bk-btn')
         assert typ in button.get_attribute('class')
 
-    def test_server_on_click_round_trip(self, bokeh_server_page):
+    def test_server_on_click_round_trip(self, bokeh_server_page) -> None:
 
         def modify_doc(doc):
             source = ColumnDataSource(dict(x=[1, 2], y=[1, 1]))
@@ -84,7 +84,7 @@ class Test_Button(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         #assert page.has_no_console_errors()
 
-    def test_server_on_event_round_trip(self, bokeh_server_page):
+    def test_server_on_event_round_trip(self, bokeh_server_page) -> None:
 
         def modify_doc(doc):
             source = ColumnDataSource(dict(x=[1, 2], y=[1, 1]))
@@ -110,7 +110,7 @@ class Test_Button(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         #assert page.has_no_console_errors()
 
-    def test_js_on_event_executes(self, bokeh_model_page):
+    def test_js_on_event_executes(self, bokeh_model_page) -> None:
         button = Button(css_classes=['foo'])
         button.js_on_event('button_click', CustomJS(code=RECORD("clicked", "true")))
 
@@ -124,7 +124,7 @@ class Test_Button(object):
 
         assert page.has_no_console_errors()
 
-    def test_js_on_click_executes(self, bokeh_model_page):
+    def test_js_on_click_executes(self, bokeh_model_page) -> None:
         button = Button(css_classes=['foo'])
         button.js_on_click(CustomJS(code=RECORD("clicked", "true")))
 

--- a/tests/integration/widgets/test_checkbox_button_group.py
+++ b/tests/integration/widgets/test_checkbox_button_group.py
@@ -43,7 +43,7 @@ LABELS = ["Option 1", "Option 2", "Option 3"]
 @pytest.mark.selenium
 class Test_CheckboxButtonGroup(object):
 
-    def test_server_on_change_round_trip(self, bokeh_server_page):
+    def test_server_on_change_round_trip(self, bokeh_server_page) -> None:
         def modify_doc(doc):
             source = ColumnDataSource(dict(x=[1, 2], y=[1, 1], val=["a", "b"]))
             plot = Plot(plot_height=400, plot_width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
@@ -76,7 +76,7 @@ class Test_CheckboxButtonGroup(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         #assert page.has_no_console_errors()
 
-    def test_js_on_change_executes(self, bokeh_model_page):
+    def test_js_on_change_executes(self, bokeh_model_page) -> None:
         group = CheckboxButtonGroup(labels=LABELS, css_classes=["foo"])
         group.js_on_click(CustomJS(code=RECORD("active", "cb_obj.active")))
 

--- a/tests/integration/widgets/test_checkbox_group.py
+++ b/tests/integration/widgets/test_checkbox_group.py
@@ -43,7 +43,7 @@ LABELS = ["Option 1", "Option 2", "Option 3"]
 class Test_CheckboxGroup(object):
 
     @pytest.mark.parametrize('inline', [True, False])
-    def test_displays_options_list_of_string_labels_setting_inline(self, inline, bokeh_model_page):
+    def test_displays_options_list_of_string_labels_setting_inline(self, inline, bokeh_model_page) -> None:
         group = CheckboxGroup(labels=LABELS, css_classes=["foo"], inline=inline)
 
         page = bokeh_model_page(group)
@@ -58,7 +58,7 @@ class Test_CheckboxGroup(object):
             assert input.get_attribute('value') == str(i)
             assert input.get_attribute('type') == 'checkbox'
 
-    def test_server_on_change_round_trip(self, bokeh_server_page):
+    def test_server_on_change_round_trip(self, bokeh_server_page) -> None:
         def modify_doc(doc):
             source = ColumnDataSource(dict(x=[1, 2], y=[1, 1], val=["a", "b"]))
             plot = Plot(plot_height=400, plot_width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
@@ -91,7 +91,7 @@ class Test_CheckboxGroup(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         #assert page.has_no_console_errors()
 
-    def test_js_on_change_executes(self, bokeh_model_page):
+    def test_js_on_change_executes(self, bokeh_model_page) -> None:
         group = CheckboxGroup(labels=LABELS, css_classes=["foo"])
         group.js_on_click(CustomJS(code=RECORD("active", "cb_obj.active")))
 

--- a/tests/integration/widgets/test_color_picker.py
+++ b/tests/integration/widgets/test_color_picker.py
@@ -62,7 +62,7 @@ def enter_value_in_color_picker(driver, el, color):
 @pytest.mark.selenium
 class Test_ColorPicker(object):
 
-    def test_display_color_input(self, bokeh_model_page):
+    def test_display_color_input(self, bokeh_model_page) -> None:
         colorpicker = ColorPicker(css_classes=["foo"])
 
         page = bokeh_model_page(colorpicker)
@@ -72,7 +72,7 @@ class Test_ColorPicker(object):
 
         assert page.has_no_console_errors()
 
-    def test_displays_title(self, bokeh_model_page):
+    def test_displays_title(self, bokeh_model_page) -> None:
         colorpicker = ColorPicker(css_classes=["foo"], title="title")
 
         page = bokeh_model_page(colorpicker)
@@ -85,7 +85,7 @@ class Test_ColorPicker(object):
 
         assert page.has_no_console_errors()
 
-    def test_input_value(self, bokeh_model_page):
+    def test_input_value(self, bokeh_model_page) -> None:
         colorpicker = ColorPicker(color='red', css_classes=["foo"])
 
         page = bokeh_model_page(colorpicker)
@@ -96,7 +96,7 @@ class Test_ColorPicker(object):
 
         assert page.has_no_console_errors()
 
-    def test_server_on_change_round_trip(self, bokeh_server_page):
+    def test_server_on_change_round_trip(self, bokeh_server_page) -> None:
         page = bokeh_server_page(modify_doc)
 
         el = page.driver.find_element_by_css_selector('.foo input')

--- a/tests/integration/widgets/test_copy_paste.py
+++ b/tests/integration/widgets/test_copy_paste.py
@@ -40,7 +40,7 @@ pytest_plugins = (
 @pytest.mark.selenium
 class Test_CopyPaste(object):
 
-    def test_copy_paste_to_textarea(self, bokeh_model_page):
+    def test_copy_paste_to_textarea(self, bokeh_model_page) -> None:
         source = ColumnDataSource(dict(x=[1, 2], y=[1, 1]))
         columns = [TableColumn(field='x', title='x'), TableColumn(field='y', title='y')]
         table = DataTable(source=source, columns=columns, editable=False, width=600)

--- a/tests/integration/widgets/test_datepicker.py
+++ b/tests/integration/widgets/test_datepicker.py
@@ -43,7 +43,7 @@ pytest_plugins = (
 @pytest.mark.selenium
 class Test_DatePicker(object):
 
-    def test_basic(self, bokeh_model_page):
+    def test_basic(self, bokeh_model_page) -> None:
         dp = DatePicker(title='Select date', value=date(2019, 9, 20), min_date=date(2019, 9, 1), max_date="2019-09-30", css_classes=["foo"])
 
         page = bokeh_model_page(dp)
@@ -56,7 +56,7 @@ class Test_DatePicker(object):
 
         assert page.has_no_console_errors()
 
-    def test_inline(self, bokeh_model_page):
+    def test_inline(self, bokeh_model_page) -> None:
         dp = DatePicker(title='Select date', value=date(2019, 9, 20), min_date=date(2019, 9, 1), max_date="2019-09-30",
                         inline=True, css_classes=["foo"])
 
@@ -70,7 +70,7 @@ class Test_DatePicker(object):
 
         assert page.has_no_console_errors()
 
-    def test_widget_disabled(self, bokeh_model_page):
+    def test_widget_disabled(self, bokeh_model_page) -> None:
         dp = DatePicker(title='Select date', value=date(2019, 9, 20), min_date=date(2019, 9, 1), max_date="2019-09-30",
                         disabled=True, css_classes=["foo"])
 
@@ -81,7 +81,7 @@ class Test_DatePicker(object):
 
         assert page.has_no_console_errors()
 
-    def test_disabled_dates(self, bokeh_model_page):
+    def test_disabled_dates(self, bokeh_model_page) -> None:
         dp = DatePicker(title='Select date', value=date(2019, 9, 20), min_date=date(2019, 9, 1), max_date="2019-09-30",
                         disabled_dates=["2019-09-14", ("2019-09-16", date(2019, 9, 18))], css_classes=["foo"])
 
@@ -116,7 +116,7 @@ class Test_DatePicker(object):
 
         assert page.has_no_console_errors()
 
-    def test_enabled_dates(self, bokeh_model_page):
+    def test_enabled_dates(self, bokeh_model_page) -> None:
         dp = DatePicker(title='Select date', value=date(2019, 9, 20), min_date=date(2019, 9, 1), max_date="2019-09-30",
                         enabled_dates=["2019-09-14", ("2019-09-16", date(2019, 9, 18))], css_classes=["foo"])
 
@@ -151,7 +151,7 @@ class Test_DatePicker(object):
 
         assert page.has_no_console_errors()
 
-    def test_js_on_change_executes(self, bokeh_model_page):
+    def test_js_on_change_executes(self, bokeh_model_page) -> None:
         dp = DatePicker(title='Select date', value=date(2019, 9, 20), min_date=date(2019, 9, 1), max_date="2019-09-30", css_classes=["foo"])
         dp.js_on_change('value', CustomJS(code=RECORD("value", "cb_obj.value")))
 
@@ -171,7 +171,7 @@ class Test_DatePicker(object):
 
         assert page.has_no_console_errors()
 
-    def test_server_on_change_round_trip(self, bokeh_server_page):
+    def test_server_on_change_round_trip(self, bokeh_server_page) -> None:
         def modify_doc(doc):
             source = ColumnDataSource(dict(x=[1, 2], y=[1, 1], val=["a", "b"]))
             plot = Plot(plot_height=400, plot_width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
@@ -196,7 +196,7 @@ class Test_DatePicker(object):
         results = page.results
         assert results['data']['val'] == ['2019-09-20', '2019-09-16']
 
-    def test_server_update_disabled(self, bokeh_server_page):
+    def test_server_update_disabled(self, bokeh_server_page) -> None:
         def modify_doc(doc):
             source = ColumnDataSource(dict(x=[1, 2], y=[1, 1], val=["a", "b"]))
             plot = Plot(plot_height=400, plot_width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)

--- a/tests/integration/widgets/test_div.py
+++ b/tests/integration/widgets/test_div.py
@@ -38,7 +38,7 @@ are <i>200</i> and <i>100</i> respectively."""
 @pytest.mark.selenium
 class Test_Div(object):
 
-    def test_displays_div_as_html(self, bokeh_model_page):
+    def test_displays_div_as_html(self, bokeh_model_page) -> None:
         div = Div(text=text, css_classes=["foo"])
 
         page = bokeh_model_page(div)
@@ -48,7 +48,7 @@ class Test_Div(object):
 
         assert page.has_no_console_errors()
 
-    def test_displays_div_as_text(self, bokeh_model_page):
+    def test_displays_div_as_text(self, bokeh_model_page) -> None:
         div = Div(text=text, css_classes=["foo"], render_as_text=True)
 
         page = bokeh_model_page(div)
@@ -58,7 +58,7 @@ class Test_Div(object):
 
         assert page.has_no_console_errors()
 
-    def test_set_style(self, bokeh_model_page):
+    def test_set_style(self, bokeh_model_page) -> None:
         para = Div(text=text, css_classes=["foo"], style={'font-size': '20pt'})
 
         page = bokeh_model_page(para)

--- a/tests/integration/widgets/test_dropdown.py
+++ b/tests/integration/widgets/test_dropdown.py
@@ -45,7 +45,7 @@ items = [("Item 1", "item_1_value"), ("Item 2", "item_2_value"), ("Item 3", "ite
 @pytest.mark.selenium
 class Test_Dropdown(object):
 
-    def test_displays_menu_items(self, bokeh_model_page):
+    def test_displays_menu_items(self, bokeh_model_page) -> None:
         button = Dropdown(label="Dropdown button", menu=items, css_classes=["foo"])
 
         page = bokeh_model_page(button)
@@ -58,7 +58,7 @@ class Test_Dropdown(object):
         assert menu.is_displayed()
 
     @pytest.mark.parametrize('typ', list(ButtonType))
-    def test_displays_button_type(self, typ, bokeh_model_page):
+    def test_displays_button_type(self, typ, bokeh_model_page) -> None:
         button = Dropdown(label="Dropdown button", menu=items, button_type=typ, css_classes=["foo"])
 
         page = bokeh_model_page(button)
@@ -66,7 +66,7 @@ class Test_Dropdown(object):
         button = page.driver.find_element_by_css_selector('.foo button')
         assert typ in button.get_attribute('class')
 
-    def test_server_on_change_round_trip(self, bokeh_server_page):
+    def test_server_on_change_round_trip(self, bokeh_server_page) -> None:
         def modify_doc(doc):
             source = ColumnDataSource(dict(x=[1, 2], y=[1, 1]))
             plot = Plot(plot_height=400, plot_width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
@@ -119,7 +119,7 @@ class Test_Dropdown(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         #assert page.has_no_console_errors()
 
-    def test_js_on_change_executes(self, bokeh_model_page):
+    def test_js_on_change_executes(self, bokeh_model_page) -> None:
         button = Dropdown(label="Dropdown button", menu=items, css_classes=["foo"])
         button.js_on_event('menu_item_click', CustomJS(code=RECORD("value", "this.item")))
 

--- a/tests/integration/widgets/test_paragraph.py
+++ b/tests/integration/widgets/test_paragraph.py
@@ -38,7 +38,7 @@ are <i>200</i> and <i>100</i> respectively."""
 @pytest.mark.selenium
 class Test_TextParagraph(object):
 
-    def test_displays_div_as_text(self, bokeh_model_page):
+    def test_displays_div_as_text(self, bokeh_model_page) -> None:
         para = Paragraph(text=text, css_classes=["foo"])
 
         page = bokeh_model_page(para)
@@ -48,7 +48,7 @@ class Test_TextParagraph(object):
 
         assert page.has_no_console_errors()
 
-    def test_set_style(self, bokeh_model_page):
+    def test_set_style(self, bokeh_model_page) -> None:
         para = Paragraph(text=text, css_classes=["foo"], style={'font-size': '20pt'})
 
         page = bokeh_model_page(para)

--- a/tests/integration/widgets/test_password_input.py
+++ b/tests/integration/widgets/test_password_input.py
@@ -54,7 +54,7 @@ def modify_doc(doc):
 @pytest.mark.selenium
 class Test_PasswordInput(object):
 
-    def test_displays_password_input(self, bokeh_model_page):
+    def test_displays_password_input(self, bokeh_model_page) -> None:
         pw_input = PasswordInput(css_classes=["foo"])
 
         page = bokeh_model_page(pw_input)
@@ -64,7 +64,7 @@ class Test_PasswordInput(object):
 
         assert page.has_no_console_errors()
 
-    def test_displays_title(self, bokeh_model_page):
+    def test_displays_title(self, bokeh_model_page) -> None:
         pw_input = PasswordInput(title="title", css_classes=["foo"])
 
         page = bokeh_model_page(pw_input)
@@ -77,7 +77,7 @@ class Test_PasswordInput(object):
 
         assert page.has_no_console_errors()
 
-    def test_displays_placeholder(self, bokeh_model_page):
+    def test_displays_placeholder(self, bokeh_model_page) -> None:
         pw_input = PasswordInput(placeholder="placeholder", css_classes=["foo"])
 
         page = bokeh_model_page(pw_input)
@@ -91,7 +91,7 @@ class Test_PasswordInput(object):
         assert page.has_no_console_errors()
 
     @flaky(max_runs=10)
-    def test_server_on_change_no_round_trip_without_enter_or_click(self, bokeh_server_page):
+    def test_server_on_change_no_round_trip_without_enter_or_click(self, bokeh_server_page) -> None:
         page = bokeh_server_page(modify_doc)
 
         el = page.driver.find_element_by_css_selector('.foo input')
@@ -108,7 +108,7 @@ class Test_PasswordInput(object):
     #@flaky(max_runs=10)
     # TODO (bev) Fix up after GH CI switch
     @pytest.mark.skip
-    def test_server_on_change_round_trip(self, bokeh_server_page):
+    def test_server_on_change_round_trip(self, bokeh_server_page) -> None:
         page = bokeh_server_page(modify_doc)
 
         el = page.driver.find_element_by_css_selector('.foo input')
@@ -139,7 +139,7 @@ class Test_PasswordInput(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         #assert page.has_no_console_errors()
 
-    def test_js_on_change_executes(self, single_plot_page):
+    def test_js_on_change_executes(self, single_plot_page) -> None:
         source = ColumnDataSource(dict(x=[1, 2], y=[1, 1]))
         plot = Plot(plot_height=400, plot_width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
         plot.add_glyph(source, Circle(x='x', y='y', size=20))

--- a/tests/integration/widgets/test_pretext.py
+++ b/tests/integration/widgets/test_pretext.py
@@ -38,7 +38,7 @@ are <i>200</i> and <i>100</i> respectively."""
 @pytest.mark.selenium
 class Test_PreText(object):
 
-    def test_displays_div_as_text(self, bokeh_model_page):
+    def test_displays_div_as_text(self, bokeh_model_page) -> None:
         para = PreText(text=text, css_classes=["foo"])
 
         page = bokeh_model_page(para)
@@ -48,7 +48,7 @@ class Test_PreText(object):
 
         assert page.has_no_console_errors()
 
-    def test_set_style(self, bokeh_model_page):
+    def test_set_style(self, bokeh_model_page) -> None:
         para = PreText(text=text, css_classes=["foo"], style={'font-size': '20pt'})
 
         page = bokeh_model_page(para)

--- a/tests/integration/widgets/test_radio_button_group.py
+++ b/tests/integration/widgets/test_radio_button_group.py
@@ -42,7 +42,7 @@ LABELS = ["Option 1", "Option 2", "Option 3"]
 @pytest.mark.selenium
 class Test_RadioButtonGroup(object):
 
-    def test_server_on_change_round_trip(self, bokeh_server_page):
+    def test_server_on_change_round_trip(self, bokeh_server_page) -> None:
         def modify_doc(doc):
             source = ColumnDataSource(dict(x=[1, 2], y=[1, 1], val=["a", "b"]))
             plot = Plot(plot_height=400, plot_width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
@@ -75,7 +75,7 @@ class Test_RadioButtonGroup(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         #assert page.has_no_console_errors()
 
-    def test_js_on_change_executes(self, bokeh_model_page):
+    def test_js_on_change_executes(self, bokeh_model_page) -> None:
         group = RadioButtonGroup(labels=LABELS, css_classes=["foo"])
         group.js_on_click(CustomJS(code=RECORD("active", "cb_obj.active")))
 

--- a/tests/integration/widgets/test_radio_group.py
+++ b/tests/integration/widgets/test_radio_group.py
@@ -43,7 +43,7 @@ LABELS = ["Option 1", "Option 2", "Option 3"]
 class Test_RadioGroup(object):
 
     @pytest.mark.parametrize('inline', [True, False])
-    def test_displays_options_list_of_string_labels_setting_inline(self, inline, bokeh_model_page):
+    def test_displays_options_list_of_string_labels_setting_inline(self, inline, bokeh_model_page) -> None:
         group = RadioGroup(labels=LABELS, css_classes=["foo"], inline=inline)
 
         page = bokeh_model_page(group)
@@ -58,7 +58,7 @@ class Test_RadioGroup(object):
             assert input.get_attribute('value') == str(i)
             assert input.get_attribute('type') == 'radio'
 
-    def test_server_on_change_round_trip(self, bokeh_server_page):
+    def test_server_on_change_round_trip(self, bokeh_server_page) -> None:
         def modify_doc(doc):
             source = ColumnDataSource(dict(x=[1, 2], y=[1, 1], val=["a", "b"]))
             plot = Plot(plot_height=400, plot_width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
@@ -91,7 +91,7 @@ class Test_RadioGroup(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         #assert page.has_no_console_errors()
 
-    def test_js_on_change_executes(self, bokeh_model_page):
+    def test_js_on_change_executes(self, bokeh_model_page) -> None:
         group = RadioGroup(labels=LABELS, css_classes=["foo"])
         group.js_on_click(CustomJS(code=RECORD("active", "cb_obj.active")))
 

--- a/tests/integration/widgets/test_range_slider.py
+++ b/tests/integration/widgets/test_range_slider.py
@@ -71,7 +71,7 @@ def get_bar_color(driver, css_class):
 @pytest.mark.selenium
 class Test_RangeSlider(object):
 
-    def test_display(self, bokeh_model_page):
+    def test_display(self, bokeh_model_page) -> None:
         slider = RangeSlider(start=0, end=10, value=(1, 5), css_classes=["foo"], width=300)
 
         page = bokeh_model_page(slider)
@@ -82,7 +82,7 @@ class Test_RangeSlider(object):
 
         assert page.has_no_console_errors()
 
-    def test_displays_title(self, bokeh_model_page):
+    def test_displays_title(self, bokeh_model_page) -> None:
         slider = RangeSlider(start=0, end=10, value=(1, 5), title="bar", css_classes=["foo"], width=300)
 
         page = bokeh_model_page(slider)
@@ -95,7 +95,7 @@ class Test_RangeSlider(object):
 
         assert page.has_no_console_errors()
 
-    def test_title_updates(self, bokeh_model_page):
+    def test_title_updates(self, bokeh_model_page) -> None:
         slider = RangeSlider(start=0, end=10, value=(1, 9), title="bar", css_classes=["foo"], width=300)
 
         page = bokeh_model_page(slider)
@@ -119,7 +119,7 @@ class Test_RangeSlider(object):
         assert page.has_no_console_errors()
 
     @pytest.mark.skip
-    def test_keypress_event(self, bokeh_model_page):
+    def test_keypress_event(self, bokeh_model_page) -> None:
         slider = RangeSlider(start=0, end=10, value=(1, 5), title="bar", css_classes=["foo"], width=300)
         page = bokeh_model_page(slider)
         el = page.driver.find_element_by_css_selector('.foo')
@@ -140,7 +140,7 @@ class Test_RangeSlider(object):
 
         assert page.has_no_console_errors()
 
-    def test_displays_bar_color(self, bokeh_model_page):
+    def test_displays_bar_color(self, bokeh_model_page) -> None:
         slider = RangeSlider(start=0, end=10, value=(1, 5), title="bar", css_classes=["foo"], width=300, bar_color="red")
 
         page = bokeh_model_page(slider)
@@ -152,7 +152,7 @@ class Test_RangeSlider(object):
 
         assert page.has_no_console_errors()
 
-    def test_js_on_change_executes(self, bokeh_model_page):
+    def test_js_on_change_executes(self, bokeh_model_page) -> None:
         slider = RangeSlider(start=0, end=10, value=(1, 5), title="bar", css_classes=["foo"], width=300)
         slider.js_on_change('value', CustomJS(code=RECORD("value", "cb_obj.value")))
 
@@ -173,7 +173,7 @@ class Test_RangeSlider(object):
         assert page.has_no_console_errors()
 
 
-    def test_server_on_change_round_trip(self, bokeh_server_page):
+    def test_server_on_change_round_trip(self, bokeh_server_page) -> None:
 
         def modify_doc(doc):
             source = ColumnDataSource(dict(x=[1, 2], y=[1, 1], val=["a", "b"]))
@@ -225,7 +225,7 @@ class Test_RangeSlider(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         # assert page.has_no_console_errors()
 
-    def test_server_bar_color_updates(self, bokeh_server_page):
+    def test_server_bar_color_updates(self, bokeh_server_page) -> None:
 
         def modify_doc(doc):
             plot = Plot(plot_height=400, plot_width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)

--- a/tests/integration/widgets/test_select.py
+++ b/tests/integration/widgets/test_select.py
@@ -51,7 +51,7 @@ def modify_doc(doc):
 @pytest.mark.selenium
 class Test_Select(object):
 
-    def test_displays_title(self, bokeh_model_page):
+    def test_displays_title(self, bokeh_model_page) -> None:
         select = Select(options=["Option 1", "Option 2", "Option 3"], css_classes=["foo"], title="title")
 
         page = bokeh_model_page(select)
@@ -61,7 +61,7 @@ class Test_Select(object):
 
         assert page.has_no_console_errors()
 
-    def test_displays_options_list_of_string_options(self, bokeh_model_page):
+    def test_displays_options_list_of_string_options(self, bokeh_model_page) -> None:
         select = Select(options=["Option 1", "Option 2", "Option 3"], css_classes=["foo"])
 
         page = bokeh_model_page(select)
@@ -80,7 +80,7 @@ class Test_Select(object):
 
         assert page.has_no_console_errors()
 
-    def test_displays_options_list_of_string_options_with_default_value(self, bokeh_model_page):
+    def test_displays_options_list_of_string_options_with_default_value(self, bokeh_model_page) -> None:
         select = Select(options=["Option 1", "Option 2", "Option 3"], css_classes=["foo"], value="Option 3")
 
         page = bokeh_model_page(select)
@@ -100,7 +100,7 @@ class Test_Select(object):
         assert page.has_no_console_errors()
 
 
-    def test_displays_list_of_tuple_options(self, bokeh_model_page):
+    def test_displays_list_of_tuple_options(self, bokeh_model_page) -> None:
         select = Select(options=[("1", "Option 1"), ("2", "Option 2"), ("3", "Option 3")], css_classes=["foo"])
 
         page = bokeh_model_page(select)
@@ -118,7 +118,7 @@ class Test_Select(object):
 
         assert page.has_no_console_errors()
 
-    def test_displays_list_of_tuple_options_with_default_value(self, bokeh_model_page):
+    def test_displays_list_of_tuple_options_with_default_value(self, bokeh_model_page) -> None:
         select = Select(options=[("1", "Option 1"), ("2", "Option 2"), ("3", "Option 3")], css_classes=["foo"], value="3")
 
         page = bokeh_model_page(select)
@@ -137,7 +137,7 @@ class Test_Select(object):
 
         assert page.has_no_console_errors()
 
-    def test_displays_options_dict_of_list_of_string_options(self, bokeh_model_page):
+    def test_displays_options_dict_of_list_of_string_options(self, bokeh_model_page) -> None:
         select = Select(options=dict(g1=["Option 11"], g2=["Option 21", "Option 22"]), css_classes=["foo"])
 
         page = bokeh_model_page(select)
@@ -159,7 +159,7 @@ class Test_Select(object):
 
         assert page.has_no_console_errors()
 
-    def test_displays_options_dict_of_list_of_string_options_with_default_value(self, bokeh_model_page):
+    def test_displays_options_dict_of_list_of_string_options_with_default_value(self, bokeh_model_page) -> None:
         select = Select(options=dict(g1=["Option 11"], g2=["Option 21", "Option 22"]), css_classes=["foo"], value="Option 22")
 
         page = bokeh_model_page(select)
@@ -182,7 +182,7 @@ class Test_Select(object):
 
         assert page.has_no_console_errors()
 
-    def test_displays_dict_of_list_of_tuple_options(self, bokeh_model_page):
+    def test_displays_dict_of_list_of_tuple_options(self, bokeh_model_page) -> None:
         select = Select(options=dict(g1=[("11", "Option 11")], g2=[("21", "Option 21"), ("22", "Option 22")]), css_classes=["foo"])
 
         page = bokeh_model_page(select)
@@ -204,7 +204,7 @@ class Test_Select(object):
 
         assert page.has_no_console_errors()
 
-    def test_displays_dict_of_list_of_tuple_options_with_default_value(self, bokeh_model_page):
+    def test_displays_dict_of_list_of_tuple_options_with_default_value(self, bokeh_model_page) -> None:
         select = Select(options=dict(g1=[("11", "Option 11")], g2=[("21", "Option 21"), ("22", "Option 22")]), css_classes=["foo"], value="22")
 
         page = bokeh_model_page(select)
@@ -227,7 +227,7 @@ class Test_Select(object):
 
         assert page.has_no_console_errors()
 
-    def test_server_on_change_round_trip(self, bokeh_server_page):
+    def test_server_on_change_round_trip(self, bokeh_server_page) -> None:
         def modify_doc(doc):
             source = ColumnDataSource(dict(x=[1, 2], y=[1, 1], val=["a", "b"]))
             plot = Plot(plot_height=400, plot_width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
@@ -266,7 +266,7 @@ class Test_Select(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         #assert page.has_no_console_errors()
 
-    def test_js_on_change_executes(self, bokeh_model_page):
+    def test_js_on_change_executes(self, bokeh_model_page) -> None:
         select = Select(options=["Option 1", "Option 2", "Option 3"], css_classes=["foo"])
         select.js_on_change('value', CustomJS(code=RECORD("value", "cb_obj.value")))
 

--- a/tests/integration/widgets/test_slider.py
+++ b/tests/integration/widgets/test_slider.py
@@ -72,7 +72,7 @@ def get_bar_color(driver, css_class):
 @pytest.mark.selenium
 class Test_Slider(object):
 
-    def test_display(self, bokeh_model_page):
+    def test_display(self, bokeh_model_page) -> None:
         slider = Slider(start=0, end=10, value=1, css_classes=["foo"], width=300)
 
         page = bokeh_model_page(slider)
@@ -83,7 +83,7 @@ class Test_Slider(object):
 
         assert page.has_no_console_errors()
 
-    def test_displays_title(self, bokeh_model_page):
+    def test_displays_title(self, bokeh_model_page) -> None:
         slider = Slider(start=0, end=10, value=1, title="bar", css_classes=["foo"], width=300)
 
         page = bokeh_model_page(slider)
@@ -96,7 +96,7 @@ class Test_Slider(object):
 
         assert page.has_no_console_errors()
 
-    def test_title_updates(self, bokeh_model_page):
+    def test_title_updates(self, bokeh_model_page) -> None:
         slider = Slider(start=0, end=10, value=1, title="bar", css_classes=["foo"], width=300)
 
         page = bokeh_model_page(slider)
@@ -117,7 +117,7 @@ class Test_Slider(object):
         assert page.has_no_console_errors()
 
     @pytest.mark.skip
-    def test_keypress_event(self, bokeh_model_page):
+    def test_keypress_event(self, bokeh_model_page) -> None:
         slider = Slider(start=0, end=10, value=1, title="bar", css_classes=["foo"], width=300)
         page = bokeh_model_page(slider)
         el = page.driver.find_element_by_css_selector('.foo')
@@ -130,7 +130,7 @@ class Test_Slider(object):
         assert float(get_title_value(page.driver, ".foo")) == 10
         assert page.has_no_console_errors()
 
-    def test_displays_bar_color(self, bokeh_model_page):
+    def test_displays_bar_color(self, bokeh_model_page) -> None:
         slider = Slider(start=0, end=10, value=1, title="bar", css_classes=["foo"], width=300, bar_color="red")
 
         page = bokeh_model_page(slider)
@@ -142,7 +142,7 @@ class Test_Slider(object):
 
         assert page.has_no_console_errors()
 
-    def test_js_on_change_executes(self, bokeh_model_page):
+    def test_js_on_change_executes(self, bokeh_model_page) -> None:
         slider = Slider(start=0, end=10, value=1, title="bar", css_classes=["foo"], width=300)
         slider.js_on_change('value', CustomJS(code=RECORD("value", "cb_obj.value")))
 
@@ -155,7 +155,7 @@ class Test_Slider(object):
 
         assert page.has_no_console_errors()
 
-    def test_server_on_change_round_trip(self, bokeh_server_page):
+    def test_server_on_change_round_trip(self, bokeh_server_page) -> None:
 
         def modify_doc(doc):
             source = ColumnDataSource(dict(x=[1, 2], y=[1, 1], val=["a", "b"]))
@@ -207,7 +207,7 @@ class Test_Slider(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         # assert page.has_no_console_errors()
 
-    def test_server_callback_value_vs_value_throttled(self, bokeh_server_page):
+    def test_server_callback_value_vs_value_throttled(self, bokeh_server_page) -> None:
         junk = dict(v=0, vt=0)
 
         def modify_doc(doc):
@@ -241,7 +241,7 @@ class Test_Slider(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         # assert page.has_no_console_errors()
 
-    def test_server_bar_color_updates(self, bokeh_server_page):
+    def test_server_bar_color_updates(self, bokeh_server_page) -> None:
 
         def modify_doc(doc):
             plot = Plot(plot_height=400, plot_width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
@@ -264,7 +264,7 @@ class Test_Slider(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         # assert page.has_no_console_errors()
 
-    def test_server_title_updates(self, bokeh_server_page):
+    def test_server_title_updates(self, bokeh_server_page) -> None:
 
         def modify_doc(doc):
             plot = Plot(plot_height=400, plot_width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)

--- a/tests/integration/widgets/test_spinner.py
+++ b/tests/integration/widgets/test_spinner.py
@@ -68,7 +68,7 @@ def enter_value_in_spinner(driver, el, value, del_prev=True):
 @pytest.mark.selenium
 class Test_Spinner(object):
 
-    def test_display_number_input(self, bokeh_model_page):
+    def test_display_number_input(self, bokeh_model_page) -> None:
         spinner = Spinner(css_classes=["foo"])
 
         page = bokeh_model_page(spinner)
@@ -78,7 +78,7 @@ class Test_Spinner(object):
 
         assert page.has_no_console_errors()
 
-    def test_displays_title(self, bokeh_model_page):
+    def test_displays_title(self, bokeh_model_page) -> None:
         spinner = Spinner(title="title", css_classes=["foo"])
 
         page = bokeh_model_page(spinner)
@@ -90,7 +90,7 @@ class Test_Spinner(object):
 
         assert page.has_no_console_errors()
 
-    def test_input_value_min_max_step(self, bokeh_model_page):
+    def test_input_value_min_max_step(self, bokeh_model_page) -> None:
         spinner = Spinner(value=1, low=0, high=10, step=1, css_classes=["foo"])
 
         page = bokeh_model_page(spinner)
@@ -104,7 +104,7 @@ class Test_Spinner(object):
 
         assert page.has_no_console_errors()
 
-    def test_server_on_change_round_trip(self, bokeh_server_page):
+    def test_server_on_change_round_trip(self, bokeh_server_page) -> None:
         page = bokeh_server_page(modify_doc)
 
         el = page.driver.find_element_by_css_selector('.foo input')

--- a/tests/integration/widgets/test_text_input.py
+++ b/tests/integration/widgets/test_text_input.py
@@ -54,7 +54,7 @@ def modify_doc(doc):
 @pytest.mark.selenium
 class Test_TextInput(object):
 
-    def test_displays_text_input(self, bokeh_model_page):
+    def test_displays_text_input(self, bokeh_model_page) -> None:
         text_input = TextInput(css_classes=["foo"])
 
         page = bokeh_model_page(text_input)
@@ -64,7 +64,7 @@ class Test_TextInput(object):
 
         assert page.has_no_console_errors()
 
-    def test_displays_title(self, bokeh_model_page):
+    def test_displays_title(self, bokeh_model_page) -> None:
         text_input = TextInput(title="title", css_classes=["foo"])
 
         page = bokeh_model_page(text_input)
@@ -77,7 +77,7 @@ class Test_TextInput(object):
 
         assert page.has_no_console_errors()
 
-    def test_displays_placeholder(self, bokeh_model_page):
+    def test_displays_placeholder(self, bokeh_model_page) -> None:
         text_input = TextInput(placeholder="placeholder", css_classes=["foo"])
 
         page = bokeh_model_page(text_input)
@@ -91,7 +91,7 @@ class Test_TextInput(object):
         assert page.has_no_console_errors()
 
     @flaky(max_runs=10)
-    def test_server_on_change_no_round_trip_without_enter_or_click(self, bokeh_server_page):
+    def test_server_on_change_no_round_trip_without_enter_or_click(self, bokeh_server_page) -> None:
         page = bokeh_server_page(modify_doc)
 
         el = page.driver.find_element_by_css_selector('.foo input')
@@ -108,7 +108,7 @@ class Test_TextInput(object):
     #@flaky(max_runs=10)
     # TODO (bev) Fix up after GH CI switch
     @pytest.mark.skip
-    def test_server_on_change_round_trip(self, bokeh_server_page):
+    def test_server_on_change_round_trip(self, bokeh_server_page) -> None:
         page = bokeh_server_page(modify_doc)
 
         el = page.driver.find_element_by_css_selector('.foo input')
@@ -139,7 +139,7 @@ class Test_TextInput(object):
         # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
         #assert page.has_no_console_errors()
 
-    def test_js_on_change_executes(self, single_plot_page):
+    def test_js_on_change_executes(self, single_plot_page) -> None:
         source = ColumnDataSource(dict(x=[1, 2], y=[1, 1]))
         plot = Plot(plot_height=400, plot_width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
         plot.add_glyph(source, Circle(x='x', y='y', size=20))

--- a/tests/integration/widgets/test_textarea_input.py
+++ b/tests/integration/widgets/test_textarea_input.py
@@ -63,7 +63,7 @@ def modify_doc(doc):
 @pytest.mark.selenium
 class Test_TextInput(object):
 
-    def test_displays_text_input(self, bokeh_model_page):
+    def test_displays_text_input(self, bokeh_model_page) -> None:
         text_input = TextAreaInput(css_classes=["foo"])
         page = bokeh_model_page(text_input)
         input_div = page.driver.find_element_by_class_name('foo')
@@ -71,7 +71,7 @@ class Test_TextInput(object):
         assert el.tag_name == 'textarea'
         assert page.has_no_console_errors()
 
-    def test_displays_placeholder(self, bokeh_model_page):
+    def test_displays_placeholder(self, bokeh_model_page) -> None:
         text_input = TextAreaInput(placeholder="placeholder", css_classes=["foo"])
         page = bokeh_model_page(text_input)
         input_div = page.driver.find_element_by_class_name('foo')
@@ -79,7 +79,7 @@ class Test_TextInput(object):
         assert el.get_attribute('placeholder') == "placeholder"
         assert page.has_no_console_errors()
 
-    def test_server_on_change_round_trip(self, bokeh_server_page):
+    def test_server_on_change_round_trip(self, bokeh_server_page) -> None:
         page = bokeh_server_page(modify_doc)
 
         el = page.driver.find_element_by_class_name('foo')

--- a/tests/integration/widgets/test_toggle.py
+++ b/tests/integration/widgets/test_toggle.py
@@ -41,7 +41,7 @@ pytest_plugins = (
 @pytest.mark.selenium
 class Test_Toggle(object):
 
-    def test_displays_label(self, bokeh_model_page):
+    def test_displays_label(self, bokeh_model_page) -> None:
         button = Toggle(label="label", css_classes=["foo"])
 
         page = bokeh_model_page(button)
@@ -50,7 +50,7 @@ class Test_Toggle(object):
         assert button.text == "label"
 
     @pytest.mark.parametrize('typ', list(ButtonType))
-    def test_displays_button_type(self, typ, bokeh_model_page):
+    def test_displays_button_type(self, typ, bokeh_model_page) -> None:
         button = Toggle(button_type=typ, css_classes=["foo"])
 
         page = bokeh_model_page(button)
@@ -58,7 +58,7 @@ class Test_Toggle(object):
         button = page.driver.find_element_by_css_selector('.foo .bk-btn')
         assert typ in button.get_attribute('class')
 
-    def test_server_on_click_round_trip(self, bokeh_server_page):
+    def test_server_on_click_round_trip(self, bokeh_server_page) -> None:
 
         def modify_doc(doc):
             source = ColumnDataSource(dict(x=[1, 2], y=[1, 1]))
@@ -105,7 +105,7 @@ class Test_Toggle(object):
 
     # XXX (bev) Toggle does not register to process ButtonClick events
 
-    def test_js_on_click_executes(self, bokeh_model_page):
+    def test_js_on_click_executes(self, bokeh_model_page) -> None:
         button = Toggle(css_classes=['foo'])
         button.js_on_click(CustomJS(code=RECORD("value", "cb_obj.active")))
 

--- a/tests/test_bokehjs.py
+++ b/tests/test_bokehjs.py
@@ -16,7 +16,7 @@ import pytest
 @pytest.mark.js
 class TestBokehJS(object):
 
-    def test_bokehjs(self):
+    def test_bokehjs(self) -> None:
         os.chdir('bokehjs')
         proc = subprocess.Popen(["node", "make", "test"], stdout=subprocess.PIPE)
         out, errs = proc.communicate()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -31,7 +31,7 @@ pytest_plugins = (
 )
 
 @pytest.mark.examples
-def test_js_examples(js_example, example, config, report):
+def test_js_examples(js_example, example, config, report) -> None:
     if example.no_js:
         if not config.option.no_js:
             warn("skipping bokehjs for %s" % example.relpath)
@@ -39,7 +39,7 @@ def test_js_examples(js_example, example, config, report):
         _run_in_browser(example, "file://%s" % example.path, config.option.verbose)
 
 @pytest.mark.examples
-def test_file_examples(file_example, example, config, report):
+def test_file_examples(file_example, example, config, report) -> None:
     (status, duration, out, err) = _run_example(example)
     info("Example run in %s" % white("%.3fs" % duration))
 
@@ -63,7 +63,7 @@ def test_file_examples(file_example, example, config, report):
         _run_in_browser(example, "file://%s.html" % example.path_no_ext, config.option.verbose)
 
 @pytest.mark.examples
-def test_server_examples(server_example, example, config, report, bokeh_server):
+def test_server_examples(server_example, example, config, report, bokeh_server) -> None:
     app = build_single_handler_application(example.path)
     doc = app.create_document()
 

--- a/tests/unit/bokeh/application/handlers/test_code.py
+++ b/tests/unit/bokeh/application/handlers/test_code.py
@@ -52,7 +52,7 @@ class TestCodeHandler(object):
 
     # Public methods ----------------------------------------------------------
 
-    def test_empty_script(self):
+    def test_empty_script(self) -> None:
         doc = Document()
         handler = bahc.CodeHandler(source="# This script does nothing", filename="path/to/test_filename")
         handler.modify_document(doc)
@@ -61,7 +61,7 @@ class TestCodeHandler(object):
 
         assert not doc.roots
 
-    def test_script_adds_roots(self):
+    def test_script_adds_roots(self) -> None:
         doc = Document()
         handler = bahc.CodeHandler(source=script_adds_two_roots, filename="path/to/test_filename")
         handler.modify_document(doc)
@@ -70,7 +70,7 @@ class TestCodeHandler(object):
 
         assert len(doc.roots) == 2
 
-    def test_script_bad_syntax(self):
+    def test_script_bad_syntax(self) -> None:
         doc = Document()
         handler = bahc.CodeHandler(source="This is a syntax error", filename="path/to/test_filename")
         handler.modify_document(doc)
@@ -78,7 +78,7 @@ class TestCodeHandler(object):
         assert handler.error is not None
         assert 'Invalid syntax' in handler.error
 
-    def test_script_runtime_error(self):
+    def test_script_runtime_error(self) -> None:
         doc = Document()
         handler = bahc.CodeHandler(source="raise RuntimeError('nope')", filename="path/to/test_filename")
         handler.modify_document(doc)
@@ -86,7 +86,7 @@ class TestCodeHandler(object):
         assert handler.error is not None
         assert 'nope' in handler.error
 
-    def test_script_sys_path(self):
+    def test_script_sys_path(self) -> None:
         doc = Document()
         handler = bahc.CodeHandler(source="""import sys; raise RuntimeError("path: '%s'" % sys.path[0])""", filename="path/to/test_filename")
         handler.modify_document(doc)
@@ -94,7 +94,7 @@ class TestCodeHandler(object):
         assert handler.error is not None
         assert "path: 'path/to'" in handler.error
 
-    def test_script_argv(self):
+    def test_script_argv(self) -> None:
         doc = Document()
         handler = bahc.CodeHandler(source="""import sys; raise RuntimeError("argv: %r" % sys.argv)""", filename="path/to/test_filename")
         handler.modify_document(doc)
@@ -110,7 +110,7 @@ class TestCodeHandler(object):
         assert handler.error is not None
         assert "argv: ['test_filename', 10, 20, 30]" in handler.error
 
-    def test_safe_to_fork(self):
+    def test_safe_to_fork(self) -> None:
         doc = Document()
         handler = bahc.CodeHandler(source="# This script does nothing", filename="path/to/test_filename")
         assert handler.safe_to_fork

--- a/tests/unit/bokeh/application/handlers/test_code_runner.py
+++ b/tests/unit/bokeh/application/handlers/test_code_runner.py
@@ -39,7 +39,7 @@ class TestCodeRunner(object):
 
     # Public methods ----------------------------------------------------------
 
-    def test_init(self):
+    def test_init(self) -> None:
         cr = bahc.CodeRunner("# test", "path", [])
         assert cr.failed is False
         assert cr.error is None
@@ -48,20 +48,20 @@ class TestCodeRunner(object):
         assert cr.source == "# test"
         assert cr.path == "path"
 
-    def test_syntax_error_init(self):
+    def test_syntax_error_init(self) -> None:
         cr = bahc.CodeRunner("This is a syntax error", "path", [])
         assert cr.failed is True
         assert "Invalid syntax in" in cr.error
         assert cr.error_detail is not None
 
-    def test_new_module_success(self):
+    def test_new_module_success(self) -> None:
         cr = bahc.CodeRunner("# test", "path", [])
         m = cr.new_module()
         assert isinstance(m, ModuleType)
         assert m.__dict__['__name__'].startswith('bk_script_')
         assert m.__dict__['__file__'] == abspath("path")
 
-    def test_new_module_resets_run_errors(self):
+    def test_new_module_resets_run_errors(self) -> None:
         cr = bahc.CodeRunner("# test", "path", [])
         cr._failed = True
         m = cr.new_module()
@@ -69,13 +69,13 @@ class TestCodeRunner(object):
         assert m.__dict__['__name__'].startswith('bk_script_')
         assert m.__dict__['__file__'] == abspath("path")
 
-    def test_new_module_returns_None_for_permanent_errors(self):
+    def test_new_module_returns_None_for_permanent_errors(self) -> None:
         cr = bahc.CodeRunner("This is a syntax error", "path", [])
         assert cr.failed is True
         m = cr.new_module()
         assert m is None
 
-    def test_reset_run_errors(self):
+    def test_reset_run_errors(self) -> None:
         cr = bahc.CodeRunner("# test", "path", [])
         cr._failed = True
         cr._error = "error"
@@ -85,7 +85,7 @@ class TestCodeRunner(object):
         assert cr.error is None
         assert cr.error_detail is None
 
-    def test_reset_run_errors_leaves_permanent_errors(self):
+    def test_reset_run_errors_leaves_permanent_errors(self) -> None:
         cr = bahc.CodeRunner("This is a syntax error", "path", [])
         cr._failed = True
         cr.reset_run_errors()
@@ -93,14 +93,14 @@ class TestCodeRunner(object):
         assert cr.error is not None
         assert cr.error_detail is not None
 
-    def test_run_sets_ran(self):
+    def test_run_sets_ran(self) -> None:
         cr = bahc.CodeRunner("# test", "path", [])
         m = cr.new_module()
         assert not cr.ran
         cr.run(m, lambda: None)
         assert cr.ran
 
-    def test_run_runs_post_check(self):
+    def test_run_runs_post_check(self) -> None:
         cr = bahc.CodeRunner("# test", "path", [])
         m = cr.new_module()
         assert not cr.ran
@@ -111,14 +111,14 @@ class TestCodeRunner(object):
         assert cr.ran
         assert result == dict(ran=True)
 
-    def test_run_fixups_argv(self):
+    def test_run_fixups_argv(self) -> None:
         cr = bahc.CodeRunner("import sys; argv = list(sys.argv)", "path", ["foo", 10])
         assert not cr.ran
         m = cr.new_module()
         cr.run(m, lambda: None)
         assert m.__dict__['argv'] == ["path", "foo", 10]
 
-    def test_run_fixups_path(self):
+    def test_run_fixups_path(self) -> None:
         cr = bahc.CodeRunner("import sys; path = list(sys.path)", "/dir/to/path", ["foo", 10])
         assert not cr.ran
         m = cr.new_module()
@@ -126,7 +126,7 @@ class TestCodeRunner(object):
         assert m.__dict__['path'][0] == dirname("/dir/to/path")
         assert m.__dict__['path'][1:] == sys.path
 
-    def test_run_restores_cwd(self):
+    def test_run_restores_cwd(self) -> None:
         old_cwd = os.getcwd()
         cr = bahc.CodeRunner("import os; os.chdir('/')", "path", ["foo", 10])
         assert not cr.ran
@@ -134,7 +134,7 @@ class TestCodeRunner(object):
         cr.run(m, lambda: None)
         assert os.getcwd() == old_cwd
 
-    def test_run_restores_argv(self):
+    def test_run_restores_argv(self) -> None:
         old_argv = list(sys.argv)
         cr = bahc.CodeRunner("# test", "path", ["foo", 10])
         assert not cr.ran
@@ -142,7 +142,7 @@ class TestCodeRunner(object):
         cr.run(m, lambda: None)
         assert sys.argv == old_argv
 
-    def test_run_restores_path(self):
+    def test_run_restores_path(self) -> None:
         old_path = list(sys.path)
         cr = bahc.CodeRunner("# test", "path", ["foo", 10])
         assert not cr.ran

--- a/tests/unit/bokeh/application/handlers/test_directory.py
+++ b/tests/unit/bokeh/application/handlers/test_directory.py
@@ -72,7 +72,7 @@ class Test_DirectoryHandler(object):
 
     # Public methods ----------------------------------------------------------
 
-    def test_directory_empty_mainpy(self):
+    def test_directory_empty_mainpy(self) -> None:
         doc = Document()
         def load(filename):
             handler = bahd.DirectoryHandler(filename=filename)
@@ -86,7 +86,7 @@ class Test_DirectoryHandler(object):
 
         assert not doc.roots
 
-    def test_directory_mainpy_adds_roots(self):
+    def test_directory_mainpy_adds_roots(self) -> None:
         doc = Document()
         def load(filename):
             handler = bahd.DirectoryHandler(filename=filename)
@@ -101,7 +101,7 @@ class Test_DirectoryHandler(object):
 
         assert len(doc.roots) == 2
 
-    def test_directory_empty_mainipynb(self):
+    def test_directory_empty_mainipynb(self) -> None:
         import nbformat
 
         doc = Document()
@@ -121,7 +121,7 @@ class Test_DirectoryHandler(object):
 
         assert not doc.roots
 
-    def test_directory_mainipynb_adds_roots(self):
+    def test_directory_mainipynb_adds_roots(self) -> None:
         import nbformat
 
         doc = Document()
@@ -144,7 +144,7 @@ class Test_DirectoryHandler(object):
 
         assert len(doc.roots) == 2
 
-    def test_directory_has_theme_file(self):
+    def test_directory_has_theme_file(self) -> None:
         doc = Document()
         def load(filename):
             handler = bahd.DirectoryHandler(filename=filename)
@@ -185,7 +185,7 @@ some.foo = 57
         assert another_model.bar == 1
 
     @pytest.mark.asyncio
-    async def test_directory_with_server_lifecycle(self):
+    async def test_directory_with_server_lifecycle(self) -> None:
         doc = Document()
         result = {}
         def load(filename):
@@ -210,7 +210,7 @@ some.foo = 57
         assert "on_session_created" == await handler.on_session_created(None)
         assert "on_session_destroyed" == await handler.on_session_destroyed(None)
 
-    def test_directory_with_static(self):
+    def test_directory_with_static(self) -> None:
         doc = Document()
         result = {}
         def load(filename):
@@ -231,7 +231,7 @@ some.foo = 57
         assert handler.static_path() is not None
         assert handler.static_path().endswith("static")
 
-    def test_directory_without_static(self):
+    def test_directory_without_static(self) -> None:
         doc = Document()
         result = {}
         def load(filename):
@@ -250,7 +250,7 @@ some.foo = 57
         handler = result['handler']
         assert handler.static_path() is None
 
-    def test_directory_with_template(self):
+    def test_directory_with_template(self) -> None:
         doc = Document()
         result = {}
         def load(filename):
@@ -269,7 +269,7 @@ some.foo = 57
 
         assert isinstance(doc.template, jinja2.Template)
 
-    def test_directory_without_template(self):
+    def test_directory_without_template(self) -> None:
         doc = Document()
         result = {}
         def load(filename):
@@ -287,7 +287,7 @@ some.foo = 57
 
         assert doc.template is FILE
 
-    def test_safe_to_fork(self):
+    def test_safe_to_fork(self) -> None:
         doc = Document()
         result = {}
         def load(filename):
@@ -303,11 +303,11 @@ some.foo = 57
             'main.py' : "# This script does nothing",
         }, load)
 
-    def test_missing_filename_raises(self):
+    def test_missing_filename_raises(self) -> None:
         with pytest.raises(ValueError):
             bahd.DirectoryHandler()
 
-    def test_url_path(self):
+    def test_url_path(self) -> None:
         doc = Document()
         result = {}
         def load(filename):

--- a/tests/unit/bokeh/application/handlers/test_document_lifecycle.py
+++ b/tests/unit/bokeh/application/handlers/test_document_lifecycle.py
@@ -46,7 +46,7 @@ class Test_DocumentLifecycleHandler(object):
 
     # Public methods ----------------------------------------------------------
 
-    def test_document_bad_on_session_destroyed_signature(self):
+    def test_document_bad_on_session_destroyed_signature(self) -> None:
         doc = Document()
 
         def destroy(a, b):
@@ -56,7 +56,7 @@ class Test_DocumentLifecycleHandler(object):
             doc.on_session_destroyed(destroy)
 
     @pytest.mark.asyncio
-    async def test_document_on_session_destroyed(self):
+    async def test_document_on_session_destroyed(self) -> None:
         doc = Document()
         handler = bahd.DocumentLifecycleHandler()
 
@@ -72,7 +72,7 @@ class Test_DocumentLifecycleHandler(object):
         assert session_context._document.session_destroyed_callbacks == set()
 
     @pytest.mark.asyncio
-    async def test_document_on_session_destroyed_calls_multiple(self):
+    async def test_document_on_session_destroyed_calls_multiple(self) -> None:
         doc = Document()
 
         def increment(session_context):

--- a/tests/unit/bokeh/application/handlers/test_function.py
+++ b/tests/unit/bokeh/application/handlers/test_function.py
@@ -45,7 +45,7 @@ class Test_FunctionHandler(object):
 
     # Public methods ----------------------------------------------------------
 
-    def test_empty_func(self):
+    def test_empty_func(self) -> None:
         def noop(doc):
             pass
         handler = bahf.FunctionHandler(noop)
@@ -55,7 +55,7 @@ class Test_FunctionHandler(object):
             raise RuntimeError(handler.error)
         assert not doc.roots
 
-    def test_func_adds_roots(self):
+    def test_func_adds_roots(self) -> None:
         def add_roots(doc):
             doc.add_root(AnotherModelInTestFunction())
             doc.add_root(SomeModelInTestFunction())
@@ -66,7 +66,7 @@ class Test_FunctionHandler(object):
             raise RuntimeError(handler.error)
         assert len(doc.roots) == 2
 
-    def test_safe_to_fork(self):
+    def test_safe_to_fork(self) -> None:
         def noop(doc):
             pass
         handler = bahf.FunctionHandler(noop)

--- a/tests/unit/bokeh/application/handlers/test_handler.py
+++ b/tests/unit/bokeh/application/handlers/test_handler.py
@@ -34,7 +34,7 @@ class Test_Handler(object):
 
     # Public methods ----------------------------------------------------------
 
-    def test_create(self):
+    def test_create(self) -> None:
         h = bahh.Handler()
         assert h.failed == False
         assert h.url_path() is None
@@ -42,20 +42,20 @@ class Test_Handler(object):
         assert h.error is None
         assert h.error_detail is None
 
-    def test_modify_document_abstract(self):
+    def test_modify_document_abstract(self) -> None:
         h = bahh.Handler()
         with pytest.raises(NotImplementedError):
             h.modify_document("doc")
 
     @pytest.mark.asyncio
-    async def test_default_hooks_return_none(self):
+    async def test_default_hooks_return_none(self) -> None:
         h = bahh.Handler()
         assert h.on_server_loaded("context") is None
         assert h.on_server_unloaded("context") is None
         assert await h.on_session_created("context") is None
         assert await h.on_session_destroyed("context") is None
 
-    def test_static_path(self):
+    def test_static_path(self) -> None:
         h = bahh.Handler()
         assert h.static_path() is None
         h._static = "path"

--- a/tests/unit/bokeh/application/handlers/test_notebook__handlers.py
+++ b/tests/unit/bokeh/application/handlers/test_notebook__handlers.py
@@ -50,7 +50,7 @@ class Test_NotebookHandler(object):
 
     # Public methods ----------------------------------------------------------
 
-    def test_runner_strips_line_magics(self, ipython):
+    def test_runner_strips_line_magics(self, ipython) -> None:
         doc = Document()
         source = nbformat.v4.new_notebook()
         source.cells.append(nbformat.v4.new_code_cell('%time'))
@@ -61,7 +61,7 @@ class Test_NotebookHandler(object):
 
         with_script_contents(source, load)
 
-    def test_runner_strips_cell_magics(self):
+    def test_runner_strips_cell_magics(self) -> None:
         doc = Document()
         source = nbformat.v4.new_notebook()
         code = '%%timeit\n1+1'
@@ -73,7 +73,7 @@ class Test_NotebookHandler(object):
 
         with_script_contents(source, load)
 
-    def test_runner_uses_source_from_filename(self):
+    def test_runner_uses_source_from_filename(self) -> None:
         doc = Document()
         source = nbformat.v4.new_notebook()
         result = {}
@@ -93,7 +93,7 @@ class Test_NotebookHandler(object):
         assert result['handler']._runner.source == expected_source
         assert not doc.roots
 
-    def test_missing_filename_raises(self):
+    def test_missing_filename_raises(self) -> None:
         with pytest.raises(ValueError):
             bahn.NotebookHandler()
 

--- a/tests/unit/bokeh/application/handlers/test_script.py
+++ b/tests/unit/bokeh/application/handlers/test_script.py
@@ -37,7 +37,7 @@ class Test_ScriptHandler(object):
 
     # Public methods ----------------------------------------------------------
 
-    def test_runner_uses_source_from_filename(self):
+    def test_runner_uses_source_from_filename(self) -> None:
         doc = Document()
         source = "# Test contents for script"
         result = {}
@@ -52,7 +52,7 @@ class Test_ScriptHandler(object):
         assert result['handler']._runner.source == source
         assert not doc.roots
 
-    def test_runner_script_with_encoding(self):
+    def test_runner_script_with_encoding(self) -> None:
         doc = Document()
         source = "# -*- coding: utf-8 -*-\nimport os"
         result = {}
@@ -67,7 +67,7 @@ class Test_ScriptHandler(object):
         assert result['handler'].failed is False
         assert not doc.roots
 
-    def test_missing_filename_raises(self):
+    def test_missing_filename_raises(self) -> None:
         with pytest.raises(ValueError):
             bahs.ScriptHandler()
 

--- a/tests/unit/bokeh/application/handlers/test_server_lifecycle.py
+++ b/tests/unit/bokeh/application/handlers/test_server_lifecycle.py
@@ -49,7 +49,7 @@ class Test_ServerLifecycleHandler(object):
     # Public methods ----------------------------------------------------------
 
     @pytest.mark.asyncio
-    async def test_empty_lifecycle(self):
+    async def test_empty_lifecycle(self) -> None:
         doc = Document()
         out = {}
         def load(filename):
@@ -66,7 +66,7 @@ class Test_ServerLifecycleHandler(object):
             raise RuntimeError(handler.error)
         assert not doc.roots
 
-    def test_lifecycle_bad_syntax(self):
+    def test_lifecycle_bad_syntax(self) -> None:
         result = {}
         def load(filename):
             handler = bahs.ServerLifecycleHandler(filename=filename)
@@ -77,7 +77,7 @@ class Test_ServerLifecycleHandler(object):
         assert handler.error is not None
         assert 'Invalid syntax' in handler.error
 
-    def test_lifecycle_runtime_error(self):
+    def test_lifecycle_runtime_error(self) -> None:
         result = {}
         def load(filename):
             handler = bahs.ServerLifecycleHandler(filename=filename)
@@ -88,7 +88,7 @@ class Test_ServerLifecycleHandler(object):
         assert handler.error is not None
         assert 'nope' in handler.error
 
-    def test_lifecycle_bad_server_loaded_signature(self):
+    def test_lifecycle_bad_server_loaded_signature(self) -> None:
         result = {}
         def load(filename):
             handler = bahs.ServerLifecycleHandler(filename=filename)
@@ -104,7 +104,7 @@ def on_server_loaded(a,b):
         assert 'func(a, b)' in handler.error
         assert "Traceback" in handler.error_detail
 
-    def test_lifecycle_bad_server_unloaded_signature(self):
+    def test_lifecycle_bad_server_unloaded_signature(self) -> None:
         result = {}
         def load(filename):
             handler = bahs.ServerLifecycleHandler(filename=filename)
@@ -120,7 +120,7 @@ def on_server_unloaded(a,b):
         assert 'func(a, b)' in handler.error
         assert "Traceback" in handler.error_detail
 
-    def test_lifecycle_bad_session_created_signature(self):
+    def test_lifecycle_bad_session_created_signature(self) -> None:
         result = {}
         def load(filename):
             handler = bahs.ServerLifecycleHandler(filename=filename)
@@ -135,7 +135,7 @@ def on_session_created(a,b):
         assert 'on_session_created must have signature func(session_context)' in handler.error
         assert 'func(a, b)' in handler.error
 
-    def test_lifecycle_bad_session_destroyed_signature(self):
+    def test_lifecycle_bad_session_destroyed_signature(self) -> None:
         result = {}
         def load(filename):
             handler = bahs.ServerLifecycleHandler(filename=filename)
@@ -151,7 +151,7 @@ def on_session_destroyed(a,b):
         assert 'func(a, b)' in handler.error
 
     @pytest.mark.asyncio
-    async def test_calling_lifecycle_hooks(self):
+    async def test_calling_lifecycle_hooks(self) -> None:
         result = {}
         def load(filename):
             handler = result['handler'] = bahs.ServerLifecycleHandler(filename=filename)
@@ -165,11 +165,11 @@ def on_session_destroyed(a,b):
         assert "on_session_created" == await handler.on_session_created(None)
         assert "on_session_destroyed" == await handler.on_session_destroyed(None)
 
-    def test_missing_filename_raises(self):
+    def test_missing_filename_raises(self) -> None:
         with pytest.raises(ValueError):
             bahs.ServerLifecycleHandler()
 
-    def test_url_path(self):
+    def test_url_path(self) -> None:
         result = {}
         def load(filename):
             handler = bahs.ServerLifecycleHandler(filename=filename)
@@ -183,7 +183,7 @@ def on_server_unloaded(server_context):
         assert handler.error is None
         assert handler.url_path().startswith("/")
 
-    def test_url_path_failed(self):
+    def test_url_path_failed(self) -> None:
         result = {}
         def load(filename):
             handler = bahs.ServerLifecycleHandler(filename=filename)

--- a/tests/unit/bokeh/application/test_application.py
+++ b/tests/unit/bokeh/application/test_application.py
@@ -53,16 +53,16 @@ class Test_Application(object):
 
     # Public methods ----------------------------------------------------------
 
-    def test_empty(self):
+    def test_empty(self) -> None:
         a = baa.Application()
         doc = a.create_document()
         assert not doc.roots
 
-    def test_invalid_kwarg(self):
+    def test_invalid_kwarg(self) -> None:
         with pytest.raises(TypeError):
             baa.Application(junk="foo")
 
-    def test_one_handler(self):
+    def test_one_handler(self) -> None:
         a = baa.Application()
         def add_roots(doc):
             doc.add_root(AnotherModelInTestApplication())
@@ -72,7 +72,7 @@ class Test_Application(object):
         doc = a.create_document()
         assert len(doc.roots) == 2
 
-    def test_two_handlers(self):
+    def test_two_handlers(self) -> None:
         a = baa.Application()
         def add_roots(doc):
             doc.add_root(AnotherModelInTestApplication())
@@ -86,7 +86,7 @@ class Test_Application(object):
         doc = a.create_document()
         assert len(doc.roots) == 3
 
-    def test_failed_handler(self, caplog):
+    def test_failed_handler(self, caplog) -> None:
         a = baa.Application()
         handler = CodeHandler(filename="junk", source="bad(")
         a.add(handler)
@@ -96,7 +96,7 @@ class Test_Application(object):
             a.initialize_document(d)
             assert len(caplog.records) == 1
 
-    def test_no_static_path(self):
+    def test_no_static_path(self) -> None:
         a = baa.Application()
         def add_roots(doc):
             doc.add_root(AnotherModelInTestApplication())
@@ -109,7 +109,7 @@ class Test_Application(object):
         a.add(handler2)
         assert a.static_path == None
 
-    def test_static_path(self):
+    def test_static_path(self) -> None:
         a = baa.Application()
         def add_roots(doc):
             doc.add_root(AnotherModelInTestApplication())
@@ -123,7 +123,7 @@ class Test_Application(object):
         a.add(handler2)
         assert a.static_path == "foo"
 
-    def test_excess_static_path(self):
+    def test_excess_static_path(self) -> None:
         a = baa.Application()
         def add_roots(doc):
             doc.add_root(AnotherModelInTestApplication())
@@ -140,7 +140,7 @@ class Test_Application(object):
         assert "More than one static path" in str(e.value)
 
     @mock.patch('bokeh.document.document.check_integrity')
-    def test_application_validates_document_by_default(self, check_integrity):
+    def test_application_validates_document_by_default(self, check_integrity) -> None:
         a = baa.Application()
         d = Document()
         d.add_root(figure())
@@ -148,7 +148,7 @@ class Test_Application(object):
         assert check_integrity.called
 
     @mock.patch('bokeh.document.document.check_integrity')
-    def test_application_doesnt_validate_document_due_to_env_var(self, check_integrity, monkeypatch):
+    def test_application_doesnt_validate_document_due_to_env_var(self, check_integrity, monkeypatch) -> None:
         monkeypatch.setenv("BOKEH_VALIDATE_DOC", "false")
         a = baa.Application()
         d = Document()
@@ -164,13 +164,13 @@ class Test_ServerContext(object):
 
     # Public methods ----------------------------------------------------------
 
-    def test_abstract(self):
+    def test_abstract(self) -> None:
         with pytest.raises(TypeError):
             baa.ServerContext()
 
 class Test_SessionContext(object):
 
-    def test_abstract(self):
+    def test_abstract(self) -> None:
         with pytest.raises(TypeError):
             baa.SessionContext()
 

--- a/tests/unit/bokeh/client/test_connection.py
+++ b/tests/unit/bokeh/client/test_connection.py
@@ -40,7 +40,7 @@ class FakeSess(object):
 
 class Test_ClientConnection(object):
 
-    def test_creation(self):
+    def test_creation(self) -> None:
         c = bcc.ClientConnection("session", "wsurl")
         assert c.url == "wsurl"
         assert c.connected == False
@@ -52,7 +52,7 @@ class Test_ClientConnection(object):
         assert c._server_info is None
         assert c._arguments is None
 
-    def test_creation_with_arguments(self):
+    def test_creation_with_arguments(self) -> None:
         c = bcc.ClientConnection("session", "wsurl", arguments=dict(foo="bar"))
         assert c.url == "wsurl"
         assert c.connected == False
@@ -64,11 +64,11 @@ class Test_ClientConnection(object):
         assert c._server_info is None
         assert c._arguments == dict(foo="bar")
 
-    def test__formatted_url(self):
+    def test__formatted_url(self) -> None:
         c = bcc.ClientConnection(FakeSess(), "wsurl")
         assert c._formatted_url() == "wsurl?bokeh-session-id=session_id"
 
-    def test__formatted_url_with_arguments(self):
+    def test__formatted_url_with_arguments(self) -> None:
         c = bcc.ClientConnection(FakeSess(), "wsurl", arguments=dict(foo="bar"))
         assert c._formatted_url() == "wsurl?bokeh-session-id=session_id&foo=bar"
 

--- a/tests/unit/bokeh/client/test_session__client.py
+++ b/tests/unit/bokeh/client/test_session__client.py
@@ -28,15 +28,15 @@ import bokeh.client.session as bcs # isort:skip
 # General API
 #-----------------------------------------------------------------------------
 
-def test_DEFAULT_SESSION_ID():
+def test_DEFAULT_SESSION_ID() -> None:
     assert bcs.DEFAULT_SESSION_ID == "default"
 
-def test_DEFAULT_SERVER_WEBSOCKET_URL():
+def test_DEFAULT_SERVER_WEBSOCKET_URL() -> None:
     assert bcs.DEFAULT_SERVER_WEBSOCKET_URL == "ws://localhost:5006/ws"
 
 class Test_ClientSession(object):
 
-    def test_creation_defaults(self):
+    def test_creation_defaults(self) -> None:
         s = bcs.ClientSession()
         assert s.connected == False
         assert s.document is None
@@ -44,14 +44,14 @@ class Test_ClientSession(object):
         assert isinstance(s.id, str)
         assert len(s.id) == 44
 
-    def test_creation_with_session_id(self):
+    def test_creation_with_session_id(self) -> None:
         s = bcs.ClientSession("sid")
         assert s.connected == False
         assert s.document is None
         assert s._connection._arguments is None
         assert s.id == "sid"
 
-    def test_creation_with_ws_url(self):
+    def test_creation_with_ws_url(self) -> None:
         s = bcs.ClientSession(websocket_url="wsurl")
         assert s.connected == False
         assert s.document is None
@@ -60,7 +60,7 @@ class Test_ClientSession(object):
         assert isinstance(s.id, str)
         assert len(s.id) == 44
 
-    def test_creation_with_ioloop(self):
+    def test_creation_with_ioloop(self) -> None:
         s = bcs.ClientSession(io_loop="io_loop")
         assert s.connected == False
         assert s.document is None
@@ -69,7 +69,7 @@ class Test_ClientSession(object):
         assert isinstance(s.id, str)
         assert len(s.id) == 44
 
-    def test_creation_with_arguments(self):
+    def test_creation_with_arguments(self) -> None:
         s = bcs.ClientSession(arguments="args")
         assert s.connected == False
         assert s.document is None
@@ -77,7 +77,7 @@ class Test_ClientSession(object):
         assert len(s.id) == 44
 
     @patch("bokeh.client.connection.ClientConnection.connect")
-    def test_connect(self, mock_connect):
+    def test_connect(self, mock_connect) -> None:
         s = bcs.ClientSession()
         s.connect()
         assert mock_connect.call_count == 1
@@ -85,7 +85,7 @@ class Test_ClientSession(object):
         assert mock_connect.call_args[1] == {}
 
     @patch("bokeh.client.connection.ClientConnection.close")
-    def test_close(self, mock_close):
+    def test_close(self, mock_close) -> None:
         s = bcs.ClientSession()
         s.close()
         assert mock_close.call_count == 1
@@ -93,7 +93,7 @@ class Test_ClientSession(object):
         assert mock_close.call_args[1] == {}
 
     @patch("bokeh.client.connection.ClientConnection.close")
-    def test_context_manager(self, mock_close):
+    def test_context_manager(self, mock_close) -> None:
         with bcs.ClientSession() as session:
             assert isinstance(session, bcs.ClientSession)
         assert mock_close.call_count == 1
@@ -101,7 +101,7 @@ class Test_ClientSession(object):
         assert mock_close.call_args[1] == {}
 
     @patch("bokeh.client.connection.ClientConnection.close")
-    def test_close_with_why(self, mock_close):
+    def test_close_with_why(self, mock_close) -> None:
         s = bcs.ClientSession()
         s.close("foo")
         assert mock_close.call_count == 1
@@ -109,7 +109,7 @@ class Test_ClientSession(object):
         assert mock_close.call_args[1] == {}
 
     @patch("bokeh.client.connection.ClientConnection.force_roundtrip")
-    def test_force_roundtrip(self, mock_force_roundtrip):
+    def test_force_roundtrip(self, mock_force_roundtrip) -> None:
         s = bcs.ClientSession()
         s.force_roundtrip()
         assert mock_force_roundtrip.call_count == 1
@@ -117,7 +117,7 @@ class Test_ClientSession(object):
         assert mock_force_roundtrip.call_args[1] == {}
 
     @patch("bokeh.client.connection.ClientConnection.request_server_info")
-    def test_request_server_info(self, mock_request_server_info):
+    def test_request_server_info(self, mock_request_server_info) -> None:
         s = bcs.ClientSession()
         s.request_server_info()
         assert mock_request_server_info.call_count == 1

--- a/tests/unit/bokeh/client/test_states.py
+++ b/tests/unit/bokeh/client/test_states.py
@@ -46,31 +46,31 @@ class MockMessage(object):
 
 
 @pytest.mark.asyncio
-async def test_NOT_YET_CONNECTED():
+async def test_NOT_YET_CONNECTED() -> None:
     s = bcs.NOT_YET_CONNECTED()
     r = await s.run(MockConnection())
     assert r == "_connect_async"
 
 @pytest.mark.asyncio
-async def test_CONNECTED_BEFORE_ACK():
+async def test_CONNECTED_BEFORE_ACK() -> None:
     s = bcs.CONNECTED_BEFORE_ACK()
     r = await s.run(MockConnection())
     assert r == "_wait_for_ack"
 
 @pytest.mark.asyncio
-async def test_CONNECTED_AFTER_ACK():
+async def test_CONNECTED_AFTER_ACK() -> None:
     s = bcs.CONNECTED_AFTER_ACK()
     r = await s.run(MockConnection())
     assert r == "_handle_messages"
 
 @pytest.mark.asyncio
-async def test_DISCONNECTED():
+async def test_DISCONNECTED() -> None:
     s = bcs.DISCONNECTED()
     r = await s.run(MockConnection())
     assert r is None
 
 @pytest.mark.asyncio
-async def test_WAITING_FOR_REPLY():
+async def test_WAITING_FOR_REPLY() -> None:
     s = bcs.WAITING_FOR_REPLY("reqid")
     assert s.reply == None
     assert s.reqid == "reqid"

--- a/tests/unit/bokeh/client/test_util__client.py
+++ b/tests/unit/bokeh/client/test_util__client.py
@@ -31,17 +31,17 @@ import bokeh.client.util as bcu # isort:skip
 
 class Test_server_url_for_websocket_url(object):
 
-    def test_with_ws(self):
+    def test_with_ws(self) -> None:
         assert bcu.server_url_for_websocket_url("ws://foo.com/ws") == "http://foo.com/"
 
-    def test_with_wss(self):
+    def test_with_wss(self) -> None:
         assert bcu.server_url_for_websocket_url("wss://foo.com/ws") == "https://foo.com/"
 
-    def test_bad_proto(self):
+    def test_bad_proto(self) -> None:
         with pytest.raises(ValueError):
             bcu.server_url_for_websocket_url("junk://foo.com/ws")
 
-    def test_bad_ending(self):
+    def test_bad_ending(self) -> None:
         with pytest.raises(ValueError):
             bcu.server_url_for_websocket_url("ws://foo.com/junk")
         with pytest.raises(ValueError):
@@ -49,15 +49,15 @@ class Test_server_url_for_websocket_url(object):
 
 class Test_websocket_url_for_server_url(object):
 
-    def test_with_http(self):
+    def test_with_http(self) -> None:
         assert bcu.websocket_url_for_server_url("http://foo.com") == "ws://foo.com/ws"
         assert bcu.websocket_url_for_server_url("http://foo.com/") == "ws://foo.com/ws"
 
-    def test_with_https(self):
+    def test_with_https(self) -> None:
         assert bcu.websocket_url_for_server_url("https://foo.com") == "wss://foo.com/ws"
         assert bcu.websocket_url_for_server_url("https://foo.com/") == "wss://foo.com/ws"
 
-    def test_bad_proto(self):
+    def test_bad_proto(self) -> None:
         with pytest.raises(ValueError):
             bcu.websocket_url_for_server_url("junk://foo.com")
 

--- a/tests/unit/bokeh/client/test_websocket.py
+++ b/tests/unit/bokeh/client/test_websocket.py
@@ -34,11 +34,11 @@ import bokeh.client.websocket as bcw # isort:skip
 
 class Test_WebSocketClientConnectionWrapper(object):
 
-    def test_creation_raises_with_None(self):
+    def test_creation_raises_with_None(self) -> None:
         with pytest.raises(ValueError):
             bcw.WebSocketClientConnectionWrapper(None)
 
-    def test_creation(self):
+    def test_creation(self) -> None:
         w = bcw.WebSocketClientConnectionWrapper("socket")
         assert w._socket == "socket"
         assert isinstance(w.write_lock, locks.Lock)

--- a/tests/unit/bokeh/colors/test_color__colors.py
+++ b/tests/unit/bokeh/colors/test_color__colors.py
@@ -30,11 +30,11 @@ import bokeh.colors.color as bcc # isort:skip
 
 class Test_Color(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         c = bcc.Color()
         assert c
 
-    def test_abstract(self):
+    def test_abstract(self) -> None:
         c = bcc.Color()
 
         with pytest.raises(NotImplementedError):
@@ -52,18 +52,18 @@ class Test_Color(object):
         with pytest.raises(NotImplementedError):
             c.to_rgb()
 
-    def test_repr(self):
+    def test_repr(self) -> None:
         c = bcc.Color()
         with pytest.raises(NotImplementedError):
             repr(c)
 
-    def test_clamp(self):
+    def test_clamp(self) -> None:
         assert bcc.Color.clamp(10) == 10
         assert bcc.Color.clamp(10, 20) == 10
         assert bcc.Color.clamp(10, 5) == 5
         assert bcc.Color.clamp(-10) == 0
 
-    def test_darken(self):
+    def test_darken(self) -> None:
         c = HSL(10, 0.2, 0.2, 0.2)
         c2 = c.darken(0.1)
         assert c2 is not c
@@ -79,7 +79,7 @@ class Test_Color(object):
         assert c2.s == 0.2
         assert c2.l == 0
 
-    def test_lighten(self):
+    def test_lighten(self) -> None:
         c = HSL(10, 0.2, 0.2, 0.2)
         c2 = c.lighten(0.2)
         assert c2 is not c

--- a/tests/unit/bokeh/colors/test_groups.py
+++ b/tests/unit/bokeh/colors/test_groups.py
@@ -198,12 +198,12 @@ _black = (
 # General API
 #-----------------------------------------------------------------------------
 
-def test__all__():
+def test__all__() -> None:
     assert bcg.__all__ == ('black', 'blue', 'brown', 'cyan', 'green', 'orange', 'pink', 'purple', 'red', 'white', 'yellow')
 
 @pytest.mark.parametrize('group', bcg.__all__)
 @pytest.mark.unit
-def test_color(group):
+def test_color(group) -> None:
     assert group in bcg.__all__
     g = getattr(bcg, group)
     ref = globals().get("_"+group)

--- a/tests/unit/bokeh/colors/test_hsl.py
+++ b/tests/unit/bokeh/colors/test_hsl.py
@@ -30,7 +30,7 @@ import bokeh.colors.hsl as bch # isort:skip
 
 class Test_HSL(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         c = bch.HSL(10, 0.2, 0.3)
         assert c
         assert c.a == 1.0
@@ -44,13 +44,13 @@ class Test_HSL(object):
         assert c.s == 0.2
         assert c.l == 0.3
 
-    def test_repr(self):
+    def test_repr(self) -> None:
         c = bch.HSL(10, 0.2, 0.3)
         assert repr(c) == c.to_css()
         c = bch.HSL(10, 0.2, 0.3, 0.3)
         assert repr(c) == c.to_css()
 
-    def test_copy(self):
+    def test_copy(self) -> None:
         c = bch.HSL(10, 0.2, 0.3)
         c2 = c.copy()
         assert c2 is not c
@@ -59,7 +59,7 @@ class Test_HSL(object):
         assert c2.s == c.s
         assert c2.l == c.l
 
-    def test_from_hsl(self):
+    def test_from_hsl(self) -> None:
         c = bch.HSL(10, 0.2, 0.3)
         c2 = bch.HSL.from_hsl(c)
         assert c2 is not c
@@ -76,7 +76,7 @@ class Test_HSL(object):
         assert c2.s == c.s
         assert c2.l == c.l
 
-    def test_from_rgb(self):
+    def test_from_rgb(self) -> None:
         c = RGB(255, 100, 0)
         c2 = bch.HSL.from_rgb(c)
         assert c2 is not c
@@ -93,13 +93,13 @@ class Test_HSL(object):
         assert c2.s == 1.0
         assert c2.l == 0.5
 
-    def test_to_css(self):
+    def test_to_css(self) -> None:
         c = bch.HSL(10, 0.2, 0.3)
         assert c.to_css() == "hsl(10, 20.0%, 30.0%)"
         c = bch.HSL(10, 0.2, 0.3, 0.3)
         assert c.to_css() == "hsla(10, 20.0%, 30.0%, 0.3)"
 
-    def test_to_hsl(self):
+    def test_to_hsl(self) -> None:
         c = bch.HSL(10, 0.2, 0.3)
         c2 = c.to_hsl()
         assert c2 is not c
@@ -116,7 +116,7 @@ class Test_HSL(object):
         assert c2.s == c.s
         assert c2.l == c.l
 
-    def test_to_rgb(self):
+    def test_to_rgb(self) -> None:
         c = bch.HSL(10, 0.2, 0.3)
         c2 = c.to_rgb()
         assert c2 is not c

--- a/tests/unit/bokeh/colors/test_named.py
+++ b/tests/unit/bokeh/colors/test_named.py
@@ -175,12 +175,12 @@ COLORS = (
 # General API
 #-----------------------------------------------------------------------------
 
-def test__all__():
+def test__all__() -> None:
     assert len(bcn.__all__) == 147
 
 @pytest.mark.parametrize('name,R,G,B', COLORS)
 @pytest.mark.unit
-def test_color(name, R, G, B):
+def test_color(name, R, G, B) -> None:
     assert name in bcn.__all__
     c = getattr(bcn, name)
     assert (c.r, c.g, c.b) == (R, G, B)

--- a/tests/unit/bokeh/colors/test_rgb.py
+++ b/tests/unit/bokeh/colors/test_rgb.py
@@ -30,7 +30,7 @@ import bokeh.colors.rgb as bcr # isort:skip
 
 class Test_RGB(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         c = bcr.RGB(10, 20, 30)
         assert c
         assert c.a == 1.0
@@ -45,13 +45,13 @@ class Test_RGB(object):
         assert c.g == 20
         assert c.b == 30
 
-    def test_repr(self):
+    def test_repr(self) -> None:
         c = bcr.RGB(10, 20, 30)
         assert repr(c) == c.to_css()
         c = bcr.RGB(10, 20, 30, 0.3)
         assert repr(c) == c.to_css()
 
-    def test_copy(self):
+    def test_copy(self) -> None:
         c = bcr.RGB(10, 0.2, 0.3)
         c2 = c.copy()
         assert c2 is not c
@@ -60,7 +60,7 @@ class Test_RGB(object):
         assert c2.g == c.g
         assert c2.b == c.b
 
-    def test_from_hsl(self):
+    def test_from_hsl(self) -> None:
         c = HSL(10, 0.1, 0.2)
         c2 = bcr.RGB.from_hsl(c)
         assert c2 is not c
@@ -77,7 +77,7 @@ class Test_RGB(object):
         assert c2.g == 48
         assert c2.b == 46
 
-    def test_from_rgb(self):
+    def test_from_rgb(self) -> None:
         c = bcr.RGB(10, 20, 30)
         c2 = bcr.RGB.from_rgb(c)
         assert c2 is not c
@@ -94,17 +94,17 @@ class Test_RGB(object):
         assert c2.g == c.g
         assert c2.b == c.b
 
-    def test_to_css(self):
+    def test_to_css(self) -> None:
         c = bcr.RGB(10, 20, 30)
         assert c.to_css() == "rgb(10, 20, 30)"
         c = bcr.RGB(10, 20, 30, 0.3)
         assert c.to_css() == "rgba(10, 20, 30, 0.3)"
 
-    def test_to_hex(self):
+    def test_to_hex(self) -> None:
         c = bcr.RGB(10, 20, 30)
         assert c.to_hex(), "#%02X%02X%02X" % (c.r, c.g, c.b)
 
-    def test_to_hsl(self):
+    def test_to_hsl(self) -> None:
         c = bcr.RGB(255, 100, 0)
         c2 = c.to_hsl()
         assert c2 is not c
@@ -121,7 +121,7 @@ class Test_RGB(object):
         assert c2.s == 1.0
         assert c2.l == 0.5
 
-    def test_to_rgb(self):
+    def test_to_rgb(self) -> None:
         c = bcr.RGB(10, 20, 30)
         c2 = c.to_rgb()
         assert c2 is not c

--- a/tests/unit/bokeh/colors/test_util__colors.py
+++ b/tests/unit/bokeh/colors/test_util__colors.py
@@ -38,38 +38,38 @@ class _TestGroup(bcu.ColorGroup):
 
 class Test_NamedColor(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         c = bcu.NamedColor("aliceblue", 240,  248,  255)
         assert c.name == "aliceblue"
 
-    def test_repr(self):
+    def test_repr(self) -> None:
         c = bcu.NamedColor("aliceblue", 240,  248,  255)
         assert repr(c) == c.to_css()
 
-    def test_to_css(self):
+    def test_to_css(self) -> None:
         c = bcu.NamedColor("aliceblue", 240,  248,  255)
         assert c.to_css() == "aliceblue"
 
 # _ColorGroupMeta is exercised here by testing ColorGroup, rather than a separate test
 class Test_ColorGroup(object):
 
-    def test_len(self):
+    def test_len(self) -> None:
         assert len(_TestGroup) == 3
 
-    def test_iter(self):
+    def test_iter(self) -> None:
         it = iter(_TestGroup)
         assert next(it) == named.red
         assert next(it) == named.green
         assert next(it) == named.blue
 
-    def test_getitem_string(self):
+    def test_getitem_string(self) -> None:
         assert _TestGroup['Red'] == named.red
         assert _TestGroup['Green'] == named.green
         assert _TestGroup['Blue'] == named.blue
         with pytest.raises(KeyError):
             _TestGroup['Junk']
 
-    def test_getitem_int(self):
+    def test_getitem_int(self) -> None:
         assert _TestGroup[0] == named.red
         assert _TestGroup[1] == named.green
         assert _TestGroup[2] == named.blue
@@ -78,7 +78,7 @@ class Test_ColorGroup(object):
         with pytest.raises(IndexError):
             _TestGroup[3]
 
-    def test_getitem_bad(self):
+    def test_getitem_bad(self) -> None:
         with pytest.raises(ValueError):
             _TestGroup[10.2]
         with pytest.raises(ValueError):

--- a/tests/unit/bokeh/command/subcommands/test___init___subcommands.py
+++ b/tests/unit/bokeh/command/subcommands/test___init___subcommands.py
@@ -30,16 +30,16 @@ import bokeh.command.subcommands as sc # isort:skip
 # Dev API
 #-----------------------------------------------------------------------------
 
-def test_all():
+def test_all() -> None:
     assert hasattr(sc, 'all')
     assert type(sc.all) is list
 
-def test_all_types():
+def test_all_types() -> None:
     from bokeh.command.subcommand import Subcommand
 
     assert all(issubclass(x, Subcommand) for x in sc.all)
 
-def test_all_count():
+def test_all_count() -> None:
     from os.path import dirname
     from os import listdir
 

--- a/tests/unit/bokeh/command/subcommands/test_html.py
+++ b/tests/unit/bokeh/command/subcommands/test_html.py
@@ -42,20 +42,20 @@ import bokeh.command.subcommands.html as schtml # isort:skip
 # Dev API
 #-----------------------------------------------------------------------------
 
-def test_create():
+def test_create() -> None:
     import argparse
     from bokeh.command.subcommand import Subcommand
 
     obj = schtml.HTML(parser=argparse.ArgumentParser())
     assert isinstance(obj, Subcommand)
 
-def test_name():
+def test_name() -> None:
     assert schtml.HTML.name == "html"
 
-def test_help():
+def test_help() -> None:
     assert schtml.HTML.help == "Create standalone HTML files for one or more applications"
 
-def test_args():
+def test_args() -> None:
     assert schtml.HTML.args == (
 
         ('files', dict(
@@ -86,7 +86,7 @@ def test_args():
 
     )
 
-def test_no_script(capsys):
+def test_no_script(capsys) -> None:
     with (TmpDir(prefix="bokeh-html-no-script")) as dirname:
         with WorkingDir(dirname):
             with pytest.raises(SystemExit):
@@ -99,7 +99,7 @@ bokeh html: error: %s
 """ % (too_few)
         assert out == ""
 
-def test_basic_script(capsys):
+def test_basic_script(capsys) -> None:
     def run(dirname):
         with WorkingDir(dirname):
             main(["bokeh", "html", "scatter.py"])
@@ -111,7 +111,7 @@ def test_basic_script(capsys):
 
     with_directory_contents({ 'scatter.py' : basic_scatter_script }, run)
 
-def test_basic_script_with_output_after(capsys):
+def test_basic_script_with_output_after(capsys) -> None:
     def run(dirname):
         with WorkingDir(dirname):
             main(["bokeh", "html", "scatter.py", "--output", "foo.html"])
@@ -123,7 +123,7 @@ def test_basic_script_with_output_after(capsys):
 
     with_directory_contents({ 'scatter.py' : basic_scatter_script }, run)
 
-def test_basic_script_with_output_before(capsys):
+def test_basic_script_with_output_before(capsys) -> None:
     def run(dirname):
         with WorkingDir(dirname):
             main(["bokeh", "html", "--output", "foo.html", "scatter.py"])
@@ -136,7 +136,7 @@ def test_basic_script_with_output_before(capsys):
     with_directory_contents({ 'scatter.py' : basic_scatter_script }, run)
 
 @patch('bokeh.util.browser.view')
-def test_show(mock_view, capsys):
+def test_show(mock_view, capsys) -> None:
     def run(dirname):
         with WorkingDir(dirname):
             main(["bokeh", "html", "--show", "scatter.py"])

--- a/tests/unit/bokeh/command/subcommands/test_info.py
+++ b/tests/unit/bokeh/command/subcommands/test_info.py
@@ -35,20 +35,20 @@ import bokeh.command.subcommands.info as scinfo # isort:skip
 # Dev API
 #-----------------------------------------------------------------------------
 
-def test_create():
+def test_create() -> None:
     import argparse
     from bokeh.command.subcommand import Subcommand
 
     obj = scinfo.Info(parser=argparse.ArgumentParser())
     assert isinstance(obj, Subcommand)
 
-def test_name():
+def test_name() -> None:
     assert scinfo.Info.name == "info"
 
-def test_help():
+def test_help() -> None:
     assert scinfo.Info.help == "Print information about Bokeh and Bokeh server configuration"
 
-def test_args():
+def test_args() -> None:
     assert scinfo.Info.args == (
         ('--static', dict(
             action='store_true',
@@ -56,7 +56,7 @@ def test_args():
         )),
     )
 
-def test_run(capsys):
+def test_run(capsys) -> None:
     main(["bokeh", "info"])
     out, err = capsys.readouterr()
     lines = out.split("\n")
@@ -71,13 +71,13 @@ def test_run(capsys):
     assert lines[7] == ""
     assert err == ""
 
-def test_run_static(capsys):
+def test_run_static(capsys) -> None:
     main(["bokeh", "info", "--static"])
     out, err = capsys.readouterr()
     assert err == ""
     assert out.endswith(join('bokeh', 'server', 'static') + '\n')
 
-def test__version_missing(ipython):
+def test__version_missing(ipython) -> None:
     assert scinfo._version('bokeh', '__version__') is not None
     assert scinfo._version('IPython', '__version__') is not None
     assert scinfo._version('tornado', 'version') is not None

--- a/tests/unit/bokeh/command/subcommands/test_json__subcommands.py
+++ b/tests/unit/bokeh/command/subcommands/test_json__subcommands.py
@@ -39,20 +39,20 @@ import bokeh.command.subcommands.json as scjson # isort:skip
 # Dev API
 #-----------------------------------------------------------------------------
 
-def test_create():
+def test_create() -> None:
     import argparse
     from bokeh.command.subcommand import Subcommand
 
     obj = scjson.JSON(parser=argparse.ArgumentParser())
     assert isinstance(obj, Subcommand)
 
-def test_name():
+def test_name() -> None:
     assert scjson.JSON.name == "json"
 
-def test_help():
+def test_help() -> None:
     assert scjson.JSON.help == "Create JSON files for one or more applications"
 
-def test_args():
+def test_args() -> None:
     assert scjson.JSON.args == (
 
         ('files', dict(
@@ -84,7 +84,7 @@ def test_args():
 
     )
 
-def test_no_script(capsys):
+def test_no_script(capsys) -> None:
     with (TmpDir(prefix="bokeh-json-no-script")) as dirname:
         with WorkingDir(dirname):
             with pytest.raises(SystemExit):
@@ -97,7 +97,7 @@ bokeh json: error: %s
 """ % (too_few)
         assert out == ""
 
-def test_basic_script(capsys):
+def test_basic_script(capsys) -> None:
     def run(dirname):
         with WorkingDir(dirname):
             main(["bokeh", "json", "scatter.py"])
@@ -110,7 +110,7 @@ def test_basic_script(capsys):
     with_directory_contents({ 'scatter.py' : basic_scatter_script },
                             run)
 
-def test_basic_script_with_output_after(capsys):
+def test_basic_script_with_output_after(capsys) -> None:
     def run(dirname):
         with WorkingDir(dirname):
             main(["bokeh", "json", "scatter.py", "--output", "foo.json"])
@@ -123,7 +123,7 @@ def test_basic_script_with_output_after(capsys):
     with_directory_contents({ 'scatter.py' : basic_scatter_script },
                             run)
 
-def test_basic_script_with_output_before(capsys):
+def test_basic_script_with_output_before(capsys) -> None:
     def run(dirname):
         with WorkingDir(dirname):
             main(["bokeh", "json", "--output", "foo.json", "scatter.py"])

--- a/tests/unit/bokeh/command/subcommands/test_png.py
+++ b/tests/unit/bokeh/command/subcommands/test_png.py
@@ -37,20 +37,20 @@ from bokeh.command.bootstrap import main
 # Dev API
 #-----------------------------------------------------------------------------
 
-def test_create():
+def test_create() -> None:
     import argparse
     from bokeh.command.subcommand import Subcommand
 
     obj = scpng.PNG(parser=argparse.ArgumentParser())
     assert isinstance(obj, Subcommand)
 
-def test_name():
+def test_name() -> None:
     assert scpng.PNG.name == "png"
 
-def test_help():
+def test_help() -> None:
     assert scpng.PNG.help == "Create standalone PNG files for one or more applications"
 
-def test_args():
+def test_args() -> None:
     assert scpng.PNG.args == (
 
         ('files', dict(
@@ -90,7 +90,7 @@ def test_args():
 
     )
 
-def test_no_script(capsys):
+def test_no_script(capsys) -> None:
     with (TmpDir(prefix="bokeh-png-no-script")) as dirname:
         with WorkingDir(dirname):
             with pytest.raises(SystemExit):
@@ -106,7 +106,7 @@ bokeh png: error: %s
 
 @pytest.mark.unit
 @pytest.mark.selenium
-def test_basic_script(capsys):
+def test_basic_script(capsys) -> None:
     def run(dirname):
         with WorkingDir(dirname):
             main(["bokeh", "png", "scatter.py"])
@@ -120,7 +120,7 @@ def test_basic_script(capsys):
 
 @pytest.mark.unit
 @pytest.mark.selenium
-def test_basic_script_with_output_after(capsys):
+def test_basic_script_with_output_after(capsys) -> None:
     def run(dirname):
         with WorkingDir(dirname):
             main(["bokeh", "png", "scatter.py", "--output", "foo.png"])
@@ -134,7 +134,7 @@ def test_basic_script_with_output_after(capsys):
 
 @pytest.mark.unit
 @pytest.mark.selenium
-def test_basic_script_with_output_before(capsys):
+def test_basic_script_with_output_before(capsys) -> None:
     def run(dirname):
         with WorkingDir(dirname):
             main(["bokeh", "png", "--output", "foo.png", "scatter.py"])
@@ -148,7 +148,7 @@ def test_basic_script_with_output_before(capsys):
 
 @pytest.mark.unit
 @pytest.mark.selenium
-def test_basic_script_with_output_stdout(capsysbinary):
+def test_basic_script_with_output_stdout(capsysbinary) -> None:
     def run(dirname):
         with WorkingDir(dirname):
             main(["bokeh", "png", "--output", "-", "scatter.py"])
@@ -163,7 +163,7 @@ def test_basic_script_with_output_stdout(capsysbinary):
 
 @pytest.mark.unit
 @pytest.mark.selenium
-def test_basic_script_with_multiple_png_plots(capsys):
+def test_basic_script_with_multiple_png_plots(capsys) -> None:
     def run(dirname):
         with WorkingDir(dirname):
             main(["bokeh", "png", "scatter1.py", "scatter2.py", "scatter3.py"])

--- a/tests/unit/bokeh/command/subcommands/test_sampledata__subcommands.py
+++ b/tests/unit/bokeh/command/subcommands/test_sampledata__subcommands.py
@@ -34,24 +34,24 @@ did_call_download = False
 # Dev API
 #-----------------------------------------------------------------------------
 
-def test_create():
+def test_create() -> None:
     import argparse
     from bokeh.command.subcommand import Subcommand
 
     obj = scsample.Sampledata(parser=argparse.ArgumentParser())
     assert isinstance(obj, Subcommand)
 
-def test_name():
+def test_name() -> None:
     assert scsample.Sampledata.name == "sampledata"
 
-def test_help():
+def test_help() -> None:
     assert scsample.Sampledata.help == "Download the bokeh sample data sets"
 
-def test_args():
+def test_args() -> None:
     assert scsample.Sampledata.args == (
     )
 
-def test_run(capsys):
+def test_run(capsys) -> None:
     main(["bokeh", "sampledata"])
     assert did_call_download == True
 

--- a/tests/unit/bokeh/command/subcommands/test_secret.py
+++ b/tests/unit/bokeh/command/subcommands/test_secret.py
@@ -32,24 +32,24 @@ import bokeh.command.subcommands.secret as scsecret # isort:skip
 # Dev API
 #-----------------------------------------------------------------------------
 
-def test_create():
+def test_create() -> None:
     import argparse
     from bokeh.command.subcommand import Subcommand
 
     obj = scsecret.Secret(parser=argparse.ArgumentParser())
     assert isinstance(obj, Subcommand)
 
-def test_name():
+def test_name() -> None:
     assert scsecret.Secret.name == "secret"
 
-def test_help():
+def test_help() -> None:
     assert scsecret.Secret.help == "Create a Bokeh secret key for use with Bokeh server"
 
-def test_args():
+def test_args() -> None:
     assert scsecret.Secret.args == (
     )
 
-def test_run(capsys):
+def test_run(capsys) -> None:
     main(["bokeh", "secret"])
     out, err = capsys.readouterr()
     assert err == ""

--- a/tests/unit/bokeh/command/subcommands/test_serve.py
+++ b/tests/unit/bokeh/command/subcommands/test_serve.py
@@ -44,23 +44,23 @@ from bokeh.resources import DEFAULT_SERVER_PORT
 # Dev API
 #-----------------------------------------------------------------------------
 
-def test_create():
+def test_create() -> None:
     import argparse
     from bokeh.command.subcommand import Subcommand
 
     obj = scserve.Serve(parser=argparse.ArgumentParser())
     assert isinstance(obj, Subcommand)
 
-def test_loglevels():
+def test_loglevels() -> None:
     assert scserve.LOGLEVELS == ('trace', 'debug', 'info', 'warning', 'error', 'critical')
 
-def test_name():
+def test_name() -> None:
     assert scserve.Serve.name == "serve"
 
-def test_help():
+def test_help() -> None:
     assert scserve.Serve.help == "Run a Bokeh server hosting one or more applications"
 
-def test_args():
+def test_args() -> None:
     from bokeh.util.string import nice_join
 
     assert scserve.Serve.args == (
@@ -318,13 +318,13 @@ def check_error(args):
         pytest.fail("command %s unexpected successful" % (cmd,))
     return out
 
-def test_host_not_available():
+def test_host_not_available() -> None:
     host = "8.8.8.8"
     out = check_error(["--address", host])
     expected = "Cannot start Bokeh server, address %r not available" % host
     assert expected in out
 
-def test_port_not_available():
+def test_port_not_available() -> None:
     sock = socket.socket()
     try:
         sock.bind(('0.0.0.0', 0))
@@ -335,7 +335,7 @@ def test_port_not_available():
     finally:
         sock.close()
 
-def test_no_glob_by_default_on_filename_if_wildcard_in_quotes():
+def test_no_glob_by_default_on_filename_if_wildcard_in_quotes() -> None:
     import os.path
 
     here = os.path.abspath(os.path.dirname(__file__))
@@ -346,7 +346,7 @@ def test_no_glob_by_default_on_filename_if_wildcard_in_quotes():
     assert '*' in out
 
 @pytest.mark.skipif(sys.platform == 'win32', reason="no fcntl on windows")
-def test_glob_flag_on_filename_if_wildcard_in_quotes():
+def test_glob_flag_on_filename_if_wildcard_in_quotes() -> None:
     from fcntl import fcntl, F_GETFL, F_SETFL
     from os import O_NONBLOCK, read
     import os.path
@@ -370,7 +370,7 @@ def test_glob_flag_on_filename_if_wildcard_in_quotes():
         assert r.status_code == 200
 
 @pytest.mark.skipif(sys.platform == 'win32', reason="no fcntl on windows")
-def test_actual_port_printed_out():
+def test_actual_port_printed_out() -> None:
     from fcntl import fcntl, F_GETFL, F_SETFL
     from os import O_NONBLOCK, read
     pat = re.compile(r'Bokeh app running at: http://localhost:(\d+)')
@@ -389,7 +389,7 @@ def test_actual_port_printed_out():
         assert r.status_code == 200
 
 @pytest.mark.skip
-def test_websocket_max_message_size_printed_out():
+def test_websocket_max_message_size_printed_out() -> None:
     pat = re.compile(r'Torndado websocket_max_message_size set to 12345')
     with run_bokeh_serve(["--websocket-max-message-size", "12345"]) as p:
         sleep(2)
@@ -399,7 +399,7 @@ def test_websocket_max_message_size_printed_out():
         pytest.fail("no matching log line in process output")
 
 @pytest.mark.skipif(sys.platform == 'win32', reason="no fcntl on windows")
-def test_xsrf_printed_option():
+def test_xsrf_printed_option() -> None:
     from fcntl import fcntl, F_GETFL, F_SETFL
     from os import O_NONBLOCK, read
     pat = re.compile(r'XSRF cookie protection enabled')
@@ -414,7 +414,7 @@ def test_xsrf_printed_option():
         pytest.fail("no matching log line in process output")
 
 @pytest.mark.skipif(sys.platform == 'win32', reason="no fcntl on windows")
-def test_xsrf_printed_envar():
+def test_xsrf_printed_envar() -> None:
     from fcntl import fcntl, F_GETFL, F_SETFL
     from os import O_NONBLOCK, read
     pat = re.compile(r'XSRF cookie protection enabled')
@@ -431,7 +431,7 @@ def test_xsrf_printed_envar():
     os.environ["BOKEH_XSRF_COOKIES"]
 
 @pytest.mark.skipif(sys.platform == 'win32', reason="no fcntl on windows")
-def test_auth_module_printed():
+def test_auth_module_printed() -> None:
     from fcntl import fcntl, F_GETFL, F_SETFL
     from os import O_NONBLOCK, read
     pat = re.compile(r'User authentication hooks provided \(no default user\)')

--- a/tests/unit/bokeh/command/subcommands/test_svg.py
+++ b/tests/unit/bokeh/command/subcommands/test_svg.py
@@ -39,20 +39,20 @@ import bokeh.command.subcommands.svg as scsvg # isort:skip
 # Dev API
 #-----------------------------------------------------------------------------
 
-def test_create():
+def test_create() -> None:
     import argparse
     from bokeh.command.subcommand import Subcommand
 
     obj = scsvg.SVG(parser=argparse.ArgumentParser())
     assert isinstance(obj, Subcommand)
 
-def test_name():
+def test_name() -> None:
     assert scsvg.SVG.name == "svg"
 
-def test_help():
+def test_help() -> None:
     assert scsvg.SVG.help == "Create standalone SVG files for one or more applications"
 
-def test_args():
+def test_args() -> None:
     assert scsvg.SVG.args == (
 
         ('files', dict(
@@ -91,7 +91,7 @@ def test_args():
 
     )
 
-def test_no_script(capsys):
+def test_no_script(capsys) -> None:
     with (TmpDir(prefix="bokeh-svg-no-script")) as dirname:
         with WorkingDir(dirname):
             with pytest.raises(SystemExit):
@@ -107,7 +107,7 @@ bokeh svg: error: %s
 
 @pytest.mark.unit
 @pytest.mark.selenium
-def test_basic_script(capsys):
+def test_basic_script(capsys) -> None:
     def run(dirname):
         with WorkingDir(dirname):
             main(["bokeh", "svg", "scatter.py"])
@@ -121,7 +121,7 @@ def test_basic_script(capsys):
 
 @pytest.mark.unit
 @pytest.mark.selenium
-def test_basic_script_with_output_after(capsys):
+def test_basic_script_with_output_after(capsys) -> None:
     def run(dirname):
         with WorkingDir(dirname):
             main(["bokeh", "svg", "scatter.py", "--output", "foo.svg"])
@@ -135,7 +135,7 @@ def test_basic_script_with_output_after(capsys):
 
 @pytest.mark.unit
 @pytest.mark.selenium
-def test_basic_script_with_output_before(capsys):
+def test_basic_script_with_output_before(capsys) -> None:
     def run(dirname):
         with WorkingDir(dirname):
             main(["bokeh", "svg", "--output", "foo.svg", "scatter.py"])
@@ -149,7 +149,7 @@ def test_basic_script_with_output_before(capsys):
 
 @pytest.mark.unit
 @pytest.mark.selenium
-def test_basic_script_with_output_stdout(capsys):
+def test_basic_script_with_output_stdout(capsys) -> None:
     def run(dirname):
         with WorkingDir(dirname):
             main(["bokeh", "svg", "--output", "-", "scatter.py"])
@@ -164,7 +164,7 @@ def test_basic_script_with_output_stdout(capsys):
 
 @pytest.mark.unit
 @pytest.mark.selenium
-def test_multiple_svg_scripts(capsys):
+def test_multiple_svg_scripts(capsys) -> None:
     def run(dirname):
         with WorkingDir(dirname):
             main(["bokeh", "svg", "scatter1.py", "scatter2.py", "scatter3.py"])
@@ -181,7 +181,7 @@ def test_multiple_svg_scripts(capsys):
 
 @pytest.mark.unit
 @pytest.mark.selenium
-def test_basic_script_with_multiple_svg_plots(capsys):
+def test_basic_script_with_multiple_svg_plots(capsys) -> None:
     def run(dirname):
         with WorkingDir(dirname):
             main(["bokeh", "svg", "scatter.py"])

--- a/tests/unit/bokeh/command/test___init___command.py
+++ b/tests/unit/bokeh/command/test___init___command.py
@@ -29,7 +29,7 @@ import bokeh.command as command # isort:skip
 # Dev API
 #-----------------------------------------------------------------------------
 
-def test_doc():
+def test_doc() -> None:
     import bokeh.command.subcommands as sc
     assert len(command.__doc__.split("\n")) == 5 + 3*len(sc.all)
     for x in sc.all:

--- a/tests/unit/bokeh/command/test_bootstrap.py
+++ b/tests/unit/bokeh/command/test_bootstrap.py
@@ -43,24 +43,24 @@ def _assert_version_output(capsys):
 # Dev API
 #-----------------------------------------------------------------------------
 
-def test_no_subcommand(capsys):
+def test_no_subcommand(capsys) -> None:
     with pytest.raises(SystemExit):
         main(["bokeh"])
     out, err = capsys.readouterr()
     assert err == "ERROR: Must specify subcommand, one of: build, html, info, init, json, png, sampledata, secret, serve, static or svg\n"
     assert out == ""
 
-def test_version(capsys):
+def test_version(capsys) -> None:
     with pytest.raises(SystemExit):
         main(["bokeh", "--version"])
     _assert_version_output(capsys)
 
-def test_version_short(capsys):
+def test_version_short(capsys) -> None:
     with pytest.raises(SystemExit):
         main(["bokeh", "-v"])
     _assert_version_output(capsys)
 
-def test_error(capsys):
+def test_error(capsys) -> None:
     from bokeh.command.subcommands.info import Info
     old_invoke = Info.invoke
     def err(x, y): raise RuntimeError("foo")

--- a/tests/unit/bokeh/command/test_subcommand.py
+++ b/tests/unit/bokeh/command/test_subcommand.py
@@ -36,34 +36,34 @@ class _Good(sc.Subcommand):
 # Dev API
 #-----------------------------------------------------------------------------
 
-def test_is_abstract():
+def test_is_abstract() -> None:
     with pytest.raises(TypeError):
         _Bad()
 
-def test_missing_args():
+def test_missing_args() -> None:
     p = MagicMock()
     _Good(p)
     p.add_argument.assert_not_called()
 
-def test_no_args():
+def test_no_args() -> None:
     _Good.args = ()
     p = MagicMock()
     _Good(p)
     p.add_argument.assert_not_called()
 
-def test_one_arg():
+def test_one_arg() -> None:
     _Good.args = (('foo', dict(a=1, b=2)),)
     p = MagicMock()
     _Good(p)
     p.add_argument.assert_called_once_with('foo', **dict(a=1, b=2))
 
-def test_args():
+def test_args() -> None:
     _Good.args = (('foo', dict(a=1, b=2)),('bar', dict(a=3, b=4)))
     p = MagicMock()
     _Good(p)
     p.call_count == 2
 
-def test_base_invoke():
+def test_base_invoke() -> None:
     with pytest.raises(NotImplementedError):
         p = MagicMock()
         obj = _Good(p)

--- a/tests/unit/bokeh/command/test_util__command.py
+++ b/tests/unit/bokeh/command/test_util__command.py
@@ -41,20 +41,20 @@ import bokeh.command.util as util # isort:skip
 # Dev API
 #-----------------------------------------------------------------------------
 
-def test_die(capsys):
+def test_die(capsys) -> None:
     with pytest.raises(SystemExit):
         util.die("foo")
     out, err = capsys.readouterr()
     assert err == "foo\n"
     assert out == ""
 
-def test_build_single_handler_application_unknown_file():
+def test_build_single_handler_application_unknown_file() -> None:
     with pytest.raises(ValueError) as e:
         f = tempfile.NamedTemporaryFile(suffix=".bad")
         util.build_single_handler_application(f.name)
     assert "Expected a '.py' script or '.ipynb' notebook, got: " in str(e.value)
 
-def test_build_single_handler_application_nonexistent_file():
+def test_build_single_handler_application_nonexistent_file() -> None:
     with pytest.raises(ValueError) as e:
         util.build_single_handler_application("junkjunkjunk")
     assert "Path for Bokeh server application does not exist: " in str(e.value)
@@ -70,7 +70,7 @@ If this is not the case, renaming main.py will suppress this warning.
 """
 
 @patch('warnings.warn')
-def test_build_single_handler_application_main_py(mock_warn):
+def test_build_single_handler_application_main_py(mock_warn) -> None:
     f = tempfile.NamedTemporaryFile(suffix="main.py", delete=False)
     f.close() #close file to open it later on windows
     util.build_single_handler_application(f.name)
@@ -81,7 +81,7 @@ def test_build_single_handler_application_main_py(mock_warn):
 _SIZE_WARNING = "Width/height arguments will be ignored for this muliple layout. (Size valus only apply when exporting single plots.)"
 
 class Test_set_single_plot_width_height(object):
-    def test_neither(self):
+    def test_neither(self) -> None:
         p = figure(plot_width=200, plot_height=300)
         d = Document()
         d.add_root(p)
@@ -89,7 +89,7 @@ class Test_set_single_plot_width_height(object):
         assert p.plot_width == 200
         assert p.plot_height == 300
 
-    def test_width(self):
+    def test_width(self) -> None:
         p = figure(plot_width=200, plot_height=300)
         d = Document()
         d.add_root(p)
@@ -97,7 +97,7 @@ class Test_set_single_plot_width_height(object):
         assert p.plot_width == 400
         assert p.plot_height == 300
 
-    def test_height(self):
+    def test_height(self) -> None:
         p = figure(plot_width=200, plot_height=300)
         d = Document()
         d.add_root(p)
@@ -105,7 +105,7 @@ class Test_set_single_plot_width_height(object):
         assert p.plot_width == 200
         assert p.plot_height == 400
 
-    def test_both(self):
+    def test_both(self) -> None:
         p = figure(plot_width=200, plot_height=300)
         d = Document()
         d.add_root(p)
@@ -113,7 +113,7 @@ class Test_set_single_plot_width_height(object):
         assert p.plot_width == 400
         assert p.plot_height == 500
 
-    def test_multiple_roots(self):
+    def test_multiple_roots(self) -> None:
         p1 = figure(plot_width=200, plot_height=300)
         p2 = figure(plot_width=200, plot_height=300)
         d = Document()
@@ -124,7 +124,7 @@ class Test_set_single_plot_width_height(object):
             assert len(warns) == 1
             assert warns[0].message.args[0] == _SIZE_WARNING
 
-    def test_layout(self):
+    def test_layout(self) -> None:
         p = figure(plot_width=200, plot_height=300)
         d = Document()
         d.add_root(row(p))

--- a/tests/unit/bokeh/core/property/test_any.py
+++ b/tests/unit/bokeh/core/property/test_any.py
@@ -36,7 +36,7 @@ ALL = (
 
 class Test_Any(object):
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpa.Any()
         assert prop.is_valid(None)
         assert prop.is_valid(False)
@@ -53,16 +53,16 @@ class Test_Any(object):
         assert prop.is_valid(_TestHasProps())
         assert prop.is_valid(_TestModel())
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         pass
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpa.Any()
         assert not prop.has_ref
 
 class Test_AnyRef(object):
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpa.AnyRef()
         assert prop.is_valid(None)
         assert prop.is_valid(False)
@@ -79,10 +79,10 @@ class Test_AnyRef(object):
         assert prop.is_valid(_TestHasProps())
         assert prop.is_valid(_TestModel())
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         pass
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpa.AnyRef()
         assert prop.has_ref
 

--- a/tests/unit/bokeh/core/property/test_auto.py
+++ b/tests/unit/bokeh/core/property/test_auto.py
@@ -35,12 +35,12 @@ ALL = (
 
 class Test_Auto(object):
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpa.Auto()
         assert prop.is_valid(None)
         assert prop.is_valid("auto")
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpa.Auto()
         assert not prop.is_valid(False)
         assert not prop.is_valid(True)
@@ -56,11 +56,11 @@ class Test_Auto(object):
         assert not prop.is_valid(_TestHasProps())
         assert not prop.is_valid(_TestModel())
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpa.Auto()
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpa.Auto()
         assert str(prop) == "Auto"
 

--- a/tests/unit/bokeh/core/property/test_bases.py
+++ b/tests/unit/bokeh/core/property/test_bases.py
@@ -44,13 +44,13 @@ ALL = (
 class TestProperty(object):
 
     @patch('bokeh.core.property.bases.Property.validate')
-    def test_is_valid_supresses_validation_detail(self, mock_validate):
+    def test_is_valid_supresses_validation_detail(self, mock_validate) -> None:
         p = bcpb.Property()
         p.is_valid(None)
         assert mock_validate.called
         assert mock_validate.call_args[0] == (None, False)
 
-    def test_serialized_default(self):
+    def test_serialized_default(self) -> None:
         p = bcpb.Property()
         assert p.serialized == True
         assert p.readonly == False
@@ -66,7 +66,7 @@ class TestProperty(object):
         assert p.readonly == True
 
 
-    def test_assert_bools(self):
+    def test_assert_bools(self) -> None:
         hp = HasProps()
         p = bcpb.Property()
 
@@ -78,7 +78,7 @@ class TestProperty(object):
                 p.prepare_value(hp, "foo", 10)
                 assert str(e) == "false"
 
-    def test_assert_functions(self):
+    def test_assert_functions(self) -> None:
         hp = HasProps()
         p = bcpb.Property()
 
@@ -92,7 +92,7 @@ class TestProperty(object):
                 p.prepare_value(hp, "foo", 10)
                 assert str(e) == "false"
 
-    def test_assert_msg_funcs(self):
+    def test_assert_msg_funcs(self) -> None:
         hp = HasProps()
         p = bcpb.Property()
 
@@ -105,7 +105,7 @@ class TestProperty(object):
                 p.prepare_value(hp, "foo", 10)
                 assert str(e) == "bad True name, 10"
 
-    def test_matches_basic_types(self, capsys):
+    def test_matches_basic_types(self, capsys) -> None:
         p = bcpb.Property()
         for x in [1, 1.2, "a", np.arange(4), None, False, True, {}, []]:
                 assert p.matches(x, x) is True
@@ -113,7 +113,7 @@ class TestProperty(object):
         out, err = capsys.readouterr()
         assert err == ""
 
-    def test_matches_compatible_arrays(self, capsys):
+    def test_matches_compatible_arrays(self, capsys) -> None:
         p = bcpb.Property()
         a = np.arange(5)
         b = np.arange(5)
@@ -125,7 +125,7 @@ class TestProperty(object):
         out, err = capsys.readouterr()
         assert err == ""
 
-    def test_matches_incompatible_arrays(self, capsys):
+    def test_matches_incompatible_arrays(self, capsys) -> None:
         p = bcpb.Property()
         a = np.arange(5)
         b = np.arange(5).astype(str)
@@ -134,7 +134,7 @@ class TestProperty(object):
         # no way to suppress FutureWarning in this case
         # assert err == ""
 
-    def test_matches_dicts_with_array_values(self, capsys):
+    def test_matches_dicts_with_array_values(self, capsys) -> None:
         p = bcpb.Property()
         d1 = dict(foo=np.arange(10))
         d2 = dict(foo=np.arange(10))
@@ -151,7 +151,7 @@ class TestProperty(object):
         out, err = capsys.readouterr()
         assert err == ""
 
-    def test_matches_non_dict_containers_with_array_false(self, capsys):
+    def test_matches_non_dict_containers_with_array_false(self, capsys) -> None:
         p = bcpb.Property()
         d1 = [np.arange(10)]
         d2 = [np.arange(10)]
@@ -166,7 +166,7 @@ class TestProperty(object):
         out, err = capsys.readouterr()
         assert err == ""
 
-    def test_matches_dicts_with_series_values(self, capsys, pd):
+    def test_matches_dicts_with_series_values(self, capsys, pd) -> None:
         p = bcpb.Property()
         d1 = pd.DataFrame(dict(foo=np.arange(10)))
         d2 = pd.DataFrame(dict(foo=np.arange(10)))
@@ -183,7 +183,7 @@ class TestProperty(object):
         out, err = capsys.readouterr()
         assert err == ""
 
-    def test_matches_dicts_with_index_values(self, capsys, pd):
+    def test_matches_dicts_with_index_values(self, capsys, pd) -> None:
         p = bcpb.Property()
         d1 = pd.DataFrame(dict(foo=np.arange(10)))
         d2 = pd.DataFrame(dict(foo=np.arange(10)))
@@ -200,7 +200,7 @@ class TestProperty(object):
         out, err = capsys.readouterr()
         assert err == ""
 
-    def test_validation_on(self):
+    def test_validation_on(self) -> None:
         assert bcpb.Property._should_validate == True
         assert bcpb.validation_on()
 

--- a/tests/unit/bokeh/core/property/test_color__property.py
+++ b/tests/unit/bokeh/core/property/test_color__property.py
@@ -39,7 +39,7 @@ ALL = (
 
 class Test_Color(object):
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpc.Color()
         assert prop.is_valid(None)
 
@@ -59,7 +59,7 @@ class Test_Color(object):
 
         assert prop.is_valid(RGB(10, 20, 30))
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpc.Color()
         assert not prop.is_valid(False)
         assert not prop.is_valid(True)
@@ -104,28 +104,28 @@ class Test_Color(object):
 
         assert not prop.is_valid("foobar")
 
-    def test_transform(self):
+    def test_transform(self) -> None:
         prop = bcpc.Color()
         assert prop.transform((0, 127, 255)) == "rgb(0, 127, 255)"
         assert prop.transform((0, 127, 255, 0.1)) == "rgba(0, 127, 255, 0.1)"
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpc.Color()
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpc.Color()
         assert str(prop) == "Color"
 
 
 class Test_RGB(object):
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpc.RGB()
         assert prop.is_valid(None)
         assert prop.is_valid(RGB(10, 20, 30))
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpc.RGB()
         assert not prop.is_valid(False)
         assert not prop.is_valid(True)
@@ -162,18 +162,18 @@ class Test_RGB(object):
 
         assert not prop.is_valid("foobar")
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpc.RGB()
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpc.RGB()
         assert str(prop) == "RGB"
 
 
 class Test_ColorHex(object):
 
-    def test_transform(self):
+    def test_transform(self) -> None:
         prop = bcpc.ColorHex()
         assert prop.transform('#ff0000') == "#ff0000"
         assert prop.transform((255, 0, 0)) == "#ff0000"

--- a/tests/unit/bokeh/core/property/test_container.py
+++ b/tests/unit/bokeh/core/property/test_container.py
@@ -48,17 +48,17 @@ ALL = (
 
 class Test_Array(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         with pytest.raises(TypeError):
             bcpc.Array()
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpc.Array(Float)
 
         assert prop.is_valid(None)
         assert prop.is_valid(np.array([1,2,3]))
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpc.Array(Float)
 
         assert not prop.is_valid(False)
@@ -77,28 +77,28 @@ class Test_Array(object):
         assert not prop.is_valid(_TestHasProps())
         assert not prop.is_valid(_TestModel())
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpc.Array(Float)
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpc.Array(Float)
         assert str(prop) == "Array(Float)"
 
 class Test_Dict(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         with pytest.raises(TypeError):
             bcpc.Dict()
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpc.Dict(String, bcpc.List(Int))
 
         assert prop.is_valid(None)
         assert prop.is_valid({})
         assert prop.is_valid({"foo": [1,2,3]})
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpc.Dict(String, bcpc.List(Int))
 
         assert not prop.is_valid(False)
@@ -119,31 +119,31 @@ class Test_Dict(object):
         assert not prop.is_valid(_TestHasProps())
         assert not prop.is_valid(_TestModel())
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpc.Dict(String, Int)
         assert not prop.has_ref
 
         prop = bcpc.Dict(String, Instance(_TestModel))
         assert prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpc.Dict(String, Int)
         assert str(prop) == "Dict(String, Int)"
 
 class Test_List(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         with pytest.raises(TypeError):
             bcpc.List()
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpc.List(Int)
 
         assert prop.is_valid(None)
         assert prop.is_valid([])
         assert prop.is_valid([1,2,3])
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpc.List(Int)
 
         assert not prop.is_valid(False)
@@ -164,24 +164,24 @@ class Test_List(object):
         assert not prop.is_valid(_TestHasProps())
         assert not prop.is_valid(_TestModel())
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpc.List(Int)
         assert not prop.has_ref
 
         prop = bcpc.List(Instance(_TestModel))
         assert prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpc.List(Int)
         assert str(prop) == "List(Int)"
 
 class Test_Seq(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         with pytest.raises(TypeError):
             bcpc.Seq()
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpc.Seq(Int)
 
         assert prop.is_valid(None)
@@ -194,7 +194,7 @@ class Test_Seq(object):
         assert prop.is_valid([1, 2])
         assert prop.is_valid(np.array([1, 2]))
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpc.Seq(Int)
 
         assert not prop.is_valid(False)
@@ -215,41 +215,41 @@ class Test_Seq(object):
         assert not prop.is_valid(_TestHasProps())
         assert not prop.is_valid(_TestModel())
 
-    def test_with_pandas_valid(self, pd):
+    def test_with_pandas_valid(self, pd) -> None:
         prop = bcpc.Seq(Int)
 
         df = pd.DataFrame([1, 2])
         assert prop.is_valid(df.index)
         assert prop.is_valid(df.iloc[0])
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpc.Seq(Int)
         assert not prop.has_ref
 
         prop = bcpc.Seq(Instance(_TestModel))
         assert prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpc.Seq(Int)
         assert str(prop) == "Seq(Int)"
 
 class Test_Tuple(object):
 
-    def test_Tuple(self):
+    def test_Tuple(self) -> None:
         with pytest.raises(TypeError):
             bcpc.Tuple()
 
         with pytest.raises(TypeError):
             bcpc.Tuple(Int)
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpc.Tuple(Int, String, bcpc.List(Int))
 
         assert prop.is_valid(None)
 
         assert prop.is_valid((1, "", [1, 2, 3]))
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpc.Tuple(Int, String, bcpc.List(Int))
 
         assert not prop.is_valid(False)
@@ -275,14 +275,14 @@ class Test_Tuple(object):
         assert not prop.is_valid((1, "", (1, 2, 3)))
         assert not prop.is_valid((1, "", [1, 2, "xyz"]))
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpc.Tuple(Int, Int)
         assert not prop.has_ref
 
         prop = bcpc.Tuple(Int, Instance(_TestModel))
         assert prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpc.Tuple(Int, Int)
         assert str(prop) == "Tuple(Int, Int)"
 

--- a/tests/unit/bokeh/core/property/test_dataspec.py
+++ b/tests/unit/bokeh/core/property/test_dataspec.py
@@ -55,7 +55,7 @@ ALL = (
 # General API
 #-----------------------------------------------------------------------------
 
-def test_strict_dataspec_key_values():
+def test_strict_dataspec_key_values() -> None:
     for typ in (bcpd.NumberSpec, bcpd.StringSpec, bcpd.FontSizeSpec, bcpd.ColorSpec, bcpd.DataDistanceSpec, bcpd.ScreenDistanceSpec):
         class Foo(HasProps):
             x = typ("x")
@@ -63,7 +63,7 @@ def test_strict_dataspec_key_values():
         with pytest.raises(ValueError):
             f.x = dict(field="foo", units="junk")
 
-def test_dataspec_dict_to_serializable():
+def test_dataspec_dict_to_serializable() -> None:
     for typ in (bcpd.NumberSpec, bcpd.StringSpec, bcpd.FontSizeSpec, bcpd.ColorSpec):
         class Foo(HasProps):
             x = typ("x")
@@ -74,7 +74,7 @@ def test_dataspec_dict_to_serializable():
 
 class Test_AngleSpec(object):
 
-    def test_default_none(self):
+    def test_default_none(self) -> None:
         class Foo(HasProps):
             x = bcpd.AngleSpec(None)
 
@@ -86,7 +86,7 @@ class Test_AngleSpec(object):
         assert a.x == 14
         assert a.x_units == 'rad'
 
-    def test_autocreate_no_parens(self):
+    def test_autocreate_no_parens(self) -> None:
         class Foo(HasProps):
             x = bcpd.AngleSpec
 
@@ -98,7 +98,7 @@ class Test_AngleSpec(object):
         assert a.x == 14
         assert a.x_units == 'rad'
 
-    def test_default_value(self):
+    def test_default_value(self) -> None:
         class Foo(HasProps):
             x = bcpd.AngleSpec(default=14)
 
@@ -107,7 +107,7 @@ class Test_AngleSpec(object):
         assert a.x == 14
         assert a.x_units == 'rad'
 
-    def test_setting_dict_sets_units(self):
+    def test_setting_dict_sets_units(self) -> None:
         class Foo(HasProps):
             x = bcpd.AngleSpec(default=14)
 
@@ -120,7 +120,7 @@ class Test_AngleSpec(object):
         assert a.x == { 'value' : 180 }
         assert a.x_units == 'deg'
 
-    def test_setting_json_sets_units_keeps_dictness(self):
+    def test_setting_json_sets_units_keeps_dictness(self) -> None:
         class Foo(HasProps):
             x = bcpd.AngleSpec(default=14)
 
@@ -133,7 +133,7 @@ class Test_AngleSpec(object):
         assert a.x == 180
         assert a.x_units == 'deg'
 
-    def test_setting_dict_does_not_modify_original_dict(self):
+    def test_setting_dict_does_not_modify_original_dict(self) -> None:
         class Foo(HasProps):
             x = bcpd.AngleSpec(default=14)
 
@@ -154,7 +154,7 @@ class Test_AngleSpec(object):
 
 class Test_ColorSpec(object):
 
-    def test_field(self):
+    def test_field(self) -> None:
         class Foo(HasProps):
             col = bcpd.ColorSpec("colorfield")
         desc = Foo.__dict__["col"]
@@ -165,7 +165,7 @@ class Test_ColorSpec(object):
         assert f.col == "myfield"
         assert desc.serializable_value(f) == {"field": "myfield"}
 
-    def test_field_default(self):
+    def test_field_default(self) -> None:
         class Foo(HasProps):
             col = bcpd.ColorSpec(default="red")
         desc = Foo.__dict__["col"]
@@ -176,7 +176,7 @@ class Test_ColorSpec(object):
         assert f.col == "myfield"
         assert desc.serializable_value(f) == {"field": "myfield"}
 
-    def test_default_tuple(self):
+    def test_default_tuple(self) -> None:
         class Foo(HasProps):
             col = bcpd.ColorSpec(default=(128, 255, 124))
         desc = Foo.__dict__["col"]
@@ -184,7 +184,7 @@ class Test_ColorSpec(object):
         assert f.col == (128, 255, 124)
         assert desc.serializable_value(f) == {"value": "rgb(128, 255, 124)"}
 
-    def test_fixed_value(self):
+    def test_fixed_value(self) -> None:
         class Foo(HasProps):
             col = bcpd.ColorSpec("gray")
         desc = Foo.__dict__["col"]
@@ -192,7 +192,7 @@ class Test_ColorSpec(object):
         assert f.col == "gray"
         assert desc.serializable_value(f) == {"value": "gray"}
 
-    def test_named_value(self):
+    def test_named_value(self) -> None:
         class Foo(HasProps):
             col = bcpd.ColorSpec("colorfield")
         desc = Foo.__dict__["col"]
@@ -205,7 +205,7 @@ class Test_ColorSpec(object):
         assert f.col == "forestgreen"
         assert desc.serializable_value(f) == {"value": "forestgreen"}
 
-    def test_case_insensitive_named_value(self):
+    def test_case_insensitive_named_value(self) -> None:
         class Foo(HasProps):
             col = bcpd.ColorSpec("colorfield")
         desc = Foo.__dict__["col"]
@@ -218,7 +218,7 @@ class Test_ColorSpec(object):
         assert f.col == "ForestGreen"
         assert desc.serializable_value(f) == {"value": "ForestGreen"}
 
-    def test_named_value_set_none(self):
+    def test_named_value_set_none(self) -> None:
         class Foo(HasProps):
             col = bcpd.ColorSpec("colorfield")
         desc = Foo.__dict__["col"]
@@ -226,14 +226,14 @@ class Test_ColorSpec(object):
         f.col = None
         assert desc.serializable_value(f) == {"value": None}
 
-    def test_named_value_unset(self):
+    def test_named_value_unset(self) -> None:
         class Foo(HasProps):
             col = bcpd.ColorSpec("colorfield")
         desc = Foo.__dict__["col"]
         f = Foo()
         assert desc.serializable_value(f) == {"field": "colorfield"}
 
-    def test_named_color_overriding_default(self):
+    def test_named_color_overriding_default(self) -> None:
         class Foo(HasProps):
             col = bcpd.ColorSpec("colorfield")
         desc = Foo.__dict__["col"]
@@ -245,7 +245,7 @@ class Test_ColorSpec(object):
         assert f.col == "myfield"
         assert desc.serializable_value(f) == {"field": "myfield"}
 
-    def test_hex_value(self):
+    def test_hex_value(self) -> None:
         class Foo(HasProps):
             col = bcpd.ColorSpec("colorfield")
         desc = Foo.__dict__["col"]
@@ -257,7 +257,7 @@ class Test_ColorSpec(object):
         assert f.col == "myfield"
         assert desc.serializable_value(f) == {"field": "myfield"}
 
-    def test_tuple_value(self):
+    def test_tuple_value(self) -> None:
         class Foo(HasProps):
             col = bcpd.ColorSpec("colorfield")
         desc = Foo.__dict__["col"]
@@ -272,7 +272,7 @@ class Test_ColorSpec(object):
         assert f.col == (100, 150, 200, 0.5)
         assert desc.serializable_value(f) == {"value": "rgba(100, 150, 200, 0.5)"}
 
-    def test_set_dict(self):
+    def test_set_dict(self) -> None:
         class Foo(HasProps):
             col = bcpd.ColorSpec("colorfield")
         desc = Foo.__dict__["col"]
@@ -285,7 +285,7 @@ class Test_ColorSpec(object):
         assert desc.serializable_value(f) == {"field": "field2"}
 
 class Test_DataDistanceSpec(object):
-    def test_basic(self):
+    def test_basic(self) -> None:
         assert issubclass(bcpd.DataDistanceSpec, bcpd.UnitsSpec)
         class Foo(HasProps):
             x = bcpd.DataDistanceSpec("x")
@@ -296,7 +296,7 @@ class Test_DataDistanceSpec(object):
         assert props['x'] is not foo.x
 
 class Test_DistanceSpec(object):
-    def test_default_none(self):
+    def test_default_none(self) -> None:
         class Foo(HasProps):
             x = bcpd.DistanceSpec(None)
 
@@ -308,7 +308,7 @@ class Test_DistanceSpec(object):
         assert a.x == 14
         assert a.x_units == 'data'
 
-    def test_autocreate_no_parens(self):
+    def test_autocreate_no_parens(self) -> None:
         class Foo(HasProps):
             x = bcpd.DistanceSpec
 
@@ -320,7 +320,7 @@ class Test_DistanceSpec(object):
         assert a.x == 14
         assert a.x_units == 'data'
 
-    def test_default_value(self):
+    def test_default_value(self) -> None:
         class Foo(HasProps):
             x = bcpd.DistanceSpec(default=14)
 
@@ -329,13 +329,13 @@ class Test_DistanceSpec(object):
         assert a.x == 14
         assert a.x_units == 'data'
 
-def test_field_function():
+def test_field_function() -> None:
     assert bcpd.field("foo") == dict(field="foo")
     assert bcpd.field("foo", "junk") == dict(field="foo", transform="junk")
     assert bcpd.field("foo", transform="junk") == dict(field="foo", transform="junk")
 
 class Test_FontSizeSpec(object):
-    def test_font_size_from_string(self):
+    def test_font_size_from_string(self) -> None:
         class Foo(HasProps):
             x = bcpd.FontSizeSpec(default=None)
 
@@ -387,7 +387,7 @@ class Test_FontSizeSpec(object):
             assert a.x == f
             assert a.lookup('x').serializable_value(a) == dict(field=f)
 
-    def test_bad_font_size_values(self):
+    def test_bad_font_size_values(self) -> None:
         class Foo(HasProps):
             x = bcpd.FontSizeSpec(default=None)
 
@@ -402,7 +402,7 @@ class Test_FontSizeSpec(object):
         with pytest.raises(ValueError):
             a.x = ""
 
-    def test_fields(self):
+    def test_fields(self) -> None:
         class Foo(HasProps):
             x = bcpd.FontSizeSpec(default=None)
 
@@ -422,7 +422,7 @@ class Test_FontSizeSpec(object):
 
 class Test_NumberSpec(object):
 
-    def test_field(self):
+    def test_field(self) -> None:
         class Foo(HasProps):
             x = bcpd.NumberSpec("xfield")
         f = Foo()
@@ -432,7 +432,7 @@ class Test_NumberSpec(object):
         assert f.x == "my_x"
         assert Foo.__dict__["x"].serializable_value(f) == {"field": "my_x"}
 
-    def test_value(self):
+    def test_value(self) -> None:
         class Foo(HasProps):
             x = bcpd.NumberSpec("xfield")
         f = Foo()
@@ -489,7 +489,7 @@ class Test_NumberSpec(object):
         f.ndt = pd.Timedelta("3000ms")
         assert f.ndt == 3000.0
 
-    def test_accepts_datetime(self):
+    def test_accepts_datetime(self) -> None:
         class Foo(HasProps):
             dt = bcpd.NumberSpec("dt", accept_datetime=True)
             ndt = bcpd.NumberSpec("ndt", accept_datetime=False)
@@ -514,7 +514,7 @@ class Test_NumberSpec(object):
         with pytest.raises(ValueError):
             f.ndt = np.datetime64("2016-05-11")
 
-    def test_default(self):
+    def test_default(self) -> None:
         class Foo(HasProps):
             y = bcpd.NumberSpec(default=12)
         f = Foo()
@@ -527,7 +527,7 @@ class Test_NumberSpec(object):
         assert f.y == 32
         assert Foo.__dict__["y"].serializable_value(f) == {"value": 32}
 
-    def test_multiple_instances(self):
+    def test_multiple_instances(self) -> None:
         class Foo(HasProps):
             x = bcpd.NumberSpec("xfield")
 
@@ -543,7 +543,7 @@ class Test_NumberSpec(object):
         assert Foo.__dict__["x"].serializable_value(a) == {"value": 13}
         assert Foo.__dict__["x"].serializable_value(b) == {"field": "x3"}
 
-    def test_autocreate_no_parens(self):
+    def test_autocreate_no_parens(self) -> None:
         class Foo(HasProps):
             x = bcpd.NumberSpec
 
@@ -553,7 +553,7 @@ class Test_NumberSpec(object):
         a.x = 14
         assert a.x == 14
 
-    def test_set_from_json_keeps_mode(self):
+    def test_set_from_json_keeps_mode(self) -> None:
         class Foo(HasProps):
             x = bcpd.NumberSpec(default=None)
 
@@ -583,7 +583,7 @@ class Test_NumberSpec(object):
 
 class Test_UnitSpec(object):
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         assert issubclass(bcpd.ScreenDistanceSpec, bcpd.UnitsSpec)
         class Foo(HasProps):
             x = bcpd.ScreenDistanceSpec("x")
@@ -593,7 +593,7 @@ class Test_UnitSpec(object):
         assert props['x']['field'] == 'foo'
         assert props['x'] is not foo.x
 
-    def test_strict_key_values(self):
+    def test_strict_key_values(self) -> None:
         class FooUnits(HasProps):
             x = bcpd.DistanceSpec("x")
         f = FooUnits()
@@ -607,7 +607,7 @@ class Test_UnitSpec(object):
         with pytest.raises(ValueError):
             f.x = dict(field="foo", units="junk", foo="crap")
 
-def test_value_function():
+def test_value_function() -> None:
     assert bcpd.value("foo") == dict(value="foo")
     assert bcpd.value("foo", "junk") == dict(value="foo", transform="junk")
     assert bcpd.value("foo", transform="junk") == dict(value="foo", transform="junk")

--- a/tests/unit/bokeh/core/property/test_datetime.py
+++ b/tests/unit/bokeh/core/property/test_datetime.py
@@ -44,13 +44,13 @@ ALL = (
 
 class Test_Date(object):
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpd.Date()
         assert prop.is_valid(datetime.date(2020, 1,11))
         assert prop.is_valid("2020-01-10")
         assert prop.is_valid(None)
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpd.Date()
         assert not prop.is_valid(datetime.datetime(2020, 1,11))
         assert not prop.is_valid("")
@@ -63,17 +63,17 @@ class Test_Date(object):
         assert not prop.is_valid(_TestHasProps())
         assert not prop.is_valid(_TestModel())
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpd.Date()
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpd.Date()
         assert str(prop) == "Date"
 
 class Test_Datetime(object):
 
-    def test_valid(self, pd):
+    def test_valid(self, pd) -> None:
         prop = bcpd.Datetime()
         assert prop.is_valid(0)
         assert prop.is_valid(1)
@@ -86,7 +86,7 @@ class Test_Datetime(object):
         if pd:
             assert prop.is_valid(pd.Timestamp("2010-01-11"))
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpd.Datetime()
         assert not prop.is_valid(None)
         assert not prop.is_valid("")
@@ -99,7 +99,7 @@ class Test_Datetime(object):
         assert not prop.is_valid(_TestHasProps())
         assert not prop.is_valid(_TestModel())
 
-    def test_is_timestamp(self):
+    def test_is_timestamp(self) -> None:
         assert bcpd.Datetime.is_timestamp(0)
         assert bcpd.Datetime.is_timestamp(0.0)
         assert bcpd.Datetime.is_timestamp(10)
@@ -110,21 +110,21 @@ class Test_Datetime(object):
         assert not bcpd.Datetime.is_timestamp(True)
         assert not bcpd.Datetime.is_timestamp(False)
 
-    def test_transform_date(self):
+    def test_transform_date(self) -> None:
         t = datetime.date(2020, 1, 11)
         prop = bcpd.Datetime()
         assert prop.transform(t) == convert_date_to_datetime(t)
 
-    def test_transform_str(self):
+    def test_transform_str(self) -> None:
         t = datetime.date(2020, 1, 11)
         prop = bcpd.Datetime()
         assert prop.transform("2020-01-11") == convert_date_to_datetime(t)
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpd.Datetime()
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpd.Datetime()
         assert str(prop) == "Datetime"
 

--- a/tests/unit/bokeh/core/property/test_descriptor_factory.py
+++ b/tests/unit/bokeh/core/property/test_descriptor_factory.py
@@ -39,12 +39,12 @@ ALL = (
 class Child(bcpdf.PropertyDescriptorFactory):
     pass
 
-def test_autocreate():
+def test_autocreate() -> None:
     obj = Child()
     value = obj.autocreate()
     assert isinstance(value, Child)
 
-def test_make_descriptors_not_implemented():
+def test_make_descriptors_not_implemented() -> None:
     obj = bcpdf.PropertyDescriptorFactory()
     with pytest.raises(NotImplementedError):
         obj.make_descriptors("foo")

--- a/tests/unit/bokeh/core/property/test_descriptors.py
+++ b/tests/unit/bokeh/core/property/test_descriptors.py
@@ -48,15 +48,15 @@ ALL = (
 
 class Test_PropertyDescriptor(object):
 
-    def test___init__(self):
+    def test___init__(self) -> None:
         d = bcpd.PropertyDescriptor("foo")
         assert d.name == "foo"
 
-    def test___str__(self):
+    def test___str__(self) -> None:
         d = bcpd.PropertyDescriptor("foo")
         assert str(d) == "PropertyDescriptor(foo)"
 
-    def test_abstract(self):
+    def test_abstract(self) -> None:
         d = bcpd.PropertyDescriptor("foo")
         class Foo(object): pass
         f = Foo()
@@ -88,14 +88,14 @@ class Test_PropertyDescriptor(object):
             d._internal_set(f, 11)
 
     @patch('bokeh.core.property.descriptors.PropertyDescriptor._internal_set')
-    def test_set_from_json(self, mock_iset):
+    def test_set_from_json(self, mock_iset) -> None:
         class Foo(object): pass
         f = Foo()
         d = bcpd.PropertyDescriptor("foo")
         d.set_from_json(f, "bar", 10)
         assert mock_iset.called_once_with((f, "bar", 10), {})
 
-    def test_erializable_value(self):
+    def test_erializable_value(self) -> None:
         result = {}
         class Foo(object):
             def serialize_value(self, val):
@@ -112,7 +112,7 @@ class Test_PropertyDescriptor(object):
         d.serializable_value(f)
         assert result['foo'] == 10
 
-    def test_add_prop_descriptor_to_class_dupe_name(self):
+    def test_add_prop_descriptor_to_class_dupe_name(self) -> None:
         d = bcpd.PropertyDescriptor("foo")
         new_class_attrs = {'foo': 10}
         with pytest.raises(RuntimeError) as e:
@@ -121,7 +121,7 @@ class Test_PropertyDescriptor(object):
 
 class Test_BasicPropertyDescriptor(object):
 
-    def test___init__(self):
+    def test___init__(self) -> None:
         class Foo(object):
             '''doc'''
             pass
@@ -131,13 +131,13 @@ class Test_BasicPropertyDescriptor(object):
         assert d.property == f
         assert d.__doc__ == f.__doc__
 
-    def test___str__(self):
+    def test___str__(self) -> None:
         class Foo(object): pass
         f = Foo()
         d = bcpd.BasicPropertyDescriptor("foo", f)
         assert str(d) == str(f)
 
-    def test___get__improper(self):
+    def test___get__improper(self) -> None:
         class Foo(object): pass
         f = Foo()
         d = bcpd.BasicPropertyDescriptor("foo", f)
@@ -145,7 +145,7 @@ class Test_BasicPropertyDescriptor(object):
             d.__get__(None, None)
         assert str(e.value).endswith("both 'obj' and 'owner' are None, don't know what to do")
 
-    def test___set__improper(self):
+    def test___set__improper(self) -> None:
         class Foo(object): pass
         f = Foo()
         d = bcpd.BasicPropertyDescriptor("foo", f)
@@ -153,7 +153,7 @@ class Test_BasicPropertyDescriptor(object):
             d.__set__("junk", None)
         assert str(e.value).endswith("Cannot set a property value 'foo' on a str instance before HasProps.__init__")
 
-    def test___delete__(self):
+    def test___delete__(self) -> None:
         class Foo(Model):
             foo = Int()
             bar = List(Int, default=[10])
@@ -211,7 +211,7 @@ class Test_BasicPropertyDescriptor(object):
         assert f._unstable_default_values == dict(bar=[10])
         assert calls == ['baz', 'baz', 'bar', 'bar']
 
-    def test_class_default(self):
+    def test_class_default(self) -> None:
         result = {}
         class Foo(object):
             def themed_default(*args, **kw):
@@ -222,21 +222,21 @@ class Test_BasicPropertyDescriptor(object):
         d.class_default(d)
         assert result['called']
 
-    def test_serialized(self):
+    def test_serialized(self) -> None:
         class Foo(object): pass
         f = Foo()
         f.serialized = "stuff"
         d = bcpd.BasicPropertyDescriptor("foo", f)
         assert d.serialized == "stuff"
 
-    def test_readonly(self):
+    def test_readonly(self) -> None:
         class Foo(object): pass
         f = Foo()
         f.readonly = "stuff"
         d = bcpd.BasicPropertyDescriptor("foo", f)
         assert d.readonly == "stuff"
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         class Foo(object): pass
         f = Foo()
         f.has_ref = "stuff"
@@ -244,7 +244,7 @@ class Test_BasicPropertyDescriptor(object):
         assert d.has_ref == "stuff"
 
     @patch('bokeh.core.property.descriptors.BasicPropertyDescriptor._trigger')
-    def test__trigger(self, mock_trigger):
+    def test__trigger(self, mock_trigger) -> None:
         class Foo(object):
             _property_values = dict(foo=10, bar=20)
         class Match(object):
@@ -264,7 +264,7 @@ class Test_BasicPropertyDescriptor(object):
 
 class Test_UnitSpecDescriptor(object):
 
-    def test___init__(self):
+    def test___init__(self) -> None:
         class Foo(object):
             '''doc'''
             pass

--- a/tests/unit/bokeh/core/property/test_either.py
+++ b/tests/unit/bokeh/core/property/test_either.py
@@ -36,11 +36,11 @@ ALL = (
 
 class Test_Either(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         with pytest.raises(TypeError):
             bcpe.Either()
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpe.Either(Interval(Int, 0, 100), Regex("^x*$"), List(Int))
 
         assert prop.is_valid(None)
@@ -58,7 +58,7 @@ class Test_Either(object):
         assert prop.is_valid(False)
         assert prop.is_valid(True)
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpe.Either(Interval(Int, 0, 100), Regex("^x*$"), List(Int))
 
         assert not prop.is_valid(0.0)
@@ -76,11 +76,11 @@ class Test_Either(object):
 
         assert not prop.is_valid([1, 2, ""])
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpe.Either(Int, Int)
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpe.Either(Int, Int)
         assert str(prop) == "Either(Int, Int)"
 

--- a/tests/unit/bokeh/core/property/test_enum.py
+++ b/tests/unit/bokeh/core/property/test_enum.py
@@ -36,7 +36,7 @@ ALL = (
 
 class Test_Enum(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         with pytest.raises(TypeError):
             bcpe.Enum()
 
@@ -46,7 +46,7 @@ class Test_Enum(object):
         with pytest.raises(TypeError):
             bcpe.Enum("red", "green", "red")
 
-    def test_from_values_valid(self):
+    def test_from_values_valid(self) -> None:
         prop = bcpe.Enum("red", "green", "blue")
 
         assert prop.is_valid(None)
@@ -55,7 +55,7 @@ class Test_Enum(object):
         assert prop.is_valid("green")
         assert prop.is_valid("blue")
 
-    def test_from_values_invalid(self):
+    def test_from_values_invalid(self) -> None:
         prop = bcpe.Enum("red", "green", "blue")
 
         assert not prop.is_valid(False)
@@ -80,7 +80,7 @@ class Test_Enum(object):
         assert not prop.is_valid(" green")
         assert not prop.is_valid(" blue")
 
-    def test_from_enum_valid(self):
+    def test_from_enum_valid(self) -> None:
         prop = bcpe.Enum(LineJoin)
 
         assert prop.is_valid(None)
@@ -89,7 +89,7 @@ class Test_Enum(object):
         assert prop.is_valid("round")
         assert prop.is_valid("bevel")
 
-    def test_from_enum_invalid(self):
+    def test_from_enum_invalid(self) -> None:
         prop = bcpe.Enum(LineJoin)
 
         assert not prop.is_valid(False)
@@ -114,18 +114,18 @@ class Test_Enum(object):
         assert not prop.is_valid(" round")
         assert not prop.is_valid(" bevel")
 
-    def test_case_insensitive_enum_valid(self):
+    def test_case_insensitive_enum_valid(self) -> None:
         prop = bcpe.Enum(NamedColor)
 
         assert prop.is_valid("red")
         assert prop.is_valid("Red")
         assert prop.is_valid("RED")
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpe.Enum("foo")
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpe.Enum("foo")
         assert str(prop).startswith("Enum(")
 

--- a/tests/unit/bokeh/core/property/test_include.py
+++ b/tests/unit/bokeh/core/property/test_include.py
@@ -40,7 +40,7 @@ class IsDelegate(HasProps):
 
 class Test_Include(object):
 
-    def test_include_with_prefix(self):
+    def test_include_with_prefix(self) -> None:
 
         class IncludesDelegateWithPrefix(HasProps):
             z = bcpi.Include(IsDelegate, use_prefix=True)
@@ -61,7 +61,7 @@ class Test_Include(object):
         assert 'z_x' not in o.properties_with_values(include_defaults=False)
         assert 'z_y' not in o.properties_with_values(include_defaults=False)
 
-    def test_include_without_prefix(self):
+    def test_include_without_prefix(self) -> None:
         class IncludesDelegateWithoutPrefix(HasProps):
             z = bcpi.Include(IsDelegate, use_prefix=False)
             y = Int(42) # override the Include
@@ -77,7 +77,7 @@ class Test_Include(object):
         assert 'y' not in o.properties_with_values(include_defaults=False)
 
 
-    def test_include_without_prefix_using_override(self):
+    def test_include_without_prefix_using_override(self) -> None:
         class IncludesDelegateWithoutPrefixUsingOverride(HasProps):
             z = bcpi.Include(IsDelegate, use_prefix=False)
             y = Override(default="world") # override the Include changing just the default

--- a/tests/unit/bokeh/core/property/test_instance.py
+++ b/tests/unit/bokeh/core/property/test_instance.py
@@ -37,25 +37,25 @@ ALL = (
 
 class Test_Instance(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         with pytest.raises(TypeError):
             bcpi.Instance()
 
-    def test_serialized(self):
+    def test_serialized(self) -> None:
         prop = bcpi.Instance(_TestModel)
         assert prop.serialized == True
 
-    def test_readonly(self):
+    def test_readonly(self) -> None:
         prop = bcpi.Instance(_TestModel)
         assert prop.readonly == False
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpi.Instance(_TestModel)
 
         assert prop.is_valid(None)
         assert prop.is_valid(_TestModel())
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpi.Instance(_TestModel)
         assert not prop.is_valid(False)
         assert not prop.is_valid(True)
@@ -71,7 +71,7 @@ class Test_Instance(object):
         assert not prop.is_valid(_TestModel2())
         assert not prop.is_valid(_TestHasProps())
 
-    def test_from_json(self):
+    def test_from_json(self) -> None:
         class MapOptions(HasProps):
             lat = Float
             lng = Float
@@ -81,11 +81,11 @@ class Test_Instance(object):
         v2 = MapOptions(lat=1, lng=2)
         assert v1.equals(v2)
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpi.Instance(_TestModel)
         assert prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpi.Instance(_TestModel)
         assert str(prop) == "Instance(_TestModel)"
 

--- a/tests/unit/bokeh/core/property/test_json__property.py
+++ b/tests/unit/bokeh/core/property/test_json__property.py
@@ -35,7 +35,7 @@ ALL = (
 
 class Test_JSON(object):
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpj.JSON()
 
         assert prop.is_valid(None)
@@ -43,7 +43,7 @@ class Test_JSON(object):
         assert prop.is_valid('[]')
         assert prop.is_valid('[{"foo": 10}]')
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpj.JSON()
 
         assert not prop.is_valid("")
@@ -67,11 +67,11 @@ class Test_JSON(object):
         assert not prop.is_valid(_TestHasProps())
         assert not prop.is_valid(_TestModel())
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpj.JSON()
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpj.JSON()
         assert str(prop) == "JSON"
 

--- a/tests/unit/bokeh/core/property/test_numeric.py
+++ b/tests/unit/bokeh/core/property/test_numeric.py
@@ -42,7 +42,7 @@ ALL = (
 
 class Test_Angle(object):
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpn.Angle()
 
         assert prop.is_valid(None)
@@ -56,7 +56,7 @@ class Test_Angle(object):
         assert prop.is_valid(0.0)
         assert prop.is_valid(1.0)
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpn.Angle()
 
         assert not prop.is_valid(1.0+1.0j)
@@ -67,24 +67,24 @@ class Test_Angle(object):
         assert not prop.is_valid(_TestHasProps())
         assert not prop.is_valid(_TestModel())
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpn.Angle()
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpn.Angle()
         assert str(prop) == "Angle"
 
 class Test_Interval(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         with pytest.raises(TypeError):
             bcpn.Interval()
 
         with pytest.raises(ValueError):
             bcpn.Interval(Int, 0.0, 1.0)
 
-    def test_valid_int(self):
+    def test_valid_int(self) -> None:
         prop = bcpn.Interval(Int, 0, 255)
 
         assert prop.is_valid(None)
@@ -97,7 +97,7 @@ class Test_Interval(object):
         assert prop.is_valid(1)
         assert prop.is_valid(127)
 
-    def test_invalid_int(self):
+    def test_invalid_int(self) -> None:
         prop = bcpn.Interval(Int, 0, 255)
 
         assert not prop.is_valid(0.0)
@@ -113,7 +113,7 @@ class Test_Interval(object):
         assert not prop.is_valid(-1)
         assert not prop.is_valid(256)
 
-    def test_valid_float(self):
+    def test_valid_float(self) -> None:
         prop = bcpn.Interval(Float, 0.0, 1.0)
 
         assert prop.is_valid(None)
@@ -128,7 +128,7 @@ class Test_Interval(object):
         assert prop.is_valid(1.0)
         assert prop.is_valid(0.5)
 
-    def test_invalid_float(self):
+    def test_invalid_float(self) -> None:
         prop = bcpn.Interval(Float, 0.0, 1.0)
 
         assert not prop.is_valid(1.0+1.0j)
@@ -142,17 +142,17 @@ class Test_Interval(object):
         assert not prop.is_valid(-0.001)
         assert not prop.is_valid( 1.001)
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpn.Interval(Float, 0.0, 1.0)
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpn.Interval(Float, 0.0, 1.0)
         assert str(prop) == "Interval(Float, 0.0, 1.0)"
 
 class Test_Size(object):
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpn.Size()
 
         assert prop.is_valid(None)
@@ -168,7 +168,7 @@ class Test_Size(object):
         assert prop.is_valid(100)
         assert prop.is_valid(100.1)
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpn.Size()
 
         assert not prop.is_valid(1.0+1.0j)
@@ -182,17 +182,17 @@ class Test_Size(object):
         assert not prop.is_valid(-100)
         assert not prop.is_valid(-0.001)
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpn.Size()
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpn.Size()
         assert str(prop) == "Size"
 
 class Test_Percent(object):
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpn.Percent()
 
         assert prop.is_valid(None)
@@ -207,7 +207,7 @@ class Test_Percent(object):
         assert prop.is_valid(1.0)
         assert prop.is_valid(0.5)
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpn.Percent()
 
         assert not prop.is_valid(1.0+1.0j)
@@ -221,17 +221,17 @@ class Test_Percent(object):
         assert not prop.is_valid(-0.001)
         assert not prop.is_valid( 1.001)
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpn.Percent()
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpn.Percent()
         assert str(prop) == "Percent"
 
 class Test_NonNegativeInt(object):
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpn.NonNegativeInt()
 
         assert prop.is_valid(None)
@@ -245,7 +245,7 @@ class Test_NonNegativeInt(object):
         assert prop.is_valid(2)
         assert prop.is_valid(100)
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpn.NonNegativeInt()
 
         assert not prop.is_valid(-1)
@@ -262,17 +262,17 @@ class Test_NonNegativeInt(object):
         assert not prop.is_valid(-100)
         assert not prop.is_valid(-0.001)
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpn.NonNegativeInt()
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpn.NonNegativeInt()
         assert str(prop) == "NonNegativeInt"
 
 class Test_PositiveInt(object):
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpn.PositiveInt()
 
         assert prop.is_valid(None)
@@ -284,7 +284,7 @@ class Test_PositiveInt(object):
         assert prop.is_valid(2)
         assert prop.is_valid(100)
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpn.PositiveInt()
 
         assert not prop.is_valid(False)
@@ -304,11 +304,11 @@ class Test_PositiveInt(object):
         assert not prop.is_valid(-100)
         assert not prop.is_valid(-0.001)
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpn.PositiveInt()
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpn.PositiveInt()
         assert str(prop) == "PositiveInt"
 

--- a/tests/unit/bokeh/core/property/test_override.py
+++ b/tests/unit/bokeh/core/property/test_override.py
@@ -34,16 +34,16 @@ ALL = (
 
 class Test_Override(object):
 
-    def test_create_default(self):
+    def test_create_default(self) -> None:
         o = bcpo.Override(default=10)
         assert o.default_overridden
         assert o.default == 10
 
-    def test_create_no_args(self):
+    def test_create_no_args(self) -> None:
         with pytest.raises(ValueError):
             bcpo.Override()
 
-    def test_create_unkown_args(self):
+    def test_create_unkown_args(self) -> None:
         with pytest.raises(ValueError):
             bcpo.Override(default=10, junk=20)
 

--- a/tests/unit/bokeh/core/property/test_pandas.py
+++ b/tests/unit/bokeh/core/property/test_pandas.py
@@ -36,11 +36,11 @@ ALL = (
 
 class Test_PandasDataFrame(object):
 
-    def test_valid(self, pd):
+    def test_valid(self, pd) -> None:
         prop = bcpp.PandasDataFrame()
         assert prop.is_valid(pd.DataFrame())
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpp.PandasDataFrame()
         assert not prop.is_valid(None)
         assert not prop.is_valid(1.0+1.0j)
@@ -52,11 +52,11 @@ class Test_PandasDataFrame(object):
 
 class Test_PandasGroupBy(object):
 
-    def test_valid(self, pd):
+    def test_valid(self, pd) -> None:
         prop = bcpp.PandasGroupBy()
         assert prop.is_valid(pd.core.groupby.GroupBy(pd.DataFrame()))
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpp.PandasGroupBy()
         assert not prop.is_valid(None)
         assert not prop.is_valid(1.0+1.0j)

--- a/tests/unit/bokeh/core/property/test_primitive.py
+++ b/tests/unit/bokeh/core/property/test_primitive.py
@@ -42,7 +42,7 @@ ALL = (
 
 class Test_Bool(object):
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpp.Bool()
 
         assert prop.is_valid(None)
@@ -53,7 +53,7 @@ class Test_Bool(object):
         assert prop.is_valid(np.bool8(False))
         assert prop.is_valid(np.bool8(True))
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpp.Bool()
 
         assert not prop.is_valid(0)
@@ -95,17 +95,17 @@ class Test_Bool(object):
         if hasattr(np, "complex256"):
             assert not prop.is_valid(np.complex256(1.0+1.0j))
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpp.Bool()
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpp.Bool()
         assert str(prop) == "Bool"
 
 class Test_Complex(object):
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpp.Complex()
 
         assert prop.is_valid(None)
@@ -147,7 +147,7 @@ class Test_Complex(object):
         assert prop.is_valid(False)
         assert prop.is_valid(True)
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpp.Complex()
 
         assert not prop.is_valid("")
@@ -160,17 +160,17 @@ class Test_Complex(object):
         assert not prop.is_valid(np.bool8(False))
         assert not prop.is_valid(np.bool8(True))
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpp.Complex()
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpp.Complex()
         assert str(prop) == "Complex"
 
 class Test_Float(object):
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpp.Float()
 
         assert prop.is_valid(None)
@@ -207,7 +207,7 @@ class Test_Float(object):
         assert prop.is_valid(False)
         assert prop.is_valid(True)
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpp.Float()
 
         assert not prop.is_valid(1.0+1.0j)
@@ -225,17 +225,17 @@ class Test_Float(object):
         if hasattr(np, "complex256"):
             assert not prop.is_valid(np.complex256(1.0+1.0j))
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpp.Float()
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpp.Float()
         assert str(prop) == "Float"
 
 class Test_Int(object):
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpp.Int()
 
         assert prop.is_valid(None)
@@ -264,7 +264,7 @@ class Test_Int(object):
         assert prop.is_valid(False)
         assert prop.is_valid(True)
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpp.Int()
 
         assert not prop.is_valid(0.0)
@@ -290,17 +290,17 @@ class Test_Int(object):
         if hasattr(np, "complex256"):
             assert not prop.is_valid(np.complex256(1.0+1.0j))
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpp.Int()
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpp.Int()
         assert str(prop) == "Int"
 
 class Test_String(object):
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpp.String()
 
         assert prop.is_valid(None)
@@ -308,7 +308,7 @@ class Test_String(object):
         assert prop.is_valid("")
         assert prop.is_valid("6")
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpp.String()
 
         assert not prop.is_valid(False)
@@ -325,11 +325,11 @@ class Test_String(object):
         assert not prop.is_valid(_TestHasProps())
         assert not prop.is_valid(_TestModel())
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpp.String()
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpp.String()
         assert str(prop) == "String"
 

--- a/tests/unit/bokeh/core/property/test_regex.py
+++ b/tests/unit/bokeh/core/property/test_regex.py
@@ -35,11 +35,11 @@ ALL = (
 
 class Test_Regex(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         with pytest.raises(TypeError):
             bcpr.Regex()
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpr.Regex("^x*$")
 
         assert prop.is_valid(None)
@@ -47,7 +47,7 @@ class Test_Regex(object):
         assert prop.is_valid("")
         assert prop.is_valid("x")
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpr.Regex("^x*$")
 
         assert not prop.is_valid("xy")
@@ -66,11 +66,11 @@ class Test_Regex(object):
         assert not prop.is_valid(_TestHasProps())
         assert not prop.is_valid(_TestModel())
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpr.Regex("")
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpr.Regex("")
         assert str(prop).startswith("Regex(")
 

--- a/tests/unit/bokeh/core/property/test_validation__property.py
+++ b/tests/unit/bokeh/core/property/test_validation__property.py
@@ -86,7 +86,7 @@ SPECS = (
 
 class TestValidationControl(object):
 
-    def test_validate(self):
+    def test_validate(self) -> None:
         assert validation_on()
         with bcpv.validate(False):
             assert not validation_on()
@@ -104,7 +104,7 @@ class TestValidationControl(object):
         bcpv.validate(True)
         assert validation_on()
 
-    def test_without_property_validation(self):
+    def test_without_property_validation(self) -> None:
         @bcpv.without_property_validation
         def f():
             assert not validation_on()
@@ -119,131 +119,131 @@ class TestValidateDetailDefault(object):
 
     # TODO (bev) test_Image
 
-    def test_Angle(self):
+    def test_Angle(self) -> None:
         p = Angle()
         with pytest.raises(ValueError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected a value of type Real, got junk of type str")
-    def test_Bool(self):
+    def test_Bool(self) -> None:
         p = Bool()
         with pytest.raises(ValueError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected a value of type bool or bool_, got junk of type str")
-    def test_Complex(self):
+    def test_Complex(self) -> None:
         p = Complex()
         with pytest.raises(ValueError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected a value of type Complex, got junk of type str")
-    def test_Float(self):
+    def test_Float(self) -> None:
         p = Float()
         with pytest.raises(ValueError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected a value of type Real, got junk of type str")
-    def test_Int(self):
+    def test_Int(self) -> None:
         p = Int()
         with pytest.raises(ValueError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected a value of type Integral, got junk of type str")
-    def test_Interval(self):
+    def test_Interval(self) -> None:
         p = Interval(Float, 0.0, 1.0)
         with pytest.raises(ValueError) as e:
             p.validate(2)
         assert matches(str(e.value), r"expected a value of type Float in range \[0.0, 1.0\], got 2")
-    def test_Percent(self):
+    def test_Percent(self) -> None:
         p = Percent()
         with pytest.raises(ValueError) as e:
             p.validate(10)
         assert matches(str(e.value), r"expected a value in range \[0, 1\], got 10")
-    def test_Size(self):
+    def test_Size(self) -> None:
         p = Size()
         with pytest.raises(ValueError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected a value of type Real, got junk of type str")
 
 
-    def test_List(self):
+    def test_List(self) -> None:
         p = List(Float)
         with pytest.raises(ValueError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected an element of List\(Float\), got 'junk'")
-    def test_Seq(self):
+    def test_Seq(self) -> None:
         p = Seq(Float)
         with pytest.raises(ValueError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected an element of Seq\(Float\), got 'junk'")
-    def test_Dict(self):
+    def test_Dict(self) -> None:
         p = Dict(String, Float)
         with pytest.raises(ValueError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected an element of Dict\(String, Float\), got 'junk'")
-    def test_Tuple(self):
+    def test_Tuple(self) -> None:
         p = Tuple(Int, Int)
         with pytest.raises(ValueError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected an element of Tuple\(Int, Int\), got 'junk'")
 
 
-    def test_Color(self):
+    def test_Color(self) -> None:
         p = Color()
         with pytest.raises(ValueError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected an element of either Enum\(.*\), .* or RGB, got 'junk'")
-    def test_ColumnData(self):
+    def test_ColumnData(self) -> None:
         p = ColumnData(String, Seq(Float))
         with pytest.raises(ValueError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected an element of ColumnData\(String, Seq\(Float\)\), got 'junk'")
-    def test_Datetime(self):
+    def test_Datetime(self) -> None:
         p = Datetime()
         with pytest.raises(ValueError) as e:
             p.validate(object())
         assert matches(str(e.value), r"Expected a date, datetime object, or timestamp, got <object object at 0x.*>")
-    def test_Date(self):
+    def test_Date(self) -> None:
         p = Date()
         with pytest.raises(ValueError) as e:
             p.validate(object())
         assert matches(str(e.value), r"Expected an ISO date string, got <object object at 0x.*>")
-    def test_DashPattern(self):
+    def test_DashPattern(self) -> None:
         p = DashPattern()
         with pytest.raises(ValueError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected an element of either Enum\(.*\), Regex\(.*\) or Seq\(Int\), got 'junk'")
-    def test_Either(self):
+    def test_Either(self) -> None:
         p = Either(Int, Float)
         with pytest.raises(ValueError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected an element of either Int or Float, got 'junk'")
-    def test_Enum(self):
+    def test_Enum(self) -> None:
         p = Enum("red", "green")
         with pytest.raises(ValueError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"invalid value: 'junk'; allowed values are red or green")
-    def test_FontSize(self):
+    def test_FontSize(self) -> None:
         p = FontSize()
         with pytest.raises(ValueError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"'junk' is not a valid font size value")
-    def test_Instance(self):
+    def test_Instance(self) -> None:
         p = Instance(HasProps)
         with pytest.raises(ValueError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected an instance of type HasProps, got junk of type str")
-    def test_MinMaxBounds(self):
+    def test_MinMaxBounds(self) -> None:
         p = MinMaxBounds()
         with pytest.raises(ValueError) as e:
             p.validate(10)
         assert matches(str(e.value), r"expected an element of either Auto, Tuple\(Float, Float\) or Tuple\(TimeDelta, TimeDelta\), got 10")
-    def test_Regex(self):
+    def test_Regex(self) -> None:
         p = Regex("green")
         with pytest.raises(ValueError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected a string matching 'green' pattern, got 'junk'")
-    def test_String(self):
+    def test_String(self) -> None:
         p = String()
         with pytest.raises(ValueError) as e:
             p.validate(10)
         assert matches(str(e.value), r"expected a value of type str, got 10 of type int")
-    def test_MarkerType(self):
+    def test_MarkerType(self) -> None:
         p = MarkerType()
         with pytest.raises(ValueError) as e:
             p.validate("foo")
@@ -251,7 +251,7 @@ class TestValidateDetailDefault(object):
 
 
     @pytest.mark.parametrize('spec', SPECS)
-    def test_Spec(self, spec):
+    def test_Spec(self, spec) -> None:
         p = spec(default=None)
         with pytest.raises(ValueError) as e:
             p.validate(dict(bad="junk"))
@@ -264,126 +264,126 @@ class TestValidateDetailExplicit(object):
 
     # TODO (bev) test_Image
 
-    def test_Angle(self, detail):
+    def test_Angle(self, detail) -> None:
         p = Angle()
         with pytest.raises(ValueError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
-    def test_Bool(self, detail):
+    def test_Bool(self, detail) -> None:
         p = Bool()
         with pytest.raises(ValueError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
-    def test_Complex(self, detail):
+    def test_Complex(self, detail) -> None:
         p = Complex()
         with pytest.raises(ValueError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
-    def test_Float(self, detail):
+    def test_Float(self, detail) -> None:
         p = Float()
         with pytest.raises(ValueError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
-    def test_Int(self, detail):
+    def test_Int(self, detail) -> None:
         p = Int()
         with pytest.raises(ValueError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
-    def test_Interval(self, detail):
+    def test_Interval(self, detail) -> None:
         p = Interval(Float, 0.0, 1.0)
         with pytest.raises(ValueError) as e:
             p.validate(2, detail)
         assert (str(e.value) == "") == (not detail)
-    def test_Percent(self, detail):
+    def test_Percent(self, detail) -> None:
         p = Percent()
         with pytest.raises(ValueError) as e:
             p.validate(10, detail)
         assert (str(e.value) == "") == (not detail)
-    def test_Size(self, detail):
+    def test_Size(self, detail) -> None:
         p = Size()
         with pytest.raises(ValueError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
 
 
-    def test_List(self, detail):
+    def test_List(self, detail) -> None:
         p = List(Float)
         with pytest.raises(ValueError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
-    def test_Seq(self, detail):
+    def test_Seq(self, detail) -> None:
         p = Seq(Float)
         with pytest.raises(ValueError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
-    def test_Dict(self, detail):
+    def test_Dict(self, detail) -> None:
         p = Dict(String, Float)
         with pytest.raises(ValueError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
-    def test_Tuple(self, detail):
+    def test_Tuple(self, detail) -> None:
         p = Tuple(Int, Int)
         with pytest.raises(ValueError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
 
 
-    def test_Color(self, detail):
+    def test_Color(self, detail) -> None:
         p = Color()
         with pytest.raises(ValueError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
-    def test_ColumnData(self, detail):
+    def test_ColumnData(self, detail) -> None:
         p = ColumnData(String, Seq(Float))
         with pytest.raises(ValueError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
-    def test_Date(self, detail):
+    def test_Date(self, detail) -> None:
         p = Date()
         with pytest.raises(ValueError) as e:
             p.validate(p, detail)
         assert (str(e.value) == "") == (not detail)
-    def test_DashPattern(self, detail):
+    def test_DashPattern(self, detail) -> None:
         p = DashPattern()
         with pytest.raises(ValueError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
-    def test_Either(self, detail):
+    def test_Either(self, detail) -> None:
         p = Either(Int, Float)
         with pytest.raises(ValueError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
-    def test_Enum(self, detail):
+    def test_Enum(self, detail) -> None:
         p = Enum("red", "green")
         with pytest.raises(ValueError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
-    def test_FontSize(self, detail):
+    def test_FontSize(self, detail) -> None:
         p = FontSize()
         with pytest.raises(ValueError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
-    def test_Instance(self, detail):
+    def test_Instance(self, detail) -> None:
         p = Instance(HasProps)
         with pytest.raises(ValueError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
-    def test_MinMaxBounds(self, detail):
+    def test_MinMaxBounds(self, detail) -> None:
         p = MinMaxBounds()
         with pytest.raises(ValueError) as e:
             p.validate(10, detail)
         assert (str(e.value) == "") == (not detail)
-    def test_Regex(self, detail):
+    def test_Regex(self, detail) -> None:
         p = Regex("green")
         with pytest.raises(ValueError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
-    def test_String(self, detail):
+    def test_String(self, detail) -> None:
         p = String()
         with pytest.raises(ValueError) as e:
             p.validate(10, detail)
         assert (str(e.value) == "") == (not detail)
-    def test_MarkerType(self, detail):
+    def test_MarkerType(self, detail) -> None:
         p = MarkerType()
         with pytest.raises(ValueError) as e:
             p.validate("foo", detail)
@@ -391,7 +391,7 @@ class TestValidateDetailExplicit(object):
 
 
     @pytest.mark.parametrize('spec', SPECS)
-    def test_Spec(self, detail, spec):
+    def test_Spec(self, detail, spec) -> None:
         p = spec(default=None)
         with pytest.raises(ValueError) as e:
             p.validate(dict(bad="junk"), detail)

--- a/tests/unit/bokeh/core/property/test_visual.py
+++ b/tests/unit/bokeh/core/property/test_visual.py
@@ -51,7 +51,7 @@ ALL = (
 
 class TestDashPattern(object):
 
-    def test_valid_named(self):
+    def test_valid_named(self) -> None:
         class Foo(HasProps):
             pat = bcpv.DashPattern()
         f = Foo()
@@ -68,7 +68,7 @@ class TestDashPattern(object):
         f.pat = "dashdot"
         assert f.pat == [6, 4, 2, 4]
 
-    def test_valid_string(self):
+    def test_valid_string(self) -> None:
         class Foo(HasProps):
             pat = bcpv.DashPattern()
         f = Foo()
@@ -85,7 +85,7 @@ class TestDashPattern(object):
         with pytest.raises(ValueError):
             f.pat = "abc 6"
 
-    def test_valid_list(self):
+    def test_valid_list(self) -> None:
         class Foo(HasProps):
             pat = bcpv.DashPattern()
         f = Foo()
@@ -104,7 +104,7 @@ class TestDashPattern(object):
         with pytest.raises(ValueError):
             f.pat = (2, "a")
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpv.DashPattern()
 
         assert prop.is_valid(None)
@@ -123,7 +123,7 @@ class TestDashPattern(object):
         assert prop.is_valid("1 2 3")
 
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpv.DashPattern()
 
         assert not prop.is_valid(False)
@@ -143,11 +143,11 @@ class TestDashPattern(object):
         assert not prop.is_valid(_TestHasProps())
         assert not prop.is_valid(_TestModel())
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpv.DashPattern()
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpv.DashPattern()
         assert str(prop) == "DashPattern"
 
@@ -155,7 +155,7 @@ css_units = "%|em|ex|ch|ic|rem|vw|vh|vi|vb|vmin|vmax|cm|mm|q|in|pc|pt|px"
 
 class Test_FontSize(object):
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpv.FontSize()
 
         assert prop.is_valid(None)
@@ -174,7 +174,7 @@ class Test_FontSize(object):
             v = '10.2%s' % unit
             assert prop.is_valid(v)
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpv.FontSize()
 
         for unit in css_units.split("|"):
@@ -205,48 +205,48 @@ class Test_FontSize(object):
         assert not prop.is_valid(_TestHasProps())
         assert not prop.is_valid(_TestModel())
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpv.FontSize()
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpv.FontSize()
         assert str(prop) == "FontSize"
 
 
 class Test_Image(object):
-    def test_default_creation(self):
+    def test_default_creation(self) -> None:
         bcpv.Image()
 
-    def test_validate_None(self):
+    def test_validate_None(self) -> None:
         prop = bcpv.Image()
         assert prop.is_valid(None)
 
-    def test_validate_string(self):
+    def test_validate_string(self) -> None:
         prop = bcpv.Image()
         assert prop.is_valid("string")
 
     @pytest.mark.parametrize('typ', ('png', 'gif', 'tiff'))
-    def test_validate_PIL(self, typ):
+    def test_validate_PIL(self, typ) -> None:
         file = BytesIO()
         image = PIL.Image.new('RGBA', size=(50, 50), color=(155, 0, 0))
         image.save(file, typ)
         prop = bcpv.Image()
         assert prop.is_valid(image)
 
-    def test_validate_numpy_RGB(self):
+    def test_validate_numpy_RGB(self) -> None:
         data = np.zeros((50, 50, 3), dtype=np.uint8)
         data[:, 30:35] = [255, 0, 0]
         prop = bcpv.Image()
         assert prop.is_valid(data)
 
-    def test_validate_numpy_RGBA(self):
+    def test_validate_numpy_RGBA(self) -> None:
         data = np.zeros((50, 50, 4), dtype=np.uint8)
         data[:, 30:35] = [255, 0, 0, 255]
         prop = bcpv.Image()
         assert prop.is_valid(data)
 
-    def test_validate_invalid(self):
+    def test_validate_invalid(self) -> None:
         prop = bcpv.Image()
         assert not prop.is_valid(10)
         assert not prop.is_valid(True)
@@ -261,11 +261,11 @@ class Test_Image(object):
         data = np.zeros((50, 50), dtype=np.uint8)
         assert not prop.is_valid(data)
 
-    def test_transform_None(self):
+    def test_transform_None(self) -> None:
         prop = bcpv.Image()
         assert prop.transform(None) is None
 
-    def test_transform_numpy(self):
+    def test_transform_numpy(self) -> None:
         data = np.zeros((50, 50, 3), dtype=np.uint8)
         data[:, 30:35] = [255, 0, 0]
         value = PIL.Image.fromarray(data)
@@ -277,7 +277,7 @@ class Test_Image(object):
         assert prop.transform(data) == expected
 
     @pytest.mark.parametrize('typ', ('png', 'gif', 'tiff'))
-    def test_transform_PIL(self, typ):
+    def test_transform_PIL(self, typ) -> None:
         image = PIL.Image.new("RGBA", size=(50, 50), color=(155, 0, 0))
         out = BytesIO()
         image.save(out, typ)
@@ -287,22 +287,22 @@ class Test_Image(object):
         prop = bcpv.Image()
         assert prop.transform(value) == expected
 
-    def test_transform_bad(self):
+    def test_transform_bad(self) -> None:
         prop = bcpv.Image()
         with pytest.raises(ValueError):
             assert prop.transform(10)
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpv.Image()
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpv.Image()
         assert str(prop) == "Image"
 
 class Test_MinMaxBounds(object):
 
-    def test_valid_no_datetime(self):
+    def test_valid_no_datetime(self) -> None:
         prop = bcpv.MinMaxBounds(accept_datetime=False)
 
         assert prop.is_valid('auto')
@@ -313,7 +313,7 @@ class Test_MinMaxBounds(object):
         assert prop.is_valid((None, 13.1))
         assert prop.is_valid((-22, None))
 
-    def test_invalid_no_datetime(self):
+    def test_invalid_no_datetime(self) -> None:
         prop = bcpv.MinMaxBounds(accept_datetime=False)
 
         assert not prop.is_valid('string')
@@ -323,25 +323,25 @@ class Test_MinMaxBounds(object):
         assert not prop.is_valid((13.1, 12.2))
         assert not prop.is_valid((datetime.date(2012, 10, 1), datetime.date(2012, 12, 2)))
 
-    def test_MinMaxBounds_with_datetime(self):
+    def test_MinMaxBounds_with_datetime(self) -> None:
         prop = bcpv.MinMaxBounds(accept_datetime=True)
 
         assert prop.is_valid((datetime.datetime(2012, 10, 1), datetime.datetime(2012, 12, 2)))
 
         assert not prop.is_valid((datetime.datetime(2012, 10, 1), 22))
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpv.MinMaxBounds()
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpv.MinMaxBounds()
         assert str(prop).startswith("MinMaxBounds(")
 
 
 class Test_MarkerType(object):
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         prop = bcpv.MarkerType()
 
         assert prop.is_valid(None)
@@ -349,7 +349,7 @@ class Test_MarkerType(object):
         for typ in MarkerType:
             assert prop.is_valid(typ)
 
-    def test_invalid(self):
+    def test_invalid(self) -> None:
         prop = bcpv.MarkerType()
 
         assert not prop.is_valid(False)
@@ -371,11 +371,11 @@ class Test_MarkerType(object):
         assert not prop.is_valid([1, 2, 3])
         assert not prop.is_valid([1, 2, 3.0])
 
-    def test_has_ref(self):
+    def test_has_ref(self) -> None:
         prop = bcpv.MarkerType()
         assert not prop.has_ref
 
-    def test_str(self):
+    def test_str(self) -> None:
         prop = bcpv.MarkerType()
         assert str(prop).startswith("MarkerType(")
 

--- a/tests/unit/bokeh/core/property/test_wrappers__property.py
+++ b/tests/unit/bokeh/core/property/test_wrappers__property.py
@@ -68,7 +68,7 @@ ALL = (
 # Dev API
 #-----------------------------------------------------------------------------
 
-def test_notify_owner():
+def test_notify_owner() -> None:
     result = {}
     class Foo(object):
         @bcpw.notify_owner
@@ -84,7 +84,7 @@ def test_notify_owner():
     assert result['old'] == 'foo'
     assert f.test.__doc__ == "Container method ``test`` instrumented to notify property owners"
 
-def test_PropertyValueContainer():
+def test_PropertyValueContainer() -> None:
     pvc = bcpw.PropertyValueContainer()
     assert pvc._owners == set()
 
@@ -98,7 +98,7 @@ def test_PropertyValueContainer():
         pvc._saved_copy()
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
-def test_PropertyValueDict_mutators(mock_notify):
+def test_PropertyValueDict_mutators(mock_notify) -> None:
     pvd = bcpw.PropertyValueDict(dict(foo=10, bar=20, baz=30))
 
     mock_notify.reset_mock()
@@ -130,7 +130,7 @@ def test_PropertyValueDict_mutators(mock_notify):
     assert mock_notify.called
 
 @patch('bokeh.core.property.descriptors.ColumnDataPropertyDescriptor._notify_mutated')
-def test_PropertyValueColumnData___setitem__(mock_notify):
+def test_PropertyValueColumnData___setitem__(mock_notify) -> None:
     from bokeh.document.events import ColumnDataChangedEvent
 
     source = ColumnDataSource(data=dict(foo=[10], bar=[20], baz=[30]))
@@ -148,7 +148,7 @@ def test_PropertyValueColumnData___setitem__(mock_notify):
     assert mock_notify.call_args[1]['hint'].cols == ['foo']
 
 @patch('bokeh.core.property.descriptors.ColumnDataPropertyDescriptor._notify_mutated')
-def test_PropertyValueColumnData_update(mock_notify):
+def test_PropertyValueColumnData_update(mock_notify) -> None:
     from bokeh.document.events import ColumnDataChangedEvent
 
     source = ColumnDataSource(data=dict(foo=[10], bar=[20], baz=[30]))
@@ -166,7 +166,7 @@ def test_PropertyValueColumnData_update(mock_notify):
     assert sorted(mock_notify.call_args[1]['hint'].cols) == ['bar', 'foo']
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
-def test_PropertyValueColumnData__stream_list_to_list(mock_notify):
+def test_PropertyValueColumnData__stream_list_to_list(mock_notify) -> None:
     from bokeh.document.events import ColumnsStreamedEvent
 
     source = ColumnDataSource(data=dict(foo=[10]))
@@ -182,7 +182,7 @@ def test_PropertyValueColumnData__stream_list_to_list(mock_notify):
     assert mock_notify.call_args[1]['hint'].rollover == None
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
-def test_PropertyValueColumnData__stream_list_to_array(mock_notify):
+def test_PropertyValueColumnData__stream_list_to_array(mock_notify) -> None:
     from bokeh.document.events import ColumnsStreamedEvent
     import numpy as np
 
@@ -200,7 +200,7 @@ def test_PropertyValueColumnData__stream_list_to_array(mock_notify):
 
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
-def test_PropertyValueColumnData__stream_list_with_rollover(mock_notify):
+def test_PropertyValueColumnData__stream_list_with_rollover(mock_notify) -> None:
     from bokeh.document.events import ColumnsStreamedEvent
 
     source = ColumnDataSource(data=dict(foo=[10, 20, 30]))
@@ -216,7 +216,7 @@ def test_PropertyValueColumnData__stream_list_with_rollover(mock_notify):
     assert mock_notify.call_args[1]['hint'].rollover == 3
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
-def test_PropertyValueColumnData__stream_array_to_array(mock_notify):
+def test_PropertyValueColumnData__stream_array_to_array(mock_notify) -> None:
     from bokeh.document.events import ColumnsStreamedEvent
     import numpy as np
 
@@ -235,7 +235,7 @@ def test_PropertyValueColumnData__stream_array_to_array(mock_notify):
     assert mock_notify.call_args[1]['hint'].rollover == None
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
-def test_PropertyValueColumnData__stream_array_to_list(mock_notify):
+def test_PropertyValueColumnData__stream_array_to_list(mock_notify) -> None:
     from bokeh.document.events import ColumnsStreamedEvent
 
     source = ColumnDataSource(data=dict(foo=[10]))
@@ -253,7 +253,7 @@ def test_PropertyValueColumnData__stream_array_to_list(mock_notify):
     assert mock_notify.call_args[1]['hint'].rollover == None
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
-def test_PropertyValueColumnData__stream_array_with_rollover(mock_notify):
+def test_PropertyValueColumnData__stream_array_with_rollover(mock_notify) -> None:
     from bokeh.document.events import ColumnsStreamedEvent
     import numpy as np
 
@@ -272,7 +272,7 @@ def test_PropertyValueColumnData__stream_array_with_rollover(mock_notify):
     assert mock_notify.call_args[1]['hint'].rollover == 3
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
-def test_PropertyValueColumnData__patch_with_simple_indices(mock_notify):
+def test_PropertyValueColumnData__patch_with_simple_indices(mock_notify) -> None:
     from bokeh.document.events import ColumnsPatchedEvent
     source = ColumnDataSource(data=dict(foo=[10, 20]))
     pvcd = bcpw.PropertyValueColumnData(source.data)
@@ -287,7 +287,7 @@ def test_PropertyValueColumnData__patch_with_simple_indices(mock_notify):
     assert mock_notify.call_args[1]['hint'].setter == 'setter'
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
-def test_PropertyValueColumnData__patch_with_repeated_simple_indices(mock_notify):
+def test_PropertyValueColumnData__patch_with_repeated_simple_indices(mock_notify) -> None:
     from bokeh.document.events import ColumnsPatchedEvent
     source = ColumnDataSource(data=dict(foo=[10, 20]))
     pvcd = bcpw.PropertyValueColumnData(source.data)
@@ -303,7 +303,7 @@ def test_PropertyValueColumnData__patch_with_repeated_simple_indices(mock_notify
 
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
-def test_PropertyValueColumnData__patch_with_slice_indices(mock_notify):
+def test_PropertyValueColumnData__patch_with_slice_indices(mock_notify) -> None:
     from bokeh.document.events import ColumnsPatchedEvent
     source = ColumnDataSource(data=dict(foo=[10, 20, 30, 40, 50]))
     pvcd = bcpw.PropertyValueColumnData(source.data)
@@ -318,7 +318,7 @@ def test_PropertyValueColumnData__patch_with_slice_indices(mock_notify):
     assert mock_notify.call_args[1]['hint'].setter == 'setter'
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
-def test_PropertyValueColumnData__patch_with_overlapping_slice_indices(mock_notify):
+def test_PropertyValueColumnData__patch_with_overlapping_slice_indices(mock_notify) -> None:
     from bokeh.document.events import ColumnsPatchedEvent
     source = ColumnDataSource(data=dict(foo=[10, 20, 30, 40, 50]))
     pvcd = bcpw.PropertyValueColumnData(source.data)
@@ -333,7 +333,7 @@ def test_PropertyValueColumnData__patch_with_overlapping_slice_indices(mock_noti
     assert mock_notify.call_args[1]['hint'].setter == 'setter'
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
-def test_PropertyValueList_mutators(mock_notify):
+def test_PropertyValueList_mutators(mock_notify) -> None:
     pvl = bcpw.PropertyValueList([10, 20, 30, 40, 50])
 
     mock_notify.reset_mock()
@@ -406,7 +406,7 @@ def test_PropertyValueList_mutators(mock_notify):
     except:
         pass
 
-def test_PropertyValueColumnData___copy__():
+def test_PropertyValueColumnData___copy__() -> None:
     source = ColumnDataSource(data=dict(foo=[10]))
     pvcd = source.data.__copy__()
     assert source.data == pvcd
@@ -414,7 +414,7 @@ def test_PropertyValueColumnData___copy__():
     pvcd['foo'][0] = 20
     assert source.data['foo'][0] == 20
 
-def test_PropertyValueColumnData___deepcopy__():
+def test_PropertyValueColumnData___deepcopy__() -> None:
     source = ColumnDataSource(data=dict(foo=[10]))
     pvcd = source.data.__deepcopy__()
     assert source.data == pvcd
@@ -422,7 +422,7 @@ def test_PropertyValueColumnData___deepcopy__():
     pvcd['foo'][0] = 20
     assert source.data['foo'][0] == 10
 
-def test_Property_wrap():
+def test_Property_wrap() -> None:
     for x in (Bool, Int, Float, Complex, String, Enum, Color,
               Regex, Seq, Tuple, Instance, Any, Interval, Either,
               DashPattern, Size, Percent, Angle, MinMaxBounds):
@@ -431,7 +431,7 @@ def test_Property_wrap():
             assert r == y
             assert isinstance(r, type(y))
 
-def test_List_wrap():
+def test_List_wrap() -> None:
     for y in (0, 1, 2.3, "foo", None, (), {}):
         r = List.wrap(y)
         assert r == y
@@ -442,7 +442,7 @@ def test_List_wrap():
     r2 = List.wrap(r)
     assert r is r2
 
-def test_Dict_wrap():
+def test_Dict_wrap() -> None:
     for y in (0, 1, 2.3, "foo", None, (), []):
         r = Dict.wrap(y)
         assert r == y
@@ -453,7 +453,7 @@ def test_Dict_wrap():
     r2 = Dict.wrap(r)
     assert r is r2
 
-def test_ColumnData_wrap():
+def test_ColumnData_wrap() -> None:
     for y in (0, 1, 2.3, "foo", None, (), []):
         r = ColumnData.wrap(y)
         assert r == y

--- a/tests/unit/bokeh/core/test_enums.py
+++ b/tests/unit/bokeh/core/test_enums.py
@@ -90,12 +90,12 @@ ALL  = (
 # Dev API
 #-----------------------------------------------------------------------------
 
-def test_Enumeration_default():
+def test_Enumeration_default() -> None:
     e = bce.Enumeration()
     assert e.__slots__ == ()
 
 class Test_enumeration(object):
-    def test_basic(self):
+    def test_basic(self) -> None:
         e = bce.enumeration("foo", "bar", "baz")
         assert isinstance(e, bce.Enumeration)
         assert str(e) == "Enumeration(foo, bar, baz)"
@@ -104,7 +104,7 @@ class Test_enumeration(object):
             assert x in e
         assert "junk" not in e
 
-    def test_case(self):
+    def test_case(self) -> None:
         e = bce.enumeration("foo", "bar", "baz", case_sensitive=False)
         assert isinstance(e, bce.Enumeration)
         assert str(e) == "Enumeration(foo, bar, baz)"
@@ -113,7 +113,7 @@ class Test_enumeration(object):
             assert x in e
         assert "junk" not in e
 
-    def test_quote(self):
+    def test_quote(self) -> None:
         e = bce.enumeration("foo", "bar", "baz", quote=True)
         assert isinstance(e, bce.Enumeration)
         assert str(e) == 'Enumeration("foo", "bar", "baz")' or str(e) == "Enumeration('foo', 'bar', 'baz')"
@@ -122,183 +122,183 @@ class Test_enumeration(object):
             assert x in e
         assert "junk" not in e
 
-    def test_default(self):
+    def test_default(self) -> None:
         # this is private but used by properties
         e = bce.enumeration("foo", "bar", "baz")
         assert e._default == "foo"
 
-    def test_len(self):
+    def test_len(self) -> None:
         e = bce.enumeration("foo", "bar", "baz")
         assert len(e) == 3
 
 class Test_bce(object):
 
-    def test_Anchor(self):
+    def test_Anchor(self) -> None:
         assert tuple(bce.Anchor) == (
             "top_left",    "top_center",    "top_right",
             "center_left", "center",        "center_right",
             "bottom_left", "bottom_center", "bottom_right"
         )
 
-    def test_AngleUnits(self):
+    def test_AngleUnits(self) -> None:
         assert tuple(bce.AngleUnits) == ('deg', 'rad')
 
-    def test_ButtonType(self):
+    def test_ButtonType(self) -> None:
         assert tuple(bce.ButtonType) == ("default", "primary", "success", "warning", "danger")
 
-    def test_CalendarPosition(self):
+    def test_CalendarPosition(self) -> None:
         assert tuple(bce.CalendarPosition) == ("auto", "above", "below")
 
-    def test_DashPattern(self):
+    def test_DashPattern(self) -> None:
         assert tuple(bce.DashPattern) ==("solid", "dashed", "dotted", "dotdash", "dashdot")
 
-    def test_DateFormat(self):
+    def test_DateFormat(self) -> None:
         assert tuple(bce.DateFormat) == ("ATOM", "W3C", "RFC-3339", "ISO-8601", "COOKIE", "RFC-822",
                                         "RFC-850", "RFC-1036", "RFC-1123", "RFC-2822", "RSS", "TIMESTAMP")
 
-    def test_DatetimeUnits(self):
+    def test_DatetimeUnits(self) -> None:
         assert tuple(bce.DatetimeUnits) == ("microseconds", "milliseconds", "seconds", "minsec",
                                             "minutes", "hourmin", "hours", "days", "months", "years")
 
-    def test_Dimension(self):
+    def test_Dimension(self) -> None:
         assert tuple(bce.Dimension) == ("width", "height")
 
-    def test_Dimensions(self):
+    def test_Dimensions(self) -> None:
         assert tuple(bce.Dimensions) == ("width", "height", "both")
 
-    def test_Direction(self):
+    def test_Direction(self) -> None:
         assert tuple(bce.Direction) == ("clock", "anticlock")
 
-    def test_FontStyle(self):
+    def test_FontStyle(self) -> None:
         assert tuple(bce.FontStyle) == ('normal', 'italic', 'bold', 'bold italic')
 
-    def test_HatchPattern(self):
+    def test_HatchPattern(self) -> None:
         assert tuple(bce.HatchPattern) == (
             "blank", "dot", "ring", "horizontal_line", "vertical_line", "cross", "horizontal_dash", "vertical_dash",
             "spiral", "right_diagonal_line", "left_diagonal_line", "diagonal_cross", "right_diagonal_dash",
             "left_diagonal_dash", "horizontal_wave", "vertical_wave", "criss_cross"
         )
 
-    def test_HatchPatternAbbreviation(self):
+    def test_HatchPatternAbbreviation(self) -> None:
         assert tuple(bce.HatchPatternAbbreviation) ==(' ', '.', 'o', '-', '|', '+', '"', ':', '@', '/', '\\', 'x', ',', '`', 'v', '>', '*')
 
-    def test_HoldPolicy(self):
+    def test_HoldPolicy(self) -> None:
         assert tuple(bce.HoldPolicy) == ("combine", "collect")
 
-    def test_HorizontalLocation(self):
+    def test_HorizontalLocation(self) -> None:
         assert tuple(bce.HorizontalLocation) == ("left", "right")
 
-    def test_JitterRandomDistribution(self):
+    def test_JitterRandomDistribution(self) -> None:
         assert tuple(bce.JitterRandomDistribution) == ("uniform", "normal")
 
-    def test_LatLon(self):
+    def test_LatLon(self) -> None:
         assert tuple(bce.LatLon) == ("lat", "lon")
 
-    def test_LegendClickPolicy(self):
+    def test_LegendClickPolicy(self) -> None:
         assert tuple(bce.LegendClickPolicy) == ("none", "hide", "mute")
 
-    def test_LegendLocation(self):
+    def test_LegendLocation(self) -> None:
         assert tuple(bce.LegendLocation) == (
             "top_left",    "top_center",    "top_right",
             "center_left", "center",        "center_right",
             "bottom_left", "bottom_center", "bottom_right"
         )
 
-    def test_LineCap(self):
+    def test_LineCap(self) -> None:
         assert tuple(bce.LineCap) == ("butt", "round", "square")
 
-    def test_LineDash(self):
+    def test_LineDash(self) -> None:
         assert tuple(bce.LineDash) == ("solid", "dashed", "dotted", "dotdash", "dashdot")
 
-    def test_LineJoin(self):
+    def test_LineJoin(self) -> None:
         assert tuple(bce.LineJoin) == ("miter", "round", "bevel")
 
-    def test_Location(self):
+    def test_Location(self) -> None:
         assert tuple(bce.Location) == ("above", "below", "left", "right")
 
-    def test_MapType(self):
+    def test_MapType(self) -> None:
         assert tuple(bce.MapType) == ("satellite", "roadmap", "terrain", "hybrid")
 
-    def test_MarkerType(self):
+    def test_MarkerType(self) -> None:
         assert tuple(bce.MarkerType) == ("asterisk", "circle", "circle_cross", "circle_x", "cross",
                                          "dash", "diamond", "diamond_cross", "hex", "inverted_triangle",
                                          "square", "square_cross", "square_x", "triangle", "x")
 
-    def test_NamedColor(self):
+    def test_NamedColor(self) -> None:
         assert len(tuple(bce.NamedColor)) == 147
         assert tuple(bce.NamedColor) == tuple(named.__all__)
 
-    def test_NumeralLanguage(self):
+    def test_NumeralLanguage(self) -> None:
         assert tuple(bce.NumeralLanguage) == ("be-nl", "chs", "cs", "da-dk", "de-ch", "de", "en",
                                               "en-gb", "es-ES", "es", "et", "fi", "fr-CA", "fr-ch",
                                               "fr", "hu", "it", "ja", "nl-nl", "pl", "pt-br",
                                               "pt-pt", "ru", "ru-UA", "sk", "th", "tr", "uk-UA")
 
-    def test_Orientation(self):
+    def test_Orientation(self) -> None:
         assert tuple(bce.Orientation) == ("horizontal", "vertical")
 
-    def test_OutputBackend(self):
+    def test_OutputBackend(self) -> None:
         assert tuple(bce.OutputBackend) == ("canvas", "svg", "webgl")
 
-    def test_PaddingUnits(self):
+    def test_PaddingUnits(self) -> None:
         assert tuple(bce.PaddingUnits) == ("percent", "absolute")
 
-    def test_Palette(self):
+    def test_Palette(self) -> None:
         assert tuple(bce.Palette) == tuple(__palettes__)
 
-    def test_RenderLevel(self):
+    def test_RenderLevel(self) -> None:
         assert tuple(bce.RenderLevel) == ("image", "underlay", "glyph", "annotation", "overlay")
 
-    def test_RenderMode(self):
+    def test_RenderMode(self) -> None:
         assert tuple(bce.RenderMode) == ("canvas", "css")
 
-    def test_ResetPolicy(self):
+    def test_ResetPolicy(self) -> None:
         assert tuple(bce.ResetPolicy) == ("standard", "event_only")
 
-    def test_RoundingFunction(self):
+    def test_RoundingFunction(self) -> None:
         assert tuple(bce.RoundingFunction) == ("round", "nearest", "floor", "rounddown", "ceil", "roundup")
 
-    def test_SizingMode(self):
+    def test_SizingMode(self) -> None:
         assert tuple(bce.SizingMode) == ("stretch_width", "stretch_height", "stretch_both", "scale_width", "scale_height", "scale_both", "fixed")
 
-    def test_SortDirection(self):
+    def test_SortDirection(self) -> None:
         assert tuple(bce.SortDirection) == ("ascending", "descending")
 
-    def test_SpatialUnits(self):
+    def test_SpatialUnits(self) -> None:
         assert tuple(bce.SpatialUnits) == ("screen", "data")
 
-    def test_StartEnd(self):
+    def test_StartEnd(self) -> None:
         assert tuple(bce.StartEnd) == ("start", "end")
 
-    def test_StepMode(self):
+    def test_StepMode(self) -> None:
         assert tuple(bce.StepMode) == ("before", "after", "center")
 
-    def test_TextAlign(self):
+    def test_TextAlign(self) -> None:
         assert tuple(bce.TextAlign) == ("left", "right", "center")
 
-    def test_TextBaseline(self):
+    def test_TextBaseline(self) -> None:
         assert tuple(bce.TextBaseline) == ("top", "middle", "bottom", "alphabetic", "hanging", "ideographic")
 
-    def test_TextureRepetition(self):
+    def test_TextureRepetition(self) -> None:
         assert tuple(bce.TextureRepetition) == ("repeat", "repeat_x", "repeat_y", "no_repeat")
 
-    def test_TickLabelOrientation(self):
+    def test_TickLabelOrientation(self) -> None:
         assert tuple(bce.TickLabelOrientation) == ("horizontal", "vertical", "parallel", "normal")
 
-    def test_TooltipAttachment(self):
+    def test_TooltipAttachment(self) -> None:
         assert tuple(bce.TooltipAttachment) == ("horizontal", "vertical", "left", "right", "above", "below")
 
-    def test_TooltipFieldFormatter(self):
+    def test_TooltipFieldFormatter(self) -> None:
         assert tuple(bce.TooltipFieldFormatter) == ("numeral", "datetime", "printf")
 
-    def test_VerticalAlign(self):
+    def test_VerticalAlign(self) -> None:
         assert tuple(bce.VerticalAlign) == ("top", "middle", "bottom")
 
-    def test_VerticalLocation(self):
+    def test_VerticalLocation(self) -> None:
         assert tuple(bce.VerticalLocation) == ("above", "below")
 
 # any changes to contents of bce.py easily trackable here
-def test_enums_contents():
+def test_enums_contents() -> None:
     assert [x for x in dir(bce) if x[0].isupper()] == [
         'Align',
         'Anchor',

--- a/tests/unit/bokeh/core/test_has_props.py
+++ b/tests/unit/bokeh/core/test_has_props.py
@@ -60,7 +60,7 @@ class Child(Parent):
 class OverrideChild(Parent):
     int1 = Override(default=20)
 
-def test_HasProps_default_init():
+def test_HasProps_default_init() -> None:
     p = Parent()
     assert p.int1 == 10
     assert p.ds1 == None
@@ -75,7 +75,7 @@ def test_HasProps_default_init():
     assert c.ds2 == None
     assert c.lst2 == [1,2,3]
 
-def test_HasProps_kw_init():
+def test_HasProps_kw_init() -> None:
     p = Parent(int1=30, ds1="foo")
     assert p.int1 == 30
     assert p.ds1 == "foo"
@@ -90,13 +90,13 @@ def test_HasProps_kw_init():
     assert c.ds2 == 10
     assert c.lst2 == [2,3,4]
 
-def test_HasProps_override():
+def test_HasProps_override() -> None:
     ov = OverrideChild()
     assert ov.int1 == 20
     assert ov.ds1 == None
     assert ov.lst1 == []
 
-def test_HasProps_equals():
+def test_HasProps_equals() -> None:
     p1 = Parent()
     p2 = Parent()
     assert p1.equals(p2)
@@ -105,7 +105,7 @@ def test_HasProps_equals():
     p2.int1 = 25
     assert p1.equals(p2)
 
-def test_HasProps_update():
+def test_HasProps_update() -> None:
     c = Child()
     c.update(**dict(lst2=[1,2], str2="baz", int1=25, ds1=dict(field="foo")))
     assert c.int1 == 25
@@ -116,7 +116,7 @@ def test_HasProps_update():
     assert c.ds2 ==  None
     assert c.lst2 == [1,2]
 
-def test_HasProps_set_from_json():
+def test_HasProps_set_from_json() -> None:
     c = Child()
     c.set_from_json('lst2', [1,2])
     assert c.int1 == 10
@@ -146,7 +146,7 @@ def test_HasProps_set_from_json():
     assert c.lst2 == [1,2]
 
 
-def test_HasProps_update_from_json():
+def test_HasProps_update_from_json() -> None:
     c = Child()
     c.update_from_json(dict(lst2=[1,2], str2="baz", int1=25, ds1=dict(field="foo")))
     assert c.int1 == 25
@@ -158,14 +158,14 @@ def test_HasProps_update_from_json():
     assert c.lst2 == [1,2]
 
 @patch('bokeh.core.has_props.HasProps.set_from_json')
-def test_HasProps_update_from_json_passes_models_and_setter(mock_set):
+def test_HasProps_update_from_json_passes_models_and_setter(mock_set) -> None:
     c = Child()
     c.update_from_json(dict(lst1=[1,2]), models="foo", setter="bar")
     assert mock_set.called
     assert mock_set.call_args[0] == ('lst1', [1, 2], 'foo', 'bar')
     assert mock_set.call_args[1] == {}
 
-def test_HasProps_set():
+def test_HasProps_set() -> None:
     c = Child()
     c.update(**dict(lst2=[1,2], str2="baz", int1=25, ds1=dict(field="foo")))
     assert c.int1 == 25
@@ -180,7 +180,7 @@ def test_HasProps_set():
     assert c.str2 == "somesome"
     assert c.str2_proxy == "somesome"
 
-def test_HasProps_set_error():
+def test_HasProps_set_error() -> None:
     c = Child()
     with pytest.raises(AttributeError) as e:
         c.int3 = 10
@@ -190,7 +190,7 @@ def test_HasProps_set_error():
     assert str(e.value).endswith("unexpected attribute 'junkjunk' to Child, possible attributes are ds1, ds2, int1, int2, lst1, lst2 or str2")
 
 
-def test_HasProps_lookup():
+def test_HasProps_lookup() -> None:
     p = Parent()
     d = p.lookup('int1')
     assert isinstance(d, BasicPropertyDescriptor)
@@ -202,7 +202,7 @@ def test_HasProps_lookup():
     assert isinstance(d, BasicPropertyDescriptor)
     assert d.name == 'lst1'
 
-def test_HasProps_apply_theme():
+def test_HasProps_apply_theme() -> None:
     c = Child()
     theme = dict(int2=10, lst1=["foo", "bar"])
     c.apply_theme(theme)
@@ -239,7 +239,7 @@ def test_HasProps_apply_theme():
     assert c.ds2 == "foo"
     assert c.lst2 == [1,2,3]
 
-def test_HasProps_unapply_theme():
+def test_HasProps_unapply_theme() -> None:
     c = Child()
     theme = dict(int2=10, lst1=["foo", "bar"])
     c.apply_theme(theme)
@@ -267,7 +267,7 @@ def test_HasProps_unapply_theme():
 class EitherSimpleDefault(hp.HasProps):
     foo = Either(List(Int), Int, default=10)
 
-def test_HasProps_apply_theme_either_simple():
+def test_HasProps_apply_theme_either_simple() -> None:
 
     # check applying multiple themes
     c = EitherSimpleDefault()
@@ -311,7 +311,7 @@ def test_HasProps_apply_theme_either_simple():
 class EitherContainerDefault(hp.HasProps):
     foo = Either(List(Int), Int, default=[10])
 
-def test_HasProps_apply_theme_either_container():
+def test_HasProps_apply_theme_either_container() -> None:
 
     # check applying multiple themes
     c = EitherContainerDefault()
@@ -355,7 +355,7 @@ def test_HasProps_apply_theme_either_container():
 class IntFuncDefault(hp.HasProps):
     foo = Int(default=lambda: 10)
 
-def test_HasProps_apply_theme_func_default():
+def test_HasProps_apply_theme_func_default() -> None:
 
     # check applying multiple themes
     c = IntFuncDefault()

--- a/tests/unit/bokeh/core/test_json_encoder.py
+++ b/tests/unit/bokeh/core/test_json_encoder.py
@@ -53,58 +53,58 @@ class TestBokehJSONEncoder(object):
         from bokeh.core.json_encoder import BokehJSONEncoder
         self.encoder = BokehJSONEncoder()
 
-    def test_fail(self):
+    def test_fail(self) -> None:
         with pytest.raises(TypeError):
             self.encoder.default({'testing': 1})
 
-    def test_panda_series(self, pd):
+    def test_panda_series(self, pd) -> None:
         s = pd.Series([1, 3, 5, 6, 8])
         assert self.encoder.default(s) == [1, 3, 5, 6, 8]
 
-    def test_numpyarray(self):
+    def test_numpyarray(self) -> None:
         a = np.arange(5)
         assert self.encoder.default(a) == [0, 1, 2, 3, 4]
 
-    def test_numpyint(self):
+    def test_numpyint(self) -> None:
         npint = np.asscalar(np.int64(1))
         assert self.encoder.default(npint) == 1
         assert isinstance(self.encoder.default(npint), int)
 
-    def test_numpyfloat(self):
+    def test_numpyfloat(self) -> None:
         npfloat = np.float64(1.33)
         assert self.encoder.default(npfloat) == 1.33
         assert isinstance(self.encoder.default(npfloat), float)
 
-    def test_numpybool_(self):
+    def test_numpybool_(self) -> None:
         nptrue = np.bool_(True)
         assert self.encoder.default(nptrue) == True
         assert isinstance(self.encoder.default(nptrue), bool)
 
-    def test_numpydatetime64(self):
+    def test_numpydatetime64(self) -> None:
         npdt64 = np.datetime64('2017-01-01')
         assert self.encoder.default(npdt64) == 1483228800000.0
         assert isinstance(self.encoder.default(npdt64), float)
 
-    def test_time(self):
+    def test_time(self) -> None:
         dttime = dt.time(12, 32, 15)
         assert self.encoder.default(dttime) == 45135000.0
         assert isinstance(self.encoder.default(dttime), float)
 
-    def test_relativedelta(self):
+    def test_relativedelta(self) -> None:
         rdelt = rd.relativedelta()
         assert isinstance(self.encoder.default(rdelt), dict)
 
-    def test_decimal(self):
+    def test_decimal(self) -> None:
         dec = decimal.Decimal(20.3)
         assert self.encoder.default(dec) == 20.3
         assert isinstance(self.encoder.default(dec), float)
 
-    def test_model(self):
+    def test_model(self) -> None:
         m = Range1d(start=10, end=20)
         assert self.encoder.default(m) == m.ref
         assert isinstance(self.encoder.default(m), dict)
 
-    def test_hasprops(self):
+    def test_hasprops(self) -> None:
         hp = HP()
         assert self.encoder.default(hp) == {}
         assert isinstance(self.encoder.default(hp), dict)
@@ -117,7 +117,7 @@ class TestBokehJSONEncoder(object):
         assert self.encoder.default(hp) == {'foo': 15, 'bar': 'test'}
         assert isinstance(self.encoder.default(hp), dict)
 
-    def test_color(self):
+    def test_color(self) -> None:
         c = RGB(16, 32, 64)
         assert self.encoder.default(c) == "rgb(16, 32, 64)"
         assert isinstance(self.encoder.default(c), str)
@@ -126,7 +126,7 @@ class TestBokehJSONEncoder(object):
         assert self.encoder.default(c) == "rgba(16, 32, 64, 0.1)"
         assert isinstance(self.encoder.default(c), str)
 
-    def test_slice(self):
+    def test_slice(self) -> None:
         c = slice(2)
         assert self.encoder.default(c) == dict(start=None, stop=2, step=None)
         assert isinstance(self.encoder.default(c), dict)
@@ -147,7 +147,7 @@ class TestBokehJSONEncoder(object):
         assert self.encoder.default(c) == dict(start=None, stop=None, step=None)
         assert isinstance(self.encoder.default(c), dict)
 
-    def test_pd_timestamp(self, pd):
+    def test_pd_timestamp(self, pd) -> None:
         ts = pd.Timestamp('April 28, 1948')
         assert self.encoder.default(ts) == -684115200000
 
@@ -159,21 +159,21 @@ class TestSerializeJson(object):
         self.serialize = serialize_json
         self.deserialize = loads
 
-    def test_with_basic(self):
+    def test_with_basic(self) -> None:
         assert self.serialize({'test': [1, 2, 3]}) == '{"test":[1,2,3]}'
 
-    def test_pretty(self):
+    def test_pretty(self) -> None:
         assert self.serialize({'test': [1, 2, 3]}, pretty=True) == '{\n  "test": [\n    1,\n    2,\n    3\n  ]\n}'
 
-    def test_with_np_array(self):
+    def test_with_np_array(self) -> None:
         a = np.arange(5)
         assert self.serialize(a) == '[0,1,2,3,4]'
 
-    def test_with_pd_series(self, pd):
+    def test_with_pd_series(self, pd) -> None:
         s = pd.Series([0, 1, 2, 3, 4])
         assert self.serialize(s) == '[0,1,2,3,4]'
 
-    def test_nans_and_infs(self):
+    def test_nans_and_infs(self) -> None:
         arr = np.array([np.nan, np.inf, -np.inf, 0])
         serialized = self.serialize(arr)
         deserialized = self.deserialize(serialized)
@@ -182,7 +182,7 @@ class TestSerializeJson(object):
         assert deserialized[2] == '-Infinity'
         assert deserialized[3] == 0
 
-    def test_nans_and_infs_pandas(self, pd):
+    def test_nans_and_infs_pandas(self, pd) -> None:
         arr = pd.Series(np.array([np.nan, np.inf, -np.inf, 0]))
         serialized = self.serialize(arr)
         deserialized = self.deserialize(serialized)
@@ -191,7 +191,7 @@ class TestSerializeJson(object):
         assert deserialized[2] == '-Infinity'
         assert deserialized[3] == 0
 
-    def test_pandas_datetime_types(self, pd):
+    def test_pandas_datetime_types(self, pd) -> None:
         """ should convert to millis """
         idx = pd.date_range('2001-1-1', '2001-1-5')
         df = pd.DataFrame({'vals' :idx}, index=idx)
@@ -211,7 +211,7 @@ class TestSerializeJson(object):
         }
         assert deserialized == baseline
 
-    def test_builtin_datetime_types(self):
+    def test_builtin_datetime_types(self) -> None:
         """ should convert to millis as-is """
 
         DT_EPOCH = dt.datetime.utcfromtimestamp(0)
@@ -232,14 +232,14 @@ class TestSerializeJson(object):
             'a': ['2016-04-28'], 'b': [1461810050000.0]
         }
 
-    def test_builtin_timedelta_types(self):
+    def test_builtin_timedelta_types(self) -> None:
         """ should convert time delta to a dictionary """
         delta = dt.timedelta(days=42, seconds=1138, microseconds=1337)
         serialized = self.serialize(delta)
         deserialized = self.deserialize(serialized)
         assert deserialized == delta.total_seconds() * 1000
 
-    def test_numpy_timedelta_types(self):
+    def test_numpy_timedelta_types(self) -> None:
         delta = np.timedelta64(3000, 'ms')
         serialized = self.serialize(delta)
         deserialized = self.deserialize(serialized)
@@ -250,17 +250,17 @@ class TestSerializeJson(object):
         deserialized = self.deserialize(serialized)
         assert deserialized == 3000000
 
-    def test_pandas_timedelta_types(self, pd):
+    def test_pandas_timedelta_types(self, pd) -> None:
         delta = pd.Timedelta("3000ms")
         serialized = self.serialize(delta)
         deserialized = self.deserialize(serialized)
         assert deserialized == 3000
 
-    def test_deque(self):
+    def test_deque(self) -> None:
         """Test that a deque is deserialized as a list."""
         assert self.serialize(deque([0, 1, 2])) == '[0,1,2]'
 
-    def test_slice(self):
+    def test_slice(self) -> None:
         """Test that a slice is deserialized as a list."""
         assert self.serialize(slice(2)) == '{"start":null,"step":null,"stop":2}'
         assert self.serialize(slice(0, 2)) == '{"start":0,"step":null,"stop":2}'
@@ -268,7 +268,7 @@ class TestSerializeJson(object):
         assert self.serialize(slice(0, None, 2)) == '{"start":0,"step":2,"stop":null}'
         assert self.serialize(slice(None, None, None)) == '{"start":null,"step":null,"stop":null}'
 
-    def test_bad_kwargs(self):
+    def test_bad_kwargs(self) -> None:
         with pytest.raises(ValueError):
             self.serialize([1], allow_nan=True)
         with pytest.raises(ValueError):

--- a/tests/unit/bokeh/core/test_properties.py
+++ b/tests/unit/bokeh/core/test_properties.py
@@ -112,7 +112,7 @@ ALL = (
 
 class Basictest(object):
 
-    def test_simple_class(self):
+    def test_simple_class(self) -> None:
         class Foo(HasProps):
             x = Int(12)
             y = String("hello")
@@ -152,7 +152,7 @@ class Basictest(object):
         without_defaults = f.properties_with_values(include_defaults=False)
         assert dict(x=18, y="bar", z=[100,2,3], zz={'a': 10}) == without_defaults
 
-    def test_enum(self):
+    def test_enum(self) -> None:
         class Foo(HasProps):
             x = Enum("blue", "red", "green")     # the first item is the default
             y = Enum("small", "medium", "large", default="large")
@@ -173,7 +173,7 @@ class Basictest(object):
         with pytest.raises(ValueError):
             f.y = "yellow"
 
-    def test_inheritance(self):
+    def test_inheritance(self) -> None:
         class Base(HasProps):
             x = Int(12)
             y = String("hello")
@@ -185,7 +185,7 @@ class Basictest(object):
         assert frozenset(['x', 'y', 'z']) == frozenset(c.properties())
         assert c.y == "hello"
 
-    def test_set(self):
+    def test_set(self) -> None:
         class Foo(HasProps):
             x = Int(12)
             y = Enum("red", "blue", "green")
@@ -202,7 +202,7 @@ class Basictest(object):
         with pytest.raises(ValueError):
             f.update(y="orange")
 
-    def test_no_parens(self):
+    def test_no_parens(self) -> None:
         class Foo(HasProps):
             x = Int
             y = Int()
@@ -211,7 +211,7 @@ class Basictest(object):
         f.x = 13
         assert f.x == 13
 
-    def test_accurate_properties_sets(self):
+    def test_accurate_properties_sets(self) -> None:
         class Base(HasProps):
             num = Int(12)
             container = List(String)
@@ -259,7 +259,7 @@ class Basictest(object):
         # in a new set every time
         #assert s.properties(with_bases=False) is s.properties(with_bases=False)
 
-    def test_accurate_dataspecs(self):
+    def test_accurate_dataspecs(self) -> None:
         class Base(HasProps):
             num = NumberSpec(12)
             not_a_dataspec = Float(10)
@@ -282,7 +282,7 @@ class Basictest(object):
         assert dict(mixin_num=mixin.lookup("mixin_num")) == mixin.dataspecs_with_props()
         assert dict(num=sub.lookup("num"), mixin_num=sub.lookup("mixin_num"), sub_num=sub.lookup("sub_num")) == sub.dataspecs_with_props()
 
-    def test_not_serialized(self):
+    def test_not_serialized(self) -> None:
         class NotSerialized(HasProps):
             x = Int(12, serialized=False)
             y = String("hello")
@@ -311,7 +311,7 @@ class Basictest(object):
         assert 'x' not in o.properties_with_values(include_defaults=False)
         assert 'y' in o.properties_with_values(include_defaults=False)
 
-    def test_readonly(self):
+    def test_readonly(self) -> None:
         class Readonly(HasProps):
             x = Int(12, readonly=True)    # with default
             y = Int(readonly=True)        # without default
@@ -345,7 +345,7 @@ class Basictest(object):
         assert o.y == None
         assert o.z == 'xyz'
 
-    def test_include_defaults(self):
+    def test_include_defaults(self) -> None:
         class IncludeDefaultsTest(HasProps):
             x = Int(12)
             y = String("hello")
@@ -367,7 +367,7 @@ class Basictest(object):
         assert 'x' in o.properties_with_values(include_defaults=False)
         assert 'y' in o.properties_with_values(include_defaults=False)
 
-    def test_include_defaults_with_kwargs(self):
+    def test_include_defaults_with_kwargs(self) -> None:
         class IncludeDefaultsKwargsTest(HasProps):
             x = Int(12)
             y = String("hello")
@@ -381,7 +381,7 @@ class Basictest(object):
         assert 'x' in o.properties_with_values(include_defaults=False)
         assert 'y' in o.properties_with_values(include_defaults=False)
 
-    def test_include_defaults_set_to_same(self):
+    def test_include_defaults_set_to_same(self) -> None:
         class IncludeDefaultsSetToSameTest(HasProps):
             x = Int(12)
             y = String("hello")
@@ -402,7 +402,7 @@ class Basictest(object):
         assert 'x' not in o.properties_with_values(include_defaults=False)
         assert 'y' not in o.properties_with_values(include_defaults=False)
 
-    def test_override_defaults(self):
+    def test_override_defaults(self) -> None:
         class FooBase(HasProps):
             x = Int(12)
 
@@ -431,7 +431,7 @@ class Basictest(object):
         assert 'x' not in f_sub.properties_with_values(include_defaults=False)
         assert 'x' not in f_sub_sub.properties_with_values(include_defaults=False)
 
-    # def test_kwargs_init(self):
+    # def test_kwargs_init(self) -> None:
     #     class Foo(HasProps):
     #         x = String
     #         y = Int
@@ -453,7 +453,7 @@ class Bar(HasProps):
 class Baz(HasProps):
     pass
 
-def test_HasProps_equals():
+def test_HasProps_equals() -> None:
     class Foo(HasProps):
         x = Int(12)
         y = String("hello")
@@ -479,7 +479,7 @@ def test_HasProps_equals():
     v = Foo().equals(FooUnrelated())
     assert v is False
 
-def test_HasProps_clone():
+def test_HasProps_clone() -> None:
     p1 = Plot(plot_width=1000)
     c1 = p1.properties_with_values(include_defaults=False)
     p2 = p1._clone()

--- a/tests/unit/bokeh/core/test_query.py
+++ b/tests/unit/bokeh/core/test_query.py
@@ -113,14 +113,14 @@ def large_plot():
 
 plot = large_plot()
 
-def test_type():
+def test_type() -> None:
 
     for typ, count in typcases.items():
         res = list(q.find(plot.references(), dict(type=typ)))
         assert len(res) == count
         assert all(isinstance(x, typ) for x in res)
 
-def test_tags_with_scalar():
+def test_tags_with_scalar() -> None:
     cases = {
         11: 1,
         12: 0,
@@ -130,7 +130,7 @@ def test_tags_with_scalar():
         res = list(q.find(plot.references(), dict(tags=tag)))
         assert len(res) == count
 
-def test_tags_with_string():
+def test_tags_with_string() -> None:
     cases = {
         "foo": 2,
         "bar": 1,
@@ -140,7 +140,7 @@ def test_tags_with_string():
         res = list(q.find(plot.references(), dict(tags=tag)))
         assert len(res) == count
 
-def test_tags_with_seq():
+def test_tags_with_seq() -> None:
     cases = {
         "foo": 2,
         "bar": 1,
@@ -153,7 +153,7 @@ def test_tags_with_seq():
     res = list(q.find(plot.references(), dict(tags=list(cases.keys()))))
     assert len(res) == 2
 
-def test_name():
+def test_name() -> None:
     cases = {
         "myline": Line,
         "mycircle": Circle,
@@ -165,7 +165,7 @@ def test_name():
         assert len(res) == 1
         assert all(isinstance(x.glyph, typ) for x in res)
 
-def test_in():
+def test_in() -> None:
     res = list(q.find(plot.references(), dict(name={q.IN: ['a', 'b']})))
     assert len(res) == 0
 
@@ -194,7 +194,7 @@ def test_in():
     res = list(q.find(plot.references(), dict(type={q.IN: list(typcases.keys())})))
     assert len(res) == 17
 
-def test_disjuction():
+def test_disjuction() -> None:
     res = list(
         q.find(plot.references(),
         {q.OR: [dict(type=Axis), dict(type=Grid)]})
@@ -219,7 +219,7 @@ def test_disjuction():
     )
     assert len(res) == 6
 
-def test_conjuction():
+def test_conjuction() -> None:
     res = list(
         q.find(plot.references(), dict(type=Axis, tags="foo"))
     )
@@ -235,7 +235,7 @@ def test_conjuction():
     )
     assert len(res) == 1
 
-def test_ops():
+def test_ops() -> None:
     res = list(
         q.find(plot.references(), {'size': {q.EQ: 5}})
     )
@@ -266,11 +266,11 @@ def test_ops():
     )
     assert len(res) == 0
 
-def test_malformed_exception():
+def test_malformed_exception() -> None:
     with pytest.raises(ValueError):
         q.match(plot, {11: {q.EQ: 5}})
 
-def test_with_context():
+def test_with_context() -> None:
     res = list(
         q.find(plot.references(), {'layout': 'below'}, {'plot': plot})
     )

--- a/tests/unit/bokeh/core/test_templates.py
+++ b/tests/unit/bokeh/core/test_templates.py
@@ -51,7 +51,7 @@ def compute_sha256(data):
 
 pinned_template_sha256 = "882bcee1a8d3a51f6e92680029f5cba119bb0c16e637d196524fa33384bd398f"
 
-def test_autoload_template_has_changed():
+def test_autoload_template_has_changed() -> None:
     """This is not really a test but a reminder that if you change the
     autoload_nb_js.js template then you should make sure that insertion of
     plots into notebooks is working as expected. In particular, this test was

--- a/tests/unit/bokeh/core/test_validation.py
+++ b/tests/unit/bokeh/core/test_validation.py
@@ -39,7 +39,7 @@ import bokeh.core.validation as v # isort:skip
 # Dev API
 #-----------------------------------------------------------------------------
 
-def test_error_decorator_code():
+def test_error_decorator_code() -> None:
     for code in ec:
         @v.error(code)
         def good():
@@ -51,7 +51,7 @@ def test_error_decorator_code():
             return "bad"
         assert bad() == [(code,) + ec[code] + ('bad',)]
 
-def test_warning_decorator_code():
+def test_warning_decorator_code() -> None:
     for code in wc:
         @v.warning(code)
         def good():
@@ -63,7 +63,7 @@ def test_warning_decorator_code():
             return "bad"
         assert bad() == [(code,) + wc[code] + ('bad',)]
 
-def test_error_decorator_custom():
+def test_error_decorator_custom() -> None:
     @v.error("E1")
     def good():
         return None
@@ -74,7 +74,7 @@ def test_error_decorator_custom():
         return "bad"
     assert bad() == [(9999, 'EXT:E2', 'Custom extension reports error', 'bad')]
 
-def test_warning_decorator_custom():
+def test_warning_decorator_custom() -> None:
     @v.warning("W1")
     def good():
         return None
@@ -99,7 +99,7 @@ class Mod(Model):
 
 @patch('bokeh.core.validation.check.log.error')
 @patch('bokeh.core.validation.check.log.warning')
-def test_check_pass(mock_warn, mock_error):
+def test_check_pass(mock_warn, mock_error) -> None:
     m = Mod()
 
     v.check_integrity([m])
@@ -108,7 +108,7 @@ def test_check_pass(mock_warn, mock_error):
 
 @patch('bokeh.core.validation.check.log.error')
 @patch('bokeh.core.validation.check.log.warning')
-def test_check_error(mock_warn, mock_error):
+def test_check_error(mock_warn, mock_error) -> None:
     m = Mod(foo=10)
     v.check_integrity([m])
     assert mock_error.called
@@ -116,7 +116,7 @@ def test_check_error(mock_warn, mock_error):
 
 @patch('bokeh.core.validation.check.log.error')
 @patch('bokeh.core.validation.check.log.warning')
-def test_check_warn(mock_warn, mock_error):
+def test_check_warn(mock_warn, mock_error) -> None:
     m = Mod(foo=-10)
     v.check_integrity([m])
     assert not mock_error.called
@@ -124,7 +124,7 @@ def test_check_warn(mock_warn, mock_error):
 
 @patch('bokeh.core.validation.check.log.error')
 @patch('bokeh.core.validation.check.log.warning')
-def test_silence_and_check_warn(mock_warn, mock_error):
+def test_silence_and_check_warn(mock_warn, mock_error) -> None:
     from bokeh.core.validation.warnings import EXT
     m = Mod(foo=-10)
     try:
@@ -140,7 +140,7 @@ def test_silence_and_check_warn(mock_warn, mock_error):
 
 @patch('bokeh.core.validation.check.log.error')
 @patch('bokeh.core.validation.check.log.warning')
-def test_silence_with_bad_input_and_check_warn(mock_warn, mock_error):
+def test_silence_with_bad_input_and_check_warn(mock_warn, mock_error) -> None:
     m = Mod(foo=-10)
     with pytest.raises(ValueError, match=('Input to silence should be a '
                                           'warning object')):
@@ -151,7 +151,7 @@ def test_silence_with_bad_input_and_check_warn(mock_warn, mock_error):
 
 @patch('bokeh.core.validation.check.log.error')
 @patch('bokeh.core.validation.check.log.warning')
-def test_silence_warning_already_in_silencers_is_ok(mock_warn, mock_error):
+def test_silence_warning_already_in_silencers_is_ok(mock_warn, mock_error) -> None:
     from bokeh.core.validation.warnings import EXT
     m = Mod(foo=-10)
     try:
@@ -171,7 +171,7 @@ def test_silence_warning_already_in_silencers_is_ok(mock_warn, mock_error):
 
 @patch('bokeh.core.validation.check.log.error')
 @patch('bokeh.core.validation.check.log.warning')
-def test_silence_remove_warning_that_is_not_in_silencers_is_ok(mock_warn, mock_error):
+def test_silence_remove_warning_that_is_not_in_silencers_is_ok(mock_warn, mock_error) -> None:
     from bokeh.core.validation.warnings import EXT
     m = Mod(foo=-10)
 

--- a/tests/unit/bokeh/document/test_document.py
+++ b/tests/unit/bokeh/document/test_document.py
@@ -59,7 +59,7 @@ class TestDocumentHold(object):
 
     @pytest.mark.parametrize('policy', document.HoldPolicy)
     @pytest.mark.unit
-    def test_hold(self, policy):
+    def test_hold(self, policy) -> None:
         d = document.Document()
         assert d._hold == None
         assert d._held_events == []
@@ -67,14 +67,14 @@ class TestDocumentHold(object):
         d.hold(policy)
         assert d._hold == policy
 
-    def test_hold_bad_policy(self):
+    def test_hold_bad_policy(self) -> None:
         d = document.Document()
         with pytest.raises(ValueError):
             d.hold("junk")
 
     @pytest.mark.parametrize('first,second', [('combine', 'collect'), ('collect', 'combine')])
     @pytest.mark.unit
-    def test_rehold(self, first, second, caplog):
+    def test_rehold(self, first, second, caplog) -> None:
         d = document.Document()
         with caplog.at_level(logging.WARN):
             d.hold(first)
@@ -96,7 +96,7 @@ class TestDocumentHold(object):
 
     @pytest.mark.parametrize('policy', document.HoldPolicy)
     @pytest.mark.unit
-    def test_unhold(self, policy):
+    def test_unhold(self, policy) -> None:
         d = document.Document()
         assert d._hold == None
         assert d._held_events == []
@@ -107,7 +107,7 @@ class TestDocumentHold(object):
         assert d._hold == None
 
     @patch("bokeh.document.document.Document._trigger_on_change")
-    def test_unhold_triggers_events(self, mock_trigger):
+    def test_unhold_triggers_events(self, mock_trigger) -> None:
         d = document.Document()
         d.hold('collect')
         d._held_events = [1,2,3]
@@ -120,7 +120,7 @@ extra = []
 
 class Test_Document_delete_modules(object):
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         d = document.Document()
         assert not d.roots
         class FakeMod(object):
@@ -135,7 +135,7 @@ class Test_Document_delete_modules(object):
         assert 'junkjunkjunk' not in sys.modules
         assert d._modules is None
 
-    def test_extra_referrer_error(self, caplog):
+    def test_extra_referrer_error(self, caplog) -> None:
         d = document.Document()
         assert not d.roots
         class FakeMod(object):
@@ -164,23 +164,23 @@ class Test_Document_delete_modules(object):
 
 class TestDocument(object):
 
-    def test_empty(self):
+    def test_empty(self) -> None:
         d = document.Document()
         assert not d.roots
 
-    def test_default_template_vars(self):
+    def test_default_template_vars(self) -> None:
         d = document.Document()
         assert not d.roots
         assert d.template_variables == {}
 
-    def test_add_roots(self):
+    def test_add_roots(self) -> None:
         d = document.Document()
         assert not d.roots
         d.add_root(AnotherModelInTestDocument())
         assert len(d.roots) == 1
         assert next(iter(d.roots)).document == d
 
-    def test_roots_preserves_insertion_order(self):
+    def test_roots_preserves_insertion_order(self) -> None:
         d = document.Document()
         assert not d.roots
         roots = [
@@ -197,13 +197,13 @@ class TestDocument(object):
         assert next(roots_iter) is roots[1]
         assert next(roots_iter) is roots[2]
 
-    def test_set_title(self):
+    def test_set_title(self) -> None:
         d = document.Document()
         assert d.title == document.DEFAULT_TITLE
         d.title = "Foo"
         assert d.title == "Foo"
 
-    def test_all_models(self):
+    def test_all_models(self) -> None:
         d = document.Document()
         assert not d.roots
         assert len(d._all_models) == 0
@@ -220,7 +220,7 @@ class TestDocument(object):
         d.remove_root(m)
         assert len(d._all_models) == 0
 
-    def test_get_model_by_id(self):
+    def test_get_model_by_id(self) -> None:
         d = document.Document()
         assert not d.roots
         assert len(d._all_models) == 0
@@ -234,7 +234,7 @@ class TestDocument(object):
         assert d.get_model_by_id(m2.id) == m2
         assert d.get_model_by_id("not a valid ID") is None
 
-    def test_get_model_by_name(self):
+    def test_get_model_by_name(self) -> None:
         d = document.Document()
         assert not d.roots
         assert len(d._all_models) == 0
@@ -249,7 +249,7 @@ class TestDocument(object):
         assert d.get_model_by_name(m2.name) == m2
         assert d.get_model_by_name("not a valid name") is None
 
-    def test_get_model_by_changed_name(self):
+    def test_get_model_by_changed_name(self) -> None:
         d = document.Document()
         m = SomeModelInTestDocument(name="foo")
         d.add_root(m)
@@ -258,7 +258,7 @@ class TestDocument(object):
         assert d.get_model_by_name("foo") == None
         assert d.get_model_by_name("bar") == m
 
-    def test_get_model_by_changed_from_none_name(self):
+    def test_get_model_by_changed_from_none_name(self) -> None:
         d = document.Document()
         m = SomeModelInTestDocument(name=None)
         d.add_root(m)
@@ -266,7 +266,7 @@ class TestDocument(object):
         m.name = "bar"
         assert d.get_model_by_name("bar") == m
 
-    def test_get_model_by_changed_to_none_name(self):
+    def test_get_model_by_changed_to_none_name(self) -> None:
         d = document.Document()
         m = SomeModelInTestDocument(name="bar")
         d.add_root(m)
@@ -274,7 +274,7 @@ class TestDocument(object):
         m.name = None
         assert d.get_model_by_name("bar") == None
 
-    def test_can_get_name_overriding_model_by_name(self):
+    def test_can_get_name_overriding_model_by_name(self) -> None:
         d = document.Document()
         m = ModelThatOverridesName(name="foo")
         d.add_root(m)
@@ -282,7 +282,7 @@ class TestDocument(object):
         m.name = "bar"
         assert d.get_model_by_name("bar") == m
 
-    def test_cannot_get_model_with_duplicate_name(self):
+    def test_cannot_get_model_with_duplicate_name(self) -> None:
         d = document.Document()
         m = SomeModelInTestDocument(name="foo")
         m2 = SomeModelInTestDocument(name="foo")
@@ -298,7 +298,7 @@ class TestDocument(object):
         d.remove_root(m)
         assert d.get_model_by_name("foo") == m2
 
-    def test_select(self):
+    def test_select(self) -> None:
         # we aren't trying to replace test_query here, only test
         # our wrappers around it, so no need to try every kind of
         # query
@@ -348,7 +348,7 @@ class TestDocument(object):
         assert set([child3, root3]) == set(d.select(dict(foo=57)))
         assert set([child3, root3]) == set(root3.select(dict(foo=57)))
 
-    def test_is_single_string_selector(self):
+    def test_is_single_string_selector(self) -> None:
         d = document.Document()
         # this is an implementation detail but just ensuring it works
         assert d._is_single_string_selector(dict(foo='c'), 'foo')
@@ -356,7 +356,7 @@ class TestDocument(object):
         assert not d._is_single_string_selector(dict(foo='c', bar='d'), 'foo')
         assert not d._is_single_string_selector(dict(foo=42), 'foo')
 
-    def test_all_models_with_multiple_references(self):
+    def test_all_models_with_multiple_references(self) -> None:
         d = document.Document()
         assert not d.roots
         assert len(d._all_models) == 0
@@ -382,7 +382,7 @@ class TestDocument(object):
         d.remove_root(root2)
         assert len(d._all_models) == 0
 
-    def test_all_models_with_cycles(self):
+    def test_all_models_with_cycles(self) -> None:
         d = document.Document()
         assert not d.roots
         assert len(d._all_models) == 0
@@ -415,7 +415,7 @@ class TestDocument(object):
         d.remove_root(root2)
         assert len(d._all_models) == 0
 
-    def test_change_notification(self):
+    def test_change_notification(self) -> None:
         d = document.Document()
         assert not d.roots
         m = AnotherModelInTestDocument()
@@ -441,7 +441,7 @@ class TestDocument(object):
         assert len(curdoc_from_listener) == 1
         assert curdoc_from_listener[0] is d
 
-    def test_stream_notification(self):
+    def test_stream_notification(self) -> None:
         d = document.Document()
         assert not d.roots
         m = ColumnDataSource(data=dict(a=[10], b=[20]))
@@ -471,7 +471,7 @@ class TestDocument(object):
         assert len(curdoc_from_listener) == 1
         assert curdoc_from_listener[0] is d
 
-    def test_patch_notification(self):
+    def test_patch_notification(self) -> None:
         d = document.Document()
         assert not d.roots
         m = ColumnDataSource(data=dict(a=[10,11], b=[20,21]))
@@ -501,7 +501,7 @@ class TestDocument(object):
         assert curdoc_from_listener[0] is d
 
 
-    def test_change_notification_removal(self):
+    def test_change_notification_removal(self) -> None:
         d = document.Document()
         assert not d.roots
         m = AnotherModelInTestDocument()
@@ -519,7 +519,7 @@ class TestDocument(object):
         m.bar = 43
         assert len(events) == 1
 
-    def test_notification_of_roots(self):
+    def test_notification_of_roots(self) -> None:
         d = document.Document()
         assert not d.roots
 
@@ -553,7 +553,7 @@ class TestDocument(object):
         assert isinstance(events[3], RootRemovedEvent)
         assert events[3].model == m2
 
-    def test_notification_of_title(self):
+    def test_notification_of_title(self) -> None:
         d = document.Document()
         assert not d.roots
         assert d.title == document.DEFAULT_TITLE
@@ -570,7 +570,7 @@ class TestDocument(object):
         assert events[0].document is d
         assert events[0].title == "Foo"
 
-    def test_add_remove_periodic_callback(self):
+    def test_add_remove_periodic_callback(self) -> None:
         d = document.Document()
 
         events = []
@@ -595,7 +595,7 @@ class TestDocument(object):
         assert isinstance(events[0], SessionCallbackAdded)
         assert isinstance(events[1], SessionCallbackRemoved)
 
-    def test_add_remove_timeout_callback(self):
+    def test_add_remove_timeout_callback(self) -> None:
         d = document.Document()
 
         events = []
@@ -620,7 +620,7 @@ class TestDocument(object):
         assert isinstance(events[0], SessionCallbackAdded)
         assert isinstance(events[1], SessionCallbackRemoved)
 
-    def test_add_partial_callback(self):
+    def test_add_partial_callback(self) -> None:
         from functools import partial
         d = document.Document()
 
@@ -641,7 +641,7 @@ class TestDocument(object):
         assert callback_obj == d.session_callbacks[0] == events[0].callback
         assert callback_obj.timeout == 1
 
-    def test_add_remove_next_tick_callback(self):
+    def test_add_remove_next_tick_callback(self) -> None:
         d = document.Document()
 
         events = []
@@ -665,7 +665,7 @@ class TestDocument(object):
         assert isinstance(events[0], SessionCallbackAdded)
         assert isinstance(events[1], SessionCallbackRemoved)
 
-    def test_periodic_callback_gets_curdoc(self):
+    def test_periodic_callback_gets_curdoc(self) -> None:
         d = document.Document()
         assert curdoc() is not d
         curdoc_from_cb = []
@@ -676,7 +676,7 @@ class TestDocument(object):
         assert len(curdoc_from_cb) == 1
         assert curdoc_from_cb[0] is d
 
-    def test_timeout_callback_gets_curdoc(self):
+    def test_timeout_callback_gets_curdoc(self) -> None:
         d = document.Document()
         assert curdoc() is not d
         curdoc_from_cb = []
@@ -687,7 +687,7 @@ class TestDocument(object):
         assert len(curdoc_from_cb) == 1
         assert curdoc_from_cb[0] is d
 
-    def test_next_tick_callback_gets_curdoc(self):
+    def test_next_tick_callback_gets_curdoc(self) -> None:
         d = document.Document()
         assert curdoc() is not d
         curdoc_from_cb = []
@@ -698,7 +698,7 @@ class TestDocument(object):
         assert len(curdoc_from_cb) == 1
         assert curdoc_from_cb[0] is d
 
-    def test_model_callback_gets_curdoc(self):
+    def test_model_callback_gets_curdoc(self) -> None:
         d = document.Document()
         m = AnotherModelInTestDocument(bar=42)
         d.add_root(m)
@@ -711,7 +711,7 @@ class TestDocument(object):
         assert len(curdoc_from_cb) == 1
         assert curdoc_from_cb[0] is d
 
-    def test_clear(self):
+    def test_clear(self) -> None:
         d = document.Document()
         assert not d.roots
         assert d.title == document.DEFAULT_TITLE
@@ -725,7 +725,7 @@ class TestDocument(object):
         assert not d._all_models
         assert d.title == "Foo" # do not reset title
 
-    def test_serialization_one_model(self):
+    def test_serialization_one_model(self) -> None:
         d = document.Document()
         assert not d.roots
         assert len(d._all_models) == 0
@@ -739,7 +739,7 @@ class TestDocument(object):
         assert len(copy.roots) == 1
         assert copy.title == "Foo"
 
-    def test_serialization_more_models(self):
+    def test_serialization_more_models(self) -> None:
         d = document.Document()
         assert not d.roots
         assert len(d._all_models) == 0
@@ -765,13 +765,13 @@ class TestDocument(object):
         some_root = next(iter(copy.roots))
         assert some_root.child.foo == 44
 
-    def test_serialization_has_version(self):
+    def test_serialization_has_version(self) -> None:
         from bokeh import __version__
         d = document.Document()
         json = d.to_json()
         assert json['version'] == __version__
 
-    def test_patch_integer_property(self):
+    def test_patch_integer_property(self) -> None:
         d = document.Document()
         assert not d.roots
         assert len(d._all_models) == 0
@@ -796,7 +796,7 @@ class TestDocument(object):
 
         assert child1.foo == 67
 
-    def test_patch_spec_property(self):
+    def test_patch_spec_property(self) -> None:
         d = document.Document()
         assert not d.roots
         assert len(d._all_models) == 0
@@ -849,7 +849,7 @@ class TestDocument(object):
         patch_test(71)
         assert 'screen' == root1.foo_units
 
-    def test_patch_reference_property(self):
+    def test_patch_reference_property(self) -> None:
         d = document.Document()
         assert not d.roots
         assert len(d._all_models) == 0
@@ -890,7 +890,7 @@ class TestDocument(object):
         assert child2.id not in d._all_models
         assert child3.id not in d._all_models
 
-    def test_patch_two_properties_at_once(self):
+    def test_patch_two_properties_at_once(self) -> None:
         d = document.Document()
         assert not d.roots
         assert len(d._all_models) == 0
@@ -914,7 +914,7 @@ class TestDocument(object):
         assert root1.child.foo == 44
 
     # a more realistic set of models instead of fake models
-    def test_scatter(self):
+    def test_scatter(self) -> None:
         from bokeh.io.doc import set_curdoc
         from bokeh.plotting import figure
         import numpy as np
@@ -931,7 +931,7 @@ class TestDocument(object):
         d.add_root(p1)
         assert len(d.roots) == 1
 
-    def test_event_handles_new_callbacks_in_event_callback(self):
+    def test_event_handles_new_callbacks_in_event_callback(self) -> None:
         from bokeh.models import Button
         d = document.Document()
         button1 = Button(label="1")

--- a/tests/unit/bokeh/document/test_events__document.py
+++ b/tests/unit/bokeh/document/test_events__document.py
@@ -53,7 +53,7 @@ class FakeModel(object):
 
 class TestDocumentChangedEvent(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         e = bde.DocumentChangedEvent("doc")
         assert e.document == "doc"
         assert e.setter == None
@@ -74,14 +74,14 @@ class TestDocumentChangedEvent(object):
         assert e.setter == "setter"
         assert e.callback_invoker == "invoker"
 
-    def test_dispatch(self):
+    def test_dispatch(self) -> None:
         e = bde.DocumentChangedEvent("doc", "setter", "invoker")
         e.dispatch(FakeEmptyDispatcher())
         d = FakeFullDispatcher()
         e.dispatch(d)
         assert d.called == ['_document_changed']
 
-    def test_combine_ignores_all(self):
+    def test_combine_ignores_all(self) -> None:
         e = bde.DocumentChangedEvent("doc", "setter", "invoker")
         e2 = bde.DocumentChangedEvent("doc", "setter", "invoker")
         assert e.combine(e2) == False
@@ -90,25 +90,25 @@ class TestDocumentChangedEvent(object):
 
 class TestDocumentPatchedEvent(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         e = bde.DocumentPatchedEvent("doc", "setter", "invoker")
         assert e.document == "doc"
         assert e.setter == "setter"
         assert e.callback_invoker == "invoker"
 
-    def test_generate(self):
+    def test_generate(self) -> None:
         e = bde.DocumentPatchedEvent("doc", "setter", "invoker")
         with pytest.raises(NotImplementedError):
             e.generate("refs", "bufs")
 
-    def test_dispatch(self):
+    def test_dispatch(self) -> None:
         e = bde.DocumentPatchedEvent("doc", "setter", "invoker")
         e.dispatch(FakeEmptyDispatcher())
         d = FakeFullDispatcher()
         e.dispatch(d)
         assert d.called == ['_document_changed', '_document_patched']
 
-    def test_combine_ignores_all(self):
+    def test_combine_ignores_all(self) -> None:
         e = bde.DocumentPatchedEvent("doc", "setter", "invoker")
         e2 = bde.DocumentPatchedEvent("doc", "setter", "invoker")
         assert e.combine(e2) == False
@@ -117,7 +117,7 @@ class TestDocumentPatchedEvent(object):
 
 class TestModelChangedEvent(object):
 
-    def test_init_defaults(self):
+    def test_init_defaults(self) -> None:
         e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew")
         assert e.document == "doc"
         assert e.setter == None
@@ -130,7 +130,7 @@ class TestModelChangedEvent(object):
         assert e.hint == None
         assert e.callback_invoker == None
 
-    def test_init_ignores_hint_with_setter(self):
+    def test_init_ignores_hint_with_setter(self) -> None:
         e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew", setter="setter", hint="hint", callback_invoker="invoker")
         assert e.document == "doc"
         assert e.setter == "setter"
@@ -143,7 +143,7 @@ class TestModelChangedEvent(object):
         assert e.hint == "hint"
         assert e.callback_invoker == "invoker"
 
-    def test_init_uses_hint_with_no_setter(self):
+    def test_init_uses_hint_with_no_setter(self) -> None:
         e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew", hint="hint", callback_invoker="invoker")
         assert e.document == "doc"
         assert e.setter == None
@@ -158,39 +158,39 @@ class TestModelChangedEvent(object):
 
     # TODO (bev) tests for generate
 
-    def test_dispatch(self):
+    def test_dispatch(self) -> None:
         e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew")
         e.dispatch(FakeEmptyDispatcher())
         d = FakeFullDispatcher()
         e.dispatch(d)
         assert d.called == ['_document_changed', '_document_patched', '_document_model_changed']
 
-    def test_combine_ignores_except_title_changd_event(self):
+    def test_combine_ignores_except_title_changd_event(self) -> None:
         e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew")
         e2 = bde.DocumentPatchedEvent("doc", "setter", "invoker")
         assert e.combine(e2) == False
 
-    def test_combine_ignores_different_setter(self):
+    def test_combine_ignores_different_setter(self) -> None:
         e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew", None, "setter")
         e2  = bde.ModelChangedEvent("doc", "model", "attr", "old2", "new2", "snew2", None, "setter2")
         assert e.combine(e2) == False
 
-    def test_combine_ignores_different_doc(self):
+    def test_combine_ignores_different_doc(self) -> None:
         e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew")
         e2 = bde.ModelChangedEvent("doc2", "model", "attr", "old2", "new2", "snew2")
         assert e.combine(e2) == False
 
-    def test_combine_ignores_different_model(self):
+    def test_combine_ignores_different_model(self) -> None:
         e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew")
         e2 = bde.ModelChangedEvent("doc", "model2", "attr", "old2", "new2", "snew2")
         assert e.combine(e2) == False
 
-    def test_combine_ignores_different_attr(self):
+    def test_combine_ignores_different_attr(self) -> None:
         e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew")
         e2 = bde.ModelChangedEvent("doc", "model", "attr2", "old2", "new2", "snew2")
         assert e.combine(e2) == False
 
-    def test_combine_with_matching_model_changed_event(self):
+    def test_combine_with_matching_model_changed_event(self) -> None:
         e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew", callback_invoker="invoker")
         e2 = bde.ModelChangedEvent("doc", "model", "attr", "old2", "new2", "snew2", callback_invoker="invoker2")
         assert e.combine(e2) == True
@@ -200,7 +200,7 @@ class TestModelChangedEvent(object):
         assert e.callback_invoker == "invoker2"
 
     @patch("bokeh.document.events.ColumnsStreamedEvent.combine")
-    def test_combine_with_hint_defers(self, mock_combine):
+    def test_combine_with_hint_defers(self, mock_combine) -> None:
         mock_combine.return_value = False
         m = FakeModel()
         h = bde.ColumnsStreamedEvent("doc", m, dict(foo=1), 200, "setter", "invoker")
@@ -216,7 +216,7 @@ class TestModelChangedEvent(object):
 
 class TestColumnDataChangedEvent(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         m = FakeModel()
         e = bde.ColumnDataChangedEvent("doc", m, [1,2], "setter", "invoker")
         assert e.document == "doc"
@@ -226,7 +226,7 @@ class TestColumnDataChangedEvent(object):
         assert e.callback_invoker == "invoker"
 
     @patch("bokeh.util.serialization.transform_column_source_data")
-    def test_generate(self, mock_tcds):
+    def test_generate(self, mock_tcds) -> None:
         mock_tcds.return_value = "new"
         m = FakeModel()
         e = bde.ColumnDataChangedEvent("doc", m, [1,2], "setter", "invoker")
@@ -237,7 +237,7 @@ class TestColumnDataChangedEvent(object):
         assert refs == dict(foo=10)
         assert bufs == set()
 
-    def test_dispatch(self):
+    def test_dispatch(self) -> None:
         m = FakeModel()
         e = bde.ColumnDataChangedEvent("doc", m, [1,2], "setter", "invoker")
         e.dispatch(FakeEmptyDispatcher())
@@ -245,7 +245,7 @@ class TestColumnDataChangedEvent(object):
         e.dispatch(d)
         assert d.called == ['_document_changed', '_document_patched', '_column_data_changed']
 
-    def test_combine_ignores_all(self):
+    def test_combine_ignores_all(self) -> None:
         m = FakeModel()
         e = bde.ColumnDataChangedEvent("doc", m, [1,2], "setter", "invoker")
         e2 = bde.ColumnDataChangedEvent("doc", m, [3,4], "setter", "invoker")
@@ -256,7 +256,7 @@ class TestColumnDataChangedEvent(object):
 
 class TestColumnsStreamedEvent(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         m = FakeModel()
         e = bde.ColumnsStreamedEvent("doc", m, dict(foo=1), 200, "setter", "invoker")
         assert e.document == "doc"
@@ -266,7 +266,7 @@ class TestColumnsStreamedEvent(object):
         assert e.setter == "setter"
         assert e.callback_invoker == "invoker"
 
-    def test_generate(self):
+    def test_generate(self) -> None:
         m = FakeModel()
         e = bde.ColumnsStreamedEvent("doc", m, dict(foo=1), 200, "setter", "invoker")
         refs = dict(foo=10)
@@ -276,7 +276,7 @@ class TestColumnsStreamedEvent(object):
         assert refs == dict(foo=10)
         assert bufs == set()
 
-    def test_dispatch(self):
+    def test_dispatch(self) -> None:
         m = FakeModel()
         e = bde.ColumnsStreamedEvent("doc", m, dict(foo=1), 200, "setter", "invoker")
         e.dispatch(FakeEmptyDispatcher())
@@ -284,7 +284,7 @@ class TestColumnsStreamedEvent(object):
         e.dispatch(d)
         assert d.called == ['_document_changed', '_document_patched', '_columns_streamed']
 
-    def test_combine_ignores_all(self):
+    def test_combine_ignores_all(self) -> None:
         m = FakeModel()
         e = bde.ColumnsStreamedEvent("doc", m, dict(foo=1), 200, "setter", "invoker")
         e2 = bde.ColumnsStreamedEvent("doc", m, dict(foo=2), 300, "setter", "invoker")
@@ -293,7 +293,7 @@ class TestColumnsStreamedEvent(object):
         assert e.data == dict(foo=1)
         assert e.rollover == 200
 
-    def test_pandas_data(self, pd):
+    def test_pandas_data(self, pd) -> None:
         m = FakeModel()
         df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
         e = bde.ColumnsStreamedEvent("doc", m, df, 200, "setter", "invoker")
@@ -304,7 +304,7 @@ class TestColumnsStreamedEvent(object):
 
 class TestColumnsPatchedEvent(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         m = FakeModel()
         e = bde.ColumnsPatchedEvent("doc", m, [1, 2], "setter", "invoker")
         assert e.document == "doc"
@@ -313,7 +313,7 @@ class TestColumnsPatchedEvent(object):
         assert e.setter == "setter"
         assert e.callback_invoker == "invoker"
 
-    def test_generate(self):
+    def test_generate(self) -> None:
         m = FakeModel()
         e = bde.ColumnsPatchedEvent("doc", m, [1, 2], "setter", "invoker")
         refs = dict(foo=10)
@@ -323,7 +323,7 @@ class TestColumnsPatchedEvent(object):
         assert refs == dict(foo=10)
         assert bufs == set()
 
-    def test_dispatch(self):
+    def test_dispatch(self) -> None:
         m = FakeModel()
         e = bde.ColumnsPatchedEvent("doc", m, [1, 2], "setter", "invoker")
         e.dispatch(FakeEmptyDispatcher())
@@ -331,7 +331,7 @@ class TestColumnsPatchedEvent(object):
         e.dispatch(d)
         assert d.called == ['_document_changed', '_document_patched', '_columns_patched']
 
-    def test_combine_ignores_all(self):
+    def test_combine_ignores_all(self) -> None:
         m = FakeModel()
         e = bde.ColumnsPatchedEvent("doc", m, [1,2], "setter", "invoker")
         e2 = bde.ColumnsPatchedEvent("doc", m, [3,4], "setter", "invoker")
@@ -342,14 +342,14 @@ class TestColumnsPatchedEvent(object):
 
 class TestTitleChangedEvent(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         e = bde.TitleChangedEvent("doc", "title", "setter", "invoker")
         assert e.document == "doc"
         assert e.title == "title"
         assert e.setter == "setter"
         assert e.callback_invoker == "invoker"
 
-    def test_generate(self):
+    def test_generate(self) -> None:
         e = bde.TitleChangedEvent("doc", "title", "setter", "invoker")
         refs = dict(foo=10)
         bufs = set()
@@ -358,35 +358,35 @@ class TestTitleChangedEvent(object):
         assert refs == dict(foo=10)
         assert bufs == set()
 
-    def test_dispatch(self):
+    def test_dispatch(self) -> None:
         e = bde.TitleChangedEvent("doc", "title", "setter", "invoker")
         e.dispatch(FakeEmptyDispatcher())
         d = FakeFullDispatcher()
         e.dispatch(d)
         assert d.called == ['_document_changed', '_document_patched']
 
-    def test_combine_ignores_except_title_changd_event(self):
+    def test_combine_ignores_except_title_changd_event(self) -> None:
         e = bde.TitleChangedEvent("doc", "title", "setter", "invoker")
         e2 = bde.DocumentPatchedEvent("doc", "setter", "invoker")
         assert e.combine(e2) == False
         assert e.title == "title"
         assert e.callback_invoker == "invoker"
 
-    def test_combine_ignores_different_setter(self):
+    def test_combine_ignores_different_setter(self) -> None:
         e = bde.TitleChangedEvent("doc", "title", "setter", "invoker")
         e2 = bde.TitleChangedEvent("doc", "title2", "setter2", "invoker2")
         assert e.combine(e2) == False
         assert e.title == "title"
         assert e.callback_invoker == "invoker"
 
-    def test_combine_ignores_different_doc(self):
+    def test_combine_ignores_different_doc(self) -> None:
         e = bde.TitleChangedEvent("doc", "title", "setter", "invoker")
         e2 = bde.TitleChangedEvent("doc2", "title2", "setter2", "invoker2")
         assert e.combine(e2) == False
         assert e.title == "title"
         assert e.callback_invoker == "invoker"
 
-    def test_combine_with_title_changed_event(self):
+    def test_combine_with_title_changed_event(self) -> None:
         e = bde.TitleChangedEvent("doc", "title", "setter", "invoker")
         e2 = bde.TitleChangedEvent("doc", "title2", "setter", "invoker2")
         assert e.combine(e2) == True
@@ -397,7 +397,7 @@ class TestTitleChangedEvent(object):
 
 class TestRootAddedEvent(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         m = FakeModel()
         e = bde.RootAddedEvent("doc", m, "setter", "invoker")
         assert e.document == "doc"
@@ -405,7 +405,7 @@ class TestRootAddedEvent(object):
         assert e.setter == "setter"
         assert e.callback_invoker == "invoker"
 
-    def test_generate(self):
+    def test_generate(self) -> None:
         m = FakeModel()
         e = bde.RootAddedEvent("doc", m, "setter", "invoker")
         refs = dict(foo=10)
@@ -415,7 +415,7 @@ class TestRootAddedEvent(object):
         assert refs == dict(foo=10, ref1=1, ref2=2)
         assert bufs == set()
 
-    def test_dispatch(self):
+    def test_dispatch(self) -> None:
         m = FakeModel()
         e = bde.RootAddedEvent("doc", m, "setter", "invoker")
         e.dispatch(FakeEmptyDispatcher())
@@ -427,7 +427,7 @@ class TestRootAddedEvent(object):
 
 class TestRootRemovedEvent(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         m = FakeModel()
         e = bde.RootRemovedEvent("doc", m, "setter", "invoker")
         assert e.document == "doc"
@@ -435,7 +435,7 @@ class TestRootRemovedEvent(object):
         assert e.setter == "setter"
         assert e.callback_invoker == "invoker"
 
-    def test_generate(self):
+    def test_generate(self) -> None:
         m = FakeModel()
         e = bde.RootRemovedEvent("doc", m, "setter", "invoker")
         refs = dict(foo=10)
@@ -445,7 +445,7 @@ class TestRootRemovedEvent(object):
         assert refs == dict(foo=10)
         assert bufs == set()
 
-    def test_dispatch(self):
+    def test_dispatch(self) -> None:
         m = FakeModel()
         e = bde.RootRemovedEvent("doc", m, "setter", "invoker")
         e.dispatch(FakeEmptyDispatcher())
@@ -457,21 +457,21 @@ class TestRootRemovedEvent(object):
 
 class TestSessionCallbackAdded(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         e = bde.SessionCallbackAdded("doc", "callback")
         assert e.document == "doc"
         assert e.callback == "callback"
         assert e.setter == None
         assert e.callback_invoker == None
 
-    def test_dispatch(self):
+    def test_dispatch(self) -> None:
         e = bde.SessionCallbackAdded("doc", "callback")
         e.dispatch(FakeEmptyDispatcher())
         d = FakeFullDispatcher()
         e.dispatch(d)
         assert d.called == ['_document_changed', '_session_callback_added']
 
-    def test_combine_ignores_all(self):
+    def test_combine_ignores_all(self) -> None:
         e = bde.SessionCallbackAdded("doc", "setter")
         e2 = bde.SessionCallbackAdded("doc", "setter")
         assert e.combine(e2) == False
@@ -480,21 +480,21 @@ class TestSessionCallbackAdded(object):
 
 class TestSessionCallbackRemoved(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         e = bde.SessionCallbackRemoved("doc", "callback")
         assert e.document == "doc"
         assert e.callback == "callback"
         assert e.setter == None
         assert e.callback_invoker == None
 
-    def test_dispatch(self):
+    def test_dispatch(self) -> None:
         e = bde.SessionCallbackRemoved("doc", "callback")
         e.dispatch(FakeEmptyDispatcher())
         d = FakeFullDispatcher()
         e.dispatch(d)
         assert d.called == ['_document_changed', '_session_callback_removed']
 
-    def test_combine_ignores_all(self):
+    def test_combine_ignores_all(self) -> None:
         e = bde.SessionCallbackAdded("doc", "setter")
         e2 = bde.SessionCallbackAdded("doc", "setter")
         assert e.combine(e2) == False

--- a/tests/unit/bokeh/document/test_locking.py
+++ b/tests/unit/bokeh/document/test_locking.py
@@ -28,7 +28,7 @@ import bokeh.document.locking as locking # isort:skip
 # General API
 #-----------------------------------------------------------------------------
 
-def test_next_tick_callback_works():
+def test_next_tick_callback_works() -> None:
     d = locking.UnlockedDocumentProxy(Document())
     assert curdoc() is not d
     curdoc_from_cb = []
@@ -42,7 +42,7 @@ def test_next_tick_callback_works():
     callback_obj = d.add_next_tick_callback(cb2)
     d.remove_next_tick_callback(callback_obj)
 
-def test_other_attrs_raise():
+def test_other_attrs_raise() -> None:
     d = locking.UnlockedDocumentProxy(Document())
     assert curdoc() is not d
     for attr in (set(dir(d._doc)) - set(dir(d))) | {'foo'}:
@@ -50,7 +50,7 @@ def test_other_attrs_raise():
             getattr(d, attr)
         assert e.value.args[0] == locking.UNSAFE_DOC_ATTR_USAGE_MSG
 
-def test_without_document_lock():
+def test_without_document_lock() -> None:
     d = Document()
     assert curdoc() is not d
     curdoc_from_cb = []

--- a/tests/unit/bokeh/embed/test_bundle.py
+++ b/tests/unit/bokeh/embed/test_bundle.py
@@ -29,27 +29,27 @@ import bokeh.embed.bundle as beb # isort:skip
 #-----------------------------------------------------------------------------
 
 @pytest.fixture
-def test_plot():
+def test_plot() -> None:
     from bokeh.plotting import figure
     test_plot = figure()
     test_plot.circle([1, 2], [2, 3])
     return test_plot
 
 @pytest.fixture
-def test_glplot():
+def test_glplot() -> None:
     from bokeh.plotting import figure
     test_glplot = figure(output_backend="webgl")
     test_glplot.circle([1, 2], [2, 3])
     return test_glplot
 
 @pytest.fixture
-def test_table():
+def test_table() -> None:
     from bokeh.models import DataTable
     test_table = DataTable()
     return test_table
 
 @pytest.fixture
-def test_widget():
+def test_widget() -> None:
     from bokeh.models import Button
     test_widget = Button()
     return test_widget
@@ -64,7 +64,7 @@ def test_widget():
 
 class Test_bundle_for_objs_and_resources(object):
 
-    def test_env_vars_precedence(self):
+    def test_env_vars_precedence(self) -> None:
         b = beb.bundle_for_objs_and_resources([], INLINE)
         assert all('localhost' not in x for x in b.js_files)
 
@@ -94,12 +94,12 @@ class Test_bundle_for_objs_and_resources(object):
 
 class Test__any(object):
 
-    def test_with_models(self, test_plot, test_table):
+    def test_with_models(self, test_plot, test_table) -> None:
         from bokeh.models import Button
         assert beb._any([test_plot, test_table], lambda x: isinstance(x, object)) is True
         assert beb._any([test_plot, test_table], lambda x: isinstance(x, Button)) is False
 
-    def test_with_doc(self, test_plot, test_table):
+    def test_with_doc(self, test_plot, test_table) -> None:
         from bokeh.models import Button
         d = Document()
         d.add_root(test_plot)
@@ -110,7 +110,7 @@ class Test__any(object):
 
 class Test__use_gl(object):
 
-    def test_without_gl(self, test_plot, test_glplot, test_table, test_widget):
+    def test_without_gl(self, test_plot, test_glplot, test_table, test_widget) -> None:
         assert beb._use_gl([test_plot]) is False
         assert beb._use_gl([test_plot, test_table]) is False
         assert beb._use_gl([test_plot, test_widget]) is False
@@ -120,7 +120,7 @@ class Test__use_gl(object):
         d.add_root(test_widget)
         assert beb._use_gl([d]) is False
 
-    def test_with_gl(self, test_plot, test_glplot, test_table, test_widget):
+    def test_with_gl(self, test_plot, test_glplot, test_table, test_widget) -> None:
         assert beb._use_gl([test_glplot]) is True
         assert beb._use_gl([test_plot, test_glplot]) is True
         assert beb._use_gl([test_plot, test_widget, test_glplot]) is True
@@ -134,7 +134,7 @@ class Test__use_gl(object):
 
 class Test__use_tables(object):
 
-    def test_without_tables(self, test_plot, test_glplot, test_table, test_widget):
+    def test_without_tables(self, test_plot, test_glplot, test_table, test_widget) -> None:
         assert beb._use_tables([test_plot]) is False
         assert beb._use_tables([test_plot, test_glplot]) is False
         assert beb._use_tables([test_plot, test_widget]) is False
@@ -144,7 +144,7 @@ class Test__use_tables(object):
         d.add_root(test_widget)
         assert beb._use_tables([d]) is False
 
-    def test_with_tables(self, test_plot, test_glplot, test_table, test_widget):
+    def test_with_tables(self, test_plot, test_glplot, test_table, test_widget) -> None:
         assert beb._use_tables([test_table]) is True
         assert beb._use_tables([test_table, test_plot]) is True
         assert beb._use_tables([test_table, test_plot, test_glplot]) is True
@@ -158,7 +158,7 @@ class Test__use_tables(object):
 
 class Test__use_widgets(object):
 
-    def test_without_widgets(self, test_plot, test_glplot, test_table, test_widget):
+    def test_without_widgets(self, test_plot, test_glplot, test_table, test_widget) -> None:
         assert beb._use_widgets([test_plot]) is False
         assert beb._use_widgets([test_plot, test_glplot]) is False
         d = Document()
@@ -166,7 +166,7 @@ class Test__use_widgets(object):
         d.add_root(test_glplot)
         assert beb._use_widgets([d]) is False
 
-    def test_with_widgets(self, test_plot, test_glplot, test_table, test_widget):
+    def test_with_widgets(self, test_plot, test_glplot, test_table, test_widget) -> None:
         assert beb._use_widgets([test_widget]) is True
         assert beb._use_widgets([test_widget, test_plot]) is True
         assert beb._use_widgets([test_widget, test_plot, test_glplot]) is True

--- a/tests/unit/bokeh/embed/test_elements.py
+++ b/tests/unit/bokeh/embed/test_elements.py
@@ -34,7 +34,7 @@ import bokeh.embed.elements as bee # isort:skip
 
 class Test_div_for_render_item(object):
 
-    def test_render(self):
+    def test_render(self) -> None:
         render_item = RenderItem(docid="doc123", elementid="foo123")
         assert bee.div_for_render_item(render_item).strip() == """<div class="bk-root" id="foo123"></div>"""
 

--- a/tests/unit/bokeh/embed/test_notebook__embed.py
+++ b/tests/unit/bokeh/embed/test_notebook__embed.py
@@ -27,7 +27,7 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 @pytest.fixture
-def test_plot():
+def test_plot() -> None:
     from bokeh.plotting import figure
     test_plot = figure()
     test_plot.circle([1, 2], [2, 3])
@@ -41,7 +41,7 @@ def test_plot():
 class Test_notebook_content(object):
 
     @patch('bokeh.embed.notebook.standalone_docs_json_and_render_items')
-    def test_notebook_content(self, mock_sdjari, test_plot):
+    def test_notebook_content(self, mock_sdjari, test_plot) -> None:
         (docs_json, render_items) = ("DOC_JSON", [RenderItem(docid="foo", elementid="bar")])
         mock_sdjari.return_value = (docs_json, render_items)
 
@@ -55,7 +55,7 @@ class Test_notebook_content(object):
         assert div == expected_div
 
     @patch('bokeh.embed.notebook.standalone_docs_json_and_render_items')
-    def test_notebook_content_with_notebook_comms_target(self, mock_sdjari, test_plot):
+    def test_notebook_content_with_notebook_comms_target(self, mock_sdjari, test_plot) -> None:
         (docs_json, render_items) = ("DOC_JSON", [RenderItem(docid="foo", elementid="bar")])
         mock_sdjari.return_value = (docs_json, render_items)
         comms_target = "NOTEBOOK_COMMS_TARGET"

--- a/tests/unit/bokeh/embed/test_server__embed.py
+++ b/tests/unit/bokeh/embed/test_server__embed.py
@@ -25,7 +25,7 @@ import bokeh.embed.server as bes # isort:skip
 #-----------------------------------------------------------------------------
 
 @pytest.fixture
-def test_plot():
+def test_plot() -> None:
     from bokeh.plotting import figure
     test_plot = figure()
     test_plot.circle([1, 2], [2, 3])
@@ -37,21 +37,21 @@ def test_plot():
 
 class TestServerDocument(object):
 
-    def test_invalid_resources_param(self):
+    def test_invalid_resources_param(self) -> None:
         with pytest.raises(ValueError):
             bes.server_document(url="http://localhost:8081/foo/bar/sliders", resources=123)
         with pytest.raises(ValueError):
             bes.server_document(url="http://localhost:8081/foo/bar/sliders", resources="whatever")
 
-    def test_resources_default_is_implicit(self):
+    def test_resources_default_is_implicit(self) -> None:
         r = bes.server_document(url="http://localhost:8081/foo/bar/sliders", resources="default")
         assert 'resources=' not in r
 
-    def test_resources_none(self):
+    def test_resources_none(self) -> None:
         r = bes.server_document(url="http://localhost:8081/foo/bar/sliders", resources=None)
         assert 'resources=none' in r
 
-    def test_general(self):
+    def test_general(self) -> None:
         r = bes.server_document(url="http://localhost:8081/foo/bar/sliders")
         assert 'bokeh-app-path=/foo/bar/sliders' in r
         assert 'bokeh-absolute-url=http://localhost:8081/foo/bar/sliders' in r
@@ -69,7 +69,7 @@ class TestServerDocument(object):
         assert attrs == { 'id' : divid,
                           'src' : src }
 
-    def test_script_attrs_arguments_provided(self):
+    def test_script_attrs_arguments_provided(self) -> None:
         r = bes.server_document(arguments=dict(foo=10))
         assert 'foo=10' in r
         html = bs4.BeautifulSoup(r, "lxml")
@@ -86,7 +86,7 @@ class TestServerDocument(object):
         assert attrs == { 'id' : divid,
                           'src' : src }
 
-    def test_script_attrs_url_provided_absolute_resources(self):
+    def test_script_attrs_url_provided_absolute_resources(self) -> None:
         r = bes.server_document(url="http://localhost:8081/foo/bar/sliders")
         assert 'bokeh-app-path=/foo/bar/sliders' in r
         assert 'bokeh-absolute-url=http://localhost:8081/foo/bar/sliders' in r
@@ -104,7 +104,7 @@ class TestServerDocument(object):
         assert attrs == { 'id' : divid,
                           'src' : src }
 
-    def test_script_attrs_url_provided(self):
+    def test_script_attrs_url_provided(self) -> None:
         r = bes.server_document(url="http://localhost:8081/foo/bar/sliders", relative_urls=True)
         assert 'bokeh-app-path=/foo/bar/sliders' in r
         html = bs4.BeautifulSoup(r, "lxml")
@@ -123,11 +123,11 @@ class TestServerDocument(object):
 
 class TestServerSession(object):
 
-    def test_return_type(self, test_plot):
+    def test_return_type(self, test_plot) -> None:
         r = bes.server_session(test_plot, session_id='fakesession')
         assert isinstance(r, str)
 
-    def test_script_attrs_session_id_provided(self, test_plot):
+    def test_script_attrs_session_id_provided(self, test_plot) -> None:
         r = bes.server_session(test_plot, session_id='fakesession')
         assert 'bokeh-session-id=fakesession' in r
         html = bs4.BeautifulSoup(r, "lxml")
@@ -144,21 +144,21 @@ class TestServerSession(object):
         assert attrs == { 'id' : divid,
                           'src' : src }
 
-    def test_invalid_resources_param(self, test_plot):
+    def test_invalid_resources_param(self, test_plot) -> None:
         with pytest.raises(ValueError):
             bes.server_session(test_plot, session_id='fakesession', resources=123)
         with pytest.raises(ValueError):
             bes.server_session(test_plot, session_id='fakesession', resources="whatever")
 
-    def test_resources_default_is_implicit(self, test_plot):
+    def test_resources_default_is_implicit(self, test_plot) -> None:
         r = bes.server_session(test_plot, session_id='fakesession', resources="default")
         assert 'resources=' not in r
 
-    def test_resources_none(self, test_plot):
+    def test_resources_none(self, test_plot) -> None:
         r = bes.server_session(test_plot, session_id='fakesession', resources=None)
         assert 'resources=none' in r
 
-    def test_model_none(self):
+    def test_model_none(self) -> None:
         r = bes.server_session(None, session_id='fakesession')
         html = bs4.BeautifulSoup(r, "lxml")
         scripts = html.findAll(name='script')
@@ -174,7 +174,7 @@ class TestServerSession(object):
         assert attrs == { 'id' : divid,
                           'src' : src }
 
-    def test_general(self, test_plot):
+    def test_general(self, test_plot) -> None:
         r = bes.server_session(test_plot, session_id='fakesession')
         assert 'bokeh-session-id=fakesession' in r
         html = bs4.BeautifulSoup(r, "lxml")
@@ -201,20 +201,20 @@ class TestServerSession(object):
 
 class Test__clean_url(object):
 
-    def test_default(self):
+    def test_default(self) -> None:
         assert bes._clean_url("default") == bes.DEFAULT_SERVER_HTTP_URL.rstrip("/")
 
-    def test_bad_ws(self):
+    def test_bad_ws(self) -> None:
         with pytest.raises(ValueError):
             bes._clean_url("ws://foo")
 
-    def test_arg(self):
+    def test_arg(self) -> None:
         assert bes._clean_url("http://foo/bar") == "http://foo/bar"
         assert bes._clean_url("http://foo/bar/") == "http://foo/bar"
 
 class Test__get_app_path(object):
 
-    def test_arg(self):
+    def test_arg(self) -> None:
         assert bes._get_app_path("foo") == "/foo"
         assert bes._get_app_path("http://foo") == "/"
         assert bes._get_app_path("http://foo/bar") == "/bar"
@@ -223,16 +223,16 @@ class Test__get_app_path(object):
 
 class Test__process_arguments(object):
 
-    def test_None(self):
+    def test_None(self) -> None:
         assert bes._process_arguments(None) == ""
 
-    def test_args(self):
+    def test_args(self) -> None:
         args = dict(foo=10, bar="baz")
         r = bes._process_arguments(args)
         # order unspecified
         assert r == "&foo=10&bar=baz" or r == "&bar=baz&foo=10"
 
-    def test_args_ignores_bokeh_prefixed(self):
+    def test_args_ignores_bokeh_prefixed(self) -> None:
         args = dict(foo=10, bar="baz")
         args["bokeh-junk"] = 20
         r = bes._process_arguments(args)
@@ -241,41 +241,41 @@ class Test__process_arguments(object):
 
 class Test__process_app_path(object):
 
-    def test_root(self):
+    def test_root(self) -> None:
         assert bes._process_app_path("/") == ""
 
-    def test_arg(self):
+    def test_arg(self) -> None:
         assert bes._process_app_path("/stuff") == "&bokeh-app-path=/stuff"
 
 class Test__process_relative_urls(object):
 
-    def test_True(self):
+    def test_True(self) -> None:
         assert bes._process_relative_urls(True, "") == ""
         assert bes._process_relative_urls(True, "/stuff") == ""
 
-    def test_Flase(self):
+    def test_Flase(self) -> None:
         assert bes._process_relative_urls(False, "/stuff") == "&bokeh-absolute-url=/stuff"
 
 class Test__process_resources(object):
 
-    def test_bad_input(self):
+    def test_bad_input(self) -> None:
         with pytest.raises(ValueError):
             bes._process_resources("foo")
 
-    def test_None(self):
+    def test_None(self) -> None:
         assert bes._process_resources(None) == "&resources=none"
 
-    def test_default(self):
+    def test_default(self) -> None:
         assert bes._process_resources("default") == ""
 
 class Test__process_session_id(object):
 
-    def test_arg(self):
+    def test_arg(self) -> None:
         assert bes._process_session_id("foo123") == "&bokeh-session-id=foo123"
 
 def Test__src_path(object):
 
-    def test_args(self):
+    def test_args(self) -> None:
         assert bes._src_path("http://foo", "1234") =="http://foo/autoload.js?bokeh-autoload-element=1234"
 
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/embed/test_standalone.py
+++ b/tests/unit/bokeh/embed/test_standalone.py
@@ -40,7 +40,7 @@ def stable_id():
     return 'ID'
 
 @pytest.fixture
-def test_plot():
+def test_plot() -> None:
     from bokeh.plotting import figure
     test_plot = figure()
     test_plot.circle([1, 2], [2, 3])
@@ -52,11 +52,11 @@ def test_plot():
 
 class Test_autoload_static(object):
 
-    def test_return_type(self, test_plot):
+    def test_return_type(self, test_plot) -> None:
         r = bes.autoload_static(test_plot, CDN, "some/path")
         assert len(r) == 2
 
-    def test_script_attrs(self, test_plot):
+    def test_script_attrs(self, test_plot) -> None:
         js, tag = bes.autoload_static(test_plot, CDN, "some/path")
         html = bs4.BeautifulSoup(tag, "lxml")
         scripts = html.findAll(name='script')
@@ -68,7 +68,7 @@ class Test_autoload_static(object):
 
 class Test_components(object):
 
-    def test_return_type(self):
+    def test_return_type(self) -> None:
         plot1 = figure()
         plot1.circle([], [])
         plot2 = figure()
@@ -95,7 +95,7 @@ class Test_components(object):
         assert all(isinstance(x, str) for x in divs.keys())
 
     @patch('bokeh.embed.util.make_globally_unique_id', new_callable=lambda: stable_id)
-    def test_plot_dict_returned_when_wrap_plot_info_is_false(self, mock_make_id):
+    def test_plot_dict_returned_when_wrap_plot_info_is_false(self, mock_make_id) -> None:
         doc = Document()
         plot1 = figure()
         plot1.circle([], [])
@@ -117,7 +117,7 @@ class Test_components(object):
         _, plotiddict = bes.components({'p1': plot1, 'p2': plot2}, wrap_plot_info=False)
         assert plotiddict == {'p1': expected_plotdict_1, 'p2': expected_plotdict_2}
 
-    def test_result_attrs(self, test_plot):
+    def test_result_attrs(self, test_plot) -> None:
         script, div = bes.components(test_plot)
         html = bs4.BeautifulSoup(script, "lxml")
         scripts = html.findAll(name='script')
@@ -125,7 +125,7 @@ class Test_components(object):
         assert scripts[0].attrs == {'type': 'text/javascript'}
 
     @patch('bokeh.embed.util.make_globally_unique_id', new=stable_id)
-    def test_div_attrs(self, test_plot):
+    def test_div_attrs(self, test_plot) -> None:
         script, div = bes.components(test_plot)
         html = bs4.BeautifulSoup(div, "lxml")
 
@@ -139,11 +139,11 @@ class Test_components(object):
         assert div.attrs['data-root-id'] == test_plot.id
         assert div.text == ''
 
-    def test_script_is_utf8_encoded(self, test_plot):
+    def test_script_is_utf8_encoded(self, test_plot) -> None:
         script, div = bes.components(test_plot)
         assert isinstance(script, str)
 
-    def test_output_is_without_script_tag_when_wrap_script_is_false(self, test_plot):
+    def test_output_is_without_script_tag_when_wrap_script_is_false(self, test_plot) -> None:
         script, div = bes.components(test_plot)
         html = bs4.BeautifulSoup(script, "lxml")
         scripts = html.findAll(name='script')
@@ -158,7 +158,7 @@ class Test_components(object):
 
 class Test_file_html(object):
 
-    def test_return_type(self, test_plot):
+    def test_return_type(self, test_plot) -> None:
 
         class fake_template:
             def __init__(self, tester, user_template_variables=None):
@@ -191,7 +191,7 @@ class Test_file_html(object):
         assert isinstance(r, str)
 
     @patch('bokeh.embed.bundle.warn')
-    def test_file_html_handles_js_only_resources(self, mock_warn, test_plot):
+    def test_file_html_handles_js_only_resources(self, mock_warn, test_plot) -> None:
         js_resources = JSResources(mode="relative", components=["bokeh"])
         template = Template("<head>{{ bokeh_js }}</head><body></body>")
         output = bes.file_html(test_plot, (js_resources, None), "title", template=template)
@@ -199,7 +199,7 @@ class Test_file_html(object):
         assert output == html
 
     @patch('bokeh.embed.bundle.warn')
-    def test_file_html_provides_warning_if_no_css(self, mock_warn, test_plot):
+    def test_file_html_provides_warning_if_no_css(self, mock_warn, test_plot) -> None:
         js_resources = JSResources()
         bes.file_html(test_plot, (js_resources, None), "title")
         mock_warn.assert_called_once_with(
@@ -207,7 +207,7 @@ class Test_file_html(object):
         )
 
     @patch('bokeh.embed.bundle.warn')
-    def test_file_html_handles_css_only_resources(self, mock_warn, test_plot):
+    def test_file_html_handles_css_only_resources(self, mock_warn, test_plot) -> None:
         css_resources = CSSResources(mode="relative", components=["bokeh"])
         template = Template("<head>{{ bokeh_css }}</head><body></body>")
         output = bes.file_html(test_plot, (None, css_resources), "title", template=template)
@@ -215,18 +215,18 @@ class Test_file_html(object):
         assert output == html
 
     @patch('bokeh.embed.bundle.warn')
-    def test_file_html_provides_warning_if_no_js(self, mock_warn, test_plot):
+    def test_file_html_provides_warning_if_no_js(self, mock_warn, test_plot) -> None:
         css_resources = CSSResources()
         bes.file_html(test_plot, (None, css_resources), "title")
         mock_warn.assert_called_once_with(
             'No Bokeh JS Resources provided to template. If required you will need to provide them manually.'
         )
 
-    def test_file_html_title_is_escaped(self, test_plot):
+    def test_file_html_title_is_escaped(self, test_plot) -> None:
         r = bes.file_html(test_plot, CDN, "&<")
         assert "<title>&amp;&lt;</title>" in r
 
-    def test_entire_doc_is_not_used(self):
+    def test_entire_doc_is_not_used(self) -> None:
         from bokeh.document import Document
         from bokeh.models import Button
 
@@ -245,29 +245,29 @@ class Test_file_html(object):
 
 class Test_json_item(object):
 
-    def test_with_target_id(self, test_plot):
+    def test_with_target_id(self, test_plot) -> None:
         out = bes.json_item(test_plot, target="foo")
         assert out['target_id'] == "foo"
 
-    def test_without_target_id(self, test_plot):
+    def test_without_target_id(self, test_plot) -> None:
         out = bes.json_item(test_plot)
         assert out['target_id'] == None
 
-    def test_doc_json(self, test_plot):
+    def test_doc_json(self, test_plot) -> None:
         out = bes.json_item(test_plot, target="foo")
         expected = list(standalone_docs_json([test_plot]).values())[0]
         assert out['doc'] == expected
 
-    def test_doc_title(self, test_plot):
+    def test_doc_title(self, test_plot) -> None:
         out = bes.json_item(test_plot, target="foo")
         assert out['doc']['title'] == ""
 
-    def test_root_id(self, test_plot):
+    def test_root_id(self, test_plot) -> None:
         out = bes.json_item(test_plot, target="foo")
         assert out['doc']['roots']['root_ids'][0] == out['root_id']
 
     @patch('bokeh.embed.standalone.OutputDocumentFor')
-    def test_apply_theme(self, mock_OFD, test_plot):
+    def test_apply_theme(self, mock_OFD, test_plot) -> None:
         # the subsequent call inside ODF will fail since the model was never
         # added to a document. Ignoring that since we just want to make sure
         # ODF is called with the expected theme arg.

--- a/tests/unit/bokeh/embed/test_util__embed.py
+++ b/tests/unit/bokeh/embed/test_util__embed.py
@@ -38,7 +38,7 @@ import bokeh.embed.util as beu # isort:skip
 #-----------------------------------------------------------------------------
 
 @pytest.fixture
-def test_plot():
+def test_plot() -> None:
     from bokeh.plotting import figure
     test_plot = figure()
     test_plot.circle([1, 2], [2, 3])
@@ -104,20 +104,20 @@ class EmbedTestUtilModel(Model):
 
 class Test_FromCurdoc(object):
 
-    def test_type(self):
+    def test_type(self) -> None:
         assert isinstance(beu.FromCurdoc, type)
 
 _ODFERR = "OutputDocumentFor expects a sequence of Models"
 
 class Test_OutputDocumentFor_general(object):
 
-    def test_error_on_empty_list(self):
+    def test_error_on_empty_list(self) -> None:
         with pytest.raises(ValueError) as e:
             with beu.OutputDocumentFor([]):
                 pass
         assert str(e.value).endswith(_ODFERR)
 
-    def test_error_on_mixed_list(self):
+    def test_error_on_mixed_list(self) -> None:
         p = SomeModel()
         d = Document()
         orig_theme = d.theme
@@ -128,13 +128,13 @@ class Test_OutputDocumentFor_general(object):
         assert d.theme is orig_theme
 
     @pytest.mark.parametrize('v', [10, -0,3, "foo", True])
-    def test_error_on_wrong_types(self, v):
+    def test_error_on_wrong_types(self, v) -> None:
         with pytest.raises(ValueError) as e:
             with beu.OutputDocumentFor(v):
                 pass
         assert str(e.value).endswith(_ODFERR)
 
-    def test_with_doc_in_child_raises_error(self):
+    def test_with_doc_in_child_raises_error(self) -> None:
         doc = Document()
         p1 = SomeModel()
         p2 = OtherModel(child=SomeModel())
@@ -148,13 +148,13 @@ class Test_OutputDocumentFor_general(object):
             assert "already in a doc" in str(e.value)
 
     @patch('bokeh.document.document.check_integrity')
-    def test_validates_document_by_default(self, check_integrity, test_plot):
+    def test_validates_document_by_default(self, check_integrity, test_plot) -> None:
         with beu.OutputDocumentFor([test_plot]):
             pass
         assert check_integrity.called
 
     @patch('bokeh.document.document.check_integrity')
-    def test_doesnt_validate_doc_due_to_env_var(self, check_integrity, monkeypatch, test_plot):
+    def test_doesnt_validate_doc_due_to_env_var(self, check_integrity, monkeypatch, test_plot) -> None:
         monkeypatch.setenv("BOKEH_VALIDATE_DOC", "false")
         with beu.OutputDocumentFor([test_plot]):
             pass
@@ -162,7 +162,7 @@ class Test_OutputDocumentFor_general(object):
 
 class Test_OutputDocumentFor_default_apply_theme(object):
 
-    def test_single_model_with_document(self):
+    def test_single_model_with_document(self) -> None:
         # should use existing doc in with-block
         p = SomeModel()
         d = Document()
@@ -174,14 +174,14 @@ class Test_OutputDocumentFor_default_apply_theme(object):
         assert p.document is d
         assert d.theme is orig_theme
 
-    def test_single_model_with_no_document(self):
+    def test_single_model_with_no_document(self) -> None:
         p = SomeModel()
         assert p.document is None
         with beu.OutputDocumentFor([p]):
             assert p.document is not None
         assert p.document is not None
 
-    def test_list_of_model_with_no_documents(self):
+    def test_list_of_model_with_no_documents(self) -> None:
         # should create new (permanent) doc for inputs
         p1 = SomeModel()
         p2 = SomeModel()
@@ -197,7 +197,7 @@ class Test_OutputDocumentFor_default_apply_theme(object):
         assert p1.document is p2.document
         assert p1.document.theme is new_theme
 
-    def test_list_of_model_same_as_roots(self):
+    def test_list_of_model_same_as_roots(self) -> None:
         # should use existing doc in with-block
         p1 = SomeModel()
         p2 = SomeModel()
@@ -213,7 +213,7 @@ class Test_OutputDocumentFor_default_apply_theme(object):
         assert p2.document is d
         assert d.theme is orig_theme
 
-    def test_list_of_model_same_as_roots_with_always_new(self):
+    def test_list_of_model_same_as_roots_with_always_new(self) -> None:
         # should use new temp doc for everything inside with-block
         p1 = SomeModel()
         p2 = SomeModel()
@@ -230,7 +230,7 @@ class Test_OutputDocumentFor_default_apply_theme(object):
         assert p2.document is d
         assert d.theme is orig_theme
 
-    def test_list_of_model_subset_roots(self):
+    def test_list_of_model_subset_roots(self) -> None:
         # should use new temp doc for subset inside with-block
         p1 = SomeModel()
         p2 = SomeModel()
@@ -247,7 +247,7 @@ class Test_OutputDocumentFor_default_apply_theme(object):
         assert p2.document is d
         assert d.theme is orig_theme
 
-    def test_list_of_models_different_docs(self):
+    def test_list_of_models_different_docs(self) -> None:
         # should use new temp doc for eveything inside with-block
         d = Document()
         orig_theme = d.theme
@@ -269,7 +269,7 @@ class Test_OutputDocumentFor_default_apply_theme(object):
 
 class Test_OutputDocumentFor_custom_apply_theme(object):
 
-    def test_single_model_with_document(self):
+    def test_single_model_with_document(self) -> None:
         # should use existing doc in with-block
         p = SomeModel()
         d = Document()
@@ -281,7 +281,7 @@ class Test_OutputDocumentFor_custom_apply_theme(object):
         assert p.document is d
         assert d.theme is orig_theme
 
-    def test_single_model_with_no_document(self):
+    def test_single_model_with_no_document(self) -> None:
         p = SomeModel()
         assert p.document is None
         with beu.OutputDocumentFor([p], apply_theme=Theme(json={})):
@@ -290,7 +290,7 @@ class Test_OutputDocumentFor_custom_apply_theme(object):
         assert p.document is not None
         assert p.document.theme is not new_theme
 
-    def test_list_of_model_with_no_documents(self):
+    def test_list_of_model_with_no_documents(self) -> None:
         # should create new (permanent) doc for inputs
         p1 = SomeModel()
         p2 = SomeModel()
@@ -308,7 +308,7 @@ class Test_OutputDocumentFor_custom_apply_theme(object):
         # should restore to default theme after with-block
         assert p1.document.theme is not new_theme
 
-    def test_list_of_model_same_as_roots(self):
+    def test_list_of_model_same_as_roots(self) -> None:
         # should use existing doc in with-block
         p1 = SomeModel()
         p2 = SomeModel()
@@ -324,7 +324,7 @@ class Test_OutputDocumentFor_custom_apply_theme(object):
         assert p2.document is d
         assert d.theme is orig_theme
 
-    def test_list_of_model_same_as_roots_with_always_new(self):
+    def test_list_of_model_same_as_roots_with_always_new(self) -> None:
         # should use new temp doc for everything inside with-block
         p1 = SomeModel()
         p2 = SomeModel()
@@ -341,7 +341,7 @@ class Test_OutputDocumentFor_custom_apply_theme(object):
         assert p2.document is d
         assert d.theme is orig_theme
 
-    def test_list_of_model_subset_roots(self):
+    def test_list_of_model_subset_roots(self) -> None:
         # should use new temp doc for subset inside with-block
         p1 = SomeModel()
         p2 = SomeModel()
@@ -358,7 +358,7 @@ class Test_OutputDocumentFor_custom_apply_theme(object):
         assert p2.document is d
         assert d.theme is orig_theme
 
-    def test_list_of_models_different_docs(self):
+    def test_list_of_models_different_docs(self) -> None:
         # should use new temp doc for eveything inside with-block
         d = Document()
         orig_theme = d.theme
@@ -387,7 +387,7 @@ class Test_OutputDocumentFor_FromCurdoc_apply_theme(object):
     def teardown_method(self):
         curdoc().theme = self.orig_theme
 
-    def test_single_model_with_document(self):
+    def test_single_model_with_document(self) -> None:
         # should use existing doc in with-block
         p = SomeModel()
         d = Document()
@@ -399,7 +399,7 @@ class Test_OutputDocumentFor_FromCurdoc_apply_theme(object):
         assert p.document is d
         assert d.theme is orig_theme
 
-    def test_single_model_with_no_document(self):
+    def test_single_model_with_no_document(self) -> None:
         p = SomeModel()
         assert p.document is None
         with beu.OutputDocumentFor([p], apply_theme=beu.FromCurdoc):
@@ -409,7 +409,7 @@ class Test_OutputDocumentFor_FromCurdoc_apply_theme(object):
         assert p.document is new_doc
         assert p.document.theme is not curdoc().theme
 
-    def test_list_of_model_with_no_documents(self):
+    def test_list_of_model_with_no_documents(self) -> None:
         # should create new (permanent) doc for inputs
         p1 = SomeModel()
         p2 = SomeModel()
@@ -427,7 +427,7 @@ class Test_OutputDocumentFor_FromCurdoc_apply_theme(object):
         # should restore to default theme after with-block
         assert p1.document.theme is not curdoc().theme
 
-    def test_list_of_model_same_as_roots(self):
+    def test_list_of_model_same_as_roots(self) -> None:
         # should use existing doc in with-block
         p1 = SomeModel()
         p2 = SomeModel()
@@ -443,7 +443,7 @@ class Test_OutputDocumentFor_FromCurdoc_apply_theme(object):
         assert p2.document is d
         assert d.theme is orig_theme
 
-    def test_list_of_model_same_as_roots_with_always_new(self):
+    def test_list_of_model_same_as_roots_with_always_new(self) -> None:
         # should use new temp doc for everything inside with-block
         p1 = SomeModel()
         p2 = SomeModel()
@@ -460,7 +460,7 @@ class Test_OutputDocumentFor_FromCurdoc_apply_theme(object):
         assert p2.document is d
         assert d.theme is orig_theme
 
-    def test_list_of_model_subset_roots(self):
+    def test_list_of_model_subset_roots(self) -> None:
         # should use new temp doc for subset inside with-block
         p1 = SomeModel()
         p2 = SomeModel()
@@ -477,7 +477,7 @@ class Test_OutputDocumentFor_FromCurdoc_apply_theme(object):
         assert p2.document is d
         assert d.theme is orig_theme
 
-    def test_list_of_models_different_docs(self):
+    def test_list_of_models_different_docs(self) -> None:
         # should use new temp doc for eveything inside with-block
         d = Document()
         orig_theme = d.theme
@@ -499,7 +499,7 @@ class Test_OutputDocumentFor_FromCurdoc_apply_theme(object):
 
 class Test_standalone_docs_json_and_render_items(object):
 
-    def test_passing_model(self):
+    def test_passing_model(self) -> None:
         p1 = SomeModel()
         d = Document()
         d.add_root(p1)
@@ -512,7 +512,7 @@ class Test_standalone_docs_json_and_render_items(object):
         assert doc['roots']['references'] == [{'attributes': {}, 'id': str(p1.id), 'type': 'test_util__embed.SomeModel'}]
         assert len(render_items) == 1
 
-    def test_passing_doc(self):
+    def test_passing_doc(self) -> None:
         p1 = SomeModel()
         d = Document()
         d.add_root(p1)
@@ -525,13 +525,13 @@ class Test_standalone_docs_json_and_render_items(object):
         assert doc['roots']['references'] == [{'attributes': {}, 'id': str(p1.id), 'type': 'test_util__embed.SomeModel'}]
         assert len(render_items) == 1
 
-    def test_exception_for_missing_doc(self):
+    def test_exception_for_missing_doc(self) -> None:
         p1 = SomeModel()
         with pytest.raises(ValueError) as e:
             beu.standalone_docs_json_and_render_items([p1])
         assert str(e.value) == "A Bokeh Model must be part of a Document to render as standalone content"
 
-    def test_log_warning_if_python_property_callback(self, caplog):
+    def test_log_warning_if_python_property_callback(self, caplog) -> None:
         d = Document()
         m1 = EmbedTestUtilModel()
         c1 = _GoodPropertyCallback()
@@ -545,7 +545,7 @@ class Test_standalone_docs_json_and_render_items(object):
             assert len(caplog.records) == 1
             assert caplog.text != ''
 
-    def test_log_warning_if_python_event_callback(self, caplog):
+    def test_log_warning_if_python_event_callback(self, caplog) -> None:
         d = Document()
         m1 = EmbedTestUtilModel()
         c1 = _GoodEventCallback()
@@ -559,7 +559,7 @@ class Test_standalone_docs_json_and_render_items(object):
             assert len(caplog.records) == 1
             assert caplog.text != ''
 
-    def test_suppress_warnings(self, caplog):
+    def test_suppress_warnings(self, caplog) -> None:
         d = Document()
         m1 = EmbedTestUtilModel()
         c1 = _GoodPropertyCallback()
@@ -580,7 +580,7 @@ class Test_standalone_docs_json_and_render_items(object):
 class Test_standalone_docs_json(object):
 
     @patch('bokeh.embed.util.standalone_docs_json_and_render_items')
-    def test_delgation(self, mock_sdjari):
+    def test_delgation(self, mock_sdjari) -> None:
         p1 = SomeModel()
         p2 = SomeModel()
         d = Document()
@@ -594,7 +594,7 @@ class Test_standalone_docs_json(object):
             pass
         mock_sdjari.assert_called_once_with([p1, p2])
 
-    def test_output(self):
+    def test_output(self) -> None:
         p1 = SomeModel()
         p2 = SomeModel()
         d = Document()
@@ -610,14 +610,14 @@ class Test_standalone_docs_json(object):
 
 class Test__create_temp_doc(object):
 
-    def test_no_docs(self):
+    def test_no_docs(self) -> None:
         p1 = SomeModel()
         p2 = SomeModel()
         beu._create_temp_doc([p1, p2])
         assert isinstance(p1.document, Document)
         assert isinstance(p2.document, Document)
 
-    def test_top_level_same_doc(self):
+    def test_top_level_same_doc(self) -> None:
         d = Document()
         p1 = SomeModel()
         p2 = SomeModel()
@@ -631,7 +631,7 @@ class Test__create_temp_doc(object):
 
         assert p2.document == p1.document
 
-    def test_top_level_different_doc(self):
+    def test_top_level_different_doc(self) -> None:
         d1 = Document()
         d2 = Document()
         p1 = SomeModel()
@@ -646,7 +646,7 @@ class Test__create_temp_doc(object):
 
         assert p2.document == p1.document
 
-    def test_child_docs(self):
+    def test_child_docs(self) -> None:
         d = Document()
         p1 = SomeModel()
         p2 = OtherModel(child=SomeModel())
@@ -665,14 +665,14 @@ class Test__create_temp_doc(object):
 
 class Test__dispose_temp_doc(object):
 
-    def test_no_docs(self):
+    def test_no_docs(self) -> None:
         p1 = SomeModel()
         p2 = SomeModel()
         beu._dispose_temp_doc([p1, p2])
         assert p1.document is None
         assert p2.document is None
 
-    def test_with_docs(self):
+    def test_with_docs(self) -> None:
         d1 = Document()
         d2 = Document()
         p1 = SomeModel()
@@ -685,7 +685,7 @@ class Test__dispose_temp_doc(object):
         assert p2.document is None
         assert p2.child.document is d2
 
-    def test_with_temp_docs(self):
+    def test_with_temp_docs(self) -> None:
         p1 = SomeModel()
         p2 = SomeModel()
         beu._create_temp_doc([p1, p2])
@@ -694,14 +694,14 @@ class Test__dispose_temp_doc(object):
         assert p2.document is None
 
 class Test__set_temp_theme(object):
-    def test_apply_None(self):
+    def test_apply_None(self) -> None:
         d = Document()
         orig = d.theme
         beu._set_temp_theme(d, None)
         assert d._old_theme is orig
         assert d.theme is orig
 
-    def test_apply_theme(self):
+    def test_apply_theme(self) -> None:
         t = Theme(json={})
         d = Document()
         orig = d.theme
@@ -709,7 +709,7 @@ class Test__set_temp_theme(object):
         assert d._old_theme is orig
         assert d.theme is t
 
-    def test_apply_from_curdoc(self):
+    def test_apply_from_curdoc(self) -> None:
         t = Theme(json={})
         curdoc().theme = t
         d = Document()
@@ -719,7 +719,7 @@ class Test__set_temp_theme(object):
         assert d.theme is t
 
 class Test__unset_temp_theme(object):
-    def test_basic(self):
+    def test_basic(self) -> None:
         t = Theme(json={})
         d = Document()
         d._old_theme = t
@@ -727,7 +727,7 @@ class Test__unset_temp_theme(object):
         assert d.theme is t
         assert not hasattr(d, "_old_theme")
 
-    def test_no_old_theme(self):
+    def test_no_old_theme(self) -> None:
         d = Document()
         orig = d.theme
         beu._unset_temp_theme(d)

--- a/tests/unit/bokeh/embed/test_wrappers__embed.py
+++ b/tests/unit/bokeh/embed/test_wrappers__embed.py
@@ -32,7 +32,7 @@ import bokeh.embed.wrappers as bew # isort:skip
 
 class Test_wrap_in_onload(object):
 
-    def test_render(self):
+    def test_render(self) -> None:
         assert bew.wrap_in_onload("code\nmorecode") == """\
 (function() {
   var fn = function() {
@@ -46,7 +46,7 @@ class Test_wrap_in_onload(object):
 
 class Test_wrap_in_safely(object):
 
-    def test_render(self):
+    def test_render(self) -> None:
         assert bew.wrap_in_safely("code\nmorecode") == """\
 Bokeh.safely(function() {
   code
@@ -56,7 +56,7 @@ Bokeh.safely(function() {
 
 class Test_wrap_in_script_tag(object):
 
-    def test_render(self):
+    def test_render(self) -> None:
         assert bew.wrap_in_script_tag("code\nmorecode") == """
 <script type="text/javascript">
   code
@@ -68,7 +68,7 @@ class Test_wrap_in_script_tag(object):
 # Private API
 #-----------------------------------------------------------------------------
 
-def test__ONLOAD():
+def test__ONLOAD() -> None:
     assert bew._ONLOAD == """\
 (function() {
   var fn = function() {
@@ -79,7 +79,7 @@ def test__ONLOAD():
 })();\
 """
 
-def test__SAFELY():
+def test__SAFELY() -> None:
     assert bew._SAFELY == """\
 Bokeh.safely(function() {
 %(code)s

--- a/tests/unit/bokeh/io/test___init___io.py
+++ b/tests/unit/bokeh/io/test___init___io.py
@@ -43,7 +43,7 @@ ALL = (
 
 Test___all__ = verify_all(bi, ALL)
 
-def test_jupyter_notebook_hook_installed():
+def test_jupyter_notebook_hook_installed() -> None:
     assert list(binb._HOOKS) == ["jupyter"]
     assert binb._HOOKS["jupyter"]['load'] == binb.load_notebook
     assert binb._HOOKS["jupyter"]['doc']  == binb.show_doc

--- a/tests/unit/bokeh/io/test_doc.py
+++ b/tests/unit/bokeh/io/test_doc.py
@@ -29,14 +29,14 @@ import bokeh.io.doc as bid # isort:skip
 # General API
 #-----------------------------------------------------------------------------
 
-def test_curdoc_from_curstate():
+def test_curdoc_from_curstate() -> None:
     assert bid.curdoc() is curstate().document
 
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------
 
-def test_set_curdoc_sets_curstate():
+def test_set_curdoc_sets_curstate() -> None:
     d = Document()
     bid.set_curdoc(d)
     assert curstate().document is d

--- a/tests/unit/bokeh/io/test_export.py
+++ b/tests/unit/bokeh/io/test_export.py
@@ -51,7 +51,7 @@ def webdriver():
 
 @pytest.mark.unit
 @pytest.mark.selenium
-def test_get_screenshot_as_png():
+def test_get_screenshot_as_png() -> None:
     layout = Plot(x_range=Range1d(), y_range=Range1d(),
                   plot_height=20, plot_width=20, toolbar_location=None,
                   outline_line_color=None, background_fill_color=None,
@@ -64,7 +64,7 @@ def test_get_screenshot_as_png():
 
 @pytest.mark.unit
 @pytest.mark.selenium
-def test_get_screenshot_as_png_with_glyph():
+def test_get_screenshot_as_png_with_glyph() -> None:
     layout = Plot(x_range=Range1d(0, 1), y_range=Range1d(0, 1),
                   plot_height=20, plot_width=20, toolbar_location=None,
                   outline_line_color=None, background_fill_color=None, min_border=2,
@@ -88,7 +88,7 @@ def test_get_screenshot_as_png_with_glyph():
 
 @pytest.mark.unit
 @pytest.mark.selenium
-def test_get_screenshot_as_png_with_driver(webdriver):
+def test_get_screenshot_as_png_with_driver(webdriver) -> None:
     layout = Plot(x_range=Range1d(), y_range=Range1d(),
                   plot_height=20, plot_width=20, toolbar_location=None,
                   outline_line_color=None, background_fill_color=None,
@@ -102,7 +102,7 @@ def test_get_screenshot_as_png_with_driver(webdriver):
 
 @pytest.mark.unit
 @pytest.mark.selenium
-def test_get_screenshot_as_png_large_plot(webdriver):
+def test_get_screenshot_as_png_large_plot(webdriver) -> None:
     layout = Plot(x_range=Range1d(), y_range=Range1d(),
                   plot_height=800, plot_width=800, toolbar_location=None,
                   outline_line_color=None, background_fill_color=None,
@@ -116,7 +116,7 @@ def test_get_screenshot_as_png_large_plot(webdriver):
 
 @pytest.mark.unit
 @pytest.mark.selenium
-def test_get_screenshot_as_png_with_unicode_minified(webdriver):
+def test_get_screenshot_as_png_with_unicode_minified(webdriver) -> None:
     p = figure(title="유니 코드 지원을위한 작은 테스트")
 
     png = bie.get_screenshot_as_png(p, driver=webdriver, resources=Resources(mode="inline", minified=True, legacy=True))
@@ -124,7 +124,7 @@ def test_get_screenshot_as_png_with_unicode_minified(webdriver):
 
 @pytest.mark.unit
 @pytest.mark.selenium
-def test_get_screenshot_as_png_with_unicode_unminified(webdriver):
+def test_get_screenshot_as_png_with_unicode_unminified(webdriver) -> None:
     p = figure(title="유니 코드 지원을위한 작은 테스트")
 
     png = bie.get_screenshot_as_png(p, driver=webdriver, resources=Resources(mode="inline", minified=False, legacy=True))
@@ -132,7 +132,7 @@ def test_get_screenshot_as_png_with_unicode_unminified(webdriver):
 
 @pytest.mark.unit
 @pytest.mark.selenium
-def test_get_svgs_no_svg_present():
+def test_get_svgs_no_svg_present() -> None:
     layout = Plot(x_range=Range1d(), y_range=Range1d(),
               plot_height=20, plot_width=20, toolbar_location=None)
 
@@ -141,7 +141,7 @@ def test_get_svgs_no_svg_present():
 
 @pytest.mark.unit
 @pytest.mark.selenium
-def test_get_svgs_with_svg_present(webdriver):
+def test_get_svgs_with_svg_present(webdriver) -> None:
 
     def fix_ids(svg):
         svg = re.sub(r'id="\w{12}"', 'id="X"', svg)
@@ -173,7 +173,7 @@ def test_get_svgs_with_svg_present(webdriver):
     assert svg0 == svg2
     assert svg1 == svg2
 
-def test_get_layout_html_resets_plot_dims():
+def test_get_layout_html_resets_plot_dims() -> None:
     initial_height, initial_width = 200, 250
 
     layout = Plot(x_range=Range1d(), y_range=Range1d(),
@@ -184,7 +184,7 @@ def test_get_layout_html_resets_plot_dims():
     assert layout.plot_height == initial_height
     assert layout.plot_width == initial_width
 
-def test_layout_html_on_child_first():
+def test_layout_html_on_child_first() -> None:
     p = Plot(x_range=Range1d(), y_range=Range1d())
 
     bie.get_layout_html(p, height=100, width=100)
@@ -192,7 +192,7 @@ def test_layout_html_on_child_first():
     layout = row(p)
     bie.get_layout_html(layout)
 
-def test_layout_html_on_parent_first():
+def test_layout_html_on_parent_first() -> None:
     p = Plot(x_range=Range1d(), y_range=Range1d())
 
     layout = row(p)
@@ -205,14 +205,14 @@ def test_layout_html_on_parent_first():
 #-----------------------------------------------------------------------------
 
 @patch('PIL.Image.Image')
-def test__crop_image_args(mock_Image):
+def test__crop_image_args(mock_Image) -> None:
     image = mock_Image()
     bie._crop_image(image, left='left', right='right', top='top', bottom='bottom', extra=10)
     assert image.crop.call_count == 1
     assert image.crop.call_args[0] == (('left', 'top', 'right', 'bottom'), )
     assert image.crop.call_args[1] == {}
 
-def test__crop_image():
+def test__crop_image() -> None:
     image = Image.new(mode="RGBA", size=(10,10))
     rect = dict(left=2, right=8, top=3, bottom=7)
     cropped = bie._crop_image(image, **rect)

--- a/tests/unit/bokeh/io/test_notebook__io.py
+++ b/tests/unit/bokeh/io/test_notebook__io.py
@@ -35,7 +35,7 @@ import bokeh.io.notebook as binb # isort:skip
 # General API
 #-----------------------------------------------------------------------------
 
-def test_install_notebook_hook():
+def test_install_notebook_hook() -> None:
     binb.install_notebook_hook("foo", "load", "doc", "app")
     assert binb._HOOKS["foo"]['load'] == "load"
     assert binb._HOOKS["foo"]['doc'] == "doc"
@@ -76,7 +76,7 @@ def test_show_doc_no_server(mock_notebook_content,
 class Test_push_notebook(object):
 
     @patch('bokeh.io.notebook.CommsHandle.comms', new_callable=PropertyMock)
-    def test_no_events(self, mock_comms):
+    def test_no_events(self, mock_comms) -> None:
         mock_comms.return_value = MagicMock()
 
         d = Document()
@@ -86,7 +86,7 @@ class Test_push_notebook(object):
         assert mock_comms.call_count == 0
 
     @patch('bokeh.io.notebook.CommsHandle.comms', new_callable=PropertyMock)
-    def test_with_events(self, mock_comms):
+    def test_with_events(self, mock_comms) -> None:
         mock_comm = MagicMock()
         mock_send = MagicMock(return_value="junk")
         mock_comm.send = mock_send
@@ -110,12 +110,12 @@ class Test_push_notebook(object):
 # Private API
 #-----------------------------------------------------------------------------
 
-def test__origin_url():
+def test__origin_url() -> None:
     assert binb._origin_url("foo.com:8888") == "foo.com:8888"
     assert binb._origin_url("http://foo.com:8888") == "foo.com:8888"
     assert binb._origin_url("https://foo.com:8888") == "foo.com:8888"
 
-def test__server_url():
+def test__server_url() -> None:
     assert binb._server_url("foo.com:8888", 10) == "http://foo.com:10/"
     assert binb._server_url("http://foo.com:8888", 10) == "http://foo.com:10/"
     assert binb._server_url("https://foo.com:8888", 10) == "https://foo.com:10/"

--- a/tests/unit/bokeh/io/test_output.py
+++ b/tests/unit/bokeh/io/test_output.py
@@ -35,7 +35,7 @@ import bokeh.io.output as bio # isort:skip
 class Test_output_file(object):
 
     @patch('bokeh.io.state.State.output_file')
-    def test_no_args(self, mock_output_file):
+    def test_no_args(self, mock_output_file) -> None:
         default_kwargs = dict(title="Bokeh Plot", mode=None, root_dir=None)
         bio.output_file("foo.html")
         assert mock_output_file.call_count == 1
@@ -43,7 +43,7 @@ class Test_output_file(object):
         assert mock_output_file.call_args[1] == default_kwargs
 
     @patch('bokeh.io.state.State.output_file')
-    def test_with_args(self, mock_output_file):
+    def test_with_args(self, mock_output_file) -> None:
         kwargs = dict(title="title", mode="cdn", root_dir="foo")
         bio.output_file("foo.html", **kwargs)
         assert mock_output_file.call_count == 1
@@ -53,7 +53,7 @@ class Test_output_file(object):
 class Test_output_notebook(object):
 
     @patch('bokeh.io.output.run_notebook_hook')
-    def test_no_args(self, mock_run_notebook_hook):
+    def test_no_args(self, mock_run_notebook_hook) -> None:
         default_load_jupyter_args = (None, False, False, 5000)
         bio.output_notebook()
         assert mock_run_notebook_hook.call_count == 1
@@ -61,7 +61,7 @@ class Test_output_notebook(object):
         assert mock_run_notebook_hook.call_args[1] == {}
 
     @patch('bokeh.io.output.run_notebook_hook')
-    def test_with_args(self, mock_run_notebook_hook):
+    def test_with_args(self, mock_run_notebook_hook) -> None:
         load_jupyter_args = (Resources(), True, True, 1000)
         bio.output_notebook(*load_jupyter_args)
         assert mock_run_notebook_hook.call_count == 1
@@ -69,7 +69,7 @@ class Test_output_notebook(object):
         assert mock_run_notebook_hook.call_args[1] == {}
 
 @patch('bokeh.io.state.State.reset')
-def test_reset_output(mock_reset):
+def test_reset_output(mock_reset) -> None:
     # might create a new one, which also calls reset
     original_call_count = curstate().reset.call_count
     bio.reset_output()

--- a/tests/unit/bokeh/io/test_saving.py
+++ b/tests/unit/bokeh/io/test_saving.py
@@ -40,21 +40,21 @@ import bokeh.io.saving as bis # isort:skip
 # Private API
 #-----------------------------------------------------------------------------
 
-def test__get_save_args_explicit_filename():
+def test__get_save_args_explicit_filename() -> None:
     filename, resources, title = bis._get_save_args(curstate(), "filename", "resources", "title")
     assert filename == "filename"
 
-def test__get_save_args_default_filename():
+def test__get_save_args_default_filename() -> None:
     curstate().reset()
     curstate().output_file("filename")
     filename, resources, title = bis._get_save_args(curstate(), None, "resources", "title")
     assert filename == "filename"
 
-def test__get_save_args_explicit_resources():
+def test__get_save_args_explicit_resources() -> None:
     filename, resources, title = bis._get_save_args(curstate(), "filename", "resources", "title")
     assert resources == "resources"
 
-def test__get_save_args_default_resources():
+def test__get_save_args_default_resources() -> None:
     curstate().reset()
     curstate().output_file("filename")
     curstate().file['resources'] = "resources"
@@ -62,7 +62,7 @@ def test__get_save_args_default_resources():
     assert resources == "resources"
 
 @patch('bokeh.io.saving.warn')
-def test__get_save_args_missing_resources(mock_warn):
+def test__get_save_args_missing_resources(mock_warn) -> None:
     curstate().reset()
     filename, resources, title = bis._get_save_args(curstate(), "filename", None, "title")
     assert resources.mode == "cdn"
@@ -72,11 +72,11 @@ def test__get_save_args_missing_resources(mock_warn):
     )
     assert mock_warn.call_args[1] == {}
 
-def test__get_save_args_explicit_title():
+def test__get_save_args_explicit_title() -> None:
     filename, resources, title = bis._get_save_args(curstate(), "filename", "resources", "title")
     assert title == "title"
 
-def test__get_save_args_default_title():
+def test__get_save_args_default_title() -> None:
     curstate().reset()
     curstate().output_file("filename")
     curstate().file['title'] = "title"
@@ -84,7 +84,7 @@ def test__get_save_args_default_title():
     assert title == "title"
 
 @patch('bokeh.io.saving.warn')
-def test__get_save_args_missing_title(mock_warn):
+def test__get_save_args_missing_title(mock_warn) -> None:
     curstate().reset()
     filename, resources, title = bis._get_save_args(curstate(), "filename", "resources", None)
     assert title == "Bokeh Plot"
@@ -97,7 +97,7 @@ def test__get_save_args_missing_title(mock_warn):
 
 @patch('io.open')
 @patch('bokeh.embed.file_html')
-def test__save_helper(mock_file_html, mock_io_open):
+def test__save_helper(mock_file_html, mock_io_open) -> None:
     obj = Plot()
     filename, resources, title = bis._get_save_args(curstate(), "filename", "resources", "title")
 

--- a/tests/unit/bokeh/io/test_showing.py
+++ b/tests/unit/bokeh/io/test_showing.py
@@ -36,7 +36,7 @@ import bokeh.io.showing as bis # isort:skip
 #-----------------------------------------------------------------------------
 
 @patch('bokeh.io.showing._show_with_state')
-def test_show_with_default_args(mock__show_with_state):
+def test_show_with_default_args(mock__show_with_state) -> None:
     curstate().reset()
     default_kwargs = dict(browser=None, new="tab", notebook_handle=False)
     p = Plot()
@@ -47,7 +47,7 @@ def test_show_with_default_args(mock__show_with_state):
     assert curdoc().roots == []
 
 @patch('bokeh.io.showing._show_with_state')
-def test_show_with_explicit_args(mock__show_with_state):
+def test_show_with_explicit_args(mock__show_with_state) -> None:
     curstate().reset()
     kwargs = dict(browser="browser", new="new", notebook_handle=True)
     p = Plot()
@@ -58,7 +58,7 @@ def test_show_with_explicit_args(mock__show_with_state):
     assert curdoc().roots == []
 
 @patch('bokeh.io.showing.run_notebook_hook')
-def test_show_with_app(mock_run_notebook_hook, ipython):
+def test_show_with_app(mock_run_notebook_hook, ipython) -> None:
     curstate().reset()
     app = Application()
     output_notebook()
@@ -70,7 +70,7 @@ def test_show_with_app(mock_run_notebook_hook, ipython):
     assert mock_run_notebook_hook.call_args[1] == {}
 
 @patch('bokeh.io.showing._show_with_state')
-def test_show_doesn_not_adds_obj_to_curdoc(m):
+def test_show_doesn_not_adds_obj_to_curdoc(m) -> None:
     curstate().reset()
     assert curstate().document.roots == []
     p = Plot()
@@ -82,7 +82,7 @@ def test_show_doesn_not_adds_obj_to_curdoc(m):
 
 @pytest.mark.parametrize('obj', [1, 2.3, None, "str", GlyphRenderer()])
 @pytest.mark.unit
-def test_show_with_bad_object(obj):
+def test_show_with_bad_object(obj) -> None:
     with pytest.raises(ValueError):
         bis.show(obj)
 

--- a/tests/unit/bokeh/io/test_state.py
+++ b/tests/unit/bokeh/io/test_state.py
@@ -33,18 +33,18 @@ import bokeh.io.state as bis # isort:skip
 
 class Test_State(object):
 
-    def test_creation(self):
+    def test_creation(self) -> None:
         s = bis.State()
         assert isinstance(s.document, Document)
         assert s.file == None
         assert s.notebook == False
 
-    def test_default_file_resources(self):
+    def test_default_file_resources(self) -> None:
         s = bis.State()
         s.output_file("foo.html")
         assert s.file['resources'].minified, True
 
-    def test_output_file(self):
+    def test_output_file(self) -> None:
         s = bis.State()
         s.output_file("foo.html")
         assert s.file['filename'] == "foo.html"
@@ -54,7 +54,7 @@ class Test_State(object):
 
     @patch('bokeh.io.state.log')
     @patch('os.path.isfile')
-    def test_output_file_file_exists(self, mock_isfile, mock_log):
+    def test_output_file_file_exists(self, mock_isfile, mock_log) -> None:
         mock_isfile.return_value = True
         s = bis.State()
         s.output_file("foo.html")
@@ -67,26 +67,26 @@ class Test_State(object):
             "Session output file 'foo.html' already exists, will be overwritten.",
         )
 
-    def test_output_notebook_noarg(self):
+    def test_output_notebook_noarg(self) -> None:
         s = bis.State()
         s.output_notebook()
         assert s.notebook == True
         assert s.notebook_type == 'jupyter'
 
-    def test_output_notebook_witharg(self):
+    def test_output_notebook_witharg(self) -> None:
         s = bis.State()
         s.output_notebook(notebook_type='notjup')
         assert s.notebook == True
         assert s.notebook_type == 'notjup'
 
-    def test_output_invalid_notebook(self):
+    def test_output_invalid_notebook(self) -> None:
         s = bis.State()
         with pytest.raises(Exception):
             s.notebook_type=None
         with pytest.raises(Exception):
             s.notebook_type=10
 
-    def test_reset(self):
+    def test_reset(self) -> None:
         s = bis.State()
         d = s.document
         s.output_file("foo.html")
@@ -97,14 +97,14 @@ class Test_State(object):
         assert isinstance(s.document, Document)
         assert s.document != d
 
-    def test_doc_set(self):
+    def test_doc_set(self) -> None:
         s = bis.State()
         d = Document()
         s.document = d
         assert isinstance(s.document, Document)
         assert s.document == d
 
-def test_curstate():
+def test_curstate() -> None:
     cs = bis.curstate()
     assert cs is bis._STATE
     print(bis.State)

--- a/tests/unit/bokeh/io/test_util__io.py
+++ b/tests/unit/bokeh/io/test_util__io.py
@@ -35,11 +35,11 @@ import bokeh.io.util as biu # isort:skip
 # Dev API
 #-----------------------------------------------------------------------------
 
-def test_detect_current_filename():
+def test_detect_current_filename() -> None:
     assert biu.detect_current_filename().endswith(("py.test", "pytest", "py.test-script.py"))
 
 @patch('bokeh.io.util.NamedTemporaryFile')
-def test_temp_filename(mock_tmp):
+def test_temp_filename(mock_tmp) -> None:
     fn = Mock()
     type(fn).name = PropertyMock(return_value="Junk.test")
     mock_tmp.return_value = fn
@@ -50,7 +50,7 @@ def test_temp_filename(mock_tmp):
     assert mock_tmp.call_args[0] == ()
     assert mock_tmp.call_args[1] == {'suffix': '.test'}
 
-def test_default_filename():
+def test_default_filename() -> None:
     old_detect_current_filename = biu.detect_current_filename
     old__no_access = biu._no_access
     old__shares_exec_prefix = biu._shares_exec_prefix
@@ -98,13 +98,13 @@ def test_default_filename():
 #-----------------------------------------------------------------------------
 
 @patch('os.access')
-def test__no_access(mock_access):
+def test__no_access(mock_access) -> None:
     biu._no_access("test")
     assert mock_access.called
     assert mock_access.call_args[0] == ("test", os.W_OK | os.X_OK)
     assert mock_access.call_args[1] == {}
 
-def test__shares_exec_prefix():
+def test__shares_exec_prefix() -> None:
     import sys
     old_ex = sys.exec_prefix
     try:

--- a/tests/unit/bokeh/io/test_webdriver.py
+++ b/tests/unit/bokeh/io/test_webdriver.py
@@ -32,11 +32,11 @@ import bokeh.io.webdriver as biw # isort:skip
 # Dev API
 #-----------------------------------------------------------------------------
 
-def test_create_phantomjs_webdriver():
+def test_create_phantomjs_webdriver() -> None:
     d = biw.create_phantomjs_webdriver()
     assert isinstance(d, selenium.webdriver.phantomjs.webdriver.WebDriver)
 
-def test_terminate_webdriver():
+def test_terminate_webdriver() -> None:
     d = biw.create_phantomjs_webdriver()
     assert d.service.process is not None
     biw.terminate_webdriver(d)
@@ -47,7 +47,7 @@ _driver_map = {
 }
 
 class Test_webdriver_control(object):
-    def test_default(self):
+    def test_default(self) -> None:
         # other tests may have interacted with the global biw.webdriver_control,
         # so create a new instance only to check default values
         wc = biw._WebdriverState()
@@ -55,7 +55,7 @@ class Test_webdriver_control(object):
         assert wc.kind == "phantomjs"
         assert wc.current is None
 
-    def test_get_with_reuse(self):
+    def test_get_with_reuse(self) -> None:
         biw.webdriver_control.reuse = True
         assert biw.webdriver_control.reuse == True
         d1 = biw.webdriver_control.get()
@@ -63,7 +63,7 @@ class Test_webdriver_control(object):
         assert d1 is d2
         biw.webdriver_control.reset()
 
-    def test_get_with_reuse_and_reset(self):
+    def test_get_with_reuse_and_reset(self) -> None:
         biw.webdriver_control.reuse = True
         assert biw.webdriver_control.reuse == True
         d1 = biw.webdriver_control.get()
@@ -74,7 +74,7 @@ class Test_webdriver_control(object):
         assert d2 is d3
         biw.webdriver_control.reset()
 
-    def test_get_without_reuse(self):
+    def test_get_without_reuse(self) -> None:
         biw.webdriver_control.reuse = False
         assert biw.webdriver_control.reuse == False
         d1 = biw.webdriver_control.get()
@@ -84,7 +84,7 @@ class Test_webdriver_control(object):
         biw.webdriver_control.reset()
 
     @pytest.mark.parametrize('kind', ['phantomjs'])
-    def test_create(self, kind):
+    def test_create(self, kind) -> None:
         biw.webdriver_control.kind = kind
         assert biw.webdriver_control.kind == kind
         d = biw.webdriver_control.create()

--- a/tests/unit/bokeh/models/test_annotations.py
+++ b/tests/unit/bokeh/models/test_annotations.py
@@ -63,7 +63,7 @@ from bokeh.models import (
 # General API
 #-----------------------------------------------------------------------------
 
-def test_Legend():
+def test_Legend() -> None:
     legend = Legend()
     assert legend.location == 'top_right'
     assert legend.orientation == 'vertical'
@@ -105,7 +105,7 @@ def test_Legend():
         prefix('inactive_', FILL))
 
 
-def test_ColorBar():
+def test_ColorBar() -> None:
     color_bar = ColorBar()
     assert color_bar.location == 'top_right'
     assert color_bar.orientation == 'vertical'
@@ -162,7 +162,7 @@ def test_ColorBar():
     )
 
 
-def test_Arrow():
+def test_Arrow() -> None:
     arrow = Arrow()
     assert arrow.x_start is None
     assert arrow.y_start is None
@@ -193,7 +193,7 @@ def test_Arrow():
         LINE)
 
 
-def test_BoxAnnotation():
+def test_BoxAnnotation() -> None:
     box = BoxAnnotation()
     assert box.left is None
     assert box.left_units == 'data'
@@ -225,7 +225,7 @@ def test_BoxAnnotation():
     ], LINE, FILL)
 
 
-def test_Band():
+def test_Band() -> None:
     band = Band()
     assert band.level == 'annotation'
     assert band.lower is None
@@ -255,7 +255,7 @@ def test_Band():
     ], LINE, FILL)
 
 
-def test_Label():
+def test_Label() -> None:
     label = Label()
     assert label.level == 'annotation'
     assert label.x is None
@@ -292,13 +292,13 @@ def test_Label():
         prefix('border_', LINE),
         prefix('background_', FILL))
 
-def test_Label_accepts_datetime_xy():
+def test_Label_accepts_datetime_xy() -> None:
     obj = Label(x = datetime(2018,8,7,0,0),
                 y = datetime(2018,8,7,0,0))
     assert obj.x == 1533600000000.0
     assert obj.y == 1533600000000.0
 
-def test_LabelSet():
+def test_LabelSet() -> None:
     label_set = LabelSet()
     assert label_set.level == 'annotation'
     assert label_set.x is None
@@ -339,7 +339,7 @@ def test_LabelSet():
         prefix('border_', LINE),
         prefix('background_', FILL))
 
-def test_Slope():
+def test_Slope() -> None:
     slope = Slope()
     assert slope.gradient is None
     assert slope.y_intercept is None
@@ -357,7 +357,7 @@ def test_Slope():
     ], LINE)
 
 
-def test_Span():
+def test_Span() -> None:
     line = Span()
     assert line.location is None
     assert line.location_units == 'data'
@@ -378,11 +378,11 @@ def test_Span():
         "render_mode"
     ], LINE)
 
-def test_Span_accepts_datetime_location():
+def test_Span_accepts_datetime_location() -> None:
     obj = Span(location = datetime(2018,8,7,0,0))
     assert obj.location == 1533600000000.0
 
-def test_Title():
+def test_Title() -> None:
     title = Title()
     assert title.level == 'annotation'
     assert title.text is None
@@ -415,7 +415,7 @@ def test_Title():
         prefix('background_', FILL))
 
 
-def test_Whisker():
+def test_Whisker() -> None:
     whisker = Whisker()
     assert whisker.level == 'underlay'
     assert whisker.lower is None
@@ -451,7 +451,7 @@ def test_Whisker():
         "y_range_name"],
         LINE)
 
-def test_Whisker_and_Band_accept_negative_values():
+def test_Whisker_and_Band_accept_negative_values() -> None:
     whisker = Whisker(base=-1., lower=-1.5, upper=-0.5)
     assert whisker.base == -1.
     assert whisker.lower == -1.5
@@ -461,7 +461,7 @@ def test_Whisker_and_Band_accept_negative_values():
     assert band.lower == -1.5
     assert band.upper == -0.5
 
-def test_can_add_multiple_glyph_renderers_to_legend_item():
+def test_can_add_multiple_glyph_renderers_to_legend_item() -> None:
     legend_item = LegendItem()
     gr_1 = GlyphRenderer()
     gr_2 = GlyphRenderer()
@@ -471,7 +471,7 @@ def test_can_add_multiple_glyph_renderers_to_legend_item():
         assert mock_logger.error.call_count == 0
 
 
-def test_legend_item_with_field_label_and_different_data_sources_raises_a_validation_error():
+def test_legend_item_with_field_label_and_different_data_sources_raises_a_validation_error() -> None:
     legend_item = LegendItem()
     gr_1 = GlyphRenderer(data_source=ColumnDataSource(data={'label': [1]}))
     gr_2 = GlyphRenderer(data_source=ColumnDataSource(data={'label': [1]}))
@@ -482,7 +482,7 @@ def test_legend_item_with_field_label_and_different_data_sources_raises_a_valida
         assert mock_logger.error.call_count == 1
 
 
-def test_legend_item_with_value_label_and_different_data_sources_does_not_raise_a_validation_error():
+def test_legend_item_with_value_label_and_different_data_sources_does_not_raise_a_validation_error() -> None:
     legend_item = LegendItem()
     gr_1 = GlyphRenderer(data_source=ColumnDataSource())
     gr_2 = GlyphRenderer(data_source=ColumnDataSource())
@@ -493,7 +493,7 @@ def test_legend_item_with_value_label_and_different_data_sources_does_not_raise_
         assert mock_logger.error.call_count == 0
 
 
-def test_legend_item_with_field_label_raises_error_if_field_not_in_cds():
+def test_legend_item_with_field_label_raises_error_if_field_not_in_cds() -> None:
     legend_item = LegendItem()
     gr_1 = GlyphRenderer(data_source=ColumnDataSource())
     legend_item.label = field('label')

--- a/tests/unit/bokeh/models/test_axes.py
+++ b/tests/unit/bokeh/models/test_axes.py
@@ -28,7 +28,7 @@ import bokeh.models.axes as bma # isort:skip
 # General API
 #-----------------------------------------------------------------------------
 
-def test_ticker_accepts_number_sequences():
+def test_ticker_accepts_number_sequences() -> None:
     a = bma.Axis(ticker=[-10, 0, 10, 20.7])
     assert isinstance(a.ticker, FixedTicker)
     assert a.ticker.ticks == [-10, 0, 10, 20.7]

--- a/tests/unit/bokeh/models/test_callbacks__models.py
+++ b/tests/unit/bokeh/models/test_callbacks__models.py
@@ -31,7 +31,7 @@ from bokeh.models import CustomJS # isort:skip
 # General API
 #-----------------------------------------------------------------------------
 
-def test_js_callback():
+def test_js_callback() -> None:
     slider = Slider()
 
     cb = CustomJS(code="foo();", args=dict(x=slider))

--- a/tests/unit/bokeh/models/test_defaults.py
+++ b/tests/unit/bokeh/models/test_defaults.py
@@ -40,7 +40,7 @@ def all_descriptors():
 
 @pytest.mark.parametrize("name, descriptor", list(all_descriptors()))
 @pytest.mark.unit
-def test_default_values(name, descriptor):
+def test_default_values(name, descriptor) -> None:
     p = descriptor.property
     assert p.is_valid(p._raw_default()) is True, "%s.%s has an invalid default value" % (name, descriptor.name)
 

--- a/tests/unit/bokeh/models/test_glyphs.py
+++ b/tests/unit/bokeh/models/test_glyphs.py
@@ -99,7 +99,7 @@ from bokeh.models.glyphs import ( # isort:skip
 # General API
 #-----------------------------------------------------------------------------
 
-def test_AnnularWedge():
+def test_AnnularWedge() -> None:
     glyph = AnnularWedge()
     assert glyph.x is None
     assert glyph.y is None
@@ -125,7 +125,7 @@ def test_AnnularWedge():
     ], FILL, LINE, GLYPH)
 
 
-def test_Annulus():
+def test_Annulus() -> None:
     glyph = Annulus()
     assert glyph.x is None
     assert glyph.y is None
@@ -143,7 +143,7 @@ def test_Annulus():
     ], FILL, LINE, GLYPH)
 
 
-def test_Arc():
+def test_Arc() -> None:
     glyph = Arc()
     assert glyph.x is None
     assert glyph.y is None
@@ -165,7 +165,7 @@ def test_Arc():
     ], LINE, GLYPH)
 
 
-def test_Bezier():
+def test_Bezier() -> None:
     glyph = Bezier()
     assert glyph.x0 is None
     assert glyph.y0 is None
@@ -188,7 +188,7 @@ def test_Bezier():
     ], LINE, GLYPH)
 
 
-def test_HArea():
+def test_HArea() -> None:
     glyph = HArea()
     assert glyph.y is None
     assert glyph.x1 is None
@@ -202,7 +202,7 @@ def test_HArea():
     ], FILL, HATCH, GLYPH)
 
 
-def test_HBar():
+def test_HBar() -> None:
     glyph = HBar()
     assert glyph.y is None
     assert glyph.height is None
@@ -219,7 +219,7 @@ def test_HBar():
     ], FILL, HATCH, LINE, GLYPH)
 
 
-def test_Image():
+def test_Image() -> None:
     glyph = Image()
     assert glyph.image is None
     assert glyph.x is None
@@ -241,7 +241,7 @@ def test_Image():
     ], GLYPH)
 
 
-def test_ImageRGBA():
+def test_ImageRGBA() -> None:
     glyph = ImageRGBA()
     assert glyph.image is None
     assert glyph.x is None
@@ -262,7 +262,7 @@ def test_ImageRGBA():
     ], GLYPH)
 
 
-def test_ImageURL():
+def test_ImageURL() -> None:
     glyph = ImageURL()
     assert glyph.url is None
     assert glyph.x is None
@@ -293,7 +293,7 @@ def test_ImageURL():
     ], GLYPH)
 
 
-def test_Line():
+def test_Line() -> None:
     glyph = Line()
     assert glyph.x is None
     assert glyph.y is None
@@ -304,7 +304,7 @@ def test_Line():
     ], LINE, GLYPH)
 
 
-def test_MultiLine():
+def test_MultiLine() -> None:
     glyph = MultiLine()
     assert glyph.xs is None
     assert glyph.ys is None
@@ -315,7 +315,7 @@ def test_MultiLine():
     ], LINE, GLYPH)
 
 
-def test_MultiPolygons():
+def test_MultiPolygons() -> None:
     glyph = MultiPolygons()
     assert glyph.xs is None
     assert glyph.ys is None
@@ -328,7 +328,7 @@ def test_MultiPolygons():
     ], FILL, HATCH, LINE, GLYPH)
 
 
-def test_Oval():
+def test_Oval() -> None:
     glyph = Oval()
     assert glyph.x is None
     assert glyph.y is None
@@ -349,7 +349,7 @@ def test_Oval():
     ], FILL, LINE, GLYPH)
 
 
-def test_Patch():
+def test_Patch() -> None:
     glyph = Patch()
     assert glyph.x is None
     assert glyph.y is None
@@ -362,7 +362,7 @@ def test_Patch():
     ], FILL, HATCH, LINE, GLYPH)
 
 
-def test_Patches():
+def test_Patches() -> None:
     glyph = Patches()
     assert glyph.xs is None
     assert glyph.ys is None
@@ -375,7 +375,7 @@ def test_Patches():
     ], FILL, HATCH, LINE, GLYPH)
 
 
-def test_Quad():
+def test_Quad() -> None:
     glyph = Quad()
     assert glyph.left is None
     assert glyph.right is None
@@ -392,7 +392,7 @@ def test_Quad():
     ], FILL, HATCH, LINE, GLYPH)
 
 
-def test_Quadratic():
+def test_Quadratic() -> None:
     glyph = Quadratic()
     assert glyph.x0 is None
     assert glyph.y0 is None
@@ -411,7 +411,7 @@ def test_Quadratic():
     ], LINE, GLYPH)
 
 
-def test_Ray():
+def test_Ray() -> None:
     glyph = Ray()
     assert glyph.x is None
     assert glyph.y is None
@@ -428,7 +428,7 @@ def test_Ray():
     ], LINE, GLYPH)
 
 
-def test_Rect():
+def test_Rect() -> None:
     glyph = Rect()
     assert glyph.x is None
     assert glyph.y is None
@@ -451,7 +451,7 @@ def test_Rect():
     ], FILL, LINE, GLYPH)
 
 
-def test_Segment():
+def test_Segment() -> None:
     glyph = Segment()
     assert glyph.x0 is None
     assert glyph.y0 is None
@@ -466,7 +466,7 @@ def test_Segment():
     ], LINE, GLYPH)
 
 
-def test_Step():
+def test_Step() -> None:
     glyph = Step()
     assert glyph.x is None
     assert glyph.y is None
@@ -479,7 +479,7 @@ def test_Step():
     ], LINE, GLYPH)
 
 
-def test_Text():
+def test_Text() -> None:
     glyph = Text()
     assert glyph.x is None
     assert glyph.y is None
@@ -497,7 +497,7 @@ def test_Text():
     ], TEXT, GLYPH)
 
 
-def test_VArea():
+def test_VArea() -> None:
     glyph = VArea()
     assert glyph.x is None
     assert glyph.y1 is None
@@ -511,7 +511,7 @@ def test_VArea():
     ], FILL, HATCH, GLYPH)
 
 
-def test_VBar():
+def test_VBar() -> None:
     glyph = VBar()
     assert glyph.x is None
     assert glyph.width is None
@@ -528,7 +528,7 @@ def test_VBar():
     ], FILL, HATCH, LINE, GLYPH)
 
 
-def test_Wedge():
+def test_Wedge() -> None:
     glyph = Wedge()
     assert glyph.x is None
     assert glyph.y is None
@@ -551,7 +551,7 @@ def test_Wedge():
     ], FILL, LINE, GLYPH)
 
 
-def test_Asterisk():
+def test_Asterisk() -> None:
     marker = Asterisk()
     check_marker_properties(marker)
     check_fill_properties(marker)
@@ -559,7 +559,7 @@ def test_Asterisk():
     check_properties_existence(marker, MARKER, FILL, LINE, GLYPH)
 
 
-def test_Circle():
+def test_Circle() -> None:
     marker = Circle()
     check_marker_properties(marker)
     assert marker.radius is None
@@ -572,7 +572,7 @@ def test_Circle():
     ], MARKER, FILL, LINE, GLYPH)
 
 
-def test_CircleCross():
+def test_CircleCross() -> None:
     marker = CircleCross()
     check_marker_properties(marker)
     check_fill_properties(marker)
@@ -580,7 +580,7 @@ def test_CircleCross():
     check_properties_existence(marker, MARKER, FILL, LINE, GLYPH)
 
 
-def test_CircleX():
+def test_CircleX() -> None:
     marker = CircleX()
     check_marker_properties(marker)
     check_fill_properties(marker)
@@ -588,7 +588,7 @@ def test_CircleX():
     check_properties_existence(marker, MARKER, FILL, LINE, GLYPH)
 
 
-def test_Cross():
+def test_Cross() -> None:
     marker = Cross()
     check_marker_properties(marker)
     check_fill_properties(marker)
@@ -596,7 +596,7 @@ def test_Cross():
     check_properties_existence(marker, MARKER, FILL, LINE, GLYPH)
 
 
-def test_Dash():
+def test_Dash() -> None:
     marker = Dash()
     check_marker_properties(marker)
     check_fill_properties(marker)
@@ -604,7 +604,7 @@ def test_Dash():
     check_properties_existence(marker, MARKER, FILL, LINE, GLYPH)
 
 
-def test_Diamond():
+def test_Diamond() -> None:
     marker = Diamond()
     check_marker_properties(marker)
     check_fill_properties(marker)
@@ -612,7 +612,7 @@ def test_Diamond():
     check_properties_existence(marker, MARKER, FILL, LINE, GLYPH)
 
 
-def test_DiamondCross():
+def test_DiamondCross() -> None:
     marker = DiamondCross()
     check_marker_properties(marker)
     check_fill_properties(marker)
@@ -620,7 +620,7 @@ def test_DiamondCross():
     check_properties_existence(marker, MARKER, FILL, LINE, GLYPH)
 
 
-def test_InvertedTriangle():
+def test_InvertedTriangle() -> None:
     marker = InvertedTriangle()
     check_marker_properties(marker)
     check_fill_properties(marker)
@@ -628,7 +628,7 @@ def test_InvertedTriangle():
     check_properties_existence(marker, MARKER, FILL, LINE, GLYPH)
 
 
-def test_Square():
+def test_Square() -> None:
     marker = Square()
     check_marker_properties(marker)
     check_fill_properties(marker)
@@ -636,7 +636,7 @@ def test_Square():
     check_properties_existence(marker, MARKER, FILL, LINE, GLYPH)
 
 
-def test_SquareCross():
+def test_SquareCross() -> None:
     marker = SquareCross()
     check_marker_properties(marker)
     check_fill_properties(marker)
@@ -644,7 +644,7 @@ def test_SquareCross():
     check_properties_existence(marker, MARKER, FILL, LINE, GLYPH)
 
 
-def test_SquareX():
+def test_SquareX() -> None:
     marker = SquareX()
     check_marker_properties(marker)
     check_fill_properties(marker)
@@ -652,7 +652,7 @@ def test_SquareX():
     check_properties_existence(marker, MARKER, FILL, LINE, GLYPH)
 
 
-def test_Triangle():
+def test_Triangle() -> None:
     marker = Triangle()
     check_marker_properties(marker)
     check_fill_properties(marker)
@@ -660,7 +660,7 @@ def test_Triangle():
     check_properties_existence(marker, MARKER, FILL, LINE, GLYPH)
 
 
-def test_X():
+def test_X() -> None:
     marker = X()
     check_marker_properties(marker)
     check_fill_properties(marker)

--- a/tests/unit/bokeh/models/test_graphs.py
+++ b/tests/unit/bokeh/models/test_graphs.py
@@ -28,12 +28,12 @@ from bokeh.models.graphs import StaticLayoutProvider, from_networkx # isort:skip
 # General API
 #-----------------------------------------------------------------------------
 
-def test_staticlayoutprovider_init_props():
+def test_staticlayoutprovider_init_props() -> None:
     provider = StaticLayoutProvider()
     assert provider.graph_layout == {}
 
 # TODO (bev) deprecation: 3.0
-def test_from_networkx_deprecated():
+def test_from_networkx_deprecated() -> None:
     G=nx.Graph()
     G.add_nodes_from([0,1,2,3])
     G.add_edges_from([[0,1], [0,2], [2,3]])

--- a/tests/unit/bokeh/models/test_grids.py
+++ b/tests/unit/bokeh/models/test_grids.py
@@ -28,7 +28,7 @@ import bokeh.models.grids as bmg # isort:skip
 # General API
 #-----------------------------------------------------------------------------
 
-def test_ticker_accepts_number_sequences():
+def test_ticker_accepts_number_sequences() -> None:
     g = bmg.Grid(ticker=[-10, 0, 10, 20.7])
     assert isinstance(g.ticker, FixedTicker)
     assert g.ticker.ticks == [-10, 0, 10, 20.7]
@@ -38,7 +38,7 @@ def test_ticker_accepts_number_sequences():
     assert isinstance(g.ticker, FixedTicker)
     assert g.ticker.ticks == [-10, 0, 10, 20.7]
 
-def test_ticker_accepts_axis():
+def test_ticker_accepts_axis() -> None:
     g = bmg.Grid(axis=LinearAxis())
     assert isinstance(g.axis, LinearAxis)
 

--- a/tests/unit/bokeh/models/test_layouts__models.py
+++ b/tests/unit/bokeh/models/test_layouts__models.py
@@ -58,12 +58,12 @@ def check_children_prop(layout_callable):
         layout_callable(children=[ColumnDataSource()])
 
 
-def test_Row():
+def test_Row() -> None:
     check_props_with_sizing_mode(Row())
     check_children_prop(Row)
 
 
-def test_Column():
+def test_Column() -> None:
     check_props_with_sizing_mode(Column())
     check_children_prop(Column)
 
@@ -85,7 +85,7 @@ def check_widget_box_children_prop(layout_callable):
         layout_callable(children=[ColumnDataSource()])
 
 
-def test_LayoutDOM_css_classes():
+def test_LayoutDOM_css_classes() -> None:
     m = LayoutDOM()
     assert m.css_classes == []
     m.css_classes = ['foo']
@@ -95,7 +95,7 @@ def test_LayoutDOM_css_classes():
 
 
 # TODO (bev) deprecation: 3.0
-def test_widgetbox_deprecated():
+def test_widgetbox_deprecated() -> None:
     from bokeh.util.deprecation import BokehDeprecationWarning
     with pytest.warns(BokehDeprecationWarning):
         WidgetBox()

--- a/tests/unit/bokeh/models/test_mappers.py
+++ b/tests/unit/bokeh/models/test_mappers.py
@@ -32,7 +32,7 @@ import bokeh.models.mappers as bmm # isort:skip
 
 class Test_CategoricalColorMapper(object):
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         mapper = bmm.CategoricalColorMapper()
         check_properties_existence(mapper, [
             "factors",
@@ -42,15 +42,15 @@ class Test_CategoricalColorMapper(object):
             "nan_color"],
         )
 
-    def test_warning_with_short_palette(self, recwarn):
+    def test_warning_with_short_palette(self, recwarn) -> None:
         bmm.CategoricalColorMapper(factors=["a", "b", "c"], palette=["red", "green"])
         assert len(recwarn) == 1
 
-    def test_no_warning_with_long_palette(self, recwarn):
+    def test_no_warning_with_long_palette(self, recwarn) -> None:
         bmm.CategoricalColorMapper(factors=["a", "b", "c"], palette=["red", "green", "orange", "blue"])
         assert len(recwarn) == 0
 
-    def test_with_pandas_index(self, pd):
+    def test_with_pandas_index(self, pd) -> None:
         fruits = ['Apples', 'Pears', 'Nectarines', 'Plums', 'Grapes', 'Strawberries']
         years = ['2015', '2016', '2017']
         data = {'2015'   : [2, 1, 4, 3, 2, 4],
@@ -66,7 +66,7 @@ class Test_CategoricalColorMapper(object):
 
 class Test_CategoricalPatternMapper(object):
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         mapper = bmm.CategoricalPatternMapper()
         check_properties_existence(mapper, [
             "factors",
@@ -78,7 +78,7 @@ class Test_CategoricalPatternMapper(object):
 
 class Test_CategoricalMarkerMapper(object):
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         mapper = bmm.CategoricalMarkerMapper()
         check_properties_existence(mapper, [
             "factors",
@@ -90,7 +90,7 @@ class Test_CategoricalMarkerMapper(object):
 
 class Test_LinearColorMapper(object):
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         mapper = bmm.LinearColorMapper()
         check_properties_existence(mapper, [
             "palette",
@@ -103,7 +103,7 @@ class Test_LinearColorMapper(object):
 
 class Test_LogColorMapper(object):
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         mapper = bmm.LogColorMapper()
         check_properties_existence(mapper, [
             "palette",

--- a/tests/unit/bokeh/models/test_markers.py
+++ b/tests/unit/bokeh/models/test_markers.py
@@ -22,7 +22,7 @@ from bokeh.models.markers import Marker, marker_types
 # Setup
 #-----------------------------------------------------------------------------
 
-def test_all_markers_in_markers_dictionary():
+def test_all_markers_in_markers_dictionary() -> None:
     not_found = [marker for marker in Marker.__subclasses__()
                  if marker not in marker_types.values()]
     assert len(not_found) == 0

--- a/tests/unit/bokeh/models/test_plots.py
+++ b/tests/unit/bokeh/models/test_plots.py
@@ -54,7 +54,7 @@ Before legend properties can be set, you must add a Legend explicitly, or call a
 
 class TestPlotLegendProperty(object):
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         plot = figure(tools='')
         x = plot.legend
         assert isinstance(x, bmp._list_attr_splat)
@@ -64,7 +64,7 @@ class TestPlotLegendProperty(object):
         assert isinstance(x, bmp._list_attr_splat)
         assert len(x) == 1
 
-    def test_warnign(self):
+    def test_warnign(self) -> None:
         plot = figure(tools='')
         with pytest.warns(UserWarning) as warns:
             plot.legend.location = "above"
@@ -78,59 +78,59 @@ class TestPlotSelect(object):
         self._plot.circle([1,2,3], [3,2,1], name='foo')
 
     @patch('bokeh.models.plots.find')
-    def test_string_arg(self, mock_find):
+    def test_string_arg(self, mock_find) -> None:
         self._plot.select('foo')
         assert mock_find.called
         assert mock_find.call_args[0][1] == dict(name='foo')
 
     @patch('bokeh.models.plots.find')
-    def test_type_arg(self, mock_find):
+    def test_type_arg(self, mock_find) -> None:
         self._plot.select(PanTool)
         assert mock_find.called
         assert mock_find.call_args[0][1] == dict(type=PanTool)
 
     @patch('bokeh.models.plots.find')
-    def test_kwargs(self, mock_find):
+    def test_kwargs(self, mock_find) -> None:
         kw = dict(name='foo', type=GlyphRenderer)
         self._plot.select(**kw)
         assert mock_find.called
         assert mock_find.call_args[0][1] == kw
 
     @patch('bokeh.models.plots.find')
-    def test_single_selector_kwarg(self, mock_find):
+    def test_single_selector_kwarg(self, mock_find) -> None:
         kw = dict(name='foo', type=GlyphRenderer)
         self._plot.select(selector=kw)
         assert mock_find.called
         assert mock_find.call_args[0][1] == kw
 
-    def test_selector_kwarg_and_extra_kwargs(self):
+    def test_selector_kwarg_and_extra_kwargs(self) -> None:
         with pytest.raises(TypeError) as exc:
             self._plot.select(selector=dict(foo='foo'), bar='bar')
         assert "when passing 'selector' keyword arg, not other keyword args may be present" == str(exc.value)
 
-    def test_bad_arg_type(self):
+    def test_bad_arg_type(self) -> None:
         with pytest.raises(TypeError) as exc:
             self._plot.select(10)
         assert "selector must be a dictionary, string or plot object." == str(exc.value)
 
-    def test_too_many_args(self):
+    def test_too_many_args(self) -> None:
         with pytest.raises(TypeError) as exc:
             self._plot.select('foo', 'bar')
         assert 'select accepts at most ONE positional argument.' == str(exc.value)
 
-    def test_no_input(self):
+    def test_no_input(self) -> None:
         with pytest.raises(TypeError) as exc:
             self._plot.select()
         assert 'select requires EITHER a positional argument, OR keyword arguments.' == str(exc.value)
 
-    def test_arg_and_kwarg(self):
+    def test_arg_and_kwarg(self) -> None:
         with pytest.raises(TypeError) as exc:
             self._plot.select('foo', type=PanTool)
         assert 'select accepts EITHER a positional argument, OR keyword arguments (not both).' == str(exc.value)
 
 class TestPlotValidation(object):
 
-    def test_missing_renderers(self):
+    def test_missing_renderers(self) -> None:
         p = figure()
         p.renderers = []
         with mock.patch('bokeh.core.validation.check.log') as mock_logger:
@@ -138,7 +138,7 @@ class TestPlotValidation(object):
         assert mock_logger.warning.call_count == 1
         assert mock_logger.warning.call_args[0][0].startswith("W-1000 (MISSING_RENDERERS): Plot has no renderers")
 
-    def test_missing_scale(self):
+    def test_missing_scale(self) -> None:
         p = figure()
         p.x_scale = None
         with mock.patch('bokeh.core.validation.check.log') as mock_logger:
@@ -152,7 +152,7 @@ class TestPlotValidation(object):
         assert mock_logger.error.call_count == 1
         assert mock_logger.error.call_args[0][0].startswith("E-1008 (REQUIRED_SCALE): A required Scale object is missing: x_scale, y_scale")
 
-    def test_missing_range(self):
+    def test_missing_range(self) -> None:
         p = figure()
         p.x_range = None
         with mock.patch('bokeh.core.validation.check.log') as mock_logger:
@@ -166,7 +166,7 @@ class TestPlotValidation(object):
         assert mock_logger.error.call_count == 1
         assert mock_logger.error.call_args[0][0].startswith("E-1004 (REQUIRED_RANGE): A required Range object is missing: x_range, y_range")
 
-    def test_bad_extra_range_name(self):
+    def test_bad_extra_range_name(self) -> None:
         p = figure()
         p.xaxis.x_range_name="junk"
         with mock.patch('bokeh.core.validation.check.log') as mock_logger:
@@ -196,27 +196,27 @@ class TestPlotValidation(object):
             check_integrity([p])
         assert mock_logger.error.call_count == 0
 
-def test_plot_add_layout_raises_error_if_not_render():
+def test_plot_add_layout_raises_error_if_not_render() -> None:
     plot = figure()
     with pytest.raises(ValueError):
         plot.add_layout(Range1d())
 
 
-def test_plot_add_layout_adds_label_to_plot_renderers():
+def test_plot_add_layout_adds_label_to_plot_renderers() -> None:
     plot = figure()
     label = Label()
     plot.add_layout(label)
     assert label in plot.center
 
 
-def test_plot_add_layout_adds_axis_to_renderers_and_side_renderers():
+def test_plot_add_layout_adds_axis_to_renderers_and_side_renderers() -> None:
     plot = figure()
     axis = LinearAxis()
     plot.add_layout(axis, 'left')
     assert axis in plot.left
 
 
-def test_sizing_mode_property_is_fixed_by_default():
+def test_sizing_mode_property_is_fixed_by_default() -> None:
     plot = figure()
     assert plot.sizing_mode is None
 
@@ -230,10 +230,10 @@ class BaseTwinAxis(object):
         range_obj['foo_range'] = self.get_range_instance()
         assert range_obj['foo_range']
 
-    def test_x_range(self):
+    def test_x_range(self) -> None:
         self.verify_axis('x')
 
-    def test_y_range(self):
+    def test_y_range(self) -> None:
         self.verify_axis('y')
 
     @staticmethod
@@ -257,12 +257,12 @@ class TestLinearTwinAxis(BaseTwinAxis, object):
         return Range1d(0, 42)
 
 
-def test_plot_with_no_title_specified_creates_an_empty_title():
+def test_plot_with_no_title_specified_creates_an_empty_title() -> None:
     plot = Plot()
     assert plot.title.text == ""
 
 
-def test_plot__scale_classmethod():
+def test_plot__scale_classmethod() -> None:
     assert isinstance(Plot._scale("auto"), LinearScale)
     assert isinstance(Plot._scale("linear"), LinearScale)
     assert isinstance(Plot._scale("log"), LogScale)
@@ -271,19 +271,19 @@ def test_plot__scale_classmethod():
         Plot._scale("malformed_type")
 
 
-def test__check_required_scale_has_scales():
+def test__check_required_scale_has_scales() -> None:
     plot = Plot()
     check = plot._check_required_scale()
     assert check == []
 
 
-def test__check_required_scale_missing_scales():
+def test__check_required_scale_missing_scales() -> None:
     plot = Plot(x_scale=None, y_scale=None)
     check = plot._check_required_scale()
     assert check != []
 
 
-def test__check_compatible_scale_and_ranges_compat_numeric():
+def test__check_compatible_scale_and_ranges_compat_numeric() -> None:
     plot = Plot(x_scale=LinearScale(), x_range=Range1d())
     check = plot._check_compatible_scale_and_ranges()
     assert check == []
@@ -294,19 +294,19 @@ def test__check_compatible_scale_and_ranges_compat_numeric():
     assert check == []
 
 
-def test__check_compatible_scale_and_ranges_compat_factor():
+def test__check_compatible_scale_and_ranges_compat_factor() -> None:
     plot = Plot(x_scale=CategoricalScale(), x_range=FactorRange())
     check = plot._check_compatible_scale_and_ranges()
     assert check == []
 
 
-def test__check_compatible_scale_and_ranges_incompat_numeric_scale_and_factor_range():
+def test__check_compatible_scale_and_ranges_incompat_numeric_scale_and_factor_range() -> None:
     plot = Plot(x_scale=LinearScale(), x_range=FactorRange())
     check = plot._check_compatible_scale_and_ranges()
     assert check != []
 
 
-def test__check_compatible_scale_and_ranges_incompat_factor_scale_and_numeric_range():
+def test__check_compatible_scale_and_ranges_incompat_factor_scale_and_numeric_range() -> None:
     plot = Plot(x_scale=CategoricalScale(), x_range=DataRange1d())
     check = plot._check_compatible_scale_and_ranges()
     assert check != []
@@ -321,7 +321,7 @@ def test__check_compatible_scale_and_ranges_incompat_factor_scale_and_numeric_ra
 
 class Test_list_attr_splat(object):
 
-    def test_set(self):
+    def test_set(self) -> None:
         obj = bmp._list_attr_splat([DataRange1d(), DataRange1d()])
         assert len(obj) == 2
         assert obj[0].start == None
@@ -330,13 +330,13 @@ class Test_list_attr_splat(object):
         assert obj[0].start == 10
         assert obj[1].start == 10
 
-    def test_set_empty(self):
+    def test_set_empty(self) -> None:
         obj = bmp._list_attr_splat([])
         assert len(obj) == 0
         obj.start = 10
         assert len(obj) == 0
 
-    def test_get_set_single(self):
+    def test_get_set_single(self) -> None:
         p = figure()
         assert len(p.xaxis) == 1
 
@@ -349,7 +349,7 @@ class Test_list_attr_splat(object):
         assert p.xaxis.formatter.power_limit_low == 100
         assert p.xaxis[0].formatter.power_limit_low == 100
 
-    def test_get_set_multi(self):
+    def test_get_set_multi(self) -> None:
         p = figure()
         assert len(p.axis) == 2
 
@@ -366,23 +366,23 @@ class Test_list_attr_splat(object):
         assert p.axis.formatter[0].power_limit_low == 100
         assert p.axis.formatter[1].power_limit_low == 100
 
-    def test_get_set_multi_mismatch(self):
+    def test_get_set_multi_mismatch(self) -> None:
         obj = bmp._list_attr_splat([LinearAxis(), FactorRange()])
         with pytest.raises(AttributeError) as e:
             obj.formatter.power_limit_low == 10
         assert str(e.value).endswith("list items have no %r attribute" % "formatter")
 
-    def test_get_empty(self):
+    def test_get_empty(self) -> None:
         obj = bmp._list_attr_splat([])
         with pytest.raises(AttributeError) as e:
             obj.start
         assert str(e.value).endswith("Trying to access %r attribute on an empty 'splattable' list" % "start")
 
-    def test_get_index(self):
+    def test_get_index(self) -> None:
         obj = bmp._list_attr_splat([1, 2, 3])
         assert obj.index(2) == 1
 
-    def test_pop_value(self):
+    def test_pop_value(self) -> None:
         obj = bmp._list_attr_splat([1, 2, 3])
         obj.pop(1)
         assert obj == [1, 3]

--- a/tests/unit/bokeh/models/test_ranges.py
+++ b/tests/unit/bokeh/models/test_ranges.py
@@ -38,7 +38,7 @@ from bokeh.models import Range1d, DataRange1d, FactorRange # isort:skip
 
 class Test_Range1d(object):
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         r = Range1d()
         check_properties_existence(r, [
             "start",
@@ -50,72 +50,72 @@ class Test_Range1d(object):
             "max_interval"],
         )
 
-    def test_init_with_timedelta(self):
+    def test_init_with_timedelta(self) -> None:
         range1d = Range1d(start=-dt.timedelta(seconds=5), end=dt.timedelta(seconds=3))
         assert range1d.start == -dt.timedelta(seconds=5)
         assert range1d.end == dt.timedelta(seconds=3)
         assert range1d.bounds is None
 
-    def test_init_with_datetime(self):
+    def test_init_with_datetime(self) -> None:
         range1d = Range1d(start=dt.datetime(2016, 4, 28, 2, 20, 50), end=dt.datetime(2017, 4, 28, 2, 20, 50))
         assert range1d.start == dt.datetime(2016, 4, 28, 2, 20, 50)
         assert range1d.end == dt.datetime(2017, 4, 28, 2, 20, 50)
         assert range1d.bounds is None
 
-    def test_init_with_float(self):
+    def test_init_with_float(self) -> None:
         range1d = Range1d(start=-1.0, end=3.0)
         assert range1d.start == -1.0
         assert range1d.end == 3.0
         assert range1d.bounds is None
 
-    def test_init_with_int(self):
+    def test_init_with_int(self) -> None:
         range1d = Range1d(start=-1, end=3)
         assert range1d.start == -1
         assert range1d.end == 3
         assert range1d.bounds is None
 
-    def test_init_with_positional_arguments(self):
+    def test_init_with_positional_arguments(self) -> None:
         range1d = Range1d(1, 2)
         assert range1d.start == 1
         assert range1d.end == 2
         assert range1d.bounds is None
 
-    def test_init_with_keyword_arguments(self):
+    def test_init_with_keyword_arguments(self) -> None:
         range1d = Range1d(start=1, end=2)
         assert range1d.start == 1
         assert range1d.end == 2
         assert range1d.bounds is None
 
-    def test_cannot_initialize_with_both_keyword_and_positional_arguments(self):
+    def test_cannot_initialize_with_both_keyword_and_positional_arguments(self) -> None:
         with pytest.raises(ValueError):
             Range1d(1, 2, start=1, end=2)
 
 
-    def test_cannot_initialize_with_three_positional_arguments(self):
+    def test_cannot_initialize_with_three_positional_arguments(self) -> None:
         with pytest.raises(ValueError):
             Range1d(1, 2, 3)
 
 
-    def test_with_max_bound_smaller_than_min_bounded_raises_valueerror(self):
+    def test_with_max_bound_smaller_than_min_bounded_raises_valueerror(self) -> None:
         with pytest.raises(ValueError):
             Range1d(1, 2, bounds=(1, 0))
         with pytest.raises(ValueError):
             Range1d(1, 2, bounds=[1, 0])
 
 
-    def test_bounds_with_text_rejected_as_the_correct_value_error(self):
+    def test_bounds_with_text_rejected_as_the_correct_value_error(self) -> None:
         with pytest.raises(ValueError) as e:
             Range1d(1, 2, bounds="21")  # The string is indexable, so this may not fail properly
         assert e.value.args[0].startswith('expected an element of either')
 
 
-    def test_bounds_with_three_item_tuple_raises_valueerror(self):
+    def test_bounds_with_three_item_tuple_raises_valueerror(self) -> None:
         with pytest.raises(ValueError):
             Range1d(1, 2, bounds=(0, 1, 2))
 
 class Test_DataRange1d(object):
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         r = DataRange1d()
         check_properties_existence(r, [
             "names",
@@ -134,42 +134,42 @@ class Test_DataRange1d(object):
             "only_visible"],
         )
 
-    def test_init_with_no_arguments(self):
+    def test_init_with_no_arguments(self) -> None:
         datarange1d = DataRange1d()
         assert datarange1d.start is None
         assert datarange1d.end is None
         assert datarange1d.bounds is None
 
-    def test_init_with_timedelta(self):
+    def test_init_with_timedelta(self) -> None:
         datarange1d = DataRange1d(start=-dt.timedelta(seconds=5), end=dt.timedelta(seconds=3))
         assert datarange1d.start == -dt.timedelta(seconds=5)
         assert datarange1d.end == dt.timedelta(seconds=3)
         assert datarange1d.bounds is None
 
-    def test_init_with_datetime(self):
+    def test_init_with_datetime(self) -> None:
         datarange1d = DataRange1d(start=dt.datetime(2016, 4, 28, 2, 20, 50), end=dt.datetime(2017, 4, 28, 2, 20, 50))
         assert datarange1d.start == dt.datetime(2016, 4, 28, 2, 20, 50)
         assert datarange1d.end == dt.datetime(2017, 4, 28, 2, 20, 50)
         assert datarange1d.bounds is None
 
-    def test_init_with_float(self):
+    def test_init_with_float(self) -> None:
         datarange1d = DataRange1d(start=-1.0, end=3.0)
         assert datarange1d.start == -1.0
         assert datarange1d.end == 3.0
         assert datarange1d.bounds is None
 
-    def test_init_with_int(self):
+    def test_init_with_int(self) -> None:
         datarange1d = DataRange1d(start=-1, end=3)
         assert datarange1d.start == -1
         assert datarange1d.end == 3
         assert datarange1d.bounds is None
 
-    def test_init_with_follow_sets_bounds_to_none(self):
+    def test_init_with_follow_sets_bounds_to_none(self) -> None:
         datarange1d = DataRange1d(follow="start")
         assert datarange1d.follow == "start"
         assert datarange1d.bounds is None
 
-    def test_init_with_bad_bounds(self):
+    def test_init_with_bad_bounds(self) -> None:
         with pytest.raises(ValueError):
             DataRange1d(1, 2, bounds=(1, 0))
         with pytest.raises(ValueError):
@@ -180,7 +180,7 @@ class Test_DataRange1d(object):
 
 class Test_FactorRange(object):
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         r = FactorRange()
         check_properties_existence(r, [
             "factors",
@@ -196,7 +196,7 @@ class Test_FactorRange(object):
             "max_interval"],
         )
 
-    def test_init_defauls(self):
+    def test_init_defauls(self) -> None:
         factor_range = FactorRange("a", "b")
         assert factor_range.factors == ["a", "b"]
         assert factor_range.range_padding == 0
@@ -208,7 +208,7 @@ class Test_FactorRange(object):
         assert factor_range.min_interval == None
         assert factor_range.max_interval == None
 
-    def test_init_with_positional_arguments(self):
+    def test_init_with_positional_arguments(self) -> None:
         factor_range = FactorRange("a", "b")
         assert factor_range.factors == ["a", "b"]
 
@@ -218,15 +218,15 @@ class Test_FactorRange(object):
         factor_range = FactorRange(["a", "x", "1'"], ["b", "y", "2"])
         assert factor_range.factors == [["a", "x", "1'"], ["b", "y", "2"]]
 
-    def test_init_with_keyword_arguments(self):
+    def test_init_with_keyword_arguments(self) -> None:
         factor_range = FactorRange(factors=["a", "b", "c", "d", "e"])
         assert factor_range.factors == ["a", "b", "c", "d", "e"]
 
-    def test_cannot_initialize_with_both_keyword_and_positional_arguments(self):
+    def test_cannot_initialize_with_both_keyword_and_positional_arguments(self) -> None:
         with pytest.raises(ValueError):
             FactorRange(["a", "b", "c"], factors=["a", "b", "c"])
 
-    def test_duplicate_factors_raises_validation_error(self):
+    def test_duplicate_factors_raises_validation_error(self) -> None:
         r = FactorRange("foo", "bar", "foo")
         with mock.patch('bokeh.core.validation.check.log') as mock_logger:
             check_integrity([r])

--- a/tests/unit/bokeh/models/test_renderers.py
+++ b/tests/unit/bokeh/models/test_renderers.py
@@ -31,7 +31,7 @@ import bokeh.models.renderers as bmr # isort:skip
 class TestGlyphRenderer(object):
 
     @pytest.mark.parametrize('glyph', [Line, Patch])
-    def test_check_cdsview_filters_with_connected_error(self, glyph):
+    def test_check_cdsview_filters_with_connected_error(self, glyph) -> None:
         renderer = bmr.GlyphRenderer()
         renderer.glyph = glyph()
 
@@ -44,7 +44,7 @@ class TestGlyphRenderer(object):
 
 class TestGraphRenderer(object):
 
-    def test_init_props(self):
+    def test_init_props(self) -> None:
         renderer = bmr.GraphRenderer()
         assert renderer.x_range_name == "default"
         assert renderer.y_range_name == "default"
@@ -52,13 +52,13 @@ class TestGraphRenderer(object):
         assert renderer.edge_renderer.data_source.data == dict(start=[], end=[])
         assert renderer.layout_provider is None
 
-    def test_check_malformed_graph_source_no_errors(self):
+    def test_check_malformed_graph_source_no_errors(self) -> None:
         renderer = bmr.GraphRenderer()
 
         check = renderer._check_malformed_graph_source()
         assert check == []
 
-    def test_check_malformed_graph_source_no_node_index(self):
+    def test_check_malformed_graph_source_no_node_index(self) -> None:
         node_source = ColumnDataSource()
         node_renderer = bmr.GlyphRenderer(data_source=node_source, glyph=Circle())
         renderer = bmr.GraphRenderer(node_renderer=node_renderer)
@@ -66,7 +66,7 @@ class TestGraphRenderer(object):
         check = renderer._check_malformed_graph_source()
         assert check != []
 
-    def test_check_malformed_graph_source_no_edge_start_or_end(self):
+    def test_check_malformed_graph_source_no_edge_start_or_end(self) -> None:
         edge_source = ColumnDataSource()
         edge_renderer = bmr.GlyphRenderer(data_source=edge_source, glyph=MultiLine())
         renderer = bmr.GraphRenderer(edge_renderer=edge_renderer)

--- a/tests/unit/bokeh/models/test_sources.py
+++ b/tests/unit/bokeh/models/test_sources.py
@@ -42,35 +42,35 @@ import bokeh.models.sources as bms # isort:skip
 
 class TestColumnDataSource(object):
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         ds = bms.ColumnDataSource()
         assert isinstance(ds, bms.DataSource)
         assert isinstance(ds.selected, Selection)
 
-    def test_selected_is_readonly(self):
+    def test_selected_is_readonly(self) -> None:
         ds = bms.ColumnDataSource()
         with pytest.raises(RuntimeError) as e:
             ds.selected = Selection()
             assert str(e).endswith("ColumnDataSource.selected is a readonly property")
 
-    def test_selected_serialized(self):
+    def test_selected_serialized(self) -> None:
         ds = bms.ColumnDataSource()
         prop = ds.lookup('selected')
         assert prop.serialized == True
 
-    def test_init_dict_arg(self):
+    def test_init_dict_arg(self) -> None:
         data = dict(a=[1], b=[2])
         ds = bms.ColumnDataSource(data)
         assert ds.data == data
         assert set(ds.column_names) == set(data.keys())
 
-    def test_init_dict_data_kwarg(self):
+    def test_init_dict_data_kwarg(self) -> None:
         data = dict(a=[1], b=[2])
         ds = bms.ColumnDataSource(data=data)
         assert ds.data == data
         assert set(ds.column_names) == set(data.keys())
 
-    def test_init_dataframe_arg(self, pd):
+    def test_init_dataframe_arg(self, pd) -> None:
         data = dict(a=[1, 2], b=[2, 3])
         df = pd.DataFrame(data)
         ds = bms.ColumnDataSource(df)
@@ -82,7 +82,7 @@ class TestColumnDataSource(object):
         assert [0, 1] == list(ds.data['index'])
         assert set(ds.column_names) - set(df.columns) == set(["index"])
 
-    def test_data_accepts_dataframe_arg(self, pd):
+    def test_data_accepts_dataframe_arg(self, pd) -> None:
         data = dict(a=[1, 2], b=[2, 3])
         df = pd.DataFrame(data)
         ds = bms.ColumnDataSource()
@@ -96,7 +96,7 @@ class TestColumnDataSource(object):
         assert [0, 1] == list(ds.data['index'])
         assert set(ds.column_names) - set(df.columns) == set(["index"])
 
-    def test_init_dataframe_data_kwarg(self, pd):
+    def test_init_dataframe_data_kwarg(self, pd) -> None:
         data = dict(a=[1, 2], b=[2, 3])
         df = pd.DataFrame(data)
         ds = bms.ColumnDataSource(data=df)
@@ -108,7 +108,7 @@ class TestColumnDataSource(object):
         assert [0, 1] == list(ds.data['index'])
         assert set(ds.column_names) - set(df.columns) == set(["index"])
 
-    def test_init_dataframe_index_named_column(self, pd):
+    def test_init_dataframe_index_named_column(self, pd) -> None:
         data = dict(a=[1, 2], b=[2, 3], index=[4, 5])
         df = pd.DataFrame(data)
         ds = bms.ColumnDataSource(data=df)
@@ -120,7 +120,7 @@ class TestColumnDataSource(object):
         assert [0, 1] == list(ds.data['level_0'])
         assert set(ds.column_names) - set(df.columns) == set(["level_0"])
 
-    def test_data_accepts_dataframe_index_named_column(self, pd):
+    def test_data_accepts_dataframe_index_named_column(self, pd) -> None:
         data = dict(a=[1, 2], b=[2, 3], index=[4, 5])
         df = pd.DataFrame(data)
         ds = bms.ColumnDataSource()
@@ -134,7 +134,7 @@ class TestColumnDataSource(object):
         assert [0, 1] == list(ds.data['level_0'])
         assert set(ds.column_names) - set(df.columns) == set(["level_0"])
 
-    def test_init_dataframe_column_categoricalindex(self, pd):
+    def test_init_dataframe_column_categoricalindex(self, pd) -> None:
         columns = pd.CategoricalIndex(['a', 'b'])
         data = [[0,2], [1,3]]
         df = pd.DataFrame(columns=columns, data=data)
@@ -147,7 +147,7 @@ class TestColumnDataSource(object):
         assert [0, 1] == list(ds.data['index'])
         assert set(ds.column_names) - set(df.columns) == set(["index"])
 
-    def test_data_accepts_dataframe_column_categoricalindex(self, pd):
+    def test_data_accepts_dataframe_column_categoricalindex(self, pd) -> None:
         columns = pd.CategoricalIndex(['a', 'b'])
         data = [[0,2], [1,3]]
         df = pd.DataFrame(columns=columns, data=data)
@@ -162,19 +162,19 @@ class TestColumnDataSource(object):
         assert [0, 1] == list(ds.data['index'])
         assert set(ds.column_names) - set(df.columns) == set(["index"])
 
-    def test_init_dataframe_nonstring_named_column(self, pd):
+    def test_init_dataframe_nonstring_named_column(self, pd) -> None:
         data = {1: [1, 2], 2: [2, 3]}
         df = pd.DataFrame(data)
         with pytest.raises(ValueError, match=r'expected an element of.*'):
             bms.ColumnDataSource(data=df)
 
-    def test_init_dataframe_nonstring_named_multicolumn(self, pd):
+    def test_init_dataframe_nonstring_named_multicolumn(self, pd) -> None:
         data = {(1, 2): [1, 2], (2, 3): [2, 3]}
         df = pd.DataFrame(data)
         with pytest.raises(TypeError, match=r'Could not flatten.*'):
             bms.ColumnDataSource(data=df)
 
-    def test_init_groupby_arg(self, pd):
+    def test_init_groupby_arg(self, pd) -> None:
         from bokeh.sampledata.autompg import autompg as df
         group = df.groupby(by=['origin', 'cyl'])
         ds = bms.ColumnDataSource(group)
@@ -186,7 +186,7 @@ class TestColumnDataSource(object):
             assert isinstance(ds.data[k2], np.ndarray)
             assert list(s[key]) == list(ds.data[k2])
 
-    def test_data_accepts_groupby_arg(self, pd):
+    def test_data_accepts_groupby_arg(self, pd) -> None:
         from bokeh.sampledata.autompg import autompg as df
         group = df.groupby(by=['origin', 'cyl'])
         ds = bms.ColumnDataSource()
@@ -200,7 +200,7 @@ class TestColumnDataSource(object):
             assert isinstance(ds.data[k2], np.ndarray)
             assert list(s[key]) == list(ds.data[k2])
 
-    def test_init_groupby_data_kwarg(self, pd):
+    def test_init_groupby_data_kwarg(self, pd) -> None:
         from bokeh.sampledata.autompg import autompg as df
         group = df.groupby(by=['origin', 'cyl'])
         ds = bms.ColumnDataSource(data=group)
@@ -212,7 +212,7 @@ class TestColumnDataSource(object):
             assert isinstance(ds.data[k2], np.ndarray)
             assert list(s[key]) == list(ds.data[k2])
 
-    def test_init_groupby_with_None_subindex_name(self, pd):
+    def test_init_groupby_with_None_subindex_name(self, pd) -> None:
         df = pd.DataFrame({"A": [1, 2, 3, 4] * 2, "B": [10, 20, 30, 40] * 2, "C": range(8)})
         group = df.groupby(['A', [10, 20, 30, 40] * 2])
         ds = bms.ColumnDataSource(data=group)
@@ -224,7 +224,7 @@ class TestColumnDataSource(object):
             assert isinstance(ds.data[k2], np.ndarray)
             assert list(s[key]) == list(ds.data[k2])
 
-    def test_data_accepts_groupby_with_None_subindex_name(self, pd):
+    def test_data_accepts_groupby_with_None_subindex_name(self, pd) -> None:
         df = pd.DataFrame({"A": [1, 2, 3, 4] * 2, "B": [10, 20, 30, 40] * 2, "C": range(8)})
         group = df.groupby(['A', [10, 20, 30, 40] * 2])
         ds = bms.ColumnDataSource()
@@ -238,7 +238,7 @@ class TestColumnDataSource(object):
             assert isinstance(ds.data[k2], np.ndarray)
             assert list(s[key]) == list(ds.data[k2])
 
-    def test_init_propertyvaluecolumndata_copy(self):
+    def test_init_propertyvaluecolumndata_copy(self) -> None:
         data = dict(a=[1], b=[2])
         cd = bms.ColumnDataSource(data).data
         ds = bms.ColumnDataSource(data=cd)
@@ -247,35 +247,35 @@ class TestColumnDataSource(object):
         ds.data['a'][0] = 2
         assert cd['a'][0] == 2
 
-    def test_add_with_name(self):
+    def test_add_with_name(self) -> None:
         ds = bms.ColumnDataSource()
         name = ds.add([1,2,3], name="foo")
         assert name == "foo"
         name = ds.add([4,5,6], name="bar")
         assert name == "bar"
 
-    def test_add_without_name(self):
+    def test_add_without_name(self) -> None:
         ds = bms.ColumnDataSource()
         name = ds.add([1,2,3])
         assert name == "Series 0"
         name = ds.add([4,5,6])
         assert name == "Series 1"
 
-    def test_add_with_and_without_name(self):
+    def test_add_with_and_without_name(self) -> None:
         ds = bms.ColumnDataSource()
         name = ds.add([1,2,3], "foo")
         assert name == "foo"
         name = ds.add([4,5,6])
         assert name == "Series 1"
 
-    def test_remove_exists(self):
+    def test_remove_exists(self) -> None:
         ds = bms.ColumnDataSource()
         name = ds.add([1,2,3], "foo")
         assert name
         ds.remove("foo")
         assert ds.column_names == []
 
-    def test_remove_exists2(self):
+    def test_remove_exists2(self) -> None:
         with warnings.catch_warnings(record=True) as w:
             ds = bms.ColumnDataSource()
             ds.remove("foo")
@@ -284,7 +284,7 @@ class TestColumnDataSource(object):
             assert w[0].category == UserWarning
             assert str(w[0].message) == "Unable to find column 'foo' in data source"
 
-    def test_stream_bad_data(self):
+    def test_stream_bad_data(self) -> None:
         ds = bms.ColumnDataSource(data=dict(a=[10], b=[20]))
         with pytest.raises(ValueError, match=r"Must stream updates to all existing columns \(missing: a, b\)"):
             ds.stream(dict())
@@ -300,15 +300,15 @@ class TestColumnDataSource(object):
         with pytest.raises(ValueError, match=r"stream\(...\) only supports 1d sequences, got ndarray with size \(.*"):
             ds.stream(dict(a=[10], b=np.ones((1,1))))
 
-    def test__df_index_name_with_named_index(self, pd):
+    def test__df_index_name_with_named_index(self, pd) -> None:
         df = pd.DataFrame(dict(a=[10], b=[20], c=[30])).set_index('c')
         assert bms.ColumnDataSource._df_index_name(df) == "c"
 
-    def test__df_index_name_with_unnamed_index(self, pd):
+    def test__df_index_name_with_unnamed_index(self, pd) -> None:
         df = pd.DataFrame(dict(a=[10], b=[20], c=[30]))
         assert bms.ColumnDataSource._df_index_name(df) == "index"
 
-    def test__df_index_name_with_named_multi_index(self, pd):
+    def test__df_index_name_with_named_multi_index(self, pd) -> None:
         data = io.StringIO(u'''
 Fruit,Color,Count,Price
 Apple,Red,3,$1.29
@@ -321,14 +321,14 @@ Lime,Green,99,$0.39
         assert df.index.names == ['Fruit', 'Color']
         assert bms.ColumnDataSource._df_index_name(df) == "Fruit_Color"
 
-    def test__df_index_name_with_unnamed_multi_index(self, pd):
+    def test__df_index_name_with_unnamed_multi_index(self, pd) -> None:
         arrays = [np.array(['bar', 'bar', 'baz', 'baz', 'foo', 'foo', 'qux', 'qux']),
                   np.array(['one', 'two', 'one', 'two', 'one', 'two', 'one', 'two'])]
         df = pd.DataFrame(np.random.randn(8, 4), index=arrays)
         assert df.index.names == [None, None]
         assert bms.ColumnDataSource._df_index_name(df) == "index"
 
-    def test__stream_good_data(self):
+    def test__stream_good_data(self) -> None:
         ds = bms.ColumnDataSource(data=dict(a=[10], b=[20]))
         ds._document = "doc"
         stuff = {}
@@ -343,7 +343,7 @@ Lime,Green,99,$0.39
         assert stuff['args'] == ("doc", ds, dict(a=[11, 12], b=[21, 22]), "foo", mock_setter)
         assert stuff['kw'] == {}
 
-    def test_stream_good_data(self):
+    def test_stream_good_data(self) -> None:
         ds = bms.ColumnDataSource(data=dict(a=[10], b=[20]))
         ds._document = "doc"
         stuff = {}
@@ -357,7 +357,7 @@ Lime,Green,99,$0.39
         assert stuff['args'] == ("doc", ds, dict(a=[11, 12], b=[21, 22]), "foo", None)
         assert stuff['kw'] == {}
 
-    def test__stream_good_datetime64_data(self):
+    def test__stream_good_datetime64_data(self) -> None:
         now = dt.datetime.now()
         dates = np.array([now+dt.timedelta(i) for i in range(1, 10)], dtype='datetime64')
         ds = bms.ColumnDataSource(data=dict(index=dates, b=list(range(1, 10))))
@@ -374,7 +374,7 @@ Lime,Green,99,$0.39
         ds._stream(dict(index=new_date, b=[10]), "foo", mock_setter)
         assert np.array_equal(stuff['args'][2]['index'], new_date)
 
-    def test__stream_good_datetime64_data_transformed(self):
+    def test__stream_good_datetime64_data_transformed(self) -> None:
         now = dt.datetime.now()
         dates = np.array([now+dt.timedelta(i) for i in range(1, 10)], dtype='datetime64')
         dates = convert_datetime_array(dates)
@@ -393,7 +393,7 @@ Lime,Green,99,$0.39
         transformed_date = convert_datetime_array(new_date)
         assert np.array_equal(stuff['args'][2]['index'], transformed_date)
 
-    def test__stream_good_df_with_date_index_data(self, pd):
+    def test__stream_good_df_with_date_index_data(self, pd) -> None:
         df = pd.DataFrame(
             index=pd.date_range('now', periods=30, freq='T'),
             columns=['A'],
@@ -417,7 +417,7 @@ Lime,Green,99,$0.39
         assert np.array_equal(stuff['args'][2]['index'], new_df.index.values)
         assert np.array_equal(stuff['args'][2]['A'], new_df.A.values)
 
-    def test__stream_good_dict_of_index_and_series_data(self, pd):
+    def test__stream_good_dict_of_index_and_series_data(self, pd) -> None:
         df = pd.DataFrame(
             index=pd.date_range('now', periods=30, freq='T'),
             columns=['A'],
@@ -441,7 +441,7 @@ Lime,Green,99,$0.39
         assert np.array_equal(stuff['args'][2]['index'], new_df.index.values)
         assert np.array_equal(stuff['args'][2]['A'], new_df.A.values)
 
-    def test__stream_good_dict_of_index_and_series_data_transformed(self, pd):
+    def test__stream_good_dict_of_index_and_series_data_transformed(self, pd) -> None:
         df = pd.DataFrame(
             index=pd.date_range('now', periods=30, freq='T'),
             columns=['A'],
@@ -472,7 +472,7 @@ Lime,Green,99,$0.39
             assert type(v) == np.ndarray
             assert np.array_equal(v, d2[k])
 
-    def test_stream_dict_to_ds_created_from_df(self, pd):
+    def test_stream_dict_to_ds_created_from_df(self, pd) -> None:
         data = pd.DataFrame(dict(a=[10], b=[20], c=[30])).set_index('c')
         ds = bms.ColumnDataSource(data)
         ds._document = "doc"
@@ -523,7 +523,7 @@ Lime,Green,99,$0.39
                                                 b=np.array([20, 21, 22]),
                                                 c=np.array([30, 31, 32])))
 
-    def test_stream_series_to_ds_created_from_df(self, pd):
+    def test_stream_series_to_ds_created_from_df(self, pd) -> None:
         data = pd.DataFrame(dict(a=[10], b=[20], c=[30]))
         ds = bms.ColumnDataSource(data)
         ds._document = "doc"
@@ -576,7 +576,7 @@ Lime,Green,99,$0.39
                                                 c=np.array([30, 31]),
                                                 index=np.array([0, 0])))
 
-    def test_stream_df_to_ds_created_from_df_named_index(self, pd):
+    def test_stream_df_to_ds_created_from_df_named_index(self, pd) -> None:
         data = pd.DataFrame(dict(a=[10], b=[20], c=[30])).set_index('c')
         ds = bms.ColumnDataSource(data)
         ds._document = "doc"
@@ -629,7 +629,7 @@ Lime,Green,99,$0.39
                                                 b=np.array([20, 21, 22]),
                                                 c=np.array([30, 31, 32])))
 
-    def test_stream_df_to_ds_created_from_df_default_index(self, pd):
+    def test_stream_df_to_ds_created_from_df_default_index(self, pd) -> None:
         data = pd.DataFrame(dict(a=[10], b=[20], c=[30]))
         ds = bms.ColumnDataSource(data)
         ds._document = "doc"
@@ -685,7 +685,7 @@ Lime,Green,99,$0.39
                                                 c=np.array([30, 31, 32]),
                                                 index=np.array([0, 0, 1])))
 
-    def test_patch_bad_columns(self):
+    def test_patch_bad_columns(self) -> None:
         ds = bms.ColumnDataSource(data=dict(a=[10, 11], b=[20, 21]))
         with pytest.raises(ValueError, match=r"Can only patch existing columns \(extra: c\)"):
             ds.patch(dict(c=[(0, 100)]))
@@ -693,12 +693,12 @@ Lime,Green,99,$0.39
             ds.patch(dict(a=[(0,100)], c=[(0, 100)], d=[(0, 100)]))
 
 
-    def test_patch_bad_simple_indices(self):
+    def test_patch_bad_simple_indices(self) -> None:
         ds = bms.ColumnDataSource(data=dict(a=[10, 11], b=[20, 21]))
         with pytest.raises(ValueError, match=r"Out-of bounds index \(3\) in patch for column: a"):
             ds.patch(dict(a=[(3, 100)]))
 
-    def test_patch_good_simple_indices(self):
+    def test_patch_good_simple_indices(self) -> None:
         ds = bms.ColumnDataSource(data=dict(a=[10, 11], b=[20, 21]))
         ds._document = "doc"
         stuff = {}
@@ -711,7 +711,7 @@ Lime,Green,99,$0.39
         assert stuff['args'] == ("doc", ds, dict(a=[(0,100), (1,101)], b=[(0,200)]), mock_setter)
         assert stuff['kw'] == {}
 
-    def test_patch_bad_slice_indices(self):
+    def test_patch_bad_slice_indices(self) -> None:
         ds = bms.ColumnDataSource(data=dict(a=[10, 11, 12, 13, 14, 15], b=[20, 21, 22, 23, 24, 25]))
         with pytest.raises(ValueError, match=r"Out-of bounds slice index stop \(10\) in patch for column: a"):
             ds.patch(dict(a=[(slice(10), list(range(10)))]))
@@ -727,7 +727,7 @@ Lime,Green,99,$0.39
             ds.patch(dict(a=[(slice(1, 10, -1), list(range(10)))]))
 
 
-    def test_patch_good_slice_indices(self):
+    def test_patch_good_slice_indices(self) -> None:
         ds = bms.ColumnDataSource(data=dict(a=[10, 11, 12, 13, 14, 15], b=[20, 21, 22, 23, 24, 25]))
         ds._document = "doc"
         stuff = {}
@@ -740,7 +740,7 @@ Lime,Green,99,$0.39
         assert stuff['args'] == ("doc", ds, dict(a=[(slice(2), [100, 101]), (slice(3, 5), [100, 101])], b=[(slice(0, None, 2), [100, 101, 102])]), mock_setter)
         assert stuff['kw'] == {}
 
-    def test_data_column_lengths(self):
+    def test_data_column_lengths(self) -> None:
         # TODO: use this when soft=False
         #
         #with pytest.raises(ValueError):
@@ -781,27 +781,27 @@ Lime,Green,99,$0.39
         assert len(warns) == 1
         assert str(warns[0].message) == "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 3), ('b', 2)"
 
-    def test_set_data_from_json_list(self):
+    def test_set_data_from_json_list(self) -> None:
         ds = bms.ColumnDataSource()
         data = {"foo": [1, 2, 3]}
         ds.set_from_json('data', data)
         assert ds.data == data
 
-    def test_set_data_from_json_base64(self):
+    def test_set_data_from_json_base64(self) -> None:
         ds = bms.ColumnDataSource()
         data = {"foo": np.arange(3, dtype=np.int64)}
         json = transform_column_source_data(data)
         ds.set_from_json('data', json)
         assert np.array_equal(ds.data["foo"], data["foo"])
 
-    def test_set_data_from_json_nested_base64(self):
+    def test_set_data_from_json_nested_base64(self) -> None:
         ds = bms.ColumnDataSource()
         data = {"foo": [[np.arange(3, dtype=np.int64)]]}
         json = transform_column_source_data(data)
         ds.set_from_json('data', json)
         assert np.array_equal(ds.data["foo"], data["foo"])
 
-    def test_set_data_from_json_nested_base64_and_list(self):
+    def test_set_data_from_json_nested_base64_and_list(self) -> None:
         ds = bms.ColumnDataSource()
         data = {"foo": [np.arange(3, dtype=np.int64), [1, 2, 3]]}
         json = transform_column_source_data(data)

--- a/tests/unit/bokeh/models/test_tools.py
+++ b/tests/unit/bokeh/models/test_tools.py
@@ -33,7 +33,7 @@ from bokeh.models.tools import Toolbar, ToolbarBox # isort:skip
 # General API
 #-----------------------------------------------------------------------------
 
-def test_Toolbar():
+def test_Toolbar() -> None:
     tb = Toolbar()
     assert tb.active_drag == 'auto'
     assert tb.active_inspect == 'auto'
@@ -42,7 +42,7 @@ def test_Toolbar():
     assert tb.autohide is False
 
 
-def test_Toolbar_with_autohide():
+def test_Toolbar_with_autohide() -> None:
     tb = Toolbar(autohide=True)
     assert tb.active_drag == 'auto'
     assert tb.active_inspect == 'auto'
@@ -54,18 +54,18 @@ def test_Toolbar_with_autohide():
 # ToolbarBox
 #
 
-def test_toolbar_box_is_instance_of_LayoutDOM():
+def test_toolbar_box_is_instance_of_LayoutDOM() -> None:
     tb_box = ToolbarBox()
     assert isinstance(tb_box, LayoutDOM)
 
 
-def test_toolbar_box_properties():
+def test_toolbar_box_properties() -> None:
     tb_box = ToolbarBox()
     assert tb_box.toolbar_location == "right"
 
 
 @mock.patch('bokeh.io.showing._show_with_state')
-def test_toolbar_box_with_no_children_does_not_raise_a_bokeh_warning(mock__show_with_state):
+def test_toolbar_box_with_no_children_does_not_raise_a_bokeh_warning(mock__show_with_state) -> None:
     # This is the normal way a ToolbarBox would be instantiated for example in
     # a gridplot. So we don't want to worry people with warnings. The children
     # for the ToolbarBox are created on the JS side.

--- a/tests/unit/bokeh/models/widgets/test_slider.py
+++ b/tests/unit/bokeh/models/widgets/test_slider.py
@@ -37,13 +37,13 @@ basicConfig()
 # General API
 #-----------------------------------------------------------------------------
 
-def test_daterangeslider_value_as_datetime_when_set_as_datetime():
+def test_daterangeslider_value_as_datetime_when_set_as_datetime() -> None:
     start = datetime(2017, 8, 9, 0, 0)
     end = datetime(2017, 8, 10, 0, 0)
     s = mws.DateRangeSlider(start=start, end=end, value=(start, end))
     assert s.value_as_datetime == (start, end)
 
-def test_daterangeslider_value_as_datetime_when_set_as_timestamp():
+def test_daterangeslider_value_as_datetime_when_set_as_timestamp() -> None:
     start = datetime(2017, 8, 9, 0, 0)
     end = datetime(2017, 8, 10, 0, 0)
     s = mws.DateRangeSlider(start=start, end=end,
@@ -52,7 +52,7 @@ def test_daterangeslider_value_as_datetime_when_set_as_timestamp():
             value=(convert_datetime_type(start), convert_datetime_type(end)))
     assert s.value_as_datetime == (start, end)
 
-def test_daterangeslider_value_as_datetime_when_set_mixed():
+def test_daterangeslider_value_as_datetime_when_set_mixed() -> None:
     start = datetime(2017, 8, 9, 0, 0)
     end = datetime(2017, 8, 10, 0, 0)
     s = mws.DateRangeSlider(start=start, end=end,
@@ -63,13 +63,13 @@ def test_daterangeslider_value_as_datetime_when_set_mixed():
             value=(convert_datetime_type(start), end))
     assert s.value_as_datetime == (start, end)
 
-def test_daterangeslider_value_as_date_when_set_as_date():
+def test_daterangeslider_value_as_date_when_set_as_date() -> None:
     start = date(2017, 8, 9)
     end = date(2017, 8, 10)
     s = mws.DateRangeSlider(start=start, end=end, value=(start, end))
     assert s.value_as_date == (start, end)
 
-def test_daterangeslider_value_as_date_when_set_as_timestamp():
+def test_daterangeslider_value_as_date_when_set_as_timestamp() -> None:
     start = date(2017, 8, 9)
     end = date(2017, 8, 10)
     s = mws.DateRangeSlider(start=start, end=end,
@@ -78,7 +78,7 @@ def test_daterangeslider_value_as_date_when_set_as_timestamp():
             value=(convert_date_to_datetime(start), convert_date_to_datetime(end)))
     assert s.value_as_date == (start, end)
 
-def test_daterangeslider_value_as_date_when_set_mixed():
+def test_daterangeslider_value_as_date_when_set_mixed() -> None:
     start = date(2017, 8, 9)
     end = date(2017, 8, 10)
     s = mws.DateRangeSlider(start=start, end=end,
@@ -89,13 +89,13 @@ def test_daterangeslider_value_as_date_when_set_mixed():
             value=(convert_date_to_datetime(start), end))
     assert s.value_as_date == (start, end)
 
-def test_rangeslider_equal_start_end_exception():
+def test_rangeslider_equal_start_end_exception() -> None:
     start = 0
     end = 0
     with pytest.raises(ValueError):
         mws.RangeSlider(start=start, end=end)
 
-def test_rangeslider_equal_start_end_validation(caplog):
+def test_rangeslider_equal_start_end_validation(caplog) -> None:
     start = 0
     end = 10
     s = mws.RangeSlider(start=start, end=end)

--- a/tests/unit/bokeh/plotting/test__decorators.py
+++ b/tests/unit/bokeh/plotting/test__decorators.py
@@ -52,7 +52,7 @@ _renderer_args_values = {
 }
 @pytest.mark.parametrize('arg,values', [(arg, _renderer_args_values[arg]) for arg in RENDERER_ARGS])
 @pytest.mark.unit
-def test__glyph_receives_renderer_arg(arg, values):
+def test__glyph_receives_renderer_arg(arg, values) -> None:
     for value in values:
         with mock.patch('bokeh.plotting._renderer.GlyphRenderer', autospec=True) as gr_mock:
             def foo(**kw): pass

--- a/tests/unit/bokeh/plotting/test__graph.py
+++ b/tests/unit/bokeh/plotting/test__graph.py
@@ -34,7 +34,7 @@ import bokeh.plotting._graph as bpg # isort:skip
 
 class Test_get_graph_kwargs(object):
 
-    def test_convert_dataframes_to_sources(self, pd):
+    def test_convert_dataframes_to_sources(self, pd) -> None:
         node_source = pd.DataFrame(data=dict(foo=[]))
         edge_source = pd.DataFrame(data=dict(start=[], end=[], bar=[]))
 
@@ -44,7 +44,7 @@ class Test_get_graph_kwargs(object):
         assert set(kw['node_renderer'].data_source.data.keys()) == {"index", "foo"}
         assert set(kw['edge_renderer'].data_source.data.keys()) == {"index", "start", "end", "bar"}
 
-    def test_handle_sources(self):
+    def test_handle_sources(self) -> None:
         node_source = ColumnDataSource(data=dict(foo=[]))
         edge_source = ColumnDataSource(data=dict(start=[], end=[], bar=[]))
 
@@ -53,7 +53,7 @@ class Test_get_graph_kwargs(object):
         assert set(kw['node_renderer'].data_source.data.keys()) == {"foo"}
         assert set(kw['edge_renderer'].data_source.data.keys()) == {"start", "end", "bar"}
 
-    def test_handle_node_property_mixins(self):
+    def test_handle_node_property_mixins(self) -> None:
         kwargs = dict(node_fill_color="purple", node_selection_fill_color="blue",
                     node_nonselection_fill_color="yellow", node_hover_fill_color="red",
                     node_muted_fill_color="orange", node_radius=0.6)
@@ -73,12 +73,12 @@ class Test_get_graph_kwargs(object):
         assert r.hover_glyph.radius == 0.6
         assert r.muted_glyph.radius == 0.6
 
-    def test_handle_node_marker(self):
+    def test_handle_node_marker(self) -> None:
         kw = bpg.get_graph_kwargs({}, {}, node_marker='x')
         node_glyph = kw['node_renderer'].glyph
         assert isinstance(node_glyph, X)
 
-    def test_handle_node_marker_dataspec_correctly(self):
+    def test_handle_node_marker_dataspec_correctly(self) -> None:
         node_source = {'marker': ['square', 'circle', 'x']}
 
         kw = bpg.get_graph_kwargs(node_source, {}, node_marker='marker')
@@ -87,7 +87,7 @@ class Test_get_graph_kwargs(object):
         assert isinstance(node_glyph, Scatter)
         assert node_glyph.marker == {'field': 'marker'}
 
-    def test_handle_edge_property_mixins(self):
+    def test_handle_edge_property_mixins(self) -> None:
         kwargs = dict(edge_line_color="purple", edge_selection_line_color="blue",
                     edge_nonselection_line_color="yellow", edge_hover_line_color="red",
                     edge_muted_line_color="orange", edge_line_width=23)

--- a/tests/unit/bokeh/plotting/test__lengends.py
+++ b/tests/unit/bokeh/plotting/test__lengends.py
@@ -43,12 +43,12 @@ LEGEND_KWS = ['legend', 'legend_label', 'legend_field', 'legend_group']
 #-----------------------------------------------------------------------------
 
 @pytest.mark.parametrize('key', LEGEND_KWS)
-def test_pop_legend_kwarg(key):
+def test_pop_legend_kwarg(key) -> None:
     kws = {'foo': 10, key: 'bar'}
     assert bpl.pop_legend_kwarg(kws) == {key: "bar"}
 
 @pytest.mark.parametrize('keys', all_combinations(LEGEND_KWS))
-def test_pop_legend_kwarg_error(keys):
+def test_pop_legend_kwarg_error(keys) -> None:
     kws = dict(zip(keys, range(len(keys))))
     with pytest.raises(ValueError):
         bpl.pop_legend_kwarg(kws)
@@ -57,7 +57,7 @@ def test_pop_legend_kwarg_error(keys):
 # Private API
 #-----------------------------------------------------------------------------
 
-def test__find_legend_item():
+def test__find_legend_item() -> None:
     legend = Legend(items=[LegendItem(label=dict(value="foo")), LegendItem(label=dict(field="bar"))])
     assert bpl._find_legend_item(dict(value="baz"), legend) is None
     assert bpl._find_legend_item(dict(value="foo"), legend) is legend.items[0]
@@ -66,11 +66,11 @@ def test__find_legend_item():
 class Test__handle_legend_deprecated(object):
 
     @pytest.mark.parametrize('arg', [1, 2.7, None, False, [], {'junk': 10}, {'label': 'foo', 'junk': 10}, {'value': 'foo', 'junk': 10}])
-    def test_bad_arg(self, arg):
+    def test_bad_arg(self, arg) -> None:
         with pytest.raises(ValueError):
             bpl._handle_legend_deprecated(arg, "legend", "renderer")
 
-    def test_value_string(self):
+    def test_value_string(self) -> None:
         legend = Legend(items=[LegendItem(label=dict(value="foo"))])
         renderer = GlyphRenderer(data_source=ColumnDataSource())
         bpl._handle_legend_deprecated("foo", legend, renderer)
@@ -80,7 +80,7 @@ class Test__handle_legend_deprecated(object):
         assert len(legend.items) == 2
         assert all("value" in item.label for item in legend.items)
 
-    def test_value_dict(self):
+    def test_value_dict(self) -> None:
         legend = Legend(items=[LegendItem(label=dict(value="foo"))])
         renderer = GlyphRenderer(data_source=ColumnDataSource())
         bpl._handle_legend_deprecated(dict(value="foo"), legend, renderer)
@@ -90,7 +90,7 @@ class Test__handle_legend_deprecated(object):
         assert len(legend.items) == 2
         assert all("value" in item.label for item in legend.items)
 
-    def test_field_string(self):
+    def test_field_string(self) -> None:
         legend = Legend(items=[LegendItem(label=dict(field="foo"))])
         renderer = GlyphRenderer(data_source=ColumnDataSource(data=dict(foo=[], bar=[])))
         bpl._handle_legend_deprecated("foo", legend, renderer)
@@ -100,7 +100,7 @@ class Test__handle_legend_deprecated(object):
         assert len(legend.items) == 2
         assert all("field" in item.label for item in legend.items)
 
-    def test_field_dict(self):
+    def test_field_dict(self) -> None:
         legend = Legend(items=[LegendItem(label=dict(field="foo"))])
         renderer = GlyphRenderer(data_source=ColumnDataSource(data=dict(foo=[], bar=[])))
         bpl._handle_legend_deprecated(dict(field="foo"), legend, renderer)
@@ -113,11 +113,11 @@ class Test__handle_legend_deprecated(object):
 class Test__handle_legend_field(object):
 
     @pytest.mark.parametrize('arg', [1, 2.7, None, False, [], {}])
-    def test_bad_arg(self, arg):
+    def test_bad_arg(self, arg) -> None:
         with pytest.raises(ValueError):
             bpl._handle_legend_field(arg, "legend", "renderer")
 
-    def test_label_already_exists(self):
+    def test_label_already_exists(self) -> None:
         legend = Legend(items=[LegendItem(label=dict(field="foo"))])
         renderer = GlyphRenderer()
         bpl._handle_legend_field("foo", legend, renderer)
@@ -125,7 +125,7 @@ class Test__handle_legend_field(object):
         assert legend.items[0].label == dict(field="foo")
         assert legend.items[0].renderers == [renderer]
 
-    def test_label_not_already_exists(self):
+    def test_label_not_already_exists(self) -> None:
         legend = Legend(items=[LegendItem(label=dict(field="foo"))])
         renderer = GlyphRenderer()
         bpl._handle_legend_field("bar", legend, renderer)
@@ -138,17 +138,17 @@ class Test__handle_legend_field(object):
 class Test__handle_legend_group(object):
 
     @pytest.mark.parametrize('arg', [1, 2.7, None, False, [], {}])
-    def test_bad_arg(self, arg):
+    def test_bad_arg(self, arg) -> None:
         with pytest.raises(ValueError):
             bpl._handle_legend_group(arg, "legend", "renderer")
 
-    def test_bad_source(self):
+    def test_bad_source(self) -> None:
         with pytest.raises(ValueError):
             bpl._handle_legend_group("foo", "legend", GlyphRenderer())
         with pytest.raises(ValueError):
             bpl._handle_legend_group("foo", "legend", GlyphRenderer(data_source=ColumnDataSource(data=dict(bar=[]))))
 
-    def test_items(self):
+    def test_items(self) -> None:
         source = ColumnDataSource(data=dict(foo=[10,10,20,30,20,30,40]))
         renderer = GlyphRenderer(data_source=source)
         legend = Legend(items=[])
@@ -173,11 +173,11 @@ class Test__handle_legend_group(object):
 class Test__handle_legend_label(object):
 
     @pytest.mark.parametrize('arg', [1, 2.7, None, False, [], {}])
-    def test_bad_arg(self, arg):
+    def test_bad_arg(self, arg) -> None:
         with pytest.raises(ValueError):
             bpl._handle_legend_label(arg, "legend", "renderer")
 
-    def test_label_already_exists(self):
+    def test_label_already_exists(self) -> None:
         legend = Legend(items=[LegendItem(label=dict(value="foo"))])
         renderer = GlyphRenderer()
         bpl._handle_legend_label("foo", legend, renderer)
@@ -185,7 +185,7 @@ class Test__handle_legend_label(object):
         assert legend.items[0].label == dict(value="foo")
         assert legend.items[0].renderers == [renderer]
 
-    def test_label_not_already_exists(self):
+    def test_label_not_already_exists(self) -> None:
         legend = Legend(items=[LegendItem(label=dict(value="foo"))])
         renderer = GlyphRenderer()
         bpl._handle_legend_label("bar", legend, renderer)

--- a/tests/unit/bokeh/plotting/test__plot.py
+++ b/tests/unit/bokeh/plotting/test__plot.py
@@ -52,7 +52,7 @@ import bokeh.plotting._plot as bpp # isort:skip
 
 class test_get_scale_factor_range(object):
 
-    def test_numeric_range_linear_axis():
+    def test_numeric_range_linear_axis() -> None:
         s = bpp.get_scale(Range1d(), "linear")
         assert isinstance(s, LinearScale)
 
@@ -62,53 +62,53 @@ class test_get_scale_factor_range(object):
         s = bpp.get_scale(Range1d(), "auto")
         assert isinstance(s, LinearScale)
 
-    def test_numeric_range_log_axis():
+    def test_numeric_range_log_axis() -> None:
         s = bpp.get_scale(DataRange1d(), "log")
         assert isinstance(s, LogScale)
 
-    def test_factor_range():
+    def test_factor_range() -> None:
         s = bpp.get_scale(FactorRange(), "auto")
         assert isinstance(s, CategoricalScale)
 
 class Test_get_range(object):
 
-    def test_with_None(self):
+    def test_with_None(self) -> None:
         r = bpp.get_range(None)
         assert isinstance(r, DataRange1d)
 
-    def test_with_Range(self):
+    def test_with_Range(self) -> None:
         for t in [Range1d, DataRange1d, FactorRange]:
             rng = t()
             r = bpp.get_range(rng)
             assert r is rng
 
-    def test_with_ndarray(self):
+    def test_with_ndarray(self) -> None:
         r = bpp.get_range(np.array([10, 20]))
         assert isinstance(r, Range1d)
         assert r.start == 10
         assert r.end == 20
 
-    def test_with_too_long_ndarray(self):
+    def test_with_too_long_ndarray(self) -> None:
         with pytest.raises(ValueError):
             bpp.get_range(np.array([10, 20, 30]))
 
-    def test_with_ndarray_factors(self):
+    def test_with_ndarray_factors(self) -> None:
         f = np.array(["Crosby", "Stills", "Nash", "Young"])
         r = bpp.get_range(f)
         assert isinstance(r, FactorRange)
         assert r.factors == list(f)
 
-    def test_with_series(self, pd):
+    def test_with_series(self, pd) -> None:
         r = bpp.get_range(pd.Series([20, 30]))
         assert isinstance(r, Range1d)
         assert r.start == 20
         assert r.end == 30
 
-    def test_with_too_long_series(self, pd):
+    def test_with_too_long_series(self, pd) -> None:
         with pytest.raises(ValueError):
             bpp.get_range(pd.Series([20, 30, 40]))
 
-    def test_with_string_seq(self):
+    def test_with_string_seq(self) -> None:
         f = ["foo" ,"end", "baz"]
         for t in [list, tuple]:
             r = bpp.get_range(t(f))
@@ -116,7 +116,7 @@ class Test_get_range(object):
             # FactorRange accepts Seq, but get_range always sets a list copy
             assert r.factors == f
 
-    def test_with_float_bounds(self):
+    def test_with_float_bounds(self) -> None:
         r = bpp.get_range((1.2, 10))
         assert isinstance(r, Range1d)
         assert r.start == 1.2
@@ -127,7 +127,7 @@ class Test_get_range(object):
         assert r.start == 1.2
         assert r.end == 10
 
-    def test_with_pandas_group(self, pd):
+    def test_with_pandas_group(self, pd) -> None:
         from bokeh.sampledata.iris import flowers
         g = flowers.groupby('species')
         r = bpp.get_range(g)
@@ -144,35 +144,35 @@ class Test__get_axis_class(object):
 
     @pytest.mark.parametrize('range', _RANGES)
     @pytest.mark.unit
-    def test_axis_type_None(self, range):
+    def test_axis_type_None(self, range) -> None:
         assert(bpp._get_axis_class(None, range, 0)) == (None, {})
         assert(bpp._get_axis_class(None, range, 1)) == (None, {})
 
     @pytest.mark.parametrize('range', _RANGES)
     @pytest.mark.unit
-    def test_axis_type_linear(self, range):
+    def test_axis_type_linear(self, range) -> None:
         assert(bpp._get_axis_class("linear", range, 0)) == (LinearAxis, {})
         assert(bpp._get_axis_class("linear", range, 1)) == (LinearAxis, {})
 
     @pytest.mark.parametrize('range', _RANGES)
     @pytest.mark.unit
-    def test_axis_type_log(self, range):
+    def test_axis_type_log(self, range) -> None:
         assert(bpp._get_axis_class("log", range, 0)) == (LogAxis, {})
         assert(bpp._get_axis_class("log", range, 1)) == (LogAxis, {})
 
     @pytest.mark.parametrize('range', _RANGES)
     @pytest.mark.unit
-    def test_axis_type_datetime(self, range):
+    def test_axis_type_datetime(self, range) -> None:
         assert(bpp._get_axis_class("datetime", range, 0)) == (DatetimeAxis, {})
         assert(bpp._get_axis_class("datetime", range, 1)) == (DatetimeAxis, {})
 
     @pytest.mark.parametrize('range', _RANGES)
     @pytest.mark.unit
-    def test_axis_type_mercator(self, range):
+    def test_axis_type_mercator(self, range) -> None:
         assert(bpp._get_axis_class("mercator", range, 0)) == (MercatorAxis, {'dimension': 'lon'})
         assert(bpp._get_axis_class("mercator", range, 1)) == (MercatorAxis, {'dimension': 'lat'})
 
-    def test_axis_type_auto(self):
+    def test_axis_type_auto(self) -> None:
         assert(bpp._get_axis_class("auto", FactorRange(), 0)) == (CategoricalAxis, {})
         assert(bpp._get_axis_class("auto", FactorRange(), 1)) == (CategoricalAxis, {})
         assert(bpp._get_axis_class("auto", DataRange1d(), 0)) == (LinearAxis, {})
@@ -184,7 +184,7 @@ class Test__get_axis_class(object):
 
     @pytest.mark.parametrize('range', _RANGES)
     @pytest.mark.unit
-    def test_axis_type_error(self, range):
+    def test_axis_type_error(self, range) -> None:
         with pytest.raises(ValueError):
             bpp._get_axis_class("junk", range, 0)
         with pytest.raises(ValueError):

--- a/tests/unit/bokeh/plotting/test__renderer.py
+++ b/tests/unit/bokeh/plotting/test__renderer.py
@@ -38,7 +38,7 @@ import bokeh.plotting._renderer as bpr # isort:skip
 
 class Test__pop_visuals(object):
 
-    def test_basic_prop(self):
+    def test_basic_prop(self) -> None:
         kwargs = dict(fill_alpha=0.7, line_alpha=0.8, line_color="red")
         ca = bpr.pop_visuals(Circle, kwargs)
         assert ca['fill_alpha'] == 0.7
@@ -47,7 +47,7 @@ class Test__pop_visuals(object):
         assert ca["fill_color"] == "#1f77b4"
         assert set(ca) == { "fill_color", "line_color", "fill_alpha", "line_alpha" }
 
-    def test_basic_trait(self):
+    def test_basic_trait(self) -> None:
         kwargs = dict(fill_alpha=0.7, alpha=0.8, color="red")
         ca = bpr.pop_visuals(Circle, kwargs)
         assert ca['fill_alpha'] == 0.7
@@ -56,14 +56,14 @@ class Test__pop_visuals(object):
         assert ca["fill_color"] == "red"
         assert set(ca) == { "fill_color", "line_color", "fill_alpha", "line_alpha" }
 
-    def test_override_defaults_with_prefix(self):
+    def test_override_defaults_with_prefix(self) -> None:
         glyph_kwargs = dict(fill_alpha=1, line_alpha=1)
         kwargs=dict(alpha=0.6)
         ca = bpr.pop_visuals(Circle, kwargs, prefix='nonselection_', defaults=glyph_kwargs, override_defaults={'alpha':0.1})
         assert ca['fill_alpha'] == 0.1
         assert ca['line_alpha'] == 0.1
 
-    def test_defaults(self):
+    def test_defaults(self) -> None:
         kwargs = dict(fill_alpha=0.7, line_alpha=0.8, line_color="red")
         ca = bpr.pop_visuals(Circle, kwargs, defaults=dict(line_color="blue", fill_color="green"))
         assert ca['fill_alpha'] == 0.7
@@ -72,7 +72,7 @@ class Test__pop_visuals(object):
         assert ca["fill_color"] == "green"
         assert set(ca) == { "fill_color", "line_color", "fill_alpha", "line_alpha" }
 
-    def test_override_defaults(self):
+    def test_override_defaults(self) -> None:
         kwargs = dict(fill_alpha=0.7, line_alpha=0.8)
         ca = bpr.pop_visuals(Circle, kwargs, defaults=dict(line_color="blue", fill_color="green"), override_defaults=dict(color="white"))
         assert ca['fill_alpha'] == 0.7
@@ -99,7 +99,7 @@ class Test__pop_visuals(object):
 # }
 # @pytest.mark.parametrize('arg,values', [(arg, _renderer_args_values[arg]) for arg in bpr.RENDERER_ARGS])
 # @pytest.mark.unit
-# def test__glyph_receives_renderer_arg(arg, values):
+# def test__glyph_receives_renderer_arg(arg, values) -> None:
 #     for value in values:
 #         with mock.patch('bokeh.plotting.helpers.GlyphRenderer', autospec=True) as gr_mock:
 #             fn = bpd._glyph_function(Marker)

--- a/tests/unit/bokeh/plotting/test__stack.py
+++ b/tests/unit/bokeh/plotting/test__stack.py
@@ -31,25 +31,25 @@ import bokeh.plotting._stack as bps # isort:skip
 
 class Test_single_stack(object):
 
-    def test_raises_when_spec_in_kwargs(self):
+    def test_raises_when_spec_in_kwargs(self) -> None:
         with pytest.raises(ValueError) as e:
             bps.single_stack(['a', 'b'], 'foo', foo=10)
 
         assert str(e.value).endswith("Stack property 'foo' cannot appear in keyword args")
 
-    def test_raises_when_kwargs_list_lengths_differ(self):
+    def test_raises_when_kwargs_list_lengths_differ(self) -> None:
         with pytest.raises(ValueError) as e:
             bps.single_stack(['a', 'b'], 'foo', baz=[1, 2], quux=[3,4,5])
 
         assert str(e.value).endswith("Keyword argument sequences for broadcasting must all be the same lengths. Got lengths: [2, 3]")
 
-    def test_raises_when_kwargs_list_lengths_and_stackers_lengths_differ(self):
+    def test_raises_when_kwargs_list_lengths_and_stackers_lengths_differ(self) -> None:
         with pytest.raises(ValueError) as e:
             bps.single_stack(['a', 'b', 'c'], 'foo',  baz=[1, 2], quux=[3,4])
 
         assert str(e.value).endswith("Keyword argument sequences for broadcasting must be the same length as stackers")
 
-    def test_broadcast_with_no_kwargs(self):
+    def test_broadcast_with_no_kwargs(self) -> None:
         stackers = ['a', 'b', 'c', 'd']
         kws = bps.single_stack(stackers, 'start')
         assert len(kws) == len(stackers)
@@ -57,7 +57,7 @@ class Test_single_stack(object):
             assert set(['start', 'name']) == set(kw.keys())
             assert list(kw['start']['expr'].fields) == stackers[:i+1]
 
-    def test_broadcast_with_scalar_kwargs(self):
+    def test_broadcast_with_scalar_kwargs(self) -> None:
         stackers = ['a', 'b', 'c', 'd']
         kws = bps.single_stack(stackers, 'start', foo=10, bar="baz")
         assert len(kws) == len(stackers)
@@ -68,7 +68,7 @@ class Test_single_stack(object):
             assert kw['bar'] == "baz"
             assert kw['name'] == stackers[i]
 
-    def test_broadcast_with_list_kwargs(self):
+    def test_broadcast_with_list_kwargs(self) -> None:
         stackers = ['a', 'b', 'c', 'd']
         kws = bps.single_stack(stackers, 'start', foo=[10, 20, 30, 40], bar="baz")
         assert len(kws) == len(stackers)
@@ -79,7 +79,7 @@ class Test_single_stack(object):
             assert kw['bar'] == "baz"
             assert kw['name'] == stackers[i]
 
-    def test_broadcast_name_scalar_overrides(self):
+    def test_broadcast_name_scalar_overrides(self) -> None:
         stackers = ['a', 'b', 'c', 'd']
         kws = bps.single_stack(stackers, 'start', foo=[10, 20, 30, 40], bar="baz", name="name")
         assert len(kws) == len(stackers)
@@ -90,7 +90,7 @@ class Test_single_stack(object):
             assert kw['bar'] == "baz"
             assert kw['name'] == "name"
 
-    def test_broadcast_name_list_overrides(self):
+    def test_broadcast_name_list_overrides(self) -> None:
         names = ["aa", "bb", "cc", "dd"]
         stackers = ['a', 'b', 'c', 'd']
         kws = bps.single_stack(stackers, 'start', foo=[10, 20, 30, 40], bar="baz", name=names)
@@ -104,7 +104,7 @@ class Test_single_stack(object):
 
 class Test_double_stack(object):
 
-    def test_raises_when_spec_in_kwargs(self):
+    def test_raises_when_spec_in_kwargs(self) -> None:
         with pytest.raises(ValueError) as e:
             bps.double_stack(['a', 'b'], 'foo', 'bar', foo=10)
 
@@ -115,19 +115,19 @@ class Test_double_stack(object):
 
         assert str(e.value).endswith("Stack property 'bar' cannot appear in keyword args")
 
-    def test_raises_when_kwargs_list_lengths_differ(self):
+    def test_raises_when_kwargs_list_lengths_differ(self) -> None:
         with pytest.raises(ValueError) as e:
             bps.double_stack(['a', 'b'], 'foo', 'bar', baz=[1, 2], quux=[3,4,5])
 
         assert str(e.value).endswith("Keyword argument sequences for broadcasting must all be the same lengths. Got lengths: [2, 3]")
 
-    def test_raises_when_kwargs_list_lengths_and_stackers_lengths_differ(self):
+    def test_raises_when_kwargs_list_lengths_and_stackers_lengths_differ(self) -> None:
         with pytest.raises(ValueError) as e:
             bps.double_stack(['a', 'b', 'c'], 'foo', 'bar', baz=[1, 2], quux=[3,4])
 
         assert str(e.value).endswith("Keyword argument sequences for broadcasting must be the same length as stackers")
 
-    def test_broadcast_with_no_kwargs(self):
+    def test_broadcast_with_no_kwargs(self) -> None:
         stackers = ['a', 'b', 'c', 'd']
         kws = bps.double_stack(stackers, 'start', 'end')
         assert len(kws) == len(stackers)
@@ -136,7 +136,7 @@ class Test_double_stack(object):
             assert list(kw['start']['expr'].fields) == stackers[:i]
             assert list(kw['end']['expr'].fields) == stackers[:(i+1)]
 
-    def test_broadcast_with_scalar_kwargs(self):
+    def test_broadcast_with_scalar_kwargs(self) -> None:
         stackers = ['a', 'b', 'c', 'd']
         kws = bps.double_stack(stackers, 'start', 'end', foo=10, bar="baz")
         assert len(kws) == len(stackers)
@@ -148,7 +148,7 @@ class Test_double_stack(object):
             assert kw['bar'] == "baz"
             assert kw['name'] == stackers[i]
 
-    def test_broadcast_with_list_kwargs(self):
+    def test_broadcast_with_list_kwargs(self) -> None:
         stackers = ['a', 'b', 'c', 'd']
         kws = bps.double_stack(stackers, 'start', 'end', foo=[10, 20, 30, 40], bar="baz")
         assert len(kws) == len(stackers)
@@ -160,7 +160,7 @@ class Test_double_stack(object):
             assert kw['bar'] == "baz"
             assert kw['name'] == stackers[i]
 
-    def test_broadcast_name_scalar_overrides(self):
+    def test_broadcast_name_scalar_overrides(self) -> None:
         stackers = ['a', 'b', 'c', 'd']
         kws = bps.double_stack(stackers, 'start', 'end', foo=[10, 20, 30, 40], bar="baz", name="name")
         assert len(kws) == len(stackers)
@@ -172,7 +172,7 @@ class Test_double_stack(object):
             assert kw['bar'] == "baz"
             assert kw['name'] == "name"
 
-    def test_broadcast_name_list_overrides(self):
+    def test_broadcast_name_list_overrides(self) -> None:
         names = ["aa", "bb", "cc", "dd"]
         stackers = ['a', 'b', 'c', 'd']
         kws = bps.double_stack(stackers, 'start', 'end', foo=[10, 20, 30, 40], bar="baz", name=names)

--- a/tests/unit/bokeh/plotting/test_figure.py
+++ b/tests/unit/bokeh/plotting/test_figure.py
@@ -48,7 +48,7 @@ from bokeh.plotting import _figure as bpf # isort:skip
 
 class TestFigure(object):
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         p = bpf.figure()
         q = bpf.figure()
         q.circle([1, 2, 3], [1, 2, 3])
@@ -58,7 +58,7 @@ class TestFigure(object):
         assert p != r
         assert q != r
 
-    def test_width_height(self):
+    def test_width_height(self) -> None:
         p = bpf.figure(width=100, height=120)
         assert p.plot_width == 100
         assert p.plot_height == 120
@@ -73,7 +73,7 @@ class TestFigure(object):
         with pytest.raises(ValueError):
             bpf.figure(plot_height=100, height=120)
 
-    def test_xaxis(self):
+    def test_xaxis(self) -> None:
         p = bpf.figure()
         p.circle([1, 2, 3], [1, 2, 3])
         assert len(p.xaxis) == 1
@@ -96,7 +96,7 @@ class TestFigure(object):
         p.right.append(LinearAxis())
         assert set(p.xaxis) == expected
 
-    def test_yaxis(self):
+    def test_yaxis(self) -> None:
         p = bpf.figure()
         p.circle([1, 2, 3], [1, 2, 3])
         assert len(p.yaxis) == 1
@@ -119,7 +119,7 @@ class TestFigure(object):
         p.below.append(LinearAxis())
         assert set(p.yaxis) == expected
 
-    def test_axis(self):
+    def test_axis(self) -> None:
         p = bpf.figure()
         p.circle([1, 2, 3], [1, 2, 3])
         assert len(p.axis) == 2
@@ -146,7 +146,7 @@ class TestFigure(object):
         p.right.append(ax4)
         assert set(p.axis) == expected
 
-    def test_log_axis(self):
+    def test_log_axis(self) -> None:
         p = bpf.figure(x_axis_type='log')
         p.circle([1, 2, 3], [1, 2, 3])
         assert isinstance(p.x_scale, LogScale)
@@ -155,7 +155,7 @@ class TestFigure(object):
         p.circle([1, 2, 3], [1, 2, 3])
         assert isinstance(p.y_scale, LogScale)
 
-    def test_grid_tickers(self):
+    def test_grid_tickers(self) -> None:
         p = bpf.figure()
         assert p.xgrid[0].axis == p.xaxis[0]
         assert p.xgrid[0].ticker is None
@@ -163,24 +163,24 @@ class TestFigure(object):
         assert p.ygrid[0].axis == p.yaxis[0]
         assert p.ygrid[0].ticker is None
 
-    def test_xgrid(self):
+    def test_xgrid(self) -> None:
         p = bpf.figure()
         p.circle([1, 2, 3], [1, 2, 3])
         assert len(p.xgrid) == 1
         assert p.xgrid[0].dimension == 0
 
-    def test_ygrid(self):
+    def test_ygrid(self) -> None:
         p = bpf.figure()
         p.circle([1, 2, 3], [1, 2, 3])
         assert len(p.ygrid) == 1
         assert p.ygrid[0].dimension == 1
 
-    def test_grid(self):
+    def test_grid(self) -> None:
         p = bpf.figure()
         p.circle([1, 2, 3], [1, 2, 3])
         assert len(p.grid) == 2
 
-    def test_tools(self):
+    def test_tools(self) -> None:
         TOOLS = "pan,box_zoom,reset,lasso_select"
         fig = bpf.figure(tools=TOOLS)
         expected = [PanTool, BoxZoomTool, ResetTool, LassoSelectTool]
@@ -189,7 +189,7 @@ class TestFigure(object):
         for i, _type in enumerate(expected):
             assert isinstance(fig.tools[i], _type)
 
-    def test_plot_fill_props(self):
+    def test_plot_fill_props(self) -> None:
         p = bpf.figure(background_fill_color='red',
                        background_fill_alpha=0.5,
                        border_fill_color='blue',
@@ -204,33 +204,33 @@ class TestFigure(object):
         assert p.background_fill_color == 'green'
         assert p.border_fill_color == 'yellow'
 
-    def test_title_kwarg_no_warning(self, recwarn):
+    def test_title_kwarg_no_warning(self, recwarn) -> None:
         bpf.figure(title="title")
         assert len(recwarn) == 0
 
 
-    def test_title_should_accept_Title(self):
+    def test_title_should_accept_Title(self) -> None:
         title = Title(text='Great Title')
         plot = bpf.figure(title=title)
         plot.line([1, 2, 3], [1, 2, 3])
         assert plot.title.text == 'Great Title'
 
-    def test_title_should_accept_string(self):
+    def test_title_should_accept_string(self) -> None:
         plot = bpf.figure(title='Great Title 2')
         plot.line([1, 2, 3], [1, 2, 3])
         assert plot.title.text == 'Great Title 2'
 
-    def test_columnsource_auto_conversion_from_dict(self):
+    def test_columnsource_auto_conversion_from_dict(self) -> None:
         p = bpf.figure()
         dct = {'x': [1, 2, 3], 'y': [2, 3, 4]}
         p.circle(x='x', y='y', source=dct)
 
-    def test_columnsource_auto_conversion_from_pandas(self, pd):
+    def test_columnsource_auto_conversion_from_pandas(self, pd) -> None:
         p = bpf.figure()
         df = pd.DataFrame({'x': [1, 2, 3], 'y': [2, 3, 4]})
         p.circle(x='x', y='y', source=df)
 
-    def test_glyph_method_errors_on_sequence_literals_with_source(self):
+    def test_glyph_method_errors_on_sequence_literals_with_source(self) -> None:
         p = bpf.figure()
         source = ColumnDataSource({'x': [1, 2, 3], 'y': [2, 3, 4]})
 
@@ -247,7 +247,7 @@ class TestFigure(object):
 class TestMarkers(object):
 
     @pytest.mark.parametrize('marker', list(MarkerType))
-    def test_mixed_inputs(self, marker):
+    def test_mixed_inputs(self, marker) -> None:
         p = bpf.figure()
         rgb = (100, 0, 0)
         rgb_other = (0, 100, 0)
@@ -274,7 +274,7 @@ class TestMarkers(object):
 
     @pytest.mark.parametrize('marker', list(MarkerType))
     @pytest.mark.parametrize('color',  [(100., 100., 100.), (50., 100., 50., 0.5), (100, 100, 100), (50, 100, 50, 0.5)])
-    def test_color_input(self, color, marker):
+    def test_color_input(self, color, marker) -> None:
         p = bpf.figure()
         func = getattr(p, marker)
         r = func([1, 2, 3], [1, 2, 3], color=color)
@@ -288,7 +288,7 @@ class TestMarkers(object):
 
     @pytest.mark.parametrize('marker', list(MarkerType))
     @pytest.mark.parametrize('color',  [(100., 100., 100.), (50., 100., 50., 0.5), (100, 100, 100), (50, 100, 50, 0.5)])
-    def test_line_color_input(self, color, marker):
+    def test_line_color_input(self, color, marker) -> None:
         p = bpf.figure()
         func = getattr(p, marker)
         r = func([1, 2, 3], [1, 2, 3], line_color=color)
@@ -299,7 +299,7 @@ class TestMarkers(object):
 
     @pytest.mark.parametrize('marker', list(MarkerType))
     @pytest.mark.parametrize('color',  [(100., 100., 100.), (50., 100., 50., 0.5), (50, 100, 50, 0.5)])
-    def test_fill_color_input(self, color, marker):
+    def test_fill_color_input(self, color, marker) -> None:
         p = bpf.figure()
         func = getattr(p, marker)
         r = func([1, 2, 3], [1, 2, 3], fill_color=color)
@@ -309,7 +309,7 @@ class TestMarkers(object):
             assert isinstance(v, int)
 
     @pytest.mark.parametrize('marker', list(MarkerType))
-    def test_render_level(self, marker):
+    def test_render_level(self, marker) -> None:
         p = bpf.figure()
         func = getattr(p, marker)
         r = func([1, 2, 3], [1, 2, 3], level="underlay")
@@ -320,20 +320,20 @@ class TestMarkers(object):
 class Test_scatter(object):
 
     @pytest.mark.parametrize('marker', list(MarkerType))
-    def test_marker_value(self, marker):
+    def test_marker_value(self, marker) -> None:
         p = bpf.figure()
         r = p.scatter([1, 2, 3], [1, 2, 3], marker=marker)
         assert isinstance(r.glyph, Scatter)
         assert r.glyph.marker == marker
 
-    def test_marker_column(self):
+    def test_marker_column(self) -> None:
         p = bpf.figure()
         data = dict(x=[1, 2, 3], y=[1, 2, 3], foo=["hex", "square", "circle"])
         r = p.scatter('x', 'y', marker='foo', source=data)
         assert isinstance(r.glyph, Scatter)
         assert r.glyph.marker == "foo"
 
-    def test_circle_with_radius(self):
+    def test_circle_with_radius(self) -> None:
         p = bpf.figure()
         r = p.scatter([1, 2, 3], [1, 2, 3], marker="circle", radius=0.2)
         assert isinstance(r.glyph, Circle)
@@ -341,7 +341,7 @@ class Test_scatter(object):
 
 class Test_hbar_stack(object):
 
-    def test_returns_renderers(self):
+    def test_returns_renderers(self) -> None:
         fruits = ['Apples', 'Pears', 'Nectarines', 'Plums', 'Grapes', 'Strawberries']
         years = ["2015", "2016", "2017"]
         colors = ["#c9d9d3", "#718dbf", "#e84d60"]
@@ -361,7 +361,7 @@ class Test_hbar_stack(object):
 
 class Test_vbar_stack(object):
 
-    def test_returns_renderers(self):
+    def test_returns_renderers(self) -> None:
         fruits = ['Apples', 'Pears', 'Nectarines', 'Plums', 'Grapes', 'Strawberries']
         years = ["2015", "2016", "2017"]
         colors = ["#c9d9d3", "#718dbf", "#e84d60"]
@@ -381,19 +381,19 @@ class Test_vbar_stack(object):
 
 def Test_figure_legends_DEPRECATED(obejct):
 
-    def test_glyph_label_is_legend_if_column_in_datasource_is_added_as_legend(self, p, source):
+    def test_glyph_label_is_legend_if_column_in_datasource_is_added_as_legend(self, p, source) -> None:
         p.circle(x='x', y='y', legend='label', source=source)
         legends = p.select(Legend)
         assert len(legends) == 1
         assert legends[0].items[0].label == {'field': 'label'}
 
-    def test_glyph_label_is_value_if_column_not_in_datasource_is_added_as_legend(self, p, source):
+    def test_glyph_label_is_value_if_column_not_in_datasource_is_added_as_legend(self, p, source) -> None:
         p.circle(x='x', y='y', legend='milk', source=source)
         legends = p.select(Legend)
         assert len(legends) == 1
         assert legends[0].items[0].label == {'value': 'milk'}
 
-    def test_glyph_label_is_legend_if_column_in_df_datasource_is_added_as_legend(self, p, pd):
+    def test_glyph_label_is_legend_if_column_in_df_datasource_is_added_as_legend(self, p, pd) -> None:
         source = pd.DataFrame(data=dict(x=[1, 2, 3], y=[1, 2, 3], label=['a', 'b', 'c']))
         p.circle(x='x', y='y', legend='label', source=source)
         legends = p.select(Legend)
@@ -401,42 +401,42 @@ def Test_figure_legends_DEPRECATED(obejct):
         assert legends[0].items[0].label == {'field': 'label'}
 
 
-    def test_glyph_label_is_value_if_column_not_in_df_datasource_is_added_as_legend(self, p, pd):
+    def test_glyph_label_is_value_if_column_not_in_df_datasource_is_added_as_legend(self, p, pd) -> None:
         source = pd.DataFrame(data=dict(x=[1, 2, 3], y=[1, 2, 3], label=['a', 'b', 'c']))
         p.circle(x='x', y='y', legend='milk', source=source)
         legends = p.select(Legend)
         assert len(legends) == 1
         assert legends[0].items[0].label == {'value': 'milk'}
 
-    def test_glyph_label_is_just_added_directly_if_not_string(self, p, source):
+    def test_glyph_label_is_just_added_directly_if_not_string(self, p, source) -> None:
         p.circle(x='x', y='y', legend={'field': 'milk'}, source=source)
         legends = p.select(Legend)
         assert len(legends) == 1
         assert legends[0].items[0].label == {'field': 'milk'}
 
-    def test_no_legend_if_legend_is_none(self, p, source):
+    def test_no_legend_if_legend_is_none(self, p, source) -> None:
         p.circle(x='x', y='y', legend=None, source=source)
         legends = p.select(Legend)
         assert len(legends) == 0
 
-    def test_legend_added_when_legend_set(self, p, source):
+    def test_legend_added_when_legend_set(self, p, source) -> None:
         renderer = p.circle(x='x', y='y', legend='label', source=source)
         legends = p.select(Legend)
         assert len(legends) == 1
         assert legends[0].items[0].renderers == [renderer]
 
-    def test_legend_not_added_when_no_legend(self, p, source):
+    def test_legend_not_added_when_no_legend(self, p, source) -> None:
         p.circle(x='x', y='y', source=source)
         legends = p.select(Legend)
         assert len(legends) == 0
 
-    def test_adding_legend_doesnt_work_when_legends_already_added(self, p, source):
+    def test_adding_legend_doesnt_work_when_legends_already_added(self, p, source) -> None:
         p.add_layout(Legend())
         p.add_layout(Legend())
         with pytest.raises(RuntimeError):
             p.circle(x='x', y='y', legend='label', source=source)
 
-    def test_multiple_renderers_correctly_added_to_legend(self, p, source):
+    def test_multiple_renderers_correctly_added_to_legend(self, p, source) -> None:
         square = p.square(x='x', y='y', legend='square', source=source)
         circle = p.circle(x='x', y='y', legend='circle', source=source)
         legends = p.select(Legend)
@@ -446,7 +446,7 @@ def Test_figure_legends_DEPRECATED(obejct):
         assert legends[0].items[1].renderers == [circle]
         assert legends[0].items[1].label == value('circle')
 
-    def test_compound_legend_behavior_initiated_if_labels_are_same_on_multiple_renderers(self, p, source):
+    def test_compound_legend_behavior_initiated_if_labels_are_same_on_multiple_renderers(self, p, source) -> None:
         # 'compound legend string' is just a value
         square = p.square(x='x', y='y', legend='compound legend string')
         circle = p.circle(x='x', y='y', legend='compound legend string')
@@ -455,7 +455,7 @@ def Test_figure_legends_DEPRECATED(obejct):
         assert legends[0].items[0].renderers == [square, circle]
         assert legends[0].items[0].label == value('compound legend string')
 
-    def test_compound_legend_behavior_initiated_if_labels_are_same_on_multiple_renderers_and_are_field(self, p, source):
+    def test_compound_legend_behavior_initiated_if_labels_are_same_on_multiple_renderers_and_are_field(self, p, source) -> None:
         # label is a field
         square = p.square(x='x', y='y', legend='label', source=source)
         circle = p.circle(x='x', y='y', legend='label', source=source)
@@ -467,29 +467,29 @@ def Test_figure_legends_DEPRECATED(obejct):
 
 def Test_figure_legends(obejct):
 
-    def test_glyph_legend_field(self, p, source):
+    def test_glyph_legend_field(self, p, source) -> None:
         p.circle(x='x', y='y', legend_field='label', source=source)
         legends = p.select(Legend)
         assert len(legends) == 1
         assert legends[0].items[0].label == {'field': 'label'}
 
-    def test_no_legend_if_legend_is_none(self, p, source):
+    def test_no_legend_if_legend_is_none(self, p, source) -> None:
         p.circle(x='x', y='y', legend_label=None, source=source)
         legends = p.select(Legend)
         assert len(legends) == 0
 
-    def test_legend_added_when_legend_set(self, p, source):
+    def test_legend_added_when_legend_set(self, p, source) -> None:
         renderer = p.circle(x='x', y='y', legend_label='label', source=source)
         legends = p.select(Legend)
         assert len(legends) == 1
         assert legends[0].items[0].renderers == [renderer]
 
-    def test_legend_not_added_when_no_legend(self, p, source):
+    def test_legend_not_added_when_no_legend(self, p, source) -> None:
         p.circle(x='x', y='y', source=source)
         legends = p.select(Legend)
         assert len(legends) == 0
 
-    def test_adding_legend_doesnt_work_when_legends_already_added(self, p, source):
+    def test_adding_legend_doesnt_work_when_legends_already_added(self, p, source) -> None:
         p.add_layout(Legend())
         p.add_layout(Legend())
         with pytest.raises(RuntimeError):
@@ -499,7 +499,7 @@ def Test_figure_legends(obejct):
         with pytest.raises(RuntimeError):
             p.circle(x='x', y='y', legend_group='label', source=source)
 
-    def test_multiple_renderers_correctly_added_to_legend(self, p, source):
+    def test_multiple_renderers_correctly_added_to_legend(self, p, source) -> None:
         square = p.square(x='x', y='y', legend_label='square', source=source)
         circle = p.circle(x='x', y='y', legend_label='circle', source=source)
         legends = p.select(Legend)
@@ -509,7 +509,7 @@ def Test_figure_legends(obejct):
         assert legends[0].items[1].renderers == [circle]
         assert legends[0].items[1].label == value('circle')
 
-    def test_compound_legend_behavior_initiated_if_labels_are_same_on_multiple_renderers(self, p, source):
+    def test_compound_legend_behavior_initiated_if_labels_are_same_on_multiple_renderers(self, p, source) -> None:
         # 'compound legend string' is just a value
         square = p.square(x='x', y='y', legend_label='compound legend string')
         circle = p.circle(x='x', y='y', legend_label='compound legend string')
@@ -518,7 +518,7 @@ def Test_figure_legends(obejct):
         assert legends[0].items[0].renderers == [square, circle]
         assert legends[0].items[0].label == value('compound legend string')
 
-    def test_compound_legend_behavior_initiated_if_labels_are_same_on_multiple_renderers_and_are_field(self, p, source):
+    def test_compound_legend_behavior_initiated_if_labels_are_same_on_multiple_renderers_and_are_field(self, p, source) -> None:
         # label is a field
         square = p.square(x='x', y='y', legend_field='label', source=source)
         circle = p.circle(x='x', y='y', legend_field='label', source=source)
@@ -529,7 +529,7 @@ def Test_figure_legends(obejct):
 
     # XXX (bev) this doesn't work yet because compound behaviour depends on renderer sources
     # matching, but passing a df means every renderer gets its own new source
-    # def test_compound_legend_behavior_initiated_if_labels_are_same_on_multiple_renderers_and_are_field_with_df_source(self, p, pd):
+    # def test_compound_legend_behavior_initiated_if_labels_are_same_on_multiple_renderers_and_are_field_with_df_source(self, p, pd) -> None:
     #     source = pd.DataFrame(data=dict(x=[1, 2, 3], y=[1, 2, 3], label=['a', 'b', 'c']))
     #     # label is a field
     #     square = p.square(x='x', y='y', legend_label='label', source=source)

--- a/tests/unit/bokeh/plotting/test_graph.py
+++ b/tests/unit/bokeh/plotting/test_graph.py
@@ -30,7 +30,7 @@ import bokeh.plotting.graph as bpg # isort:skip
 # General API
 #-----------------------------------------------------------------------------
 
-def test_from_networkx_method():
+def test_from_networkx_method() -> None:
     G=nx.Graph()
     G.add_nodes_from([0,1,2,3])
     G.add_edges_from([[0,1], [0,2], [2,3]])
@@ -44,7 +44,7 @@ def test_from_networkx_method():
     assert set(gl.keys()) == set([0,1,2,3])
     assert_allclose(gl[0], np.array([1., 0.]), atol=1e-7)
 
-def test_from_networkx_method_with_kwargs():
+def test_from_networkx_method_with_kwargs() -> None:
     G=nx.Graph()
     G.add_nodes_from([0,1,2,3])
     G.add_edges_from([[0,1], [0,2], [2,3]])
@@ -55,7 +55,7 @@ def test_from_networkx_method_with_kwargs():
     assert set(gl.keys()) == set([0,1,2,3])
     assert_allclose(gl[0], np.array([2., 0.]), atol=1e-7)
 
-def test_from_networkx_with_scalar_attributes():
+def test_from_networkx_with_scalar_attributes() -> None:
     G = nx.Graph()
     G.add_nodes_from([(0, {"attr_1": "a", "attr_2": 10}),
                       (1, {"attr_1": "b"}),
@@ -75,7 +75,7 @@ def test_from_networkx_with_scalar_attributes():
     assert renderer.edge_renderer.data_source.data["attr_2"] == [None, 10]
 
 @pytest.mark.parametrize('typ', [list, tuple])
-def test_from_networkx_with_sequence_attributes(typ):
+def test_from_networkx_with_sequence_attributes(typ) -> None:
     G = nx.Graph()
     G.add_nodes_from([(0, {"attr_1": typ([1, 2]), "attr_2": 10}),
                       (1, {}),
@@ -94,7 +94,7 @@ def test_from_networkx_with_sequence_attributes(typ):
     assert renderer.edge_renderer.data_source.data["attr_1"] == [[1, 11], [2, 22]]
     assert renderer.edge_renderer.data_source.data["attr_2"] == [None, 10]
 
-def test_from_networkx_errors_with_mixed_attributes():
+def test_from_networkx_errors_with_mixed_attributes() -> None:
     G = nx.Graph()
     G.add_nodes_from([(0, {"attr_1": [1, 2], "attr_2": 10}),
                       (1, {}),
@@ -110,7 +110,7 @@ def test_from_networkx_errors_with_mixed_attributes():
     with pytest.raises(ValueError):
         bpg.from_networkx(G, nx.circular_layout)
 
-def test_from_networkx_with_bad_attributes():
+def test_from_networkx_with_bad_attributes() -> None:
     G = nx.Graph()
     G.add_nodes_from([(0, {"index": "a", "attr_1": 10}),
                       (1, {"index": "b", "attr_1": 20})])
@@ -141,7 +141,7 @@ def test_from_networkx_with_bad_attributes():
         assert renderer.edge_renderer.data_source.data["end"] == [1]
         assert renderer.edge_renderer.data_source.data["attr_1"] == [10]
 
-def test_from_networkx_fixed_layout():
+def test_from_networkx_fixed_layout() -> None:
     G = nx.Graph()
     G.add_nodes_from([0, 1, 2])
     G.add_edges_from([[0, 1], [0, 2]])
@@ -161,7 +161,7 @@ def test_from_networkx_fixed_layout():
     assert renderer.layout_provider.graph_layout[1] == fixed_layout[1]
     assert renderer.layout_provider.graph_layout[2] == fixed_layout[2]
 
-def test_from_networkx_with_missing_layout():
+def test_from_networkx_with_missing_layout() -> None:
     G = nx.Graph()
     G.add_nodes_from([0, 1, 2])
     G.add_edges_from([[0, 1], [0, 2]])

--- a/tests/unit/bokeh/protocol/messages/test_patch_doc.py
+++ b/tests/unit/bokeh/protocol/messages/test_patch_doc.py
@@ -64,11 +64,11 @@ class TestPatchDocument(object):
         doc.add_root(SomeModelInTestPatchDoc())
         return doc
 
-    def test_create_no_events(self):
+    def test_create_no_events(self) -> None:
         with pytest.raises(ValueError):
             proto.create("PATCH-DOC", [])
 
-    def test_create_multiple_docs(self):
+    def test_create_multiple_docs(self) -> None:
         sample1 = self._sample_doc()
         obj1 = next(iter(sample1.roots))
         event1 = ModelChangedEvent(sample1, obj1, 'foo', obj1.foo, 42, 42)
@@ -79,13 +79,13 @@ class TestPatchDocument(object):
         with pytest.raises(ValueError):
             proto.create("PATCH-DOC", [event1, event2])
 
-    def test_create_model_changed(self):
+    def test_create_model_changed(self) -> None:
         sample = self._sample_doc()
         obj = next(iter(sample.roots))
         event = ModelChangedEvent(sample, obj, 'foo', obj.foo, 42, 42)
         proto.create("PATCH-DOC", [event])
 
-    def test_create_then_apply_model_changed(self):
+    def test_create_then_apply_model_changed(self) -> None:
         sample = self._sample_doc()
 
         foos = []
@@ -107,7 +107,7 @@ class TestPatchDocument(object):
         foos.sort()
         assert foos == [ 2, 42 ]
 
-    def test_patch_event_contains_setter(self):
+    def test_patch_event_contains_setter(self) -> None:
         sample = self._sample_doc()
         root = None
         other_root = None
@@ -198,7 +198,7 @@ class _Event(object):
 class _M(Model):
     pass
 
-def test_process_document_events_no_refs():
+def test_process_document_events_no_refs() -> None:
     e = _Event([], [])
     r, bufs = process_document_events([e])
     assert bufs == []
@@ -208,7 +208,7 @@ def test_process_document_events_no_refs():
     assert len(json['events']) == 1
     assert json['events'] == ['junk']
 
-def test_process_document_events_with_refs():
+def test_process_document_events_with_refs() -> None:
     e = _Event([_M(),_M()], [])
     r, bufs = process_document_events([e])
     assert bufs == []
@@ -218,7 +218,7 @@ def test_process_document_events_with_refs():
     assert len(json['events']) == 1
     assert json['events'] == ['junk']
 
-def test_process_document_events_no_buffers():
+def test_process_document_events_no_buffers() -> None:
     e = _Event([], [])
     r, bufs = process_document_events([e])
     assert bufs == []
@@ -228,7 +228,7 @@ def test_process_document_events_no_buffers():
     assert len(json['events']) == 1
     assert json['events'] == ['junk']
 
-def test_process_document_events_with_buffers():
+def test_process_document_events_with_buffers() -> None:
     e = _Event([], [1,2])
     r, bufs = process_document_events([e])
     assert bufs == [1, 2]
@@ -238,7 +238,7 @@ def test_process_document_events_with_buffers():
     assert len(json['events']) == 1
     assert json['events'] == ['junk']
 
-def test_process_document_events_mixed():
+def test_process_document_events_mixed() -> None:
     e1 = _Event([], [1,2])
     e2 = _Event([_M(),_M(),_M()], [3,4, 5])
     e3 = _Event([_M(),_M()], [])
@@ -250,7 +250,7 @@ def test_process_document_events_mixed():
     assert len(json['events']) == 3
     assert json['events'] == ['junk', 'junk', 'junk']
 
-def test_process_document_events_with_buffers_and_use_buffers_false():
+def test_process_document_events_with_buffers_and_use_buffers_false() -> None:
     e = _Event([], [1,2])
     r, bufs = process_document_events([e], use_buffers=False)
     assert bufs == []

--- a/tests/unit/bokeh/protocol/messages/test_pull_doc.py
+++ b/tests/unit/bokeh/protocol/messages/test_pull_doc.py
@@ -48,14 +48,14 @@ class TestPullDocument(object):
         doc.add_root(SomeModelInTestPullDoc())
         return doc
 
-    def test_create_req(self):
+    def test_create_req(self) -> None:
         proto.create("PULL-DOC-REQ")
 
-    def test_create_reply(self):
+    def test_create_reply(self) -> None:
         sample = self._sample_doc()
         proto.create("PULL-DOC-REPLY", 'fakereqid', sample)
 
-    def test_create_reply_then_parse(self):
+    def test_create_reply_then_parse(self) -> None:
         sample = self._sample_doc()
         msg = proto.create("PULL-DOC-REPLY", 'fakereqid', sample)
         copy = document.Document()

--- a/tests/unit/bokeh/protocol/messages/test_push_doc.py
+++ b/tests/unit/bokeh/protocol/messages/test_push_doc.py
@@ -48,11 +48,11 @@ class TestPushDocument(object):
         doc.add_root(SomeModelInTestPushDoc())
         return doc
 
-    def test_create(self):
+    def test_create(self) -> None:
         sample = self._sample_doc()
         proto.create("PUSH-DOC", sample)
 
-    def test_create_then_parse(self):
+    def test_create_then_parse(self) -> None:
         sample = self._sample_doc()
         msg = proto.create("PUSH-DOC", sample)
         copy = document.Document()

--- a/tests/unit/bokeh/protocol/test_message.py
+++ b/tests/unit/bokeh/protocol/test_message.py
@@ -25,7 +25,7 @@ import bokeh.protocol.message as message # isort:skip
 # General API
 #-----------------------------------------------------------------------------
 
-def test_create_header(monkeypatch):
+def test_create_header(monkeypatch) -> None:
     message.Message.msgtype = "msgtype"
     monkeypatch.setattr("bokeh.util.serialization.make_id", lambda: "msgid")
     header = message.Message.create_header(request_id="bar")

--- a/tests/unit/bokeh/protocol/test_receiver.py
+++ b/tests/unit/bokeh/protocol/test_receiver.py
@@ -31,11 +31,11 @@ proto = Protocol()
 # General API
 #-----------------------------------------------------------------------------
 
-def test_creation():
+def test_creation() -> None:
     receiver.Receiver(None)
 
 @pytest.mark.asyncio
-async def test_validation_success():
+async def test_validation_success() -> None:
     msg = proto.create('ACK')
     r = receiver.Receiver(proto)
 
@@ -53,7 +53,7 @@ async def test_validation_success():
     assert partial.metadata == msg.metadata
 
 @pytest.mark.asyncio
-async def test_validation_success_with_one_buffer():
+async def test_validation_success_with_one_buffer() -> None:
     r = receiver.Receiver(proto)
 
     partial = await r.consume('{"msgtype": "PATCH-DOC", "msgid": "10", "num_buffers":1}')
@@ -77,7 +77,7 @@ async def test_validation_success_with_one_buffer():
     assert partial.buffers == [('header', b'payload')]
 
 @pytest.mark.asyncio
-async def test_multiple_validation_success_with_multiple_buffers():
+async def test_multiple_validation_success_with_multiple_buffers() -> None:
     r = receiver.Receiver(proto)
 
     for N in range(10):
@@ -97,14 +97,14 @@ async def test_multiple_validation_success_with_multiple_buffers():
         assert partial.buffers == [('header%d' % i, b'payload%d' %i) for i in range(N)]
 
 @pytest.mark.asyncio
-async def test_binary_header_raises_error():
+async def test_binary_header_raises_error() -> None:
     r = receiver.Receiver(proto)
 
     with pytest.raises(ValidationError):
         await r.consume(b'header')
 
 @pytest.mark.asyncio
-async def test_binary_metadata_raises_error():
+async def test_binary_metadata_raises_error() -> None:
     r = receiver.Receiver(proto)
 
     await r.consume('header')
@@ -112,7 +112,7 @@ async def test_binary_metadata_raises_error():
         await r.consume(b'metadata')
 
 @pytest.mark.asyncio
-async def test_binary_content_raises_error():
+async def test_binary_content_raises_error() -> None:
     r = receiver.Receiver(proto)
 
     await r.consume('header')
@@ -121,7 +121,7 @@ async def test_binary_content_raises_error():
         await r.consume(b'content')
 
 @pytest.mark.asyncio
-async def test_binary_payload_header_raises_error():
+async def test_binary_payload_header_raises_error() -> None:
     r = receiver.Receiver(proto)
 
     await r.consume('{"msgtype": "PATCH-DOC", "msgid": "10", "num_buffers":1}')
@@ -130,7 +130,7 @@ async def test_binary_payload_header_raises_error():
     with pytest.raises(ValidationError):
         await r.consume(b'buf_header')
 @pytest.mark.asyncio
-async def test_text_payload_buffer_raises_error():
+async def test_text_payload_buffer_raises_error() -> None:
     r = receiver.Receiver(proto)
 
     await r.consume('{"msgtype": "PATCH-DOC", "msgid": "10", "num_buffers":1}')

--- a/tests/unit/bokeh/sampledata/test_airport_routes.py
+++ b/tests/unit/bokeh/sampledata/test_airport_routes.py
@@ -36,14 +36,14 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.airport_routes", ALL))
 
 @pytest.mark.sampledata
-def test_airports(pd):
+def test_airports(pd) -> None:
     import bokeh.sampledata.airport_routes as bsa
     assert isinstance(bsa.airports, pd.DataFrame)
 
     # don't check detail for external data
 
 @pytest.mark.sampledata
-def test_routes(pd):
+def test_routes(pd) -> None:
     import bokeh.sampledata.airport_routes as bsa
     assert isinstance(bsa.routes, pd.DataFrame)
 

--- a/tests/unit/bokeh/sampledata/test_airports.py
+++ b/tests/unit/bokeh/sampledata/test_airports.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.airports", ALL))
 
 @pytest.mark.sampledata
-def test_data(pd):
+def test_data(pd) -> None:
     import bokeh.sampledata.airports as bsa
     assert isinstance(bsa.data, pd.DataFrame)
 

--- a/tests/unit/bokeh/sampledata/test_autompg.py
+++ b/tests/unit/bokeh/sampledata/test_autompg.py
@@ -36,7 +36,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.autompg", ALL))
 
 @pytest.mark.sampledata
-def test_autompg(pd):
+def test_autompg(pd) -> None:
     import bokeh.sampledata.autompg as bsa
     assert isinstance(bsa.autompg, pd.DataFrame)
 
@@ -45,7 +45,7 @@ def test_autompg(pd):
     assert all(x in [1,2,3] for x in bsa.autompg.origin)
 
 @pytest.mark.sampledata
-def test_autompg_clean(pd):
+def test_autompg_clean(pd) -> None:
     import bokeh.sampledata.autompg as bsa
     assert isinstance(bsa.autompg_clean, pd.DataFrame)
 

--- a/tests/unit/bokeh/sampledata/test_autompg2.py
+++ b/tests/unit/bokeh/sampledata/test_autompg2.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.autompg2", ALL))
 
 @pytest.mark.sampledata
-def test_autompg2(pd):
+def test_autompg2(pd) -> None:
     import bokeh.sampledata.autompg2 as bsa
     assert isinstance(bsa.autompg2, pd.DataFrame)
 

--- a/tests/unit/bokeh/sampledata/test_browsers.py
+++ b/tests/unit/bokeh/sampledata/test_browsers.py
@@ -36,7 +36,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.browsers", ALL))
 
 @pytest.mark.sampledata
-def test_browsers_nov_2013(pd):
+def test_browsers_nov_2013(pd) -> None:
     import bokeh.sampledata.browsers as bsb
     assert isinstance(bsb.browsers_nov_2013, pd.DataFrame)
 
@@ -44,7 +44,7 @@ def test_browsers_nov_2013(pd):
     assert len(bsb.browsers_nov_2013) == 118
 
 @pytest.mark.sampledata
-def test_icons():
+def test_icons() -> None:
     import bokeh.sampledata.browsers as bsb
     assert isinstance(bsb.icons, dict)
 

--- a/tests/unit/bokeh/sampledata/test_commits.py
+++ b/tests/unit/bokeh/sampledata/test_commits.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.commits", ALL))
 
 @pytest.mark.sampledata
-def test_data(pd):
+def test_data(pd) -> None:
     import bokeh.sampledata.commits as bsc
     assert isinstance(bsc.data, pd.DataFrame)
 

--- a/tests/unit/bokeh/sampledata/test_daylight.py
+++ b/tests/unit/bokeh/sampledata/test_daylight.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.daylight", ALL))
 
 @pytest.mark.sampledata
-def test_daylight_warsaw_2013(pd):
+def test_daylight_warsaw_2013(pd) -> None:
     import bokeh.sampledata.daylight as bsd
     assert isinstance(bsd.daylight_warsaw_2013, pd.DataFrame)
 

--- a/tests/unit/bokeh/sampledata/test_degrees.py
+++ b/tests/unit/bokeh/sampledata/test_degrees.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.degrees", ALL))
 
 @pytest.mark.sampledata
-def test_data(pd):
+def test_data(pd) -> None:
     import bokeh.sampledata.degrees as bsd
     assert isinstance(bsd.data, pd.DataFrame)
 

--- a/tests/unit/bokeh/sampledata/test_gapminder.py
+++ b/tests/unit/bokeh/sampledata/test_gapminder.py
@@ -39,7 +39,7 @@ Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.gapminder", A
 
 @pytest.mark.sampledata
 @pytest.mark.parametrize('name', ['fertility', 'life_expectancy', 'population', 'regions'])
-def test_data(pd, name):
+def test_data(pd, name) -> None:
     import bokeh.sampledata.gapminder as bsg
     data = getattr(bsg, name)
     assert isinstance(data, pd.DataFrame)

--- a/tests/unit/bokeh/sampledata/test_glucose.py
+++ b/tests/unit/bokeh/sampledata/test_glucose.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.glucose", ALL))
 
 @pytest.mark.sampledata
-def test_data(pd):
+def test_data(pd) -> None:
     import bokeh.sampledata.glucose as bsg
     assert isinstance(bsg.data, pd.DataFrame)
 

--- a/tests/unit/bokeh/sampledata/test_haar_cascade.py
+++ b/tests/unit/bokeh/sampledata/test_haar_cascade.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.haar_cascade", ALL))
 
 @pytest.mark.sampledata
-def test_data(pd):
+def test_data(pd) -> None:
     import bokeh.sampledata.haar_cascade as bsh
     assert isinstance(bsh.frontalface_default_path, str)
 

--- a/tests/unit/bokeh/sampledata/test_iris.py
+++ b/tests/unit/bokeh/sampledata/test_iris.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.iris", ALL))
 
 @pytest.mark.sampledata
-def test_flowers(pd):
+def test_flowers(pd) -> None:
     import bokeh.sampledata.iris as bsi
     assert isinstance(bsi.flowers, pd.DataFrame)
 

--- a/tests/unit/bokeh/sampledata/test_les_mis.py
+++ b/tests/unit/bokeh/sampledata/test_les_mis.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.les_mis", ALL))
 
 @pytest.mark.sampledata
-def test_data():
+def test_data() -> None:
     import bokeh.sampledata.les_mis as bsl
     assert isinstance(bsl.data, dict)
 

--- a/tests/unit/bokeh/sampledata/test_movies_data.py
+++ b/tests/unit/bokeh/sampledata/test_movies_data.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.movies_data", ALL))
 
 @pytest.mark.sampledata
-def test_movie_path():
+def test_movie_path() -> None:
     import bokeh.sampledata.movies_data as bsm
     assert isinstance(bsm.movie_path, str)
 

--- a/tests/unit/bokeh/sampledata/test_mtb.py
+++ b/tests/unit/bokeh/sampledata/test_mtb.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.mtb", ALL))
 
 @pytest.mark.sampledata
-def test_obiszow_mtb_xcm(pd):
+def test_obiszow_mtb_xcm(pd) -> None:
     import bokeh.sampledata.mtb as bsm
     assert isinstance(bsm.obiszow_mtb_xcm, pd.DataFrame)
 

--- a/tests/unit/bokeh/sampledata/test_olympics2014.py
+++ b/tests/unit/bokeh/sampledata/test_olympics2014.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.olympics2014", ALL))
 
 @pytest.mark.sampledata
-def test_data():
+def test_data() -> None:
     import bokeh.sampledata.olympics2014 as bso
     assert isinstance(bso.data, dict)
 

--- a/tests/unit/bokeh/sampledata/test_perceptions.py
+++ b/tests/unit/bokeh/sampledata/test_perceptions.py
@@ -36,7 +36,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.perceptions", ALL))
 
 @pytest.mark.sampledata
-def test_numberly(pd):
+def test_numberly(pd) -> None:
     import bokeh.sampledata.perceptions as bsp
     assert isinstance(bsp.numberly, pd.DataFrame)
 
@@ -44,7 +44,7 @@ def test_numberly(pd):
     assert len(bsp.numberly) == 46
 
 @pytest.mark.sampledata
-def test_probly(pd):
+def test_probly(pd) -> None:
     import bokeh.sampledata.perceptions as bsp
     assert isinstance(bsp.probly, pd.DataFrame)
 

--- a/tests/unit/bokeh/sampledata/test_periodic_table.py
+++ b/tests/unit/bokeh/sampledata/test_periodic_table.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.periodic_table", ALL))
 
 @pytest.mark.sampledata
-def test_elements(pd):
+def test_elements(pd) -> None:
     import bokeh.sampledata.periodic_table as bsp
     assert isinstance(bsp.elements, pd.DataFrame)
 

--- a/tests/unit/bokeh/sampledata/test_population.py
+++ b/tests/unit/bokeh/sampledata/test_population.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.population", ALL))
 
 @pytest.mark.sampledata
-def test_data(pd):
+def test_data(pd) -> None:
     import bokeh.sampledata.population as bsp
     assert isinstance(bsp.data, pd.DataFrame)
 

--- a/tests/unit/bokeh/sampledata/test_sample_geojson.py
+++ b/tests/unit/bokeh/sampledata/test_sample_geojson.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.sample_geojson", ALL))
 
 @pytest.mark.sampledata
-def test_geojson():
+def test_geojson() -> None:
     import bokeh.sampledata.sample_geojson as bsg
     assert isinstance(bsg.geojson, str)
 

--- a/tests/unit/bokeh/sampledata/test_sea_surface_temperature.py
+++ b/tests/unit/bokeh/sampledata/test_sea_surface_temperature.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.sea_surface_temperature", ALL))
 
 @pytest.mark.sampledata
-def test_sea_surface_temperature(pd):
+def test_sea_surface_temperature(pd) -> None:
     import bokeh.sampledata.sea_surface_temperature as bss
     assert isinstance(bss.sea_surface_temperature, pd.DataFrame)
 

--- a/tests/unit/bokeh/sampledata/test_sprint.py
+++ b/tests/unit/bokeh/sampledata/test_sprint.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.sprint", ALL))
 
 @pytest.mark.sampledata
-def test_sprint(pd):
+def test_sprint(pd) -> None:
     import bokeh.sampledata.sprint as bss
     assert isinstance(bss.sprint, pd.DataFrame)
 

--- a/tests/unit/bokeh/sampledata/test_stocks.py
+++ b/tests/unit/bokeh/sampledata/test_stocks.py
@@ -40,7 +40,7 @@ Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.stocks", ALL)
 
 @pytest.mark.sampledata
 @pytest.mark.parametrize('name', ['AAPL', 'FB', 'GOOG', 'IBM', 'MSFT'])
-def test_data(name):
+def test_data(name) -> None:
     import bokeh.sampledata.stocks as bss
     data = getattr(bss, name)
     assert isinstance(data, dict)

--- a/tests/unit/bokeh/sampledata/test_unemployment.py
+++ b/tests/unit/bokeh/sampledata/test_unemployment.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.unemployment", ALL))
 
 @pytest.mark.sampledata
-def test_data():
+def test_data() -> None:
     import bokeh.sampledata.unemployment as bsu
     assert isinstance(bsu.data, dict)
 

--- a/tests/unit/bokeh/sampledata/test_unemployment1948.py
+++ b/tests/unit/bokeh/sampledata/test_unemployment1948.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.unemployment1948", ALL))
 
 @pytest.mark.sampledata
-def test_data(pd):
+def test_data(pd) -> None:
     import bokeh.sampledata.unemployment1948 as bsu
     assert isinstance(bsu.data, pd.DataFrame)
 

--- a/tests/unit/bokeh/sampledata/test_us_cities.py
+++ b/tests/unit/bokeh/sampledata/test_us_cities.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.us_cities", ALL))
 
 @pytest.mark.sampledata
-def test_data():
+def test_data() -> None:
     import bokeh.sampledata.us_cities as bsu
     assert isinstance(bsu.data, dict)
 

--- a/tests/unit/bokeh/sampledata/test_us_counties.py
+++ b/tests/unit/bokeh/sampledata/test_us_counties.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.us_counties", ALL))
 
 @pytest.mark.sampledata
-def test_data():
+def test_data() -> None:
     import bokeh.sampledata.us_counties as bsu
     assert isinstance(bsu.data, dict)
 

--- a/tests/unit/bokeh/sampledata/test_us_holidays.py
+++ b/tests/unit/bokeh/sampledata/test_us_holidays.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.us_holidays", ALL))
 
 @pytest.mark.sampledata
-def test_us_holidays():
+def test_us_holidays() -> None:
     import bokeh.sampledata.us_holidays as bsu
     assert isinstance(bsu.us_holidays, list)
 

--- a/tests/unit/bokeh/sampledata/test_us_marriages_divorces.py
+++ b/tests/unit/bokeh/sampledata/test_us_marriages_divorces.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.us_marriages_divorces", ALL))
 
 @pytest.mark.sampledata
-def test_data(pd):
+def test_data(pd) -> None:
     import bokeh.sampledata.us_marriages_divorces as bsu
     assert isinstance(bsu.data, pd.DataFrame)
 

--- a/tests/unit/bokeh/sampledata/test_us_states.py
+++ b/tests/unit/bokeh/sampledata/test_us_states.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.us_states", ALL))
 
 @pytest.mark.sampledata
-def test_data():
+def test_data() -> None:
     import bokeh.sampledata.us_states as bsu
     assert isinstance(bsu.data, dict)
 

--- a/tests/unit/bokeh/sampledata/test_world_cities.py
+++ b/tests/unit/bokeh/sampledata/test_world_cities.py
@@ -35,7 +35,7 @@ ALL = (
 Test___all__ = pytest.mark.sampledata(verify_all("bokeh.sampledata.world_cities", ALL))
 
 @pytest.mark.sampledata
-def test_data(pd):
+def test_data(pd) -> None:
     import bokeh.sampledata.world_cities as bsw
     assert isinstance(bsw.data, pd.DataFrame)
 

--- a/tests/unit/bokeh/server/test_auth_provider.py
+++ b/tests/unit/bokeh/server/test_auth_provider.py
@@ -48,32 +48,32 @@ def null_auth():
 Test___all__ = verify_all(bsa, ALL)
 
 class TestNullAuth(object):
-    def test_endpoints(self, null_auth):
+    def test_endpoints(self, null_auth) -> None:
         assert null_auth.endpoints == []
 
-    def test_get_user(self, null_auth):
+    def test_get_user(self, null_auth) -> None:
         assert null_auth.get_user ==  None
 
-    def test_get_user_async(self, null_auth):
+    def test_get_user_async(self, null_auth) -> None:
         assert null_auth.get_user_async ==  None
 
-    def test_login_url(self, null_auth):
+    def test_login_url(self, null_auth) -> None:
         assert null_auth.login_url ==  None
 
-    def test_get_login_url(self, null_auth):
+    def test_get_login_url(self, null_auth) -> None:
         assert null_auth.get_login_url ==  None
 
-    def test_login_handler(self, null_auth):
+    def test_login_handler(self, null_auth) -> None:
         assert null_auth.login_handler ==  None
 
-    def test_logout_url(self, null_auth):
+    def test_logout_url(self, null_auth) -> None:
         assert null_auth.logout_url ==  None
 
-    def test_logout_handler(self, null_auth):
+    def test_logout_handler(self, null_auth) -> None:
         assert null_auth.logout_handler ==  None
 
 class TestAuthModule_properties(object):
-    def test_no_endpoints(self):
+    def test_no_endpoints(self) -> None:
         def func(filename):
             am = bsa.AuthModule(filename)
             assert am.endpoints == []
@@ -88,7 +88,7 @@ def get_user(): pass
 login_url = "/foo"
         """, func, suffix='.py')
 
-    def test_login_url_endpoint(self):
+    def test_login_url_endpoint(self) -> None:
         def func(filename):
             am = bsa.AuthModule(filename)
             assert am.endpoints[0][0] == '/foo'
@@ -100,7 +100,7 @@ login_url = "/foo"
 class LoginHandler(RequestHandler): pass
         """, func, suffix='.py')
 
-    def test_logout_url_endpoint(self):
+    def test_logout_url_endpoint(self) -> None:
         def func(filename):
             am = bsa.AuthModule(filename)
             assert am.endpoints[0][0] == '/bar'
@@ -113,7 +113,7 @@ logout_url = "/bar"
 class LogoutHandler(RequestHandler): pass
         """, func, suffix='.py')
 
-    def test_login_logout_url_endpoint(self):
+    def test_login_logout_url_endpoint(self) -> None:
         def func(filename):
             am = bsa.AuthModule(filename)
             endpoints = sorted(am.endpoints)
@@ -131,7 +131,7 @@ from tornado.web import RequestHandler
 class LogoutHandler(RequestHandler): pass
         """, func, suffix='.py')
 
-    def test_get_user(self):
+    def test_get_user(self) -> None:
         def func(filename):
             am = bsa.AuthModule(filename)
             assert am.get_user is not None
@@ -144,7 +144,7 @@ login_url = "/foo"
 
 # TODO (bev) enable when Bokeh 2 uses native coroutine
 #     @pytest.mark.asyncio
-#     async def test_get_user_async(self):
+#     async def test_get_user_async(self) -> None:
 #         async def func(filename):
 #             am = bsa.AuthModule(filename)
 #             assert am.get_user_async is not None
@@ -155,7 +155,7 @@ login_url = "/foo"
 # login_url = "/foo"
 #         """, func, suffix='.py')
 
-    def test_login_url(self):
+    def test_login_url(self) -> None:
         def func(filename):
             am = bsa.AuthModule(filename)
             assert am.login_url == "/foo"
@@ -169,7 +169,7 @@ def get_user(handler): return 10
 login_url = "/foo"
         """, func, suffix='.py')
 
-    def test_get_login_url(self):
+    def test_get_login_url(self) -> None:
         def func(filename):
             am = bsa.AuthModule(filename)
             assert am.login_url is None
@@ -183,7 +183,7 @@ def get_user(handler): return 10
 def get_login_url(handler): return 20
         """, func, suffix='.py')
 
-    def test_login_handler(self):
+    def test_login_handler(self) -> None:
         def func(filename):
             am = bsa.AuthModule(filename)
             assert am.login_url == "/foo"
@@ -199,7 +199,7 @@ from tornado.web import RequestHandler
 class LoginHandler(RequestHandler): pass
         """, func, suffix='.py')
 
-    def test_logout_url(self):
+    def test_logout_url(self) -> None:
         def func(filename):
             am = bsa.AuthModule(filename)
             assert am.login_url == "/foo"
@@ -214,7 +214,7 @@ login_url = "/foo"
 logout_url = "/bar"
         """, func, suffix='.py')
 
-    def test_logout_handler(self):
+    def test_logout_handler(self) -> None:
         def func(filename):
             am = bsa.AuthModule(filename)
             assert am.login_url == "/foo"
@@ -233,12 +233,12 @@ class LogoutHandler(RequestHandler): pass
 
 
 class TestAuthModule_validation(object):
-    def test_no_file(self):
+    def test_no_file(self) -> None:
         with pytest.raises(ValueError) as e:
             bsa.AuthModule("junkjunkjunk")
             assert str(e).startswith("no file exists at module_path:")
 
-    def test_both_user(self):
+    def test_both_user(self) -> None:
         def func(filename):
             with pytest.raises(ValueError) as e:
                 bsa.AuthModule(filename)
@@ -250,7 +250,7 @@ def get_user_async(handler): return 20
     """, func, suffix='.py')
 
     @pytest.mark.parametrize('user_func', ['get_user', 'get_user_async'])
-    def test_no_login(self, user_func):
+    def test_no_login(self, user_func) -> None:
         def func(filename):
             with pytest.raises(ValueError) as e:
                 bsa.AuthModule(filename)
@@ -260,7 +260,7 @@ def get_user_async(handler): return 20
 def %s(handler): return 10
     """ % user_func, func, suffix='.py')
 
-    def test_both_login(self):
+    def test_both_login(self) -> None:
         def func(filename):
             with pytest.raises(ValueError) as e:
                 bsa.AuthModule(filename)
@@ -272,7 +272,7 @@ def get_login_url(handler): return 20
 login_url = "/foo"
     """, func, suffix='.py')
 
-    def test_handler_with_get_login_url(self):
+    def test_handler_with_get_login_url(self) -> None:
         def func(filename):
             with pytest.raises(ValueError) as e:
                 bsa.AuthModule(filename)
@@ -285,7 +285,7 @@ from tornado.web import RequestHandler
 class LoginHandler(RequestHandler): pass
     """, func, suffix='.py')
 
-    def test_login_handler_wrong_type(self):
+    def test_login_handler_wrong_type(self) -> None:
         def func(filename):
             with pytest.raises(ValueError) as e:
                 bsa.AuthModule(filename)
@@ -298,7 +298,7 @@ class LoginHandler(object): pass
     """, func, suffix='.py')
 
     @pytest.mark.parametrize('login_url', ['http://foo.com', 'https://foo.com', '//foo.com'])
-    def test_login_handler_wrong_url(self, login_url):
+    def test_login_handler_wrong_url(self, login_url) -> None:
         def func(filename):
             with pytest.raises(ValueError) as e:
                 bsa.AuthModule(filename)
@@ -309,7 +309,7 @@ def get_user(handler): return 10
 login_url = %r
     """ % login_url, func, suffix='.py')
 
-    def test_logout_handler_wrong_type(self):
+    def test_logout_handler_wrong_type(self) -> None:
         def func(filename):
             with pytest.raises(ValueError) as e:
                 bsa.AuthModule(filename)
@@ -322,7 +322,7 @@ class LogoutHandler(object): pass
     """, func, suffix='.py')
 
     @pytest.mark.parametrize('logout_url', ['http://foo.com', 'https://foo.com', '//foo.com'])
-    def test_logout_handler_wrong_url(self, logout_url):
+    def test_logout_handler_wrong_url(self, logout_url) -> None:
         def func(filename):
             with pytest.raises(ValueError) as e:
                 bsa.AuthModule(filename)
@@ -343,14 +343,14 @@ class LoginHandler(object):
     pass
 """
 
-def test_load_auth_module():
+def test_load_auth_module() -> None:
     def func(filename):
         m =  bsa.load_auth_module(filename)
         assert isinstance(m, ModuleType)
         assert [x for x in sorted(dir(m)) if not x.startswith("__")] == ['LoginHandler', 'get_login_url', 'logout_url']
     with_file_contents(_source, func, suffix='.py')
 
-def test_probably_relative_url():
+def test_probably_relative_url() -> None:
     assert bsa.probably_relative_url("httpabc")
     assert bsa.probably_relative_url("httpsabc")
     assert bsa.probably_relative_url("/abc")

--- a/tests/unit/bokeh/server/test_callbacks__server.py
+++ b/tests/unit/bokeh/server/test_callbacks__server.py
@@ -72,7 +72,7 @@ class LoopAndGroup(object):
 #-----------------------------------------------------------------------------
 
 class TestCallbackGroup(object):
-    def test_next_tick_runs(self):
+    def test_next_tick_runs(self) -> None:
         with (LoopAndGroup()) as ctx:
             func = _make_invocation_counter(ctx.io_loop)
             assert 0 == len(ctx.group._next_tick_callback_removers)
@@ -82,7 +82,7 @@ class TestCallbackGroup(object):
         # check for leaks
         assert 0 == len(ctx.group._next_tick_callback_removers)
 
-    def test_timeout_runs(self):
+    def test_timeout_runs(self) -> None:
         with (LoopAndGroup()) as ctx:
             func = _make_invocation_counter(ctx.io_loop)
             assert 0 == len(ctx.group._timeout_callback_removers)
@@ -92,7 +92,7 @@ class TestCallbackGroup(object):
         # check for leaks
         assert 0 == len(ctx.group._timeout_callback_removers)
 
-    def test_periodic_runs(self):
+    def test_periodic_runs(self) -> None:
         with (LoopAndGroup()) as ctx:
             func = _make_invocation_counter(ctx.io_loop, stop_after=5)
             assert 0 == len(ctx.group._periodic_callback_removers)
@@ -104,28 +104,28 @@ class TestCallbackGroup(object):
         ctx.group.remove_periodic_callback(cb_id)
         assert 0 == len(ctx.group._periodic_callback_removers)
 
-    def test_next_tick_does_not_run_if_removed_immediately(self):
+    def test_next_tick_does_not_run_if_removed_immediately(self) -> None:
         with (LoopAndGroup(quit_after=15)) as ctx:
             func = _make_invocation_counter(ctx.io_loop)
             cb_id = ctx.group.add_next_tick_callback(func)
             ctx.group.remove_next_tick_callback(cb_id)
         assert 0 == func.count()
 
-    def test_timeout_does_not_run_if_removed_immediately(self):
+    def test_timeout_does_not_run_if_removed_immediately(self) -> None:
         with (LoopAndGroup(quit_after=15)) as ctx:
             func = _make_invocation_counter(ctx.io_loop)
             cb_id = ctx.group.add_timeout_callback(func, timeout_milliseconds=1)
             ctx.group.remove_timeout_callback(cb_id)
         assert 0 == func.count()
 
-    def test_periodic_does_not_run_if_removed_immediately(self):
+    def test_periodic_does_not_run_if_removed_immediately(self) -> None:
         with (LoopAndGroup(quit_after=15)) as ctx:
             func = _make_invocation_counter(ctx.io_loop, stop_after=5)
             cb_id = ctx.group.add_periodic_callback(func, period_milliseconds=1)
             ctx.group.remove_periodic_callback(cb_id)
         assert 0 == func.count()
 
-    def test_same_callback_as_all_three_types(self):
+    def test_same_callback_as_all_three_types(self) -> None:
         with (LoopAndGroup()) as ctx:
             func = _make_invocation_counter(ctx.io_loop, stop_after=5)
             # we want the timeout and next_tick to run before the periodic
@@ -134,28 +134,28 @@ class TestCallbackGroup(object):
             ctx.group.add_next_tick_callback(func)
         assert 5 == func.count()
 
-    def test_adding_next_tick_twice(self):
+    def test_adding_next_tick_twice(self) -> None:
         with (LoopAndGroup()) as ctx:
             func = _make_invocation_counter(ctx.io_loop, stop_after=2)
             ctx.group.add_next_tick_callback(func)
             ctx.group.add_next_tick_callback(func)
         assert 2 == func.count()
 
-    def test_adding_timeout_twice(self):
+    def test_adding_timeout_twice(self) -> None:
         with (LoopAndGroup()) as ctx:
             func = _make_invocation_counter(ctx.io_loop, stop_after=2)
             ctx.group.add_timeout_callback(func, timeout_milliseconds=1)
             ctx.group.add_timeout_callback(func, timeout_milliseconds=2)
         assert 2 == func.count()
 
-    def test_adding_periodic_twice(self):
+    def test_adding_periodic_twice(self) -> None:
         with (LoopAndGroup()) as ctx:
             func = _make_invocation_counter(ctx.io_loop, stop_after=2)
             ctx.group.add_periodic_callback(func, period_milliseconds=3)
             ctx.group.add_periodic_callback(func, period_milliseconds=2)
         assert 2 == func.count()
 
-    def test_remove_all_callbacks(self):
+    def test_remove_all_callbacks(self) -> None:
         with (LoopAndGroup(quit_after=15)) as ctx:
             # add a callback that will remove all the others
             def remove_all():
@@ -168,7 +168,7 @@ class TestCallbackGroup(object):
             ctx.group.add_next_tick_callback(func)
         assert 0 == func.count()
 
-    def test_removing_next_tick_twice(self):
+    def test_removing_next_tick_twice(self) -> None:
         with (LoopAndGroup(quit_after=15)) as ctx:
             func = _make_invocation_counter(ctx.io_loop)
             cb_id = ctx.group.add_next_tick_callback(func)
@@ -178,7 +178,7 @@ class TestCallbackGroup(object):
         assert 0 == func.count()
         assert "twice" in repr(exc.value)
 
-    def test_removing_timeout_twice(self):
+    def test_removing_timeout_twice(self) -> None:
         with (LoopAndGroup(quit_after=15)) as ctx:
             func = _make_invocation_counter(ctx.io_loop)
             cb_id = ctx.group.add_timeout_callback(func, timeout_milliseconds=1)
@@ -188,7 +188,7 @@ class TestCallbackGroup(object):
         assert 0 == func.count()
         assert "twice" in repr(exc.value)
 
-    def test_removing_periodic_twice(self):
+    def test_removing_periodic_twice(self) -> None:
         with (LoopAndGroup(quit_after=15)) as ctx:
             func = _make_invocation_counter(ctx.io_loop, stop_after=5)
             cb_id = ctx.group.add_periodic_callback(func, period_milliseconds=1)
@@ -198,7 +198,7 @@ class TestCallbackGroup(object):
         assert 0 == func.count()
         assert "twice" in repr(exc.value)
 
-    def test_adding_next_tick_from_another_thread(self):
+    def test_adding_next_tick_from_another_thread(self) -> None:
         # The test has probabilistic nature - there's a slight change it'll give a false negative
         with LoopAndGroup(quit_after=15) as ctx:
             n = 1000

--- a/tests/unit/bokeh/server/test_contexts.py
+++ b/tests/unit/bokeh/server/test_contexts.py
@@ -30,12 +30,12 @@ import bokeh.server.contexts as bsc # isort:skip
 
 class TestBokehServerContext(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         ac = bsc.ApplicationContext("app", io_loop="ioloop")
         c = bsc.BokehServerContext(ac)
         assert c.application_context == ac
 
-    def test_sessions(self):
+    def test_sessions(self) -> None:
         ac = bsc.ApplicationContext("app", io_loop="ioloop")
         ac._sessions = dict(foo=1, bar=2)
         c = bsc.BokehServerContext(ac)
@@ -43,7 +43,7 @@ class TestBokehServerContext(object):
 
 class TestBokehSessionContext(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         ac = bsc.ApplicationContext("app", io_loop="ioloop")
         sc = bsc.BokehServerContext(ac)
         c = bsc.BokehSessionContext("id", sc, "doc")
@@ -52,7 +52,7 @@ class TestBokehSessionContext(object):
         assert not c.destroyed
         assert c.logout_url is None
 
-    def test_destroyed(self):
+    def test_destroyed(self) -> None:
         class FakeSession(object):
             destroyed = False
         ac = bsc.ApplicationContext("app", io_loop="ioloop")
@@ -64,7 +64,7 @@ class TestBokehSessionContext(object):
         sess.destroyed = True
         assert c.destroyed
 
-    def test_logout_url(self):
+    def test_logout_url(self) -> None:
         ac = bsc.ApplicationContext("app", io_loop="ioloop")
         sc = bsc.BokehServerContext(ac)
         c = bsc.BokehSessionContext("id", sc, "doc", logout_url="/logout")
@@ -75,7 +75,7 @@ class TestBokehSessionContext(object):
 
 class TestApplicationContext(object):
 
-    def test_init(self):
+    def test_init(self) -> None:
         c = bsc.ApplicationContext("app", io_loop="ioloop")
         assert c.io_loop == "ioloop"
         assert c.application == "app"
@@ -86,17 +86,17 @@ class TestApplicationContext(object):
         assert c.application == "app"
         assert c.url == "url"
 
-    def test_sessions(self):
+    def test_sessions(self) -> None:
         c = bsc.ApplicationContext("app", io_loop="ioloop")
         c._sessions = dict(foo=1, bar=2)
         assert set(c.sessions) == set([1,2])
 
-    def test_get_session_success(self):
+    def test_get_session_success(self) -> None:
         c = bsc.ApplicationContext("app", io_loop="ioloop")
         c._sessions = dict(foo=1, bar=2)
         assert c.get_session("foo") == 1
 
-    def test_get_session_failure(self):
+    def test_get_session_failure(self) -> None:
         c = bsc.ApplicationContext("app", io_loop="ioloop")
         c._sessions = dict(foo=1, bar=2)
         with pytest.raises(bsc.ProtocolError) as e:
@@ -104,7 +104,7 @@ class TestApplicationContext(object):
         assert str(e.value).endswith("No such session bax")
 
     @pytest.mark.asyncio
-    async def test_create_session_if_needed_new(self):
+    async def test_create_session_if_needed_new(self) -> None:
         app = Application()
         c = bsc.ApplicationContext(app, io_loop="ioloop")
         class FakeRequest(object):
@@ -114,7 +114,7 @@ class TestApplicationContext(object):
         assert c.get_session("foo") == s
 
     @pytest.mark.asyncio
-    async def test_create_session_if_needed_exists(self):
+    async def test_create_session_if_needed_exists(self) -> None:
         app = Application()
         c = bsc.ApplicationContext(app, io_loop="ioloop")
         class FakeRequest(object):
@@ -125,7 +125,7 @@ class TestApplicationContext(object):
         assert s1 == s2
 
     @pytest.mark.asyncio
-    async def test_create_session_if_needed_bad_sessionid(self):
+    async def test_create_session_if_needed_bad_sessionid(self) -> None:
         app = Application()
         c = bsc.ApplicationContext(app, io_loop="ioloop")
         class FakeRequest(object):
@@ -137,7 +137,7 @@ class TestApplicationContext(object):
         assert str(e.value).endswith("Session ID must not be empty")
 
     @pytest.mark.asyncio
-    async def test_create_session_if_needed_logout_url(self):
+    async def test_create_session_if_needed_logout_url(self) -> None:
         app = Application()
         c = bsc.ApplicationContext(app, io_loop="ioloop", logout_url="/logout")
         class FakeRequest(object):

--- a/tests/unit/bokeh/server/test_server__server.py
+++ b/tests/unit/bokeh/server/test_server__server.py
@@ -157,7 +157,7 @@ class HookTestHandler(Handler):
 # General API
 #-----------------------------------------------------------------------------
 
-def test_prefix(ManagedServerLoop):
+def test_prefix(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         assert server.prefix == ""
@@ -165,7 +165,7 @@ def test_prefix(ManagedServerLoop):
     with ManagedServerLoop(application, prefix="foo") as server:
         assert server.prefix == "foo"
 
-def test_index(ManagedServerLoop):
+def test_index(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         assert server.index is None
@@ -174,7 +174,7 @@ def test_index(ManagedServerLoop):
         assert server.index == "foo"
 
 @pytest.mark.asyncio
-async def test_get_sessions(ManagedServerLoop):
+async def test_get_sessions(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         server_sessions = server.get_sessions('/')
@@ -258,12 +258,12 @@ def resource_files_requested(response, requested=True):
         else:
             assert file not in response
 
-def test_use_xheaders(ManagedServerLoop):
+def test_use_xheaders(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application, use_xheaders=True) as server:
         assert server._http.xheaders == True
 
-def test_ssl_args_plumbing(ManagedServerLoop):
+def test_ssl_args_plumbing(ManagedServerLoop) -> None:
     with mock.patch.object(ssl, 'SSLContext'):
         with ManagedServerLoop({}, ssl_certfile="foo") as server:
             assert server._http.ssl_options.load_cert_chain.call_args[0] == ()
@@ -281,7 +281,7 @@ def test_ssl_args_plumbing(ManagedServerLoop):
 
 # This test just maintains basic creation and setup, detailed functionality
 # is exercised by Server tests above
-def test_base_server():
+def test_base_server() -> None:
     app = BokehTornado(Application())
     httpserver = HTTPServer(app)
     httpserver.start()
@@ -300,7 +300,7 @@ def test_base_server():
     server.io_loop.close()
 
 @pytest.mark.asyncio
-async def test_server_applications_callable_arg(ManagedServerLoop):
+async def test_server_applications_callable_arg(ManagedServerLoop) -> None:
     def modify_doc(doc):
         doc.title = "Hello, world!"
 
@@ -324,7 +324,7 @@ async def test_server_applications_callable_arg(ManagedServerLoop):
 
 @pytest.mark.skipif(sys.platform == "win32",
                     reason="Lifecycle hooks order different on Windows (TODO open issue)")
-def test__lifecycle_hooks(ManagedServerLoop):
+def test__lifecycle_hooks(ManagedServerLoop) -> None:
     application = Application()
     handler = HookTestHandler()
     application.add(handler)
@@ -392,7 +392,7 @@ def test__lifecycle_hooks(ManagedServerLoop):
     assert server_hook_list.hooks == ["session_created", "modify"]
 
 @pytest.mark.asyncio
-async def test__request_in_session_context(ManagedServerLoop):
+async def test__request_in_session_context(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         response = await http_get(server.io_loop, url(server) + "?foo=10")
@@ -406,7 +406,7 @@ async def test__request_in_session_context(ManagedServerLoop):
         assert session_context.request is not None
 
 @pytest.mark.asyncio
-async def test__request_in_session_context_has_arguments(ManagedServerLoop):
+async def test__request_in_session_context_has_arguments(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         response = await http_get(server.io_loop, url(server) + "?foo=10")
@@ -420,7 +420,7 @@ async def test__request_in_session_context_has_arguments(ManagedServerLoop):
         assert session_context.request.arguments['foo'] == [b'10']
 
 @pytest.mark.asyncio
-async def test__no_request_arguments_in_session_context(ManagedServerLoop):
+async def test__no_request_arguments_in_session_context(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         response = await http_get(server.io_loop, url(server))
@@ -442,7 +442,7 @@ async def test__no_request_arguments_in_session_context(ManagedServerLoop):
 ])
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test__resource_files_requested(querystring, requested, ManagedServerLoop):
+async def test__resource_files_requested(querystring, requested, ManagedServerLoop) -> None:
     """
     Checks if the loading of resource files is requested by the autoload.js
     response based on the value of the "resources" parameter.
@@ -453,7 +453,7 @@ async def test__resource_files_requested(querystring, requested, ManagedServerLo
         resource_files_requested(response.body, requested=requested)
 
 @pytest.mark.asyncio
-async def test__autocreate_session_autoload(ManagedServerLoop):
+async def test__autocreate_session_autoload(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         sessions = server.get_sessions('/')
@@ -468,7 +468,7 @@ async def test__autocreate_session_autoload(ManagedServerLoop):
         assert sessionid == sessions[0].id
 
 @pytest.mark.asyncio
-async def test__no_set_title_autoload(ManagedServerLoop):
+async def test__no_set_title_autoload(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         sessions = server.get_sessions('/')
@@ -480,7 +480,7 @@ async def test__no_set_title_autoload(ManagedServerLoop):
         assert use_for_title == "false"
 
 @pytest.mark.asyncio
-async def test__autocreate_session_doc(ManagedServerLoop):
+async def test__autocreate_session_doc(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         sessions = server.get_sessions('/')
@@ -495,7 +495,7 @@ async def test__autocreate_session_doc(ManagedServerLoop):
         assert sessionid == sessions[0].id
 
 @pytest.mark.asyncio
-async def test__no_autocreate_session_websocket(ManagedServerLoop):
+async def test__no_autocreate_session_websocket(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         sessions = server.get_sessions('/')
@@ -507,7 +507,7 @@ async def test__no_autocreate_session_websocket(ManagedServerLoop):
         assert 0 == len(sessions)
 
 @pytest.mark.asyncio
-async def test__use_provided_session_autoload(ManagedServerLoop):
+async def test__use_provided_session_autoload(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         sessions = server.get_sessions('/')
@@ -524,7 +524,7 @@ async def test__use_provided_session_autoload(ManagedServerLoop):
         assert expected == sessions[0].id
 
 @pytest.mark.asyncio
-async def test__use_provided_session_doc(ManagedServerLoop):
+async def test__use_provided_session_doc(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         sessions = server.get_sessions('/')
@@ -541,7 +541,7 @@ async def test__use_provided_session_doc(ManagedServerLoop):
         assert expected == sessions[0].id
 
 @pytest.mark.asyncio
-async def test__use_provided_session_websocket(ManagedServerLoop):
+async def test__use_provided_session_websocket(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         sessions = server.get_sessions('/')
@@ -556,7 +556,7 @@ async def test__use_provided_session_websocket(ManagedServerLoop):
         assert expected == sessions[0].id
 
 @pytest.mark.asyncio
-async def test__autocreate_signed_session_autoload(ManagedServerLoop):
+async def test__autocreate_signed_session_autoload(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application, sign_sessions=True, secret_key='foo') as server:
         sessions = server.get_sessions('/')
@@ -573,7 +573,7 @@ async def test__autocreate_signed_session_autoload(ManagedServerLoop):
         assert check_session_id_signature(sessionid, signed=True, secret_key='foo')
 
 @pytest.mark.asyncio
-async def test__autocreate_signed_session_doc(ManagedServerLoop):
+async def test__autocreate_signed_session_doc(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application, sign_sessions=True, secret_key='foo') as server:
         sessions = server.get_sessions('/')
@@ -590,7 +590,7 @@ async def test__autocreate_signed_session_doc(ManagedServerLoop):
         assert check_session_id_signature(sessionid, signed=True, secret_key='foo')
 
 @pytest.mark.asyncio
-async def test__reject_unsigned_session_autoload(ManagedServerLoop):
+async def test__reject_unsigned_session_autoload(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application, sign_sessions=True, secret_key='bar') as server:
         sessions = server.get_sessions('/')
@@ -605,7 +605,7 @@ async def test__reject_unsigned_session_autoload(ManagedServerLoop):
         assert 0 == len(sessions)
 
 @pytest.mark.asyncio
-async def test__reject_unsigned_session_doc(ManagedServerLoop):
+async def test__reject_unsigned_session_doc(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application, sign_sessions=True, secret_key='bar') as server:
         sessions = server.get_sessions('/')
@@ -620,7 +620,7 @@ async def test__reject_unsigned_session_doc(ManagedServerLoop):
         assert 0 == len(sessions)
 
 @pytest.mark.asyncio
-async def test__reject_unsigned_session_websocket(ManagedServerLoop):
+async def test__reject_unsigned_session_websocket(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application, sign_sessions=True, secret_key='bar') as server:
         sessions = server.get_sessions('/')
@@ -633,7 +633,7 @@ async def test__reject_unsigned_session_websocket(ManagedServerLoop):
         sessions = server.get_sessions('/')
         assert 0 == len(sessions)
 @pytest.mark.asyncio
-async def test__no_generate_session_autoload(ManagedServerLoop):
+async def test__no_generate_session_autoload(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application, generate_session_ids=False) as server:
         sessions = server.get_sessions('/')
@@ -647,7 +647,7 @@ async def test__no_generate_session_autoload(ManagedServerLoop):
         assert 0 == len(sessions)
 
 @pytest.mark.asyncio
-async def test__no_generate_session_doc(ManagedServerLoop):
+async def test__no_generate_session_doc(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application, generate_session_ids=False) as server:
         sessions = server.get_sessions('/')
@@ -662,7 +662,7 @@ async def test__no_generate_session_doc(ManagedServerLoop):
 
 @pytest.mark.skipif(sys.platform == "win32",
                     reason="multiple processes not supported on Windows")
-def test__server_multiple_processes():
+def test__server_multiple_processes() -> None:
 
     # Can't use an ioloop in this test
     with mock.patch('tornado.httpserver.HTTPServer.add_sockets'):
@@ -672,7 +672,7 @@ def test__server_multiple_processes():
 
         tornado_fp.assert_called_with(3, mock.ANY)
 
-def test__existing_ioloop_with_multiple_processes_exception(ManagedServerLoop, event_loop):
+def test__existing_ioloop_with_multiple_processes_exception(ManagedServerLoop, event_loop) -> None:
     application = Application()
     loop = IOLoop.current()
     with pytest.raises(RuntimeError):
@@ -680,14 +680,14 @@ def test__existing_ioloop_with_multiple_processes_exception(ManagedServerLoop, e
             pass
 
 @pytest.mark.asyncio
-async def test__actual_port_number(ManagedServerLoop):
+async def test__actual_port_number(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application, port=0) as server:
         port = server.port
         assert port > 0
         await http_get(server.io_loop, url(server))
 
-def test__ioloop_not_forcibly_stopped():
+def test__ioloop_not_forcibly_stopped() -> None:
     # Issue #5494
     application = Application()
     loop = IOLoop()

--- a/tests/unit/bokeh/server/test_session__server.py
+++ b/tests/unit/bokeh/server/test_session__server.py
@@ -31,7 +31,7 @@ import bokeh.server.session as bss # isort:skip
 # General API
 #-----------------------------------------------------------------------------
 
-def test_creation():
+def test_creation() -> None:
     d = Document()
     s = bss.ServerSession('some-id', d, 'ioloop')
     assert s.id == 'some-id'
@@ -40,7 +40,7 @@ def test_creation():
     assert s.expiration_requested is False
     assert s.expiration_blocked == 0
 
-def test_subscribe():
+def test_subscribe() -> None:
     d = Document()
     s = bss.ServerSession('some-id', d, 'ioloop')
     assert s.connection_count == 0
@@ -53,7 +53,7 @@ def test_subscribe():
     s.unsubscribe('connection2')
     assert s.connection_count == 0
 
-def test_destroy_calls():
+def test_destroy_calls() -> None:
     d = Document()
     s = bss.ServerSession('some-id', d, 'ioloop')
     with mock.patch('bokeh.document.Document.delete_modules') as docdm:

--- a/tests/unit/bokeh/server/test_tornado__server.py
+++ b/tests/unit/bokeh/server/test_tornado__server.py
@@ -39,7 +39,7 @@ logging.basicConfig(level=logging.DEBUG)
 # General API
 #-----------------------------------------------------------------------------
 
-def test_default_resources(ManagedServerLoop):
+def test_default_resources(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         r = server._tornado.resources()
@@ -77,7 +77,7 @@ def test_default_resources(ManagedServerLoop):
         assert r.root_url == "/foo/bar/"
         assert r.path_versioner == StaticHandler.append_version
 
-def test_env_resources(ManagedServerLoop):
+def test_env_resources(ManagedServerLoop) -> None:
     os.environ['BOKEH_RESOURCES'] = 'cdn'
     application = Application()
     with ManagedServerLoop(application) as server:
@@ -85,7 +85,7 @@ def test_env_resources(ManagedServerLoop):
         assert r.mode == "cdn"
     del os.environ['BOKEH_RESOURCES']
 
-def test_dev_resources(ManagedServerLoop):
+def test_dev_resources(ManagedServerLoop) -> None:
     os.environ['BOKEH_DEV'] = 'yes'
     application = Application()
     with ManagedServerLoop(application) as server:
@@ -94,7 +94,7 @@ def test_dev_resources(ManagedServerLoop):
         assert r.dev
     del os.environ['BOKEH_DEV']
 
-def test_index(ManagedServerLoop):
+def test_index(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         assert server._tornado.index is None
@@ -102,7 +102,7 @@ def test_index(ManagedServerLoop):
     with ManagedServerLoop(application, index='foo') as server:
         assert server._tornado.index == "foo"
 
-def test_prefix(ManagedServerLoop):
+def test_prefix(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         assert server._tornado.prefix == ""
@@ -111,14 +111,14 @@ def test_prefix(ManagedServerLoop):
         with ManagedServerLoop(application, prefix=prefix) as server:
             assert server._tornado.prefix == "/foo"
 
-def test_xsrf_cookies():
+def test_xsrf_cookies() -> None:
     bt = tornado.BokehTornado(applications={})
     assert not bt.settings['xsrf_cookies']
 
     bt = tornado.BokehTornado(applications={}, xsrf_cookies=True)
     assert bt.settings['xsrf_cookies']
 
-def test_auth_provider():
+def test_auth_provider() -> None:
     bt = tornado.BokehTornado(applications={})
     assert isinstance(bt.auth_provider, NullAuth)
 
@@ -128,12 +128,12 @@ def test_auth_provider():
     bt = tornado.BokehTornado(applications={}, auth_provider=FakeAuth)
     assert bt.auth_provider is FakeAuth
 
-def test_websocket_max_message_size_bytes():
+def test_websocket_max_message_size_bytes() -> None:
     app = Application()
     t = tornado.BokehTornado({"/": app}, websocket_max_message_size_bytes=12345)
     assert t.settings['websocket_max_message_size'] == 12345
 
-def test_websocket_origins(ManagedServerLoop, unused_tcp_port):
+def test_websocket_origins(ManagedServerLoop, unused_tcp_port) -> None:
     application = Application()
     with ManagedServerLoop(application, port=unused_tcp_port) as server:
         assert server._tornado.websocket_origins == set(["localhost:%s" % unused_tcp_port])
@@ -150,7 +150,7 @@ def test_websocket_origins(ManagedServerLoop, unused_tcp_port):
     with ManagedServerLoop(application, allow_websocket_origin=["foo:8080", "bar"]) as server:
         assert server._tornado.websocket_origins == set(["foo:8080", "bar:80"])
 
-def test_default_app_paths():
+def test_default_app_paths() -> None:
     app = Application()
     t = tornado.BokehTornado({}, "", [])
     assert t.app_paths == set()
@@ -164,7 +164,7 @@ def test_default_app_paths():
 # tried to use capsys to test what's actually logged and it wasn't
 # working, in the meantime at least this tests that log_stats
 # doesn't crash in various scenarios
-def test_log_stats(ManagedServerLoop):
+def test_log_stats(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         server._tornado._log_stats()
@@ -180,7 +180,7 @@ def test_log_stats(ManagedServerLoop):
         server._tornado._log_stats()
 
 @pytest.mark.asyncio
-async def test_metadata(ManagedServerLoop):
+async def test_metadata(ManagedServerLoop) -> None:
     application = Application(metadata=dict(hi="hi", there="there"))
     with ManagedServerLoop(application) as server:
         meta_url = url(server) + 'metadata'

--- a/tests/unit/bokeh/server/test_util.py
+++ b/tests/unit/bokeh/server/test_util.py
@@ -28,26 +28,26 @@ import bokeh.server.util as util # isort:skip
 # General API
 #-----------------------------------------------------------------------------
 
-def test_bind_sockets_with_zero_port():
+def test_bind_sockets_with_zero_port() -> None:
     ss, port = util.bind_sockets("127.0.0.1", 0)
     assert isinstance(ss, list)
     assert len(ss) == 1
     assert isinstance(ss[0], socket.socket)
     assert isinstance(port, int)
 
-def test_check_whitelist_rejects_port_mismatch():
+def test_check_whitelist_rejects_port_mismatch() -> None:
     assert False == util.check_whitelist("foo:100", ["foo:101", "foo:102"])
 
-def test_check_whitelist_rejects_name_mismatch():
+def test_check_whitelist_rejects_name_mismatch() -> None:
     assert False == util.check_whitelist("foo:100", ["bar:100", "baz:100"])
 
-def test_check_whitelist_accepts_name_port_match():
+def test_check_whitelist_accepts_name_port_match() -> None:
     assert True == util.check_whitelist("foo:100", ["foo:100", "baz:100"])
 
-def test_check_whitelist_accepts_implicit_port_80():
+def test_check_whitelist_accepts_implicit_port_80() -> None:
     assert True == util.check_whitelist("foo", ["foo:80"])
 
-def test_check_whitelist_accepts_all_on_star():
+def test_check_whitelist_accepts_all_on_star() -> None:
     assert True == util.check_whitelist("192.168.0.1", ['*'])
     assert True == util.check_whitelist("192.168.0.1:80", ['*'])
     assert True == util.check_whitelist("192.168.0.1:5006", ['*'])
@@ -70,32 +70,32 @@ def test_check_whitelist_accepts_all_on_star():
     assert True == util.check_whitelist("foobarbaz:5006", ['*:*'])
     assert True == util.check_whitelist("foobarbaz:5006", ['*:5006'])
 
-def test_create_hosts_whitelist_no_host():
+def test_create_hosts_whitelist_no_host() -> None:
     hosts = util.create_hosts_whitelist(None, 1000)
     assert hosts == ["localhost:1000"]
 
     hosts = util.create_hosts_whitelist([], 1000)
     assert hosts == ["localhost:1000"]
 
-def test_create_hosts_whitelist_host_value_with_port_use_port():
+def test_create_hosts_whitelist_host_value_with_port_use_port() -> None:
     hosts = util.create_hosts_whitelist(["foo:1000"], 1000)
     assert hosts == ["foo:1000"]
 
     hosts = util.create_hosts_whitelist(["foo:1000","bar:2100"], 1000)
     assert hosts == ["foo:1000","bar:2100"]
 
-def test_create_hosts_whitelist_host_without_port_use_port_80():
+def test_create_hosts_whitelist_host_without_port_use_port_80() -> None:
     hosts = util.create_hosts_whitelist(["foo"], 1000)
     assert hosts == ["foo:80"]
 
     hosts = util.create_hosts_whitelist(["foo","bar"], 1000)
     assert hosts == ["foo:80","bar:80"]
 
-def test_create_hosts_whitelist_host_non_int_port_raises():
+def test_create_hosts_whitelist_host_non_int_port_raises() -> None:
     with pytest.raises(ValueError):
         util.create_hosts_whitelist(["foo:xyz"], 1000)
 
-def test_create_hosts_whitelist_bad_host_raises():
+def test_create_hosts_whitelist_bad_host_raises() -> None:
     with pytest.raises(ValueError):
         util.create_hosts_whitelist([""], 1000)
 
@@ -105,7 +105,7 @@ def test_create_hosts_whitelist_bad_host_raises():
     with pytest.raises(ValueError):
         util.create_hosts_whitelist([":80"], 1000)
 
-def test_match_host():
+def test_match_host() -> None:
         assert util.match_host('192.168.0.1:80', '192.168.0.1:80') == True
         assert util.match_host('192.168.0.1:80', '192.168.0.1') == True
         assert util.match_host('192.168.0.1:80', '192.168.0.1:8080') == False

--- a/tests/unit/bokeh/server/views/test_ws.py
+++ b/tests/unit/bokeh/server/views/test_ws.py
@@ -39,7 +39,7 @@ basicConfig()
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_send_message_raises(caplog):
+async def test_send_message_raises(caplog) -> None:
     class ExcMessage(object):
         def send(self, handler):
             raise WebSocketClosedError()

--- a/tests/unit/bokeh/test___init__.py
+++ b/tests/unit/bokeh/test___init__.py
@@ -72,28 +72,28 @@ THE POSSIBILITY OF SUCH DAMAGE.
 
 Test___all__ = verify_all(b, ALL)
 
-def test___version___type():
+def test___version___type() -> None:
     assert isinstance(b.__version__, str)
 
-def test___version___defined():
+def test___version___defined() -> None:
     assert b.__version__ != 'unknown'
 
-def test_license(capsys):
+def test_license(capsys) -> None:
     b.license()
     out, err = capsys.readouterr()
     assert out == _LICENSE
 
 class TestWarnings(object):
     @pytest.mark.parametrize('cat', (BokehDeprecationWarning, BokehUserWarning))
-    def test_bokeh_custom(self, cat):
+    def test_bokeh_custom(self, cat) -> None:
         r = warnings.formatwarning("message", cat, "line", "lineno")
         assert r == "%s: %s\n" %(cat.__name__, "message")
 
-    def test_general_default(self):
+    def test_general_default(self) -> None:
         r = warnings.formatwarning("message", RuntimeWarning, "line", "lineno")
         assert r == "line:lineno: RuntimeWarning: message\n"
 
-    def test_filters(self):
+    def test_filters(self) -> None:
         assert ('always', None, BokehUserWarning, None, 0) in warnings.filters
         assert ('always', None, BokehDeprecationWarning, None, 0) in warnings.filters
 

--- a/tests/unit/bokeh/test___main__.py
+++ b/tests/unit/bokeh/test___main__.py
@@ -38,7 +38,7 @@ ALL =  (
 Test___all__ = verify_all(bm, ALL)
 
 @patch('bokeh.command.bootstrap.main')
-def test_main(mock_main):
+def test_main(mock_main) -> None:
     import sys
     old_argv = sys.argv
     sys.argv = ["foo", "bar"]

--- a/tests/unit/bokeh/test_client_server.py
+++ b/tests/unit/bokeh/test_client_server.py
@@ -73,7 +73,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 class TestClientServer(object):
 
-    def test_minimal_connect_and_disconnect(self, ManagedServerLoop):
+    def test_minimal_connect_and_disconnect(self, ManagedServerLoop) -> None:
         application = Application()
         with ManagedServerLoop(application) as server:
             # we don't have to start the server because it
@@ -85,7 +85,7 @@ class TestClientServer(object):
             session.connect()
             assert session.connected
 
-    def test_disconnect_on_error(self, ManagedServerLoop):
+    def test_disconnect_on_error(self, ManagedServerLoop) -> None:
         application = Application()
         with ManagedServerLoop(application) as server:
             session = ClientSession(session_id='test_disconnect_on_error',
@@ -103,7 +103,7 @@ class TestClientServer(object):
             session._loop_until_closed()
             assert not session.connected
 
-    def test_connect_with_prefix(self, ManagedServerLoop):
+    def test_connect_with_prefix(self, ManagedServerLoop) -> None:
         application = Application()
         with ManagedServerLoop(application, prefix="foo") as server:
             # we don't have to start the server because it
@@ -164,7 +164,7 @@ class TestClientServer(object):
         await self.check_connect_session_fails(server, origin=origin)
 
     @pytest.mark.asyncio
-    async def test_allow_websocket_origin(self, ManagedServerLoop):
+    async def test_allow_websocket_origin(self, ManagedServerLoop) -> None:
         application = Application()
 
         # allow good origin
@@ -225,7 +225,7 @@ class TestClientServer(object):
             await self.check_http_ok_socket_blocked(server, origin="http://example.com:8081")
             del os.environ["BOKEH_ALLOW_WS_ORIGIN"]
 
-    def test_push_document(self, ManagedServerLoop):
+    def test_push_document(self, ManagedServerLoop) -> None:
         application = Application()
         with ManagedServerLoop(application) as server:
             doc = document.Document()
@@ -256,7 +256,7 @@ class TestClientServer(object):
             client_session._loop_until_closed()
             assert not client_session.connected
 
-    def test_pull_document(self, ManagedServerLoop):
+    def test_pull_document(self, ManagedServerLoop) -> None:
         application = Application()
         def add_roots(doc):
             doc.add_root(AnotherModelInTestClientServer(bar=43))
@@ -286,7 +286,7 @@ class TestClientServer(object):
             client_session._loop_until_closed()
             assert not client_session.connected
 
-    def test_request_server_info(self, ManagedServerLoop):
+    def test_request_server_info(self, ManagedServerLoop) -> None:
         application = Application()
         with ManagedServerLoop(application) as server:
             session = ClientSession(session_id='test_request_server_info',
@@ -308,7 +308,7 @@ class TestClientServer(object):
             assert not session.connected
 
     @pytest.mark.skipif(sys.platform == "win32", reason="uninmportant failure on win")
-    def test_ping(self, ManagedServerLoop):
+    def test_ping(self, ManagedServerLoop) -> None:
         application = Application()
         with ManagedServerLoop(application, keep_alive_milliseconds=0) as server:
             session = ClientSession(session_id='test_ping',
@@ -335,7 +335,7 @@ class TestClientServer(object):
             session._loop_until_closed()
             assert not session.connected
 
-    def test_client_changes_go_to_server(self, ManagedServerLoop):
+    def test_client_changes_go_to_server(self, ManagedServerLoop) -> None:
         application = Application()
         with ManagedServerLoop(application) as server:
             doc = document.Document()
@@ -383,7 +383,7 @@ class TestClientServer(object):
             client_session._loop_until_closed()
             assert not client_session.connected
 
-    def test_server_changes_go_to_client(self, ManagedServerLoop):
+    def test_server_changes_go_to_client(self, ManagedServerLoop) -> None:
         application = Application()
         with ManagedServerLoop(application) as server:
             doc = document.Document()
@@ -450,7 +450,7 @@ class TestClientServer(object):
         await asyncio.sleep(0) # this ensures we actually return to the loop
         return value
 
-    def test_client_session_timeout_async(self, ManagedServerLoop):
+    def test_client_session_timeout_async(self, ManagedServerLoop) -> None:
         application = Application()
         with ManagedServerLoop(application) as server:
             doc = document.Document()
@@ -482,7 +482,7 @@ class TestClientServer(object):
 
             assert dict(a=0, b=1, c=2, d=3, e=4) == result.values
 
-    def test_client_session_timeout_async_added_before_push(self, ManagedServerLoop):
+    def test_client_session_timeout_async_added_before_push(self, ManagedServerLoop) -> None:
         application = Application()
         with ManagedServerLoop(application) as server:
             doc = document.Document()
@@ -515,7 +515,7 @@ class TestClientServer(object):
             assert dict(a=0, b=1, c=2, d=3, e=4) == result.values
 
     @pytest.mark.skip(reason="broken (see PR #9426)")
-    def test_server_session_timeout_async(self, ManagedServerLoop):
+    def test_server_session_timeout_async(self, ManagedServerLoop) -> None:
         application = Application()
         with ManagedServerLoop(application) as server:
             doc = document.Document()
@@ -550,7 +550,7 @@ class TestClientServer(object):
 
             assert dict(a=0, b=1, c=2, d=3, e=4) == result.values
 
-    def test_client_session_next_tick_async(self, ManagedServerLoop):
+    def test_client_session_next_tick_async(self, ManagedServerLoop) -> None:
         application = Application()
         with ManagedServerLoop(application) as server:
             doc = document.Document()
@@ -582,7 +582,7 @@ class TestClientServer(object):
 
             assert dict(a=0, b=1, c=2, d=3, e=4) == result.values
 
-    def test_client_session_next_tick_async_added_before_push(self, ManagedServerLoop):
+    def test_client_session_next_tick_async_added_before_push(self, ManagedServerLoop) -> None:
         application = Application()
         with ManagedServerLoop(application) as server:
             doc = document.Document()
@@ -615,7 +615,7 @@ class TestClientServer(object):
             assert dict(a=0, b=1, c=2, d=3, e=4) == result.values
 
     @pytest.mark.skip(reason="broken (see PR #9426)")
-    def test_server_session_next_tick_async(self, ManagedServerLoop):
+    def test_server_session_next_tick_async(self, ManagedServerLoop) -> None:
         application = Application()
         with ManagedServerLoop(application) as server: # XXX io_loop=IOLoop()
             doc = document.Document()
@@ -650,7 +650,7 @@ class TestClientServer(object):
 
             assert dict(a=0, b=1, c=2, d=3, e=4) == result.values
 
-    def test_client_session_periodic_async(self, ManagedServerLoop):
+    def test_client_session_periodic_async(self, ManagedServerLoop) -> None:
         application = Application()
         with ManagedServerLoop(application) as server:
             doc = document.Document()
@@ -680,7 +680,7 @@ class TestClientServer(object):
 
             assert dict(a=0, b=1, c=2, d=3, e=4) == result.values
 
-    def test_client_session_periodic_async_added_before_push(self, ManagedServerLoop):
+    def test_client_session_periodic_async_added_before_push(self, ManagedServerLoop) -> None:
         application = Application()
         with ManagedServerLoop(application) as server:
             doc = document.Document()
@@ -711,7 +711,7 @@ class TestClientServer(object):
             assert dict(a=0, b=1, c=2, d=3, e=4) == result.values
 
     @pytest.mark.skip(reason="broken (see PR #9426)")
-    def test_server_session_periodic_async(self, ManagedServerLoop):
+    def test_server_session_periodic_async(self, ManagedServerLoop) -> None:
         application = Application()
         with ManagedServerLoop(application) as server:
             doc = document.Document()
@@ -745,7 +745,7 @@ class TestClientServer(object):
             assert dict(a=0, b=1, c=2, d=3, e=4) == result.values
 
     @pytest.mark.skip(reason="broken (see PR #9426)")
-    def test_lots_of_concurrent_messages(self, ManagedServerLoop):
+    def test_lots_of_concurrent_messages(self, ManagedServerLoop) -> None:
         application = Application()
         def setup_stuff(doc):
             m1 = AnotherModelInTestClientServer(bar=43, name='m1')
@@ -834,7 +834,7 @@ class TestClientServer(object):
             assert result['server_connection_count'] == 1
             assert result['server_close_code'] is None
 
-def test_client_changes_do_not_boomerang(monkeypatch, ManagedServerLoop):
+def test_client_changes_do_not_boomerang(monkeypatch, ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         doc = document.Document()
@@ -880,7 +880,7 @@ def test_client_changes_do_not_boomerang(monkeypatch, ManagedServerLoop):
         assert not client_session.connected
         server.unlisten() # clean up so next test can run
 
-def test_server_changes_do_not_boomerang(monkeypatch, ManagedServerLoop):
+def test_server_changes_do_not_boomerang(monkeypatch, ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         doc = document.Document()
@@ -930,7 +930,7 @@ def test_server_changes_do_not_boomerang(monkeypatch, ManagedServerLoop):
 
 # this test is because we do the funky serializable_value
 # tricks with the units specs
-def test_unit_spec_changes_do_not_boomerang(monkeypatch, ManagedServerLoop):
+def test_unit_spec_changes_do_not_boomerang(monkeypatch, ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         doc = document.Document()
@@ -988,7 +988,7 @@ def test_unit_spec_changes_do_not_boomerang(monkeypatch, ManagedServerLoop):
 
 
 @patch('bokeh.client.session.show_session')
-def test_session_show_adds_obj_to_curdoc_if_necessary(m):
+def test_session_show_adds_obj_to_curdoc_if_necessary(m) -> None:
     session = ClientSession()
     session._document = Document()
     p = Plot()

--- a/tests/unit/bokeh/test_driving.py
+++ b/tests/unit/bokeh/test_driving.py
@@ -53,14 +53,14 @@ offset = 2
 
 Test___all__ = verify_all(bd, ALL)
 
-def test_bounce():
+def test_bounce() -> None:
     results = []
     func = bd.bounce([0, 1, 5, -1])(_collector(results))
     for i in range(8):
         func()
     assert results == [0, 1, 5, -1, -1, 5, 1, 0]
 
-def test_cosine():
+def test_cosine() -> None:
     results = []
     func = bd.cosine(w, A, phi, offset)(_collector(results))
     for i in range(4):
@@ -70,14 +70,14 @@ def test_cosine():
         [4.985012495834077, 4.763182982008655, 4.294526561853465, 3.6209069176044197]
     )
 
-def test_count():
+def test_count() -> None:
     results = []
     func = bd.count()(_collector(results))
     for i in range(8):
         func()
     assert results == list(range(8))
 
-def test_force():
+def test_force() -> None:
     results = []
     seq = (x for x in ["foo", "bar", "baz"])
     w = bd.force(_collector(results), seq)
@@ -88,21 +88,21 @@ def test_force():
     w()
     assert results == ["foo", "bar", "baz"]
 
-def test_linear():
+def test_linear() -> None:
     results = []
     func = bd.linear(m=2.5, b=3.7)(_collector(results))
     for i in range(4):
         func()
     assert_allclose(results, [3.7, 6.2, 8.7, 11.2])
 
-def test_repeat():
+def test_repeat() -> None:
     results = []
     func = bd.repeat([0, 1, 5, -1])(_collector(results))
     for i in range(8):
         func()
     assert results == [0, 1, 5, -1, 0, 1, 5, -1]
 
-def test_sine():
+def test_sine() -> None:
     results = []
     func = bd.sine(w, A, phi, offset)(_collector(results))
     for i in range(4):
@@ -120,7 +120,7 @@ def test_sine():
 # Private API
 #-----------------------------------------------------------------------------
 
-def test__advance():
+def test__advance() -> None:
     results = []
     testf = _collector(results)
     s = bd._advance(testf)

--- a/tests/unit/bokeh/test_events.py
+++ b/tests/unit/bokeh/test_events.py
@@ -44,18 +44,18 @@ class EventCallback(object):
         self.event_name = event.event_name
         self.payload = {attr:getattr(event, attr) for attr in self.attributes}
 
-def test_event_metaclass():
+def test_event_metaclass() -> None:
     # All events currently in the namespace should be in the EVENT_CLASSES set
     assert len(concrete_events - set(events._CONCRETE_EVENT_CLASSES.values())) == 0
 
-def test_common_decode_json():
+def test_common_decode_json() -> None:
     for event_name, event_cls in events._CONCRETE_EVENT_CLASSES.items():
         if event_name is None: continue # Skip abstract base class
         event = events.Event.decode_json({'event_name':event_cls.event_name,
                                           'event_values':{'model': {'id': 'test-model-id'}}})
         assert event._model_id == 'test-model-id'
 
-def test_pointevent_subclass_decode_json():
+def test_pointevent_subclass_decode_json() -> None:
     event_values = dict(model_id='test-model-id', sx=3, sy=-2, x=10, y=100)
     for event_cls in point_events:
         if event_cls.event_name is None: continue # Skip abstract base class
@@ -67,7 +67,7 @@ def test_pointevent_subclass_decode_json():
         assert event.y == 100
         assert event._model_id == 'test-model-id'
 
-def test_panevent_decode_json():
+def test_panevent_decode_json() -> None:
     event_values = dict(model={'id': 'test-model-id'}, delta_x=0.1, delta_y=0.3,
                         sx=3, sy=-2, x=10, y=100)
     event = events.Event.decode_json({'event_name':  events.Pan.event_name,
@@ -80,7 +80,7 @@ def test_panevent_decode_json():
     assert event.y == 100
     assert event._model_id == 'test-model-id'
 
-def test_mousewheelevent_decode_json():
+def test_mousewheelevent_decode_json() -> None:
     event_values = dict(model={'id': 'test-model-id'}, delta=-0.1, sx=3, sy=-2, x=10, y=100)
     event = events.Event.decode_json({'event_name':  events.MouseWheel.event_name,
                                       'event_values': event_values.copy()})
@@ -91,7 +91,7 @@ def test_mousewheelevent_decode_json():
     assert event.y == 100
     assert event._model_id == 'test-model-id'
 
-def test_pinchevent_decode_json():
+def test_pinchevent_decode_json() -> None:
     event_values = dict(model={'id': 'test-model-id'}, scale=42, sx=3, sy=-2, x=10, y=100)
     event = events.Event.decode_json({'event_name':  events.Pinch.event_name,
                                       'event_values': event_values.copy()})
@@ -102,75 +102,75 @@ def test_pinchevent_decode_json():
     assert event.y == 100
     assert event._model_id == 'test-model-id'
 
-def test_event_constructor_button():
+def test_event_constructor_button() -> None:
     model = Button()
     event = events.Event(model)
     assert event._model_id == model.id
 
-def test_event_constructor_div():
+def test_event_constructor_div() -> None:
     model = Div()
     event = events.Event(model)
     assert event._model_id == model.id
 
-def test_event_constructor_plot():
+def test_event_constructor_plot() -> None:
     model = Plot()
     event = events.Event(model)
     assert event._model_id == model.id
 
-def test_buttonclick_constructor_button():
+def test_buttonclick_constructor_button() -> None:
     model = Button()
     event = events.ButtonClick(model)
     assert event._model_id == model.id
 
-def test_buttonclick_constructor_div():
+def test_buttonclick_constructor_div() -> None:
     with pytest.raises(ValueError):
         events.ButtonClick(Div())
 
-def test_buttonclick_constructor_plot():
+def test_buttonclick_constructor_plot() -> None:
     with pytest.raises(ValueError):
         events.ButtonClick(Plot())
 
-def test_lodstart_constructor_button():
+def test_lodstart_constructor_button() -> None:
     with pytest.raises(ValueError):
         events.LODStart(Button())
 
-def test_lodstart_constructor_div():
+def test_lodstart_constructor_div() -> None:
     with pytest.raises(ValueError):
         events.LODStart(Div())
 
-def test_lodstart_constructor_plot():
+def test_lodstart_constructor_plot() -> None:
     model = Plot()
     event = events.LODStart(model)
     assert event._model_id == model.id
 
-def test_lodend_constructor_button():
+def test_lodend_constructor_button() -> None:
     with pytest.raises(ValueError):
         events.LODEnd(Button())
 
-def test_lodend_constructor_div():
+def test_lodend_constructor_div() -> None:
     with pytest.raises(ValueError):
         events.LODEnd(Div())
 
-def test_lodend_constructor_plot():
+def test_lodend_constructor_plot() -> None:
     model = Plot()
     event = events.LODEnd(model)
     assert event._model_id == model.id
 
 
-def test_plotevent_constructor_button():
+def test_plotevent_constructor_button() -> None:
     with pytest.raises(ValueError):
         events.PlotEvent(Button())
 
-def test_plotevent_constructor_div():
+def test_plotevent_constructor_div() -> None:
     with pytest.raises(ValueError):
         events.PlotEvent(Div())
 
-def test_plotevent_constructor_plot():
+def test_plotevent_constructor_plot() -> None:
     model = Plot()
     event = events.PlotEvent(model)
     assert event._model_id == model.id
 
-def test_pointEvent_constructor_plot():
+def test_pointEvent_constructor_plot() -> None:
     model = Plot()
     event = events.PointEvent(model, sx=3, sy=-2, x=10, y=100)
     assert event.sx == 3
@@ -179,15 +179,15 @@ def test_pointEvent_constructor_plot():
     assert event.y == 100
     assert event._model_id == model.id
 
-def test_pointevent_constructor_button():
+def test_pointevent_constructor_button() -> None:
     with pytest.raises(ValueError):
         events.PointEvent(Button(), sx=3, sy=-2, x=10, y=100)
 
-def test_pointevent_constructor_div():
+def test_pointevent_constructor_div() -> None:
     with pytest.raises(ValueError):
         events.PointEvent(Div(), sx=3, sy=-2, x=10, y=100)
 
-def test_pointevent_subclass_constructor_plot():
+def test_pointevent_subclass_constructor_plot() -> None:
     model = Plot()
     for subcls in point_events:
         event = subcls(model, sx=3, sy=-2, x=10, y=100)
@@ -197,13 +197,13 @@ def test_pointevent_subclass_constructor_plot():
         assert event.y == 100
         assert event._model_id == model.id
 
-def test_pointevent_subclass_constructor_button():
+def test_pointevent_subclass_constructor_button() -> None:
     model = Button()
     for subcls in point_events:
         with pytest.raises(ValueError):
             subcls(model, sx=3, sy=-2, x=10, y=100)
 
-def test_pointevent_subclass_constructor_div():
+def test_pointevent_subclass_constructor_div() -> None:
     model = Div()
     for subcls in point_events:
         with pytest.raises(ValueError):
@@ -211,7 +211,7 @@ def test_pointevent_subclass_constructor_div():
 
 # Testing event callback invocation
 
-def test_buttonclick_event_callbacks():
+def test_buttonclick_event_callbacks() -> None:
     button = Button()
     test_callback = EventCallback()
     button.on_event(events.ButtonClick, test_callback)
@@ -219,7 +219,7 @@ def test_buttonclick_event_callbacks():
     button._trigger_event(events.ButtonClick(button))
     assert test_callback.event_name == events.ButtonClick.event_name
 
-def test_atomic_plot_event_callbacks():
+def test_atomic_plot_event_callbacks() -> None:
     plot = Plot()
     for event_cls in [events.LODStart, events.LODEnd]:
         test_callback = EventCallback()
@@ -229,7 +229,7 @@ def test_atomic_plot_event_callbacks():
         assert test_callback.event_name == event_cls.event_name
 
 
-def test_pointevent_callbacks():
+def test_pointevent_callbacks() -> None:
     plot = Plot()
     payload = dict(sx=3, sy=-2, x=10, y=100)
     for event_cls in point_events:
@@ -240,7 +240,7 @@ def test_pointevent_callbacks():
         assert test_callback.event_name == event_cls.event_name
         assert test_callback.payload == payload
 
-def test_mousewheel_callbacks():
+def test_mousewheel_callbacks() -> None:
     plot = Plot()
     payload = dict(sx=3, sy=-2, x=10, y=100, delta=5)
     test_callback = EventCallback(['sx','sy','x','y', 'delta'])
@@ -250,7 +250,7 @@ def test_mousewheel_callbacks():
     assert test_callback.event_name == events.MouseWheel.event_name
     assert test_callback.payload == payload
 
-def test_pan_callbacks():
+def test_pan_callbacks() -> None:
     plot = Plot()
     payload = dict(sx=3, sy=-2, x=10, y=100, delta_x=2, delta_y=3.2)
     test_callback = EventCallback(['sx','sy','x','y', 'delta_x', 'delta_y'])
@@ -260,7 +260,7 @@ def test_pan_callbacks():
     assert test_callback.event_name == events.Pan.event_name
     assert test_callback.payload == payload
 
-def test_pinch_callbacks():
+def test_pinch_callbacks() -> None:
     plot = Plot()
     payload = dict(sx=3, sy=-2, x=10, y=100, scale=42)
     test_callback = EventCallback(['sx','sy','x','y', 'scale'])

--- a/tests/unit/bokeh/test_ext.py
+++ b/tests/unit/bokeh/test_ext.py
@@ -28,7 +28,7 @@ import bokeh.ext as ext # isort:skip
 # General API
 #-----------------------------------------------------------------------------
 
-def test_ext_commands(tmpdir):
+def test_ext_commands(tmpdir) -> None:
     tmp = str(tmpdir.mkdir("bk_ext_01"))
 
     assert _names(tmp) == []

--- a/tests/unit/bokeh/test_layouts.py
+++ b/tests/unit/bokeh/test_layouts.py
@@ -27,7 +27,7 @@ from bokeh.plotting import figure
 # General API
 #-----------------------------------------------------------------------------
 
-def test_gridplot_merge_tools_flat():
+def test_gridplot_merge_tools_flat() -> None:
     p1, p2, p3, p4 = figure(), figure(), figure(), figure()
 
     gridplot([[p1, p2], [p3, p4]], merge_tools=True)
@@ -35,7 +35,7 @@ def test_gridplot_merge_tools_flat():
     for p in p1, p2, p3, p4:
         assert p.toolbar_location is None
 
-def test_gridplot_merge_tools_with_None():
+def test_gridplot_merge_tools_with_None() -> None:
     p1, p2, p3, p4 = figure(), figure(), figure(), figure()
 
     gridplot([[p1, None, p2], [p3, p4, None]], merge_tools=True)
@@ -43,7 +43,7 @@ def test_gridplot_merge_tools_with_None():
     for p in p1, p2, p3, p4:
         assert p.toolbar_location is None
 
-def test_gridplot_merge_tools_nested():
+def test_gridplot_merge_tools_nested() -> None:
     p1, p2, p3, p4, p5, p6, p7 = figure(), figure(), figure(), figure(), figure(), figure(), figure()
     r1 = row(p1, p2)
     r2 = row(p3, p4)
@@ -54,7 +54,7 @@ def test_gridplot_merge_tools_nested():
     for p in p1, p2, p3, p4, p5, p6, p7:
         assert p.toolbar_location is None
 
-def test_gridplot_None():
+def test_gridplot_None() -> None:
     def p():
         p = figure()
         p.circle([1, 2, 3], [4, 5, 6])
@@ -66,7 +66,7 @@ def test_gridplot_None():
     assert isinstance(g, GridBox) and len(g.children) == 4
     assert g.children == [(p0, 0, 0), (p1, 0, 1), (p2, 2, 0), (p3, 2, 1)]
 
-def test_layout_simple():
+def test_layout_simple() -> None:
     p1, p2, p3, p4 = figure(), figure(), figure(), figure()
 
     grid = layout([[p1, p2], [p3, p4]], sizing_mode='fixed')
@@ -75,14 +75,14 @@ def test_layout_simple():
     for r in grid.children:
         assert isinstance(r, Row)
 
-def test_layout_kwargs():
+def test_layout_kwargs() -> None:
     p1, p2, p3, p4 = figure(), figure(), figure(), figure()
 
     grid = layout([[p1, p2], [p3, p4]], sizing_mode='fixed', name='simple')
 
     assert grid.name == 'simple'
 
-def test_layout_nested():
+def test_layout_nested() -> None:
     p1, p2, p3, p4, p5, p6 = figure(), figure(), figure(), figure(), figure(), figure()
 
     grid = layout([[[p1, p1], [p2, p2]], [[p3, p4], [p5, p6]]], sizing_mode='fixed')
@@ -93,7 +93,7 @@ def test_layout_nested():
         for c in r.children:
             assert isinstance(c, Column)
 
-def test_grid():
+def test_grid() -> None:
     s0 = Spacer()
     s1 = Spacer()
     s2 = Spacer()

--- a/tests/unit/bokeh/test_model.py
+++ b/tests/unit/bokeh/test_model.py
@@ -38,18 +38,18 @@ class SomeModel(Model):
 
 class Test_js_on_change(object):
 
-    def test_exception_for_no_callbacks(self):
+    def test_exception_for_no_callbacks(self) -> None:
         m = SomeModel()
         with pytest.raises(ValueError):
             m.js_on_change('foo')
 
-    def test_exception_for_bad_callbacks(self):
+    def test_exception_for_bad_callbacks(self) -> None:
         m = SomeModel()
         for val in [10, "bar", None, [1], {}, 10.2]:
             with pytest.raises(ValueError):
                 m.js_on_change('foo', val)
 
-    def test_with_propname(self):
+    def test_with_propname(self) -> None:
         cb = CustomJS(code="")
         m0 = SomeModel()
         for name in m0.properties(self):
@@ -57,7 +57,7 @@ class Test_js_on_change(object):
             m.js_on_change(name, cb)
             assert m.js_property_callbacks == {"change:%s" % name: [cb]}
 
-    def test_with_non_propname(self):
+    def test_with_non_propname(self) -> None:
         cb = CustomJS(code="")
         m1 = SomeModel()
         m1.js_on_change('foo', cb)
@@ -67,14 +67,14 @@ class Test_js_on_change(object):
         m2.js_on_change('change:b', cb)
         assert m2.js_property_callbacks == {"change:b": [cb]}
 
-    def test_with_multple_callbacks(self):
+    def test_with_multple_callbacks(self) -> None:
         cb1 = CustomJS(code="")
         cb2 = CustomJS(code="")
         m = SomeModel()
         m.js_on_change('foo', cb1, cb2)
         assert m.js_property_callbacks == {"foo": [cb1, cb2]}
 
-    def test_with_multple_callbacks_separately(self):
+    def test_with_multple_callbacks_separately(self) -> None:
         cb1 = CustomJS(code="")
         cb2 = CustomJS(code="")
         m = SomeModel()
@@ -83,7 +83,7 @@ class Test_js_on_change(object):
         m.js_on_change('foo', cb2)
         assert m.js_property_callbacks == {"foo": [cb1, cb2]}
 
-    def test_ignores_dupe_callbacks(self):
+    def test_ignores_dupe_callbacks(self) -> None:
         cb = CustomJS(code="")
         m = SomeModel()
         m.js_on_change('foo', cb, cb)
@@ -91,27 +91,27 @@ class Test_js_on_change(object):
 
 class Test_js_link(object):
 
-    def test_value_error_on_bad_attr(self):
+    def test_value_error_on_bad_attr(self) -> None:
         m1 = SomeModel()
         m2 = SomeModel()
         with pytest.raises(ValueError) as e:
             m1.js_link('junk', m2, 'b')
         assert str(e.value).endswith("%r is not a property of self (%r)" % ("junk", m1))
 
-    def test_value_error_on_bad_other(self):
+    def test_value_error_on_bad_other(self) -> None:
         m1 = SomeModel()
         with pytest.raises(ValueError) as e:
             m1.js_link('a', 'junk', 'b')
         assert str(e.value).endswith("'other' is not a Bokeh model: %r" % "junk")
 
-    def test_value_error_on_bad_other_attr(self):
+    def test_value_error_on_bad_other_attr(self) -> None:
         m1 = SomeModel()
         m2 = SomeModel()
         with pytest.raises(ValueError) as e:
             m1.js_link('a', m2, 'junk')
         assert str(e.value).endswith("%r is not a property of other (%r)" % ("junk", m2))
 
-    def test_creates_customjs(self):
+    def test_creates_customjs(self) -> None:
         m1 = SomeModel()
         m2 = SomeModel()
         assert len(m1.js_property_callbacks) == 0
@@ -125,7 +125,7 @@ class Test_js_link(object):
         assert cb.args == dict(other=m2)
         assert cb.code == "other.b = this.a"
 
-def test_all_builtin_models_default_constructible():
+def test_all_builtin_models_default_constructible() -> None:
     bad = []
     for name, cls in Model.model_class_reverse_map.items():
         try:

--- a/tests/unit/bokeh/test_objects.py
+++ b/tests/unit/bokeh/test_objects.py
@@ -96,13 +96,13 @@ class TestModelCls(object):
             foo = 1
         return Test_Class
 
-    def test_metaclassing(self):
+    def test_metaclassing(self) -> None:
         tclass = self.mkclass()
         assert hasattr(tclass, '__view_model__')
         with pytest.raises(Warning):
             self.mkclass()
 
-    def test_get_class(self):
+    def test_get_class(self) -> None:
         from bokeh.model import get_class
         self.mkclass()
         tclass = get_class('test_objects.Test_Class')
@@ -118,11 +118,11 @@ class DeepModel(Model):
 
 class TestCollectModels(object):
 
-    def test_references_large(self):
+    def test_references_large(self) -> None:
         root, objects = large_plot(10)
         assert set(root.references()) == objects
 
-    def test_references_deep(self):
+    def test_references_deep(self) -> None:
         root = DeepModel()
         objects = set([root])
         parent = root
@@ -147,7 +147,7 @@ class TestModel(object):
         self.pObjectClass = SomeModel
         self.maxDiff = None
 
-    def test_init(self):
+    def test_init(self) -> None:
         testObject = self.pObjectClass(id='test_id')
         assert testObject.id == 'test_id'
 
@@ -159,11 +159,11 @@ class TestModel(object):
             testObject.properties_with_values(include_defaults=True)
         assert dict() == testObject.properties_with_values(include_defaults=False)
 
-    def test_struct(self):
+    def test_struct(self) -> None:
         testObject = self.pObjectClass(id='test_id')
         assert {'type': 'test_objects.SomeModel', 'id': 'test_id'} == testObject.struct
 
-    def test_references_by_ref_by_value(self):
+    def test_references_by_ref_by_value(self) -> None:
         from bokeh.core.has_props import HasProps
         from bokeh.core.properties import Instance, Int
 
@@ -197,7 +197,7 @@ class TestModel(object):
         assert x1.references() == {t1, y, t2,     x1}
         assert x2.references() == {t1, y, t2, z2, x2}
 
-    def test_references_in_containers(self):
+    def test_references_in_containers(self) -> None:
         from bokeh.core.properties import Int, String, Instance, List, Tuple, Dict
 
         # XXX: can't use Y, because of:
@@ -220,7 +220,7 @@ class TestModel(object):
 
         assert v.references() == set([v, u1, u2, u3, u4, u5])
 
-    def test_to_json(self):
+    def test_to_json(self) -> None:
         child_obj = SomeModelToJson(foo=57, bar="hello")
         obj = SomeModelToJson(child=child_obj,
                               foo=42, bar="world")
@@ -242,7 +242,7 @@ class TestModel(object):
                 '"foo":42,"id":"%s","js_event_callbacks":{},"js_property_callbacks":{},' +
                 '"name":null,"subscribed_events":[],"tags":[]}') % (child_obj.id, obj.id) == json_string
 
-    def test_no_units_in_json(self):
+    def test_no_units_in_json(self) -> None:
         from bokeh.models import AnnularWedge
         obj = AnnularWedge()
         json = obj.to_json(include_defaults=True)
@@ -251,7 +251,7 @@ class TestModel(object):
         assert 'outer_radius' in json
         assert 'outer_radius_units' not in json
 
-    def test_dataspec_field_in_json(self):
+    def test_dataspec_field_in_json(self) -> None:
         from bokeh.models import AnnularWedge
         obj = AnnularWedge()
         obj.start_angle = "fieldname"
@@ -260,7 +260,7 @@ class TestModel(object):
         assert 'start_angle_units' not in json
         assert dict(units='rad', field='fieldname') == json['start_angle']
 
-    def test_dataspec_value_in_json(self):
+    def test_dataspec_value_in_json(self) -> None:
         from bokeh.models import AnnularWedge
         obj = AnnularWedge()
         obj.start_angle = 60
@@ -269,7 +269,7 @@ class TestModel(object):
         assert 'start_angle_units' not in json
         assert dict(units='rad', value=60) == json['start_angle']
 
-    def test_list_default(self):
+    def test_list_default(self) -> None:
         class HasListDefault(Model):
             value = List(String, default=["hello"])
         obj = HasListDefault()
@@ -285,7 +285,7 @@ class TestModel(object):
         # 'value' should now be included
         assert 'value' in obj.properties_with_values(include_defaults=False)
 
-    def test_dict_default(self):
+    def test_dict_default(self) -> None:
         class HasDictDefault(Model):
             value = Dict(String, Int, default=dict(hello=42))
         obj = HasDictDefault()
@@ -303,7 +303,7 @@ class TestModel(object):
         assert 'value' in obj.properties_with_values(include_defaults=False)
         assert dict(hello=42, world=57) == obj.value
 
-    def test_func_default_with_counter(self):
+    def test_func_default_with_counter(self) -> None:
         counter = dict(value=0)
         def next_value():
             counter['value'] += 1
@@ -318,7 +318,7 @@ class TestModel(object):
         # non-default because it's unstable.
         assert 'value' in obj1.properties_with_values(include_defaults=False)
 
-    def test_func_default_with_model(self):
+    def test_func_default_with_model(self) -> None:
         class HasFuncDefaultModel(Model):
             child = Instance(Model, lambda: SomeModel())
         obj1 = HasFuncDefaultModel()
@@ -357,7 +357,7 @@ class HasListProp(Model):
 
 class TestListMutation(TestContainerMutation):
 
-    def test_whether_included_in_props_with_values(self):
+    def test_whether_included_in_props_with_values(self) -> None:
         obj = HasListProp()
         assert 'foo' not in obj.properties_with_values(include_defaults=False)
         assert 'foo' in obj.properties_with_values(include_defaults=True)
@@ -372,7 +372,7 @@ class TestListMutation(TestContainerMutation):
         assert 'foo' in obj.properties_with_values(include_defaults=False)
         assert 'foo' in obj.properties_with_values(include_defaults=True)
 
-    def test_assignment_maintains_owners(self):
+    def test_assignment_maintains_owners(self) -> None:
         obj = HasListProp()
         old_list = obj.foo
         assert isinstance(old_list, PropertyValueList)
@@ -384,7 +384,7 @@ class TestListMutation(TestContainerMutation):
         assert 0 == len(old_list._owners)
         assert 1 == len(new_list._owners)
 
-    def test_list_delitem(self):
+    def test_list_delitem(self) -> None:
         obj = HasListProp(foo=["a", "b", "c"])
         assert isinstance(obj.foo, PropertyValueList)
         def mutate(x):
@@ -393,7 +393,7 @@ class TestListMutation(TestContainerMutation):
                              ["a", "b", "c"],
                              ["a", "c"])
 
-    def test_list_delslice(self):
+    def test_list_delslice(self) -> None:
         obj = HasListProp(foo=["a", "b", "c", "d"])
         assert isinstance(obj.foo, PropertyValueList)
         def mutate(x):
@@ -402,7 +402,7 @@ class TestListMutation(TestContainerMutation):
                              ["a", "b", "c", "d"],
                              ["a", "d"])
 
-    def test_list_iadd(self):
+    def test_list_iadd(self) -> None:
         obj = HasListProp(foo=["a"])
         assert isinstance(obj.foo, PropertyValueList)
         def mutate(x):
@@ -411,7 +411,7 @@ class TestListMutation(TestContainerMutation):
                              ["a"],
                              ["a", "b"])
 
-    def test_list_imul(self):
+    def test_list_imul(self) -> None:
         obj = HasListProp(foo=["a"])
         assert isinstance(obj.foo, PropertyValueList)
         def mutate(x):
@@ -420,7 +420,7 @@ class TestListMutation(TestContainerMutation):
                              ["a"],
                              ["a", "a", "a"])
 
-    def test_list_setitem(self):
+    def test_list_setitem(self) -> None:
         obj = HasListProp(foo=["a"])
         assert isinstance(obj.foo, PropertyValueList)
         def mutate(x):
@@ -429,7 +429,7 @@ class TestListMutation(TestContainerMutation):
                              ["a"],
                              ["b"])
 
-    def test_list_setslice(self):
+    def test_list_setslice(self) -> None:
         obj = HasListProp(foo=["a", "b", "c", "d"])
         assert isinstance(obj.foo, PropertyValueList)
         def mutate(x):
@@ -438,45 +438,45 @@ class TestListMutation(TestContainerMutation):
                              ["a", "b", "c", "d"],
                              ["a", "x", "d"])
 
-    def test_list_append(self):
+    def test_list_append(self) -> None:
         obj = HasListProp()
         assert isinstance(obj.foo, PropertyValueList)
         self._check_mutation(obj, 'foo', lambda x: x.append("bar"), [], ["bar"])
 
-    def test_list_extend(self):
+    def test_list_extend(self) -> None:
         obj = HasListProp()
         assert isinstance(obj.foo, PropertyValueList)
         self._check_mutation(obj, 'foo', lambda x: x.extend(["x", "y"]), [], ["x", "y"])
 
-    def test_list_insert(self):
+    def test_list_insert(self) -> None:
         obj = HasListProp(foo=["a", "b"])
         assert isinstance(obj.foo, PropertyValueList)
         self._check_mutation(obj, 'foo', lambda x: x.insert(1, "x"),
                              ["a", "b"],
                              ["a", "x", "b"])
 
-    def test_list_pop(self):
+    def test_list_pop(self) -> None:
         obj = HasListProp(foo=["a", "b"])
         assert isinstance(obj.foo, PropertyValueList)
         self._check_mutation(obj, 'foo', lambda x: x.pop(),
                              ["a", "b"],
                              ["a"])
 
-    def test_list_remove(self):
+    def test_list_remove(self) -> None:
         obj = HasListProp(foo=["a", "b"])
         assert isinstance(obj.foo, PropertyValueList)
         self._check_mutation(obj, 'foo', lambda x: x.remove("b"),
                              ["a", "b"],
                              ["a"])
 
-    def test_list_reverse(self):
+    def test_list_reverse(self) -> None:
         obj = HasListProp(foo=["a", "b"])
         assert isinstance(obj.foo, PropertyValueList)
         self._check_mutation(obj, 'foo', lambda x: x.reverse(),
                              ["a", "b"],
                              ["b", "a"])
 
-    def test_list_sort(self):
+    def test_list_sort(self) -> None:
         obj = HasListProp(foo=["b", "a"])
         assert isinstance(obj.foo, PropertyValueList)
         self._check_mutation(obj, 'foo', lambda x: x.sort(),
@@ -496,7 +496,7 @@ class HasIntDictProp(Model):
 
 class TestDictMutation(TestContainerMutation):
 
-    def test_whether_included_in_props_with_values(self):
+    def test_whether_included_in_props_with_values(self) -> None:
         obj = HasStringDictProp()
         assert 'foo' not in obj.properties_with_values(include_defaults=False)
         assert 'foo' in obj.properties_with_values(include_defaults=True)
@@ -511,7 +511,7 @@ class TestDictMutation(TestContainerMutation):
         assert 'foo' in obj.properties_with_values(include_defaults=False)
         assert 'foo' in obj.properties_with_values(include_defaults=True)
 
-    def test_assignment_maintains_owners(self):
+    def test_assignment_maintains_owners(self) -> None:
         obj = HasStringDictProp()
         old_dict = obj.foo
         assert isinstance(old_dict, PropertyValueDict)
@@ -523,7 +523,7 @@ class TestDictMutation(TestContainerMutation):
         assert 0 == len(old_dict._owners)
         assert 1 == len(new_dict._owners)
 
-    def test_dict_delitem_string(self):
+    def test_dict_delitem_string(self) -> None:
         obj = HasStringDictProp(foo=dict(a=1, b=2, c=3))
         assert isinstance(obj.foo, PropertyValueDict)
         def mutate(x):
@@ -532,7 +532,7 @@ class TestDictMutation(TestContainerMutation):
                              dict(a=1, b=2, c=3),
                              dict(a=1, c=3))
 
-    def test_dict_delitem_int(self):
+    def test_dict_delitem_int(self) -> None:
         obj = HasIntDictProp(foo={ 1 : "a", 2 : "b", 3 : "c" })
         assert isinstance(obj.foo, PropertyValueDict)
         def mutate(x):
@@ -541,7 +541,7 @@ class TestDictMutation(TestContainerMutation):
                              { 1 : "a", 2 : "b", 3 : "c" },
                              { 2 : "b", 3 : "c" })
 
-    def test_dict_setitem_string(self):
+    def test_dict_setitem_string(self) -> None:
         obj = HasStringDictProp(foo=dict(a=1, b=2, c=3))
         assert isinstance(obj.foo, PropertyValueDict)
         def mutate(x):
@@ -550,7 +550,7 @@ class TestDictMutation(TestContainerMutation):
                              dict(a=1, b=2, c=3),
                              dict(a=1, b=42, c=3))
 
-    def test_dict_setitem_int(self):
+    def test_dict_setitem_int(self) -> None:
         obj = HasIntDictProp(foo={ 1 : "a", 2 : "b", 3 : "c" })
         assert isinstance(obj.foo, PropertyValueDict)
         def mutate(x):
@@ -559,7 +559,7 @@ class TestDictMutation(TestContainerMutation):
                              { 1 : "a", 2 : "b", 3 : "c" },
                              { 1 : "a", 2 : "bar", 3 : "c" })
 
-    def test_dict_clear(self):
+    def test_dict_clear(self) -> None:
         obj = HasStringDictProp(foo=dict(a=1, b=2, c=3))
         assert isinstance(obj.foo, PropertyValueDict)
         def mutate(x):
@@ -568,7 +568,7 @@ class TestDictMutation(TestContainerMutation):
                              dict(a=1, b=2, c=3),
                              dict())
 
-    def test_dict_pop(self):
+    def test_dict_pop(self) -> None:
         obj = HasStringDictProp(foo=dict(a=1, b=2, c=3))
         assert isinstance(obj.foo, PropertyValueDict)
         def mutate(x):
@@ -577,19 +577,19 @@ class TestDictMutation(TestContainerMutation):
                              dict(a=1, b=2, c=3),
                              dict(a=1, c=3))
 
-    def test_dict_pop_default_works(self):
+    def test_dict_pop_default_works(self) -> None:
         obj = HasStringDictProp(foo=dict(a=1, b=2, c=3))
         assert isinstance(obj.foo, PropertyValueDict)
         assert 42 == obj.foo.pop('z', 42)
 
-    def test_dict_popitem_works(self):
+    def test_dict_popitem_works(self) -> None:
         obj = HasStringDictProp(foo=dict(a=1, b=2, c=3))
         assert isinstance(obj.foo, PropertyValueDict)
         i = obj.foo.popitem()
         assert i == ('a', 1) or i == ('b', 2) or i == ('c', 3)
         # we don't _check_mutation since the end value is nondeterministic
 
-    def test_dict_setdefault(self):
+    def test_dict_setdefault(self) -> None:
         obj = HasStringDictProp(foo=dict(a=1, b=2, c=3))
         assert isinstance(obj.foo, PropertyValueDict)
         def mutate(x):
@@ -602,7 +602,7 @@ class TestDictMutation(TestContainerMutation):
                              dict(a=1, b=2, c=3),
                              dict(a=1, b=2, c=3, z=44))
 
-    def test_dict_update(self):
+    def test_dict_update(self) -> None:
         obj = HasStringDictProp(foo=dict(a=1, b=2, c=3))
         assert isinstance(obj.foo, PropertyValueDict)
         def mutate(x):

--- a/tests/unit/bokeh/test_palettes.py
+++ b/tests/unit/bokeh/test_palettes.py
@@ -25,7 +25,7 @@ import bokeh.palettes as pal # isort:skip
 # General API
 #-----------------------------------------------------------------------------
 
-def test_cmap_generator_function():
+def test_cmap_generator_function() -> None:
     assert pal.viridis(256) == pal.Viridis256
     assert pal.magma(256) == pal.Magma256
     assert pal.plasma(256) == pal.Plasma256
@@ -35,10 +35,10 @@ def test_cmap_generator_function():
     assert pal.turbo(256) == pal.Turbo256
     assert pal.diverging_palette(pal.Reds9, pal.Greys9, n=18, midpoint=0.5) == pal.Reds9 + pal.Greys9[::-1]
 
-def test_all_palettes___palettes__():
+def test_all_palettes___palettes__() -> None:
     assert sum(len(p) for p in pal.all_palettes.values()) == len(pal.__palettes__)
 
-def test_palettes_dir():
+def test_palettes_dir() -> None:
     assert 'viridis' in dir(pal)
     assert 'cividis' in dir(pal)
     assert 'magma' in dir(pal)

--- a/tests/unit/bokeh/test_resources.py
+++ b/tests/unit/bokeh/test_resources.py
@@ -49,7 +49,7 @@ VERSION_PAT = re.compile(r"^(\d+\.\d+\.\d+)$")
 
 
 class TestSRIHashes(object):
-    def test_get_all_hashes_valid_format(self):
+    def test_get_all_hashes_valid_format(self) -> None:
         all_hashes = resources.get_all_sri_hashes()
         for key, value in all_hashes.items():
             assert VERSION_PAT.match(key), f"{key} is not a valid version for the SRI hashes dict"
@@ -60,7 +60,7 @@ class TestSRIHashes(object):
             for h in value.values():
                 assert len(h) == 64
 
-    def test_get_all_hashes_copies(self):
+    def test_get_all_hashes_copies(self) -> None:
         ah1 = resources.get_all_sri_hashes()
         ah2 = resources.get_all_sri_hashes()
         assert ah1 == ah2 == resources._SRI_HASHES
@@ -70,7 +70,7 @@ class TestSRIHashes(object):
 
     # TODO: (bev) conda build on CI is generating bogus versions like "0+untagged.1.g19dd2c8"
     @pytest.mark.skip
-    def test_get_all_hashes_no_future_keys(self):
+    def test_get_all_hashes_no_future_keys(self) -> None:
         current = V(__version__.split("-", 1)[0])  # remove git hash, "-dirty", etc
         all_hashes = resources.get_all_sri_hashes()
         for key in all_hashes:
@@ -78,7 +78,7 @@ class TestSRIHashes(object):
                 V(key) < current
             ), f"SRI hash dict contains vesion {key} which is newer than current version {__version__}"
 
-    def test_get_sri_hashes_for_version(self):
+    def test_get_sri_hashes_for_version(self) -> None:
         all_hashes = resources.get_all_sri_hashes()
         for key, value in all_hashes.items():
             h = resources.get_sri_hashes_for_version(key)
@@ -88,12 +88,12 @@ class TestSRIHashes(object):
 ## Test JSResources
 
 
-def test_js_resources_default_mode_is_cdn():
+def test_js_resources_default_mode_is_cdn() -> None:
     r = resources.JSResources()
     assert r.mode == "cdn"
 
 
-def test_js_resources_inline_has_no_css_resources():
+def test_js_resources_inline_has_no_css_resources() -> None:
     r = resources.JSResources(mode="inline")
     assert r.mode == "inline"
     assert r.dev is False
@@ -107,12 +107,12 @@ def test_js_resources_inline_has_no_css_resources():
 ## Test CSSResources
 
 
-def test_css_resources_default_mode_is_cdn():
+def test_css_resources_default_mode_is_cdn() -> None:
     r = resources.CSSResources()
     assert r.mode == "cdn"
 
 
-def test_inline_css_resources():
+def test_inline_css_resources() -> None:
     r = resources.CSSResources(mode="inline")
     assert r.mode == "inline"
     assert r.dev is False
@@ -123,11 +123,11 @@ def test_inline_css_resources():
 
 
 class TestResources(object):
-    def test_basic(self):
+    def test_basic(self) -> None:
         r = resources.Resources()
         assert r.mode == "cdn"
 
-    def test_log_level(self):
+    def test_log_level(self) -> None:
         r = resources.Resources()
         for level in LOG_LEVELS:
             r.log_level = level
@@ -137,11 +137,11 @@ class TestResources(object):
         with pytest.raises(ValueError):
             setattr(r, "log_level", "foo")
 
-    def test_module_attrs(self):
+    def test_module_attrs(self) -> None:
         assert resources.CDN.mode == "cdn"
         assert resources.INLINE.mode == "inline"
 
-    def test_inline(self):
+    def test_inline(self) -> None:
         r = resources.Resources(mode="inline")
         assert r.mode == "inline"
         assert r.dev == False
@@ -151,13 +151,13 @@ class TestResources(object):
         assert len(r.css_raw) == 0
         assert r.messages == []
 
-    def test_get_cdn_urls(self):
+    def test_get_cdn_urls(self) -> None:
         dev_version = "0.0.1dev2"
         result = _get_cdn_urls(version=dev_version)
         url = result["urls"](["bokeh"], "js")[0]
         assert "bokeh/dev" in url
 
-    def test_cdn(self):
+    def test_cdn(self) -> None:
         resources.__version__ = "1.0"
         r = resources.Resources(mode="cdn", version="1.0")
         assert r.mode == "cdn"
@@ -176,7 +176,7 @@ class TestResources(object):
             }
         ]
 
-    def test_server_default(self):
+    def test_server_default(self) -> None:
         r = resources.Resources(mode="server")
         assert r.mode == "server"
         assert r.dev == False
@@ -192,7 +192,7 @@ class TestResources(object):
             "http://localhost:5006/static/js/bokeh-gl.min.js",
         ]
 
-    def test_server_root_url(self):
+    def test_server_root_url(self) -> None:
         r = resources.Resources(mode="server", root_url="http://foo/")
 
         assert r.js_raw == [DEFAULT_LOG_JS_RAW]
@@ -206,7 +206,7 @@ class TestResources(object):
             "http://foo/static/js/bokeh-gl.min.js",
         ]
 
-    def test_server_root_url_empty(self):
+    def test_server_root_url_empty(self) -> None:
         r = resources.Resources(mode="server", root_url="")
 
         assert r.js_raw == [DEFAULT_LOG_JS_RAW]
@@ -220,7 +220,7 @@ class TestResources(object):
             "static/js/bokeh-gl.min.js",
         ]
 
-    def test_server_with_versioner(self):
+    def test_server_with_versioner(self) -> None:
         def versioner(path):
             return path + "?v=VERSIONED"
 
@@ -233,7 +233,7 @@ class TestResources(object):
             "http://foo/static/js/bokeh-gl.min.js?v=VERSIONED",
         ]
 
-    def test_server_dev(self):
+    def test_server_dev(self) -> None:
         r = resources.Resources(mode="server-dev")
         assert r.mode == "server"
         assert r.dev == True
@@ -248,7 +248,7 @@ class TestResources(object):
         assert r.css_raw == []
         assert r.messages == []
 
-    def test_relative(self):
+    def test_relative(self) -> None:
         r = resources.Resources(mode="relative")
         assert r.mode == "relative"
         assert r.dev == False
@@ -257,7 +257,7 @@ class TestResources(object):
         assert r.css_raw == []
         assert r.messages == []
 
-    def test_relative_dev(self):
+    def test_relative_dev(self) -> None:
         r = resources.Resources(mode="relative-dev")
         assert r.mode == "relative"
         assert r.dev == True
@@ -266,7 +266,7 @@ class TestResources(object):
         assert r.css_raw == []
         assert r.messages == []
 
-    def test_absolute(self):
+    def test_absolute(self) -> None:
         r = resources.Resources(mode="absolute")
         assert r.mode == "absolute"
         assert r.dev == False
@@ -275,7 +275,7 @@ class TestResources(object):
         assert r.css_raw == []
         assert r.messages == []
 
-    def test_absolute_dev(self):
+    def test_absolute_dev(self) -> None:
         r = resources.Resources(mode="absolute-dev")
         assert r.mode == "absolute"
         assert r.dev == True
@@ -284,7 +284,7 @@ class TestResources(object):
         assert r.css_raw == []
         assert r.messages == []
 
-    def test_argument_checks(self):
+    def test_argument_checks(self) -> None:
         with pytest.raises(ValueError):
             resources.Resources("foo")
 
@@ -304,7 +304,7 @@ class TestResources(object):
 ## Test external resources
 
 
-def test_external_js_and_css_resource_embedding():
+def test_external_js_and_css_resource_embedding() -> None:
     """ This test method has to be at the end of the test modules because
     subclassing a Model causes the CustomModel to be added as a Model and
     messes up the Resources state for the other tests.
@@ -340,7 +340,7 @@ def test_external_js_and_css_resource_embedding():
     assert r.js_files.count("external_js_1") == 1
 
 
-def test_external_js_and_css_resource_ordering():
+def test_external_js_and_css_resource_ordering() -> None:
     class ZClass(Model):
         __javascript__ = "z_class"
 

--- a/tests/unit/bokeh/test_server.py
+++ b/tests/unit/bokeh/test_server.py
@@ -39,7 +39,7 @@ logging.basicConfig(level=logging.DEBUG)
 # test_client_server.py is the test for the main functionality
 # of the server, here we're testing some properties in isolation
 class TestServer(object):
-    def test_port(self):
+    def test_port(self) -> None:
         loop = IOLoop()
         loop.make_current()
         server = Server(Application(), port=1234)
@@ -47,7 +47,7 @@ class TestServer(object):
         server.stop()
         server.unlisten()
 
-    def test_address(self):
+    def test_address(self) -> None:
         loop = IOLoop()
         loop.make_current()
         server = Server(Application(), address='0.0.0.0')

--- a/tests/unit/bokeh/test_settings.py
+++ b/tests/unit/bokeh/test_settings.py
@@ -71,21 +71,21 @@ _expected_settings = (
 
 class TestSettings(object):
 
-    def test_standard_settings(self):
+    def test_standard_settings(self) -> None:
         settings = [k for k,v in bs.settings.__class__.__dict__.items() if isinstance(v, bs.PrioritizedSetting)]
         assert set(settings) == set(_expected_settings)
 
     @pytest.mark.parametrize("name", _expected_settings)
-    def test_prefix(self, name):
+    def test_prefix(self, name) -> None:
         ps = getattr(bs.settings, name)
         assert ps.env_var.startswith("BOKEH_")
 
     @pytest.mark.parametrize("name", _expected_settings)
-    def test_parent(self, name):
+    def test_parent(self, name) -> None:
         ps = getattr(bs.settings, name)
         assert ps._parent == bs.settings
 
-    def test_types(self):
+    def test_types(self) -> None:
         assert bs.settings.ignore_filename.convert_type == "Bool"
         assert bs.settings.minified.convert_type == "Bool"
         assert bs.settings.perform_document_validation.convert_type == "Bool"
@@ -118,29 +118,29 @@ class TestSettings(object):
 
 class TestConverters(object):
     @pytest.mark.parametrize("value", ["Yes", "YES", "yes", "1", "ON", "on", "true", "True", True])
-    def test_convert_bool(self, value):
+    def test_convert_bool(self, value) -> None:
         assert bs.convert_bool(value)
 
     @pytest.mark.parametrize("value", ["No", "NO", "no", "0", "OFF", "off", "false", "False", False])
-    def test_convert_bool_false(self, value):
+    def test_convert_bool_false(self, value) -> None:
         assert not bs.convert_bool(value)
 
     @pytest.mark.parametrize("value", [True, False])
-    def test_convert_bool_identity(self, value):
+    def test_convert_bool_identity(self, value) -> None:
         assert bs.convert_bool(value) == value
 
-    def test_convert_bool_bad(self):
+    def test_convert_bool_bad(self) -> None:
         with pytest.raises(ValueError):
             bs.convert_bool("junk")
 
     @pytest.mark.parametrize("value", ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"])
-    def test_convert_logging_good(self, value):
+    def test_convert_logging_good(self, value) -> None:
         assert bs.convert_logging(value) == getattr(logging, value)
 
         # check lowercase works too
         assert bs.convert_logging(value.lower()) == getattr(logging, value)
 
-    def test_convert_logging_none(self):
+    def test_convert_logging_none(self) -> None:
         assert bs.convert_logging("NONE") == None
 
         # check lowercase works
@@ -150,51 +150,51 @@ class TestConverters(object):
         assert bs.convert_logging(None) == None
 
     @pytest.mark.parametrize("value", ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"])
-    def test_convert_logging_identity(self, value):
+    def test_convert_logging_identity(self, value) -> None:
         level = getattr(logging, value)
         assert bs.convert_logging(level) == level
 
-    def test_convert_logging_bad(self):
+    def test_convert_logging_bad(self) -> None:
         with pytest.raises(ValueError):
             bs.convert_logging("junk")
 
 class TestPrioritizedSetting(object):
-    def test_env_var_property(self):
+    def test_env_var_property(self) -> None:
         ps = bs.PrioritizedSetting("foo", env_var="BOKEH_FOO")
         assert ps.env_var == "BOKEH_FOO"
 
-    def test_everything_unset_raises(self):
+    def test_everything_unset_raises(self) -> None:
         ps = bs.PrioritizedSetting("foo")
         with pytest.raises(RuntimeError):
             ps()
 
-    def test_implict_default(self):
+    def test_implict_default(self) -> None:
         ps = bs.PrioritizedSetting("foo", default=10)
         assert ps() == 10
 
-    def test_implict_default_converts(self):
+    def test_implict_default_converts(self) -> None:
         ps = bs.PrioritizedSetting("foo", convert=int, default="10")
         assert ps() == 10
 
-    def test_help(self):
+    def test_help(self) -> None:
         ps = bs.PrioritizedSetting("foo", env_var="BOKEH_FOO", default=10, help="bar")
         assert ps.help == "bar"
 
-    def test_name(self):
+    def test_name(self) -> None:
         ps = bs.PrioritizedSetting("foo", env_var="BOKEH_FOO", default=10)
         assert ps.name == "foo"
 
-    def test_global_default(self):
+    def test_global_default(self) -> None:
         ps = bs.PrioritizedSetting("foo", env_var="BOKEH_FOO", default=10)
         assert ps.default == 10
         assert ps() == 10
 
-    def test_local_default(self):
+    def test_local_default(self) -> None:
         ps = bs.PrioritizedSetting("foo", env_var="BOKEH_FOO", default=10)
         assert ps.default == 10
         assert ps(default=20) == 20
 
-    def test_dev_default(self):
+    def test_dev_default(self) -> None:
         ps = bs.PrioritizedSetting("foo", env_var="BOKEH_FOO", default=10, dev_default=25)
         assert ps.dev_default == 25
         os.environ['BOKEH_DEV'] = "yes"
@@ -202,7 +202,7 @@ class TestPrioritizedSetting(object):
         assert ps(default=20) == 25
         del os.environ['BOKEH_DEV']
 
-    def test_env_var(self):
+    def test_env_var(self) -> None:
         os.environ["BOKEH_FOO"] = "30"
         ps = bs.PrioritizedSetting("foo", env_var="BOKEH_FOO")
         assert ps.env_var == "BOKEH_FOO"
@@ -210,40 +210,40 @@ class TestPrioritizedSetting(object):
         assert ps(default=20) == "30"
         del os.environ["BOKEH_FOO"]
 
-    def test_env_var_converts(self):
+    def test_env_var_converts(self) -> None:
         os.environ["BOKEH_FOO"] = "30"
         ps = bs.PrioritizedSetting("foo", convert=int, env_var="BOKEH_FOO")
         assert ps() == 30
         del os.environ["BOKEH_FOO"]
 
-    def test_user_set(self):
+    def test_user_set(self) -> None:
         ps = bs.PrioritizedSetting("foo")
         ps.set_value(40)
         assert ps() == 40
         assert ps(default=20) == 40
 
-    def test_user_unset(self):
+    def test_user_unset(self) -> None:
         ps = bs.PrioritizedSetting("foo", default=2)
         ps.set_value(40)
         assert ps() == 40
         ps.unset_value()
         assert ps() == 2
 
-    def test_user_set_converts(self):
+    def test_user_set_converts(self) -> None:
         ps = bs.PrioritizedSetting("foo", convert=int)
         ps.set_value("40")
         assert ps() == 40
 
-    def test_immediate(self):
+    def test_immediate(self) -> None:
         ps = bs.PrioritizedSetting("foo")
         assert ps(50) == 50
         assert ps(50, default=20) == 50
 
-    def test_immediate_converts(self):
+    def test_immediate_converts(self) -> None:
         ps = bs.PrioritizedSetting("foo", convert=int)
         assert ps("50") == 50
 
-    def test_precedence(self):
+    def test_precedence(self) -> None:
         class FakeSettings(object):
             config_override = {}
             config_user = {}
@@ -294,7 +294,7 @@ class TestPrioritizedSetting(object):
 
         del os.environ["BOKEH_FOO"]
 
-    def test_descriptors(self):
+    def test_descriptors(self) -> None:
         class FakeSettings(object):
             foo = bs.PrioritizedSetting("foo", env_var="BOKEH_FOO")
             bar = bs.PrioritizedSetting("bar", env_var="BOKEH_BAR", default=10)

--- a/tests/unit/bokeh/test_themes.py
+++ b/tests/unit/bokeh/test_themes.py
@@ -55,7 +55,7 @@ attrs:
 
 class TestThemes(object):
 
-    def test_construct_empty_theme_from_file(self):
+    def test_construct_empty_theme_from_file(self) -> None:
         # windows will throw permissions error with auto-delete
         with (tempfile.NamedTemporaryFile(delete=False)) as file:
             # create and apply empty theme with no exception thrown
@@ -66,34 +66,34 @@ class TestThemes(object):
         file.close()
         os.remove(file.name)
 
-    def test_construct_empty_theme_from_json(self):
+    def test_construct_empty_theme_from_json(self) -> None:
         # create and apply empty theme with no exception thrown
         theme = Theme(json=dict())
         theme.apply_to_model(ThemedModel())
 
-    def test_construct_no_json_or_filename(self):
+    def test_construct_no_json_or_filename(self) -> None:
         with pytest.raises(ValueError) as exc:
             Theme()
         assert "requires json or a filename" in repr(exc.value)
 
-    def test_construct_json_and_filename(self):
+    def test_construct_json_and_filename(self) -> None:
         with pytest.raises(ValueError) as exc:
             # we check "" and {} as falsey values, to try to trick
             # our code into thinking they weren't provided.
             Theme(filename="", json={})
         assert "not both" in repr(exc.value)
 
-    def test_construct_bad_attrs(self):
+    def test_construct_bad_attrs(self) -> None:
         with pytest.raises(ValueError) as exc:
             Theme(json=dict(attrs=42))
         assert "should be a dictionary of class names" in repr(exc.value)
 
-    def test_construct_bad_class_props(self):
+    def test_construct_bad_class_props(self) -> None:
         with pytest.raises(ValueError) as exc:
             Theme(json=dict(attrs=dict(SomeClass=42)))
         assert "should be a dictionary of properties" in repr(exc.value)
 
-    def test_construct_nonempty_theme_from_file(self):
+    def test_construct_nonempty_theme_from_file(self) -> None:
         # windows will throw permissions error with auto-delete
         with (tempfile.NamedTemporaryFile(delete=False)) as file:
             # create and apply empty theme with no exception thrown
@@ -105,7 +105,7 @@ class TestThemes(object):
         file.close()
         os.remove(file.name)
 
-    def test_theming_a_model(self):
+    def test_theming_a_model(self) -> None:
         theme = Theme(json={
             'attrs' : {
                 'ThemedModel' : {
@@ -123,7 +123,7 @@ class TestThemes(object):
         assert 'w00t' == obj.string
         assert [('string', 'hello', 'w00t')] == changes['calls']
 
-    def test_theming_a_model_via_base(self):
+    def test_theming_a_model_via_base(self) -> None:
         theme = Theme(json={
             'attrs' : {
                 'ThemedModel' : {
@@ -141,7 +141,7 @@ class TestThemes(object):
         assert 'w00t' == obj.string
         assert [('string', 'hello', 'w00t')] == changes['calls']
 
-    def test_subclass_theme_used_rather_than_base(self):
+    def test_subclass_theme_used_rather_than_base(self) -> None:
         theme = Theme(json={
             'attrs' : {
                 'ThemedModel' : {
@@ -162,7 +162,7 @@ class TestThemes(object):
         assert 'bar' == obj.string
         assert [('string', 'hello', 'bar')] == changes['calls']
 
-    def test_theming_a_document_after_adding_root(self):
+    def test_theming_a_document_after_adding_root(self) -> None:
         theme = Theme(json={
             'attrs' : {
                 'ThemedModel' : {
@@ -185,7 +185,7 @@ class TestThemes(object):
         assert 'hello' == obj.string
         assert [('string', 'hello', 'w00t'), ('string', 'w00t', 'hello')] == changes['calls']
 
-    def test_theming_a_document_before_adding_root(self):
+    def test_theming_a_document_before_adding_root(self) -> None:
         theme = Theme(json={
             'attrs' : {
                 'ThemedModel' : {
@@ -208,7 +208,7 @@ class TestThemes(object):
         assert 'hello' == obj.string
         assert [('string', 'hello', 'w00t'), ('string', 'w00t', 'hello')] == changes['calls']
 
-    def test_setting_document_theme_to_none(self):
+    def test_setting_document_theme_to_none(self) -> None:
         theme = Theme(json={
             'attrs' : {
                 'ThemedModel' : {
@@ -254,7 +254,7 @@ class TestThemes(object):
         else:
             raise RuntimeError("Could not find class for " + model_name)
 
-    def test_default_theme_is_empty(self):
+    def test_default_theme_is_empty(self) -> None:
         # this is kind of a silly test once we fix default.yaml to be empty :-)
         # the point is to list all the things to fix.
         doc = Document()
@@ -273,28 +273,28 @@ class TestThemes(object):
         self._compare_dict_to_model_class_defaults(doc.theme._line_defaults, LineProps)
         assert 0 == len(doc.theme._line_defaults)
 
-    def test_setting_built_in_theme_obj(self):
+    def test_setting_built_in_theme_obj(self) -> None:
         obj = SomeModel()
         doc = Document()
         doc.add_root(obj)
         doc.theme = built_in_themes[LIGHT_MINIMAL]
         assert "#5B5B5B" == doc.theme._json['attrs']['ColorBar']['title_text_color']
 
-    def test_setting_built_in_theme_str(self):
+    def test_setting_built_in_theme_str(self) -> None:
         obj = SomeModel()
         doc = Document()
         doc.add_root(obj)
         doc.theme = DARK_MINIMAL
         assert "#20262B" == doc.theme._json['attrs']['Figure']['background_fill_color']
 
-    def test_setting_built_in_theme_missing(self):
+    def test_setting_built_in_theme_missing(self) -> None:
         obj = SomeModel()
         doc = Document()
         doc.add_root(obj)
         with pytest.raises(ValueError):
             doc.theme = 'some_theme_i_guess'
 
-    def test_setting_built_in_theme_error(self):
+    def test_setting_built_in_theme_error(self) -> None:
         obj = SomeModel()
         doc = Document()
         doc.add_root(obj)

--- a/tests/unit/bokeh/test_tile_providers.py
+++ b/tests/unit/bokeh/test_tile_providers.py
@@ -84,15 +84,15 @@ _ESRI_URLS = {
 @pytest.mark.parametrize('name', [ 'STAMEN_TERRAIN',  'STAMEN_TERRAIN_RETINA', 'STAMEN_TONER', 'STAMEN_TONER_BACKGROUND', 'STAMEN_TONER_LABELS',])
 @pytest.mark.unit
 class Test_StamenProviders(object):
-    def test_type(self, name):
+    def test_type(self, name) -> None:
         p = getattr(bt, name)
         assert isinstance(p, str)
 
-    def test_url(self, name):
+    def test_url(self, name) -> None:
         p = bt.get_provider(getattr(bt, name))
         assert p.url == _STAMEN_URLS[name]
 
-    def test_attribution(self, name):
+    def test_attribution(self, name) -> None:
         p = bt.get_provider(getattr(bt, name))
 
         assert p.attribution == (
@@ -102,7 +102,7 @@ class Test_StamenProviders(object):
             'under %s.'
         ) % _STAMEN_LIC[name]
 
-    def test_copies(self, name):
+    def test_copies(self, name) -> None:
         p1 = bt.get_provider(getattr(bt, name))
         p2 = bt.get_provider(getattr(bt, name))
         assert p1 is not p2
@@ -110,22 +110,22 @@ class Test_StamenProviders(object):
 @pytest.mark.parametrize('name', ['CARTODBPOSITRON', 'CARTODBPOSITRON_RETINA'])
 @pytest.mark.unit
 class Test_CartoProviders(object):
-    def test_type(self, name):
+    def test_type(self, name) -> None:
         p = getattr(bt, name)
         assert isinstance(p, str)
 
-    def test_url(self, name):
+    def test_url(self, name) -> None:
         p = bt.get_provider(getattr(bt, name))
         assert p.url == _CARTO_URLS[name]
 
-    def test_attribution(self, name):
+    def test_attribution(self, name) -> None:
         p = bt.get_provider(getattr(bt, name))
         assert p.attribution == (
             '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors,'
             '&copy; <a href="https://cartodb.com/attributions">CartoDB</a>'
         )
 
-    def test_copies(self, name):
+    def test_copies(self, name) -> None:
         p1 = bt.get_provider(getattr(bt, name))
         p2 = bt.get_provider(getattr(bt, name))
         assert p1 is not p2
@@ -133,21 +133,21 @@ class Test_CartoProviders(object):
 @pytest.mark.parametrize('name', ['OSM'])
 @pytest.mark.unit
 class Test_OsmProvider(object):
-    def test_type(self, name):
+    def test_type(self, name) -> None:
         p = getattr(bt, name)
         assert isinstance(p, str)
 
-    def test_url(self, name):
+    def test_url(self, name) -> None:
         p = bt.get_provider(getattr(bt, name))
         assert p.url == _OSM_URLS[name]
 
-    def test_attribution(self, name):
+    def test_attribution(self, name) -> None:
         p = bt.get_provider(getattr(bt, name))
         assert p.attribution == (
             '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         )
 
-    def test_copies(self, name):
+    def test_copies(self, name) -> None:
         p1 = bt.get_provider(getattr(bt, name))
         p2 = bt.get_provider(getattr(bt, name))
         assert p1 is not p2
@@ -155,21 +155,21 @@ class Test_OsmProvider(object):
 @pytest.mark.parametrize('name', ['WIKIMEDIA'])
 @pytest.mark.unit
 class Test_WikimediaProvider(object):
-    def test_type(self, name):
+    def test_type(self, name) -> None:
         p = getattr(bt, name)
         assert isinstance(p, str)
 
-    def test_url(self, name):
+    def test_url(self, name) -> None:
         p = bt.get_provider(getattr(bt, name))
         assert p.url == _WIKIMEDIA_URLS[name]
 
-    def test_attribution(self, name):
+    def test_attribution(self, name) -> None:
         p = bt.get_provider(getattr(bt, name))
         assert p.attribution == (
             '&copy; <a href="https://foundation.wikimedia.org/wiki/Maps_Terms_of_Use">Wikimedia Maps</a> contributors'
         )
 
-    def test_copies(self, name):
+    def test_copies(self, name) -> None:
         p1 = bt.get_provider(getattr(bt, name))
         p2 = bt.get_provider(getattr(bt, name))
         assert p1 is not p2
@@ -177,21 +177,21 @@ class Test_WikimediaProvider(object):
 @pytest.mark.parametrize('name', ['ESRI_IMAGERY'])
 @pytest.mark.unit
 class Test_EsriProvider(object):
-    def test_type(self, name):
+    def test_type(self, name) -> None:
         p = getattr(bt, name)
         assert isinstance(p, str)
 
-    def test_url(self, name):
+    def test_url(self, name) -> None:
         p = bt.get_provider(getattr(bt, name))
         assert p.url == _ESRI_URLS[name]
 
-    def test_attribution(self, name):
+    def test_attribution(self, name) -> None:
         p = bt.get_provider(getattr(bt, name))
         assert p.attribution == (
             '&copy; <a href="http://downloads.esri.com/ArcGISOnline/docs/tou_summary.pdf">Esri</a>, '
             'Earthstar Geographics'
         )
-    def test_copies(self, name):
+    def test_copies(self, name) -> None:
         p1 = bt.get_provider(getattr(bt, name))
         p2 = bt.get_provider(getattr(bt, name))
         assert p1 is not p2
@@ -204,7 +204,7 @@ class Test_GetProvider(object):
     @pytest.mark.parametrize('name', ['CARTODBPOSITRON', 'CARTODBPOSITRON_RETINA', 'STAMEN_TERRAIN',
                                       'STAMEN_TERRAIN_RETINA', 'STAMEN_TONER', 'STAMEN_TONER_BACKGROUND',
                                       'STAMEN_TONER_LABELS', 'OSM', 'WIKIMEDIA', 'ESRI_IMAGERY', ])
-    def test_get_provider(self, name):
+    def test_get_provider(self, name) -> None:
         assert name in bt.Vendors
         enum_member = getattr(bt.Vendors, name)
         assert hasattr(bt, name)
@@ -224,7 +224,7 @@ class Test_GetProvider(object):
         assert p1.url == p2.url == p3.url == p4.url
         assert p1.attribution == p2.attribution == p3.attribution == p4.attribution
 
-    def test_unknown_vendor(self):
+    def test_unknown_vendor(self) -> None:
         with pytest.raises(ValueError):
             bt.get_provider("This is not a valid tile vendor")
 

--- a/tests/unit/bokeh/test_transform.py
+++ b/tests/unit/bokeh/test_transform.py
@@ -57,7 +57,7 @@ Test___all__ = verify_all(bt, ALL)
 
 class Test_cumsum(object):
 
-    def test_basic(object):
+    def test_basic(object) -> None:
         s = bt.cumsum("foo")
         assert isinstance(s, dict)
         assert list(s.keys()) == ["expr"]
@@ -65,7 +65,7 @@ class Test_cumsum(object):
         assert s['expr'].field == 'foo'
         assert s['expr'].include_zero == False
 
-    def test_include_zero(object):
+    def test_include_zero(object) -> None:
         s = bt.cumsum("foo", include_zero=True)
         assert isinstance(s, dict)
         assert list(s.keys()) == ["expr"]
@@ -76,7 +76,7 @@ class Test_cumsum(object):
 
 class Test_dodge(object):
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         t = bt.dodge("foo", 0.5)
         assert isinstance(t, dict)
         assert set(t) == {"field", "transform"}
@@ -85,7 +85,7 @@ class Test_dodge(object):
         assert t['transform'].value == 0.5
         assert t['transform'].range is None
 
-    def test_with_range(self):
+    def test_with_range(self) -> None:
         r = FactorRange("a")
         t = bt.dodge("foo", 0.5, range=r)
         assert isinstance(t, dict)
@@ -98,7 +98,7 @@ class Test_dodge(object):
 
 class Test_factor_cmap(object):
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         t = bt.factor_cmap("foo", ["red", "green"], ["foo", "bar"], start=1, end=2, nan_color="pink")
         assert isinstance(t, dict)
         assert set(t) == {"field", "transform"}
@@ -110,7 +110,7 @@ class Test_factor_cmap(object):
         assert t['transform'].end == 2
         assert t['transform'].nan_color == "pink"
 
-    def test_defaults(self):
+    def test_defaults(self) -> None:
         t = bt.factor_cmap("foo", ["red", "green"], ["foo", "bar"])
         assert isinstance(t, dict)
         assert set(t) == {"field", "transform"}
@@ -124,7 +124,7 @@ class Test_factor_cmap(object):
 
 class Test_factor_hatch(object):
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         t = bt.factor_hatch("foo", ["+", "-"], ["foo", "bar"], start=1, end=2)
         assert isinstance(t, dict)
         assert set(t) == {"field", "transform"}
@@ -135,7 +135,7 @@ class Test_factor_hatch(object):
         assert t['transform'].start == 1
         assert t['transform'].end == 2
 
-    def test_defaults(self):
+    def test_defaults(self) -> None:
         t = bt.factor_hatch("foo", ["+", "-"], ["foo", "bar"])
         assert isinstance(t, dict)
         assert set(t) == {"field", "transform"}
@@ -149,7 +149,7 @@ class Test_factor_hatch(object):
 
 class Test_factor_mark(object):
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         t = bt.factor_mark("foo", ["hex", "square"], ["foo", "bar"], start=1, end=2)
         assert isinstance(t, dict)
         assert set(t) == {"field", "transform"}
@@ -160,7 +160,7 @@ class Test_factor_mark(object):
         assert t['transform'].start == 1
         assert t['transform'].end == 2
 
-    def test_defaults(self):
+    def test_defaults(self) -> None:
         t = bt.factor_mark("foo", ["hex", "square"], ["foo", "bar"])
         assert isinstance(t, dict)
         assert set(t) == {"field", "transform"}
@@ -173,7 +173,7 @@ class Test_factor_mark(object):
 
 class Test_jitter(object):
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         t = bt.jitter("foo", width=0.5, mean=0.1, distribution="normal")
         assert isinstance(t, dict)
         assert set(t) == {"field", "transform"}
@@ -184,7 +184,7 @@ class Test_jitter(object):
         assert t['transform'].distribution == "normal"
         assert t['transform'].range is None
 
-    def test_defaults(self):
+    def test_defaults(self) -> None:
         t = bt.jitter("foo", width=0.5)
         assert isinstance(t, dict)
         assert set(t) == {"field", "transform"}
@@ -195,7 +195,7 @@ class Test_jitter(object):
         assert t['transform'].distribution == "uniform"
         assert t['transform'].range is None
 
-    def test_with_range(self):
+    def test_with_range(self) -> None:
         r = FactorRange("a")
         t = bt.jitter("foo", width=0.5, mean=0.1, range=r)
         assert isinstance(t, dict)
@@ -210,7 +210,7 @@ class Test_jitter(object):
 
 class Test_linear_cmap(object):
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         t = bt.linear_cmap("foo", ["red", "green"], 0, 10, low_color="orange", high_color="blue", nan_color="pink")
         assert isinstance(t, dict)
         assert set(t) == {"field", "transform"}
@@ -223,7 +223,7 @@ class Test_linear_cmap(object):
         assert t['transform'].high_color == "blue"
         assert t['transform'].nan_color == "pink"
 
-    def test_defaults(self):
+    def test_defaults(self) -> None:
         t = bt.linear_cmap("foo", ["red", "green"], 0, 10)
         assert isinstance(t, dict)
         assert set(t) == {"field", "transform"}
@@ -238,7 +238,7 @@ class Test_linear_cmap(object):
 
 class Test_log_cmap(object):
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         t = bt.log_cmap("foo", ["red", "green"], 0, 10, low_color="orange", high_color="blue", nan_color="pink")
         assert isinstance(t, dict)
         assert set(t) == {"field", "transform"}
@@ -251,7 +251,7 @@ class Test_log_cmap(object):
         assert t['transform'].high_color == "blue"
         assert t['transform'].nan_color == "pink"
 
-    def test_defaults(self):
+    def test_defaults(self) -> None:
         t = bt.log_cmap("foo", ["red", "green"], 0, 10)
         assert isinstance(t, dict)
         assert set(t) == {"field", "transform"}
@@ -266,7 +266,7 @@ class Test_log_cmap(object):
 
 class Test_stack(object):
 
-    def test_basic(object):
+    def test_basic(object) -> None:
         s = bt.stack("foo", "junk")
         assert isinstance(s, dict)
         assert list(s.keys()) == ["expr"]
@@ -275,7 +275,7 @@ class Test_stack(object):
 
 class Test_transform(object):
 
-    def test_basic(object):
+    def test_basic(object) -> None:
         t = bt.transform("foo", "junk")
         assert t == dict(field="foo", transform="junk")
 

--- a/tests/unit/bokeh/test_widgets.py
+++ b/tests/unit/bokeh/test_widgets.py
@@ -45,12 +45,12 @@ class TestPanel(object):
         from bokeh.models import Panel
         self.panelCls = Panel
 
-    def test_expectedprops(self):
+    def test_expectedprops(self) -> None:
         expected_properties = set(['title', 'child'])
         actual_properties = get_prop_set(self.panelCls)
         assert expected_properties.issubset(actual_properties)
 
-    def test_prop_defaults(self):
+    def test_prop_defaults(self) -> None:
         p1 = self.panelCls()
         p2 = self.panelCls()
         assert p1.title == ""
@@ -65,12 +65,12 @@ class TestTabs(object):
         self.tabsCls = Tabs
         self.panelCls = Panel
 
-    def test_expected_props(self):
+    def test_expected_props(self) -> None:
         expected_properties = set(['tabs', 'active'])
         actual_properties = get_prop_set(self.tabsCls)
         assert expected_properties.issubset(actual_properties)
 
-    def test_props_defaults(self):
+    def test_props_defaults(self) -> None:
         tab = self.tabsCls()
         assert tab.tabs == []
         assert tab.active == 0

--- a/tests/unit/bokeh/util/test_browser.py
+++ b/tests/unit/bokeh/util/test_browser.py
@@ -40,29 +40,29 @@ class _RecordingWebBrowser(object):
 # General API
 #-----------------------------------------------------------------------------
 
-def test_get_browser_controller_dummy():
+def test_get_browser_controller_dummy() -> None:
     b = bub.get_browser_controller('none')
     assert isinstance(b, bub.DummyWebBrowser)
 
-def test_get_browser_controller_None():
+def test_get_browser_controller_None() -> None:
     b = bub.get_browser_controller(None)
     assert b == webbrowser
 
 @patch('webbrowser.get')
-def test_get_browser_controller_value(mock_get):
+def test_get_browser_controller_value(mock_get) -> None:
     bub.get_browser_controller('foo')
     assert mock_get.called
     assert mock_get.call_args[0] == ("foo",)
     assert mock_get.call_args[1] == {}
 
 @patch('webbrowser.get')
-def test_get_browser_controller_dummy_with_env(mock_get):
+def test_get_browser_controller_dummy_with_env(mock_get) -> None:
     os.environ['BOKEH_BROWSER'] = "bar"
     bub.get_browser_controller('none')
     del os.environ['BOKEH_BROWSER']
 
 @patch('webbrowser.get')
-def test_get_browser_controller_None_with_env(mock_get):
+def test_get_browser_controller_None_with_env(mock_get) -> None:
     os.environ['BOKEH_BROWSER'] = "bar"
     bub.get_browser_controller()
     assert mock_get.called
@@ -71,7 +71,7 @@ def test_get_browser_controller_None_with_env(mock_get):
     del os.environ['BOKEH_BROWSER']
 
 @patch('webbrowser.get')
-def test_get_browser_controller_value_with_env(mock_get):
+def test_get_browser_controller_value_with_env(mock_get) -> None:
     os.environ['BOKEH_BROWSER'] = "bar"
     bub.get_browser_controller('foo')
     assert mock_get.called
@@ -79,12 +79,12 @@ def test_get_browser_controller_value_with_env(mock_get):
     assert mock_get.call_args[1] == {}
     del os.environ['BOKEH_BROWSER']
 
-def test_view_bad_new():
+def test_view_bad_new() -> None:
     with pytest.raises(RuntimeError) as e:
         bub.view("foo", new="junk")
         assert str(e) == "invalid 'new' value passed to view: 'junk', valid values are: 'same', 'window', or 'tab'"
 
-def test_view_args():
+def test_view_args() -> None:
     db = bub.DummyWebBrowser
     bub.DummyWebBrowser = _RecordingWebBrowser
 
@@ -113,7 +113,7 @@ def test_view_args():
 
     bub.DummyWebBrowser = db
 
-def test_NEW_PARAM():
+def test_NEW_PARAM() -> None:
     assert bub.NEW_PARAM == {'tab': 2, 'window': 1}
 
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/util/test_callback_manager.py
+++ b/tests/unit/bokeh/util/test_callback_manager.py
@@ -104,62 +104,62 @@ def _partially_bad_event(event):
 
 class TestPropertyCallbackManager(object):
 
-    def test_creation(self):
+    def test_creation(self) -> None:
         m = cbm.PropertyCallbackManager()
         assert len(m._callbacks) == 0
 
-    def test_on_change_good_method(self):
+    def test_on_change_good_method(self) -> None:
         m = cbm.PropertyCallbackManager()
         good = _GoodPropertyCallback()
         m.on_change('foo', good.method)
         assert len(m._callbacks) == 1
         assert m._callbacks['foo'] == [good.method]
 
-    def test_on_change_good_partial_function(self):
+    def test_on_change_good_partial_function(self) -> None:
         m = cbm.PropertyCallbackManager()
         p = partial(_partially_good_property, 'foo')
         m.on_change('bar', p)
         assert len(m._callbacks) == 1
 
-    def test_on_change_good_partial_method(self):
+    def test_on_change_good_partial_method(self) -> None:
         m = cbm.PropertyCallbackManager()
         good = _GoodPropertyCallback()
         p = partial(good.partially_good, 'foo')
         m.on_change('bar', p)
         assert len(m._callbacks) == 1
 
-    def test_on_change_good_extra_kwargs_function(self):
+    def test_on_change_good_extra_kwargs_function(self) -> None:
         m = cbm.PropertyCallbackManager()
         m.on_change('bar', _just_fine_property)
         assert len(m._callbacks) == 1
 
-    def test_on_change_good_extra_kwargs_method(self):
+    def test_on_change_good_extra_kwargs_method(self) -> None:
         m = cbm.PropertyCallbackManager()
         good = _GoodPropertyCallback()
         m.on_change('bar', good.just_fine)
         assert len(m._callbacks) == 1
 
-    def test_on_change_good_functor(self):
+    def test_on_change_good_functor(self) -> None:
         m = cbm.PropertyCallbackManager()
         good = _GoodPropertyCallback()
         m.on_change('foo', good)
         assert len(m._callbacks) == 1
         assert m._callbacks['foo'] == [good]
 
-    def test_on_change_good_function(self):
+    def test_on_change_good_function(self) -> None:
         m = cbm.PropertyCallbackManager()
         m.on_change('foo', _good_property)
         assert len(m._callbacks) == 1
         assert m._callbacks['foo'] == [_good_property]
 
-    def test_on_change_good_lambda(self):
+    def test_on_change_good_lambda(self) -> None:
         m = cbm.PropertyCallbackManager()
         good = lambda x, y, z: x
         m.on_change('foo', good)
         assert len(m._callbacks) == 1
         assert m._callbacks['foo'] == [good]
 
-    def test_on_change_good_closure(self):
+    def test_on_change_good_closure(self) -> None:
         def good(x, y, z):
             pass
         m = cbm.PropertyCallbackManager()
@@ -167,7 +167,7 @@ class TestPropertyCallbackManager(object):
         assert len(m._callbacks) == 1
         assert len(m._callbacks['foo']) == 1
 
-    def test_on_change_bad_method(self):
+    def test_on_change_bad_method(self) -> None:
         m = cbm.PropertyCallbackManager()
         bad = _BadPropertyCallback()
         with pytest.raises(ValueError):
@@ -175,7 +175,7 @@ class TestPropertyCallbackManager(object):
         assert len(m._callbacks) == 1
         assert len(m._callbacks['foo']) == 0
 
-    def test_on_change_bad_functor(self):
+    def test_on_change_bad_functor(self) -> None:
         m = cbm.PropertyCallbackManager()
         bad = _BadPropertyCallback()
         with pytest.raises(ValueError):
@@ -183,21 +183,21 @@ class TestPropertyCallbackManager(object):
         assert len(m._callbacks) == 1
         assert len(m._callbacks['foo']) == 0
 
-    def test_on_change_bad_function(self):
+    def test_on_change_bad_function(self) -> None:
         m = cbm.PropertyCallbackManager()
         with pytest.raises(ValueError):
             m.on_change('foo', _bad_property)
         assert len(m._callbacks) == 1
         assert len(m._callbacks['foo']) == 0
 
-    def test_on_change_bad_lambda(self):
+    def test_on_change_bad_lambda(self) -> None:
         m = cbm.PropertyCallbackManager()
         with pytest.raises(ValueError):
             m.on_change('foo', lambda x, y: x)
         assert len(m._callbacks) == 1
         assert len(m._callbacks['foo']) == 0
 
-    def test_on_change_bad_closure(self):
+    def test_on_change_bad_closure(self) -> None:
         def bad(x, y):
             pass
         m = cbm.PropertyCallbackManager()
@@ -206,7 +206,7 @@ class TestPropertyCallbackManager(object):
         assert len(m._callbacks) == 1
         assert len(m._callbacks['foo']) == 0
 
-    def test_on_change_same_attr_twice_multiple_calls(self):
+    def test_on_change_same_attr_twice_multiple_calls(self) -> None:
         def good1(x, y, z):
             pass
 
@@ -218,7 +218,7 @@ class TestPropertyCallbackManager(object):
         assert len(m1._callbacks) == 1
         assert m1._callbacks['foo'] == [good1, good2]
 
-    def test_on_change_same_attr_twice_one_call(self):
+    def test_on_change_same_attr_twice_one_call(self) -> None:
         def good1(x, y, z):
             pass
 
@@ -229,7 +229,7 @@ class TestPropertyCallbackManager(object):
         assert len(m2._callbacks) == 1
         assert m2._callbacks['foo'] == [good1, good2]
 
-    def test_on_change_different_attrs(self):
+    def test_on_change_different_attrs(self) -> None:
         def good1(x, y, z):
             pass
 
@@ -242,7 +242,7 @@ class TestPropertyCallbackManager(object):
         assert m1._callbacks['foo'] == [good1]
         assert m1._callbacks['bar'] == [good2]
 
-    def test_trigger(self):
+    def test_trigger(self) -> None:
         m = cbm.PropertyCallbackManager()
         good = _GoodPropertyCallback()
         m.on_change('foo', good.method)
@@ -251,7 +251,7 @@ class TestPropertyCallbackManager(object):
         assert good.last_old == 42
         assert good.last_new == 43
 
-    def test_trigger_with_two_callbacks(self):
+    def test_trigger_with_two_callbacks(self) -> None:
         m = cbm.PropertyCallbackManager()
         good1 = _GoodPropertyCallback()
         good2 = _GoodPropertyCallback()
@@ -267,11 +267,11 @@ class TestPropertyCallbackManager(object):
 
 class TestEventCallbackManager(object):
 
-    def test_creation(self):
+    def test_creation(self) -> None:
         m = cbm.EventCallbackManager()
         assert len(m._event_callbacks) == 0
 
-    def test_on_change_good_method(self):
+    def test_on_change_good_method(self) -> None:
         m = cbm.EventCallbackManager()
         m.subscribed_events = []
         good = _GoodEventCallback()
@@ -279,7 +279,7 @@ class TestEventCallbackManager(object):
         assert len(m._event_callbacks) == 1
         assert m._event_callbacks['foo'] == [good.method]
 
-    def test_on_change_good_partial_function(self):
+    def test_on_change_good_partial_function(self) -> None:
         m = cbm.EventCallbackManager()
         p = partial(_partially_good_event, 'foo')
         m.subscribed_events = []
@@ -287,14 +287,14 @@ class TestEventCallbackManager(object):
         assert len(m._event_callbacks) == 1
         assert m._event_callbacks['foo'] == [p]
 
-    def test_on_change_bad_partial_function(self):
+    def test_on_change_bad_partial_function(self) -> None:
         m = cbm.EventCallbackManager()
         p = partial(_partially_bad_event, 'foo')
         m.subscribed_events = []
         m.on_event('foo', p)
         assert len(m._event_callbacks) == 1
 
-    def test_on_change_good_partial_method(self):
+    def test_on_change_good_partial_method(self) -> None:
         m = cbm.EventCallbackManager()
         m.subscribed_events = []
         good = _GoodEventCallback()
@@ -302,7 +302,7 @@ class TestEventCallbackManager(object):
         m.on_event('foo', p)
         assert len(m._event_callbacks) == 1
 
-    def test_on_change_good_functor(self):
+    def test_on_change_good_functor(self) -> None:
         m = cbm.EventCallbackManager()
         m.subscribed_events = []
         good = _GoodEventCallback()
@@ -310,21 +310,21 @@ class TestEventCallbackManager(object):
         assert len(m._event_callbacks) == 1
         assert m._event_callbacks['foo'] == [good]
 
-    def test_on_change_good_function(self):
+    def test_on_change_good_function(self) -> None:
         m = cbm.EventCallbackManager()
         m.subscribed_events = []
         m.on_event('foo', _good_event)
         assert len(m._event_callbacks) == 1
         assert m._event_callbacks['foo'] == [_good_event]
 
-    def test_on_change_unicode_event_name(self):
+    def test_on_change_unicode_event_name(self) -> None:
         m = cbm.EventCallbackManager()
         m.subscribed_events = []
         m.on_event(u'foo', _good_event)
         assert len(m._event_callbacks) == 1
         assert m._event_callbacks['foo'] == [_good_event]
 
-    def test_on_change_good_lambda(self):
+    def test_on_change_good_lambda(self) -> None:
         m = cbm.EventCallbackManager()
         m.subscribed_events = []
         good = lambda event: event
@@ -332,7 +332,7 @@ class TestEventCallbackManager(object):
         assert len(m._event_callbacks) == 1
         assert m._event_callbacks['foo'] == [good]
 
-    def test_on_change_good_closure(self):
+    def test_on_change_good_closure(self) -> None:
         def good(event):
             pass
         m = cbm.EventCallbackManager()
@@ -341,35 +341,35 @@ class TestEventCallbackManager(object):
         assert len(m._event_callbacks) == 1
         assert len(m._event_callbacks['foo']) == 1
 
-    def test_on_change_bad_method(self):
+    def test_on_change_bad_method(self) -> None:
         m = cbm.EventCallbackManager()
         m.subscribed_events = []
         bad = _BadEventCallback()
         m.on_event('foo', bad.method)
         assert len(m._event_callbacks) == 1
 
-    def test_on_change_bad_functor(self):
+    def test_on_change_bad_functor(self) -> None:
         m = cbm.EventCallbackManager()
         m.subscribed_events = []
         bad = _BadEventCallback()
         m.on_event('foo', bad)
         assert len(m._event_callbacks) == 1
 
-    def test_on_change_bad_function(self):
+    def test_on_change_bad_function(self) -> None:
         m = cbm.EventCallbackManager()
         m.subscribed_events = []
         with pytest.raises(ValueError):
             m.on_event('foo', _bad_event)
         assert len(m._event_callbacks) == 0
 
-    def test_on_change_bad_lambda(self):
+    def test_on_change_bad_lambda(self) -> None:
         m = cbm.EventCallbackManager()
         m.subscribed_events = []
         with pytest.raises(ValueError):
             m.on_event('foo', lambda x, y: x)
         assert len(m._event_callbacks) == 0
 
-    def test_on_change_bad_closure(self):
+    def test_on_change_bad_closure(self) -> None:
         def bad(event, y):
             pass
         m = cbm.EventCallbackManager()
@@ -378,7 +378,7 @@ class TestEventCallbackManager(object):
             m.on_event('foo', bad)
         assert len(m._event_callbacks) == 0
 
-    def test_on_change_with_two_callbacks(self):
+    def test_on_change_with_two_callbacks(self) -> None:
         m = cbm.EventCallbackManager()
         m.subscribed_events = []
         good1 = _GoodEventCallback()
@@ -386,7 +386,7 @@ class TestEventCallbackManager(object):
         m.on_event('foo', good1.method)
         m.on_event('foo', good2.method)
 
-    def test_on_change_with_two_callbacks_one_bad(self):
+    def test_on_change_with_two_callbacks_one_bad(self) -> None:
         m = cbm.EventCallbackManager()
         m.subscribed_events = []
         good = _GoodEventCallback()
@@ -394,7 +394,7 @@ class TestEventCallbackManager(object):
         m.on_event('foo', good.method, bad.method)
         assert len(m._event_callbacks) == 1
 
-    def test__trigger_event_wraps_curdoc(self):
+    def test__trigger_event_wraps_curdoc(self) -> None:
         # This test is pretty clunky by assures that callbacks triggered by
         # events use the correct value of curdoc()
         from bokeh.io.doc import set_curdoc

--- a/tests/unit/bokeh/util/test_compiler.py
+++ b/tests/unit/bokeh/util/test_compiler.py
@@ -33,7 +33,7 @@ import bokeh.util.compiler as buc # isort:skip
 # General API
 #-----------------------------------------------------------------------------
 
-def test_nodejs_compile_javascript():
+def test_nodejs_compile_javascript() -> None:
     assert buc.nodejs_compile("""function f(a, b) { return a + b; };""", "javascript", "some.js") == \
         dict(code="""\
 function f(a, b) { return a + b; }
@@ -71,18 +71,18 @@ exports.MyModel = MyModel;
             '\x1b[7m1\x1b[0m function f(a, b) { eturn a + b; };\n'
             '\x1b[7m \x1b[0m \x1b[91m                         ~\x1b[0m\n')
 
-def test_nodejs_compile_less():
+def test_nodejs_compile_less() -> None:
     assert buc.nodejs_compile(""".bk-some-style { color: mix(#ff0000, #0000ff, 50%); }""", "less", "some.less") == \
         dict(code=""".bk-some-style{color:#800080}""")
 
     assert buc.nodejs_compile(""".bk-some-style color: green; }""", "less", "some.less") == \
         dict(error="ParseError: Unrecognised input in some.less on line 1, column 21:\n1 .bk-some-style color: green; }\n")
 
-def test_Implementation():
+def test_Implementation() -> None:
     obj = buc.Implementation()
     assert obj.file == None
 
-def test_Inline():
+def test_Inline() -> None:
     obj = buc.Inline("code")
     assert obj.code == "code"
     assert obj.file == None
@@ -91,21 +91,21 @@ def test_Inline():
     assert obj.code == "code"
     assert obj.file == "file"
 
-def test_TypeScript():
+def test_TypeScript() -> None:
     obj = buc.TypeScript("code")
     assert isinstance(obj, buc.Inline)
     assert obj.code == "code"
     assert obj.file == None
     assert obj.lang == "typescript"
 
-def test_JavaScript():
+def test_JavaScript() -> None:
     obj = buc.JavaScript("code")
     assert isinstance(obj, buc.Inline)
     assert obj.code == "code"
     assert obj.file == None
     assert obj.lang == "javascript"
 
-def test_Less():
+def test_Less() -> None:
     obj = buc.Less("code")
     assert isinstance(obj, buc.Inline)
     assert obj.code == "code"
@@ -113,7 +113,7 @@ def test_Less():
     assert obj.lang == "less"
 
 @patch('io.open')
-def test_FromFile(mock_open):
+def test_FromFile(mock_open) -> None:
     obj = buc.FromFile("path.ts")
     assert obj.lang == "typescript"
 
@@ -126,16 +126,16 @@ def test_FromFile(mock_open):
     obj = buc.FromFile("path.less")
     assert obj.lang == "less"
 
-def test_exts():
+def test_exts() -> None:
     assert buc.exts == (".ts", ".js", ".css", ".less")
 
-def test_jsons():
+def test_jsons() -> None:
     for file in os.listdir(os.path.join(buc.bokehjs_dir, "js")):
         if file.endswith('.json'):
             with io.open(os.path.join(buc.bokehjs_dir, "js", file), encoding="utf-8") as f:
                 assert all(['\\' not in mod for mod in json.loads(f.read())])
 
-def test_inline_extension():
+def test_inline_extension() -> None:
     from bokeh.io import save
     from bokeh.models import TickFormatter
     from bokeh.plotting import figure

--- a/tests/unit/bokeh/util/test_dependencies.py
+++ b/tests/unit/bokeh/util/test_dependencies.py
@@ -27,36 +27,36 @@ import bokeh.util.dependencies as dep # isort:skip
 
 class Test_detect_phantomjs(object):
 
-    def test_detect_phantomjs_success(self):
+    def test_detect_phantomjs_success(self) -> None:
         assert dep.detect_phantomjs() is not None
 
-    def test_detect_phantomjs_bad_path(self, monkeypatch):
+    def test_detect_phantomjs_bad_path(self, monkeypatch) -> None:
         monkeypatch.setenv("BOKEH_PHANTOMJS_PATH", "bad_path")
         with pytest.raises(RuntimeError):
             dep.detect_phantomjs()
 
-    def test_detect_phantomjs_bad_version(self):
+    def test_detect_phantomjs_bad_version(self) -> None:
         with pytest.raises(RuntimeError) as e:
             dep.detect_phantomjs('10.1')
         assert str(e.value).endswith("PhantomJS version to old. Version>=10.1 required, installed: 2.1.1")
 
-    def test_detect_phantomjs_default_required_version(self):
+    def test_detect_phantomjs_default_required_version(self) -> None:
         assert dep.detect_phantomjs.__defaults__ == ('2.1',)
 
 class Test_import_optional(object):
 
-    def test_success(self):
+    def test_success(self) -> None:
         assert dep.import_optional('sys') is not None
 
-    def test_fail(self):
+    def test_fail(self) -> None:
         assert dep.import_optional('bleepbloop') is None
 
 class Test_import_required(object):
 
-    def test_success(self):
+    def test_success(self) -> None:
         assert dep.import_required('sys', 'yep') is not None
 
-    def test_fail(self):
+    def test_fail(self) -> None:
         with pytest.raises(RuntimeError) as excinfo:
             dep.import_required('bleepbloop', 'nope')
         assert 'nope' in str(excinfo.value)

--- a/tests/unit/bokeh/util/test_deprecation.py
+++ b/tests/unit/bokeh/util/test_deprecation.py
@@ -30,19 +30,19 @@ def foo(): pass
 # General API
 #-----------------------------------------------------------------------------
 
-def test_bad_arg_type():
+def test_bad_arg_type() -> None:
     for x in [10, True, foo, [], (), {}]:
         with pytest.raises(ValueError):
             dep.deprecated(x)
 
 @patch('warnings.warn')
-def test_message(mock_warn):
+def test_message(mock_warn) -> None:
     dep.deprecated('test')
     assert mock_warn.called
     assert mock_warn.call_args[0] == ("test", dep.BokehDeprecationWarning)
     assert mock_warn.call_args[1] == {'stacklevel': 2}
 
-def test_message_no_extra_args():
+def test_message_no_extra_args() -> None:
     with pytest.raises(ValueError):
         dep.deprecated('test', 'foo')
     with pytest.raises(ValueError):
@@ -52,7 +52,7 @@ def test_message_no_extra_args():
     with pytest.raises(ValueError):
         dep.deprecated('test', extra='foo')
 
-def test_since_missing_extra_args():
+def test_since_missing_extra_args() -> None:
     with pytest.raises(ValueError):
         dep.deprecated((1,2,3))
     with pytest.raises(ValueError):
@@ -60,7 +60,7 @@ def test_since_missing_extra_args():
     with pytest.raises(ValueError):
         dep.deprecated((1,2,3), new="foo")
 
-def test_since_bad_tuple():
+def test_since_bad_tuple() -> None:
     with pytest.raises(ValueError):
         dep.deprecated((1,), old="foo", new="bar")
     with pytest.raises(ValueError):
@@ -73,14 +73,14 @@ def test_since_bad_tuple():
         dep.deprecated((1,2,"3"), old="foo", new="bar")
 
 @patch('warnings.warn')
-def test_since(mock_warn):
+def test_since(mock_warn) -> None:
     dep.deprecated((1,2,3), old="foo", new="bar")
     assert mock_warn.called
     assert mock_warn.call_args[0] == ("foo was deprecated in Bokeh 1.2.3 and will be removed, use bar instead.", dep.BokehDeprecationWarning)
     assert mock_warn.call_args[1] == {'stacklevel': 2}
 
 @patch('warnings.warn')
-def test_since_with_extra(mock_warn):
+def test_since_with_extra(mock_warn) -> None:
     dep.deprecated((1,2,3), old="foo", new="bar", extra="baz")
     assert mock_warn.called
     assert mock_warn.call_args[0] == ("foo was deprecated in Bokeh 1.2.3 and will be removed, use bar instead. baz", dep.BokehDeprecationWarning)

--- a/tests/unit/bokeh/util/test_hex.py
+++ b/tests/unit/bokeh/util/test_hex.py
@@ -35,7 +35,7 @@ y = 2 + np.random.standard_normal(n)
 
 class Test_axial_to_cartesian(object):
 
-    def test_default_aspect_pointytop(self):
+    def test_default_aspect_pointytop(self) -> None:
         q = np.array([0, 0, 0, 1, -1, 1, -1])
         r = np.array([0, 1, -1, 0, 1, -1, 0])
 
@@ -46,7 +46,7 @@ class Test_axial_to_cartesian(object):
         assert list(y) == [-0.0, -1.5, 1.5, -0.0, -1.5, 1.5, -0.0]
 
 
-    def test_default_aspect_flattop(self):
+    def test_default_aspect_flattop(self) -> None:
         q = np.array([0, 0, 0, 1, -1, 1, -1])
         r = np.array([0, 1, -1, 0, 1, -1, 0])
 
@@ -58,7 +58,7 @@ class Test_axial_to_cartesian(object):
 
 class Test_cartesian_to_axial(object):
 
-    def test_default_aspect_pointytop(self):
+    def test_default_aspect_pointytop(self) -> None:
         x = np.array([0, -2, 2, -1.5, -1.5, 1.5, 1.5])
         y = np.array([0, 0, 0, 1.5, -1.5, 1.5, -1.5])
 
@@ -68,7 +68,7 @@ class Test_cartesian_to_axial(object):
             (0,0), (-1, 0), (1,0), (0,-1), (-1, 1), (1, -1), (0,1)
         ]
 
-    def test_default_aspect_flattop(self):
+    def test_default_aspect_flattop(self) -> None:
         x = np.array([0, 0, 0, 1.5, -1.5, 1.5, -1.5])
         y = np.array([0, -2, 2, -1.5, -1.5, 1.5, 1.5])
 
@@ -82,7 +82,7 @@ class Test_hexbin(object):
 
     # hexbin requires pandas
 
-    def test_gaussian_pointytop(self, pd):
+    def test_gaussian_pointytop(self, pd) -> None:
         bins = buh.hexbin(x, y, 2)
         assert list(bins.q) == [0,0,1,1,1,2,2]
         assert list(bins.r) == [-1,0,-2,-1,0,-2,-1]
@@ -90,7 +90,7 @@ class Test_hexbin(object):
 
         assert bins.equals(buh.hexbin(x, y, 2, "pointytop"))
 
-    def test_gaussian_flattop(self, pd):
+    def test_gaussian_flattop(self, pd) -> None:
         bins = buh.hexbin(x, y, 2, "flattop")
         assert list(bins.q) == [0, 0, 1, 1, 1, 2]
         assert list(bins.r) == [-1, 0, -2, -1, 0, -2]

--- a/tests/unit/bokeh/util/test_options.py
+++ b/tests/unit/bokeh/util/test_options.py
@@ -32,28 +32,28 @@ class DummyOpts(Options):
 # General API
 #-----------------------------------------------------------------------------
 
-def test_empty():
+def test_empty() -> None:
     empty = dict()
     o = DummyOpts(empty)
     assert o.foo == "thing"
     assert o.bar == None
     assert empty == {}
 
-def test_exact():
+def test_exact() -> None:
     exact = dict(foo="stuff", bar=10)
     o = DummyOpts(exact)
     assert o.foo == "stuff"
     assert o.bar == 10
     assert exact == {}
 
-def test_extra():
+def test_extra() -> None:
     extra = dict(foo="stuff", bar=10, baz=22.2)
     o = DummyOpts(extra)
     assert o.foo == "stuff"
     assert o.bar == 10
     assert extra == {'baz': 22.2}
 
-def test_mixed():
+def test_mixed() -> None:
     mixed = dict(foo="stuff", baz=22.2)
     o = DummyOpts(mixed)
     assert o.foo == "stuff"

--- a/tests/unit/bokeh/util/test_serialization.py
+++ b/tests/unit/bokeh/util/test_serialization.py
@@ -36,35 +36,35 @@ import bokeh.util.serialization as bus # isort:skip
 
 class Test_make_id(object):
 
-    def test_default(self):
+    def test_default(self) -> None:
         bus._simple_id = 999
         assert bus.make_id() == "1000"
         assert bus.make_id() == "1001"
         assert bus.make_id() == "1002"
 
-    def test_simple_ids_yes(self):
+    def test_simple_ids_yes(self) -> None:
         bus._simple_id = 999
         os.environ["BOKEH_SIMPLE_IDS"] = "yes"
         assert bus.make_id() == "1000"
         assert bus.make_id() == "1001"
         assert bus.make_id() == "1002"
 
-    def test_simple_ids_no(self):
+    def test_simple_ids_no(self) -> None:
         os.environ["BOKEH_SIMPLE_IDS"] = "no"
         assert len(bus.make_id()) == 36
         assert isinstance(bus.make_id(), str)
         del os.environ["BOKEH_SIMPLE_IDS"]
 
 class Test_make_globally_unique_id(object):
-    def test_basic(self):
+    def test_basic(self) -> None:
         assert len(bus.make_globally_unique_id()) == 36
         assert isinstance(bus.make_globally_unique_id(), str)
 
-def test_np_consts():
+def test_np_consts() -> None:
     assert bus.NP_EPOCH == np.datetime64(0, 'ms')
     assert bus.NP_MS_DELTA == np.timedelta64(1, 'ms')
 
-def test_binary_array_types():
+def test_binary_array_types() -> None:
     assert len(bus.BINARY_ARRAY_TYPES) == 8
     for typ in [np.dtype(np.float32),
                 np.dtype(np.float64),
@@ -76,37 +76,37 @@ def test_binary_array_types():
                 np.dtype(np.int32)]:
         assert typ in bus.BINARY_ARRAY_TYPES
 
-def test_datetime_types(pd):
+def test_datetime_types(pd) -> None:
     if pd is None:
         assert len(bus.DATETIME_TYPES) == 3
     else:
         assert len(bus.DATETIME_TYPES) == 7
 
-def test_is_timedelta_type_non_pandas_types():
+def test_is_timedelta_type_non_pandas_types() -> None:
     assert bus.is_timedelta_type(datetime.timedelta(3000))
     assert bus.is_timedelta_type(np.timedelta64(3000, 'ms'))
 
-def test_is_timedelta_type_pandas_types(pd):
+def test_is_timedelta_type_pandas_types(pd) -> None:
     assert bus.is_timedelta_type(pd.Timedelta("3000ms"))
 
-def test_convert_timedelta_type_non_pandas_types():
+def test_convert_timedelta_type_non_pandas_types() -> None:
     assert bus.convert_timedelta_type(datetime.timedelta(3000)) == 259200000000.0
     assert bus.convert_timedelta_type(np.timedelta64(3000, 'ms')) == 3000.
 
-def test_convert_timedelta_type_pandas_types(pd):
+def test_convert_timedelta_type_pandas_types(pd) -> None:
     assert bus.convert_timedelta_type(pd.Timedelta("3000ms")) == 3000.0
 
-def test_is_datetime_type_non_pandas_types():
+def test_is_datetime_type_non_pandas_types() -> None:
     assert bus.is_datetime_type(datetime.datetime(2016, 5, 11))
     assert bus.is_datetime_type(datetime.time(3, 54))
     assert bus.is_datetime_type(np.datetime64("2011-05-11"))
 
-def test_is_datetime_type_pandas_types(pd):
+def test_is_datetime_type_pandas_types(pd) -> None:
     assert bus.is_datetime_type(bus._pd_timestamp(3000000))
     assert bus.is_datetime_type(pd.Period('1900', 'A-DEC'))
     assert bus.is_datetime_type(pd.NaT)
 
-def test_convert_datetime_type_non_pandas_types():
+def test_convert_datetime_type_non_pandas_types() -> None:
     assert bus.convert_datetime_type(datetime.datetime(2018, 1, 3, 15, 37, 59, 922452)) == 1514993879922.452
     assert bus.convert_datetime_type(datetime.datetime(2018, 1, 3, 15, 37, 59)) == 1514993879000.0
     assert bus.convert_datetime_type(datetime.datetime(2016, 5, 11)) == 1462924800000.0
@@ -114,7 +114,7 @@ def test_convert_datetime_type_non_pandas_types():
     assert bus.convert_datetime_type(datetime.date(2016, 5, 11)) == 1462924800000.0
     assert bus.convert_datetime_type(np.datetime64("2016-05-11")) == 1462924800000.0
 
-def test_convert_datetime_type_pandas_types(pd):
+def test_convert_datetime_type_pandas_types(pd) -> None:
     assert bus.convert_datetime_type(bus._pd_timestamp(3000000)) == 3.0
     assert bus.convert_datetime_type(pd.Period('1900', 'A-DEC')) == -2208988800000.0
     assert bus.convert_datetime_type(pd.Period('1900', 'A-DEC')) == bus.convert_datetime_type(np.datetime64("1900-01-01"))
@@ -122,14 +122,14 @@ def test_convert_datetime_type_pandas_types(pd):
 
 @pytest.mark.parametrize('obj', [[1,2], (1,2), dict(), set(), 10.2, "foo"])
 @pytest.mark.unit
-def test_convert_datetime_type_array_ignores_non_array(obj):
+def test_convert_datetime_type_array_ignores_non_array(obj) -> None:
     assert bus.convert_datetime_array(obj) is obj
 
-def test_convert_datetime_type_array_ignores_non_datetime_array():
+def test_convert_datetime_type_array_ignores_non_datetime_array() -> None:
     a = np.arange(0,10,100)
     assert bus.convert_datetime_array(a) is a
 
-def test_convert_datetime_type_array():
+def test_convert_datetime_type_array() -> None:
     a = np.array(['2018-01-03T15:37:59', '2018-01-03T15:37:59.922452', '2016-05-11'], dtype='datetime64')
     r = bus.convert_datetime_array(a)
     assert r[0] == 1514993879000.0
@@ -137,7 +137,7 @@ def test_convert_datetime_type_array():
     assert r[2] == 1462924800000.0
     assert r.dtype == 'float64'
 
-def test_convert_datetime_type_with_tz():
+def test_convert_datetime_type_with_tz() -> None:
     # This ensures datetimes are sent to BokehJS timezone-naive
     # see https://github.com/bokeh/bokeh/issues/6480
     for tz in pytz.all_timezones:
@@ -146,19 +146,19 @@ def test_convert_datetime_type_with_tz():
 testing = [[float('nan'), 3], [float('-inf'), [float('inf')]]]
 expected = [['NaN', 3.0], ['-Infinity', ['Infinity']]]
 
-def test_traverse_data():
+def test_traverse_data() -> None:
     assert bus.traverse_data(testing) == expected
 
 @pytest.mark.parametrize('dt', bus.BINARY_ARRAY_TYPES)
 @pytest.mark.unit
-def test_transform_array_force_list_default(dt):
+def test_transform_array_force_list_default(dt) -> None:
     a = np.empty(shape=10, dtype=dt)
     out = bus.transform_array(a)
     assert isinstance(out, dict)
 
 @pytest.mark.parametrize('dt', bus.BINARY_ARRAY_TYPES)
 @pytest.mark.unit
-def test_transform_array_force_list_default_with_buffers(dt):
+def test_transform_array_force_list_default_with_buffers(dt) -> None:
     a = np.empty(shape=10, dtype=dt)
     bufs = []
     out = bus.transform_array(a, buffers=bufs)
@@ -174,12 +174,12 @@ def test_transform_array_force_list_default_with_buffers(dt):
 
 @pytest.mark.parametrize('dt', bus.BINARY_ARRAY_TYPES)
 @pytest.mark.unit
-def test_transform_array_force_list_true(dt):
+def test_transform_array_force_list_true(dt) -> None:
     a = np.empty(shape=10, dtype=dt)
     out = bus.transform_array(a, force_list=True)
     assert isinstance(out, list)
 
-def test_transform_series_force_list_default(pd):
+def test_transform_series_force_list_default(pd) -> None:
     # default int seems to be int64, can't be encoded!
     df = pd.Series([1, 3, 5, 6, 8])
     out = bus.transform_series(df)
@@ -198,7 +198,7 @@ def test_transform_series_force_list_default(pd):
     out = bus.transform_series(df)
     assert isinstance(out, dict)
 
-def test_transform_series_force_list_default_with_buffers(pd):
+def test_transform_series_force_list_default_with_buffers(pd) -> None:
     # default int seems to be int64, can't be converted to buffer!
     df = pd.Series([1, 3, 5, 6, 8])
     out = bus.transform_series(df)
@@ -299,7 +299,7 @@ def test_transform_series_force_list_default_with_buffers(pd):
     assert '__buffer__' in out
 
 
-def test_transform_series_force_list_true(pd):
+def test_transform_series_force_list_true(pd) -> None:
     df = pd.Series([1, 3, 5, 6, 8])
     out = bus.transform_series(df, force_list=True)
     assert isinstance(out, list)
@@ -318,20 +318,20 @@ def test_transform_series_force_list_true(pd):
 
 @pytest.mark.parametrize('dt', bus.BINARY_ARRAY_TYPES)
 @pytest.mark.unit
-def test_transform_array_to_list(dt):
+def test_transform_array_to_list(dt) -> None:
     a = np.empty(shape=10, dtype=dt)
     out = bus.transform_array_to_list(a)
     assert isinstance(out, list)
 
 @pytest.mark.parametrize('values', [(['cat', 'dog']), ([1.2, 'apple'])])
 @pytest.mark.unit
-def test_transform_array_with_nans_to_list(pd, values):
+def test_transform_array_with_nans_to_list(pd, values) -> None:
     s = pd.Series([np.nan, values[0], values[1]])
     out = bus.transform_array_to_list(s)
     assert isinstance(out, list)
     assert out == ['NaN', values[0], values[1]]
 
-def test_array_encoding_disabled_by_dtype():
+def test_array_encoding_disabled_by_dtype() -> None:
 
     assert len(bus.BINARY_ARRAY_TYPES) > 0
 
@@ -349,7 +349,7 @@ def test_array_encoding_disabled_by_dtype():
 @pytest.mark.parametrize('dt', [np.float32, np.float64, np.int64])
 @pytest.mark.parametrize('shape', [(12,), (2, 6), (2,2,3)])
 @pytest.mark.unit
-def test_encode_base64_dict(dt, shape):
+def test_encode_base64_dict(dt, shape) -> None:
     a = np.arange(12, dtype=dt)
     a.reshape(shape)
     d = bus.encode_base64_dict(a)
@@ -368,7 +368,7 @@ def test_encode_base64_dict(dt, shape):
 @pytest.mark.parametrize('dt', [np.float32, np.float64, np.int64])
 @pytest.mark.parametrize('shape', [(12,), (2, 6), (2,2,3)])
 @pytest.mark.unit
-def test_decode_base64_dict(dt, shape):
+def test_decode_base64_dict(dt, shape) -> None:
     a = np.arange(12, dtype=dt)
     a.reshape(shape)
     data = base64.b64encode(a).decode('utf-8')
@@ -390,7 +390,7 @@ def test_decode_base64_dict(dt, shape):
 @pytest.mark.parametrize('dt', [np.float32, np.float64, np.int64])
 @pytest.mark.parametrize('shape', [(12,), (2, 6), (2,2,3)])
 @pytest.mark.unit
-def test_encode_decode_roundtrip(dt, shape):
+def test_encode_decode_roundtrip(dt, shape) -> None:
     a = np.arange(12, dtype=dt)
     a.reshape(shape)
     d = bus.encode_base64_dict(a)
@@ -401,7 +401,7 @@ def test_encode_decode_roundtrip(dt, shape):
 @pytest.mark.parametrize('dt', bus.BINARY_ARRAY_TYPES)
 @pytest.mark.parametrize('shape', [(12,), (2, 6), (2,2,3)])
 @pytest.mark.unit
-def test_encode_binary_dict(dt, shape):
+def test_encode_binary_dict(dt, shape) -> None:
     a = np.arange(12, dtype=dt)
     a.reshape(shape)
     bufs = []
@@ -422,7 +422,7 @@ def test_encode_binary_dict(dt, shape):
 @pytest.mark.parametrize('dt1', [np.float32, np.float64, np.int64])
 @pytest.mark.parametrize('dt2', [np.float32, np.float64, np.int64])
 @pytest.mark.unit
-def test_transform_column_source_data_with_buffers(pd, cols, dt1, dt2):
+def test_transform_column_source_data_with_buffers(pd, cols, dt1, dt2) -> None:
     d = dict(a=[1,2,3], b=np.array([4,5,6], dtype=dt1), c=pd.Series([7,8,9], dtype=dt2))
     bufs = []
     out = bus.transform_column_source_data(d, buffers=bufs, cols=cols)

--- a/tests/unit/bokeh/util/test_session_id.py
+++ b/tests/unit/bokeh/util/test_session_id.py
@@ -68,13 +68,13 @@ _MERSENNE_MSG = 'A secure pseudo-random number generator is not available on you
 #-----------------------------------------------------------------------------
 
 class TestSessionId(object):
-    def test_base64_roundtrip(self):
+    def test_base64_roundtrip(self) -> None:
         for s in [ "", "a", "ab", "abc", "abcd", "abcde", "abcdef", "abcdefg",
                    "abcdefgh", "abcdefghi",
                    "abcdefghijklmnopqrstuvwxyz" ]:
             assert s == _base64_decode_utf8(_base64_encode(s))
 
-    def test_reseed_if_needed(self):
+    def test_reseed_if_needed(self) -> None:
         # we have to set a seed in order to be able to get state
         random.seed(codecs.encode("abcdefg", "utf-8"))
         state = random.getstate()
@@ -91,14 +91,14 @@ class TestSessionId(object):
         finally:
             bokeh.util.session_id.random = saved
 
-    def test_signature(self):
+    def test_signature(self) -> None:
         sig = _signature("xyz", secret_key="abc")
         with_same_key = _signature("xyz", secret_key="abc")
         assert sig == with_same_key
         with_different_key = _signature("xyz", secret_key="qrs")
         assert sig != with_different_key
 
-    def test_generate_unsigned(self):
+    def test_generate_unsigned(self) -> None:
         session_id = generate_session_id(signed=False)
         assert 44 == len(session_id)
         another_session_id = generate_session_id(signed=False)
@@ -106,33 +106,33 @@ class TestSessionId(object):
 
         assert session_id != another_session_id
 
-    def test_generate_signed(self):
+    def test_generate_signed(self) -> None:
         session_id = generate_session_id(signed=True, secret_key="abc")
         assert '-' in session_id
         assert check_session_id_signature(session_id, secret_key="abc", signed=True)
         assert not check_session_id_signature(session_id, secret_key="qrs", signed=True)
 
-    def test_check_signature_of_unsigned(self):
+    def test_check_signature_of_unsigned(self) -> None:
         session_id = generate_session_id(signed=False, secret_key="abc") # secret shouldn't be used
         assert not check_session_id_signature(session_id, secret_key="abc", signed=True)
 
-    def test_check_signature_of_empty_string(self):
+    def test_check_signature_of_empty_string(self) -> None:
         assert not check_session_id_signature("", secret_key="abc", signed=True)
 
-    def test_check_signature_of_junk_with_hyphen_in_it(self):
+    def test_check_signature_of_junk_with_hyphen_in_it(self) -> None:
         assert not check_session_id_signature("foo-bar-baz", secret_key="abc", signed=True)
 
-    def test_check_signature_with_signing_disabled(self):
+    def test_check_signature_with_signing_disabled(self) -> None:
         assert check_session_id_signature("gobbledygook", secret_key="abc", signed=False)
 
-    def test_generate_secret_key(self):
+    def test_generate_secret_key(self) -> None:
         key = generate_secret_key()
         assert 44 == len(key)
         key2 = generate_secret_key()
         assert 44 == len(key2)
         assert key != key2
 
-    def test_string_encoding_does_not_affect_session_id_check(self):
+    def test_string_encoding_does_not_affect_session_id_check(self) -> None:
         # originates from #6653
         session_id = generate_session_id(signed=True, secret_key="abc")
         assert check_session_id_signature(session_id, secret_key="abc", signed=True)
@@ -148,7 +148,7 @@ class TestSessionId(object):
 
 class Test__get_sysrandom(object):
 
-    def test_default(self):
+    def test_default(self) -> None:
         import random
         try:
             random.SystemRandom()
@@ -159,7 +159,7 @@ class Test__get_sysrandom(object):
         assert using_sysrandom == expected
 
     @patch('random.SystemRandom', new_callable=_nie)
-    def test_missing_sysrandom_no_secret_key(self, _mock_sysrandom):
+    def test_missing_sysrandom_no_secret_key(self, _mock_sysrandom) -> None:
         with pytest.warns(UserWarning) as warns:
             random, using_sysrandom = _get_sysrandom()
             assert not using_sysrandom
@@ -173,7 +173,7 @@ class Test__get_sysrandom(object):
             )
 
     @patch('random.SystemRandom', new_callable=_nie)
-    def test_missing_sysrandom_with_secret_key(self, _mock_sysrandom):
+    def test_missing_sysrandom_with_secret_key(self, _mock_sysrandom) -> None:
         os.environ["BOKEH_SECRET_KEY"] = "foo"
         with pytest.warns(UserWarning) as warns:
             random, using_sysrandom = _get_sysrandom()

--- a/tests/unit/bokeh/util/test_string.py
+++ b/tests/unit/bokeh/util/test_string.py
@@ -26,19 +26,19 @@ import bokeh.util.string as bus # isort:skip
 #-----------------------------------------------------------------------------
 
 class Test_format_doctring(object):
-    def test_no_argument(self):
+    def test_no_argument(self) -> None:
         doc__ = "hello world"
         assert bus.format_docstring(doc__) == doc__
         doc__ = None
         assert bus.format_docstring(doc__) == None
 
-    def test_arguments_unused(self):
+    def test_arguments_unused(self) -> None:
         doc__ = "hello world"
         assert bus.format_docstring(doc__, 'hello ', not_used='world') == doc__
         doc__ = None
         assert bus.format_docstring(doc__, 'hello ', not_used='world') == None
 
-    def test_arguments(self):
+    def test_arguments(self) -> None:
         doc__ = "-- {}{as_parameter} --"
         assert bus.format_docstring(doc__, 'hello ', as_parameter='world') == "-- hello world --"
         doc__ = None
@@ -47,42 +47,42 @@ class Test_format_doctring(object):
 class Test_indent(object):
     TEXT = "some text\nto indent\n  goes here"
 
-    def test_default_args(self):
+    def test_default_args(self) -> None:
         assert bus.indent(self.TEXT) == "  some text\n  to indent\n    goes here"
 
-    def test_with_n(self):
+    def test_with_n(self) -> None:
         assert bus.indent(self.TEXT, n=3) == "   some text\n   to indent\n     goes here"
 
-    def test_with_ch(self):
+    def test_with_ch(self) -> None:
         assert bus.indent(self.TEXT, ch="-") == "--some text\n--to indent\n--  goes here"
 
 class Test_nice_join(object):
 
-    def test_default(self):
+    def test_default(self) -> None:
         assert bus.nice_join(["one"]) == "one"
         assert bus.nice_join(["one", "two"]) == "one or two"
         assert bus.nice_join(["one", "two", "three"]) == "one, two or three"
         assert bus.nice_join(["one", "two", "three", "four"]) == "one, two, three or four"
 
-    def test_string_conjunction(self):
+    def test_string_conjunction(self) -> None:
         assert bus.nice_join(["one"], conjuction="and") == "one"
         assert bus.nice_join(["one", "two"], conjuction="and") == "one and two"
         assert bus.nice_join(["one", "two", "three"], conjuction="and") == "one, two and three"
         assert bus.nice_join(["one", "two", "three", "four"], conjuction="and") == "one, two, three and four"
 
-    def test_None_conjunction(self):
+    def test_None_conjunction(self) -> None:
         assert bus.nice_join(["one"], conjuction=None) == "one"
         assert bus.nice_join(["one", "two"], conjuction=None) == "one, two"
         assert bus.nice_join(["one", "two", "three"], conjuction=None) == "one, two, three"
         assert bus.nice_join(["one", "two", "three", "four"], conjuction=None) == "one, two, three, four"
 
-    def test_sep(self):
+    def test_sep(self) -> None:
         assert bus.nice_join(["one"], sep='; ') == "one"
         assert bus.nice_join(["one", "two"], sep='; ') == "one or two"
         assert bus.nice_join(["one", "two", "three"], sep='; ') == "one; two or three"
         assert bus.nice_join(["one", "two", "three", "four"], sep="; ") == "one; two; three or four"
 
-def test_snakify():
+def test_snakify() -> None:
     assert bus.snakify("MyClassName") == "my_class_name"
     assert bus.snakify("My1Class23Name456") == "my1_class23_name456"
     assert bus.snakify("MySUPERClassName") == "my_super_class_name"

--- a/tests/unit/bokeh/util/test_version.py
+++ b/tests/unit/bokeh/util/test_version.py
@@ -38,28 +38,28 @@ VERSION_PAT = re.compile(r"^(\d+\.\d+\.\d+)$")
 
 class Test___version__(object):
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         assert isinstance(buv.__version__, str)
         assert buv.__version__ == get_versions()['version']
 
 class Test_base_version(object):
 
-    def test_returns_helper(self):
+    def test_returns_helper(self) -> None:
         with mock.patch('bokeh.util.version._base_version_helper') as helper:
             buv.base_version()
             assert helper.called
 
 class Test_is_full_release(object):
 
-    def test_actual(self):
+    def test_actual(self) -> None:
         assert buv.is_full_release() == bool(VERSION_PAT.match(buv.__version__))
 
-    def test_mock_full(self, monkeypatch):
+    def test_mock_full(self, monkeypatch) -> None:
         monkeypatch.setattr(buv, '__version__', "1.5.0")
         assert buv.is_full_release()
 
     @pytest.mark.parametrize('v', ("1.2.3dev2", "1.4.5rc3", "junk"))
-    def test_mock_not_full(self, monkeypatch, v):
+    def test_mock_not_full(self, monkeypatch, v) -> None:
         monkeypatch.setattr(buv, '__version__', v)
         assert not buv.is_full_release()
 
@@ -73,15 +73,15 @@ class Test_is_full_release(object):
 
 class Test__base_version_helper(object):
 
-    def test_release_version_unchanged(self):
+    def test_release_version_unchanged(self) -> None:
         assert buv._base_version_helper("0.2.3") == "0.2.3"
         assert buv._base_version_helper("1.2.3") == "1.2.3"
 
-    def test_dev_version_stripped(self):
+    def test_dev_version_stripped(self) -> None:
         assert buv._base_version_helper("0.2.3dev2") == "0.2.3"
         assert buv._base_version_helper("1.2.3dev10") == "1.2.3"
 
-    def test_rc_version_stripped(self):
+    def test_rc_version_stripped(self) -> None:
         assert buv._base_version_helper("0.2.3rc2") == "0.2.3"
         assert buv._base_version_helper("1.2.3rc10") == "1.2.3"
 


### PR DESCRIPTION
This makes editing test files with mypy linter enabled less annoying. Note that test files aren't currently type-checked, so this doesn't affect running mypy manually or as a part of tests.