### PR TITLE
Redesign of bokehjs' properties system

### DIFF
--- a/bokehjs/src/lib/api/plotting.ts
+++ b/bokehjs/src/lib/api/plotting.ts
@@ -2,7 +2,7 @@ import {Document} from "../document"
 import * as embed from "../embed"
 import * as models from "./models"
 import {HasProps} from "../core/has_props"
-import {Omit, Color, Data, Attrs} from "../core/types"
+import {Color, Data, Attrs} from "../core/types"
 import {Value, Field, Vector} from "../core/vectorization"
 import {VectorSpec, ScalarSpec, Property} from "../core/properties"
 import {Class} from "../core/class"
@@ -658,13 +658,13 @@ export class Figure extends Plot {
 
     const result: Attrs = {}
     const traits = new Set()
-    for (const pname in cls.prototype.props) {
+    for (const pname in cls.prototype._props) {
       if (_is_visual(pname)) {
         const trait = _split_feature_trait(pname)[1]
         if (props.hasOwnProperty(prefix+pname)) {
           result[pname] = props[prefix+pname]
           delete props[prefix+pname]
-        } else if (!cls.prototype.props.hasOwnProperty(trait)
+        } else if (!cls.prototype._props.hasOwnProperty(trait)
                  && props.hasOwnProperty(prefix+trait)) {
           result[pname] = props[prefix+trait]
         } else if (override_defaults.hasOwnProperty(trait)) {
@@ -674,7 +674,7 @@ export class Figure extends Plot {
         } else if (trait_defaults.hasOwnProperty(trait)) {
           result[pname] = trait_defaults[trait]
         }
-        if (!cls.prototype.props.hasOwnProperty(trait)) {
+        if (!cls.prototype._props.hasOwnProperty(trait)) {
           traits.add(trait)
         }
       }
@@ -701,7 +701,7 @@ export class Figure extends Plot {
   _fixup_values(cls: Class<HasProps>, data: Data, attrs: Attrs): void {
     for (const name in attrs) {
       const value = attrs[name]
-      const prop = cls.prototype.props[name]
+      const prop = cls.prototype._props[name]
 
       if (prop != null) {
         if (prop.type.prototype instanceof VectorSpec) {

--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -76,7 +76,7 @@ export abstract class HasProps extends Signalable() {
   default_view: Class<View, [View.Options]>
   _props: {[key: string]: {
     type: p.PropertyConstructor<unknown, unknown>,
-    default_value: any,          // T
+    default_value: any,
     options: p.PropertyOptions,
   }}
   mixins: string[]
@@ -210,8 +210,12 @@ export abstract class HasProps extends Signalable() {
   finalize(): void {
     for (const name in this.properties) {
       const prop = this.properties[name]
-      if (prop.spec.transform != null)
-        this.connect(prop.spec.transform.change, () => this.transformchange.emit())
+      if (prop instanceof p.SpecProperty) {
+        const {transform} = prop.get_value()
+        if (transform != null) {
+          this.connect(transform.change, () => this.transformchange.emit())
+        }
+      }
     }
 
     this.initialize()

--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -75,7 +75,7 @@ export abstract class HasProps extends Signalable() {
   // {{{ prototype
   default_view: Class<View, [View.Options]>
   _props: {[key: string]: {
-    type: p.PropertyConstructor<unknown>,
+    type: p.PropertyConstructor<unknown, unknown>,
     default_value: any,          // T
     options: p.PropertyOptions,
   }}

--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -26,7 +26,6 @@ export module HasProps {
     check_eq?: boolean
     silent?: boolean
     no_change?: boolean
-    defaults?: boolean
     setter_id?: string
   }
 }
@@ -65,20 +64,20 @@ export abstract class HasProps extends Signalable() {
   }
 
   static init_HasProps(): void {
-    this.prototype.props = {}
+    this.prototype._props = {}
     this.prototype.mixins = []
 
     this.define<HasProps.Props>({
-      id: [ p.Any ],
+      id: [ p.String, () => uniqueId() ],
     })
   }
 
   // {{{ prototype
   default_view: Class<View, [View.Options]>
-  props: {[key: string]: {
-    type: Class<Property<any>>,  // T
+  _props: {[key: string]: {
+    type: p.PropertyConstructor<unknown>,
     default_value: any,          // T
-    internal: boolean,
+    options: p.PropertyOptions,
   }}
   mixins: string[]
   // }}}
@@ -104,7 +103,7 @@ export abstract class HasProps extends Signalable() {
   static define<T>(obj: Partial<p.DefineOf<T>>): void {
     for (const name in obj) {
       const prop = obj[name]
-      if (this.prototype.props[name] != null)
+      if (this.prototype._props[name] != null)
         throw new Error(`attempted to redefine property '${this.prototype.type}.${name}'`)
 
       if ((this.prototype as any)[name] != null)
@@ -124,25 +123,24 @@ export abstract class HasProps extends Signalable() {
         enumerable: true,
       })
 
-      const [type, default_value, internal] = prop as any
+      const [type, default_value, options] = prop as any
       const refined_prop = {
         type,
         default_value: this._fix_default(default_value, name),
-        internal: internal || false,
+        options,
       }
 
-      const props = clone(this.prototype.props)
+      const props = clone(this.prototype._props)
       props[name] = refined_prop
-      this.prototype.props = props
+      this.prototype._props = props
     }
   }
 
   static internal(obj: any): void {
     const _object: any = {}
     for (const name in obj) {
-      const prop = obj[name]
-      const [type, default_value] = prop
-      _object[name] = [type, default_value, true]
+      const [type, default_value, options = {}] = obj[name]
+      _object[name] = [type, default_value, {...options, internal: true}]
     }
     this.define(_object)
   }
@@ -160,12 +158,12 @@ export abstract class HasProps extends Signalable() {
   static override(obj: any): void {
     for (const name in obj) {
       const default_value = this._fix_default(obj[name], name)
-      const value = this.prototype.props[name]
+      const value = this.prototype._props[name]
       if (value == null)
         throw new Error(`attempted to override nonexistent '${this.prototype.type}.${name}'`)
-      const props = clone(this.prototype.props)
+      const props = clone(this.prototype._props)
       props[name] = {...value, default_value}
-      this.prototype.props = props
+      this.prototype._props = props
     }
   }
 
@@ -181,55 +179,37 @@ export abstract class HasProps extends Signalable() {
   readonly change          = new Signal0<this>(this, "change")
   readonly transformchange = new Signal0<this>(this, "transformchange")
 
-  readonly attributes: {[key: string]: any} = {}
-  readonly properties: {[key: string]: any} = {}
+  readonly properties: {[key: string]: Property<unknown>} = {}
 
-  protected readonly _set_after_defaults: {[key: string]: boolean} = {}
+  get attributes(): Attrs {
+    const attrs: Attrs = {}
+    for (const key in this.properties) {
+      attrs[key] = this.properties[key].get_value()
+    }
+    return attrs
+  }
 
   constructor(attrs: Attrs = {}) {
     super()
 
-    for (const name in this.props) {
-      const {type, default_value} = this.props[name]
+    for (const name in this._props) {
+      const {type, default_value, options} = this._props[name]
       if (type != null)
-        this.properties[name] = new type(this, name, default_value)
+        this.properties[name] = new type(this, name, default_value, attrs[name], options)
       else
         throw new Error(`undefined property type for ${this.type}.${name}`)
     }
 
-    // auto generating ID
-    if (attrs.id == null)
-      this.setv({id: uniqueId()}, {silent: true})
-
-    const deferred = attrs.__deferred__ || false
-    if (deferred) {
-      attrs = clone(attrs)
-      delete attrs.__deferred__
-    }
-
-    this.setv(attrs, {silent: true})
-
     // allowing us to defer initialization when loading many models
     // when loading a bunch of models, we want to do initialization as a second pass
     // because other objects that this one depends on might not be loaded yet
-
-    if (!deferred)
+    if (!(attrs.__deferred__ ?? false))
       this.finalize()
   }
 
   finalize(): void {
-    // This is necessary because the initial creation of properties relies on
-    // model.get which is not usable at that point yet in the constructor. This
-    // initializer is called when deferred initialization happens for all models
-    // and insures that the Bokeh properties are initialized from Backbone
-    // attributes in a consistent way.
-    //
-    // TODO (bev) split property creation up into two parts so that only the
-    // portion of init that can be done happens in HasProps constructor and so
-    // that subsequent updates do not duplicate that setup work.
     for (const name in this.properties) {
       const prop = this.properties[name]
-      prop.update()
       if (prop.spec.transform != null)
         this.connect(prop.spec.transform.change, () => this.transformchange.emit())
     }
@@ -270,25 +250,23 @@ export abstract class HasProps extends Signalable() {
     const changing   = this._changing
     this._changing = true
 
-    const current = this.attributes
-
-    // For each `set` attribute, update or delete the current value.
     for (const attr in attrs) {
+      const prop = this.properties[attr]
       const val = attrs[attr]
-      if (check_eq !== false) {
-        if (!isEqual(current[attr], val))
-          changes.push(attr)
-      } else
-        changes.push(attr)
-      current[attr] = val
+
+      if (check_eq === false || !isEqual(prop.get_value(), val)) {
+        prop.set_value(val)
+        changes.push(prop)
+      }
     }
 
     // Trigger all relevant attribute changes.
     if (!silent) {
       if (changes.length > 0)
         this._pending = true
-      for (let i = 0; i < changes.length; i++)
-        this.properties[changes[i]].change.emit()
+      for (const prop of changes) {
+        prop.change.emit()
+      }
     }
 
     // You might be wondering why there's a `while` loop here. Changes can
@@ -312,11 +290,8 @@ export abstract class HasProps extends Signalable() {
         continue
 
       const prop_name = key
-      if (this.props[prop_name] == null)
+      if (this.properties[prop_name] == null)
         throw new Error(`property ${this.type}.${prop_name} wasn't declared`)
-
-      if (!(options != null && options.defaults))
-        this._set_after_defaults[key] = true
     }
 
     if (!isEmpty(attrs)) {
@@ -333,11 +308,11 @@ export abstract class HasProps extends Signalable() {
     }
   }
 
-  getv(prop_name: string): any {
-    if (this.props[prop_name] == null)
-      throw new Error(`property ${this.type}.${prop_name} wasn't declared`)
+  getv(name: string): any {
+    if (this.properties[name] != null)
+      return this.properties[name].get_value()
     else
-      return this.attributes[prop_name]
+      throw new Error(`property ${this.type}.${name} wasn't declared`)
   }
 
   ref(): Ref {
@@ -363,7 +338,7 @@ export abstract class HasProps extends Signalable() {
   }
 
   attribute_is_serializable(attr: string): boolean {
-    const prop = this.props[attr]
+    const prop = this.properties[attr]
     if (prop == null)
       throw new Error(`${this.type}.attribute_is_serializable('${attr}'): ${attr} wasn't declared`)
     else
@@ -375,13 +350,14 @@ export abstract class HasProps extends Signalable() {
   // Document's models, subtypes that do that have to remove their
   // extra attributes here.
   serializable_attributes(): Attrs {
-    const attrs: Attrs = {}
-    for (const name in this.attributes) {
-      const value = this.attributes[name]
-      if (this.attribute_is_serializable(name))
-        attrs[name] = value
+    const {attributes} = this
+
+    for (const name in attributes) {
+      if (!this.attribute_is_serializable(name))
+        delete attributes[name]
     }
-    return attrs
+
+    return attributes
   }
 
   static _value_to_json(_key: string, value: any, _optional_parent_object: any): any {
@@ -412,11 +388,10 @@ export abstract class HasProps extends Signalable() {
     const attrs: Attrs = {}
     for (const key in serializable) {
       if (serializable.hasOwnProperty(key)) {
-        const value = serializable[key]
-        if (include_defaults)
+        if (include_defaults || this.properties[key].dirty) {
+          const value = serializable[key]
           attrs[key] = value
-        else if (key in this._set_after_defaults)
-          attrs[key] = value
+        }
       }
     }
     return value_to_json("attributes", attrs, this)
@@ -448,8 +423,7 @@ export abstract class HasProps extends Signalable() {
   // is true then descend into refs, if false only
   // descend into non-refs
   static _value_record_references(v: any, result: Attrs, recurse: boolean): void {
-    if (v == null) {
-    } else if (v instanceof HasProps) {
+    if (v instanceof HasProps) {
       if (!(v.id in result)) {
         result[v.id] = v
         if (recurse) {
@@ -458,7 +432,6 @@ export abstract class HasProps extends Signalable() {
             HasProps._value_record_references(obj, result, true) // true=recurse
         }
       }
-    } else if (v.buffer instanceof ArrayBuffer) {
     } else if (isArray(v)) {
       for (const elem of v)
         HasProps._value_record_references(elem, result, recurse)
@@ -550,7 +523,7 @@ export abstract class HasProps extends Signalable() {
       if (!(prop instanceof p.VectorSpec))
         continue
       // this skips optional properties like radius for circles
-      if (prop.optional && prop.spec.value == null && !(name in this._set_after_defaults))
+      if (prop.optional && prop.spec.value == null && !prop.dirty)
         continue
 
       const array = prop.array(source)

--- a/bokehjs/src/lib/core/types.ts
+++ b/bokehjs/src/lib/core/types.ts
@@ -1,5 +1,3 @@
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
-
 export type Color = string
 
 export type TypedArray =

--- a/bokehjs/src/lib/core/vectorization.ts
+++ b/bokehjs/src/lib/core/vectorization.ts
@@ -23,20 +23,28 @@ export type Expr<T> = {
   expr: Expression<T>
 }
 
-export type Scalar<T> = Value<T>
+export type Scalar<T> = Value<T> & Transformable<T>
 
-export type Vector<T> = Value<T> | Field | Expr<T>
+export type Vector<T> = (Value<T> | Field | Expr<T>) & Transformable<T>
 
 export type Dimensional<T, U> = T & {units?: U}
 
-export type Transformed<T> = {
+export type Transformable<T> = {
   transform?: Transform<T, T>
 }
 
-export function isValue<T>(obj: unknown): obj is Value<T> {
-  return isPlainObject(obj) && "value" in obj
+export function is_Value<T>(obj: Value<T> | Field | Expr<T>): obj is Value<T> {
+  return "value" in obj
 }
 
-export function isField(obj: unknown): obj is Field {
-  return isPlainObject(obj) && "field" in obj
+export function is_Field<T>(obj: Value<T> | Field | Expr<T>): obj is Field {
+  return "field" in obj
+}
+
+export function is_Expr<T>(obj: Value<T> | Field | Expr<T>): obj is Expr<T> {
+  return "expr" in obj
+}
+
+export function is_Spec<T>(obj: unknown): obj is Value<T> | Field | Expr<T> {
+  return isPlainObject(obj) && ("value" in obj || "field" in obj || "expr" in obj)
 }

--- a/bokehjs/src/lib/core/visuals.ts
+++ b/bokehjs/src/lib/core/visuals.ts
@@ -204,7 +204,7 @@ export abstract class ContextProperties {
       const prop = this.obj.properties[this.prefix + attr]
       if (prop.spec.value !== undefined) // TODO (bev) better test?
         this.cache[attr] = prop.spec.value
-      else if (source != null)
+      else if (source != null && prop instanceof p.VectorSpec)
         this.cache[attr + "_array"] = prop.array(source)
       else
         throw new Error("source is required with a vectorized visual property")

--- a/bokehjs/src/lib/core/visuals.ts
+++ b/bokehjs/src/lib/core/visuals.ts
@@ -406,6 +406,10 @@ export class Hatch extends ContextProperties {
     const [r, g, b, a] = color2rgba(this.hatch_color.scalar(), this.hatch_alpha.scalar())
     return `rgba(${r*255},${g*255},${b*255},${a})`
   }
+
+  set_scalar(_ctx: Context2d): void {
+    throw new Error("not implemented")
+  }
 }
 
 Hatch.prototype.attrs = Object.keys(mixins.hatch())

--- a/bokehjs/src/lib/core/visuals.ts
+++ b/bokehjs/src/lib/core/visuals.ts
@@ -221,6 +221,8 @@ export abstract class ContextProperties {
     return value
   }
 
+  abstract set_scalar(ctx: Context2d): void
+
   set_vectorize(ctx: Context2d, i: number): void {
     if (this.all_indices != null) // all_indices is set by a Visuals instance associated with a CDSView
       this._set_vectorize(ctx, this.all_indices[i])
@@ -241,14 +243,14 @@ export class Line extends ContextProperties {
   readonly line_dash:        p.Array
   readonly line_dash_offset: p.Number
 
-  set_value(ctx: Context2d): void {
-    ctx.strokeStyle = this.line_color.value()
-    ctx.globalAlpha = this.line_alpha.value()
-    ctx.lineWidth   = this.line_width.value()
-    ctx.lineJoin    = this.line_join.value()
-    ctx.lineCap     = this.line_cap.value()
-    ctx.setLineDash(this.line_dash.value())
-    ctx.setLineDashOffset(this.line_dash_offset.value())
+  set_scalar(ctx: Context2d): void {
+    ctx.strokeStyle = this.line_color.scalar()
+    ctx.globalAlpha = this.line_alpha.scalar()
+    ctx.lineWidth   = this.line_width.scalar()
+    ctx.lineJoin    = this.line_join.scalar()
+    ctx.lineCap     = this.line_cap.scalar()
+    ctx.setLineDash(this.line_dash.scalar())
+    ctx.setLineDashOffset(this.line_dash_offset.scalar())
   }
 
   get doit(): boolean {
@@ -288,7 +290,7 @@ export class Line extends ContextProperties {
   }
 
   color_value(): string {
-    const [r, g, b, a] = color2rgba(this.line_color.value(), this.line_alpha.value())
+    const [r, g, b, a] = color2rgba(this.line_color.scalar(), this.line_alpha.scalar())
     return `rgba(${r*255},${g*255},${b*255},${a})`
   }
 }
@@ -300,9 +302,9 @@ export class Fill extends ContextProperties {
   readonly fill_color: p.ColorSpec
   readonly fill_alpha: p.NumberSpec
 
-  set_value(ctx: Context2d): void {
-    ctx.fillStyle   = this.fill_color.value()
-    ctx.globalAlpha = this.fill_alpha.value()
+  set_scalar(ctx: Context2d): void {
+    ctx.fillStyle   = this.fill_color.scalar()
+    ctx.globalAlpha = this.fill_alpha.scalar()
   }
 
   get doit(): boolean {
@@ -321,7 +323,7 @@ export class Fill extends ContextProperties {
   }
 
   color_value(): string {
-    const [r, g, b, a] = color2rgba(this.fill_color.value(), this.fill_alpha.value())
+    const [r, g, b, a] = color2rgba(this.fill_color.scalar(), this.fill_alpha.scalar())
     return `rgba(${r*255},${g*255},${b*255},${a})`
   }
 }
@@ -401,7 +403,7 @@ export class Hatch extends ContextProperties {
   }
 
   color_value(): string {
-    const [r, g, b, a] = color2rgba(this.hatch_color.value(), this.hatch_alpha.value())
+    const [r, g, b, a] = color2rgba(this.hatch_color.scalar(), this.hatch_alpha.scalar())
     return `rgba(${r*255},${g*255},${b*255},${a})`
   }
 }
@@ -435,23 +437,23 @@ export class Text extends ContextProperties {
   }
 
   font_value(): string {
-    const font       = this.text_font.value()
-    const font_size  = this.text_font_size.value()
-    const font_style = this.text_font_style.value()
+    const font       = this.text_font.scalar()
+    const font_size  = this.text_font_size.scalar()
+    const font_style = this.text_font_style.scalar()
     return font_style + " " + font_size + " " + font
   }
 
   color_value(): string {
-    const [r, g, b, a] = color2rgba(this.text_color.value(), this.text_alpha.value())
+    const [r, g, b, a] = color2rgba(this.text_color.scalar(), this.text_alpha.scalar())
     return `rgba(${r*255},${g*255},${b*255},${a})`
   }
 
-  set_value(ctx: Context2d): void {
+  set_scalar(ctx: Context2d): void {
     ctx.font         = this.font_value()
-    ctx.fillStyle    = this.text_color.value()
-    ctx.globalAlpha  = this.text_alpha.value()
-    ctx.textAlign    = this.text_align.value()
-    ctx.textBaseline = this.text_baseline.value()
+    ctx.fillStyle    = this.text_color.scalar()
+    ctx.globalAlpha  = this.text_alpha.scalar()
+    ctx.textAlign    = this.text_align.scalar()
+    ctx.textBaseline = this.text_baseline.scalar()
   }
 
   get doit(): boolean {

--- a/bokehjs/src/lib/models/annotations/band.ts
+++ b/bokehjs/src/lib/models/annotations/band.ts
@@ -108,7 +108,7 @@ export class BandView extends AnnotationView {
     ctx.closePath()
 
     if (this.visuals.fill.doit) {
-      this.visuals.fill.set_value(ctx)
+      this.visuals.fill.set_scalar(ctx)
       ctx.fill()
     }
 
@@ -120,7 +120,7 @@ export class BandView extends AnnotationView {
     }
 
     if (this.visuals.line.doit) {
-      this.visuals.line.set_value(ctx)
+      this.visuals.line.set_scalar(ctx)
       ctx.stroke()
     }
 
@@ -132,7 +132,7 @@ export class BandView extends AnnotationView {
     }
 
     if (this.visuals.line.doit) {
-      this.visuals.line.set_value(ctx)
+      this.visuals.line.set_scalar(ctx)
       ctx.stroke()
     }
   }

--- a/bokehjs/src/lib/models/annotations/box_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/box_annotation.ts
@@ -85,7 +85,7 @@ export class BoxAnnotationView extends AnnotationView {
   }
 
   protected _css_box(sleft: number, sright: number, sbottom: number, stop: number): void {
-    const line_width = this.model.properties.line_width.value()
+    const line_width = this.model.properties.line_width.scalar()
     const sw = Math.floor(sright - sleft) - line_width
     const sh = Math.floor(sbottom - stop) - line_width
 
@@ -94,12 +94,12 @@ export class BoxAnnotationView extends AnnotationView {
     this.el.style.top = `${stop}px`
     this.el.style.height = `${sh}px`
     this.el.style.borderWidth = `${line_width}px`
-    this.el.style.borderColor = this.model.properties.line_color.value()
-    this.el.style.backgroundColor = this.model.properties.fill_color.value()
-    this.el.style.opacity = this.model.properties.fill_alpha.value()
+    this.el.style.borderColor = this.model.properties.line_color.scalar()
+    this.el.style.backgroundColor = this.model.properties.fill_color.scalar()
+    this.el.style.opacity = this.model.properties.fill_alpha.scalar()
 
     // try our best to honor line dashing in some way, if we can
-    const ld = this.model.properties.line_dash.value().length < 2 ? "solid" : "dashed"
+    const ld = this.model.properties.line_dash.scalar().length < 2 ? "solid" : "dashed"
     this.el.style.borderStyle = ld
 
     display(this.el)
@@ -112,17 +112,17 @@ export class BoxAnnotationView extends AnnotationView {
     ctx.beginPath()
     ctx.rect(sleft, stop, sright-sleft, sbottom-stop)
 
-    this.visuals.fill.set_value(ctx)
+    this.visuals.fill.set_scalar(ctx)
     ctx.fill()
 
-    this.visuals.line.set_value(ctx)
+    this.visuals.line.set_scalar(ctx)
     ctx.stroke()
 
     ctx.restore()
   }
 
   interactive_bbox(): BBox {
-    const tol = this.model.properties.line_width.value() + EDGE_TOLERANCE
+    const tol = this.model.properties.line_width.scalar() + EDGE_TOLERANCE
     return new BBox({
       x0: this.sleft-tol,
       y0: this.stop-tol,

--- a/bokehjs/src/lib/models/annotations/color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/color_bar.ts
@@ -223,11 +223,11 @@ export class ColorBarView extends AnnotationView {
     const bbox = this.compute_legend_dimensions()
     ctx.save()
     if (this.visuals.background_fill.doit) {
-      this.visuals.background_fill.set_value(ctx)
+      this.visuals.background_fill.set_scalar(ctx)
       ctx.fillRect(0, 0, bbox.width, bbox.height)
     }
     if (this.visuals.border_line.doit) {
-      this.visuals.border_line.set_value(ctx)
+      this.visuals.border_line.set_scalar(ctx)
       ctx.strokeRect(0, 0, bbox.width, bbox.height)
     }
     ctx.restore()
@@ -240,7 +240,7 @@ export class ColorBarView extends AnnotationView {
     ctx.globalAlpha = this.model.scale_alpha
     ctx.drawImage(this.image, 0, 0, image.width, image.height)
     if (this.visuals.bar_line.doit) {
-      this.visuals.bar_line.set_value(ctx)
+      this.visuals.bar_line.set_scalar(ctx)
       ctx.strokeRect(0, 0, image.width, image.height)
     }
     ctx.restore()
@@ -260,7 +260,7 @@ export class ColorBarView extends AnnotationView {
 
     ctx.save()
     ctx.translate(x_offset, y_offset)
-    this.visuals.major_tick_line.set_value(ctx)
+    this.visuals.major_tick_line.set_scalar(ctx)
     for (let i = 0, end = sx.length; i < end; i++) {
       ctx.beginPath()
       ctx.moveTo(Math.round(sx[i] + nx*tout), Math.round(sy[i] + ny*tout))
@@ -284,7 +284,7 @@ export class ColorBarView extends AnnotationView {
 
     ctx.save()
     ctx.translate(x_offset, y_offset)
-    this.visuals.minor_tick_line.set_value(ctx)
+    this.visuals.minor_tick_line.set_scalar(ctx)
     for (let i = 0, end = sx.length; i < end; i++) {
       ctx.beginPath()
       ctx.moveTo(Math.round(sx[i] + nx*tout), Math.round(sy[i] + ny*tout))
@@ -308,7 +308,7 @@ export class ColorBarView extends AnnotationView {
 
     const formatted_labels = tick_info.labels.major
 
-    this.visuals.major_label_text.set_value(ctx)
+    this.visuals.major_label_text.set_scalar(ctx)
 
     ctx.save()
     ctx.translate(x_offset + x_standoff, y_offset + y_standoff)
@@ -325,7 +325,7 @@ export class ColorBarView extends AnnotationView {
       return
 
     ctx.save()
-    this.visuals.title_text.set_value(ctx)
+    this.visuals.title_text.set_scalar(ctx)
     ctx.fillText(this.model.title, 0, -this.model.title_standoff)
     ctx.restore()
   }
@@ -337,7 +337,7 @@ export class ColorBarView extends AnnotationView {
     if (this.model.color_mapper.low != null && this.model.color_mapper.high != null && !isEmpty(major_labels)) {
       const {ctx} = this.plot_view.canvas_view
       ctx.save()
-      this.visuals.major_label_text.set_value(ctx)
+      this.visuals.major_label_text.set_scalar(ctx)
       switch (this.model.orientation) {
         case "vertical":
           label_extent = max((major_labels.map((label) => ctx.measureText(label.toString()).width)))

--- a/bokehjs/src/lib/models/annotations/label.ts
+++ b/bokehjs/src/lib/models/annotations/label.ts
@@ -16,7 +16,7 @@ export class LabelView extends TextAnnotationView {
 
   protected _get_size(): Size {
     const {ctx} = this.plot_view.canvas_view
-    this.visuals.text.set_value(ctx)
+    this.visuals.text.set_scalar(ctx)
 
     const {width, ascent} = ctx.measureText(this.model.text)
     return {width, height: ascent}

--- a/bokehjs/src/lib/models/annotations/label_set.ts
+++ b/bokehjs/src/lib/models/annotations/label_set.ts
@@ -111,7 +111,7 @@ export class LabelSetView extends TextAnnotationView {
 
   protected _get_size(): Size {
     const {ctx} = this.plot_view.canvas_view
-    this.visuals.text.set_value(ctx)
+    this.visuals.text.set_scalar(ctx)
 
     const {width, ascent} = ctx.measureText(this._text[0])
     return {width, height: ascent}
@@ -155,7 +155,7 @@ export class LabelSetView extends TextAnnotationView {
     const bbox_dims = this._calculate_bounding_box_dimensions(ctx, text)
 
     // attempt to support vector-style ("8 4 8") line dashing for css mode
-    const ld = this.visuals.border_line.line_dash.value()
+    const ld = this.visuals.border_line.line_dash.scalar()
     const line_dash = ld.length < 2 ? "solid" : "dashed"
 
     this.visuals.border_line.set_vectorize(ctx, i)
@@ -164,8 +164,8 @@ export class LabelSetView extends TextAnnotationView {
     el.style.position = 'absolute'
     el.style.left = `${sx + bbox_dims[0]}px`
     el.style.top = `${sy + bbox_dims[1]}px`
-    el.style.color = `${this.visuals.text.text_color.value()}`
-    el.style.opacity = `${this.visuals.text.text_alpha.value()}`
+    el.style.color = `${this.visuals.text.text_color.scalar()}`
+    el.style.opacity = `${this.visuals.text.text_alpha.scalar()}`
     el.style.font = `${this.visuals.text.font_value()}`
     el.style.lineHeight = "normal"  // needed to prevent ipynb css override
 
@@ -179,7 +179,7 @@ export class LabelSetView extends TextAnnotationView {
 
     if (this.visuals.border_line.doit) {
       el.style.borderStyle = `${line_dash}`
-      el.style.borderWidth = `${this.visuals.border_line.line_width.value()}px`
+      el.style.borderWidth = `${this.visuals.border_line.line_width.scalar()}px`
       el.style.borderColor = `${this.visuals.border_line.color_value()}`
     }
 

--- a/bokehjs/src/lib/models/annotations/legend.ts
+++ b/bokehjs/src/lib/models/annotations/legend.ts
@@ -30,7 +30,7 @@ export class LegendView extends AnnotationView {
   }
 
   get legend_padding(): number {
-    return this.visuals.border_line.line_color.value() != null ? this.model.padding : 0
+    return this.visuals.border_line.line_color.scalar() != null ? this.model.padding : 0
   }
 
   connect_signals(): void {
@@ -52,13 +52,13 @@ export class LegendView extends AnnotationView {
     // this is to measure text properties
     const { ctx } = this.plot_view.canvas_view
     ctx.save()
-    this.visuals.label_text.set_value(ctx)
+    this.visuals.label_text.set_scalar(ctx)
     this.text_widths = {}
     for (const name of legend_names) {
       this.text_widths[name] = max([ctx.measureText(name).width, label_width])
     }
 
-    this.visuals.title_text.set_value(ctx)
+    this.visuals.title_text.set_scalar(ctx)
     this.title_height = this.model.title ? measure_font(this.visuals.title_text.font_value()).height + this.model.title_standoff : 0
     this.title_width = this.model.title ? ctx.measureText(this.model.title).width : 0
 
@@ -230,10 +230,10 @@ export class LegendView extends AnnotationView {
   protected _draw_legend_box(ctx: Context2d, bbox: BBox): void {
     ctx.beginPath()
     ctx.rect(bbox.x, bbox.y, bbox.width, bbox.height)
-    this.visuals.background_fill.set_value(ctx)
+    this.visuals.background_fill.set_scalar(ctx)
     ctx.fill()
     if (this.visuals.border_line.doit) {
-      this.visuals.border_line.set_value(ctx)
+      this.visuals.border_line.set_scalar(ctx)
       ctx.stroke()
     }
   }
@@ -273,7 +273,7 @@ export class LegendView extends AnnotationView {
         else
           xoffset += this.text_widths[label] + glyph_width + label_standoff + legend_spacing
 
-        this.visuals.label_text.set_value(ctx)
+        this.visuals.label_text.set_scalar(ctx)
         ctx.fillText(label, x2 + label_standoff, y1 + this.max_label_height/2.0)
         for (const r of item.renderers) {
           const view = this.plot_view.renderer_views[r.id] as GlyphRendererView
@@ -289,7 +289,7 @@ export class LegendView extends AnnotationView {
 
           ctx.beginPath()
           ctx.rect(x1, y1, w, h)
-          this.visuals.inactive_fill.set_value(ctx)
+          this.visuals.inactive_fill.set_scalar(ctx)
           ctx.fill()
         }
       }
@@ -302,7 +302,7 @@ export class LegendView extends AnnotationView {
 
     ctx.save()
     ctx.translate(bbox.x0, bbox.y0 + this.title_height)
-    this.visuals.title_text.set_value(ctx)
+    this.visuals.title_text.set_scalar(ctx)
     ctx.fillText(this.model.title, this.legend_padding, this.legend_padding-this.model.title_standoff)
     ctx.restore()
   }

--- a/bokehjs/src/lib/models/annotations/poly_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/poly_annotation.ts
@@ -56,12 +56,12 @@ export class PolyAnnotationView extends AnnotationView {
     ctx.closePath()
 
     if (this.visuals.line.doit) {
-      this.visuals.line.set_value(ctx)
+      this.visuals.line.set_scalar(ctx)
       ctx.stroke()
     }
 
     if (this.visuals.fill.doit) {
-      this.visuals.fill.set_value(ctx)
+      this.visuals.fill.set_scalar(ctx)
       ctx.fill()
     }
   }

--- a/bokehjs/src/lib/models/annotations/slope.ts
+++ b/bokehjs/src/lib/models/annotations/slope.ts
@@ -51,7 +51,7 @@ export class SlopeView extends AnnotationView {
     ctx.save()
 
     ctx.beginPath()
-    this.visuals.line.set_value(ctx)
+    this.visuals.line.set_scalar(ctx)
     ctx.moveTo(sx_start, sy_start)
     ctx.lineTo(sx_end, sy_end)
 

--- a/bokehjs/src/lib/models/annotations/span.ts
+++ b/bokehjs/src/lib/models/annotations/span.ts
@@ -71,11 +71,11 @@ export class SpanView extends AnnotationView {
       stop = _calc_dim(yscale, frame.yview)
       sleft = frame._left.value
       width = frame._width.value
-      height = this.model.properties.line_width.value()
+      height = this.model.properties.line_width.scalar()
     } else {
       stop = frame._top.value
       sleft = _calc_dim(xscale, frame.xview)
-      width = this.model.properties.line_width.value()
+      width = this.model.properties.line_width.scalar()
       height = frame._height.value
     }
 
@@ -84,15 +84,15 @@ export class SpanView extends AnnotationView {
       this.el.style.left = `${sleft}px`
       this.el.style.width = `${width}px`
       this.el.style.height = `${height}px`
-      this.el.style.backgroundColor = this.model.properties.line_color.value()
-      this.el.style.opacity = this.model.properties.line_alpha.value()
+      this.el.style.backgroundColor = this.model.properties.line_color.scalar()
+      this.el.style.opacity = this.model.properties.line_alpha.scalar()
       display(this.el)
     } else if (this.model.render_mode == "canvas") {
       const {ctx} = this.plot_view.canvas_view
       ctx.save()
 
       ctx.beginPath()
-      this.visuals.line.set_value(ctx)
+      this.visuals.line.set_scalar(ctx)
       ctx.moveTo(sleft, stop)
       if (this.model.dimension == "width") {
         ctx.lineTo(sleft + width, stop)

--- a/bokehjs/src/lib/models/annotations/text_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/text_annotation.ts
@@ -70,7 +70,7 @@ export abstract class TextAnnotationView extends AnnotationView {
   abstract render(): void
 
   protected _canvas_text(ctx: Context2d, text: string, sx: number, sy: number, angle: number): void {
-    this.visuals.text.set_value(ctx)
+    this.visuals.text.set_scalar(ctx)
     const bbox_dims = this._calculate_bounding_box_dimensions(ctx, text)
 
     ctx.save()
@@ -84,17 +84,17 @@ export abstract class TextAnnotationView extends AnnotationView {
     ctx.rect(bbox_dims[0], bbox_dims[1], bbox_dims[2], bbox_dims[3])
 
     if (this.visuals.background_fill.doit) {
-      this.visuals.background_fill.set_value(ctx)
+      this.visuals.background_fill.set_scalar(ctx)
       ctx.fill()
     }
 
     if (this.visuals.border_line.doit) {
-      this.visuals.border_line.set_value(ctx)
+      this.visuals.border_line.set_scalar(ctx)
       ctx.stroke()
     }
 
     if (this.visuals.text.doit) {
-      this.visuals.text.set_value(ctx)
+      this.visuals.text.set_scalar(ctx)
       ctx.fillText(text, 0, 0)
     }
 
@@ -104,21 +104,21 @@ export abstract class TextAnnotationView extends AnnotationView {
   protected _css_text(ctx: Context2d, text: string, sx: number, sy: number, angle: number): void {
     undisplay(this.el)
 
-    this.visuals.text.set_value(ctx)
+    this.visuals.text.set_scalar(ctx)
     const bbox_dims = this._calculate_bounding_box_dimensions(ctx, text)
 
     // attempt to support vector string-style ("8 4 8") line dashing for css mode
-    const ld = this.visuals.border_line.line_dash.value()
+    const ld = this.visuals.border_line.line_dash.scalar()
     const line_dash = ld.length < 2 ? "solid" : "dashed"
 
-    this.visuals.border_line.set_value(ctx)
-    this.visuals.background_fill.set_value(ctx)
+    this.visuals.border_line.set_scalar(ctx)
+    this.visuals.background_fill.set_scalar(ctx)
 
     this.el.style.position = 'absolute'
     this.el.style.left = `${sx + bbox_dims[0]}px`
     this.el.style.top = `${sy + bbox_dims[1]}px`
-    this.el.style.color = `${this.visuals.text.text_color.value()}`
-    this.el.style.opacity = `${this.visuals.text.text_alpha.value()}`
+    this.el.style.color = `${this.visuals.text.text_color.scalar()}`
+    this.el.style.opacity = `${this.visuals.text.text_alpha.scalar()}`
     this.el.style.font = `${this.visuals.text.font_value()}`
     this.el.style.lineHeight = "normal" // needed to prevent ipynb css override
 
@@ -132,7 +132,7 @@ export abstract class TextAnnotationView extends AnnotationView {
 
     if (this.visuals.border_line.doit) {
       this.el.style.borderStyle = `${line_dash}`
-      this.el.style.borderWidth = `${this.visuals.border_line.line_width.value()}px`
+      this.el.style.borderWidth = `${this.visuals.border_line.line_width.scalar()}px`
       this.el.style.borderColor = `${this.visuals.border_line.color_value()}`
     }
 

--- a/bokehjs/src/lib/models/annotations/title.ts
+++ b/bokehjs/src/lib/models/annotations/title.ts
@@ -97,9 +97,9 @@ export class TitleView extends TextAnnotationView {
     if (text == null || text.length == 0)
       return {width: 0, height: 0}
     else {
-      this.visuals.text.set_value(this.ctx)
+      this.visuals.text.set_scalar(this.ctx)
       const {width, ascent} = this.ctx.measureText(text)
-      return {width, height: ascent * this.visuals.text.text_line_height.value() + 10}
+      return {width, height: ascent * this.visuals.text.text_line_height.scalar() + 10}
     }
   }
 }

--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -105,7 +105,7 @@ export class AxisView extends GuideRendererView {
     const [nx, ny]     = this.normals
     const [xoff, yoff] = this.offsets
 
-    this.visuals.axis_line.set_value(ctx)
+    this.visuals.axis_line.set_scalar(ctx)
 
     ctx.beginPath()
     ctx.moveTo(Math.round(sxs[0] + nx*xoff), Math.round(sys[0] + ny*yoff))
@@ -190,7 +190,7 @@ export class AxisView extends GuideRendererView {
     const [nxin,  nyin]  = [nx * (xoff-tin),  ny * (yoff-tin)]
     const [nxout, nyout] = [nx * (xoff+tout), ny * (yoff+tout)]
 
-    visuals.set_value(ctx)
+    visuals.set_scalar(ctx)
 
     for (let i = 0; i < sxs.length; i++) {
       const sx0 = Math.round(sxs[i] + nxout)
@@ -227,7 +227,7 @@ export class AxisView extends GuideRendererView {
     const nxd = nx * (xoff + standoff)
     const nyd = ny * (yoff + standoff)
 
-    visuals.set_value(ctx)
+    visuals.set_scalar(ctx)
     this.panel.apply_label_text_heuristics(ctx, orient)
 
     let angle: number
@@ -283,7 +283,7 @@ export class AxisView extends GuideRendererView {
       return 0
 
     const ctx = this.plot_view.canvas_view.ctx
-    visuals.set_value(ctx)
+    visuals.set_scalar(ctx)
 
     let hscale: number
     let angle: number

--- a/bokehjs/src/lib/models/glyphs/annular_wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/annular_wedge.ts
@@ -6,6 +6,7 @@ import {Arrayable, Rect} from "core/types"
 import {Line, Fill} from "core/visuals"
 import * as hittest from "core/hittest"
 import * as p from "core/properties"
+import {Direction} from "core/enums"
 import {angle_between} from "core/util/math"
 import {Context2d} from "core/util/canvas"
 import {Selection} from "../selections/selection"
@@ -61,7 +62,7 @@ export class AnnularWedgeView extends XYGlyphView {
 
       ctx.moveTo(souter_radius[i], 0)
       ctx.beginPath()
-      ctx.arc(0, 0, souter_radius[i], 0, _angle[i], direction)
+      ctx.arc(0, 0, souter_radius[i], 0, _angle[i], !!direction)
       ctx.rotate(_angle[i])
       ctx.lineTo(sinner_radius[i], 0)
       ctx.arc(0, 0, sinner_radius[i], 0, -_angle[i], !direction)
@@ -154,7 +155,7 @@ export namespace AnnularWedge {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = XYGlyph.Props & LineVector & FillVector & {
-    direction: p.Direction
+    direction: p.Property<Direction, 0 | 1>
     inner_radius: p.DistanceSpec
     outer_radius: p.DistanceSpec
     start_angle: p.AngleSpec
@@ -178,7 +179,7 @@ export class AnnularWedge extends XYGlyph {
 
     this.mixins(['line', 'fill'])
     this.define<AnnularWedge.Props>({
-      direction:    [ p.Direction,   'anticlock' ],
+      direction:    [ p.Direction as any,   'anticlock' ],
       inner_radius: [ p.DistanceSpec             ],
       outer_radius: [ p.DistanceSpec             ],
       start_angle:  [ p.AngleSpec                ],

--- a/bokehjs/src/lib/models/glyphs/annular_wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/annular_wedge.ts
@@ -50,7 +50,7 @@ export class AnnularWedgeView extends XYGlyphView {
 
   protected _render(ctx: Context2d, indices: number[],
                     {sx, sy, _start_angle, _angle, sinner_radius, souter_radius}: AnnularWedgeData): void {
-    const direction = this.model.properties.direction.value()
+    const direction = this.model.properties.direction.scalar()
 
     for (const i of indices) {
       if (isNaN(sx[i] + sy[i] + sinner_radius[i] + souter_radius[i] + _start_angle[i] + _angle[i]))
@@ -118,7 +118,7 @@ export class AnnularWedgeView extends XYGlyphView {
         candidates.push([i, dist])
     }
 
-    const direction = this.model.properties.direction.value()
+    const direction = this.model.properties.direction.scalar()
     const hits: [number, number][] = []
     for (const [i, dist] of candidates) {
       // NOTE: minus the angle because JS uses non-mathy convention for angles

--- a/bokehjs/src/lib/models/glyphs/arc.ts
+++ b/bokehjs/src/lib/models/glyphs/arc.ts
@@ -40,7 +40,7 @@ export class ArcView extends XYGlyphView {
           continue
 
         ctx.beginPath()
-        ctx.arc(sx[i], sy[i], sradius[i], _start_angle[i], _end_angle[i], direction)
+        ctx.arc(sx[i], sy[i], sradius[i], _start_angle[i], _end_angle[i], !!direction)
 
         this.visuals.line.set_vectorize(ctx, i)
         ctx.stroke()
@@ -57,7 +57,7 @@ export namespace Arc {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = XYGlyph.Props & LineVector & {
-    direction: p.Property<Direction>
+    direction: p.Property<Direction, 0 | 1>
     radius: p.DistanceSpec
     start_angle: p.AngleSpec
     end_angle: p.AngleSpec
@@ -80,7 +80,7 @@ export class Arc extends XYGlyph {
 
     this.mixins(['line'])
     this.define<Arc.Props>({
-      direction:   [ p.Direction,   'anticlock' ],
+      direction:   [ p.Direction as any,   'anticlock' ],
       radius:      [ p.DistanceSpec             ],
       start_angle: [ p.AngleSpec                ],
       end_angle:   [ p.AngleSpec                ],

--- a/bokehjs/src/lib/models/glyphs/arc.ts
+++ b/bokehjs/src/lib/models/glyphs/arc.ts
@@ -33,7 +33,7 @@ export class ArcView extends XYGlyphView {
   protected _render(ctx: Context2d, indices: number[],
                     {sx, sy, sradius, _start_angle, _end_angle}: ArcData): void {
     if (this.visuals.line.doit) {
-      const direction = this.model.properties.direction.value()
+      const direction = this.model.properties.direction.scalar()
 
       for (const i of indices) {
         if (isNaN(sx[i] + sy[i] + sradius[i] + _start_angle[i] + _end_angle[i]))

--- a/bokehjs/src/lib/models/glyphs/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/circle.ts
@@ -32,9 +32,8 @@ export class CircleView extends XYGlyphView {
     // XXX: Order is important here: size is always present (at least
     // a default), but radius is only present if a user specifies it.
     if (this._radius != null) {
-      if (this.model.properties.radius.spec.units == "data") {
-        const rd = this.model.properties.radius_dimension.spec.value
-        switch (rd) {
+      if (this.model.properties.radius.units == "data") {
+        switch (this.model.radius_dimension) {
           case "x": {
             this.sradius = this.sdist(this.renderer.xscale, this._x, this._radius)
             break
@@ -282,13 +281,8 @@ export class Circle extends XYGlyph {
     this.define<Circle.Props>({
       angle:            [ p.AngleSpec,       0                             ],
       size:             [ p.DistanceSpec,    { units: "screen", value: 4 } ],
-      radius:           [ p.DistanceSpec                                   ], // XXX: null
+      radius:           [ p.DistanceSpec,    undefined, {optional: true}   ], // XXX: null
       radius_dimension: [ p.RadiusDimension, 'x'                           ],
     })
-  }
-
-  initialize(): void {
-    super.initialize()
-    this.properties.radius.optional = true
   }
 }

--- a/bokehjs/src/lib/models/glyphs/harea.ts
+++ b/bokehjs/src/lib/models/glyphs/harea.ts
@@ -56,7 +56,7 @@ export class HAreaView extends AreaView {
   protected _render(ctx: Context2d, _indices: number[], {sx1, sx2, sy}: HAreaData): void {
 
     if (this.visuals.fill.doit) {
-      this.visuals.fill.set_value(ctx)
+      this.visuals.fill.set_scalar(ctx)
       this._inner(ctx, sx1, sx2, sy, ctx.fill)
     }
 

--- a/bokehjs/src/lib/models/glyphs/line.ts
+++ b/bokehjs/src/lib/models/glyphs/line.ts
@@ -21,7 +21,7 @@ export class LineView extends XYGlyphView {
     let drawing = false
     let last_index: number | null = null
 
-    this.visuals.line.set_value(ctx)
+    this.visuals.line.set_scalar(ctx)
     for (const i of indices) {
       if (drawing) {
         if (!isFinite(sx[i] + sy[i])) {
@@ -65,7 +65,7 @@ export class LineView extends XYGlyphView {
     const result = hittest.create_empty_hit_test_result()
     const point = {x: geometry.sx, y: geometry.sy}
     let shortest = 9999
-    const threshold = Math.max(2, this.visuals.line.line_width.value() / 2)
+    const threshold = Math.max(2, this.visuals.line.line_width.scalar() / 2)
 
     for (let i = 0, end = this.sx.length-1; i < end; i++) {
       const p0 = {x: this.sx[i],     y: this.sy[i]    }

--- a/bokehjs/src/lib/models/glyphs/patch.ts
+++ b/bokehjs/src/lib/models/glyphs/patch.ts
@@ -36,14 +36,14 @@ export class PatchView extends XYGlyphView {
   }
   protected _render(ctx: Context2d, indices: number[], {sx, sy}: PatchData): void {
     if (this.visuals.fill.doit) {
-      this.visuals.fill.set_value(ctx)
+      this.visuals.fill.set_scalar(ctx)
       this._inner_loop(ctx, indices, sx, sy, ctx.fill)
     }
 
     this.visuals.hatch.doit2(ctx, 0, () => this._inner_loop(ctx, indices, sx, sy, ctx.fill), () => this.renderer.request_render())
 
     if (this.visuals.line.doit) {
-      this.visuals.line.set_value(ctx)
+      this.visuals.line.set_scalar(ctx)
       this._inner_loop(ctx, indices, sx, sy, ctx.stroke)
     }
   }

--- a/bokehjs/src/lib/models/glyphs/step.ts
+++ b/bokehjs/src/lib/models/glyphs/step.ts
@@ -19,7 +19,7 @@ export class StepView extends XYGlyphView {
     let drawing = false
     let last_index: number | null = null
 
-    this.visuals.line.set_value(ctx)
+    this.visuals.line.set_scalar(ctx)
 
     const L = indices.length
     if (L < 2)

--- a/bokehjs/src/lib/models/glyphs/text.ts
+++ b/bokehjs/src/lib/models/glyphs/text.ts
@@ -55,7 +55,7 @@ export class TextView extends XYGlyphView {
 
         const font = this.visuals.text.cache_select("font", i)
         const {height} = measure_font(font)
-        const line_height = this.visuals.text.text_line_height.value()*height
+        const line_height = this.visuals.text.text_line_height.scalar()*height
         if (text.indexOf("\n") == -1){
           ctx.fillText(text, 0, 0)
           const x0 = sx[i] + _x_offset[i]

--- a/bokehjs/src/lib/models/glyphs/varea.ts
+++ b/bokehjs/src/lib/models/glyphs/varea.ts
@@ -56,7 +56,7 @@ export class VAreaView extends AreaView {
   protected _render(ctx: Context2d, _indices: number[], {sx, sy1, sy2}: VAreaData): void {
 
     if (this.visuals.fill.doit) {
-      this.visuals.fill.set_value(ctx)
+      this.visuals.fill.set_scalar(ctx)
       this._inner(ctx, sx, sy1, sy2, ctx.fill)
     }
 

--- a/bokehjs/src/lib/models/glyphs/webgl/base.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/base.ts
@@ -116,7 +116,7 @@ export function attach_float(prog: Program, vbo: VertexBuffer & {used?: boolean}
     prog.set_attribute(att_name, 'float', [0])
   } else if (visual_prop_is_singular(visual, name)) {
     vbo.used = false
-    prog.set_attribute(att_name, 'float', visual[name].value())
+    prog.set_attribute(att_name, 'float', visual[name].scalar())
   } else {
     vbo.used = true
     const a = new Float32Array(visual.cache[name + '_array'])
@@ -142,7 +142,7 @@ export function attach_color(prog: Program, vbo: VertexBuffer & {used?: boolean}
   } else if (visual_prop_is_singular(visual, colorname) && visual_prop_is_singular(visual, alphaname)) {
     // Nice and simple; both color and alpha are singular
     vbo.used = false
-    rgba = color2rgba(visual[colorname].value(), visual[alphaname].value())
+    rgba = color2rgba(visual[colorname].scalar(), visual[alphaname].scalar())
     prog.set_attribute(att_name, 'vec4', rgba)
   } else {
     // Use vbo; we need an array for both the color and the alpha
@@ -153,7 +153,7 @@ export function attach_color(prog: Program, vbo: VertexBuffer & {used?: boolean}
       colors = ((() => {
         const result = []
         for (let i = 0, end = n; i < end; i++) {
-          result.push(visual[colorname].value())
+          result.push(visual[colorname].scalar())
         }
         return result
       })())
@@ -162,7 +162,7 @@ export function attach_color(prog: Program, vbo: VertexBuffer & {used?: boolean}
     }
     // Get array of alphas
     if (visual_prop_is_singular(visual, alphaname)) {
-      alphas = fill_array_with_float(n, visual[alphaname].value())
+      alphas = fill_array_with_float(n, visual[alphaname].scalar())
     } else {
       alphas = visual.cache[alphaname+'_array']
     }

--- a/bokehjs/src/lib/models/glyphs/webgl/line.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/line.ts
@@ -255,12 +255,12 @@ export class LineGLGlyph extends BaseGLGlyph {
   }
 
   protected _set_visuals(): void {
-    const color = color2rgba(this.glyph.visuals.line.line_color.value(), this.glyph.visuals.line.line_alpha.value())
-    const cap = caps[this.glyph.visuals.line.line_cap.value()]
-    const join = joins[this.glyph.visuals.line.line_join.value()]
+    const color = color2rgba(this.glyph.visuals.line.line_color.scalar(), this.glyph.visuals.line.line_alpha.scalar())
+    const cap = caps[this.glyph.visuals.line.line_cap.scalar()]
+    const join = joins[this.glyph.visuals.line.line_join.scalar()]
 
     this.prog.set_uniform('u_color', 'vec4', color)
-    this.prog.set_uniform('u_linewidth', 'float', [this.glyph.visuals.line.line_width.value()])
+    this.prog.set_uniform('u_linewidth', 'float', [this.glyph.visuals.line.line_width.scalar()])
     this.prog.set_uniform('u_antialias', 'float', [0.9])  // Smaller aa-region to obtain crisper images
 
     this.prog.set_uniform('u_linecaps', 'vec2', [cap, cap])
@@ -268,13 +268,13 @@ export class LineGLGlyph extends BaseGLGlyph {
     this.prog.set_uniform('u_miter_limit', 'float', [10.0])  // 10 should be a good value
     // https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-miterlimit
 
-    const dash_pattern = this.glyph.visuals.line.line_dash.value()
+    const dash_pattern = this.glyph.visuals.line.line_dash.scalar()
     let dash_index = 0; let dash_period = 1
     if (dash_pattern.length) {
       [dash_index, dash_period] = this.dash_atlas.get_atlas_data(dash_pattern)
     }
     this.prog.set_uniform('u_dash_index', 'float', [dash_index])  // 0 means solid line
-    this.prog.set_uniform('u_dash_phase', 'float', [this.glyph.visuals.line.line_dash_offset.value()])
+    this.prog.set_uniform('u_dash_phase', 'float', [this.glyph.visuals.line.line_dash_offset.scalar()])
     this.prog.set_uniform('u_dash_period', 'float', [dash_period])
     this.prog.set_uniform('u_dash_caps', 'vec2', [cap, cap])
     this.prog.set_uniform('u_closed', 'float', [0])  // We dont do closed lines

--- a/bokehjs/src/lib/models/glyphs/wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/wedge.ts
@@ -35,7 +35,7 @@ export class WedgeView extends XYGlyphView {
   }
 
   protected _render(ctx: Context2d, indices: number[], {sx, sy, sradius, _start_angle, _end_angle}: WedgeData): void {
-    const direction = this.model.properties.direction.value()
+    const direction = this.model.properties.direction.scalar()
 
     for (const i of indices) {
       if (isNaN(sx[i] + sy[i] + sradius[i] + _start_angle[i] + _end_angle[i]))
@@ -95,7 +95,7 @@ export class WedgeView extends XYGlyphView {
       }
     }
 
-    const direction = this.model.properties.direction.value()
+    const direction = this.model.properties.direction.scalar()
     const hits: [number, number][] = []
     for (const [i, dist] of candidates) {
       // NOTE: minus the angle because JS uses non-mathy convention for angles

--- a/bokehjs/src/lib/models/glyphs/wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/wedge.ts
@@ -42,7 +42,7 @@ export class WedgeView extends XYGlyphView {
         continue
 
       ctx.beginPath()
-      ctx.arc(sx[i], sy[i], sradius[i], _start_angle[i], _end_angle[i], direction)
+      ctx.arc(sx[i], sy[i], sradius[i], _start_angle[i], _end_angle[i], !!direction)
       ctx.lineTo(sx[i], sy[i])
       ctx.closePath()
 
@@ -131,7 +131,7 @@ export namespace Wedge {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = XYGlyph.Props & LineVector & FillVector & {
-    direction: p.Property<Direction>
+    direction: p.Property<Direction, 0 | 1>
     radius: p.DistanceSpec
     start_angle: p.AngleSpec
     end_angle: p.AngleSpec
@@ -154,7 +154,7 @@ export class Wedge extends XYGlyph {
 
     this.mixins(['line', 'fill'])
     this.define<Wedge.Props>({
-      direction:    [ p.Direction,   'anticlock' ],
+      direction:    [ p.Direction as any,   'anticlock' ],
       radius:       [ p.DistanceSpec             ],
       start_angle:  [ p.AngleSpec                ],
       end_angle:    [ p.AngleSpec                ],

--- a/bokehjs/src/lib/models/grids/grid.ts
+++ b/bokehjs/src/lib/models/grids/grid.ts
@@ -33,7 +33,7 @@ export class GridView extends GuideRendererView {
     if (!this.visuals.band_fill.doit && !this.visuals.band_hatch.doit)
       return
 
-    this.visuals.band_fill.set_value(ctx)
+    this.visuals.band_fill.set_scalar(ctx)
 
     const [xs, ys] = this.grid_coords('major', false)
     for (let i = 0; i < xs.length-1; i++) {
@@ -67,7 +67,7 @@ export class GridView extends GuideRendererView {
   }
 
   protected _draw_grid_helper(ctx: Context2d, visuals: visuals.Line, xs: number[][], ys: number[][]): void {
-    visuals.set_value(ctx)
+    visuals.set_scalar(ctx)
     for (let i = 0; i < xs.length; i++) {
       const [sx, sy] = this.plot_view.map_to_screen(xs[i], ys[i], this.model.x_range_name, this.model.y_range_name)
       ctx.beginPath()

--- a/bokehjs/src/lib/models/plots/plot.ts
+++ b/bokehjs/src/lib/models/plots/plot.ts
@@ -178,13 +178,16 @@ export class Plot extends LayoutDOM {
     })
   }
 
+  // TODO: change this when we drop ES5 compatibility (https://github.com/microsoft/TypeScript/issues/338)
   get width(): number | null {
-    const width = this.getv("width")
+    // const width = super.width
+    const width = this.properties.width.get_value()
     return width != null ? width : this.plot_width
   }
 
   get height(): number | null {
-    const height = this.getv("height")
+    // const height = super.height
+    const height = this.properties.height.get_value()
     return height != null ? height : this.plot_height
   }
 
@@ -217,8 +220,8 @@ export class Plot extends LayoutDOM {
   }
 
   add_layout(renderer: Annotation | GuideRenderer, side: Place = "center"): void {
-    const side_renderers = this.getv(side)
-    side_renderers.push(renderer as any /* XXX */)
+    const side_renderers = this.properties[side].get_value()
+    side_renderers.push(renderer)
   }
 
   remove_layout(renderer: Annotation | GuideRenderer): void {

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -1020,7 +1020,7 @@ export class PlotView extends LayoutDOMView {
 
     if (this.visuals.outline_line.doit) {
       ctx.save()
-      this.visuals.outline_line.set_value(ctx)
+      this.visuals.outline_line.set_scalar(ctx)
       let [x0, y0, w, h] = frame_box
       // XXX: shrink outline region by 1px to make right and bottom lines visible
       // if they are on the edge of the canvas.
@@ -1079,13 +1079,13 @@ export class PlotView extends LayoutDOMView {
     ctx.clearRect(cx, cy, cw, ch)
 
     if (this.visuals.border_fill.doit) {
-      this.visuals.border_fill.set_value(ctx)
+      this.visuals.border_fill.set_scalar(ctx)
       ctx.fillRect(cx, cy, cw, ch)
       ctx.clearRect(fx, fy, fw, fh)
     }
 
     if (this.visuals.background_fill.doit) {
-      this.visuals.background_fill.set_value(ctx)
+      this.visuals.background_fill.set_scalar(ctx)
       ctx.fillRect(fx, fy, fw, fh)
     }
   }

--- a/bokehjs/src/lib/models/sources/column_data_source.ts
+++ b/bokehjs/src/lib/models/sources/column_data_source.ts
@@ -170,15 +170,13 @@ export class ColumnDataSource extends ColumnarDataSource {
   attributes_as_json(include_defaults: boolean = true, value_to_json = ColumnDataSource._value_to_json): any {
     const attrs: Attrs = {}
     const obj = this.serializable_attributes()
-    for (const key of keys(obj)) {
-      let value = obj[key]
-      if (key === 'data')
-        value = encode_column_data(value as Data, this._shapes)
-
-      if (include_defaults)
+    for (const key of keys(obj) as (keyof ColumnDataSource.Props)[]) {
+      if (include_defaults || this.properties[key].dirty) {
+        let value = obj[key]
+        if (key === "data")
+          value = encode_column_data(value as Data, this._shapes)
         attrs[key] = value
-      else if (key in this._set_after_defaults)
-        attrs[key] = value
+      }
     }
     return value_to_json("attributes", attrs, this)
   }

--- a/bokehjs/src/lib/models/tiles/tile_renderer.ts
+++ b/bokehjs/src/lib/models/tiles/tile_renderer.ts
@@ -244,7 +244,7 @@ export class TileRendererView extends DataRendererView {
   }
 
   protected _set_rect(): void {
-    const outline_width = this.plot_model.properties.outline_line_width.value()
+    const outline_width = this.plot_model.properties.outline_line_width.scalar()
     const l = this.map_frame._left.value + (outline_width/2)
     const t = this.map_frame._top.value + (outline_width/2)
     const w = this.map_frame._width.value - outline_width

--- a/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
@@ -42,8 +42,7 @@ export class BoxEditToolView extends EditToolView {
               append: boolean, emit: boolean = false): void {
     const renderer = this.model.renderers[0]
     const frame = this.plot_view.frame
-    // Type once dataspecs are typed
-    const glyph: any = renderer.glyph
+    const glyph = renderer.glyph
     const cds = renderer.data_source
     const xscale = frame.xscales[renderer.x_range_name]
     const yscale = frame.yscales[renderer.y_range_name]

--- a/bokehjs/src/lib/models/tools/edit/edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/edit_tool.ts
@@ -94,8 +94,7 @@ export abstract class EditToolView extends GestureToolView {
       const [x, y] = point
       const [px, py] = basepoint
       const [dx, dy] = [x-px, y-py]
-      // Type once dataspecs are typed
-      const glyph: any = renderer.glyph
+      const glyph = renderer.glyph
       const cds = renderer.data_source
       const [xkey, ykey] = [glyph.x.field, glyph.y.field]
       for (const index of cds.selected.indices) {

--- a/bokehjs/src/lib/models/tools/edit/freehand_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/freehand_draw_tool.ts
@@ -19,7 +19,7 @@ export class FreehandDrawToolView extends EditToolView {
 
     const [x, y] = point
     const cds = renderer.data_source
-    const glyph: any = renderer.glyph
+    const glyph = renderer.glyph
     const [xkey, ykey] = [glyph.xs.field, glyph.ys.field]
     if (mode == 'new') {
       this._pop_glyphs(cds, this.model.num_objects)

--- a/bokehjs/src/lib/models/tools/edit/point_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/point_draw_tool.ts
@@ -20,8 +20,7 @@ export class PointDrawToolView extends EditToolView {
     if (point == null)
       return
 
-    // Type once dataspecs are typed
-    const glyph: any = renderer.glyph
+    const glyph = renderer.glyph
     const cds = renderer.data_source
     const [xkey, ykey] = [glyph.x.field, glyph.y.field]
     const [x, y] = point

--- a/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
@@ -36,7 +36,7 @@ export class PolyDrawToolView extends PolyToolView {
     const [x, y] = this._snap_to_vertex(ev, ...point)
 
     const cds = renderer.data_source
-    const glyph: any = renderer.glyph
+    const glyph = renderer.glyph
     const [xkey, ykey] = [glyph.xs.field, glyph.ys.field]
     if (mode == 'new') {
       this._pop_glyphs(cds, this.model.num_objects)
@@ -86,7 +86,7 @@ export class PolyDrawToolView extends PolyToolView {
     for (let i=0; i<this.model.renderers.length; i++) {
       const renderer = this.model.renderers[i]
       const cds = renderer.data_source
-      const glyph: any = renderer.glyph
+      const glyph = renderer.glyph
       const [xkey, ykey] = [glyph.xs.field, glyph.ys.field]
       if (xkey) {
         for (const array of cds.get_array(xkey))
@@ -126,7 +126,7 @@ export class PolyDrawToolView extends PolyToolView {
   _remove(): void {
     const renderer = this.model.renderers[0]
     const cds = renderer.data_source
-    const glyph: any = renderer.glyph
+    const glyph = renderer.glyph
     const [xkey, ykey] = [glyph.xs.field, glyph.ys.field]
     if (xkey) {
       const xidx = cds.data[xkey].length-1
@@ -176,8 +176,7 @@ export class PolyDrawToolView extends PolyToolView {
         continue
 
       const cds = renderer.data_source
-      // Type once dataspecs are typed
-      const glyph: any = renderer.glyph
+      const glyph = renderer.glyph
       const [xkey, ykey] = [glyph.xs.field, glyph.ys.field]
       if (!xkey && !ykey)
         continue

--- a/bokehjs/src/lib/models/tools/edit/poly_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_edit_tool.ts
@@ -30,8 +30,7 @@ export class PolyEditToolView extends PolyToolView {
     // Perform hit testing
     const vertex_selected = this._select_event(ev, false, [this.model.vertex_renderer])
     const point_cds = this.model.vertex_renderer.data_source
-    // Type once dataspecs are typed
-    const point_glyph: any = this.model.vertex_renderer.glyph
+    const point_glyph = this.model.vertex_renderer.glyph
     const [pxkey, pykey] = [point_glyph.x.field, point_glyph.y.field]
     if (vertex_selected.length && this._selected_renderer != null) {
       // Insert a new point after the selected vertex and enter draw mode
@@ -65,7 +64,7 @@ export class PolyEditToolView extends PolyToolView {
     }
 
     const renderer = renderers[0]
-    const glyph: any = renderer.glyph
+    const glyph = renderer.glyph
     const cds = renderer.data_source
     const index = cds.selected.indices[0]
     const [xkey, ykey] = [glyph.xs.field, glyph.ys.field]
@@ -94,7 +93,7 @@ export class PolyEditToolView extends PolyToolView {
     if (this._drawing && this._selected_renderer != null) {
       const renderer = this.model.vertex_renderer
       const cds = renderer.data_source
-      const glyph: any = renderer.glyph
+      const glyph = renderer.glyph
       const point = this._map_drag(ev.sx, ev.sy, renderer)
       if (point == null)
         return
@@ -119,8 +118,7 @@ export class PolyEditToolView extends PolyToolView {
     else if (this._drawing && this._selected_renderer) {
       let [x, y] = point
       const cds = renderer.data_source
-      // Type once dataspecs are typed
-      const glyph: any = renderer.glyph
+      const glyph = renderer.glyph
       const [xkey, ykey] = [glyph.x.field, glyph.y.field]
       const indices = cds.selected.indices
       ;[x, y] = this._snap_to_vertex(ev, x, y)
@@ -152,8 +150,7 @@ export class PolyEditToolView extends PolyToolView {
       return
     const renderer = this.model.vertex_renderer
     const cds = renderer.data_source
-    // Type once dataspecs are typed
-    const glyph: any = renderer.glyph
+    const glyph = renderer.glyph
     const index = cds.selected.indices[0]
     const [xkey, ykey] = [glyph.x.field, glyph.y.field]
     if (xkey) cds.get_array(xkey).splice(index, 1)

--- a/bokehjs/src/lib/models/tools/edit/poly_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_tool.ts
@@ -15,7 +15,7 @@ export class PolyToolView extends EditToolView {
   model: PolyTool
 
   _set_vertices(xs: number[] | number, ys: number[] | number): void {
-    const point_glyph: any = this.model.vertex_renderer.glyph
+    const point_glyph = this.model.vertex_renderer.glyph
     const point_cds = this.model.vertex_renderer.data_source
     const [pxkey, pykey] = [point_glyph.x.field, point_glyph.y.field]
     if (pxkey) {
@@ -42,8 +42,7 @@ export class PolyToolView extends EditToolView {
       // If an existing vertex is hit snap to it
       const vertex_selected = this._select_event(ev, false, [this.model.vertex_renderer])
       const point_ds = this.model.vertex_renderer.data_source
-      // Type once dataspecs are typed
-      const point_glyph: any = this.model.vertex_renderer.glyph
+      const point_glyph = this.model.vertex_renderer.glyph
       const [pxkey, pykey] = [point_glyph.x.field, point_glyph.y.field]
       if (vertex_selected.length) {
         const index = point_ds.selected.indices[0]

--- a/bokehjs/src/lib/models/tools/gestures/range_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/range_tool.ts
@@ -135,7 +135,7 @@ export class RangeToolView extends GestureToolView {
     const overlay = this.model.overlay
     const {left, right, top, bottom} = overlay
 
-    const tolerance = this.model.overlay.properties.line_width.value() + EDGE_TOLERANCE
+    const tolerance = this.model.overlay.properties.line_width.scalar() + EDGE_TOLERANCE
 
     if (xr != null && this.model.x_interaction) {
       if (is_near(ev.sx, left, xscale, tolerance))

--- a/bokehjs/test/unit/core/has_props.ts
+++ b/bokehjs/test/unit/core/has_props.ts
@@ -66,7 +66,7 @@ class SubclassWithOptionalSpec extends HasProps {
   baz: any // XXX
 }
 SubclassWithOptionalSpec.define<any>({
-  foo: [ p.NumberSpec, {value: null}      ],
+  foo: [ p.NumberSpec, {value: null}, {optional: true} ],
   bar: [ p.Boolean,    true               ],
   baz: [ p.NumberSpec, {field: 'colname'} ],
 })
@@ -148,7 +148,6 @@ describe("has_properties module", () => {
     it("should collect ignore optional specs with null values", () => {
       const r = new ColumnDataSource({data: {colname: [1, 2, 3, 4]}})
       const obj = new SubclassWithOptionalSpec()
-      obj.properties.foo.optional = true
       const data = obj.materialize_dataspecs(r)
       expect(data).to.be.deep.equal({_baz: [1, 2, 3, 4]})
     })

--- a/bokehjs/test/unit/core/properties.ts
+++ b/bokehjs/test/unit/core/properties.ts
@@ -298,17 +298,17 @@ describe("properties module", () => {
         })
       })
 
-      describe("transform", () => {
+      describe("normalize", () => {
         it("should be the identity", () => {
-          expect(p.Property.prototype.transform(10)).to.be.equal(10)
-          expect(p.Property.prototype.transform("foo")).to.be.equal("foo")
-          expect(p.Property.prototype.transform(null)).to.be.null
+          expect(p.Property.prototype.normalize(10)).to.be.equal(10)
+          expect(p.Property.prototype.normalize("foo")).to.be.equal("foo")
+          expect(p.Property.prototype.normalize(null)).to.be.null
         })
 
         it("should return the same type as passed", () => {
-          const r1 = p.Number.prototype.transform([10, 20, 30])
+          const r1 = p.Number.prototype.normalize([10, 20, 30])
           expect(r1).to.be.deep.equal([10, 20, 30])
-          const r2 = p.Number.prototype.transform(new Float64Array([10, 20, 30]))
+          const r2 = p.Number.prototype.normalize(new Float64Array([10, 20, 30]))
           expect(r2).to.be.deep.equal(new Float64Array([10, 20, 30]))
         })
       })
@@ -361,9 +361,9 @@ describe("properties module", () => {
       })
     })
 
-    describe("transform", () => {
-      it("should be Property.transform", () => {
-        expect(prop.transform).to.be.equal(p.Property.prototype.transform)
+    describe("normalize", () => {
+      it("should be Property.normalize", () => {
+        expect(prop.normalize).to.be.equal(p.Property.prototype.normalize)
       })
     })
   })
@@ -382,33 +382,33 @@ describe("properties module", () => {
       })
     })
 
-    describe("transform", () => {
-      it("should be Property.transform", () => {
-        expect(prop.transform).to.be.equal(p.Property.prototype.transform)
+    describe("normalize", () => {
+      it("should be Property.normalize", () => {
+        expect(prop.normalize).to.be.equal(p.Property.prototype.normalize)
       })
     })
   })
 
   describe("Angle", () => {
 
-    describe("transform", () => {
-      it("should be Property.transform", () => {
+    describe("normalize", () => {
+      it("should be Property.normalize", () => {
         const prop = new p.Angle(new SomeHasProps({a: {value: 10}}), 'a')
-        expect(prop.transform).to.be.equal(p.Property.prototype.transform)
+        expect(prop.normalize).to.be.equal(p.Property.prototype.normalize)
       })
     })
   })
 
   describe("AngleSpec", () => {
-    describe("transform", () => {
+    describe("normalize", () => {
       it("should multiply radians by -1", () => {
         const prop = new p.AngleSpec(new SomeHasProps({a: {value: 10, units: "rad"}}), 'a')
-        expect(prop.transform([-10, 0, 10, 20])).to.be.deep.equal([10, -0, -10, -20])
+        expect(prop.normalize([-10, 0, 10, 20])).to.be.deep.equal([10, -0, -10, -20])
       })
 
       it("should convert degrees to -1 * radians", () => {
         const prop = new p.AngleSpec(new SomeHasProps({a: {value: 10, units: "deg"}}), 'a')
-        expect(prop.transform([-180, 0, 180])).to.be.deep.equal([Math.PI, -0, -Math.PI])
+        expect(prop.normalize([-180, 0, 180])).to.be.deep.equal([Math.PI, -0, -Math.PI])
       })
     })
   })
@@ -438,9 +438,9 @@ describe("properties module", () => {
       })
     })
 
-    describe("transform", () => {
-      it("should be Property.transform", () => {
-        expect(prop.transform).to.be.equal(p.Property.prototype.transform)
+    describe("normalize", () => {
+      it("should be Property.normalize", () => {
+        expect(prop.normalize).to.be.equal(p.Property.prototype.normalize)
       })
     })
   })
@@ -470,9 +470,9 @@ describe("properties module", () => {
       })
     })
 
-    describe("transform", () => {
-      it("should be Property.transform", () => {
-        expect(prop.transform).to.be.equal(p.Property.prototype.transform)
+    describe("normalize", () => {
+      it("should be Property.normalize", () => {
+        expect(prop.normalize).to.be.equal(p.Property.prototype.normalize)
       })
     })
   })
@@ -564,9 +564,9 @@ describe("properties module", () => {
       })
     })
 
-    describe("transform", () => {
-      it("should be Property.transform", () => {
-        expect(prop.transform).to.be.equal(p.Property.prototype.transform)
+    describe("normalize", () => {
+      it("should be Property.normalize", () => {
+        expect(prop.normalize).to.be.equal(p.Property.prototype.normalize)
       })
     })
   })
@@ -589,19 +589,19 @@ describe("properties module", () => {
       })
     })
 
-    describe("transform", () => {
+    describe("normalize", () => {
       it("should convert 'clock' to false", () => {
-        const result = prop.transform(["clock"])
+        const result = prop.normalize(["clock"])
         expect(result).to.be.deep.equal(new Uint8Array([0]))
       })
 
       it("should convert 'anticlock' to true", () => {
-        const result = prop.transform(["anticlock"])
+        const result = prop.normalize(["anticlock"])
         expect(result).to.be.deep.equal(new Uint8Array([1]))
       })
 
       it("should return a Uint8Array", () => {
-        const result = prop.transform(["clock", "anticlock"])
+        const result = prop.normalize(["clock", "anticlock"])
         expect(result).to.be.deep.equal(new Uint8Array([0, 1]))
       })
     })
@@ -627,17 +627,17 @@ describe("properties module", () => {
 
       it("should throw an Error on bad units", () => {
         function fn(): void {
-          const x = new SomeHasProps({a: {value: 10, units:"bad"}})
+          const x = new SomeHasProps({a: {value: 10, units: "bad"}})
           new p.DistanceSpec(x, 'a')
         }
         expect(fn).to.throw(Error, "units must be one of screen, data; got: bad")
       })
     })
 
-    describe("transform", () => {
-      it("should be Property.transform", () => {
+    describe("normalize", () => {
+      it("should be Property.normalize", () => {
         const prop = new p.DistanceSpec(new SomeHasProps({a: {value: 10}}), 'a')
-        expect(prop.transform).to.be.equal(p.Property.prototype.transform)
+        expect(prop.normalize).to.be.equal(p.Property.prototype.normalize)
       })
     })
   })
@@ -666,9 +666,9 @@ describe("properties module", () => {
       })
     })
 
-    describe("transform", () => {
-      it("should be Property.transform", () => {
-        expect(prop.transform).to.be.equal(p.Property.prototype.transform)
+    describe("normalize", () => {
+      it("should be Property.normalize", () => {
+        expect(prop.normalize).to.be.equal(p.Property.prototype.normalize)
       })
     })
   })
@@ -691,9 +691,9 @@ describe("properties module", () => {
       })
     })
 
-    describe("transform", () => {
-      it("should be Property.transform", () => {
-        expect(prop.transform).to.be.equal(p.Property.prototype.transform)
+    describe("normalize", () => {
+      it("should be Property.normalize", () => {
+        expect(prop.normalize).to.be.equal(p.Property.prototype.normalize)
       })
     })
   })
@@ -720,9 +720,9 @@ describe("properties module", () => {
       })
     })
 
-    describe("transform", () => {
-      it("should be Property.transform", () => {
-        expect(prop.transform).to.be.equal(p.Property.prototype.transform)
+    describe("normalize", () => {
+      it("should be Property.normalize", () => {
+        expect(prop.normalize).to.be.equal(p.Property.prototype.normalize)
       })
     })
   })
@@ -745,9 +745,9 @@ describe("properties module", () => {
       })
     })
 
-    describe("transform", () => {
-      it("should be Property.transform", () => {
-        expect(prop.transform).to.be.equal(p.Property.prototype.transform)
+    describe("normalize", () => {
+      it("should be Property.normalize", () => {
+        expect(prop.normalize).to.be.equal(p.Property.prototype.normalize)
       })
     })
   })
@@ -770,9 +770,9 @@ describe("properties module", () => {
       })
     })
 
-    describe("transform", () => {
-      it("should be Property.transform", () => {
-        expect(prop.transform).to.be.equal(p.Property.prototype.transform)
+    describe("normalize", () => {
+      it("should be Property.normalize", () => {
+        expect(prop.normalize).to.be.equal(p.Property.prototype.normalize)
       })
     })
   })
@@ -795,9 +795,9 @@ describe("properties module", () => {
       })
     })
 
-    describe("transform", () => {
-      it("should be Property.transform", () => {
-        expect(prop.transform).to.be.equal(p.Property.prototype.transform)
+    describe("normalize", () => {
+      it("should be Property.normalize", () => {
+        expect(prop.normalize).to.be.equal(p.Property.prototype.normalize)
       })
     })
   })
@@ -826,9 +826,9 @@ describe("properties module", () => {
       })
     })
 
-    describe("transform", () => {
-      it("should be Property.transform", () => {
-        expect(prop.transform).to.be.equal(p.Property.prototype.transform)
+    describe("normalize", () => {
+      it("should be Property.normalize", () => {
+        expect(prop.normalize).to.be.equal(p.Property.prototype.normalize)
       })
     })
   })
@@ -851,9 +851,9 @@ describe("properties module", () => {
       })
     })
 
-    describe("transform", () => {
-      it("should be Property.transform", () => {
-        expect(prop.transform).to.be.equal(p.Property.prototype.transform)
+    describe("normalize", () => {
+      it("should be Property.normalize", () => {
+        expect(prop.normalize).to.be.equal(p.Property.prototype.normalize)
       })
     })
   })
@@ -876,9 +876,9 @@ describe("properties module", () => {
       })
     })
 
-    describe("transform", () => {
-      it("should be Property.transform", () => {
-        expect(prop.transform).to.be.equal(p.Property.prototype.transform)
+    describe("normalize", () => {
+      it("should be Property.normalize", () => {
+        expect(prop.normalize).to.be.equal(p.Property.prototype.normalize)
       })
     })
   })
@@ -901,9 +901,9 @@ describe("properties module", () => {
       })
     })
 
-    describe("transform", () => {
-      it("should be Property.transform", () => {
-        expect(prop.transform).to.be.equal(p.Property.prototype.transform)
+    describe("normalize", () => {
+      it("should be Property.normalize", () => {
+        expect(prop.normalize).to.be.equal(p.Property.prototype.normalize)
       })
     })
   })
@@ -933,9 +933,9 @@ describe("properties module", () => {
       })
     })
 
-    describe("transform", () => {
-      it("should be Property.transform", () => {
-        expect(prop.transform).to.be.equal(p.Property.prototype.transform)
+    describe("normalize", () => {
+      it("should be Property.normalize", () => {
+        expect(prop.normalize).to.be.equal(p.Property.prototype.normalize)
       })
     })
   })
@@ -958,9 +958,9 @@ describe("properties module", () => {
       })
     })
 
-    describe("transform", () => {
-      it("should be Property.transform", () => {
-        expect(prop.transform).to.be.equal(p.Property.prototype.transform)
+    describe("normalize", () => {
+      it("should be Property.normalize", () => {
+        expect(prop.normalize).to.be.equal(p.Property.prototype.normalize)
       })
     })
   })
@@ -983,9 +983,9 @@ describe("properties module", () => {
       })
     })
 
-    describe("transform", () => {
-      it("should be Property.transform", () => {
-        expect(prop.transform).to.be.equal(p.Property.prototype.transform)
+    describe("normalize", () => {
+      it("should be Property.normalize", () => {
+        expect(prop.normalize).to.be.equal(p.Property.prototype.normalize)
       })
     })
   })

--- a/bokehjs/test/unit/core/properties.ts
+++ b/bokehjs/test/unit/core/properties.ts
@@ -168,25 +168,25 @@ describe("properties module", () => {
     describe("value", () => {
       it("should return a value if there is a value spec", () => {
         const p1 = new MyProperty(new SomeHasProps(fixed), 'a')
-        expect(p1.value()).to.be.equal(1)
+        expect(p1.scalar()).to.be.equal(1)
         const p2 = new MyProperty(new SomeHasProps(spec_value), 'a')
-        expect(p2.value()).to.be.equal(2)
+        expect(p2.scalar()).to.be.equal(2)
       })
 
       it("should return a transformed value if there is a value spec with transform", () => {
         const prop = new MyProperty(new SomeHasProps(spec_value_trans), 'a')
-        expect(prop.value()).to.be.equal(3)
+        expect(prop.scalar()).to.be.equal(3)
       })
 
       it("should allow a fixed null value", () => {
         const prop = new MyProperty(new SomeHasProps(spec_value_null), 'a')
-        expect(prop.value()).to.be.null
+        expect(prop.scalar()).to.be.null
       })
 
       it("should throw an Error otherwise", () => {
         function fn(): void {
           const prop = new MyProperty(new SomeHasProps(spec_field_only), 'a')
-          prop.value()
+          prop.scalar()
         }
         expect(fn).to.throw(Error, "attempted to retrieve property value for property without value specification")
       })

--- a/bokehjs/test/unit/core/visuals.ts
+++ b/bokehjs/test/unit/core/visuals.ts
@@ -21,7 +21,7 @@ describe("Fill", () => {
         attrs[spec] = {value}
         const model = new Circle(attrs)
         const fill = new Fill(model)
-        fill.set_value(ctx)
+        fill.set_scalar(ctx)
         expect(ctx[attr]).to.be.equal(value)
       })
     }
@@ -72,7 +72,7 @@ describe("Line", () => {
         attrs[spec] = {value}
         const model = new Circle(attrs)
         const line = new Line(model)
-        line.set_value(ctx)
+        line.set_scalar(ctx)
         expect(ctx[attr]).to.be.equal(value)
         expect(ctx.lineDash).to.be.deep.equal([1, 2])
       })
@@ -123,7 +123,7 @@ describe("Text", () => {
         attrs[spec] = {value}
         const model = new text_glyph.Text(attrs)
         const text = new Text(model)
-        text.set_value(ctx)
+        text.set_scalar(ctx)
         expect(ctx[attr]).to.be.equal(value)
         expect(ctx.font).to.be.equal("bold 12pt times")
       })


### PR DESCRIPTION
This is an early WIP preview.

The primary goal of this work is to separate concerns between `HasProps` and the properties system. The current situation is a mess, where value storage is duplicated (`HasProps.attributes` and `Property.spec`), models and properties communicate over signals when changes occur (which negatively affects performance), the logic is hard to reason about, static typing isn't great and other code (e.g. visuals) uses private implementation details all over the place. This PR is a preparatory step for future work on the properties system (e.g. #9518) and in aiding in splitting up bokehjs (#9296).

In this PR the burden of managing values and data is a sole responsibility of properties. `HasProps` role is to manage properties and coordinate changes across their subsets. A clear separation between (primitive) properties and specs (scalar, vector; units) is introduced, in hope to to allow splitting up generic bokehjs code from visual-related (e.g. using just layouts or widgets, without plotting, shouldn't require specs, visuals, etc.).