### PR TITLE
Touch events on iOS 13.x workaround

### DIFF
--- a/bokehjs/src/lib/core/ui_events.ts
+++ b/bokehjs/src/lib/core/ui_events.ts
@@ -105,7 +105,7 @@ export class UIEvents implements EventListenerObject {
   readonly keydown:      UISignal<KeyEvent>     = new Signal(this, 'keydown')
   readonly keyup:        UISignal<KeyEvent>     = new Signal(this, 'keyup')
 
-  private readonly hammer = new Hammer(this.hit_area, {touchAction: 'auto'})
+  private readonly hammer = new Hammer(this.hit_area, {touchAction: 'auto', inputClass: Hammer.TouchMouseInput})
 
   constructor(readonly plot_view: PlotView,
               readonly toolbar: Toolbar,

--- a/bokehjs/src/lib/core/ui_events.ts
+++ b/bokehjs/src/lib/core/ui_events.ts
@@ -107,7 +107,7 @@ export class UIEvents implements EventListenerObject {
 
   private readonly hammer = new Hammer(this.hit_area, {
     touchAction: 'auto',
-    inputClass: Hammer.TouchMouseInput // https://github.com/bokeh/bokeh/issues/9187
+    inputClass: Hammer.TouchMouseInput, // https://github.com/bokeh/bokeh/issues/9187
   })
 
   constructor(readonly plot_view: PlotView,

--- a/bokehjs/src/lib/core/ui_events.ts
+++ b/bokehjs/src/lib/core/ui_events.ts
@@ -105,7 +105,10 @@ export class UIEvents implements EventListenerObject {
   readonly keydown:      UISignal<KeyEvent>     = new Signal(this, 'keydown')
   readonly keyup:        UISignal<KeyEvent>     = new Signal(this, 'keyup')
 
-  private readonly hammer = new Hammer(this.hit_area, {touchAction: 'auto', inputClass: Hammer.TouchMouseInput})
+  private readonly hammer = new Hammer(this.hit_area, {
+    touchAction: 'auto',
+    inputClass: Hammer.TouchMouseInput // https://github.com/bokeh/bokeh/issues/9187
+  })
 
   constructor(readonly plot_view: PlotView,
               readonly toolbar: Toolbar,


### PR DESCRIPTION
Hammer.js has several issues related to Pointer Event implementation.
iOS 13 delivered built-in PointerEvents in Safari which made Hammer's touch recognisers (pan, pinch, swipe) behave incorrectly in certain cases.

However, most of problems may be addressed with Hammer's constructor options.
`Hammer.TouchMouseInput` does a trick for Pinch and Pan Tools in Bokeh.

- [x] issues: resolves #9187
- [ ] tests added / passed
