### PR TITLE
Support TickFormatter instances in RangeSlider

### DIFF
--- a/bokeh/models/widgets/sliders.py
+++ b/bokeh/models/widgets/sliders.py
@@ -28,8 +28,10 @@ from ...core.properties import (
     Bool,
     Color,
     Datetime,
+    Either,
     Enum,
     Float,
+    Instance,
     Int,
     Override,
     String,
@@ -37,6 +39,7 @@ from ...core.properties import (
 )
 from ...core.validation import error
 from ...core.validation.errors import EQUAL_SLIDER_START_END
+from ..formatters import TickFormatter
 from .widget import Widget
 
 #-----------------------------------------------------------------------------
@@ -63,6 +66,7 @@ class AbstractSlider(Widget):
         if 'start' in kwargs and 'end' in kwargs:
             if kwargs['start'] == kwargs['end']:
                 raise ValueError("Slider 'start' and 'end' cannot be equal.")
+
         super().__init__(**kwargs)
 
     title = String(default="", help="""
@@ -73,7 +77,7 @@ class AbstractSlider(Widget):
     Whether or not show slider's value.
     """)
 
-    format = String(help="""
+    format = Either(String, Instance(TickFormatter), help="""
     """)
 
     direction = Enum("ltr", "rtl", help="""

--- a/bokehjs/src/lib/models/widgets/abstract_slider.ts
+++ b/bokehjs/src/lib/models/widgets/abstract_slider.ts
@@ -8,6 +8,7 @@ import {repeat} from "core/util/array"
 import {Control, ControlView} from "./control"
 
 import {bk_slider_value, bk_slider_title, bk_input_group} from "styles/widgets/sliders"
+import {TickFormatter} from "../formatters/tick_formatter"
 
 const prefix = 'bk-noUi-'
 
@@ -260,7 +261,7 @@ export namespace AbstractSlider {
     value: p.Property<any> // XXX
     value_throttled: p.Property<any> // XXX
     step: p.Property<number>
-    format: p.Property<string>
+    format: p.Property<string | TickFormatter>
     direction: p.Property<"ltr" | "rtl">
     tooltips: p.Property<boolean>
     bar_color: p.Property<Color>
@@ -285,7 +286,7 @@ export abstract class AbstractSlider extends Control {
       value:             [ p.Any                                ],
       value_throttled:   [ p.Any                                ],
       step:              [ p.Number,               1            ],
-      format:            [ p.String                             ],
+      format:            [ p.Any                                ],
       direction:         [ p.Any,                  "ltr"        ],
       tooltips:          [ p.Boolean,              true         ],
       bar_color:         [ p.Color,                "#e6e6e6"    ],
@@ -295,7 +296,7 @@ export abstract class AbstractSlider extends Control {
   behaviour: "drag" | "tap"
   connected: false | boolean[] = false
 
-  protected _formatter(value: number, _format: string): string {
+  protected _formatter(value: number, _format: string | TickFormatter): string {
     return `${value}`
   }
 

--- a/bokehjs/src/lib/models/widgets/date_slider.ts
+++ b/bokehjs/src/lib/models/widgets/date_slider.ts
@@ -1,5 +1,6 @@
-import {AbstractSlider, AbstractSliderView} from "./abstract_slider"
 import tz from "timezone"
+
+import {AbstractSlider, AbstractSliderView} from "./abstract_slider"
 import * as p from "core/properties"
 
 export class DateSliderView extends AbstractSliderView {

--- a/bokehjs/src/lib/models/widgets/range_slider.ts
+++ b/bokehjs/src/lib/models/widgets/range_slider.ts
@@ -2,6 +2,8 @@ import * as numbro from "numbro"
 
 import {AbstractSlider, AbstractRangeSliderView} from "./abstract_slider"
 import * as p from "core/properties"
+import {isString} from "core/util/types"
+import {TickFormatter} from "../formatters/tick_formatter"
 
 export class RangeSliderView extends AbstractRangeSliderView {
   model: RangeSlider
@@ -33,7 +35,11 @@ export class RangeSlider extends AbstractSlider {
   behaviour = "drag" as "drag"
   connected = [false, true, false]
 
-  protected _formatter(value: number, format: string): string {
-    return numbro.format(value, format)
+  protected _formatter(value: number, format: string | TickFormatter): string {
+    if (isString(format)){
+      return numbro.format(value, format)
+    } else {
+      return format.doFormat([value], {loc: 0})[0]
+    }
   }
 }

--- a/bokehjs/src/lib/models/widgets/slider.ts
+++ b/bokehjs/src/lib/models/widgets/slider.ts
@@ -2,6 +2,8 @@ import * as numbro from "numbro"
 
 import {AbstractSlider, AbstractSliderView} from "./abstract_slider"
 import * as p from "core/properties"
+import {isString} from "core/util/types"
+import {TickFormatter} from "../formatters/tick_formatter"
 
 export class SliderView extends AbstractSliderView {
   model: Slider
@@ -33,7 +35,11 @@ export class Slider extends AbstractSlider {
   behaviour = "tap" as "tap"
   connected = [true, false]
 
-  protected _formatter(value: number, format: string): string {
-    return numbro.format(value, format)
+  protected _formatter(value: number, format: string | TickFormatter): string {
+    if (isString(format)){
+      return numbro.format(value, format)
+    } else {
+      return format.doFormat([value], {loc: 0})[0]
+    }
   }
 }

--- a/tests/integration/widgets/test_range_slider.py
+++ b/tests/integration/widgets/test_range_slider.py
@@ -35,6 +35,7 @@ from bokeh.models import (
     Range1d,
     RangeSlider,
 )
+from bokeh.models.formatters import BasicTickFormatter
 
 #-----------------------------------------------------------------------------
 # Tests
@@ -91,6 +92,20 @@ class Test_RangeSlider(object):
 
         assert get_title_text(page.driver, ".foo") == "bar: 1 .. 5"
         assert get_title_value(page.driver, ".foo") == "1 .. 5"
+
+        assert page.has_no_console_errors()
+
+    def test_displays_title_scientific(self, bokeh_model_page) -> None:
+        slider = RangeSlider(start=0, end=10e-6, step=1e-6, value=(1e-6, 8e-6), title="bar",
+            format=BasicTickFormatter(precision=2), css_classes=["foo"], width=300)
+
+        page = bokeh_model_page(slider)
+
+        el = page.driver.find_element_by_css_selector('.foo')
+        assert len(el.find_elements_by_css_selector('div.bk-input-group > div')) == 2
+
+        assert get_title_text(page.driver, ".foo") == "bar: 1.00e-6 .. 8.00e-6"
+        assert get_title_value(page.driver, ".foo") == "1.00e-6 .. 8.00e-6"
 
         assert page.has_no_console_errors()
 


### PR DESCRIPTION
Fixes #9469 as a non-general solution. A better solution would be to be to implement a general formatter attribute which takes a TickFormatter instance.

Now we can do following:

```python
from bokeh.io import output_file, show
from bokeh.layouts import column
from bokeh.models.widgets import RangeSlider
from bokeh.models.formatters import BasicTickFormatter

output_file("range_slider.html", mode="inline")

# will print a warning
range_slider_small = RangeSlider(start=1e-7, end=10e-7, value=(1e-7,8e-7), step=1e-7, title="Bla", format="0[.]00") 

# will print a warning
range_slider_large = RangeSlider(start=1e7, end=10e7, value=(2e7,8e7), step=1e6, title="Bla", format="0a")

# New
range_slider_custom = RangeSlider(start=1e-7, end=10e-7, value=(1e-7,8e-7), step=1e-7, title="Bla",
 formatter=BasicTickFormatter(precision=2))

# default behaviour
range_slider_default = RangeSlider(start=1e7, end=10e7, value=(2e7,8e7), step=1e6, title="Bla")

show(column(range_slider_small, range_slider_large, range_slider_custom, range_slider_default))
```
Result:

![image](https://user-images.githubusercontent.com/12762439/73611416-f5156680-45e1-11ea-8dd3-a3f4520ccd27.png)

This is my first OS contribution, so please do not hesitate to comment on my PR.

- [x] issues: fixes #9469
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

I was thinking to support for all AbstractSlider subclasses, what do you think?