### PR TITLE
Prevent hover from overflowing on right side of screen

### DIFF
--- a/bokehjs/src/lib/models/annotations/tooltip.ts
+++ b/bokehjs/src/lib/models/annotations/tooltip.ts
@@ -56,6 +56,7 @@ export class TooltipView extends AnnotationView {
       return
 
     const {frame} = this.plot_view
+    console.log(this)
 
     for (const [sx, sy, content] of data) {
       if (this.model.inner_only && !frame.bbox.contains(sx, sy))
@@ -80,7 +81,9 @@ export class TooltipView extends AnnotationView {
 
     // slightly confusing: side "left" (for example) is relative to point that
     // is being annotated but CS class ".bk-left" is relative to the tooltip itself
-    let left: number, top: number
+    let top: number
+    let left = 0
+    let right = 0
     switch (side) {
       case "right":
         this.el.classList.add(bk_left)
@@ -89,7 +92,7 @@ export class TooltipView extends AnnotationView {
         break
       case "left":
         this.el.classList.add(bk_right)
-        left = sx - this.el.offsetWidth - arrow_size
+        right = (this.ctx.canvas.width - sx) + arrow_size
         top = sy - this.el.offsetHeight/2
         break
       case "below":
@@ -112,7 +115,8 @@ export class TooltipView extends AnnotationView {
     // be problematic
     if (this.el.childNodes.length > 0) {
       this.el.style.top = `${top}px`
-      this.el.style.left = `${left}px`
+      this.el.style.left = left ? `${left}px` : 'unset'
+      this.el.style.right = right ? `${right}px` : 'unset'
     } else
       undisplay(this.el)
   }

--- a/bokehjs/src/lib/models/annotations/tooltip.ts
+++ b/bokehjs/src/lib/models/annotations/tooltip.ts
@@ -114,8 +114,8 @@ export class TooltipView extends AnnotationView {
     // be problematic
     if (this.el.childNodes.length > 0) {
       this.el.style.top = `${top}px`
-      this.el.style.left = left ? `${left}px` : 'unset'
-      this.el.style.right = right ? `${right}px` : 'unset'
+      this.el.style.left = left ? `${left}px` : 'inherit'
+      this.el.style.right = right ? `${right}px` : 'inherit'
     } else
       undisplay(this.el)
   }

--- a/bokehjs/src/lib/models/annotations/tooltip.ts
+++ b/bokehjs/src/lib/models/annotations/tooltip.ts
@@ -56,7 +56,6 @@ export class TooltipView extends AnnotationView {
       return
 
     const {frame} = this.plot_view
-    console.log(this)
 
     for (const [sx, sy, content] of data) {
       if (this.model.inner_only && !frame.bbox.contains(sx, sy))

--- a/bokehjs/src/lib/models/annotations/tooltip.ts
+++ b/bokehjs/src/lib/models/annotations/tooltip.ts
@@ -83,6 +83,7 @@ export class TooltipView extends AnnotationView {
     let top: number
     let left = 0
     let right = 0
+
     switch (side) {
       case "right":
         this.el.classList.add(bk_left)
@@ -91,7 +92,7 @@ export class TooltipView extends AnnotationView {
         break
       case "left":
         this.el.classList.add(bk_right)
-        right = (this.ctx.canvas.width - sx) + arrow_size
+        right = (this.plot_view.layout.bbox.width - sx) + arrow_size
         top = sy - this.el.offsetHeight/2
         break
       case "below":


### PR DESCRIPTION
- [x] issues: fixes #2673
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

Try it out:

```python
from bokeh.plotting import figure, output_file, show, ColumnDataSource
from bokeh.models import HoverTool

output_file("toolbar.html")

source = ColumnDataSource(data=dict(
    x=[1, 2, 3, 4, 5],
    y=[2, 5, 8, 2, 7],
    desc= ['bbb'] + ['aaaaa ' * 100 for i in range(4)]
))

hover = HoverTool(tooltips=[
    ("index", "$index"),
    ("(x,y)", "($x, $y)"),
    ("desc", "@desc"),
])

p = figure(tools=[hover],sizing_mode="stretch_both",
           title="Mouse over the dots")

p.circle('x', 'y', size=20, source=source)

show(p)
```