### PR TITLE
Implicitly apply pytest.mark.asyncio to async defs

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -16,11 +16,12 @@ from inspect import iscoroutinefunction
 from typing import List
 
 # External imports
-import pytest
 import _pytest
+import pytest
 
 # Bokeh imports
 from bokeh._testing.util.git import version_from_git
+
 
 def pytest_collection_modifyitems(items: List[_pytest.nodes.Item]) -> None:
     for item in items:

--- a/conftest.py
+++ b/conftest.py
@@ -11,12 +11,24 @@ pytest_plugins = (
     "bokeh._testing.plugins.pandas",
 )
 
+# Standard library imports
+from inspect import iscoroutinefunction
+from typing import List
+
+# External imports
+import pytest
+import _pytest
+
 # Bokeh imports
 from bokeh._testing.util.git import version_from_git
 
+def pytest_collection_modifyitems(items: List[_pytest.nodes.Item]) -> None:
+    for item in items:
+        if iscoroutinefunction(item.obj):
+            item.add_marker(pytest.mark.asyncio)
 
 # Unfortunately these seem to all need to be centrally defined at the top level
-def pytest_addoption(parser):
+def pytest_addoption(parser: _pytest.config.argparsing.Parser) -> None:
 
     # plugins/selenium
     parser.addoption(

--- a/tests/unit/bokeh/application/handlers/test_directory.py
+++ b/tests/unit/bokeh/application/handlers/test_directory.py
@@ -268,7 +268,6 @@ some.foo = 57
         assert "on_session_created" == await handler.on_session_created(None)
         assert "on_session_destroyed" == await handler.on_session_destroyed(None)
 
-    @pytest.mark.asyncio
     async def test_directory_with_app_hooks(self) -> None:
         doc = Document()
         result = {}
@@ -295,7 +294,6 @@ some.foo = 57
         assert "on_session_destroyed" == await handler.on_session_destroyed(None)
         assert dict(foo=10) == handler.process_request(dict(headers=dict(foo=10)))
 
-    @pytest.mark.asyncio
     async def test_directory_with_lifecycle_and_app_hooks_errors(self) -> None:
         def load(filename):
             with pytest.raises(ValueError):
@@ -308,7 +306,6 @@ some.foo = 57
             'server_lifecycle.py': script_has_request_handler
         }, load)
 
-    @pytest.mark.asyncio
     async def test_directory_with_request_handler(self) -> None:
         doc = Document()
         result = {}

--- a/tests/unit/bokeh/application/handlers/test_directory.py
+++ b/tests/unit/bokeh/application/handlers/test_directory.py
@@ -236,7 +236,6 @@ some.foo = 57
         assert some_model.foo == 2
         assert another_model.bar == 1
 
-    @pytest.mark.asyncio
     async def test_directory_with_server_lifecycle(self) -> None:
         doc = Document()
         result = {}

--- a/tests/unit/bokeh/application/handlers/test_document_lifecycle.py
+++ b/tests/unit/bokeh/application/handlers/test_document_lifecycle.py
@@ -58,7 +58,6 @@ class Test_DocumentLifecycleHandler(object):
         with pytest.raises(ValueError):
             doc.on_session_destroyed(destroy)
 
-    @pytest.mark.asyncio
     async def test_document_on_session_destroyed(self) -> None:
         doc = Document()
         handler = bahd.DocumentLifecycleHandler()
@@ -74,7 +73,6 @@ class Test_DocumentLifecycleHandler(object):
         assert session_context.status == 'Destroyed'
         assert session_context._document.session_destroyed_callbacks == set()
 
-    @pytest.mark.asyncio
     async def test_document_on_session_destroyed_calls_multiple(self) -> None:
         doc = Document()
 
@@ -93,7 +91,6 @@ class Test_DocumentLifecycleHandler(object):
         await handler.on_session_destroyed(session_context)
         assert session_context.counter == 3, 'DocumentLifecycleHandler did not call all callbacks'
 
-    @pytest.mark.asyncio
     async def test_document_on_session_destroyed_exceptions(self, caplog) -> None:
         doc = Document()
 

--- a/tests/unit/bokeh/application/handlers/test_handler.py
+++ b/tests/unit/bokeh/application/handlers/test_handler.py
@@ -52,7 +52,6 @@ class Test_Handler(object):
         assert h.on_server_loaded("context") is None
         assert h.on_server_unloaded("context") is None
 
-    @pytest.mark.asyncio
     async def test_default_sesssion_hooks_return_none(self) -> None:
         h = bahh.Handler()
         assert await h.on_session_created("context") is None

--- a/tests/unit/bokeh/application/handlers/test_server_lifecycle.py
+++ b/tests/unit/bokeh/application/handlers/test_server_lifecycle.py
@@ -48,7 +48,6 @@ class Test_ServerLifecycleHandler(object):
 
     # Public methods ----------------------------------------------------------
 
-    @pytest.mark.asyncio
     async def test_empty_lifecycle(self) -> None:
         doc = Document()
         out = {}
@@ -150,7 +149,6 @@ def on_session_destroyed(a,b):
         assert 'on_session_destroyed must have signature func(session_context)' in handler.error
         assert 'func(a, b)' in handler.error
 
-    @pytest.mark.asyncio
     async def test_calling_lifecycle_hooks(self) -> None:
         result = {}
         def load(filename):

--- a/tests/unit/bokeh/application/handlers/test_server_request_handler.py
+++ b/tests/unit/bokeh/application/handlers/test_server_request_handler.py
@@ -97,7 +97,6 @@ def process_request(a,b):
         with pytest.raises(ValueError):
             basrh.ServerRequestHandler()
 
-    @pytest.mark.asyncio
     async def test_empty_request_handler(self) -> None:
         out = {}
         def load(filename):
@@ -110,7 +109,6 @@ def process_request(a,b):
             raise RuntimeError(handler.error)
         assert payload == {}
 
-    @pytest.mark.asyncio
     async def test_calling_request_handler(self) -> None:
         result = {}
         def load(filename):

--- a/tests/unit/bokeh/client/test_states.py
+++ b/tests/unit/bokeh/client/test_states.py
@@ -45,31 +45,26 @@ class MockMessage(object):
 #-----------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_NOT_YET_CONNECTED() -> None:
     s = bcs.NOT_YET_CONNECTED()
     r = await s.run(MockConnection())
     assert r == "_connect_async"
 
-@pytest.mark.asyncio
 async def test_CONNECTED_BEFORE_ACK() -> None:
     s = bcs.CONNECTED_BEFORE_ACK()
     r = await s.run(MockConnection())
     assert r == "_wait_for_ack"
 
-@pytest.mark.asyncio
 async def test_CONNECTED_AFTER_ACK() -> None:
     s = bcs.CONNECTED_AFTER_ACK()
     r = await s.run(MockConnection())
     assert r == "_handle_messages"
 
-@pytest.mark.asyncio
 async def test_DISCONNECTED() -> None:
     s = bcs.DISCONNECTED()
     r = await s.run(MockConnection())
     assert r is None
 
-@pytest.mark.asyncio
 async def test_WAITING_FOR_REPLY() -> None:
     s = bcs.WAITING_FOR_REPLY("reqid")
     assert s.reply == None

--- a/tests/unit/bokeh/protocol/test_receiver.py
+++ b/tests/unit/bokeh/protocol/test_receiver.py
@@ -34,7 +34,6 @@ proto = Protocol()
 def test_creation() -> None:
     receiver.Receiver(None)
 
-@pytest.mark.asyncio
 async def test_validation_success() -> None:
     msg = proto.create('ACK')
     r = receiver.Receiver(proto)
@@ -52,7 +51,6 @@ async def test_validation_success() -> None:
     assert partial.content == msg.content
     assert partial.metadata == msg.metadata
 
-@pytest.mark.asyncio
 async def test_validation_success_with_one_buffer() -> None:
     r = receiver.Receiver(proto)
 
@@ -76,7 +74,6 @@ async def test_validation_success_with_one_buffer() -> None:
     assert partial.metadata == {}
     assert partial.buffers == [('header', b'payload')]
 
-@pytest.mark.asyncio
 async def test_multiple_validation_success_with_multiple_buffers() -> None:
     r = receiver.Receiver(proto)
 
@@ -96,14 +93,12 @@ async def test_multiple_validation_success_with_multiple_buffers() -> None:
         assert partial.metadata == {}
         assert partial.buffers == [('header%d' % i, b'payload%d' %i) for i in range(N)]
 
-@pytest.mark.asyncio
 async def test_binary_header_raises_error() -> None:
     r = receiver.Receiver(proto)
 
     with pytest.raises(ValidationError):
         await r.consume(b'header')
 
-@pytest.mark.asyncio
 async def test_binary_metadata_raises_error() -> None:
     r = receiver.Receiver(proto)
 
@@ -111,7 +106,6 @@ async def test_binary_metadata_raises_error() -> None:
     with pytest.raises(ValidationError):
         await r.consume(b'metadata')
 
-@pytest.mark.asyncio
 async def test_binary_content_raises_error() -> None:
     r = receiver.Receiver(proto)
 
@@ -120,7 +114,6 @@ async def test_binary_content_raises_error() -> None:
     with pytest.raises(ValidationError):
         await r.consume(b'content')
 
-@pytest.mark.asyncio
 async def test_binary_payload_header_raises_error() -> None:
     r = receiver.Receiver(proto)
 
@@ -129,7 +122,6 @@ async def test_binary_payload_header_raises_error() -> None:
     await r.consume('{}')
     with pytest.raises(ValidationError):
         await r.consume(b'buf_header')
-@pytest.mark.asyncio
 async def test_text_payload_buffer_raises_error() -> None:
     r = receiver.Receiver(proto)
 

--- a/tests/unit/bokeh/server/test_auth_provider.py
+++ b/tests/unit/bokeh/server/test_auth_provider.py
@@ -142,7 +142,6 @@ def get_user(handler): return 10
 login_url = "/foo"
         """, func, suffix='.py')
 
-    @pytest.mark.asyncio
     async def test_get_user_async(self) -> None:
         async def func(filename):
             am = bsa.AuthModule(filename)

--- a/tests/unit/bokeh/server/test_contexts.py
+++ b/tests/unit/bokeh/server/test_contexts.py
@@ -103,7 +103,6 @@ class TestApplicationContext(object):
             c.get_session("bax")
         assert str(e.value).endswith("No such session bax")
 
-    @pytest.mark.asyncio
     async def test_create_session_if_needed_new(self) -> None:
         app = Application()
         c = bsc.ApplicationContext(app, io_loop="ioloop")
@@ -113,7 +112,6 @@ class TestApplicationContext(object):
         s = await c.create_session_if_needed("foo", request=req)
         assert c.get_session("foo") == s
 
-    @pytest.mark.asyncio
     async def test_create_session_if_needed_exists(self) -> None:
         app = Application()
         c = bsc.ApplicationContext(app, io_loop="ioloop")
@@ -124,7 +122,6 @@ class TestApplicationContext(object):
         s2 = await c.create_session_if_needed("foo", request=req)
         assert s1 == s2
 
-    @pytest.mark.asyncio
     async def test_create_session_if_needed_bad_sessionid(self) -> None:
         app = Application()
         c = bsc.ApplicationContext(app, io_loop="ioloop")
@@ -136,7 +133,6 @@ class TestApplicationContext(object):
             await r
         assert str(e.value).endswith("Session ID must not be empty")
 
-    @pytest.mark.asyncio
     async def test_create_session_if_needed_logout_url(self) -> None:
         app = Application()
         c = bsc.ApplicationContext(app, io_loop="ioloop", logout_url="/logout")

--- a/tests/unit/bokeh/server/test_server__server.py
+++ b/tests/unit/bokeh/server/test_server__server.py
@@ -318,7 +318,6 @@ async def test_server_applications_callable_arg(ManagedServerLoop) -> None:
         session = server.get_sessions('/foo')[0]
         assert session.document.title == "Hello, world!"
 
-@pytest.mark.asyncio
 async def test__include_headers(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application, include_headers=['Custom']) as server:
@@ -332,7 +331,6 @@ async def test__include_headers(ManagedServerLoop) -> None:
         assert 'headers' in payload
         assert payload['headers'] == {'Custom': 'Test'}
 
-@pytest.mark.asyncio
 async def test__exclude_headers(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application, exclude_headers=['Connection', 'Host']) as server:
@@ -346,7 +344,6 @@ async def test__exclude_headers(ManagedServerLoop) -> None:
         assert 'headers' in payload
         assert payload['headers'] == {'Accept-Encoding': 'gzip'}
 
-@pytest.mark.asyncio
 async def test__include_cookies(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application, include_cookies=['custom']) as server:
@@ -360,7 +357,6 @@ async def test__include_cookies(ManagedServerLoop) -> None:
         assert 'cookies' in payload
         assert payload['cookies'] == {'custom': 'test'}
 
-@pytest.mark.asyncio
 async def test__exclude_cookies(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application, exclude_cookies=['custom']) as server:

--- a/tests/unit/bokeh/server/test_server__server.py
+++ b/tests/unit/bokeh/server/test_server__server.py
@@ -173,7 +173,6 @@ def test_index(ManagedServerLoop) -> None:
     with ManagedServerLoop(application, index="foo") as server:
         assert server.index == "foo"
 
-@pytest.mark.asyncio
 async def test_get_sessions(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
@@ -299,7 +298,6 @@ def test_base_server() -> None:
     server.stop()
     server.io_loop.close()
 
-@pytest.mark.asyncio
 async def test_server_applications_callable_arg(ManagedServerLoop) -> None:
     def modify_doc(doc):
         doc.title = "Hello, world!"
@@ -391,7 +389,6 @@ def test__lifecycle_hooks(ManagedServerLoop) -> None:
     assert client_hook_list.hooks == ["session_created", "modify"]
     assert server_hook_list.hooks == ["session_created", "modify"]
 
-@pytest.mark.asyncio
 async def test__request_in_session_context(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
@@ -405,7 +402,6 @@ async def test__request_in_session_context(ManagedServerLoop) -> None:
         # do we have a request
         assert session_context.request is not None
 
-@pytest.mark.asyncio
 async def test__request_in_session_context_has_arguments(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
@@ -419,7 +415,6 @@ async def test__request_in_session_context_has_arguments(ManagedServerLoop) -> N
         # test if we can get the argument from the request
         assert session_context.request.arguments['foo'] == [b'10']
 
-@pytest.mark.asyncio
 async def test__no_request_arguments_in_session_context(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
@@ -441,7 +436,6 @@ async def test__no_request_arguments_in_session_context(ManagedServerLoop) -> No
     ("&resources=none", False),
 ])
 
-@pytest.mark.asyncio
 async def test__resource_files_requested(querystring, requested, ManagedServerLoop) -> None:
     """
     Checks if the loading of resource files is requested by the autoload.js
@@ -452,7 +446,6 @@ async def test__resource_files_requested(querystring, requested, ManagedServerLo
         response = await http_get(server.io_loop, autoload_url(server) + querystring)
         resource_files_requested(response.body, requested=requested)
 
-@pytest.mark.asyncio
 async def test__autocreate_session_autoload(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
@@ -467,7 +460,6 @@ async def test__autocreate_session_autoload(ManagedServerLoop) -> None:
         assert 1 == len(sessions)
         assert sessionid == sessions[0].id
 
-@pytest.mark.asyncio
 async def test__no_set_title_autoload(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
@@ -479,7 +471,6 @@ async def test__no_set_title_autoload(ManagedServerLoop) -> None:
         use_for_title = extract_use_for_title_from_json(js)
         assert use_for_title == "false"
 
-@pytest.mark.asyncio
 async def test__autocreate_session_doc(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
@@ -494,7 +485,6 @@ async def test__autocreate_session_doc(ManagedServerLoop) -> None:
         assert 1 == len(sessions)
         assert sessionid == sessions[0].id
 
-@pytest.mark.asyncio
 async def test__no_autocreate_session_websocket(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
@@ -506,7 +496,6 @@ async def test__no_autocreate_session_websocket(ManagedServerLoop) -> None:
         sessions = server.get_sessions('/')
         assert 0 == len(sessions)
 
-@pytest.mark.asyncio
 async def test__use_provided_session_autoload(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
@@ -523,7 +512,6 @@ async def test__use_provided_session_autoload(ManagedServerLoop) -> None:
         assert 1 == len(sessions)
         assert expected == sessions[0].id
 
-@pytest.mark.asyncio
 async def test__use_provided_session_doc(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
@@ -540,7 +528,6 @@ async def test__use_provided_session_doc(ManagedServerLoop) -> None:
         assert 1 == len(sessions)
         assert expected == sessions[0].id
 
-@pytest.mark.asyncio
 async def test__use_provided_session_websocket(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
@@ -555,7 +542,6 @@ async def test__use_provided_session_websocket(ManagedServerLoop) -> None:
         assert 1 == len(sessions)
         assert expected == sessions[0].id
 
-@pytest.mark.asyncio
 async def test__autocreate_signed_session_autoload(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application, sign_sessions=True, secret_key='foo') as server:
@@ -572,7 +558,6 @@ async def test__autocreate_signed_session_autoload(ManagedServerLoop) -> None:
 
         assert check_session_id_signature(sessionid, signed=True, secret_key='foo')
 
-@pytest.mark.asyncio
 async def test__autocreate_signed_session_doc(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application, sign_sessions=True, secret_key='foo') as server:
@@ -589,7 +574,6 @@ async def test__autocreate_signed_session_doc(ManagedServerLoop) -> None:
 
         assert check_session_id_signature(sessionid, signed=True, secret_key='foo')
 
-@pytest.mark.asyncio
 async def test__reject_unsigned_session_autoload(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application, sign_sessions=True, secret_key='bar') as server:
@@ -604,7 +588,6 @@ async def test__reject_unsigned_session_autoload(ManagedServerLoop) -> None:
         sessions = server.get_sessions('/')
         assert 0 == len(sessions)
 
-@pytest.mark.asyncio
 async def test__reject_unsigned_session_doc(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application, sign_sessions=True, secret_key='bar') as server:
@@ -619,7 +602,6 @@ async def test__reject_unsigned_session_doc(ManagedServerLoop) -> None:
         sessions = server.get_sessions('/')
         assert 0 == len(sessions)
 
-@pytest.mark.asyncio
 async def test__reject_unsigned_session_websocket(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application, sign_sessions=True, secret_key='bar') as server:
@@ -632,7 +614,6 @@ async def test__reject_unsigned_session_websocket(ManagedServerLoop) -> None:
 
         sessions = server.get_sessions('/')
         assert 0 == len(sessions)
-@pytest.mark.asyncio
 async def test__no_generate_session_autoload(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application, generate_session_ids=False) as server:
@@ -646,7 +627,6 @@ async def test__no_generate_session_autoload(ManagedServerLoop) -> None:
         sessions = server.get_sessions('/')
         assert 0 == len(sessions)
 
-@pytest.mark.asyncio
 async def test__no_generate_session_doc(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application, generate_session_ids=False) as server:
@@ -679,7 +659,6 @@ def test__existing_ioloop_with_multiple_processes_exception(ManagedServerLoop, e
         with ManagedServerLoop(application, io_loop=loop, num_procs=3):
             pass
 
-@pytest.mark.asyncio
 async def test__actual_port_number(ManagedServerLoop) -> None:
     application = Application()
     with ManagedServerLoop(application, port=0) as server:

--- a/tests/unit/bokeh/server/test_tornado__server.py
+++ b/tests/unit/bokeh/server/test_tornado__server.py
@@ -179,7 +179,6 @@ def test_log_stats(ManagedServerLoop) -> None:
         session2.close()
         server._tornado._log_stats()
 
-@pytest.mark.asyncio
 async def test_metadata(ManagedServerLoop) -> None:
     application = Application(metadata=dict(hi="hi", there="there"))
     with ManagedServerLoop(application) as server:

--- a/tests/unit/bokeh/server/views/test_ws.py
+++ b/tests/unit/bokeh/server/views/test_ws.py
@@ -37,7 +37,6 @@ basicConfig()
 # General API
 #-----------------------------------------------------------------------------
 
-@pytest.mark.asyncio
 async def test_send_message_raises(caplog) -> None:
     class ExcMessage(object):
         def send(self, handler):

--- a/tests/unit/bokeh/test_client_server.py
+++ b/tests/unit/bokeh/test_client_server.py
@@ -123,47 +123,39 @@ class TestClientServer(object):
             session.close()
             session._loop_until_closed()
 
-    @pytest.mark.asyncio
     async def check_http_gets_fail(self, server):
         with pytest.raises(HTTPError):
             await http_get(server.io_loop, url(server))
         with pytest.raises(HTTPError):
             await http_get(server.io_loop, url(server) + "autoload.js?bokeh-autoload-element=foo")
 
-    @pytest.mark.asyncio
     async def check_connect_session_fails(self, server, origin):
         with pytest.raises(HTTPError):
             await websocket_open(server.io_loop,
                                  ws_url(server)+"?bokeh-session-id=foo",
                                  origin=origin)
 
-    @pytest.mark.asyncio
     async def check_http_gets(self, server):
         await http_get(server.io_loop, url(server))
         await http_get(server.io_loop, url(server) + "autoload.js?bokeh-autoload-element=foo")
 
-    @pytest.mark.asyncio
     async def check_connect_session(self, server, origin):
         await websocket_open(server.io_loop,
                              ws_url(server)+"?bokeh-session-id=foo",
                              origin=origin)
 
-    @pytest.mark.asyncio
     async def check_http_ok_socket_ok(self, server, origin=None):
         await self.check_http_gets(server)
         await self.check_connect_session(server, origin=origin)
 
-    @pytest.mark.asyncio
     async def check_http_ok_socket_blocked(self, server, origin=None):
         await self.check_http_gets(server)
         await self.check_connect_session_fails(server, origin=origin)
 
-    @pytest.mark.asyncio
     async def check_http_blocked_socket_blocked(self, server, origin=None):
         await self.check_http_gets_fail(server)
         await self.check_connect_session_fails(server, origin=origin)
 
-    @pytest.mark.asyncio
     async def test_allow_websocket_origin(self, ManagedServerLoop) -> None:
         application = Application()
 


### PR DESCRIPTION
Expanding a bit on top of PR #9635. Currently an async test requires both `async` modifier and `asyncio` marker. With this PR only async modifier is needed. Note this uses pytest's test collection hooks, so only appropriate test functions will be marked. I will update this and mark as ready when PR #9536 is merged.
