### PR TITLE
remove bad super usage

### DIFF
--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -125,6 +125,7 @@ DataSpec Properties
 .. autoclass:: FontSizeSpec
 .. autoclass:: MarkerSpec
 .. autoclass:: NumberSpec
+.. autoclass:: PropertyUnitsSpec
 .. autoclass:: ScreenDistanceSpec
 .. autoclass:: StringSpec
 .. autoclass:: UnitsSpec
@@ -222,6 +223,7 @@ __all__ = (
     'PandasGroupBy',
     'Percent',
     'PositiveInt',
+    'PropertyUnitsSpec',
     'RGB',
     'Regex',
     'RelativeDelta',
@@ -273,6 +275,7 @@ from .property.dataspec import FontSizeSpec; FontSizeSpec
 from .property.dataspec import HatchPatternSpec; HatchPatternSpec
 from .property.dataspec import MarkerSpec; MarkerSpec
 from .property.dataspec import NumberSpec; NumberSpec
+from .property.dataspec import PropertyUnitsSpec; PropertyUnitsSpec
 from .property.dataspec import ScreenDistanceSpec; ScreenDistanceSpec
 from .property.dataspec import StringSpec; StringSpec
 from .property.dataspec import UnitsSpec; UnitsSpec

--- a/bokeh/core/property/dataspec.py
+++ b/bokeh/core/property/dataspec.py
@@ -374,14 +374,17 @@ class UnitsSpec(NumberSpec):
         units_props = self._units_type.make_descriptors(units_name)
         return units_props + [ UnitsSpecPropertyDescriptor(base_name, self, units_props[0]) ]
 
-    def to_serializable(self, obj, name, val):
+    def to_serializable(self, obj, name, val, units=None):
         d = super().to_serializable(obj, name, val)
         if d is not None and 'units' not in d:
             # d is a PropertyValueDict at this point, we need to convert it to
             # a plain dict if we are going to modify its value, otherwise a
             # notify_change that should not happen will be triggered
             d = dict(d)
-            d["units"] = getattr(obj, name+"_units")
+            if units:
+                d["units"] = units
+            else:
+                d["units"] = getattr(obj, name+"_units")
         return d
 
 class AngleSpec(UnitsSpec):
@@ -454,14 +457,7 @@ class ScreenDistanceSpec(UnitsSpec):
         return [ UnitsSpecPropertyDescriptor(base_name, self, units_props[0]) ]
 
     def to_serializable(self, obj, name, val):
-        d = super(UnitsSpec, self).to_serializable(obj, name, val) # note super special case
-        if d is not None and 'units' not in d:
-            # d is a PropertyValueDict at this point, we need to convert it to
-            # a plain dict if we are going to modify its value, otherwise a
-            # notify_change that should not happen will be triggered
-            d = dict(d)
-            d["units"] = "screen"
-        return d
+        return super().to_serializable(obj, name, val, "screen")
 
 
 class DataDistanceSpec(UnitsSpec):
@@ -505,14 +501,7 @@ class DataDistanceSpec(UnitsSpec):
         return [ UnitsSpecPropertyDescriptor(base_name, self, units_props[0]) ]
 
     def to_serializable(self, obj, name, val):
-        d = super(UnitsSpec, self).to_serializable(obj, name, val) # note super special case
-        if d is not None and 'units' not in d:
-            # d is a PropertyValueDict at this point, we need to convert it to
-            # a plain dict if we are going to modify its value, otherwise a
-            # notify_change that should not happen will be triggered
-            d = dict(d)
-            d["units"] = "data"
-        return d
+        return super().to_serializable(obj, name, val, "data")
 
 class ColorSpec(DataSpec):
     ''' A |DataSpec| property that accepts |Color| fixed values.

--- a/bokeh/core/property/dataspec.py
+++ b/bokeh/core/property/dataspec.py
@@ -337,7 +337,7 @@ class MarkerSpec(DataSpec):
 
 class UnitsSpec(NumberSpec):
     ''' A |DataSpec| property that accepts numeric fixed values, and also
-    provides an associated units property to store units information.
+    serializes associated units values.
 
     '''
     def __init__(self, default, units_type, units_default, help=None):
@@ -352,6 +352,9 @@ class UnitsSpec(NumberSpec):
 
     def __str__(self):
         return "%s(units_default=%r)" % (self.__class__.__name__, self._units_type._default)
+
+    def get_units(self, obj, name):
+        raise NotImplementedError()
 
     def make_descriptors(self, base_name):
         ''' Return a list of ``PropertyDescriptor`` instances to install on a
@@ -374,20 +377,29 @@ class UnitsSpec(NumberSpec):
         units_props = self._units_type.make_descriptors(units_name)
         return units_props + [ UnitsSpecPropertyDescriptor(base_name, self, units_props[0]) ]
 
-    def to_serializable(self, obj, name, val, units=None):
+    def to_serializable(self, obj, name, val):
         d = super().to_serializable(obj, name, val)
         if d is not None and 'units' not in d:
             # d is a PropertyValueDict at this point, we need to convert it to
             # a plain dict if we are going to modify its value, otherwise a
             # notify_change that should not happen will be triggered
             d = dict(d)
-            if units:
-                d["units"] = units
-            else:
-                d["units"] = getattr(obj, name+"_units")
+            d["units"] = self.get_units(obj, name)
         return d
 
-class AngleSpec(UnitsSpec):
+class PropertyUnitsSpec(UnitsSpec):
+    ''' A |DataSpec| property that accepts numeric fixed values, and also
+    provides an associated units property to store units information.
+
+    '''
+    def to_serializable(self, obj, name, val):
+        return super().to_serializable(obj, name, val)
+
+    def get_units(self, obj, name):
+        return getattr(obj, name+"_units")
+
+
+class AngleSpec(PropertyUnitsSpec):
     ''' A |DataSpec| property that accepts numeric fixed values, and also
     provides an associated units property to store angle units.
 
@@ -397,7 +409,7 @@ class AngleSpec(UnitsSpec):
     def __init__(self, default=None, units_default="rad", help=None):
         super().__init__(default=default, units_type=Enum(enums.AngleUnits), units_default=units_default, help=help)
 
-class DistanceSpec(UnitsSpec):
+class DistanceSpec(PropertyUnitsSpec):
     ''' A |DataSpec| property that accepts numeric fixed values or strings
     that refer to columns in a :class:`~bokeh.models.sources.ColumnDataSource`,
     and also provides an associated units property to store units information.
@@ -415,18 +427,13 @@ class DistanceSpec(UnitsSpec):
             pass
         return super().prepare_value(cls, name, value)
 
-class ScreenDistanceSpec(UnitsSpec):
-    ''' A |DataSpec| property that accepts numeric fixed values for screen
-    distances, and also provides an associated units property that reports
-    ``"screen"`` as the units.
-
-    .. note::
-        Units are always ``"screen"``.
-
-    '''
+class _FixedUnitsDistanceSpec(UnitsSpec):
 
     def __init__(self, default=None, help=None):
-        super().__init__(default=default, units_type=Enum(enums.enumeration("screen")), units_default="screen", help=help)
+        super().__init__(default=default, units_type=Enum(enums.enumeration(self._units)), units_default=self._units, help=help)
+
+    def get_units(self, _obj, _name):
+        return self._units
 
     def prepare_value(self, cls, name, value):
         try:
@@ -457,51 +464,23 @@ class ScreenDistanceSpec(UnitsSpec):
         return [ UnitsSpecPropertyDescriptor(base_name, self, units_props[0]) ]
 
     def to_serializable(self, obj, name, val):
-        return super().to_serializable(obj, name, val, "screen")
+        return super().to_serializable(obj, name, val)
 
+class ScreenDistanceSpec(_FixedUnitsDistanceSpec):
+    ''' A |DataSpec| property that accepts numeric fixed values for screen-space
+    distances, and also provides an associated units property that reports
+    ``"screen"`` as the units.
 
-class DataDistanceSpec(UnitsSpec):
+    '''
+    _units = "screen"
+
+class DataDistanceSpec(_FixedUnitsDistanceSpec):
     ''' A |DataSpec| property that accepts numeric fixed values for data-space
     distances, and also provides an associated units property that reports
     ``"data"`` as the units.
 
-    .. note::
-        Units are always ``"data"``.
-
     '''
-    def __init__(self, default=None, help=None):
-        super().__init__(default=default, units_type=Enum(enums.enumeration("data")), units_default="data", help=help)
-
-    def prepare_value(self, cls, name, value):
-        try:
-            if value is not None and value < 0:
-                raise ValueError("Distances must be positive or None!")
-        except TypeError:
-            pass
-        return super().prepare_value(cls, name, value)
-
-    def make_descriptors(self, base_name):
-        ''' Return a list of ``PropertyDescriptor`` instances to install on a
-        class, in order to delegate attribute access to this property.
-
-        Unlike simpler property types, ``UnitsSpec`` returns multiple
-        descriptors to install. In particular, descriptors for the base
-        property as well as the associated units property are returned.
-
-        Args:
-            name (str) : the name of the property these descriptors are for
-
-        Returns:
-            list[PropertyDescriptor]
-
-        The descriptors returned are collected by the ``MetaHasProps``
-        metaclass and added to ``HasProps`` subclasses during class creation.
-        '''
-        units_props = self._units_type.make_descriptors("unused")
-        return [ UnitsSpecPropertyDescriptor(base_name, self, units_props[0]) ]
-
-    def to_serializable(self, obj, name, val):
-        return super().to_serializable(obj, name, val, "data")
+    _units = "data"
 
 class ColorSpec(DataSpec):
     ''' A |DataSpec| property that accepts |Color| fixed values.

--- a/bokeh/core/property/wrappers.py
+++ b/bokeh/core/property/wrappers.py
@@ -353,7 +353,8 @@ class PropertyValueColumnData(PropertyValueDict):
     def update(self, *args, **kwargs):
         old = self._saved_copy()
 
-        result = super(PropertyValueDict, self).update(*args, **kwargs) # note super special case
+        # call dict.update directly, bypass wrapped version on base class
+        result = dict.update(self, *args, **kwargs)
 
         from ...document.events import ColumnDataChangedEvent
 
@@ -415,7 +416,8 @@ class PropertyValueColumnData(PropertyValueDict):
                 data = np.append(self[k], new_data[k])
                 if rollover and len(data) > rollover:
                     data = data[-rollover:]
-                super(PropertyValueDict, self).__setitem__(k, data) # note super special case
+                # call dict.__setitem__ directly, bypass wrapped version on base class
+                dict.__setitem__(self, k, data)
             else:
                 L = self[k]
                 L.extend(new_data[k])

--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -51,11 +51,11 @@ from ..core.properties import (
     List,
     NumberSpec,
     Override,
+    PropertyUnitsSpec,
     Seq,
     String,
     StringSpec,
     Tuple,
-    UnitsSpec,
     value,
 )
 from ..core.property_mixins import (
@@ -629,15 +629,15 @@ class Band(Annotation):
     ''' Render a filled area band along a dimension.
 
     '''
-    lower = UnitsSpec(default=None, units_type=Enum(SpatialUnits), units_default="data", help="""
+    lower = PropertyUnitsSpec(default=None, units_type=Enum(SpatialUnits), units_default="data", help="""
     The coordinates of the lower portion of the filled area band.
     """)
 
-    upper = UnitsSpec(default=None, units_type=Enum(SpatialUnits), units_default="data", help="""
+    upper = PropertyUnitsSpec(default=None, units_type=Enum(SpatialUnits), units_default="data", help="""
     The coordinates of the upper portion of the filled area band.
     """)
 
-    base = UnitsSpec(default=None, units_type=Enum(SpatialUnits), units_default="data", help="""
+    base = PropertyUnitsSpec(default=None, units_type=Enum(SpatialUnits), units_default="data", help="""
     The orthogonal coordinates of the upper and lower values.
     """)
 
@@ -1115,7 +1115,7 @@ class Whisker(Annotation):
 
     '''
 
-    lower = UnitsSpec(default=None, units_type=Enum(SpatialUnits), units_default="data", help="""
+    lower = PropertyUnitsSpec(default=None, units_type=Enum(SpatialUnits), units_default="data", help="""
     The coordinates of the lower end of the whiskers.
     """)
 
@@ -1123,7 +1123,7 @@ class Whisker(Annotation):
     Instance of ``ArrowHead``.
     """)
 
-    upper = UnitsSpec(default=None, units_type=Enum(SpatialUnits), units_default="data", help="""
+    upper = PropertyUnitsSpec(default=None, units_type=Enum(SpatialUnits), units_default="data", help="""
     The coordinates of the upper end of the whiskers.
     """)
 
@@ -1131,7 +1131,7 @@ class Whisker(Annotation):
     Instance of ``ArrowHead``.
     """)
 
-    base = UnitsSpec(default=None, units_type=Enum(SpatialUnits), units_default="data", help="""
+    base = PropertyUnitsSpec(default=None, units_type=Enum(SpatialUnits), units_default="data", help="""
     The orthogonal coordinates of the upper and lower values.
     """)
 

--- a/sphinx/source/docs/releases/2.0.0.rst
+++ b/sphinx/source/docs/releases/2.0.0.rst
@@ -127,6 +127,14 @@ Missing Renderers Warning
 The ``W-1000 (MISSING_RENDERERS)`` validation warning will no longer trigger
 for plots that have added annotations, even if no other glyphs are present.
 
+UnitsSpec hierarchy
+~~~~~~~~~~~~~~~~~~~
+
+The ``UnitsSpec`` class is now a base class and is not useful ln its own. If you
+were using ``UnitsSpec`` in an extension model, you should change to use the new
+``PropertyUnitsSpec`` class, which affords the capability for adding separate
+``*_units`` properties.
+
 API Removals
 ~~~~~~~~~~~~
 

--- a/tests/unit/bokeh/core/test_properties.py
+++ b/tests/unit/bokeh/core/test_properties.py
@@ -85,6 +85,7 @@ ALL = (
     'PandasGroupBy',
     'Percent',
     'PositiveInt',
+    'PropertyUnitsSpec',
     'RGB',
     'Regex',
     'RelativeDelta',


### PR DESCRIPTION
This PR cleans up some unusual/bad usage of super:

* in `wrappers.py` we can just call the method directly on `dict`, that is the actual intent, and clearer

* in `dataspec.py` the wonky situation with unit spec subclasses is improved as described below