### PR TITLE
force srgb color profile on chrome

### DIFF
--- a/bokeh/io/webdriver.py
+++ b/bokeh/io/webdriver.py
@@ -64,6 +64,7 @@ def create_chromium_webdriver() -> WebDriver:
     options.add_argument("--headless")
     options.add_argument("--hide-scrollbars")
     options.add_argument("--force-device-scale-factor=1")
+    options.add_argument("--force-color-profile=srgb")
     return webdriver.Chrome(options=options)
 
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/io/test_export.py
+++ b/tests/unit/bokeh/io/test_export.py
@@ -71,8 +71,7 @@ def test_get_screenshot_as_png(webdriver, dimensions: Tuple[int, int]) -> None:
 
     data = png.tobytes()
     assert len(data) == 4*width*height
-    assert (data == b"\x00\xff\x00\xff"*width*height or
-            data == b"\x2e\xff\x05\xff"*width*height)   # XXX: Chrome on MacOS
+    assert data == b"\x00\xff\x00\xff"*width*height
 
 
 @pytest.mark.selenium
@@ -101,8 +100,7 @@ def test_get_screenshot_as_png_with_glyph(webdriver, dimensions: Tuple[int, int]
     count = 0
     for x in range(width*height):
         pixel = data[x*4:x*4+4]
-        if pixel == b"\xff\x00\x00\xff" or \
-           pixel == b"\xfc\x00\x06\xff":     # XXX: Chrome on MacOS
+        if pixel == b"\xff\x00\x00\xff":
             count += 1
 
     w, h, b = width, height, border


### PR DESCRIPTION
cc @mattpap  This forces the chrome webdriver to always use standard RGB color profile. Otherwise, on OSX PIL images come back with an explicit ICC profile attached that causes the raw bytes to be different than expected. With this change, all unit tests can now be run successfully on OSX. 

This PR also removes the "or" values in export tests that were previously compensating for some difference in OSX. Now all platforms are identical. 