### PR TITLE
Drop usage of backingStorePixelRatio API

### DIFF
--- a/bokehjs/src/lib/core/util/canvas.ts
+++ b/bokehjs/src/lib/core/util/canvas.ts
@@ -1,5 +1,3 @@
-import {OutputBackend} from "../enums"
-
 export type Context2d = {
   setLineDashOffset(offset: number): void
   getLineDashOffset(): number
@@ -98,19 +96,4 @@ export function fixup_ctx(ctx: any): void {
   fixup_image_smoothing(ctx)
   fixup_measure_text(ctx)
   fixup_ellipse(ctx)
-}
-
-export function get_scale_ratio(ctx: any, hidpi: boolean, backend: OutputBackend): number {
-  if (backend == "svg")
-    return 1
-  else if (hidpi) {
-    const devicePixelRatio = window.devicePixelRatio || 1
-    const backingStoreRatio = ctx.webkitBackingStorePixelRatio ||
-                              ctx.mozBackingStorePixelRatio    ||
-                              ctx.msBackingStorePixelRatio     ||
-                              ctx.oBackingStorePixelRatio      ||
-                              ctx.backingStorePixelRatio       || 1
-    return devicePixelRatio / backingStoreRatio
-  } else
-    return 1
 }

--- a/bokehjs/src/lib/models/canvas/canvas.ts
+++ b/bokehjs/src/lib/models/canvas/canvas.ts
@@ -5,7 +5,7 @@ import * as p from "core/properties"
 import {div, canvas, append} from "core/dom"
 import {OutputBackend} from "core/enums"
 import {BBox} from "core/util/bbox"
-import {Context2d, fixup_ctx, get_scale_ratio} from "core/util/canvas"
+import {Context2d, fixup_ctx} from "core/util/canvas"
 import {bk_canvas, bk_canvas_underlays, bk_canvas_overlays, bk_canvas_events} from "styles/canvas"
 
 // Notes on WebGL support:
@@ -114,13 +114,13 @@ export class CanvasView extends DOMView {
   }
 
   prepare_canvas(width: number, height: number): void {
-    // Ensure canvas has the correct size, taking HIDPI into account
     this.bbox = new BBox({left: 0, top: 0, width, height})
 
     this.el.style.width = `${width}px`
     this.el.style.height = `${height}px`
 
-    const pixel_ratio = get_scale_ratio(this.ctx, this.model.use_hidpi, this.model.output_backend)
+    const {use_hidpi, output_backend} = this.model
+    const pixel_ratio = use_hidpi && output_backend != "svg" ? devicePixelRatio : 1
     this.model.pixel_ratio = pixel_ratio
 
     this.canvas_el.style.width = `${width}px`


### PR DESCRIPTION
This is unlikely to improve anything with regards to issue #8478, but it's a good thing to do anyway.

addresses #8478 
