### PR TITLE
Ensure Toolbar is initialized before ProxyToolbar

### DIFF
--- a/bokeh/layouts.py
+++ b/bokeh/layouts.py
@@ -272,7 +272,7 @@ def gridplot(children, sizing_mode=None, toolbar_location='above', ncols=None,
         children = []
 
     # Make the grid
-    tools = []
+    toolbars = []
     items = []
 
     for y, row in enumerate(children):
@@ -282,7 +282,7 @@ def gridplot(children, sizing_mode=None, toolbar_location='above', ncols=None,
             elif isinstance(item, LayoutDOM):
                 if merge_tools:
                     for plot in item.select(dict(type=Plot)):
-                        tools += plot.toolbar.tools
+                        toolbars.append(plot.toolbar)
                         plot.toolbar_location = None
 
                 if isinstance(item, Plot):
@@ -302,7 +302,8 @@ def gridplot(children, sizing_mode=None, toolbar_location='above', ncols=None,
         return GridBox(children=items, sizing_mode=sizing_mode)
 
     grid = GridBox(children=items)
-    proxy = ProxyToolbar(tools=tools, **toolbar_options)
+    tools = sum([ toolbar.tools for toolbar in toolbars ], [])
+    proxy = ProxyToolbar(toolbars=toolbars, tools=tools, **toolbar_options)
     toolbar = ToolbarBox(toolbar=proxy, toolbar_location=toolbar_location)
 
     if toolbar_location == 'above':

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -241,6 +241,9 @@ class ProxyToolbar(ToolbarBase):
 
     '''
 
+    toolbars = List(Instance(Toolbar), help="""
+    """)
+
 class ToolbarBox(LayoutDOM):
     ''' A layoutable toolbar that can accept the tools of multiple plots, and
     can merge the tools into a single button for convenience.

--- a/bokehjs/src/lib/api/gridplot.ts
+++ b/bokehjs/src/lib/api/gridplot.ts
@@ -1,4 +1,4 @@
-import {LayoutDOM, Row, Column, GridBox, ToolbarBox, ProxyToolbar, Plot, Tool} from "./models"
+import {LayoutDOM, Row, Column, GridBox, ToolbarBox, ProxyToolbar, Plot, Tool, Toolbar} from "./models"
 import {SizingMode, Location} from "../core/enums"
 
 export interface GridPlotOpts {
@@ -21,7 +21,7 @@ export function gridplot(children: (LayoutDOM | null)[][], opts: GridPlotOpts = 
   const merge_tools      = or_else(opts.merge_tools, true)
   const sizing_mode      = or_else(opts.sizing_mode, null)
 
-  const tools: Tool[] = []
+  const toolbars: Toolbar[] = []
   const items: [LayoutDOM, number, number][] = []
 
   for (let y = 0; y < children.length; y++) {
@@ -35,7 +35,7 @@ export function gridplot(children: (LayoutDOM | null)[][], opts: GridPlotOpts = 
       else {
         if (item instanceof Plot) { // XXX: semantics differ
           if (merge_tools) {
-            tools.push(...item.toolbar.tools)
+            toolbars.push(item.toolbar)
             item.toolbar_location = null
           }
 
@@ -55,8 +55,12 @@ export function gridplot(children: (LayoutDOM | null)[][], opts: GridPlotOpts = 
 
   const grid = new GridBox({children: items, sizing_mode})
 
+  const tools: Tool[] = []
+  for (const toolbar of toolbars) {
+    tools.push(...toolbar.tools)
+  }
   const toolbar = new ToolbarBox({
-    toolbar: new ProxyToolbar({tools}),
+    toolbar: new ProxyToolbar({toolbars, tools}),
     toolbar_location,
   })
 

--- a/bokehjs/src/lib/models/tools/toolbar_box.ts
+++ b/bokehjs/src/lib/models/tools/toolbar_box.ts
@@ -8,6 +8,7 @@ import {ActionTool} from "./actions/action_tool"
 import {GestureTool} from "./gestures/gesture_tool"
 import {InspectTool} from "./inspectors/inspect_tool"
 import {ToolbarBase, GestureType} from "./toolbar_base"
+import {Toolbar} from "./toolbar"
 import {ToolProxy} from "./tool_proxy"
 
 import {LayoutDOM, LayoutDOMView} from "../layouts/layout_dom"
@@ -16,7 +17,9 @@ import {ContentBox} from "core/layout"
 export namespace ProxyToolbar {
   export type Attrs = p.AttrsOf<Props>
 
-  export type Props = ToolbarBase.Props
+  export type Props = ToolbarBase.Props & {
+    toolbars: p.Property<Toolbar[]>
+  }
 }
 
 export interface ProxyToolbar extends ProxyToolbar.Attrs {}
@@ -26,6 +29,12 @@ export class ProxyToolbar extends ToolbarBase {
 
   constructor(attrs?: Partial<ProxyToolbar.Attrs>) {
     super(attrs)
+  }
+
+  static init_ProxyToolbar(): void {
+    this.define<ProxyToolbar.Props>({
+      toolbars: [ p.Array, [] ],
+    })
   }
 
   _proxied_tools: (Tool | ToolProxy)[]


### PR DESCRIPTION
This establishes a relationship between `ProxyToolbar` and `Toolbar` models, where the former requires the later to be initialized first. Previously `ProxyToolbar` knew only about individual tools, thus toolbars owning those tools could be initialized at any point, including after `ProxyToolbar`. This is a minimal change I could come up with to resolve this issue. There are better solutions possible, and more impactful on the overall design, but I will leave that for after 2.0.

fixes #9699