### PR TITLE
js_link feature update to allow attr indexing

### DIFF
--- a/bokeh/model.py
+++ b/bokeh/model.py
@@ -378,7 +378,7 @@ class Model(HasProps, PropertyCallbackManager, EventCallbackManager):
             self.js_event_callbacks[event].append(callback)
 
 
-    def js_link(self, attr, other, other_attr):
+    def js_link(self, attr, other, other_attr, attr_selector=None):
         ''' Link two Bokeh model properties using JavaScript.
 
         This is a convenience method that simplifies adding a CustomJS callback
@@ -431,7 +431,15 @@ class Model(HasProps, PropertyCallbackManager, EventCallbackManager):
             raise ValueError("%r is not a property of other (%r)" % (other_attr, other))
 
         from bokeh.models import CustomJS
-        cb = CustomJS(args=dict(other=other), code="other.%s = this.%s" % (other_attr, attr))
+
+        if attr_selector is None:
+            cb = CustomJS(args=dict(other=other), code="other.%s = this.%s" % (other_attr, attr))
+        else:
+            if type(attr_selector) is str:
+                attr_selector = "\"%s\"" % attr_selector
+            else:
+                attr_selector = str(attr_selector)
+            cb = CustomJS(args=dict(other=other), code="other.%s = this.%s[%s]" % (other_attr, attr, attr_selector))
 
         self.js_on_change(attr, cb)
 

--- a/tests/unit/bokeh/test_model.py
+++ b/tests/unit/bokeh/test_model.py
@@ -127,6 +127,34 @@ class Test_js_link(object):
         assert cb.args == dict(other=m2)
         assert cb.code == "other.b = this.a"
 
+    def test_attr_selector_creates_customjs_int(self) -> None:
+        m1 = SomeModel()
+        m2 = SomeModel()
+        assert len(m1.js_property_callbacks) == 0
+        m1.js_link('a', m2, 'b', 1)
+        assert len(m1.js_property_callbacks) == 1
+        assert "change:a" in m1.js_property_callbacks
+        cbs = m1.js_property_callbacks["change:a"]
+        assert len(cbs) == 1
+        cb = cbs[0]
+        assert isinstance(cb, CustomJS)
+        assert cb.args == dict(other=m2)
+        assert cb.code == "other.b = this.a[1]"
+
+    def test_attr_selector_creates_customjs_str(self) -> None:
+        m1 = SomeModel()
+        m2 = SomeModel()
+        assert len(m1.js_property_callbacks) == 0
+        m1.js_link('a', m2, 'b', "test")
+        assert len(m1.js_property_callbacks) == 1
+        assert "change:a" in m1.js_property_callbacks
+        cbs = m1.js_property_callbacks["change:a"]
+        assert len(cbs) == 1
+        cb = cbs[0]
+        assert isinstance(cb, CustomJS)
+        assert cb.args == dict(other=m2)
+        assert cb.code == "other.b = this.a[\"test\"]"
+
 def test_all_builtin_models_default_constructible() -> None:
     bad = []
     for name, cls in Model.model_class_reverse_map.items():

--- a/tests/unit/bokeh/test_model.py
+++ b/tests/unit/bokeh/test_model.py
@@ -153,7 +153,7 @@ class Test_js_link(object):
         cb = cbs[0]
         assert isinstance(cb, CustomJS)
         assert cb.args == dict(other=m2)
-        assert cb.code == "other.b = this.a[\"test\"]"
+        assert cb.code == "other.b = this.a['test']"
 
 def test_all_builtin_models_default_constructible() -> None:
     bad = []


### PR DESCRIPTION
Enchances js_link functionality to allow a user to index into a subscriptable attr value. For example one could now do `RangeSlider.js_link('value', other, other_attr, attr_selector=0)` to access the start value of the range.

- [x] issues: fixes #9706 
- [x] tests added / passed
- [x] release document entry (if new feature or API change)