### PR TITLE
Rename BOKEH_VERSION

### DIFF
--- a/bokeh/command/bootstrap.py
+++ b/bokeh/command/bootstrap.py
@@ -93,9 +93,6 @@ def main(argv: List[str]) -> None:
         prog=argv[0],
         epilog="See '<command> --help' to read about a specific subcommand.")
 
-    # we don't use settings.version() because the point of this option
-    # is to report the actual version of Bokeh, while settings.version()
-    # lets people change the version used for CDN for example.
     parser.add_argument('-v', '--version', action='version', version=__version__)
 
     subs = parser.add_subparsers(help="Sub-commands")

--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -227,7 +227,7 @@ class BaseResources(object):
         del mode
         self.root_dir = settings.rootdir(root_dir)
         del root_dir
-        self.version = settings.version(version)
+        self.version = settings.cdn_version(version)
         del version
         self.minified = settings.minified(minified)
         del minified

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -460,6 +460,12 @@ class Settings(object):
     .. _webbrowser: https://docs.python.org/2/library/webbrowser.html
     """)
 
+    cdn_version = PrioritizedSetting("version", "BOKEH_CDN_VERSION", default=None, help="""
+    What version of BokehJS to use with CDN resources.
+
+    See the :class:`~bokeh.resources.Resources` class reference for full details.
+    """)
+
     cookie_secret = PrioritizedSetting("cookie_secret", "BOKEH_COOKIE_SECRET", default=None, help="""
     Configure the ``cookie_secret`` setting in Tornado. This value is required
     if you use ``get_secure_cookie`` or ``set_secure_cookie``.  It should be a
@@ -599,12 +605,6 @@ class Settings(object):
 
     strict = PrioritizedSetting("strict", "BOKEH_STRICT", convert=convert_bool, help="""
     Whether validation checks should be strict (i.e. raise errors).
-    """)
-
-    version = PrioritizedSetting("version", "BOKEH_VERSION", default=None, help="""
-    What version of BokehJS to use with CDN resources.
-
-    See the :class:`~bokeh.resources.Resources` class reference for full details.
     """)
 
     xsrf_cookies = PrioritizedSetting("xsrf_cookies", "BOKEH_XSRF_COOKIES", default=False, convert=convert_bool, help="""

--- a/sphinx/source/docs/releases/2.0.0.rst
+++ b/sphinx/source/docs/releases/2.0.0.rst
@@ -143,6 +143,13 @@ early experimental tools that were never widely promoted. It was recently
 discovered that they have been broken since version 1.0, indicating that they
 are completely unused. To reduce codebase cruft, they have been removed.
 
+BOKEH_VERSION
+~~~~~~~~~~~~~
+
+The previous environment variable BOKEH_VERSION that could be use to specify
+which version of BokehJS should be loaded from CDN, has been renamed to
+BOKEH_CDN_VERSION.
+
 API Removals
 ~~~~~~~~~~~~
 

--- a/tests/unit/bokeh/test_settings.py
+++ b/tests/unit/bokeh/test_settings.py
@@ -44,6 +44,7 @@ _expected_settings = (
     'allowed_ws_origin',
     'auth_module',
     'browser',
+    'cdn_version',
     'cookie_secret',
     'docs_cdn',
     'docs_version',
@@ -64,7 +65,6 @@ _expected_settings = (
     'ssl_keyfile',
     'ssl_password',
     'strict',
-    'version',
     'xsrf_cookies',
 )
 


### PR DESCRIPTION

Changes to BOKEH_CDN_VERSION which is actually more description, but also solves the issues users were having with name conflicts. 