### PR TITLE
Inherited members for refdocs

### DIFF
--- a/bokeh/sphinxext/_templates/model_detail.rst
+++ b/bokeh/sphinxext/_templates/model_detail.rst
@@ -1,7 +1,7 @@
 .. autoclass::  {{ module_name }}.{{ name }}
     :members:
-    :undoc-members:
     :show-inheritance:
+    :inherited-members:
 
 .. _{{ name }}.json:
 


### PR DESCRIPTION
- [x] issues: fixes #4966
- [x] release document entry (if new feature or API change)

Now that glyphs are split out on to separate pages this change is less onerous. I am sure there are further improvements to make (e.g. pruning out some things users probably have no reason to ever care about) but this will dp for now. 