### PR TITLE
Use auto so that the tooltip doesn't stretch to the left

### DIFF
--- a/bokehjs/src/lib/models/annotations/tooltip.ts
+++ b/bokehjs/src/lib/models/annotations/tooltip.ts
@@ -115,8 +115,8 @@ export class TooltipView extends AnnotationView {
     // be problematic
     if (this.el.childNodes.length > 0) {
       this.el.style.top = `${top}px`
-      this.el.style.left = left ? `${left}px` : 'inherit'
-      this.el.style.right = right ? `${right}px` : 'inherit'
+      this.el.style.left = left ? `${left}px` : 'auto'
+      this.el.style.right = right ? `${right}px` : 'auto'
     } else
       undisplay(this.el)
   }


### PR DESCRIPTION
I introduced #9717 in #9634. @bryevdv recommended this fix: https://github.com/bokeh/bokeh/issues/9717#issuecomment-590191046 and I've verified that the original issue is still fixed, so I wanted to just open this PR. 

- [x] issues: fixes #9717
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
