### PR TITLE
File input multi

### DIFF
--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -30,7 +30,6 @@ from ...core.properties import (
     Enum,
     Float,
     Int,
-    Interval,
     List,
     PositiveInt,
     String,
@@ -48,7 +47,6 @@ __all__ = (
     'DatePicker',
     'FileInput',
     'InputWidget',
-    'MultiChoice',
     'MultiSelect',
     'PasswordInput',
     'Select',
@@ -89,26 +87,25 @@ class InputWidget(Widget):
 #-----------------------------------------------------------------------------
 
 class FileInput(Widget):
-    ''' Present a file-chooser dialog to users and return the contents of a
-    selected file.
+    ''' Present a file-chooser dialog to users and return the contents of the 
+    selected files 
 
     '''
+    
+    value = Either(String, List(String),default='', readonly=True, help='''
+    if multiple = 'False' or ommitted, base64-encoded string of the contents of the selected file,
+    if multiple = 'True' or 'Multiple' a list of base64 encoded strings of the contents of selected files in the order given by filename
+    ''')
 
-    value = String(default="", readonly=True, help="""
-    A base64-encoded string of the contents of the selected file.
-    """)
+    mime_type = Either(String, List(String),default='', readonly=True, help='''
+    if multiple = 'False' or ommitted, string with the mime-type of the selected file,
+    if multiple = 'True' or 'Multiple' a list of strings with the mime-types of the selected files in the order given by filename
+    ''')
 
-    mime_type = String(default="", readonly=True, help="""
-    The mime type of the selected file.
-    """)
-
-    filename = String(default="", readonly=True, help="""
-    The filename of the selected file.
-
-    .. note::
-        The full file path is not included since browsers will not provide
-        access to that information for security reasons.
-    """)
+    filename = Either(String, List(String),default='', readonly=True, help='''
+    if multiple = 'False' or ommitted, the filename of the selected file as string,
+    if multiple = 'True' or 'Multiple' a list of strings giving the filenames of the selected files 
+    ''')
 
     accept = String(default="", help="""
     Comma-separated list of standard HTML file input filters that restrict what
@@ -130,6 +127,11 @@ class FileInput(Widget):
         A valid `IANA Media Type`_, with no parameters.
 
     .. _IANA Media Type: https://www.iana.org/assignments/media-types/media-types.xhtml
+    """)
+        
+    multiple = String(default="False", help="""
+    set to "multiple" or "True" if selection of more than one file at a time
+    should be supported.
     """)
 
 
@@ -242,42 +244,6 @@ class MultiSelect(InputWidget):
     """)
 
 
-class MultiChoice(InputWidget):
-    ''' MultiChoice widget.
-
-    '''
-
-    options = List(Either(String, Tuple(String, String)), help="""
-    Available selection options. Options may be provided either as a list of
-    possible string values, or as a list of tuples, each of the form
-    ``(value, label)``. In the latter case, the visible widget text for each
-    value will be corresponding given label.
-    """)
-
-    value = List(String, help="""
-    Initial or selected values.
-    """)
-
-    delete_button = Bool(default=True, help="""
-    Whether to add a button to remove a selected option.
-    """)
-
-    max_items = Int(default=None, help="""
-    The maximum number of items that can be selected.
-    """)
-
-    option_limit = Int(default=None, help="""
-    The number of choices that will be rendered in the dropdown.
-    """)
-
-    placeholder = String(default=None, help="""
-    A string that is displayed if not item is added.
-    """)
-
-    solid = Bool(default=True, help="""
-    Specify whether the choices should be solidly filled.""")
-
-
 class DatePicker(InputWidget):
     ''' Calendar-based date picker widget.
 
@@ -341,7 +307,7 @@ class Spinner(InputWidget):
     The initial value of the spinner
     """)
 
-    step = Interval(Float, start=1e-16, end=float('inf'), default=1, help="""
+    step = Float(default=1, help="""
     The step added or subtracted to the current value
     """)
 

--- a/bokehjs/src/lib/models/widgets/file_input.ts
+++ b/bokehjs/src/lib/models/widgets/file_input.ts
@@ -3,8 +3,11 @@ import {Widget, WidgetView} from "models/widgets/widget"
 
 export class FileInputView extends WidgetView {
   model: FileInput
-
+  
   protected dialogEl: HTMLInputElement
+  mime_type: string[] = []
+  filename: string[] = []
+  value: string[] = []
 
   connect_signals(): void {
     super.connect_signals()
@@ -16,43 +19,68 @@ export class FileInputView extends WidgetView {
     if (this.dialogEl == null) {
       this.dialogEl = document.createElement('input')
       this.dialogEl.type = "file"
-      this.dialogEl.multiple = false
-      this.dialogEl.onchange = (e) => this.load_file(e)
+      this.dialogEl.multiple = false  
+      this.dialogEl.onchange = async (e) => await this.load_files(e)
       this.el.appendChild(this.dialogEl)
     }
     if (this.model.accept != null && this.model.accept != '')
       this.dialogEl.accept = this.model.accept
+    if (this.model.multiple == 'multiple' || this.model.multiple == 'True'){
+      this.dialogEl.multiple = true
+    }
     this.dialogEl.style.width = `{this.model.width}px`
     this.dialogEl.disabled = this.model.disabled
   }
 
-  load_file(e: any): void {
-    const reader = new FileReader()
-    this.model.filename = e.target.files[0].name
-    reader.onload = (e) => this.file(e)
-    reader.readAsDataURL(e.target.files[0])
+
+  // multiple = True
+  async load_files(e: any): Promise<void> {
+    const files = e.target.files
+    var i : number
+    var value : string[] = []
+    var filename : string[] = []
+    var mime_type : string[] = []
+    
+    for (i=0; i< files.length ; i++){
+      filename.push(files[i].name)
+      let content = await this.readfile(files[i])
+      const file_arr = content.split(",")
+      value.push(file_arr[1])
+      mime_type.push(file_arr[0].split(":")[1].split(";")[0])
+      //console.log(content);
+    }
+    if (this.model.multiple == 'multiple' || this.model.multiple == 'True'){
+      this.model.filename = filename
+      this.model.mime_type= mime_type
+      this.model.value = value
+    }
+    else {
+      this.model.filename = filename[0]
+      this.model.mime_type= mime_type[0]
+      this.model.value = value[0]
+    }
+    //console.log('load_files:')
+    //console.log(this.model.filename)
+    //console.log(this.model.value)
   }
-
-  file(e: any): void {
-    const file = e.target.result
-    const file_arr = file.split(",")
-
-    const content = file_arr[1]
-    const header = file_arr[0].split(":")[1].split(";")[0]
-
-    this.model.value = content
-    this.model.mime_type = header
-
+  
+  readfile(file: any): Promise<string> { //<string | ArrayBuffer | null>
+    return new Promise<any>((resolve) => {
+      const reader = new FileReader()
+      reader.onload = (e) => resolve(e.target ? e.target.result : "")
+      reader.readAsDataURL(file)
+    })
   }
 }
 
 export namespace FileInput {
   export type Attrs = p.AttrsOf<Props>
   export type Props = Widget.Props & {
-    value: p.Property<string>
-    mime_type: p.Property<string>
-    filename: p.Property<string>
+    value: p.Property<string|string[]>
+    mime_type: p.Property<string|string[]>
+    filename: p.Property<string|string[]>
     accept: p.Property<string>
+    multiple: p.Property<string>
   }
 }
 
@@ -70,10 +98,11 @@ export abstract class FileInput extends Widget {
     this.prototype.default_view = FileInputView
 
     this.define<FileInput.Props>({
-      value:     [ p.String, '' ],
-      mime_type: [ p.String, '' ],
-      filename:  [ p.String, '' ],
+      value:     [ p.Any, [] ],
+      mime_type: [ p.Any, [] ],
+      filename:  [ p.Any, [] ],
       accept:    [ p.String, '' ],
+      multiple:  [ p.String, '' ],
     })
   }
 }


### PR DESCRIPTION
- [ ] issues: fixes #9727
- [ ] tests added / passed (None)

The PR amends the capability of multi-file selection to bokeh's FileInput widget.
It adapts the property types of _class FileInput_ in 
 - inputs.py 

and adapts the help-texts.
It extends the TS-code in 
- file_input.ts 

to ensure complete file reading/upload and return of either scalars (single file API) or Arrays (multi file API).
