### PR TITLE
File input multi2

### DIFF
--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -89,8 +89,8 @@ class InputWidget(Widget):
 #-----------------------------------------------------------------------------
 
 class FileInput(Widget):
-    ''' Present a file-chooser dialog to users and return the contents of the 
-    selected files 
+    ''' Present a file-chooser dialog to users and return the contents of the
+    selected files.
     '''
     
     value = Either(String, List(String), default='', readonly=True, help='''
@@ -99,8 +99,8 @@ class FileInput(Widget):
     If `mulitiple` is set to False (default), this value is a single string with the contents
     of the single file that was chosen.
 
-    If `multiple` is True, this value is a list of strings, each containing the contents of 
-    one of the multiple files that were chosen. 
+    If `multiple` is True, this value is a list of strings, each containing the contents of
+    one of the multiple files that were chosen.
 
     The sequence of files is given by the list of filenames (see below)
     ''')
@@ -108,11 +108,11 @@ class FileInput(Widget):
     mime_type = Either(String, List(String), default='', readonly=True, help='''
     The mime-type of the file or files that were loaded.
 
-    If `mulitiple` is set to False (default), this value is a single string with the 
+    If `mulitiple` is set to False (default), this value is a single string with the
     mime-type of the single file that was chosen.
 
-    If `multiple` is True, this value is a list of strings, each containing the 
-    mime-type of one of the multiple files that were chosen. 
+    If `multiple` is True, this value is a list of strings, each containing the
+    mime-type of one of the multiple files that were chosen.
 
     The sequence of files is given by the list of filename (see below)
     ''')
@@ -120,17 +120,17 @@ class FileInput(Widget):
     filename = Either(String, List(String), default='', readonly=True, help='''
     The name(s) of the file or files that were loaded.
 
-    If `mulitiple` is set to False (default), this value is a single string with the 
+    If `mulitiple` is set to False (default), this value is a single string with the
     name of the single file that was chosen.
 
-    If `multiple` is True, this value is a list of strings, each containing the 
-    name of one of the multiple files that were chosen. 
+    If `multiple` is True, this value is a list of strings, each containing the
+    name of one of the multiple files that were chosen.
 
     This list provides the sequence of files for the respective lists in value and mime-type
    
     .. note::
         The full file path is not included since browsers will not provide
-        access to that information for security reasons.   
+        access to that information for security reasons.
     ''')
 
     accept = String(default="", help="""
@@ -154,9 +154,9 @@ class FileInput(Widget):
 
     .. _IANA Media Type: https://www.iana.org/assignments/media-types/media-types.xhtml
     """)
-       
+
     multiple = Bool(default=False, help="""
-    set multiple=False (default) for single file selection, set multiple=True if 
+    set multiple=False (default) for single file selection, set multiple=True if
     selection of more than one file at a time should be possible.
     """)
 

--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -94,18 +94,22 @@ class FileInput(Widget):
     '''
     
     value = Either(String, List(String), default='', readonly=True, help='''
-    if multiple = 'False' or ommitted, base64-encoded string of the contents of the selected file,
-    if multiple = 'True' or 'Multiple' a list of base64 encoded strings of the contents of selected files in the order given by filename
+    if multiple=False or ommitted, base64-encoded string of the contents of the 
+    selected file,
+    if multiple=True or 'Multiple' a list of base64 encoded strings of the contents 
+    of selected files in the order given by filename
     ''')
 
     mime_type = Either(String, List(String), default='', readonly=True, help='''
-    if multiple = 'False' or ommitted, string with the mime-type of the selected file,
-    if multiple = 'True' or 'Multiple' a list of strings with the mime-types of the selected files in the order given by filename
+    if multiple=False or ommitted, string with the mime-type of the selected file,
+    if multiple=True or 'Multiple' a list of strings with the mime-types of the 
+    selected files in the order given by filename
     ''')
 
     filename = Either(String, List(String), default='', readonly=True, help='''
-    if multiple = 'False' or ommitted, the filename of the selected file as string,
-    if multiple = 'True' or 'Multiple' a list of strings giving the filenames of the selected files 
+    if multiple=False or ommitted, the filename of the selected file as string,
+    if multiple=True or 'Multiple' a list of strings giving the filenames of the 
+    selected files 
     ''')
 
     accept = String(default="", help="""
@@ -124,9 +128,9 @@ class FileInput(Widget):
     .. _IANA Media Type: https://www.iana.org/assignments/media-types/media-types.xhtml
     """)
         
-    multiple = String(default="False", help="""
-    set to "multiple" or "True" if selection of more than one file at a time
-    should be supported.
+    multiple = Bool(default=False, help="""
+    set multiple=False (default) for single file selection, set multiple=True if 
+    selection of more than one file at a time should be possible.
     """)
 
 

--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -92,7 +92,7 @@ class FileInput(Widget):
     ''' Present a file-chooser dialog to users and return the contents of the
     selected files.
     '''
-    
+
     value = Either(String, List(String), default='', readonly=True, help='''
     The base64-enconded contents of the file or files that were loaded.
 
@@ -127,7 +127,7 @@ class FileInput(Widget):
     name of one of the multiple files that were chosen.
 
     This list provides the sequence of files for the respective lists in value and mime-type
-   
+
     .. note::
         The full file path is not included since browsers will not provide
         access to that information for security reasons.

--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -89,47 +89,44 @@ class InputWidget(Widget):
 #-----------------------------------------------------------------------------
 
 class FileInput(Widget):
-    ''' Present a file-chooser dialog to users and return the contents of a
-    selected file.
-
+    ''' Present a file-chooser dialog to users and return the contents of the 
+    selected files 
     '''
+    
+    value = Either(String, List(String), default='', readonly=True, help='''
+    if multiple = 'False' or ommitted, base64-encoded string of the contents of the selected file,
+    if multiple = 'True' or 'Multiple' a list of base64 encoded strings of the contents of selected files in the order given by filename
+    ''')
 
-    value = String(default="", readonly=True, help="""
-    A base64-encoded string of the contents of the selected file.
-    """)
+    mime_type = Either(String, List(String), default='', readonly=True, help='''
+    if multiple = 'False' or ommitted, string with the mime-type of the selected file,
+    if multiple = 'True' or 'Multiple' a list of strings with the mime-types of the selected files in the order given by filename
+    ''')
 
-    mime_type = String(default="", readonly=True, help="""
-    The mime type of the selected file.
-    """)
-
-    filename = String(default="", readonly=True, help="""
-    The filename of the selected file.
-
-    .. note::
-        The full file path is not included since browsers will not provide
-        access to that information for security reasons.
-    """)
+    filename = Either(String, List(String), default='', readonly=True, help='''
+    if multiple = 'False' or ommitted, the filename of the selected file as string,
+    if multiple = 'True' or 'Multiple' a list of strings giving the filenames of the selected files 
+    ''')
 
     accept = String(default="", help="""
     Comma-separated list of standard HTML file input filters that restrict what
     files the user can pick from. Values can be:
-
     `<file extension>`:
         Specific file extension(s) (e.g: .gif, .jpg, .png, .doc) are pickable
-
     `audio/*`:
         all sound files are pickable
-
     `video/*`:
         all video files are pickable
-
     `image/*`:
         all image files are pickable
-
     `<media type>`:
         A valid `IANA Media Type`_, with no parameters.
-
     .. _IANA Media Type: https://www.iana.org/assignments/media-types/media-types.xhtml
+    """)
+        
+    multiple = String(default="False", help="""
+    set to "multiple" or "True" if selection of more than one file at a time
+    should be supported.
     """)
 
 

--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -94,40 +94,67 @@ class FileInput(Widget):
     '''
     
     value = Either(String, List(String), default='', readonly=True, help='''
-    if multiple=False or ommitted, base64-encoded string of the contents of the 
-    selected file,
-    if multiple=True or 'Multiple' a list of base64 encoded strings of the contents 
-    of selected files in the order given by filename
+    The base64-enconded contents of the file or files that were loaded.
+
+    If `mulitiple` is set to False (default), this value is a single string with the contents
+    of the single file that was chosen.
+
+    If `multiple` is True, this value is a list of strings, each containing the contents of 
+    one of the multiple files that were chosen. 
+
+    The sequence of files is given by the list of filenames (see below)
     ''')
 
     mime_type = Either(String, List(String), default='', readonly=True, help='''
-    if multiple=False or ommitted, string with the mime-type of the selected file,
-    if multiple=True or 'Multiple' a list of strings with the mime-types of the 
-    selected files in the order given by filename
+    The mime-type of the file or files that were loaded.
+
+    If `mulitiple` is set to False (default), this value is a single string with the 
+    mime-type of the single file that was chosen.
+
+    If `multiple` is True, this value is a list of strings, each containing the 
+    mime-type of one of the multiple files that were chosen. 
+
+    The sequence of files is given by the list of filename (see below)
     ''')
 
     filename = Either(String, List(String), default='', readonly=True, help='''
-    if multiple=False or ommitted, the filename of the selected file as string,
-    if multiple=True or 'Multiple' a list of strings giving the filenames of the 
-    selected files 
+    The name(s) of the file or files that were loaded.
+
+    If `mulitiple` is set to False (default), this value is a single string with the 
+    name of the single file that was chosen.
+
+    If `multiple` is True, this value is a list of strings, each containing the 
+    name of one of the multiple files that were chosen. 
+
+    This list provides the sequence of files for the respective lists in value and mime-type
+   
+    .. note::
+        The full file path is not included since browsers will not provide
+        access to that information for security reasons.   
     ''')
 
     accept = String(default="", help="""
     Comma-separated list of standard HTML file input filters that restrict what
     files the user can pick from. Values can be:
+
     `<file extension>`:
         Specific file extension(s) (e.g: .gif, .jpg, .png, .doc) are pickable
+
     `audio/*`:
         all sound files are pickable
+
     `video/*`:
         all video files are pickable
+
     `image/*`:
         all image files are pickable
+
     `<media type>`:
         A valid `IANA Media Type`_, with no parameters.
+
     .. _IANA Media Type: https://www.iana.org/assignments/media-types/media-types.xhtml
     """)
-        
+       
     multiple = Bool(default=False, help="""
     set multiple=False (default) for single file selection, set multiple=True if 
     selection of more than one file at a time should be possible.

--- a/bokehjs/src/lib/models/widgets/file_input.ts
+++ b/bokehjs/src/lib/models/widgets/file_input.ts
@@ -17,7 +17,12 @@ export class FileInputView extends WidgetView {
       this.dialogEl = document.createElement('input')
       this.dialogEl.type = "file"
       this.dialogEl.multiple = this.model.multiple
-      this.dialogEl.onchange = async (e) => await this.load_files(e)
+      this.dialogEl.onchange = () => {
+        const {files} = this.dialogEl
+        if (files != null) {
+          this.load_files(files)
+        }
+      }        
       this.el.appendChild(this.dialogEl)
     }
     if (this.model.accept != null && this.model.accept != '')
@@ -27,8 +32,7 @@ export class FileInputView extends WidgetView {
     this.dialogEl.disabled = this.model.disabled
   }
 
-  async load_files(e: any): Promise<void> {
-    const files = e.target.files
+  async load_files(files: FileList): Promise<void> {
     const value: string[] = []
     const filename: string[] = []
     const mime_type: string[] = []
@@ -52,10 +56,15 @@ export class FileInputView extends WidgetView {
     }
   }
 
-  readfile(file: any): Promise<string> {
-    return new Promise<any>((resolve) => {
+  readfile(file: File): Promise<string> {
+    return new Promise<string>((resolve) => {
       const reader = new FileReader()
-      reader.onload = (e) => resolve(e.target ? e.target.result : "")
+      reader.onload = (e) => {
+        if (e.target) {
+            resolve(e.target.result ? String(e.target.result) : "")
+        }
+        else {resolve("")}
+      }
       reader.readAsDataURL(file)
     })
   }

--- a/bokehjs/src/lib/models/widgets/file_input.ts
+++ b/bokehjs/src/lib/models/widgets/file_input.ts
@@ -22,7 +22,7 @@ export class FileInputView extends WidgetView {
     }
     if (this.model.accept != null && this.model.accept != '')
       this.dialogEl.accept = this.model.accept
-    
+
     this.dialogEl.style.width = `{this.model.width}px`
     this.dialogEl.disabled = this.model.disabled
   }

--- a/bokehjs/src/lib/models/widgets/file_input.ts
+++ b/bokehjs/src/lib/models/widgets/file_input.ts
@@ -40,7 +40,6 @@ export class FileInputView extends WidgetView {
       const file_arr = content.split(",")
       value.push(file_arr[1])
       mime_type.push(file_arr[0].split(":")[1].split(";")[0])
-      //console.log(content);
     }
     if (this.model.multiple) {
       this.model.filename = filename
@@ -51,9 +50,6 @@ export class FileInputView extends WidgetView {
       this.model.mime_type= mime_type[0]
       this.model.value = value[0]
     }
-    //console.log('load_files:')
-    //console.log(this.model.filename)
-    //console.log(this.model.value)
   }
   
   readfile(file: any): Promise<string> {

--- a/bokehjs/src/lib/models/widgets/file_input.ts
+++ b/bokehjs/src/lib/models/widgets/file_input.ts
@@ -51,7 +51,7 @@ export class FileInputView extends WidgetView {
       this.model.value = value[0]
     }
   }
-  
+
   readfile(file: any): Promise<string> {
     return new Promise<any>((resolve) => {
       const reader = new FileReader()

--- a/bokehjs/src/lib/models/widgets/file_input.ts
+++ b/bokehjs/src/lib/models/widgets/file_input.ts
@@ -57,13 +57,14 @@ export class FileInputView extends WidgetView {
   }
 
   readfile(file: File): Promise<string> {
-    return new Promise<string>((resolve) => {
+    return new Promise<string>((resolve, reject) => {
       const reader = new FileReader()
-      reader.onload = (e) => {
-        if (e.target) {
-          resolve(e.target.result ? String(e.target.result) : "")
+      reader.onload = () => {
+        const {result} = reader
+        if (result != null) {
+          resolve(result as string)
         } else {
-          resolve("")
+          reject(reader.error ?? new Error(`unable to read '${file.name}'`))
         }
       }
       reader.readAsDataURL(file)

--- a/bokehjs/src/lib/models/widgets/file_input.ts
+++ b/bokehjs/src/lib/models/widgets/file_input.ts
@@ -36,7 +36,7 @@ export class FileInputView extends WidgetView {
 
     for (i=0; i<files.length; i++){
       filename.push(files[i].name)
-      let content = await this.readfile(files[i])
+      const content = await this.readfile(files[i])
       const file_arr = content.split(",")
       value.push(file_arr[1])
       mime_type.push(file_arr[0].split(":")[1].split(";")[0])

--- a/bokehjs/src/lib/models/widgets/file_input.ts
+++ b/bokehjs/src/lib/models/widgets/file_input.ts
@@ -29,10 +29,10 @@ export class FileInputView extends WidgetView {
 
   async load_files(e: any): Promise<void> {
     const files = e.target.files
-    var i: number
-    var value: string[] = []
-    var filename: string[] = []
-    var mime_type: string[] = []
+    const value: string[] = []
+    const filename: string[] = []
+    const mime_type: string[] = []
+    let i: number
 
     for (i=0; i<files.length; i++){
       filename.push(files[i].name)

--- a/bokehjs/src/lib/models/widgets/file_input.ts
+++ b/bokehjs/src/lib/models/widgets/file_input.ts
@@ -22,7 +22,7 @@ export class FileInputView extends WidgetView {
         if (files != null) {
           this.load_files(files)
         }
-      }        
+      }
       this.el.appendChild(this.dialogEl)
     }
     if (this.model.accept != null && this.model.accept != '')
@@ -61,9 +61,10 @@ export class FileInputView extends WidgetView {
       const reader = new FileReader()
       reader.onload = (e) => {
         if (e.target) {
-            resolve(e.target.result ? String(e.target.result) : "")
+          resolve(e.target.result ? String(e.target.result) : "")
+        } else {
+          resolve("")
         }
-        else {resolve("")}
       }
       reader.readAsDataURL(file)
     })

--- a/bokehjs/src/lib/models/widgets/file_input.ts
+++ b/bokehjs/src/lib/models/widgets/file_input.ts
@@ -34,20 +34,20 @@ export class FileInputView extends WidgetView {
     const mime_type: string[] = []
     let i: number
 
-    for (i=0; i<files.length; i++){
+    for (i = 0; i < files.length; i++){
       filename.push(files[i].name)
-      const content = await this.readfile(files[i])
-      const file_arr = content.split(",")
-      value.push(file_arr[1])
-      mime_type.push(file_arr[0].split(":")[1].split(";")[0])
+      const data_url = await this.readfile(files[i])
+      const [, mime, , data] = data_url.split(/[:;,]/, 4)
+      value.push(data)
+      mime_type.push(mime)
     }
     if (this.model.multiple) {
       this.model.filename = filename
-      this.model.mime_type= mime_type
+      this.model.mime_type = mime_type
       this.model.value = value
     } else {
       this.model.filename = filename[0]
-      this.model.mime_type= mime_type[0]
+      this.model.mime_type = mime_type[0]
       this.model.value = value[0]
     }
   }


### PR DESCRIPTION
- [ ] issues: fixes #9727
**This PR replaces PR #9728**

The PR amends the capability of multi-file selection to bokeh's FileInput widget.
It adapts the property types of class FileInput in
- inputs.py

and adapts the help-texts.
It extends the TS-code in
- file_input.ts

to ensure complete file reading/upload and return of either scalars (single file API) or Arrays (multi file API).
