### PR TITLE
Fix spelling mistakes in documentation

### DIFF
--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -203,7 +203,7 @@ variable ``BOKEH_SSL_CERTFILE``.
 
 If the private key is stored separately, its location may be supplied by
 setting the ``--ssl-keyfile`` command line argument, or by setting the
-``BOKEH_SSL_KEYFILE`` evironment variable. If a password is required for the
+``BOKEH_SSL_KEYFILE`` environment variable. If a password is required for the
 private key, it should be supplied by setting the ``BOKEH_SSL_PASSWORD``
 environment variable.
 

--- a/bokeh/embed/util.py
+++ b/bokeh/embed/util.py
@@ -83,7 +83,7 @@ def OutputDocumentFor(objs, apply_theme=None, always_new=False):
     * If passed a subset of Document.roots, then OutputDocumentFor temporarily "re-homes"
       the models in a new bare Document that is only available inside the context manager.
 
-    * If passed a list of models that have differnet documents, then OutputDocumentFor
+    * If passed a list of models that have different documents, then OutputDocumentFor
       temporarily "re-homes" the models in a new bare Document that is only available
       inside the context manager.
 

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -588,7 +588,7 @@ class Settings(object):
     Whether Bokeh should use simple integers for model IDs (starting at 1000).
 
     If False, Bokeh will use UUIDs for object identifiers. This might be needed,
-    e.g., if mulitple processes are contributing to a single Bokeh Document.
+    e.g., if multiple processes are contributing to a single Bokeh Document.
     """)
 
     ssl_certfile = PrioritizedSetting("ssl_certfile", "BOKEH_SSL_CERTFILE", default=None, help="""

--- a/examples/howto/notebook_comms/Numba Image Example.ipynb
+++ b/examples/howto/notebook_comms/Numba Image Example.ipynb
@@ -404,7 +404,7 @@
    "source": [
     "## Wavelet Decomposition\n",
     "\n",
-    "This last example demostrates a Haar wavelet decomposition using a Numba-compiled function. Play around with the slider to see differnet levels of decomposition of the image. "
+    "This last example demostrates a Haar wavelet decomposition using a Numba-compiled function. Play around with the slider to see different levels of decomposition of the image. "
    ]
   },
   {

--- a/sphinx/source/docs/user_guide/categorical.rst
+++ b/sphinx/source/docs/user_guide/categorical.rst
@@ -126,7 +126,7 @@ fruit type stacked instead of grouped:
 .. bokeh-plot:: docs/user_guide/examples/categorical_bar_stacked.py
     :source-position: above
 
-Note that behing the scenes, these functions work by stacking up the
+Note that behind the scenes, these functions work by stacking up the
 successive columns in separate calls to ``vbar`` or ``hbar``. This kind of
 operation is akin the to dodge example above (i.e. the data in this case is
 *not* in a "tidy" data format).
@@ -188,7 +188,7 @@ Grouped
 When creating bar charts, it is often desirable to visually display the
 data according to sub-groups. There are two basic methods that can be used,
 depending on your use case: using nested categorical coordinates, or
-applying vidual dodges.
+applying visual dodges.
 
 .. _userguide_categorical_bars_grouped_nested:
 
@@ -303,7 +303,7 @@ to make life easier when you do.
 Below is a plot that demonstrates some advantages when using Pandas with
 Bokeh:
 
-* Pandas ``GroupBy`` objects can be used to initialize a ``CoumnDataSource``,
+* Pandas ``GroupBy`` objects can be used to initialize a ``ColumnDataSource``,
   automatically creating columns for many statistical measures such as the
   group mean or count
 

--- a/sphinx/source/docs/user_guide/geo.rst
+++ b/sphinx/source/docs/user_guide/geo.rst
@@ -22,7 +22,7 @@ appropriate attribution which can be added to a plot using the
     :source-position: below
 
 Notice also that passing ``x_axis_type="mercator"`` and ``y_axis_type="mercator"``
-to ``figure`` generate axes with latitude and longitute labels, instead of raw Web
+to ``figure`` generate axes with latitude and longitude labels, instead of raw Web
 Mercator coordinates.
 
 .. _userguide_geo_google_maps:

--- a/sphinx/source/docs/user_guide/jupyter.rst
+++ b/sphinx/source/docs/user_guide/jupyter.rst
@@ -8,7 +8,7 @@ Using with Jupyter
 Working in Notebooks
 --------------------
 
-`Jupyter`_ notebooks are computible documents often used for exploratory work,
+`Jupyter`_ notebooks are computable documents often used for exploratory work,
 data analysis, teaching, and demonstration. A notebook is a series of *input
 cells* that can be individually executed to display their output immediately
 after the cell. In addition to  *Classic Notebooks* there are also notebooks for
@@ -22,7 +22,7 @@ content with either.
 Standalone output
 ~~~~~~~~~~~~~~~~~
 
-Standalone Bokeh content (i.e. that does not ue a Bokeh server) can be embedded
+Standalone Bokeh content (i.e. that does not use a Bokeh server) can be embedded
 directly in classic Jupyter notebooks as well as in JupyterLab.
 
 Classic Notebook
@@ -68,7 +68,7 @@ Bokeh Server Applications
 It is also possible to embed full Bokeh server applications, that can connect
 plot events, and Bokeh's built-in widgets, directly to Python callback code.
 See :ref:`userguide_server` for general information about Bokeh server
-applications, and the follwoing notebook for a complete example of a Bokeh
+applications, and the following notebook for a complete example of a Bokeh
 application embedded in a Jupyter notebook:
 
 * :bokeh-tree:`examples/howto/server_embed/notebook_embed.ipynb`
@@ -355,7 +355,7 @@ Then we add the wrapper to a Bokeh document:
     doc = curdoc()
     doc.add_root(ipywidget)
 
-To to run this, assuming the code is saved under ``ipy_slider.py``, we issue
+To run this, assuming the code is saved under ``ipy_slider.py``, we issue
 ``bokeh serve ipy_slider.py`` (see :ref:`userguide_server` for details). The
 application is available at http://localhost:5006/ipy_slider.
 

--- a/sphinx/source/docs/user_guide/layout.rst
+++ b/sphinx/source/docs/user_guide/layout.rst
@@ -155,7 +155,7 @@ how a single plot responds to different modes:
     If the enclosing DOM element does not define any specific height to fill,
     sizing modes that scale or stretch to height may shrink to a minimum size.
 
-Mulitple Objects
+Multiple Objects
 ~~~~~~~~~~~~~~~~
 
 Below is a more sophisticated (but fairly typical) example of a nested layout
@@ -165,7 +165,7 @@ with different sizing modes:
     :source-position: none
 
 In the example above, the layout nests different subcomponents with various
-differnet sizing modes:
+different sizing modes:
 
 .. code-block:: python
 
@@ -193,7 +193,7 @@ The Bokeh layout system is not a completely generic, general purpose layout
 engine. It intentionally sacrifices some capability in order to make common
 use cases and scenarios simple to express. Extremely nested layouts with
 many different sizing modes may yield undesirable results, either in terms of
-perfomance, or visual appearance. For such cases it is recommended to use the
+performance, or visual appearance. For such cases it is recommended to use the
 methods in :ref:`userguide_embed` along with your own custom HTML templates in
 order to take advantage of more sophisticated CSS layout possibilities.
 

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -280,7 +280,7 @@ The full set of files that Bokeh server knows about is:
 
 The optional components are
 
-* An ``__init__.py`` file that marks this direcory as a package. Package relative imports, e.g. ``from . import mymod`` and ``from .mymod import func`` will be possible.
+* An ``__init__.py`` file that marks this directory as a package. Package relative imports, e.g. ``from . import mymod`` and ``from .mymod import func`` will be possible.
 
 * A ``request_handler.py`` file that allows declaring an optional function which processes the HTTP request and returns a dictionary of items to be included in the session token, as described in :ref:`userguide_server_request_handler`.
 
@@ -299,7 +299,7 @@ however you like.
 
 Additionally, the application directory is also added to ``sys.path`` so that
 Python modules in the application directory may be easily imported. However, if
-an ``__init__.py`` is present in the direcory then the app is usable as a
+an ``__init__.py`` is present in the directory then the app is usable as a
 package, and standard package-relative imports will also work.
 
 An example might be:
@@ -427,7 +427,7 @@ available as ``curdoc().session_context``. The most useful function of the
 session context is to make the Tornado HTTP request object available to the
 application as ``session_context.request``. Due to an incompatibility issue with
 the usage of ``--num-procs`` the HTTP request is not made available directly.
-Instead only the ``arguments`` attribute is available in full and and only the
+Instead only the ``arguments`` attribute is available in full and only the
 subset of ``cookies`` and ``headers`` which are allowed by the ``--include-headers``,
 ``--exclude-headers``, ``--include-cookies`` and ``--exclude-cookies`` are
 made available. Attempting to access any other attribute on ``request`` will
@@ -939,11 +939,11 @@ variable ``BOKEH_SSL_CERTFILE``.
 
 If the private key is stored separately, its location may be supplied by
 setting the ``--ssl-keyfile`` command line argument, or by setting the
-``BOKEH_SSL_KEYFILE`` evironment variable. If a password is required for the
+``BOKEH_SSL_KEYFILE`` environment variable. If a password is required for the
 private key, it should be supplied by setting the ``BOKEH_SSL_PASSWORD``
 environment variable.
 
-Alternativey, you may wish to run a Boekh server behind a proxy, and have the
+Alternatively, you may wish to run a Bokeh server behind a proxy, and have the
 proxy terminate SSL. That scenario is described in the next section.
 
 .. _userguide_server_deplyoment_proxy:
@@ -985,7 +985,7 @@ server configuration block is shown below:
 
     }
 
-The above ``server`` block sets up Nginx to to proxy incoming connections
+The above ``server`` block sets up Nginx to proxy incoming connections
 to ``127.0.0.1`` on port 80 to ``127.0.0.1:5100`` internally. To work in this
 configuration, we will need to use some of the command line options to
 configure the Bokeh Server. In particular we need to use ``--port`` to specify
@@ -1346,8 +1346,8 @@ Now, consider when a Bokeh server is embedded inside another web page, using
 for the request to the Bokeh server is the URL of page that has the Bokeh
 content embedded it. For example, if a user navigates to our page at
 ``https://acme.com/products``, which has a Bokeh application embedded in it,
-then the origin header reported by the broweer will be ``acme.com``. In this
-instance, we typically want to restict the Bokeh server to honoring *only*
+then the origin header reported by the browser will be ``acme.com``. In this
+instance, we typically want to restrict the Bokeh server to honoring *only*
 requests that originate from our ``acme.com`` page, so that other pages cannot
 embed our Bokeh app without our knowledge.
 


### PR DESCRIPTION
Fixes spelling mistakes in docs.

Related issue: https://github.com/bokeh/bokeh/issues/8448
