### PR TITLE
only check resource passed-in args

### DIFF
--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -225,6 +225,16 @@ class BaseResources(object):
 
         self.mode = settings.resources(mode)
         del mode
+
+        if root_dir and not self.mode.startswith("relative"):
+            raise ValueError("setting 'root_dir' makes sense only when 'mode' is set to 'relative'")
+
+        if version and not self.mode.startswith("cdn"):
+            raise ValueError("setting 'version' makes sense only when 'mode' is set to 'cdn'")
+
+        if root_url and not self.mode.startswith("server"):
+            raise ValueError("setting 'root_url' makes sense only when 'mode' is set to 'server'")
+
         self.root_dir = settings.rootdir(root_dir)
         del root_dir
         self.version = settings.cdn_version(version)
@@ -256,15 +266,6 @@ class BaseResources(object):
                 "wrong value for 'mode' parameter, expected "
                 "'inline', 'cdn', 'server(-dev)', 'relative(-dev)' or 'absolute(-dev)', got %r" % self.mode
             )
-
-        if self.root_dir and not self.mode.startswith("relative"):
-            raise ValueError("setting 'root_dir' makes sense only when 'mode' is set to 'relative'")
-
-        if self.version and not self.mode.startswith("cdn"):
-            raise ValueError("setting 'version' makes sense only when 'mode' is set to 'cdn'")
-
-        if root_url and not self.mode.startswith("server"):
-            raise ValueError("setting 'root_url' makes sense only when 'mode' is set to 'server'")
 
         self.dev = self.mode.endswith("-dev")
         if self.dev:

--- a/tests/unit/bokeh/test_resources.py
+++ b/tests/unit/bokeh/test_resources.py
@@ -17,6 +17,8 @@ import pytest  # noqa isort:skip
 # Standard library imports
 import os
 import re
+import subprocess
+import sys
 
 # External imports
 from packaging.version import Version as V
@@ -315,6 +317,15 @@ class TestResources(object):
         for mode in ("inline", "cdn", "relative", "relative-dev", "absolute", "absolute-dev"):
             with pytest.raises(ValueError):
                 resources.Resources(mode, root_url="foo")
+
+    @pytest.mark.parametrize('env', ["BOKEH_CDN_VERSION", "BOKEH_ROOTDIR"])
+    def test_builtin_importable_with_env(self, monkeypatch, env) -> None:
+        cmd = [sys.executable, "-c", "import bokeh.resources"]
+        monkeypatch.setenv(env, "foo")
+        try:
+            subprocess.check_call(cmd, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError:
+            pytest.fail(f"resources import failed with {env} set")
 
 
 ## Test external resources


### PR DESCRIPTION
Resources checks for incompatible arguments should only consider passed-in args, not env var values like BOKEH_CDN_VERSION. (Otherwise INLINE, etc will blow up if any env var is set).