### PR TITLE
include script text in notebook publish

### DIFF
--- a/bokeh/core/_templates/autoload_nb_js.js
+++ b/bokeh/core/_templates/autoload_nb_js.js
@@ -75,6 +75,7 @@
       var script_attrs = bk_div.children[0].attributes;
       for (var i = 0; i < script_attrs.length; i++) {
         toinsert[toinsert.length - 1].firstChild.setAttribute(script_attrs[i].name, script_attrs[i].value);
+        toinsert[toinsert.length - 1].firstChild.textContent = bk_div.children[0].textContent
       }
       // store reference to server id on output_area
       output_area._bokeh_server_id = output.metadata[EXEC_MIME_TYPE]["server_id"];

--- a/tests/unit/bokeh/core/test_templates.py
+++ b/tests/unit/bokeh/core/test_templates.py
@@ -49,7 +49,7 @@ def compute_sha256(data):
     sha256.update(data)
     return sha256.hexdigest()
 
-pinned_template_sha256 = "882bcee1a8d3a51f6e92680029f5cba119bb0c16e637d196524fa33384bd398f"
+pinned_template_sha256 = "f3667e80d84d19b7d2b0642a3dd17131b72c0468981a3dd08227345d1fb2cfe5"
 
 def test_autoload_template_has_changed() -> None:
     """This is not really a test but a reminder that if you change the


### PR DESCRIPTION
Previously we only added an empty script tag that copied over the Bokeh autoload tag, since it was specifying a `src` attribute. Now the autoload request tag has a script as text content, which also needs to be copied over. 

- [x] issues: fixes #9737

