### PR TITLE
Fixed the multi-line example to now output

### DIFF
--- a/examples/plotting/file/multi_line.py
+++ b/examples/plotting/file/multi_line.py
@@ -5,7 +5,7 @@ from scipy.stats import norm
 
 from bokeh.layouts import gridplot
 from bokeh.models import HoverTool, TapTool
-from bokeh.palettes import Viridis6
+from bokeh.palettes import Viridis6 
 from bokeh.plotting import figure, show
 
 mass_spec = defaultdict(list)
@@ -37,12 +37,12 @@ line_opts = dict(
 )
 
 rt_plot = figure(tools=[HoverTool(**hover_opts), TapTool()], **figure_opts)
-rt_plot.multi_line(xs='RT', ys='RT_intensity', legend_field="Intensity_tip", **line_opts)
+rt_plot.multi_line(xs='RT', ys='RT_intensity',  **line_opts)
 rt_plot.xaxis.axis_label = "Retention Time (sec)"
 rt_plot.yaxis.axis_label = "Intensity"
 
 mz_plot = figure(tools=[HoverTool(**hover_opts), TapTool()], **figure_opts)
-mz_plot.multi_line(xs='MZ', ys='MZ_intensity', legend_field="Intensity_tip", **line_opts)
+mz_plot.multi_line(xs='MZ', ys='MZ_intensity',  **line_opts)
 mz_plot.legend.location = "top_center"
 mz_plot.xaxis.axis_label = "MZ"
 mz_plot.yaxis.axis_label = "Intensity"


### PR DESCRIPTION
The multi-line example was broken due to multi_line using the legend_field argument.
However this argument has been deprecated, so it was removed to make the example display output.

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [ ] issues: fixes #xxxx
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
