### PR TITLE
allow sdist to --install-js

### DIFF
--- a/_setup_support.py
+++ b/_setup_support.py
@@ -160,24 +160,22 @@ def conda_rendering():
     return os.getenv("CONDA_BUILD_STATE" ,"junk") == "RENDER"
 
 
-def fixup_building_sdist():
-    ''' Check for 'sdist' and ensure we always build BokehJS when packaging
+def check_building_sdist():
+    ''' Check for 'sdist' and ensure we always build or install BokehJS when
+    packaging
 
     Source distributions do not ship with BokehJS source code, but must ship
-    with a pre-built BokehJS library. This function modifies ``sys.argv`` as
-    necessary so that ``--build-js`` IS present, and ``--install-js` is NOT.
+    with a pre-built BokehJS library. This function checks ``sys.argv`` to
+    ensure that ``--build-js`` or ``--install-js` is present.
 
     Returns:
         None
 
     '''
     if "sdist" in sys.argv:
-        if "--install-js" in sys.argv:
-            print("Removing '--install-js' incompatible with 'sdist'")
-            sys.argv.remove('--install-js')
-        if "--build-js" not in sys.argv:
-            print("Adding '--build-js' required for 'sdist'")
-            sys.argv.append('--build-js')
+        if "--install-js" not in sys.argv and "--build-js" not in sys.argv:
+            print("Error: Option '--build-js' or '--install-js' must be present with 'sdist', exiting.")
+            sys.exit(1)
 
 def fixup_for_packaged():
     ''' If we are installing FROM an sdist, then a pre-built BokehJS is

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ if sys.version_info[:2] < (3, 6):
 from setuptools import find_packages, setup
 
 from _setup_support import (
-    build_or_install_bokehjs, conda_rendering, fixup_building_sdist,
+    build_or_install_bokehjs, check_building_sdist, conda_rendering,
     fixup_for_packaged, get_cmdclass, get_package_data, get_version,
     install_js, package_files, package_path, ROOT, SERVER, show_bokehjs,
     show_help
@@ -100,7 +100,7 @@ REQUIRES = [
 # if this is just conda-build skimming information, skip all this actual work
 if not conda_rendering():
     fixup_for_packaged()   # --build_js and --install_js not valid FROM sdist
-    fixup_building_sdist() # must build BokehJS when MAKING sdists
+    check_building_sdist() # must build or install BokehJS when MAKING sdists
 
     bokehjs_action = build_or_install_bokehjs()
 


### PR DESCRIPTION
The previous build process already double-built BokehJS. This would go to triple to compute SRI unless things are change. This PR allows sdists to be built by calling `--install-js` which will allow BokehJS to be built once up front. 
