### PR TITLE
Use variadic tuple types in signaling API

### DIFF
--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -2,7 +2,7 @@
 import {View} from "./view"
 import {Class} from "./class"
 import {Attrs} from "./types"
-import {Signal0, Signal, Signalable} from "./signaling"
+import {Signal, Signalable} from "./signaling"
 import * as property_mixins from "./property_mixins"
 import {Struct, Ref, is_ref} from "./util/refs"
 import * as p from "./properties"
@@ -177,9 +177,9 @@ export abstract class HasProps extends Signalable() {
 
   document: Document | null = null
 
-  readonly destroyed       = new Signal0<this>(this, "destroyed")
-  readonly change          = new Signal0<this>(this, "change")
-  readonly transformchange = new Signal0<this>(this, "transformchange")
+  readonly destroyed       = new Signal<this>(this, "destroyed")
+  readonly change          = new Signal<this>(this, "change")
+  readonly transformchange = new Signal<this>(this, "transformchange")
 
   readonly attributes: {[key: string]: any} = {}
   readonly properties: {[key: string]: any} = {}

--- a/bokehjs/src/lib/core/properties.ts
+++ b/bokehjs/src/lib/core/properties.ts
@@ -1,4 +1,4 @@
-import {Signal0, Signal, Signalable} from "./signaling"
+import {Signal, Signalable} from "./signaling"
 import {HasProps} from "./has_props"  // XXX: only for type purpose
 import * as enums from "./enums"
 import {Arrayable, Color as ColorType} from "./types"
@@ -58,13 +58,13 @@ export abstract class Property<T> extends Signalable() {
 
   optional: boolean = false
 
-  readonly change: Signal0<HasProps>
+  readonly change: Signal<HasProps>
 
   constructor(readonly obj: HasProps,
               readonly attr: string,
               readonly default_value?: (obj: HasProps) => T) {
     super()
-    this.change = new Signal0(this.obj, "change")
+    this.change = new Signal(this.obj, "change")
     this._init()
     this.connect(this.change, () => this._init())
   }

--- a/bokehjs/src/lib/core/ui_events.ts
+++ b/bokehjs/src/lib/core/ui_events.ts
@@ -75,7 +75,7 @@ export type KeyEvent = {
 
 export type EventType = "pan" | "pinch" | "rotate" | "move" | "tap" | "press" | "pressup" | "scroll"
 
-export type UISignal<E> = Signal<{id: string | null, e: E}, UIEvents>
+export type UISignal<E> = Signal<UIEvents, [{id: string | null, e: E}]>
 
 export class UIEvents implements EventListenerObject {
 

--- a/bokehjs/src/lib/core/view.ts
+++ b/bokehjs/src/lib/core/view.ts
@@ -1,6 +1,6 @@
 import /*type*/ {HasProps} from "./has_props"
 import {Property} from "./properties"
-import {Signal0, Signal, Slot, ISignalable} from "./signaling"
+import {Signal, Slot, ISignalable} from "./signaling"
 import {isArray} from "./util/types"
 import {uniqueId} from "./util/string"
 
@@ -16,7 +16,7 @@ export namespace View {
 
 export class View implements ISignalable {
 
-  readonly removed = new Signal0<this>(this, "removed")
+  readonly removed = new Signal<this>(this, "removed")
 
   readonly id: string
 
@@ -29,16 +29,16 @@ export class View implements ISignalable {
     return this._ready
   }
 
-  connect<Args, Sender extends object>(signal: Signal<Args, Sender>, slot: Slot<Args, Sender>): boolean {
-    const new_slot = (args: Args, sender: Sender): void => {
-      const promise = Promise.resolve(slot.call(this, args, sender))
+  connect<Sender extends object, Args extends unknown[]>(signal: Signal<Sender, Args>, slot: Slot<Sender, Args>): boolean {
+    const new_slot = (...args: unknown[]): void => {
+      const promise = Promise.resolve(slot.apply(this, args))
       this._ready = this._ready.then(() => promise)
     }
 
     return signal.connect(new_slot, this)
   }
 
-  disconnect<Args, Sender extends object>(signal: Signal<Args, Sender>, slot: Slot<Args, Sender>): boolean {
+  disconnect<Sender extends object, Args extends unknown[]>(signal: Signal<Sender, Args>, slot: Slot<Sender, Args>): boolean {
     return signal.disconnect(slot, this)
   }
 

--- a/bokehjs/src/lib/document/document.ts
+++ b/bokehjs/src/lib/document/document.ts
@@ -4,7 +4,7 @@ import {logger} from "../core/logging"
 import {BokehEvent, LODStart, LODEnd} from "core/bokeh_events"
 import {HasProps} from "core/has_props"
 import {Attrs} from "core/types"
-import {Signal0} from "core/signaling"
+import {Signal} from "core/signaling"
 import {Struct, is_ref} from "core/util/refs"
 import {decode_column_data} from "core/util/serialization"
 import {MultiDict, Set as OurSet} from "core/util/data_structures"
@@ -73,7 +73,7 @@ export const DEFAULT_TITLE = "Bokeh Application"
 export class Document {
 
   readonly event_manager: EventManager
-  readonly idle: Signal0<this>
+  readonly idle: Signal<this>
 
   protected readonly _init_timestamp: number
   protected _title: string
@@ -98,7 +98,7 @@ export class Document {
     this._callbacks = []
     this._message_callbacks = new Map()
     this.event_manager = new EventManager(this)
-    this.idle = new Signal0(this, "idle")
+    this.idle = new Signal(this, "idle")
     this._idle_roots = new WeakMap() // TODO: WeakSet would be better
     this._interactive_timestamp = null
     this._interactive_plot = null

--- a/bokehjs/src/lib/models/annotations/box_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/box_annotation.ts
@@ -1,6 +1,6 @@
 import {Annotation, AnnotationView} from "./annotation"
 import {Scale} from "../scales/scale"
-import {Signal0} from "core/signaling"
+import {Signal} from "core/signaling"
 import {LineScalar, FillScalar} from "core/property_mixins"
 import {Line, Fill} from "core/visuals"
 import {SpatialUnits, RenderMode} from "core/enums"
@@ -218,11 +218,11 @@ export class BoxAnnotation extends Annotation {
     })
   }
 
-  data_update: Signal0<this>
+  data_update: Signal<this>
 
   initialize(): void {
     super.initialize()
-    this.data_update = new Signal0(this, "data_update")
+    this.data_update = new Signal(this, "data_update")
   }
 
   update({left, right, top, bottom}: {left: number | null, right: number | null, top: number | null, bottom: number | null}): void {

--- a/bokehjs/src/lib/models/annotations/legend.ts
+++ b/bokehjs/src/lib/models/annotations/legend.ts
@@ -5,7 +5,7 @@ import {Orientation, LegendLocation, LegendClickPolicy} from "core/enums"
 import * as visuals from "core/visuals"
 import * as mixins from "core/property_mixins"
 import * as p from "core/properties"
-import {Signal0} from "core/signaling"
+import {Signal} from "core/signaling"
 import {Class} from "core/class"
 import {Size} from "core/layout"
 import {measure_font} from "core/util/text"
@@ -354,7 +354,7 @@ export class Legend extends Annotation {
   properties: Legend.Props
   default_view: Class<LegendView>
 
-  item_change: Signal0<this>
+  item_change: Signal<this>
 
   constructor(attrs?: Partial<Legend.Attrs>) {
     super(attrs)
@@ -362,7 +362,7 @@ export class Legend extends Annotation {
 
   initialize(): void {
     super.initialize()
-    this.item_change = new Signal0(this, "item_change")
+    this.item_change = new Signal(this, "item_change")
   }
 
   static init_Legend(): void {

--- a/bokehjs/src/lib/models/annotations/poly_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/poly_annotation.ts
@@ -2,7 +2,7 @@ import {Annotation, AnnotationView} from "./annotation"
 import {LineScalar, FillScalar} from "core/property_mixins"
 import {Line, Fill} from "core/visuals"
 import {SpatialUnits} from "core/enums"
-import {Signal0} from "core/signaling"
+import {Signal} from "core/signaling"
 import * as p from "core/properties"
 
 export class PolyAnnotationView extends AnnotationView {
@@ -88,7 +88,7 @@ export interface PolyAnnotation extends PolyAnnotation.Attrs {}
 export class PolyAnnotation extends Annotation {
   properties: PolyAnnotation.Props
 
-  data_update: Signal0<this>
+  data_update: Signal<this>
 
   constructor(attrs?: Partial<PolyAnnotation.Attrs>) {
     super(attrs)
@@ -122,7 +122,7 @@ export class PolyAnnotation extends Annotation {
 
   initialize(): void {
     super.initialize()
-    this.data_update = new Signal0(this, "data_update")
+    this.data_update = new Signal(this, "data_update")
   }
 
   update({xs, ys}: {xs: number[], ys: number[]}): void {

--- a/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
@@ -1,4 +1,4 @@
-import {Signal0} from "core/signaling"
+import {Signal} from "core/signaling"
 import {div, remove} from "core/dom"
 import {wgs84_mercator} from "core/util/projections"
 import {Context2d} from "core/util/canvas"
@@ -11,7 +11,7 @@ declare global {
   }
 }
 
-const gmaps_ready = new Signal0({}, "gmaps_ready")
+const gmaps_ready = new Signal({}, "gmaps_ready")
 
 const load_google_api = function(api_key: string): void {
   window._bokeh_gmaps_callback = () => gmaps_ready.emit()

--- a/bokehjs/src/lib/models/plots/plot.ts
+++ b/bokehjs/src/lib/models/plots/plot.ts
@@ -2,7 +2,7 @@ import * as mixins from "core/property_mixins"
 import * as visuals from "core/visuals"
 import * as p from "core/properties"
 import {Class} from "core/class"
-import {Signal0} from "core/signaling"
+import {Signal} from "core/signaling"
 import {Place, Location, OutputBackend, ResetPolicy} from "core/enums"
 import {remove_by, concat} from "core/util/array"
 import {values} from "core/util/object"
@@ -105,7 +105,7 @@ export class Plot extends LayoutDOM {
 
   use_map?: boolean
 
-  reset: Signal0<this>
+  reset: Signal<this>
 
   constructor(attrs?: Partial<Plot.Attrs>) {
     super(attrs)
@@ -197,7 +197,7 @@ export class Plot extends LayoutDOM {
   initialize(): void {
     super.initialize()
 
-    this.reset = new Signal0(this, "reset")
+    this.reset = new Signal(this, "reset")
 
     for (const xr of values(this.extra_x_ranges).concat(this.x_range)) {
       let plots = xr.plots

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -15,7 +15,7 @@ import {ToolbarPanel} from "../annotations/toolbar_panel"
 
 import {Reset} from "core/bokeh_events"
 import {Arrayable, Rect, Interval} from "core/types"
-import {Signal0} from "core/signaling"
+import {Signal} from "core/signaling"
 import {build_view, build_views, remove_views} from "core/build_views"
 import {UIEvents} from "core/ui_events"
 import {Visuals} from "core/visuals"
@@ -129,8 +129,8 @@ export class PlotView extends LayoutDOMView {
   protected _needs_paint: boolean = true
   protected _needs_layout: boolean = false
 
-  force_paint: Signal0<this>
-  state_changed: Signal0<this>
+  force_paint: Signal<this>
+  state_changed: Signal<this>
   visibility_callbacks: ((visible: boolean) => void)[]
 
   protected _is_paused?: number
@@ -222,8 +222,8 @@ export class PlotView extends LayoutDOMView {
 
     super.initialize()
 
-    this.force_paint = new Signal0(this, "force_paint")
-    this.state_changed = new Signal0(this, "state_changed")
+    this.force_paint = new Signal(this, "force_paint")
+    this.state_changed = new Signal(this, "state_changed")
 
     this.lod_started = false
     this.visuals = new Visuals(this.model) as any // XXX

--- a/bokehjs/src/lib/models/sources/columnar_data_source.ts
+++ b/bokehjs/src/lib/models/sources/columnar_data_source.ts
@@ -1,5 +1,5 @@
 import {DataSource} from "./data_source"
-import {Signal, Signal0} from "core/signaling"
+import {Signal} from "core/signaling"
 import {logger} from "core/logging"
 import {SelectionManager} from "core/selection_manager"
 import * as p from "core/properties"
@@ -44,11 +44,11 @@ export abstract class ColumnarDataSource extends DataSource {
     return column as T[]
   }
 
-  _select: Signal0<this>
-  inspect: Signal<unknown, this> // XXX: <[indices, tool, renderer-view, source, data], this>
+  _select: Signal<this>
+  inspect: Signal<this, [unknown]> // XXX: <[indices, tool, renderer-view, source, data], this>
 
-  streaming: Signal0<this>
-  patching: Signal<number[], this>
+  streaming: Signal<this>
+  patching: Signal<this, [number[]]>
 
   constructor(attrs?: Partial<ColumnarDataSource.Attrs>) {
     super(attrs)
@@ -69,10 +69,10 @@ export abstract class ColumnarDataSource extends DataSource {
   initialize(): void {
     super.initialize()
 
-    this._select = new Signal0(this, "select")
+    this._select = new Signal(this, "select")
     this.inspect = new Signal(this, "inspect") // XXX: <[indices, tool, renderer-view, source, data], this>
 
-    this.streaming = new Signal0(this, "streaming")
+    this.streaming = new Signal(this, "streaming")
     this.patching = new Signal(this, "patching")
   }
 

--- a/bokehjs/src/lib/models/tools/actions/action_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/action_tool.ts
@@ -1,5 +1,5 @@
 import {ButtonTool, ButtonToolView, ButtonToolButtonView} from "../button_tool"
-import {Signal0} from "core/signaling"
+import {Signal} from "core/signaling"
 import * as p from "core/properties"
 
 export class ActionToolButtonView extends ButtonToolButtonView {
@@ -38,5 +38,5 @@ export abstract class ActionTool extends ButtonTool {
 
   button_view = ActionToolButtonView
 
-  do = new Signal0<this>(this, "do")
+  do = new Signal<this>(this, "do")
 }

--- a/bokehjs/src/lib/models/tools/tool_proxy.ts
+++ b/bokehjs/src/lib/models/tools/tool_proxy.ts
@@ -1,6 +1,6 @@
 import * as p from "core/properties"
 import {EventType} from "core/ui_events"
-import {Signal0} from "core/signaling"
+import {Signal} from "core/signaling"
 import {Class} from "core/class"
 import {Model} from "../../model"
 import {ButtonTool, ButtonToolButtonView} from "./button_tool"
@@ -33,7 +33,7 @@ export class ToolProxy extends Model {
     })
   }
 
-  do: Signal0<this>
+  do: Signal<this>
 
   // Operates all the tools given only one button
 
@@ -68,7 +68,7 @@ export class ToolProxy extends Model {
 
   initialize(): void {
     super.initialize()
-    this.do = new Signal0(this, "do")
+    this.do = new Signal(this, "do")
   }
 
   connect_signals(): void {

--- a/bokehjs/test/unit/core/signaling.ts
+++ b/bokehjs/test/unit/core/signaling.ts
@@ -9,26 +9,30 @@ describe("core/signaling module", () => {
     })
 
     it("should support `{dis}connect()` method", () => {
-      const signal = new Signal(Object.create(null), "some")
+      class Obj {}
+      const signal = new Signal<Obj, [number, string, number[]]>(new Obj(), "some")
 
-      let signaled: number = 0
-      const fn = (val: number) => signaled = val
+      let signaled: [number, string, number[], Obj?] | null = null
 
-      expect(signal.connect(fn)).to.be.equal(true)
-      expect(signal.connect(fn)).to.be.equal(false)
+      const fn0 = (val0: number, val1: string, val2: number[]) => {
+        signaled = [val0, val1, val2]
+      }
 
-      expect(signaled).to.be.equal(0)
+      expect(signal.connect(fn0)).to.be.equal(true)
+      expect(signal.connect(fn0)).to.be.equal(false)
 
-      signal.emit(1)
-      expect(signaled).to.be.equal(1)
-      signal.emit(2)
-      expect(signaled).to.be.equal(2)
+      expect(signaled).to.be.equal(null)
 
-      expect(signal.disconnect(fn)).to.be.equal(true)
-      expect(signal.disconnect(fn)).to.be.equal(false)
+      signal.emit(1, "a", [0, 1])
+      expect(signaled).to.be.deep.equal([1, "a", [0, 1]])
+      signal.emit(2, "b", [1, 2])
+      expect(signaled).to.be.deep.equal([2, "b", [1, 2]])
 
-      signal.emit(3)
-      expect(signaled).to.be.equal(2)
+      expect(signal.disconnect(fn0)).to.be.equal(true)
+      expect(signal.disconnect(fn0)).to.be.equal(false)
+
+      signal.emit(3, "c", [2, 3])
+      expect(signaled).to.be.deep.equal([2, "b", [1, 2]])
     })
   })
 })


### PR DESCRIPTION
This attempts to drop `Signal0` and to allow strictly statically typed API with just `Signal` class.