### PR TITLE
Update setting asyncio event loop policy

### DIFF
--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -689,16 +689,7 @@ BokehTornado.__doc__ = format_docstring(
 # See https://github.com/bokeh/bokeh/issues/9507
 if sys.platform == 'win32' and sys.version_info[:3] >= (3, 8, 0):
     import asyncio
-    try:
-        from asyncio import (
-            WindowsProactorEventLoopPolicy,
-            WindowsSelectorEventLoopPolicy,
-        )
-    except ImportError:
-        # not affected
-        pass
-    else:
-        if type(asyncio.get_event_loop_policy()) is WindowsProactorEventLoopPolicy:
-            # WindowsProactorEventLoopPolicy is not compatible with tornado 6
-            # fallback to the pre-3.8 default of WindowsSelectorEventLoopPolicy
-            asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())
+    if type(asyncio.get_event_loop_policy()) is asyncio.WindowsProactorEventLoopPolicy:
+        # WindowsProactorEventLoopPolicy is not compatible with tornado 6
+        # fallback to the pre-3.8 default of WindowsSelectorEventLoopPolicy
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -689,4 +689,16 @@ BokehTornado.__doc__ = format_docstring(
 # See https://github.com/bokeh/bokeh/issues/9507
 if sys.platform == 'win32' and sys.version_info[:3] >= (3, 8, 0):
     import asyncio
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    try:
+        from asyncio import (
+            WindowsProactorEventLoopPolicy,
+            WindowsSelectorEventLoopPolicy,
+        )
+    except ImportError:
+        # not affected
+        pass
+    else:
+        if type(asyncio.get_event_loop_policy()) is WindowsProactorEventLoopPolicy:
+            # WindowsProactorEventLoopPolicy is not compatible with tornado 6
+            # fallback to the pre-3.8 default of WindowsSelectorEventLoopPolicy
+            asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())


### PR DESCRIPTION
This PR updates when we set the event loop policy to ensure that we continue to avoid using `asyncio.WindowsProactorEventLoopPolicy` on Windows and Python 3.8+ (which is incompatible with tornado https://github.com/tornadoweb/tornado/issues/2608), but also avoids clashing with other applications that use `bokeh` and also need to use custom event loop policies. This is a similar approach that was [taken over in Jupyter](https://github.com/jupyter/notebook/blob/f354740e57f206d67bfb077a9f23bb8d22b6b311/notebook/notebookapp.py#L1741-L1755).

- [x] issues: fixes #9775
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
