### PR TITLE
Fixes typos and adds missing words to documentation

### DIFF
--- a/bokeh/core/__init__.py
+++ b/bokeh/core/__init__.py
@@ -18,7 +18,7 @@ custom extensions to Bokeh. These are listed below:
 
 :ref:`bokeh.core.properties`
     The fundamental building block of Bokeh apps and documents is the Bokeh
-    models, for instance plots, ranges, axes, etc. Bokeh models are comrpised
+    models, for instance plots, ranges, axes, etc. Bokeh models are comprised
     of properties, which are named attributes with specified types. Model
     properties can automatically validate and serialize themselves. This
     section describes all the property types that can be attached to Bokeh

--- a/sphinx/source/docs/dev_guide/server.rst
+++ b/sphinx/source/docs/dev_guide/server.rst
@@ -30,8 +30,8 @@ session; the application fills in the session's document with whatever plots,
 widgets, or other content it desires. The application can also set up
 callbacks, to run periodically or to run when the document changes.
 
-Applications are represented by the ``Application`` class. This class is
-contains list of ``Handler`` instances and optional metadata. Handlers
+Applications are represented by the ``Application`` class. This class
+contains a list of ``Handler`` instances and optional metadata. Handlers
 can be created in lots of ways; from JSON files, from Python functions, from
 Python files, and perhaps many more ways in the future.  The optional metadata
 is available as a JSON blob via the ``/metadata`` endpoint.  For example,

--- a/sphinx/source/docs/reference/core/properties.rst
+++ b/sphinx/source/docs/reference/core/properties.rst
@@ -3,7 +3,7 @@
 bokeh.core.properties
 ---------------------
 
-In order to streamline and automate the creation and use of models that can
+In order to streamline and automate the creation and use of models that can be used
 for describing plots and scenes, Bokeh provides a collection of properties
 and property mixins. Property classes provide automatic validation and
 serialization for a large collection of useful types. Mixin and container


### PR DESCRIPTION
Fixes typos and adds missing words to documentation.

Related issue: #8448