### PR TITLE
Allow subclasses of Serve subcommand to modify server_kwargs

### DIFF
--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -412,7 +412,7 @@ import argparse
 import os
 from fnmatch import fnmatch
 from glob import glob
-from typing import List
+from typing import List, Dict, Any
 
 # External imports
 from tornado.autoreload import watch
@@ -727,6 +727,11 @@ class Serve(Subcommand):
         )),
     )
 
+    def _update_server_kwargs(self, args: argparse.Namespace, server_kwargs: Dict[str, Any]) -> None:
+        '''
+        Allows subclasses of the Subcommand to modify server_kwargs.
+        '''
+
     def invoke(self, args: argparse.Namespace) -> None:
         '''
 
@@ -866,6 +871,8 @@ class Serve(Subcommand):
 
             find_autoreload_targets(args.files[0])
             add_optional_autoreload_files(args.dev)
+
+        self._update_server_kwargs(args, server_kwargs)
 
         with report_server_init_errors(**server_kwargs):
             server = Server(applications, **server_kwargs)

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -728,10 +728,11 @@ class Serve(Subcommand):
     )
 
     def customize_kwargs(self, args: argparse.Namespace, server_kwargs: Dict[str, Any]) -> Dict[str, Any]:
-        '''Allows subclasses to return kwargs to be merged with server_kwargs.
+        '''Allows subclasses to customize ``server_kwargs``.
 
+        Should modify and return a copy of the ``server_kwargs`` dictionary.
         '''
-        return {}
+        return dict(server_kwargs)
 
     def invoke(self, args: argparse.Namespace) -> None:
         '''
@@ -873,7 +874,7 @@ class Serve(Subcommand):
             find_autoreload_targets(args.files[0])
             add_optional_autoreload_files(args.dev)
 
-        server_kwargs.update(self.customize_kwargs(args, server_kwargs))
+        server_kwargs = self.customize_kwargs(args, server_kwargs)
 
         with report_server_init_errors(**server_kwargs):
             server = Server(applications, **server_kwargs)

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -412,7 +412,7 @@ import argparse
 import os
 from fnmatch import fnmatch
 from glob import glob
-from typing import List, Dict, Any
+from typing import Any, Dict, List
 
 # External imports
 from tornado.autoreload import watch
@@ -727,10 +727,11 @@ class Serve(Subcommand):
         )),
     )
 
-    def _update_server_kwargs(self, args: argparse.Namespace, server_kwargs: Dict[str, Any]) -> None:
+    def customize_kwargs(self, args: argparse.Namespace, server_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        '''Allows subclasses to return kwargs to be merged with server_kwargs.
+
         '''
-        Allows subclasses of the Subcommand to modify server_kwargs.
-        '''
+        return {}
 
     def invoke(self, args: argparse.Namespace) -> None:
         '''
@@ -872,7 +873,7 @@ class Serve(Subcommand):
             find_autoreload_targets(args.files[0])
             add_optional_autoreload_files(args.dev)
 
-        self._update_server_kwargs(args, server_kwargs)
+        server_kwargs.update(self.customize_kwargs(args, server_kwargs))
 
         with report_server_init_errors(**server_kwargs):
             server = Server(applications, **server_kwargs)


### PR DESCRIPTION
Minor addition which allows downstream libraries (e.g. Panel) to subclass the `bokeh serve` CLI subcommand to add additional server_kwargs, e.g. to add additional tornado RequestHandlers. 

(Apologies I don't know how best to tag this)

- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
