### PR TITLE
Add support for Bokeh.loader["@bokehjs/module/name"]

### DIFF
--- a/bokehjs/src/compiler/prelude.ts
+++ b/bokehjs/src/compiler/prelude.ts
@@ -104,6 +104,15 @@ ${comment(license)}
     var main = require(entry);
     main.require = require;
 
+    if (typeof Proxy !== "undefined") {
+      // allow Bokeh.loader["@bokehjs/module/name"] syntax
+      main.loader = new Proxy({}, {
+        get: function(_obj, module) {
+          return require(module);
+        }
+      });
+    }
+
     main.register_plugin = function(plugin_modules, plugin_entry, plugin_aliases, plugin_externals) {
       if (plugin_aliases === undefined) plugin_aliases = {};
       if (plugin_externals === undefined) plugin_externals = {};


### PR DESCRIPTION
This is required to allow bokehjs external imports from webpack bundles (e.g. from extensions packed with webpack). Webpack can support such workflow, but only through their convoluted approach, i.e. one can't just rewrite `import {HasProps} from "@bokehjs/core/has_props"` as `const {HasProps} = Bokeh.require("@bokehjs/core/has_props")`, which we currently support, but it must be `const {HasProps} = window["Bokeh"]["loader"]["@bokehjs/core/has_props"]`. The indexing part is fixed in webpack and can't be changed through configuration, but can be worked around with a `Proxy`. This isn't supported in IE, but given this is need for ipywidgets support, IE is not in the picture anyway.