### PR TITLE
Allow to serve extensions' bundles and related resources

### DIFF
--- a/bokeh/embed/bundle.py
+++ b/bokeh/embed/bundle.py
@@ -19,7 +19,9 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from os.path import dirname, exists, join
+import json
+from os.path import abspath, basename, dirname, exists, join
+from typing import Dict, List, NamedTuple, Optional
 from warnings import warn
 
 # Bokeh imports
@@ -176,7 +178,17 @@ def bundle_for_objs_and_resources(objs, resources):
         css_files.extend(css_resources.css_files)
         css_raw.extend(css_resources.css_raw)
 
-    js_raw.extend(_bundle_extensions(objs, resources))
+    if js_resources:
+        extensions = _bundle_extensions(objs, js_resources)
+        mode = js_resources.mode if resources is not None else "inline"
+        if mode == "inline":
+            js_raw.extend([ Resources._inline(bundle.artifact_path) for bundle in extensions ])
+        elif mode == "server":
+            js_files.extend([ bundle.server_url for bundle in extensions ])
+        elif mode == "cdn":
+            js_files.extend([ bundle.cdn_url for bundle in extensions ])
+        else:
+            js_files.extend([ bundle.artifact_path for bundle in extensions ])
 
     models = [ obj.__class__ for obj in _all_objs(objs) ] if objs else None
     ext = bundle_models(models)
@@ -209,9 +221,20 @@ def _query_extensions(objs, query):
 
     return False
 
-def _bundle_extensions(objs, resources):
+_default_cdn_host = "https://unpkg.com"
+
+class ExtensionEmbed(NamedTuple):
+    artifact_path: str
+    server_url: str
+    cdn_url: Optional[str] = None
+
+extension_dirs: Dict[str, str] = {} # name -> path
+
+def _bundle_extensions(objs, resources: Resources) -> List[ExtensionEmbed]:
     names = set()
-    extensions = []
+    bundles = []
+
+    extensions = [".min.js", ".js"] if resources.minified else [".js"]
 
     for obj in _all_objs(objs) if objs is not None else Model.model_class_reverse_map.values():
         if hasattr(obj, "__implementation__"):
@@ -223,13 +246,58 @@ def _bundle_extensions(objs, resources):
             continue
         names.add(name)
         module = __import__(name)
-        ext = ".min.js" if resources is None or resources.minified else ".js"
-        artifact = join(dirname(module.__file__), "dist", name + ext)
-        if exists(artifact):
-            bundle = BaseResources._inline(artifact)
-            extensions.append(bundle)
+        this_file = abspath(module.__file__)
+        base_dir = dirname(this_file)
+        dist_dir = join(base_dir, "dist")
 
-    return extensions
+        ext_path = join(base_dir, "bokeh.ext.json")
+        if not exists(ext_path):
+            continue
+
+        server_prefix = f"{resources.root_url}static/extensions"
+        package_path = join(base_dir, "package.json")
+
+        pkg: Optional[str] = None
+
+        if exists(package_path):
+            with open(package_path) as io:
+                try:
+                    pkg = json.load(io)
+                except json.decoder.JSONDecodeError:
+                    pass
+
+        artifact_path: str
+        server_url: str
+        cdn_url: Optional[str] = None
+
+        if pkg is not None:
+            pkg_name = pkg["name"]
+            pkg_version = pkg.get("version", "latest")
+            pkg_main = pkg.get("module", pkg.get("main", None))
+            if pkg_main is not None:
+                cdn_url = f"{_default_cdn_host}/{pkg_name}@^{pkg_version}/{pkg_main}"
+            else:
+                pkg_main = join(dist_dir, f"{name}.js")
+            artifact_path = join(base_dir, pkg_main)
+            artifacts_dir = dirname(artifact_path)
+            artifact_name = basename(artifact_path)
+            server_path = f"{name}/{artifact_name}"
+        else:
+            for ext in extensions:
+                artifact_path = join(dist_dir, f"{name}{ext}")
+                artifacts_dir = dist_dir
+                server_path = f"{name}/{name}{ext}"
+                if exists(artifact_path):
+                    break
+            else:
+                raise ValueError(f"can't resolve artifact path for '{name}' extension")
+
+        extension_dirs[name] = artifacts_dir
+        server_url = f"{server_prefix}/{server_path}"
+        embed = ExtensionEmbed(artifact_path, server_url, cdn_url)
+        bundles.append(embed)
+
+    return bundles
 
 def _all_objs(objs):
     all_objs = set()

--- a/bokeh/server/urls.py
+++ b/bokeh/server/urls.py
@@ -53,9 +53,11 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Bokeh imports
+from ..embed.bundle import extension_dirs
 from .views.autoload_js_handler import AutoloadJsHandler
 from .views.doc_handler import DocHandler
 from .views.metadata_handler import MetadataHandler
+from .views.multi_root_static_handler import MultiRootStaticHandler
 from .views.root_handler import RootHandler
 from .views.static_handler import StaticHandler
 from .views.ws import WSHandler
@@ -79,6 +81,7 @@ __all__ = (
 
 toplevel_patterns = [
     (r'/?', RootHandler),
+    (r'/static/extensions/(.*)', MultiRootStaticHandler, dict(root=extension_dirs)),
     (r'/static/(.*)', StaticHandler),
 ]
 


### PR DESCRIPTION
So far, extensions compiled ahead of time (new-style extensions) can be embedded only inline. This PR allows to serve compiled bundles by bokeh server and consume extensions' resources from CDN (unpkg.com). This is an early preview and I will need to redesign this to allow serving other resources (e.g. fonts). This is needed to finalize https://github.com/bokeh/ipywidgets_bokeh/pull/5.