### PR TITLE
fixed typos and git pre-commit hook instructions

### DIFF
--- a/sphinx/source/docs/dev_guide/setup.rst
+++ b/sphinx/source/docs/dev_guide/setup.rst
@@ -223,7 +223,7 @@ In order to help prevent some accidental errors, here are some git hooks
 that may be useful. The scripts below should be placed in the ``.git/hooks``
 subdirectory in the top level of the *source checkout* directory and be
 marked executable with e.g. ``chmod +x pre-commit``. For more information
-on git hooks, see `this turorial`_.
+on git hooks, see `this tutorial`_.
 
 ``pre-commit``
 
@@ -235,7 +235,7 @@ on git hooks, see `this turorial`_.
 
         #!/bin/bash
 
-        py.test -m codebase
+        py.test tests/codebase
         exit $?
 
 ``pre-push``
@@ -422,4 +422,4 @@ If you have any problems with the steps here, please `contact the developers`_.
 .. _Installing Git: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
 .. _meta.yaml: http://github.com/bokeh/bokeh/blob/master/conda.recipe/meta.yaml
 .. _Pro Git Book: https://git-scm.com/book/en/v2
-.. _this turorial: https://www.digitalocean.com/community/tutorials/how-to-use-git-hooks-to-automate-development-and-deployment-tasks
+.. _this tutorial: https://www.digitalocean.com/community/tutorials/how-to-use-git-hooks-to-automate-development-and-deployment-tasks


### PR DESCRIPTION
This is a fix for #9816, with one additional "turorial" corrected to "tutorial."