### PR TITLE
Docs: clarify that ``DataSource.selected`` is read-only

### DIFF
--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -71,7 +71,9 @@ class DataSource(Model):
     '''
 
     selected = Instance(Selection, default=lambda: Selection(), readonly=True, help="""
-    A Selection that indicates selected indices on this ``DataSource``.
+    An instance of a ``Selection`` that indicates selected indices on this ``DataSource``.
+    This is a read-only property. You may only change the attributes of this object
+    to change the selection (e.g., ``selected.indices``).
     """)
 
 @abstract


### PR DESCRIPTION
In #9823 I reported being confused that the constructor of `ColumnDataSource` no longer accepts a `selected` argument as of v2.0, even though it is listed as one of the class properties [in the reference docs](http://docs.bokeh.org/en/latest/docs/reference/models/sources.html?highlight=columndatasource#bokeh.models.sources.ColumnDataSource.selected).

This PR proposes a small addition to the documentation to emphasize that `ColumnDataSource.selected` is now read-only.