### PR TITLE
[WIP] Move functionality from Server to BaseServer and BokehTornado

### DIFF
--- a/bokeh/server/server.py
+++ b/bokeh/server/server.py
@@ -43,7 +43,6 @@ from tornado.ioloop import IOLoop
 
 # Bokeh imports
 from .. import __version__
-from ..application import Application
 from ..core.properties import Bool, Int, List, String
 from ..resources import DEFAULT_SERVER_PORT
 from ..util.options import Options
@@ -409,8 +408,8 @@ class Server(BaseServer):
         try:
             tornado_app = BokehTornado(applications,
                                        extra_websocket_origins=extra_websocket_origins,
-                                       prefix=self.prefix,
-                                       index=self.index,
+                                       prefix=opts.prefix,
+                                       index=opts.index,
                                        websocket_max_message_size_bytes=opts.websocket_max_message_size,
                                        **kwargs)
 

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -224,6 +224,23 @@ class BokehTornado(TornadoApplication):
         # This will be set when initialize is called
         self._loop = None
 
+        # Convert functions into Applications
+        from bokeh.application.handlers.function import FunctionHandler
+        from bokeh.application.handlers.document_lifecycle import DocumentLifecycleHandler
+
+        if callable(applications):
+            applications = Application(FunctionHandler(applications))
+
+        if isinstance(applications, Application):
+            applications = { '/' : applications }
+
+        for k, v in list(applications.items()):
+            if callable(v):
+                applications[k] = Application(FunctionHandler(v))
+            if all(not isinstance(handler, DocumentLifecycleHandler)
+                   for handler in applications[k]._handlers):
+                applications[k].add(DocumentLifecycleHandler())
+
         if isinstance(applications, Application):
             applications = { '/' : applications }
 


### PR DESCRIPTION
This makes it easier to use Bokeh Server with existing HTTPServers
by moving some logic from the Server constructor (which assumes that it
creates an HTTPServer) off to BaseServer and BokehTornado, which don't
make that assumption.

Fixes #9813

- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)