### PR TITLE
Skip painting empty indices when using webgl backend

### DIFF
--- a/bokehjs/src/lib/models/glyphs/webgl/base.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/base.ts
@@ -33,6 +33,11 @@ export abstract class BaseGLGlyph {
   }
 
   render(_ctx: Context2d, indices: number[], mainglyph: GlyphView): boolean {
+    if (indices.length == 0) {
+      // Implementations assume at least one index to draw. We return true,
+      // because there is no need to switch back to a fallback renderer.
+      return true
+    }
     // Get transform
     const [a, b, c] = [0, 1, 2]
     let wx = 1   // Weights to scale our vectors

--- a/bokehjs/test/baselines/Plot__with_webgl_backend__should_allow_empty_circle_glyphs
+++ b/bokehjs/test/baselines/Plot__with_webgl_backend__should_allow_empty_circle_glyphs
@@ -1,0 +1,3 @@
+Plot bbox=[0, 0, 200, 200]
+  LinearAxis bbox=[18, 176, 177, 24]
+  LinearAxis bbox=[0, 5, 18, 171]

--- a/bokehjs/test/baselines/Plot__with_webgl_backend__should_allow_empty_line_glyphs
+++ b/bokehjs/test/baselines/Plot__with_webgl_backend__should_allow_empty_line_glyphs
@@ -1,0 +1,3 @@
+Plot bbox=[0, 0, 200, 200]
+  LinearAxis bbox=[18, 176, 177, 24]
+  LinearAxis bbox=[0, 5, 18, 171]

--- a/bokehjs/test/devtools/template.html
+++ b/bokehjs/test/devtools/template.html
@@ -20,6 +20,7 @@
       }
     </style>
     <script type="text/javascript" src="/static/js/bokeh.js"></script>
+    <script type="text/javascript" src="/static/js/bokeh-gl.js"></script>
     <script type="text/javascript" src="/static/js/bokeh-api.js"></script>
     <script type="text/javascript" src="/static/js/bokeh-widgets.js"></script>
     <script type="text/javascript" src="/static/js/bokeh-tables.js"></script>

--- a/bokehjs/test/integration/index.ts
+++ b/bokehjs/test/integration/index.ts
@@ -378,6 +378,26 @@ describe("Plot", () => {
     const row = new Row({children: [fig0, fig1]})
     await display(row, [600, 300])
   })
+
+  describe("with webgl backend", () => {
+    function webgl_figure() {
+      return figure({width: 200, height: 200, toolbar_location: null, title: null, output_backend: "webgl"})
+    }
+
+    it("should allow empty line glyphs", async () => {
+      const p = webgl_figure()
+      p.line([1, 2, 3], [1, 4, 9], {line_width: 3})
+      p.line([], [], {line_width: 3})
+      await display(p, [300, 300])
+    })
+
+    it("should allow empty circle glyphs", async () => {
+      const p = webgl_figure()
+      p.circle([1, 2, 3], [1, 4, 9], {size: 10})
+      p.circle([], [], {size: 10})
+      await display(p, [300, 300])
+    })
+  })
 })
 
 describe("ToolbarBox", () => {


### PR DESCRIPTION
fixes #9837 