### PR TITLE
Allow to use multiple versions of bokehjs on one page

### DIFF
--- a/bokeh/io/export.py
+++ b/bokeh/io/export.py
@@ -362,7 +362,7 @@ function done() {
   window._bokeh_render_complete = true;
 }
 
-var doc = window.Bokeh.documents[0];
+var doc = Bokeh.documents[0];
 
 if (doc.is_idle)
   done();

--- a/bokehjs/make/tasks/scripts.ts
+++ b/bokehjs/make/tasks/scripts.ts
@@ -5,6 +5,7 @@ import {task, log} from "../task"
 import {rename, write} from "@compiler/sys"
 import {compile_typescript} from "@compiler/compiler"
 import {Linker} from "@compiler/linker"
+import * as preludes from "@compiler/prelude"
 import * as paths from "../paths"
 
 import pkg from "../../package.json"
@@ -40,6 +41,8 @@ task("scripts:bundle", ["scripts:compile"], async () => {
     entries: packages.map((pkg) => pkg.main),
     bases: [paths.build_dir.lib, "./node_modules"],
     cache: argv.cache !== false ? join(paths.build_dir.js, "bokeh.json") : undefined,
+    prelude: preludes.prelude,
+    plugin_prelude: () => preludes.plugin_prelude({version: pkg.version}),
     transpile: "ES2017",
     exports: ["tslib"],
   })

--- a/bokehjs/make/tasks/scripts.ts
+++ b/bokehjs/make/tasks/scripts.ts
@@ -2,12 +2,22 @@ import {join} from "path"
 import {argv} from "yargs"
 
 import {task, log} from "../task"
-import {rename} from "@compiler/sys"
+import {rename, write} from "@compiler/sys"
 import {compile_typescript} from "@compiler/compiler"
 import {Linker} from "@compiler/linker"
 import * as paths from "../paths"
 
-task("scripts:compile", ["styles:compile"], async () => {
+import pkg from "../../package.json"
+
+task("scripts:version", async () => {
+  const js = `export const version = "${pkg.version}";\n`
+  write(join(paths.build_dir.lib, "version.js"), js)
+
+  const dts = `export declare const version: string;\n`
+  write(join(paths.build_dir.types, "version.d.ts"), dts)
+})
+
+task("scripts:compile", ["styles:compile", "scripts:version"], async () => {
   const success = compile_typescript(join(paths.src_dir.lib, "tsconfig.json"), {
     log,
     out_dir: {js: paths.build_dir.lib, dts: paths.build_dir.types},

--- a/bokehjs/make/tasks/test.ts
+++ b/bokehjs/make/tasks/test.ts
@@ -103,7 +103,7 @@ function bundle(name: string): void {
     cache: join(paths.build_dir.test, `${name}.json`),
     transpile: "ES2017",
     externals: [/^@bokehjs\//],
-    prelude: default_prelude({global: "Tests"}),
+    prelude: () => default_prelude({global: "Tests"}),
     shims: ["fs", "module"],
   })
 

--- a/bokehjs/src/lib/embed/notebook.ts
+++ b/bokehjs/src/lib/embed/notebook.ts
@@ -12,7 +12,7 @@ import "styles/notebook"
 
 // This exists to allow the @bokeh/jupyter_bokeh extension to store the
 // notebook kernel so that _init_comms can register the comms target.
-// This has to be available at window.Bokeh.embed.kernels in JupyterLab.
+// This has to be available at Bokeh.embed.kernels in JupyterLab.
 export const kernels: {[key: string]: unknown} = {}
 
 function _handle_notebook_comms(this: Document, receiver: Receiver, comm_msg: CommMessage): void {

--- a/bokehjs/src/lib/version.d.ts
+++ b/bokehjs/src/lib/version.d.ts
@@ -1,0 +1,1 @@
+declare export const version: string

--- a/bokehjs/src/lib/version.ts
+++ b/bokehjs/src/lib/version.ts
@@ -1,1 +1,0 @@
-export const version = '2.0.2-dev.1'

--- a/release/git.py
+++ b/release/git.py
@@ -10,6 +10,7 @@ import json
 import re
 from os.path import abspath, dirname, join, pardir
 from subprocess import CalledProcessError
+from typing import List
 
 # External imports
 from packaging.version import Version as V
@@ -124,12 +125,9 @@ def update_changelog(config: Config, system: System) -> None:
 
 
 def update_bokehjs_versions(config: Config, system: System) -> None:
+    regex_filenames: List[str] = []
 
-    regex_filenames = [
-        "bokehjs/src/lib/version.ts",
-    ]
-
-    json_filenames = [
+    json_filenames: List[str] = [
         "bokehjs/package.json",
         "bokehjs/package-lock.json",
     ]


### PR DESCRIPTION
Currently when bokehjs is loaded from bundles it stores an instance of its main bundle's entry point as `Bokeh` global. If multiple versions of bokehjs are loaded, then they overwrite that global and it's impossible to use any version than the last. This PR makes only the first bundle to touch `Bokeh`. The first and all other bundle will register themselves as `Bokeh[version]` (so the first one can be accessed by both), where `version` is the version of bokehjs as defined in `package.json`.

fixes #9812
