### PR TITLE
Fix minor typo in bokeh.transform reference docs

### DIFF
--- a/bokeh/transform.py
+++ b/bokeh/transform.py
@@ -53,7 +53,7 @@ __all__ = (
 #-----------------------------------------------------------------------------
 
 def cumsum(field, include_zero=False):
-    ''' Create a Create a ``DataSpec`` dict to generate a ``CumSum`` expression
+    ''' Create a ``DataSpec`` dict to generate a ``CumSum`` expression
     for a ``ColumnDataSource``.
 
     Examples:


### PR DESCRIPTION
Fixes a minor typo in bokeh.transform reference docs
> **cumsum(field, include_zero=False)**
>    &nbsp; &nbsp; Create a Create a DataSpec dict to generate a CumSum expression for a ColumnDataSource.

The `Create a` occurs twice.

- [x] issues: fixes #9848 