### PR TITLE
Bryanv/correct js version full release

### DIFF
--- a/release/config.py
+++ b/release/config.py
@@ -42,6 +42,8 @@ class Config(object):
         self.upload_status: Dict[str, ActionStatus] = defaultdict(lambda: ActionStatus.NOT_STARTED)
 
     def _to_js_version(self, v: str) -> str:
+        if FULL_VERSION.match(v):
+            return v
         match = ANY_VERSION.match(v)
         if not match:
             raise ValueError(f"Invalid verison {v!r}")


### PR DESCRIPTION
On a full release version, JS version update code produced:

> [PASS] Updated version from '2.0.1-rc.2' to '2.0.1-**None.None**' in file 'bokehjs/src/lib/version.ts'


