### PR TITLE
Sphinx 3.0 compat

### DIFF
--- a/bokeh/embed/__init__.py
+++ b/bokeh/embed/__init__.py
@@ -7,13 +7,6 @@
 ''' Provide functions for embedding Bokeh standalone and server content in
 web pages.
 
-.. autofunction:: autoload_static
-.. autofunction:: components
-.. autofunction:: file_html
-.. autofunction:: json_item
-.. autofunction:: server_document
-.. autofunction:: server_session
-
 '''
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Checked out the docs build with the newly released Sphinx 3.0 and we had one warning that failed the build. It was valid and was causing all the functions in the `bokeh.embed` refguide show up twice. 
