### PR TITLE
Manually edited nbformat_minor in notebooks to fix validation errors (issue #9892)

### DIFF
--- a/examples/howto/Hover callback.ipynb
+++ b/examples/howto/Hover callback.ipynb
@@ -92,5 +92,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/examples/howto/Linked panning.ipynb
+++ b/examples/howto/Linked panning.ipynb
@@ -104,5 +104,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/examples/howto/Range update callback.ipynb
+++ b/examples/howto/Range update callback.ipynb
@@ -120,5 +120,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/examples/howto/notebook_comms/Basic Usage.ipynb
+++ b/examples/howto/notebook_comms/Basic Usage.ipynb
@@ -211,5 +211,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 2
 }

--- a/examples/howto/notebook_comms/Continuous Updating.ipynb
+++ b/examples/howto/notebook_comms/Continuous Updating.ipynb
@@ -149,5 +149,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 2
 }

--- a/examples/howto/notebook_comms/Jupyter Interactors.ipynb
+++ b/examples/howto/notebook_comms/Jupyter Interactors.ipynb
@@ -108,5 +108,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/examples/howto/notebook_comms/Numba Image Example.ipynb
+++ b/examples/howto/notebook_comms/Numba Image Example.ipynb
@@ -549,5 +549,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 2
 }


### PR DESCRIPTION

- [ ] issues: fixes #9892 
- [ ] tests passed: All the changed notebooks were opened manually in a jupyter session, "Run all cells" selected and then the notebook was saved. This failed in all cases before the edit and passed in all cases after the edit. Only manual tests were possible - using jupyter nbconvert --to notebook --execute returns successfully even when the bug is present.

