### PR TITLE
suppress gridspec warning

### DIFF
--- a/bokeh/layouts.py
+++ b/bokeh/layouts.py
@@ -527,13 +527,13 @@ class GridSpec(object):
             self._arrangement[row1, col1] = obj
         elif row2 is None:
             for col in range(col1, col2):
-                self._arrangement[row1, col] = get_or_else(lambda: obj[col-col1], None)
+                self._arrangement[row1, col] = get_or_else(lambda: obj[col-col1], None) # lgtm [py/loop-variable-capture]
         elif col2 is None:
             for row in range(row1, row2):
-                self._arrangement[row, col1] = get_or_else(lambda: obj[row-row1], None)
+                self._arrangement[row, col1] = get_or_else(lambda: obj[row-row1], None) # lgtm [py/loop-variable-capture]
         else:
             for row, col in zip(range(row1, row2), range(col1, col2)):
-                self._arrangement[row, col] = get_or_else(lambda: obj[row-row1][col-col1], None)
+                self._arrangement[row, col] = get_or_else(lambda: obj[row-row1][col-col1], None) # lgtm [py/loop-variable-capture]
 
     def __iter__(self):
         array = [ [ None ]*self.ncols for _ in range(0, self.nrows) ]

--- a/bokeh/layouts.py
+++ b/bokeh/layouts.py
@@ -491,6 +491,9 @@ class GridSpec(object):
         self.ncols = ncols
         self._arrangement = {}
 
+        from .util.deprecation import deprecated
+        deprecated("'GridSpec' is deprecated and will be removed in Bokeh 3.0")
+
     def __setitem__(self, key, obj):
         k1, k2 = key
 

--- a/tests/unit/bokeh/test_layouts.py
+++ b/tests/unit/bokeh/test_layouts.py
@@ -15,7 +15,7 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Bokeh imports
-from bokeh.layouts import column, grid, gridplot, layout, row
+from bokeh.layouts import GridSpec, column, grid, gridplot, layout, row
 from bokeh.models import Column, GridBox, Row, Spacer
 from bokeh.plotting import figure
 
@@ -26,6 +26,12 @@ from bokeh.plotting import figure
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
+
+# TODO (bev) deprecation: 3.0
+def test_GridSpec_deprecated() -> None:
+    from bokeh.util.deprecation import BokehDeprecationWarning
+    with pytest.warns(BokehDeprecationWarning):
+        GridSpec(2, 2)
 
 def test_gridplot_merge_tools_flat() -> None:
     p1, p2, p3, p4 = figure(), figure(), figure(), figure()


### PR DESCRIPTION
This suppresses some LGTM false positives for loop capture. I am not surprised they are missed, it's not easy to tell statically that the enclosing functions will evaluate the lambdas immediately. 

However, @mattpap what I actually ~very much desire~ intend to do is to deprecate `GridSpec` now, and slate it for removal in 3.0. This class is: 

* completely undocumented
* without any tests whatsoever
* not used or demonstrated by anything, anywhere:
    ```
    (dev) ❯ grin GridSpec
    ./bokeh/layouts.py:
       39 :     'GridSpec',
      212 :             ncols. OR an instance of GridSpec.
      486 : class GridSpec(object):
      555 :         elif len(args) == 1 and isinstance(args[0], GridSpec):
    ./bokeh/plotting/__init__.py:
       38 :     'GridSpec',
       78 : from ..layouts import gridplot, GridSpec; gridplot, GridSpec
    ```

This is pure useless dead weight cruft from a maintenance perspective as well as a possible source of unwanted support questions.  Keeping this would require an extremely compelling argument. 