### PR TITLE
make auth method overrides explicit

### DIFF
--- a/bokeh/server/views/auth_mixin.py
+++ b/bokeh/server/views/auth_mixin.py
@@ -18,9 +18,6 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
-# External imports
-from tornado import gen
-
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
@@ -69,13 +66,12 @@ class AuthMixin(object):
             return self.application.auth_provider.get_user(self)
         return "default_user"
 
-    @gen.coroutine
-    def prepare(self):
+    async def prepare(self):
         ''' Async counterpart to ``get_current_user``
 
         '''
         if self.application.auth_provider.get_user_async is not None:
-            self.current_user = yield self.application.auth_provider.get_user_async(self)
+            self.current_user = await self.application.auth_provider.get_user_async(self)
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/bokeh/server/views/root_handler.py
+++ b/bokeh/server/views/root_handler.py
@@ -63,6 +63,12 @@ class RootHandler(AuthMixin, RequestHandler):
             index = "app_index.html" if self.index is None else self.index
             self.render(index, prefix=prefix, items=sorted(self.applications.keys()))
 
+    # NOTE: The methods below exist on both AuthMixin and RequestHandler. This
+    # makes it explicit which of the versions is intended to be called.
+    get_login_url = AuthMixin.get_login_url
+    get_current_user = AuthMixin.get_current_user
+    prepare = AuthMixin.prepare
+
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------

--- a/bokeh/server/views/session_handler.py
+++ b/bokeh/server/views/session_handler.py
@@ -121,6 +121,12 @@ class SessionHandler(AuthMixin, RequestHandler):
 
         return session
 
+    # NOTE: The methods below exist on both AuthMixin and RequestHandler. This
+    # makes it explicit which of the versions is intended to be called.
+    get_login_url = AuthMixin.get_login_url
+    get_current_user = AuthMixin.get_current_user
+    prepare = AuthMixin.prepare
+
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/server/test_auth_provider.py
+++ b/tests/unit/bokeh/server/test_auth_provider.py
@@ -52,25 +52,25 @@ class TestNullAuth(object):
         assert null_auth.endpoints == []
 
     def test_get_user(self, null_auth) -> None:
-        assert null_auth.get_user ==  None
+        assert null_auth.get_user == None
 
-    def test_get_user_async(self, null_auth) -> None:
-        assert null_auth.get_user_async ==  None
+    async def test_get_user_async(self, null_auth) -> None:
+        assert null_auth.get_user_async == None
 
     def test_login_url(self, null_auth) -> None:
-        assert null_auth.login_url ==  None
+        assert null_auth.login_url == None
 
     def test_get_login_url(self, null_auth) -> None:
-        assert null_auth.get_login_url ==  None
+        assert null_auth.get_login_url == None
 
     def test_login_handler(self, null_auth) -> None:
-        assert null_auth.login_handler ==  None
+        assert null_auth.login_handler == None
 
     def test_logout_url(self, null_auth) -> None:
-        assert null_auth.logout_url ==  None
+        assert null_auth.logout_url == None
 
     def test_logout_handler(self, null_auth) -> None:
-        assert null_auth.logout_handler ==  None
+        assert null_auth.logout_handler == None
 
 class TestAuthModule_properties(object):
     def test_no_endpoints(self) -> None:
@@ -245,7 +245,7 @@ class TestAuthModule_validation(object):
 
         with_file_contents("""
 def get_user(handler): return 10
-def get_user_async(handler): return 20
+async def get_user_async(handler): return 20
     """, func, suffix='.py')
 
     @pytest.mark.parametrize('user_func', ['get_user', 'get_user_async'])


### PR DESCRIPTION
This makes a the auth methods method overrides explicit, rather than depending delicately on base class order. Additionally a lingering `@gen.coroutine` was replaced with a native coroutine, and also fixes some small issues in the auth provider tests.  
