### PR TITLE
Temporary fix for Django server resource handling

### DIFF
--- a/bokeh/server/django/consumers.py
+++ b/bokeh/server/django/consumers.py
@@ -87,7 +87,7 @@ class ConsumerHelper(AsyncConsumer):
         return self.arguments.get(name, default)
 
     def resources(self, absolute_url: Optional[str] = None) -> Resources:
-        mode = settings.resources(default="server")
+        mode = settings.resources(default="cdn")
         if mode == "server":
             root_url = urljoin(absolute_url, self._prefix) if absolute_url else self._prefix
             return Resources(mode="server", root_url=root_url, path_versioner=StaticHandler.append_version)


### PR DESCRIPTION
Temporary fix until we can work out how to serve JS and CSS resources correctly when `Resources(mode="server")`.

- [x] issues: fixes #9924
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
