### PR TITLE
Fix bokeh's unit tests after bs4 update

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -63,7 +63,6 @@ test:
     - geckodriver
     - ipython
     - isort >=4.3.21
-    - lxml
     - mock
     - mypy
     - nbconvert >=5.4

--- a/examples/embed/custom_server/color_scatter_server.py
+++ b/examples/embed/custom_server/color_scatter_server.py
@@ -51,7 +51,6 @@ def plot_html():
 def plot_js():
     return Response(js, mimetype='text/javascript')
 
-    #import ipdb; ipdb.set_trace()
     #return app.send_static_file("plot.js")
     #with open("plot.js") as plot_js:
     #    js = plot_js.read()

--- a/tests/unit/bokeh/embed/test_server__embed.py
+++ b/tests/unit/bokeh/embed/test_server__embed.py
@@ -64,7 +64,7 @@ class TestServerDocument(object):
         divid = attrs['id']
         request = "xhr.open('GET', \"%s/autoload.js?bokeh-autoload-element=%s&bokeh-app-path=/foo/bar/sliders&bokeh-absolute-url=%s\", true);" % \
               ("http://localhost:8081/foo/bar/sliders", divid, "http://localhost:8081/foo/bar/sliders")
-        assert request in script.text
+        assert request in script.string
 
     def test_script_attrs_arguments_provided(self) -> None:
         r = bes.server_document(arguments=dict(foo=10))
@@ -78,7 +78,7 @@ class TestServerDocument(object):
         divid = attrs['id']
         request = "xhr.open('GET', \"%s/autoload.js?bokeh-autoload-element=%s&bokeh-absolute-url=%s&foo=10\", true);" % \
               ("http://localhost:5006", divid, "http://localhost:5006")
-        assert request in script.text
+        assert request in script.string
 
     def test_script_attrs_url_provided_absolute_resources(self) -> None:
         r = bes.server_document(url="http://localhost:8081/foo/bar/sliders")
@@ -93,7 +93,7 @@ class TestServerDocument(object):
         divid = attrs['id']
         request = "xhr.open('GET', \"%s/autoload.js?bokeh-autoload-element=%s&bokeh-app-path=/foo/bar/sliders&bokeh-absolute-url=%s\", true);" % \
               ("http://localhost:8081/foo/bar/sliders", divid, "http://localhost:8081/foo/bar/sliders")
-        assert request in script.text
+        assert request in script.string
 
     def test_script_attrs_url_provided(self) -> None:
         r = bes.server_document(url="http://localhost:8081/foo/bar/sliders", relative_urls=True)
@@ -107,7 +107,7 @@ class TestServerDocument(object):
         divid = attrs['id']
         request = "xhr.open('GET', \"%s/autoload.js?bokeh-autoload-element=%s&bokeh-app-path=/foo/bar/sliders\", true);" % \
               ("http://localhost:8081/foo/bar/sliders", divid)
-        assert request in script.text
+        assert request in script.string
 
 class TestServerSession(object):
 
@@ -126,8 +126,8 @@ class TestServerSession(object):
         divid = attrs['id']
         request = "xhr.open('GET', \"%s/autoload.js?bokeh-autoload-element=%s&bokeh-absolute-url=%s\", true);" % \
               ("http://localhost:5006", divid, "http://localhost:5006")
-        assert request in script.text
-        assert 'xhr.setRequestHeader("Bokeh-Session-Id", "fakesession")' in script.text
+        assert request in script.string
+        assert 'xhr.setRequestHeader("Bokeh-Session-Id", "fakesession")' in script.string
 
     def test_invalid_resources_param(self, test_plot) -> None:
         with pytest.raises(ValueError):
@@ -154,8 +154,8 @@ class TestServerSession(object):
         divid = attrs['id']
         request = "%s/autoload.js?bokeh-autoload-element=%s&bokeh-absolute-url=%s" % \
               ("http://localhost:5006", divid, "http://localhost:5006")
-        assert request in script.text
-        assert 'xhr.setRequestHeader("Bokeh-Session-Id", "fakesession")' in script.text
+        assert request in script.string
+        assert 'xhr.setRequestHeader("Bokeh-Session-Id", "fakesession")' in script.string
 
     def test_general(self, test_plot) -> None:
         r = bes.server_session(test_plot, session_id='fakesession')
@@ -168,8 +168,8 @@ class TestServerSession(object):
         divid = attrs['id']
         request = "xhr.open('GET', \"%s/autoload.js?bokeh-autoload-element=%s&bokeh-absolute-url=%s\", true);" % \
               ("http://localhost:5006", divid, "http://localhost:5006")
-        assert request in script.text
-        assert 'xhr.setRequestHeader("Bokeh-Session-Id", "fakesession")' in script.text
+        assert request in script.string
+        assert 'xhr.setRequestHeader("Bokeh-Session-Id", "fakesession")' in script.string
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/embed/test_server__embed.py
+++ b/tests/unit/bokeh/embed/test_server__embed.py
@@ -55,7 +55,7 @@ class TestServerDocument(object):
         r = bes.server_document(url="http://localhost:8081/foo/bar/sliders")
         assert 'bokeh-app-path=/foo/bar/sliders' in r
         assert 'bokeh-absolute-url=http://localhost:8081/foo/bar/sliders' in r
-        html = bs4.BeautifulSoup(r, "lxml")
+        html = bs4.BeautifulSoup(r, "html.parser")
         scripts = html.findAll(name='script')
         assert len(scripts) == 1
         script = scripts[0]
@@ -69,7 +69,7 @@ class TestServerDocument(object):
     def test_script_attrs_arguments_provided(self) -> None:
         r = bes.server_document(arguments=dict(foo=10))
         assert 'foo=10' in r
-        html = bs4.BeautifulSoup(r, "lxml")
+        html = bs4.BeautifulSoup(r, "html.parser")
         scripts = html.findAll(name='script')
         assert len(scripts) == 1
         script = scripts[0]
@@ -84,7 +84,7 @@ class TestServerDocument(object):
         r = bes.server_document(url="http://localhost:8081/foo/bar/sliders")
         assert 'bokeh-app-path=/foo/bar/sliders' in r
         assert 'bokeh-absolute-url=http://localhost:8081/foo/bar/sliders' in r
-        html = bs4.BeautifulSoup(r, "lxml")
+        html = bs4.BeautifulSoup(r, "html.parser")
         scripts = html.findAll(name='script')
         assert len(scripts) == 1
         script = scripts[0]
@@ -98,7 +98,7 @@ class TestServerDocument(object):
     def test_script_attrs_url_provided(self) -> None:
         r = bes.server_document(url="http://localhost:8081/foo/bar/sliders", relative_urls=True)
         assert 'bokeh-app-path=/foo/bar/sliders' in r
-        html = bs4.BeautifulSoup(r, "lxml")
+        html = bs4.BeautifulSoup(r, "html.parser")
         scripts = html.findAll(name='script')
         assert len(scripts) == 1
         script = scripts[0]
@@ -117,7 +117,7 @@ class TestServerSession(object):
 
     def test_script_attrs_session_id_provided(self, test_plot) -> None:
         r = bes.server_session(test_plot, session_id='fakesession')
-        html = bs4.BeautifulSoup(r, "lxml")
+        html = bs4.BeautifulSoup(r, "html.parser")
         scripts = html.findAll(name='script')
         assert len(scripts) == 1
         script = scripts[0]
@@ -145,7 +145,7 @@ class TestServerSession(object):
 
     def test_model_none(self) -> None:
         r = bes.server_session(None, session_id='fakesession')
-        html = bs4.BeautifulSoup(r, "lxml")
+        html = bs4.BeautifulSoup(r, "html.parser")
         scripts = html.findAll(name='script')
         assert len(scripts) == 1
         script = scripts[0]
@@ -159,7 +159,7 @@ class TestServerSession(object):
 
     def test_general(self, test_plot) -> None:
         r = bes.server_session(test_plot, session_id='fakesession')
-        html = bs4.BeautifulSoup(r, "lxml")
+        html = bs4.BeautifulSoup(r, "html.parser")
         scripts = html.findAll(name='script')
         assert len(scripts) == 1
         script = scripts[0]

--- a/tests/unit/bokeh/embed/test_standalone.py
+++ b/tests/unit/bokeh/embed/test_standalone.py
@@ -242,7 +242,7 @@ class Test_components(object):
         assert div.attrs['class'] == ['bk-root']
         assert div.attrs['id'] == 'ID'
         assert div.attrs['data-root-id'] == test_plot.id
-        assert div.text == ''
+        assert div.string is None
 
     def test_script_is_utf8_encoded(self, test_plot) -> None:
         script, div = bes.components(test_plot)

--- a/tests/unit/bokeh/embed/test_standalone.py
+++ b/tests/unit/bokeh/embed/test_standalone.py
@@ -79,7 +79,7 @@ class Test_autoload_static(object):
 
     def test_script_attrs(self, test_plot) -> None:
         js, tag = bes.autoload_static(test_plot, CDN, "some/path")
-        html = bs4.BeautifulSoup(tag, "lxml")
+        html = bs4.BeautifulSoup(tag, "html.parser")
         scripts = html.findAll(name='script')
         assert len(scripts) == 1
         attrs = scripts[0].attrs
@@ -224,7 +224,7 @@ class Test_components(object):
 
     def test_result_attrs(self, test_plot) -> None:
         script, div = bes.components(test_plot)
-        html = bs4.BeautifulSoup(script, "lxml")
+        html = bs4.BeautifulSoup(script, "html.parser")
         scripts = html.findAll(name='script')
         assert len(scripts) == 1
         assert scripts[0].attrs == {'type': 'text/javascript'}
@@ -232,7 +232,7 @@ class Test_components(object):
     @patch('bokeh.embed.util.make_globally_unique_id', new=stable_id)
     def test_div_attrs(self, test_plot) -> None:
         script, div = bes.components(test_plot)
-        html = bs4.BeautifulSoup(div, "lxml")
+        html = bs4.BeautifulSoup(div, "html.parser")
 
         divs = html.findAll(name='div')
         assert len(divs) == 1
@@ -250,7 +250,7 @@ class Test_components(object):
 
     def test_output_is_without_script_tag_when_wrap_script_is_false(self, test_plot) -> None:
         script, div = bes.components(test_plot)
-        html = bs4.BeautifulSoup(script, "lxml")
+        html = bs4.BeautifulSoup(script, "html.parser")
         scripts = html.findAll(name='script')
         assert len(scripts) == 1
 

--- a/tests/unit/bokeh/test_resources.py
+++ b/tests/unit/bokeh/test_resources.py
@@ -339,7 +339,7 @@ class TestResources(object):
         html = bs4.BeautifulSoup(out, "lxml")
         scripts = html.findAll(name='script')
         for script in scripts:
-            if "set_log_level" in script.text:
+            if "src" not in script.attrs:
                 continue
             assert script.attrs['crossorigin'] == "anonymous"
             assert script.attrs['integrity'].startswith("sha384-")
@@ -362,7 +362,7 @@ class TestResources(object):
         html = bs4.BeautifulSoup(out, "lxml")
         scripts = html.findAll(name='script')
         for script in scripts:
-            if "set_log_level" in script.text:
+            if "src" not in script.attrs:
                 continue
             assert script.attrs['crossorigin'] == "anonymous"
             assert script.attrs['integrity'].startswith("sha384-")

--- a/tests/unit/bokeh/test_resources.py
+++ b/tests/unit/bokeh/test_resources.py
@@ -336,7 +336,7 @@ class TestResources(object):
         monkeypatch.setattr(buv, "__version__", "2.0.0")
         monkeypatch.setattr(resources, "__version__", "2.0.0")
         out = resources.CDN.render_js()
-        html = bs4.BeautifulSoup(out, "lxml")
+        html = bs4.BeautifulSoup(out, "html.parser")
         scripts = html.findAll(name='script')
         for script in scripts:
             if "src" not in script.attrs:
@@ -349,7 +349,7 @@ class TestResources(object):
         monkeypatch.setattr(buv, "__version__", v)
         monkeypatch.setattr(resources, "__version__", v)
         out = resources.CDN.render_js()
-        html = bs4.BeautifulSoup(out, "lxml")
+        html = bs4.BeautifulSoup(out, "html.parser")
         scripts = html.findAll(name='script')
         for script in scripts:
             assert "crossorigin" not in script.attrs
@@ -359,7 +359,7 @@ class TestResources(object):
         monkeypatch.setattr(buv, "__version__", "2.0.0-foo")
         monkeypatch.setattr(resources, "__version__", "2.0.0-foo")
         out = resources.CDN.render_js()
-        html = bs4.BeautifulSoup(out, "lxml")
+        html = bs4.BeautifulSoup(out, "html.parser")
         scripts = html.findAll(name='script')
         for script in scripts:
             if "src" not in script.attrs:
@@ -372,7 +372,7 @@ class TestResources(object):
         monkeypatch.setattr(buv, "__version__", v)
         monkeypatch.setattr(resources, "__version__", v)
         out = resources.INLINE.render_js()
-        html = bs4.BeautifulSoup(out, "lxml")
+        html = bs4.BeautifulSoup(out, "html.parser")
         scripts = html.findAll(name='script')
         for script in scripts:
             assert "crossorigin" not in script.attrs


### PR DESCRIPTION
Fixes broken tests after bs4 4.9 release which subtly changed the behavior of `.text` property.