### PR TITLE
Improve tile provider docs

### DIFF
--- a/bokeh/tile_providers.py
+++ b/bokeh/tile_providers.py
@@ -6,113 +6,111 @@
 #-----------------------------------------------------------------------------
 ''' Pre-configured tile sources for common third party tile services.
 
+get_provider
+    Use this function to retrieve an instance of a predefined tile provider.
 
-Attributes:
+    Args:
+        provider_name (Union[str, Vendors])
+            Name of the tile provider to supply.
 
-    .. bokeh-enum:: Vendors
-        :module: bokeh.tile_providers
+            Use a ``tile_providers.Vendors`` enumeration value, or the string
+            name of one of the known providers.
 
-    get_provider
-        Use this function to retrieve an instance of a predefined tile provider.
+    Returns:
+        WMTSTileProviderSource: The desired tile provider instance
 
-        Args:
-            provider_name (Union[str, Vendors])
-                Name of the tile provider to supply.
-                Use tile_providers.Vendors enum, or the name of a provider as string
+    Raises:
+        ValueError, if the specified provider can not be found
 
-        Returns:
-            WMTSTileProviderSource: The desired tile provider instance
+    Example:
 
-        Raises:
-            ValueError, if the provider can not be found
-            ValueError, if the attribution for that provider can not be found
+        .. code-block:: python
 
+                >>> from bokeh.tile_providers import get_provider, Vendors
+                >>> get_provider(Vendors.CARTODBPOSITRON)
+                <class 'bokeh.models.tiles.WMTSTileSource'>
+                >>> get_provider('CARTODBPOSITRON')
+                <class 'bokeh.models.tiles.WMTSTileSource'>
 
-        Example:
+The available built-in tile providers are listed in the ``Vendors`` enum:
 
-            .. code-block:: python
+.. bokeh-enum:: Vendors
+    :module: bokeh.tile_providers
+    :noindex:
 
-                    >>> from bokeh.tile_providers import get_provider, Vendors
-                    >>> get_provider(Vendors.CARTODBPOSITRON)
-                    <class 'bokeh.models.tiles.WMTSTileSource'>
-                    >>> get_provider('CARTODBPOSITRON')
-                    <class 'bokeh.models.tiles.WMTSTileSource'>
+Any of these values may be be passed to the ``get_provider`` function in order
+to obtain a tile provider to use with a Bokeh plot. Representative samples of
+each tile provider are shown below.
 
+CARTODBPOSITRON
+    Tile Source for CartoDB Tile Service
 
-    CARTODBPOSITRON
-        Tile Source for CartoDB Tile Service
+    .. raw:: html
 
-        Warns:
-            BokehDeprecationWarning: Deprecated in bokeh 1.1.0. Use get_provider instead
+        <img src="https://tiles.basemaps.cartocdn.com/light_all/14/2627/6331.png" />
 
-        .. raw:: html
+CARTODBPOSITRON_RETINA
+    Tile Source for CartoDB Tile Service (tiles at 'retina' resolution)
 
-            <img src="https://tiles.basemaps.cartocdn.com/light_all/14/2627/6331.png" />
+    .. raw:: html
 
-    CARTODBPOSITRON_RETINA
-        Tile Source for CartoDB Tile Service (tiles at 'retina' resolution)
+        <img src="https://tiles.basemaps.cartocdn.com/light_all/14/2627/6331@2x.png" />
 
-        Warns:
-            BokehDeprecationWarning: Deprecated in bokeh 1.1.0. Use get_provider instead
+ESRI_IMAGERY
+    Tile Source for ESRI public tiles.
 
-        .. raw:: html
+    .. raw:: html
 
-            <img src="https://tiles.basemaps.cartocdn.com/light_all/14/2627/6331@2x.png" />
+        <img src="https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/14/6331/2627.jpg" />
 
-    STAMEN_TERRAIN
-        Tile Source for Stamen Terrain Service
+OSM
+    Tile Source for Open Street Maps.
 
-        Warns:
-            BokehDeprecationWarning: Deprecated in bokeh 1.1.0. Use get_provider instead
+    .. raw:: html
 
-        .. raw:: html
+        <img src="https://c.tile.openstreetmap.org/14/2627/6331.png" />
 
-            <img src="http://c.tile.stamen.com/terrain/14/2627/6331.png" />
+STAMEN_TERRAIN
+    Tile Source for Stamen Terrain Service
 
-    STAMEN_TERRAIN_RETINA
-        Tile Source for Stamen Terrain Service
+    .. raw:: html
 
-        Warns:
-            BokehDeprecationWarning: Deprecated in bokeh 1.1.0. Use get_provider instead
+        <img src="http://c.tile.stamen.com/terrain/14/2627/6331.png" />
 
-        .. raw:: html
+STAMEN_TERRAIN_RETINA
+    Tile Source for Stamen Terrain Service (tiles at 'retina' resolution)
 
-            <img src="http://c.tile.stamen.com/terrain/14/2627/6331@2x.png" />
+    .. raw:: html
 
-    STAMEN_TONER
-        Tile Source for Stamen Toner Service
+        <img src="http://c.tile.stamen.com/terrain/14/2627/6331@2x.png" />
 
-        Warns:
-            BokehDeprecationWarning: Deprecated in bokeh 1.1.0. Use get_provider instead
+STAMEN_TONER
+    Tile Source for Stamen Toner Service
 
-        .. raw:: html
+    .. raw:: html
 
-            <img src="http://c.tile.stamen.com/toner/14/2627/6331.png" />
+        <img src="http://c.tile.stamen.com/toner/14/2627/6331.png" />
 
-    STAMEN_TONER_BACKGROUND
-        Tile Source for Stamen Toner Background Service which does not include labels
+STAMEN_TONER_BACKGROUND
+    Tile Source for Stamen Toner Background Service which does not include labels
 
-        Warns:
-            BokehDeprecationWarning: Deprecated in bokeh 1.1.0. Use get_provider instead
+    .. raw:: html
 
-        .. raw:: html
+        <img src="http://c.tile.stamen.com/toner-background/14/2627/6331.png" />
 
-            <img src="http://c.tile.stamen.com/toner-background/14/2627/6331.png" />
+STAMEN_TONER_LABELS
+    Tile Source for Stamen Toner Service which includes only labels
 
-    STAMEN_TONER_LABELS
-        Tile Source for Stamen Toner Service which includes only labels
+    .. raw:: html
 
-        Warns:
-            BokehDeprecationWarning: Deprecated in bokeh 1.1.0. Use get_provider instead
+        <img src="http://c.tile.stamen.com/toner-labels/14/2627/6331.png" />
 
-        .. raw:: html
+WIKIMEDIA
+    Tile Source for Wikimedia tile service.
 
-            <img src="http://c.tile.stamen.com/toner-labels/14/2627/6331.png" />
+    .. raw:: html
 
-Additional information available at:
-
-* Stamen tile service - http://maps.stamen.com/
-* CartoDB tile service - https://carto.com/location-data-services/basemaps/
+        <img src="https://maps.wikimedia.org/osm-intl/14/2627/6331@2x.png" />
 
 '''
 
@@ -229,7 +227,8 @@ class _TileProvidersModule(types.ModuleType):
         elif selected_provider.startswith('ESRI_IMAGERY'):
             attribution = self._ESRI_IMAGERY_ATTRIBUTION
         else:
-            raise ValueError('Can not retrieve attribution for %s' % selected_provider)
+
+            raise RuntimeError('Can not retrieve attribution for %s' % selected_provider)
         return WMTSTileSource(url=url, attribution=attribution)
 
     # Properties --------------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #-----------------------------------------------------------------------------
-# Copyright (c) 2012 - 2017, Anaconda, Inc. All rights reserved.
-#
-# Powered by the Bokeh Development Team.
+# Copyright (c) 2012 - 2020, Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Noticed the tile provider docs were both confusing and missing examples for all the new tile sources. This is a quick update to make the page at least serviceable. 
