### PR TITLE
release build first steps

### DIFF
--- a/.github/workflows/bokeh-release.yml
+++ b/.github/workflows/bokeh-release.yml
@@ -1,0 +1,38 @@
+name: Bokeh Release Build
+
+on:
+  repository_dispatch:
+    types: [build]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2-beta
+
+      - name: Configure conda
+        env:
+          CONDA_REQS: "conda=4.8.1 conda-build=3.18.10 conda-verify=3.4.2 ripgrep=0.10.0 jinja2"
+        run: |
+          run: |
+          conda config --set auto_update_conda off
+          conda config --append channels bokeh
+          conda config --get channels
+          conda install --yes --quiet $CONDA_REQS
+
+      - name: Install conda packages
+        run: |
+          BUILD_DEPS=`python scripts/deps.py build`
+          conda install --yes --quiet $BUILD_DEPS
+
+      - name: Install node modules
+        run: |
+          pushd bokehjs
+          npm install -g npm
+          npm ci --no-progress
+          popd
+
+      - name: Execute Build
+        run: |
+          python -m release build ${{ github.event.client_payload.version }}

--- a/release/__main__.py
+++ b/release/__main__.py
@@ -8,21 +8,4 @@
 # Standard library imports
 import sys
 
-# Bokeh imports
-from .config import Config
-from .stages import BUILD_CHECKS, BUILD_STEPS
-from .system import System
-from .ui import banner, blue
-
-config = Config(sys.argv[1])
-system = System()
-
-banner(blue, "{:^80}".format("Starting a Bokeh release BUILD"))
-
-for step in BUILD_CHECKS:
-    step(config, system)
-
-for step in BUILD_STEPS:
-    step(config, system)
-
-banner(blue, "{:^80}".format(f"Bokeh {config.version!r} BUILD: SUCCESS"))
+print(f"GOT {sys.argv}")


### PR DESCRIPTION
@bokeh/dev Just a heads up. `repository_dispatch` events only trigger off master. I will probably be making various commits straight to master when working on this to reduce the iteration cycle time. I'll make sure to run codebase tests first, which is all that should matter. Here's an outline of what I would like to work eventually:

* Trigger release "build" event. Could be via script, or via Postman, etc. This will require a repository scoped PAT but we may want to layer in some additional validation of the user issuing the event

* The build workflow runs checks, and assuming they all pass, executes the build

* A release deployment tarball is uploaded as an artifact. 

  At this point BokehJS has been uploaded to CDN and the repo has been provisionally tagged, but no packages or docs have beeb published.

* Intend to call a Slack incoming webhook to report status of the build job in a `#releases` channel

* local testing happens with the packages in the deployment tarball

*  If testing uncovers issues with a full release, the tag and SRI hashes can be reverted, and CDN JS files taken down.

* In later work, there will be a separate "deploy" workflow that is run after testing, that retrieves the deployment tarball and publishes the docs and packages.