### PR TITLE
Fix adding glyphs with legend args dynamically

### DIFF
--- a/bokeh/plotting/_renderer.py
+++ b/bokeh/plotting/_renderer.py
@@ -122,10 +122,13 @@ def create_renderer(glyphclass, plot, **kwargs):
         muted_glyph=make_glyph(glyphclass, kwargs, muted_visuals),
         **renderer_kws)
 
-    if legend_kwarg:
-        update_legend(plot, legend_kwarg, glyph_renderer)
-
     plot.renderers.append(glyph_renderer)
+
+    if legend_kwarg:
+        # It must be after the renderer is added because
+        # if it creates a new `LegendItem`, the referenced
+        # renderer must already be present.
+        update_legend(plot, legend_kwarg, glyph_renderer)
 
     return glyph_renderer
 


### PR DESCRIPTION
If a new glyph adds a legend item, two patches are
sent to the BokehJS documents - one for the renderer
and the other for the legend item. The renderer one
must arrive first, otherwise the newly created legend
item will have an invalid model reference.

- [x] issues: fixes #9953
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
