### PR TITLE
Delay connect_signals during initialization

### DIFF
--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -213,8 +213,10 @@ export abstract class HasProps extends Signalable() {
     // when loading a bunch of models, we want to do initialization as a second pass
     // because other objects that this one depends on might not be loaded yet
 
-    if (!deferred)
+    if (!deferred) {
       this.finalize()
+      this.connect_signals()
+    }
   }
 
   finalize(): void {
@@ -235,7 +237,6 @@ export abstract class HasProps extends Signalable() {
     }
 
     this.initialize()
-    this.connect_signals()
   }
 
   initialize(): void {}


### PR DESCRIPTION
- [x] issues: fixes #9218
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

I don't think it's possible to add a reliable test case for this. The manifestation of the bug depends on the iteration order over a map, which is intrinsically undefined. And I really don't think we should make it defined by sorting something because performance matters.