### PR TITLE
Add field name to column name if title not given

### DIFF
--- a/bokehjs/src/lib/models/widgets/tables/table_column.ts
+++ b/bokehjs/src/lib/models/widgets/tables/table_column.ts
@@ -49,7 +49,7 @@ export class TableColumn extends Model {
     return {
       id: uniqueId(),
       field: this.field,
-      name: this.title,
+      name: this.title || this.field,
       width: this.width,
       formatter: this.formatter != null ? this.formatter.doFormat.bind(this.formatter) : undefined,
       model: this.editor,

--- a/bokehjs/src/lib/models/widgets/tables/table_column.ts
+++ b/bokehjs/src/lib/models/widgets/tables/table_column.ts
@@ -49,7 +49,7 @@ export class TableColumn extends Model {
     return {
       id: uniqueId(),
       field: this.field,
-      name: this.title || this.field,
+      name: this.title != null ? this.title : this.field,
       width: this.width,
       formatter: this.formatter != null ? this.formatter.doFormat.bind(this.formatter) : undefined,
       model: this.editor,

--- a/bokehjs/src/lib/models/widgets/tables/table_column.ts
+++ b/bokehjs/src/lib/models/widgets/tables/table_column.ts
@@ -49,7 +49,7 @@ export class TableColumn extends Model {
     return {
       id: uniqueId(),
       field: this.field,
-      name: this.title != null ? this.title : this.field,
+      name: this.title ?? this.field,
       width: this.width,
       formatter: this.formatter != null ? this.formatter.doFormat.bind(this.formatter) : undefined,
       model: this.editor,


### PR DESCRIPTION
I thought I should just go ahead and make the change. This most probably will work fine as the library would use column field name instead if the title is not externally given.
- [ ] issues: fixes #9871 