### PR TITLE
Speed up setting up of visuals

### DIFF
--- a/bokehjs/src/lib/core/util/color.ts
+++ b/bokehjs/src/lib/core/util/color.ts
@@ -54,6 +54,15 @@ export function color2rgba(color: string, alpha: number = 1.0): RGBA {
   return rgba.slice(0, 4) as RGBA
 }
 
+export function color2css(color: string, alpha: number = 1.0): string {
+  if (alpha == 1.0)
+    return color
+  else {
+    const [r, g, b, a] = color2rgba(color, alpha)
+    return `rgba(${r*255},${g*255},${b*255},${a})`
+  }
+}
+
 export function valid_rgb(value: string): boolean {
   let params: {start: string, len: number, alpha: boolean}
   switch (value.substring(0, 4)) {

--- a/bokehjs/src/lib/core/visuals.ts
+++ b/bokehjs/src/lib/core/visuals.ts
@@ -264,32 +264,25 @@ export class Line extends ContextProperties {
 
   protected _set_vectorize(ctx: Context2d, i: number): void {
     this.cache_select("line_color", i)
-    if (ctx.strokeStyle !== this.cache.line_color)
-      ctx.strokeStyle = this.cache.line_color
+    ctx.strokeStyle = this.cache.line_color
 
     this.cache_select("line_alpha", i)
-    if (ctx.globalAlpha !== this.cache.line_alpha)
-      ctx.globalAlpha = this.cache.line_alpha
+    ctx.globalAlpha = this.cache.line_alpha
 
     this.cache_select("line_width", i)
-    if (ctx.lineWidth !== this.cache.line_width)
-      ctx.lineWidth = this.cache.line_width
+    ctx.lineWidth = this.cache.line_width
 
     this.cache_select("line_join", i)
-    if (ctx.lineJoin !== this.cache.line_join)
-      ctx.lineJoin = this.cache.line_join
+    ctx.lineJoin = this.cache.line_join
 
     this.cache_select("line_cap", i)
-    if (ctx.lineCap !== this.cache.line_cap)
-      ctx.lineCap = this.cache.line_cap
+    ctx.lineCap = this.cache.line_cap
 
     this.cache_select("line_dash", i)
-    if (ctx.getLineDash() !== this.cache.line_dash)
-      ctx.setLineDash(this.cache.line_dash)
+    ctx.setLineDash(this.cache.line_dash)
 
     this.cache_select("line_dash_offset", i)
-    if (ctx.getLineDashOffset() !== this.cache.line_dash_offset)
-      ctx.setLineDashOffset(this.cache.line_dash_offset)
+    ctx.setLineDashOffset(this.cache.line_dash_offset)
   }
 
   color_value(): string {
@@ -316,12 +309,10 @@ export class Fill extends ContextProperties {
 
   protected _set_vectorize(ctx: Context2d, i: number): void {
     this.cache_select("fill_color", i)
-    if (ctx.fillStyle !== this.cache.fill_color)
-      ctx.fillStyle = this.cache.fill_color
+    ctx.fillStyle = this.cache.fill_color
 
     this.cache_select("fill_alpha", i)
-    if (ctx.globalAlpha !== this.cache.fill_alpha)
-      ctx.globalAlpha = this.cache.fill_alpha
+    ctx.globalAlpha = this.cache.fill_alpha
   }
 
   color_value(): string {
@@ -398,8 +389,7 @@ export class Hatch extends ContextProperties {
     ctx.fillStyle = this.cache.pattern(ctx)
 
     this.cache_select("hatch_alpha", i)
-    if (ctx.globalAlpha !== this.cache.hatch_alpha)
-      ctx.globalAlpha = this.cache.hatch_alpha
+    ctx.globalAlpha = this.cache.hatch_alpha
   }
 
   color_value(): string {
@@ -465,24 +455,19 @@ export class Text extends ContextProperties {
 
   protected _set_vectorize(ctx: Context2d, i: number): void {
     this.cache_select("font", i)
-    if (ctx.font !== this.cache.font)
-      ctx.font = this.cache.font
+    ctx.font = this.cache.font
 
     this.cache_select("text_color", i)
-    if (ctx.fillStyle !== this.cache.text_color)
-      ctx.fillStyle = this.cache.text_color
+    ctx.fillStyle = this.cache.text_color
 
     this.cache_select("text_alpha", i)
-    if (ctx.globalAlpha !== this.cache.text_alpha)
-      ctx.globalAlpha = this.cache.text_alpha
+    ctx.globalAlpha = this.cache.text_alpha
 
     this.cache_select("text_align", i)
-    if (ctx.textAlign !== this.cache.text_align)
-      ctx.textAlign = this.cache.text_align
+    ctx.textAlign = this.cache.text_align
 
     this.cache_select("text_baseline", i)
-    if (ctx.textBaseline !== this.cache.text_baseline)
-      ctx.textBaseline = this.cache.text_baseline
+    ctx.textBaseline = this.cache.text_baseline
   }
 }
 

--- a/bokehjs/src/lib/core/visuals.ts
+++ b/bokehjs/src/lib/core/visuals.ts
@@ -1,6 +1,6 @@
 import * as mixins from "./property_mixins"
 import * as p from "./properties"
-import {color2rgba} from "./util/color"
+import {color2css} from "./util/color"
 import {Context2d} from "./util/canvas"
 import {Class} from "./class"
 import {LineJoin, LineCap, FontStyle, TextAlign, TextBaseline} from "./enums"
@@ -229,11 +229,6 @@ export abstract class ContextProperties {
   }
 
   protected abstract _set_vectorize(ctx: Context2d, i: number): void
-
-  protected _color_value(color: string, alpha: number): string {
-    const [r, g, b, a] = color2rgba(color, alpha)
-    return `rgba(${r*255},${g*255},${b*255},${a})`
-  }
 }
 
 export class Line extends ContextProperties {
@@ -286,7 +281,7 @@ export class Line extends ContextProperties {
   }
 
   color_value(): string {
-    return this._color_value(this.line_color.value(), this.line_alpha.value())
+    return color2css(this.line_color.value(), this.line_alpha.value())
   }
 }
 
@@ -316,7 +311,7 @@ export class Fill extends ContextProperties {
   }
 
   color_value(): string {
-    return this._color_value(this.fill_color.value(), this.fill_alpha.value())
+    return color2css(this.fill_color.value(), this.fill_alpha.value())
   }
 }
 
@@ -393,7 +388,7 @@ export class Hatch extends ContextProperties {
   }
 
   color_value(): string {
-    return this._color_value(this.hatch_color.value(), this.hatch_alpha.value())
+    return color2css(this.hatch_color.value(), this.hatch_alpha.value())
   }
 }
 
@@ -411,7 +406,7 @@ export class Text extends ContextProperties {
   readonly text_line_height: p.Number
 
   color_value(): string {
-    return this._color_value(this.text_color.value(), this.text_alpha.value())
+    return color2css(this.text_color.value(), this.text_alpha.value())
   }
 
   font_value(): string {


### PR DESCRIPTION
Based on a suggestion in another PR (I can't find it right now), I checked what's the performance impact of all those comparisons in `core/visuals.ts`, and there is a visible negative impact for large datasets. I tested in Chrome and FF. For example, `plotting/file/color_catter` with `N=100_000` has its run time reduced by roughly 100ms (700->600ms in Chrome and 1100->1000 in FF). There's quite a bit of dispersion though (not unexpected with JIT and GC), so I started working on benchmarking tooling for bokehjs, so that we could get consistent and statistically significant results. Though it will take awhile to finish this.
