### PR TITLE
Use Map<K, V> or Set<V> instead of {[key: string]: V}

### DIFF
--- a/bokehjs/src/lib/core/types.ts
+++ b/bokehjs/src/lib/core/types.ts
@@ -21,6 +21,8 @@ export type Data = {[key: string]: Arrayable<unknown>}
 
 export type Attrs = {[key: string]: unknown}
 
+export type PlainObject = Attrs
+
 export type Size = {
   width: number
   height: number

--- a/bokehjs/src/lib/core/util/data_structures.ts
+++ b/bokehjs/src/lib/core/util/data_structures.ts
@@ -63,7 +63,7 @@ export class Set<T> {
     return copy(this._values).sort()
   }
 
-  constructor(obj?: T[] | Set<T>) {
+  constructor(obj?: Iterable<T> | Set<T>) {
     if (obj == null)
       this._values = []
     else if (obj instanceof Set)

--- a/bokehjs/test/unit/document/document.ts
+++ b/bokehjs/test/unit/document/document.ts
@@ -1,7 +1,7 @@
 import {expect} from "chai"
 import * as sinon from "sinon"
 
-import {values, size} from "@bokehjs/core/util/object"
+import {values} from "@bokehjs/core/util/object"
 import {Document, DEFAULT_TITLE} from "@bokehjs/document"
 import * as ev from "@bokehjs/document/events"
 import {version as js_version} from "@bokehjs/version"
@@ -229,28 +229,28 @@ describe("Document", () => {
   it("tracks all_models", () => {
     const d = new Document()
     expect(d.roots().length).to.equal(0)
-    expect(Object.keys(d._all_models).length).to.equal(0)
+    expect(d._all_models.size).to.equal(0)
     const m = new SomeModel()
     const m2 = new AnotherModel()
     m.child = m2
     expect(m.child).to.equal(m2)
     d.add_root(m)
     expect(d.roots().length).to.equal(1)
-    expect(Object.keys(d._all_models).length).to.equal(2)
+    expect(d._all_models.size).to.equal(2)
 
     m.child = null
-    expect(Object.keys(d._all_models).length).to.equal(1)
+    expect(d._all_models.size).to.equal(1)
     m.child = m2
-    expect(Object.keys(d._all_models).length).to.equal(2)
+    expect(d._all_models.size).to.equal(2)
     d.remove_root(m)
     expect(d.roots().length).to.equal(0)
-    expect(Object.keys(d._all_models).length).to.equal(0)
+    expect(d._all_models.size).to.equal(0)
   })
 
   it("tracks all_models with list property", () => {
     const d = new Document()
     expect(d.roots().length).to.equal(0)
-    expect(Object.keys(d._all_models).length).to.equal(0)
+    expect(d._all_models.size).to.equal(0)
     const m = new SomeModelWithChildren()
     const m2 = new AnotherModel()
     m.children = [m2]
@@ -258,26 +258,26 @@ describe("Document", () => {
     // check that we get the right all_models on initial add_root
     d.add_root(m)
     expect(d.roots().length).to.equal(1)
-    expect(Object.keys(d._all_models).length).to.equal(2)
+    expect(d._all_models.size).to.equal(2)
 
     // check that removing children list drops the models beneath it
     m.children = []
-    expect(Object.keys(d._all_models).length).to.equal(1)
+    expect(d._all_models.size).to.equal(1)
 
     // check that adding children back re-adds the models
     m.children = [m2]
-    expect(Object.keys(d._all_models).length).to.equal(2)
+    expect(d._all_models.size).to.equal(2)
 
     // check that removing root removes the models
     d.remove_root(m)
     expect(d.roots().length).to.equal(0)
-    expect(Object.keys(d._all_models).length).to.equal(0)
+    expect(d._all_models.size).to.equal(0)
   })
 
   it("tracks all_models with list property where list elements have a child", () => {
     const d = new Document()
     expect(d.roots().length).to.equal(0)
-    expect(Object.keys(d._all_models).length).to.equal(0)
+    expect(d._all_models.size).to.equal(0)
     const m = new SomeModelWithChildren()
     const m3 = new AnotherModel()
     const m2 = new SomeModel({ child: m3 })
@@ -287,20 +287,20 @@ describe("Document", () => {
     // check that we get the right all_models on initial add_root
     d.add_root(m)
     expect(d.roots().length).to.equal(1)
-    expect(Object.keys(d._all_models).length).to.equal(3)
+    expect(d._all_models.size).to.equal(3)
 
     // check that removing children list drops the models beneath it
     m.children = []
-    expect(Object.keys(d._all_models).length).to.equal(1)
+    expect(d._all_models.size).to.equal(1)
 
     // check that adding children back re-adds the models
     m.children = [m2]
-    expect(Object.keys(d._all_models).length).to.equal(3)
+    expect(d._all_models.size).to.equal(3)
 
     // check that removing root removes the models
     d.remove_root(m)
     expect(d.roots().length).to.equal(0)
-    expect(Object.keys(d._all_models).length).to.equal(0)
+    expect(d._all_models.size).to.equal(0)
   })
 
   it("lets us get_model_by_id", () => {
@@ -355,7 +355,7 @@ describe("Document", () => {
   it("can have all_models with multiple references", () => {
     const d = new Document()
     expect(d.roots().length).to.equal(0)
-    expect(size(d._all_models)).to.equal(0)
+    expect(d._all_models.size).to.equal(0)
 
     const root1 = new SomeModel()
     const root2 = new SomeModel()
@@ -365,31 +365,31 @@ describe("Document", () => {
     d.add_root(root1)
     d.add_root(root2)
     expect(d.roots().length).to.equal(2)
-    expect(size(d._all_models)).to.equal(3)
+    expect(d._all_models.size).to.equal(3)
 
     root1.child = null
-    expect(size(d._all_models)).to.equal(3)
+    expect(d._all_models.size).to.equal(3)
 
     root2.child = null
-    expect(size(d._all_models)).to.equal(2)
+    expect(d._all_models.size).to.equal(2)
 
     root1.child = child1
-    expect(size(d._all_models)).to.equal(3)
+    expect(d._all_models.size).to.equal(3)
 
     root2.child = child1
-    expect(size(d._all_models)).to.equal(3)
+    expect(d._all_models.size).to.equal(3)
 
     d.remove_root(root1)
-    expect(size(d._all_models)).to.equal(2)
+    expect(d._all_models.size).to.equal(2)
 
     d.remove_root(root2)
-    expect(size(d._all_models)).to.equal(0)
+    expect(d._all_models.size).to.equal(0)
   })
 
   it("can have all_models with cycles", () => {
     const d = new Document()
     expect(d.roots().length).to.equal(0)
-    expect(size(d._all_models)).to.equal(0)
+    expect(d._all_models.size).to.equal(0)
 
     const root1 = new SomeModel()
     const root2 = new SomeModel()
@@ -400,22 +400,22 @@ describe("Document", () => {
     d.add_root(root1)
     d.add_root(root2)
     expect(d.roots().length).to.equal(2)
-    expect(size(d._all_models)).to.equal(3)
+    expect(d._all_models.size).to.equal(3)
 
     root1.child = null
-    expect(size(d._all_models)).to.equal(3)
+    expect(d._all_models.size).to.equal(3)
 
     root2.child = null
-    expect(size(d._all_models)).to.equal(2)
+    expect(d._all_models.size).to.equal(2)
 
     root1.child = child1
-    expect(size(d._all_models)).to.equal(3)
+    expect(d._all_models.size).to.equal(3)
   })
 
   it("can have all_models with cycles through lists", () => {
     const d = new Document()
     expect(d.roots().length).to.equal(0)
-    expect(size(d._all_models)).to.equal(0)
+    expect(d._all_models.size).to.equal(0)
 
     const root1 = new SomeModelWithChildren()
     const root2 = new SomeModelWithChildren()
@@ -426,16 +426,16 @@ describe("Document", () => {
     d.add_root(root1)
     d.add_root(root2)
     expect(d.roots().length).to.equal(2)
-    expect(size(d._all_models)).to.equal(3)
+    expect(d._all_models.size).to.equal(3)
 
     root1.children = []
-    expect(size(d._all_models)).to.equal(3)
+    expect(d._all_models.size).to.equal(3)
 
     root2.children = []
-    expect(size(d._all_models)).to.equal(2)
+    expect(d._all_models.size).to.equal(2)
 
     root1.children = [child1]
-    expect(size(d._all_models)).to.equal(3)
+    expect(d._all_models.size).to.equal(3)
   })
 
   it("can notify on changes", () => {
@@ -555,7 +555,7 @@ describe("Document", () => {
     expect(d.title()).to.equal('Foo')
     d.clear()
     expect(d.roots().length).to.equal(0)
-    expect(size(d._all_models)).to.equal(0)
+    expect(d._all_models.size).to.equal(0)
     // does not reset title
     expect(d.title()).to.equal('Foo')
   })
@@ -710,7 +710,7 @@ describe("Document", () => {
   it("can patch an integer property", () => {
     const d = new Document()
     expect(d.roots().length).to.equal(0)
-    expect(Object.keys(d._all_models).length).to.equal(0)
+    expect(d._all_models.size).to.equal(0)
 
     const root1 = new SomeModel({ foo: 42 })
     const root2 = new SomeModel({ foo: 43 })
@@ -737,7 +737,7 @@ describe("Document", () => {
   it("can patch a reference property", () => {
     const d = new Document()
     expect(d.roots().length).to.equal(0)
-    expect(Object.keys(d._all_models).length).to.equal(0)
+    expect(d._all_models.size).to.equal(0)
 
     const root1 = new SomeModel({ foo: 42 })
     const root2 = new SomeModel({ foo: 43 })
@@ -750,9 +750,9 @@ describe("Document", () => {
     d.add_root(root2)
     expect(d.roots().length).to.equal(2)
 
-    expect(d._all_models).to.have.property(child1.id)
-    expect(d._all_models).to.not.have.property(child2.id)
-    expect(d._all_models).to.not.have.property(child3.id)
+    expect([...d._all_models.keys()]).to.include(child1.id)
+    expect([...d._all_models.keys()]).to.not.include(child2.id)
+    expect([...d._all_models.keys()]).to.not.include(child3.id)
 
     const event1 = new ev.ModelChangedEvent(d, root1, 'child', root1.child, child3)
     const patch1 = d.create_json_patch_string([event1])
@@ -762,9 +762,9 @@ describe("Document", () => {
     expect(root1.child).to.be.instanceof(SomeModel)
     const root1_child0 = root1.child as SomeModel
     expect(root1_child0.child!.id).to.equal(child2.id)
-    expect(d._all_models).to.have.property(child1.id)
-    expect(d._all_models).to.have.property(child2.id)
-    expect(d._all_models).to.have.property(child3.id)
+    expect([...d._all_models.keys()]).to.include(child1.id)
+    expect([...d._all_models.keys()]).to.include(child2.id)
+    expect([...d._all_models.keys()]).to.include(child3.id)
 
     // put it back how it was before
     const event2 = new ev.ModelChangedEvent(d, root1, 'child', child1.child, child1)
@@ -775,15 +775,15 @@ describe("Document", () => {
     expect(root1.child).to.be.instanceof(SomeModel)
     const root1_child1 = root1.child as SomeModel
     expect(root1_child1.child).to.be.equal(null)
-    expect(d._all_models).to.have.property(child1.id)
-    expect(d._all_models).to.not.have.property(child2.id)
-    expect(d._all_models).to.not.have.property(child3.id)
+    expect([...d._all_models.keys()]).to.include(child1.id)
+    expect([...d._all_models.keys()]).to.not.include(child2.id)
+    expect([...d._all_models.keys()]).to.not.include(child3.id)
   })
 
   it("can patch two properties at once", () => {
     const d = new Document()
     expect(d.roots().length).to.equal(0)
-    expect(Object.keys(d._all_models).length).to.equal(0)
+    expect(d._all_models.size).to.equal(0)
 
     const root1 = new SomeModel({ foo: 42 })
     const child1 = new SomeModel({ foo: 43 })
@@ -807,7 +807,7 @@ describe("Document", () => {
   it("sets proper document on models added during patching", () => {
     const d = new Document()
     expect(d.roots().length).to.equal(0)
-    expect(Object.keys(d._all_models).length).to.equal(0)
+    expect(d._all_models.size).to.equal(0)
 
     const root1 = new SomeModel({ foo: 42 })
     const child1 = new SomeModel({ foo: 44 })
@@ -833,7 +833,7 @@ describe("Document", () => {
   it("sets proper document on models added during construction", () => {
     const d = new Document()
     expect(d.roots().length).to.equal(0)
-    expect(Object.keys(d._all_models).length).to.equal(0)
+    expect(d._all_models.size).to.equal(0)
 
     const root1 = new ModelWithConstructTimeChanges()
     // change it so it doesn't match what initialize() does
@@ -862,7 +862,7 @@ describe("Document", () => {
   it("computes patch for models added during construction", () => {
     const d = new Document()
     expect(d.roots().length).to.equal(0)
-    expect(Object.keys(d._all_models).length).to.equal(0)
+    expect(d._all_models.size).to.equal(0)
 
     const root1 = new ModelWithConstructTimeChanges()
     // change it so it doesn't match what initialize() does
@@ -891,7 +891,7 @@ describe("Document", () => {
     // changes while constructing the parsed document.
     const d = new Document()
     expect(d.roots().length).to.equal(0)
-    expect(Object.keys(d._all_models).length).to.equal(0)
+    expect(d._all_models.size).to.equal(0)
 
     const root1 = new ComplicatedModelWithConstructTimeChanges()
     // change it so it doesn't match what initialize() does

--- a/bokehjs/test/unit/document/events.ts
+++ b/bokehjs/test/unit/document/events.ts
@@ -17,8 +17,6 @@ const EVENTS = [
   "RootRemovedEvent",
 ]
 
-const EMPTY_REFS = {}
-
 class TestModel extends HasProps {}
 
 class TestModelWithRefs extends HasProps {
@@ -49,7 +47,8 @@ describe("events module", () => {
       const d = new Document()
       const m = new TestModel()
       const evt = new events.ColumnsPatchedEvent(d, m.ref(), {foo: [[1, 2]]})
-      const json = evt.json(EMPTY_REFS)
+      const refs = new Set<HasProps>()
+      const json = evt.json(refs)
       expect(json).to.be.deep.equal({
         kind: "ColumnsPatched",
         column_source: m.ref(),
@@ -63,7 +62,8 @@ describe("events module", () => {
       const d = new Document()
       const m = new TestModel()
       const evt = new events.ColumnsStreamedEvent(d, m.ref(), {foo: [1, 2], bar: [3, 4]}, 10)
-      const json = evt.json(EMPTY_REFS)
+      const refs = new Set<HasProps>()
+      const json = evt.json(refs)
       expect(json).to.be.deep.equal({
         kind: "ColumnsStreamed",
         column_source: m.ref(),
@@ -76,7 +76,8 @@ describe("events module", () => {
       const d = new Document()
       const m = new TestModel()
       const evt = new events.ColumnsStreamedEvent(d, m.ref(), {foo: [1, 2], bar: [3, 4]})
-      const json = evt.json(EMPTY_REFS)
+      const refs = new Set<HasProps>()
+      const json = evt.json(refs)
       expect(json).to.be.deep.equal({
         kind: "ColumnsStreamed",
         column_source: m.ref(),
@@ -91,14 +92,15 @@ describe("events module", () => {
       const d = new Document()
       const m = new TestModel()
       const evt = new events.ModelChangedEvent(d, m, "id", 1, 2)
-      expect(() => evt.json(EMPTY_REFS)).to.throw(Error)
+      const refs = new Set<HasProps>()
+      expect(() => evt.json(refs)).to.throw(Error)
     })
 
     it("should generating json with no references", () =>{
       const d = new Document()
       const m = new TestModel()
       const evt = new events.ModelChangedEvent(d, m, "foo", 1, 2)
-      const refs = {}
+      const refs = new Set<HasProps>()
       const json = evt.json(refs)
       expect(json).to.be.deep.equal({
         kind: "ModelChanged",
@@ -113,7 +115,7 @@ describe("events module", () => {
       const m = new TestModel()
       const m2 = new TestModelWithRefs({foo:[]})
       const evt = new events.ModelChangedEvent(d, m2, "foo", [], [m])
-      const refs = {}
+      const refs = new Set<HasProps>()
       const json = evt.json(refs)
       expect(json).to.be.deep.equal({
         kind: "ModelChanged",
@@ -121,8 +123,8 @@ describe("events module", () => {
         attr: "foo",
         new: [m.ref()],
       })
-      const expected_refs: {[key: string]: HasProps} = {}
-      expected_refs[m.id] = m
+      const expected_refs = new Set<HasProps>()
+      expected_refs.add(m)
       expect(refs).to.be.deep.equal(expected_refs)
     })
 
@@ -133,7 +135,8 @@ describe("events module", () => {
       const m = new TestModel()
       const hint = new events.ColumnsStreamedEvent(d, m.ref(), {foo: [1, 2], bar: [3, 4]})
       const evt = new events.ModelChangedEvent(d, m, "foo", 1, 2, undefined, hint)
-      const json = evt.json(EMPTY_REFS)
+      const refs = new Set<HasProps>()
+      const json = evt.json(refs)
       expect(json).to.be.deep.equal({
         kind: "ColumnsStreamed",
         column_source: m.ref(),
@@ -147,7 +150,8 @@ describe("events module", () => {
     it("should generate json", () => {
       const d = new Document()
       const evt = new events.TitleChangedEvent(d, "foo")
-      const json = evt.json(EMPTY_REFS)
+      const refs = new Set<HasProps>()
+      const json = evt.json(refs)
       expect(json).to.be.deep.equal({
         kind: "TitleChanged",
         title: "foo",
@@ -160,7 +164,8 @@ describe("events module", () => {
       const d = new Document()
       const m = new TestModel()
       const evt = new events.RootAddedEvent(d, m)
-      const json = evt.json(EMPTY_REFS)
+      const refs = new Set<HasProps>()
+      const json = evt.json(refs)
       expect(json).to.be.deep.equal({
         kind: "RootAdded",
         model: m.ref(),
@@ -173,7 +178,8 @@ describe("events module", () => {
       const d = new Document()
       const m = new TestModel()
       const evt = new events.RootRemovedEvent(d, m)
-      const json = evt.json(EMPTY_REFS)
+      const refs = new Set<HasProps>()
+      const json = evt.json(refs)
       expect(json).to.be.deep.equal({
         kind: "RootRemoved",
         model: m.ref(),


### PR DESCRIPTION
Backport of PR #9836. ~~This is based on PR #10004. I will rebase on top of `master` when that is merged~~. Note this PR doesn't replace all occurrences of `{[key: string]: V}`. Further incremental changes will be needed.