### PR TITLE
Adding 2 more themes: night_sky, contrast [ci disable examples]

### DIFF
--- a/bokeh/themes/__init__.py
+++ b/bokeh/themes/__init__.py
@@ -61,6 +61,42 @@ LIGHT_MINIMAL
     p.line(x, y)
     show(p)
 
+NIGHT_SKY
+~~~~~~~~~~~~~
+
+.. bokeh-plot::
+
+    from bokeh.plotting import figure, output_file, show
+    from bokeh.themes import built_in_themes
+    from bokeh.io import curdoc
+
+    x = [1, 2, 3, 4, 5]
+    y = [6, 7, 6, 4, 5]
+
+    output_file("night_sky.html")
+    curdoc().theme = 'night_sky'
+    p = figure(title='night_sky', plot_width=300, plot_height=300)
+    p.line(x, y)
+    show(p)
+
+CONTRAST
+~~~~~~~~~~~~~
+
+.. bokeh-plot::
+
+    from bokeh.plotting import figure, output_file, show
+    from bokeh.themes import built_in_themes
+    from bokeh.io import curdoc
+
+    x = [1, 2, 3, 4, 5]
+    y = [6, 7, 6, 4, 5]
+
+    output_file("contrast.html")
+    curdoc().theme = 'contrast'
+    p = figure(title='contrast', plot_width=300, plot_height=300)
+    p.line(x, y)
+    show(p)
+
 as well as the ``Theme`` class that can be used to create new Themes.
 
 .. autoclass:: Theme
@@ -78,7 +114,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Bokeh imports
-from . import _caliber, _dark_minimal, _light_minimal
+from . import _caliber, _dark_minimal, _light_minimal, _night_sky, _contrast
 from .theme import Theme
 
 #-----------------------------------------------------------------------------
@@ -89,6 +125,8 @@ __all__ = (
     'CALIBER',
     'DARK_MINIMAL',
     'LIGHT_MINIMAL',
+    'NIGHT_SKY',
+    'CONTRAST',
     'Theme',
     'built_in_themes',
     'default',
@@ -101,6 +139,8 @@ __all__ = (
 CALIBER       = 'caliber'
 LIGHT_MINIMAL = 'light_minimal'
 DARK_MINIMAL  = 'dark_minimal'
+NIGHT_SKY  = 'night_sky'
+CONTRAST  = 'contrast'
 
 default = Theme(json={})
 
@@ -108,6 +148,8 @@ built_in_themes = {
     CALIBER       : Theme(json=_caliber.json),
     DARK_MINIMAL  : Theme(json=_dark_minimal.json),
     LIGHT_MINIMAL : Theme(json=_caliber.json),
+    NIGHT_SKY : Theme(json=_night_sky.json),
+    CONTRAST : Theme(json=_contrast.json),
 }
 
 #-----------------------------------------------------------------------------

--- a/bokeh/themes/__init__.py
+++ b/bokeh/themes/__init__.py
@@ -114,7 +114,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Bokeh imports
-from . import _caliber, _dark_minimal, _light_minimal, _night_sky, _contrast
+from . import _caliber, _contrast, _dark_minimal, _light_minimal, _night_sky
 from .theme import Theme
 
 #-----------------------------------------------------------------------------

--- a/bokeh/themes/_contrast.py
+++ b/bokeh/themes/_contrast.py
@@ -1,0 +1,78 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2020, Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+json = {
+    "attrs": {
+        "Figure" : {
+            "background_fill_color": "#000000",
+            "border_fill_color": "#FFFFFF",
+            "outline_line_color": "#000000",
+            "outline_line_alpha": 0.25
+        },
+
+        "Grid": {
+            "grid_line_color": "#E0E0E0",
+            "grid_line_alpha": 0.25
+        },
+
+        "Axis": {
+            "major_tick_line_alpha": 0,
+            "major_tick_line_color": "#000000",
+
+            "minor_tick_line_alpha": 0,
+            "minor_tick_line_color": "#000000",
+
+            "axis_line_alpha": 0,
+            "axis_line_color": "#000000",
+
+            "major_label_text_color": "#000000",
+            "major_label_text_font": "Helvetica",
+            "major_label_text_font_size": "1.025em",
+
+            "axis_label_standoff": 10,
+            "axis_label_text_color": "#000000",
+            "axis_label_text_font": "Helvetica",
+            "axis_label_text_font_size": "1.25em",
+            "axis_label_text_font_style": "normal"
+        },
+
+        "Legend": {
+            "spacing": 8,
+            "glyph_width": 15,
+
+            "label_standoff": 8,
+            "label_text_color": "#FFFFFF",
+            "label_text_font": "Helvetica",
+            "label_text_font_size": "1.025em",
+
+            "border_line_alpha": 0,
+            "background_fill_alpha": 0.25,
+            "background_fill_color": "#000000"
+        },
+
+        "ColorBar": {
+            "title_text_color": "#E0E0E0",
+            "title_text_font": "Helvetica",
+            "title_text_font_size": "1.025em",
+            "title_text_font_style": "normal",
+
+            "major_label_text_color": "#E0E0E0",
+            "major_label_text_font": "Helvetica",
+            "major_label_text_font_size": "1.025em",
+
+            "background_fill_color": "#15191C",
+            "major_tick_line_alpha": 0,
+            "bar_line_alpha": 0
+        },
+
+        "Title": {
+            "text_color": "#000000",
+            "text_font": "Helvetica",
+            "text_font_size": "1.15em"
+        }
+    }
+}

--- a/bokeh/themes/_night_sky.py
+++ b/bokeh/themes/_night_sky.py
@@ -1,0 +1,78 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2020, Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+json = {
+    "attrs": {
+        "Figure" : {
+            "background_fill_color": "#2C001E",
+            "border_fill_color": "#15191C",
+            "outline_line_color": "#E0E0E0",
+            "outline_line_alpha": 0.25
+        },
+
+        "Grid": {
+            "grid_line_color": "#E0E0E0",
+            "grid_line_alpha": 0.25
+        },
+
+        "Axis": {
+            "major_tick_line_alpha": 0,
+            "major_tick_line_color": "#E0E0E0",
+
+            "minor_tick_line_alpha": 0,
+            "minor_tick_line_color": "#E0E0E0",
+
+            "axis_line_alpha": 0,
+            "axis_line_color": "#E0E0E0",
+
+            "major_label_text_color": "#E0E0E0",
+            "major_label_text_font": "Helvetica",
+            "major_label_text_font_size": "1.025em",
+
+            "axis_label_standoff": 10,
+            "axis_label_text_color": "#E0E0E0",
+            "axis_label_text_font": "Helvetica",
+            "axis_label_text_font_size": "1.25em",
+            "axis_label_text_font_style": "normal"
+        },
+
+        "Legend": {
+            "spacing": 8,
+            "glyph_width": 15,
+
+            "label_standoff": 8,
+            "label_text_color": "#E0E0E0",
+            "label_text_font": "Helvetica",
+            "label_text_font_size": "1.025em",
+
+            "border_line_alpha": 0,
+            "background_fill_alpha": 0.25,
+            "background_fill_color": "#2C001E"
+        },
+
+        "ColorBar": {
+            "title_text_color": "#E0E0E0",
+            "title_text_font": "Helvetica",
+            "title_text_font_size": "1.025em",
+            "title_text_font_style": "normal",
+
+            "major_label_text_color": "#E0E0E0",
+            "major_label_text_font": "Helvetica",
+            "major_label_text_font_size": "1.025em",
+
+            "background_fill_color": "#15191C",
+            "major_tick_line_alpha": 0,
+            "bar_line_alpha": 0
+        },
+
+        "Title": {
+            "text_color": "#E0E0E0",
+            "text_font": "Helvetica",
+            "text_font_size": "1.15em"
+        }
+    }
+}


### PR DESCRIPTION
All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [x] issues: fixes #10028
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

No tests added for the themes.

Here are the previews:

**Contrast**
![contrast preview 1](https://github.com/Cheukting/bokeh/raw/theme-preview/pictures/contrast01.png)
![contrast preview 2](https://github.com/Cheukting/bokeh/raw/theme-preview/pictures/contrast02.png)

**Night Sky**
![night sky preview1](https://github.com/Cheukting/bokeh/raw/theme-preview/pictures/night_sky01.png)
![night sky preview2](https://github.com/Cheukting/bokeh/raw/theme-preview/pictures/night_sky02.png)