### PR TITLE
Fix documentation section

### DIFF
--- a/sphinx/source/docs/dev_guide/documentation.rst
+++ b/sphinx/source/docs/dev_guide/documentation.rst
@@ -94,6 +94,14 @@ before calling ``make``:
 
     BOKEH_DOCS_CDN=local make clean html serve
 
+Built docs require to setup the ``GOOGLE_API_KEY`` environment variable for geo maps.
+You can create a new API `create a new API Key <https://developers.google.com/maps/documentation/javascript/get-api-key>`_.
+Or if you don't mind of having broken maps, you can setup the variable with a fake value before calling ``make``:
+
+.. code-block:: sh
+
+    GOOGLE_API_KEY=foo make clean html serve
+
 Source Code Documentation
 -------------------------
 

--- a/sphinx/source/docs/dev_guide/documentation.rst
+++ b/sphinx/source/docs/dev_guide/documentation.rst
@@ -94,9 +94,9 @@ before calling ``make``:
 
     BOKEH_DOCS_CDN=local make clean html serve
 
-Built docs require to setup the ``GOOGLE_API_KEY`` environment variable for geo maps.
-You can create a new API `create a new API Key <https://developers.google.com/maps/documentation/javascript/get-api-key>`_.
-Or if you don't mind of having broken maps, you can setup the variable with a fake value before calling ``make``:
+Building the docs also requires setting up the ``GOOGLE_API_KEY`` environment variable that ``gmap`` plots use.
+You can `create a new API Key <https://developers.google.com/maps/documentation/javascript/get-api-key>`_.
+Or if you don't care whether ``gmap`` plots work, you can set the variable with a fake value before calling ``make``:
 
 .. code-block:: sh
 


### PR DESCRIPTION
Sphinx docs build fails  when GOOGLE_API_KEY environment variable is not set up. 
Adding proper documentation on Dev guid, documentation section.

- [x] issues: fixes #10030 
