### PR TITLE
Refactor implementation of Image and ImageRGBA glyphs

### DIFF
--- a/bokehjs/src/lib/models/glyphs/image.ts
+++ b/bokehjs/src/lib/models/glyphs/image.ts
@@ -3,8 +3,6 @@ import {ColorMapper} from "../mappers/color_mapper"
 import {LinearColorMapper} from "../mappers/linear_color_mapper"
 import {Arrayable} from "core/types"
 import * as p from "core/properties"
-import {concat} from "core/util/array"
-import {Context2d} from "core/util/canvas"
 
 export interface ImageData extends ImageDataBase {}
 
@@ -14,73 +12,22 @@ export class ImageView extends ImageBaseView {
   model: Image
   visuals: Image.Visuals
 
-  protected _width: Arrayable<number>
-  protected _height: Arrayable<number>
-
-  initialize(): void {
-    super.initialize()
+  connect_signals(): void {
+    super.connect_signals()
     this.connect(this.model.color_mapper.change, () => this._update_image())
-    this.connect(this.model.properties.global_alpha.change, () => this.renderer.request_render())
   }
 
   protected _update_image(): void {
     // Only reset image_data if already initialized
     if (this.image_data != null) {
-      this._set_data()
+      this._set_data(null)
       this.renderer.plot_view.request_render()
     }
   }
 
-  protected _set_data(): void {
-    this._set_width_heigh_data()
-
+  protected _flat_img_to_buf8(img: Arrayable<number>): Uint8Array {
     const cmap = this.model.color_mapper.rgba_mapper
-
-    for (let i = 0, end = this._image.length; i < end; i++) {
-      let img: Arrayable<number>
-      if (this._image_shape != null && this._image_shape[i].length > 0) {
-        img = this._image[i] as Arrayable<number>
-        const shape = this._image_shape[i]
-        this._height[i] = shape[0]
-        this._width[i] = shape[1]
-      } else {
-        const _image = this._image[i] as number[][]
-        img = concat(_image)
-        this._height[i] = _image.length
-        this._width[i] = _image[0].length
-      }
-
-      const buf8 = cmap.v_compute(img)
-      this._set_image_data_from_buffer(i, buf8)
-
-    }
-  }
-
-  protected _render(ctx: Context2d, indices: number[], {image_data, sx, sy, sw, sh}: ImageData): void {
-    const old_smoothing = ctx.getImageSmoothingEnabled()
-    ctx.setImageSmoothingEnabled(false)
-
-    ctx.globalAlpha = this.model.global_alpha
-
-    for (const i of indices) {
-      if (image_data[i] == null)
-        continue
-
-      if (isNaN(sx[i] + sy[i] + sw[i] + sh[i]))
-        continue
-
-      const y_offset = sy[i]
-
-      ctx.translate(0, y_offset)
-      ctx.scale(1, -1)
-      ctx.translate(0, -y_offset)
-      ctx.drawImage(image_data[i], sx[i]|0, sy[i]|0, sw[i], sh[i])
-      ctx.translate(0, y_offset)
-      ctx.scale(1, -1)
-      ctx.translate(0, -y_offset)
-    }
-
-    ctx.setImageSmoothingEnabled(old_smoothing)
+    return cmap.v_compute(img)
   }
 }
 
@@ -91,11 +38,6 @@ export namespace Image {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = ImageBase.Props & {
-    image: p.NumberSpec
-    dw: p.DistanceSpec
-    dh: p.DistanceSpec
-    global_alpha: p.Property<number>
-    dilate: p.Property<boolean>
     color_mapper: p.Property<ColorMapper>
   }
 
@@ -116,7 +58,7 @@ export class Image extends ImageBase {
     this.prototype.default_view = ImageView
 
     this.define<Image.Props>({
-      color_mapper: [ p.Instance,  () => new LinearColorMapper({palette: Greys9()}) ],
+      color_mapper: [ p.Instance, () => new LinearColorMapper({palette: Greys9()}) ],
     })
   }
 }

--- a/bokehjs/src/lib/models/glyphs/image_rgba.ts
+++ b/bokehjs/src/lib/models/glyphs/image_rgba.ts
@@ -1,8 +1,7 @@
 import {ImageBase, ImageBaseView, ImageDataBase} from "./image_base"
 import {Arrayable, TypedArray} from "core/types"
+import {isArray} from "core/util/types"
 import * as p from "core/properties"
-import {concat} from "core/util/array"
-import {Context2d} from "core/util/canvas"
 
 export interface ImageRGBAData extends ImageDataBase {}
 
@@ -12,80 +11,21 @@ export class ImageRGBAView extends ImageBaseView {
   model: ImageRGBA
   visuals: ImageRGBA.Visuals
 
-  protected _width: Arrayable<number>
-  protected _height: Arrayable<number>
-
-  initialize(): void {
-    super.initialize()
-    this.connect(this.model.properties.global_alpha.change, () => this.renderer.request_render())
-  }
-
-  protected _set_data(indices: number[] | null): void {
-    this._set_width_heigh_data()
-
-    for (let i = 0, end = this._image.length; i < end; i++) {
-      if (indices != null && indices.indexOf(i) < 0)
-        continue
-
-      let buf: ArrayBuffer
-      if (this._image_shape != null && this._image_shape[i].length > 0) {
-        buf = (this._image[i] as TypedArray).buffer
-        const shape = this._image_shape[i]
-        this._height[i] = shape[0]
-        this._width[i] = shape[1]
-      } else {
-        const _image = this._image[i] as number[][]
-        const flat = concat(_image)
-        buf = new ArrayBuffer(flat.length * 4)
-        const color = new Uint32Array(buf)
-        for (let j = 0, endj = flat.length; j < endj; j++) {
-          color[j] = flat[j]
-        }
-        this._height[i] = _image.length
-        this._width[i] = _image[0].length
-      }
-
-      const buf8 = new Uint8Array(buf)
-      this._set_image_data_from_buffer(i, buf8)
-
+  protected _flat_img_to_buf8(img: Arrayable<number>): Uint8Array {
+    let array: TypedArray
+    if (isArray(img)) {
+      array = new Uint32Array(img)
+    } else {
+      array = img as TypedArray
     }
-  }
-
-  protected _render(ctx: Context2d, indices: number[], {image_data, sx, sy, sw, sh}: ImageRGBAData): void {
-    const old_smoothing = ctx.getImageSmoothingEnabled()
-    ctx.setImageSmoothingEnabled(false)
-
-    ctx.globalAlpha = this.model.global_alpha
-
-    for (const i of indices) {
-      if (isNaN(sx[i] + sy[i] + sw[i] + sh[i]))
-        continue
-
-      const y_offset = sy[i]
-
-      ctx.translate(0, y_offset)
-      ctx.scale(1, -1)
-      ctx.translate(0, -y_offset)
-      ctx.drawImage(image_data[i], sx[i]|0, sy[i]|0, sw[i], sh[i])
-      ctx.translate(0, y_offset)
-      ctx.scale(1, -1)
-      ctx.translate(0, -y_offset)
-    }
-
-    ctx.setImageSmoothingEnabled(old_smoothing)
+    return new Uint8Array(array.buffer)
   }
 }
 
 export namespace ImageRGBA {
   export type Attrs = p.AttrsOf<Props>
 
-  export type Props = ImageBase.Props & {
-    image: p.NumberSpec
-    dw: p.DistanceSpec
-    dh: p.DistanceSpec
-    global_alpha: p.Property<number>
-    dilate: p.Property<boolean>
-  }
+  export type Props = ImageBase.Props
 
   export type Visuals = ImageBase.Visuals
 }


### PR DESCRIPTION
`Image` and `ImageRGBA` already have a common base, but they still repeat quite a bit of their implementations. This PR resolves this by pulling most of the common code into `ImageBase` class.
