### PR TITLE
Replace setter_id with a less verbose mechanism

### DIFF
--- a/bokeh/client/session.py
+++ b/bokeh/client/session.py
@@ -430,10 +430,6 @@ class ClientSession(object):
         self._callbacks.add_session_callbacks(self._document.session_callbacks)
 
     def _document_patched(self, event):
-        if event.setter is self:
-            log.debug("Not sending notification back to server for a change it requested")
-            return
-
         # TODO (havocp): our "change sync" protocol is flawed
         # because if both sides change the same attribute at the
         # same time, they will each end up with the state of the
@@ -447,7 +443,7 @@ class ClientSession(object):
         return session_id
 
     def _handle_patch(self, message):
-        message.apply_to_document(self.document, self)
+        message.apply_to_document(self.document)
 
     def _loop_until_closed(self):
         ''' Execute a blocking loop that runs and executes event callbacks

--- a/bokeh/core/has_props.py
+++ b/bokeh/core/has_props.py
@@ -307,7 +307,7 @@ class HasProps(object, metaclass=MetaHasProps):
         else:
             return self.properties_with_values() == other.properties_with_values()
 
-    def set_from_json(self, name, json, models=None, setter=None):
+    def set_from_json(self, name, json, models=None):
         ''' Set a property value on this object from JSON.
 
         Args:
@@ -321,16 +321,6 @@ class HasProps(object, metaclass=MetaHasProps):
                 This is needed in cases where the attributes to update also
                 have values that have references.
 
-            setter(ClientSession or ServerSession or None, optional) :
-                This is used to prevent "boomerang" updates to Bokeh apps.
-
-                In the context of a Bokeh server application, incoming updates
-                to properties will be annotated with the session that is
-                doing the updating. This value is propagated through any
-                subsequent change notifications that the update triggers.
-                The session can compare the event setter to itself, and
-                suppress any updates that originate from itself.
-
         Returns:
             None
 
@@ -338,7 +328,7 @@ class HasProps(object, metaclass=MetaHasProps):
         if name in self.properties():
             log.trace("Patching attribute %r of %r with %r", name, self, json)
             descriptor = self.lookup(name)
-            descriptor.set_from_json(self, json, models, setter)
+            descriptor.set_from_json(self, json, models)
         else:
             log.warning("JSON had attr %r on obj %r, which is a client-only or invalid attribute that shouldn't have been sent", name, self)
 
@@ -369,7 +359,7 @@ class HasProps(object, metaclass=MetaHasProps):
         for k,v in kwargs.items():
             setattr(self, k, v)
 
-    def update_from_json(self, json_attributes, models=None, setter=None):
+    def update_from_json(self, json_attributes, models=None):
         ''' Updates the object's properties from a JSON attributes dictionary.
 
         Args:
@@ -381,22 +371,12 @@ class HasProps(object, metaclass=MetaHasProps):
                 This is needed in cases where the attributes to update also
                 have values that have references.
 
-            setter(ClientSession or ServerSession or None, optional) :
-                This is used to prevent "boomerang" updates to Bokeh apps.
-
-                In the context of a Bokeh server application, incoming updates
-                to properties will be annotated with the session that is
-                doing the updating. This value is propagated through any
-                subsequent change notifications that the update triggers.
-                The session can compare the event setter to itself, and
-                suppress any updates that originate from itself.
-
         Returns:
             None
 
         '''
         for k, v in json_attributes.items():
-            self.set_from_json(k, v, models, setter)
+            self.set_from_json(k, v, models)
 
     @classmethod
     def lookup(cls, name):

--- a/bokeh/core/property/descriptors.py
+++ b/bokeh/core/property/descriptors.py
@@ -158,13 +158,8 @@ class PropertyDescriptor(object):
         '''
         raise NotImplementedError("Implement __get__")
 
-    def __set__(self, obj, value, setter=None):
+    def __set__(self, obj, value):
         ''' Implement the setter for the Python `descriptor protocol`_.
-
-        .. note::
-            An optional argument ``setter`` has been added to the standard
-            setter arguments. When needed, this value should be provided by
-            explicitly invoking ``__set__``. See below for more information.
 
         Args:
             obj (HasProps) :
@@ -172,17 +167,6 @@ class PropertyDescriptor(object):
 
             value (obj) :
                 The new value to set the property to
-
-            setter (ClientSession or ServerSession or None, optional) :
-                This is used to prevent "boomerang" updates to Bokeh apps.
-                (default: None)
-
-                In the context of a Bokeh server application, incoming updates
-                to properties will be annotated with the session that is
-                doing the updating. This value is propagated through any
-                subsequent change notifications that the update triggers.
-                The session can compare the event setter to itself, and
-                suppress any updates that originate from itself.
 
         Returns:
             None
@@ -289,7 +273,7 @@ class PropertyDescriptor(object):
         value = self.__get__(obj, obj.__class__)
         return self.property.serialize_value(value)
 
-    def set_from_json(self, obj, json, models=None, setter=None):
+    def set_from_json(self, obj, json, models=None):
         '''Sets the value of this property from a JSON value.
 
         Args:
@@ -303,22 +287,11 @@ class PropertyDescriptor(object):
                 This is needed in cases where the attributes to update also
                 have values that have references.
 
-            setter (ClientSession or ServerSession or None, optional) :
-                This is used to prevent "boomerang" updates to Bokeh apps.
-                (default: None)
-
-                In the context of a Bokeh server application, incoming updates
-                to properties will be annotated with the session that is
-                doing the updating. This value is propagated through any
-                subsequent change notifications that the update triggers.
-                The session can compare the event setter to itself, and
-                suppress any updates that originate from itself.
-
         Returns:
             None
 
         '''
-        self._internal_set(obj, json, setter=setter)
+        self._internal_set(obj, json)
 
     def trigger_if_changed(self, obj, old):
         ''' Send a change event notification if the property is set to a
@@ -390,7 +363,7 @@ class PropertyDescriptor(object):
         '''
         raise NotImplementedError("Implement serialized()")
 
-    def _internal_set(self, obj, value, hint=None, setter=None):
+    def _internal_set(self, obj, value, hint=None):
         ''' Internal implementation to set property values, that is used
         by __set__, set_from_json, etc.
 
@@ -408,17 +381,6 @@ class PropertyDescriptor(object):
                 Update event hints are usually used at times when better
                 update performance can be obtained by special-casing in
                 some way (e.g. streaming or patching column data sources)
-
-            setter (ClientSession or ServerSession or None, optional) :
-                This is used to prevent "boomerang" updates to Bokeh apps.
-                (default: None)
-
-                In the context of a Bokeh server application, incoming updates
-                to properties will be annotated with the session that is
-                doing the updating. This value is propagated through any
-                subsequent change notifications that the update triggers.
-                The session can compare the event setter to itself, and
-                suppress any updates that originate from itself.
 
         Raises:
             NotImplementedError
@@ -498,13 +460,8 @@ class BasicPropertyDescriptor(PropertyDescriptor):
             # called __get__ explicitly but in a bad way.
             raise ValueError("both 'obj' and 'owner' are None, don't know what to do")
 
-    def __set__(self, obj, value, setter=None):
+    def __set__(self, obj, value):
         ''' Implement the setter for the Python `descriptor protocol`_.
-
-        .. note::
-            An optional argument ``setter`` has been added to the standard
-            setter arguments. When needed, this value should be provided by
-            explicitly invoking ``__set__``. See below for more information.
 
         Args:
             obj (HasProps) :
@@ -512,18 +469,6 @@ class BasicPropertyDescriptor(PropertyDescriptor):
 
             value (obj) :
                 The new value to set the property to
-
-            setter (ClientSession or ServerSession or None, optional) :
-                This is used to prevent "boomerang" updates to Bokeh apps.
-                (default: None)
-
-                In the context of a Bokeh server application, incoming updates
-                to properties will be annotated with the session that is
-                doing the updating. This value is propagated through any
-                subsequent change notifications that the update triggers.
-                The session can compare the event setter to itself, and
-                suppress any updates that originate from itself.
-
         Returns:
             None
 
@@ -536,7 +481,7 @@ class BasicPropertyDescriptor(PropertyDescriptor):
         if self.property._readonly:
             raise RuntimeError("%s.%s is a readonly property" % (obj.__class__.__name__, self.name))
 
-        self._internal_set(obj, value, setter=setter)
+        self._internal_set(obj, value)
 
     def __delete__(self, obj):
         ''' Implement the deleter for the Python `descriptor protocol`_.
@@ -580,7 +525,7 @@ class BasicPropertyDescriptor(PropertyDescriptor):
         '''
         return self.property.themed_default(obj.__class__, self.name, obj.themed_values())
 
-    def set_from_json(self, obj, json, models=None, setter=None):
+    def set_from_json(self, obj, json, models=None):
         ''' Sets the value of this property from a JSON value.
 
         This method first
@@ -592,24 +537,11 @@ class BasicPropertyDescriptor(PropertyDescriptor):
 
             models(seq[Model], optional) :
 
-            setter (ClientSession or ServerSession or None, optional) :
-                This is used to prevent "boomerang" updates to Bokeh apps.
-                (default: None)
-
-                In the context of a Bokeh server application, incoming updates
-                to properties will be annotated with the session that is
-                doing the updating. This value is propagated through any
-                subsequent change notifications that the update triggers.
-                The session can compare the event setter to itself, and
-                suppress any updates that originate from itself.
-
         Returns:
             None
 
         '''
-        return super().set_from_json(obj,
-                                                        self.property.from_json(json, models),
-                                                        models, setter)
+        return super().set_from_json(obj, self.property.from_json(json, models), models)
 
     def trigger_if_changed(self, obj, old):
         ''' Send a change event notification if the property is set to a
@@ -720,7 +652,7 @@ class BasicPropertyDescriptor(PropertyDescriptor):
 
         return default
 
-    def _internal_set(self, obj, value, hint=None, setter=None):
+    def _internal_set(self, obj, value, hint=None):
         ''' Internal implementation to set property values, that is used
         by __set__, set_from_json, etc.
 
@@ -742,17 +674,6 @@ class BasicPropertyDescriptor(PropertyDescriptor):
                 update performance can be obtained by special-casing in
                 some way (e.g. streaming or patching column data sources)
 
-            setter (ClientSession or ServerSession or None, optional) :
-                This is used to prevent "boomerang" updates to Bokeh apps.
-                (default: None)
-
-                In the context of a Bokeh server application, incoming updates
-                to properties will be annotated with the session that is
-                doing the updating. This value is propagated through any
-                subsequent change notifications that the update triggers.
-                The session can compare the event setter to itself, and
-                suppress any updates that originate from itself.
-
         Returns:
             None
 
@@ -760,9 +681,9 @@ class BasicPropertyDescriptor(PropertyDescriptor):
         value = self.property.prepare_value(obj, self.name, value)
 
         old = self.__get__(obj, obj.__class__)
-        self._real_set(obj, old, value, hint=hint, setter=setter)
+        self._real_set(obj, old, value, hint=hint)
 
-    def _real_set(self, obj, old, value, hint=None, setter=None):
+    def _real_set(self, obj, old, value, hint=None):
         ''' Internal implementation helper to set property values.
 
         This function handles bookkeeping around noting whether values have
@@ -782,17 +703,6 @@ class BasicPropertyDescriptor(PropertyDescriptor):
                 Update event hints are usually used at times when better
                 update performance can be obtained by special-casing in
                 some way (e.g. streaming or patching column data sources)
-
-            setter (ClientSession or ServerSession or None, optional) :
-                This is used to prevent "boomerang" updates to Bokeh apps.
-                (default: None)
-
-                In the context of a Bokeh server application, incoming updates
-                to properties will be annotated with the session that is
-                doing the updating. This value is propagated through any
-                subsequent change notifications that the update triggers.
-                The session can compare the event setter to itself, and
-                suppress any updates that originate from itself.
 
         Returns:
             None
@@ -829,7 +739,7 @@ class BasicPropertyDescriptor(PropertyDescriptor):
             obj._property_values[self.name] = value
 
         # for notification purposes, "old" should be the logical old
-        self._trigger(obj, old, value, hint=hint, setter=setter)
+        self._trigger(obj, old, value, hint=hint)
 
     # called when a container is mutated "behind our back" and
     # we detect it with our collection wrappers.
@@ -868,7 +778,7 @@ class BasicPropertyDescriptor(PropertyDescriptor):
 
         self._real_set(obj, old, value, hint=hint)
 
-    def _trigger(self, obj, old, value, hint=None, setter=None):
+    def _trigger(self, obj, old, value, hint=None):
         ''' Unconditionally send a change event notification for the property.
 
         Args:
@@ -889,24 +799,12 @@ class BasicPropertyDescriptor(PropertyDescriptor):
                 update performance can be obtained by special-casing in
                 some way (e.g. streaming or patching column data sources)
 
-            setter (ClientSession or ServerSession or None, optional) :
-                This is used to prevent "boomerang" updates to Bokeh apps.
-                (default: None)
-
-                In the context of a Bokeh server application, incoming updates
-                to properties will be annotated with the session that is
-                doing the updating. This value is propagated through any
-                subsequent change notifications that the update triggers.
-                The session can compare the event setter to itself, and
-                suppress any updates that originate from itself.
-
-
         Returns:
             None
 
         '''
         if hasattr(obj, 'trigger'):
-            obj.trigger(self.name, old, value, hint, setter)
+            obj.trigger(self.name, old, value, hint)
 
 
 _CDS_SET_FROM_CDS_ERROR = """
@@ -922,7 +820,7 @@ class ColumnDataPropertyDescriptor(BasicPropertyDescriptor):
 
     '''
 
-    def __set__(self, obj, value, setter=None):
+    def __set__(self, obj, value):
         ''' Implement the setter for the Python `descriptor protocol`_.
 
         This method first separately extracts and removes any ``units`` field
@@ -930,28 +828,12 @@ class ColumnDataPropertyDescriptor(BasicPropertyDescriptor):
         remaining value is then passed to the superclass ``__set__`` to
         be handled.
 
-        .. note::
-            An optional argument ``setter`` has been added to the standard
-            setter arguments. When needed, this value should be provided by
-            explicitly invoking ``__set__``. See below for more information.
-
         Args:
             obj (HasProps) :
                 The instance to set a new property value on
 
             value (obj) :
                 The new value to set the property to
-
-            setter (ClientSession or ServerSession or None, optional) :
-                This is used to prevent "boomerang" updates to Bokeh apps.
-                (default: None)
-
-                In the context of a Bokeh server application, incoming updates
-                to properties will be annotated with the session that is
-                doing the updating. This value is propagated through any
-                subsequent change notifications that the update triggers.
-                The session can compare the event setter to itself, and
-                suppress any updates that originate from itself.
 
         Returns:
             None
@@ -971,11 +853,11 @@ class ColumnDataPropertyDescriptor(BasicPropertyDescriptor):
         from ...document.events import ColumnDataChangedEvent
 
         if obj.document:
-            hint = ColumnDataChangedEvent(obj.document, obj, setter=setter)
+            hint = ColumnDataChangedEvent(obj.document, obj)
         else:
             hint = None
 
-        self._internal_set(obj, value, hint=hint, setter=setter)
+        self._internal_set(obj, value, hint=hint)
 
 class DataSpecPropertyDescriptor(BasicPropertyDescriptor):
     ''' A ``PropertyDescriptor`` for Bokeh |DataSpec| properties that serialize to
@@ -989,7 +871,7 @@ class DataSpecPropertyDescriptor(BasicPropertyDescriptor):
         '''
         return self.property.to_serializable(obj, self.name, getattr(obj, self.name))
 
-    def set_from_json(self, obj, json, models=None, setter=None):
+    def set_from_json(self, obj, json, models=None):
         ''' Sets the value of this property from a JSON value.
 
         This method first
@@ -1000,17 +882,6 @@ class DataSpecPropertyDescriptor(BasicPropertyDescriptor):
             json (JSON-dict) :
 
             models(seq[Model], optional) :
-
-            setter (ClientSession or ServerSession or None, optional) :
-                This is used to prevent "boomerang" updates to Bokeh apps.
-                (default: None)
-
-                In the context of a Bokeh server application, incoming updates
-                to properties will be annotated with the session that is
-                doing the updating. This value is propagated through any
-                subsequent change notifications that the update triggers.
-                The session can compare the event setter to itself, and
-                suppress any updates that originate from itself.
 
         Returns:
             None
@@ -1030,7 +901,7 @@ class DataSpecPropertyDescriptor(BasicPropertyDescriptor):
                         json = json['field']
                 # leave it as a dict if 'old' was a dict
 
-        super().set_from_json(obj, json, models, setter)
+        super().set_from_json(obj, json, models)
 
 class UnitsSpecPropertyDescriptor(DataSpecPropertyDescriptor):
     ''' A ``PropertyDecscriptor`` for Bokeh |UnitsSpec| properties that contribute
@@ -1055,18 +926,13 @@ class UnitsSpecPropertyDescriptor(DataSpecPropertyDescriptor):
         super().__init__(name, property)
         self.units_prop = units_property
 
-    def __set__(self, obj, value, setter=None):
+    def __set__(self, obj, value):
         ''' Implement the setter for the Python `descriptor protocol`_.
 
         This method first separately extracts and removes any ``units`` field
         in the JSON, and sets the associated units property directly. The
         remaining value is then passed to the superclass ``__set__`` to
         be handled.
-
-        .. note::
-            An optional argument ``setter`` has been added to the standard
-            setter arguments. When needed, this value should be provided by
-            explicitly invoking ``__set__``. See below for more information.
 
         Args:
             obj (HasProps) :
@@ -1075,25 +941,14 @@ class UnitsSpecPropertyDescriptor(DataSpecPropertyDescriptor):
             value (obj) :
                 The new value to set the property to
 
-            setter (ClientSession or ServerSession or None, optional) :
-                This is used to prevent "boomerang" updates to Bokeh apps.
-                (default: None)
-
-                In the context of a Bokeh server application, incoming updates
-                to properties will be annotated with the session that is
-                doing the updating. This value is propagated through any
-                subsequent change notifications that the update triggers.
-                The session can compare the event setter to itself, and
-                suppress any updates that originate from itself.
-
         Returns:
             None
 
         '''
         value = self._extract_units(obj, value)
-        super().__set__(obj, value, setter)
+        super().__set__(obj, value)
 
-    def set_from_json(self, obj, json, models=None, setter=None):
+    def set_from_json(self, obj, json, models=None):
         ''' Sets the value of this property from a JSON value.
 
         This method first separately extracts and removes any ``units`` field
@@ -1112,23 +967,12 @@ class UnitsSpecPropertyDescriptor(DataSpecPropertyDescriptor):
                 This is needed in cases where the attributes to update also
                 have values that have references.
 
-            setter (ClientSession or ServerSession or None, optional) :
-                This is used to prevent "boomerang" updates to Bokeh apps.
-                (default: None)
-
-                In the context of a Bokeh server application, incoming updates
-                to properties will be annotated with the session that is
-                doing the updating. This value is propagated through any
-                subsequent change notifications that the update triggers.
-                The session can compare the event setter to itself, and
-                suppress any updates that originate from itself.
-
         Returns:
             None
 
         '''
         json = self._extract_units(obj, json)
-        super().set_from_json(obj, json, models, setter)
+        super().set_from_json(obj, json, models)
 
     def _extract_units(self, obj, value):
         ''' Internal helper for dealing with units associated units properties

--- a/bokeh/core/property/wrappers.py
+++ b/bokeh/core/property/wrappers.py
@@ -380,7 +380,7 @@ class PropertyValueColumnData(PropertyValueDict):
         return result
 
     # don't wrap with notify_owner --- notifies owners explicitly
-    def _stream(self, doc, source, new_data, rollover=None, setter=None):
+    def _stream(self, doc, source, new_data, rollover=None):
         ''' Internal implementation to handle special-casing stream events
         on ``ColumnDataSource`` columns.
 
@@ -427,10 +427,10 @@ class PropertyValueColumnData(PropertyValueDict):
         from ...document.events import ColumnsStreamedEvent
 
         self._notify_owners(old,
-                            hint=ColumnsStreamedEvent(doc, source, new_data, rollover, setter))
+                            hint=ColumnsStreamedEvent(doc, source, new_data, rollover))
 
     # don't wrap with notify_owner --- notifies owners explicitly
-    def _patch(self, doc, source, patches, setter=None):
+    def _patch(self, doc, source, patches):
         ''' Internal implementation to handle special-casing patch events
         on ``ColumnDataSource`` columns.
 
@@ -466,9 +466,7 @@ class PropertyValueColumnData(PropertyValueDict):
                     self[name][ind[0]][tuple(ind[1:])] = np.array(value, copy=False).reshape(shape)
 
         from ...document.events import ColumnsPatchedEvent
-
-        self._notify_owners(old,
-                            hint=ColumnsPatchedEvent(doc, source, patches, setter))
+        self._notify_owners(old, hint=ColumnsPatchedEvent(doc, source, patches))
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/bokeh/document/util.py
+++ b/bokeh/document/util.py
@@ -41,7 +41,7 @@ __all__ = (
 # Dev API
 #-----------------------------------------------------------------------------
 
-def initialize_references_json(references_json, references, setter=None):
+def initialize_references_json(references_json, references):
     ''' Given a JSON representation of the models in a graph, and new model
     objects, set the properties on the models from the JSON
 
@@ -57,17 +57,6 @@ def initialize_references_json(references_json, references, setter=None):
             **This is an "out" parameter**. The values it contains will be
             modified in-place.
 
-        setter (ClientSession or ServerSession or None, optional) :
-                This is used to prevent "boomerang" updates to Bokeh apps.
-                (default: None)
-
-                In the context of a Bokeh server application, incoming updates
-                to properties will be annotated with the session that is
-                doing the updating. This value is propagated through any
-                subsequent change notifications that the update triggers.
-                The session can compare the event setter to itself, and
-                suppress any updates that originate from itself.
-
     '''
 
     for obj in references_json:
@@ -81,7 +70,7 @@ def initialize_references_json(references_json, references, setter=None):
         # general HasProps machinery that sets properties, so call it explicitly
         HasProps.__init__(instance)
 
-        instance.update_from_json(obj_attrs, models=references, setter=setter)
+        instance.update_from_json(obj_attrs, models=references)
 
 def instantiate_references_json(references_json):
     ''' Given a JSON representation of all the models in a graph, return a

--- a/bokeh/model.py
+++ b/bokeh/model.py
@@ -637,7 +637,7 @@ class Model(HasProps, PropertyCallbackManager, EventCallbackManager):
         # for example).
         return serialize_json(json_like)
 
-    def trigger(self, attr, old, new, hint=None, setter=None):
+    def trigger(self, attr, old, new, hint=None):
         '''
 
         '''
@@ -658,7 +658,7 @@ class Model(HasProps, PropertyCallbackManager, EventCallbackManager):
                 if dirty['count'] > 0:
                     self._document._invalidate_all_models()
         # chain up to invoke callbacks
-        super().trigger(attr, old, new, hint=hint, setter=setter)
+        super().trigger(attr, old, new, hint=hint)
 
     def _attach_document(self, doc):
         ''' Attach a model to a Bokeh |Document|.

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -414,10 +414,9 @@ class ColumnDataSource(ColumnarDataSource):
         # calls internal implementation
         self._stream(new_data, rollover)
 
-    def _stream(self, new_data, rollover=None, setter=None):
+    def _stream(self, new_data, rollover=None):
         ''' Internal implementation to efficiently update data source columns
-        with new append-only data. The internal implementation adds the setter
-        attribute.  [https://github.com/bokeh/bokeh/issues/6577]
+        with new append-only data.
 
         In cases where it is necessary to update data columns in, this method
         can efficiently send only the new data, instead of requiring the
@@ -435,15 +434,7 @@ class ColumnDataSource(ColumnarDataSource):
             rollover (int, optional) : A maximum column size, above which data
                 from the start of the column begins to be discarded. If None,
                 then columns will continue to grow unbounded (default: None)
-            setter (ClientSession or ServerSession or None, optional) :
-                This is used to prevent "boomerang" updates to Bokeh apps.
-                (default: None)
-                In the context of a Bokeh server application, incoming updates
-                to properties will be annotated with the session that is
-                doing the updating. This value is propagated through any
-                subsequent change notifications that the update triggers.
-                The session can compare the event setter to itself, and
-                suppress any updates that originate from itself.
+
         Returns:
             None
 
@@ -524,9 +515,9 @@ class ColumnDataSource(ColumnarDataSource):
             else:
                 new_data[key] = values
 
-        self.data._stream(self.document, self, new_data, rollover, setter)
+        self.data._stream(self.document, self, new_data, rollover)
 
-    def patch(self, patches, setter=None):
+    def patch(self, patches):
         ''' Efficiently update data source columns at specific locations
 
         If it is only necessary to update a small subset of data in a
@@ -681,7 +672,7 @@ class ColumnDataSource(ColumnarDataSource):
                 else:
                     raise ValueError("Invalid patch index: %s" % ind)
 
-        self.data._patch(self.document, self, patches, setter)
+        self.data._patch(self.document, self, patches)
 
 class CDSView(Model):
     ''' A view into a ``ColumnDataSource`` that represents a row-wise subset.

--- a/bokeh/protocol/messages/patch_doc.py
+++ b/bokeh/protocol/messages/patch_doc.py
@@ -97,7 +97,8 @@ class patch_doc(Message):
         '''
 
         '''
-        doc._with_self_as_curdoc(lambda: doc.apply_json_patch(self.content))
+        with doc.no_sync():
+            doc._with_self_as_curdoc(lambda: doc.apply_json_patch(self.content))
 
 def process_document_events(events, use_buffers=True):
     ''' Create a JSON string describing a patch to be applied as well as

--- a/bokeh/protocol/messages/patch_doc.py
+++ b/bokeh/protocol/messages/patch_doc.py
@@ -93,11 +93,11 @@ class patch_doc(Message):
 
         return msg
 
-    def apply_to_document(self, doc, setter=None):
+    def apply_to_document(self, doc):
         '''
 
         '''
-        doc._with_self_as_curdoc(lambda: doc.apply_json_patch(self.content, setter))
+        doc._with_self_as_curdoc(lambda: doc.apply_json_patch(self.content))
 
 def process_document_events(events, use_buffers=True):
     ''' Create a JSON string describing a patch to be applied as well as

--- a/bokeh/util/callback_manager.py
+++ b/bokeh/util/callback_manager.py
@@ -136,7 +136,7 @@ class PropertyCallbackManager(object):
         for callback in callbacks:
             _callbacks.remove(callback)
 
-    def trigger(self, attr, old, new, hint=None, setter=None):
+    def trigger(self, attr, old, new, hint=None):
         ''' Trigger callbacks for ``attr`` on this object.
 
         Args:
@@ -154,7 +154,7 @@ class PropertyCallbackManager(object):
                 for callback in callbacks:
                     callback(attr, old, new)
         if hasattr(self, '_document') and self._document is not None:
-            self._document._notify_change(self, attr, old, new, hint, setter, invoke)
+            self._document._notify_change(self, attr, old, new, hint, invoke)
         else:
             invoke()
 

--- a/bokehjs/src/lib/client/session.ts
+++ b/bokehjs/src/lib/client/session.ts
@@ -57,10 +57,6 @@ export class ClientSession {
   }
 
   protected _document_changed(event: DocumentEvent): void {
-    // Filter out events that were initiated by the ClientSession itself
-    if ((event as any).setter_id === this.id) // XXX: not all document events define this
-      return
-
     const events = event instanceof DocumentEventBatch ? event.events : [event]
     const patch = this.document.create_json_patch(events)
 
@@ -71,7 +67,7 @@ export class ClientSession {
   }
 
   protected _handle_patch(message: Message): void {
-    this.document.apply_json_patch(message.content, message.buffers, this.id)
+    this.document.apply_json_patch(message.content, message.buffers)
   }
 
   protected _handle_ok(message: Message): void {

--- a/bokehjs/src/lib/client/session.ts
+++ b/bokehjs/src/lib/client/session.ts
@@ -67,7 +67,10 @@ export class ClientSession {
   }
 
   protected _handle_patch(message: Message): void {
-    this.document.apply_json_patch(message.content, message.buffers)
+    const {document} = this
+    document.no_sync(() => {
+      document.apply_json_patch(message.content, message.buffers)
+    })
   }
 
   protected _handle_ok(message: Message): void {

--- a/bokehjs/src/lib/client/session.ts
+++ b/bokehjs/src/lib/client/session.ts
@@ -67,10 +67,7 @@ export class ClientSession {
   }
 
   protected _handle_patch(message: Message): void {
-    const {document} = this
-    document.no_sync(() => {
-      document.apply_json_patch(message.content, message.buffers)
-    })
+    this.document.apply_json_patch(message.content, message.buffers)
   }
 
   protected _handle_ok(message: Message): void {

--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -26,7 +26,6 @@ export module HasProps {
     check_eq?: boolean
     silent?: boolean
     no_change?: boolean
-    setter_id?: string
   }
 }
 
@@ -378,7 +377,7 @@ export abstract class HasProps extends Signalable() {
       }
 
       if (options.silent !== true) {
-        this._push_changes(changed, options)
+        this._push_changes(changed)
       }
     }
   }
@@ -558,17 +557,15 @@ export abstract class HasProps extends Signalable() {
     return false
   }
 
-  protected _push_changes(changes: [Property, unknown, unknown][], options: {setter_id?: string} = {}): void {
+  protected _push_changes(changes: [Property, unknown, unknown][]): void {
     const {document} = this
     if (document == null)
       return
 
-    const {setter_id} = options
-
     const events = []
     for (const [prop, old_value, new_value] of changes) {
       if (prop.syncable)
-        events.push(new ModelChangedEvent(document, this, prop.attr, old_value, new_value, setter_id))
+        events.push(new ModelChangedEvent(document, this, prop.attr, old_value, new_value))
     }
 
     if (events.length != 0) {
@@ -576,7 +573,7 @@ export abstract class HasProps extends Signalable() {
       if (events.length == 1)
         [event] = events
       else
-        event = new DocumentEventBatch(document, events, setter_id)
+        event = new DocumentEventBatch(document, events)
       document._trigger_on_change(event)
     }
   }

--- a/bokehjs/src/lib/document/document.ts
+++ b/bokehjs/src/lib/document/document.ts
@@ -65,6 +65,15 @@ export const documents: Document[] = []
 
 export const DEFAULT_TITLE = "Bokeh Application"
 
+function no_sync() {
+  return (_target: unknown, _key: string, descriptor: PropertyDescriptor) => {
+    const fn = descriptor.value
+    descriptor.value = function(this: Document, ...args: unknown[]) {
+      this.no_sync(fn.bind(this, ...args))
+    }
+  }
+}
+
 // This class should match the API of the Python Document class
 // as much as possible.
 export class Document {
@@ -681,6 +690,7 @@ export class Document {
     }
   }
 
+  @no_sync()
   apply_json_patch(patch: Patch, buffers: Buffers | ReturnType<Buffers["entries"]> = new Map()): void {
     const references_json = patch.references
     const events_json = patch.events

--- a/bokehjs/src/lib/document/events.ts
+++ b/bokehjs/src/lib/document/events.ts
@@ -61,7 +61,7 @@ export abstract class DocumentEvent {
 }
 
 export class DocumentEventBatch<T extends DocumentChangedEvent> extends DocumentEvent {
-  constructor(document: Document, readonly events: T[], readonly setter_id?: string) {
+  constructor(document: Document, readonly events: T[]) {
     super(document)
   }
 }
@@ -100,7 +100,6 @@ export class ModelChangedEvent extends DocumentChangedEvent {
       readonly attr: string,
       readonly old: unknown,
       readonly new_: unknown,
-      readonly setter_id?: string,
       readonly hint?: any) {
     super(document)
   }
@@ -172,7 +171,7 @@ export class ColumnsStreamedEvent extends DocumentChangedEvent {
 
 export class TitleChangedEvent extends DocumentChangedEvent {
 
-  constructor(document: Document, readonly title: string, readonly setter_id?: string) {
+  constructor(document: Document, readonly title: string) {
     super(document)
   }
 
@@ -186,7 +185,7 @@ export class TitleChangedEvent extends DocumentChangedEvent {
 
 export class RootAddedEvent extends DocumentChangedEvent {
 
-  constructor(document: Document, readonly model: HasProps, readonly setter_id?: string) {
+  constructor(document: Document, readonly model: HasProps) {
     super(document)
   }
 
@@ -201,7 +200,7 @@ export class RootAddedEvent extends DocumentChangedEvent {
 
 export class RootRemovedEvent extends DocumentChangedEvent {
 
-  constructor(document: Document, readonly model: HasProps, readonly setter_id?: string) {
+  constructor(document: Document, readonly model: HasProps) {
     super(document)
   }
 

--- a/bokehjs/src/lib/models/sources/column_data_source.ts
+++ b/bokehjs/src/lib/models/sources/column_data_source.ts
@@ -186,7 +186,7 @@ export class ColumnDataSource extends ColumnarDataSource {
       return HasProps._value_to_json(key, value, optional_parent_object)
   }
 
-  stream(new_data: Data, rollover?: number, setter_id?: string): void {
+  stream(new_data: Data, rollover?: number): void {
     const {data} = this
     for (const k in new_data) {
       data[k] = stream_to_column(data[k], new_data[k], rollover)
@@ -195,11 +195,11 @@ export class ColumnDataSource extends ColumnarDataSource {
     this.streaming.emit()
     if (this.document != null) {
       const hint = new ColumnsStreamedEvent(this.document, this.ref(), new_data, rollover)
-      this.document._notify_change(this, 'data', null, null, {setter_id, hint})
+      this.document._notify_change(this, 'data', null, null, {hint})
     }
   }
 
-  patch(patches: PatchSet, setter_id?: string): void {
+  patch(patches: PatchSet): void {
     const {data} = this
     let patched: Set<number> = new Set()
     for (const k in patches) {
@@ -210,7 +210,7 @@ export class ColumnDataSource extends ColumnarDataSource {
     this.patching.emit([...patched])
     if (this.document != null) {
       const hint = new ColumnsPatchedEvent(this.document, this.ref(), patches)
-      this.document._notify_change(this, 'data', null, null, {setter_id, hint})
+      this.document._notify_change(this, 'data', null, null, {hint})
     }
   }
 }

--- a/bokehjs/test/unit/document/events.ts
+++ b/bokehjs/test/unit/document/events.ts
@@ -134,7 +134,7 @@ describe("events module", () => {
       const d = new Document()
       const m = new TestModel()
       const hint = new events.ColumnsStreamedEvent(d, m.ref(), {foo: [1, 2], bar: [3, 4]})
-      const evt = new events.ModelChangedEvent(d, m, "foo", 1, 2, undefined, hint)
+      const evt = new events.ModelChangedEvent(d, m, "foo", 1, 2, hint)
       const refs = new Set<HasProps>()
       const json = evt.json(refs)
       expect(json).to.be.deep.equal({

--- a/sphinx/source/docs/dev_guide/server.rst
+++ b/sphinx/source/docs/dev_guide/server.rst
@@ -377,14 +377,6 @@ socket connection. When a message is received by the client or server
 session it will extract the patch and apply it directly to the
 ``Document``.
 
-In order to avoid events bouncing back and forth between client and
-server (as each patch would generate new events, which would in turn
-be sent back), the session informs the ``Document`` that it was
-responsible for generating the patch and any subsequent events that
-are generated. In this way, when a ``Session`` is notified of a change
-to the document it can check whether the ``event.setter`` is identical
-with itself and therefore skip processing the event.
-
 Serialization
 ^^^^^^^^^^^^^
 

--- a/tests/unit/bokeh/core/property/test_wrappers__property.py
+++ b/tests/unit/bokeh/core/property/test_wrappers__property.py
@@ -173,12 +173,11 @@ def test_PropertyValueColumnData__stream_list_to_list(mock_notify) -> None:
     pvcd = bcpw.PropertyValueColumnData(source.data)
 
     mock_notify.reset_mock()
-    pvcd._stream("doc", source, dict(foo=[20]), setter="setter")
+    pvcd._stream("doc", source, dict(foo=[20]))
     assert mock_notify.call_count == 1
     assert mock_notify.call_args[0] == ({'foo': [10, 20]},) # streaming to list, "old" is actually updated value
     assert 'hint' in mock_notify.call_args[1]
     assert isinstance(mock_notify.call_args[1]['hint'], ColumnsStreamedEvent)
-    assert mock_notify.call_args[1]['hint'].setter == 'setter'
     assert mock_notify.call_args[1]['hint'].rollover == None
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
@@ -190,12 +189,11 @@ def test_PropertyValueColumnData__stream_list_to_array(mock_notify) -> None:
     pvcd = bcpw.PropertyValueColumnData(source.data)
 
     mock_notify.reset_mock()
-    pvcd._stream("doc", source, dict(foo=[20]), setter="setter")
+    pvcd._stream("doc", source, dict(foo=[20]))
     assert mock_notify.call_count == 1
     assert (mock_notify.call_args[0][0]['foo'] == np.array([10])).all()
     assert 'hint' in mock_notify.call_args[1]
     assert isinstance(mock_notify.call_args[1]['hint'], ColumnsStreamedEvent)
-    assert mock_notify.call_args[1]['hint'].setter == 'setter'
     assert mock_notify.call_args[1]['hint'].rollover == None
 
 
@@ -207,12 +205,11 @@ def test_PropertyValueColumnData__stream_list_with_rollover(mock_notify) -> None
     pvcd = bcpw.PropertyValueColumnData(source.data)
 
     mock_notify.reset_mock()
-    pvcd._stream("doc", source, dict(foo=[40]), rollover=3, setter="setter")
+    pvcd._stream("doc", source, dict(foo=[40]), rollover=3)
     assert mock_notify.call_count == 1
     assert mock_notify.call_args[0] == ({'foo': [20, 30, 40]},) # streaming to list, "old" is actually updated value
     assert 'hint' in mock_notify.call_args[1]
     assert isinstance(mock_notify.call_args[1]['hint'], ColumnsStreamedEvent)
-    assert mock_notify.call_args[1]['hint'].setter == 'setter'
     assert mock_notify.call_args[1]['hint'].rollover == 3
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
@@ -224,14 +221,13 @@ def test_PropertyValueColumnData__stream_array_to_array(mock_notify) -> None:
     pvcd = bcpw.PropertyValueColumnData(source.data)
 
     mock_notify.reset_mock()
-    pvcd._stream("doc", source, dict(foo=[20]), setter="setter")
+    pvcd._stream("doc", source, dict(foo=[20]))
     assert mock_notify.call_count == 1
     assert len(mock_notify.call_args[0]) == 1
     assert 'foo' in mock_notify.call_args[0][0]
     assert (mock_notify.call_args[0][0]['foo'] == np.array([10])).all()
     assert 'hint' in mock_notify.call_args[1]
     assert isinstance(mock_notify.call_args[1]['hint'], ColumnsStreamedEvent)
-    assert mock_notify.call_args[1]['hint'].setter == 'setter'
     assert mock_notify.call_args[1]['hint'].rollover == None
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
@@ -242,14 +238,13 @@ def test_PropertyValueColumnData__stream_array_to_list(mock_notify) -> None:
     pvcd = bcpw.PropertyValueColumnData(source.data)
 
     mock_notify.reset_mock()
-    pvcd._stream("doc", source, dict(foo=[20]), setter="setter")
+    pvcd._stream("doc", source, dict(foo=[20]))
     assert mock_notify.call_count == 1
     assert len(mock_notify.call_args[0]) == 1
     assert 'foo' in mock_notify.call_args[0][0]
     assert mock_notify.call_args[0] == ({'foo': [10, 20]},) # streaming to list, "old" is actually updated value
     assert 'hint' in mock_notify.call_args[1]
     assert isinstance(mock_notify.call_args[1]['hint'], ColumnsStreamedEvent)
-    assert mock_notify.call_args[1]['hint'].setter == 'setter'
     assert mock_notify.call_args[1]['hint'].rollover == None
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
@@ -261,14 +256,13 @@ def test_PropertyValueColumnData__stream_array_with_rollover(mock_notify) -> Non
     pvcd = bcpw.PropertyValueColumnData(source.data)
 
     mock_notify.reset_mock()
-    pvcd._stream("doc", source, dict(foo=[40]), rollover=3, setter="setter")
+    pvcd._stream("doc", source, dict(foo=[40]), rollover=3)
     assert mock_notify.call_count == 1
     assert len(mock_notify.call_args[0]) == 1
     assert 'foo' in mock_notify.call_args[0][0]
     assert (mock_notify.call_args[0][0]['foo'] == np.array([10, 20, 30])).all()
     assert 'hint' in mock_notify.call_args[1]
     assert isinstance(mock_notify.call_args[1]['hint'], ColumnsStreamedEvent)
-    assert mock_notify.call_args[1]['hint'].setter == 'setter'
     assert mock_notify.call_args[1]['hint'].rollover == 3
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
@@ -278,13 +272,12 @@ def test_PropertyValueColumnData__patch_with_simple_indices(mock_notify) -> None
     pvcd = bcpw.PropertyValueColumnData(source.data)
 
     mock_notify.reset_mock()
-    pvcd._patch("doc", source, dict(foo=[(1, 40)]), setter='setter')
+    pvcd._patch("doc", source, dict(foo=[(1, 40)]))
     assert mock_notify.call_count == 1
     assert mock_notify.call_args[0] == ({'foo': [10, 40]},)
     assert pvcd == dict(foo=[10, 40])
     assert 'hint' in mock_notify.call_args[1]
     assert isinstance(mock_notify.call_args[1]['hint'], ColumnsPatchedEvent)
-    assert mock_notify.call_args[1]['hint'].setter == 'setter'
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
 def test_PropertyValueColumnData__patch_with_repeated_simple_indices(mock_notify) -> None:
@@ -293,13 +286,12 @@ def test_PropertyValueColumnData__patch_with_repeated_simple_indices(mock_notify
     pvcd = bcpw.PropertyValueColumnData(source.data)
 
     mock_notify.reset_mock()
-    pvcd._patch("doc", source, dict(foo=[(1, 40), (1, 50)]), setter='setter')
+    pvcd._patch("doc", source, dict(foo=[(1, 40), (1, 50)]))
     assert mock_notify.call_count == 1
     assert mock_notify.call_args[0] == ({'foo': [10, 50]},)
     assert pvcd == dict(foo=[10, 50])
     assert 'hint' in mock_notify.call_args[1]
     assert isinstance(mock_notify.call_args[1]['hint'], ColumnsPatchedEvent)
-    assert mock_notify.call_args[1]['hint'].setter == 'setter'
 
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
@@ -309,13 +301,12 @@ def test_PropertyValueColumnData__patch_with_slice_indices(mock_notify) -> None:
     pvcd = bcpw.PropertyValueColumnData(source.data)
 
     mock_notify.reset_mock()
-    pvcd._patch("doc", source, dict(foo=[(slice(2), [1,2])]), setter='setter')
+    pvcd._patch("doc", source, dict(foo=[(slice(2), [1,2])]))
     assert mock_notify.call_count == 1
     assert mock_notify.call_args[0] == ({'foo': [1, 2, 30, 40, 50]},)
     assert pvcd == dict(foo=[1, 2, 30, 40, 50])
     assert 'hint' in mock_notify.call_args[1]
     assert isinstance(mock_notify.call_args[1]['hint'], ColumnsPatchedEvent)
-    assert mock_notify.call_args[1]['hint'].setter == 'setter'
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
 def test_PropertyValueColumnData__patch_with_overlapping_slice_indices(mock_notify) -> None:
@@ -324,13 +315,12 @@ def test_PropertyValueColumnData__patch_with_overlapping_slice_indices(mock_noti
     pvcd = bcpw.PropertyValueColumnData(source.data)
 
     mock_notify.reset_mock()
-    pvcd._patch("doc", source, dict(foo=[(slice(2), [1,2]), (slice(1,3), [1000,2000])]), setter='setter')
+    pvcd._patch("doc", source, dict(foo=[(slice(2), [1,2]), (slice(1,3), [1000,2000])]))
     assert mock_notify.call_count == 1
     assert mock_notify.call_args[0] == ({'foo': [1, 1000, 2000, 40, 50]},)
     assert pvcd == dict(foo=[1, 1000, 2000, 40, 50])
     assert 'hint' in mock_notify.call_args[1]
     assert isinstance(mock_notify.call_args[1]['hint'], ColumnsPatchedEvent)
-    assert mock_notify.call_args[1]['hint'].setter == 'setter'
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
 def test_PropertyValueList_mutators(mock_notify) -> None:

--- a/tests/unit/bokeh/core/test_has_props.py
+++ b/tests/unit/bokeh/core/test_has_props.py
@@ -157,14 +157,6 @@ def test_HasProps_update_from_json() -> None:
     assert c.ds2 ==  None
     assert c.lst2 == [1,2]
 
-@patch('bokeh.core.has_props.HasProps.set_from_json')
-def test_HasProps_update_from_json_passes_models_and_setter(mock_set) -> None:
-    c = Child()
-    c.update_from_json(dict(lst1=[1,2]), models="foo", setter="bar")
-    assert mock_set.called
-    assert mock_set.call_args[0] == ('lst1', [1, 2], 'foo', 'bar')
-    assert mock_set.call_args[1] == {}
-
 def test_HasProps_set() -> None:
     c = Child()
     c.update(**dict(lst2=[1,2], str2="baz", int1=25, ds1=dict(field="foo")))

--- a/tests/unit/bokeh/models/test_sources.py
+++ b/tests/unit/bokeh/models/test_sources.py
@@ -332,15 +332,14 @@ Lime,Green,99,$0.39
         ds = bms.ColumnDataSource(data=dict(a=[10], b=[20]))
         ds._document = "doc"
         stuff = {}
-        mock_setter = object()
 
         def mock(*args, **kw):
             stuff['args'] = args
             stuff['kw'] = kw
         ds.data._stream = mock
         # internal implementation of stream
-        ds._stream(dict(a=[11, 12], b=[21, 22]), "foo", mock_setter)
-        assert stuff['args'] == ("doc", ds, dict(a=[11, 12], b=[21, 22]), "foo", mock_setter)
+        ds._stream(dict(a=[11, 12], b=[21, 22]), "foo")
+        assert stuff['args'] == ("doc", ds, dict(a=[11, 12], b=[21, 22]), "foo")
         assert stuff['kw'] == {}
 
     def test_stream_good_data(self) -> None:
@@ -363,7 +362,6 @@ Lime,Green,99,$0.39
         ds = bms.ColumnDataSource(data=dict(index=dates, b=list(range(1, 10))))
         ds._document = "doc"
         stuff = {}
-        mock_setter = object()
 
         def mock(*args, **kw):
             stuff['args'] = args
@@ -371,7 +369,7 @@ Lime,Green,99,$0.39
         ds.data._stream = mock
         # internal implementation of stream
         new_date = np.array([now+dt.timedelta(10)], dtype='datetime64')
-        ds._stream(dict(index=new_date, b=[10]), "foo", mock_setter)
+        ds._stream(dict(index=new_date, b=[10]), "foo")
         assert np.array_equal(stuff['args'][2]['index'], new_date)
 
     def test__stream_good_datetime64_data_transformed(self) -> None:
@@ -381,7 +379,6 @@ Lime,Green,99,$0.39
         ds = bms.ColumnDataSource(data=dict(index=dates, b=list(range(1, 10))))
         ds._document = "doc"
         stuff = {}
-        mock_setter = object()
 
         def mock(*args, **kw):
             stuff['args'] = args
@@ -389,7 +386,7 @@ Lime,Green,99,$0.39
         ds.data._stream = mock
         # internal implementation of stream
         new_date = np.array([now+dt.timedelta(10)], dtype='datetime64')
-        ds._stream(dict(index=new_date, b=[10]), "foo", mock_setter)
+        ds._stream(dict(index=new_date, b=[10]), "foo")
         transformed_date = convert_datetime_array(new_date)
         assert np.array_equal(stuff['args'][2]['index'], transformed_date)
 
@@ -402,7 +399,6 @@ Lime,Green,99,$0.39
         ds = bms.ColumnDataSource(data=df)
         ds._document = "doc"
         stuff = {}
-        mock_setter = object()
 
         def mock(*args, **kw):
             stuff['args'] = args
@@ -413,7 +409,7 @@ Lime,Green,99,$0.39
             columns=df.columns,
             data=np.random.standard_normal(30)
         )
-        ds._stream(new_df, "foo", mock_setter)
+        ds._stream(new_df, "foo")
         assert np.array_equal(stuff['args'][2]['index'], new_df.index.values)
         assert np.array_equal(stuff['args'][2]['A'], new_df.A.values)
 
@@ -426,7 +422,6 @@ Lime,Green,99,$0.39
         ds = bms.ColumnDataSource(data=df)
         ds._document = "doc"
         stuff = {}
-        mock_setter = object()
 
         def mock(*args, **kw):
             stuff['args'] = args
@@ -437,7 +432,7 @@ Lime,Green,99,$0.39
             columns=df.columns,
             data=np.random.standard_normal(30)
         )
-        ds._stream({'index': new_df.index, 'A': new_df.A}, "foo", mock_setter)
+        ds._stream({'index': new_df.index, 'A': new_df.A}, "foo")
         assert np.array_equal(stuff['args'][2]['index'], new_df.index.values)
         assert np.array_equal(stuff['args'][2]['A'], new_df.A.values)
 
@@ -451,7 +446,6 @@ Lime,Green,99,$0.39
                                     'A': df.A})
         ds._document = "doc"
         stuff = {}
-        mock_setter = object()
 
         def mock(*args, **kw):
             stuff['args'] = args
@@ -462,7 +456,7 @@ Lime,Green,99,$0.39
             columns=df.columns,
             data=np.random.standard_normal(30)
         )
-        ds._stream({'index': new_df.index, 'A': new_df.A}, "foo", mock_setter)
+        ds._stream({'index': new_df.index, 'A': new_df.A}, "foo")
         assert np.array_equal(stuff['args'][2]['index'], convert_datetime_array(new_df.index.values))
         assert np.array_equal(stuff['args'][2]['A'], new_df.A.values)
 
@@ -702,13 +696,12 @@ Lime,Green,99,$0.39
         ds = bms.ColumnDataSource(data=dict(a=[10, 11], b=[20, 21]))
         ds._document = "doc"
         stuff = {}
-        mock_setter = object()
         def mock(*args, **kw):
             stuff['args'] = args
             stuff['kw'] = kw
         ds.data._patch = mock
-        ds.patch(dict(a=[(0,100), (1,101)], b=[(0,200)]), mock_setter)
-        assert stuff['args'] == ("doc", ds, dict(a=[(0,100), (1,101)], b=[(0,200)]), mock_setter)
+        ds.patch(dict(a=[(0,100), (1,101)], b=[(0,200)]))
+        assert stuff['args'] == ("doc", ds, dict(a=[(0,100), (1,101)], b=[(0,200)]))
         assert stuff['kw'] == {}
 
     def test_patch_bad_slice_indices(self) -> None:
@@ -731,13 +724,12 @@ Lime,Green,99,$0.39
         ds = bms.ColumnDataSource(data=dict(a=[10, 11, 12, 13, 14, 15], b=[20, 21, 22, 23, 24, 25]))
         ds._document = "doc"
         stuff = {}
-        mock_setter = object()
         def mock(*args, **kw):
             stuff['args'] = args
             stuff['kw'] = kw
         ds.data._patch = mock
-        ds.patch(dict(a=[(slice(2), [100, 101]), (slice(3, 5), [100, 101])], b=[(slice(0, None, 2), [100, 101, 102])]), mock_setter)
-        assert stuff['args'] == ("doc", ds, dict(a=[(slice(2), [100, 101]), (slice(3, 5), [100, 101])], b=[(slice(0, None, 2), [100, 101, 102])]), mock_setter)
+        ds.patch(dict(a=[(slice(2), [100, 101]), (slice(3, 5), [100, 101])], b=[(slice(0, None, 2), [100, 101, 102])]))
+        assert stuff['args'] == ("doc", ds, dict(a=[(slice(2), [100, 101]), (slice(3, 5), [100, 101])], b=[(slice(0, None, 2), [100, 101, 102])]))
         assert stuff['kw'] == {}
 
     def test_data_column_lengths(self) -> None:

--- a/tests/unit/bokeh/protocol/messages/test_patch_doc.py
+++ b/tests/unit/bokeh/protocol/messages/test_patch_doc.py
@@ -132,40 +132,40 @@ class TestPatchDocument(object):
         # Model property changed
         event = ModelChangedEvent(sample, root, 'child', root.child, new_child, new_child)
         msg = proto.create("PATCH-DOC", [event])
-        msg.apply_to_document(sample, mock_session)
+        msg.apply_to_document(sample)
         assert msg.buffers == []
 
         # RootAdded
         event2 = RootAddedEvent(sample, root)
         msg2 = proto.create("PATCH-DOC", [event2])
-        msg2.apply_to_document(sample, mock_session)
+        msg2.apply_to_document(sample)
         assert msg2.buffers == []
 
         # RootRemoved
         event3 = RootRemovedEvent(sample, root)
         msg3 = proto.create("PATCH-DOC", [event3])
-        msg3.apply_to_document(sample, mock_session)
+        msg3.apply_to_document(sample)
         assert msg3.buffers == []
 
         # ColumnsStreamed
         event4 = ModelChangedEvent(sample, cds, 'data', 10, None, None,
                                    hint=ColumnsStreamedEvent(sample, cds, {"a": [3]}, None, mock_session))
         msg4 = proto.create("PATCH-DOC", [event4])
-        msg4.apply_to_document(sample, mock_session)
+        msg4.apply_to_document(sample)
         assert msg4.buffers == []
 
         # ColumnsPatched
         event5 = ModelChangedEvent(sample, cds, 'data', 10, None, None,
                                    hint=ColumnsPatchedEvent(sample, cds, {"a": [(0, 11)]}))
         msg5 = proto.create("PATCH-DOC", [event5])
-        msg5.apply_to_document(sample, mock_session)
+        msg5.apply_to_document(sample)
         assert msg5.buffers == []
 
         # ColumnDataChanged, use_buffers=False
         event6 = ModelChangedEvent(sample, cds, 'data', {'a': np.array([0., 1.])}, None, None,
                                    hint=ColumnDataChangedEvent(sample, cds))
         msg6 = proto.create("PATCH-DOC", [event6], use_buffers=False)
-        msg6.apply_to_document(sample, mock_session)
+        msg6.apply_to_document(sample)
         assert msg6.buffers == []
 
         print(cds.data)
@@ -174,7 +174,7 @@ class TestPatchDocument(object):
                                    hint=ColumnDataChangedEvent(sample, cds))
         msg7 = proto.create("PATCH-DOC", [event7])
         # can't test apply, doc not set up to *receive* binary buffers
-        # msg7.apply_to_document(sample, mock_session)
+        # msg7.apply_to_document(sample)
         assert len(msg7.buffers) == 1
         buf = msg7.buffers.pop()
         assert len(buf) == 2


### PR DESCRIPTION
Proof of concept. Instead of sprinkling `setter_id` in various places, this PR blocks all document events that are triggered during `apply_json_patch()` with `Document.no_sync()`. This approach may be a bit too aggressive, so alternatively all calls to `setv()`, `add_root()`, etc. during application of a patch can be guarded instead.