### PR TITLE
Use Map instead of {} as view storage

### DIFF
--- a/bokehjs/src/lib/core/build_views.ts
+++ b/bokehjs/src/lib/core/build_views.ts
@@ -2,7 +2,7 @@ import {HasProps} from "./has_props"
 import {View, ViewOf} from "./view"
 import {difference} from "./util/array"
 
-export type ViewStorage = {[key: string]: View}
+export type ViewStorage<T extends HasProps> = Map<T, ViewOf<T>>
 export type Options = {parent: View | null}
 
 async function _build_view<T extends HasProps>(view_cls: T["default_view"], model: T, options: Options): Promise<ViewOf<T>> {
@@ -19,22 +19,22 @@ export async function build_view<T extends HasProps>(model: T, options: Options 
   return view
 }
 
-export async function build_views<T extends HasProps>(view_storage: ViewStorage, models: T[],
+export async function build_views<T extends HasProps>(view_storage: ViewStorage<T>, models: T[],
     options: Options = {parent: null}, cls: (model: T) => T["default_view"] = (model) => model.default_view): Promise<ViewOf<T>[]> {
 
-  const to_remove = difference(Object.keys(view_storage), models.map((model) => model.id))
+  const to_remove = difference([...view_storage.keys()], models)
 
-  for (const model_id of to_remove) {
-    view_storage[model_id].remove()
-    delete view_storage[model_id]
+  for (const model of to_remove) {
+    view_storage.get(model)!.remove()
+    view_storage.delete(model)
   }
 
   const created_views = []
-  const new_models = models.filter((model) => view_storage[model.id] == null)
+  const new_models = models.filter((model) => !view_storage.has(model))
 
   for (const model of new_models) {
     const view = await _build_view(cls(model), model, options)
-    view_storage[model.id] = view
+    view_storage.set(model, view)
     created_views.push(view)
   }
 
@@ -44,9 +44,9 @@ export async function build_views<T extends HasProps>(view_storage: ViewStorage,
   return created_views
 }
 
-export function remove_views(view_storage: ViewStorage): void {
-  for (const id in view_storage) {
-    view_storage[id].remove()
-    delete view_storage[id]
+export function remove_views(view_storage: ViewStorage<HasProps>): void {
+  for (const [model, view] of view_storage) {
+    view.remove()
+    view_storage.delete(model)
   }
 }

--- a/bokehjs/src/lib/core/selection_manager.ts
+++ b/bokehjs/src/lib/core/selection_manager.ts
@@ -32,7 +32,7 @@ export class SelectionManager extends HasProps {
     })
   }
 
-  inspectors: {[key: string]: Selection} = {}
+  inspectors: Map<Renderer, Selection> = new Map()
 
   select(renderer_views: RendererView[], geometry: Geometry, final: boolean, mode: SelectionMode = "replace"): boolean {
     // divide renderers into glyph_renderers or graph_renderers
@@ -87,9 +87,12 @@ export class SelectionManager extends HasProps {
       this.get_or_create_inspector(rview.model).clear()
   }
 
-  get_or_create_inspector(rmodel: Renderer): Selection {
-    if (this.inspectors[rmodel.id] == null)
-      this.inspectors[rmodel.id] = new Selection()
-    return this.inspectors[rmodel.id]
+  get_or_create_inspector(renderer: Renderer): Selection {
+    let selection = this.inspectors.get(renderer)
+    if (selection == null) {
+      selection = new Selection()
+      this.inspectors.set(renderer, selection)
+    }
+    return selection
   }
 }

--- a/bokehjs/src/lib/core/types.ts
+++ b/bokehjs/src/lib/core/types.ts
@@ -1,3 +1,5 @@
+export type ID = string
+
 export type Color = string
 
 export type TypedArray =

--- a/bokehjs/src/lib/document/document.ts
+++ b/bokehjs/src/lib/document/document.ts
@@ -3,7 +3,7 @@ import {version as js_version} from "../version"
 import {logger} from "../core/logging"
 import {BokehEvent, LODStart, LODEnd} from "core/bokeh_events"
 import {HasProps} from "core/has_props"
-import {Attrs, PlainObject} from "core/types"
+import {ID, Attrs, PlainObject} from "core/types"
 import {Signal0} from "core/signaling"
 import {Struct, is_ref} from "core/util/refs"
 import {decode_column_data, Buffers} from "core/util/serialization"
@@ -20,8 +20,6 @@ import {
   RootRemovedEvent, TitleChangedEvent, MessageSentEvent,
   DocumentChanged, ModelChanged, RootAddedEvent,
 } from "./events"
-
-export type ID = string
 
 export class EventManager {
   // Dispatches events to the subscribed models

--- a/bokehjs/src/lib/models/annotations/legend.ts
+++ b/bokehjs/src/lib/models/annotations/legend.ts
@@ -275,7 +275,7 @@ export class LegendView extends AnnotationView {
         this.visuals.label_text.set_value(ctx)
         ctx.fillText(label, x2 + label_standoff, y1 + this.max_label_height/2.0)
         for (const r of item.renderers) {
-          const view = this.plot_view.renderer_views[r.id] as GlyphRendererView
+          const view = this.plot_view.renderer_views.get(r)! as GlyphRendererView
           view.draw_legend(ctx, x1, x2, y1, y2, field, label, item.index)
         }
 

--- a/bokehjs/src/lib/models/layouts/grid_box.ts
+++ b/bokehjs/src/lib/models/layouts/grid_box.ts
@@ -22,7 +22,7 @@ export class GridBoxView extends LayoutDOMView {
     this.layout.spacing = this.model.spacing
 
     for (const [child, row, col, row_span, col_span] of this.model.children) {
-      const child_view = this._child_views[child.id]
+      const child_view = this._child_views.get(child)!
       this.layout.items.push({layout: child_view.layout, row, col, row_span, col_span})
     }
 

--- a/bokehjs/src/lib/models/layouts/layout_dom.ts
+++ b/bokehjs/src/lib/models/layouts/layout_dom.ts
@@ -19,7 +19,7 @@ export abstract class LayoutDOMView extends DOMView {
 
   protected _idle_notified: boolean = false
 
-  protected _child_views: {[key: string]: LayoutDOMView}
+  protected _child_views: Map<LayoutDOM, LayoutDOMView>
 
   protected _on_resize?: () => void
 
@@ -34,7 +34,7 @@ export abstract class LayoutDOMView extends DOMView {
   initialize(): void {
     super.initialize()
     this.el.style.position = this.is_root ? "relative" : "absolute"
-    this._child_views = {}
+    this._child_views = new Map()
   }
 
   async lazy_initialize(): Promise<void> {
@@ -44,7 +44,7 @@ export abstract class LayoutDOMView extends DOMView {
   remove(): void {
     for (const child_view of this.child_views)
       child_view.remove()
-    this._child_views = {}
+    this._child_views.clear()
     super.remove()
   }
 
@@ -101,7 +101,7 @@ export abstract class LayoutDOMView extends DOMView {
   abstract get child_models(): LayoutDOM[]
 
   get child_views(): LayoutDOMView[] {
-    return this.child_models.map((child) => this._child_views[child.id])
+    return this.child_models.map((child) => this._child_views.get(child)!)
   }
 
   async build_child_views(): Promise<void> {

--- a/bokehjs/src/lib/models/renderers/graph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/graph_renderer.ts
@@ -4,7 +4,7 @@ import {LayoutProvider} from "../graphs/layout_provider"
 import {GraphHitTestPolicy, NodesOnly} from "../graphs/graph_hit_test_policy"
 import {Scale} from "../scales/scale"
 import * as p from "core/properties"
-import {build_views} from "core/build_views"
+import {build_views, remove_views} from "core/build_views"
 import {SelectionManager} from "core/selection_manager"
 
 export class GraphRendererView extends DataRendererView {
@@ -16,7 +16,7 @@ export class GraphRendererView extends DataRendererView {
   xscale: Scale
   yscale: Scale
 
-  protected _renderer_views: {[key: string]: GlyphRendererView}
+  protected _renderer_views: Map<GlyphRenderer, GlyphRendererView>
 
   initialize(): void {
     super.initialize()
@@ -24,7 +24,7 @@ export class GraphRendererView extends DataRendererView {
     this.xscale = this.plot_view.frame.xscales.default
     this.yscale = this.plot_view.frame.yscales.default
 
-    this._renderer_views = {}
+    this._renderer_views = new Map()
   }
 
   async lazy_initialize(): Promise<void> {
@@ -34,6 +34,11 @@ export class GraphRendererView extends DataRendererView {
     ], {parent: this.parent})
 
     this.set_data()
+  }
+
+  remove(): void {
+    remove_views(this._renderer_views)
+    super.remove()
   }
 
   connect_signals(): void {

--- a/bokehjs/src/lib/models/tools/edit/edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/edit_tool.ts
@@ -148,7 +148,7 @@ export abstract class EditToolView extends GestureToolView {
     for (const renderer of renderers) {
       const sm = renderer.get_selection_manager()
       const cds = renderer.data_source
-      const views = [this.plot_view.renderer_views[renderer.id]]
+      const views = [this.plot_view.renderer_views.get(renderer)!]
       const did_hit = sm.select(views, geometry, true, mode)
       if (did_hit) {
         selected.push(renderer)

--- a/bokehjs/src/lib/models/tools/gestures/select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/select_tool.ts
@@ -87,7 +87,7 @@ export abstract class SelectToolView extends GestureToolView {
       const r_views = []
       for (const r of renderers) {
         if (r.id in this.plot_view.renderer_views)
-          r_views.push(this.plot_view.renderer_views[r.id])
+          r_views.push(this.plot_view.renderer_views.get(r)!)
       }
       sm.select(r_views, geometry, final, mode)
     }

--- a/bokehjs/src/lib/models/tools/gestures/tap_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/tap_tool.ts
@@ -25,7 +25,7 @@ export class TapToolView extends SelectToolView {
       for (const id in renderers_by_source) {
         const renderers = renderers_by_source[id]
         const sm = renderers[0].get_selection_manager()
-        const r_views = renderers.map((r) => this.plot_view.renderer_views[r.id])
+        const r_views = renderers.map((r) => this.plot_view.renderer_views.get(r)!)
         const did_hit = sm.select(r_views, geometry, final, mode)
 
         if (did_hit && callback != null) {
@@ -44,7 +44,7 @@ export class TapToolView extends SelectToolView {
     } else {
       for (const r of this.computed_renderers) {
         const sm = r.get_selection_manager()
-        const did_hit = sm.inspect(this.plot_view.renderer_views[r.id], geometry)
+        const did_hit = sm.inspect(this.plot_view.renderer_views.get(r)!, geometry)
 
         if (did_hit && callback != null) {
           const {frame} = this.plot_view

--- a/bokehjs/src/lib/models/tools/toolbar_base.ts
+++ b/bokehjs/src/lib/models/tools/toolbar_base.ts
@@ -57,12 +57,12 @@ export class ToolbarViewModel extends Model {
 export class ToolbarBaseView extends DOMView {
   model: ToolbarBase
 
-  protected _tool_button_views: {[key: string]: ButtonToolButtonView}
+  protected _tool_button_views: Map<ButtonTool, ButtonToolButtonView>
   protected _toolbar_view_model: ToolbarViewModel
 
   initialize(): void {
     super.initialize()
-    this._tool_button_views = {}
+    this._tool_button_views = new Map()
     this._toolbar_view_model = new ToolbarViewModel({autohide: this.model.autohide})
   }
 
@@ -94,7 +94,7 @@ export class ToolbarBaseView extends DOMView {
 
   protected async _build_tool_button_views(): Promise<void> {
     const tools: ButtonTool[] = (this.model._proxied_tools != null ? this.model._proxied_tools : this.model.tools) as any // XXX
-    await build_views(this._tool_button_views, tools, {parent: this}, (tool) => tool.button_view)
+    await build_views(this._tool_button_views as any, tools, {parent: this}, (tool) => tool.button_view) // XXX: no ButtonToolButton model
   }
 
   set_visibility(visible: boolean): void {
@@ -126,15 +126,14 @@ export class ToolbarBaseView extends DOMView {
       this.el.appendChild(logo)
     }
 
-    for (const id in this._tool_button_views) {
-      const tool_view = this._tool_button_views[id]
-      tool_view.render()
+    for (const [, button_view] of this._tool_button_views) {
+      button_view.render()
     }
 
     const bars: HTMLElement[][] = []
 
-    const el = (tool: Tool) => {
-      return this._tool_button_views[tool.id].el
+    const el = (tool: ButtonTool) => {
+      return this._tool_button_views.get(tool)!.el
     }
 
     const {gestures} = this.model

--- a/bokehjs/test/unit/models/annotations/color_bar.ts
+++ b/bokehjs/test/unit/models/annotations/color_bar.ts
@@ -28,7 +28,7 @@ async function color_bar_view(attrs: Partial<ColorBar.Attrs> = {}, place: Place 
   plot.add_layout(color_bar, place)
 
   const plot_view = (await build_view(plot)).build()
-  return plot_view.renderer_views[color_bar.id] as ColorBarView
+  return plot_view.renderer_views.get(color_bar)! as ColorBarView
 }
 
 describe("ColorBar module", () => {

--- a/bokehjs/test/unit/models/axes/axis.ts
+++ b/bokehjs/test/unit/models/axes/axis.ts
@@ -26,7 +26,7 @@ describe("Axis", () => {
     })
     plot.add_layout(axis, "below")
     const plot_view = (await build_view(plot)).build()
-    const axis_view = plot_view.renderer_views[axis.id] as AxisView
+    const axis_view = plot_view.renderer_views.get(axis)! as AxisView
 
     expect(axis_view.compute_labels([0, 2, 4.0, 6, 8, 10])).to.be.deep.equal(["zero", "2", "four", "6", "8", "ten"])
   })
@@ -45,7 +45,7 @@ describe("Axis", () => {
     })
     plot.add_layout(axis, "below")
     const plot_view = (await build_view(plot)).build()
-    const axis_view = plot_view.renderer_views[axis.id] as AxisView
+    const axis_view = plot_view.renderer_views.get(axis)! as AxisView
     expect(axis_view.loc).to.equal(10)
   })
 
@@ -63,7 +63,7 @@ describe("Axis", () => {
     })
     plot.add_layout(axis, "left")
     const plot_view = (await build_view(plot)).build()
-    const axis_view = plot_view.renderer_views[axis.id] as AxisView
+    const axis_view = plot_view.renderer_views.get(axis)! as AxisView
     expect(axis_view.offsets).to.deep.equal([0, 0])
   })
 
@@ -82,7 +82,7 @@ describe("Axis", () => {
     })
     plot.add_layout(axis, "left")
     const plot_view = (await build_view(plot)).build()
-    const axis_view = plot_view.renderer_views[axis.id] as AxisView
+    const axis_view = plot_view.renderer_views.get(axis)! as AxisView
     expect(axis_view.offsets).to.deep.equal([0, 0])
   })
 
@@ -101,7 +101,7 @@ describe("Axis", () => {
     })
     plot.add_layout(axis, "left")
     const plot_view = (await build_view(plot)).build()
-    const axis_view = plot_view.renderer_views[axis.id] as AxisView
+    const axis_view = plot_view.renderer_views.get(axis)! as AxisView
     expect(axis_view.loc).to.equal(0.5)
   })
 })
@@ -128,7 +128,7 @@ describe("AxisView", () => {
     plot.add_layout(axis, 'below')
 
     const plot_view = (await build_view(plot)).build()
-    const axis_view = plot_view.renderer_views[axis.id] as AxisView
+    const axis_view = plot_view.renderer_views.get(axis)! as AxisView
 
     return {axis, axis_view}
   }

--- a/bokehjs/test/unit/models/grids/grid.ts
+++ b/bokehjs/test/unit/models/grids/grid.ts
@@ -23,7 +23,7 @@ describe("Grid", () => {
     const grid = new Grid({ticker})
     plot.add_layout(grid, 'center')
     const plot_view = (await build_view(plot)).build()
-    const grid_view = plot_view.renderer_views[grid.id] as GridView
+    const grid_view = plot_view.renderer_views.get(grid)! as GridView
 
     expect(grid_view.computed_bounds()).to.be.deep.equal([2, 8])
   })
@@ -40,7 +40,7 @@ describe("Grid", () => {
     const grid = new Grid({ticker})
     plot.add_layout(grid, 'center')
     const plot_view = (await build_view(plot)).build()
-    const grid_view = plot_view.renderer_views[grid.id] as GridView
+    const grid_view = plot_view.renderer_views.get(grid)! as GridView
 
     expect(grid_view.computed_bounds()).to.be.deep.equal([0, 10])
   })
@@ -57,7 +57,7 @@ describe("Grid", () => {
     const grid = new Grid({ticker, bounds: [1, 9]})
     plot.add_layout(grid, 'center')
     const plot_view = (await build_view(plot)).build()
-    const grid_view = plot_view.renderer_views[grid.id] as GridView
+    const grid_view = plot_view.renderer_views.get(grid)! as GridView
 
     expect(grid_view.computed_bounds()).to.be.deep.equal([1, 9])
   })
@@ -74,7 +74,7 @@ describe("Grid", () => {
     const grid = new Grid({ticker})
     plot.add_layout(grid, 'center')
     const plot_view = (await build_view(plot)).build()
-    const grid_view = plot_view.renderer_views[grid.id] as GridView
+    const grid_view = plot_view.renderer_views.get(grid)! as GridView
 
     expect(grid_view.grid_coords('major')).to.be.deep.equal([
       [[2, 2],     [4, 4],     [6, 6],     [8, 8]    ],
@@ -94,7 +94,7 @@ describe("Grid", () => {
     const grid = new Grid({ticker})
     plot.add_layout(grid, 'center')
     const plot_view = (await build_view(plot)).build()
-    const grid_view = plot_view.renderer_views[grid.id] as GridView
+    const grid_view = plot_view.renderer_views.get(grid)! as GridView
 
     expect(grid_view.grid_coords('major', false)).to.be.deep.equal([
       [[0.1, 0.1], [2, 2],     [4, 4],     [6, 6],     [8, 8],     [9.9, 9.9]],
@@ -114,7 +114,7 @@ describe("Grid", () => {
     const grid = new Grid({axis})
     plot.add_layout(grid, 'center')
     const plot_view = (await build_view(plot)).build()
-    const grid_view = plot_view.renderer_views[grid.id] as GridView
+    const grid_view = plot_view.renderer_views.get(grid)! as GridView
 
     expect(grid_view.grid_coords('major', false)).to.be.deep.equal([
       [[0.1, 0.1], [2, 2],     [4, 4],     [6, 6],     [8, 8],     [9.9, 9.9]],
@@ -137,7 +137,7 @@ describe("Grid", () => {
     const grid = new Grid({axis, ticker})
     plot.add_layout(grid, 'center')
     const plot_view = (await build_view(plot)).build()
-    const grid_view = plot_view.renderer_views[grid.id] as GridView
+    const grid_view = plot_view.renderer_views.get(grid)! as GridView
 
     expect(grid_view.grid_coords('major', false)).to.be.deep.equal([
       [[0.1, 0.1], [2, 2],     [4, 4],     [6, 6],     [8, 8],     [9.9, 9.9]],

--- a/bokehjs/test/unit/models/plots/plot.ts
+++ b/bokehjs/test/unit/models/plots/plot.ts
@@ -84,12 +84,13 @@ describe("Plot module", () => {
     it("should rebuild renderer views after add_layout", async () => {
       const view = await new_plot_view()
       for (const side of Place) {
-        view.model.add_layout(new Label({x: 0, y: 0, text: side, id: side}), side)
+        const label = new Label({x: 0, y: 0, text: side})
+        view.model.add_layout(label, side)
         // We need to do this for each side separately because otherwise
         // even if only e.g. `center.change` is connected, all other changes
         // will be taken into account by `build_renderer_views`.
         await view.ready
-        expect(view.renderer_views[side]).to.be.instanceof(LabelView)
+        expect(view.renderer_views.get(label)).to.be.instanceof(LabelView)
       }
     })
 

--- a/bokehjs/test/unit/models/tools/actions/zoom_in_tool.ts
+++ b/bokehjs/test/unit/models/tools/actions/zoom_in_tool.ts
@@ -40,7 +40,7 @@ describe("ZoomInTool", () => {
       const zoom_in_tool = new ZoomInTool()
       const plot_view = await mkplot(zoom_in_tool)
 
-      const zoom_in_tool_view = plot_view.tool_views[zoom_in_tool.id] as ZoomInToolView
+      const zoom_in_tool_view = plot_view.tool_views.get(zoom_in_tool)! as ZoomInToolView
 
       // perform the tool action
       zoom_in_tool_view.doit()
@@ -56,7 +56,7 @@ describe("ZoomInTool", () => {
       const zoom_in_tool = new ZoomInTool({dimensions: 'width'})
       const plot_view = await mkplot(zoom_in_tool)
 
-      const zoom_in_tool_view = plot_view.tool_views[zoom_in_tool.id] as ZoomInToolView
+      const zoom_in_tool_view = plot_view.tool_views.get(zoom_in_tool)! as ZoomInToolView
 
       // perform the tool action
       zoom_in_tool_view.doit()
@@ -72,7 +72,7 @@ describe("ZoomInTool", () => {
       const zoom_in_tool = new ZoomInTool({dimensions: 'height'})
       const plot_view = await mkplot(zoom_in_tool)
 
-      const zoom_in_tool_view = plot_view.tool_views[zoom_in_tool.id] as ZoomInToolView
+      const zoom_in_tool_view = plot_view.tool_views.get(zoom_in_tool)! as ZoomInToolView
 
       // perform the tool action
       zoom_in_tool_view.doit()

--- a/bokehjs/test/unit/models/tools/actions/zoom_out_tool.ts
+++ b/bokehjs/test/unit/models/tools/actions/zoom_out_tool.ts
@@ -40,7 +40,7 @@ describe("ZoomOutTool", () => {
       const zoom_out_tool = new ZoomOutTool()
       const plot_view = await mkplot(zoom_out_tool)
 
-      const zoom_out_tool_view = plot_view.tool_views[zoom_out_tool.id] as ZoomOutToolView
+      const zoom_out_tool_view = plot_view.tool_views.get(zoom_out_tool)! as ZoomOutToolView
 
       // perform the tool action
       zoom_out_tool_view.doit()
@@ -56,7 +56,7 @@ describe("ZoomOutTool", () => {
       const zoom_out_tool = new ZoomOutTool({dimensions: 'width'})
       const plot_view = await mkplot(zoom_out_tool)
 
-      const zoom_out_tool_view = plot_view.tool_views[zoom_out_tool.id] as ZoomOutToolView
+      const zoom_out_tool_view = plot_view.tool_views.get(zoom_out_tool)! as ZoomOutToolView
 
       // perform the tool action
       zoom_out_tool_view.doit()
@@ -72,7 +72,7 @@ describe("ZoomOutTool", () => {
       const zoom_out_tool = new ZoomOutTool({dimensions: 'height'})
       const plot_view = await mkplot(zoom_out_tool)
 
-      const zoom_out_tool_view = plot_view.tool_views[zoom_out_tool.id] as ZoomOutToolView
+      const zoom_out_tool_view = plot_view.tool_views.get(zoom_out_tool)! as ZoomOutToolView
 
       // perform the tool action
       zoom_out_tool_view.doit()

--- a/bokehjs/test/unit/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/box_edit_tool.ts
@@ -57,8 +57,8 @@ async function make_testcase(): Promise<BoxEditTestCase> {
   plot.add_tools(draw_tool)
   await plot_view.ready
 
-  const draw_tool_view = plot_view.tool_views[draw_tool.id] as BoxEditToolView
-  plot_view.renderer_views[glyph_renderer.id] = glyph_renderer_view
+  const draw_tool_view = plot_view.tool_views.get(draw_tool)! as BoxEditToolView
+  plot_view.renderer_views.set(glyph_renderer, glyph_renderer_view)
 
   return {
     data,

--- a/bokehjs/test/unit/models/tools/edit/freehand_draw_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/freehand_draw_tool.ts
@@ -53,8 +53,8 @@ async function make_testcase(): Promise<FreehandDrawTestCase> {
   plot.add_tools(draw_tool)
   await plot_view.ready
 
-  const draw_tool_view = plot_view.tool_views[draw_tool.id] as FreehandDrawToolView
-  plot_view.renderer_views[glyph_renderer.id] = glyph_renderer_view
+  const draw_tool_view = plot_view.tool_views.get(draw_tool)! as FreehandDrawToolView
+  plot_view.renderer_views.set(glyph_renderer, glyph_renderer_view)
   sinon.stub(glyph_renderer_view, "set_data")
 
   return {

--- a/bokehjs/test/unit/models/tools/edit/point_draw_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/point_draw_tool.ts
@@ -50,8 +50,8 @@ async function make_testcase(): Promise<PointDrawTestCase> {
   plot.add_tools(draw_tool)
   await plot_view.ready
 
-  const draw_tool_view = plot_view.tool_views[draw_tool.id] as PointDrawToolView
-  plot_view.renderer_views[glyph_renderer.id] = glyph_renderer_view
+  const draw_tool_view = plot_view.tool_views.get(draw_tool)! as PointDrawToolView
+  plot_view.renderer_views.set(glyph_renderer, glyph_renderer_view)
 
   return {
     data,

--- a/bokehjs/test/unit/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/poly_draw_tool.ts
@@ -53,8 +53,8 @@ async function make_testcase(): Promise<PolyDrawTestCase> {
   plot.add_tools(draw_tool)
   await plot_view.ready
 
-  const draw_tool_view = plot_view.tool_views[draw_tool.id] as PolyDrawToolView
-  plot_view.renderer_views[glyph_renderer.id] = glyph_renderer_view
+  const draw_tool_view = plot_view.tool_views.get(draw_tool)! as PolyDrawToolView
+  plot_view.renderer_views.set(glyph_renderer, glyph_renderer_view)
   sinon.stub(glyph_renderer_view, "set_data")
 
   return {

--- a/bokehjs/test/unit/models/tools/edit/poly_edit_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/poly_edit_tool.ts
@@ -69,9 +69,9 @@ async function make_testcase(): Promise<PolyEditTestCase> {
   plot.add_tools(draw_tool)
   await plot_view.ready
 
-  const draw_tool_view = plot_view.tool_views[draw_tool.id] as PolyEditToolView
-  plot_view.renderer_views[glyph_renderer.id] = glyph_renderer_view
-  plot_view.renderer_views[vertex_renderer.id] = vertex_renderer_view
+  const draw_tool_view = plot_view.tool_views.get(draw_tool)! as PolyEditToolView
+  plot_view.renderer_views.set(glyph_renderer, glyph_renderer_view)
+  plot_view.renderer_views.set(vertex_renderer, vertex_renderer_view)
 
   return {
     data,

--- a/bokehjs/test/unit/models/tools/gestures/box_zoom_tool.ts
+++ b/bokehjs/test/unit/models/tools/gestures/box_zoom_tool.ts
@@ -40,7 +40,7 @@ describe("BoxZoomTool", () => {
       const box_zoom = new BoxZoomTool()
       const plot_view = await mkplot(box_zoom)
 
-      const box_zoom_view = plot_view.tool_views[box_zoom.id] as BoxZoomToolView
+      const box_zoom_view = plot_view.tool_views.get(box_zoom)! as BoxZoomToolView
 
       // perform the tool action
       const zoom_event0 = {type: "pan" as "pan", sx: 200, sy: 100, deltaX: 0, deltaY: 0, scale: 1, ctrlKey: false, shiftKey: false}
@@ -62,7 +62,7 @@ describe("BoxZoomTool", () => {
       const box_zoom = new BoxZoomTool({match_aspect: true})
       const plot_view = await mkplot(box_zoom)
 
-      const box_zoom_view = plot_view.tool_views[box_zoom.id] as BoxZoomToolView
+      const box_zoom_view = plot_view.tool_views.get(box_zoom)! as BoxZoomToolView
 
       // perform the tool action
       const zoom_event0 = {type: "pan" as "pan", sx: 200, sy: 200, deltaX: 0, deltaY: 0, scale: 1, ctrlKey: false, shiftKey: false}

--- a/bokehjs/test/unit/models/tools/gestures/wheel_pan_tool.ts
+++ b/bokehjs/test/unit/models/tools/gestures/wheel_pan_tool.ts
@@ -37,7 +37,7 @@ describe("WheelPanTool", () => {
       const x_wheel_pan_tool = new WheelPanTool()
       const plot_view = await mkplot(x_wheel_pan_tool)
 
-      const wheel_pan_tool_view = plot_view.tool_views[x_wheel_pan_tool.id] as WheelPanToolView
+      const wheel_pan_tool_view = plot_view.tool_views.get(x_wheel_pan_tool)! as WheelPanToolView
 
       // negative factors move in positive x-data direction
       wheel_pan_tool_view._update_ranges(-0.5)
@@ -55,7 +55,7 @@ describe("WheelPanTool", () => {
       const x_wheel_pan_tool = new WheelPanTool({dimension: 'height'})
       const plot_view = await mkplot(x_wheel_pan_tool)
 
-      const wheel_pan_tool_view = plot_view.tool_views[x_wheel_pan_tool.id] as WheelPanToolView
+      const wheel_pan_tool_view = plot_view.tool_views.get(x_wheel_pan_tool)! as WheelPanToolView
 
       // positive factors move in positive y-data direction
       wheel_pan_tool_view._update_ranges(0.75)

--- a/bokehjs/test/unit/models/tools/gestures/wheel_zoom_tool.ts
+++ b/bokehjs/test/unit/models/tools/gestures/wheel_zoom_tool.ts
@@ -42,7 +42,7 @@ describe("WheelZoomTool", () => {
       const wheel_zoom = new WheelZoomTool()
       const plot_view = await mkplot(wheel_zoom)
 
-      const wheel_zoom_view = plot_view.tool_views[wheel_zoom.id] as WheelZoomToolView
+      const wheel_zoom_view = plot_view.tool_views.get(wheel_zoom)! as WheelZoomToolView
 
       // positive delta will zoom in
       const zoom_event = {type: "wheel" as "wheel", sx: 300, sy: 300, delta: 100, ctrlKey: false, shiftKey: false}
@@ -63,7 +63,7 @@ describe("WheelZoomTool", () => {
       const wheel_zoom = new WheelZoomTool()
       const plot_view = await mkplot(wheel_zoom)
 
-      const wheel_zoom_view = plot_view.tool_views[wheel_zoom.id] as WheelZoomToolView
+      const wheel_zoom_view = plot_view.tool_views.get(wheel_zoom)! as WheelZoomToolView
 
       // positive delta will zoom out
       const zoom_event = {type: "wheel" as "wheel", sx: 300, sy: 300, delta: -100, ctrlKey: false, shiftKey: false}
@@ -84,7 +84,7 @@ describe("WheelZoomTool", () => {
       const wheel_zoom = new WheelZoomTool({dimensions: 'width'})
       const plot_view = await mkplot(wheel_zoom)
 
-      const wheel_zoom_view = plot_view.tool_views[wheel_zoom.id] as WheelZoomToolView
+      const wheel_zoom_view = plot_view.tool_views.get(wheel_zoom)! as WheelZoomToolView
 
       // positive delta will zoom in
       const zoom_event = {type: "wheel" as "wheel", sx: 300, sy: 300, delta: 100, ctrlKey: false, shiftKey: false}
@@ -104,7 +104,7 @@ describe("WheelZoomTool", () => {
       const wheel_zoom = new WheelZoomTool({dimensions: 'both'})
       const plot_view = await mkplot(wheel_zoom)
 
-      const wheel_zoom_view = plot_view.tool_views[wheel_zoom.id] as WheelZoomToolView
+      const wheel_zoom_view = plot_view.tool_views.get(wheel_zoom)! as WheelZoomToolView
 
       // positive delta will zoom in
       const zoom_event = {type: "wheel" as "wheel", sx: 300, sy: 0, delta: 100, ctrlKey: false, shiftKey: false}
@@ -124,7 +124,7 @@ describe("WheelZoomTool", () => {
       const wheel_zoom = new WheelZoomTool({dimensions: 'height'})
       const plot_view = await mkplot(wheel_zoom)
 
-      const wheel_zoom_view = plot_view.tool_views[wheel_zoom.id] as WheelZoomToolView
+      const wheel_zoom_view = plot_view.tool_views.get(wheel_zoom)! as WheelZoomToolView
 
       // positive delta will zoom in
       const zoom_event = {type: "wheel" as "wheel", sx: 300, sy: 300, delta: 100, ctrlKey: false, shiftKey: false}
@@ -144,7 +144,7 @@ describe("WheelZoomTool", () => {
       const wheel_zoom = new WheelZoomTool({dimensions: 'both'})
       const plot_view = await mkplot(wheel_zoom)
 
-      const wheel_zoom_view = plot_view.tool_views[wheel_zoom.id] as WheelZoomToolView
+      const wheel_zoom_view = plot_view.tool_views.get(wheel_zoom)! as WheelZoomToolView
 
       // positive delta will zoom in
       const zoom_event = {type: "wheel" as "wheel", sx: 0, sy: 300, delta: 100, ctrlKey: false, shiftKey: false}
@@ -164,7 +164,7 @@ describe("WheelZoomTool", () => {
       const wheel_zoom = new WheelZoomTool({dimensions: 'both'})
       const plot_view = await mkplot(wheel_zoom)
 
-      const wheel_zoom_view = plot_view.tool_views[wheel_zoom.id] as WheelZoomToolView
+      const wheel_zoom_view = plot_view.tool_views.get(wheel_zoom)! as WheelZoomToolView
 
       // positive delta will zoom in
       const zoom_event = {type: "wheel" as "wheel", sx: 100, sy: 100, delta: 100, ctrlKey: false, shiftKey: false}


### PR DESCRIPTION
Slowly chipping away usage of plain objects (`{[key: string]: T}`), in favour of `Map<K, V>`.