### PR TITLE
Drop isStrictNaN in favour of built-in isNaN

### DIFF
--- a/bokehjs/src/lib/core/util/types.ts
+++ b/bokehjs/src/lib/core/util/types.ts
@@ -24,10 +24,6 @@ export function isString(obj: unknown): obj is string {
   return toString.call(obj) === "[object String]"
 }
 
-export function isStrictNaN(obj: unknown): obj is number {
-  return isNumber(obj) && obj !== +obj
-}
-
 export function isFunction(obj: unknown): obj is Function {
   return toString.call(obj) === "[object Function]"
 }

--- a/bokehjs/src/lib/models/glyphs/multi_line.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_line.ts
@@ -7,7 +7,6 @@ import * as hittest from "core/hittest"
 import * as p from "core/properties"
 import {min, max} from "core/util/array"
 import {to_object} from "core/util/object"
-import {isStrictNaN} from "core/util/types"
 import {Context2d} from "core/util/canvas"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
 import {generic_line_legend, line_interpolation} from "./utils"
@@ -37,7 +36,7 @@ export class MultiLineView extends GlyphView {
       const xs: number[] = []
       for (let j = 0, n = _xsi.length; j < n; j++) {
         const x = _xsi[j]
-        if (!isStrictNaN(x))
+        if (!isNaN(x))
           xs.push(x)
       }
 
@@ -45,7 +44,7 @@ export class MultiLineView extends GlyphView {
       const ys: number[] = []
       for (let j = 0, n = _ysi.length; j < n; j++) {
         const y = _ysi[j]
-        if (!isStrictNaN(y))
+        if (!isNaN(y))
           ys.push(y)
       }
 

--- a/bokehjs/src/lib/models/glyphs/patches.ts
+++ b/bokehjs/src/lib/models/glyphs/patches.ts
@@ -3,7 +3,6 @@ import {Glyph, GlyphView, GlyphData} from "./glyph"
 import {generic_area_legend} from "./utils"
 import {min, max, copy, find_last_index} from "core/util/array"
 import {sum} from "core/util/arrayable"
-import {isStrictNaN} from "core/util/types"
 import {Arrayable, Rect} from "core/types"
 import {PointGeometry, RectGeometry} from "core/geometry"
 import {Context2d} from "core/util/canvas"
@@ -53,7 +52,7 @@ export class PatchesView extends GlyphView {
       ds[i] = []
       let qs = copy(nanned_qs[i])
       while (qs.length > 0) {
-        const nan_index = find_last_index(qs, (q) => isStrictNaN(q))
+        const nan_index = find_last_index(qs, (q) => isNaN(q))
 
         let qs_part
         if (nan_index >= 0)
@@ -63,7 +62,7 @@ export class PatchesView extends GlyphView {
           qs = []
         }
 
-        const denanned = qs_part.filter((q) => !isStrictNaN(q))
+        const denanned = qs_part.filter((q) => !isNaN(q))
         ds[i].push(denanned)
       }
     }

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -22,7 +22,7 @@ import {Visuals} from "core/visuals"
 import {logger} from "core/logging"
 import {Side, RenderLevel} from "core/enums"
 import {throttle} from "core/util/throttle"
-import {isArray, isStrictNaN} from "core/util/types"
+import {isArray} from "core/util/types"
 import {copy, reversed} from "core/util/array"
 import {values} from "core/util/object"
 import {Context2d} from "core/util/canvas"
@@ -828,7 +828,7 @@ export class PlotView extends LayoutDOMView {
     const yrs: {[key: string]: Interval} = {}
     for (const name in x_ranges) {
       const {start, end} = x_ranges[name]
-      if (start == null || end == null || isStrictNaN(start + end)) {
+      if (start == null || end == null || isNaN(start + end)) {
         good_vals = false
         break
       }
@@ -837,7 +837,7 @@ export class PlotView extends LayoutDOMView {
     if (good_vals) {
       for (const name in y_ranges) {
         const {start, end} = y_ranges[name]
-        if (start == null || end == null || isStrictNaN(start + end)) {
+        if (start == null || end == null || isNaN(start + end)) {
           good_vals = false
           break
         }

--- a/bokehjs/src/lib/models/tickers/continuous_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/continuous_ticker.ts
@@ -1,7 +1,6 @@
 import {Ticker, TickSpec} from "./ticker"
 import * as p from "core/properties"
 import {range} from "core/util/array"
-import {isStrictNaN} from "core/util/types"
 
 // The base class for all Ticker objects.  It needs to be subclassed before
 // being used.  The simplest subclass is SingleIntervalTicker.
@@ -66,7 +65,7 @@ export abstract class ContinuousTicker extends Ticker<number> {
     const start_factor = Math.floor(data_low / interval)
     const end_factor   = Math.ceil(data_high / interval)
     let factors: number[]
-    if (isStrictNaN(start_factor) || isStrictNaN(end_factor))
+    if (isNaN(start_factor) || isNaN(end_factor))
       factors = []
     else
       factors = range(start_factor, end_factor + 1)


### PR DESCRIPTION
All code paths that still used `isStrictNaN()` work on `number`s, so there should be no difference anymore.

fixes #5744