### PR TITLE
Reduce usage of for-in loop an in operator

### DIFF
--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -523,6 +523,7 @@ export abstract class HasProps extends Signalable() {
   }
 
   protected _doc_attached(): void {}
+  protected _doc_detached(): void {}
 
   attach_document(doc: Document): void {
     // This should only be called by the Document implementation to set the document field
@@ -535,6 +536,7 @@ export abstract class HasProps extends Signalable() {
 
   detach_document(): void {
     // This should only be called by the Document implementation to unset the document field
+    this._doc_detached()
     this.document = null
   }
 

--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -9,7 +9,7 @@ import * as mixins from "./property_mixins"
 import {Property} from "./properties"
 import {uniqueId} from "./util/string"
 import {max, copy} from "./util/array"
-import {clone, extend, isEmpty} from "./util/object"
+import {entries, clone, extend, isEmpty} from "./util/object"
 import {isPlainObject, isObject, isArray, isString, isFunction} from "./util/types"
 import {isEqual} from './util/eq'
 import {ColumnarDataSource} from "models/sources/columnar_data_source"
@@ -106,8 +106,7 @@ export abstract class HasProps extends Signalable() {
 
   // TODO: don't use Partial<>, but exclude inherited properties
   static define<T>(obj: Partial<p.DefineOf<T>>): void {
-    for (const name in obj) {
-      const prop = obj[name]
+    for (const [name, prop] of entries(obj)) {
       if (this.prototype._props[name] != null)
         throw new Error(`attempted to redefine property '${this.prototype.type}.${name}'`)
 
@@ -143,8 +142,8 @@ export abstract class HasProps extends Signalable() {
 
   static internal(obj: any): void {
     const _object: any = {}
-    for (const name in obj) {
-      const [type, default_value, options = {}] = obj[name]
+    for (const [name, entry] of entries(obj)) {
+      const [type, default_value, options = {}] = entry as any
       _object[name] = [type, default_value, {...options, internal: true}]
     }
     this.define(_object)
@@ -167,8 +166,7 @@ export abstract class HasProps extends Signalable() {
 
     function rename(prefix: string, mixin: Attrs): Attrs {
       const result: Attrs = {}
-      for (const name in mixin) {
-        const prop = mixin[name]
+      for (const [name, prop] of entries(mixin)) {
         result[prefix + name] = prop
       }
       return result
@@ -205,8 +203,8 @@ export abstract class HasProps extends Signalable() {
   }
 
   static override(obj: any): void {
-    for (const name in obj) {
-      const default_value = this._fix_default(obj[name], name)
+    for (const [name, prop] of entries(obj)) {
+      const default_value = this._fix_default(prop, name)
       const value = this.prototype._props[name]
       if (value == null)
         throw new Error(`attempted to override nonexistent '${this.prototype.type}.${name}'`)
@@ -251,8 +249,7 @@ export abstract class HasProps extends Signalable() {
 
     const get = attrs instanceof Map ? attrs.get : (name: string) => attrs[name]
 
-    for (const name in this._props) {
-      const {type, default_value, options} = this._props[name]
+    for (const [name, {type, default_value, options}] of entries(this._props)) {
       if (type != null)
         this.properties[name] = new type(this, name, default_value, get(name), options)
       else
@@ -269,8 +266,7 @@ export abstract class HasProps extends Signalable() {
   }
 
   finalize(): void {
-    for (const name in this.properties) {
-      const prop = this.properties[name]
+    for (const prop of this) {
       if (prop.spec.transform != null)
         this.connect(prop.spec.transform.change, () => this.transformchange.emit())
     }

--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -1,7 +1,7 @@
 //import {logger} from "./logging"
 import {View} from "./view"
 import {Class} from "./class"
-import {Attrs} from "./types"
+import {Attrs, PlainObject} from "./types"
 import {Signal0, Signal, Signalable, ISignalable} from "./signaling"
 import {Struct, Ref, is_ref} from "./util/refs"
 import * as p from "./properties"
@@ -100,7 +100,7 @@ export abstract class HasProps extends Signalable() {
       if (isArray(default_value))
         return () => copy(default_value)
       else
-        return () => clone(default_value)
+        return () => clone(default_value as PlainObject)
     }
   }
 

--- a/bokehjs/src/lib/core/types.ts
+++ b/bokehjs/src/lib/core/types.ts
@@ -23,7 +23,7 @@ export type Data = {[key: string]: Arrayable<unknown>}
 
 export type Attrs = {[key: string]: unknown}
 
-export type PlainObject = Attrs
+export type PlainObject<T = unknown> = {[key: string]: T}
 
 export type Size = {
   width: number

--- a/bokehjs/src/lib/core/ui_events.ts
+++ b/bokehjs/src/lib/core/ui_events.ts
@@ -6,8 +6,7 @@ import {DOMView} from "./dom_view"
 import {logger} from "./logging"
 import {offset, Keys} from "./dom"
 import {getDeltaY} from "./util/wheel"
-import {reversed} from "./util/array"
-import {isEmpty} from "./util/object"
+import {reversed, is_empty} from "./util/array"
 import {isString} from "./util/types"
 import {is_mobile} from "./util/compat"
 import {PlotView} from "../models/plots/plot"
@@ -325,14 +324,14 @@ export class UIEvents implements EventListenerObject {
         if (view != null) {
           cursor = view.cursor(e.sx, e.sy) || cursor
 
-          if (!isEmpty(active_inspectors)) {
+          if (!is_empty(active_inspectors)) {
             // override event_type to cause inspectors to clear overlays
             signal = this.move_exit as any // XXX
           }
 
         // the event happened on the plot frame but off a renderer
         } else if (this._hit_test_frame(e.sx, e.sy)) {
-          if (!isEmpty(active_inspectors)) {
+          if (!is_empty(active_inspectors)) {
             cursor = "crosshair"
           }
         }

--- a/bokehjs/src/lib/core/util/array.ts
+++ b/bokehjs/src/lib/core/util/array.ts
@@ -6,8 +6,8 @@
 import {randomIn} from "./math"
 import {assert} from "./assert"
 
-import {map, reduce, min, min_by, max, max_by, sum, cumsum, every, some, find, find_last, find_index, find_last_index, sorted_index} from "./arrayable"
-export {map, reduce, min, min_by, max, max_by, sum, cumsum, every, some, find, find_last, find_index, find_last_index, sorted_index}
+import {map, reduce, min, min_by, max, max_by, sum, cumsum, every, some, find, find_last, find_index, find_last_index, sorted_index, is_empty} from "./arrayable"
+export {map, reduce, min, min_by, max, max_by, sum, cumsum, every, some, find, find_last, find_index, find_last_index, sorted_index, is_empty}
 
 const slice = Array.prototype.slice
 

--- a/bokehjs/src/lib/core/util/arrayable.ts
+++ b/bokehjs/src/lib/core/util/arrayable.ts
@@ -1,5 +1,9 @@
 import {Arrayable, ArrayableNew} from "../types"
 
+export function is_empty(array: Arrayable): boolean {
+  return array.length == 0
+}
+
 export function splice<T>(array: Arrayable<T>, start: number, k?: number, ...items: T[]): Arrayable<T> {
   const len = array.length
 

--- a/bokehjs/src/lib/core/util/object.ts
+++ b/bokehjs/src/lib/core/util/object.ts
@@ -1,22 +1,6 @@
 import {concat, union} from "./array"
 
-export const {keys, assign: extend} = Object
-
-export const values: <T>(object: {[key: string]: T}) => T[] = (() => {
-  if (typeof Object.values !== "undefined")
-    return Object.values
-  else {
-    return <T>(object: {[key: string]: T}): T[] => {
-      const keys = Object.keys(object)
-      const length = keys.length
-      const values = new Array<T>(length)
-      for (let i = 0; i < length; i++) {
-        values[i] = object[keys[i]]
-      }
-      return values
-    }
-  }
-})()
+export const {keys, values, entries, assign: extend} = Object
 
 export function clone<T extends object>(obj: T): T {
   return {...obj}

--- a/bokehjs/src/lib/core/util/object.ts
+++ b/bokehjs/src/lib/core/util/object.ts
@@ -1,16 +1,17 @@
+import {PlainObject} from "../types"
 import {concat, union} from "./array"
 
 export const {keys, values, entries, assign: extend} = Object
 
-export function clone<T extends object>(obj: T): T {
+export function clone<T>(obj: PlainObject<T>): PlainObject<T> {
   return {...obj}
 }
 
-export function merge<T>(obj1: {[key: string]: T[]}, obj2: {[key: string]: T[]}): {[key: string]: T[]} {
+export function merge<T>(obj1: PlainObject<T[]>, obj2: PlainObject<T[]>): PlainObject<T[]> {
   /*
    * Returns an object with the array values for obj1 and obj2 unioned by key.
    */
-  const result: {[key: string]: T[]} = Object.create(Object.prototype)
+  const result: PlainObject<T[]> = Object.create(Object.prototype)
 
   const keys = concat([Object.keys(obj1), Object.keys(obj2)])
 
@@ -23,18 +24,18 @@ export function merge<T>(obj1: {[key: string]: T[]}, obj2: {[key: string]: T[]})
   return result
 }
 
-export function size<T>(obj: T): number {
+export function size(obj: PlainObject): number {
   return Object.keys(obj).length
 }
 
-export function isEmpty<T>(obj: T): boolean {
-  return size(obj) === 0
+export function isEmpty(obj: PlainObject): boolean {
+  return size(obj) == 0
 }
 
-export function to_object<T>(map: Map<unknown, T>): {[key: string]: T} {
-  const obj: {[key: string]: T} = {}
+export function to_object<T>(map: Map<string | number, T>): PlainObject<T> {
+  const obj: PlainObject<T> = {}
   for (const [key, val] of map) {
-    obj[`${key}`] = val
+    obj[key] = val
   }
   return obj
 }

--- a/bokehjs/src/lib/document/document.ts
+++ b/bokehjs/src/lib/document/document.ts
@@ -21,11 +21,10 @@ import {
   DocumentChanged, ModelChanged, RootAddedEvent,
 } from "./events"
 
+// Dispatches events to the subscribed models
 export class EventManager {
-  // Dispatches events to the subscribed models
-
   session: ClientSession | null = null
-  subscribed_models: Set<ID> = new Set()
+  subscribed_models: Set<Model> = new Set()
 
   constructor(readonly document: Document) {}
 
@@ -35,12 +34,10 @@ export class EventManager {
   }
 
   trigger(event: BokehEvent): void {
-    for (const id of this.subscribed_models) {
-      if (event.origin != null && event.origin.id !== id)
+    for (const model of this.subscribed_models) {
+      if (event.origin != null && event.origin != model)
         continue
-      const model = this.document._all_models.get(id)
-      if (model != null && model instanceof Model)
-        model._process_event(event)
+      model._process_event(event)
     }
   }
 }

--- a/bokehjs/src/lib/models/annotations/color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/color_bar.ts
@@ -16,9 +16,8 @@ import * as visuals from "core/visuals"
 import * as mixins from "core/property_mixins"
 import * as p from "core/properties"
 import * as text_util from "core/util/text"
-import {min, max, range, reversed} from "core/util/array"
+import {min, max, range, reversed, is_empty} from "core/util/array"
 import {map} from "core/util/arrayable"
-import {isEmpty} from "core/util/object"
 import {isString, isArray} from "core/util/types"
 import {Context2d} from "core/util/canvas"
 import {Size} from "core/layout"
@@ -334,7 +333,7 @@ export class ColorBarView extends AnnotationView {
     const major_labels = this.tick_info().labels.major
 
     let label_extent: number
-    if (this.model.color_mapper.low != null && this.model.color_mapper.high != null && !isEmpty(major_labels)) {
+    if (this.model.color_mapper.low != null && this.model.color_mapper.high != null && !is_empty(major_labels)) {
       const {ctx} = this.layer
       ctx.save()
       this.visuals.major_label_text.set_value(ctx)

--- a/bokehjs/src/lib/models/tickers/composite_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/composite_ticker.ts
@@ -1,8 +1,7 @@
 import {TickSpec} from "./ticker"
 import {ContinuousTicker} from "./continuous_ticker"
 import * as p from "core/properties"
-import {argmin, sorted_index} from "core/util/array"
-import {isEmpty} from "core/util/object"
+import {argmin, sorted_index, is_empty} from "core/util/array"
 
 // This Ticker takes a collection of Tickers and picks the one most appropriate
 // for a given range.
@@ -68,7 +67,7 @@ export class CompositeTicker extends ContinuousTicker {
 
     let best_ticker
 
-    if (isEmpty(errors.filter((e) => !isNaN(e)))) {
+    if (is_empty(errors.filter((e) => !isNaN(e)))) {
       // this can happen if the data isn't loaded yet, we just default to the first scale
       best_ticker = this.tickers[0]
     } else {

--- a/bokehjs/src/lib/models/tiles/tile_source.ts
+++ b/bokehjs/src/lib/models/tiles/tile_source.ts
@@ -1,5 +1,6 @@
 import {Model} from "../../model"
 import {Extent, Bounds} from "./tile_utils"
+import {entries} from "core/util/object"
 import * as p from "core/properties"
 
 export type Tile = {
@@ -60,8 +61,7 @@ export abstract class TileSource extends Model {
 
   string_lookup_replace(str: string, lookup: {[key: string]: string}): string {
     let result_str = str
-    for (const key in lookup) {
-      const value = lookup[key]
+    for (const [key, value] of entries(lookup)) {
       result_str = result_str.replace(`{${key}}`, value)
     }
     return result_str

--- a/bokehjs/src/lib/models/tools/gestures/tap_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/tap_tool.ts
@@ -22,8 +22,7 @@ export class TapToolView extends SelectToolView {
     if (this.model.behavior == "select") {
       const renderers_by_source = this._computed_renderers_by_data_source()
 
-      for (const id in renderers_by_source) {
-        const renderers = renderers_by_source[id]
+      for (const [, renderers] of renderers_by_source) {
         const sm = renderers[0].get_selection_manager()
         const r_views = renderers.map((r) => this.plot_view.renderer_views.get(r)!)
         const did_hit = sm.select(r_views, geometry, final, mode)

--- a/bokehjs/src/lib/models/widgets/selectbox.ts
+++ b/bokehjs/src/lib/models/widgets/selectbox.ts
@@ -1,5 +1,6 @@
 import {select, option, optgroup} from "core/dom"
 import {isString, isArray} from "core/util/types"
+import {entries} from "core/util/object"
 import {logger} from "core/logging"
 import * as p from "core/properties"
 
@@ -38,8 +39,7 @@ export class SelectView extends InputWidgetView {
     else {
       contents = []
       const options = this.model.options
-      for (const key in options) {
-        const value = options[key]
+      for (const [key, value] of entries(options)) {
         contents.push(optgroup({label: key}, this.build_options(value)))
       }
     }

--- a/bokehjs/src/lib/polyfill.ts
+++ b/bokehjs/src/lib/polyfill.ts
@@ -1,4 +1,5 @@
 import "es5-ext/object/assign/implement"
+import "es5-ext/object/entries/implement"
 import "es5-ext/number/is-integer/implement"
 import "es5-ext/string/#/repeat/implement"
 import "es5-ext/array/from/implement"
@@ -9,6 +10,12 @@ import "es6-map/implement"
 import "es6-weak-map/implement"
 
 import "es6-promise/auto"
+
+if (typeof Object.values === "undefined") {
+  Object.values = function(obj: {[key: string]: unknown}) {
+    return Object.keys(obj).map((key) => obj[key])
+  }
+}
 
 // fixes up a problem with some versions of IE11
 // ref: http://stackoverflow.com/questions/22062313/imagedata-set-in-internetexplorer

--- a/bokehjs/test/unit/models/ranges/data_range1d.ts
+++ b/bokehjs/test/unit/models/ranges/data_range1d.ts
@@ -242,29 +242,29 @@ describe("datarange1d module", () => {
 
     it("should compute max/min for dimension of a single plot_bounds", () => {
       const r = new DataRange1d()
-      const bds = {
-        1: {x0: 0, x1: 10, y0: 5, y1:6},
-      }
-      expect(r._compute_min_max(bds, 0)).to.be.deep.equal([0, 10])
-      expect(r._compute_min_max(bds, 1)).to.be.deep.equal([5, 6])
+      const bounds = [
+        {x0: 0, x1: 10, y0: 5, y1: 6},
+      ]
+      expect(r._compute_min_max(bounds, 0)).to.be.deep.equal([0, 10])
+      expect(r._compute_min_max(bounds, 1)).to.be.deep.equal([5, 6])
     })
 
     it("should compute max/min for dimension of multiple plot_bounds", () => {
       const r = new DataRange1d()
-      const bds0 = {
-        1: {x0: 0, x1: 10, y0: 5, y1: 6},
-        2: {x0: 0, x1: 15, y0: 5.5, y1: 5.6},
-      }
-      expect(r._compute_min_max(bds0, 0)).to.be.deep.equal([0, 15])
-      expect(r._compute_min_max(bds0, 1)).to.be.deep.equal([5, 6])
+      const bounds0 = [
+        {x0: 0, x1: 10, y0: 5, y1: 6},
+        {x0: 0, x1: 15, y0: 5.5, y1: 5.6},
+      ]
+      expect(r._compute_min_max(bounds0, 0)).to.be.deep.equal([0, 15])
+      expect(r._compute_min_max(bounds0, 1)).to.be.deep.equal([5, 6])
 
-      const bds1 = {
-        1: {x0: 0, x1: 10, y0: 5, y1: 6},
-        2: {x0: 0, x1: 15, y0: 5.5, y1: 5.6},
-        3: {x0: -10, x1: 15, y0: 0, y1: 2},
-      }
-      expect(r._compute_min_max(bds1, 0)).to.be.deep.equal([-10, 15])
-      expect(r._compute_min_max(bds1, 1)).to.be.deep.equal([0, 6])
+      const bounds1 = [
+        {x0: 0, x1: 10, y0: 5, y1: 6},
+        {x0: 0, x1: 15, y0: 5.5, y1: 5.6},
+        {x0: -10, x1: 15, y0: 0, y1: 2},
+      ]
+      expect(r._compute_min_max(bounds1, 0)).to.be.deep.equal([-10, 15])
+      expect(r._compute_min_max(bounds1, 1)).to.be.deep.equal([0, 6])
     })
   })
 
@@ -273,49 +273,52 @@ describe("datarange1d module", () => {
     it("should compute bounds from configured renderers", () => {
       const r = new DataRange1d()
 
-      const g1 = new GlyphRenderer({id: "1"})
-      const g2 = new GlyphRenderer({id: "2"})
+      const g1 = new GlyphRenderer()
+      const g2 = new GlyphRenderer()
+      const g3 = new GlyphRenderer()
 
-      const bds = {
-        1: {x0: 0, x1: 10, y0: 5, y1: 6},
-        2: {x0: 0, x1: 15, y0: 5.5, y1: 5.6},
-        3: {x0: -10, x1: 15, y0: 0, y1: 2},
-      }
+      const bounds = new Map([
+        [g1, {x0: 0, x1: 10, y0: 5, y1: 6}],
+        [g2, {x0: 0, x1: 15, y0: 5.5, y1: 5.6}],
+        [g3, {x0: -10, x1: 15, y0: 0, y1: 2}],
+      ])
 
-      expect(r._compute_plot_bounds([g1], bds)).to.be.deep.equal({x0: 0, x1: 10, y0: 5, y1: 6})
-      expect(r._compute_plot_bounds([g1, g2], bds)).to.be.deep.equal({x0: 0, x1: 15, y0: 5, y1: 6})
+      expect(r._compute_plot_bounds([g1], bounds)).to.be.deep.equal({x0: 0, x1: 10, y0: 5, y1: 6})
+      expect(r._compute_plot_bounds([g1, g2], bounds)).to.be.deep.equal({x0: 0, x1: 15, y0: 5, y1: 6})
     })
 
     it("should use invisble renderers by default", () => {
       const r = new DataRange1d()
 
-      const g1 = new GlyphRenderer({id: "1", visible: false})
-      const g2 = new GlyphRenderer({id: "2"})
+      const g1 = new GlyphRenderer({visible: false})
+      const g2 = new GlyphRenderer()
+      const g3 = new GlyphRenderer()
 
-      const bds = {
-        1: {x0: 0, x1: 10, y0: 5, y1: 6},
-        2: {x0: 0, x1: 15, y0: 5.5, y1: 5.6},
-        3: {x0: -10, x1: 15, y0: 0, y1: 2},
-      }
+      const bounds = new Map([
+        [g1, {x0: 0, x1: 10, y0: 5, y1: 6}],
+        [g2, {x0: 0, x1: 15, y0: 5.5, y1: 5.6}],
+        [g3, {x0: -10, x1: 15, y0: 0, y1: 2}],
+      ])
 
-      expect(r._compute_plot_bounds([g1], bds)).to.be.deep.equal({x0: 0, x1: 10, y0: 5, y1: 6})
-      expect(r._compute_plot_bounds([g1, g2], bds)).to.be.deep.equal({x0: 0, x1: 15, y0: 5, y1: 6})
+      expect(r._compute_plot_bounds([g1], bounds)).to.be.deep.equal({x0: 0, x1: 10, y0: 5, y1: 6})
+      expect(r._compute_plot_bounds([g1, g2], bounds)).to.be.deep.equal({x0: 0, x1: 15, y0: 5, y1: 6})
     })
 
     it("should skip invisble renderers if only_visible=false", () => {
       const r = new DataRange1d({only_visible: true})
 
-      const g1 = new GlyphRenderer({id: "1"})
-      const g2 = new GlyphRenderer({id: "2", visible: false})
+      const g1 = new GlyphRenderer()
+      const g2 = new GlyphRenderer({visible: false})
+      const g3 = new GlyphRenderer()
 
-      const bds = {
-        1: {x0: 0, x1: 10, y0: 5, y1: 6},
-        2: {x0: 0, x1: 15, y0: 5.5, y1: 5.6},
-        3: {x0: -10, x1: 15, y0: 0, y1: 2},
-      }
+      const bounds = new Map([
+        [g1, {x0: 0, x1: 10, y0: 5, y1: 6}],
+        [g2, {x0: 0, x1: 15, y0: 5.5, y1: 5.6}],
+        [g3, {x0: -10, x1: 15, y0: 0, y1: 2}],
+      ])
 
-      expect(r._compute_plot_bounds([g1], bds)).to.be.deep.equal({x0: 0, x1: 10, y0: 5, y1: 6})
-      expect(r._compute_plot_bounds([g1, g2], bds)).to.be.deep.equal({x0: 0, x1: 10, y0: 5, y1: 6})
+      expect(r._compute_plot_bounds([g1], bounds)).to.be.deep.equal({x0: 0, x1: 10, y0: 5, y1: 6})
+      expect(r._compute_plot_bounds([g1, g2], bounds)).to.be.deep.equal({x0: 0, x1: 10, y0: 5, y1: 6})
     })
   })
 
@@ -326,11 +329,11 @@ describe("datarange1d module", () => {
       const p = new Plot({renderers: [g]})
       const r = new DataRange1d({plots: [p]})
 
-      const bds = {
-        id: {x0: -10, x1: -6, y0: 5, y1: 6},
-      }
+      const bounds = new Map([
+        [g, {x0: -10, x1: -6, y0: 5, y1: 6}],
+      ])
 
-      r.update(bds, 0, "id")
+      r.update(bounds, 0, p)
       expect(r.start).to.be.equal(-10.2)
     })
 
@@ -339,11 +342,11 @@ describe("datarange1d module", () => {
       const p = new Plot({renderers: [g]})
       const r = new DataRange1d({scale_hint: "log", plots: [p]})
 
-      const bds = {
-        id: {x0: Infinity, x1: -Infinity, y0: 5, y1: 6},
-      }
+      const bounds = new Map([
+        [g, {x0: Infinity, x1: -Infinity, y0: 5, y1: 6}],
+      ])
 
-      r.update(bds, 0, "id")
+      r.update(bounds, 0, p)
       expect(r.start).not.to.be.NaN
       expect(r.end).not.to.be.NaN
     })
@@ -356,22 +359,22 @@ describe("datarange1d module", () => {
   describe("adjust_bounds_for_aspect", () => {
     it("should preserve y axis when it is larger", () => {
       const r = new DataRange1d()
-      const bds = r.adjust_bounds_for_aspect({x0: 0, x1: 1, y0: 0, y1: 2}, 4)
+      const bounds = r.adjust_bounds_for_aspect({x0: 0, x1: 1, y0: 0, y1: 2}, 4)
 
-      expect(bds.x0).to.be.equal(-3.5)
-      expect(bds.x1).to.be.equal(4.5)
-      expect(bds.y0).to.be.equal(0)
-      expect(bds.y1).to.be.equal(2)
+      expect(bounds.x0).to.be.equal(-3.5)
+      expect(bounds.x1).to.be.equal(4.5)
+      expect(bounds.y0).to.be.equal(0)
+      expect(bounds.y1).to.be.equal(2)
     })
 
     it("should preserve x axis when it is larger", () => {
       const r = new DataRange1d()
-      const bds = r.adjust_bounds_for_aspect({x0: 0, x1: 8, y0: 0, y1: 1}, 4)
+      const bounds = r.adjust_bounds_for_aspect({x0: 0, x1: 8, y0: 0, y1: 1}, 4)
 
-      expect(bds.x0).to.be.equal(0)
-      expect(bds.x1).to.be.equal(8)
-      expect(bds.y0).to.be.equal(-0.5)
-      expect(bds.y1).to.be.equal(1.5)
+      expect(bounds.x0).to.be.equal(0)
+      expect(bounds.x1).to.be.equal(8)
+      expect(bounds.y0).to.be.equal(-0.5)
+      expect(bounds.y1).to.be.equal(1.5)
     })
   })
 })


### PR DESCRIPTION
This fixes broken selections after PR #10054. There reason for breakage was a stray `in` operator. I fixed that and took a stab at removing as many `for-in` loops and usage of `in` operator as I could in one sitting. I think two more PRs and bokehjs' codebase will be cleaned up.