### PR TITLE
Improve support for ndarray serialization

### DIFF
--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -521,7 +521,7 @@ def encode_binary_dict(array, buffers):
         '__buffer__'  : buffer_id,
         'shape'       : array.shape,
         'dtype'       : array.dtype.name,
-        'order'       : sys.byteorder
+        'order'       : sys.byteorder,
     }
 
 def encode_base64_dict(array):
@@ -546,9 +546,10 @@ def encode_base64_dict(array):
 
     '''
     return {
-        '__ndarray__'  : base64.b64encode(array.data).decode('utf-8'),
-        'shape'        : array.shape,
-        'dtype'        : array.dtype.name
+        '__ndarray__' : base64.b64encode(array.data).decode('utf-8'),
+        'shape'       : array.shape,
+        'dtype'       : array.dtype.name,
+        'order'       : sys.byteorder,
     }
 
 def decode_base64_dict(data):

--- a/bokehjs/src/lib/core/types.ts
+++ b/bokehjs/src/lib/core/types.ts
@@ -2,11 +2,7 @@ export type ID = string
 
 export type Color = string
 
-export type TypedArray =
-  Uint8Array   | Int8Array    |
-  Uint16Array  | Int16Array   |
-  Uint32Array  | Int32Array   |
-  Float32Array | Float64Array
+export {TypedArray} from "./util/ndarray"
 
 export type Arrayable<T = any> = {
   readonly length: number

--- a/bokehjs/src/lib/core/util/ndarray.ts
+++ b/bokehjs/src/lib/core/util/ndarray.ts
@@ -1,0 +1,159 @@
+import {isObject, isArray} from "./types"
+import {unreachable} from "./assert"
+
+export type DataType = "uint8" | "int8" | "uint16" | "int16" | "uint32" | "int32" | "float32" | "float64"
+
+const __ndarray__ = Symbol("__ndarray__")
+
+export class Uint8NDArray extends Uint8Array {
+  readonly __ndarray__ = __ndarray__
+  readonly dtype: "uint8" = "uint8"
+  readonly shape: number[]
+
+  constructor(seq: ArrayLike<number> | ArrayBufferLike, shape?: number[]) {
+    super(seq)
+    this.shape = shape ?? [this.length]
+  }
+}
+
+export class Int8NDArray extends Int8Array {
+  readonly __ndarray__ = __ndarray__
+  readonly dtype: "int8" = "int8"
+  readonly shape: number[]
+
+  constructor(seq: ArrayLike<number> | ArrayBufferLike, shape?: number[]) {
+    super(seq)
+    this.shape = shape ?? [this.length]
+  }
+}
+
+export class Uint16NDArray extends Uint16Array {
+  readonly __ndarray__ = __ndarray__
+  readonly dtype: "uint16" = "uint16"
+  readonly shape: number[]
+
+  constructor(seq: ArrayLike<number> | ArrayBufferLike, shape?: number[]) {
+    super(seq)
+    this.shape = shape ?? [this.length]
+  }
+}
+
+export class Int16NDArray extends Int16Array {
+  readonly __ndarray__ = __ndarray__
+  readonly dtype: "int16" = "int16"
+  readonly shape: number[]
+
+  constructor(seq: ArrayLike<number> | ArrayBufferLike, shape?: number[]) {
+    super(seq)
+    this.shape = shape ?? [this.length]
+  }
+}
+
+export class Uint32NDArray extends Uint32Array {
+  readonly __ndarray__ = __ndarray__
+  readonly dtype: "uint32" = "uint32"
+  readonly shape: number[]
+
+  constructor(seq: ArrayLike<number> | ArrayBufferLike, shape?: number[]) {
+    super(seq)
+    this.shape = shape ?? [this.length]
+  }
+}
+
+export class Int32NDArray extends Int32Array {
+  readonly __ndarray__ = __ndarray__
+  readonly dtype: "int32" = "int32"
+  readonly shape: number[]
+
+  constructor(seq: ArrayLike<number> | ArrayBufferLike, shape?: number[]) {
+    super(seq)
+    this.shape = shape ?? [this.length]
+  }
+}
+
+export class Float32NDArray extends Float32Array {
+  readonly __ndarray__ = __ndarray__
+  readonly dtype: "float32" = "float32"
+  readonly shape: number[]
+
+  constructor(seq: ArrayLike<number> | ArrayBufferLike, shape?: number[]) {
+    super(seq)
+    this.shape = shape ?? [this.length]
+  }
+}
+
+export class Float64NDArray extends Float64Array {
+  readonly __ndarray__ = __ndarray__
+  readonly dtype: "float64" = "float64"
+  readonly shape: number[]
+
+  constructor(seq: ArrayLike<number> | ArrayBufferLike, shape?: number[]) {
+    super(seq)
+    this.shape = shape ?? [this.length]
+  }
+}
+
+export type TypedArray =
+  Uint8Array   | Int8Array    |
+  Uint16Array  | Int16Array   |
+  Uint32Array  | Int32Array   |
+  Float32Array | Float64Array
+
+export type NDArray =
+  Uint8NDArray   | Int8NDArray    |
+  Uint16NDArray  | Int16NDArray   |
+  Uint32NDArray  | Int32NDArray   |
+  Float32NDArray | Float64NDArray
+
+export function is_NDArray(v: unknown): v is NDArray {
+  return isObject(v) && (v as any).__ndarray__ == __ndarray__
+}
+
+export type NDArrayTypes = {
+  "uint8":   {typed: Uint8Array,   ndarray: Uint8NDArray}
+  "int8":    {typed: Int8Array,    ndarray: Int8NDArray}
+  "uint16":  {typed: Uint16Array,  ndarray: Uint16NDArray}
+  "int16":   {typed: Int16Array,   ndarray: Int16NDArray}
+  "uint32":  {typed: Uint32Array,  ndarray: Uint32NDArray}
+  "int32":   {typed: Int32Array,   ndarray: Int32NDArray}
+  "float32": {typed: Float32Array, ndarray: Float32NDArray}
+  "float64": {typed: Float64Array, ndarray: Float64NDArray}
+}
+
+export function ndarray<K extends DataType = "float64">(array: ArrayBuffer | number[], options?: {dtype?: K, shape?: number[]}): NDArrayTypes[K]["ndarray"]
+export function ndarray<K extends DataType>(array: NDArrayTypes[K]["typed"], options?: {dtype?: K, shape?: number[]}): NDArrayTypes[K]["ndarray"]
+
+export function ndarray(array: ArrayBuffer | TypedArray | number[], options: {dtype?: DataType, shape?: number[]} = {}): NDArray {
+  let {dtype} = options
+  if (dtype == null) {
+    if (array instanceof ArrayBuffer || isArray(array)) {
+      dtype = "float64"
+    } else {
+      dtype = (() => {
+        switch (true) {
+          case array instanceof Uint8Array:   return "uint8"
+          case array instanceof Int8Array:    return "int8"
+          case array instanceof Uint16Array:  return "uint16"
+          case array instanceof Int16Array:   return "int16"
+          case array instanceof Uint32Array:  return "uint32"
+          case array instanceof Int32Array:   return "int32"
+          case array instanceof Float32Array: return "float32"
+          case array instanceof Float64Array: return "float64"
+          default:
+            unreachable()
+        }
+      })()
+    }
+  }
+  const {shape} = options
+  switch (dtype) {
+    case "uint8":   return new Uint8NDArray(array, shape)
+    case "int8":    return new Int8NDArray(array, shape)
+    case "uint16":  return new Uint16NDArray(array, shape)
+    case "int16":   return new Int16NDArray(array, shape)
+    case "uint32":  return new Uint32NDArray(array, shape)
+    case "int32":   return new Int32NDArray(array, shape)
+    case "float32": return new Float32NDArray(array, shape)
+    case "float64": return new Float64NDArray(array, shape)
+  }
+}

--- a/bokehjs/src/lib/core/util/ndarray.ts
+++ b/bokehjs/src/lib/core/util/ndarray.ts
@@ -23,7 +23,7 @@ export class Int8NDArray extends Int8Array {
 
   constructor(seq: ArrayLike<number> | ArrayBufferLike, shape?: number[]) {
     super(seq)
-    this.shape = shape ?? [this.length]
+    this.shape = shape ?? (is_NDArray(seq) ? seq.shape : [this.length])
   }
 }
 
@@ -34,7 +34,7 @@ export class Uint16NDArray extends Uint16Array {
 
   constructor(seq: ArrayLike<number> | ArrayBufferLike, shape?: number[]) {
     super(seq)
-    this.shape = shape ?? [this.length]
+    this.shape = shape ?? (is_NDArray(seq) ? seq.shape : [this.length])
   }
 }
 
@@ -45,7 +45,7 @@ export class Int16NDArray extends Int16Array {
 
   constructor(seq: ArrayLike<number> | ArrayBufferLike, shape?: number[]) {
     super(seq)
-    this.shape = shape ?? [this.length]
+    this.shape = shape ?? (is_NDArray(seq) ? seq.shape : [this.length])
   }
 }
 
@@ -56,7 +56,7 @@ export class Uint32NDArray extends Uint32Array {
 
   constructor(seq: ArrayLike<number> | ArrayBufferLike, shape?: number[]) {
     super(seq)
-    this.shape = shape ?? [this.length]
+    this.shape = shape ?? (is_NDArray(seq) ? seq.shape : [this.length])
   }
 }
 
@@ -67,7 +67,7 @@ export class Int32NDArray extends Int32Array {
 
   constructor(seq: ArrayLike<number> | ArrayBufferLike, shape?: number[]) {
     super(seq)
-    this.shape = shape ?? [this.length]
+    this.shape = shape ?? (is_NDArray(seq) ? seq.shape : [this.length])
   }
 }
 
@@ -78,7 +78,7 @@ export class Float32NDArray extends Float32Array {
 
   constructor(seq: ArrayLike<number> | ArrayBufferLike, shape?: number[]) {
     super(seq)
-    this.shape = shape ?? [this.length]
+    this.shape = shape ?? (is_NDArray(seq) ? seq.shape : [this.length])
   }
 }
 
@@ -89,7 +89,7 @@ export class Float64NDArray extends Float64Array {
 
   constructor(seq: ArrayLike<number> | ArrayBufferLike, shape?: number[]) {
     super(seq)
-    this.shape = shape ?? [this.length]
+    this.shape = shape ?? (is_NDArray(seq) ? seq.shape : [this.length])
   }
 }
 

--- a/bokehjs/src/lib/core/util/serialization.ts
+++ b/bokehjs/src/lib/core/util/serialization.ts
@@ -1,51 +1,25 @@
-import {Arrayable, TypedArray, Data} from "../types"
-import {isTypedArray, isArray, isPlainObject} from "./types"
+import {ID} from "../types"
+import {isPlainObject} from "./types"
 import {is_little_endian} from "./compat"
+import {DataType, NDArray} from "./ndarray"
+import {uniqueId} from "./string"
+import * as ndarray from "./ndarray"
 
-export const ARRAY_TYPES = {
-  uint8:   Uint8Array,
-  int8:    Int8Array,
-  uint16:  Uint16Array,
-  int16:   Int16Array,
-  uint32:  Uint32Array,
-  int32:   Int32Array,
-  float32: Float32Array,
-  float64: Float64Array,
+export function buffer_to_base64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer)
+  const chars = Array.from(bytes).map((b) => String.fromCharCode(b))
+  return btoa(chars.join(""))
 }
 
-export const DTYPES = {
-  Uint8Array:   "uint8"   as "uint8",
-  Int8Array:    "int8"    as "int8",
-  Uint16Array:  "uint16"  as "uint16",
-  Int16Array:   "int16"   as "int16",
-  Uint32Array:  "uint32"  as "uint32",
-  Int32Array:   "int32"   as "int32",
-  Float32Array: "float32" as "float32",
-  Float64Array: "float64" as "float64",
-}
-
-function arrayName(array: TypedArray): ArrayName {
-  if ("name" in array.constructor)
-    return array.constructor.name as ArrayName
-  else {
-    switch (true) {
-      case array instanceof Uint8Array:   return "Uint8Array"
-      case array instanceof Int8Array:    return "Int8Array"
-      case array instanceof Uint16Array:  return "Uint16Array"
-      case array instanceof Int16Array:   return "Int16Array"
-      case array instanceof Uint32Array:  return "Uint32Array"
-      case array instanceof Int32Array:   return "Int32Array"
-      case array instanceof Float32Array: return "Float32Array"
-      case array instanceof Float64Array: return "Float64Array"
-      default:
-        throw new Error("unsupported typed array")
-    }
+export function base64_to_buffer(base64: string): ArrayBuffer {
+  const binary_string = atob(base64)
+  const len = binary_string.length
+  const bytes = new Uint8Array(len)
+  for (let i = 0, end = len; i < end; i++) {
+    bytes[i] = binary_string.charCodeAt(i)
   }
+  return bytes.buffer
 }
-
-export type ArrayName = keyof typeof DTYPES
-
-export type DType = keyof typeof ARRAY_TYPES
 
 export type ByteOrder = "little" | "big"
 
@@ -92,182 +66,83 @@ export function swap64(a: Float64Array): void {
 
 export type Shape = number[]
 
-export type BufferSpec = {
+export type BufferRef = {
   __buffer__: string
   order: ByteOrder
-  dtype: DType
+  dtype: DataType
   shape: Shape
 }
 
-export type NDArray = {
+export type NDArrayRef = {
   __ndarray__: string
-  shape?: Shape
-  dtype: DType
+  order: ByteOrder
+  dtype: DataType
+  shape: Shape
 }
 
-export type Buffers = Map<string, ArrayBuffer>
+export function is_NDArray_ref(v: unknown): v is BufferRef | NDArrayRef {
+  return isPlainObject(v) && ("__buffer__" in v || "__ndarray__" in v)
+}
 
-export function process_buffer(specification: BufferSpec, buffers: Buffers): [TypedArray, Shape] {
-  const need_swap = specification.order !== BYTE_ORDER
-  const {shape} = specification
-  const bytes = buffers.get(specification.__buffer__)
-  if (bytes == null) {
-    throw new Error(`buffer for ${specification.__buffer__} not found`)
+export type Buffers = Map<ID, ArrayBuffer>
+
+export function decode_NDArray(ref: BufferRef | NDArrayRef, buffers: Buffers): NDArray {
+  const {shape, dtype, order} = ref
+
+  let bytes: ArrayBuffer
+  if ("__buffer__" in ref) {
+    const buffer = buffers.get(ref.__buffer__)
+    if (buffer != null)
+      bytes = buffer
+    else
+      throw new Error(`buffer for ${ref.__buffer__} not found`)
+  } else {
+    bytes = base64_to_buffer(ref.__ndarray__)
   }
-  const arr = new (ARRAY_TYPES[specification.dtype])(bytes)
-  if (need_swap) {
-    if (arr.BYTES_PER_ELEMENT === 2) {
-      swap16(arr as Int16Array | Uint16Array)
-    } else if (arr.BYTES_PER_ELEMENT === 4) {
-      swap32(arr as Int32Array | Uint32Array | Float32Array)
-    } else if (arr.BYTES_PER_ELEMENT === 8) {
-      swap64(arr as Float64Array)
+
+  const array = (() => {
+    switch (dtype) {
+      case "uint8":   return new ndarray.Uint8NDArray(bytes, shape)
+      case "int8":    return new ndarray.Int8NDArray(bytes, shape)
+      case "uint16":  return new ndarray.Uint16NDArray(bytes, shape)
+      case "int16":   return new ndarray.Int16NDArray(bytes, shape)
+      case "uint32":  return new ndarray.Uint32NDArray(bytes, shape)
+      case "int32":   return new ndarray.Int32NDArray(bytes, shape)
+      case "float32": return new ndarray.Float32NDArray(bytes, shape)
+      case "float64": return new ndarray.Float64NDArray(bytes, shape)
+    }
+  })()
+
+  if (order !== BYTE_ORDER) {
+    switch (array.BYTES_PER_ELEMENT) {
+      case 2:
+        swap16(array as Int16Array | Uint16Array)
+        break
+      case 4:
+        swap32(array as Int32Array | Uint32Array | Float32Array)
+        break
+      case 8:
+        swap64(array as Float64Array)
+        break
     }
   }
-  return [arr, shape]
+
+  return array
 }
 
-export function process_array(obj: NDArray | BufferSpec | Arrayable, buffers: Buffers): [Arrayable, number[]] {
-  if (isPlainObject(obj) && '__ndarray__' in obj)
-    return decode_base64(obj)
-  else if (isPlainObject(obj) && '__buffer__' in obj)
-    return process_buffer(obj, buffers)
-  else if (isArray(obj) || isTypedArray(obj))
-    return [obj, []]
-  else
-    return undefined as never
-}
-
-export function arrayBufferToBase64(buffer: ArrayBuffer): string {
-  const bytes = new Uint8Array(buffer)
-  const chars = Array.from(bytes).map((b) => String.fromCharCode(b))
-  return btoa(chars.join(""))
-}
-
-export function base64ToArrayBuffer(base64: string): ArrayBuffer {
-  const binary_string = atob(base64)
-  const len = binary_string.length
-  const bytes = new Uint8Array(len)
-  for (let i = 0, end = len; i < end; i++) {
-    bytes[i] = binary_string.charCodeAt(i)
-  }
-  return bytes.buffer
-}
-
-export function decode_base64(input: NDArray): [TypedArray, Shape] {
-  const bytes = base64ToArrayBuffer(input.__ndarray__)
-  const dtype = input.dtype
-  const shape = input.shape!
-
-  let array: TypedArray
-  if (dtype in ARRAY_TYPES)
-    array = new (ARRAY_TYPES[dtype])(bytes)
-  else
-    throw new Error(`unknown dtype: ${dtype}`)
-
-  return [array, shape]
-}
-
-export function encode_base64(array: TypedArray, shape?: Shape): NDArray {
-  const b64 = arrayBufferToBase64(array.buffer)
-  const name = arrayName(array)
-
-  let dtype: DType
-  if (name in DTYPES)
-    dtype = DTYPES[name]
-  else
-    throw new Error(`unknown array type: ${name}`)
-
+export function encode_NDArray(array: NDArray, buffers?: Buffers): BufferRef | NDArrayRef {
   const data = {
-    __ndarray__: b64,
-    shape,
-    dtype,
-  }
-  return data
-}
-
-export type Shapes = {[key: string]: Shape | Shape[] | Shape[][] | Shape[][][]}
-
-export type EncodedData = {[key: string]: NDArray | Arrayable}
-
-function decode_traverse_data(v: unknown[], buffers: Buffers): [Arrayable, any] {
-  // v is just a regular array of scalars
-  if (v.length == 0 || !(isPlainObject(v[0]) || isArray(v[0]))) {
-    return [v, []]
+    order: BYTE_ORDER,
+    dtype: array.dtype,
+    shape: array.shape,
   }
 
-  const arrays: Arrayable[] = []
-  const shapes: Shape[] = []
-
-  for (const obj of v) {
-    const [arr, shape] = isArray(obj) ? decode_traverse_data(obj, buffers)
-                                      : process_array(obj as NDArray, buffers)
-    arrays.push(arr)
-    shapes.push(shape)
+  if (buffers != null) {
+    const __buffer__ = uniqueId()
+    buffers.set(__buffer__, array.buffer)
+    return {__buffer__, ...data}
+  } else {
+    const __ndarray__ = buffer_to_base64(array.buffer)
+    return {__ndarray__, ...data}
   }
-  // If there is a list of empty lists, reduce that to just a list
-  const filtered_shapes = shapes.map((shape) => shape.filter((v) => (v as any).length != 0))
-  return [arrays, filtered_shapes]
-}
-
-export function decode_column_data(data: EncodedData, buffers: Buffers = new Map()): [Data, Shapes] {
-  const new_data: Data = {}
-  const new_shapes: Shapes = {}
-
-  for (const k in data) {
-
-    // might be array of scalars, or might be ragged array or arrays
-    const v = data[k]
-    if (isArray(v)) {
-      // v is just a regular array of scalars
-      if (v.length == 0 || !(isPlainObject(v[0]) || isArray(v[0]))) {
-        new_data[k] = v
-        continue
-      }
-      // v is a ragged array of arrays
-      const [arrays, shapes] = decode_traverse_data(v, buffers)
-      new_data[k] = arrays
-      new_shapes[k] = shapes
-
-    // must be object or array (single array case)
-    } else {
-      const [arr, shape] = process_array(v, buffers)
-      new_data[k] = arr
-      new_shapes[k] = shape
-    }
-  }
-
-  return [new_data, new_shapes]
-}
-
-function encode_traverse_data(v: unknown[], shapes?: any) {
-  const new_array: any[] = []
-  for (let i = 0, end = v.length; i < end; i++) {
-    const item = v[i]
-    if (isTypedArray(item)) {
-      const shape = shapes[i] ? shapes[i] : undefined
-      new_array.push(encode_base64(item, shape))
-    } else if (isArray(item)) {
-      new_array.push(encode_traverse_data(item, shapes ? shapes[i] : []))
-    } else
-      new_array.push(item)
-  }
-  return new_array
-}
-
-export function encode_column_data(data: Data, shapes?: Shapes): EncodedData {
-  const new_data: EncodedData = {}
-  for (const k in data) {
-    const v = data[k]
-    const shapes_k = shapes != null ? shapes[k] as Shape : undefined
-    let new_v: NDArray | Arrayable
-    if (isTypedArray(v)) {
-      new_v = encode_base64(v, shapes_k)
-    } else if (isArray(v)) {
-      new_v = encode_traverse_data(v, shapes_k || [])
-    } else
-      new_v = v
-    new_data[k] = new_v
-  }
-  return new_data
 }

--- a/bokehjs/src/lib/core/util/serialization.ts
+++ b/bokehjs/src/lib/core/util/serialization.ts
@@ -2,7 +2,6 @@ import {ID} from "../types"
 import {isPlainObject} from "./types"
 import {is_little_endian} from "./compat"
 import {DataType, NDArray} from "./ndarray"
-import {uniqueId} from "./string"
 import * as ndarray from "./ndarray"
 
 export function buffer_to_base64(buffer: ArrayBuffer): string {
@@ -138,7 +137,7 @@ export function encode_NDArray(array: NDArray, buffers?: Buffers): BufferRef | N
   }
 
   if (buffers != null) {
-    const __buffer__ = uniqueId()
+    const __buffer__ = `${buffers.size}`
     buffers.set(__buffer__, array.buffer)
     return {__buffer__, ...data}
   } else {

--- a/bokehjs/src/lib/document/events.ts
+++ b/bokehjs/src/lib/document/events.ts
@@ -50,7 +50,7 @@ export interface ColumnsStreamed {
 export interface ColumnsPatched {
   kind: "ColumnsPatched"
   column_source: Ref
-  patches: PatchSet
+  patches: PatchSet<unknown>
 }
 
 export type DocumentChanged =
@@ -77,7 +77,7 @@ export class MessageSentEvent extends DocumentChangedEvent {
 
   json(_references: Set<HasProps>): DocumentChanged {
     const value = this.msg_data
-    const value_json = HasProps._value_to_json("", value, null)
+    const value_json = HasProps._value_to_json(value)
     const value_refs = new Set<HasProps>()
     HasProps._value_record_references(value, value_refs, {recursive: true})
     /* XXX: this will cause all referenced models to be reinitialized
@@ -114,7 +114,7 @@ export class ModelChangedEvent extends DocumentChangedEvent {
       return this.hint.json(references)
 
     const value = this.new_
-    const value_json = HasProps._value_to_json(this.attr, value, this.model)
+    const value_json = HasProps._value_to_json(value)
     const value_refs = new Set<HasProps>()
     HasProps._value_record_references(value, value_refs, {recursive: true})
     if (value_refs.has(this.model) && this.model !== value) {
@@ -138,7 +138,7 @@ export class ColumnsPatchedEvent extends DocumentChangedEvent {
 
   constructor(document: Document,
       readonly column_source: Ref,
-      readonly patches: PatchSet) {
+      readonly patches: PatchSet<unknown>) {
     super(document)
   }
 

--- a/bokehjs/src/lib/models/glyphs/image_base.ts
+++ b/bokehjs/src/lib/models/glyphs/image_base.ts
@@ -6,15 +6,14 @@ import {Selection, ImageIndex} from "../selections/selection"
 import {PointGeometry} from "core/geometry"
 import {SpatialIndex} from "core/util/spatial"
 import {concat} from "core/util/array"
+import {NDArray, is_NDArray} from "core/util/ndarray"
 
 export interface ImageDataBase extends XYGlyphData {
   image_data: HTMLCanvasElement[]
 
-  _image: (Arrayable<number> | number[][])[]
+  _image: (NDArray | number[][])[]
   _dw: Arrayable<number>
   _dh: Arrayable<number>
-
-  _image_shape?: [number, number][]
 
   sw: Arrayable<number>
   sh: Arrayable<number>
@@ -67,20 +66,19 @@ export abstract class ImageBaseView extends XYGlyphView {
       if (indices != null && indices.indexOf(i) < 0)
         continue
 
-      let img: Arrayable<number>
-      if (this._image_shape != null && this._image_shape[i].length > 0) {
-        img = this._image[i] as Arrayable<number>
-        const shape = this._image_shape[i]
-        this._height[i] = shape[0]
-        this._width[i] = shape[1]
+      const img = this._image[i]
+      let flat_img: Arrayable<number>
+      if (is_NDArray(img)) {
+        flat_img = img
+        this._height[i] = img.shape[0]
+        this._width[i] = img.shape[1]
       } else {
-        const _image = this._image[i] as number[][]
-        img = concat(_image)
-        this._height[i] = _image.length
-        this._width[i] = _image[0].length
+        flat_img = concat(img)
+        this._height[i] = img.length
+        this._width[i] = img[0].length
       }
 
-      const buf8 = this._flat_img_to_buf8(img)
+      const buf8 = this._flat_img_to_buf8(flat_img)
       this._set_image_data_from_buffer(i, buf8)
     }
   }

--- a/bokehjs/src/lib/models/sources/columnar_data_source.ts
+++ b/bokehjs/src/lib/models/sources/columnar_data_source.ts
@@ -7,7 +7,6 @@ import {Arrayable, ArrayableNew} from "core/types"
 import {isArray} from "core/util/types"
 import {uniq, range} from "core/util/array"
 import {keys, values} from "core/util/object"
-import {Shape} from "core/util/serialization"
 import {Selection} from "../selections/selection"
 import {SelectionPolicy, UnionRenderers} from "../selections/interaction_policy"
 
@@ -22,7 +21,6 @@ export namespace ColumnarDataSource {
     selection_policy: p.Property<SelectionPolicy>
     selection_manager: p.Property<SelectionManager>
     inspected: p.Property<Selection>
-    _shapes: p.Property<{[key: string]: Shape | Shape[] | Shape[][] | Shape[][][]}>
   }
 }
 
@@ -62,7 +60,6 @@ export abstract class ColumnarDataSource extends DataSource {
     this.internal({
       selection_manager: [ p.Instance, (self: ColumnarDataSource) => new SelectionManager({source: self}) ],
       inspected:         [ p.Instance, () => new Selection() ],
-      _shapes:           [ p.Any, {}],
     })
   }
 

--- a/bokehjs/test/unit/core/has_props.ts
+++ b/bokehjs/test/unit/core/has_props.ts
@@ -5,6 +5,7 @@ import {HasProps} from "@bokehjs/core/has_props"
 import * as mixins from "@bokehjs/core/property_mixins"
 import * as p from "@bokehjs/core/properties"
 import {keys} from "@bokehjs/core/util/object"
+import {ndarray} from "@bokehjs/core/util/ndarray"
 
 class TestModel extends HasProps {}
 
@@ -126,23 +127,24 @@ describe("has_properties module", () => {
     })
 
     it("should collect shapes when they are present", () => {
-      const r = new ColumnDataSource({data: {colname: [1, 2, 3, 4]}})
-      r._shapes.colname = [2, 2]
+      const array = ndarray([1, 2, 3, 4], {shape: [2, 2]})
+      const r = new ColumnDataSource({data: {colname: array}})
       const obj = new SubclassWithNumberSpec()
       const data = obj.materialize_dataspecs(r)
-      expect(data).to.be.deep.equal({_foo: [1, 2, 3, 4], _foo_shape: [2, 2]})
+      expect(data).to.be.deep.equal({_foo: ndarray([1, 2, 3, 4], {shape: [2, 2]})})
     })
 
     it("should collect max vals for distance specs", () => {
-      const r = new ColumnDataSource({data: {colname: [1, 2, 3, 4, 2]}})
+      const r0 = new ColumnDataSource({data: {colname: [1, 2, 3, 4, 2]}})
       const obj = new SubclassWithDistanceSpec()
 
-      const data0 = obj.materialize_dataspecs(r)
+      const data0 = obj.materialize_dataspecs(r0)
       expect(data0).to.be.deep.equal({_foo: [1, 2, 3, 4, 2], max_foo: 4})
 
-      r._shapes.colname = [2, 2]
-      const data1 = obj.materialize_dataspecs(r)
-      expect(data1).to.be.deep.equal({_foo: [1, 2, 3, 4, 2], _foo_shape: [2, 2], max_foo: 4})
+      const array1 = ndarray([1, 2, 3, 4, 2], {shape: [2, 2]})
+      const r1 = new ColumnDataSource({data: {colname: array1}})
+      const data1 = obj.materialize_dataspecs(r1)
+      expect(data1).to.be.deep.equal({_foo: ndarray([1, 2, 3, 4, 2], {shape: [2, 2]}), max_foo: 4})
     })
 
     it("should collect ignore optional specs with null values", () => {

--- a/bokehjs/test/unit/core/util/index.ts
+++ b/bokehjs/test/unit/core/util/index.ts
@@ -1,3 +1,4 @@
+import "./ndarray"
 import "./array"
 import "./arrayable"
 import "./typed_array"

--- a/bokehjs/test/unit/core/util/ndarray.ts
+++ b/bokehjs/test/unit/core/util/ndarray.ts
@@ -1,0 +1,413 @@
+import {expect} from "chai"
+
+import {
+  ndarray, is_NDArray,
+  Uint8NDArray, Int8NDArray,
+  Uint16NDArray, Int16NDArray,
+  Uint32NDArray, Int32NDArray,
+  Float32NDArray, Float64NDArray,
+} from "@bokehjs/core/util/ndarray"
+
+describe("core/util/ndarray module", () => {
+
+  it("should support is_NDArray predicate", () => {
+    const nd0 = new Uint8NDArray([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(nd0)).to.be.true
+    const nd1 = new Int8NDArray([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(nd1)).to.be.true
+    const nd2 = new Uint16NDArray([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(nd2)).to.be.true
+    const nd3 = new Int16NDArray([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(nd3)).to.be.true
+    const nd4 = new Uint32NDArray([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(nd4)).to.be.true
+    const nd5 = new Int32NDArray([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(nd5)).to.be.true
+    const nd6 = new Float32NDArray([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(nd6)).to.be.true
+    const nd7 = new Float64NDArray([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(nd7)).to.be.true
+
+    const a0 = new Uint8Array([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(a0)).to.be.false
+    const a1 = new Int8Array([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(a1)).to.be.false
+    const a2 = new Uint16Array([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(a2)).to.be.false
+    const a3 = new Int16Array([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(a3)).to.be.false
+    const a4 = new Uint32Array([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(a4)).to.be.false
+    const a5 = new Int32Array([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(a5)).to.be.false
+    const a6 = new Float32Array([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(a6)).to.be.false
+    const a7 = new Float64Array([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(a7)).to.be.false
+
+    expect(is_NDArray([1, 2, 3, 4, 5, 6])).to.be.false
+  })
+
+  it("should support Uint8NDArray", () => {
+    const nd0 = new Uint8NDArray([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(nd0)).to.be.true
+    expect(nd0.dtype).to.be.equal("uint8")
+    expect(nd0.shape).to.be.deep.equal([6])
+    expect(nd0.length).to.be.equal(6)
+
+    const nd1 = new Uint8NDArray([1, 2, 3, 4, 5, 6], [2, 3])
+    expect(is_NDArray(nd1)).to.be.true
+    expect(nd1.dtype).to.be.equal("uint8")
+    expect(nd1.shape).to.be.deep.equal([2, 3])
+    expect(nd1.length).to.be.equal(6)
+
+    const nd2 = new Uint8NDArray(nd1, [3, 2])
+    expect(is_NDArray(nd2)).to.be.true
+    expect(nd2.dtype).to.be.equal("uint8")
+    expect(nd2.shape).to.be.deep.equal([3, 2])
+    expect(nd2.length).to.be.equal(6)
+
+    const a3 = new Uint8Array(6)
+    const nd3 = new Uint8NDArray(a3, [2, 3])
+    expect(is_NDArray(nd3)).to.be.true
+    expect(nd3.dtype).to.be.equal("uint8")
+    expect(nd3.shape).to.be.deep.equal([2, 3])
+    expect(nd3.length).to.be.equal(6)
+
+    const b4 = new ArrayBuffer(1*6)
+    const nd4 = new Uint8NDArray(b4, [2, 3])
+    expect(is_NDArray(nd4)).to.be.true
+    expect(nd4.dtype).to.be.equal("uint8")
+    expect(nd4.shape).to.be.deep.equal([2, 3])
+    expect(nd4.length).to.be.equal(6)
+  })
+
+  it("should support Uint16NDArray", () => {
+    const nd0 = new Uint16NDArray([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(nd0)).to.be.true
+    expect(nd0.dtype).to.be.equal("uint16")
+    expect(nd0.shape).to.be.deep.equal([6])
+    expect(nd0.length).to.be.equal(6)
+
+    const nd1 = new Uint16NDArray([1, 2, 3, 4, 5, 6], [2, 3])
+    expect(is_NDArray(nd1)).to.be.true
+    expect(nd1.dtype).to.be.equal("uint16")
+    expect(nd1.shape).to.be.deep.equal([2, 3])
+    expect(nd1.length).to.be.equal(6)
+
+    const nd2 = new Uint16NDArray(nd1, [3, 2])
+    expect(is_NDArray(nd2)).to.be.true
+    expect(nd2.dtype).to.be.equal("uint16")
+    expect(nd2.shape).to.be.deep.equal([3, 2])
+    expect(nd2.length).to.be.equal(6)
+
+    const a3 = new Uint16Array(6)
+    const nd3 = new Uint16NDArray(a3, [2, 3])
+    expect(is_NDArray(nd3)).to.be.true
+    expect(nd3.dtype).to.be.equal("uint16")
+    expect(nd3.shape).to.be.deep.equal([2, 3])
+    expect(nd3.length).to.be.equal(6)
+
+    const b4 = new ArrayBuffer(2*6)
+    const nd4 = new Uint16NDArray(b4, [2, 3])
+    expect(is_NDArray(nd4)).to.be.true
+    expect(nd4.dtype).to.be.equal("uint16")
+    expect(nd4.shape).to.be.deep.equal([2, 3])
+    expect(nd4.length).to.be.equal(6)
+  })
+
+  it("should support Uint32NDArray", () => {
+    const nd0 = new Uint32NDArray([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(nd0)).to.be.true
+    expect(nd0.dtype).to.be.equal("uint32")
+    expect(nd0.shape).to.be.deep.equal([6])
+    expect(nd0.length).to.be.equal(6)
+
+    const nd1 = new Uint32NDArray([1, 2, 3, 4, 5, 6], [2, 3])
+    expect(is_NDArray(nd1)).to.be.true
+    expect(nd1.dtype).to.be.equal("uint32")
+    expect(nd1.shape).to.be.deep.equal([2, 3])
+    expect(nd1.length).to.be.equal(6)
+
+    const nd2 = new Uint32NDArray(nd1, [3, 2])
+    expect(is_NDArray(nd2)).to.be.true
+    expect(nd2.dtype).to.be.equal("uint32")
+    expect(nd2.shape).to.be.deep.equal([3, 2])
+    expect(nd2.length).to.be.equal(6)
+
+    const a3 = new Uint32Array(6)
+    const nd3 = new Uint32NDArray(a3, [2, 3])
+    expect(is_NDArray(nd3)).to.be.true
+    expect(nd3.dtype).to.be.equal("uint32")
+    expect(nd3.shape).to.be.deep.equal([2, 3])
+    expect(nd3.length).to.be.equal(6)
+
+    const b4 = new ArrayBuffer(4*6)
+    const nd4 = new Uint32NDArray(b4, [2, 3])
+    expect(is_NDArray(nd4)).to.be.true
+    expect(nd4.dtype).to.be.equal("uint32")
+    expect(nd4.shape).to.be.deep.equal([2, 3])
+    expect(nd4.length).to.be.equal(6)
+  })
+
+  it("should support Int8NDArray", () => {
+    const nd0 = new Int8NDArray([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(nd0)).to.be.true
+    expect(nd0.dtype).to.be.equal("int8")
+    expect(nd0.shape).to.be.deep.equal([6])
+    expect(nd0.length).to.be.equal(6)
+
+    const nd1 = new Int8NDArray([1, 2, 3, 4, 5, 6], [2, 3])
+    expect(is_NDArray(nd1)).to.be.true
+    expect(nd1.dtype).to.be.equal("int8")
+    expect(nd1.shape).to.be.deep.equal([2, 3])
+    expect(nd1.length).to.be.equal(6)
+
+    const nd2 = new Int8NDArray(nd1, [3, 2])
+    expect(is_NDArray(nd2)).to.be.true
+    expect(nd2.dtype).to.be.equal("int8")
+    expect(nd2.shape).to.be.deep.equal([3, 2])
+    expect(nd2.length).to.be.equal(6)
+
+    const a3 = new Int8Array(6)
+    const nd3 = new Int8NDArray(a3, [2, 3])
+    expect(is_NDArray(nd3)).to.be.true
+    expect(nd3.dtype).to.be.equal("int8")
+    expect(nd3.shape).to.be.deep.equal([2, 3])
+    expect(nd3.length).to.be.equal(6)
+
+    const b4 = new ArrayBuffer(1*6)
+    const nd4 = new Int8NDArray(b4, [2, 3])
+    expect(is_NDArray(nd4)).to.be.true
+    expect(nd4.dtype).to.be.equal("int8")
+    expect(nd4.shape).to.be.deep.equal([2, 3])
+    expect(nd4.length).to.be.equal(6)
+  })
+
+  it("should support Int16NDArray", () => {
+    const nd0 = new Int16NDArray([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(nd0)).to.be.true
+    expect(nd0.dtype).to.be.equal("int16")
+    expect(nd0.shape).to.be.deep.equal([6])
+    expect(nd0.length).to.be.equal(6)
+
+    const nd1 = new Int16NDArray([1, 2, 3, 4, 5, 6], [2, 3])
+    expect(is_NDArray(nd1)).to.be.true
+    expect(nd1.dtype).to.be.equal("int16")
+    expect(nd1.shape).to.be.deep.equal([2, 3])
+    expect(nd1.length).to.be.equal(6)
+
+    const nd2 = new Int16NDArray(nd1, [3, 2])
+    expect(is_NDArray(nd2)).to.be.true
+    expect(nd2.dtype).to.be.equal("int16")
+    expect(nd2.shape).to.be.deep.equal([3, 2])
+    expect(nd2.length).to.be.equal(6)
+
+    const a3 = new Int16Array(6)
+    const nd3 = new Int16NDArray(a3, [2, 3])
+    expect(is_NDArray(nd3)).to.be.true
+    expect(nd3.dtype).to.be.equal("int16")
+    expect(nd3.shape).to.be.deep.equal([2, 3])
+    expect(nd3.length).to.be.equal(6)
+
+    const b4 = new ArrayBuffer(2*6)
+    const nd4 = new Int16NDArray(b4, [2, 3])
+    expect(is_NDArray(nd4)).to.be.true
+    expect(nd4.dtype).to.be.equal("int16")
+    expect(nd4.shape).to.be.deep.equal([2, 3])
+    expect(nd4.length).to.be.equal(6)
+  })
+
+  it("should support Int32NDArray", () => {
+    const nd0 = new Int32NDArray([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(nd0)).to.be.true
+    expect(nd0.dtype).to.be.equal("int32")
+    expect(nd0.shape).to.be.deep.equal([6])
+    expect(nd0.length).to.be.equal(6)
+
+    const nd1 = new Int32NDArray([1, 2, 3, 4, 5, 6], [2, 3])
+    expect(is_NDArray(nd1)).to.be.true
+    expect(nd1.dtype).to.be.equal("int32")
+    expect(nd1.shape).to.be.deep.equal([2, 3])
+    expect(nd1.length).to.be.equal(6)
+
+    const nd2 = new Int32NDArray(nd1, [3, 2])
+    expect(is_NDArray(nd2)).to.be.true
+    expect(nd2.dtype).to.be.equal("int32")
+    expect(nd2.shape).to.be.deep.equal([3, 2])
+    expect(nd2.length).to.be.equal(6)
+
+    const a3 = new Int32Array(6)
+    const nd3 = new Int32NDArray(a3, [2, 3])
+    expect(is_NDArray(nd3)).to.be.true
+    expect(nd3.dtype).to.be.equal("int32")
+    expect(nd3.shape).to.be.deep.equal([2, 3])
+    expect(nd3.length).to.be.equal(6)
+
+    const b4 = new ArrayBuffer(4*6)
+    const nd4 = new Int32NDArray(b4, [2, 3])
+    expect(is_NDArray(nd4)).to.be.true
+    expect(nd4.dtype).to.be.equal("int32")
+    expect(nd4.shape).to.be.deep.equal([2, 3])
+    expect(nd4.length).to.be.equal(6)
+  })
+
+  it("should support Float32NDArray", () => {
+    const nd0 = new Float32NDArray([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(nd0)).to.be.true
+    expect(nd0.dtype).to.be.equal("float32")
+    expect(nd0.shape).to.be.deep.equal([6])
+    expect(nd0.length).to.be.equal(6)
+
+    const nd1 = new Float32NDArray([1, 2, 3, 4, 5, 6], [2, 3])
+    expect(is_NDArray(nd1)).to.be.true
+    expect(nd1.dtype).to.be.equal("float32")
+    expect(nd1.shape).to.be.deep.equal([2, 3])
+    expect(nd1.length).to.be.equal(6)
+
+    const nd2 = new Float32NDArray(nd1, [3, 2])
+    expect(is_NDArray(nd2)).to.be.true
+    expect(nd2.dtype).to.be.equal("float32")
+    expect(nd2.shape).to.be.deep.equal([3, 2])
+    expect(nd2.length).to.be.equal(6)
+
+    const a3 = new Float32Array(6)
+    const nd3 = new Float32NDArray(a3, [2, 3])
+    expect(is_NDArray(nd3)).to.be.true
+    expect(nd3.dtype).to.be.equal("float32")
+    expect(nd3.shape).to.be.deep.equal([2, 3])
+    expect(nd3.length).to.be.equal(6)
+
+    const b4 = new ArrayBuffer(4*6)
+    const nd4 = new Float32NDArray(b4, [2, 3])
+    expect(is_NDArray(nd4)).to.be.true
+    expect(nd4.dtype).to.be.equal("float32")
+    expect(nd4.shape).to.be.deep.equal([2, 3])
+    expect(nd4.length).to.be.equal(6)
+  })
+
+  it("should support Float64NDArray", () => {
+    const nd0 = new Float64NDArray([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(nd0)).to.be.true
+    expect(nd0.dtype).to.be.equal("float64")
+    expect(nd0.shape).to.be.deep.equal([6])
+    expect(nd0.length).to.be.equal(6)
+
+    const nd1 = new Float64NDArray([1, 2, 3, 4, 5, 6], [2, 3])
+    expect(is_NDArray(nd1)).to.be.true
+    expect(nd1.dtype).to.be.equal("float64")
+    expect(nd1.shape).to.be.deep.equal([2, 3])
+    expect(nd1.length).to.be.equal(6)
+
+    const nd2 = new Float64NDArray(nd1, [3, 2])
+    expect(is_NDArray(nd2)).to.be.true
+    expect(nd2.dtype).to.be.equal("float64")
+    expect(nd2.shape).to.be.deep.equal([3, 2])
+    expect(nd2.length).to.be.equal(6)
+
+    const a3 = new Float64Array(6)
+    const nd3 = new Float64NDArray(a3, [2, 3])
+    expect(is_NDArray(nd3)).to.be.true
+    expect(nd3.dtype).to.be.equal("float64")
+    expect(nd3.shape).to.be.deep.equal([2, 3])
+    expect(nd3.length).to.be.equal(6)
+
+    const b4 = new ArrayBuffer(8*6)
+    const nd4 = new Float64NDArray(b4, [2, 3])
+    expect(is_NDArray(nd4)).to.be.true
+    expect(nd4.dtype).to.be.equal("float64")
+    expect(nd4.shape).to.be.deep.equal([2, 3])
+    expect(nd4.length).to.be.equal(6)
+  })
+
+  it("should support ndarray() function", () => {
+    const nd0 = ndarray([1, 2, 3, 4, 5, 6])
+    expect(is_NDArray(nd0)).to.be.true
+    expect(nd0.dtype).to.be.equal("float64")
+    expect(nd0.shape).to.be.deep.equal([6])
+  })
+
+  it("should support ndarray() function's dtype argument", () => {
+    const nd0 = ndarray([1, 2, 3, 4, 5, 6], {dtype: "uint8"})
+    expect(is_NDArray(nd0)).to.be.true
+    expect(nd0.dtype).to.be.equal("uint8")
+    expect(nd0.shape).to.be.deep.equal([6])
+
+    const nd1 = ndarray([1, 2, 3, 4, 5, 6], {dtype: "uint16"})
+    expect(is_NDArray(nd1)).to.be.true
+    expect(nd1.dtype).to.be.equal("uint16")
+    expect(nd1.shape).to.be.deep.equal([6])
+
+    const nd2 = ndarray([1, 2, 3, 4, 5, 6], {dtype: "uint32"})
+    expect(is_NDArray(nd2)).to.be.true
+    expect(nd2.dtype).to.be.equal("uint32")
+    expect(nd2.shape).to.be.deep.equal([6])
+
+    const nd3 = ndarray([1, 2, 3, 4, 5, 6], {dtype: "int8"})
+    expect(is_NDArray(nd3)).to.be.true
+    expect(nd3.dtype).to.be.equal("int8")
+    expect(nd3.shape).to.be.deep.equal([6])
+
+    const nd4 = ndarray([1, 2, 3, 4, 5, 6], {dtype: "int16"})
+    expect(is_NDArray(nd4)).to.be.true
+    expect(nd4.dtype).to.be.equal("int16")
+    expect(nd4.shape).to.be.deep.equal([6])
+
+    const nd5 = ndarray([1, 2, 3, 4, 5, 6], {dtype: "int32"})
+    expect(is_NDArray(nd5)).to.be.true
+    expect(nd5.dtype).to.be.equal("int32")
+    expect(nd5.shape).to.be.deep.equal([6])
+
+    const nd6 = ndarray([1, 2, 3, 4, 5, 6], {dtype: "float32"})
+    expect(is_NDArray(nd6)).to.be.true
+    expect(nd6.dtype).to.be.equal("float32")
+    expect(nd6.shape).to.be.deep.equal([6])
+
+    const nd7 = ndarray([1, 2, 3, 4, 5, 6], {dtype: "float64"})
+    expect(is_NDArray(nd7)).to.be.true
+    expect(nd7.dtype).to.be.equal("float64")
+    expect(nd7.shape).to.be.deep.equal([6])
+  })
+
+  it("should support ndarray() function's shape argument", () => {
+    const nd0 = ndarray([1, 2, 3, 4, 5, 6], {dtype: "uint8", shape: [2, 3]})
+    expect(is_NDArray(nd0)).to.be.true
+    expect(nd0.dtype).to.be.equal("uint8")
+    expect(nd0.shape).to.be.deep.equal([2, 3])
+
+    const nd1 = ndarray([1, 2, 3, 4, 5, 6], {dtype: "uint16", shape: [2, 3]})
+    expect(is_NDArray(nd1)).to.be.true
+    expect(nd1.dtype).to.be.equal("uint16")
+    expect(nd1.shape).to.be.deep.equal([2, 3])
+
+    const nd2 = ndarray([1, 2, 3, 4, 5, 6], {dtype: "uint32", shape: [2, 3]})
+    expect(is_NDArray(nd2)).to.be.true
+    expect(nd2.dtype).to.be.equal("uint32")
+    expect(nd2.shape).to.be.deep.equal([2, 3])
+
+    const nd3 = ndarray([1, 2, 3, 4, 5, 6], {dtype: "int8", shape: [2, 3]})
+    expect(is_NDArray(nd3)).to.be.true
+    expect(nd3.dtype).to.be.equal("int8")
+    expect(nd3.shape).to.be.deep.equal([2, 3])
+
+    const nd4 = ndarray([1, 2, 3, 4, 5, 6], {dtype: "int16", shape: [2, 3]})
+    expect(is_NDArray(nd4)).to.be.true
+    expect(nd4.dtype).to.be.equal("int16")
+    expect(nd4.shape).to.be.deep.equal([2, 3])
+
+    const nd5 = ndarray([1, 2, 3, 4, 5, 6], {dtype: "int32", shape: [2, 3]})
+    expect(is_NDArray(nd5)).to.be.true
+    expect(nd5.dtype).to.be.equal("int32")
+    expect(nd5.shape).to.be.deep.equal([2, 3])
+
+    const nd6 = ndarray([1, 2, 3, 4, 5, 6], {dtype: "float32", shape: [2, 3]})
+    expect(is_NDArray(nd6)).to.be.true
+    expect(nd6.dtype).to.be.equal("float32")
+    expect(nd6.shape).to.be.deep.equal([2, 3])
+
+    const nd7 = ndarray([1, 2, 3, 4, 5, 6], {dtype: "float64", shape: [2, 3]})
+    expect(is_NDArray(nd7)).to.be.true
+    expect(nd7.dtype).to.be.equal("float64")
+    expect(nd7.shape).to.be.deep.equal([2, 3])
+  })
+})

--- a/bokehjs/test/unit/core/util/serialization.ts
+++ b/bokehjs/test/unit/core/util/serialization.ts
@@ -1,7 +1,6 @@
 import {expect} from "chai"
 
 import * as ser from "@bokehjs/core/util/serialization"
-import {isObject} from "@bokehjs/core/util/types"
 
 const GOOD_TYPES = [
   Float32Array, Float64Array, Uint8Array, Int8Array,
@@ -9,31 +8,6 @@ const GOOD_TYPES = [
 ]
 
 describe("serialization module", () => {
-
-  describe("ARRAY_TYPES", () => {
-
-    it("should map to all available typed array types", () => {
-      const expected  = {
-        float32: Float32Array,
-        float64: Float64Array,
-        uint8: Uint8Array,
-        int8: Int8Array,
-        uint16: Uint16Array,
-        int16: Int16Array,
-        uint32: Uint32Array,
-        int32: Int32Array,
-      }
-      expect(ser.ARRAY_TYPES).to.be.deep.equal(expected)
-    })
-  })
-
-  describe("DTYPES", () => {
-    for (const typ of GOOD_TYPES) {
-      it(`should map ${typ.name} type names to ${ser.DTYPES[typ.name as ser.ArrayName]}`, () => {
-        expect(ser.ARRAY_TYPES[ser.DTYPES[typ.name as ser.ArrayName]]).to.be.equal(typ)
-      })
-    }
-  })
 
   describe("BYTE_ORDER", () => {
     it("should be big or little", () => {
@@ -120,180 +94,12 @@ describe("serialization module", () => {
         }
 
         const b = new typ(a)
-        const b64 = ser.arrayBufferToBase64(b.buffer)
+        const b64 = ser.buffer_to_base64(b.buffer)
         expect(typeof b64).to.be.equal("string")
-        const buf = ser.base64ToArrayBuffer(b64)
+        const buf = ser.base64_to_buffer(b64)
         const c = new typ(buf)
         expect(c).to.be.deep.equal(b)
       })
     }
-  })
-
-  describe("encode/decode base64 functions", () => {
-
-    for (const typ of GOOD_TYPES) {
-      it(`should roundtrip ${typ.name} arrays`, () => {
-        const array = new typ([1, 2])
-        const shape = [2]
-        const e = ser.encode_base64(array, shape)
-        expect(isObject(e)).to.be.true
-        expect(Object.keys(e).length).to.be.equal(3)
-        expect(e.dtype).to.equal(ser.DTYPES[typ.name as ser.ArrayName])
-        expect(e.shape).to.be.deep.equal([2])
-
-        const [d, s] = ser.decode_base64(e)
-        expect(array).to.be.deep.equal(d)
-        expect(shape).to.be.deep.equal(s)
-      })
-    }
-  })
-
-  describe("decode_column_data", () => {
-
-    it("should encode typed column data source", () => {
-      const data = {
-        x: new Float64Array([1, 2]),
-        y: new Float64Array([1.1, 2.2]),
-      }
-      const shapes = {
-        x: [2],
-        y: [2],
-      }
-      const e = ser.encode_column_data(data, shapes)
-      const [d, s] = ser.decode_column_data(e)
-      expect(data).to.be.deep.equal(d)
-      expect(shapes).to.be.deep.equal(s)
-    })
-
-    it("should encode nested typed column data source", () => {
-      const data = {
-        x: [new Float64Array([1, 2]), new Float64Array([2, 3])],
-        y: [new Float64Array([1.1, 2.2]), new Float64Array([3.3, 4.4])],
-      }
-      const shapes = {
-        x: [[2], [2]],
-        y: [[2], [2]],
-      }
-      const e = ser.encode_column_data(data, shapes)
-      const [d, s] = ser.decode_column_data(e)
-      expect(data).to.be.deep.equal(d)
-      expect(shapes).to.be.deep.equal(s)
-    })
-
-    it("should encode mixed type column data source", () => {
-      const data = {
-        x: new Float64Array([1, 2]),
-        y: [2.2, 3.3],
-      }
-      const shapes = {x: [2]}
-      const e = ser.encode_column_data(data, shapes)
-      const [d, s] = ser.decode_column_data(e)
-      expect(data).to.be.deep.equal(d)
-      expect(shapes).to.be.deep.equal(s)
-    })
-
-    it("should encode deeply nested typed column data source", () => {
-      const data = {
-        x: [[[new Float64Array([1, 2])]], [[new Float64Array([2, 3])]]],
-        y: [[[new Float64Array([1.1, 2.2])]], [[new Float64Array([3.3, 4.4])]]],
-      }
-      const shapes = {
-        x: [[[[2]]], [[[2]]]],
-        y: [[[[2]]], [[[2]]]],
-      }
-      const e = ser.encode_column_data(data, shapes)
-      const [d, s] = ser.decode_column_data(e)
-      expect(data).to.be.deep.equal(d)
-      expect(shapes).to.be.deep.equal(s)
-    })
-
-    it("should encode deeply nested typed mixed type column data source", () => {
-      const data = {
-        x: [[[[1, 2]]], [[new Float64Array([2, 3])]]],
-        y: [[[[1.1, 2.2]]], [[new Float64Array([3.3, 4.4])]]],
-      }
-      const shapes = {
-        x: [[], [[[2]]]],
-        y: [[], [[[2]]]],
-      }
-      const e = ser.encode_column_data(data, shapes)
-      const [d, s] = ser.decode_column_data(e)
-      expect(data).to.be.deep.equal(d)
-      expect(shapes).to.be.deep.equal(s)
-    })
-
-  })
-
-  describe("encode_column_data", () => {
-
-    for (const typ of GOOD_TYPES) {
-      it(`should encode ${typ.name} array columns`, () => {
-        const data = {a: new typ([1, 2]), b: [10, 20]}
-        const enc = ser.encode_column_data(data)
-        expect(enc.b).to.be.deep.equal([10, 20])
-        expect(enc.a).to.be.deep.equal({
-          __ndarray__: ser.arrayBufferToBase64(data.a.buffer),
-          shape: undefined,
-          dtype: ser.DTYPES[typ.name as ser.ArrayName],
-        })
-      })
-    }
-
-    for (const typ of GOOD_TYPES) {
-      it(`should encode ragged ${typ.name} array columns`, () => {
-        const data = {a: [new typ([1, 2]), new typ([1, 2])], b: [10, 20]}
-        const enc = ser.encode_column_data(data)
-        expect(enc.b).to.be.deep.equal([10, 20])
-        expect(enc.a).to.be.deep.equal([{
-          __ndarray__: ser.arrayBufferToBase64(data.a[0].buffer),
-          shape: undefined,
-          dtype: ser.DTYPES[typ.name as ser.ArrayName],
-        }, {
-          __ndarray__: ser.arrayBufferToBase64(data.a[1].buffer),
-          shape: undefined,
-          dtype: ser.DTYPES[typ.name as ser.ArrayName],
-        }])
-      })
-    }
-
-    for (const typ of GOOD_TYPES) {
-      it(`should encode ${typ.name} array columns with shapes`, () => {
-        const data1 = {a: new typ([1, 2, 3, 4]), b: [10, 20]}
-        const enc1 = ser.encode_column_data(data1, {a: [2, 2]})
-        expect(enc1.b).to.be.deep.equal([10, 20])
-        expect(enc1.a).to.be.deep.equal({
-          __ndarray__: ser.arrayBufferToBase64(data1.a.buffer),
-          shape: [2, 2],
-          dtype: ser.DTYPES[typ.name as ser.ArrayName],
-        })
-
-        const data2 = {a: [new typ([1, 2]), new typ([1, 2])], b: [10, 20]}
-        const enc2 = ser.encode_column_data(data2, {a: [[1, 2], [2, 1]]})
-        expect(enc2.b).to.be.deep.equal([10, 20])
-        expect(enc2.a).to.be.deep.equal([{
-          __ndarray__: ser.arrayBufferToBase64(data2.a[0].buffer),
-          shape: [1, 2],
-          dtype: ser.DTYPES[typ.name as ser.ArrayName],
-        }, {
-          __ndarray__: ser.arrayBufferToBase64(data2.a[1].buffer),
-          shape: [2, 1],
-          dtype: ser.DTYPES[typ.name as ser.ArrayName],
-        }])
-      })
-    }
-  })
-
-  describe("process_array", () => {
-    it("should return arrays as-is", () => {
-      const arr = [1, 2, 3.4]
-      expect(ser.process_array(arr, new Map())).to.be.deep.equal([arr, []])
-    })
-
-    it("should return typed arrays as-is", () => {
-      for (const typ of GOOD_TYPES) {
-        const arr = new typ([1, 2, 3.4])
-        expect(ser.process_array(arr, new Map())).to.be.deep.equal([arr, []])
-      }
-    })
   })
 })

--- a/bokehjs/test/unit/core/util/serialization.ts
+++ b/bokehjs/test/unit/core/util/serialization.ts
@@ -1,6 +1,7 @@
 import {expect} from "chai"
 
 import * as ser from "@bokehjs/core/util/serialization"
+import {ndarray} from "@bokehjs/core/util/ndarray"
 
 const GOOD_TYPES = [
   Float32Array, Float64Array, Uint8Array, Int8Array,
@@ -101,5 +102,34 @@ describe("serialization module", () => {
         expect(c).to.be.deep.equal(b)
       })
     }
+  })
+
+  it("should support NDArray serialization and de-serialization", () => {
+    const nd0 = ndarray([1, 2, 3, 4, 5, 6], {dtype: "int32", shape: [2, 3]})
+
+    const buffers0 = new Map<string, ArrayBuffer>()
+    const ref0_0 = ser.encode_NDArray(nd0, buffers0)
+    expect(ref0_0).to.be.deep.equal({
+      __buffer__: "0",
+      order: ser.BYTE_ORDER,
+      dtype: "int32",
+      shape: [2, 3],
+    })
+    expect(buffers0).to.be.deep.equal(new Map([["0", nd0.buffer]]))
+
+    const deref0_0 = ser.decode_NDArray(ref0_0, buffers0)
+    expect(deref0_0).to.be.deep.equal(nd0)
+    expect(() => ser.decode_NDArray(ref0_0, new Map())).to.throw()
+
+    const ref0_1 = ser.encode_NDArray(nd0)
+    expect(ref0_1).to.be.deep.equal({
+      __ndarray__: "AQAAAAIAAAADAAAABAAAAAUAAAAGAAAA",
+      order: ser.BYTE_ORDER,
+      dtype: "int32",
+      shape: [2, 3],
+    })
+
+    const deref0_1 = ser.decode_NDArray(ref0_1, new Map())
+    expect(deref0_1).to.be.deep.equal(nd0)
   })
 })

--- a/bokehjs/test/unit/models/sources/column_data_source.ts
+++ b/bokehjs/test/unit/models/sources/column_data_source.ts
@@ -6,6 +6,8 @@ import {keys} from "@bokehjs/core/util/object"
 import {difference} from "@bokehjs/core/util/set"
 import {ColumnDataSource, stream_to_column, slice, patch_to_column} from "@bokehjs/models/sources/column_data_source"
 
+import {ndarray, Int32NDArray, Float32NDArray, Float64NDArray} from "@bokehjs/core/util/ndarray"
+
 import {trap} from "../../../util"
 
 describe("column_data_source module", () => {
@@ -45,40 +47,34 @@ describe("column_data_source module", () => {
     describe("with single integer index", () => {
 
       it("should patch Arrays to Arrays", () => {
-        const a = [1, 2, 3, 4, 5]
-        patch_to_column(a, [[3, 100]], [])
-        expect(a).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([1, 2, 3, 100, 5])
+        const a = ndarray([1, 2, 3, 4, 5])
+        patch_to_column(a, [[3, 100]])
+        expect(a).to.be.deep.equal(ndarray([1, 2, 3, 100, 5]))
 
-        patch_to_column(a, [[2, 101]], [])
-        expect(a).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([1, 2, 101, 100, 5])
+        patch_to_column(a, [[2, 101]])
+        expect(a).to.be.deep.equal(ndarray([1, 2, 101, 100, 5]))
       })
 
       it("should patch typed Arrays to typed Arrays", () => {
-        for (const typ of [Float32Array, Float64Array, Int32Array]) {
+        for (const typ of [Float32NDArray, Float64NDArray, Int32NDArray]) {
           const a = new typ([1, 2, 3, 4, 5])
-          patch_to_column(a, [[3, 100]], [])
-          expect(a).to.be.instanceof(typ)
+          patch_to_column(a, [[3, 100]])
           expect(a).to.be.deep.equal(new typ([1, 2, 3, 100, 5]))
 
-          patch_to_column(a, [[2, 101]], [])
-          expect(a).to.be.instanceof(typ)
+          patch_to_column(a, [[2, 101]])
           expect(a).to.be.deep.equal(new typ([1, 2, 101, 100, 5]))
         }
       })
 
       it("should handle multi-part patches", () => {
-        const a = [1, 2, 3, 4, 5]
-        patch_to_column(a, [[3, 100], [0, 10], [4, -1]], [])
-        expect(a).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([10, 2, 3, 100, -1])
+        const a = ndarray([1, 2, 3, 4, 5])
+        patch_to_column(a, [[3, 100], [0, 10], [4, -1]])
+        expect(a).to.be.deep.equal(ndarray([10, 2, 3, 100, -1]))
       })
 
       it("should return a Set of the patched indices", () => {
-        const a = [1, 2, 3, 4, 5]
-        const s = patch_to_column(a, [[3, 100], [0, 10], [4, -1]], [])
-        expect(s).to.be.instanceof(Set)
+        const a = ndarray([1, 2, 3, 4, 5])
+        const s = patch_to_column(a, [[3, 100], [0, 10], [4, -1]])
         expect(difference(s, new Set([0, 3, 4]))).to.be.deep.equal(new Set())
       })
     })
@@ -86,47 +82,40 @@ describe("column_data_source module", () => {
     describe("with single slice index", () => {
 
       it("should patch Arrays to Arrays", () => {
-        const a = [1, 2, 3, 4, 5]
-        patch_to_column(a, [[{start:2, stop:4, step:1}, [100, 101]]], [])
-        expect(a).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([1, 2, 100, 101, 5])
+        const a = ndarray([1, 2, 3, 4, 5])
+        patch_to_column(a, [[{start:2, stop:4, step:1}, [100, 101]]])
+        expect(a).to.be.deep.equal(ndarray([1, 2, 100, 101, 5]))
 
-        patch_to_column(a, [[{start:1, stop:3, step:1}, [99, 102]]], [])
-        expect(a).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([1, 99, 102, 101, 5])
+        patch_to_column(a, [[{start:1, stop:3, step:1}, [99, 102]]])
+        expect(a).to.be.deep.equal(ndarray([1, 99, 102, 101, 5]))
       })
 
       it("should patch typed Arrays to typed Arrays", () => {
-        for (const typ of [Float32Array, Float64Array, Int32Array]) {
+        for (const typ of [Float32NDArray, Float64NDArray, Int32NDArray]) {
           const a = new typ([1, 2, 3, 4, 5])
-          patch_to_column(a, [[{start:2, stop:4, step:1}, [100, 101]]], [])
-          expect(a).to.be.instanceof(typ)
+          patch_to_column(a, [[{start:2, stop:4, step:1}, [100, 101]]])
           expect(a).to.be.deep.equal(new typ([1, 2, 100, 101, 5]))
 
-          patch_to_column(a, [[{start:1, stop:3, step:1}, [99, 102]]], [])
-          expect(a).to.be.instanceof(typ)
+          patch_to_column(a, [[{start:1, stop:3, step:1}, [99, 102]]])
           expect(a).to.be.deep.equal(new typ([1, 99, 102, 101, 5]))
         }
       })
 
       it("should handle patch indices with strides", () => {
-        const a = new Int32Array([1, 2, 3, 4, 5])
-        patch_to_column(a, [[{start:1, stop:5, step:2}, [100, 101]]], [])
-        expect(a).to.be.instanceof(Int32Array)
-        expect(a).to.be.deep.equal(new Int32Array([1, 100, 3, 101, 5]))
+        const a = ndarray([1, 2, 3, 4, 5], {dtype: "int32"})
+        patch_to_column(a, [[{start:1, stop:5, step:2}, [100, 101]]])
+        expect(a).to.be.deep.equal(new Int32NDArray([1, 100, 3, 101, 5]))
       })
 
       it("should handle multi-part patches", () => {
-        const a = [1, 2, 3, 4, 5]
-        patch_to_column(a, [[{start:2, stop:4, step:1}, [100, 101]], [{stop:1, step:1}, [10]], [4, -1]], [])
-        expect(a).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([10, 2, 100, 101, -1])
+        const a = ndarray([1, 2, 3, 4, 5])
+        patch_to_column(a, [[{start:2, stop:4, step:1}, [100, 101]], [{stop:1, step:1}, [10]], [4, -1]])
+        expect(a).to.be.deep.equal(ndarray([10, 2, 100, 101, -1]))
       })
 
       it("should return a Set of the patched indices", () => {
-        const a = [1, 2, 3, 4, 5]
-        const s = patch_to_column(a, [[{start:2, stop:4, step:1}, [100, 101]], [{stop:1, step:1}, [10]], [4, -1]], [])
-        expect(s).to.be.instanceof(Set)
+        const a = ndarray([1, 2, 3, 4, 5])
+        const s = patch_to_column(a, [[{start:2, stop:4, step:1}, [100, 101]], [{stop:1, step:1}, [10]], [4, -1]])
         expect(difference(s, new Set([0, 2, 3, 4]))).to.be.deep.equal(new Set())
       })
     })
@@ -134,51 +123,39 @@ describe("column_data_source module", () => {
     describe("with multi-index for 1d subarrays", () => {
 
       it("should patch Arrays to Arrays", () => {
-        const a = [1, 2, 3, 4, 5]
-        const b = [10, 20, -1, -2, 0, 10]
-        const c = [1, 2, 3, 4]
+        const a = ndarray([1, 2, 3, 4, 5], {shape: [5]})
+        const b = ndarray([10, 20, -1, -2, 0, 10], {shape: [6]})
+        const c = ndarray([1, 2, 3, 4], {shape: [4]})
         patch_to_column([a, b, c], [
           [[0, {start:2, stop:4, step:1}], [100, 101]],
-        ], [[5], [6], [4]])
-        expect(a).to.be.instanceof(Array)
-        expect(b).to.be.instanceof(Array)
-        expect(c).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([1, 2, 100, 101, 5])
-        expect(b).to.be.deep.equal([10, 20, -1, -2, 0, 10])
-        expect(c).to.be.deep.equal([1, 2, 3, 4])
+        ])
+        expect(a).to.be.deep.equal(ndarray([1, 2, 100, 101, 5]))
+        expect(b).to.be.deep.equal(ndarray([10, 20, -1, -2, 0, 10]))
+        expect(c).to.be.deep.equal(ndarray([1, 2, 3, 4]))
 
         patch_to_column([a, b, c], [
           [[1, {start:2, stop:4, step:1}], [100, 101]],
-        ], [[5], [6], [4]])
-        expect(a).to.be.instanceof(Array)
-        expect(b).to.be.instanceof(Array)
-        expect(c).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([1, 2, 100, 101, 5])
-        expect(b).to.be.deep.equal([10, 20, 100, 101, 0, 10])
-        expect(c).to.be.deep.equal([1, 2, 3, 4])
+        ])
+        expect(a).to.be.deep.equal(ndarray([1, 2, 100, 101, 5]))
+        expect(b).to.be.deep.equal(ndarray([10, 20, 100, 101, 0, 10]))
+        expect(c).to.be.deep.equal(ndarray([1, 2, 3, 4]))
       })
 
       it("should patch typed Arrays to typed Arrays", () => {
-        for (const typ of [Float32Array, Float64Array, Int32Array]) {
-          const a = new typ([1, 2, 3, 4, 5])
-          const b = new typ([10, 20, -1, -2, 0, 10])
-          const c = new typ([1, 2, 3, 4])
+        for (const typ of [Float32NDArray, Float64NDArray, Int32NDArray]) {
+          const a = new typ([1, 2, 3, 4, 5], [5])
+          const b = new typ([10, 20, -1, -2, 0, 10], [6])
+          const c = new typ([1, 2, 3, 4], [4])
           patch_to_column([a, b, c], [
             [[0, {start:2, stop:4, step:1}], [100, 101]],
-          ], [[5], [6], [4]])
-          expect(a).to.be.instanceof(typ)
-          expect(b).to.be.instanceof(typ)
-          expect(c).to.be.instanceof(typ)
+          ])
           expect(a).to.be.deep.equal(new typ([1, 2, 100, 101, 5]))
           expect(b).to.be.deep.equal(new typ([10, 20, -1, -2, 0, 10]))
           expect(c).to.be.deep.equal(new typ([1, 2, 3, 4]))
 
           patch_to_column([a, b, c], [
             [[1, {start:2, stop:4, step:1}], [100, 101]],
-          ], [[5], [6], [4]])
-          expect(a).to.be.instanceof(typ)
-          expect(b).to.be.instanceof(typ)
-          expect(c).to.be.instanceof(typ)
+          ])
           expect(a).to.be.deep.equal(new typ([1, 2, 100, 101, 5]))
           expect(b).to.be.deep.equal(new typ([10, 20, 100, 101, 0, 10]))
           expect(c).to.be.deep.equal(new typ([1, 2, 3, 4]))
@@ -186,57 +163,47 @@ describe("column_data_source module", () => {
       })
 
       it("should handle patch indices with strides", () => {
-        const a = new Int32Array([1, 2, 3, 4, 5])
-        const b = new Int32Array([10, 20, -1, -2, 0, 10])
-        const c = new Int32Array([1, 2, 3, 4])
+        const a = new Int32NDArray([1, 2, 3, 4, 5], [5])
+        const b = new Int32NDArray([10, 20, -1, -2, 0, 10], [6])
+        const c = new Int32NDArray([1, 2, 3, 4], [4])
         patch_to_column([a, b, c], [
           [[0, {start:1, stop:5, step:2}], [100, 101]],
-        ], [[5], [6], [4]])
-        expect(a).to.be.instanceof(Int32Array)
-        expect(b).to.be.instanceof(Int32Array)
-        expect(c).to.be.instanceof(Int32Array)
-        expect(a).to.be.deep.equal(new Int32Array([1, 100, 3, 101, 5]))
-        expect(b).to.be.deep.equal(new Int32Array([10, 20, -1, -2, 0, 10]))
-        expect(c).to.be.deep.equal(new Int32Array([1, 2, 3, 4]))
+        ])
+        expect(a).to.be.deep.equal(new Int32NDArray([1, 100, 3, 101, 5]))
+        expect(b).to.be.deep.equal(new Int32NDArray([10, 20, -1, -2, 0, 10]))
+        expect(c).to.be.deep.equal(new Int32NDArray([1, 2, 3, 4]))
 
         patch_to_column([a, b, c], [
           [[1, {step:3}], [100, 101]],
-        ], [[5], [6], [4]])
-        expect(a).to.be.instanceof(Int32Array)
-        expect(b).to.be.instanceof(Int32Array)
-        expect(c).to.be.instanceof(Int32Array)
-        expect(a).to.be.deep.equal(new Int32Array([1, 100, 3, 101, 5]))
-        expect(b).to.be.deep.equal(new Int32Array([100, 20, -1, 101, 0, 10]))
-        expect(c).to.be.deep.equal(new Int32Array([1, 2, 3, 4]))
+        ])
+        expect(a).to.be.deep.equal(new Int32NDArray([1, 100, 3, 101, 5]))
+        expect(b).to.be.deep.equal(new Int32NDArray([100, 20, -1, 101, 0, 10]))
+        expect(c).to.be.deep.equal(new Int32NDArray([1, 2, 3, 4]))
       })
 
       it("should handle multi-part patches", () => {
-        const a = [1, 2, 3, 4, 5]
-        const b = [10, 20, -1, -2, 0, 10]
-        const c = [1, 2, 3, 4]
+        const a = ndarray([1, 2, 3, 4, 5], {shape: [5]})
+        const b = ndarray([10, 20, -1, -2, 0, 10], {shape: [6]})
+        const c = ndarray([1, 2, 3, 4], {shape: [4]})
         patch_to_column([a, b, c], [
           [[0, {start:2, stop:4, step:1}], [100, 101]],
           [[1, {stop:2, step:1}], [999, 999]],
           [[1, 5], [6]],
-        ], [[5], [6], [4]])
-        expect(a).to.be.instanceof(Array)
-        expect(b).to.be.instanceof(Array)
-        expect(c).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([1, 2, 100, 101, 5])
-        expect(b).to.be.deep.equal([999, 999, -1, -2, 0, 6])
-        expect(c).to.be.deep.equal([1, 2, 3, 4])
+        ])
+        expect(a).to.be.deep.equal(ndarray([1, 2, 100, 101, 5]))
+        expect(b).to.be.deep.equal(ndarray([999, 999, -1, -2, 0, 6]))
+        expect(c).to.be.deep.equal(ndarray([1, 2, 3, 4]))
       })
 
       it("should return a Set of the patched indices", () => {
-        const a = [1, 2, 3, 4, 5]
-        const b = [10, 20, -1, -2, 0, 10]
-        const c = [1, 2, 3, 4]
+        const a = ndarray([1, 2, 3, 4, 5], {shape: [5]})
+        const b = ndarray([10, 20, -1, -2, 0, 10], {shape: [6]})
+        const c = ndarray([1, 2, 3, 4], {shape: [4]})
         const s = patch_to_column([a, b, c], [
           [[0, {start:2, stop:4, step:1}], [100, 101]],
           [[1, {stop:2, step:1}], [999, 999]],
           [[1, 5], [6]],
-        ], [[5], [6], [4]])
-        expect(s).to.be.instanceof(Set)
+        ])
         expect(difference(s, new Set([0, 1]))).to.be.deep.equal(new Set())
       })
     })
@@ -244,107 +211,83 @@ describe("column_data_source module", () => {
     describe("with multi-index for 2d subarrays", () => {
 
       it("should patch Arrays to Arrays", () => {
-        const a = [1, 2, 3, 4, 5, 6]
-        const b = [10, 20, -1, -2, 0, 10]
-        const c = [1, 2]
-        patch_to_column([a, b, c], [[[0, {}, 2], [100, 101]]], [[2, 3], [3, 2], [1, 2]])
-        expect(a).to.be.instanceof(Array)
-        expect(b).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([1, 2, 100, 4, 5, 101])
-        expect(b).to.be.deep.equal([10, 20, -1, -2, 0, 10])
-        expect(c).to.be.deep.equal([1, 2])
+        const a = ndarray([1, 2, 3, 4, 5, 6], {shape: [2, 3]})
+        const b = ndarray([10, 20, -1, -2, 0, 10], {shape: [3, 2]})
+        const c = ndarray([1, 2], {shape: [1, 2]})
+        patch_to_column([a, b, c], [[[0, {}, 2], [100, 101]]])
+        expect(a).to.be.deep.equal(ndarray([1, 2, 100, 4, 5, 101], {shape: [2, 3]}))
+        expect(b).to.be.deep.equal(ndarray([10, 20, -1, -2, 0, 10], {shape: [3, 2]}))
+        expect(c).to.be.deep.equal(ndarray([1, 2], {shape: [1, 2]}))
 
         patch_to_column([a, b, c], [
           [[1, {start:0, stop:2, step:1}, {start:0, stop:1, step:1}], [100, 101]],
-        ], [[2, 3], [3, 2], [1, 2]])
-        expect(a).to.be.instanceof(Array)
-        expect(b).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([1, 2, 100, 4, 5, 101])
-        expect(b).to.be.deep.equal([100, 20, 101, -2, 0, 10])
-        expect(c).to.be.deep.equal([1, 2])
+        ])
+        expect(a).to.be.deep.equal(ndarray([1, 2, 100, 4, 5, 101], {shape: [2, 3]}))
+        expect(b).to.be.deep.equal(ndarray([100, 20, 101, -2, 0, 10], {shape: [3, 2]}))
+        expect(c).to.be.deep.equal(ndarray([1, 2], {shape: [1, 2]}))
       })
 
       it("should patch typed Arrays to types Arrays", () => {
-        for (const typ of [Float32Array, Float64Array, Int32Array]) {
-          const a = new typ([1, 2, 3,
-                             4, 5, 6])
-          const b = new typ([10, 20,
-                             -1, -2,
-                             0, 10])
-          const c = new typ([1, 2])
+        for (const typ of [Float32NDArray, Float64NDArray, Int32NDArray]) {
+          const a = new typ([1, 2, 3, 4, 5, 6], [2, 3])
+          const b = new typ([10, 20, -1, -2, 0, 10], [3, 2])
+          const c = new typ([1, 2], [1, 2])
           patch_to_column([a, b, c], [
             [[0, {}, 2], [100, 101]],
-          ], [[2, 3], [3, 2], [1, 2]])
-          expect(a).to.be.instanceof(typ)
-          expect(b).to.be.instanceof(typ)
-          expect(c).to.be.instanceof(typ)
-          expect(a).to.be.deep.equal(new typ([1, 2, 100, 4, 5, 101]))
-          expect(b).to.be.deep.equal(new typ([10, 20, -1, -2, 0, 10]))
-          expect(c).to.be.deep.equal(new typ([1, 2]))
+          ])
+          expect(a).to.be.deep.equal(new typ([1, 2, 100, 4, 5, 101], [2, 3]))
+          expect(b).to.be.deep.equal(new typ([10, 20, -1, -2, 0, 10], [3, 2]))
+          expect(c).to.be.deep.equal(new typ([1, 2], [1, 2]))
 
           patch_to_column([a, b, c], [
             [[1, {start:0, stop:2, step:1}, {start:0, stop:1, step:1}], [100, 101]],
-          ], [[2, 3], [3, 2], [1, 2]])
-          expect(a).to.be.instanceof(typ)
-          expect(b).to.be.instanceof(typ)
-          expect(c).to.be.instanceof(typ)
-          expect(a).to.be.deep.equal(new typ([1, 2, 100, 4, 5, 101]))
-          expect(b).to.be.deep.equal(new typ([100, 20, 101, -2, 0, 10]))
-          expect(c).to.be.deep.equal(new typ([1, 2]))
+          ])
+          expect(a).to.be.deep.equal(new typ([1, 2, 100, 4, 5, 101], [2, 3]))
+          expect(b).to.be.deep.equal(new typ([100, 20, 101, -2, 0, 10], [3, 2]))
+          expect(c).to.be.deep.equal(new typ([1, 2], [1, 2]))
         }
       })
 
       it("should handle patch indices with strides", () => {
-        const a = new Int32Array([1, 2, 3, 4, 5, 6])
-        const b = new Int32Array([10, 20, -1, -2, 0, 10])
-        const c = new Int32Array([1, 2])
+        const a = new Int32NDArray([1, 2, 3, 4, 5, 6], [2, 3])
+        const b = new Int32NDArray([10, 20, -1, -2, 0, 10], [3, 2])
+        const c = new Int32NDArray([1, 2], [1, 2])
         patch_to_column([a, b, c], [
           [[0, {step:1}, 2], [100, 101]],
-        ], [[2, 3], [3, 2], [1, 2]])
-        expect(a).to.be.instanceof(Int32Array)
-        expect(b).to.be.instanceof(Int32Array)
-        expect(c).to.be.instanceof(Int32Array)
-        expect(a).to.be.deep.equal(new Int32Array([1, 2, 100, 4, 5, 101]))
-        expect(b).to.be.deep.equal(new Int32Array([10, 20, -1, -2, 0, 10]))
-        expect(c).to.be.deep.equal(new Int32Array([1, 2]))
+        ])
+        expect(a).to.be.deep.equal(new Int32NDArray([1, 2, 100, 4, 5, 101], [2, 3]))
+        expect(b).to.be.deep.equal(new Int32NDArray([10, 20, -1, -2, 0, 10], [3, 2]))
+        expect(c).to.be.deep.equal(new Int32NDArray([1, 2], [1, 2]))
 
         patch_to_column([a, b, c], [
           [[1, {start:0, stop:3, step:2}, {start:0, stop:1, step:1}], [100, 101]],
-        ], [[2, 3], [3, 2], [1, 2]])
-        expect(a).to.be.instanceof(Int32Array)
-        expect(b).to.be.instanceof(Int32Array)
-        expect(c).to.be.instanceof(Int32Array)
-        expect(c).to.be.deep.equal(new Int32Array([1, 2]))
-        expect(a).to.be.deep.equal(new Int32Array([1, 2, 100, 4, 5, 101]))
-        expect(b).to.be.deep.equal(new Int32Array([100, 20, -1, -2, 101, 10]))
-        expect(c).to.be.deep.equal(new Int32Array([1, 2]))
+        ])
+        expect(a).to.be.deep.equal(new Int32NDArray([1, 2, 100, 4, 5, 101], [2, 3]))
+        expect(b).to.be.deep.equal(new Int32NDArray([100, 20, -1, -2, 101, 10], [3, 2]))
+        expect(c).to.be.deep.equal(new Int32NDArray([1, 2], [1, 2]))
       })
 
       it("should handle multi-part patches", () => {
-        const a = [1, 2, 3, 4, 5, 6]
-        const b = [10, 20, -1, -2, 0, 10]
-        const c = [1, 2]
+        const a = ndarray([1, 2, 3, 4, 5, 6], {shape: [2, 3]})
+        const b = ndarray([10, 20, -1, -2, 0, 10], {shape: [3, 2]})
+        const c = ndarray([1, 2], {shape: [1, 2]})
         patch_to_column([a, b, c], [
           [[0, {step:1}, 2], [100, 101]],
           [[1, {start:0, stop:2, step:1}, {start:0, stop:1, step:1}], [100, 101]],
-        ], [[2, 3], [3, 2], [1, 2]])
-        expect(a).to.be.instanceof(Array)
-        expect(b).to.be.instanceof(Array)
-        expect(c).to.be.instanceof(Array)
-        expect(a).to.be.deep.equal([1, 2, 100, 4, 5, 101])
-        expect(b).to.be.deep.equal([100, 20, 101, -2, 0, 10])
-        expect(c).to.be.deep.equal([1, 2])
+        ])
+        expect(a).to.be.deep.equal(ndarray([1, 2, 100, 4, 5, 101], {shape: [2, 3]}))
+        expect(b).to.be.deep.equal(ndarray([100, 20, 101, -2, 0, 10], {shape: [3, 2]}))
+        expect(c).to.be.deep.equal(ndarray([1, 2], {shape: [1, 2]}))
       })
 
       it("should return a Set of the patched indices", () => {
-        const a = [1, 2, 3, 4, 5, 6]
-        const b = [10, 20, -1, -2, 0, 10]
-        const c = [1, 2]
+        const a = ndarray([1, 2, 3, 4, 5, 6], {shape: [2, 3]})
+        const b = ndarray([10, 20, -1, -2, 0, 10], {shape: [3, 2]})
+        const c = ndarray([1, 2], {shape: [1, 2]})
         const s = patch_to_column([a, b, c], [
           [[0, {step:1}, 2], [100, 101]],
           [[1, {start:0, stop:2, step:1}, {start:0, stop:1, step:1}], [100, 101]],
-        ], [[2, 3], [3, 2], [1, 2]])
-        expect(s).to.be.instanceof(Set)
+        ])
         expect(difference(s, new Set([0, 1]))).to.be.deep.equal(new Set())
       })
     })
@@ -355,101 +298,86 @@ describe("column_data_source module", () => {
     it("should stream Arrays to Arrays", () => {
       const a = [1, 2, 3, 4, 5]
       const r = stream_to_column(a, [100, 200])
-      expect(r).to.be.instanceof(Array)
       expect(r).to.be.deep.equal([1, 2, 3, 4, 5, 100, 200])
     })
 
     it("should stream Arrays to Arrays with rollover", () => {
       const a0 = [1, 2, 3, 4, 5]
       const r0 = stream_to_column(a0, [100, 200, 300], 5)
-      expect(r0).to.be.instanceof(Array)
       expect(r0).to.be.deep.equal([4, 5, 100, 200, 300])
 
       const a1 = [1, 2, 3, 4, 5]
       const r1 = stream_to_column(a1, [100, 200, 300], 6)
-      expect(r1).to.be.instanceof(Array)
       expect(r1).to.be.deep.equal([3, 4, 5, 100, 200, 300])
     })
 
     it("should stream Float32 to Float32", () => {
-      const a = new Float32Array([1, 2, 3, 4, 5])
+      const a = new Float32NDArray([1, 2, 3, 4, 5])
       const r = stream_to_column(a, [100, 200])
-      expect(r).to.be.instanceof(Float32Array)
-      expect(r).to.be.deep.equal(new Float32Array([1, 2, 3, 4, 5, 100, 200]))
+      expect(r).to.be.deep.equal(new Float32NDArray([1, 2, 3, 4, 5, 100, 200]))
     })
 
     it("should stream Float32 to Float32 with rollover", () => {
       // test when col is already at rollover len
-      const a0 = new Float32Array([1, 2, 3, 4, 5])
+      const a0 = new Float32NDArray([1, 2, 3, 4, 5])
       const r0 = stream_to_column(a0, [100, 200, 300], 5)
-      expect(r0).to.be.instanceof(Float32Array)
-      expect(r0).to.be.deep.equal(new Float32Array([4, 5, 100, 200, 300]))
+      expect(r0).to.be.deep.equal(new Float32NDArray([4, 5, 100, 200, 300]))
 
       // test when col is not at rollover len but will exceed
-      const a1 = new Float32Array([1, 2, 3, 4, 5])
+      const a1 = new Float32NDArray([1, 2, 3, 4, 5])
       const r1 = stream_to_column(a1, [100, 200, 300], 6)
-      expect(r1).to.be.instanceof(Float32Array)
-      expect(r1).to.be.deep.equal(new Float32Array([3, 4, 5, 100, 200, 300]))
+      expect(r1).to.be.deep.equal(new Float32NDArray([3, 4, 5, 100, 200, 300]))
 
       // test when col is not at rollover len and will not exceed
-      const a2 = new Float32Array([1, 2, 3, 4, 5])
+      const a2 = new Float32NDArray([1, 2, 3, 4, 5])
       const r2 = stream_to_column(a2, [100, 200, 300], 10)
-      expect(r2).to.be.instanceof(Float32Array)
-      expect(r2).to.be.deep.equal(new Float32Array([1, 2, 3, 4, 5, 100, 200, 300]))
+      expect(r2).to.be.deep.equal(new Float32NDArray([1, 2, 3, 4, 5, 100, 200, 300]))
     })
 
     it("should stream Float64 to Float64", () => {
-      const a = new Float64Array([1, 2, 3, 4, 5])
+      const a = new Float64NDArray([1, 2, 3, 4, 5])
       const r = stream_to_column(a, [100, 200])
-      expect(r).to.be.instanceof(Float64Array)
-      expect(r).to.be.deep.equal(new Float64Array([1, 2, 3, 4, 5, 100, 200]))
+      expect(r).to.be.deep.equal(new Float64NDArray([1, 2, 3, 4, 5, 100, 200]))
     })
 
     it("should stream Float64 to Float64 with rollover", () => {
       // test when col is already at rollover len
-      const a0 = new Float64Array([1, 2, 3, 4, 5])
+      const a0 = new Float64NDArray([1, 2, 3, 4, 5])
       const r0 = stream_to_column(a0, [100, 200, 300], 5)
-      expect(r0).to.be.instanceof(Float64Array)
-      expect(r0).to.be.deep.equal(new Float64Array([4, 5, 100, 200, 300]))
+      expect(r0).to.be.deep.equal(new Float64NDArray([4, 5, 100, 200, 300]))
 
       // test when col is not at rollover len but will exceed
-      const a1 = new Float64Array([1, 2, 3, 4, 5])
+      const a1 = new Float64NDArray([1, 2, 3, 4, 5])
       const r1 = stream_to_column(a1, [100, 200, 300], 6)
-      expect(r1).to.be.instanceof(Float64Array)
-      expect(r1).to.be.deep.equal(new Float64Array([3, 4, 5, 100, 200, 300]))
+      expect(r1).to.be.deep.equal(new Float64NDArray([3, 4, 5, 100, 200, 300]))
 
       // test when col is not at rollover len and will not exceed
-      const a2 = new Float64Array([1, 2, 3, 4, 5])
+      const a2 = new Float64NDArray([1, 2, 3, 4, 5])
       const r2 = stream_to_column(a2, [100, 200, 300], 10)
-      expect(r2).to.be.instanceof(Float64Array)
-      expect(r2).to.be.deep.equal(new Float64Array([1, 2, 3, 4, 5, 100, 200, 300]))
+      expect(r2).to.be.deep.equal(new Float64NDArray([1, 2, 3, 4, 5, 100, 200, 300]))
     })
 
     it("should stream Int32 to Int32", () => {
-      const a = new Int32Array([1, 2, 3, 4, 5])
+      const a = new Int32NDArray([1, 2, 3, 4, 5])
       const r = stream_to_column(a, [100, 200])
-      expect(r).to.be.instanceof(Int32Array)
-      expect(r).to.be.deep.equal(new Int32Array([1, 2, 3, 4, 5, 100, 200]))
+      expect(r).to.be.deep.equal(new Int32NDArray([1, 2, 3, 4, 5, 100, 200]))
     })
 
     it("should stream Int32 to Int32 with rollover", () => {
       // test when col is already at rollover len
-      const a0 = new Int32Array([1, 2, 3, 4, 5])
+      const a0 = new Int32NDArray([1, 2, 3, 4, 5])
       const r0 = stream_to_column(a0, [100, 200, 300], 5)
-      expect(r0).to.be.instanceof(Int32Array)
-      expect(r0).to.be.deep.equal(new Int32Array([4, 5, 100, 200, 300]))
+      expect(r0).to.be.deep.equal(new Int32NDArray([4, 5, 100, 200, 300]))
 
       // test when col is not at rollover len but will exceed
-      const a1 = new Int32Array([1, 2, 3, 4, 5])
+      const a1 = new Int32NDArray([1, 2, 3, 4, 5])
       const r1 = stream_to_column(a1, [100, 200, 300], 6)
-      expect(r1).to.be.instanceof(Int32Array)
-      expect(r1).to.be.deep.equal(new Int32Array([3, 4, 5, 100, 200, 300]))
+      expect(r1).to.be.deep.equal(new Int32NDArray([3, 4, 5, 100, 200, 300]))
 
       // test when col is not at rollover len and will not exceed
-      const a2 = new Int32Array([1, 2, 3, 4, 5])
+      const a2 = new Int32NDArray([1, 2, 3, 4, 5])
       const r2 = stream_to_column(a2, [100, 200, 300], 10)
-      expect(r2).to.be.instanceof(Int32Array)
-      expect(r2).to.be.deep.equal(new Int32Array([1, 2, 3, 4, 5, 100, 200, 300]))
+      expect(r2).to.be.deep.equal(new Int32NDArray([1, 2, 3, 4, 5, 100, 200, 300]))
     })
   })
 
@@ -574,7 +502,7 @@ describe("column_data_source module", () => {
     })
 
     it("should clear typed arrays to typed arrays", () => {
-      for (const typ of [Float32Array, Float64Array, Int32Array]) {
+      for (const typ of [Float32NDArray, Float64NDArray, Int32NDArray]) {
         const r = new ColumnDataSource({data: {foo: [10, 20], bar: new typ([1, 2])}})
         r.clear()
         expect(r.data).to.be.deep.equal({foo: [], bar: new typ([])})
@@ -582,7 +510,7 @@ describe("column_data_source module", () => {
     })
 
     it("should clear columns added later", () => {
-      for (const typ of [Float32Array, Float64Array, Int32Array]) {
+      for (const typ of [Float32NDArray, Float64NDArray, Int32NDArray]) {
         const r = new ColumnDataSource({data: {foo: [10, 20]}})
         r.data.bar = [100, 200]
         r.data.baz = new typ([1, 2])


### PR DESCRIPTION
This extends typed arrays with `dtype` and `shape`, and allows to handle shapes by arrays, instead of globally. This allows to support ndarrays and base64/binary encoding everywhere (not only in `data`), and removes custom serialization code, etc. Note this is a stop gap measure, and not how I intend ndarrays to look like and work in bokeh 3.0, but backwards compatibility and the lack of ability to override `[]` operator makes proper changes impossible right now. Tentatively adding to 2.1, but it may need to be postponed, depending on how badly it breaks things.