### PR TITLE
use semi-stranparent button background highlight

### DIFF
--- a/bokehjs/src/less/toolbar.less
+++ b/bokehjs/src/less/toolbar.less
@@ -68,7 +68,7 @@
     background-position: center center;
 
     &:hover {
-      background-color: #f9f9f9;
+      background-color: rgba(192, 192, 192, 0.15);
     }
 
     &:focus {


### PR DESCRIPTION
cc @bokeh/dev 

- [x] issues: fixes #9909

The color here is chosen purely by experimentation. Open to any other suggestions for CSS styling to improve. Ultimate I think perhaps we should expose properties on the toolbar to control bg color and possibly blend mode. 

<img width="153" alt="Screen Shot 2020-05-27 at 5 28 47 PM" src="https://user-images.githubusercontent.com/1078448/83085041-987e0180-a03f-11ea-9860-35d9f79658e2.png">
<img width="97" alt="Screen Shot 2020-05-27 at 5 28 54 PM" src="https://user-images.githubusercontent.com/1078448/83085044-99169800-a03f-11ea-8041-9ba690cb7348.png">



