### PR TITLE
More usage of Map<K, V> and Set<V>

### DIFF
--- a/bokehjs/src/lib/core/view.ts
+++ b/bokehjs/src/lib/core/view.ts
@@ -2,13 +2,11 @@ import type {HasProps} from "./has_props"
 import {Property} from "./properties"
 import {Signal0, Signal, Slot, ISignalable} from "./signaling"
 import {isArray} from "./util/types"
-import {uniqueId} from "./util/string"
 
 export type ViewOf<T extends HasProps> = T["__view_type__"]
 
 export namespace View {
   export type Options = {
-    id?: string
     model: HasProps
     parent: View | null
   }
@@ -17,8 +15,6 @@ export namespace View {
 export class View implements ISignalable {
 
   readonly removed = new Signal0<this>(this, "removed")
-
-  readonly id: string
 
   readonly model: HasProps
 
@@ -49,7 +45,6 @@ export class View implements ISignalable {
       throw new Error("model of a view wasn't configured")
 
     this._parent = options.parent
-    this.id = options.id || uniqueId()
   }
 
   initialize(): void {}
@@ -63,7 +58,7 @@ export class View implements ISignalable {
   }
 
   toString(): string {
-    return `${this.model.type}View(${this.id})`
+    return `${this.model.type}View(${this.model.id})`
   }
 
   serializable_state(): {[key: string]: unknown} {

--- a/bokehjs/src/lib/models/filters/boolean_filter.ts
+++ b/bokehjs/src/lib/models/filters/boolean_filter.ts
@@ -33,18 +33,18 @@ export class BooleanFilter extends Filter {
     if (booleans != null && booleans.length > 0) {
       if (every(booleans, isBoolean)) {
         if (booleans.length !== source.get_length()) {
-          logger.warn(`BooleanFilter ${this.id}: length of booleans doesn't match data source`)
+          logger.warn(`${this}: length of booleans doesn't match data source`)
         }
         return range(0, booleans.length).filter((i) => booleans[i] === true)
       } else {
-        logger.warn(`BooleanFilter ${this.id}: booleans should be array of booleans, defaulting to no filtering`)
+        logger.warn(`${this}: booleans should be array of booleans, defaulting to no filtering`)
         return null
       }
     } else {
       if (booleans != null && booleans.length == 0)
-        logger.warn(`BooleanFilter ${this.id}: booleans is empty, defaulting to no filtering`)
+        logger.warn(`${this}: booleans is empty, defaulting to no filtering`)
       else
-        logger.warn(`BooleanFilter ${this.id}: booleans was not set, defaulting to no filtering`)
+        logger.warn(`${this}: booleans was not set, defaulting to no filtering`)
       return null
     }
   }

--- a/bokehjs/src/lib/models/filters/filter.ts
+++ b/bokehjs/src/lib/models/filters/filter.ts
@@ -37,10 +37,10 @@ export class Filter extends Model {
       if (isArrayOf(filter, isInteger)) {
         return filter
       }
-      logger.warn(`Filter ${this.id}: filter should either be array of only booleans or only integers, defaulting to no filtering`)
+      logger.warn(`${this}: filter should either be array of only booleans or only integers, defaulting to no filtering`)
       return null
     } else {
-      logger.warn(`Filter ${this.id}: filter was not set to be an array, defaulting to no filtering`)
+      logger.warn(`${this}: filter was not set to be an array, defaulting to no filtering`)
       return null
     }
   }

--- a/bokehjs/src/lib/models/filters/index_filter.ts
+++ b/bokehjs/src/lib/models/filters/index_filter.ts
@@ -33,11 +33,11 @@ export class IndexFilter extends Filter {
       if (every(this.indices, isInteger))
         return this.indices
       else {
-        logger.warn(`IndexFilter ${this.id}: indices should be array of integers, defaulting to no filtering`)
+        logger.warn(`${this}: indices should be array of integers, defaulting to no filtering`)
         return null
       }
     } else {
-      logger.warn(`IndexFilter ${this.id}: indices was not set, defaulting to no filtering`)
+      logger.warn(`${this}: indices was not set, defaulting to no filtering`)
       return null
     }
   }

--- a/bokehjs/src/lib/models/ranges/data_range1d.ts
+++ b/bokehjs/src/lib/models/ranges/data_range1d.ts
@@ -106,9 +106,9 @@ export class DataRange1d extends DataRange {
     if (names.length > 0)
       renderers = renderers.filter((r) => includes(names, r.name))
 
-    logger.debug(`computed ${renderers.length} renderers for DataRange1d ${this.id}`)
-    for (const r of renderers) {
-      logger.trace(` - ${r.type} ${r.id}`)
+    logger.debug(`computed ${renderers.length} renderers for ${this}`)
+    for (const renderer of renderers) {
+      logger.trace(` - ${renderer}`)
     }
 
     return renderers

--- a/bokehjs/src/lib/models/ranges/factor_range.ts
+++ b/bokehjs/src/lib/models/ranges/factor_range.ts
@@ -27,19 +27,21 @@ export type L3OffsetFactor = [string, string, string, number]
 
 export type OffsetFactor = L1OffsetFactor | L2OffsetFactor | L3OffsetFactor
 
-export type L1Mapping = {[key: string]: {value: number}}
-export type L2Mapping = {[key: string]: {value: number, mapping: L1Mapping}}
-export type L3Mapping = {[key: string]: {value: number, mapping: L2Mapping}}
+export type L1Mapping = Map<string, {value: number}>
+export type L2Mapping = Map<string, {value: number, mapping: L1Mapping}>
+export type L3Mapping = Map<string, {value: number, mapping: L2Mapping}>
+
+export type Mapping = L1Mapping | L2Mapping | L3Mapping
 
 export function map_one_level(factors: L1Factor[], padding: number, offset: number = 0): [L1Mapping, number] {
-  const mapping: L1Mapping = {}
+  const mapping: L1Mapping = new Map()
 
   for (let i = 0; i < factors.length; i++) {
     const factor = factors[i]
-    if (factor in mapping)
-      throw new Error(`duplicate factor or subfactor: ${factor}`)
+    if (!mapping.has(factor))
+      mapping.set(factor, {value: 0.5 + i*(1 + padding) + offset})
     else
-      mapping[factor] = {value: 0.5 + i*(1 + padding) + offset}
+      throw new Error(`duplicate factor or subfactor: ${factor}`)
   }
 
   return [mapping, (factors.length - 1)*padding]
@@ -47,64 +49,53 @@ export function map_one_level(factors: L1Factor[], padding: number, offset: numb
 
 export function map_two_levels(factors: L2Factor[],
                                outer_pad: number, factor_pad: number,
-                               offset: number = 0): [L2Mapping, string[], number] {
-  const mapping: L2Mapping = {}
+                               offset: number = 0): [L2Mapping, number] {
+  const mapping: L2Mapping = new Map()
 
-  const tops: {[key: string]: string[]} = {}
-  const tops_order: string[] = []
+  const tops: Map<string, string[]> = new Map()
   for (const [f0, f1] of factors) {
-    if (!(f0 in tops)) {
-      tops[f0] = []
-      tops_order.push(f0)
-    }
-    tops[f0].push(f1)
+    const top = tops.get(f0) ?? []
+    tops.set(f0, [...top, f1])
   }
 
   let suboffset = offset
   let total_subpad = 0
-  for (const f0 of tops_order) {
-    const n = tops[f0].length
-    const [submap, subpad] = map_one_level(tops[f0], factor_pad, suboffset)
+  for (const [f0, top] of tops) {
+    const n = top.length
+    const [submap, subpad] = map_one_level(top, factor_pad, suboffset)
     total_subpad += subpad
-    const subtot = sum(tops[f0].map((f1) => submap[f1].value))
-    mapping[f0] = {value: subtot/n, mapping: submap}
+    const subtot = sum(top.map((f1) => submap.get(f1)!.value))
+    mapping.set(f0, {value: subtot/n, mapping: submap})
     suboffset += n + outer_pad + subpad
   }
 
-  return [mapping, tops_order, (tops_order.length-1)*outer_pad + total_subpad]
+  return [mapping, (tops.size - 1)*outer_pad + total_subpad]
 }
 
-export function map_three_levels(factors: L3Factor[],
-                                 outer_pad: number, inner_pad: number, factor_pad: number,
-                                 offset: number = 0): [L3Mapping, string[], [string, string][], number] {
-  const mapping: L3Mapping = {}
+export function map_three_levels(
+    factors: L3Factor[],
+    outer_pad: number, inner_pad: number, factor_pad: number,
+    offset: number = 0): [L3Mapping, number] {
+  const mapping: L3Mapping = new Map()
 
-  const tops: {[key: string]: [string, string][]} = {}
-  const tops_order: string[] = []
+  const tops: Map<string, [string, string][]> = new Map()
   for (const [f0, f1, f2] of factors) {
-    if (!(f0 in tops)) {
-      tops[f0] = []
-      tops_order.push(f0)
-    }
-    tops[f0].push([f1, f2])
+    const top = tops.get(f0) ?? []
+    tops.set(f0, [...top, [f1, f2]])
   }
-
-  const mids_order: [string, string][] = []
 
   let suboffset = offset
   let total_subpad = 0
-  for (const f0 of tops_order) {
-    const n = tops[f0].length
-    const [submap, submids_order, subpad] = map_two_levels(tops[f0], inner_pad, factor_pad, suboffset)
-    for (const f1 of submids_order)
-      mids_order.push([f0, f1])
+  for (const [f0, top] of tops) {
+    const n = top.length
+    const [submap, subpad] = map_two_levels(top, inner_pad, factor_pad, suboffset)
     total_subpad += subpad
-    const subtot = sum(tops[f0].map(([f1]) => submap[f1].value))
-    mapping[f0] = {value: subtot/n, mapping: submap}
+    const subtot = sum(top.map(([f1]) => submap.get(f1)!.value))
+    mapping.set(f0, {value: subtot/n, mapping: submap})
     suboffset += n + outer_pad + subpad
   }
 
-  return [mapping, tops_order, mids_order, (tops_order.length-1)*outer_pad + total_subpad]
+  return [mapping, (tops.size - 1)*outer_pad + total_subpad]
 }
 
 export namespace FactorRange {
@@ -123,7 +114,6 @@ export namespace FactorRange {
     levels: p.Property<number>
     mids: p.Property<[string, string][] | null>
     tops: p.Property<string[] | null>
-    tops_groups: p.Property<string[]>
   }
 }
 
@@ -152,11 +142,10 @@ export class FactorRange extends Range {
       levels:      [ p.Number      ], // how many levels of
       mids:        [ p.Array, null ], // mid level factors (if 3 total levels)
       tops:        [ p.Array, null ], // top level factors (whether 2 or 3 total levels)
-      tops_groups: [ p.Array       ], // ordered list of full factors for each top level factor in tops
     })
   }
 
-  protected _mapping: L1Mapping | L2Mapping | L3Mapping
+  protected _mapping: Mapping
 
   get min(): number {
     return this.start
@@ -187,26 +176,41 @@ export class FactorRange extends Range {
   }
 
   protected _lookup(x: BoxedFactor): number {
-    if (x.length == 1) {
-      const m = this._mapping as L1Mapping
-      if (!m.hasOwnProperty(x[0])) {
+    switch (x.length) {
+      case 1: {
+        const [f0] = x
+        const mapping = this._mapping as L1Mapping
+        const y0 = mapping.get(f0)
+        return y0 != null ? y0.value : NaN
+      }
+      case 2: {
+        const [f0, f1] = x
+        const mapping = this._mapping as L2Mapping
+        const y0 = mapping.get(f0)
+        if (y0 != null) {
+          const y1 = y0.mapping.get(f1)
+          if (y1 != null)
+            return y1.value
+        }
         return NaN
       }
-      return m[x[0]].value
-    } else if (x.length == 2) {
-      const m = this._mapping as L2Mapping
-      if (!m.hasOwnProperty(x[0]) || !m[x[0]].mapping.hasOwnProperty(x[1])) {
+      case 3: {
+        const [f0, f1, f2] = x
+        const mapping = this._mapping as L3Mapping
+        const y0 = mapping.get(f0)
+        if (y0 != null) {
+          const y1 = y0.mapping.get(f1)
+          if (y1 != null) {
+            const y2 = y1.mapping.get(f2)
+            if (y2 != null)
+              return y2.value
+          }
+        }
         return NaN
       }
-      return m[x[0]].mapping[x[1]].value
-    } else if (x.length == 3) {
-      const m = this._mapping as L3Mapping
-      if (!m.hasOwnProperty(x[0]) || !m[x[0]].mapping.hasOwnProperty(x[1]) || !m[x[0]].mapping[x[1]].mapping.hasOwnProperty(x[2]))  {
-        return NaN
-      }
-      return m[x[0]].mapping[x[1]].mapping[x[2]].value
-    } else
-      unreachable()
+      default:
+        unreachable()
+    }
   }
 
   // convert a string factor into a synthetic coordinate
@@ -233,21 +237,37 @@ export class FactorRange extends Range {
   }
 
   protected _init(silent: boolean): void {
-    let levels: number
-    let inside_padding: number
-    this.tops = null
-    this.mids = null
-    if (every(this.factors, isString)) {
-      levels = 1;
-      [this._mapping, inside_padding] = map_one_level(this.factors as string[], this.factor_padding)
-    } else if (every(this.factors, (x) => isArray(x) && x.length == 2 && isString(x[0]) && isString(x[1]))) {
-      levels = 2;
-      [this._mapping, this.tops, inside_padding] = map_two_levels(this.factors as [string, string][], this.group_padding, this.factor_padding)
-    } else if (every(this.factors, (x) => isArray(x) && x.length == 3  && isString(x[0]) && isString(x[1]) && isString(x[2]))) {
-      levels = 3;
-      [this._mapping, this.tops, this.mids, inside_padding] = map_three_levels(this.factors as [string, string, string][], this.group_padding, this.subgroup_padding, this.factor_padding)
-    } else
-      unreachable()
+    const {levels, mapping, tops, mids, inside_padding} = (() => {
+      if (every(this.factors, isString)) {
+        const factors = this.factors as string[]
+        const [mapping, inside_padding] = map_one_level(factors, this.factor_padding)
+        const tops = null
+        const mids = null
+        return {levels: 1, mapping, tops, mids, inside_padding}
+      } else if (every(this.factors, (x) => isArray(x) && x.length == 2 && isString(x[0]) && isString(x[1]))) {
+        const factors = this.factors as [string, string][]
+        const [mapping, inside_padding] = map_two_levels(factors, this.group_padding, this.factor_padding)
+        const tops = [...mapping.keys()]
+        const mids = null
+        return {levels: 2, mapping, tops, mids, inside_padding}
+      } else if (every(this.factors, (x) => isArray(x) && x.length == 3 && isString(x[0]) && isString(x[1]) && isString(x[2]))) {
+        const factors = this.factors as [string, string, string][]
+        const [mapping, inside_padding] = map_three_levels(factors, this.group_padding, this.subgroup_padding, this.factor_padding)
+        const tops = [...mapping.keys()]
+        const mids: [string, string][] = []
+        for (const [f0, L2] of mapping) {
+          for (const f1 of L2.mapping.keys()) {
+            mids.push([f0, f1])
+          }
+        }
+        return {levels: 3, mapping, tops, mids, inside_padding}
+      } else
+        unreachable()
+    })()
+
+    this._mapping = mapping
+    this.tops = tops
+    this.mids = mids
 
     let start = 0
     let end = this.factors.length + inside_padding

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -193,7 +193,7 @@ export class GlyphRendererView extends DataRendererView {
     }
 
     const dt = Date.now() - t0
-    logger.debug(`${this.glyph.model.type} GlyphRenderer (${this.model.id}): set_data finished in ${dt}ms`)
+    logger.debug(`${this.glyph.model.type} ${this.model}): set_data finished in ${dt}ms`)
 
     this.set_data_timestamp = Date.now()
 
@@ -350,7 +350,7 @@ export class GlyphRendererView extends DataRendererView {
     this.last_dtrender = dtrender
 
     const dttot = Date.now() - t0
-    logger.debug(`${this.glyph.model.type} GlyphRenderer (${this.model.id}): render finished in ${dttot}ms`)
+    logger.debug(`${this.glyph.model.type} ${this.model}: render finished in ${dttot}ms`)
     logger.trace(` - map_data finished in       : ${dtmap}ms`)
     logger.trace(` - mask_data finished in      : ${dtmask}ms`)
     if (dtselect != null) {

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -295,7 +295,7 @@ export class GlyphRendererView extends DataRendererView {
           glyph.render(ctx, this.all_indices, this.glyph)
         } else {
           for (const sglyph of inspected.selected_glyphs) {
-            if (sglyph.id == this.glyph.model.id)
+            if (sglyph == this.glyph.model)
               this.hover_glyph.render(ctx, this.all_indices, this.glyph)
           }
         }

--- a/bokehjs/src/lib/models/tools/toolbar_base.ts
+++ b/bokehjs/src/lib/models/tools/toolbar_base.ts
@@ -262,7 +262,7 @@ export class ToolbarBase extends Model {
     }
     const check_event_type = (et: EventType, tool: Tool) => {
       if (!(et in this.gestures)) {
-        logger.warn(`Toolbar: unknown event type '${et}' for tool: ${tool.type} (${tool.id})`)
+        logger.warn(`Toolbar: unknown event type '${et}' for tool: ${tool}`)
       }
     }
     const new_gestures = createGestureMap()
@@ -310,11 +310,11 @@ export class ToolbarBase extends Model {
       if (tool.active) {
         const currently_active_tool = this.gestures[et].active
         if (currently_active_tool != null && tool != currently_active_tool) {
-          logger.debug(`Toolbar: deactivating tool: ${currently_active_tool.type} (${currently_active_tool.id}) for event type '${et}'`)
+          logger.debug(`Toolbar: deactivating tool: ${currently_active_tool} for event type '${et}'`)
           currently_active_tool.active = false
         }
         this.gestures[et].active = tool
-        logger.debug(`Toolbar: activating tool: ${tool.type} (${tool.id}) for event type '${et}'`)
+        logger.debug(`Toolbar: activating tool: ${tool} for event type '${et}'`)
       } else
         this.gestures[et].active = null
     }

--- a/bokehjs/src/lib/models/widgets/selectbox.ts
+++ b/bokehjs/src/lib/models/widgets/selectbox.ts
@@ -48,7 +48,6 @@ export class SelectView extends InputWidgetView {
 
     this.input_el = select({
       class: bk_input,
-      id: this.model.id,
       name: this.model.name,
       disabled: this.model.disabled,
     }, this.options_el())

--- a/bokehjs/test/unit/models/ranges/factor_range.ts
+++ b/bokehjs/test/unit/models/ranges/factor_range.ts
@@ -36,77 +36,77 @@ describe("factor_range module", () => {
     describe("with zero padding", () => {
 
       it("should evenly map a list of factors starting at 0.5 (with no offset by default)", () => {
-        const r0 = map_one_level(['a'], 0)
-        expect(r0[0]).to.deep.equal({a: {value: 0.5}})
-        expect(r0[1]).to.be.equal(0)
+        const [m0, p0] = map_one_level(['a'], 0)
+        expect(m0).to.deep.equal(new Map([["a", {value: 0.5}]]))
+        expect(p0).to.be.equal(0)
 
-        const r1 = map_one_level(['a', 'b'], 0)
-        expect(r1[0]).to.deep.equal({a: {value: 0.5}, b: {value: 1.5}})
-        expect(r1[1]).to.be.equal(0)
+        const [m1, p1] = map_one_level(['a', 'b'], 0)
+        expect(m1).to.deep.equal(new Map([["a", {value: 0.5}], ["b", {value: 1.5}]]))
+        expect(p1).to.be.equal(0)
 
-        const r2 = map_one_level(['a', 'b', 'c'], 0)
-        expect(r2[0]).to.deep.equal({a: {value: 0.5}, b: {value: 1.5}, c: {value: 2.5}})
-        expect(r2[1]).to.be.equal(0)
+        const [m2, p2] = map_one_level(['a', 'b', 'c'], 0)
+        expect(m2).to.deep.equal(new Map([["a", {value: 0.5}], ["b", {value: 1.5}], ["c", {value: 2.5}]]))
+        expect(p2).to.be.equal(0)
 
-        const r3 = map_one_level(['a', 'b', 'c', 'd'], 0)
-        expect(r3[0]).to.deep.equal({a: {value: 0.5}, b: {value: 1.5}, c: {value: 2.5}, d: {value: 3.5}})
-        expect(r3[1]).to.be.equal(0)
+        const [m3, p3] = map_one_level(['a', 'b', 'c', 'd'], 0)
+        expect(m3).to.deep.equal(new Map([["a", {value: 0.5}], ["b", {value: 1.5}], ["c", {value: 2.5}], ["d", {value: 3.5}]]))
+        expect(p3).to.be.equal(0)
       })
 
       it("should also apply an offset if provided", () => {
-        const r0 = map_one_level(['a'], 0, 1)
-        expect(r0[0]).to.deep.equal({a: {value: 1.5}})
-        expect(r0[1]).to.be.equal(0)
+        const [m0, p0] = map_one_level(['a'], 0, 1)
+        expect(m0).to.deep.equal(new Map([["a", {value: 1.5}]]))
+        expect(p0).to.be.equal(0)
 
-        const r1 = map_one_level(['a', 'b'], 0, 1)
-        expect(r1[0]).to.deep.equal({a: {value: 1.5}, b: {value: 2.5}})
-        expect(r1[1]).to.be.equal(0)
+        const [m1, p1] = map_one_level(['a', 'b'], 0, 1)
+        expect(m1).to.deep.equal(new Map([["a", {value: 1.5}], ["b", {value: 2.5}]]))
+        expect(p1).to.be.equal(0)
 
-        const r2 = map_one_level(['a', 'b', 'c'], 0, 1)
-        expect(r2[0]).to.deep.equal({a: {value: 1.5}, b: {value: 2.5}, c: {value: 3.5}})
-        expect(r2[1]).to.be.equal(0)
+        const [m2, p2] = map_one_level(['a', 'b', 'c'], 0, 1)
+        expect(m2).to.deep.equal(new Map([["a", {value: 1.5}], ["b", {value: 2.5}], ["c", {value: 3.5}]]))
+        expect(p2).to.be.equal(0)
 
-        const r3 = map_one_level(['a', 'b', 'c', 'd'], 0, 1)
-        expect(r3[0]).to.deep.equal({a: {value: 1.5}, b: {value: 2.5}, c: {value: 3.5}, d: {value: 4.5}})
-        expect(r3[1]).to.be.equal(0)
+        const [m3, p3] = map_one_level(['a', 'b', 'c', 'd'], 0, 1)
+        expect(m3).to.deep.equal(new Map([["a", {value: 1.5}], ["b", {value: 2.5}], ["c", {value: 3.5}], ["d", {value: 4.5}]]))
+        expect(p3).to.be.equal(0)
       })
 
       describe("with positive padding", () => {
 
         it("should evenly map a list of factors, padded, starting at 0.5 (with no offset by default)", () => {
-          const r0 = map_one_level(['a'], 0.5)
-          expect(r0[0]).to.deep.equal({a: {value: 0.5}})
-          expect(r0[1]).to.be.equal(0)
+          const [m0, p0] = map_one_level(['a'], 0.5)
+          expect(m0).to.deep.equal(new Map([["a", {value: 0.5}]]))
+          expect(p0).to.be.equal(0)
 
-          const r1 = map_one_level(['a', 'b'], 0.5)
-          expect(r1[0]).to.deep.equal({a: {value: 0.5}, b: {value: 2}})
-          expect(r1[1]).to.be.equal(0.5)
+          const [m1, p1] = map_one_level(['a', 'b'], 0.5)
+          expect(m1).to.deep.equal(new Map([["a", {value: 0.5}], ["b", {value: 2}]]))
+          expect(p1).to.be.equal(0.5)
 
-          const r2 = map_one_level(['a', 'b', 'c'], 0.5)
-          expect(r2[0]).to.deep.equal({a: {value: 0.5}, b: {value: 2}, c: {value: 3.5}})
-          expect(r2[1]).to.be.equal(1)
+          const [m2, p2] = map_one_level(['a', 'b', 'c'], 0.5)
+          expect(m2).to.deep.equal(new Map([["a", {value: 0.5}], ["b", {value: 2}], ["c", {value: 3.5}]]))
+          expect(p2).to.be.equal(1)
 
-          const r3 = map_one_level(['a', 'b', 'c', 'd'], 0.5)
-          expect(r3[0]).to.deep.equal({a: {value: 0.5}, b: {value: 2}, c: {value: 3.5}, d: {value: 5}})
-          expect(r3[1]).to.be.equal(1.5)
+          const [m3, p3] = map_one_level(['a', 'b', 'c', 'd'], 0.5)
+          expect(m3).to.deep.equal(new Map([["a", {value: 0.5}], ["b", {value: 2}], ["c", {value: 3.5}], ["d", {value: 5}]]))
+          expect(p3).to.be.equal(1.5)
         })
 
         it("should also apply an offset if provided", () => {
-          const r0 = map_one_level(['a'], 0.5, 1)
-          expect(r0[0]).to.deep.equal({a: {value: 1.5}})
-          expect(r0[1]).to.be.equal(0)
+          const [m0, p0] = map_one_level(['a'], 0.5, 1)
+          expect(m0).to.deep.equal(new Map([["a", {value: 1.5}]]))
+          expect(p0).to.be.equal(0)
 
-          const r1 = map_one_level(['a', 'b'], 0.5, 1)
-          expect(r1[0]).to.deep.equal({a: {value: 1.5}, b: {value: 3}})
-          expect(r1[1]).to.be.equal(0.5)
+          const [m1, p1] = map_one_level(['a', 'b'], 0.5, 1)
+          expect(m1).to.deep.equal(new Map([["a", {value: 1.5}], ["b", {value: 3}]]))
+          expect(p1).to.be.equal(0.5)
 
-          const r2 = map_one_level(['a', 'b', 'c'], 0.5, 1)
-          expect(r2[0]).to.deep.equal({a: {value: 1.5}, b: {value: 3}, c: {value: 4.5}})
-          expect(r2[1]).to.be.equal(1)
+          const [m2, p2] = map_one_level(['a', 'b', 'c'], 0.5, 1)
+          expect(m2).to.deep.equal(new Map([["a", {value: 1.5}], ["b", {value: 3}], ["c", {value: 4.5}]]))
+          expect(p2).to.be.equal(1)
 
-          const r3 = map_one_level(['a', 'b', 'c', 'd'], 0.5, 1)
-          expect(r3[0]).to.deep.equal({a: {value: 1.5}, b: {value: 3}, c: {value: 4.5}, d: {value: 6}})
-          expect(r3[1]).to.be.equal(1.5)
+          const [m3, p3] = map_one_level(['a', 'b', 'c', 'd'], 0.5, 1)
+          expect(m3).to.deep.equal(new Map([["a", {value: 1.5}], ["b", {value: 3}], ["c", {value: 4.5}], ["d", {value: 6}]]))
+          expect(p3).to.be.equal(1.5)
         })
       })
     })
@@ -117,396 +117,348 @@ describe("factor_range module", () => {
     describe("with zero outer_padding and zero factor_padding", () => {
 
       it("should evenly map a list of factors starting at 0.5 (with no offset by default)", () => {
-        const r0 = map_two_levels([['a', '1']], 0, 0)
-        expect(r0[0]).to.deep.equal({
-          a: {value: 0.5, mapping: {1: {value: 0.5}}},
-        })
-        expect(r0[1]).to.deep.equal(['a'])
-        expect(r0[2]).to.be.equal(0)
+        const [m0, p0] = map_two_levels([['a', '1']], 0, 0)
+        expect(m0).to.deep.equal(new Map([
+          ["a", {value: 0.5, mapping: new Map([["1", {value: 0.5}]])}],
+        ]))
+        expect(p0).to.be.equal(0)
 
-        const r1 = map_two_levels([['a', '1'], ['a', '2']], 0, 0)
-        expect(r1[0]).to.deep.equal({
-          a: {value: 1, mapping: {1: {value: 0.5}, 2: {value: 1.5}}},
-        })
-        expect(r1[1]).to.deep.equal(['a'])
-        expect(r1[2]).to.be.equal(0)
+        const [m1, p1] = map_two_levels([['a', '1'], ['a', '2']], 0, 0)
+        expect(m1).to.deep.equal(new Map([
+          ["a", {value: 1, mapping: new Map([["1", {value: 0.5}], ["2", {value: 1.5}]])}],
+        ]))
+        expect(p1).to.be.equal(0)
 
-        const r2 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3']], 0, 0)
-        expect(r2[0]).to.deep.equal({
-          a: {value: 1.5, mapping: {1: {value: 0.5}, 2: {value: 1.5}, 3: {value: 2.5}}},
-        })
-        expect(r2[1]).to.deep.equal(['a'])
-        expect(r2[2]).to.be.equal(0)
+        const [m2, p2] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3']], 0, 0)
+        expect(m2).to.deep.equal(new Map([
+          ["a", {value: 1.5, mapping: new Map([["1", {value: 0.5}], ["2", {value: 1.5}], ["3", {value: 2.5}]])}],
+        ]))
+        expect(p2).to.be.equal(0)
 
-        const r3 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1']], 0, 0)
-        expect(r3[0]).to.deep.equal({
-          a: {value: 1.5, mapping: {1: {value: 0.5}, 2: {value: 1.5}, 3: {value: 2.5}}},
-          b: {value: 3.5, mapping: {1: {value: 3.5}}},
-        })
-        expect(r3[1]).to.deep.equal(['a', 'b'])
-        expect(r3[2]).to.be.equal(0)
+        const [m3, p3] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1']], 0, 0)
+        expect(m3).to.deep.equal(new Map([
+          ["a", {value: 1.5, mapping: new Map([["1", {value: 0.5}], ["2", {value: 1.5}], ["3", {value: 2.5}]])}],
+          ["b", {value: 3.5, mapping: new Map([["1", {value: 3.5}]])}],
+        ]))
+        expect(p3).to.be.equal(0)
 
-        const r4 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4']], 0, 0)
-        expect(r4[0]).to.deep.equal({
-          a: {value: 1.5, mapping: {1: {value: 0.5}, 2: {value: 1.5}, 3: {value: 2.5}}},
-          b: {value: 4,   mapping: {1: {value: 3.5}, 4: {value: 4.5}}},
-        })
-        expect(r4[1]).to.deep.equal(['a', 'b'])
-        expect(r4[2]).to.be.equal(0)
+        const [m4, p4] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4']], 0, 0)
+        expect(m4).to.deep.equal(new Map([
+          ["a", {value: 1.5, mapping: new Map([["1", {value: 0.5}], ["2", {value: 1.5}], ["3", {value: 2.5}]])}],
+          ["b", {value: 4,   mapping: new Map([["1", {value: 3.5}], ["4", {value: 4.5}]])}],
+        ]))
+        expect(p4).to.be.equal(0)
 
-        const r5 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4'], ['c', '0']], 0, 0)
-        expect(r5[0]).to.deep.equal({
-          a: {value: 1.5, mapping: {1: {value: 0.5}, 2: {value: 1.5}, 3: {value: 2.5}}},
-          b: {value: 4,   mapping: {1: {value: 3.5}, 4: {value: 4.5}}},
-          c: {value: 5.5, mapping: {0: {value: 5.5}}},
-        })
-        expect(r5[1]).to.deep.equal(['a', 'b', 'c'])
-        expect(r5[2]).to.be.equal(0)
+        const [m5, p5] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4'], ['c', '0']], 0, 0)
+        expect(m5).to.deep.equal(new Map([
+          ["a", {value: 1.5, mapping: new Map([["1", {value: 0.5}], ["2", {value: 1.5}], ["3", {value: 2.5}]])}],
+          ["b", {value: 4,   mapping: new Map([["1", {value: 3.5}], ["4", {value: 4.5}]])}],
+          ["c", {value: 5.5, mapping: new Map([["0", {value: 5.5}]])}],
+        ]))
+        expect(p5).to.be.equal(0)
       })
 
       it("should also apply an offset if provided", () => {
-        const r0 = map_two_levels([['a', '1']], 0, 0, 1)
-        expect(r0[0]).to.deep.equal({
-          a: {value: 1.5, mapping: {1: {value: 1.5}}},
-        })
-        expect(r0[1]).to.deep.equal(['a'])
-        expect(r0[2]).to.be.equal(0)
+        const [m0, p0] = map_two_levels([['a', '1']], 0, 0, 1)
+        expect(m0).to.deep.equal(new Map([
+          ["a", {value: 1.5, mapping: new Map([["1", {value: 1.5}]])}],
+        ]))
+        expect(p0).to.be.equal(0)
 
-        const r1 = map_two_levels([['a', '1'], ['a', '2']], 0, 0, 1)
-        expect(r1[0]).to.deep.equal({
-          a: {value: 2, mapping: {1: {value: 1.5}, 2: {value: 2.5}}},
-        })
-        expect(r1[1]).to.deep.equal(['a'])
-        expect(r1[2]).to.be.equal(0)
+        const [m1, p1] = map_two_levels([['a', '1'], ['a', '2']], 0, 0, 1)
+        expect(m1).to.deep.equal(new Map([
+          ["a", {value: 2, mapping: new Map([["1", {value: 1.5}], ["2", {value: 2.5}]])}],
+        ]))
+        expect(p1).to.be.equal(0)
 
-        const r2 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3']], 0, 0, 1)
-        expect(r2[0]).to.deep.equal({
-          a: {value: 2.5, mapping: {1: {value: 1.5}, 2: {value: 2.5}, 3: {value: 3.5}}},
-        })
-        expect(r2[1]).to.deep.equal(['a'])
-        expect(r2[2]).to.be.equal(0)
+        const [m2, p2] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3']], 0, 0, 1)
+        expect(m2).to.deep.equal(new Map([
+          ["a", {value: 2.5, mapping: new Map([["1", {value: 1.5}], ["2", {value: 2.5}], ["3", {value: 3.5}]])}],
+        ]))
+        expect(p2).to.be.equal(0)
 
-        const r3 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1']], 0, 0, 1)
-        expect(r3[0]).to.deep.equal({
-          a: {value: 2.5, mapping: {1: {value: 1.5}, 2: {value: 2.5}, 3: {value: 3.5}}},
-          b: {value: 4.5, mapping: {1: {value: 4.5}}},
-        })
-        expect(r3[1]).to.deep.equal(['a', 'b'])
-        expect(r3[2]).to.be.equal(0)
+        const [m3, p3] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1']], 0, 0, 1)
+        expect(m3).to.deep.equal(new Map([
+          ["a", {value: 2.5, mapping: new Map([["1", {value: 1.5}], ["2", {value: 2.5}], ["3", {value: 3.5}]])}],
+          ["b", {value: 4.5, mapping: new Map([["1", {value: 4.5}]])}],
+        ]))
+        expect(p3).to.be.equal(0)
 
-        const r4 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4']], 0, 0, 1)
-        expect(r4[0]).to.deep.equal({
-          a: {value: 2.5, mapping: {1: {value: 1.5}, 2: {value: 2.5}, 3: {value: 3.5}}},
-          b: {value: 5, mapping: {1: {value: 4.5}, 4: {value: 5.5}}},
-        })
-        expect(r4[1]).to.deep.equal(['a', 'b'])
-        expect(r4[2]).to.be.equal(0)
+        const [m4, p4] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4']], 0, 0, 1)
+        expect(m4).to.deep.equal(new Map([
+          ["a", {value: 2.5, mapping: new Map([["1", {value: 1.5}], ["2", {value: 2.5}], ["3", {value: 3.5}]])}],
+          ["b", {value: 5, mapping: new Map([["1", {value: 4.5}], ["4", {value: 5.5}]])}],
+        ]))
+        expect(p4).to.be.equal(0)
 
-        const r5 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4'], ['c', '0']], 0, 0, 1)
-        expect(r5[0]).to.deep.equal({
-          a: {value: 2.5, mapping: {1: {value: 1.5}, 2: {value: 2.5}, 3: {value: 3.5}}},
-          b: {value: 5, mapping: {1: {value: 4.5}, 4: {value: 5.5}}},
-          c: {value: 6.5, mapping: {0: {value: 6.5}}},
-        })
-        expect(r5[1]).to.deep.equal(['a', 'b', 'c'])
-        expect(r5[2]).to.be.equal(0)
+        const [m5, p5] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4'], ['c', '0']], 0, 0, 1)
+        expect(m5).to.deep.equal(new Map([
+          ["a", {value: 2.5, mapping: new Map([["1", {value: 1.5}], ["2", {value: 2.5}], ["3", {value: 3.5}]])}],
+          ["b", {value: 5, mapping: new Map([["1", {value: 4.5}], ["4", {value: 5.5}]])}],
+          ["c", {value: 6.5, mapping: new Map([["0", {value: 6.5}]])}],
+        ]))
+        expect(p5).to.be.equal(0)
       })
     })
 
     describe("with nonzero outer_padding and zero factor_padding", () => {
 
       it("should map a list of factors starting at 0.5 (with no offset by default)", () => {
-        const r0 = map_two_levels([['a', '1']], 2, 0)
-        expect(r0[0]).to.deep.equal({
-          a: {value: 0.5, mapping: {1: {value: 0.5}}},
-        })
-        expect(r0[1]).to.deep.equal(['a'])
-        expect(r0[2]).to.be.equal(0)
+        const [m0, p0] = map_two_levels([['a', '1']], 2, 0)
+        expect(m0).to.deep.equal(new Map([
+          ["a", {value: 0.5, mapping: new Map([["1", {value: 0.5}]])}],
+        ]))
+        expect(p0).to.be.equal(0)
 
-        const r1 = map_two_levels([['a', '1'], ['a', '2']], 2, 0)
-        expect(r1[0]).to.deep.equal({
-          a: {value: 1, mapping: {1: {value: 0.5}, 2: {value: 1.5}}},
-        })
-        expect(r1[1]).to.deep.equal(['a'])
-        expect(r1[2]).to.be.equal(0)
+        const [m1, p1] = map_two_levels([['a', '1'], ['a', '2']], 2, 0)
+        expect(m1).to.deep.equal(new Map([
+          ["a", {value: 1, mapping: new Map([["1", {value: 0.5}], ["2", {value: 1.5}]])}],
+        ]))
+        expect(p1).to.be.equal(0)
 
-        const r2 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3']], 2, 0)
-        expect(r2[0]).to.deep.equal({
-          a: {value: 1.5, mapping: {1: {value: 0.5}, 2: {value: 1.5}, 3: {value: 2.5}}},
-        })
-        expect(r2[1]).to.deep.equal(['a'])
-        expect(r2[2]).to.be.equal(0)
+        const [m2, p2] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3']], 2, 0)
+        expect(m2).to.deep.equal(new Map([
+          ["a", {value: 1.5, mapping: new Map([["1", {value: 0.5}], ["2", {value: 1.5}], ["3", {value: 2.5}]])}],
+        ]))
+        expect(p2).to.be.equal(0)
 
-        const r3 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1']], 2, 0)
-        expect(r3[0]).to.deep.equal({
-          a: {value: 1.5, mapping: {1: {value: 0.5}, 2: {value: 1.5}, 3: {value: 2.5}}},
-          b: {value: 5.5, mapping: {1: {value: 5.5}}},
-        })
-        expect(r3[1]).to.deep.equal(['a', 'b'])
-        expect(r3[2]).to.be.equal(2)
+        const [m3, p3] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1']], 2, 0)
+        expect(m3).to.deep.equal(new Map([
+          ["a", {value: 1.5, mapping: new Map([["1", {value: 0.5}], ["2", {value: 1.5}], ["3", {value: 2.5}]])}],
+          ["b", {value: 5.5, mapping: new Map([["1", {value: 5.5}]])}],
+        ]))
+        expect(p3).to.be.equal(2)
 
-        const r4 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4']], 2, 0)
-        expect(r4[0]).to.deep.equal({
-          a: {value: 1.5, mapping: {1: {value: 0.5}, 2: {value: 1.5}, 3: {value: 2.5}}},
-          b: {value: 6,   mapping: {1: {value: 5.5}, 4: {value: 6.5}}},
-        })
-        expect(r4[1]).to.deep.equal(['a', 'b'])
-        expect(r4[2]).to.be.equal(2)
+        const [m4, p4] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4']], 2, 0)
+        expect(m4).to.deep.equal(new Map([
+          ["a", {value: 1.5, mapping: new Map([["1", {value: 0.5}], ["2", {value: 1.5}], ["3", {value: 2.5}]])}],
+          ["b", {value: 6,   mapping: new Map([["1", {value: 5.5}], ["4", {value: 6.5}]])}],
+        ]))
+        expect(p4).to.be.equal(2)
 
-        const r5 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4'], ['c', '0']], 2, 0)
-        expect(r5[0]).to.deep.equal({
-          a: {value: 1.5, mapping: {1: {value: 0.5}, 2: {value: 1.5}, 3: {value: 2.5}}},
-          b: {value: 6,   mapping: {1: {value: 5.5}, 4: {value: 6.5}}},
-          c: {value: 9.5, mapping: {0: {value: 9.5}}},
-        })
-        expect(r5[1]).to.deep.equal(['a', 'b', 'c'])
-        expect(r5[2]).to.be.equal(4)
+        const [m5, p5] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4'], ['c', '0']], 2, 0)
+        expect(m5).to.deep.equal(new Map([
+          ["a", {value: 1.5, mapping: new Map([["1", {value: 0.5}], ["2", {value: 1.5}], ["3", {value: 2.5}]])}],
+          ["b", {value: 6,   mapping: new Map([["1", {value: 5.5}], ["4", {value: 6.5}]])}],
+          ["c", {value: 9.5, mapping: new Map([["0", {value: 9.5}]])}],
+        ]))
+        expect(p5).to.be.equal(4)
       })
 
       it("should also apply an offset if provided", () => {
-        const r0 = map_two_levels([['a', '1']], 2, 0, 1)
-        expect(r0[0]).to.deep.equal({
-          a: {value: 1.5, mapping: {1: {value: 1.5}}},
-        })
-        expect(r0[1]).to.deep.equal(['a'])
-        expect(r0[2]).to.be.equal(0)
+        const [m0, p0] = map_two_levels([['a', '1']], 2, 0, 1)
+        expect(m0).to.deep.equal(new Map([
+          ["a", {value: 1.5, mapping: new Map([["1", {value: 1.5}]])}],
+        ]))
+        expect(p0).to.be.equal(0)
 
-        const r1 = map_two_levels([['a', '1'], ['a', '2']], 2, 0, 1)
-        expect(r1[0]).to.deep.equal({
-          a: {value: 2, mapping: {1: {value: 1.5}, 2: {value: 2.5}}},
-        })
-        expect(r1[1]).to.deep.equal(['a'])
-        expect(r1[2]).to.be.equal(0)
+        const [m1, p1] = map_two_levels([['a', '1'], ['a', '2']], 2, 0, 1)
+        expect(m1).to.deep.equal(new Map([
+          ["a", {value: 2, mapping: new Map([["1", {value: 1.5}], ["2", {value: 2.5}]])}],
+        ]))
+        expect(p1).to.be.equal(0)
 
-        const r2 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3']], 2, 0, 1)
-        expect(r2[0]).to.deep.equal({
-          a: {value: 2.5, mapping: {1: {value: 1.5}, 2: {value: 2.5}, 3: {value: 3.5}}},
-        })
-        expect(r2[1]).to.deep.equal(['a'])
-        expect(r2[2]).to.be.equal(0)
+        const [m2, p2] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3']], 2, 0, 1)
+        expect(m2).to.deep.equal(new Map([
+          ["a", {value: 2.5, mapping: new Map([["1", {value: 1.5}], ["2", {value: 2.5}], ["3", {value: 3.5}]])}],
+        ]))
+        expect(p2).to.be.equal(0)
 
-        const r3 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1']], 2, 0, 1)
-        expect(r3[0]).to.deep.equal({
-          a: {value: 2.5, mapping: {1: {value: 1.5}, 2: {value: 2.5}, 3: {value: 3.5}}},
-          b: {value: 6.5, mapping: {1: {value: 6.5}}},
-        })
-        expect(r3[1]).to.deep.equal(['a', 'b'])
-        expect(r3[2]).to.be.equal(2)
+        const [m3, p3] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1']], 2, 0, 1)
+        expect(m3).to.deep.equal(new Map([
+          ["a", {value: 2.5, mapping: new Map([["1", {value: 1.5}], ["2", {value: 2.5}], ["3", {value: 3.5}]])}],
+          ["b", {value: 6.5, mapping: new Map([["1", {value: 6.5}]])}],
+        ]))
+        expect(p3).to.be.equal(2)
 
-        const r4 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4']], 2, 0, 1)
-        expect(r4[0]).to.deep.equal({
-          a: {value: 2.5, mapping: {1: {value: 1.5}, 2: {value: 2.5}, 3: {value: 3.5}}},
-          b: {value: 7, mapping: {1: {value: 6.5}, 4: {value: 7.5}}},
-        })
-        expect(r4[1]).to.deep.equal(['a', 'b'])
-        expect(r4[2]).to.be.equal(2)
+        const [m4, p4] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4']], 2, 0, 1)
+        expect(m4).to.deep.equal(new Map([
+          ["a", {value: 2.5, mapping: new Map([["1", {value: 1.5}], ["2", {value: 2.5}], ["3", {value: 3.5}]])}],
+          ["b", {value: 7, mapping: new Map([["1", {value: 6.5}], ["4", {value: 7.5}]])}],
+        ]))
+        expect(p4).to.be.equal(2)
 
-        const r5 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4'], ['c', '0']], 2, 0, 1)
-        expect(r5[0]).to.deep.equal({
-          a: {value: 2.5, mapping: {1: {value:  1.5}, 2: {value: 2.5}, 3: {value: 3.5}}},
-          b: {value: 7, mapping: {1: {value:  6.5}, 4: {value: 7.5}}},
-          c: {value: 10.5, mapping: {0: {value: 10.5}}},
-        })
-        expect(r5[1]).to.deep.equal(['a', 'b', 'c'])
-        expect(r5[2]).to.be.equal(4)
+        const [m5, p5] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4'], ['c', '0']], 2, 0, 1)
+        expect(m5).to.deep.equal(new Map([
+          ["a", {value: 2.5, mapping: new Map([["1", {value:  1.5}], ["2", {value: 2.5}], ["3", {value: 3.5}]])}],
+          ["b", {value: 7, mapping: new Map([["1", {value:  6.5}], ["4", {value: 7.5}]])}],
+          ["c", {value: 10.5, mapping: new Map([["0", {value: 10.5}]])}],
+        ]))
+        expect(p5).to.be.equal(4)
       })
     })
 
     describe("with zero outer_padding and nonzero factor_padding", () => {
 
       it("should map a list of factors starting at 0.5 (with no offset by default)", () => {
-        const r0 = map_two_levels([['a', '1']], 0, 1)
-        expect(r0[0]).to.deep.equal({
-          a: {value: 0.5, mapping: {1: {value: 0.5}}},
-        })
-        expect(r0[1]).to.deep.equal(['a'])
-        expect(r0[2]).to.be.equal(0)
+        const [m0, p0] = map_two_levels([['a', '1']], 0, 1)
+        expect(m0).to.deep.equal(new Map([
+          ["a", {value: 0.5, mapping: new Map([["1", {value: 0.5}]])}],
+        ]))
+        expect(p0).to.be.equal(0)
 
-        const r1 = map_two_levels([['a', '1'], ['a', '2']], 0, 1)
-        expect(r1[0]).to.deep.equal({
-          a: {value: 1.5, mapping: {1: {value: 0.5}, 2: {value: 2.5}}},
-        })
-        expect(r1[1]).to.deep.equal(['a'])
-        expect(r1[2]).to.be.equal(1)
+        const [m1, p1] = map_two_levels([['a', '1'], ['a', '2']], 0, 1)
+        expect(m1).to.deep.equal(new Map([
+          ["a", {value: 1.5, mapping: new Map([["1", {value: 0.5}], ["2", {value: 2.5}]])}],
+        ]))
+        expect(p1).to.be.equal(1)
 
-        const r2 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3']], 0, 1)
-        expect(r2[0]).to.deep.equal({
-          a: {value: 2.5, mapping: {1: {value: 0.5}, 2: {value: 2.5}, 3: {value: 4.5}}},
-        })
-        expect(r2[1]).to.deep.equal(['a'])
-        expect(r2[2]).to.be.equal(2)
+        const [m2, p2] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3']], 0, 1)
+        expect(m2).to.deep.equal(new Map([
+          ["a", {value: 2.5, mapping: new Map([["1", {value: 0.5}], ["2", {value: 2.5}], ["3", {value: 4.5}]])}],
+        ]))
+        expect(p2).to.be.equal(2)
 
-        const r3 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1']], 0, 1)
-        expect(r3[0]).to.deep.equal({
-          a: {value: 2.5, mapping: {1: {value: 0.5}, 2: {value: 2.5}, 3: {value: 4.5}}},
-          b: {value: 5.5, mapping: {1: {value: 5.5}}},
-        })
-        expect(r3[1]).to.deep.equal(['a', 'b'])
-        expect(r3[2]).to.be.equal(2)
+        const [m3, p3] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1']], 0, 1)
+        expect(m3).to.deep.equal(new Map([
+          ["a", {value: 2.5, mapping: new Map([["1", {value: 0.5}], ["2", {value: 2.5}], ["3", {value: 4.5}]])}],
+          ["b", {value: 5.5, mapping: new Map([["1", {value: 5.5}]])}],
+        ]))
+        expect(p3).to.be.equal(2)
 
-        const r4 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4']], 0, 1)
-        expect(r4[0]).to.deep.equal({
-          a: {value: 2.5, mapping: {1: {value: 0.5}, 2: {value: 2.5}, 3: {value: 4.5}}},
-          b: {value: 6.5, mapping: {1: {value: 5.5}, 4: {value: 7.5}}},
-        })
-        expect(r4[1]).to.deep.equal(['a', 'b'])
-        expect(r4[2]).to.be.equal(3)
+        const [m4, p4] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4']], 0, 1)
+        expect(m4).to.deep.equal(new Map([
+          ["a", {value: 2.5, mapping: new Map([["1", {value: 0.5}], ["2", {value: 2.5}], ["3", {value: 4.5}]])}],
+          ["b", {value: 6.5, mapping: new Map([["1", {value: 5.5}], ["4", {value: 7.5}]])}],
+        ]))
+        expect(p4).to.be.equal(3)
 
-        const r5 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4'], ['c', '0']], 0, 1)
-        expect(r5[0]).to.deep.equal({
-          a: {value: 2.5, mapping: {1: {value: 0.5}, 2: {value: 2.5}, 3: {value: 4.5}}},
-          b: {value: 6.5, mapping: {1: {value: 5.5}, 4: {value: 7.5}}},
-          c: {value: 8.5, mapping: {0: {value: 8.5}}},
-        })
-        expect(r5[1]).to.deep.equal(['a', 'b', 'c'])
-        expect(r5[2]).to.be.equal(3)
+        const [m5, p5] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4'], ['c', '0']], 0, 1)
+        expect(m5).to.deep.equal(new Map([
+          ["a", {value: 2.5, mapping: new Map([["1", {value: 0.5}], ["2", {value: 2.5}], ["3", {value: 4.5}]])}],
+          ["b", {value: 6.5, mapping: new Map([["1", {value: 5.5}], ["4", {value: 7.5}]])}],
+          ["c", {value: 8.5, mapping: new Map([["0", {value: 8.5}]])}],
+        ]))
+        expect(p5).to.be.equal(3)
       })
 
       it("should also apply an offset if provided", () => {
-        const r0 = map_two_levels([['a', '1']], 0, 1, 1)
-        expect(r0[0]).to.deep.equal({
-          a: {value: 1.5, mapping: {1: {value: 1.5}}},
-        })
-        expect(r0[1]).to.deep.equal(['a'])
-        expect(r0[2]).to.be.equal(0)
+        const [m0, p0] = map_two_levels([['a', '1']], 0, 1, 1)
+        expect(m0).to.deep.equal(new Map([
+          ["a", {value: 1.5, mapping: new Map([["1", {value: 1.5}]])}],
+        ]))
+        expect(p0).to.be.equal(0)
 
-        const r1 = map_two_levels([['a', '1'], ['a', '2']], 0, 1, 1)
-        expect(r1[0]).to.deep.equal({
-          a: {value: 2.5, mapping: {1: {value: 1.5}, 2: {value: 3.5}}},
-        })
-        expect(r1[1]).to.deep.equal(['a'])
-        expect(r1[2]).to.be.equal(1)
+        const [m1, p1] = map_two_levels([['a', '1'], ['a', '2']], 0, 1, 1)
+        expect(m1).to.deep.equal(new Map([
+          ["a", {value: 2.5, mapping: new Map([["1", {value: 1.5}], ["2", {value: 3.5}]])}],
+        ]))
+        expect(p1).to.be.equal(1)
 
-        const r2 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3']], 0, 1, 1)
-        expect(r2[0]).to.deep.equal({
-          a: {value: 3.5, mapping: {1: {value: 1.5}, 2: {value: 3.5}, 3: {value: 5.5}}},
-        })
-        expect(r2[1]).to.deep.equal(['a'])
-        expect(r2[2]).to.be.equal(2)
+        const [m2, p2] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3']], 0, 1, 1)
+        expect(m2).to.deep.equal(new Map([
+          ["a", {value: 3.5, mapping: new Map([["1", {value: 1.5}], ["2", {value: 3.5}], ["3", {value: 5.5}]])}],
+        ]))
+        expect(p2).to.be.equal(2)
 
-        const r3 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1']], 0, 1, 1)
-        expect(r3[0]).to.deep.equal({
-          a: {value: 3.5, mapping: {1: {value: 1.5}, 2: {value: 3.5}, 3: {value: 5.5}}},
-          b: {value: 6.5, mapping: {1: {value: 6.5}}},
-        })
-        expect(r3[1]).to.deep.equal(['a', 'b'])
-        expect(r3[2]).to.be.equal(2)
+        const [m3, p3] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1']], 0, 1, 1)
+        expect(m3).to.deep.equal(new Map([
+          ["a", {value: 3.5, mapping: new Map([["1", {value: 1.5}], ["2", {value: 3.5}], ["3", {value: 5.5}]])}],
+          ["b", {value: 6.5, mapping: new Map([["1", {value: 6.5}]])}],
+        ]))
+        expect(p3).to.be.equal(2)
 
-        const r4 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4']], 0, 1, 1)
-        expect(r4[0]).to.deep.equal({
-          a: {value: 3.5, mapping: {1: {value: 1.5}, 2: {value: 3.5}, 3: {value: 5.5}}},
-          b: {value: 7.5, mapping: {1: {value: 6.5}, 4: {value: 8.5}}},
-        })
-        expect(r4[1]).to.deep.equal(['a', 'b'])
-        expect(r4[2]).to.be.equal(3)
+        const [m4, p4] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4']], 0, 1, 1)
+        expect(m4).to.deep.equal(new Map([
+          ["a", {value: 3.5, mapping: new Map([["1", {value: 1.5}], ["2", {value: 3.5}], ["3", {value: 5.5}]])}],
+          ["b", {value: 7.5, mapping: new Map([["1", {value: 6.5}], ["4", {value: 8.5}]])}],
+        ]))
+        expect(p4).to.be.equal(3)
 
-        const r5 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4'], ['c', '0']], 0, 1, 1)
-        expect(r5[0]).to.deep.equal({
-          a: {value: 3.5, mapping: {1: {value: 1.5}, 2: {value: 3.5}, 3: {value: 5.5}}},
-          b: {value: 7.5, mapping: {1: {value: 6.5}, 4: {value: 8.5}}},
-          c: {value: 9.5, mapping: {0: {value: 9.5}}},
-        })
-        expect(r5[1]).to.deep.equal(['a', 'b', 'c'])
-        expect(r5[2]).to.be.equal(3)
+        const [m5, p5] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4'], ['c', '0']], 0, 1, 1)
+        expect(m5).to.deep.equal(new Map([
+          ["a", {value: 3.5, mapping: new Map([["1", {value: 1.5}], ["2", {value: 3.5}], ["3", {value: 5.5}]])}],
+          ["b", {value: 7.5, mapping: new Map([["1", {value: 6.5}], ["4", {value: 8.5}]])}],
+          ["c", {value: 9.5, mapping: new Map([["0", {value: 9.5}]])}],
+        ]))
+        expect(p5).to.be.equal(3)
       })
     })
 
     describe("with nonzero outer_padding and nonzero factor_padding", () => {
 
       it("should map a list of factors starting at 0.5 (with no offset by default)", () => {
-        const r0 = map_two_levels([['a', '1']], 2, 1)
-        expect(r0[0]).to.deep.equal({
-          a: {value: 0.5, mapping: {1: {value: 0.5}}},
-        })
-        expect(r0[1]).to.deep.equal(['a'])
-        expect(r0[2]).to.be.equal(0)
+        const [m0, p0] = map_two_levels([['a', '1']], 2, 1)
+        expect(m0).to.deep.equal(new Map([
+          ["a", {value: 0.5, mapping: new Map([["1", {value: 0.5}]])}],
+        ]))
+        expect(p0).to.be.equal(0)
 
-        const r1 = map_two_levels([['a', '1'], ['a', '2']], 2, 1)
-        expect(r1[0]).to.deep.equal({
-          a: {value: 1.5, mapping: {1: {value: 0.5}, 2: {value: 2.5}}},
-        })
-        expect(r1[1]).to.deep.equal(['a'])
-        expect(r1[2]).to.be.equal(1)
+        const [m1, p1] = map_two_levels([['a', '1'], ['a', '2']], 2, 1)
+        expect(m1).to.deep.equal(new Map([
+          ["a", {value: 1.5, mapping: new Map([["1", {value: 0.5}], ["2", {value: 2.5}]])}],
+        ]))
+        expect(p1).to.be.equal(1)
 
-        const r2 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3']], 2, 1)
-        expect(r2[0]).to.deep.equal({
-          a: {value: 2.5, mapping: {1: {value: 0.5}, 2: {value: 2.5}, 3: {value: 4.5}}},
-        })
-        expect(r2[1]).to.deep.equal(['a'])
-        expect(r2[2]).to.be.equal(2)
+        const [m2, p2] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3']], 2, 1)
+        expect(m2).to.deep.equal(new Map([
+          ["a", {value: 2.5, mapping: new Map([["1", {value: 0.5}], ["2", {value: 2.5}], ["3", {value: 4.5}]])}],
+        ]))
+        expect(p2).to.be.equal(2)
 
-        const r3 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1']], 2, 1)
-        expect(r3[0]).to.deep.equal({
-          a: {value: 2.5, mapping: {1: {value: 0.5}, 2: {value: 2.5}, 3: {value: 4.5}}},
-          b: {value: 7.5, mapping: {1: {value: 7.5}}},
-        })
-        expect(r3[1]).to.deep.equal(['a', 'b'])
-        expect(r3[2]).to.be.equal(4)
+        const [m3, p3] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1']], 2, 1)
+        expect(m3).to.deep.equal(new Map([
+          ["a", {value: 2.5, mapping: new Map([["1", {value: 0.5}], ["2", {value: 2.5}], ["3", {value: 4.5}]])}],
+          ["b", {value: 7.5, mapping: new Map([["1", {value: 7.5}]])}],
+        ]))
+        expect(p3).to.be.equal(4)
 
-        const r4 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4']], 2, 1)
-        expect(r4[0]).to.deep.equal({
-          a: {value: 2.5, mapping: {1: {value: 0.5}, 2: {value: 2.5}, 3: {value: 4.5}}},
-          b: {value: 8.5, mapping: {1: {value: 7.5}, 4: {value: 9.5}}},
-        })
-        expect(r4[1]).to.deep.equal(['a', 'b'])
-        expect(r4[2]).to.be.equal(5)
+        const [m4, p4] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4']], 2, 1)
+        expect(m4).to.deep.equal(new Map([
+          ["a", {value: 2.5, mapping: new Map([["1", {value: 0.5}], ["2", {value: 2.5}], ["3", {value: 4.5}]])}],
+          ["b", {value: 8.5, mapping: new Map([["1", {value: 7.5}], ["4", {value: 9.5}]])}],
+        ]))
+        expect(p4).to.be.equal(5)
 
-        const r5 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4'], ['c', '0']], 2, 1)
-        expect(r5[0]).to.deep.equal({
-          a: {value: 2.5, mapping: {1: {value: 0.5}, 2: {value: 2.5}, 3: {value: 4.5}}},
-          b: {value: 8.5, mapping: {1: {value: 7.5}, 4: {value: 9.5}}},
-          c: {value: 12.5, mapping: {0: {value: 12.5}}},
-        })
-        expect(r5[1]).to.deep.equal(['a', 'b', 'c'])
-        expect(r5[2]).to.be.equal(7)
+        const [m5, p5] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4'], ['c', '0']], 2, 1)
+        expect(m5).to.deep.equal(new Map([
+          ["a", {value: 2.5, mapping: new Map([["1", {value: 0.5}], ["2", {value: 2.5}], ["3", {value: 4.5}]])}],
+          ["b", {value: 8.5, mapping: new Map([["1", {value: 7.5}], ["4", {value: 9.5}]])}],
+          ["c", {value: 12.5, mapping: new Map([["0", {value: 12.5}]])}],
+        ]))
+        expect(p5).to.be.equal(7)
       })
 
       it("should also apply an offset if provided", () => {
-        const r0 = map_two_levels([['a', '1']], 2, 1, 1)
-        expect(r0[0]).to.deep.equal({
-          a: {value: 1.5, mapping: {1: {value: 1.5}}},
-        })
-        expect(r0[1]).to.deep.equal(['a'])
-        expect(r0[2]).to.be.equal(0)
+        const [m0, p0] = map_two_levels([['a', '1']], 2, 1, 1)
+        expect(m0).to.deep.equal(new Map([
+          ["a", {value: 1.5, mapping: new Map([["1", {value: 1.5}]])}],
+        ]))
+        expect(p0).to.be.equal(0)
 
-        const r1 = map_two_levels([['a', '1'], ['a', '2']], 2, 1, 1)
-        expect(r1[0]).to.deep.equal({
-          a: {value: 2.5, mapping: {1: {value: 1.5}, 2: {value: 3.5}}},
-        })
-        expect(r1[1]).to.deep.equal(['a'])
-        expect(r1[2]).to.be.equal(1)
+        const [m1, p1] = map_two_levels([['a', '1'], ['a', '2']], 2, 1, 1)
+        expect(m1).to.deep.equal(new Map([
+          ["a", {value: 2.5, mapping: new Map([["1", {value: 1.5}], ["2", {value: 3.5}]])}],
+        ]))
+        expect(p1).to.be.equal(1)
 
-        const r2 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3']], 2, 1, 1)
-        expect(r2[0]).to.deep.equal({
-          a: {value: 3.5, mapping: {1: {value: 1.5}, 2: {value: 3.5}, 3: {value: 5.5}}},
-        })
-        expect(r2[1]).to.deep.equal(['a'])
-        expect(r2[2]).to.be.equal(2)
+        const [m2, p2] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3']], 2, 1, 1)
+        expect(m2).to.deep.equal(new Map([
+          ["a", {value: 3.5, mapping: new Map([["1", {value: 1.5}], ["2", {value: 3.5}], ["3", {value: 5.5}]])}],
+        ]))
+        expect(p2).to.be.equal(2)
 
-        const r3 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1']], 2, 1, 1)
-        expect(r3[0]).to.deep.equal({
-          a: {value: 3.5, mapping: {1: {value: 1.5}, 2: {value: 3.5}, 3: {value: 5.5}}},
-          b: {value: 8.5, mapping: {1: {value: 8.5}}},
-        })
-        expect(r3[1]).to.deep.equal(['a', 'b'])
-        expect(r3[2]).to.be.equal(4)
+        const [m3, p3] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1']], 2, 1, 1)
+        expect(m3).to.deep.equal(new Map([
+          ["a", {value: 3.5, mapping: new Map([["1", {value: 1.5}], ["2", {value: 3.5}], ["3", {value: 5.5}]])}],
+          ["b", {value: 8.5, mapping: new Map([["1", {value: 8.5}]])}],
+        ]))
+        expect(p3).to.be.equal(4)
 
-        const r4 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4']], 2, 1, 1)
-        expect(r4[0]).to.deep.equal({
-          a: {value: 3.5, mapping: {1: {value: 1.5}, 2: {value: 3.5}, 3: {value: 5.5}}},
-          b: {value: 9.5, mapping: {1: {value: 8.5}, 4: {value: 10.5}}},
-        })
-        expect(r4[1]).to.deep.equal(['a', 'b'])
-        expect(r4[2]).to.be.equal(5)
+        const [m4, p4] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4']], 2, 1, 1)
+        expect(m4).to.deep.equal(new Map([
+          ["a", {value: 3.5, mapping: new Map([["1", {value: 1.5}], ["2", {value: 3.5}], ["3", {value: 5.5}]])}],
+          ["b", {value: 9.5, mapping: new Map([["1", {value: 8.5}], ["4", {value: 10.5}]])}],
+        ]))
+        expect(p4).to.be.equal(5)
 
-        const r5 = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4'], ['c', '0']], 2, 1, 1)
-        expect(r5[0]).to.deep.equal({
-          a: {value: 3.5, mapping: {1: {value: 1.5}, 2: {value: 3.5}, 3: {value: 5.5}}},
-          b: {value: 9.5, mapping: {1: {value: 8.5}, 4: {value: 10.5}}},
-          c: {value: 13.5, mapping: {0: {value: 13.5}}},
-        })
-        expect(r5[1]).to.deep.equal(['a', 'b', 'c'])
-        expect(r5[2]).to.be.equal(7)
+        const [m5, p5] = map_two_levels([['a', '1'], ['a', '2'], ['a', '3'], ['b', '1'], ['b', '4'], ['c', '0']], 2, 1, 1)
+        expect(m5).to.deep.equal(new Map([
+          ["a", {value: 3.5, mapping: new Map([["1", {value: 1.5}], ["2", {value: 3.5}], ["3", {value: 5.5}]])}],
+          ["b", {value: 9.5, mapping: new Map([["1", {value: 8.5}], ["4", {value: 10.5}]])}],
+          ["c", {value: 13.5, mapping: new Map([["0", {value: 13.5}]])}],
+        ]))
+        expect(p5).to.be.equal(7)
       })
     })
   })


### PR DESCRIPTION
In particular this rewrites `FactorRange` using `Map` as mappings instead of plain objects. Additionally I removed all usage of `HasProps.id` that isn't completely necessary (e.g. where `toString()` can be used instead in error/log formatting, etc.).