### PR TITLE
only use local bokeh package in tests

### DIFF
--- a/ci/install_bokeh_package.sh
+++ b/ci/install_bokeh_package.sh
@@ -2,7 +2,7 @@
 
 set -x #echo on
 
-conda install --yes --quiet --override-channels --offline -c file:///tmp/conda-bld bokeh
+conda install --yes --quiet --offline /tmp/conda-bld/noarch/bokeh-*.bz2
 
 # TODO (bev) remove this when move from bokeh -> src dir struture
 python setup.py --install-js

--- a/ci/install_bokeh_package.sh
+++ b/ci/install_bokeh_package.sh
@@ -2,7 +2,7 @@
 
 set -x #echo on
 
-conda install --yes --quiet -c file:///tmp/conda-bld bokeh
+conda install --yes --quiet --override-channels --offline -c file:///tmp/conda-bld bokeh
 
 # TODO (bev) remove this when move from bokeh -> src dir struture
 python setup.py --install-js


### PR DESCRIPTION
Not sure whats up, everything passed multiple times in PR but now on master reliably installs the wrong (release) version of Bokeh in three tests. This attempts to make sure that only the local artifact package is ever installed. 
