### PR TITLE
AutocompleteInput case insensitive completion functionality added per #9922 request

### DIFF
--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -228,6 +228,7 @@ class AutocompleteInput(TextInput):
     The number of characters a user must type before completions are presented.
     """)
 
+    case_sensitive = Bool(default=False, help="""Enable or disable case sensitivity""")
 
 class Select(InputWidget):
     ''' Single-select widget.

--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -228,7 +228,7 @@ class AutocompleteInput(TextInput):
     The number of characters a user must type before completions are presented.
     """)
 
-    case_sensitive = Bool(default=False, help="""Enable or disable case sensitivity""")
+    case_sensitive = Bool(default=True, help="""Enable or disable case sensitivity""")
 
 class Select(InputWidget):
     ''' Single-select widget.

--- a/bokehjs/src/lib/models/widgets/autocomplete_input.ts
+++ b/bokehjs/src/lib/models/widgets/autocomplete_input.ts
@@ -139,16 +139,16 @@ export class AutocompleteInputView extends TextInputView {
         }
 
         const completions: string[] = []
-        const case_sensitive: boolean = this.model.case_sensitive
-        let actest: (t: string, v: string) => boolean;
+        const {case_sensitive} = this.model
+        let acnorm: (t: string) => string
         if (case_sensitive) {
-          actest = (t: string, v: string): boolean => { return t.startsWith(v); }
+          acnorm = (t)  => t
         } else {
-          actest = (t: string, v: string): boolean => { return t.toLowerCase().startsWith(v.toLowerCase()); }
+          acnorm = (t)  => t.toLowerCase()
         }
 
         for (const text of this.model.completions) {
-          if (actest(text, value)) {
+          if (acnorm(text).startsWith(acnorm(value))) {
             completions.push(text)
             }
         }
@@ -190,7 +190,7 @@ export class AutocompleteInput extends TextInput {
     this.define<AutocompleteInput.Props>({
       completions:    [ p.Array, [] ],
       min_characters: [ p.Int,   2  ],
-      case_sensitive: [ p.Boolean,  false ],
+      case_sensitive: [ p.Boolean,  true ],
     })
   }
 }

--- a/bokehjs/src/lib/models/widgets/autocomplete_input.ts
+++ b/bokehjs/src/lib/models/widgets/autocomplete_input.ts
@@ -139,9 +139,18 @@ export class AutocompleteInputView extends TextInputView {
         }
 
         const completions: string[] = []
+        const case_sensitive: boolean = this.model.case_sensitive
+        let actest: (t: string, v: string) => boolean;
+        if (case_sensitive) {
+          actest = (t: string, v: string): boolean => { return t.startsWith(v); }
+        } else {
+          actest = (t: string, v: string): boolean => { return t.toLowerCase().startsWith(v.toLowerCase()); }
+        }
+
         for (const text of this.model.completions) {
-          if (text.startsWith(value))
+          if (actest(text, value)) {
             completions.push(text)
+            }
         }
 
         this._update_completions(completions)
@@ -161,6 +170,7 @@ export namespace AutocompleteInput {
   export type Props = TextInput.Props & {
     completions: p.Property<string[]>
     min_characters: p.Property<number>
+    case_sensitive: p.Property<boolean>
   }
 }
 
@@ -180,6 +190,7 @@ export class AutocompleteInput extends TextInput {
     this.define<AutocompleteInput.Props>({
       completions:    [ p.Array, [] ],
       min_characters: [ p.Int,   2  ],
+      case_sensitive: [ p.Boolean,  false ],
     })
   }
 }

--- a/tests/integration/widgets/test_autocomplete_input.py
+++ b/tests/integration/widgets/test_autocomplete_input.py
@@ -125,7 +125,7 @@ class Test_AutocompleteInput(object):
 
     def test_min_characters(self, bokeh_model_page) -> None:
         text_input = AutocompleteInput(title="title", css_classes=["foo"],
-                                       completions = ["100001", "12344556", "12344557", "3194567289", "209374209374"],
+                                       completions = ["100001", "12344556", "12344557", "3194567289", "209374209374", "aaaaaa", "aaabbb", "AAAaAA", "AAABbB"],
                                        min_characters=1)
 
         page = bokeh_model_page(text_input)
@@ -148,6 +148,97 @@ class Test_AutocompleteInput(object):
         assert "bk-active" in items[0].get_attribute('class')
         assert "bk-active" not in items[1].get_attribute('class')
         assert "bk-active" not in items[2].get_attribute('class')
+
+    def test_case_insensitivity(self, bokeh_model_page) -> None:
+        # case_sensitive=False by default
+        text_input = AutocompleteInput(title="title", css_classes=["foo"], completions = ["100001", "aaaaaa", "aaabbb", "AAAaAA", "AAABbB"])
+
+        page = bokeh_model_page(text_input)
+
+        el = page.driver.find_element_by_css_selector('.foo .bk-menu')
+        assert 'display: none;' in el.get_attribute('style')
+
+        # double click to highlight and overwrite old text
+        el = page.driver.find_element_by_css_selector('.foo input')
+        enter_text_in_element(page.driver, el, "aAa", click=2, enter=False)
+
+        el = page.driver.find_element_by_css_selector('.foo .bk-menu')
+        assert 'display: none;' not in el.get_attribute('style')
+
+        items = el.find_elements_by_tag_name("div")
+        assert len(items) == 4
+        assert items[0].text == "aaaaaa"
+        assert items[1].text == "aaabbb"
+        assert items[2].text == "AAAaAA"
+        assert items[3].text == "AAABbB"
+        assert "bk-active" in items[0].get_attribute('class')
+
+        el = page.driver.find_element_by_css_selector('.foo input')
+        enter_text_in_element(page.driver, el, "aAaB", click=2, enter=False)
+
+        el = page.driver.find_element_by_css_selector('.foo .bk-menu')
+        assert 'display: none;' not in el.get_attribute('style')
+
+        items = el.find_elements_by_tag_name("div")
+        assert len(items) == 2
+        assert items[0].text == "aaabbb"
+        assert items[1].text == "AAABbB"
+        assert "bk-active" in items[0].get_attribute('class')
+        assert "bk-active" not in items[1].get_attribute('class')
+
+        enter_text_in_element(page.driver, el, Keys.DOWN, click=0, enter=False)
+        items = el.find_elements_by_tag_name("div")
+        assert len(items) == 2
+        assert items[0].text == "aaabbb"
+        assert items[1].text == "AAABbB"
+        assert "bk-active" not in items[0].get_attribute('class')
+        assert "bk-active" in items[1].get_attribute('class')
+
+        assert page.has_no_console_errors()
+
+    def test_case_sensitivity(self, bokeh_model_page) -> None:
+        text_input = AutocompleteInput(title="title", css_classes=["foo"], case_sensitive=True, completions = ["100001", "aAaaaa", "aAaBbb", "AAAaAA", "aAaBbB"])
+
+        page = bokeh_model_page(text_input)
+
+        el = page.driver.find_element_by_css_selector('.foo .bk-menu')
+        assert 'display: none;' in el.get_attribute('style')
+
+        # double click to highlight and overwrite old text
+        el = page.driver.find_element_by_css_selector('.foo input')
+        enter_text_in_element(page.driver, el, "aAa", click=2, enter=False)
+
+        el = page.driver.find_element_by_css_selector('.foo .bk-menu')
+        assert 'display: none;' not in el.get_attribute('style')
+
+        items = el.find_elements_by_tag_name("div")
+        assert len(items) == 3
+        assert items[0].text == "aAaaaa"
+        assert items[1].text == "aAaBbb"
+        assert items[2].text == "aAaBbB"
+        assert "bk-active" in items[0].get_attribute('class')
+
+        el = page.driver.find_element_by_css_selector('.foo input')
+        enter_text_in_element(page.driver, el, "aAaB", click=2, enter=False)
+
+        el = page.driver.find_element_by_css_selector('.foo .bk-menu')
+        assert 'display: none;' not in el.get_attribute('style')
+
+        items = el.find_elements_by_tag_name("div")
+        assert len(items) == 2
+        assert items[0].text == "aAaBbb"
+        assert items[1].text == "aAaBbB"
+        assert "bk-active" in items[0].get_attribute('class')
+
+        enter_text_in_element(page.driver, el, Keys.DOWN, click=0, enter=False)
+        items = el.find_elements_by_tag_name("div")
+        assert len(items) == 2
+        assert items[0].text == "aAaBbb"
+        assert items[1].text == "aAaBbB"
+        assert "bk-active" not in items[0].get_attribute('class')
+        assert "bk-active" in items[1].get_attribute('class')
+
+        assert page.has_no_console_errors()
 
     def test_arrow_cannot_escape_menu(self, bokeh_model_page) -> None:
         text_input = AutocompleteInput(title="title", css_classes=["foo"], completions = ["100001", "12344556", "12344557", "3194567289", "209374209374"])

--- a/tests/integration/widgets/test_autocomplete_input.py
+++ b/tests/integration/widgets/test_autocomplete_input.py
@@ -150,8 +150,7 @@ class Test_AutocompleteInput(object):
         assert "bk-active" not in items[2].get_attribute('class')
 
     def test_case_insensitivity(self, bokeh_model_page) -> None:
-        # case_sensitive=False by default
-        text_input = AutocompleteInput(title="title", css_classes=["foo"], completions = ["100001", "aaaaaa", "aaabbb", "AAAaAA", "AAABbB"])
+        text_input = AutocompleteInput(title="title", css_classes=["foo"], case_sensitive=False, completions = ["100001", "aaaaaa", "aaabbb", "AAAaAA", "AAABbB"])
 
         page = bokeh_model_page(text_input)
 
@@ -197,7 +196,8 @@ class Test_AutocompleteInput(object):
         assert page.has_no_console_errors()
 
     def test_case_sensitivity(self, bokeh_model_page) -> None:
-        text_input = AutocompleteInput(title="title", css_classes=["foo"], case_sensitive=True, completions = ["100001", "aAaaaa", "aAaBbb", "AAAaAA", "aAaBbB"])
+        # case_sensitive=True by default
+        text_input = AutocompleteInput(title="title", css_classes=["foo"], completions = ["100001", "aAaaaa", "aAaBbb", "AAAaAA", "aAaBbB"])
 
         page = bokeh_model_page(text_input)
 


### PR DESCRIPTION
I've added case insensitive completion to the AutocompleteInput widget. I figured the case_sensitive property should be False (case insensitive matching) by default but lmk if it should be the inverse. I've added two tests, one for case_sensitivity and one for case_insensitivity. This functionality was requested in issue #9922. I should note I've been using this new version of the AutocompleteInput widget for a covid-19 dashboard I built https://speediedan.github.io/covid19/county_covid_explorer.html for several weeks without issue. Thanks for this immensely useful library! This is my first PR on the project but I'm really impressed by the community here!
Dan

- [x] issues: fixes #9922  
- [x] tests added / passed
  - test_autocomplete_input.py::Test_AutocompleteInput::test_case_insensitivity
  - test_autocomplete_input.py::Test_AutocompleteInput::test_case_sensitivity
- [x] release document entry (if new feature or API change)
   - AutocompleteInput widget now supports case insensitive completion :bokeh-issue:`9922`
