### PR TITLE
Cache measurements in HTML-based widgets

### DIFF
--- a/bokehjs/src/lib/core/layout/html.ts
+++ b/bokehjs/src/lib/core/layout/html.ts
@@ -16,7 +16,6 @@ export class ContentBox extends ContentLayoutable {
 }
 
 export class VariadicBox extends Layoutable {
-
   constructor(readonly el: HTMLElement) {
     super()
   }
@@ -28,5 +27,29 @@ export class VariadicBox extends Layoutable {
       const {border, padding} = extents(this.el)
       return content.grow_by(border).grow_by(padding).map(Math.ceil)
     })
+  }
+}
+
+export class CachedVariadicBox extends VariadicBox {
+  private readonly _cache: Map<string, SizeHint> = new Map()
+
+  constructor(el: HTMLElement) {
+    super(el)
+  }
+
+  protected _measure(viewport: Size): SizeHint {
+    const {width, height} = viewport
+    const key = `${width},${height}`
+
+    let size_hint = this._cache.get(key)
+    if (size_hint == null) {
+      size_hint = super._measure(viewport)
+      this._cache.set(key, size_hint)
+    }
+    return size_hint
+  }
+
+  invalidate_cache(): void {
+    this._cache.clear()
   }
 }

--- a/bokehjs/src/lib/models/widgets/markup.ts
+++ b/bokehjs/src/lib/models/widgets/markup.ts
@@ -1,4 +1,4 @@
-import {VariadicBox} from "core/layout"
+import {CachedVariadicBox} from "core/layout/html"
 import {div} from "core/dom"
 import * as p from "core/properties"
 
@@ -9,12 +9,14 @@ import clearfix_css from "styles/clearfix.css"
 
 export abstract class MarkupView extends WidgetView {
   model: Markup
+  layout: CachedVariadicBox
 
   protected markup_el: HTMLElement
 
   connect_signals(): void {
     super.connect_signals()
     this.connect(this.model.change, () => {
+      this.layout.invalidate_cache()
       this.render()
       this.root.compute_layout() // XXX: invalidate_layout?
     })
@@ -25,7 +27,7 @@ export abstract class MarkupView extends WidgetView {
   }
 
   _update_layout(): void {
-    this.layout = new VariadicBox(this.el)
+    this.layout = new CachedVariadicBox(this.el)
     this.layout.set_sizing(this.box_sizing())
   }
 


### PR DESCRIPTION
When tested with:
```py
from bokeh.models import Div
from bokeh.layouts import column, row
from bokeh.io import save

def divs(i):
  return [ Div(text=f"Text i={i} j={j}") for j in range(20) ]

c0_0 = column(divs(1))
c1_0 = column(divs(10))
c2_0 = column(divs(100))
c3_0 = column(divs(1000))

c0_1 = column(divs(2))
c1_1 = column(divs(20))
c2_1 = column(divs(200))
c3_1 = column(divs(2000))

r0 = row(c0_0, c1_0, c2_0, c3_0)
r1 = row(c0_1, c1_1, c2_1, c3_1)

c = column(r0, r1)
save(c)
```
gives ~4x speed improvement.

fixes #9515
