### PR TITLE
Allow using string for EditTool empty_value

### DIFF
--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -1221,7 +1221,7 @@ class EditTool(Gesture):
     A custom tooltip label to override the default name.
     """)
 
-    empty_value = Either(Bool, Int, Float, Date, Datetime, Color, help="""
+    empty_value = Either(Bool, Int, Float, Date, Datetime, Color, String, help="""
     Defines the value to insert on non-coordinate columns when a new
     glyph is inserted into the ``ColumnDataSource`` columns, e.g. when a
     circle glyph defines 'x', 'y' and 'color' columns, adding a new


### PR DESCRIPTION
Very simple addition, adding String to the acceptable EditTool.empty_value types.

- [x] issues: fixes #10132
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
