### PR TITLE
Prefer inclusive language

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,7 @@
     - #9879 [component: bokehjs] [bug] impossible to change factorrange to a lower dimension with different number of factors
     - #9900 Bundling and serving precompiled extensions in broken on windows
     - #9931 [component: build] Installation of bokeh>=2.0.0 adds `release` directory to site-packages
-    - #9938 [component: server] [bug] timezone bug in generate_jwt_token 
+    - #9938 [component: server] [bug] timezone bug in generate_jwt_token
   * features:
     - #9339 [API: models] [feature] add broader themes
     - #9812 [component: bokehjs] Load multiple versions of bokeh into a single web page
@@ -64,7 +64,7 @@
     - #9458 [component: bokehjs] [bug] hovertool in 'vline' mode doesn't work with vertical segments
     - #9581 Update dockertools
     - #9692 [component: bokehjs] [typescript] Upgrade to typescript 3.8
-    - #9750 [component: bokehjs] [component: build] [feature] improve bokehjs dependency and project management 
+    - #9750 [component: bokehjs] [component: build] [feature] improve bokehjs dependency and project management
     - #9758 [component: bokehjs] Deprecate bokehjs package and suggest @bokeh/bokehjs
     - #9766 [component: docs] Doc: add missing '@' in hovertool.formatters example
     - #9775 [component: server] [bug] always setting asyncio event loop policy
@@ -130,7 +130,7 @@
     - #9304 [component: bokehjs] [widgets] [feature] scientific notation for numberformatter
     - #9469 [component: bokehjs] [widgets] [feature]add scientific notation to supported number formats
     - #9505 [component: bokehjs] [component: server] Overhaul session expiry and generalize token
-    - #9524 [component: bokehjs] [feature] bokehjs embed_item should return a reference to the plot. 
+    - #9524 [component: bokehjs] [feature] bokehjs embed_item should return a reference to the plot.
     - #9532 [component: bokehjs] [widgets] Please replace multiselect widget with something more compact, effective and nicer looking
     - #9545 [component: server] Allow package relative imports for directory style apps
     - #9560 Add tile providers for openstreetmap and esri imagery
@@ -153,7 +153,7 @@
     - #9238 [component: docs] [bug] gridlines are rendered under image plot
     - #9248 [feature] make the palettes module ide-friendly
     - #9334 Deprecate widgetbox
-    - #9362 [component: docs] Docs report "no title" 
+    - #9362 [component: docs] Docs report "no title"
     - #9365 Landing 2.0
     - #9366 [component: tests] Flake8 shouldn't descend into node_modules
     - #9367 [component: build] Use `npm ci` to force usage of the lock file
@@ -185,7 +185,7 @@
     - #9463 [bug] fixing spell mistakes
     - #9476 [component: examples] [bug] non-daemon worker thread prevents gunicorn from shutting down cleanly
     - #9480 [component: build] Expose sri hashes
-    - #9482 [component: build] Resolve ipython 7.9 pin 
+    - #9482 [component: build] Resolve ipython 7.9 pin
     - #9484 [component: docs] Update twitter handle in docs
     - #9490 Improve sampledata downloading
     - #9500 [component: docs] Use new nf verbiage
@@ -275,7 +275,7 @@
     - #9073 [component: docs] [docs] page for selection tools does not tell users how to get the values/indices of the selection
     - #9150 [component: docs] Use bokehjs from cdn when the commit is tagged
     - #9155 [component: bokehjs] [component: build] Migrate from tslint to (typescript-)eslint
-    - #9157 [component: tests] Remove bokeh.embed.notebook.widgets from -oo blacklist
+    - #9157 [component: tests] Remove bokeh.embed.notebook.widgets from -oo skiplist
     - #9159 [component: build] Unpin python 3.7 version when possible
     - #9160 [component: bokehjs] Enable more eslint rules
     - #9163 [component: build] [component: examples] Don't upload to s3 on py27 tests
@@ -307,7 +307,7 @@
     - #9262 [component: docs] Fix structure issues in palette docs
     - #9264 [component: build] Cdn invalidations too narrow
     - #9265 [component: docs] Rename modify_doc in notebook app contexts
-    - #9271 [component: bokehjs] Upgrade from deprecated package istanbul 
+    - #9271 [component: bokehjs] Upgrade from deprecated package istanbul
     - #9272 [bug] improve exception when import _requires fails
     - #9274 If import of channels fails, improve error message to install it via pip
     - #9278 [component: docs] Consistently use https protcol for cdn.pydata.org urls

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2355,7 +2355,7 @@
     - #3962 Custom web templates with `bokeh serve`
     - #3994 [component: server] Add option to extend sys.path with app directory
     - #4008 Allow for the injection of raw html code
-    - #4051 --host whitelist doesn't trust 127.0.0.1 by default
+    - #4051 --host allowlist doesn't trust 127.0.0.1 by default
     - #4057 [API: charts] Request: reorderable legends with chart api
     - #4064 [component: bokehjs] [component: examples] Add stock example using ts api
     - #4065 [component: bokehjs] The box (zoom or select) tool should be configurable to respect aspect
@@ -2722,7 +2722,7 @@
     - #3962 Custom web templates with `bokeh serve`
     - #3994 [component: server] Add option to extend sys.path with app directory
     - #4008 Allow for the injection of raw html code
-    - #4051 --host whitelist doesn't trust 127.0.0.1 by default
+    - #4051 --host allowlist doesn't trust 127.0.0.1 by default
     - #4057 [API: charts] Request: reorderable legends with chart api
     - #4064 [component: bokehjs] [component: examples] Add stock example using ts api
     - #4065 [component: bokehjs] The box (zoom or select) tool should be configurable to respect aspect
@@ -3118,7 +3118,7 @@
     - #3490 Fix a leftover log message and broken log message in has_properties.coffee
     - #3500 [bokehjs] Bokeh.js must load first, before widgets, compiler
     - #3512 Make bokeh.js set window.bokeh not only bokeh in current scope
-    - #3513 [server] Accept implicit port 80 on whitelist
+    - #3513 [server] Accept implicit port 80 on allowlist
     - #3525 Random tiles example: temporary fix for bounds issue on map
     - #3532 [bokehjs] Add support for inline autoload and restore support for inline resources in notebook
     - #3540 Graphs are not displayed when using runipy

--- a/bokeh/server/server.py
+++ b/bokeh/server/server.py
@@ -47,7 +47,7 @@ from ..core.properties import Bool, Int, List, String
 from ..resources import DEFAULT_SERVER_PORT
 from ..util.options import Options
 from .tornado import DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES, BokehTornado
-from .util import bind_sockets, create_hosts_whitelist
+from .util import bind_sockets, create_hosts_allowlist
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -395,7 +395,7 @@ class Server(BaseServer):
         sockets, self._port = bind_sockets(opts.address, opts.port)
         self._address = opts.address
 
-        extra_websocket_origins = create_hosts_whitelist(opts.allow_websocket_origin, opts.port)
+        extra_websocket_origins = create_hosts_allowlist(opts.allow_websocket_origin, opts.port)
         try:
             tornado_app = BokehTornado(applications,
                                        extra_websocket_origins=extra_websocket_origins,

--- a/bokeh/server/util.py
+++ b/bokeh/server/util.py
@@ -28,8 +28,8 @@ from tornado import netutil
 
 __all__ = (
     'bind_sockets',
-    'check_whitelist',
-    'create_hosts_whitelist',
+    'check_allowlist',
+    'create_hosts_allowlist',
     'match_host',
 )
 
@@ -66,48 +66,48 @@ def bind_sockets(address, port):
         assert actual_port == port
     return ss, actual_port
 
-def check_whitelist(host, whitelist):
-    ''' Check a given request host against a whitelist.
+def check_allowlist(host, allowlist):
+    ''' Check a given request host against a allowlist.
 
     Args:
         host (str) :
-            A host string to compare against a whitelist.
+            A host string to compare against a allowlist.
 
             If the host does not specify a port, then ``":80"`` is implicitly
             assumed.
 
-        whitelist (seq[str]) :
+        allowlist (seq[str]) :
             A list of host patterns to match against
 
     Returns:
-        ``True``, if ``host`` matches any pattern in ``whitelist``, otherwise
+        ``True``, if ``host`` matches any pattern in ``allowlist``, otherwise
         ``False``
 
      '''
     if ':' not in host:
         host = host + ':80'
 
-    if host in whitelist:
+    if host in allowlist:
         return True
 
-    return any(match_host(host, pattern) for pattern in whitelist)
+    return any(match_host(host, pattern) for pattern in allowlist)
 
-def create_hosts_whitelist(host_list, port):
+def create_hosts_allowlist(host_list, port):
     '''
 
-    This whitelist can be used to restrict websocket or other connections to
+    This allowlist can be used to restrict websocket or other connections to
     only those explicitly originating from approved hosts.
 
     Args:
         host_list (seq[str]) :
             A list of string `<name>` or `<name>:<port>` values to add to the
-            whitelist.
+            allowlist.
 
             If no port is specified in a host string, then ``":80"``  is
             implicitly assumed.
 
         port (int) :
-            If ``host_list`` is empty or ``None``, then the whitelist will
+            If ``host_list`` is empty or ``None``, then the allowlist will
             be the single item list `` [ 'localhost:<port>' ]``
 
             If ``host_list`` is not empty, this parameter has no effect.

--- a/bokeh/server/views/ws.py
+++ b/bokeh/server/views/ws.py
@@ -80,7 +80,7 @@ class WSHandler(WebSocketHandler):
     def check_origin(self, origin):
         ''' Implement a check_origin policy for Tornado to call.
 
-        The supplied origin will be compared to the Bokeh server whitelist. If the
+        The supplied origin will be compared to the Bokeh server allowlist. If the
         origin is not allow, an error will be logged and ``False`` will be returned.
 
         Args:
@@ -91,7 +91,7 @@ class WSHandler(WebSocketHandler):
             bool, True if the connection is allowed, False otherwise
 
         '''
-        from ..util import check_whitelist
+        from ..util import check_allowlist
         parsed_origin = urlparse(origin)
         origin_host = parsed_origin.netloc.lower()
 
@@ -99,7 +99,7 @@ class WSHandler(WebSocketHandler):
         if settings.allowed_ws_origin():
             allowed_hosts = set(settings.allowed_ws_origin())
 
-        allowed = check_whitelist(origin_host, allowed_hosts)
+        allowed = check_allowlist(origin_host, allowed_hosts)
         if allowed:
             return True
         else:

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -1326,10 +1326,10 @@ When an HTTP request is made to the Bokeh server, it immediately returns a
 script that will initiate a websocket connection, and all subsequent
 communication happens over the websocket. To reduce the risk of cross-site
 misuse, the bokeh server will only initiate websocket connections from
-origins that are explicitly whitelisted. Requests with Origin headers that
-do not match the whitelist will generate HTTP 403 error responses.
+origins that are explicitly allowlisted. Requests with Origin headers that
+do not match the allowlist will generate HTTP 403 error responses.
 
-By default only ``localhost:5006`` is whitelisted. I.e the following two
+By default only ``localhost:5006`` is allowlisted. I.e the following two
 invocations are identical:
 
 .. code-block:: sh
@@ -1344,7 +1344,7 @@ and
 
 Both of these will open a browser to the default application URL
 ``localhost:5006`` and since ``localhost:5006`` is in the allowed websocket
-origin whitelist, the Bokeh server will create and display a new session.
+origin allowlist, the Bokeh server will create and display a new session.
 
 Now, consider when a Bokeh server is embedded inside another web page, using
 |server_document| or |server_session|. In this instance, the "Origin" header

--- a/tests/codebase/test_python_execution_with_OO.py
+++ b/tests/codebase/test_python_execution_with_OO.py
@@ -27,7 +27,7 @@ from . import TOP_PATH
 # Tests
 #-----------------------------------------------------------------------------
 
-blacklist = {}
+skiplist = {}
 
 def test_python_execution_with_OO() -> None:
     ''' Running python with -OO will discard docstrings (__doc__ is None)
@@ -56,7 +56,7 @@ def test_python_execution_with_OO() -> None:
             else:
                 mod = path.replace(os.sep, ".") + "." + file[:-3]
 
-            if mod in blacklist:
+            if mod in skiplist:
                 continue
 
             imports.append("import " + mod)

--- a/tests/unit/bokeh/server/test_util.py
+++ b/tests/unit/bokeh/server/test_util.py
@@ -35,75 +35,75 @@ def test_bind_sockets_with_zero_port() -> None:
     assert isinstance(ss[0], socket.socket)
     assert isinstance(port, int)
 
-def test_check_whitelist_rejects_port_mismatch() -> None:
-    assert False == util.check_whitelist("foo:100", ["foo:101", "foo:102"])
+def test_check_allowlist_rejects_port_mismatch() -> None:
+    assert False == util.check_allowlist("foo:100", ["foo:101", "foo:102"])
 
-def test_check_whitelist_rejects_name_mismatch() -> None:
-    assert False == util.check_whitelist("foo:100", ["bar:100", "baz:100"])
+def test_check_allowlist_rejects_name_mismatch() -> None:
+    assert False == util.check_allowlist("foo:100", ["bar:100", "baz:100"])
 
-def test_check_whitelist_accepts_name_port_match() -> None:
-    assert True == util.check_whitelist("foo:100", ["foo:100", "baz:100"])
+def test_check_allowlist_accepts_name_port_match() -> None:
+    assert True == util.check_allowlist("foo:100", ["foo:100", "baz:100"])
 
-def test_check_whitelist_accepts_implicit_port_80() -> None:
-    assert True == util.check_whitelist("foo", ["foo:80"])
+def test_check_allowlist_accepts_implicit_port_80() -> None:
+    assert True == util.check_allowlist("foo", ["foo:80"])
 
-def test_check_whitelist_accepts_all_on_star() -> None:
-    assert True == util.check_whitelist("192.168.0.1", ['*'])
-    assert True == util.check_whitelist("192.168.0.1:80", ['*'])
-    assert True == util.check_whitelist("192.168.0.1:5006", ['*'])
-    assert True == util.check_whitelist("192.168.0.1:80", ['*:80'])
-    assert False == util.check_whitelist("192.168.0.1:80", ['*:81'])
-    assert True == util.check_whitelist("192.168.0.1:5006", ['*:*'])
-    assert True == util.check_whitelist("192.168.0.1", ['192.168.0.*'])
-    assert True == util.check_whitelist("192.168.0.1:5006", ['192.168.0.*'])
-    assert False == util.check_whitelist("192.168.1.1", ['192.168.0.*'])
-    assert True == util.check_whitelist("foobarbaz", ['*'])
-    assert True == util.check_whitelist("192.168.0.1", ['192.168.0.*'])
-    assert False == util.check_whitelist("192.168.1.1", ['192.168.0.*'])
-    assert False == util.check_whitelist("192.168.0.1", ['192.168.0.*:5006'])
-    assert True == util.check_whitelist("192.168.0.1", ['192.168.0.*:80'])
-    assert True == util.check_whitelist("foobarbaz", ['*'])
-    assert True == util.check_whitelist("foobarbaz", ['*:*'])
-    assert True == util.check_whitelist("foobarbaz", ['*:80'])
-    assert False == util.check_whitelist("foobarbaz", ['*:5006'])
-    assert True == util.check_whitelist("foobarbaz:5006", ['*'])
-    assert True == util.check_whitelist("foobarbaz:5006", ['*:*'])
-    assert True == util.check_whitelist("foobarbaz:5006", ['*:5006'])
+def test_check_allowlist_accepts_all_on_star() -> None:
+    assert True == util.check_allowlist("192.168.0.1", ['*'])
+    assert True == util.check_allowlist("192.168.0.1:80", ['*'])
+    assert True == util.check_allowlist("192.168.0.1:5006", ['*'])
+    assert True == util.check_allowlist("192.168.0.1:80", ['*:80'])
+    assert False == util.check_allowlist("192.168.0.1:80", ['*:81'])
+    assert True == util.check_allowlist("192.168.0.1:5006", ['*:*'])
+    assert True == util.check_allowlist("192.168.0.1", ['192.168.0.*'])
+    assert True == util.check_allowlist("192.168.0.1:5006", ['192.168.0.*'])
+    assert False == util.check_allowlist("192.168.1.1", ['192.168.0.*'])
+    assert True == util.check_allowlist("foobarbaz", ['*'])
+    assert True == util.check_allowlist("192.168.0.1", ['192.168.0.*'])
+    assert False == util.check_allowlist("192.168.1.1", ['192.168.0.*'])
+    assert False == util.check_allowlist("192.168.0.1", ['192.168.0.*:5006'])
+    assert True == util.check_allowlist("192.168.0.1", ['192.168.0.*:80'])
+    assert True == util.check_allowlist("foobarbaz", ['*'])
+    assert True == util.check_allowlist("foobarbaz", ['*:*'])
+    assert True == util.check_allowlist("foobarbaz", ['*:80'])
+    assert False == util.check_allowlist("foobarbaz", ['*:5006'])
+    assert True == util.check_allowlist("foobarbaz:5006", ['*'])
+    assert True == util.check_allowlist("foobarbaz:5006", ['*:*'])
+    assert True == util.check_allowlist("foobarbaz:5006", ['*:5006'])
 
-def test_create_hosts_whitelist_no_host() -> None:
-    hosts = util.create_hosts_whitelist(None, 1000)
+def test_create_hosts_allowlist_no_host() -> None:
+    hosts = util.create_hosts_allowlist(None, 1000)
     assert hosts == ["localhost:1000"]
 
-    hosts = util.create_hosts_whitelist([], 1000)
+    hosts = util.create_hosts_allowlist([], 1000)
     assert hosts == ["localhost:1000"]
 
-def test_create_hosts_whitelist_host_value_with_port_use_port() -> None:
-    hosts = util.create_hosts_whitelist(["foo:1000"], 1000)
+def test_create_hosts_allowlist_host_value_with_port_use_port() -> None:
+    hosts = util.create_hosts_allowlist(["foo:1000"], 1000)
     assert hosts == ["foo:1000"]
 
-    hosts = util.create_hosts_whitelist(["foo:1000","bar:2100"], 1000)
+    hosts = util.create_hosts_allowlist(["foo:1000","bar:2100"], 1000)
     assert hosts == ["foo:1000","bar:2100"]
 
-def test_create_hosts_whitelist_host_without_port_use_port_80() -> None:
-    hosts = util.create_hosts_whitelist(["foo"], 1000)
+def test_create_hosts_allowlist_host_without_port_use_port_80() -> None:
+    hosts = util.create_hosts_allowlist(["foo"], 1000)
     assert hosts == ["foo:80"]
 
-    hosts = util.create_hosts_whitelist(["foo","bar"], 1000)
+    hosts = util.create_hosts_allowlist(["foo","bar"], 1000)
     assert hosts == ["foo:80","bar:80"]
 
-def test_create_hosts_whitelist_host_non_int_port_raises() -> None:
+def test_create_hosts_allowlist_host_non_int_port_raises() -> None:
     with pytest.raises(ValueError):
-        util.create_hosts_whitelist(["foo:xyz"], 1000)
+        util.create_hosts_allowlist(["foo:xyz"], 1000)
 
-def test_create_hosts_whitelist_bad_host_raises() -> None:
+def test_create_hosts_allowlist_bad_host_raises() -> None:
     with pytest.raises(ValueError):
-        util.create_hosts_whitelist([""], 1000)
-
-    with pytest.raises(ValueError):
-        util.create_hosts_whitelist(["a:b:c"], 1000)
+        util.create_hosts_allowlist([""], 1000)
 
     with pytest.raises(ValueError):
-        util.create_hosts_whitelist([":80"], 1000)
+        util.create_hosts_allowlist(["a:b:c"], 1000)
+
+    with pytest.raises(ValueError):
+        util.create_hosts_allowlist([":80"], 1000)
 
 def test_match_host() -> None:
         assert util.match_host('192.168.0.1:80', '192.168.0.1:80') == True


### PR DESCRIPTION
This PR removes our usage of the names `whitelist` and `blacklist`. 

This affects two util functions:

*  `check_whitelist`
 * `create_hosts_whitelist`

These are technically public (dev) API, but in practice there is no reason for anyone to use these outside the library internals. 