### PR TITLE
Reduce memory footprint of data indexing

### DIFF
--- a/bokehjs/src/lib/core/util/spatial.ts
+++ b/bokehjs/src/lib/core/util/spatial.ts
@@ -8,17 +8,34 @@ export type IndexedRect = Rect & {i: number}
 export class SpatialIndex {
   private readonly index: FlatBush | null = null
 
-  constructor(private readonly points: IndexedRect[]) {
-    if (points.length > 0) {
-      this.index = new FlatBush(points.length)
-
-      for (const p of points) {
-        const {x0, y0, x1, y1} = p
-        this.index.add(x0, y0, x1, y1)
-      }
-
-      this.index.finish()
+  constructor(size: number) {
+    if (size > 0) {
+      this.index = new FlatBush(size)
     }
+  }
+
+  static from(points: IndexedRect[]): SpatialIndex {
+    const index = new SpatialIndex(points.length)
+
+    for (const p of points) {
+      const {x0, y0, x1, y1} = p
+      index.add(x0, y0, x1, y1)
+    }
+
+    index.finish()
+    return index
+  }
+
+  add(x0: number, y0: number, x1: number, y1: number): void {
+    this.index?.add(x0, y0, x1, y1)
+  }
+
+  add_empty(): void {
+    this.index?.add(Infinity, Infinity, -Infinity, -Infinity)
+  }
+
+  finish(): void {
+    this.index?.finish()
   }
 
   protected _normalize(rect: Rect): Rect {
@@ -39,17 +56,34 @@ export class SpatialIndex {
     }
   }
 
-  search(rect: Rect): IndexedRect[] {
+  indices(rect: Rect): number[] {
     if (this.index == null)
       return []
     else {
       const {x0, y0, x1, y1} = this._normalize(rect)
-      const indices = this.index.search(x0, y0, x1, y1)
-      return indices.map((j) => this.points[j])
+      return this.index.search(x0, y0, x1, y1)
     }
   }
 
-  indices(rect: Rect): number[] {
-    return this.search(rect).map(({i}) => i)
+  bounds(rect: Rect): Rect {
+    const bounds = empty()
+
+    for (const i of this.indices(rect)) {
+      const boxes = (this.index as any)._boxes as Float64Array
+      const x1 = boxes[4*i + 0]
+      const y1 = boxes[4*i + 1]
+      const x0 = boxes[4*i + 2]
+      const y0 = boxes[4*i + 3]
+      if (x0 < bounds.x0)
+        bounds.x0 = x0
+      if (x1 > bounds.x1)
+        bounds.x1 = x1
+      if (y0 < bounds.y0)
+        bounds.y0 = y0
+      if (y1 > bounds.y1)
+        bounds.y1 = y1
+    }
+
+    return bounds
   }
 }

--- a/bokehjs/src/lib/models/glyphs/bezier.ts
+++ b/bokehjs/src/lib/models/glyphs/bezier.ts
@@ -101,18 +101,18 @@ export class BezierView extends GlyphView {
   model: Bezier
   visuals: Bezier.Visuals
 
-  protected _index_data(): SpatialIndex {
-    const points = []
-    for (let i = 0, end = this._x0.length; i < end; i++) {
+  protected _index_data(index: SpatialIndex): void {
+    const {data_size} = this
+
+    for (let i = 0; i < data_size; i++) {
       if (isNaN(this._x0[i] + this._x1[i] + this._y0[i] + this._y1[i] + this._cx0[i] + this._cy0[i] + this._cx1[i] + this._cy1[i]))
-        continue
-
-      const [x0, y0, x1, y1] = _cbb(this._x0[i],  this._y0[i],  this._x1[i],  this._y1[i],
-                                    this._cx0[i], this._cy0[i], this._cx1[i], this._cy1[i])
-      points.push({x0, y0, x1, y1, i})
+        index.add_empty()
+      else {
+        const [x0, y0, x1, y1] = _cbb(this._x0[i],  this._y0[i],  this._x1[i],  this._y1[i],
+                                      this._cx0[i], this._cy0[i], this._cx1[i], this._cy1[i])
+        index.add(x0, y0, x1, y1)
+      }
     }
-
-    return new SpatialIndex(points)
   }
 
   protected _render(ctx: Context2d, indices: number[],

--- a/bokehjs/src/lib/models/glyphs/box.ts
+++ b/bokehjs/src/lib/models/glyphs/box.ts
@@ -50,23 +50,17 @@ export abstract class BoxView extends GlyphView {
 
   protected abstract _lrtb(i: number): [number, number, number, number]
 
-  protected _index_box(len: number): SpatialIndex {
-    const points = []
+  protected _index_data(index: SpatialIndex): void {
+    const {min, max} = Math
+    const {data_size} = this
 
-    for (let i = 0; i < len; i++) {
+    for (let i = 0; i < data_size; i++) {
       const [l, r, t, b] = this._lrtb(i)
       if (isNaN(l + r + t + b) || !isFinite(l + r + t + b))
-        continue
-      points.push({
-        x0: Math.min(l, r),
-        y0: Math.min(t, b),
-        x1: Math.max(r, l),
-        y1: Math.max(t, b),
-        i,
-      })
+        index.add_empty()
+      else
+        index.add(min(l, r), min(t, b), max(r, l), max(t, b))
     }
-
-    return new SpatialIndex(points)
   }
 
   protected _render(ctx: Context2d, indices: number[],

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -326,10 +326,14 @@ export abstract class GlyphView extends View {
 
   protected _set_data(_indices: number[] | null): void {}
 
+  protected get _index_size(): number {
+    return this.data_size
+  }
+
   protected abstract _index_data(index: SpatialIndex): void
 
   index_data(): void {
-    const index = new SpatialIndex(this.data_size)
+    const index = new SpatialIndex(this._index_size)
     this._index_data(index)
     index.finish()
     this._index = index

--- a/bokehjs/src/lib/models/glyphs/harea.ts
+++ b/bokehjs/src/lib/models/glyphs/harea.ts
@@ -2,7 +2,7 @@ import {PointGeometry} from 'core/geometry'
 import {Arrayable, NumberArray} from "core/types"
 import {Area, AreaView, AreaData} from "./area"
 import {Context2d} from "core/util/canvas"
-import {SpatialIndex, IndexedRect} from "core/util/spatial"
+import {SpatialIndex} from "core/util/spatial"
 import * as hittest from "core/hittest"
 import * as p from "core/properties"
 import {Selection} from "../selections/selection"
@@ -23,21 +23,20 @@ export class HAreaView extends AreaView {
   model: HArea
   visuals: HArea.Visuals
 
-  protected _index_data(): SpatialIndex {
-    const points: IndexedRect[] = []
+  protected _index_data(index: SpatialIndex): void {
+    const {min, max} = Math
+    const {data_size} = this
 
-    for (let i = 0, end = this._x1.length; i < end; i++) {
+    for (let i = 0; i < data_size; i++) {
       const x1 = this._x1[i]
       const x2 = this._x2[i]
       const y = this._y[i]
 
       if (isNaN(x1 + x2 + y) || !isFinite(x1 + x2 + y))
-        continue
-
-      points.push({x0: Math.min(x1, x2), y0: y, x1: Math.max(x1, x2), y1: y, i})
+        index.add_empty()
+      else
+        index.add(min(x1, x2), y, max(x1, x2), y)
     }
-
-    return new SpatialIndex(points)
   }
 
   protected _inner(ctx: Context2d, sx1: Arrayable<number>, sx2: Arrayable<number>, sy: Arrayable<number>, func: (this: Context2d) => void): void {

--- a/bokehjs/src/lib/models/glyphs/hbar.ts
+++ b/bokehjs/src/lib/models/glyphs/hbar.ts
@@ -1,7 +1,6 @@
 import {Box, BoxView, BoxData} from "./box"
 import {NumberArray} from "core/types"
 import * as p from "core/properties"
-import {SpatialIndex} from "core/util/spatial"
 
 export interface HBarData extends BoxData {
   _left: NumberArray
@@ -31,10 +30,6 @@ export class HBarView extends BoxView {
 
   scentery(i: number): number {
     return this.sy[i]
-  }
-
-  protected _index_data(): SpatialIndex {
-    return this._index_box(this._y.length)
   }
 
   protected _lrtb(i: number): [number, number, number, number] {

--- a/bokehjs/src/lib/models/glyphs/hex_tile.ts
+++ b/bokehjs/src/lib/models/glyphs/hex_tile.ts
@@ -63,7 +63,7 @@ export class HexTileView extends GlyphView {
     }
   }
 
-  protected _index_data(): SpatialIndex {
+  protected _index_data(index: SpatialIndex): void {
     let ysize = this.model.size
     let xsize = Math.sqrt(3)*ysize/2
 
@@ -73,15 +73,17 @@ export class HexTileView extends GlyphView {
     } else
       xsize /= this.model.aspect_scale
 
-    const points = []
-    for (let i = 0; i < this._x.length; i++) {
+    const {data_size} = this
+
+    for (let i = 0; i < data_size; i++) {
       const x = this._x[i]
       const y = this._y[i]
-      if (isNaN(x+y) || !isFinite(x+y))
-        continue
-      points.push({x0: x-xsize, y0: y-ysize, x1: x+xsize, y1: y+ysize, i})
+
+      if (isNaN(x + y) || !isFinite(x + y))
+        index.add_empty()
+      else
+        index.add(x - xsize, y - ysize, x + xsize, y + ysize)
     }
-    return new SpatialIndex(points)
   }
 
   // overriding map_data instead of _map_data because the default automatic mappings

--- a/bokehjs/src/lib/models/glyphs/image_base.ts
+++ b/bokehjs/src/lib/models/glyphs/image_base.ts
@@ -83,16 +83,16 @@ export abstract class ImageBaseView extends XYGlyphView {
     }
   }
 
-  _index_data(): SpatialIndex {
-    const points = []
-    for (let i = 0, end = this._x.length; i < end; i++) {
+  protected _index_data(index: SpatialIndex): void {
+    const {data_size} = this
+
+    for (let i = 0; i < data_size; i++) {
       const [l, r, t, b] = this._lrtb(i)
-      if (isNaN(l + r + t + b) || !isFinite(l + r + t + b)) {
-        continue
-      }
-      points.push({x0: l, y0: b, x1: r, y1: t, i})
+      if (isNaN(l + r + t + b) || !isFinite(l + r + t + b))
+        index.add_empty()
+      else
+        index.add(l, b, r, t)
     }
-    return new SpatialIndex(points)
   }
 
   _lrtb(i: number): [number, number, number, number]{

--- a/bokehjs/src/lib/models/glyphs/image_url.ts
+++ b/bokehjs/src/lib/models/glyphs/image_url.ts
@@ -40,8 +40,13 @@ export class ImageURLView extends XYGlyphView {
     this.connect(this.model.properties.global_alpha.change, () => this.renderer.request_render())
   }
 
-  protected _index_data(): SpatialIndex {
-    return new SpatialIndex([])
+  protected _index_data(index: SpatialIndex): void {
+    const {data_size} = this
+
+    for (let i = 0; i < data_size; i++) {
+      // TODO: add a proper implementation (same as ImageBase?)
+      index.add_empty()
+    }
   }
 
   protected _set_data(): void {

--- a/bokehjs/src/lib/models/glyphs/multi_line.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_line.ts
@@ -26,24 +26,27 @@ export class MultiLineView extends GlyphView {
   model: MultiLine
   visuals: MultiLine.Visuals
 
-  protected _index_data(): SpatialIndex {
-    const points = []
-    for (let i = 0, end = this._xs.length; i < end; i++) {
+  protected _index_data(index: SpatialIndex): void {
+    const {data_size} = this
+
+    for (let i = 0; i < data_size; i++) {
       const xsi = this._xs[i]
-      if (xsi == null || xsi.length == 0) // XXX: null?, so include in types
+      if (xsi == null || xsi.length == 0) { // XXX: null?, so include in types
+        index.add_empty()
         continue
+      }
 
       const ysi = this._ys[i]
-      if (ysi == null || ysi.length == 0) // XXX: null?, so include in types
+      if (ysi == null || ysi.length == 0) { // XXX: null?, so include in types
+        index.add_empty()
         continue
+      }
 
       const [x0, x1] = minmax(xsi)
       const [y0, y1] = minmax(ysi)
 
-      points.push({x0, y0, x1, y1, i})
+      index.add(x0, y0, x1, y1)
     }
-
-    return new SpatialIndex(points)
   }
 
   protected _render(ctx: Context2d, indices: number[], {sxs, sys}: MultiLineData): void {

--- a/bokehjs/src/lib/models/glyphs/multi_polygons.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_polygons.ts
@@ -30,24 +30,26 @@ export class MultiPolygonsView extends GlyphView {
   model: MultiPolygons
   visuals: MultiPolygons.Visuals
 
-  protected _index_data(): SpatialIndex {
-    const points = []
-    for (let i = 0, end = this._xs.length; i < end; i++) {
+  protected _index_data(index: SpatialIndex): void {
+    const {data_size} = this
+
+    for (let i = 0; i < data_size; i++) {
       for (let j = 0, endj = this._xs[i].length; j < endj; j++) {
         const xs = this._xs[i][j][0]  // do not use holes
         const ys = this._ys[i][j][0]  // do not use holes
 
         if (xs.length == 0)
-          continue
+          index.add_empty()
+        else {
+          const [x0, x1] = minmax(xs)
+          const [y0, y1] = minmax(ys)
 
-        const [x0, x1] = minmax(xs)
-        const [y0, y1] = minmax(ys)
-
-        points.push({x0, y0, x1, y1, i})
+          index.add(x0, y0, x1, y1)
+        }
       }
     }
+
     this.hole_index = this._index_hole_data()  // should this be set here?
-    return new SpatialIndex(points)
   }
 
   protected _index_hole_data(): SpatialIndex {
@@ -71,7 +73,7 @@ export class MultiPolygonsView extends GlyphView {
         }
       }
     }
-    return new SpatialIndex(points)
+    return SpatialIndex.from(points)
   }
 
   protected _mask_data(): number[] {

--- a/bokehjs/src/lib/models/glyphs/patches.ts
+++ b/bokehjs/src/lib/models/glyphs/patches.ts
@@ -69,27 +69,27 @@ export class PatchesView extends GlyphView {
     return ds
   }
 
-  protected _index_data(): SpatialIndex {
+  protected _index_data(index: SpatialIndex): void {
     const xss = this._build_discontinuous_object(this._xs)
     const yss = this._build_discontinuous_object(this._ys)
 
-    const points = []
-    for (let i = 0, end = this._xs.length; i < end; i++) {
+    const {data_size} = this
+
+    for (let i = 0; i < data_size; i++) {
       for (let j = 0, endj = xss[i].length; j < endj; j++) {
         const xs = xss[i][j]
         const ys = yss[i][j]
 
         if (xs.length == 0)
-          continue
+          index.add_empty()
+        else {
+          const [x0, x1] = minmax(xs)
+          const [y0, y1] = minmax(ys)
 
-        const [x0, x1] = minmax(xs)
-        const [y0, y1] = minmax(ys)
-
-        points.push({x0, y0, x1, y1, i})
+          index.add(x0, y0, x1, y1)
+        }
       }
     }
-
-    return new SpatialIndex(points)
   }
 
   protected _mask_data(): number[] {

--- a/bokehjs/src/lib/models/glyphs/patches.ts
+++ b/bokehjs/src/lib/models/glyphs/patches.ts
@@ -70,24 +70,19 @@ export class PatchesView extends GlyphView {
   }
 
   protected _index_data(index: SpatialIndex): void {
-    const xss = this._build_discontinuous_object(this._xs)
-    const yss = this._build_discontinuous_object(this._ys)
-
     const {data_size} = this
 
     for (let i = 0; i < data_size; i++) {
-      for (let j = 0, endj = xss[i].length; j < endj; j++) {
-        const xs = xss[i][j]
-        const ys = yss[i][j]
+      const xsi = this._xs[i]
+      const ysi = this._ys[i]
 
-        if (xs.length == 0)
-          index.add_empty()
-        else {
-          const [x0, x1] = minmax(xs)
-          const [y0, y1] = minmax(ys)
+      if (xsi.length == 0)
+        index.add_empty()
+      else {
+        const [x0, x1] = minmax(xsi)
+        const [y0, y1] = minmax(ysi)
 
-          index.add(x0, y0, x1, y1)
-        }
+        index.add(x0, y0, x1, y1)
       }
     }
   }

--- a/bokehjs/src/lib/models/glyphs/quad.ts
+++ b/bokehjs/src/lib/models/glyphs/quad.ts
@@ -1,6 +1,5 @@
 import {Box, BoxView, BoxData} from "./box"
 import {NumberArray} from "core/types"
-import {SpatialIndex} from "core/util/spatial"
 import * as p from "core/properties"
 
 export interface QuadData extends BoxData {
@@ -27,10 +26,6 @@ export class QuadView extends BoxView {
 
   scentery(i: number): number {
     return (this.stop[i] + this.sbottom[i])/2
-  }
-
-  protected _index_data(): SpatialIndex {
-    return this._index_box(this._right.length)
   }
 
   protected _lrtb(i: number): [number, number, number, number] {

--- a/bokehjs/src/lib/models/glyphs/quadratic.ts
+++ b/bokehjs/src/lib/models/glyphs/quadratic.ts
@@ -49,20 +49,19 @@ export class QuadraticView extends GlyphView {
   model: Quadratic
   visuals: Quadratic.Visuals
 
-  protected _index_data(): SpatialIndex {
-    const points = []
+  protected _index_data(index: SpatialIndex): void {
+    const {data_size} = this
 
-    for (let i = 0, end = this._x0.length; i < end; i++) {
+    for (let i = 0; i < data_size; i++) {
       if (isNaN(this._x0[i] + this._x1[i] + this._y0[i] + this._y1[i] + this._cx[i] + this._cy[i]))
-        continue
+        index.add_empty()
+      else {
+        const [x0, x1] = _qbb(this._x0[i], this._cx[i], this._x1[i])
+        const [y0, y1] = _qbb(this._y0[i], this._cy[i], this._y1[i])
 
-      const [x0, x1] = _qbb(this._x0[i], this._cx[i], this._x1[i])
-      const [y0, y1] = _qbb(this._y0[i], this._cy[i], this._y1[i])
-
-      points.push({x0, y0, x1, y1, i})
+        index.add(x0, y0, x1, y1)
+      }
     }
-
-    return new SpatialIndex(points)
   }
 
   protected _render(ctx: Context2d, indices: number[], {sx0, sy0, sx1, sy1, scx, scy}: QuadraticData): void {

--- a/bokehjs/src/lib/models/glyphs/segment.ts
+++ b/bokehjs/src/lib/models/glyphs/segment.ts
@@ -28,27 +28,21 @@ export class SegmentView extends GlyphView {
   model: Segment
   visuals: Segment.Visuals
 
-  protected _index_data(): SpatialIndex {
-    const points = []
+  protected _index_data(index: SpatialIndex): void {
+    const {min, max} = Math
+    const {data_size} = this
 
-    for (let i = 0, end = this._x0.length; i < end; i++) {
+    for (let i = 0; i < data_size; i++) {
       const x0 = this._x0[i]
       const x1 = this._x1[i]
       const y0 = this._y0[i]
       const y1 = this._y1[i]
 
-      if (!isNaN(x0 + x1 + y0 + y1)) {
-        points.push({
-          x0: Math.min(x0, x1),
-          y0: Math.min(y0, y1),
-          x1: Math.max(x0, x1),
-          y1: Math.max(y0, y1),
-          i,
-        })
-      }
+      if (isNaN(x0 + x1 + y0 + y1))
+        index.add_empty()
+      else
+        index.add(min(x0, x1), min(y0, y1), max(x0, x1), max(y0, y1))
     }
-
-    return new SpatialIndex(points)
   }
 
   protected _render(ctx: Context2d, indices: number[], {sx0, sy0, sx1, sy1}: SegmentData): void {

--- a/bokehjs/src/lib/models/glyphs/varea.ts
+++ b/bokehjs/src/lib/models/glyphs/varea.ts
@@ -2,7 +2,7 @@ import {PointGeometry} from 'core/geometry'
 import {Arrayable, NumberArray} from "core/types"
 import {Area, AreaView, AreaData} from "./area"
 import {Context2d} from "core/util/canvas"
-import {SpatialIndex, IndexedRect} from "core/util/spatial"
+import {SpatialIndex} from "core/util/spatial"
 import * as hittest from "core/hittest"
 import * as p from "core/properties"
 import {Selection} from "../selections/selection"
@@ -23,21 +23,20 @@ export class VAreaView extends AreaView {
   model: VArea
   visuals: VArea.Visuals
 
-  protected _index_data(): SpatialIndex {
-    const points: IndexedRect[] = []
+  protected _index_data(index: SpatialIndex): void {
+    const {min, max} = Math
+    const {data_size} = this
 
-    for (let i = 0, end = this._x.length; i < end; i++) {
+    for (let i = 0; i < data_size; i++) {
       const x = this._x[i]
       const y1 = this._y1[i]
       const y2 = this._y2[i]
 
       if (isNaN(x + y1 + y2) || !isFinite(x + y1 + y2))
-        continue
-
-      points.push({x0: x, y0: Math.min(y1, y2), x1: x, y1: Math.max(y1, y2), i})
+        index.add_empty()
+      else
+        index.add(x, min(y1, y2), x, max(y1, y2))
     }
-
-    return new SpatialIndex(points)
   }
 
   protected _inner(ctx: Context2d, sx: Arrayable<number>, sy1: Arrayable<number>, sy2: Arrayable<number>, func: (this: Context2d) => void): void {

--- a/bokehjs/src/lib/models/glyphs/vbar.ts
+++ b/bokehjs/src/lib/models/glyphs/vbar.ts
@@ -1,7 +1,6 @@
 import {Box, BoxView, BoxData} from "./box"
 import {NumberArray} from "core/types"
 import * as p from "core/properties"
-import {SpatialIndex} from "core/util/spatial"
 
 export interface VBarData extends BoxData {
   _x: NumberArray
@@ -31,10 +30,6 @@ export class VBarView extends BoxView {
 
   scentery(i: number): number {
     return (this.stop[i] + this.sbottom[i])/2
-  }
-
-  protected _index_data(): SpatialIndex {
-    return this._index_box(this._x.length)
   }
 
   protected _lrtb(i: number): [number, number, number, number] {

--- a/bokehjs/src/lib/models/glyphs/xy_glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/xy_glyph.ts
@@ -1,5 +1,5 @@
 import {NumberArray} from "core/types"
-import {SpatialIndex, IndexedRect} from "core/util/spatial"
+import {SpatialIndex} from "core/util/spatial"
 import * as p from "core/properties"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
 
@@ -17,20 +17,18 @@ export abstract class XYGlyphView extends GlyphView {
   model: XYGlyph
   visuals: XYGlyph.Visuals
 
-  protected _index_data(): SpatialIndex {
-    const points: IndexedRect[] = []
+  protected _index_data(index: SpatialIndex): void {
+    const {data_size} = this
 
-    for (let i = 0, end = this._x.length; i < end; i++) {
+    for (let i = 0; i < data_size; i++) {
       const x = this._x[i]
       const y = this._y[i]
 
       if (isNaN(x + y) || !isFinite(x + y))
-        continue
-
-      points.push({x0: x, y0: y, x1: x, y1: y, i})
+        index.add_empty()
+      else
+        index.add(x, y, x, y)
     }
-
-    return new SpatialIndex(points)
   }
 
   scenterx(i: number): number {

--- a/bokehjs/test/unit/models/glyphs/glyph.ts
+++ b/bokehjs/test/unit/models/glyphs/glyph.ts
@@ -18,9 +18,7 @@ describe("glyph module", () => {
       class SomeGlyphView extends GlyphView {
         model: SomeGlyph
 
-        protected _index_data(): SpatialIndex {
-          return new SpatialIndex([])
-        }
+        protected _index_data(_index: SpatialIndex): void {}
 
         protected _render(_ctx: Context2d, _indices: number[], {}: object): void {}
 


### PR DESCRIPTION
Currently data indexing is very inefficient, because it doesn't work in fixed memory, doesn't use typed arrays and creates a lot of intermediate objects. However, the underlying spatial indexing library (`flatbush`) is very efficient.

This PR does the following:

- no intermediate objects are created during indexing
- data is transferred directly from data arrays to the index (typed array to typed array)
- the index is pre-allocated and doesn't require intermediate reallocations

The size of the index is defined as the length of the shortest column in a data source (all columns should be of the same length in general, but this still isn't enforced).

~~This is based on PR #10161~~.