### PR TITLE
Ensure typed arrays are used for storing numerical data

### DIFF
--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -625,7 +625,7 @@ export abstract class HasProps extends Signalable() implements Equals, Printable
 
   materialize_dataspecs(source: ColumnarDataSource): {[key: string]: Arrayable<unknown> | number} {
     // Note: this should be moved to a function separate from HasProps
-    const data: {[key: string]: unknown[] | number} = {}
+    const data: {[key: string]: Arrayable<unknown> | number} = {}
     for (const prop of this) {
       if (!(prop instanceof p.VectorSpec))
         continue
@@ -638,7 +638,7 @@ export abstract class HasProps extends Signalable() implements Equals, Printable
 
       data[`_${name}`] = array
       if (prop instanceof p.DistanceSpec)
-        data[`max_${name}`] = max(array)
+        data[`max_${name}`] = max(array as Arrayable<number>)
     }
     return data
   }

--- a/bokehjs/src/lib/core/properties.ts
+++ b/bokehjs/src/lib/core/properties.ts
@@ -1,7 +1,7 @@
 import {Signal0} from "./signaling"
 import type {HasProps} from "./has_props"
 import * as enums from "./enums"
-import {Arrayable} from "./types"
+import {Arrayable, NumberArray} from "./types"
 import * as types from "./types"
 import {includes, repeat} from "./util/array"
 import {map} from "./util/arrayable"
@@ -367,7 +367,7 @@ export abstract class VectorSpec<T, V extends Vector<T> = Vector<T>> extends Pro
       this.validate(this.spec.value)
   }
 
-  array(source: ColumnarDataSource): any[] {
+  array(source: ColumnarDataSource): Arrayable<unknown> {
     let ret: any
 
     if (this.spec.field != null) {
@@ -416,7 +416,13 @@ export abstract class UnitsSpec<T, Units> extends VectorSpec<T, Dimensional<Vect
   }
 }
 
-export class AngleSpec extends UnitsSpec<number, enums.AngleUnits> {
+export abstract class NumberUnitsSpec<Units> extends UnitsSpec<number, Units> {
+  array(source: ColumnarDataSource): NumberArray {
+    return new NumberArray(super.array(source) as any)
+  }
+}
+
+export class AngleSpec extends NumberUnitsSpec<enums.AngleUnits> {
   get default_units(): enums.AngleUnits { return "rad" as "rad" }
   get valid_units(): enums.AngleUnits[] { return enums.AngleUnits }
 
@@ -428,25 +434,35 @@ export class AngleSpec extends UnitsSpec<number, enums.AngleUnits> {
   }
 }
 
-export class BooleanSpec extends DataSpec<boolean> {}
+export class DistanceSpec extends NumberUnitsSpec<enums.SpatialUnits> {
+  get default_units(): enums.SpatialUnits { return "data" as "data" }
+  get valid_units(): enums.SpatialUnits[] { return enums.SpatialUnits }
+}
 
-export class ColorSpec extends DataSpec<types.Color | null> {}
+export class BooleanSpec extends DataSpec<boolean> {
+  array(source: ColumnarDataSource): Uint8Array {
+    return new Uint8Array(super.array(source) as any)
+  }
+}
+
+export class NumberSpec extends DataSpec<number> {
+  array(source: ColumnarDataSource): NumberArray {
+    return new NumberArray(super.array(source) as any)
+  }
+}
 
 export class CoordinateSpec extends DataSpec<number | Factor> {}
 
 export class CoordinateSeqSpec extends DataSpec<number[] | Factor[]> {}
 
-export class DistanceSpec extends UnitsSpec<number, enums.SpatialUnits> {
-  get default_units(): enums.SpatialUnits { return "data" as "data" }
-  get valid_units(): enums.SpatialUnits[] { return enums.SpatialUnits }
-}
+export class ColorSpec extends DataSpec<types.Color | null> {}
 
 export class FontSizeSpec extends DataSpec<string> {}
 
 export class MarkerSpec extends DataSpec<string> {}
 
-export class NumberSpec extends DataSpec<number> {}
-
 export class StringSpec extends DataSpec<string> {}
 
 export class NullStringSpec extends DataSpec<string | null> {}
+
+export class NDArraySpec extends DataSpec<number> {}

--- a/bokehjs/src/lib/core/types.ts
+++ b/bokehjs/src/lib/core/types.ts
@@ -4,6 +4,9 @@ export type Color = string
 
 export {TypedArray} from "./util/ndarray"
 
+export type NumberArray = Float64Array
+export const NumberArray = Float64Array
+
 export type Arrayable<T = any> = {
   readonly length: number
   [n: number]: T

--- a/bokehjs/src/lib/core/util/arrayable.ts
+++ b/bokehjs/src/lib/core/util/arrayable.ts
@@ -77,7 +77,7 @@ export function map(array: Float64Array, fn: (item: number, i: number, array: Fl
 export function map<T, U>(array: T[], fn: (item: T, i: number, array: Arrayable<T>) => U): U[]
 export function map<T, U>(array: Arrayable<T>, fn: (item: T, i: number, array: Arrayable<T>) => U): Arrayable<U>
 
-export function map<T, U>(array: Arrayable<T>, fn: (item: T, i: number, array: Arrayable<T>) => U): Arrayable<U> {
+export function map<T, U>(array: Arrayable<T>, fn: (item: T, i: number, array: any) => U): Arrayable<U> {
   const n = array.length
   const result = new (array.constructor as ArrayableNew)<U>(n)
   for (let i = 0; i < n; i++) {

--- a/bokehjs/src/lib/core/util/arrayable.ts
+++ b/bokehjs/src/lib/core/util/arrayable.ts
@@ -73,6 +73,7 @@ export function indexOf<T>(array: Arrayable<T>, item: T): number {
   return -1
 }
 
+export function map(array: Float64Array, fn: (item: number, i: number, array: Float64Array) => number): Float64Array
 export function map<T, U>(array: T[], fn: (item: T, i: number, array: Arrayable<T>) => U): U[]
 export function map<T, U>(array: Arrayable<T>, fn: (item: T, i: number, array: Arrayable<T>) => U): Arrayable<U>
 

--- a/bokehjs/src/lib/core/util/arrayable.ts
+++ b/bokehjs/src/lib/core/util/arrayable.ts
@@ -73,6 +73,15 @@ export function indexOf<T>(array: Arrayable<T>, item: T): number {
   return -1
 }
 
+export function subselect<T>(array: Arrayable<T>, indices: Arrayable<number>): Arrayable<T> {
+  const n = indices.length
+  const result = new (array.constructor as ArrayableNew)<T>(n)
+  for (let i = 0; i < n; i++) {
+    result[i] = array[indices[i]]
+  }
+  return result
+}
+
 export function map(array: Float64Array, fn: (item: number, i: number, array: Float64Array) => number): Float64Array
 export function map<T, U>(array: T[], fn: (item: T, i: number, array: Arrayable<T>) => U): U[]
 export function map<T, U>(array: Arrayable<T>, fn: (item: T, i: number, array: Arrayable<T>) => U): Arrayable<U>

--- a/bokehjs/src/lib/core/util/projections.ts
+++ b/bokehjs/src/lib/core/util/projections.ts
@@ -2,6 +2,7 @@ import proj4 from "proj4/lib/core"
 import Projection from "proj4/lib/Proj"
 
 import {LatLon} from "../enums"
+import {Arrayable, NumberArray} from "../types"
 
 const mercator = new Projection('GOOGLE')
 const wgs84    = new Projection('WGS84')
@@ -18,9 +19,11 @@ const latlon_bounds = {
   lat: [-85.06, 85.06],
 }
 
+const {min, max} = Math
+
 export function clip_mercator(low: number, high: number, dimension: LatLon): [number, number] {
-  const [min, max] = mercator_bounds[dimension]
-  return [Math.max(low, min), Math.min(high, max)]
+  const [vmin, vmax] = mercator_bounds[dimension]
+  return [max(low, vmin), min(high, vmax)]
 }
 
 export function in_bounds(value: number, dimension: LatLon): boolean {
@@ -28,10 +31,10 @@ export function in_bounds(value: number, dimension: LatLon): boolean {
   return min < value && value < max
 }
 
-export function project_xy(x: number[], y: number[]): [number[], number[]] {
-  const n = Math.min(x.length, y.length)
-  const merc_x_s: number[] = new Array(n)
-  const merc_y_s: number[] = new Array(n)
+export function project_xy(x: Arrayable<number>, y: Arrayable<number>): [NumberArray, NumberArray] {
+  const n = min(x.length, y.length)
+  const merc_x_s = new NumberArray(n)
+  const merc_y_s = new NumberArray(n)
   for (let i = 0; i < n; i++) {
     const [merc_x, merc_y] = wgs84_mercator.forward([x[i], y[i]])
     merc_x_s[i] = merc_x
@@ -40,10 +43,10 @@ export function project_xy(x: number[], y: number[]): [number[], number[]] {
   return [merc_x_s, merc_y_s]
 }
 
-export function project_xsys(xs: number[][], ys: number[][]): [number[][], number[][]] {
-  const n = Math.min(xs.length, ys.length)
-  const merc_xs_s: number[][] = new Array(n)
-  const merc_ys_s: number[][] = new Array(n)
+export function project_xsys(xs: Arrayable<number>[], ys: Arrayable<number>[]): [NumberArray[], NumberArray[]] {
+  const n = min(xs.length, ys.length)
+  const merc_xs_s: NumberArray[] = new Array(n)
+  const merc_ys_s: NumberArray[] = new Array(n)
   for (let i = 0; i < n; i++) {
     const [merc_x_s, merc_y_s] = project_xy(xs[i], ys[i])
     merc_xs_s[i] = merc_x_s

--- a/bokehjs/src/lib/models/canvas/cartesian_frame.ts
+++ b/bokehjs/src/lib/models/canvas/cartesian_frame.ts
@@ -8,7 +8,7 @@ import {DataRange1d} from "../ranges/data_range1d"
 import {FactorRange} from "../ranges/factor_range"
 
 import {LayoutItem} from "core/layout"
-import {Arrayable} from "core/types"
+import {Arrayable, NumberArray} from "core/types"
 import {BBox} from "core/util/bbox"
 
 export type Ranges = {[key: string]: Range}
@@ -36,7 +36,7 @@ export class CartesianFrame extends LayoutItem {
   protected _yscales: Scales
 
   map_to_screen(x: Arrayable<number>, y: Arrayable<number>,
-                x_name: string = "default", y_name: string = "default"): [Arrayable<number>, Arrayable<number>] {
+                x_name: string = "default", y_name: string = "default"): [NumberArray, NumberArray] {
     const sx = this.xscales[x_name].v_compute(x)
     const sy = this.yscales[y_name].v_compute(y)
     return [sx, sy]

--- a/bokehjs/src/lib/models/glyphs/annular_wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/annular_wedge.ts
@@ -2,7 +2,7 @@ import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {generic_area_legend} from "./utils"
 import {PointGeometry} from "core/geometry"
 import {LineVector, FillVector} from "core/property_mixins"
-import {Arrayable, Rect} from "core/types"
+import {Rect, NumberArray} from "core/types"
 import {Line, Fill} from "core/visuals"
 import * as p from "core/properties"
 import {angle_between} from "core/util/math"
@@ -10,14 +10,14 @@ import {Context2d} from "core/util/canvas"
 import {Selection} from "../selections/selection"
 
 export interface AnnularWedgeData extends XYGlyphData {
-  _inner_radius: Arrayable<number>
-  _outer_radius: Arrayable<number>
-  _start_angle: Arrayable<number>
-  _end_angle: Arrayable<number>
-  _angle: Arrayable<number>
+  _inner_radius: NumberArray
+  _outer_radius: NumberArray
+  _start_angle: NumberArray
+  _end_angle: NumberArray
+  _angle: NumberArray
 
-  sinner_radius: Arrayable<number>
-  souter_radius: Arrayable<number>
+  sinner_radius: NumberArray
+  souter_radius: NumberArray
 
   max_inner_radius: number
   max_outer_radius: number
@@ -40,7 +40,7 @@ export class AnnularWedgeView extends XYGlyphView {
     else
       this.souter_radius = this._outer_radius
 
-    this._angle = new Float32Array(this._start_angle.length)
+    this._angle = new NumberArray(this._start_angle.length)
 
     for (let i = 0, end = this._start_angle.length; i < end; i++) {
       this._angle[i] = this._end_angle[i] - this._start_angle[i]

--- a/bokehjs/src/lib/models/glyphs/annulus.ts
+++ b/bokehjs/src/lib/models/glyphs/annulus.ts
@@ -1,5 +1,5 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
-import {Arrayable, Rect} from "core/types"
+import {Rect, NumberArray} from "core/types"
 import {PointGeometry} from "core/geometry"
 import {LineVector, FillVector} from "core/property_mixins"
 import {Line, Fill} from "core/visuals"
@@ -9,11 +9,11 @@ import {is_ie} from "core/util/compat"
 import {Selection} from "../selections/selection"
 
 export interface AnnulusData extends XYGlyphData {
-  _inner_radius: Arrayable<number>
-  _outer_radius: Arrayable<number>
+  _inner_radius: NumberArray
+  _outer_radius: NumberArray
 
-  sinner_radius: Arrayable<number>
-  souter_radius: Arrayable<number>
+  sinner_radius: NumberArray
+  souter_radius: NumberArray
 
   max_inner_radius: number
   max_outer_radius: number

--- a/bokehjs/src/lib/models/glyphs/arc.ts
+++ b/bokehjs/src/lib/models/glyphs/arc.ts
@@ -2,17 +2,17 @@ import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {generic_line_legend} from "./utils"
 import {LineVector} from "core/property_mixins"
 import {Line} from "core/visuals"
-import {Arrayable, Rect} from "core/types"
+import {Rect, NumberArray} from "core/types"
 import {Direction} from "core/enums"
 import * as p from "core/properties"
 import {Context2d} from "core/util/canvas"
 
 export interface ArcData extends XYGlyphData {
-  _radius: Arrayable<number>
-  _start_angle: Arrayable<number>
-  _end_angle: Arrayable<number>
+  _radius: NumberArray
+  _start_angle: NumberArray
+  _end_angle: NumberArray
 
-  sradius: Arrayable<number>
+  sradius: NumberArray
 
   max_radius: number
 }

--- a/bokehjs/src/lib/models/glyphs/bezier.ts
+++ b/bokehjs/src/lib/models/glyphs/bezier.ts
@@ -1,6 +1,6 @@
 import {LineVector} from "core/property_mixins"
 import {Line} from "core/visuals"
-import {Arrayable, Rect} from "core/types"
+import {Rect, NumberArray} from "core/types"
 import {SpatialIndex} from "core/util/spatial"
 import {Context2d} from "core/util/canvas"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
@@ -76,23 +76,23 @@ function _cbb(x0: number, y0: number,
 }
 
 export interface BezierData extends GlyphData {
-  _x0: Arrayable<number>
-  _y0: Arrayable<number>
-  _x1: Arrayable<number>
-  _y1: Arrayable<number>
-  _cx0: Arrayable<number>
-  _cy0: Arrayable<number>
-  _cx1: Arrayable<number>
-  _cy1: Arrayable<number>
+  _x0: NumberArray
+  _y0: NumberArray
+  _x1: NumberArray
+  _y1: NumberArray
+  _cx0: NumberArray
+  _cy0: NumberArray
+  _cx1: NumberArray
+  _cy1: NumberArray
 
-  sx0: Arrayable<number>
-  sy0: Arrayable<number>
-  sx1: Arrayable<number>
-  sy1: Arrayable<number>
-  scx0: Arrayable<number>
-  scy0: Arrayable<number>
-  scx1: Arrayable<number>
-  scy1: Arrayable<number>
+  sx0: NumberArray
+  sy0: NumberArray
+  sx1: NumberArray
+  sy1: NumberArray
+  scx0: NumberArray
+  scy0: NumberArray
+  scx1: NumberArray
+  scy1: NumberArray
 }
 
 export interface BezierView extends BezierData {}

--- a/bokehjs/src/lib/models/glyphs/box.ts
+++ b/bokehjs/src/lib/models/glyphs/box.ts
@@ -1,5 +1,5 @@
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
-import {Arrayable, Rect} from "core/types"
+import {Rect, NumberArray} from "core/types"
 import {Anchor} from "core/enums"
 import {Line, Fill, Hatch} from "core/visuals"
 import {SpatialIndex} from "core/util/spatial"
@@ -11,15 +11,15 @@ import {Selection} from "../selections/selection"
 import * as p from "core/properties"
 
 export interface BoxData extends GlyphData {
-  _right: Arrayable<number>
-  _bottom: Arrayable<number>
-  _left: Arrayable<number>
-  _top: Arrayable<number>
+  _right: NumberArray
+  _bottom: NumberArray
+  _left: NumberArray
+  _top: NumberArray
 
-  sright: Arrayable<number>
-  sbottom: Arrayable<number>
-  sleft: Arrayable<number>
-  stop: Arrayable<number>
+  sright: NumberArray
+  sbottom: NumberArray
+  sleft: NumberArray
+  stop: NumberArray
 }
 
 export interface BoxView extends BoxData {}

--- a/bokehjs/src/lib/models/glyphs/center_rotatable.ts
+++ b/bokehjs/src/lib/models/glyphs/center_rotatable.ts
@@ -1,16 +1,16 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {LineVector, FillVector} from "core/property_mixins"
 import {Line, Fill} from "core/visuals"
-import {Arrayable} from "core/types"
+import {NumberArray} from "core/types"
 import * as p from "core/properties"
 
 export interface CenterRotatableData extends XYGlyphData {
-  _angle: Arrayable<number>
-  _width: Arrayable<number>
-  _height: Arrayable<number>
+  _angle: NumberArray
+  _width: NumberArray
+  _height: NumberArray
 
-  sw: Arrayable<number>
-  sh: Arrayable<number>
+  sw: NumberArray
+  sh: NumberArray
 
   max_width: number
   max_height: number

--- a/bokehjs/src/lib/models/glyphs/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/circle.ts
@@ -3,7 +3,7 @@ import type {MarkerGLGlyph} from "./webgl/markers"
 import {PointGeometry, SpanGeometry, RectGeometry, PolyGeometry} from "core/geometry"
 import {LineVector, FillVector} from "core/property_mixins"
 import {Line, Fill} from "core/visuals"
-import {Arrayable, Rect} from "core/types"
+import {Rect, NumberArray} from "core/types"
 import {RadiusDimension} from "core/enums"
 import * as hittest from "core/hittest"
 import * as p from "core/properties"
@@ -13,11 +13,11 @@ import {Context2d} from "core/util/canvas"
 import {Selection} from "../selections/selection"
 
 export interface CircleData extends XYGlyphData {
-  _angle: Arrayable<number>
-  _size: Arrayable<number>
-  _radius?: Arrayable<number>
+  _angle: NumberArray
+  _size: NumberArray
+  _radius?: NumberArray
 
-  sradius: Arrayable<number>
+  sradius: NumberArray
 
   max_size: number
   max_radius: number

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -9,7 +9,7 @@ import {View} from "core/view"
 import {Model} from "../../model"
 import {Anchor} from "core/enums"
 import {logger} from "core/logging"
-import {Arrayable, Rect} from "core/types"
+import {Arrayable, Rect, NumberArray} from "core/types"
 import {map} from "core/util/arrayable"
 import {extend} from "core/util/object"
 import {isArray, isTypedArray} from "core/util/types"
@@ -150,7 +150,7 @@ export abstract class GlyphView extends View {
   abstract scentery(i: number, _sx: number, _sy: number): number
 
   sdist(scale: Scale, pts: Arrayable<number>, spans: Arrayable<number>,
-        pts_location: "center" | "edge" = "edge", dilate: boolean = false): Arrayable<number> {
+        pts_location: "center" | "edge" = "edge", dilate: boolean = false): NumberArray {
     let pt0: Arrayable<number>
     let pt1: Arrayable<number>
 
@@ -348,7 +348,7 @@ export abstract class GlyphView extends View {
   // This is where specs not included in coords are computed, e.g. radius.
   protected _map_data(): void {}
 
-  map_to_screen(x: Arrayable<number>, y: Arrayable<number>): [Arrayable<number>, Arrayable<number>] {
+  map_to_screen(x: Arrayable<number>, y: Arrayable<number>): [NumberArray, NumberArray] {
     return this.renderer.plot_view.map_to_screen(x, y, this.model.x_range_name, this.model.y_range_name)
   }
 }

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -272,31 +272,34 @@ export abstract class GlyphView extends View {
       const xr = this.renderer.plot_view.frame.x_ranges[this.model.x_range_name]
       const yr = this.renderer.plot_view.frame.y_ranges[this.model.y_range_name]
 
-      for (let [xname, yname] of this.model._coords) {
-        xname = `_${xname}`
-        yname = `_${yname}`
+      // XXX: MultiPolygons is a special case of special cases
+      if (this.model.type != "MultiPolygons") {
+        for (let [xname, yname] of this.model._coords) {
+          xname = `_${xname}`
+          yname = `_${yname}`
 
-        // TODO (bev) more robust detection of multi-glyph case
-        // hand multi glyph case
-        if (self._xs != null) {
-          if (xr instanceof FactorRange)
-            self[xname] = map(self[xname], (arr: any) => xr.v_synthetic(arr))
-          else
-            self[xname] = map(self[xname], num_array)
-          if (yr instanceof FactorRange)
-            self[yname] = map(self[yname], (arr: any) => yr.v_synthetic(arr))
-          else
-            self[yname] = map(self[yname], num_array)
-        } else {
-          // hand standard glyph case
-          if (xr instanceof FactorRange)
-            self[xname] = xr.v_synthetic(self[xname])
-          else
-            self[xname] = num_array(self[xname])
-          if (yr instanceof FactorRange)
-            self[yname] = yr.v_synthetic(self[yname])
-          else
-            self[yname] = num_array(self[yname])
+          // TODO (bev) more robust detection of multi-glyph case
+          // hand multi glyph case
+          if (self._xs != null) {
+            if (xr instanceof FactorRange)
+              self[xname] = map(self[xname], (arr: any) => xr.v_synthetic(arr))
+            else
+              self[xname] = map(self[xname], num_array)
+            if (yr instanceof FactorRange)
+              self[yname] = map(self[yname], (arr: any) => yr.v_synthetic(arr))
+            else
+              self[yname] = map(self[yname], num_array)
+          } else {
+            // hand standard glyph case
+            if (xr instanceof FactorRange)
+              self[xname] = xr.v_synthetic(self[xname])
+            else
+              self[xname] = num_array(self[xname])
+            if (yr instanceof FactorRange)
+              self[yname] = yr.v_synthetic(self[yname])
+            else
+              self[yname] = num_array(self[yname])
+          }
         }
       }
     }

--- a/bokehjs/src/lib/models/glyphs/harea.ts
+++ b/bokehjs/src/lib/models/glyphs/harea.ts
@@ -1,5 +1,5 @@
 import {PointGeometry} from 'core/geometry'
-import {Arrayable} from "core/types"
+import {Arrayable, NumberArray} from "core/types"
 import {Area, AreaView, AreaData} from "./area"
 import {Context2d} from "core/util/canvas"
 import {SpatialIndex, IndexedRect} from "core/util/spatial"
@@ -8,13 +8,13 @@ import * as p from "core/properties"
 import {Selection} from "../selections/selection"
 
 export interface HAreaData extends AreaData {
-  _x1: Arrayable<number>
-  _x2: Arrayable<number>
-  _y: Arrayable<number>
+  _x1: NumberArray
+  _x2: NumberArray
+  _y: NumberArray
 
-  sx1: Arrayable<number>
-  sx2: Arrayable<number>
-  sy: Arrayable<number>
+  sx1: NumberArray
+  sx2: NumberArray
+  sy: NumberArray
 }
 
 export interface HAreaView extends HAreaData {}
@@ -66,8 +66,8 @@ export class HAreaView extends AreaView {
 
   protected _hit_point(geometry: PointGeometry): Selection {
     const L = this.sy.length
-    const sx = new Float64Array(2*L)
-    const sy = new Float64Array(2*L)
+    const sx = new NumberArray(2*L)
+    const sy = new NumberArray(2*L)
 
     for (let i = 0, end = L; i < end; i++) {
       sx[i] = this.sx1[i]

--- a/bokehjs/src/lib/models/glyphs/hbar.ts
+++ b/bokehjs/src/lib/models/glyphs/hbar.ts
@@ -1,20 +1,20 @@
 import {Box, BoxView, BoxData} from "./box"
-import {Arrayable} from "core/types"
+import {NumberArray} from "core/types"
 import * as p from "core/properties"
 import {SpatialIndex} from "core/util/spatial"
 
 export interface HBarData extends BoxData {
-  _left: Arrayable<number>
-  _y: Arrayable<number>
-  _height: Arrayable<number>
-  _right: Arrayable<number>
+  _left: NumberArray
+  _y: NumberArray
+  _height: NumberArray
+  _right: NumberArray
 
-  sy: Arrayable<number>
-  sh: Arrayable<number>
-  sleft: Arrayable<number>
-  sright: Arrayable<number>
-  stop: Arrayable<number>
-  sbottom: Arrayable<number>
+  sy: NumberArray
+  sh: NumberArray
+  sleft: NumberArray
+  sright: NumberArray
+  stop: NumberArray
+  sbottom: NumberArray
 
   max_height: number
 }
@@ -52,8 +52,8 @@ export class HBarView extends BoxView {
     this.sright = this.renderer.xscale.v_compute(this._right)
 
     const n = this.sy.length
-    this.stop = new Float64Array(n)
-    this.sbottom = new Float64Array(n)
+    this.stop = new NumberArray(n)
+    this.sbottom = new NumberArray(n)
     for (let i = 0; i < n; i++) {
       this.stop[i] = this.sy[i] - this.sh[i]/2
       this.sbottom[i] = this.sy[i] + this.sh[i]/2

--- a/bokehjs/src/lib/models/glyphs/hex_tile.ts
+++ b/bokehjs/src/lib/models/glyphs/hex_tile.ts
@@ -4,7 +4,7 @@ import {PointGeometry, RectGeometry, SpanGeometry} from "core/geometry"
 import * as hittest from "core/hittest"
 import * as p from "core/properties"
 import {LineVector, FillVector} from "core/property_mixins"
-import {Arrayable, Rect} from "core/types"
+import {Rect, NumberArray} from "core/types"
 import {Context2d} from "core/util/canvas"
 import {SpatialIndex} from "core/util/spatial"
 import {Line, Fill} from "core/visuals"
@@ -14,16 +14,16 @@ import {generic_area_legend} from "./utils"
 import {Selection} from "../selections/selection"
 
 export interface HexTileData extends GlyphData {
-  _q: Arrayable<number>
-  _r: Arrayable<number>
+  _q: NumberArray
+  _r: NumberArray
 
-  _x: Arrayable<number>
-  _y: Arrayable<number>
+  _x: NumberArray
+  _y: NumberArray
 
-  _scale: Arrayable<number>
+  _scale: NumberArray
 
-  sx: Arrayable<number>
-  sy: Arrayable<number>
+  sx: NumberArray
+  sy: NumberArray
 
   svx: number[]
   svy: number[]
@@ -47,8 +47,8 @@ export class HexTileView extends GlyphView {
     const size = this.model.size
     const aspect_scale = this.model.aspect_scale
 
-    this._x = new Float64Array(n)
-    this._y = new Float64Array(n)
+    this._x = new NumberArray(n)
+    this._y = new NumberArray(n)
 
     if (this.model.orientation == "pointytop") {
       for (let i = 0; i < n; i++) {

--- a/bokehjs/src/lib/models/glyphs/image_base.ts
+++ b/bokehjs/src/lib/models/glyphs/image_base.ts
@@ -202,7 +202,7 @@ export namespace ImageBase {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = XYGlyph.Props & {
-    image: p.NumberSpec
+    image: p.NDArraySpec
     dw: p.DistanceSpec
     dh: p.DistanceSpec
     global_alpha: p.Property<number>
@@ -224,7 +224,7 @@ export abstract class ImageBase extends XYGlyph {
 
   static init_ImageBase(): void {
     this.define<ImageBase.Props>({
-      image:        [ p.NumberSpec       ], // TODO (bev) array spec?
+      image:        [ p.NDArraySpec      ],
       dw:           [ p.DistanceSpec     ],
       dh:           [ p.DistanceSpec     ],
       dilate:       [ p.Boolean,   false ],

--- a/bokehjs/src/lib/models/glyphs/image_base.ts
+++ b/bokehjs/src/lib/models/glyphs/image_base.ts
@@ -1,5 +1,5 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
-import {Arrayable} from "core/types"
+import {Arrayable, NumberArray} from "core/types"
 import * as p from "core/properties"
 import {Context2d} from "core/util/canvas"
 import {Selection, ImageIndex} from "../selections/selection"
@@ -12,11 +12,11 @@ export interface ImageDataBase extends XYGlyphData {
   image_data: HTMLCanvasElement[]
 
   _image: (NDArray | number[][])[]
-  _dw: Arrayable<number>
-  _dh: Arrayable<number>
+  _dw: NumberArray
+  _dh: NumberArray
 
-  sw: Arrayable<number>
-  sh: Arrayable<number>
+  sw: NumberArray
+  sh: NumberArray
 }
 
 export interface ImageBaseView extends ImageDataBase {}
@@ -25,8 +25,8 @@ export abstract class ImageBaseView extends XYGlyphView {
   model: ImageBase
   visuals: ImageBase.Visuals
 
-  protected _width: Arrayable<number>
-  protected _height: Arrayable<number>
+  protected _width: NumberArray
+  protected _height: NumberArray
 
   connect_signals(): void {
     super.connect_signals()
@@ -114,10 +114,10 @@ export abstract class ImageBaseView extends XYGlyphView {
       this.image_data = new Array(this._image.length)
 
     if (this._width == null || this._width.length != this._image.length)
-      this._width = new Array(this._image.length)
+      this._width = new NumberArray(this._image.length)
 
     if (this._height == null || this._height.length != this._image.length)
-      this._height = new Array(this._image.length)
+      this._height = new NumberArray(this._image.length)
   }
 
   protected _get_or_create_canvas(i: number): HTMLCanvasElement {

--- a/bokehjs/src/lib/models/glyphs/image_url.ts
+++ b/bokehjs/src/lib/models/glyphs/image_url.ts
@@ -1,5 +1,5 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
-import {Arrayable, Rect} from "core/types"
+import {Arrayable, Rect, NumberArray} from "core/types"
 import {Anchor} from "core/enums"
 import * as p from "core/properties"
 import {map, minmax} from "core/util/arrayable"
@@ -10,21 +10,21 @@ import {ImageLoader} from "core/util/image"
 export type CanvasImage = HTMLImageElement
 
 export interface ImageURLData extends XYGlyphData {
-  _url: Arrayable<string>
-  _angle: Arrayable<number>
-  _w: Arrayable<number>
-  _h: Arrayable<number>
+  _url: string[]
+  _angle: NumberArray
+  _w: NumberArray
+  _h: NumberArray
   _bounds_rect: Rect
 
-  sx: Arrayable<number>
-  sy: Arrayable<number>
-  sw: Arrayable<number>
-  sh: Arrayable<number>
+  sx: NumberArray
+  sy: NumberArray
+  sw: NumberArray
+  sh: NumberArray
 
   max_w: number
   max_h: number
 
-  image: Arrayable<CanvasImage | null>
+  image: (CanvasImage | null)[]
 }
 
 export interface ImageURLView extends ImageURLData {}

--- a/bokehjs/src/lib/models/glyphs/multi_line.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_line.ts
@@ -2,7 +2,7 @@ import {SpatialIndex} from "core/util/spatial"
 import {PointGeometry, SpanGeometry} from "core/geometry"
 import {LineVector} from "core/property_mixins"
 import {Line} from "core/visuals"
-import {Arrayable, Rect} from "core/types"
+import {Arrayable, Rect, NumberArray} from "core/types"
 import * as hittest from "core/hittest"
 import * as p from "core/properties"
 import {minmax} from "core/util/arrayable"
@@ -13,11 +13,11 @@ import {generic_line_legend, line_interpolation} from "./utils"
 import {Selection} from "../selections/selection"
 
 export interface MultiLineData extends GlyphData {
-  _xs: Arrayable<number>[]
-  _ys: Arrayable<number>[]
+  _xs: NumberArray[]
+  _ys: NumberArray[]
 
-  sxs: Arrayable<number>[]
-  sys: Arrayable<number>[]
+  sxs: NumberArray[]
+  sys: NumberArray[]
 }
 
 export interface MultiLineView extends MultiLineData {}

--- a/bokehjs/src/lib/models/glyphs/multi_polygons.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_polygons.ts
@@ -3,7 +3,7 @@ import {Glyph, GlyphView, GlyphData} from "./glyph"
 import {generic_area_legend} from "./utils"
 import {minmax} from "core/util/arrayable"
 import {sum} from "core/util/arrayable"
-import {Arrayable, Rect} from "core/types"
+import {Arrayable, Rect, NumberArray} from "core/types"
 import {PointGeometry, RectGeometry} from "core/geometry"
 import {Context2d} from "core/util/canvas"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
@@ -15,11 +15,11 @@ import {isArray, isTypedArray} from "core/util/types"
 import {unreachable} from "core/util/assert"
 
 export interface MultiPolygonsData extends GlyphData {
-  _xs: Arrayable<Arrayable<Arrayable<Arrayable<number>>>>
-  _ys: Arrayable<Arrayable<Arrayable<Arrayable<number>>>>
+  _xs: NumberArray[][][]
+  _ys: NumberArray[][][]
 
-  sxs: Arrayable<Arrayable<Arrayable<Arrayable<number>>>>
-  sys: Arrayable<Arrayable<Arrayable<Arrayable<number>>>>
+  sxs: NumberArray[][][]
+  sys: NumberArray[][][]
 
   hole_index: SpatialIndex
 }
@@ -183,7 +183,7 @@ export class MultiPolygonsView extends GlyphView {
       for (let j = 0, endj = sxs.length; j < endj; j++) {
         const nk = sxs[j].length
 
-        if (hittest.point_in_poly(sx, sy, (sxs[j][0] as number[]), (sys[j][0] as number[]))) {
+        if (hittest.point_in_poly(sx, sy, sxs[j][0], sys[j][0])) {
           if (nk == 1) {
             indices.push(index)
           } else if (hole_candidates.indexOf(index) == -1) {
@@ -191,8 +191,8 @@ export class MultiPolygonsView extends GlyphView {
           } else if (nk > 1) {
             let in_a_hole = false
             for (let k = 1; k < nk; k++) {
-              const sxs_k = sxs[j][k] as number[]
-              const sys_k = sys[j][k] as number[]
+              const sxs_k = sxs[j][k]
+              const sys_k = sys[j][k]
               if (hittest.point_in_poly(sx, sy, sxs_k, sys_k)) {
                 in_a_hole = true
                 break
@@ -225,7 +225,7 @@ export class MultiPolygonsView extends GlyphView {
       const sxs = this.sxs[i]
       const sys = this.sys[i]
       for (let j = 0, end = sxs.length; j < end; j++) {
-        if (hittest.point_in_poly(sx, sy, (sxs[j][0] as number[]), (sys[j][0] as number[])))
+        if (hittest.point_in_poly(sx, sy, sxs[j][0], sys[j][0]))
           return this._get_snap_coord(sxs[j][0])
       }
     }
@@ -243,7 +243,7 @@ export class MultiPolygonsView extends GlyphView {
       const sxs = this.sxs[i]
       const sys = this.sys[i]
       for (let j = 0, end = sxs.length; j < end; j++) {
-        if (hittest.point_in_poly(sx, sy, (sxs[j][0] as number[]), (sys[j][0] as number[])))
+        if (hittest.point_in_poly(sx, sy, sxs[j][0], sys[j][0]))
           return this._get_snap_coord(sys[j][0])
       }
     }

--- a/bokehjs/src/lib/models/glyphs/patches.ts
+++ b/bokehjs/src/lib/models/glyphs/patches.ts
@@ -3,7 +3,7 @@ import {Glyph, GlyphView, GlyphData} from "./glyph"
 import {generic_area_legend} from "./utils"
 import {find_last_index} from "core/util/array"
 import {minmax, sum} from "core/util/arrayable"
-import {Arrayable, Rect} from "core/types"
+import {Arrayable, Rect, NumberArray} from "core/types"
 import {PointGeometry, RectGeometry} from "core/geometry"
 import {Context2d} from "core/util/canvas"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
@@ -14,11 +14,11 @@ import {Selection} from "../selections/selection"
 import {unreachable} from "core/util/assert"
 
 export interface PatchesData extends GlyphData {
-  _xs: Arrayable<number>[]
-  _ys: Arrayable<number>[]
+  _xs: NumberArray[]
+  _ys: NumberArray[]
 
-  sxs: Arrayable<number>[]
-  sys: Arrayable<number>[]
+  sxs: NumberArray[]
+  sys: NumberArray[]
 
   sxss: Arrayable<number>[][]
   syss: Arrayable<number>[][]

--- a/bokehjs/src/lib/models/glyphs/quad.ts
+++ b/bokehjs/src/lib/models/glyphs/quad.ts
@@ -1,18 +1,18 @@
 import {Box, BoxView, BoxData} from "./box"
-import {Arrayable} from "core/types"
+import {NumberArray} from "core/types"
 import {SpatialIndex} from "core/util/spatial"
 import * as p from "core/properties"
 
 export interface QuadData extends BoxData {
-  _right: Arrayable<number>
-  _bottom: Arrayable<number>
-  _left: Arrayable<number>
-  _top: Arrayable<number>
+  _right: NumberArray
+  _bottom: NumberArray
+  _left: NumberArray
+  _top: NumberArray
 
-  sright: Arrayable<number>
-  sbottom: Arrayable<number>
-  sleft: Arrayable<number>
-  stop: Arrayable<number>
+  sright: NumberArray
+  sbottom: NumberArray
+  sleft: NumberArray
+  stop: NumberArray
 }
 
 export interface QuadView extends QuadData {}

--- a/bokehjs/src/lib/models/glyphs/quadratic.ts
+++ b/bokehjs/src/lib/models/glyphs/quadratic.ts
@@ -1,6 +1,6 @@
 import {LineVector} from "core/property_mixins"
 import {Line} from "core/visuals"
-import {Arrayable, Rect} from "core/types"
+import {Rect, NumberArray} from "core/types"
 import {SpatialIndex} from "core/util/spatial"
 import {Context2d} from "core/util/canvas"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
@@ -28,19 +28,19 @@ function _qbb(u: number, v: number, w: number): [number, number] {
 }
 
 export interface QuadraticData extends GlyphData {
-  _x0: Arrayable<number>
-  _y0: Arrayable<number>
-  _x1: Arrayable<number>
-  _y1: Arrayable<number>
-  _cx: Arrayable<number>
-  _cy: Arrayable<number>
+  _x0: NumberArray
+  _y0: NumberArray
+  _x1: NumberArray
+  _y1: NumberArray
+  _cx: NumberArray
+  _cy: NumberArray
 
-  sx0: Arrayable<number>
-  sy0: Arrayable<number>
-  sx1: Arrayable<number>
-  sy1: Arrayable<number>
-  scx: Arrayable<number>
-  scy: Arrayable<number>
+  sx0: NumberArray
+  sy0: NumberArray
+  sx1: NumberArray
+  sy1: NumberArray
+  scx: NumberArray
+  scy: NumberArray
 }
 
 export interface QuadraticView extends QuadraticData {}

--- a/bokehjs/src/lib/models/glyphs/ray.ts
+++ b/bokehjs/src/lib/models/glyphs/ray.ts
@@ -2,15 +2,15 @@ import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {generic_line_legend} from "./utils"
 import {LineVector} from "core/property_mixins"
 import {Line} from "core/visuals"
-import {Arrayable, Rect} from "core/types"
+import {Rect, NumberArray} from "core/types"
 import * as p from "core/properties"
 import {Context2d} from "core/util/canvas"
 
 export interface RayData extends XYGlyphData {
-  _length: Arrayable<number>
-  _angle: Arrayable<number>
+  _length: NumberArray
+  _angle: NumberArray
 
-  slength: Arrayable<number>
+  slength: NumberArray
 }
 
 export interface RayView extends RayData {}

--- a/bokehjs/src/lib/models/glyphs/rect.ts
+++ b/bokehjs/src/lib/models/glyphs/rect.ts
@@ -2,7 +2,7 @@ import {CenterRotatable, CenterRotatableView, CenterRotatableData} from "./cente
 import {generic_area_legend} from "./utils"
 import {PointGeometry, RectGeometry} from "core/geometry"
 import {LineVector, FillVector} from "core/property_mixins"
-import {Arrayable} from "core/types"
+import {Arrayable, NumberArray} from "core/types"
 import * as types from "core/types"
 import * as p from "core/properties"
 import {max} from "core/util/arrayable"
@@ -11,9 +11,9 @@ import {Selection} from "../selections/selection"
 import {Scale} from "../scales/scale"
 
 export interface RectData extends CenterRotatableData {
-  sx0: Arrayable<number>
-  sy1: Arrayable<number>
-  ssemi_diag: Arrayable<number>
+  sx0: NumberArray
+  sy1: NumberArray
+  ssemi_diag: NumberArray
 }
 
 export interface RectView extends RectData {}
@@ -39,7 +39,7 @@ export class RectView extends CenterRotatableView {
       this.sw = this._width
 
       const n = this.sx.length
-      this.sx0 = new Float64Array(n)
+      this.sx0 = new NumberArray(n)
       for (let i = 0; i < n; i++)
         this.sx0[i] = this.sx[i] - this.sw[i]/2
     }
@@ -50,13 +50,13 @@ export class RectView extends CenterRotatableView {
       this.sh = this._height
 
       const n =  this.sy.length
-      this.sy1 = new Float64Array(n)
+      this.sy1 = new NumberArray(n)
       for (let i = 0; i < n; i++)
         this.sy1[i] = this.sy[i] - this.sh[i]/2
     }
 
     const n = this.sw.length
-    this.ssemi_diag = new Float64Array(n)
+    this.ssemi_diag = new NumberArray(n)
     for (let i = 0; i < n; i++)
       this.ssemi_diag[i] = Math.sqrt((this.sw[i]/2 * this.sw[i])/2 + (this.sh[i]/2 * this.sh[i])/2)
   }
@@ -167,15 +167,15 @@ export class RectView extends CenterRotatableView {
   }
 
   protected _map_dist_corner_for_data_side_length(coord: Arrayable<number>, side_length: Arrayable<number>,
-                                                  scale: Scale): [Arrayable<number>, Arrayable<number>] {
+                                                  scale: Scale): [NumberArray, NumberArray] {
     const n = coord.length
 
-    const pt0 = new Float64Array(n)
-    const pt1 = new Float64Array(n)
+    const pt0 = new NumberArray(n)
+    const pt1 = new NumberArray(n)
 
     for (let i = 0; i < n; i++) {
-      pt0[i] = Number(coord[i]) - side_length[i]/2
-      pt1[i] = Number(coord[i]) + side_length[i]/2
+      pt0[i] = coord[i] - side_length[i]/2
+      pt1[i] = coord[i] + side_length[i]/2
     }
 
     const spt0 = scale.v_compute(pt0)
@@ -194,13 +194,13 @@ export class RectView extends CenterRotatableView {
     return [sside_length, spt_corner]
   }
 
-  protected _ddist(dim: 0 | 1, spts: Arrayable<number>, spans: Arrayable<number>): Arrayable<number> {
+  protected _ddist(dim: 0 | 1, spts: Arrayable<number>, spans: Arrayable<number>): NumberArray {
     const scale = dim == 0 ? this.renderer.xscale : this.renderer.yscale
 
     const spt0 = spts
 
     const m = spt0.length
-    const spt1 = new Float64Array(m)
+    const spt1 = new NumberArray(m)
     for (let i = 0; i < m; i++)
       spt1[i] = spt0[i] + spans[i]
 
@@ -208,7 +208,7 @@ export class RectView extends CenterRotatableView {
     const pt1 = scale.v_invert(spt1)
 
     const n = pt0.length
-    const ddist = new Float64Array(n)
+    const ddist = new NumberArray(n)
     for (let i = 0; i < n; i++)
       ddist[i] = Math.abs(pt1[i] - pt0[i])
     return ddist

--- a/bokehjs/src/lib/models/glyphs/segment.ts
+++ b/bokehjs/src/lib/models/glyphs/segment.ts
@@ -3,7 +3,7 @@ import * as hittest from "core/hittest"
 import * as p from "core/properties"
 import {LineVector} from "core/property_mixins"
 import {Line} from "core/visuals"
-import {Arrayable, Rect} from "core/types"
+import {Arrayable, Rect, NumberArray} from "core/types"
 import {SpatialIndex} from "core/util/spatial"
 import {Context2d} from "core/util/canvas"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
@@ -11,15 +11,15 @@ import {generic_line_legend} from "./utils"
 import {Selection} from "../selections/selection"
 
 export interface SegmentData extends GlyphData {
-  _x0: Arrayable<number>
-  _y0: Arrayable<number>
-  _x1: Arrayable<number>
-  _y1: Arrayable<number>
+  _x0: NumberArray
+  _y0: NumberArray
+  _x1: NumberArray
+  _y1: NumberArray
 
-  sx0: Arrayable<number>
-  sy0: Arrayable<number>
-  sx1: Arrayable<number>
-  sy1: Arrayable<number>
+  sx0: NumberArray
+  sy0: NumberArray
+  sx1: NumberArray
+  sy1: NumberArray
 }
 
 export interface SegmentView extends SegmentData {}

--- a/bokehjs/src/lib/models/glyphs/text.ts
+++ b/bokehjs/src/lib/models/glyphs/text.ts
@@ -2,7 +2,7 @@ import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {TextVector} from "core/property_mixins"
 import {PointGeometry} from "core/geometry"
 import * as hittest from "core/hittest"
-import {Arrayable} from "core/types"
+import {NumberArray} from "core/types"
 import * as visuals from "core/visuals"
 import * as p from "core/properties"
 import {measure_font} from "core/util/text"
@@ -11,10 +11,10 @@ import {assert} from "core/util/assert"
 import {Selection} from "../selections/selection"
 
 export interface TextData extends XYGlyphData {
-  _text: Arrayable<string>
-  _angle: Arrayable<number>
-  _x_offset: Arrayable<number>
-  _y_offset: Arrayable<number>
+  _text: string[]
+  _angle: NumberArray
+  _x_offset: NumberArray
+  _y_offset: NumberArray
 
   _sxs: number[][][]
   _sys: number[][][]

--- a/bokehjs/src/lib/models/glyphs/varea.ts
+++ b/bokehjs/src/lib/models/glyphs/varea.ts
@@ -1,5 +1,5 @@
 import {PointGeometry} from 'core/geometry'
-import {Arrayable} from "core/types"
+import {Arrayable, NumberArray} from "core/types"
 import {Area, AreaView, AreaData} from "./area"
 import {Context2d} from "core/util/canvas"
 import {SpatialIndex, IndexedRect} from "core/util/spatial"
@@ -8,13 +8,13 @@ import * as p from "core/properties"
 import {Selection} from "../selections/selection"
 
 export interface VAreaData extends AreaData {
-  _x: Arrayable<number>
-  _y1: Arrayable<number>
-  _y2: Arrayable<number>
+  _x: NumberArray
+  _y1: NumberArray
+  _y2: NumberArray
 
-  sx: Arrayable<number>
-  sy1: Arrayable<number>
-  sy2: Arrayable<number>
+  sx: NumberArray
+  sy1: NumberArray
+  sy2: NumberArray
 }
 
 export interface VAreaView extends VAreaData {}
@@ -74,8 +74,8 @@ export class VAreaView extends AreaView {
 
   protected _hit_point(geometry: PointGeometry): Selection {
     const L = this.sx.length
-    const sx = new Float64Array(2*L)
-    const sy = new Float64Array(2*L)
+    const sx = new NumberArray(2*L)
+    const sy = new NumberArray(2*L)
 
     for (let i = 0, end = L; i < end; i++) {
       sx[i] = this.sx[i]

--- a/bokehjs/src/lib/models/glyphs/vbar.ts
+++ b/bokehjs/src/lib/models/glyphs/vbar.ts
@@ -1,20 +1,20 @@
 import {Box, BoxView, BoxData} from "./box"
-import {Arrayable} from "core/types"
+import {NumberArray} from "core/types"
 import * as p from "core/properties"
 import {SpatialIndex} from "core/util/spatial"
 
 export interface VBarData extends BoxData {
-  _x: Arrayable<number>
-  _bottom: Arrayable<number>
-  _width: Arrayable<number>
-  _top: Arrayable<number>
+  _x: NumberArray
+  _bottom: NumberArray
+  _width: NumberArray
+  _top: NumberArray
 
-  sx: Arrayable<number>
-  sw: Arrayable<number>
-  stop: Arrayable<number>
-  sbottom: Arrayable<number>
-  sleft: Arrayable<number>
-  sright: Arrayable<number>
+  sx: NumberArray
+  sw: NumberArray
+  stop: NumberArray
+  sbottom: NumberArray
+  sleft: NumberArray
+  sright: NumberArray
 
   max_width: number
 }
@@ -52,8 +52,8 @@ export class VBarView extends BoxView {
     this.sbottom = this.renderer.yscale.v_compute(this._bottom)
 
     const n = this.sx.length
-    this.sleft = new Float64Array(n)
-    this.sright = new Float64Array(n)
+    this.sleft = new NumberArray(n)
+    this.sright = new NumberArray(n)
     for (let i = 0; i < n; i++) {
       this.sleft[i] = this.sx[i] - this.sw[i]/2
       this.sright[i] = this.sx[i] + this.sw[i]/2

--- a/bokehjs/src/lib/models/glyphs/wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/wedge.ts
@@ -3,7 +3,7 @@ import {generic_area_legend} from "./utils"
 import {PointGeometry} from "core/geometry"
 import {LineVector, FillVector} from "core/property_mixins"
 import {Line, Fill} from "core/visuals"
-import {Arrayable, Rect} from "core/types"
+import {Rect, NumberArray} from "core/types"
 import {Direction} from "core/enums"
 import * as p from "core/properties"
 import {angle_between} from "core/util/math"
@@ -11,11 +11,11 @@ import {Context2d} from "core/util/canvas"
 import {Selection} from "../selections/selection"
 
 export interface WedgeData extends XYGlyphData {
-  _radius: Arrayable<number>
-  _start_angle: Arrayable<number>
-  _end_angle: Arrayable<number>
+  _radius: NumberArray
+  _start_angle: NumberArray
+  _end_angle: NumberArray
 
-  sradius: Arrayable<number>
+  sradius: NumberArray
 
   max_radius: number
 }

--- a/bokehjs/src/lib/models/glyphs/xy_glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/xy_glyph.ts
@@ -1,14 +1,14 @@
-import {Arrayable} from "core/types"
+import {NumberArray} from "core/types"
 import {SpatialIndex, IndexedRect} from "core/util/spatial"
 import * as p from "core/properties"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
 
 export interface XYGlyphData extends GlyphData {
-  _x: Arrayable<number>
-  _y: Arrayable<number>
+  _x: NumberArray
+  _y: NumberArray
 
-  sx: Arrayable<number>
-  sy: Arrayable<number>
+  sx: NumberArray
+  sy: NumberArray
 }
 
 export interface XYGlyphView extends XYGlyphData {}

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -15,7 +15,7 @@ import {Axis, AxisView} from "../axes/axis"
 import {ToolbarPanel} from "../annotations/toolbar_panel"
 
 import {Reset} from "core/bokeh_events"
-import {Arrayable, Interval} from "core/types"
+import {Arrayable, NumberArray, Interval} from "core/types"
 import {Signal0} from "core/signaling"
 import {build_view, build_views, remove_views} from "core/build_views"
 import {UIEvents} from "core/ui_events"
@@ -504,7 +504,7 @@ export class PlotView extends LayoutDOMView {
   }
 
   map_to_screen(x: Arrayable<number>, y: Arrayable<number>,
-                x_name: string = "default", y_name: string = "default"): [Arrayable<number>, Arrayable<number>] {
+                x_name: string = "default", y_name: string = "default"): [NumberArray, NumberArray] {
     return this.frame.map_to_screen(x, y, x_name, y_name)
   }
 

--- a/bokehjs/src/lib/models/ranges/factor_range.ts
+++ b/bokehjs/src/lib/models/ranges/factor_range.ts
@@ -1,8 +1,7 @@
 import {Range} from "./range"
 import {PaddingUnits} from "core/enums"
 import * as p from "core/properties"
-import {Arrayable} from "core/types"
-import {map} from "core/util/arrayable"
+import {Arrayable, NumberArray} from "core/types"
 import {every, sum} from "core/util/array"
 import {isArray, isNumber, isString} from "core/util/types"
 import {unreachable} from "core/util/assert"
@@ -232,8 +231,13 @@ export class FactorRange extends Range {
   }
 
   // convert an array of string factors into synthetic coordinates
-  v_synthetic(xs: Arrayable<number | Factor | [string] | OffsetFactor>): Arrayable<number> {
-    return map(xs, (x) => this.synthetic(x))
+  v_synthetic(xs: Arrayable<number | Factor | [string] | OffsetFactor>): NumberArray {
+    const n = xs.length
+    const array = new NumberArray(n)
+    for (let i = 0; i < n; i++) {
+      array[i] = this.synthetic(xs[i])
+    }
+    return array
   }
 
   protected _init(silent: boolean): void {

--- a/bokehjs/src/lib/models/scales/categorical_scale.ts
+++ b/bokehjs/src/lib/models/scales/categorical_scale.ts
@@ -1,6 +1,6 @@
 import {Scale} from "./scale"
 import {FactorRange} from "../ranges/factor_range"
-import {Arrayable} from "core/types"
+import {Arrayable, NumberArray} from "core/types"
 import * as p from "core/properties"
 
 export namespace CategoricalScale {
@@ -24,7 +24,7 @@ export class CategoricalScale extends Scale {
     return super._linear_compute(this.source_range.synthetic(x))
   }
 
-  v_compute(xs: Arrayable<any>): Arrayable<number> {
+  v_compute(xs: Arrayable<any>): NumberArray {
     return super._linear_v_compute(this.source_range.v_synthetic(xs))
   }
 
@@ -32,7 +32,7 @@ export class CategoricalScale extends Scale {
     return this._linear_invert(xprime)
   }
 
-  v_invert(xprimes: Arrayable<number>): Arrayable<number> {
+  v_invert(xprimes: Arrayable<number>): NumberArray {
     return this._linear_v_invert(xprimes)
   }
 }

--- a/bokehjs/src/lib/models/scales/linear_scale.ts
+++ b/bokehjs/src/lib/models/scales/linear_scale.ts
@@ -1,5 +1,5 @@
 import {ContinuousScale} from "./continuous_scale"
-import {Arrayable} from "core/types"
+import {Arrayable, NumberArray} from "core/types"
 import * as p from "core/properties"
 
 export namespace LinearScale {
@@ -21,7 +21,7 @@ export class LinearScale extends ContinuousScale {
     return this._linear_compute(x)
   }
 
-  v_compute(xs: Arrayable<number>): Arrayable<number> {
+  v_compute(xs: Arrayable<number>): NumberArray {
     return this._linear_v_compute(xs)
   }
 
@@ -29,7 +29,7 @@ export class LinearScale extends ContinuousScale {
     return this._linear_invert(xprime)
   }
 
-  v_invert(xprimes: Arrayable<number>): Arrayable<number> {
+  v_invert(xprimes: Arrayable<number>): NumberArray {
     return this._linear_v_invert(xprimes)
   }
 }

--- a/bokehjs/src/lib/models/scales/log_scale.ts
+++ b/bokehjs/src/lib/models/scales/log_scale.ts
@@ -1,5 +1,5 @@
 import {ContinuousScale} from "./continuous_scale"
-import {Arrayable} from "core/types"
+import {Arrayable, NumberArray} from "core/types"
 import * as p from "core/properties"
 
 export namespace LogScale {
@@ -34,10 +34,10 @@ export class LogScale extends ContinuousScale {
     return value
   }
 
-  v_compute(xs: Arrayable<number>): Arrayable<number> {
+  v_compute(xs: Arrayable<number>): NumberArray {
     const [factor, offset, inter_factor, inter_offset] = this._compute_state()
 
-    const result = new Float64Array(xs.length)
+    const result = new NumberArray(xs.length)
 
     if (inter_factor == 0) {
       for (let i = 0; i < xs.length; i++)
@@ -63,9 +63,9 @@ export class LogScale extends ContinuousScale {
     return Math.exp(inter_factor*value + inter_offset)
   }
 
-  v_invert(xprimes: Arrayable<number>): Arrayable<number> {
+  v_invert(xprimes: Arrayable<number>): NumberArray {
     const [factor, offset, inter_factor, inter_offset] = this._compute_state()
-    const result = new Float64Array(xprimes.length)
+    const result = new NumberArray(xprimes.length)
     for (let i = 0; i < xprimes.length; i++) {
       const value = (xprimes[i] - offset) / factor
       result[i] = Math.exp(inter_factor*value + inter_offset)

--- a/bokehjs/src/lib/models/scales/scale.ts
+++ b/bokehjs/src/lib/models/scales/scale.ts
@@ -1,7 +1,7 @@
 import {Transform} from "../transforms"
 import {Range} from "../ranges/range"
 import {Range1d} from "../ranges/range1d"
-import {Arrayable} from "core/types"
+import {Arrayable, NumberArray} from "core/types"
 import * as p from "core/properties"
 
 export namespace Scale {
@@ -31,11 +31,11 @@ export abstract class Scale extends Transform {
 
   abstract compute(x: number): number
 
-  abstract v_compute(xs: Arrayable<number>): Arrayable<number>
+  abstract v_compute(xs: Arrayable<number>): NumberArray
 
   abstract invert(sx: number): number
 
-  abstract v_invert(sxs: Arrayable<number>): Arrayable<number>
+  abstract v_invert(sxs: Arrayable<number>): NumberArray
 
   r_compute(x0: number, x1: number): [number, number] {
     if (this.target_range.is_reversed)
@@ -58,9 +58,9 @@ export abstract class Scale extends Transform {
     return factor * x + offset
   }
 
-  _linear_v_compute(xs: Arrayable<number>): Arrayable<number> {
+  _linear_v_compute(xs: Arrayable<number>): NumberArray {
     const [factor, offset] = this._linear_compute_state()
-    const result = new Float64Array(xs.length)
+    const result = new NumberArray(xs.length)
     for (let i = 0; i < xs.length; i++)
       result[i] = factor*xs[i] + offset
     return result
@@ -71,9 +71,9 @@ export abstract class Scale extends Transform {
     return (xprime - offset) / factor
   }
 
-  _linear_v_invert(xprimes: Arrayable<number>): Arrayable<number> {
+  _linear_v_invert(xprimes: Arrayable<number>): NumberArray {
     const [factor, offset] = this._linear_compute_state()
-    const result = new Float64Array(xprimes.length)
+    const result = new NumberArray(xprimes.length)
     for (let i = 0; i < xprimes.length; i++)
       result[i] = (xprimes[i] - offset) / factor
     return result

--- a/bokehjs/test/unit/core/has_props.ts
+++ b/bokehjs/test/unit/core/has_props.ts
@@ -117,7 +117,7 @@ describe("core/has_props module", () => {
       const r = new ColumnDataSource({data: {colname: [1, 2, 3, 4]}})
       const obj = new SubclassWithNumberSpec()
       const data = obj.materialize_dataspecs(r)
-      expect(data).to.be.equal({_foo: [1, 2, 3, 4]})
+      expect(data).to.be.equal({_foo: new Float64Array([1, 2, 3, 4])})
     })
 
     it("should collect shapes when they are present", () => {
@@ -133,7 +133,7 @@ describe("core/has_props module", () => {
       const obj = new SubclassWithDistanceSpec()
 
       const data0 = obj.materialize_dataspecs(r0)
-      expect(data0).to.be.equal({_foo: [1, 2, 3, 4, 2], max_foo: 4})
+      expect(data0).to.be.equal({_foo: new Float64Array([1, 2, 3, 4, 2]), max_foo: 4})
 
       const array1 = ndarray([1, 2, 3, 4, 2], {shape: [2, 2]})
       const r1 = new ColumnDataSource({data: {colname: array1}})
@@ -145,7 +145,7 @@ describe("core/has_props module", () => {
       const r = new ColumnDataSource({data: {colname: [1, 2, 3, 4]}})
       const obj = new SubclassWithOptionalSpec()
       const data = obj.materialize_dataspecs(r)
-      expect(data).to.be.equal({_baz: [1, 2, 3, 4]})
+      expect(data).to.be.equal({_baz: new Float64Array([1, 2, 3, 4])})
     })
   })
 

--- a/bokehjs/test/unit/core/properties.ts
+++ b/bokehjs/test/unit/core/properties.ts
@@ -246,12 +246,12 @@ describe("properties module", () => {
         const obj1 = new Some({number_spec: 1})
         const p1 = obj1.properties.number_spec
         const arr1 = p1.array(source)
-        expect(arr1).to.be.equal([1, 1, 1, 1, 1])
+        expect(arr1).to.be.equal(new Float64Array([1, 1, 1, 1, 1]))
 
         const obj2 = new Some({number_spec: {value: 2}})
         const p2 = obj2.properties.number_spec
         const arr2 = p2.array(source)
-        expect(arr2).to.be.equal([2, 2, 2, 2, 2])
+        expect(arr2).to.be.equal(new Float64Array([2, 2, 2, 2, 2]))
       })
 
       it("should return an array if there is a valid expr spec", () => {
@@ -259,7 +259,7 @@ describe("properties module", () => {
         const obj = new Some({number_spec: {expr: new TestExpression()}})
         const prop = obj.properties.number_spec
         const arr = prop.array(source)
-        expect(arr).to.be.equal([0, 1, 2, 3, 4])
+        expect(arr).to.be.equal(new Float64Array([0, 1, 2, 3, 4]))
       })
 
       it("should return an array if there is a valid field spec", () => {
@@ -267,7 +267,7 @@ describe("properties module", () => {
         const obj = new Some({number_spec: {field: "foo"}})
         const prop = obj.properties.number_spec
         const arr = prop.array(source)
-        expect(arr).to.be.equal([0, 1, 2, 3, 10])
+        expect(arr).to.be.equal(new Float64Array([0, 1, 2, 3, 10]))
       })
 
       it("should return an array if there is a valid field spec named 'field'", () => {
@@ -275,7 +275,7 @@ describe("properties module", () => {
         const obj = new Some({number_spec: {field: "field"}})
         const prop = obj.properties.number_spec
         const arr = prop.array(source)
-        expect(arr).to.be.equal([0, 1, 2, 3, 10])
+        expect(arr).to.be.equal(new Float64Array([0, 1, 2, 3, 10]))
       })
 
       it("should throw an Error otherwise", () => {
@@ -293,7 +293,7 @@ describe("properties module", () => {
         const obj = new Some({number_spec: {field: "foo", transform: new TestTransform()}} as any) // XXX: transform
         const prop = obj.properties.number_spec
         const arr = prop.array(source)
-        expect(arr).to.be.equal([0, 2, 4, 6, 14])
+        expect(arr).to.be.equal(new Float64Array([0, 2, 4, 6, 14]))
       })
 
       it("should apply a spec transform to a value array", () => {
@@ -301,7 +301,7 @@ describe("properties module", () => {
         const obj = new Some({number_spec: {value: 2, transform: new TestTransform()}} as any) // XXX: transform
         const prop = obj.properties.number_spec
         const arr = prop.array(source)
-        expect(arr).to.be.equal([2, 3, 4, 5, 6])
+        expect(arr).to.be.equal(new Float64Array([2, 3, 4, 5, 6]))
       })
 
       describe("changing the property attribute value", () => {

--- a/bokehjs/test/unit/models/glyphs/image.ts
+++ b/bokehjs/test/unit/models/glyphs/image.ts
@@ -41,8 +41,8 @@ describe("Image module", () => {
       const image_view = await create_glyph_view(image)
       image_view.map_data()
 
-      expect(image_view.sw).to.be.equal([1])
-      expect(image_view.sh).to.be.equal([2])
+      expect(image_view.sw).to.be.equal(new Float64Array([1]))
+      expect(image_view.sh).to.be.equal(new Float64Array([2]))
     })
   })
 })

--- a/bokehjs/test/unit/models/glyphs/image_rgba.ts
+++ b/bokehjs/test/unit/models/glyphs/image_rgba.ts
@@ -41,8 +41,8 @@ describe("ImageRGBA module", () => {
       const image_rgba_view = await create_glyph_view(image_rgba)
       image_rgba_view.map_data()
 
-      expect(image_rgba_view.sw).to.be.equal([1])
-      expect(image_rgba_view.sh).to.be.equal([2])
+      expect(image_rgba_view.sw).to.be.equal(new Float64Array([1]))
+      expect(image_rgba_view.sh).to.be.equal(new Float64Array([2]))
     })
   })
 })

--- a/bokehjs/test/unit/models/glyphs/image_url.ts
+++ b/bokehjs/test/unit/models/glyphs/image_url.ts
@@ -63,8 +63,8 @@ describe("ImageURL module", () => {
       const image_url_view = await create_glyph_view(image_url)
       image_url_view.map_data()
 
-      expect(image_url_view.sw).to.be.equal([1])
-      expect(image_url_view.sh).to.be.equal([2])
+      expect(image_url_view.sw).to.be.equal(new Float64Array([1]))
+      expect(image_url_view.sh).to.be.equal(new Float64Array([2]))
     })
 
     it("`_map_data` should map data to NaN if w and h are null, 'data' units", async () => {
@@ -90,8 +90,8 @@ describe("ImageURL module", () => {
       const image_url_view = await create_glyph_view(image_url)
       image_url_view.map_data()
 
-      expect(image_url_view.sw).to.be.equal([NaN])
-      expect(image_url_view.sh).to.be.equal([NaN])
+      expect(image_url_view.sw).to.be.equal(new Float64Array([NaN]))
+      expect(image_url_view.sh).to.be.equal(new Float64Array([NaN]))
     })
   })
 })

--- a/bokehjs/test/unit/models/glyphs/ray.ts
+++ b/bokehjs/test/unit/models/glyphs/ray.ts
@@ -38,7 +38,7 @@ describe("Ray", () => {
 
         set_scales(glyph_view, "linear")
         glyph_view.map_data()
-        expect(glyph_view.slength).to.be.equal([10])
+        expect(glyph_view.slength).to.be.equal(new Float64Array([10]))
       }
     })
 
@@ -64,7 +64,7 @@ describe("Ray", () => {
 
         set_scales(glyph_view, "linear", true)
         glyph_view.map_data()
-        expect(glyph_view.slength).to.be.equal([10])
+        expect(glyph_view.slength).to.be.equal(new Float64Array([10]))
       }
     })
   })

--- a/bokehjs/test/unit/models/glyphs/rect.ts
+++ b/bokehjs/test/unit/models/glyphs/rect.ts
@@ -128,8 +128,8 @@ describe("Rect", () => {
 
       set_scales(glyph_view, "linear")
       glyph_view.map_data()
-      expect(glyph_view.sw).to.be.equal([10])
-      expect(glyph_view.sh).to.be.equal([20])
+      expect(glyph_view.sw).to.be.equal(new Float64Array([10]))
+      expect(glyph_view.sh).to.be.equal(new Float64Array([20]))
     })
 
     // XXX: needs update

--- a/bokehjs/test/unit/models/ranges/factor_range.ts
+++ b/bokehjs/test/unit/models/ranges/factor_range.ts
@@ -599,31 +599,31 @@ describe("factor_range module", () => {
         const r = new FactorRange({factors: ['A', 'B', 'C'], factor_padding: 0.1})
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.2)
-        expect(r.v_synthetic(['A', 'B', 'C'])).to.be.equal([0.5, 1.6, 2.7])
+        expect(r.v_synthetic(['A', 'B', 'C'])).to.be.equal(new Float64Array([0.5, 1.6, 2.7]))
       })
 
       it("should update range when changed", () => {
         const r = new FactorRange({factors: ['A', 'B', 'C'], factor_padding: 0.1})
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.2)
-        expect(r.v_synthetic(['A', 'B', 'C'])).to.be.equal([0.5, 1.6, 2.7])
+        expect(r.v_synthetic(['A', 'B', 'C'])).to.be.equal(new Float64Array([0.5, 1.6, 2.7]))
 
         r.factor_padding = 0.2
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.4)
-        expect(r.v_synthetic(['A', 'B', 'C'])).to.be.equal([0.5, 1.7, 2.9])
+        expect(r.v_synthetic(['A', 'B', 'C'])).to.be.equal(new Float64Array([0.5, 1.7, 2.9]))
       })
 
       it("should update start/end when factors changed", () => {
         const r = new FactorRange({factors: ['A', 'B'], factor_padding: 0.1})
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(2.1)
-        expect(r.v_synthetic(['A', 'B'])).to.be.equal([0.5, 1.6])
+        expect(r.v_synthetic(['A', 'B'])).to.be.equal(new Float64Array([0.5, 1.6]))
 
         r.factors = ['A', 'B', 'C']
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.2)
-        expect(r.v_synthetic(['A', 'B', 'C'])).to.be.equal([0.5, 1.6, 2.7])
+        expect(r.v_synthetic(['A', 'B', 'C'])).to.be.equal(new Float64Array([0.5, 1.6, 2.7]))
       })
     })
 
@@ -666,26 +666,26 @@ describe("factor_range module", () => {
 
       it("should return an Array", () => {
         const x0 = r.v_synthetic([10, 10.2, -5.7, -5])
-        expect(x0).to.be.instanceof(Array)
+        expect(x0).to.be.instanceof(Float64Array)
 
         const x1 = r.v_synthetic(["A", "B", "C", "A"])
-        expect(x1).to.be.instanceof(Array)
+        expect(x1).to.be.instanceof(Float64Array)
 
         const x2 = r.v_synthetic([])
-        expect(x2).to.be.instanceof(Array)
+        expect(x2).to.be.instanceof(Float64Array)
       })
 
       it("should return lists of numeric offsets as-is", () => {
         const x = r.v_synthetic([10, 10.2, -5.7, -5])
-        expect(x).to.be.equal([10, 10.2, -5.7, -5])
+        expect(x).to.be.equal(new Float64Array([10, 10.2, -5.7, -5]))
       })
 
       it("should map simple factors to synthetic coords", () => {
-        expect(r.v_synthetic(["A", "B", "C", "A"])).to.be.equal([0.5, 1.5, 2.5, 0.5])
+        expect(r.v_synthetic(["A", "B", "C", "A"])).to.be.equal(new Float64Array([0.5, 1.5, 2.5, 0.5]))
       })
 
       it("should map simple factors with offsets to synthetic coords", () => {
-        expect(r.v_synthetic([["A", 0.1], ["B", -0.2], ["C"], ["A", 0]])).to.be.equal([0.6, 1.3, 2.5, 0.5])
+        expect(r.v_synthetic([["A", 0.1], ["B", -0.2], ["C"], ["A", 0]])).to.be.equal(new Float64Array([0.6, 1.3, 2.5, 0.5]))
       })
 
       it("should not modify inputs", () => {
@@ -695,8 +695,8 @@ describe("factor_range module", () => {
       })
 
       it("should map unknown factors to NaN", () => {
-        expect(r.v_synthetic(["A", "JUNK", "C", "A"])).to.be.equal([0.5, NaN, 2.5, 0.5])
-        expect(r.v_synthetic([["A", 0.1], ["JUNK", -0.2], ["C"], ["A", 0]])).to.be.equal([0.6, NaN, 2.5, 0.5])
+        expect(r.v_synthetic(["A", "JUNK", "C", "A"])).to.be.equal(new Float64Array([0.5, NaN, 2.5, 0.5]))
+        expect(r.v_synthetic([["A", 0.1], ["JUNK", -0.2], ["C"], ["A", 0]])).to.be.equal(new Float64Array([0.6, NaN, 2.5, 0.5]))
       })
     })
   })
@@ -846,31 +846,31 @@ describe("factor_range module", () => {
         const r = new FactorRange({factors: [['A', '1'], ['A', '2'], ['C', '1']], factor_padding: 0.1, group_padding: 0})
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.1)
-        expect(r.v_synthetic([['A', '1'], ['A', '2'], ['C', '1']])).to.be.equal([0.5, 1.6, 2.6])
+        expect(r.v_synthetic([['A', '1'], ['A', '2'], ['C', '1']])).to.be.equal(new Float64Array([0.5, 1.6, 2.6]))
       })
 
       it("should update range when changed", () => {
         const r = new FactorRange({factors: [['A', '1'], ['A', '2'], ['C', '1']], factor_padding: 0.1, group_padding: 0})
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.1)
-        expect(r.v_synthetic([['A', '1'], ['A', '2'], ['C', '1']])).to.be.equal([0.5, 1.6, 2.6])
+        expect(r.v_synthetic([['A', '1'], ['A', '2'], ['C', '1']])).to.be.equal(new Float64Array([0.5, 1.6, 2.6]))
 
         r.factor_padding = 0.2
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.2)
-        expect(r.v_synthetic([['A', '1'], ['A', '2'], ['C', '1']])).to.be.equal([0.5, 1.7, 2.7])
+        expect(r.v_synthetic([['A', '1'], ['A', '2'], ['C', '1']])).to.be.equal(new Float64Array([0.5, 1.7, 2.7]))
       })
 
       it("should update start/end when factors changed", () => {
         const r = new FactorRange({factors: [['A', '1'], ['A', '2'], ['C', '1']], factor_padding: 0.1, group_padding: 0})
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.1)
-        expect(r.v_synthetic([['A', '1'], ['A', '2'], ['C', '1']])).to.be.equal([0.5, 1.6, 2.6])
+        expect(r.v_synthetic([['A', '1'], ['A', '2'], ['C', '1']])).to.be.equal(new Float64Array([0.5, 1.6, 2.6]))
 
         r.factors = [['A', '1'], ['A', '2'], ['C', '1'], ['D', '2']]
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(4.1)
-        expect(r.v_synthetic([['A', '1'], ['A', '2'], ['C', '1'], ['D', '2']])).to.be.equal([0.5, 1.6, 2.6, 3.6])
+        expect(r.v_synthetic([['A', '1'], ['A', '2'], ['C', '1'], ['D', '2']])).to.be.equal(new Float64Array([0.5, 1.6, 2.6, 3.6]))
       })
     })
 
@@ -880,31 +880,31 @@ describe("factor_range module", () => {
         const r = new FactorRange({factors: [['A', '1'], ['A', '2'], ['C', '1']], group_padding: 0.1})
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.1)
-        expect(r.v_synthetic([['A', '1'], ['A', '2'], ['C', '1']])).to.be.equal([0.5, 1.5, 2.6])
+        expect(r.v_synthetic([['A', '1'], ['A', '2'], ['C', '1']])).to.be.equal(new Float64Array([0.5, 1.5, 2.6]))
       })
 
       it("should update range when changed", () => {
         const r = new FactorRange({factors: [['A', '1'], ['A', '2'], ['C', '1']], group_padding: 0.1})
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.1)
-        expect(r.v_synthetic([['A', '1'], ['A', '2'], ['C', '1']])).to.be.equal([0.5, 1.5, 2.6])
+        expect(r.v_synthetic([['A', '1'], ['A', '2'], ['C', '1']])).to.be.equal(new Float64Array([0.5, 1.5, 2.6]))
 
         r.group_padding = 0.2
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.2)
-        expect(r.v_synthetic([['A', '1'], ['A', '2'], ['C', '1']])).to.be.equal([0.5, 1.5, 2.7])
+        expect(r.v_synthetic([['A', '1'], ['A', '2'], ['C', '1']])).to.be.equal(new Float64Array([0.5, 1.5, 2.7]))
       })
 
       it("should update start/end when factors changed", () => {
         const r = new FactorRange({factors: [['A', '1'], ['A', '2'], ['C', '1']], group_padding: 0.1})
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.1)
-        expect(r.v_synthetic([['A', '1'], ['A', '2'], ['C', '1']])).to.be.equal([0.5, 1.5, 2.6])
+        expect(r.v_synthetic([['A', '1'], ['A', '2'], ['C', '1']])).to.be.equal(new Float64Array([0.5, 1.5, 2.6]))
 
         r.factors = [['A', '1'], ['A', '2'], ['C', '1'], ['D', '2']]
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(4.2)
-        expect(r.v_synthetic([['A', '1'], ['A', '2'], ['C', '1'], ['D', '2']])).to.be.equal([0.5, 1.5, 2.6, 3.7])
+        expect(r.v_synthetic([['A', '1'], ['A', '2'], ['C', '1'], ['D', '2']])).to.be.equal(new Float64Array([0.5, 1.5, 2.6, 3.7]))
       })
     })
 
@@ -963,36 +963,36 @@ describe("factor_range module", () => {
 
       it("should return an Array", () => {
         const x0 = r.v_synthetic([10, 10.2, -5.7, -5])
-        expect(x0).to.be.instanceof(Array)
+        expect(x0).to.be.instanceof(Float64Array)
 
         const x1 = r.v_synthetic(["A", "C", "A"])
-        expect(x1).to.be.instanceof(Array)
+        expect(x1).to.be.instanceof(Float64Array)
 
         const x2 = r.v_synthetic([])
-        expect(x2).to.be.instanceof(Array)
+        expect(x2).to.be.instanceof(Float64Array)
       })
 
       it("should return lists of numeric offsets as-is", () => {
         const x = r.v_synthetic([10, 10.2, -5.7, -5])
-        expect(x).to.be.equal([10, 10.2, -5.7, -5])
+        expect(x).to.be.equal(new Float64Array([10, 10.2, -5.7, -5]))
       })
 
       it("should map dual factors to synthetic coords", () => {
-        expect(r.v_synthetic([['A', '1'], ['A', '2'], ['C', '1']])).to.be.equal([0.5, 1.5, 2.5])
+        expect(r.v_synthetic([['A', '1'], ['A', '2'], ['C', '1']])).to.be.equal(new Float64Array([0.5, 1.5, 2.5]))
       })
 
       it("should map dual factors with offsets to synthetic coords", () => {
-        expect(r.v_synthetic([['A', '1', 0.1], ['A', '2', -0.2], ['C', '1', 0]])).to.be.equal([0.6, 1.3, 2.5])
+        expect(r.v_synthetic([['A', '1', 0.1], ['A', '2', -0.2], ['C', '1', 0]])).to.be.equal(new Float64Array([0.6, 1.3, 2.5]))
       })
 
       it("should map first-level factors to average group synthetic coords", () => {
-        expect(r.v_synthetic([['A'], ['C']])).to.be.equal([1, 2.5])
+        expect(r.v_synthetic([['A'], ['C']])).to.be.equal(new Float64Array([1, 2.5]))
 
-        expect(r.v_synthetic(['A', 'C'])).to.be.equal([1, 2.5])
+        expect(r.v_synthetic(['A', 'C'])).to.be.equal(new Float64Array([1, 2.5]))
       })
 
       it("should map first-level factors with offsets to average group synthetic coords", () => {
-        expect(r.v_synthetic([['A', 0.1], ['C', -0.2], ['C', 0]])).to.be.equal([1.1, 2.3, 2.5])
+        expect(r.v_synthetic([['A', 0.1], ['C', -0.2], ['C', 0]])).to.be.equal(new Float64Array([1.1, 2.3, 2.5]))
       })
 
       it("should not modify inputs", () => {
@@ -1002,12 +1002,12 @@ describe("factor_range module", () => {
       })
 
       it("should map unknown factors to NaN", () => {
-        expect(r.v_synthetic([['A'], ['JUNK']])).to.be.equal([1, NaN])
-        expect(r.v_synthetic([['A', 0.1], ['JUNK', -0.2], ['C', 0]])).to.be.equal([1.1, NaN, 2.5])
-        expect(r.v_synthetic([['A', '1'], ['JUNK', '2'], ['C', '1']])).to.be.equal([0.5, NaN, 2.5])
-        expect(r.v_synthetic([['A', '1'], ['A', 'JUNK'], ['C', '1']])).to.be.equal([0.5, NaN, 2.5])
-        expect(r.v_synthetic([['A', '1', 0.1], ['JUNK', '2', -0.2], ['C', '1', 0]])).to.be.equal([0.6, NaN, 2.5])
-        expect(r.v_synthetic([['A', '1', 0.1], ['A', 'JUNK', -0.2], ['C', '1', 0]])).to.be.equal([0.6, NaN, 2.5])
+        expect(r.v_synthetic([['A'], ['JUNK']])).to.be.equal(new Float64Array([1, NaN]))
+        expect(r.v_synthetic([['A', 0.1], ['JUNK', -0.2], ['C', 0]])).to.be.equal(new Float64Array([1.1, NaN, 2.5]))
+        expect(r.v_synthetic([['A', '1'], ['JUNK', '2'], ['C', '1']])).to.be.equal(new Float64Array([0.5, NaN, 2.5]))
+        expect(r.v_synthetic([['A', '1'], ['A', 'JUNK'], ['C', '1']])).to.be.equal(new Float64Array([0.5, NaN, 2.5]))
+        expect(r.v_synthetic([['A', '1', 0.1], ['JUNK', '2', -0.2], ['C', '1', 0]])).to.be.equal(new Float64Array([0.6, NaN, 2.5]))
+        expect(r.v_synthetic([['A', '1', 0.1], ['A', 'JUNK', -0.2], ['C', '1', 0]])).to.be.equal(new Float64Array([0.6, NaN, 2.5]))
       })
     })
   })
@@ -1168,31 +1168,31 @@ describe("factor_range module", () => {
         const r = new FactorRange({factors: [['A', '1', 'foo'], ['A', '1', 'bar'], ['C', '1', 'foo']], factor_padding: 0.1, group_padding: 0, subgroup_padding: 0})
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.1)
-        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '1', 'bar'], ['C', '1', 'foo']])).to.be.equal([0.5, 1.6, 2.6])
+        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '1', 'bar'], ['C', '1', 'foo']])).to.be.equal(new Float64Array([0.5, 1.6, 2.6]))
       })
 
       it("should update range when changed", () => {
         const r = new FactorRange({factors: [['A', '1', 'foo'], ['A', '1', 'bar'], ['C', '1', 'foo']], factor_padding: 0.1, group_padding: 0, subgroup_padding: 0})
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.1)
-        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '1', 'bar'], ['C', '1', 'foo']])).to.be.equal([0.5, 1.6, 2.6])
+        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '1', 'bar'], ['C', '1', 'foo']])).to.be.equal(new Float64Array([0.5, 1.6, 2.6]))
 
         r.factor_padding = 0.2
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.2)
-        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '1', 'bar'], ['C', '1', 'foo']])).to.be.equal([0.5, 1.7, 2.7])
+        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '1', 'bar'], ['C', '1', 'foo']])).to.be.equal(new Float64Array([0.5, 1.7, 2.7]))
       })
 
       it("should update start/end when factors changed", () => {
         const r = new FactorRange({factors: [['A', '1', 'foo'], ['A', '1', 'bar'], ['C', '1', 'foo']], factor_padding: 0.1, group_padding: 0, subgroup_padding: 0})
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.1)
-        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '1', 'bar'], ['C', '1', 'foo']])).to.be.equal([0.5, 1.6, 2.6])
+        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '1', 'bar'], ['C', '1', 'foo']])).to.be.equal(new Float64Array([0.5, 1.6, 2.6]))
 
         r.factors = [['A', '1', 'foo'], ['A', '1', 'bar'], ['C', '1', 'foo'], ['D', '2', 'foo']]
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(4.1)
-        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '1', 'bar'], ['C', '1', 'foo'], ['D', '2', 'foo']])).to.be.equal([0.5, 1.6, 2.6, 3.6])
+        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '1', 'bar'], ['C', '1', 'foo'], ['D', '2', 'foo']])).to.be.equal(new Float64Array([0.5, 1.6, 2.6, 3.6]))
       })
     })
 
@@ -1202,31 +1202,31 @@ describe("factor_range module", () => {
         const r = new FactorRange({factors: [['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo']], factor_padding: 0, group_padding: 0, subgroup_padding: 0.1})
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.1)
-        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo']])).to.be.equal([0.5, 1.6, 2.6])
+        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo']])).to.be.equal(new Float64Array([0.5, 1.6, 2.6]))
       })
 
       it("should update range when changed", () => {
         const r = new FactorRange({factors: [['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo']], factor_padding: 0, group_padding: 0, subgroup_padding: 0.1})
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.1)
-        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo']])).to.be.equal([0.5, 1.6, 2.6])
+        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo']])).to.be.equal(new Float64Array([0.5, 1.6, 2.6]))
 
         r.subgroup_padding = 0.2
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.2)
-        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo']])).to.be.equal([0.5, 1.7, 2.7])
+        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo']])).to.be.equal(new Float64Array([0.5, 1.7, 2.7]))
       })
 
       it("should update start/end when factors changed", () => {
         const r = new FactorRange({factors: [['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo']], factor_padding: 0, group_padding: 0, subgroup_padding: 0.1})
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.1)
-        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo']])).to.be.equal([0.5, 1.6, 2.6])
+        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo']])).to.be.equal(new Float64Array([0.5, 1.6, 2.6]))
 
         r.factors = [['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo'], ['D', '2', 'foo']]
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(4.1)
-        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo'], ['D', '2', 'foo']])).to.be.equal([0.5, 1.6, 2.6, 3.6])
+        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo'], ['D', '2', 'foo']])).to.be.equal(new Float64Array([0.5, 1.6, 2.6, 3.6]))
       })
     })
 
@@ -1236,31 +1236,31 @@ describe("factor_range module", () => {
         const r = new FactorRange({factors: [['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo']], factor_padding: 0, subgroup_padding: 0, group_padding: 0.1})
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.1)
-        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo']])).to.be.equal([0.5, 1.5, 2.6])
+        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo']])).to.be.equal(new Float64Array([0.5, 1.5, 2.6]))
       })
 
       it("should update range when changed", () => {
         const r = new FactorRange({factors: [['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo']], factor_padding: 0, subgroup_padding: 0, group_padding: 0.1})
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.1)
-        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo']])).to.be.equal([0.5, 1.5, 2.6])
+        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo']])).to.be.equal(new Float64Array([0.5, 1.5, 2.6]))
 
         r.group_padding = 0.2
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.2)
-        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo']])).to.be.equal([0.5, 1.5, 2.7])
+        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo']])).to.be.equal(new Float64Array([0.5, 1.5, 2.7]))
       })
 
       it("should update start/end when factors changed", () => {
         const r = new FactorRange({factors: [['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo']], factor_padding: 0, subgroup_padding: 0, group_padding: 0.1})
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(3.1)
-        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo']])).to.be.equal([0.5, 1.5, 2.6])
+        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo']])).to.be.equal(new Float64Array([0.5, 1.5, 2.6]))
 
         r.factors = [['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo'], ['D', '2', 'foo']]
         expect(r.start).to.be.equal(0)
         expect(r.end).to.be.equal(4.2)
-        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo'], ['D', '2', 'foo']])).to.be.equal([0.5, 1.5, 2.6, 3.7])
+        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '2', 'foo'], ['C', '1', 'foo'], ['D', '2', 'foo']])).to.be.equal(new Float64Array([0.5, 1.5, 2.6, 3.7]))
       })
     })
 
@@ -1333,44 +1333,44 @@ describe("factor_range module", () => {
 
       it("should return an Array", () => {
         const x0 = r.v_synthetic([10, 10.2, -5.7, -5])
-        expect(x0).to.be.instanceof(Array)
+        expect(x0).to.be.instanceof(Float64Array)
 
         const x1 = r.v_synthetic(["A", "C", "A"])
-        expect(x1).to.be.instanceof(Array)
+        expect(x1).to.be.instanceof(Float64Array)
 
         const x2 = r.v_synthetic([])
-        expect(x2).to.be.instanceof(Array)
+        expect(x2).to.be.instanceof(Float64Array)
       })
 
       it("should return lists of numeric offsets as-is", () => {
         const x = r.v_synthetic([10, 10.2, -5.7, -5])
-        expect(x).to.be.equal([10, 10.2, -5.7, -5])
+        expect(x).to.be.equal(new Float64Array([10, 10.2, -5.7, -5]))
       })
 
       it("should map triple factors to synthetic coords", () => {
-        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '1', 'bar'], ['C', '1', 'foo']])).to.be.equal([0.5, 1.5, 2.5])
+        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '1', 'bar'], ['C', '1', 'foo']])).to.be.equal(new Float64Array([0.5, 1.5, 2.5]))
       })
 
       it("should map triple factors with offsets to synthetic coords", () => {
-        expect(r.v_synthetic([['A', '1', 'foo', 0.1], ['A', '1', 'bar', -0.2], ['C', '1', 'foo', 0]])).to.be.equal([0.6, 1.3, 2.5])
+        expect(r.v_synthetic([['A', '1', 'foo', 0.1], ['A', '1', 'bar', -0.2], ['C', '1', 'foo', 0]])).to.be.equal(new Float64Array([0.6, 1.3, 2.5]))
       })
 
       it("should map first-level factors to average group synthetic coords", () => {
-        expect(r.v_synthetic([['A'], ['C']])).to.be.equal([1, 2.5])
+        expect(r.v_synthetic([['A'], ['C']])).to.be.equal(new Float64Array([1, 2.5]))
 
-        expect(r.v_synthetic(['A', 'C'])).to.be.equal([1, 2.5])
+        expect(r.v_synthetic(['A', 'C'])).to.be.equal(new Float64Array([1, 2.5]))
       })
 
       it("should map first-level factors with offsets to average group synthetic coords", () => {
-        expect(r.v_synthetic([['A', 0.1], ['C', -0.2], ['C', 0]])).to.be.equal([1.1, 2.3, 2.5])
+        expect(r.v_synthetic([['A', 0.1], ['C', -0.2], ['C', 0]])).to.be.equal(new Float64Array([1.1, 2.3, 2.5]))
       })
 
       it("should map second-level factors to average group synthetic coords", () => {
-        expect(r.v_synthetic([['A', '1']])).to.be.equal([1])
+        expect(r.v_synthetic([['A', '1']])).to.be.equal(new Float64Array([1]))
       })
 
       it("should map second-level factors with offsets to average group synthetic coords", () => {
-        expect(r.v_synthetic([['A', '1', 0.1]])).to.be.equal([1.1])
+        expect(r.v_synthetic([['A', '1', 0.1]])).to.be.equal(new Float64Array(new Float64Array([1.1])))
       })
 
       it("should not modify inputs", () => {
@@ -1380,19 +1380,19 @@ describe("factor_range module", () => {
       })
 
       it("should map unknown factors to NaN", () => {
-        expect(r.v_synthetic([['A', '1', 'foo'], ['JUNK', '1', 'bar'], ['C', '1', 'foo']])).to.be.equal([0.5, NaN, 2.5])
-        expect(r.v_synthetic([['A', '1', 'foo'], ['A', 'JUNK', 'bar'], ['C', '1', 'foo']])).to.be.equal([0.5, NaN, 2.5])
-        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '1', 'JUNK'], ['C', '1', 'foo']])).to.be.equal([0.5, NaN, 2.5])
-        expect(r.v_synthetic([['A', '1', 'foo', 0.1], ['JUNK', '1', 'bar', -0.2], ['C', '1', 'foo', 0]])).to.be.equal([0.6, NaN, 2.5])
-        expect(r.v_synthetic([['A', '1', 'foo', 0.1], ['A', 'JUNK', 'bar', -0.2], ['C', '1', 'foo', 0]])).to.be.equal([0.6, NaN, 2.5])
-        expect(r.v_synthetic([['A', '1', 'foo', 0.1], ['A', '1', 'JUNK', -0.2], ['C', '1', 'foo', 0]])).to.be.equal([0.6, NaN, 2.5])
-        expect(r.v_synthetic([['A'], ['JUNK']])).to.be.equal([1, NaN])
-        expect(r.v_synthetic(['A', 'JUNK'])).to.be.equal([1, NaN])
-        expect(r.v_synthetic([['A', 0.1], ['JUNK', -0.2], ['C', 0]])).to.be.equal([1.1, NaN, 2.5])
-        expect(r.v_synthetic([['JUNK', '1']])).to.be.equal([NaN])
-        expect(r.v_synthetic([['A', 'JUNK']])).to.be.equal([NaN])
-        expect(r.v_synthetic([['JUNK', '1', 0.1]])).to.be.equal([NaN])
-        expect(r.v_synthetic([['A', 'JUNK', 0.1]])).to.be.equal([NaN])
+        expect(r.v_synthetic([['A', '1', 'foo'], ['JUNK', '1', 'bar'], ['C', '1', 'foo']])).to.be.equal(new Float64Array([0.5, NaN, 2.5]))
+        expect(r.v_synthetic([['A', '1', 'foo'], ['A', 'JUNK', 'bar'], ['C', '1', 'foo']])).to.be.equal(new Float64Array([0.5, NaN, 2.5]))
+        expect(r.v_synthetic([['A', '1', 'foo'], ['A', '1', 'JUNK'], ['C', '1', 'foo']])).to.be.equal(new Float64Array([0.5, NaN, 2.5]))
+        expect(r.v_synthetic([['A', '1', 'foo', 0.1], ['JUNK', '1', 'bar', -0.2], ['C', '1', 'foo', 0]])).to.be.equal(new Float64Array([0.6, NaN, 2.5]))
+        expect(r.v_synthetic([['A', '1', 'foo', 0.1], ['A', 'JUNK', 'bar', -0.2], ['C', '1', 'foo', 0]])).to.be.equal(new Float64Array([0.6, NaN, 2.5]))
+        expect(r.v_synthetic([['A', '1', 'foo', 0.1], ['A', '1', 'JUNK', -0.2], ['C', '1', 'foo', 0]])).to.be.equal(new Float64Array([0.6, NaN, 2.5]))
+        expect(r.v_synthetic([['A'], ['JUNK']])).to.be.equal(new Float64Array([1, NaN]))
+        expect(r.v_synthetic(['A', 'JUNK'])).to.be.equal(new Float64Array([1, NaN]))
+        expect(r.v_synthetic([['A', 0.1], ['JUNK', -0.2], ['C', 0]])).to.be.equal(new Float64Array([1.1, NaN, 2.5]))
+        expect(r.v_synthetic([['JUNK', '1']])).to.be.equal(new Float64Array([NaN]))
+        expect(r.v_synthetic([['A', 'JUNK']])).to.be.equal(new Float64Array([NaN]))
+        expect(r.v_synthetic([['JUNK', '1', 0.1]])).to.be.equal(new Float64Array([NaN]))
+        expect(r.v_synthetic([['A', 'JUNK', 0.1]])).to.be.equal(new Float64Array([NaN]))
       })
     })
   })


### PR DESCRIPTION
This is a transitional PR, so existing and a few new hacks will be removed in near future work. This PR ensures that all fields of `*Data` interfaces are stored as typed arrays whenever applicable (e.g. excluding `TextData.text`, because there is no typed array for storing strings). This ensures that projections, `v_synthetic()` and other array to numerical array transforms return typed arrays (`type NumberArray = Float64Array` to be specific).