### PR TITLE
Websocket local origin: use port returned by bind_sockets

### DIFF
--- a/bokeh/server/server.py
+++ b/bokeh/server/server.py
@@ -395,7 +395,7 @@ class Server(BaseServer):
         sockets, self._port = bind_sockets(opts.address, opts.port)
         self._address = opts.address
 
-        extra_websocket_origins = create_hosts_allowlist(opts.allow_websocket_origin, opts.port)
+        extra_websocket_origins = create_hosts_allowlist(opts.allow_websocket_origin, self.port)
         try:
             tornado_app = BokehTornado(applications,
                                        extra_websocket_origins=extra_websocket_origins,

--- a/tests/unit/bokeh/test_client_server.py
+++ b/tests/unit/bokeh/test_client_server.py
@@ -165,6 +165,10 @@ class TestClientServer(object):
     async def test_allow_websocket_origin(self, ManagedServerLoop) -> None:
         application = Application()
 
+        # allow good local origin with random port
+        with ManagedServerLoop(application, port=0) as server:
+            await self.check_http_ok_socket_ok(server, origin="http://localhost:%s" % server.port)
+
         # allow good origin
         with ManagedServerLoop(application, allow_websocket_origin=["example.com"]) as server:
             await self.check_http_ok_socket_ok(server, origin="http://example.com:80")


### PR DESCRIPTION
- [x] issues: fixes #10175
- [x] tests added / passed
