### PR TITLE
Fill in the gaps in bokehjs' property definitions

### DIFF
--- a/bokehjs/src/lib/core/enums.ts
+++ b/bokehjs/src/lib/core/enums.ts
@@ -1,87 +1,89 @@
+import {Enum} from "./kinds"
+
 export type Align = "start" | "center" | "end"
-export const Align: Align[] = ["start", "center", "end"]
+export const Align = Enum("start", "center", "end")
 
 export type Anchor =
   "top_left"    | "top_center"    | "top_right"    |
   "center_left" | "center"        | "center_right" |
   "bottom_left" | "bottom_center" | "bottom_right"
-export const Anchor: Anchor[] = [
+export const Anchor = Enum(
   "top_left",    "top_center",    "top_right",
   "center_left", "center",        "center_right",
   "bottom_left", "bottom_center", "bottom_right",
-]
+)
 
 export type AngleUnits = "deg" | "rad"
-export const AngleUnits: AngleUnits[] = ["deg", "rad"]
+export const AngleUnits = Enum("deg", "rad")
 
 export type BoxOrigin = "corner" | "center"
-export const BoxOrigin: BoxOrigin[] = ["corner", "center"]
+export const BoxOrigin = Enum("corner", "center")
 
 export type ButtonType = "default" | "primary" | "success" | "warning" | "danger"
-export const ButtonType: ButtonType[] = ["default", "primary", "success", "warning", "danger"]
+export const ButtonType = Enum("default", "primary", "success", "warning", "danger")
 
 export type CalendarPosition = "auto" | "above" | "below"
-export const CalendarPosition: CalendarPosition[] = ["auto", "above", "below"]
+export const CalendarPosition = Enum("auto", "above", "below")
 
 export type Dimension = "width" | "height"
-export const Dimension: Dimension[] = ["width", "height"]
+export const Dimension = Enum("width", "height")
 
 export type Dimensions = "width" | "height" | "both"
-export const Dimensions: Dimensions[] = ["width", "height", "both"]
+export const Dimensions = Enum("width", "height", "both")
 
 export type Direction = "clock" | "anticlock"
-export const Direction: Direction[] = ["clock", "anticlock"]
+export const Direction = Enum("clock", "anticlock")
 
 export type Distribution = "uniform" | "normal"
-export const Distribution: Distribution[] = ["uniform", "normal"]
+export const Distribution = Enum("uniform", "normal")
 
 export type FontStyle = "normal" | "italic" | "bold" | "bold italic"
-export const FontStyle: FontStyle[] = ["normal", "italic", "bold", "bold italic"]
+export const FontStyle = Enum("normal", "italic", "bold", "bold italic")
 
 export type HatchPatternType =
   'blank' | 'dot' | 'ring' | 'horizontal_line' | 'vertical_line' | 'cross' | 'horizontal_dash' |
   'vertical_dash' | 'spiral' | 'right_diagonal_line' | 'left_diagonal_line' | 'diagonal_cross' |
   'right_diagonal_dash' | 'left_diagonal_dash' | 'horizontal_wave' | 'vertical_wave' | 'criss_cross' |
   ' ' | '.' | 'o' | '-' | '|' | '+' | '"' | ':' | '@' | '/' | '\\' | 'x' | ',' | '`' | 'v' | '>' | '*'
-export const HatchPatternType: HatchPatternType[] = [
+export const HatchPatternType = Enum(
   'blank', 'dot', 'ring', 'horizontal_line', 'vertical_line', 'cross', 'horizontal_dash',
   'vertical_dash', 'spiral', 'right_diagonal_line', 'left_diagonal_line', 'diagonal_cross',
   'right_diagonal_dash', 'left_diagonal_dash', 'horizontal_wave', 'vertical_wave', 'criss_cross',
   ' ', '.', 'o', '-', '|', '+', '"', ':', '@',  '/', '\\', 'x', ',', '`', 'v', '>', '*',
-]
+)
 
 export type HTTPMethod = "POST" | "GET"
-export const HTTPMethod: HTTPMethod[] = ["POST", "GET"]
+export const HTTPMethod = Enum("POST", "GET")
 
 export type HexTileOrientation = "pointytop" | "flattop"
-export const HexTileOrientation: HexTileOrientation[] = ["pointytop", "flattop"]
+export const HexTileOrientation = Enum("pointytop", "flattop")
 
 export type HoverMode = "mouse" | "hline" | "vline"
-export const HoverMode: HoverMode[] = ["mouse", "hline", "vline"]
+export const HoverMode = Enum("mouse", "hline", "vline")
 
 export type LatLon = "lat" | "lon"
-export const LatLon: LatLon[] = ["lat", "lon"]
+export const LatLon = Enum("lat", "lon")
 
 export type LegendClickPolicy = "none" | "hide" | "mute"
-export const LegendClickPolicy: LegendClickPolicy[] = ["none", "hide", "mute"]
+export const LegendClickPolicy = Enum("none", "hide", "mute")
 
 export type LegendLocation = Anchor
-export const LegendLocation: LegendLocation[] = Anchor
+export const LegendLocation = Anchor
 
 export type LineCap = "butt" | "round" | "square"
-export const LineCap: LineCap[] = ["butt", "round", "square"]
+export const LineCap = Enum("butt", "round", "square")
 
 export type LineJoin = "miter" | "round" | "bevel"
-export const LineJoin: LineJoin[] = ["miter", "round", "bevel"]
+export const LineJoin = Enum("miter", "round", "bevel")
 
 export type LinePolicy = "prev" | "next" | "nearest" | "interp" | "none"
-export const LinePolicy: LinePolicy[] = ["prev", "next", "nearest", "interp", "none"]
+export const LinePolicy = Enum("prev", "next", "nearest", "interp", "none")
 
 export type Location = "above" | "below" | "left" | "right"
-export const Location: Location[] = ["above", "below", "left", "right"]
+export const Location = Enum("above", "below", "left", "right")
 
 export type Logo = "normal" | "grey"
-export const Logo: Logo[] = ["normal", "grey"]
+export const Logo = Enum("normal", "grey")
 
 export type MarkerType =
   "asterisk" | "circle" | "circle_cross" | "circle_dot" | "circle_x" |
@@ -89,88 +91,88 @@ export type MarkerType =
   "dot" | "hex" | "hex_dot" | "inverted_triangle" | "plus" | "square" |
   "square_cross" | "square_dot" | "square_pin" | "square_x" | "triangle" |
   "triangle_dot" | "triangle_pin" | "x" | "y"
-export const MarkerType: MarkerType[] = [
+export const MarkerType = Enum(
   "asterisk", "circle", "circle_cross", "circle_dot", "circle_x",
   "circle_y", "cross", "dash", "diamond", "diamond_cross", "diamond_dot",
   "dot", "hex", "hex_dot", "inverted_triangle", "plus", "square",
   "square_cross", "square_dot", "square_pin", "square_x", "triangle",
   "triangle_dot", "triangle_pin", "x", "y",
-]
+)
 
 export type MutedPolicy = "show" | "ignore"
-export const MutedPolicy: MutedPolicy[] = ["show", "ignore"]
+export const MutedPolicy = Enum("show", "ignore")
 
 export type Orientation = "vertical" | "horizontal"
-export const Orientation: Orientation[] = ["vertical", "horizontal"]
+export const Orientation = Enum("vertical", "horizontal")
 
 export type OutputBackend = "canvas" | "svg" | "webgl"
-export const OutputBackend: OutputBackend[] = ["canvas", "svg", "webgl"]
+export const OutputBackend = Enum("canvas", "svg", "webgl")
 
 export type PaddingUnits = "percent" | "absolute"
-export const PaddingUnits: PaddingUnits[] = ["percent", "absolute"]
+export const PaddingUnits = Enum("percent", "absolute")
 
 export type Place = Side | "center"
-export const Place: Place[] = ["above", "below", "left", "right", "center"]
+export const Place = Enum("above", "below", "left", "right", "center")
 
 export type PointPolicy = "snap_to_data" | "follow_mouse" | "none"
-export const PointPolicy: PointPolicy[] = ["snap_to_data", "follow_mouse", "none"]
+export const PointPolicy = Enum("snap_to_data", "follow_mouse", "none")
 
 export type RadiusDimension = "x" | "y" | "max" | "min"
-export const RadiusDimension: RadiusDimension[] = ["x", "y", "max", "min"]
+export const RadiusDimension = Enum("x", "y", "max", "min")
 
 export type RenderLevel = "image" | "underlay" | "glyph" | "guide" | "annotation" | "overlay"
-export const RenderLevel: RenderLevel[] = ["image", "underlay", "glyph", "guide", "annotation", "overlay"]
+export const RenderLevel = Enum("image", "underlay", "glyph", "guide", "annotation", "overlay")
 
 export type RenderMode = "canvas" | "css"
-export const RenderMode: RenderMode[] = ["canvas", "css"]
+export const RenderMode = Enum("canvas", "css")
 
 export type ResetPolicy = "standard" | "event_only"
-export const ResetPolicy: ResetPolicy[] = ["standard", "event_only"]
+export const ResetPolicy = Enum("standard", "event_only")
 
 export type RoundingFunction = "round" | "nearest" | "floor" | "rounddown" | "ceil" | "roundup"
-export const RoundingFunction: RoundingFunction[] = ["round", "nearest", "floor", "rounddown", "ceil", "roundup"]
+export const RoundingFunction = Enum("round", "nearest", "floor", "rounddown", "ceil", "roundup")
 
 export type SelectionMode = "replace" | "append" | "intersect" | "subtract"
-export const SelectionMode: SelectionMode[] = ["replace", "append", "intersect", "subtract"]
+export const SelectionMode = Enum("replace", "append", "intersect", "subtract")
 
 export type Side = "above" | "below" | "left" | "right"
-export const Side: Side[] = ["above", "below", "left", "right"]
+export const Side = Enum("above", "below", "left", "right")
 
 export type SizingMode = "stretch_width" | "stretch_height" | "stretch_both" | "scale_width" | "scale_height" | "scale_both" | "fixed"
-export const SizingMode: SizingMode[] = ["stretch_width", "stretch_height", "stretch_both", "scale_width", "scale_height", "scale_both", "fixed"]
+export const SizingMode = Enum("stretch_width", "stretch_height", "stretch_both", "scale_width", "scale_height", "scale_both", "fixed")
 
 export type Sort = "ascending" | "descending"
-export const Sort: Sort[] = ["ascending", "descending"]
+export const Sort = Enum("ascending", "descending")
 
 export type SpatialUnits = "screen" | "data"
-export const SpatialUnits: SpatialUnits[] = ["screen", "data"]
+export const SpatialUnits = Enum("screen", "data")
 
 export type StartEnd = "start" | "end"
-export const StartEnd: StartEnd[] = ["start", "end"]
+export const StartEnd = Enum("start", "end")
 
 export type StepMode = "after" | "before" | "center"
-export const StepMode: StepMode[] = ["after", "before", "center"]
+export const StepMode = Enum("after", "before", "center")
 
 export type TapBehavior = "select" | "inspect"
-export const TapBehavior: TapBehavior[] = ["select", "inspect"]
+export const TapBehavior = Enum("select", "inspect")
 
 export type TextAlign = "left" | "right" | "center"
-export const TextAlign: TextAlign[] = ["left", "right", "center"]
+export const TextAlign = Enum("left", "right", "center")
 
 export type TextBaseline = "top" | "middle" | "bottom" | "alphabetic" | "hanging" | "ideographic"
-export const TextBaseline: TextBaseline[] = ["top", "middle", "bottom", "alphabetic", "hanging", "ideographic"]
+export const TextBaseline = Enum("top", "middle", "bottom", "alphabetic", "hanging", "ideographic")
 
 export type TextureRepetition = "repeat" | "repeat_x" | "repeat_y" | "no_repeat"
-export const TextureRepetition: TextureRepetition[] = ["repeat", "repeat_x", "repeat_y", "no_repeat"]
+export const TextureRepetition = Enum("repeat", "repeat_x", "repeat_y", "no_repeat")
 
 export type TickLabelOrientation = "vertical" | "horizontal" | "parallel" | "normal"
-export const TickLabelOrientation: TickLabelOrientation[] = ["vertical", "horizontal", "parallel", "normal"]
+export const TickLabelOrientation = Enum("vertical", "horizontal", "parallel", "normal")
 
 export type TooltipAttachment = "horizontal" | "vertical" | "left" | "right" | "above" | "below"
-export const TooltipAttachment: TooltipAttachment[] = ["horizontal", "vertical", "left", "right", "above", "below"]
+export const TooltipAttachment = Enum("horizontal", "vertical", "left", "right", "above", "below")
 
 export type UpdateMode = "replace" | "append"
-export const UpdateMode: UpdateMode[] = ["replace", "append"]
+export const UpdateMode = Enum("replace", "append")
 
 export type VerticalAlign = "top" | "middle" | "bottom"
-export const VerticalAlign: VerticalAlign[] = ["top", "middle", "bottom"]
+export const VerticalAlign = Enum("top", "middle", "bottom")

--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -47,7 +47,7 @@ export interface HasProps extends HasProps.Attrs, ISignalable {
   id: string
 }
 
-export type PropertyGenerator = Generator<Property, void>
+export type PropertyGenerator = Generator<Property, void, undefined>
 
 export abstract class HasProps extends Signalable() implements Equals, Printable {
   __view_type__: View
@@ -439,9 +439,7 @@ export abstract class HasProps extends Signalable() implements Equals, Printable
   }
 
   *[Symbol.iterator](): PropertyGenerator {
-    for (const prop of values(this.properties)) {
-      yield prop
-    }
+    yield* values(this.properties)
   }
 
   *syncable_properties(): PropertyGenerator {

--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -5,6 +5,7 @@ import {Arrayable, Attrs} from "./types"
 import {Signal0, Signal, Signalable, ISignalable} from "./signaling"
 import {Struct, Ref, is_ref} from "./util/refs"
 import * as p from "./properties"
+import * as k from "./kinds"
 import * as mixins from "./property_mixins"
 import {Property} from "./properties"
 import {uniqueId} from "./util/string"
@@ -280,10 +281,14 @@ export abstract class HasProps extends Signalable() implements Equals, Printable
     const get = attrs instanceof Map ? attrs.get : (name: string) => attrs[name]
 
     for (const [name, {type, default_value, options}] of entries(this._props)) {
-      if (type != null)
-        this.properties[name] = new type(this, name, default_value, get(name), options)
+      let property: p.Property<unknown>
+
+      if (type instanceof k.Kind)
+        property = new p.PrimitiveProperty(this, name, type, default_value, get(name), options)
       else
-        throw new Error(`undefined property type for ${this.type}.${name}`)
+        property = new type(this, name, k.Any, default_value, get(name), options)
+
+      this.properties[name] = property
     }
 
     // allowing us to defer initialization when loading many models

--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -19,6 +19,7 @@ import {is_NDArray} from "./util/ndarray"
 import {encode_NDArray} from "./util/serialization"
 import {equals, Equals, Comparator} from "./util/eq"
 import {pretty, Printable, Printer} from "./util/pretty"
+import * as kinds from "./kinds"
 
 export module HasProps {
   export type Attrs = p.AttrsOf<Props>
@@ -112,8 +113,8 @@ export abstract class HasProps extends Signalable() implements Equals, Printable
   }
 
   // TODO: don't use Partial<>, but exclude inherited properties
-  static define<T>(obj: Partial<p.DefineOf<T>>): void {
-    for (const [name, prop] of entries(obj)) {
+  static define<T>(obj: Partial<p.DefineOf<T>> | ((types: typeof kinds) => Partial<p.DefineOf<T>>)): void {
+    for (const [name, prop] of entries(isFunction(obj) ? obj(kinds) : obj)) {
       if (this.prototype._props[name] != null)
         throw new Error(`attempted to redefine property '${this.prototype.type}.${name}'`)
 

--- a/bokehjs/src/lib/core/kinds.ts
+++ b/bokehjs/src/lib/core/kinds.ts
@@ -1,0 +1,212 @@
+import * as tp from "./util/types"
+import {Color as ColorType} from "./types"
+import {is_color} from "./util/color"
+
+import type {HasProps} from "./has_props"
+
+export abstract class Kind<T> {
+  __type__: T
+
+  abstract valid(value: unknown): value is this["__type__"]
+}
+
+type Constructor<T> = Function & {prototype: T}
+
+export namespace Kinds {
+  export class Any extends Kind<any> {
+    valid(_value: unknown): _value is any {
+      return true
+    }
+  }
+
+  export class Unknown extends Kind<unknown> {
+    valid(_value: unknown): _value is unknown {
+      return true
+    }
+  }
+
+  export class Boolean extends Kind<boolean> {
+    valid(value: unknown): value is boolean {
+      return tp.isBoolean(value)
+    }
+  }
+
+  export class Instance<ObjType extends HasProps> extends Kind<ObjType> {
+    constructor(readonly obj_type: Constructor<ObjType>) {
+      super()
+    }
+
+    valid(value: unknown): value is ObjType {
+      return value instanceof this.obj_type
+    }
+  }
+
+  export class Number extends Kind<number> {
+    valid(value: unknown): value is number {
+      return tp.isNumber(value)
+    }
+  }
+
+  export class Int extends Number {
+    valid(value: unknown): value is number {
+      return super.valid(value) && tp.isInteger(value)
+    }
+  }
+
+  export type TupleKind<T extends unknown[]> = {[K in keyof T]: T[K] extends T[number] ? Kind<T[K]> : never}
+
+  export class Or<T extends unknown[]> extends Kind<T[number]> {
+    constructor(readonly types: TupleKind<T>) {
+      super()
+      this.types = types
+    }
+
+    valid(value: unknown): value is T[number] {
+      return this.types.some((type) => type.valid(value))
+    }
+  }
+
+  export class Tuple<T extends [unknown, ...unknown[]]> extends Kind<T> {
+    constructor(readonly types: TupleKind<T>) {
+      super()
+      this.types = types
+    }
+
+    valid(value: unknown): value is T {
+      if (!tp.isArray(value))
+        return false
+
+      for (let i = 0; i < this.types.length; i++) {
+        const type = this.types[i]
+        const item = value[i]
+        if (!type.valid(item))
+          return false
+      }
+
+      return true
+    }
+  }
+
+  export class Array<ItemType> extends Kind<ItemType[]> {
+
+    constructor(readonly item_type: Kind<ItemType>) {
+      super()
+    }
+
+    valid(value: unknown): value is ItemType[] {
+      return tp.isArray(value) && value.every((item) => this.item_type.valid(item))
+    }
+  }
+
+  export class Null extends Kind<null> {
+    valid(value: unknown): value is null {
+      return value === null
+    }
+  }
+
+  export class Nullable<BaseType> extends Kind<BaseType | null> {
+    constructor(readonly base_type: Kind<BaseType>) {
+      super()
+    }
+
+    valid(value: unknown): value is BaseType | null {
+      return value === null || this.base_type.valid(value)
+    }
+  }
+
+  export class String extends Kind<string> {
+    valid(value: unknown): value is string {
+      return tp.isString(value)
+    }
+  }
+
+  export class Enum<T extends string> extends Kind<T> {
+    readonly values: Set<T>
+
+    constructor(values: Iterable<T>) {
+      super()
+      this.values = new Set(values)
+    }
+
+    valid(value: unknown): value is T {
+      return this.values.has(value as T)
+    }
+  }
+
+  export class Struct<ItemType> extends Kind<{[key: string]: ItemType}> {
+
+    constructor(readonly item_type: Kind<ItemType>) {
+      super()
+    }
+
+    valid(value: unknown): value is this["__type__"] {
+      if (!tp.isPlainObject(value))
+        return false
+
+      for (const key in value) {
+        if (value.hasOwnProperty(key)) {
+          const item = value[key]
+          if (!this.item_type.valid(item))
+            return false
+        }
+      }
+
+      return true
+    }
+  }
+
+  export class Dict<KeyType, ItemType> extends Kind<Map<KeyType, ItemType>> {
+
+    constructor(readonly key_type: Kind<KeyType>, readonly item_type: Kind<ItemType>) {
+      super()
+    }
+
+    valid(value: unknown): value is this["__type__"] {
+      if (!(value instanceof Map))
+        return false
+
+      for (const [key, item] of value.entries()) {
+        if (!(this.key_type.valid(key) && this.item_type.valid(item)))
+          return false
+      }
+
+      return true
+    }
+  }
+
+  export class Color extends Kind<ColorType> {
+    valid(value: unknown): value is ColorType {
+      return tp.isString(value) && is_color(value)
+    }
+  }
+
+  export class Percent extends Number {
+    valid(value: unknown): value is number {
+      return super.valid(value) && 0 <= value && value <= 1.0
+    }
+  }
+}
+
+export const Any = new Kinds.Any()
+export const Unknown = new Kinds.Unknown()
+export const Boolean = new Kinds.Boolean()
+export const Number = new Kinds.Number()
+export const Int = new Kinds.Int()
+export const String = new Kinds.String()
+export const Null = new Kinds.Null()
+export const Nullable = <BaseType>(base_type: Kind<BaseType>) => new Kinds.Nullable(base_type)
+export const Or = <T extends unknown[]>(...types: Kinds.TupleKind<T>) => new Kinds.Or(types)
+export const Tuple = <T extends [unknown, ...unknown[]]>(...types: Kinds.TupleKind<T>) => new Kinds.Tuple(types)
+export const Array = <ItemType>(item_type: Kind<ItemType>) => new Kinds.Array(item_type)
+export const Struct = <V>(item_type: Kind<V>) => new Kinds.Struct(item_type)
+export const Dict = <K, V>(key_type: Kind<K>, item_type: Kind<V>) => new Kinds.Dict(key_type, item_type)
+export const Enum = <T extends string>(...values: T[]) => new Kinds.Enum(values)
+export const Instance = <ObjType extends HasProps>(obj_type: Constructor<ObjType>) => new Kinds.Instance<ObjType>(obj_type)
+
+export const Percent = new Kinds.Percent()
+export const Color = new Kinds.Color()
+export const Auto = Enum("auto")
+
+export const FontSize = String
+export const Font = String
+export const Angle = Number

--- a/bokehjs/src/lib/core/kinds.ts
+++ b/bokehjs/src/lib/core/kinds.ts
@@ -131,6 +131,10 @@ export namespace Kinds {
     valid(value: unknown): value is T {
       return this.values.has(value as T)
     }
+
+    *[Symbol.iterator](): Generator<T, void, undefined> {
+      yield* this.values
+    }
   }
 
   export class Struct<ItemType> extends Kind<{[key: string]: ItemType}> {

--- a/bokehjs/src/lib/core/kinds.ts
+++ b/bokehjs/src/lib/core/kinds.ts
@@ -2,8 +2,6 @@ import * as tp from "./util/types"
 import {Color as ColorType} from "./types"
 import {is_color} from "./util/color"
 
-import type {HasProps} from "./has_props"
-
 export abstract class Kind<T> {
   __type__: T
 
@@ -31,7 +29,7 @@ export namespace Kinds {
     }
   }
 
-  export class Instance<ObjType extends HasProps> extends Kind<ObjType> {
+  export class Ref<ObjType extends object> extends Kind<ObjType> {
     constructor(readonly obj_type: Constructor<ObjType>) {
       super()
     }
@@ -205,7 +203,7 @@ export const Array = <ItemType>(item_type: Kind<ItemType>) => new Kinds.Array(it
 export const Struct = <V>(item_type: Kind<V>) => new Kinds.Struct(item_type)
 export const Dict = <K, V>(key_type: Kind<K>, item_type: Kind<V>) => new Kinds.Dict(key_type, item_type)
 export const Enum = <T extends string>(...values: T[]) => new Kinds.Enum(values)
-export const Instance = <ObjType extends HasProps>(obj_type: Constructor<ObjType>) => new Kinds.Instance<ObjType>(obj_type)
+export const Ref = <ObjType extends object>(obj_type: Constructor<ObjType>) => new Kinds.Ref<ObjType>(obj_type)
 
 export const Percent = new Kinds.Percent()
 export const Color = new Kinds.Color()

--- a/bokehjs/src/lib/core/kinds.ts
+++ b/bokehjs/src/lib/core/kinds.ts
@@ -35,7 +35,11 @@ export namespace Kinds {
     }
 
     valid(value: unknown): value is ObjType {
-      return value instanceof this.obj_type
+      // XXX: disable validation for now, because object graph
+      // initialization depends on this.
+      value
+      return true
+      //return value instanceof this.obj_type
     }
   }
 

--- a/bokehjs/src/lib/core/layout/types.ts
+++ b/bokehjs/src/lib/core/layout/types.ts
@@ -1,4 +1,5 @@
 import {Align} from "../enums"
+import {Enum} from "../kinds"
 
 import {Size, Extents} from "../types"
 export {Size}
@@ -70,6 +71,7 @@ export type Margin = Extents
 export type SizeHint = Size & {inner?: Margin, align?: boolean}
 
 export type SizingPolicy = "fixed" | "fit" | "min" | "max"
+export const SizingPolicy = Enum("fixed", "fit", "min", "max")
 
 export type Sizing = number | "fit" | "min" | "max"
 

--- a/bokehjs/src/lib/core/properties.ts
+++ b/bokehjs/src/lib/core/properties.ts
@@ -169,9 +169,7 @@ export abstract class Property<T = unknown> {
 // Primitive Properties
 //
 
-export class PrimitiveProperty<T> extends Property<T> {
-
-}
+export class PrimitiveProperty<T> extends Property<T> {}
 
 export class Any extends Property<any> {}
 

--- a/bokehjs/src/lib/core/properties.ts
+++ b/bokehjs/src/lib/core/properties.ts
@@ -249,17 +249,17 @@ export abstract class EnumProperty<T extends string> extends Property<T> {
   }
 }
 
-export function Enum<T extends string>(values: T[]): PropertyConstructor<T> {
+export function Enum<T extends string>(values: Iterable<T>): PropertyConstructor<T> {
   return class extends EnumProperty<T> {
     get enum_values(): T[] {
-      return values
+      return [...values]
     }
   }
 }
 
 export class Direction extends EnumProperty<enums.Direction> {
   get enum_values(): enums.Direction[] {
-    return enums.Direction
+    return [...enums.Direction]
   }
 
   normalize(values: any): any {
@@ -274,6 +274,7 @@ export class Direction extends EnumProperty<enums.Direction> {
   }
 }
 
+/* TODO: remove this {{{ */
 export const Anchor = Enum(enums.Anchor)
 export const AngleUnits = Enum(enums.AngleUnits)
 export const BoxOrigin = Enum(enums.BoxOrigin)
@@ -321,6 +322,7 @@ export const TickLabelOrientation = Enum(enums.TickLabelOrientation)
 export const TooltipAttachment = Enum(enums.TooltipAttachment)
 export const UpdateMode = Enum(enums.UpdateMode)
 export const VerticalAlign = Enum(enums.VerticalAlign)
+/* }}} */
 
 //
 // DataSpec properties
@@ -462,7 +464,7 @@ export class YCoordinateSeqSeqSeqSpec extends CoordinateSeqSeqSeqSpec { readonly
 
 export class AngleSpec extends NumberUnitsSpec<enums.AngleUnits> {
   get default_units(): enums.AngleUnits { return "rad" as "rad" }
-  get valid_units(): enums.AngleUnits[] { return enums.AngleUnits }
+  get valid_units(): enums.AngleUnits[] { return [...enums.AngleUnits] }
 
   normalize(values: Arrayable): Arrayable {
     if (this.spec.units == "deg")
@@ -474,7 +476,7 @@ export class AngleSpec extends NumberUnitsSpec<enums.AngleUnits> {
 
 export class DistanceSpec extends NumberUnitsSpec<enums.SpatialUnits> {
   get default_units(): enums.SpatialUnits { return "data" as "data" }
-  get valid_units(): enums.SpatialUnits[] { return enums.SpatialUnits }
+  get valid_units(): enums.SpatialUnits[] { return [...enums.SpatialUnits] }
 }
 
 export class BooleanSpec extends DataSpec<boolean> {

--- a/bokehjs/src/lib/core/properties.ts
+++ b/bokehjs/src/lib/core/properties.ts
@@ -12,6 +12,7 @@ import {Factor/*, OffsetFactor*/} from "../models/ranges/factor_range"
 import {ColumnarDataSource} from "../models/sources/columnar_data_source"
 import {Scalar, Vector, Dimensional} from "./vectorization"
 import {settings} from "./settings"
+import {Kind} from "./kinds"
 
 function valueToString(value: any): string {
   try {
@@ -37,7 +38,7 @@ export type AttrsOf<P> = {
 }
 
 export type DefineOf<P> = {
-  [K in keyof P]: P[K] extends Property<infer T> ? [PropertyConstructor<T>, (T | (() => T))?, PropertyOptions?] : never
+  [K in keyof P]: P[K] extends Property<infer T> ? [PropertyConstructor<T> | Kind<T>, (T | (() => T))?, PropertyOptions?] : never
 }
 
 export type PropertyOptions = {
@@ -46,7 +47,7 @@ export type PropertyOptions = {
 }
 
 export interface PropertyConstructor<T> {
-  new (obj: HasProps, attr: string, default_value?: (obj: HasProps) => T, initial_value?: T, options?: PropertyOptions): Property<T>
+  new (obj: HasProps, attr: string, kind: Kind<T>, default_value?: (obj: HasProps) => T, initial_value?: T, options?: PropertyOptions): Property<T>
   readonly prototype: Property<T>
 }
 
@@ -96,6 +97,7 @@ export abstract class Property<T = unknown> {
 
   constructor(readonly obj: HasProps,
               readonly attr: string,
+              readonly kind: Kind<T>,
               readonly default_value?: (obj: HasProps) => T,
               initial_value?: T,
               options: PropertyOptions = {}) {
@@ -147,8 +149,8 @@ export abstract class Property<T = unknown> {
       throw new Error(`${this.obj.type}.${this.attr} given invalid value: ${valueToString(value)}`)
   }
 
-  valid(_value: unknown): boolean {
-    return true
+  valid(value: unknown): boolean {
+    return this.kind.valid(value)
   }
 
   // ----- property accessors
@@ -166,6 +168,10 @@ export abstract class Property<T = unknown> {
 //
 // Primitive Properties
 //
+
+export class PrimitiveProperty<T> extends Property<T> {
+
+}
 
 export class Any extends Property<any> {}
 

--- a/bokehjs/src/lib/models/layouts/layout_dom.ts
+++ b/bokehjs/src/lib/models/layouts/layout_dom.ts
@@ -5,7 +5,6 @@ import {empty, position, classes, extents, undisplayed} from "core/dom"
 import {logger} from "core/logging"
 import {isNumber, isArray} from "core/util/types"
 import * as p from "core/properties"
-import {Boolean, Number, String, Null, Array, Tuple, Or, Auto, Color as TColor} from "core/kinds"
 
 import {build_views} from "core/build_views"
 import {DOMView} from "core/dom_view"
@@ -397,25 +396,28 @@ export abstract class LayoutDOM extends Model {
   }
 
   static init_LayoutDOM(): void {
-    this.define<LayoutDOM.Props>({
-      width:         [ Or(Number, Null), null ],
-      height:        [ Or(Number, Null), null ],
-      min_width:     [ Or(Number, Null), null ],
-      min_height:    [ Or(Number, Null), null ],
-      max_width:     [ Or(Number, Null), null ],
-      max_height:    [ Or(Number, Null), null ],
-      margin:        [ Or(Number,
-                          Tuple(Number, Number),
-                          Tuple(Number, Number, Number, Number)), [0, 0, 0, 0] ],
-      width_policy:  [ Or(SizingPolicy, Auto), "auto" ],
-      height_policy: [ Or(SizingPolicy, Auto), "auto" ],
-      aspect_ratio:  [ Or(Number, Auto, Null), null ],
-      sizing_mode:   [ Or(SizingMode, Null), null ],
-      visible:       [ Boolean, true ],
-      disabled:      [ Boolean, false ],
-      align:         [ Or(Align, Tuple(Align, Align)), "start" ],
-      background:    [ Or(TColor, Null), null ],
-      css_classes:   [ Array(String), [] ],
+    this.define<LayoutDOM.Props>((types) => {
+      const {Boolean, Number, String, Null, Auto, Color, Array, Tuple, Or} = types
+      const Number2 = Tuple(Number, Number)
+      const Number4 = Tuple(Number, Number, Number, Number)
+      return {
+        width:         [ Or(Number, Null), null ],
+        height:        [ Or(Number, Null), null ],
+        min_width:     [ Or(Number, Null), null ],
+        min_height:    [ Or(Number, Null), null ],
+        max_width:     [ Or(Number, Null), null ],
+        max_height:    [ Or(Number, Null), null ],
+        margin:        [ Or(Number, Number2, Number4), [0, 0, 0, 0] ],
+        width_policy:  [ Or(SizingPolicy, Auto), "auto" ],
+        height_policy: [ Or(SizingPolicy, Auto), "auto" ],
+        aspect_ratio:  [ Or(Number, Auto, Null), null ],
+        sizing_mode:   [ Or(SizingMode, Null), null ],
+        visible:       [ Boolean, true ],
+        disabled:      [ Boolean, false ],
+        align:         [ Or(Align, Tuple(Align, Align)), "start" ],
+        background:    [ Or(Color, Null), null ],
+        css_classes:   [ Array(String), [] ],
+      }
     })
   }
 }

--- a/bokehjs/src/lib/models/layouts/layout_dom.ts
+++ b/bokehjs/src/lib/models/layouts/layout_dom.ts
@@ -5,6 +5,7 @@ import {empty, position, classes, extents, undisplayed} from "core/dom"
 import {logger} from "core/logging"
 import {isNumber, isArray} from "core/util/types"
 import * as p from "core/properties"
+import {Boolean, Number, String, Null, Array, Tuple, Or, Auto, Color as TColor} from "core/kinds"
 
 import {build_views} from "core/build_views"
 import {DOMView} from "core/dom_view"
@@ -397,22 +398,24 @@ export abstract class LayoutDOM extends Model {
 
   static init_LayoutDOM(): void {
     this.define<LayoutDOM.Props>({
-      width:         [ p.Number,     null         ],
-      height:        [ p.Number,     null         ],
-      min_width:     [ p.Number,     null         ],
-      min_height:    [ p.Number,     null         ],
-      max_width:     [ p.Number,     null         ],
-      max_height:    [ p.Number,     null         ],
-      margin:        [ p.Any,        [0, 0, 0, 0] ],
-      width_policy:  [ p.Any,        "auto"       ],
-      height_policy: [ p.Any,        "auto"       ],
-      aspect_ratio:  [ p.Any,        null         ],
-      sizing_mode:   [ p.SizingMode, null         ],
-      visible:       [ p.Boolean,    true         ],
-      disabled:      [ p.Boolean,    false        ],
-      align:         [ p.Any,        "start"      ],
-      background:    [ p.Color,      null         ],
-      css_classes:   [ p.Array,      []           ],
+      width:         [ Or(Number, Null), null ],
+      height:        [ Or(Number, Null), null ],
+      min_width:     [ Or(Number, Null), null ],
+      min_height:    [ Or(Number, Null), null ],
+      max_width:     [ Or(Number, Null), null ],
+      max_height:    [ Or(Number, Null), null ],
+      margin:        [ Or(Number,
+                          Tuple(Number, Number),
+                          Tuple(Number, Number, Number, Number)), [0, 0, 0, 0] ],
+      width_policy:  [ Or(SizingPolicy, Auto), "auto" ],
+      height_policy: [ Or(SizingPolicy, Auto), "auto" ],
+      aspect_ratio:  [ Or(Number, Auto, Null), null ],
+      sizing_mode:   [ Or(SizingMode, Null), null ],
+      visible:       [ Boolean, true ],
+      disabled:      [ Boolean, false ],
+      align:         [ Or(Align, Tuple(Align, Align)), "start" ],
+      background:    [ Or(TColor, Null), null ],
+      css_classes:   [ Array(String), [] ],
     })
   }
 }

--- a/bokehjs/src/lib/models/widgets/abstract_slider.ts
+++ b/bokehjs/src/lib/models/widgets/abstract_slider.ts
@@ -284,18 +284,20 @@ export abstract class AbstractSlider extends Control {
   }
 
   static init_AbstractSlider(): void {
-    this.define<AbstractSlider.Props>({
-      title:             [ p.String,               ""           ],
-      show_value:        [ p.Boolean,              true         ],
-      start:             [ p.Any                                ],
-      end:               [ p.Any                                ],
-      value:             [ p.Any                                ],
-      value_throttled:   [ p.Any                                ],
-      step:              [ p.Number,               1            ],
-      format:            [ p.Any                                ],
-      direction:         [ p.Any,                  "ltr"        ],
-      tooltips:          [ p.Boolean,              true         ],
-      bar_color:         [ p.Color,                "#e6e6e6"    ],
+    this.define<AbstractSlider.Props>(({Any, Boolean, Number, String, Color, Or, Enum, Ref}) => {
+      return {
+        title:           [ String, "" ],
+        show_value:      [ Boolean, true ],
+        start:           [ Any ],
+        end:             [ Any ],
+        value:           [ Any ],
+        value_throttled: [ Any ],
+        step:            [ Number, 1 ],
+        format:          [ Or(String, Ref(TickFormatter)) ],
+        direction:       [ Enum("ltr", "rtl"), "ltr" ],
+        tooltips:        [ Boolean, true ],
+        bar_color:       [ Color, "#e6e6e6" ],
+      }
     })
   }
 

--- a/bokehjs/test/integration/glyphs/markers.ts
+++ b/bokehjs/test/integration/glyphs/markers.ts
@@ -12,20 +12,22 @@ describe("Marker glyph", () => {
 
   for (const marker_type of MarkerType) {
     it(`should support '${marker_type}' marker type`, async () => {
-      const plots = OutputBackend.map((output_backend) => {
-        const p = fig([150, 150], {
-          output_backend,
-          title: `${marker_type} - ${output_backend}`,
-          x_axis_type: null,
-          y_axis_type: null,
-        })
-        p.scatter({
-          x, y, marker: marker_type, size: 14,
-          line_color: "navy", fill_color: "orange", alpha: 0.5,
-        })
-        return p
-      })
-      await display(row(plots), [3*150 + 50, 150 + 50])
+      function* plots() {
+        for (const output_backend of OutputBackend) {
+          const p = fig([150, 150], {
+            output_backend,
+            title: `${marker_type} - ${output_backend}`,
+            x_axis_type: null,
+            y_axis_type: null,
+          })
+          p.scatter({
+            x, y, marker: marker_type, size: 14,
+            line_color: "navy", fill_color: "orange", alpha: 0.5,
+          })
+          yield p
+        }
+      }
+      await display(row([...plots()]), [3*150 + 50, 150 + 50])
     })
   }
 })

--- a/bokehjs/test/unit/core/enums.ts
+++ b/bokehjs/test/unit/core/enums.ts
@@ -5,7 +5,7 @@ import * as enums from "@bokehjs/core/enums"
 describe("enums module", () => {
 
   it("should have Anchor", () => {
-    expect(enums.Anchor).to.be.equal([
+    expect([...enums.Anchor]).to.be.equal([
       "top_left",    "top_center",    "top_right",
       "center_left", "center",        "center_right",
       "bottom_left", "bottom_center", "bottom_right",
@@ -13,39 +13,39 @@ describe("enums module", () => {
   })
 
   it("should have AngleUnits", () => {
-    expect(enums.AngleUnits).to.be.equal(["deg", "rad"])
+    expect([...enums.AngleUnits]).to.be.equal(["deg", "rad"])
   })
 
   it("should have BoxOrigin", () => {
-    expect(enums.BoxOrigin).to.be.equal(["corner", "center"])
+    expect([...enums.BoxOrigin]).to.be.equal(["corner", "center"])
   })
 
   it("should have ButtonType", () => {
-    expect(enums.ButtonType).to.be.equal(["default", "primary", "success", "warning", "danger"])
+    expect([...enums.ButtonType]).to.be.equal(["default", "primary", "success", "warning", "danger"])
   })
 
   it("should have Dimension", () => {
-    expect(enums.Dimension).to.be.equal(["width", "height"])
+    expect([...enums.Dimension]).to.be.equal(["width", "height"])
   })
 
   it("should have Dimensions", () => {
-    expect(enums.Dimensions).to.be.equal(["width", "height", "both"])
+    expect([...enums.Dimensions]).to.be.equal(["width", "height", "both"])
   })
 
   it("should have Direction", () => {
-    expect(enums.Direction).to.be.equal(["clock", "anticlock"])
+    expect([...enums.Direction]).to.be.equal(["clock", "anticlock"])
   })
 
   it("should have Distribution", () => {
-    expect(enums.Distribution).to.be.equal(["uniform", "normal"])
+    expect([...enums.Distribution]).to.be.equal(["uniform", "normal"])
   })
 
   it("should have FontStyle", () => {
-    expect(enums.FontStyle).to.be.equal(["normal", "italic", "bold", "bold italic"])
+    expect([...enums.FontStyle]).to.be.equal(["normal", "italic", "bold", "bold italic"])
   })
 
   it("should have HatchPatternType", () => {
-    expect(enums.HatchPatternType).to.be.equal([
+    expect([...enums.HatchPatternType]).to.be.equal([
       'blank', 'dot', 'ring', 'horizontal_line', 'vertical_line', 'cross', 'horizontal_dash',
       'vertical_dash', 'spiral', 'right_diagonal_line', 'left_diagonal_line', 'diagonal_cross',
       'right_diagonal_dash', 'left_diagonal_dash', 'horizontal_wave', 'vertical_wave', 'criss_cross',
@@ -54,27 +54,27 @@ describe("enums module", () => {
   })
 
   it("should have HTTPMethod", () => {
-    expect(enums.HTTPMethod).to.be.equal(["POST", "GET"])
+    expect([...enums.HTTPMethod]).to.be.equal(["POST", "GET"])
   })
 
   it("should have HexTileOrientation", () => {
-    expect(enums.HexTileOrientation).to.be.equal(["pointytop", "flattop"])
+    expect([...enums.HexTileOrientation]).to.be.equal(["pointytop", "flattop"])
   })
 
   it("should have HoverMode", () => {
-    expect(enums.HoverMode).to.be.equal(["mouse", "hline", "vline"])
+    expect([...enums.HoverMode]).to.be.equal(["mouse", "hline", "vline"])
   })
 
   it("should have LatLon", () => {
-    expect(enums.LatLon).to.be.equal(["lat", "lon"])
+    expect([...enums.LatLon]).to.be.equal(["lat", "lon"])
   })
 
   it("should have LegendClickPolicy", () => {
-    expect(enums.LegendClickPolicy).to.be.equal(["none", "hide", "mute"])
+    expect([...enums.LegendClickPolicy]).to.be.equal(["none", "hide", "mute"])
   })
 
   it("should have LegendLocation", () => {
-    expect(enums.LegendLocation).to.be.equal([
+    expect([...enums.LegendLocation]).to.be.equal([
       "top_left",    "top_center",    "top_right",
       "center_left", "center",        "center_right",
       "bottom_left", "bottom_center", "bottom_right",
@@ -82,27 +82,27 @@ describe("enums module", () => {
   })
 
   it("should have LineCap", () => {
-    expect(enums.LineCap).to.be.equal(["butt", "round", "square"])
+    expect([...enums.LineCap]).to.be.equal(["butt", "round", "square"])
   })
 
   it("should have LineJoin", () => {
-    expect(enums.LineJoin).to.be.equal(["miter", "round", "bevel"])
+    expect([...enums.LineJoin]).to.be.equal(["miter", "round", "bevel"])
   })
 
   it("should have LinePolicy", () => {
-    expect(enums.LinePolicy).to.be.equal(["prev", "next", "nearest", "interp", "none"])
+    expect([...enums.LinePolicy]).to.be.equal(["prev", "next", "nearest", "interp", "none"])
   })
 
   it("should have Location", () => {
-    expect(enums.Location).to.be.equal(["above", "below", "left", "right"])
+    expect([...enums.Location]).to.be.equal(["above", "below", "left", "right"])
   })
 
   it("should have Logo", () => {
-    expect(enums.Logo).to.be.equal(["normal", "grey"])
+    expect([...enums.Logo]).to.be.equal(["normal", "grey"])
   })
 
   it("should have MarkerType", () => {
-    expect(enums.MarkerType).to.be.equal([
+    expect([...enums.MarkerType]).to.be.equal([
       "asterisk", "circle", "circle_cross", "circle_dot", "circle_x", "circle_y",
       "cross", "dash", "diamond", "diamond_cross", "diamond_dot", "dot", "hex",
       "hex_dot", "inverted_triangle", "plus", "square", "square_cross", "square_dot",
@@ -111,98 +111,98 @@ describe("enums module", () => {
   })
 
   it("should have Orientation", () => {
-    expect(enums.Orientation).to.be.equal(["vertical", "horizontal"])
+    expect([...enums.Orientation]).to.be.equal(["vertical", "horizontal"])
   })
 
   it("should have OutputBackend", () => {
-    expect(enums.OutputBackend).to.be.equal(["canvas", "svg", "webgl"])
+    expect([...enums.OutputBackend]).to.be.equal(["canvas", "svg", "webgl"])
   })
 
   it("should have PaddingUnits", () => {
-    expect(enums.PaddingUnits).to.be.equal(["percent", "absolute"])
+    expect([...enums.PaddingUnits]).to.be.equal(["percent", "absolute"])
   })
 
   it("should have Place", () => {
-    expect(enums.Place).to.be.equal(["above", "below", "left", "right", "center"])
+    expect([...enums.Place]).to.be.equal(["above", "below", "left", "right", "center"])
   })
 
   it("should have PointPolicy", () => {
-    expect(enums.PointPolicy).to.be.equal(["snap_to_data", "follow_mouse", "none"])
+    expect([...enums.PointPolicy]).to.be.equal(["snap_to_data", "follow_mouse", "none"])
   })
 
   it("should have RadiusDimension", () => {
-    expect(enums.RadiusDimension).to.be.equal(["x", "y", "max", "min"])
+    expect([...enums.RadiusDimension]).to.be.equal(["x", "y", "max", "min"])
   })
 
   it("should have RenderLevel", () => {
-    expect(enums.RenderLevel).to.be.equal(["image", "underlay", "glyph", "guide", "annotation", "overlay"])
+    expect([...enums.RenderLevel]).to.be.equal(["image", "underlay", "glyph", "guide", "annotation", "overlay"])
   })
 
   it("should have RenderMode", () => {
-    expect(enums.RenderMode).to.be.equal(["canvas", "css"])
+    expect([...enums.RenderMode]).to.be.equal(["canvas", "css"])
   })
 
   it("should have ResetPolicy", () => {
-    expect(enums.ResetPolicy).to.be.equal(["standard", "event_only"])
+    expect([...enums.ResetPolicy]).to.be.equal(["standard", "event_only"])
   })
 
   it("should have RoundingFunction", () => {
-    expect(enums.RoundingFunction).to.be.equal(["round", "nearest", "floor", "rounddown", "ceil", "roundup"])
+    expect([...enums.RoundingFunction]).to.be.equal(["round", "nearest", "floor", "rounddown", "ceil", "roundup"])
   })
 
   it("should have Side", () => {
-    expect(enums.Side).to.be.equal(["above", "below", "left", "right"])
+    expect([...enums.Side]).to.be.equal(["above", "below", "left", "right"])
   })
 
   it("should have SizingMode", () => {
-    expect(enums.SizingMode).to.be.equal(["stretch_width", "stretch_height", "stretch_both", "scale_width", "scale_height", "scale_both", "fixed"])
+    expect([...enums.SizingMode]).to.be.equal(["stretch_width", "stretch_height", "stretch_both", "scale_width", "scale_height", "scale_both", "fixed"])
   })
 
   it("should have Sort", () => {
-    expect(enums.Sort).to.be.equal(["ascending", "descending"])
+    expect([...enums.Sort]).to.be.equal(["ascending", "descending"])
   })
 
   it("should have SpatialUnits", () => {
-    expect(enums.SpatialUnits).to.be.equal(["screen", "data"])
+    expect([...enums.SpatialUnits]).to.be.equal(["screen", "data"])
   })
 
   it("should have StartEnd", () => {
-    expect(enums.StartEnd).to.be.equal(["start", "end"])
+    expect([...enums.StartEnd]).to.be.equal(["start", "end"])
   })
 
   it("should have StepMode", () => {
-    expect(enums.StepMode).to.be.equal(["after", "before", "center"])
+    expect([...enums.StepMode]).to.be.equal(["after", "before", "center"])
   })
 
   it("should have TapBehavior", () => {
-    expect(enums.TapBehavior).to.be.equal(["select", "inspect"])
+    expect([...enums.TapBehavior]).to.be.equal(["select", "inspect"])
   })
 
   it("should have TextAlign", () => {
-    expect(enums.TextAlign).to.be.equal(["left", "right", "center"])
+    expect([...enums.TextAlign]).to.be.equal(["left", "right", "center"])
   })
 
   it("should have TextBaseline", () => {
-    expect(enums.TextBaseline).to.be.equal(["top", "middle", "bottom", "alphabetic", "hanging", "ideographic"])
+    expect([...enums.TextBaseline]).to.be.equal(["top", "middle", "bottom", "alphabetic", "hanging", "ideographic"])
   })
 
   it("should have TextureRepetition", () => {
-    expect(enums.TextureRepetition).to.be.equal(["repeat", "repeat_x", "repeat_y", "no_repeat"])
+    expect([...enums.TextureRepetition]).to.be.equal(["repeat", "repeat_x", "repeat_y", "no_repeat"])
   })
 
   it("should have TickLabelOrientation", () => {
-    expect(enums.TickLabelOrientation).to.be.equal(["vertical", "horizontal", "parallel", "normal"])
+    expect([...enums.TickLabelOrientation]).to.be.equal(["vertical", "horizontal", "parallel", "normal"])
   })
 
   it("should have TooltipAttachment", () => {
-    expect(enums.TooltipAttachment).to.be.equal(["horizontal", "vertical", "left", "right", "above", "below"])
+    expect([...enums.TooltipAttachment]).to.be.equal(["horizontal", "vertical", "left", "right", "above", "below"])
   })
 
   it("should have UpdateMode", () => {
-    expect(enums.UpdateMode).to.be.equal(["replace", "append"])
+    expect([...enums.UpdateMode]).to.be.equal(["replace", "append"])
   })
 
   it("should have VerticalAlign", () => {
-    expect(enums.VerticalAlign).to.be.equal(["top", "middle", "bottom"])
+    expect([...enums.VerticalAlign]).to.be.equal(["top", "middle", "bottom"])
   })
 })


### PR DESCRIPTION
Currently bokehjs' properties consist of property declarations (`Props` type/interface) and property definitions (`HasProps.define()`), which implement properties at run time. The former are fairly well typed (up to `nul` handling), as they use TypeScript's type system. However, the later are not, with a lot of `p.Any` and/or poorly typed definitions or mismatches with `Props`. This PR attempts to fix this, filling in the gaps which will allow more robust validation, etc. Given the design, this may also allow to remove property type declarations, because with this approach, such declarations can be inferred from definitions.