### PR TITLE
Allow to store buffers separately from JSON

### DIFF
--- a/bokeh/core/_templates/script_tag.html
+++ b/bokeh/core/_templates/script_tag.html
@@ -1,10 +1,9 @@
 {#
 Renders a ``<script>`` tag for raw JavaScript code.
 
-:param js_code: raw JavaScript code to put in the tag.
-:type js_code: str
-
+:param content: raw JavaScript code to put in the tag.
+:type content: str
 #}
-<script type="{{ type }}"{%if id %} id="{{ id }}"{% endif %}>
-{{ js_code }}
-</script>
+<script type="{{ type }}"{% for key, val in attrs.items() %} {{ key }}="{{ val }}"{% endfor %}>
+{{ content }}
+ </script>

--- a/bokeh/embed/wrappers.py
+++ b/bokeh/embed/wrappers.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import Optional
+from typing import Dict
 
 # Bokeh imports
 from ..core.templates import SCRIPT_TAG
@@ -55,11 +55,11 @@ def wrap_in_safely(code: str) -> str:
     '''
     return _SAFELY % dict(code=indent(code, 2))
 
-def wrap_in_script_tag(js: str, type: str="text/javascript", id: Optional[str]=None) -> str:
+def wrap_in_script_tag(content: str, *, type: str="text/javascript", **attrs: Dict[str, str]) -> str:
     '''
 
     '''
-    return SCRIPT_TAG.render(js_code=indent(js, 2), type=type, id=id)
+    return SCRIPT_TAG.render(content=indent(content, 2), type=type, attrs=attrs)
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/bokehjs/src/lib/client/connection.ts
+++ b/bokehjs/src/lib/client/connection.ts
@@ -149,7 +149,7 @@ export class ClientConnection {
           logger.debug("Got new document after connection was already closed")
           reject(new Error("The connection has been closed"))
         } else {
-          const document = Document.from_json(doc_json)
+          const document = await Document.from_json(doc_json)
 
           // Constructing models changes some of their attributes, we deal with that
           // here. This happens when models set attributes during construction

--- a/bokehjs/src/lib/embed/index.ts
+++ b/bokehjs/src/lib/embed/index.ts
@@ -53,7 +53,7 @@ async function _embed_items(docs_json: string | DocsJson, render_items: RenderIt
   const docs: {[key: string]: Document} = {}
   for (const docid in docs_json) {
     const doc_json = docs_json[docid]
-    docs[docid] = Document.from_json(doc_json)
+    docs[docid] = await Document.from_json(doc_json)
   }
 
   const views: View[][] = []

--- a/bokehjs/src/lib/embed/notebook.ts
+++ b/bokehjs/src/lib/embed/notebook.ts
@@ -82,11 +82,11 @@ function _init_comms(target: string, doc: Document): void {
   }
 }
 
-export function embed_items_notebook(docs_json: DocsJson, render_items: RenderItem[]): void {
+export async function embed_items_notebook(docs_json: DocsJson, render_items: RenderItem[]): Promise<void> {
   if (size(docs_json) != 1)
     throw new Error("embed_items_notebook expects exactly one document in docs_json")
 
-  const document = Document.from_json(values(docs_json)[0])
+  const document = await Document.from_json(values(docs_json)[0])
 
   for (const item of render_items) {
     if (item.notebook_comms_target != null)


### PR DESCRIPTION
This allows to store buffers separately from JSON representation when using standalone HTML files, improving load performance, because buffers don't have to be JSON-parsed and reduces output size, because of base64 encoding. Buffer data is stored as data-urls encoded in `<script>` tags, e.g.:
```html
<script type="application/octet-stream" data-bokeh-buffer="ID">
data:application/octet-stream;base64,DATA
</script>
```
This is early work in progress. This amends the protocol, so it's a breaking change, however, it may be possible to allow this in 2.x branch behind a flag.