### PR TITLE
Fixes for sphinx 3.1.1

### DIFF
--- a/bokeh/plotting/gmap.py
+++ b/bokeh/plotting/gmap.py
@@ -58,7 +58,7 @@ class GMap(GMapPlot):
 
             https://developers.google.com/maps/documentation/javascript/get-api-key
 
-        map_options: (GMapOptions)
+        map_options: (:class:`~bokeh.models.map_plots.GMapOptions`)
             Configuration specific to a Google Map
 
     In addition to all the Bokeh model property attributes documented below,
@@ -66,7 +66,7 @@ class GMap(GMapPlot):
     help simplify configuration:
 
     .. bokeh-options:: GMapFigureOptions
-        :module: bokeh.plotting.figure
+        :module: bokeh.plotting.gmap
 
     '''
 
@@ -218,7 +218,7 @@ def gmap(google_api_key, map_options, **kwargs):
 
             The Google API key will be stored in the Bokeh Document JSON.
 
-        map_options: (GMapOptions)
+        map_options: (:class:`~bokeh.models.map_plots.GMapOptions`)
             Configuration specific to a Google Map
 
     In addition to the standard :class:`~bokeh.plotting.gmap.GMap` keyword

--- a/sphinx/source/docs/reference.rst
+++ b/sphinx/source/docs/reference.rst
@@ -26,10 +26,10 @@ be especially useful.
 
 :ref:`bokeh.plotting`
     The ``bokeh.plotting`` API is centered around the
-    :func:`~bokeh.plotting.figure.figure` command,
+    :func:`~bokeh.plotting.figure` command,
     and the associated glyph functions such as
-    :func:`~bokeh.plotting.figure.Figure.circle`,
-    :func:`~bokeh.plotting.figure.Figure.wedge`, etc.
+    :func:`~bokeh.plotting.Figure.circle`,
+    :func:`~bokeh.plotting.Figure.wedge`, etc.
     This section has detailed information on these elements.
 
 :ref:`bokeh.layouts`

--- a/sphinx/source/docs/reference/plotting.rst
+++ b/sphinx/source/docs/reference/plotting.rst
@@ -3,15 +3,15 @@
 bokeh.plotting
 ==============
 
-.. autofunction:: bokeh.plotting.figure.figure
+.. autofunction:: bokeh.plotting.figure
 
-.. autoclass:: bokeh.plotting.figure.Figure
+.. autoclass:: bokeh.plotting.Figure
     :members:
     :undoc-members:
 
-.. autofunction:: bokeh.plotting.gmap.gmap
+.. autofunction:: bokeh.plotting.gmap
 
-.. autoclass:: bokeh.plotting.gmap.GMapPlot
+.. autoclass:: bokeh.plotting.GMap
     :members:
     :undoc-members:
 

--- a/sphinx/source/docs/releases/0.12.7.rst
+++ b/sphinx/source/docs/releases/0.12.7.rst
@@ -16,8 +16,8 @@ important features and fixes several bugs. Some of the highlights include:
 * New module :ref:`bokeh.transform` with helper functions for simplifying
   ``DataSpec`` expressions, including  :func:`~bokeh.transform.jitter`,
   :func:`~bokeh.transform.dodge`, :func:`~bokeh.transform.factor_cmap`, etc.
-* Added :func:`~bokeh.plotting.figure.Figure.hbar_stack` and
-  :func:`~bokeh.plotting.figure.Figure.vbar_stack` to greatly simplify
+* Added :func:`~bokeh.plotting.Figure.hbar_stack` and
+  :func:`~bokeh.plotting.Figure.vbar_stack` to greatly simplify
   creation of stacked bar charts.
 * Improvements for using Bokeh with Categorical data:
 

--- a/sphinx/source/docs/user_guide/annotations.rst
+++ b/sphinx/source/docs/user_guide/annotations.rst
@@ -310,7 +310,7 @@ single point would be one common use for the Whisker annotation.
 
 .. |Plot| replace:: :class:`~bokeh.models.plots.Plot`
 
-.. |Figure| replace:: :class:`~bokeh.plotting.figure.Figure`
+.. |Figure| replace:: :class:`~bokeh.plotting.Figure`
 
 .. |figure| replace:: :func:`~bokeh.plotting.figure`
 

--- a/sphinx/source/docs/user_guide/categorical.rst
+++ b/sphinx/source/docs/user_guide/categorical.rst
@@ -19,8 +19,8 @@ Basic
 ~~~~~
 
 Bokeh make it simple to create basic bar charts using the
-:func:`~bokeh.plotting.figure.Figure.hbar` and
-:func:`~bokeh.plotting.figure.Figure.vbar` glyphs methods. In the example
+:func:`~bokeh.plotting.Figure.hbar` and
+:func:`~bokeh.plotting.Figure.vbar` glyphs methods. In the example
 below, we have the following sequence of simple 1-level factors:
 
 .. code-block:: python
@@ -28,7 +28,7 @@ below, we have the following sequence of simple 1-level factors:
     fruits = ['Apples', 'Pears', 'Nectarines', 'Plums', 'Grapes', 'Strawberries']
 
 To inform Bokeh that the x-axis is categorical, we pass this list of factors
-as the ``x_range`` argument to :func:`~bokeh.plotting.figure.figure`:
+as the ``x_range`` argument to :func:`~bokeh.plotting.figure`:
 
 .. code-block:: python
 
@@ -118,8 +118,8 @@ Stacked
 
 Another common operation or bar charts is to stack bars on top of one
 another. Bokeh makes this easy to do with the specialized
-:func:`~bokeh.plotting.figure.Figure.hbar_stack` and
-:func:`~bokeh.plotting.figure.Figure.vbar_stack` functions. The example
+:func:`~bokeh.plotting.Figure.hbar_stack` and
+:func:`~bokeh.plotting.Figure.vbar_stack` functions. The example
 below shows the fruits data from above, but with the bars for each
 fruit type stacked instead of grouped:
 

--- a/sphinx/source/docs/user_guide/data.rst
+++ b/sphinx/source/docs/user_guide/data.rst
@@ -420,5 +420,5 @@ For more information about how to set up the data for these types of plots, see
 .. |BooleanFilter| replace:: :class:`~bokeh.models.filters.BooleanFilter`
 .. |GroupFilter| replace:: :class:`~bokeh.models.filters.GroupFilter`
 .. |CustomJSFilter| replace:: :class:`~bokeh.models.filters.CustomJSFilter`
-.. |Figure| replace:: :class:`~bokeh.plotting.figure.Figure`
+.. |Figure| replace:: :class:`~bokeh.plotting.Figure`
 .. |DataTable| replace:: :class:`~bokeh.models.widgets.tables.DataTable`

--- a/sphinx/source/docs/user_guide/geo.rst
+++ b/sphinx/source/docs/user_guide/geo.rst
@@ -30,7 +30,7 @@ Mercator coordinates.
 Google Maps
 -----------
 
-Bokeh can also plot glyphs over a Google Map using the :func:`~bokeh.plotting.gmap.gmap`
+Bokeh can also plot glyphs over a Google Map using the :func:`~bokeh.plotting.gmap`
 function. You must pass this function a `Google API Key`_ in order for it to work, as
 well as any :class:`~bokeh.models.map_plots.GMapOptions` to configure the Google Map
 underlay. The Google API Key will be stored in the Bokeh Document JSON.

--- a/sphinx/source/docs/user_guide/plotting.rst
+++ b/sphinx/source/docs/user_guide/plotting.rst
@@ -195,7 +195,7 @@ Hex Tiles
 ~~~~~~~~~
 
 Bokeh can plot hexagonal tiles, which are often used for showing binned
-aggregations. The :func:`~bokeh.plotting.figure.Figure.hex_tile` method
+aggregations. The :func:`~bokeh.plotting.Figure.hex_tile` method
 takes a `size` parameter to define the size of the hex grid, and
 `axial coordinates`_ to specify which tiles are present.
 
@@ -208,7 +208,7 @@ A more realistic example below computes counts per bin using the
 .. bokeh-plot:: docs/user_guide/examples/plotting_hex_tile_binning.py
     :source-position: above
 
-The above code can be made even simpler by calling the :func:`~bokeh.plotting.figure.Figure.hexbin`
+The above code can be made even simpler by calling the :func:`~bokeh.plotting.Figure.hexbin`
 method of ``Figure``.
 
 .. _userguide_plotting_directed_areas:
@@ -604,64 +604,64 @@ below:
 .. _axial coordinates: https://www.redblobgames.com/grids/hexagons/#coordinates-axial
 
 .. |bokeh.plotting| replace:: :ref:`bokeh.plotting <bokeh.plotting>`
-.. |Figure| replace:: :class:`~bokeh.plotting.figure.Figure`
+.. |Figure| replace:: :class:`~bokeh.plotting.Figure`
 .. |figure| replace:: :func:`~bokeh.plotting.figure`
 .. |Plot| replace:: :class:`~bokeh.models.plots.Plot`
 
-.. |annular_wedge|     replace:: :func:`~bokeh.plotting.figure.Figure.annular_wedge`
-.. |annulus|           replace:: :func:`~bokeh.plotting.figure.Figure.annulus`
-.. |arc|               replace:: :func:`~bokeh.plotting.figure.Figure.arc`
-.. |asterisk|          replace:: :func:`~bokeh.plotting.figure.Figure.asterisk`
-.. |bezier|            replace:: :func:`~bokeh.plotting.figure.Figure.bezier`
-.. |circle|            replace:: :func:`~bokeh.plotting.figure.Figure.circle`
-.. |circle_cross|      replace:: :func:`~bokeh.plotting.figure.Figure.circle_cross`
-.. |circle_dot|        replace:: :func:`~bokeh.plotting.figure.Figure.circle_dot`
-.. |circle_x|          replace:: :func:`~bokeh.plotting.figure.Figure.circle_x`
-.. |circle_y|          replace:: :func:`~bokeh.plotting.figure.Figure.circle_y`
-.. |cross|             replace:: :func:`~bokeh.plotting.figure.Figure.cross`
-.. |dash|              replace:: :func:`~bokeh.plotting.figure.Figure.dash`
-.. |diamond|           replace:: :func:`~bokeh.plotting.figure.Figure.diamond`
-.. |diamond_cross|     replace:: :func:`~bokeh.plotting.figure.Figure.diamond_cross`
-.. |diamond_dot|       replace:: :func:`~bokeh.plotting.figure.Figure.diamond_dot`
-.. |dot|               replace:: :func:`~bokeh.plotting.figure.Figure.dot`
-.. |ellipse|           replace:: :func:`~bokeh.plotting.figure.Figure.ellipse`
-.. |harea|             replace:: :func:`~bokeh.plotting.figure.Figure.harea`
-.. |harea_stack|       replace:: :func:`~bokeh.plotting.figure.Figure.harea_stack`
-.. |hbar|              replace:: :func:`~bokeh.plotting.figure.Figure.hbar`
-.. |hbar_stack|        replace:: :func:`~bokeh.plotting.figure.Figure.hbar_stack`
-.. |hex|               replace:: :func:`~bokeh.plotting.figure.Figure.hex`
-.. |hex_dot|           replace:: :func:`~bokeh.plotting.figure.Figure.hex_dot`
-.. |hline_stack|       replace:: :func:`~bokeh.plotting.figure.Figure.hline_stack`
-.. |inverted_triangle| replace:: :func:`~bokeh.plotting.figure.Figure.inverted_triangle`
-.. |image|             replace:: :func:`~bokeh.plotting.figure.Figure.image`
-.. |image_rgba|        replace:: :func:`~bokeh.plotting.figure.Figure.image_rgba`
-.. |image_url|         replace:: :func:`~bokeh.plotting.figure.Figure.image_url`
-.. |line|              replace:: :func:`~bokeh.plotting.figure.Figure.line`
-.. |multi_line|        replace:: :func:`~bokeh.plotting.figure.Figure.multi_line`
-.. |multi_polygons|    replace:: :func:`~bokeh.plotting.figure.Figure.multi_polygons`
-.. |oval|              replace:: :func:`~bokeh.plotting.figure.Figure.oval`
-.. |patch|             replace:: :func:`~bokeh.plotting.figure.Figure.patch`
-.. |patches|           replace:: :func:`~bokeh.plotting.figure.Figure.patches`
-.. |plus|              replace:: :func:`~bokeh.plotting.figure.Figure.plus`
-.. |quad|              replace:: :func:`~bokeh.plotting.figure.Figure.quad`
-.. |quadratic|         replace:: :func:`~bokeh.plotting.figure.Figure.quadratic`
-.. |ray|               replace:: :func:`~bokeh.plotting.figure.Figure.ray`
-.. |rect|              replace:: :func:`~bokeh.plotting.figure.Figure.rect`
-.. |segment|           replace:: :func:`~bokeh.plotting.figure.Figure.segment`
-.. |step|              replace:: :func:`~bokeh.plotting.figure.Figure.step`
-.. |square|            replace:: :func:`~bokeh.plotting.figure.Figure.square`
-.. |square_cross|      replace:: :func:`~bokeh.plotting.figure.Figure.square_cross`
-.. |square_dot|        replace:: :func:`~bokeh.plotting.figure.Figure.square_dot`
-.. |square_pin|        replace:: :func:`~bokeh.plotting.figure.Figure.square_pin`
-.. |square_x|          replace:: :func:`~bokeh.plotting.figure.Figure.square_x`
-.. |triangle|          replace:: :func:`~bokeh.plotting.figure.Figure.triangle`
-.. |triangle_dot|      replace:: :func:`~bokeh.plotting.figure.Figure.triangle_dot`
-.. |triangle_pin|      replace:: :func:`~bokeh.plotting.figure.Figure.triangle_pin`
-.. |varea|             replace:: :func:`~bokeh.plotting.figure.Figure.varea`
-.. |varea_stack|       replace:: :func:`~bokeh.plotting.figure.Figure.varea_stack`
-.. |vbar|              replace:: :func:`~bokeh.plotting.figure.Figure.vbar`
-.. |vbar_stack|        replace:: :func:`~bokeh.plotting.figure.Figure.vbar_stack`
-.. |vline_stack|       replace:: :func:`~bokeh.plotting.figure.Figure.vline_stack`
-.. |wedge|             replace:: :func:`~bokeh.plotting.figure.Figure.wedge`
-.. |x|                 replace:: :func:`~bokeh.plotting.figure.Figure.x`
-.. |y|                 replace:: :func:`~bokeh.plotting.figure.Figure.y`
+.. |annular_wedge|     replace:: :func:`~bokeh.plotting.Figure.annular_wedge`
+.. |annulus|           replace:: :func:`~bokeh.plotting.Figure.annulus`
+.. |arc|               replace:: :func:`~bokeh.plotting.Figure.arc`
+.. |asterisk|          replace:: :func:`~bokeh.plotting.Figure.asterisk`
+.. |bezier|            replace:: :func:`~bokeh.plotting.Figure.bezier`
+.. |circle|            replace:: :func:`~bokeh.plotting.Figure.circle`
+.. |circle_cross|      replace:: :func:`~bokeh.plotting.Figure.circle_cross`
+.. |circle_dot|        replace:: :func:`~bokeh.plotting.Figure.circle_dot`
+.. |circle_x|          replace:: :func:`~bokeh.plotting.Figure.circle_x`
+.. |circle_y|          replace:: :func:`~bokeh.plotting.Figure.circle_y`
+.. |cross|             replace:: :func:`~bokeh.plotting.Figure.cross`
+.. |dash|              replace:: :func:`~bokeh.plotting.Figure.dash`
+.. |diamond|           replace:: :func:`~bokeh.plotting.Figure.diamond`
+.. |diamond_cross|     replace:: :func:`~bokeh.plotting.Figure.diamond_cross`
+.. |diamond_dot|       replace:: :func:`~bokeh.plotting.Figure.diamond_dot`
+.. |dot|               replace:: :func:`~bokeh.plotting.Figure.dot`
+.. |ellipse|           replace:: :func:`~bokeh.plotting.Figure.ellipse`
+.. |harea|             replace:: :func:`~bokeh.plotting.Figure.harea`
+.. |harea_stack|       replace:: :func:`~bokeh.plotting.Figure.harea_stack`
+.. |hbar|              replace:: :func:`~bokeh.plotting.Figure.hbar`
+.. |hbar_stack|        replace:: :func:`~bokeh.plotting.Figure.hbar_stack`
+.. |hex|               replace:: :func:`~bokeh.plotting.Figure.hex`
+.. |hex_dot|           replace:: :func:`~bokeh.plotting.Figure.hex_dot`
+.. |hline_stack|       replace:: :func:`~bokeh.plotting.Figure.hline_stack`
+.. |inverted_triangle| replace:: :func:`~bokeh.plotting.Figure.inverted_triangle`
+.. |image|             replace:: :func:`~bokeh.plotting.Figure.image`
+.. |image_rgba|        replace:: :func:`~bokeh.plotting.Figure.image_rgba`
+.. |image_url|         replace:: :func:`~bokeh.plotting.Figure.image_url`
+.. |line|              replace:: :func:`~bokeh.plotting.Figure.line`
+.. |multi_line|        replace:: :func:`~bokeh.plotting.Figure.multi_line`
+.. |multi_polygons|    replace:: :func:`~bokeh.plotting.Figure.multi_polygons`
+.. |oval|              replace:: :func:`~bokeh.plotting.Figure.oval`
+.. |patch|             replace:: :func:`~bokeh.plotting.Figure.patch`
+.. |patches|           replace:: :func:`~bokeh.plotting.Figure.patches`
+.. |plus|              replace:: :func:`~bokeh.plotting.Figure.plus`
+.. |quad|              replace:: :func:`~bokeh.plotting.Figure.quad`
+.. |quadratic|         replace:: :func:`~bokeh.plotting.Figure.quadratic`
+.. |ray|               replace:: :func:`~bokeh.plotting.Figure.ray`
+.. |rect|              replace:: :func:`~bokeh.plotting.Figure.rect`
+.. |segment|           replace:: :func:`~bokeh.plotting.Figure.segment`
+.. |step|              replace:: :func:`~bokeh.plotting.Figure.step`
+.. |square|            replace:: :func:`~bokeh.plotting.Figure.square`
+.. |square_cross|      replace:: :func:`~bokeh.plotting.Figure.square_cross`
+.. |square_dot|        replace:: :func:`~bokeh.plotting.Figure.square_dot`
+.. |square_pin|        replace:: :func:`~bokeh.plotting.Figure.square_pin`
+.. |square_x|          replace:: :func:`~bokeh.plotting.Figure.square_x`
+.. |triangle|          replace:: :func:`~bokeh.plotting.Figure.triangle`
+.. |triangle_dot|      replace:: :func:`~bokeh.plotting.Figure.triangle_dot`
+.. |triangle_pin|      replace:: :func:`~bokeh.plotting.Figure.triangle_pin`
+.. |varea|             replace:: :func:`~bokeh.plotting.Figure.varea`
+.. |varea_stack|       replace:: :func:`~bokeh.plotting.Figure.varea_stack`
+.. |vbar|              replace:: :func:`~bokeh.plotting.Figure.vbar`
+.. |vbar_stack|        replace:: :func:`~bokeh.plotting.Figure.vbar_stack`
+.. |vline_stack|       replace:: :func:`~bokeh.plotting.Figure.vline_stack`
+.. |wedge|             replace:: :func:`~bokeh.plotting.Figure.wedge`
+.. |x|                 replace:: :func:`~bokeh.plotting.Figure.x`
+.. |y|                 replace:: :func:`~bokeh.plotting.Figure.y`

--- a/sphinx/source/docs/user_guide/quickstart.rst
+++ b/sphinx/source/docs/user_guide/quickstart.rst
@@ -573,16 +573,16 @@ Be sure to follow us on Twitter `@bokeh <Twitter_>`_!
 .. |glyphs|  replace:: :ref:`glyphs <bokeh.models.glyphs>`
 .. |markers| replace:: :ref:`markers <bokeh.models.markers>`
 
-.. |figure| replace:: :func:`~bokeh.plotting.figure.figure`
-.. |Figure| replace:: :class:`~bokeh.plotting.figure.Figure`
+.. |figure| replace:: :func:`~bokeh.plotting.figure`
+.. |Figure| replace:: :class:`~bokeh.plotting.Figure`
 
-.. |legend| replace:: :class:`~bokeh.plotting.figure.Figure.legend`
-.. |grid|   replace:: :class:`~bokeh.plotting.figure.Figure.grid`
-.. |xgrid|  replace:: :class:`~bokeh.plotting.figure.Figure.xgrid`
-.. |ygrid|  replace:: :class:`~bokeh.plotting.figure.Figure.ygrid`
-.. |axis|   replace:: :class:`~bokeh.plotting.figure.Figure.axis`
-.. |xaxis|  replace:: :class:`~bokeh.plotting.figure.Figure.xaxis`
-.. |yaxis|  replace:: :class:`~bokeh.plotting.figure.Figure.yaxis`
+.. |legend| replace:: :class:`~bokeh.plotting.Figure.legend`
+.. |grid|   replace:: :class:`~bokeh.plotting.Figure.grid`
+.. |xgrid|  replace:: :class:`~bokeh.plotting.Figure.xgrid`
+.. |ygrid|  replace:: :class:`~bokeh.plotting.Figure.ygrid`
+.. |axis|   replace:: :class:`~bokeh.plotting.Figure.axis`
+.. |xaxis|  replace:: :class:`~bokeh.plotting.Figure.xaxis`
+.. |yaxis|  replace:: :class:`~bokeh.plotting.Figure.yaxis`
 
 .. |output_file|     replace:: :func:`~bokeh.io.output_file`
 .. |output_notebook| replace:: :func:`~bokeh.io.output_notebook`
@@ -593,10 +593,10 @@ Be sure to follow us on Twitter `@bokeh <Twitter_>`_!
 .. |DatetimeAxis|     replace:: :class:`~bokeh.models.axes.DatetimeAxis`
 .. |Line|             replace:: :class:`~bokeh.models.glyphs.Line`
 
-.. |Figure.circle|   replace:: :func:`~bokeh.plotting.figure.Figure.circle`
-.. |Figure.line|     replace:: :func:`~bokeh.plotting.figure.Figure.line`
-.. |Figure.square|   replace:: :func:`~bokeh.plotting.figure.Figure.square`
-.. |Figure.triangle| replace:: :func:`~bokeh.plotting.figure.Figure.triangle`
+.. |Figure.circle|   replace:: :func:`~bokeh.plotting.Figure.circle`
+.. |Figure.line|     replace:: :func:`~bokeh.plotting.Figure.line`
+.. |Figure.square|   replace:: :func:`~bokeh.plotting.Figure.square`
+.. |Figure.triangle| replace:: :func:`~bokeh.plotting.Figure.triangle`
 
 .. |gridplot| replace:: :func:`~bokeh.layouts.gridplot`
 


### PR DESCRIPTION
A new version of Sphinx has broken the docs build on the main branch. Our usage of `figure` as a function name and as a submodule under `bokeh.plotting` confuses it, but it seems fine to simply document the transitively imported function directly at this point. 

An issue with documenting GMapOptions was also improved. 
