### PR TITLE
Improve performance by replacing _build_discontinuous_regions()

### DIFF
--- a/bokehjs/src/lib/models/glyphs/annular_wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/annular_wedge.ts
@@ -134,18 +134,12 @@ export class AnnularWedgeView extends XYGlyphView {
     generic_area_legend(this.visuals, ctx, bbox, index)
   }
 
-  private _scenterxy(i: number): {x: number, y: number} {
+  scenterxy(i: number): [number, number] {
     const r = (this.sinner_radius[i] + this.souter_radius[i])/2
     const a = (this._start_angle[i]  + this._end_angle[i])   /2
-    return {x: this.sx[i] + (r*Math.cos(a)), y: this.sy[i] + (r*Math.sin(a))}
-  }
-
-  scenterx(i: number): number {
-    return this._scenterxy(i).x
-  }
-
-  scentery(i: number): number {
-    return this._scenterxy(i).y
+    const scx = this.sx[i] + r*Math.cos(a)
+    const scy = this.sy[i] + r*Math.sin(a)
+    return [scx, scy]
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/bezier.ts
+++ b/bokehjs/src/lib/models/glyphs/bezier.ts
@@ -136,12 +136,8 @@ export class BezierView extends GlyphView {
     generic_line_legend(this.visuals, ctx, bbox, index)
   }
 
-  scenterx(): number {
-    throw new Error("not implemented")
-  }
-
-  scentery(): number {
-    throw new Error("not implemented")
+  scenterxy(): [number, number] {
+    throw new Error(`${this}.scenterxy() is not implemented`)
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -140,16 +140,18 @@ export abstract class GlyphView extends View {
 
   get_anchor_point(anchor: Anchor, i: number, [sx, sy]: [number, number]): {x: number, y: number} | null {
     switch (anchor) {
-      case "center": return {x: this.scenterx(i, sx, sy), y: this.scentery(i, sx, sy)}
-      default:       return null
+      case "center": {
+        const [x, y] = this.scenterxy(i, sx, sy)
+        return {x, y}
+      }
+      default:
+        return null
     }
   }
 
   // glyphs that need more sophisticated "snap to data" behaviour (like
   // snapping to a patch centroid, e.g, should override these
-  abstract scenterx(i: number, _sx: number, _sy: number): number
-
-  abstract scentery(i: number, _sx: number, _sy: number): number
+  abstract scenterxy(i: number, sx: number, sy: number): [number, number]
 
   sdist(scale: Scale, pts: Arrayable<number>, spans: Arrayable<number>,
         pts_location: "center" | "edge" = "edge", dilate: boolean = false): NumberArray {

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -153,6 +153,15 @@ export abstract class GlyphView extends View {
   // snapping to a patch centroid, e.g, should override these
   abstract scenterxy(i: number, sx: number, sy: number): [number, number]
 
+  /** @deprecated */
+  scenterx(i: number, sx: number, sy: number): number {
+    return this.scenterxy(i, sx, sy)[0]
+  }
+  /** @deprecated */
+  scentery(i: number, sx: number, sy: number): number {
+    return this.scenterxy(i, sx, sy)[1]
+  }
+
   sdist(scale: Scale, pts: Arrayable<number>, spans: Arrayable<number>,
         pts_location: "center" | "edge" = "edge", dilate: boolean = false): NumberArray {
     let pt0: Arrayable<number>

--- a/bokehjs/src/lib/models/glyphs/harea.ts
+++ b/bokehjs/src/lib/models/glyphs/harea.ts
@@ -85,12 +85,10 @@ export class HAreaView extends AreaView {
     return result
   }
 
-  scenterx(i: number): number {
-    return (this.sx1[i] + this.sx2[i])/2
-  }
-
-  scentery(i: number): number {
-    return this.sy[i]
+  scenterxy(i: number): [number, number] {
+    const scx = (this.sx1[i] + this.sx2[i])/2
+    const scy = this.sy[i]
+    return [scx, scy]
   }
 
   protected _map_data(): void {

--- a/bokehjs/src/lib/models/glyphs/hbar.ts
+++ b/bokehjs/src/lib/models/glyphs/hbar.ts
@@ -24,12 +24,10 @@ export class HBarView extends BoxView {
   model: HBar
   visuals: HBar.Visuals
 
-  scenterx(i: number): number {
-    return (this.sleft[i] + this.sright[i])/2
-  }
-
-  scentery(i: number): number {
-    return this.sy[i]
+  scenterxy(i: number): [number, number] {
+    const scx = (this.sleft[i] + this.sright[i])/2
+    const scy = this.sy[i]
+    return [scx, scy]
   }
 
   protected _lrtb(i: number): [number, number, number, number] {

--- a/bokehjs/src/lib/models/glyphs/hex_tile.ts
+++ b/bokehjs/src/lib/models/glyphs/hex_tile.ts
@@ -37,9 +37,12 @@ export class HexTileView extends GlyphView {
   model: HexTile
   visuals: HexTile.Visuals
 
-  scenterx(i: number): number { return this.sx[i] }
+  scenterxy(i: number): [number, number] {
+    const scx = this.sx[i]
+    const scy = this.sy[i]
+    return [scx, scy]
+  }
 
-  scentery(i: number): number { return this.sy[i] }
 
   protected _set_data(): void {
     const n = this._q.length

--- a/bokehjs/src/lib/models/glyphs/multi_line.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_line.ts
@@ -139,12 +139,8 @@ export class MultiLineView extends GlyphView {
     generic_line_legend(this.visuals, ctx, bbox, index)
   }
 
-  scenterx(): number {
-    throw new Error("not implemented")
-  }
-
-  scentery(): number {
-    throw new Error("not implemented")
+  scenterxy(): [number, number] {
+    throw new Error(`${this}.scenterxy() is not implemented`)
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/multi_polygons.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_polygons.ts
@@ -260,36 +260,23 @@ export class MultiPolygonsView extends GlyphView {
     return sum(array) / array.length
   }
 
-  scenterx(i: number, sx: number, sy: number): number {
+  scenterxy(i: number, sx: number, sy: number): [number, number] {
     if (this.sxs[i].length == 1) {
       // We don't have discontinuous objects so we're ok
-      return this._get_snap_coord(this.sxs[i][0][0])
+      const scx = this._get_snap_coord(this.sxs[i][0][0])
+      const scy = this._get_snap_coord(this.sys[i][0][0])
+      return [scx, scy]
     } else {
       // We have discontinuous objects, so we need to find which
       // one we're in, we can use point_in_poly again
       const sxs = this.sxs[i]
       const sys = this.sys[i]
       for (let j = 0, end = sxs.length; j < end; j++) {
-        if (hittest.point_in_poly(sx, sy, sxs[j][0], sys[j][0]))
-          return this._get_snap_coord(sxs[j][0])
-      }
-    }
-
-    unreachable()
-  }
-
-  scentery(i: number, sx: number, sy: number): number {
-    if (this.sys[i].length == 1) {
-      // We don't have discontinuous objects so we're ok
-      return this._get_snap_coord(this.sys[i][0][0])
-    } else {
-      // We have discontinuous objects, so we need to find which
-      // one we're in, we can use point_in_poly again
-      const sxs = this.sxs[i]
-      const sys = this.sys[i]
-      for (let j = 0, end = sxs.length; j < end; j++) {
-        if (hittest.point_in_poly(sx, sy, sxs[j][0], sys[j][0]))
-          return this._get_snap_coord(sys[j][0])
+        if (hittest.point_in_poly(sx, sy, sxs[j][0], sys[j][0])) {
+          const scx = this._get_snap_coord(sxs[j][0])
+          const scy = this._get_snap_coord(sys[j][0])
+          return [scx, scy]
+        }
       }
     }
 

--- a/bokehjs/src/lib/models/glyphs/patches.ts
+++ b/bokehjs/src/lib/models/glyphs/patches.ts
@@ -162,7 +162,7 @@ export class PatchesView extends GlyphView {
     return sum(array) / array.length
   }
 
-  scenterx(i: number, sx: number, sy: number): number {
+  scenterxy(i: number, sx: number, sy: number): [number, number] {
     const sxsi = this.sxs[i]
     const sysi = this.sys[i]
 
@@ -173,43 +173,18 @@ export class PatchesView extends GlyphView {
       has_nan = has_nan || this_nan
 
       if (j == n && !has_nan) {
-        return this._get_snap_coord(sxsi)
+        const scx = this._get_snap_coord(sxsi)
+        const scy = this._get_snap_coord(sysi)
+        return [scx, scy]
       }
 
       if (this_nan || j == n) {
         const sxsi_kj = sxsi.subarray(k, j)
         const sysi_kj = sysi.subarray(k, j)
         if (hittest.point_in_poly(sx, sy, sxsi_kj, sysi_kj)) {
-          return this._get_snap_coord(sxsi_kj)
-        }
-        k = j + 1
-      }
-      if (j == n)
-        break
-    }
-
-    unreachable()
-  }
-
-  scentery(i: number, sx: number, sy: number): number {
-    const sxsi = this.sxs[i]
-    const sysi = this.sys[i]
-
-    const n = sxsi.length
-    let has_nan = false
-    for (let k = 0, j = 0;; j++) {
-      const this_nan = isNaN(sxsi[j])
-      has_nan = has_nan || this_nan
-
-      if (j == n && !has_nan) {
-        return this._get_snap_coord(sysi)
-      }
-
-      if (this_nan || j == n) {
-        const sxsi_kj = sxsi.subarray(k, j)
-        const sysi_kj = sysi.subarray(k, j)
-        if (hittest.point_in_poly(sx, sy, sxsi_kj, sysi_kj)) {
-          return this._get_snap_coord(sysi_kj)
+          const scx = this._get_snap_coord(sxsi_kj)
+          const scy = this._get_snap_coord(sysi_kj)
+          return [scx, scy]
         }
         k = j + 1
       }

--- a/bokehjs/src/lib/models/glyphs/quad.ts
+++ b/bokehjs/src/lib/models/glyphs/quad.ts
@@ -20,12 +20,10 @@ export class QuadView extends BoxView {
   model: Quad
   visuals: Quad.Visuals
 
-  scenterx(i: number): number {
-    return (this.sleft[i] + this.sright[i])/2
-  }
-
-  scentery(i: number): number {
-    return (this.stop[i] + this.sbottom[i])/2
+  scenterxy(i: number): [number, number] {
+    const scx = (this.sleft[i] + this.sright[i])/2
+    const scy = (this.stop[i] + this.sbottom[i])/2
+    return [scx, scy]
   }
 
   protected _lrtb(i: number): [number, number, number, number] {

--- a/bokehjs/src/lib/models/glyphs/quadratic.ts
+++ b/bokehjs/src/lib/models/glyphs/quadratic.ts
@@ -84,12 +84,8 @@ export class QuadraticView extends GlyphView {
     generic_line_legend(this.visuals, ctx, bbox, index)
   }
 
-  scenterx(): number {
-    throw new Error("not implemented")
-  }
-
-  scentery(): number {
-    throw new Error("not implemented")
+  scenterxy(): [number, number] {
+    throw new Error(`${this}.scenterxy() is not implemented`)
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/segment.ts
+++ b/bokehjs/src/lib/models/glyphs/segment.ts
@@ -129,12 +129,10 @@ export class SegmentView extends GlyphView {
     return new Selection({indices})
   }
 
-  scenterx(i: number): number {
-    return (this.sx0[i] + this.sx1[i])/2
-  }
-
-  scentery(i: number): number {
-    return (this.sy0[i] + this.sy1[i])/2
+  scenterxy(i: number): [number, number] {
+    const scx = (this.sx0[i] + this.sx1[i])/2
+    const scy = (this.sy0[i] + this.sy1[i])/2
+    return [scx, scy]
   }
 
   draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {

--- a/bokehjs/src/lib/models/glyphs/text.ts
+++ b/bokehjs/src/lib/models/glyphs/text.ts
@@ -128,7 +128,7 @@ export class TextView extends XYGlyphView {
     return new Selection({indices})
   }
 
-  private _scenterxy(i: number): {x: number, y: number} {
+  scenterxy(i: number): [number, number] {
     const sxs = this._sxs[i]
     const sys = this._sys[i]
     assert(sxs.length != 0 && sys.length != 0)
@@ -137,15 +137,7 @@ export class TextView extends XYGlyphView {
     const sxc = (sxs[0][2] + sx0) / 2
     const syc = (sys[0][2] + sy0) / 2
     const [sxcr, sycr] = this._rotate_point(sxc, syc, sx0, sy0, this._angle[i])
-    return {x: sxcr, y:sycr}
-  }
-
-  scenterx(i: number): number {
-    return this._scenterxy(i).x
-  }
-
-  scentery(i: number): number {
-    return this._scenterxy(i).y
+    return [sxcr, sycr]
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/varea.ts
+++ b/bokehjs/src/lib/models/glyphs/varea.ts
@@ -63,12 +63,10 @@ export class VAreaView extends AreaView {
 
   }
 
-  scenterx(i: number): number {
-    return this.sx[i]
-  }
-
-  scentery(i: number): number {
-    return (this.sy1[i] + this.sy2[i])/2
+  scenterxy(i: number): [number, number] {
+    const scx = this.sx[i]
+    const scy = (this.sy1[i] + this.sy2[i])/2
+    return [scx, scy]
   }
 
   protected _hit_point(geometry: PointGeometry): Selection {

--- a/bokehjs/src/lib/models/glyphs/vbar.ts
+++ b/bokehjs/src/lib/models/glyphs/vbar.ts
@@ -24,12 +24,10 @@ export class VBarView extends BoxView {
   model: VBar
   visuals: VBar.Visuals
 
-  scenterx(i: number): number {
-    return this.sx[i]
-  }
-
-  scentery(i: number): number {
-    return (this.stop[i] + this.sbottom[i])/2
+  scenterxy(i: number): [number, number] {
+    const scx = this.sx[i]
+    const scy = (this.stop[i] + this.sbottom[i])/2
+    return [scx, scy]
   }
 
   protected _lrtb(i: number): [number, number, number, number] {

--- a/bokehjs/src/lib/models/glyphs/wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/wedge.ts
@@ -112,18 +112,12 @@ export class WedgeView extends XYGlyphView {
     generic_area_legend(this.visuals, ctx, bbox, index)
   }
 
-  private _scenterxy(i: number): {x: number, y: number} {
+  scenterxy(i: number): [number, number] {
     const r = this.sradius[i] / 2
     const a = (this._start_angle[i] + this._end_angle[i]) / 2
-    return {x: this.sx[i] + (r * Math.cos(a)), y: this.sy[i] + (r * Math.sin(a))}
-  }
-
-  scenterx(i: number): number {
-    return this._scenterxy(i).x
-  }
-
-  scentery(i: number): number {
-    return this._scenterxy(i).y
+    const scx = this.sx[i] + r*Math.cos(a)
+    const scy = this.sy[i] + r*Math.sin(a)
+    return [scx, scy]
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/xy_glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/xy_glyph.ts
@@ -31,12 +31,8 @@ export abstract class XYGlyphView extends GlyphView {
     }
   }
 
-  scenterx(i: number): number {
-    return this.sx[i]
-  }
-
-  scentery(i: number): number {
-    return this.sy[i]
+  scenterxy(i: number): [number, number] {
+    return [this.sx[i], this.sy[i]]
   }
 }
 

--- a/bokehjs/test/unit/models/glyphs/glyph.ts
+++ b/bokehjs/test/unit/models/glyphs/glyph.ts
@@ -22,12 +22,8 @@ describe("glyph module", () => {
 
         protected _render(_ctx: Context2d, _indices: number[], {}: object): void {}
 
-        scenterx(_i: number): number {
-          return 0
-        }
-
-        scentery(_i: number): number {
-          return 0
+        scenterxy(): [number, number] {
+          return [0, 0]
         }
 
         protected _hit_point?(_geometry: PointGeometry): Selection {

--- a/sphinx/source/docs/releases/2.2.0.rst
+++ b/sphinx/source/docs/releases/2.2.0.rst
@@ -1,0 +1,21 @@
+.. _release-2-2-0:
+
+2.2.0
+=====
+
+Bokeh Version ``2.2.0`` (July 2020) is a minor-release.
+
+* TODO
+
+And several other bug fixes and docs additions. For full details see the
+:bokeh-tree:`CHANGELOG`.
+
+.. _release-2-2-0-migration:
+
+`Migration Guide <releases.html#release-2-2-0-migration>`__
+-----------------------------------------------------------
+
+``Glyph.scenterx()`` (and ``y``) deprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Implement ``Glyph.scenterxy()`` instead.


### PR DESCRIPTION
`Patches._build_discontinuous_regions()` is very inefficient, especially memory utilization-wise, due to high GC churn. It's more efficient to just iterate over `NaN` separated regions and use `TypedArray.subarray()` to create data views for other functions to use. Additionally I also merged `scenterx()` and `scentery()` into one method, as those often had repeated logic and required computing things twice.
