### PR TITLE
Corrected EqHistColorMapper with inverted colormap edge transform

### DIFF
--- a/bokehjs/src/lib/core/util/arrayable.ts
+++ b/bokehjs/src/lib/core/util/arrayable.ts
@@ -149,6 +149,22 @@ export function min(array: Arrayable<number>): number {
   return result
 }
 
+export function argmin(array: Arrayable<number>): number {
+  let value: number
+  let minimum = Infinity
+  let result = Infinity
+
+  for (let i = 0, length = array.length; i < length; i++) {
+    value = array[i]
+    if (!isNaN(value) && value < minimum) {
+      minimum = value
+      result = i
+    }
+  }
+
+  return result
+}
+
 export function max(array: Arrayable<number>): number {
   let value: number
   let result = -Infinity
@@ -162,6 +178,23 @@ export function max(array: Arrayable<number>): number {
 
   return result
 }
+
+export function argmax(array: Arrayable<number>): number {
+  let value: number
+  let maximum = -Infinity
+  let result = Infinity
+
+  for (let i = 0, length = array.length; i < length; i++) {
+    value = array[i]
+    if (!isNaN(value) && value > maximum) {
+      maximum = value
+      result = i
+    }
+  }
+
+  return result
+}
+
 
 export function minmax(array: Arrayable<number>): [number, number] {
   let value: number

--- a/bokehjs/src/lib/core/util/arrayable.ts
+++ b/bokehjs/src/lib/core/util/arrayable.ts
@@ -355,7 +355,7 @@ function lerp(x: number, x0: number, y0: number, x1: number, y1: number): number
   return res
 }
 
-function left_edge_index(point: number, intervals: Arrayable<number>): number {
+export function left_edge_index(point: number, intervals: Arrayable<number>): number {
   if (point < intervals[0])
     return -1
   if (point > intervals[intervals.length - 1])

--- a/bokehjs/src/lib/core/util/arrayable.ts
+++ b/bokehjs/src/lib/core/util/arrayable.ts
@@ -149,22 +149,6 @@ export function min(array: Arrayable<number>): number {
   return result
 }
 
-export function argmin(array: Arrayable<number>): number {
-  let value: number
-  let minimum = Infinity
-  let result = Infinity
-
-  for (let i = 0, length = array.length; i < length; i++) {
-    value = array[i]
-    if (!isNaN(value) && value < minimum) {
-      minimum = value
-      result = i
-    }
-  }
-
-  return result
-}
-
 export function max(array: Arrayable<number>): number {
   let value: number
   let result = -Infinity
@@ -178,23 +162,6 @@ export function max(array: Arrayable<number>): number {
 
   return result
 }
-
-export function argmax(array: Arrayable<number>): number {
-  let value: number
-  let maximum = -Infinity
-  let result = Infinity
-
-  for (let i = 0, length = array.length; i < length; i++) {
-    value = array[i]
-    if (!isNaN(value) && value > maximum) {
-      maximum = value
-      result = i
-    }
-  }
-
-  return result
-}
-
 
 export function minmax(array: Arrayable<number>): [number, number] {
   let value: number
@@ -357,20 +324,33 @@ export function interpolate(points: Arrayable<number>, x_values: Arrayable<numbe
       index--
     }
 
-    const x0 = x_values[index]
-    const y0 = y_values[index]
-    const x1 = x_values[index + 1]
-    const y1 = y_values[index + 1]
-    results[i] = lerp(point, x0, y0, x1, y1)
+    let res: number
+    if (index == x_values.length)
+      res = y_values[y_values.length-1]
+    else if ((index == x_values.length-1) || (x_values[index] == point))
+      res = y_values[index]
+    else {
+      const x0 = x_values[index]
+      const y0 = y_values[index]
+      const x1 = x_values[index + 1]
+      const y1 = y_values[index + 1]
+      res = lerp(point, x0, y0, x1, y1)
+    }
+    results[i] = res
   }
-
   return results
 }
 
 function lerp(x: number, x0: number, y0: number, x1: number, y1: number): number {
+  // Copies NumPy's np.interp implementation
   const a = (y1 - y0)/(x1 - x0)
-  const b = -a*x0 + y0
-  return a*x + b
+  let res = a*(x-x0) + y0
+  if (!isFinite(res)) {
+    res = a*(x-x1) + y1
+    if (!isFinite(res))
+      res = y0
+  }
+  return res
 }
 
 function left_edge_index(point: number, intervals: Arrayable<number>): number {

--- a/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
@@ -54,7 +54,12 @@ export class EqHistColorMapper extends ScanningColorMapper {
     let iterations = 0
     let guess = n*2
     while ((finite_bins != n) && (iterations < 4) && (finite_bins != 0)) {
-      guess = Math.round(Math.max(n * guess/finite_bins, n))
+      let ratio = guess/finite_bins
+      if (ratio > 1000) {
+        // Abort if distribution is extremely skewed
+        break;
+      }
+      guess = Math.round(Math.max(n*ratio, n))
 
       // Interpolate
       const palette_edges = range(0, guess)

--- a/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
@@ -44,10 +44,9 @@ export class EqHistColorMapper extends ScanningColorMapper {
     // Interpolate
     const palette_edges = linspace(0, n, n + 1)
     const palette_cdf = map(norm_cdf, (x) => x*n)
-    const interpolated = interpolate(palette_edges, palette_cdf, eq_bin_edges)
-    const lower = argmin(interpolated)
-    const upper = argmax(interpolated)
-    const binning = map(interpolated, (x) => isNaN(x) ? 0 : x)
+    const binning = interpolate(palette_edges, palette_cdf, eq_bin_edges)
+    const lower = argmin(binning)
+    const upper = argmax(binning)
     return {min: low, max: high, binning, lower, upper}
   }
 }

--- a/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
@@ -56,8 +56,10 @@ export class EqHistColorMapper extends ScanningColorMapper {
     const bins = []
 	for (let bin of binning)
       bins.push(bin)
-	const low_bin = uniq(bins)[1]
+	const uniq_bins = uniq(bins)
+	const low_bin = uniq_bins[1]
 	const lower = bins.indexOf(low_bin)
-    return {min: low, max: high, binning, lower}
+	const offset = Math.round(uniq_bins.length*((low_bin-bins[0])/n))
+    return {min: low, max: high, binning, lower: lower-offset}
   }
 }

--- a/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
@@ -13,28 +13,6 @@ export namespace EqHistColorMapper {
   }
 }
 
-function eq_hist(data: Arrayable<number>, low: number, high: number, nbins: number, n: number): number[] {
-  const eq_bin_edges = linspace(low, high, nbins+1)
-  const hist = bin_counts(data, eq_bin_edges)
-
-  const eq_bin_centers = new Array(nbins)
-  for (let i = 0, length = eq_bin_edges.length; i < (length-1); i++) {
-    const left = eq_bin_edges[i]
-    const right = eq_bin_edges[i+1]
-    eq_bin_centers[i] = (left+right)/2
-  }
-
-  // CDFs
-  const cdf = cumsum(hist)
-  const cdf_max = cdf[cdf.length - 1]
-  const norm_cdf = map(cdf, (x) => x / cdf_max)
-
-  // Interpolate
-  const palette_edges = range(0, n)
-  const palette_cdf = map(norm_cdf, (x) => x*(n-1))
-  return (interpolate(palette_edges, palette_cdf, eq_bin_centers) as number[])
-}
-
 export interface EqHistColorMapper extends EqHistColorMapper.Attrs {}
 
 export class EqHistColorMapper extends ScanningColorMapper {
@@ -54,20 +32,41 @@ export class EqHistColorMapper extends ScanningColorMapper {
     const low = this.low != null ? this.low : min(data)
     const high = this.high != null ? this.high : max(data)
 
-    // Iteratively find as many finite bins as there are colors
     const nbins = this.bins
+    const eq_bin_edges = linspace(low, high, nbins+1)
+    const hist = bin_counts(data, eq_bin_edges)
+
+    const eq_bin_centers = new Array(nbins)
+    for (let i = 0, length = eq_bin_edges.length; i < (length-1); i++) {
+      const left = eq_bin_edges[i]
+      const right = eq_bin_edges[i+1]
+      eq_bin_centers[i] = (left+right)/2
+    }
+
+    // CDFs
+    const cdf = cumsum(hist)
+    const cdf_max = cdf[cdf.length - 1]
+    const norm_cdf = map(cdf, (x) => x / cdf_max)
+
+    // Iteratively find as many finite bins as there are colors
     let finite_bins = n-1
     let binning: number[] = []
     let iterations = 0
-    let guess = n*1.5
-    while (finite_bins != n && iterations<10 && (finite_bins != 0)) {
+    let guess = n*2
+    while (finite_bins != n && iterations<4 && (finite_bins != 0)) {
       guess = Math.round(Math.max(n * guess/finite_bins, n))
-      binning = eq_hist(data, low, high, nbins, guess)
+
+      // Interpolate
+      const palette_edges = range(0, guess)
+      const palette_cdf = map(norm_cdf, (x) => x*(guess-1))
+      binning = (interpolate(palette_edges, palette_cdf, eq_bin_centers) as number[])
+
+      // Evaluate binning
       const uniq_bins = uniq(binning)
       finite_bins = uniq_bins.length-1
       iterations++
     }
-	if (finite_bins == 0)
+    if (finite_bins == 0)
       binning = [low, high]
     else
       binning = binning.slice(binning.length-n)

--- a/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
@@ -1,7 +1,7 @@
 import {ScanningColorMapper} from "./scanning_color_mapper"
 import {Arrayable} from "core/types"
-import {min, max, bin_counts, map, filter, interpolate} from "core/util/arrayable"
-import {linspace, range, cumsum} from "core/util/array"
+import {min, max, bin_counts, map, interpolate} from "core/util/arrayable"
+import {linspace, range, cumsum, uniq} from "core/util/array"
 import * as p from "core/properties"
 
 export namespace EqHistColorMapper {
@@ -27,7 +27,7 @@ export class EqHistColorMapper extends ScanningColorMapper {
     })
   }
 
-  protected scan(data: Arrayable<number>, n: number): {min: number, max: number, lower: number, upper: number, binning: Arrayable<number>} {
+  protected scan(data: Arrayable<number>, n: number): {min: number, max: number, lower: number, binning: Arrayable<number>} {
     const low = this.low != null ? this.low : min(data)
     const high = this.high != null ? this.high : max(data)
 
@@ -50,11 +50,14 @@ export class EqHistColorMapper extends ScanningColorMapper {
 
     // Interpolate
     const palette_edges = range(0, n)
-    const palette_cdf = map(norm_cdf, (x) => x*n)
+    const palette_cdf = map(norm_cdf, (x) => x*(n-1))
     const binning = interpolate(palette_edges, palette_cdf, eq_bin_centers)
 
-    const left = low == 0 ? min(filter(data, (n) => n != low)) : low
-    const [lower, upper] = interpolate([left, high], binning, palette_edges)
-    return {min: low, max: high, binning, lower, upper}
+    const bins = []
+	for (let bin of binning)
+      bins.push(bin)
+	const low_bin = uniq(bins)[1]
+	const lower = bins.indexOf(low_bin)
+    return {min: low, max: high, binning, lower}
   }
 }

--- a/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
@@ -53,7 +53,7 @@ export class EqHistColorMapper extends ScanningColorMapper {
     let binning: number[] = []
     let iterations = 0
     let guess = n*2
-    while (finite_bins != n && iterations<4 && (finite_bins != 0)) {
+    while ((finite_bins != n) && (iterations < 4) && (finite_bins != 0)) {
       guess = Math.round(Math.max(n * guess/finite_bins, n))
 
       // Interpolate
@@ -66,12 +66,15 @@ export class EqHistColorMapper extends ScanningColorMapper {
       finite_bins = uniq_bins.length-1
       iterations++
     }
-    if (finite_bins == 0)
+    if (finite_bins == 0) {
       binning = [low, high]
-    else
-      binning = binning.slice(binning.length-n)
+      for (let j = 0; j < (n-1); j++)
+        binning.push(high)
+    } else {
+      binning = binning.slice(binning.length-n-1)
       if (finite_bins != n)
         logger.warn("EqHistColorMapper warning: Histogram equalization did not converge.")
-    return {min: low, max: high, binning}
+	}
+	return {min: low, max: high, binning}
   }
 }

--- a/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
@@ -52,7 +52,6 @@ export class EqHistColorMapper extends ScanningColorMapper {
     const palette_edges = range(0, n)
     const palette_cdf = map(norm_cdf, (x) => x*n)
     const binning = interpolate(palette_edges, palette_cdf, eq_bin_centers)
-    console.log(palette_edges, palette_cdf, eq_bin_centers, binning)
 
     let minimum = binning[0]
     let maximum = binning[0];
@@ -71,6 +70,6 @@ export class EqHistColorMapper extends ScanningColorMapper {
         upper = i
       }
     }
-    return {min: low, max: high, binning, lower: lower-1, upper}
+    return {min: low, max: high, binning, lower: lower, upper}
   }
 }

--- a/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
@@ -1,7 +1,7 @@
 import {ScanningColorMapper} from "./scanning_color_mapper"
 import {Arrayable} from "core/types"
-import {min, max, bin_counts, interpolate, map} from "core/util/arrayable"
-import {linspace, cumsum} from "core/util/array"
+import {min, max, bin_counts, interpolate, map, filter} from "core/util/arrayable"
+import {linspace, cumsum, sum} from "core/util/array"
 import * as p from "core/properties"
 
 export namespace EqHistColorMapper {
@@ -34,27 +34,63 @@ export class EqHistColorMapper extends ScanningColorMapper {
 
     // Compute bin edges and histogram counts
     const nbins = this.bins
-    const bin_edges = linspace(low, high, nbins+1)
-    const hist = bin_counts(data, bin_edges)
+    const eq_bin_edges = linspace(low, high, nbins+1)
+    const raw_hist = bin_counts(data, eq_bin_edges)
+
+    const bin_edges = new Array(1)
+    bin_edges[0] = eq_bin_edges[0]; 
+    const hist = new Array() // Could also zero-filter hist in a pass 
+    // Dropping edges/bins zero zero count hist to avoid flat sections of CDF
+    for (let i = 0; i < nbins; i++) {
+        if (raw_hist[i] != 0) {
+            bin_edges.push(eq_bin_edges[i+1])
+            hist.push(raw_hist[i])
+        }
+    }   
 
     // Compute bin centers
-    const bin_centers = new Array(nbins)
-    for (let i = 0; i < nbins; i++) {
+    const bin_centers = new Array(bin_edges.length - 1)
+    for (let i = 0; i < (bin_edges.length - 1); i++) {
       bin_centers[i] = (bin_edges[i] + bin_edges[i + 1])/2
-    }
-    //const lower_edges = bin_edges.slice(0, -1)
-    //const upper_edges = bin_edges.slice(1, undefined)
-    //const bin_centers = map(range(0, bin_edges.length-1), (i) => (lower_edges[i] + upper_edges[i])/2)
-
+    }      
+      
     // CDFs
     const cdf = cumsum(hist)
     const cdf_max = cdf[cdf.length - 1]
     const norm_cdf = map(cdf, (x) => x / cdf_max)
 
     // Interpolate
-    const palette_range = linspace(low, high, n + 1)
-    const norm_interpolated = interpolate(palette_range, bin_centers, norm_cdf)
-    const result = map(norm_interpolated, (x) => low + x*span)
+    const palette_edges = linspace(low, high, n + 1)
+
+    // Compute bin centers
+    const palette_centers = new Array(palette_edges.length - 1)
+      for (let i = 0; i < (palette_edges.length - 1); i++) {
+        palette_centers[i] = (palette_edges[i] + palette_edges[i + 1])/2
+      }
+
+    const interpolated = interpolate(palette_centers, bin_centers, norm_cdf)
+    const min_interp = min(interpolated)
+    const interp_span = max(interpolated) - min_interp
+    const rescaled_interpolated = map(interpolated, (x) => (x - min_interp)/interp_span)
+    // This is currently the most suspect step due to the magic 0.999 number
+    // The problem is that edge values greater than 1 are problematic
+    const norm_interpolated = filter(rescaled_interpolated, (x) => x < 0.999)
+
+    let diff = [];
+    for (let i = 1; i < (norm_interpolated.length); i++) {
+        diff.push(norm_interpolated[i] - norm_interpolated[i - 1])
+    }
+
+    let delta = 1/diff.length
+    let ratio = diff.map( x  =>  x / delta)
+    let inv_ratio = ratio.map( x  =>  1 / x)
+    let ratio_sum = sum(ratio)
+    let inv_ratio_sum = sum(inv_ratio)
+    let adjusted = inv_ratio.map(x => (x / inv_ratio_sum) * ratio_sum)
+    let adjusted_bins = adjusted.map((_, i) => adjusted[i] * delta)
+    let adjusted_edges = [0].concat(cumsum(adjusted_bins))
+      
+    const result = map(adjusted_edges, (x) =>  (x-low)*span)
     return {min: low, max: high, binning: result}
   }
 }

--- a/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
@@ -3,6 +3,7 @@ import {Arrayable} from "core/types"
 import {min, max, bin_counts, map, interpolate} from "core/util/arrayable"
 import {linspace, range, cumsum, uniq} from "core/util/array"
 import * as p from "core/properties"
+import {logger} from "core/logging"
 
 export namespace EqHistColorMapper {
   export type Attrs = p.AttrsOf<Props>
@@ -10,6 +11,28 @@ export namespace EqHistColorMapper {
   export type Props = ScanningColorMapper.Props & {
     bins: p.Property<number>
   }
+}
+
+function eq_hist(data: Arrayable<number>, low: number, high: number, nbins: number, n: number): number[] {
+  const eq_bin_edges = linspace(low, high, nbins+1)
+  const hist = bin_counts(data, eq_bin_edges)
+
+  const eq_bin_centers = new Array(nbins)
+  for (let i = 0, length = eq_bin_edges.length; i < (length-1); i++) {
+    const left = eq_bin_edges[i]
+    const right = eq_bin_edges[i+1]
+    eq_bin_centers[i] = (left+right)/2
+  }
+
+  // CDFs
+  const cdf = cumsum(hist)
+  const cdf_max = cdf[cdf.length - 1]
+  const norm_cdf = map(cdf, (x) => x / cdf_max)
+
+  // Interpolate
+  const palette_edges = range(0, n)
+  const palette_cdf = map(norm_cdf, (x) => x*(n-1))
+  return (interpolate(palette_edges, palette_cdf, eq_bin_centers) as number[])
 }
 
 export interface EqHistColorMapper extends EqHistColorMapper.Attrs {}
@@ -27,39 +50,29 @@ export class EqHistColorMapper extends ScanningColorMapper {
     })
   }
 
-  protected scan(data: Arrayable<number>, n: number): {min: number, max: number, lower: number, binning: Arrayable<number>} {
+  protected scan(data: Arrayable<number>, n: number): {min: number, max: number, binning: Arrayable<number>} {
     const low = this.low != null ? this.low : min(data)
     const high = this.high != null ? this.high : max(data)
 
-    // Compute bin edges and histogram counts
+    // Iteratively find as many finite bins as there are colors
     const nbins = this.bins
-    const eq_bin_edges = linspace(low, high, nbins+1)
-    const hist = bin_counts(data, eq_bin_edges)
-
-    const eq_bin_centers = new Array(nbins)
-    for (let i = 0, length = eq_bin_edges.length; i < (length-1); i++) {
-      const left = eq_bin_edges[i]
-      const right = eq_bin_edges[i+1]
-      eq_bin_centers[i] = (left+right)/2
+    let finite_bins = n-1
+    let binning: number[] = []
+    let iterations = 0
+    let guess = n*1.5
+    while (finite_bins != n && iterations<10 && (finite_bins != 0)) {
+      guess = Math.round(Math.max(n * guess/finite_bins, n))
+      binning = eq_hist(data, low, high, nbins, guess)
+      const uniq_bins = uniq(binning)
+      finite_bins = uniq_bins.length-1
+      iterations++
     }
-
-    // CDFs
-    const cdf = cumsum(hist)
-    const cdf_max = cdf[cdf.length - 1]
-    const norm_cdf = map(cdf, (x) => x / cdf_max)
-
-    // Interpolate
-    const palette_edges = range(0, n)
-    const palette_cdf = map(norm_cdf, (x) => x*(n-1))
-    const binning = interpolate(palette_edges, palette_cdf, eq_bin_centers)
-
-    const bins = []
-	for (let bin of binning)
-      bins.push(bin)
-	const uniq_bins = uniq(bins)
-	const low_bin = uniq_bins[1]
-	const lower = bins.indexOf(low_bin)
-	const offset = Math.round(uniq_bins.length*((low_bin-bins[0])/n))
-    return {min: low, max: high, binning, lower: lower-offset}
+	if (finite_bins == 0)
+      binning = [low, high]
+    else
+      binning = binning.slice(binning.length-n)
+      if (finite_bins != n)
+        logger.warn("EqHistColorMapper warning: Histogram equalization did not converge.")
+    return {min: low, max: high, binning}
   }
 }

--- a/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
@@ -1,6 +1,6 @@
 import {ScanningColorMapper} from "./scanning_color_mapper"
 import {Arrayable} from "core/types"
-import {min, max, bin_counts, map, interpolate} from "core/util/arrayable"
+import {min, max, bin_counts, map, filter, interpolate} from "core/util/arrayable"
 import {linspace, range, cumsum} from "core/util/array"
 import * as p from "core/properties"
 
@@ -53,23 +53,8 @@ export class EqHistColorMapper extends ScanningColorMapper {
     const palette_cdf = map(norm_cdf, (x) => x*n)
     const binning = interpolate(palette_edges, palette_cdf, eq_bin_centers)
 
-    let minimum = binning[0]
-    let maximum = binning[0];
-    let lower: number = 0
-	let upper: number = binning.length
-    for (let i = 0, length = binning.length; i < length; i++) {
-      const value = binning[i]
-      if (isNaN(value))
-        continue
-	  if (value <= minimum) {
-        minimum = value
-        lower = i
-      }
-	  if (value >= maximum) {
-        maximum = value
-        upper = i
-      }
-    }
-    return {min: low, max: high, binning, lower: lower, upper}
+    const left = low == 0 ? min(filter(data, (n) => n != low)) : low
+    const [lower, upper] = interpolate([left, high], binning, palette_edges)
+    return {min: low, max: high, binning, lower, upper}
   }
 }

--- a/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
@@ -47,7 +47,7 @@ export class EqHistColorMapper extends ScanningColorMapper {
     const interpolated = interpolate(palette_edges, palette_cdf, eq_bin_edges)
     const lower = argmin(interpolated)
     const upper = argmax(interpolated)
-    const binning = map(interpolated, (x) => (x || 0))
+    const binning = map(interpolated, (x) => isNaN(x) ? 0 : x)
     return {min: low, max: high, binning, lower, upper}
   }
 }

--- a/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
@@ -35,10 +35,9 @@ export abstract class ScanningColorMapper extends ContinuousColorMapper {
     }
 
     // Adjust for non-finite bins
-	const lower = edges.lower-2
 	const n = palette.length-1
-    const span = (n-lower)
-    const index = Math.floor(((key-lower) / span) * n)
-    return palette[index]
+    const span = (n-edges.lower)
+    const index = Math.floor(((key-edges.lower) / span) * n)
+	return palette[Math.max(index, 0)]
   }
 }

--- a/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
@@ -35,9 +35,8 @@ export abstract class ScanningColorMapper extends ContinuousColorMapper {
     }
 
     // Adjust for zero-valued bins
-    const lower = Math.max(edges.lower-1, 0)
-    const span = (edges.upper-lower)
-    const index = Math.floor(((key-lower) / span) * palette.length)
+    const span = (edges.upper-edges.lower)
+    const index = Math.floor(((key-edges.lower) / span) * palette.length)
     return palette[Math.max(index, 0)]
   }
 }

--- a/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
@@ -34,9 +34,11 @@ export abstract class ScanningColorMapper extends ContinuousColorMapper {
         break
     }
 
-    // Adjust for zero-valued bins
-    const span = (edges.upper-edges.lower)
-    const index = Math.floor(((key-edges.lower) / span) * palette.length)
-    return palette[Math.max(index, 0)]
+    // Adjust for non-finite bins
+	const lower = edges.lower-2
+	const n = palette.length-1
+    const span = (n-lower)
+    const index = Math.floor(((key-lower) / span) * n)
+    return palette[index]
   }
 }

--- a/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
@@ -35,8 +35,8 @@ export abstract class ScanningColorMapper extends ContinuousColorMapper {
     }
 
     // Adjust for zero-valued bins
-    const span = (palette.length-edges.nonzero)
-    const index = Math.floor(((key - edges.nonzero) / span) * palette.length)
+    const span = (edges.upper-edges.lower)
+    const index = Math.floor(((key - edges.lower) / span) * palette.length)
     return palette[Math.max(index, 0)]
   }
 }

--- a/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
@@ -28,14 +28,14 @@ export abstract class ScanningColorMapper extends ContinuousColorMapper {
     let key = 0
     for (let i = 0, end = edges.binning.length-2; i < end; i++) {
       const low_edge = edges.binning[i]
-	  const high_edge = edges.binning[i+1]
+      const high_edge = edges.binning[i+1]
       key = i
       if ((d >= low_edge) && (d < high_edge))
         break
     }
 
     // Adjust for zero-valued bins
-	const lower = Math.max(edges.lower-1, 0)
+    const lower = Math.max(edges.lower-1, 0)
     const span = (edges.upper-lower)
     const index = Math.floor(((key-lower) / span) * palette.length)
     return palette[Math.max(index, 0)]

--- a/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
@@ -26,11 +26,10 @@ export abstract class ScanningColorMapper extends ContinuousColorMapper {
       return high_color
 
     let key = 0
-    for (let i = 0, end = edges.binning.length - 1; i < end; i++) {
-      const low_edge = edges.binning[i]
-      const high_edge = edges.binning[i+1]
-      key = i
-      if ((d >= low_edge) && (d < high_edge))
+    for (let i = 1, end = edges.binning.length; i < end; i++) {
+      const high_edge = edges.binning[i]
+      key = i-1
+      if (d < high_edge)
         break
     }
 

--- a/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
@@ -1,7 +1,6 @@
 import {ContinuousColorMapper} from "./continuous_color_mapper"
 import {Arrayable} from "core/types"
 import * as p from "core/properties"
-import {assert} from "core/util/assert"
 
 export namespace ScanningColorMapper {
   export type Attrs = p.AttrsOf<Props>
@@ -20,20 +19,19 @@ export abstract class ScanningColorMapper extends ContinuousColorMapper {
 
   metrics: {min: number, max: number, binning: Arrayable<number>}
 
-  protected cmap<T>(d: number, palette: Arrayable<T>, low_color: T, high_color: T, edges: Arrayable<number>): T {
-    assert(edges.length > 0)
+    protected cmap<T>(d: number, palette: Arrayable<T>, low_color: T, high_color: T, edges: any): T {
 
-    if (d < edges[0]) {
+    if (d < edges.binning[0]) {
       return low_color
     }
-    if (d > edges[edges.length-1]) {
+    if (d > edges.binning[edges.binning.length-1]) {
       return high_color
     }
 
     let key = 0
-    for (let i = 0, end = edges.length - 2; i < end; i++) {
-      const low_edge = edges[i]
-      const high_edge = edges[i+1]
+    for (let i = 0, end = edges.binning.length - 2; i < end; i++) {
+      const low_edge = edges.binning[i]
+      const high_edge = edges.binning[i+1]
       key = i
       if (low_edge <= d && d < high_edge) {
         break

--- a/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
@@ -26,10 +26,11 @@ export abstract class ScanningColorMapper extends ContinuousColorMapper {
       return high_color
 
     let key = 0
-    for (let i = 1, end = edges.binning.length; i < end; i++) {
-      const high_edge = edges.binning[i]
-      key = i-1
-      if (d < high_edge)
+    for (let i = 0, end = edges.binning.length-2; i < end; i++) {
+      const low_edge = edges.binning[i]
+	  const high_edge = edges.binning[i+1]
+      key = i
+      if ((d >= low_edge) && (d < high_edge))
         break
     }
 

--- a/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
@@ -1,5 +1,6 @@
 import {ContinuousColorMapper} from "./continuous_color_mapper"
 import {Arrayable} from "core/types"
+import {left_edge_index} from "core/util/arrayable"
 import * as p from "core/properties"
 
 export namespace ScanningColorMapper {
@@ -25,15 +26,7 @@ export abstract class ScanningColorMapper extends ContinuousColorMapper {
     if (d > edges.binning[edges.binning.length-1])
       return high_color
 
-    let key = 0
-    for (let i = 0, end = edges.binning.length-2; i < end; i++) {
-      const low_edge = edges.binning[i]
-      const high_edge = edges.binning[i+1]
-      key = i
-      if ((d >= low_edge) && (d < high_edge))
-        break
-    }
-
+	const key = left_edge_index(d, edges.binning)
     return palette[key]
   }
 }

--- a/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
@@ -19,24 +19,24 @@ export abstract class ScanningColorMapper extends ContinuousColorMapper {
 
   metrics: {min: number, max: number, binning: Arrayable<number>}
 
-    protected cmap<T>(d: number, palette: Arrayable<T>, low_color: T, high_color: T, edges: any): T {
-
-    if (d < edges.binning[0]) {
+  protected cmap<T>(d: number, palette: Arrayable<T>, low_color: T, high_color: T, edges: any): T {
+    if (d < edges.binning[0])
       return low_color
-    }
-    if (d > edges.binning[edges.binning.length-1]) {
+    if (d > edges.binning[edges.binning.length-1])
       return high_color
-    }
 
     let key = 0
-    for (let i = 0, end = edges.binning.length - 2; i < end; i++) {
+    for (let i = 0, end = edges.binning.length - 1; i < end; i++) {
       const low_edge = edges.binning[i]
       const high_edge = edges.binning[i+1]
       key = i
-      if (low_edge <= d && d < high_edge) {
+      if ((d >= low_edge) && (d < high_edge))
         break
-      }
     }
-    return palette[key]
+
+    // Adjust for zero-valued bins
+    const span = (palette.length-edges.nonzero)
+    const index = Math.floor(((key - edges.nonzero) / span) * palette.length)
+    return palette[Math.max(index, 0)]
   }
 }

--- a/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
@@ -35,8 +35,9 @@ export abstract class ScanningColorMapper extends ContinuousColorMapper {
     }
 
     // Adjust for zero-valued bins
-    const span = (edges.upper-edges.lower)
-    const index = Math.floor(((key - edges.lower) / span) * palette.length)
+	const lower = Math.max(edges.lower-1, 0)
+    const span = (edges.upper-lower)
+    const index = Math.floor(((key-lower) / span) * palette.length)
     return palette[Math.max(index, 0)]
   }
 }

--- a/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
@@ -34,10 +34,6 @@ export abstract class ScanningColorMapper extends ContinuousColorMapper {
         break
     }
 
-    // Adjust for non-finite bins
-	const n = palette.length-1
-    const span = (n-edges.lower)
-    const index = Math.floor(((key-edges.lower) / span) * n)
-	return palette[Math.max(index, 0)]
+    return palette[key]
   }
 }


### PR DESCRIPTION
Continues the incomplete work from #8765. This PR is currently working but a few important issues need to be addressed so it should be considered WIP. This PR is branched off @mattpap's work which will allow the colormapping to dynamically update in response to viewport and selection events.

### Problem being addressed 

PR #8765 attempted to bring the functionality of datashader's histogram equalization (originally from scikit image) to Bokeh. While a lot of work was done in that PR to port the algorithm as closely as possible to Typescript with some success, the PR did not achieve the correct mapping as the transform applied by datashader and required by Bokeh for colormapping are two different things.

The datashader (and scikit image) algorithm are designed to distort the *image data* while the goal here is to supply an appropriately distorted *colormap*. This is crucial as inspection of the data with say the Bokeh hover tool should reveal the true data values, not some distorted representation of it.

These two transforms are in a sense inverse mappings: the eqhist algorithms on exponentially distributed data input effectively acts like a logarithmic transform to flatten it. Trying to achieve the same visual representation of this data after eqhist requires a colorbar where the bins grow exponentially so that a wide range of large values map to the same color. Of course this is just an illustration: the difficulty is that the data can have *any* distribution that needs to be equalized.

Figuring out this reverse mapping was quite tricky and there are still some issues to address (described below) but this PR does show one approach that is based off the original datashader/scikit image algorithm (which is much faster than a completely naive algorithm). The mapping process should be quick as it operates in the space of the color palette (e.g 256 color bins instead of the NxM samples of the input image).


### Matplotlib reference (eqhist applied to the data):

![image](https://user-images.githubusercontent.com/890576/85988789-2d647980-b9b5-11ea-93f3-b2dd5f9ac294.png)

Linear colormap on the left, eqhist on the right.

### Output from this PR

![image](https://user-images.githubusercontent.com/890576/85988458-a6af9c80-b9b4-11ea-96b3-957d559a8a53.png)

Linear colormap on the left, eqhist on the right.

## Open issues

The biggest problem is that although the core eqhist transform *should* be 1-to-1 i.e monotonically increasing input *should* map to monotonically increasing output. However, both in the Python and Javascript implementations (including the original datashader code), two *different input* values, say **A** and **B** can map to the *same* output value, say **A'**. I believe that in the mathematic ideal, everything is correct but somehow, either due to finite input samples or floating point precision issues, the CDF based algorithm has this problem in practice.

This means that bin edges passed in to the algorithm can result in zero width bins which then result in zero division errors when applying the inverse transform. These zero width bins are conceptually problematic and shouldn't ever appear even in the base Python algorithm, but they do. As a bin of zero width has no information inside it, no inverse transform will be able to handle them.

This PR does two things to try to alleviate this issue:

1. Merge histogram bins with zero counts before computing the CDF so all bins have at least one sample (now the bin sizes will vary). This helps avoid flat portions of the CDF curve which would result in zero bin width during interpolation. In my tests  in Python (so far) this doesn't affect the visual output but I need to check whether this has an effect if the number of sample values is sparse.
2. Trim off problematic zero-width bins (and edges > 1) off the tail boundary. In this PR this is done by removing edges `> 0.999` (which is close to the end of the required distribution which ends at 1.0). Presumably there is a similar potential issue at the lower boundary. There is a related problem after interpolation with `np.interp`. 

These changes will need to be considered and justified carefully. Meanwhile, where is one issue I do know how to fix which involves mapping bin centers back to edges (which hopefully will close the remaining visible gap between the Bokeh implementation and the matplotlib reference).


### TODO

Before a detailed code review, these items need to be addressed:

- [ ] Fix the edge distribution by mapping palette bin centers back to edges.
- [ ] Remove zero width bins after interpolation in a more principled way (slicing off the end won't help if there are zero width bins in the middle).
- [ ] Figure out how to handle edges that are slightly greater than 1.0 after interpolation.
- [ ] Decide whether dropping zero counts is ok for the CDF and test with data with sparse value distributions.
- [ ] Decide on how to address boundary issues after interpolation correctly.
- [ ] Testing