### PR TITLE
ClientSession: Add different error messages (Close #3653)

### DIFF
--- a/bokeh/client/connection.py
+++ b/bokeh/client/connection.py
@@ -112,16 +112,18 @@ class ClientConnection(object):
 
     @property
     def error_code(self):
-        ''' If there was an error that caused a disconnect,
-        this property holds the error id. 0 otherwise. '''
+        ''' If there was an error that caused a disconnect, this property holds
+        the error code. None otherwise.
+
+        '''
         if not isinstance(self._state, DISCONNECTED):
             return 0
         return self._state.error_code
 
     @property
     def error_detail(self):
-        ''' If there was an error that caused a disconnect,
-        this property holds the error detail. Empty string otherwise.
+        ''' If there was an error that caused a disconnect, this property holds
+        the error detail. Empty string otherwise.
 
         '''
         if not isinstance(self._state, DISCONNECTED):

--- a/bokeh/client/connection.py
+++ b/bokeh/client/connection.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # External imports
-from tornado.httpclient import HTTPRequest, HTTPClientError
+from tornado.httpclient import HTTPClientError, HTTPRequest
 from tornado.ioloop import IOLoop
 from tornado.websocket import WebSocketError, websocket_connect
 
@@ -36,10 +36,10 @@ from .states import (
     CONNECTED_AFTER_ACK,
     CONNECTED_BEFORE_ACK,
     DISCONNECTED,
+    DISCONNECTED_HTTP_ERROR,
+    DISCONNECTED_NETWORK_ERROR,
     NOT_YET_CONNECTED,
     WAITING_FOR_REPLY,
-    DISCONNECTED_NETWORK_ERROR,
-    DISCONNECTED_HTTP_ERROR
 )
 from .websocket import WebSocketClientConnectionWrapper
 
@@ -116,7 +116,7 @@ class ClientConnection(object):
     def error_msg(self):
         ''' If there was an error that caused a disconnect,
         this property holds the error message. Empty string otherwise.
-        
+
         '''
         if not isinstance(self._state, DISCONNECTED):
             return ""
@@ -126,7 +126,7 @@ class ClientConnection(object):
     def is_http_error(self):
         ''' Was the reason for the disconnect an HTTP error? '''
         return isinstance(self._state, DISCONNECTED_HTTP_ERROR)
-    
+
     @property
     def is_network_error(self):
         ''' Was the reason for the disconnect a Networ error? '''

--- a/bokeh/client/connection.py
+++ b/bokeh/client/connection.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # External imports
-from tornado.httpclient import HTTPRequest
+from tornado.httpclient import HTTPRequest, HTTPClientError
 from tornado.ioloop import IOLoop
 from tornado.websocket import WebSocketError, websocket_connect
 
@@ -38,6 +38,8 @@ from .states import (
     DISCONNECTED,
     NOT_YET_CONNECTED,
     WAITING_FOR_REPLY,
+    DISCONNECTED_NETWORK_ERROR,
+    DISCONNECTED_HTTP_ERROR
 )
 from .websocket import WebSocketClientConnectionWrapper
 
@@ -101,6 +103,34 @@ class ClientConnection(object):
     def url(self):
         ''' The URL of the websocket this Connection is to. '''
         return self._url
+
+    @property
+    def error_id(self):
+        ''' If there was an error that caused a disconnect,
+        this property holds the error id. 0 otherwise. '''
+        if not isinstance(self._state, DISCONNECTED):
+            return 0
+        return self._state.error_id
+
+    @property
+    def error_msg(self):
+        ''' If there was an error that caused a disconnect,
+        this property holds the error message. Empty string otherwise.
+        
+        '''
+        if not isinstance(self._state, DISCONNECTED):
+            return ""
+        return self._state.error_msg
+
+    @property
+    def is_http_error(self):
+        ''' Was the reason for the disconnect an HTTP error? '''
+        return isinstance(self._state, DISCONNECTED_HTTP_ERROR)
+    
+    @property
+    def is_network_error(self):
+        ''' Was the reason for the disconnect a Networ error? '''
+        return isinstance(self._state, DISCONNECTED_NETWORK_ERROR)
 
     # Internal methods --------------------------------------------------------
 
@@ -240,18 +270,21 @@ class ClientConnection(object):
         try:
             socket = await websocket_connect(request, subprotocols=["bokeh", self._session.token])
             self._socket = WebSocketClientConnectionWrapper(socket)
+        except HTTPClientError as e:
+            await self._transition_to_disconnected(DISCONNECTED_HTTP_ERROR(e.code, e.message))
+            return
         except Exception as e:
             log.info("Failed to connect to server: %r", e)
 
         if self._socket is None:
-            await self._transition_to_disconnected()
+            await self._transition_to_disconnected(DISCONNECTED_NETWORK_ERROR(-1, "Socket invalid."))
         else:
             await self._transition(CONNECTED_BEFORE_ACK())
 
     async def _handle_messages(self):
         message = await self._pop_message()
         if message is None:
-            await self._transition_to_disconnected()
+            await self._transition_to_disconnected(DISCONNECTED_HTTP_ERROR(500, "Internal server error."))
         else:
             if message.msgtype == 'PATCH-DOC':
                 log.debug("Got PATCH-DOC, applying to session")
@@ -357,9 +390,9 @@ class ClientConnection(object):
         self._state = new_state
         await self._next()
 
-    async def _transition_to_disconnected(self):
+    async def _transition_to_disconnected(self, dis_state):
         self._tell_session_about_disconnect()
-        await self._transition(DISCONNECTED())
+        await self._transition(dis_state)
 
     async def _wait_for_ack(self):
         message = await self._pop_message()
@@ -367,7 +400,7 @@ class ClientConnection(object):
             log.debug("Received %r", message)
             await self._transition(CONNECTED_AFTER_ACK())
         elif message is None:
-            await self._transition_to_disconnected()
+            await self._transition_to_disconnected(DISCONNECTED_HTTP_ERROR(500, "Internal server error."))
         else:
             raise ProtocolError("Received %r instead of ACK" % message)
 

--- a/bokeh/client/session.py
+++ b/bokeh/client/session.py
@@ -366,8 +366,6 @@ class ClientSession(object):
                 if self.error_code == 404:
                     raise IOError("Check your application path! The given Path is not valid: {}".format(self.url))
                 raise IOError("We received an HTTP-Error. Disconnected with error code: {}, given message: {}".format(self.error_id, self.error_message))
-            #elif self.error_reason is ErrorReason.NETWORK_ERROR:
-            #default:
             raise IOError("We failed to connect to the server (to start the server, try the 'bokeh serve' command)")
 
 

--- a/bokeh/client/session.py
+++ b/bokeh/client/session.py
@@ -293,7 +293,7 @@ class ClientSession(object):
     @property
     def is_http_error(self):
         return self._connection.is_http_error
-        
+
     @property
     def error_id(self):
         return self._connection.error_id
@@ -351,14 +351,14 @@ class ClientSession(object):
         self._connection.force_roundtrip()
 
     def check_connection_errors(self):
-        ''' Raises an error, when the connection could not have been 
-        established. 
-        
+        ''' Raises an error, when the connection could not have been
+        established.
+
         Should be used, after a call to connect.
 
         Returns:
             None
-        
+
         '''
         if not self.connected:
             if self.is_http_error:
@@ -366,7 +366,7 @@ class ClientSession(object):
                     raise IOError("Check your application path! The given Path is not valid: {}".format(self.url))
                 #default http_error:
                 raise IOError("We received an HTTP-Error. Disconnected with error code: {}, given message: {}".format(self.error_id, self.error_message))
-                
+
             #elif self.is_network_error:
             #default:
             raise IOError("We failed to connect to the server (to start the server, try the 'bokeh serve' command)")

--- a/bokeh/client/session.py
+++ b/bokeh/client/session.py
@@ -417,8 +417,6 @@ class ClientSession(object):
 
         self.connect()
         self.check_connection_errors()
-        #if not self.connected:
-         #   raise IOError("Cannot push session document because we failed to connect to the server (to start the server, try the 'bokeh serve' command)")
         self._connection.push_doc(doc)
         if self._document is None:
             self._attach_document(doc)

--- a/bokeh/client/session.py
+++ b/bokeh/client/session.py
@@ -39,6 +39,7 @@ from ..document import Document
 from ..resources import DEFAULT_SERVER_HTTP_URL, _SessionCoordinates
 from ..util.browser import NEW_PARAM
 from ..util.token import generate_jwt_token, generate_session_id
+from .states import ErrorReason
 from .util import server_url_for_websocket_url, websocket_url_for_server_url
 
 #-----------------------------------------------------------------------------
@@ -291,16 +292,16 @@ class ClientSession(object):
         return self._connection.connected
 
     @property
-    def is_http_error(self):
-        return self._connection.is_http_error
+    def error_reason(self):
+        return self._connection.error_reason
 
     @property
-    def error_id(self):
-        return self._connection.error_id
+    def error_code(self):
+        return self._connection.error_code
 
     @property
-    def error_message(self):
-        return self._connection.error_message
+    def error_detail(self):
+        return self._connection.error_detail
 
     @property
     def url(self):
@@ -361,13 +362,11 @@ class ClientSession(object):
 
         '''
         if not self.connected:
-            if self.is_http_error:
-                if self.error_id == 404:
+            if self.error_reason is ErrorReason.HTTP_ERROR:
+                if self.error_code == 404:
                     raise IOError("Check your application path! The given Path is not valid: {}".format(self.url))
-                #default http_error:
                 raise IOError("We received an HTTP-Error. Disconnected with error code: {}, given message: {}".format(self.error_id, self.error_message))
-
-            #elif self.is_network_error:
+            #elif self.error_reason is ErrorReason.NETWORK_ERROR:
             #default:
             raise IOError("We failed to connect to the server (to start the server, try the 'bokeh serve' command)")
 

--- a/bokeh/client/states.py
+++ b/bokeh/client/states.py
@@ -19,6 +19,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from enum import Enum, auto
+
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
@@ -27,10 +30,9 @@ __all__ = (
     'CONNECTED_BEFORE_ACK',
     'CONNECTED_AFTER_ACK',
     'DISCONNECTED',
+    'ErrorReason',
     'NOT_YET_CONNECTED',
     'WAITING_FOR_REPLY',
-    'DISCONNECTED_NETWORK_ERROR',
-    'DISCONNECTED_HTTP_ERROR'
 )
 
 #-----------------------------------------------------------------------------
@@ -40,6 +42,11 @@ __all__ = (
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------
+
+class ErrorReason(Enum):
+    NO_ERROR        = auto()
+    HTTP_ERROR      = auto()
+    NETWORK_ERROR   = auto()
 
 class NOT_YET_CONNECTED(object):
     ''' The ``ClientConnection`` is not yet connected.
@@ -70,49 +77,39 @@ class CONNECTED_AFTER_ACK(object):
 class DISCONNECTED(object):
     ''' The ``ClientConnection`` was connected to a Bokeh server, but is
     now disconnected.
-    The reason, why the connection has been closed is unknown.
 
     '''
-    def __init__(self):
-        self._errid = 0
-        self._message = ""
 
-    @property
-    def error_id(self):
-        ''' Holds the error id.
+    def __init__(self, reason=ErrorReason.NO_ERROR, error_code=0, error_detail=""):
+        ''' Constructs a DISCONNECT-State with given reason (``ErrorReason`` enum),
+        error id and additional infromation provided as string.
+
         '''
-        return self._errid
+        self._error_code = error_code
+        self._error_detail = error_detail
+        self._error_reason = reason
+
 
     @property
-    def error_message(self):
+    def error_reason(self):
+        ''' The reason for the error encoded as an enumeration value.
+        '''
+        return self._error_reason
+
+    @property
+    def error_code(self):
+        ''' Holds the error code.
+        '''
+        return self._error_code
+
+    @property
+    def error_detail(self):
         ''' Holds the error message, if any.
         '''
-        return self._message
+        return self._error_detail
 
     async def run(self, connection):
         return None
-
-class DISCONNECTED_NETWORK_ERROR(DISCONNECTED):
-    ''' The ``ClientConnection`` was connected to a Bokeh server, but is
-    now disconnected.
-    An network error was the cause of the disconnection.
-
-    '''
-    def __init__(self, network_errid, error_message ):
-            super().__init__()
-            self._errid = network_errid
-            self._message = error_message
-
-class DISCONNECTED_HTTP_ERROR(DISCONNECTED):
-    ''' The ``ClientConnection`` was connected to a Bokeh server, but is
-    now disconnected.
-    An HTTP error was the cause of the disconnection.
-
-    '''
-    def __init__(self, http_errid, http_message):
-        super().__init__()
-        self._errid    = http_errid
-        self._message  = http_message
 
 class WAITING_FOR_REPLY(object):
     ''' The ``ClientConnection`` has sent a message to the Bokeh Server which

--- a/bokeh/client/states.py
+++ b/bokeh/client/states.py
@@ -29,6 +29,8 @@ __all__ = (
     'DISCONNECTED',
     'NOT_YET_CONNECTED',
     'WAITING_FOR_REPLY',
+    'DISCONNECTED_NETWORK_ERROR',
+    'DISCONNECTED_HTTP_ERROR'
 )
 
 #-----------------------------------------------------------------------------
@@ -68,11 +70,49 @@ class CONNECTED_AFTER_ACK(object):
 class DISCONNECTED(object):
     ''' The ``ClientConnection`` was connected to a Bokeh server, but is
     now disconnected.
+    The reason, why the connection has been closed is unknown.
 
     '''
+    def __init__(self):
+        self._errid = 0
+        self._message = ""
+
+    @property
+    def error_id(self):
+        ''' Holds the error id.
+        '''
+        return self._errid
+
+    @property
+    def error_message(self):
+        ''' Holds the error message, if any.
+        '''
+        return self._message
 
     async def run(self, connection):
         return None
+
+class DISCONNECTED_NETWORK_ERROR(DISCONNECTED):
+    ''' The ``ClientConnection`` was connected to a Bokeh server, but is
+    now disconnected.
+    An network error was the cause of the disconnection.
+
+    '''
+    def __init__(self, network_errid, error_message ):
+            super().__init__()
+            self._errid = network_errid
+            self._message = error_message
+
+class DISCONNECTED_HTTP_ERROR(DISCONNECTED):
+    ''' The ``ClientConnection`` was connected to a Bokeh server, but is
+    now disconnected.
+    An HTTP error was the cause of the disconnection.
+
+    '''
+    def __init__(self, http_errid, http_message):
+        super().__init__()
+        self._errid    = http_errid
+        self._message  = http_message
 
 class WAITING_FOR_REPLY(object):
     ''' The ``ClientConnection`` has sent a message to the Bokeh Server which

--- a/bokeh/client/states.py
+++ b/bokeh/client/states.py
@@ -80,9 +80,9 @@ class DISCONNECTED(object):
 
     '''
 
-    def __init__(self, reason=ErrorReason.NO_ERROR, error_code=0, error_detail=""):
-        ''' Constructs a DISCONNECT-State with given reason (``ErrorReason`` enum),
-        error id and additional infromation provided as string.
+    def __init__(self, reason=ErrorReason.NO_ERROR, error_code=None, error_detail=""):
+        ''' Constructs a DISCONNECT-State with given reason (``ErrorReason``
+        enum), error id and additional information provided as string.
 
         '''
         self._error_code = error_code
@@ -93,18 +93,21 @@ class DISCONNECTED(object):
     @property
     def error_reason(self):
         ''' The reason for the error encoded as an enumeration value.
+
         '''
         return self._error_reason
 
     @property
     def error_code(self):
-        ''' Holds the error code.
+        ''' Holds the error code, if any. None otherwise.
+
         '''
         return self._error_code
 
     @property
     def error_detail(self):
-        ''' Holds the error message, if any.
+        ''' Holds the error message, if any. Empty string otherwise.
+
         '''
         return self._error_detail
 

--- a/tests/unit/bokeh/test_client_server.py
+++ b/tests/unit/bokeh/test_client_server.py
@@ -288,6 +288,14 @@ class TestClientServer(object):
             client_session._loop_until_closed()
             assert not client_session.connected
 
+    def test__check_error_404(self, ManagedServerLoop) -> None:
+        application = Application()
+        with ManagedServerLoop(application) as server:
+            with pytest.raises(IOError):
+                client_session = pull_session(session_id='test__check_error_404',
+                                              url=url(server) + 'file_not_found',
+                                              io_loop=server.io_loop)
+
     def test_request_server_info(self, ManagedServerLoop) -> None:
         application = Application()
         with ManagedServerLoop(application) as server:
@@ -988,7 +996,6 @@ def test_unit_spec_changes_do_not_boomerang(monkeypatch, ManagedServerLoop) -> N
         client_session._loop_until_closed()
         assert not client_session.connected
         server.unlisten() # clean up so next test can run
-
 
 @patch('bokeh.client.session.show_session')
 def test_session_show_adds_obj_to_curdoc_if_necessary(m) -> None:

--- a/tests/unit/bokeh/test_client_server.py
+++ b/tests/unit/bokeh/test_client_server.py
@@ -292,7 +292,7 @@ class TestClientServer(object):
         application = Application()
         with ManagedServerLoop(application) as server:
             with pytest.raises(IOError):
-                client_session = pull_session(session_id='test__check_error_404',
+                pull_session(session_id='test__check_error_404',
                                               url=url(server) + 'file_not_found',
                                               io_loop=server.io_loop)
 


### PR DESCRIPTION
As mentioned in issue #3653 the error messages from
ClientSession.pull and ClientSession.push did not take the cause of the
connection loss into account.

Therefore we add different Disconnected States to the client/states.py
to distinguish the reason of the connection loss and store information
about the error itself (error id, error message). Those information is
accessible through the ClientConnection class and is used in the
ClientSession to create more descriptive error messages.

- [x] issues: fixes #3653 
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
