### PR TITLE
Misc warnings cleanup

### DIFF
--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -82,6 +82,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import warnings
 from os import getenv
 from os.path import basename, dirname, join
 from uuid import uuid4
@@ -98,6 +99,7 @@ from sphinx.util.nodes import set_source_info
 from bokeh.document import Document
 from bokeh.embed import autoload_static
 from bokeh.model import Model
+from bokeh.util.warnings import BokehDeprecationWarning
 
 # Bokeh imports
 from .example_handler import ExampleHandler
@@ -241,7 +243,15 @@ def _process_script(source, filename, env, js_name, use_relative_paths=False):
 
     c = ExampleHandler(source=run_source, filename=filename)
     d = Document()
-    c.modify_document(d)
+
+    # We may need to instantiate deprecated objects as part of documenting
+    # them in the reference guide. Suppress any warnings here to keep the
+    # docs build clean just for this case
+    with warnings.catch_warnings():
+        if "reference" in env.docname:
+            warnings.filterwarnings("ignore", category=BokehDeprecationWarning)
+        c.modify_document(d)
+
     if c.error:
         raise RuntimeError(c.error_detail)
 

--- a/bokeh/sphinxext/bokeh_prop.py
+++ b/bokeh/sphinxext/bokeh_prop.py
@@ -53,10 +53,14 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import importlib
 import textwrap
+import warnings
 
 # External imports
 from docutils.parsers.rst.directives import unchanged
 from sphinx.errors import SphinxError
+
+# Bokeh imports
+from bokeh.util.warnings import BokehDeprecationWarning
 
 # Bokeh imports
 from .bokeh_directive import BokehDirective
@@ -101,7 +105,12 @@ class BokehPropDirective(BokehDirective):
         if model is None:
             raise SphinxError("Unable to generate reference docs for %s, no model '%s' in %s" % (self.arguments[0], model_name, self.options['module']))
 
-        model_obj = model()
+        # We may need to instantiate deprecated objects as part of documenting
+        # them in the reference guide. Suppress any warnings here to keep the
+        # docs build clean just for this case
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=BokehDeprecationWarning)
+            model_obj = model()
 
         try:
             descriptor = getattr(model_obj.__class__, prop_name)

--- a/bokehjs/src/lib/core/util/pretty.ts
+++ b/bokehjs/src/lib/core/util/pretty.ts
@@ -59,7 +59,7 @@ export class Printer {
   }
 
   string(val: string): string {
-    return `"${val.replace(/'/g, "\\'")}"`
+    return `"${val.replace(/'/g, "\\'")}"`  // lgtm [js/incomplete-sanitization]
   }
 
   array(obj: Iterable<unknown>): string {


### PR DESCRIPTION
This silences deprecation warnings in the docs build that show up when documenting deprecated things in the reference guide (cc @p-himik I think you had asked about this). My position is that once something is deprecated, it should generally *only* be documented in the reference guide, so an attempt has been made to allow deprecation warnings to still show in other cases. As of this PR, the docs build is 100% clean. 

This also clears the [one LGTM warning we currently have](https://lgtm.com/projects/g/bokeh/bokeh/snapshot/fe2ff065437c33d13b6916e1a679ab1be9bba816/files/bokehjs/src/lib/core/util/pretty.ts?sort=name&dir=ASC&mode=heatmap#xea8aa1d026c79741:1) cc @mattpap I assume you know and intend things to be as they are in this case but noting, just in case. 