### PR TITLE
Add support for scalable text

### DIFF
--- a/bokeh/core/property/dataspec.py
+++ b/bokeh/core/property/dataspec.py
@@ -18,6 +18,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+import numbers
+
 # Bokeh imports
 from ... import colors
 from ...util.serialization import convert_datetime_type, convert_timedelta_type
@@ -289,7 +292,11 @@ class FontSizeSpec(DataSpec):
         # We want to preserve existing semantics and be a little more restrictive. This
         # validations makes m.font_size = "" or m.font_size = "6" an error
         super().validate(value, detail)
-        if isinstance(value, str):
+
+        if isinstance(value, numbers.Real):
+            if not (0 <= value <= 100):
+                raise ValueError(f"{value} is not a valid font size")
+        elif isinstance(value, str):
             if len(value) == 0 or value[0].isdigit() and FontSize._font_size_re.match(value) is None:
                 msg = "" if not detail else "%r is not a valid font size value" % value
                 raise ValueError(msg)

--- a/bokeh/core/property/visual.py
+++ b/bokeh/core/property/visual.py
@@ -21,6 +21,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import base64
 import datetime  # lgtm [py/import-and-import-from]
+import numbers
 import re
 from io import BytesIO
 
@@ -104,14 +105,20 @@ class DashPattern(Either):
     def _sphinx_type(self):
         return self._sphinx_prop_link()
 
-class FontSize(String):
+class FontSize(Either):
 
     _font_size_re = re.compile(r"^[0-9]+(.[0-9]+)?(%|em|ex|ch|ic|rem|vw|vh|vi|vb|vmin|vmax|cm|mm|q|in|pc|pt|px)$", re.I)
+
+    def __init__(self, default=None, help=None):
+        super().__init__(String, Float, default=default, help=help)
 
     def validate(self, value, detail=True):
         super().validate(value, detail)
 
-        if isinstance(value, str):
+        if isinstance(value, numbers.Real):
+            if not (0 <= value <= 100):
+                raise ValueError(f"{value} is not a valid font size")
+        elif isinstance(value, str):
             if len(value) == 0:
                 msg = "" if not detail else "empty string is not a valid font size value"
                 raise ValueError(msg)

--- a/bokehjs/src/lib/core/properties.ts
+++ b/bokehjs/src/lib/core/properties.ts
@@ -218,7 +218,7 @@ export class NullString extends Property<string | null> {
   }
 }
 
-export class FontSize extends String {}
+export class FontSize extends Any {}
 
 export class Font extends String {
   _default_override(): string | undefined {
@@ -457,7 +457,7 @@ export class CoordinateSeqSpec extends DataSpec<number[] | Factor[]> {}
 
 export class ColorSpec extends DataSpec<types.Color | null> {}
 
-export class FontSizeSpec extends DataSpec<string> {}
+export class FontSizeSpec extends DataSpec<string | number> {}
 
 export class MarkerSpec extends DataSpec<string> {}
 

--- a/bokehjs/src/lib/core/property_mixins.ts
+++ b/bokehjs/src/lib/core/property_mixins.ts
@@ -3,6 +3,8 @@ import {Color} from "./types"
 import {LineJoin, LineCap, FontStyle, HatchPatternType, TextAlign, TextBaseline} from "./enums"
 import {Texture} from "models/textures/texture"
 
+export type FontSize = string | number
+
 export type HatchPattern = HatchPatternType | string
 export type HatchExtra = {[key: string]: Texture}
 
@@ -36,7 +38,7 @@ export type Text = {
   text_color: p.Property<Color | null>
   text_alpha: p.Property<number>
   text_font: p.Property<string>
-  text_font_size: p.Property<string>
+  text_font_size: p.Property<FontSize>
   text_font_style: p.Property<FontStyle>
   text_align: p.Property<TextAlign>
   text_baseline: p.Property<TextBaseline>
@@ -108,7 +110,7 @@ export type TextScalar = {
   text_color: p.ScalarSpec<Color | null>
   text_alpha: p.ScalarSpec<number>
   text_font: p.ScalarSpec<string>
-  text_font_size: p.ScalarSpec<string>
+  text_font_size: p.ScalarSpec<FontSize>
   text_font_style: p.ScalarSpec<FontStyle>
   text_align: p.ScalarSpec<TextAlign>
   text_baseline: p.ScalarSpec<TextBaseline>
@@ -180,7 +182,7 @@ export type TextVector = {
   text_color: p.VectorSpec<Color | null>
   text_alpha: p.VectorSpec<number>
   text_font: p.Property<string>
-  text_font_size: p.VectorSpec<string>
+  text_font_size: p.VectorSpec<FontSize>
   text_font_style: p.Property<FontStyle>
   text_align: p.Property<TextAlign>
   text_baseline: p.Property<TextBaseline>

--- a/bokehjs/src/lib/models/annotations/color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/color_bar.ts
@@ -307,6 +307,9 @@ export class ColorBarView extends AnnotationView {
     const formatted_labels = tick_info.labels.major
 
     this.visuals.major_label_text.set_value(ctx)
+    const viewport = this.plot_view.layout.bbox
+    const angle = this.model.orientation == "horizontal" ? 0 : Math.PI/2
+    this.visuals.major_label_text.set_font(ctx, viewport, angle)
 
     ctx.save()
     ctx.translate(x_offset + x_standoff, y_offset + y_standoff)
@@ -324,6 +327,8 @@ export class ColorBarView extends AnnotationView {
 
     ctx.save()
     this.visuals.title_text.set_value(ctx)
+    const viewport = this.plot_view.layout.bbox
+    this.visuals.title_text.set_font(ctx, viewport, 0)
     ctx.fillText(this.model.title, 0, -this.model.title_standoff)
     ctx.restore()
   }
@@ -340,9 +345,11 @@ export class ColorBarView extends AnnotationView {
         case "vertical":
           label_extent = max((major_labels.map((label) => ctx.measureText(label.toString()).width)))
           break
-        case "horizontal":
-          label_extent = text_util.measure_font(this.visuals.major_label_text.font_value()).height
+        case "horizontal": {
+          const viewport = this.plot_view.layout.bbox
+          label_extent = text_util.measure_font(this.visuals.major_label_text.font_value(viewport)).height
           break
+        }
       }
 
       label_extent += this.model.label_standoff

--- a/bokehjs/src/lib/models/annotations/label.ts
+++ b/bokehjs/src/lib/models/annotations/label.ts
@@ -16,6 +16,8 @@ export class LabelView extends TextAnnotationView {
   protected _get_size(): Size {
     const {ctx} = this.layer
     this.visuals.text.set_value(ctx)
+    const viewport = this.plot_view.layout.bbox
+    this.visuals.text.set_font(ctx, viewport, this.model.angle)
 
     const {width, ascent} = ctx.measureText(this.model.text)
     return {width, height: ascent}

--- a/bokehjs/src/lib/models/annotations/label_set.ts
+++ b/bokehjs/src/lib/models/annotations/label_set.ts
@@ -112,7 +112,9 @@ export class LabelSetView extends TextAnnotationView {
 
   protected _v_canvas_text(ctx: Context2d, i: number, text: string, sx: number, sy: number, angle: number): void {
     this.visuals.text.set_vectorize(ctx, i)
-    const bbox_dims = this._calculate_bounding_box_dimensions(ctx, text)
+    const viewport = this.plot_view.layout.bbox
+    const font = this.visuals.text.set_v_font(ctx, i, viewport, angle)
+    const bbox_dims = this._calculate_bounding_box_dimensions(ctx, text, font)
 
     ctx.save()
 
@@ -145,7 +147,9 @@ export class LabelSetView extends TextAnnotationView {
     el.textContent = text
 
     this.visuals.text.set_vectorize(ctx, i)
-    const bbox_dims = this._calculate_bounding_box_dimensions(ctx, text)
+    const viewport = this.plot_view.layout.bbox
+    const font = this.visuals.text.set_v_font(ctx, i, viewport, angle)
+    const bbox_dims = this._calculate_bounding_box_dimensions(ctx, text, font)
 
     // attempt to support vector-style ("8 4 8") line dashing for css mode
     const ld = this.visuals.border_line.line_dash.value()
@@ -159,7 +163,7 @@ export class LabelSetView extends TextAnnotationView {
     el.style.top = `${sy + bbox_dims[1]}px`
     el.style.color = `${this.visuals.text.text_color.value()}`
     el.style.opacity = `${this.visuals.text.text_alpha.value()}`
-    el.style.font = `${this.visuals.text.font_value()}`
+    el.style.font = font
     el.style.lineHeight = "normal"  // needed to prevent ipynb css override
 
     if (angle) {

--- a/bokehjs/src/lib/models/annotations/legend.ts
+++ b/bokehjs/src/lib/models/annotations/legend.ts
@@ -43,21 +43,25 @@ export class LegendView extends AnnotationView {
     const {glyph_height, glyph_width} = this.model
     const {label_height, label_width} = this.model
 
-    this.max_label_height = max(
-      [measure_font(this.visuals.label_text.font_value()).height, label_height, glyph_height],
-    )
+    const viewport = this.plot_view.layout.bbox
 
     // this is to measure text properties
     const {ctx} = this.layer
     ctx.save()
     this.visuals.label_text.set_value(ctx)
+    const label_font = this.visuals.label_text.set_font(ctx, viewport, 0)
     this.text_widths = new Map()
     for (const name of legend_names) {
       this.text_widths.set(name, max([ctx.measureText(name).width, label_width]))
     }
 
+    this.max_label_height = max(
+      [measure_font(label_font).height, label_height, glyph_height],
+    )
+
     this.visuals.title_text.set_value(ctx)
-    this.title_height = this.model.title ? measure_font(this.visuals.title_text.font_value()).height + this.model.title_standoff : 0
+    const title_font = this.visuals.title_text.set_font(ctx, viewport, 0)
+    this.title_height = this.model.title ? measure_font(title_font).height + this.model.title_standoff : 0
     this.title_width = this.model.title ? ctx.measureText(this.model.title).width : 0
 
     ctx.restore()

--- a/bokehjs/src/lib/models/annotations/text_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/text_annotation.ts
@@ -47,14 +47,14 @@ export abstract class TextAnnotationView extends AnnotationView {
     super.render()
   }
 
-  protected _calculate_text_dimensions(ctx: Context2d, text: string): [number, number] {
+  protected _calculate_text_dimensions(ctx: Context2d, text: string, font: string): [number, number] {
     const {width} = ctx.measureText(text)
-    const {height} = measure_font(this.visuals.text.font_value())
+    const {height} = measure_font(font)
     return [width, height]
   }
 
-  protected _calculate_bounding_box_dimensions(ctx: Context2d, text: string): [number, number, number, number] {
-    const [width, height] = this._calculate_text_dimensions(ctx, text)
+  protected _calculate_bounding_box_dimensions(ctx: Context2d, text: string, font: string): [number, number, number, number] {
+    const [width, height] = this._calculate_text_dimensions(ctx, text, font)
 
     let x_offset: number
     switch (ctx.textAlign) {
@@ -83,7 +83,9 @@ export abstract class TextAnnotationView extends AnnotationView {
 
   protected _canvas_text(ctx: Context2d, text: string, sx: number, sy: number, angle: number): void {
     this.visuals.text.set_value(ctx)
-    const bbox_dims = this._calculate_bounding_box_dimensions(ctx, text)
+    const viewport = this.plot_view.layout.bbox
+    const font = this.visuals.text.set_font(ctx, viewport, angle)
+    const bbox_dims = this._calculate_bounding_box_dimensions(ctx, text, font)
 
     ctx.save()
 
@@ -120,7 +122,9 @@ export abstract class TextAnnotationView extends AnnotationView {
     undisplay(el)
 
     this.visuals.text.set_value(ctx)
-    const bbox_dims = this._calculate_bounding_box_dimensions(ctx, text)
+    const viewport = this.plot_view.layout.bbox
+    const font = this.visuals.text.set_font(ctx, viewport, angle)
+    const bbox_dims = this._calculate_bounding_box_dimensions(ctx, text, font)
 
     // attempt to support vector string-style ("8 4 8") line dashing for css mode
     const ld = this.visuals.border_line.line_dash.value()
@@ -134,7 +138,7 @@ export abstract class TextAnnotationView extends AnnotationView {
     el.style.top = `${sy + bbox_dims[1]}px`
     el.style.color = `${this.visuals.text.text_color.value()}`
     el.style.opacity = `${this.visuals.text.text_alpha.value()}`
-    el.style.font = `${this.visuals.text.font_value()}`
+    el.style.font = font
     el.style.lineHeight = "normal" // needed to prevent ipynb css override
 
     if (angle) {

--- a/bokehjs/src/lib/models/annotations/title.ts
+++ b/bokehjs/src/lib/models/annotations/title.ts
@@ -91,7 +91,11 @@ export class TitleView extends TextAnnotationView {
     if (text == null || text.length == 0)
       return {width: 0, height: 0}
     else {
-      this.visuals.text.set_value(this.layer.ctx)
+      const {ctx} = this.layer
+      this.visuals.text.set_value(ctx)
+      const viewport = this.plot_view.layout.bbox
+      const angle = this.panel!.get_label_angle_heuristic("parallel")
+      this.visuals.text.set_font(ctx, viewport, angle)
       const {width, ascent} = this.layer.ctx.measureText(text)
       return {width, height: ascent * this.visuals.text.text_line_height.value() + 10}
     }

--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -218,14 +218,16 @@ export class AxisView extends GuideRendererView {
     const nxd = nx * (xoff + standoff)
     const nyd = ny * (yoff + standoff)
 
-    visuals.set_value(ctx)
-    this.panel.apply_label_text_heuristics(ctx, orient)
-
     let angle: number
     if (isString(orient))
       angle = this.panel.get_label_angle_heuristic(orient)
     else
       angle = -orient
+
+    visuals.set_value(ctx)
+    const viewport = this.plot_view.layout.bbox
+    visuals.set_font(ctx, viewport, angle)
+    this.panel.apply_label_text_heuristics(ctx, orient)
 
     for (let i = 0; i < sxs.length; i++) {
       const sx = Math.round(sxs[i] + nxd)

--- a/bokehjs/src/lib/models/glyphs/text.ts
+++ b/bokehjs/src/lib/models/glyphs/text.ts
@@ -41,23 +41,32 @@ export class TextView extends XYGlyphView {
   protected _render(ctx: Context2d, indices: number[], {sx, sy, _x_offset, _y_offset, _angle, _text}: TextData): void {
     this._sys = []
     this._sxs = []
+
     for (const i of indices) {
+      const angle = _angle[i]
+
       this._sxs[i] = []
       this._sys[i] = []
-      if (isNaN(sx[i] + sy[i] + _x_offset[i] + _y_offset[i] + _angle[i]) || _text[i] == null)
+
+      if (isNaN(sx[i] + sy[i] + _x_offset[i] + _y_offset[i] + angle) || _text[i] == null)
         continue
       if (this.visuals.text.doit) {
         const text = `${_text[i]}`
 
         ctx.save()
         ctx.translate(sx[i] + _x_offset[i], sy[i] + _y_offset[i])
-        ctx.rotate(_angle[i])
+        ctx.rotate(angle)
+
         this.visuals.text.set_vectorize(ctx, i)
 
-        const font = this.visuals.text.cache_select("font", i)
+        const viewport = this.renderer.plot_view.layout.bbox
+        const font = this.visuals.text.set_v_font(ctx, i, viewport, angle)
         const {height} = measure_font(font)
+
         const line_height = this.visuals.text.text_line_height.value()*height
         if (text.indexOf("\n") == -1) {
+          const metrics = ctx.measureText(text)
+          console.log(font, height, metrics)
           ctx.fillText(text, 0, 0)
           const x0 = sx[i] + _x_offset[i]
           const y0 = sy[i] + _y_offset[i]


### PR DESCRIPTION
This is an early WIP experiment that implements scalable text without depending on CSS support.

There are a few reasons why not to rely on CSS:

1. Support for `vh`, `vw`, `vb` and `vi` is spotty or non-existent (across supported browsers).
2. It's not clear what viewport or containing block means in the context of bokeh's components and supported embedding modes. Exposing CSS spec directly may expose internal implementation details (e.g. consider DOM layout vs. canvas based grid plots).
3. Integration with layout and reaction to viewport/block changes have to be done manually anyway.
4. Font metrics' caching.

fixes #9407