### PR TITLE
#8448 Fix typo "do no yet work" -> "do not yet work" in bokeh/sphinx/source/docs/user_guide/interaction/legends.rst

### DIFF
--- a/sphinx/source/docs/user_guide/embed.rst
+++ b/sphinx/source/docs/user_guide/embed.rst
@@ -104,7 +104,7 @@ Then the target id can be controlled on the JavaScript side:
     item = JSON.parse(item_text);
     Bokeh.embed.embed_item(item, "myplot");
 
-As a more complete example, it a Flask server may be configured to serve Bokeh
+As a more complete example, a Flask server may be configured to serve Bokeh
 JSON items from a */plot* endpoint:
 
 .. code-block:: python

--- a/sphinx/source/docs/user_guide/interaction/legends.rst
+++ b/sphinx/source/docs/user_guide/interaction/legends.rst
@@ -11,7 +11,7 @@ either ``"hide"`` or ``"mute"``.
 
 .. note::
     Interactive legend features currently work on "per-glyph" legends. Legends
-    that are created by specifying a column to automatically group do no yet
+    that are created by specifying a column to automatically group do not yet
     work with the features described below
 
 Hiding Glyphs

--- a/sphinx/source/docs/user_guide/interaction/legends.rst
+++ b/sphinx/source/docs/user_guide/interaction/legends.rst
@@ -10,9 +10,8 @@ corresponding glyph in a plot. These modes are activated by setting the
 either ``"hide"`` or ``"mute"``.
 
 .. note::
-    Interactive legend features currently work on "per-glyph" legends. Legends
-    that are created by specifying a column to automatically group do not yet
-    work with the features described below
+    Interactive legends only work on "per-glyph" legends. Grouped legends
+    do not yet support the features described below.
 
 Hiding Glyphs
 ~~~~~~~~~~~~~


### PR DESCRIPTION
This PR is intended to fix a typo found in `bokeh/sphinx/source/docs/user_guide/interaction/legends.rst`

It originally contained "automatically group do no yet work with the".
I have replaced it with "automatically group do not yet work with the".

This is intended to help with efforts in #8448.

Related issue: #8448