### PR TITLE
Add DocumentReady event

### DIFF
--- a/bokeh/document/document.py
+++ b/bokeh/document/document.py
@@ -48,7 +48,7 @@ from ..core.json_encoder import serialize_json
 from ..core.query import find
 from ..core.templates import FILE
 from ..core.validation import check_integrity
-from ..events import Event
+from ..events import DocumentEvent, Event, ModelEvent, _CONCRETE_EVENT_CLASSES
 from ..model import Model
 from ..themes import Theme, built_in_themes
 from ..themes import default as default_theme
@@ -113,6 +113,7 @@ class Document(object):
         self._all_models_by_name = MultiValuedDict()
         self._all_former_model_ids = set()
         self._callbacks = {}
+        self._event_callbacks = {}
         self._message_callbacks = {}
         self._session_destroyed_callbacks = set()
         self._session_callbacks = set()
@@ -352,6 +353,9 @@ class Document(object):
             subscribed = self._subscribed_models[event.event_name].copy()
             for model in subscribed:
                 model._trigger_event(event)
+
+        for cb in self._event_callbacks.get(event.event_name, []):
+            cb(event)
 
     def apply_json_patch(self, patch, setter=None):
         ''' Apply a JSON patch object and process any resulting events.
@@ -685,6 +689,26 @@ class Document(object):
         if message_callbacks is not None:
             for cb in message_callbacks:
                 cb(msg_data)
+
+    def on_event(self, event, *callbacks):
+        ''' Provide callbacks to invoke if a bokeh event is received.
+
+        '''
+        if not isinstance(event, str) and issubclass(event, Event):
+            event = event.event_name
+
+        if not issubclass(_CONCRETE_EVENT_CLASSES[event], DocumentEvent):
+            raise ValueError("Document.on_event may only be used to subscribe "
+                             "to events of type DocumentEvent. To subscribe "
+                             "to a ModelEvent use the Model.on_event method.")
+
+        for callback in callbacks:
+            _check_callback(callback, ('event',), what='Event callback')
+
+        if event not in self._event_callbacks:
+            self._event_callbacks[event] = [cb for cb in callbacks]
+        else:
+            self._event_callbacks[event].extend(callbacks)
 
     def on_change(self, *callbacks):
         ''' Provide callbacks to invoke if the document or any Model reachable

--- a/bokeh/document/document.py
+++ b/bokeh/document/document.py
@@ -48,7 +48,7 @@ from ..core.json_encoder import serialize_json
 from ..core.query import find
 from ..core.templates import FILE
 from ..core.validation import check_integrity
-from ..events import DocumentEvent, Event, ModelEvent, _CONCRETE_EVENT_CLASSES
+from ..events import _CONCRETE_EVENT_CLASSES, DocumentEvent, Event
 from ..model import Model
 from ..themes import Theme, built_in_themes
 from ..themes import default as default_theme

--- a/bokeh/events.py
+++ b/bokeh/events.py
@@ -180,7 +180,7 @@ class DocumentReady(DocumentEvent):
     event_name = 'document_ready'
 
 
-class ModelEvent(object):
+class ModelEvent(Event):
     ''' Base class for all Bokeh Model events.
 
     This base class is not typically useful to instantiate on its own.

--- a/bokeh/events.py
+++ b/bokeh/events.py
@@ -121,18 +121,6 @@ class Event(object):
         if hasattr(cls, "event_name"):
             _CONCRETE_EVENT_CLASSES[cls.event_name] = cls
 
-    def __init__(self, model):
-        ''' Create a new base event.
-
-        Args:
-
-            model (Model) : a Bokeh model to register event callbacks on
-
-        '''
-        self._model_id = None
-        if model is not None:
-            self._model_id = model.id
-
     @classmethod
     def decode_json(cls, dct):
         ''' Custom JSON decoder for Events.
@@ -168,11 +156,51 @@ class Event(object):
 
         event_values = dct['event_values']
         model_id = event_values.pop('model', {"id": None})["id"]
-        event = _CONCRETE_EVENT_CLASSES[event_name](model=None, **event_values)
-        event._model_id = model_id
+        event_cls = _CONCRETE_EVENT_CLASSES[event_name]
+        if issubclass(event_cls, ModelEvent):
+            event = event_cls(model=None, **event_values)
+            event._model_id = model_id
+        else:
+            event = event_cls(**event_values)
         return event
 
-class ButtonClick(Event):
+
+class DocumentEvent(Event):
+    ''' Base class for all Bokeh Document events.
+
+    This base class is not typically useful to instantiate on its own.
+
+    '''
+
+
+class DocumentReady(DocumentEvent):
+    ''' Announce when a Document is fully idle.
+
+    '''
+    event_name = 'document_ready'
+
+
+class ModelEvent(object):
+    ''' Base class for all Bokeh Model events.
+
+    This base class is not typically useful to instantiate on its own.
+
+    '''
+
+    def __init__(self, model):
+        ''' Create a new base event.
+
+        Args:
+
+            model (Model) : a Bokeh model to register event callbacks on
+
+        '''
+        self._model_id = None
+        if model is not None:
+            self._model_id = model.id
+
+
+class ButtonClick(ModelEvent):
     ''' Announce a button click event on a Bokeh button widget.
 
     '''
@@ -185,7 +213,7 @@ class ButtonClick(Event):
             raise ValueError(msg.format(clsname=self.__class__.__name__))
         super().__init__(model=model)
 
-class MenuItemClick(Event):
+class MenuItemClick(ModelEvent):
     ''' Announce a button click event on a Bokeh menu item.
 
     '''
@@ -195,7 +223,7 @@ class MenuItemClick(Event):
         self.item = item
         super().__init__(model=model)
 
-class PlotEvent(Event):
+class PlotEvent(ModelEvent):
     ''' The base class for all events applicable to Plot models.
 
     '''

--- a/bokehjs/src/lib/core/bokeh_events.ts
+++ b/bokehjs/src/lib/core/bokeh_events.ts
@@ -13,7 +13,6 @@ function event(event_name: string) {
 }
 
 export abstract class BokehEvent {
-
   /* prototype */ event_name: string
 
   to_json(): EventJSON {
@@ -21,9 +20,7 @@ export abstract class BokehEvent {
     return {event_name, event_values: this._to_json()}
   }
 
-  protected _to_json(): JSON {
-    return {}
-  }
+  protected abstract _to_json(): JSON
 }
 
 export abstract class ModelEvent extends BokehEvent {
@@ -36,7 +33,11 @@ export abstract class ModelEvent extends BokehEvent {
 }
 
 @event("document_ready")
-export class DocumentReady extends BokehEvent {}
+export class DocumentReady extends BokehEvent {
+  protected _to_json(): JSON {
+    return {}
+  }
+}
 
 @event("button_click")
 export class ButtonClick extends ModelEvent {}

--- a/bokehjs/src/lib/core/bokeh_events.ts
+++ b/bokehjs/src/lib/core/bokeh_events.ts
@@ -16,23 +16,33 @@ export abstract class BokehEvent {
 
   /* prototype */ event_name: string
 
-  origin: HasProps | null = null
-
   to_json(): EventJSON {
     const {event_name} = this
     return {event_name, event_values: this._to_json()}
   }
 
   protected _to_json(): JSON {
+    return {}
+  }
+}
+
+export abstract class ModelEvent extends BokehEvent {
+
+  origin: HasProps | null = null
+
+  protected _to_json(): JSON {
     return {model: this.origin}
   }
 }
 
+@event("document_ready")
+export class DocumentReady extends BokehEvent {}
+
 @event("button_click")
-export class ButtonClick extends BokehEvent {}
+export class ButtonClick extends ModelEvent {}
 
 @event("menu_item_click")
-export class MenuItemClick extends BokehEvent {
+export class MenuItemClick extends ModelEvent {
 
   constructor(readonly item: string) {
     super()
@@ -46,7 +56,7 @@ export class MenuItemClick extends BokehEvent {
 
 // A UIEvent is an event originating on a canvas this includes.
 // DOM events such as keystrokes as well as hammer events and LOD events.
-export abstract class UIEvent extends BokehEvent {}
+export abstract class UIEvent extends ModelEvent {}
 
 @event("lodstart")
 export class LODStart extends UIEvent {}

--- a/bokehjs/src/lib/document/document.ts
+++ b/bokehjs/src/lib/document/document.ts
@@ -1,7 +1,7 @@
 import {Models} from "../base"
 import {version as js_version} from "../version"
 import {logger} from "../core/logging"
-import {BokehEvent, LODStart, LODEnd} from "core/bokeh_events"
+import {BokehEvent, DocumentReady, ModelEvent, LODStart, LODEnd} from "core/bokeh_events"
 import {HasProps} from "core/has_props"
 import {ID, Attrs, Data, PlainObject} from "core/types"
 import {Signal0} from "core/signaling"
@@ -34,7 +34,7 @@ export class EventManager {
     this.document._trigger_on_change(event)
   }
 
-  trigger(event: BokehEvent): void {
+  trigger(event: ModelEvent): void {
     for (const model of this.subscribed_models) {
       if (event.origin != null && event.origin != model)
         continue
@@ -113,6 +113,7 @@ export class Document {
     this._idle_roots.set(model, true)
     if (this.is_idle) {
       logger.info(`document idle at ${Date.now() - this._init_timestamp} ms`)
+      this.event_manager.send_event(new DocumentReady())
       this.idle.emit()
     }
   }

--- a/bokehjs/src/lib/model.ts
+++ b/bokehjs/src/lib/model.ts
@@ -1,6 +1,6 @@
 import {HasProps} from "./core/has_props"
 import {Class} from "./core/class"
-import {BokehEvent} from "./core/bokeh_events"
+import {ModelEvent} from "./core/bokeh_events"
 import * as p from "./core/properties"
 import {isString} from "./core/util/types"
 import {isEmpty, entries} from "./core/util/object"
@@ -14,7 +14,7 @@ export namespace Model {
     tags: p.Property<string[]>
     name: p.Property<string | null>
     js_property_callbacks: p.Property<{[key: string]: CallbackLike0<Model>[]}>
-    js_event_callbacks: p.Property<{[key: string]: CallbackLike0<BokehEvent>[]}>
+    js_event_callbacks: p.Property<{[key: string]: CallbackLike0<ModelEvent>[]}>
     subscribed_events: p.Property<string[]>
   }
 }
@@ -54,7 +54,7 @@ export class Model extends HasProps {
     this.connect(this.properties.subscribed_events.change, () => this._update_event_callbacks())
   }
 
-  /*protected*/ _process_event(event: BokehEvent): void {
+  /*protected*/ _process_event(event: ModelEvent): void {
     for (const callback of this.js_event_callbacks[event.event_name] || [])
       callback.execute(event)
 
@@ -62,7 +62,7 @@ export class Model extends HasProps {
       this.document.event_manager.send_event(event)
   }
 
-  trigger_event(event: BokehEvent): void {
+  trigger_event(event: ModelEvent): void {
     if (this.document != null) {
       event.origin = this
       this.document.event_manager.trigger(event)

--- a/bokehjs/test/unit/document/document.ts
+++ b/bokehjs/test/unit/document/document.ts
@@ -432,6 +432,28 @@ describe("Document", () => {
     expect(d._all_models.size).to.be.equal(3)
   })
 
+  it("can notify on ready", () => {
+    const doc = new Document()
+
+    let signals = 0
+    doc.idle.connect(() => signals += 1)
+
+    const events: ev.DocumentEvent[] = []
+    doc.on_change((event) => events.push(event))
+
+    const root = new SomeModelWithChildren()
+    doc.add_root(root)
+    doc.notify_idle(root)
+
+    expect(signals).to.be.equal(1)
+    expect(events.length).to.be.equal(2) // [RootAdded, MessageSent]
+
+    const [, event] = events
+    assert(event instanceof ev.MessageSentEvent)
+    expect(event.msg_type).to.be.equal("bokeh_event")
+    expect(event.msg_data).to.be.equal({event_name: "document_ready", event_values: {}})
+  })
+
   it("can notify on changes", () => {
     const d = new Document()
     expect(d.roots().length).to.be.equal(0)

--- a/tests/unit/bokeh/test_events.py
+++ b/tests/unit/bokeh/test_events.py
@@ -51,9 +51,13 @@ def test_event_metaclass() -> None:
 def test_common_decode_json() -> None:
     for event_name, event_cls in events._CONCRETE_EVENT_CLASSES.items():
         if event_name is None: continue # Skip abstract base class
-        event = events.Event.decode_json({'event_name':event_cls.event_name,
-                                          'event_values':{'model': {'id': 'test-model-id'}}})
-        assert event._model_id == 'test-model-id'
+        event = events.Event.decode_json({
+            'event_name': event_cls.event_name,
+            'event_values': {'model': {'id': 'test-model-id'}},
+        })
+        assert isinstance(event, events.Event)
+        if isinstance(event, events.ModelEvent):
+            assert event._model_id == 'test-model-id'
 
 def test_pointevent_subclass_decode_json() -> None:
     event_values = dict(model_id='test-model-id', sx=3, sy=-2, x=10, y=100)
@@ -104,17 +108,17 @@ def test_pinchevent_decode_json() -> None:
 
 def test_event_constructor_button() -> None:
     model = Button()
-    event = events.Event(model)
+    event = events.ModelEvent(model)
     assert event._model_id == model.id
 
 def test_event_constructor_div() -> None:
     model = Div()
-    event = events.Event(model)
+    event = events.ModelEvent(model)
     assert event._model_id == model.id
 
 def test_event_constructor_plot() -> None:
     model = Plot()
-    event = events.Event(model)
+    event = events.ModelEvent(model)
     assert event._model_id == model.id
 
 def test_buttonclick_constructor_button() -> None:


### PR DESCRIPTION
Implements #10265 by adding a `Document.on_event` method to subscribe to a new class of `DocumentEvent` types the first of which is a `DocumentReady` event, which fires when the Document is done rendering.

- [x] issues: fixes #10265 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
