### PR TITLE
Fix typos in User Guide

### DIFF
--- a/sphinx/source/docs/user_guide/annotations.rst
+++ b/sphinx/source/docs/user_guide/annotations.rst
@@ -225,8 +225,7 @@ Box Annotations
 
 A |BoxAnnotation| can be linked to either data or screen coordinates in order
 to emphasize specific plot regions. By default, box annotation dimensions (e.g.
-``left`` or ``top``) will extend the annotation to the edge of the
-plot area.
+``left`` or ``top``) will extend the annotation to the edge of the plot area.
 
 .. bokeh-plot:: docs/user_guide/examples/plotting_box_annotation.py
     :source-position: above
@@ -310,7 +309,7 @@ single point would be one common use for the Whisker annotation.
 
 .. |Plot| replace:: :class:`~bokeh.models.plots.Plot`
 
-.. |Figure| replace:: :class:`~bokeh.plotting.figure.Figure`
+.. |Figure| replace:: :class:`~bokeh.plotting.Figure`
 
 .. |figure| replace:: :func:`~bokeh.plotting.figure`
 

--- a/sphinx/source/docs/user_guide/annotations.rst
+++ b/sphinx/source/docs/user_guide/annotations.rst
@@ -37,7 +37,7 @@ properties as well as the title text and title alignment using ``.title``:
     :source-position: above
 
 Note that the alignment is measured along the direction of text. For
-example for titles on the left side of a plot "left" will be in the
+example, for titles on the left side of a plot, "left" will be in the
 lower corner.
 
 In addition to the default title, it is possible to create and add
@@ -54,8 +54,8 @@ the same space:
     :source-position: above
 
 If the plot size is large enough, this can result in a more compact plot.
-However if the plot size is not large enough, the title and toolbar may
-visually overlap in way that is not desirable.
+However, if the plot size is not large enough, the title and toolbar may
+visually overlap in a way that is not desirable.
 
 .. _userguide_plotting_legends:
 
@@ -63,19 +63,19 @@ Legends
 -------
 
 It is possible to create |Legend| annotations easily by specifying legend
-arguments to the glyph methods, when creating a plot.
+arguments to the glyph methods when creating a plot.
 
 Basic Legend Label
 ~~~~~~~~~~~~~~~~~~
 
-To provide a simple explicit label for a glypy, pass the ``legend_label``
+To provide a simple explicit label for a glyph, pass the ``legend_label``
 keyword argument:
 
 .. code-block:: python
 
     p.circle('x', 'y', legend_label="some label")
 
-If multiple glyphs are given the same label, they will all be combined in to a
+If multiple glyphs are given the same label, they will all be combined into a
 single legend item with that label.
 
 .. bokeh-plot:: docs/user_guide/examples/plotting_legend_label.py
@@ -116,8 +116,8 @@ on a column that is only computed on the JavaScript side.
 
     p.circle('x', 'y', legend_field="colname", source=source)
 
-In this case the Python code does *not* see multiple items in ``Legend.items``.
-Instead there is only a single item that represents the grouping to perform in
+In this case, the Python code does *not* see multiple items in ``Legend.items``.
+Instead, there is only a single item that represents the grouping to perform in
 the browser.
 
 .. bokeh-plot:: docs/user_guide/examples/plotting_legend_field.py
@@ -137,7 +137,7 @@ Other times, it may be useful to explicitly tell Bokeh which index into a
 ``ColumnDataSource`` should be used when drawing a legend item. In particular,
 if you want to draw multiple legend items for "multi" glyphs such as
 ``MultiLine`` or ``Patches``. This is accomplished by specifying an ``index``
-for the legend item as shown below.
+for the legend item, as shown below.
 
 .. bokeh-plot:: docs/user_guide/examples/plotting_legends_multi_index.py
     :source-position: above
@@ -147,7 +147,7 @@ Interactive Legends
 
 It's also possible to configure legends to be interactive, so that clicking
 or tapping on legend entries affects the corresponding glyph visibility. See
-the :ref:`userguide_interaction_legends` section of the User's Guide for more
+the :ref:`userguide_interaction_legends` section of the User Guide for more
 information and examples.
 
 .. note::
@@ -181,7 +181,7 @@ Arrows
 to simply highlight plot regions. Arrows are compound annotations, meaning
 that their ``start`` and ``end`` attributes are themselves other |ArrowHead|
 annotations. By default, the |Arrow| annotation is one-sided with the ``end``
-set as an ``OpenHead``-type arrow head (an open-backed wedge style) and the
+set as an ``OpenHead``-type arrowhead (an open-backed wedge style) and the
 ``start`` property set to ``None``. Double-sided arrows can be created by
 setting both the ``start`` and ``end`` properties as appropriate |ArrowHead|
 subclass instances.
@@ -198,10 +198,10 @@ Arrows may also be configured to refer to additional non-default x- or
 y-ranges with the ``x_range`` and ``y_range`` properties, in the same way
 as :ref:`userguide_plotting_twin_axes`.
 
-Additionally any arrow head objects in ``start`` or ``end`` have a ``size``
-property to control how big the arrow head is, as well as both line and
-fill properties. The line properties control the outline of the arrow head,
-and the fill properties control the interior of the arrow head (if applicable).
+Additionally, any arrowhead objects in ``start`` or ``end`` have a ``size``
+property to control how big the arrowhead is, as well as both line and
+fill properties. The line properties control the outline of the arrowhead,
+and the fill properties control the interior of the arrowhead (if applicable).
 
 .. bokeh-plot:: docs/user_guide/examples/plotting_arrow.py
     :source-position: above
@@ -211,7 +211,7 @@ and the fill properties control the interior of the arrow head (if applicable).
 Bands
 -----
 
-A |Band| will create a dimensionally-linked "stripe", either located in data
+A |Band| will create a dimensionally linked "stripe", either located in data
 or screen coordinates. One common use for the Band annotation is to indicate
 uncertainty related to a series of measurements.
 
@@ -225,7 +225,7 @@ Box Annotations
 
 A |BoxAnnotation| can be linked to either data or screen coordinates in order
 to emphasize specific plot regions. By default, box annotation dimensions (e.g.
-``left`` or ``top``) default will extend the annotation to the edge of the
+``left`` or ``top``) will extend the annotation to the edge of the
 plot area.
 
 .. bokeh-plot:: docs/user_guide/examples/plotting_box_annotation.py
@@ -242,7 +242,7 @@ regions.
 To create a single text label, use the |Label| annotation. This annotation
 is configured with a ``text`` property containing the text to be displayed,
 as well as ``x`` and ``y`` properties to set the position (in screen or data
-space units). Additionally a render mode ``"canvas"`` or ``"css"`` may be
+space units). Additionally, a render mode ``"canvas"`` or ``"css"`` may be
 specified. Finally, labels have ``text``, ``border_line``, and
 ``background_fill`` properties. These control the visual appearance of the
 text, as well as the border and background of the bounding box for the text:
@@ -255,10 +255,10 @@ text, as well as the border and background of the bounding box for the text:
 
 To create several labels at once, possibly to easily annotate another existing
 glyph, use the |LabelSet| annotation, which is configured with a data
-source, with the ``text`` and ``x`` and ``y`` positions are given as column
+source in which the ``text`` and ``x`` and ``y`` positions are given as column
 names. ``LabelSet`` objects can also have ``x_offset`` and ``y_offset``,
 which specify a distance in screen space units to offset the label positions
-from ``x`` and ``y``. Finally the render level may be controlled with the
+from ``x`` and ``y``. Finally, the render level may be controlled with the
 ``level`` property, to place the label above or underneath other renderers:
 
 
@@ -299,7 +299,7 @@ and extend to the edge of the plot area.
 Whiskers
 --------
 
-A |Whisker| will create a dimensionally-linked "stem", either located in data
+A |Whisker| will create a dimensionally linked "stem", either located in data
 or screen coordinates. Indicating error or uncertainty for measurements at a
 single point would be one common use for the Whisker annotation.
 
@@ -310,7 +310,7 @@ single point would be one common use for the Whisker annotation.
 
 .. |Plot| replace:: :class:`~bokeh.models.plots.Plot`
 
-.. |Figure| replace:: :class:`~bokeh.plotting.Figure`
+.. |Figure| replace:: :class:`~bokeh.plotting.figure.Figure`
 
 .. |figure| replace:: :func:`~bokeh.plotting.figure`
 

--- a/sphinx/source/docs/user_guide/bokehjs.rst
+++ b/sphinx/source/docs/user_guide/bokehjs.rst
@@ -27,10 +27,10 @@ section of the :ref:`installation` page for more details.
 
 .. _userguide_bokehjs_models:
 
-Low Level Models
+Low-Level Models
 ----------------
 
-The low level models for building up plots and applications (e.g. guides
+The low-level models for building up plots and applications (e.g. guides
 and glyphs and widgets, etc.) generally match the Bokeh Python models
 exactly. Accordingly, the :ref:`refguide` is a primary resource for
 answering questions about BokehJS models, even though it is presented
@@ -45,7 +45,7 @@ The complete list of models available from JavaScript can be seen at
 When creating models from JavaScript, all of the keyword arguments that
 would get passed to the Python object initializer are passed as a
 JavaScript object. Here is a comparison of how to create a `Range1d`
-model. First, in python:
+model. First, in Python:
 
 .. code-block:: python
 
@@ -76,9 +76,9 @@ Python to JavaScript at this level is nearly one-to-one:
 Interfaces
 ----------
 
-Similar to the Python Bokeh library, BokehJS provides various higher level
-interfaces for interacting with and composing the low level model objects.
-These higher level interfaces currently comprise  ``Bokeh.Plotting`` and
+Similar to the Python Bokeh library, BokehJS provides various higher-level
+interfaces for interacting with and composing the low-level model objects.
+These higher-level interfaces currently comprise  ``Bokeh.Plotting`` and
 ``Bokeh.Charts``.
 
 .. note::
@@ -96,7 +96,7 @@ The JavaScript ``Bokeh.Plotting`` API is a port of the Python
 :ref:`userguide_plotting` section of the User Guide can be a useful
 reference in addition to the material here.
 
-Here is an example that is very similar the Python example
+Here is an example that is very similar to the Python example
 :bokeh-tree:`examples/plotting/file/color_scatter.py`:
 
 .. bokehjs-content::
@@ -146,7 +146,7 @@ Here is an example that is very similar the Python example
 ~~~~~~~~~~~~~~~~
 
 The JavaScript ``Bokeh.Charts`` API is a high-level interface for charting
-that is unique to BokehJS. Currently , there are two high level charts
+that is unique to BokehJS. Currently, there are two high-level charts
 supported: ``pie`` and ``bar``.
 
 .. _userguide_bokehjs_interfaces_charts_pie:
@@ -223,7 +223,7 @@ To create bar charts using ``Bokeh.Charts.bar``, the basic usage is:
     Bokeh.Charts.bar(data, { options })
 
 Where ``data`` is a JavaScript array that has as elements lists that are
-"rows" from a data table. The first "row" should contain the column headers. H
+"rows" from a data table. The first "row" should contain the column headers.
 Here is an example that might represent sales data from different regions for
 different years:
 
@@ -249,7 +249,7 @@ the following optional keys:
 :``palette``: *Palette | Array<Color>* --- a named palette, or list of colors to colormap the values
 :``axis_number_format``: *string* --- a format string to use for axis ticks
 
-By default, plots created ``Bokeh.Charts.bar`` automatically add a tooltip
+By default, plots created with ``Bokeh.Charts.bar`` automatically add a tooltip
 and hover policy. Here is some example code that demonstrates the ``bar``
 function, with the plot it generates shown below:
 

--- a/sphinx/source/docs/user_guide/categorical.rst
+++ b/sphinx/source/docs/user_guide/categorical.rst
@@ -19,8 +19,8 @@ Basic
 ~~~~~
 
 Bokeh makes it simple to create basic bar charts using the
-:func:`~bokeh.plotting.figure.Figure.hbar` and
-:func:`~bokeh.plotting.figure.Figure.vbar` glyphs methods. In the example
+:func:`~bokeh.plotting.Figure.hbar` and
+:func:`~bokeh.plotting.Figure.vbar` glyphs methods. In the example
 below, we have the following sequence of simple 1-level factors:
 
 .. code-block:: python
@@ -28,7 +28,7 @@ below, we have the following sequence of simple 1-level factors:
     fruits = ['Apples', 'Pears', 'Nectarines', 'Plums', 'Grapes', 'Strawberries']
 
 To inform Bokeh that the x-axis is categorical, we pass this list of factors
-as the ``x_range`` argument to :func:`~bokeh.plotting.figure.figure`:
+as the ``x_range`` argument to :func:`~bokeh.plotting.figure`:
 
 .. code-block:: python
 
@@ -118,8 +118,8 @@ Stacked
 
 Another common operation on bar charts is to stack bars on top of one
 another. Bokeh makes this easy to do with the specialized
-:func:`~bokeh.plotting.figure.Figure.hbar_stack` and
-:func:`~bokeh.plotting.figure.Figure.vbar_stack` functions. The example
+:func:`~bokeh.plotting.Figure.hbar_stack` and
+:func:`~bokeh.plotting.Figure.vbar_stack` functions. The example
 below shows the fruits data from above, but with the bars for each
 fruit type stacked instead of grouped:
 

--- a/sphinx/source/docs/user_guide/categorical.rst
+++ b/sphinx/source/docs/user_guide/categorical.rst
@@ -18,9 +18,9 @@ Bars
 Basic
 ~~~~~
 
-Bokeh make it simple to create basic bar charts using the
-:func:`~bokeh.plotting.Figure.hbar` and
-:func:`~bokeh.plotting.Figure.vbar` glyphs methods. In the example
+Bokeh makes it simple to create basic bar charts using the
+:func:`~bokeh.plotting.figure.Figure.hbar` and
+:func:`~bokeh.plotting.figure.Figure.vbar` glyphs methods. In the example
 below, we have the following sequence of simple 1-level factors:
 
 .. code-block:: python
@@ -28,7 +28,7 @@ below, we have the following sequence of simple 1-level factors:
     fruits = ['Apples', 'Pears', 'Nectarines', 'Plums', 'Grapes', 'Strawberries']
 
 To inform Bokeh that the x-axis is categorical, we pass this list of factors
-as the ``x_range`` argument to :func:`~bokeh.plotting.figure`:
+as the ``x_range`` argument to :func:`~bokeh.plotting.figure.figure`:
 
 .. code-block:: python
 
@@ -45,7 +45,7 @@ notation is:
 This more explicit form is useful when you want to customize the
 ``FactorRange``, e.g. by changing the range or category padding.
 
-Next we can call ``vbar`` with the list of fruit name factors as the ``x``
+Next, we can call ``vbar`` with the list of fruit name factors as the ``x``
 coordinate, the bar height as the ``top`` coordinate, and optionally any
 ``width`` or other properties that we would like to set:
 
@@ -86,7 +86,7 @@ Filled
 Colors
 ''''''
 
-Often times we may want to have bars that are shaded some color. This can be
+Oftentimes we may want to have bars that are shaded some color. This can be
 accomplished in different ways. One way is to supply all the colors up front.
 This can be done by putting all the data, including the colors for each bar,
 in a ``ColumnDataSource``. Then the name of the column containing the colors
@@ -105,7 +105,7 @@ colormaps the bars inside the browser. There is a function
     factor_cmap('fruits', palette=Spectral6, factors=fruits)
 
 This can be passed to ``vbar`` in the same way as the column name in the
-previous example. Putting everything together we obtain the same plot in
+previous example. Putting everything together, we obtain the same plot in
 a different way:
 
 .. bokeh-plot:: docs/user_guide/examples/categorical_bar_colormapped.py
@@ -116,10 +116,10 @@ a different way:
 Stacked
 ~~~~~~~
 
-Another common operation or bar charts is to stack bars on top of one
+Another common operation on bar charts is to stack bars on top of one
 another. Bokeh makes this easy to do with the specialized
-:func:`~bokeh.plotting.Figure.hbar_stack` and
-:func:`~bokeh.plotting.Figure.vbar_stack` functions. The example
+:func:`~bokeh.plotting.figure.Figure.hbar_stack` and
+:func:`~bokeh.plotting.figure.Figure.vbar_stack` functions. The example
 below shows the fruits data from above, but with the bars for each
 fruit type stacked instead of grouped:
 
@@ -128,7 +128,7 @@ fruit type stacked instead of grouped:
 
 Note that behind the scenes, these functions work by stacking up the
 successive columns in separate calls to ``vbar`` or ``hbar``. This kind of
-operation is akin the to dodge example above (i.e. the data in this case is
+operation is akin to the dodge example above (i.e. the data in this case is
 *not* in a "tidy" data format).
 
 Sometimes we may want to stack bars that have both positive and negative
@@ -187,7 +187,7 @@ Grouped
 
 When creating bar charts, it is often desirable to visually display the
 data according to sub-groups. There are two basic methods that can be used,
-depending on your use case: using nested categorical coordinates, or
+depending on your use case: using nested categorical coordinates or
 applying visual dodges.
 
 .. _userguide_categorical_bars_grouped_nested:
@@ -210,8 +210,8 @@ the plot groups the axes by fruit type, with a single call to ``vbar``:
     :source-position: above
 
 We can also apply a color mapping, similar to the earlier example. To obtain
-same grouped bar plot of fruits data as above, except with the bars shaded by
-the year, changethe ``vbar`` function call to use ``factor_cmap`` for the
+the same grouped bar plot of fruits data as above, except with the bars shaded by
+the year, change the ``vbar`` function call to use ``factor_cmap`` for the
 ``fill_color``:
 
 .. code-block:: python
@@ -238,9 +238,9 @@ Another method for achieving grouped bars is to explicitly specify a visual
 displacement for the bars. Such a visual offset is also referred to as a
 *dodge*.
 
-In this scenario, our data is not "tidy". Instead a single table with
+In this scenario, our data is not "tidy". Instead of a single table with
 rows indexed by factors ``(fruit, year)``, we have separate series for each
-year. We can plot all the year series using separate calls to ``vbar`` but
+year. We can plot all the year series using separate calls to ``vbar``, but
 since every bar in each group has the same ``fruit`` factor, the bars would
 overlap visually. We can prevent this overlap and distinguish the bars
 visually by using the :func:`~bokeh.transform.dodge` function to provide an
@@ -255,7 +255,7 @@ Stacked and Grouped
 ~~~~~~~~~~~~~~~~~~~
 
 The above techniques for stacking and grouping may also be used together to
-crate a stacked, grouped bar plot.
+create a stacked, grouped bar plot.
 
 Continuing the example above with bars grouped by quarter, we might stack each
 individual bar by region.
@@ -280,7 +280,7 @@ example, if you have range with the hierarchical factors
     ]
 
 Then it is possible to use just `"Sales"` and `"Marketing"` etc. as positions
-for glyphs. In this case the position is the center of the entire group. The
+for glyphs. In this case, the position is the center of the entire group. The
 example below shows bars for each month, grouped by financial quarter, and
 also adds a line (perhaps for a quarterly average) at the coordinates for
 ``Q1``, ``Q2``, etc.:
@@ -313,13 +313,13 @@ Bokeh:
 .. bokeh-plot:: docs/user_guide/examples/categorical_bar_pandas_groupby_colormapped.py
     :source-position: above
 
-Not that in the example above, we grouped by the column ``'cyl'`` so our CDS
+Note that in the example above we grouped by the column ``'cyl'``, so our CDS
 has a column ``'cyl'`` for this index. Additionally, other non-grouped columns
-like ``'mpg'`` have had associated columns such ``'mpg_mean'`` added, that
+like ``'mpg'`` have had associated columns such as ``'mpg_mean'`` added, that
 give the mean MPG value for each group.
 
 This usage also works when the grouping is multi-level. The example below shows
-how grouping the same data by ``('cyl', 'mfr')`` results in a hierarchical
+how grouping the same data by ``('cyl', 'mfr')`` results in a hierarchically
 nested axis. In this case, the index column name ``'cyl_mfr'`` is made by
 joining the names of the grouped columns together.
 
@@ -410,10 +410,10 @@ patch coordinates for the timeseries inside each category.
 
 .. _userguide_categorical_heatmaps:
 
-Heat Maps
----------
+Heatmaps
+--------
 
-In all of the cases above, we have had one categorical axis, and one
+In all of the cases above, we have had one categorical axis and one
 continuous axis. It is possible to have plots with two categorical axes. If
 we shade the rectangle that defines each pair of categories, we end up with
 a *Categorical Heatmap*
@@ -421,7 +421,7 @@ a *Categorical Heatmap*
 The plot below shows such a plot, where the x-axis categories are a list of
 years from 1948 to 2016, and the y-axis categories are the months of the
 years. Each rectangle corresponding to a ``(year, month)`` combination is
-color mapped by the unemployment rate for that month and year. Since the
+colormapped by the unemployment rate for that month and year. Since the
 unemployment rate is a continuous variable, a ``LinearColorMapper`` is used
 to colormap the plot, and is also passed to a color bar to provide a visual
 legend on the right:
@@ -432,7 +432,7 @@ legend on the right:
 A final example combines many of the techniques in this chapter: color mappers,
 visual dodges, and Pandas DataFrames. These are used to create a different
 sort of "heatmap" that results in a periodic table of the elements. A hover
-tool as also been added so that additional information about each element
+tool has also been added so that additional information about each element
 can be inspected:
 
 .. bokeh-plot:: docs/user_guide/examples/categorical_heatmap_periodic.py

--- a/sphinx/source/docs/user_guide/categorical.rst
+++ b/sphinx/source/docs/user_guide/categorical.rst
@@ -374,7 +374,7 @@ Categorical Offsets
 -------------------
 
 We've seen above how categorical locations can be modified by operations like
-*dodge* and *jitter*.  It is also possible to supply an offset to a categorical
+*dodge* and *jitter*. It is also possible to supply an offset to a categorical
 location explicitly. This is done by adding a numeric value to the end of a
 category, e.g. ``["Jan", 0.2]`` is the category "Jan" offset by a value of 0.2.
 For hierarchical categories, the value is added at the end of the existing

--- a/sphinx/source/docs/user_guide/compat.rst
+++ b/sphinx/source/docs/user_guide/compat.rst
@@ -10,7 +10,7 @@ BokehJS
 -------
 
 Bokeh generates JavaScript, and so Bokeh output can be combined with a
-wide variety of JavaScript libraries, such as `React`_.  Listing
+wide variety of JavaScript libraries, such as `React`_. Listing
 such libraries is beyond the scope of this document; it's best just to
 try and see!
 
@@ -21,16 +21,16 @@ Datashader
 A major strength of Bokeh is that it copies your data from Python
 directly into the browser, which makes it possible for the user to
 interact with the represented data quickly and responsively, even
-without a live Python process running.  However, for plotting millions
+without a live Python process running. However, for plotting millions
 or billions of points, this strength can turn into a liability,
 because current web browsers are very limited in how much data they
-can feasibly work with.  Moreover, the visual representation of such
+can feasibly work with. Moreover, the visual representation of such
 large datasets is often misleading due to `overplotting`_ and related
 issues.
 
 `Datashader`_ is a separately available Python library that
 pre-renders even the largest datasets into a fixed-size raster image
-that faithfully represents the data's distribution.  Datashader
+that faithfully represents the data's distribution. Datashader
 includes tools and examples showing how to build interactive Bokeh
 plots that dynamically re-render these images when zooming and panning
 in Bokeh, making it practical to work with arbitrarily large datasets
@@ -55,7 +55,7 @@ HoloViews
 Bokeh is designed to provide an enormous amount of power and
 flexibility to the Python programmer, making it feasible to develop
 complex visualization-focused applications for deployment on web
-browsers.  However, for day-to-day work exploring and visualizing
+browsers. However, for day-to-day work exploring and visualizing
 data, it can be helpful to have a higher-level API on top of what
 Bokeh provides, to make it simpler to do common visualization tasks
 without specifying each step explicitly.
@@ -63,7 +63,7 @@ without specifying each step explicitly.
 `HoloViews`_ is a separately maintained package that provides a
 concise declarative interface for building Bokeh plots. HoloViews is
 particularly focused on interactive use in a Jupyter notebook,
-allowing quick prototyping of figures for data analysis.  For
+allowing quick prototyping of figures for data analysis. For
 instance, to build an interactive figure with three linked Bokeh plots
 requires only one line of code in HoloViews:
 
@@ -75,9 +75,9 @@ requires only one line of code in HoloViews:
  :align: center
 
 Adding overlaid plots, slider widgets, selector widgets, selection
-tools, and tabs is similarly straightforward.  HoloViews objects can
+tools, and tabs is similarly straightforward. HoloViews objects can
 also be rendered using a Matplotlib-based backend, which allows SVG or
-PDF output not currently available for native Bokeh plots.  See the
+PDF output not currently available for native Bokeh plots. See the
 Holoviews `Bokeh_Backend`_ tutorial for more details.
 
 

--- a/sphinx/source/docs/user_guide/concepts.rst
+++ b/sphinx/source/docs/user_guide/concepts.rst
@@ -9,13 +9,13 @@ Glossary
 --------
 
 In order to make the best use of this User Guide, it is important to have
-context for some high level concepts and terms. Here is a small glossary of
+context for some high-level concepts and terms. Here is a small glossary of
 some of the most important concepts in Bokeh.
 
 ----
 
 Application
-    A Bokeh application is a recipe for generating Bokeh documents. Typically
+    A Bokeh application is a recipe for generating Bokeh documents. Typically,
     this is Python code run by a Bokeh server when new sessions are created.
 
 BokehJS
@@ -207,8 +207,8 @@ assemble the appropriate Bokeh Models to form a scenegraph
 that BokehJS can render is handled automatically.
 
 The main class in the |bokeh.plotting| interface is the |figure| function. This
-creates a |Figure| model, that includes methods for adding different kinds of
-glyphs to a plot. Additionally it composes default axes, grids, and tools in
+creates a |Figure| model that includes methods for adding different kinds of
+glyphs to a plot. Additionally, it composes default axes, grids, and tools in
 the proper way without any extra effort.
 
 A prototypical example of the |bokeh.plotting| usage is show below, along
@@ -221,7 +221,7 @@ The main observation is that the typical usage involves creating plot objects
 with the |figure| function, then using the glyph methods like |Figure.circle|
 to add renderers for our data. We do not have to worry about configuring any
 axes or grids (although we can configure them if we need to), and specifying
-tools is done simply with the names of tools to add. Finally we use some output
+tools is done simply with the names of tools to add. Finally, we use some output
 functions to display our plot.
 
 There are many other possibilities: saving our plot instead of showing it,

--- a/sphinx/source/docs/user_guide/data.rst
+++ b/sphinx/source/docs/user_guide/data.rst
@@ -8,7 +8,7 @@ In this section, the various ways of providing data for plots are explained, fro
 passing data values directly to creating a |ColumnDataSource| and filtering using
 a |CDSView|.
 
-Providing data directly
+Providing Data Directly
 -----------------------
 
 In Bokeh, it is possible to pass lists of values directly into plotting functions.
@@ -379,7 +379,7 @@ A full example (shown below) can be seen at
 
 .. _userguide_data_linked_selection:
 
-Linked selection
+Linked Selection
 ----------------
 
 Using the same |ColumnDataSource| in the two plots below allows their selections to be
@@ -390,7 +390,7 @@ shared.
 
 .. _userguide_data_linked_selection_with_filtering:
 
-Linked selection with filtered data
+Linked Selection with Filtered Data
 -----------------------------------
 
 With the ability to specify a subset of data to be used for each glyph renderer, it is

--- a/sphinx/source/docs/user_guide/data.rst
+++ b/sphinx/source/docs/user_guide/data.rst
@@ -27,7 +27,7 @@ to the ``circle`` plotting method (see :ref:`userguide_plotting` for more exampl
 
 When you pass in data like this, Bokeh works behind the scenes to make a
 |ColumnDataSource| for you. But learning to create and use the |ColumnDataSource|
-will enable you access more advanced capabilities, such as streaming data,
+will enable you to access more advanced capabilities, such as streaming data,
 sharing data between plots, and filtering data.
 
 ColumnDataSource
@@ -44,9 +44,9 @@ highlighted in a second plot (:ref:`userguide_data_linked_selection`).
 At the most basic level, a |ColumnDataSource| is simply a mapping between column
 names and lists of data. The |ColumnDataSource| takes a ``data`` parameter which is a dict,
 with string column names as keys and lists (or arrays) of data values as values. If one positional
-argument is passed in to the |ColumnDataSource| initializer, it will be taken as ``data``. Once the
+argument is passed into the |ColumnDataSource| initializer, it will be taken as ``data``. Once the
 |ColumnDataSource| has been created, it can be passed into the ``source`` parameter of
-plotting methods which allows you to pass a column's name as a stand in for the data values:
+plotting methods which allows you to pass a column's name as a stand-in for the data values:
 
 .. code-block:: python
 
@@ -183,7 +183,7 @@ Colors
 To perform linear colormapping in the browser, the
 :func:`~bokeh.transform.linear_cmap` function may be used. It accepts the name
 of a ``ColumnDataSource`` column to colormap, a palette (which can be a built-in
-palette name, or an actual list of colors), and min/max values for the color
+palette name or an actual list of colors), and min/max values for the color
 mapping range. The result can be passed to a color property on glyphs:
 
 .. code-block:: python
@@ -298,7 +298,7 @@ GroupFilter
 
 The |GroupFilter| allows you to select rows from a dataset that have a specific value for
 a categorical variable. The |GroupFilter| has two properties, ``column_name``, the name of
-column in the |ColumnDataSource|, and ``group``, the value of the column to select for.
+the column in the |ColumnDataSource|, and ``group``, the value of the column to select for.
 
 In the example below, ``flowers`` contains a categorical variable ``species`` which is
 either ``setosa``, ``versicolor``, or ``virginica``.
@@ -350,7 +350,7 @@ provides this capability.
 The ``AjaxDataSource`` is configured with a URL to a REST endpoint and a
 polling interval. In the browser, the data source will request data from the
 endpoint at the specified interval and update the data locally. Existing
-data may either be replaced entirely, or appended to (up to a configurable
+data may either be replaced entirely or appended to (up to a configurable
 ``max_size``). The endpoint that is supplied should return a JSON dict that
 matches the standard ``ColumnDataSource`` format:
 

--- a/sphinx/source/docs/user_guide/data.rst
+++ b/sphinx/source/docs/user_guide/data.rst
@@ -44,7 +44,7 @@ highlighted in a second plot (:ref:`userguide_data_linked_selection`).
 At the most basic level, a |ColumnDataSource| is simply a mapping between column
 names and lists of data. The |ColumnDataSource| takes a ``data`` parameter which is a dict,
 with string column names as keys and lists (or arrays) of data values as values. If one positional
-argument is passed into the |ColumnDataSource| initializer, it will be taken as ``data``. Once the
+argument is passed to the |ColumnDataSource| initializer, it will be taken as ``data``. Once the
 |ColumnDataSource| has been created, it can be passed into the ``source`` parameter of
 plotting methods which allows you to pass a column's name as a stand-in for the data values:
 

--- a/sphinx/source/docs/user_guide/embed.rst
+++ b/sphinx/source/docs/user_guide/embed.rst
@@ -30,7 +30,7 @@ linked to a Bokeh server) may be published or embedded in a variety of ways.
 
 .. _userguide_embed_standalone_html:
 
-HTML files
+HTML Files
 ~~~~~~~~~~
 
 Bokeh can generate complete HTML pages for Bokeh documents using the
@@ -512,7 +512,7 @@ Here is an example of how to use |server_session| and Flask:
     if __name__ == '__main__':
         app.run(port=8080)
 
-Standard template
+Standard Template
 -----------------
 
 Bokeh also provides a standard Jinja template that can be useful for quickly

--- a/sphinx/source/docs/user_guide/embed.rst
+++ b/sphinx/source/docs/user_guide/embed.rst
@@ -10,13 +10,13 @@ First, a reminder of the distinction between standalone documents and apps:
     These are Bokeh documents that are not backed by a Bokeh server. They
     may have many tools and interactions (e.g. from ``CustomJS`` callbacks)
     but are self-contained HTML, JavaScript, and CSS. They can be
-    embedded into other HTML pages as one large document, or as a set of
+    embedded into other HTML pages as one large document or as a set of
     sub-components templated individually.
 
 :ref:`userguide_embed_apps`
     These are Bokeh documents that are backed by a Bokeh Server. In addition
     to all the features of standalone documents, it is also possible to connect
-    events and tools to real Python callbacks, that execute in the
+    events and tools to real Python callbacks that execute in the
     Bokeh server. See :ref:`userguide_server` for more information about
     creating and running Bokeh apps.
 
@@ -50,13 +50,13 @@ interactive tools (pan, zoom, etc.) for your plot. Here is an example:
 
     html = file_html(plot, CDN, "my plot")
 
-The returned HTML text can be saved to a file using standard python file
+The returned HTML text can be saved to a file using standard Python file
 operations. You can also provide your own template and pass in custom, or
 additional, template variables. See the |file_html| documentation for more
 details.
-G
+
 This is a fairly low-level, explicit way to generate an HTML file, which
-may be useful for use from a web application, e.g. a Flask app. When using
+may be useful for use in a web application, e.g. a Flask app. When using
 the |bokeh.plotting| interface in a script or Jupyter notebook, users will
 typically call the function |output_file| in conjunction with |show| or
 |save| instead.
@@ -134,7 +134,7 @@ or with modern syntax:
     Bokeh.embed.embed_item(item)
     </script>
 
-A full example can be found a :bokeh-tree:`examples/embed/json_item.py`.
+A full example can be found at :bokeh-tree:`examples/embed/json_item.py`.
 
 .. _userguide_embed_standalone_components:
 
@@ -196,7 +196,7 @@ These two elements can be inserted or templated into your HTML text, and the
 script, when executed, will replace the div with the plot.
 
 Using these components assumes that BokehJS has already been loaded, for
-instance either inline in the document text, or from CDN. To load BokehJS
+instance either inline in the document text or from CDN. To load BokehJS
 from CDN, add the following lines in your HTML text or template with the
 appropriate version replacing ``x.y.z``:
 
@@ -227,10 +227,10 @@ For example, to use version ``1.4.0``, including widgets and tables support:
 .. note::
     You must provide the closing `</script>` tag. This is required by all
     browsers and the page will typically not render without it. You should also
-    always include the `crossorigin="anonymous"` attribute on the script.
+    always include the `crossorigin="anonymous"` attribute in the script.
 
 If you would like to include `Subresource Integrity`_ hashes to your explicit
-script tags by setting the `integrity` attribute, the necesary hashes can be
+script tags by setting the `integrity` attribute, the necessary hashes can be
 obtained by calling :func:`~bokeh.resources.get_sri_hashes_for_version` e.g.
 
 .. code-block:: python
@@ -245,7 +245,7 @@ obtained by calling :func:`~bokeh.resources.get_sri_hashes_for_version` e.g.
 
     'bokeh-widgets-2.0.0.min.js': '2ltAd1cQhavmLeBEZXGgnna8fjbw+FjvDq9m2dig4+8KVS8JcYFUQaALvLT//qHE'}
 
-These are the bare hashes, and must be prefixed with `sha384-` to use. For
+These are the bare hashes, and they must be prefixed with `sha384-` to use. For
 example:
 
 .. code-block:: html
@@ -259,7 +259,7 @@ or release candidates).
 
 In addition to a single Bokeh model (e.g. a plot), the |components| function
 also accepts a list or tuple of models, or a dictionary of keys and models.
-Each returns a tuple with one script script and a corresponding data structure
+Each returns a tuple with one script and a corresponding data structure
 for the divs.
 
 The following illustrates how different input types correlate to outputs:
@@ -386,9 +386,9 @@ Autoload Scripts
 ~~~~~~~~~~~~~~~~
 
 A final way to embed standalone documents is the |autoload_static| function.
-This function with provide a  ``<script>`` tag that will replace itself with
+This function provides a  ``<script>`` tag that will replace itself with
 a Bokeh plot, wherever the tag happens to be located. The script will also check
-for BokehJS and load it, if necessary. Using this function it is possible to
+for BokehJS and load it, if necessary. Using this function, it is possible to
 embed a plot by placing this script tag alone in your document.
 
 This function takes a Bokeh model (e.g. a plot) that you want to display, a

--- a/sphinx/source/docs/user_guide/embed.rst
+++ b/sphinx/source/docs/user_guide/embed.rst
@@ -181,8 +181,8 @@ The returned ``<script>`` will look something like:
 
     </script>
 
-Note that in Jupyter Notebooks, it is not possible to use components and show in
-the same notebook cell.
+Note that in Jupyter notebooks, it is not possible to use |components| and
+|show| in the same notebook cell.
 
 All of the data and plot or widget objects are contained in the ``docs_json``
 variable (contents omitted here for brevity). The resulting ``<div>`` will
@@ -227,7 +227,7 @@ For example, to use version ``1.4.0``, including widgets and tables support:
 .. note::
     You must provide the closing `</script>` tag. This is required by all
     browsers and the page will typically not render without it. You should also
-    always include the `crossorigin="anonymous"` attribute in the script.
+    always include the `crossorigin="anonymous"` attribute on the script tag.
 
 If you would like to include `Subresource Integrity`_ hashes to your explicit
 script tags by setting the `integrity` attribute, the necessary hashes can be

--- a/sphinx/source/docs/user_guide/examples/interaction_callbacks_for_hover.py
+++ b/sphinx/source/docs/user_guide/examples/interaction_callbacks_for_hover.py
@@ -21,7 +21,7 @@ source = ColumnDataSource({'x0': [], 'y0': [], 'x1': [], 'y1': []})
 sr = p.segment(x0='x0', y0='y0', x1='x1', y1='y1', color='olive', alpha=0.6, line_width=3, source=source, )
 cr = p.circle(x, y, color='olive', size=30, alpha=0.4, hover_color='olive', hover_alpha=1.0)
 
-# Add a hover tool, that sets the link data for a hovered circle
+# add a hover tool that sets the link data for a hovered circle
 code = """
 const links = %s
 const data = {'x0': [], 'y0': [], 'x1': [], 'y1': []}

--- a/sphinx/source/docs/user_guide/examples/interaction_div.py
+++ b/sphinx/source/docs/user_guide/examples/interaction_div.py
@@ -5,7 +5,7 @@ output_file("div.html")
 
 div = Div(text="""Your <a href="https://en.wikipedia.org/wiki/HTML">HTML</a>-supported text is initialized with the <b>text</b> argument.  The
 remaining div arguments are <b>width</b> and <b>height</b>. For this example, those values
-are <i>200</i> and <i>100</i> respectively.""",
+are <i>200</i> and <i>100</i>, respectively.""",
 width=200, height=100)
 
 show(div)

--- a/sphinx/source/docs/user_guide/examples/interaction_paragraph.py
+++ b/sphinx/source/docs/user_guide/examples/interaction_paragraph.py
@@ -5,7 +5,7 @@ output_file("div.html")
 
 p = Paragraph(text="""Your text is initialized with the 'text' argument.  The
 remaining Paragraph arguments are 'width' and 'height'. For this example, those values
-are 200 and 100 respectively.""",
+are 200 and 100, respectively.""",
 width=200, height=100)
 
 show(p)

--- a/sphinx/source/docs/user_guide/examples/interaction_pretext.py
+++ b/sphinx/source/docs/user_guide/examples/interaction_pretext.py
@@ -6,7 +6,7 @@ output_file("div.html")
 pre = PreText(text="""Your text is initialized with the 'text' argument.
 
 The remaining Paragraph arguments are 'width' and 'height'. For this example,
-those values are 500 and 100 respectively.""",
+those values are 500 and 100, respectively.""",
 width=500, height=100)
 
 show(pre)

--- a/sphinx/source/docs/user_guide/examples/js_events.py
+++ b/sphinx/source/docs/user_guide/examples/js_events.py
@@ -1,5 +1,5 @@
 """ Demonstration of how to register event callbacks using an adaptation
-of the color_scatter example from the bokeh gallery
+of the color_scatter example from the Bokeh gallery
 """
 import numpy as np
 

--- a/sphinx/source/docs/user_guide/examples/layout_sizing_mode_multiple.py
+++ b/sphinx/source/docs/user_guide/examples/layout_sizing_mode_multiple.py
@@ -41,7 +41,7 @@ phase.js_on_change('value', callback)
 offset.js_on_change('value', callback)
 
 heading = Div(sizing_mode="stretch_width", height=80, text="In this wave example, the sliders on the left "
- "can be used to change the amplitude, frequency, phase and offset of the wave.")
+ "can be used to change the amplitude, frequency, phase, and offset of the wave.")
 
 layout = column(heading, row(widgets, plot), sizing_mode="stretch_both")
 

--- a/sphinx/source/docs/user_guide/examples/plotting_patch_single.py
+++ b/sphinx/source/docs/user_guide/examples/plotting_patch_single.py
@@ -4,7 +4,7 @@ output_file("patch.html")
 
 p = figure(plot_width=400, plot_height=400)
 
-# add a patch renderer with an alpha an line width
+# add a patch renderer with an alpha and line width
 p.patch([1, 2, 3, 4, 5], [6, 7, 8, 7, 3], alpha=0.5, line_width=2)
 
 show(p)

--- a/sphinx/source/docs/user_guide/examples/styling_axis_properties.py
+++ b/sphinx/source/docs/user_guide/examples/styling_axis_properties.py
@@ -5,12 +5,12 @@ output_file("axes.html")
 p = figure(plot_width=400, plot_height=400)
 p.circle([1,2,3,4,5], [2,5,8,2,7], size=10)
 
-# change just some things about the x-axes
+# change just some things about the x-axis
 p.xaxis.axis_label = "Temp"
 p.xaxis.axis_line_width = 3
 p.xaxis.axis_line_color = "red"
 
-# change just some things about the y-axes
+# change just some things about the y-axis
 p.yaxis.axis_label = "Pressure"
 p.yaxis.major_label_text_color = "orange"
 p.yaxis.major_label_orientation = "vertical"

--- a/sphinx/source/docs/user_guide/export.rst
+++ b/sphinx/source/docs/user_guide/export.rst
@@ -3,7 +3,7 @@
 Exporting Plots
 ===============
 
-Additional dependencies
+Additional Dependencies
 -----------------------
 
 In order to use the |export| functions, users may have to install additional
@@ -40,7 +40,7 @@ Limitations
 Responsive sizing_modes may generate layouts with unexpected size and aspect
 ratios. It is recommended to use the default ``fixed`` sizing mode.
 
-Example usage
+Example Usage
 ~~~~~~~~~~~~~
 
 Usage is similar to the |save| and |show| functions.
@@ -92,7 +92,7 @@ SVG plot using a SaveTool from the toolbar. However, currently an SVG export
 of a plot with a toolbar will have a blank area where the toolbar was rendered
 in the browser.
 
-Example usage
+Example Usage
 ~~~~~~~~~~~~~
 
 The SVG backend is activated by setting the ``Plot.output_backend`` attribute

--- a/sphinx/source/docs/user_guide/export.rst
+++ b/sphinx/source/docs/user_guide/export.rst
@@ -13,7 +13,7 @@ dependencies. One option is to install them via conda:
 
     conda install selenium geckodriver firefox -c conda-forge
 
-Alternatively one can use ``chromedriver`` and ``chromium`` browser (or one of
+Alternatively, one can use ``chromedriver`` and ``chromium`` browser (or one of
 its variants). Typically at least one compatible browser will be available on
 modern systems, thus installing a web browser may not be necessary. Bokeh will
 search for available browsers (and drivers) and use what's available, unless
@@ -76,10 +76,10 @@ that can be edited in image editing programs such as Adobe Illustrator and/or
 converted to PDFs.
 
 The SVG output isn't as performant as the default Canvas backend when it comes
-to rendering large number of glyphs or handling lots of user interactions like
+to rendering a large number of glyphs or handling lots of user interactions like
 panning.
 
-Like PNGs, in order to create a SVG with a transparent background, users
+Like PNGs, in order to create an SVG with a transparent background, users
 should set the ``Plot.background_fill_color`` and ``Plot.border_fill_color``
 properties to ``None``.
 
@@ -87,7 +87,7 @@ Limitations
 ~~~~~~~~~~~
 
 It's not possible to create a single SVG for a layout of plots, as each plot
-is it's own distinct SVG element. Alternatively, it's possible to download a
+is its own distinct SVG element. Alternatively, it's possible to download an
 SVG plot using a SaveTool from the toolbar. However, currently an SVG export
 of a plot with a toolbar will have a blank area where the toolbar was rendered
 in the browser.
@@ -105,22 +105,22 @@ to ``"svg"``.
     # option two
     plot.output_backend = "svg"
 
-Exporting a SVG Image
-~~~~~~~~~~~~~~~~~~~~~
+Exporting an SVG Image
+~~~~~~~~~~~~~~~~~~~~~~
 
-The simplest method to manually export a SVG plot is to install a browser
+The simplest method to manually export an SVG plot is to install a browser
 bookmarklet from the New York Times called `SVG-Crowbar`_. When clicked, it
 runs a snippet of JavaScript and adds a prompt on the page to download the
 plot. It's written to work with Chrome and should work with Firefox in most
 cases.
 
-Alternatively, it's possible to download a SVG plot using the ``SaveTool``, but
+Alternatively, it's possible to download an SVG plot using the ``SaveTool``, but
 the toolbar isn't captured though it figures into the plot layout solver
 calculations. It's not great, but a workable option.
 
 For headless export, there's a utility function, |export_svgs|, which similar
 usage to the |save| and |show| functions. This function will download all of
-SVG-enabled plots within a layout as distinct SVG files.
+the SVG-enabled plots within a layout as distinct SVG files.
 
 .. code-block:: python
 

--- a/sphinx/source/docs/user_guide/extensions.rst
+++ b/sphinx/source/docs/user_guide/extensions.rst
@@ -189,7 +189,7 @@ the special header update as the slider moves:
 .. bokeh-plot:: docs/user_guide/examples/extensions_putting_together_ts.py
     :source-position: none
 
-.. _userguide_extensions_specifying_implemenation_languages:
+.. _userguide_extensions_specifying_implementation_languages:
 
 Specifying Implementation Languages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -295,7 +295,7 @@ of the base classes in :bokeh-tree:`bokehjs/src/lib/models`.
 
 .. _userguide_extensions_prebuilt:
 
-Pre-built extensions
+Pre-Built Extensions
 --------------------
 
 So far, we covered simple, typically inline extensions. Those are great for

--- a/sphinx/source/docs/user_guide/extensions.rst
+++ b/sphinx/source/docs/user_guide/extensions.rst
@@ -12,13 +12,13 @@ custom user extensions.
 
 * Modify the behavior of existing Bokeh models
 * Add new models to connect third-party JavaScript libraries to Python
-* Create highly specialized models for domain specific use-cases.
+* Create highly specialized models for domain-specific use-cases.
 
 Custom extensions can be made and used with standard releases, and do not
 require setting up a development environment or building anything from source.
 They provide the easiest way to get involved in Bokeh development. By lowering
 the bar for extending Bokeh, users are afforded the ability to "try out" new
-features and functionality (which might some day be candidates for adding to
+features and functionalities (which might someday be candidates for adding to
 the core library) without having to wait on the core team.
 
 .. _userguide_extensions_structure:
@@ -52,7 +52,7 @@ below:
 
         slider = Instance(Slider)
 
-Since we would like to create a custom extension that can participate in DOM
+Since we would like to create a custom extension that can participate in the DOM
 layout, we subclass from :class:`~bokeh.models.layouts.HTMLBox`. We also
 added two properties: a :class:`~bokeh.core.properties.String` to configure
 a text message for the readout, and an :class:`~bokeh.core.properties.Instance`
@@ -144,10 +144,10 @@ Putting it Together
 
 For built-in Bokeh models, the implementation in BokehJS is automatically
 matched with the corresponding Python model by the build process. In order
-connect JavaScript implementations to Python models, one additional step
-is needed. The Python class should have have a class attribute called
+to connect JavaScript implementations to Python models, one additional step
+is needed. The Python class should have a class attribute called
 ``__implementation__`` whose value is the TypeScript (or JavaScript) code
-that the defines the client-side model as well as any optional views.
+that defines the client-side model as well as any optional views.
 
 Assuming the TypeScript code above was saved in a file ``custom.ts``,
 then the complete Python class might look like:
@@ -165,7 +165,7 @@ then the complete Python class might look like:
 
         slider = Instance(Slider)
 
-Then, if this class is defined in a Python module ``custom.py`` then the custom
+If this class is defined in a Python module ``custom.py``, the custom
 extension can now be used exactly like any built-in Bokeh model:
 
 .. code-block:: python
@@ -195,7 +195,7 @@ Specifying Implementation Languages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the value of ``__implementation__`` is a single line that ends in one of
-the know extensions ``.js``, or ``.ts`` then the it is interpretedas a filename.
+the know extensions ``.js``, or ``.ts``, it is interpreted as a filename.
 The corresponding file is opened and its contents are compiled appropriately
 according to the file extension.
 
@@ -219,8 +219,8 @@ include third-party Javascript libraries or CSS resources. Bokeh supports
 supplying external resources through the Python class attributes
 ``__javascript__`` and ``__css__`` of custom models.
 
-Including the URL paths to external resources will causes Bokeh to add
-the resources to the html document head, causing the Javascript library to be
+Including the URL paths to external resources will cause Bokeh to add
+the resources to the HTML document head, causing the Javascript library to be
 available in the global namespace and the custom CSS styling to be applied.
 
 One example is including the JS and CSS files for `KaTeX`_ (a
@@ -250,7 +250,7 @@ Integration with Bokeh Server
 No special work or modification is needed to integrate custom user extensions
 with the Bokeh server. As for standalone documents, the JavaScript
 implementation is automatically included in the rendered application.
-Additionally the standard synchronization of Bokeh model properties that
+Additionally, the standard synchronization of Bokeh model properties that
 happens for all built-in models happens transparently for custom user
 extensions as well.
 
@@ -261,7 +261,7 @@ Examples
 
 Here we present some complete examples to serve as a reference. It is hoped
 that the information in this section is a useful point of departure for anyone
-creating a custom extensions. However, creating extensions is a somewhat
+creating a custom extension. However, creating extensions is a somewhat
 advanced topic. In many cases, it will be required to study the source code
 of the base classes in :bokeh-tree:`bokehjs/src/lib/models`.
 
@@ -275,7 +275,7 @@ of the base classes in :bokeh-tree:`bokehjs/src/lib/models`.
 
 :ref:`userguide_extensions_examples_ticking`
     Subclass built-in Bokeh models for axis ticking to customize their
-    behaviour.
+    behavior.
 
 :ref:`userguide_extensions_examples_tool`
     Make a completely new tool that can draw on a plot canvas.
@@ -298,21 +298,21 @@ of the base classes in :bokeh-tree:`bokehjs/src/lib/models`.
 Pre-built extensions
 --------------------
 
-So far we covered simple, typically inline extensions. Those are great for
-adhoc additions to bokeh, but serious development like this gets pretty
-tedious very quickly. For example, writing extension's TypeScript or
-JavaScript files in an IDE doesn't allow to take full advantage of such
-IDE's capabilities, due to implicit nature of certain configuration files
+So far, we covered simple, typically inline extensions. Those are great for
+ad hoc additions to Bokeh, but serious development like this gets pretty
+tedious very quickly. For example, writing an extension's TypeScript or
+JavaScript files in an IDE doesn't allow us to take full advantage of such
+IDE's capabilities, due to the implicit nature of certain configuration files
 like ``package.json`` or ``tsconfig.json``. This can be fixed by using
-another approach to bokeh extensions, which are pre-built extensions.
+another approach to Bokeh extensions, which are pre-built extensions.
 
-To create a pre-built extension one can use ``bokeh init`` command, which
+To create a pre-built extension, one can use the ``bokeh init`` command, which
 creates all the necessary files, including ``bokeh.ext.json``, ``package.json``
-and ``tsconfig.json``, and possibly other. Additionally using ``bokeh init
---interactive`` allows to create and customize an extension step-by-step.
-Later such extension can be build with ``bokeh build`` command. This runs
+and ``tsconfig.json``, and possibly others. Additionally, using ``bokeh init
+--interactive`` allows us to create and customize an extension step by step.
+Later, such an extension can be built with ``bokeh build`` command. This runs
 ``npm install`` if necessary, compiles TypeScript files, transpiles JavaScript
-files, resolves modules and links them together in distributable bundles.
+files, resolves modules, and links them together in distributable bundles.
 Compilation products are cached for improved performance. If this causes
-issues, one can rebuild an extension from scratch by using ``bokeh build
+issues, one can rebuild an extension from scratch by using the ``bokeh build
 --rebuild`` command.

--- a/sphinx/source/docs/user_guide/extensions.rst
+++ b/sphinx/source/docs/user_guide/extensions.rst
@@ -18,7 +18,7 @@ Custom extensions can be made and used with standard releases, and do not
 require setting up a development environment or building anything from source.
 They provide the easiest way to get involved in Bokeh development. By lowering
 the bar for extending Bokeh, users are afforded the ability to "try out" new
-features and functionalities (which might someday be candidates for adding to
+features and improved functionality (which might someday be candidates for adding to
 the core library) without having to wait on the core team.
 
 .. _userguide_extensions_structure:

--- a/sphinx/source/docs/user_guide/geo.rst
+++ b/sphinx/source/docs/user_guide/geo.rst
@@ -67,11 +67,10 @@ Bokeh's ``GeoJSONDataSource`` can be used almost seamlessly in place of Bokeh's
     :source-position: above
 
 .. warning::
-    It is important to note that, behind the scenes, Bokeh converts the
-    GeoJSON coordinates into columns called `x` and `y` or `xs` and `ys`
-    (depending on whether the features are Points, Lines, MultiLines, Polygons,
-    or MultiPolygons). *Properties with clashing names will be overridden when
-    the GeoJSON is converted and should be avoided*.
+    Behind the scenes, Bokeh converts the GeoJSON coordinates into columns called
+    `x` and `y` or `xs` and `ys` (depending on whether the features are Points, 
+    Lines, MultiLines, Polygons, or MultiPolygons). *Properties with clashing names
+    will be overridden when the GeoJSON is converted and should be avoided*.
 
 .. _GeoJSON: http://geojson.org
 .. _github: https://github.com/bokeh/bokeh

--- a/sphinx/source/docs/user_guide/geo.rst
+++ b/sphinx/source/docs/user_guide/geo.rst
@@ -68,7 +68,7 @@ Bokeh's ``GeoJSONDataSource`` can be used almost seamlessly in place of Bokeh's
 
 .. warning::
     Behind the scenes, Bokeh converts the GeoJSON coordinates into columns called
-    `x` and `y` or `xs` and `ys` (depending on whether the features are Points, 
+    `x` and `y` or `xs` and `ys` (depending on whether the features are Points,
     Lines, MultiLines, Polygons, or MultiPolygons). *Properties with clashing names
     will be overridden when the GeoJSON is converted and should be avoided*.
 

--- a/sphinx/source/docs/user_guide/geo.rst
+++ b/sphinx/source/docs/user_guide/geo.rst
@@ -5,8 +5,8 @@ Mapping Geo Data
 
 Bokeh has started adding support for working with Geographical data. There are
 a number of powerful features already available, but we still have more to add.
-Please tell us your use cases through the `Discourse`_ or on `github`_ so that we
-can continue to build out these features to meet your needs.
+Please tell us your use cases through `Discourse`_ or on `GitHub`_ so that we
+can continue to extend these features to meet your needs.
 
 .. _userguide_geo_tile_provider_maps:
 
@@ -31,7 +31,7 @@ Google Maps
 -----------
 
 Bokeh can also plot glyphs over a Google Map using the :func:`~bokeh.plotting.gmap`
-function. You must pass this function a `Google API Key`_ in order for it to work, as
+function. You must pass a `Google API Key`_ to this function in order for it to work, as
 well as any :class:`~bokeh.models.map_plots.GMapOptions` to configure the Google Map
 underlay. The Google API Key will be stored in the Bokeh Document JSON.
 
@@ -39,10 +39,10 @@ underlay. The Google API Key will be stored in the Bokeh Document JSON.
     :source-position: below
 
 .. note::
-    Google has its own terms of service for using Google Maps API and any use
+    Google has its own Terms of Service for using the Google Maps API, and any use
     of Bokeh with Google Maps must be within Google's Terms of Service
 
-Also note that Google Maps exert explicit control over aspect ratios at all
+Also note that Google Maps exerts explicit control over aspect ratios at all
 times, which imposes some limitations on ``GMapPlot``:
 
 * Only ``Range1d`` ranges are supported. Attempting to use other range types
@@ -57,7 +57,7 @@ GeoJSON Data
 ------------
 
 `GeoJSON`_ is a popular open standard for representing geographical features
-with JSON. It describes points, lines and polygons (called Patches in Bokeh) as a
+with JSON. It describes points, lines, and polygons (called Patches in Bokeh) as a
 collection of features. Each feature can also have a set of properties.
 
 Bokeh's ``GeoJSONDataSource`` can be used almost seamlessly in place of Bokeh's
@@ -67,11 +67,11 @@ Bokeh's ``GeoJSONDataSource`` can be used almost seamlessly in place of Bokeh's
     :source-position: above
 
 .. warning::
-    It is important to note that behind the scenes, Bokeh converts the
-    GeoJSON coordinates into columns called `x` and `y` or `xs` and `ys`)
-    (depending on whether the features are Points, Lines, MultiLines, Polygons
+    It is important to note that, behind the scenes, Bokeh converts the
+    GeoJSON coordinates into columns called `x` and `y` or `xs` and `ys`
+    (depending on whether the features are Points, Lines, MultiLines, Polygons,
     or MultiPolygons). *Properties with clashing names will be overridden when
-    the GeoJSON is converted, and should be avoided*.
+    the GeoJSON is converted and should be avoided*.
 
 .. _GeoJSON: http://geojson.org
 .. _github: https://github.com/bokeh/bokeh

--- a/sphinx/source/docs/user_guide/graph.rst
+++ b/sphinx/source/docs/user_guide/graph.rst
@@ -14,16 +14,16 @@ sub-GlyphRenderers for the graph nodes and the graph edges. This allows for
 customizing the nodes by modifying the GraphRenderer's ``node_renderer``
 property. It's possible to replace the default Circle node glyph with any
 XYGlyph instance, for example a Rect or Ellipse glyph. Similarly, the style
-properties of the edges can modified through the ``edge_renderer`` property.
+properties of the edges can be modified through the ``edge_renderer`` property.
 The edge glyph is currently limited to a MultiLine glyph.
 
-There are a couple requirements for the data sources belonging to these
+There are a couple of requirements for the data sources belonging to these
 sub-renderers:
 
 - The ColumnDataSource associated with the node sub-renderer must have a column
   named ``"index"`` that contains the unique indices of the nodes.
 - The ColumnDataSource associated with the edge sub-renderer has two required
-  columns: ``"start"`` and ``"end"``. These columns contain the node indices of
+  columns: ``"start"`` and ``"end"``. These columns contain the node indices
   for the start and end of the edges.
 
 It's possible to add extra meta-data to these data sources to in order to
@@ -70,7 +70,7 @@ Layout Providers
 ----------------
 
 Bokeh uses a separate ``LayoutProvider`` model in order to supply the coordinates
-of a graph in Cartesian space. Currently the only built-in provider is the
+of a graph in Cartesian space. Currently, the only built-in provider is the
 :class:`~bokeh.models.graphs.StaticLayoutProvider` model, which contains a
 dictionary of (x,y) coordinates for the nodes.
 
@@ -82,16 +82,16 @@ This example adds a provider to the above code snippet:
 Explicit Paths
 --------------
 
-By default the :class:`~bokeh.models.graphs.StaticLayoutProvider` will
+By default, the :class:`~bokeh.models.graphs.StaticLayoutProvider` will
 draw straight-line paths between the supplied node positions. In order
-to supply explicit edge paths you may also supply lists of paths to
+to supply explicit edge paths, you may also supply lists of paths to
 the ``edge_renderer``
 :class:`bokeh.models.sources.ColumnDataSource`. The
 :class:`~bokeh.models.graphs.StaticLayoutProvider` will look for these
 paths on the ``"xs"`` and ``"ys"`` columns of the data source. Note
 that these paths should be in the same order as the ``"start"`` and
 ``"end"`` points. Also note that there is no validation that they
-match up with the node positions so be extra careful when setting
+match up with the node positions, so be extra careful when setting
 explicit paths.
 
 This example extends the example from above to draw quadratic bezier
@@ -143,7 +143,7 @@ In ``from_networkx``, NetworkX's node/edge attributes are converted for
 GraphRenderer's ``node_renderer``/``edge_renderer``.
 
 For example, "Zachary's Karate Club graph" dataset has a node attribute named
-"club". It's possible to hover these information using the node attributes
+"club". It's possible to hover this information using the node attributes
 converted in ``from_networkx``. Similarly, node/edge attributes can also be
 used for color information.
 

--- a/sphinx/source/docs/user_guide/interaction.rst
+++ b/sphinx/source/docs/user_guide/interaction.rst
@@ -15,7 +15,7 @@ Making Interactions
     highlighting when making selections.
 
 :ref:`userguide_interaction_legends`
-    Bokeh ``Legends`` can be configure to allow for easily hiding or muting
+    Bokeh ``Legends`` can be configured to allow for easily hiding or muting
     corresponding glyphs.
 
 :ref:`userguide_interaction_widgets`

--- a/sphinx/source/docs/user_guide/interaction/callbacks.rst
+++ b/sphinx/source/docs/user_guide/interaction/callbacks.rst
@@ -4,24 +4,24 @@ JavaScript Callbacks
 --------------------
 
 While the main goal of Bokeh is to provide a path to create rich interactive
-visualizations in the browser, purely from python, there will always be
+visualizations in the browser purely from Python, there will always be
 specialized use-cases that are outside the capabilities of the core library.
 For this reason, Bokeh provides different ways for users to supply custom
 JavaScript when necessary, so that users may add custom or specialized
-behaviours in response to property changes and other events.
+behaviors in response to property changes and other events.
 
 One mechanism is the ability to add entire new custom extension models,
-as described in :ref:`userguide_extensions`. However it is also possible
+as described in :ref:`userguide_extensions`. However, it is also possible
 to supply small snippets of JavaScript as callbacks to use, e.g when property
-values change, or when UI or other events occur. This kind of callback can be
-used to add interesting interactions to Bokeh documents without the need to
-use a Bokeh server (but can also be used in conjunction with a Bokeh server).
+values change or when UI or other events occur. This kind of callback can be
+used to add interesting interactions to Bokeh documents without requiring
+a Bokeh server (but can also be used in conjunction with a Bokeh server).
 
 .. warning::
     The explicit purpose of these callbacks is to embed *raw JavaScript
     code* for a browser to execute. If any part of the code is derived from
     untrusted user inputs, then you must take appropriate care to sanitize
-    the user input prior to passing to Bokeh.
+    the user input prior to passing it to Bokeh.
 
 .. _userguide_interaction_jscallbacks_customjs:
 
@@ -74,7 +74,7 @@ any Bokeh model, using the ``js_on_change`` method of Bokeh models:
 
 It should be mentioned that the first parameter to ``js_on_change`` is
 actually the name of a BokehJS event. The full format for a property
-change event is, e.g. ``"change:start"`` but Bokeh will automatically
+change event is, e.g., "change:start", but Bokeh will automatically
 convert any property name into one of these BokehJS change events for you.
 Additionally, some Bokeh models have additional specialized events. For
 example, the ``ColumnDataSource`` also supports ``"patch"`` and ``"stream"``
@@ -124,7 +124,7 @@ available event classes using the ``display_event`` function in order to
 generate the ``CustomJS`` objects. This function is used to update the ``Div``
 with the event name (always accessible from the ``event_name``
 attribute) as well as all the other applicable event attributes. The
-result is a plot that when interacted with, displays the corresponding
+result is a plot that, when interacted with, displays the corresponding
 event on the right:
 
 .. bokeh-plot:: docs/user_guide/examples/js_events.py
@@ -136,7 +136,7 @@ Examples
 CustomJS for Widgets
 ''''''''''''''''''''
 
-A common use case for property callbacks is responsing to changes to widgets.
+A common use case for property callbacks is responding to changes to widgets.
 The code below shows an example of ``CustomJS`` set on a slider Widget that
 changes the source of a plot when the slider is used.
 
@@ -156,7 +156,7 @@ similar way.
     :source-position: above
 
 Another more sophisticated example is shown below. It computes the average `y`
-value of any selected points (including multiple disjoint selections), and draws
+value of any selected points (including multiple disjoint selections) and draws
 a line through that value.
 
 .. bokeh-plot:: docs/user_guide/examples/interaction_callbacks_for_selections_lasso_mean.py
@@ -187,7 +187,7 @@ CustomJS for Specialized Events
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In addition to the generic mechanisms described above for adding ``CustomJS``
-callbacks to Bokeh models, there are also a some Bokeh models that have a
+callbacks to Bokeh models, there are also some Bokeh models that have a
 ``.callback`` property specifically for executing ``CustomJS`` in response
 to specific events or situations.
 
@@ -201,7 +201,7 @@ CustomJS for Hover
 ''''''''''''''''''
 
 The ``HoverTool`` has a callback which comes with two pieces of built-in data: the
-`index`, and the `geometry`. The `index` is the indices of any points that the
+`index` and the `geometry`. The `index` is the indices of any points that the
 hover tool is over.
 
 .. bokeh-plot:: docs/user_guide/examples/interaction_callbacks_for_hover.py
@@ -213,7 +213,7 @@ OpenURL
 Opening an URL when users click on a glyph (for instance a circle marker) is
 a very popular feature. Bokeh lets users enable this feature by exposing an
 OpenURL callback object that can be passed to a Tap tool in order to have that
-action called whenever the users clicks on the glyph.
+action called whenever the user clicks on the glyph.
 
 The following code shows how to use the OpenURL action combined with a TapTool
 to open an URL whenever the user clicks on a circle.

--- a/sphinx/source/docs/user_guide/interaction/callbacks.rst
+++ b/sphinx/source/docs/user_guide/interaction/callbacks.rst
@@ -74,7 +74,7 @@ any Bokeh model, using the ``js_on_change`` method of Bokeh models:
 
 It should be mentioned that the first parameter to ``js_on_change`` is
 actually the name of a BokehJS event. The full format for a property
-change event is, e.g., "change:start", but Bokeh will automatically
+change event is, e.g., ``"change:start"``, but Bokeh will automatically
 convert any property name into one of these BokehJS change events for you.
 Additionally, some Bokeh models have additional specialized events. For
 example, the ``ColumnDataSource`` also supports ``"patch"`` and ``"stream"``
@@ -124,8 +124,8 @@ available event classes using the ``display_event`` function in order to
 generate the ``CustomJS`` objects. This function is used to update the ``Div``
 with the event name (always accessible from the ``event_name``
 attribute) as well as all the other applicable event attributes. The
-result is a plot that, when interacted with, displays the corresponding
-event on the right:
+result is a plot that displays the corresponding event on the right when the
+user interacts with it:
 
 .. bokeh-plot:: docs/user_guide/examples/js_events.py
     :source-position: above
@@ -201,7 +201,7 @@ CustomJS for Hover
 ''''''''''''''''''
 
 The ``HoverTool`` has a callback which comes with two pieces of built-in data: the
-`index` and the `geometry`. The `index` is the indices of any points that the
+``index`` and the ``geometry``. The ``index`` is the indices of any points that the
 hover tool is over.
 
 .. bokeh-plot:: docs/user_guide/examples/interaction_callbacks_for_hover.py

--- a/sphinx/source/docs/user_guide/interaction/legends.rst
+++ b/sphinx/source/docs/user_guide/interaction/legends.rst
@@ -29,7 +29,7 @@ Muting Glyphs
 Other times it is preferable for legend interaction to mute a glyph, instead
 of hiding it entirely. In this case, set ``click_policy`` property to
 ``"mute"``. Additionally, the visual properties of a "muted glyph" also
-need to be specified. In general this is does in exactly the same way as for
+need to be specified. In general, this is done in exactly the same way as for
 :ref:`userguide_styling_selected_unselected_glyphs` or
 :ref:`userguide_styling_hover_inspections`. In the example below,
 ``muted_alpha=0.2`` and ``muted_color=color`` are passed to ``circle`` to

--- a/sphinx/source/docs/user_guide/interaction/linking.rst
+++ b/sphinx/source/docs/user_guide/interaction/linking.rst
@@ -4,7 +4,7 @@ Linking Behavior
 ----------------
 
 It's often useful to link plots to add connected interactivity between plots.
-This section shows an easy way to do it using the |bokeh.plotting| interface.
+This section shows an easy way to do this, using the |bokeh.plotting| interface.
 
 .. _userguide_interaction_linked_panning:
 

--- a/sphinx/source/docs/user_guide/interaction/widgets.rst
+++ b/sphinx/source/docs/user_guide/interaction/widgets.rst
@@ -128,7 +128,7 @@ A multi-select widget to present multiple available options:
 RadioButtonGroup
 ~~~~~~~~~~~~~~~~
 
-A radio button group can have at most one selected button at at time:
+A radio button group can have at most one selected button at a time:
 
 .. bokeh-plot:: docs/user_guide/examples/interaction_radio_button_group.py
     :source-position: below
@@ -153,7 +153,7 @@ Slider
 ~~~~~~
 
 The Bokeh slider can be configured with ``start`` and ``end`` values, a ``step`` size,
-an initial ``value`` and a ``title``:
+an initial ``value``, and a ``title``:
 
 .. bokeh-plot:: docs/user_guide/examples/interaction_slider.py
     :source-position: below
@@ -162,7 +162,7 @@ RangeSlider
 ~~~~~~~~~~~
 
 The Bokeh range-slider can be configured with ``start`` and ``end`` values, a ``step`` size,
-an initial ``value`` and a ``title``:
+an initial ``value``, and a ``title``:
 
 .. bokeh-plot:: docs/user_guide/source_examples/interaction_range_slider.py
     :source-position: below
@@ -170,7 +170,7 @@ an initial ``value`` and a ``title``:
 Tabs
 ~~~~
 
-Tab panes allow multiple plots or layouts to be show in selectable tabs:
+Tab panes allow multiple plots or layouts to be shown in selectable tabs:
 
 .. bokeh-plot:: docs/user_guide/examples/interaction_tab_panes.py
     :source-position: below

--- a/sphinx/source/docs/user_guide/jupyter.rst
+++ b/sphinx/source/docs/user_guide/jupyter.rst
@@ -11,7 +11,7 @@ Working in Notebooks
 `Jupyter`_ notebooks are computable documents often used for exploratory work,
 data analysis, teaching, and demonstration. A notebook is a series of *input
 cells* that can be individually executed to display their output immediately
-after the cell. In addition to  *Classic Notebooks*, there are also notebooks for
+after the cell. In addition to  *Classic* notebooks, there are also notebooks for
 the newer *JupyterLab* project. Bokeh can embed both standalone and Bokeh server
 content with either.
 
@@ -23,12 +23,12 @@ Standalone Output
 ~~~~~~~~~~~~~~~~~
 
 Standalone Bokeh content (i.e. that does not use a Bokeh server) can be embedded
-directly in classic Jupyter Notebooks as well as in JupyterLab.
+directly in classic Jupyter notebooks as well as in JupyterLab.
 
 Classic Notebook
 ++++++++++++++++
 
-To display Bokeh plots inline in a classic Jupyter Notebook, use the
+To display Bokeh plots inline in a classic Jupyter notebook, use the
 |output_notebook| function from |bokeh.io| instead of (or in addition to)
 the |output_file| function we have seen previously. No other modifications
 are required. When |show| is called, the plot will be displayed inline in
@@ -75,7 +75,7 @@ It is also possible to embed full Bokeh server applications that can connect
 plot events and Bokeh's built-in widgets directly to Python callback code.
 See :ref:`userguide_server` for general information about Bokeh server
 applications, and the following notebook for a complete example of a Bokeh
-application embedded in a Jupyter Notebook:
+application embedded in a Jupyter notebook:
 
 * :bokeh-tree:`examples/howto/server_embed/notebook_embed.ipynb`
 
@@ -157,7 +157,7 @@ is typically located under the "File" menu:
 Notebook Slides
 ~~~~~~~~~~~~~~~
 
-It is possible to use a Jupyter Notebook in conjunction with `Reveal.js`_
+It is possible to use a notebook in conjunction with `Reveal.js`_
 to generate slideshows from notebook cell content. It is also possible to
 include standalone (i.e. non-server) Bokeh plots in such sideshows, however,
 some steps must be followed to correctly display the output. Primarily: **the
@@ -230,7 +230,7 @@ following example notebooks:
 Jupyter Interactors
 ~~~~~~~~~~~~~~~~~~~
 
-It is possible to drive updates to Bokeh plots using Jupyter Notebook widgets,
+It is possible to drive updates to Bokeh plots using notebook widgets,
 known as `interactors`_. The key to doing this is the |push_notebook| function
 described above. Typically it is called in the update callback for the
 interactors, to update the plot from widget values. A screenshot of the
@@ -257,14 +257,14 @@ notebook is shown below:
 More Example Notebooks
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Many more examples using Jupyter Notebook can be found in the `bokeh-notebook`_
+Many more examples using notebook can be found in the `bokeh-notebook`_
 repository. First, clone the repository locally:
 
 .. code:: sh
 
     git clone https://github.com/bokeh/bokeh-notebooks.git
 
-Then, launch Jupyter Notebook in your web browser. Alternatively, live notebooks
+Then, launch the Jupyter notebooks in your web browser. Alternatively, live notebooks
 that can be run immediately online are hosted by `Binder`_.
 
 Additionally, there are some notebooks under `examples`_ in the main `Bokeh`_
@@ -366,7 +366,7 @@ To run this, assuming the code is saved under ``ipy_slider.py``, we issue
 application is available at http://localhost:5006/ipy_slider.
 
 From here, one can create more complex layouts and include advanced widgets,
-like `ipyleaflet`_, `ipyvolume`_, etc. More examples are available in Bokeh's
+like `ipyleaflet`_, `ipyvolume`_, etc. More examples are available in the Bokeh
 repository under ``examples/howto/ipywidgets``.
 
 .. _IPyWidgets: https://ipywidgets.readthedocs.io

--- a/sphinx/source/docs/user_guide/jupyter.rst
+++ b/sphinx/source/docs/user_guide/jupyter.rst
@@ -11,7 +11,7 @@ Working in Notebooks
 `Jupyter`_ notebooks are computable documents often used for exploratory work,
 data analysis, teaching, and demonstration. A notebook is a series of *input
 cells* that can be individually executed to display their output immediately
-after the cell. In addition to  *Classic Notebooks* there are also notebooks for
+after the cell. In addition to  *Classic Notebooks*, there are also notebooks for
 the newer *JupyterLab* project. Bokeh can embed both standalone and Bokeh server
 content with either.
 
@@ -19,16 +19,16 @@ content with either.
 
 .. _userguide_jupyter_notebook_inline_plots:
 
-Standalone output
+Standalone Output
 ~~~~~~~~~~~~~~~~~
 
 Standalone Bokeh content (i.e. that does not use a Bokeh server) can be embedded
-directly in classic Jupyter notebooks as well as in JupyterLab.
+directly in classic Jupyter Notebooks as well as in JupyterLab.
 
 Classic Notebook
 ++++++++++++++++
 
-To display Bokeh plots inline in a classic Jupyter notebooks, use the
+To display Bokeh plots inline in a classic Jupyter Notebook, use the
 |output_notebook| function from |bokeh.io| instead of (or in addition to)
 the |output_file| function we have seen previously. No other modifications
 are required. When |show| is called, the plot will be displayed inline in
@@ -49,7 +49,7 @@ JupyterLab
 ++++++++++
 
 In order to embed Bokeh plots inside of JupyterLab, you need to install
-the two JupyterLab extensions. First install *jupyterlab-manager* by running
+the two JupyterLab extensions. First, install *jupyterlab-manager* by running
 the following command:
 
 .. code:: sh
@@ -71,11 +71,11 @@ Once this is installed, usage is the same as with classic notebooks above.
 Bokeh Server Applications
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It is also possible to embed full Bokeh server applications, that can connect
-plot events, and Bokeh's built-in widgets, directly to Python callback code.
+It is also possible to embed full Bokeh server applications that can connect
+plot events and Bokeh's built-in widgets directly to Python callback code.
 See :ref:`userguide_server` for general information about Bokeh server
 applications, and the following notebook for a complete example of a Bokeh
-application embedded in a Jupyter notebook:
+application embedded in a Jupyter Notebook:
 
 * :bokeh-tree:`examples/howto/server_embed/notebook_embed.ipynb`
 
@@ -85,12 +85,12 @@ JupyterHub
 In order to embed Bokeh server applications when running notebooks from your own
 JupyterHub instance, some additional steps are necessary to enable network
 connectivity between the client browser and the Bokeh server running in the
-JupyterLab cell.  This is because your browser needs to connect to the port the
+JupyterLab cell. This is because your browser needs to connect to the port the
 Bokeh server is listening on, but JupyterHub is acting as a reverse proxy
 between your browser and your JupyterLab container. Follow all the JupyterLab
 instructions above, then continue with the following steps below.
 
-First, you must install the ``nbserverproxy`` server extension This can be done
+First, you must install the ``nbserverproxy`` server extension. This can be done
 by running the command:
 
 .. code:: sh
@@ -98,10 +98,10 @@ by running the command:
     pip install nbserverproxy && jupyter serverextension enable --py nbserverproxy
 
 Second, you must define a function to help create the URL that the browser
-uses to connect to the Bokeh server.  This will be passed into |show| in
-the final step.  A reference implementation is provided here, although you
+uses to connect to the Bokeh server. This will be passed into |show| in
+the final step. A reference implementation is provided here, although you
 must either modify it or define the environment variable ``EXTERNAL_URL``
-to the URL of your JupyterHub installation.  By default, JupyterHub will set
+to the URL of your JupyterHub installation. By default, JupyterHub will set
 ``JUPYTERHUB_SERVICE_PREFIX``.
 
 .. code-block:: python
@@ -140,10 +140,10 @@ setting up the server and creating the URL for loading the graph:
 At this point, the Bokeh graph should load and execute python
 callbacks defined in your JupyterLab environment.
 
-Trusting notebooks
+Trusting Notebooks
 ~~~~~~~~~~~~~~~~~~
 
-Depending on the version of the Notebook in use, it may be necessary to
+Depending on the version of the notebook in use, it may be necessary to
 "trust" the notebook in order for Bokeh plots to re-render when the
 notebook is closed and subsequently re-opened. The "Trust Notebook" option
 is typically located under the "File" menu:
@@ -157,10 +157,10 @@ is typically located under the "File" menu:
 Notebook Slides
 ~~~~~~~~~~~~~~~
 
-It is possible to use the Jupyter notebook in conjunction with `Reveal.js`_
+It is possible to use a Jupyter Notebook in conjunction with `Reveal.js`_
 to generate slideshows from notebook cell content. It is also possible to
-include standalone (i.e. non-server) Bokeh plots in such sideshows, however
-some steps must be followed for output to correctly display. Primarily: **the
+include standalone (i.e. non-server) Bokeh plots in such sideshows, however,
+some steps must be followed to correctly display the output. Primarily: **the
 cell containing** ``output_notebook`` **must be not be skipped**.
 
 The rendered cell output of the ``output_notebook`` call is responsible
@@ -174,8 +174,8 @@ wish to hide this cell, is to mark it as the *"notes"* slide type.
 Notebook Handles
 ~~~~~~~~~~~~~~~~
 
-It is possible to update a previously shown plot in-place. When the argument
-``notebook_handle=True`` is passed to |show| then a handle object is returned.
+It is possible to update a previously shown plot in place. When the argument
+``notebook_handle=True`` is passed to |show|, a handle object is returned.
 This handle object can be used with the |push_notebook| function to update
 the plot with any recent changes to plots properties, data source values, etc.
 This `notebook handle` functionality is only supported in classic Jupyter
@@ -230,8 +230,8 @@ following example notebooks:
 Jupyter Interactors
 ~~~~~~~~~~~~~~~~~~~
 
-It is possible to drive updates to Bokeh plots using Jupyter notebook widgets,
-known as `interactors`_. The key doing this is the |push_notebook| function
+It is possible to drive updates to Bokeh plots using Jupyter Notebook widgets,
+known as `interactors`_. The key to doing this is the |push_notebook| function
 described above. Typically it is called in the update callback for the
 interactors, to update the plot from widget values. A screenshot of the
 :bokeh-tree:`examples/howto/notebook_comms/Jupyter Interactors.ipynb` example
@@ -258,13 +258,13 @@ More Example Notebooks
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Many more examples using Jupyter Notebook can be found in the `bokeh-notebook`_
-repository. First clone the repository locally:
+repository. First, clone the repository locally:
 
 .. code:: sh
 
     git clone https://github.com/bokeh/bokeh-notebooks.git
 
-Then launch Jupyter Notebook in your web browser. Alternatively, live notebooks
+Then, launch Jupyter Notebook in your web browser. Alternatively, live notebooks
 that can be run immediately online are hosted by `Binder`_.
 
 Additionally, there are some notebooks under `examples`_ in the main `Bokeh`_
@@ -305,10 +305,10 @@ Notebook comms examples:
 
 .. _userguide_jupyter_ipywidgets:
 
-IPyWidgets Outside the Notebook
+IPyWidgets outside the Notebook
 -------------------------------
 
-In the previous section we learnt how to use Bokeh in JupyterLab and classical
+In the previous section, we learned how to use Bokeh in JupyterLab and classical
 notebook environments. Suppose we would like to do the opposite and take
 advantage of the vibrant Jupyter ecosystem, in particular `IPyWidgets`_, in
 a Bokeh application, outside the confines of those environments. This can be
@@ -366,7 +366,7 @@ To run this, assuming the code is saved under ``ipy_slider.py``, we issue
 application is available at http://localhost:5006/ipy_slider.
 
 From here, one can create more complex layouts and include advanced widgets,
-like `ipyleaflet`_, `ipyvolume`_, etc. More examples are available in bokeh's
+like `ipyleaflet`_, `ipyvolume`_, etc. More examples are available in Bokeh's
 repository under ``examples/howto/ipywidgets``.
 
 .. _IPyWidgets: https://ipywidgets.readthedocs.io

--- a/sphinx/source/docs/user_guide/layout.rst
+++ b/sphinx/source/docs/user_guide/layout.rst
@@ -37,7 +37,7 @@ Grids Layout for Plots
 ~~~~~~~~~~~~~~~~~~~~~~
 
 The |gridplot| function can be used to arrange
-Bokeh Plots in grid layout. |gridplot| also collects all
+Bokeh Plots in a grid layout. |gridplot| also collects all
 tools into a single toolbar, and the currently active tool is the same
 for all plots in the grid. It is possible to leave "empty" spaces in
 the grid by passing ``None`` instead of a plot object.
@@ -45,7 +45,7 @@ the grid by passing ``None`` instead of a plot object.
 .. bokeh-plot:: docs/user_guide/examples/layout_grid.py
     :source-position: above
 
-For convenience you can also just pass a list of plots, and specify the
+For convenience, you can also just pass a list of plots and specify the
 number of columns you want in your grid. For example,
 
 .. code-block:: python
@@ -189,11 +189,11 @@ different sizing modes:
 Limitations
 -----------
 
-The Bokeh layout system is not a completely generic, general purpose layout
+The Bokeh layout system is not a completely generic, general-purpose layout
 engine. It intentionally sacrifices some capability in order to make common
 use cases and scenarios simple to express. Extremely nested layouts with
 many different sizing modes may yield undesirable results, either in terms of
-performance, or visual appearance. For such cases it is recommended to use the
+performance, or visual appearance. For such cases, it is recommended to use the
 methods in :ref:`userguide_embed` along with your own custom HTML templates in
 order to take advantage of more sophisticated CSS layout possibilities.
 

--- a/sphinx/source/docs/user_guide/plotting.rst
+++ b/sphinx/source/docs/user_guide/plotting.rst
@@ -104,7 +104,7 @@ accomplished with the |multi_line| glyph method:
     :source-position: above
 
 .. note::
-    This glyph is unlike most other glyphs. Instead of accepting a 
+    This glyph is unlike most other glyphs. Instead of accepting a
     one-dimensional list or array of scalar values, it accepts a "list of lists"
     for x and y positions of each line, parameters xs and ys. multi_line
     also expects a scalar value or a list of scalers per each line for
@@ -266,10 +266,10 @@ This can be accomplished with the |patches| glyph method:
     :source-position: above
 
 .. note::
-    This glyph is unlike most other glyphs. Instead of accepting a 
+    This glyph is unlike most other glyphs. Instead of accepting a
     one-dimensional list or array of scalar values, it accepts a "list
     of lists" for x and y positions of each patch, parameters xs and ys.
-    patches also expects a scalar value or a list of scalers per each 
+    patches also expects a scalar value or a list of scalers per each
     patch for parameters such as color, alpha, linewidth, etc. Similarly,
     a ColumnDataSource may be used consisting of a "list of lists" and a
     list of scalars where the length of the list of scalars and length of

--- a/sphinx/source/docs/user_guide/plotting.rst
+++ b/sphinx/source/docs/user_guide/plotting.rst
@@ -9,7 +9,7 @@ Creating Figures
 ----------------
 
 Note that Bokeh plots created using the |bokeh.plotting| interface come with
-a default set of tools, and default visual styles. See :ref:`userguide_styling`
+a default set of tools and default visual styles. See :ref:`userguide_styling`
 for information about how to customize the visual style of plots, and
 :ref:`userguide_tools` for information about changing or specifying tools.
 
@@ -75,7 +75,7 @@ Single Lines
 ''''''''''''
 
 Below is an example that shows how to generate a single line glyph from
-one dimensional sequences of *x* and *y* points using the |line| glyph
+one-dimensional sequences of *x* and *y* points using the |line| glyph
 method:
 
 .. bokeh-plot:: docs/user_guide/examples/plotting_line_single.py
@@ -104,13 +104,13 @@ accomplished with the |multi_line| glyph method:
     :source-position: above
 
 .. note::
-    This glyph is unlike most other glyphs. Instead of accepting a one
-    dimensional list or array of scalar values, it accepts a "list of lists"
+    This glyph is unlike most other glyphs. Instead of accepting a 
+    one-dimensional list or array of scalar values, it accepts a "list of lists"
     for x and y positions of each line, parameters xs and ys. multi_line
     also expects a scalar value or a list of scalers per each line for
     parameters such as color, alpha, linewidth, etc. Similarly, a
     ColumnDataSource may be used consisting of a "list of lists" and a
-    lists of scalars where the length of the list of scalars and length of
+    list of scalars where the length of the list of scalars and length of
     lists must match.
 
 Missing Points
@@ -143,7 +143,7 @@ Bars and Rectangles
 Bars
 ''''
 
-When drawing rectangular bars (often representing intervals) it is often
+When drawing rectangular bars (often representing intervals), it is often
 more convenient to have coordinates that are a hybrid of the two systems
 above. Bokeh provides the |hbar| and |vbar| glyphs function for this
 purpose.
@@ -164,7 +164,7 @@ Stacked Bars
 ''''''''''''
 
 It is often desirable to stack bars. This can be accomplished with the
-|vbar_stack| and |hbar_stack| convenience methods. Note the these methods
+|vbar_stack| and |hbar_stack| convenience methods. Note that these methods
 stack columns from an explicitly supplied ``ColumnDataSource`` (see the section
 :ref:`userguide_data` for more information).
 
@@ -234,9 +234,9 @@ Stacked Areas
 '''''''''''''
 
 It is often desirable to stack directed areas. This can be accomplished with
-the |varea_stack| and |harea_stack| convenience methods. Note the these methods
+the |varea_stack| and |harea_stack| convenience methods. Note that these methods
 stack columns from an explicitly supplied ``ColumnDataSource`` (see the section
-:ref:`userguide_data` for more information.
+:ref:`userguide_data` for more information).
 
 .. bokeh-plot:: docs/user_guide/examples/plotting_varea_stack.py
     :source-position: above
@@ -250,7 +250,7 @@ Single Patches
 ''''''''''''''
 
 Below is an example that shows how to generate a single polygonal patch
-glyph from one dimensional sequences of *x* and *y* points using the
+glyph from one-dimensional sequences of *x* and *y* points using the
 |patch| glyph method:
 
 .. bokeh-plot:: docs/user_guide/examples/plotting_patch_single.py
@@ -266,13 +266,13 @@ This can be accomplished with the |patches| glyph method:
     :source-position: above
 
 .. note::
-    This glyph is unlike most other glyphs. Instead of accepting a one
-    dimensional list or array of scalar values, it accepts a "list of lists"
-    for x and y positions of each patch, parameters xs and ys. patches
-    also expects a scalar value or a list of scalers per each patch for
-    parameters such as color, alpha, linewidth, etc. Similarly, a
-    ColumnDataSource may be used consisting of a "list of lists" and a
-    lists of scalars where the length of the list of scalars and length of
+    This glyph is unlike most other glyphs. Instead of accepting a 
+    one-dimensional list or array of scalar values, it accepts a "list
+    of lists" for x and y positions of each patch, parameters xs and ys.
+    patches also expects a scalar value or a list of scalers per each 
+    patch for parameters such as color, alpha, linewidth, etc. Similarly,
+    a ColumnDataSource may be used consisting of a "list of lists" and a
+    list of scalars where the length of the list of scalars and length of
     lists must match.
 
 Missing Points
@@ -296,12 +296,12 @@ Polygons with Holes
 
 The |multi_polygons| glyph uses nesting to accept a variety of information
 relevant to polygons. Anything that can be rendered as a |Patches| can also be
-rendered as |multi_polygons|, but additionally |multi_polygons| can render
+rendered as |multi_polygons|, but additionally, |multi_polygons| can render
 holes inside each polygon.
 
 .. note::
-    This glyph is unlike most other glyphs. Instead of accepting a one
-    dimensional list or array of scalar values, it accepts a 3 times nested
+    This glyph is unlike most other glyphs. Instead of accepting a one-dimensional
+    list or array of scalar values, it accepts a 3 times nested
     list of x and y positions for the exterior and holes composing each
     polygon. MultiPolygons also expects a scalar value or a list of scalers
     per each item for parameters such as color, alpha, linewidth, etc.
@@ -343,7 +343,7 @@ represents a part of the MultiPolygon:
 Multiple MultiPolygons
 ''''''''''''''''''''''
 
-The top level of nesting is used to separate each MultiPolygon from the
+The top-level of nesting is used to separate each MultiPolygon from the
 others. Each MultiPolygon can be thought of as a row in the data source -
 potentially with a corresponding label or color.
 
@@ -369,7 +369,7 @@ Images
 
 You can display images on Bokeh plots using the |image|, |image_rgba|, and
 |image_url| glyph methods. It is possible to use a hover tool with image glyphs
-to allow for interactive inspection of the values any any pixel. For more
+to allow for interactive inspection of the values of any pixel. For more
 information on how to enable hover with images, please consult the
 :ref:`Image Hover section <userguide_tools_image_hover>` of the User's Guide.
 
@@ -396,7 +396,7 @@ method. The next example shows how to do this:
 .. bokeh-plot:: docs/user_guide/examples/plotting_image.py
     :source-position: above
 
-Also note in the above example we have set the render level to ``"image"``.
+Also note that in the above example we have set the render level to ``"image"``.
 Normally, all glyphs are drawn *above* grid lines, but setting the ``"image"``
 render level can be used to draw *underneath* the grid lines.
 
@@ -444,7 +444,7 @@ filled wedge instead:
     :source-position: above
 
 The |annular_wedge| glyph method is similar to |arc|, but draws a filled area.
-It accepts a ``inner_radius`` and ``outer_radius`` instead of just ``radius``:
+It accepts an ``inner_radius`` and ``outer_radius`` instead of just ``radius``:
 
 .. bokeh-plot:: docs/user_guide/examples/plotting_annular_wedge.py
     :source-position: above
@@ -527,7 +527,7 @@ Categorical Axes
 
 Categorical axes are created by specifying a
 :class:`~bokeh.models.ranges.FactorRange` for one of the plot ranges (or a
-lists of factors to be converted to one). Below is a simple example, for
+list of factors to be converted to one). Below is a simple example, for
 complete details see :ref:`userguide_categorical`.
 
 .. bokeh-plot:: docs/user_guide/examples/plotting_categorical_axis.py
@@ -543,7 +543,7 @@ times, it is desirable to have an axis that can display labels that
 are appropriate to different date and time scales.
 
 .. note::
-    This example requires a network connection, and depends on the
+    This example requires a network connection and depends on the
     open source Pandas library in order to more easily present realistic
     timeseries data.
 

--- a/sphinx/source/docs/user_guide/quickstart.rst
+++ b/sphinx/source/docs/user_guide/quickstart.rst
@@ -50,7 +50,7 @@ NumPy, you may instead use ``pip`` at the command line:
     The ``pip`` method does not install the examples. Clone the Git repository
     and look in the ``examples/`` directory of the checkout to see examples.
 
-.. _userguide_quickstart_gettng_started:
+.. _userguide_quickstart_getting_started:
 
 Getting Started
 ===============
@@ -61,8 +61,8 @@ detailed information please consult the full :ref:`userguide`.
 
 Let's begin with some examples.
 
-Plotting data in basic Python lists as a line plot including zoom,
-pan, save, and other tools is simple and straightforward:
+Plotting data in basic Python lists as a line plot, including zoom,
+pan, save, and other tools, is simple and straightforward:
 
 .. bokeh-plot::
     :source-position: above
@@ -86,18 +86,18 @@ pan, save, and other tools is simple and straightforward:
     show(p)
 
 When you execute this script, you will see that a new output file
-``"lines.html"`` is created, and that a browser automatically opens a new tab
-to display it. (For presentation purposes we have included the plot output
-directly inline in this document.)
+``"lines.html"`` is created and that a browser automatically opens a new tab
+to display it (for presentation purposes we have included the plot output
+directly inline in this document).
 
 The basic steps to creating plots with the |bokeh.plotting| interface are:
 
 Prepare some data
-    In this case plain Python lists, but NumPy arrays or Pandas series also
+    In this case, plain Python lists, but NumPy arrays or Pandas series also
     work.
 
 Tell Bokeh where to generate output
-    In this case using |output_file|, with the filename ``"lines.html"``.
+    In this case, using |output_file|, with the filename ``"lines.html"``.
     Another option is |output_notebook| for use in Jupyter notebooks.
 
 Call |figure|
@@ -106,7 +106,7 @@ Call |figure|
 
 Add renderers
     In this case, we use |Figure.line| for our data, specifying visual
-    customizations like colors, legends and widths.
+    customizations like colors, legends, and widths.
 
 Ask Bokeh to |show| or |save| the results
     These functions save the plot to an HTML file and optionally display it in
@@ -117,7 +117,7 @@ some of the examples below.
 
 The |bokeh.plotting| interface is also quite handy if we need to customize
 the output a bit more by adding more data series, glyphs, logarithmic axis,
-and so on. It's easy to combine multiple glyphs together on one plot as shown
+and so on. It's easy to combine multiple glyphs together on one plot, as shown
 below:
 
 .. bokeh-plot::
@@ -175,7 +175,7 @@ The `Bokeh GitHub repository`_ also has a number of example notebooks in the
 
     jupyter notebook
 
-You can open and interact with any of the notebooks listed in the index page
+You can open and interact with any of the notebooks listed on the index page
 that automatically opens up. In particular, you might check out these examples,
 which show how Bokeh can be used together with Jupyter interactive widgets:
 
@@ -275,7 +275,7 @@ load BokehJS from ``cdn.bokeh.org``. However, you can also configure Bokeh
 to generate static HTML files with BokehJS resources embedded directly inside,
 by passing the argument ``mode="inline"`` to the |output_file| function.
 
-More examples
+More Examples
 =============
 
 Here are a few more examples to demonstrate other common tasks and use cases
@@ -283,7 +283,7 @@ with the |bokeh.plotting| interface.
 
 .. _userguide_quickstart_vectorized:
 
-Vectorized colors and sizes
+Vectorized Colors and Sizes
 ---------------------------
 
 This example shows how it is possible to provide sequences of data values for
@@ -328,7 +328,7 @@ for in this example:
 
 .. _userguide_quickstart_linked:
 
-Linked panning and brushing
+Linked Panning and Brushing
 ---------------------------
 
 Linking together various aspects of different plots can be a useful technique
@@ -433,14 +433,14 @@ plot.
 
 .. _userguide_quickstart_datetime:
 
-Datetime axes
+Datetime Axes
 -------------
 
 Dealing with date and time series is another common task. Bokeh has a
 sophisticated |DatetimeAxis| that can change the displayed ticks based
 on the current scale of the plot. There are some inputs for which Bokeh
 will automatically default to |DatetimeAxis|, but you can always
-explicitly ask for one by passing the value ``"datetime"`` to  the
+explicitly ask for one by passing the value ``"datetime"`` to the
 ``x_axis_type`` or ``y_axis_type`` parameters to |figure|. A few things
 of interest to look out for in this example:
 
@@ -535,10 +535,10 @@ and apps, consult the :ref:`userguide_server` section of the
 
 .. _userguide_quickstart_next:
 
-What's next?
+What's Next?
 ============
 
-This Quickstart barely scratches the surface of Bokeh capability.
+This Quickstart barely scratches the surface of Bokeh's capabilities.
 
 For more information about the different plotting APIs Bokeh offers,
 using the Bokeh server, and how to embed Bokeh plots in your own apps and

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -14,22 +14,22 @@ running Python code.
 
 The architecture of Bokeh is such that high-level "model objects"
 (representing things like plots, ranges, axes, glyphs, etc.) are created
-in Python, and then converted to a JSON format that is consumed by the
+in Python and then converted to a JSON format that is consumed by the
 client library, BokehJS. (See :ref:`userguide_concepts` for a more detailed
-discussion.) By itself, this flexible and decoupled design offers advantages,
-for instance it is easy to have other languages (R, Scala, Lua, ...) drive
+discussion.) By itself, this flexible and decoupled design offers advantages.
+For instance, it is easy to have other languages (R, Scala, Lua, ...) drive
 the exact same Bokeh plots and visualizations in the browser.
 
-However, if it were possible to keep the "model objects" in python and in
-the browser in sync with one another, then more additional and powerful
+However, if it were possible to keep the "model objects" in Python and in
+the browser in sync with one another, more additional and powerful
 possibilities immediately open up:
 
 * respond to UI and tool events generated in a browser with computations or
-  queries using the full power of python
+  queries using the full power of Python
 * automatically push server-side updates to the UI (i.e. widgets or plots in a browser)
 * use periodic, timeout, and asynchronous callbacks to drive streaming updates
 
-**This capability to synchronize between python and the browser is the main
+**This capability to synchronize between Python and the browser is the main
 purpose of the Bokeh Server.**
 
 ----
@@ -74,7 +74,7 @@ Local or Individual Use
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 One way that you might want to use the Bokeh server is during exploratory
-data analysis, possibly in a Jupyter notebook. Alternatively, you might
+data analysis, possibly in a Jupyter Notebook. Alternatively, you might
 want to create a small app that you can run locally, or that you can send
 to colleagues to run locally. The Bokeh server is very useful and easy to
 use in this scenario. Both of the methods here below can be used effectively:
@@ -82,7 +82,7 @@ use in this scenario. Both of the methods here below can be used effectively:
 * :ref:`userguide_server_bokeh_client`
 * :ref:`userguide_server_applications`
 
-For the most flexible approach, that could transition most directly to a
+For the most flexible approach which could transition most directly to a
 deployable application, it is suggested to follow the techniques in
 :ref:`userguide_server_applications`.
 
@@ -107,11 +107,11 @@ Shared Publishing
 ~~~~~~~~~~~~~~~~~
 
 Both of the scenarios above involve a *single creator* making applications
-on the server, either for their own local use, or for consumption by a
+on the server, either for their own local use or for consumption by a
 larger audience. Another scenario is the case where a group of *several
-creators* all want publish different applications to the same server. **This
-is not a good use-case for single Bokeh server.** Because it is possible to
-create applications that execute arbitrary python code, process isolation and
+creators* all want to publish different applications to the same server. **This
+is not a good use-case for a single Bokeh server.** Because it is possible to
+create applications that execute arbitrary Python code, process isolation and
 security concerns make this kind of shared tenancy prohibitive.
 
 In order to support this kind of multi-creator, multi-application environment,
@@ -155,7 +155,7 @@ There are a few different ways to provide the application code.
 
 .. _userguide_server_applications_single_module:
 
-Single module format
+Single Module Format
 ~~~~~~~~~~~~~~~~~~~~
 
 Let's look again at a complete example and then examine some specific parts
@@ -242,7 +242,7 @@ also possible to create applications from directories.
 
 .. _userguide_server_applications_directory:
 
-Directory format
+Directory Format
 ~~~~~~~~~~~~~~~~
 
 Bokeh applications may also be created by creating and populating a filesystem
@@ -292,14 +292,14 @@ The optional components are
 
 * A ``templates`` subdirectory with ``index.html`` Jinja template file. The directory may contain additional Jinja templates for ``index.html`` to refer to. The template should have the same parameters as the :class:`~bokeh.core.templates.FILE` template. See :ref:`userguide_server_template` for more details.
 
-When executing your ``main.py`` Bokeh server ensures that the standard
+When executing your ``main.py``, Bokeh server ensures that the standard
 ``__file__`` module attribute works as you would expect. So it is possible
-to include data files or custom user defined models in your directory
+to include data files or custom user-defined models in your directory
 however you like.
 
 Additionally, the application directory is also added to ``sys.path`` so that
 Python modules in the application directory may be easily imported. However, if
-an ``__init__.py`` is present in the directory then the app is usable as a
+an ``__init__.py`` is present in the directory, the app is usable as a
 package, and standard package-relative imports will also work.
 
 An example might be:
@@ -350,7 +350,7 @@ from ``models/custom.js``
 
 .. _userguide_server_template:
 
-Customising the Application's Jinja Template
+Customizing the Application's Jinja Template
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As described above in :ref:`userguide_server_applications_directory`, you can override
@@ -367,7 +367,7 @@ Embedding Figures in the Template
 
 In the main thread of the Bokeh application, i.e. ``main.py``, any Bokeh figures
 that are going to be referenced in the templated code need to have their ``name``
-attribute set, and be added to the current document root.
+attribute set and be added to the current document root.
 
 .. code-block:: python
 
@@ -426,8 +426,8 @@ When a session is created for a Bokeh application, the session context is made
 available as ``curdoc().session_context``. The most useful function of the
 session context is to make the Tornado HTTP request object available to the
 application as ``session_context.request``. Due to an incompatibility issue with
-the usage of ``--num-procs`` the HTTP request is not made available directly.
-Instead only the ``arguments`` attribute is available in full and only the
+the usage of ``--num-procs``, the HTTP request is not made available directly.
+Instead, only the ``arguments`` attribute is available in full, and only the
 subset of ``cookies`` and ``headers`` which are allowed by the ``--include-headers``,
 ``--exclude-headers``, ``--include-cookies`` and ``--exclude-cookies`` are
 made available. Attempting to access any other attribute on ``request`` will
@@ -464,7 +464,7 @@ plot):
 Request Handler Hooks
 ~~~~~~~~~~~~~~~~~~~~~
 
-Since the full tornado HTTP request is not guaranteed to be available on the
+Since the full Tornado HTTP request is not guaranteed to be available on the
 process serving the session, a custom handler can be defined to make additional
 information available.
 
@@ -480,8 +480,8 @@ a conventionally named ``process_request`` function:
         return {}
 
 The handler is given the Tornado HTTP request and can process the request
-and return a dictionary which will be made available on
-``curdoc().session_context.token_payload``. In this way additional information
+and return a dictionary, which will be made available on
+``curdoc().session_context.token_payload``. In this way, additional information
 can be made available to work around some of the issues when ``--num-procs``
 is used.
 
@@ -490,7 +490,7 @@ is used.
 Callbacks and Events
 ~~~~~~~~~~~~~~~~~~~~
 
-Before jumping in to callbacks and events specifically in the context of the
+Before jumping into callbacks and events specifically in the context of the
 Bokeh Server, it's worth discussing different use-cases for callbacks in
 general.
 
@@ -502,8 +502,8 @@ create callbacks that execute in the browser, using ``CustomJS`` and other
 methods. See :ref:`userguide_interaction_jscallbacks` for more detailed
 information and examples.
 
-It is critical to note that **no python code is ever executed when a CustomJS
-callback is used**. This is true even when the call back is supplied as python
+It is critical to note that **no Python code is ever executed when a CustomJS
+callback is used**. This is true even when the call back is supplied as Python
 code to be translated to JavaScript. A ``CustomJS`` callback is only executed
 inside the browser's JavaScript interpreter, and thus can only directly interact
 with JavaScript data and functions (e.g., BokehJS models).
@@ -519,18 +519,18 @@ the Jupyter Python kernel. It is often useful to have these callbacks call
 detailed information, see :ref:`userguide_jupyter_notebook_jupyter_interactors`.
 
 .. note::
-    It is currently possible to push updates from python, to BokehJS (i.e.,
-    to update plots, etc.) using :func:`~bokeh.io.push_notebook`. To add
+    It is currently possible to push updates from Python to BokehJS (i.e.
+    to update plots, etc.), using :func:`~bokeh.io.push_notebook`. To add
     two-way communication (e.g. to have a range or selection update trigger
-    a python callback) embed a Bokeh Server in the notebook.
+    a Python callback), embed a Bokeh Server in the notebook.
     See :bokeh-tree:`examples/howto/server_embed/notebook_embed.ipynb`
 
-Updating From Threads
+Updating from Threads
 '''''''''''''''''''''
 
 If the app needs to perform blocking computation, it is possible to perform
 that work in a separate thread. However, updates to the Document must be
-scheduled via a next-tick callback.  The callback
+scheduled via a next-tick callback. The callback
 will execute as soon as possible on the next iteration of the
 Tornado event loop, and will automatically acquire necessary locks to update the
 document state safely.
@@ -542,7 +542,7 @@ document state safely.
 
 It is important to emphasize that the document update must be scheduled in a "next tick callback".
 Any usage that directly updates the document state from another thread, either by calling other document
-methods, or by setting properties on Bokeh models, risks data and protocol
+methods or by setting properties on Bokeh models, risks data and protocol
 corruption.
 
 It is also important to save a local copy of ``curdoc()`` so that all
@@ -598,15 +598,15 @@ then execute
 
 .. warning::
     There is currently no locking around adding next tick callbacks to
-    documents. It is recommended that at most one thread add callbacks to
-    the document. It is planned to add more fine grained locking to
+    documents. It is recommended that at most one thread adds callbacks to
+    the document. It is planned to add more fine-grained locking to
     callback methods in the future.
 
 Updating from Unlocked Callbacks
 ''''''''''''''''''''''''''''''''
 
 Normally Bokeh session callbacks recursively lock the document until all
-future work they initiate is completed.  However, you may want to drive
+future work they initiate is completed. However, you may want to drive
 blocking computations from callbacks using Tornado's
 ``ThreadPoolExecutor`` in an asynchronous callback. This can work, but requires
 the Bokeh provided :func:`~bokeh.document.without_document_lock` decorator
@@ -680,7 +680,7 @@ Lifecycle Hooks
 ~~~~~~~~~~~~~~~
 
 Sometimes it is desirable to have code execute at specific times in a server
-or session lifetime. For instance, if you are using a Bokeh Server along side
+or session lifetime. For instance, if you are using a Bokeh Server alongside
 a Django server, you would need to call ``django.setup()`` once, as each
 Bokeh server starts, to initialize Django properly for use by Bokeh
 application code.
@@ -737,7 +737,7 @@ Embedding Bokeh Server as a Library
 -----------------------------------
 
 It can be useful to embed the Bokeh Server in a larger Tornado application, or the
-Jupyter notebook, and use the already existing Tornado ``IOloop``.  Here is the
+Jupyter Notebook, and use the already existing Tornado ``IOloop``. Here is the
 basis of how to integrate Bokeh in such a scenario:
 
 .. code-block:: python
@@ -754,7 +754,7 @@ basis of how to integrate Bokeh in such a scenario:
    server.start()
 
 It is also possible to create and control an ``IOLoop`` directly. This can
-be useful to create standalone "normal" python scripts that serve Bokeh apps,
+be useful to create standalone "normal" Python scripts that serve Bokeh apps,
 or to embed a Bokeh application into a framework like Flask or Django without
 having to run a separate Bokeh server process. Some examples of this technique
 can be found in the examples directory:
@@ -775,15 +775,15 @@ Connecting with ``bokeh.client``
 --------------------------------
 
 There is also a client API for interacting directly with a Bokeh Server. The
-client API can be used to make modifications Bokeh documents in existing
+client API can be used to make modifications to Bokeh documents in existing
 sessions in a Bokeh server.
 
 .. figure:: /_images/bokeh_serve_client.svg
     :align: center
     :width: 65%
 
-    Typically web browsers make connections to a Bokeh server, but it is
-    possible to connect from python by using the ``bokeh.client`` module.
+    Typically, web browsers make connections to a Bokeh server, but it is
+    possible to connect from Python by using the ``bokeh.client`` module.
 
 This can be useful, for example, to make user-specific customizations to a
 Bokeh app that is embedded by another web framework such as Flask or Django.
@@ -822,7 +822,7 @@ embeds the sliders app, but changes the plot title *before* passing to the user:
     outside a Bokeh server, including running and servicing callbacks by making
     a blocking call to ``session.loop_until_closed`` in the external Python
     process using ``bokeh.client``. This usage has a number of inherent
-    technical disadvantages, and should be considered unsupported.
+    technical disadvantages and should be considered unsupported.
 
 .. _userguide_server_deployment:
 
@@ -831,8 +831,8 @@ Deployment Scenarios
 
 With an application we are developing, we can run it locally any time we want to interact
 with it. To share it with other people who are able to install the required
-python stack, we can share the application with them, and let them run it locally
-themselves in the same manner. However, we might also want to deploy the application
+Python stack, we can share the application and let them run it locally
+in the same manner. However, we might also want to deploy the application
 in a way that other people can access it as a service:
 
 * without having to install all of the prerequisites
@@ -855,7 +855,7 @@ internal network.
 
 However, it is often the case that there are needs around authentication,
 scaling, and uptime. In these cases, more sophisticated deployment
-configurations are needed. In the following sections we discuss some of
+configurations are needed. In the following sections, we discuss some of
 these considerations.
 
 SSH Tunnels
@@ -884,12 +884,12 @@ tunnel to the remote host:
 Replace *user* with your username on the remote host and *remote.host* with
 the hostname/IP address of the system hosting the Bokeh server. You may be
 prompted for login credentials for the remote system. After the connection
-is set up you will be able to navigate to ``localhost:5006`` as though the
+is set up, you will be able to navigate to ``localhost:5006`` as though the
 Bokeh server were running on the local machine.
 
 The second, slightly more complicated case occurs when there is a gateway
-between the server and the local machine.  In that situation a reverse tunnel
-must be established from the server to the gateway. Additionally the tunnel
+between the server and the local machine. In that situation, a reverse tunnel
+must be established from the server to the gateway. Additionally, the tunnel
 from the local machine will also point to the gateway.
 
 Issue the following commands on the **remote host** where the Bokeh server
@@ -913,14 +913,14 @@ gateway. On the **local machine**:
 
 Again, replace *user* with your username on the gateway and *gateway.host*
 with the hostname/IP address of the gateway. You should now be able to access
-the Bokeh server from the local machine by navigating to ``localhost:5006``
-on the local machine, as if the Bokeh server were running on the local machine.
-You can even set up client connections from a Jupyter notebook running on the
+the Bokeh server from the local machine as if the Bokeh server were running
+on the local machine by navigating to ``localhost:5006`` on the local machine.
+You can even set up client connections from a Jupyter Notebook running on the
 local machine.
 
 .. note::
     We intend to expand this section with more guidance for other tools and
-    configurations. If have experience with other web deployment scenarios
+    configurations. If you have experience with other web deployment scenarios
     and wish to contribute your knowledge here, please
     contact us on https://discourse.bokeh.org
 
@@ -929,7 +929,7 @@ local machine.
 SSL Termination
 ~~~~~~~~~~~~~~~
 
-A Bokeh server can be configure to terminate SSL connections (i.e. to service
+A Bokeh server can be configured to terminate SSL connections (i.e. to service
 secure HTTPS and WSS sessions) directly. At a minimum, the ``--ssl-certfile``
 argument must be supplied. The value must be the path to a single file in PEM
 format containing the certificate as well as any number of CA certificates
@@ -948,15 +948,15 @@ setting the ``--ssl-keyfile`` command line argument, or by setting the
 private key, it should be supplied by setting the ``BOKEH_SSL_PASSWORD``
 environment variable.
 
-Alternatively, you may wish to run a Bokeh server behind a proxy, and have the
+Alternatively, you may wish to run a Bokeh server behind a proxy and have the
 proxy terminate SSL. That scenario is described in the next section.
 
-.. _userguide_server_deplyoment_proxy:
+.. _userguide_server_deployment_proxy:
 
 Basic Reverse Proxy Setup
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If the goal is to serve an web application to the general Internet, it is
+If the goal is to serve a web application to the general internet, it is
 often desirable to host the application on an internal network, and proxy
 connections to it through some dedicated HTTP server. This sections provides
 guidance for basic configuration behind some common reverse proxies.
@@ -993,14 +993,14 @@ server configuration block is shown below:
 The above ``server`` block sets up Nginx to proxy incoming connections
 to ``127.0.0.1`` on port 80 to ``127.0.0.1:5100`` internally. To work in this
 configuration, we will need to use some of the command line options to
-configure the Bokeh Server. In particular we need to use ``--port`` to specify
+configure the Bokeh Server. In particular, we need to use ``--port`` to specify
 that the Bokeh Server should listen itself on port 5100.
 
 .. code-block:: sh
 
     bokeh serve myapp.py --port 5100
 
-Note that in the basic server block above we have not configured any special
+Note that in the basic server block above, we have not configured any special
 handling for static resources, e.g., the Bokeh JS and CSS files. This means
 that these files are served directly by the Bokeh server itself. While this
 works, it places an unnecessary additional load on the Bokeh server, since
@@ -1022,7 +1022,7 @@ process.
 Apache
 ''''''
 
-Another common HTTP server and proxy is Apache. Here is sample configuration
+Another common HTTP server and proxy is Apache. Here is a sample configuration
 for running a Bokeh server behind Apache:
 
 .. code-block:: apache
@@ -1054,7 +1054,7 @@ for running a Bokeh server behind Apache:
     </VirtualHost>
 
 The above configuration aliases `/static` to the location of the Bokeh
-static resources directory, however it is also possible (and probably
+static resources directory. However, it is also possible (and probably
 preferable) to copy the Bokeh static resources to whatever standard
 static files location is configured for Apache as part of the deployment.
 
@@ -1153,8 +1153,8 @@ Load Balancing with Nginx
 
 The architecture of the Bokeh server is specifically designed to be
 scalable---by and large, if you need more capacity, you simply run additional
-servers. Often in this situation it is desired to run all the Bokeh server
-instances behind a load balancer, so that new connections are distributed
+servers. In this situation, it is often desired to run all the Bokeh server
+instances behind a load balancer so that new connections are distributed
 amongst the individual servers.
 
 .. figure:: /_images/bokeh_serve_scale.svg
@@ -1227,7 +1227,7 @@ Authentication
 
 The Bokeh server itself does not have any facilities for authentication or
 authorization. However, the Bokeh server can be configured with an "Auth
-Provider" that hooks in to Tornado's underlying capabilities. For background
+Provider" that hooks into Tornado's underlying capabilities. For background
 information, see the Tornado docs for `Authentication and security`_. The rest
 of this section assumes some familiarity with that material.
 
@@ -1284,9 +1284,9 @@ vary based on the request, or cookies, etc. It is not possible to specify a
 ``LoginHandler`` when ``get_url_function`` is defined.
 
 Analogous to the login options, optional ``logout_url`` and ``LogoutHandler``
-values may be define an endpoint for logging users out.
+values may be used to define an endpoint for logging users out.
 
-If no auth module is provided, then a default user will be assumed, and no
+If no auth module is provided, a default user will be assumed, and no
 authentication will be required to access Bokeh server endpoints.
 
 .. warning::
@@ -1329,7 +1329,7 @@ misuse, the bokeh server will only initiate websocket connections from
 origins that are explicitly allowlisted. Requests with Origin headers that
 do not match the allowlist will generate HTTP 403 error responses.
 
-By default only ``localhost:5006`` is allowlisted. I.e the following two
+By default, only ``localhost:5006`` is allowlisted. I.e the following two
 invocations are identical:
 
 .. code-block:: sh
@@ -1343,12 +1343,12 @@ and
     bokeh serve --show --allow-websocket-origin=localhost:5006 myapp.py
 
 Both of these will open a browser to the default application URL
-``localhost:5006`` and since ``localhost:5006`` is in the allowed websocket
+``localhost:5006``, and since ``localhost:5006`` is in the allowed websocket
 origin allowlist, the Bokeh server will create and display a new session.
 
 Now, consider when a Bokeh server is embedded inside another web page, using
 |server_document| or |server_session|. In this instance, the "Origin" header
-for the request to the Bokeh server is the URL of page that has the Bokeh
+for the request to the Bokeh server is the URL of the page that has the Bokeh
 content embedded it. For example, if a user navigates to our page at
 ``https://acme.com/products``, which has a Bokeh application embedded in it,
 then the origin header reported by the browser will be ``acme.com``. In this
@@ -1356,7 +1356,7 @@ instance, we typically want to restrict the Bokeh server to honoring *only*
 requests that originate from our ``acme.com`` page, so that other pages cannot
 embed our Bokeh app without our knowledge.
 
-This can be accomplished  by setting the ``--allow-websocket-origin`` command
+This can be accomplished by setting the ``--allow-websocket-origin`` command
 line argument:
 
 .. code-block:: sh
@@ -1365,7 +1365,7 @@ line argument:
 
 This will prevent other sites from embedding our Bokeh application in their
 pages, because requests from users viewing those pages will report a different
-origin than  ``acme.com``, and the Bokeh server will reject them.
+origin than ``acme.com``, and the Bokeh server will reject them.
 
 .. warning::
     Bear in mind that this only prevents *other web pages* from surreptitiously
@@ -1376,7 +1376,7 @@ If multiple allowed origins are required, then multiple instances of
 ``--allow-websocket-origin`` can be passed on the command line.
 
 It is also possible to configure a Bokeh server to allow any and all connections
-Regardless of origin:
+regardless of origin:
 
 .. code-block:: sh
 
@@ -1390,12 +1390,12 @@ Signed session IDs
 By default, the Bokeh server will automatically create new sessions for all
 new requests from allowed websocket origins, even if no session ID is provided.
 When embedding a Bokeh app inside another web application (e.g. Flask, Django),
-we would like ensure that our web application, and *only* our web application,
+we would like to ensure that our web application, and *only* our web application,
 is capable of generating proper requests to the Bokeh server. It is possible to
 configure the Bokeh server to only create sessions when a cryptographically
 signed session ID is provided.
 
-To do this, you need to first create a secret for signing session ids with,
+To do this, you need to first create a secret to sign session ids with,
 using the ``bokeh secret`` command, e.g.
 
 .. code-block:: sh
@@ -1434,8 +1434,8 @@ Django or whatever tool is in use).
 XSRF Cookies
 ''''''''''''
 
-Bokeh can enable the use of Tornado's cross-site request forgery protection
-protection. To turn this feature on, use the ``--enable-xsrf-cookies`` option,
+Bokeh can enable the use of Tornado's cross-site request forgery protection. 
+To turn this feature on, use the ``--enable-xsrf-cookies`` option,
 or set the environment variable ``BOKEH_XSRF_COOKIES=yes``. If this setting is
 enabled, any PUT, POST, or DELETE operations on custom or login handlers must be
 instrumented properly in order to function. Typically, this means adding the
@@ -1450,7 +1450,7 @@ documentation on `XSRF Cookies`_.
 
 .. _userguide_server_deployment_scaling:
 
-Scaling the server
+Scaling the Server
 ~~~~~~~~~~~~~~~~~~
 
 You can fork multiple server processes with the `num-procs` option. For
@@ -1469,7 +1469,7 @@ Further Reading
 ---------------
 Now that you are familiar with the concepts of :ref:`userguide_server`, you
 may be interested in learning more about the internals of the Bokeh server
-in :ref:`devguide_server`
+in :ref:`devguide_server`.
 
 .. _Authentication and security: https://www.tornadoweb.org/en/stable/guide/security.html
 .. _demo.bokeh.org: https://demo.bokeh.org

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -1434,7 +1434,7 @@ Django or whatever tool is in use).
 XSRF Cookies
 ''''''''''''
 
-Bokeh can enable the use of Tornado's cross-site request forgery protection. 
+Bokeh can enable the use of Tornado's cross-site request forgery protection.
 To turn this feature on, use the ``--enable-xsrf-cookies`` option,
 or set the environment variable ``BOKEH_XSRF_COOKIES=yes``. If this setting is
 enabled, any PUT, POST, or DELETE operations on custom or login handlers must be

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -74,7 +74,7 @@ Local or Individual Use
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 One way that you might want to use the Bokeh server is during exploratory
-data analysis, possibly in a Jupyter Notebook. Alternatively, you might
+data analysis, possibly in a Jupyter notebook. Alternatively, you might
 want to create a small app that you can run locally, or that you can send
 to colleagues to run locally. The Bokeh server is very useful and easy to
 use in this scenario. Both of the methods here below can be used effectively:
@@ -511,7 +511,7 @@ with JavaScript data and functions (e.g., BokehJS models).
 Python Callbacks with Jupyter Interactors
 '''''''''''''''''''''''''''''''''''''''''
 
-If you are working in the Jupyter Notebook, it is possible to use Jupyter
+If you are working in the Jupyter notebook, it is possible to use Jupyter
 interactors to quickly create simple GUI forms automatically. Updates to the
 widgets in the GUI can trigger python callback functions that execute in
 the Jupyter Python kernel. It is often useful to have these callbacks call
@@ -737,7 +737,7 @@ Embedding Bokeh Server as a Library
 -----------------------------------
 
 It can be useful to embed the Bokeh Server in a larger Tornado application, or the
-Jupyter Notebook, and use the already existing Tornado ``IOloop``. Here is the
+Jupyter notebook, and use the already existing Tornado ``IOloop``. Here is the
 basis of how to integrate Bokeh in such a scenario:
 
 .. code-block:: python
@@ -915,7 +915,7 @@ Again, replace *user* with your username on the gateway and *gateway.host*
 with the hostname/IP address of the gateway. You should now be able to access
 the Bokeh server from the local machine as if the Bokeh server were running
 on the local machine by navigating to ``localhost:5006`` on the local machine.
-You can even set up client connections from a Jupyter Notebook running on the
+You can even set up client connections from a Jupyter notebook running on the
 local machine.
 
 .. note::

--- a/sphinx/source/docs/user_guide/styling.rst
+++ b/sphinx/source/docs/user_guide/styling.rst
@@ -9,7 +9,7 @@ Using Palettes
 --------------
 
 Palettes are sequences (lists or tuples) of RGB(A) hex strings that define a
-colormap and be can set as the ``color`` attribute of many plot objects from
+colormap and can be set as the ``color`` attribute of many plot objects from
 ``bokeh.plotting``. Bokeh offers many of the standard Brewer palettes, which
 can be imported from the ``bokeh.palettes`` module. For example, importing
 “Spectral6” gives a six element list of RGB(A) hex strings from the Brewer
@@ -53,7 +53,7 @@ These mapper functions return a ``DataSpec`` property that can be passed to the 
 Visual Properties
 -----------------
 
-In order to style the visual attributes of Bokeh plots, you first must
+In order to style the visual attributes of Bokeh plots, you need to
 know what the available properties are. The full :ref:`refguide` will
 list all the properties of every object individually, though there are three
 broad groups of properties that show up often. They are:
@@ -101,7 +101,7 @@ and off.
 .. bokeh-plot:: docs/user_guide/examples/styling_visible_property.py
     :source-position: above
 
-This can be particularly useful in interactive examples with bokeh server or CustomJS.
+This can be particularly useful in interactive examples with a Bokeh server or CustomJS.
 
 .. bokeh-plot:: docs/user_guide/examples/styling_visible_annotation_with_interaction.py
     :source-position: above
@@ -110,7 +110,7 @@ Specifying Colors
 ~~~~~~~~~~~~~~~~~
 
 Colors properties are used in many places in Bokeh, to specify the colors to
-use for lines, fills or text. Color values can be provided in any of the
+use for lines, fills, or text. Color values can be provided in any of the
 following ways:
 
 .. include:: ../includes/colors.txt
@@ -128,7 +128,7 @@ following ways:
 .. _GitHub: https://github.com/bokeh/bokeh/issues/2622
 
 Color alpha can be specified in multiple ways for the visual properties. This
-can be by specifying the alpha directly with ``line|fill_alpha``, or by
+can be done by specifying the alpha directly with ``line|fill_alpha``, or by
 providing the alpha through the RGBA 4-tuple for the ``line|fill_color``.
 
 Additionally, there is also the freedom to use a combination of the two, or no
@@ -153,9 +153,9 @@ Styling Arrow Annotations
 
 There are several `ArrowHead` subtypes that can be applied to Arrow
 annotations. Setting the `start` or `end` property to None will
-cause no arrow head to be applied at the specified arrow end. Double-sided
+cause no arrowhead to be applied at the specified arrow end. Double-sided
 arrows can be created by setting both `start` and `end` styles. Setting
-`visible` to false on an arrow will also make the corresponding arrow head
+`visible` to false on an arrow will also make the corresponding arrowhead
 invisible.
 
 .. bokeh-plot:: docs/user_guide/examples/styling_arrow_annotations.py
@@ -214,7 +214,7 @@ Plots
 |Plot| objects themselves have many visual characteristics that can be styled:
 the dimensions of the plot, backgrounds, borders, outlines, etc. This section
 describes how to change these attributes of a Bokeh plot. The example code
-primarily uses the |bokeh.plotting| interface to create plots, however the
+primarily uses the |bokeh.plotting| interface to create plots. However, the
 instructions apply regardless of how a Bokeh plot was created.
 
 .. _userguide_styling_plot_dimensions:
@@ -307,7 +307,7 @@ Outline
 ~~~~~~~
 
 The styling of the outline of the plotting area is controlled by a set of
-`Line Properties`_ on the |Plot|, that are prefixed with ``outline_``. For
+`Line Properties`_ on the |Plot|, which are prefixed with ``outline_``. For
 instance, to set the color of the outline, use ``outline_line_color``:
 
 .. bokeh-plot:: docs/user_guide/examples/styling_plot_outline_line_color.py
@@ -357,7 +357,7 @@ of the |GlyphRenderer| either manually or by passing them to |add_glyph|.
 
 The plot below demonstrates how to set these attributes using the
 |bokeh.plotting| interface. Click or tap circles on the plot to see the
-effect on the selected and nonselected glyphs. To clear the selection
+effect on the selected and non-selected glyphs. To clear the selection
 and restore the original state, click anywhere in the plot *outside* of a
 circle.
 
@@ -365,7 +365,7 @@ circle.
     :source-position: above
 
 If you just need to set the color or alpha parameters of the selected or
-nonselected glyphs, this can be accomplished even more simply by providing
+non-selected glyphs, this can be accomplished even more easily by providing
 color and alpha arguments to the glyph function, prefixed by ``"selection_"``
 or ``"nonselection_"``. The plot below demonstrates this technique:
 
@@ -399,7 +399,7 @@ Hover Inspections
 ~~~~~~~~~~~~~~~~~
 
 Setting the highlight policy for glyphs that are hovered over is completely
-analogous to setting the ``selection_glyph`` or ``nonselection_glyph``, or
+analogous to setting the ``selection_glyph`` or ``nonselection_glyph`` or
 by passing color or alpha parameters prefixed with ``"hover_"``. The example
 below demonstrates the latter method:
 
@@ -415,7 +415,7 @@ below demonstrates the latter method:
 Tool Overlays
 -------------
 
-Some Bokeh tools also have configurable visual attributes. For instance the
+Some Bokeh tools also have configurable visual attributes. For instance, the
 various region selection tools and box zoom tool all have an ``overlay``
 whose line and fill properties may be set:
 
@@ -430,8 +430,7 @@ ToolBar Autohide
 
 In addition to selecting the tools in toolbars, you can also control
 their appearance. The ``autohide`` attribute specifies that the toolbar is
-visible only when the mouse is inside the plot area, and otherwise it is
-hidden:
+visible only when the mouse is inside the plot area, otherwise it is hidden.
 
 .. bokeh-plot:: docs/user_guide/examples/styling_toolbar_autohide.py
     :source-position: above
@@ -442,7 +441,7 @@ hidden:
 Axes
 ----
 
-In this section you will learn how to change various visual properties
+In this section, you will learn how to change various visual properties
 of Bokeh plot axes.
 
 To set style attributes on Axis objects, use the |xaxis|, |yaxis|, and
@@ -454,7 +453,7 @@ To set style attributes on Axis objects, use the |xaxis|, |yaxis|, and
     [<bokeh.models.axes.LinearAxis at 0x106fa2390>]
 
 This returns a list of Axis objects (since there may be more than
-one). But note that, as convenience, these lists are *splattable*,
+one). But note that, as a convenience, these lists are *splattable*,
 meaning that you can set attributes directly on this result, and
 the attributes will be applied to all the axes in the list:
 
@@ -478,7 +477,7 @@ Labels
 
 The text of an overall label for an axis is controlled by the ``axis_label``
 property. Additionally, there are `Text Properties`_ prefixed with
-``axis_label_`` that control the visual appearance of the label. For instance
+``axis_label_`` that control the visual appearance of the label. For instance,
 to set the color of the label, set ``axis_label_text_color``. Finally, to
 change the distance between the axis label and the major tick labels, set
 the ``axis_label_standoff`` property:
@@ -525,7 +524,7 @@ explicitly, e.g.
     # no additional tick locations will be displayed on the x-axis
     p.xaxis.ticker = FixedTicker(ticks=[10, 20, 37.4])
 
-However it is also possible to supply the list of ticks directly, as a
+However, it is also possible to supply the list of ticks directly as a
 shortcut, e.g. ``p.xaxis.ticker = [10, 20, 37.4]``. The example below
 demonstrates this method.
 
@@ -540,7 +539,7 @@ a collection of `Line Properties`_, prefixed with ``major_tick_`` and
 ``minor_tick_``, respectively. For instance, to set the color of the
 major ticks, use ``major_tick_line_color``. To hide either set of ticks,
 set the color to ``None``. Additionally, you can control how far in and
-out of the plotting area the ticks extend, with the properties
+out of the plotting area the ticks extend with the properties
 ``major_tick_in``/``major_tick_out`` and ``minor_tick_in``/``minor_tick_out``.
 These values are in screen units, and negative values are acceptable.
 
@@ -556,7 +555,7 @@ The text styling of axis labels is controlled by a ``TickFormatter`` object
 configured on the axis' ``formatter`` property. Bokeh uses a number of ticker
 formatters by default in different situations:
 
-* |BasicTickFormatter| --- Default formatter for  linear axes.
+* |BasicTickFormatter| --- Default formatter for linear axes.
 
 * |CategoricalTickFormatter| --- Default formatter for categorical axes.
 
@@ -565,7 +564,7 @@ formatters by default in different situations:
 * |LogTickFormatter| --- Default formatter for log axes.
 
 These default tick formatters do not expose many configurable properties.
-To control tick formatting at a finer grained level, use one of the
+To control tick formatting at a finer-grained level, use one of the
 |NumeralTickFormatter| or |PrintfTickFormatter| described below.
 
 .. note::
@@ -582,7 +581,7 @@ to control the text formatting of axis ticks.
 .. bokeh-plot:: docs/user_guide/examples/styling_numerical_tick_formatter.py
     :source-position: above
 
-Many additional formats are available, see the full |NumeralTickFormatter|
+Many additional formats are available. See the full |NumeralTickFormatter|
 documentation in the :ref:`refguide`.
 
 ``PrintfTickFormatter``
@@ -635,7 +634,7 @@ section of the :ref:`refguide`.
 Grids
 -----
 
-In this section you will learn how to set the visual properties of grid
+In this section, you will learn how to set the visual properties of grid
 lines and grid bands on Bokeh plots.
 
 Similar to the convenience methods for axes, there are |xgrid|, |ygrid|,
@@ -649,7 +648,7 @@ objects:
      <bokeh.models.grids.Grid at 0x106fa22e8>]
 
 These methods also return splattable lists, so that you can set an attribute
-on the list, as if it was a single object, and the attribute is changed
+on the list as if it was a single object, and the attribute is changed
 for every element of the list:
 
 .. code-block:: python
@@ -741,7 +740,7 @@ objects:
     [<bokeh.models.annotations.Legend at 0x106fa2278>]
 
 This method also returns a splattable list, so that you can set an attribute
-on the list, as if it was a single object, and the attribute is changed
+on the list as if it was a single object, and the attribute is changed
 for every element of the list:
 
 .. code-block:: python

--- a/sphinx/source/docs/user_guide/styling.rst
+++ b/sphinx/source/docs/user_guide/styling.rst
@@ -95,7 +95,7 @@ Text Properties
 Visible property
 ~~~~~~~~~~~~~~~~
 
-Glyph renderers, axes, grids, and annotations all have a visible property that can be used to turn them on
+Glyph renderers, axes, grids, and annotations all have a ``visible`` property that can be used to turn them on
 and off.
 
 .. bokeh-plot:: docs/user_guide/examples/styling_visible_property.py

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -581,7 +581,7 @@ If no formatter is specified for a column name, the default ``"numeral"``
 formatter is assumed.
 
 Note that format specifications are also compatible with column names that
-have spaces. For example, ```@{adjusted close}{($ 0.00 a)}`` applies a format
+have spaces. For example, ``@{adjusted close}{($ 0.00 a)}`` applies a format
 to a column named "adjusted close".
 
 The example code below shows explicitly configuring a ``HoverTool`` with

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -17,11 +17,11 @@ Gestures
     - :ref:`userguide_tools_scrollpinch`
 
     For each type of gesture, one tool can be active at any given time, and
-    the active tool is indicated on the toolbar by a highlight next to to the
+    the active tool is indicated on the toolbar by a highlight next to the
     tool icon.
 
 :ref:`userguide_tools_actions`
-    These  are immediate or modal operations that are only activated when their
+    These are immediate or modal operations that are only activated when their
     button in the toolbar is pressed, such as the ``ResetTool``.
 
 :ref:`userguide_tools_inspectors`
@@ -42,8 +42,8 @@ describes how the toolbar may be configured.
 Positioning the Toolbar
 -----------------------
 
-By default, Bokeh plots come with a toolbar above the plot. In this section
-you will learn how to specify a different location for the toolbar, or to
+By default, Bokeh plots come with a toolbar above the plot. In this section,
+you will learn how to specify a different location for the toolbar, or how to
 remove it entirely.
 
 The toolbar location can be specified by passing the ``toolbar_location``
@@ -62,9 +62,9 @@ running the code and changing the ``toolbar_location`` value.
 .. bokeh-plot:: docs/user_guide/examples/tools_position_toolbar_clash.py
     :source-position: above
 
-Note that the toolbar position clashes with the default axes, in this case
+Note that the toolbar position clashes with the default axes, In this case,
 setting the ``toolbar_sticky`` option to ``False`` will move the toolbar
-to outside of the region where the axis is drawn.
+outside of the area where the axis is drawn.
 
 .. bokeh-plot:: docs/user_guide/examples/tools_position_toolbar.py
     :source-position: above
@@ -93,7 +93,7 @@ function. The tools parameter accepts a list of tool objects, for instance:
 
     tools = [BoxZoomTool(), ResetTool()]
 
-Tools can also be supplied conveniently with a comma-separate string
+Tools can also be supplied conveniently with a comma-separated string
 containing tool shortcut names:
 
 .. code-block:: python
@@ -123,7 +123,7 @@ Bokeh toolbars can have (at most) one active tool from each kind of gesture
 order of preference to choose one of each kind from the set of configured
 tools, to be active.
 
-However it is possible to exert control over which tool is active. At the
+However, it is possible to exert control over which tool is active. At the
 lowest ``bokeh.models`` level, this is accomplished by using the ``active_drag``,
 ``active_inspect``, ``active_scroll``, and ``active_tap`` properties of
 ``Toolbar``. These properties can take the following values:
@@ -204,7 +204,7 @@ BoxZoomTool
 * icon: |box_zoom_icon|
 
 The box zoom tool allows the user to define a rectangular region to zoom the
-plot bounds too, by left-dragging a mouse, or dragging a finger across the
+plot bounds to. This is done by left-dragging a mouse, or dragging a finger across the
 plot area.
 
 LassoSelectTool
@@ -312,8 +312,8 @@ WheelZoomTool
 * icon: |wheel_zoom_icon|
 
 The wheel zoom tool will zoom the plot in and out, centered on the current
-mouse location. It will respect any min and max values and ranges preventing
-zooming in and out beyond these.
+mouse location. It will respect any min and max values and ranges, preventing
+zooming in and out beyond these values.
 
 It is also possible to constraint the wheel zoom tool to only act on either
 just the x-axis or just the y-axis by setting the ``dimensions`` property to
@@ -328,7 +328,7 @@ WheelPanTool
 
 The wheel pan tool will translate the plot window along the specified
 dimension without changing the window's aspect ratio. The tool will respect any
-min and max values and ranges preventing panning beyond these values.
+min and max values and ranges, preventing panning beyond these values.
 
 .. _userguide_tools_actions:
 
@@ -344,7 +344,7 @@ UndoTool
 * name: ``'undo'``
 * icon: |undo_icon|
 
-The undo tool allows to restore previous state of the plot.
+The undo tool allows to restore the previous state of the plot.
 
 RedoTool
 ~~~~~~~~
@@ -352,7 +352,7 @@ RedoTool
 * name: ``'redo'``
 * icon: |redo_icon|
 
-The redo tool reverses the last action performed by undo tool.
+The redo tool reverses the last action performed by the undo tool.
 
 ResetTool
 ~~~~~~~~~
@@ -378,7 +378,7 @@ ZoomInTool
 * icon: |zoom_in_icon|
 
 The zoom-in tool will increase the zoom of the plot. It will respect any min and max
-values and ranges preventing zooming in and out beyond these.
+values and ranges, preventing zooming in and out beyond these.
 
 It is also possible to constraint the wheel zoom tool to only act on either
 just the x-axis or just the y-axis by setting the ``dimensions`` property to
@@ -392,7 +392,7 @@ ZoomOutTool
 * icon: |zoom_out_icon|
 
 The zoom-out tool will decrease the zoom level of the plot. It will respect any min and
-max values and ranges preventing zooming in and out beyond these.
+max values and ranges, preventing zooming in and out beyond these values.
 
 It is also possible to constraint the wheel zoom tool to only act on either
 just the x-axis or just the y-axis by setting the ``dimensions`` property to
@@ -435,7 +435,7 @@ Basic Tooltips
 ''''''''''''''
 
 By default, the hover tool will generate a "tabular" tooltip where each row
-contains a label, and its associated value. The labels and values are supplied
+contains a label and its associated value. The labels and values are supplied
 as a list of *(label, value)* tuples. For instance, the tooltip below on the
 left was created with the accompanying ``tooltips`` definition on the right.
 
@@ -484,17 +484,17 @@ in data or screen space. These special fields are listed here:
     and ``swatch`` to also display a small color swatch.
 
 Field names that begin with ``@`` are associated with columns in a
-``ColumnDataSource``. For instance the field name ``"@price"`` will display
+``ColumnDataSource``. For instance, the field name ``"@price"`` will display
 values from the ``"price"`` column whenever a hover is triggered. If the hover
 is for the 17th glyph, then the hover tooltip will correspondingly display
 the 17th price value.
 
-Note that if a column name contains spaces, the it must be supplied by
+Note that if a column name contains spaces, it must be supplied by
 surrounding it in curly braces, e.g. ``@{adjusted close}`` will display values
 from a column named ``"adjusted close"``.
 
 Sometimes (especially with stacked charts) it is desirable to allow the
-name of the column be specified indirectly. The field name ``@$name`` is
+name of the column to be specified indirectly. The field name ``@$name`` is
 distinguished in that it will look up the ``name`` field on the hovered
 glyph renderer, and use that value as the column name. For instance, if
 a user hovers with the name ``"US East"``, then ``@$name`` is equivalent to
@@ -506,21 +506,21 @@ the ``tooltips`` argument to ``figure``:
 .. bokeh-plot:: docs/user_guide/examples/tools_hover_tooltips.py
     :source-position: above
 
-Hit-testing Behavior
+Hit-Testing Behavior
 ''''''''''''''''''''
 
 The hover tool displays informational tooltips associated with individual
-glyphs. These tooltips can be configured to activate in in different ways
+glyphs. These tooltips can be configured to activate in different ways
 with a ``mode`` property:
 
 :``"mouse"``:
     only when the mouse is directly over a glyph
 
 :``"vline"``:
-    whenever the a vertical line from the mouse position intersects a glyph
+    whenever a vertical line from the mouse position intersects a glyph
 
 :``"hline"``:
-    whenever the a horizontal line from the mouse position intersects a glyph
+    whenever a horizontal line from the mouse position intersects a glyph
 
 The default configuration is ``mode = "mouse"``. This can be observed in the
 :ref:`userguide_tools_basic_tooltips` example above. The example below in
@@ -533,7 +533,7 @@ Formatting Tooltip Fields
 '''''''''''''''''''''''''
 
 By default, values for fields (e.g. ``@foo``) are displayed in a basic numeric
-format. However it is possible to control the formatting of values more
+format. However, it is possible to control the formatting of values more
 precisely. Fields can be modified by appending a format specified to the end
 in curly braces. Some examples are below.
 
@@ -581,7 +581,7 @@ If no formatter is specified for a column name, the default ``"numeral"``
 formatter is assumed.
 
 Note that format specifications are also compatible with column names that
-have spaces. For example ```@{adjusted close}{($ 0.00 a)}`` applies a format
+have spaces. For example, ```@{adjusted close}{($ 0.00 a)}`` applies a format
 to a column named "adjusted close".
 
 The example code below shows explicitly configuring a ``HoverTool`` with
@@ -627,10 +627,10 @@ layers of data in the corresponding ``ColumnDataSource``:
 .. bokeh-plot:: docs/user_guide/examples/tools_hover_tooltips_image.py
     :source-position: above
 
-In this example, three image patterns are defined named ``ramp``,
-``steps`` and ``bitmask``. The hover tooltip shows the index of the
+In this example, three image patterns are defined, named ``ramp``,
+``steps``, and ``bitmask``. The hover tooltip shows the index of the
 image, the name of the pattern, the ``x`` and ``y`` position of the
-cursor as well as the corresponding value and value squared.
+cursor, as well as the corresponding value and value squared.
 
 .. _custom_hover_tooltip:
 
@@ -654,7 +654,7 @@ Edit Tools
 ----------
 
 The edit tools provide functionality for drawing and editing glyphs
-client-side by adding, modifying and deleting ``ColumnDataSource``
+client-side by adding, modifying, and deleting ``ColumnDataSource``
 data.
 
 All the edit tools share a small number of key bindings:
@@ -669,7 +669,7 @@ ESC
   Clear the selection
 
 .. note::
-   On MacBooks and some other keyboards the BACKSPACE key is labelled
+   On MacBooks and some other keyboards, the BACKSPACE key is labeled
    "delete".
 
 BoxEditTool
@@ -678,7 +678,7 @@ BoxEditTool
 * name: ``'box_edit'``
 * menu icon: |box_edit_icon|
 
-The BoxEditTool allows drawing, dragging and deleting ``Rect`` glyphs
+The BoxEditTool allows drawing, dragging, and deleting ``Rect`` glyphs
 on one or more renderers by editing the underlying
 ``ColumnDataSource`` data. Like other drawing tools, the renderers
 that are to be edited must be supplied explicitly as a list:
@@ -690,16 +690,16 @@ that are to be edited must be supplied explicitly as a list:
     tool = BoxEditTool(renderers=[r1, r2])
 
 The tool will automatically modify the columns on the data source
-corresponding to the ``x``, ``y``, ``width`` and ``height`` values of
+corresponding to the ``x``, ``y``, ``width``, and ``height`` values of
 the glyph. Any additional columns in the data source will be padded
 with the declared ``empty_value``, when adding a new box. When drawing
-a new box the data will always be added to the ``ColumnDataSource`` on
+a new box, the data will always be added to the ``ColumnDataSource`` on
 the first supplied renderer.
 
 It is also often useful to limit the number of elements that can be
 drawn, e.g. when specifying a specific number of regions of interest.
-Using the ``num_objects`` property we can ensure that once the limit
-has been reached the oldest box will be popped off the queue to make
+Using the ``num_objects`` property, we can ensure that once the limit
+has been reached, the oldest box will be popped off the queue to make
 space for the new box being added.
 
 .. raw:: html
@@ -713,16 +713,16 @@ showing the pressed keys. The ``BoxEditTool`` can **Add**, **Move**
 and **Delete** boxes on plots:
 
 Add box
-  Hold shift then click and drag anywhere on the plot or double tap
+  Hold shift, then click and drag anywhere on the plot or double tap
   once to start drawing, move the mouse and double tap again to
   finish drawing.
 
 Move box
-  Click and drag an existing box, the box will be dropped once you let
+  Click and drag an existing box. The box will be dropped once you let
   go of the mouse button.
 
 Delete box
-  Tap a box to select it then press BACKSPACE key while the mouse is
+  Tap a box to select it then press the BACKSPACE key while the mouse is
   within the plot area.
 
 To **Move** or **Delete** multiple boxes at once:
@@ -766,8 +766,8 @@ supplied renderer.
 
 It is also often useful to limit the number of elements that can be
 drawn, e.g. when specifying a specific number of regions of interest.
-Using the ``num_objects`` property we can ensure that once the limit
-has been reached the oldest patch/multi-line will be popped off the
+Using the ``num_objects`` property, we can ensure that once the limit
+has been reached, the oldest patch/multi-line will be popped off the
 queue to make space for the new patch/multi-line being added.
 
 .. raw:: html
@@ -785,13 +785,13 @@ Draw patch/multi-line
   finish drawing
 
 Delete patch/multi-line
-  Tap a line or patch to select it then press BACKSPACE key while the
+  Tap a line or patch to select it then press the BACKSPACE key while the
   mouse is within the plot area.
 
  To **Delete** multiple patches/lines at once:
 
 Delete selection
-  Select patches/lines with SHIFT+tap (or another selection tool) then
+  Select patches/lines with SHIFT+tap (or another selection tool), then
   press BACKSPACE while the mouse is within the plot area.
 
 PointDrawTool
@@ -800,7 +800,7 @@ PointDrawTool
 * name: ``'point_draw'``
 * menu icon: |point_draw_icon|
 
-The ``PointDrawTool`` allows adding, dragging and deleting point-like
+The ``PointDrawTool`` allows adding, dragging, and deleting point-like
 glyphs (of ``XYGlyph`` type) on one or more renderers by editing the
 underlying ``ColumnDataSource`` data. Like other drawing tools, the
 renderers that are to be edited must be supplied explicitly as a
@@ -820,8 +820,8 @@ be inserted on the ``ColumnDataSource`` of the first supplied
 renderer.
 
 It is also often useful to limit the number of elements that can be
-drawn.  Using the ``num_objects`` property we can ensure that once the
-limit has been reached the oldest point will be popped off the queue
+drawn. Using the ``num_objects`` property, we can ensure that once the
+limit has been reached, the oldest point will be popped off the queue
 to make space for the new point being added.
 
 .. raw:: html
@@ -831,14 +831,14 @@ to make space for the new point being added.
 
 The animation above shows the supported tool actions, highlighting
 mouse actions with a circle around the cursor and key strokes by
-showing the pressed keys. The PointDrawTool can **Add**, **Move** and
+showing the pressed keys. The PointDrawTool can **Add**, **Move**, and
 **Delete** point-like glyphs on plots:
 
 Add point
-  Tap anywhere on the plot
+  Tap anywhere on the plot.
 
 Move point
-  Tap and drag an existing point, the point will be dropped once
+  Tap and drag an existing point. The point will be dropped once
   you let go of the mouse button.
 
 Delete point
@@ -848,12 +848,12 @@ Delete point
 To **Move** or **Delete** multiple points at once:
 
 Move selection
-  Select point(s) with SHIFT+tap (or another selection tool) then drag
+  Select point(s) with SHIFT+tap (or another selection tool), then drag
   anywhere on the plot. Selecting and then dragging a specific point
   will move both.
 
 Delete selection
-  Select point(s) with SHIFT+tap (or another selection tool) then
+  Select point(s) with SHIFT+tap (or another selection tool), then
   press BACKSPACE while the mouse is within the plot area.
 
 .. bokeh-plot:: docs/user_guide/examples/tools_point_draw.py
@@ -866,7 +866,7 @@ PolyDrawTool
 * name: ``'poly_draw'``
 * menu icon: |poly_draw_icon|
 
-The ``PolyDrawTool`` allows drawing, selecting and deleting
+The ``PolyDrawTool`` allows drawing, selecting, and deleting
 ``Patches`` and ``MultiLine`` glyphs on one or more renderers by
 editing the underlying ``ColumnDataSource`` data. Like other drawing
 tools, the renderers that are to be edited must be supplied explicitly
@@ -881,12 +881,12 @@ supplied renderer.
 
 It is also often useful to limit the number of elements that can be
 drawn, e.g. when specifying a specific number of regions of interest.
-Using the ``num_objects`` property we can ensure that once the limit
+Using the ``num_objects`` property, we can ensure that once the limit
 has been reached the oldest patch/multi-line will be popped off the
 queue to make space for the new patch/multi-line being added.
 
-If a ``vertex_renderer`` with an point-like glyph is supplied the
-PolyDrawTool will use it to display the vertices of the
+If a ``vertex_renderer`` with a point-like glyph is supplied, the
+PolyDrawTool it will use it to display the vertices of the
 multi-lines/patches on all supplied renderers. This also enables the
 ability to snap to existing vertices while drawing.
 
@@ -897,20 +897,20 @@ ability to snap to existing vertices while drawing.
 
 The animation above shows the supported tool actions, highlighting
 mouse actions with a circle around the cursor and key strokes by
-showing the pressed keys. The ``PolyDrawTool`` can **Add**, **Move**
+showing the pressed keys. The ``PolyDrawTool`` can **Add**, **Move**,
 and **Delete** patches and multi-lines:
 
 Add patch/multi-line
   Double tap to add the first vertex, then use tap to add each
-  subsequent vertex, to finalize the draw action double tap to insert
+  subsequent vertex. To finalize the draw action, double tap to insert
   the final vertex or press the ESC key.
 
 Move patch/multi-line
-  Tap and drag an existing patch/multi-line, the point will be dropped
+  Tap and drag an existing patch/multi-line. The point will be dropped
   once you let go of the mouse button.
 
 Delete patch/multi-line
-  Tap a patch/multi-line to select it then press BACKSPACE key while
+  Tap a patch/multi-line to select it, then press the BACKSPACE key while
   the mouse is within the plot area.
 
 .. bokeh-plot:: docs/user_guide/examples/tools_poly_draw.py
@@ -925,7 +925,7 @@ PolyEditTool
 
 The PolyEditTool allows editing the vertices of one or more
 ``Patches`` or ``MultiLine`` glyphs. The glyphs to be edited can
-be defined via the ``renderers`` property and the renderer for the
+be defined via the ``renderers`` property. The renderer for the
 vertices can be defined via the ``vertex_renderer``, which must
 render a point-like Glyph (of ``XYGlyph`` type).
 
@@ -941,23 +941,23 @@ additional columns in the data source will be padded with the declared
 
 The animation above shows the supported tool actions, highlighting
 mouse actions with a circle around the cursor and key strokes by
-showing the pressed keys. The ``PolyEditTool`` can **Add**, **Move**
+showing the pressed keys. The ``PolyEditTool`` can **Add**, **Move**,
 and **Delete** vertices on existing patches and multi-lines:
 
 Show vertices
   Double tap an existing patch or multi-line
 
 Add vertex
-  Double tap an existing vertex to select it, the tool will draw the
-  next point, to add it tap in a new location. To finish editing
-  and add a point double tap otherwise press the ESC key to cancel.
+  Double tap an existing vertex to select it. The tool will draw the
+  next point. To add it, tap in a new location. To finish editing
+  and add a point, double tap. Otherwise press the ESC key to cancel.
 
 Move vertex
   Drag an existing vertex and let go of the mouse button to release
   it.
 
 Delete vertex
-  After selecting one or more vertices press BACKSPACE while the mouse
+  After selecting one or more vertices, press BACKSPACE while the mouse
   cursor is within the plot area.
 
 .. bokeh-plot:: docs/user_guide/examples/tools_poly_edit.py
@@ -970,12 +970,12 @@ Controlling Level of Detail
 ---------------------------
 
 Although the HTML canvas can comfortably display tens or even hundreds of
-thousands of glyphs, doing so can have adverse affects on interactive
+thousands of glyphs, doing so can have adverse effects on interactive
 performance. In order to accommodate large-ish (but not enormous) data
 sizes, Bokeh plots offer "Level of Detail" (LOD) capability in the client.
 
 .. note::
-    Another option, when dealing with very large data volumes, is to use the
+    Another option when dealing with very large data volumes is to use the
     Bokeh Server to perform downsampling on data before it is sent to the
     browser. Such an approach is unavoidable past a certain data size. See
     :ref:`userguide_server` for more information.

--- a/sphinx/source/docs/user_guide/webgl.rst
+++ b/sphinx/source/docs/user_guide/webgl.rst
@@ -14,7 +14,7 @@ WebGL is a JavaScript API that allows rendering content in the browser
 via the Graphics Processing Unit (GPU), without the need for plugins.
 WebGL is standardized and available in all modern browsers.
 
-How to enable WebGL
+How to Enable WebGL
 -------------------
 
 To enable WebGL, set the plot's ``output_backend`` property to ``"webgl"``:
@@ -46,7 +46,7 @@ Notes
   in WebGL.
 * When the scale is non-linear (e.g. log), the system falls back to 2D
   rendering.
-* Making a selections of markers on Internet Explorer will reduce the size
+* Making a selection of markers on Internet Explorer will reduce the size
   of the markers to 1 pixel (looks like a bug in IE).
 
 Examples


### PR DESCRIPTION
Fixes typos in User Guide .rst files, partially fixes issue #8448.
This PR is focussing on errors such as misspelled words, omitted words, superfluous words, and some punctuation issues. 
This first commit includes about half the rst files, and I will add the remaining files in the coming days. I'm starting this PR with status: WIP and would be happy for some early feedback. I will tag it as ready once I have committed all rst files.