### PR TITLE
fix over-quoting by components

### DIFF
--- a/bokeh/embed/elements.py
+++ b/bokeh/embed/elements.py
@@ -151,7 +151,8 @@ def script_for_render_items(docs_json_or_id, render_items: List[RenderItem],
         # is safe, because " in strings was already encoded by JSON, and the semi-encoded
         # JSON string is included in JavaScript in single quotes.
         docs_json = serialize_json(docs_json_or_id, pretty=False) # JSON string
-        docs_json = escape(docs_json, quote=("'",))               # make HTML-safe
+        docs_json = escape(docs_json, quote=False)                # make HTML-safe
+        docs_json = docs_json.replace("'", "&#x27;")              # remove single quotes
         docs_json = docs_json.replace("\\", "\\\\")               # double encode escapes
         docs_json =  "'" + docs_json + "'"                        # JS string
 

--- a/tests/unit/bokeh/embed/test_standalone.py
+++ b/tests/unit/bokeh/embed/test_standalone.py
@@ -49,7 +49,7 @@ def stable_id():
 @pytest.fixture
 def test_plot() -> None:
     from bokeh.plotting import figure
-    test_plot = figure()
+    test_plot = figure(title="'foo'")
     test_plot.circle([1, 2], [2, 3])
     return test_plot
 
@@ -247,6 +247,12 @@ class Test_components(object):
     def test_script_is_utf8_encoded(self, test_plot) -> None:
         script, div = bes.components(test_plot)
         assert isinstance(script, str)
+
+    def test_quoting(self, test_plot) -> None:
+        script, div = bes.components(test_plot)
+        assert "&quot;" not in script
+        assert "'foo'" not in script
+        assert "&#x27;foo&#x27;" in script
 
     def test_output_is_without_script_tag_when_wrap_script_is_false(self, test_plot) -> None:
         script, div = bes.components(test_plot)


### PR DESCRIPTION
ref: https://github.com/bokeh/bokeh/issues/10268#issuecomment-655190968

@mattpap since the "only replace single quotes" is only needed in one place I just used `str.replace` plus a (now-appropriately-called) stdlib `html.escape`