### PR TITLE
Redesign set_data() and set_visuals()

### DIFF
--- a/bokehjs/src/lib/models/annotations/arrow.ts
+++ b/bokehjs/src/lib/models/annotations/arrow.ts
@@ -38,7 +38,6 @@ export class ArrowView extends AnnotationView {
 
   set_data(source: ColumnarDataSource): void {
     super.set_data(source)
-    this.visuals.warm_cache(source)
     this.plot_view.request_render()
   }
 

--- a/bokehjs/src/lib/models/annotations/band.ts
+++ b/bokehjs/src/lib/models/annotations/band.ts
@@ -40,7 +40,6 @@ export class BandView extends AnnotationView {
 
   set_data(source: ColumnarDataSource): void {
     super.set_data(source)
-    this.visuals.warm_cache(source)
     this.plot_view.request_render()
   }
 

--- a/bokehjs/src/lib/models/annotations/label.ts
+++ b/bokehjs/src/lib/models/annotations/label.ts
@@ -8,11 +8,6 @@ export class LabelView extends TextAnnotationView {
   model: Label
   visuals: Label.Visuals
 
-  initialize(): void {
-    super.initialize()
-    this.visuals.warm_cache()
-  }
-
   protected _get_size(): Size {
     const {ctx} = this.layer
     this.visuals.text.set_value(ctx)

--- a/bokehjs/src/lib/models/annotations/label_set.ts
+++ b/bokehjs/src/lib/models/annotations/label_set.ts
@@ -74,11 +74,6 @@ export class LabelSetView extends TextAnnotationView {
     }
   }
 
-  set_data(source: ColumnarDataSource): void {
-    super.set_data(source)
-    this.visuals.warm_cache(source)
-  }
-
   protected _map_data(): [Arrayable<number>, Arrayable<number>] {
     const xscale = this.scope.x_scale
     const yscale = this.scope.y_scale

--- a/bokehjs/src/lib/models/annotations/title.ts
+++ b/bokehjs/src/lib/models/annotations/title.ts
@@ -11,7 +11,7 @@ export class TitleView extends TextAnnotationView {
 
   initialize(): void {
     super.initialize()
-    this.visuals.text = new Text(this.model)
+    this.visuals.text = new Text(this)
   }
 
   protected _get_location(): [number, number] {

--- a/bokehjs/src/lib/models/annotations/whisker.ts
+++ b/bokehjs/src/lib/models/annotations/whisker.ts
@@ -39,7 +39,6 @@ export class WhiskerView extends AnnotationView {
 
   set_data(source: ColumnarDataSource): void {
     super.set_data(source)
-    this.visuals.warm_cache(source)
     this.plot_view.request_render()
   }
 

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -171,7 +171,7 @@ export class PlotView extends LayoutDOMView {
     this.state_changed = new Signal0(this, "state_changed")
 
     this.lod_started = false
-    this.visuals = new Visuals(this.model) as any // XXX
+    this.visuals = new Visuals(this) as Plot.Visuals
 
     this._initial_state_info = {
       selection: new Map(),               // XXX: initial selection?

--- a/bokehjs/src/lib/models/renderers/renderer.ts
+++ b/bokehjs/src/lib/models/renderers/renderer.ts
@@ -22,7 +22,7 @@ export abstract class RendererView extends View {
 
   initialize(): void {
     super.initialize()
-    this.visuals = new visuals.Visuals(this.model)
+    this.visuals = new visuals.Visuals(this)
     this._initialize_scope()
   }
 

--- a/bokehjs/test/unit/core/visuals.ts
+++ b/bokehjs/test/unit/core/visuals.ts
@@ -1,7 +1,6 @@
 import {expect} from "assertions"
 import {create_glyph_renderer_view} from "../models/glyphs/glyph_utils"
 
-import {Indices} from "@bokehjs/core/types"
 import {Fill, Line, Text, Visuals} from "@bokehjs/core/visuals"
 import {Context2d} from "@bokehjs/core/util/canvas"
 import {ColumnDataSource} from "@bokehjs/models/sources/column_data_source"
@@ -170,8 +169,6 @@ describe("Visuals", () => {
     const circle = new Circle(attrs)
     const visuals = new Visuals(circle) as Visuals & {fill: Fill}
 
-    visuals.warm_cache(source)
-
     const ctx = {} as Context2d
     visuals.fill.set_vectorize(ctx, 1)
     expect(ctx.fillStyle).to.be.equal("rgba(0, 128, 0, 0.5)")
@@ -183,9 +180,6 @@ describe("Visuals", () => {
 
     const circle = new Circle(attrs)
     const visuals = new Visuals(circle) as Visuals & {fill: Fill}
-
-    const subset = Indices.from_indices(3, [1, 2])
-    visuals.warm_cache(source, subset)
 
     const ctx = {} as Context2d
     visuals.fill.set_vectorize(ctx, 1)


### PR DESCRIPTION
Early work in progress. The goals of this work are:

- bring initialization of coordinate and visual data under one code path
- cleanly separate scalar visuals from vector
- allow to redefine non-visual properties in selection glyphs, etc.
- allow to use glyphs of similar (not exact) type as selection glyphs, etc.