### PR TITLE
Change all references of 'py.test' to 'pytest'

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Run codebase checks
         shell: bash -l {0}
-        run: py.test --color=yes tests/codebase
+        run: pytest --color=yes tests/codebase
 
       - name: MyPy
         shell: bash -l {0}
@@ -153,7 +153,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         shell: bash -l {0}
         run: |
-          py.test -s -v --color=yes --tb line tests/test_examples.py
+          pytest -s -v --color=yes --tb line tests/test_examples.py
 
       - name: Collect results
         if: always()
@@ -257,7 +257,7 @@ jobs:
 
       - name: Run tests
         shell: bash -l {0}
-        run: py.test -v --tb=short --driver chrome --color=yes tests/integration
+        run: pytest -v --tb=short --driver chrome --color=yes tests/integration
 
   unit-test:
     needs: build
@@ -320,7 +320,7 @@ jobs:
         shell: bash -l {0}
         run: |
           if [[ ! "$(python -c 'import platform; print(platform.python_version())' | cut -d' ' -f2)" == "${{ matrix.python-version }}"* ]]; then exit 1; fi
-          py.test --cov=bokeh --cov-config=tests/.coveragerc --color=yes tests/unit
+          pytest --cov=bokeh --cov-config=tests/.coveragerc --color=yes tests/unit
 
   minimal-deps:
     needs: build
@@ -368,7 +368,7 @@ jobs:
 
       - name: Run tests
         shell: bash -l {0}
-        run: py.test -m "not sampledata" --cov=bokeh --cov-config=tests/.coveragerc --color=yes tests/unit
+        run: pytest -m "not sampledata" --cov=bokeh --cov-config=tests/.coveragerc --color=yes tests/unit
 
   documentation:
     needs: build

--- a/ci/run_downstream_tests.sh
+++ b/ci/run_downstream_tests.sh
@@ -5,7 +5,7 @@ set -x #echo on
 set +e
 
 pushd `python -c "import site; print(site.getsitepackages()[0])"`
-py.test distributed/dashboard
+pytest distributed/dashboard
 nosetests holoviews/tests/plotting/bokeh
 popd
 

--- a/sphinx/source/docs/dev_guide/setup.rst
+++ b/sphinx/source/docs/dev_guide/setup.rst
@@ -166,7 +166,7 @@ on git hooks, see `this tutorial`_.
 
         #!/bin/bash
 
-        py.test tests/codebase
+        pytest tests/codebase
         exit $?
 
 ``pre-push``

--- a/sphinx/source/docs/dev_guide/testing.rst
+++ b/sphinx/source/docs/dev_guide/testing.rst
@@ -35,7 +35,7 @@ level of the repository:
 
 .. code-block:: sh
 
-    py.test tests/unit
+    pytest tests/unit
 
 Note that this includes unit tests that require Selenium as well as appropriate
 web drivers (e.g. chromedriver and geckodriver) to be installed. To exclude
@@ -43,13 +43,13 @@ those unit tests, you can run the command:
 
 .. code-block:: sh
 
-    py.test -m "not selenium" tests/unit
+    pytest -m "not selenium" tests/unit
 
 To run just the BokehJS unit tests, execute:
 
 .. code-block:: sh
 
-    py.test tests/test_bokehjs.py
+    pytest tests/test_bokehjs.py
 
 Alternatively, you can also navigate to the `bokehjs` subdirectory of the
 source checkout and execute:
@@ -63,7 +63,7 @@ and integration tests) **from the top level directory** by executing:
 
 .. code-block:: sh
 
-    py.test
+    pytest
 
 To learn more about marking test functions and selecting/deselecting them for
 a run, please consult the pytest documentation for `custom markers`_. The list
@@ -79,7 +79,7 @@ To run any of the tests with coverage use the following:
 
 .. code-block:: sh
 
-  py.test --cov=bokeh
+  pytest --cov=bokeh
 
 To report on a subset of the Bokeh package, pass e.g. ``-cov=bokeh/models``.
 
@@ -90,9 +90,9 @@ To run any of the tests without standard output captured use:
 
 .. code-block:: sh
 
-  py.test -s
+  pytest -s
 
-See the `pytest`_ documentation for further information on ``py.test`` and
+See the `pytest`_ documentation for further information on ``pytest`` and
 its options.
 
 Examples tests
@@ -110,7 +110,7 @@ To run just the examples tests, run the command:
 
 .. code-block:: sh
 
-    py.test --report-path=examples.html test_examples.py
+    pytest --report-path=examples.html test_examples.py
 
 After the tests have run, you will be able to see the test report at
 ``examples.html``. Running locally, you can name the test report whatever
@@ -120,7 +120,7 @@ The examples tests can run slowly, to speed them up, you can parallelize them:
 
 .. code-block:: sh
 
-    py.test --report-path=examples.html -n 5 test_examples.py
+    pytest --report-path=examples.html -n 5 test_examples.py
 
 Where ``n`` is the number is the number of cores you want to use.
 
@@ -182,7 +182,7 @@ shot tests should follow the general guidelines:
 
 Once a new test is written, a base image for comparison is needed. To create
 a new base image, add ``--set-new-base-screenshot`` to your the standard
-``py.test`` command to run the test. This will generate an image with the name
+``pytest`` command to run the test. This will generate an image with the name
 ``base__<name_of_your_test>.png`` in the appropriate directory. Use ``git``
 to check this image into the repository, and then all future screen shot tests
 will be compared against this base image.

--- a/sphinx/source/docs/releases/1.0.0.rst
+++ b/sphinx/source/docs/releases/1.0.0.rst
@@ -134,7 +134,7 @@ Codebase Tests
 ~~~~~~~~~~~~~~
 
 The Pytest "quality" mark has been changed to "codebase". Now to run the
-codebase tests, execute ``py.test -m codebase``. If you have installed a
+codebase tests, execute ``pytest -m codebase``. If you have installed a
 pre-commit hook to run quality tests before allowing a commit, the hook code
 should be updated as above. This change is only expected to affect those who
 are developing the Bokeh codebase.


### PR DESCRIPTION
The `pytest` command has been the recommended entry point since pytest 3.0,
cf. https://github.com/pytest-dev/pytest/issues/1629

- [x] issues: fixes #10284 
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
