### PR TITLE
Add bokeh logo palette; remove rogue double-quote from template

### DIFF
--- a/bokeh/palettes.py
+++ b/bokeh/palettes.py
@@ -1099,11 +1099,11 @@ Colorblind4 = Colorblind8[:4]
 Colorblind3 = Colorblind8[:3]
 
 # Bokeh palette created from colors of shutter logo
-BokehPalette7 = ('#EC1557', '#F05223', '#F6A91B', '#A5CD39', '#20B254', '#00AAAE', '#892889')
-BokehPalette6 = BokehPalette7[:6]
-BokehPalette5 = BokehPalette7[:5]
-BokehPalette4 = BokehPalette7[:4]
-BokehPalette3 = BokehPalette7[:3]
+Bokeh7 = ('#EC1557', '#F05223', '#F6A91B', '#A5CD39', '#20B254', '#00AAAE', '#892889')
+Bokeh6 = Bokeh7[:6]
+Bokeh5 = Bokeh7[:5]
+Bokeh4 = Bokeh7[:4]
+Bokeh3 = Bokeh7[:3]
 
 
 YlGn     = { 3: YlGn3,     4: YlGn4,     5: YlGn5,     6: YlGn6,     7: YlGn7,     8: YlGn8,     9: YlGn9 }
@@ -1162,7 +1162,7 @@ Category20c = { 3:  Category20c_3,  4:  Category20c_4,  5:  Category20c_5,  6:  
                 13: Category20c_13, 14: Category20c_14, 15: Category20c_15, 16: Category20c_16, 17: Category20c_17,
                 18: Category20c_18, 19: Category20c_19, 20: Category20c_20 }
 Colorblind  = { 3: Colorblind3, 4: Colorblind4, 5: Colorblind5, 6: Colorblind6, 7: Colorblind7, 8: Colorblind8 }
-BokehPalette = { 3: BokehPalette3, 4: BokehPalette4, 5: BokehPalette5, 6: BokehPalette6, 7: BokehPalette7 }
+Bokeh = { 3: Bokeh3, 4: Bokeh4, 5: Bokeh5, 6: Bokeh6, 7: Bokeh7 }
 
 brewer = {
     "YlGn"     : YlGn,
@@ -1203,7 +1203,7 @@ brewer = {
 }
 
 bokeh = {
-    "Bokeh": BokehPalette
+    "Bokeh" : Bokeh
 }
 
 d3 = {
@@ -1234,6 +1234,7 @@ all_palettes["Plasma"]     = Plasma
 all_palettes["Viridis"]    = Viridis
 all_palettes["Cividis"]    = Cividis
 all_palettes["Turbo"]      = Turbo
+all_palettes["Bokeh"]      = Bokeh
 
 small_palettes = deepcopy(all_palettes)
 del small_palettes["Greys"][256]

--- a/bokeh/palettes.py
+++ b/bokeh/palettes.py
@@ -116,6 +116,7 @@ This module contains the following sets of palettes:
 * All `ColorBrewer`_ palettes
 * Categorical `D3`_ palettes
 * The `Matplotlib`_ palettes Magma, Inferno, Plasma, and Viridis
+* A 'Bokeh'_ palette comprised of the Bokeh shutter logo colors
 * Palettes designed for color-deficient usability
 
 Additionally, you can also use any of the 256-color perceptually uniform
@@ -166,6 +167,13 @@ Brewer Palettes
 Bokeh includes all the `ColorBrewer`_ palettes, shown below:
 
 .. bokeh-palette-group:: brewer
+
+Bokeh Palette
+~~~~~~~~~~~~~~~
+
+Bokeh's own palette, comprised of the shutter logo colors:
+
+.. bokeh-palette-group:: bokeh
 
 Usability Palettes
 ~~~~~~~~~~~~~~~~~~
@@ -1090,6 +1098,14 @@ Colorblind5 = Colorblind8[:5]
 Colorblind4 = Colorblind8[:4]
 Colorblind3 = Colorblind8[:3]
 
+# Bokeh palette created from colors of shutter logo
+BokehPalette7 = ('#EC1557', '#F05223', '#F6A91B', '#A5CD39', '#20B254', '#00AAAE', '#892889')
+BokehPalette6 = BokehPalette7[:6]
+BokehPalette5 = BokehPalette7[:5]
+BokehPalette4 = BokehPalette7[:4]
+BokehPalette3 = BokehPalette7[:3]
+
+
 YlGn     = { 3: YlGn3,     4: YlGn4,     5: YlGn5,     6: YlGn6,     7: YlGn7,     8: YlGn8,     9: YlGn9 }
 YlGnBu   = { 3: YlGnBu3,   4: YlGnBu4,   5: YlGnBu5,   6: YlGnBu6,   7: YlGnBu7,   8: YlGnBu8,   9: YlGnBu9 }
 GnBu     = { 3: GnBu3,     4: GnBu4,     5: GnBu5,     6: GnBu6,     7: GnBu7,     8: GnBu8,     9: GnBu9 }
@@ -1146,6 +1162,7 @@ Category20c = { 3:  Category20c_3,  4:  Category20c_4,  5:  Category20c_5,  6:  
                 13: Category20c_13, 14: Category20c_14, 15: Category20c_15, 16: Category20c_16, 17: Category20c_17,
                 18: Category20c_18, 19: Category20c_19, 20: Category20c_20 }
 Colorblind  = { 3: Colorblind3, 4: Colorblind4, 5: Colorblind5, 6: Colorblind6, 7: Colorblind7, 8: Colorblind8 }
+BokehPalette = { 3: BokehPalette3, 4: BokehPalette4, 5: BokehPalette5, 6: BokehPalette6, 7: BokehPalette7 }
 
 brewer = {
     "YlGn"     : YlGn,
@@ -1183,6 +1200,10 @@ brewer = {
     "Set1"     : Set1,
     "Set2"     : Set2,
     "Set3"     : Set3,
+}
+
+bokeh = {
+    "Bokeh": BokehPalette
 }
 
 d3 = {

--- a/bokeh/sphinxext/bokeh_palette_group.py
+++ b/bokeh/sphinxext/bokeh_palette_group.py
@@ -82,17 +82,18 @@ class BokehPaletteGroupDirective(Directive):
         node['group'] = self.arguments[0]
         return [node]
 
+
 # NOTE: This extension now *assumes* both Bootstrap and JQuery are present
 # (which is now the case for the Bokeh docs theme).
 def html_visit_bokeh_palette_group(self, node):
-    self.body.append('<div class="container-fluid"><div class="row">"')
+    self.body.append('<div class="container-fluid"><div class="row">')
     group = getattr(bp, node['group'], None)
     if not isinstance(group, dict):
         raise SphinxError("invalid palette group name %r" % node['group'])
     names = sorted(group)
     for name in names:
         palettes = group[name]
-        # arbitrary cuttoff here, idea is to not show large (e.g 256 length) palettes
+        # arbitrary cutoff here, idea is to not show large (e.g 256 length) palettes
         numbers = [x for x in sorted(palettes) if x < 30]
         html = PALETTE_GROUP_DETAIL.render(name=name, numbers=numbers, palettes=palettes)
         self.body.append(html)


### PR DESCRIPTION
Adds a palette based on the Bokeh colorway provided by Chris G in the #brand Slack channel. 

Also removes a stray " that was appearing on the palettes doc page.