### PR TITLE
don't dupe version extension in bokehjs version

### DIFF
--- a/ci/environment-test-3.6.yml
+++ b/ci/environment-test-3.6.yml
@@ -28,7 +28,7 @@ dependencies:
   - flaky
   - geckodriver
   - ipython
-  - isort >=4.3.21
+  - isort <5.0
   - mock
   - mypy
   - nbconvert >=5.4

--- a/ci/environment-test-3.7.yml
+++ b/ci/environment-test-3.7.yml
@@ -28,7 +28,7 @@ dependencies:
   - flaky
   - geckodriver
   - ipython
-  - isort >=4.3.21
+  - isort <5.0
   - mock
   - mypy
   - nbconvert >=5.4

--- a/ci/environment-test-3.8.yml
+++ b/ci/environment-test-3.8.yml
@@ -28,7 +28,7 @@ dependencies:
   - flaky
   - geckodriver
   - ipython
-  - isort >=4.3.21
+  - isort <5.0
   - mock
   - mypy
   - nbconvert >=5.4

--- a/environment.yml
+++ b/environment.yml
@@ -36,7 +36,7 @@ dependencies:
   - flaky
   - geckodriver
   - ipython
-  - isort >=4.3.21
+  - isort <5.0
   - mock
   - mypy
   - nbconvert >=5.4

--- a/release/config.py
+++ b/release/config.py
@@ -71,7 +71,7 @@ class Config(object):
     def js_version(self) -> str:
         if self.ext is None:
             return self.version
-        return f"{self.version}-{self.ext_type}.{self.ext_number}"
+        return f"{self.base_version}-{self.ext_type}.{self.ext_number}"
 
     @property
     def release_level(self) -> str:


### PR DESCRIPTION
- [x] issues: fixes #10301

Definitely my goal to add a full test suite for release automation but let's sort out the new branching model first. 

```
In [5]: from release.config import Config

In [6]: version = "2.2.0dev4"

In [7]: config = Config(version=version)

In [8]: config.js_version
Out[8]: '2.2.0-dev.4'
```

Edit: defaults picked up isort 5 finally so I had to pin it here