### PR TITLE
Fix typos in Dev Guide

### DIFF
--- a/sphinx/source/docs/dev_guide/bindings.rst
+++ b/sphinx/source/docs/dev_guide/bindings.rst
@@ -3,7 +3,7 @@
 Language Bindings
 =================
 
-Because the input accepted by BokehJS is an object graph, represented by
+Because the input accepted by BokehJS is an object graph represented by
 declarative bits of JSON, any language that can generate the right JSON
 can generate Bokeh plots in the browser.
 
@@ -14,7 +14,7 @@ Since the low-level object interface in Python mirrors the JSON schema
 exactly, the best, most authoritative source of information for anyone
 writing bindings for Bokeh are the reference guide sections for the
 :ref:`bokeh.core.properties` and :ref:`bokeh.models`. In
-particular, the models reference has a JSON prototype for every models
+particular, the models reference has a JSON prototype for every model
 in the Bokeh object system.
 
 Additionally, there is a very low-traffic ``bokeh-dev`` mailing list

--- a/sphinx/source/docs/dev_guide/bokehjs.rst
+++ b/sphinx/source/docs/dev_guide/bokehjs.rst
@@ -61,7 +61,7 @@ the string ``bk-``. For instance some examples are: ``.bk-plot``, ``.bk-toolbar-
 Development
 -----------
 
-bokehjs's source code is located in ``bokehjs/`` directory in bokeh's monorepo
+BokehJS's source code is located in the ``bokehjs/`` directory in Bokeh's monorepo
 repository. All further instructions and shell commands assume that ``bokehjs/``
 is the current directory.
 
@@ -78,7 +78,7 @@ You can install nodejs with conda:
 
     $ conda install -c conda-forge nodejs
 
-or follow official installation `instructions <https://nodejs.org/en/download/>`_.
+or follow the official installation `instructions <https://nodejs.org/en/download/>`_.
 
 Upgrade your npm after installing or updating nodejs, or whenever asked by npm:
 
@@ -92,14 +92,14 @@ Officially supported platforms are as follows:
 * Windows 10 (or Server 2019)
 * MacOS 10.15
 
-bokehjs can be developed on different platforms and versions of aforementioned
+BokehJS can be developed on different platforms and versions of aforementioned
 software, but results may vary, especially when it comes to testing (visual
 testing in particular).
 
 Building
 ~~~~~~~~
 
-bokehjs' build is maintained by using an in-house tool that visually resembles
+BokehJS's build is maintained by using an in-house tool that visually resembles
 gulp. All commands start with ``node make`` (don't confuse this with GNU make).
 
 Most common commands:
@@ -118,7 +118,7 @@ it for code emit, because we rely on AST transforms to produce viable library co
 Testing
 ~~~~~~~
 
-bokehjs testing is performed with ``node make test`` command. You can run individual
+BokehJS testing is performed with the ``node make test`` command. You can run individual
 test suites with ``node make test:suite_name``. Known tests suites are:
 
 * ``node make test:size``
@@ -130,23 +130,23 @@ The last to can be run with ``node make test:lib``. Unit and integration tests a
 run in a web browser (see requirements), which is started automatically with the
 right settings to guarantee consistent test results.
 
-To review visual tests' output, start bokehjs' devtools server:
+To review the visual tests' output, start BokehJS's devtools server:
 
 .. code-block:: sh
 
     $ node test/devtools server
     listening on 127.0.0.1:5777
 
-and navigate to ``/integration/report``. Devtools server can be also used to
-manually inspect and debug tests. For that the following endpoints are available:
+and navigate to ``/integration/report``. Devtools server can also be used to
+manually inspect and debug tests. For that, the following endpoints are available:
 
 * ``/unit``
 * ``/defaults``
 * ``/integration``
 
-Those load bokehjs and tests, but don't anything. You have to issue ``Tests.run_all()``
-in JavaScript console. This allows to you to set breakpoints before running code. You
-can filter out tests by providing a string keyword or a regular expression. Alternatively
+Those load BokehJS and the tests, but don't do anything. You have to issue ``Tests.run_all()``
+in a JavaScript console. This allows you to set breakpoints before running code. You
+can filter out tests by providing a string keyword or a regular expression. Alternatively,
 you can run tests immediately with these endpoints:
 
 * ``/unit/run``
@@ -155,7 +155,7 @@ you can run tests immediately with these endpoints:
 
 You can use ``?k=some%20text`` to filter tests by a keyword.
 
-CI and visual testing
+CI and Visual Testing
 ~~~~~~~~~~~~~~~~~~~~~
 
 ``test:integration`` does two types of tests:
@@ -176,27 +176,27 @@ The full procedure for visual testing is as follows:
 2. Use ``node make tests`` to incrementally test your changes on your system.
 3. Commit changes to textual baselines (``test/baselines/*``).
 4. Push your changes to GitHub and wait for CI to finish.
-5. If you added new tests and CI will expectedly fail with "missing baseline
+5. If you added new tests, CI will expectedly fail with "missing baseline
    images" error message.
-6. If tests passed then your are done.
-7. If tests failed, go to bokehjs' GitHub_Actions_ page. Find the most recent
+6. If tests passed then you are done.
+7. If tests failed, go to BokehJS's GitHub_Actions_ page. Find the most recent
    test run for your PR and download the associated ``bokehjs-report`` artifact.
 8. Unzip the artifact archive.
 9. Assuming devtools server is running in the background, go to ``/integration/report?platform=name``
-   where ``name`` is either ``linux``, ``macos`` or ``windows`` and review test output
+   where ``name`` is either ``linux``, ``macos`` or ``windows`` and review the test output
    for each platform. If there are no unintentional differences, then commit all
    new or modified files under ``test/baselines/{linux,macos,windows}``.
 10. Push your changes again to GitHub and verify that tests pass this time.
 
 .. note::
 
-    Make sure to monitor state of ``test/baselines`` directory, so that you don't
-    commit unnecessary files. If you do so, subsequent tests will fail.
+    Make sure to monitor the state of the ``test/baselines`` directory, so that you
+    don't commit unnecessary files. If you do so, subsequent tests will fail.
 
-Minimal model/view module
+Minimal Model/View Module
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Models (and views) come in many forms and sizes. At minimum a model is implemented.
+Models (and views) come in many forms and sizes. At minimum, a model is implemented.
 A view may follow if a "visual" model is being implemented. A minimal model/view
 module looks like this:
 
@@ -250,13 +250,13 @@ module looks like this:
     }
 
 For trivial modules like this, most of the code is just boilerplate to make
-bokehjs' code statically type-check and generate useful type declarations
+BokehJS's code statically type-check and generate useful type declarations
 for further consumption (in tests or by users).
 
-Code style guide
+Code Style Guide
 ~~~~~~~~~~~~~~~~
 
-bokehjs doesn't have an explicit style guide. Make your changes consistent in
+BokehJS doesn't have an explicit style guide. Make your changes consistent in
 formatting. Use ``node make lint``. Follow patterns observed in the surrounding
 code and apply common sense.
 

--- a/sphinx/source/docs/dev_guide/bokehjs.rst
+++ b/sphinx/source/docs/dev_guide/bokehjs.rst
@@ -126,7 +126,7 @@ test suites with ``node make test:suite_name``. Known tests suites are:
 * ``node make test:unit``
 * ``node make test:integration``
 
-The last to can be run with ``node make test:lib``. Unit and integration tests are
+The last two can be run with ``node make test:lib``. Unit and integration tests are
 run in a web browser (see requirements), which is started automatically with the
 right settings to guarantee consistent test results.
 

--- a/sphinx/source/docs/dev_guide/documentation.rst
+++ b/sphinx/source/docs/dev_guide/documentation.rst
@@ -9,7 +9,7 @@ edit documentation locally, as well as describes conventions that the project
 adheres to.
 
 Helping with documentation is one of the most valuable ways to contribute to a
-project. It's also a good way to to get started and introduce yourself as a new
+project. It's also a good way to get started and introduce yourself as a new
 contributor. The most likely way for typos or other small documentation errors
 to be resolved is for the person who notices the problem to immediately submit
 a Pull Request to with a correction. *This is always appreciated!* In
@@ -24,11 +24,11 @@ of Bokeh on JavaScript, no other output formats are supported by the official
 build configuration. This section describes how to use Sphinx to build the
 Bokeh documentation from source.
 
-Install requirements
+Install Requirements
 ~~~~~~~~~~~~~~~~~~~~
 
-In order to build the docs from source, you should have followed the
-instructions in :ref:`devguide_setup`.
+In order to build the docs from source, it is recommended that you first
+follow the instructions in :ref:`devguide_setup`.
 
 Some of the Bokeh examples in the documentation rely on sample data that is
 not included in the Bokeh GitHub repository or released packages, due to
@@ -55,7 +55,7 @@ subdirectory of the Bokeh source tree.
     cd sphinx
 
 Sphinx uses the ``make`` tool to control the build process. The most common
-targets or the Bokeh makefile are:
+targets of the Bokeh makefile are:
 
 ``clean``
     Remove all previously built documentation output. All outputs will
@@ -63,15 +63,15 @@ targets or the Bokeh makefile are:
 
 ``html``
     Build any HTML output that is not built, or needs re-building (e.g.
-    because the input source file has changed since the last build)
+    because the input source file has changed since the last build).
 
 ``serve``
-    Start a server to serve the docs open a web browser to display. Note
-    that due to the JavaScript files involved, starting a real server is
+    Start a server to serve the docs and open a web browser to display them.
+    Note that due to the JavaScript files involved, starting a real server is
     necessary to view many portions of the docs fully.
 
-For example, clean the docs build directory, run the follow command at the
-command line:
+For example, to clean the docs build directory, run the following command at
+the command line:
 
 .. code-block:: sh
 
@@ -79,7 +79,7 @@ command line:
 
 Multiple targets may be combined in a single `make` invocation. For instance,
 executing the following command will clean the docs build, generate all HTML
-docs from scratch, then open a browser to display the results:
+docs from scratch, and then open a browser to display the results:
 
 .. code-block:: sh
 
@@ -217,7 +217,7 @@ key points and sections. The following outlines the headings hierarchy:
     Top level
     =========
 
-    This will add a "Top Level" entry in the navigation sidebar
+    This will add a "Top Level" entry in the navigation sidebar.
 
     Second level
     ------------
@@ -237,7 +237,7 @@ Release Notes
 ~~~~~~~~~~~~~
 
 Each release should add a new file under ``sphinx/source/docs/releases`` that
-briefly describes the changes in the release including any migration notes.
+briefly describes the changes in the release, including any migration notes.
 The filename should be ``<version>.rst``, for example
 :bokeh-tree:`sphinx/source/docs/releases/0.12.7.rst`. The
 Sphinx build will automatically add this content to the list of all releases.

--- a/sphinx/source/docs/dev_guide/env_vars.rst
+++ b/sphinx/source/docs/dev_guide/env_vars.rst
@@ -27,4 +27,4 @@ default log levels, and makes generated HTML and JSON more human-readable
 
     We recommend manually setting ``BOKEH_RESOURCES`` to ``server``
     for server work, and ``inline`` for notebooks (other
-    :class:`~bokeh.resources.Resources` settings may also work)
+    :class:`~bokeh.resources.Resources` settings may also work).

--- a/sphinx/source/docs/dev_guide/models.rst
+++ b/sphinx/source/docs/dev_guide/models.rst
@@ -67,7 +67,7 @@ There is a wide variety of property types, ranging from primitive types such as:
 * :class:`~bokeh.core.properties.Complex`
 * :class:`~bokeh.core.properties.String`
 
-as well as container-like properties, that take other Properties as parameters:
+as well as container-like properties, that take other properties as parameters:
 
 * :class:`~bokeh.core.properties.List` --- for a list of one type of objects: ``List(Int)``
 * :class:`~bokeh.core.properties.Dict` --- for a mapping between two type: ``Dict(String, Double)``

--- a/sphinx/source/docs/dev_guide/models.rst
+++ b/sphinx/source/docs/dev_guide/models.rst
@@ -3,7 +3,7 @@
 Bokeh Models
 =============
 
-Low-level Interface
+Low-Level Interface
 -------------------
 
 Below is a notional diagram that shows many of the most common kinds
@@ -12,7 +12,7 @@ objects are created and assembled, and then this object graph is serialized
 to JSON. This JSON representation is consumed by the BokehJS client library,
 which uses it to render the plot.
 
-Where space permits, the attributes of the model are show inline. Not all
+Where space permits, the attributes of the model are shown inline. Not all
 objects are shown below; see the :ref:`refguide` for full details.
 
 .. image:: /_images/objects.png
@@ -32,7 +32,8 @@ that inherit from `HasProps` at some point::
         """ `Whatever` model. """
 
 Models can derive from other models as well as mixins that provide common
-sets of properties (e.g. see :class:`~bokeh.core.property_mixins.LineProps`, etc. in :ref:`bokeh.core.property_mixins`).
+sets of properties (e.g. see :class:`~bokeh.core.property_mixins.LineProps`,
+etc. in :ref:`bokeh.core.property_mixins`).
 An example might look like this::
 
     class Another(Whatever, LineProps):
@@ -49,16 +50,16 @@ Models contain properties, which are class attributes of type
 
 The `IntProps` model represents objects that have three integer values,
 ``prop1``, ``prop2``, and ``prop3``, that can be automatically serialized
-from python, and unserialized by BokehJS.
+from Python, and unserialized by BokehJS.
 
 .. note::
     Technically, ``prop1`` isn't an instance of ``Int``, but ``HasFields`` uses a
     metaclass that automatically instantiates `Property` classes when necessary,
     so ``prop1`` and ``prop2`` are equivalent (though independent) properties.
     This is useful for readability; if you don't need to pass any arguments to
-    property's constructor then prefer the former over the later.
+    property's constructor, then prefer the former over the later.
 
-There is wide variety of property types, ranging from primitive types such as:
+There is a wide variety of property types, ranging from primitive types such as:
 
 * :class:`~bokeh.core.properties.Byte`
 * :class:`~bokeh.core.properties.Int`
@@ -66,25 +67,25 @@ There is wide variety of property types, ranging from primitive types such as:
 * :class:`~bokeh.core.properties.Complex`
 * :class:`~bokeh.core.properties.String`
 
-As well as container-like properties, that take other Properties as parameters:
+as well as container-like properties, that take other Properties as parameters:
 
 * :class:`~bokeh.core.properties.List` --- for a list of one type of objects: ``List(Int)``
 * :class:`~bokeh.core.properties.Dict` --- for a mapping between two type: ``Dict(String, Double)``
 
-and finally some specialized types like
+to finally some specialized types like:
 
 * :class:`~bokeh.core.properties.Instance` --- to hold a reference to another model: ``Instance(Plot)``
 * :class:`~bokeh.core.properties.Enum` --- to represent enumerated values: ``Enum("foo", "bar", "baz")``
 * :class:`~bokeh.core.properties.Either` --- to create a union type: ``Either(Int, String)``
 * :class:`~bokeh.core.properties.Range` --- to restrict values to a given range: ``Instance(Plot)``
 
-The primary benefit of these property types is that validation can be performed
+The primary benefit of these property types is that validation can be performed,
 and meaningful error reporting can occur when an attempt is made to assign an
 invalid type or value.
 
 .. warning::
     There is an :class:`~bokeh.core.properties.Any` that is the super-type of all other
-    types, and will accept any type of value. Since this circumvents all type validation,
+    types and will accept any type of value. Since this circumvents all type validation,
     make sure to use it sparingly, if at all.
 
 See :ref:`bokeh.core.properties` for full details.
@@ -100,20 +101,20 @@ An example of a more complex, realistic model might look like this::
         prop4 = Range(Float, 0.0, 1.0)
         prop5 = List(Instance(Range1d))
 
-There is a special property-like type named :class:`~bokeh.core.properties.Include`,
-that make it simpler to mix in in properties from a mixin using a prefix, e.g.::
+There is a special property-like type named :class:`~bokeh.core.properties.Include`
+that makes it simpler to mix in properties from a mixin using a prefix, e.g.::
 
     class Includes(HasProps):
         """ `Includes` model. """
 
         some_props = Include(FillProps)
 
-In this case there is a placeholder property `some_props`, that will be removed
+In this case, there is a placeholder property `some_props`, that will be removed
 and automatically replaced with all the properties from :class:`~bokeh.core.property_mixins.FillProps`,
 each with `some_` appended as a prefix.
 
 .. note::
-    The prefix can be a valid identifier. If it ends with ``_props`` then ``props``
+    The prefix can be a valid identifier. If it ends with ``_props``, then ``props``
     will be removed. Adding ``_props`` isn't necessary, but can be useful if a
     property ``some`` already exists in parallel (see ``Plot.title`` as an example).
 
@@ -134,7 +135,7 @@ case, as well::
         some = String
         some_props = Include(FillProps)
 
-but note that this is  equivalent to::
+but note that this is equivalent to::
 
     class ExplicitIncludesExtends(HasProps):
         """ `ExplicitIncludesExtends` model. """

--- a/sphinx/source/docs/dev_guide/server.rst
+++ b/sphinx/source/docs/dev_guide/server.rst
@@ -14,7 +14,7 @@ You might want to read this if you are:
 A custom server process can add additional routes (web pages or
 REST endpoints) using Tornado's web framework.
 
-If an application developer uses ``bokeh serve`` they typically should not need
+If an application developer uses ``bokeh serve``, they typically should not need
 to import from ``bokeh.server`` at all. An application developer would only use
 the ``Server`` class if it is doing something specialized, such as a custom
 or embedded server process.
@@ -32,9 +32,9 @@ callbacks, to run periodically or to run when the document changes.
 
 Applications are represented by the ``Application`` class. This class
 contains a list of ``Handler`` instances and optional metadata. Handlers
-can be created in lots of ways; from JSON files, from Python functions, from
-Python files, and perhaps many more ways in the future.  The optional metadata
-is available as a JSON blob via the ``/metadata`` endpoint.  For example,
+can be created in lots of ways: from JSON files, from Python functions, from
+Python files, and perhaps many more ways in the future. The optional metadata
+is available as a JSON blob via the ``/metadata`` endpoint. For example,
 creating a ``Application`` instance with::
 
     Application(metadata=dict(hi="hi", there="there"))
@@ -52,7 +52,7 @@ will have ``http://server/myapp/metadata`` return (``application/json``)::
 Around each application, the server creates an ``ApplicationContext``. Its
 primary role is to hold the set of sessions for the application.
 
-Sessions are represented by class ``ServerSession``.
+Sessions are represented by the class ``ServerSession``.
 
 Each application has a route (called an ``app_path`` in the client
 API), and each session has an ID. The combination of the two
@@ -101,20 +101,20 @@ To work on the server, you'll need an understanding of Tornado's
 The Tornado documentation will be the best resource, but here are
 some quick things to know:
 
-- the Bokeh server is single-threaded, so it's important not to
+- The Bokeh server is single-threaded, so it's important not to
   write "blocking" code, meaning code that uses up the single
   thread while it waits for IO or performs a long computation. If
   you do this, you'll rapidly increase the latency seen by users
   of your application. For example, if you block for 100ms every
   time someone moves a slider, and ten users are doing this at
-  once, users could easily see 10*100ms=1s of lag... with only
+  once, users could easily see 10*100ms=1s of lag with only
   ten users.
-- in Tornado, nonblocking code is modeled with functions or
-  methods that return an instance of the ``Future`` class.  You
-  may have seen the ``@gen.coroutine`` decorator, which
+- In Tornado, non-blocking code is modeled with functions or
+  methods that return an instance of the ``Future`` class. You
+  may have seen the ``@gen.coroutine`` decorator. This decorator
   transforms the decorated method into a method which returns a
   ``Future``.
-- when no code is running, Tornado waits in its ``IOLoop``
+- When no code is running, Tornado waits in its ``IOLoop``
   (sometimes called a "main loop" or "event loop"), which means
   it's waiting for something to happen. When something happens,
   ``IOLoop`` executes any callbacks that were interested in that
@@ -162,7 +162,7 @@ Here are the steps in the lifecycle:
    ``Document`` if it likes. ``on_session_created()`` happens before
    ``modify_document()``.
 3. When there are no connections to a session, it will eventually
-   time out and ``on_session_destroyed()`` will be called.
+   time out, and ``on_session_destroyed()`` will be called.
 4. If the server process shuts down cleanly, it will call
    ``on_server_unloaded()`` on each application. This is probably
    rare in production: it's typical for server processes to be
@@ -172,7 +172,7 @@ Here are the steps in the lifecycle:
 
 These hooks can add periodic or one-shot callbacks to the
 ``ServerContext``. These callbacks may be asynchronous (using
-Tornado's async IO facilities), and are able to update all live
+Tornado's async IO facilities) and are able to update all live
 session documents.
 
 **Critical consideration when using ``on_server_loaded()``**:
@@ -192,7 +192,7 @@ the server.
 Locking
 ^^^^^^^
 
-The trickiest aspect of ``ServerSession`` may be locking.  In general, we
+The trickiest aspect of ``ServerSession`` may be locking. In general, we
 want one callback or one websocket request to be processed at a time; we
 don't want to interleave them, because it would be difficult to implement
 callbacks and request handlers if they had to worry about interleaving.
@@ -235,14 +235,14 @@ If an attacker knows someone's session ID, they can eavesdrop on or modify
 the session. If you're writing a larger web app with a Bokeh app embedded
 inside, this may affect how you design your larger app.
 
-When hacking on the server, for the most part session IDs are opaque strings
+When hacking on the server, for the most part session IDs are opaque strings,
 and after initially validating the ID, it doesn't matter to the server code
 what the ID is.
 
 Session Timeout
 ^^^^^^^^^^^^^^^^
 
-To avoid resource exhaustion, unused sessions will time out according to code in
+To avoid resource exhaustion, unused sessions will time out according to code
 in ``application_context.py``
 
 Websocket Protocol
@@ -252,9 +252,9 @@ The server has a websocket connection open to each client (each browser tab,
 in typical usage). The primary role of the websocket is to keep the session's
 ``Document`` in sync between the client and the server.
 
-There are two client implementations in the Bokeh codebase; one is a Python
+There are two client implementations in the Bokeh codebase: one is a Python
 ``ClientSession``, the other is a JavaScript ``ClientSession``.
-Client and server sessions are mostly symmetrical; on both sides, we are
+Client and server sessions are mostly symmetrical. On both sides, we are
 receiving change notifications from the other side's ``Document``, and sending
 notification of changes made on our side. In this way, the two ``Document``
 are kept in sync.
@@ -265,14 +265,14 @@ use it.
 
 Websockets already implement "frames" for us, and they guarantee frames will
 arrive in the same order they were sent. Frames are strings or byte arrays
-(or special internal frame types, such as pings). A websocket looks like a
+(or special internal frame types, such as pings). A websocket looks like
 two sequences of frames, one sequence in each direction ("full duplex").
 
 On top of websocket frames, we implement our own ``Message`` concept. A Bokeh
 ``Message`` spans multiple websocket frames. It always contains a header frame,
 metadata frame, and content frame. These three frames each contain a JSON
 string. The code permits these three frames to be followed by optional binary data
-frames. In principle this could allow for example, for sending numpy arrays
+frames. In principle, this could allow, for example, for sending NumPy arrays
 directly from their memory buffers to the websocket with no additional copies.
 However, the binary data frames are not yet used in Bokeh.
 
@@ -280,8 +280,8 @@ The header frame indicates the message type and gives messages an ID. Message
 IDs are used to match replies with requests (the reply contains a field saying
 "I am the reply to the request with ID xyz").
 
-The metadata frame has nothing in it for now, but could be used for debugging
-data or another purpose in the future.
+The metadata frame has nothing in it for now but could be used for debugging
+data or for another purpose in the future.
 
 The content frame has the "body" of the message.
 
@@ -303,7 +303,7 @@ There aren't many messages right now. A quick overview:
 - ``PATCH-DOC`` sends changes to the session's document to the
   other side
 
-Typically, when opening a connection one side will pull or push
+Typically, when opening a connection, one side will pull or push
 the entire document; after the initial pull or push, the two sides
 stay in sync using ``PATCH-DOC`` messages.
 
@@ -315,7 +315,7 @@ Some Current Protocol Caveats
    end up out-of-sync if this happens, because the two
    ``PATCH-DOC`` are in flight at the same time). It's easy to
    devise a scheme to detect this situation, but it's less clear
-   what to do when it's detected, so right now we don't detect it
+   what to do when it's detected, so right now, we don't detect it
    and do nothing. In most cases, applications should avoid this
    situation because even if we could make sense of it and handle
    it somehow, it would probably be inefficient for the two sides
@@ -329,9 +329,9 @@ Some Current Protocol Caveats
    changes.
 
 3. At the moment, we do not optimize binary data by sending it
-   over binary websocket frames.  However, NumPy arrays of
-   dtype ``float32``, ``float64`` and integer types smaller than ``int32``
-   are base64 encoded in content frame to avoid performance
+   over binary websocket frames. However, NumPy arrays of
+   dtype ``float32``, ``float64``, and integer types smaller than ``int32``
+   are base64 encoded in a content frame to avoid performance
    limitations of naive JSON string serialization.
    JavaScript's lack of native 64-bit integer support precludes
    them from inclusion in this optimization.
@@ -355,26 +355,26 @@ In brief:
   backs the ``bokeh.embed.server_document()`` and ``bokeh.embed.server_session()``
   functionality
 
-Bokeh server isn't intended to be a general-purpose web framework. You can
-however pass new endpoints to ``Server`` using the ``extra_patterns`` parameter
+Bokeh server isn't intended to be a general-purpose web framework. You can,
+however, pass new endpoints to ``Server`` using the ``extra_patterns`` parameter
 and the Tornado APIs.
 
-Additional details
+Additional Details
 ------------------
 
 Events
 ^^^^^^
 
-In general whenever a model property is modified, the new value is
+In general, whenever a model property is modified, the new value is
 first validated, and the ``Document`` is notified of the change. Just
 as models may have ``on_change`` callbacks, so can a
 ``Document``. When a ``Document`` is notified of a change to one of
-its models it will generate the appropriate event (usually a
+its models, it will generate the appropriate event (usually a
 ``ModelChangedEvent``) and trigger the ``on_change`` callbacks,
 passing them this new event. Sessions are one such callback, which
 will turn the event into a patch that can be sent across the web
 socket connection. When a message is received by the client or server
-session it will extract the patch and apply it directly to the
+session, it will extract the patch and apply it directly to the
 ``Document``.
 
 In order to avoid events bouncing back and forth between client and
@@ -382,31 +382,31 @@ server (as each patch would generate new events, which would in turn
 be sent back), the session informs the ``Document`` that it was
 responsible for generating the patch and any subsequent events that
 are generated. In this way, when a ``Session`` is notified of a change
-to the document it can check whether the ``event.setter`` is identical
+to the document, it can check whether the ``event.setter`` is identical
 with itself and therefore skip processing the event.
 
 Serialization
 ^^^^^^^^^^^^^
 
-In general all the concepts above are agnostic as to how precisely the
+In general, all the concepts above are agnostic as to how precisely the
 models and change events are encoded and decoded. Each model and its
 properties are responsible for converting their values to a JSON-like
-format, which can be sent across the Websocket connection. One
+format, which can be sent across the websocket connection. One
 difficulty here is that one model can reference other models, often in
-highly interconnected and even circular ways. Therefore during the
-conversion to a JSON-like format all references by one model to other
-models are replaced with ID references.  Additionally models and
-properties can define special serialization behaviors, one such
+highly interconnected and even circular ways. Therefore, during the
+conversion to a JSON-like format, all references by one model to other
+models are replaced with ID references. Additionally, models and
+properties can define special serialization behavior. One such
 example is the ``ColumnData`` property on a ``ColumnDataSource``,
 which will convert NumPy arrays to a base64 encoded representation,
 which is significantly more efficient than sending numeric arrays in a
-string based format. The ``ColumnData`` property
-``serializable_value`` method applies this encoding and the from_json
-method will convert the data back. Equivalently the JS-based
+string-based format. The ``ColumnData`` property
+``serializable_value`` method applies this encoding, and the from_json
+method will convert the data back. Equivalently, the JS-based
 ``ColumnDataSource`` knows how to interpret the base64 encoded data
-and converts it to Javascript typed arrays and its
+and converts it to JavaScript typed arrays, and its
 ``attributes_as_json`` methods also knows how to encode the data. In
-this way models can implement optimized serialization formats.
+this way, models can implement optimized serialization formats.
 
 
 Testing
@@ -416,7 +416,7 @@ To test client-server functionality, use the utilities in
 ``bokeh.server.tests.utils``.
 
 Using ``ManagedServerLoop``, you can start up a server instance
-in-process; share ``server.io_loop`` with a client and you can
+in-process. Share ``server.io_loop`` with a client, and you can
 test any aspect of the server. Check out the existing tests for
-lots of examples. Anytime you add a new websocket message or http
+lots of examples. Anytime you add a new websocket message or HTTP
 endpoint, be sure to add tests!

--- a/sphinx/source/docs/dev_guide/setup.rst
+++ b/sphinx/source/docs/dev_guide/setup.rst
@@ -25,8 +25,8 @@ Git
 ~~~
 
 The Bokeh source code is stored in a `Git`_ source control repository.
-The first step to working on Bokeh is to install Git on to your system.
-There are different ways to do this depending on whether, you are using
+The first step to working on Bokeh is to install Git on your system.
+There are different ways to do this, depending on whether you are using
 Windows, OSX, or Linux.
 
 To install Git on any platform, refer to the `Installing Git`_ section of
@@ -64,9 +64,9 @@ source repository, issue the following command:
     Active @bokeh/dev contributors should clone the main source repository to
     make sure the complete CI testing automation runs successfully.
 
-New or casual contributors are required to clone their forks of the `bokeh source
-repository`_. To fork and clone Github repositories, refer to `Fork a repo`_
-section of `GitHub Help`_.
+    New or casual contributors are required to clone their forks of the `bokeh source
+    repository`_. To fork and clone Github repositories, refer to `Fork a repo`_
+    section of `GitHub Help`_.
 
 This will create a ``bokeh`` directory at your file system location. This
 ``bokeh`` directory is referred to as the *source checkout* for the remainder
@@ -98,22 +98,22 @@ Then, to activate the environment:
 Installing Node Packages
 ------------------------
 
-Building BokehJS also requires installing  JavaScript dependencies using
+Building BokehJS also requires installing JavaScript dependencies using
 the Node Package Manager. If you have followed the instructions above,
 ``conda`` has already installed the necessary ``npm`` and ``node.js``
 packages to your system.
 
 Bokeh is typically updated to require the latest major revision of ``npm``
-in order to build. To install the lastest version globally, start from the
+in order to build. To install the latest version globally, start from the
 top level of the *source checkout* directory, and execute the following
-commands
+commands:
 
 .. code-block:: sh
 
     cd bokehjs
     npm install -g npm
 
-If you do not wish to install globally (i.e. with ``-g``) then all
+If you do not wish to install globally (i.e. with ``-g``), then all
 subsequent ``npm`` commands will need to be adjusted to use the local
 version installed under ``bokehjs/node_modules``.
 
@@ -127,11 +127,10 @@ to install all of BokehJS JavaScript dependencies:
 This command will install the necessary packages into the ``node_modules``
 subdirectory.
 
-----
-
-Typically, these instructions only need to be followed once, when you are
-first getting set up. Occasionally, however, dependencies may be added or
-changed, in which case these instructions will need to be followed again.
+.. note::
+    Typically, these instructions only need to be followed once, when you are
+    first getting set up. Occasionally, however, dependencies may be added or
+    changed, in which case these instructions will need to be followed again.
 
 .. _devguide_configuring_git:
 
@@ -216,7 +215,7 @@ You can replace ``vim`` with whatever your favorite editor command is.
 Building and Installing
 -----------------------
 
-Once you have all the required depencies installed, the simplest way to
+Once you have all the required dependencies installed, the simplest way to
 build and install Bokeh and BokehJS is to use the ``setup.py`` script at
 the top level of the *source checkout* directory.
 
@@ -302,9 +301,9 @@ You should see output similar to:
     npm version         :  6.14.5
 
 The next check that can be made is to run some of the examples. There are
-different ways in which bokeh can be used which suit a variety of use cases.
+different ways in which Bokeh can be used to suit a variety of use cases.
 
-To create an html file,
+To create an HTML file,
 
 .. code-block:: sh
 
@@ -319,11 +318,11 @@ which will create a file ``iris.html`` locally and open up a web browser.
 The variable ``BOKEH_RESOURCES`` determines where the css and JavaScript
 resources required by bokeh are found. By specifying ``inline`` we are using
 the version of BokehJS we just built to include the resources inline as part of
-the html file. The ``BOKEH_RESOURCES`` variable is required as the default
-behaviour is to use CDN resources.
+the HTML file. The ``BOKEH_RESOURCES`` variable is required as the default
+behavior is to use CDN resources.
 
 Another method of running bokeh is as a server. An example of this mode of
-operation can be run using the command
+operation can be run using the command:
 
 .. code-block:: sh
 

--- a/sphinx/source/docs/dev_guide/testing.rst
+++ b/sphinx/source/docs/dev_guide/testing.rst
@@ -59,7 +59,7 @@ source checkout and execute:
     node make test
 
 You can run all available tests (python and JS unit tests, as well as example
-and integration tests) **from the top level directory** by executing:
+and integration tests) **from the top-level directory** by executing:
 
 .. code-block:: sh
 
@@ -75,7 +75,7 @@ of currently defined test markers is below:
 Code Coverage
 ~~~~~~~~~~~~~
 
-To run any of the tests with coverage use the following:
+To run any of the tests with coverage, use the following:
 
 .. code-block:: sh
 
@@ -95,7 +95,7 @@ To run any of the tests without standard output captured use:
 See the `pytest`_ documentation for further information on ``pytest`` and
 its options.
 
-Examples tests
+Examples Tests
 ~~~~~~~~~~~~~~
 
 The ``examples`` tests run a selection of the Bokeh examples and generate
@@ -122,13 +122,13 @@ The examples tests can run slowly, to speed them up, you can parallelize them:
 
     pytest --report-path=examples.html -n 5 test_examples.py
 
-Where ``n`` is the number is the number of cores you want to use.
+Where ``n`` is the number of cores you want to use.
 
 In addition, the examples tests generate a log file, examples.log which you
 can view at ``examples.log`` in the same directory that you the tests
 were run from.
 
-Integration tests
+Integration Tests
 ~~~~~~~~~~~~~~~~~
 
 Writing Tests
@@ -171,10 +171,10 @@ appropriate entry in the directory ``index`` file should be added.
 Integration Tests
 ~~~~~~~~~~~~~~~~~
 
-To add a new screen shot integration test, first make sure you can run
-existing screen shot tests, for example
-:bokeh-tree:`tests/integration/annotations/test_whisker.py`. New screen
-shot tests should follow the general guidelines:
+To add a new screenshot integration test, first make sure you can run
+existing screenshot tests, for example
+:bokeh-tree:`tests/integration/annotations/test_whisker.py`. New screenshot
+tests should follow these general guidelines:
 
 * Be as simple as possible (only include things under test and nothing extra)
 
@@ -184,7 +184,7 @@ Once a new test is written, a base image for comparison is needed. To create
 a new base image, add ``--set-new-base-screenshot`` to your the standard
 ``pytest`` command to run the test. This will generate an image with the name
 ``base__<name_of_your_test>.png`` in the appropriate directory. Use ``git``
-to check this image into the repository, and then all future screen shot tests
+to check this image into the repository, and then all future screenshot tests
 will be compared against this base image.
 
 Continuous Integration


### PR DESCRIPTION
Fixes typos in Developer Guide, partially fixes issue #8448.
Based on pull request #10269 (Fix typos in the User Guide), I have fixed several typos in the Developer Guide.
The same basic assumptions apply here as well, i.e. this pull request is focussing exclusively on fixing errors such as misspelled words, omitted words, superfluous words, capitalization inconsistencies and some punctuation issues (see [this comment](https://github.com/bokeh/bokeh/pull/10269#issuecomment-656485540)).
This commit includes all my changes, this pull request is status: ready!
[ci disable examples]