### PR TITLE
Replace for-in loop with for-of and keys()/values()/entries()

### DIFF
--- a/bokehjs/eslint.json
+++ b/bokehjs/eslint.json
@@ -66,6 +66,7 @@
       "named": "never",
       "asyncArrow": "always"
     }],
-    "space-in-parens": ["error", "never"]
+    "space-in-parens": ["error", "never"],
+    "guard-for-in": ["error"]
   }
 }

--- a/bokehjs/src/lib/api/plotting.ts
+++ b/bokehjs/src/lib/api/plotting.ts
@@ -10,7 +10,7 @@ import {Location} from "../core/enums"
 import {startsWith} from "../core/util/string"
 import {isEqual} from "../core/util/eq"
 import {some, every, includes} from "../core/util/array"
-import {clone} from "../core/util/object"
+import {clone, keys, entries} from "../core/util/object"
 import {isNumber, isString, isArray} from "../core/util/types"
 import {ViewOf} from "core/view"
 import {enumerate} from "core/util/iterator"
@@ -631,14 +631,13 @@ export class Figure extends Plot {
 
     const result: Attrs = {}
     const traits = new Set()
-    for (const pname in cls.prototype._props) {
+    for (const pname of keys(cls.prototype._props)) {
       if (_is_visual(pname)) {
         const trait = _split_feature_trait(pname)[1]
         if (props.hasOwnProperty(prefix+pname)) {
           result[pname] = props[prefix+pname]
           delete props[prefix+pname]
-        } else if (!cls.prototype._props.hasOwnProperty(trait)
-                 && props.hasOwnProperty(prefix+trait)) {
+        } else if (!cls.prototype._props.hasOwnProperty(trait) && props.hasOwnProperty(prefix+trait)) {
           result[pname] = props[prefix+trait]
         } else if (override_defaults.hasOwnProperty(trait)) {
           result[pname] = override_defaults[trait]
@@ -672,8 +671,7 @@ export class Figure extends Plot {
   }
 
   _fixup_values(cls: Class<HasProps>, data: Data, attrs: Attrs): void {
-    for (const name in attrs) {
-      const value = attrs[name]
+    for (const [name, value] of entries(attrs)) {
       const prop = cls.prototype._props[name]
 
       if (prop != null) {

--- a/bokehjs/src/lib/base.ts
+++ b/bokehjs/src/lib/base.ts
@@ -1,4 +1,5 @@
 import {isObject} from "./core/util/types"
+import {values} from "./core/util/object"
 import {HasProps} from "./core/has_props"
 
 export const overrides: {[key: string]: typeof HasProps} = {}
@@ -38,9 +39,7 @@ Models.register_models = (models, force = false, errorFn?) => {
   if (models == null)
     return
 
-  for (const name in models) {
-    const model = models[name]
-
+  for (const model of values(models)) {
     if (is_HasProps(model)) {
       const qualified = model.__qualified__
       if (force || !_all_models.has(qualified))

--- a/bokehjs/src/lib/core/dom.ts
+++ b/bokehjs/src/lib/core/dom.ts
@@ -1,4 +1,5 @@
 import {isBoolean, isString, isArray, isPlainObject} from "./util/types"
+import {entries} from "./util/object"
 import {Size, Box, Extents} from "./types"
 
 export type HTMLAttrs = {[name: string]: any}
@@ -10,9 +11,7 @@ const _createElement = <T extends keyof HTMLElementTagNameMap>(tag: T) => {
     const element = document.createElement(tag)
     element.classList.add("bk")
 
-    for (const attr in attrs) {
-      let value = attrs[attr]
-
+    for (let [attr, value] of entries(attrs)) {
       if (value == null || isBoolean(value) && !value)
         continue
 
@@ -30,15 +29,15 @@ const _createElement = <T extends keyof HTMLElementTagNameMap>(tag: T) => {
       }
 
       if (attr === "style" && isPlainObject(value)) {
-        for (const prop in value) {
-          (element.style as any)[prop] = value[prop]
+        for (const [prop, data] of entries(value)) {
+          (element.style as any)[prop] = data
         }
         continue
       }
 
       if (attr === "data" && isPlainObject(value)) {
-        for (const key in value) {
-          element.dataset[key] = value[key] as string | undefined // XXX: attrs needs a better type
+        for (const [key, data] of entries(value)) {
+          element.dataset[key] = data as string | undefined // XXX: attrs needs a better type
         }
         continue
       }

--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -9,7 +9,7 @@ import * as mixins from "./property_mixins"
 import {Property} from "./properties"
 import {uniqueId} from "./util/string"
 import {max, copy} from "./util/array"
-import {entries, clone, extend} from "./util/object"
+import {values, entries, clone, extend} from "./util/object"
 import {isPlainObject, isObject, isArray, isTypedArray, isString, isFunction} from "./util/types"
 import {isEqual} from './util/eq'
 import {ColumnarDataSource} from "models/sources/columnar_data_source"
@@ -434,8 +434,8 @@ export abstract class HasProps extends Signalable() implements Equals, Printable
   }
 
   *[Symbol.iterator](): PropertyGenerator {
-    for (const name in this.properties) {
-      yield this.properties[name]
+    for (const prop of values(this.properties)) {
+      yield prop
     }
   }
 
@@ -470,9 +470,8 @@ export abstract class HasProps extends Signalable() implements Equals, Printable
       return ref_array
     } else if (isPlainObject(value)) {
       const ref_obj: Attrs = {}
-      for (const subkey in value) {
-        if (value.hasOwnProperty(subkey))
-          ref_obj[subkey] = HasProps._value_to_json(value[subkey])
+      for (const [subkey, subvalue] of entries(value)) {
+        ref_obj[subkey] = HasProps._value_to_json(subvalue)
       }
       return ref_obj
     } else
@@ -504,11 +503,8 @@ export abstract class HasProps extends Signalable() implements Equals, Printable
       for (const elem of v)
         HasProps._json_record_references(doc, elem, refs, {recursive})
     } else if (isPlainObject(v)) {
-      for (const k in v) {
-        if (v.hasOwnProperty(k)) {
-          const elem = v[k]
-          HasProps._json_record_references(doc, elem, refs, {recursive})
-        }
+      for (const elem of values(v)) {
+        HasProps._json_record_references(doc, elem, refs, {recursive})
       }
     }
   }
@@ -531,11 +527,8 @@ export abstract class HasProps extends Signalable() implements Equals, Printable
       for (const elem of v)
         HasProps._value_record_references(elem, refs, {recursive})
     } else if (isPlainObject(v)) {
-      for (const k in v) {
-        if (v.hasOwnProperty(k)) {
-          const elem = v[k]
-          HasProps._value_record_references(elem, refs, {recursive})
-        }
+      for (const elem of values(v)) {
+        HasProps._value_record_references(elem, refs, {recursive})
       }
     }
   }

--- a/bokehjs/src/lib/core/logging.ts
+++ b/bokehjs/src/lib/core/logging.ts
@@ -1,6 +1,7 @@
 // This is based on https://github.com/pimterry/loglevel
 
 import {isString} from "./util/types"
+import {entries} from "./util/object"
 
 const _loggers: {[key: string]: Logger} = {}
 
@@ -68,9 +69,7 @@ export class Logger {
 
     const logger_name = `[${this._name}]`
 
-    for (const name in Logger.log_levels) {
-      const log_level = Logger.log_levels[name]
-
+    for (const [name, log_level] of entries(Logger.log_levels)) {
       if (log_level.level < this._log_level.level || this._log_level.level === Logger.OFF.level)
         (this as any)[name] = function() {}
       else

--- a/bokehjs/src/lib/document/document.ts
+++ b/bokehjs/src/lib/document/document.ts
@@ -8,6 +8,7 @@ import {Signal0} from "core/signaling"
 import {Struct, is_ref} from "core/util/refs"
 import {Buffers, is_NDArray_ref, decode_NDArray} from "core/util/serialization"
 import {difference, intersection, copy, includes} from "core/util/array"
+import {values, entries} from "core/util/object"
 import * as sets from "core/util/set"
 import {isEqual} from "core/util/eq"
 import {isArray, isPlainObject} from "core/util/types"
@@ -402,8 +403,7 @@ export class Document {
 
     function resolve_dict(dict: PlainObject) {
       const resolved: PlainObject = {}
-      for (const k in dict) {
-        const v = dict[k]
+      for (const [k, v] of entries(dict)) {
         resolved[k] = resolve_ref(v)
       }
       return resolved
@@ -440,8 +440,8 @@ export class Document {
           const {instance, is_new} = to_update.get(v.id)!
           const {attributes} = instance
 
-          for (const attr in attributes) {
-            finalize_all_by_dfs(attributes[attr])
+          for (const value of values(attributes)) {
+            finalize_all_by_dfs(value)
           }
 
           if (is_new) {
@@ -457,8 +457,8 @@ export class Document {
         for (const e of v)
           finalize_all_by_dfs(e)
       } else if (isPlainObject(v)) {
-        for (const k in v)
-          finalize_all_by_dfs(v[k])
+        for (const value of values(v))
+          finalize_all_by_dfs(value)
       }
     }
 

--- a/bokehjs/src/lib/embed/index.ts
+++ b/bokehjs/src/lib/embed/index.ts
@@ -1,6 +1,7 @@
 import {Document, DocJson} from "../document"
 import {logger} from "../core/logging"
 import {unescape, uuid4} from "../core/util/string"
+import {entries} from "core/util/object"
 import {isString} from "../core/util/types"
 import {defer} from "core/util/callback"
 import {View} from "core/view"
@@ -51,8 +52,7 @@ async function _embed_items(docs_json: string | DocsJson, render_items: RenderIt
     docs_json = JSON.parse(unescape(docs_json)) as DocsJson
 
   const docs: {[key: string]: Document} = {}
-  for (const docid in docs_json) {
-    const doc_json = docs_json[docid]
+  for (const [docid, doc_json] of entries(docs_json)) {
     docs[docid] = Document.from_json(doc_json)
   }
 

--- a/bokehjs/src/lib/models/sources/ajax_data_source.ts
+++ b/bokehjs/src/lib/models/sources/ajax_data_source.ts
@@ -2,6 +2,7 @@ import {WebDataSource} from "./web_data_source"
 import {UpdateMode, HTTPMethod} from "core/enums"
 import {logger} from "core/logging"
 import * as p from "core/properties"
+import {entries} from "core/util/object"
 
 export namespace AjaxDataSource {
   export type Attrs = p.AttrsOf<Props>
@@ -71,8 +72,7 @@ export class AjaxDataSource extends WebDataSource {
     xhr.setRequestHeader("Content-Type", this.content_type)
 
     const http_headers = this.http_headers
-    for (const name in http_headers) {
-      const value = http_headers[name]
+    for (const [name, value] of entries(http_headers)) {
       xhr.setRequestHeader(name, value)
     }
 

--- a/bokehjs/src/lib/models/sources/column_data_source.ts
+++ b/bokehjs/src/lib/models/sources/column_data_source.ts
@@ -164,8 +164,8 @@ export class ColumnDataSource extends ColumnarDataSource {
 
   stream(new_data: Data, rollover?: number, setter_id?: string): void {
     const {data} = this
-    for (const k in new_data) {
-      data[k] = stream_to_column(data[k], new_data[k], rollover)
+    for (const [name, new_column] of entries(new_data)) {
+      data[name] = stream_to_column(data[name], new_column, rollover)
     }
     this.setv({data}, {silent: true})
     this.streaming.emit()

--- a/bokehjs/src/lib/models/sources/geojson_data_source.ts
+++ b/bokehjs/src/lib/models/sources/geojson_data_source.ts
@@ -8,6 +8,7 @@ import {logger} from "core/logging"
 import * as p from "core/properties"
 import {Arrayable} from "core/types"
 import {range} from "core/util/array"
+import {entries} from "core/util/object"
 
 type GeoItem = Point | MultiPoint | LineString | MultiLineString | Polygon | MultiPolygon | GeometryCollection
 
@@ -75,12 +76,12 @@ export class GeoJSONDataSource extends ColumnarDataSource {
   }
 
   private _add_properties(item: Feature<GeoItem>, data: GeoData, i: number, item_count: number): void {
-    const properties = item.properties || {}
-    for (const property in properties) {
+    const properties = item.properties ?? {}
+    for (const [property, value] of entries(properties)) {
       if (!data.hasOwnProperty(property))
         data[property] = this._get_new_nan_array(item_count)
       // orNaN necessary here to prevent null values from ending up in the column
-      data[property][i] = orNaN(properties[property])
+      data[property][i] = orNaN(value)
     }
   }
 

--- a/bokehjs/src/lib/models/tools/toolbar.ts
+++ b/bokehjs/src/lib/models/tools/toolbar.ts
@@ -1,12 +1,13 @@
 import * as p from "core/properties"
 import {isArray} from "core/util/types"
 import {sort_by, includes, intersection} from "core/util/array"
+import {values, entries} from "core/util/object"
 
 import {Tool} from "./tool"
 import {GestureTool} from "./gestures/gesture_tool"
 import {InspectTool} from "./inspectors/inspect_tool"
 
-import {ToolbarBase, ToolbarBaseView, GestureType} from "./toolbar_base"
+import {ToolbarBase, ToolbarBaseView} from "./toolbar_base"
 
 // XXX: add appropriate base classes to get rid of this
 export type Drag = Tool
@@ -113,21 +114,18 @@ export class Toolbar extends ToolbarBase {
     }
 
     // Connecting signals has to be done before changing the active state of the tools.
-    for (const et in this.gestures) {
-      const gesture = this.gestures[et as GestureType]
-
+    for (const gesture of values(this.gestures)) {
       gesture.tools = sort_by(gesture.tools, (tool) => tool.default_order)
       for (const tool of gesture.tools) {
         this.connect(tool.properties.active.change, () => this._active_change(tool))
       }
     }
 
-    for (const et in this.gestures) {
+    for (const [et, gesture] of entries(this.gestures)) {
       const active_attr = _get_active_attr(et)
       if (active_attr) {
         const active_tool = this[active_attr]
         if (active_tool == 'auto') {
-          const gesture = this.gestures[et as GestureType]
           if (gesture.tools.length != 0 && _supports_auto(et)) {
             _activate_gesture(gesture.tools[0])
           }

--- a/bokehjs/src/lib/models/tools/toolbar_base.ts
+++ b/bokehjs/src/lib/models/tools/toolbar_base.ts
@@ -6,6 +6,7 @@ import {DOMView} from "core/dom_view"
 import {Logo, Location} from "core/enums"
 import {EventType} from "core/ui_events"
 import {some, every} from "core/util/array"
+import {values} from "core/util/object"
 import {isString} from "core/util/types"
 import {Model} from "model"
 import {Tool} from "./tool"
@@ -136,8 +137,8 @@ export class ToolbarBaseView extends DOMView {
     }
 
     const {gestures} = this.model
-    for (const et in gestures) {
-      bars.push(gestures[et as EventType].tools.map(el))
+    for (const gesture of values(gestures)) {
+      bars.push(gesture.tools.map(el))
     }
 
     bars.push(this.model.actions.map(el))

--- a/bokehjs/src/lib/models/tools/toolbar_box.ts
+++ b/bokehjs/src/lib/models/tools/toolbar_box.ts
@@ -1,6 +1,7 @@
 import * as p from "core/properties"
 import {Location} from "core/enums"
 import {includes, sort_by} from "core/util/array"
+import {keys, values, entries} from "core/util/object"
 
 import {Tool} from "./tool"
 import {ButtonTool} from "./button_tool"
@@ -64,8 +65,7 @@ export class ProxyToolbar extends ToolbarBase {
     this._proxied_tools.push(...new_help_tools)
     this.help = new_help_tools
 
-    for (const event_type in this.gestures) {
-      const gesture = this.gestures[event_type as GestureType]
+    for (const [event_type, gesture] of entries(this.gestures)) {
       if (!(event_type in gestures)) {
         gestures[event_type] = {}
       }
@@ -98,11 +98,11 @@ export class ProxyToolbar extends ToolbarBase {
       return proxy
     }
 
-    for (const event_type in gestures) {
+    for (const event_type of keys(gestures)) {
       const gesture = this.gestures[event_type as GestureType]
       gesture.tools = []
 
-      for (const tool_type in gestures[event_type]) {
+      for (const tool_type of keys(gestures[event_type])) {
         const tools = gestures[event_type][tool_type]
 
         if (tools.length > 0) {
@@ -122,9 +122,7 @@ export class ProxyToolbar extends ToolbarBase {
     }
 
     this.actions = []
-    for (const tool_type in actions) {
-      const tools = actions[tool_type]
-
+    for (const [tool_type, tools] of entries(actions)) {
       if (tool_type == 'CustomAction') {
         for (const tool of tools)
           this.actions.push(make_proxy([tool]) as any)
@@ -134,15 +132,12 @@ export class ProxyToolbar extends ToolbarBase {
     }
 
     this.inspectors = []
-    for (const tool_type in inspectors) {
-      const tools = inspectors[tool_type]
-
+    for (const tools of values(inspectors)) {
       if (tools.length > 0)
         this.inspectors.push(make_proxy(tools, true) as any) // XXX
     }
 
-    for (const et in this.gestures) {
-      const gesture = this.gestures[et as GestureType]
+    for (const [et, gesture] of entries(this.gestures)) {
       if (gesture.tools.length == 0)
         continue
 

--- a/bokehjs/test/codebase/size.ts
+++ b/bokehjs/test/codebase/size.ts
@@ -6,25 +6,24 @@ import * as path from "path"
 
 const build_dir = path.normalize(`${__dirname}/../..`) // build/test/codebase -> build
 
-const LIMITS: {[key: string]: number} = {
+const LIMITS = new Map([
   // es2017
-  "js/bokeh.min.js":          700,
-  "js/bokeh-widgets.min.js":  300,
-  "js/bokeh-tables.min.js":   270,
-  "js/bokeh-api.min.js":      90,
-  "js/bokeh-gl.min.js":       70,
+  ["js/bokeh.min.js",                700],
+  ["js/bokeh-widgets.min.js",        300],
+  ["js/bokeh-tables.min.js",         270],
+  ["js/bokeh-api.min.js",             90],
+  ["js/bokeh-gl.min.js",              70],
   // legacy (es5)
-  "js/bokeh.legacy.min.js":         850,
-  "js/bokeh-widgets.legacy.min.js": 300,
-  "js/bokeh-tables.legacy.min.js":  270,
-  "js/bokeh-api.legacy.min.js":      90,
-  "js/bokeh-gl.legacy.min.js":       70,
-}
+  ["js/bokeh.legacy.min.js",         850],
+  ["js/bokeh-widgets.legacy.min.js", 300],
+  ["js/bokeh-tables.legacy.min.js",  270],
+  ["js/bokeh-api.legacy.min.js",      90],
+  ["js/bokeh-gl.legacy.min.js",       70],
+])
 
 describe(`bokehjs/build/*/*.min.js file sizes`, () => {
-  for (const filename in LIMITS) {
+  for (const [filename, limit] of LIMITS) {
     const stats = fs.statSync(path.join(build_dir, filename))
-    const limit = LIMITS[filename]
 
     describe(`${filename} file size`, () => {
       it(`should be ${Math.round(stats.size/1024)} kB < ${limit} kB`, () => {

--- a/bokehjs/test/defaults/index.ts
+++ b/bokehjs/test/defaults/index.ts
@@ -7,7 +7,7 @@ import all_defaults from "../.generated_defaults/defaults.json"
 
 import {isArray, isPlainObject} from "@bokehjs/core/util/types"
 import {difference} from "@bokehjs/core/util/array"
-import {keys} from "@bokehjs/core/util/object"
+import {keys, values, entries} from "@bokehjs/core/util/object"
 import {isEqual} from "@bokehjs/core/util/eq"
 
 import {Models} from "@bokehjs/base"
@@ -47,9 +47,8 @@ function deep_value_to_serializable(_key: string, value: any, _optional_parent_o
     return ref_array
   } else if (isPlainObject(value)) {
     const ref_obj: {[key: string]: any} = {}
-    for (const subkey in value) {
-      if (value.hasOwnProperty(subkey))
-        ref_obj[subkey] = deep_value_to_serializable(subkey, value[subkey], value)
+    for (const [subkey, subvalue] of entries(value)) {
+      ref_obj[subkey] = deep_value_to_serializable(subkey, subvalue, value)
     }
     return ref_obj
   } else
@@ -62,9 +61,8 @@ function check_matching_defaults(name: string, python_defaults: KV, bokehjs_defa
   const different: string[] = []
   const python_missing: string[] = []
   const bokehjs_missing: string[] = []
-  for (const k in bokehjs_defaults) {
-    const js_v = bokehjs_defaults[k]
 
+  for (const [k, js_v] of entries(bokehjs_defaults)) {
     // special case for graph renderer node_renderer
     if (name === "GraphRenderer" && k === "node_renderer")
       continue
@@ -145,9 +143,8 @@ function check_matching_defaults(name: string, python_defaults: KV, bokehjs_defa
     }
   }
 
-  for (const k in python_defaults) {
+  for (const [k, v] of entries(python_defaults)) {
     if (!(k in bokehjs_defaults)) {
-      const v = python_defaults[k]
       bokehjs_missing.push(`${name}.${k}: python defaults to ${safe_stringify(v)} but bokehjs has no such property`)
     }
   }
@@ -176,8 +173,8 @@ function strip_ids(value: any): void {
     if ('id' in value) {
       delete value.id
     }
-    for (const k in value) {
-      strip_ids(value[k])
+    for (const v of values(value)) {
+      strip_ids(v)
     }
   }
 }

--- a/bokehjs/test/unit/core/properties.ts
+++ b/bokehjs/test/unit/core/properties.ts
@@ -2,6 +2,7 @@ import {expect} from "assertions"
 
 import * as p from "@bokehjs/core/properties"
 import * as enums from "@bokehjs/core/enums"
+import {keys} from "@bokehjs/core/util/object"
 
 import {HasProps} from  "@bokehjs/core/has_props"
 import {ColumnDataSource} from "@bokehjs/models/sources/column_data_source"
@@ -458,7 +459,7 @@ describe("properties module", () => {
       })
 
       it("should return undefined on svg color input", () => {
-        for (const color in svg_colors) {
+        for (const color of keys(svg_colors)) {
           expect(prop.valid(color)).to.be.true
         }
       })

--- a/bokehjs/test/unit/document/document.ts
+++ b/bokehjs/test/unit/document/document.ts
@@ -2,7 +2,7 @@ import {expect} from "assertions"
 import * as sinon from "sinon"
 
 import {assert} from "@bokehjs/core/util/assert"
-import {values} from "@bokehjs/core/util/object"
+import {values, entries} from "@bokehjs/core/util/object"
 import {Document, DEFAULT_TITLE} from "@bokehjs/document"
 import * as ev from "@bokehjs/document/events"
 import {version as js_version} from "@bokehjs/version"
@@ -933,8 +933,7 @@ describe("Document", () => {
     const patch = Document._compute_patch_since_json(JSON.parse(json), copy)
 
     // document should have the values we set above
-    for (const key in serialized_values) {
-      const value = (serialized_values as any)[key] // XXX: own
+    for (const [key, value] of entries(serialized_values)) {
       expect(root1.property(key).get_value()).to.be.equal(value)
     }
 


### PR DESCRIPTION
This is a follow up on issue #10320 and several other. No more for-in loops, especially unguarded by `hasOwnProperty()`, after this PR. Use for-of loop in combination with `keys()`, `values()` and/or `entries()` from `core/util/object` module instead.