### PR TITLE
Perform eslint checks on codebase tests

### DIFF
--- a/tests/codebase/test_eslint.py
+++ b/tests/codebase/test_eslint.py
@@ -1,0 +1,40 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2017, Anaconda, Inc. All rights reserved.
+#
+# Powered by the Bokeh Development Team.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+import pytest ; pytest
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+from os import chdir
+from pathlib import Path
+from subprocess import run
+
+# Bokeh imports
+from . import TOP_PATH
+
+#-----------------------------------------------------------------------------
+# Tests
+#-----------------------------------------------------------------------------
+
+def test_eslint() -> None:
+    ''' Assures that the BokehJS codebase passes configured eslint checks
+
+    '''
+    chdir(Path(TOP_PATH) / "bokehjs")
+    proc = run(["node", "make", "lint"], capture_output=True)
+    assert proc.returncode == 0, f"eslint issues:\n{proc.stdout.decode('utf-8')}"
+
+#-----------------------------------------------------------------------------
+# Support
+#-----------------------------------------------------------------------------


### PR DESCRIPTION
Adds `node make lint` test to `tests/codebase`. This is slightly duplicative since the BokehJS-CI job also runs eslint, but I want to make sure that `py.test tests/codebase` passing locally means a guarantee that no linter-related fails will happen on CI. 