### PR TITLE
Code dupe experiements

### DIFF
--- a/bokehjs/src/lib/models/annotations/band.ts
+++ b/bokehjs/src/lib/models/annotations/band.ts
@@ -1,33 +1,13 @@
-import {Annotation, AnnotationView} from "./annotation"
+import {UpperLower, UpperLowerView} from "./upper_lower"
 import {ColumnarDataSource} from "../sources/columnar_data_source"
-import {ColumnDataSource} from "../sources/column_data_source"
 import * as mixins from "core/property_mixins"
 import {Line, Fill} from "core/visuals"
-import {Arrayable} from "core/types"
 import {Dimension} from "core/enums"
 import * as p from "core/properties"
 
-export class BandView extends AnnotationView {
+export class BandView extends UpperLowerView {
   model: Band
   visuals: Band.Visuals
-
-  protected _lower: Arrayable<number>
-  protected _upper: Arrayable<number>
-  protected _base:  Arrayable<number>
-
-  protected max_lower: number
-  protected max_upper: number
-  protected max_base:  number
-
-  protected _lower_sx: Arrayable<number>
-  protected _lower_sy: Arrayable<number>
-  protected _upper_sx: Arrayable<number>
-  protected _upper_sy: Arrayable<number>
-
-  initialize(): void {
-    super.initialize()
-    this.set_data(this.model.source)
-  }
 
   connect_signals(): void {
     super.connect_signals()
@@ -36,55 +16,6 @@ export class BandView extends AnnotationView {
     this.connect(this.model.source.streaming, update)
     this.connect(this.model.source.patching, update)
     this.connect(this.model.source.change, update)
-  }
-
-  set_data(source: ColumnarDataSource): void {
-    super.set_data(source)
-    this.visuals.warm_cache(source)
-    this.plot_view.request_render()
-  }
-
-  protected _map_data(): void {
-    const {frame} = this.plot_view
-    const dim = this.model.dimension
-
-    const xscale = this.coordinates.x_scale
-    const yscale = this.coordinates.y_scale
-
-    const limit_scale = dim == "height" ? yscale : xscale
-    const base_scale  = dim == "height" ? xscale : yscale
-
-    const limit_view = dim == "height" ? frame.yview : frame.xview
-    const base_view  = dim == "height" ? frame.xview : frame.yview
-
-    let _lower_sx
-    if (this.model.properties.lower.units == "data")
-      _lower_sx = limit_scale.v_compute(this._lower)
-    else
-      _lower_sx = limit_view.v_compute(this._lower)
-
-    let _upper_sx
-    if (this.model.properties.upper.units == "data")
-      _upper_sx = limit_scale.v_compute(this._upper)
-    else
-      _upper_sx = limit_view.v_compute(this._upper)
-
-    let _base_sx
-    if (this.model.properties.base.units  == "data")
-      _base_sx  = base_scale.v_compute(this._base)
-    else
-      _base_sx  = base_view.v_compute(this._base)
-
-    const [i, j] = dim == 'height' ? [1, 0] : [0, 1]
-
-    const _lower = [_lower_sx, _base_sx]
-    const _upper = [_upper_sx, _base_sx]
-
-    this._lower_sx = _lower[i]
-    this._lower_sy = _lower[j]
-
-    this._upper_sx = _upper[i]
-    this._upper_sy = _upper[j]
   }
 
   protected _render(): void {
@@ -140,7 +71,7 @@ export class BandView extends AnnotationView {
 export namespace Band {
   export type Attrs = p.AttrsOf<Props>
 
-  export type Props = Annotation.Props & {
+  export type Props = UpperLower.Props & {
     lower: p.DistanceSpec
     upper: p.DistanceSpec
     base: p.DistanceSpec
@@ -150,12 +81,12 @@ export namespace Band {
 
   export type Mixins = mixins.Line/*Scalar*/ & mixins.Fill/*Scalar*/
 
-  export type Visuals = Annotation.Visuals & {line: Line, fill: Fill}
+  export type Visuals = UpperLower.Visuals & {line: Line, fill: Fill}
 }
 
 export interface Band extends Band.Attrs {}
 
-export class Band extends Annotation {
+export class Band extends UpperLower {
   properties: Band.Props
   __view_type__: BandView
 
@@ -167,14 +98,6 @@ export class Band extends Annotation {
     this.prototype.default_view = BandView
 
     this.mixins<Band.Mixins>([mixins.Line/*Scalar*/, mixins.Fill/*Scalar*/])
-
-    this.define<Band.Props>({
-      lower:        [ p.DistanceSpec                               ],
-      upper:        [ p.DistanceSpec                               ],
-      base:         [ p.DistanceSpec                               ],
-      dimension:    [ p.Dimension,    'height'                     ],
-      source:       [ p.Instance,     () => new ColumnDataSource() ],
-    })
 
     this.override({
       fill_color: "#fff9ba",

--- a/bokehjs/src/lib/models/annotations/upper_lower.ts
+++ b/bokehjs/src/lib/models/annotations/upper_lower.ts
@@ -1,0 +1,112 @@
+import {Annotation, AnnotationView} from "./annotation"
+import {ColumnarDataSource} from "../sources/columnar_data_source"
+import {ColumnDataSource} from "../sources/column_data_source"
+import {Arrayable} from "core/types"
+import {Dimension} from "core/enums"
+import * as p from "core/properties"
+
+export abstract class UpperLowerView extends AnnotationView {
+  model: UpperLower
+  visuals: UpperLower.Visuals
+
+  protected _lower: Arrayable<number>
+  protected _upper: Arrayable<number>
+  protected _base:  Arrayable<number>
+
+  protected max_lower: number
+  protected max_upper: number
+  protected max_base:  number
+
+  protected _lower_sx: Arrayable<number>
+  protected _lower_sy: Arrayable<number>
+  protected _upper_sx: Arrayable<number>
+  protected _upper_sy: Arrayable<number>
+
+  initialize(): void {
+    super.initialize()
+    this.set_data(this.model.source)
+  }
+
+  set_data(source: ColumnarDataSource): void {
+    super.set_data(source)
+    this.visuals.warm_cache(source)
+    this.plot_view.request_render()
+  }
+
+  protected _map_data(): void {
+    const {frame} = this.plot_view
+    const dim = this.model.dimension
+
+    const xscale = this.coordinates.x_scale
+    const yscale = this.coordinates.y_scale
+
+    const limit_scale = dim == "height" ? yscale : xscale
+    const base_scale  = dim == "height" ? xscale : yscale
+
+    const limit_view = dim == "height" ? frame.yview : frame.xview
+    const base_view  = dim == "height" ? frame.xview : frame.yview
+
+    let _lower_sx
+    if (this.model.properties.lower.units == "data")
+      _lower_sx = limit_scale.v_compute(this._lower)
+    else
+      _lower_sx = limit_view.v_compute(this._lower)
+
+    let _upper_sx
+    if (this.model.properties.upper.units == "data")
+      _upper_sx = limit_scale.v_compute(this._upper)
+    else
+      _upper_sx = limit_view.v_compute(this._upper)
+
+    let _base_sx
+    if (this.model.properties.base.units  == "data")
+      _base_sx  = base_scale.v_compute(this._base)
+    else
+      _base_sx  = base_view.v_compute(this._base)
+
+    const [i, j] = dim == 'height' ? [1, 0] : [0, 1]
+
+    const _lower = [_lower_sx, _base_sx]
+    const _upper = [_upper_sx, _base_sx]
+
+    this._lower_sx = _lower[i]
+    this._lower_sy = _lower[j]
+
+    this._upper_sx = _upper[i]
+    this._upper_sy = _upper[j]
+  }
+}
+
+export namespace UpperLower {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = Annotation.Props & {
+    lower: p.DistanceSpec
+    upper: p.DistanceSpec
+    base: p.DistanceSpec
+    dimension: p.Property<Dimension>
+    source: p.Property<ColumnarDataSource>
+  }
+
+  export type Visuals = Annotation.Visuals
+}
+
+export interface UpperLower extends UpperLower.Attrs {}
+
+export class UpperLower extends Annotation {
+  properties: UpperLower.Props
+
+  constructor(attrs?: Partial<UpperLower.Attrs>) {
+    super(attrs)
+  }
+
+  static init_UpperLower(): void {
+    this.define<UpperLower.Props>({
+      lower:        [ p.DistanceSpec                               ],
+      upper:        [ p.DistanceSpec                               ],
+      base:         [ p.DistanceSpec                               ],
+      dimension:    [ p.Dimension,    'height'                     ],
+      source:       [ p.Instance,     () => new ColumnDataSource() ],
+    })
+  }
+}

--- a/bokehjs/src/lib/models/annotations/whisker.ts
+++ b/bokehjs/src/lib/models/annotations/whisker.ts
@@ -1,89 +1,18 @@
-import {Annotation, AnnotationView} from "./annotation"
-import {ColumnarDataSource} from "../sources/columnar_data_source"
-import {ColumnDataSource} from "../sources/column_data_source"
+import {UpperLower, UpperLowerView} from "./upper_lower"
 import {ArrowHead, TeeHead} from "./arrow_head"
 import {LineVector} from "core/property_mixins"
 import {Line} from "core/visuals"
-import {Arrayable} from "core/types"
-import {Dimension} from "core/enums"
 import * as p from "core/properties"
 
-export class WhiskerView extends AnnotationView {
+export class WhiskerView extends UpperLowerView {
   model: Whisker
   visuals: Whisker.Visuals
-
-  protected _lower: Arrayable<number>
-  protected _upper: Arrayable<number>
-  protected _base:  Arrayable<number>
-
-  protected max_lower: number
-  protected max_upper: number
-  protected max_base:  number
-
-  protected _lower_sx: Arrayable<number>
-  protected _lower_sy: Arrayable<number>
-  protected _upper_sx: Arrayable<number>
-  protected _upper_sy: Arrayable<number>
-
-  initialize(): void {
-    super.initialize()
-    this.set_data(this.model.source)
-  }
 
   connect_signals(): void {
     super.connect_signals()
     this.connect(this.model.source.streaming, () => this.set_data(this.model.source))
     this.connect(this.model.source.patching, () => this.set_data(this.model.source))
     this.connect(this.model.source.change, () => this.set_data(this.model.source))
-  }
-
-  set_data(source: ColumnarDataSource): void {
-    super.set_data(source)
-    this.visuals.warm_cache(source)
-    this.plot_view.request_render()
-  }
-
-  protected _map_data(): void {
-    const {frame} = this.plot_view
-    const dim = this.model.dimension
-
-    const xscale = this.coordinates.x_scale
-    const yscale = this.coordinates.y_scale
-
-    const limit_scale = dim == "height" ? yscale : xscale
-    const base_scale  = dim == "height" ? xscale : yscale
-
-    const limit_view = dim == "height" ? frame.yview : frame.xview
-    const base_view  = dim == "height" ? frame.xview : frame.yview
-
-    let _lower_sx
-    if (this.model.properties.lower.units == "data")
-      _lower_sx = limit_scale.v_compute(this._lower)
-    else
-      _lower_sx = limit_view.v_compute(this._lower)
-
-    let _upper_sx
-    if (this.model.properties.upper.units == "data")
-      _upper_sx = limit_scale.v_compute(this._upper)
-    else
-      _upper_sx = limit_view.v_compute(this._upper)
-
-    let _base_sx
-    if (this.model.properties.base.units  == "data")
-      _base_sx  = base_scale.v_compute(this._base)
-    else
-      _base_sx  = base_view.v_compute(this._base)
-
-    const [i, j] = dim == 'height' ? [1, 0] : [0, 1]
-
-    const _lower = [_lower_sx, _base_sx]
-    const _upper = [_upper_sx, _base_sx]
-
-    this._lower_sx = _lower[i]
-    this._lower_sy = _lower[j]
-
-    this._upper_sx = _upper[i]
-    this._upper_sy = _upper[j]
   }
 
   protected _render(): void {
@@ -128,24 +57,19 @@ export class WhiskerView extends AnnotationView {
 export namespace Whisker {
   export type Attrs = p.AttrsOf<Props>
 
-  export type Props = Annotation.Props & {
-    lower: p.DistanceSpec
+  export type Props = UpperLower.Props & {
     lower_head: p.Property<ArrowHead>
-    upper: p.DistanceSpec
     upper_head: p.Property<ArrowHead>
-    base: p.DistanceSpec
-    dimension: p.Property<Dimension>
-    source: p.Property<ColumnarDataSource>
   } & Mixins
 
   export type Mixins = LineVector
 
-  export type Visuals = Annotation.Visuals & {line: Line}
+  export type Visuals = UpperLower.Visuals & {line: Line}
 }
 
 export interface Whisker extends Whisker.Attrs {}
 
-export class Whisker extends Annotation {
+export class Whisker extends UpperLower {
   properties: Whisker.Props
   __view_type__: WhiskerView
 
@@ -159,13 +83,8 @@ export class Whisker extends Annotation {
     this.mixins<Whisker.Mixins>(LineVector)
 
     this.define<Whisker.Props>({
-      lower:        [ p.DistanceSpec                    ],
       lower_head:   [ p.Instance,     () => new TeeHead({level: "underlay", size: 10}) ],
-      upper:        [ p.DistanceSpec                    ],
       upper_head:   [ p.Instance,     () => new TeeHead({level: "underlay", size: 10}) ],
-      base:         [ p.DistanceSpec                    ],
-      dimension:    [ p.Dimension,    'height'          ],
-      source:       [ p.Instance,     () => new ColumnDataSource()                     ],
     })
 
     this.override({

--- a/bokehjs/src/lib/models/markers/marker.ts
+++ b/bokehjs/src/lib/models/markers/marker.ts
@@ -63,8 +63,7 @@ export abstract class MarkerView extends XYGlyphView {
   }
 
   protected _mask_data(): Indices {
-    // dilate the inner screen region by max_size and map back to data space for use in
-    // spatial query
+    // dilate the inner screen region by max_size and map back to data space for use in spatial query
     const hr = this.renderer.plot_view.frame.bbox.h_range
     const sx0 = hr.start - this.max_size
     const sx1 = hr.end + this.max_size
@@ -151,9 +150,8 @@ export abstract class MarkerView extends XYGlyphView {
     return new Selection({indices})
   }
 
-  draw_legend_for_index(ctx: Context2d, {x0, x1, y0, y1}: Rect, index: number): void {
-    // using objects like this seems a little wonky, since the keys are coerced to
-    // stings, but it works
+  _get_legend_args({x0, x1, y0, y1}: Rect, index: number): any {
+    // using objects like this seems a little wonky, since the keys are coerced to strings, but it works
     const len = index + 1
 
     const sx: number[] = new Array(len)
@@ -166,7 +164,12 @@ export abstract class MarkerView extends XYGlyphView {
     const angle: number[] = new Array(len)
     angle[index] = 0 // don't attempt to match glyph angle
 
-    this._render(ctx, [index], {sx, sy, _size: size, _angle: angle} as any) // XXX
+    return {sx, sy, _size: size, _angle: angle}
+  }
+
+  draw_legend_for_index(ctx: Context2d, {x0, x1, y0, y1}: Rect, index: number): void {
+    const args = this._get_legend_args({x0, x1, y0, y1}, index)
+    this._render(ctx, [index], args) // XXX
   }
 }
 

--- a/bokehjs/src/lib/models/markers/scatter.ts
+++ b/bokehjs/src/lib/models/markers/scatter.ts
@@ -37,24 +37,14 @@ export class ScatterView extends MarkerView {
   }
 
   draw_legend_for_index(ctx: Context2d, {x0, x1, y0, y1}: Rect, index: number): void {
-    // using objects like this seems a little wonky, since the keys are coerced to
-    // stings, but it works
+    const args = this._get_legend_args({x0, x1, y0, y1}, index)
+
     const len = index + 1
-
-    const sx: number[] = new Array(len)
-    sx[index] = (x0 + x1)/2
-    const sy: number[] = new Array(len)
-    sy[index] = (y0 + y1)/2
-
-    const size: number[] = new Array(len)
-    size[index] = Math.min(Math.abs(x1 - x0), Math.abs(y1 - y0))*0.4
-    const angle: number[] = new Array(len)
-    angle[index] = 0 // don't attempt to match glyph angle
-
     const marker: string[] = new Array(len)
     marker[index] = this._marker[index]
+    args._marker = marker
 
-    this._render(ctx, [index], {sx, sy, _size: size, _angle: angle, _marker: marker} as any) // XXX
+    this._render(ctx, [index], args) // XXX
   }
 }
 

--- a/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
@@ -1,0 +1,62 @@
+import {ActionTool, ActionToolView} from "./action_tool"
+import {Dimensions} from "core/enums"
+import {scale_range} from "core/util/zoom"
+import * as p from "core/properties"
+
+export class ZoomBaseToolView extends ActionToolView {
+  model: ZoomBaseTool
+
+  doit(): void {
+    const frame = this.plot_view.frame
+    const dims = this.model.dimensions
+
+    // restrict to axis configured in tool's dimensions property
+    const h_axis = dims == 'width'  || dims == 'both'
+    const v_axis = dims == 'height' || dims == 'both'
+
+    const zoom_info = scale_range(frame, this.model.sign * this.model.factor, h_axis, v_axis)
+
+    this.plot_view.push_state('zoom_out', {range: zoom_info})
+    this.plot_view.update_range(zoom_info, false, true)
+
+    if (this.model.document)
+      this.model.document.interactive_start(this.plot_model)
+  }
+}
+
+export namespace ZoomBaseTool {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = ActionTool.Props & {
+    factor: p.Property<number>
+    dimensions: p.Property<Dimensions>
+  }
+}
+
+export interface ZoomBaseTool extends ZoomBaseTool.Attrs {}
+
+export class ZoomBaseTool extends ActionTool {
+  properties: ZoomBaseTool.Props
+  __view_type__: ZoomBaseToolView
+
+  constructor(attrs?: Partial<ZoomBaseTool.Attrs>) {
+    super(attrs)
+  }
+
+  static init_ZoomBaseTool(): void {
+    this.prototype.default_view = ZoomBaseToolView
+
+    this.define<ZoomBaseTool.Props>({
+      factor:     [ p.Percent,    0.1    ],
+      dimensions: [ p.Dimensions, "both" ],
+    })
+  }
+
+  sign: number
+  tool_name: string
+  icon: string
+
+  get tooltip(): string {
+    return this._get_dim_tooltip(this.tool_name, this.dimensions)
+  }
+}

--- a/bokehjs/src/lib/models/tools/actions/zoom_in_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_in_tool.ts
@@ -1,66 +1,26 @@
-import {ActionTool, ActionToolView} from "./action_tool"
-import {Dimensions} from "core/enums"
-import {scale_range} from "core/util/zoom"
-import * as p from "core/properties"
+import {ZoomBaseTool, ZoomBaseToolView} from "./zoom_base_tool"
 import {bk_tool_icon_zoom_in} from "styles/icons"
 
-export class ZoomInToolView extends ActionToolView {
-  model: ZoomInTool
+export interface ZoomInTool extends ZoomBaseTool.Attrs {}
 
-  doit(): void {
-    const frame = this.plot_view.frame
-    const dims = this.model.dimensions
+export class ZoomInTool extends ZoomBaseTool {
+  properties: ZoomBaseTool.Props
+  __view_type__: ZoomBaseToolView
 
-    // restrict to axis configured in tool's dimensions property
-    const h_axis = dims == 'width'  || dims == 'both'
-    const v_axis = dims == 'height' || dims == 'both'
-
-    const zoom_info = scale_range(frame, this.model.factor, h_axis, v_axis)
-
-    this.plot_view.push_state('zoom_out', {range: zoom_info})
-    this.plot_view.update_range(zoom_info, false, true)
-
-    if (this.model.document)
-      this.model.document.interactive_start(this.plot_model)
-  }
-}
-
-export namespace ZoomInTool {
-  export type Attrs = p.AttrsOf<Props>
-
-  export type Props = ActionTool.Props & {
-    factor: p.Property<number>
-    dimensions: p.Property<Dimensions>
-  }
-}
-
-export interface ZoomInTool extends ZoomInTool.Attrs {}
-
-export class ZoomInTool extends ActionTool {
-  properties: ZoomInTool.Props
-  __view_type__: ZoomInToolView
-
-  constructor(attrs?: Partial<ZoomInTool.Attrs>) {
+  constructor(attrs?: Partial<ZoomBaseTool.Attrs>) {
     super(attrs)
   }
 
   static init_ZoomInTool(): void {
-    this.prototype.default_view = ZoomInToolView
-
-    this.define<ZoomInTool.Props>({
-      factor:     [ p.Percent,    0.1    ],
-      dimensions: [ p.Dimensions, "both" ],
-    })
+    this.prototype.default_view = ZoomBaseToolView
 
     this.register_alias("zoom_in", () => new ZoomInTool({dimensions: 'both'}))
     this.register_alias("xzoom_in", () => new ZoomInTool({dimensions: 'width'}))
     this.register_alias("yzoom_in", () => new ZoomInTool({dimensions: 'height'}))
   }
 
+  sign = 1
   tool_name = "Zoom In"
   icon = bk_tool_icon_zoom_in
 
-  get tooltip(): string {
-    return this._get_dim_tooltip(this.tool_name, this.dimensions)
-  }
 }

--- a/bokehjs/src/lib/models/tools/actions/zoom_out_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_out_tool.ts
@@ -1,67 +1,26 @@
-import {ActionTool, ActionToolView} from "./action_tool"
-import {Dimensions} from "core/enums"
-import {scale_range} from "core/util/zoom"
-import * as p from "core/properties"
+import {ZoomBaseTool, ZoomBaseToolView} from "./zoom_base_tool"
 import {bk_tool_icon_zoom_out} from "styles/icons"
 
-export class ZoomOutToolView extends ActionToolView {
-  model: ZoomOutTool
+export interface ZoomOutTool extends ZoomBaseTool.Attrs {}
 
-  doit(): void {
-    const frame = this.plot_view.frame
-    const dims = this.model.dimensions
+export class ZoomOutTool extends ZoomBaseTool {
+  properties: ZoomBaseTool.Props
+  __view_type__: ZoomBaseToolView
 
-    // restrict to axis configured in tool's dimensions property
-    const h_axis = dims == 'width'  || dims == 'both'
-    const v_axis = dims == 'height' || dims == 'both'
-
-    // zooming out requires a negative factor to scale_range
-    const zoom_info = scale_range(frame, -this.model.factor, h_axis, v_axis)
-
-    this.plot_view.push_state('zoom_out', {range: zoom_info})
-    this.plot_view.update_range(zoom_info, false, true)
-
-    if (this.model.document)
-      this.model.document.interactive_start(this.plot_model)
-  }
-}
-
-export namespace ZoomOutTool {
-  export type Attrs = p.AttrsOf<Props>
-
-  export type Props = ActionTool.Props & {
-    factor: p.Property<number>
-    dimensions: p.Property<Dimensions>
-  }
-}
-
-export interface ZoomOutTool extends ZoomOutTool.Attrs {}
-
-export class ZoomOutTool extends ActionTool {
-  properties: ZoomOutTool.Props
-  __view_type__: ZoomOutToolView
-
-  constructor(attrs?: Partial<ZoomOutTool.Attrs>) {
+  constructor(attrs?: Partial<ZoomBaseTool.Attrs>) {
     super(attrs)
   }
 
   static init_ZoomOutTool(): void {
-    this.prototype.default_view = ZoomOutToolView
-
-    this.define<ZoomOutTool.Props>({
-      factor:     [ p.Percent,    0.1    ],
-      dimensions: [ p.Dimensions, "both" ],
-    })
+    this.prototype.default_view = ZoomBaseToolView
 
     this.register_alias("zoom_out", () => new ZoomOutTool({dimensions: 'both'}))
     this.register_alias("xzoom_out", () => new ZoomOutTool({dimensions: 'width'}))
     this.register_alias("yzoom_out", () => new ZoomOutTool({dimensions: 'height'}))
   }
 
+  sign = -1
   tool_name = "Zoom Out"
   icon = bk_tool_icon_zoom_out
 
-  get tooltip(): string {
-    return this._get_dim_tooltip(this.tool_name, this.dimensions)
-  }
 }

--- a/bokehjs/src/lib/models/tools/gestures/lasso_select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/lasso_select_tool.ts
@@ -1,5 +1,6 @@
 import {SelectTool, SelectToolView} from "./select_tool"
 import {PolyAnnotation} from "../../annotations/poly_annotation"
+import {DEFAULT_POLY_OVERLAY} from "./poly_select_tool"
 import {SelectionMode} from "core/enums"
 import {PolyGeometry} from "core/geometry"
 import {PanEvent, KeyEvent} from "core/ui_events"
@@ -67,20 +68,6 @@ export class LassoSelectToolView extends SelectToolView {
     this._select(geometry, final, mode)
   }
 
-}
-
-const DEFAULT_POLY_OVERLAY = () => {
-  return new PolyAnnotation({
-    level: "overlay",
-    xs_units: "screen",
-    ys_units: "screen",
-    fill_color: "lightgrey",
-    fill_alpha: 0.5,
-    line_color: "black",
-    line_alpha: 1.0,
-    line_width: 2,
-    line_dash: [4, 4],
-  })
 }
 
 export namespace LassoSelectTool {

--- a/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
@@ -3,7 +3,17 @@ import * as p from "core/properties"
 import {PanEvent} from "core/ui_events"
 import {Dimensions} from "core/enums"
 import {Interval} from "core/types"
+import {Scale} from "models/scales/scale"
 import {bk_tool_icon_pan, bk_tool_icon_xpan, bk_tool_icon_ypan} from "styles/icons"
+
+export function update_ranges(scales: Map<string, Scale>, p0: number, p1: number): Map<string, Interval> {
+  const r: Map<string, Interval> = new Map()
+  for (const [name, scale] of scales) {
+    const [start, end] = scale.r_invert(p0, p1)
+    r.set(name, {start, end})
+  }
+  return r
+}
 
 export class PanToolView extends GestureToolView {
   model: PanTool
@@ -100,18 +110,8 @@ export class PanToolView extends GestureToolView {
     this.last_dy = dy
 
     const {x_scales, y_scales} = frame
-
-    const xrs: Map<string, Interval> = new Map()
-    for (const [name, scale] of x_scales) {
-      const [start, end] = scale.r_invert(sx0, sx1)
-      xrs.set(name, {start, end})
-    }
-
-    const yrs: Map<string, Interval> = new Map()
-    for (const [name, scale] of y_scales) {
-      const [start, end] = scale.r_invert(sy0, sy1)
-      yrs.set(name, {start, end})
-    }
+    const xrs = update_ranges(x_scales, sx0, sx1)
+    const yrs = update_ranges(y_scales, sy0, sy1)
 
     this.pan_info = {xrs, yrs, sdx, sdy}
     this.plot_view.update_range(this.pan_info, true)

--- a/bokehjs/src/lib/models/tools/gestures/poly_select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/poly_select_tool.ts
@@ -64,7 +64,7 @@ export class PolySelectToolView extends SelectToolView {
 
 }
 
-const DEFAULT_POLY_OVERLAY = () => {
+export const DEFAULT_POLY_OVERLAY = () => {
   return new PolyAnnotation({
     level: "overlay",
     xs_units: "screen",

--- a/bokehjs/src/lib/models/tools/gestures/wheel_pan_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/wheel_pan_tool.ts
@@ -2,8 +2,8 @@ import {GestureTool, GestureToolView} from "./gesture_tool"
 import * as p from "core/properties"
 import {ScrollEvent} from "core/ui_events"
 import {Dimension} from "core/enums"
-import {Interval} from "core/types"
 import {bk_tool_icon_wheel_pan} from "styles/icons"
+import {update_ranges} from "./pan_tool"
 
 export class WheelPanToolView extends GestureToolView {
   model: WheelPanTool
@@ -56,18 +56,8 @@ export class WheelPanToolView extends GestureToolView {
     }
 
     const {x_scales, y_scales} = frame
-
-    const xrs: Map<string, Interval> = new Map()
-    for (const [name, scale] of x_scales) {
-      const [start, end] = scale.r_invert(sx0, sx1)
-      xrs.set(name, {start, end})
-    }
-
-    const yrs: Map<string, Interval> = new Map()
-    for (const [name, scale] of y_scales) {
-      const [start, end] = scale.r_invert(sy0, sy1)
-      yrs.set(name, {start, end})
-    }
+    const xrs = update_ranges(x_scales, sx0, sx1)
+    const yrs = update_ranges(y_scales, sy0, sy1)
 
     // OK this sucks we can't set factor independently in each direction. It is used
     // for GMap plots, and GMap plots always preserve aspect, so effective the value

--- a/bokehjs/src/lib/models/transforms/dodge.ts
+++ b/bokehjs/src/lib/models/transforms/dodge.ts
@@ -1,22 +1,17 @@
-import {Transform} from "./transform"
-import {Range} from "../ranges/range"
-import {Factor, FactorRange} from "../ranges/factor_range"
+import {RangeTransform} from "./range_transform"
 import * as p from "core/properties"
-import {Arrayable} from "core/types"
-import {isNumber, isArrayableOf} from "core/util/types"
 
 export namespace Dodge {
   export type Attrs = p.AttrsOf<Props>
 
-  export type Props = Transform.Props & {
+  export type Props = RangeTransform.Props & {
     value: p.Property<number>
-    range: p.Property<Range>
   }
 }
 
 export interface Dodge extends Dodge.Attrs {}
 
-export class Dodge extends Transform {
+export class Dodge extends RangeTransform {
   properties: Dodge.Props
 
   constructor(attrs?: Partial<Dodge.Attrs>) {
@@ -26,35 +21,7 @@ export class Dodge extends Transform {
   static init_Dodge(): void {
     this.define<Dodge.Props>({
       value: [ p.Number,  0 ],
-      range: [ p.Instance   ],
     })
-  }
-
-  // XXX: this is repeated in ./jitter.ts
-  v_compute(xs0: Arrayable<number | Factor>): Arrayable<number> {
-    let xs: Arrayable<number>
-    if (this.range instanceof FactorRange)
-      xs = this.range.v_synthetic(xs0)
-    else if (isArrayableOf(xs0, isNumber))
-      xs = xs0
-    else
-      throw new Error("unexpected")
-
-    const result = new Float64Array(xs.length)
-    for (let i = 0; i < xs.length; i++) {
-      const x = xs[i]
-      result[i] = this._compute(x)
-    }
-    return result
-  }
-
-  compute(x: number | Factor): number {
-    if (this.range instanceof FactorRange)
-      return this._compute(this.range.synthetic(x))
-    else if (isNumber(x))
-      return this._compute(x)
-    else
-      throw new Error("unexpected")
   }
 
   protected _compute(x: number): number {

--- a/bokehjs/src/lib/models/transforms/jitter.ts
+++ b/bokehjs/src/lib/models/transforms/jitter.ts
@@ -1,27 +1,24 @@
-import {Transform} from "./transform"
-import {Range} from "../ranges/range"
-import {Factor, FactorRange} from "../ranges/factor_range"
+import {RangeTransform} from "./range_transform"
+import {Factor} from "../ranges/factor_range"
 import {Distribution} from "core/enums"
 import {Arrayable} from "core/types"
-import {isNumber, isArrayableOf} from "core/util/types"
 import * as p from "core/properties"
 import * as bokeh_math from "core/util/math"
 
 export namespace Jitter {
   export type Attrs = p.AttrsOf<Props>
 
-  export type Props = Transform.Props & {
+  export type Props = RangeTransform.Props & {
     mean: p.Property<number>
     width: p.Property<number>
     distribution: p.Property<Distribution>
-    range: p.Property<Range>
     previous_values: p.Property<Arrayable<number>>
   }
 }
 
 export interface Jitter extends Jitter.Attrs {}
 
-export class Jitter extends Transform {
+export class Jitter extends RangeTransform {
   properties: Jitter.Props
 
   constructor(attrs?: Partial<Jitter.Attrs>) {
@@ -33,7 +30,6 @@ export class Jitter extends Transform {
       mean:         [ p.Number, 0        ],
       width:        [ p.Number, 1        ],
       distribution: [ p.Distribution, 'uniform'],
-      range:        [ p.Instance               ],
     })
 
     this.internal({
@@ -44,31 +40,8 @@ export class Jitter extends Transform {
   v_compute(xs0: Arrayable<number | Factor>): Arrayable<number> {
     if (this.previous_values != null && this.previous_values.length == xs0.length)
       return this.previous_values
-
-    let xs: Arrayable<number>
-    if (this.range instanceof FactorRange)
-      xs = this.range.v_synthetic(xs0)
-    else if (isArrayableOf(xs0, isNumber))
-      xs = xs0
-    else
-      throw new Error("unexpected")
-
-    const result = new Float64Array(xs.length)
-    for (let i = 0; i < xs.length; i++) {
-      const x = xs[i]
-      result[i] = this._compute(x)
-    }
-    this.previous_values = result
-    return result
-  }
-
-  compute(x: number | Factor): number {
-    if (this.range instanceof FactorRange)
-      return this._compute(this.range.synthetic(x))
-    else if (isNumber(x))
-      return this._compute(x)
-    else
-      throw new Error("unexpected")
+    this.previous_values = super.v_compute(xs0)
+    return this.previous_values
   }
 
   protected _compute(x: number): number {

--- a/bokehjs/src/lib/models/transforms/range_transform.ts
+++ b/bokehjs/src/lib/models/transforms/range_transform.ts
@@ -1,0 +1,59 @@
+import {Transform} from "./transform"
+import {Range} from "../ranges/range"
+import {Factor, FactorRange} from "../ranges/factor_range"
+import * as p from "core/properties"
+import {Arrayable} from "core/types"
+import {isNumber, isArrayableOf} from "core/util/types"
+
+export namespace RangeTransform {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = Transform.Props & {
+    range: p.Property<Range>
+  }
+}
+
+export interface RangeTransform extends RangeTransform.Attrs {}
+
+export abstract class RangeTransform extends Transform {
+  properties: RangeTransform.Props
+
+  constructor(attrs?: Partial<RangeTransform.Attrs>) {
+    super(attrs)
+  }
+
+  static init_RangeTransform(): void {
+    this.define<RangeTransform.Props>({
+      range: [ p.Instance ],
+    })
+  }
+
+  v_compute(xs0: Arrayable<number | Factor>): Arrayable<number> {
+    let xs: Arrayable<number>
+    if (this.range instanceof FactorRange)
+      xs = this.range.v_synthetic(xs0)
+    else if (isArrayableOf(xs0, isNumber))
+      xs = xs0
+    else
+      throw new Error("unexpected")
+
+    const result = new Float64Array(xs.length)
+    for (let i = 0; i < xs.length; i++) {
+      const x = xs[i]
+      result[i] = this._compute(x)
+    }
+    return result
+  }
+
+  compute(x: number | Factor): number {
+    if (this.range instanceof FactorRange)
+      return this._compute(this.range.synthetic(x))
+    else if (isNumber(x))
+      return this._compute(x)
+    else
+      throw new Error("unexpected")
+  }
+
+  protected abstract _compute(x: number): number
+
+}

--- a/bokehjs/test/unit/models/tools/actions/zoom_in_tool.ts
+++ b/bokehjs/test/unit/models/tools/actions/zoom_in_tool.ts
@@ -2,7 +2,8 @@ import {expect} from "assertions"
 
 import {Document} from "@bokehjs/document"
 import {Tool} from "@bokehjs/models/tools/tool"
-import {ZoomInTool, ZoomInToolView} from "@bokehjs/models/tools/actions/zoom_in_tool"
+import {ZoomInTool} from "@bokehjs/models/tools/actions/zoom_in_tool"
+import {ZoomBaseToolView} from "@bokehjs/models/tools/actions/zoom_base_tool"
 import {Range1d} from "@bokehjs/models/ranges/range1d"
 import {Plot, PlotView} from "@bokehjs/models/plots/plot"
 import {build_view} from "@bokehjs/core/build_views"
@@ -40,7 +41,7 @@ describe("ZoomInTool", () => {
       const zoom_in_tool = new ZoomInTool()
       const plot_view = await mkplot(zoom_in_tool)
 
-      const zoom_in_tool_view = plot_view.tool_views.get(zoom_in_tool)! as ZoomInToolView
+      const zoom_in_tool_view = plot_view.tool_views.get(zoom_in_tool)! as ZoomBaseToolView
 
       // perform the tool action
       zoom_in_tool_view.doit()
@@ -56,7 +57,7 @@ describe("ZoomInTool", () => {
       const zoom_in_tool = new ZoomInTool({dimensions: 'width'})
       const plot_view = await mkplot(zoom_in_tool)
 
-      const zoom_in_tool_view = plot_view.tool_views.get(zoom_in_tool)! as ZoomInToolView
+      const zoom_in_tool_view = plot_view.tool_views.get(zoom_in_tool)! as ZoomBaseToolView
 
       // perform the tool action
       zoom_in_tool_view.doit()
@@ -72,7 +73,7 @@ describe("ZoomInTool", () => {
       const zoom_in_tool = new ZoomInTool({dimensions: 'height'})
       const plot_view = await mkplot(zoom_in_tool)
 
-      const zoom_in_tool_view = plot_view.tool_views.get(zoom_in_tool)! as ZoomInToolView
+      const zoom_in_tool_view = plot_view.tool_views.get(zoom_in_tool)! as ZoomBaseToolView
 
       // perform the tool action
       zoom_in_tool_view.doit()

--- a/bokehjs/test/unit/models/tools/actions/zoom_out_tool.ts
+++ b/bokehjs/test/unit/models/tools/actions/zoom_out_tool.ts
@@ -2,7 +2,8 @@ import {expect} from "assertions"
 
 import {Document} from "@bokehjs/document"
 import {Tool} from "@bokehjs/models/tools/tool"
-import {ZoomOutTool, ZoomOutToolView} from "@bokehjs/models/tools/actions/zoom_out_tool"
+import {ZoomOutTool} from "@bokehjs/models/tools/actions/zoom_out_tool"
+import {ZoomBaseToolView} from "@bokehjs/models/tools/actions/zoom_base_tool"
 import {Range1d} from "@bokehjs/models/ranges/range1d"
 import {Plot, PlotView} from "@bokehjs/models/plots/plot"
 import {build_view} from "@bokehjs/core/build_views"
@@ -40,7 +41,7 @@ describe("ZoomOutTool", () => {
       const zoom_out_tool = new ZoomOutTool()
       const plot_view = await mkplot(zoom_out_tool)
 
-      const zoom_out_tool_view = plot_view.tool_views.get(zoom_out_tool)! as ZoomOutToolView
+      const zoom_out_tool_view = plot_view.tool_views.get(zoom_out_tool)! as ZoomBaseToolView
 
       // perform the tool action
       zoom_out_tool_view.doit()
@@ -56,7 +57,7 @@ describe("ZoomOutTool", () => {
       const zoom_out_tool = new ZoomOutTool({dimensions: 'width'})
       const plot_view = await mkplot(zoom_out_tool)
 
-      const zoom_out_tool_view = plot_view.tool_views.get(zoom_out_tool)! as ZoomOutToolView
+      const zoom_out_tool_view = plot_view.tool_views.get(zoom_out_tool)! as ZoomBaseToolView
 
       // perform the tool action
       zoom_out_tool_view.doit()
@@ -72,7 +73,7 @@ describe("ZoomOutTool", () => {
       const zoom_out_tool = new ZoomOutTool({dimensions: 'height'})
       const plot_view = await mkplot(zoom_out_tool)
 
-      const zoom_out_tool_view = plot_view.tool_views.get(zoom_out_tool)! as ZoomOutToolView
+      const zoom_out_tool_view = plot_view.tool_views.get(zoom_out_tool)! as ZoomBaseToolView
 
       // perform the tool action
       zoom_out_tool_view.doit()


### PR DESCRIPTION
Decided to try out [`jscpd`](https://www.npmjs.com/package/jscpd#html) for detecting duplicated code and it seems pretty nice. Maybe we should consider integrating it in to our automation at some point. 

This PR is just to try and remove some of the worst/easies targets. It removes about 150 lines of dupe and shaves ~1k off the bundle size. The tool reports there are still 1100+ lines of duped code in blocks of size 5 or greater. 