### PR TITLE
Update out of date HoverTool docstring

### DIFF
--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -994,8 +994,6 @@ class HoverTool(Inspection):
             * annulus
             * arc
             * bezier
-            * image
-            * image_rgba
             * image_url
             * oval
             * patch


### PR DESCRIPTION
Still lists image glyphs as unsupported
