### PR TITLE
Add nan_format option to DataTable NumberFormatter

### DIFF
--- a/bokeh/models/widgets/tables.py
+++ b/bokeh/models/widgets/tables.py
@@ -227,6 +227,9 @@ class NumberFormatter(StringFormatter):
     The language to use for formatting language-specific features (e.g. thousands separator).
     """)
 
+    nan_format = String(help="""
+    Formatting to apply to NaN and None values (falls back to Numbro formatting if not set).""")
+
     rounding = Enum(RoundingFunction, help="""
     Rounding functions (round, floor, ceil) and their synonyms (nearest, rounddown, roundup).
     """)

--- a/bokeh/models/widgets/tables.py
+++ b/bokeh/models/widgets/tables.py
@@ -228,7 +228,8 @@ class NumberFormatter(StringFormatter):
     """)
 
     nan_format = String(help="""
-    Formatting to apply to NaN and None values (falls back to Numbro formatting if not set).""")
+    Formatting to apply to NaN and None values (falls back to Numbro formatting if not set).
+    """)
 
     rounding = Enum(RoundingFunction, help="""
     Rounding functions (round, floor, ceil) and their synonyms (nearest, rounddown, roundup).

--- a/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
@@ -142,6 +142,7 @@ export namespace NumberFormatter {
   export type Props = StringFormatter.Props & {
     format: p.Property<string>
     language: p.Property<string>
+    nan_format: p.Property<string>
     rounding: p.Property<RoundingFunction>
   }
 }
@@ -158,14 +159,15 @@ export class NumberFormatter extends StringFormatter {
   static init_NumberFormatter(): void {
 
     this.define<NumberFormatter.Props>({
-      format:   [ p.String,           '0,0'   ], // TODO (bev)
-      language: [ p.String,           'en'    ], // TODO (bev)
-      rounding: [ p.RoundingFunction, 'round' ], // TODO (bev)
+      format:    [ p.String,           '0,0'   ], // TODO (bev)
+      language:  [ p.String,           'en'    ], // TODO (bev)
+      rounding:  [ p.RoundingFunction, 'round' ], // TODO (bev)
+      nan_format: [ p.String ],
     })
   }
 
   doFormat(row: any, cell: any, value: any, columnDef: any, dataContext: any): string {
-    const {format, language} = this
+    const {format, language, nan_format} = this
     const rounding = (() => {
       switch (this.rounding) {
         case "round": case "nearest":   return Math.round
@@ -173,7 +175,10 @@ export class NumberFormatter extends StringFormatter {
         case "ceil":  case "roundup":   return Math.ceil
       }
     })()
-    value = Numbro.format(value, format, language, rounding)
+    if ((value == null || isNaN(value)) && nan_format != null)
+      value = nan_format
+    else
+      value = Numbro.format(value, format, language, rounding)
     return super.doFormat(row, cell, value, columnDef, dataContext)
   }
 }

--- a/bokehjs/test/unit/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/test/unit/models/widgets/tables/cell_formatters.ts
@@ -1,6 +1,6 @@
 import {expect} from "assertions"
 
-import {DateFormatter} from "@bokehjs/models/widgets/tables/cell_formatters"
+import {DateFormatter, NumberFormatter} from "@bokehjs/models/widgets/tables/cell_formatters"
 
 describe("cell_formatters module", () => {
 
@@ -71,6 +71,22 @@ describe("cell_formatters module", () => {
       it("should map custom formats to themselves", () => {
         const df = new DateFormatter({format: "CUST"})
         expect(df.getFormat()).to.be.equal("CUST")
+      })
+    })
+  })
+
+  describe("NumberFormatter", () => {
+
+    describe("doFormat method", () => {
+
+      it("should apply nan_format to null", () => {
+        const df = new NumberFormatter({nan_format: "-"})
+        expect(df.doFormat(0, 0, null, {}, {})).to.be.equal('<div class="bk" style="text-align: left;">-</div>')
+      })
+
+      it("should apply nan_format to nan", () => {
+        const df = new NumberFormatter({nan_format: "-"})
+        expect(df.doFormat(0, 0, NaN, {}, {})).to.be.equal('<div class="bk" style="text-align: left;">-</div>')
       })
     })
   })


### PR DESCRIPTION
Adds a `nan_format` option to the DataTable NumberFormatter.

- [x] issues: fixes #10374
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
