### PR TITLE
Make *NDArray classes work with legacy bundles under ES5

### DIFF
--- a/bokehjs/eslint.json
+++ b/bokehjs/eslint.json
@@ -50,7 +50,7 @@
       "ObjectExpression": "first",
       "ImportDeclaration": "first",
       "VariableDeclarator": "first",
-      "CallExpression": {"arguments": "first"},
+      "CallExpression": {"arguments": 1},
       "FunctionDeclaration": {"body": 1, "parameters": "off"},
       "FunctionExpression": {"body": 1, "parameters": "off"},
       "ignoredNodes": ["ConditionalExpression"]

--- a/bokehjs/examples/burtin/burtin.ts
+++ b/bokehjs/examples/burtin/burtin.ts
@@ -95,49 +95,60 @@ export namespace Burtin {
   p.annular_wedge(0, 0, inner_radius, outer_radius, angles.map((angle) => -big_angle + angle), angles, {color: colors})
 
   // small wedges
-  p.annular_wedge(0, 0, inner_radius, rad(df.penicillin),
-                  angles.map((angle) => -big_angle+angle+5*small_angle),
-                  angles.map((angle) => -big_angle+angle+6*small_angle),
-                  {color: drug_color.Penicillin})
-  p.annular_wedge(0, 0, inner_radius, rad(df.streptomycin),
-                  angles.map((angle) => -big_angle+angle+3*small_angle),
-                  angles.map((angle) => -big_angle+angle+4*small_angle),
-                  {color: drug_color.Streptomycin})
-  p.annular_wedge(0, 0, inner_radius, rad(df.neomycin),
-                  angles.map((angle) => -big_angle+angle+1*small_angle),
-                  angles.map((angle) => -big_angle+angle+2*small_angle),
-                  {color: drug_color.Neomycin})
+  p.annular_wedge(
+    0, 0, inner_radius, rad(df.penicillin),
+    angles.map((angle) => -big_angle+angle+5*small_angle),
+    angles.map((angle) => -big_angle+angle+6*small_angle),
+    {color: drug_color.Penicillin})
+  p.annular_wedge(
+    0, 0, inner_radius, rad(df.streptomycin),
+    angles.map((angle) => -big_angle+angle+3*small_angle),
+    angles.map((angle) => -big_angle+angle+4*small_angle),
+    {color: drug_color.Streptomycin})
+  p.annular_wedge(
+    0, 0, inner_radius, rad(df.neomycin),
+    angles.map((angle) => -big_angle+angle+1*small_angle),
+    angles.map((angle) => -big_angle+angle+2*small_angle),
+    {color: drug_color.Neomycin})
 
   // circular axes and lables
   const labels = range(-3, 4).map((v) => 10**v)
   const radii = labels.map((label) => a * Math.sqrt(Math.log(label * 1E4)) + b)
 
   p.circle(0, 0, {radius: radii, fill_color: null, line_color: "white"})
-  p.text(0, radii.slice(0, -1), labels.slice(0, -1).map((label) => label.toString()),
-         {text_font_size: "11px", text_align: "center", text_baseline: "middle"})
+  p.text(0, radii.slice(0, -1), labels.slice(0, -1).map((label) => label.toString()), {
+    text_font_size: "11px", text_align: "center", text_baseline: "middle",
+  })
 
   // radial axes
-  p.annular_wedge(0, 0, inner_radius-10, outer_radius+10,
-                  angles.map((angle) => -big_angle+angle),
-                  angles.map((angle) => -big_angle+angle),
-                  {color: "black"})
+  p.annular_wedge(
+    0, 0, inner_radius-10, outer_radius+10,
+    angles.map((angle) => -big_angle+angle),
+    angles.map((angle) => -big_angle+angle),
+    {color: "black"})
 
   // bacteria labels
   const xr = angles.map((angle) => radii[0]*Math.cos(-big_angle/2 + angle))
   const yr = angles.map((angle) => radii[0]*Math.sin(-big_angle/2 + angle))
   const label_angle = angles.map((angle) => -big_angle/2 + angle)
     .map((angle) => (angle < -Math.PI/2) ? angle + Math.PI : angle)
-  p.text(xr, yr, df.bacteria, {angle: label_angle,
-                               text_font_size: "12px", text_align: "center", text_baseline: "middle"})
+  p.text(xr, yr, df.bacteria, {
+    angle: label_angle,
+    text_font_size: "12px",
+    text_align: "center",
+    text_baseline: "middle",
+  })
 
   // OK, these hand drawn legends are pretty clunky, will be improved in future release
   p.circle([-40, -40], [-370, -390], {color: values(gram_color), radius: 5})
-  p.text([-30, -30], [-370, -390], Object.keys(gram_color).map((gram) => `Gram-${gram}`),
-         {text_font_size: "9px", text_align: "left", text_baseline: "middle"})
+  p.text([-30, -30], [-370, -390], Object.keys(gram_color).map((gram) => `Gram-${gram}`), {
+    text_font_size: "9px", text_align: "left", text_baseline: "middle",
+  })
 
   p.rect([-40, -40, -40], [18, 0, -18], 30, 13, {color: values(drug_color)})
-  p.text([-15, -15, -15], [18, 0, -18], Object.keys(drug_color),
-         {text_font_size: "12px", text_align: "left", text_baseline: "middle"})
+  p.text([-15, -15, -15], [18, 0, -18], Object.keys(drug_color), {
+    text_font_size: "12px", text_align: "left", text_baseline: "middle",
+  })
 
   plt.show(p)
 }

--- a/bokehjs/examples/stocks/stocks.ts
+++ b/bokehjs/examples/stocks/stocks.ts
@@ -30,8 +30,9 @@ export namespace Stocks {
     for (const key in source.data) {
       if (key != 't') {
         i += 1
-        plot.line({field: 't'}, {field: key},
-                  {source, legend: key, line_color: colors[i%6], line_width: 2})
+        plot.line({field: 't'}, {field: key}, {
+          source, legend: key, line_color: colors[i%6], line_width: 2,
+        })
       }
     }
 

--- a/bokehjs/src/compiler/linker.ts
+++ b/bokehjs/src/compiler/linker.ts
@@ -642,7 +642,15 @@ export ${export_type} css;
         const {ES2020, ES2017, ES5} = ts.ScriptTarget
         const target = this.target == "ES2020" ? ES2020 : (this.target == "ES2017" ? ES2017 : ES5)
         const imports = new Set<string>(["tslib"])
-        const transform = {before: [transforms.collect_imports(imports), transforms.rename_exports()], after: []}
+
+        const transform: {before: Transformers, after: Transformers} = {
+          before: [transforms.collect_imports(imports), transforms.rename_exports()],
+          after: [],
+        }
+        if (canonical == "core/util/ndarray" && target == ES5) {
+          transform.after.push(transforms.es5_fix_extend_builtins())
+        }
+
         // XXX: .json extension will cause an internal error
         const {output, error} = transpile(type == "json" ? `${file}.ts` : file, source, target, transform)
         if (error)

--- a/bokehjs/src/lib/core/util/svg.ts
+++ b/bokehjs/src/lib/core/util/svg.ts
@@ -792,8 +792,10 @@ export class SVGRenderingContext2D /*implements CanvasRenderingContext2D*/ {
     const endAngle = getAngle(unit_vec_origin_end_tangent)
 
     // Connect the point (x0, y0) to the start tangent point by a straight line
-    this.lineTo(x + unit_vec_origin_start_tangent[0] * radius,
-                y + unit_vec_origin_start_tangent[1] * radius)
+    this.lineTo(
+      x + unit_vec_origin_start_tangent[0] * radius,
+      y + unit_vec_origin_start_tangent[1] * radius,
+    )
 
     // Connect the start tangent point to the end tangent point by arc
     // and adding the end tangent point to the subpath.

--- a/bokehjs/src/lib/models/annotations/color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/color_bar.ts
@@ -310,9 +310,11 @@ export class ColorBarView extends AnnotationView {
     ctx.save()
     ctx.translate(x_offset + x_standoff, y_offset + y_standoff)
     for (let i = 0, end = sx.length; i < end; i++) {
-      ctx.fillText(formatted_labels[i],
-                   Math.round(sx[i] + nx*this.model.label_standoff),
-                   Math.round(sy[i] + ny*this.model.label_standoff))
+      ctx.fillText(
+        formatted_labels[i],
+        Math.round(sx[i] + nx*this.model.label_standoff),
+        Math.round(sy[i] + ny*this.model.label_standoff),
+      )
     }
     ctx.restore()
   }

--- a/bokehjs/src/lib/models/annotations/legend_item.ts
+++ b/bokehjs/src/lib/models/annotations/legend_item.ts
@@ -71,8 +71,7 @@ export class LegendItem extends Model {
   initialize(): void {
     super.initialize()
     this.legend = null
-    this.connect(this.change,
-                 () => { if (this.legend != null) this.legend.item_change.emit() })
+    this.connect(this.change, () => this.legend?.item_change.emit())
 
     // Validate data_sources match
     const data_source_validation = this._check_data_sources_on_renderers()

--- a/bokehjs/src/lib/models/glyphs/bezier.ts
+++ b/bokehjs/src/lib/models/glyphs/bezier.ts
@@ -114,8 +114,10 @@ export class BezierView extends GlyphView {
       if (isNaN(this._x0[i] + this._x1[i] + this._y0[i] + this._y1[i] + this._cx0[i] + this._cy0[i] + this._cx1[i] + this._cy1[i]))
         index.add_empty()
       else {
-        const [x0, y0, x1, y1] = _cbb(this._x0[i],  this._y0[i],  this._x1[i],  this._y1[i],
-                                      this._cx0[i], this._cy0[i], this._cx1[i], this._cy1[i])
+        const [x0, y0, x1, y1] = _cbb(
+          this._x0[i],  this._y0[i],  this._x1[i],  this._y1[i],
+          this._cx0[i], this._cy0[i], this._cx1[i], this._cy1[i],
+        )
         index.add(x0, y0, x1, y1)
       }
     }

--- a/bokehjs/src/lib/models/glyphs/webgl/line.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/line.ts
@@ -337,8 +337,10 @@ export class LineGL extends BaseGLGlyph {
     // Angles
     const A = new Float32Array(n)
     for (let i = 0, end = n; i < end; i++) {
-      A[i] = Math.atan2((Vt[(i*4)+0]*Vt[(i*4)+3]) - (Vt[(i*4)+1]*Vt[(i*4)+2]),
-                        (Vt[(i*4)+0]*Vt[(i*4)+2]) + (Vt[(i*4)+1]*Vt[(i*4)+3]))
+      A[i] = Math.atan2(
+        (Vt[(i*4)+0]*Vt[(i*4)+3]) - (Vt[(i*4)+1]*Vt[(i*4)+2]),
+        (Vt[(i*4)+0]*Vt[(i*4)+2]) + (Vt[(i*4)+1]*Vt[(i*4)+3]),
+      )
     }
     for (let i = 0, end = n-1; i < end; i++) {
       V_angles[(i*2)+0] = A[i]


### PR DESCRIPTION
This adds an AST transformer specific to ES5 and `core/util/ndarray` module, which "fixes" the TypeScript emitted NDArray constructors, so that they work under ES5. This completes the task of fixing legacy bundles, but I expect there may be still some issues in corner cases.

fixes #10233