### PR TITLE
Support `$name` special variable with image tooltips

### DIFF
--- a/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
+++ b/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
@@ -266,7 +266,11 @@ export class HoverToolView extends InspectToolView {
     }
 
     for (const struct of indices.image_indices) {
-      const vars = {index: struct.index, x, y, sx, sy}
+      const vars = {
+        index: struct.index,
+        x, y, sx, sy,
+        name: renderer_view.model.name,
+      }
       const rendered = this._render_tooltips(ds, struct, vars)
       tooltips.push([sx, sy, rendered])
     }

--- a/sphinx/source/docs/user_guide/examples/tools_hover_tooltips_image.py
+++ b/sphinx/source/docs/user_guide/examples/tools_hover_tooltips_image.py
@@ -17,6 +17,7 @@ data = dict(image=[ramp, steps, bitmask],
             dh=[10,  10, 25])
 
 TOOLTIPS = [
+    ('name', "$name"),
     ('index', "$index"),
     ('pattern', '@pattern'),
     ("x", "$x"),
@@ -25,7 +26,7 @@ TOOLTIPS = [
     ('squared', '@squared')
 ]
 
-p = figure( x_range=(0, 35), y_range=(0, 35), tools='hover,wheel_zoom', tooltips=TOOLTIPS)
-p.image(source=data, image='image', x='x', y='y', dw='dw', dh='dh', palette="Inferno256")
+p = figure(x_range=(0, 35), y_range=(0, 35), tools='hover,wheel_zoom', tooltips=TOOLTIPS)
+p.image(source=data, image='image', x='x', y='y', dw='dw', dh='dh', palette="Inferno256", name="Image Glyph")
 
 show(p)


### PR DESCRIPTION
Only image case didn't support `$name`.

fixes #10319 
