### PR TITLE
Mark webdriver's tests as flaky

### DIFF
--- a/tests/unit/bokeh/io/test_webdriver.py
+++ b/tests/unit/bokeh/io/test_webdriver.py
@@ -15,6 +15,7 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # External imports
+from flaky import flaky
 import selenium.webdriver.chrome.webdriver
 import selenium.webdriver.firefox.webdriver
 
@@ -34,6 +35,7 @@ import bokeh.io.webdriver as biw # isort:skip
 #-----------------------------------------------------------------------------
 
 @pytest.mark.selenium
+@flaky(max_runs=10)
 def test_create_firefox_webdriver() -> None:
     d = biw.create_firefox_webdriver()
     try:
@@ -42,6 +44,7 @@ def test_create_firefox_webdriver() -> None:
         d.quit()
 
 @pytest.mark.selenium
+@flaky(max_runs=10)
 def test_create_chromium_webdriver() -> None:
     d = biw.create_chromium_webdriver()
     try:
@@ -54,7 +57,9 @@ _driver_map = {
     "chromium": selenium.webdriver.chrome.webdriver.WebDriver,
 }
 
+@flaky(max_runs=10)
 class Test_webdriver_control:
+
     def test_default(self) -> None:
         # other tests may have interacted with the global biw.webdriver_control,
         # so create a new instance only to check default values

--- a/tests/unit/bokeh/io/test_webdriver.py
+++ b/tests/unit/bokeh/io/test_webdriver.py
@@ -15,9 +15,9 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # External imports
-from flaky import flaky
 import selenium.webdriver.chrome.webdriver
 import selenium.webdriver.firefox.webdriver
+from flaky import flaky
 
 # Module under test
 import bokeh.io.webdriver as biw # isort:skip


### PR DESCRIPTION
`tests/unit/bokeh/io/test_webdriver` fails regularly on macos and windows due to webdriver's unreliability.
