### PR TITLE
Implemented nan_format for other CellFormatters

### DIFF
--- a/bokeh/models/widgets/tables.py
+++ b/bokeh/models/widgets/tables.py
@@ -128,6 +128,11 @@ class ScientificFormatter(StringFormatter):
     ''' Display numeric values from continuous ranges as "basic numbers",
     using scientific notation when appropriate by default.
     '''
+
+    nan_format = String(help="""
+    Formatting to apply to NaN and None values (falls back to scientific formatting if not set).
+    """)
+
     precision = Int(10, help="""
     How many digits of precision to display.
     """)
@@ -244,7 +249,7 @@ class BooleanFormatter(CellFormatter):
     The icon visualizing the check mark.
     """)
 
-class DateFormatter(CellFormatter):
+class DateFormatter(StringFormatter):
     ''' Date cell formatter.
 
     '''
@@ -453,6 +458,11 @@ class DateFormatter(CellFormatter):
     .. _github issue: https://github.com/bokeh/bokeh/issues
 
     """)
+
+    nan_format = String(help="""
+    Formatting to apply to NaN and None values (falls back to regular date formatting if not set).
+    """)
+
 
 class HTMLTemplateFormatter(CellFormatter):
     ''' HTML formatter using a template.

--- a/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
@@ -238,7 +238,7 @@ export class DateFormatter extends StringFormatter {
 
     this.define<DateFormatter.Props>({
       format: [ p.String, 'ISO-8601' ],
-      nan_format: [ p.String ]
+      nan_format: [ p.String ],
     })
   }
 

--- a/bokehjs/test/unit/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/test/unit/models/widgets/tables/cell_formatters.ts
@@ -1,6 +1,6 @@
 import {expect} from "assertions"
 
-import {DateFormatter, NumberFormatter} from "@bokehjs/models/widgets/tables/cell_formatters"
+import {DateFormatter, NumberFormatter, ScientificFormatter} from "@bokehjs/models/widgets/tables/cell_formatters"
 
 describe("cell_formatters module", () => {
 
@@ -73,6 +73,19 @@ describe("cell_formatters module", () => {
         expect(df.getFormat()).to.be.equal("CUST")
       })
     })
+
+    describe("doFormat method", () => {
+
+      it("should apply nan_format to null", () => {
+        const df = new DateFormatter({nan_format: "-"})
+        expect(df.doFormat(0, 0, null, {}, {})).to.be.equal('<div class="bk" style="text-align: left;">-</div>')
+      })
+
+      it("should apply nan_format to nan", () => {
+        const df = new DateFormatter({nan_format: "-"})
+        expect(df.doFormat(0, 0, null, {}, {})).to.be.equal('<div class="bk" style="text-align: left;">-</div>')
+      })
+    })
   })
 
   describe("NumberFormatter", () => {
@@ -86,6 +99,22 @@ describe("cell_formatters module", () => {
 
       it("should apply nan_format to nan", () => {
         const df = new NumberFormatter({nan_format: "-"})
+        expect(df.doFormat(0, 0, NaN, {}, {})).to.be.equal('<div class="bk" style="text-align: left;">-</div>')
+      })
+    })
+  })
+
+  describe("ScientificFormatter", () => {
+
+    describe("doFormat method", () => {
+
+      it("should apply nan_format to null", () => {
+        const df = new ScientificFormatter({nan_format: "-"})
+        expect(df.doFormat(0, 0, null, {}, {})).to.be.equal('<div class="bk" style="text-align: left;">-</div>')
+      })
+
+      it("should apply nan_format to nan", () => {
+        const df = new ScientificFormatter({nan_format: "-"})
         expect(df.doFormat(0, 0, NaN, {}, {})).to.be.equal('<div class="bk" style="text-align: left;">-</div>')
       })
     })

--- a/sphinx/source/docs/releases/2.2.0.rst
+++ b/sphinx/source/docs/releases/2.2.0.rst
@@ -6,7 +6,7 @@
 Bokeh Version ``2.2.0`` (Aug 2020) is a minor-release that focused with
 substantial improvements to performance, SVG export, and DataTable.
 
-* Improvements to ``DataTable`` styling and functionality (:bokeh-issue:`6864`, :bokeh-issue:`8595`, :bokeh-issue:`10251`, :bokeh-issue:`10353`, :bokeh-issue:`10363`, :bokeh-issue:`10374`)
+* Improvements to ``DataTable`` styling and functionality (:bokeh-issue:`6864`, :bokeh-issue:`8595`, :bokeh-issue:`10251`, :bokeh-issue:`10353`, :bokeh-issue:`10363`, :bokeh-issue:`10374`, :bokeh-issue:`10416`)
 * Improvements and fixes to SVG rendering  (:bokeh-issue:`6775`, :bokeh-issue:`8046`, :bokeh-issue:`8446`, :bokeh-issue:`8744`, :bokeh-issue:`9001`, :bokeh-issue:`9169`, :bokeh-issue:`9213`, :bokeh-issue:`9551`, :bokeh-issue:`10273`, :bokeh-issue:`10305`)
 * Memory and Performance improvements (:bokeh-issue:`10162`, :bokeh-issue:`10176`, :bokeh-issue:`10225`, :bokeh-issue:`10226`, :bokeh-issue:`10234`, :bokeh-issue:`10235`, :bokeh-issue:`10272`, :bokeh-issue:`10384`)
 * Fixes for properties not triggering updates (:bokeh-issue:`9436`, :bokeh-issue:`10147`, :bokeh-issue:`10215`, :bokeh-issue:`10247`)


### PR DESCRIPTION
Adds `nan_format` to both `ScientificFormatter` and `DateFormatter` after having added it to NumberFormatter in #10375. Also turns `DateFormatter` into a `StringFormatter` subclass to expose some of the other string formatting options which are already supported for the Scientific and Date formatters. I'm not sure `nan_format` is the most accurate on the `DateFormatter` since technically there shouldn't be NaNs, only nulls and there is no NaT type in JS, but in this case I vote for consistency over precision in the naming.