### PR TITLE
Implement nan_format for NaT types on DateFormatter

### DIFF
--- a/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
@@ -273,7 +273,8 @@ export class DateFormatter extends StringFormatter {
     const {nan_format} = this
     value = isString(value) ? parseInt(value, 10) : value
     let date: string
-    if ((value == null || isNaN(value)) && nan_format != null)
+    // Handle null, NaN and NaT
+    if ((value == null || isNaN(value) || value === -9223372036854776) && nan_format != null)
       date = nan_format
     else
       date = value == null ? '' : tz(value, this.getFormat())

--- a/bokehjs/test/unit/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/test/unit/models/widgets/tables/cell_formatters.ts
@@ -83,7 +83,12 @@ describe("cell_formatters module", () => {
 
       it("should apply nan_format to nan", () => {
         const df = new DateFormatter({nan_format: "-"})
-        expect(df.doFormat(0, 0, null, {}, {})).to.be.equal('<div class="bk" style="text-align: left;">-</div>')
+        expect(df.doFormat(0, 0, NaN, {}, {})).to.be.equal('<div class="bk" style="text-align: left;">-</div>')
+      })
+
+      it("should apply nan_format to NaT", () => {
+        const df = new DateFormatter({nan_format: "-"})
+        expect(df.doFormat(0, 0, -9223372036854776, {}, {})).to.be.equal('<div class="bk" style="text-align: left;">-</div>')
       })
     })
   })


### PR DESCRIPTION
Handles `nan_format` for NaT types on the DataTable DateFormatter.

- [x] issues: fixes #10448
- [x] tests added / passed