### PR TITLE
Miscellaneous refactorings in bokehjs

### DIFF
--- a/bokehjs/make/tasks/test.ts
+++ b/bokehjs/make/tasks/test.ts
@@ -69,7 +69,7 @@ function mocha(files: string[]): Promise<void> {
     args.push("--grep", argv.k as string)
 
   args = args.concat(
-    ["--reporter", (argv.reporter as string | undefined) || "spec"],
+    ["--reporter", (argv.reporter as string | undefined) ?? "spec"],
     ["--slow", "5s"],
     ["--exit"],
     files,

--- a/bokehjs/src/compiler/build.ts
+++ b/bokehjs/src/compiler/build.ts
@@ -295,7 +295,7 @@ export async function build(base_dir: Path, bokehjs_dir: Path, base_setup: Build
   }
 
   const dist_dir = join(base_dir, "dist")
-  const lib_dir = options.outDir || dist_dir
+  const lib_dir = options.outDir ?? dist_dir
 
   const artifact = basename(base_dir)
 

--- a/bokehjs/src/compiler/linker.ts
+++ b/bokehjs/src/compiler/linker.ts
@@ -315,7 +315,7 @@ export class Linker {
     }
 
     const print = (module: ModuleInfo): string => {
-      let ast = module.ast || this.parse_module(module)
+      let ast = module.ast ?? this.parse_module(module)
       ast = transforms.apply(ast, ...transformers(module))
       const source = transforms.print_es(ast)
       return convert.removeMapFileComments(source)
@@ -484,7 +484,7 @@ export class Linker {
     const json_file = path + ".json"
     const has_js_file = file_exists(js_file)
     const has_json_file = file_exists(json_file)
-    const has_file = has_js_file || has_json_file
+    const has_file = has_js_file ?? has_json_file
 
     if (directory_exists(path)) {
       const pkg_file = this.resolve_package(path)
@@ -808,5 +808,5 @@ export function minify(module: ModuleInfo, source: string, ecma: terser.ECMA): {
     throw new BuildError("linker", `${module.file}:${line-1}:${col}: ${message}`)
   }
 
-  return {min_source: code || "", min_map: typeof map === "string" ? map : undefined}
+  return {min_source: code ?? "", min_map: typeof map === "string" ? map : undefined}
 }

--- a/bokehjs/src/compiler/main.ts
+++ b/bokehjs/src/compiler/main.ts
@@ -28,9 +28,9 @@ async function compile() {
   if (argv.file != null) {
     const input = {
       code: argv.code != null ? argv.code as string : read(argv.file as string)!,
-      lang: (argv.lang as string | undefined) || "typescript",
+      lang: (argv.lang as string | undefined) ?? "typescript",
       file: argv.file as string,
-      bokehjs_dir: (argv.bokehjsDir as string | undefined) || "./build", // this is what bokeh.settings defaults to
+      bokehjs_dir: (argv.bokehjsDir as string | undefined) ?? "./build", // this is what bokeh.settings defaults to
     }
     return await compile_and_resolve_deps(input)
   } else {

--- a/bokehjs/src/lib/api/charts.ts
+++ b/bokehjs/src/lib/api/charts.ts
@@ -165,7 +165,7 @@ export function pie(data: PieChartData, opts: PieChartOpts = {}): Plot {
 
   const g2 = new Text({
     x: {field: "text_cx"}, y: {field: "text_cy"},
-    text: {field: opts.slice_labels || "labels"},
+    text: {field: opts.slice_labels ?? "labels"},
     angle: {field: "text_angles"},
     text_align: "center", text_baseline: "middle",
     text_color: {field: "text_colors"}, text_font_size: "12px",

--- a/bokehjs/src/lib/base.ts
+++ b/bokehjs/src/lib/base.ts
@@ -14,7 +14,7 @@ export interface Models {
 }
 
 export const Models = ((name: string): typeof HasProps => {
-  const model = overrides[name] || _all_models.get(name)
+  const model = overrides[name] ?? _all_models.get(name)
 
   if (model == null) {
     throw new Error(`Model '${name}' does not exist. This could be due to a widget or a custom model not being registered before first usage.`)

--- a/bokehjs/src/lib/core/dom.ts
+++ b/bokehjs/src/lib/core/dom.ts
@@ -163,7 +163,7 @@ export function offset(element: HTMLElement) {
 
 export function matches(el: HTMLElement, selector: string): boolean {
   const p: any = Element.prototype
-  const f = p.matches || p.webkitMatchesSelector || p.mozMatchesSelector || p.msMatchesSelector
+  const f = p.matches ?? p.webkitMatchesSelector ?? p.mozMatchesSelector ?? p.msMatchesSelector
   return f.call(el, selector)
 }
 

--- a/bokehjs/src/lib/core/layout/grid.ts
+++ b/bokehjs/src/lib/core/layout/grid.ts
@@ -193,7 +193,7 @@ export class Grid extends Layoutable {
     const rows: RowSpec[] = new Array(nrows)
     for (let y = 0; y < nrows; y++) {
       const row = ((): RowSizing => {
-        const sizing = isPlainObject(this.rows) ? this.rows[y] || this.rows["*"] : this.rows
+        const sizing = isPlainObject(this.rows) ? this.rows[y] ?? this.rows["*"] : this.rows
 
         if (sizing == null)
           return {policy: "auto"}
@@ -205,14 +205,14 @@ export class Grid extends Layoutable {
           return sizing
       })()
 
-      const align = row.align || "auto"
+      const align = row.align ?? "auto"
 
       if (row.policy == "fixed")
         rows[y] = {policy: "fixed", height: row.height, align}
       else if (row.policy == "min")
         rows[y] = {policy: "min", align}
       else if (row.policy == "fit" || row.policy == "max")
-        rows[y] = {policy: row.policy, flex: row.flex || 1, align}
+        rows[y] = {policy: row.policy, flex: row.flex ?? 1, align}
       else if (row.policy == "auto") {
         if (some(items.row(y), (layout) => layout.is_height_expanding()))
           rows[y] = {policy: "max", flex: 1, align}
@@ -225,7 +225,7 @@ export class Grid extends Layoutable {
     const cols: ColSpec[] = new Array(ncols)
     for (let x = 0; x < ncols; x++) {
       const col = ((): ColSizing => {
-        const sizing = isPlainObject(this.cols) ? this.cols[x] || this.cols["*"] : this.cols
+        const sizing = isPlainObject(this.cols) ? this.cols[x] ?? this.cols["*"] : this.cols
 
         if (sizing == null)
           return {policy: "auto"}
@@ -237,14 +237,14 @@ export class Grid extends Layoutable {
           return sizing
       })()
 
-      const align = col.align || "auto"
+      const align = col.align ?? "auto"
 
       if (col.policy == "fixed")
         cols[x] = {policy: "fixed", width: col.width, align}
       else if (col.policy == "min")
         cols[x] = {policy: "min", align}
       else if (col.policy == "fit" || col.policy == "max")
-        cols[x] = {policy: col.policy, flex: col.flex || 1, align}
+        cols[x] = {policy: col.policy, flex: col.flex ?? 1, align}
       else if (col.policy == "auto") {
         if (some(items.col(x), (layout) => layout.is_width_expanding()))
           cols[x] = {policy: "max", flex: 1, align}

--- a/bokehjs/src/lib/core/layout/layoutable.ts
+++ b/bokehjs/src/lib/core/layout/layoutable.ts
@@ -28,21 +28,21 @@ export abstract class Layoutable {
   }
 
   set_sizing(sizing: Partial<BoxSizing>): void {
-    const width_policy = sizing.width_policy || "fit"
+    const width_policy = sizing.width_policy ?? "fit"
     const width = sizing.width
     const min_width = sizing.min_width != null ? sizing.min_width : 0
     const max_width = sizing.max_width != null ? sizing.max_width : Infinity
 
-    const height_policy = sizing.height_policy || "fit"
+    const height_policy = sizing.height_policy ?? "fit"
     const height = sizing.height
     const min_height = sizing.min_height != null ? sizing.min_height : 0
     const max_height = sizing.max_height != null ? sizing.max_height : Infinity
 
     const aspect = sizing.aspect
-    const margin = sizing.margin || {top: 0, right: 0, bottom: 0, left: 0}
+    const margin = sizing.margin ?? {top: 0, right: 0, bottom: 0, left: 0}
     const visible = sizing.visible !== false
-    const halign = sizing.halign || "start"
-    const valign = sizing.valign || "start"
+    const halign = sizing.halign ?? "start"
+    const valign = sizing.valign ?? "start"
 
     this._sizing = {
       width_policy, min_width, width, max_width,
@@ -68,7 +68,7 @@ export abstract class Layoutable {
   }
 
   set_geometry(outer: BBox, inner?: BBox): void {
-    this._set_geometry(outer, inner || outer)
+    this._set_geometry(outer, inner ?? outer)
   }
 
   is_width_expanding(): boolean {

--- a/bokehjs/src/lib/core/ui_events.ts
+++ b/bokehjs/src/lib/core/ui_events.ts
@@ -322,7 +322,7 @@ export class UIEvents implements EventListenerObject {
 
         // the event happened on a renderer
         if (view != null) {
-          cursor = view.cursor(e.sx, e.sy) || cursor
+          cursor = view.cursor(e.sx, e.sy) ?? cursor
 
           if (!is_empty(active_inspectors)) {
             // override event_type to cause inspectors to clear overlays

--- a/bokehjs/src/lib/core/util/math.ts
+++ b/bokehjs/src/lib/core/util/math.ts
@@ -76,9 +76,9 @@ export function rnorm(mu: number, sigma: number): number {
 }
 
 export function clamp(val: number, min: number, max: number): number {
-  if (val < min)
-    return min
-  if (val > max)
-    return max
-  return val
+  return val < min ? min : (val > max ? max : val)
+}
+
+export function log(x: number, base: number = Math.E): number {
+  return Math.log(x)/Math.log(base)
 }

--- a/bokehjs/src/lib/core/util/string.ts
+++ b/bokehjs/src/lib/core/util/string.ts
@@ -60,3 +60,7 @@ export function unescape(s: string): string {
 export function use_strict(code: string): string {
   return `'use strict';\n${code}`
 }
+
+export function to_fixed(val: number, precision?: number): string {
+  return val.toFixed(precision).replace(/(\.[0-9]*?)0+$/, "$1").replace(/\.$/, "")
+}

--- a/bokehjs/src/lib/core/util/svg.ts
+++ b/bokehjs/src/lib/core/util/svg.ts
@@ -37,7 +37,7 @@ function randomString(holder: KV<string>): string {
 function createNamedToNumberedLookup(input: string, radix: number): Map<string, string> {
   const lookup = new Map()
   const items = input.split(',')
-  radix = radix || 10
+  radix = radix ?? 10
   // Map from named to numbered entities.
   for (let i = 0; i < items.length; i += 2) {
     const entity = '&' + items[i + 1] + ';'
@@ -53,14 +53,14 @@ function createNamedToNumberedLookup(input: string, radix: number): Map<string, 
 function getTextAnchor(textAlign: string): string {
   // TODO: support rtl languages
   const mapping: KV<string> = {left:"start", right:"end", center:"middle", start:"start", end:"end"}
-  return mapping[textAlign] || mapping.start
+  return mapping[textAlign] ?? mapping.start
 }
 
 // helper function to map canvas-textBaseline to svg-dominantBaseline
 function getDominantBaseline(textBaseline: string): string {
   // INFO: not supported in all browsers
   const mapping: KV<string> = {alphabetic: "alphabetic", hanging: "hanging", top:"text-before-edge", bottom:"text-after-edge", middle:"central"}
-  return mapping[textBaseline] || mapping.alphabetic
+  return mapping[textBaseline] ?? mapping.alphabetic
 }
 
 // Unpack entities lookup where the numbers are in radix 32 to reduce the size
@@ -910,11 +910,11 @@ export class SVGRenderingContext2D /*implements CanvasRenderingContext2D*/ {
     const regex = /^\s*(?=(?:(?:[-a-z]+\s*){0,2}(italic|oblique))?)(?=(?:(?:[-a-z]+\s*){0,2}(small-caps))?)(?=(?:(?:[-a-z]+\s*){0,2}(bold(?:er)?|lighter|[1-9]00))?)(?:(?:normal|\1|\2|\3)\s*){0,3}((?:xx?-)?(?:small|large)|medium|smaller|larger|[.\d]+(?:\%|in|[cem]m|ex|p[ctx]))(?:\s*\/\s*(normal|[.\d]+(?:\%|in|[cem]m|ex|p[ctx])))?\s*([-,\'\"\sa-z0-9]+?)\s*$/i
     const fontPart = regex.exec(this.font)!
     const data: FontData = {
-      style: fontPart[1] || 'normal',
-      size: fontPart[4] || '10px',
-      family: fontPart[6] || 'sans-serif',
-      weight: fontPart[3] || 'normal',
-      decoration: fontPart[2] || 'normal',
+      style: fontPart[1] ?? 'normal',
+      size: fontPart[4] ?? '10px',
+      family: fontPart[6] ?? 'sans-serif',
+      weight: fontPart[3] ?? 'normal',
+      decoration: fontPart[2] ?? 'normal',
     }
 
     // canvas doesn't support underline natively, but we can pass this attribute

--- a/bokehjs/src/lib/core/util/throttle.ts
+++ b/bokehjs/src/lib/core/util/throttle.ts
@@ -4,10 +4,10 @@ function _delay_animation(callback: FrameRequestCallback): number {
 }
 
 const delay_animation =
-  (typeof window !== 'undefined' ?  window        .requestAnimationFrame       : undefined) ||
-  (typeof window !== 'undefined' ?  window        .webkitRequestAnimationFrame : undefined) ||
-  (typeof window !== 'undefined' ? (window as any).mozRequestAnimationFrame    : undefined) ||
-  (typeof window !== 'undefined' ? (window as any).msRequestAnimationFrame     : undefined) || _delay_animation
+  (typeof window !== 'undefined' ?  window        .requestAnimationFrame       : undefined) ??
+  (typeof window !== 'undefined' ?  window        .webkitRequestAnimationFrame : undefined) ??
+  (typeof window !== 'undefined' ? (window as any).mozRequestAnimationFrame    : undefined) ??
+  (typeof window !== 'undefined' ? (window as any).msRequestAnimationFrame     : undefined) ?? _delay_animation
 
 // Returns a function, that, when invoked, will only be triggered at
 // most once during a given window of time.

--- a/bokehjs/src/lib/core/util/wheel.ts
+++ b/bokehjs/src/lib/core/util/wheel.ts
@@ -14,8 +14,8 @@ function fontSize(element: Element): number | null {
 }
 
 function lineHeight(element: HTMLElement): number {
-  const parent = element.offsetParent || document.body
-  return fontSize(parent) || fontSize(element) || 16
+  const parent = element.offsetParent ?? document.body
+  return fontSize(parent) ?? fontSize(element) ?? 16
 }
 
 function pageHeight(element: HTMLElement): number {

--- a/bokehjs/src/lib/document/document.ts
+++ b/bokehjs/src/lib/document/document.ts
@@ -360,7 +360,7 @@ export class Document {
     for (const obj of references_json) {
       const obj_id = obj.id
       const obj_type = obj.type
-      const obj_attrs = obj.attributes || {}
+      const obj_attrs = obj.attributes ?? {}
 
       let instance = existing_models.get(obj_id)
       if (instance == null) {

--- a/bokehjs/src/lib/model.ts
+++ b/bokehjs/src/lib/model.ts
@@ -55,7 +55,7 @@ export class Model extends HasProps {
   }
 
   /*protected*/ _process_event(event: ModelEvent): void {
-    for (const callback of this.js_event_callbacks[event.event_name] || [])
+    for (const callback of this.js_event_callbacks[event.event_name] ?? [])
       callback.execute(event)
 
     if (this.document != null && this.subscribed_events.some((m) => m == event.event_name))

--- a/bokehjs/src/lib/models/annotations/color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/color_bar.ts
@@ -479,7 +479,7 @@ export class ColorBarView extends AnnotationView {
   protected _format_major_labels(initial_labels: number[], major_ticks: Arrayable<number>): string[] {
     // XXX: passing null as cross_loc probably means MercatorTickFormatters, etc
     // will not function properly in conjunction with colorbars
-    const formatted_labels = this.model.formatter.doFormat(initial_labels, null as any)
+    const formatted_labels = this.model.formatter.doFormat(initial_labels, {loc: NaN})
 
     for (let i = 0, end = major_ticks.length; i < end; i++) {
       if (major_ticks[i] in this.model.major_label_overrides)
@@ -508,9 +508,7 @@ export class ColorBarView extends AnnotationView {
     const [i, j] = this._normals()
     const [start, end] = [this.model.color_mapper.metrics.min, this.model.color_mapper.metrics.max]
 
-    // XXX: passing null as cross_loc probably means MercatorTickers, etc
-    // will not function properly in conjunction with colorbars
-    const ticks = this.model.ticker.get_ticks(start, end, null, null, this.model.ticker.desired_num_ticks)
+    const ticks = this.model.ticker.get_ticks_no_defaults(start, end, NaN, this.model.ticker.desired_num_ticks)
 
     const majors = ticks.major
     const minors = ticks.minor

--- a/bokehjs/src/lib/models/annotations/toolbar_panel.ts
+++ b/bokehjs/src/lib/models/annotations/toolbar_panel.ts
@@ -22,6 +22,7 @@ export class ToolbarPanelView extends AnnotationView {
   }
 
   async lazy_initialize(): Promise<void> {
+    await super.lazy_initialize()
     this._toolbar_view = await build_view(this.model.toolbar, {parent: this}) as ToolbarBaseView
     this.plot_view.visibility_callbacks.push((visible) => this._toolbar_view.set_visibility(visible))
   }

--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -503,7 +503,7 @@ export namespace Axis {
 
   export type Props = GuideRenderer.Props & {
     bounds: p.Property<[number, number] | "auto">
-    ticker: p.Property<Ticker<any>> // TODO
+    ticker: p.Property<Ticker>
     formatter: p.Property<TickFormatter>
     axis_label: p.Property<string | null>
     axis_label_standoff: p.Property<number>

--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -430,7 +430,7 @@ export class AxisView extends GuideRendererView {
     const [range] = this.ranges
     const [start, end] = this.computed_bounds
 
-    const ticks = this.model.ticker.get_ticks(start, end, range, this.loc, {})
+    const ticks = this.model.ticker.get_ticks(start, end, range, this.loc)
     const majors = ticks.major
     const minors = ticks.minor
 

--- a/bokehjs/src/lib/models/axes/categorical_axis.ts
+++ b/bokehjs/src/lib/models/axes/categorical_axis.ts
@@ -87,7 +87,7 @@ export class CategoricalAxisView extends AxisView {
     const [start, end] = this.computed_bounds
     const loc = this.loc
 
-    const ticks = this.model.ticker.get_ticks(start, end, range, loc, {})
+    const ticks = this.model.ticker.get_ticks(start, end, range, loc)
     const coords = this.tick_coords
 
     const info: [string[], Coords, Orient | number, visuals.Text][] = []
@@ -120,7 +120,7 @@ export class CategoricalAxisView extends AxisView {
     const [range] = (this.ranges as any) as [FactorRange, FactorRange]
     const [start, end] = this.computed_bounds
 
-    const ticks = this.model.ticker.get_ticks(start, end, range, this.loc, {})
+    const ticks = this.model.ticker.get_ticks(start, end, range, this.loc)
 
     const coords: CategoricalTickCoords = {
       major: [[], []],

--- a/bokehjs/src/lib/models/axes/categorical_axis.ts
+++ b/bokehjs/src/lib/models/axes/categorical_axis.ts
@@ -25,7 +25,7 @@ export class CategoricalAxisView extends AxisView {
   }
 
   protected _draw_group_separators(ctx: Context2d, _extents: Extents, _tick_coords: TickCoords): void {
-    const [range] = (this.ranges as any) as [FactorRange, FactorRange]
+    const [range] = this.ranges as [FactorRange, FactorRange]
     const [start, end] = this.computed_bounds
 
     if (!range.tops || range.tops.length < 2 || !this.visuals.separator_line.doit)
@@ -83,7 +83,7 @@ export class CategoricalAxisView extends AxisView {
   }
 
   protected _get_factor_info(): [string[], Coords, Orient | number, visuals.Text][] {
-    const [range] = (this.ranges as any) as [FactorRange, FactorRange]
+    const [range] = this.ranges as [FactorRange, FactorRange]
     const [start, end] = this.computed_bounds
     const loc = this.loc
 
@@ -113,11 +113,10 @@ export class CategoricalAxisView extends AxisView {
     return info
   }
 
-  // {{{ TODO: state
   get tick_coords(): CategoricalTickCoords {
     const i = this.dimension
     const j = (i + 1) % 2
-    const [range] = (this.ranges as any) as [FactorRange, FactorRange]
+    const [range] = this.ranges as [FactorRange, FactorRange]
     const [start, end] = this.computed_bounds
 
     const ticks = this.model.ticker.get_ticks(start, end, range, this.loc)
@@ -130,21 +129,20 @@ export class CategoricalAxisView extends AxisView {
     }
 
     coords.major[i] = ticks.major as any
-    coords.major[j] = ticks.major.map((_x) => this.loc)
+    coords.major[j] = ticks.major.map(() => this.loc)
 
     if (range.levels == 3) {
       coords.mids[i] = ticks.mids as any
-      coords.mids[j] = ticks.mids.map((_x) => this.loc)
+      coords.mids[j] = ticks.mids.map(() => this.loc)
     }
 
     if (range.levels > 1) {
       coords.tops[i] = ticks.tops as any
-      coords.tops[j] = ticks.tops.map((_x) => this.loc)
+      coords.tops[j] = ticks.tops.map(() => this.loc)
     }
 
     return coords
   }
-  // }}}
 }
 
 export namespace CategoricalAxis {

--- a/bokehjs/src/lib/models/canvas/canvas.ts
+++ b/bokehjs/src/lib/models/canvas/canvas.ts
@@ -237,7 +237,7 @@ export class CanvasView extends DOMView {
       const {gl, canvas} = webgl
       gl.viewport(0, 0, canvas.width, canvas.height)
       gl.clearColor(0, 0, 0, 0)
-      gl.clear(gl.COLOR_BUFFER_BIT || gl.DEPTH_BUFFER_BIT)
+      gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT)
     }
   }
 

--- a/bokehjs/src/lib/models/expressions/cumsum.ts
+++ b/bokehjs/src/lib/models/expressions/cumsum.ts
@@ -29,7 +29,7 @@ export class CumSum extends Expression {
   }
 
   protected _v_compute(source: ColumnarDataSource): Arrayable<number> {
-    const result = new NumberArray(source.get_length() || 0)
+    const result = new NumberArray(source.get_length() ?? 0)
     const col = source.data[this.field]
     const offset = this.include_zero ? 1 : 0
     result[0] = this.include_zero ? 0 : col[0]

--- a/bokehjs/src/lib/models/formatters/basic_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/basic_tick_formatter.ts
@@ -1,4 +1,5 @@
 import {TickFormatter} from "./tick_formatter"
+import {to_fixed} from "core/util/string"
 import * as p from "core/properties"
 
 export namespace BasicTickFormatter {
@@ -60,29 +61,19 @@ export class BasicTickFormatter extends TickFormatter {
     return false
   }
 
-  _format_with_precision(ticks: number[], need_sci: boolean, precision: number|undefined): string[] {
-    const labels: string[] = new Array(ticks.length)
-
+  _format_with_precision(ticks: number[], need_sci: boolean, precision: number | undefined): string[] {
     if (need_sci) {
-      for (let i = 0, end = ticks.length; i < end; i++) {
-        labels[i] = ticks[i].toExponential(precision)
-      }
+      return ticks.map((tick) => tick.toExponential(precision))
     } else {
-      for (let i = 0, end = ticks.length; i < end; i++) {
-        // strip trailing zeros
-        labels[i] = ticks[i].toFixed(precision).replace(/(\.[0-9]*?)0+$/, "$1").replace(/\.$/, "")
-      }
+      return ticks.map((tick) => to_fixed(tick, precision))
     }
-
-    return labels
   }
 
-  _auto_precision(ticks: number[], need_sci: boolean): number|undefined {
+  _auto_precision(ticks: number[], need_sci: boolean): number | undefined {
     const labels: string[] = new Array(ticks.length)
     const asc = this.last_precision <= 15
 
-    outer:
-    for (let x = this.last_precision; asc ? x <= 15 : x >= 1; asc ? x++ : x--) {
+    outer: for (let x = this.last_precision; asc ? x <= 15 : x >= 1; asc ? x++ : x--) {
       if (need_sci) {
         labels[0] = ticks[0].toExponential(x)
         for (let i = 1; i < ticks.length; i++) {
@@ -93,9 +84,9 @@ export class BasicTickFormatter extends TickFormatter {
         this.last_precision = x
         break
       } else {
-        labels[0] = ticks[0].toFixed(x).replace(/(\.[0-9]*?)0+$/, "$1").replace(/\.$/, "")
+        labels[0] = to_fixed(ticks[0], x)
         for (let i = 1; i < ticks.length; i++) {
-          labels[i] = ticks[i].toFixed(x).replace(/(\.[0-9]*?)0+$/, "$1").replace(/\.$/, "")
+          labels[i] = to_fixed(ticks[i], x)
           if (labels[i] == labels[i-1]) {
             continue outer
           }

--- a/bokehjs/src/lib/models/grids/grid.ts
+++ b/bokehjs/src/lib/models/grids/grid.ts
@@ -182,7 +182,7 @@ export namespace Grid {
     bounds: p.Property<[number, number] | "auto">
     dimension: p.Property<0 | 1>
     axis: p.Property<Axis>
-    ticker: p.Property<Ticker<any>>
+    ticker: p.Property<Ticker>
   } & Mixins
 
   export type Mixins =
@@ -235,7 +235,7 @@ export class Grid extends GuideRenderer {
     })
   }
 
-  get_ticker(): Ticker<any> | null {
+  get_ticker(): Ticker | null {
     if (this.ticker != null) {
       return this.ticker
     }

--- a/bokehjs/src/lib/models/grids/grid.ts
+++ b/bokehjs/src/lib/models/grids/grid.ts
@@ -140,7 +140,7 @@ export class GridView extends GuideRendererView {
       return coords
     }
 
-    const ticks = ticker.get_ticks(start, end, range, cross_range.min, {})[location]
+    const ticks = ticker.get_ticks(start, end, range, cross_range.min)[location]
 
     const min = range.min
     const max = range.max

--- a/bokehjs/src/lib/models/layouts/layout_dom.ts
+++ b/bokehjs/src/lib/models/layouts/layout_dom.ts
@@ -39,6 +39,7 @@ export abstract class LayoutDOMView extends DOMView {
   }
 
   async lazy_initialize(): Promise<void> {
+    await super.lazy_initialize()
     await this.build_child_views()
   }
 

--- a/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
@@ -76,7 +76,7 @@ export class GMapPlotView extends PlotView {
 
     // PAN ----------------------------
     } else if (range_info.sdx != null || range_info.sdy != null) {
-      this.map.panBy(range_info.sdx || 0, range_info.sdy || 0)
+      this.map.panBy(range_info.sdx ?? 0, range_info.sdy ?? 0)
       super.update_range(range_info)
 
     // ZOOM ---------------------------

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -211,6 +211,8 @@ export class PlotView extends LayoutDOMView {
   }
 
   async lazy_initialize(): Promise<void> {
+    await super.lazy_initialize()
+
     this.canvas_view = await build_view(this.canvas, {parent: this})
     this.ui_event_bus = new UIEvents(this, this.model.toolbar, this.canvas_view.events_el)
 

--- a/bokehjs/src/lib/models/tickers/adaptive_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/adaptive_ticker.ts
@@ -1,16 +1,7 @@
 import {ContinuousTicker} from "./continuous_ticker"
 import {argmin, nth} from "core/util/array"
+import {clamp, log} from "core/util/math"
 import * as p from "core/properties"
-
-// Forces a number x into a specified range [min_val, max_val].
-function clamp(x: number, min_val: number, max_val: number): number {
-  return Math.max(min_val, Math.min(max_val, x))
-}
-
-// A log function with an optional base.
-function log(x: number, base=Math.E): number {
-  return Math.log(x) / Math.log(base)
-}
 
 // This Ticker produces nice round ticks at any magnitude.
 // AdaptiveTicker([1, 2, 5]) will choose the best tick interval from the

--- a/bokehjs/src/lib/models/tickers/categorical_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/categorical_ticker.ts
@@ -25,8 +25,8 @@ export class CategoricalTicker extends Ticker<Factor> {
   get_ticks(start: number, end: number, range: FactorRange, _cross_loc: number): FactorTickSpec {
     const majors = this._collect(range.factors, range, start, end)
 
-    const tops = this._collect(range.tops || [], range, start, end)
-    const mids = this._collect(range.mids || [], range, start, end)
+    const tops = this._collect(range.tops ?? [], range, start, end)
+    const mids = this._collect(range.mids ?? [], range, start, end)
 
     return {
       major: majors,

--- a/bokehjs/src/lib/models/tickers/categorical_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/categorical_ticker.ts
@@ -22,7 +22,7 @@ export class CategoricalTicker extends Ticker<Factor> {
     super(attrs)
   }
 
-  get_ticks(start: number, end: number, range: FactorRange, _cross_loc: any, _: any): FactorTickSpec {
+  get_ticks(start: number, end: number, range: FactorRange, _cross_loc: number): FactorTickSpec {
     const majors = this._collect(range.factors, range, start, end)
 
     const tops = this._collect(range.tops || [], range, start, end)

--- a/bokehjs/src/lib/models/tickers/categorical_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/categorical_ticker.ts
@@ -2,7 +2,7 @@ import {Ticker, TickSpec} from "./ticker"
 import {FactorRange, Factor} from "../ranges/factor_range"
 import * as p from "core/properties"
 
-export interface FactorTickSpec extends TickSpec<Factor> {
+export type FactorTickSpec = TickSpec<Factor> & {
   tops: Factor[]
   mids: Factor[]
 }
@@ -15,7 +15,7 @@ export namespace CategoricalTicker {
 
 export interface CategoricalTicker extends CategoricalTicker.Attrs {}
 
-export class CategoricalTicker extends Ticker<Factor> {
+export class CategoricalTicker extends Ticker {
   properties: CategoricalTicker.Props
 
   constructor(attrs?: Partial<CategoricalTicker.Attrs>) {

--- a/bokehjs/src/lib/models/tickers/composite_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/composite_ticker.ts
@@ -84,7 +84,7 @@ export class CompositeTicker extends ContinuousTicker {
     return best_ticker.get_interval(data_low, data_high, desired_n_ticks)
   }
 
-  get_ticks_no_defaults(data_low: number, data_high: number, cross_loc: any, desired_n_ticks: number): TickSpec<number> {
+  get_ticks_no_defaults(data_low: number, data_high: number, cross_loc: number, desired_n_ticks: number): TickSpec<number> {
     const best_ticker = this.get_best_ticker(data_low, data_high, desired_n_ticks)
     return best_ticker.get_ticks_no_defaults(data_low, data_high, cross_loc, desired_n_ticks)
   }

--- a/bokehjs/src/lib/models/tickers/continuous_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/continuous_ticker.ts
@@ -1,4 +1,5 @@
 import {Ticker, TickSpec} from "./ticker"
+import {Range} from "../ranges/range"
 import * as p from "core/properties"
 import {range} from "core/util/array"
 
@@ -40,7 +41,7 @@ export abstract class ContinuousTicker extends Ticker<number> {
     }))
   }
 
-  get_ticks(data_low: number, data_high: number, _range: any, cross_loc: any, _: any): TickSpec<number> {
+  get_ticks(data_low: number, data_high: number, _range: Range, cross_loc: number): TickSpec<number> {
     return this.get_ticks_no_defaults(data_low, data_high, cross_loc, this.desired_num_ticks)
   }
 
@@ -57,7 +58,7 @@ export abstract class ContinuousTicker extends Ticker<number> {
 
   // The version of get_ticks() that does the work (and the version that
   // should be overridden in subclasses).
-  get_ticks_no_defaults(data_low: number, data_high: number, _cross_loc: any, desired_n_ticks: number): TickSpec<number> {
+  get_ticks_no_defaults(data_low: number, data_high: number, _cross_loc: number, desired_n_ticks: number): TickSpec<number> {
     const interval = this.get_interval(data_low, data_high, desired_n_ticks)
     const start_factor = Math.floor(data_low / interval)
     const end_factor   = Math.ceil(data_high / interval)

--- a/bokehjs/src/lib/models/tickers/continuous_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/continuous_ticker.ts
@@ -27,7 +27,7 @@ export namespace ContinuousTicker {
 
 export interface ContinuousTicker extends ContinuousTicker.Attrs {}
 
-export abstract class ContinuousTicker extends Ticker<number> {
+export abstract class ContinuousTicker extends Ticker {
   properties: ContinuousTicker.Props
 
   constructor(attrs?: Partial<ContinuousTicker.Attrs>) {

--- a/bokehjs/src/lib/models/tickers/days_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/days_ticker.ts
@@ -68,7 +68,7 @@ export class DaysTicker extends SingleIntervalTicker {
       this.interval = 31*ONE_DAY
   }
 
-  get_ticks_no_defaults(data_low: number, data_high: number, _cross_loc: any, _desired_n_ticks: number): TickSpec<number> {
+  get_ticks_no_defaults(data_low: number, data_high: number, _cross_loc: number, _desired_n_ticks: number): TickSpec<number> {
     const month_dates = date_range_by_month(data_low, data_high)
 
     const days = this.days

--- a/bokehjs/src/lib/models/tickers/fixed_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/fixed_ticker.ts
@@ -27,7 +27,7 @@ export class FixedTicker extends ContinuousTicker {
     }))
   }
 
-  get_ticks_no_defaults(_data_low: number, _data_high: number, _cross_loc: any, _desired_n_ticks: number): TickSpec<number> {
+  get_ticks_no_defaults(_data_low: number, _data_high: number, _cross_loc: number, _desired_n_ticks: number): TickSpec<number> {
     return {
       major: this.ticks,
       minor: this.minor_ticks,

--- a/bokehjs/src/lib/models/tickers/log_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/log_ticker.ts
@@ -24,7 +24,7 @@ export class LogTicker extends AdaptiveTicker {
     })
   }
 
-  get_ticks_no_defaults(data_low: number, data_high: number, _cross_loc: any, desired_n_ticks: number): TickSpec<number> {
+  get_ticks_no_defaults(data_low: number, data_high: number, _cross_loc: number, desired_n_ticks: number): TickSpec<number> {
     const num_minor_ticks = this.num_minor_ticks
     const minor_ticks = []
 

--- a/bokehjs/src/lib/models/tickers/mercator_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/mercator_ticker.ts
@@ -27,7 +27,7 @@ export class MercatorTicker extends BasicTicker {
     }))
   }
 
-  get_ticks_no_defaults(data_low: number, data_high: number, cross_loc: any, desired_n_ticks: number): TickSpec<number> {
+  get_ticks_no_defaults(data_low: number, data_high: number, cross_loc: number, desired_n_ticks: number): TickSpec<number> {
     if (this.dimension == null) {
       throw new Error(`${this}.dimension wasn't configured`)
     }
@@ -40,7 +40,7 @@ export class MercatorTicker extends BasicTicker {
       return this._get_ticks_lat(data_low, data_high, cross_loc, desired_n_ticks)
   }
 
-  protected _get_ticks_lon(data_low: number, data_high: number, cross_loc: any, desired_n_ticks: number): TickSpec<number> {
+  protected _get_ticks_lon(data_low: number, data_high: number, cross_loc: number, desired_n_ticks: number): TickSpec<number> {
     const [proj_low] = wgs84_mercator.invert(data_low, cross_loc)
     const [proj_high, proj_cross_loc] = wgs84_mercator.invert(data_high, cross_loc)
 
@@ -65,7 +65,7 @@ export class MercatorTicker extends BasicTicker {
     return {major, minor}
   }
 
-  protected _get_ticks_lat(data_low: number, data_high: number, cross_loc: any, desired_n_ticks: number): TickSpec<number> {
+  protected _get_ticks_lat(data_low: number, data_high: number, cross_loc: number, desired_n_ticks: number): TickSpec<number> {
     const [, proj_low] = wgs84_mercator.invert(cross_loc, data_low)
     const [proj_cross_loc, proj_high] = wgs84_mercator.invert(cross_loc, data_high)
 

--- a/bokehjs/src/lib/models/tickers/months_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/months_ticker.ts
@@ -61,7 +61,7 @@ export class MonthsTicker extends SingleIntervalTicker {
       this.interval = 12*ONE_MONTH
   }
 
-  get_ticks_no_defaults(data_low: number, data_high: number, _cross_loc: any, _desired_n_ticks: number): TickSpec<number> {
+  get_ticks_no_defaults(data_low: number, data_high: number, _cross_loc: number, _desired_n_ticks: number): TickSpec<number> {
     const year_dates = date_range_by_year(data_low, data_high)
 
     const months = this.months

--- a/bokehjs/src/lib/models/tickers/ticker.ts
+++ b/bokehjs/src/lib/models/tickers/ticker.ts
@@ -1,4 +1,5 @@
 import {Model} from "../../model"
+import {Range} from "../ranges/range"
 import * as p from "core/properties"
 
 export type TickSpec<T> = {
@@ -35,5 +36,5 @@ export abstract class Ticker<T> extends Model {
   }
 
   // Generates a nice series of ticks for a given range.
-  abstract get_ticks(data_low: number, data_high: number, range: any, cross_loc: any, unused: any): TickSpec<T>
+  abstract get_ticks(data_low: number, data_high: number, range: Range, cross_loc: number): TickSpec<T>
 }

--- a/bokehjs/src/lib/models/tickers/ticker.ts
+++ b/bokehjs/src/lib/models/tickers/ticker.ts
@@ -26,9 +26,9 @@ export namespace Ticker{
   export type Props = Model.Props
 }
 
-export interface Ticker<T> extends Ticker.Attrs {}
+export interface Ticker extends Ticker.Attrs {}
 
-export abstract class Ticker<T> extends Model {
+export abstract class Ticker extends Model {
   properties: Ticker.Props
 
   constructor(attrs?: Partial<Ticker.Attrs>) {
@@ -36,5 +36,6 @@ export abstract class Ticker<T> extends Model {
   }
 
   // Generates a nice series of ticks for a given range.
-  abstract get_ticks(data_low: number, data_high: number, range: Range, cross_loc: number): TickSpec<T>
+  // TODO: any -> unknown or number | Factor
+  abstract get_ticks(data_low: number, data_high: number, range: Range, cross_loc: number): TickSpec<any>
 }

--- a/bokehjs/src/lib/models/tickers/years_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/years_ticker.ts
@@ -27,7 +27,7 @@ export class YearsTicker extends SingleIntervalTicker {
     this.basic_ticker = new BasicTicker({num_minor_ticks: 0})
   }
 
-  get_ticks_no_defaults(data_low: number, data_high: number, cross_loc: any, desired_n_ticks: number): TickSpec<number> {
+  get_ticks_no_defaults(data_low: number, data_high: number, cross_loc: number, desired_n_ticks: number): TickSpec<number> {
     const start_year = last_year_no_later_than(new Date(data_low)).getUTCFullYear()
     const end_year = last_year_no_later_than(new Date(data_high)).getUTCFullYear()
 

--- a/bokehjs/src/lib/models/tools/edit/edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/edit_tool.ts
@@ -191,10 +191,10 @@ export abstract class EditTool extends GestureTool {
   }
 
   get tooltip(): string {
-    return this.custom_tooltip || this.tool_name
+    return this.custom_tooltip ?? this.tool_name
   }
 
   get computed_icon(): string {
-    return this.custom_icon || this.icon
+    return this.custom_icon ?? this.icon
   }
 }

--- a/bokehjs/src/lib/models/tools/toolbar_base.ts
+++ b/bokehjs/src/lib/models/tools/toolbar_base.ts
@@ -67,6 +67,7 @@ export class ToolbarBaseView extends DOMView {
   }
 
   async lazy_initialize(): Promise<void> {
+    await super.lazy_initialize()
     await this._build_tool_button_views()
   }
 

--- a/bokehjs/src/lib/models/widgets/color_picker.ts
+++ b/bokehjs/src/lib/models/widgets/color_picker.ts
@@ -10,7 +10,7 @@ export class ColorPickerView extends InputWidgetView {
 
   connect_signals(): void {
     super.connect_signals()
-    this.connect(this.model.properties.name.change, () => this.input_el.name = this.model.name || "")
+    this.connect(this.model.properties.name.change, () => this.input_el.name = this.model.name ?? "")
     this.connect(this.model.properties.color.change, () => this.input_el.value = this.model.color)
     this.connect(this.model.properties.disabled.change, () => this.input_el.disabled = this.model.disabled)
   }

--- a/bokehjs/src/lib/models/widgets/tables/cell_editors.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_editors.ts
@@ -346,7 +346,7 @@ export class IntEditorView extends CellEditorView {
   }
 
   serializeValue(): any {
-    return parseInt(this.getValue(), 10) || 0
+    return parseInt(this.getValue(), 10) ?? 0
   }
 
   loadValue(item: Item): void {
@@ -405,7 +405,7 @@ export class NumberEditorView extends CellEditorView {
   }
 
   serializeValue(): any {
-    return parseFloat(this.getValue()) || 0.0
+    return parseFloat(this.getValue()) ?? 0.0
   }
 
   loadValue(item: Item): void {

--- a/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
@@ -7,6 +7,7 @@ import {div, i} from "core/dom"
 import {Color} from "core/types"
 import {FontStyle, TextAlign, RoundingFunction} from "core/enums"
 import {isString} from "core/util/types"
+import {to_fixed} from "core/util/string"
 import {Model} from "../../../model"
 
 export namespace CellFormatter {
@@ -129,11 +130,10 @@ export class ScientificFormatter extends StringFormatter {
 
     if ((value == null || isNaN(value)) && this.nan_format != null)
       value = this.nan_format
-    else if (need_sci) {
+    else if (need_sci)
       value = value.toExponential(precision)
-    } else {
-      value = value.toFixed(precision).replace(/(\.[0-9]*?)0+$/, "$1").replace(/\.$/, "")
-    }
+    else
+      value = to_fixed(value, precision)
 
     // add StringFormatter formatting
     return super.doFormat(row, cell, value, columnDef, dataContext)

--- a/bokehjs/src/lib/models/widgets/tables/data_cube.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_cube.ts
@@ -32,7 +32,7 @@ function indentFormatter(formatter?: Formatter<Item>, indent?: number): Formatte
   return (row: number, cell: number, value: unknown, columnDef: Column<Item>, dataContext: Item) => {
     const spacer = span({
       class: 'slick-group-toggle',
-      style: { 'margin-left': `${(indent || 0) * 15}px`},
+      style: { 'margin-left': `${(indent ?? 0) * 15}px`},
     })
     const formatted = formatter ? formatter(row, cell, value, columnDef, dataContext) : `${value}`
 

--- a/bokehjs/src/lib/models/widgets/text_input.ts
+++ b/bokehjs/src/lib/models/widgets/text_input.ts
@@ -12,7 +12,7 @@ export class TextInputView extends InputWidgetView {
 
   connect_signals(): void {
     super.connect_signals()
-    this.connect(this.model.properties.name.change, () => this.input_el.name = this.model.name || "")
+    this.connect(this.model.properties.name.change, () => this.input_el.name = this.model.name ?? "")
     this.connect(this.model.properties.value.change, () => this.input_el.value = this.model.value)
     this.connect(this.model.properties.value_input.change, () => this.input_el.value = this.model.value_input)
     this.connect(this.model.properties.disabled.change, () => this.input_el.disabled = this.model.disabled)

--- a/bokehjs/src/lib/models/widgets/textarea_input.ts
+++ b/bokehjs/src/lib/models/widgets/textarea_input.ts
@@ -12,7 +12,7 @@ export class TextAreaInputView extends InputWidgetView {
 
   connect_signals(): void {
     super.connect_signals()
-    this.connect(this.model.properties.name.change, () => this.input_el.name = this.model.name || "")
+    this.connect(this.model.properties.name.change, () => this.input_el.name = this.model.name ?? "")
     this.connect(this.model.properties.value.change, () => this.input_el.value = this.model.value)
     this.connect(this.model.properties.disabled.change, () => this.input_el.disabled = this.model.disabled)
     this.connect(this.model.properties.placeholder.change, () => this.input_el.placeholder = this.model.placeholder)

--- a/bokehjs/test/devtools/devtools.ts
+++ b/bokehjs/test/devtools/devtools.ts
@@ -68,7 +68,7 @@ async function run_tests(): Promise<boolean> {
     try {
       function collect_trace(stackTrace: Protocol.Runtime.StackTrace): CallFrame[] {
         return stackTrace.callFrames.map(({functionName, url, lineNumber, columnNumber}) => {
-          return {name: functionName || "(anonymous)", url, line: lineNumber+1, col: columnNumber+1}
+          return {name: functionName ?? "(anonymous)", url, line: lineNumber+1, col: columnNumber+1}
         })
       }
 
@@ -76,7 +76,7 @@ async function run_tests(): Promise<boolean> {
         const {text, exception, url, lineNumber, columnNumber, stackTrace} = exceptionDetails
         return {
           text: exception != null && exception.description != null ? exception.description : text,
-          url: url || "(inline)",
+          url: url ?? "(inline)",
           line: lineNumber+1,
           col: columnNumber+1,
           trace: stackTrace ? collect_trace(stackTrace) : [],

--- a/bokehjs/test/unit/models/tickers/categorical_ticker.ts
+++ b/bokehjs/test/unit/models/tickers/categorical_ticker.ts
@@ -10,7 +10,7 @@ describe("CategoricalTicker Model", () => {
     it("should handle case where range has no factors", () => {
       const ticker = new CategoricalTicker()
       const range = new FactorRange()
-      const ticks = ticker.get_ticks(0, 10, range, null, {}) // cross_loc is null
+      const ticks = ticker.get_ticks(0, 10, range, NaN)
       expect(ticks.major).to.be.equal([])
       expect(ticks.minor).to.be.equal([])
     })
@@ -18,7 +18,7 @@ describe("CategoricalTicker Model", () => {
     it("should handle case where range has factors", () => {
       const ticker = new CategoricalTicker()
       const range = new FactorRange({factors: ["foo", "bar", "bat"]})
-      const ticks = ticker.get_ticks(0, 3, range, null, {}) // cross_loc is null
+      const ticks = ticker.get_ticks(0, 3, range, NaN)
       expect(ticks.major).to.be.equal(["foo", "bar", "bat"])
       expect(ticks.minor).to.be.equal([])
     })
@@ -27,7 +27,7 @@ describe("CategoricalTicker Model", () => {
       const ticker = new CategoricalTicker()
       const range = new FactorRange({factors: ["foo", "bar", "bat"]})
       //  should just show middle factor (index=2)
-      const ticks = ticker.get_ticks(1, 2, range, null, {}) // cross_loc is null
+      const ticks = ticker.get_ticks(1, 2, range, NaN)
       expect(ticks.major).to.be.equal(["bar"])
       expect(ticks.minor).to.be.equal([])
     })

--- a/bokehjs/test/unit/models/tickers/continuous_ticker.ts
+++ b/bokehjs/test/unit/models/tickers/continuous_ticker.ts
@@ -1,6 +1,7 @@
 import {expect} from "assertions"
 
 import {ContinuousTicker} from "@bokehjs/models/tickers/continuous_ticker"
+import {Range1d} from "@bokehjs/models/ranges/range1d"
 
 describe("ContinuousTicker Model", () => {
 
@@ -21,11 +22,12 @@ describe("ContinuousTicker Model", () => {
     }
   }
 
+  const range = new Range1d({start: 0, end: 100})
+
   it("should have five major and minor ticks only inside bounds", () => {
     const ticker = new MyTicker({num_minor_ticks: 2, desired_num_ticks: 5})
 
-    // `range` and `cross_loc` aren't used by the AdaptiveTicker, so are passed as null args
-    const ticks = ticker.get_ticks(-200, 200, null, null, {})
+    const ticks = ticker.get_ticks(-200, 200, range, NaN)
     expect(ticks.major).to.be.equal([-200, -100, 0, 100, 200])
     expect(ticks.minor).to.be.equal([-200, -150, -100, -50, 0, 50, 100, 150, 200])
   })
@@ -33,8 +35,7 @@ describe("ContinuousTicker Model", () => {
   it("should have five major and matching minor ticks", () => {
     const ticker = new MyTicker({num_minor_ticks: 1, desired_num_ticks: 5})
 
-    // `range` and `cross_loc` aren't used by the AdaptiveTicker, so are passed as null args
-    const ticks = ticker.get_ticks(-200, 200, null, null, {})
+    const ticks = ticker.get_ticks(-200, 200, range, NaN)
     expect(ticks.major).to.be.equal([-200, -100, 0, 100, 200])
     expect(ticks.minor).to.be.equal([-200, -100, 0, 100, 200])
   })
@@ -42,8 +43,7 @@ describe("ContinuousTicker Model", () => {
   it("should have five major and zero minor ticks", () => {
     const ticker = new MyTicker({num_minor_ticks: 0, desired_num_ticks: 5})
 
-    // `range` and `cross_loc` aren't used by the AdaptiveTicker, so are passed as null args
-    const ticks = ticker.get_ticks(-200, 200, null, null, {})
+    const ticks = ticker.get_ticks(-200, 200, range, NaN)
     expect(ticks.major).to.be.equal([-200, -100, 0, 100, 200])
     expect(ticks.minor).to.be.equal([])
   })
@@ -51,8 +51,7 @@ describe("ContinuousTicker Model", () => {
   it("should handle empty start/end case by returning no ticks", () => {
     const ticker = new MyTicker({num_minor_ticks: 2, desired_num_ticks: 5})
 
-    // `range` and `cross_loc` aren't used by the AdaptiveTicker, so are passed as null args
-    const ticks = ticker.get_ticks(NaN, NaN, null, null, {})
+    const ticks = ticker.get_ticks(NaN, NaN, range, NaN)
     expect(ticks.major).to.be.equal([])
     expect(ticks.minor).to.be.equal([])
   })

--- a/bokehjs/test/unit/models/tickers/days_ticker.ts
+++ b/bokehjs/test/unit/models/tickers/days_ticker.ts
@@ -17,7 +17,7 @@ describe("DaysTicker Model", () => {
 
   it("should return nice ticks on a single interval", () => {
     const ticker = new DaysTicker({days: [6]})
-    const ticks = ticker.get_ticks_no_defaults(Date.UTC(2000, 0, 1), Date.UTC(2000, 3, 31), null, 5)
+    const ticks = ticker.get_ticks_no_defaults(Date.UTC(2000, 0, 1), Date.UTC(2000, 3, 31), NaN, 5)
     const expected_major = [0, 1, 2, 3].map((month) => Date.UTC(2000, month, 6))
     expect(ticks.major).to.be.equal(expected_major)
     expect(ticks.minor).to.be.equal([])
@@ -26,7 +26,7 @@ describe("DaysTicker Model", () => {
   it("should skip end ticks if interval is too small", () => {
     const ticker = new DaysTicker({days: [1, 4, 7, 10, 13, 16, 19, 22, 25, 28, 31]})
     expect(ticker.interval).to.be.equal(3*ONE_DAY)
-    const ticks = ticker.get_ticks_no_defaults(Date.UTC(2001, 2, 15), Date.UTC(2001, 3, 9), null, 5)
+    const ticks = ticker.get_ticks_no_defaults(Date.UTC(2001, 2, 15), Date.UTC(2001, 3, 9), NaN, 5)
     const expected_major = [
       Date.UTC(2001, 2, 16), Date.UTC(2001, 2, 19), Date.UTC(2001, 2, 22), Date.UTC(2001, 2, 25),
       Date.UTC(2001, 2, 28),  // this should not be here but JS date is boken

--- a/bokehjs/test/unit/models/tickers/fixed_ticker.ts
+++ b/bokehjs/test/unit/models/tickers/fixed_ticker.ts
@@ -9,14 +9,14 @@ describe("FixedTicker Model", () => {
     it("should return ticks property as major ticks if set", () => {
       const t = [0, 5, 10]
       const ticker = new FixedTicker({ticks: t})
-      const ticks = ticker.get_ticks_no_defaults(NaN, NaN, null, NaN)
+      const ticks = ticker.get_ticks_no_defaults(NaN, NaN, NaN, NaN)
       expect(ticks.major).to.be.equal(t)
       expect(ticks.minor).to.be.equal([])
     })
 
     it("should return empty array as major ticks if ticks property is unset", () => {
       const ticker = new FixedTicker()
-      const ticks = ticker.get_ticks_no_defaults(NaN, NaN, null, NaN)
+      const ticks = ticker.get_ticks_no_defaults(NaN, NaN, NaN, NaN)
       expect(ticks.major).to.be.equal([])
       expect(ticks.minor).to.be.equal([])
     })

--- a/bokehjs/test/unit/models/tickers/log_ticker.ts
+++ b/bokehjs/test/unit/models/tickers/log_ticker.ts
@@ -10,14 +10,14 @@ describe("LogTicker Model", () => {
 
     it("should return empty ticks when start/end is not finite", () => {
       const ticker = new LogTicker()
-      const ticks = ticker.get_ticks_no_defaults(NaN, NaN, null, 3)
+      const ticks = ticker.get_ticks_no_defaults(NaN, NaN, NaN, 3)
       expect(ticks.major).to.be.equal([])
       expect(ticks.minor).to.be.equal([])
     })
 
     it("should return empty ticks when log(start) or log(end) not finite", () => {
       const ticker = new LogTicker()
-      const ticks = ticker.get_ticks_no_defaults(0, 100, null, 3)
+      const ticks = ticker.get_ticks_no_defaults(0, 100, NaN, 3)
       expect(ticks.major).to.be.equal([])
       expect(ticks.minor).to.be.equal([])
     })
@@ -26,21 +26,21 @@ describe("LogTicker Model", () => {
 
     it("should have three major ticks and zero minor ticks for short range", () => {
       const ticker = new LogTicker({desired_num_ticks: 3, num_minor_ticks: 0})
-      const ticks = ticker.get_ticks_no_defaults(1, 999, null, 3)
+      const ticks = ticker.get_ticks_no_defaults(1, 999, NaN, 3)
       expect(ticks.major).to.be.equal([1, 10, 100])
       expect(ticks.minor).to.be.equal([])
     })
 
     it("should have three major ticks and three minor ticks for short range", () => {
       const ticker = new LogTicker({desired_num_ticks: 3, num_minor_ticks: 1})
-      const ticks = ticker.get_ticks_no_defaults(1, 999, null, 3)
+      const ticks = ticker.get_ticks_no_defaults(1, 999, NaN, 3)
       expect(ticks.major).to.be.equal([1, 10, 100])
       expect(ticks.minor).to.be.equal([1, 10, 100])
     })
 
     it("should have three major ticks and six minor ticks for short range", () => {
       const ticker = new LogTicker({desired_num_ticks: 3, num_minor_ticks: 2})
-      const ticks = ticker.get_ticks_no_defaults(1, 999, null, 3)
+      const ticks = ticker.get_ticks_no_defaults(1, 999, NaN, 3)
       expect(ticks.major).to.be.equal([1, 10, 100])
       expect(ticks.minor).to.be.equal([1, 5, 10, 50, 100, 500])
     })
@@ -49,28 +49,28 @@ describe("LogTicker Model", () => {
 
     it("should have four major ticks and zero minor ticks for long range", () => {
       const ticker = new LogTicker({num_minor_ticks: 0})
-      const ticks = ticker.get_ticks_no_defaults(1, 1000, null, 4)
+      const ticks = ticker.get_ticks_no_defaults(1, 1000, NaN, 4)
       expect(ticks.major).to.be.equal([1e0, 1e1, 1e2, 1e3])
       expect(ticks.minor).to.be.equal([])
     })
 
     it("should have four major ticks and four minor ticks for long range", () => {
       const ticker = new LogTicker({num_minor_ticks: 1})
-      const ticks = ticker.get_ticks_no_defaults(1, 1000, null, 4)
+      const ticks = ticker.get_ticks_no_defaults(1, 1000, NaN, 4)
       expect(ticks.major).to.be.equal([1e0, 1e1, 1e2, 1e3])
       expect(ticks.minor).to.be.equal([1e0, 1e1, 1e2, 1e3])
     })
 
     it("should have four major ticks and seven minor ticks for long range", () => {
       const ticker = new LogTicker({num_minor_ticks: 2})
-      const ticks = ticker.get_ticks_no_defaults(1, 1000, null, 4)
+      const ticks = ticker.get_ticks_no_defaults(1, 1000, NaN, 4)
       expect(ticks.major).to.be.equal([1e0, 1e1, 1e2, 1e3])
       expect(ticks.minor).to.be.equal([1e0, 5e0, 1e1, 5e1, 1e2, 5e2, 1e3])
     })
 
     it("should have correct default ticks for (1.0001, 1e3) range", () => {
       const ticker = new LogTicker()
-      const ticks = ticker.get_ticks_no_defaults(1.0001, 1e3, null, 4)
+      const ticks = ticker.get_ticks_no_defaults(1.0001, 1e3, NaN, 4)
       expect(ticks.major).to.be.equal([1e1, 1e2, 1e3])
       expect(ticks.minor).to.be.equal([2, 4, 6, 8, 10, 20, 40, 60, 80, 100, 200, 400, 600, 800, 1000])
     })

--- a/bokehjs/test/unit/models/tickers/months_ticker.ts
+++ b/bokehjs/test/unit/models/tickers/months_ticker.ts
@@ -17,7 +17,7 @@ describe("MonthsTicker Model", () => {
 
   it("should return nice ticks on a single interval", () => {
     const ticker = new MonthsTicker({months: [6]})
-    const ticks = ticker.get_ticks_no_defaults(Date.UTC(2000, 0, 1), Date.UTC(2005, 0, 1), null, 5)
+    const ticks = ticker.get_ticks_no_defaults(Date.UTC(2000, 0, 1), Date.UTC(2005, 0, 1), NaN, 5)
     const expected_major = [2000, 2001, 2002, 2003, 2004].map((year) => Date.UTC(year, 6, 1))
     expect(ticks.major).to.be.equal(expected_major)
     expect(ticks.minor).to.be.equal([])
@@ -25,7 +25,7 @@ describe("MonthsTicker Model", () => {
 
   it("should return nice ticks on multiple intervals", () => {
     const ticker = new MonthsTicker({months: [3, 9]})
-    const ticks = ticker.get_ticks_no_defaults(Date.UTC(2000, 0, 1), Date.UTC(2002, 0, 1), null, 5)
+    const ticks = ticker.get_ticks_no_defaults(Date.UTC(2000, 0, 1), Date.UTC(2002, 0, 1), NaN, 5)
     const expected_major = [Date.UTC(2000, 3, 1), Date.UTC(2000, 9, 1), Date.UTC(2001, 3, 1), Date.UTC(2001, 9, 1)]
     expect(ticks.major).to.be.equal(expected_major)
     expect(ticks.minor).to.be.equal([])

--- a/bokehjs/test/unit/models/tickers/years_ticker.ts
+++ b/bokehjs/test/unit/models/tickers/years_ticker.ts
@@ -12,7 +12,7 @@ describe("YearsTicker Model", () => {
 
   it("should return nice ticks on year intervals", () => {
     const ticker = new YearsTicker()
-    const ticks = ticker.get_ticks_no_defaults(Date.UTC(2000, 0, 1), Date.UTC(2005, 0, 1), null, 5)
+    const ticks = ticker.get_ticks_no_defaults(Date.UTC(2000, 0, 1), Date.UTC(2005, 0, 1), NaN, 5)
     const expected_major = [2000, 2001, 2002, 2003, 2004, 2005].map((year) => Date.UTC(year, 0, 1))
     expect(ticks.major).to.be.equal(expected_major)
     expect(ticks.minor).to.be.equal([])
@@ -20,7 +20,7 @@ describe("YearsTicker Model", () => {
 
   it("should return nice ticks on multi year intervals", () => {
     const ticker = new YearsTicker()
-    const ticks = ticker.get_ticks_no_defaults(Date.UTC(1900, 0, 1), Date.UTC(2000, 0, 1), null, 5)
+    const ticks = ticker.get_ticks_no_defaults(Date.UTC(1900, 0, 1), Date.UTC(2000, 0, 1), NaN, 5)
     const expected_major = [1900, 1920, 1940, 1960, 1980, 2000].map((year) => Date.UTC(year, 0, 1))
     expect(ticks.major).to.be.equal(expected_major)
     expect(ticks.minor).to.be.equal([])


### PR DESCRIPTION
Most changes should be self evident (one commit per change class). One thing that needs some explanation is making `Ticker<T>` non-generic. This has been an artifact from early transition period to TypeScript. Retrospectively treating models as generic was an obviously wrong choice, and the information about types (primarily `number` for continuous case and `Factor` for categorical) is now embedded within the class structure in various ways (this will have to be unified at some point across relevant models). 