### PR TITLE
AutocompleteInput: allow user-defined value

### DIFF
--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -295,7 +295,7 @@ class AutocompleteInput(TextInput):
 
     case_sensitive = Bool(default=True, help="""Enable or disable case sensitivity""")
 
-    restrict_value = Bool(default=True, help="""
+    strict = Bool(default=True, help="""
     Set to False in order to allow users to enter text that is not present in the list of completion strings.
     """)
 

--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -295,7 +295,7 @@ class AutocompleteInput(TextInput):
 
     case_sensitive = Bool(default=True, help="""Enable or disable case sensitivity""")
 
-    strict = Bool(default=True, help="""
+    restrict = Bool(default=True, help="""
     Set to False in order to allow users to enter text that is not present in the list of completion strings.
     """)
 

--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -295,6 +295,10 @@ class AutocompleteInput(TextInput):
 
     case_sensitive = Bool(default=True, help="""Enable or disable case sensitivity""")
 
+    restrict_value = Bool(default=True, help="""
+    Set to False in order to allow users to enter text that is not present in the list of completion strings.
+    """)
+
 
 class Select(InputWidget):
     ''' Single-select widget.

--- a/bokehjs/src/lib/models/widgets/autocomplete_input.ts
+++ b/bokehjs/src/lib/models/widgets/autocomplete_input.ts
@@ -133,6 +133,10 @@ export class AutocompleteInputView extends TextInputView {
       default: {
         const value = this.input_el.value
 
+        if (! this.model.restrict_value) {
+          this.model.value = this.input_el.value
+        }
+
         if (value.length < this.model.min_characters) {
           this._hide_menu()
           return
@@ -171,6 +175,7 @@ export namespace AutocompleteInput {
     completions: p.Property<string[]>
     min_characters: p.Property<number>
     case_sensitive: p.Property<boolean>
+    restrict_value: p.Property<boolean>
   }
 }
 
@@ -191,6 +196,7 @@ export class AutocompleteInput extends TextInput {
       completions:    [ Array(String), [] ],
       min_characters: [ Int, 2 ],
       case_sensitive: [ Boolean, true ],
+      restrict_value: [ Boolean, true],
     }))
   }
 }

--- a/bokehjs/src/lib/models/widgets/autocomplete_input.ts
+++ b/bokehjs/src/lib/models/widgets/autocomplete_input.ts
@@ -43,6 +43,7 @@ export class AutocompleteInputView extends TextInputView {
       this.input_el.focus()
       this._hide_menu()
     }
+    super.change_input()
   }
 
   protected _update_completions(completions: string[]): void {
@@ -132,10 +133,6 @@ export class AutocompleteInputView extends TextInputView {
       }
       default: {
         const value = this.input_el.value
-
-        if (!this.model.strict) {
-          this.model.value = this.input_el.value
-        }
 
         if (value.length < this.model.min_characters) {
           this._hide_menu()

--- a/bokehjs/src/lib/models/widgets/autocomplete_input.ts
+++ b/bokehjs/src/lib/models/widgets/autocomplete_input.ts
@@ -43,7 +43,10 @@ export class AutocompleteInputView extends TextInputView {
       this.input_el.focus()
       this._hide_menu()
     }
-    super.change_input()
+
+    if (!this.model.restrict) {
+      super.change_input()
+    }
   }
 
   protected _update_completions(completions: string[]): void {
@@ -172,7 +175,7 @@ export namespace AutocompleteInput {
     completions: p.Property<string[]>
     min_characters: p.Property<number>
     case_sensitive: p.Property<boolean>
-    strict: p.Property<boolean>
+    restrict: p.Property<boolean>
   }
 }
 
@@ -193,7 +196,7 @@ export class AutocompleteInput extends TextInput {
       completions:    [ Array(String), [] ],
       min_characters: [ Int, 2 ],
       case_sensitive: [ Boolean, true ],
-      strict: [ Boolean, true ],
+      restrict: [ Boolean, true ],
     }))
   }
 }

--- a/bokehjs/src/lib/models/widgets/autocomplete_input.ts
+++ b/bokehjs/src/lib/models/widgets/autocomplete_input.ts
@@ -133,7 +133,7 @@ export class AutocompleteInputView extends TextInputView {
       default: {
         const value = this.input_el.value
 
-        if (! this.model.restrict_value) {
+        if (!this.model.strict) {
           this.model.value = this.input_el.value
         }
 
@@ -175,7 +175,7 @@ export namespace AutocompleteInput {
     completions: p.Property<string[]>
     min_characters: p.Property<number>
     case_sensitive: p.Property<boolean>
-    restrict_value: p.Property<boolean>
+    strict: p.Property<boolean>
   }
 }
 
@@ -196,7 +196,7 @@ export class AutocompleteInput extends TextInput {
       completions:    [ Array(String), [] ],
       min_characters: [ Int, 2 ],
       case_sensitive: [ Boolean, true ],
-      restrict_value: [ Boolean, true],
+      strict: [ Boolean, true ],
     }))
   }
 }

--- a/tests/integration/widgets/test_autocomplete_input.py
+++ b/tests/integration/widgets/test_autocomplete_input.py
@@ -240,15 +240,15 @@ class Test_AutocompleteInput:
 
         assert page.has_no_console_errors()
 
-    def test_restrict_value(self, bokeh_model_page) -> None:
-        # restrict_value=True by default
-        text_input = AutocompleteInput(title="title", css_classes=["foo"], completions = ["100001", "aAaaaa", "aAaBbb", "AAAaAA", "aAaBbB"], restrict_value=False)
+    def test_strict(self, bokeh_model_page) -> None:
+        # strict=True by default
+        text_input = AutocompleteInput(title="title", css_classes=["foo"], completions = ["100001", "aAaaaa", "aAaBbb", "AAAaAA", "aAaBbB"], strict=False)
 
         page = bokeh_model_page(text_input)
 
         el = page.driver.find_element_by_css_selector('.foo input')
         text = "not in completions"
-        enter_text_in_element(page.driver, el, text, click=2, enter=False)
+        enter_text_in_element(page.driver, el, text, click=2, enter=True)
 
         assert text_input.value == text
         assert page.has_no_console_errors()

--- a/tests/integration/widgets/test_autocomplete_input.py
+++ b/tests/integration/widgets/test_autocomplete_input.py
@@ -240,9 +240,9 @@ class Test_AutocompleteInput:
 
         assert page.has_no_console_errors()
 
-    def test_strict(self, bokeh_model_page) -> None:
-        """Test effect of 'strict=False' with explicit JS callback"""
-        text_input = AutocompleteInput(css_classes=["foo"], completions = ["aAaBbb", "aAaBbB"], strict=False)
+    def test_restrict(self, bokeh_model_page) -> None:
+        """Test effect of 'restrict=False' with explicit JS callback"""
+        text_input = AutocompleteInput(css_classes=["foo"], completions = ["aAaBbb", "aAaBbB"], restrict=False)
         text_input.js_on_change('value', CustomJS(code=RECORD("value", "cb_obj.value")))
 
         page = bokeh_model_page(text_input)
@@ -256,9 +256,9 @@ class Test_AutocompleteInput:
         assert page.has_no_console_errors()
 
 
-    def test_server_strict(self, bokeh_server_page) -> None:
-        """Test effect of 'strict=False' without explicit callback."""
-        text_input = AutocompleteInput(css_classes=["foo"], completions = ["aAaBbb", "aAaBbB"], strict=False)
+    def test_server_restrict(self, bokeh_server_page) -> None:
+        """Test effect of 'restrict=False' without explicit callback."""
+        text_input = AutocompleteInput(css_classes=["foo"], completions = ["aAaBbb", "aAaBbB"], restrict=False)
 
         def add_autocomplete(doc):
             # note: for some reason, bokeh_server_page requires a 'canvas' in the document

--- a/tests/integration/widgets/test_autocomplete_input.py
+++ b/tests/integration/widgets/test_autocomplete_input.py
@@ -15,8 +15,10 @@ import pytest ; pytest
 # Imports
 #-----------------------------------------------------------------------------
 
-# External imports
+# Standard library imports
 import time
+
+# External imports
 from flaky import flaky
 from selenium.webdriver.common.keys import Keys
 
@@ -271,7 +273,7 @@ class Test_AutocompleteInput:
         el = page.driver.find_element_by_css_selector('.foo input')
         text = "not in completions"
         enter_text_in_element(page.driver, el, text, click=1, enter=True)
-        
+
         # without wait time, text_input.value is incomplete
         time.sleep(0.1)
         assert text_input.value == text

--- a/tests/integration/widgets/test_autocomplete_input.py
+++ b/tests/integration/widgets/test_autocomplete_input.py
@@ -15,9 +15,6 @@ import pytest ; pytest
 # Imports
 #-----------------------------------------------------------------------------
 
-# Standard library imports
-import time
-
 # External imports
 from flaky import flaky
 from selenium.webdriver.common.keys import Keys
@@ -274,8 +271,6 @@ class Test_AutocompleteInput:
         text = "not in completions"
         enter_text_in_element(page.driver, el, text, click=1, enter=True)
 
-        # without wait time, text_input.value is incomplete
-        time.sleep(0.1)
         assert text_input.value == text
         assert page.has_no_console_errors()
 

--- a/tests/integration/widgets/test_autocomplete_input.py
+++ b/tests/integration/widgets/test_autocomplete_input.py
@@ -240,6 +240,19 @@ class Test_AutocompleteInput:
 
         assert page.has_no_console_errors()
 
+    def test_restrict_value(self, bokeh_model_page) -> None:
+        # restrict_value=True by default
+        text_input = AutocompleteInput(title="title", css_classes=["foo"], completions = ["100001", "aAaaaa", "aAaBbb", "AAAaAA", "aAaBbB"], restrict_value=False)
+
+        page = bokeh_model_page(text_input)
+
+        el = page.driver.find_element_by_css_selector('.foo input')
+        text = "not in completions"
+        enter_text_in_element(page.driver, el, text, click=2, enter=False)
+
+        assert text_input.value == text
+        assert page.has_no_console_errors()
+
     def test_arrow_cannot_escape_menu(self, bokeh_model_page) -> None:
         text_input = AutocompleteInput(title="title", css_classes=["foo"], completions = ["100001", "12344556", "12344557", "3194567289", "209374209374"])
 


### PR DESCRIPTION
- [x] issues: fixes #10295
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)

One of the main purposes of the AutocompleteInput widget is to select a
value from a long list (for short lists, one could use Select). However,
lists tend to become long when people keep adding to them.

Previously, AutocompleteInput would not accept text input that was not
present in the list of completions, thus excluding users from the
process of building the list.

This PR adds a `restrict_value` option (default: True), which allows
developers to lift the restriction of values to the list of completions.


P.S. While reading through the contributing guidelines, I noticed that they [recommend making a PR against the `master` branch](https://github.com/bokeh/bokeh/blob/branch-2.3/.github/CONTRIBUTING.md#creating-a-pull-request-pr), which does not exist.
