### PR TITLE
Fix the typo in the Autoload Scripts docs section

### DIFF
--- a/sphinx/source/docs/user_guide/embed.rst
+++ b/sphinx/source/docs/user_guide/embed.rst
@@ -431,7 +431,7 @@ on the server at `"some/path"`, from the document that has the plot embedded.
 
 .. note::
     The ``<script>`` tag loads a ``<div>`` in place, so it must be placed
-    under ``<head>``.
+    under ``<body>``.
 
 .. _userguide_embed_apps:
 


### PR DESCRIPTION
- [x] issues: fixes #10484
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
