### PR TITLE
Split off range management code from PlotCanvas

### DIFF
--- a/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
@@ -3,8 +3,15 @@ import {div, remove} from "core/dom"
 import {wgs84_mercator} from "core/util/projections"
 import {Context2d} from "core/util/canvas"
 import {GMapPlot} from "./gmap_plot"
-import {PlotView, RangeInfo} from "./plot_canvas"
+import {PlotView} from "./plot_canvas"
 import {FrameBox} from "../canvas/canvas"
+import {RangeInfo, RangeOptions} from "./range_manager"
+
+type GMapRangeInfo = RangeInfo & {
+  sdx?: number
+  sdy?: number
+  factor?: number
+}
 
 declare global {
   interface Window {
@@ -67,17 +74,17 @@ export class GMapPlotView extends PlotView {
     super.remove()
   }
 
-  update_range(range_info: RangeInfo & {sdx?: number, sdy?: number, factor?: number} | null): void {
+  update_range(range_info: GMapRangeInfo | null, options?: RangeOptions): void {
     // RESET -------------------------
     if (range_info == null) {
       this.map.setCenter({lat: this.initial_lat, lng: this.initial_lng})
       this.map.setOptions({zoom: this.initial_zoom})
-      super.update_range(null)
+      super.update_range(null, options)
 
     // PAN ----------------------------
     } else if (range_info.sdx != null || range_info.sdy != null) {
       this.map.panBy(range_info.sdx ?? 0, range_info.sdy ?? 0)
-      super.update_range(range_info)
+      super.update_range(range_info, options)
 
     // ZOOM ---------------------------
     } else if (range_info.factor != null) {
@@ -91,7 +98,7 @@ export class GMapPlotView extends PlotView {
 
       this.pause()
 
-      super.update_range(range_info)
+      super.update_range(range_info, options)
 
       const zoom_change = range_info.factor < 0 ?  -1 : 1
 

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -1,9 +1,7 @@
 import {CartesianFrame} from "../canvas/cartesian_frame"
 import {Canvas, CanvasView, FrameBox, CanvasLayer} from "../canvas/canvas"
-import {Range} from "../ranges/range"
-import {DataRange1d, Bounds} from "../ranges/data_range1d"
 import {Renderer, RendererView} from "../renderers/renderer"
-import {DataRenderer, DataRendererView} from "../renderers/data_renderer"
+import {DataRenderer} from "../renderers/data_renderer"
 import {Tool, ToolView} from "../tools/tool"
 import {Selection} from "../selections/selection"
 import {LayoutDOM, LayoutDOMView} from "../layouts/layout_dom"
@@ -14,7 +12,6 @@ import {Axis, AxisView} from "../axes/axis"
 import {ToolbarPanel} from "../annotations/toolbar_panel"
 
 import {Reset} from "core/bokeh_events"
-import {Interval} from "core/types"
 import {Signal0} from "core/signaling"
 import {build_view, build_views, remove_views} from "core/build_views"
 import {UIEvents} from "core/ui_events"
@@ -31,11 +28,7 @@ import {BorderLayout} from "core/layout/border"
 import {SidePanel} from "core/layout/side_panel"
 import {Row, Column} from "core/layout/grid"
 import {BBox} from "core/util/bbox"
-
-export type RangeInfo = {
-  xrs: Map<string, Interval>
-  yrs: Map<string, Interval>
-}
+import {RangeInfo, RangeOptions, RangeManager} from "./range_manager"
 
 export type StateInfo = {
   range?: RangeInfo
@@ -67,10 +60,10 @@ export class PlotView extends LayoutDOMView {
   protected _invalidated_painters: Set<RendererView> = new Set()
   protected _invalidate_all: boolean = true
 
+  protected _range_manager: RangeManager
 
-  protected _invalidate_dataranges: boolean = true
   set invalidate_dataranges(value: boolean) {
-    this._invalidate_dataranges = value
+    this._range_manager.invalidate_dataranges = value
   }
 
   state_changed: Signal0<this>
@@ -188,6 +181,9 @@ export class PlotView extends LayoutDOMView {
 
     this.state = {history: [], index: -1}
 
+    this.renderer_views = new Map()
+    this.tool_views = new Map()
+
     const {hidpi, output_backend} = this.model
     this.canvas = new Canvas({hidpi, output_backend})
 
@@ -199,6 +195,8 @@ export class PlotView extends LayoutDOMView {
       this.model.extra_x_ranges,
       this.model.extra_y_ranges,
     )
+
+    this._range_manager = new RangeManager(this)
 
     this.throttled_paint = throttle(() => this.repaint(), 1000/60)
 
@@ -212,9 +210,6 @@ export class PlotView extends LayoutDOMView {
       this._toolbar = new ToolbarPanel({toolbar})
       toolbar.toolbar_location = toolbar_location
     }
-
-    this.renderer_views = new Map()
-    this.tool_views = new Map()
   }
 
   async lazy_initialize(): Promise<void> {
@@ -226,7 +221,7 @@ export class PlotView extends LayoutDOMView {
     await this.build_renderer_views()
     await this.build_tool_views()
 
-    this.update_dataranges()
+    this._range_manager.update_dataranges()
     this.unpause(true)
 
     logger.debug("PlotView initialized")
@@ -381,80 +376,6 @@ export class PlotView extends LayoutDOMView {
       callback(visible)
   }
 
-  update_dataranges(): void {
-    // Update any DataRange1ds here
-    const bounds: Bounds = new Map()
-    const log_bounds: Bounds = new Map()
-
-    let calculate_log_bounds = false
-    for (const [, xr] of this.frame.x_ranges) {
-      if (xr instanceof DataRange1d && xr.scale_hint == "log")
-        calculate_log_bounds = true
-    }
-    for (const [, yr] of this.frame.y_ranges) {
-      if (yr instanceof DataRange1d && yr.scale_hint == "log")
-        calculate_log_bounds = true
-    }
-
-    for (const [renderer, renderer_view] of this.renderer_views) {
-      if (renderer_view instanceof DataRendererView) {
-        const bds = renderer_view.glyph_view.bounds()
-        if (bds != null)
-          bounds.set(renderer, bds)
-
-        if (calculate_log_bounds) {
-          const log_bds = renderer_view.glyph_view.log_bounds()
-          if (log_bds != null)
-            log_bounds.set(renderer, log_bds)
-        }
-      }
-    }
-
-    let follow_enabled = false
-    let has_bounds = false
-
-    const {width, height} = this.frame.bbox
-    let r: number | undefined
-    if (this.model.match_aspect !== false && width != 0 && height != 0)
-      r = (1/this.model.aspect_scale)*(width/height)
-
-    for (const [, xr] of this.frame.x_ranges) {
-      if (xr instanceof DataRange1d) {
-        const bounds_to_use = xr.scale_hint == "log" ? log_bounds : bounds
-        xr.update(bounds_to_use, 0, this.model, r)
-        if (xr.follow) {
-          follow_enabled = true
-        }
-      }
-      if (xr.bounds != null)
-        has_bounds = true
-    }
-
-    for (const [, yr] of this.frame.y_ranges) {
-      if (yr instanceof DataRange1d) {
-        const bounds_to_use = yr.scale_hint == "log" ? log_bounds : bounds
-        yr.update(bounds_to_use, 1, this.model, r)
-        if (yr.follow) {
-          follow_enabled = true
-        }
-      }
-      if (yr.bounds != null)
-        has_bounds = true
-    }
-
-    if (follow_enabled && has_bounds) {
-      logger.warn('Follow enabled so bounds are unset.')
-      for (const [, xr] of this.frame.x_ranges) {
-        xr.bounds = null
-      }
-      for (const [, yr] of this.frame.y_ranges) {
-        yr.bounds = null
-      }
-    }
-
-    this._invalidate_dataranges = false
-  }
-
   push_state(type: string, new_info: Partial<StateInfo>): void {
     const {history, index} = this.state
 
@@ -497,6 +418,16 @@ export class PlotView extends LayoutDOMView {
     }
   }
 
+  update_range(range_info: RangeInfo | null, options?: RangeOptions): void {
+    this.pause()
+    this._range_manager.update(range_info, options)
+    this.unpause()
+  }
+
+  reset_range(): void {
+    this.update_range(null)
+  }
+
   protected _do_state_change(index: number): void {
     const info = this.state.history[index] != null ? this.state.history[index].info : this._initial_state_info
 
@@ -536,162 +467,6 @@ export class PlotView extends LayoutDOMView {
 
   reset_selection(): void {
     this.update_selection(null)
-  }
-
-  protected _update_ranges_together(range_info_iter: [Range, Interval][]): void {
-    // Get weight needed to scale the diff of the range to honor interval limits
-    let weight = 1.0
-    for (const [rng, range_info] of range_info_iter) {
-      weight = Math.min(weight, this._get_weight_to_constrain_interval(rng, range_info))
-    }
-    // Apply shared weight to all ranges
-    if (weight < 1) {
-      for (const [rng, range_info] of range_info_iter) {
-        range_info.start = weight*range_info.start + (1 - weight)*rng.start
-        range_info.end = weight*range_info.end + (1 - weight)*rng.end
-      }
-    }
-  }
-
-  protected _update_ranges_individually(range_info_iter: [Range, Interval][],
-                                        is_panning: boolean, is_scrolling: boolean, maintain_focus: boolean): void {
-    let hit_bound = false
-    for (const [rng, range_info] of range_info_iter) {
-
-      // Limit range interval first. Note that for scroll events,
-      // the interval has already been limited for all ranges simultaneously
-      if (!is_scrolling) {
-        const weight = this._get_weight_to_constrain_interval(rng, range_info)
-        if (weight < 1) {
-          range_info.start = weight*range_info.start + (1 - weight)*rng.start
-          range_info.end = weight*range_info.end + (1 - weight)*rng.end
-        }
-      }
-
-      // Prevent range from going outside limits
-      // Also ensure that range keeps the same delta when panning/scrolling
-      if (rng.bounds != null && rng.bounds != "auto") { // check `auto` for type-checking purpose
-        const [min, max] = rng.bounds
-        const new_interval = Math.abs(range_info.end - range_info.start)
-
-        if (rng.is_reversed) {
-          if (min != null) {
-            if (min >= range_info.end) {
-              hit_bound = true
-              range_info.end = min
-              if (is_panning || is_scrolling) {
-                range_info.start = min + new_interval
-              }
-            }
-          }
-          if (max != null) {
-            if (max <= range_info.start) {
-              hit_bound = true
-              range_info.start = max
-              if (is_panning || is_scrolling) {
-                range_info.end = max - new_interval
-              }
-            }
-          }
-        } else {
-          if (min != null) {
-            if (min >= range_info.start) {
-              hit_bound = true
-              range_info.start = min
-              if (is_panning || is_scrolling) {
-                range_info.end = min + new_interval
-              }
-            }
-          }
-          if (max != null) {
-            if (max <= range_info.end) {
-              hit_bound = true
-              range_info.end = max
-              if (is_panning || is_scrolling) {
-                range_info.start = max - new_interval
-              }
-            }
-          }
-        }
-      }
-    }
-
-    // Cancel the event when hitting a bound while scrolling. This ensures that
-    // the scroll-zoom tool maintains its focus position. Setting `maintain_focus`
-    // to false results in a more "gliding" behavior, allowing one to
-    // zoom out more smoothly, at the cost of losing the focus position.
-    if (is_scrolling && hit_bound && maintain_focus)
-      return
-
-    for (const [rng, range_info] of range_info_iter) {
-      rng.have_updated_interactively = true
-      if (rng.start != range_info.start || rng.end != range_info.end)
-        rng.setv(range_info)
-    }
-  }
-
-  protected _get_weight_to_constrain_interval(rng: Range, range_info: Interval): number {
-    // Get the weight by which a range-update can be applied
-    // to still honor the interval limits (including the implicit
-    // max interval imposed by the bounds)
-    const {min_interval} = rng
-    let {max_interval} = rng
-
-    // Express bounds as a max_interval. By doing this, the application of
-    // bounds and interval limits can be applied independent from each-other.
-    if (rng.bounds != null && rng.bounds != "auto") { // check `auto` for type-checking purpose
-      const [min, max] = rng.bounds
-      if (min != null && max != null) {
-        const max_interval2 = Math.abs(max - min)
-        max_interval = max_interval != null ? Math.min(max_interval, max_interval2) : max_interval2
-      }
-    }
-
-    let weight = 1.0
-    if (min_interval != null || max_interval != null) {
-      const old_interval = Math.abs(rng.end - rng.start)
-      const new_interval = Math.abs(range_info.end - range_info.start)
-      if (min_interval != null && min_interval > 0 && new_interval < min_interval) {
-        weight = (old_interval - min_interval) / (old_interval - new_interval)
-      }
-      if (max_interval != null && max_interval > 0 && new_interval > max_interval) {
-        weight = (max_interval - old_interval) / (new_interval - old_interval)
-      }
-      weight = Math.max(0.0, Math.min(1.0, weight))
-    }
-    return weight
-  }
-
-  update_range(range_info: RangeInfo | null,
-               is_panning: boolean = false, is_scrolling: boolean = false, maintain_focus: boolean = true): void {
-    this.pause()
-    const {x_ranges, y_ranges} = this.frame
-    if (range_info == null) {
-      for (const [, range] of x_ranges) {
-        range.reset()
-      }
-      for (const [, range] of y_ranges) {
-        range.reset()
-      }
-      this.update_dataranges()
-    } else {
-      const range_info_iter: [Range, Interval][] = []
-      for (const [name, range] of x_ranges) {
-        range_info_iter.push([range, range_info.xrs.get(name)!])
-      }
-      for (const [name, range] of y_ranges) {
-        range_info_iter.push([range, range_info.yrs.get(name)!])
-      }
-      if (is_scrolling) {
-        this._update_ranges_together(range_info_iter)   // apply interval bounds while keeping aspect
-      }
-      this._update_ranges_individually(range_info_iter, is_panning, is_scrolling, maintain_focus)
-    }
-    this.unpause()
-  }
-
-  reset_range(): void {
-    this.update_range(null)
   }
 
   protected _invalidate_layout(): void {
@@ -764,37 +539,6 @@ export class PlotView extends LayoutDOMView {
     this.connect(this.model.reset, () => this.reset())
   }
 
-  set_initial_range(): void {
-    // check for good values for ranges before setting initial range
-    let good_vals = true
-    const {x_ranges, y_ranges} = this.frame
-    const xrs: Map<string, Interval> = new Map()
-    const yrs: Map<string, Interval> = new Map()
-    for (const [name, range] of x_ranges) {
-      const {start, end} = range
-      if (start == null || end == null || isNaN(start + end)) {
-        good_vals = false
-        break
-      }
-      xrs.set(name, {start, end})
-    }
-    if (good_vals) {
-      for (const [name, range] of y_ranges) {
-        const {start, end} = range
-        if (start == null || end == null || isNaN(start + end)) {
-          good_vals = false
-          break
-        }
-        yrs.set(name, {start, end})
-      }
-    }
-    if (good_vals) {
-      this._initial_state_info.range = {xrs, yrs}
-      logger.debug("initial ranges set")
-    } else
-      logger.warn('could not set initial ranges')
-  }
-
   has_finished(): boolean {
     if (!super.has_finished())
       return false
@@ -823,7 +567,7 @@ export class PlotView extends LayoutDOMView {
 
     if (this.model.match_aspect !== false) {
       this.pause()
-      this.update_dataranges()
+      this._range_manager.update_dataranges()
       this.unpause(true)
     }
 
@@ -874,8 +618,8 @@ export class PlotView extends LayoutDOMView {
         document.interactive_stop()
     }
 
-    if (this._invalidate_dataranges) {
-      this.update_dataranges()
+    if (this._range_manager.invalidate_dataranges) {
+      this._range_manager.update_dataranges()
     }
 
     let do_primary = false
@@ -930,8 +674,9 @@ export class PlotView extends LayoutDOMView {
       overlays.finish()
     }
 
-    if (this._initial_state_info.range == null)
-      this.set_initial_range()
+    if (this._initial_state_info.range == null) {
+      this._initial_state_info.range = this._range_manager.compute_initial() ?? undefined
+    }
 
     this._needs_paint = false
   }

--- a/bokehjs/src/lib/models/plots/range_manager.ts
+++ b/bokehjs/src/lib/models/plots/range_manager.ts
@@ -1,0 +1,287 @@
+import {Range} from "../ranges/range"
+import {DataRange1d, Bounds} from "../ranges/data_range1d"
+import {CartesianFrame} from "../canvas/cartesian_frame"
+import type {PlotView} from "./plot_canvas"
+import {Interval} from "core/types"
+import {logger} from "core/logging"
+
+export type RangeInfo = {
+  xrs: Map<string, Interval>
+  yrs: Map<string, Interval>
+}
+
+export type RangeOptions = {
+  panning?: boolean
+  scrolling?: boolean
+  maintain_focus?: boolean
+}
+
+export class RangeManager {
+  constructor(readonly parent: PlotView) {}
+
+  get frame(): CartesianFrame {
+    return this.parent.frame
+  }
+
+  invalidate_dataranges: boolean = true
+
+  update(range_info: RangeInfo | null, options?: RangeOptions): void {
+    const {x_ranges, y_ranges} = this.frame
+    if (range_info == null) {
+      for (const [, range] of x_ranges) {
+        range.reset()
+      }
+      for (const [, range] of y_ranges) {
+        range.reset()
+      }
+      this.update_dataranges()
+    } else {
+      const range_info_iter: [Range, Interval][] = []
+      for (const [name, range] of x_ranges) {
+        range_info_iter.push([range, range_info.xrs.get(name)!])
+      }
+      for (const [name, range] of y_ranges) {
+        range_info_iter.push([range, range_info.yrs.get(name)!])
+      }
+      if (options?.scrolling) {
+        this._update_ranges_together(range_info_iter)   // apply interval bounds while keeping aspect
+      }
+      this._update_ranges_individually(range_info_iter, options)
+    }
+  }
+
+  reset(): void {
+    this.update(null)
+  }
+
+  update_dataranges(): void {
+    // Update any DataRange1ds here
+    const bounds: Bounds = new Map()
+    const log_bounds: Bounds = new Map()
+
+    let calculate_log_bounds = false
+    for (const [, xr] of this.frame.x_ranges) {
+      if (xr instanceof DataRange1d && xr.scale_hint == "log")
+        calculate_log_bounds = true
+    }
+    for (const [, yr] of this.frame.y_ranges) {
+      if (yr instanceof DataRange1d && yr.scale_hint == "log")
+        calculate_log_bounds = true
+    }
+
+    for (const renderer of this.parent.model.data_renderers) {
+      const renderer_view = this.parent.renderer_view(renderer)!
+
+      const bds = renderer_view.glyph_view.bounds()
+      if (bds != null)
+        bounds.set(renderer, bds)
+
+      if (calculate_log_bounds) {
+        const log_bds = renderer_view.glyph_view.log_bounds()
+        if (log_bds != null)
+          log_bounds.set(renderer, log_bds)
+      }
+    }
+
+    let follow_enabled = false
+    let has_bounds = false
+
+    const {width, height} = this.frame.bbox
+    let r: number | undefined
+    if (this.parent.model.match_aspect !== false && width != 0 && height != 0)
+      r = (1/this.parent.model.aspect_scale)*(width/height)
+
+    for (const [, xr] of this.frame.x_ranges) {
+      if (xr instanceof DataRange1d) {
+        const bounds_to_use = xr.scale_hint == "log" ? log_bounds : bounds
+        xr.update(bounds_to_use, 0, this.parent.model, r)
+        if (xr.follow) {
+          follow_enabled = true
+        }
+      }
+      if (xr.bounds != null)
+        has_bounds = true
+    }
+
+    for (const [, yr] of this.frame.y_ranges) {
+      if (yr instanceof DataRange1d) {
+        const bounds_to_use = yr.scale_hint == "log" ? log_bounds : bounds
+        yr.update(bounds_to_use, 1, this.parent.model, r)
+        if (yr.follow) {
+          follow_enabled = true
+        }
+      }
+      if (yr.bounds != null)
+        has_bounds = true
+    }
+
+    if (follow_enabled && has_bounds) {
+      logger.warn('Follow enabled so bounds are unset.')
+      for (const [, xr] of this.frame.x_ranges) {
+        xr.bounds = null
+      }
+      for (const [, yr] of this.frame.y_ranges) {
+        yr.bounds = null
+      }
+    }
+
+    this.invalidate_dataranges = false
+  }
+
+  compute_initial(): RangeInfo | null {
+    // check for good values for ranges before setting initial range
+    let good_vals = true
+    const {x_ranges, y_ranges} = this.frame
+    const xrs: Map<string, Interval> = new Map()
+    const yrs: Map<string, Interval> = new Map()
+    for (const [name, range] of x_ranges) {
+      const {start, end} = range
+      if (start == null || end == null || isNaN(start + end)) {
+        good_vals = false
+        break
+      }
+      xrs.set(name, {start, end})
+    }
+    if (good_vals) {
+      for (const [name, range] of y_ranges) {
+        const {start, end} = range
+        if (start == null || end == null || isNaN(start + end)) {
+          good_vals = false
+          break
+        }
+        yrs.set(name, {start, end})
+      }
+    }
+    if (good_vals)
+      return {xrs, yrs}
+    else {
+      logger.warn('could not set initial ranges')
+      return null
+    }
+  }
+
+  protected _update_ranges_together(range_info_iter: [Range, Interval][]): void {
+    // Get weight needed to scale the diff of the range to honor interval limits
+    let weight = 1.0
+    for (const [rng, range_info] of range_info_iter) {
+      weight = Math.min(weight, this._get_weight_to_constrain_interval(rng, range_info))
+    }
+    // Apply shared weight to all ranges
+    if (weight < 1) {
+      for (const [rng, range_info] of range_info_iter) {
+        range_info.start = weight*range_info.start + (1 - weight)*rng.start
+        range_info.end = weight*range_info.end + (1 - weight)*rng.end
+      }
+    }
+  }
+
+  protected _update_ranges_individually(range_info_iter: [Range, Interval][], options?: RangeOptions): void {
+    const panning = !!options?.panning
+    const scrolling = !!options?.scrolling
+
+    let hit_bound = false
+    for (const [rng, range_info] of range_info_iter) {
+      // Limit range interval first. Note that for scroll events,
+      // the interval has already been limited for all ranges simultaneously
+      if (!scrolling) {
+        const weight = this._get_weight_to_constrain_interval(rng, range_info)
+        if (weight < 1) {
+          range_info.start = weight*range_info.start + (1 - weight)*rng.start
+          range_info.end = weight*range_info.end + (1 - weight)*rng.end
+        }
+      }
+
+      // Prevent range from going outside limits
+      // Also ensure that range keeps the same delta when panning/scrolling
+      if (rng.bounds != null && rng.bounds != "auto") { // check `auto` for type-checking purpose
+        const [min, max] = rng.bounds
+        const new_interval = Math.abs(range_info.end - range_info.start)
+
+        if (rng.is_reversed) {
+          if (min != null) {
+            if (min >= range_info.end) {
+              hit_bound = true
+              range_info.end = min
+              if (panning || scrolling) {
+                range_info.start = min + new_interval
+              }
+            }
+          }
+          if (max != null) {
+            if (max <= range_info.start) {
+              hit_bound = true
+              range_info.start = max
+              if (panning || scrolling) {
+                range_info.end = max - new_interval
+              }
+            }
+          }
+        } else {
+          if (min != null) {
+            if (min >= range_info.start) {
+              hit_bound = true
+              range_info.start = min
+              if (panning || scrolling) {
+                range_info.end = min + new_interval
+              }
+            }
+          }
+          if (max != null) {
+            if (max <= range_info.end) {
+              hit_bound = true
+              range_info.end = max
+              if (panning || scrolling) {
+                range_info.start = max - new_interval
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Cancel the event when hitting a bound while scrolling. This ensures that
+    // the scroll-zoom tool maintains its focus position. Setting `maintain_focus`
+    // to false results in a more "gliding" behavior, allowing one to
+    // zoom out more smoothly, at the cost of losing the focus position.
+    if (scrolling && hit_bound && options?.maintain_focus)
+      return
+
+    for (const [rng, range_info] of range_info_iter) {
+      rng.have_updated_interactively = true
+      if (rng.start != range_info.start || rng.end != range_info.end)
+        rng.setv(range_info)
+    }
+  }
+
+  protected _get_weight_to_constrain_interval(rng: Range, range_info: Interval): number {
+    // Get the weight by which a range-update can be applied
+    // to still honor the interval limits (including the implicit
+    // max interval imposed by the bounds)
+    const {min_interval} = rng
+    let {max_interval} = rng
+
+    // Express bounds as a max_interval. By doing this, the application of
+    // bounds and interval limits can be applied independent from each-other.
+    if (rng.bounds != null && rng.bounds != "auto") { // check `auto` for type-checking purpose
+      const [min, max] = rng.bounds
+      if (min != null && max != null) {
+        const max_interval2 = Math.abs(max - min)
+        max_interval = max_interval != null ? Math.min(max_interval, max_interval2) : max_interval2
+      }
+    }
+
+    let weight = 1.0
+    if (min_interval != null || max_interval != null) {
+      const old_interval = Math.abs(rng.end - rng.start)
+      const new_interval = Math.abs(range_info.end - range_info.start)
+      if (min_interval != null && min_interval > 0 && new_interval < min_interval) {
+        weight = (old_interval - min_interval) / (old_interval - new_interval)
+      }
+      if (max_interval != null && max_interval > 0 && new_interval > max_interval) {
+        weight = (max_interval - old_interval) / (new_interval - old_interval)
+      }
+      weight = Math.max(0.0, Math.min(1.0, weight))
+    }
+    return weight
+  }
+}

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -131,7 +131,7 @@ export class GlyphRendererView extends DataRendererView {
       this.connect(this.model.data_source.inspect, () => this.request_render())
     this.connect(this.model.properties.view.change, () => this.set_data())
     this.connect(this.model.view.change, () => this.set_data())
-    this.connect(this.model.properties.visible.change, () => this.plot_view.update_dataranges())
+    this.connect(this.model.properties.visible.change, () => this.plot_view.invalidate_dataranges = true)
 
     const {x_ranges, y_ranges} = this.plot_view.frame
 

--- a/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
@@ -17,7 +17,7 @@ export class ZoomBaseToolView extends ActionToolView {
     const zoom_info = scale_range(frame, this.model.sign * this.model.factor, h_axis, v_axis)
 
     this.plot_view.push_state('zoom_out', {range: zoom_info})
-    this.plot_view.update_range(zoom_info, false, true)
+    this.plot_view.update_range(zoom_info, {scrolling: true})
 
     if (this.model.document)
       this.model.document.interactive_start(this.plot_model)

--- a/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
@@ -114,7 +114,7 @@ export class PanToolView extends GestureToolView {
     const yrs = update_ranges(y_scales, sy0, sy1)
 
     this.pan_info = {xrs, yrs, sdx, sdy}
-    this.plot_view.update_range(this.pan_info, true)
+    this.plot_view.update_range(this.pan_info, {panning: true})
   }
 }
 

--- a/bokehjs/src/lib/models/tools/gestures/wheel_pan_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/wheel_pan_tool.ts
@@ -64,7 +64,7 @@ export class WheelPanToolView extends GestureToolView {
     // of 'dimensions' is ignored.
     const pan_info = {xrs, yrs, factor}
     this.plot_view.push_state('wheel_pan', {range: pan_info})
-    this.plot_view.update_range(pan_info, false, true)
+    this.plot_view.update_range(pan_info, {scrolling: true})
 
     if (this.model.document != null)
       this.model.document.interactive_start(this.plot_model)

--- a/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
@@ -45,7 +45,9 @@ export class WheelZoomToolView extends GestureToolView {
     const zoom_info = scale_range(frame, factor, h_axis, v_axis, {x: sx, y: sy})
 
     this.plot_view.push_state('wheel_zoom', {range: zoom_info})
-    this.plot_view.update_range(zoom_info, false, true, this.model.maintain_focus)
+
+    const {maintain_focus} = this.model
+    this.plot_view.update_range(zoom_info, {scrolling: true, maintain_focus})
 
     if (this.model.document != null)
       this.model.document.interactive_start(this.plot_model)


### PR DESCRIPTION
Range management is a complex piece of logic that takes 25% of `PlotCanvas`' implementation, and as such deserves to be treated as an independent unit, thus this refactoring. This PR is the first step out of many towards the goal of making plots composable, allowing multiple plots per canvas, plots-in-plots, implementing color bar in terms of plot building blocks (layout, frame, glyphs, axes), etc. Code and module structure should be treated as WIP, which I will be refining as work progresses (within 2.3 timeframe).