### PR TITLE
Strictly type View.serializable_state()

### DIFF
--- a/bokehjs/src/lib/core/view.ts
+++ b/bokehjs/src/lib/core/view.ts
@@ -3,10 +3,17 @@ import {Property} from "./properties"
 import {Signal0, Signal, Slot, ISignalable} from "./signaling"
 import {StyleSheet, stylesheet} from "./dom"
 import {isArray} from "./util/types"
+import {Box} from "./types"
 
 import root_css from "styles/root.css"
 
 export type ViewOf<T extends HasProps> = T["__view_type__"]
+
+export type SerializableState = {
+  type: string
+  bbox?: Box
+  children?: SerializableState[]
+}
 
 export namespace View {
   export type Options = {
@@ -73,7 +80,7 @@ export class View implements ISignalable {
     return `${this.model.type}View(${this.model.id})`
   }
 
-  serializable_state(): {[key: string]: unknown} {
+  serializable_state(): SerializableState {
     return {type: this.model.type}
   }
 

--- a/bokehjs/src/lib/models/annotations/annotation.ts
+++ b/bokehjs/src/lib/models/annotations/annotation.ts
@@ -1,5 +1,6 @@
 import {SidePanel} from "core/layout/side_panel"
 import {Size} from "core/layout"
+import {SerializableState} from "core/view"
 import * as proj from "core/util/projections"
 import {extend} from "core/util/object"
 
@@ -51,7 +52,7 @@ export abstract class AnnotationView extends RendererView {
     return this.layout == null // TODO: change this, when center layout is fully implemented
   }
 
-  serializable_state(): {[key: string]: unknown} {
+  serializable_state(): SerializableState {
     const state = super.serializable_state()
     return this.layout == null ? state : {...state, bbox: this.layout.bbox.box}
   }

--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -7,6 +7,7 @@ import * as visuals from "core/visuals"
 import * as mixins from "core/property_mixins"
 import * as p from "core/properties"
 import {Arrayable} from "core/types"
+import {SerializableState} from "core/view"
 import {Side, TickLabelOrientation, SpatialUnits} from "core/enums"
 import {Size} from "core/layout"
 import {SidePanel, Orient} from "core/layout/side_panel"
@@ -490,7 +491,7 @@ export class AxisView extends GuideRendererView {
   }
   // }}}
 
-  serializable_state(): {[key: string]: unknown} {
+  serializable_state(): SerializableState {
     return {
       ...super.serializable_state(),
       bbox: this.layout.bbox.box,

--- a/bokehjs/src/lib/models/layouts/layout_dom.ts
+++ b/bokehjs/src/lib/models/layouts/layout_dom.ts
@@ -11,6 +11,7 @@ import {DOMView} from "core/dom_view"
 import {SizingPolicy, BoxSizing, Size, Layoutable} from "core/layout"
 import {bk_root} from "styles/root"
 import {CanvasLayer} from "../canvas/canvas"
+import {SerializableState} from "core/view"
 
 export abstract class LayoutDOMView extends DOMView {
   model: LayoutDOM
@@ -371,7 +372,7 @@ export abstract class LayoutDOMView extends DOMView {
     return composite
   }
 
-  serializable_state(): {[key: string]: unknown} {
+  serializable_state(): SerializableState {
     return {
       ...super.serializable_state(),
       bbox: this.layout.bbox.box,

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -21,6 +21,7 @@ import {UIEvents} from "core/ui_events"
 import {Visuals} from "core/visuals"
 import {logger} from "core/logging"
 import {Side, RenderLevel} from "core/enums"
+import {SerializableState} from "core/view"
 import {throttle} from "core/util/throttle"
 import {isArray} from "core/util/types"
 import {copy, reversed} from "core/util/array"
@@ -1013,11 +1014,11 @@ export class PlotView extends LayoutDOMView {
     return composite
   }
 
-  serializable_state(): {[key: string]: unknown} {
+  serializable_state(): SerializableState {
     const {children, ...state} = super.serializable_state()
     const renderers = this.get_renderer_views()
       .map((view) => view.serializable_state())
-      .filter((item) => "bbox" in item)
-    return {...state, children: [...(children as any), ...renderers]} // XXX
+      .filter((item) => item.bbox != null)
+    return {...state, children: [...children ?? [], ...renderers]}
   }
 }

--- a/bokehjs/test/framework.ts
+++ b/bokehjs/test/framework.ts
@@ -243,7 +243,7 @@ async function _run_test(suites: Suite[], test: Test): Promise<PartialResult> {
       const left = rect.left + window.pageXOffset - document.documentElement!.clientLeft
       const top = rect.top + window.pageYOffset - document.documentElement!.clientTop
       const bbox = {x: left, y: top, width: rect.width, height: rect.height}
-      const state = test.view.serializable_state() as any
+      const state = test.view.serializable_state()
       return {error, time, state, bbox}
     } catch (err: unknown) {
       error = err instanceof Error ? err : new Error(`${err}`)


### PR DESCRIPTION
Results in one fewer `as any` cast.
