### PR TITLE
AutocompleteInput: add more tests

### DIFF
--- a/tests/integration/widgets/test_autocomplete_input.py
+++ b/tests/integration/widgets/test_autocomplete_input.py
@@ -240,7 +240,25 @@ class Test_AutocompleteInput:
 
         assert page.has_no_console_errors()
 
-    def test_restrict(self, bokeh_model_page) -> None:
+    def test_server_restriction_to_list(self, bokeh_server_page) -> None:
+        """Test that input entered manually doesn't end up in the value."""
+        text_input = AutocompleteInput(css_classes=["foo"], completions = ["aAaBbb"], restrict=True)
+
+        def add_autocomplete(doc):
+            # note: for some reason, bokeh_server_page requires a 'canvas' in the document
+            plot = Plot()
+            doc.add_root(column(text_input,plot))
+
+        page = bokeh_server_page(add_autocomplete)
+
+        el = page.driver.find_element_by_css_selector('.foo input')
+        text = "not in completions"
+        enter_text_in_element(page.driver, el, text, click=1, enter=True)
+
+        assert text_input.value == ''
+        assert page.has_no_console_errors()
+
+    def test_no_restriction(self, bokeh_model_page) -> None:
         """Test effect of 'restrict=False' with explicit JS callback"""
         text_input = AutocompleteInput(css_classes=["foo"], completions = ["aAaBbb", "aAaBbB"], restrict=False)
         text_input.js_on_change('value', CustomJS(code=RECORD("value", "cb_obj.value")))
@@ -255,8 +273,7 @@ class Test_AutocompleteInput:
         assert results['value'] == text
         assert page.has_no_console_errors()
 
-
-    def test_server_restrict(self, bokeh_server_page) -> None:
+    def test_server_no_restriction(self, bokeh_server_page) -> None:
         """Test effect of 'restrict=False' without explicit callback."""
         text_input = AutocompleteInput(css_classes=["foo"], completions = ["aAaBbb", "aAaBbB"], restrict=False)
 


### PR DESCRIPTION
Add a test for restrict=True (default) ensuring that random text input
does not end up in the input.value

- [ ] issues: fixes #xxxx
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
