### PR TITLE
Restructure documentation landing page

### DIFF
--- a/ci/environment-test-3.6.yml
+++ b/ci/environment-test-3.6.yml
@@ -48,6 +48,9 @@ dependencies:
   - selenium >=3.8
   - scipy
   - sphinx
+  - pip
+  - pip:
+    - sphinx-panels
 
   # examples
   - flask >=1.0

--- a/ci/environment-test-3.7.yml
+++ b/ci/environment-test-3.7.yml
@@ -48,6 +48,9 @@ dependencies:
   - selenium >=3.8
   - scipy
   - sphinx
+  - pip
+  - pip:
+    - sphinx-panels
 
   # examples
   - flask >=1.0

--- a/ci/environment-test-3.8.yml
+++ b/ci/environment-test-3.8.yml
@@ -48,6 +48,9 @@ dependencies:
   - selenium >=3.8
   - scipy
   - sphinx
+  - pip
+  - pip:
+    - sphinx-panels
 
   # examples
   - flask >=1.0

--- a/environment.yml
+++ b/environment.yml
@@ -23,6 +23,9 @@ dependencies:
   - colorcet
   - pygments
   - sphinx >=1.8
+  - pip
+  - pip:
+    - sphinx-panels
 
   # tests
   - beautifulsoup4

--- a/sphinx/source/bokeh/static/custom.css
+++ b/sphinx/source/bokeh/static/custom.css
@@ -38,16 +38,14 @@ html {
 }
 
 .bd-search {
-    position: relative;
-    padding: 1rem 15px;
-    margin-right: -15px;
-    margin-left: -15px;
-    border-bottom: 1px solid rgba(0,0,0,.05);
+  position: relative;
+  padding-bottom: 20px;
 }
 
-.search-front-page {
-    margin: 0 auto;
-    width: 50%;
+@media (min-width: 768px) {
+  .search-front-page {
+      width: 50%;
+  }
 }
 
 /* minimal copy paste from bootstrap docs css to get sidebars working */
@@ -414,4 +412,25 @@ a.nav-external:after {
 
 span.highlighted {
   background-color: #ECD078;
+}
+
+.bg-bokeh-one {
+  background-color: rgba(246,169,27,0.3);
+}
+
+.bg-bokeh-two {
+  background-color: rgba(165,205,57,0.3);
+}
+
+.bg-bokeh-three {
+  background-color: rgba(0,170,174,0.3);
+}
+
+.card-header p {
+	font-weight: 600;
+	font-size: 125%;
+}
+
+.card-text a {
+	font-weight: 600;
 }

--- a/sphinx/source/bokeh/static/custom.css
+++ b/sphinx/source/bokeh/static/custom.css
@@ -416,6 +416,15 @@ span.highlighted {
 
 /* Custom styles for documentation landing page (index.rst) */
 
+.bokeh-examples {
+  padding: 0px;
+}
+
+.bokeh-examples img {
+  width: 100%;
+  height: 100%;
+}
+
 .bg-bokeh-one {
   background-color: rgba(246,169,27,0.3);
 }
@@ -435,4 +444,12 @@ span.highlighted {
 
 .card-text a {
 	font-weight: 600;
+}
+
+/* The example boxes disappear on very small screens because I could not get
+sphinx-panels/bootstrap to work right*/
+@media (max-width: 575px) {
+	.examples-container {
+	  display: none
+	}
 }

--- a/sphinx/source/bokeh/static/custom.css
+++ b/sphinx/source/bokeh/static/custom.css
@@ -414,6 +414,8 @@ span.highlighted {
   background-color: #ECD078;
 }
 
+/* Custom styles for documentation landing page (index.rst) */
+
 .bg-bokeh-one {
   background-color: rgba(246,169,27,0.3);
 }

--- a/sphinx/source/bokeh/static/custom.css
+++ b/sphinx/source/bokeh/static/custom.css
@@ -44,7 +44,7 @@ html {
 
 @media (min-width: 768px) {
   .search-front-page {
-      width: 50%;
+    width: 50%;
   }
 }
 
@@ -438,18 +438,18 @@ span.highlighted {
 }
 
 .card-header p {
-	font-weight: 600;
-	font-size: 125%;
+  font-weight: 600;
+  font-size: 125%;
 }
 
 .card-text a {
-	font-weight: 600;
+  font-weight: 600;
 }
 
 /* The example boxes disappear on very small screens because I could not get
 sphinx-panels/bootstrap to work right*/
 @media (max-width: 575px) {
-	.examples-container {
-	  display: none
-	}
+  .examples-container {
+    display: none
+  }
 }

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -18,7 +18,7 @@ add_module_names = False
 exclude_patterns = ['docs/releases/*']
 
 extensions = [
-	'sphinx_panels',
+    'sphinx_panels',
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.ifconfig',

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -18,6 +18,7 @@ add_module_names = False
 exclude_patterns = ['docs/releases/*']
 
 extensions = [
+	'sphinx_panels',
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.ifconfig',

--- a/sphinx/source/index.rst
+++ b/sphinx/source/index.rst
@@ -52,7 +52,7 @@ Bokeh's documentation consists of several components:
     If you need more advanced information
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    Get to know every aspect of Bokeh: 
+    Get to know every aspect of Bokeh:
 
     * :ref:`refguide` Guide: Detailed information about all of Bokeh's components
 

--- a/sphinx/source/index.rst
+++ b/sphinx/source/index.rst
@@ -1,24 +1,59 @@
 .. _about:
 
-Bokeh is an interactive visualization library for modern web browsers. It
-provides elegant, concise construction of versatile graphics, and affords
-high-performance interactivity over large or streaming datasets. Bokeh can help
-anyone who would like to quickly and easily make interactive plots, dashboards,
-and data applications.
+Bokeh documentation
+===================
 
-To get started using Bokeh to make your visualizations, begin with the
-:ref:`userguide`.
+Bokeh is a Python library for creating interactive visualizations for modern
+web browsers. It helps you build beautiful graphics, ranging from simple plots
+to complex dashboards with streaming datasets. With Bokeh, you can create
+JavaScript-powered visualizations without writing any JavaScript yourself.
 
-For examples of how you might use Bokeh with your own data, peruse
-the :ref:`gallery`.
+Finding the right documentation resources
+-----------------------------------------
 
-For detailed information about specific Bokeh components, consult the
-:ref:`refguide`.
+Bokeh's documentation consists of several components:
 
-If you are interested in contributing to Bokeh, or extending the library,
-check out the :ref:`devguide` Guide.
+.. panels::
+    :container: container-fluid pb-3
+    :column: col-lg-4 col-md-4 col-sm-12 col-xs-12 p-2
 
-If you'd like to search for a particular topic, use the search box below:
+    :header: bg-bokeh-one
+
+    If you are new to Bokeh
+    ^^^^^^^^^^^^^^^^^^^^^^^
+
+    Follow these guides to get started:
+
+    * `Installation and quickstart`_: Tutorials that walk you through installing Bokeh and creating your first visualizations.
+
+    * :ref:`userguide`: Explanations of all key functionalities of Bokeh and how to use them.
+
+    ---
+    :header: bg-bokeh-two
+    If you have some basic knowledge of Bokeh
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    Learn more by exploring examples:
+
+    * :ref:`gallery`: A collection of examples with source code
+
+    * `Interactive tutorial notebooks`_: A collection of interactive notebooks to experiment with all elements of Bokeh
+
+    ---
+    :header: bg-bokeh-three
+    If you need more advanced information
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    Get to know every aspect of Bokeh: 
+
+    * :ref:`refguide` Guide: Detailed information about all of Bokeh's components
+
+    * :ref:`devguide` Guide: Information on the various ways you can contribute to the Bokeh Project.
+
+Searching the documentation
+---------------------------
+
+To search for a particular topic or keyword, use this search box:
 
 .. raw:: html
 
@@ -26,12 +61,20 @@ If you'd like to search for a particular topic, use the search box below:
       <input type="search" class="form-control search-front-page" name="q" id="search-input" placeholder="&#128269; Search the docs ..." aria-label="Search the docs ..." autocomplete="off">
     </form>
 
-|
+Connecting with the Bokeh community
+-----------------------------------
 
-.. include:: docs/includes/hero.txt
+There are various ways to get in touch with the `Bokeh community`_:
 
-|
-|
+* The `Bokeh Discourse`_ is the best place to ask usage questions and is a
+  great way to get feedback from other users on how to approach a problem.
+* Questions involving pandas or other libraries may find a wider audience by
+  posting with the `"bokeh" tag on Stackoveflow`_.
+* If you think you've found a bug, or would like to request a feature, please
+  report an issue at `Bokeh's GitHub repository`_.
+
+You can also find more information about Bokeh on `Twitter`_, `Medium`_ and
+`LinkedIn`_.
 
 .. toctree::
     :maxdepth: 3
@@ -43,3 +86,13 @@ If you'd like to search for a particular topic, use the search box below:
     docs/reference
     docs/dev_guide
     docs/releases
+
+.. _Installation and quickstart: https://docs.bokeh.org/en/latest/docs/installation.html
+.. _Interactive tutorial notebooks: https://mybinder.org/v2/gh/bokeh/bokeh-notebooks/master?filepath=tutorial%2F00%20-%20Introduction%20and%20Setup.ipynb
+.. _Bokeh community: https://bokeh.org/community/
+.. _Bokeh Discourse: https://discourse.bokeh.org
+.. _`"bokeh" tag on Stackoveflow`: https://stackoverflow.com/questions/tagged/bokeh
+.. _`Bokeh's GitHub repository`: https://github.com/bokeh/bokeh
+.. _Twitter: https://twitter.com/bokeh
+.. _Medium: https://medium.com/bokeh
+.. _LinkedIn: https://www.linkedin.com/company/project-bokeh/

--- a/sphinx/source/index.rst
+++ b/sphinx/source/index.rst
@@ -69,11 +69,11 @@ There are various ways to get in touch with the `Bokeh community`_:
 * The `Bokeh Discourse`_ is the best place to ask usage questions and is a
   great way to get feedback from other users on how to approach a problem.
 * Questions involving pandas or other libraries may find a wider audience by
-  posting with the `"bokeh" tag on Stackoveflow`_.
+  posting with the `"bokeh" tag on Stack Overflow`_.
 * If you think you've found a bug, or would like to request a feature, please
   report an issue at `Bokeh's GitHub repository`_.
 
-You can also find more information about Bokeh on `Twitter`_, `Medium`_ and
+You can also find more information about Bokeh on `Twitter`_, `Medium`_, and
 `LinkedIn`_.
 
 .. toctree::
@@ -91,7 +91,7 @@ You can also find more information about Bokeh on `Twitter`_, `Medium`_ and
 .. _Interactive tutorial notebooks: https://mybinder.org/v2/gh/bokeh/bokeh-notebooks/master?filepath=tutorial%2F00%20-%20Introduction%20and%20Setup.ipynb
 .. _Bokeh community: https://bokeh.org/community/
 .. _Bokeh Discourse: https://discourse.bokeh.org
-.. _`"bokeh" tag on Stackoveflow`: https://stackoverflow.com/questions/tagged/bokeh
+.. _`"bokeh" tag on Stack Overflow`: https://stackoverflow.com/questions/tagged/bokeh
 .. _`Bokeh's GitHub repository`: https://github.com/bokeh/bokeh
 .. _Twitter: https://twitter.com/bokeh
 .. _Medium: https://medium.com/bokeh

--- a/sphinx/source/index.rst
+++ b/sphinx/source/index.rst
@@ -8,6 +8,12 @@ web browsers. It helps you build beautiful graphics, ranging from simple plots
 to complex dashboards with streaming datasets. With Bokeh, you can create
 JavaScript-powered visualizations without writing any JavaScript yourself.
 
+.. raw:: html
+
+    <form class="bd-search align-items-center" action="search.html" method="get">
+      <input type="search" class="form-control search-front-page" name="q" id="search-input" placeholder="&#128269; Search the docs ..." aria-label="Search the docs ..." autocomplete="off">
+    </form>
+
 Finding the right documentation resources
 -----------------------------------------
 
@@ -24,9 +30,9 @@ Bokeh's documentation consists of several components:
 
     Follow these guides to get started:
 
-    * `Installation and quickstart`_: Tutorials that walk you through installing Bokeh and creating your first visualizations.
+    * :ref:`installation`: Instructions for installing Bokeh.
 
-    * :ref:`userguide`: Explanations of all key functionalities of Bokeh and how to use them.
+    * :ref:`userguide`: Explanations of all key functionalities of Bokeh and how to use them. Includes a quickstart tutorial and several examples.
 
     ---
     :header: bg-bokeh-two
@@ -39,6 +45,8 @@ Bokeh's documentation consists of several components:
 
     * `Interactive tutorial notebooks`_: A collection of interactive notebooks to experiment with all elements of Bokeh
 
+    * :ref:`userguide`: Explanations of all key functionalities of Bokeh and how to use them, including examples.
+
     ---
     :header: bg-bokeh-three
     If you need more advanced information
@@ -49,17 +57,6 @@ Bokeh's documentation consists of several components:
     * :ref:`refguide` Guide: Detailed information about all of Bokeh's components
 
     * :ref:`devguide` Guide: Information on the various ways you can contribute to the Bokeh Project.
-
-Searching the documentation
----------------------------
-
-To search for a particular topic or keyword, use this search box:
-
-.. raw:: html
-
-    <form class="bd-search align-items-center" action="search.html" method="get">
-      <input type="search" class="form-control search-front-page" name="q" id="search-input" placeholder="&#128269; Search the docs ..." aria-label="Search the docs ..." autocomplete="off">
-    </form>
 
 Connecting with the Bokeh community
 -----------------------------------
@@ -76,6 +73,61 @@ There are various ways to get in touch with the `Bokeh community`_:
 You can also find more information about Bokeh on `Twitter`_, `Medium`_, and
 `LinkedIn`_.
 
+
+.. panels::
+    :body: bokeh-examples
+    :container: container-fluid pb-3 examples-container
+    :column: col-lg-1 col-md-1 col-sm-2 col-xs-4 p-2
+
+    .. image:: /_images/thumbs/image_t.png
+       :target: docs/gallery/image.html
+       :alt: Thumbnail for image example
+    ---
+    .. image:: /_images/thumbs/anscombe_t.png
+       :target: docs/gallery/anscombe.html
+       :alt: Thumbnail for Anscombe's quartet example
+    ---
+    .. image:: /_images/thumbs/stocks_t.png
+       :target: docs/gallery/stocks.html
+       :alt: Thumbnail for stocks example
+    ---
+    .. image:: /_images/thumbs/lorenz_t.png
+       :target: docs/gallery/lorenz.html
+       :alt: Thumbnail for Lorenz attractor example
+    ---
+    .. image:: /_images/thumbs/candlestick_t.png
+       :target: docs/gallery/candlestick.html
+       :alt: Thumbnail for candlestick example
+    ---
+    .. image:: /_images/thumbs/scatter_t.png
+       :target: docs/gallery/color_scatter.html
+       :alt: Thumbnail for color scatter example
+    ---
+    .. image:: /_images/thumbs/les_mis_t.png
+       :target: docs/gallery/les_mis.html
+       :alt: Thumbnail for Les Mis occurrences example
+    ---
+    .. image:: /_images/thumbs/histogram_t.png
+       :target: docs/gallery/histogram.html
+       :alt: Thumbnail for histogram example
+    ---
+    .. image:: /_images/thumbs/iris_t.png
+       :target: docs/gallery/iris.html
+       :alt: Thumbnail for iris morphology example
+    ---
+    .. image:: /_images/thumbs/choropleth_t.png
+       :target: docs/gallery/texas.html
+       :alt: Thumbnail for choropleth example
+    ---
+    .. image:: /_images/thumbs/splom_t.png
+       :target: docs/gallery/iris_splom.html
+       :alt: Thumbnail for iris example
+    ---
+    .. image:: /_images/thumbs/burtin_t.png
+       :target: docs/gallery/burtin.html
+       :alt: Thumbnail for Burtin example
+
+
 .. toctree::
     :maxdepth: 3
     :hidden:
@@ -87,7 +139,6 @@ You can also find more information about Bokeh on `Twitter`_, `Medium`_, and
     docs/dev_guide
     docs/releases
 
-.. _Installation and quickstart: https://docs.bokeh.org/en/latest/docs/installation.html
 .. _Interactive tutorial notebooks: https://mybinder.org/v2/gh/bokeh/bokeh-notebooks/master?filepath=tutorial%2F00%20-%20Introduction%20and%20Setup.ipynb
 .. _Bokeh community: https://bokeh.org/community/
 .. _Bokeh Discourse: https://discourse.bokeh.org


### PR DESCRIPTION
As part of Google's Season of Docs, this pull request restructures the [landing page for Bokeh's documentation](https://docs.bokeh.org/en/latest/). As discussed with @bryevdv, @hyles-lineata, and @pavithraes.