### PR TITLE
Improve inline/link colors for docs

### DIFF
--- a/sphinx/source/bokeh/static/custom.css
+++ b/sphinx/source/bokeh/static/custom.css
@@ -301,14 +301,14 @@ body { font-family: "Lato", sans-serif; }
 .btn-primary { filter: brightness(90%); background-color: #C02942; border-color: #C02942; }
 .btn-primary:hover { filter: brightness(100%); background-color: #C02942; border-color: #C02942; }
 
-a { color: #D95B43; }
+a { color: #CF462A; }
 
 h1 { font-family: "Work Sans", sans-serif; }
 h2 { font-family: "Work Sans", sans-serif; }
 h3 { font-family: "Work Sans", sans-serif; }
 h4 { font-family: "Work Sans", sans-serif; }
 
-.link { color: #D95B43; }
+.link { color: #CF462A; }
 
 .links { background-color: #542437; color: #fff; font-family: "Lato", sans-serif; }
 .links h6 { font-family: "Work Sans", sans-serif; font-weight: 700; font-size: 14px; }
@@ -324,7 +324,7 @@ h4 { font-family: "Work Sans", sans-serif; }
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
-    color: #D95B43;
+    color: #CF462A;
     cursor: pointer;
     display: block;
     font-size: 1em;
@@ -363,7 +363,7 @@ h4 { font-family: "Work Sans", sans-serif; }
 }
 
 #banner .version-alert {
-  background-color: #D95B43;
+  background-color: #CF462A;
   padding: 1em;
   color: #fff;
   font-family: "Work Sans", sans-serif;

--- a/sphinx/source/bokeh/static/custom.css
+++ b/sphinx/source/bokeh/static/custom.css
@@ -392,7 +392,9 @@ div.bk-root {
 }
 
 code {
-  color: #D95B43;
+  color: rgb(33, 37, 41);
+  padding: 2px 1px;
+  background-color:#eef0f1;
 }
 
 a.headerlink {

--- a/sphinx/source/bokeh/static/custom.css
+++ b/sphinx/source/bokeh/static/custom.css
@@ -394,7 +394,7 @@ div.bk-root {
 code {
   font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, "Lucida Console", Courier, monospace;
   color: rgb(33, 37, 41);
-  padding: 4px 3px 2px 3px;
+  padding: 2px 3px 0px 3px;
   font-size: 80%;
   background-color:#eef0f1;
 }

--- a/sphinx/source/bokeh/static/custom.css
+++ b/sphinx/source/bokeh/static/custom.css
@@ -392,8 +392,10 @@ div.bk-root {
 }
 
 code {
+  font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, "Lucida Console", Courier, monospace;
   color: rgb(33, 37, 41);
-  padding: 2px 1px;
+  padding: 4px 3px 2px 3px;
+  font-size: 80%;
   background-color:#eef0f1;
 }
 


### PR DESCRIPTION
As part of Google's Season of Docs, this pull request slightly changes the colors of inline code and links for Bokeh's documentation. The goal is to increase legibility and increase compliance with the [WCAG's contrast criterion](https://www.w3.org/TR/WCAG21/#contrast-minimum). As discussed with @bryevdv, @hyles-lineata, and @pavithraes.
