### PR TITLE
Dropped redundant TOC in developer docs

### DIFF
--- a/sphinx/source/docs/dev_guide/setup.rst
+++ b/sphinx/source/docs/dev_guide/setup.rst
@@ -12,9 +12,6 @@ For this reason, in order to develop Bokeh from a source checkout, you must
 first be able to build BokehJS. This chapter will walk you through getting a
 full development environment set up.
 
-.. contents::
-    :local:
-    :depth: 2
 
 .. dev_guide_preliminaries:
 

--- a/sphinx/source/docs/dev_guide/testing.rst
+++ b/sphinx/source/docs/dev_guide/testing.rst
@@ -9,9 +9,6 @@ regressions. This chapter describes how to run various tests locally in
 a development environment, guidelines for writing tests, and information
 regarding the continuous testing infrastructure.
 
-.. contents::
-    :local:
-    :depth: 2
 
 Running Tests Locally
 ---------------------


### PR DESCRIPTION
Dropped the TOC which were present in developer documents in the Getting started and Testing sections
 as mentioned in the issue #10467 
