### PR TITLE
Dynamically create year for footer in docs

### DIFF
--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -1,5 +1,6 @@
 # Standard library imports
 import os
+from datetime import date
 
 # Bokeh imports
 from bokeh import __version__
@@ -8,8 +9,9 @@ from bokeh.settings import settings
 # -- Project configuration -----------------------------------------------------
 
 author = "Bokeh Contributors"
+year = date.today().year
 
-copyright = f"©2019 {author}."
+copyright = f"©{year} {author}."
 
 project = 'Bokeh'
 


### PR DESCRIPTION
Currently, the year that is displayed in the documentation's footer is hardcoded as '2019' into the sphinx configuration file. This pull request uses the Python datetime library to always use the current year instead. Fixes issue #10529.