### PR TITLE
[Docs] Fix display of example boxes on very small screens

### DIFF
--- a/sphinx/source/bokeh/static/custom.css
+++ b/sphinx/source/bokeh/static/custom.css
@@ -450,10 +450,8 @@ span.highlighted {
   font-weight: 600;
 }
 
-/* The example boxes disappear on very small screens because I could not get
-sphinx-panels/bootstrap to work right*/
 @media (max-width: 575px) {
-  .examples-container {
-    display: none
+  .examples-container .d-flex {
+    width: 25%;
   }
 }


### PR DESCRIPTION
As noted by @pavithraes in #10519, the boxes with examples at the bottom of the page are not displayed on very small screens. This pull request fixes the CSS to display those boxes correctly.