### PR TITLE
Factor out code from PlotView

### DIFF
--- a/bokehjs/src/lib/core/ui_events.ts
+++ b/bokehjs/src/lib/core/ui_events.ts
@@ -10,10 +10,10 @@ import {reversed, is_empty} from "./util/array"
 import {isString} from "./util/types"
 import {is_mobile} from "./util/compat"
 import {PlotView} from "../models/plots/plot"
-import {Toolbar} from "../models/tools/toolbar"
 import {ToolView} from "../models/tools/tool"
 import {ContextMenu} from "./util/menus"
 import {RendererView} from "../models/renderers/renderer"
+import type {CanvasView} from "../models/canvas/canvas"
 
 function is_touch(event: unknown): event is TouchEvent {
   return typeof TouchEvent !== "undefined" && event instanceof TouchEvent
@@ -85,9 +85,9 @@ export type KeyEvent = {
 
 export type EventType = "pan" | "pinch" | "rotate" | "move" | "tap" | "press" | "pressup" | "scroll"
 
-export type UISignal<E> = Signal<{id: string | null, e: E}, UIEvents>
+export type UISignal<E> = Signal<{id: string | null, e: E}, UIEventBus>
 
-export class UIEvents implements EventListenerObject {
+export class UIEventBus implements EventListenerObject {
   readonly pan_start:    UISignal<PanEvent> = new Signal(this, 'pan:start')
   readonly pan:          UISignal<PanEvent> = new Signal(this, 'pan')
   readonly pan_end:      UISignal<PanEvent> = new Signal(this, 'pan:end')
@@ -121,9 +121,11 @@ export class UIEvents implements EventListenerObject {
 
   private menu: ContextMenu
 
-  constructor(readonly plot_view: PlotView,
-              readonly toolbar: Toolbar,
-              readonly hit_area: HTMLElement) {
+  get hit_area(): HTMLElement {
+    return this.canvas_view.events_el
+  }
+
+  constructor(readonly canvas_view: CanvasView) {
     this._configure_hammerjs()
 
     // Mouse & keyboard events not handled through hammerjs
@@ -279,8 +281,8 @@ export class UIEvents implements EventListenerObject {
     }
   }
 
-  protected _hit_test_renderers(sx: number, sy: number): RendererView | null {
-    const views = this.plot_view.get_renderer_views()
+  protected _hit_test_renderers(plot_view: PlotView, sx: number, sy: number): RendererView | null {
+    const views = plot_view.get_renderer_views()
 
     for (const view of reversed(views)) {
       const {level} = view.model
@@ -293,22 +295,133 @@ export class UIEvents implements EventListenerObject {
     return null
   }
 
-  protected _hit_test_frame(sx: number, sy: number): boolean {
-    return this.plot_view.frame.bbox.contains(sx, sy)
+  set_cursor(cursor: string = "default"): void {
+    this.hit_area.style.cursor = cursor
   }
 
-  protected _hit_test_canvas(sx: number, sy: number): boolean {
-    return this.plot_view.layout.bbox.contains(sx, sy)
+  protected _hit_test_frame(plot_view: PlotView, sx: number, sy: number): boolean {
+    return plot_view.frame.bbox.contains(sx, sy)
   }
+
+  protected _hit_test_canvas(plot_view: PlotView, sx: number, sy: number): boolean {
+    return plot_view.layout.bbox.contains(sx, sy)
+  }
+
+  protected _hit_test_plot(sx: number, sy: number): PlotView | null {
+    // TODO: z-index
+    for (const plot_view of this.canvas_view.plot_views) {
+      if (plot_view.layout.bbox.relative()/*XXX*/.contains(sx, sy))
+        return plot_view
+    }
+
+    return null
+  }
+
+  protected _prev_move: {sx: number, sy: number, plot_view: PlotView | null} | null = null
+
+  protected _curr_pan: {plot_view: PlotView} | null = null
+  protected _curr_pinch: {plot_view: PlotView} | null = null
+  protected _curr_rotate: {plot_view: PlotView} | null = null
 
   _trigger<E extends UIEvent>(signal: UISignal<E>, e: E, srcEvent: Event): void {
-    const gestures = this.toolbar.gestures
+    const {sx, sy} = e
+    const plot_view = this._hit_test_plot(sx, sy)
+    const curr_view = plot_view
+
+    const relativize_event = (_plot_view: PlotView): E => {
+      const [rel_sx, rel_sy] = [sx, sy] // plot_view.layout.bbox.relativize(sx, sy)
+      return {...e, sx: rel_sx, sy: rel_sy}
+    }
+
+    if (e.type == "panstart" || e.type == "pan" || e.type == "panend") {
+      let pan_view: PlotView | null
+      if (e.type == "panstart" && curr_view != null) {
+        this._curr_pan = {plot_view: curr_view}
+        pan_view = curr_view
+      } else if (e.type == "pan" && this._curr_pan != null) {
+        pan_view = this._curr_pan.plot_view
+      } else if (e.type == "panend" && this._curr_pan != null) {
+        pan_view = this._curr_pan.plot_view
+        this._curr_pan = null
+      } else {
+        pan_view = null
+      }
+
+      if (pan_view != null) {
+        const event = relativize_event(pan_view)
+        this.__trigger(pan_view, signal, event, srcEvent)
+      }
+    } else if (e.type == "pinchstart" || e.type == "pinch" || e.type == "pinchend") {
+      let pinch_view: PlotView | null
+      if (e.type == "pinchstart" && curr_view != null) {
+        this._curr_pinch = {plot_view: curr_view}
+        pinch_view = curr_view
+      } else if (e.type == "pinch" && this._curr_pinch != null) {
+        pinch_view = this._curr_pinch.plot_view
+      } else if (e.type == "pinchend" && this._curr_pinch != null) {
+        pinch_view = this._curr_pinch.plot_view
+        this._curr_pinch = null
+      } else {
+        pinch_view = null
+      }
+
+      if (pinch_view != null) {
+        const event = relativize_event(pinch_view)
+        this.__trigger(pinch_view, signal, event, srcEvent)
+      }
+    } else if (e.type == "rotatestart" || e.type == "rotate" || e.type == "rotateend") {
+      let rotate_view: PlotView | null
+      if (e.type == "rotatestart" && curr_view != null) {
+        this._curr_rotate = {plot_view: curr_view}
+        rotate_view = curr_view
+      } else if (e.type == "rotate" && this._curr_rotate != null) {
+        rotate_view = this._curr_rotate.plot_view
+      } else if (e.type == "rotateend" && this._curr_rotate != null) {
+        rotate_view = this._curr_rotate.plot_view
+        this._curr_rotate = null
+      } else {
+        rotate_view = null
+      }
+
+      if (rotate_view != null) {
+        const event = relativize_event(rotate_view)
+        this.__trigger(rotate_view, signal, event, srcEvent)
+      }
+    } else if (e.type == "mouseenter" || e.type == "mousemove" || e.type == "mouseleave") {
+      const prev_view = this._prev_move?.plot_view
+
+      if (prev_view != null && (e.type == "mouseleave" || prev_view != curr_view)) {
+        const {sx, sy} = relativize_event(prev_view)
+        this.__trigger(prev_view, this.move_exit, {type: "mouseleave", sx, sy, shiftKey: false, ctrlKey: false}, srcEvent)
+      }
+
+      if (curr_view != null && (e.type == "mouseenter" || prev_view != curr_view)) {
+        const {sx, sy} = relativize_event(curr_view)
+        this.__trigger(curr_view, this.move_enter, {type: "mouseenter", sx, sy, shiftKey: false, ctrlKey: false}, srcEvent)
+      }
+
+      if (curr_view != null && e.type == "mousemove") {
+        const event = relativize_event(curr_view)
+        this.__trigger(curr_view, signal, event, srcEvent)
+      }
+
+      this._prev_move = {sx, sy, plot_view: curr_view}
+    } else {
+      if (curr_view != null) {
+        const event = relativize_event(curr_view)
+        this.__trigger(curr_view, signal, event, srcEvent)
+      }
+    }
+  }
+
+  __trigger<E extends UIEvent>(plot_view: PlotView, signal: UISignal<E>, e: E, srcEvent: Event): void {
+    const gestures = plot_view.model.toolbar.gestures
     type BaseType = keyof typeof gestures
 
     const event_type = signal.name
     const base_type = event_type.split(":")[0] as BaseType
-    const view = this._hit_test_renderers(e.sx, e.sy)
-    const on_canvas = this._hit_test_canvas(e.sx, e.sy)
+    const view = this._hit_test_renderers(plot_view, e.sx, e.sy)
+    const on_canvas = this._hit_test_canvas(plot_view, e.sx, e.sy)
 
     switch (base_type) {
       case "move": {
@@ -316,7 +429,7 @@ export class UIEvents implements EventListenerObject {
         if (active_gesture != null)
           this.trigger(signal, e, active_gesture.id)
 
-        const active_inspectors = this.toolbar.inspectors.filter(t => t.active)
+        const active_inspectors = plot_view.model.toolbar.inspectors.filter(t => t.active)
         let cursor = "default"
 
         // the event happened on a renderer
@@ -329,14 +442,14 @@ export class UIEvents implements EventListenerObject {
           }
 
         // the event happened on the plot frame but off a renderer
-        } else if (this._hit_test_frame(e.sx, e.sy)) {
+        } else if (this._hit_test_frame(plot_view, e.sx, e.sy)) {
           if (!is_empty(active_inspectors)) {
             cursor = "crosshair"
           }
         }
 
-        this.plot_view.set_cursor(cursor)
-        this.plot_view.set_toolbar_visibility(on_canvas)
+        this.set_cursor(cursor)
+        plot_view.set_toolbar_visibility(on_canvas)
 
         active_inspectors.map((inspector) => this.trigger(signal, e, inspector.id))
         break
@@ -383,18 +496,18 @@ export class UIEvents implements EventListenerObject {
       }
     }
 
-    this._trigger_bokeh_event(e)
+    this._trigger_bokeh_event(plot_view, e)
   }
 
   trigger<E>(signal: UISignal<E>, e: E, id: string | null = null): void {
     signal.emit({id, e})
   }
 
-  protected _trigger_bokeh_event(e: UIEvent): void {
+  protected _trigger_bokeh_event(plot_view: PlotView, e: UIEvent): void {
     const ev = (() => {
       const {sx, sy} = e
-      const x = this.plot_view.frame.x_scale.invert(sx)
-      const y = this.plot_view.frame.y_scale.invert(sy)
+      const x = plot_view.frame.x_scale.invert(sx)
+      const y = plot_view.frame.y_scale.invert(sy)
 
       switch (e.type) {
         case "wheel":
@@ -437,7 +550,7 @@ export class UIEvents implements EventListenerObject {
     })()
 
     if (ev != null)
-      this.plot_view.model.trigger_event(ev)
+      plot_view.model.trigger_event(ev)
   }
 
   private _get_sxy(event: TouchEvent | MouseEvent | PointerEvent): ScreenCoord {
@@ -560,10 +673,7 @@ export class UIEvents implements EventListenerObject {
   }
 
   private _doubletap(e: HammerEvent): void {
-    // NOTE: doubletap event triggered unconditionally
-    const ev = this._tap_event(e)
-    this._trigger_bokeh_event(ev)
-    this.trigger(this.doubletap, ev)
+    this._trigger(this.doubletap, this._tap_event(e), e.srcEvent)
   }
 
   private _press(e: HammerEvent): void {

--- a/bokehjs/src/lib/core/ui_events.ts
+++ b/bokehjs/src/lib/core/ui_events.ts
@@ -1,5 +1,4 @@
-import Hammer, {Input} from "hammerjs"
-type HammerEvent = typeof Input
+import Hammer from "hammerjs"
 
 import {Signal} from "./signaling"
 import {logger} from "./logging"
@@ -17,6 +16,15 @@ import type {CanvasView} from "../models/canvas/canvas"
 
 function is_touch(event: unknown): event is TouchEvent {
   return typeof TouchEvent !== "undefined" && event instanceof TouchEvent
+}
+
+type HammerEvent = {
+  type: string
+  deltaX: number
+  deltaY: number
+  scale: number
+  rotation: number
+  srcEvent: TouchEvent | MouseEvent | PointerEvent
 }
 
 export type ScreenCoord = {sx: number, sy: number}

--- a/bokehjs/src/lib/core/ui_events.ts
+++ b/bokehjs/src/lib/core/ui_events.ts
@@ -243,6 +243,7 @@ export class UIEventBus implements EventListenerObject {
       }
       case "tap": {
         if (v._tap != null)          v.connect(this.tap,          conditionally(v._tap.bind(v)))
+        if (v._doubletap != null)    v.connect(this.doubletap,    conditionally(v._doubletap.bind(v)))
         break
       }
       case "press": {
@@ -261,9 +262,6 @@ export class UIEventBus implements EventListenerObject {
     // Skip shared events if registering multi-tool
     if (!shared)
       return
-
-    if (v._doubletap != null)
-      v.connect(this.doubletap, unconditionally(v._doubletap.bind(v)))
 
     if (v._keydown != null)
       v.connect(this.keydown, unconditionally(v._keydown.bind(v)))
@@ -467,6 +465,12 @@ export class UIEventBus implements EventListenerObject {
           this.trigger(signal, e, active_gesture.id)
         break
       }
+      case "doubletap": {
+        const active_gesture = gestures.doubletap.active ?? gestures.tap.active
+        if (active_gesture != null)
+          this.trigger(signal, e, active_gesture.id)
+        break
+      }
       case "scroll": {
         // Dual touch hack part 2/2
         // This is a hack for laptops with touch screen who may be pinching or scrolling
@@ -503,7 +507,7 @@ export class UIEventBus implements EventListenerObject {
     signal.emit({id, e})
   }
 
-  protected _trigger_bokeh_event(plot_view: PlotView, e: UIEvent): void {
+  /*protected*/ _trigger_bokeh_event(plot_view: PlotView, e: UIEvent): void {
     const ev = (() => {
       const {sx, sy} = e
       const x = plot_view.frame.x_scale.invert(sx)
@@ -553,7 +557,7 @@ export class UIEventBus implements EventListenerObject {
       plot_view.model.trigger_event(ev)
   }
 
-  private _get_sxy(event: TouchEvent | MouseEvent | PointerEvent): ScreenCoord {
+  /*private*/ _get_sxy(event: TouchEvent | MouseEvent | PointerEvent): ScreenCoord {
     const {pageX, pageY} = is_touch(event) ? (event.touches.length != 0 ? event.touches : event.changedTouches)[0] : event
     const {left, top} = offset(this.hit_area)
     return {
@@ -562,7 +566,7 @@ export class UIEventBus implements EventListenerObject {
     }
   }
 
-  private _pan_event(e: HammerEvent): PanEvent {
+  /*private*/ _pan_event(e: HammerEvent): PanEvent {
     return {
       type: e.type as PanEvent["type"],
       ...this._get_sxy(e.srcEvent),
@@ -573,7 +577,7 @@ export class UIEventBus implements EventListenerObject {
     }
   }
 
-  private _pinch_event(e: HammerEvent): PinchEvent {
+  /*private*/ _pinch_event(e: HammerEvent): PinchEvent {
     return {
       type: e.type as PinchEvent["type"],
       ...this._get_sxy(e.srcEvent),
@@ -583,7 +587,7 @@ export class UIEventBus implements EventListenerObject {
     }
   }
 
-  private _rotate_event(e: HammerEvent): RotateEvent {
+  /*private*/ _rotate_event(e: HammerEvent): RotateEvent {
     return {
       type: e.type as RotateEvent["type"],
       ...this._get_sxy(e.srcEvent),
@@ -593,7 +597,7 @@ export class UIEventBus implements EventListenerObject {
     }
   }
 
-  private _tap_event(e: HammerEvent): TapEvent {
+  /*private*/ _tap_event(e: HammerEvent): TapEvent {
     return {
       type: e.type as TapEvent["type"],
       ...this._get_sxy(e.srcEvent),
@@ -602,7 +606,7 @@ export class UIEventBus implements EventListenerObject {
     }
   }
 
-  private _move_event(e: MouseEvent): MoveEvent {
+  /*private*/ _move_event(e: MouseEvent): MoveEvent {
     return {
       type: e.type as MoveEvent["type"],
       ...this._get_sxy(e),
@@ -611,7 +615,7 @@ export class UIEventBus implements EventListenerObject {
     }
   }
 
-  private _scroll_event(e: WheelEvent): ScrollEvent {
+  /*private*/ _scroll_event(e: WheelEvent): ScrollEvent {
     return {
       type: e.type as ScrollEvent["type"],
       ...this._get_sxy(e),
@@ -621,14 +625,14 @@ export class UIEventBus implements EventListenerObject {
     }
   }
 
-  private _key_event(e: KeyboardEvent): KeyEvent {
+  /*private*/ _key_event(e: KeyboardEvent): KeyEvent {
     return {
       type: e.type as KeyEvent["type"],
       keyCode: e.keyCode,
     }
   }
 
-  private _pan_start(e: HammerEvent): void {
+  /*private*/ _pan_start(e: HammerEvent): void {
     const ev = this._pan_event(e)
     // back out delta to get original center point
     ev.sx -= e.deltaX
@@ -636,71 +640,71 @@ export class UIEventBus implements EventListenerObject {
     this._trigger(this.pan_start, ev, e.srcEvent)
   }
 
-  private _pan(e: HammerEvent): void {
+  /*private*/ _pan(e: HammerEvent): void {
     this._trigger(this.pan, this._pan_event(e), e.srcEvent)
   }
 
-  private _pan_end(e: HammerEvent): void {
+  /*private*/ _pan_end(e: HammerEvent): void {
     this._trigger(this.pan_end, this._pan_event(e), e.srcEvent)
   }
 
-  private _pinch_start(e: HammerEvent): void {
+  /*private*/ _pinch_start(e: HammerEvent): void {
     this._trigger(this.pinch_start, this._pinch_event(e), e.srcEvent)
   }
 
-  private _pinch(e: HammerEvent): void {
+  /*private*/ _pinch(e: HammerEvent): void {
     this._trigger(this.pinch, this._pinch_event(e), e.srcEvent)
   }
 
-  private _pinch_end(e: HammerEvent): void {
+  /*private*/ _pinch_end(e: HammerEvent): void {
     this._trigger(this.pinch_end, this._pinch_event(e), e.srcEvent)
   }
 
-  private _rotate_start(e: HammerEvent): void {
+  /*private*/ _rotate_start(e: HammerEvent): void {
     this._trigger(this.rotate_start, this._rotate_event(e), e.srcEvent)
   }
 
-  private _rotate(e: HammerEvent): void {
+  /*private*/ _rotate(e: HammerEvent): void {
     this._trigger(this.rotate, this._rotate_event(e), e.srcEvent)
   }
 
-  private _rotate_end(e: HammerEvent): void {
+  /*private*/ _rotate_end(e: HammerEvent): void {
     this._trigger(this.rotate_end, this._rotate_event(e), e.srcEvent)
   }
 
-  private _tap(e: HammerEvent): void {
+  /*private*/ _tap(e: HammerEvent): void {
     this._trigger(this.tap, this._tap_event(e), e.srcEvent)
   }
 
-  private _doubletap(e: HammerEvent): void {
+  /*private*/ _doubletap(e: HammerEvent): void {
     this._trigger(this.doubletap, this._tap_event(e), e.srcEvent)
   }
 
-  private _press(e: HammerEvent): void {
+  /*private*/ _press(e: HammerEvent): void {
     this._trigger(this.press, this._tap_event(e), e.srcEvent)
   }
 
-  private _pressup(e: HammerEvent): void {
+  /*private*/ _pressup(e: HammerEvent): void {
     this._trigger(this.pressup, this._tap_event(e), e.srcEvent)
   }
 
-  private _mouse_enter(e: MouseEvent): void {
+  /*private*/ _mouse_enter(e: MouseEvent): void {
     this._trigger(this.move_enter, this._move_event(e), e)
   }
 
-  private _mouse_move(e: MouseEvent): void {
+  /*private*/ _mouse_move(e: MouseEvent): void {
     this._trigger(this.move, this._move_event(e), e)
   }
 
-  private _mouse_exit(e: MouseEvent): void {
+  /*private*/ _mouse_exit(e: MouseEvent): void {
     this._trigger(this.move_exit, this._move_event(e), e)
   }
 
-  private _mouse_wheel(e: WheelEvent): void {
+  /*private*/ _mouse_wheel(e: WheelEvent): void {
     this._trigger(this.scroll, this._scroll_event(e), e)
   }
 
-  private _context_menu(e: MouseEvent): void {
+  /*private*/ _context_menu(e: MouseEvent): void {
     if (!this.menu.is_open && this.menu.can_open) {
       e.preventDefault()
     }
@@ -709,12 +713,12 @@ export class UIEventBus implements EventListenerObject {
     this.menu.toggle({left: sx, top: sy})
   }
 
-  private _key_down(e: KeyboardEvent): void {
+  /*private*/ _key_down(e: KeyboardEvent): void {
     // NOTE: keyup event triggered unconditionally
     this.trigger(this.keydown, this._key_event(e))
   }
 
-  private _key_up(e: KeyboardEvent): void {
+  /*private*/ _key_up(e: KeyboardEvent): void {
     // NOTE: keyup event triggered unconditionally
     this.trigger(this.keyup, this._key_event(e))
   }

--- a/bokehjs/src/lib/core/util/bbox.ts
+++ b/bokehjs/src/lib/core/util/bbox.ts
@@ -162,9 +162,13 @@ export class BBox implements Rect {
   get hcenter(): number { return (this.left + this.right)/2 }
   get vcenter(): number { return (this.top + this.bottom)/2 }
 
-  relativize(): BBox {
+  relative(): BBox {
     const {width, height} = this
     return new BBox({x: 0, y: 0, width, height})
+  }
+
+  relativize(x: number, y: number): [number, number] {
+    return [x - this.x, y - this.y]
   }
 
   contains(x: number, y: number): boolean {

--- a/bokehjs/src/lib/models/annotations/color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/color_bar.ts
@@ -401,19 +401,21 @@ export class ColorBarView extends AnnotationView {
       * The parallel frame dimension * 0.80
     */
 
-    const frame_height = this.plot_view.frame.bbox.height
-    const frame_width = this.plot_view.frame.bbox.width
+    const {bbox} = this.panel ?? this.plot_view.frame
+    const {padding} = this.model
     const title_extent = this._title_extent()
 
-    let height: number, width: number
+    let width: number
+    let height: number
+
     switch (this.model.orientation) {
       case "vertical": {
         if (this.model.height == 'auto') {
           if (this.panel != null)
-            height = frame_height - 2*this.model.padding - title_extent
+            height = bbox.height - 2*padding - title_extent
           else {
-            height = max([this.model.color_mapper.palette.length*SHORT_DIM, frame_height*LONG_DIM_MIN_SCALAR])
-            height = min([height, frame_height*LONG_DIM_MAX_SCALAR - 2*this.model.padding - title_extent])
+            height = max([this.model.color_mapper.palette.length*SHORT_DIM, bbox.height*LONG_DIM_MIN_SCALAR])
+            height = min([height, bbox.height*LONG_DIM_MAX_SCALAR - 2*padding - title_extent])
           }
         } else
           height = this.model.height
@@ -426,10 +428,10 @@ export class ColorBarView extends AnnotationView {
 
         if (this.model.width == 'auto') {
           if (this.panel != null)
-            width = frame_width - 2*this.model.padding
+            width = bbox.width - 2*padding
           else {
-            width = max([this.model.color_mapper.palette.length*SHORT_DIM, frame_width*LONG_DIM_MIN_SCALAR])
-            width = min([width, frame_width*LONG_DIM_MAX_SCALAR - 2*this.model.padding])
+            width = max([this.model.color_mapper.palette.length*SHORT_DIM, bbox.width*LONG_DIM_MIN_SCALAR])
+            width = min([width, bbox.width*LONG_DIM_MAX_SCALAR - 2*padding])
           }
         } else
           width = this.model.width

--- a/bokehjs/src/lib/models/annotations/slope.ts
+++ b/bokehjs/src/lib/models/annotations/slope.ts
@@ -1,16 +1,11 @@
 import {Annotation, AnnotationView} from "./annotation"
 import * as mixins from "core/property_mixins"
 import {Line} from "core/visuals"
-import {Color} from "core/types"
 import * as p from "core/properties"
 
 export class SlopeView extends AnnotationView {
   model: Slope
   visuals: Slope.Visuals
-
-  initialize(): void {
-    super.initialize()
-  }
 
   connect_signals(): void {
     super.connect_signals()
@@ -18,11 +13,9 @@ export class SlopeView extends AnnotationView {
   }
 
   protected _render(): void {
-    const gradient = this.model.gradient
-    const y_intercept = this.model.y_intercept
-    if (gradient == null || y_intercept == null) {
+    const {gradient, y_intercept} = this.model
+    if (gradient == null || y_intercept == null)
       return
-    }
 
     const {frame} = this.plot_view
 
@@ -69,10 +62,6 @@ export namespace Slope {
   export type Props = Annotation.Props & {
     gradient: p.Property<number | null>
     y_intercept: p.Property<number | null>
-
-    line_color: p.Property<Color>
-    line_width: p.Property<number>
-    line_alpha: p.Property<number>
   } & Mixins
 
   export type Mixins = mixins.Line/*Scalar*/

--- a/bokehjs/src/lib/models/annotations/tooltip.ts
+++ b/bokehjs/src/lib/models/annotations/tooltip.ts
@@ -69,7 +69,7 @@ export class TooltipView extends AnnotationView {
     const [sx, sy] = position
 
     const side = (() => {
-      const area = this.parent.layout.bbox.relativize()
+      const area = this.parent.layout.bbox.relative()
       const {attachment} = this.model
       switch (attachment) {
         case "horizontal":

--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -285,14 +285,10 @@ export class AxisView extends GuideRendererView {
     const ctx = this.layer.ctx
     visuals.set_value(ctx)
 
-    let hscale: number
     let angle: number
-
     if (isString(orient)) {
-      hscale = 1
       angle = this.panel.get_label_angle_heuristic(orient)
     } else {
-      hscale = 2
       angle = -orient
     }
     angle = Math.abs(angle)
@@ -309,9 +305,9 @@ export class AxisView extends GuideRendererView {
       let val: number
 
       if (side == "above" || side == "below")
-        val = w*s + (h/hscale)*c
+        val = w*s + h*c
       else
-        val = w*c + (h/hscale)*s
+        val = w*c + h*s
 
       // update extent if current value is larger
       if (val > extent)

--- a/bokehjs/src/lib/models/canvas/canvas.ts
+++ b/bokehjs/src/lib/models/canvas/canvas.ts
@@ -5,9 +5,11 @@ import * as p from "core/properties"
 import {div, canvas, append} from "core/dom"
 import {OutputBackend} from "core/enums"
 import {extend} from "core/util/object"
+import {UIEventBus} from "core/ui_events"
 import {BBox} from "core/util/bbox"
 import {Context2d, fixup_ctx} from "core/util/canvas"
 import {SVGRenderingContext2D} from "core/util/svg"
+import {PlotView} from "../plots/plot"
 
 export type FrameBox = [number, number, number, number]
 
@@ -156,6 +158,8 @@ export class CanvasView extends DOMView {
   overlays_el: HTMLElement
   events_el: HTMLElement
 
+  ui_event_bus: UIEventBus
+
   initialize(): void {
     super.initialize()
 
@@ -181,7 +185,12 @@ export class CanvasView extends DOMView {
     extend(this.el.style, style)
     append(this.el, ...elements)
 
-    logger.debug("CanvasView initialized")
+    this.ui_event_bus = new UIEventBus(this)
+  }
+
+  remove(): void {
+    this.ui_event_bus.destroy()
+    super.remove()
   }
 
   add_underlay(el: HTMLElement): void {
@@ -274,6 +283,13 @@ export class CanvasView extends DOMView {
   to_blob(): Promise<Blob> {
     return this.compose().to_blob()
   }
+
+  plot_views: PlotView[]
+  /*
+  get plot_views(): PlotView[] {
+    return [] // XXX
+  }
+  */
 }
 
 export namespace Canvas {

--- a/bokehjs/src/lib/models/canvas/canvas.ts
+++ b/bokehjs/src/lib/models/canvas/canvas.ts
@@ -236,17 +236,7 @@ export class CanvasView extends DOMView {
       // Setup blending
       gl.enable(gl.BLEND)
       gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE_MINUS_DST_ALPHA, gl.ONE)   // premultipliedAlpha == true
-    }
-  }
-
-  clear_webgl(): void {
-    const {webgl} = this
-    if (webgl != null) {
-      // Prepare GL for drawing
-      const {gl, canvas} = webgl
-      gl.viewport(0, 0, canvas.width, canvas.height)
-      gl.clearColor(0, 0, 0, 0)
-      gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT)
+      this._clear_webgl()
     }
   }
 
@@ -267,6 +257,18 @@ export class CanvasView extends DOMView {
         ctx.scale(ratio, ratio)
         ctx.translate(0.5, 0.5)
       }
+      this._clear_webgl()
+    }
+  }
+
+  protected _clear_webgl(): void {
+    const {webgl} = this
+    if (webgl != null) {
+      // Prepare GL for drawing
+      const {gl, canvas} = webgl
+      gl.viewport(0, 0, canvas.width, canvas.height)
+      gl.clearColor(0, 0, 0, 0)
+      gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT)
     }
   }
 

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -489,25 +489,32 @@ export class PlotView extends LayoutDOMView {
     return this.computed_renderers.map((r) => this.renderer_views.get(r)!)
   }
 
-  async build_renderer_views(): Promise<void> {
-    this.computed_renderers = []
-
+  protected *_compute_renderers(): Generator<Renderer, void, undefined> {
     const {above, below, left, right, center, renderers} = this.model
-    this.computed_renderers.push(...above, ...below, ...left, ...right, ...center, ...renderers)
+
+    yield* above
+    yield* below
+    yield* left
+    yield* right
+    yield* center
+    yield* renderers
 
     if (this._title != null)
-      this.computed_renderers.push(this._title)
+      yield this._title
 
     if (this._toolbar != null)
-      this.computed_renderers.push(this._toolbar)
+      yield this._toolbar
 
     for (const tool of this.model.toolbar.tools) {
       if (tool.overlay != null)
-        this.computed_renderers.push(tool.overlay)
+        yield tool.overlay
 
-      this.computed_renderers.push(...tool.synthetic_renderers)
+      yield* tool.synthetic_renderers
     }
+  }
 
+  async build_renderer_views(): Promise<void> {
+    this.computed_renderers = [...this._compute_renderers()]
     await build_views(this.renderer_views, this.computed_renderers, {parent: this})
   }
 

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -455,7 +455,7 @@ export class PlotView extends LayoutDOMView {
 
   async build_tool_views(): Promise<void> {
     const tool_models = this.model.toolbar.tools
-    const new_tool_views = await build_views(this.tool_views, tool_models, {parent: this}) as ToolView[]
+    const new_tool_views = await build_views(this.tool_views, tool_models, {parent: this})
     new_tool_views.map((tool_view) => this.canvas_view.ui_event_bus.register_tool(tool_view))
   }
 

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -14,7 +14,6 @@ import {ToolbarPanel} from "../annotations/toolbar_panel"
 import {Reset} from "core/bokeh_events"
 import {Signal0} from "core/signaling"
 import {build_view, build_views, remove_views} from "core/build_views"
-import {UIEvents} from "core/ui_events"
 import {Visuals} from "core/visuals"
 import {logger} from "core/logging"
 import {Side, RenderLevel} from "core/enums"
@@ -82,7 +81,6 @@ export class PlotView extends LayoutDOMView {
   }
 
   protected throttled_paint: () => void
-  protected ui_event_bus: UIEvents
 
   computed_renderers: Renderer[]
 
@@ -158,7 +156,6 @@ export class PlotView extends LayoutDOMView {
   }
 
   remove(): void {
-    this.ui_event_bus.destroy()
     remove_views(this.renderer_views)
     remove_views(this.tool_views)
     this.canvas_view.remove()
@@ -225,7 +222,7 @@ export class PlotView extends LayoutDOMView {
     await super.lazy_initialize()
 
     this.canvas_view = await build_view(this.canvas, {parent: this})
-    this.ui_event_bus = new UIEvents(this, this.model.toolbar, this.canvas_view.events_el)
+    this.canvas_view.plot_views = [this]
 
     await this.build_renderer_views()
     await this.build_tool_views()
@@ -376,10 +373,6 @@ export class PlotView extends LayoutDOMView {
     return views
   }
 
-  set_cursor(cursor: string = "default"): void {
-    this.canvas_view.el.style.cursor = cursor
-  }
-
   set_toolbar_visibility(visible: boolean): void {
     for (const callback of this.visibility_callbacks)
       callback(visible)
@@ -521,7 +514,7 @@ export class PlotView extends LayoutDOMView {
   async build_tool_views(): Promise<void> {
     const tool_models = this.model.toolbar.tools
     const new_tool_views = await build_views(this.tool_views, tool_models, {parent: this}) as ToolView[]
-    new_tool_views.map((tool_view) => this.ui_event_bus.register_tool(tool_view))
+    new_tool_views.map((tool_view) => this.canvas_view.ui_event_bus.register_tool(tool_view))
   }
 
   connect_signals(): void {

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -593,7 +593,6 @@ export class PlotView extends LayoutDOMView {
     if (do_primary) {
       primary.prepare()
       this.canvas_view.prepare_webgl(frame_box)
-      this.canvas_view.clear_webgl()
 
       this._map_hook(primary.ctx, frame_box)
       this._paint_empty(primary.ctx, frame_box)
@@ -639,7 +638,6 @@ export class PlotView extends LayoutDOMView {
 
       if (renderer_view.has_webgl && renderer_view.needs_webgl_blit) {
         this.canvas_view.blit_webgl(ctx)
-        this.canvas_view.clear_webgl()
       }
     }
   }

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -377,20 +377,15 @@ export class PlotView extends LayoutDOMView {
 
   get_selection(): Map<DataRenderer, Selection> {
     const selection = new Map<DataRenderer, Selection>()
-    for (const renderer of this.model.renderers) {
-      if (renderer instanceof DataRenderer) {
-        const {selected} = renderer.selection_manager.source
-        selection.set(renderer, selected)
-      }
+    for (const renderer of this.model.data_renderers) {
+      const {selected} = renderer.selection_manager.source
+      selection.set(renderer, selected)
     }
     return selection
   }
 
   update_selection(selections: Map<DataRenderer, Selection> | null): void {
-    for (const renderer of this.model.renderers) {
-      if (!(renderer instanceof DataRenderer))
-        continue
-
+    for (const renderer of this.model.data_renderers) {
       const ds = renderer.selection_manager.source
       if (selections != null) {
         const selection = selections.get(renderer)

--- a/bokehjs/src/lib/models/plots/state_manager.ts
+++ b/bokehjs/src/lib/models/plots/state_manager.ts
@@ -1,0 +1,76 @@
+import {Signal0} from "core/signaling"
+import type {PlotView} from "./plot_canvas"
+import type {RangeInfo} from "./range_manager"
+import {Selection} from "../selections/selection"
+import type {DataRenderer} from "../renderers/data_renderer"
+
+export type StateInfo = {
+  range?: RangeInfo
+  selection: Map<DataRenderer, Selection>
+  dimensions: {
+    width: number
+    height: number
+  }
+}
+
+export class StateManager {
+  constructor(readonly parent: PlotView, readonly initial_state: StateInfo) {}
+
+  readonly changed: Signal0<this["parent"]> = new Signal0(this.parent, "state_changed")
+
+  protected history: {type: string, state: StateInfo}[] = []
+  protected index: number = -1
+
+  protected _do_state_change(index: number): void {
+    const state = this.history[index] != null ? this.history[index].state : this.initial_state
+
+    if (state.range != null)
+      this.parent.update_range(state.range)
+
+    if (state.selection != null)
+      this.parent.update_selection(state.selection)
+  }
+
+  push(type: string, new_state: Partial<StateInfo>): void {
+    const {history, index} = this
+
+    const prev_state = history[index] != null ? history[index].state : {}
+    const state = {...this.initial_state, ...prev_state, ...new_state}
+
+    this.history = this.history.slice(0, this.index + 1)
+    this.history.push({type, state})
+    this.index = this.history.length - 1
+
+    this.changed.emit()
+  }
+
+  clear(): void {
+    this.history = []
+    this.index = -1
+    this.changed.emit()
+  }
+
+  undo(): void {
+    if (this.can_undo) {
+      this.index -= 1
+      this._do_state_change(this.index)
+      this.changed.emit()
+    }
+  }
+
+  redo(): void {
+    if (this.can_redo) {
+      this.index += 1
+      this._do_state_change(this.index)
+      this.changed.emit()
+    }
+  }
+
+  get can_undo(): boolean {
+    return this.index >= 0
+  }
+
+  get can_redo(): boolean {
+    return this.index < this.history.length - 1
+  }
+}

--- a/bokehjs/src/lib/models/tools/actions/redo_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/redo_tool.ts
@@ -7,11 +7,11 @@ export class RedoToolView extends ActionToolView {
 
   connect_signals(): void {
     super.connect_signals()
-    this.connect(this.plot_view.state_changed, () => this.model.disabled = !this.plot_view.can_redo())
+    this.connect(this.plot_view.state.changed, () => this.model.disabled = !this.plot_view.state.can_redo)
   }
 
   doit(): void {
-    this.plot_view.redo()
+    this.plot_view.state.redo()
   }
 }
 

--- a/bokehjs/src/lib/models/tools/actions/undo_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/undo_tool.ts
@@ -7,11 +7,11 @@ export class UndoToolView extends ActionToolView {
 
   connect_signals(): void {
     super.connect_signals()
-    this.connect(this.plot_view.state_changed, () => this.model.disabled = !this.plot_view.can_undo())
+    this.connect(this.plot_view.state.changed, () => this.model.disabled = !this.plot_view.state.can_undo)
   }
 
   doit(): void {
-    this.plot_view.undo()
+    this.plot_view.state.undo()
   }
 }
 

--- a/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
@@ -19,8 +19,7 @@ export class ZoomBaseToolView extends ActionToolView {
     this.plot_view.push_state('zoom_out', {range: zoom_info})
     this.plot_view.update_range(zoom_info, {scrolling: true})
 
-    if (this.model.document)
-      this.model.document.interactive_start(this.plot_model)
+    this.model.document?.interactive_start(this.plot_model)
   }
 }
 

--- a/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
@@ -16,7 +16,7 @@ export class ZoomBaseToolView extends ActionToolView {
 
     const zoom_info = scale_range(frame, this.model.sign * this.model.factor, h_axis, v_axis)
 
-    this.plot_view.push_state('zoom_out', {range: zoom_info})
+    this.plot_view.state.push("zoom_out", {range: zoom_info})
     this.plot_view.update_range(zoom_info, {scrolling: true})
 
     this.model.document?.interactive_start(this.plot_model)

--- a/bokehjs/src/lib/models/tools/gestures/box_select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/box_select_tool.ts
@@ -53,7 +53,7 @@ export class BoxSelectToolView extends SelectToolView {
 
     this._base_point = null
 
-    this.plot_view.push_state('box_select', {selection: this.plot_view.get_selection()})
+    this.plot_view.state.push("box_select", {selection: this.plot_view.get_selection()})
   }
 
   _do_select([sx0, sx1]: [number, number], [sy0, sy1]: [number, number], final: boolean, mode: SelectionMode = "replace"): void {

--- a/bokehjs/src/lib/models/tools/gestures/box_zoom_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/box_zoom_tool.ts
@@ -143,7 +143,7 @@ export class BoxZoomToolView extends GestureToolView {
 
     const zoom_info = {xrs, yrs}
 
-    this.plot_view.push_state('box_zoom', {range: zoom_info})
+    this.plot_view.state.push("box_zoom", {range: zoom_info})
     this.plot_view.update_range(zoom_info)
   }
 }

--- a/bokehjs/src/lib/models/tools/gestures/lasso_select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/lasso_select_tool.ts
@@ -56,7 +56,7 @@ export class LassoSelectToolView extends SelectToolView {
   _pan_end(ev: PanEvent): void {
     this._clear_overlay()
     this._do_select(this.data!.sx, this.data!.sy, true, this._select_mode(ev))
-    this.plot_view.push_state('lasso_select', {selection: this.plot_view.get_selection()})
+    this.plot_view.state.push("lasso_select", {selection: this.plot_view.get_selection()})
   }
 
   _clear_overlay(): void {

--- a/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
@@ -45,15 +45,12 @@ export class PanToolView extends GestureToolView {
         this.h_axis_only = true
     }
 
-    if (this.model.document != null)
-      this.model.document.interactive_start(this.plot_model)
+    this.model.document?.interactive_start(this.plot_model)
   }
 
   _pan(ev: PanEvent): void {
     this._update(ev.deltaX, ev.deltaY)
-
-    if (this.model.document != null)
-      this.model.document.interactive_start(this.plot_model)
+    this.model.document?.interactive_start(this.plot_model)
   }
 
   _pan_end(_e: PanEvent): void {

--- a/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
@@ -58,7 +58,7 @@ export class PanToolView extends GestureToolView {
     this.v_axis_only = false
 
     if (this.pan_info != null)
-      this.plot_view.push_state('pan', {range: this.pan_info})
+      this.plot_view.state.push("pan", {range: this.pan_info})
   }
 
   _update(dx: number, dy: number): void {

--- a/bokehjs/src/lib/models/tools/gestures/poly_select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/poly_select_tool.ts
@@ -35,7 +35,7 @@ export class PolySelectToolView extends SelectToolView {
 
   _doubletap(ev: TapEvent): void {
     this._do_select(this.data.sx, this.data.sy, true, this._select_mode(ev))
-    this.plot_view.push_state('poly_select', {selection: this.plot_view.get_selection()})
+    this.plot_view.state.push("poly_select", {selection: this.plot_view.get_selection()})
     this._clear_data()
   }
 

--- a/bokehjs/src/lib/models/tools/gestures/tap_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/tap_tool.ts
@@ -39,7 +39,7 @@ export class TapToolView extends SelectToolView {
       }
 
       this._emit_selection_event(geometry)
-      this.plot_view.push_state('tap', {selection: this.plot_view.get_selection()})
+      this.plot_view.state.push("tap", {selection: this.plot_view.get_selection()})
     } else {
       for (const r of this.computed_renderers) {
         const rv = this.plot_view.renderer_view(r)

--- a/bokehjs/src/lib/models/tools/gestures/wheel_pan_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/wheel_pan_tool.ts
@@ -66,8 +66,7 @@ export class WheelPanToolView extends GestureToolView {
     this.plot_view.push_state('wheel_pan', {range: pan_info})
     this.plot_view.update_range(pan_info, {scrolling: true})
 
-    if (this.model.document != null)
-      this.model.document.interactive_start(this.plot_model)
+    this.model.document?.interactive_start(this.plot_model)
   }
 }
 

--- a/bokehjs/src/lib/models/tools/gestures/wheel_pan_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/wheel_pan_tool.ts
@@ -63,7 +63,7 @@ export class WheelPanToolView extends GestureToolView {
     // for GMap plots, and GMap plots always preserve aspect, so effective the value
     // of 'dimensions' is ignored.
     const pan_info = {xrs, yrs, factor}
-    this.plot_view.push_state('wheel_pan', {range: pan_info})
+    this.plot_view.state.push("wheel_pan", {range: pan_info})
     this.plot_view.update_range(pan_info, {scrolling: true})
 
     this.model.document?.interactive_start(this.plot_model)

--- a/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
@@ -44,7 +44,7 @@ export class WheelZoomToolView extends GestureToolView {
 
     const zoom_info = scale_range(frame, factor, h_axis, v_axis, {x: sx, y: sy})
 
-    this.plot_view.push_state('wheel_zoom', {range: zoom_info})
+    this.plot_view.state.push("wheel_zoom", {range: zoom_info})
 
     const {maintain_focus} = this.model
     this.plot_view.update_range(zoom_info, {scrolling: true, maintain_focus})

--- a/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
@@ -49,8 +49,7 @@ export class WheelZoomToolView extends GestureToolView {
     const {maintain_focus} = this.model
     this.plot_view.update_range(zoom_info, {scrolling: true, maintain_focus})
 
-    if (this.model.document != null)
-      this.model.document.interactive_start(this.plot_model)
+    this.model.document?.interactive_start(this.plot_model)
   }
 }
 

--- a/bokehjs/test/unit/core/ui_events.ts
+++ b/bokehjs/test/unit/core/ui_events.ts
@@ -14,10 +14,10 @@ import {WheelZoomTool} from "@bokehjs/models/tools/gestures/wheel_zoom_tool"
 import {Legend} from "@bokehjs/models/annotations/legend"
 import {Plot, PlotView} from "@bokehjs/models/plots/plot"
 import {Range1d} from "@bokehjs/models/ranges/range1d"
-import {UIEvents, UIEvent, PanEvent, TapEvent} from "@bokehjs/core/ui_events"
+import {UIEventBus, UIEvent, PanEvent, TapEvent} from "@bokehjs/core/ui_events"
 import {build_view} from "@bokehjs/core/build_views"
 
-describe("ui_events module", () => {
+describe("ui_event_bus module", () => {
 
   async function new_plot(): Promise<PlotView> {
     const plot = new Plot({
@@ -29,15 +29,15 @@ describe("ui_events module", () => {
 
   let hammer_stub: sinon.SinonStub
   let plot_view: PlotView
-  let ui_events: UIEvents
-  let ANY_ui_events: any
+  let ui_event_bus: UIEventBus
+  let ANY_ui_event_bus: any
 
   before_each(async () => {
-    hammer_stub = sinon.stub(UIEvents.prototype as any, "_configure_hammerjs") // XXX: protected
+    hammer_stub = sinon.stub(UIEventBus.prototype as any, "_configure_hammerjs") // XXX: protected
 
     plot_view = await new_plot()
-    ui_events = (plot_view as any).ui_event_bus // XXX: protected
-    ANY_ui_events = ui_events // XXX: protected
+    ui_event_bus = plot_view.canvas_view.ui_event_bus
+    ANY_ui_event_bus = ui_event_bus // XXX: testing protected methods/properties
   })
 
   after_each(() => {
@@ -45,11 +45,10 @@ describe("ui_events module", () => {
   })
 
   describe("_trigger method", () => {
-
     let spy_trigger: sinon.SinonSpy
 
     before_each(() => {
-      spy_trigger = sinon.spy(ui_events, "trigger")
+      spy_trigger = sinon.spy(ui_event_bus, "trigger")
     })
 
     after_each(() => {
@@ -59,9 +58,10 @@ describe("ui_events module", () => {
     describe("base_type=move", () => {
       let e: UIEvent
       let spy_cursor: sinon.SinonSpy
+
       before_each(() => {
         e = {type: "mousemove", sx: 0, sy: 0, ctrlKey: false, shiftKey: false}
-        spy_cursor = sinon.spy(plot_view, "set_cursor")
+        spy_cursor = sinon.spy(ui_event_bus, "set_cursor")
       })
 
       after_each(() => {
@@ -73,10 +73,10 @@ describe("ui_events module", () => {
         plot_view.model.add_tools(inspector)
         await plot_view.ready
 
-        ui_events._trigger(ui_events.move, e, new Event("mousemove"))
+        ui_event_bus._trigger(ui_event_bus.move, e, new Event("mousemove"))
 
         expect(spy_trigger.calledOnce).to.be.true
-        expect(spy_trigger.args[0]).to.be.equal([ui_events.move, e, inspector.id])
+        expect(spy_trigger.args[0]).to.be.equal([ui_event_bus.move, e, inspector.id])
       })
 
       it("should not trigger move event for inactive inspectors", async () => {
@@ -84,13 +84,13 @@ describe("ui_events module", () => {
         plot_view.model.add_tools(inspector)
         await plot_view.ready
 
-        ui_events._trigger(ui_events.move, e, new Event("mousemove"))
+        ui_event_bus._trigger(ui_event_bus.move, e, new Event("mousemove"))
 
         expect(spy_trigger.notCalled).to.be.true
       })
 
       it("should use default cursor no active inspector", () => {
-        ui_events._trigger(ui_events.move, e, new Event("mousemove"))
+        ui_event_bus._trigger(ui_event_bus.move, e, new Event("mousemove"))
 
         expect(spy_cursor.calledOnce).to.be.true
         expect(spy_cursor.calledWith("default")).to.be.true
@@ -101,9 +101,9 @@ describe("ui_events module", () => {
         plot_view.model.add_tools(inspector)
         await plot_view.ready
 
-        const ss = sinon.stub(ui_events as any, "_hit_test_frame").returns(false) // XXX: protected
+        const ss = sinon.stub(ui_event_bus as any, "_hit_test_frame").returns(false) // XXX: protected
 
-        ui_events._trigger(ui_events.move, e, new Event("mousemove"))
+        ui_event_bus._trigger(ui_event_bus.move, e, new Event("mousemove"))
         expect(spy_cursor.calledOnce).to.be.true
         expect(spy_cursor.calledWith("default")).to.be.true
 
@@ -115,9 +115,9 @@ describe("ui_events module", () => {
         plot_view.model.add_tools(inspector)
         await plot_view.ready
 
-        const ss = sinon.stub(ui_events as any, "_hit_test_frame").returns(true) // XXX: protected
+        const ss = sinon.stub(ui_event_bus as any, "_hit_test_frame").returns(true) // XXX: protected
 
-        ui_events._trigger(ui_events.move, e, new Event("mousemove"))
+        ui_event_bus._trigger(ui_event_bus.move, e, new Event("mousemove"))
         expect(spy_cursor.calledOnce).to.be.true
         expect(spy_cursor.calledWith("crosshair")).to.be.true
 
@@ -128,9 +128,9 @@ describe("ui_events module", () => {
         const legend = new Legend({click_policy: "mute"})
         const legend_view = await build_view(legend, {parent: plot_view})
 
-        const ss = sinon.stub(ui_events as any, "_hit_test_renderers").returns(legend_view) // XXX: protected
+        const ss = sinon.stub(ui_event_bus as any, "_hit_test_renderers").returns(legend_view) // XXX: protected
 
-        ui_events._trigger(ui_events.move, e, new Event("mousemove"))
+        ui_event_bus._trigger(ui_event_bus.move, e, new Event("mousemove"))
         expect(spy_cursor.calledOnce).to.be.true
         expect(spy_cursor.calledWith("pointer")).to.be.true
 
@@ -145,11 +145,11 @@ describe("ui_events module", () => {
         const legend = new Legend({click_policy: "mute"})
         const legend_view = await build_view(legend, {parent: plot_view})
 
-        const ss = sinon.stub(ui_events as any, "_hit_test_renderers").returns(legend_view) // XXX: protected
+        const ss = sinon.stub(ui_event_bus as any, "_hit_test_renderers").returns(legend_view) // XXX: protected
 
-        ui_events._trigger(ui_events.move, e, new Event("mousemove"))
+        ui_event_bus._trigger(ui_event_bus.move, e, new Event("mousemove"))
         expect(spy_trigger.calledOnce).to.be.true
-        expect(spy_trigger.args[0]).to.be.equal([ui_events.move_exit, e, inspector.id])
+        expect(spy_trigger.args[0]).to.be.equal([ui_event_bus.move_exit, e, inspector.id])
         // should also use view renderer cursor and not inspector cursor
         expect(spy_cursor.calledOnce).to.be.true
         expect(spy_cursor.calledWith("pointer")).to.be.true
@@ -165,7 +165,7 @@ describe("ui_events module", () => {
       })
 
       it("should not trigger tap event if no active tap tool", () => {
-        ui_events._trigger(ui_events.tap, e, new Event("mousemove"))
+        ui_event_bus._trigger(ui_event_bus.tap, e, new Event("mousemove"))
         expect(spy_trigger.notCalled).to.be.true
       })
 
@@ -174,20 +174,20 @@ describe("ui_events module", () => {
         plot_view.model.add_tools(gesture)
         await plot_view.ready
 
-        ui_events._trigger(ui_events.tap, e, new Event("mousemove"))
+        ui_event_bus._trigger(ui_event_bus.tap, e, new Event("mousemove"))
 
         expect(spy_trigger.calledOnce).to.be.true
-        expect(spy_trigger.args[0]).to.be.equal([ui_events.tap, e, gesture.id])
+        expect(spy_trigger.args[0]).to.be.equal([ui_event_bus.tap, e, gesture.id])
       })
 
       it("should call on_hit method on view renderer if exists", async () => {
         const legend = new Legend({click_policy: "mute"})
         const legend_view = await build_view(legend, {parent: plot_view})
 
-        const ss = sinon.stub(ui_events as any, "_hit_test_renderers").returns(legend_view) // XXX: protected
+        const ss = sinon.stub(ui_event_bus as any, "_hit_test_renderers").returns(legend_view) // XXX: protected
         const on_hit = sinon.stub(legend_view, "on_hit")
 
-        ui_events._trigger(ui_events.tap, e, new Event("mousemove"))
+        ui_event_bus._trigger(ui_event_bus.tap, e, new Event("mousemove"))
         expect(on_hit.calledOnce).to.be.true
         expect(on_hit.args[0]).to.be.equal([10, 15])
 
@@ -217,7 +217,7 @@ describe("ui_events module", () => {
 
       it("should not trigger scroll event if no active scroll tool", () => {
         plot_view.model.toolbar.gestures.scroll.active = null
-        ui_events._trigger(ui_events.scroll, e, srcEvent)
+        ui_event_bus._trigger(ui_event_bus.scroll, e, srcEvent)
         expect(spy_trigger.notCalled).to.be.true
 
         // assert that default scrolling isn't hijacked
@@ -233,14 +233,14 @@ describe("ui_events module", () => {
         // unclear why add_tools doesn't activate the tool, so have to do it manually
         plot_view.model.toolbar.gestures.scroll.active = gesture
 
-        ui_events._trigger(ui_events.scroll, e, srcEvent)
+        ui_event_bus._trigger(ui_event_bus.scroll, e, srcEvent)
 
         // assert that default scrolling is disabled
         expect(preventDefault.calledOnce).to.be.true
         expect(stopPropagation.calledOnce).to.be.true
 
         expect(spy_trigger.calledOnce).to.be.true
-        expect(spy_trigger.args[0]).to.be.equal([ui_events.scroll, e, gesture.id])
+        expect(spy_trigger.args[0]).to.be.equal([ui_event_bus.scroll, e, gesture.id])
       })
     })
 
@@ -251,7 +251,7 @@ describe("ui_events module", () => {
       })
 
       it("should not trigger event if no active tool", () => {
-        ui_events._trigger(ui_events.pan, e, new Event("pointerdown"))
+        ui_event_bus._trigger(ui_event_bus.pan, e, new Event("pointerdown"))
         expect(spy_trigger.notCalled).to.be.true
       })
 
@@ -260,10 +260,10 @@ describe("ui_events module", () => {
         plot_view.model.add_tools(gesture)
         await plot_view.ready
 
-        ui_events._trigger(ui_events.pan, e, new Event("pointerdown"))
+        ui_event_bus._trigger(ui_event_bus.pan, e, new Event("pointerdown"))
 
         expect(spy_trigger.calledOnce).to.be.true
-        expect(spy_trigger.args[0]).to.be.equal([ui_events.pan, e, gesture.id])
+        expect(spy_trigger.args[0]).to.be.equal([ui_event_bus.pan, e, gesture.id])
       })
     })
   })
@@ -287,8 +287,8 @@ describe("ui_events module", () => {
       e.pointerType = "mouse"
       e.srcEvent = {pageX: 100, pageY: 200}
 
-      const ev = ANY_ui_events._tap_event(e)
-      ANY_ui_events._trigger_bokeh_event(ev)
+      const ev = ANY_ui_event_bus._tap_event(e)
+      ANY_ui_event_bus._trigger_bokeh_event(ev)
 
       const bk_event = spy.args[0][0]
 
@@ -303,8 +303,8 @@ describe("ui_events module", () => {
       e.pageX = 100 // XXX: readonly
       e.pageY = 200 // XXX: readonly
 
-      const ev = ANY_ui_events._move_event(e)
-      ANY_ui_events._trigger_bokeh_event(ev)
+      const ev = ANY_ui_event_bus._move_event(e)
+      ANY_ui_event_bus._trigger_bokeh_event(ev)
 
       const bk_event = spy.args[0][0]
 
@@ -318,7 +318,7 @@ describe("ui_events module", () => {
   describe("_event methods", () => {
     // These tests are mildly integration tests. Based on an Event (as would be
     // initiated by event listeners attached in the _register_tool method), they
-    // check whether the BokehEvent and UIEvents are correctly triggered.
+    // check whether the BokehEvent and UIEventBus are correctly triggered.
 
     let dom_stub: sinon.SinonStub
     let spy_plot: sinon.SinonSpy
@@ -329,7 +329,7 @@ describe("ui_events module", () => {
       // The BokehEvent that is triggered by the plot
       spy_plot = sinon.spy(plot_view.model, "trigger_event")
       // The event is that triggered on UIEvent for tool interactions
-      spy_uievent = sinon.spy(ui_events, "trigger")
+      spy_uievent = sinon.spy(ui_event_bus, "trigger")
     })
 
     after_each(() => {
@@ -346,7 +346,7 @@ describe("ui_events module", () => {
       plot_view.model.add_tools(new TapTool())
       await plot_view.ready
 
-      ANY_ui_events._tap(e)
+      ANY_ui_event_bus._tap(e)
 
       expect(spy_plot.callCount).to.be.equal(2) // tap event and selection event
       expect(spy_uievent.calledOnce).to.be.true
@@ -360,7 +360,7 @@ describe("ui_events module", () => {
       plot_view.model.add_tools(new PolySelectTool())
       await plot_view.ready
 
-      ANY_ui_events._doubletap(e)
+      ANY_ui_event_bus._doubletap(e)
 
       expect(spy_plot.callCount).to.be.equal(2) // tap event and selection event
       expect(spy_uievent.calledOnce).to.be.true
@@ -371,7 +371,7 @@ describe("ui_events module", () => {
       e.pointerType = "mouse"
       e.srcEvent = {pageX: 100, pageY: 200, preventDefault: () => {}}
 
-      ANY_ui_events._press(e)
+      ANY_ui_event_bus._press(e)
 
       expect(spy_plot.calledOnce).to.be.true
       // There isn't a tool that uses the _press method
@@ -383,7 +383,7 @@ describe("ui_events module", () => {
       e.pointerType = "mouse"
       e.srcEvent = {pageX: 100, pageY: 200, preventDefault: () => {}}
 
-      ANY_ui_events._pressup(e)
+      ANY_ui_event_bus._pressup(e)
 
       expect(spy_plot.calledOnce).to.be.true
     })
@@ -397,7 +397,7 @@ describe("ui_events module", () => {
       plot_view.model.add_tools(pan_tool)
       await plot_view.ready
 
-      ANY_ui_events._pan_start(e)
+      ANY_ui_event_bus._pan_start(e)
 
       expect(spy_plot.called).to.be.true
       expect(spy_uievent.calledOnce).to.be.true
@@ -412,7 +412,7 @@ describe("ui_events module", () => {
       plot_view.model.add_tools(pan_tool)
       await plot_view.ready
 
-      ANY_ui_events._pan(e)
+      ANY_ui_event_bus._pan(e)
 
       expect(spy_plot.called).to.be.true
       expect(spy_uievent.calledOnce).to.be.true
@@ -427,7 +427,7 @@ describe("ui_events module", () => {
       plot_view.model.add_tools(pan_tool)
       await plot_view.ready
 
-      ANY_ui_events._pan_end(e)
+      ANY_ui_event_bus._pan_end(e)
 
       expect(spy_plot.calledOnce).to.be.true
       expect(spy_uievent.calledOnce).to.be.true
@@ -445,7 +445,7 @@ describe("ui_events module", () => {
       //idk why it's not auto active
       plot_view.model.toolbar.gestures.pinch.active = wheel_zoom_tool
 
-      ANY_ui_events._pinch_start(e)
+      ANY_ui_event_bus._pinch_start(e)
 
       expect(spy_plot.calledOnce).to.be.true
       // wheelzoomtool doesn't have _pinch_start but will emit event anyway
@@ -464,7 +464,7 @@ describe("ui_events module", () => {
       //idk why it's not auto active
       plot_view.model.toolbar.gestures.pinch.active = wheel_zoom_tool
 
-      ANY_ui_events._pinch(e)
+      ANY_ui_event_bus._pinch(e)
 
       expect(spy_plot.calledOnce).to.be.true
       expect(spy_uievent.calledOnce).to.be.true
@@ -482,7 +482,7 @@ describe("ui_events module", () => {
       //idk why it's not auto active
       plot_view.model.toolbar.gestures.pinch.active = wheel_zoom_tool
 
-      ANY_ui_events._pinch_end(e)
+      ANY_ui_event_bus._pinch_end(e)
 
       expect(spy_plot.calledOnce).to.be.true
       // wheelzoomtool doesn't have _pinch_start but will emit event anyway
@@ -496,7 +496,7 @@ describe("ui_events module", () => {
       plot_view.model.add_tools(crosshair_tool)
       await plot_view.ready
 
-      ANY_ui_events._mouse_enter(e)
+      ANY_ui_event_bus._mouse_enter(e)
 
       expect(spy_plot.calledOnce).to.be.true
       expect(spy_uievent.calledOnce).to.be.true
@@ -509,7 +509,7 @@ describe("ui_events module", () => {
       plot_view.model.add_tools(crosshair_tool)
       await plot_view.ready
 
-      ANY_ui_events._mouse_move(e)
+      ANY_ui_event_bus._mouse_move(e)
 
       expect(spy_plot.calledOnce).to.be.true
       expect(spy_uievent.calledOnce).to.be.true
@@ -522,7 +522,7 @@ describe("ui_events module", () => {
       plot_view.model.add_tools(crosshair_tool)
       await plot_view.ready
 
-      ANY_ui_events._mouse_exit(e)
+      ANY_ui_event_bus._mouse_exit(e)
 
       expect(spy_plot.calledOnce).to.be.true
       expect(spy_uievent.calledOnce).to.be.true
@@ -538,7 +538,7 @@ describe("ui_events module", () => {
       //idk why it's not auto active
       plot_view.model.toolbar.gestures.scroll.active = wheel_zoom_tool
 
-      ANY_ui_events._mouse_wheel(e)
+      ANY_ui_event_bus._mouse_wheel(e)
 
       expect(spy_plot.called).to.be.true
       expect(spy_uievent.calledOnce).to.be.true
@@ -551,7 +551,7 @@ describe("ui_events module", () => {
       plot_view.model.add_tools(poly_select_tool)
       await plot_view.ready
 
-      ANY_ui_events._key_up(e)
+      ANY_ui_event_bus._key_up(e)
 
       // There isn't a BokehEvent model for keydown events
       // expect(spy_plot.calledOnce).to.be.true
@@ -580,13 +580,13 @@ describe("ui_events module", () => {
       etap.pointerType = "mouse"
       etap.srcEvent = {pageX: 100, pageY: 200, preventDefault: () => {}}
 
-      ANY_ui_events._tap(etap)
+      ANY_ui_event_bus._tap(etap)
       expect(spy_uievent.calledOnce).to.be.true
 
       const epan: any = new Event("pan") // XXX: not a hammerjs event
       epan.pointerType = "mouse"
       epan.srcEvent = {pageX: 100, pageY: 200, preventDefault: () => {}}
-      ANY_ui_events._pan(epan)
+      ANY_ui_event_bus._pan(epan)
       expect(spy_uievent.calledTwice).to.be.true
     })
   })

--- a/bokehjs/test/unit/models/plots/plot.ts
+++ b/bokehjs/test/unit/models/plots/plot.ts
@@ -51,7 +51,7 @@ describe("Plot module", () => {
 
     it("should perform standard reset actions by default", async () => {
       const view = await new_plot_view()
-      const spy_state = sinon.spy(view, 'clear_state')
+      const spy_state = sinon.spy(view.state, 'clear')
       const spy_range = sinon.spy(view, 'reset_range')
       const spy_selection = sinon.spy(view, 'reset_selection')
       const spy_event = sinon.spy(view.model, 'trigger_event')
@@ -64,7 +64,7 @@ describe("Plot module", () => {
 
     it("should skip standard reset actions for event_only policy", async () => {
       const view = await new_plot_view({reset_policy: "event_only"})
-      const spy_state = sinon.spy(view, 'clear_state')
+      const spy_state = sinon.spy(view.state, 'clear')
       const spy_range = sinon.spy(view, 'reset_range')
       const spy_selection = sinon.spy(view, 'reset_selection')
       const spy_event = sinon.spy(view.model, 'trigger_event')


### PR DESCRIPTION
Continuing on top of PR #10491, this PR:

- [x] moves UI event handling to canvas (in preparation to make canvas a standalone model and reusing for non-plot purpose)
- [x] splits off state management code (undo/redo/reset) (in preparation to add support for multi-plot state, e.g. in grid plots)
- [x] makes various minor improvements in related code (e.g. use `Plot.data_renderers` instead of explicit `instanceof` checks)
