### PR TITLE
add bk- prefix to make serialization id valid for css

### DIFF
--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -267,7 +267,8 @@ def make_globally_unique_id():
         str
 
     '''
-    return str(uuid.uuid4())
+    # add bk prefix to make id valid for css
+    return 'bk-' + str(uuid.uuid4())
 
 def array_encoding_disabled(array):
     ''' Determine whether an array may be binary encoded.

--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -257,7 +257,9 @@ def make_id():
             str_id = str(_simple_id)
     else:
         str_id = make_globally_unique_id()
+
     # add bk- prefix to make id valid for css
+    # https://github.com/bokeh/bokeh/issues/10547
     return 'bk-' + str_id
 
 def make_globally_unique_id():

--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -243,6 +243,7 @@ def make_id():
     IDs (as strings) for identifying Bokeh objects within a Document. However,
     if it is desirable to have globally unique for every object, this behavior
     can be overridden by setting the environment variable ``BOKEH_SIMPLE_IDS=no``.
+    IDs are returned with a prefix of ``bk-``.
 
     Returns:
         str
@@ -253,9 +254,11 @@ def make_id():
     if settings.simple_ids():
         with _simple_id_lock:
             _simple_id += 1
-            return str(_simple_id)
+            str_id = str(_simple_id)
     else:
-        return make_globally_unique_id()
+        str_id = make_globally_unique_id()
+    # add bk- prefix to make id valid for css
+    return 'bk-' + str_id
 
 def make_globally_unique_id():
     ''' Return a globally unique UUID.
@@ -267,8 +270,7 @@ def make_globally_unique_id():
         str
 
     '''
-    # add bk prefix to make id valid for css
-    return 'bk-' + str(uuid.uuid4())
+    return str(uuid.uuid4())
 
 def array_encoding_disabled(array):
     ''' Determine whether an array may be binary encoded.

--- a/tests/unit/bokeh/util/test_serialization.py
+++ b/tests/unit/bokeh/util/test_serialization.py
@@ -51,13 +51,13 @@ class Test_make_id:
 
     def test_simple_ids_no(self) -> None:
         os.environ["BOKEH_SIMPLE_IDS"] = "no"
-        assert len(bus.make_id()) == 36
+        assert len(bus.make_id()) == 39
         assert isinstance(bus.make_id(), str)
         del os.environ["BOKEH_SIMPLE_IDS"]
 
 class Test_make_globally_unique_id:
     def test_basic(self) -> None:
-        assert len(bus.make_globally_unique_id()) == 36
+        assert len(bus.make_globally_unique_id()) == 39
         assert isinstance(bus.make_globally_unique_id(), str)
 
 def test_np_consts() -> None:

--- a/tests/unit/bokeh/util/test_serialization.py
+++ b/tests/unit/bokeh/util/test_serialization.py
@@ -38,16 +38,16 @@ import bokeh.util.serialization as bus # isort:skip
 class Test_make_id:
     def test_default(self) -> None:
         bus._simple_id = 999
-        assert bus.make_id() == "1000"
-        assert bus.make_id() == "1001"
-        assert bus.make_id() == "1002"
+        assert bus.make_id() == "bk-1000"
+        assert bus.make_id() == "bk-1001"
+        assert bus.make_id() == "bk-1002"
 
     def test_simple_ids_yes(self) -> None:
         bus._simple_id = 999
         os.environ["BOKEH_SIMPLE_IDS"] = "yes"
-        assert bus.make_id() == "1000"
-        assert bus.make_id() == "1001"
-        assert bus.make_id() == "1002"
+        assert bus.make_id() == "bk-1000"
+        assert bus.make_id() == "bk-1001"
+        assert bus.make_id() == "bk-1002"
 
     def test_simple_ids_no(self) -> None:
         os.environ["BOKEH_SIMPLE_IDS"] = "no"
@@ -57,7 +57,7 @@ class Test_make_id:
 
 class Test_make_globally_unique_id:
     def test_basic(self) -> None:
-        assert len(bus.make_globally_unique_id()) == 39
+        assert len(bus.make_globally_unique_id()) == 36
         assert isinstance(bus.make_globally_unique_id(), str)
 
 def test_np_consts() -> None:

--- a/tests/unit/bokeh/util/test_serialization.py
+++ b/tests/unit/bokeh/util/test_serialization.py
@@ -53,6 +53,7 @@ class Test_make_id:
         os.environ["BOKEH_SIMPLE_IDS"] = "no"
         assert len(bus.make_id()) == 39
         assert isinstance(bus.make_id(), str)
+        assert bus.make_id().startswith("bk-")
         del os.environ["BOKEH_SIMPLE_IDS"]
 
 class Test_make_globally_unique_id:


### PR DESCRIPTION
In CSS, identifiers cannot start with a digit. This PR makes the globally unique ids generated for bokeh serialization start with a non-digit (specifically, `bk-`). This makes it a valid identifier for selection by CSS and still globally unique.

- [x] issues: fixes #10547
- [x] tests added / passed
