### PR TITLE
Remove overwrite prompt for windows make.bat

### DIFF
--- a/sphinx/make.bat
+++ b/sphinx/make.bat
@@ -38,7 +38,7 @@ if "%1" == "all" (
 
 if "%1" == "html" (
 	%SPHINXBUILD% -b html %ALLSPHINXOPTS% %BUILDDIR%\html
-	xcopy ..\bokeh\server\static %BUILDDIR%\html\static\ /s /e /h
+	xcopy ..\bokeh\server\static %BUILDDIR%\html\static\ /s /e /h /y
 	if errorlevel 1 exit /b 1
 	echo.
 	echo.Build finished. The HTML pages are in %BUILDDIR%/html.


### PR DESCRIPTION
When building the docs on a Windows system with Bokeh's `make.bat` file (e.g. `make.bat html`), Windows unnecessarily prompts the user to overwrite existing files. Adding the option `/y` to the .bat-file's xcopy command will automatically overwrite those files.
Solves #10551