### PR TITLE
Clean up usage of `requestAnimationFrame`

### DIFF
--- a/bokehjs/src/lib/core/signaling.ts
+++ b/bokehjs/src/lib/core/signaling.ts
@@ -1,6 +1,6 @@
 // Based on https://github.com/phosphorjs/phosphor/blob/master/packages/signaling/src/index.ts
 
-import {defer} from "./util/callback"
+import {defer} from "./util/defer"
 import {find, remove_by} from "./util/array"
 
 export type Slot<Args, Sender extends object> = (args: Args, sender: Sender) => void
@@ -181,7 +181,10 @@ const dirty_set = new Set<Connection[]>()
 
 function scheduleCleanup(connections: Connection[]): void {
   if (dirty_set.size === 0) {
-    defer(cleanup_dirty_set)
+    (async () => {
+      await defer()
+      cleanup_dirty_set()
+    })()
   }
   dirty_set.add(connections)
 }

--- a/bokehjs/src/lib/core/util/callback.ts
+++ b/bokehjs/src/lib/core/util/callback.ts
@@ -3,19 +3,7 @@
 //     (c) 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
 //     Underscore may be freely distributed under the MIT license.
 
-export function delay(func: () => void, wait: number): number {
-  return setTimeout(func, wait)
-}
-
-const _defer = typeof requestAnimationFrame === "function" ? requestAnimationFrame : setImmediate
-
-export function defer<T>(func: () => T): Promise<T> {
-  return new Promise((resolve) => {
-    _defer(() => resolve(func()))
-  })
-}
-
-export interface ThrottleOptions {
+export type ThrottleOptions = {
   leading?: boolean
   trailing?: boolean
 }

--- a/bokehjs/src/lib/core/util/defer.ts
+++ b/bokehjs/src/lib/core/util/defer.ts
@@ -1,0 +1,24 @@
+const channel = new MessageChannel()
+const tasks: Map<number, () => void> = new Map()
+
+channel.port1.onmessage = (event) => {
+  const handle = event.data
+  const fn = tasks.get(handle)
+  if (fn != null) {
+    try {
+      fn()
+    } finally {
+      tasks.delete(handle)
+    }
+  }
+}
+
+let counter = 1
+
+export function defer(): Promise<void> {
+  return new Promise((resolve) => {
+    const handle = counter++
+    tasks.set(handle, resolve)
+    channel.port2.postMessage(handle)
+  })
+}

--- a/bokehjs/src/lib/core/util/throttle.ts
+++ b/bokehjs/src/lib/core/util/throttle.ts
@@ -1,25 +1,12 @@
-function _delay_animation(callback: FrameRequestCallback): number {
-  callback(Date.now()) // XXX: performance.now()
-  return -1
-}
-
-const delay_animation =
-  (typeof window !== 'undefined' ?  window.requestAnimationFrame       : undefined) ??
-  (typeof window !== 'undefined' ?  window.webkitRequestAnimationFrame : undefined) ??
-  (typeof window !== 'undefined' ? (window as any).mozRequestAnimationFrame    : undefined) ??
-  (typeof window !== 'undefined' ? (window as any).msRequestAnimationFrame     : undefined) ?? _delay_animation
-
-// Returns a function, that, when invoked, will only be triggered at
-// most once during a given window of time.
-//
-// In addition, if the browser supports requestAnimationFrame, the
-// throttled function will be run no more frequently than request
-// animation frame allows.
-//
-// @param func [function] the function to throttle
-// @param wait [number] time in milliseconds to use for window
-// @return [function] throttled function
-//
+/**
+ * Returns a function, that, when invoked, will only be triggered at
+ * most once during a given interval of time and no more frequently
+ * than the animation frame rate allows it.
+ *
+ * @param func [function] the function to throttle
+ * @param wait [number] time in milliseconds to use for window
+ * @return [function] throttled function
+ */
 export function throttle(func: () => void, wait: number): () => Promise<void> {
   let timeout: number | null = null
   let previous = 0
@@ -46,9 +33,9 @@ export function throttle(func: () => void, wait: number): () => Promise<void> {
           clearTimeout(timeout)
         }
         pending = true
-        delay_animation(later)
+        requestAnimationFrame(later)
       } else if (!timeout && !pending) {
-        timeout = setTimeout(() => delay_animation(later), remaining)
+        timeout = setTimeout(() => requestAnimationFrame(later), remaining)
       } else {
         resolve()
       }

--- a/bokehjs/src/lib/embed/index.ts
+++ b/bokehjs/src/lib/embed/index.ts
@@ -3,7 +3,7 @@ import {logger} from "../core/logging"
 import {unescape, uuid4} from "../core/util/string"
 import {entries} from "core/util/object"
 import {isString} from "../core/util/types"
-import {defer} from "core/util/callback"
+import {defer} from "core/util/defer"
 import {View} from "core/view"
 
 import {DocsJson, RenderItem} from "./json"
@@ -35,7 +35,9 @@ export async function embed_item(item: JsonItem, target_id?: string): Promise<Vi
   const roots: Roots = {[item.root_id]: target_id}
   const render_item: RenderItem = {roots, root_ids: [item.root_id], docid: doc_id}
 
-  const [views] = await defer(() => _embed_items(docs_json, [render_item]))
+  await defer()
+
+  const [views] = await _embed_items(docs_json, [render_item])
   return views
 }
 
@@ -44,7 +46,8 @@ export async function embed_item(item: JsonItem, target_id?: string): Promise<Vi
 // absolute_url as well if non-relative links are needed for resources. This function
 // should probably be split in to two pieces to reflect the different usage patterns
 export async function embed_items(docs_json: string | DocsJson, render_items: RenderItem[], app_path?: string, absolute_url?: string): Promise<View[][]> {
-  return await defer(() => _embed_items(docs_json, render_items, app_path, absolute_url))
+  await defer()
+  return _embed_items(docs_json, render_items, app_path, absolute_url)
 }
 
 async function _embed_items(docs_json: string | DocsJson, render_items: RenderItem[], app_path?: string, absolute_url?: string): Promise<View[][]> {


### PR DESCRIPTION
This PR does two things:

1. Removes `requestAnimationFrame`'s polyfill, because all supported browsers implement it.
2. Replaces incorrect usage of `requestAnimationFrame` in bokehjs, especially in `defer()`, which is replaced with an efficient (zero delay) implementation using `postMessage` technique.