### PR TITLE
Switch sphinx-panels from pip to conda

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,9 +23,7 @@ dependencies:
   - colorcet
   - pygments
   - sphinx >=1.8
-  - pip
-  - pip:
-    - sphinx-panels
+  - sphinx-panels
 
   # tests
   - beautifulsoup4


### PR DESCRIPTION
The Sphinx extension sphinx-panels has [recently become available](https://github.com/conda-forge/staged-recipes/pull/12517) on conda forge. Therefore, it is no longer necessary to install this extension with pip.