### PR TITLE
Redesign how serialization works in bokehjs

### DIFF
--- a/bokeh/models/arrow_heads.py
+++ b/bokeh/models/arrow_heads.py
@@ -47,14 +47,14 @@ class ArrowHead(Model):
 
     '''
 
+    size = Float(default=25, help="""
+    The size, in pixels, of the arrow head.
+    """)
+
 class OpenHead(ArrowHead):
     ''' Render an open-body arrow head.
 
     '''
-
-    size = Float(default=25, help="""
-    The size, in pixels, of the arrow head.
-    """)
 
     line_props = Include(ScalarLineProps, use_prefix=False, help="""
 
@@ -65,10 +65,6 @@ class NormalHead(ArrowHead):
     ''' Render a closed-body arrow head.
 
     '''
-
-    size = Float(default=25, help="""
-    The size, in pixels, of the arrow head.
-    """)
 
     line_props = Include(ScalarLineProps, use_prefix=False, help="""
     The %s values for the arrow head outline.
@@ -85,10 +81,6 @@ class TeeHead(ArrowHead):
 
     '''
 
-    size = Float(default=25, help="""
-    The size, in pixels, of the arrow head.
-    """)
-
     line_props = Include(ScalarLineProps, use_prefix=False, help="""
     The %s values for the arrow head outline.
     """)
@@ -97,10 +89,6 @@ class VeeHead(ArrowHead):
     ''' Render a vee-style arrow head.
 
     '''
-
-    size = Float(default=25, help="""
-    The size, in pixels, of the arrow head.
-    """)
 
     line_props = Include(ScalarLineProps, use_prefix=False, help="""
     The %s values for the arrow head outline.

--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -71,7 +71,7 @@ from ..core.properties import (
     String,
     StringSpec,
 )
-from ..core.property.dataspec import field
+from ..core.property.dataspec import field, value
 from ..core.property_mixins import (
     FillProps,
     HatchProps,
@@ -393,15 +393,15 @@ class HBar(LineGlyph, FillGlyph, HatchGlyph):
     The y-coordinates of the centers of the horizontal bars.
     """)
 
-    height = NumberSpec(help="""
+    height = NumberSpec(default=value(1), help="""
     The heights of the vertical bars.
     """)
 
-    left = NumberSpec(default=0, help="""
+    left = NumberSpec(default=value(0), help="""
     The x-coordinates of the left edges.
     """)
 
-    right = NumberSpec(help="""
+    right = NumberSpec(default=field("right"), help="""
     The x-coordinates of the right edges.
     """)
 
@@ -934,19 +934,19 @@ class Quad(LineGlyph, FillGlyph, HatchGlyph):
     # functions derived from this class
     _args = ('left', 'right', 'top', 'bottom')
 
-    left = NumberSpec(help="""
+    left = NumberSpec(default=field("left"), help="""
     The x-coordinates of the left edges.
     """)
 
-    right = NumberSpec(help="""
+    right = NumberSpec(default=field("right"), help="""
     The x-coordinates of the right edges.
     """)
 
-    bottom = NumberSpec(help="""
+    bottom = NumberSpec(default=field("bottom"), help="""
     The y-coordinates of the bottom edges.
     """)
 
-    top = NumberSpec(help="""
+    top = NumberSpec(default=field("top"), help="""
     The y-coordinates of the top edges.
     """)
 
@@ -1242,7 +1242,7 @@ class VBar(LineGlyph, FillGlyph, HatchGlyph):
     The x-coordinates of the centers of the vertical bars.
     """)
 
-    width = NumberSpec(help="""
+    width = NumberSpec(default=value(1), help="""
     The widths of the vertical bars.
     """)
 
@@ -1250,7 +1250,7 @@ class VBar(LineGlyph, FillGlyph, HatchGlyph):
     The y-coordinates of the bottom edges.
     """)
 
-    top = NumberSpec(help="""
+    top = NumberSpec(default=field("top"), help="""
     The y-coordinates of the top edges.
     """)
 

--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -71,7 +71,7 @@ from ..core.properties import (
     String,
     StringSpec,
 )
-from ..core.property.dataspec import field, value
+from ..core.property.dataspec import field
 from ..core.property_mixins import (
     FillProps,
     HatchProps,
@@ -393,11 +393,11 @@ class HBar(LineGlyph, FillGlyph, HatchGlyph):
     The y-coordinates of the centers of the horizontal bars.
     """)
 
-    height = NumberSpec(default=value(1), help="""
+    height = NumberSpec(default=1, help="""
     The heights of the vertical bars.
     """)
 
-    left = NumberSpec(default=value(0), help="""
+    left = NumberSpec(default=0, help="""
     The x-coordinates of the left edges.
     """)
 
@@ -1242,7 +1242,7 @@ class VBar(LineGlyph, FillGlyph, HatchGlyph):
     The x-coordinates of the centers of the vertical bars.
     """)
 
-    width = NumberSpec(default=value(1), help="""
+    width = NumberSpec(default=1, help="""
     The widths of the vertical bars.
     """)
 

--- a/bokeh/models/renderers.py
+++ b/bokeh/models/renderers.py
@@ -46,7 +46,7 @@ from ..core.validation.errors import (
 from ..model import Model
 from .glyphs import Circle, ConnectedXYGlyph, Glyph, MultiLine
 from .graphs import GraphHitTestPolicy, LayoutProvider, NodesOnly
-from .sources import CDSView, ColumnDataSource, DataSource, WebSource
+from .sources import CDSView, ColumnDataSource, DataSource, WebDataSource
 from .tiles import TileSource, WMTSTileSource
 
 #-----------------------------------------------------------------------------
@@ -154,7 +154,7 @@ class GlyphRenderer(DataRenderer):
     def _check_bad_column_name(self):
         if not self.glyph: return
         if not self.data_source: return
-        if isinstance(self.data_source, WebSource): return
+        if isinstance(self.data_source, WebDataSource): return
         missing_values = set()
         specs = self.glyph.dataspecs()
         for name, item in self.glyph.properties_with_values(include_defaults=False).items():

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -57,7 +57,7 @@ __all__ = (
     'DataSource',
     'GeoJSONDataSource',
     'ServerSentDataSource',
-    'WebSource',
+    'WebDataSource',
 )
 
 #-----------------------------------------------------------------------------
@@ -709,7 +709,7 @@ class GeoJSONDataSource(ColumnarDataSource):
     """)
 
 @abstract
-class WebSource(ColumnDataSource):
+class WebDataSource(ColumnDataSource):
     ''' Base class for web column data sources that can update from data
     URLs.
 
@@ -744,13 +744,13 @@ class WebSource(ColumnDataSource):
     A URL to to fetch data from.
     """)
 
-class ServerSentDataSource(WebSource):
+class ServerSentDataSource(WebDataSource):
     ''' A data source that can populate columns by receiving server sent
     events endpoints.
 
     '''
 
-class AjaxDataSource(WebSource):
+class AjaxDataSource(WebDataSource):
     ''' A data source that can populate columns by making Ajax calls to REST
     endpoints.
 

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -58,6 +58,7 @@ __all__ = (
     'GeoJSONDataSource',
     'ServerSentDataSource',
     'WebDataSource',
+    'WebSource',
 )
 
 #-----------------------------------------------------------------------------
@@ -743,6 +744,9 @@ class WebDataSource(ColumnDataSource):
     data_url = String(help="""
     A URL to to fetch data from.
     """)
+
+# TODO: deprecated, remove at bokeh 3.0
+WebSource = WebDataSource
 
 class ServerSentDataSource(WebDataSource):
     ''' A data source that can populate columns by receiving server sent

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -96,6 +96,7 @@ from .renderers import GlyphRenderer, Renderer
 #-----------------------------------------------------------------------------
 
 __all__ = (
+    'Action',
     'ActionTool',
     'BoxEditTool',
     'BoxSelectTool',
@@ -108,7 +109,9 @@ __all__ = (
     'FreehandDrawTool',
     'HelpTool',
     'HoverTool',
+    'Inspect',
     'InspectTool',
+    'Gesture',
     'GestureTool',
     'LassoSelectTool',
     'LineEditTool',
@@ -172,12 +175,18 @@ class ActionTool(Tool):
     '''
     pass
 
+# TODO: deprecated, remove at bokeh 3.0
+Action = ActionTool
+
 @abstract
 class GestureTool(Tool):
     ''' A base class for tools that respond to drag events.
 
     '''
     pass
+
+# TODO: deprecated, remove at bokeh 3.0
+Gesture = GestureTool
 
 @abstract
 class Drag(GestureTool):
@@ -232,6 +241,9 @@ class InspectTool(GestureTool):
     inspection tool. If ``False``, the viewers of a plot will not be able to
     toggle the inspector on or off using the toolbar.
     """)
+
+# TODO: deprecated, remove at bokeh 3.0
+Inspect = InspectTool
 
 @abstract
 class ToolbarBase(Model):

--- a/bokeh/models/widgets/buttons.py
+++ b/bokeh/models/widgets/buttons.py
@@ -68,7 +68,7 @@ class AbstractButton(Widget, ButtonLike):
 
     '''
 
-    label = String("", help="""
+    label = String("Button", help="""
     The text label for the button to display.
     """)
 

--- a/bokeh/plotting/_tools.py
+++ b/bokeh/plotting/_tools.py
@@ -36,7 +36,7 @@ from typing_extensions import Literal
 
 # Bokeh imports
 from ..models import HoverTool, Plot, Tool, Toolbar
-from ..models.tools import Drag, Inspection, Scroll, Tap
+from ..models.tools import Drag, InspectTool, Scroll, Tap
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -58,7 +58,7 @@ __all__ = (
 # TODO: str should be literal union of e.g. pan | xpan | ypan
 Auto = Literal["auto"]
 ActiveDrag = Union[Drag, Auto, str, None]
-ActiveInspect = Union[List[Inspection], Inspection, Auto, str, None]
+ActiveInspect = Union[List[InspectTool], InspectTool, Auto, str, None]
 ActiveScroll = Union[Scroll, Auto, str, None]
 ActiveTap = Union[Tap, Auto, str, None]
 

--- a/bokeh/plotting/figure.py
+++ b/bokeh/plotting/figure.py
@@ -30,7 +30,7 @@ from ..core.properties import (
     Tuple,
 )
 from ..models import ColumnDataSource, GraphRenderer, Plot, Title, Tool, glyphs, markers
-from ..models.tools import Drag, Inspection, Scroll, Tap
+from ..models.tools import Drag, InspectTool, Scroll, Tap
 from ..transform import linear_cmap
 from ..util.options import Options
 from ._decorators import glyph_method
@@ -1605,7 +1605,7 @@ class FigureOptions(Options):
     Which drag tool should initially be active.
     """)
 
-    active_inspect = Either(Auto, String, Instance(Inspection), Seq(Instance(Inspection)), default="auto", help="""
+    active_inspect = Either(Auto, String, Instance(InspectTool), Seq(Instance(InspectTool)), default="auto", help="""
     Which drag tool should initially be active.
     """)
 

--- a/bokeh/plotting/gmap.py
+++ b/bokeh/plotting/gmap.py
@@ -27,7 +27,7 @@ from ..models import (
     Title,
     Tool,
 )
-from ..models.tools import Drag, Inspection, Scroll, Tap
+from ..models.tools import Drag, InspectTool, Scroll, Tap
 from ..util.options import Options
 from ._tools import process_active_tools, process_tools_arg
 from .figure import Figure
@@ -272,7 +272,7 @@ class GMapFigureOptions(Options):
     Which drag tool should initially be active.
     """)
 
-    active_inspect = Either(Auto, String, Instance(Inspection), Seq(Instance(Inspection)), default="auto", help="""
+    active_inspect = Either(Auto, String, Instance(InspectTool), Seq(Instance(InspectTool)), default="auto", help="""
     Which drag tool should initially be active.
     """)
 

--- a/bokehjs/make/tasks/generate_defaults.py
+++ b/bokehjs/make/tasks/generate_defaults.py
@@ -1,70 +1,40 @@
 # Standard library imports
-import inspect
 import os
 import sys
 import warnings
 from json import loads
 
 # Bokeh imports
-import bokeh.models as models
 from bokeh.core.json_encoder import serialize_json
 from bokeh.model import Model
 from bokeh.util.warnings import BokehDeprecationWarning
 
+import bokeh.models; bokeh.models # isort:skip
+
 dest_dir = sys.argv[1]
 
-classes = [member for name, member in inspect.getmembers(models) if inspect.isclass(member)]
-model_class = next(klass for klass in classes if klass.__name__ == 'Model')
-
-# getclasstree returns a list which contains [ (class, parentClass), [(subClassOfClass, class), ...]]
-# where the subclass list is omitted if there are no subclasses.
-# If you say unique=True then mixins will be registered as leaves so don't use unique=True,
-# and expect to have duplicates in the result of leaves()
-all_tree = inspect.getclasstree(classes, unique=False)
-
-def leaves(tree, underneath):
-    if len(tree) == 0:
-        return []
-    elif len(tree) > 1 and isinstance(tree[1], list):
-        subs = tree[1]
-        if underneath is None or tree[0][0] != underneath:
-            return leaves(subs, underneath) + leaves(tree[2:], underneath)
-        else:
-            # underneath=None to return all leaves from here out
-            return leaves(subs, underneath=None)
-    else:
-        leaf = tree[0]
-        tail = tree[1:]
-        if leaf[0] == underneath:
-            return [leaf]
-        elif underneath is not None:
-            return leaves(tail, underneath)
-        else:
-            return [leaf] + leaves(tail, underneath)
-
 all_json = {}
-for leaf in leaves(all_tree, model_class):
-    klass = leaf[0]
-    vm_name = klass.__view_model__
-    if vm_name in all_json:
-        continue
-    defaults = {}
+for name, model in Model.model_class_reverse_map.items():
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=BokehDeprecationWarning)
-        instance = klass()
-    props_with_values = instance.query_properties_with_values(lambda prop: prop.readonly or prop.serialized)
-    for name, default in props_with_values.items():
+        obj = model()
+
+    props_with_values = obj.query_properties_with_values(lambda prop: prop.readonly or prop.serialized)
+    defaults = {}
+
+    for attr, default in props_with_values.items():
         if isinstance(default, Model):
             struct = default.struct
             raw_attrs = default._to_json_like(include_defaults=True)
             attrs = loads(serialize_json(raw_attrs))
-            struct['attributes'] = attrs
-            del struct['id'] # there's no way the ID will match bokehjs
+            struct["attributes"] = attrs
+            del struct["id"] # there's no way the ID will match bokehjs
             default = struct
-        elif isinstance(default, float) and default == float('inf'):
+        elif isinstance(default, float) and default == float("inf"):
             default = None
-        defaults[name] = default
-    all_json[vm_name] = defaults
+        defaults[attr] = default
+
+    all_json[name] = defaults
 
 def output_defaults_module(filename, defaults):
     dest = os.path.join(dest_dir, ".generated_defaults", filename)

--- a/bokehjs/package-lock.json
+++ b/bokehjs/package-lock.json
@@ -2844,6 +2844,11 @@
         "ipaddr.js": "1.9.1"
       }
     },
+    "proxy-polyfill": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/proxy-polyfill/-/proxy-polyfill-0.3.2.tgz",
+      "integrity": "sha512-ENKSXOMCewnQTOyqrQXxEjIhzT6dy572mtehiItbDoIUF5Sv5UkmRUc8kowg2MFvr232Uo8rwRpNg3V5kgTKbA=="
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -83,6 +83,7 @@
     "es6-map": "^0.1.5",
     "es6-set": "^0.1.5",
     "es6-symbol": "^3.1.3",
+    "proxy-polyfill": "^0.3.2",
     "flatbush": "^3.2.1",
     "flatpickr": "^4.6.6",
     "hammerjs": "^2.0.4",

--- a/bokehjs/src/lib/base.ts
+++ b/bokehjs/src/lib/base.ts
@@ -54,7 +54,7 @@ Models.register_models = (models, force = false, errorFn?) => {
 
 export const register_models = Models.register_models
 
-Models.registered_names = () => Array.from(_all_models.keys())
+Models.registered_names = () => [..._all_models.keys()]
 
 // TODO: this doesn't belong here, but it's easier this way for backwards compatibility
 import * as AllModels from "./models"

--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -298,9 +298,13 @@ export abstract class HasProps extends Signalable() implements Equatable, Printa
     for (const [name, {type, default_value, options}] of entries(this._props)) {
       let property: p.Property<unknown>
 
-      if (type instanceof p.PropertyAlias)
-        property = this.properties[type.attr]
-      else if (type instanceof k.Kind)
+      if (type instanceof p.PropertyAlias) {
+        property = new Proxy(this.properties[type.attr], {
+          get(target, member) {
+            return member == "attr" ? name : target[member as keyof typeof target]
+          },
+        })
+      } else if (type instanceof k.Kind)
         property = new p.PrimitiveProperty(this, name, type, default_value, get(name), options)
       else
         property = new type(this, name, k.Any, default_value, get(name), options)

--- a/bokehjs/src/lib/core/serializer.ts
+++ b/bokehjs/src/lib/core/serializer.ts
@@ -1,0 +1,99 @@
+import {assert} from "./util/assert"
+import {entries} from "./util/object"
+import {Ref, Struct} from "./util/refs"
+import {isPlainObject, isArray, isTypedArray, isBoolean, isNumber, isString} from "./util/types"
+
+export type SerializableType =
+  | null
+  | boolean
+  | number
+  | string
+  | Serializable
+  | SerializableType[]
+  | {[key: string]: SerializableType}
+  //| Map<SerializableType, SerializableType>
+  //| Set<SerializableType>
+  //| ArrayBuffer
+  // TypedArray?
+
+export const serialize = Symbol("serialize")
+
+export interface Serializable {
+  [serialize](serializer: Serializer): unknown
+}
+
+function is_Serializable<T>(obj: T): obj is T & Serializable {
+  return serialize in Object(obj)
+}
+
+export type SerializableOf<T extends SerializableType> =
+  T extends Serializable       ? ReturnType<T[typeof serialize]> :
+  T extends SerializableType[] ? SerializableOf<T[number]>[]     : unknown
+
+export class SerializationError extends Error {}
+
+export class Serializer {
+  private readonly _references: Map<unknown, Ref> = new Map()
+  private readonly _definitions: Map<unknown, Struct> = new Map()
+
+  readonly include_defaults: boolean
+
+  constructor(options?: {include_defaults?: boolean}) {
+    this.include_defaults = options?.include_defaults ?? true
+  }
+
+  add_ref(obj: unknown, ref: Ref): void {
+    this._references.set(obj, ref)
+  }
+
+  add_def(obj: unknown, def: Struct): void {
+    assert(this._references.has(obj))
+    this._definitions.set(obj, def)
+  }
+
+  get objects(): Set<unknown> {
+    return new Set(this._references.keys())
+  }
+
+  get references(): Set<Ref> {
+    return new Set(this._references.values())
+  }
+
+  get definitions(): Set<Struct> {
+    return new Set(this._definitions.values())
+  }
+
+  remove_ref(obj: unknown): boolean {
+    return this._references.delete(obj)
+  }
+
+  remove_def(obj: unknown): boolean {
+    return this._definitions.delete(obj)
+  }
+
+  to_serializable<T extends SerializableType>(obj: T): SerializableOf<T>
+  to_serializable(obj: unknown): unknown
+
+  to_serializable(obj: unknown): unknown {
+    if (is_Serializable(obj))
+      return obj[serialize](this)
+    else if (isArray(obj) || isTypedArray(obj)) {
+      const n = obj.length
+      const result: unknown[] = new Array(n)
+      for (let i = 0; i < n; i++) {
+        const value = obj[i]
+        result[i] = this.to_serializable(value)
+      }
+      return result
+    } else if (isPlainObject(obj)) {
+      const result: {[key: string]: unknown} = {}
+      for (const [key, value] of entries(obj)) {
+        result[key] = this.to_serializable(value)
+      }
+      return result
+    } else if (obj === null || isBoolean(obj) || isNumber(obj) || isString(obj)) {
+      return obj
+    } else
+      throw new SerializationError(`${Object.prototype.toString.call(obj)} is not serializable`)
+  }
+}

--- a/bokehjs/src/lib/core/serializer.ts
+++ b/bokehjs/src/lib/core/serializer.ts
@@ -35,6 +35,7 @@ export class SerializationError extends Error {}
 export class Serializer {
   private readonly _references: Map<unknown, Ref> = new Map()
   private readonly _definitions: Map<unknown, Struct> = new Map()
+  private readonly _refmap: Map<Ref, Struct> = new Map()
 
   readonly include_defaults: boolean
 
@@ -47,8 +48,10 @@ export class Serializer {
   }
 
   add_def(obj: unknown, def: Struct): void {
-    assert(this._references.has(obj))
+    const ref = this._references.get(obj)
+    assert(ref != null)
     this._definitions.set(obj, def)
+    this._refmap.set(ref, def)
   }
 
   get objects(): Set<unknown> {
@@ -61,6 +64,10 @@ export class Serializer {
 
   get definitions(): Set<Struct> {
     return new Set(this._definitions.values())
+  }
+
+  resolve_ref(ref: Ref): Struct | undefined {
+    return this._refmap.get(ref)
   }
 
   remove_ref(obj: unknown): boolean {

--- a/bokehjs/src/lib/core/util/bitset.ts
+++ b/bokehjs/src/lib/core/util/bitset.ts
@@ -1,8 +1,8 @@
-import {equals, Equals, Comparator} from "./eq"
+import {equals, Equatable, Comparator} from "./eq"
 import {Arrayable, ArrayableNew} from "../types"
 import {assert} from "./assert"
 
-export class BitSet implements Equals {
+export class BitSet implements Equatable {
   private readonly _array: Uint32Array
   private readonly _nwords: number
 

--- a/bokehjs/src/lib/core/util/cloneable.ts
+++ b/bokehjs/src/lib/core/util/cloneable.ts
@@ -1,0 +1,55 @@
+import {entries} from "./object"
+import {isPlainObject, isArray, isBoolean, isNumber, isString} from "./types"
+
+export type CloneableType =
+  | null
+  | boolean
+  | number
+  | string
+  | Cloneable
+  | CloneableType[]
+  | {[key: string]: CloneableType}
+  //| Map<CloneableType, CloneableType>
+  //| Set<CloneableType>
+
+export const clone = Symbol("clone")
+
+export interface Cloneable {
+  [clone](cloner: Cloner): this
+}
+
+export function is_Cloneable<T>(obj: T): obj is T & Cloneable {
+  return clone in Object(obj)
+}
+
+export class CloningError extends Error {}
+
+export class Cloner {
+  constructor() {}
+
+  clone<T extends CloneableType>(obj: T): T
+  clone(obj: unknown): unknown
+
+  clone(obj: unknown): unknown {
+    if (is_Cloneable(obj))
+      return obj[clone](this)
+    else if (isArray(obj)) {
+      const n = obj.length
+      const result: unknown[] = new Array(n)
+      for (let i = 0; i < n; i++) {
+        const value = obj[i]
+        result[i] = this.clone(value)
+      }
+      return result
+    } else if (isPlainObject(obj)) {
+      const result: {[key: string]: unknown} = {}
+      for (const [key, value] of entries(obj)) {
+        result[key] = this.clone(value)
+      }
+      return result
+    } else if (obj === null || isBoolean(obj) || isNumber(obj) || isString(obj)) {
+      return obj
+    } else
+      throw new CloningError(`${Object.prototype.toString.call(obj)} is not cloneable`)
+  }
+}

--- a/bokehjs/src/lib/core/util/eq.ts
+++ b/bokehjs/src/lib/core/util/eq.ts
@@ -4,8 +4,12 @@ import {PlainObject} from "../types"
 
 export const equals = Symbol("equals")
 
-export interface Equals {
+export interface Equatable {
   [equals](that: this, cmp: Comparator): boolean
+}
+
+function is_Equatable<T>(obj: T): obj is T & Equatable {
+  return equals in Object(obj)
 }
 
 export const wildcard: any = Symbol("wildcard")
@@ -59,7 +63,7 @@ export class Comparator {
     b_stack.push(b)
 
     const result = (() => {
-      if (a[equals] != null && b[equals] != null) {
+      if (is_Equatable(a) && is_Equatable(b)) {
         return a[equals](b, this)
       }
 

--- a/bokehjs/src/lib/core/util/ndarray.ts
+++ b/bokehjs/src/lib/core/util/ndarray.ts
@@ -1,12 +1,14 @@
 import {isObject, isArray} from "./types"
 import {unreachable} from "./assert"
-import {equals, Equals, Comparator} from "./eq"
+import {equals, Equatable, Comparator} from "./eq"
+import {serialize, Serializable, Serializer} from "../serializer"
+import {encode_NDArray} from "./serialization"
 
 export type DataType = "uint8" | "int8" | "uint16" | "int16" | "uint32" | "int32" | "float32" | "float64"
 
 const __ndarray__ = Symbol("__ndarray__")
 
-export class Uint8NDArray extends Uint8Array implements Equals {
+export class Uint8NDArray extends Uint8Array implements Equatable, Serializable {
   readonly __ndarray__ = __ndarray__
   readonly dtype: "uint8" = "uint8"
   readonly shape: number[]
@@ -21,9 +23,13 @@ export class Uint8NDArray extends Uint8Array implements Equals {
   [equals](that: this, cmp: Comparator): boolean {
     return cmp.eq(this.shape, that.shape) && cmp.arrays(this, that)
   }
+
+  [serialize](_serializer: Serializer): unknown {
+    return encode_NDArray(this)
+  }
 }
 
-export class Int8NDArray extends Int8Array implements Equals {
+export class Int8NDArray extends Int8Array implements Equatable, Serializable {
   readonly __ndarray__ = __ndarray__
   readonly dtype: "int8" = "int8"
   readonly shape: number[]
@@ -38,9 +44,13 @@ export class Int8NDArray extends Int8Array implements Equals {
   [equals](that: this, cmp: Comparator): boolean {
     return cmp.eq(this.shape, that.shape) && cmp.arrays(this, that)
   }
+
+  [serialize](_serializer: Serializer): unknown {
+    return encode_NDArray(this)
+  }
 }
 
-export class Uint16NDArray extends Uint16Array implements Equals {
+export class Uint16NDArray extends Uint16Array implements Equatable, Serializable {
   readonly __ndarray__ = __ndarray__
   readonly dtype: "uint16" = "uint16"
   readonly shape: number[]
@@ -55,9 +65,13 @@ export class Uint16NDArray extends Uint16Array implements Equals {
   [equals](that: this, cmp: Comparator): boolean {
     return cmp.eq(this.shape, that.shape) && cmp.arrays(this, that)
   }
+
+  [serialize](_serializer: Serializer): unknown {
+    return encode_NDArray(this)
+  }
 }
 
-export class Int16NDArray extends Int16Array implements Equals {
+export class Int16NDArray extends Int16Array implements Equatable, Serializable {
   readonly __ndarray__ = __ndarray__
   readonly dtype: "int16" = "int16"
   readonly shape: number[]
@@ -72,9 +86,13 @@ export class Int16NDArray extends Int16Array implements Equals {
   [equals](that: this, cmp: Comparator): boolean {
     return cmp.eq(this.shape, that.shape) && cmp.arrays(this, that)
   }
+
+  [serialize](_serializer: Serializer): unknown {
+    return encode_NDArray(this)
+  }
 }
 
-export class Uint32NDArray extends Uint32Array implements Equals {
+export class Uint32NDArray extends Uint32Array implements Equatable, Serializable {
   readonly __ndarray__ = __ndarray__
   readonly dtype: "uint32" = "uint32"
   readonly shape: number[]
@@ -89,9 +107,13 @@ export class Uint32NDArray extends Uint32Array implements Equals {
   [equals](that: this, cmp: Comparator): boolean {
     return cmp.eq(this.shape, that.shape) && cmp.arrays(this, that)
   }
+
+  [serialize](_serializer: Serializer): unknown {
+    return encode_NDArray(this)
+  }
 }
 
-export class Int32NDArray extends Int32Array implements Equals {
+export class Int32NDArray extends Int32Array implements Equatable, Serializable {
   readonly __ndarray__ = __ndarray__
   readonly dtype: "int32" = "int32"
   readonly shape: number[]
@@ -106,9 +128,13 @@ export class Int32NDArray extends Int32Array implements Equals {
   [equals](that: this, cmp: Comparator): boolean {
     return cmp.eq(this.shape, that.shape) && cmp.arrays(this, that)
   }
+
+  [serialize](_serializer: Serializer): unknown {
+    return encode_NDArray(this)
+  }
 }
 
-export class Float32NDArray extends Float32Array implements Equals {
+export class Float32NDArray extends Float32Array implements Equatable, Serializable {
   readonly __ndarray__ = __ndarray__
   readonly dtype: "float32" = "float32"
   readonly shape: number[]
@@ -123,9 +149,13 @@ export class Float32NDArray extends Float32Array implements Equals {
   [equals](that: this, cmp: Comparator): boolean {
     return cmp.eq(this.shape, that.shape) && cmp.arrays(this, that)
   }
+
+  [serialize](_serializer: Serializer): unknown {
+    return encode_NDArray(this)
+  }
 }
 
-export class Float64NDArray extends Float64Array implements Equals {
+export class Float64NDArray extends Float64Array implements Equatable, Serializable {
   readonly __ndarray__ = __ndarray__
   readonly dtype: "float64" = "float64"
   readonly shape: number[]
@@ -139,6 +169,10 @@ export class Float64NDArray extends Float64Array implements Equals {
 
   [equals](that: this, cmp: Comparator): boolean {
     return cmp.eq(this.shape, that.shape) && cmp.arrays(this, that)
+  }
+
+  [serialize](_serializer: Serializer): unknown {
+    return encode_NDArray(this)
   }
 }
 

--- a/bokehjs/src/lib/core/util/pretty.ts
+++ b/bokehjs/src/lib/core/util/pretty.ts
@@ -8,7 +8,7 @@ export interface Printable {
   [pretty](printer: Printer): string
 }
 
-function isPrintable<T>(obj: T): obj is T & Printable {
+function is_Printable<T>(obj: T): obj is T & Printable {
   return pretty in Object(obj)
 }
 
@@ -24,7 +24,7 @@ export class Printer {
   }
 
   to_string(obj: unknown): string {
-    if (isPrintable(obj))
+    if (is_Printable(obj))
       return obj[pretty](this)
     else if (isBoolean(obj))
       return this.boolean(obj)

--- a/bokehjs/src/lib/core/util/ragged_array.ts
+++ b/bokehjs/src/lib/core/util/ragged_array.ts
@@ -1,8 +1,8 @@
 import {NumberArray} from "../types"
-import {equals, Equals, Comparator} from "./eq"
+import {equals, Equatable, Comparator} from "./eq"
 import {assert} from "./assert"
 
-export class RaggedArray implements Equals {
+export class RaggedArray implements Equatable {
   static [Symbol.toStringTag] = "RaggedArray"
 
   constructor(readonly offsets: Uint32Array, readonly array: NumberArray) {}

--- a/bokehjs/src/lib/core/util/refs.ts
+++ b/bokehjs/src/lib/core/util/refs.ts
@@ -2,14 +2,14 @@ import {Attrs} from "../types"
 import {isPlainObject} from "./types"
 import {keys} from "./object"
 
-export interface Struct {
+export type Struct = {
   id: string
   type: string
   subtype?: string
   attributes: Attrs
 }
 
-export interface Ref {
+export type Ref = {
   id: string
 }
 

--- a/bokehjs/src/lib/core/util/serialization.ts
+++ b/bokehjs/src/lib/core/util/serialization.ts
@@ -4,8 +4,6 @@ import {is_little_endian} from "./compat"
 import {DataType, NDArray} from "./ndarray"
 import * as ndarray from "./ndarray"
 
-export class SerializationError extends Error {}
-
 export function buffer_to_base64(buffer: ArrayBuffer): string {
   const bytes = new Uint8Array(buffer)
   const chars = Array.from(bytes).map((b) => String.fromCharCode(b))

--- a/bokehjs/src/lib/core/util/types.ts
+++ b/bokehjs/src/lib/core/util/types.ts
@@ -53,7 +53,7 @@ export function isObject(obj: unknown): obj is object {
   return tp === 'function' || tp === 'object' && !!obj
 }
 
-export function isPlainObject(obj: unknown): obj is {[key: string]: unknown} {
+export function isPlainObject<T>(obj: unknown): obj is {[key: string]: T} {
   return isObject(obj) && (obj.constructor == null || obj.constructor === Object)
 }
 

--- a/bokehjs/src/lib/core/util/types.ts
+++ b/bokehjs/src/lib/core/util/types.ts
@@ -24,6 +24,12 @@ export function isString(obj: unknown): obj is string {
   return toString.call(obj) === "[object String]"
 }
 
+export type Primitive = null | boolean | number | string
+
+export function isPrimitive(obj: unknown): obj is Primitive {
+  return obj === null || isBoolean(obj) || isNumber(obj) || isString(obj)
+}
+
 export function isFunction(obj: unknown): obj is Function {
   return toString.call(obj) === "[object Function]"
 }

--- a/bokehjs/src/lib/models/annotations/upper_lower.ts
+++ b/bokehjs/src/lib/models/annotations/upper_lower.ts
@@ -80,6 +80,8 @@ export abstract class UpperLowerView extends AnnotationView {
 export class XOrYCoordinateSpec extends p.CoordinateSpec {
   readonly obj: UpperLower
 
+  spec: p.Spec & {units: SpatialUnits}
+
   get dimension(): "x" | "y" {
     return this.obj.dimension == "width" ? "x" : "y"
   }

--- a/bokehjs/src/lib/models/plots/gmap_plot.ts
+++ b/bokehjs/src/lib/models/plots/gmap_plot.ts
@@ -1,5 +1,3 @@
-import {logger} from "core/logging"
-
 import {Plot} from "./plot"
 import * as p from "core/properties"
 import {Model} from "../../model"
@@ -80,6 +78,8 @@ export interface GMapPlot extends GMapPlot.Attrs {}
 export class GMapPlot extends Plot {
   properties: GMapPlot.Props
 
+  use_map = true
+
   constructor(attrs?: Partial<GMapPlot.Attrs>) {
     super(attrs)
   }
@@ -99,12 +99,5 @@ export class GMapPlot extends Plot {
       x_range: () => new Range1d(),
       y_range: () => new Range1d(),
     })
-  }
-
-  initialize(): void {
-    super.initialize()
-    this.use_map = true
-    if (!this.api_key)
-      logger.error("api_key is required. See https://developers.google.com/maps/documentation/javascript/get-api-key for more information on how to obtain your own.")
   }
 }

--- a/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
@@ -1,3 +1,4 @@
+import {logger} from "core/logging"
 import {Signal0} from "core/signaling"
 import {div, remove} from "core/dom"
 import {wgs84_mercator} from "core/util/projections"
@@ -57,6 +58,11 @@ export class GMapPlotView extends PlotView {
     this.initial_zoom = zoom
     this.initial_lat = lat
     this.initial_lng = lng
+
+    if (!this.model.api_key) {
+      const url = "https://developers.google.com/maps/documentation/javascript/get-api-key"
+      logger.error(`api_key is required. See ${url} for more information on how to obtain your own.`)
+    }
 
     if (typeof google === "undefined" || google.maps == null) {
       if (typeof window._bokeh_gmaps_callback === "undefined") {

--- a/bokehjs/src/lib/models/plots/plot.ts
+++ b/bokehjs/src/lib/models/plots/plot.ts
@@ -107,7 +107,7 @@ export class Plot extends LayoutDOM {
   properties: Plot.Props
   __view_type__: PlotView
 
-  use_map?: boolean
+  readonly use_map: boolean = false
 
   reset: Signal0<this>
 

--- a/bokehjs/src/lib/models/renderers/renderer.ts
+++ b/bokehjs/src/lib/models/renderers/renderer.ts
@@ -115,7 +115,7 @@ export abstract class Renderer extends Model {
 
   static init_Renderer(): void {
     this.define<Renderer.Props>(({Boolean, String}) => ({
-      level:        [ RenderLevel ],
+      level:        [ RenderLevel, "image" ],
       visible:      [ Boolean, true ],
       x_range_name: [ String, "default" ],
       y_range_name: [ String, "default" ],

--- a/bokehjs/src/lib/polyfill.ts
+++ b/bokehjs/src/lib/polyfill.ts
@@ -13,6 +13,8 @@ import "es6-symbol/implement"
 
 import "es6-promise/auto"
 
+import "proxy-polyfill"
+
 if (typeof Object.is === "undefined") {
   Object.is = function(a: any, b: any): boolean {
     if (a === b)

--- a/bokehjs/test/defaults/index.ts
+++ b/bokehjs/test/defaults/index.ts
@@ -1,20 +1,19 @@
 import {describe, it} from "../framework"
 export * from "../framework"
 
-import {expect} from "../unit/assertions"
+import {expect, ExpectationError} from "../unit/assertions"
 
 import all_defaults from "../.generated_defaults/defaults.json"
 
 import {isArray, isPlainObject} from "@bokehjs/core/util/types"
-import {difference} from "@bokehjs/core/util/array"
-import {keys, values, entries} from "@bokehjs/core/util/object"
+import {keys, entries} from "@bokehjs/core/util/object"
 import {is_equal} from "@bokehjs/core/util/eq"
-import {SerializationError} from "@bokehjs/core/serializer"
+import {to_string} from "@bokehjs/core/util/pretty"
+import {Serializer} from "@bokehjs/core/serializer"
+import {is_ref} from "@bokehjs/core/util/refs"
 
 import {Models} from "@bokehjs/base"
-import {PropertyAlias} from "@bokehjs/core/properties"
 import {settings} from "@bokehjs/core/settings"
-import {Document} from "@bokehjs/document"
 
 import "@bokehjs/models/widgets/main"
 import "@bokehjs/models/widgets/tables/main"
@@ -27,44 +26,36 @@ function get_defaults(name: string) {
     throw new Error(`can't find defaults for ${name}`)
 }
 
-function safe_stringify(v: unknown): string {
-  if (v === Infinity) {
-    return "Infinity"
-  } else {
-    try {
-      return JSON.stringify(v)
-    } catch {
-      return `${v}`
-    }
-  }
-}
-
 type KV = {[key: string]: any}
 
-function check_matching_defaults(name: string, python_defaults: KV, bokehjs_defaults: KV): boolean {
+function check_matching_defaults(name: string, python_defaults: KV, bokehjs_defaults: KV, serializer: Serializer): boolean {
   const different: string[] = []
   const python_missing: string[] = []
   const bokehjs_missing: string[] = []
 
-  for (const [k, js_v] of entries(bokehjs_defaults)) {
-    // special case for graph renderer node_renderer
-    if (name === "GraphRenderer" && k === "node_renderer")
+  for (let [k, js_v] of entries(bokehjs_defaults)) {
+    // special case for graph renderer node_renderer/edge_renderer
+    if (name == "GraphRenderer" && (k == "node_renderer" || k == "edge_renderer"))
       continue
 
-    // special case for graph renderer node_renderer
-    if (name === "GraphRenderer" && k === "edge_renderer")
+    // special case for factor range and start/end (null vs 0)
+    if (name == "FactorRange" && (k == "start" || k == "end"))
       continue
 
     // special case for date picker, default is "now"
-    if (name === 'DatePicker' && k === 'value')
+    if (name == 'DatePicker' && k == 'value')
       continue
 
     // special case for date time tickers, class hierarchy and attributes are handled differently
-    if (name === "DatetimeTicker" && k === "tickers")
+    if (name == "DatetimeTicker" && k == "tickers")
+      continue
+
+    // special case for days/months/years tickers (null vs computed integer)
+    if ((name == "DaysTicker" || name == "MonthsTicker" || name == "YearsTicker") && k == "interval")
       continue
 
     // special case for Title derived text properties
-    if (name === "Title" && (k === "text_align" || k === "text_baseline"))
+    if (name == "Title" && (k == "text_align" || k == "text_baseline"))
       continue
 
     if (name == "DateSlider" && (k == "start" || k == "end" || k == "value" || k == "value_throttled"))
@@ -77,14 +68,14 @@ function check_matching_defaults(name: string, python_defaults: KV, bokehjs_defa
     if (settings.dev && k.includes("text_font") && js_v == "Bokeh")
       continue
 
-    if (k === "id")
-      continue
-
     if (k in python_defaults) {
       let py_v = python_defaults[k]
 
-      strip_ids(js_v)
-      strip_ids(py_v)
+      if (is_ref(js_v)) {
+        if (is_ref(py_v))
+          continue // TODO: defaults.json stops at one reference level, so assume equal
+        js_v = serializer.resolve_ref(js_v)!
+      }
 
       if (!is_equal(py_v, js_v)) {
         // these two conditionals compare 'foo' and {value: 'foo'}
@@ -94,8 +85,8 @@ function check_matching_defaults(name: string, python_defaults: KV, bokehjs_defa
           continue
 
         if (isPlainObject(js_v) && 'attributes' in js_v && isPlainObject(py_v) && 'attributes' in py_v) {
-          if (js_v.type === py_v.type) {
-            check_matching_defaults(`${name}.${k}`, py_v.attributes as KV, js_v.attributes as KV)
+          if (js_v.type == py_v.type) {
+            check_matching_defaults(`${name}.${k}`, py_v.attributes as KV, js_v.attributes as KV, serializer)
             continue
           }
         }
@@ -105,7 +96,7 @@ function check_matching_defaults(name: string, python_defaults: KV, bokehjs_defa
           let equal = true
 
           // palettes in JS are stored as int color values
-          if (k === 'palette') {
+          if (k == 'palette') {
             py_v = (py_v as string[]).map((x) => parseInt(x.slice(1), 16))
           }
 
@@ -113,9 +104,14 @@ function check_matching_defaults(name: string, python_defaults: KV, bokehjs_defa
             equal = false
           else {
             for (let i = 0; i < js_v.length; i++) {
-              delete (js_v[i] as any).id
-              delete (py_v[i] as any).id
-              if (!is_equal(js_v[i], py_v[i])) {
+              let js_vi = js_v[i]
+              const py_vi = py_v[i]
+              if (is_ref(js_vi)) {
+                if (is_ref(py_vi))
+                  continue // TODO: defaults.json stops at one reference level, so assume equal
+                js_vi = serializer.resolve_ref(js_vi)!
+              }
+              if (!is_equal(js_vi, py_vi)) {
                 equal = false
                 break
               }
@@ -126,16 +122,16 @@ function check_matching_defaults(name: string, python_defaults: KV, bokehjs_defa
             continue
         }
 
-        different.push(`${name}.${k}: bokehjs defaults to ${safe_stringify(js_v)} but python defaults to ${safe_stringify(py_v)}`)
+        different.push(`${name}.${k}: bokehjs defaults to ${to_string(js_v)} but python defaults to ${to_string(py_v)}`)
       }
     } else {
-      python_missing.push(`${name}.${k}: bokehjs defaults to ${safe_stringify(js_v)} but python has no such property`)
+      python_missing.push(`${name}.${k}: bokehjs defaults to ${to_string(js_v)} but python has no such property`)
     }
   }
 
   for (const [k, v] of entries(python_defaults)) {
     if (!(k in bokehjs_defaults)) {
-      bokehjs_missing.push(`${name}.${k}: python defaults to ${safe_stringify(v)} but bokehjs has no such property`)
+      bokehjs_missing.push(`${name}.${k}: python defaults to ${to_string(v)} but bokehjs has no such property`)
     }
   }
 
@@ -151,22 +147,7 @@ function check_matching_defaults(name: string, python_defaults: KV, bokehjs_defa
   complain(python_missing, `${name}: python is missing some properties found in bokehjs`)
   complain(bokehjs_missing, `${name}: bokehjs is missing some properties found in Python`)
 
-  return different.length === 0 && python_missing.length === 0 && bokehjs_missing.length === 0
-}
-
-function strip_ids(value: any): void {
-  if (isArray(value)) {
-    for (const v of value) {
-      strip_ids(v)
-    }
-  } else if (isPlainObject(value)) {
-    if ('id' in value) {
-      delete value.id
-    }
-    for (const v of values(value)) {
-      strip_ids(v)
-    }
-  }
+  return different.length == 0 && python_missing.length == 0 && bokehjs_missing.length == 0
 }
 
 describe("Defaults", () => {
@@ -189,44 +170,24 @@ describe("Defaults", () => {
     expect(missing.length).to.be.equal(0)
   })
 
-  it("match between Python and bokehjs", () => {
-    let fail_count = 0
-    const all_view_model_names = keys(all_defaults)
-    for (const name of all_view_model_names) {
-      const model = Models(name)
-      const attrs: {[key: string]: unknown} = {}
-      for (const [attr, prop] of Object.entries(model.prototype._props)) {
-        if (prop.options?.internal !== true) {
-          const actual_prop = prop.type instanceof PropertyAlias ? model.prototype._props[prop.type.attr] : prop
-          // XXX: required proprties and defaults depending on model's instance
-          const value = actual_prop.default_value != null ? actual_prop.default_value({} as any) : null
-          attrs[attr] = deep_value_to_serializable(attr, value, undefined)
-        }
-      }
-
-      const python_defaults = get_defaults(name)
-      const bokehjs_defaults = attrs
-      if (!check_matching_defaults(name, python_defaults, bokehjs_defaults)) {
-        console.error(name)
-        console.error(difference(keys(python_defaults), keys(bokehjs_defaults)))
-        fail_count += 1
-      }
-    }
-
-    console.error(`Python/bokehjs matching defaults problems: ${fail_count}`)
-    expect(fail_count).to.be.equal(0)
-  })
-
   for (const name of keys(all_defaults)) {
     // TODO: add a default to GeoJSONDataSource.geojson?
     const fn = name == "GeoJSONDataSource" ? it.skip : it
 
-    fn(`have ${name} model serializable`, () => {
+    fn(`bokehjs should implement serializable ${name} model and match defaults with bokeh`, () => {
       const model = Models(name) as any
-      const doc = new Document()
       const obj = new model() // TODO: this relies on null hack in properties
-      doc.add_root(obj)
-      expect(() => doc.to_json(true)).to.not.throw(SerializationError)
+
+      const serializer = new Serializer()
+      const ref = serializer.to_serializable(obj)
+      const attrs = serializer.resolve_ref(ref)!.attributes
+
+      const python_defaults = get_defaults(name)
+      const bokehjs_defaults = attrs
+
+      if (!check_matching_defaults(name, python_defaults, bokehjs_defaults, serializer)) {
+        throw new ExpectationError(`expected ${name} model to match defaults with bokeh`)
+      }
     })
   }
 })

--- a/bokehjs/test/defaults/index.ts
+++ b/bokehjs/test/defaults/index.ts
@@ -9,10 +9,9 @@ import {isArray, isPlainObject} from "@bokehjs/core/util/types"
 import {difference} from "@bokehjs/core/util/array"
 import {keys, values, entries} from "@bokehjs/core/util/object"
 import {is_equal} from "@bokehjs/core/util/eq"
-import {SerializationError} from "@bokehjs/core/util/serialization"
+import {SerializationError} from "@bokehjs/core/serializer"
 
 import {Models} from "@bokehjs/base"
-import {HasProps} from "@bokehjs/core/has_props"
 import {PropertyAlias} from "@bokehjs/core/properties"
 import {settings} from "@bokehjs/core/settings"
 import {Document} from "@bokehjs/document"
@@ -38,25 +37,6 @@ function safe_stringify(v: unknown): string {
       return `${v}`
     }
   }
-}
-
-function deep_value_to_serializable(_key: string, value: unknown, _optional_parent_object: any): any {
-  if (value instanceof HasProps) {
-    return {type: value.type, attributes: value.attributes_as_json()}
-  } else if (isArray(value)) {
-    const ref_array: any[] = []
-    for (let i = 0; i < value.length; i++) {
-      ref_array.push(deep_value_to_serializable(i.toString(), value[i], value))
-    }
-    return ref_array
-  } else if (isPlainObject(value)) {
-    const ref_obj: {[key: string]: any} = {}
-    for (const [subkey, subvalue] of entries(value)) {
-      ref_obj[subkey] = deep_value_to_serializable(subkey, subvalue, value)
-    }
-    return ref_obj
-  } else
-    return value
 }
 
 type KV = {[key: string]: any}

--- a/bokehjs/test/unit/core/has_props.ts
+++ b/bokehjs/test/unit/core/has_props.ts
@@ -6,7 +6,6 @@ import * as mixins from "@bokehjs/core/property_mixins"
 import * as p from "@bokehjs/core/properties"
 import {keys} from "@bokehjs/core/util/object"
 import {ndarray} from "@bokehjs/core/util/ndarray"
-import {BYTE_ORDER} from "@bokehjs/core/util/serialization"
 
 class TestModel extends HasProps {}
 
@@ -130,38 +129,38 @@ describe("core/has_props module", () => {
 
   describe("creation", () => {
 
-    it("should have only id property", () => {
+    it("empty model should have no properties", () => {
       const obj = new TestModel()
-      expect(keys(obj.properties)).to.be.equal(['id'])
-      expect(keys(obj.attributes)).to.be.equal(['id'])
+      expect(keys(obj.properties)).to.be.equal([])
+      expect(keys(obj.attributes)).to.be.equal([])
     })
 
     it("should combine props from subclasses", () => {
       const obj = new SubclassWithProps()
-      expect(keys(obj.properties)).to.be.equal(['id', 'foo', 'bar'])
+      expect(keys(obj.properties)).to.be.equal(['foo', 'bar'])
     })
 
     it("should combine props from sub-subclasses", () => {
       const obj = new SubSubclassWithProps()
-      expect(keys(obj.properties)).to.be.equal(['id', 'foo', 'bar', 'baz'])
+      expect(keys(obj.properties)).to.be.equal(['foo', 'bar', 'baz'])
     })
 
     it("should combine mixins from subclasses", () => {
       const obj = new SubclassWithMixins()
       const props = keys(mixins.Line)
-      expect(keys(obj.properties)).to.be.equal(['id'].concat(props))
+      expect(keys(obj.properties)).to.be.equal(props)
     })
 
     it("should combine mixins from sub-subclasses", () => {
       const obj = new SubSubclassWithMixins()
       const props = [...keys(mixins.Line), ...keys(mixins.Fill).map((key) => `foo_${key}`)]
-      expect(keys(obj.properties)).to.be.equal(['id'].concat(props))
+      expect(keys(obj.properties)).to.be.equal(props)
     })
 
     it("should combine multiple mixins from subclasses", () => {
       const obj = new SubclassWithMultipleMixins()
       const props = [...keys(mixins.Line), ...keys(mixins.Text).map((key) => `bar_${key}`)]
-      expect(keys(obj.properties)).to.be.equal(['id'].concat(props))
+      expect(keys(obj.properties)).to.be.equal(props)
     })
   })
 
@@ -219,50 +218,6 @@ describe("core/has_props module", () => {
       expect(struct.id).to.be.equal(obj.id)
       expect(struct.type).to.be.equal(obj.type)
       expect(struct.subtype).to.be.equal("bar")
-    })
-  })
-
-  describe("HasProps._value_to_json()", () => {
-    it("should support primitive values", () => {
-      expect(HasProps._value_to_json(1)).to.be.equal(1)
-      expect(HasProps._value_to_json("a")).to.be.equal("a")
-    })
-
-    it("should support HasProps instances", () => {
-      const obj0 = new TestModel()
-      expect(HasProps._value_to_json(obj0)).to.be.equal({id: obj0.id})
-
-      const obj1 = new SubSubclassWithProps({foo: 17})
-      expect(HasProps._value_to_json(obj1)).to.be.equal({id: obj1.id})
-    })
-
-    it("should support ndarrays", () => {
-      const nd0 = ndarray([1, 2, 3, 4, 5, 6], {dtype: "int32", shape: [2, 3]})
-
-      expect(HasProps._value_to_json(nd0)).to.be.equal({
-        __ndarray__: "AQAAAAIAAAADAAAABAAAAAUAAAAGAAAA",
-        order: BYTE_ORDER,
-        dtype: "int32",
-        shape: [2, 3],
-      })
-    })
-
-    it("should support typed arrays", () => {
-      expect(HasProps._value_to_json(new Float32Array([1, 2, 3]))).to.be.equal([1, 2, 3])
-    })
-
-    it("should support arrays and typed arrays", () => {
-      const obj0 = new TestModel()
-
-      expect(HasProps._value_to_json([1, 2, 3])).to.be.equal([1, 2, 3])
-      expect(HasProps._value_to_json([1, 2, obj0])).to.be.equal([1, 2, {id: obj0.id}])
-    })
-
-    it("should support plain objects", () => {
-      const obj0 = new TestModel()
-
-      expect(HasProps._value_to_json({a: 1, b: 2})).to.be.equal({a: 1, b: 2})
-      expect(HasProps._value_to_json({a: 1, b: obj0})).to.be.equal({a: 1, b: {id: obj0.id}})
     })
   })
 })

--- a/bokehjs/test/unit/core/properties.ts
+++ b/bokehjs/test/unit/core/properties.ts
@@ -499,19 +499,19 @@ describe("properties module", () => {
       it("should default to data units", () => {
         const obj = new Some({distance_spec: {value: 10}})
         const prop = obj.properties.distance_spec
-        expect(prop.spec.units).to.be.equal("data")
+        expect(prop.units).to.be.equal("data")
       })
 
       it("should accept screen units", () => {
         const obj = new Some({distance_spec: {value: 10, units: "screen"}})
         const prop = obj.properties.distance_spec
-        expect(prop.spec.units).to.be.equal("screen")
+        expect(prop.units).to.be.equal("screen")
       })
 
       it("should accept data units", () => {
         const obj = new Some({distance_spec: {value: 10, units: "data"}})
         const prop = obj.properties.distance_spec
-        expect(prop.spec.units).to.be.equal("data")
+        expect(prop.units).to.be.equal("data")
       })
 
       it("should throw an Error on bad units", () => {

--- a/bokehjs/test/unit/core/serializer.ts
+++ b/bokehjs/test/unit/core/serializer.ts
@@ -1,0 +1,102 @@
+import {expect} from "assertions"
+
+import {Serializer} from "@bokehjs/core/serializer"
+import {HasProps} from "@bokehjs/core/has_props"
+import * as p from "@bokehjs/core/properties"
+import {ndarray} from "@bokehjs/core/util/ndarray"
+import {BYTE_ORDER} from "@bokehjs/core/util/serialization"
+
+function to_serializable(obj: unknown): {repr: unknown, json: string} {
+  const serializer = new Serializer()
+  const repr = serializer.to_serializable(obj)
+  const json = JSON.stringify(repr)
+  return {repr, json}
+}
+
+namespace SomeModel {
+  export type Attrs = p.AttrsOf<Props>
+  export type Props = HasProps.Props & {
+    value: p.Property<number>
+    array: p.Property<number[]>
+    dict: p.Property<{[key: string]: number}>
+    map: p.Property<Map<string, number>>
+  }
+}
+
+interface SomeModel extends SomeModel.Attrs {}
+
+class SomeModel extends HasProps {
+  properties: SomeModel.Props
+
+  constructor(attrs?: Partial<SomeModel.Attrs>) {
+    super(attrs)
+  }
+
+  static init_SomeModel(): void {
+    this.define<SomeModel.Props>(({Number, Array, Dict}) => ({
+      value: [ Number, 1 ],
+      array: [ Array(Number), [] ],
+      dict: [ Dict(Number), {} ],
+    }))
+  }
+}
+
+describe("core/serializer module", () => {
+  describe("implements to_serializable() function", () => {
+    it("that supports null", () => {
+      expect(to_serializable(null)).to.be.equal({repr: null, json: "null"})
+    })
+
+    it("that supports booleans", () => {
+      expect(to_serializable(false)).to.be.equal({repr: false, json: "false"})
+      expect(to_serializable(true)).to.be.equal({repr: true, json: "true"})
+    })
+
+    it("that supports numbers", () => {
+      expect(to_serializable(0)).to.be.equal({repr: 0, json: "0"})
+      expect(to_serializable(1)).to.be.equal({repr: 1, json: "1"})
+      expect(to_serializable(-1)).to.be.equal({repr: -1, json: "-1"})
+      expect(to_serializable(NaN)).to.be.equal({repr: NaN, json: "null"})               // XXX
+      expect(to_serializable(Infinity)).to.be.equal({repr: Infinity, json: "null"})     // XXX
+      expect(to_serializable(-Infinity)).to.be.equal({repr: -Infinity, json: "null"})   // XXX
+      expect(to_serializable(Number.MAX_SAFE_INTEGER)).to.be.equal({repr: Number.MAX_SAFE_INTEGER, json: `${Number.MAX_SAFE_INTEGER}`})
+      expect(to_serializable(Number.MIN_SAFE_INTEGER)).to.be.equal({repr: Number.MIN_SAFE_INTEGER, json: `${Number.MIN_SAFE_INTEGER}`})
+      expect(to_serializable(Number.MAX_VALUE)).to.be.equal({repr: Number.MAX_VALUE, json: `${Number.MAX_VALUE}`})
+      expect(to_serializable(Number.MIN_VALUE)).to.be.equal({repr: Number.MIN_VALUE, json: `${Number.MIN_VALUE}`})
+    })
+
+    it("that supports strings", () => {
+      expect(to_serializable("")).to.be.equal({repr: "", json: '""'})
+      expect(to_serializable("a")).to.be.equal({repr: "a", json: '"a"'})
+      expect(to_serializable("a'b'c")).to.be.equal({repr: "a'b'c", json: '"a\'b\'c"'})
+    })
+
+    it("that supports arrays", () => {
+      expect(to_serializable([])).to.be.equal({repr: [], json: "[]"})
+      expect(to_serializable([1, 2, 3])).to.be.equal({repr: [1, 2, 3], json: "[1,2,3]"})
+    })
+
+    it("that supports plain objects", () => {
+      expect(to_serializable({})).to.be.equal({repr: {}, json: "{}"})
+    })
+
+    it("should support HasProps instances", () => {
+      const obj0 = new SomeModel()
+      expect(to_serializable(obj0)).to.be.equal({repr: {id: obj0.id}, json: `{"id":"${obj0.id}"}`})
+    })
+
+    it("should support ndarrays", () => {
+      const nd0 = ndarray([1, 2, 3], {dtype: "int32", shape: [1, 3]})
+
+      expect(to_serializable(nd0)).to.be.equal({
+        repr: {
+          __ndarray__: "AQAAAAIAAAADAAAA",
+          order: BYTE_ORDER,
+          dtype: "int32",
+          shape: [1, 3],
+        },
+        json: `{"__ndarray__":"AQAAAAIAAAADAAAA","order":"${BYTE_ORDER}","dtype":"int32","shape":[1,3]}`,
+      })
+    })
+  })
+})

--- a/bokehjs/test/unit/core/util/cloneable.ts
+++ b/bokehjs/test/unit/core/util/cloneable.ts
@@ -1,0 +1,121 @@
+import {expect} from "assertions"
+
+import {Cloner, clone, Cloneable, CloneableType} from "@bokehjs/core/util/cloneable"
+import {Comparator, equals, Equatable} from "@bokehjs/core/util/eq"
+
+function copy<T extends CloneableType>(obj: T): T {
+  const cloner = new Cloner()
+  return cloner.clone(obj)
+}
+
+describe("core/util/cloneable module", () => {
+  describe("implements clone() function", () => {
+    it("that supports null", () => {
+      const v0 = null
+      const r0 = copy(v0)
+
+      expect(r0).to.be.equal(v0)
+      expect(r0).to.be.identical(v0)
+    })
+
+    it("that supports booleans", () => {
+      const v0 = true
+      const r0 = copy(v0)
+
+      expect(r0).to.be.equal(v0)
+      expect(r0).to.be.identical(v0)
+
+      const v1 = false
+      const r1 = copy(v1)
+
+      expect(r1).to.be.equal(v1)
+      expect(r1).to.be.identical(v1)
+    })
+
+    it("that supports numbers", () => {
+      const v0 = 123
+      const r0 = copy(v0)
+
+      expect(r0).to.be.equal(v0)
+      expect(r0).to.be.identical(v0)
+    })
+
+    it("that supports strings", () => {
+      const v0 = "abc"
+      const r0 = copy(v0)
+
+      expect(r0).to.be.equal(v0)
+      expect(r0).to.be.identical(v0)
+    })
+
+    it("that supports arrays", () => {
+      const v0: number[] = []
+      const r0 = copy(v0)
+
+      expect(r0).to.be.equal(v0)
+      expect(r0).to.not.be.identical(v0)
+
+      const v1 = [0, 1, 2]
+      const r1 = copy(v1)
+
+      expect(r1).to.be.equal(v1)
+      expect(r1).to.not.be.identical(v1)
+
+      const v2 = [[0, 1, 2], [3, 4, 5]]
+      const r2 = copy(v2)
+
+      expect(r2).to.be.equal(v2)
+      expect(r2).to.not.be.identical(v2)
+      expect(r2[0]).to.be.equal(v2[0])
+      expect(r2[0]).to.not.be.identical(v2[0])
+      expect(r2[1]).to.be.equal(v2[1])
+      expect(r2[1]).to.not.be.identical(v2[1])
+    })
+
+    it("that supports plain objects", () => {
+      const v0 = {}
+      const r0 = copy(v0)
+
+      expect(r0).to.be.equal(v0)
+      expect(r0).to.not.be.identical(v0)
+
+      const v1 = {k0: 0, k1: 1}
+      const r1 = copy(v1)
+
+      expect(r1).to.be.equal(v1)
+      expect(r1).to.not.be.identical(v1)
+
+      const v2 = {k0: {k01: 0}, k1: {k11: 1}}
+      const r2 = copy(v2)
+
+      expect(r2).to.be.equal(v2)
+      expect(r2).to.not.be.identical(v2)
+      expect(r2.k0).to.be.equal(v2.k0)
+      expect(r2.k0).to.not.be.identical(v2.k0)
+      expect(r2.k1).to.be.equal(v2.k1)
+      expect(r2.k1).to.not.be.identical(v2.k1)
+    })
+
+    it("that supports objects implementing Cloneable interface", () => {
+      class Some implements Cloneable, Equatable {
+        constructor(readonly value: number[]) {}
+
+        [clone](cloner: Cloner): this {
+          return new Some(cloner.clone(this.value)) as this
+        }
+
+        [equals](that: this, cmp: Comparator): boolean {
+          return cmp.eq(this.value, that.value)
+        }
+      }
+
+      const v0 = new Some([0, 1, 2])
+      const r0 = copy(v0)
+
+      expect(r0).to.be.equal(v0)
+      expect(r0).to.not.be.identical(v0)
+      expect(r0.value).to.be.equal(v0.value)
+      expect(r0.value).to.not.be.identical(v0.value)
+    })
+  })
+})

--- a/bokehjs/test/unit/core/util/eq.ts
+++ b/bokehjs/test/unit/core/util/eq.ts
@@ -1,6 +1,6 @@
 import {expect} from "assertions"
 
-import {is_equal, equals, Equals, Comparator} from "@bokehjs/core/util/eq"
+import {is_equal, equals, Equatable, Comparator} from "@bokehjs/core/util/eq"
 
 describe("core/util/eq module", () => {
   describe("implements is_equal() function", () => {
@@ -132,8 +132,8 @@ describe("core/util/eq module", () => {
     })
   })
 
-  it("that supports Equals interface", () => {
-    class X implements Equals {
+  it("that supports Equatable interface", () => {
+    class X implements Equatable {
       constructor(readonly f: number) {}
 
       [equals](that: this, cmp: Comparator): boolean {

--- a/bokehjs/test/unit/document/events.ts
+++ b/bokehjs/test/unit/document/events.ts
@@ -1,6 +1,7 @@
 import {expect} from "assertions"
 
 import {HasProps} from "@bokehjs/core/has_props"
+import {Serializer} from "@bokehjs/core/serializer"
 import {Document} from "@bokehjs/document/document"
 import * as events from "@bokehjs/document/events"
 
@@ -32,9 +33,9 @@ describe("events module", () => {
 
   describe("exports", () => {
 
-    for (const evt of EVENTS) {
-      it(`"should have ${evt}"`, () => {
-        expect(evt in events).to.be.true
+    for (const event of EVENTS) {
+      it(`"should have ${event}"`, () => {
+        expect(event in events).to.be.true
       })
     }
   })
@@ -43,10 +44,10 @@ describe("events module", () => {
     it("should generate json", () => {
       const d = new Document()
       const m = new TestModel()
-      const evt = new events.ColumnsPatchedEvent(d, m.ref(), {foo: [[1, 2]]})
-      const refs = new Set<HasProps>()
-      const json = evt.json(refs)
-      expect(json).to.be.equal({
+      const event = new events.ColumnsPatchedEvent(d, m.ref(), {foo: [[1, 2]]})
+      const serializer = new Serializer()
+      const result = serializer.to_serializable(event)
+      expect(result).to.be.equal({
         kind: "ColumnsPatched",
         column_source: m.ref(),
         patches: {foo: [[1, 2]]},
@@ -58,10 +59,10 @@ describe("events module", () => {
     it("should generate json with rollover", () => {
       const d = new Document()
       const m = new TestModel()
-      const evt = new events.ColumnsStreamedEvent(d, m.ref(), {foo: [1, 2], bar: [3, 4]}, 10)
-      const refs = new Set<HasProps>()
-      const json = evt.json(refs)
-      expect(json).to.be.equal({
+      const event = new events.ColumnsStreamedEvent(d, m.ref(), {foo: [1, 2], bar: [3, 4]}, 10)
+      const serializer = new Serializer()
+      const result = serializer.to_serializable(event)
+      expect(result).to.be.equal({
         kind: "ColumnsStreamed",
         column_source: m.ref(),
         data: {foo: [1, 2], bar: [3, 4]},
@@ -72,10 +73,10 @@ describe("events module", () => {
     it("should generate json without rollover", () => {
       const d = new Document()
       const m = new TestModel()
-      const evt = new events.ColumnsStreamedEvent(d, m.ref(), {foo: [1, 2], bar: [3, 4]})
-      const refs = new Set<HasProps>()
-      const json = evt.json(refs)
-      expect(json).to.be.equal({
+      const event = new events.ColumnsStreamedEvent(d, m.ref(), {foo: [1, 2], bar: [3, 4]})
+      const serializer = new Serializer()
+      const result = serializer.to_serializable(event)
+      expect(result).to.be.equal({
         kind: "ColumnsStreamed",
         column_source: m.ref(),
         data: {foo: [1, 2], bar: [3, 4]},
@@ -85,21 +86,13 @@ describe("events module", () => {
   })
 
   describe("ModelChangedEvent", () => {
-    it("should throw an error if attr=id", () => {
-      const d = new Document()
-      const m = new TestModel()
-      const evt = new events.ModelChangedEvent(d, m, "id", 1, 2)
-      const refs = new Set<HasProps>()
-      expect(() => evt.json(refs)).to.throw()
-    })
-
     it("should generating json with no references", () =>{
       const d = new Document()
       const m = new TestModel()
-      const evt = new events.ModelChangedEvent(d, m, "foo", 1, 2)
-      const refs = new Set<HasProps>()
-      const json = evt.json(refs)
-      expect(json).to.be.equal({
+      const event = new events.ModelChangedEvent(d, m, "foo", 1, 2)
+      const serializer = new Serializer()
+      const result = serializer.to_serializable(event)
+      expect(result).to.be.equal({
         kind: "ModelChanged",
         model: m.ref(),
         attr: "foo",
@@ -111,18 +104,17 @@ describe("events module", () => {
       const d = new Document()
       const m = new TestModel()
       const m2 = new TestModelWithRefs({foo: []})
-      const evt = new events.ModelChangedEvent(d, m2, "foo", [], [m])
-      const refs = new Set<HasProps>()
-      const json = evt.json(refs)
-      expect(json).to.be.equal({
+      const event = new events.ModelChangedEvent(d, m2, "foo", [], [m])
+      const serializer = new Serializer()
+      const result = serializer.to_serializable(event)
+      expect(result).to.be.equal({
         kind: "ModelChanged",
         model: m2.ref(),
         attr: "foo",
         new: [m.ref()],
       })
-      const expected_refs = new Set<HasProps>()
-      expected_refs.add(m)
-      expect(refs).to.be.equal(expected_refs)
+      const expected_refs = new Set([m])
+      expect(serializer.objects).to.be.equal(expected_refs)
     })
 
     // TODO (bev) test the case with references returned
@@ -131,10 +123,10 @@ describe("events module", () => {
       const d = new Document()
       const m = new TestModel()
       const hint = new events.ColumnsStreamedEvent(d, m.ref(), {foo: [1, 2], bar: [3, 4]})
-      const evt = new events.ModelChangedEvent(d, m, "foo", 1, 2, undefined, hint)
-      const refs = new Set<HasProps>()
-      const json = evt.json(refs)
-      expect(json).to.be.equal({
+      const event = new events.ModelChangedEvent(d, m, "foo", 1, 2, undefined, hint)
+      const serializer = new Serializer()
+      const result = serializer.to_serializable(event)
+      expect(result).to.be.equal({
         kind: "ColumnsStreamed",
         column_source: m.ref(),
         data: {foo: [1, 2], bar: [3, 4]},
@@ -146,10 +138,10 @@ describe("events module", () => {
   describe("TitleChangedEvent", () => {
     it("should generate json", () => {
       const d = new Document()
-      const evt = new events.TitleChangedEvent(d, "foo")
-      const refs = new Set<HasProps>()
-      const json = evt.json(refs)
-      expect(json).to.be.equal({
+      const event = new events.TitleChangedEvent(d, "foo")
+      const serializer = new Serializer()
+      const result = serializer.to_serializable(event)
+      expect(result).to.be.equal({
         kind: "TitleChanged",
         title: "foo",
       })
@@ -160,10 +152,10 @@ describe("events module", () => {
     it("should generate json", () => {
       const d = new Document()
       const m = new TestModel()
-      const evt = new events.RootAddedEvent(d, m)
-      const refs = new Set<HasProps>()
-      const json = evt.json(refs)
-      expect(json).to.be.equal({
+      const event = new events.RootAddedEvent(d, m)
+      const serializer = new Serializer()
+      const result = serializer.to_serializable(event)
+      expect(result).to.be.equal({
         kind: "RootAdded",
         model: m.ref(),
       })
@@ -174,10 +166,10 @@ describe("events module", () => {
     it("should generate json", () => {
       const d = new Document()
       const m = new TestModel()
-      const evt = new events.RootRemovedEvent(d, m)
-      const refs = new Set<HasProps>()
-      const json = evt.json(refs)
-      expect(json).to.be.equal({
+      const event = new events.RootRemovedEvent(d, m)
+      const serializer = new Serializer()
+      const result = serializer.to_serializable(event)
+      expect(result).to.be.equal({
         kind: "RootRemoved",
         model: m.ref(),
       })

--- a/bokehjs/test/unit/models/ranges/data_range1d.ts
+++ b/bokehjs/test/unit/models/ranges/data_range1d.ts
@@ -341,7 +341,7 @@ describe("datarange1d module", () => {
   describe("update", () => {
 
     it("should update its start and end values", () => {
-      const g = new GlyphRenderer({id: "id"})
+      const g = new GlyphRenderer()
       const p = new Plot({renderers: [g]})
       const r = new DataRange1d({plots: [p]})
 
@@ -354,7 +354,7 @@ describe("datarange1d module", () => {
     })
 
     it("should not update its start or end values to NaN when log", () => {
-      const g = new GlyphRenderer({id: "id"})
+      const g = new GlyphRenderer()
       const p = new Plot({renderers: [g]})
       const r = new DataRange1d({scale_hint: "log", plots: [p]})
 

--- a/bokehjs/test/unit/models/renderers/graph_renderer.ts
+++ b/bokehjs/test/unit/models/renderers/graph_renderer.ts
@@ -8,7 +8,7 @@ import {Circle, MultiLine} from "@bokehjs/models/glyphs"
 import {Plot} from "@bokehjs/models/plots"
 import {Document} from "@bokehjs/document"
 import {build_view} from "@bokehjs/core/build_views"
-import {SerializationError} from "@bokehjs/core/util/serialization"
+import {SerializationError} from "@bokehjs/core/serializer"
 
 describe("GraphRendererView", () => {
   it("should have node_renderer and edge_renderer glyphs serializable after initialization", async () => {

--- a/examples/app/gapminder/theme.yaml
+++ b/examples/app/gapminder/theme.yaml
@@ -5,9 +5,9 @@ attrs:
     min_border: 20
 
   Axis:
-    minor_tick_in: null
-    minor_tick_out: null
-    major_tick_in: null
+    minor_tick_in: 0
+    minor_tick_out: 0
+    major_tick_in: 0
     major_label_text_font_size: '13px'
     major_label_text_font_style: 'normal'
     axis_label_text_font_size: '13px'

--- a/examples/custom/parallel_plot/parallel_reset.py
+++ b/examples/custom/parallel_plot/parallel_reset.py
@@ -1,7 +1,7 @@
-from bokeh.models import Action
+from bokeh.models import ActionTool
 
 
-class ParallelResetTool(Action):
+class ParallelResetTool(ActionTool):
     """ Tool to reset only plot axes and not selections
     """
 

--- a/sphinx/source/docs/releases/2.3.0.rst
+++ b/sphinx/source/docs/releases/2.3.0.rst
@@ -20,3 +20,22 @@ And several other bug fixes and docs additions. For full details see the
 intended to work like one and didn't fully implement its protocol. After this
 change you won't be able to use properties like ``level``, ``x_range_name``,
 etc., but those wheren't respected by renderers anyway.
+
+Renamed bokeh's base models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Certain base models were renamed to unify naming convention with bokehjs:
+
++---------------+-------------------+
+| Old name      | New name          |
++===============+===================+
+| ``WebSource`` | ``WebDataSource`` |
++---------------+-------------------+
+| ``Action``    | ``ActionTool``    |
++---------------+-------------------+
+| ``Gesture``   | ``GestureTool``   |
++---------------+-------------------+
+| ``Inspect``   | ``InspectTool``   |
++---------------+-------------------+
+
+Old names are deprecated and will be removed in bokeh 3.0.

--- a/tests/unit/bokeh/models/test_glyphs.py
+++ b/tests/unit/bokeh/models/test_glyphs.py
@@ -46,7 +46,7 @@ from bokeh.core.enums import (
 )
 from bokeh.core.enums import NamedColor as Color
 from bokeh.core.enums import TextAlign, TextBaseline
-from bokeh.core.property.dataspec import field
+from bokeh.core.property.dataspec import field, value
 from bokeh.models.glyphs import (
     Asterisk,
     CircleCross,
@@ -205,9 +205,9 @@ def test_HArea() -> None:
 def test_HBar() -> None:
     glyph = HBar()
     assert glyph.y == field("y")
-    assert glyph.height is None
-    assert glyph.left == 0
-    assert glyph.right is None
+    assert glyph.height == value(1)
+    assert glyph.left == value(0)
+    assert glyph.right == field("right")
     check_fill_properties(glyph)
     check_hatch_properties(glyph)
     check_line_properties(glyph)
@@ -377,10 +377,10 @@ def test_Patches() -> None:
 
 def test_Quad() -> None:
     glyph = Quad()
-    assert glyph.left is None
-    assert glyph.right is None
-    assert glyph.bottom is None
-    assert glyph.top is None
+    assert glyph.left == field("left")
+    assert glyph.right == field("right")
+    assert glyph.bottom == field("bottom")
+    assert glyph.top == field("top")
     check_fill_properties(glyph)
     check_hatch_properties(glyph)
     check_line_properties(glyph)
@@ -514,8 +514,8 @@ def test_VArea() -> None:
 def test_VBar() -> None:
     glyph = VBar()
     assert glyph.x == field("x")
-    assert glyph.width is None
-    assert glyph.top is None
+    assert glyph.width == value(1)
+    assert glyph.top == field("top")
     assert glyph.bottom == 0
     check_fill_properties(glyph)
     check_hatch_properties(glyph)

--- a/tests/unit/bokeh/models/test_glyphs.py
+++ b/tests/unit/bokeh/models/test_glyphs.py
@@ -46,7 +46,7 @@ from bokeh.core.enums import (
 )
 from bokeh.core.enums import NamedColor as Color
 from bokeh.core.enums import TextAlign, TextBaseline
-from bokeh.core.property.dataspec import field, value
+from bokeh.core.property.dataspec import field
 from bokeh.models.glyphs import (
     Asterisk,
     CircleCross,
@@ -205,8 +205,8 @@ def test_HArea() -> None:
 def test_HBar() -> None:
     glyph = HBar()
     assert glyph.y == field("y")
-    assert glyph.height == value(1)
-    assert glyph.left == value(0)
+    assert glyph.height == 1
+    assert glyph.left == 0
     assert glyph.right == field("right")
     check_fill_properties(glyph)
     check_hatch_properties(glyph)
@@ -514,7 +514,7 @@ def test_VArea() -> None:
 def test_VBar() -> None:
     glyph = VBar()
     assert glyph.x == field("x")
-    assert glyph.width == value(1)
+    assert glyph.width == 1
     assert glyph.top == field("top")
     assert glyph.bottom == 0
     check_fill_properties(glyph)


### PR DESCRIPTION
The goal of this work is to:

- introduce distinction between serialized representation and a wire encoding, i.e. JSON is a string, not a JS object
- move serialization code completely away from `HasProps` and at least partially away from `Document`
- test serialization and wire encoding of all supported value types and objects

Non-goals for this PR:

- fix the representation of `NaN`/ `+/-oo` or add support for `Map`/`Set`, etc.
- implement a comprehensive serialization schema test suite for cross testing bokehjs and bokeh, and for compliance testing of third-party implementations

Both non-goals will be implemented in future PRs.

At this point this PR focuses on bokehjs, but when working on PR #10564, I implemented a similar scheme in bokeh, which in fact inspired this work.

To make things work consistently, `HasProps.id` is not a property anymore (never truly was; just a convenience measure), but a plain immutable class member. This makes cloning `HasProps` finally work, by not preserving object identity.