### PR TITLE
Don't escape raw strings in replace_placeholders() by default

### DIFF
--- a/bokehjs/src/lib/core/util/templating.ts
+++ b/bokehjs/src/lib/core/util/templating.ts
@@ -3,7 +3,6 @@ import {sprintf as sprintf_js} from "sprintf-js"
 import tz from "timezone"
 
 import {Enum} from "../kinds"
-import {escape} from "./string"
 import {isNumber, isString, isArray, isTypedArray} from "./types"
 
 import {ColumnarDataSource} from "models/sources/columnar_data_source"
@@ -113,7 +112,8 @@ export function get_value(raw_name: string, data_source: ColumnarDataSource, i: 
   }
 }
 
-export function replace_placeholders(content: string | {html: string}, data_source: ColumnarDataSource, i: Index, formatters?: Formatters, special_vars: Vars = {}): string | Node[]  {
+export function replace_placeholders(content: string | {html: string}, data_source: ColumnarDataSource,
+    i: Index, formatters?: Formatters, special_vars: Vars = {}, encode?: (v: string) => string): string | Node[]  {
   let str: string
   let has_html: boolean
 
@@ -140,7 +140,7 @@ export function replace_placeholders(content: string | {html: string}, data_sour
 
     // missing value, return ???
     if (value == null)
-      return `${escape("???")}`
+      return encode ? encode("???") : "???"
 
     // 'safe' format, return the value as-is
     if (format == 'safe') {
@@ -150,7 +150,8 @@ export function replace_placeholders(content: string | {html: string}, data_sour
 
     // format and escape everything else
     const formatter = get_formatter(spec, format, formatters)
-    return `${escape(formatter(value, format, special_vars))}`
+    const result = `${formatter(value, format, special_vars)}`
+    return encode ? encode(result) : result
   })
 
   if (!has_html)

--- a/bokehjs/src/lib/models/callbacks/open_url.ts
+++ b/bokehjs/src/lib/models/callbacks/open_url.ts
@@ -31,7 +31,7 @@ export class OpenURL extends Callback {
 
   execute(_cb_obj: unknown, {source}: {source: ColumnarDataSource}): void {
     const open_url = (i: number) => {
-      const url = replace_placeholders(this.url, source, i)
+      const url = replace_placeholders(this.url, source, i, undefined, undefined, encodeURIComponent)
       if (!isString(url))
         throw new Error("HTML output is not supported in this context")
 

--- a/bokehjs/test/unit/core/util/templating.ts
+++ b/bokehjs/test/unit/core/util/templating.ts
@@ -155,7 +155,11 @@ describe("templating module", () => {
   })
 
   describe("replace_placeholders", () => {
-    const source = new ColumnDataSource({data: {foo: [10, 1.002], bar: ["a", "<div>b</div>"], baz: [1492890671885, 1290460671885]}})
+    const source = new ColumnDataSource({data: {
+      foo: [10, 1.002, -1],
+      bar: ["a", "<div>b</div>", "'qux'\"quux\""],
+      baz: [1492890671885, 1290460671885, 1090410671285],
+    }})
 
     it("should replace unknown field names with ???", () => {
       const s = tmpl.replace_placeholders("stuff @junk", source, 0)
@@ -173,7 +177,10 @@ describe("templating module", () => {
       expect(s3).to.be.equal("stuff a")
 
       const s4 = tmpl.replace_placeholders("stuff @bar", source, 1)
-      expect(s4).to.be.equal("stuff &lt;div&gt;b&lt;/div&gt;")
+      expect(s4).to.be.equal("stuff <div>b</div>")
+
+      const s5 = tmpl.replace_placeholders("stuff @bar", source, 2)
+      expect(s5).to.be.equal("stuff 'qux'\"quux\"")
     })
 
     it("should replace field names with values as-is with safe format", () => {
@@ -264,6 +271,17 @@ describe("templating module", () => {
     it("should handle special @$name case by using special_vars.name as the column", () => {
       const s = tmpl.replace_placeholders("stuff @$name", source, 0, {}, {name: "foo"})
       expect(s).to.be.equal("stuff 10")
+    })
+
+    it("should allow custom string encoding (e.g. encodeURIComponent)", () => {
+      const s0 = tmpl.replace_placeholders("stuff @bar", source, 0, undefined, undefined, encodeURIComponent)
+      expect(s0).to.be.equal("stuff a")
+
+      const s1 = tmpl.replace_placeholders("stuff @bar", source, 1, undefined, undefined, encodeURIComponent)
+      expect(s1).to.be.equal("stuff %3Cdiv%3Eb%3C%2Fdiv%3E")
+
+      const s2 = tmpl.replace_placeholders("stuff @bar", source, 2, undefined, undefined, encodeURIComponent)
+      expect(s2).to.be.equal("stuff 'qux'%22quux%22")
     })
   })
 })


### PR DESCRIPTION
fixes #10604