### PR TITLE
Add OpenGraph metadata to docs

### DIFF
--- a/ci/environment-release-build.yml
+++ b/ci/environment-release-build.yml
@@ -35,3 +35,6 @@ dependencies:
   - scipy
   - sphinx
   - sphinx-panels
+  - pip
+  - pip:
+    - sphinxext-opengraph

--- a/ci/environment-test-3.6.yml
+++ b/ci/environment-test-3.6.yml
@@ -48,9 +48,10 @@ dependencies:
   - selenium >=3.8
   - scipy
   - sphinx
+  - sphinx-panels
   - pip
   - pip:
-    - sphinx-panels
+    - sphinxext-opengraph
 
   # examples
   - flask >=1.0

--- a/ci/environment-test-3.7.yml
+++ b/ci/environment-test-3.7.yml
@@ -48,9 +48,10 @@ dependencies:
   - selenium >=3.8
   - scipy
   - sphinx
+  - sphinx-panels
   - pip
   - pip:
-    - sphinx-panels
+    - sphinxext-opengraph
 
   # examples
   - flask >=1.0

--- a/ci/environment-test-3.8.yml
+++ b/ci/environment-test-3.8.yml
@@ -48,9 +48,10 @@ dependencies:
   - selenium >=3.8
   - scipy
   - sphinx
+  - sphinx-panels
   - pip
   - pip:
-    - sphinx-panels
+    - sphinxext-opengraph
 
   # examples
   - flask >=1.0

--- a/environment.yml
+++ b/environment.yml
@@ -23,9 +23,10 @@ dependencies:
   - colorcet
   - pygments
   - sphinx >=1.8
+  - sphinx-panels
   - pip
   - pip:
-    - sphinx-panels
+    - sphinxext-opengraph
 
   # tests
   - beautifulsoup4

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -94,6 +94,10 @@ pygments_style = 'sphinx'
 # configuration for sphinxext.opengraph
 ogp_site_url = 'https://docs.bokeh.org/en/latest/'
 ogp_image = 'http://static.bokeh.org/og/logotype-on-hex.png'
+ogp_custom_meta_tags = [
+    '<meta name="twitter:card" content="summary_large_image" />'
+    '<meta property="twitter:site" content="@bokeh" />',
+]
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -24,6 +24,7 @@ add_module_names = False
 exclude_patterns = ['docs/releases/*']
 
 extensions = [
+    'sphinxext.opengraph',
     'sphinx_panels',
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
@@ -89,6 +90,10 @@ intersphinx_mapping = {
 napoleon_include_init_with_doc = True
 
 pygments_style = 'sphinx'
+
+ogp_site_url = 'https://docs.bokeh.org/en/latest/'
+ogp_image = 'https://static.bokeh.org/opengraph/bokeh-logo.png'
+ogp_image_alt = 'Logo of the Bokeh visualization library'
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -92,7 +92,7 @@ napoleon_include_init_with_doc = True
 pygments_style = 'sphinx'
 
 ogp_site_url = 'https://docs.bokeh.org/en/latest/'
-ogp_image = 'https://static.bokeh.org/opengraph/bokeh-logo.png'
+ogp_image = 'http://static.bokeh.org/og/logotype-on-hex.png'
 ogp_image_alt = 'Logo of the Bokeh visualization library'
 
 # -- Options for HTML output ---------------------------------------------------

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -95,7 +95,7 @@ pygments_style = 'sphinx'
 ogp_site_url = 'https://docs.bokeh.org/en/latest/'
 ogp_image = 'http://static.bokeh.org/og/logotype-on-hex.png'
 ogp_custom_meta_tags = [
-    '<meta name="twitter:card" content="summary_large_image" />'
+    '<meta name="twitter:card" content="summary_large_image" />',
     '<meta property="twitter:site" content="@bokeh" />',
 ]
 

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -91,9 +91,9 @@ napoleon_include_init_with_doc = True
 
 pygments_style = 'sphinx'
 
+# configuration for sphinxext.opengraph
 ogp_site_url = 'https://docs.bokeh.org/en/latest/'
 ogp_image = 'http://static.bokeh.org/og/logotype-on-hex.png'
-ogp_image_alt = 'Logo of the Bokeh visualization library'
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -97,6 +97,7 @@ ogp_image = 'http://static.bokeh.org/og/logotype-on-hex.png'
 ogp_custom_meta_tags = [
     '<meta name="twitter:card" content="summary_large_image" />',
     '<meta property="twitter:site" content="@bokeh" />',
+    '<meta name="image" property="og:image" content="http://static.bokeh.org/og/logotype-on-hex.png">',
 ]
 
 # -- Options for HTML output ---------------------------------------------------


### PR DESCRIPTION
As part of Google's Season of Docs, this pull request will add [OpenGraph metadata](https://ogp.me/) to Bokeh's docs. OpenGraph metadata is used by services like Facebook, Twitter, LinkedIn or Discourse to generate rich previews of links.