### PR TITLE
Invalidate computed renderers when HoverToolView.plot_model.renderers changes

### DIFF
--- a/bokeh/models/ranges.py
+++ b/bokeh/models/ranges.py
@@ -27,6 +27,7 @@ from collections import Counter
 from ..core.enums import PaddingUnits, StartEnd
 from ..core.has_props import abstract
 from ..core.properties import (
+    Auto,
     Bool,
     Datetime,
     Either,
@@ -152,9 +153,13 @@ class DataRange(Range):
     A list of names to query for. If set, only renderers that
     have a matching value for their ``name`` attribute will be used
     for autoranging.
+
+    .. note:
+        This property is deprecated and will be removed in bokeh 3.0.
+
     """)
 
-    renderers = List(Instance(Renderer), help="""
+    renderers = Either(List(Instance(Renderer)), Auto, help="""
     An explicit list of renderers to autorange against. If unset,
     defaults to all renderers on a plot.
     """)

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -218,6 +218,10 @@ class SelectTool(GestureTool):
     names = List(String, help="""
     A list of names to query for. If set, only renderers that have a matching
     value for their ``name`` attribute will be used.
+
+    .. note:
+        This property is deprecated and will be removed in bokeh 3.0.
+
     """)
 
     renderers = Either(Auto, List(Instance(Renderer)), default="auto", help="""
@@ -988,6 +992,15 @@ class HoverTool(InspectTool):
         :height: 24px
 
     '''
+
+    names = List(String, help="""
+    A list of names to query for. If set, only renderers that have a matching
+    value for their ``name`` attribute will be used.
+
+    .. note:
+        This property is deprecated and will be removed in bokeh 3.0.
+
+    """)
 
     renderers = Either(Auto, List(Instance(Renderer)), default="auto", help="""
     An explicit list of renderers to hit test against. If unset, defaults to

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -989,11 +989,6 @@ class HoverTool(InspectTool):
 
     '''
 
-    names = List(String, help="""
-    A list of names to query for. If set, only renderers that have a matching
-    value for their ``name`` attribute will be used.
-    """)
-
     renderers = Either(Auto, List(Instance(Renderer)), default="auto", help="""
     An explicit list of renderers to hit test against. If unset, defaults to
     all renderers on a plot.

--- a/bokehjs/src/lib/core/signaling.ts
+++ b/bokehjs/src/lib/core/signaling.ts
@@ -112,7 +112,7 @@ export namespace Signal {
     scheduleCleanup(receivers)
   }
 
-  export function disconnectReceiver(receiver: object): void {
+  export function disconnectReceiver(receiver: object, slot?: Slot<any, any>, except_senders?: Set<object>): void {
     const senders = sendersForReceiver.get(receiver)
     if (senders == null || senders.length === 0)
       return
@@ -121,7 +121,13 @@ export namespace Signal {
       if (connection.signal == null)
         return
 
+      if (slot != null && connection.slot != slot)
+        continue
+
       const sender = connection.signal.sender
+      if (except_senders != null && except_senders.has(sender))
+        continue
+
       connection.signal = null
       scheduleCleanup(receiversForSender.get(sender)!)
     }

--- a/bokehjs/src/lib/core/signaling.ts
+++ b/bokehjs/src/lib/core/signaling.ts
@@ -16,7 +16,7 @@ export class Signal<Args, Sender extends object> {
 
     const receivers = receiversForSender.get(this.sender)!
 
-    if (findConnection(receivers, this, slot, context) != null) {
+    if (find_connection(receivers, this, slot, context) != null) {
       return false
     }
 
@@ -41,7 +41,7 @@ export class Signal<Args, Sender extends object> {
       return false
     }
 
-    const connection = findConnection(receivers, this, slot, context)
+    const connection = find_connection(receivers, this, slot, context)
     if (connection == null) {
       return false
     }
@@ -50,8 +50,8 @@ export class Signal<Args, Sender extends object> {
     const senders = sendersForReceiver.get(receiver)!
 
     connection.signal = null
-    scheduleCleanup(receivers)
-    scheduleCleanup(senders)
+    schedule_cleanup(receivers)
+    schedule_cleanup(senders)
 
     return true
   }
@@ -74,7 +74,7 @@ export class Signal0<Sender extends object> extends Signal<void, Sender> {
 }
 
 export namespace Signal {
-  export function disconnectBetween(sender: object, receiver: object): void {
+  export function disconnect_between(sender: object, receiver: object): void {
     const receivers = receiversForSender.get(sender)
     if (receivers == null || receivers.length === 0)
       return
@@ -91,11 +91,11 @@ export namespace Signal {
         connection.signal = null
     }
 
-    scheduleCleanup(receivers)
-    scheduleCleanup(senders)
+    schedule_cleanup(receivers)
+    schedule_cleanup(senders)
   }
 
-  export function disconnectSender(sender: object): void {
+  export function disconnect_sender(sender: object): void {
     const receivers = receiversForSender.get(sender)
     if (receivers == null || receivers.length === 0)
       return
@@ -106,13 +106,13 @@ export namespace Signal {
 
       const receiver = connection.context ?? connection.slot
       connection.signal = null
-      scheduleCleanup(sendersForReceiver.get(receiver)!)
+      schedule_cleanup(sendersForReceiver.get(receiver)!)
     }
 
-    scheduleCleanup(receivers)
+    schedule_cleanup(receivers)
   }
 
-  export function disconnectReceiver(receiver: object, slot?: Slot<any, any>, except_senders?: Set<object>): void {
+  export function disconnect_receiver(receiver: object, slot?: Slot<any, any>, except_senders?: Set<object>): void {
     const senders = sendersForReceiver.get(receiver)
     if (senders == null || senders.length === 0)
       return
@@ -129,19 +129,19 @@ export namespace Signal {
         continue
 
       connection.signal = null
-      scheduleCleanup(receiversForSender.get(sender)!)
+      schedule_cleanup(receiversForSender.get(sender)!)
     }
 
-    scheduleCleanup(senders)
+    schedule_cleanup(senders)
   }
 
-  export function disconnectAll(obj: object): void {
+  export function disconnect_all(obj: object): void {
     const receivers = receiversForSender.get(obj)
     if (receivers != null && receivers.length !== 0) {
       for (const connection of receivers) {
         connection.signal = null
       }
-      scheduleCleanup(receivers)
+      schedule_cleanup(receivers)
     }
 
     const senders = sendersForReceiver.get(obj)
@@ -149,9 +149,21 @@ export namespace Signal {
       for (const connection of senders) {
         connection.signal = null
       }
-      scheduleCleanup(senders)
+      schedule_cleanup(senders)
     }
   }
+
+  /** @deprecated */
+  export const disconnectBetween = disconnect_between
+
+  /** @deprecated */
+  export const disconnectSender = disconnect_sender
+
+  /** @deprecated */
+  export const disconnectReceiver = disconnect_receiver
+
+  /** @deprecated */
+  export const disconnectAll = disconnect_all
 }
 
 export interface ISignalable {
@@ -170,7 +182,7 @@ export function Signalable() {
   }
 }
 
-interface Connection {
+type Connection = {
   signal: Signal<any, object> | null
   readonly slot: Slot<any, any>
   readonly context: object | null
@@ -179,13 +191,13 @@ interface Connection {
 const receiversForSender = new WeakMap<object, Connection[]>()
 const sendersForReceiver = new WeakMap<object, Connection[]>()
 
-function findConnection(conns: Connection[], signal: Signal<any, any>, slot: Slot<any, any>, context: any): Connection | undefined {
+function find_connection(conns: Connection[], signal: Signal<any, any>, slot: Slot<any, any>, context: any): Connection | undefined {
   return find(conns, conn => conn.signal === signal && conn.slot === slot && conn.context === context)
 }
 
 const dirty_set = new Set<Connection[]>()
 
-function scheduleCleanup(connections: Connection[]): void {
+function schedule_cleanup(connections: Connection[]): void {
   if (dirty_set.size === 0) {
     (async () => {
       await defer()

--- a/bokehjs/src/lib/core/view.ts
+++ b/bokehjs/src/lib/core/view.ts
@@ -37,10 +37,15 @@ export class View implements ISignalable {
 
   protected _has_finished: boolean
 
+  private _slots = new WeakMap<Slot<any, any>, Slot<any, any>>()
   connect<Args, Sender extends object>(signal: Signal<Args, Sender>, slot: Slot<Args, Sender>): boolean {
-    const new_slot = (args: Args, sender: Sender): void => {
-      const promise = Promise.resolve(slot.call(this, args, sender))
-      this._ready = this._ready.then(() => promise)
+    let new_slot = this._slots.get(slot)
+    if (new_slot == null) {
+      new_slot = (args: Args, sender: Sender): void => {
+        const promise = Promise.resolve(slot.call(this, args, sender))
+        this._ready = this._ready.then(() => promise)
+      }
+      this._slots.set(slot, new_slot)
     }
 
     return signal.connect(new_slot, this)

--- a/bokehjs/src/lib/core/view.ts
+++ b/bokehjs/src/lib/core/view.ts
@@ -37,7 +37,7 @@ export class View implements ISignalable {
 
   protected _has_finished: boolean
 
-  private _slots = new WeakMap<Slot<any, any>, Slot<any, any>>()
+  protected _slots = new WeakMap<Slot<any, any>, Slot<any, any>>()
   connect<Args, Sender extends object>(signal: Signal<Args, Sender>, slot: Slot<Args, Sender>): boolean {
     let new_slot = this._slots.get(slot)
     if (new_slot == null) {

--- a/bokehjs/src/lib/core/view.ts
+++ b/bokehjs/src/lib/core/view.ts
@@ -37,7 +37,9 @@ export class View implements ISignalable {
 
   protected _has_finished: boolean
 
+  /** @internal */
   protected _slots = new WeakMap<Slot<any, any>, Slot<any, any>>()
+
   connect<Args, Sender extends object>(signal: Signal<Args, Sender>, slot: Slot<Args, Sender>): boolean {
     let new_slot = this._slots.get(slot)
     if (new_slot == null) {
@@ -108,7 +110,7 @@ export class View implements ISignalable {
   connect_signals(): void {}
 
   disconnect_signals(): void {
-    Signal.disconnectReceiver(this)
+    Signal.disconnect_receiver(this)
   }
 
   on_change(properties: Property<unknown> | Property<unknown>[], fn: () => void): void {

--- a/bokehjs/src/lib/models/ranges/data_range.ts
+++ b/bokehjs/src/lib/models/ranges/data_range.ts
@@ -6,8 +6,9 @@ export namespace DataRange {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = Range.Props & {
+    /** @deprecated */
     names: p.Property<string[]>
-    renderers: p.Property<DataRenderer[]>
+    renderers: p.Property<DataRenderer[] | "auto">
   }
 }
 
@@ -23,7 +24,7 @@ export abstract class DataRange extends Range {
   static init_DataRange(): void {
     this.define<DataRange.Props>(({String, Array, Ref}) => ({
       names:     [ Array(String), [] ],
-      renderers: [ Array(Ref(DataRenderer)), [] ],
+      renderers: [ Array(Ref(DataRenderer)), [] ], // TODO: [] -> "auto"
     }))
   }
 }

--- a/bokehjs/src/lib/models/ranges/data_range1d.ts
+++ b/bokehjs/src/lib/models/ranges/data_range1d.ts
@@ -3,11 +3,12 @@ import {Renderer} from "../renderers/renderer"
 import {DataRenderer} from "../renderers/data_renderer"
 import {PaddingUnits, StartEnd} from "core/enums"
 import {Rect} from "core/types"
+import {concat} from "core/util/array"
 import {logger} from "core/logging"
 import * as p from "core/properties"
 import * as bbox from "core/util/bbox"
-import {includes} from "core/util/array"
 import type {Plot} from "../plots/plot"
+import {compute_renderers} from "../util"
 
 export type Dim = 0 | 1
 export type Bounds = Map<Renderer, Rect>
@@ -93,24 +94,9 @@ export class DataRange1d extends DataRange {
 
   computed_renderers(): DataRenderer[] {
     // TODO (bev) check that renderers actually configured with this range
-    const names = this.names
-    let renderers = this.renderers
-
-    if (renderers.length == 0) {
-      for (const plot of this.plots) {
-        renderers = renderers.concat(plot.data_renderers)
-      }
-    }
-
-    if (names.length > 0)
-      renderers = renderers.filter((r) => includes(names, r.name))
-
-    logger.debug(`computed ${renderers.length} renderers for ${this}`)
-    for (const renderer of renderers) {
-      logger.trace(` - ${renderer}`)
-    }
-
-    return renderers
+    const {renderers, names} = this
+    const all_renderers = concat(this.plots.map((plot) => plot.data_renderers))
+    return compute_renderers(renderers.length == 0 ? "auto" : renderers, all_renderers, names)
   }
 
   /*protected*/ _compute_plot_bounds(renderers: Renderer[], bounds: Bounds): Rect {

--- a/bokehjs/src/lib/models/tools/gestures/select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/select_tool.ts
@@ -3,7 +3,7 @@ import {GlyphRenderer} from "../../renderers/glyph_renderer"
 import {GraphRenderer} from "../../renderers/graph_renderer"
 import {DataRenderer, DataRendererView} from "../../renderers/data_renderer"
 import {DataSource} from "../../sources/data_source"
-import {compute_renderers, RendererSpec} from "../util"
+import {compute_renderers} from "../../util"
 import * as p from "core/properties"
 import {KeyEvent, UIEvent} from "core/ui_events"
 import {SelectionMode} from "core/enums"
@@ -23,9 +23,8 @@ export abstract class SelectToolView extends GestureToolView {
   }
 
   get computed_renderers(): DataRenderer[] {
-    const renderers = this.model.renderers
+    const {renderers, names} = this.model
     const all_renderers = this.plot_model.data_renderers
-    const names = this.model.names
     return compute_renderers(renderers, all_renderers, names)
   }
 
@@ -142,7 +141,8 @@ export namespace SelectTool {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = GestureTool.Props & {
-    renderers: p.Property<RendererSpec>
+    renderers: p.Property<DataRenderer[] | "auto">
+    /** @deprecated */
     names: p.Property<string[]>
     mode: p.Property<SelectionMode>
   }
@@ -166,8 +166,8 @@ export abstract class SelectTool extends GestureTool {
   }
 
   static init_SelectTool(): void {
-    this.define<SelectTool.Props>(({String, Array, Ref, Or, Auto, Null}) => ({
-      renderers: [ Or(Array(Ref(DataRenderer)), Auto, Null), "auto" ],
+    this.define<SelectTool.Props>(({String, Array, Ref, Or, Auto}) => ({
+      renderers: [ Or(Array(Ref(DataRenderer)), Auto), "auto" ],
       names:     [ Array(String), [] ],
       mode:      [ SelectionMode, "replace" ],
     }))

--- a/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
+++ b/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
@@ -86,16 +86,7 @@ export class HoverToolView extends InspectToolView {
   connect_signals(): void {
     super.connect_signals()
 
-    for (const r of this.computed_renderers) {
-      if (r instanceof GlyphRenderer)
-        this.connect(r.data_source.inspect, this._update)
-      else if (r instanceof GraphRenderer) {
-        this.connect(r.node_renderer.data_source.inspect, this._update)
-        this.connect(r.edge_renderer.data_source.inspect, this._update)
-      }
-    }
-
-    // TODO: this.connect(this.plot_model.properties.renderers.change, () => this._computed_renderers = this._ttmodels = null)
+    this.connect(this.plot_model.properties.renderers.change, () => this._computed_renderers = this._ttmodels = null)
     this.connect(this.model.properties.renderers.change, () => this._computed_renderers = this._ttmodels = null)
     this.connect(this.model.properties.names.change,     () => this._computed_renderers = this._ttmodels = null)
     this.connect(this.model.properties.tooltips.change,  () => this._ttmodels = null)
@@ -139,6 +130,15 @@ export class HoverToolView extends InspectToolView {
       const all_renderers = this.plot_model.data_renderers
       const names = this.model.names
       this._computed_renderers = compute_renderers(renderers, all_renderers, names)
+
+      for (const r of this._computed_renderers) {
+        if (r instanceof GlyphRenderer)
+          this.connect(r.data_source.inspect, this._update)
+        else if (r instanceof GraphRenderer) {
+          this.connect(r.node_renderer.data_source.inspect, this._update)
+          this.connect(r.edge_renderer.data_source.inspect, this._update)
+        }
+      }
     }
     return this._computed_renderers
   }

--- a/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
+++ b/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
@@ -26,6 +26,7 @@ import {ImageIndex} from "../../selections/selection"
 import {bk_tool_icon_hover} from "styles/icons"
 import {bk_tooltip_row_label, bk_tooltip_row_value, bk_tooltip_color_block} from "styles/tooltips"
 import {Signal} from "core/signaling"
+import {compute_renderers} from "../../util"
 
 export type TooltipVars = {index: number} & Vars
 
@@ -136,7 +137,7 @@ export class HoverToolView extends InspectToolView {
     const slot = this._slots.get(this._update)
     if (slot != null) {
       const except = new Set(glyph_renderers.map((r) => r.data_source))
-      Signal.disconnectReceiver(this, slot, except)
+      Signal.disconnect_receiver(this, slot, except)
     }
 
     for (const r of glyph_renderers) {
@@ -145,8 +146,9 @@ export class HoverToolView extends InspectToolView {
   }
 
   get computed_renderers(): DataRenderer[] {
-    const {renderers} = this.model
-    return renderers == "auto" ? this.plot_model.data_renderers : renderers
+    const {renderers, names} = this.model
+    const all_renderers = this.plot_model.data_renderers
+    return compute_renderers(renderers, all_renderers, names)
   }
 
   get ttmodels(): Map<GlyphRenderer, Tooltip> {
@@ -506,6 +508,8 @@ export namespace HoverTool {
     tooltips: p.Property<null | string | [string, string][] | ((source: ColumnarDataSource, vars: TooltipVars) => HTMLElement)>
     formatters: p.Property<Formatters>
     renderers: p.Property<DataRenderer[] | "auto">
+    /** @deprecated */
+    names: p.Property<string[]>
     mode: p.Property<HoverMode>
     muted_policy: p.Property<MutedPolicy>
     point_policy: p.Property<PointPolicy>
@@ -538,6 +542,7 @@ export class HoverTool extends InspectTool {
       ]],
       formatters:   [ Dict(Or(Ref(CustomJSHover), FormatterType)), {} ],
       renderers:    [ Or(Array(Ref(DataRenderer)), Auto), "auto" ],
+      names:        [ Array(String), [] ],
       mode:         [ HoverMode, "mouse" ],
       muted_policy: [ MutedPolicy, "show" ],
       point_policy: [ PointPolicy, "snap_to_data" ],

--- a/bokehjs/src/lib/models/util.ts
+++ b/bokehjs/src/lib/models/util.ts
@@ -1,4 +1,4 @@
-import {DataRenderer} from "../renderers/data_renderer"
+import {DataRenderer} from "./renderers/data_renderer"
 import {includes} from "core/util/array"
 
 export type RendererSpec = DataRenderer[] | "auto" | null
@@ -7,7 +7,7 @@ export function compute_renderers(renderers: RendererSpec, all_renderers: DataRe
   if (renderers == null)
     return []
 
-  let result: DataRenderer[] = renderers == 'auto' ?  all_renderers : renderers
+  let result: DataRenderer[] = renderers == "auto" ? all_renderers : renderers
 
   if (names.length > 0)
     result = result.filter((r) => includes(names, r.name))

--- a/bokehjs/test/unit/_util.ts
+++ b/bokehjs/test/unit/_util.ts
@@ -1,0 +1,22 @@
+export {describe, it, display} from "../framework"
+
+import {Matrix} from "@bokehjs/core/util/matrix"
+import {Figure, figure} from "@bokehjs/api/plotting"
+import {LayoutDOM, Row, Column, GridBox} from "@bokehjs/models/layouts/index"
+
+export function grid(items: Matrix<LayoutDOM> | LayoutDOM[][], opts?: Partial<GridBox.Attrs>): GridBox {
+  const children = Matrix.from(items).to_sparse()
+  return new GridBox({...opts, children})
+}
+
+export function row(children: LayoutDOM[], opts?: Partial<Row.Attrs>): Row {
+  return new Row({...opts, children})
+}
+
+export function column(children: LayoutDOM[], opts?: Partial<Column.Attrs>): Column {
+  return new Column({...opts, children})
+}
+
+export function fig([width, height]: [number, number], attrs?: Partial<Figure.Attrs>): Figure {
+  return figure({width, height, title: null, toolbar_location: null, ...attrs})
+}

--- a/bokehjs/test/unit/models/util.ts
+++ b/bokehjs/test/unit/models/util.ts
@@ -1,6 +1,6 @@
 import {expect} from "assertions"
 
-import {compute_renderers} from "@bokehjs/models/tools/util"
+import {compute_renderers} from "@bokehjs/models/util"
 import {GlyphRenderer} from "@bokehjs/models/renderers/glyph_renderer"
 import {GraphRenderer} from "@bokehjs/models/renderers/graph_renderer"
 

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -1,0 +1,22 @@
+import {expect} from "assertions"
+import {display, fig} from "./_util"
+
+import {HoverTool} from "@bokehjs/models"
+
+describe("Bug", () => {
+  describe("in issue #10612", () => {
+    it("prevents hovering over dynamically added glyphs", async () => {
+      const hover = new HoverTool({renderers: "auto"})
+      const plot = fig([200, 200], {tools: [hover]})
+      plot.circle([1, 2, 3], [4, 5, 6])
+      const {view} = await display(plot, [250, 250])
+      const hover_view = view.tool_views.get(hover)! as HoverTool["__view_type__"]
+      expect(hover_view.computed_renderers.length).to.be.equal(1)
+
+      plot.circle([2, 3, 4], [4, 5, 6])
+      plot.circle([3, 4, 5], [4, 5, 6])
+      await view.ready
+      expect(hover_view.computed_renderers.length).to.be.equal(3)
+    })
+  })
+})

--- a/sphinx/source/docs/releases/2.3.0.rst
+++ b/sphinx/source/docs/releases/2.3.0.rst
@@ -39,3 +39,10 @@ Certain base models were renamed to unify naming convention with bokehjs:
 +---------------+-------------------+
 
 Old names are deprecated and will be removed in bokeh 3.0.
+
+``names`` properties were deprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``DataRange.names``, ``SelectTool.names`` and ``HoverTool.names`` were deprecated
+and will be removed in bokeh 3.0. Use respective ``renderers`` properties instead,
+possibly in combination with ``plot.select(name="renderer name")``.


### PR DESCRIPTION
This fixes also fixes memory leak when connecting views' slots and adds support for selectively disconnecting senders, which could be generalized to disconnect signals of removed models.

- [x] tests

fixes #10612