### PR TITLE
Implement views for arrow head models

### DIFF
--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -116,7 +116,7 @@ def _DEFAULT_ARROW():
 # This only exists to prevent a circular import.
 def _DEFAULT_TEE():
     from .arrow_heads import TeeHead
-    return TeeHead(level="underlay", size=10)
+    return TeeHead(size=10)
 
 #-----------------------------------------------------------------------------
 # General API

--- a/bokeh/models/arrow_heads.py
+++ b/bokeh/models/arrow_heads.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 from ..core.has_props import abstract
 from ..core.properties import Float, Include, Override
 from ..core.property_mixins import ScalarFillProps, ScalarLineProps
-from .annotations import Annotation
+from ..model import Model
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -42,7 +42,7 @@ __all__ = (
 #-----------------------------------------------------------------------------
 
 @abstract
-class ArrowHead(Annotation):
+class ArrowHead(Model):
     ''' Base class for arrow heads.
 
     '''

--- a/bokehjs/src/lib/models/annotations/arrow.ts
+++ b/bokehjs/src/lib/models/annotations/arrow.ts
@@ -1,11 +1,12 @@
 import {Annotation, AnnotationView} from "./annotation"
-import {ArrowHead, OpenHead} from "./arrow_head"
+import {ArrowHead, ArrowHeadView, OpenHead} from "./arrow_head"
 import {ColumnarDataSource} from "../sources/columnar_data_source"
 import {ColumnDataSource} from "../sources/column_data_source"
 import {LineVector} from "core/property_mixins"
 import {Line} from "core/visuals"
 import {SpatialUnits} from "core/enums"
 import {Arrayable} from "core/types"
+import {build_view} from "core/build_views"
 import * as p from "core/properties"
 import {atan2} from "core/util/math"
 import {Context2d} from "core/util/canvas"
@@ -21,9 +22,29 @@ export class ArrowView extends AnnotationView {
   protected _x_end: Arrayable<number>
   protected _y_end: Arrayable<number>
 
+  protected start: ArrowHeadView | null
+  protected end: ArrowHeadView | null
+
   initialize(): void {
     super.initialize()
     this.set_data(this.model.source)
+  }
+
+  async lazy_initialize(): Promise<void> {
+    await super.lazy_initialize()
+
+    const {start, end} = this.model
+    const {parent} = this
+    if (start != null)
+      this.start = await build_view(start, {parent})
+    if (end != null)
+      this.end = await build_view(end, {parent})
+  }
+
+  remove(): void {
+    this.start?.remove()
+    this.end?.remove()
+    super.remove()
   }
 
   connect_signals(): void {
@@ -71,20 +92,20 @@ export class ArrowView extends AnnotationView {
     // Order in this function is important. First we draw all the arrow heads.
     const [start, end] = this._map_data()
 
-    if (this.model.end != null)
-      this._arrow_head(ctx, "render", this.model.end, start, end)
-    if (this.model.start != null)
-      this._arrow_head(ctx, "render", this.model.start, end, start)
+    if (this.end != null)
+      this._arrow_head(ctx, "render", this.end, start, end)
+    if (this.start != null)
+      this._arrow_head(ctx, "render", this.start, end, start)
 
     // Next we call .clip on all the arrow heads, inside an initial canvas sized
     // rect, to create an "inverted" clip region for the arrow heads
     ctx.beginPath()
     const {x, y, width, height} = this.plot_view.frame.bbox
     ctx.rect(x, y, width, height)
-    if (this.model.end != null)
-      this._arrow_head(ctx, "clip", this.model.end, start, end)
-    if (this.model.start != null)
-      this._arrow_head(ctx, "clip", this.model.start, end, start)
+    if (this.end != null)
+      this._arrow_head(ctx, "clip", this.end, start, end)
+    if (this.start != null)
+      this._arrow_head(ctx, "clip", this.start, end, start)
     ctx.closePath()
     ctx.clip()
 
@@ -95,7 +116,7 @@ export class ArrowView extends AnnotationView {
     ctx.restore()
   }
 
-  protected _arrow_head(ctx: Context2d, action: "render" | "clip", head: ArrowHead, start: Coords, end: Coords): void {
+  protected _arrow_head(ctx: Context2d, action: "render" | "clip", head: ArrowHeadView, start: Coords, end: Coords): void {
     for (let i = 0, _end = this._x_start.length; i < _end; i++) {
       // arrow head runs orthogonal to arrow body
       const angle = Math.PI/2 + atan2([start[0][i], start[1][i]], [end[0][i], end[1][i]])

--- a/bokehjs/src/lib/models/annotations/arrow_head.ts
+++ b/bokehjs/src/lib/models/annotations/arrow_head.ts
@@ -1,21 +1,39 @@
-import {Annotation} from "./annotation"
-import {Visuals, Line, Fill} from "core/visuals"
+import {Model} from "model"
+import {View} from "core/view"
+import * as visuals from "core/visuals"
 import {LineVector, FillVector} from "core/property_mixins"
 import * as p from "core/properties"
 import {Context2d} from "core/util/canvas"
 
+export abstract class ArrowHeadView extends View {
+  model: ArrowHead
+  visuals: ArrowHead.Visuals
+
+  initialize(): void {
+    super.initialize()
+    this.visuals = new visuals.Visuals(this.model)
+  }
+
+  abstract render(ctx: Context2d, i: number): void
+
+  abstract clip(ctx: Context2d, i: number): void // This method should not begin or close a path
+}
+
 export namespace ArrowHead {
   export type Attrs = p.AttrsOf<Props>
 
-  export type Props = Annotation.Props & {
+  export type Props = Model.Props & {
     size: p.Property<number>
   }
+
+  export type Visuals = visuals.Visuals
 }
 
 export interface ArrowHead extends ArrowHead.Attrs {}
 
-export abstract class ArrowHead extends Annotation {
+export abstract class ArrowHead extends Model {
   properties: ArrowHead.Props
+  __view_type__: ArrowHeadView
 
   constructor(attrs?: Partial<ArrowHead.Attrs>) {
     super(attrs)
@@ -26,17 +44,35 @@ export abstract class ArrowHead extends Annotation {
       size: [ Number, 25 ],
     }))
   }
+}
 
-  visuals: Visuals
+export class OpenHeadView extends ArrowHeadView {
+  model: OpenHead
+  visuals: OpenHead.Visuals
 
-  initialize(): void {
-    super.initialize()
-    this.visuals = new Visuals(this)
+  clip(ctx: Context2d, i: number): void {
+    // This method should not begin or close a path
+    this.visuals.line.set_vectorize(ctx, i)
+    const {size} = this.model
+    ctx.moveTo(0.5*size, size)
+    ctx.lineTo(0.5*size, -2)
+    ctx.lineTo(-0.5*size, -2)
+    ctx.lineTo(-0.5*size, size)
+    ctx.lineTo(0, 0)
+    ctx.lineTo(0.5*size, size)
   }
 
-  abstract render(ctx: Context2d, i: number): void
-
-  abstract clip(ctx: Context2d, i: number): void // This method should not begin or close a path
+  render(ctx: Context2d, i: number): void {
+    if (this.visuals.line.doit) {
+      this.visuals.line.set_vectorize(ctx, i)
+      const {size} = this.model
+      ctx.beginPath()
+      ctx.moveTo(0.5*size, size)
+      ctx.lineTo(0, 0)
+      ctx.lineTo(-0.5*size, size)
+      ctx.stroke()
+    }
+  }
 }
 
 export namespace OpenHead {
@@ -45,82 +81,40 @@ export namespace OpenHead {
   export type Props = ArrowHead.Props & Mixins
 
   export type Mixins = LineVector
+
+  export type Visuals = ArrowHead.Visuals & {line: visuals.Line}
 }
 
 export interface OpenHead extends OpenHead.Attrs {}
 
 export class OpenHead extends ArrowHead {
   properties: OpenHead.Props
+  __view_type__: OpenHeadView
 
   constructor(attrs?: Partial<OpenHead.Attrs>) {
     super(attrs)
   }
 
   static init_OpenHead(): void {
+    this.prototype.default_view = OpenHeadView
+
     this.mixins<OpenHead.Mixins>(LineVector)
   }
+}
 
-  visuals: Visuals & {line: Line}
+export class NormalHeadView extends ArrowHeadView {
+  model: NormalHead
+  visuals: NormalHead.Visuals
 
   clip(ctx: Context2d, i: number): void {
     // This method should not begin or close a path
     this.visuals.line.set_vectorize(ctx, i)
-    ctx.moveTo(0.5*this.size, this.size)
-    ctx.lineTo(0.5*this.size, -2)
-    ctx.lineTo(-0.5*this.size, -2)
-    ctx.lineTo(-0.5*this.size, this.size)
-    ctx.lineTo(0, 0)
-    ctx.lineTo(0.5*this.size, this.size)
-  }
-
-  render(ctx: Context2d, i: number): void {
-    if (this.visuals.line.doit) {
-      this.visuals.line.set_vectorize(ctx, i)
-
-      ctx.beginPath()
-      ctx.moveTo(0.5*this.size, this.size)
-      ctx.lineTo(0, 0)
-      ctx.lineTo(-0.5*this.size, this.size)
-      ctx.stroke()
-    }
-  }
-}
-
-export namespace NormalHead {
-  export type Attrs = p.AttrsOf<Props>
-
-  export type Props = ArrowHead.Props & Mixins
-
-  export type Mixins = LineVector & FillVector
-}
-
-export interface NormalHead extends NormalHead.Attrs {}
-
-export class NormalHead extends ArrowHead {
-  properties: NormalHead.Props
-
-  constructor(attrs?: Partial<NormalHead.Attrs>) {
-    super(attrs)
-  }
-
-  static init_NormalHead(): void {
-    this.mixins<NormalHead.Mixins>([LineVector, FillVector])
-
-    this.override<NormalHead.Props>({
-      fill_color: 'black',
-    })
-  }
-
-  visuals: Visuals & {line: Line, fill: Fill}
-
-  clip(ctx: Context2d, i: number): void {
-    // This method should not begin or close a path
-    this.visuals.line.set_vectorize(ctx, i)
-    ctx.moveTo(0.5*this.size, this.size)
-    ctx.lineTo(0.5*this.size, -2)
-    ctx.lineTo(-0.5*this.size, -2)
-    ctx.lineTo(-0.5*this.size, this.size)
-    ctx.lineTo(0.5*this.size, this.size)
+    const {size} = this.model
+    ctx.moveTo(0.5*size, size)
+    ctx.lineTo(0.5*size, -2)
+    ctx.lineTo(-0.5*size, -2)
+    ctx.lineTo(-0.5*size, size)
+    ctx.lineTo(0.5*size, size)
   }
 
   render(ctx: Context2d, i: number): void {
@@ -137,11 +131,84 @@ export class NormalHead extends ArrowHead {
     }
   }
 
-  _normal(ctx: Context2d, _i: number): void {
+  protected _normal(ctx: Context2d, _i: number): void {
+    const {size} = this.model
     ctx.beginPath()
-    ctx.moveTo(0.5*this.size, this.size)
+    ctx.moveTo(0.5*size, size)
     ctx.lineTo(0, 0)
-    ctx.lineTo(-0.5*this.size, this.size)
+    ctx.lineTo(-0.5*size, size)
+    ctx.closePath()
+  }
+}
+
+export namespace NormalHead {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = ArrowHead.Props & Mixins
+
+  export type Mixins = LineVector & FillVector
+
+  export type Visuals = ArrowHead.Visuals & {line: visuals.Line, fill: visuals.Fill}
+}
+
+export interface NormalHead extends NormalHead.Attrs {}
+
+export class NormalHead extends ArrowHead {
+  properties: NormalHead.Props
+  __view_type__: NormalHeadView
+
+  constructor(attrs?: Partial<NormalHead.Attrs>) {
+    super(attrs)
+  }
+
+  static init_NormalHead(): void {
+    this.prototype.default_view = NormalHeadView
+
+    this.mixins<NormalHead.Mixins>([LineVector, FillVector])
+
+    this.override<NormalHead.Props>({
+      fill_color: "black",
+    })
+  }
+}
+
+export class VeeHeadView extends ArrowHeadView {
+  model: VeeHead
+  visuals: VeeHead.Visuals
+
+  clip(ctx: Context2d, i: number): void {
+    // This method should not begin or close a path
+    this.visuals.line.set_vectorize(ctx, i)
+    const {size} = this.model
+    ctx.moveTo(0.5*size, size)
+    ctx.lineTo(0.5*size, -2)
+    ctx.lineTo(-0.5*size, -2)
+    ctx.lineTo(-0.5*size, size)
+    ctx.lineTo(0, 0.5*size)
+    ctx.lineTo(0.5*size, size)
+  }
+
+  render(ctx: Context2d, i: number): void {
+    if (this.visuals.fill.doit) {
+      this.visuals.fill.set_vectorize(ctx, i)
+      this._vee(ctx, i)
+      ctx.fill()
+    }
+
+    if (this.visuals.line.doit) {
+      this.visuals.line.set_vectorize(ctx, i)
+      this._vee(ctx, i)
+      ctx.stroke()
+    }
+  }
+
+  protected _vee(ctx: Context2d, _i: number): void {
+    const {size} = this.model
+    ctx.beginPath()
+    ctx.moveTo(0.5*size, size)
+    ctx.lineTo(0, 0)
+    ctx.lineTo(-0.5*size, size)
+    ctx.lineTo(0, 0.5*size)
     ctx.closePath()
   }
 }
@@ -152,60 +219,47 @@ export namespace VeeHead {
   export type Props = ArrowHead.Props & Mixins
 
   export type Mixins = LineVector & FillVector
+
+  export type Visuals = ArrowHead.Visuals & {line: visuals.Line, fill: visuals.Fill}
 }
 
 export interface VeeHead extends VeeHead.Attrs {}
 
 export class VeeHead extends ArrowHead {
   properties: VeeHead.Props
+  __view_type__: VeeHeadView
 
   constructor(attrs?: Partial<VeeHead.Attrs>) {
     super(attrs)
   }
 
   static init_VeeHead(): void {
+    this.prototype.default_view = VeeHeadView
+
     this.mixins<VeeHead.Mixins>([LineVector, FillVector])
 
     this.override<VeeHead.Props>({
-      fill_color: 'black',
+      fill_color: "black",
     })
   }
+}
 
-  visuals: Visuals & {line: Line, fill: Fill}
-
-  clip(ctx: Context2d, i: number): void {
-    // This method should not begin or close a path
-    this.visuals.line.set_vectorize(ctx, i)
-    ctx.moveTo(0.5*this.size, this.size)
-    ctx.lineTo(0.5*this.size, -2)
-    ctx.lineTo(-0.5*this.size, -2)
-    ctx.lineTo(-0.5*this.size, this.size)
-    ctx.lineTo(0, 0.5*this.size)
-    ctx.lineTo(0.5*this.size, this.size)
-  }
+export class TeeHeadView extends ArrowHeadView {
+  model: TeeHead
+  visuals: TeeHead.Visuals
 
   render(ctx: Context2d, i: number): void {
-    if (this.visuals.fill.doit) {
-      this.visuals.fill.set_vectorize(ctx, i)
-      this._vee(ctx, i)
-      ctx.fill()
-    }
-
     if (this.visuals.line.doit) {
       this.visuals.line.set_vectorize(ctx, i)
-      this._vee(ctx, i)
+      const {size} = this.model
+      ctx.beginPath()
+      ctx.moveTo(0.5*size, 0)
+      ctx.lineTo(-0.5*size, 0)
       ctx.stroke()
     }
   }
 
-  _vee(ctx: Context2d, _i: number): void {
-    ctx.beginPath()
-    ctx.moveTo(0.5*this.size, this.size)
-    ctx.lineTo(0, 0)
-    ctx.lineTo(-0.5*this.size, this.size)
-    ctx.lineTo(0, 0.5*this.size)
-    ctx.closePath()
-  }
+  clip(_ctx: Context2d, _i: number): void {}
 }
 
 export namespace TeeHead {
@@ -214,32 +268,23 @@ export namespace TeeHead {
   export type Props = ArrowHead.Props & Mixins
 
   export type Mixins = LineVector
+
+  export type Visuals = ArrowHead.Visuals & {line: visuals.Line}
 }
 
 export interface TeeHead extends TeeHead.Attrs {}
 
 export class TeeHead extends ArrowHead {
   properties: TeeHead.Props
+  __view_type__: TeeHeadView
 
   constructor(attrs?: Partial<TeeHead.Attrs>) {
     super(attrs)
   }
 
   static init_TeeHead(): void {
+    this.prototype.default_view = TeeHeadView
+
     this.mixins<TeeHead.Mixins>(LineVector)
   }
-
-  visuals: Visuals & {line: Line}
-
-  render(ctx: Context2d, i: number): void {
-    if (this.visuals.line.doit) {
-      this.visuals.line.set_vectorize(ctx, i)
-      ctx.beginPath()
-      ctx.moveTo(0.5*this.size, 0)
-      ctx.lineTo(-0.5*this.size, 0)
-      ctx.stroke()
-    }
-  }
-
-  clip(_ctx: Context2d, _i: number): void {}
 }

--- a/sphinx/source/docs/releases/2.3.0.rst
+++ b/sphinx/source/docs/releases/2.3.0.rst
@@ -1,0 +1,22 @@
+.. _release-2-3-0:
+
+2.3.0
+=====
+
+Bokeh Version ``2.3.0`` (TODO Nov/Dev 2020) is a minor-release.
+
+And several other bug fixes and docs additions. For full details see the
+:bokeh-tree:`CHANGELOG`.
+
+.. _release-2-3-0-migration:
+
+`Migration Guide <releases.html#release-2-3-0-migration>`__
+-----------------------------------------------------------
+
+``ArrowHead`` is not an annotation anymore
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``ArrowHead`` used to inherit from ``Annotation`` base class, but was never
+intended to work like one and didn't fully implement its protocol. After this
+change you won't be able to use properties like ``level``, ``x_range_name``,
+etc., but those wheren't respected by renderers anyway.

--- a/tests/unit/bokeh/models/test_annotations.py
+++ b/tests/unit/bokeh/models/test_annotations.py
@@ -428,12 +428,10 @@ def test_Whisker() -> None:
     assert whisker.lower_units == 'data'
     assert isinstance(whisker.lower_head, ArrowHead)
     assert whisker.lower_head.size == 10
-    assert whisker.lower_head.level == 'underlay'
     assert whisker.upper == field("upper")
     assert whisker.upper_units == 'data'
     assert isinstance(whisker.upper_head, ArrowHead)
     assert whisker.upper_head.size == 10
-    assert whisker.upper_head.level == 'underlay'
     assert whisker.base == field("base")
     assert whisker.dimension == 'height'
     assert isinstance(whisker.source, ColumnDataSource)


### PR DESCRIPTION
Currently arrow head models mix model and view code, so this PR addresses this issue. Additionally arrow heads are currently annotations, but they aren't used like ones (the interface is not fulfilled), so I changed their base to `Model`. In future I will add a proper `Graphics`  (or something like that) base classes, to group paintable objects that aren't glyphs nor annotations.
