### PR TITLE
Push to server only actually changed properties

### DIFF
--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -356,22 +356,22 @@ export abstract class HasProps extends Signalable() implements Equatable, Printa
   // Set a hash of model attributes on the object, firing `"change"`. This is
   // the core primitive operation of a model, updating the data and notifying
   // anyone who needs to know about the change in state. The heart of the beast.
-  private _setv(changes: Map<Property, unknown>, options: HasProps.SetOptions): void {
+  private _setv(changes: Map<Property, unknown>, options: HasProps.SetOptions): Set<Property> {
     // Extract attributes and options.
     const check_eq   = options.check_eq
-    const changed    = []
+    const changed    = new Set<Property>()
     const changing   = this._changing
     this._changing = true
 
     for (const [prop, value] of changes) {
       if (check_eq === false || !is_equal(prop.get_value(), value)) {
         prop.set_value(value)
-        changed.push(prop)
+        changed.add(prop)
       }
     }
 
     // Trigger all relevant attribute changes.
-    if (changed.length > 0) {
+    if (changed.size > 0) {
       this._watchers = new WeakMap()
       this._pending = true
     }
@@ -381,17 +381,19 @@ export abstract class HasProps extends Signalable() implements Equatable, Printa
 
     // You might be wondering why there's a `while` loop here. Changes can
     // be recursively nested within `"change"` events.
-    if (changing)
-      return
-    if (!(options.no_change ?? false)) {
-      while (this._pending) {
-        this._pending = false
-        this.change.emit()
+    if (!changing) {
+      if (!(options.no_change ?? false)) {
+        while (this._pending) {
+          this._pending = false
+          this.change.emit()
+        }
       }
+
+      this._pending = false
+      this._changing = false
     }
 
-    this._pending = false
-    this._changing = false
+    return changed
   }
 
   setv(changed_attrs: Attrs, options: HasProps.SetOptions = {}): void {
@@ -419,13 +421,14 @@ export abstract class HasProps extends Signalable() implements Equatable, Printa
       previous.set(prop, prop.get_value())
     }
 
-    this._setv(changed, options)
+    const updated = this._setv(changed, options)
 
     const {document} = this
     if (document != null) {
       const changed: [Property, unknown, unknown][] = []
       for (const [prop, value] of previous) {
-        changed.push([prop, value, prop.get_value()])
+        if (updated.has(prop))
+          changed.push([prop, value, prop.get_value()])
       }
 
       for (const [, old_value, new_value] of changed) {

--- a/bokehjs/src/lib/models/tools/edit/edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/edit_tool.ts
@@ -97,8 +97,8 @@ export abstract class EditToolView extends GestureToolView {
     if (redraw)
       cds.change.emit()
     if (emit) {
-      cds.data = cds.data
-      cds.properties.data.change.emit()
+      const {data} = cds
+      cds.setv({data}, {check_eq: false})
     }
   }
 

--- a/bokehjs/src/lib/models/tools/edit/point_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/point_draw_tool.ts
@@ -30,9 +30,8 @@ export class PointDrawToolView extends EditToolView {
     if (ykey) cds.get_array(ykey).push(y)
     this._pad_empty_columns(cds, [xkey, ykey])
 
-    cds.change.emit()
-    cds.data = cds.data
-    cds.properties.data.change.emit()
+    const {data} = cds
+    cds.setv({data}, {check_eq: false}) // XXX: inplace updates
   }
 
   override _keyup(ev: KeyEvent): void {

--- a/bokehjs/test/unit/document/document.ts
+++ b/bokehjs/test/unit/document/document.ts
@@ -473,6 +473,23 @@ describe("Document", () => {
     expect(event.new_).to.be.equal(42)
   })
 
+  it("notifies only on actual changes", () => {
+    const d = new Document()
+    expect(d.roots().length).to.be.equal(0)
+
+    const m = new AnotherModel()
+
+    d.add_root(m)
+    expect(d.roots().length).to.be.equal(1)
+
+    const events: ev.DocumentEvent[] = []
+    d.on_change((event) => events.push(event))
+
+    expect(m.bar).to.be.equal(1)
+    m.bar = 1
+    expect(events.length).to.be.equal(0)
+  })
+
   it("can notify on changes in batches", () => {
     const d = new Document()
     const m = new SomeModel()

--- a/sphinx/source/docs/releases/3.0.0.rst
+++ b/sphinx/source/docs/releases/3.0.0.rst
@@ -139,3 +139,10 @@ bokehjs changes
 ``Figure`` now return a model proxy object, which mimics the behavior of bokeh's
 plotting API. Arrays of axes/grids can be obtained using new ``xaxes``, ``yaxes``,
 ``axes``, ``xgrids``, ``ygrids`` and ``grids`` attributes.
+
+Property changes push to server
+...............................
+
+Previously all changes were pushed to server, even if no actual changes were made.
+Now only effective changes are pushed, which now maches the internal behavior of
+bokehjs.


### PR DESCRIPTION
This seems like a big omission and it always worked like this. Maybe there was historically a reason for this? Testing locally didn't show any issues with this change.

- [x] tests

fixes #10621