### PR TITLE
Auto-compute lod_factor based on glyph rendering times

### DIFF
--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -24,8 +24,10 @@ import warnings
 # Bokeh imports
 from ..core.enums import Location, OutputBackend, ResetPolicy
 from ..core.properties import (
+    Auto,
     Bool,
     Dict,
+    Either,
     Enum,
     Float,
     Include,
@@ -637,8 +639,10 @@ class Plot(LayoutDOM):
     it will override ``min_border``.
     """)
 
-    lod_factor = Int(10, help="""
-    Decimation factor to use when applying level-of-detail decimation.
+    lod_factor = Either(Int, Auto, default=10, help="""
+    Decimation factor to use when applying level-of-detail decimation. If
+    set to ``"auto"``, live rendering time will be used to determine the
+    factor.
     """)
 
     lod_threshold = Int(2000, help="""

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -84,8 +84,18 @@ export abstract class GlyphView extends View {
         return
     }
 
+    const t0 = performance.now()
     this._render(ctx, indices, data)
+    const t1 = performance.now()
+
+    if (indices.length > 0) {
+      const ti = this._render_time_per_index
+      const tj = (t1 - t0)/indices.length
+      this._render_time_per_index = ti != null ? (ti + tj)/2 : tj
+    }
   }
+
+  /*private*/ _render_time_per_index?: number
 
   protected abstract _render(ctx: Context2d, indices: number[], data: any): void
 

--- a/bokehjs/src/lib/models/plots/plot.ts
+++ b/bokehjs/src/lib/models/plots/plot.ts
@@ -64,7 +64,7 @@ export namespace Plot {
     x_scale: p.Property<Scale>
     y_scale: p.Property<Scale>
 
-    lod_factor: p.Property<number>
+    lod_factor: p.Property<number | "auto">
     lod_interval: p.Property<number>
     lod_threshold: p.Property<number>
     lod_timeout: p.Property<number>
@@ -124,7 +124,7 @@ export class Plot extends LayoutDOM {
       ["border_",     mixins.Fill],
     ])
 
-    this.define<Plot.Props>(({Boolean, Number, String, Array, Dict, Or, Ref, Null, Nullable}) => ({
+    this.define<Plot.Props>(({Boolean, Number, String, Array, Dict, Or, Ref, Null, Nullable, Auto}) => ({
       toolbar:           [ Ref(Toolbar), () => new Toolbar() ],
       toolbar_location:  [ Nullable(Location), "right" ],
       toolbar_sticky:    [ Boolean, true ],
@@ -154,7 +154,7 @@ export class Plot extends LayoutDOM {
       x_scale:           [ Ref(Scale), () => new LinearScale() ],
       y_scale:           [ Ref(Scale), () => new LinearScale() ],
 
-      lod_factor:        [ Number, 10 ],
+      lod_factor:        [ Or(Number, Auto), 10 ],
       lod_interval:      [ Number, 300 ],
       lod_threshold:     [ Number, 2000 ],
       lod_timeout:       [ Number, 500 ],

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -168,13 +168,6 @@ export class GlyphRendererView extends DataRendererView {
 
     this._update_masked_indices()
 
-    const {lod_factor} = this.plot_model
-    const n = this.all_indices.count
-    this.decimated = new Indices(n)
-    for (let i = 0; i < n; i += lod_factor) {
-      this.decimated.set(i)
-    }
-
     this.plot_view.invalidate_dataranges = true
 
     if (request_render) {
@@ -249,6 +242,21 @@ export class GlyphRendererView extends DataRendererView {
     if ((this.model.document != null ? this.model.document.interactive_duration() > 0 : false)
         && !glsupport && lod_threshold != null && all_indices.length > lod_threshold) {
       // Render decimated during interaction if too many elements and not using GL
+      let {lod_factor} = this.plot_model
+      if (lod_factor == "auto") {
+        const N = all_indices.length
+        const ti = this.glyph._render_time_per_index ?? 0
+        const T = N*ti
+        const Tf = 1000/60
+        lod_factor = T <= Tf ? 1 : Math.ceil(T/Tf)
+      }
+
+      const n = this.all_indices.count
+      this.decimated = new Indices(n)
+      for (let i = 0; i < n; i += lod_factor) {
+        this.decimated.set(i)
+      }
+
       indices = [...this.decimated]
       glyph = this.decimated_glyph
       nonselection_glyph = this.decimated_glyph

--- a/examples/plotting/file/color_scatter.py
+++ b/examples/plotting/file/color_scatter.py
@@ -12,7 +12,7 @@ colors = [
 
 TOOLS="hover,crosshair,pan,wheel_zoom,zoom_in,zoom_out,box_zoom,undo,redo,reset,tap,save,box_select,poly_select,lasso_select,"
 
-p = figure(tools=TOOLS)
+p = figure(tools=TOOLS, lod_factor="auto")
 
 p.scatter(x, y, radius=radii,
           fill_color=colors, fill_alpha=0.6,


### PR DESCRIPTION
Experimental PR. The current behavior of LOD doesn't seem very useful, as it doesn't account for rendering conditions, so this PR attempts to fix that, by computing the LOD factor based on actual rendering times, assuming 60 Hz refresh rate, so rendering must finish in ~16 ms.