### PR TITLE
Use the correct variant of hasOwnProperty check

### DIFF
--- a/bokeh/core/_templates/autoload_nb_js.js
+++ b/bokeh/core/_templates/autoload_nb_js.js
@@ -58,7 +58,7 @@
     var output = handle.output;
 
     // limit handleAddOutput to display_data with EXEC_MIME_TYPE content only
-    if ((output.output_type != "display_data") || (!output.data.hasOwnProperty(EXEC_MIME_TYPE))) {
+    if ((output.output_type != "display_data") || (!Object.prototype.hasOwnProperty.call(output.data, EXEC_MIME_TYPE))) {
       return
     }
 

--- a/bokehjs/src/lib/api/plotting.ts
+++ b/bokehjs/src/lib/api/plotting.ts
@@ -25,6 +25,8 @@ import {Legend} from "models/annotations/legend"
 export {gridplot} from "./gridplot"
 export {rgb2hex as color} from "../core/util/color"
 
+const {hasOwnProperty} = Object.prototype
+
 export type ToolName = keyof ToolAliases
 
 const _default_tools: ToolName[] = ["pan", "wheel_zoom", "box_zoom", "save", "reset", "help"]
@@ -691,14 +693,14 @@ export class Figure extends Plot {
     }
 
     defaults = {...defaults}
-    if (!defaults.hasOwnProperty('text_color')) {
+    if (!hasOwnProperty.call(defaults, 'text_color')) {
       defaults.text_color = 'black'
     }
     const trait_defaults: Attrs = {}
-    if (!trait_defaults.hasOwnProperty('color')) {
+    if (!hasOwnProperty.call(trait_defaults, 'color')) {
       trait_defaults.color = _default_color
     }
-    if (!trait_defaults.hasOwnProperty('alpha')){
+    if (!hasOwnProperty.call(trait_defaults, 'alpha')){
       trait_defaults.alpha = _default_alpha
     }
 
@@ -707,19 +709,19 @@ export class Figure extends Plot {
     for (const pname of keys(cls.prototype._props)) {
       if (_is_visual(pname)) {
         const trait = _split_feature_trait(pname)[1]
-        if (props.hasOwnProperty(prefix+pname)) {
+        if (hasOwnProperty.call(props, prefix+pname)) {
           result[pname] = props[prefix+pname]
           delete props[prefix+pname]
-        } else if (!cls.prototype._props.hasOwnProperty(trait) && props.hasOwnProperty(prefix+trait)) {
+        } else if (!hasOwnProperty.call(cls.prototype._props, trait) && hasOwnProperty.call(props, prefix+trait)) {
           result[pname] = props[prefix+trait]
-        } else if (override_defaults.hasOwnProperty(trait)) {
+        } else if (hasOwnProperty.call(override_defaults, trait)) {
           result[pname] = override_defaults[trait]
-        } else if (defaults.hasOwnProperty(pname)) {
+        } else if (hasOwnProperty.call(defaults, pname)) {
           result[pname] = defaults[pname]
-        } else if (trait_defaults.hasOwnProperty(trait)) {
+        } else if (hasOwnProperty.call(trait_defaults, trait)) {
           result[pname] = trait_defaults[trait]
         }
-        if (!cls.prototype._props.hasOwnProperty(trait)) {
+        if (!hasOwnProperty.call(cls.prototype._props, trait)) {
           traits.add(trait)
         }
       }

--- a/bokehjs/src/lib/core/kinds.ts
+++ b/bokehjs/src/lib/core/kinds.ts
@@ -6,6 +6,8 @@ import {size} from "./util/object"
 type ESMap<K, V> = Map<K, V>
 const ESMap = window.Map
 
+const {hasOwnProperty} = Object.prototype
+
 export abstract class Kind<T> {
   __type__: T
 
@@ -120,8 +122,8 @@ export namespace Kinds {
         return false
 
       for (const key in struct_type) {
-        if (struct_type.hasOwnProperty(key)) {
-          if (!value.hasOwnProperty(key))
+        if (hasOwnProperty.call(struct_type, key)) {
+          if (!hasOwnProperty.call(value, key))
             return false
 
           const item_type = struct_type[key]
@@ -212,7 +214,7 @@ export namespace Kinds {
         return false
 
       for (const key in value) {
-        if (value.hasOwnProperty(key)) {
+        if (hasOwnProperty.call(value, key)) {
           const item = value[key]
           if (!this.item_type.valid(item))
             return false

--- a/bokehjs/src/lib/core/util/eq.ts
+++ b/bokehjs/src/lib/core/util/eq.ts
@@ -2,6 +2,8 @@
 
 import {PlainObject} from "../types"
 
+const {hasOwnProperty} = Object.prototype
+
 export const equals = Symbol("equals")
 
 export interface Equatable {
@@ -175,7 +177,7 @@ export class Comparator {
       return false
 
     for (const key of keys) {
-      if (!b.hasOwnProperty(key) || !this.eq(a[key], b[key]))
+      if (!hasOwnProperty.call(b, key) || !this.eq(a[key], b[key]))
         return false
     }
 

--- a/bokehjs/src/lib/core/util/object.ts
+++ b/bokehjs/src/lib/core/util/object.ts
@@ -1,6 +1,8 @@
 import {PlainObject} from "../types"
 import {concat, union} from "./array"
 
+const {hasOwnProperty} = Object.prototype
+
 export const {keys, values, entries, assign: extend} = Object
 
 export function clone<T>(obj: PlainObject<T>): PlainObject<T> {
@@ -16,8 +18,8 @@ export function merge<T>(obj1: PlainObject<T[]>, obj2: PlainObject<T[]>): PlainO
   const keys = concat([Object.keys(obj1), Object.keys(obj2)])
 
   for (const key of keys){
-    const arr1 = obj1.hasOwnProperty(key) ? obj1[key] : []
-    const arr2 = obj2.hasOwnProperty(key) ? obj2[key] : []
+    const arr1 = hasOwnProperty.call(obj1, key) ? obj1[key] : []
+    const arr2 = hasOwnProperty.call(obj2, key) ? obj2[key] : []
     result[key] = union(arr1, arr2)
   }
 

--- a/bokehjs/src/lib/core/visuals.ts
+++ b/bokehjs/src/lib/core/visuals.ts
@@ -13,6 +13,8 @@ import {Texture} from "models/textures/texture"
 import {SVGRenderingContext2D} from "core/util/svg"
 import {CanvasLayer} from "models/canvas/canvas"
 
+const {hasOwnProperty} = Object.prototype
+
 function color2css(color: Color | number, alpha: number): string {
   const [r, g, b, a] = isString(color) ? color2rgba(color) : decode_rgba(color)
   return `rgba(${r*255}, ${g*255}, ${b*255}, ${a == 1.0 ? alpha : a})`
@@ -314,7 +316,7 @@ export class Hatch extends ContextProperties {
       const weight = this.cache_select("hatch_weight", i)
 
       const {hatch_extra} = this.cache
-      if (hatch_extra != null && hatch_extra.hasOwnProperty(pattern)) {
+      if (hatch_extra != null && hasOwnProperty.call(hatch_extra, pattern)) {
         const custom: Texture = hatch_extra[pattern]
         this.cache.pattern = custom.get_pattern(color, alpha, scale, weight)
       } else {
@@ -336,7 +338,7 @@ export class Hatch extends ContextProperties {
 
   private _try_defer(defer_func: () => void): void {
     const {hatch_pattern, hatch_extra} = this.cache
-    if (hatch_extra != null && hatch_extra.hasOwnProperty(hatch_pattern)) {
+    if (hatch_extra != null && hasOwnProperty.call(hatch_extra, hatch_pattern)) {
       const custom = hatch_extra[hatch_pattern]
       custom.onload(defer_func)
     }
@@ -468,7 +470,7 @@ export class Visuals {
 
   warm_cache(source?: ColumnarDataSource, all_indices?: Indices): void {
     for (const name in this) {
-      if (this.hasOwnProperty(name)) {
+      if (hasOwnProperty.call(this, name)) {
         const prop: any = this[name]
         if (prop instanceof ContextProperties)
           prop.warm_cache(source, all_indices)

--- a/bokehjs/src/lib/models/sources/geojson_data_source.ts
+++ b/bokehjs/src/lib/models/sources/geojson_data_source.ts
@@ -36,6 +36,8 @@ function orNaN(v: number | undefined): number {
   return v != null ? v : NaN
 }
 
+const {hasOwnProperty} = Object.prototype
+
 export class GeoJSONDataSource extends ColumnarDataSource {
   properties: GeoJSONDataSource.Props
 
@@ -78,7 +80,7 @@ export class GeoJSONDataSource extends ColumnarDataSource {
   private _add_properties(item: Feature<GeoItem>, data: GeoData, i: number, item_count: number): void {
     const properties = item.properties ?? {}
     for (const [property, value] of entries(properties)) {
-      if (!data.hasOwnProperty(property))
+      if (!hasOwnProperty.call(data, property))
         data[property] = this._get_new_nan_array(item_count)
       // orNaN necessary here to prevent null values from ending up in the column
       data[property][i] = orNaN(value)

--- a/tests/unit/bokeh/core/test_templates.py
+++ b/tests/unit/bokeh/core/test_templates.py
@@ -48,7 +48,7 @@ def compute_sha256(data):
     sha256.update(data)
     return sha256.hexdigest()
 
-pinned_template_sha256 = "f3667e80d84d19b7d2b0642a3dd17131b72c0468981a3dd08227345d1fb2cfe5"
+pinned_template_sha256 = "7ef90f10663ac0168363c95050a718ad5a0caa27a69145b2b4cdf916787a8554"
 
 def test_autoload_template_has_changed() -> None:
     """This is not really a test but a reminder that if you change the


### PR DESCRIPTION
In particular this approach works with prototype-less plain objects (i.e. `Object.create(null)`).