### PR TITLE
[Spinner] Avoid twice incrementation with laptop pad

### DIFF
--- a/bokehjs/src/lib/models/widgets/spinner.ts
+++ b/bokehjs/src/lib/models/widgets/spinner.ts
@@ -46,10 +46,13 @@ export class SpinnerView extends NumericInputView {
   protected wrapper_el: HTMLDivElement
   protected btn_up_el: HTMLButtonElement
   protected btn_down_el: HTMLButtonElement
-  private _interval_handle: ReturnType<typeof setInterval>
+  private _handles:  {
+    interval: ReturnType<typeof setInterval> | undefined
+    timeout: ReturnType<typeof setTimeout> | undefined
+  }
   private _counter: number
   private _interval: number
-
+  
   *buttons(): Generator<HTMLButtonElement> {
     yield this.btn_up_el
     yield this.btn_down_el
@@ -57,6 +60,10 @@ export class SpinnerView extends NumericInputView {
 
   initialize(): void {
     super.initialize()
+    this._handles = {
+      interval: undefined,
+      timeout: undefined
+    }
     this._interval = 200
   }
 
@@ -106,8 +113,13 @@ export class SpinnerView extends NumericInputView {
     return max(p(abs(low ?? 0)), p(abs(high ?? 0)), p(abs(step)))
   }
 
+  remove(): void {
+    this._stop_incrementation()
+    super.remove()
+  }
+
   _start_incrementation(sign: 1|-1): void {
-    clearInterval(this._interval_handle)
+    clearInterval(this._handles.interval)
     this._counter = 0
     const {step} = this.model
     const increment_with_increasing_rate = (step: number) => {
@@ -115,20 +127,23 @@ export class SpinnerView extends NumericInputView {
       if (this._counter % 5 == 0) {
         const quotient  = Math.floor(this._counter / 5)
         if (quotient < 10) {
-          clearInterval(this._interval_handle)
-          this._interval_handle = setInterval(() => increment_with_increasing_rate(step), this._interval/(quotient+1))
+          clearInterval(this._handles.interval)
+          this._handles.interval = setInterval(() => increment_with_increasing_rate(step), this._interval/(quotient+1))
         } else if (quotient >= 10 && quotient <= 13) {
-          clearInterval(this._interval_handle)
-          this._interval_handle = setInterval(() => increment_with_increasing_rate(step*2), this._interval/10)
+          clearInterval(this._handles.interval)
+          this._handles.interval = setInterval(() => increment_with_increasing_rate(step*2), this._interval/10)
         }
       }
       this.increment(step)
     }
-    this._interval_handle = setInterval(() => increment_with_increasing_rate(sign * step), this._interval)
+    this._handles.interval = setInterval(() => increment_with_increasing_rate(sign * step), this._interval)
   }
 
   _stop_incrementation(): void {
-    clearInterval(this._interval_handle)
+    clearTimeout(this._handles.timeout)
+    this._handles.timeout = undefined
+    clearInterval(this._handles.interval)
+    this._handles.interval = undefined
     this.model.value_throttled = this.model.value
   }
 
@@ -138,7 +153,7 @@ export class SpinnerView extends NumericInputView {
     this.increment(sign * this.model.step)
     this.input_el.focus()
     //while mouse is down we increment at a certain rate
-    this._start_incrementation(sign)
+    this._handles.timeout = setTimeout(() => this._start_incrementation(sign), this._interval)
   }
 
   _btn_mouse_up(): void {

--- a/bokehjs/src/lib/models/widgets/spinner.ts
+++ b/bokehjs/src/lib/models/widgets/spinner.ts
@@ -52,7 +52,7 @@ export class SpinnerView extends NumericInputView {
   }
   private _counter: number
   private _interval: number
-  
+
   *buttons(): Generator<HTMLButtonElement> {
     yield this.btn_up_el
     yield this.btn_down_el

--- a/bokehjs/src/lib/models/widgets/spinner.ts
+++ b/bokehjs/src/lib/models/widgets/spinner.ts
@@ -60,10 +60,7 @@ export class SpinnerView extends NumericInputView {
 
   initialize(): void {
     super.initialize()
-    this._handles = {
-      interval: undefined,
-      timeout: undefined
-    }
+    this._handles = {interval: undefined, timeout: undefined}
     this._interval = 200
   }
 


### PR DESCRIPTION
I haven't open an issue related to this.
But I noticed when we press spinner arrows to increment it, with the laptop pad, the number increment twice
To correct it I add a timeout before setting the interval.

@mattpap I noticed KeyboardEvent.keyCode is deprecated what is the recommended way to handle it now?
