### PR TITLE
Split visuals into scalar and vector

### DIFF
--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -1137,7 +1137,7 @@ class Step(XYGlyph, LineGlyph):
     The y-coordinates for the steps.
     """)
 
-    line_props = Include(LineProps, use_prefix=False, help="""
+    line_props = Include(ScalarLineProps, use_prefix=False, help="""
     The %s values for the steps.
     """)
 

--- a/bokehjs/src/lib/core/property_mixins.ts
+++ b/bokehjs/src/lib/core/property_mixins.ts
@@ -223,7 +223,7 @@ export const TextVector: p.DefineOf<TextVector> = {
   text_line_height: [ k.Number, 1.2 ],
 }
 
-type Prefixed<P extends string, T> = {[key in keyof T & string as `${P}_${key}`]: T[key]}
+export type Prefixed<P extends string, T> = {[key in keyof T & string as `${P}_${key}`]: T[key]}
 
 export type AxisLabelText = Prefixed<"axis_label", Text>
 export type AxisLine = Prefixed<"axis", Line>

--- a/bokehjs/src/lib/core/visuals.ts
+++ b/bokehjs/src/lib/core/visuals.ts
@@ -218,7 +218,7 @@ export abstract class ContextProperties {
   protected abstract _set_vectorize(ctx: Context2d, i: number): void
 }
 
-export class Line extends ContextProperties {
+class _Line extends ContextProperties {
   readonly line_color:       p.ColorSpec
   readonly line_width:       p.NumberSpec
   readonly line_alpha:       p.NumberSpec
@@ -267,9 +267,9 @@ export class Line extends ContextProperties {
   }
 }
 
-Line.prototype.attrs = Object.keys(mixins.LineVector)
+_Line.prototype.attrs = Object.keys(mixins.LineVector)
 
-export class Fill extends ContextProperties {
+class _Fill extends ContextProperties {
   readonly fill_color: p.ColorSpec
   readonly fill_alpha: p.NumberSpec
 
@@ -297,9 +297,9 @@ export class Fill extends ContextProperties {
   }
 }
 
-Fill.prototype.attrs = Object.keys(mixins.FillVector)
+_Fill.prototype.attrs = Object.keys(mixins.FillVector)
 
-export class Hatch extends ContextProperties {
+class _Hatch extends ContextProperties {
   readonly hatch_color: p.ColorSpec
   readonly hatch_alpha: p.NumberSpec
   readonly hatch_scale: p.NumberSpec
@@ -377,9 +377,9 @@ export class Hatch extends ContextProperties {
   }
 }
 
-Hatch.prototype.attrs = Object.keys(mixins.HatchVector)
+_Hatch.prototype.attrs = Object.keys(mixins.HatchVector)
 
-export class Text extends ContextProperties {
+class _Text extends ContextProperties {
   readonly text_font:        p.Font
   readonly text_font_size:   p.StringSpec
   readonly text_font_style:  p.Property<FontStyle>
@@ -448,7 +448,7 @@ export class Text extends ContextProperties {
   }
 }
 
-Text.prototype.attrs = Object.keys(mixins.TextVector)
+_Text.prototype.attrs = Object.keys(mixins.TextVector)
 
 export class Visuals {
 
@@ -478,3 +478,19 @@ export class Visuals {
     }
   }
 }
+
+export class Line extends _Line {}
+//export class LineScalar extends _Line {}
+export class LineVector extends _Line {}
+
+export class Fill extends _Fill {}
+//export class FillScalar extends _Fill {}
+export class FillVector extends _Fill {}
+
+export class Text extends _Text {}
+//export class TextScalar extends _Text {}
+export class TextVector extends _Text {}
+
+export class Hatch extends _Hatch {}
+//export class HatchScalar extends _Hatch {}
+export class HatchVector extends _Hatch {}

--- a/bokehjs/src/lib/models/annotations/arrow.ts
+++ b/bokehjs/src/lib/models/annotations/arrow.ts
@@ -3,7 +3,7 @@ import {ArrowHead, ArrowHeadView, OpenHead} from "./arrow_head"
 import {ColumnarDataSource} from "../sources/columnar_data_source"
 import {ColumnDataSource} from "../sources/column_data_source"
 import {LineVector} from "core/property_mixins"
-import {Line} from "core/visuals"
+import * as visuals from "core/visuals"
 import {SpatialUnits} from "core/enums"
 import {Arrayable} from "core/types"
 import {build_view} from "core/build_views"
@@ -167,7 +167,7 @@ export namespace Arrow {
 
   export type Mixins = LineVector
 
-  export type Visuals = Annotation.Visuals & {line: Line}
+  export type Visuals = Annotation.Visuals & {line: visuals.LineVector}
 }
 
 export interface Arrow extends Arrow.Attrs {}

--- a/bokehjs/src/lib/models/annotations/arrow_head.ts
+++ b/bokehjs/src/lib/models/annotations/arrow_head.ts
@@ -82,7 +82,7 @@ export namespace OpenHead {
 
   export type Mixins = LineVector
 
-  export type Visuals = ArrowHead.Visuals & {line: visuals.Line}
+  export type Visuals = ArrowHead.Visuals & {line: visuals.LineVector}
 }
 
 export interface OpenHead extends OpenHead.Attrs {}
@@ -148,7 +148,7 @@ export namespace NormalHead {
 
   export type Mixins = LineVector & FillVector
 
-  export type Visuals = ArrowHead.Visuals & {line: visuals.Line, fill: visuals.Fill}
+  export type Visuals = ArrowHead.Visuals & {line: visuals.LineVector, fill: visuals.FillVector}
 }
 
 export interface NormalHead extends NormalHead.Attrs {}
@@ -220,7 +220,7 @@ export namespace VeeHead {
 
   export type Mixins = LineVector & FillVector
 
-  export type Visuals = ArrowHead.Visuals & {line: visuals.Line, fill: visuals.Fill}
+  export type Visuals = ArrowHead.Visuals & {line: visuals.LineVector, fill: visuals.FillVector}
 }
 
 export interface VeeHead extends VeeHead.Attrs {}
@@ -269,7 +269,7 @@ export namespace TeeHead {
 
   export type Mixins = LineVector
 
-  export type Visuals = ArrowHead.Visuals & {line: visuals.Line}
+  export type Visuals = ArrowHead.Visuals & {line: visuals.LineVector}
 }
 
 export interface TeeHead extends TeeHead.Attrs {}

--- a/bokehjs/src/lib/models/annotations/band.ts
+++ b/bokehjs/src/lib/models/annotations/band.ts
@@ -1,6 +1,6 @@
 import {UpperLower, UpperLowerView} from "./upper_lower"
 import * as mixins from "core/property_mixins"
-import {Line, Fill} from "core/visuals"
+import * as visuals from "core/visuals"
 import * as p from "core/properties"
 
 export class BandView extends UpperLowerView {
@@ -73,7 +73,7 @@ export namespace Band {
 
   export type Mixins = mixins.Line/*Scalar*/ & mixins.Fill/*Scalar*/
 
-  export type Visuals = UpperLower.Visuals & {line: Line, fill: Fill}
+  export type Visuals = UpperLower.Visuals & {line: visuals.Line/*Scalar*/, fill: visuals.Fill/*Scalar*/}
 }
 
 export interface Band extends Band.Attrs {}

--- a/bokehjs/src/lib/models/annotations/box_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/box_annotation.ts
@@ -2,7 +2,7 @@ import {Annotation, AnnotationView} from "./annotation"
 import {Scale} from "../scales/scale"
 import {Signal0} from "core/signaling"
 import * as mixins from "core/property_mixins"
-import {Line, Fill} from "core/visuals"
+import * as visuals from "core/visuals"
 import {SpatialUnits, RenderMode} from "core/enums"
 import * as p from "core/properties"
 import {BBox, CoordinateMapper} from "core/util/bbox"
@@ -127,7 +127,7 @@ export namespace BoxAnnotation {
 
   export type Mixins = mixins.Line/*Scalar*/ & mixins.Fill/*Scalar*/
 
-  export type Visuals = Annotation.Visuals & {line: Line, fill: Fill}
+  export type Visuals = Annotation.Visuals & {line: visuals.Line/*Scalar*/, fill: visuals.Fill/*Scalar*/}
 }
 
 export interface BoxAnnotation extends BoxAnnotation.Attrs {}

--- a/bokehjs/src/lib/models/annotations/label_set.ts
+++ b/bokehjs/src/lib/models/annotations/label_set.ts
@@ -2,6 +2,7 @@ import {TextAnnotation, TextAnnotationView} from "./text_annotation"
 import {ColumnarDataSource} from "../sources/columnar_data_source"
 import {ColumnDataSource} from "../sources/column_data_source"
 import * as mixins from "core/property_mixins"
+import * as visuals from "core/visuals"
 import {SpatialUnits} from "core/enums"
 import {div, display} from "core/dom"
 import * as p from "core/properties"
@@ -199,7 +200,11 @@ export namespace LabelSet {
     mixins.Prefixed<"border", mixins.LineVector> &
     mixins.Prefixed<"background", mixins.FillVector>
 
-  export type Visuals = TextAnnotation.Visuals
+  export type Visuals = TextAnnotation.Visuals & {
+    text: visuals.TextVector
+    border_line: visuals.LineVector
+    background_fill: visuals.FillVector
+  }
 }
 
 export interface LabelSet extends LabelSet.Attrs {}

--- a/bokehjs/src/lib/models/annotations/label_set.ts
+++ b/bokehjs/src/lib/models/annotations/label_set.ts
@@ -2,7 +2,6 @@ import {TextAnnotation, TextAnnotationView} from "./text_annotation"
 import {ColumnarDataSource} from "../sources/columnar_data_source"
 import {ColumnDataSource} from "../sources/column_data_source"
 import * as mixins from "core/property_mixins"
-import {LineJoin, LineCap} from "core/enums"
 import {SpatialUnits} from "core/enums"
 import {div, display} from "core/dom"
 import * as p from "core/properties"
@@ -193,22 +192,12 @@ export namespace LabelSet {
     x_offset: p.NumberSpec
     y_offset: p.NumberSpec
     source: p.Property<ColumnarDataSource>
-
-    // line:border_ v
-    border_line_color: p.ColorSpec
-    border_line_width: p.NumberSpec
-    border_line_alpha: p.NumberSpec
-    border_line_join: p.Property<LineJoin>
-    border_line_cap: p.Property<LineCap>
-    border_line_dash: p.Property<number[]>
-    border_line_dash_offset: p.Property<number>
-
-    // fill:background_ v
-    background_fill_color: p.ColorSpec
-    background_fill_alpha: p.NumberSpec
   } & Mixins
 
-  export type Mixins = mixins.TextVector
+  export type Mixins =
+    mixins.TextVector &
+    mixins.Prefixed<"border", mixins.LineVector> &
+    mixins.Prefixed<"background", mixins.FillVector>
 
   export type Visuals = TextAnnotation.Visuals
 }

--- a/bokehjs/src/lib/models/annotations/poly_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/poly_annotation.ts
@@ -1,6 +1,6 @@
 import {Annotation, AnnotationView} from "./annotation"
 import * as mixins from "core/property_mixins"
-import {Line, Fill} from "core/visuals"
+import * as visuals from "core/visuals"
 import {SpatialUnits} from "core/enums"
 import {Signal0} from "core/signaling"
 import * as p from "core/properties"
@@ -77,7 +77,7 @@ export namespace PolyAnnotation {
 
   export type Mixins = mixins.Line/*Scalar*/ & mixins.Fill/*Scalar*/
 
-  export type Visuals = Annotation.Visuals & {line: Line, fill: Fill}
+  export type Visuals = Annotation.Visuals & {line: visuals.Line/*Scalar*/, fill: visuals.Fill/*Scalar*/}
 }
 
 export interface PolyAnnotation extends PolyAnnotation.Attrs {}

--- a/bokehjs/src/lib/models/annotations/slope.ts
+++ b/bokehjs/src/lib/models/annotations/slope.ts
@@ -1,6 +1,6 @@
 import {Annotation, AnnotationView} from "./annotation"
 import * as mixins from "core/property_mixins"
-import {Line} from "core/visuals"
+import * as visuals from "core/visuals"
 import * as p from "core/properties"
 
 export class SlopeView extends AnnotationView {
@@ -66,7 +66,7 @@ export namespace Slope {
 
   export type Mixins = mixins.Line/*Scalar*/
 
-  export type Visuals = Annotation.Visuals & {line: Line}
+  export type Visuals = Annotation.Visuals & {line: visuals.Line/*Scalar*/}
 }
 
 export interface Slope extends Slope.Attrs {}

--- a/bokehjs/src/lib/models/annotations/span.ts
+++ b/bokehjs/src/lib/models/annotations/span.ts
@@ -1,7 +1,7 @@
 import {Annotation, AnnotationView} from "./annotation"
 import {Scale} from "../scales/scale"
 import * as mixins from "core/property_mixins"
-import {Line} from "core/visuals"
+import * as visuals from "core/visuals"
 import {SpatialUnits, RenderMode, Dimension} from "core/enums"
 import * as p from "core/properties"
 import {CoordinateMapper} from "core/util/bbox"
@@ -76,7 +76,7 @@ export namespace Span {
 
   export type Mixins = mixins.Line/*Scalar*/
 
-  export type Visuals = Annotation.Visuals & {line: Line}
+  export type Visuals = Annotation.Visuals & {line: visuals.Line/*Scalar*/}
 }
 
 export interface Span extends Span.Attrs {}

--- a/bokehjs/src/lib/models/annotations/text_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/text_annotation.ts
@@ -1,5 +1,5 @@
 import {Annotation, AnnotationView} from "./annotation"
-import {Text, Line, Fill} from "core/visuals"
+import * as visuals from "core/visuals"
 import {div, display, undisplay, remove} from "core/dom"
 import {RenderMode} from "core/enums"
 import * as p from "core/properties"
@@ -164,9 +164,9 @@ export namespace TextAnnotation {
   }
 
   export type Visuals = Annotation.Visuals & {
-    text: Text
-    border_line: Line
-    background_fill: Fill
+    text: visuals.Text
+    border_line: visuals.Line
+    background_fill: visuals.Fill
   }
 }
 

--- a/bokehjs/src/lib/models/annotations/title.ts
+++ b/bokehjs/src/lib/models/annotations/title.ts
@@ -1,7 +1,7 @@
 import {TextAnnotation, TextAnnotationView} from "./text_annotation"
 import {FontStyle, VerticalAlign, TextAlign, TextBaseline} from "core/enums"
 import {Size} from "core/layout"
-import {Text} from "core/visuals"
+import * as visuals from "core/visuals"
 import * as mixins from "core/property_mixins"
 import * as p from "core/properties"
 
@@ -11,7 +11,7 @@ export class TitleView extends TextAnnotationView {
 
   initialize(): void {
     super.initialize()
-    this.visuals.text = new Text(this.model)
+    this.visuals.text = new visuals.Text(this.model)
   }
 
   protected _get_location(): [number, number] {

--- a/bokehjs/src/lib/models/annotations/whisker.ts
+++ b/bokehjs/src/lib/models/annotations/whisker.ts
@@ -2,7 +2,7 @@ import {UpperLower, UpperLowerView} from "./upper_lower"
 import {ArrowHead, ArrowHeadView, TeeHead} from "./arrow_head"
 import {build_view} from "core/build_views"
 import {LineVector} from "core/property_mixins"
-import {Line} from "core/visuals"
+import * as visuals from "core/visuals"
 import * as p from "core/properties"
 
 export class WhiskerView extends UpperLowerView {
@@ -79,7 +79,7 @@ export namespace Whisker {
 
   export type Mixins = LineVector
 
-  export type Visuals = UpperLower.Visuals & {line: Line}
+  export type Visuals = UpperLower.Visuals & {line: visuals.LineVector}
 }
 
 export interface Whisker extends Whisker.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/annular_wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/annular_wedge.ts
@@ -1,5 +1,5 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
-import {generic_area_legend} from "./utils"
+import {generic_area_vector_legend} from "./utils"
 import {PointGeometry} from "core/geometry"
 import {LineVector, FillVector} from "core/property_mixins"
 import {Rect, NumberArray} from "core/types"
@@ -132,7 +132,7 @@ export class AnnularWedgeView extends XYGlyphView {
   }
 
   draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
-    generic_area_legend(this.visuals, ctx, bbox, index)
+    generic_area_vector_legend(this.visuals, ctx, bbox, index)
   }
 
   scenterxy(i: number): [number, number] {

--- a/bokehjs/src/lib/models/glyphs/annular_wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/annular_wedge.ts
@@ -3,7 +3,7 @@ import {generic_area_legend} from "./utils"
 import {PointGeometry} from "core/geometry"
 import {LineVector, FillVector} from "core/property_mixins"
 import {Rect, NumberArray} from "core/types"
-import {Line, Fill} from "core/visuals"
+import * as visuals from "core/visuals"
 import {Direction} from "core/enums"
 import * as p from "core/properties"
 import {angle_between} from "core/util/math"
@@ -157,7 +157,7 @@ export namespace AnnularWedge {
 
   export type Mixins = LineVector & FillVector
 
-  export type Visuals = XYGlyph.Visuals & {line: Line, fill: Fill}
+  export type Visuals = XYGlyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector}
 }
 
 export interface AnnularWedge extends AnnularWedge.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/annulus.ts
+++ b/bokehjs/src/lib/models/glyphs/annulus.ts
@@ -2,7 +2,7 @@ import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {Rect, NumberArray} from "core/types"
 import {PointGeometry} from "core/geometry"
 import {LineVector, FillVector} from "core/property_mixins"
-import {Line, Fill} from "core/visuals"
+import * as visuals from "core/visuals"
 import * as p from "core/properties"
 import {Context2d} from "core/util/canvas"
 import {is_ie} from "core/util/compat"
@@ -144,7 +144,7 @@ export namespace Annulus {
 
   export type Mixins = LineVector & FillVector
 
-  export type Visuals = XYGlyph.Visuals & {line: Line, fill: Fill}
+  export type Visuals = XYGlyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector}
 }
 
 export interface Annulus extends Annulus.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/arc.ts
+++ b/bokehjs/src/lib/models/glyphs/arc.ts
@@ -1,5 +1,5 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
-import {generic_line_legend} from "./utils"
+import {generic_line_vector_legend} from "./utils"
 import {LineVector} from "core/property_mixins"
 import * as visuals from "core/visuals"
 import {Rect, NumberArray} from "core/types"
@@ -49,7 +49,7 @@ export class ArcView extends XYGlyphView {
   }
 
   draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
-    generic_line_legend(this.visuals, ctx, bbox, index)
+    generic_line_vector_legend(this.visuals, ctx, bbox, index)
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/arc.ts
+++ b/bokehjs/src/lib/models/glyphs/arc.ts
@@ -1,7 +1,7 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {generic_line_legend} from "./utils"
 import {LineVector} from "core/property_mixins"
-import {Line} from "core/visuals"
+import * as visuals from "core/visuals"
 import {Rect, NumberArray} from "core/types"
 import {Direction} from "core/enums"
 import * as p from "core/properties"
@@ -65,7 +65,7 @@ export namespace Arc {
 
   export type Mixins = LineVector
 
-  export type Visuals = XYGlyph.Visuals & {line: Line}
+  export type Visuals = XYGlyph.Visuals & {line: visuals.LineVector}
 }
 
 export interface Arc extends Arc.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/area.ts
+++ b/bokehjs/src/lib/models/glyphs/area.ts
@@ -1,6 +1,6 @@
 import {Glyph, GlyphView, GlyphData} from "./glyph"
 import {generic_area_legend} from "./utils"
-import {Fill, Hatch} from "core/visuals"
+import * as visuals from "core/visuals"
 import {Rect} from "core/types"
 import {Context2d} from "core/util/canvas"
 import * as p from "core/properties"
@@ -26,7 +26,7 @@ export namespace Area {
 
   export type Mixins = mixins.Fill/*Scalar*/ & mixins.HatchVector
 
-  export type Visuals = Glyph.Visuals & {fill: Fill, hatch: Hatch}
+  export type Visuals = Glyph.Visuals & {fill: visuals.Fill/*Scalar*/, hatch: visuals.HatchVector}
 }
 
 export interface Area extends Area.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/area.ts
+++ b/bokehjs/src/lib/models/glyphs/area.ts
@@ -14,8 +14,8 @@ export abstract class AreaView extends GlyphView {
   model: Area
   visuals: Area.Visuals
 
-  draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
-    generic_area_legend(this.visuals, ctx, bbox, index)
+  draw_legend_for_index(ctx: Context2d, bbox: Rect, _index: number): void {
+    generic_area_legend(this.visuals, ctx, bbox)
   }
 }
 
@@ -24,9 +24,9 @@ export namespace Area {
 
   export type Props = Glyph.Props & Mixins
 
-  export type Mixins = mixins.Fill/*Scalar*/ & mixins.HatchVector
+  export type Mixins = mixins.Fill/*Scalar*/ & mixins.Hatch/*Scalar*/
 
-  export type Visuals = Glyph.Visuals & {fill: visuals.Fill/*Scalar*/, hatch: visuals.HatchVector}
+  export type Visuals = Glyph.Visuals & {fill: visuals.Fill/*Scalar*/, hatch: visuals.Hatch/*Scalar*/}
 }
 
 export interface Area extends Area.Attrs {}
@@ -40,6 +40,6 @@ export class Area extends Glyph {
   }
 
   static init_Area(): void {
-    this.mixins<Area.Mixins>([mixins.Fill/*Scalar*/, mixins.HatchVector])
+    this.mixins<Area.Mixins>([mixins.Fill/*Scalar*/, mixins.Hatch/*Scalar*/])
   }
 }

--- a/bokehjs/src/lib/models/glyphs/area.ts
+++ b/bokehjs/src/lib/models/glyphs/area.ts
@@ -1,5 +1,5 @@
 import {Glyph, GlyphView, GlyphData} from "./glyph"
-import {generic_area_legend} from "./utils"
+import {generic_area_scalar_legend} from "./utils"
 import * as visuals from "core/visuals"
 import {Rect} from "core/types"
 import {Context2d} from "core/util/canvas"
@@ -15,7 +15,7 @@ export abstract class AreaView extends GlyphView {
   visuals: Area.Visuals
 
   draw_legend_for_index(ctx: Context2d, bbox: Rect, _index: number): void {
-    generic_area_legend(this.visuals, ctx, bbox)
+    generic_area_scalar_legend(this.visuals, ctx, bbox)
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/bezier.ts
+++ b/bokehjs/src/lib/models/glyphs/bezier.ts
@@ -4,7 +4,7 @@ import {Rect, NumberArray} from "core/types"
 import {SpatialIndex} from "core/util/spatial"
 import {Context2d} from "core/util/canvas"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
-import {generic_line_legend} from "./utils"
+import {generic_line_vector_legend} from "./utils"
 import {inplace} from "core/util/projections"
 import * as p from "core/properties"
 
@@ -141,7 +141,7 @@ export class BezierView extends GlyphView {
   }
 
   draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
-    generic_line_legend(this.visuals, ctx, bbox, index)
+    generic_line_vector_legend(this.visuals, ctx, bbox, index)
   }
 
   scenterxy(): [number, number] {

--- a/bokehjs/src/lib/models/glyphs/bezier.ts
+++ b/bokehjs/src/lib/models/glyphs/bezier.ts
@@ -1,5 +1,5 @@
 import {LineVector} from "core/property_mixins"
-import {Line} from "core/visuals"
+import * as visuals from "core/visuals"
 import {Rect, NumberArray} from "core/types"
 import {SpatialIndex} from "core/util/spatial"
 import {Context2d} from "core/util/canvas"
@@ -165,7 +165,7 @@ export namespace Bezier {
 
   export type Mixins = LineVector
 
-  export type Visuals = Glyph.Visuals & {line: Line}
+  export type Visuals = Glyph.Visuals & {line: visuals.LineVector}
 }
 
 export interface Bezier extends Bezier.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/box.ts
+++ b/bokehjs/src/lib/models/glyphs/box.ts
@@ -1,7 +1,7 @@
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
 import {Rect, NumberArray} from "core/types"
 import {Anchor} from "core/enums"
-import {Line, Fill, Hatch} from "core/visuals"
+import * as visuals from "core/visuals"
 import {SpatialIndex} from "core/util/spatial"
 import {Context2d} from "core/util/canvas"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
@@ -151,7 +151,7 @@ export namespace Box {
 
   export type Mixins = LineVector & FillVector & HatchVector
 
-  export type Visuals = Glyph.Visuals & {line: Line, fill: Fill, hatch: Hatch}
+  export type Visuals = Glyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector, hatch: visuals.HatchVector}
 }
 
 export interface Box extends Box.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/box.ts
+++ b/bokehjs/src/lib/models/glyphs/box.ts
@@ -5,7 +5,7 @@ import * as visuals from "core/visuals"
 import {SpatialIndex} from "core/util/spatial"
 import {Context2d} from "core/util/canvas"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
-import {generic_area_legend} from "./utils"
+import {generic_area_vector_legend} from "./utils"
 import {PointGeometry, SpanGeometry, RectGeometry} from "core/geometry"
 import {Selection} from "../selections/selection"
 import * as p from "core/properties"
@@ -140,7 +140,7 @@ export abstract class BoxView extends GlyphView {
   }
 
   draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
-    generic_area_legend(this.visuals, ctx, bbox, index)
+    generic_area_vector_legend(this.visuals, ctx, bbox, index)
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/center_rotatable.ts
+++ b/bokehjs/src/lib/models/glyphs/center_rotatable.ts
@@ -1,6 +1,6 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {LineVector, FillVector} from "core/property_mixins"
-import {Line, Fill} from "core/visuals"
+import * as visuals from "core/visuals"
 import {NumberArray} from "core/types"
 import * as p from "core/properties"
 
@@ -37,7 +37,7 @@ export namespace CenterRotatable {
 
   export type Mixins = LineVector & FillVector
 
-  export type Visuals = XYGlyph.Visuals & {line: Line, fill: Fill}
+  export type Visuals = XYGlyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector}
 }
 
 export interface CenterRotatable extends CenterRotatable.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/circle.ts
@@ -2,7 +2,7 @@ import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {MarkerGL, CircleGL} from "./webgl/markers"
 import {PointGeometry, SpanGeometry, RectGeometry, PolyGeometry} from "core/geometry"
 import {LineVector, FillVector} from "core/property_mixins"
-import {Line, Fill} from "core/visuals"
+import * as visuals from "core/visuals"
 import {Rect, NumberArray, Indices} from "core/types"
 import {RadiusDimension} from "core/enums"
 import * as hittest from "core/hittest"
@@ -264,7 +264,7 @@ export namespace Circle {
 
   export type Mixins = LineVector & FillVector
 
-  export type Visuals = XYGlyph.Visuals & {line: Line, fill: Fill}
+  export type Visuals = XYGlyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector}
 }
 
 export interface Circle extends Circle.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -332,6 +332,4 @@ export abstract class Glyph extends Model {
   constructor(attrs?: Partial<Glyph.Attrs>) {
     super(attrs)
   }
-
-  static init_Glyph(): void {}
 }

--- a/bokehjs/src/lib/models/glyphs/harea.ts
+++ b/bokehjs/src/lib/models/glyphs/harea.ts
@@ -58,7 +58,7 @@ export class HAreaView extends AreaView {
       this._inner(ctx, sx1, sx2, sy, ctx.fill)
     }
 
-    this.visuals.hatch.doit2(ctx, 0, () => this._inner(ctx, sx1, sx2, sy, ctx.fill), () => this.renderer.request_render())
+    this.visuals.hatch.doit2(ctx, () => this._inner(ctx, sx1, sx2, sy, ctx.fill), () => this.renderer.request_render())
   }
 
   protected _hit_point(geometry: PointGeometry): Selection {

--- a/bokehjs/src/lib/models/glyphs/hex_tile.ts
+++ b/bokehjs/src/lib/models/glyphs/hex_tile.ts
@@ -7,7 +7,7 @@ import {LineVector, FillVector} from "core/property_mixins"
 import {Rect, NumberArray} from "core/types"
 import {Context2d} from "core/util/canvas"
 import {SpatialIndex} from "core/util/spatial"
-import {Line, Fill} from "core/visuals"
+import * as visuals from "core/visuals"
 import {HexTileOrientation} from "core/enums"
 import {inplace} from "core/util/projections"
 
@@ -221,7 +221,7 @@ export namespace HexTile {
 
   export type Mixins = LineVector & FillVector
 
-  export type Visuals = Glyph.Visuals & {line: Line, fill: Fill}
+  export type Visuals = Glyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector}
 }
 
 export interface HexTile extends HexTile.Attrs { }

--- a/bokehjs/src/lib/models/glyphs/hex_tile.ts
+++ b/bokehjs/src/lib/models/glyphs/hex_tile.ts
@@ -11,7 +11,7 @@ import * as visuals from "core/visuals"
 import {HexTileOrientation} from "core/enums"
 import {inplace} from "core/util/projections"
 
-import {generic_area_legend} from "./utils"
+import {generic_area_vector_legend} from "./utils"
 import {Selection} from "../selections/selection"
 
 export type Vertices = [number, number, number, number, number, number]
@@ -203,7 +203,7 @@ export class HexTileView extends GlyphView {
   }
 
   draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
-    generic_area_legend(this.visuals, ctx, bbox, index)
+    generic_area_vector_legend(this.visuals, ctx, bbox, index)
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/line.ts
+++ b/bokehjs/src/lib/models/glyphs/line.ts
@@ -1,5 +1,5 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
-import {generic_line_legend, line_interpolation} from "./utils"
+import {generic_line_scalar_legend, line_interpolation} from "./utils"
 import {LineGL} from "./webgl/line"
 import {PointGeometry, SpanGeometry} from "core/geometry"
 import {Arrayable, Rect} from "core/types"
@@ -127,7 +127,7 @@ export class LineView extends XYGlyphView {
   }
 
   draw_legend_for_index(ctx: Context2d, bbox: Rect, _index: number): void {
-    generic_line_legend(this.visuals, ctx, bbox)
+    generic_line_scalar_legend(this.visuals, ctx, bbox)
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/line.ts
+++ b/bokehjs/src/lib/models/glyphs/line.ts
@@ -126,8 +126,8 @@ export class LineView extends XYGlyphView {
     return line_interpolation(this.renderer, geometry, x2, y2, x3, y3)
   }
 
-  draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
-    generic_line_legend(this.visuals, ctx, bbox, index)
+  draw_legend_for_index(ctx: Context2d, bbox: Rect, _index: number): void {
+    generic_line_legend(this.visuals, ctx, bbox)
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/line.ts
+++ b/bokehjs/src/lib/models/glyphs/line.ts
@@ -138,7 +138,7 @@ export namespace Line {
 
   export type Mixins = mixins.Line/*Scalar*/
 
-  export type Visuals = XYGlyph.Visuals & {line: visuals.Line}
+  export type Visuals = XYGlyph.Visuals & {line: visuals.Line/*Scalar*/}
 }
 
 export interface Line extends Line.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/multi_line.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_line.ts
@@ -10,7 +10,7 @@ import {minmax} from "core/util/arrayable"
 import {to_object} from "core/util/object"
 import {Context2d} from "core/util/canvas"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
-import {generic_line_legend, line_interpolation} from "./utils"
+import {generic_line_vector_legend, line_interpolation} from "./utils"
 import {Selection} from "../selections/selection"
 
 export interface MultiLineData extends GlyphData {
@@ -151,7 +151,7 @@ export class MultiLineView extends GlyphView {
   }
 
   draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
-    generic_line_legend(this.visuals, ctx, bbox, index)
+    generic_line_vector_legend(this.visuals, ctx, bbox, index)
   }
 
   scenterxy(): [number, number] {

--- a/bokehjs/src/lib/models/glyphs/multi_line.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_line.ts
@@ -2,7 +2,7 @@ import {SpatialIndex} from "core/util/spatial"
 import {inplace} from "core/util/projections"
 import {PointGeometry, SpanGeometry} from "core/geometry"
 import {LineVector} from "core/property_mixins"
-import {Line} from "core/visuals"
+import * as visuals from "core/visuals"
 import {Rect, RaggedArray} from "core/types"
 import * as hittest from "core/hittest"
 import * as p from "core/properties"
@@ -169,7 +169,7 @@ export namespace MultiLine {
 
   export type Mixins = LineVector
 
-  export type Visuals = Glyph.Visuals & {line: Line}
+  export type Visuals = Glyph.Visuals & {line: visuals.LineVector}
 }
 
 export interface MultiLine extends MultiLine.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/multi_polygons.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_polygons.ts
@@ -1,6 +1,6 @@
 import {SpatialIndex} from "core/util/spatial"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
-import {generic_area_legend} from "./utils"
+import {generic_area_vector_legend} from "./utils"
 import {minmax} from "core/util/arrayable"
 import {sum} from "core/util/arrayable"
 import {Arrayable, Rect, NumberArray, Indices} from "core/types"
@@ -298,7 +298,7 @@ export class MultiPolygonsView extends GlyphView {
   }
 
   draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
-    generic_area_legend(this.visuals, ctx, bbox, index)
+    generic_area_vector_legend(this.visuals, ctx, bbox, index)
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/multi_polygons.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_polygons.ts
@@ -7,7 +7,7 @@ import {Arrayable, Rect, NumberArray, Indices} from "core/types"
 import {PointGeometry, RectGeometry} from "core/geometry"
 import {Context2d} from "core/util/canvas"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
-import {Line, Fill, Hatch} from "core/visuals"
+import * as visuals from "core/visuals"
 import * as hittest from "core/hittest"
 import * as p from "core/properties"
 import {Selection} from "../selections/selection"
@@ -312,7 +312,7 @@ export namespace MultiPolygons {
 
   export type Mixins = LineVector & FillVector & HatchVector
 
-  export type Visuals = Glyph.Visuals & {line: Line, fill: Fill, hatch: Hatch}
+  export type Visuals = Glyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector, hatch: visuals.HatchVector}
 }
 
 export interface MultiPolygons extends MultiPolygons.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/patch.ts
+++ b/bokehjs/src/lib/models/glyphs/patch.ts
@@ -1,5 +1,5 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
-import {generic_area_legend} from "./utils"
+import {generic_area_scalar_legend} from "./utils"
 import {PointGeometry} from "core/geometry"
 import * as visuals from "core/visuals"
 import {Arrayable, Rect} from "core/types"
@@ -49,7 +49,7 @@ export class PatchView extends XYGlyphView {
   }
 
   draw_legend_for_index(ctx: Context2d, bbox: Rect, _index: number): void {
-    generic_area_legend(this.visuals, ctx, bbox)
+    generic_area_scalar_legend(this.visuals, ctx, bbox)
   }
 
   protected _hit_point(geometry: PointGeometry): Selection {

--- a/bokehjs/src/lib/models/glyphs/patch.ts
+++ b/bokehjs/src/lib/models/glyphs/patch.ts
@@ -1,7 +1,7 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {generic_area_legend} from "./utils"
 import {PointGeometry} from "core/geometry"
-import {Line, Fill, Hatch} from "core/visuals"
+import * as visuals from "core/visuals"
 import {Arrayable, Rect} from "core/types"
 import {Context2d} from "core/util/canvas"
 import * as hittest from "core/hittest"
@@ -71,7 +71,7 @@ export namespace Patch {
 
   export type Mixins = mixins.Line/*Scalar*/ & mixins.Fill/*Scalar*/ & mixins.Hatch/*Scalar*/
 
-  export type Visuals = XYGlyph.Visuals & {line: Line, fill: Fill, hatch: Hatch}
+  export type Visuals = XYGlyph.Visuals & {line: visuals.Line/*Scalar*/, fill: visuals.Fill/*Scalar*/, hatch: visuals.Hatch/*Scalar*/}
 }
 
 export interface Patch extends Patch.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/patch.ts
+++ b/bokehjs/src/lib/models/glyphs/patch.ts
@@ -40,7 +40,7 @@ export class PatchView extends XYGlyphView {
       this._inner_loop(ctx, indices, sx, sy, ctx.fill)
     }
 
-    this.visuals.hatch.doit2(ctx, 0, () => this._inner_loop(ctx, indices, sx, sy, ctx.fill), () => this.renderer.request_render())
+    this.visuals.hatch.doit2(ctx, () => this._inner_loop(ctx, indices, sx, sy, ctx.fill), () => this.renderer.request_render())
 
     if (this.visuals.line.doit) {
       this.visuals.line.set_value(ctx)
@@ -48,8 +48,8 @@ export class PatchView extends XYGlyphView {
     }
   }
 
-  draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
-    generic_area_legend(this.visuals, ctx, bbox, index)
+  draw_legend_for_index(ctx: Context2d, bbox: Rect, _index: number): void {
+    generic_area_legend(this.visuals, ctx, bbox)
   }
 
   protected _hit_point(geometry: PointGeometry): Selection {

--- a/bokehjs/src/lib/models/glyphs/patches.ts
+++ b/bokehjs/src/lib/models/glyphs/patches.ts
@@ -6,7 +6,7 @@ import {Arrayable, Rect, RaggedArray, Indices} from "core/types"
 import {PointGeometry, RectGeometry} from "core/geometry"
 import {Context2d} from "core/util/canvas"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
-import {Line, Fill, Hatch} from "core/visuals"
+import * as visuals from "core/visuals"
 import * as hittest from "core/hittest"
 import * as p from "core/properties"
 import {Selection} from "../selections/selection"
@@ -208,7 +208,7 @@ export namespace Patches {
 
   export type Mixins = LineVector & FillVector & HatchVector
 
-  export type Visuals = Glyph.Visuals & {line: Line, fill: Fill, hatch: Hatch}
+  export type Visuals = Glyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector, hatch: visuals.HatchVector}
 }
 
 export interface Patches extends Patches.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/patches.ts
+++ b/bokehjs/src/lib/models/glyphs/patches.ts
@@ -1,6 +1,6 @@
 import {SpatialIndex} from "core/util/spatial"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
-import {generic_area_legend} from "./utils"
+import {generic_area_vector_legend} from "./utils"
 import {minmax, sum} from "core/util/arrayable"
 import {Arrayable, Rect, RaggedArray, Indices} from "core/types"
 import {PointGeometry, RectGeometry} from "core/geometry"
@@ -194,7 +194,7 @@ export class PatchesView extends GlyphView {
   }
 
   draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
-    generic_area_legend(this.visuals, ctx, bbox, index)
+    generic_area_vector_legend(this.visuals, ctx, bbox, index)
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/quadratic.ts
+++ b/bokehjs/src/lib/models/glyphs/quadratic.ts
@@ -1,5 +1,5 @@
 import {LineVector} from "core/property_mixins"
-import {Line} from "core/visuals"
+import * as visuals from "core/visuals"
 import {Rect, NumberArray} from "core/types"
 import {SpatialIndex} from "core/util/spatial"
 import {inplace} from "core/util/projections"
@@ -109,7 +109,7 @@ export namespace Quadratic {
 
   export type Mixins = LineVector
 
-  export type Visuals = Glyph.Visuals & {line: Line}
+  export type Visuals = Glyph.Visuals & {line: visuals.LineVector}
 }
 
 export interface Quadratic extends Quadratic.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/quadratic.ts
+++ b/bokehjs/src/lib/models/glyphs/quadratic.ts
@@ -5,7 +5,7 @@ import {SpatialIndex} from "core/util/spatial"
 import {inplace} from "core/util/projections"
 import {Context2d} from "core/util/canvas"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
-import {generic_line_legend} from "./utils"
+import {generic_line_vector_legend} from "./utils"
 import * as p from "core/properties"
 
 // Formula from: http://pomax.nihongoresources.com/pages/bezier/
@@ -87,7 +87,7 @@ export class QuadraticView extends GlyphView {
   }
 
   draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
-    generic_line_legend(this.visuals, ctx, bbox, index)
+    generic_line_vector_legend(this.visuals, ctx, bbox, index)
   }
 
   scenterxy(): [number, number] {

--- a/bokehjs/src/lib/models/glyphs/ray.ts
+++ b/bokehjs/src/lib/models/glyphs/ray.ts
@@ -1,5 +1,5 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
-import {generic_line_legend} from "./utils"
+import {generic_line_vector_legend} from "./utils"
 import {LineVector} from "core/property_mixins"
 import * as visuals from "core/visuals"
 import {Rect, NumberArray} from "core/types"
@@ -58,7 +58,7 @@ export class RayView extends XYGlyphView {
   }
 
   draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
-    generic_line_legend(this.visuals, ctx, bbox, index)
+    generic_line_vector_legend(this.visuals, ctx, bbox, index)
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/ray.ts
+++ b/bokehjs/src/lib/models/glyphs/ray.ts
@@ -1,7 +1,7 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {generic_line_legend} from "./utils"
 import {LineVector} from "core/property_mixins"
-import {Line} from "core/visuals"
+import * as visuals from "core/visuals"
 import {Rect, NumberArray} from "core/types"
 import * as p from "core/properties"
 import {Context2d} from "core/util/canvas"
@@ -72,7 +72,7 @@ export namespace Ray {
 
   export type Mixins = LineVector
 
-  export type Visuals = XYGlyph.Visuals & {line: Line}
+  export type Visuals = XYGlyph.Visuals & {line: visuals.LineVector}
 }
 
 export interface Ray extends Ray.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/rect.ts
+++ b/bokehjs/src/lib/models/glyphs/rect.ts
@@ -1,5 +1,5 @@
 import {CenterRotatable, CenterRotatableView, CenterRotatableData} from "./center_rotatable"
-import {generic_area_legend} from "./utils"
+import {generic_area_vector_legend} from "./utils"
 import {PointGeometry, RectGeometry} from "core/geometry"
 import {LineVector, FillVector} from "core/property_mixins"
 import {Arrayable, NumberArray} from "core/types"
@@ -222,7 +222,7 @@ export class RectView extends CenterRotatableView {
   }
 
   draw_legend_for_index(ctx: Context2d, bbox: types.Rect, index: number): void {
-    generic_area_legend(this.visuals, ctx, bbox, index)
+    generic_area_vector_legend(this.visuals, ctx, bbox, index)
   }
 
   protected _bounds({x0, x1, y0, y1}: types.Rect): types.Rect {

--- a/bokehjs/src/lib/models/glyphs/segment.ts
+++ b/bokehjs/src/lib/models/glyphs/segment.ts
@@ -2,7 +2,7 @@ import {PointGeometry, SpanGeometry} from "core/geometry"
 import * as hittest from "core/hittest"
 import * as p from "core/properties"
 import {LineVector} from "core/property_mixins"
-import {Line} from "core/visuals"
+import * as visuals from "core/visuals"
 import {Arrayable, Rect, NumberArray} from "core/types"
 import {SpatialIndex} from "core/util/spatial"
 import {inplace} from "core/util/projections"
@@ -158,7 +158,7 @@ export namespace Segment {
 
   export type Mixins = LineVector
 
-  export type Visuals = Glyph.Visuals & {line: Line}
+  export type Visuals = Glyph.Visuals & {line: visuals.LineVector}
 }
 
 export interface Segment extends Segment.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/segment.ts
+++ b/bokehjs/src/lib/models/glyphs/segment.ts
@@ -8,7 +8,7 @@ import {SpatialIndex} from "core/util/spatial"
 import {inplace} from "core/util/projections"
 import {Context2d} from "core/util/canvas"
 import {Glyph, GlyphView, GlyphData} from "./glyph"
-import {generic_line_legend} from "./utils"
+import {generic_line_vector_legend} from "./utils"
 import {Selection} from "../selections/selection"
 
 export interface SegmentData extends GlyphData {
@@ -142,7 +142,7 @@ export class SegmentView extends GlyphView {
   }
 
   draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
-    generic_line_legend(this.visuals, ctx, bbox, index)
+    generic_line_vector_legend(this.visuals, ctx, bbox, index)
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/step.ts
+++ b/bokehjs/src/lib/models/glyphs/step.ts
@@ -95,9 +95,9 @@ export namespace Step {
     mode: p.Property<StepMode>
   } & Mixins
 
-  export type Mixins = Line/*Vector*/
+  export type Mixins = Line/*Scalar*/
 
-  export type Visuals = XYGlyph.Visuals & {line: visuals.Line/*Vector*/}
+  export type Visuals = XYGlyph.Visuals & {line: visuals.Line/*Scalar*/}
 }
 
 export interface Step extends Step.Attrs {}
@@ -113,7 +113,7 @@ export class Step extends XYGlyph {
   static init_Step(): void {
     this.prototype.default_view = StepView
 
-    this.mixins<Step.Mixins>(Line/*Vector*/)
+    this.mixins<Step.Mixins>(Line/*Scalar*/)
     this.define<Step.Props>(() => ({
       mode: [ StepMode, "before"],
     }))

--- a/bokehjs/src/lib/models/glyphs/step.ts
+++ b/bokehjs/src/lib/models/glyphs/step.ts
@@ -1,7 +1,7 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {generic_line_legend} from "./utils"
 import {LineVector} from "core/property_mixins"
-import {Line} from "core/visuals"
+import * as visuals from "core/visuals"
 import * as p from "core/properties"
 import {Rect} from "core/types"
 import {StepMode} from "core/enums"
@@ -97,7 +97,7 @@ export namespace Step {
 
   export type Mixins = LineVector
 
-  export type Visuals = XYGlyph.Visuals & {line: Line}
+  export type Visuals = XYGlyph.Visuals & {line: visuals.LineVector}
 }
 
 export interface Step extends Step.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/step.ts
+++ b/bokehjs/src/lib/models/glyphs/step.ts
@@ -1,5 +1,5 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
-import {generic_line_legend} from "./utils"
+import {generic_line_scalar_legend} from "./utils"
 import {Line} from "core/property_mixins"
 import * as visuals from "core/visuals"
 import * as p from "core/properties"
@@ -84,7 +84,7 @@ export class StepView extends XYGlyphView {
   }
 
   draw_legend_for_index(ctx: Context2d, bbox: Rect, _index: number): void {
-    generic_line_legend(this.visuals, ctx, bbox)
+    generic_line_scalar_legend(this.visuals, ctx, bbox)
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/step.ts
+++ b/bokehjs/src/lib/models/glyphs/step.ts
@@ -1,6 +1,6 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {generic_line_legend} from "./utils"
-import {LineVector} from "core/property_mixins"
+import {Line} from "core/property_mixins"
 import * as visuals from "core/visuals"
 import * as p from "core/properties"
 import {Rect} from "core/types"
@@ -83,8 +83,8 @@ export class StepView extends XYGlyphView {
     ctx.stroke()
   }
 
-  draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
-    generic_line_legend(this.visuals, ctx, bbox, index)
+  draw_legend_for_index(ctx: Context2d, bbox: Rect, _index: number): void {
+    generic_line_legend(this.visuals, ctx, bbox)
   }
 }
 
@@ -95,9 +95,9 @@ export namespace Step {
     mode: p.Property<StepMode>
   } & Mixins
 
-  export type Mixins = LineVector
+  export type Mixins = Line/*Vector*/
 
-  export type Visuals = XYGlyph.Visuals & {line: visuals.LineVector}
+  export type Visuals = XYGlyph.Visuals & {line: visuals.Line/*Vector*/}
 }
 
 export interface Step extends Step.Attrs {}
@@ -113,7 +113,7 @@ export class Step extends XYGlyph {
   static init_Step(): void {
     this.prototype.default_view = StepView
 
-    this.mixins<Step.Mixins>(LineVector)
+    this.mixins<Step.Mixins>(Line/*Vector*/)
     this.define<Step.Props>(() => ({
       mode: [ StepMode, "before"],
     }))

--- a/bokehjs/src/lib/models/glyphs/text.ts
+++ b/bokehjs/src/lib/models/glyphs/text.ts
@@ -153,7 +153,7 @@ export namespace Text {
 
   export type Mixins = TextVector
 
-  export type Visuals = XYGlyph.Visuals & {text: visuals.Text}
+  export type Visuals = XYGlyph.Visuals & {text: visuals.TextVector}
 }
 
 export interface Text extends Text.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/utils.ts
+++ b/bokehjs/src/lib/models/glyphs/utils.ts
@@ -1,11 +1,23 @@
-import {LineVector, FillVector, HatchVector} from "core/visuals"
+import {Line, LineVector, Fill, FillVector, Hatch, HatchVector} from "core/visuals"
 import {Context2d} from "core/util/canvas"
 import {Rect} from "core/types"
 import {PointGeometry, SpanGeometry} from "core/geometry"
 import * as hittest from "core/hittest"
 import {GlyphRendererView} from "../renderers/glyph_renderer"
 
-export function generic_line_legend(visuals: {line: LineVector}, ctx: Context2d, {x0, x1, y0, y1}: Rect, index: number): void {
+export function generic_line_legend(visuals: {line: Line}, ctx: Context2d, {x0, x1, y0, y1}: Rect): void {
+  ctx.save()
+  ctx.beginPath()
+  ctx.moveTo(x0, (y0 + y1) /2)
+  ctx.lineTo(x1, (y0 + y1) /2)
+  if (visuals.line.doit) {
+    visuals.line.set_value(ctx)
+    ctx.stroke()
+  }
+  ctx.restore()
+}
+
+export function generic_line_vector_legend(visuals: {line: LineVector}, ctx: Context2d, {x0, x1, y0, y1}: Rect, index: number): void {
   ctx.save()
   ctx.beginPath()
   ctx.moveTo(x0, (y0 + y1) /2)
@@ -17,7 +29,37 @@ export function generic_line_legend(visuals: {line: LineVector}, ctx: Context2d,
   ctx.restore()
 }
 
-export function generic_area_legend(visuals: {line?: LineVector, fill: FillVector, hatch?: HatchVector}, ctx: Context2d, {x0, x1, y0, y1}: Rect, index: number): void {
+export function generic_area_legend(visuals: {line?: Line, fill: Fill, hatch?: Hatch}, ctx: Context2d, {x0, x1, y0, y1}: Rect): void {
+  const w = Math.abs(x1 - x0)
+  const dw = w*0.1
+  const h = Math.abs(y1 - y0)
+  const dh = h*0.1
+
+  const sx0 = x0 + dw
+  const sx1 = x1 - dw
+
+  const sy0 = y0 + dh
+  const sy1 = y1 - dh
+
+  if (visuals.fill.doit) {
+    visuals.fill.set_value(ctx)
+    ctx.fillRect(sx0, sy0, sx1 - sx0, sy1 - sy0)
+  }
+
+  if (visuals.hatch?.doit) {
+    visuals.hatch.set_value(ctx)
+    ctx.fillRect(sx0, sy0, sx1 - sx0, sy1 - sy0)
+  }
+
+  if (visuals.line?.doit) {
+    ctx.beginPath()
+    ctx.rect(sx0, sy0, sx1 - sx0, sy1 - sy0)
+    visuals.line.set_value(ctx)
+    ctx.stroke()
+  }
+}
+
+export function generic_area_vector_legend(visuals: {line?: LineVector, fill: FillVector, hatch?: HatchVector}, ctx: Context2d, {x0, x1, y0, y1}: Rect, index: number): void {
   const w = Math.abs(x1 - x0)
   const dw = w*0.1
   const h = Math.abs(y1 - y0)

--- a/bokehjs/src/lib/models/glyphs/utils.ts
+++ b/bokehjs/src/lib/models/glyphs/utils.ts
@@ -1,11 +1,11 @@
-import {Visuals, Line, Fill, Hatch} from "core/visuals"
+import {LineVector, FillVector, HatchVector} from "core/visuals"
 import {Context2d} from "core/util/canvas"
 import {Rect} from "core/types"
 import {PointGeometry, SpanGeometry} from "core/geometry"
 import * as hittest from "core/hittest"
 import {GlyphRendererView} from "../renderers/glyph_renderer"
 
-export function generic_line_legend(visuals: Visuals & {line: Line}, ctx: Context2d, {x0, x1, y0, y1}: Rect, index: number): void {
+export function generic_line_legend(visuals: {line: LineVector}, ctx: Context2d, {x0, x1, y0, y1}: Rect, index: number): void {
   ctx.save()
   ctx.beginPath()
   ctx.moveTo(x0, (y0 + y1) /2)
@@ -17,7 +17,7 @@ export function generic_line_legend(visuals: Visuals & {line: Line}, ctx: Contex
   ctx.restore()
 }
 
-export function generic_area_legend(visuals: {line?: Line, fill: Fill, hatch?: Hatch}, ctx: Context2d, {x0, x1, y0, y1}: Rect, index: number): void {
+export function generic_area_legend(visuals: {line?: LineVector, fill: FillVector, hatch?: HatchVector}, ctx: Context2d, {x0, x1, y0, y1}: Rect, index: number): void {
   const w = Math.abs(x1 - x0)
   const dw = w*0.1
   const h = Math.abs(y1 - y0)
@@ -34,12 +34,12 @@ export function generic_area_legend(visuals: {line?: Line, fill: Fill, hatch?: H
     ctx.fillRect(sx0, sy0, sx1 - sx0, sy1 - sy0)
   }
 
-  if (visuals.hatch != null && visuals.hatch.doit) {
+  if (visuals.hatch?.doit) {
     visuals.hatch.set_vectorize(ctx, index)
     ctx.fillRect(sx0, sy0, sx1 - sx0, sy1 - sy0)
   }
 
-  if (visuals.line && visuals.line.doit) {
+  if (visuals.line?.doit) {
     ctx.beginPath()
     ctx.rect(sx0, sy0, sx1 - sx0, sy1 - sy0)
     visuals.line.set_vectorize(ctx, index)

--- a/bokehjs/src/lib/models/glyphs/utils.ts
+++ b/bokehjs/src/lib/models/glyphs/utils.ts
@@ -5,7 +5,7 @@ import {PointGeometry, SpanGeometry} from "core/geometry"
 import * as hittest from "core/hittest"
 import {GlyphRendererView} from "../renderers/glyph_renderer"
 
-export function generic_line_legend(visuals: {line: Line}, ctx: Context2d, {x0, x1, y0, y1}: Rect): void {
+export function generic_line_scalar_legend(visuals: {line: Line}, ctx: Context2d, {x0, x1, y0, y1}: Rect): void {
   ctx.save()
   ctx.beginPath()
   ctx.moveTo(x0, (y0 + y1) /2)
@@ -29,7 +29,7 @@ export function generic_line_vector_legend(visuals: {line: LineVector}, ctx: Con
   ctx.restore()
 }
 
-export function generic_area_legend(visuals: {line?: Line, fill: Fill, hatch?: Hatch}, ctx: Context2d, {x0, x1, y0, y1}: Rect): void {
+export function generic_area_scalar_legend(visuals: {line?: Line, fill: Fill, hatch?: Hatch}, ctx: Context2d, {x0, x1, y0, y1}: Rect): void {
   const w = Math.abs(x1 - x0)
   const dw = w*0.1
   const h = Math.abs(y1 - y0)
@@ -88,6 +88,9 @@ export function generic_area_vector_legend(visuals: {line?: LineVector, fill: Fi
     ctx.stroke()
   }
 }
+
+export {generic_line_vector_legend as generic_line_legend}
+export {generic_area_vector_legend as generic_area_legend}
 
 export function line_interpolation(renderer: GlyphRendererView, geometry: PointGeometry | SpanGeometry, x2: number, y2: number, x3: number, y3: number): [number, number] {
   const {sx, sy} = geometry

--- a/bokehjs/src/lib/models/glyphs/varea.ts
+++ b/bokehjs/src/lib/models/glyphs/varea.ts
@@ -58,7 +58,7 @@ export class VAreaView extends AreaView {
       this._inner(ctx, sx, sy1, sy2, ctx.fill)
     }
 
-    this.visuals.hatch.doit2(ctx, 0, () => this._inner(ctx, sx, sy1, sy2, ctx.fill), () => this.renderer.request_render())
+    this.visuals.hatch.doit2(ctx, () => this._inner(ctx, sx, sy1, sy2, ctx.fill), () => this.renderer.request_render())
   }
 
   scenterxy(i: number): [number, number] {

--- a/bokehjs/src/lib/models/glyphs/wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/wedge.ts
@@ -1,5 +1,5 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
-import {generic_area_legend} from "./utils"
+import {generic_area_vector_legend} from "./utils"
 import {PointGeometry} from "core/geometry"
 import {LineVector, FillVector} from "core/property_mixins"
 import * as visuals from "core/visuals"
@@ -108,7 +108,7 @@ export class WedgeView extends XYGlyphView {
   }
 
   draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
-    generic_area_legend(this.visuals, ctx, bbox, index)
+    generic_area_vector_legend(this.visuals, ctx, bbox, index)
   }
 
   scenterxy(i: number): [number, number] {

--- a/bokehjs/src/lib/models/glyphs/wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/wedge.ts
@@ -2,7 +2,7 @@ import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {generic_area_legend} from "./utils"
 import {PointGeometry} from "core/geometry"
 import {LineVector, FillVector} from "core/property_mixins"
-import {Line, Fill} from "core/visuals"
+import * as visuals from "core/visuals"
 import {Rect, NumberArray} from "core/types"
 import {Direction} from "core/enums"
 import * as p from "core/properties"
@@ -132,7 +132,7 @@ export namespace Wedge {
 
   export type Mixins = LineVector & FillVector
 
-  export type Visuals = XYGlyph.Visuals & {line: Line, fill: Fill}
+  export type Visuals = XYGlyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector}
 }
 
 export interface Wedge extends Wedge.Attrs {}

--- a/bokehjs/src/lib/models/grids/grid.ts
+++ b/bokehjs/src/lib/models/grids/grid.ts
@@ -43,7 +43,7 @@ export class GridView extends GuideRendererView {
       if (this.visuals.band_fill.doit)
         ctx.fillRect(sx0[0], sy0[0], sx1[1] - sx0[0], sy1[1] - sy0[0])
 
-      this.visuals.band_hatch.doit2(ctx, i, () => {
+      this.visuals.band_hatch.doit2(ctx, () => {
         ctx.fillRect(sx0[0], sy0[0], sx1[1] - sx0[0], sy1[1] - sy0[0])
       }, () => this.request_render())
     }

--- a/bokehjs/src/lib/models/markers/defs.ts
+++ b/bokehjs/src/lib/models/markers/defs.ts
@@ -1,7 +1,7 @@
 import {Marker, MarkerView} from "./marker"
 import {MarkerType} from "core/enums"
 import {Class} from "core/class"
-import {Line, Fill} from "core/visuals"
+import {LineVector, FillVector} from "core/visuals"
 import {Context2d} from "core/util/canvas"
 import * as glmarks from "../glyphs/webgl/markers"
 
@@ -73,7 +73,7 @@ function _one_tri(ctx: Context2d, r: number): void {
   ctx.closePath()
 }
 
-function asterisk(ctx: Context2d, i: number, r: number, line: Line, _fill: Fill): void {
+function asterisk(ctx: Context2d, i: number, r: number, line: LineVector, _fill: FillVector): void {
   _one_cross(ctx, r)
   _one_x(ctx, r)
 
@@ -83,7 +83,7 @@ function asterisk(ctx: Context2d, i: number, r: number, line: Line, _fill: Fill)
   }
 }
 
-function circle(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): void {
+function circle(ctx: Context2d, i: number, r: number, line: LineVector, fill: FillVector): void {
   ctx.arc(0, 0, r, 0, 2*Math.PI, false)
 
   if (fill.doit) {
@@ -97,7 +97,7 @@ function circle(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): v
   }
 }
 
-function circle_cross(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): void {
+function circle_cross(ctx: Context2d, i: number, r: number, line: LineVector, fill: FillVector): void {
   ctx.arc(0, 0, r, 0, 2*Math.PI, false)
 
   if (fill.doit) {
@@ -112,12 +112,12 @@ function circle_cross(ctx: Context2d, i: number, r: number, line: Line, fill: Fi
   }
 }
 
-function circle_dot(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): void {
+function circle_dot(ctx: Context2d, i: number, r: number, line: LineVector, fill: FillVector): void {
   circle(ctx, i, r, line, fill)
   dot(ctx, i, r, line, fill)
 }
 
-function circle_y(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): void {
+function circle_y(ctx: Context2d, i: number, r: number, line: LineVector, fill: FillVector): void {
   ctx.arc(0, 0, r, 0, 2*Math.PI, false)
 
   if (fill.doit) {
@@ -132,7 +132,7 @@ function circle_y(ctx: Context2d, i: number, r: number, line: Line, fill: Fill):
   }
 }
 
-function circle_x(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): void {
+function circle_x(ctx: Context2d, i: number, r: number, line: LineVector, fill: FillVector): void {
   ctx.arc(0, 0, r, 0, 2*Math.PI, false)
 
   if (fill.doit) {
@@ -147,7 +147,7 @@ function circle_x(ctx: Context2d, i: number, r: number, line: Line, fill: Fill):
   }
 }
 
-function cross(ctx: Context2d, i: number, r: number, line: Line, _fill: Fill): void {
+function cross(ctx: Context2d, i: number, r: number, line: LineVector, _fill: FillVector): void {
   _one_cross(ctx, r)
 
   if (line.doit) {
@@ -156,7 +156,7 @@ function cross(ctx: Context2d, i: number, r: number, line: Line, _fill: Fill): v
   }
 }
 
-function diamond(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): void {
+function diamond(ctx: Context2d, i: number, r: number, line: LineVector, fill: FillVector): void {
   _one_diamond(ctx, r)
 
   if (fill.doit) {
@@ -170,7 +170,7 @@ function diamond(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): 
   }
 }
 
-function diamond_cross(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): void {
+function diamond_cross(ctx: Context2d, i: number, r: number, line: LineVector, fill: FillVector): void {
   _one_diamond(ctx, r)
 
   if (fill.doit) {
@@ -188,12 +188,12 @@ function diamond_cross(ctx: Context2d, i: number, r: number, line: Line, fill: F
   }
 }
 
-function diamond_dot(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): void {
+function diamond_dot(ctx: Context2d, i: number, r: number, line: LineVector, fill: FillVector): void {
   diamond(ctx, i, r, line, fill)
   dot(ctx, i, r, line, fill)
 }
 
-function dot(ctx: Context2d, i: number, r: number, line: Line, _fill: Fill): void {
+function dot(ctx: Context2d, i: number, r: number, line: LineVector, _fill: FillVector): void {
   _one_dot(ctx, r)
 
   line.set_vectorize(ctx, i)
@@ -201,7 +201,7 @@ function dot(ctx: Context2d, i: number, r: number, line: Line, _fill: Fill): voi
   ctx.fill()
 }
 
-function hex(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): void {
+function hex(ctx: Context2d, i: number, r: number, line: LineVector, fill: FillVector): void {
   _one_hex(ctx, r)
 
   if (fill.doit) {
@@ -215,12 +215,12 @@ function hex(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): void
   }
 }
 
-function hex_dot(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): void {
+function hex_dot(ctx: Context2d, i: number, r: number, line: LineVector, fill: FillVector): void {
   hex(ctx, i, r, line, fill)
   dot(ctx, i, r, line, fill)
 }
 
-function inverted_triangle(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): void {
+function inverted_triangle(ctx: Context2d, i: number, r: number, line: LineVector, fill: FillVector): void {
   ctx.rotate(Math.PI)
   _one_tri(ctx, r)
   ctx.rotate(-Math.PI)
@@ -236,7 +236,7 @@ function inverted_triangle(ctx: Context2d, i: number, r: number, line: Line, fil
   }
 }
 
-function plus(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): void {
+function plus(ctx: Context2d, i: number, r: number, line: LineVector, fill: FillVector): void {
   const a = 3*r/8
   const b = r
   const xs = [a, a, b,  b,  a,  a, -a, -a, -b, -b, -a, -a]
@@ -258,7 +258,7 @@ function plus(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): voi
   }
 }
 
-function square(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): void {
+function square(ctx: Context2d, i: number, r: number, line: LineVector, fill: FillVector): void {
   const size = 2*r
 
   ctx.rect(-r, -r, size, size)
@@ -274,7 +274,7 @@ function square(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): v
   }
 }
 
-function square_pin(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): void {
+function square_pin(ctx: Context2d, i: number, r: number, line: LineVector, fill: FillVector): void {
   const a = 3*r/8
 
   ctx.moveTo(-r, -r)
@@ -298,7 +298,7 @@ function square_pin(ctx: Context2d, i: number, r: number, line: Line, fill: Fill
   }
 }
 
-function square_cross(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): void {
+function square_cross(ctx: Context2d, i: number, r: number, line: LineVector, fill: FillVector): void {
   const size = 2*r
 
   ctx.rect(-r, -r, size, size)
@@ -315,12 +315,12 @@ function square_cross(ctx: Context2d, i: number, r: number, line: Line, fill: Fi
   }
 }
 
-function square_dot(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): void {
+function square_dot(ctx: Context2d, i: number, r: number, line: LineVector, fill: FillVector): void {
   square(ctx, i, r, line, fill)
   dot(ctx, i, r, line, fill)
 }
 
-function square_x(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): void {
+function square_x(ctx: Context2d, i: number, r: number, line: LineVector, fill: FillVector): void {
   const size = 2*r
 
   ctx.rect(-r, -r, size, size)
@@ -340,7 +340,7 @@ function square_x(ctx: Context2d, i: number, r: number, line: Line, fill: Fill):
   }
 }
 
-function triangle(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): void {
+function triangle(ctx: Context2d, i: number, r: number, line: LineVector, fill: FillVector): void {
   _one_tri(ctx, r)
 
   if (fill.doit) {
@@ -354,12 +354,12 @@ function triangle(ctx: Context2d, i: number, r: number, line: Line, fill: Fill):
   }
 }
 
-function triangle_dot(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): void {
+function triangle_dot(ctx: Context2d, i: number, r: number, line: LineVector, fill: FillVector): void {
   triangle(ctx, i, r, line, fill)
   dot(ctx, i, r, line, fill)
 }
 
-function triangle_pin(ctx: Context2d, i: number, r: number, line: Line, fill: Fill): void {
+function triangle_pin(ctx: Context2d, i: number, r: number, line: LineVector, fill: FillVector): void {
   const h = r*SQ3
   const a = h/3
   const b = 3*a/8
@@ -381,7 +381,7 @@ function triangle_pin(ctx: Context2d, i: number, r: number, line: Line, fill: Fi
   }
 }
 
-function dash(ctx: Context2d, i: number, r: number, line: Line, _fill: Fill): void {
+function dash(ctx: Context2d, i: number, r: number, line: LineVector, _fill: FillVector): void {
   _one_line(ctx, r)
 
   if (line.doit) {
@@ -390,7 +390,7 @@ function dash(ctx: Context2d, i: number, r: number, line: Line, _fill: Fill): vo
   }
 }
 
-function x(ctx: Context2d, i: number, r: number, line: Line, _fill: Fill): void {
+function x(ctx: Context2d, i: number, r: number, line: LineVector, _fill: FillVector): void {
   _one_x(ctx, r)
 
   if (line.doit) {
@@ -399,7 +399,7 @@ function x(ctx: Context2d, i: number, r: number, line: Line, _fill: Fill): void 
   }
 }
 
-function y(ctx: Context2d, i: number, r: number, line: Line, _fill: Fill): void {
+function y(ctx: Context2d, i: number, r: number, line: LineVector, _fill: FillVector): void {
   _one_y(ctx, r)
 
   if (line.doit) {
@@ -428,7 +428,7 @@ function _mk_model(type: string, f: RenderOne, glglyph_cls?: Class<glmarks.Marke
   return model
 }
 
-export type RenderOne = (ctx: Context2d, i: number, r: number, line: Line, fill: Fill) => void
+export type RenderOne = (ctx: Context2d, i: number, r: number, line: LineVector, fill: FillVector) => void
 
 // markers are final, so no need to export views
 export const Asterisk = _mk_model('Asterisk', asterisk, glmarks.AsteriskGL)

--- a/bokehjs/src/lib/models/markers/marker.ts
+++ b/bokehjs/src/lib/models/markers/marker.ts
@@ -3,7 +3,7 @@ import {XYGlyph, XYGlyphView, XYGlyphData} from "../glyphs/xy_glyph"
 import type {MarkerGL} from "../glyphs/webgl/markers"
 import {PointGeometry, SpanGeometry, RectGeometry, PolyGeometry} from "core/geometry"
 import {LineVector, FillVector} from "core/property_mixins"
-import {Line, Fill} from "core/visuals"
+import * as visuals from "core/visuals"
 import {Arrayable, Rect, Indices} from "core/types"
 import * as hittest from "core/hittest"
 import * as p from "core/properties"
@@ -181,7 +181,7 @@ export namespace Marker {
 
   export type Mixins = LineVector & FillVector
 
-  export type Visuals = XYGlyph.Visuals & {line: Line, fill: Fill}
+  export type Visuals = XYGlyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector}
 }
 
 export interface Marker extends Marker.Attrs {}

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -9,7 +9,7 @@ import {CDSView} from "../sources/cds_view"
 import {Color, Indices} from "core/types"
 import * as p from "core/properties"
 import {indexOf, filter} from "core/util/arrayable"
-import {difference, includes} from "core/util/array"
+import {difference} from "core/util/array"
 import {extend, clone} from "core/util/object"
 import {HitTestResult} from "core/hittest"
 import {Geometry} from "core/geometry"
@@ -61,9 +61,12 @@ export class GlyphRendererView extends DataRendererView {
     await super.lazy_initialize()
 
     const base_glyph = this.model.glyph
-    const has_fill = includes(base_glyph._mixins, "fill")
-    const has_line = includes(base_glyph._mixins, "line")
-    const glyph_attrs = clone(base_glyph.attributes)
+    this.glyph = await this.build_glyph_view(base_glyph)
+
+    const has_fill = "fill" in this.glyph.visuals
+    const has_line = "line" in this.glyph.visuals
+
+    const glyph_attrs = {...base_glyph.attributes}
     delete glyph_attrs.id
 
     function mk_glyph(defaults: Defaults): typeof base_glyph {
@@ -72,8 +75,6 @@ export class GlyphRendererView extends DataRendererView {
       if (has_line) extend(attrs, defaults.line)
       return new (base_glyph.constructor as any)(attrs)
     }
-
-    this.glyph = await this.build_glyph_view(base_glyph)
 
     let {selection_glyph} = this.model
     if (selection_glyph == null)

--- a/bokehjs/test/unit/core/has_props.ts
+++ b/bokehjs/test/unit/core/has_props.ts
@@ -51,13 +51,13 @@ class SubSubclassWithProps extends SubclassWithProps {
 
 // TODO {{{
 class SubclassWithMixins extends HasProps {}
-SubclassWithMixins.mixins(['line'])
+SubclassWithMixins.mixins([mixins.Line])
 
 class SubSubclassWithMixins extends SubclassWithMixins {}
-SubSubclassWithMixins.mixins(['fill:foo_'])
+SubSubclassWithMixins.mixins([["foo_", mixins.Fill]])
 
 class SubclassWithMultipleMixins extends HasProps {}
-SubclassWithMultipleMixins.mixins(['line', 'text:bar_'])
+SubclassWithMultipleMixins.mixins([mixins.Line, ["bar_", mixins.Text]])
 // }}}
 
 namespace SubclassWithNumberSpec {

--- a/bokehjs/test/unit/core/visuals.ts
+++ b/bokehjs/test/unit/core/visuals.ts
@@ -2,7 +2,7 @@ import {expect} from "assertions"
 import {create_glyph_renderer_view} from "../models/glyphs/_util"
 
 import {Indices} from "@bokehjs/core/types"
-import {Fill, Line, Text, Visuals} from "@bokehjs/core/visuals"
+import {Fill, FillVector, Line, Text, Visuals} from "@bokehjs/core/visuals"
 import {Context2d} from "@bokehjs/core/util/canvas"
 import {ColumnDataSource} from "@bokehjs/models/sources/column_data_source"
 import {CDSView} from "@bokehjs/models/sources/cds_view"
@@ -168,7 +168,7 @@ describe("Visuals", () => {
     const attrs = {fill_color: {field: "fill_color"}, fill_alpha: {field: "fill_alpha"}}
 
     const circle = new Circle(attrs)
-    const visuals = new Visuals(circle) as Visuals & {fill: Fill}
+    const visuals = new Visuals(circle) as Visuals & {fill: FillVector}
 
     visuals.warm_cache(source)
 
@@ -182,7 +182,7 @@ describe("Visuals", () => {
     const attrs = {fill_color: {field: "fill_color"}, fill_alpha: {field: "fill_alpha"}}
 
     const circle = new Circle(attrs)
-    const visuals = new Visuals(circle) as Visuals & {fill: Fill}
+    const visuals = new Visuals(circle) as Visuals & {fill: FillVector}
 
     const subset = Indices.from_indices(3, [1, 2])
     visuals.warm_cache(source, subset)

--- a/examples/custom/gears/gear.ts
+++ b/examples/custom/gears/gear.ts
@@ -1,5 +1,5 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "models/glyphs/xy_glyph"
-import {generic_area_legend} from "models/glyphs/utils"
+import {generic_area_vector_legend} from "models/glyphs/utils"
 import {isString} from "core/util/types"
 import {Context2d} from "core/util/canvas"
 import {Arrayable, Rect} from "core/types"
@@ -142,7 +142,7 @@ export class GearView extends XYGlyphView {
   }
 
   draw_legend_for_index(ctx: Context2d, bbox: Rect, index: number): void {
-    generic_area_legend(this.visuals, ctx, bbox, index)
+    generic_area_vector_legend(this.visuals, ctx, bbox, index)
   }
 }
 

--- a/examples/custom/gears/gear.ts
+++ b/examples/custom/gears/gear.ts
@@ -4,7 +4,7 @@ import {isString} from "core/util/types"
 import {Context2d} from "core/util/canvas"
 import {Arrayable, Rect} from "core/types"
 import {LineVector, FillVector} from "core/property_mixins"
-import {Line, Fill} from "core/visuals"
+import * as visuals from "core/visuals"
 import * as p from "core/properties"
 
 import {Draw, gear_tooth, internal_gear_tooth}  from "./gear_utils"
@@ -160,7 +160,7 @@ export namespace Gear {
 
   export type Mixins = LineVector & FillVector
 
-  export type Visuals = XYGlyph.Visuals & {line: Line, fill: Fill}
+  export type Visuals = XYGlyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector}
 }
 
 export interface Gear extends Gear.Attrs {}

--- a/sphinx/source/docs/releases/2.3.0.rst
+++ b/sphinx/source/docs/releases/2.3.0.rst
@@ -46,3 +46,11 @@ Old names are deprecated and will be removed in bokeh 3.0.
 ``DataRange.names``, ``SelectTool.names`` and ``HoverTool.names`` were deprecated
 and will be removed in bokeh 3.0. Use respective ``renderers`` properties instead,
 possibly in combination with ``plot.select(name="renderer name")``.
+
+bokehjs' visuals have different semantics
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously ``Line``, ``Fill``, ``Text`` and ``Hatch`` visuals were used in primitive,
+scalar and vector contexts. Those were split and now context-specific visuals, e.g.,
+``Line``, ``LineScalar`` and ``LineVector`` have to used in respective contexts. This
+aligns visuals with mixins, among other things.


### PR DESCRIPTION
This PR splits visuals' API into scalar and vector, aligning it with property mixins, so that e.g. `set_value()` is available only on scalar visuals and `set_vectorized()` only on vectorized. This may allow to reduce type overhead by coalescing `type Mixins` and `type Visuals` into one type, as one can be now inferred from the other. Mind code quality especially in `core/visuals`. This PR is an excerpt from a larger one, so the implementation will get refined in future PRs when all work is completed. 