### PR TITLE
Unify initialization of visuals and data

### DIFF
--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -1,19 +1,17 @@
 //import {logger} from "./logging"
 import {View} from "./view"
 import {Class} from "./class"
-import {Arrayable, Attrs} from "./types"
+import {Attrs} from "./types"
 import {Signal0, Signal, Signalable, ISignalable} from "./signaling"
 import {Struct, Ref, is_ref} from "./util/refs"
 import * as p from "./properties"
 import * as k from "./kinds"
 import {Property} from "./properties"
 import {uniqueId} from "./util/string"
-import {max} from "./util/array"
 import {values, entries, extend} from "./util/object"
 import {isPlainObject, isArray, isFunction, isPrimitive} from "./util/types"
 import {is_equal} from './util/eq'
 import {serialize, Serializable, Serializer} from "./serializer"
-import {ColumnarDataSource} from "models/sources/columnar_data_source"
 import {Document, DocumentEvent, DocumentEventBatch, ModelChangedEvent} from "../document"
 import {equals, Equatable, Comparator} from "./util/eq"
 import {pretty, Printable, Printer} from "./util/pretty"
@@ -563,26 +561,6 @@ export abstract class HasProps extends Signalable() implements Equatable, Printa
         event = new DocumentEventBatch(document, events, setter_id)
       document._trigger_on_change(event)
     }
-  }
-
-  materialize_dataspecs(source: ColumnarDataSource): {[key: string]: Arrayable<unknown> | number} {
-    // Note: this should be moved to a function separate from HasProps
-    const data: {[key: string]: Arrayable<unknown> | number} = {}
-    for (const prop of this) {
-      if (!(prop instanceof p.VectorSpec))
-        continue
-      // this skips optional properties like radius for circles
-      if (prop.optional && prop.spec.value == null && !prop.dirty)
-        continue
-
-      const name = prop.attr
-      const array = prop.array(source)
-
-      data[`_${name}`] = array
-      if (prop instanceof p.DistanceSpec)
-        data[`max_${name}`] = max(array as Arrayable<number>)
-    }
-    return data
   }
 
   on_change(properties: Property<unknown> | Property<unknown>[], fn: () => void): void {

--- a/bokehjs/src/lib/core/types.ts
+++ b/bokehjs/src/lib/core/types.ts
@@ -1,3 +1,7 @@
+export type uint8  = number
+export type uint16 = number
+export type uint32 = number
+
 export type ID = string
 
 export type Color = string

--- a/bokehjs/src/lib/core/util/color.ts
+++ b/bokehjs/src/lib/core/util/color.ts
@@ -1,5 +1,6 @@
 import {svg_colors, is_svg_color} from "./svg_colors"
 import {includes} from "./array"
+import {uint32} from "../types"
 
 export function is_color(value: string): boolean {
   return is_svg_color(value.toLowerCase()) || value.substring(0, 1) == "#" || valid_rgb(value)
@@ -34,13 +35,13 @@ export function color2hex(color: string): string {
 }
 
 // each component is in [0, 1] range
-export type RGBA = [number, number, number, number]
+export type RGBAf = [number, number, number, number]
 
-export function encode_rgba([r, g, b, a]: RGBA): number {
+export function encode_rgba([r, g, b, a]: RGBAf): uint32 {
   return (r*255 | 0) << 24 | (g*255 | 0) << 16 | (b*255 | 0) << 8 | (a*255 | 0)
 }
 
-export function decode_rgba(rgba: number): RGBA {
+export function decode_rgba(rgba: uint32): RGBAf {
   const r = ((rgba >> 24) & 0xff) / 255
   const g = ((rgba >> 16) & 0xff) / 255
   const b = ((rgba >>  8) & 0xff) / 255
@@ -48,7 +49,7 @@ export function decode_rgba(rgba: number): RGBA {
   return [r, g, b, a]
 }
 
-export function color2rgba(color: string | null, alpha: number = 1.0): RGBA {
+export function color2rgba(color: string | null, alpha: number = 1.0): RGBAf {
   if (!color)  // NaN, null, '', etc.
     return [0, 0, 0, 0]  // transparent
   // Convert to hex and then to clean version of 6 or 8 chars
@@ -64,7 +65,7 @@ export function color2rgba(color: string | null, alpha: number = 1.0): RGBA {
     rgba.push(0)
   if (rgba.length < 4)
     rgba.push(alpha)
-  return rgba.slice(0, 4) as RGBA
+  return rgba.slice(0, 4) as RGBAf
 }
 
 export function valid_rgb(value: string): boolean {

--- a/bokehjs/src/lib/core/util/color.ts
+++ b/bokehjs/src/lib/core/util/color.ts
@@ -49,9 +49,21 @@ export function decode_rgba(rgba: uint32): RGBAf {
   return [r, g, b, a]
 }
 
+function transparent(): RGBAf {
+  return [0, 0, 0, 0]
+}
+
+let _last_color = "transparent"
+let _last_alpha = 1.0
+let _last_rgbaf = transparent()
+
 export function color2rgba(color: string | null, alpha: number = 1.0): RGBAf {
-  if (!color)  // NaN, null, '', etc.
-    return [0, 0, 0, 0]  // transparent
+  if (!color || color == "transparent")  // NaN, null, '', etc.
+    return transparent()
+
+  if (color == _last_color && alpha == _last_alpha)
+    return [..._last_rgbaf]
+
   // Convert to hex and then to clean version of 6 or 8 chars
   let hex = color2hex(color)
   hex = hex.replace(/ |#/g, '')
@@ -65,7 +77,12 @@ export function color2rgba(color: string | null, alpha: number = 1.0): RGBAf {
     rgba.push(0)
   if (rgba.length < 4)
     rgba.push(alpha)
-  return rgba.slice(0, 4) as RGBAf
+
+  const rgbaf = rgba.slice(0, 4) as RGBAf
+  _last_color = color
+  _last_alpha = alpha
+  _last_rgbaf = rgbaf
+  return rgbaf
 }
 
 export function valid_rgb(value: string): boolean {

--- a/bokehjs/src/lib/core/visuals.ts
+++ b/bokehjs/src/lib/core/visuals.ts
@@ -209,8 +209,8 @@ export abstract class ContextProperties {
       return (this.obj as any)[`_${prop.attr}`][i]
   }
 
-  get_array(attr: string): Arrayable {
-    return (this.obj as any)[`_${attr}`]
+  get_array(prop: p.Property<unknown>): Arrayable {
+    return (this.obj as any)[`_${prop.attr}`]
   }
 
   abstract get doit(): boolean

--- a/bokehjs/src/lib/core/visuals.ts
+++ b/bokehjs/src/lib/core/visuals.ts
@@ -203,7 +203,7 @@ export abstract class ContextProperties {
   }
 
   cache_select(prop: p.Property<unknown>, i: number): any {
-    if (prop.spec.value !== undefined) // TODO (bev) better test?
+    if (prop.is_value)
       return prop.spec.value
     else
       return (this.obj as any)[`_${prop.attr}`][i]

--- a/bokehjs/src/lib/core/visuals.ts
+++ b/bokehjs/src/lib/core/visuals.ts
@@ -186,9 +186,20 @@ export abstract class ContextProperties {
 
   protected readonly cache: {[key: string]: any} = {}
 
+  private readonly _props: p.Property<unknown>[]
+
+  *[Symbol.iterator](): Generator<p.Property<unknown>, void, undefined> {
+    yield* this._props
+  }
+
   constructor(readonly obj: View, readonly prefix: string = "") {
-    for (const attr of this.attrs)
-      (this as any)[attr] = obj.model.properties[prefix + attr]
+    const self = this as any
+    this._props = []
+    for (const attr of this.attrs) {
+      const prop = obj.model.properties[prefix + attr]
+      self[attr] = prop
+      this._props.push(prop)
+    }
   }
 
   cache_select(prop: p.Property<unknown>, i: number): any {

--- a/bokehjs/src/lib/models/annotations/annotation.ts
+++ b/bokehjs/src/lib/models/annotations/annotation.ts
@@ -1,8 +1,10 @@
 import {SidePanel} from "core/layout/side_panel"
 import {Size} from "core/layout"
+import {Arrayable} from "core/types"
 import {SerializableState} from "core/view"
+import * as p from "core/properties"
 import * as proj from "core/util/projections"
-import {extend} from "core/util/object"
+import {max} from "core/util/array"
 
 import {Renderer, RendererView} from "../renderers/renderer"
 import {ColumnarDataSource} from "../sources/columnar_data_source"
@@ -36,11 +38,23 @@ export abstract class AnnotationView extends RendererView {
   }
 
   set_data(source: ColumnarDataSource): void {
-    const data = this.model.materialize_dataspecs(source)
-    extend(this as any, data)
+    const self = this as any
+
+    for (const prop of this.model) {
+      if (!(prop instanceof p.VectorSpec))
+        continue
+
+      // this skips optional properties like radius for circles
+      if (prop.optional && prop.spec.value == null && !prop.dirty)
+        continue
+
+      const array = prop.array(source)
+      self[`_${prop.attr}`] = array
+      if (prop instanceof p.DistanceSpec)
+        self[`max_${prop.attr}`] = max(array as Arrayable<number>)
+    }
 
     if (this.plot_model.use_map) {
-      const self = this as any
       if (self._x != null)
         [self._x, self._y] = proj.project_xy(self._x, self._y)
       if (self._xs != null)

--- a/bokehjs/src/lib/models/annotations/arrow.ts
+++ b/bokehjs/src/lib/models/annotations/arrow.ts
@@ -57,7 +57,6 @@ export class ArrowView extends AnnotationView {
 
   set_data(source: ColumnarDataSource): void {
     super.set_data(source)
-    this.visuals.warm_cache(source)
     this.plot_view.request_render()
   }
 

--- a/bokehjs/src/lib/models/annotations/arrow_head.ts
+++ b/bokehjs/src/lib/models/annotations/arrow_head.ts
@@ -26,7 +26,7 @@ export namespace ArrowHead {
     size: p.Property<number>
   }
 
-  export type Visuals = visuals.Visuals
+  export type Visuals = {}
 }
 
 export interface ArrowHead extends ArrowHead.Attrs {}

--- a/bokehjs/src/lib/models/annotations/arrow_head.ts
+++ b/bokehjs/src/lib/models/annotations/arrow_head.ts
@@ -11,7 +11,7 @@ export abstract class ArrowHeadView extends View {
 
   initialize(): void {
     super.initialize()
-    this.visuals = new visuals.Visuals(this.model)
+    this.visuals = new visuals.Visuals(this)
   }
 
   abstract render(ctx: Context2d, i: number): void

--- a/bokehjs/src/lib/models/annotations/color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/color_bar.ts
@@ -384,9 +384,8 @@ export class ColorBarView extends AnnotationView {
   }
 
   _title_extent(): number {
-    const {title_text_font_style, title_text_font_size, title_text_font} = this.model
-    const font_value = `${title_text_font_style} ${title_text_font_size} ${title_text_font}`
-    const title_extent = this.model.title ? text_util.measure_font(font_value).height + this.model.title_standoff : 0
+    const font = this.visuals.title_text.font_value()
+    const title_extent = this.model.title ? text_util.measure_font(font).height + this.model.title_standoff : 0
     return title_extent
   }
 

--- a/bokehjs/src/lib/models/annotations/label.ts
+++ b/bokehjs/src/lib/models/annotations/label.ts
@@ -9,11 +9,6 @@ export class LabelView extends TextAnnotationView {
   model: Label
   visuals: Label.Visuals
 
-  initialize(): void {
-    super.initialize()
-    this.visuals.warm_cache()
-  }
-
   protected _get_size(): Size {
     const {ctx} = this.layer
     this.visuals.text.set_value(ctx)

--- a/bokehjs/src/lib/models/annotations/label_set.ts
+++ b/bokehjs/src/lib/models/annotations/label_set.ts
@@ -74,11 +74,6 @@ export class LabelSetView extends TextAnnotationView {
     }
   }
 
-  set_data(source: ColumnarDataSource): void {
-    super.set_data(source)
-    this.visuals.warm_cache(source)
-  }
-
   protected _map_data(): [Arrayable<number>, Arrayable<number>] {
     const xscale = this.coordinates.x_scale
     const yscale = this.coordinates.y_scale

--- a/bokehjs/src/lib/models/annotations/title.ts
+++ b/bokehjs/src/lib/models/annotations/title.ts
@@ -11,7 +11,7 @@ export class TitleView extends TextAnnotationView {
 
   initialize(): void {
     super.initialize()
-    this.visuals.text = new visuals.Text(this.model)
+    this.visuals.text = new visuals.Text(this)
   }
 
   protected _get_location(): [number, number] {

--- a/bokehjs/src/lib/models/annotations/upper_lower.ts
+++ b/bokehjs/src/lib/models/annotations/upper_lower.ts
@@ -13,10 +13,6 @@ export abstract class UpperLowerView extends AnnotationView {
   protected _upper: Arrayable<number>
   protected _base:  Arrayable<number>
 
-  protected max_lower: number
-  protected max_upper: number
-  protected max_base:  number
-
   protected _lower_sx: Arrayable<number>
   protected _lower_sy: Arrayable<number>
   protected _upper_sx: Arrayable<number>
@@ -29,7 +25,6 @@ export abstract class UpperLowerView extends AnnotationView {
 
   set_data(source: ColumnarDataSource): void {
     super.set_data(source)
-    this.visuals.warm_cache(source)
     this.plot_view.request_render()
   }
 

--- a/bokehjs/src/lib/models/glyphs/center_rotatable.ts
+++ b/bokehjs/src/lib/models/glyphs/center_rotatable.ts
@@ -1,7 +1,7 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {LineVector, FillVector} from "core/property_mixins"
 import * as visuals from "core/visuals"
-import {NumberArray} from "core/types"
+import {NumberArray, Rect} from "core/types"
 import * as p from "core/properties"
 
 export interface CenterRotatableData extends XYGlyphData {
@@ -14,9 +14,6 @@ export interface CenterRotatableData extends XYGlyphData {
 
   max_width: number
   max_height: number
-
-  max_w2: number
-  max_h2: number
 }
 
 export interface CenterRotatableView extends CenterRotatableData {}
@@ -24,6 +21,24 @@ export interface CenterRotatableView extends CenterRotatableData {}
 export abstract class CenterRotatableView extends XYGlyphView {
   model: CenterRotatable
   visuals: CenterRotatable.Visuals
+
+  get max_w2(): number {
+    return this.model.properties.width.units == "data" ? this.max_width/2 : 0
+  }
+
+  get max_h2(): number {
+    return this.model.properties.height.units == "data" ? this.max_height/2 : 0
+  }
+
+  protected _bounds({x0, x1, y0, y1}: Rect): Rect {
+    const {max_w2, max_h2} = this
+    return {
+      x0: x0 - max_w2,
+      x1: x1 + max_w2,
+      y0: y0 - max_h2,
+      y1: y1 + max_h2,
+    }
+  }
 }
 
 export namespace CenterRotatable {

--- a/bokehjs/src/lib/models/glyphs/ellipse_oval.ts
+++ b/bokehjs/src/lib/models/glyphs/ellipse_oval.ts
@@ -1,6 +1,5 @@
 import {CenterRotatable, CenterRotatableView, CenterRotatableData} from "./center_rotatable"
 import {PointGeometry} from "core/geometry"
-import {LineVector, FillVector} from "core/property_mixins"
 import * as hittest from "core/hittest"
 import {Rect} from "core/types"
 import {Context2d} from "core/util/canvas"
@@ -14,16 +13,6 @@ export interface EllipseOvalView extends EllipseOvalData {}
 export abstract class EllipseOvalView extends CenterRotatableView  {
   model: EllipseOval
   visuals: EllipseOval.Visuals
-
-  protected _set_data(): void {
-    this.max_w2 = 0
-    if (this.model.properties.width.units == "data")
-      this.max_w2 = this.max_width/2
-
-    this.max_h2 = 0
-    if (this.model.properties.height.units == "data")
-      this.max_h2 = this.max_height/2
-  }
 
   protected _map_data(): void {
     if (this.model.properties.width.units == "data")
@@ -118,21 +107,12 @@ export abstract class EllipseOvalView extends CenterRotatableView  {
 
     this._render(ctx, [index], {sx, sy, sw, sh, _angle: [0]} as any) // XXX
   }
-
-  protected _bounds({x0, x1, y0, y1}: Rect): Rect {
-    return {
-      x0: x0 - this.max_w2,
-      x1: x1 + this.max_w2,
-      y0: y0 - this.max_h2,
-      y1: y1 + this.max_h2,
-    }
-  }
 }
 
 export namespace EllipseOval {
   export type Attrs = p.AttrsOf<Props>
 
-  export type Props = CenterRotatable.Props & LineVector & FillVector
+  export type Props = CenterRotatable.Props
 
   export type Visuals = CenterRotatable.Visuals
 }

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -320,7 +320,7 @@ export namespace Glyph {
 
   export type Props = Model.Props
 
-  export type Visuals = visuals.Visuals
+  export type Visuals = {}
 }
 
 export interface Glyph extends Glyph.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -11,6 +11,7 @@ import {logger} from "core/logging"
 import {Arrayable, Rect, NumberArray, Indices} from "core/types"
 import {RaggedArray} from "core/util/ragged_array"
 import {map, max} from "core/util/arrayable"
+import {values} from "core/util/object"
 import {SpatialIndex} from "core/util/spatial"
 import {Scale} from "../scales/scale"
 import {FactorRange} from "../ranges/factor_range"
@@ -66,13 +67,6 @@ export abstract class GlyphView extends View {
   initialize(): void {
     super.initialize()
     this.visuals = new visuals.Visuals(this)
-  }
-
-  set_visuals(source: ColumnarDataSource, indices: Indices): void {
-    this.visuals.warm_cache(source, indices)
-
-    if (this.glglyph != null)
-      this.glglyph.set_visuals_changed()
   }
 
   render(ctx: Context2d, indices: number[], data: any): void {
@@ -213,13 +207,38 @@ export abstract class GlyphView extends View {
 
   protected _project_data(): void {}
 
+  private *_iter_visuals(): Generator<p.VectorSpec<unknown>> {
+    for (const visual of values<visuals.ContextProperties>(this.visuals)) {
+      for (const prop of visual) {
+        if (prop instanceof p.VectorSpec)
+          yield prop
+      }
+    }
+  }
+
+  set_visuals(source: ColumnarDataSource, indices: Indices): void {
+    const self = this as any
+
+    for (const prop of this._iter_visuals()) {
+      const base_array = prop.array(source)
+      const array = indices.select(base_array)
+      self[`_${prop.attr}`] = array
+    }
+
+    this.glglyph?.set_visuals_changed()
+  }
+
   set_data(source: ColumnarDataSource, indices: Indices, indices_to_update: number[] | null): void {
     const {x_range, y_range} = this.renderer.coordinates
 
     this._data_size = indices.count
 
+    const visual_props = new Set(this._iter_visuals())
     for (const prop of this.model) {
       if (!(prop instanceof p.VectorSpec))
+        continue
+
+      if (visual_props.has(prop)) // let set_visuals() do the work
         continue
 
       // this skips optional properties like radius for circles

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -65,7 +65,7 @@ export abstract class GlyphView extends View {
 
   initialize(): void {
     super.initialize()
-    this.visuals = new visuals.Visuals(this.model)
+    this.visuals = new visuals.Visuals(this)
   }
 
   set_visuals(source: ColumnarDataSource, indices: Indices): void {

--- a/bokehjs/src/lib/models/glyphs/image_base.ts
+++ b/bokehjs/src/lib/models/glyphs/image_base.ts
@@ -145,27 +145,15 @@ export abstract class ImageBaseView extends XYGlyphView {
   }
 
   protected _map_data(): void {
-    switch (this.model.properties.dw.units) {
-      case "data": {
-        this.sw = this.sdist(this.renderer.xscale, this._x, this._dw, 'edge', this.model.dilate)
-        break
-      }
-      case "screen": {
-        this.sw = this._dw
-        break
-      }
-    }
+    if (this.model.properties.dw.units == "data")
+      this.sw = this.sdist(this.renderer.xscale, this._x, this._dw, 'edge', this.model.dilate)
+    else
+      this.sw = this._dw
 
-    switch (this.model.properties.dh.units) {
-      case "data": {
-        this.sh = this.sdist(this.renderer.yscale, this._y, this._dh, 'edge', this.model.dilate)
-        break
-      }
-      case "screen": {
-        this.sh = this._dh
-        break
-      }
-    }
+    if (this.model.properties.dh.units == "data")
+      this.sh = this.sdist(this.renderer.yscale, this._y, this._dh, 'edge', this.model.dilate)
+    else
+      this.sh = this._dh
   }
 
   _image_index(index: number, x: number, y: number): ImageIndex {

--- a/bokehjs/src/lib/models/glyphs/image_url.ts
+++ b/bokehjs/src/lib/models/glyphs/image_url.ts
@@ -146,27 +146,15 @@ export class ImageURLView extends XYGlyphView {
     const ws = this.model.w != null ? this._w : map(this._x, () => NaN)
     const hs = this.model.h != null ? this._h : map(this._x, () => NaN)
 
-    switch (this.model.properties.w.units) {
-      case "data": {
-        this.sw = this.sdist(this.renderer.xscale, this._x, ws, "edge", this.model.dilate)
-        break
-      }
-      case "screen": {
-        this.sw = ws
-        break
-      }
-    }
+    if (this.model.properties.w.units == "data")
+      this.sw = this.sdist(this.renderer.xscale, this._x, ws, "edge", this.model.dilate)
+    else
+      this.sw = ws
 
-    switch (this.model.properties.h.units) {
-      case "data": {
-        this.sh = this.sdist(this.renderer.yscale, this._y, hs, "edge", this.model.dilate)
-        break
-      }
-      case "screen": {
-        this.sh = hs
-        break
-      }
-    }
+    if (this.model.properties.h.units == "data")
+      this.sh = this.sdist(this.renderer.yscale, this._y, hs, "edge", this.model.dilate)
+    else
+      this.sh = hs
   }
 
   protected _render(ctx: Context2d, indices: number[],

--- a/bokehjs/src/lib/models/glyphs/multi_line.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_line.ts
@@ -79,10 +79,11 @@ export class MultiLineView extends GlyphView {
   protected _hit_point(geometry: PointGeometry): Selection {
     const point = {x: geometry.sx, y: geometry.sy}
     let shortest = 9999
+    const {line_width} = this.model.properties
 
     const hits: Map<number, number[]> = new Map()
     for (let i = 0, end = this.sxs.length; i < end; i++) {
-      const threshold = Math.max(2, this.visuals.line.cache_select('line_width', i) / 2)
+      const threshold = Math.max(2, this.visuals.line.cache_select(line_width, i) / 2)
 
       const sxsi = this.sxs.get(i)
       const sysi = this.sys.get(i)

--- a/bokehjs/src/lib/models/glyphs/rect.ts
+++ b/bokehjs/src/lib/models/glyphs/rect.ts
@@ -1,7 +1,6 @@
 import {CenterRotatable, CenterRotatableView, CenterRotatableData} from "./center_rotatable"
 import {generic_area_vector_legend} from "./utils"
 import {PointGeometry, RectGeometry} from "core/geometry"
-import {LineVector, FillVector} from "core/property_mixins"
 import {Arrayable, NumberArray} from "core/types"
 import * as types from "core/types"
 import * as p from "core/properties"
@@ -22,16 +21,6 @@ export class RectView extends CenterRotatableView {
   model: Rect
   visuals: Rect.Visuals
 
-  protected _set_data(): void {
-    this.max_w2 = 0
-    if (this.model.properties.width.units == "data")
-      this.max_w2 = this.max_width/2
-
-    this.max_h2 = 0
-    if (this.model.properties.height.units == "data")
-      this.max_h2 = this.max_height/2
-  }
-
   protected _map_data(): void {
     if (this.model.properties.width.units == "data")
       [this.sw, this.sx0] = this._map_dist_corner_for_data_side_length(this._x, this._width, this.renderer.xscale)
@@ -49,7 +38,7 @@ export class RectView extends CenterRotatableView {
     else {
       this.sh = this._height
 
-      const n =  this.sy.length
+      const n = this.sy.length
       this.sy1 = new NumberArray(n)
       for (let i = 0; i < n; i++)
         this.sy1[i] = this.sy[i] - this.sh[i]/2
@@ -224,21 +213,12 @@ export class RectView extends CenterRotatableView {
   draw_legend_for_index(ctx: Context2d, bbox: types.Rect, index: number): void {
     generic_area_vector_legend(this.visuals, ctx, bbox, index)
   }
-
-  protected _bounds({x0, x1, y0, y1}: types.Rect): types.Rect {
-    return {
-      x0: x0 - this.max_w2,
-      x1: x1 + this.max_w2,
-      y0: y0 - this.max_h2,
-      y1: y1 + this.max_h2,
-    }
-  }
 }
 
 export namespace Rect {
   export type Attrs = p.AttrsOf<Props>
 
-  export type Props = CenterRotatable.Props & LineVector & FillVector & {
+  export type Props = CenterRotatable.Props & {
     dilate: p.Property<boolean>
   }
 

--- a/bokehjs/src/lib/models/glyphs/segment.ts
+++ b/bokehjs/src/lib/models/glyphs/segment.ts
@@ -79,8 +79,10 @@ export class SegmentView extends GlyphView {
     const candidates = this.index.indices({x0, y0, x1, y1})
     const indices = []
 
+    const {line_width} = this.model.properties
+
     for (const i of candidates) {
-      const threshold2 = Math.max(2, this.visuals.line.cache_select('line_width', i) / 2)**2
+      const threshold2 = Math.max(2, this.visuals.line.cache_select(line_width, i) / 2)**2
       const p0 = {x: this.sx0[i], y: this.sy0[i]}
       const p1 = {x: this.sx1[i], y: this.sy1[i]}
       const dist2 = hittest.dist_to_segment_squared(point, p0, p1)
@@ -113,11 +115,13 @@ export class SegmentView extends GlyphView {
     const [y0, y1] = this.renderer.yscale.r_invert(vr.start, vr.end)
     const candidates = this.index.indices({x0, y0, x1, y1})
 
+    const {line_width} = this.model.properties
+
     for (const i of candidates) {
       if ((v0[i] <= val && val <= v1[i]) || (v1[i] <= val && val <= v0[i]))
         indices.push(i)
 
-      const threshold = 1.5 + (this.visuals.line.cache_select('line_width', i) / 2)// Maximum pixel difference to detect hit
+      const threshold = 1.5 + (this.visuals.line.cache_select(line_width, i) / 2)// Maximum pixel difference to detect hit
 
       if (v0[i] == v1[i]) {
         if (geometry.direction == 'h') {

--- a/bokehjs/src/lib/models/glyphs/text.ts
+++ b/bokehjs/src/lib/models/glyphs/text.ts
@@ -54,9 +54,9 @@ export class TextView extends XYGlyphView {
         ctx.rotate(_angle[i])
         this.visuals.text.set_vectorize(ctx, i)
 
-        const font = this.visuals.text.cache_select("font", i)
+        const font = this.visuals.text.v_font_value(i)
         const {height} = measure_font(font)
-        const line_height = this.visuals.text.text_line_height.value()*height
+        const line_height = this.model.text_line_height*height
         if (text.indexOf("\n") == -1) {
           ctx.fillText(text, 0, 0)
           const x0 = sx[i] + _x_offset[i]
@@ -68,7 +68,7 @@ export class TextView extends XYGlyphView {
         } else {
           const lines = text.split("\n")
           const block_height = line_height*lines.length
-          const baseline = this.visuals.text.cache_select("text_baseline", i)
+          const baseline = this.model.text_baseline
 
           let y: number
           switch (baseline) {

--- a/bokehjs/src/lib/models/glyphs/webgl/markers.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/markers.ts
@@ -7,67 +7,60 @@ import {CircleView} from "../circle"
 import {Class} from "core/class"
 import {map} from "core/util/arrayable"
 import {logger} from "core/logging"
-import {Arrayable} from "core/types"
-import {color2rgba, encode_rgba, decode_rgba} from "core/util/color"
+import {color2rgba, decode_rgba, RGBAf} from "core/util/color"
+import * as visuals from "core/visuals"
+import * as p from "core/properties"
 
-export function attach_float(prog: Program, vbo: VertexBuffer & {used?: boolean}, att_name: string, n: number, visual: any, name: string): void {
+function attach_float(prog: Program, vbo: VertexBuffer & {used?: boolean}, att_name: string, n: number,
+    visual: visuals.LineVector | visuals.FillVector, prop: p.NumberSpec): void {
   // Attach a float attribute to the program. Use singleton value if we can,
   // otherwise use VBO to apply array.
   if (!visual.doit) {
     vbo.used = false
     prog.set_attribute(att_name, 'float', [0])
-  } else if (visual[name].is_value) {
+  } else if (prop.is_value) {
     vbo.used = false
-    prog.set_attribute(att_name, 'float', [visual[name].value()])
+    prog.set_attribute(att_name, 'float', [prop.value()])
   } else {
     vbo.used = true
-    const a = new Float32Array(visual.get_array(name))
+    const a = new Float32Array(visual.get_array(prop))
     vbo.set_size(n*4)
     vbo.set_data(0, a)
     prog.set_attribute(att_name, 'float', vbo)
   }
 }
 
-export function attach_color(prog: Program, vbo: VertexBuffer & {used?: boolean}, att_name: string, n: number, visual: any, prefix: string): void {
+function attach_color(prog: Program, vbo: VertexBuffer & {used?: boolean}, att_name: string, n: number,
+    visual: visuals.LineVector | visuals.FillVector, color_prop: p.ColorSpec, alpha_prop: p.NumberSpec): void {
   // Attach the color attribute to the program. If there's just one color,
   // then use this single color for all vertices (no VBO). Otherwise we
   // create an array and upload that to the VBO, which we attahce to the prog.
   const m = 4
-  const colorname = prefix + '_color'
-  const alphaname = prefix + '_alpha'
+
+  function compose(color: RGBAf, alpha: number): RGBAf {
+    const [r, g, b, a] = color
+    return a == 1.0 ? [r, g, b, alpha] : color
+  }
 
   if (!visual.doit) {
     // Don't draw (draw transparent)
     vbo.used = false
     prog.set_attribute(att_name, 'vec4', [0, 0, 0, 0])
+  } else if (color_prop.is_value && alpha_prop.is_value) {
+    vbo.used = false
+    const color = compose(color2rgba(color_prop.value()), alpha_prop.value())
+    prog.set_attribute(att_name, 'vec4', color)
   } else {
     // Use vbo; we need an array for both the color and the alpha
     vbo.used = true
 
-    let colors: Arrayable<number>
-    if (visual[colorname].is_value) {
-      const val = encode_rgba(color2rgba(visual[colorname].value()))
-      const array = new Uint32Array(n)
-      array.fill(val)
-      colors = array
-    } else
-      colors = visual.get_array(colorname)
-
-    let alphas: Arrayable<number>
-    if (visual[alphaname].is_value) {
-      const val = visual[alphaname].value()
-      const array = new Float32Array(n)
-      array.fill(val)
-      alphas = array
-    } else
-      alphas = visual.get_array(alphaname)
+    const colors = visual.get_array(color_prop)
+    const alphas = visual.get_array(alpha_prop)
 
     // Create array of rgbs
     const a = new Float32Array(n*m)
     for (let i = 0, end = n; i < end; i++) {
-      const rgba = decode_rgba(colors[i])
-      if (rgba[3] == 1.0)
-        rgba[3] = alphas[i]
+      const rgba = compose(decode_rgba(colors[i]), alphas[i])
       a.set(rgba, i*m)
     }
     // Attach vbo
@@ -76,7 +69,6 @@ export function attach_color(prog: Program, vbo: VertexBuffer & {used?: boolean}
     prog.set_attribute(att_name, 'vec4', vbo)
   }
 }
-
 
 // Base class for markers. All markers share the same GLSL, except for one
 // function that defines the marker geometry.
@@ -234,9 +226,10 @@ export abstract class MarkerGL extends BaseGLGlyph {
   }
 
   protected _set_visuals(nvertices: number): void {
-    attach_float(this.prog, this.vbo_linewidth, 'a_linewidth', nvertices, this.glyph.visuals.line, 'line_width')
-    attach_color(this.prog, this.vbo_fg_color, 'a_fg_color', nvertices, this.glyph.visuals.line, 'line')
-    attach_color(this.prog, this.vbo_bg_color, 'a_bg_color', nvertices, this.glyph.visuals.fill, 'fill')
+    const {line, fill} = this.glyph.visuals
+    attach_float(this.prog, this.vbo_linewidth, 'a_linewidth', nvertices, line, line.line_width)
+    attach_color(this.prog, this.vbo_fg_color, 'a_fg_color', nvertices, line, line.line_color, line.line_alpha)
+    attach_color(this.prog, this.vbo_bg_color, 'a_bg_color', nvertices, fill, fill.fill_color, fill.fill_alpha)
     // Static value for antialias. Smaller aa-region to obtain crisper images
     this.prog.set_uniform('u_antialias', 'float', [0.8])
   }

--- a/bokehjs/src/lib/models/plots/plot.ts
+++ b/bokehjs/src/lib/models/plots/plot.ts
@@ -94,7 +94,7 @@ export namespace Plot {
     mixins.BackgroundFill &
     mixins.BorderFill
 
-  export type Visuals = visuals.Visuals & {
+  export type Visuals = {
     outline_line: visuals.Line
     background_fill: visuals.Fill
     border_fill: visuals.Fill

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -165,7 +165,7 @@ export class PlotView extends LayoutDOMView {
     super.initialize()
 
     this.lod_started = false
-    this.visuals = new Visuals(this.model) as any // XXX
+    this.visuals = new Visuals(this) as Plot.Visuals
 
     this._initial_state = {
       selection: new Map(),               // XXX: initial selection?

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -101,6 +101,12 @@ export class GlyphRendererView extends DataRendererView {
     const decimated_glyph = mk_glyph(decimated_defaults)
     this.decimated_glyph = await this.build_glyph_view(decimated_glyph)
 
+    this.selection_glyph.set_base(this.glyph)
+    this.nonselection_glyph.set_base(this.glyph)
+    this.hover_glyph?.set_base(this.glyph)
+    this.muted_glyph?.set_base(this.glyph)
+    this.decimated_glyph.set_base(this.glyph)
+
     this.set_data(false)
   }
 

--- a/bokehjs/src/lib/models/renderers/renderer.ts
+++ b/bokehjs/src/lib/models/renderers/renderer.ts
@@ -100,7 +100,7 @@ export namespace Renderer {
     y_range_name: p.Property<string>
   }
 
-  export type Visuals = visuals.Visuals
+  export type Visuals = {}
 }
 
 export interface Renderer extends Renderer.Attrs {}

--- a/bokehjs/src/lib/models/renderers/renderer.ts
+++ b/bokehjs/src/lib/models/renderers/renderer.ts
@@ -24,7 +24,7 @@ export abstract class RendererView extends View {
 
   initialize(): void {
     super.initialize()
-    this.visuals = new visuals.Visuals(this.model)
+    this.visuals = new visuals.Visuals(this)
     this.needs_webgl_blit = false
     this._initialize_coordinates()
   }

--- a/bokehjs/test/unit/core/has_props.ts
+++ b/bokehjs/test/unit/core/has_props.ts
@@ -1,11 +1,9 @@
 import {expect} from "assertions"
 
-import {ColumnDataSource} from "@bokehjs/models/sources/column_data_source"
 import {HasProps} from "@bokehjs/core/has_props"
 import * as mixins from "@bokehjs/core/property_mixins"
 import * as p from "@bokehjs/core/properties"
 import {keys} from "@bokehjs/core/util/object"
-import {ndarray} from "@bokehjs/core/util/ndarray"
 
 class TestModel extends HasProps {}
 
@@ -60,71 +58,6 @@ class SubclassWithMultipleMixins extends HasProps {}
 SubclassWithMultipleMixins.mixins([mixins.Line, ["bar_", mixins.Text]])
 // }}}
 
-namespace SubclassWithNumberSpec {
-  export type Attrs = p.AttrsOf<Props>
-  export type Props = HasProps.Props & {
-    foo: p.NumberSpec
-    bar: p.Property<boolean>
-  }
-}
-interface SubclassWithNumberSpec extends SubclassWithNumberSpec.Attrs {}
-class SubclassWithNumberSpec extends HasProps {
-  properties: SubclassWithNumberSpec.Props
-  constructor(attrs?: Partial<SubclassWithNumberSpec.Attrs>) {
-    super(attrs)
-  }
-  static init_SubclassWithNumberSpec() {
-    this.define<SubclassWithNumberSpec.Props>(({Boolean}) => ({
-      foo: [ p.NumberSpec, {field: "colname"} ],
-      bar: [ Boolean, true ],
-    }))
-  }
-}
-
-namespace SubclassWithDistanceSpec {
-  export type Attrs = p.AttrsOf<Props>
-  export type Props = HasProps.Props & {
-    foo: p.DistanceSpec
-    bar: p.Property<boolean>
-  }
-}
-interface SubclassWithDistanceSpec extends SubclassWithDistanceSpec.Attrs {}
-class SubclassWithDistanceSpec extends HasProps {
-  properties: SubclassWithDistanceSpec.Props
-  constructor(attrs?: Partial<SubclassWithDistanceSpec.Attrs>) {
-    super(attrs)
-  }
-  static init_SubclassWithDistanceSpec() {
-    this.define<SubclassWithDistanceSpec.Props>(({Boolean}) => ({
-      foo: [ p.DistanceSpec, {field: "colname"} ],
-      bar: [ Boolean, true ],
-    }))
-  }
-}
-
-namespace SubclassWithOptionalSpec {
-  export type Attrs = p.AttrsOf<Props>
-  export type Props = HasProps.Props & {
-    foo: p.NumberSpec
-    bar: p.Property<boolean>
-    baz: p.NumberSpec
-  }
-}
-interface SubclassWithOptionalSpec extends SubclassWithOptionalSpec.Attrs {}
-class SubclassWithOptionalSpec extends HasProps {
-  properties: SubclassWithOptionalSpec.Props
-  constructor(attrs?: Partial<SubclassWithOptionalSpec.Attrs>) {
-    super(attrs)
-  }
-  static init_SubclassWithOptionalSpec() {
-    this.define<SubclassWithOptionalSpec.Props>(({Boolean}) => ({
-      foo: [ p.NumberSpec, undefined, {optional: true} ],
-      bar: [ Boolean, true ],
-      baz: [ p.NumberSpec, {field: "colname"} ],
-    }))
-  }
-}
-
 describe("core/has_props module", () => {
 
   describe("creation", () => {
@@ -161,43 +94,6 @@ describe("core/has_props module", () => {
       const obj = new SubclassWithMultipleMixins()
       const props = [...keys(mixins.Line), ...keys(mixins.Text).map((key) => `bar_${key}`)]
       expect(keys(obj.properties)).to.be.equal(props)
-    })
-  })
-
-  describe("materialize_dataspecs", () => {
-    it("should collect dataspecs", () => {
-      const r = new ColumnDataSource({data: {colname: [1, 2, 3, 4]}})
-      const obj = new SubclassWithNumberSpec()
-      const data = obj.materialize_dataspecs(r)
-      expect(data).to.be.equal({_foo: new Float32Array([1, 2, 3, 4])})
-    })
-
-    it("should collect shapes when they are present", () => {
-      const array = ndarray([1, 2, 3, 4], {shape: [2, 2]})
-      const r = new ColumnDataSource({data: {colname: array}})
-      const obj = new SubclassWithNumberSpec()
-      const data = obj.materialize_dataspecs(r)
-      expect(data).to.be.equal({_foo: ndarray([1, 2, 3, 4], {shape: [2, 2]})})
-    })
-
-    it("should collect max vals for distance specs", () => {
-      const r0 = new ColumnDataSource({data: {colname: [1, 2, 3, 4, 2]}})
-      const obj = new SubclassWithDistanceSpec()
-
-      const data0 = obj.materialize_dataspecs(r0)
-      expect(data0).to.be.equal({_foo: new Float32Array([1, 2, 3, 4, 2]), max_foo: 4})
-
-      const array1 = ndarray([1, 2, 3, 4, 2], {shape: [2, 2]})
-      const r1 = new ColumnDataSource({data: {colname: array1}})
-      const data1 = obj.materialize_dataspecs(r1)
-      expect(data1).to.be.equal({_foo: ndarray([1, 2, 3, 4, 2], {shape: [2, 2]}), max_foo: 4})
-    })
-
-    it("should collect ignore optional specs with null values", () => {
-      const r = new ColumnDataSource({data: {colname: [1, 2, 3, 4]}})
-      const obj = new SubclassWithOptionalSpec()
-      const data = obj.materialize_dataspecs(r)
-      expect(data).to.be.equal({_baz: new Float32Array([1, 2, 3, 4])})
     })
   })
 

--- a/bokehjs/test/unit/core/visuals.ts
+++ b/bokehjs/test/unit/core/visuals.ts
@@ -185,17 +185,17 @@ describe("core/visuals", () => {
 
     describe("interacting with GlyphViews", () => {
 
-      it("warm_cache(..., all_indices) should be called by the glyph view", async () => {
+      it("should get initialized with appropriate indices", async () => {
         const circle = new Circle({fill_color: {field: "fill_color"}, fill_alpha: {field: "fill_alpha"}})
         const data = {fill_color: ["red", "green", "blue"], fill_alpha: [0, 0.5, 1]}
         const renderer_view = await create_glyph_renderer_view(circle, data)
 
         const filter = new IndexFilter({indices: [1, 2]})
         renderer_view.model.view = new CDSView({source: renderer_view.model.data_source, filters: [filter]})
-        //need to manually set_data because signals for renderer aren't connected by create_glyph_view util
+        // XXX: need to manually set_data because signals for renderer aren't connected by create_glyph_view util
         renderer_view.set_data()
 
-        const {ctx} = renderer_view.layer
+        const ctx = {} as Context2d
         const glyph_view = renderer_view.glyph as CircleView
         glyph_view.visuals.fill.set_vectorize(ctx, 1)
 

--- a/bokehjs/test/unit/core/visuals.ts
+++ b/bokehjs/test/unit/core/visuals.ts
@@ -19,7 +19,8 @@ describe("Fill", () => {
         fill_alpha: 0.5,
       }
       const model = new Circle(attrs)
-      const fill = new Fill(model)
+      const view = new SomeView({model})
+      const fill = new Fill(view)
 
       const ctx = {} as Context2d
       fill.set_value(ctx)
@@ -32,21 +33,24 @@ describe("Fill", () => {
     it("should be false if fill_color is null", () => {
       const attrs = {fill_alpha: {value: 1}, fill_color: {value: null}}
       const model = new Circle(attrs)
-      const fill = new Fill(model)
+      const view = new SomeView({model})
+      const fill = new Fill(view)
       expect(fill.doit).to.be.false
     })
 
     it("should be false if fill_alpha is 0", () => {
       const attrs = {fill_alpha: {value: 0}, fill_color: {value: "red"}}
       const model = new Circle(attrs)
-      const fill = new Fill(model)
+      const view = new SomeView({model})
+      const fill = new Fill(view)
       expect(fill.doit).to.be.false
     })
 
     it("should be true otherwise", () => {
       const attrs = {fill_alpha: {value: 1}, fill_color: {value: "red"}}
       const model = new Circle(attrs)
-      const fill = new Fill(model)
+      const view = new SomeView({model})
+      const fill = new Fill(view)
       expect(fill.doit).to.be.true
     })
   })
@@ -66,7 +70,8 @@ describe("Line", () => {
         line_dash_offset: 2,
       }
       const model = new Circle(attrs)
-      const line = new Line(model)
+      const view = new SomeView({model})
+      const line = new Line(view)
 
       const ctx = {} as Context2d
       line.set_value(ctx)
@@ -84,28 +89,32 @@ describe("Line", () => {
     it("should be false if line_color is null", () => {
       const attrs = {line_alpha: {value: 1}, line_color: {value: null}, line_width: {value: 1}}
       const model = new Circle(attrs)
-      const line = new Line(model)
+      const view = new SomeView({model})
+      const line = new Line(view)
       expect(line.doit).to.be.false
     })
 
     it("should be false if line_width is 0", () => {
       const attrs = {line_alpha: {value: 1}, line_color: {value: "red"}, line_width: {value: 0}}
       const model = new Circle(attrs)
-      const line = new Line(model)
+      const view = new SomeView({model})
+      const line = new Line(view)
       expect(line.doit).to.be.false
     })
 
     it("should be false if line_alpha is 0", () => {
       const attrs = {line_alpha: {value: 0}, line_color: {value: "red"}, line_width: {value: 1}}
       const model = new Circle(attrs)
-      const line = new Line(model)
+      const view = new SomeView({model})
+      const line = new Line(view)
       expect(line.doit).to.be.false
     })
 
     it("should be true otherwise", () => {
       const attrs = {line_alpha: {value: 1}, line_color: {value: "red"}, line_width: {value: 1}}
       const model = new Circle(attrs)
-      const line = new Line(model)
+      const view = new SomeView({model})
+      const line = new Line(view)
       expect(line.doit).to.be.true
     })
   })
@@ -125,7 +134,8 @@ describe("Text", () => {
         text_baseline: "bottom" as "bottom",
       }
       const model = new text_glyph.Text(attrs)
-      const text = new Text(model)
+      const view = new SomeView({model})
+      const text = new Text(view)
 
       const ctx = {} as Context2d
       text.set_value(ctx)

--- a/bokehjs/test/unit/core/visuals.ts
+++ b/bokehjs/test/unit/core/visuals.ts
@@ -1,223 +1,206 @@
 import {expect} from "assertions"
 import {create_glyph_renderer_view} from "../models/glyphs/_util"
 
-import {Indices} from "@bokehjs/core/types"
-import {Fill, FillVector, Line, Text, Visuals} from "@bokehjs/core/visuals"
+import {Fill, Line, Text} from "@bokehjs/core/visuals"
 import {Context2d} from "@bokehjs/core/util/canvas"
-import {ColumnDataSource} from "@bokehjs/models/sources/column_data_source"
 import {CDSView} from "@bokehjs/models/sources/cds_view"
 import {IndexFilter} from "@bokehjs/models/filters/index_filter"
 import {Circle, CircleView} from "@bokehjs/models/glyphs/circle"
 import * as text_glyph from "@bokehjs/models/glyphs/text"
 
-describe("Fill", () => {
+import {Model} from "@bokehjs/model"
+import {View} from "@bokehjs/core/view"
 
-  describe("set_value", () => {
-    it("should set canvas context attributes", () => {
-      const attrs = {
-        fill_color: "red",
-        fill_alpha: 0.5,
-      }
-      const model = new Circle(attrs)
-      const view = new SomeView({model})
-      const fill = new Fill(view)
+class SomeView extends View {
+  model: Model
+}
 
-      const ctx = {} as Context2d
-      fill.set_value(ctx)
+describe("core/visuals", () => {
 
-      expect(ctx.fillStyle).to.be.equal("rgba(255, 0, 0, 0.5)")
+  describe("Fill", () => {
+
+    describe("set_value", () => {
+      it("should set canvas context attributes", () => {
+        const attrs = {
+          fill_color: "red",
+          fill_alpha: 0.5,
+        }
+        const model = new Circle(attrs)
+        const view = new SomeView({model, parent: null})
+        const fill = new Fill(view)
+
+        const ctx = {} as Context2d
+        fill.set_value(ctx)
+
+        expect(ctx.fillStyle).to.be.equal("rgba(255, 0, 0, 0.5)")
+      })
+    })
+
+    describe("doit", () => {
+      it("should be false if fill_color is null", () => {
+        const attrs = {fill_alpha: {value: 1}, fill_color: {value: null}}
+        const model = new Circle(attrs)
+        const view = new SomeView({model, parent: null})
+        const fill = new Fill(view)
+        expect(fill.doit).to.be.false
+      })
+
+      it("should be false if fill_alpha is 0", () => {
+        const attrs = {fill_alpha: {value: 0}, fill_color: {value: "red"}}
+        const model = new Circle(attrs)
+        const view = new SomeView({model, parent: null})
+        const fill = new Fill(view)
+        expect(fill.doit).to.be.false
+      })
+
+      it("should be true otherwise", () => {
+        const attrs = {fill_alpha: {value: 1}, fill_color: {value: "red"}}
+        const model = new Circle(attrs)
+        const view = new SomeView({model, parent: null})
+        const fill = new Fill(view)
+        expect(fill.doit).to.be.true
+      })
     })
   })
 
-  describe("doit", () => {
-    it("should be false if fill_color is null", () => {
-      const attrs = {fill_alpha: {value: 1}, fill_color: {value: null}}
-      const model = new Circle(attrs)
-      const view = new SomeView({model})
-      const fill = new Fill(view)
-      expect(fill.doit).to.be.false
+  describe("Line", () => {
+
+    describe("set_value", () => {
+      it("should set canvas context attributes", () =>{
+        const attrs = {
+          line_color: "red",
+          line_alpha: 0.5,
+          line_width: 2,
+          line_join: "miter" as "miter",
+          line_cap: "butt" as "butt",
+          line_dash: [1, 2],
+          line_dash_offset: 2,
+        }
+        const model = new Circle(attrs)
+        const view = new SomeView({model, parent: null})
+        const line = new Line(view)
+
+        const ctx = {} as Context2d
+        line.set_value(ctx)
+
+        expect(ctx.strokeStyle).to.be.equal("rgba(255, 0, 0, 0.5)")
+        expect(ctx.lineWidth).to.be.equal(2)
+        expect(ctx.lineJoin).to.be.equal("miter")
+        expect(ctx.lineCap).to.be.equal("butt")
+        expect(ctx.lineDash).to.be.equal([1, 2])
+        expect(ctx.lineDashOffset).to.be.equal(2)
+      })
     })
 
-    it("should be false if fill_alpha is 0", () => {
-      const attrs = {fill_alpha: {value: 0}, fill_color: {value: "red"}}
-      const model = new Circle(attrs)
-      const view = new SomeView({model})
-      const fill = new Fill(view)
-      expect(fill.doit).to.be.false
-    })
+    describe("doit", () => {
+      it("should be false if line_color is null", () => {
+        const attrs = {line_alpha: {value: 1}, line_color: {value: null}, line_width: {value: 1}}
+        const model = new Circle(attrs)
+        const view = new SomeView({model, parent: null})
+        const line = new Line(view)
+        expect(line.doit).to.be.false
+      })
 
-    it("should be true otherwise", () => {
-      const attrs = {fill_alpha: {value: 1}, fill_color: {value: "red"}}
-      const model = new Circle(attrs)
-      const view = new SomeView({model})
-      const fill = new Fill(view)
-      expect(fill.doit).to.be.true
-    })
-  })
-})
+      it("should be false if line_width is 0", () => {
+        const attrs = {line_alpha: {value: 1}, line_color: {value: "red"}, line_width: {value: 0}}
+        const model = new Circle(attrs)
+        const view = new SomeView({model, parent: null})
+        const line = new Line(view)
+        expect(line.doit).to.be.false
+      })
 
-describe("Line", () => {
+      it("should be false if line_alpha is 0", () => {
+        const attrs = {line_alpha: {value: 0}, line_color: {value: "red"}, line_width: {value: 1}}
+        const model = new Circle(attrs)
+        const view = new SomeView({model, parent: null})
+        const line = new Line(view)
+        expect(line.doit).to.be.false
+      })
 
-  describe("set_value", () => {
-    it("should set canvas context attributes", () =>{
-      const attrs = {
-        line_color: "red",
-        line_alpha: 0.5,
-        line_width: 2,
-        line_join: "miter" as "miter",
-        line_cap: "butt" as "butt",
-        line_dash: [1, 2],
-        line_dash_offset: 2,
-      }
-      const model = new Circle(attrs)
-      const view = new SomeView({model})
-      const line = new Line(view)
-
-      const ctx = {} as Context2d
-      line.set_value(ctx)
-
-      expect(ctx.strokeStyle).to.be.equal("rgba(255, 0, 0, 0.5)")
-      expect(ctx.lineWidth).to.be.equal(2)
-      expect(ctx.lineJoin).to.be.equal("miter")
-      expect(ctx.lineCap).to.be.equal("butt")
-      expect(ctx.lineDash).to.be.equal([1, 2])
-      expect(ctx.lineDashOffset).to.be.equal(2)
-    })
-  })
-
-  describe("doit", () => {
-    it("should be false if line_color is null", () => {
-      const attrs = {line_alpha: {value: 1}, line_color: {value: null}, line_width: {value: 1}}
-      const model = new Circle(attrs)
-      const view = new SomeView({model})
-      const line = new Line(view)
-      expect(line.doit).to.be.false
-    })
-
-    it("should be false if line_width is 0", () => {
-      const attrs = {line_alpha: {value: 1}, line_color: {value: "red"}, line_width: {value: 0}}
-      const model = new Circle(attrs)
-      const view = new SomeView({model})
-      const line = new Line(view)
-      expect(line.doit).to.be.false
-    })
-
-    it("should be false if line_alpha is 0", () => {
-      const attrs = {line_alpha: {value: 0}, line_color: {value: "red"}, line_width: {value: 1}}
-      const model = new Circle(attrs)
-      const view = new SomeView({model})
-      const line = new Line(view)
-      expect(line.doit).to.be.false
-    })
-
-    it("should be true otherwise", () => {
-      const attrs = {line_alpha: {value: 1}, line_color: {value: "red"}, line_width: {value: 1}}
-      const model = new Circle(attrs)
-      const view = new SomeView({model})
-      const line = new Line(view)
-      expect(line.doit).to.be.true
-    })
-  })
-})
-
-describe("Text", () => {
-
-  describe("set_value", () => {
-    it("should set canvas context attributes", () => {
-      const attrs = {
-        text_font: "times",
-        text_font_size: "16px",
-        text_font_style: "bold" as "bold",
-        text_color: "red",
-        text_alpha: 0.5,
-        text_align: "center" as "center",
-        text_baseline: "bottom" as "bottom",
-      }
-      const model = new text_glyph.Text(attrs)
-      const view = new SomeView({model})
-      const text = new Text(view)
-
-      const ctx = {} as Context2d
-      text.set_value(ctx)
-
-      expect(ctx.fillStyle).to.be.equal("rgba(255, 0, 0, 0.5)")
-      expect(ctx.textAlign).to.be.equal("center")
-      expect(ctx.textBaseline).to.be.equal("bottom")
-      expect(ctx.font).to.be.equal("bold 16px times")
+      it("should be true otherwise", () => {
+        const attrs = {line_alpha: {value: 1}, line_color: {value: "red"}, line_width: {value: 1}}
+        const model = new Circle(attrs)
+        const view = new SomeView({model, parent: null})
+        const line = new Line(view)
+        expect(line.doit).to.be.true
+      })
     })
   })
 
-  describe("doit", () => {
-    it("should be false if text_color is null", () => {
-      const attrs = {text_alpha: {value: 1}, text_color: {value: null}}
-      const model = new text_glyph.Text(attrs)
-      const text = new Text(model)
-      expect(text.doit).to.be.false
+  describe("Text", () => {
+
+    describe("set_value", () => {
+      it("should set canvas context attributes", () => {
+        const attrs = {
+          text_font: "times",
+          text_font_size: "16px",
+          text_font_style: "bold" as "bold",
+          text_color: "red",
+          text_alpha: 0.5,
+          text_align: "center" as "center",
+          text_baseline: "bottom" as "bottom",
+        }
+        const model = new text_glyph.Text(attrs)
+        const view = new SomeView({model, parent: null})
+        const text = new Text(view)
+
+        const ctx = {} as Context2d
+        text.set_value(ctx)
+
+        expect(ctx.fillStyle).to.be.equal("rgba(255, 0, 0, 0.5)")
+        expect(ctx.textAlign).to.be.equal("center")
+        expect(ctx.textBaseline).to.be.equal("bottom")
+        expect(ctx.font).to.be.equal("bold 16px times")
+      })
     })
 
-    it("should be false if text_alpha is 0", () => {
-      const attrs = {text_alpha: {value: 0}, text_color: {value: "red"}}
-      const model = new text_glyph.Text(attrs)
-      const text = new Text(model)
-      expect(text.doit).to.be.false
+    describe("doit", () => {
+      it("should be false if text_color is null", () => {
+        const attrs = {text_alpha: {value: 1}, text_color: {value: null}}
+        const model = new text_glyph.Text(attrs)
+        const view = new SomeView({model, parent: null})
+        const text = new Text(view)
+        expect(text.doit).to.be.false
+      })
+
+      it("should be false if text_alpha is 0", () => {
+        const attrs = {text_alpha: {value: 0}, text_color: {value: "red"}}
+        const model = new text_glyph.Text(attrs)
+        const view = new SomeView({model, parent: null})
+        const text = new Text(view)
+        expect(text.doit).to.be.false
+      })
+
+      it("should be true otherwise", () => {
+        const attrs = {text_alpha: {value: 1}, text_color: {value: "red"}}
+        const model = new text_glyph.Text(attrs)
+        const view = new SomeView({model, parent: null})
+        const text = new Text(view)
+        expect(text.doit).to.be.true
+      })
     })
-
-    it("should be true otherwise", () => {
-      const attrs = {text_alpha: {value: 1}, text_color: {value: "red"}}
-      const model = new text_glyph.Text(attrs)
-      const text = new Text(model)
-      expect(text.doit).to.be.true
-    })
-  })
-})
-
-describe("Visuals", () => {
-
-  it("should set the correct visual values when values are vectorized", () => {
-    const source = new ColumnDataSource({data: {fill_color: ["red", "green", "blue"], fill_alpha: [0, 0.5, 1]}})
-    const attrs = {fill_color: {field: "fill_color"}, fill_alpha: {field: "fill_alpha"}}
-
-    const circle = new Circle(attrs)
-    const visuals = new Visuals(circle) as Visuals & {fill: FillVector}
-
-    visuals.warm_cache(source)
-
-    const ctx = {} as Context2d
-    visuals.fill.set_vectorize(ctx, 1)
-    expect(ctx.fillStyle).to.be.equal("rgba(0, 128, 0, 0.5)")
   })
 
-  it("should set the correct visual values when values are vectorized and all_indices is set", () => {
-    const source = new ColumnDataSource({data: {fill_color: ["red", "green", "blue"], fill_alpha: [0, 0.5, 1]}})
-    const attrs = {fill_color: {field: "fill_color"}, fill_alpha: {field: "fill_alpha"}}
+  describe("Visuals", () => {
 
-    const circle = new Circle(attrs)
-    const visuals = new Visuals(circle) as Visuals & {fill: FillVector}
+    describe("interacting with GlyphViews", () => {
 
-    const subset = Indices.from_indices(3, [1, 2])
-    visuals.warm_cache(source, subset)
+      it("warm_cache(..., all_indices) should be called by the glyph view", async () => {
+        const circle = new Circle({fill_color: {field: "fill_color"}, fill_alpha: {field: "fill_alpha"}})
+        const data = {fill_color: ["red", "green", "blue"], fill_alpha: [0, 0.5, 1]}
+        const renderer_view = await create_glyph_renderer_view(circle, data)
 
-    const ctx = {} as Context2d
-    visuals.fill.set_vectorize(ctx, 1)
-    expect(ctx.fillStyle).to.be.equal("rgba(0, 0, 255, 1)")
-  })
+        const filter = new IndexFilter({indices: [1, 2]})
+        renderer_view.model.view = new CDSView({source: renderer_view.model.data_source, filters: [filter]})
+        //need to manually set_data because signals for renderer aren't connected by create_glyph_view util
+        renderer_view.set_data()
 
-  describe("interacting with GlyphViews", () => {
+        const {ctx} = renderer_view.layer
+        const glyph_view = renderer_view.glyph as CircleView
+        glyph_view.visuals.fill.set_vectorize(ctx, 1)
 
-    it("warm_cache(..., all_indices) should be called by the glyph view", async () => {
-      const attrs = {fill_color: {field: "fill_color"}, fill_alpha: {field: "fill_alpha"}}
-
-      const circle = new Circle(attrs)
-      const renderer_view = await create_glyph_renderer_view(circle, {fill_color: ["red", "green", "blue"], fill_alpha: [0, 0.5, 1]})
-
-      const filter = new IndexFilter({indices: [1, 2]})
-      renderer_view.model.view = new CDSView({source: renderer_view.model.data_source, filters: [filter]})
-      //need to manually set_data because signals for renderer aren't connected by create_glyph_view util
-      renderer_view.set_data()
-
-      const ctx = {} as Context2d
-      (renderer_view.glyph as CircleView).visuals.fill.set_vectorize(ctx, 1)
-      expect(ctx.fillStyle).to.be.equal("rgba(0, 0, 255, 1)")
+        expect(ctx.fillStyle).to.be.equal("rgba(0, 0, 255, 1)")
+      })
     })
   })
 })

--- a/bokehjs/test/unit/models/annotations/annotation.ts
+++ b/bokehjs/test/unit/models/annotations/annotation.ts
@@ -1,0 +1,156 @@
+import {expect} from "assertions"
+
+import {Annotation, AnnotationView} from "@bokehjs/models/annotations/annotation"
+import {Plot, PlotView} from "@bokehjs/models/plots/plot"
+import {ColumnDataSource} from "@bokehjs/models/sources/column_data_source"
+import {Arrayable} from "@bokehjs/core/types"
+import {ndarray} from "@bokehjs/core/util/ndarray"
+import {build_view} from "@bokehjs/core/build_views"
+import * as p from "@bokehjs/core/properties"
+
+class SubclassWithNumberSpecView extends AnnotationView {
+  model: SubclassWithNumberSpec
+  protected _render(): void {}
+  _foo: Arrayable<number>
+}
+namespace SubclassWithNumberSpec {
+  export type Attrs = p.AttrsOf<Props>
+  export type Props = Annotation.Props & {
+    foo: p.NumberSpec
+    bar: p.Property<boolean>
+  }
+}
+interface SubclassWithNumberSpec extends SubclassWithNumberSpec.Attrs {}
+class SubclassWithNumberSpec extends Annotation {
+  properties: SubclassWithNumberSpec.Props
+  __view_type__: SubclassWithNumberSpecView
+
+  constructor(attrs?: Partial<SubclassWithNumberSpec.Attrs>) {
+    super(attrs)
+  }
+
+  static init_SubclassWithNumberSpec() {
+    this.prototype.default_view = SubclassWithNumberSpecView
+
+    this.define<SubclassWithNumberSpec.Props>(({Boolean}) => ({
+      foo: [ p.NumberSpec, {field: "colname"} ],
+      bar: [ Boolean, true ],
+    }))
+  }
+}
+
+class SubclassWithDistanceSpecView extends AnnotationView {
+  model: SubclassWithDistanceSpec
+  protected _render(): void {}
+  _foo: Arrayable<number>
+  max_foo: number
+}
+namespace SubclassWithDistanceSpec {
+  export type Attrs = p.AttrsOf<Props>
+  export type Props = Annotation.Props & {
+    foo: p.DistanceSpec
+    bar: p.Property<boolean>
+  }
+}
+interface SubclassWithDistanceSpec extends SubclassWithDistanceSpec.Attrs {}
+class SubclassWithDistanceSpec extends Annotation {
+  properties: SubclassWithDistanceSpec.Props
+  __view_type__: SubclassWithDistanceSpecView
+
+  constructor(attrs?: Partial<SubclassWithDistanceSpec.Attrs>) {
+    super(attrs)
+  }
+
+  static init_SubclassWithDistanceSpec() {
+    this.prototype.default_view = SubclassWithDistanceSpecView
+
+    this.define<SubclassWithDistanceSpec.Props>(({Boolean}) => ({
+      foo: [ p.DistanceSpec, {field: "colname"} ],
+      bar: [ Boolean, true ],
+    }))
+  }
+}
+
+class SubclassWithOptionalSpecView extends AnnotationView {
+  model: SubclassWithOptionalSpec
+  protected _render(): void {}
+  _foo: Arrayable<number>
+  _baz: Arrayable<number>
+}
+namespace SubclassWithOptionalSpec {
+  export type Attrs = p.AttrsOf<Props>
+  export type Props = Annotation.Props & {
+    foo: p.NumberSpec
+    bar: p.Property<boolean>
+    baz: p.NumberSpec
+  }
+}
+interface SubclassWithOptionalSpec extends SubclassWithOptionalSpec.Attrs {}
+class SubclassWithOptionalSpec extends Annotation {
+  properties: SubclassWithOptionalSpec.Props
+  __view_type__: SubclassWithOptionalSpecView
+
+  constructor(attrs?: Partial<SubclassWithOptionalSpec.Attrs>) {
+    super(attrs)
+  }
+
+  static init_SubclassWithOptionalSpec() {
+    this.prototype.default_view = SubclassWithOptionalSpecView
+
+    this.define<SubclassWithOptionalSpec.Props>(({Boolean}) => ({
+      foo: [ p.NumberSpec, undefined, {optional: true} ],
+      bar: [ Boolean, true ],
+      baz: [ p.NumberSpec, {field: "colname"} ],
+    }))
+  }
+}
+
+describe("AnnotationView", () => {
+  async function plot(): Promise<PlotView> {
+    return await build_view(new Plot())
+  }
+
+  describe("set_data()", () => {
+    it("should collect dataspecs", async () => {
+      const ds = new ColumnDataSource({data: {colname: [1, 2, 3, 4]}})
+      const obj = new SubclassWithNumberSpec()
+      const view = await build_view(obj, {parent: await plot()})
+      view.set_data(ds)
+      expect(view._foo).to.be.equal(new Float32Array([1, 2, 3, 4]))
+    })
+
+    it("should collect shapes when they are present", async () => {
+      const array = ndarray([1, 2, 3, 4], {shape: [2, 2]})
+      const ds = new ColumnDataSource({data: {colname: array}})
+      const obj = new SubclassWithNumberSpec()
+      const view = await build_view(obj, {parent: await plot()})
+      view.set_data(ds)
+      expect(view._foo).to.be.equal(ndarray([1, 2, 3, 4], {shape: [2, 2]}))
+    })
+
+    it("should collect max vals for distance specs", async () => {
+      const ds0 = new ColumnDataSource({data: {colname: [1, 2, 3, 4, 2]}})
+      const obj0 = new SubclassWithDistanceSpec()
+      const view0 = await build_view(obj0, {parent: await plot()})
+      view0.set_data(ds0)
+      expect(view0._foo).to.be.equal(new Float32Array([1, 2, 3, 4, 2]))
+      expect(view0.max_foo).to.be.equal(4)
+
+      const array1 = ndarray([1, 2, 3, 4, 2], {shape: [2, 2]})
+      const ds1 = new ColumnDataSource({data: {colname: array1}})
+      const obj1 = new SubclassWithDistanceSpec()
+      const view1 = await build_view(obj1, {parent: await plot()})
+      view1.set_data(ds1)
+      expect(view1._foo).to.be.equal(ndarray([1, 2, 3, 4, 2], {shape: [2, 2]}))
+      expect(view1.max_foo).to.be.equal(4)
+    })
+
+    it("should collect ignore optional specs with null values", async () => {
+      const ds = new ColumnDataSource({data: {colname: [1, 2, 3, 4]}})
+      const obj = new SubclassWithOptionalSpec()
+      const view = await build_view(obj, {parent: await plot()})
+      view.set_data(ds)
+      expect(view._baz).to.be.equal(new Float32Array([1, 2, 3, 4]))
+    })
+  })
+})


### PR DESCRIPTION
Previously visuals were initialized twice, first by `Glyph.set_data()` and then by `Visuals.warm_cache()`. Additionally, handling of subset indices, etc., were done separately, causing bugs and regressions. Now glyphs are fully responsible for data management and visuals only apply data to a canvas context. As a side effect, visuals now apply to views and not models. Note that within a glyph, there are still separate `set_data()` and `set_visuals()`, this will be sorted out in the following 1~2 PRs.