### PR TITLE
Add support for webgl scatter rendering

### DIFF
--- a/bokehjs/src/lib/models/glyphs/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/circle.ts
@@ -1,10 +1,10 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
-import {MarkerGL, CircleGL} from "./webgl/markers"
+import {MarkerGL} from "./webgl/markers"
 import {PointGeometry, SpanGeometry, RectGeometry, PolyGeometry} from "core/geometry"
 import {LineVector, FillVector} from "core/property_mixins"
 import * as visuals from "core/visuals"
 import {Rect, NumberArray, Indices} from "core/types"
-import {RadiusDimension} from "core/enums"
+import {RadiusDimension, MarkerType} from "core/enums"
 import * as hittest from "core/hittest"
 import * as p from "core/properties"
 import {range} from "core/util/array"
@@ -38,8 +38,12 @@ export class CircleView extends XYGlyphView {
 
     const {webgl} = this.renderer.plot_view.canvas_view
     if (webgl != null) {
-      this.glglyph = new CircleGL(webgl.gl, this)
+      this.glglyph = new MarkerGL(webgl.gl, this)
     }
+  }
+
+  get_marker_type(): number {
+    return [...MarkerType].indexOf("circle")
   }
 
   protected _map_data(): void {

--- a/bokehjs/src/lib/models/glyphs/webgl/markers.frag.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/markers.frag.ts
@@ -1,4 +1,4 @@
-export const fragment_shader = (marker_code: string): string => `
+export const fragment_shader: string = `
 precision mediump float;
 const float SQRT_2 = 1.4142135623730951;
 const float PI = 3.14159265358979323846264;
@@ -7,11 +7,181 @@ uniform float u_antialias;
 //
 varying vec4  v_fg_color;
 varying vec4  v_bg_color;
+varying float v_marker_type;
 varying float v_linewidth;
 varying float v_size;
 varying vec2  v_rotation;
 
-${marker_code}
+float circle(vec2 P, float size)
+{
+    return length(P) - size/2.0;
+}
+
+float square(vec2 P, float size)
+{
+    return max(abs(P.x), abs(P.y)) - size/2.0;
+}
+
+float diamond(vec2 P, float size)
+{
+    float x = SQRT_2 / 2.0 * (P.x * 1.5 - P.y);
+    float y = SQRT_2 / 2.0 * (P.x * 1.5 + P.y);
+    float r1 = max(abs(x), abs(y)) - size / (2.0 * SQRT_2);
+    return r1 / SQRT_2;
+}
+
+float hex(vec2 P, float size)
+{
+    vec2 q = abs(P);
+    return max(q.y * 0.57735 + q.x - 1.0 * size/2.0, q.y - 0.866 * size/2.0);
+}
+
+float triangle(vec2 P, float size)
+{
+    P.y -= size * 0.3;
+    float x = SQRT_2 / 2.0 * (P.x * 1.7 - P.y);
+    float y = SQRT_2 / 2.0 * (P.x * 1.7 + P.y);
+    float r1 = max(abs(x), abs(y)) - size / 1.6;
+    float r2 = P.y;
+    return max(r1 / SQRT_2, r2);  // Intersect diamond with rectangle
+}
+
+float invertedtriangle(vec2 P, float size)
+{
+    P.y += size * 0.3;
+    float x = SQRT_2 / 2.0 * (P.x * 1.7 - P.y);
+    float y = SQRT_2 / 2.0 * (P.x * 1.7 + P.y);
+    float r1 = max(abs(x), abs(y)) - size / 1.6;
+    float r2 = - P.y;
+    return max(r1 / SQRT_2, r2);  // Intersect diamond with rectangle
+}
+
+float cross(vec2 P, float size)
+{
+    float square = max(abs(P.x), abs(P.y)) - size / 2.5;   // 2.5 is a tweak
+    float cross = min(abs(P.x), abs(P.y)) - size / 100.0;  // bit of "width" for aa
+    return max(square, cross);
+}
+
+float circlecross(vec2 P, float size)
+{
+    // Define quadrants
+    float qs = size / 2.0;  // quadrant size
+    float s1 = max(abs(P.x - qs), abs(P.y - qs)) - qs;
+    float s2 = max(abs(P.x + qs), abs(P.y - qs)) - qs;
+    float s3 = max(abs(P.x - qs), abs(P.y + qs)) - qs;
+    float s4 = max(abs(P.x + qs), abs(P.y + qs)) - qs;
+    // Intersect main shape with quadrants (to form cross)
+    float circle = length(P) - size/2.0;
+    float c1 = max(circle, s1);
+    float c2 = max(circle, s2);
+    float c3 = max(circle, s3);
+    float c4 = max(circle, s4);
+    // Union
+    return min(min(min(c1, c2), c3), c4);
+}
+
+float squarecross(vec2 P, float size)
+{
+    // Define quadrants
+    float qs = size / 2.0;  // quadrant size
+    float s1 = max(abs(P.x - qs), abs(P.y - qs)) - qs;
+    float s2 = max(abs(P.x + qs), abs(P.y - qs)) - qs;
+    float s3 = max(abs(P.x - qs), abs(P.y + qs)) - qs;
+    float s4 = max(abs(P.x + qs), abs(P.y + qs)) - qs;
+    // Intersect main shape with quadrants (to form cross)
+    float square = max(abs(P.x), abs(P.y)) - size/2.0;
+    float c1 = max(square, s1);
+    float c2 = max(square, s2);
+    float c3 = max(square, s3);
+    float c4 = max(square, s4);
+    // Union
+    return min(min(min(c1, c2), c3), c4);
+}
+
+float diamondcross(vec2 P, float size)
+{
+    // Define quadrants
+    float qs = size / 2.0;  // quadrant size
+    float s1 = max(abs(P.x - qs), abs(P.y - qs)) - qs;
+    float s2 = max(abs(P.x + qs), abs(P.y - qs)) - qs;
+    float s3 = max(abs(P.x - qs), abs(P.y + qs)) - qs;
+    float s4 = max(abs(P.x + qs), abs(P.y + qs)) - qs;
+    // Intersect main shape with quadrants (to form cross)
+    float x = SQRT_2 / 2.0 * (P.x * 1.5 - P.y);
+    float y = SQRT_2 / 2.0 * (P.x * 1.5 + P.y);
+    float diamond = max(abs(x), abs(y)) - size / (2.0 * SQRT_2);
+    diamond /= SQRT_2;
+    float c1 = max(diamond, s1);
+    float c2 = max(diamond, s2);
+    float c3 = max(diamond, s3);
+    float c4 = max(diamond, s4);
+    // Union
+    return min(min(min(c1, c2), c3), c4);
+}
+
+float x(vec2 P, float size)
+{
+    float circle = length(P) - size / 1.6;
+    float X = min(abs(P.x - P.y), abs(P.x + P.y)) - size / 100.0;  // bit of "width" for aa
+    return max(circle, X);
+}
+
+float circlex(vec2 P, float size)
+{
+    float x = P.x - P.y;
+    float y = P.x + P.y;
+    // Define quadrants
+    float qs = size / 2.0;  // quadrant size
+    float s1 = max(abs(x - qs), abs(y - qs)) - qs;
+    float s2 = max(abs(x + qs), abs(y - qs)) - qs;
+    float s3 = max(abs(x - qs), abs(y + qs)) - qs;
+    float s4 = max(abs(x + qs), abs(y + qs)) - qs;
+    // Intersect main shape with quadrants (to form cross)
+    float circle = length(P) - size/2.0;
+    float c1 = max(circle, s1);
+    float c2 = max(circle, s2);
+    float c3 = max(circle, s3);
+    float c4 = max(circle, s4);
+    // Union
+    float almost = min(min(min(c1, c2), c3), c4);
+    // In this case, the X is also outside of the main shape
+    float Xmask = length(P) - size / 1.6;  // a circle
+    float X = min(abs(P.x - P.y), abs(P.x + P.y)) - size / 100.0;  // bit of "width" for aa
+    return min(max(X, Xmask), almost);
+}
+
+float squarex(vec2 P, float size)
+{
+    float x = P.x - P.y;
+    float y = P.x + P.y;
+    // Define quadrants
+    float qs = size / 2.0;  // quadrant size
+    float s1 = max(abs(x - qs), abs(y - qs)) - qs;
+    float s2 = max(abs(x + qs), abs(y - qs)) - qs;
+    float s3 = max(abs(x - qs), abs(y + qs)) - qs;
+    float s4 = max(abs(x + qs), abs(y + qs)) - qs;
+    // Intersect main shape with quadrants (to form cross)
+    float square = max(abs(P.x), abs(P.y)) - size/2.0;
+    float c1 = max(square, s1);
+    float c2 = max(square, s2);
+    float c3 = max(square, s3);
+    float c4 = max(square, s4);
+    // Union
+    return min(min(min(c1, c2), c3), c4);
+}
+
+float asterisk(vec2 P, float size)
+{
+    // Masks
+    float diamond = max(abs(SQRT_2 / 2.0 * (P.x - P.y)), abs(SQRT_2 / 2.0 * (P.x + P.y))) - size / (2.0 * SQRT_2);
+    float square = max(abs(P.x), abs(P.y)) - size / (2.0 * SQRT_2);
+    // Shapes
+    float X = min(abs(P.x - P.y), abs(P.x + P.y)) - size / 100.0;  // bit of "width" for aa
+    float cross = min(abs(P.x), abs(P.y)) - size / 100.0;  // bit of "width" for aa
+    // Result is union of masked shapes
+    return min(max(X, diamond), max(cross, square));
+}
 
 vec4 outline(float distance, float linewidth, float antialias, vec4 fg_color, vec4 bg_color)
 {
@@ -50,206 +220,65 @@ void main()
     P = vec2(v_rotation.x*P.x - v_rotation.y*P.y,
              v_rotation.y*P.x + v_rotation.x*P.y);
     float point_size = SQRT_2*v_size  + 2.0 * (v_linewidth + 1.5*u_antialias);
-    float distance = marker(P*point_size, v_size);
+
+    int i_marker_type = int(v_marker_type);
+    float distance;
+    if (i_marker_type == 0) {         // asterisk
+        distance = asterisk(P*point_size, v_size);
+    } else if (i_marker_type == 1) {  // circle
+        distance = circle(P*point_size, v_size);
+    } else if (i_marker_type == 2) {  // circle_cross
+        distance = circlecross(P*point_size, v_size);
+    } else if (i_marker_type == 3) {  // circle_dot
+        distance = 0.0;
+    } else if (i_marker_type == 4) {  // circle_x
+        distance = circlex(P*point_size, v_size);
+    } else if (i_marker_type == 5) {  // circle_y
+        distance = 0.0;
+    } else if (i_marker_type == 6) {  // cross
+        distance = cross(P*point_size, v_size);
+    } else if (i_marker_type == 7) {  // dash
+        distance = 0.0;
+    } else if (i_marker_type == 8) {  // diamond
+        distance = diamond(P*point_size, v_size);
+    } else if (i_marker_type == 9) {  // diamond_cross
+        distance = diamondcross(P*point_size, v_size);
+    } else if (i_marker_type == 10) { // diamond_dot
+        distance = 0.0;
+    } else if (i_marker_type == 11) { // dot
+        distance = 0.0;
+    } else if (i_marker_type == 12) { // hex
+        distance = hex(P*point_size, v_size);
+    } else if (i_marker_type == 13) { // hex_dot
+        distance = 0.0;
+    } else if (i_marker_type == 14) { // inverted_triangle
+        distance = invertedtriangle(P*point_size, v_size);
+    } else if (i_marker_type == 15) { // plus
+        distance = 0.0;
+    } else if (i_marker_type == 16) { // square
+        distance = square(P*point_size, v_size);
+    } else if (i_marker_type == 17) { // square_cross
+        distance = squarecross(P*point_size, v_size);
+    } else if (i_marker_type == 18) { // square_dot
+        distance = 0.0;
+    } else if (i_marker_type == 19) { // square_pin
+        distance = 0.0;
+    } else if (i_marker_type == 20) { // square_x
+        distance = squarex(P*point_size, v_size);
+    } else if (i_marker_type == 21) { // triangle
+        distance = triangle(P*point_size, v_size);
+    } else if (i_marker_type == 22) { // triangle_dot
+        distance = 0.0;
+    } else if (i_marker_type == 23) { // triangle_pin
+        distance = 0.0;
+    } else if (i_marker_type == 24) { // x
+        distance = x(P*point_size, v_size);
+    } else if (i_marker_type == 25) { // y
+        distance = 0.0;
+    } else {
+        distance = 0.0;
+    }
+
     gl_FragColor = outline(distance, v_linewidth, u_antialias, v_fg_color, v_bg_color);
-}
-`
-
-export const circle = `
-float marker(vec2 P, float size)
-{
-    return length(P) - size/2.0;
-}
-`
-
-export const square = `
-float marker(vec2 P, float size)
-{
-    return max(abs(P.x), abs(P.y)) - size/2.0;
-}
-`
-
-export const diamond = `
-float marker(vec2 P, float size)
-{
-    float x = SQRT_2 / 2.0 * (P.x * 1.5 - P.y);
-    float y = SQRT_2 / 2.0 * (P.x * 1.5 + P.y);
-    float r1 = max(abs(x), abs(y)) - size / (2.0 * SQRT_2);
-    return r1 / SQRT_2;
-}
-`
-
-export const hex = `
-float marker(vec2 P, float size)
-{
-    vec2 q = abs(P);
-    return max(q.y * 0.57735 + q.x - 1.0 * size/2.0, q.y - 0.866 * size/2.0);
-}
-`
-
-export const triangle = `
-float marker(vec2 P, float size)
-{
-    P.y -= size * 0.3;
-    float x = SQRT_2 / 2.0 * (P.x * 1.7 - P.y);
-    float y = SQRT_2 / 2.0 * (P.x * 1.7 + P.y);
-    float r1 = max(abs(x), abs(y)) - size / 1.6;
-    float r2 = P.y;
-    return max(r1 / SQRT_2, r2);  // Intersect diamond with rectangle
-}
-`
-
-export const invertedtriangle = `
-float marker(vec2 P, float size)
-{
-    P.y += size * 0.3;
-    float x = SQRT_2 / 2.0 * (P.x * 1.7 - P.y);
-    float y = SQRT_2 / 2.0 * (P.x * 1.7 + P.y);
-    float r1 = max(abs(x), abs(y)) - size / 1.6;
-    float r2 = - P.y;
-    return max(r1 / SQRT_2, r2);  // Intersect diamond with rectangle
-}
-`
-
-export const cross = `
-float marker(vec2 P, float size)
-{
-    float square = max(abs(P.x), abs(P.y)) - size / 2.5;   // 2.5 is a tweak
-    float cross = min(abs(P.x), abs(P.y)) - size / 100.0;  // bit of "width" for aa
-    return max(square, cross);
-}
-`
-
-export const circlecross = `
-float marker(vec2 P, float size)
-{
-    // Define quadrants
-    float qs = size / 2.0;  // quadrant size
-    float s1 = max(abs(P.x - qs), abs(P.y - qs)) - qs;
-    float s2 = max(abs(P.x + qs), abs(P.y - qs)) - qs;
-    float s3 = max(abs(P.x - qs), abs(P.y + qs)) - qs;
-    float s4 = max(abs(P.x + qs), abs(P.y + qs)) - qs;
-    // Intersect main shape with quadrants (to form cross)
-    float circle = length(P) - size/2.0;
-    float c1 = max(circle, s1);
-    float c2 = max(circle, s2);
-    float c3 = max(circle, s3);
-    float c4 = max(circle, s4);
-    // Union
-    return min(min(min(c1, c2), c3), c4);
-}
-`
-
-export const squarecross = `
-float marker(vec2 P, float size)
-{
-    // Define quadrants
-    float qs = size / 2.0;  // quadrant size
-    float s1 = max(abs(P.x - qs), abs(P.y - qs)) - qs;
-    float s2 = max(abs(P.x + qs), abs(P.y - qs)) - qs;
-    float s3 = max(abs(P.x - qs), abs(P.y + qs)) - qs;
-    float s4 = max(abs(P.x + qs), abs(P.y + qs)) - qs;
-    // Intersect main shape with quadrants (to form cross)
-    float square = max(abs(P.x), abs(P.y)) - size/2.0;
-    float c1 = max(square, s1);
-    float c2 = max(square, s2);
-    float c3 = max(square, s3);
-    float c4 = max(square, s4);
-    // Union
-    return min(min(min(c1, c2), c3), c4);
-}
-`
-
-export const diamondcross = `
-float marker(vec2 P, float size)
-{
-    // Define quadrants
-    float qs = size / 2.0;  // quadrant size
-    float s1 = max(abs(P.x - qs), abs(P.y - qs)) - qs;
-    float s2 = max(abs(P.x + qs), abs(P.y - qs)) - qs;
-    float s3 = max(abs(P.x - qs), abs(P.y + qs)) - qs;
-    float s4 = max(abs(P.x + qs), abs(P.y + qs)) - qs;
-    // Intersect main shape with quadrants (to form cross)
-    float x = SQRT_2 / 2.0 * (P.x * 1.5 - P.y);
-    float y = SQRT_2 / 2.0 * (P.x * 1.5 + P.y);
-    float diamond = max(abs(x), abs(y)) - size / (2.0 * SQRT_2);
-    diamond /= SQRT_2;
-    float c1 = max(diamond, s1);
-    float c2 = max(diamond, s2);
-    float c3 = max(diamond, s3);
-    float c4 = max(diamond, s4);
-    // Union
-    return min(min(min(c1, c2), c3), c4);
-}
-`
-
-export const x = `
-float marker(vec2 P, float size)
-{
-    float circle = length(P) - size / 1.6;
-    float X = min(abs(P.x - P.y), abs(P.x + P.y)) - size / 100.0;  // bit of "width" for aa
-    return max(circle, X);
-}
-`
-
-export const circlex = `
-float marker(vec2 P, float size)
-{
-    float x = P.x - P.y;
-    float y = P.x + P.y;
-    // Define quadrants
-    float qs = size / 2.0;  // quadrant size
-    float s1 = max(abs(x - qs), abs(y - qs)) - qs;
-    float s2 = max(abs(x + qs), abs(y - qs)) - qs;
-    float s3 = max(abs(x - qs), abs(y + qs)) - qs;
-    float s4 = max(abs(x + qs), abs(y + qs)) - qs;
-    // Intersect main shape with quadrants (to form cross)
-    float circle = length(P) - size/2.0;
-    float c1 = max(circle, s1);
-    float c2 = max(circle, s2);
-    float c3 = max(circle, s3);
-    float c4 = max(circle, s4);
-    // Union
-    float almost = min(min(min(c1, c2), c3), c4);
-    // In this case, the X is also outside of the main shape
-    float Xmask = length(P) - size / 1.6;  // a circle
-    float X = min(abs(P.x - P.y), abs(P.x + P.y)) - size / 100.0;  // bit of "width" for aa
-    return min(max(X, Xmask), almost);
-}
-`
-
-export const squarex = `
-float marker(vec2 P, float size)
-{
-    float x = P.x - P.y;
-    float y = P.x + P.y;
-    // Define quadrants
-    float qs = size / 2.0;  // quadrant size
-    float s1 = max(abs(x - qs), abs(y - qs)) - qs;
-    float s2 = max(abs(x + qs), abs(y - qs)) - qs;
-    float s3 = max(abs(x - qs), abs(y + qs)) - qs;
-    float s4 = max(abs(x + qs), abs(y + qs)) - qs;
-    // Intersect main shape with quadrants (to form cross)
-    float square = max(abs(P.x), abs(P.y)) - size/2.0;
-    float c1 = max(square, s1);
-    float c2 = max(square, s2);
-    float c3 = max(square, s3);
-    float c4 = max(square, s4);
-    // Union
-    return min(min(min(c1, c2), c3), c4);
-}
-`
-
-export const asterisk = `
-float marker(vec2 P, float size)
-{
-    // Masks
-    float diamond = max(abs(SQRT_2 / 2.0 * (P.x - P.y)), abs(SQRT_2 / 2.0 * (P.x + P.y))) - size / (2.0 * SQRT_2);
-    float square = max(abs(P.x), abs(P.y)) - size / (2.0 * SQRT_2);
-    // Shapes
-    float X = min(abs(P.x - P.y), abs(P.x + P.y)) - size / 100.0;  // bit of "width" for aa
-    float cross = min(abs(P.x), abs(P.y)) - size / 100.0;  // bit of "width" for aa
-    // Result is union of masked shapes
-    return min(max(X, diamond), max(cross, square));
 }
 `

--- a/bokehjs/src/lib/models/glyphs/webgl/markers.vert.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/markers.vert.ts
@@ -12,10 +12,12 @@ attribute float a_sx;
 attribute float a_sy;
 attribute float a_size;
 attribute float a_angle;  // in radians
+attribute float a_marker_type;
 attribute float a_linewidth;
 attribute vec4  a_fg_color;
 attribute vec4  a_bg_color;
 //
+varying float v_marker_type;
 varying float v_linewidth;
 varying float v_size;
 varying vec4  v_fg_color;
@@ -25,6 +27,7 @@ varying vec2  v_rotation;
 void main (void)
 {
     v_size = a_size * u_pixel_ratio;
+    v_marker_type = a_marker_type;
     v_linewidth = a_linewidth * u_pixel_ratio;
     v_fg_color = a_fg_color;
     v_bg_color = a_bg_color;

--- a/bokehjs/src/lib/models/glyphs/webgl/utils/program.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/utils/program.ts
@@ -31,6 +31,7 @@ export class Program {
   }
 
   ATYPEINFO: {[key: string]: [number, number]} = {
+    uint8: [1, 5121],
     float: [1, 5126],
     vec2: [2, 5126],
     vec3: [3, 5126],
@@ -318,7 +319,7 @@ export class Program {
 
   _validate(): void {
     if (this._unset_variables.size) {
-      console.log(`Program has unset variables: ${this._unset_variables}`)
+      console.log(`Program has unset variables: ${[...this._unset_variables]}`)
     }
     this.gl.validateProgram(this.handle)
     if (!this.gl.getProgramParameter(this.handle, this.gl.VALIDATE_STATUS)) {

--- a/bokehjs/src/lib/models/markers/defs.ts
+++ b/bokehjs/src/lib/models/markers/defs.ts
@@ -3,7 +3,7 @@ import {MarkerType} from "core/enums"
 import {Class} from "core/class"
 import {LineVector, FillVector} from "core/visuals"
 import {Context2d} from "core/util/canvas"
-import * as glmarks from "../glyphs/webgl/markers"
+import {marker_type_gl} from "../glyphs/webgl/markers"
 
 const SQ3 = Math.sqrt(3)
 
@@ -408,11 +408,17 @@ function y(ctx: Context2d, i: number, r: number, line: LineVector, _fill: FillVe
   }
 }
 
-function _mk_model(type: string, f: RenderOne, glglyph_cls?: Class<glmarks.MarkerGL>): Class<Marker> {
+function _mk_model(type: string, f: RenderOne, marker_type: MarkerType): Class<Marker> {
   const view = class extends MarkerView {
+    initialize(): void {
+      super.initialize()
+      if (marker_type_gl[this.marker_type])
+        this._init_glglyph()
+    }
+
     static initClass(): void {
       this.prototype._render_one = f
-      this.prototype.glglyph_cls = glglyph_cls
+      this.prototype.marker_type = marker_type
     }
   }
   view.initClass()
@@ -431,31 +437,31 @@ function _mk_model(type: string, f: RenderOne, glglyph_cls?: Class<glmarks.Marke
 export type RenderOne = (ctx: Context2d, i: number, r: number, line: LineVector, fill: FillVector) => void
 
 // markers are final, so no need to export views
-export const Asterisk = _mk_model('Asterisk', asterisk, glmarks.AsteriskGL)
-export const CircleCross = _mk_model('CircleCross', circle_cross, glmarks.CircleCrossGL)
-export const CircleDot = _mk_model('CircleDot', circle_dot)
-export const CircleY = _mk_model('CircleY', circle_y)
-export const CircleX = _mk_model('CircleX', circle_x, glmarks.CircleXGL)
-export const Cross = _mk_model('Cross', cross, glmarks.CrossGL)
-export const Dash = _mk_model('Dash', dash)
-export const Diamond = _mk_model('Diamond', diamond, glmarks.DiamondGL)
-export const DiamondCross = _mk_model('DiamondCross', diamond_cross, glmarks.DiamondCrossGL)
-export const DiamondDot = _mk_model('DiamondDot', diamond_dot)
-export const Dot = _mk_model('Dot', dot)
-export const Hex = _mk_model('Hex', hex, glmarks.HexGL)
-export const HexDot = _mk_model('HexDot', hex_dot)
-export const InvertedTriangle = _mk_model('InvertedTriangle', inverted_triangle, glmarks.InvertedTriangleGL)
-export const Plus = _mk_model('Plus', plus)
-export const Square = _mk_model('Square', square, glmarks.SquareGL)
-export const SquareCross = _mk_model('SquareCross', square_cross, glmarks.SquareCrossGL)
-export const SquareDot = _mk_model('SquareDot', square_dot)
-export const SquarePin = _mk_model('SquarePin', square_pin)
-export const SquareX = _mk_model('SquareX', square_x, glmarks.SquareXGL)
-export const Triangle = _mk_model('Triangle', triangle, glmarks.TriangleGL)
-export const TriangleDot = _mk_model('TriangleDot', triangle_dot)
-export const TrianglePin = _mk_model('TrianglePin', triangle_pin)
-export const X = _mk_model('X', x, glmarks.XGL)
-export const Y = _mk_model('Y', y)
+export const Asterisk = _mk_model('Asterisk', asterisk, "asterisk")
+export const CircleCross = _mk_model('CircleCross', circle_cross, "circle_cross")
+export const CircleDot = _mk_model('CircleDot', circle_dot, "circle_dot")
+export const CircleY = _mk_model('CircleY', circle_y, "circle_y")
+export const CircleX = _mk_model('CircleX', circle_x, "circle_x")
+export const Cross = _mk_model('Cross', cross, "cross")
+export const Dash = _mk_model('Dash', dash, "dash")
+export const Diamond = _mk_model('Diamond', diamond, "diamond")
+export const DiamondCross = _mk_model('DiamondCross', diamond_cross, "diamond_cross")
+export const DiamondDot = _mk_model('DiamondDot', diamond_dot, "diamond_dot")
+export const Dot = _mk_model('Dot', dot, "dot")
+export const Hex = _mk_model('Hex', hex, "hex")
+export const HexDot = _mk_model('HexDot', hex_dot, "hex_dot")
+export const InvertedTriangle = _mk_model('InvertedTriangle', inverted_triangle, "inverted_triangle")
+export const Plus = _mk_model('Plus', plus, "plus")
+export const Square = _mk_model('Square', square, "square")
+export const SquareCross = _mk_model('SquareCross', square_cross, "square_cross")
+export const SquareDot = _mk_model('SquareDot', square_dot, "square_dot")
+export const SquarePin = _mk_model('SquarePin', square_pin, "square_pin")
+export const SquareX = _mk_model('SquareX', square_x, "square_x")
+export const Triangle = _mk_model('Triangle', triangle, "triangle")
+export const TriangleDot = _mk_model('TriangleDot', triangle_dot, "triangle_dot")
+export const TrianglePin = _mk_model('TrianglePin', triangle_pin, "triangle_pin")
+export const X = _mk_model('X', x, "x")
+export const Y = _mk_model('Y', y, "y")
 
 export const marker_funcs: {[key in MarkerType]: RenderOne} = {
   asterisk,

--- a/bokehjs/src/lib/models/markers/marker.ts
+++ b/bokehjs/src/lib/models/markers/marker.ts
@@ -1,6 +1,7 @@
 import {RenderOne} from "./defs"
 import {XYGlyph, XYGlyphView, XYGlyphData} from "../glyphs/xy_glyph"
-import type {MarkerGL} from "../glyphs/webgl/markers"
+import {MarkerGL} from "../glyphs/webgl/markers"
+import {MarkerType} from "core/enums"
 import {PointGeometry, SpanGeometry, RectGeometry, PolyGeometry} from "core/geometry"
 import {LineVector, FillVector} from "core/property_mixins"
 import * as visuals from "core/visuals"
@@ -10,7 +11,6 @@ import * as p from "core/properties"
 import {range} from "core/util/array"
 import {Context2d} from "core/util/canvas"
 import {Selection} from "../selections/selection"
-import {Class} from "core/class"
 
 export interface MarkerData extends XYGlyphData {
   _size: Arrayable<number>
@@ -26,17 +26,19 @@ export abstract class MarkerView extends XYGlyphView {
   visuals: Marker.Visuals
 
   /** @internal */
-  glglyph_cls?: Class<MarkerGL>
   glglyph?: MarkerGL
+  marker_type: MarkerType
+
+  get_marker_type(): number | Uint8Array {
+    return [...MarkerType].indexOf(this.marker_type)
+  }
 
   protected _render_one: RenderOne
 
-  initialize(): void {
-    super.initialize()
-
+  protected _init_glglyph(): void {
     const {webgl} = this.renderer.plot_view.canvas_view
-    if (webgl != null && this.glglyph_cls != null) {
-      this.glglyph = new this.glglyph_cls(webgl.gl, this)
+    if (webgl != null) {
+      this.glglyph = new MarkerGL(webgl.gl, this)
     }
   }
 

--- a/examples/webgl/marker_compare.py
+++ b/examples/webgl/marker_compare.py
@@ -4,27 +4,90 @@ This covers all markers supported by scatter. The plots are put in tabs,
 so that you can easily switch to compare positioning and appearance.
 
 """
+import random
+
 from bokeh.core.enums import MarkerType
-from bokeh.layouts import row
+from bokeh.layouts import row, column
 from bokeh.models import ColumnDataSource, Panel, Tabs
 from bokeh.plotting import figure, output_file, show
 from bokeh.sampledata.iris import flowers
 
 source = ColumnDataSource(flowers)
+n = len(source.data["petal_length"])
 
+gl_types = [
+    "asterisk", "circle", "circle_cross", "circle_x", "cross", "diamond", "diamond_cross",
+    "hex", "inverted_triangle", "square", "square_cross", "square_x", "triangle", "x",
+]
+
+u = lambda: int(random.uniform(0, 255))
+
+markers = [ random.choice(gl_types) for i in range(0, n) ]
+colors = [ "#%02x%02x%02x" % (u(), u(), u()) for i in range(0, n) ]
+
+source.data["markers"] = markers
+source.data["colors"] = colors
+
+def fig():
+    return figure(plot_width=500, plot_height=500, output_backend="webgl")
+
+def scatter():
+    p = fig()
+    p.scatter("petal_length", "petal_width", source=source, color="colors", fill_alpha=0.2, size=12, marker="markers")
+    return p
+
+def plot(f):
+    p = fig()
+    getattr(p, f)("petal_length", "petal_width", source=source, color="colors", fill_alpha=0.2, size=12)
+    return p
+
+plots = [
+    scatter(),
+    plot("asterisk"),
+    plot("circle"),
+    plot("circle_cross"),
+    #plot("circle_dot"),
+    plot("circle_x"),
+    #plot("circle_y"),
+    plot("cross"),
+    plot("diamond"),
+    #plot("diamond_dot"),
+    plot("diamond_cross"),
+    #plot("dot"),
+    plot("hex"),
+    #plot("hex_dot"),
+    plot("inverted_triangle"),
+    #plot("plus"),
+    plot("square"),
+    plot("square_cross"),
+    #plot("square_dot"),
+    #plot("square_pin"),
+    plot("square_x"),
+    plot("triangle"),
+    #plot("triangle_dot"),
+    #plot("triangle_pin"),
+    #plot("dash"),
+    plot("x"),
+    #plot("y"),
+]
+
+show(column(plots))
+#show(p)
+
+"""
 def make_plot(title, marker, backend):
     p = figure(title=title, plot_width=350, plot_height=350, output_backend=backend)
-    p.scatter("petal_length", "petal_width", source=source,
-              color='blue', fill_alpha=0.2, size=12, marker=marker)
+    p.scatter("petal_length", "petal_width", source=source, color=colors, fill_alpha=0.2, size=12, marker=markers)
     return p
 
 tabs = []
 for marker in MarkerType:
-    p1 = make_plot(marker, marker, "canvas")
-    p2 = make_plot(marker + ' SVG', marker, "svg")
+    #p1 = make_plot(marker, marker, "canvas")
+    #p2 = make_plot(marker + ' SVG', marker, "svg")
     p3 = make_plot(marker + ' GL', marker, "webgl")
-    tabs.append(Panel(child=row(p1, p2, p3), title=marker))
+    tabs.append(Panel(child=row(p3), title=marker))
 
 output_file("marker_compare.html", title="Compare regular, SVG, and WebGL markers")
 
 show(Tabs(tabs=tabs))
+"""


### PR DESCRIPTION
Proof of concept. Allows to render `Scatter` glyphs with variadic marker types. WebGL renderer is used when all used marker types support webgl. This is checked in `_set_data`. Marker glyphs share glglyph implementation with `Scatter`, but use a uniform for marker type instead of a buffer (similarly to how visuals work). Example:

![image](https://user-images.githubusercontent.com/27475/99154095-89eadb80-26ad-11eb-8b96-52e67dd253da.png)

(based on `examples/webgl/marker_compare`).

As a side effect of this work it will be possible to store glsl code unwrapped in the src tree, and wrap in build.

I would like to drop individual marker glyphs (but keep glyph functions) and just use scatter glyph in all cases. There should be no memory usage and performance difference if marker type is not resolved to an array in scalar case.

fixes #10413
