### PR TITLE
Fix backwards compatibility alias for InspectTool

### DIFF
--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -109,7 +109,7 @@ __all__ = (
     'FreehandDrawTool',
     'HelpTool',
     'HoverTool',
-    'Inspect',
+    'Inspection',
     'InspectTool',
     'Gesture',
     'GestureTool',

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -247,7 +247,7 @@ class InspectTool(GestureTool):
     """)
 
 # TODO: deprecated, remove at bokeh 3.0
-Inspect = InspectTool
+Inspection = InspectTool
 
 @abstract
 class ToolbarBase(Model):


### PR DESCRIPTION
The backwards compatibility alias was misnamed (`Inspect` instead of the actual old name `Inspection`) so that the old import no longer works and breaks downstream libraries.