### PR TITLE
Add support for Tool.description property

### DIFF
--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -149,6 +149,12 @@ class Tool(Model):
 
     '''
 
+    description = String(default=None, help="""
+    A string describing the purpose of this tool. If not defined, an auto-generated
+    description will be used. This description will be typically presented in the
+    user interface as a tooltip.
+    """)
+
     _known_aliases: tp.ClassVar[tp.Dict[str, tp.Callable[[], "Tool"]]] = {}
 
     @classmethod

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -66,6 +66,7 @@ from ..core.properties import (
     Instance,
     Int,
     List,
+    Override,
     Percent,
     Seq,
     String,
@@ -83,6 +84,7 @@ from ..core.validation.errors import (
     NO_RANGE_TOOL_RANGES,
 )
 from ..model import Model
+from ..util.deprecation import deprecated
 from ..util.string import nice_join
 from .annotations import BoxAnnotation, PolyAnnotation
 from .callbacks import Callback
@@ -486,9 +488,23 @@ class CustomAction(ActionTool):
 
     '''
 
-    action_tooltip = String(default="Perform a Custom Action", help="""
-    Tooltip displayed when hovering over the custom action icon.
-    """)
+    def __init__(self, *args, **kwargs):
+        action_tooltip = kwargs.pop("action_tooltip", None)
+        if action_tooltip is not None:
+            deprecated((2, 3, 0), "CustomAction.action_tooltip", "CustomAction.description")
+            kwargs["description"] = action_tooltip
+        super().__init__(*args, **kwargs)
+
+    @property
+    def action_tooltip(self):
+        deprecated((2, 3, 0), "CustomAction.action_tooltip", "CustomAction.description")
+        return self.description
+    @action_tooltip.setter
+    def action_tooltip(self, description):
+        deprecated((2, 3, 0), "CustomAction.action_tooltip", "CustomAction.description")
+        self.description = description
+
+    description = Override(default="Perform a Custom Action")
 
     callback = Instance(Callback, help="""
     A Bokeh callback to execute when the custom action icon is activated.
@@ -1182,9 +1198,23 @@ class HelpTool(ActionTool):
 
     '''
 
-    help_tooltip = String(default=DEFAULT_HELP_TIP, help="""
-    Tooltip displayed when hovering over the help icon.
-    """)
+    def __init__(self, *args, **kwargs):
+        help_tooltip = kwargs.pop("help_tooltip", None)
+        if help_tooltip is not None:
+            deprecated((2, 3, 0), "HelpTool.help_tooltip", "HelpTool.description")
+            kwargs["description"] = help_tooltip
+        super().__init__(*args, **kwargs)
+
+    @property
+    def help_tooltip(self):
+        deprecated((2, 3, 0), "HelpTool.help_tooltip", "HelpTool.description")
+        return self.description
+    @help_tooltip.setter
+    def help_tooltip(self, description):
+        deprecated((2, 3, 0), "HelpTool.help_tooltip", "HelpTool.description")
+        self.description = description
+
+    description = Override(default=DEFAULT_HELP_TIP)
 
     redirect = String(default=DEFAULT_HELP_URL, help="""
     Site to be redirected through upon click.
@@ -1216,9 +1246,21 @@ class EditTool(GestureTool):
 
     '''
 
-    custom_tooltip = String(None, help="""
-    A custom tooltip label to override the default name.
-    """)
+    def __init__(self, *args, **kwargs):
+        custom_tooltip = kwargs.pop("custom_tooltip", None)
+        if custom_tooltip is not None:
+            deprecated((2, 3, 0), "EditTool.custom_tooltip", "EditTool.description")
+            kwargs["description"] = custom_tooltip
+        super().__init__(*args, **kwargs)
+
+    @property
+    def custom_tooltip(self):
+        deprecated((2, 3, 0), "EditTool.custom_tooltip", "EditTool.description")
+        return self.description
+    @custom_tooltip.setter
+    def custom_tooltip(self, description):
+        deprecated((2, 3, 0), "EditTool.custom_tooltip", "EditTool.description")
+        self.description = description
 
     empty_value = Either(Bool, Int, Float, Date, Datetime, Color, String, help="""
     Defines the value to insert on non-coordinate columns when a new

--- a/bokehjs/src/lib/models/tools/actions/custom_action.ts
+++ b/bokehjs/src/lib/models/tools/actions/custom_action.ts
@@ -43,6 +43,7 @@ export class CustomAction extends ActionTool {
     this.prototype.default_view = CustomActionView
 
     this.define<CustomAction.Props>(({Any, String, Nullable}) => ({
+      /** @deprecated */
       action_tooltip: [ String, "Perform a Custom Action" ],
       callback:       [ Nullable(Any /*TODO*/) ],
       icon:           [ String ],
@@ -54,6 +55,6 @@ export class CustomAction extends ActionTool {
   button_view = CustomActionButtonView
 
   get tooltip(): string {
-    return this.action_tooltip
+    return this.description ?? this.action_tooltip
   }
 }

--- a/bokehjs/src/lib/models/tools/actions/custom_action.ts
+++ b/bokehjs/src/lib/models/tools/actions/custom_action.ts
@@ -23,7 +23,6 @@ export namespace CustomAction {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = ActionTool.Props & {
-    action_tooltip: p.Property<string>
     callback: p.Property<CallbackLike0<CustomAction> | null>
     icon: p.Property<string>
   }
@@ -43,18 +42,15 @@ export class CustomAction extends ActionTool {
     this.prototype.default_view = CustomActionView
 
     this.define<CustomAction.Props>(({Any, String, Nullable}) => ({
-      /** @deprecated */
-      action_tooltip: [ String, "Perform a Custom Action" ],
-      callback:       [ Nullable(Any /*TODO*/) ],
-      icon:           [ String ],
+      callback: [ Nullable(Any /*TODO*/) ],
+      icon:     [ String ],
     }))
+
+    this.override<CustomAction.Props>({
+      description: "Perform a Custom Action",
+    })
   }
 
   tool_name = "Custom Action"
-
   button_view = CustomActionButtonView
-
-  get tooltip(): string {
-    return this.description ?? this.action_tooltip
-  }
 }

--- a/bokehjs/src/lib/models/tools/actions/help_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/help_tool.ts
@@ -33,6 +33,7 @@ export class HelpTool extends ActionTool {
     this.prototype.default_view = HelpToolView
 
     this.define<HelpTool.Props>(({String}) => ({
+      /** @deprecated */
       help_tooltip: [ String, 'Click the question mark to learn more about Bokeh plot tools.'],
       redirect:     [ String, 'https://docs.bokeh.org/en/latest/docs/user_guide/tools.html'],
     }))
@@ -44,6 +45,6 @@ export class HelpTool extends ActionTool {
   icon = bk_tool_icon_help
 
   get tooltip(): string {
-    return this.help_tooltip
+    return this.description ?? this.help_tooltip
   }
 }

--- a/bokehjs/src/lib/models/tools/actions/help_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/help_tool.ts
@@ -14,7 +14,6 @@ export namespace HelpTool {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = ActionTool.Props & {
-    help_tooltip: p.Property<string>
     redirect: p.Property<string>
   }
 }
@@ -33,18 +32,16 @@ export class HelpTool extends ActionTool {
     this.prototype.default_view = HelpToolView
 
     this.define<HelpTool.Props>(({String}) => ({
-      /** @deprecated */
-      help_tooltip: [ String, 'Click the question mark to learn more about Bokeh plot tools.'],
-      redirect:     [ String, 'https://docs.bokeh.org/en/latest/docs/user_guide/tools.html'],
+      redirect: [ String, "https://docs.bokeh.org/en/latest/docs/user_guide/tools.html"],
     }))
+
+    this.override<HelpTool.Props>({
+      description: "Click the question mark to learn more about Bokeh plot tools.",
+    })
 
     this.register_alias("help", () => new HelpTool())
   }
 
   tool_name = "Help"
   icon = bk_tool_icon_help
-
-  get tooltip(): string {
-    return this.description ?? this.help_tooltip
-  }
 }

--- a/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
@@ -3,7 +3,7 @@ import {Dimensions} from "core/enums"
 import {scale_range} from "core/util/zoom"
 import * as p from "core/properties"
 
-export class ZoomBaseToolView extends ActionToolView {
+export abstract class ZoomBaseToolView extends ActionToolView {
   model: ZoomBaseTool
 
   doit(): void {
@@ -14,7 +14,7 @@ export class ZoomBaseToolView extends ActionToolView {
     const h_axis = dims == 'width'  || dims == 'both'
     const v_axis = dims == 'height' || dims == 'both'
 
-    const zoom_info = scale_range(frame, this.model.sign * this.model.factor, h_axis, v_axis)
+    const zoom_info = scale_range(frame, this.model.sign*this.model.factor, h_axis, v_axis)
 
     this.plot_view.state.push("zoom_out", {range: zoom_info})
     this.plot_view.update_range(zoom_info, {scrolling: true})
@@ -34,7 +34,7 @@ export namespace ZoomBaseTool {
 
 export interface ZoomBaseTool extends ZoomBaseTool.Attrs {}
 
-export class ZoomBaseTool extends ActionTool {
+export abstract class ZoomBaseTool extends ActionTool {
   properties: ZoomBaseTool.Props
   __view_type__: ZoomBaseToolView
 
@@ -43,17 +43,13 @@ export class ZoomBaseTool extends ActionTool {
   }
 
   static init_ZoomBaseTool(): void {
-    this.prototype.default_view = ZoomBaseToolView
-
     this.define<ZoomBaseTool.Props>(({Percent}) => ({
       factor:     [ Percent,    0.1    ],
       dimensions: [ Dimensions, "both" ],
     }))
   }
 
-  sign: number
-  tool_name: string
-  icon: string
+  readonly sign: -1 | 1
 
   get tooltip(): string {
     return this.description ?? this._get_dim_tooltip(this.tool_name, this.dimensions)

--- a/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
@@ -52,6 +52,6 @@ export abstract class ZoomBaseTool extends ActionTool {
   readonly sign: -1 | 1
 
   get tooltip(): string {
-    return this.description ?? this._get_dim_tooltip(this.tool_name, this.dimensions)
+    return this._get_dim_tooltip(this.dimensions)
   }
 }

--- a/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
@@ -56,6 +56,6 @@ export class ZoomBaseTool extends ActionTool {
   icon: string
 
   get tooltip(): string {
-    return this._get_dim_tooltip(this.tool_name, this.dimensions)
+    return this.description ?? this._get_dim_tooltip(this.tool_name, this.dimensions)
   }
 }

--- a/bokehjs/src/lib/models/tools/actions/zoom_in_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_in_tool.ts
@@ -1,6 +1,10 @@
 import {ZoomBaseTool, ZoomBaseToolView} from "./zoom_base_tool"
 import {bk_tool_icon_zoom_in} from "styles/icons"
 
+export class ZoomInToolView extends ZoomBaseToolView {
+  model: ZoomBaseTool
+}
+
 export interface ZoomInTool extends ZoomBaseTool.Attrs {}
 
 export class ZoomInTool extends ZoomBaseTool {
@@ -12,14 +16,14 @@ export class ZoomInTool extends ZoomBaseTool {
   }
 
   static init_ZoomInTool(): void {
-    this.prototype.default_view = ZoomBaseToolView
+    this.prototype.default_view = ZoomInToolView
 
-    this.register_alias("zoom_in", () => new ZoomInTool({dimensions: 'both'}))
-    this.register_alias("xzoom_in", () => new ZoomInTool({dimensions: 'width'}))
-    this.register_alias("yzoom_in", () => new ZoomInTool({dimensions: 'height'}))
+    this.register_alias("zoom_in", () => new ZoomInTool({dimensions: "both"}))
+    this.register_alias("xzoom_in", () => new ZoomInTool({dimensions: "width"}))
+    this.register_alias("yzoom_in", () => new ZoomInTool({dimensions: "height"}))
   }
 
-  sign = 1
+  sign = 1 as 1
   tool_name = "Zoom In"
   icon = bk_tool_icon_zoom_in
 }

--- a/bokehjs/src/lib/models/tools/actions/zoom_out_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_out_tool.ts
@@ -1,6 +1,10 @@
 import {ZoomBaseTool, ZoomBaseToolView} from "./zoom_base_tool"
 import {bk_tool_icon_zoom_out} from "styles/icons"
 
+export class ZoomOutToolView extends ZoomBaseToolView {
+  model: ZoomBaseTool
+}
+
 export interface ZoomOutTool extends ZoomBaseTool.Attrs {}
 
 export class ZoomOutTool extends ZoomBaseTool {
@@ -12,14 +16,14 @@ export class ZoomOutTool extends ZoomBaseTool {
   }
 
   static init_ZoomOutTool(): void {
-    this.prototype.default_view = ZoomBaseToolView
+    this.prototype.default_view = ZoomOutToolView
 
-    this.register_alias("zoom_out", () => new ZoomOutTool({dimensions: 'both'}))
-    this.register_alias("xzoom_out", () => new ZoomOutTool({dimensions: 'width'}))
-    this.register_alias("yzoom_out", () => new ZoomOutTool({dimensions: 'height'}))
+    this.register_alias("zoom_out", () => new ZoomOutTool({dimensions: "both"}))
+    this.register_alias("xzoom_out", () => new ZoomOutTool({dimensions: "width"}))
+    this.register_alias("yzoom_out", () => new ZoomOutTool({dimensions: "height"}))
   }
 
-  sign = -1
+  sign = -1 as -1
   tool_name = "Zoom Out"
   icon = bk_tool_icon_zoom_out
 }

--- a/bokehjs/src/lib/models/tools/button_tool.ts
+++ b/bokehjs/src/lib/models/tools/button_tool.ts
@@ -142,7 +142,7 @@ export abstract class ButtonTool extends Tool {
   button_view: Class<ButtonToolButtonView>
 
   get tooltip(): string {
-    return this.tool_name
+    return this.description ?? this.tool_name
   }
 
   get computed_icon(): string {

--- a/bokehjs/src/lib/models/tools/button_tool.ts
+++ b/bokehjs/src/lib/models/tools/button_tool.ts
@@ -4,6 +4,7 @@ import {Class} from "core/class"
 import {DOMView} from "core/dom_view"
 import {Tool, ToolView} from "./tool"
 import {empty} from "core/dom"
+import {Dimensions} from "core/enums"
 import * as p from "core/properties"
 import {startsWith} from "core/util/string"
 import {isString} from "core/util/types"
@@ -140,6 +141,18 @@ export abstract class ButtonTool extends Tool {
   icon: string
 
   button_view: Class<ButtonToolButtonView>
+
+  // utility function to return a tool name, modified
+  // by the active dimensions. Used by tools that have dimensions
+  protected _get_dim_tooltip(dims: Dimensions): string {
+    const {description, tool_name} = this
+    if (description != null)
+      return description
+    else if (dims == "both")
+      return tool_name
+    else
+      return `${tool_name} (${dims == "width" ? "x" : "y"}-axis)`
+  }
 
   get tooltip(): string {
     return this.description ?? this.tool_name

--- a/bokehjs/src/lib/models/tools/edit/edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/edit_tool.ts
@@ -188,15 +188,16 @@ export abstract class EditTool extends GestureTool {
 
   static init_EditTool(): void {
     this.define<EditTool.Props>(({Unknown, String, Array, Ref}) => ({
-      custom_icon:    [ String ],
+      /** @deprecated */
       custom_tooltip: [ String ],
+      custom_icon:    [ String ],
       empty_value:    [ Unknown ],
       renderers:      [ Array(Ref(GlyphRenderer)), [] ],
     }))
   }
 
   get tooltip(): string {
-    return this.custom_tooltip ?? this.tool_name
+    return this.description ?? this.custom_tooltip ?? this.tool_name
   }
 
   get computed_icon(): string {

--- a/bokehjs/src/lib/models/tools/edit/edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/edit_tool.ts
@@ -170,7 +170,6 @@ export namespace EditTool {
 
   export type Props = GestureTool.Props & {
     custom_icon: p.Property<string>
-    custom_tooltip: p.Property<string>
     empty_value: p.Property<unknown>
     renderers: p.Property<GlyphRenderer[]>
   }
@@ -188,16 +187,10 @@ export abstract class EditTool extends GestureTool {
 
   static init_EditTool(): void {
     this.define<EditTool.Props>(({Unknown, String, Array, Ref}) => ({
-      /** @deprecated */
-      custom_tooltip: [ String ],
-      custom_icon:    [ String ],
-      empty_value:    [ Unknown ],
-      renderers:      [ Array(Ref(GlyphRenderer)), [] ],
+      custom_icon: [ String ],
+      empty_value: [ Unknown ],
+      renderers:   [ Array(Ref(GlyphRenderer)), [] ],
     }))
-  }
-
-  get tooltip(): string {
-    return this.description ?? this.custom_tooltip ?? this.tool_name
   }
 
   get computed_icon(): string {

--- a/bokehjs/src/lib/models/tools/edit/line_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/line_edit_tool.ts
@@ -158,6 +158,6 @@ export class LineEditTool extends LineTool {
   default_order = 4
 
   get tooltip(): string {
-    return this.description ?? this._get_dim_tooltip(this.tool_name, this.dimensions)
+    return this._get_dim_tooltip(this.dimensions)
   }
 }

--- a/bokehjs/src/lib/models/tools/edit/line_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/line_edit_tool.ts
@@ -158,6 +158,6 @@ export class LineEditTool extends LineTool {
   default_order = 4
 
   get tooltip(): string {
-    return this._get_dim_tooltip(this.tool_name, this.dimensions)
+    return this.description ?? this._get_dim_tooltip(this.tool_name, this.dimensions)
   }
 }

--- a/bokehjs/src/lib/models/tools/gestures/box_select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/box_select_tool.ts
@@ -123,6 +123,6 @@ export class BoxSelectTool extends SelectTool {
   default_order = 30
 
   get tooltip(): string {
-    return this._get_dim_tooltip(this.tool_name, this.dimensions)
+    return this.description ?? this._get_dim_tooltip(this.tool_name, this.dimensions)
   }
 }

--- a/bokehjs/src/lib/models/tools/gestures/box_select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/box_select_tool.ts
@@ -123,6 +123,6 @@ export class BoxSelectTool extends SelectTool {
   default_order = 30
 
   get tooltip(): string {
-    return this.description ?? this._get_dim_tooltip(this.tool_name, this.dimensions)
+    return this._get_dim_tooltip(this.dimensions)
   }
 }

--- a/bokehjs/src/lib/models/tools/gestures/box_zoom_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/box_zoom_tool.ts
@@ -208,6 +208,6 @@ export class BoxZoomTool extends GestureTool {
   default_order = 20
 
   get tooltip(): string {
-    return this._get_dim_tooltip(this.tool_name, this.dimensions)
+    return this.description ?? this._get_dim_tooltip(this.tool_name, this.dimensions)
   }
 }

--- a/bokehjs/src/lib/models/tools/gestures/box_zoom_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/box_zoom_tool.ts
@@ -208,6 +208,6 @@ export class BoxZoomTool extends GestureTool {
   default_order = 20
 
   get tooltip(): string {
-    return this.description ?? this._get_dim_tooltip(this.tool_name, this.dimensions)
+    return this._get_dim_tooltip(this.dimensions)
   }
 }

--- a/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
@@ -164,6 +164,6 @@ export class PanTool extends GestureTool {
   default_order = 10
 
   get tooltip(): string {
-    return this.description ?? this._get_dim_tooltip(this.tool_name, this.dimensions)
+    return this._get_dim_tooltip(this.dimensions)
   }
 }

--- a/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
@@ -164,6 +164,6 @@ export class PanTool extends GestureTool {
   default_order = 10
 
   get tooltip(): string {
-    return this._get_dim_tooltip("Pan", this.dimensions)
+    return this.description ?? this._get_dim_tooltip(this.tool_name, this.dimensions)
   }
 }

--- a/bokehjs/src/lib/models/tools/gestures/wheel_pan_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/wheel_pan_tool.ts
@@ -110,6 +110,6 @@ export class WheelPanTool extends GestureTool {
   default_order = 12
 
   get tooltip(): string {
-    return this._get_dim_tooltip(this.tool_name, this.dimension)
+    return this.description ?? this._get_dim_tooltip(this.tool_name, this.dimension)
   }
 }

--- a/bokehjs/src/lib/models/tools/gestures/wheel_pan_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/wheel_pan_tool.ts
@@ -51,8 +51,6 @@ export class WheelPanToolView extends GestureToolView {
         sy1 = sy_high
         break
       }
-      default:
-        throw new Error("this shouldn't have happened")
     }
 
     const {x_scales, y_scales} = frame
@@ -110,6 +108,6 @@ export class WheelPanTool extends GestureTool {
   default_order = 12
 
   get tooltip(): string {
-    return this.description ?? this._get_dim_tooltip(this.tool_name, this.dimension)
+    return this._get_dim_tooltip(this.dimension)
   }
 }

--- a/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
@@ -95,6 +95,6 @@ export class WheelZoomTool extends GestureTool {
   default_order = 10
 
   get tooltip(): string {
-    return this.description ?? this._get_dim_tooltip(this.tool_name, this.dimensions)
+    return this._get_dim_tooltip(this.dimensions)
   }
 }

--- a/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
@@ -95,6 +95,6 @@ export class WheelZoomTool extends GestureTool {
   default_order = 10
 
   get tooltip(): string {
-    return this._get_dim_tooltip(this.tool_name, this.dimensions)
+    return this.description ?? this._get_dim_tooltip(this.tool_name, this.dimensions)
   }
 }

--- a/bokehjs/src/lib/models/tools/inspectors/crosshair_tool.ts
+++ b/bokehjs/src/lib/models/tools/inspectors/crosshair_tool.ts
@@ -98,7 +98,7 @@ export class CrosshairTool extends InspectTool {
   icon = bk_tool_icon_crosshair
 
   get tooltip(): string {
-    return this._get_dim_tooltip("Crosshair", this.dimensions)
+    return this.description ?? this._get_dim_tooltip(this.tool_name, this.dimensions)
   }
 
   get synthetic_renderers(): Renderer[] {

--- a/bokehjs/src/lib/models/tools/inspectors/crosshair_tool.ts
+++ b/bokehjs/src/lib/models/tools/inspectors/crosshair_tool.ts
@@ -98,7 +98,7 @@ export class CrosshairTool extends InspectTool {
   icon = bk_tool_icon_crosshair
 
   get tooltip(): string {
-    return this.description ?? this._get_dim_tooltip(this.tool_name, this.dimensions)
+    return this._get_dim_tooltip(this.dimensions)
   }
 
   get synthetic_renderers(): Renderer[] {

--- a/bokehjs/src/lib/models/tools/tool.ts
+++ b/bokehjs/src/lib/models/tools/tool.ts
@@ -121,6 +121,7 @@ export namespace Tool {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = Model.Props & {
+    description: p.Property<string | null>
     active: p.Property<boolean>
   }
 }
@@ -139,6 +140,10 @@ export abstract class Tool extends Model {
 
   static init_Tool(): void {
     this.prototype._known_aliases = new Map()
+
+    this.define<Tool.Props>(({String, Nullable}) => ({
+      description: [ Nullable(String), null ],
+    }))
 
     this.internal<Tool.Props>(({Boolean}) => ({
       active: [ Boolean, false ],

--- a/bokehjs/src/lib/models/tools/tool.ts
+++ b/bokehjs/src/lib/models/tools/tool.ts
@@ -156,16 +156,6 @@ export abstract class Tool extends Model {
     return []
   }
 
-  // utility function to return a tool name, modified
-  // by the active dimensions. Used by tools that have dimensions
-  protected _get_dim_tooltip(name: string, dims: Dimensions): string {
-    switch (dims) {
-      case "width":  return `${name} (x-axis)`
-      case "height": return `${name} (y-axis)`
-      case "both":   return name
-    }
-  }
-
   // utility function to get limits along both dimensions, given
   // optional dimensional constraints
   _get_dim_limits([sx0, sy0]: [number, number], [sx1, sy1]: [number, number],

--- a/bokehjs/test/unit/models/tools/actions/zoom_in_tool.ts
+++ b/bokehjs/test/unit/models/tools/actions/zoom_in_tool.ts
@@ -14,18 +14,26 @@ describe("ZoomInTool", () => {
 
     it("should create proper tooltip", () => {
       const tool = new ZoomInTool()
-      expect(tool.tooltip).to.be.equal('Zoom In')
+      expect(tool.tooltip).to.be.equal("Zoom In")
 
-      const x_tool = new ZoomInTool({dimensions: 'width'})
-      expect(x_tool.tooltip).to.be.equal('Zoom In (x-axis)')
+      const x_tool = new ZoomInTool({dimensions: "width"})
+      expect(x_tool.tooltip).to.be.equal("Zoom In (x-axis)")
 
-      const y_tool = new ZoomInTool({dimensions: 'height'})
-      expect(y_tool.tooltip).to.be.equal('Zoom In (y-axis)')
+      const y_tool = new ZoomInTool({dimensions: "height"})
+      expect(y_tool.tooltip).to.be.equal("Zoom In (y-axis)")
+
+      const tool_custom = new ZoomInTool({description: "My zoom in tool"})
+      expect(tool_custom.tooltip).to.be.equal("My zoom in tool")
+
+      const x_tool_custom = new ZoomInTool({dimensions: "width", description: "My x-zoom in tool"})
+      expect(x_tool_custom.tooltip).to.be.equal("My x-zoom in tool")
+
+      const y_tool_custom = new ZoomInTool({dimensions: "height", description: "My y-zoom in tool"})
+      expect(y_tool_custom.tooltip).to.be.equal("My y-zoom in tool")
     })
   })
 
   describe("View", () => {
-
     async function mkplot(tool: Tool): Promise<PlotView> {
       const plot = new Plot({
         x_range: new Range1d({start: -1, end: 1}),

--- a/bokehjs/test/unit/models/tools/actions/zoom_out_tool.ts
+++ b/bokehjs/test/unit/models/tools/actions/zoom_out_tool.ts
@@ -14,18 +14,26 @@ describe("ZoomOutTool", () => {
 
     it("should create proper tooltip", () => {
       const tool = new ZoomOutTool()
-      expect(tool.tooltip).to.be.equal('Zoom Out')
+      expect(tool.tooltip).to.be.equal("Zoom Out")
 
-      const x_tool = new ZoomOutTool({dimensions: 'width'})
-      expect(x_tool.tooltip).to.be.equal('Zoom Out (x-axis)')
+      const x_tool = new ZoomOutTool({dimensions: "width"})
+      expect(x_tool.tooltip).to.be.equal("Zoom Out (x-axis)")
 
-      const y_tool = new ZoomOutTool({dimensions: 'height'})
-      expect(y_tool.tooltip).to.be.equal('Zoom Out (y-axis)')
+      const y_tool = new ZoomOutTool({dimensions: "height"})
+      expect(y_tool.tooltip).to.be.equal("Zoom Out (y-axis)")
+
+      const tool_custom = new ZoomOutTool({description: "My zoom out tool"})
+      expect(tool_custom.tooltip).to.be.equal("My zoom out tool")
+
+      const x_tool_custom = new ZoomOutTool({dimensions: "width", description: "My x-zoom out tool"})
+      expect(x_tool_custom.tooltip).to.be.equal("My x-zoom out tool")
+
+      const y_tool_custom = new ZoomOutTool({dimensions: "height", description: "My y-zoom out tool"})
+      expect(y_tool_custom.tooltip).to.be.equal("My y-zoom out tool")
     })
   })
 
   describe("View", () => {
-
     async function mkplot(tool: Tool): Promise<PlotView> {
       const plot = new Plot({
         x_range: new Range1d({start: -1, end: 1}),

--- a/bokehjs/test/unit/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/box_edit_tool.ts
@@ -73,11 +73,14 @@ describe("BoxEditTool", () => {
   describe("Model", () => {
 
     it("should create proper tooltip", () => {
-      const tool = new BoxEditTool()
-      expect(tool.tooltip).to.be.equal('Box Edit Tool')
+      const tool0 = new BoxEditTool()
+      expect(tool0.tooltip).to.be.equal("Box Edit Tool")
 
-      const custom_tool = new BoxEditTool({custom_tooltip: 'Box Edit Custom'})
-      expect(custom_tool.tooltip).to.be.equal('Box Edit Custom')
+      const tool1 = new BoxEditTool({description: "My Box Edit"})
+      expect(tool1.tooltip).to.be.equal("My Box Edit")
+
+      const tool2 = new BoxEditTool({custom_tooltip: "Box Edit Custom"})
+      expect(tool2.tooltip).to.be.equal("Box Edit Custom")
     })
   })
 

--- a/bokehjs/test/unit/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/box_edit_tool.ts
@@ -78,9 +78,6 @@ describe("BoxEditTool", () => {
 
       const tool1 = new BoxEditTool({description: "My Box Edit"})
       expect(tool1.tooltip).to.be.equal("My Box Edit")
-
-      const tool2 = new BoxEditTool({custom_tooltip: "Box Edit Custom"})
-      expect(tool2.tooltip).to.be.equal("Box Edit Custom")
     })
   })
 

--- a/bokehjs/test/unit/models/tools/edit/freehand_draw_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/freehand_draw_tool.ts
@@ -70,11 +70,14 @@ describe("FreehandDrawTool", () => {
   describe("Model", () => {
 
     it("should create proper tooltip", () => {
-      const tool = new FreehandDrawTool()
-      expect(tool.tooltip).to.be.equal('Freehand Draw Tool')
+      const tool0 = new FreehandDrawTool()
+      expect(tool0.tooltip).to.be.equal("Freehand Draw Tool")
 
-      const custom_tool = new FreehandDrawTool({custom_tooltip: 'Freehand Draw Custom'})
-      expect(custom_tool.tooltip).to.be.equal('Freehand Draw Custom')
+      const tool1 = new FreehandDrawTool({description: "My Freehand Draw"})
+      expect(tool1.tooltip).to.be.equal("My Freehand Draw")
+
+      const tool2 = new FreehandDrawTool({custom_tooltip: "Freehand Draw Custom"})
+      expect(tool2.tooltip).to.be.equal("Freehand Draw Custom")
     })
   })
 

--- a/bokehjs/test/unit/models/tools/edit/freehand_draw_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/freehand_draw_tool.ts
@@ -75,9 +75,6 @@ describe("FreehandDrawTool", () => {
 
       const tool1 = new FreehandDrawTool({description: "My Freehand Draw"})
       expect(tool1.tooltip).to.be.equal("My Freehand Draw")
-
-      const tool2 = new FreehandDrawTool({custom_tooltip: "Freehand Draw Custom"})
-      expect(tool2.tooltip).to.be.equal("Freehand Draw Custom")
     })
   })
 

--- a/bokehjs/test/unit/models/tools/edit/point_draw_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/point_draw_tool.ts
@@ -66,11 +66,14 @@ describe("PointDrawTool", (): void => {
   describe("Model", () => {
 
     it("should create proper tooltip", () => {
-      const tool = new PointDrawTool()
-      expect(tool.tooltip).to.be.equal('Point Draw Tool')
+      const tool0 = new PointDrawTool()
+      expect(tool0.tooltip).to.be.equal("Point Draw Tool")
 
-      const custom_tool = new PointDrawTool({custom_tooltip: 'Point Draw Custom'})
-      expect(custom_tool.tooltip).to.be.equal('Point Draw Custom')
+      const tool1 = new PointDrawTool({description: "My Point Draw"})
+      expect(tool1.tooltip).to.be.equal("My Point Draw")
+
+      const tool2 = new PointDrawTool({custom_tooltip: "Point Draw Custom"})
+      expect(tool2.tooltip).to.be.equal("Point Draw Custom")
     })
   })
 

--- a/bokehjs/test/unit/models/tools/edit/point_draw_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/point_draw_tool.ts
@@ -71,9 +71,6 @@ describe("PointDrawTool", (): void => {
 
       const tool1 = new PointDrawTool({description: "My Point Draw"})
       expect(tool1.tooltip).to.be.equal("My Point Draw")
-
-      const tool2 = new PointDrawTool({custom_tooltip: "Point Draw Custom"})
-      expect(tool2.tooltip).to.be.equal("Point Draw Custom")
     })
   })
 

--- a/bokehjs/test/unit/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/poly_draw_tool.ts
@@ -71,11 +71,14 @@ describe("PolyDrawTool", (): void => {
   describe("Model", () => {
 
     it("should create proper tooltip", () => {
-      const tool = new PolyDrawTool()
-      expect(tool.tooltip).to.be.equal('Polygon Draw Tool')
+      const tool0 = new PolyDrawTool()
+      expect(tool0.tooltip).to.be.equal("Polygon Draw Tool")
 
-      const custom_tool = new PolyDrawTool({custom_tooltip: 'Poly Draw Custom'})
-      expect(custom_tool.tooltip).to.be.equal('Poly Draw Custom')
+      const tool1 = new PolyDrawTool({description: "My Poly Draw"})
+      expect(tool1.tooltip).to.be.equal("My Poly Draw")
+
+      const tool2 = new PolyDrawTool({custom_tooltip: "Poly Draw Custom"})
+      expect(tool2.tooltip).to.be.equal("Poly Draw Custom")
     })
   })
 

--- a/bokehjs/test/unit/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/poly_draw_tool.ts
@@ -76,9 +76,6 @@ describe("PolyDrawTool", (): void => {
 
       const tool1 = new PolyDrawTool({description: "My Poly Draw"})
       expect(tool1.tooltip).to.be.equal("My Poly Draw")
-
-      const tool2 = new PolyDrawTool({custom_tooltip: "Poly Draw Custom"})
-      expect(tool2.tooltip).to.be.equal("Poly Draw Custom")
     })
   })
 

--- a/bokehjs/test/unit/models/tools/edit/poly_edit_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/poly_edit_tool.ts
@@ -90,11 +90,14 @@ describe("PolyEditTool", (): void => {
   describe("Model", () => {
 
     it("should create proper tooltip", () => {
-      const tool = new PolyEditTool()
-      expect(tool.tooltip).to.be.equal('Poly Edit Tool')
+      const tool0 = new PolyEditTool()
+      expect(tool0.tooltip).to.be.equal("Poly Edit Tool")
 
-      const custom_tool = new PolyEditTool({custom_tooltip: 'Poly Edit Custom'})
-      expect(custom_tool.tooltip).to.be.equal('Poly Edit Custom')
+      const tool1 = new PolyEditTool({description: "My Poly Edit"})
+      expect(tool1.tooltip).to.be.equal("My Poly Edit")
+
+      const tool2 = new PolyEditTool({custom_tooltip: "Poly Edit Custom"})
+      expect(tool2.tooltip).to.be.equal("Poly Edit Custom")
     })
   })
 

--- a/bokehjs/test/unit/models/tools/edit/poly_edit_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/poly_edit_tool.ts
@@ -95,9 +95,6 @@ describe("PolyEditTool", (): void => {
 
       const tool1 = new PolyEditTool({description: "My Poly Edit"})
       expect(tool1.tooltip).to.be.equal("My Poly Edit")
-
-      const tool2 = new PolyEditTool({custom_tooltip: "Poly Edit Custom"})
-      expect(tool2.tooltip).to.be.equal("Poly Edit Custom")
     })
   })
 

--- a/bokehjs/test/unit/models/tools/gestures/box_zoom_tool.ts
+++ b/bokehjs/test/unit/models/tools/gestures/box_zoom_tool.ts
@@ -13,18 +13,26 @@ describe("BoxZoomTool", () => {
 
     it("should create proper tooltip", () => {
       const tool = new BoxZoomTool()
-      expect(tool.tooltip).to.be.equal('Box Zoom')
+      expect(tool.tooltip).to.be.equal("Box Zoom")
 
-      const x_tool = new BoxZoomTool({dimensions: 'width'})
-      expect(x_tool.tooltip).to.be.equal('Box Zoom (x-axis)')
+      const x_tool = new BoxZoomTool({dimensions: "width"})
+      expect(x_tool.tooltip).to.be.equal("Box Zoom (x-axis)")
 
-      const y_tool = new BoxZoomTool({dimensions: 'height'})
-      expect(y_tool.tooltip).to.be.equal('Box Zoom (y-axis)')
+      const y_tool = new BoxZoomTool({dimensions: "height"})
+      expect(y_tool.tooltip).to.be.equal("Box Zoom (y-axis)")
+
+      const tool_custom = new BoxZoomTool({description: "My box zoom tool"})
+      expect(tool_custom.tooltip).to.be.equal("My box zoom tool")
+
+      const x_tool_custom = new BoxZoomTool({dimensions: "width", description: "My box x-zoom tool"})
+      expect(x_tool_custom.tooltip).to.be.equal("My box x-zoom tool")
+
+      const y_tool_custom = new BoxZoomTool({dimensions: "height", description: "My box y-zoom tool"})
+      expect(y_tool_custom.tooltip).to.be.equal("My box y-zoom tool")
     })
   })
 
   describe("View", () => {
-
     async function mkplot(tool: Tool): Promise<PlotView> {
       const plot = new Plot({
         x_range: new Range1d({start: -1, end: 1}),

--- a/bokehjs/test/unit/models/tools/gestures/wheel_pan_tool.ts
+++ b/bokehjs/test/unit/models/tools/gestures/wheel_pan_tool.ts
@@ -12,16 +12,21 @@ describe("WheelPanTool", () => {
   describe("Model", () => {
 
     it("should create proper tooltip", () => {
-      const x_tool = new WheelPanTool({dimension: 'width'})
-      expect(x_tool.tooltip).to.be.equal('Wheel Pan (x-axis)')
+      const x_tool = new WheelPanTool({dimension: "width"})
+      expect(x_tool.tooltip).to.be.equal("Wheel Pan (x-axis)")
 
-      const y_tool = new WheelPanTool({dimension: 'height'})
-      expect(y_tool.tooltip).to.be.equal('Wheel Pan (y-axis)')
+      const y_tool = new WheelPanTool({dimension: "height"})
+      expect(y_tool.tooltip).to.be.equal("Wheel Pan (y-axis)")
+
+      const x_tool_custom = new WheelPanTool({dimension: "width", description: "My wheel x-pan tool"})
+      expect(x_tool_custom.tooltip).to.be.equal("My wheel x-pan tool")
+
+      const y_tool_custom = new WheelPanTool({dimension: "height", description: "My wheel y-pan tool"})
+      expect(y_tool_custom.tooltip).to.be.equal("My wheel y-pan tool")
     })
   })
 
   describe("View", () => {
-
     async function mkplot(tool: Tool): Promise<PlotView> {
       const plot = new Plot({
         x_range: new Range1d({start: 0, end: 1}),

--- a/bokehjs/test/unit/models/tools/gestures/wheel_zoom_tool.ts
+++ b/bokehjs/test/unit/models/tools/gestures/wheel_zoom_tool.ts
@@ -13,18 +13,26 @@ describe("WheelZoomTool", () => {
 
     it("should create proper tooltip", () => {
       const tool = new WheelZoomTool()
-      expect(tool.tooltip).to.be.equal('Wheel Zoom')
+      expect(tool.tooltip).to.be.equal("Wheel Zoom")
 
-      const x_tool = new WheelZoomTool({dimensions: 'width'})
-      expect(x_tool.tooltip).to.be.equal('Wheel Zoom (x-axis)')
+      const x_tool = new WheelZoomTool({dimensions: "width"})
+      expect(x_tool.tooltip).to.be.equal("Wheel Zoom (x-axis)")
 
-      const y_tool = new WheelZoomTool({dimensions: 'height'})
-      expect(y_tool.tooltip).to.be.equal('Wheel Zoom (y-axis)')
+      const y_tool = new WheelZoomTool({dimensions: "height"})
+      expect(y_tool.tooltip).to.be.equal("Wheel Zoom (y-axis)")
+
+      const tool_custom = new WheelZoomTool({description: "My wheel zoom tool"})
+      expect(tool_custom.tooltip).to.be.equal("My wheel zoom tool")
+
+      const x_tool_custom = new WheelZoomTool({dimensions: "width", description: "My wheel x-zoom tool"})
+      expect(x_tool_custom.tooltip).to.be.equal("My wheel x-zoom tool")
+
+      const y_tool_custom = new WheelZoomTool({dimensions: "height", description: "My wheel y-zoom tool"})
+      expect(y_tool_custom.tooltip).to.be.equal("My wheel y-zoom tool")
     })
   })
 
   describe("View", () => {
-
     // Note default plot dimensions is 600 x 600 (height x width)
     // This is why zooming at {sx: 300, sy: 300} causes the x/y ranges to zoom equally
     async function mkplot(tool: Tool): Promise<PlotView> {

--- a/sphinx/source/docs/releases/2.3.0.rst
+++ b/sphinx/source/docs/releases/2.3.0.rst
@@ -54,3 +54,8 @@ Previously ``Line``, ``Fill``, ``Text`` and ``Hatch`` visuals were used in primi
 scalar and vector contexts. Those were split and now context-specific visuals, e.g.,
 ``Line``, ``LineScalar`` and ``LineVector`` have to used in respective contexts. This
 aligns visuals with mixins, among other things.
+
+``EditTool.custom_tooltip``, ``HelpTool.help_tooltip`` and ``CustomAction.action_tooltip`` were deprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use ``Tool.description`` instead, which can also be used with all other types tools.


### PR DESCRIPTION
This PR also deprecates all "custom" description/tooltip properties, i.e. `action_tooltip`, `help_tooltip`, `custom_tooltip`.

fixes #10662