### PR TITLE
Update vertex_renderer properly in PolyEditTool

### DIFF
--- a/bokehjs/src/lib/models/tools/edit/poly_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_edit_tool.ts
@@ -85,8 +85,8 @@ export class PolyEditToolView extends PolyToolView {
     const index = this._cur_index
     const [xkey, ykey] = [glyph.xs.field, glyph.ys.field]
 
-    if ((index === null) && (xkey || ykey))
-      return
+    if (this._drawing) return
+    if ((index === null) && (xkey || ykey)) return
 
     let xs: number[]
     let ys: number[]

--- a/bokehjs/src/lib/models/tools/edit/poly_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_edit_tool.ts
@@ -59,8 +59,7 @@ export class PolyEditToolView extends PolyToolView {
 
     const vsync_renderer = this.model.renderers[0]
     const vsync_updater = () => this._update_vertices(vsync_renderer)
-    let vsync_ds = null
-    if (vsync_renderer !== undefined) vsync_ds = vsync_renderer.data_source
+    const vsync_ds = vsync_renderer?.data_source
 
     const renderers = this._select_event(ev, "replace", this.model.renderers)
     if (!renderers.length) {
@@ -68,11 +67,11 @@ export class PolyEditToolView extends PolyToolView {
       this._selected_renderer = null
       this._drawing = false
       this._cur_index = null
-      if (vsync_ds !== null)
+      if (vsync_ds != null)
         vsync_ds.disconnect(vsync_ds.properties.data.change, vsync_updater)
       return
     }
-    if (vsync_ds !== null)
+    if (vsync_ds != null)
       vsync_ds.connect(vsync_ds.properties.data.change, vsync_updater)
 
     this._cur_index = renderers[0].data_source.selected.indices[0]
@@ -86,11 +85,11 @@ export class PolyEditToolView extends PolyToolView {
     const [xkey, ykey] = [glyph.xs.field, glyph.ys.field]
 
     if (this._drawing) return
-    if ((index === null) && (xkey || ykey)) return
+    if ((index == null) && (xkey || ykey)) return
 
     let xs: number[]
     let ys: number[]
-    if (xkey && index !== null) {  // redundant xkey null check to satisfy build-time checks
+    if (xkey && index != null) {  // redundant xkey null check to satisfy build-time checks
       xs = cds.data[xkey][index]
       if (!isArray(xs))
         cds.data[xkey][index] = xs = Array.from(xs)
@@ -98,7 +97,7 @@ export class PolyEditToolView extends PolyToolView {
       xs = glyph.xs.value
     }
 
-    if (ykey && index !== null) {
+    if (ykey && index != null) {
       ys = cds.data[ykey][index]
       if (!isArray(ys))
         cds.data[ykey][index] = ys = Array.from(ys)

--- a/bokehjs/src/lib/models/tools/edit/poly_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_edit_tool.ts
@@ -18,6 +18,7 @@ export class PolyEditToolView extends PolyToolView {
   _selected_renderer: GlyphRenderer | null
   _basepoint: [number, number] | null
   _drawing: boolean = false
+  _cur_index: number | null = null
 
   _doubletap(ev: TapEvent): void {
     if (!this.model.active)
@@ -66,25 +67,30 @@ export class PolyEditToolView extends PolyToolView {
       this._set_vertices([], [])
       this._selected_renderer = null
       this._drawing = false
-      if (vsync_ds !== null) vsync_ds.disconnect(vsync_ds.properties.data.change, vsync_updater)
+      this._cur_index = null
+      if (vsync_ds !== null)
+        vsync_ds.disconnect(vsync_ds.properties.data.change, vsync_updater)
       return
     }
-    if (vsync_ds !== null) vsync_ds.connect(vsync_ds.properties.data.change, vsync_updater)
+    if (vsync_ds !== null)
+      vsync_ds.connect(vsync_ds.properties.data.change, vsync_updater)
+
+    this._cur_index = renderers[0].data_source.selected.indices[0]
     this._update_vertices(renderers[0])
   }
 
   _update_vertices(renderer: GlyphRenderer): void {
     const glyph: any = renderer.glyph
     const cds = renderer.data_source
-    const index = cds.selected.indices[0]
+    const index = this._cur_index
     const [xkey, ykey] = [glyph.xs.field, glyph.ys.field]
 
-    if ((index === undefined) && (xkey || ykey))
+    if ((index === null) && (xkey || ykey))
       return
 
     let xs: number[]
     let ys: number[]
-    if (xkey) {
+    if (xkey && index !== null) {  // redundant xkey null check to satisfy build-time checks
       xs = cds.data[xkey][index]
       if (!isArray(xs))
         cds.data[xkey][index] = xs = Array.from(xs)
@@ -92,7 +98,7 @@ export class PolyEditToolView extends PolyToolView {
       xs = glyph.xs.value
     }
 
-    if (ykey) {
+    if (ykey && index !== null) {
       ys = cds.data[ykey][index]
       if (!isArray(ys))
         cds.data[ykey][index] = ys = Array.from(ys)

--- a/tests/integration/tools/test_poly_edit_tool.py
+++ b/tests/integration/tools/test_poly_edit_tool.py
@@ -19,7 +19,6 @@ import pytest ; pytest
 import time
 
 # External imports
-from flaky import flaky
 
 # Bokeh imports
 from bokeh._testing.util.compare import cds_data_almost_equal

--- a/tests/integration/tools/test_poly_edit_tool.py
+++ b/tests/integration/tools/test_poly_edit_tool.py
@@ -63,10 +63,10 @@ def _make_plot():
     return plot
 
 def _make_server_plot(expected):
+    data = {"xs": [[1, 2], [1.6, 2.45]],
+            "ys": [[1, 1], [1.5, 0.75]]}
+    source = ColumnDataSource(data)
     def modify_doc(doc):
-        data = {"xs": [[1, 2], [1.6, 2.45]],
-                "ys": [[1, 1], [1.5, 0.75]]}
-        source = ColumnDataSource(data)
         plot = Plot(plot_height=400, plot_width=400, x_range=Range1d(0, 3), y_range=Range1d(0, 3), min_border=0)
         renderer = plot.add_glyph(source, MultiLine(xs='xs', ys='ys'))
         tool = PolyEditTool(renderers=[renderer])
@@ -78,18 +78,21 @@ def _make_server_plot(expected):
         plot.toolbar_sticky = False
         div = Div(text='False')
         def cb(attr, old, new):
-            if cds_data_almost_equal(new, expected):
-                div.text = 'True'
+            try:
+                if cds_data_almost_equal(new, expected):
+                    div.text = 'True'
+            except ValueError:
+                return
         source.on_change('data', cb)
         code = RECORD("matches", "div.text")
         plot.add_tools(CustomAction(callback=CustomJS(args=dict(div=div), code=code)))
         doc.add_root(column(plot, div))
-    return modify_doc
+    return modify_doc, source
 
 
 @pytest.mark.selenium
 class Test_PolyEditTool:
-    def _test_selected_by_default(self, single_plot_page):
+    def test_selected_by_default(self, single_plot_page):
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -99,7 +102,7 @@ class Test_PolyEditTool:
 
         assert page.has_no_console_errors()
 
-    def _test_can_be_deselected_and_selected(self, single_plot_page):
+    def test_can_be_deselected_and_selected(self, single_plot_page):
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -120,7 +123,7 @@ class Test_PolyEditTool:
 
         assert page.has_no_console_errors()
 
-    def _test_double_click_triggers_edit(self, single_plot_page):
+    def test_double_click_triggers_edit(self, single_plot_page):
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -134,13 +137,13 @@ class Test_PolyEditTool:
         time.sleep(0.5)
         page.click_custom_action()
 
-        expected = {'xs': [[1, 2], [1.6, 2.45, 2.027027027027027, 1.6]],
-                    'ys': [[1, 1], [1.5, 0.75, 1.8749999999999998, 1.5]]}
+        expected = {'xs': [[1, 2], [1.6, 2.45, 2.027027027027027]],
+                    'ys': [[1, 1], [1.5, 0.75, 1.8749999999999998]]}
         assert cds_data_almost_equal(page.results, expected)
 
         assert page.has_no_console_errors()
 
-    def _test_double_click_snaps_to_vertex(self, single_plot_page):
+    def test_double_click_snaps_to_vertex(self, single_plot_page):
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -162,7 +165,7 @@ class Test_PolyEditTool:
 
         assert page.has_no_console_errors()
 
-    def _test_drag_moves_vertex(self, single_plot_page):
+    def test_drag_moves_vertex(self, single_plot_page):
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -185,7 +188,7 @@ class Test_PolyEditTool:
 
         assert page.has_no_console_errors()
 
-    def _test_backspace_removes_vertex(self, single_plot_page):
+    def test_backspace_removes_vertex(self, single_plot_page):
         plot = _make_plot()
 
         page = single_plot_page(plot)
@@ -206,14 +209,12 @@ class Test_PolyEditTool:
         expected = {"xs": [[1, 2], [1.6, 2.027027027027027]],
                     "ys": [[1, 1], [1.5, 1.8749999999999998]]}
         assert cds_data_almost_equal(page.results, expected)
-
         assert page.has_no_console_errors()
 
-    @flaky(max_runs=10)
-    def _test_poly_edit_syncs_to_server(self, bokeh_server_page):
+    def test_poly_edit_syncs_to_server(self, bokeh_server_page):
         expected = {'xs': [[1, 2], [1.6, 2.45, 2.027027027027027]],
                     'ys': [[1, 1], [1.5, 0.75, 1.8749999999999998]]}
-        page = bokeh_server_page(_make_server_plot(expected))
+        page = bokeh_server_page(_make_server_plot(expected)[0])
 
         # ensure double clicking shows vertices and edits them
         page.double_click_canvas_at_position(200, 200)
@@ -225,13 +226,13 @@ class Test_PolyEditTool:
 
         page.click_custom_action()
         assert page.results == {"matches": "True"}
+        assert page.has_no_console_errors()
 
-    @flaky(max_runs=10)
-    def _test_poly_drag_syncs_to_server(self, bokeh_server_page):
+    def test_poly_drag_syncs_to_server(self, bokeh_server_page):
         expected = {"xs": [[1, 2], [1.6, 2.45, 2.5945945945945947]],
                     "ys": [[1, 1], [1.5, 0.75, 1.5]]}
 
-        page = bokeh_server_page(_make_server_plot(expected))
+        page = bokeh_server_page(_make_server_plot(expected)[0])
 
         # ensure drag moves vertex
         page.double_click_canvas_at_position(200, 200)
@@ -246,14 +247,40 @@ class Test_PolyEditTool:
 
         page.click_custom_action()
         assert page.results == {"matches": "True"}
+        assert page.has_no_console_errors()
 
-    # TODO (bev) Fix up after GH CI switch
-    @pytest.mark.skip
-    @flaky(max_runs=10)
+    def test_poly_drag_sync_after_source_edit(self, bokeh_server_page):
+        expected = {"xs": [[1, 2], [1.6, 2.45, 2.5945945945945947]],
+                    "ys": [[1, 1], [1.5, 0.75, 1.5]]}
+
+        mod, ds = _make_server_plot(expected)
+        page = bokeh_server_page(mod)
+
+        # ensure drag moves vertex
+        page.double_click_canvas_at_position(200, 200)
+        time.sleep(0.5)
+        page.double_click_canvas_at_position(298, 298)
+        time.sleep(0.5)
+        page.click_canvas_at_position(250, 150)
+        time.sleep(0.5)
+        page.send_keys("\ue00c")  # Escape
+        time.sleep(0.5)
+
+        def f(): ds.data = dict(ds.data)  # update the data source
+        ds.document.add_next_tick_callback(f)
+        time.sleep(0.5)
+
+        page.drag_canvas_at_position(250, 150, 70, 50)
+        time.sleep(0.5)
+
+        page.click_custom_action()
+        assert page.results == {"matches": "True"}
+        assert page.has_no_console_errors()
+
     def test_poly_delete_syncs_to_server(self, bokeh_server_page) -> None:
         expected = {"xs": [[1, 2], [1.6, 2.027027027027027]],
                     "ys": [[1, 1], [1.5, 1.8749999999999998]]}
-        page = bokeh_server_page(_make_server_plot(expected))
+        page = bokeh_server_page(_make_server_plot(expected)[0])
 
         # ensure backspace removes vertex
         page.double_click_canvas_at_position(200, 200)
@@ -269,3 +296,4 @@ class Test_PolyEditTool:
 
         page.click_custom_action()
         assert page.results == {"matches": "True"}
+        assert page.has_no_console_errors()


### PR DESCRIPTION
Proposed (partial) fix for #10670

This adds a listener to the PolyEditTool's first renderer's data source.  The listener updates the `vertex_renderer` appropriately when the data source is updated.

An alternative implementation would add such listeners to _all_ of the renderers present, rather than just the first.  However, I don't think this is required, because:
1) In most (all?) use cases, all the renderers will share the same data source
2) It will always be possible to update the `vertex_renderer` appropriately via the first renderer's data source

This is a partial fix, as it doesn't cover the edge case where you want to change the length of the data source (i.e the number of points) while simultaneously editing with the PolyEditTool.  In this case, #10670 persists in the same manner, and you have to double click the line to fix it.  I think this is a relatively uncommon use case, and it's not made worse due to this PR.  With that being said, perhaps I've misunderstood how the internal logic is supposed to work, giving rise to this behavior.  

Please let me know what you think of this approach and if there are any improvements you'd like me to take a look at.  Thanks!