### PR TITLE
Add support for publishing npm packages

### DIFF
--- a/release/build.py
+++ b/release/build.py
@@ -87,11 +87,11 @@ def install_bokehjs(config: Config, system: System) -> ActionReturn:
 def npm_install(config: Config, system: System) -> ActionReturn:
     try:
         system.cd("bokehjs")
-        system.run("npm install")
+        system.run("npm ci")
         system.cd("..")
-        return PASSED("npm install succeeded")
+        return PASSED("npm ci succeeded")
     except RuntimeError as e:
-        return FAILED("npm install did NOT succeed", details=e.args)
+        return FAILED("npm ci did NOT succeed", details=e.args)
 
 
 def pack_deployment_tarball(config: Config, system: System) -> ActionReturn:

--- a/release/build.py
+++ b/release/build.py
@@ -42,6 +42,16 @@ def build_bokehjs(config: Config, system: System) -> ActionReturn:
         return FAILED("BokehJS build did NOT succeed", details=e.args)
 
 
+def build_npm_packages(config: Config, system: System) -> ActionReturn:
+    try:
+        system.cd("bokehjs")
+        system.run("npm pack")
+        system.cd("..")
+        return PASSED("npm pack succeeded")
+    except RuntimeError as e:
+        return FAILED("npm pack did NOT succeed", details=e.args)
+
+
 def build_conda_packages(config: Config, system: System) -> ActionReturn:
     try:
         system.run("conda build conda.recipe --quiet --no-test --output-folder .")
@@ -99,6 +109,7 @@ def pack_deployment_tarball(config: Config, system: System) -> ActionReturn:
         dirname = f"deployment-{config.version}"
         filename = f"{dirname}.tgz"
         system.run(f"mkdir {dirname}")
+        system.run(f"cp bokehjs/bokeh-bokehjs-{config.js_version}.tgz {dirname}")
         system.run(f"cp noarch/bokeh-{config.version}-py_0.tar.bz2 {dirname}")
         system.run(f"cp dist/bokeh-*.tar.gz {dirname}")  # TODO: handle .dev version variant better
         system.run(f"mkdir {dirname}/bokehjs")

--- a/release/deploy.py
+++ b/release/deploy.py
@@ -13,11 +13,23 @@ from .system import System
 __all__ = (
     "publish_conda_package",
     "publish_documentation",
+    "publish_npm_package",
     "publish_pip_package",
     "unpack_deployment_tarball",
 )
 
 CLOUDFRONT_ID = "E2OC6Q27H5UQ63"
+
+
+def publish_npm_package(config: Config, system: System) -> ActionReturn:
+    version = config.version
+    path = f"deployment-{version}/bokeh-bokehjs-{config.js_version}.tgz"
+    tags = "--tag=dev" if config.prerelease else ""
+    try:
+        system.run(f"npm publish --access=public {tags} {path}")
+        return PASSED("Publish to npmjs.com succeeded")
+    except RuntimeError as e:
+        return FAILED("Could NOT publish to npmjs.com", details=e.args)
 
 
 def publish_conda_package(config: Config, system: System) -> ActionReturn:

--- a/release/remote.py
+++ b/release/remote.py
@@ -59,7 +59,7 @@ def publish_bokehjs_to_cdn(config: Config, system: System) -> ActionReturn:
 
         content_type = "application/javascript"
         for name in ("bokeh", "bokeh-api", "bokeh-widgets", "bokeh-tables"):
-            for suffix in ("js", "min.js", "legacy.js", "legacy.min.js"):
+            for suffix in ("js", "min.js", "esm.js", "esm.min.js", "legacy.js", "legacy.min.js"):
                 local_path = f"bokehjs/build/js/{name}.{suffix}"
                 cdn_path = f"bokeh/{subdir}/{name}-{version}.{suffix}"
                 for bucket in buckets:

--- a/release/stages.py
+++ b/release/stages.py
@@ -13,6 +13,7 @@ from .build import (
     build_bokehjs,
     build_conda_packages,
     build_docs,
+    build_npm_packages,
     build_sdist_packages,
     dev_install,
     install_bokehjs,
@@ -49,6 +50,7 @@ from .credentials import (
 from .deploy import (
     publish_conda_package,
     publish_documentation,
+    publish_npm_package,
     publish_pip_package,
     unpack_deployment_tarball,
 )
@@ -107,6 +109,7 @@ BUILD_STEPS: StepListType = (
     update_hash_manifest,
     commit_staging_branch,
     tag_release_version,
+    build_npm_packages,
     build_conda_packages,
     build_sdist_packages,
     build_docs,
@@ -134,6 +137,7 @@ DEPLOY_CHECKS: StepListType = (
 DEPLOY_STEPS: StepListType = (
     download_deployment_tarball,
     unpack_deployment_tarball,
+    publish_npm_package,
     publish_conda_package,
     publish_pip_package,
     publish_documentation,


### PR DESCRIPTION
This assumes `NPM_TOKEN` was configured as an [automation token](https://github.blog/changelog/2020-10-02-npm-automation-tokens/), which means OTP is not going to be needed in CI.