### PR TITLE
Legend by glyph size

### DIFF
--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -328,6 +328,8 @@ class Legend(Annotation):
 
     Or, when constructing a legend according to scatter glyph size:
 
+    .. code-block:: python
+
         legend = Legend(items=[
             LegendItem(label="small", renderers=[r], index=0, size=10),
             LegendItem(label="medium", renderers=[r], index=1, size=20),

--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -187,8 +187,8 @@ class LegendItem(Model):
     """)
 
     size = Int(default=20, help="""
-    The integer size of the representative glyphs in the Legend when creating a 
-    scatter plot differentiated by marker size. 
+    The integer size of the representative glyphs in the Legend when creating a
+    scatter plot differentiated by marker size.
     """)
 
     @error(NON_MATCHING_DATA_SOURCES_ON_LEGEND_ITEM_RENDERERS)
@@ -325,9 +325,9 @@ class Legend(Annotation):
             LegendItem(label="2*sin(x)" , renderers=[r2]),
             LegendItem(label="3*sin(x)" , renderers=[r3, r4])
         ])
-        
+
     Or, when constructing a legend according to scatter glyph size:
-    
+
         legend = Legend(items=[
             LegendItem(label="small", renderers=[r], index=0, size=10),
             LegendItem(label="medium", renderers=[r], index=1, size=20),

--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -346,11 +346,7 @@ class Legend(Annotation):
 
     where each tuple is of the form: *(label, renderers)*.
 
-    """).accepts(List(Tuple(String, List(Instance(GlyphRenderer)))), lambda items: [LegendItem(label=item[0], 
-                                                                                               renderers=item[1], 
-                                                                                               index=Int(default=0), 
-                                                                                               size=Int(default=20)
-                                                                                               ) for item in items])
+    """).accepts(List(Tuple(String, List(Instance(GlyphRenderer)))), lambda items: [LegendItem(label=item[0], renderers=item[1]) for item in items])
 
 class ColorBar(Annotation):
     ''' Render a color bar based on a color mapper.

--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -346,7 +346,11 @@ class Legend(Annotation):
 
     where each tuple is of the form: *(label, renderers)*.
 
-    """).accepts(List(Tuple(String, List(Instance(GlyphRenderer)))), lambda items: [LegendItem(label=item[0], renderers=item[1], index=Int(default=0), size=Int(default=20)) for item in items])
+    """).accepts(List(Tuple(String, List(Instance(GlyphRenderer)))), lambda items: [LegendItem(label=item[0], 
+                                                                                               renderers=item[1], 
+                                                                                               index=Int(default=0), 
+                                                                                               size=Int(default=20)
+                                                                                               ) for item in items])
 
 class ColorBar(Annotation):
     ''' Render a color bar based on a color mapper.

--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -186,6 +186,11 @@ class LegendItem(Model):
     If set to a number, Bokeh will use that number as the index in all cases.
     """)
 
+    size = Int(default=20, help="""
+    The integer size of the representative glyphs in the Legend when creating a 
+    scatter plot differentiated by marker size. 
+    """)
+
     @error(NON_MATCHING_DATA_SOURCES_ON_LEGEND_ITEM_RENDERERS)
     def _check_data_sources_on_renderers(self):
         if self.label and 'field' in self.label:
@@ -320,6 +325,14 @@ class Legend(Annotation):
             LegendItem(label="2*sin(x)" , renderers=[r2]),
             LegendItem(label="3*sin(x)" , renderers=[r3, r4])
         ])
+        
+    Or, when constructing a legend according to scatter glyph size:
+    
+        legend = Legend(items=[
+            LegendItem(label="small", renderers=[r], index=0, size=10),
+            LegendItem(label="medium", renderers=[r], index=1, size=20),
+            LegendItem(label="large", renderers=[r], index=2, size=30)
+        ])
 
     But as a convenience, can also be given more compactly as a list of tuples:
 
@@ -333,7 +346,7 @@ class Legend(Annotation):
 
     where each tuple is of the form: *(label, renderers)*.
 
-    """).accepts(List(Tuple(String, List(Instance(GlyphRenderer)))), lambda items: [LegendItem(label=item[0], renderers=item[1]) for item in items])
+    """).accepts(List(Tuple(String, List(Instance(GlyphRenderer)))), lambda items: [LegendItem(label=item[0], renderers=item[1], index=Int(default=0), size=Int(default=20)) for item in items])
 
 class ColorBar(Annotation):
     ''' Render a color bar based on a color mapper.

--- a/bokehjs/src/lib/models/annotations/legend.ts
+++ b/bokehjs/src/lib/models/annotations/legend.ts
@@ -233,7 +233,7 @@ export class LegendView extends AnnotationView {
   }
 
   protected _draw_legend_items(ctx: Context2d, bbox: BBox): void {
-    var {glyph_width, glyph_height} = this.model
+    let {glyph_width, glyph_height} = this.model
     const {legend_padding} = this
     const legend_spacing = this.model.spacing
     const {label_standoff} = this.model
@@ -427,8 +427,8 @@ export class Legend extends Annotation {
     return legend_names
   }
 
-  get_max_glyph_size(): number {  // should this return a Size? but Size is 2d, which seems unnecessary
-    var max_glyph_size: number = 0
+  get_max_glyph_size(): number {
+    let max_glyph_size: number = 0
     for (const item of this.items) {
       if (item.size != null && item.size > max_glyph_size){
         max_glyph_size = item.size

--- a/bokehjs/src/lib/models/annotations/legend.ts
+++ b/bokehjs/src/lib/models/annotations/legend.ts
@@ -41,12 +41,9 @@ export class LegendView extends AnnotationView {
     const legend_names = this.model.get_legend_names()
 
     this.max_glyph_size = this.model.get_max_glyph_size()
-    //const {glyph_height, glyph_width} = this.model
-    //const {glyph_height} = this.model
     const {label_height, label_width} = this.model
 
     this.max_label_height = max(
-      //[measure_font(this.visuals.label_text.font_value()).height, label_height, glyph_height],
       [measure_font(this.visuals.label_text.font_value()).height, label_height, this.max_glyph_size],
     )
 
@@ -65,7 +62,6 @@ export class LegendView extends AnnotationView {
 
     ctx.restore()
 
-    // TODO: can i use this idea to find max glyph size?
     const max_label_width = Math.max(max([...this.text_widths.values()]), 0)
 
     const legend_margin = this.model.margin

--- a/bokehjs/src/lib/models/annotations/legend_item.ts
+++ b/bokehjs/src/lib/models/annotations/legend_item.ts
@@ -14,6 +14,7 @@ export namespace LegendItem {
     label: p.DataSpec<string | null> // TODO: spec!
     renderers: p.Property<GlyphRenderer[]>
     index: p.Property<number | null>
+    size: p.Property<number | null>
   }
 }
 
@@ -33,6 +34,7 @@ export class LegendItem extends Model {
       label:     [ p.NullStringSpec, null ],
       renderers: [ Array(Ref(GlyphRenderer)), [] ],
       index:     [ Nullable(Int), null ],
+      size:      [ Nullable(Int), 20 ],
     }))
   }
 


### PR DESCRIPTION
- [ ] issues: fixes #2603

Adds functionality for a legend to differentiate glyphs based on a passed-in, explicit marker size. 

Known limitations:
- No logic to reject or alert if `size` arg is passed for non-scatter type plots. Open to suggestions here.
- Vertical alignment on legend labels does not have the glyph centered. This is obnoxious to me, but I am slow at understanding the JS, wanted to get this in, and can fix later.

Examples of output:
![image](https://user-images.githubusercontent.com/43212692/100665642-decd5980-331d-11eb-846c-697b5f321832.png)

This is my first time working with BokehJS, so please let me know (I'm sure you would anyway) if there are any best practices violations or other issues I may not have considered.

Thank you!
