### PR TITLE
Decouple Color Swatch

### DIFF
--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -971,6 +971,9 @@ class HoverTool(InspectTool):
             ("(x,y)", "($x, $y)"),
             ("radius", "@radius"),
             ("fill color", "$color[hex, swatch]:fill_color"),
+            ("fill color", "$color[hex]:fill_color"),
+            ("fill color", "$color:fill_color"),
+            ("fill color", "$swatch:fill_color"),
             ("foo", "@foo"),
             ("bar", "@bar"),
             ("baz", "@baz{safe}"),
@@ -1055,8 +1058,9 @@ class HoverTool(InspectTool):
     :$sy: y-coordinate under the cursor in screen (canvas) space
     :$color: color data from data source, with the syntax:
         ``$color[options]:field_name``. The available options
-        are: 'hex' (to display the color as a hex value), and
-        'swatch' to also display a small color swatch.
+        are: ``hex`` (to display the color as a hex value), ``swatch``
+        (color data from data source displayed as a small color box)
+    :$swatch: color data from data source displayed as a small color box
 
     Field names that begin with ``@`` are associated with columns in a
     ``ColumnDataSource``. For instance the field name ``"@price"`` will

--- a/bokehjs/src/lib/core/dom.ts
+++ b/bokehjs/src/lib/core/dom.ts
@@ -146,8 +146,8 @@ export function undisplay(element: HTMLElement): void {
 }
 
 export function textOnly(element: HTMLElement): void {
-  element.style.width = "0";
-  element.style.height = "0";
+  element.style.width = "0"
+  element.style.height = "0"
 }
 
 export function show(element: HTMLElement): void {

--- a/bokehjs/src/lib/core/dom.ts
+++ b/bokehjs/src/lib/core/dom.ts
@@ -145,6 +145,11 @@ export function undisplay(element: HTMLElement): void {
   element.style.display = "none"
 }
 
+export function textOnly(element: HTMLElement): void {
+  element.style.width = "0";
+  element.style.height = "0";
+}
+
 export function show(element: HTMLElement): void {
   element.style.visibility = ""
 }

--- a/bokehjs/src/lib/core/dom.ts
+++ b/bokehjs/src/lib/core/dom.ts
@@ -145,11 +145,6 @@ export function undisplay(element: HTMLElement): void {
   element.style.display = "none"
 }
 
-export function textOnly(element: HTMLElement): void {
-  element.style.width = "0"
-  element.style.height = "0"
-}
-
 export function show(element: HTMLElement): void {
   element.style.visibility = ""
 }

--- a/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
+++ b/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
@@ -451,7 +451,7 @@ export class HoverToolView extends InspectToolView {
     const swatch_re = /\$swatch:(\w*)/
 
     for (const [[, value], j] of enumerate(tooltips)) {
-      var tooltipValue = value;
+      let tooltipValue = value
 
       const colorFieldMatch = value.match(color_re)
       const swatchFieldMatch = value.match(swatch_re)
@@ -465,13 +465,13 @@ export class HoverToolView extends InspectToolView {
 
         if (column == null) {
           swatch_els[j].textContent = `(unknown)`
-          textOnly(swatch_els[j]);
+          textOnly(swatch_els[j])
         } else {
-          let color = isNumber(i) ? column[i] : null
+          const color = isNumber(i) ? column[i] : null
 
           if (color == null) {
             swatch_els[j].textContent = "(null)"
-            textOnly(swatch_els[j]);
+            textOnly(swatch_els[j])
           } else {
             swatch_els[j].style.backgroundColor = color
           }

--- a/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
+++ b/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
@@ -451,14 +451,14 @@ export class HoverToolView extends InspectToolView {
     const swatch_re = /\$swatch:(\w*)/
 
     for (const [[, value], j] of enumerate(tooltips)) {
-      let tooltipValue = value
+      let tooltip_value = value
 
-      const colorFieldMatch = value.match(color_re)
-      const swatchFieldMatch = value.match(swatch_re)
+      const color_field_match = value.match(color_re)
+      const swatch_field_match = value.match(swatch_re)
 
-      if (swatchFieldMatch) {
-        tooltipValue = value.replace(swatch_re, "")
-        const [, colname] = swatchFieldMatch
+      if (swatch_field_match) {
+        tooltip_value = value.replace(swatch_re, "")
+        const [, colname] = swatch_field_match
         const column = ds.get_column(colname)
 
         display(swatch_els[j])
@@ -469,17 +469,14 @@ export class HoverToolView extends InspectToolView {
         } else {
           const color = isNumber(i) ? column[i] : null
 
-          if (color == null) {
-            swatch_els[j].textContent = "(null)"
-            textOnly(swatch_els[j])
-          } else {
+          if (color != null) {
             swatch_els[j].style.backgroundColor = color
           }
         }
       }
 
-      if (colorFieldMatch != null) {
-        const [, opts = "", colname] = colorFieldMatch
+      if (color_field_match != null) {
+        const [, opts = "", colname] = color_field_match
         const column = ds.get_column(colname) // XXX: change to columnar ds
         if (column == null) {
           value_els[j].textContent = `${colname} unknown`
@@ -498,7 +495,7 @@ export class HoverToolView extends InspectToolView {
           display(swatch_els[j])
         }
       } else {
-        const content = replace_placeholders(tooltipValue.replace("$~", "$data_"), ds, i, this.model.formatters, vars)
+        const content = replace_placeholders(tooltip_value.replace("$~", "$data_"), ds, i, this.model.formatters, vars)
         if (isString(content)) {
           value_els[j].textContent = content
         } else {

--- a/bokehjs/test/unit/models/tools/inspectors/hover_tool.ts
+++ b/bokehjs/test/unit/models/tools/inspectors/hover_tool.ts
@@ -1,4 +1,6 @@
 import {expect} from "assertions"
+import {display, fig} from "_util"
+
 import {assert} from "@bokehjs/core/util/assert"
 import {build_view} from "@bokehjs/core/build_views"
 import {ColumnDataSource} from "@bokehjs/models/sources/column_data_source"
@@ -55,5 +57,171 @@ describe("HoverTool", () => {
       assert(el2 != null)
       expect(el2.childElementCount).to.be.equal(2)
     })
+  })
+
+  it("should allow to render various combinations of color[hex] and swatch", async () => {
+    const tooltips: [string, string][] = [
+      ["index", "$index"],
+      ["(x,y)", "($x, $y)"],
+      ["radius", "@radius"],
+      ["hex & swatch (known)", "$color[hex, swatch]:colors"],
+      ["swatch & hex (known)", "$color[swatch, hex]:colors"],
+      ["hex, swatch (known)", "$color[hex]:colors $swatch:colors"],
+      ["swatch, hex (known)", "$swatch:colors $color[hex]:colors"],
+      ["hex (known)", "$color[hex]:colors"],
+      ["swatch (known)", "$swatch:colors"],
+      ["hex & swatch (unknown)", "$color[hex, swatch]:__colors"],
+      ["swatch & hex (unknown)", "$color[swatch, hex]:__colors"],
+      ["hex, swatch (unknown)", "$color[hex]:__colors $swatch:__colors"],
+      ["swatch, hex (unknown)", "$swatch:__colors $color[hex]:__colors"],
+      ["hex (unknown)", "$color[hex]:__colors"],
+      ["swatch (unknown)", "$swatch:__colors"],
+      ["foo", "@foo"],
+      ["bar", "@bar"],
+    ]
+
+    const hover = new HoverTool({tooltips})
+    const p = fig([200, 200], {tools: [hover]})
+    const r = p.circle({
+      x: [1, 2, 3],
+      y: [4, 5, 6],
+      radius: [0.2, 0.4, 0.6],
+      fill_color: ["red", "green", "blue"],
+      source: {
+        foo: ["abcd", "bacd", "bcad"],
+        bar: [-1, -2, -3],
+      },
+    })
+
+    const {view} = await display(p)
+
+    const hover_view = view.tool_views.get(hover)! as HoverTool["__view_type__"]
+    const el = hover_view._render_tooltips(r.data_source, 0, {index: 0, x: 10, y: 20})
+
+    const html =
+`
+<div class="bk" style="display: table; border-spacing: 2px;">
+  <div class="bk" style="display: table-row;">
+    <div class="bk bk-tooltip-row-label" style="display: table-cell;">index: </div>
+    <div class="bk bk-tooltip-row-value" style="display: table-cell;">
+      <span class="bk" data-value="">0</span>
+      <span class="bk bk-tooltip-color-block" data-swatch="" style="display: none;"> </span>
+    </div>
+  </div>
+  <div class="bk" style="display: table-row;">
+    <div class="bk bk-tooltip-row-label" style="display: table-cell;">(x,y): </div>
+    <div class="bk bk-tooltip-row-value" style="display: table-cell;">
+      <span class="bk" data-value="">(10, 20)</span>
+      <span class="bk bk-tooltip-color-block" data-swatch="" style="display: none;"> </span>
+    </div>
+  </div>
+  <div class="bk" style="display: table-row;">
+    <div class="bk bk-tooltip-row-label" style="display: table-cell;">radius: </div>
+    <div class="bk bk-tooltip-row-value" style="display: table-cell;">
+      <span class="bk" data-value="">0.200</span>
+      <span class="bk bk-tooltip-color-block" data-swatch="" style="display: none;"> </span>
+    </div>
+  </div>
+  <div class="bk" style="display: table-row;">
+    <div class="bk bk-tooltip-row-label" style="display: table-cell;">hex &amp; swatch (known): </div>
+    <div class="bk bk-tooltip-row-value" style="display: table-cell;">
+      <span class="bk" data-value="">colors unknown</span>
+      <span class="bk bk-tooltip-color-block" data-swatch="" style="display: none;"> </span>
+    </div>
+  </div>
+  <div class="bk" style="display: table-row;">
+    <div class="bk bk-tooltip-row-label" style="display: table-cell;">swatch &amp; hex (known): </div>
+    <div class="bk bk-tooltip-row-value" style="display: table-cell;">
+      <span class="bk" data-value="">colors unknown</span>
+      <span class="bk bk-tooltip-color-block" data-swatch="" style="display: none;"> </span>
+    </div>
+  </div>
+  <div class="bk" style="display: table-row;">
+    <div class="bk bk-tooltip-row-label" style="display: table-cell;">hex, swatch (known): </div>
+    <div class="bk bk-tooltip-row-value" style="display: table-cell;">
+      <span class="bk" data-value="">colors unknown</span>
+      <span class="bk bk-tooltip-color-block" data-swatch="" style="display: none;"> </span>
+    </div>
+  </div>
+  <div class="bk" style="display: table-row;">
+    <div class="bk bk-tooltip-row-label" style="display: table-cell;">swatch, hex (known): </div>
+    <div class="bk bk-tooltip-row-value" style="display: table-cell;">
+      <span class="bk" data-value="">colors unknown</span>
+      <span class="bk bk-tooltip-color-block" data-swatch="" style="display: none;"> </span>
+    </div>
+  </div>
+  <div class="bk" style="display: table-row;">
+    <div class="bk bk-tooltip-row-label" style="display: table-cell;">hex (known): </div>
+    <div class="bk bk-tooltip-row-value" style="display: table-cell;">
+      <span class="bk" data-value="">colors unknown</span>
+      <span class="bk bk-tooltip-color-block" data-swatch="" style="display: none;"> </span>
+    </div>
+  </div>
+  <div class="bk" style="display: table-row;">
+    <div class="bk bk-tooltip-row-label" style="display: table-cell;">swatch (known): </div>
+    <div class="bk bk-tooltip-row-value" style="display: table-cell;">
+      <span class="bk" data-value="">colors unknown</span>
+      <span class="bk bk-tooltip-color-block" data-swatch="" style="display: none;"> </span>
+    </div>
+  </div>
+  <div class="bk" style="display: table-row;">
+    <div class="bk bk-tooltip-row-label" style="display: table-cell;">hex &amp; swatch (unknown): </div>
+    <div class="bk bk-tooltip-row-value" style="display: table-cell;">
+      <span class="bk" data-value="">__colors unknown</span>
+      <span class="bk bk-tooltip-color-block" data-swatch="" style="display: none;"> </span>
+    </div>
+  </div>
+  <div class="bk" style="display: table-row;">
+    <div class="bk bk-tooltip-row-label" style="display: table-cell;">swatch &amp; hex (unknown): </div>
+    <div class="bk bk-tooltip-row-value" style="display: table-cell;">
+      <span class="bk" data-value="">__colors unknown</span>
+      <span class="bk bk-tooltip-color-block" data-swatch="" style="display: none;"> </span>
+    </div>
+  </div>
+  <div class="bk" style="display: table-row;">
+    <div class="bk bk-tooltip-row-label" style="display: table-cell;">hex, swatch (unknown): </div>
+    <div class="bk bk-tooltip-row-value" style="display: table-cell;">
+      <span class="bk" data-value="">__colors unknown</span>
+      <span class="bk bk-tooltip-color-block" data-swatch="" style="display: none;"> </span>
+    </div>
+  </div>
+  <div class="bk" style="display: table-row;">
+    <div class="bk bk-tooltip-row-label" style="display: table-cell;">swatch, hex (unknown): </div>
+    <div class="bk bk-tooltip-row-value" style="display: table-cell;">
+      <span class="bk" data-value="">__colors unknown</span>
+      <span class="bk bk-tooltip-color-block" data-swatch="" style="display: none;"> </span>
+    </div>
+  </div>
+  <div class="bk" style="display: table-row;">
+    <div class="bk bk-tooltip-row-label" style="display: table-cell;">hex (unknown): </div>
+    <div class="bk bk-tooltip-row-value" style="display: table-cell;">
+      <span class="bk" data-value="">__colors unknown</span>
+      <span class="bk bk-tooltip-color-block" data-swatch="" style="display: none;"> </span>
+    </div>
+  </div>
+  <div class="bk" style="display: table-row;">
+    <div class="bk bk-tooltip-row-label" style="display: table-cell;">swatch (unknown): </div>
+    <div class="bk bk-tooltip-row-value" style="display: table-cell;">
+      <span class="bk" data-value="">__colors unknown</span>
+      <span class="bk bk-tooltip-color-block" data-swatch="" style="display: none;"> </span>
+    </div>
+  </div>
+  <div class="bk" style="display: table-row;">
+    <div class="bk bk-tooltip-row-label" style="display: table-cell;">foo: </div>
+    <div class="bk bk-tooltip-row-value" style="display: table-cell;">
+      <span class="bk" data-value="">abcd</span>
+      <span class="bk bk-tooltip-color-block" data-swatch="" style="display: none;"> </span>
+    </div>
+  </div>
+  <div class="bk" style="display: table-row;">
+    <div class="bk bk-tooltip-row-label" style="display: table-cell;">bar: </div>
+    <div class="bk bk-tooltip-row-value" style="display: table-cell;">
+      <span class="bk" data-value="">-1</span>
+      <span class="bk bk-tooltip-color-block" data-swatch="" style="display: none;"> </span>
+    </div>
+  </div>
+</div>
+`
+    expect(el!.outerHTML).to.be.equal(html.trim().split("\n").map((s) => s.trim()).join(""))
   })
 })

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -452,6 +452,9 @@ left was created with the accompanying ``tooltips`` definition on the right.
     |                    |        ("(x,y)", "($x, $y)"),                             |
     |   |hover_basic|    |        ("radius", "@radius"),                             |
     |                    |        ("fill color", "$color[hex, swatch]:fill_color"),  |
+    |                    |        ("fill color", "$color[hex]:fill_color"),          |
+    |                    |        ("fill color", "$color:fill_color"),               |
+    |                    |        ("fill color", "$swatch:fill_color"),              |
     |                    |        ("foo", "@foo"),                                   |
     |                    |        ("bar", "@bar"),                                   |
     |                    |    ]                                                      |
@@ -476,7 +479,9 @@ in data or screen space. These special fields are listed here:
 :``$color``:
     colors from a data source, with the syntax: ``$color[options]:field_name``.
     The available options are: ``hex`` (to display the color as a hex value),
-    and ``swatch`` to also display a small color swatch.
+    ``swatch`` (color data from data source displayed as a small color box).
+:``$swatch``:
+    color data from data source displayed as a small color box.
 
 Field names that begin with ``@`` are associated with columns in a
 ``ColumnDataSource``. For instance, the field name ``"@price"`` will display


### PR DESCRIPTION


I updated the code as requested. I defined a new special variable called "swatch" which decouples the swatch functionality from the color field. Now, you can add the swatch element to any field you want. In addition, the code is backwards compatible so that the swatch option continues to work for the color field. For bad input handling, I was not sure what the preferred behavior is. Right now, I hide the swatch element and just display text.

I can update the documentation if the behavior looks good. In terms of testing, I looked around and couldn't finding existing tests for testing specific special variables used in the hover_tool. Do we need tests for this case?



- [x] issues: fixes #10506
- [x] release document entry 