### PR TITLE
Add tooltip arrow styling to HoverTool

### DIFF
--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -38,6 +38,7 @@ from ..core.properties import (
     AngleSpec,
     Auto,
     Bool,
+    Color,
     ColorSpec,
     Datetime,
     Dict,
@@ -1058,6 +1059,10 @@ class Tooltip(Annotation):
     show_arrow = Bool(default=True, help="""
     Whether tooltip's arrow should be shown.
     """)
+
+    tooltip_arrow_color = Color(default="#909599", help="""
+    The color of the tooltip's arrow as a CSS colour (e.g. '#FFFFFF', 'white', etc.).
+    """)  # XXX: keep default in sync with tooltips.less
 
 class Whisker(Annotation):
     ''' Render a whisker along a dimension.

--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -1060,9 +1060,17 @@ class Tooltip(Annotation):
     Whether tooltip's arrow should be shown.
     """)
 
-    tooltip_arrow_color = Color(default="#909599", help="""
+    arrow_fill_color = Color(default="#909599", help="""
     The color of the tooltip's arrow as a CSS colour (e.g. '#FFFFFF', 'white', etc.).
     """)  # XXX: keep default in sync with tooltips.less
+
+    arrow_fill_alpha = Float(default=1.0, help="""
+    An alpha value to use to fill the tooltip arrow with.
+
+    Acceptable values are floating point numbers between 0 (transparent)
+    and 1 (opaque).
+
+    """)
 
 class Whisker(Annotation):
     ''' Render a whisker along a dimension.

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -1187,9 +1187,17 @@ class HoverTool(InspectTool):
     Whether tooltip's arrow should be shown.
     """)
 
-    tooltip_arrow_color = Color(default="#909599", help="""
+    arrow_fill_color = Color(default="#909599", help="""
     The color of the tooltip's arrow as a CSS colour (e.g. '#FFFFFF', 'white', etc.).
     """)  # XXX: keep default in sync with tooltips.less
+
+    arrow_fill_alpha = Float(default=1.0, help="""
+    An alpha value to use to fill the tooltip arrow with.
+
+    Acceptable values are floating point numbers between 0 (transparent)
+    and 1 (opaque).
+
+    """)
 
 DEFAULT_HELP_TIP = "Click the question mark to learn more about Bokeh plot tools."
 DEFAULT_HELP_URL = "https://docs.bokeh.org/en/latest/docs/user_guide/tools.html"

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -1187,6 +1187,10 @@ class HoverTool(InspectTool):
     Whether tooltip's arrow should be shown.
     """)
 
+    tooltip_arrow_color = Color(default="#909599", help="""
+    The color of the tooltip's arrow as a CSS colour (e.g. '#FFFFFF', 'white', etc.).
+    """)  # XXX: keep default in sync with tooltips.less
+
 DEFAULT_HELP_TIP = "Click the question mark to learn more about Bokeh plot tools."
 DEFAULT_HELP_URL = "https://docs.bokeh.org/en/latest/docs/user_guide/tools.html"
 

--- a/bokehjs/src/less/tooltips.less
+++ b/bokehjs/src/less/tooltips.less
@@ -1,11 +1,13 @@
 @import "./_mixins.less";
 
 .bk-root {
+  --tooltipArrowColor: #909599; /* Gray of icons */
+
   @tooltipBorder: #e5e5e5;  /* Same border color used everywhere */
   @tooltipColor: white;
   @tooltipText: #2f2f2f;
 
-  @tooltipArrowColor: #909599;  /* Gray of icons */
+  @tooltipArrowColor: var(--tooltipArrowColor);
   @tooltipArrowWidth: 10px;
   @tooltipArrowHeight: 10px;
   @tooltipArrowHalfWidth: 7px;

--- a/bokehjs/src/less/tooltips.less
+++ b/bokehjs/src/less/tooltips.less
@@ -2,12 +2,14 @@
 
 .bk-root {
   --tooltipArrowColor: #909599; /* Gray of icons */
+  --tooltipArrowAlpha: 1.0; /* Gray of icons */
 
   @tooltipBorder: #e5e5e5;  /* Same border color used everywhere */
   @tooltipColor: white;
   @tooltipText: #2f2f2f;
 
   @tooltipArrowColor: var(--tooltipArrowColor);
+  @tooltipArrowAlpha: var(--tooltipArrowAlpha);
   @tooltipArrowWidth: 10px;
   @tooltipArrowHeight: 10px;
   @tooltipArrowHalfWidth: 7px;
@@ -41,6 +43,7 @@
     border-style: solid;
     border-width: @tooltipArrowHalfHeight 0 @tooltipArrowHalfHeight 0;
     border-color: transparent;
+    opacity: @tooltipArrowAlpha;
     content: " ";
     display: block;
   }
@@ -54,6 +57,7 @@
     border-style: solid;
     border-width: 0 @tooltipArrowHalfWidth 0 @tooltipArrowHalfWidth;
     border-color: transparent;
+    opacity: @tooltipArrowAlpha;
     content: " ";
     display: block;
   }

--- a/bokehjs/src/lib/models/annotations/tooltip.ts
+++ b/bokehjs/src/lib/models/annotations/tooltip.ts
@@ -2,6 +2,7 @@ import {Annotation, AnnotationView} from "./annotation"
 import {TooltipAttachment} from "core/enums"
 import {div, display, undisplay, empty, remove, classes} from "core/dom"
 import * as p from "core/properties"
+import {Color} from "core/types"
 
 import tooltips_css, * as tooltips from "styles/tooltips.css"
 
@@ -127,6 +128,7 @@ export namespace Tooltip {
     attachment: p.Property<TooltipAttachment>
     inner_only: p.Property<boolean>
     show_arrow: p.Property<boolean>
+    tooltip_arrow_color: p.Property<Color>
     position: p.Property<[number, number] | null>
     content: p.Property<HTMLElement>
     custom: p.Property<boolean>
@@ -146,10 +148,11 @@ export class Tooltip extends Annotation {
   static init_Tooltip(): void {
     this.prototype.default_view = TooltipView
 
-    this.define<Tooltip.Props>(({Boolean}) => ({
+    this.define<Tooltip.Props>(({Boolean, Color}) => ({
       attachment: [ TooltipAttachment, "horizontal" ],
       inner_only: [ Boolean, true ],
       show_arrow: [ Boolean, true ],
+      tooltip_arrow_color:  [ Color, "#909599" /* Gray of icons */ ],
     }))
 
     this.internal<Tooltip.Props>(({Boolean, Number, Tuple, Ref, Nullable}) => ({

--- a/bokehjs/src/lib/models/annotations/tooltip.ts
+++ b/bokehjs/src/lib/models/annotations/tooltip.ts
@@ -55,7 +55,8 @@ export class TooltipView extends AnnotationView {
 
     if (this.model.show_arrow) {
       this.el.classList.add(tooltips.tooltip_arrow)
-      this.el.style.setProperty("--tooltipArrowColor", this.model.tooltip_arrow_color)
+      this.el.style.setProperty("--tooltipArrowColor", this.model.arrow_fill_color)
+      this.el.style.setProperty("--tooltipArrowAlpha", String(this.model.arrow_fill_alpha))
     }
   }
 
@@ -130,7 +131,8 @@ export namespace Tooltip {
     attachment: p.Property<TooltipAttachment>
     inner_only: p.Property<boolean>
     show_arrow: p.Property<boolean>
-    tooltip_arrow_color: p.Property<Color>
+    arrow_fill_color: p.Property<Color>
+    arrow_fill_alpha: p.Property<number>
     position: p.Property<[number, number] | null>
     content: p.Property<HTMLElement>
     custom: p.Property<boolean>
@@ -150,11 +152,12 @@ export class Tooltip extends Annotation {
   static init_Tooltip(): void {
     this.prototype.default_view = TooltipView
 
-    this.define<Tooltip.Props>(({Boolean, Color}) => ({
+    this.define<Tooltip.Props>(({Boolean, Color, Number}) => ({
       attachment: [ TooltipAttachment, "horizontal" ],
       inner_only: [ Boolean, true ],
       show_arrow: [ Boolean, true ],
-      tooltip_arrow_color:  [ Color, "#909599" /* Gray of icons */ ],
+      arrow_fill_color:  [ Color, "#909599" /* Gray of icons */ ],
+      arrow_fill_alpha:  [ Number, 1 ],
     }))
 
     this.internal<Tooltip.Props>(({Boolean, Number, Tuple, Ref, Nullable}) => ({

--- a/bokehjs/src/lib/models/annotations/tooltip.ts
+++ b/bokehjs/src/lib/models/annotations/tooltip.ts
@@ -53,8 +53,10 @@ export class TooltipView extends AnnotationView {
     classes(this.el).toggle("bk-tooltip-custom", this.model.custom)
     this.el.appendChild(content)
 
-    if (this.model.show_arrow)
+    if (this.model.show_arrow) {
       this.el.classList.add(tooltips.tooltip_arrow)
+      this.el.style.setProperty("--tooltipArrowColor", this.model.tooltip_arrow_color)
+    }
   }
 
   protected _reposition(): void {

--- a/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
+++ b/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
@@ -13,7 +13,7 @@ import {MoveEvent} from "core/ui_events"
 import {replace_placeholders, Formatters, FormatterType, Vars} from "core/util/templating"
 import {div, span, display, undisplay, empty} from "core/dom"
 import * as p from "core/properties"
-import {NumberArray} from "core/types"
+import {Color, NumberArray} from "core/types"
 import {color2hex} from "core/util/color"
 import {isEmpty} from "core/util/object"
 import {enumerate} from "core/util/iterator"
@@ -104,6 +104,7 @@ export class HoverToolView extends InspectToolView {
           custom: isString(tooltips) || isFunction(tooltips),
           attachment: this.model.attachment,
           show_arrow: this.model.show_arrow,
+          tooltip_arrow_color: this.model.tooltip_arrow_color,
         })
 
         if (r instanceof GlyphRenderer) {
@@ -513,6 +514,7 @@ export namespace HoverTool {
     point_policy: p.Property<PointPolicy>
     line_policy: p.Property<LinePolicy>
     show_arrow: p.Property<boolean>
+    tooltip_arrow_color: p.Property<Color>
     anchor: p.Property<Anchor>
     attachment: p.Property<TooltipAttachment>
     callback: p.Property<CallbackLike1<HoverTool, {geometry: GeometryData, renderer: Renderer}> | null>
@@ -532,7 +534,7 @@ export class HoverTool extends InspectTool {
   static init_HoverTool(): void {
     this.prototype.default_view = HoverToolView
 
-    this.define<HoverTool.Props>(({Any, Boolean, String, Array, Tuple, Dict, Or, Ref, Function, Auto, Nullable}) => ({
+    this.define<HoverTool.Props>(({Any, Color, Boolean, String, Array, Tuple, Dict, Or, Ref, Function, Auto, Nullable}) => ({
       tooltips: [ Nullable(Or(String, Array(Tuple(String, String)), Function<[ColumnarDataSource, TooltipVars], HTMLElement>())), [
         ["index",         "$index"    ],
         ["data (x, y)",   "($x, $y)"  ],
@@ -546,6 +548,7 @@ export class HoverTool extends InspectTool {
       point_policy: [ PointPolicy, "snap_to_data" ],
       line_policy:  [ LinePolicy, "nearest" ],
       show_arrow:   [ Boolean, true ],
+      tooltip_arrow_color:  [ Color, "#909599" /* Gray of icons */ ],
       anchor:       [ Anchor, "center" ],
       attachment:   [ TooltipAttachment, "horizontal" ],
       callback:     [ Nullable(Any /*TODO*/) ],

--- a/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
+++ b/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
@@ -104,7 +104,8 @@ export class HoverToolView extends InspectToolView {
           custom: isString(tooltips) || isFunction(tooltips),
           attachment: this.model.attachment,
           show_arrow: this.model.show_arrow,
-          tooltip_arrow_color: this.model.tooltip_arrow_color,
+          arrow_fill_color: this.model.arrow_fill_color,
+          arrow_fill_alpha: this.model.arrow_fill_alpha,
         })
 
         if (r instanceof GlyphRenderer) {
@@ -514,7 +515,8 @@ export namespace HoverTool {
     point_policy: p.Property<PointPolicy>
     line_policy: p.Property<LinePolicy>
     show_arrow: p.Property<boolean>
-    tooltip_arrow_color: p.Property<Color>
+    arrow_fill_color: p.Property<Color>
+    arrow_fill_alpha: p.Property<number>
     anchor: p.Property<Anchor>
     attachment: p.Property<TooltipAttachment>
     callback: p.Property<CallbackLike1<HoverTool, {geometry: GeometryData, renderer: Renderer}> | null>
@@ -534,7 +536,7 @@ export class HoverTool extends InspectTool {
   static init_HoverTool(): void {
     this.prototype.default_view = HoverToolView
 
-    this.define<HoverTool.Props>(({Any, Color, Boolean, String, Array, Tuple, Dict, Or, Ref, Function, Auto, Nullable}) => ({
+    this.define<HoverTool.Props>(({Any, Color, Boolean, Number, String, Array, Tuple, Dict, Or, Ref, Function, Auto, Nullable}) => ({
       tooltips: [ Nullable(Or(String, Array(Tuple(String, String)), Function<[ColumnarDataSource, TooltipVars], HTMLElement>())), [
         ["index",         "$index"    ],
         ["data (x, y)",   "($x, $y)"  ],
@@ -548,7 +550,8 @@ export class HoverTool extends InspectTool {
       point_policy: [ PointPolicy, "snap_to_data" ],
       line_policy:  [ LinePolicy, "nearest" ],
       show_arrow:   [ Boolean, true ],
-      tooltip_arrow_color:  [ Color, "#909599" /* Gray of icons */ ],
+      arrow_fill_color:  [ Color, "#909599" /* Gray of icons */ ],
+      arrow_fill_alpha:  [ Number, 1 ],
       anchor:       [ Anchor, "center" ],
       attachment:   [ TooltipAttachment, "horizontal" ],
       callback:     [ Nullable(Any /*TODO*/) ],


### PR DESCRIPTION
Add ability to style the HoverTool's tooltip arrow, specifically recolouring.

- [ ] issues: fixes #9378 
- [ ] tests added / passed
  - Couldn't find an existing testing plan for HoverTool configuration, but I might be mistaken; looks like there's some discussion in #10743 where this may be done in the future?
- [ ] release document entry (if new feature or API change)
  - If the behaviour looks good and there are no additional configuration options requested, I can look into updating the docs

---

I ran the `examples/app/gapminder` demo, replacing the existing `HoverTool` creation (L51) with the following (`black` could be replaced with any CSS colour-like string e.g. `#000000` or `rgb(0, 0, 0)` etc.):
```python
plot.add_tools(HoverTool(tooltips="@Country", tooltip_arrow_color='black', point_policy='follow_mouse'))
```

It looks like this:

![image](https://user-images.githubusercontent.com/32231895/100698421-6343ca80-3366-11eb-904e-299375ad61ae.png)
