### PR TITLE
Manually quote arguments to npx

### DIFF
--- a/bokehjs/package-lock.json
+++ b/bokehjs/package-lock.json
@@ -80,7 +80,7 @@
       },
       "engines": {
         "node": ">=14",
-        "npm": ">=7"
+        "npm": ">=7.1"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -18,7 +18,7 @@
   },
   "engines": {
     "node": ">=14",
-    "npm": ">=7"
+    "npm": ">=7.1"
   },
   "files": [
     "build/js/bokeh*.min.js",

--- a/sphinx/source/docs/dev_guide/bokehjs.rst
+++ b/sphinx/source/docs/dev_guide/bokehjs.rst
@@ -75,7 +75,7 @@ Requirements
 ~~~~~~~~~~~~
 
 * node 14.*
-* npm 7+ (most recent version)
+* npm 7.1+ (most recent version)
 * chrome/chromium browser 87+ or equivalent
 
 You can install nodejs with conda:

--- a/tests/codebase/test_js_license_set.py
+++ b/tests/codebase/test_js_license_set.py
@@ -43,7 +43,7 @@ def test_js_license_set() -> None:
     '''
     os.chdir('bokehjs')
     proc = Popen([
-        "npx", "license-checker", "--production", "--summary", "--onlyAllow", "%s" % ";".join(LICENSES)
+        "npx", "license-checker", "--production", "--summary", "--onlyAllow", "'%s'" % ";".join(LICENSES)
     ],stdout=PIPE)
     proc.communicate()
     proc.wait()


### PR DESCRIPTION
npx from npm 7.1 stopped quoting arguments, making `test_js_licenses` fail.