### PR TITLE
Changed the link to the installation documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ To install using pip, enter the following command at a Bash or Windows command p
 pip install bokeh
 ```
 
-For more information, refer to the [installation documentation](https://docs.bokeh.org/en/latest/docs/first_steps/installation.html).
+For more information, refer to the [installation documentation](https://docs.bokeh.org/en/latest/docs/installation.html).
 
 ## Resources
 


### PR DESCRIPTION
I just made a change from the broken link to the new one. The second link works while the first one does not. A test can be done via the browser and thus not included.

Below is the working link to the installation documentation.

https://docs.bokeh.org/en/latest/docs/installation.html

- [x] issues: fixes #10767
