### PR TITLE
Displaying low/high color values of LinearColorMapper #10376

### DIFF
--- a/bokeh/core/enums.py
+++ b/bokeh/core/enums.py
@@ -92,7 +92,7 @@ __all__ = (
     'Direction',
     'Enumeration',
     'enumeration',
-    'Extend',
+    'ExtendColorBar',
     'FontStyle',
     'HatchPattern',
     'HatchPatternAbbreviation',
@@ -264,7 +264,7 @@ Dimensions = enumeration("width", "height", "both")
 Direction = enumeration("clock", "anticlock")
 
 #: Specify whether to include low_color and high_color in color_bar
-Extend = enumeration("neither", "min", "max", "both")
+ExtendColorBar = enumeration("none", "min", "max", "both")
 
 #: Specify the font style for rendering text
 FontStyle = enumeration("normal", "italic", "bold", "bold italic")

--- a/bokeh/core/enums.py
+++ b/bokeh/core/enums.py
@@ -262,6 +262,9 @@ Dimensions = enumeration("width", "height", "both")
 #: Specify a stroke direction for circles, wedges, etc.
 Direction = enumeration("clock", "anticlock")
 
+#: Specify whether to include low_color and high_color in color_bar
+Extend = enumeration("neither", "min", "max", "both")
+
 #: Specify the font style for rendering text
 FontStyle = enumeration("normal", "italic", "bold", "bold italic")
 

--- a/bokeh/core/enums.py
+++ b/bokeh/core/enums.py
@@ -92,6 +92,7 @@ __all__ = (
     'Direction',
     'Enumeration',
     'enumeration',
+    'Extend',
     'FontStyle',
     'HatchPattern',
     'HatchPatternAbbreviation',

--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 from ..core.enums import (
     AngleUnits,
     Dimension,
-    Extend,
+    ExtendColorBar,
     FontStyle,
     LegendClickPolicy,
     LegendLocation,
@@ -411,8 +411,8 @@ class ColorBar(Annotation):
         (i.e. `low=0`), the tick and tick labels won't be rendered.
     """)
 
-    extend = Enum(Extend, default = "neither", help="""
-    Whether the low_color and high_color should be included as an extension
+    extend = Enum(ExtendColorBar, default="none", help="""
+    Whether the `low_color` and `high_color` should be included as an extension.
     """)
 
     margin = Int(30, help="""

--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -22,6 +22,7 @@ log = logging.getLogger(__name__)
 from ..core.enums import (
     AngleUnits,
     Dimension,
+    Extend,
     FontStyle,
     LegendClickPolicy,
     LegendLocation,
@@ -408,6 +409,10 @@ class ColorBar(Annotation):
         passed to the `ticker` argument and either or both of the logarithms
         of `low` and `high` values of the color_mapper are non-numeric
         (i.e. `low=0`), the tick and tick labels won't be rendered.
+    """)
+
+    extend = Enum(Extend, default = "neither", help="""
+    Whether the low_color and high_color should be included as an extension
     """)
 
     margin = Int(30, help="""

--- a/bokehjs/src/lib/core/enums.ts
+++ b/bokehjs/src/lib/core/enums.ts
@@ -37,8 +37,8 @@ export const Direction = Enum("clock", "anticlock")
 export type Distribution = "uniform" | "normal"
 export const Distribution = Enum("uniform", "normal")
 
-export type Extend = "neither" | "min" | "max" | "both"
-export const Extend = Enum("neither", "min", "max", "both")
+export type ExtendColorBar = "none" | "min" | "max" | "both"
+export const ExtendColorBar = Enum("none", "min", "max", "both")
 
 export type FontStyle = "normal" | "italic" | "bold" | "bold italic"
 export const FontStyle = Enum("normal", "italic", "bold", "bold italic")

--- a/bokehjs/src/lib/core/enums.ts
+++ b/bokehjs/src/lib/core/enums.ts
@@ -37,6 +37,9 @@ export const Direction = Enum("clock", "anticlock")
 export type Distribution = "uniform" | "normal"
 export const Distribution = Enum("uniform", "normal")
 
+export type Extend = "neither" | "min" | "max" | "both"
+export const Extend = Enum("neither", "min", "max", "both")
+
 export type FontStyle = "normal" | "italic" | "bold" | "bold italic"
 export const FontStyle = Enum("normal", "italic", "bold", "bold italic")
 

--- a/bokehjs/src/lib/models/annotations/color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/color_bar.ts
@@ -341,21 +341,85 @@ export class ColorBarView extends AnnotationView {
 
   protected _draw_extensions(ctx: Context2d): void {
     const image = this._computed_image_dimensions()
+    const triangle_height = 15;
+    let [show_high, show_low] = [false, false]
 
-    if (this.model.color_mapper.low_color != null) {
-      ctx.translate(0, -15)
-      ctx.save()
-      ctx.fillStyle = this.model.color_mapper.low_color
-      ctx.fillRect(0, 0, image.width, 15)
-      ctx.restore()
-      ctx.translate(0, 15)
+    switch (this.model.extend) {
+      case "max":
+        show_high = true;
+        break
+      case "min":
+        show_low = true;
+        break
+      case "both":
+        show_high = true;
+        show_low = true;
+        break
     }
-    if (this.model.color_mapper.high_color != null) {
-      ctx.translate(0, image.height)
-      ctx.fillStyle = this.model.color_mapper.high_color
-      ctx.fillRect(0, 0, image.width, 15)
-      ctx.restore()
-      ctx.translate(0, -image.height)
+
+    switch (this.model.orientation) {
+      case "vertical":
+        if (show_high && this.model.color_mapper.high_color != null) {
+          ctx.save()
+
+          ctx.beginPath()
+          ctx.lineTo(image.width / 2, -triangle_height)
+          ctx.lineTo(image.width, 0)
+          ctx.lineTo(0, 0)
+          ctx.closePath()
+
+          ctx.fillStyle = this.model.color_mapper.high_color
+          ctx.fill()
+
+          ctx.restore()
+        }
+        if (show_low && this.model.color_mapper.low_color != null) {
+          ctx.save()
+
+          ctx.beginPath()
+          ctx.translate(0, image.height)
+          ctx.lineTo(image.width / 2, triangle_height)
+          ctx.lineTo(image.width, 0)
+          ctx.lineTo(0, 0)
+          ctx.closePath()
+
+          ctx.fillStyle = this.model.color_mapper.low_color
+          ctx.fill()
+
+          ctx.restore()
+        }
+        break
+      case "horizontal":
+        if (show_high && this.model.color_mapper.high_color != null) {
+          ctx.save()
+
+          ctx.beginPath()
+          ctx.lineTo(triangle_height, image.height / 2)
+          ctx.lineTo(0, image.height)
+          ctx.lineTo(0, 0)
+          ctx.closePath()
+
+          ctx.fillStyle = this.model.color_mapper.high_color
+          ctx.fill()
+
+          ctx.restore()
+        }
+        if (show_low && this.model.color_mapper.low_color != null) {
+          ctx.save()
+
+          ctx.beginPath()
+          ctx.translate(image.width, 0)
+          ctx.lineTo(-triangle_height, image.height / 2)
+          ctx.lineTo(0, image.height)
+          ctx.lineTo(0, 0)
+          ctx.closePath()
+
+          ctx.fillStyle = this.model.color_mapper.low_color
+          ctx.fill()
+
+          ctx.restore()
+        }
+        break
     }
   }
 

--- a/bokehjs/src/lib/models/annotations/color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/color_bar.ts
@@ -480,19 +480,6 @@ export class ColorBarView extends AnnotationView {
     return max([this.model.major_tick_out, this.model.minor_tick_out])
   }
 
-  _get_extend_colorbar(): number {
-    switch (this.model.extend) {
-      case "none":
-        return 0
-      case "min":
-        return 1
-      case "max":
-        return 2
-      case "both":
-        return 3
-    }
-  }
-
   _computed_image_dimensions(): {height: number, width: number} {
     /*
     Heuristics to determine ColorBar image dimensions if set to "auto"

--- a/bokehjs/src/lib/models/annotations/color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/color_bar.ts
@@ -93,30 +93,6 @@ export class ColorBarView extends AnnotationView {
   protected _set_canvas_image(): void {
     let {palette} = this.model.color_mapper.clone()
 
-    switch (this.model.extend) {
-      case "max": {
-        if (this.model.color_mapper.high_color != null) {
-          palette.push(this.model.color_mapper.high_color)
-        }
-        break
-      }
-      case "min": {
-        if (this.model.color_mapper.low_color != null) {
-          palette.unshift(this.model.color_mapper.low_color)
-        }
-        break
-      }
-      case "both": {
-        if (this.model.color_mapper.low_color != null) {
-          palette.unshift(this.model.color_mapper.low_color)
-        }
-        if (this.model.color_mapper.high_color != null) {
-          palette.push(this.model.color_mapper.high_color)
-        }
-        break
-      }
-    }
-
     if (this.model.orientation == 'vertical')
       palette = reversed(palette)
 
@@ -251,6 +227,9 @@ export class ColorBarView extends AnnotationView {
     this._draw_minor_ticks(ctx, tick_info)
     this._draw_major_labels(ctx, tick_info)
 
+    this._draw_extensions(ctx)
+
+
     if (this.model.title)
       this._draw_title(ctx)
 
@@ -358,6 +337,26 @@ export class ColorBarView extends AnnotationView {
       )
     }
     ctx.restore()
+  }
+
+  protected _draw_extensions(ctx: Context2d): void {
+    const image = this._computed_image_dimensions()
+
+    if (this.model.color_mapper.low_color != null) {
+      ctx.translate(0, -15)
+      ctx.save()
+      ctx.fillStyle = this.model.color_mapper.low_color
+      ctx.fillRect(0, 0, image.width, 15)
+      ctx.restore()
+      ctx.translate(0, 15)
+    }
+    if (this.model.color_mapper.high_color != null) {
+      ctx.translate(0, image.height)
+      ctx.fillStyle = this.model.color_mapper.high_color
+      ctx.fillRect(0, 0, image.width, 15)
+      ctx.restore()
+      ctx.translate(0, -image.height)
+    }
   }
 
   protected _draw_title(ctx: Context2d): void {

--- a/bokehjs/src/lib/models/annotations/color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/color_bar.ts
@@ -341,19 +341,19 @@ export class ColorBarView extends AnnotationView {
 
   protected _draw_extensions(ctx: Context2d): void {
     const image = this._computed_image_dimensions()
-    const triangle_height = 15;
+    const triangle_height = 15
     let [show_high, show_low] = [false, false]
 
     switch (this.model.extend) {
       case "max":
-        show_high = true;
+        show_high = true
         break
       case "min":
-        show_low = true;
+        show_low = true
         break
       case "both":
-        show_high = true;
-        show_low = true;
+        show_high = true
+        show_low = true
         break
     }
 
@@ -491,7 +491,7 @@ export class ColorBarView extends AnnotationView {
       case "both":
         return 3
     }
-  } 
+  }
 
   _computed_image_dimensions(): {height: number, width: number} {
     /*
@@ -745,7 +745,7 @@ export class ColorBar extends Annotation {
 
     this.define<ColorBar.Props>(({Alpha, Number, String, Tuple, Dict, Or, Ref, Auto}) => ({
       location:              [ Or(LegendLocation, Tuple(Number, Number)), "top_right" ],
-      extend:                [ ExtendColorBar , "none"],
+      extend:                [ ExtendColorBar, "none"],
       orientation:           [ Orientation, "vertical" ],
       title:                 [ String ],
       title_standoff:        [ Number, 2 ],

--- a/bokehjs/src/lib/models/annotations/color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/color_bar.ts
@@ -368,7 +368,7 @@ export class ColorBarView extends AnnotationView {
           ctx.lineTo(0, 0)
           ctx.closePath()
 
-          ctx.fillStyle = this.model.color_mapper.high_color
+          ctx.fillStyle = this.model.color_mapper.high_color as string
           ctx.fill()
 
           ctx.restore()
@@ -383,7 +383,7 @@ export class ColorBarView extends AnnotationView {
           ctx.lineTo(0, 0)
           ctx.closePath()
 
-          ctx.fillStyle = this.model.color_mapper.low_color
+          ctx.fillStyle = this.model.color_mapper.low_color as string
           ctx.fill()
 
           ctx.restore()
@@ -399,7 +399,7 @@ export class ColorBarView extends AnnotationView {
           ctx.lineTo(0, 0)
           ctx.closePath()
 
-          ctx.fillStyle = this.model.color_mapper.high_color
+          ctx.fillStyle = this.model.color_mapper.high_color as string
           ctx.fill()
 
           ctx.restore()
@@ -414,7 +414,7 @@ export class ColorBarView extends AnnotationView {
           ctx.lineTo(0, 0)
           ctx.closePath()
 
-          ctx.fillStyle = this.model.color_mapper.low_color
+          ctx.fillStyle = this.model.color_mapper.low_color as string
           ctx.fill()
 
           ctx.restore()

--- a/bokehjs/src/lib/models/annotations/color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/color_bar.ts
@@ -91,7 +91,28 @@ export class ColorBarView extends AnnotationView {
   }
 
   protected _set_canvas_image(): void {
-    let {palette} = this.model.color_mapper
+    let {palette} = this.model.color_mapper.clone()
+
+    switch (this.model.extend) {
+      case "max": {
+        if (this.model.color_mapper.high_color != null) {
+          palette.push(this.model.color_mapper.high_color)
+        }
+      }
+      case "min": {
+        if (this.model.color_mapper.low_color != null) {
+          palette.unshift(this.model.color_mapper.low_color)
+        }
+      }
+      case "both": {
+        if (this.model.color_mapper.low_color != null) {
+          palette.unshift(this.model.color_mapper.low_color)
+        }
+        if (this.model.color_mapper.high_color != null) {
+          palette.push(this.model.color_mapper.high_color)
+        }
+      }
+    }
 
     if (this.model.orientation == 'vertical')
       palette = reversed(palette)

--- a/bokehjs/src/lib/models/annotations/color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/color_bar.ts
@@ -480,6 +480,19 @@ export class ColorBarView extends AnnotationView {
     return max([this.model.major_tick_out, this.model.minor_tick_out])
   }
 
+  _get_extend_colorbar(): number {
+    switch (this.model.extend) {
+      case "none":
+        return 0
+      case "min":
+        return 1
+      case "max":
+        return 2
+      case "both":
+        return 3
+    }
+  } 
+
   _computed_image_dimensions(): {height: number, width: number} {
     /*
     Heuristics to determine ColorBar image dimensions if set to "auto"

--- a/bokehjs/src/lib/models/annotations/color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/color_bar.ts
@@ -15,7 +15,7 @@ import {LogScale} from "../scales/log_scale"
 import {Range1d} from "../ranges/range1d"
 
 import {Arrayable} from "core/types"
-import {Extend, LegendLocation, Orientation} from "core/enums"
+import {ExtendColorBar, LegendLocation, Orientation} from "core/enums"
 import * as visuals from "core/visuals"
 import * as mixins from "core/property_mixins"
 import * as p from "core/properties"
@@ -91,7 +91,7 @@ export class ColorBarView extends AnnotationView {
   }
 
   protected _set_canvas_image(): void {
-    let {palette} = this.model.color_mapper.clone()
+    let {palette} = this.model.color_mapper
 
     if (this.model.orientation == 'vertical')
       palette = reversed(palette)
@@ -603,7 +603,7 @@ export namespace ColorBar {
 
   export type Props = Annotation.Props & {
     location: p.Property<LegendLocation | [number, number]>
-    extend: p.Property<Extend>
+    extend: p.Property<ExtendColorBar>
     orientation: p.Property<Orientation>
     title: p.Property<string>
     title_standoff: p.Property<number>
@@ -668,7 +668,7 @@ export class ColorBar extends Annotation {
 
     this.define<ColorBar.Props>(({Alpha, Number, String, Tuple, Dict, Or, Ref, Auto}) => ({
       location:              [ Or(LegendLocation, Tuple(Number, Number)), "top_right" ],
-      extend:                [ Extend , "neither"],
+      extend:                [ ExtendColorBar , "none"],
       orientation:           [ Orientation, "vertical" ],
       title:                 [ String ],
       title_standoff:        [ Number, 2 ],

--- a/bokehjs/src/lib/models/annotations/color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/color_bar.ts
@@ -98,11 +98,13 @@ export class ColorBarView extends AnnotationView {
         if (this.model.color_mapper.high_color != null) {
           palette.push(this.model.color_mapper.high_color)
         }
+        break
       }
       case "min": {
         if (this.model.color_mapper.low_color != null) {
           palette.unshift(this.model.color_mapper.low_color)
         }
+        break
       }
       case "both": {
         if (this.model.color_mapper.low_color != null) {
@@ -111,6 +113,7 @@ export class ColorBarView extends AnnotationView {
         if (this.model.color_mapper.high_color != null) {
           palette.push(this.model.color_mapper.high_color)
         }
+        break
       }
     }
 

--- a/bokehjs/src/lib/models/annotations/color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/color_bar.ts
@@ -15,7 +15,7 @@ import {LogScale} from "../scales/log_scale"
 import {Range1d} from "../ranges/range1d"
 
 import {Arrayable} from "core/types"
-import {LegendLocation, Orientation} from "core/enums"
+import {Extend, LegendLocation, Orientation} from "core/enums"
 import * as visuals from "core/visuals"
 import * as mixins from "core/property_mixins"
 import * as p from "core/properties"
@@ -580,6 +580,7 @@ export namespace ColorBar {
 
   export type Props = Annotation.Props & {
     location: p.Property<LegendLocation | [number, number]>
+    extend: p.Property<Extend>
     orientation: p.Property<Orientation>
     title: p.Property<string>
     title_standoff: p.Property<number>
@@ -644,6 +645,7 @@ export class ColorBar extends Annotation {
 
     this.define<ColorBar.Props>(({Alpha, Number, String, Tuple, Dict, Or, Ref, Auto}) => ({
       location:              [ Or(LegendLocation, Tuple(Number, Number)), "top_right" ],
+      extend:                [ Extend , "neither"],
       orientation:           [ Orientation, "vertical" ],
       title:                 [ String ],
       title_standoff:        [ Number, 2 ],

--- a/bokehjs/test/integration/color_mapping.ts
+++ b/bokehjs/test/integration/color_mapping.ts
@@ -109,6 +109,7 @@ describe("Color mapping", () => {
         orientation: "horizontal",
         location: [0, 0],
         padding: 0,
+        extend: 'both',
       })
       p.add_layout(color_bar, "below")
 

--- a/bokehjs/test/unit/core/enums.ts
+++ b/bokehjs/test/unit/core/enums.ts
@@ -40,6 +40,10 @@ describe("enums module", () => {
     expect([...enums.Distribution]).to.be.equal(["uniform", "normal"])
   })
 
+  it("should have ExtendColorBar", () => {
+    expect([...enums.ExtendColorBar]).to.be.equal(["none", "min", "max", "both"])
+  })
+
   it("should have FontStyle", () => {
     expect([...enums.FontStyle]).to.be.equal(["normal", "italic", "bold", "bold italic"])
   })

--- a/bokehjs/test/unit/models/annotations/color_bar.ts
+++ b/bokehjs/test/unit/models/annotations/color_bar.ts
@@ -69,8 +69,8 @@ describe("ColorBar module", () => {
       })
     })
 
-    describe("ColorBar._get_extend_colorbar method", () => {
-      it("_get_extend_colorbar should return 0 when extend is not specified and defaulted to none", async () => {
+    describe("ColorBar.extend field", () => {
+      it("when ColorBar.extend is not specified, it defaulted to 'none'", async () => {
         const pal = ["red", "green", "blue"]
         const color_map = new LinearColorMapper({low: 0.3, high: 1, palette: pal, low_color: "pink", high_color: "orange"})
         const view = await color_bar_view({
@@ -81,7 +81,7 @@ describe("ColorBar module", () => {
         expect(view.model.extend).to.be.equal('none')
       })
 
-      it("_get_extend_colorbar should return 0 when extend is none", async () => {
+      it("ColorBar.extend = 'none'", async () => {
         const pal = ["red", "green", "blue"]
         const color_map = new LinearColorMapper({low: 0.3, high: 1, palette: pal, low_color: "pink", high_color: "orange"})
         const view = await color_bar_view({
@@ -93,7 +93,7 @@ describe("ColorBar module", () => {
         expect(view.model.extend).to.be.equal('none')
       })
 
-      it("_get_extend_colorbar should return 1 when extend is min", async () => {
+      it("ColorBar.extend = 'min'", async () => {
         const pal = ["red", "green", "blue"]
         const color_map = new LinearColorMapper({low: 0.3, high: 1, palette: pal, low_color: "pink", high_color: "orange"})
         const view = await color_bar_view({
@@ -105,7 +105,7 @@ describe("ColorBar module", () => {
         expect(view.model.extend).to.be.equal('min')
       })
 
-      it("_get_extend_colorbar should return 2 when extend is max", async () => {
+      it("ColorBar.extend = 'max'", async () => {
         const pal = ["red", "green", "blue"]
         const color_map = new LinearColorMapper({low: 0.3, high: 1, palette: pal, low_color: "pink", high_color: "orange"})
         const view = await color_bar_view({
@@ -117,7 +117,7 @@ describe("ColorBar module", () => {
         expect(view.model.extend).to.be.equal('max')
       })
 
-      it("_get_extend_colorbar should return 3 when extend is both", async () => {
+      it("ColorBar.extend = 'both'", async () => {
         const pal = ["red", "green", "blue"]
         const color_map = new LinearColorMapper({low: 0.3, high: 1, palette: pal, low_color: "pink", high_color: "orange"})
         const view = await color_bar_view({

--- a/bokehjs/test/unit/models/annotations/color_bar.ts
+++ b/bokehjs/test/unit/models/annotations/color_bar.ts
@@ -69,6 +69,57 @@ describe("ColorBar module", () => {
       })
     })
 
+    describe("ColorBar._get_extend_colorbar method", () => {
+      it("_get_extend_colorbar should return 0 when extend is not specified and defaulted to none", async () => {
+        const pal = ["red", "green", "blue"]
+        const color_map = new LinearColorMapper({low: 0.3, high: 1, palette: pal, low_color: "pink", high_color: "orange"})
+        const view = await color_bar_view({
+          color_mapper: color_map,
+        })
+        expect(view._get_extend_colorbar()).to.be.equal(0)
+      })
+
+      it("_get_extend_colorbar should return 0 when extend is none", async () => {
+        const pal = ["red", "green", "blue"]
+        const color_map = new LinearColorMapper({low: 0.3, high: 1, palette: pal, low_color: "pink", high_color: "orange"})
+        const view = await color_bar_view({
+          color_mapper: color_map,
+          extend: 'none',
+        })
+        expect(view._get_extend_colorbar()).to.be.equal(0)
+      })
+
+      it("_get_extend_colorbar should return 1 when extend is min", async () => {
+        const pal = ["red", "green", "blue"]
+        const color_map = new LinearColorMapper({low: 0.3, high: 1, palette: pal, low_color: "pink", high_color: "orange"})
+        const view = await color_bar_view({
+          color_mapper: color_map,
+          extend: 'min',
+        })
+        expect(view._get_extend_colorbar()).to.be.equal(1)
+      })
+
+      it("_get_extend_colorbar should return 2 when extend is max", async () => {
+        const pal = ["red", "green", "blue"]
+        const color_map = new LinearColorMapper({low: 0.3, high: 1, palette: pal, low_color: "pink", high_color: "orange"})
+        const view = await color_bar_view({
+          color_mapper: color_map,
+          extend: 'max',
+        })
+        expect(view._get_extend_colorbar()).to.be.equal(2)
+      })
+
+      it("_get_extend_colorbar should return 3 when extend is both", async () => {
+        const pal = ["red", "green", "blue"]
+        const color_map = new LinearColorMapper({low: 0.3, high: 1, palette: pal, low_color: "pink", high_color: "orange"})
+        const view = await color_bar_view({
+          color_mapper: color_map,
+          extend: 'both',
+        })
+        expect(view._get_extend_colorbar()).to.be.equal(3)
+      })
+    })
+
     describe("ColorBar._tick_extent method", () => {
       it("Should return zero if either low or high are unset", async () => {
         const view = await color_bar_view({

--- a/bokehjs/test/unit/models/annotations/color_bar.ts
+++ b/bokehjs/test/unit/models/annotations/color_bar.ts
@@ -78,7 +78,7 @@ describe("ColorBar module", () => {
         })
         const vals = color_map.v_compute([0.2, 0.35, 0.55, 1, 1.1])
         expect(vals).to.be.equal(["pink", "red", "green", "blue", "orange"])
-        expect(view._get_extend_colorbar()).to.be.equal(0)
+        expect(view.model.extend).to.be.equal('none')
       })
 
       it("_get_extend_colorbar should return 0 when extend is none", async () => {
@@ -90,7 +90,7 @@ describe("ColorBar module", () => {
         })
         const vals = color_map.v_compute([0.2, 0.35, 0.55, 1, 1.1])
         expect(vals).to.be.equal(["pink", "red", "green", "blue", "orange"])
-        expect(view._get_extend_colorbar()).to.be.equal(0)
+        expect(view.model.extend).to.be.equal('none')
       })
 
       it("_get_extend_colorbar should return 1 when extend is min", async () => {
@@ -102,7 +102,7 @@ describe("ColorBar module", () => {
         })
         const vals = color_map.v_compute([0.2, 0.35, 0.55, 1, 1.1])
         expect(vals).to.be.equal(["pink", "red", "green", "blue", "orange"])
-        expect(view._get_extend_colorbar()).to.be.equal(1)
+        expect(view.model.extend).to.be.equal('min')
       })
 
       it("_get_extend_colorbar should return 2 when extend is max", async () => {
@@ -114,7 +114,7 @@ describe("ColorBar module", () => {
         })
         const vals = color_map.v_compute([0.2, 0.35, 0.55, 1, 1.1])
         expect(vals).to.be.equal(["pink", "red", "green", "blue", "orange"])
-        expect(view._get_extend_colorbar()).to.be.equal(2)
+        expect(view.model.extend).to.be.equal('max')
       })
 
       it("_get_extend_colorbar should return 3 when extend is both", async () => {
@@ -126,7 +126,7 @@ describe("ColorBar module", () => {
         })
         const vals = color_map.v_compute([0.2, 0.35, 0.55, 1, 1.1])
         expect(vals).to.be.equal(["pink", "red", "green", "blue", "orange"])
-        expect(view._get_extend_colorbar()).to.be.equal(3)
+        expect(view.model.extend).to.be.equal('both')
       })
     })
 

--- a/bokehjs/test/unit/models/annotations/color_bar.ts
+++ b/bokehjs/test/unit/models/annotations/color_bar.ts
@@ -76,6 +76,8 @@ describe("ColorBar module", () => {
         const view = await color_bar_view({
           color_mapper: color_map,
         })
+        const vals = color_map.v_compute([0.2, 0.35, 0.55, 1, 1.1])
+        expect(vals).to.be.equal(["pink", "red", "green", "blue", "orange"])
         expect(view._get_extend_colorbar()).to.be.equal(0)
       })
 
@@ -86,6 +88,8 @@ describe("ColorBar module", () => {
           color_mapper: color_map,
           extend: 'none',
         })
+        const vals = color_map.v_compute([0.2, 0.35, 0.55, 1, 1.1])
+        expect(vals).to.be.equal(["pink", "red", "green", "blue", "orange"])
         expect(view._get_extend_colorbar()).to.be.equal(0)
       })
 
@@ -96,6 +100,8 @@ describe("ColorBar module", () => {
           color_mapper: color_map,
           extend: 'min',
         })
+        const vals = color_map.v_compute([0.2, 0.35, 0.55, 1, 1.1])
+        expect(vals).to.be.equal(["pink", "red", "green", "blue", "orange"])
         expect(view._get_extend_colorbar()).to.be.equal(1)
       })
 
@@ -106,6 +112,8 @@ describe("ColorBar module", () => {
           color_mapper: color_map,
           extend: 'max',
         })
+        const vals = color_map.v_compute([0.2, 0.35, 0.55, 1, 1.1])
+        expect(vals).to.be.equal(["pink", "red", "green", "blue", "orange"])
         expect(view._get_extend_colorbar()).to.be.equal(2)
       })
 
@@ -116,6 +124,8 @@ describe("ColorBar module", () => {
           color_mapper: color_map,
           extend: 'both',
         })
+        const vals = color_map.v_compute([0.2, 0.35, 0.55, 1, 1.1])
+        expect(vals).to.be.equal(["pink", "red", "green", "blue", "orange"])
         expect(view._get_extend_colorbar()).to.be.equal(3)
       })
     })

--- a/tests/unit/bokeh/core/test_enums.py
+++ b/tests/unit/bokeh/core/test_enums.py
@@ -171,7 +171,7 @@ class Test_bce:
 
     def test_Direction(self) -> None:
         assert tuple(bce.Direction) == ("clock", "anticlock")
-    
+
     def test_ExtendColorBar(self) -> None:
         assert tuple(bce.ExtendColorBar) == ("none", "min", "max", "both")
 

--- a/tests/unit/bokeh/core/test_enums.py
+++ b/tests/unit/bokeh/core/test_enums.py
@@ -41,6 +41,7 @@ ALL  = (
     'Direction',
     'Enumeration',
     'enumeration',
+    'ExtendColorBar',
     'FontStyle',
     'HatchPattern',
     'HatchPatternAbbreviation',
@@ -170,6 +171,9 @@ class Test_bce:
 
     def test_Direction(self) -> None:
         assert tuple(bce.Direction) == ("clock", "anticlock")
+    
+    def test_ExtendColorBar(self) -> None:
+        assert tuple(bce.ExtendColorBar) == ("none", "min", "max", "both")
 
     def test_FontStyle(self) -> None:
         assert tuple(bce.FontStyle) == ('normal', 'italic', 'bold', 'bold italic')
@@ -319,6 +323,7 @@ def test_enums_contents() -> None:
         'Dimensions',
         'Direction',
         'Enumeration',
+        'ExtendColorBar',
         'FontStyle',
         'HatchPattern',
         'HatchPatternAbbreviation',

--- a/tests/unit/bokeh/models/test_annotations.py
+++ b/tests/unit/bokeh/models/test_annotations.py
@@ -126,6 +126,7 @@ def test_ColorBar() -> None:
     assert color_bar.major_tick_out == 0
     assert color_bar.minor_tick_in == 0
     assert color_bar.minor_tick_out == 0
+    assert color_bar.extend == 'none'
     check_text_properties(color_bar, "title_", "13px", "bottom", "italic", scalar=True)
     check_text_properties(color_bar, "major_label_", "11px", "middle", "normal", "center", scalar=True)
     check_line_properties(color_bar, "major_tick_", "#ffffff")
@@ -155,7 +156,8 @@ def test_ColorBar() -> None:
         "major_tick_out",
         "minor_tick_in",
         "minor_tick_out",
-        "major_label_overrides"],
+        "major_label_overrides",
+        "extend"],
         prefix('title_', TEXT),
         prefix('major_label_', TEXT),
         prefix('major_tick_', LINE),


### PR DESCRIPTION
WIP but I wanted to get some first hand looks before proceeding further.

Currently I've implemented displaying low_color and high_color using the new extend field of the ColorBar. I modified the code snippet from the issue as below to produce the following color bar.

```
colormapper = LinearColorMapper(
    palette=palettes.magma(7)[::-1], low=0.3, high=1.0, low_color="red", high_color="blue"
)
```

```
color_bar = ColorBar(
    color_mapper=colormapper,
    location=(0, 0),
    extend = "both",
)
```

![Screen Shot 2020-12-15 at 4 55 41 AM](https://user-images.githubusercontent.com/43485776/102199583-cae33500-3e91-11eb-949d-0fd2b75785a7.png)

I plan on modifying the ticks so it aligns and modifying the labels so that "low" and "high" labels are displayed correctly, but I wanted to get a confirmation that this visualization is in the right direction. Thank you!


#10376 