### PR TITLE
Request paint only for changed renderers

### DIFF
--- a/bokehjs/src/lib/api/plotting.ts
+++ b/bokehjs/src/lib/api/plotting.ts
@@ -5,7 +5,7 @@ import {Color, Data, Attrs, Arrayable} from "../core/types"
 import {Value, Field, Vector} from "../core/vectorization"
 import {VectorSpec, ScalarSpec, ColorSpec, Property} from "../core/properties"
 import {Class} from "../core/class"
-import {Location, MarkerType} from "../core/enums"
+import {Location, MarkerType, RenderLevel} from "../core/enums"
 import {startsWith} from "../core/util/string"
 import {is_equal} from "../core/util/eq"
 import {some, includes} from "../core/util/array"
@@ -100,6 +100,7 @@ export type AuxGlyph = {
   source: ColumnarDataSource
   view: CDSView
   legend: string
+  level: RenderLevel
 }
 
 export type ArgsOf<P> = {
@@ -834,6 +835,9 @@ export class Figure extends Plot {
     const legend = this._process_legend(attrs.legend, source)
     delete attrs.legend
 
+    const level = attrs.level
+    delete attrs.level
+
     const has_sglyph = some(Object.keys(attrs), key => startsWith(key, "selection_"))
     const has_hglyph = some(Object.keys(attrs), key => startsWith(key, "hover_"))
 
@@ -867,6 +871,7 @@ export class Figure extends Plot {
       nonselection_glyph: nsglyph,
       selection_glyph:    sglyph,
       hover_glyph:        hglyph,
+      level,
     })
 
     if (legend != null) {

--- a/bokehjs/src/lib/models/annotations/arrow.ts
+++ b/bokehjs/src/lib/models/annotations/arrow.ts
@@ -63,7 +63,7 @@ export class ArrowView extends AnnotationView {
 
   set_data(source: ColumnarDataSource): void {
     super.set_data(source)
-    this.plot_view.request_render()
+    this.request_render()
   }
 
   protected _map_data(): void {

--- a/bokehjs/src/lib/models/annotations/color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/color_bar.ts
@@ -77,11 +77,11 @@ export class ColorBarView extends AnnotationView {
 
   connect_signals(): void {
     super.connect_signals()
-    this.connect(this._ticker.change, () => this.plot_view.request_render())
-    this.connect(this._formatter.change, () => this.plot_view.request_render())
+    this.connect(this._ticker.change, () => this.request_render())
+    this.connect(this._formatter.change, () => this.request_render())
     this.connect(this.model.color_mapper.change, () => {
       this._set_canvas_image()
-      this.plot_view.request_render()
+      this.request_render()
     })
   }
 

--- a/bokehjs/src/lib/models/annotations/label_set.ts
+++ b/bokehjs/src/lib/models/annotations/label_set.ts
@@ -57,19 +57,19 @@ export class LabelSetView extends TextAnnotationView {
     } else {
       this.connect(this.model.change, () => {
         this.set_data(this.model.source)
-        this.plot_view.request_render()
+        this.request_render()
       })
       this.connect(this.model.source.streaming, () => {
         this.set_data(this.model.source)
-        this.plot_view.request_render()
+        this.request_render()
       })
       this.connect(this.model.source.patching, () => {
         this.set_data(this.model.source)
-        this.plot_view.request_render()
+        this.request_render()
       })
       this.connect(this.model.source.change, () => {
         this.set_data(this.model.source)
-        this.plot_view.request_render()
+        this.request_render()
       })
     }
   }

--- a/bokehjs/src/lib/models/annotations/legend.ts
+++ b/bokehjs/src/lib/models/annotations/legend.ts
@@ -32,8 +32,8 @@ export class LegendView extends AnnotationView {
 
   connect_signals(): void {
     super.connect_signals()
-    this.connect(this.model.change, () => this.plot_view.request_render())
-    this.connect(this.model.item_change, () => this.plot_view.request_render())
+    this.connect(this.model.change, () => this.request_render())
+    this.connect(this.model.item_change, () => this.request_render())
   }
 
   compute_legend_bbox(): BBox {

--- a/bokehjs/src/lib/models/annotations/poly_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/poly_annotation.ts
@@ -13,8 +13,8 @@ export class PolyAnnotationView extends AnnotationView {
     super.connect_signals()
     // need to respond to either normal BB change events or silent
     // "data only updates" that tools might want to use
-    this.connect(this.model.change, () => this.plot_view.request_render())
-    this.connect(this.model.data_update, () => this.plot_view.request_render())
+    this.connect(this.model.change, () => this.request_render())
+    this.connect(this.model.data_update, () => this.request_render())
   }
 
   protected _render(): void {

--- a/bokehjs/src/lib/models/annotations/slope.ts
+++ b/bokehjs/src/lib/models/annotations/slope.ts
@@ -9,7 +9,7 @@ export class SlopeView extends AnnotationView {
 
   connect_signals(): void {
     super.connect_signals()
-    this.connect(this.model.change, () => this.plot_view.request_render())
+    this.connect(this.model.change, () => this.request_render())
   }
 
   protected _render(): void {

--- a/bokehjs/src/lib/models/annotations/text_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/text_annotation.ts
@@ -36,7 +36,7 @@ export abstract class TextAnnotationView extends AnnotationView {
       // dispatch CSS update immediately
       this.connect(this.model.change, () => this.render())
     } else {
-      this.connect(this.model.change, () => this.plot_view.request_render())
+      this.connect(this.model.change, () => this.request_render())
     }
   }
 

--- a/bokehjs/src/lib/models/annotations/upper_lower.ts
+++ b/bokehjs/src/lib/models/annotations/upper_lower.ts
@@ -25,7 +25,7 @@ export abstract class UpperLowerView extends AnnotationView {
 
   set_data(source: ColumnarDataSource): void {
     super.set_data(source)
-    this.plot_view.request_render()
+    this.request_render()
   }
 
   protected _map_data(): void {

--- a/bokehjs/src/lib/models/glyphs/image.ts
+++ b/bokehjs/src/lib/models/glyphs/image.ts
@@ -21,7 +21,7 @@ export class ImageView extends ImageBaseView {
     // Only reset image_data if already initialized
     if (this.image_data != null) {
       this._set_data(null)
-      this.renderer.plot_view.request_render()
+      this.renderer.request_render()
     }
   }
 

--- a/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
@@ -70,7 +70,7 @@ export class GMapPlotView extends PlotView {
         const decoded_api_key = atob(this.model.api_key)
         load_google_api(decoded_api_key)
       }
-      gmaps_ready.connect(() => this.request_render())
+      gmaps_ready.connect(() => this.request_paint("everything"))
     }
 
     this.unpause()

--- a/bokehjs/src/lib/models/ranges/data_range1d.ts
+++ b/bokehjs/src/lib/models/ranges/data_range1d.ts
@@ -265,6 +265,12 @@ export class DataRange1d extends DataRange {
         end = this._initial_end
     }
 
+    let needs_emit = false
+    if (this.bounds == "auto") {
+      this.setv({bounds: [start, end]}, {silent: true})
+      needs_emit = true
+    }
+
     // only trigger updates when there are changes
     const [_start, _end] = [this.start, this.end]
     if (start != _start || end != _end) {
@@ -274,12 +280,11 @@ export class DataRange1d extends DataRange {
       if (end != _end)
         new_range.end = end
       this.setv(new_range)
+      needs_emit = false
     }
 
-    if (this.bounds == 'auto')
-      this.setv({bounds: [start, end]}, {silent: true})
-
-    this.change.emit()
+    if (needs_emit)
+      this.change.emit()
   }
 
   reset(): void {

--- a/bokehjs/src/lib/models/renderers/renderer.ts
+++ b/bokehjs/src/lib/models/renderers/renderer.ts
@@ -57,7 +57,7 @@ export abstract class RendererView extends View {
   }
 
   request_render(): void {
-    this.plot_view.request_render()
+    this.plot_view.request_paint(this)
   }
 
   notify_finished(): void {

--- a/bokehjs/src/lib/models/tools/gestures/select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/select_tool.ts
@@ -72,7 +72,8 @@ export abstract class SelectToolView extends GestureToolView {
     for (const renderer of this.computed_renderers) {
       renderer.get_selection_manager().clear()
     }
-    this.plot_view.request_render()
+    const renderer_views = this.computed_renderers.map((r) => this.plot_view.renderer_view(r)!)
+    this.plot_view.request_paint(renderer_views)
   }
 
   _select(geometry: Geometry, final: boolean, mode: SelectionMode): void {

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -1,7 +1,9 @@
+import sinon from "sinon"
+
 import {expect} from "assertions"
 import {display, fig} from "./_util"
 
-import {HoverTool} from "@bokehjs/models"
+import {HoverTool, BoxAnnotation} from "@bokehjs/models"
 
 describe("Bug", () => {
   describe("in issue #10612", () => {
@@ -17,6 +19,46 @@ describe("Bug", () => {
       plot.circle([3, 4, 5], [4, 5, 6])
       await view.ready
       expect(hover_view.computed_renderers.length).to.be.equal(3)
+    })
+  })
+
+  describe("in issue #10784", () => {
+    it("doesn't allow to repaint an individual layer of a plot", async () => {
+      const plot = fig([200, 200])
+      const r0 = plot.circle([0, 1, 2], [3, 4, 5], {fill_color: "blue", level: "glyph"})
+      const r1 = plot.circle(1, 3, {fill_color: "red", level: "overlay"})
+      const r2 = new BoxAnnotation({left: 0, right: 2, bottom: 3, top: 5, level: "overlay"})
+      plot.add_layout(r2)
+      const {view} = await display(plot)
+
+      const rv0 = view.renderer_view(r0)!
+      const rv1 = view.renderer_view(r1)!
+      const rv2 = view.renderer_view(r2)!
+
+      const rv0_spy = sinon.spy(rv0, "render")
+      const rv1_spy = sinon.spy(rv1, "render")
+      const rv2_spy = sinon.spy(rv2, "render")
+
+      r1.glyph.x = 2
+      await view.ready
+
+      expect(rv0_spy.callCount).to.be.equal(0)
+      expect(rv1_spy.callCount).to.be.equal(1)
+      expect(rv2_spy.callCount).to.be.equal(1)
+
+      r1.glyph.y = 4
+      await view.ready
+
+      expect(rv0_spy.callCount).to.be.equal(0)
+      expect(rv1_spy.callCount).to.be.equal(2)
+      expect(rv2_spy.callCount).to.be.equal(2)
+
+      r2.left = 1
+      await view.ready
+
+      expect(rv0_spy.callCount).to.be.equal(0)
+      expect(rv1_spy.callCount).to.be.equal(3)
+      expect(rv2_spy.callCount).to.be.equal(3)
     })
   })
 })


### PR DESCRIPTION
This makes paint invalidation process more selective, allowing to have glyphs on multiple layers, where updating a glyph on one layer doesn't force repaint on other layers. For now we have two implicit layers (base and overlays), but I will get this generalized in near future, so that the user will be able to create his own layers and stack them, allowing to take advantage of the full potential of this change.

- [x] integration tests

fixes #10784