### PR TITLE
Make Websocket compression configurable on Tornado server

### DIFF
--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -721,6 +721,22 @@ class Serve(Subcommand):
             type    = int,
         )),
 
+        ('--websocket-compression-level', dict(
+            metavar = 'LEVEL',
+            action  = 'store',
+            help    = "Set the Tornado WebSocket compression_level",
+            default = None,
+            type    = int,
+        )),
+
+        ('--websocket-compression-mem-level', dict(
+            metavar = 'LEVEL',
+            action  = 'store',
+            help    = "Set the Tornado WebSocket compression mem_level",
+            default = None,
+            type    = int,
+        )),
+
         ('--glob', dict(
             action='store_true',
             help='Process all filename arguments as globs',
@@ -799,6 +815,8 @@ class Serve(Subcommand):
                                                               'mem_log_frequency_milliseconds',
                                                               'use_xheaders',
                                                               'websocket_max_message_size',
+                                                              'websocket_compression_level',
+                                                              'websocket_compression_mem_level',
                                                               'include_cookies',
                                                               'include_headers',
                                                               'exclude_cookies',

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -41,6 +41,7 @@ from .contexts import ApplicationContext
 from .urls import per_app_patterns, toplevel_patterns
 from .views.root_handler import RootHandler
 from .views.static_handler import StaticHandler
+from .views.ws import WSHandler
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -164,6 +165,14 @@ class BokehTornado(TornadoApplication):
             Set the Tornado ``websocket_max_message_size`` value.
             (default: {DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES})
 
+        websocket_compression_level (int, optional):
+            Set the Tornado WebSocket ``compression_level`` documented in
+            https://docs.python.org/3.6/library/zlib.html#zlib.compressobj.
+
+        websocket_compression_mem_level (int, optional):
+            Set the Tornado WebSocket compression ``mem_level`` documented in
+            https://docs.python.org/3.6/library/zlib.html#zlib.compressobj.
+
         index (str, optional):
             Path to a Jinja2 template to use for the root URL
 
@@ -211,6 +220,8 @@ class BokehTornado(TornadoApplication):
                  use_index=True,
                  redirect_root=True,
                  websocket_max_message_size_bytes=DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES,
+                 websocket_compression_level=None,
+                 websocket_compression_mem_level=None,
                  index=None,
                  auth_provider=NullAuth(),
                  xsrf_cookies=False,
@@ -353,8 +364,12 @@ class BokehTornado(TornadoApplication):
                     route = p[0]
                 else:
                     route = key + p[0]
+                context = {"application_context": self._applications[key]}
+                if issubclass(p[1], WSHandler):
+                    context['compression_level'] = websocket_compression_level
+                    context['mem_level'] = websocket_compression_mem_level
                 route = self._prefix + route
-                app_patterns.append((route, p[1], { "application_context" : self._applications[key] }))
+                app_patterns.append((route, p[1], context))
 
             websocket_path = None
             for r in app_patterns:

--- a/bokeh/server/views/ws.py
+++ b/bokeh/server/views/ws.py
@@ -72,6 +72,9 @@ class WSHandler(AuthMixin, WebSocketHandler):
 
         self._token = None
 
+        self._compression_level = kw.pop('compression_level', None)
+        self._mem_level = kw.pop('mem_level', None)
+
         # Note: tornado_app is stored as self.application
         super().__init__(tornado_app, *args, **kw)
 
@@ -157,6 +160,14 @@ class WSHandler(AuthMixin, WebSocketHandler):
             return None
         self._token = subprotocols[1]
         return subprotocols[0]
+
+    def get_compression_options(self):
+        if self._compression_level is None:
+            return None
+        options = {'compression_level': self._compression_level}
+        if self._mem_level is not None:
+            options['mem_level'] = self._mem_level
+        return options
 
     async def _async_open(self, token):
         ''' Perform the specific steps needed to open a connection to a Bokeh session

--- a/tests/codebase/test_js_license_set.py
+++ b/tests/codebase/test_js_license_set.py
@@ -43,7 +43,7 @@ def test_js_license_set() -> None:
     '''
     os.chdir('bokehjs')
     proc = Popen([
-        "npx", "license-checker", "--production", "--summary", "--onlyAllow", "%r" % ";".join(LICENSES)
+        "npx", "license-checker", "--production", "--summary", "--onlyAllow", "%s" % ";".join(LICENSES)
     ],stdout=PIPE)
     proc.communicate()
     proc.wait()

--- a/tests/codebase/test_js_license_set.py
+++ b/tests/codebase/test_js_license_set.py
@@ -43,7 +43,7 @@ def test_js_license_set() -> None:
     '''
     os.chdir('bokehjs')
     proc = Popen([
-        "npx", "license-checker", "--production", "--summary", "--onlyAllow", "%s" % ";".join(LICENSES)
+        "npx", "license-checker", "--production", "--summary", "--onlyAllow", "%r" % ";".join(LICENSES)
     ],stdout=PIPE)
     proc.communicate()
     proc.wait()

--- a/tests/unit/bokeh/command/subcommands/test_serve.py
+++ b/tests/unit/bokeh/command/subcommands/test_serve.py
@@ -323,6 +323,14 @@ def test_args() -> None:
             type    = int,
         )),
 
+        ('--websocket-compression-level', dict(
+            metavar = 'LEVEL',
+            action  = 'store',
+            help    = "Set the Tornado WebSocket compression_level",
+            default = None,
+            type    = int,
+        )),
+
         ('--websocket-compression-mem-level', dict(
             metavar = 'LEVEL',
             action  = 'store',

--- a/tests/unit/bokeh/command/subcommands/test_serve.py
+++ b/tests/unit/bokeh/command/subcommands/test_serve.py
@@ -323,6 +323,14 @@ def test_args() -> None:
             type    = int,
         )),
 
+        ('--websocket-compression-mem-level', dict(
+            metavar = 'LEVEL',
+            action  = 'store',
+            help    = "Set the Tornado WebSocket compression mem_level",
+            default = None,
+            type    = int,
+        )),
+
         ('--glob', dict(
             action='store_true',
             help='Process all filename arguments as globs',

--- a/tests/unit/bokeh/server/test_tornado__server.py
+++ b/tests/unit/bokeh/server/test_tornado__server.py
@@ -27,6 +27,7 @@ from bokeh.application import Application
 from bokeh.client import pull_session
 from bokeh.server.auth_provider import NullAuth
 from bokeh.server.views.static_handler import StaticHandler
+from bokeh.server.views.ws import WSHandler
 
 # Module under test
 import bokeh.server.tornado as tornado # isort:skip
@@ -139,6 +140,16 @@ def test_websocket_max_message_size_bytes() -> None:
     app = Application()
     t = tornado.BokehTornado({"/": app}, websocket_max_message_size_bytes=12345)
     assert t.settings['websocket_max_message_size'] == 12345
+
+def test_websocket_compression_level() -> None:
+    app = Application()
+    t = tornado.BokehTornado({"/": app}, websocket_compression_level=2,
+                             websocket_compression_mem_level=3)
+    ws_rules = [rule for rule in t.wildcard_router.rules if isinstance(r.target, WSHandler)]
+    assert len(ws_rules) == 1
+    ws_rule = ws_rules[0]
+    assert ws_rule.target_kwargs.get('compression_level') == 2
+    assert ws_rule.target_kwargs.get('mem_level') == 3
 
 def test_websocket_origins(ManagedServerLoop, unused_tcp_port) -> None:
     application = Application()

--- a/tests/unit/bokeh/server/test_tornado__server.py
+++ b/tests/unit/bokeh/server/test_tornado__server.py
@@ -145,7 +145,7 @@ def test_websocket_compression_level() -> None:
     app = Application()
     t = tornado.BokehTornado({"/": app}, websocket_compression_level=2,
                              websocket_compression_mem_level=3)
-    ws_rules = [rule for rule in t.wildcard_router.rules if isinstance(r.target, WSHandler)]
+    ws_rules = [rule for rule in t.wildcard_router.rules if isinstance(rule.target, WSHandler)]
     assert len(ws_rules) == 1
     ws_rule = ws_rules[0]
     assert ws_rule.target_kwargs.get('compression_level') == 2

--- a/tests/unit/bokeh/server/test_tornado__server.py
+++ b/tests/unit/bokeh/server/test_tornado__server.py
@@ -145,7 +145,7 @@ def test_websocket_compression_level() -> None:
     app = Application()
     t = tornado.BokehTornado({"/": app}, websocket_compression_level=2,
                              websocket_compression_mem_level=3)
-    ws_rules = [rule for rule in t.wildcard_router.rules if isinstance(rule.target, WSHandler)]
+    ws_rules = [rule for rule in t.wildcard_router.rules if issubclass(rule.target, WSHandler)]
     assert len(ws_rules) == 1
     ws_rule = ws_rules[0]
     assert ws_rule.target_kwargs.get('compression_level') == 2


### PR DESCRIPTION
This PR makes it possible to enable WebSocket compression but does not enable it by default.

- [x] issues: fixes #10798
- [x] tests added / passed
- [x] release document entry (if new feature or API change)
