### PR TITLE
Make exports consider current theme

### DIFF
--- a/bokeh/io/export.py
+++ b/bokeh/io/export.py
@@ -302,7 +302,7 @@ def get_layout_html(obj: Union[LayoutDOM, Document], *, resources: Resources = I
     {% endblock %}
     """
 
-    try:        
+    try:
         html = file_html(obj, resources, title="", template=template, suppress_callback_warning=True,
                          _always_new=True, theme=curstate().document.theme)
     finally:

--- a/bokeh/io/export.py
+++ b/bokeh/io/export.py
@@ -34,6 +34,7 @@ from ..document import Document
 from ..embed import file_html
 from ..models.layouts import LayoutDOM
 from ..resources import INLINE, Resources
+from .state import curstate
 from .util import default_filename
 
 #-----------------------------------------------------------------------------
@@ -301,8 +302,9 @@ def get_layout_html(obj: Union[LayoutDOM, Document], *, resources: Resources = I
     {% endblock %}
     """
 
-    try:
-        html = file_html(obj, resources, title="", template=template, suppress_callback_warning=True, _always_new=True)
+    try:        
+        html = file_html(obj, resources, title="", template=template, suppress_callback_warning=True,
+                         _always_new=True, theme=curstate().document.theme)
     finally:
         if resize:
             assert isinstance(obj, Plot)

--- a/bokeh/io/state.py
+++ b/bokeh/io/state.py
@@ -210,7 +210,7 @@ class State:
         self._document = doc
         self._reset_keeping_doc()
 
-def curstate():
+def curstate() -> State:
     ''' Return the current State object
 
     Returns:


### PR DESCRIPTION
This PR should make exports consider the current theme.
- [x] issues: fixes #10804
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

Should I add a test to https://github.com/bokeh/bokeh/blob/branch-2.3/tests/unit/bokeh/io/test_export.py which checks that e.g. the export function works as excepted using a similar example as given in the issue?