### PR TITLE
Fix CustomJSFilter args dict: warn if disallowed key is passed

### DIFF
--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -114,6 +114,7 @@ Container Properties
 .. autoclass:: RelativeDelta
 .. autoclass:: Seq
 .. autoclass:: Tuple
+.. autoclass:: RestrictedDict
 
 DataSpec Properties
 -------------------
@@ -232,6 +233,7 @@ __all__ = (
     'RGB',
     'Regex',
     'RelativeDelta',
+    'RestrictedDict',
     'ScreenDistanceSpec',
     'Seq',
     'Size',
@@ -269,6 +271,7 @@ from .property.container import List; List
 from .property.container import Seq; Seq
 from .property.container import Tuple; Tuple
 from .property.container import RelativeDelta; RelativeDelta
+from .property.container import RestrictedDict; RestrictedDict
 
 from .property.dataspec import AlphaSpec; AlphaSpec
 from .property.dataspec import AngleSpec; AngleSpec

--- a/bokeh/core/property/container.py
+++ b/bokeh/core/property/container.py
@@ -362,16 +362,13 @@ class RestrictedDict(Dict):
     """
 
     def __init__(self, disallow, keys_type, values_type, default={}, help=None):
-        self._disallow = disallow
+        self._disallow = set(disallow)
         super.__init__(self, keys_type, values_type, default={}, help=None)
         
     def validate(self, value, detail=True):
         super().validate(value, detail)
-
-        disallowed_keys = self._disallow
-        user_keys = self.keys()
         
-        error_keys = list(set(disallowed_keys) & set(user_keys))
+        error_keys = self._disallow & value.keys()
         
         if not error_keys:
             msg = "The key(s): " + " ".join(error_keys) + " are disallowed."

--- a/bokeh/core/property/container.py
+++ b/bokeh/core/property/container.py
@@ -361,17 +361,22 @@ class RestrictedDict(Dict):
 
     """
 
+    def __init__(self, disallow, keys_type, values_type, default={}, help=None):
+        self._disallow = disallow
+        super.__init__(self, keys_type, values_type, default={}, help=None)
+        
     def validate(self, value, detail=True):
         super().validate(value, detail)
 
-        disallowed_keys = self.disallow
+        disallowed_keys = self._disallow
         user_keys = self.keys()
-
-        for k in user_keys:
-            if k in disallowed_keys:
-                msg = f"{k} key is disallowed"
-                raise ValueError(msg)
-            break
+        
+        error_keys = list(set(disallowed_keys) & set(user_keys))
+        
+        if not error_keys:
+            msg = "The key(s): " + " ".join(error_keys) + " are disallowed."
+            raise ValueError(msg)
+            
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------

--- a/bokeh/core/property/container.py
+++ b/bokeh/core/property/container.py
@@ -364,16 +364,16 @@ class RestrictedDict(Dict):
     def __init__(self, disallow, keys_type, values_type, default={}, help=None):
         self._disallow = set(disallow)
         super().__init__(keys_type=keys_type, values_type=values_type, default=default, help=help)
-        
+
     def validate(self, value, detail=True):
         super().validate(value, detail)
-        
+
         error_keys = self._disallow & value.keys()
-        
+
         if not error_keys:
-            msg = msg = "" if not detail else f"Disallowed keys: {error_keys!r}"
+            msg = "" if not detail else f"Disallowed keys: {error_keys!r}"
             raise ValueError(msg)
-            
+
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------

--- a/bokeh/core/property/container.py
+++ b/bokeh/core/property/container.py
@@ -371,7 +371,7 @@ class RestrictedDict(Dict):
         error_keys = self._disallow & value.keys()
         
         if not error_keys:
-            msg = "The key(s): " + " ".join(error_keys) + " are disallowed."
+            msg = msg = "" if not detail else f"Disallowed keys: {error_keys!r}"
             raise ValueError(msg)
             
 #-----------------------------------------------------------------------------

--- a/bokeh/core/property/container.py
+++ b/bokeh/core/property/container.py
@@ -371,7 +371,7 @@ class RestrictedDict(Dict):
         error_keys = self._disallow & value.keys()
 
         if not error_keys:
-            msg = "" if not detail else f"Disallowed keys: {error_keys!r}"
+            msg = f"Disallowed keys: {error_keys!r}"
             raise ValueError(msg)
 
 #-----------------------------------------------------------------------------

--- a/bokeh/core/property/container.py
+++ b/bokeh/core/property/container.py
@@ -39,6 +39,7 @@ __all__ = (
     'Dict',
     'List',
     'RelativeDelta',
+    'RestrictedDict',
     'Seq',
     'Tuple',
 )

--- a/bokeh/core/property/container.py
+++ b/bokeh/core/property/container.py
@@ -363,7 +363,7 @@ class RestrictedDict(Dict):
 
     def __init__(self, disallow, keys_type, values_type, default={}, help=None):
         self._disallow = set(disallow)
-        super.__init__(keys_type=keys_type, values_type=values_type, default=default, help=help)
+        super().__init__(keys_type=keys_type, values_type=values_type, default=default, help=help)
         
     def validate(self, value, detail=True):
         super().validate(value, detail)

--- a/bokeh/core/property/container.py
+++ b/bokeh/core/property/container.py
@@ -363,7 +363,7 @@ class RestrictedDict(Dict):
 
     def __init__(self, disallow, keys_type, values_type, default={}, help=None):
         self._disallow = set(disallow)
-        super.__init__(self, keys_type, values_type, default={}, help=None)
+        super.__init__(keys_type=keys_type, values_type=values_type, default=default, help=help)
         
     def validate(self, value, detail=True):
         super().validate(value, detail)

--- a/bokeh/core/property/container.py
+++ b/bokeh/core/property/container.py
@@ -370,8 +370,8 @@ class RestrictedDict(Dict):
 
         error_keys = self._disallow & value.keys()
 
-        if not error_keys:
-            msg = f"Disallowed keys: {error_keys!r}"
+        if error_keys:
+            msg = "" if not detail else f"Disallowed keys: {error_keys!r}"
             raise ValueError(msg)
 
 #-----------------------------------------------------------------------------

--- a/bokeh/core/property/container.py
+++ b/bokeh/core/property/container.py
@@ -361,7 +361,7 @@ class RestrictedDict(Dict):
 
     """
 
-    def __init__(self, disallow, keys_type, values_type, default={}, help=None):
+    def __init__(self, keys_type, values_type, disallow, default={}, help=None):
         self._disallow = set(disallow)
         super().__init__(keys_type=keys_type, values_type=values_type, default=default, help=help)
 

--- a/bokeh/core/property/container.py
+++ b/bokeh/core/property/container.py
@@ -356,6 +356,22 @@ class RelativeDelta(Dict):
     def __str__(self):
         return self.__class__.__name__
 
+class RestrictedDict(Dict):
+    """ Check for disallowed key(s).
+
+    """
+
+    def validate(self, value, detail=True):
+        super().validate(value, detail)
+
+        disallowed_keys = self.disallow
+        user_keys = self.keys()
+
+        for k in user_keys:
+            if k in disallowed_keys:
+                msg = f"{k} key is disallowed"
+                raise ValueError(msg)
+            break
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------

--- a/bokeh/models/filters.py
+++ b/bokeh/models/filters.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 # Bokeh imports
 from ..core.has_props import abstract
-from ..core.properties import AnyRef, Bool, Dict, Int, Seq, String
+from ..core.properties import AnyRef, Bool, Dict, Int, Seq, String, RestrictedDict
 from ..model import Model
 
 #-----------------------------------------------------------------------------

--- a/bokeh/models/filters.py
+++ b/bokeh/models/filters.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 # Bokeh imports
 from ..core.has_props import abstract
-from ..core.properties import AnyRef, Bool, Dict, Int, Seq, String, RestrictedDict
+from ..core.properties import AnyRef, Bool, Int, Seq, String, RestrictedDict
 from ..model import Model
 
 #-----------------------------------------------------------------------------

--- a/bokeh/models/filters.py
+++ b/bokeh/models/filters.py
@@ -102,7 +102,7 @@ class CustomJSFilter(Filter):
 
     '''
 
-    args = Dict(String, AnyRef, help="""
+    args = RestrictedDict(String, AnyRef, disallowed=("source",), help="""
     A mapping of names to Python objects. In particular those can be bokeh's models.
     These objects are made available to the callback's code snippet as the values of
     named parameters to the callback.

--- a/bokeh/models/filters.py
+++ b/bokeh/models/filters.py
@@ -102,7 +102,7 @@ class CustomJSFilter(Filter):
 
     '''
 
-    args = RestrictedDict(String, AnyRef, disallowed=("source",), help="""
+    args = RestrictedDict(String, AnyRef, disallow=("source",), help="""
     A mapping of names to Python objects. In particular those can be bokeh's models.
     These objects are made available to the callback's code snippet as the values of
     named parameters to the callback.

--- a/tests/unit/bokeh/core/property/test_container.py
+++ b/tests/unit/bokeh/core/property/test_container.py
@@ -35,6 +35,7 @@ ALL = (
     'Dict',
     'List',
     'RelativeDelta',
+    'RestrictedDict',
     'Seq',
     'Tuple',
 )
@@ -285,6 +286,13 @@ class Test_Tuple:
     def test_str(self) -> None:
         prop = bcpc.Tuple(Int, Int)
         assert str(prop) == "Tuple(Int, Int)"
+
+class Test_RestrictedDict:
+    def test_invalid(self) -> None:
+        prop = bcpc.RestrictedDict(String, bcpc.List(Int), disallow=("disallowed_key_1", "disallowed_key_2"))
+
+        assert not prop.is_valid({"disallowed_key_1": [1,2,3]})
+        assert not prop.is_valid({"disallowed_key_2": [1,2,3]})
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/core/property/test_container.py
+++ b/tests/unit/bokeh/core/property/test_container.py
@@ -35,7 +35,6 @@ ALL = (
     'Dict',
     'List',
     'RelativeDelta',
-    'RestrictedDict',
     'Seq',
     'Tuple',
 )

--- a/tests/unit/bokeh/core/property/test_container.py
+++ b/tests/unit/bokeh/core/property/test_container.py
@@ -288,6 +288,12 @@ class Test_Tuple:
         assert str(prop) == "Tuple(Int, Int)"
 
 class Test_RestrictedDict:
+    def test_valid(self) -> None:
+        prop = bcpc.RestrictedDict(String, bcpc.List(Int), disallow=("disallowed_key_1", "disallowed_key_2"))
+
+        assert prop.is_valid({"non_disallowed_key_1": [1,2,3]})
+        assert prop.is_valid({"non_disallowed_key_2": [1,2,3]})
+
     def test_invalid(self) -> None:
         prop = bcpc.RestrictedDict(String, bcpc.List(Int), disallow=("disallowed_key_1", "disallowed_key_2"))
 

--- a/tests/unit/bokeh/core/property/test_container.py
+++ b/tests/unit/bokeh/core/property/test_container.py
@@ -35,6 +35,7 @@ ALL = (
     'Dict',
     'List',
     'RelativeDelta',
+    'RestrictedDict',
     'Seq',
     'Tuple',
 )

--- a/tests/unit/bokeh/core/test_properties.py
+++ b/tests/unit/bokeh/core/test_properties.py
@@ -92,6 +92,7 @@ ALL = (
     'RGB',
     'Regex',
     'RelativeDelta',
+    'RestrictedDict',
     'ScreenDistanceSpec',
     'Seq',
     'Size',


### PR DESCRIPTION
Add `RestrictedDict` (a subclass of `Dict`) which raises an error if a disallowed key is passed.

Change `args = Dict(...)` to `args = RestrictedDict(disallow=(), ...)` in CustomJSFilter.

TODO: Add unit test.

I'm unsure about the unit tests can someone guide me on how it is to be added?
Thanks!

fixes #9958