### PR TITLE
Implement "views" for tick formatters

### DIFF
--- a/bokehjs/src/lib/api/plotting.ts
+++ b/bokehjs/src/lib/api/plotting.ts
@@ -995,7 +995,6 @@ export class Figure extends Plot {
         const axis = new MercatorAxis()
         const dimension = dim == 0 ? "lon" : "lat"
         axis.ticker.dimension = dimension
-        axis.formatter.dimension = dimension
         return axis
       }
       case "auto":

--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -1,6 +1,6 @@
 import {GuideRenderer, GuideRendererView} from "../renderers/guide_renderer"
 import {Ticker} from "../tickers/ticker"
-import {TickFormatter} from "../formatters/tick_formatter"
+import {TickFormatter, TickFormatterView} from "../formatters/tick_formatter"
 import {LabelingPolicy, AllLabels, DistanceMeasure} from "../policies/labeling"
 import {Range} from "../ranges/range"
 
@@ -9,6 +9,7 @@ import * as mixins from "core/property_mixins"
 import * as p from "core/properties"
 import {SerializableState} from "core/view"
 import {Side, TickLabelOrientation} from "core/enums"
+import {build_view} from "core/build_views"
 import {Size, Layoutable} from "core/layout"
 import {Indices} from "core/types"
 import {Panel, SideLayout, Orient} from "core/layout/side_panel"
@@ -40,6 +41,13 @@ export class AxisView extends GuideRendererView {
 
   panel: Panel
   layout: Layoutable
+
+  protected formatter_view: TickFormatterView
+
+  async lazy_initialize(): Promise<void> {
+    await super.lazy_initialize()
+    this.formatter_view = await build_view(this.model.formatter, {parent: this})
+  }
 
   update_layout(): void {
     this.layout = new SideLayout(this.panel, () => this.get_size(), true)
@@ -369,7 +377,7 @@ export class AxisView extends GuideRendererView {
   }
 
   compute_labels(ticks: number[]): GraphicsBoxes {
-    const labels = this.model.formatter.format_graphics(ticks, this)
+    const labels = this.formatter_view.format_graphics(ticks)
     const {major_label_overrides} = this.model
     for (let i = 0; i < ticks.length; i++) {
       const override = major_label_overrides[ticks[i]]

--- a/bokehjs/src/lib/models/axes/categorical_axis.ts
+++ b/bokehjs/src/lib/models/axes/categorical_axis.ts
@@ -99,7 +99,7 @@ export class CategoricalAxisView extends AxisView {
     }
 
     const format = (ticks: L1Factor[]) => {
-      return map(this.model.formatter.doFormat(ticks, this))
+      return map(this.formatter_view.format(ticks))
     }
 
     if (range.levels == 1) {

--- a/bokehjs/src/lib/models/axes/mercator_axis.ts
+++ b/bokehjs/src/lib/models/axes/mercator_axis.ts
@@ -34,8 +34,8 @@ export class MercatorAxis extends LinearAxis {
     this.prototype.default_view = MercatorAxisView
 
     this.override<MercatorAxis.Props>({
-      ticker:    () => new MercatorTicker({dimension: "lat"}),
-      formatter: () => new MercatorTickFormatter({dimension: "lat"}),
+      ticker:    () => new MercatorTicker(),
+      formatter: () => new MercatorTickFormatter(),
     })
   }
 }

--- a/bokehjs/src/lib/models/formatters/categorical_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/categorical_tick_formatter.ts
@@ -1,6 +1,14 @@
-import {TickFormatter} from "./tick_formatter"
+import {TickFormatter, TickFormatterView} from "./tick_formatter"
 import {copy} from "core/util/array"
 import * as p from "core/properties"
+
+export class CategoricalTickFormatterView extends TickFormatterView {
+  model: CategoricalTickFormatter
+
+  format(ticks: string[]): string[] {
+    return copy(ticks)
+  }
+}
 
 export namespace CategoricalTickFormatter {
   export type Attrs = p.AttrsOf<Props>
@@ -12,12 +20,13 @@ export interface CategoricalTickFormatter extends CategoricalTickFormatter.Attrs
 
 export class CategoricalTickFormatter extends TickFormatter {
   properties: CategoricalTickFormatter.Props
+  __view_type__: CategoricalTickFormatterView
 
   constructor(attrs?: Partial<CategoricalTickFormatter.Attrs>) {
     super(attrs)
   }
 
-  doFormat(ticks: string[], _opts: {loc: number}): string[] {
-    return copy(ticks)
+  static init_CategoricalTickFormatter(): void {
+    this.prototype.default_view = CategoricalTickFormatterView
   }
 }

--- a/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
@@ -1,6 +1,6 @@
 import tz from "timezone"
 
-import {TickFormatter} from "./tick_formatter"
+import {TickFormatter, TickFormatterView} from "./tick_formatter"
 import {logger} from "core/logging"
 import * as p from "core/properties"
 import {sprintf} from "core/util/templating"
@@ -48,46 +48,8 @@ const format_order = [
   'microseconds', 'milliseconds', 'seconds', 'minsec', 'minutes', 'hourmin', 'hours', 'days', 'months', 'years',
 ]
 
-export namespace DatetimeTickFormatter {
-  export type Attrs = p.AttrsOf<Props>
-
-  export type Props = TickFormatter.Props & {
-    microseconds: p.Property<string[]>
-    milliseconds: p.Property<string[]>
-    seconds: p.Property<string[]>
-    minsec: p.Property<string[]>
-    minutes: p.Property<string[]>
-    hourmin: p.Property<string[]>
-    hours: p.Property<string[]>
-    days: p.Property<string[]>
-    months: p.Property<string[]>
-    years: p.Property<string[]>
-  }
-}
-
-export interface DatetimeTickFormatter extends DatetimeTickFormatter.Attrs {}
-
-export class DatetimeTickFormatter extends TickFormatter {
-  properties: DatetimeTickFormatter.Props
-
-  constructor(attrs?: Partial<DatetimeTickFormatter.Attrs>) {
-    super(attrs)
-  }
-
-  static init_DatetimeTickFormatter(): void {
-    this.define<DatetimeTickFormatter.Props>(({String, Array}) => ({
-      microseconds: [ Array(String), ['%fus'] ],
-      milliseconds: [ Array(String), ['%3Nms', '%S.%3Ns'] ],
-      seconds:      [ Array(String), ['%Ss'] ],
-      minsec:       [ Array(String), [':%M:%S'] ],
-      minutes:      [ Array(String), [':%M', '%Mm'] ],
-      hourmin:      [ Array(String), ['%H:%M'] ],
-      hours:        [ Array(String), ['%Hh', '%H:%M'] ],
-      days:         [ Array(String), ['%m/%d', '%a%d'] ],
-      months:       [ Array(String), ['%m/%Y', '%b %Y'] ],
-      years:        [ Array(String), ['%Y'] ],
-    }))
-  }
+export class DatetimeTickFormatterView extends TickFormatterView {
+  model: DatetimeTickFormatter
 
   // Whether or not to strip the leading zeros on tick labels.
   protected strip_leading_zeros = true
@@ -108,17 +70,18 @@ export class DatetimeTickFormatter extends TickFormatter {
       return unzip(sorted)
     }
 
+    const {model} = this
     this._width_formats = {
-      microseconds: _widths(this.microseconds),
-      milliseconds: _widths(this.milliseconds),
-      seconds:      _widths(this.seconds),
-      minsec:       _widths(this.minsec),
-      minutes:      _widths(this.minutes),
-      hourmin:      _widths(this.hourmin),
-      hours:        _widths(this.hours),
-      days:         _widths(this.days),
-      months:       _widths(this.months),
-      years:        _widths(this.years),
+      microseconds: _widths(model.microseconds),
+      milliseconds: _widths(model.milliseconds),
+      seconds:      _widths(model.seconds),
+      minsec:       _widths(model.minsec),
+      minutes:      _widths(model.minutes),
+      hourmin:      _widths(model.hourmin),
+      hours:        _widths(model.hours),
+      days:         _widths(model.days),
+      months:       _widths(model.months),
+      years:        _widths(model.years),
     }
   }
 
@@ -145,7 +108,7 @@ export class DatetimeTickFormatter extends TickFormatter {
     }
   }
 
-  doFormat(ticks: number[], _opts: {loc: number}): string[] {
+  format(ticks: number[]): string[] {
     // In order to pick the right set of labels, we need to determine
     // the resolution of the ticks.  We can do this using a ticker if
     // it's provided, or by computing the resolution from the actual
@@ -240,5 +203,50 @@ export class DatetimeTickFormatter extends TickFormatter {
     }
 
     return labels
+  }
+}
+
+export namespace DatetimeTickFormatter {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = TickFormatter.Props & {
+    microseconds: p.Property<string[]>
+    milliseconds: p.Property<string[]>
+    seconds: p.Property<string[]>
+    minsec: p.Property<string[]>
+    minutes: p.Property<string[]>
+    hourmin: p.Property<string[]>
+    hours: p.Property<string[]>
+    days: p.Property<string[]>
+    months: p.Property<string[]>
+    years: p.Property<string[]>
+  }
+}
+
+export interface DatetimeTickFormatter extends DatetimeTickFormatter.Attrs {}
+
+export class DatetimeTickFormatter extends TickFormatter {
+  properties: DatetimeTickFormatter.Props
+  __view_type__: DatetimeTickFormatterView
+
+  constructor(attrs?: Partial<DatetimeTickFormatter.Attrs>) {
+    super(attrs)
+  }
+
+  static init_DatetimeTickFormatter(): void {
+    this.prototype.default_view = DatetimeTickFormatterView
+
+    this.define<DatetimeTickFormatter.Props>(({String, Array}) => ({
+      microseconds: [ Array(String), ['%fus'] ],
+      milliseconds: [ Array(String), ['%3Nms', '%S.%3Ns'] ],
+      seconds:      [ Array(String), ['%Ss'] ],
+      minsec:       [ Array(String), [':%M:%S'] ],
+      minutes:      [ Array(String), [':%M', '%Mm'] ],
+      hourmin:      [ Array(String), ['%H:%M'] ],
+      hours:        [ Array(String), ['%Hh', '%H:%M'] ],
+      days:         [ Array(String), ['%m/%d', '%a%d'] ],
+      months:       [ Array(String), ['%m/%Y', '%b %Y'] ],
+      years:        [ Array(String), ['%Y'] ],
+    }))
   }
 }

--- a/bokehjs/src/lib/models/formatters/func_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/func_tick_formatter.ts
@@ -1,7 +1,30 @@
-import {TickFormatter} from "./tick_formatter"
+import {TickFormatter, TickFormatterView} from "./tick_formatter"
 import * as p from "core/properties"
 import {keys, values} from "core/util/object"
 import {use_strict} from "core/util/string"
+
+export class FuncTickFormatterView extends TickFormatterView {
+  model: FuncTickFormatter
+
+  get names(): string[] {
+    return keys(this.model.args)
+  }
+
+  get values(): any[] {
+    return values(this.model.args)
+  }
+
+  /*protected*/ _make_func(): Function {
+    const code = use_strict(this.model.code)
+    return new Function("tick", "index", "ticks", ...this.names, code)
+  }
+
+  format(ticks: number[]): string[] {
+    const cache = {}
+    const func = this._make_func().bind(cache)
+    return ticks.map((tick, index, ticks) => func(tick, index, ticks, ...this.values))
+  }
+}
 
 export namespace FuncTickFormatter {
   export type Attrs = p.AttrsOf<Props>
@@ -16,34 +39,18 @@ export interface FuncTickFormatter extends FuncTickFormatter.Attrs {}
 
 export class FuncTickFormatter extends TickFormatter {
   properties: FuncTickFormatter.Props
+  __view_type__: FuncTickFormatterView
 
   constructor(attrs?: Partial<FuncTickFormatter.Attrs>) {
     super(attrs)
   }
 
   static init_FuncTickFormatter(): void {
+    this.prototype.default_view = FuncTickFormatterView
+
     this.define<FuncTickFormatter.Props>(({Unknown, String, Dict}) => ({
       args: [ Dict(Unknown), {} ],
       code: [ String, "" ],
     }))
-  }
-
-  get names(): string[] {
-    return keys(this.args)
-  }
-
-  get values(): any[] {
-    return values(this.args)
-  }
-
-  /*protected*/ _make_func(): Function {
-    const code = use_strict(this.code)
-    return new Function("tick", "index", "ticks", ...this.names, code)
-  }
-
-  doFormat(ticks: number[], _opts: {loc: number}): string[] {
-    const cache = {}
-    const func = this._make_func().bind(cache)
-    return ticks.map((tick, index, ticks) => func(tick, index, ticks, ...this.values))
   }
 }

--- a/bokehjs/src/lib/models/formatters/log_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/log_tick_formatter.ts
@@ -1,57 +1,28 @@
-import {TickFormatter} from "./tick_formatter"
-import {BasicTickFormatter, unicode_replace} from "./basic_tick_formatter"
+import {TickFormatter, TickFormatterView} from "./tick_formatter"
+import {BasicTickFormatter, BasicTickFormatterView, unicode_replace} from "./basic_tick_formatter"
 import {LogTicker} from "../tickers/log_ticker"
+import type {LogAxisView} from "../axes/log_axis"
 import {GraphicsBox, BaseExpo, TextBox} from "core/graphics"
+import {build_view} from "core/build_views"
 import * as p from "core/properties"
 
 const {log, round} = Math
 
-export namespace LogTickFormatter {
-  export type Attrs = p.AttrsOf<Props>
-
-  export type Props = TickFormatter.Props & {
-    ticker: p.Property<LogTicker | null>
-  }
-}
-
-export interface LogTickFormatter extends LogTickFormatter.Attrs {}
-
-export class LogTickFormatter extends TickFormatter {
-  properties: LogTickFormatter.Props
-
-  constructor(attrs?: Partial<LogTickFormatter.Attrs>) {
-    super(attrs)
-  }
-
-  static init_LogTickFormatter(): void {
-    this.define<LogTickFormatter.Props>(({Ref, Nullable}) => ({
-      ticker: [ Nullable(Ref(LogTicker)), null ],
-    }))
-  }
+export class LogTickFormatterView extends TickFormatterView {
+  model: LogTickFormatter
+  parent: LogAxisView
 
   protected basic_formatter: BasicTickFormatter
+  protected basic_formatter_view: BasicTickFormatterView
 
   initialize(): void {
     super.initialize()
     this.basic_formatter = new BasicTickFormatter()
   }
 
-  format_graphics(ticks: number[], opts: {loc: number}): GraphicsBox[] {
-    if (ticks.length == 0)
-      return []
-
-    const base = this.ticker?.base ?? 10
-    const expos = this._exponents(ticks, base)
-
-    if (expos == null)
-      return this.basic_formatter.format_graphics(ticks, opts)
-    else {
-      return expos.map((expo) => {
-        const b = new TextBox({text: unicode_replace(`${base}`)})
-        const e = new TextBox({text: unicode_replace(`${expo}`)})
-        return new BaseExpo(b, e)
-      })
-    }
+  async lazy_initialize(): Promise<void> {
+    await super.lazy_initialize()
+    this.basic_formatter_view = await build_view(this.basic_formatter, {parent: this.parent})
   }
 
   protected _exponents(ticks: number[], base: number): number[] | null {
@@ -68,16 +39,63 @@ export class LogTickFormatter extends TickFormatter {
     return exponents
   }
 
-  doFormat(ticks: number[], opts: {loc: number}): string[] {
+  format_graphics(ticks: number[]): GraphicsBox[] {
     if (ticks.length == 0)
       return []
 
-    const base = this.ticker?.base ?? 10
+    const {base} = this.parent.model.ticker
     const expos = this._exponents(ticks, base)
 
     if (expos == null)
-      return this.basic_formatter.doFormat(ticks, opts)
+      return this.basic_formatter_view.format_graphics(ticks)
+    else {
+      return expos.map((expo) => {
+        const b = new TextBox({text: unicode_replace(`${base}`)})
+        const e = new TextBox({text: unicode_replace(`${expo}`)})
+        return new BaseExpo(b, e)
+      })
+    }
+  }
+
+  format(ticks: number[]): string[] {
+    if (ticks.length == 0)
+      return []
+
+    const {base} = this.parent.model.ticker
+    const expos = this._exponents(ticks, base)
+
+    if (expos == null)
+      return this.basic_formatter_view.format(ticks)
     else
       return expos.map((expo) => unicode_replace(`${base}^${expo}`))
+  }
+}
+
+export namespace LogTickFormatter {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = TickFormatter.Props & {
+    /** @deprecated */
+    ticker: p.Property<LogTicker | null>
+  }
+}
+
+export interface LogTickFormatter extends LogTickFormatter.Attrs {}
+
+export class LogTickFormatter extends TickFormatter {
+  properties: LogTickFormatter.Props
+  __view_type__: LogTickFormatterView
+
+  constructor(attrs?: Partial<LogTickFormatter.Attrs>) {
+    super(attrs)
+  }
+
+  static init_LogTickFormatter(): void {
+    this.prototype.default_view = LogTickFormatterView
+
+    this.define<LogTickFormatter.Props>(({Ref, Nullable}) => ({
+      /** @deprecated */
+      ticker: [ Nullable(Ref(LogTicker)), null ],
+    }))
   }
 }

--- a/bokehjs/src/lib/models/formatters/mercator_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/mercator_tick_formatter.ts
@@ -1,7 +1,38 @@
-import {BasicTickFormatter} from "./basic_tick_formatter"
+import {BasicTickFormatter, BasicTickFormatterView} from "./basic_tick_formatter"
 import {LatLon} from "core/enums"
 import * as p from "core/properties"
 import {wgs84_mercator} from "core/util/projections"
+
+export class MercatorTickFormatterView extends BasicTickFormatterView {
+  model: MercatorTickFormatter
+
+  get dimension(): LatLon {
+    return this.model.dimension ?? (this.parent.dimension == 0 ? "lon" : "lat")
+  }
+
+  format(ticks: number[]): string[] {
+    if (ticks.length == 0)
+      return []
+
+    const n = ticks.length
+    const proj_ticks = new Array(n)
+
+    const {loc} = this.parent
+    if (this.dimension == "lon") {
+      for (let i = 0; i < n; i++) {
+        const [lon] = wgs84_mercator.invert(ticks[i], loc)
+        proj_ticks[i] = lon
+      }
+    } else {
+      for (let i = 0; i < n; i++) {
+        const [, lat] = wgs84_mercator.invert(loc, ticks[i])
+        proj_ticks[i] = lat
+      }
+    }
+
+    return super.format(proj_ticks)
+  }
+}
 
 export namespace MercatorTickFormatter {
   export type Attrs = p.AttrsOf<Props>
@@ -15,39 +46,17 @@ export interface MercatorTickFormatter extends MercatorTickFormatter.Attrs {}
 
 export class MercatorTickFormatter extends BasicTickFormatter {
   properties: MercatorTickFormatter.Props
+  __view_type__: MercatorTickFormatterView
 
   constructor(attrs?: Partial<MercatorTickFormatter.Attrs>) {
     super(attrs)
   }
 
   static init_MercatorTickFormatter(): void {
+    this.prototype.default_view = MercatorTickFormatterView
+
     this.define<MercatorTickFormatter.Props>(({Nullable}) => ({
       dimension: [ Nullable(LatLon), null ],
     }))
-  }
-
-  doFormat(ticks: number[], opts: {loc: number}): string[] {
-    if (this.dimension == null)
-      throw new Error("MercatorTickFormatter.dimension not configured")
-
-    if (ticks.length == 0)
-      return []
-
-    const n = ticks.length
-    const proj_ticks = new Array(n)
-
-    if (this.dimension == "lon") {
-      for (let i = 0; i < n; i++) {
-        const [lon] = wgs84_mercator.invert(ticks[i], opts.loc)
-        proj_ticks[i] = lon
-      }
-    } else {
-      for (let i = 0; i < n; i++) {
-        const [, lat] = wgs84_mercator.invert(opts.loc, ticks[i])
-        proj_ticks[i] = lat
-      }
-    }
-
-    return super.doFormat(proj_ticks, opts)
   }
 }

--- a/bokehjs/src/lib/models/formatters/numeral_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/numeral_tick_formatter.ts
@@ -1,8 +1,32 @@
 import * as Numbro from "@bokeh/numbro"
 
-import {TickFormatter} from "./tick_formatter"
+import {TickFormatter, TickFormatterView} from "./tick_formatter"
 import {RoundingFunction} from "core/enums"
 import * as p from "core/properties"
+
+export class NumeralTickFormatterView extends TickFormatterView {
+  model: NumeralTickFormatter
+
+  private get _rounding_fn(): (v: number) => number {
+    switch (this.model.rounding) {
+      case "round":
+      case "nearest":
+        return Math.round
+      case "floor":
+      case "rounddown":
+        return Math.floor
+      case "ceil":
+      case "roundup":
+        return Math.ceil
+    }
+  }
+
+  format(ticks: number[]): string[] {
+    const {format, language} = this.model
+    const {_rounding_fn} = this
+    return ticks.map((tick) => Numbro.format(tick, format, language, _rounding_fn))
+  }
+}
 
 export namespace NumeralTickFormatter {
   export type Attrs = p.AttrsOf<Props>
@@ -18,36 +42,20 @@ export interface NumeralTickFormatter extends NumeralTickFormatter.Attrs {}
 
 export class NumeralTickFormatter extends TickFormatter {
   properties: NumeralTickFormatter.Props
+  __view_type__: NumeralTickFormatterView
 
   constructor(attrs?: Partial<NumeralTickFormatter.Attrs>) {
     super(attrs)
   }
 
   static init_NumeralTickFormatter(): void {
+    this.prototype.default_view = NumeralTickFormatterView
+
     this.define<NumeralTickFormatter.Props>(({String}) => ({
       // TODO (bev) all of these could be tightened up
       format:   [ String,           "0,0"   ],
       language: [ String,           "en"    ],
       rounding: [ RoundingFunction, "round" ],
     }))
-  }
-
-  private get _rounding_fn(): (v: number) => number {
-    switch (this.rounding) {
-      case "round":
-      case "nearest":
-        return Math.round
-      case "floor":
-      case "rounddown":
-        return Math.floor
-      case "ceil":
-      case "roundup":
-        return Math.ceil
-    }
-  }
-
-  doFormat(ticks: number[], _opts: {loc: number}): string[] {
-    const {format, language, _rounding_fn} = this
-    return ticks.map((tick) => Numbro.format(tick, format, language, _rounding_fn))
   }
 }

--- a/bokehjs/src/lib/models/formatters/printf_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/printf_tick_formatter.ts
@@ -1,6 +1,15 @@
-import {TickFormatter} from "./tick_formatter"
+import {TickFormatter, TickFormatterView} from "./tick_formatter"
 import {sprintf} from "core/util/templating"
 import * as p from "core/properties"
+
+export class PrintfTickFormatterView extends TickFormatterView {
+  model: PrintfTickFormatter
+
+  format(ticks: number[]): string[] {
+    const {format} = this.model
+    return ticks.map((tick) => sprintf(format, tick))
+  }
+}
 
 export namespace PrintfTickFormatter {
   export type Attrs = p.AttrsOf<Props>
@@ -14,18 +23,17 @@ export interface PrintfTickFormatter extends PrintfTickFormatter.Attrs {}
 
 export class PrintfTickFormatter extends TickFormatter {
   properties: PrintfTickFormatter.Props
+  __view_type__: PrintfTickFormatterView
 
   constructor(attrs?: Partial<PrintfTickFormatter.Attrs>) {
     super(attrs)
   }
 
   static init_PrintfTickFormatter(): void {
+    this.prototype.default_view = PrintfTickFormatterView
+
     this.define<PrintfTickFormatter.Props>(({String}) => ({
       format: [ String, "%s" ],
     }))
-  }
-
-  doFormat(ticks: number[], _opts: {loc: number}): string[] {
-    return ticks.map((tick) => sprintf(this.format, tick))
   }
 }

--- a/bokehjs/src/lib/models/formatters/tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/tick_formatter.ts
@@ -1,6 +1,27 @@
 import {Model} from "../../model"
+import {View} from "core/view"
+import type {AxisView} from "../axes/axis"
 import {GraphicsBox, TextBox} from "core/graphics"
 import * as p from "core/properties"
+
+export abstract class TickFormatterView extends View {
+  model: TickFormatter
+  parent: AxisView
+
+  abstract format(ticks: string[] | number[]): string[]
+
+  format_graphics(ticks: string[] | number[]): GraphicsBox[] {
+    return this.format(ticks).map((text) => new TextBox({text}))
+  }
+
+  compute(tick: string | number): string {
+    return this.format([tick] as string[] | number[])[0]
+  }
+
+  v_compute(tick: string[] | number[]): string[] {
+    return this.format(tick)
+  }
+}
 
 export namespace TickFormatter {
   export type Attrs = p.AttrsOf<Props>
@@ -12,22 +33,9 @@ export interface TickFormatter extends TickFormatter.Attrs {}
 
 export abstract class TickFormatter extends Model {
   properties: TickFormatter.Props
+  __view_type__: TickFormatterView
 
   constructor(attrs?: Partial<TickFormatter.Attrs>) {
     super(attrs)
-  }
-
-  abstract doFormat(ticks: string[] | number[], opts: {loc: number}): string[]
-
-  format_graphics(ticks: string[] | number[], opts: {loc: number}): GraphicsBox[] {
-    return this.doFormat(ticks, opts).map((text) => new TextBox({text}))
-  }
-
-  compute(tick: string | number, opts?: {loc: number}): string {
-    return this.doFormat([tick] as string[] | number[], opts ?? {loc: 0})[0]
-  }
-
-  v_compute(tick: string[] | number[], opts?: {loc: number}): string[] {
-    return this.doFormat(tick, opts ?? {loc: 0})
   }
 }

--- a/bokehjs/src/lib/models/widgets/date_range_slider.ts
+++ b/bokehjs/src/lib/models/widgets/date_range_slider.ts
@@ -7,6 +7,13 @@ import {isString} from "core/util/types"
 
 export class DateRangeSliderView extends AbstractRangeSliderView {
   model: DateRangeSlider
+
+  protected _formatter(value: number, format: string | TickFormatter): string {
+    if (isString(format))
+      return tz(value, format)
+    else
+      return this._formatter_view!.compute(value)
+  }
 }
 
 export namespace DateRangeSlider {
@@ -35,11 +42,4 @@ export class DateRangeSlider extends AbstractSlider {
 
   behaviour = "drag" as "drag"
   connected = [false, true, false]
-
-  protected _formatter(value: number, format: string | TickFormatter): string {
-    if (isString(format))
-      return tz(value, format)
-    else
-      return format.compute(value)
-  }
 }

--- a/bokehjs/src/lib/models/widgets/date_slider.ts
+++ b/bokehjs/src/lib/models/widgets/date_slider.ts
@@ -7,6 +7,13 @@ import {isString} from "core/util/types"
 
 export class DateSliderView extends AbstractSliderView {
   model: DateSlider
+
+  protected _formatter(value: number, format: string | TickFormatter): string {
+    if (isString(format))
+      return tz(value, format)
+    else
+      return this._formatter_view!.compute(value)
+  }
 }
 
 export namespace DateSlider {
@@ -35,11 +42,4 @@ export class DateSlider extends AbstractSlider {
 
   behaviour = "tap" as "tap"
   connected = [true, false]
-
-  protected _formatter(value: number, format: string | TickFormatter): string {
-    if (isString(format))
-      return tz(value, format)
-    else
-      return format.compute(value)
-  }
 }

--- a/bokehjs/src/lib/models/widgets/range_slider.ts
+++ b/bokehjs/src/lib/models/widgets/range_slider.ts
@@ -7,6 +7,13 @@ import {isString} from "core/util/types"
 
 export class RangeSliderView extends AbstractRangeSliderView {
   model: RangeSlider
+
+  protected _formatter(value: number, format: string | TickFormatter): string {
+    if (isString(format))
+      return numbro.format(value, format)
+    else
+      return this._formatter_view!.compute(value)
+  }
 }
 
 export namespace RangeSlider {
@@ -35,11 +42,4 @@ export class RangeSlider extends AbstractSlider {
 
   behaviour = "drag" as "drag"
   connected = [false, true, false]
-
-  protected _formatter(value: number, format: string | TickFormatter): string {
-    if (isString(format))
-      return numbro.format(value, format)
-    else
-      return format.compute(value)
-  }
 }

--- a/bokehjs/src/lib/models/widgets/slider.ts
+++ b/bokehjs/src/lib/models/widgets/slider.ts
@@ -7,6 +7,13 @@ import {isString} from "core/util/types"
 
 export class SliderView extends AbstractSliderView {
   model: Slider
+
+  protected _formatter(value: number, format: string | TickFormatter): string {
+    if (isString(format))
+      return numbro.format(value, format)
+    else
+      return this._formatter_view!.compute(value)
+  }
 }
 
 export namespace Slider {
@@ -35,11 +42,4 @@ export class Slider extends AbstractSlider {
 
   behaviour = "tap" as "tap"
   connected = [true, false]
-
-  protected _formatter(value: number, format: string | TickFormatter): string {
-    if (isString(format))
-      return numbro.format(value, format)
-    else
-      return format.compute(value)
-  }
 }

--- a/bokehjs/test/unit/models/formatters/func_tick_formatter.ts
+++ b/bokehjs/test/unit/models/formatters/func_tick_formatter.ts
@@ -2,33 +2,37 @@ import {expect} from "assertions"
 
 import {FuncTickFormatter} from "@bokehjs/models/formatters/func_tick_formatter"
 import {Range1d} from "@bokehjs/models/ranges/range1d"
+import {build_view} from "@bokehjs/core/build_views"
 
 describe("func_tick_formatter module", () => {
 
-  describe("FuncTickFormatter._make_func method", () => {
+  describe("FuncTickFormatter._make_func method", async () => {
     const formatter = new FuncTickFormatter({code: "return 10"})
+    const formatter_view = await build_view(formatter)
 
     it("should return a Function", () => {
-      expect(formatter._make_func()).to.be.instanceof(Function)
+      expect(formatter_view._make_func()).to.be.instanceof(Function)
     })
 
     it("should have code property as function body", () => {
       const func = new Function("tick", "index", "ticks", "'use strict';\nreturn 10")
-      expect(formatter._make_func().toString()).to.be.equal(func.toString())
+      expect(formatter_view._make_func().toString()).to.be.equal(func.toString())
     })
 
     it("should have values as function args", () => {
       const rng = new Range1d()
       formatter.args = {foo: rng.ref()}
       const func = new Function("tick", "index", "ticks", "foo", "'use strict';\nreturn 10")
-      expect(formatter._make_func().toString()).to.be.equal(func.toString())
+      expect(formatter_view._make_func().toString()).to.be.equal(func.toString())
     })
   })
 
   describe("doFormat method", () => {
-    it("should format numerical ticks appropriately", () => {
+    it("should format numerical ticks appropriately", async () => {
       const formatter = new FuncTickFormatter({code: "return tick.toFixed(2)"})
-      const labels = formatter.doFormat([-10, -0.1, 0, 0.1, 10], {loc: 0})
+      const formatter_view = await build_view(formatter)
+
+      const labels = formatter_view.format([-10, -0.1, 0, 0.1, 10])
       expect(labels).to.be.equal(["-10.00", "-0.10", "0.00", "0.10", "10.00"])
     })
 
@@ -40,23 +44,27 @@ describe("func_tick_formatter module", () => {
     })
     */
 
-    it("should handle args appropriately", () => {
+    it("should handle args appropriately", async () => {
       const rng = new Range1d({start: 5, end: 10})
       const formatter = new FuncTickFormatter({
         code: "return (foo.start + foo.end + tick).toFixed(2)",
         args: {foo: rng},
       })
-      const labels = formatter.doFormat([-10, -0.1, 0, 0.1, 10], {loc: 0})
+      const formatter_view = await build_view(formatter)
+
+      const labels = formatter_view.format([-10, -0.1, 0, 0.1, 10])
       expect(labels).to.be.equal(["5.00", "14.90", "15.00", "15.10", "25.00"])
     })
 
-    it("should handle array of ticks", () => {
+    it("should handle array of ticks", async () => {
       const formatter = new FuncTickFormatter({
         code: "this.k = this.k || (ticks.length > 3 ? 10 : 100); return (tick * this.k).toFixed(2)",
       })
-      const labels0 = formatter.doFormat([-10, -0.1, 0, 0.1, 10], {loc: 0})
+      const formatter_view = await build_view(formatter)
+
+      const labels0 = formatter_view.format([-10, -0.1, 0, 0.1, 10])
       expect(labels0).to.be.equal(["-100.00", "-1.00", "0.00", "1.00", "100.00"])
-      const labels1 = formatter.doFormat([-0.1, 0, 0.1], {loc: 0})
+      const labels1 = formatter_view.format([-0.1, 0, 0.1])
       expect(labels1).to.be.equal(["-10.00", "0.00", "10.00"])
     })
   })

--- a/bokehjs/test/unit/models/formatters/mercator_tick_formatter.ts
+++ b/bokehjs/test/unit/models/formatters/mercator_tick_formatter.ts
@@ -3,34 +3,32 @@ import {expect} from "assertions"
 import {MercatorTickFormatter} from "@bokehjs/models/formatters/mercator_tick_formatter"
 import {unicode_replace} from "@bokehjs/models/formatters/basic_tick_formatter"
 import {wgs84_mercator} from "@bokehjs/core/util/projections"
+import {build_view} from "@bokehjs/core/build_views"
 
 describe("mercator_tick_formatter module", () => {
 
-  it("should throw exception if dimension not configured", () => {
-    const obj = new MercatorTickFormatter()
-    expect(() => obj.doFormat([30, 60, 90], {loc: 90})).to.throw()
-  })
-
   // these tests assume default superclass BasicTickFormatter behavior, re: displayed precision
 
-  it("should compute latitude tick labels when dimension=lat", () => {
-    const obj = new MercatorTickFormatter({dimension: 'lat'})
+  it("should compute latitude tick labels when dimension=lat", async () => {
+    const formatter = new MercatorTickFormatter()
     for (const lat of [-72, -60.5, -30, -2, 1, -0.5, 0, 0.5, 1, 10, 33.7, 42.123, 50]) {
       for (const lon of [-120, -90, -88, -32.7, -10, -1, 0, 0.5, 1, 5, 12.3, 57, 60.123, 95, 110.1, 120, 130]) {
         const [mlon, mlat] = wgs84_mercator.compute(lon, lat)
-        const labels = obj.doFormat([mlat], {loc: mlon})
-        expect(labels[0]).to.be.equal(unicode_replace(`${lat}`))
+        const formatter_view = await build_view(formatter, {parent: {loc: mlon, dimension: 1}}) /* lat */
+        const labels = formatter_view.compute(mlat)
+        expect(labels).to.be.equal(unicode_replace(`${lat}`))
       }
     }
   })
 
-  it("should compute longitude tick labels when dimension=lon", () => {
-    const obj = new MercatorTickFormatter({dimension: 'lon'})
+  it("should compute longitude tick labels when dimension=lon", async () => {
+    const formatter = new MercatorTickFormatter()
     for (const lat of [-72, -60.5, -30, -2, 1, -0.5, 0, 0.5, 1, 10, 33.7, 42.123, 50]) {
       for (const lon of [-120, -90, -88, -32.7, -10, -1, 0, 0.5, 1, 5, 12.3, 57, 60.123, 95, 110.1, 120, 130]) {
         const [mlon, mlat] = wgs84_mercator.compute(lon, lat)
-        const labels = obj.doFormat([mlon], {loc: mlat})
-        expect(labels[0]).to.be.equal(unicode_replace(`${lon}`))
+        const formatter_view = await build_view(formatter, {parent: {loc: mlat, dimension: 0}}) /* lon */
+        const labels = formatter_view.compute(mlon)
+        expect(labels).to.be.equal(unicode_replace(`${lon}`))
       }
     }
   })

--- a/bokehjs/test/unit/models/formatters/numeral_tick_formatter.ts
+++ b/bokehjs/test/unit/models/formatters/numeral_tick_formatter.ts
@@ -1,12 +1,15 @@
 import {expect} from "assertions"
 
 import {NumeralTickFormatter} from "@bokehjs/models/formatters/numeral_tick_formatter"
+import {build_view} from "@bokehjs/core/build_views"
 
 describe("numeral_tick_formatter module", () => {
 
-  it("should round numbers appropriately", () => {
-    const obj = new NumeralTickFormatter({format: "0.00"})
-    const labels = obj.doFormat([0.1, 0.01, 0.001, 0.009], {loc: 0})
+  it("should round numbers appropriately", async () => {
+    const formatter = new NumeralTickFormatter({format: "0.00"})
+    const formatter_view = await build_view(formatter)
+
+    const labels = formatter_view.format([0.1, 0.01, 0.001, 0.009])
     expect(labels).to.be.equal(["0.10", "0.01", "0.00", "0.01"])
   })
 })

--- a/bokehjs/test/unit/models/widgets/slider.ts
+++ b/bokehjs/test/unit/models/widgets/slider.ts
@@ -9,7 +9,7 @@ describe("SliderView", () => {
 
   it("_calc_from should return integer if start/end/step all integers", async () => {
     const s = new Slider({start: 0, end: 10, step: 1})
-    const sv = (await build_view(s)).build()
+    const sv = await build_view(s)
 
     const r = (sv as any /* XXX: protected */)._calc_from([5.0])
     expect(r).to.be.equal(5)
@@ -18,53 +18,61 @@ describe("SliderView", () => {
 })
 
 describe("Slider", () => {
-  it("should support string format", () => {
+  it("should support string format", async () => {
     const slider = new Slider({format: "0a"})
-    expect(slider.pretty(-104000)).to.be.equal("-104k")
+    const slider_view = await build_view(slider)
+    expect(slider_view.pretty(-104000)).to.be.equal("-104k")
   })
 
-  it("should support TickFormatter format", () => {
+  it("should support TickFormatter format", async () => {
     const format = new FuncTickFormatter({code: "return (tick/1000).toFixed(0) + 'k'"})
     const slider = new Slider({format})
-    expect(slider.pretty(-104000)).to.be.equal("-104k")
+    const slider_view = await build_view(slider)
+    expect(slider_view.pretty(-104000)).to.be.equal("-104k")
   })
 })
 
 describe("RangeSlider", () => {
-  it("should support string format", () => {
+  it("should support string format", async () => {
     const slider = new RangeSlider({format: "0a"})
-    expect(slider.pretty(-104000)).to.be.equal("-104k")
+    const slider_view = await build_view(slider)
+    expect(slider_view.pretty(-104000)).to.be.equal("-104k")
   })
 
-  it("should support TickFormatter format", () => {
+  it("should support TickFormatter format", async () => {
     const format = new FuncTickFormatter({code: "return (tick/1000).toFixed(0) + 'k'"})
     const slider = new RangeSlider({format})
-    expect(slider.pretty(-104000)).to.be.equal("-104k")
+    const slider_view = await build_view(slider)
+    expect(slider_view.pretty(-104000)).to.be.equal("-104k")
   })
 })
 
 describe("DateSlider", () => {
-  it("should support string format", () => {
+  it("should support string format", async () => {
     const slider = new DateSlider({format: "%Y"})
-    expect(slider.pretty(1599402993268)).to.be.equal("2020")
+    const slider_view = await build_view(slider)
+    expect(slider_view.pretty(1599402993268)).to.be.equal("2020")
   })
 
-  it("should support TickFormatter format", () => {
+  it("should support TickFormatter format", async () => {
     const format = new FuncTickFormatter({code: "return Math.floor(1970 + tick/(1000*60*60*24*365)).toFixed(0)"})
     const slider = new DateSlider({format})
-    expect(slider.pretty(1599402993268)).to.be.equal("2020")
+    const slider_view = await build_view(slider)
+    expect(slider_view.pretty(1599402993268)).to.be.equal("2020")
   })
 })
 
 describe("DateRangeSlider", () => {
-  it("should support string format", () => {
+  it("should support string format", async () => {
     const slider = new DateRangeSlider({format: "%Y"})
-    expect(slider.pretty(1599402993268)).to.be.equal("2020")
+    const slider_view = await build_view(slider)
+    expect(slider_view.pretty(1599402993268)).to.be.equal("2020")
   })
 
-  it("should support TickFormatter format", () => {
+  it("should support TickFormatter format", async () => {
     const format = new FuncTickFormatter({code: "return Math.floor(1970 + tick/(1000*60*60*24*365)).toFixed(0)"})
     const slider = new DateRangeSlider({format})
-    expect(slider.pretty(1599402993268)).to.be.equal("2020")
+    const slider_view = await build_view(slider)
+    expect(slider_view.pretty(1599402993268)).to.be.equal("2020")
   })
 })


### PR DESCRIPTION
Our current understanding of the term "view" may be skewed towards the UI, which is indeed true if one looks at the existing implementation of `View` class. However, the term is broader than that. In the case of tick formatters this may not be immediate, but consider `MercatorTickFormatter`, which requires cross-coordinates, which are only available to views (`AxisView`). The current approach of resolving this issue exposes internal bokehjs state to models and skews entire tick formatter API for that particular case. Another instance, though less prominent, is `LogTickFormatter`, which requires access to the ticker, which can be implicitly provided, assuming formatting is done on the view level (no need for providing explicit ticker as this is done currently, or a back ref to an axis, as it used to be done). Besides this, current tick formatters don't take advantage of visual space information, but that may change. For example one could adjust the format of labels, depending on the available space (e.g. improve readability for compact plots). Perhaps tick formatters also could produce non-string labels. Finally, this is required to allow separation of models from views, and allowing reuse of models in other contexts (i.e. node).

The downside of this change is that using `TickFormatter`s outside axes is cumbersome (e.g. sliders, `NumberInput`), but that's fine, because this exposes a design flaw where a models of certain kind are pushed out of their design context. In this case using tick formatters for generic formatting applications.

Then there's the question of backwards compatibility, which I think can be resolved, by dynamically creating views for formatters that implement `doFormat()` method.