### PR TITLE
Fix example of LabelSet in user manual

### DIFF
--- a/sphinx/source/docs/user_guide/annotations.rst
+++ b/sphinx/source/docs/user_guide/annotations.rst
@@ -261,7 +261,7 @@ to place the label above or underneath other renderers:
 
 .. code-block:: python
 
-    LabelSet(x='x', y='y', text='names', level='glyph',
+    LabelSet(x='x', y='y', text='names',
              x_offset=5, y_offset=5, source=source)
 
 The following example illustrates the use of both:

--- a/sphinx/source/docs/user_guide/examples/plotting_label.py
+++ b/sphinx/source/docs/user_guide/examples/plotting_label.py
@@ -14,7 +14,7 @@ p.scatter(x='weight', y='height', size=8, source=source)
 p.xaxis[0].axis_label = 'Weight (lbs)'
 p.yaxis[0].axis_label = 'Height (in)'
 
-labels = LabelSet(x='weight', y='height', text='names', level='glyph',
+labels = LabelSet(x='weight', y='height', text='names',
               x_offset=5, y_offset=5, source=source, render_mode='canvas')
 
 citation = Label(x=70, y=70, x_units='screen', y_units='screen',


### PR DESCRIPTION
Remove the level attribute from the LabelSet example as it is broken (at least as used in example).
Fixes #10819.
