### PR TITLE
Updated DataTable fit_columns docstring

### DIFF
--- a/bokeh/models/widgets/tables.py
+++ b/bokeh/models/widgets/tables.py
@@ -674,11 +674,11 @@ class DataTable(TableWidget):
     """)
 
     fit_columns = Bool(help="""
-    **This is a legacy parameter.** For new development, use the 
-    ``autosize_mode`` parameter. 
-    
-    Whether columns should be fit to the available width. This results in 
-    no horizontal scrollbar showing up, but data can get unreadable if there 
+    **This is a legacy parameter.** For new development, use the
+    ``autosize_mode`` parameter.
+
+    Whether columns should be fit to the available width. This results in
+    no horizontal scrollbar showing up, but data can get unreadable if there
     is not enough space available. If set to ``True``, each column's width is
     understood as maximum width.
     """)

--- a/bokeh/models/widgets/tables.py
+++ b/bokeh/models/widgets/tables.py
@@ -636,7 +636,7 @@ class TableWidget(Widget):
             self.view = CDSView(source=self.source)
 
 class DataTable(TableWidget):
-    ''' Two dimensional grid for visualisation and editing large amounts
+    ''' Two-dimensional grid for visualization and editing large amounts
     of data.
 
     '''
@@ -645,7 +645,7 @@ class DataTable(TableWidget):
     Describes the column autosizing mode with one of the following options:
 
     ``"fit_columns"``
-        Compute columns widths based on cell contents but ensure the
+        Compute column widths based on cell contents but ensure the
         table fits into the available viewport. This results in no
         horizontal scrollbar showing up, but data can get unreadable
         if there is not enough space available.
@@ -674,9 +674,12 @@ class DataTable(TableWidget):
     """)
 
     fit_columns = Bool(help="""
-    Whether columns should be fit to the available width. This results in no
-    horizontal scrollbar showing up, but data can get unreadable if there is
-    not enough space available. If set to ``True``, columns' width is
+    **This is a legacy parameter.** For new development, use the 
+    ``autosize_mode`` parameter. 
+    
+    Whether columns should be fit to the available width. This results in 
+    no horizontal scrollbar showing up, but data can get unreadable if there 
+    is not enough space available. If set to ``True``, each column's width is
     understood as maximum width.
     """)
 


### PR DESCRIPTION
Update to DataTable documentation as suggested on the Discourse. 

@philippjfr or @mattpap it looked like the functionality on the `fit_columns` param was duplicated/replaced by the `autosize_mode` param, so I just marked the `fit_columns` one as legacy to avoid confusion. CCing you for verification-- if this is wrong, let me know.

- [ ] issues: fixes #10748
