### PR TITLE
Properly derive `WebDataSource` from `ColumnDataSource`

### DIFF
--- a/bokehjs/src/lib/models/glyphs/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/circle.ts
@@ -279,7 +279,7 @@ export namespace Circle {
     size: p.DistanceSpec
     radius: p.NullDistanceSpec
     radius_dimension: p.Property<RadiusDimension>
-    hit_dilation:  p.Property<number>
+    hit_dilation: p.Property<number>
   } & Mixins
 
   export type Mixins = LineVector & FillVector & HatchVector
@@ -307,7 +307,7 @@ export class Circle extends XYGlyph {
       size:             [ p.ScreenDistanceSpec, {value: 4} ],
       radius:           [ p.NullDistanceSpec, null ],
       radius_dimension: [ RadiusDimension, "x" ],
-      hit_dilation: [ Number, 1.0 ],
+      hit_dilation:     [ Number, 1.0 ],
     }))
   }
 }

--- a/bokehjs/src/lib/models/plots/plot.ts
+++ b/bokehjs/src/lib/models/plots/plot.ts
@@ -19,7 +19,7 @@ import {Toolbar} from "../tools/toolbar"
 import {Range} from "../ranges/range"
 import {Scale} from "../scales/scale"
 import {Glyph} from "../glyphs/glyph"
-import {DataSource} from "../sources/data_source"
+import {ColumnarDataSource} from "../sources/columnar_data_source"
 import {ColumnDataSource} from "../sources/column_data_source"
 import {Renderer} from "../renderers/renderer"
 import {DataRenderer} from "../renderers/data_renderer"
@@ -244,9 +244,9 @@ export class Plot extends LayoutDOM {
     this.renderers = this.renderers.concat(renderers)
   }
 
-  add_glyph(glyph: Glyph, source: DataSource = new ColumnDataSource(), extra_attrs: any = {}): GlyphRenderer {
-    const attrs = {...extra_attrs, data_source: source, glyph}
-    const renderer = new GlyphRenderer(attrs)
+  add_glyph(glyph: Glyph, source: ColumnarDataSource = new ColumnDataSource(),
+      attrs: Partial<GlyphRenderer.Attrs> = {}): GlyphRenderer {
+    const renderer = new GlyphRenderer({...attrs, data_source: source, glyph})
     this.add_renderers(renderer)
     return renderer
   }

--- a/bokehjs/src/lib/models/sources/web_data_source.ts
+++ b/bokehjs/src/lib/models/sources/web_data_source.ts
@@ -30,6 +30,10 @@ export abstract class WebDataSource extends ColumnDataSource {
     return column != null ? column : []
   }
 
+  get_length(): number {
+    return super.get_length() ?? 0
+  }
+
   // override this method to setup the connection to the web source
   abstract setup(): void
 

--- a/bokehjs/test/unit/models/sources/ajax_data_source.ts
+++ b/bokehjs/test/unit/models/sources/ajax_data_source.ts
@@ -139,12 +139,14 @@ describe("ajax_data_source module", () => {
       })
     })
 
-    describe("get_column method", () => {
+    describe("get_column() method", () => {
 
       it("should return empty lists for not-yet-existant columns", () => {
         const s = new AjaxDataSource({data_url: "http://foo.com"})
         const c = s.get_column("foo")
         expect(c).to.be.equal([])
+        const n = s.get_length()
+        expect(n).to.be.equal(0)
       })
     })
 

--- a/examples/howto/ajax_source.py
+++ b/examples/howto/ajax_source.py
@@ -8,10 +8,10 @@ from bokeh.plotting import figure, show
 
 adapter = CustomJS(code="""
     const result = {x: [], y: []}
-    const pts = cb_data.response.points
-    for (let i=0; i<pts.length; i++) {
-        result.x.push(pts[i][0])
-        result.y.push(pts[i][1])
+    const {points} = cb_data.response
+    for (const [x, y] of points) {
+        result.x.push(x)
+        result.y.push(y)
     }
     return result
 """)


### PR DESCRIPTION
This is more a workaround than a solution to the underlying data size determination issue, but at least it fixes web data sources and broken examples.

fixes #10853