### PR TITLE
Miscellaneous bokehjs build changes 

### DIFF
--- a/bokehjs/make/index.js
+++ b/bokehjs/make/index.js
@@ -51,10 +51,6 @@ if (!is_up_to_date("package.json")) {
   npm_install()
 }
 
-const package_lock = fs.readFileSync("package-lock.json", {encoding: "utf-8"})
-const package_lock_updated = package_lock.replace(/\bhttp:\/\//g, "https://")
-fs.writeFileSync("package-lock.json", package_lock_updated, {encoding: "utf-8"})
-
 const {register} = require("ts-node")
 
 process.on('uncaughtException', function(err) {

--- a/bokehjs/package-lock.json
+++ b/bokehjs/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@bokeh/bokehjs",
-      "version": "2.3.0-dev.9",
+      "version": "2.3.0-dev.11",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@bokeh/numbro": "^1.6.2",

--- a/bokehjs/package-lock.json
+++ b/bokehjs/package-lock.json
@@ -80,7 +80,7 @@
       },
       "engines": {
         "node": ">=14",
-        "npm": ">=7.1"
+        "npm": ">=7.4"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -18,7 +18,7 @@
   },
   "engines": {
     "node": ">=14",
-    "npm": ">=7.1"
+    "npm": ">=7.4"
   },
   "files": [
     "build/js/bokeh*.min.js",

--- a/release/build.py
+++ b/release/build.py
@@ -134,7 +134,9 @@ def update_bokehjs_versions(config: Config, system: System) -> ActionReturn:
     for filename in filenames:
         content = json.load(open(filename))
         try:
+            assert content["lockfileVersion"] == 2
             content["version"] = config.js_version
+            content["packages"][""]["version"] = config.js_version
             with open(filename, "w") as f:
                 json.dump(content, f, indent=2)
                 f.write("\n")


### PR DESCRIPTION
- URL fixing is not needed anymore in `npm@7`
- require `npm >= 7.4` due to `npx` regressions (`test_js_license_set` failures)
- makes release scripts set bokehjs version in `package-lock.json` (v2) correctly