### PR TITLE
Update URL for numpy intersphinx inventory

### DIFF
--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -85,7 +85,7 @@ bokeh_plot_pyfile_include_dirs = ['docs']
 intersphinx_mapping = {
     'python' : ('https://docs.python.org/3/', None),
     'pandas' : ('https://pandas.pydata.org/pandas-docs/stable/', None),
-    'numpy'  : ('https://docs.scipy.org/doc/numpy/', None)
+    'numpy'  : ('https://numpy.org/doc/stable/', None)
 }
 
 napoleon_include_init_with_doc = True


### PR DESCRIPTION
Numpy's intersphinx inventory has moved from` https://docs.scipy.org/doc/numpy/` to `https://numpy.org/doc/stable/`. This pull request updates the URL in `conf.py`. This takes care of a warning message that Sphinx currently shows with every docs build ("`intersphinx inventory has moved: https://docs.scipy.org/doc/numpy/objects.inv -> https://numpy.org/doc/stable/objects.inv`").