### PR TITLE
Followup fixes after PR #10842

### DIFF
--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -314,6 +314,8 @@ from .property.datetime import Date; Date
 from .property.datetime import Datetime; Datetime
 from .property.datetime import TimeDelta; TimeDelta
 
+from .property.descriptors import UnsetValueError; UnsetValueError
+
 from .property.either import Either; Either
 
 from .property.enum import Enum; Enum

--- a/bokeh/core/property/bases.py
+++ b/bokeh/core/property/bases.py
@@ -101,6 +101,7 @@ class Property(PropertyDescriptorFactory):
 
         self._readonly = readonly
         self._default = default
+        self._help = help
         self.__doc__ = help
 
         self.alternatives = []
@@ -416,8 +417,7 @@ class Property(PropertyDescriptorFactory):
         return self
 
 class ParameterizedProperty(Property):
-    """ A base class for Properties that have type parameters, e.g.
-    ``List(String)``.
+    """ A base class for Properties that have type parameters, e.g. ``List(String)``.
 
     """
 
@@ -429,6 +429,9 @@ class ParameterizedProperty(Property):
             else:
                 type_param = type_param.__name__
         elif isinstance(type_param, Property):
+            if type_param._help is not None:
+                raise ValueError("setting 'help' on type parameters doesn't make sense")
+
             return type_param
 
         raise ValueError(f"expected a Property as type parameter, got {type_param}")

--- a/bokeh/core/property/descriptors.py
+++ b/bokeh/core/property/descriptors.py
@@ -544,7 +544,8 @@ class BasicPropertyDescriptor(PropertyDescriptor):
             class_name = obj.__class__.__name__
             raise RuntimeError(f"Cannot set a property value {self.name!r} on a {class_name} instance before HasProps.__init__")
 
-        if self.property._readonly:
+        if self.property._readonly and obj._initialized:
+            # Allow to set a value during object initialization (e.g. value -> value_throttled)
             class_name = obj.__class__.__name__
             raise RuntimeError(f"{class_name}.{self.name} is a readonly property")
 
@@ -978,7 +979,8 @@ class ColumnDataPropertyDescriptor(BasicPropertyDescriptor):
             class_name = obj.__class__.__name__
             raise RuntimeError(f"Cannot set a property value {self.name!r} on a {class_name} instance before HasProps.__init__")
 
-        if self.property._readonly:
+        if self.property._readonly and obj._initialized:
+            # Allow to set a value during object initialization (e.g. value -> value_throttled)
             class_name = obj.__class__.__name__
             raise RuntimeError(f"{class_name}.{self.name} is a readonly property")
 

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -637,7 +637,7 @@ class Plot(LayoutDOM):
     Decimation factor to use when applying level-of-detail decimation.
     """)
 
-    lod_threshold = Int(2000, help="""
+    lod_threshold = Nullable(Int, default=2000, help="""
     A number of data points, above which level-of-detail downsampling may
     be performed by glyph renderers. Set to ``None`` to disable any
     level-of-detail downsampling.

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -268,7 +268,7 @@ class ToolbarBase(Model):
 
     '''
 
-    logo = Enum("normal", "grey", help="""
+    logo = Nullable(Enum("normal", "grey"), default="normal", help="""
     What version of the Bokeh logo to display on the toolbar. If
     set to None, no logo will be displayed.
     """)

--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -208,6 +208,12 @@ class Spinner(NumericInput):
 
     '''
 
+    def __init__(self, **kwargs):
+        if "value" in kwargs and "value_throttled" not in kwargs:
+            kwargs["value_throttled"] = kwargs["value"]
+
+        super().__init__(**kwargs)
+
     value_throttled = Readonly(Either(Null, Float, Int), help="""
     value reported at the end of interactions
     """)

--- a/bokeh/models/widgets/sliders.py
+++ b/bokeh/models/widgets/sliders.py
@@ -70,6 +70,9 @@ class AbstractSlider(Widget):
             if kwargs['start'] == kwargs['end']:
                 raise ValueError("Slider 'start' and 'end' cannot be equal.")
 
+        if "value" in kwargs and "value_throttled" not in kwargs:
+            kwargs["value_throttled"] = kwargs["value"]
+
         super().__init__(**kwargs)
 
     title = Nullable(String, default="", help="""
@@ -117,7 +120,7 @@ class Slider(AbstractSlider):
     Initial or selected value.
     """)
 
-    value_throttled = Readonly(Float, help="""
+    value_throttled = Readonly(NonNullable(Float), help="""
     Initial or selected value, throttled according to report only on mouseup.
     """)
 
@@ -134,7 +137,7 @@ class RangeSlider(AbstractSlider):
     Initial or selected range.
     """)
 
-    value_throttled = Readonly(Tuple(Float, Float), help="""
+    value_throttled = Readonly(NonNullable(Tuple(Float, Float)), help="""
     Initial or selected value, throttled according to report only on mouseup.
     """)
 
@@ -184,19 +187,19 @@ class DateSlider(AbstractSlider):
 
         return self.value
 
-    value = Datetime(help="""
+    value = NonNullable(Datetime, help="""
     Initial or selected value.
     """)
 
-    value_throttled = Readonly(Datetime, help="""
+    value_throttled = Readonly(NonNullable(Datetime), help="""
     Initial or selected value, throttled to report only on mouseup.
     """)
 
-    start = Datetime(help="""
+    start = NonNullable(Datetime, help="""
     The minimum allowable value.
     """)
 
-    end = Datetime(help="""
+    end = NonNullable(Datetime, help="""
     The maximum allowable value.
     """)
 
@@ -251,19 +254,19 @@ class DateRangeSlider(AbstractSlider):
             d2 = v2
         return d1, d2
 
-    value = Tuple(Datetime, Datetime, help="""
+    value = NonNullable(Tuple(Datetime, Datetime), help="""
     Initial or selected range.
     """)
 
-    value_throttled = Readonly(Tuple(Datetime, Datetime), help="""
+    value_throttled = Readonly(NonNullable(Tuple(Datetime, Datetime)), help="""
     Initial or selected value, throttled to report only on mouseup.
     """)
 
-    start = Datetime(help="""
+    start = NonNullable(Datetime, help="""
     The minimum allowable value.
     """)
 
-    end = Datetime(help="""
+    end = NonNullable(Datetime, help="""
     The maximum allowable value.
     """)
 

--- a/bokeh/plotting/figure.py
+++ b/bokeh/plotting/figure.py
@@ -1629,11 +1629,11 @@ class FigureOptions(Options):
     Where the y-axis should be located.
     """)
 
-    x_axis_label = String(default="", help="""
+    x_axis_label = Nullable(String, default="", help="""
     A label for the x-axis.
     """)
 
-    y_axis_label = String(default="", help="""
+    y_axis_label = Nullable(String, default="", help="""
     A label for the y-axis.
     """)
 

--- a/bokeh/plotting/figure.py
+++ b/bokeh/plotting/figure.py
@@ -155,10 +155,6 @@ class Figure(Plot):
             raise ValueError("Figure called with both 'plot_width' and 'width' supplied, supply only one")
         if 'plot_height' in kw and 'height' in kw:
             raise ValueError("Figure called with both 'plot_height' and 'height' supplied, supply only one")
-        if 'height' in kw:
-            kw['plot_height'] = kw.pop('height')
-        if 'width' in kw:
-            kw['plot_width'] = kw.pop('width')
 
         opts = FigureOptions(kw)
 

--- a/bokehjs/src/lib/models/plots/plot.ts
+++ b/bokehjs/src/lib/models/plots/plot.ts
@@ -66,7 +66,7 @@ export namespace Plot {
 
     lod_factor: p.Property<number>
     lod_interval: p.Property<number>
-    lod_threshold: p.Property<number>
+    lod_threshold: p.Property<number | null>
     lod_timeout: p.Property<number>
 
     hidpi: p.Property<boolean>
@@ -156,7 +156,7 @@ export class Plot extends LayoutDOM {
 
       lod_factor:        [ Number, 10 ],
       lod_interval:      [ Number, 300 ],
-      lod_threshold:     [ Number, 2000 ],
+      lod_threshold:     [ Nullable(Number), 2000 ],
       lod_timeout:       [ Number, 500 ],
 
       hidpi:             [ Boolean, true ],

--- a/bokehjs/src/lib/models/tools/toolbar_base.ts
+++ b/bokehjs/src/lib/models/tools/toolbar_base.ts
@@ -189,7 +189,7 @@ export namespace ToolbarBase {
 
   export type Props = Model.Props & {
     tools: p.Property<Tool[]>
-    logo: p.Property<Logo>
+    logo: p.Property<Logo | null>
     gestures: p.Property<GesturesMap>
     actions: p.Property<ActionTool[]>
     inspectors: p.Property<InspectTool[]>
@@ -226,9 +226,9 @@ export class ToolbarBase extends Model {
   static init_ToolbarBase(): void {
     this.prototype.default_view = ToolbarBaseView
 
-    this.define<ToolbarBase.Props>(({Boolean, Array, Ref}) => ({
+    this.define<ToolbarBase.Props>(({Boolean, Array, Ref, Nullable}) => ({
       tools:    [ Array(Ref(Tool)), [] ],
-      logo:     [ Logo, "normal" ],
+      logo:     [ Nullable(Logo), "normal" ],
       autohide: [ Boolean, false ],
     }))
 

--- a/bokehjs/src/lib/models/widgets/slider.ts
+++ b/bokehjs/src/lib/models/widgets/slider.ts
@@ -30,7 +30,6 @@ export class Slider extends AbstractSlider {
 
     this.override<Slider.Props>({
       format: "0[.]00",
-      value_throttled: 0,
     })
   }
 

--- a/tests/unit/bokeh/core/property/test_nullable.py
+++ b/tests/unit/bokeh/core/property/test_nullable.py
@@ -39,6 +39,11 @@ class Test_Nullable:
     def test_init(self) -> None:
         with pytest.raises(TypeError):
             bcpn.Nullable()
+        with pytest.raises(ValueError):
+            bcpn.Nullable(Int(help="inner help"))
+
+        prop0 = bcpn.Nullable(Int(), help="help")
+        assert prop0._help == prop0.__doc__ == "help"
 
     def test_valid(self) -> None:
         prop = bcpn.Nullable(List(Int))

--- a/tests/unit/bokeh/models/widgets/test_slider.py
+++ b/tests/unit/bokeh/models/widgets/test_slider.py
@@ -19,6 +19,7 @@ import logging
 from datetime import date, datetime
 
 # Bokeh imports
+from bokeh.core.properties import UnsetValueError
 from bokeh.core.validation.check import check_integrity
 from bokeh.util.logconfig import basicConfig
 from bokeh.util.serialization import convert_date_to_datetime, convert_datetime_type
@@ -37,8 +38,109 @@ basicConfig()
 # General API
 #-----------------------------------------------------------------------------
 
+class TestSlider:
+    def test_value_and_value_throttled(self) -> None:
+        s0 = mws.Slider(start=0, end=10)
+        with pytest.raises(UnsetValueError):
+            s0.value
+        with pytest.raises(UnsetValueError):
+            s0.value_throttled
+
+        s1 = mws.Slider(start=0, end=10, value=5)
+        assert s1.value == 5
+        assert s1.value_throttled == 5
+
+class TestRangeSlider:
+    def test_value_and_value_throttled(self) -> None:
+        s0 = mws.RangeSlider(start=0, end=10)
+        with pytest.raises(UnsetValueError):
+            s0.value
+        with pytest.raises(UnsetValueError):
+            s0.value_throttled
+
+        s1 = mws.RangeSlider(start=0, end=10, value=(4, 6))
+        assert s1.value == (4, 6)
+        assert s1.value_throttled == (4, 6)
+
+    def test_rangeslider_equal_start_end_exception(self) -> None:
+        start = 0
+        end = 0
+        with pytest.raises(ValueError):
+            mws.RangeSlider(start=start, end=end)
+
+    def test_rangeslider_equal_start_end_validation(self, caplog) -> None:
+        start = 0
+        end = 10
+        s = mws.RangeSlider(start=start, end=end)
+        #with caplog.at_level(logging.ERROR, logger='bokeh.core.validation.check'):
+        with caplog.at_level(logging.ERROR):
+            assert len(caplog.records) == 0
+            s.end = 0
+            check_integrity([s])
+            assert len(caplog.records) == 1
+
+class TestDateSlider:
+    def test_value_and_value_throttled(self) -> None:
+        start = datetime(2021, 1, 1)
+        end = datetime(2021, 12, 31)
+        value = convert_date_to_datetime(datetime(2021, 2, 1))
+
+        s0 = mws.DateSlider(start=start, end=end)
+        with pytest.raises(UnsetValueError):
+            s0.value
+        with pytest.raises(UnsetValueError):
+            s0.value_throttled
+
+        s1 = mws.DateSlider(start=start, end=end, value=value)
+        assert s1.value == value
+        assert s1.value_throttled == value
+
+    def test_value_as_datetime_when_set_as_datetime(self) -> None:
+        start = datetime(2017, 8, 9, 0, 0)
+        end = datetime(2017, 8, 10, 0, 0)
+        s = mws.DateSlider(start=start, end=end, value=start)
+        assert s.value_as_datetime == start
+
+    def test_value_as_datetime_when_set_as_timestamp(self) -> None:
+        start = datetime(2017, 8, 9, 0, 0)
+        end = datetime(2017, 8, 10, 0, 0)
+        s = mws.DateSlider(start=start, end=end,
+            # Bokeh serializes as ms since epoch, if they get set as numbers (e.g.)
+            # by client side update, this is the units they will be
+            value=convert_datetime_type(start))
+        assert s.value_as_datetime == start
+
+    def test_value_as_date_when_set_as_date(self) -> None:
+        start = date(2017, 8, 9)
+        end = date(2017, 8, 10)
+        s = mws.DateSlider(start=start, end=end, value=end)
+        assert s.value_as_date == end
+
+    def test_value_as_date_when_set_as_timestamp(self) -> None:
+        start = date(2017, 8, 9)
+        end = date(2017, 8, 10)
+        s = mws.DateSlider(start=start, end=end,
+            # Bokeh serializes as ms since epoch, if they get set as numbers (e.g.)
+            # by client side update, this is the units they will be
+            value=convert_date_to_datetime(end))
+        assert s.value_as_date == end
 
 class TestDateRangeSlider:
+    def test_value_and_value_throttled(self) -> None:
+        start = datetime(2021, 1, 1)
+        end = datetime(2021, 12, 31)
+        value = (convert_datetime_type(datetime(2021, 2, 1)), convert_datetime_type(datetime(2021, 2, 28)))
+
+        s0 = mws.DateRangeSlider(start=start, end=end)
+        with pytest.raises(UnsetValueError):
+            s0.value
+        with pytest.raises(UnsetValueError):
+            s0.value_throttled
+
+        s1 = mws.DateRangeSlider(start=start, end=end, value=value)
+        assert s1.value == value
+        assert s1.value_throttled == value
+
     def test_value_as_datetime_when_set_as_datetime(self) -> None:
         start = datetime(2017, 8, 9, 0, 0)
         end = datetime(2017, 8, 10, 0, 0)
@@ -90,58 +192,6 @@ class TestDateRangeSlider:
         s = mws.DateRangeSlider(start=start, end=end,
                 value=(convert_date_to_datetime(start), end))
         assert s.value_as_date == (start, end)
-
-
-class TestDateSlider:
-    def test_value_as_datetime_when_set_as_datetime(self) -> None:
-        start = datetime(2017, 8, 9, 0, 0)
-        end = datetime(2017, 8, 10, 0, 0)
-        s = mws.DateSlider(start=start, end=end, value=start)
-        assert s.value_as_datetime == start
-
-    def test_value_as_datetime_when_set_as_timestamp(self) -> None:
-        start = datetime(2017, 8, 9, 0, 0)
-        end = datetime(2017, 8, 10, 0, 0)
-        s = mws.DateSlider(start=start, end=end,
-            # Bokeh serializes as ms since epoch, if they get set as numbers (e.g.)
-            # by client side update, this is the units they will be
-            value=convert_datetime_type(start))
-        assert s.value_as_datetime == start
-
-    def test_value_as_date_when_set_as_date(self) -> None:
-        start = date(2017, 8, 9)
-        end = date(2017, 8, 10)
-        s = mws.DateSlider(start=start, end=end, value=end)
-        assert s.value_as_date == end
-
-    def test_value_as_date_when_set_as_timestamp(self) -> None:
-        start = date(2017, 8, 9)
-        end = date(2017, 8, 10)
-        s = mws.DateSlider(start=start, end=end,
-            # Bokeh serializes as ms since epoch, if they get set as numbers (e.g.)
-            # by client side update, this is the units they will be
-            value=convert_date_to_datetime(end))
-        assert s.value_as_date == end
-
-
-class TestRangeSlider:
-    def test_rangeslider_equal_start_end_exception(self) -> None:
-        start = 0
-        end = 0
-        with pytest.raises(ValueError):
-            mws.RangeSlider(start=start, end=end)
-
-    def test_rangeslider_equal_start_end_validation(self, caplog) -> None:
-        start = 0
-        end = 10
-        s = mws.RangeSlider(start=start, end=end)
-        #with caplog.at_level(logging.ERROR, logger='bokeh.core.validation.check'):
-        with caplog.at_level(logging.ERROR):
-            assert len(caplog.records) == 0
-            s.end = 0
-            check_integrity([s])
-            assert len(caplog.records) == 1
-
 
 #-----------------------------------------------------------------------------
 # Dev API


### PR DESCRIPTION
- [x] initial value for `value_throttled` matching `value`
- [x] don't allow `default`, `help`, etc. for "inner" types (e.g. disallow `Nullable(String(help="..."))`)
- [x] fixes #10880