### PR TITLE
Update doc; reference outdated 'nbserverproxy'

### DIFF
--- a/sphinx/source/docs/user_guide/jupyter.rst
+++ b/sphinx/source/docs/user_guide/jupyter.rst
@@ -90,12 +90,12 @@ Bokeh server is listening on, but JupyterHub is acting as a reverse proxy
 between your browser and your JupyterLab container. Follow all the JupyterLab
 instructions above, then continue with the following steps below.
 
-First, you must install the ``nbserverproxy`` server extension. This can be done
+First, you must install the ``jupyter-server-proxy`` server extension. This can be done
 by running the command:
 
 .. code:: sh
 
-    pip install nbserverproxy && jupyter serverextension enable --py nbserverproxy
+    pip install jupyter-server-proxy && jupyter serverextension enable --sys-prefix jupyter_server_proxy
 
 Second, you must define a function to help create the URL that the browser
 uses to connect to the Bokeh server. This will be passed into |show| in


### PR DESCRIPTION
Reason for propose change:
> Note: This project used to be called nbserverproxy. As nbserverproxy is an older version of jupyter-server-proxy, uninstall nbserverproxy before installing jupyter-server-proxy to avoid conflicts. [ref](https://github.com/jupyterhub/jupyter-server-proxy#jupyter-server-proxy)

I haven't verified that this works, since I'm in the midst of developing a solution to a larger issue where this was a subset of it.

Additional doc:
[jupyter-server-proxy - installation](https://github.com/jupyterhub/jupyter-server-proxy/blob/master/docs/install.rst)

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [ ] issues: fixes #xxxx
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
