### PR TITLE
Add note about deprecated marker classes.

### DIFF
--- a/sphinx/source/docs/dev_guide/models.rst
+++ b/sphinx/source/docs/dev_guide/models.rst
@@ -18,6 +18,17 @@ objects are shown below; see the :ref:`refguide` for full details.
 .. image:: /_images/objects.png
     :align: center
 
+.. note::
+    The individual marker classes in the module
+    :class:`~bokeh.models.markers` are **deprecated
+    as of Bokeh 2.3.0.** Please replace all occurrences of ``Marker`` models
+    with :class:`~bokeh.models.glyphs.Scatter` glyphs. For example: instead of
+    ``Asterisk()``, use ``Scatter(marker="asterisk")``.
+
+    For backwards compatibility, all markers in this module currently link to
+    their respective replacements using the
+    :class:`~bokeh.models.glyphs.Scatter` glyph.
+
 Models and Properties
 ---------------------
 

--- a/sphinx/source/docs/dev_guide/models.rst
+++ b/sphinx/source/docs/dev_guide/models.rst
@@ -13,7 +13,8 @@ to JSON. This JSON representation is consumed by the BokehJS client library,
 which uses it to render the plot.
 
 Where space permits, the attributes of the model are shown inline. Not all
-objects are shown below; see the :ref:`refguide` for full details.
+objects are shown below, and some information might be outdated; see the
+:ref:`refguide` for full details.
 
 .. image:: /_images/objects.png
     :align: center
@@ -88,7 +89,6 @@ to finally some specialized types like:
 * :class:`~bokeh.core.properties.Instance` --- to hold a reference to another model: ``Instance(Plot)``
 * :class:`~bokeh.core.properties.Enum` --- to represent enumerated values: ``Enum("foo", "bar", "baz")``
 * :class:`~bokeh.core.properties.Either` --- to create a union type: ``Either(Int, String)``
-* :class:`~bokeh.core.properties.Range` --- to restrict values to a given range: ``Instance(Plot)``
 
 The primary benefit of these property types is that validation can be performed,
 and meaningful error reporting can occur when an attempt is made to assign an


### PR DESCRIPTION
This pull request adds a note about the deprecated marker classes to the figure in the section "Bokeh Models" of the Developers Guide. It complements #10885 and also fixes #10875. 