### PR TITLE
Update server.rst - "acme:com"?

### DIFF
--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -1346,7 +1346,7 @@ as follows:
 
 .. code-block:: sh
 
-    bokeh serve --show --allow-websocket-origin=acme:com myapp.py
+    bokeh serve --show --allow-websocket-origin=acme.com myapp.py
 
 This will prevent other sites from embedding your Bokeh application in their
 pages because requests from users viewing those pages will report a different


### PR DESCRIPTION
I assume this is invalid value: `--allow-websocket-origin=acme:com`

- [x] issues: fixes #10908
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
