### PR TITLE
consider view for legend representatives

### DIFF
--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -423,9 +423,18 @@ export class GlyphRenderer extends DataRenderer {
     if (field != null) {
       const data = this.data_source.get_column(field)
       if (data != null) {
-        const i = indexOf(data, value)
-        if (i != -1)
-          index = i
+        if (this.view == null) {
+          const i = indexOf(data, value)
+          if (i != -1)
+            index = i
+        } else {
+          for (const [k, v] of Object.entries(this.view.indices_map)) {
+            if (data[parseInt(k)] == value) {
+              index = v
+              break
+            }
+          }
+        }
       }
     }
     return index

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -4,7 +4,7 @@ import {expect} from "assertions"
 import {display, fig} from "./_util"
 
 import {
-  HoverTool, BoxAnnotation, ColumnDataSource, CDSView, BooleanFilter, GlyphRenderer, Circle,
+  HoverTool, BoxAnnotation, ColumnDataSource, CDSView, BooleanFilter, GlyphRenderer, Circle, Legend, LegendItem,
 } from "@bokehjs/models"
 
 describe("Bug", () => {
@@ -88,6 +88,19 @@ describe("Bug", () => {
       const filter = new BooleanFilter({booleans: [false, false]})
       const view = new CDSView({filters: [filter]})
       plot.square([1, 2], [3, 4], {fill_color: ["red", "green"], view, legend: "square"})
+      await display(plot)
+    })
+  })
+
+  describe("in issue #10935 (2)", () => {
+    it("prevents to render a legend and an empty view", async () => {
+      const plot = fig([200, 200])
+      const filter = new BooleanFilter({booleans: [true, true, false, false]})
+      const view = new CDSView({filters: [filter]})
+      const data_source = new ColumnDataSource({data: {x: [1, 2, 3, 4], y: [5, 6, 7, 8], fld: ["a", "a", "b", "b"]}})
+      const r = plot.square('x', 'y', {fill_color: ["red", "red", "green", "green"], view, source: data_source})
+      const legend = new Legend({items: [new LegendItem({label: {field: "fld"}, renderers: [r]})]})
+      plot.add_layout(legend)
       await display(plot)
     })
   })


### PR DESCRIPTION
- [x] issues: fixes #10935
- [x] tests added / passed

@mattpap this fails the test with the expected out-of-bounds error without the changes, and passes the test with the changes. It also behaves well with more extensive dask operations e.g. 
```
In [2]: import dask.array as da
   ...:
   ...: X = da.random.random((2000000, 100), chunks=(100000, 100)).persist()
   ...: u, s, v = da.linalg.svd_compressed(X, k=5)

In [3]: v.compute()
```
and as far as I can tell, the graph looks correct (nodes later after "processing" nodes are marked "waiting" etc.) cc @quasiben 

I am sure the code could be cleaner or make use of better APIs I am just unfamiliar with. Please do one of two things first things in the morning:

* make any small changes or improvements, then merge, or
* merge as-is if you are content with it

I do still plan to release tomorrow with this fix included. 
