### PR TITLE
do not add SRI hashes to Bokeh-generated output

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -441,6 +441,10 @@ jobs:
         shell: bash -l {0}
         run: bash ci/install_downstream_packages.sh
 
+      - name: Install downstream packages
+        shell: bash -l {0}
+        run: bash ci/install_downstream_packages.sh
+
       - name: Download Bokehjs
         uses: actions/download-artifact@v1
         with:


### PR DESCRIPTION
- [x] issues: fixes #10877
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)

This PR removes SRI hash injection into Bokeh's built-in templates. I have left the hashes on the resource bundle:

* to minimize the amount of code to change
* in case anyone wants to use hashes, they might be useful

I also made minimal changes to the tests to now assert affirmatively that the `crossorigin` and `integrity` attributes are not present (rather than deleting those tests and leaving the behavior undefined).

@philippjfr please help double-check that there is not anywhere else that needs removal

@tcmetzger I looked and I don't think there are any docs to update but if you can take a look as well that will be appreciated. 

This PR will need one more update to add a note in the release notes (an initial 2.4 release notes file is in another still-open PR) but I am otherwise marking `ready` for review. 
