### PR TITLE
Optimization when processing docs

### DIFF
--- a/bokeh/sphinxext/bokeh_releases.py
+++ b/bokeh/sphinxext/bokeh_releases.py
@@ -99,7 +99,7 @@ class BokehReleases(BokehDirective):
 
         rst = []
 
-        versions = [x.rstrip(".rst") for x in listdir(join(app.srcdir, "docs", "releases"))]
+        versions = [x.rstrip(".rst") for x in listdir(join(app.srcdir, "docs", "releases")) if x.endswith(".rst")]
         versions.sort(key=V, reverse=True)
 
         for v in versions:


### PR DESCRIPTION
Fixes: https://github.com/bokeh/bokeh/issues/10934

Now the list comprehension only cares about .rst files, and also we don't sort non-related file names.
