### PR TITLE
Add dask/dask to downstream tests

### DIFF
--- a/ci/install_downstream_packages.sh
+++ b/ci/install_downstream_packages.sh
@@ -2,7 +2,7 @@
 
 set -x #echo on
 
-conda install --yes --quiet distributed
+conda install --yes --quiet dask distributed
 conda install --yes --quiet -c pyviz/label/dev holoviews nose
 pip install pandas_bokeh
 pip install geopandas

--- a/ci/run_downstream_tests.sh
+++ b/ci/run_downstream_tests.sh
@@ -5,6 +5,7 @@ set -x #echo on
 set +e
 
 pushd `python -c "import site; print(site.getsitepackages()[0])"`
+pytest dask/diagnostics
 pytest distributed/dashboard
 nosetests holoviews/tests/plotting/bokeh
 popd


### PR DESCRIPTION
Currently bokeh-related tests for `dask/distributed` are tested as part of the downstream CI build. This PR ensures that the same happens for `dask/dask`.

- [x] issues: xref https://github.com/bokeh/bokeh/issues/10978
- [ ] ~~tests added / passed~~
- [ ] ~~release document entry (if new feature or API change)~~
