### PR TITLE
Add support for incremental TypeScript builds

### DIFF
--- a/bokehjs/src/compiler/tsconfig.json
+++ b/bokehjs/src/compiler/tsconfig.json
@@ -27,7 +27,9 @@
     "lib": ["es2020", "dom", "dom.iterable"],
     "types": ["node"],
     "baseUrl": ".",
-    "outDir": "../../build/js/compiler"
+    "outDir": "../../build/js/compiler",
+    "incremental": true,
+    "tsBuildInfoFile": "../../build/js/compiler/compiler.tsbuildinfo"
   },
   "include": ["./**/*.ts"]
 }

--- a/bokehjs/src/lib/tsconfig.json
+++ b/bokehjs/src/lib/tsconfig.json
@@ -31,7 +31,9 @@
     "rootDir": ".",
     "outDir": "../../build/js/lib",
     "declarationDir": "../../build/js/types",
-    "rootDirs": [".", "../../build/dts/"]
+    "rootDirs": [".", "../../build/dts/"],
+    "incremental": true,
+    "tsBuildInfoFile": "../../build/js/bokehjs.tsbuildinfo"
   },
   "include": ["./**/*.ts", "../../build/dts"]
 }


### PR DESCRIPTION
Early WIP. Reduces compilation time of bokehjs from 20s to 12s (from second run), however increases compilation time in tests.
