### PR TITLE
Initial timezone support in DatetimeTickFormatter (#1135)

### DIFF
--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -578,6 +578,8 @@ class DatetimeTickFormatter(TickFormatter):
                         help=_DATETIME_TICK_FORMATTER_HELP("``years``"),
                         default=['%Y']).accepts(String, lambda fmt: [fmt])
 
+    timezone     = String(help="Timezone with which to display ticks")
+
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------

--- a/bokehjs/src/lib/external/timezone.d.ts
+++ b/bokehjs/src/lib/external/timezone.d.ts
@@ -1,3 +1,7 @@
 declare module "timezone" {
-  export default function timezone(value: unknown, format?: string): string
+  export default function timezone(value: unknown, format?: string, timezone?: string): string
+}
+
+declare module "timezone/loaded" {
+  export default function timezone(value: unknown, format?: string, timezone?: string): string
 }

--- a/examples/models/file/datetime_tz_formatter.py
+++ b/examples/models/file/datetime_tz_formatter.py
@@ -1,0 +1,97 @@
+"""
+Example demonstrating DatetimeTickFormatter with tick labels displayed in different timezones.
+"""
+from bokeh.io import output_notebook, output_file, show
+from bokeh.models import ColumnDataSource, FuncTickFormatter, DatetimeTickFormatter
+from bokeh.models.axes import DatetimeAxis
+from bokeh.models.tools import HoverTool
+from bokeh.plotting import figure
+
+from jinja2 import Template
+import numpy as np
+import pandas as pd
+
+# output_notebook()
+
+# create dummy time series
+t = pd.Timestamp("2021/02/11 23:01-05:00")
+# NOTE: currently, HoverTool is not natively capable of displaying
+# sub-millisecond precision when formatting timestamps. As a workaround,
+# one can store sub-millisecond values in a separate column for a given
+# ColumnDataSource and use the printf formatter to display those values.
+interval = np.timedelta64(250, "ms") + np.timedelta64(50, "us")
+df = pd.DataFrame({"t": [t, t + interval, t + 2*interval], "v": [1, 3, 2]})
+
+def make_datetime_tz_formatter(display_timezone, include_date=False):
+    """Creates a bokeh.TickFormatter to display datetimes with TZ
+
+    Uses the javascript Date.toLocateString methods to get timestamp
+    string for given timezone. This is a lot less flexible than say
+    strftime since there are a limited set of locale formats to choose from,
+    but it works okay for more conventional string representations.
+    """
+    js_code_template = """
+var dt = new Date(tick);
+var tz = "{{ display_timezone }}";
+var locale_date_str = dt.toLocaleDateString("sv-SE", {"timeZone": tz});  // yyyy-mm-dd, currently not using
+var locale_time_str = dt.toLocaleTimeString("en-GB", {"timeZone": tz});  // 24 hour time
+{% if include_date %}
+locale_time_str = locale_date_str.slice(-5) + " " + locale_time_str;
+{% endif %}
+
+// bokeh uses floating point precision to represent sub-millisecond resolution,
+// can round to get intended microsecond value
+var millis = Math.floor(tick) % 1000;
+
+// build timestamp string
+var result = "";
+if (millis == 0) {
+    result = locale_time_str;
+} else {
+    // leftpad milliseconds to 3 digits
+    result = locale_time_str + "." + ("000" + millis).slice(-3);
+}
+return result;
+"""
+    js_code = Template(js_code_template).render(display_timezone=display_timezone, include_date=include_date)
+    return FuncTickFormatter(code=js_code)
+
+def make_figure():
+    # note: bokeh datetime tooltip formatter is limited to millisecond precision. Sub-millisecond precision
+    # would have to be provided separately.
+    tools = [
+        "xpan",
+        # "wheel_zoom",  # does not work if there is a bound y-axis
+        "xwheel_zoom",
+        "xzoom_in",
+        "xzoom_out",
+        "box_zoom",
+        "reset",
+        HoverTool(tooltips=[("time", "($x{%H:%M:%S.%N}, $y)")], formatters={"$x": "datetime"}),
+    ]
+    f = figure(x_axis_type="datetime", height=800, width=800, tools=tools, toolbar_location="above")
+    
+    datetime_fmt = {
+            "microseconds": "%H:%M:%S.%f",
+            "milliseconds": "%H:%M:%S.%f",
+            "seconds": "%H:%M:%S",
+            "minsec": "%H:%M:%S",
+            "minutes": "%H:%M:%S",
+            "hourmin": "%H:%M:%S",
+            "hours": "%H:%M:%S",
+            "days": "%x",
+    }
+    
+    source = ColumnDataSource(df)
+    f.line(x="t", y="v", source=source)
+    extra_axis = DatetimeAxis(axis_label="DatetimeTickFormatter", formatter=DatetimeTickFormatter(**datetime_fmt))
+    f.add_layout(extra_axis, "below")
+    for tz in ("UTC", "US/Eastern", "Asia/Tokyo", "Asia/Calcutta"):
+        extra_axis = DatetimeAxis(axis_label="FuncTickFormatter:" + tz, formatter=make_datetime_tz_formatter(tz, include_date=True))
+        f.add_layout(extra_axis, "below")
+        extra_axis = DatetimeAxis(axis_label="DatetimeTickFormatter:" + tz, formatter=DatetimeTickFormatter(timezone=tz, **datetime_fmt))
+        f.add_layout(extra_axis, "below")
+    return f
+
+output_file("datetime_tz_formatter.html", title="Timezones")
+show(make_figure())

--- a/examples/models/file/datetime_tz_formatter.py
+++ b/examples/models/file/datetime_tz_formatter.py
@@ -1,7 +1,7 @@
 """
 Example demonstrating DatetimeTickFormatter with tick labels displayed in different timezones.
 """
-from bokeh.io import output_notebook, output_file, show
+from bokeh.io import output_file, show  # output_notebook
 from bokeh.models import ColumnDataSource, FuncTickFormatter, DatetimeTickFormatter
 from bokeh.models.axes import DatetimeAxis
 from bokeh.models.tools import HoverTool
@@ -20,7 +20,8 @@ t = pd.Timestamp("2021/02/11 23:01-05:00")
 # one can store sub-millisecond values in a separate column for a given
 # ColumnDataSource and use the printf formatter to display those values.
 interval = np.timedelta64(250, "ms") + np.timedelta64(50, "us")
-df = pd.DataFrame({"t": [t, t + interval, t + 2*interval], "v": [1, 3, 2]})
+df = pd.DataFrame({"t": [t, t + interval, t + 2 * interval], "v": [1, 3, 2]})
+
 
 def make_datetime_tz_formatter(display_timezone, include_date=False):
     """Creates a bokeh.TickFormatter to display datetimes with TZ
@@ -56,6 +57,7 @@ return result;
     js_code = Template(js_code_template).render(display_timezone=display_timezone, include_date=include_date)
     return FuncTickFormatter(code=js_code)
 
+
 def make_figure():
     # note: bokeh datetime tooltip formatter is limited to millisecond precision. Sub-millisecond precision
     # would have to be provided separately.
@@ -70,28 +72,35 @@ def make_figure():
         HoverTool(tooltips=[("time", "($x{%H:%M:%S.%N}, $y)")], formatters={"$x": "datetime"}),
     ]
     f = figure(x_axis_type="datetime", height=800, width=800, tools=tools, toolbar_location="above")
-    
+
     datetime_fmt = {
-            "microseconds": "%H:%M:%S.%f",
-            "milliseconds": "%H:%M:%S.%f",
-            "seconds": "%H:%M:%S",
-            "minsec": "%H:%M:%S",
-            "minutes": "%H:%M:%S",
-            "hourmin": "%H:%M:%S",
-            "hours": "%H:%M:%S",
-            "days": "%x",
+        "microseconds": "%H:%M:%S.%f",
+        "milliseconds": "%H:%M:%S.%f",
+        "seconds": "%H:%M:%S",
+        "minsec": "%H:%M:%S",
+        "minutes": "%H:%M:%S",
+        "hourmin": "%H:%M:%S",
+        "hours": "%H:%M:%S",
+        "days": "%x",
     }
-    
+
     source = ColumnDataSource(df)
     f.line(x="t", y="v", source=source)
     extra_axis = DatetimeAxis(axis_label="DatetimeTickFormatter", formatter=DatetimeTickFormatter(**datetime_fmt))
     f.add_layout(extra_axis, "below")
     for tz in ("UTC", "US/Eastern", "Asia/Tokyo", "Asia/Calcutta"):
-        extra_axis = DatetimeAxis(axis_label="FuncTickFormatter:" + tz, formatter=make_datetime_tz_formatter(tz, include_date=True))
+        extra_axis = DatetimeAxis(
+            axis_label="FuncTickFormatter:" + tz,
+            formatter=make_datetime_tz_formatter(tz, include_date=True),
+        )
         f.add_layout(extra_axis, "below")
-        extra_axis = DatetimeAxis(axis_label="DatetimeTickFormatter:" + tz, formatter=DatetimeTickFormatter(timezone=tz, **datetime_fmt))
+        extra_axis = DatetimeAxis(
+            axis_label="DatetimeTickFormatter:" + tz,
+            formatter=DatetimeTickFormatter(timezone=tz, **datetime_fmt),
+        )
         f.add_layout(extra_axis, "below")
     return f
+
 
 output_file("datetime_tz_formatter.html", title="Timezones")
 show(make_figure())


### PR DESCRIPTION
Initial proof-of-concept.

Load all timezones in `datetime_tick_formatter.ts` and have an optional `timezone` property in `DatetimeTickFormatter`. If supplied, use the given timezone to format the tick labels. Included a simple example of this in `datetime_tz_formatter.py` along with a different implementation using `FuncTickFormatter`.

![image](https://user-images.githubusercontent.com/7894671/110258007-5a1d6600-8005-11eb-89d2-a599c014d137.png)

Main thing I'm not sure about is if/how to [load specific timezones via timezone.js](https://bigeasy.github.io/timezone/). The examples there all dynamically load specific timezone implementations at runtime, such as `require("timezone/America/New_York")`. The current commit simply loads all of the timezones at `import` time, loading around ~580 timezone modules (1.8k lines of JS un-minified). It's probably possible with [dynamic imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#dynamic_import) but I don't know how to do this since [imports are not synchronous](https://stackoverflow.com/questions/51069002/convert-import-to-synchronous).

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [ ] issues: fixes #1135
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
