### PR TITLE
exposes Palettes

### DIFF
--- a/bokehjs/src/lib/api/index.ts
+++ b/bokehjs/src/lib/api/index.ts
@@ -7,6 +7,9 @@ export {Charts}
 import * as Plotting from "./plotting"
 export {Plotting}
 
+import * as Palettes from "./palettes"
+export {Palettes}
+
 export {Document} from "../document"
 
 export {sprintf} from "../core/util/templating"


### PR DESCRIPTION
Adds `Bokeh.Palettes` to the API, exposing the color palettes to the user. Useful when working with `ColorMapper` objects, which cannot currently use strings as they are defined in the base `bokeh.js`

- [x] issues: fixes #11034

Unless there are plans to provide support for named palettes in the `ColorMapper` objects when the API has been loaded, we may want to update docs as well, to reflect this API difference.