### PR TITLE
Drop unnecessary -webkit- prefixes from flexbox

### DIFF
--- a/bokehjs/src/less/_mixins.less
+++ b/bokehjs/src/less/_mixins.less
@@ -6,56 +6,6 @@
 
 @line-height-computed: floor((@font-size*@line-height));
 
-.flex() {
-  display: flex;
-  display: -webkit-flex;
-}
-
-.inline-flex() {
-  display: inline-flex;
-  display: -webkit-inline-flex;
-}
-
-.flex-wrap(@wrap) {
-  flex-wrap: @wrap;
-  -webkit-flex-wrap: @wrap;
-}
-
-.align-items(@align) {
-  align-items: @align;
-  -webkit-align-items: @align;
-}
-
-.flex-direction(@direction) {
-  flex-direction: @direction;
-  -webkit-flex-direction: @direction;
-}
-
-.flex-grow(@grow) {
-  flex-grow: @grow;
-  -webkit-flex-grow: @grow;
-}
-
-.flex-shrink(@shrink) {
-  flex-shrink: @shrink;
-  -webkit-flex-shrink: @shrink;
-}
-
-.justify-content(@justify) {
-  justify-content: @justify;
-  -webkit-justify-content: @justify;
-}
-
-.order(@order) {
-  order: @order;
-  -webkit-order: @order;
-}
-
-.item-flex(@grow, @shrink, @basis) {
-  flex: @grow @shrink @basis;
-  -webkit-flex: @grow @shrink @basis;
-}
-
 .no-user-select() {
   user-select: none;
   -ms-user-select: none;

--- a/bokehjs/src/less/buttons.less
+++ b/bokehjs/src/less/buttons.less
@@ -103,13 +103,13 @@
   .bk-btn-group {
     height: 100%;
 
-    .flex();
-    .flex-wrap(nowrap);
-    .align-items(center);
-    .flex-direction(row);
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    flex-direction: row;
 
     & > .bk-btn {
-      .flex-grow(1);
+      flex-grow: 1;
     }
 
     & > .bk-btn + .bk-btn {
@@ -131,7 +131,7 @@
     }
 
     .bk-dropdown-toggle {
-      .item-flex(0, 0, 0);
+      flex: 0 0 0;
       padding: @padding-vertical (@padding-horizontal ./ 2);
     }
   }

--- a/bokehjs/src/less/menus.less
+++ b/bokehjs/src/less/menus.less
@@ -13,15 +13,15 @@
 
   .bk-context-menu {
     position: absolute;
-    .inline-flex();
-    .flex-wrap(nowrap);
+    display: inline-flex;
+    flex-wrap: nowrap;
     .no-user-select();
 
     &.bk-horizontal {
-      .flex-direction(row);
+      flex-direction: row;
     }
     &.bk-vertical {
-      .flex-direction(column);
+      flex-direction: column;
     }
 
     width: auto;

--- a/bokehjs/src/less/tabs.less
+++ b/bokehjs/src/less/tabs.less
@@ -2,9 +2,9 @@
 
 .bk-root {
   .bk-tabs-header {
-    .flex();
-    .flex-wrap(nowrap);
-    .align-items(center);
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
     overflow: hidden;
 
     .no-user-select();
@@ -14,14 +14,14 @@
       margin-right: 5px;
 
       & > .bk-btn {
-        .flex-grow(0);
+        flex-grow: 0;
         height: auto;
         padding: 4px 4px;
       }
     }
 
     .bk-headers-wrapper {
-      .flex-grow(1);
+      flex-grow: 1;
       overflow: hidden;
       color: lighten(black, 40%);
     }
@@ -33,25 +33,25 @@
     &.bk-left  .bk-headers-wrapper { border-right:  @border; }
 
     &.bk-above, &.bk-below {
-      .flex-direction(row);
+      flex-direction: row;
 
       .bk-headers {
-        .flex-direction(row);
+        flex-direction: row;
       }
     }
     &.bk-left,  &.bk-right {
-      .flex-direction(column);
+      flex-direction: column;
 
       .bk-headers {
-        .flex-direction(column);
+        flex-direction: column;
       }
     }
 
     .bk-headers {
       position: relative;
-      .flex();
-      .flex-wrap(nowrap);
-      .align-items(center);
+      display: flex;
+      flex-wrap: nowrap;
+      align-items: center;
     }
 
     .bk-tab {

--- a/bokehjs/src/less/toolbar.less
+++ b/bokehjs/src/less/toolbar.less
@@ -14,43 +14,43 @@
   }
 
   .bk-toolbar, .bk-button-bar {
-    .flex();
-    .flex-wrap(nowrap);
-    .align-items(center);
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
     .no-user-select();
   }
 
   .bk-toolbar .bk-logo {
-    .flex-shrink(0);
+    flex-shrink: 0;
   }
 
   .bk-toolbar.bk-above, .bk-toolbar.bk-below {
-    .flex-direction(row);
-    .justify-content(flex-end);
+    flex-direction: row;
+    justify-content: flex-end;
 
     .bk-button-bar {
-      .flex();
-      .flex-direction(row);
+      display: flex;
+      flex-direction: row;
     }
 
     .bk-logo {
-      .order(1);
+      order: 1;
       margin-left: 5px;
       margin-right: 0px;
     }
   }
 
   .bk-toolbar.bk-left, .bk-toolbar.bk-right {
-    .flex-direction(column);
-    .justify-content(flex-start);
+    flex-direction: column;
+    justify-content: flex-start;
 
     .bk-button-bar {
-      .flex();
-      .flex-direction(column);
+      display: flex;
+      flex-direction: column;
     }
 
     .bk-logo {
-      .order(0);
+      order: 0;
       margin-bottom: 5px;
       margin-top: 0px;
     }

--- a/bokehjs/src/less/widgets/inputs.less
+++ b/bokehjs/src/less/widgets/inputs.less
@@ -4,7 +4,7 @@
   .bk-input {
     display: inline-block;
     width: 100%;
-    .flex-grow(1);
+    flex-grow: 1;
     min-height: (@line-height-computed + (@padding-vertical*2) + 2);
     padding: 0 @padding-horizontal;
     background-color: #fff;
@@ -49,15 +49,15 @@
   .bk-input-group {
     width: 100%;
     height: 100%;
-    .inline-flex();
-    .flex-wrap(nowrap);
-    .align-items(start);
-    .flex-direction(column);
+    display: inline-flex;
+    flex-wrap: nowrap;
+    align-items: start;
+    flex-direction: column;
 
     white-space: nowrap;
 
     &.bk-inline {
-      .flex-direction(row);
+      flex-direction: row;
 
       & > *:not(:first-child) {
         margin-left: 5px;


### PR DESCRIPTION
All supported browsers support non-prefixed standard version, so there's no point in keeping this around.