### PR TITLE
Simplify rendering code with visuals.apply()

### DIFF
--- a/bokehjs/src/lib/core/visuals/fill.ts
+++ b/bokehjs/src/lib/core/visuals/fill.ts
@@ -14,6 +14,15 @@ export class Fill extends VisualProperties {
     return !(color == null || alpha == 0)
   }
 
+  apply(ctx: Context2d, rule?: CanvasFillRule): boolean {
+    const {doit} = this
+    if (doit) {
+      this.set_value(ctx)
+      ctx.fill(rule)
+    }
+    return doit
+  }
+
   set_value(ctx: Context2d): void {
     const color = this.fill_color.get_value()
     const alpha = this.fill_alpha.get_value()
@@ -31,6 +40,15 @@ export class FillScalar extends VisualUniforms {
     const alpha = this.fill_alpha.value
 
     return !(color == 0 || alpha == 0)
+  }
+
+  apply(ctx: Context2d, rule?: CanvasFillRule): boolean {
+    const {doit} = this
+    if (doit) {
+      this.set_value(ctx)
+      ctx.fill(rule)
+    }
+    return doit
   }
 
   set_value(ctx: Context2d): void {
@@ -53,6 +71,15 @@ export class FillVector extends VisualUniforms {
     if (fill_alpha.is_Scalar() && fill_alpha.value == 0)
       return false
     return true
+  }
+
+  apply(ctx: Context2d, i: number, rule?: CanvasFillRule): boolean {
+    const {doit} = this
+    if (doit) {
+      this.set_vectorize(ctx, i)
+      ctx.fill(rule)
+    }
+    return doit
   }
 
   set_vectorize(ctx: Context2d, i: number): void {

--- a/bokehjs/src/lib/core/visuals/hatch.ts
+++ b/bokehjs/src/lib/core/visuals/hatch.ts
@@ -58,6 +58,15 @@ export class Hatch extends VisualProperties {
     return !(color == null || alpha == 0 || pattern == " " || pattern == "blank" || pattern == null)
   }
 
+  apply(ctx: Context2d, rule?: CanvasFillRule): boolean {
+    const {doit} = this
+    if (doit) {
+      this.set_value(ctx)
+      ctx.fill(rule)
+    }
+    return doit
+  }
+
   set_value(ctx: Context2d): void {
     const pattern = this.pattern(ctx)
     ctx.fillStyle = pattern ?? "transparent"
@@ -153,6 +162,15 @@ export class HatchScalar extends VisualUniforms {
 
   get doit(): boolean {
     return this._static_doit
+  }
+
+  apply(ctx: Context2d, rule?: CanvasFillRule): boolean {
+    const {doit} = this
+    if (doit) {
+      this.set_value(ctx)
+      ctx.fill(rule)
+    }
+    return doit
   }
 
   set_value(ctx: Context2d): void {
@@ -284,6 +302,15 @@ export class HatchVector extends VisualUniforms {
 
   get doit(): boolean {
     return this._static_doit
+  }
+
+  apply(ctx: Context2d, i: number, rule?: CanvasFillRule): boolean {
+    const {doit} = this
+    if (doit) {
+      this.set_vectorize(ctx, i)
+      ctx.fill(rule)
+    }
+    return doit
   }
 
   set_vectorize(ctx: Context2d, i: number): void {

--- a/bokehjs/src/lib/core/visuals/line.ts
+++ b/bokehjs/src/lib/core/visuals/line.ts
@@ -33,6 +33,15 @@ export class Line extends VisualProperties {
     return !(color == null || alpha == 0 || width == 0)
   }
 
+  apply(ctx: Context2d): boolean {
+    const {doit} = this
+    if (doit) {
+      this.set_value(ctx)
+      ctx.stroke()
+    }
+    return doit
+  }
+
   set_value(ctx: Context2d): void {
     const color = this.line_color.get_value()
     const alpha = this.line_alpha.get_value()
@@ -61,6 +70,15 @@ export class LineScalar extends VisualUniforms {
     const width = this.line_width.value
 
     return !(color == 0 || alpha == 0 || width == 0)
+  }
+
+  apply(ctx: Context2d): boolean {
+    const {doit} = this
+    if (doit) {
+      this.set_value(ctx)
+      ctx.stroke()
+    }
+    return doit
   }
 
   set_value(ctx: Context2d): void {
@@ -96,6 +114,15 @@ export class LineVector extends VisualUniforms {
     if (line_width.is_Scalar() && line_width.value == 0)
       return false
     return true
+  }
+
+  apply(ctx: Context2d, i: number): boolean {
+    const {doit} = this
+    if (doit) {
+      this.set_vectorize(ctx, i)
+      ctx.stroke()
+    }
+    return doit
   }
 
   set_vectorize(ctx: Context2d, i: number): void {

--- a/bokehjs/src/lib/models/annotations/band.ts
+++ b/bokehjs/src/lib/models/annotations/band.ts
@@ -22,11 +22,7 @@ export class BandView extends UpperLowerView {
     }
 
     ctx.closePath()
-
-    if (this.visuals.fill.doit) {
-      this.visuals.fill.set_value(ctx)
-      ctx.fill()
-    }
+    this.visuals.fill.apply(ctx)
 
     // Draw the lower band edge
     ctx.beginPath()
@@ -35,10 +31,7 @@ export class BandView extends UpperLowerView {
       ctx.lineTo(this._lower_sx[i], this._lower_sy[i])
     }
 
-    if (this.visuals.line.doit) {
-      this.visuals.line.set_value(ctx)
-      ctx.stroke()
-    }
+    this.visuals.line.apply(ctx)
 
     // Draw the upper band edge
     ctx.beginPath()
@@ -47,10 +40,7 @@ export class BandView extends UpperLowerView {
       ctx.lineTo(this._upper_sx[i], this._upper_sy[i])
     }
 
-    if (this.visuals.line.doit) {
-      this.visuals.line.set_value(ctx)
-      ctx.stroke()
-    }
+    this.visuals.line.apply(ctx)
   }
 }
 

--- a/bokehjs/src/lib/models/annotations/box_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/box_annotation.ts
@@ -64,20 +64,9 @@ export class BoxAnnotationView extends AnnotationView {
     ctx.beginPath()
     ctx.rect(left, top, width, height)
 
-    if (this.visuals.fill.doit) {
-      this.visuals.fill.set_value(ctx)
-      ctx.fill()
-    }
-
-    if (this.visuals.hatch.doit) {
-      this.visuals.hatch.set_value(ctx)
-      ctx.fill()
-    }
-
-    if (this.visuals.line.doit) {
-      this.visuals.line.set_value(ctx)
-      ctx.stroke()
-    }
+    this.visuals.fill.apply(ctx)
+    this.visuals.hatch.apply(ctx)
+    this.visuals.line.apply(ctx)
 
     ctx.restore()
   }

--- a/bokehjs/src/lib/models/annotations/label_set.ts
+++ b/bokehjs/src/lib/models/annotations/label_set.ts
@@ -109,15 +109,8 @@ export class LabelSetView extends TextAnnotationView {
 
     ctx.rect(bbox_dims[0], bbox_dims[1], bbox_dims[2], bbox_dims[3])
 
-    if (this.visuals.background_fill.doit) {
-      this.visuals.background_fill.set_vectorize(ctx, i)
-      ctx.fill()
-    }
-
-    if (this.visuals.border_line.doit) {
-      this.visuals.border_line.set_vectorize(ctx, i)
-      ctx.stroke()
-    }
+    this.visuals.background_fill.apply(ctx, i)
+    this.visuals.border_line.apply(ctx, i)
 
     if (this.visuals.text.doit) {
       this.visuals.text.set_vectorize(ctx, i)

--- a/bokehjs/src/lib/models/annotations/legend.ts
+++ b/bokehjs/src/lib/models/annotations/legend.ts
@@ -235,12 +235,8 @@ export class LegendView extends AnnotationView {
   protected _draw_legend_box(ctx: Context2d, bbox: BBox): void {
     ctx.beginPath()
     ctx.rect(bbox.x, bbox.y, bbox.width, bbox.height)
-    this.visuals.background_fill.set_value(ctx)
-    ctx.fill()
-    if (this.visuals.border_line.doit) {
-      this.visuals.border_line.set_value(ctx)
-      ctx.stroke()
-    }
+    this.visuals.background_fill.apply(ctx)
+    this.visuals.border_line.apply(ctx)
   }
 
   protected _draw_legend_items(ctx: Context2d, bbox: BBox): void {

--- a/bokehjs/src/lib/models/annotations/poly_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/poly_annotation.ts
@@ -49,20 +49,9 @@ export class PolyAnnotationView extends AnnotationView {
     }
     ctx.closePath()
 
-    if (this.visuals.fill.doit) {
-      this.visuals.fill.set_value(ctx)
-      ctx.fill()
-    }
-
-    if (this.visuals.hatch.doit) {
-      this.visuals.hatch.set_value(ctx)
-      ctx.fill()
-    }
-
-    if (this.visuals.line.doit) {
-      this.visuals.line.set_value(ctx)
-      ctx.stroke()
-    }
+    this.visuals.fill.apply(ctx)
+    this.visuals.hatch.apply(ctx)
+    this.visuals.line.apply(ctx)
   }
 }
 

--- a/bokehjs/src/lib/models/annotations/text_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/text_annotation.ts
@@ -102,15 +102,8 @@ export abstract class TextAnnotationView extends AnnotationView {
 
     ctx.rect(bbox_dims[0], bbox_dims[1], bbox_dims[2], bbox_dims[3])
 
-    if (this.visuals.background_fill.doit) {
-      this.visuals.background_fill.set_value(ctx)
-      ctx.fill()
-    }
-
-    if (this.visuals.border_line.doit) {
-      this.visuals.border_line.set_value(ctx)
-      ctx.stroke()
-    }
+    this.visuals.background_fill.apply(ctx)
+    this.visuals.border_line.apply(ctx)
 
     if (this.visuals.text.doit) {
       this.visuals.text.set_value(ctx)

--- a/bokehjs/src/lib/models/glyphs/annular_wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/annular_wedge.ts
@@ -73,20 +73,9 @@ export class AnnularWedgeView extends XYGlyphView {
       ctx.rotate(-angle_i - start_angle_i)
       ctx.translate(-sx_i, -sy_i)
 
-      if (this.visuals.fill.doit) {
-        this.visuals.fill.set_vectorize(ctx, i)
-        ctx.fill()
-      }
-
-      if (this.visuals.hatch.doit) {
-        this.visuals.hatch.set_vectorize(ctx, i)
-        ctx.fill()
-      }
-
-      if (this.visuals.line.doit) {
-        this.visuals.line.set_vectorize(ctx, i)
-        ctx.stroke()
-      }
+      this.visuals.fill.apply(ctx, i)
+      this.visuals.hatch.apply(ctx, i)
+      this.visuals.line.apply(ctx, i)
     }
   }
 

--- a/bokehjs/src/lib/models/glyphs/annulus.ts
+++ b/bokehjs/src/lib/models/glyphs/annulus.ts
@@ -71,20 +71,9 @@ export class AnnulusView extends XYGlyphView {
         ctx.arc(sx_i, sy_i, souter_radius_i, 2 * Math.PI, 0, false)
       }
 
-      if (this.visuals.fill.doit) {
-        this.visuals.fill.set_vectorize(ctx, i)
-        ctx.fill()
-      }
-
-      if (this.visuals.hatch.doit) {
-        this.visuals.hatch.set_vectorize(ctx, i)
-        ctx.fill()
-      }
-
-      if (this.visuals.line.doit) {
-        this.visuals.line.set_vectorize(ctx, i)
-        ctx.stroke()
-      }
+      this.visuals.fill.apply(ctx, i)
+      this.visuals.hatch.apply(ctx, i)
+      this.visuals.line.apply(ctx, i)
     }
   }
 

--- a/bokehjs/src/lib/models/glyphs/box.ts
+++ b/bokehjs/src/lib/models/glyphs/box.ts
@@ -79,20 +79,9 @@ export abstract class BoxView extends GlyphView {
       ctx.beginPath()
       ctx.rect(sleft_i, stop_i, sright_i - sleft_i, sbottom_i - stop_i)
 
-      if (this.visuals.fill.doit) {
-        this.visuals.fill.set_vectorize(ctx, i)
-        ctx.fill()
-      }
-
-      if (this.visuals.hatch.doit) {
-        this.visuals.hatch.set_vectorize(ctx, i)
-        ctx.fill()
-      }
-
-      if (this.visuals.line.doit) {
-        this.visuals.line.set_vectorize(ctx, i)
-        ctx.stroke()
-      }
+      this.visuals.fill.apply(ctx, i)
+      this.visuals.hatch.apply(ctx, i)
+      this.visuals.line.apply(ctx, i)
     }
   }
 

--- a/bokehjs/src/lib/models/glyphs/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/circle.ts
@@ -124,20 +124,9 @@ export class CircleView extends XYGlyphView {
       ctx.beginPath()
       ctx.arc(sx_i, sy_i, sradius_i, 0, 2*Math.PI, false)
 
-      if (this.visuals.fill.doit) {
-        this.visuals.fill.set_vectorize(ctx, i)
-        ctx.fill()
-      }
-
-      if (this.visuals.hatch.doit) {
-        this.visuals.hatch.set_vectorize(ctx, i)
-        ctx.fill()
-      }
-
-      if (this.visuals.line.doit) {
-        this.visuals.line.set_vectorize(ctx, i)
-        ctx.stroke()
-      }
+      this.visuals.fill.apply(ctx, i)
+      this.visuals.hatch.apply(ctx, i)
+      this.visuals.line.apply(ctx, i)
     }
   }
 

--- a/bokehjs/src/lib/models/glyphs/defs.ts
+++ b/bokehjs/src/lib/models/glyphs/defs.ts
@@ -97,43 +97,22 @@ function asterisk(ctx: Context2d, i: number, r: number, visuals: VectorVisuals):
   _one_cross(ctx, r)
   _one_x(ctx, r)
 
-  if (visuals.line.doit) {
-    visuals.line.set_vectorize(ctx, i)
-    ctx.stroke()
-  }
+  visuals.line.apply(ctx, i)
 }
 
 function circle(ctx: Context2d, i: number, r: number, visuals: VectorVisuals): void {
   ctx.arc(0, 0, r, 0, 2*Math.PI, false)
 
-  if (visuals.fill.doit) {
-    visuals.fill.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.hatch.doit) {
-    visuals.hatch.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.line.doit) {
-    visuals.line.set_vectorize(ctx, i)
-    ctx.stroke()
-  }
+  visuals.fill.apply(ctx, i)
+  visuals.hatch.apply(ctx, i)
+  visuals.line.apply(ctx, i)
 }
 
 function circle_cross(ctx: Context2d, i: number, r: number, visuals: VectorVisuals): void {
   ctx.arc(0, 0, r, 0, 2*Math.PI, false)
 
-  if (visuals.fill.doit) {
-    visuals.fill.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.hatch.doit) {
-    visuals.hatch.set_vectorize(ctx, i)
-    ctx.fill()
-  }
+  visuals.fill.apply(ctx, i)
+  visuals.hatch.apply(ctx, i)
 
   if (visuals.line.doit) {
     visuals.line.set_vectorize(ctx, i)
@@ -150,15 +129,8 @@ function circle_dot(ctx: Context2d, i: number, r: number, visuals: VectorVisuals
 function circle_y(ctx: Context2d, i: number, r: number, visuals: VectorVisuals): void {
   ctx.arc(0, 0, r, 0, 2*Math.PI, false)
 
-  if (visuals.fill.doit) {
-    visuals.fill.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.hatch.doit) {
-    visuals.hatch.set_vectorize(ctx, i)
-    ctx.fill()
-  }
+  visuals.fill.apply(ctx, i)
+  visuals.hatch.apply(ctx, i)
 
   if (visuals.line.doit) {
     visuals.line.set_vectorize(ctx, i)
@@ -170,15 +142,8 @@ function circle_y(ctx: Context2d, i: number, r: number, visuals: VectorVisuals):
 function circle_x(ctx: Context2d, i: number, r: number, visuals: VectorVisuals): void {
   ctx.arc(0, 0, r, 0, 2*Math.PI, false)
 
-  if (visuals.fill.doit) {
-    visuals.fill.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.hatch.doit) {
-    visuals.hatch.set_vectorize(ctx, i)
-    ctx.fill()
-  }
+  visuals.fill.apply(ctx, i)
+  visuals.hatch.apply(ctx, i)
 
   if (visuals.line.doit) {
     visuals.line.set_vectorize(ctx, i)
@@ -190,43 +155,22 @@ function circle_x(ctx: Context2d, i: number, r: number, visuals: VectorVisuals):
 function cross(ctx: Context2d, i: number, r: number, visuals: VectorVisuals): void {
   _one_cross(ctx, r)
 
-  if (visuals.line.doit) {
-    visuals.line.set_vectorize(ctx, i)
-    ctx.stroke()
-  }
+  visuals.line.apply(ctx, i)
 }
 
 function diamond(ctx: Context2d, i: number, r: number, visuals: VectorVisuals): void {
   _one_diamond(ctx, r)
 
-  if (visuals.fill.doit) {
-    visuals.fill.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.hatch.doit) {
-    visuals.hatch.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.line.doit) {
-    visuals.line.set_vectorize(ctx, i)
-    ctx.stroke()
-  }
+  visuals.fill.apply(ctx, i)
+  visuals.hatch.apply(ctx, i)
+  visuals.line.apply(ctx, i)
 }
 
 function diamond_cross(ctx: Context2d, i: number, r: number, visuals: VectorVisuals): void {
   _one_diamond(ctx, r)
 
-  if (visuals.fill.doit) {
-    visuals.fill.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.hatch.doit) {
-    visuals.hatch.set_vectorize(ctx, i)
-    ctx.fill()
-  }
+  visuals.fill.apply(ctx, i)
+  visuals.hatch.apply(ctx, i)
 
   if (visuals.line.doit) {
     visuals.line.set_vectorize(ctx, i)
@@ -254,20 +198,9 @@ function dot(ctx: Context2d, i: number, r: number, visuals: VectorVisuals): void
 function hex(ctx: Context2d, i: number, r: number, visuals: VectorVisuals): void {
   _one_hex(ctx, r)
 
-  if (visuals.fill.doit) {
-    visuals.fill.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.hatch.doit) {
-    visuals.hatch.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.line.doit) {
-    visuals.line.set_vectorize(ctx, i)
-    ctx.stroke()
-  }
+  visuals.fill.apply(ctx, i)
+  visuals.hatch.apply(ctx, i)
+  visuals.line.apply(ctx, i)
 }
 
 function hex_dot(ctx: Context2d, i: number, r: number, visuals: VectorVisuals): void {
@@ -280,20 +213,9 @@ function inverted_triangle(ctx: Context2d, i: number, r: number, visuals: Vector
   _one_tri(ctx, r)
   ctx.rotate(-Math.PI)
 
-  if (visuals.fill.doit) {
-    visuals.fill.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.hatch.doit) {
-    visuals.hatch.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.line.doit) {
-    visuals.line.set_vectorize(ctx, i)
-    ctx.stroke()
-  }
+  visuals.fill.apply(ctx, i)
+  visuals.hatch.apply(ctx, i)
+  visuals.line.apply(ctx, i)
 }
 
 function plus(ctx: Context2d, i: number, r: number, visuals: VectorVisuals): void {
@@ -308,20 +230,9 @@ function plus(ctx: Context2d, i: number, r: number, visuals: VectorVisuals): voi
   }
   ctx.closePath()
 
-  if (visuals.fill.doit) {
-    visuals.fill.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.hatch.doit) {
-    visuals.hatch.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.line.doit) {
-    visuals.line.set_vectorize(ctx, i)
-    ctx.stroke()
-  }
+  visuals.fill.apply(ctx, i)
+  visuals.hatch.apply(ctx, i)
+  visuals.line.apply(ctx, i)
 }
 
 function square(ctx: Context2d, i: number, r: number, visuals: VectorVisuals): void {
@@ -329,20 +240,9 @@ function square(ctx: Context2d, i: number, r: number, visuals: VectorVisuals): v
 
   ctx.rect(-r, -r, size, size)
 
-  if (visuals.fill.doit) {
-    visuals.fill.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.hatch.doit) {
-    visuals.hatch.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.line.doit) {
-    visuals.line.set_vectorize(ctx, i)
-    ctx.stroke()
-  }
+  visuals.fill.apply(ctx, i)
+  visuals.hatch.apply(ctx, i)
+  visuals.line.apply(ctx, i)
 }
 
 function square_pin(ctx: Context2d, i: number, r: number, visuals: VectorVisuals): void {
@@ -358,20 +258,9 @@ function square_pin(ctx: Context2d, i: number, r: number, visuals: VectorVisuals
 
   ctx.closePath()
 
-  if (visuals.fill.doit) {
-    visuals.fill.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.hatch.doit) {
-    visuals.hatch.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.line.doit) {
-    visuals.line.set_vectorize(ctx, i)
-    ctx.stroke()
-  }
+  visuals.fill.apply(ctx, i)
+  visuals.hatch.apply(ctx, i)
+  visuals.line.apply(ctx, i)
 }
 
 function square_cross(ctx: Context2d, i: number, r: number, visuals: VectorVisuals): void {
@@ -379,15 +268,8 @@ function square_cross(ctx: Context2d, i: number, r: number, visuals: VectorVisua
 
   ctx.rect(-r, -r, size, size)
 
-  if (visuals.fill.doit) {
-    visuals.fill.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.hatch.doit) {
-    visuals.hatch.set_vectorize(ctx, i)
-    ctx.fill()
-  }
+  visuals.fill.apply(ctx, i)
+  visuals.hatch.apply(ctx, i)
 
   if (visuals.line.doit) {
     visuals.line.set_vectorize(ctx, i)
@@ -406,15 +288,8 @@ function square_x(ctx: Context2d, i: number, r: number, visuals: VectorVisuals):
 
   ctx.rect(-r, -r, size, size)
 
-  if (visuals.fill.doit) {
-    visuals.fill.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.hatch.doit) {
-    visuals.hatch.set_vectorize(ctx, i)
-    ctx.fill()
-  }
+  visuals.fill.apply(ctx, i)
+  visuals.hatch.apply(ctx, i)
 
   if (visuals.line.doit) {
     visuals.line.set_vectorize(ctx, i)
@@ -429,20 +304,9 @@ function square_x(ctx: Context2d, i: number, r: number, visuals: VectorVisuals):
 function star(ctx: Context2d, i: number, r: number, visuals: VectorVisuals): void {
   _one_star(ctx, r)
 
-  if (visuals.fill.doit) {
-    visuals.fill.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.hatch.doit) {
-    visuals.hatch.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.line.doit) {
-    visuals.line.set_vectorize(ctx, i)
-    ctx.stroke()
-  }
+  visuals.fill.apply(ctx, i)
+  visuals.hatch.apply(ctx, i)
+  visuals.line.apply(ctx, i)
 }
 
 function star_dot(ctx: Context2d, i: number, r: number, visuals: VectorVisuals): void {
@@ -453,20 +317,9 @@ function star_dot(ctx: Context2d, i: number, r: number, visuals: VectorVisuals):
 function triangle(ctx: Context2d, i: number, r: number, visuals: VectorVisuals): void {
   _one_tri(ctx, r)
 
-  if (visuals.fill.doit) {
-    visuals.fill.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.hatch.doit) {
-    visuals.hatch.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.line.doit) {
-    visuals.line.set_vectorize(ctx, i)
-    ctx.stroke()
-  }
+  visuals.fill.apply(ctx, i)
+  visuals.hatch.apply(ctx, i)
+  visuals.line.apply(ctx, i)
 }
 
 function triangle_dot(ctx: Context2d, i: number, r: number, visuals: VectorVisuals): void {
@@ -485,47 +338,24 @@ function triangle_pin(ctx: Context2d, i: number, r: number, visuals: VectorVisua
   ctx.quadraticCurveTo(-SQ3*b/2, b/2, -r, a)
   ctx.closePath()
 
-  if (visuals.fill.doit) {
-    visuals.fill.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.hatch.doit) {
-    visuals.hatch.set_vectorize(ctx, i)
-    ctx.fill()
-  }
-
-  if (visuals.line.doit) {
-    visuals.line.set_vectorize(ctx, i)
-    ctx.stroke()
-  }
+  visuals.fill.apply(ctx, i)
+  visuals.hatch.apply(ctx, i)
+  visuals.line.apply(ctx, i)
 }
 
 function dash(ctx: Context2d, i: number, r: number, visuals: VectorVisuals): void {
   _one_line(ctx, r)
-
-  if (visuals.line.doit) {
-    visuals.line.set_vectorize(ctx, i)
-    ctx.stroke()
-  }
+  visuals.line.apply(ctx, i)
 }
 
 function x(ctx: Context2d, i: number, r: number, visuals: VectorVisuals): void {
   _one_x(ctx, r)
-
-  if (visuals.line.doit) {
-    visuals.line.set_vectorize(ctx, i)
-    ctx.stroke()
-  }
+  visuals.line.apply(ctx, i)
 }
 
 function y(ctx: Context2d, i: number, r: number, visuals: VectorVisuals): void {
   _one_y(ctx, r)
-
-  if (visuals.line.doit) {
-    visuals.line.set_vectorize(ctx, i)
-    ctx.stroke()
-  }
+  visuals.line.apply(ctx, i)
 }
 
 export type RenderOne = (ctx: Context2d, i: number, r: number, visuals: VectorVisuals) => void

--- a/bokehjs/src/lib/models/glyphs/ellipse_oval.ts
+++ b/bokehjs/src/lib/models/glyphs/ellipse_oval.ts
@@ -42,20 +42,9 @@ export abstract class EllipseOvalView extends CenterRotatableView  {
       ctx.beginPath()
       ctx.ellipse(sx_i, sy_i, sw_i/2.0, sh_i/2.0, angle_i, 0, 2 * Math.PI)
 
-      if (this.visuals.fill.doit) {
-        this.visuals.fill.set_vectorize(ctx, i)
-        ctx.fill()
-      }
-
-      if (this.visuals.hatch.doit) {
-        this.visuals.hatch.set_vectorize(ctx, i)
-        ctx.fill()
-      }
-
-      if (this.visuals.line.doit) {
-        this.visuals.line.set_vectorize(ctx, i)
-        ctx.stroke()
-      }
+      this.visuals.fill.apply(ctx, i)
+      this.visuals.hatch.apply(ctx, i)
+      this.visuals.line.apply(ctx, i)
     }
   }
 

--- a/bokehjs/src/lib/models/glyphs/harea.ts
+++ b/bokehjs/src/lib/models/glyphs/harea.ts
@@ -48,15 +48,8 @@ export class HAreaView extends AreaView {
     }
     ctx.closePath()
 
-    if (this.visuals.fill.doit) {
-      this.visuals.fill.set_value(ctx)
-      ctx.fill()
-    }
-
-    if (this.visuals.hatch.doit) {
-      this.visuals.hatch.set_value(ctx)
-      ctx.fill()
-    }
+    this.visuals.fill.apply(ctx)
+    this.visuals.hatch.apply(ctx)
   }
 
   protected _hit_point(geometry: PointGeometry): Selection {

--- a/bokehjs/src/lib/models/glyphs/hex_tile.ts
+++ b/bokehjs/src/lib/models/glyphs/hex_tile.ts
@@ -151,20 +151,9 @@ export class HexTileView extends GlyphView {
       ctx.closePath()
       ctx.translate(-sx_i, -sy_i)
 
-      if (this.visuals.fill.doit) {
-        this.visuals.fill.set_vectorize(ctx, i)
-        ctx.fill()
-      }
-
-      if (this.visuals.hatch.doit) {
-        this.visuals.hatch.set_vectorize(ctx, i)
-        ctx.fill()
-      }
-
-      if (this.visuals.line.doit) {
-        this.visuals.line.set_vectorize(ctx, i)
-        ctx.stroke()
-      }
+      this.visuals.fill.apply(ctx, i)
+      this.visuals.hatch.apply(ctx, i)
+      this.visuals.line.apply(ctx, i)
     }
   }
 

--- a/bokehjs/src/lib/models/glyphs/multi_polygons.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_polygons.ts
@@ -157,20 +157,9 @@ export class MultiPolygonsView extends GlyphView {
           }
         }
 
-        if (this.visuals.fill.doit) {
-          this.visuals.fill.set_vectorize(ctx, i)
-          ctx.fill("evenodd")
-        }
-
-        if (this.visuals.hatch.doit) {
-          this.visuals.hatch.set_vectorize(ctx, i)
-          ctx.fill("evenodd")
-        }
-
-        if (this.visuals.line.doit) {
-          this.visuals.line.set_vectorize(ctx, i)
-          ctx.stroke()
-        }
+        this.visuals.fill.apply(ctx, i, "evenodd")
+        this.visuals.hatch.apply(ctx, i, "evenodd")
+        this.visuals.line.apply(ctx, i)
       }
     }
   }

--- a/bokehjs/src/lib/models/glyphs/patch.ts
+++ b/bokehjs/src/lib/models/glyphs/patch.ts
@@ -41,20 +41,9 @@ export class PatchView extends XYGlyphView {
 
     ctx.closePath()
 
-    if (this.visuals.fill.doit) {
-      this.visuals.fill.set_value(ctx)
-      ctx.fill()
-    }
-
-    if (this.visuals.hatch.doit) {
-      this.visuals.hatch.set_value(ctx)
-      ctx.fill()
-    }
-
-    if (this.visuals.line.doit) {
-      this.visuals.line.set_value(ctx)
-      ctx.stroke()
-    }
+    this.visuals.fill.apply(ctx)
+    this.visuals.hatch.apply(ctx)
+    this.visuals.line.apply(ctx)
   }
 
   draw_legend_for_index(ctx: Context2d, bbox: Rect, _index: number): void {

--- a/bokehjs/src/lib/models/glyphs/patches.ts
+++ b/bokehjs/src/lib/models/glyphs/patches.ts
@@ -80,20 +80,9 @@ export class PatchesView extends GlyphView {
 
       ctx.closePath()
 
-      if (this.visuals.fill.doit) {
-        this.visuals.fill.set_vectorize(ctx, i)
-        ctx.fill()
-      }
-
-      if (this.visuals.hatch.doit) {
-        this.visuals.hatch.set_vectorize(ctx, i)
-        ctx.fill()
-      }
-
-      if (this.visuals.line.doit) {
-        this.visuals.line.set_vectorize(ctx, i)
-        ctx.stroke()
-      }
+      this.visuals.fill.apply(ctx, i)
+      this.visuals.hatch.apply(ctx, i)
+      this.visuals.line.apply(ctx, i)
     }
   }
 

--- a/bokehjs/src/lib/models/glyphs/rect.ts
+++ b/bokehjs/src/lib/models/glyphs/rect.ts
@@ -78,20 +78,9 @@ export class RectView extends CenterRotatableView {
       } else
         ctx.rect(sx0_i, sy1_i, sw_i, sh_i)
 
-      if (this.visuals.fill.doit) {
-        this.visuals.fill.set_vectorize(ctx, i)
-        ctx.fill()
-      }
-
-      if (this.visuals.hatch.doit) {
-        this.visuals.hatch.set_vectorize(ctx, i)
-        ctx.fill()
-      }
-
-      if (this.visuals.line.doit) {
-        this.visuals.line.set_vectorize(ctx, i)
-        ctx.stroke()
-      }
+      this.visuals.fill.apply(ctx, i)
+      this.visuals.hatch.apply(ctx, i)
+      this.visuals.line.apply(ctx, i)
     }
   }
 

--- a/bokehjs/src/lib/models/glyphs/utils.ts
+++ b/bokehjs/src/lib/models/glyphs/utils.ts
@@ -11,23 +11,17 @@ export function generic_line_scalar_legend(visuals: {line: v.LineScalar},
   ctx.beginPath()
   ctx.moveTo(x0, (y0 + y1) /2)
   ctx.lineTo(x1, (y0 + y1) /2)
-  if (visuals.line.doit) {
-    visuals.line.set_value(ctx)
-    ctx.stroke()
-  }
+  visuals.line.apply(ctx)
   ctx.restore()
 }
 
 export function generic_line_vector_legend(visuals: {line: v.LineVector},
-    ctx: Context2d, {x0, x1, y0, y1}: Rect, index: number): void {
+    ctx: Context2d, {x0, x1, y0, y1}: Rect, i: number): void {
   ctx.save()
   ctx.beginPath()
   ctx.moveTo(x0, (y0 + y1) /2)
   ctx.lineTo(x1, (y0 + y1) /2)
-  if (visuals.line.doit) {
-    visuals.line.set_vectorize(ctx, index)
-    ctx.stroke()
-  }
+  visuals.line.apply(ctx, i)
   ctx.restore()
 }
 
@@ -47,24 +41,13 @@ export function generic_area_scalar_legend(visuals: {line?: v.LineScalar, fill: 
   ctx.beginPath()
   ctx.rect(sx0, sy0, sx1 - sx0, sy1 - sy0)
 
-  if (visuals.fill.doit) {
-    visuals.fill.set_value(ctx)
-    ctx.fill()
-  }
-
-  if (visuals.hatch?.doit) {
-    visuals.hatch.set_value(ctx)
-    ctx.fill()
-  }
-
-  if (visuals.line?.doit) {
-    visuals.line.set_value(ctx)
-    ctx.stroke()
-  }
+  visuals.fill.apply(ctx)
+  visuals.hatch?.apply(ctx)
+  visuals.line?.apply(ctx)
 }
 
 export function generic_area_vector_legend(visuals: {line?: v.LineVector, fill: v.FillVector, hatch?: v.HatchVector},
-    ctx: Context2d, {x0, x1, y0, y1}: Rect, index: number): void {
+    ctx: Context2d, {x0, x1, y0, y1}: Rect, i: number): void {
   const w = Math.abs(x1 - x0)
   const dw = w*0.1
   const h = Math.abs(y1 - y0)
@@ -79,20 +62,9 @@ export function generic_area_vector_legend(visuals: {line?: v.LineVector, fill: 
   ctx.beginPath()
   ctx.rect(sx0, sy0, sx1 - sx0, sy1 - sy0)
 
-  if (visuals.fill.doit) {
-    visuals.fill.set_vectorize(ctx, index)
-    ctx.fill()
-  }
-
-  if (visuals.hatch?.doit) {
-    visuals.hatch.set_vectorize(ctx, index)
-    ctx.fill()
-  }
-
-  if (visuals.line?.doit) {
-    visuals.line.set_vectorize(ctx, index)
-    ctx.stroke()
-  }
+  visuals.fill.apply(ctx, i)
+  visuals.hatch?.apply(ctx, i)
+  visuals.line?.apply(ctx, i)
 }
 
 export {generic_line_vector_legend as generic_line_legend}

--- a/bokehjs/src/lib/models/glyphs/varea.ts
+++ b/bokehjs/src/lib/models/glyphs/varea.ts
@@ -48,15 +48,8 @@ export class VAreaView extends AreaView {
     }
     ctx.closePath()
 
-    if (this.visuals.fill.doit) {
-      this.visuals.fill.set_value(ctx)
-      ctx.fill()
-    }
-
-    if (this.visuals.hatch.doit) {
-      this.visuals.hatch.set_value(ctx)
-      ctx.fill()
-    }
+    this.visuals.fill.apply(ctx)
+    this.visuals.hatch.apply(ctx)
   }
 
   scenterxy(i: number): [number, number] {

--- a/bokehjs/src/lib/models/glyphs/wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/wedge.ts
@@ -51,20 +51,9 @@ export class WedgeView extends XYGlyphView {
       ctx.lineTo(sx_i, sy_i)
       ctx.closePath()
 
-      if (this.visuals.fill.doit) {
-        this.visuals.fill.set_vectorize(ctx, i)
-        ctx.fill()
-      }
-
-      if (this.visuals.hatch.doit) {
-        this.visuals.hatch.set_vectorize(ctx, i)
-        ctx.fill()
-      }
-
-      if (this.visuals.line.doit) {
-        this.visuals.line.set_vectorize(ctx, i)
-        ctx.stroke()
-      }
+      this.visuals.fill.apply(ctx, i)
+      this.visuals.hatch.apply(ctx, i)
+      this.visuals.line.apply(ctx, i)
     }
   }
 

--- a/bokehjs/src/lib/models/grids/grid.ts
+++ b/bokehjs/src/lib/models/grids/grid.ts
@@ -41,15 +41,8 @@ export class GridView extends GuideRendererView {
       ctx.beginPath()
       ctx.rect(sx0[0], sy0[0], sx1[1] - sx0[0], sy1[1] - sy0[0])
 
-      if (this.visuals.band_fill.doit) {
-        this.visuals.band_fill.set_value(ctx)
-        ctx.fill()
-      }
-
-      if (this.visuals.band_hatch.doit) {
-        this.visuals.band_hatch.set_value(ctx)
-        ctx.fill()
-      }
+      this.visuals.band_fill.apply(ctx)
+      this.visuals.band_hatch.apply(ctx)
     }
   }
 

--- a/examples/custom/gears/gear.ts
+++ b/examples/custom/gears/gear.ts
@@ -78,20 +78,9 @@ export class GearView extends XYGlyphView {
         ctx.arc(0, 0, shaft_radius, 0, 2*Math.PI, true)
       }
 
-      if (this.visuals.fill.doit) {
-        this.visuals.fill.set_vectorize(ctx, i)
-        ctx.fill()
-      }
-
-      if (this.visuals.hatch.doit) {
-        this.visuals.hatch.set_vectorize(ctx, i)
-        ctx.fill()
-      }
-
-      if (this.visuals.line.doit) {
-        this.visuals.line.set_vectorize(ctx, i)
-        ctx.stroke()
-      }
+      this.visuals.fill.apply(ctx, i)
+      this.visuals.hatch.apply(ctx, i)
+      this.visuals.line.apply(ctx, i)
 
       ctx.restore()
     }


### PR DESCRIPTION
This substitutes the most commonly appearing pattern:
```ts
if (this.visuals.line.doit) {
  this.visuals.line.set_vectorize(ctx, i)
  ctx.stroke()
}
```
with
```ts
this.visuals.line.apply(ctx, i)
```