### PR TITLE
Allow to test against a provided git reference

### DIFF
--- a/bokehjs/make/tasks/test.ts
+++ b/bokehjs/make/tasks/test.ts
@@ -221,6 +221,7 @@ function devtools(devtools_port: number, server_port: number, name: string, base
     `--port=${devtools_port}`,
     opt("k", argv.k),
     opt("grep", argv.grep),
+    opt("ref", argv.ref),
     opt("baselines-root", baselines_root),
     `--screenshot=${argv.screenshot ?? "test"}`,
   ]

--- a/bokehjs/test/devtools/baselines.ts
+++ b/bokehjs/test/devtools/baselines.ts
@@ -26,13 +26,13 @@ export function create_baseline(items: State[]): string {
   return baseline
 }
 
-export function load_baseline(baseline_path: string): string | null {
-  const proc = cp.spawnSync("git", ["show", `:./${baseline_path}`], {encoding: "utf-8"})
+export function load_baseline(baseline_path: string, ref: string): string | null {
+  const proc = cp.spawnSync("git", ["show", `${ref}:./${baseline_path}`], {encoding: "utf-8"})
   return proc.status == 0 ? proc.stdout : null
 }
 
-export function load_baseline_image(image_path: string): Buffer | null {
-  const proc = cp.spawnSync("git", ["show", `:./${image_path}`], {encoding: "buffer"})
+export function load_baseline_image(image_path: string, ref: string): Buffer | null {
+  const proc = cp.spawnSync("git", ["show", `${ref}:./${image_path}`], {encoding: "buffer"})
   return proc.status == 0 ? proc.stdout : null
 }
 
@@ -40,8 +40,8 @@ function git(...args: string[]): cp.SpawnSyncReturns<string> {
   return cp.spawnSync("git", [...args], {encoding: "utf8"})
 }
 
-export function diff_baseline(baseline_path: string): string {
-  const proc = git("diff", "--color", "--exit-code", baseline_path)
+export function diff_baseline(baseline_path: string, ref: string): string {
+  const proc = git("diff", "--color", "--exit-code", ref, "--", baseline_path)
   if (proc.status == 0) {
     const proc = git("diff", "--color", "/dev/null", baseline_path)
     return proc.stdout

--- a/bokehjs/test/devtools/devtools.ts
+++ b/bokehjs/test/devtools/devtools.ts
@@ -35,6 +35,7 @@ process.on("exit", () => {
 
 const url = argv._[0] as string
 const port = parseInt(argv.port as string | undefined ?? "9222")
+const ref = (argv.ref ?? "HEAD") as string
 
 interface CallFrame {
   name: string
@@ -393,12 +394,12 @@ async function run_tests(): Promise<boolean> {
                         await fs.promises.writeFile(baseline_file, baseline)
                         status.baseline = baseline
 
-                        const existing = load_baseline(baseline_file)
+                        const existing = load_baseline(baseline_file, ref)
                         if (existing != baseline) {
                           if (existing == null) {
                             status.errors.push("missing baseline")
                           }
-                          const diff = diff_baseline(baseline_file)
+                          const diff = diff_baseline(baseline_file, ref)
                           status.failure = true
                           status.baseline_diff = diff
                           status.errors.push(diff)
@@ -414,7 +415,7 @@ async function run_tests(): Promise<boolean> {
 
                           const image_file = `${baseline_path}.png`
                           const write_image = async () => fs.promises.writeFile(image_file, current)
-                          const existing = load_baseline_image(image_file)
+                          const existing = load_baseline_image(image_file, ref)
 
                           switch (argv.screenshot) {
                             case undefined:


### PR DESCRIPTION
For example:
```
node make test:integration --ref HEAD~5
```
or
```
node make test:integration --ref origin/branch-2.4
```
This is particularly useful when checking out other people's work when baselines were already updated (so, there is no difference between working tree and `HEAD`).
