### PR TITLE
Add "maintain_focus" parameter to zoom_base_tools

### DIFF
--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -466,8 +466,8 @@ class WheelZoomTool(Scroll):
 
     maintain_focus = Bool(default=True, help="""
     Whether or not zooming tool maintains its focus position. Setting to False
-    results in a more "gliding" behavior, allowing one to zoom out more
-    smoothly, at the cost of losing the focus position.
+    allows zoom-out to happen even at the boundaries of the graph by applying
+    necessary panning in addition to the zoom out, respecting the boundaries.
     """)
 
     zoom_on_axis = Bool(default=True, help="""
@@ -734,11 +734,11 @@ class ZoomInTool(ActionTool):
     """)
 
     maintain_focus = Bool(default=True, help="""
-    Whether or not zooming tool maintains its focus position. Setting to False
-    results in a more "gliding" behavior, allowing one to zoom out more
-    smoothly, at the cost of losing the focus position.
+    Whether or not zooming tool maintains a centered focus position. Setting to
+    False allows zoom-out to happen even at the boundaries of the graph by
+    applying necessary panning in addition to the zoom out, respecting the
+    boundaries.
     """)
-
 
 class ZoomOutTool(ActionTool):
     ''' *toolbar icon*: |zoom_out_icon|
@@ -762,9 +762,10 @@ class ZoomOutTool(ActionTool):
     """)
 
     maintain_focus = Bool(default=True, help="""
-    Whether or not zooming tool maintains its focus position. Setting to False
-    results in a more "gliding" behavior, allowing one to zoom out more
-    smoothly, at the cost of losing the focus position.
+    Whether or not zooming tool maintains a centered focus position. Setting to
+    False allows zoom-out to happen even at the boundaries of the graph by
+    applying necessary panning in addition to the zoom out, respecting the
+    boundaries.
     """)
 
 class BoxSelectTool(Drag, SelectTool):

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -733,13 +733,6 @@ class ZoomInTool(ActionTool):
     Percentage to zoom for each click of the zoom-in tool.
     """)
 
-    maintain_focus = Bool(default=True, help="""
-    Whether or not zooming tool maintains a centered focus position. Setting to
-    False allows zoom-out to happen even at the boundaries of the graph by
-    applying necessary panning in addition to the zoom out, respecting the
-    boundaries.
-    """)
-
 class ZoomOutTool(ActionTool):
     ''' *toolbar icon*: |zoom_out_icon|
 

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -754,6 +754,12 @@ class ZoomOutTool(ActionTool):
     Percentage to zoom for each click of the zoom-in tool.
     """)
 
+    maintain_focus = Bool(default=True, help="""
+    Whether or not zooming tool maintains its focus position. Setting to False
+    results in a more "gliding" behavior, allowing one to zoom out more
+    smoothly, at the cost of losing the focus position.
+    """)
+
 class BoxSelectTool(Drag, SelectTool):
     ''' *toolbar icon*: |box_select_icon|
 

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -733,6 +733,13 @@ class ZoomInTool(ActionTool):
     Percentage to zoom for each click of the zoom-in tool.
     """)
 
+    maintain_focus = Bool(default=True, help="""
+    Whether or not zooming tool maintains its focus position. Setting to False
+    results in a more "gliding" behavior, allowing one to zoom out more
+    smoothly, at the cost of losing the focus position.
+    """)
+
+
 class ZoomOutTool(ActionTool):
     ''' *toolbar icon*: |zoom_out_icon|
 

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -465,9 +465,10 @@ class WheelZoomTool(Scroll):
     """)
 
     maintain_focus = Bool(default=True, help="""
-    Whether or not zooming tool maintains its focus position. Setting to False
-    allows zoom-out to happen even at the boundaries of the graph by applying
-    necessary panning in addition to the zoom out, respecting the boundaries.
+    If True, then hitting a range bound in any one dimension will prevent all
+    further zooming all dimensions. If False, zooming can continue
+    independently in any dimension that has not yet reached its bounds, even if
+    that causes overall focus or aspect ratio to change.
     """)
 
     zoom_on_axis = Bool(default=True, help="""
@@ -755,10 +756,10 @@ class ZoomOutTool(ActionTool):
     """)
 
     maintain_focus = Bool(default=True, help="""
-    Whether or not zooming tool maintains a centered focus position. Setting to
-    False allows zoom-out to happen even at the boundaries of the graph by
-    applying necessary panning in addition to the zoom out, respecting the
-    boundaries.
+    If True, then hitting a range bound in any one dimension will prevent all
+    further zooming all dimensions. If False, zooming can continue
+    independently in any dimension that has not yet reached its bounds, even if
+    that causes overall focus or aspect ratio to change.
     """)
 
 class BoxSelectTool(Drag, SelectTool):

--- a/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
@@ -17,8 +17,7 @@ export abstract class ZoomBaseToolView extends ActionToolView {
     const zoom_info = scale_range(frame, this.model.sign*this.model.factor, h_axis, v_axis)
 
     this.plot_view.state.push("zoom_out", {range: zoom_info})
-    const {maintain_focus} = this.model
-    this.plot_view.update_range(zoom_info, {scrolling: true, maintain_focus})
+    this.plot_view.update_range(zoom_info, {scrolling: true, maintain_focus: this.model.get_maintain_focus()})
 
     this.model.document?.interactive_start(this.plot_model)
   }
@@ -30,7 +29,6 @@ export namespace ZoomBaseTool {
   export type Props = ActionTool.Props & {
     factor: p.Property<number>
     dimensions: p.Property<Dimensions>
-    maintain_focus: p.Property<boolean>
   }
 }
 
@@ -45,10 +43,9 @@ export abstract class ZoomBaseTool extends ActionTool {
   }
 
   static init_ZoomBaseTool(): void {
-    this.define<ZoomBaseTool.Props>(({Boolean, Percent}) => ({
+    this.define<ZoomBaseTool.Props>(({Percent}) => ({
       factor:     [ Percent,    0.1    ],
       dimensions: [ Dimensions, "both" ],
-      maintain_focus: [ Boolean, true ],
     }))
   }
 
@@ -57,4 +54,5 @@ export abstract class ZoomBaseTool extends ActionTool {
   get tooltip(): string {
     return this._get_dim_tooltip(this.dimensions)
   }
+  abstract get_maintain_focus() : boolean;
 }

--- a/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
@@ -54,5 +54,5 @@ export abstract class ZoomBaseTool extends ActionTool {
   get tooltip(): string {
     return this._get_dim_tooltip(this.dimensions)
   }
-  abstract get_maintain_focus() : boolean;
+  abstract get_maintain_focus(): boolean
 }

--- a/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
@@ -17,7 +17,7 @@ export abstract class ZoomBaseToolView extends ActionToolView {
     const zoom_info = scale_range(frame, this.model.sign*this.model.factor, h_axis, v_axis)
 
     this.plot_view.state.push("zoom_out", {range: zoom_info})
-    this.plot_view.update_range(zoom_info, {scrolling: true, maintain_focus: this.model._maintain_focus})
+    this.plot_view.update_range(zoom_info, {scrolling: true, maintain_focus: this.model.maintain_focus})
 
     this.model.document?.interactive_start(this.plot_model)
   }
@@ -54,5 +54,5 @@ export abstract class ZoomBaseTool extends ActionTool {
   get tooltip(): string {
     return this._get_dim_tooltip(this.dimensions)
   }
-  get _maintain_focus(): boolean { return true }
+  readonly maintain_focus: boolean = true
 }

--- a/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
@@ -17,7 +17,7 @@ export abstract class ZoomBaseToolView extends ActionToolView {
     const zoom_info = scale_range(frame, this.model.sign*this.model.factor, h_axis, v_axis)
 
     this.plot_view.state.push("zoom_out", {range: zoom_info})
-    this.plot_view.update_range(zoom_info, {scrolling: true, maintain_focus: this.model.get_maintain_focus()})
+    this.plot_view.update_range(zoom_info, {scrolling: true, maintain_focus: this.model._maintain_focus})
 
     this.model.document?.interactive_start(this.plot_model)
   }
@@ -54,5 +54,5 @@ export abstract class ZoomBaseTool extends ActionTool {
   get tooltip(): string {
     return this._get_dim_tooltip(this.dimensions)
   }
-  abstract get_maintain_focus(): boolean
+  get _maintain_focus(): boolean { return true }
 }

--- a/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
@@ -17,7 +17,8 @@ export abstract class ZoomBaseToolView extends ActionToolView {
     const zoom_info = scale_range(frame, this.model.sign*this.model.factor, h_axis, v_axis)
 
     this.plot_view.state.push("zoom_out", {range: zoom_info})
-    this.plot_view.update_range(zoom_info, {scrolling: true})
+    const {maintain_focus} = this.model
+    this.plot_view.update_range(zoom_info, {scrolling: true, maintain_focus})
 
     this.model.document?.interactive_start(this.plot_model)
   }
@@ -29,6 +30,7 @@ export namespace ZoomBaseTool {
   export type Props = ActionTool.Props & {
     factor: p.Property<number>
     dimensions: p.Property<Dimensions>
+    maintain_focus: p.Property<boolean>
   }
 }
 
@@ -43,9 +45,10 @@ export abstract class ZoomBaseTool extends ActionTool {
   }
 
   static init_ZoomBaseTool(): void {
-    this.define<ZoomBaseTool.Props>(({Percent}) => ({
+    this.define<ZoomBaseTool.Props>(({Boolean, Percent}) => ({
       factor:     [ Percent,    0.1    ],
       dimensions: [ Dimensions, "both" ],
+      maintain_focus: [ Boolean, true ],
     }))
   }
 

--- a/bokehjs/src/lib/models/tools/actions/zoom_in_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_in_tool.ts
@@ -23,7 +23,7 @@ export class ZoomInTool extends ZoomBaseTool {
     this.register_alias("yzoom_in", () => new ZoomInTool({dimensions: "height"}))
   }
 
-  get_maintain_focus() : boolean {
+  get_maintain_focus(): boolean {
     // Constant as it makes no difference when zooming in
     return true
   }

--- a/bokehjs/src/lib/models/tools/actions/zoom_in_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_in_tool.ts
@@ -23,6 +23,11 @@ export class ZoomInTool extends ZoomBaseTool {
     this.register_alias("yzoom_in", () => new ZoomInTool({dimensions: "height"}))
   }
 
+  get_maintain_focus() : boolean {
+    // Constant as it makes no difference when zooming in
+    return true
+  }
+
   sign = 1 as 1
   tool_name = "Zoom In"
   icon = tool_icon_zoom_in

--- a/bokehjs/src/lib/models/tools/actions/zoom_in_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_in_tool.ts
@@ -23,11 +23,6 @@ export class ZoomInTool extends ZoomBaseTool {
     this.register_alias("yzoom_in", () => new ZoomInTool({dimensions: "height"}))
   }
 
-  get_maintain_focus(): boolean {
-    // Constant as it makes no difference when zooming in
-    return true
-  }
-
   sign = 1 as 1
   tool_name = "Zoom In"
   icon = tool_icon_zoom_in

--- a/bokehjs/src/lib/models/tools/actions/zoom_out_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_out_tool.ts
@@ -1,14 +1,23 @@
 import {ZoomBaseTool, ZoomBaseToolView} from "./zoom_base_tool"
 import {tool_icon_zoom_out} from "styles/icons.css"
+import * as p from "core/properties"
 
 export class ZoomOutToolView extends ZoomBaseToolView {
   model: ZoomBaseTool
 }
 
+export namespace ZoomOutTool {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = ZoomBaseTool.Props & {
+    maintain_focus: p.Property<boolean>
+  }
+}
+
 export interface ZoomOutTool extends ZoomBaseTool.Attrs {}
 
 export class ZoomOutTool extends ZoomBaseTool {
-  properties: ZoomBaseTool.Props
+  properties: ZoomOutTool.Props
   __view_type__: ZoomBaseToolView
 
   constructor(attrs?: Partial<ZoomBaseTool.Attrs>) {
@@ -17,6 +26,10 @@ export class ZoomOutTool extends ZoomBaseTool {
 
   static init_ZoomOutTool(): void {
     this.prototype.default_view = ZoomOutToolView
+
+    this.define<ZoomOutTool.Props>(({Boolean}) => ({
+      maintain_focus: [ Boolean, true ],
+    }))
 
     this.register_alias("zoom_out", () => new ZoomOutTool({dimensions: "both"}))
     this.register_alias("xzoom_out", () => new ZoomOutTool({dimensions: "width"}))

--- a/bokehjs/src/lib/models/tools/actions/zoom_out_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_out_tool.ts
@@ -36,8 +36,6 @@ export class ZoomOutTool extends ZoomBaseTool {
     this.register_alias("yzoom_out", () => new ZoomOutTool({dimensions: "height"}))
   }
 
-  get _maintain_focus(): boolean { return this.properties.maintain_focus.get_value() }
-
   sign = -1 as -1
   tool_name = "Zoom Out"
   icon = tool_icon_zoom_out

--- a/bokehjs/src/lib/models/tools/actions/zoom_out_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_out_tool.ts
@@ -35,10 +35,8 @@ export class ZoomOutTool extends ZoomBaseTool {
     this.register_alias("xzoom_out", () => new ZoomOutTool({dimensions: "width"}))
     this.register_alias("yzoom_out", () => new ZoomOutTool({dimensions: "height"}))
   }
-  get_maintain_focus(): boolean {
-    return this.properties.maintain_focus.get_value()
-  }
 
+  get _maintain_focus(): boolean { return this.properties.maintain_focus.get_value() }
 
   sign = -1 as -1
   tool_name = "Zoom Out"

--- a/bokehjs/src/lib/models/tools/actions/zoom_out_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_out_tool.ts
@@ -35,7 +35,7 @@ export class ZoomOutTool extends ZoomBaseTool {
     this.register_alias("xzoom_out", () => new ZoomOutTool({dimensions: "width"}))
     this.register_alias("yzoom_out", () => new ZoomOutTool({dimensions: "height"}))
   }
-  get_maintain_focus() : boolean {
+  get_maintain_focus(): boolean {
     return this.properties.maintain_focus.get_value()
   }
 

--- a/bokehjs/src/lib/models/tools/actions/zoom_out_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_out_tool.ts
@@ -35,6 +35,10 @@ export class ZoomOutTool extends ZoomBaseTool {
     this.register_alias("xzoom_out", () => new ZoomOutTool({dimensions: "width"}))
     this.register_alias("yzoom_out", () => new ZoomOutTool({dimensions: "height"}))
   }
+  get_maintain_focus() : boolean {
+    return this.properties.maintain_focus.get_value()
+  }
+
 
   sign = -1 as -1
   tool_name = "Zoom Out"


### PR DESCRIPTION
Initially added in #7683 for the WheelZoomTool, it makes sense to also
provide the option for the ZoomOutTool, as currently trying to zoom out at
the border of a graph leads to no zooming out happening.

- [x] issues: fixes #11120
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
