### PR TITLE
Add RangesUpdate event

### DIFF
--- a/bokeh/events.py
+++ b/bokeh/events.py
@@ -87,6 +87,7 @@ __all__ = (
     'Pinch',
     'PinchEnd',
     'PinchStart',
+    'RangesUpdate',
     'Rotate',
     'RotateEnd',
     'RotateStart',
@@ -259,6 +260,31 @@ class LODEnd(PlotEvent):
 
     '''
     event_name = 'lodend'
+
+class RangesUpdate(PlotEvent):
+    ''' Announce combined range updates in a single event.
+
+    Attributes:
+        x0 (float) : start x-coordinate for the default x-range
+        x1 (float) : end x-coordinate for the default x-range
+        y0 (float) : start x-coordinate for the default y-range
+        y1 (float) : end y-coordinate for the default x-range
+
+    Callbacks may be added to range ``start`` and ``end`` properties to respond
+    to range changes, but this can result in multiple callbacks being invoked
+    for a single logical operation (e.g. a pan or zoom). This event is emitted
+    by supported tools when the entire range update is complete, in order to
+    afford a *single* event that can be responded to.
+
+    '''
+    event_name = 'rangesupdate'
+
+    def __init__(self, model, x0=None, x1=None, y0=None, y1=None):
+        self.x0 = x0
+        self.x1 = x1
+        self.y0 = y0
+        self.y1 = y1
+        super().__init__(model=model)
 
 class SelectionGeometry(PlotEvent):
     ''' Announce the coordinates of a selection event on a plot.

--- a/bokehjs/src/lib/core/bokeh_events.ts
+++ b/bokehjs/src/lib/core/bokeh_events.ts
@@ -55,7 +55,7 @@ export class MenuItemClick extends ModelEvent {
 }
 
 // A UIEvent is an event originating on a canvas this includes.
-// DOM events such as keystrokes as well as hammer events and LOD events.
+// DOM events such as keystrokes as well as hammer, LOD, and range events.
 export abstract class UIEvent extends ModelEvent {}
 
 @event("lodstart")
@@ -63,6 +63,20 @@ export class LODStart extends UIEvent {}
 
 @event("lodend")
 export class LODEnd extends UIEvent {}
+
+@event("rangesupdate")
+export class RangesUpdate extends UIEvent {
+
+  constructor(readonly x0: number, readonly x1: number, readonly y0: number, readonly y1: number) {
+    super()
+  }
+
+  protected _to_json(): JSON {
+    const {x0, x1, y0, y1} = this
+    return {...super._to_json(), x0, x1, y0, y1}
+  }
+
+}
 
 @event("selectiongeometry")
 export class SelectionGeometry extends UIEvent {

--- a/bokehjs/src/lib/document/document.ts
+++ b/bokehjs/src/lib/document/document.ts
@@ -84,6 +84,7 @@ export class Document {
   private _idle_roots: WeakMap<Model, boolean>
   protected _interactive_timestamp: number | null
   protected _interactive_plot: Model | null
+  protected _interactive_finalize: (() => void)| null
 
   constructor(options?: {resolver?: ModelResolver}) {
     documents.push(this)
@@ -134,20 +135,25 @@ export class Document {
     }
   }
 
-  interactive_start(plot: Model): void {
+  interactive_start(plot: Model, finalize: (() => void)|null = null): void {
     if (this._interactive_plot == null) {
       this._interactive_plot = plot
       this._interactive_plot.trigger_event(new LODStart())
     }
+    this._interactive_finalize = finalize
     this._interactive_timestamp = Date.now()
   }
 
   interactive_stop(): void {
     if (this._interactive_plot != null) {
       this._interactive_plot.trigger_event(new LODEnd())
+      if (this._interactive_finalize != null) {
+        this._interactive_finalize()
+      }
     }
     this._interactive_plot = null
     this._interactive_timestamp = null
+    this._interactive_finalize = null
   }
 
   interactive_duration(): number {

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -15,6 +15,7 @@ import {Reset} from "core/bokeh_events"
 import {build_view, build_views, remove_views} from "core/build_views"
 import {Visuals, Renderable} from "core/visuals"
 import {logger} from "core/logging"
+import {RangesUpdate} from "core/bokeh_events"
 import {Side, RenderLevel} from "core/enums"
 import {SerializableState} from "core/view"
 import {throttle} from "core/util/throttle"
@@ -405,6 +406,8 @@ export class PlotView extends LayoutDOMView implements Renderable {
 
   reset_range(): void {
     this.update_range(null)
+    const {x_range, y_range} = this.model
+    this.model.trigger_event(new RangesUpdate(x_range.start, x_range.end, y_range.start, y_range.end))
   }
 
   get_selection(): Map<DataRenderer, Selection> {

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -406,6 +406,10 @@ export class PlotView extends LayoutDOMView implements Renderable {
 
   reset_range(): void {
     this.update_range(null)
+    this.trigger_ranges_update_event()
+  }
+
+  trigger_ranges_update_event(): void {
     const {x_range, y_range} = this.model
     this.model.trigger_event(new RangesUpdate(x_range.start, x_range.end, y_range.start, y_range.end))
   }

--- a/bokehjs/src/lib/models/plots/state_manager.ts
+++ b/bokehjs/src/lib/models/plots/state_manager.ts
@@ -21,7 +21,7 @@ export class StateManager {
   protected history: {type: string, state: StateInfo}[] = []
   protected index: number = -1
 
-  protected _do_state_change(index: number): void {
+  protected _do_state_change(index: number): StateInfo {
     const state = this.history[index] != null ? this.history[index].state : this.initial_state
 
     if (state.range != null)
@@ -29,6 +29,8 @@ export class StateManager {
 
     if (state.selection != null)
       this.parent.update_selection(state.selection)
+
+    return state
   }
 
   push(type: string, new_state: Partial<StateInfo>): void {
@@ -50,20 +52,24 @@ export class StateManager {
     this.changed.emit()
   }
 
-  undo(): void {
+  undo(): StateInfo|null {
     if (this.can_undo) {
       this.index -= 1
-      this._do_state_change(this.index)
+      const state = this._do_state_change(this.index)
       this.changed.emit()
+      return state
     }
+    return null
   }
 
-  redo(): void {
+  redo(): StateInfo|null {
     if (this.can_redo) {
       this.index += 1
-      this._do_state_change(this.index)
+      const state = this._do_state_change(this.index)
       this.changed.emit()
+      return state
     }
+    return null
   }
 
   get can_undo(): boolean {

--- a/bokehjs/src/lib/models/plots/state_manager.ts
+++ b/bokehjs/src/lib/models/plots/state_manager.ts
@@ -52,7 +52,7 @@ export class StateManager {
     this.changed.emit()
   }
 
-  undo(): StateInfo|null {
+  undo(): StateInfo | null {
     if (this.can_undo) {
       this.index -= 1
       const state = this._do_state_change(this.index)
@@ -62,7 +62,7 @@ export class StateManager {
     return null
   }
 
-  redo(): StateInfo|null {
+  redo(): StateInfo | null {
     if (this.can_redo) {
       this.index += 1
       const state = this._do_state_change(this.index)

--- a/bokehjs/src/lib/models/tools/actions/redo_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/redo_tool.ts
@@ -11,7 +11,11 @@ export class RedoToolView extends ActionToolView {
   }
 
   doit(): void {
-    this.plot_view.state.redo()
+    const state = this.plot_view.state.redo()
+
+    if (state?.range != null) {
+      this._trigger_ranges_update()
+    }
   }
 }
 

--- a/bokehjs/src/lib/models/tools/actions/redo_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/redo_tool.ts
@@ -14,7 +14,7 @@ export class RedoToolView extends ActionToolView {
     const state = this.plot_view.state.redo()
 
     if (state?.range != null) {
-      this._trigger_ranges_update()
+      this.plot_view.trigger_ranges_update_event()
     }
   }
 }

--- a/bokehjs/src/lib/models/tools/actions/reset_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/reset_tool.ts
@@ -6,6 +6,7 @@ export class ResetToolView extends ActionToolView {
   model: ResetTool
 
   doit(): void {
+    // reset() issues the RangesUpdate event
     this.plot_view.reset()
   }
 }

--- a/bokehjs/src/lib/models/tools/actions/undo_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/undo_tool.ts
@@ -11,7 +11,11 @@ export class UndoToolView extends ActionToolView {
   }
 
   doit(): void {
-    this.plot_view.state.undo()
+    const state = this.plot_view.state.undo()
+
+    if (state?.range != null) {
+      this._trigger_ranges_update()
+    }
   }
 }
 

--- a/bokehjs/src/lib/models/tools/actions/undo_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/undo_tool.ts
@@ -14,7 +14,7 @@ export class UndoToolView extends ActionToolView {
     const state = this.plot_view.state.undo()
 
     if (state?.range != null) {
-      this._trigger_ranges_update()
+      this.plot_view.trigger_ranges_update_event()
     }
   }
 }

--- a/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
@@ -20,6 +20,8 @@ export abstract class ZoomBaseToolView extends ActionToolView {
     this.plot_view.update_range(zoom_info, {scrolling: true, maintain_focus: this.model.maintain_focus})
 
     this.model.document?.interactive_start(this.plot_model)
+
+    this._trigger_ranges_update()
   }
 }
 

--- a/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
@@ -21,7 +21,7 @@ export abstract class ZoomBaseToolView extends ActionToolView {
 
     this.model.document?.interactive_start(this.plot_model)
 
-    this._trigger_ranges_update()
+    this.plot_view.trigger_ranges_update_event()
   }
 }
 

--- a/bokehjs/src/lib/models/tools/gestures/box_zoom_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/box_zoom_tool.ts
@@ -118,6 +118,8 @@ export class BoxZoomToolView extends GestureToolView {
 
     this.model.overlay.update({left: null, right: null, top: null, bottom: null})
     this._base_point = null
+
+    this._trigger_ranges_update()
   }
 
   _update([sx0, sx1]: [number, number], [sy0, sy1]: [number, number]): void {

--- a/bokehjs/src/lib/models/tools/gestures/box_zoom_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/box_zoom_tool.ts
@@ -119,7 +119,7 @@ export class BoxZoomToolView extends GestureToolView {
     this.model.overlay.update({left: null, right: null, top: null, bottom: null})
     this._base_point = null
 
-    this._trigger_ranges_update()
+    this.plot_view.trigger_ranges_update_event()
   }
 
   _update([sx0, sx1]: [number, number], [sy0, sy1]: [number, number]): void {

--- a/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
@@ -59,6 +59,8 @@ export class PanToolView extends GestureToolView {
 
     if (this.pan_info != null)
       this.plot_view.state.push("pan", {range: this.pan_info})
+
+    this._trigger_ranges_update()
   }
 
   _update(dx: number, dy: number): void {

--- a/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
@@ -60,7 +60,7 @@ export class PanToolView extends GestureToolView {
     if (this.pan_info != null)
       this.plot_view.state.push("pan", {range: this.pan_info})
 
-    this._trigger_ranges_update()
+    this.plot_view.trigger_ranges_update_event()
   }
 
   _update(dx: number, dy: number): void {

--- a/bokehjs/src/lib/models/tools/gestures/range_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/range_tool.ts
@@ -2,7 +2,7 @@ import {PanEvent} from "core/ui_events"
 import {BoxAnnotation, EDGE_TOLERANCE} from "../../annotations/box_annotation"
 import {Range} from "../../ranges/range"
 import {Range1d} from "../../ranges/range1d"
-import {Scale} from '../../scales/scale'
+import {Scale} from "../../scales/scale"
 import {logger} from "core/logging"
 import * as p from "core/properties"
 import {GestureTool, GestureToolView} from "./gesture_tool"
@@ -203,6 +203,7 @@ export class RangeToolView extends GestureToolView {
 
   _pan_end(_ev: PanEvent): void {
     this.side = Side.None
+    this._trigger_ranges_update()
   }
 }
 

--- a/bokehjs/src/lib/models/tools/gestures/range_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/range_tool.ts
@@ -203,7 +203,7 @@ export class RangeToolView extends GestureToolView {
 
   _pan_end(_ev: PanEvent): void {
     this.side = Side.None
-    this._trigger_ranges_update()
+    this.plot_view.trigger_ranges_update_event()
   }
 }
 

--- a/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
@@ -49,7 +49,7 @@ export class WheelZoomToolView extends GestureToolView {
     const {maintain_focus} = this.model
     this.plot_view.update_range(zoom_info, {scrolling: true, maintain_focus})
 
-    this.model.document?.interactive_start(this.plot_model)
+    this.model.document?.interactive_start(this.plot_model, () => this._trigger_ranges_update())
   }
 }
 

--- a/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
@@ -49,7 +49,7 @@ export class WheelZoomToolView extends GestureToolView {
     const {maintain_focus} = this.model
     this.plot_view.update_range(zoom_info, {scrolling: true, maintain_focus})
 
-    this.model.document?.interactive_start(this.plot_model, () => this._trigger_ranges_update())
+    this.model.document?.interactive_start(this.plot_model, () =>  this.plot_view.trigger_ranges_update_event())
   }
 }
 

--- a/bokehjs/src/lib/models/tools/tool.ts
+++ b/bokehjs/src/lib/models/tools/tool.ts
@@ -8,6 +8,7 @@ import {CartesianFrame} from "../canvas/cartesian_frame"
 import {Plot, PlotView} from "../plots/plot"
 import {Annotation} from "../annotations/annotation"
 import {EventType, PanEvent, PinchEvent, RotateEvent, ScrollEvent, TapEvent, MoveEvent, KeyEvent} from "core/ui_events"
+import {RangesUpdate} from "core/bokeh_events"
 
 import type {PanTool} from "./gestures/pan_tool"
 import type {WheelPanTool} from "./gestures/wheel_pan_tool"
@@ -89,6 +90,12 @@ export abstract class ToolView extends View {
 
   // deactivate is triggered by toolbar ui actions
   deactivate(): void {}
+
+  // this is just here to avoid duplicating it on many various tools
+  _trigger_ranges_update(): void {
+    const {x_range, y_range} = this.plot_model
+    this.plot_model.trigger_event(new RangesUpdate(x_range.start, x_range.end, y_range.start, y_range.end))
+  }
 
   _pan_start?(e: PanEvent): void
   _pan?(e: PanEvent): void

--- a/bokehjs/src/lib/models/tools/tool.ts
+++ b/bokehjs/src/lib/models/tools/tool.ts
@@ -8,7 +8,6 @@ import {CartesianFrame} from "../canvas/cartesian_frame"
 import {Plot, PlotView} from "../plots/plot"
 import {Annotation} from "../annotations/annotation"
 import {EventType, PanEvent, PinchEvent, RotateEvent, ScrollEvent, TapEvent, MoveEvent, KeyEvent} from "core/ui_events"
-import {RangesUpdate} from "core/bokeh_events"
 
 import type {PanTool} from "./gestures/pan_tool"
 import type {WheelPanTool} from "./gestures/wheel_pan_tool"
@@ -90,12 +89,6 @@ export abstract class ToolView extends View {
 
   // deactivate is triggered by toolbar ui actions
   deactivate(): void {}
-
-  // this is just here to avoid duplicating it on many various tools
-  _trigger_ranges_update(): void {
-    const {x_range, y_range} = this.plot_model
-    this.plot_model.trigger_event(new RangesUpdate(x_range.start, x_range.end, y_range.start, y_range.end))
-  }
 
   _pan_start?(e: PanEvent): void
   _pan?(e: PanEvent): void

--- a/bokehjs/test/unit/core/ui_events.ts
+++ b/bokehjs/test/unit/core/ui_events.ts
@@ -438,7 +438,7 @@ describe("ui_event_bus module", () => {
       ui_event_bus._pan_start({...e, type: "panstart"})
       ui_event_bus._pan_end(e)
 
-      expect(spy_plot.callCount).to.be.equal(2)
+      expect(spy_plot.callCount).to.be.equal(3) // Also RangesUpdate event
       expect(spy_uievent.callCount).to.be.equal(2)
     })
 

--- a/examples/howto/events_app.py
+++ b/examples/howto/events_app.py
@@ -57,7 +57,7 @@ colors = [
     "#%02x%02x%02x" % (int(r), int(g), 150) for r, g in zip(50+2*x, 30+2*y)
 ]
 
-p = figure(tools="pan,wheel_zoom,zoom_in,zoom_out,reset,tap,lasso_select,box_select")
+p = figure(tools="pan,wheel_zoom,zoom_in,zoom_out,reset,tap,lasso_select,box_select,box_zoom,undo,redo")
 
 p.scatter(x, y, radius=radii,
           fill_color=colors, fill_alpha=0.6,
@@ -94,7 +94,7 @@ p.js_on_event(events.Press,     display_event(div, attributes=point_attributes))
 p.js_on_event(events.MouseWheel, display_event(div,attributes=wheel_attributes))
 
 # Mouse move, enter and leave
-p.js_on_event(events.MouseMove,  display_event(div, attributes=point_attributes))
+# p.js_on_event(events.MouseMove,  display_event(div, attributes=point_attributes))
 p.js_on_event(events.MouseEnter, display_event(div, attributes=point_attributes))
 p.js_on_event(events.MouseLeave, display_event(div, attributes=point_attributes))
 
@@ -111,9 +111,11 @@ p.js_on_event(events.PinchEnd,   display_event(div, attributes=point_attributes)
 # Selection events
 p.js_on_event(events.SelectionGeometry, display_event(div, attributes=['geometry', 'final']))
 
+# Ranges Update events
+p.js_on_event(events.RangesUpdate, display_event(div, attributes=['x0','x1','y0','y1']))
+
 # Reset events
 p.js_on_event(events.Reset, display_event(div))
-
 
 ## Register Python event callbacks
 
@@ -134,7 +136,7 @@ p.on_event(events.Press,     print_event(attributes=point_attributes))
 p.on_event(events.MouseWheel, print_event(attributes=wheel_attributes))
 
 # Mouse move, enter and leave
-p.on_event(events.MouseMove,  print_event(attributes=point_attributes))
+# p.on_event(events.MouseMove,  print_event(attributes=point_attributes))
 p.on_event(events.MouseEnter, print_event(attributes=point_attributes))
 p.on_event(events.MouseLeave, print_event(attributes=point_attributes))
 
@@ -147,6 +149,9 @@ p.on_event(events.PanEnd,   print_event(attributes=point_attributes))
 p.on_event(events.Pinch,      print_event(attributes=pinch_attributes))
 p.on_event(events.PinchStart, print_event(attributes=point_attributes))
 p.on_event(events.PinchEnd,   print_event(attributes=point_attributes))
+
+# Ranges Update events
+p.on_event(events.RangesUpdate, print_event(attributes=['x0','x1','y0','y1']))
 
 # Selection events
 p.on_event(events.SelectionGeometry, print_event(attributes=['geometry', 'final']))

--- a/examples/howto/js_events.py
+++ b/examples/howto/js_events.py
@@ -44,7 +44,7 @@ colors = [
     "#%02x%02x%02x" % (int(r), int(g), 150) for r, g in zip(50+2*x, 30+2*y)
 ]
 
-p = figure(tools="pan,wheel_zoom,zoom_in,zoom_out,reset,tap,lasso_select,box_select")
+p = figure(tools="pan,wheel_zoom,zoom_in,zoom_out,reset,tap,lasso_select,box_select,box_zoom,undo,redo")
 
 p.scatter(x, y, radius=radii,
           fill_color=colors, fill_alpha=0.6,
@@ -77,7 +77,7 @@ p.js_on_event(events.PressUp,   display_event(div, attributes=point_attributes))
 p.js_on_event(events.MouseWheel, display_event(div,attributes=point_attributes+['delta']))
 
 # Mouse move, enter and leave
-p.js_on_event(events.MouseMove,  display_event(div, attributes=point_attributes))
+# p.js_on_event(events.MouseMove,  display_event(div, attributes=point_attributes))
 p.js_on_event(events.MouseEnter, display_event(div, attributes=point_attributes))
 p.js_on_event(events.MouseLeave, display_event(div, attributes=point_attributes))
 
@@ -92,6 +92,9 @@ pinch_attributes = point_attributes + ['scale']
 p.js_on_event(events.Pinch,      display_event(div, attributes=pinch_attributes))
 p.js_on_event(events.PinchStart, display_event(div, attributes=point_attributes))
 p.js_on_event(events.PinchEnd,   display_event(div, attributes=point_attributes))
+
+# Ranges Update events
+p.js_on_event(events.RangesUpdate, display_event(div, attributes=['x0','x1','y0','y1']))
 
 # Selection events
 p.js_on_event(events.SelectionGeometry, display_event(div, attributes=['geometry', 'final']))

--- a/tests/integration/tools/test_reset_tool.py
+++ b/tests/integration/tools/test_reset_tool.py
@@ -17,6 +17,7 @@ import pytest ; pytest
 
 # Bokeh imports
 from bokeh._testing.util.selenium import RECORD
+from bokeh.events import RangesUpdate
 from bokeh.models import (
     Circle,
     ColumnDataSource,
@@ -132,5 +133,38 @@ class Test_ResetTool:
         assert results['indices'] == []
         assert results['line_indices'] == []
         assert results['multiline_indices'] == {}
+
+        assert page.has_no_console_errors()
+
+    def test_ranges_udpate(self, single_plot_page) -> None:
+        source = ColumnDataSource(dict(x=[1, 2], y=[1, 1]))
+        plot = Plot(plot_height=400, plot_width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
+        plot.add_glyph(source, Rect(x='x', y='y', width=0.9, height=0.9))
+        plot.add_tools(ResetTool(), ZoomInTool())
+        code = RECORD("event_name", "cb_obj.event_name", final=False) + \
+               RECORD("x0", "cb_obj.x0", final=False) + \
+               RECORD("x1", "cb_obj.x1", final=False) + \
+               RECORD("y0", "cb_obj.y0", final=False) + \
+               RECORD("y1", "cb_obj.y1")
+        plot.js_on_event(RangesUpdate, CustomJS(code=code))
+        plot.add_tools(CustomAction(callback=CustomJS(code="")))
+        plot.toolbar_sticky = False
+
+        page = single_plot_page(plot)
+
+        button = page.get_toolbar_button('zoom-in')
+        button.click()
+
+        button = page.get_toolbar_button('reset')
+        button.click()
+
+        page.click_custom_action()
+
+        results = page.results
+        assert results['event_name'] == "rangesupdate"
+        assert results['x0'] == 0
+        assert results['x1'] == 1
+        assert results['y0'] == 0
+        assert results['y1'] == 1
 
         assert page.has_no_console_errors()

--- a/tests/integration/tools/test_wheel_zoom_tool.py
+++ b/tests/integration/tools/test_wheel_zoom_tool.py
@@ -17,6 +17,7 @@ import pytest ; pytest
 
 # Bokeh imports
 from bokeh._testing.util.selenium import RECORD, SCROLL
+from bokeh.events import RangesUpdate
 from bokeh.models import (
     ColumnDataSource,
     CustomAction,
@@ -227,5 +228,37 @@ class Test_WheelZoomTool:
         assert results['xrend'] == 1
         assert results['yrstart'] < 0
         assert results['yrend'] > 1
+
+        assert page.has_no_console_errors()
+
+    def test_ranges_update(self, single_plot_page) -> None:
+        source = ColumnDataSource(dict(x=[1, 2], y=[1, 1]))
+        plot = Plot(plot_height=400, plot_width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
+        plot.add_glyph(source, Rect(x='x', y='y', width=0.9, height=0.9))
+        plot.add_tools(WheelZoomTool())
+        code = RECORD("event_name", "cb_obj.event_name", final=False) + \
+               RECORD("x0", "cb_obj.x0", final=False) + \
+               RECORD("x1", "cb_obj.x1", final=False) + \
+               RECORD("y0", "cb_obj.y0", final=False) + \
+               RECORD("y1", "cb_obj.y1")
+        plot.js_on_event(RangesUpdate, CustomJS(code=code))
+        plot.add_tools(CustomAction(callback=CustomJS(code="")))
+        plot.toolbar_sticky = False
+
+        page = single_plot_page(plot)
+
+        button = page.get_toolbar_button('wheel-zoom')
+        button.click()
+
+        page.driver.execute_script(SCROLL(-200))
+
+        page.click_custom_action()
+
+        results = page.results
+        assert results['event_name'] == "rangesupdate"
+        assert results['x0'] > 0
+        assert results['x1'] < 1
+        assert results['y0'] > 0
+        assert results['y1'] < 1
 
         assert page.has_no_console_errors()

--- a/tests/integration/tools/test_zoom_in_tool.py
+++ b/tests/integration/tools/test_zoom_in_tool.py
@@ -17,6 +17,7 @@ import pytest ; pytest
 
 # Bokeh imports
 from bokeh._testing.util.selenium import RECORD
+from bokeh.events import RangesUpdate
 from bokeh.models import (
     ColumnDataSource,
     CustomAction,
@@ -87,5 +88,35 @@ class Test_ZoomInTool:
         assert second['xrend'] < first['xrend']
         assert second['yrstart'] > first['yrstart']
         assert second['yrend'] < first['yrend']
+
+        assert page.has_no_console_errors()
+
+    def test_ranges_udpate(self, single_plot_page) -> None:
+        source = ColumnDataSource(dict(x=[1, 2], y=[1, 1]))
+        plot = Plot(plot_height=400, plot_width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
+        plot.add_glyph(source, Rect(x='x', y='y', width=0.9, height=0.9))
+        plot.add_tools(ZoomInTool())
+        code = RECORD("event_name", "cb_obj.event_name", final=False) + \
+               RECORD("x0", "cb_obj.x0", final=False) + \
+               RECORD("x1", "cb_obj.x1", final=False) + \
+               RECORD("y0", "cb_obj.y0", final=False) + \
+               RECORD("y1", "cb_obj.y1")
+        plot.js_on_event(RangesUpdate, CustomJS(code=code))
+        plot.add_tools(CustomAction(callback=CustomJS(code="")))
+        plot.toolbar_sticky = False
+
+        page = single_plot_page(plot)
+
+        button = page.get_toolbar_button('zoom-in')
+        button.click()
+
+        page.click_custom_action()
+
+        results = page.results
+        assert results['event_name'] == "rangesupdate"
+        assert results['x0'] > 0
+        assert results['x1'] < 1
+        assert results['y0'] > 0
+        assert results['y1'] < 1
 
         assert page.has_no_console_errors()

--- a/tests/integration/tools/test_zoom_out_tool.py
+++ b/tests/integration/tools/test_zoom_out_tool.py
@@ -17,6 +17,7 @@ import pytest ; pytest
 
 # Bokeh imports
 from bokeh._testing.util.selenium import RECORD
+from bokeh.events import RangesUpdate
 from bokeh.models import (
     ColumnDataSource,
     CustomAction,
@@ -87,5 +88,35 @@ class Test_ZoomOutTool:
         assert second['xrend'] > first['xrend']
         assert second['yrstart'] < first['yrstart']
         assert second['yrend'] > first['yrend']
+
+        assert page.has_no_console_errors()
+
+    def test_ranges_udpate(self, single_plot_page) -> None:
+        source = ColumnDataSource(dict(x=[1, 2], y=[1, 1]))
+        plot = Plot(plot_height=400, plot_width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
+        plot.add_glyph(source, Rect(x='x', y='y', width=0.9, height=0.9))
+        plot.add_tools(ZoomOutTool())
+        code = RECORD("event_name", "cb_obj.event_name", final=False) + \
+               RECORD("x0", "cb_obj.x0", final=False) + \
+               RECORD("x1", "cb_obj.x1", final=False) + \
+               RECORD("y0", "cb_obj.y0", final=False) + \
+               RECORD("y1", "cb_obj.y1")
+        plot.js_on_event(RangesUpdate, CustomJS(code=code))
+        plot.add_tools(CustomAction(callback=CustomJS(code="")))
+        plot.toolbar_sticky = False
+
+        page = single_plot_page(plot)
+
+        button = page.get_toolbar_button('zoom-out')
+        button.click()
+
+        page.click_custom_action()
+
+        results = page.results
+        assert results['event_name'] == "rangesupdate"
+        assert results['x0'] < 0
+        assert results['x1'] > 1
+        assert results['y0'] < 0
+        assert results['y1'] > 1
 
         assert page.has_no_console_errors()


### PR DESCRIPTION
- [x] issues: fixes #11095
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

Some notes: 

* I made it so that this event only fires when a wheel zoom "finishes". It seems to me that if you want all the intermediate range values you could register for the `MouseWheel` event and change range. Otherwise, if `RangesUpdate` fires on "intermediate" range updates, then there would be no way to get the "final" range value (which is what I think will people actually want)

* It's getting near (past?)  time that the collection of "interactive_foo" properties on Document be factored out into something more sensible. 

* I had to make undo / redo methods return the state that was popped, so that this event can fire only when that state actually includes a range change

* Thoughts on testing @mattpap ? I can definitely add/expand the selenium tests for this, but if there is some other means I am open to suggestion. I guess the current sinon spy tests in `unit/core/ui_events.ts` could be improved.
  
  Tangentially, the Python events unit tests are pretty bad and rely on (require?) event initializers accepting default None arguments. This really should be improved as well. 

* I commented out the mouse events in the examples, they make the output mostly impossible to read. I suppose it might be nice to offer a checkbox to toggle them, or even a checkbox to toggle all the events. 

cc @bokeh/dev 