### PR TITLE
Remove all cyclic dependencies from bokehjs

### DIFF
--- a/bokehjs/make/tasks/scripts.ts
+++ b/bokehjs/make/tasks/scripts.ts
@@ -124,7 +124,7 @@ task("scripts:bundle", [passthrough("scripts:compile")], async () => {
     cache: argv.cache !== false ? join(paths.build_dir.js, "bokeh.json") : undefined,
     target: "ES2017",
     exports: ["tslib"],
-    detect_cycles: argv.detectCycles === true,
+    detect_cycles: argv.detectCycles as boolean | undefined,
   })
 
   if (!argv.rebuild) linker.load_cache()

--- a/bokehjs/src/compiler/linker.ts
+++ b/bokehjs/src/compiler/linker.ts
@@ -296,7 +296,7 @@ export class Linker {
     this.plugin = opts.plugin ?? false
 
     this.shims = new Set(opts.shims ?? [])
-    this.detect_cycles = opts.detect_cycles ?? false
+    this.detect_cycles = opts.detect_cycles ?? true
   }
 
   is_external(dep: string): boolean {

--- a/bokehjs/src/lib/core/selection_manager.ts
+++ b/bokehjs/src/lib/core/selection_manager.ts
@@ -1,4 +1,3 @@
-import {HasProps} from "./has_props"
 import {Geometry} from "./geometry"
 import {SelectionMode} from "core/enums"
 import {Selection} from "models/selections/selection"
@@ -6,7 +5,6 @@ import type {ColumnarDataSource} from "models/sources/columnar_data_source"
 import {DataRenderer, DataRendererView} from "models/renderers/data_renderer"
 import type {GlyphRendererView} from "models/renderers/glyph_renderer"
 import type {GraphRendererView} from "models/renderers/graph_renderer"
-import * as p from "./properties"
 
 // XXX: this is needed to cut circular dependency between this, models/renderers/* and models/sources/*
 function is_GlyphRendererView(renderer_view: DataRendererView): renderer_view is GlyphRendererView {
@@ -16,28 +14,8 @@ function is_GraphRendererView(renderer_view: DataRendererView): renderer_view is
   return renderer_view.model.type == "GraphRenderer"
 }
 
-export namespace SelectionManager {
-  export type Props = HasProps.Props & {
-    source: p.Property<ColumnarDataSource>
-  }
-
-  export type Attrs = p.AttrsOf<Props>
-}
-
-export interface SelectionManager extends SelectionManager.Attrs {}
-
-export class SelectionManager extends HasProps {
-  properties: SelectionManager.Props
-
-  constructor(attrs?: Partial<SelectionManager.Attrs>) {
-    super(attrs)
-  }
-
-  static init_SelectionManager(): void {
-    this.internal<SelectionManager.Props>(({AnyRef}) => ({
-      source: [ AnyRef() ],
-    }))
-  }
+export class SelectionManager {
+  constructor(readonly source: ColumnarDataSource) {}
 
   inspectors: Map<DataRenderer, Selection> = new Map()
 

--- a/bokehjs/src/lib/core/types.ts
+++ b/bokehjs/src/lib/core/types.ts
@@ -16,8 +16,13 @@ export const ColorArray = Uint32Array
 export type RGBAArray = Uint8ClampedArray
 export const RGBAArray = Uint8ClampedArray
 
-import {TypedArray} from "./util/ndarray"
-export {TypedArray}
+export type DataType = "uint8" | "int8" | "uint16" | "int16" | "uint32" | "int32" | "float32" | "float64"
+
+export type TypedArray =
+  Uint8Array   | Int8Array    |
+  Uint16Array  | Int16Array   |
+  Uint32Array  | Int32Array   |
+  Float32Array | Float64Array
 
 export type FloatArray = Float32Array | Float64Array
 export type FloatArrayConstructor = Float32ArrayConstructor | Float64ArrayConstructor

--- a/bokehjs/src/lib/core/util/buffer.ts
+++ b/bokehjs/src/lib/core/util/buffer.ts
@@ -1,4 +1,4 @@
-import {TypedArray} from "../types"
+import {DataType} from "../types"
 
 export function buffer_to_base64(buffer: ArrayBuffer): string {
   const bytes = new Uint8Array(buffer)
@@ -16,12 +16,10 @@ export function base64_to_buffer(base64: string): ArrayBuffer {
   return bytes.buffer
 }
 
-type Array16 = Int16Array | Uint16Array
-type Array32 = Int32Array | Uint32Array | Float32Array
-type Array64 = Float64Array
+// NOTE: swap{16,32,64} assume byteOffset == 0
 
-function swap16(a: Array16): void {
-  const x = new Uint8Array(a.buffer, a.byteOffset, a.length * 2)
+function swap16(buffer: ArrayBuffer): void {
+  const x = new Uint8Array(buffer)
   for (let i = 0, end = x.length; i < end; i += 2) {
     const t = x[i]
     x[i] = x[i + 1]
@@ -29,8 +27,8 @@ function swap16(a: Array16): void {
   }
 }
 
-function swap32(a: Array32): void {
-  const x = new Uint8Array(a.buffer, a.byteOffset, a.length * 4)
+function swap32(buffer: ArrayBuffer): void {
+  const x = new Uint8Array(buffer)
   for (let i = 0, end = x.length; i < end; i += 4) {
     let t = x[i]
     x[i] = x[i + 3]
@@ -41,8 +39,8 @@ function swap32(a: Array32): void {
   }
 }
 
-function swap64(a: Array64): void {
-  const x = new Uint8Array(a.buffer, a.byteOffset, a.length * 8)
+function swap64(buffer: ArrayBuffer): void {
+  const x = new Uint8Array(buffer)
   for (let i = 0, end = x.length; i < end; i += 8) {
     let t = x[i]
     x[i] = x[i + 7]
@@ -59,16 +57,19 @@ function swap64(a: Array64): void {
   }
 }
 
-export function swap(array: TypedArray): void {
-  switch (array.BYTES_PER_ELEMENT) {
-    case 2:
-      swap16(array as Array16)
+export function swap(buffer: ArrayBuffer, dtype: DataType): void {
+  switch (dtype) {
+    case "uint16":
+    case "int16":
+      swap16(buffer)
       break
-    case 4:
-      swap32(array as Array32)
+    case "uint32":
+    case "int32":
+    case "float32":
+      swap32(buffer)
       break
-    case 8:
-      swap64(array as Array64)
+    case "float64":
+      swap64(buffer)
       break
   }
 }

--- a/bokehjs/src/lib/core/util/ndarray.ts
+++ b/bokehjs/src/lib/core/util/ndarray.ts
@@ -1,10 +1,9 @@
+import {DataType, TypedArray} from "../types"
 import {isObject, isArray} from "./types"
 import {unreachable} from "./assert"
 import {equals, Equatable, Comparator} from "./eq"
 import {serialize, Serializable, Serializer} from "../serializer"
 import {encode_NDArray} from "./serialization"
-
-export type DataType = "uint8" | "int8" | "uint16" | "int16" | "uint32" | "int32" | "float32" | "float64"
 
 const __ndarray__ = Symbol("__ndarray__")
 
@@ -192,12 +191,6 @@ export class Float64NDArray extends Float64Array implements NDArrayType {
     return encode_NDArray(this)
   }
 }
-
-export type TypedArray =
-  Uint8Array   | Int8Array    |
-  Uint16Array  | Int16Array   |
-  Uint32Array  | Int32Array   |
-  Float32Array | Float64Array
 
 export type NDArray =
   Uint8NDArray   | Int8NDArray    |

--- a/bokehjs/src/lib/document/document.ts
+++ b/bokehjs/src/lib/document/document.ts
@@ -8,6 +8,7 @@ import {ID, Attrs, Data, PlainObject} from "core/types"
 import {Signal0} from "core/signaling"
 import {Struct, is_ref} from "core/util/refs"
 import {Buffers, is_NDArray_ref, decode_NDArray} from "core/util/serialization"
+import {ndarray} from "core/util/ndarray"
 import {difference, intersection, copy, includes} from "core/util/array"
 import {values, entries} from "core/util/object"
 import * as sets from "core/util/set"
@@ -376,7 +377,8 @@ export class Document {
         else
           throw new Error(`reference ${JSON.stringify(v)} isn't known (not in Document?)`)
       } else if (is_NDArray_ref(v)) {
-        return decode_NDArray(v, buffers)
+        const {buffer, dtype, shape} = decode_NDArray(v, buffers)
+        return ndarray(buffer, {dtype, shape})
       } else if (isArray(v))
         return resolve_array(v)
       else if (isPlainObject(v))

--- a/bokehjs/src/lib/models/glyphs/webgl/markers.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/markers.ts
@@ -1,7 +1,8 @@
 import {BaseGLGlyph, Transform} from "./base"
 import {ReglWrapper} from "./regl_wrap"
-import {ScatterView} from "../scatter"
-import {CircleView} from "../circle"
+import type {GlyphView} from "../glyph"
+import type {ScatterView} from "../scatter"
+import type {CircleView} from "../circle"
 import {MarkerType} from "core/enums"
 import {uint32} from "core/types"
 import {Uniform} from "core/uniforms"
@@ -16,6 +17,10 @@ const missing_point = -10000
 
 type MarkerLikeView = ScatterView | CircleView
 
+// XXX: this is needed to cut circular dependency between this and models/glyphs/circle
+function is_CircleView(glyph_view: GlyphView): glyph_view is CircleView {
+  return glyph_view.model.type == "Circle"
+}
 
 function color_to_uint8_array(color_prop: Uniform<uint32>, alpha_prop: Uniform<number>): Uint8Array {
   const ncolors: number = Math.max(color_prop.length, alpha_prop.length)
@@ -115,7 +120,7 @@ export class MarkerGL extends BaseGLGlyph {
     // Correct solution depends on keeping the webgl properties constant and
     // only changing the indices, which in turn depends on the correct webgl
     // instanced rendering.
-    if (mainGlGlyph.data_changed || this.glyph instanceof CircleView) {
+    if (mainGlGlyph.data_changed || is_CircleView(this.glyph)) {
       mainGlGlyph._set_data()
       mainGlGlyph.data_changed = false
     }
@@ -177,7 +182,7 @@ export class MarkerGL extends BaseGLGlyph {
       }
     }
 
-    if (this.glyph instanceof CircleView && this.glyph.radius != null) {
+    if (is_CircleView(this.glyph) && this.glyph.radius != null) {
       this._sizes = new Float32Array(nmarkers)
       for (let i = 0; i < nmarkers; i++)
         this._sizes[i] = this.glyph.sradius[i]*2

--- a/bokehjs/src/lib/models/sources/columnar_data_source.ts
+++ b/bokehjs/src/lib/models/sources/columnar_data_source.ts
@@ -22,7 +22,6 @@ export namespace ColumnarDataSource {
   export type Props = DataSource.Props & {
     data: p.Property<{[key: string]: Arrayable}> // XXX: this is hack!!!
     selection_policy: p.Property<SelectionPolicy>
-    selection_manager: p.Property<SelectionManager>
     inspected: p.Property<Selection>
   }
 }
@@ -51,6 +50,8 @@ export abstract class ColumnarDataSource extends DataSource {
   streaming: Signal0<this>
   patching: Signal<number[], this>
 
+  readonly selection_manager = new SelectionManager(this)
+
   constructor(attrs?: Partial<ColumnarDataSource.Attrs>) {
     super(attrs)
   }
@@ -61,7 +62,6 @@ export abstract class ColumnarDataSource extends DataSource {
     }))
 
     this.internal<ColumnarDataSource.Props>(({AnyRef}) => ({
-      selection_manager: [ AnyRef(), (self) => new SelectionManager({source: self as ColumnarDataSource}) ],
       inspected:         [ AnyRef(), () => new Selection() ],
     }))
   }

--- a/bokehjs/test/unit/core/util/buffer.ts
+++ b/bokehjs/test/unit/core/util/buffer.ts
@@ -18,7 +18,7 @@ describe("serialization module", () => {
       swapped[1] = 0
       swapped[2] = 3
       swapped[3] = 2
-      swap(b)
+      swap(b.buffer, "uint16")
       expect(a).to.be.equal(swapped)
     })
 
@@ -38,7 +38,7 @@ describe("serialization module", () => {
       swapped[5] = 6
       swapped[6] = 5
       swapped[7] = 4
-      swap(b)
+      swap(b.buffer, "float32")
       expect(a).to.be.equal(swapped)
     })
 
@@ -66,7 +66,7 @@ describe("serialization module", () => {
       swapped[13] = 10
       swapped[14] = 9
       swapped[15] = 8
-      swap(b)
+      swap(b.buffer, "float64")
       expect(a).to.be.equal(swapped)
     })
   })

--- a/bokehjs/test/unit/core/util/serialization.ts
+++ b/bokehjs/test/unit/core/util/serialization.ts
@@ -20,7 +20,10 @@ describe("serialization module", () => {
     })
     expect(buffers0).to.be.equal(new Map([["0", nd0.buffer]]))
 
-    const deref0_0 = decode_NDArray(ref0_0, buffers0)
+    const deref0_0 = (() => {
+      const {buffer, dtype, shape} = decode_NDArray(ref0_0, buffers0)
+      return ndarray(buffer, {dtype, shape})
+    })()
     expect(deref0_0).to.be.equal(nd0)
     expect(() => decode_NDArray(ref0_0, new Map())).to.throw()
 
@@ -32,7 +35,10 @@ describe("serialization module", () => {
       shape: [2, 3],
     })
 
-    const deref0_1 = decode_NDArray(ref0_1, new Map())
+    const deref0_1 = (() => {
+      const {buffer, dtype, shape} = decode_NDArray(ref0_1, new Map())
+      return ndarray(buffer, {dtype, shape})
+    })()
     expect(deref0_1).to.be.equal(nd0)
   })
 })


### PR DESCRIPTION
This is a followup on PR #10707. This PR finishes the job and enables cycle detection by default in bokehjs' build.