### PR TITLE
Added flag to TapTool such that OpenURL uses source.inspected.indices

### DIFF
--- a/bokehjs/src/lib/models/callbacks/open_url.ts
+++ b/bokehjs/src/lib/models/callbacks/open_url.ts
@@ -44,28 +44,14 @@ export class OpenURL extends Callback {
       this.navigate(url)
     }
 
-    if (source.data.tap_type == "select")
-    {
-      const {selected} = source
+    const selected = source.data.behavior == "select" ? source.selected : source.inspected
 
-      for (const i of selected.indices)
+    for (const i of selected.indices)
         open_url(i)
   
       for (const i of selected.line_indices)
         open_url(i)
   
       // TODO: multiline_indices: {[key: string]: number[]}
-    } else {
-      const {inspected} = source
-
-      for (const i of inspected.indices)
-        open_url(i)
-  
-      for (const i of inspected.line_indices)
-        open_url(i)
-  
-      // TODO: multiline_indices: {[key: string]: number[]}
-    }
-    
   }
 }

--- a/bokehjs/src/lib/models/callbacks/open_url.ts
+++ b/bokehjs/src/lib/models/callbacks/open_url.ts
@@ -3,7 +3,7 @@ import {ColumnarDataSource} from "../sources/columnar_data_source"
 import {replace_placeholders} from "core/util/templating"
 import {isString} from "core/util/types"
 import * as p from "core/properties"
-import { TapBehavior } from "core/enums"
+import {TapBehavior} from "core/enums"
 
 export namespace OpenURL {
   export type Attrs = p.AttrsOf<Props>
@@ -48,10 +48,10 @@ export class OpenURL extends Callback {
     const selected = behavior == "select" ? source.selected : source.inspected
 
     for (const i of selected.indices)
-        open_url(i)
+      open_url(i)
 
     for (const i of selected.line_indices)
-        open_url(i)
+      open_url(i)
 
     // TODO: multiline_indices: {[key: string]: number[]}
   }

--- a/bokehjs/src/lib/models/callbacks/open_url.ts
+++ b/bokehjs/src/lib/models/callbacks/open_url.ts
@@ -3,6 +3,7 @@ import {ColumnarDataSource} from "../sources/columnar_data_source"
 import {replace_placeholders} from "core/util/templating"
 import {isString} from "core/util/types"
 import * as p from "core/properties"
+import { TapBehavior } from "core/enums"
 
 export namespace OpenURL {
   export type Attrs = p.AttrsOf<Props>
@@ -36,7 +37,7 @@ export class OpenURL extends Callback {
       window.open(url)
   }
 
-  execute(_cb_obj: unknown, {source}: {source: ColumnarDataSource}): void {
+  execute(_cb_obj: unknown, {source, behavior}: {source: ColumnarDataSource, behavior: TapBehavior}): void {
     const open_url = (i: number) => {
       const url = replace_placeholders(this.url, source, i, undefined, undefined, encodeURI)
       if (!isString(url))
@@ -44,14 +45,14 @@ export class OpenURL extends Callback {
       this.navigate(url)
     }
 
-    const selected = source.data.behavior == "select" ? source.selected : source.inspected
+    const selected = behavior == "select" ? source.selected : source.inspected
 
     for (const i of selected.indices)
         open_url(i)
-  
-      for (const i of selected.line_indices)
+
+    for (const i of selected.line_indices)
         open_url(i)
-  
-      // TODO: multiline_indices: {[key: string]: number[]}
+
+    // TODO: multiline_indices: {[key: string]: number[]}
   }
 }

--- a/bokehjs/src/lib/models/callbacks/open_url.ts
+++ b/bokehjs/src/lib/models/callbacks/open_url.ts
@@ -44,14 +44,28 @@ export class OpenURL extends Callback {
       this.navigate(url)
     }
 
-    const {selected} = source
+    if (source.data.tap_type == "select")
+    {
+      const {selected} = source
 
-    for (const i of selected.indices)
-      open_url(i)
+      for (const i of selected.indices)
+        open_url(i)
+  
+      for (const i of selected.line_indices)
+        open_url(i)
+  
+      // TODO: multiline_indices: {[key: string]: number[]}
+    } else {
+      const {inspected} = source
 
-    for (const i of selected.line_indices)
-      open_url(i)
-
-    // TODO: multiline_indices: {[key: string]: number[]}
+      for (const i of inspected.indices)
+        open_url(i)
+  
+      for (const i of inspected.line_indices)
+        open_url(i)
+  
+      // TODO: multiline_indices: {[key: string]: number[]}
+    }
+    
   }
 }

--- a/bokehjs/src/lib/models/tools/gestures/tap_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/tap_tool.ts
@@ -43,7 +43,7 @@ export class TapToolView extends SelectToolView {
         if (did_hit && callback != null) {
           const x = r_views[0].coordinates.x_scale.invert(geometry.sx)
           const y = r_views[0].coordinates.y_scale.invert(geometry.sy)
-          const data = {geometries: {...geometry, x, y}, source: sm.source, tap_type: this.model.behavior}
+          const data = {geometries: {...geometry, x, y}, source: sm.source, behavior: this.model.behavior}
           callback.execute(this.model, data)
         }
       }
@@ -62,7 +62,7 @@ export class TapToolView extends SelectToolView {
         if (did_hit && callback != null) {
           const x = rv.coordinates.x_scale.invert(geometry.sx)
           const y = rv.coordinates.y_scale.invert(geometry.sy)
-          const data = {geometries: {...geometry, x, y}, source: sm.source, tap_type: this.model.behavior}
+          const data = {geometries: {...geometry, x, y}, source: sm.source, behavior: this.model.behavior}
           callback.execute(this.model, data)
         }
       }
@@ -79,7 +79,7 @@ export namespace TapTool {
     callback: p.Property<CallbackLike1<TapTool, {
       geometries: PointGeometry & {x: number, y: number}
       source: ColumnarDataSource
-      tap_type: TapBehavior
+      behavior: TapBehavior
     }> | null>
   }
 }

--- a/bokehjs/src/lib/models/tools/gestures/tap_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/tap_tool.ts
@@ -43,7 +43,7 @@ export class TapToolView extends SelectToolView {
         if (did_hit && callback != null) {
           const x = r_views[0].coordinates.x_scale.invert(geometry.sx)
           const y = r_views[0].coordinates.y_scale.invert(geometry.sy)
-          const data = {geometries: {...geometry, x, y}, source: sm.source}
+          const data = {geometries: {...geometry, x, y}, source: sm.source, tap_type: this.model.behavior}
           callback.execute(this.model, data)
         }
       }
@@ -62,7 +62,7 @@ export class TapToolView extends SelectToolView {
         if (did_hit && callback != null) {
           const x = rv.coordinates.x_scale.invert(geometry.sx)
           const y = rv.coordinates.y_scale.invert(geometry.sy)
-          const data = {geometries: {...geometry, x, y}, source: sm.source}
+          const data = {geometries: {...geometry, x, y}, source: sm.source, tap_type: this.model.behavior}
           callback.execute(this.model, data)
         }
       }
@@ -79,6 +79,7 @@ export namespace TapTool {
     callback: p.Property<CallbackLike1<TapTool, {
       geometries: PointGeometry & {x: number, y: number}
       source: ColumnarDataSource
+      tap_type: TapBehavior
     }> | null>
   }
 }

--- a/bokehjs/test/unit/models/tools/gestures/tap_tool.ts
+++ b/bokehjs/test/unit/models/tools/gestures/tap_tool.ts
@@ -9,6 +9,7 @@ import {GlyphRenderer} from "@bokehjs/models/renderers"
 import {ColumnDataSource} from "@bokehjs/models/sources"
 import {Quad} from "@bokehjs/models/glyphs"
 import {TapEvent} from "@bokehjs/core/ui_events"
+import { TapBehavior } from "@bokehjs/core/enums"
 
 describe("TapTool", () => {
   async function test_case(tool: Tool): Promise<PlotView> {
@@ -51,6 +52,7 @@ describe("TapTool", () => {
 
       tap(plot_view, 50, 50)
       expect(called).to.be.true
+      expect(tool.behavior).to.be.equal("select")
     })
 
     it("and not trigger on 'tap' event when didn't hit a glyph", async () => {
@@ -61,6 +63,7 @@ describe("TapTool", () => {
 
       tap(plot_view, 150, 50)
       expect(called).to.be.false
+      expect(tool.behavior).to.be.equal("select")
     })
 
     it("and not trigger on 'doubletap' event", async () => {
@@ -71,6 +74,7 @@ describe("TapTool", () => {
 
       doubletap(plot_view, 50, 50)
       expect(called).to.be.false
+      expect(tool.behavior).to.be.equal("select")
     })
   })
 
@@ -83,6 +87,7 @@ describe("TapTool", () => {
 
       tap(plot_view, 50, 50)
       expect(called).to.be.false
+      expect(tool.behavior).to.be.equal("select")
     })
 
     it("and trigger on 'doubletap' event", async () => {
@@ -93,6 +98,7 @@ describe("TapTool", () => {
 
       doubletap(plot_view, 50, 50)
       expect(called).to.be.true
+      expect(tool.behavior).to.be.equal("select")
     })
 
     it("and not trigger on 'doubletap' event when didn't hit a glyph", async () => {
@@ -103,6 +109,7 @@ describe("TapTool", () => {
 
       doubletap(plot_view, 150, 50)
       expect(called).to.be.false
+      expect(tool.behavior).to.be.equal("select")
     })
   })
 
@@ -115,6 +122,7 @@ describe("TapTool", () => {
 
       tap(plot_view, 50, 50)
       expect(called).to.be.true
+      expect(tool.behavior).to.be.equal("inspect")
     })
 
     it("and not trigger on 'tap' event when didn't hit a glyph", async () => {
@@ -125,6 +133,7 @@ describe("TapTool", () => {
 
       tap(plot_view, 150, 50)
       expect(called).to.be.false
+      expect(tool.behavior).to.be.equal("inspect")
     })
 
     it("and not trigger on 'doubletap' event", async () => {
@@ -135,10 +144,11 @@ describe("TapTool", () => {
 
       doubletap(plot_view, 50, 50)
       expect(called).to.be.false
+      expect(tool.behavior).to.be.equal("inspect")
     })
   })
 
-  describe("should support 'doubletap' gesture with behavior 'select'", () => {
+  describe("should support 'doubletap' gesture with behavior 'inspect'", () => {
     it("and not trigger on 'tap' event", async () => {
       let called = false
       const callback = {execute() { called = true }}
@@ -147,6 +157,7 @@ describe("TapTool", () => {
 
       tap(plot_view, 50, 50)
       expect(called).to.be.false
+      expect(tool.behavior).to.be.equal("inspect")
     })
 
     it("and trigger on 'doubletap' event", async () => {
@@ -157,6 +168,7 @@ describe("TapTool", () => {
 
       doubletap(plot_view, 50, 50)
       expect(called).to.be.true
+      expect(tool.behavior).to.be.equal("inspect")
     })
 
     it("and not trigger on 'doubletap' event when didn't hit a glyph", async () => {
@@ -167,6 +179,7 @@ describe("TapTool", () => {
 
       doubletap(plot_view, 150, 50)
       expect(called).to.be.false
+      expect(tool.behavior).to.be.equal("inspect")
     })
   })
 })

--- a/bokehjs/test/unit/models/tools/gestures/tap_tool.ts
+++ b/bokehjs/test/unit/models/tools/gestures/tap_tool.ts
@@ -9,7 +9,6 @@ import {GlyphRenderer} from "@bokehjs/models/renderers"
 import {ColumnDataSource} from "@bokehjs/models/sources"
 import {Quad} from "@bokehjs/models/glyphs"
 import {TapEvent} from "@bokehjs/core/ui_events"
-import { TapBehavior } from "@bokehjs/core/enums"
 
 describe("TapTool", () => {
   async function test_case(tool: Tool): Promise<PlotView> {

--- a/bokehjs/test/unit/models/tools/gestures/tap_tool.ts
+++ b/bokehjs/test/unit/models/tools/gestures/tap_tool.ts
@@ -42,7 +42,7 @@ describe("TapTool", () => {
     ui_event_bus._trigger(ui_event_bus.doubletap, event, new Event("mousemove"))
   }
 
-  describe("should support 'tap' gesture", () => {
+  describe("should support 'tap' gesture with behavior 'select'", () => {
     it("and trigger on 'tap' event", async () => {
       let called = false
       const callback = {execute() { called = true }}
@@ -74,7 +74,7 @@ describe("TapTool", () => {
     })
   })
 
-  describe("should support 'doubletap' gesture", () => {
+  describe("should support 'doubletap' gesture with behavior 'select'", () => {
     it("and not trigger on 'tap' event", async () => {
       let called = false
       const callback = {execute() { called = true }}
@@ -99,6 +99,70 @@ describe("TapTool", () => {
       let called = false
       const callback = {execute() { called = true }}
       const tool = new TapTool({behavior: "select", gesture: "doubletap", callback})
+      const plot_view = await test_case(tool)
+
+      doubletap(plot_view, 150, 50)
+      expect(called).to.be.false
+    })
+  })
+
+  describe("should support 'tap' gesture with behavior 'inspect'", () => {
+    it("and trigger on 'tap' event", async () => {
+      let called = false
+      const callback = {execute() { called = true }}
+      const tool = new TapTool({behavior: "inspect", gesture: "tap", callback})
+      const plot_view = await test_case(tool)
+
+      tap(plot_view, 50, 50)
+      expect(called).to.be.true
+    })
+
+    it("and not trigger on 'tap' event when didn't hit a glyph", async () => {
+      let called = false
+      const callback = {execute() { called = true }}
+      const tool = new TapTool({behavior: "inspect", gesture: "tap", callback})
+      const plot_view = await test_case(tool)
+
+      tap(plot_view, 150, 50)
+      expect(called).to.be.false
+    })
+
+    it("and not trigger on 'doubletap' event", async () => {
+      let called = false
+      const callback = {execute() { called = true }}
+      const tool = new TapTool({behavior: "inspect", gesture: "tap", callback})
+      const plot_view = await test_case(tool)
+
+      doubletap(plot_view, 50, 50)
+      expect(called).to.be.false
+    })
+  })
+
+  describe("should support 'doubletap' gesture with behavior 'select'", () => {
+    it("and not trigger on 'tap' event", async () => {
+      let called = false
+      const callback = {execute() { called = true }}
+      const tool = new TapTool({behavior: "inspect", gesture: "doubletap", callback})
+      const plot_view = await test_case(tool)
+
+      tap(plot_view, 50, 50)
+      expect(called).to.be.false
+    })
+
+    it("and trigger on 'doubletap' event", async () => {
+      let called = false
+      const callback = {execute() { called = true }}
+      const tool = new TapTool({behavior: "inspect", gesture: "doubletap", callback})
+      const plot_view = await test_case(tool)
+
+      doubletap(plot_view, 50, 50)
+      expect(called).to.be.true
+    })
+
+    it("and not trigger on 'doubletap' event when didn't hit a glyph", async () => {
+      let called = false
+      const callback = {execute() { called = true }}
+      const tool = new TapTool({behavior: "inspect", gesture: "doubletap", callback})
       const plot_view = await test_case(tool)
 
       doubletap(plot_view, 150, 50)

--- a/bokehjs/test/unit/models/tools/gestures/tap_tool.ts
+++ b/bokehjs/test/unit/models/tools/gestures/tap_tool.ts
@@ -45,140 +45,152 @@ describe("TapTool", () => {
   describe("should support 'tap' gesture with behavior 'select'", () => {
     it("and trigger on 'tap' event", async () => {
       let called = false
-      const callback = {execute() { called = true }}
+      let behavior = "select"
+      const callback = {execute() { called = true, behavior = "select" }}
       const tool = new TapTool({behavior: "select", gesture: "tap", callback})
       const plot_view = await test_case(tool)
 
       tap(plot_view, 50, 50)
       expect(called).to.be.true
-      expect(tool.behavior).to.be.equal("select")
+      expect(behavior).to.be.equal("select")
     })
 
     it("and not trigger on 'tap' event when didn't hit a glyph", async () => {
       let called = false
-      const callback = {execute() { called = true }}
+      let behavior = "select"
+      const callback = {execute() { called = true, behavior = "select" }}
       const tool = new TapTool({behavior: "select", gesture: "tap", callback})
       const plot_view = await test_case(tool)
 
       tap(plot_view, 150, 50)
       expect(called).to.be.false
-      expect(tool.behavior).to.be.equal("select")
+      expect(behavior).to.be.equal("select")
     })
 
     it("and not trigger on 'doubletap' event", async () => {
       let called = false
-      const callback = {execute() { called = true }}
+      let behavior = "select"
+      const callback = {execute() { called = true, behavior = "select" }}
       const tool = new TapTool({behavior: "select", gesture: "tap", callback})
       const plot_view = await test_case(tool)
 
       doubletap(plot_view, 50, 50)
       expect(called).to.be.false
-      expect(tool.behavior).to.be.equal("select")
+      expect(behavior).to.be.equal("select")
     })
   })
 
   describe("should support 'doubletap' gesture with behavior 'select'", () => {
     it("and not trigger on 'tap' event", async () => {
       let called = false
-      const callback = {execute() { called = true }}
+      let behavior = "select"
+      const callback = {execute() { called = true, behavior = "select" }}
       const tool = new TapTool({behavior: "select", gesture: "doubletap", callback})
       const plot_view = await test_case(tool)
 
       tap(plot_view, 50, 50)
       expect(called).to.be.false
-      expect(tool.behavior).to.be.equal("select")
+      expect(behavior).to.be.equal("select")
     })
 
     it("and trigger on 'doubletap' event", async () => {
       let called = false
-      const callback = {execute() { called = true }}
+      let behavior = "select"
+      const callback = {execute() { called = true, behavior = "select" }}
       const tool = new TapTool({behavior: "select", gesture: "doubletap", callback})
       const plot_view = await test_case(tool)
 
       doubletap(plot_view, 50, 50)
       expect(called).to.be.true
-      expect(tool.behavior).to.be.equal("select")
+      expect(behavior).to.be.equal("select")
     })
 
     it("and not trigger on 'doubletap' event when didn't hit a glyph", async () => {
       let called = false
-      const callback = {execute() { called = true }}
+      let behavior = "select"
+      const callback = {execute() { called = true, behavior = "select" }}
       const tool = new TapTool({behavior: "select", gesture: "doubletap", callback})
       const plot_view = await test_case(tool)
 
       doubletap(plot_view, 150, 50)
       expect(called).to.be.false
-      expect(tool.behavior).to.be.equal("select")
+      expect(behavior).to.be.equal("select")
     })
   })
 
   describe("should support 'tap' gesture with behavior 'inspect'", () => {
     it("and trigger on 'tap' event", async () => {
       let called = false
-      const callback = {execute() { called = true }}
+      let behavior = "inspect"
+      const callback = {execute() { called = true, behavior = "inspect" }}
       const tool = new TapTool({behavior: "inspect", gesture: "tap", callback})
       const plot_view = await test_case(tool)
 
       tap(plot_view, 50, 50)
       expect(called).to.be.true
-      expect(tool.behavior).to.be.equal("inspect")
+      expect(behavior).to.be.equal("inspect")
     })
 
     it("and not trigger on 'tap' event when didn't hit a glyph", async () => {
       let called = false
-      const callback = {execute() { called = true }}
+      let behavior = "inspect"
+      const callback = {execute() { called = true, behavior = "inspect" }}
       const tool = new TapTool({behavior: "inspect", gesture: "tap", callback})
       const plot_view = await test_case(tool)
 
       tap(plot_view, 150, 50)
       expect(called).to.be.false
-      expect(tool.behavior).to.be.equal("inspect")
+      expect(behavior).to.be.equal("inspect")
     })
 
     it("and not trigger on 'doubletap' event", async () => {
       let called = false
-      const callback = {execute() { called = true }}
+      let behavior = "inspect"
+      const callback = {execute() { called = true, behavior = "inspect" }}
       const tool = new TapTool({behavior: "inspect", gesture: "tap", callback})
       const plot_view = await test_case(tool)
 
       doubletap(plot_view, 50, 50)
       expect(called).to.be.false
-      expect(tool.behavior).to.be.equal("inspect")
+      expect(behavior).to.be.equal("inspect")
     })
   })
 
   describe("should support 'doubletap' gesture with behavior 'inspect'", () => {
     it("and not trigger on 'tap' event", async () => {
       let called = false
-      const callback = {execute() { called = true }}
+      let behavior = "inspect"
+      const callback = {execute() { called = true, behavior = "inspect" }}
       const tool = new TapTool({behavior: "inspect", gesture: "doubletap", callback})
       const plot_view = await test_case(tool)
 
       tap(plot_view, 50, 50)
       expect(called).to.be.false
-      expect(tool.behavior).to.be.equal("inspect")
+      expect(behavior).to.be.equal("inspect")
     })
 
     it("and trigger on 'doubletap' event", async () => {
       let called = false
-      const callback = {execute() { called = true }}
+      let behavior = "inspect"
+      const callback = {execute() { called = true, behavior = "inspect" }}
       const tool = new TapTool({behavior: "inspect", gesture: "doubletap", callback})
       const plot_view = await test_case(tool)
 
       doubletap(plot_view, 50, 50)
       expect(called).to.be.true
-      expect(tool.behavior).to.be.equal("inspect")
+      expect(behavior).to.be.equal("inspect")
     })
 
     it("and not trigger on 'doubletap' event when didn't hit a glyph", async () => {
       let called = false
-      const callback = {execute() { called = true }}
+      let behavior = "inspect"
+      const callback = {execute() { called = true, behavior = "inspect" }}
       const tool = new TapTool({behavior: "inspect", gesture: "doubletap", callback})
       const plot_view = await test_case(tool)
 
       doubletap(plot_view, 150, 50)
       expect(called).to.be.false
-      expect(tool.behavior).to.be.equal("inspect")
+      expect(behavior).to.be.equal("inspect")
     })
   })
 })


### PR DESCRIPTION
This is my proposed solution for #11075. Added `tap_type` to `data` in `TapTool._select`, and then made `OpenURL.execute` check for the tap behavior such that it looks at `source.selected.indices` or `source.inspected.indices` appropriately. I had trouble with setting up debugging, and this is my first time working with TypeScript, so I apologize for any errors. The part I'm unsure about is line 44 in open_url.ts. I believe this is the correct way to access the flag I placed in `data`.