### PR TITLE
More HasProps cleanup

### DIFF
--- a/bokeh/core/has_props.py
+++ b/bokeh/core/has_props.py
@@ -367,7 +367,7 @@ class HasProps(metaclass=MetaHasProps):
     def to_serializable(self, serializer):
         pass # TODO: new serializer, hopefully in near future
 
-    def set_from_json(self, name, json, models=None, setter=None):
+    def set_from_json(self, name, json, *, models=None, setter=None):
         ''' Set a property value on this object from JSON.
 
         Args:
@@ -398,7 +398,7 @@ class HasProps(metaclass=MetaHasProps):
         if name in self.properties():
             log.trace("Patching attribute %r of %r with %r", name, self, json)
             descriptor = self.lookup(name)
-            descriptor.set_from_json(self, json, models, setter)
+            descriptor.set_from_json(self, json, models=models, setter=setter)
         else:
             log.warning("JSON had attr %r on obj %r, which is a client-only or invalid attribute that shouldn't have been sent", name, self)
 
@@ -429,7 +429,7 @@ class HasProps(metaclass=MetaHasProps):
         for k,v in kwargs.items():
             setattr(self, k, v)
 
-    def update_from_json(self, json_attributes, models=None, setter=None):
+    def update_from_json(self, json_attributes, *, models=None, setter=None):
         ''' Updates the object's properties from a JSON attributes dictionary.
 
         Args:
@@ -456,7 +456,7 @@ class HasProps(metaclass=MetaHasProps):
 
         '''
         for k, v in json_attributes.items():
-            self.set_from_json(k, v, models, setter)
+            self.set_from_json(k, v, models=models, setter=setter)
 
     @classmethod
     def lookup(cls, name: str, *, raises: bool = True) -> Optional[PropertyDescriptor]:

--- a/bokeh/core/has_props.py
+++ b/bokeh/core/has_props.py
@@ -473,12 +473,9 @@ class HasProps(metaclass=MetaHasProps):
         '''
         resolved_name = cls._property_aliases().get(name, name)
         attr = getattr(cls, resolved_name, None)
-        if attr is not None:
+        if attr is not None or (attr is None and not raises):
             return attr
-        elif not raises:
-            return None
-        else:
-            raise AttributeError(f"{cls.__name__}.{name} property descriptor does not exist")
+        raise AttributeError(f"{cls.__name__}.{name} property descriptor does not exist")
 
     @classmethod
     def properties_with_refs(cls):

--- a/bokeh/core/has_props.py
+++ b/bokeh/core/has_props.py
@@ -28,7 +28,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import difflib
 from functools import lru_cache
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional, Set, Union
 from warnings import warn
 
 # Bokeh imports
@@ -411,7 +411,7 @@ class HasProps(metaclass=MetaHasProps):
 
     @classmethod
     @lru_cache(None)
-    def properties(cls, *, _with_props: bool = False) -> Union[List[str], Dict[str, PropertyDescriptorFactory]]:
+    def properties(cls, *, _with_props: bool = False) -> Union[Set[str], Dict[str, PropertyDescriptorFactory]]:
         ''' Collect the names of properties on this class.
 
         .. warning::
@@ -428,7 +428,7 @@ class HasProps(metaclass=MetaHasProps):
             props.update(getattr(c, "__properties__", {}))
 
         if not _with_props:
-            return list(props)
+            return set(props)
 
         return props
 

--- a/bokeh/core/has_props.py
+++ b/bokeh/core/has_props.py
@@ -180,9 +180,11 @@ class HasProps(metaclass=MetaHasProps):
             return super().__setattr__(name, value)
 
         properties = self.properties()
-        descriptor = getattr(self.__class__, name, None)
+        if name in properties:
+            return super().__setattr__(name, value)
 
-        if name in properties or isinstance(descriptor, property): # Python property
+        descriptor = getattr(self.__class__, name, None)
+        if isinstance(descriptor, property): # Python property
             return super().__setattr__(name, value)
 
         self._raise_attribute_error_with_matches(name, properties)
@@ -206,9 +208,11 @@ class HasProps(metaclass=MetaHasProps):
             return super().__getattr__(name)
 
         properties = self.properties()
-        descriptor = getattr(self.__class__, name, None)
+        if name in properties:
+            return super().__getattr__(name)
 
-        if name in properties or isinstance(descriptor, property): # Python property
+        descriptor = getattr(self.__class__, name, None)
+        if isinstance(descriptor, property): # Python property
             return super().__getattr__(name)
 
         self._raise_attribute_error_with_matches(name, properties)

--- a/bokeh/core/has_props.py
+++ b/bokeh/core/has_props.py
@@ -106,13 +106,13 @@ def _property_aliases(class_dict):
 # explicit property caching in HasProps is replaced with memoized queries
 def _is_container_prop(x):
     from .property.bases import ContainerProperty
-    from .property.descriptors import BasicPropertyDescriptor
-    return isinstance(x, BasicPropertyDescriptor) and isinstance(x.property, ContainerProperty)
+    from .property.descriptors import PropertyDescriptor
+    return isinstance(x, PropertyDescriptor) and isinstance(x.property, ContainerProperty)
 
 def _is_dataspec_prop(x):
     from .property.dataspec import DataSpec
-    from .property.descriptors import BasicPropertyDescriptor
-    return isinstance(x, BasicPropertyDescriptor) and isinstance(x.property, DataSpec)
+    from .property.descriptors import PropertyDescriptor
+    return isinstance(x, PropertyDescriptor) and isinstance(x.property, DataSpec)
 
 class MetaHasProps(type):
     ''' Specialize the construction of |HasProps| classes.
@@ -125,7 +125,7 @@ class MetaHasProps(type):
 
     '''
 
-    def __new__(meta_cls, class_name, bases, class_dict):
+    def __new__(cls, class_name, bases, class_dict):
         '''
 
         '''
@@ -164,7 +164,7 @@ class MetaHasProps(type):
         class_dict["__overridden_defaults__"] = overridden_defaults
         class_dict["__dataspecs__"] = dataspecs
 
-        return super().__new__(meta_cls, class_name, bases, class_dict)
+        return super().__new__(cls, class_name, bases, class_dict)
 
     def __init__(cls, class_name, bases, __):
         # Check for improperly redeclaring a Property attribute.

--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -142,6 +142,8 @@ Special Properties
 ------------------
 
 .. autoclass:: Include
+.. autoclass:: Nullable
+.. autoclass:: NonNullable
 .. autoclass:: Override
 
 Validation-only Properties

--- a/bokeh/core/property/_sphinx.py
+++ b/bokeh/core/property/_sphinx.py
@@ -4,7 +4,7 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-''' Functions useful for string manipulations or encoding.
+''' Functions useful for generating rich sphinx links for properties
 
 '''
 
@@ -19,9 +19,6 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
-# Standard library imports
-from inspect import isclass
-
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
@@ -29,30 +26,34 @@ from inspect import isclass
 __all__ = (
     'model_link',
     'property_link',
+    'register_type_link',
+    'type_link',
 )
+
+_type_links = {}
 
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
 
 def model_link(fullname):
-    """ Generate a sphinx :class: link to given named model.
-
-    """
     # (double) escaped space at the end is to appease Sphinx
     # https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#gotchas
     return f":class:`~{fullname}`\\ "
 
-def property_link(cls_or_obj):
-    """ Generate a sphinx :class: link to a property.
-
-    """
+def property_link(obj):
     # (double) escaped space at the end is to appease Sphinx
     # https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#gotchas
-    if isclass(cls_or_obj):
-        return f":class:`~bokeh.core.properties.{cls_or_obj.__name__}`\\ "
-    else:
-        return f":class:`~bokeh.core.properties.{cls_or_obj.__class__.__name__}`\\ "
+    return f":class:`~bokeh.core.properties.{obj.__class__.__name__}`\\ "
+
+def register_type_link(cls):
+    def decorator(func):
+        _type_links[cls] = func
+        return func
+    return decorator
+
+def type_link(obj):
+    return _type_links.get(obj.__class__, property_link)(obj)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/core/property/alias.py
+++ b/bokeh/core/property/alias.py
@@ -25,6 +25,10 @@ log = logging.getLogger(__name__)
 # Standard library imports
 from typing import Optional
 
+# Bokeh imports
+from .bases import Property
+from .descriptors import AliasPropertyDescriptor
+
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
@@ -37,7 +41,7 @@ __all__ = (
 # General API
 #-----------------------------------------------------------------------------
 
-class Alias:
+class Alias(Property):
     """
     Alias another property of a model.
 
@@ -61,9 +65,28 @@ class Alias:
     name: str
     help: Optional[str]
 
-    def __init__(self, name: str, *, help: Optional[str] = None):
-        self.name = name
+    serialized = False
+    _default = None
+
+    def __init__(self, aliased_name: str, *, help: Optional[str] = None):
+        self.aliased_name = aliased_name
         self.help = help
+
+    def make_descriptors(self, base_name):
+        """ Return a list of ``AliasPropertyDescriptor`` instances to
+        install on a class, in order to delegate attribute access to this
+        property.
+
+        Args:
+            aliased_name (str) : the name of the property this alias is for
+
+        Returns:
+            list[AliasPropertyDescriptor]
+
+        The descriptors returned are collected by the ``MetaHasProps``
+        metaclass and added to ``HasProps`` subclasses during class creation.
+        """
+        return [ AliasPropertyDescriptor(base_name, self.aliased_name, self) ]
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/core/property/alias.py
+++ b/bokeh/core/property/alias.py
@@ -41,7 +41,7 @@ __all__ = (
 # General API
 #-----------------------------------------------------------------------------
 
-class Alias(Property):
+class Alias(Property): # lgtm [py/missing-call-to-init]
     """
     Alias another property of a model.
 
@@ -65,6 +65,8 @@ class Alias(Property):
     name: str
     help: Optional[str]
 
+    # Alias is somewhat a quasi-property
+    readonly = False
     serialized = False
     _default = None
 

--- a/bokeh/core/property/auto.py
+++ b/bokeh/core/property/auto.py
@@ -66,10 +66,6 @@ class Auto(Enum):
     def __str__(self):
         return self.__class__.__name__
 
-    def _sphinx_type(self):
-        from ...util._sphinx import property_link
-        return property_link(self)
-
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------

--- a/bokeh/core/property/bases.py
+++ b/bokeh/core/property/bases.py
@@ -110,30 +110,13 @@ class Property(PropertyDescriptorFactory):
     def __str__(self):
         return self.__class__.__name__
 
-    @classmethod
-    def _sphinx_prop_link(cls):
-        """ Generate a sphinx :class: link to this property.
-
-        """
-        # (double) escaped space at the end is to appease Sphinx
-        # https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#gotchas
-        return f":class:`~bokeh.core.properties.{cls.__name__}`\\ "
-
-    @staticmethod
-    def _sphinx_model_link(name):
-        """ Generate a sphinx :class: link to given named model.
-
-        """
-        # (double) escaped space at the end is to appease Sphinx
-        # https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#gotchas
-        return f":class:`~{name}`\\ "
-
     def _sphinx_type(self):
         """ Generate a Sphinx-style reference to this type for documentation
         automation purposes.
 
         """
-        return self._sphinx_prop_link()
+        from ...util._sphinx import property_link
+        return property_link(self)
 
     def make_descriptors(self, base_name):
         """ Return a list of ``PropertyDescriptor`` instances to install
@@ -462,7 +445,8 @@ class SingleParameterizedProperty(ParameterizedProperty):
         return f"{self.__class__.__name__}({self.type_param})"
 
     def _sphinx_type(self):
-        return f"{self._sphinx_prop_link()}({self.type_param._sphinx_type()})"
+        from ...util._sphinx import property_link
+        return f"{property_link(self)}({self.type_param._sphinx_type()})"
 
     def validate(self, value: Any, detail: bool = True) -> None:
         super().validate(value, detail=detail)
@@ -520,7 +504,8 @@ class PrimitiveProperty(Property):
         raise DeserializationError(msg)
 
     def _sphinx_type(self):
-        return self._sphinx_prop_link()
+        from ...util._sphinx import property_link
+        return property_link(self)
 
 class ContainerProperty(ParameterizedProperty):
     """ A base class for Container-like type properties.

--- a/bokeh/core/property/bases.py
+++ b/bokeh/core/property/bases.py
@@ -252,7 +252,7 @@ class Property(PropertyDescriptorFactory):
         except ValueError:
             return False
 
-    def from_json(self, json, models=None):
+    def from_json(self, json, *, models=None):
         """ Convert from JSON-compatible values into a value for this property.
 
         JSON-compatible values are: list, dict, number, string, bool, None
@@ -468,7 +468,7 @@ class SingleParameterizedProperty(ParameterizedProperty):
         super().validate(value, detail=detail)
         self.type_param.validate(value, detail=detail)
 
-    def from_json(self, json, models=None):
+    def from_json(self, json, *, models=None):
         return self.type_param.from_json(json, models=models)
 
     def transform(self, value):
@@ -512,7 +512,7 @@ class PrimitiveProperty(Property):
         msg = f"expected a value of type {expected_type}, got {value} of type {type(value).__name__}"
         raise ValueError(msg)
 
-    def from_json(self, json, models=None):
+    def from_json(self, json, *, models=None):
         if isinstance(json, self._underlying_type):
             return json
         expected_type = nice_join([ cls.__name__ for cls in self._underlying_type ])

--- a/bokeh/core/property/bases.py
+++ b/bokeh/core/property/bases.py
@@ -37,7 +37,7 @@ from ...util.dependencies import import_optional
 from ...util.string import nice_join
 from ..has_props import HasProps
 from .descriptor_factory import PropertyDescriptorFactory
-from .descriptors import BasicPropertyDescriptor
+from .descriptors import PropertyDescriptor
 from .singletons import Intrinsic, Undefined
 
 #-----------------------------------------------------------------------------
@@ -136,19 +136,19 @@ class Property(PropertyDescriptorFactory):
         return self._sphinx_prop_link()
 
     def make_descriptors(self, base_name):
-        """ Return a list of ``BasicPropertyDescriptor`` instances to install
+        """ Return a list of ``PropertyDescriptor`` instances to install
         on a class, in order to delegate attribute access to this property.
 
         Args:
             name (str) : the name of the property these descriptors are for
 
         Returns:
-            list[BasicPropertyDescriptor]
+            list[PropertyDescriptor]
 
         The descriptors returned are collected by the ``MetaHasProps``
         metaclass and added to ``HasProps`` subclasses during class creation.
         """
-        return [ BasicPropertyDescriptor(base_name, self) ]
+        return [ PropertyDescriptor(base_name, self) ]
 
     def _may_have_unstable_default(self):
         """ False if we have a default that is immutable, and will be the

--- a/bokeh/core/property/bases.py
+++ b/bokeh/core/property/bases.py
@@ -36,6 +36,7 @@ import numpy as np
 from ...util.dependencies import import_optional
 from ...util.string import nice_join
 from ..has_props import HasProps
+from ._sphinx import property_link, register_type_link, type_link
 from .descriptor_factory import PropertyDescriptorFactory
 from .descriptors import PropertyDescriptor
 from .singletons import Intrinsic, Undefined
@@ -109,14 +110,6 @@ class Property(PropertyDescriptorFactory):
 
     def __str__(self):
         return self.__class__.__name__
-
-    def _sphinx_type(self):
-        """ Generate a Sphinx-style reference to this type for documentation
-        automation purposes.
-
-        """
-        from ...util._sphinx import property_link
-        return property_link(self)
 
     def make_descriptors(self, base_name):
         """ Return a list of ``PropertyDescriptor`` instances to install
@@ -444,10 +437,6 @@ class SingleParameterizedProperty(ParameterizedProperty):
     def __str__(self):
         return f"{self.__class__.__name__}({self.type_param})"
 
-    def _sphinx_type(self):
-        from ...util._sphinx import property_link
-        return f"{property_link(self)}({self.type_param._sphinx_type()})"
-
     def validate(self, value: Any, detail: bool = True) -> None:
         super().validate(value, detail=detail)
         self.type_param.validate(value, detail=detail)
@@ -503,10 +492,6 @@ class PrimitiveProperty(Property):
         msg = f"{self} expected {expected_type}, got {json} of type {type(json).__name__}"
         raise DeserializationError(msg)
 
-    def _sphinx_type(self):
-        from ...util._sphinx import property_link
-        return property_link(self)
-
 class ContainerProperty(ParameterizedProperty):
     """ A base class for Container-like type properties.
 
@@ -532,3 +517,7 @@ def validation_on():
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
+
+@register_type_link(SingleParameterizedProperty)
+def _sphinx_type(obj):
+    return f"{property_link(obj)}({type_link(obj.type_param)})"

--- a/bokeh/core/property/color.py
+++ b/bokeh/core/property/color.py
@@ -142,7 +142,8 @@ class Color(Either):
         return value
 
     def _sphinx_type(self):
-        return self._sphinx_prop_link()
+        from ...util._sphinx import property_link
+        return property_link(self)
 
 
 class ColorHex(Color):

--- a/bokeh/core/property/color.py
+++ b/bokeh/core/property/color.py
@@ -141,10 +141,6 @@ class Color(Either):
             value = colors.RGB(*value).to_css()
         return value
 
-    def _sphinx_type(self):
-        from ...util._sphinx import property_link
-        return property_link(self)
-
 
 class ColorHex(Color):
     """ ref Color

--- a/bokeh/core/property/container.py
+++ b/bokeh/core/property/container.py
@@ -103,9 +103,8 @@ class Seq(ContainerProperty):
         return value
 
     def _sphinx_type(self):
-        prop_link = self._sphinx_prop_link()
-        item_type = self.item_type._sphinx_type()
-        return f"{prop_link}({item_type})"
+        from ...util._sphinx import property_link
+        return f"{property_link(self)}({self.item_type._sphinx_type()})"
 
 class List(Seq):
     """ Accept Python list values.
@@ -199,10 +198,10 @@ class Dict(ContainerProperty):
             return value
 
     def _sphinx_type(self):
-        prop_link = self._sphinx_prop_link()
+        from ...util._sphinx import property_link
         key_type = self.keys_type._sphinx_type()
         value_type = self.values_type._sphinx_type()
-        return f"{prop_link}({key_type}, {value_type})"
+        return f"{property_link(self)}({key_type}, {value_type})"
 
 class ColumnData(Dict):
     """ Accept a Python dictionary suitable as the ``data`` attribute of a
@@ -313,9 +312,9 @@ class Tuple(ContainerProperty):
         return tuple(typ.serialize_value(x) for (typ, x) in zip(self.type_params, value))
 
     def _sphinx_type(self):
-        prop_link = self._sphinx_prop_link()
+        from ...util._sphinx import property_link
         item_types = ", ".join(x._sphinx_type() for x in self.type_params)
-        return f"{prop_link}({item_types})"
+        return f"{property_link(self)}({item_types})"
 
 
 

--- a/bokeh/core/property/dataspec.py
+++ b/bokeh/core/property/dataspec.py
@@ -550,6 +550,21 @@ class ColorSpec(DataSpec):
         return isinstance(val, str) and \
                ((len(val) == 7 and val[0] == "#") or val in enums.NamedColor)
 
+    @classmethod
+    def is_color_tuple_shape(cls, val):
+        """ Whether the value is the correct shape to be a color tuple
+
+        Checks for a 3 or 4-tuple of numbers
+
+        Args:
+            val (str) : the value to check
+
+        Returns:
+            True, if the value could be a color tuple
+
+        """
+        return isinstance(val, tuple) and len(val) in (3, 4) and all(isinstance(v, (float, int)) for v in val)
+
     def to_serializable(self, obj, name, val):
         if val is None:
             return dict(value=None)
@@ -585,7 +600,7 @@ class ColorSpec(DataSpec):
         # at this point, since Color is very strict about only accepting
         # tuples of (integer) bytes. This conditions tuple values to only
         # have integer RGB components
-        if isinstance(value, tuple) and len(value) in (3, 4) and all(isinstance(v, (float, int)) for v in value):
+        if self.is_color_tuple_shape(value):
             value = tuple(int(v) if i < 3 else v for i, v in enumerate(value))
         return super().prepare_value(cls, name, value)
 

--- a/bokeh/core/property/dataspec.py
+++ b/bokeh/core/property/dataspec.py
@@ -210,7 +210,8 @@ class DataSpec(Either):
         return dict(val)
 
     def _sphinx_type(self):
-        return self._sphinx_prop_link()
+        from ...util._sphinx import property_link
+        return property_link(self)
 
 class IntSpec(DataSpec):
     def __init__(self, default, help=None, key_type=_ExprFieldValueTransform):

--- a/bokeh/core/property/dataspec.py
+++ b/bokeh/core/property/dataspec.py
@@ -209,10 +209,6 @@ class DataSpec(Either):
         # Must be dict, return a new dict
         return dict(val)
 
-    def _sphinx_type(self):
-        from ...util._sphinx import property_link
-        return property_link(self)
-
 class IntSpec(DataSpec):
     def __init__(self, default, help=None, key_type=_ExprFieldValueTransform):
         super().__init__(key_type, Int, default=default, help=help)

--- a/bokeh/core/property/descriptor_factory.py
+++ b/bokeh/core/property/descriptor_factory.py
@@ -96,7 +96,7 @@ class PropertyDescriptorFactory:
 
         # The class itself has had a descriptor for 'foo' installed
         >>> getattr(SomeModel, 'foo')
-        <bokeh.core.property.descriptors.BasicPropertyDescriptor at 0x1065ffb38>
+        <bokeh.core.property.descriptors.PropertyDescriptor at 0x1065ffb38>
 
         # which is used when 'foo' is accessed on instances
         >>> m.foo

--- a/bokeh/core/property/descriptors.py
+++ b/bokeh/core/property/descriptors.py
@@ -99,7 +99,6 @@ from .wrappers import PropertyValueColumnData, PropertyValueContainer
 #-----------------------------------------------------------------------------
 
 __all__ = (
-    'BasicPropertyDescriptor',
     'ColumnDataPropertyDescriptor',
     'DataSpecPropertyDescriptor',
     'PropertyDescriptor',
@@ -119,273 +118,7 @@ class UnsetValueError(ValueError):
     """ Represents state in which descriptor without value was accessed. """
 
 class PropertyDescriptor:
-    """ Base class for a python descriptor that delegates access for a named
-    attribute to a Bokeh |Property| instance.
-
-    """
-
-    def __init__(self, name):
-        """ Create a descriptor for a hooking up a named Bokeh property
-        as an attribute on a |HasProps| class.
-
-        Args:
-            name (str) : the attribute name that this descriptor is for
-
-        """
-        self.name = name
-
-    def __str__(self):
-        """ Basic string representation of ``PropertyDescriptor``.
-
-        **Subclasses must implement this to serve their specific needs.**
-
-        """
-        return f"PropertyDescriptor({self.name})"
-
-    def __get__(self, obj, owner):
-        """ Implement the getter for the Python `descriptor protocol`_.
-
-        Args:
-            obj (HasProps or None) :
-                The instance to set a new property value on (for instance
-                attribute access), or None (for class attribute access)
-
-            owner (obj) :
-                The new value to set the property to
-
-        Returns:
-            None
-
-        Raises:
-            NotImplementedError
-
-        **Subclasses must implement this to serve their specific needs.**
-
-        """
-        raise NotImplementedError("Implement __get__")
-
-    def __set__(self, obj, value, setter=None):
-        """ Implement the setter for the Python `descriptor protocol`_.
-
-        .. note::
-            An optional argument ``setter`` has been added to the standard
-            setter arguments. When needed, this value should be provided by
-            explicitly invoking ``__set__``. See below for more information.
-
-        Args:
-            obj (HasProps) :
-                The instance to set a new property value on
-
-            value (obj) :
-                The new value to set the property to
-
-            setter (ClientSession or ServerSession or None, optional) :
-                This is used to prevent "boomerang" updates to Bokeh apps.
-                (default: None)
-
-                In the context of a Bokeh server application, incoming updates
-                to properties will be annotated with the session that is
-                doing the updating. This value is propagated through any
-                subsequent change notifications that the update triggers.
-                The session can compare the event setter to itself, and
-                suppress any updates that originate from itself.
-
-        Returns:
-            None
-
-        Raises:
-            NotImplementedError
-
-        **Subclasses must implement this to serve their specific needs.**
-
-        """
-        raise NotImplementedError("Implement __set__")
-
-    def __delete__(self, obj):
-        """ Implement the deleter for the Python `descriptor protocol`_.
-
-        Args:
-            obj (HasProps) : An instance to delete this property from
-
-        Raises:
-            NotImplementedError
-
-        **Subclasses must implement this to serve their specific needs.**
-
-        """
-        raise NotImplementedError("Implement __delete__")
-
-    def class_default(self, cls):
-        """ The default as computed for a certain class, ignoring any
-        per-instance theming.
-
-        Raises:
-            NotImplementedError
-
-        **Subclasses must implement this to serve their specific needs.**
-
-        """
-        raise NotImplementedError("Implement class_default()")
-
-    def serializable_value(self, obj):
-        """ Produce the value as it should be serialized.
-
-        Sometimes it is desirable for the serialized value to differ from
-        the ``__get__`` in order for the ``__get__`` value to appear simpler
-        for user or developer convenience.
-
-        Args:
-            obj (HasProps) : the object to get the serialized attribute for
-
-        Returns:
-            JSON-like
-
-        """
-        value = self.__get__(obj, obj.__class__)
-        return self.property.serialize_value(value)
-
-    def set_from_json(self, obj, json, models=None, setter=None):
-        """Sets the value of this property from a JSON value.
-
-        Args:
-            obj: (HasProps) : instance to set the property value on
-
-            json: (JSON-value) : value to set to the attribute to
-
-            models (dict or None, optional) :
-                Mapping of model ids to models (default: None)
-
-                This is needed in cases where the attributes to update also
-                have values that have references.
-
-            setter (ClientSession or ServerSession or None, optional) :
-                This is used to prevent "boomerang" updates to Bokeh apps.
-                (default: None)
-
-                In the context of a Bokeh server application, incoming updates
-                to properties will be annotated with the session that is
-                doing the updating. This value is propagated through any
-                subsequent change notifications that the update triggers.
-                The session can compare the event setter to itself, and
-                suppress any updates that originate from itself.
-
-        Returns:
-            None
-
-        """
-        self._internal_set(obj, json, setter=setter)
-
-    def trigger_if_changed(self, obj, old):
-        """ Send a change event notification if the property is set to a
-        value is not equal to ``old``.
-
-        Args:
-            obj (HasProps)
-                The object the property is being set on.
-
-            old (obj) :
-                The previous value of the property to compare
-
-        Raises:
-            NotImplementedError
-
-        **Subclasses must implement this to serve their specific needs.**
-
-        """
-        raise NotImplementedError("Implement trigger_if_changed()")
-
-    @property
-    def has_ref(self):
-        """ Whether the property can refer to another ``HasProps`` instance.
-
-        This is typically True for container properties, ``Instance``, etc.
-
-        Raises:
-            NotImplementedError
-
-        **Subclasses must implement this to serve their specific needs.**
-
-        """
-        raise NotImplementedError("Implement has_ref()")
-
-    @property
-    def readonly(self):
-        """ Whether this property is read-only.
-
-        Read-only properties may only be modified by the client (i.e., by
-        BokehJS, in the browser). Read only properties are useful for
-        quantities that originate or that can only be computed in the
-        browser, for instance the "inner" plot dimension of a plot area,
-        which depend on the current layout state. It is useful for Python
-        callbacks to be able to know these values, but they can only be
-        computed in the actual browser.
-
-        Raises:
-            NotImplementedError
-
-        **Subclasses must implement this to serve their specific needs.**
-
-        """
-        raise NotImplementedError("Implement readonly()")
-
-    @property
-    def serialized(self):
-        """ Whether the property should be serialized when serializing
-        an object.
-
-        This would be False for a "virtual" or "convenience" property that
-        duplicates information already available in other properties, for
-        example.
-
-        Raises:
-            NotImplementedError
-
-        **Subclasses must implement this to serve their specific needs.**
-
-        """
-        raise NotImplementedError("Implement serialized()")
-
-    def _internal_set(self, obj, value, hint=None, setter=None):
-        """ Internal implementation to set property values, that is used
-        by __set__, set_from_json, etc.
-
-        Args:
-            obj (HasProps)
-                The object the property is being set on.
-
-            old (obj) :
-                The previous value of the property to compare
-
-            hint (event hint or None, optional)
-                An optional update event hint, e.g. ``ColumnStreamedEvent``
-                (default: None)
-
-                Update event hints are usually used at times when better
-                update performance can be obtained by special-casing in
-                some way (e.g. streaming or patching column data sources)
-
-            setter (ClientSession or ServerSession or None, optional) :
-                This is used to prevent "boomerang" updates to Bokeh apps.
-                (default: None)
-
-                In the context of a Bokeh server application, incoming updates
-                to properties will be annotated with the session that is
-                doing the updating. This value is propagated through any
-                subsequent change notifications that the update triggers.
-                The session can compare the event setter to itself, and
-                suppress any updates that originate from itself.
-
-        Raises:
-            NotImplementedError
-
-        **Subclasses must implement this to serve their specific needs.**
-
-        """
-        raise NotImplementedError("Implement _internal_set()")
-
-class BasicPropertyDescriptor(PropertyDescriptor):
-    """ A ``PropertyDescriptor`` for basic Bokeh properties (e.g, ``Int``,
-    ``String``, ``Float``, etc.) with simple get/set and serialization
+    """ A base class for Bokeh properties with simple get/set and serialization
     behavior.
 
     """
@@ -398,12 +131,12 @@ class BasicPropertyDescriptor(PropertyDescriptor):
             property (Property) : A basic property to create a descriptor for
 
         """
-        super().__init__(name)
+        self.name = name
         self.property = property
         self.__doc__ = self.property.__doc__
 
     def __str__(self):
-        """ Basic string representation of ``BasicPropertyDescriptor``.
+        """ Basic string representation of ``PropertyDescriptor``.
 
         Delegates to ``self.property.__str__``
 
@@ -441,7 +174,7 @@ class BasicPropertyDescriptor(PropertyDescriptor):
 
                 # class attribute access, returns the property descriptor
                 >>> Range1d.start
-                <bokeh.core.property.descriptors.BasicPropertyDescriptor at 0x1148b3390>
+                <bokeh.core.property.descriptors.PropertyDescriptor at 0x1148b3390>
 
         """
         if obj is not None:
@@ -498,7 +231,9 @@ class BasicPropertyDescriptor(PropertyDescriptor):
             class_name = obj.__class__.__name__
             raise RuntimeError(f"{class_name}.{self.name} is a readonly property")
 
-        self._internal_set(obj, value, setter=setter)
+        value = self.property.prepare_value(obj, self.name, value)
+        old = self._get(obj)
+        self._set(obj, old, value, setter=setter)
 
     def __delete__(self, obj):
         """ Implement the deleter for the Python `descriptor protocol`_.
@@ -542,17 +277,36 @@ class BasicPropertyDescriptor(PropertyDescriptor):
         """
         return self.property.themed_default(obj.__class__, self.name, obj.themed_values())
 
-    def set_from_json(self, obj, json, models=None, setter=None):
-        """ Sets the value of this property from a JSON value.
+    def serializable_value(self, obj):
+        """ Produce the value as it should be serialized.
 
-        This method first
+        Sometimes it is desirable for the serialized value to differ from
+        the ``__get__`` in order for the ``__get__`` value to appear simpler
+        for user or developer convenience.
 
         Args:
-            obj (HasProps) :
+            obj (HasProps) : the object to get the serialized attribute for
 
-            json (JSON-dict) :
+        Returns:
+            JSON-like
 
-            models(seq[Model], optional) :
+        """
+        value = self.__get__(obj, obj.__class__)
+        return self.property.serialize_value(value)
+
+    def set_from_json(self, obj, json, models=None, setter=None):
+        """Sets the value of this property from a JSON value.
+
+        Args:
+            obj: (HasProps) : instance to set the property value on
+
+            json: (JSON-value) : value to set to the attribute to
+
+            models (dict or None, optional) :
+                Mapping of model ids to models (default: None)
+
+                This is needed in cases where the attributes to update also
+                have values that have references.
 
             setter (ClientSession or ServerSession or None, optional) :
                 This is used to prevent "boomerang" updates to Bokeh apps.
@@ -569,7 +323,9 @@ class BasicPropertyDescriptor(PropertyDescriptor):
             None
 
         """
-        return super().set_from_json(obj, self.property.from_json(json, models), models, setter)
+        value = self.property.prepare_value(obj, self.name, self.property.from_json(json, models))
+        old = self._get(obj)
+        self._set(obj, old, value, setter=setter)
 
     def trigger_if_changed(self, obj, old):
         """ Send a change event notification if the property is set to a
@@ -624,7 +380,7 @@ class BasicPropertyDescriptor(PropertyDescriptor):
 
     def _get(self, obj):
         """ Internal implementation of instance attribute access for the
-        ``BasicPropertyDescriptor`` getter.
+        ``PropertyDescriptor`` getter.
 
         If the value has not been explicitly set by a user, return that
         value. Otherwise, return the default.
@@ -693,48 +449,7 @@ class BasicPropertyDescriptor(PropertyDescriptor):
 
         obj._property_values[self.name] = value
 
-    def _internal_set(self, obj, value, hint=None, setter=None):
-        """ Internal implementation to set property values, that is used
-        by __set__, set_from_json, etc.
-
-        Delegate to the |Property| instance to prepare the value appropriately,
-        then `set.
-
-        Args:
-            obj (HasProps)
-                The object the property is being set on.
-
-            old (obj) :
-                The previous value of the property to compare
-
-            hint (event hint or None, optional)
-                An optional update event hint, e.g. ``ColumnStreamedEvent``
-                (default: None)
-
-                Update event hints are usually used at times when better
-                update performance can be obtained by special-casing in
-                some way (e.g. streaming or patching column data sources)
-
-            setter (ClientSession or ServerSession or None, optional) :
-                This is used to prevent "boomerang" updates to Bokeh apps.
-                (default: None)
-
-                In the context of a Bokeh server application, incoming updates
-                to properties will be annotated with the session that is
-                doing the updating. This value is propagated through any
-                subsequent change notifications that the update triggers.
-                The session can compare the event setter to itself, and
-                suppress any updates that originate from itself.
-
-        Returns:
-            None
-
-        """
-        value = self.property.prepare_value(obj, self.name, value)
-        old = self._get(obj)
-        self._real_set(obj, old, value, hint=hint, setter=setter)
-
-    def _real_set(self, obj, old, value, hint=None, setter=None):
+    def _set(self, obj, old, value, hint=None, setter=None):
         """ Internal implementation helper to set property values.
 
         This function handles bookkeeping around noting whether values have
@@ -832,7 +547,7 @@ class BasicPropertyDescriptor(PropertyDescriptor):
         # in some cases this could give us a new object for the value
         value = self.property.prepare_value(obj, self.name, value)
 
-        self._real_set(obj, old, value, hint=hint)
+        self._set(obj, old, value, hint=hint)
 
     def _trigger(self, obj, old, value, hint=None, setter=None):
         """ Unconditionally send a change event notification for the property.
@@ -883,7 +598,7 @@ If you need to copy set from one CDS to another, make a shallow copy by
 calling dict: s1.data = dict(s2.data)
 """
 
-class ColumnDataPropertyDescriptor(BasicPropertyDescriptor):
+class ColumnDataPropertyDescriptor(PropertyDescriptor):
     """ A ``PropertyDescriptor`` specialized to handling ``ColumnData`` properties.
 
     """
@@ -943,9 +658,11 @@ class ColumnDataPropertyDescriptor(BasicPropertyDescriptor):
         else:
             hint = None
 
-        self._internal_set(obj, value, hint=hint, setter=setter)
+        value = self.property.prepare_value(obj, self.name, value)
+        old = self._get(obj)
+        self._set(obj, old, value, hint=hint, setter=setter)
 
-class DataSpecPropertyDescriptor(BasicPropertyDescriptor):
+class DataSpecPropertyDescriptor(PropertyDescriptor):
     """ A ``PropertyDescriptor`` for Bokeh |DataSpec| properties that serialize to
     field/value dictionaries.
 

--- a/bokeh/core/property/descriptors.py
+++ b/bokeh/core/property/descriptors.py
@@ -141,7 +141,7 @@ class AliasPropertyDescriptor:
         return setattr(obj, self.aliased_name, value)
 
     @property
-    def readonly():
+    def readonly(self):
         return self.property.readonly
 
 class PropertyDescriptor:

--- a/bokeh/core/property/descriptors.py
+++ b/bokeh/core/property/descriptors.py
@@ -99,6 +99,7 @@ from .wrappers import PropertyValueColumnData, PropertyValueContainer
 #-----------------------------------------------------------------------------
 
 __all__ = (
+    'AliasPropertyDescriptor',
     'ColumnDataPropertyDescriptor',
     'DataSpecPropertyDescriptor',
     'PropertyDescriptor',
@@ -116,6 +117,28 @@ __all__ = (
 
 class UnsetValueError(ValueError):
     """ Represents state in which descriptor without value was accessed. """
+
+class AliasPropertyDescriptor:
+    """
+
+    """
+
+    serialized = False
+
+    def __init__(self, name, aliased_name, property):
+        self.name = name
+        self.aliased_name = aliased_name
+        self.property = property
+        self.__doc__ = f"This is a compatibility alias for the ``{aliased_name}`` property"
+
+    def __get__(self, obj, owner):
+        if obj is not None:
+            return getattr(obj, self.aliased_name)
+        elif owner is not None:
+            return self
+
+    def __set__(self, obj, value):
+        return setattr(obj, self.aliased_name, value)
 
 class PropertyDescriptor:
     """ A base class for Bokeh properties with simple get/set and serialization

--- a/bokeh/core/property/descriptors.py
+++ b/bokeh/core/property/descriptors.py
@@ -189,7 +189,7 @@ class PropertyDescriptor:
         # This should really never happen. If it does, __get__ was called in a bad way.
         raise ValueError("both 'obj' and 'owner' are None, don't know what to do")
 
-    def __set__(self, obj, value, setter=None):
+    def __set__(self, obj, value, *, setter=None):
         """ Implement the setter for the Python `descriptor protocol`_.
 
         .. note::
@@ -292,7 +292,7 @@ class PropertyDescriptor:
         value = self.__get__(obj, obj.__class__)
         return self.property.serialize_value(value)
 
-    def set_from_json(self, obj, json, models=None, setter=None):
+    def set_from_json(self, obj, json, *, models=None, setter=None):
         """Sets the value of this property from a JSON value.
 
         Args:
@@ -321,7 +321,7 @@ class PropertyDescriptor:
             None
 
         """
-        value = self.property.prepare_value(obj, self.name, self.property.from_json(json, models))
+        value = self.property.prepare_value(obj, self.name, self.property.from_json(json, models=models))
         old = self._get(obj)
         self._set(obj, old, value, setter=setter)
 
@@ -444,7 +444,7 @@ class PropertyDescriptor:
 
         obj._property_values[self.name] = value
 
-    def _set(self, obj, old, value, hint=None, setter=None):
+    def _set(self, obj, old, value, *, hint=None, setter=None):
         """ Internal implementation helper to set property values.
 
         This function handles bookkeeping around noting whether values have
@@ -541,7 +541,7 @@ class PropertyDescriptor:
 
         self._set(obj, old, value, hint=hint)
 
-    def _trigger(self, obj, old, value, hint=None, setter=None):
+    def _trigger(self, obj, old, value, *, hint=None, setter=None):
         """ Unconditionally send a change event notification for the property.
 
         Args:
@@ -595,7 +595,7 @@ class ColumnDataPropertyDescriptor(PropertyDescriptor):
 
     """
 
-    def __set__(self, obj, value, setter=None):
+    def __set__(self, obj, value, *, setter=None):
         """ Implement the setter for the Python `descriptor protocol`_.
 
         This method first separately extracts and removes any ``units`` field
@@ -663,7 +663,7 @@ class DataSpecPropertyDescriptor(PropertyDescriptor):
         """
         return self.property.to_serializable(obj, self.name, getattr(obj, self.name))
 
-    def set_from_json(self, obj, json, models=None, setter=None):
+    def set_from_json(self, obj, json, *, models=None, setter=None):
         """ Sets the value of this property from a JSON value.
 
         This method first
@@ -704,7 +704,7 @@ class DataSpecPropertyDescriptor(PropertyDescriptor):
                         json = json['field']
                 # leave it as a dict if 'old' was a dict
 
-        super().set_from_json(obj, json, models, setter)
+        super().set_from_json(obj, json, models=models, setter=setter)
 
 class UnitsSpecPropertyDescriptor(DataSpecPropertyDescriptor):
     """ A ``PropertyDescriptor`` for Bokeh |PropertyUnitsSpec| properties that
@@ -729,7 +729,7 @@ class UnitsSpecPropertyDescriptor(DataSpecPropertyDescriptor):
         super().__init__(name, property)
         self.units_prop = units_property
 
-    def __set__(self, obj, value, setter=None):
+    def __set__(self, obj, value, *, setter=None):
         """ Implement the setter for the Python `descriptor protocol`_.
 
         This method first separately extracts and removes any ``units`` field
@@ -765,9 +765,9 @@ class UnitsSpecPropertyDescriptor(DataSpecPropertyDescriptor):
 
         """
         value = self._extract_units(obj, value)
-        super().__set__(obj, value, setter)
+        super().__set__(obj, value, setter=setter)
 
-    def set_from_json(self, obj, json, models=None, setter=None):
+    def set_from_json(self, obj, json, *, models=None, setter=None):
         """ Sets the value of this property from a JSON value.
 
         This method first separately extracts and removes any ``units`` field
@@ -802,7 +802,7 @@ class UnitsSpecPropertyDescriptor(DataSpecPropertyDescriptor):
 
         """
         json = self._extract_units(obj, json)
-        super().set_from_json(obj, json, models, setter)
+        super().set_from_json(obj, json, models=models, setter=setter)
 
     def _extract_units(self, obj, value):
         """ Internal helper for dealing with units associated units properties

--- a/bokeh/core/property/descriptors.py
+++ b/bokeh/core/property/descriptors.py
@@ -140,6 +140,10 @@ class AliasPropertyDescriptor:
     def __set__(self, obj, value):
         return setattr(obj, self.aliased_name, value)
 
+    @property
+    def readonly():
+        return self.property.readonly
+
 class PropertyDescriptor:
     """ A base class for Bokeh properties with simple get/set and serialization
     behavior.

--- a/bokeh/core/property/either.py
+++ b/bokeh/core/property/either.py
@@ -80,10 +80,10 @@ class Either(ParameterizedProperty):
     def type_params(self):
         return self._type_params
 
-    def from_json(self, json, models=None):
+    def from_json(self, json, *, models=None):
         for tp in self.type_params:
             try:
-                return tp.from_json(json, models)
+                return tp.from_json(json, models=models)
             except DeserializationError:
                 pass
         raise DeserializationError(f"{self} couldn't deserialize {json}")

--- a/bokeh/core/property/either.py
+++ b/bokeh/core/property/either.py
@@ -111,9 +111,9 @@ class Either(ParameterizedProperty):
     #     return any(tp._may_have_unstable_default() for tp in self.type_params)
 
     def _sphinx_type(self):
-        prop_link = self._sphinx_prop_link()
+        from ...util._sphinx import property_link
         subtypes = ", ".join(x._sphinx_type() for x in self.type_params)
-        return f"{prop_link}({subtypes})"
+        return f"{property_link(self)}({subtypes})"
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/core/property/either.py
+++ b/bokeh/core/property/either.py
@@ -23,6 +23,7 @@ log = logging.getLogger(__name__)
 
 # Bokeh imports
 from ...util.string import nice_join
+from ._sphinx import property_link, register_type_link, type_link
 from .bases import DeserializationError, ParameterizedProperty
 from .singletons import Intrinsic
 
@@ -110,11 +111,6 @@ class Either(ParameterizedProperty):
     # def _may_have_unstable_default(self):
     #     return any(tp._may_have_unstable_default() for tp in self.type_params)
 
-    def _sphinx_type(self):
-        from ...util._sphinx import property_link
-        subtypes = ", ".join(x._sphinx_type() for x in self.type_params)
-        return f"{property_link(self)}({subtypes})"
-
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------
@@ -126,3 +122,8 @@ class Either(ParameterizedProperty):
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
+
+@register_type_link(Either)
+def _sphinx_type_link(obj):
+    subtypes = ", ".join(type_link(x) for x in obj.type_params)
+    return f"{property_link(obj)}({subtypes})"

--- a/bokeh/core/property/enum.py
+++ b/bokeh/core/property/enum.py
@@ -21,6 +21,7 @@ log = logging.getLogger(__name__)
 # Bokeh imports
 from ...util.string import nice_join
 from .. import enums
+from ._sphinx import model_link, property_link, register_type_link
 from .primitive import String
 from .singletons import Intrinsic
 
@@ -72,19 +73,6 @@ class Enum(String):
         msg = "" if not detail else f"invalid value: {value!r}; allowed values are {nice_join(self.allowed_values)}"
         raise ValueError(msg)
 
-    def _sphinx_type(self):
-        from ...util._sphinx import model_link, property_link
-
-        # try to return a link to a proper enum in bokeh.core.enums if possible
-        if self._enum in enums.__dict__.values():
-            for name, obj in enums.__dict__.items():
-                if self._enum is obj:
-                    fullname = f"{self._enum.__module__}.{name}"
-                    return f"{property_link(self)}({model_link(fullname)})"
-
-        # otherwise just a basic str name format
-        return f"{property_link(self)}({self._enum})"
-
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------
@@ -96,3 +84,15 @@ class Enum(String):
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
+
+@register_type_link(Enum)
+def _sphinx_type(obj):
+    # try to return a link to a proper enum in bokeh.core.enums if possible
+    if obj._enum in enums.__dict__.values():
+        for name, value in enums.__dict__.items():
+            if obj._enum is value:
+                fullname = f"{obj._enum.__module__}.{name}"
+                return f"{property_link(obj)}({model_link(fullname)})"
+
+    # otherwise just a basic str name format
+    return f"{property_link(obj)}({obj._enum})"

--- a/bokeh/core/property/enum.py
+++ b/bokeh/core/property/enum.py
@@ -73,15 +73,17 @@ class Enum(String):
         raise ValueError(msg)
 
     def _sphinx_type(self):
+        from ...util._sphinx import model_link, property_link
+
         # try to return a link to a proper enum in bokeh.core.enums if possible
         if self._enum in enums.__dict__.values():
             for name, obj in enums.__dict__.items():
                 if self._enum is obj:
-                    val = self._sphinx_model_link(f"{self._enum.__module__}.{name}")
-                    return f"{self._sphinx_prop_link()}({val})"
+                    fullname = f"{self._enum.__module__}.{name}"
+                    return f"{property_link(self)}({model_link(fullname)})"
 
         # otherwise just a basic str name format
-        return f"{self._sphinx_prop_link()}({self._enum})"
+        return f"{property_link(self)}({self._enum})"
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/core/property/instance.py
+++ b/bokeh/core/property/instance.py
@@ -25,6 +25,7 @@ log = logging.getLogger(__name__)
 from importlib import import_module
 
 # Bokeh imports
+from ._sphinx import model_link, property_link, register_type_link
 from .bases import DeserializationError, Property
 from .singletons import Undefined
 
@@ -119,11 +120,6 @@ class Instance(Property):
         # because the instance value is mutable
         return True
 
-    def _sphinx_type(self):
-        from ...util._sphinx import model_link, property_link
-        fullname = f"{self.instance_type.__module__}.{self.instance_type.__name__}"
-        return f"{property_link(self)}({model_link(fullname)}"
-
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------
@@ -135,3 +131,8 @@ class Instance(Property):
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
+
+@register_type_link(Instance)
+def _sphinx_type_link(obj):
+    fullname = f"{obj.instance_type.__module__}.{obj.instance_type.__name__}"
+    return f"{property_link(obj)}({model_link(fullname)}"

--- a/bokeh/core/property/instance.py
+++ b/bokeh/core/property/instance.py
@@ -120,8 +120,9 @@ class Instance(Property):
         return True
 
     def _sphinx_type(self):
+        from ...util._sphinx import model_link, property_link
         fullname = f"{self.instance_type.__module__}.{self.instance_type.__name__}"
-        return f"{self._sphinx_prop_link()}({self._sphinx_model_link(fullname)})"
+        return f"{property_link(self)}({model_link(fullname)}"
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/core/property/instance.py
+++ b/bokeh/core/property/instance.py
@@ -78,7 +78,7 @@ class Instance(Property):
 
         return self._instance_type
 
-    def from_json(self, json, models=None):
+    def from_json(self, json, *, models=None):
         if isinstance(json, dict):
             from ...model import Model
             if issubclass(self.instance_type, Model):
@@ -96,7 +96,7 @@ class Instance(Property):
 
                 for name, value in json.items():
                     prop_descriptor = self.instance_type.lookup(name).property
-                    attrs[name] = prop_descriptor.from_json(value, models)
+                    attrs[name] = prop_descriptor.from_json(value, models=models)
 
                 # XXX: this doesn't work when Instance(Superclass) := Subclass()
                 # Serialization dict must carry type information to resolve this.

--- a/bokeh/core/property/nullable.py
+++ b/bokeh/core/property/nullable.py
@@ -42,7 +42,7 @@ class Nullable(SingleParameterizedProperty):
     def __init__(self, type_param, *, default=None, help=None, serialized=None, readonly=False):
         super().__init__(type_param, default=default, help=help, serialized=serialized, readonly=readonly)
 
-    def from_json(self, json, models=None):
+    def from_json(self, json, *, models=None):
         return None if json is None else super().from_json(json, models=models)
 
     def transform(self, value):

--- a/bokeh/core/property/nullable.py
+++ b/bokeh/core/property/nullable.py
@@ -20,6 +20,7 @@ log = logging.getLogger(__name__)
 from typing import Any
 
 # Bokeh imports
+from ._sphinx import property_link, register_type_link, type_link
 from .bases import SingleParameterizedProperty
 from .singletons import Undefined
 
@@ -65,19 +66,11 @@ class Nullable(SingleParameterizedProperty):
         msg = "" if not detail else f"expected either None or a value of type {self.type_param}, got {value!r}"
         raise ValueError(msg)
 
-    def _sphinx_type(self):
-        from ...util._sphinx import property_link
-        return f"{property_link(self)}({self.type_param._sphinx_type()})"
-
 class NonNullable(SingleParameterizedProperty):
     """ A property accepting a value of some other type while having undefined default. """
 
     def __init__(self, type_param, *, default=Undefined, help=None, serialized=None, readonly=False):
         super().__init__(type_param, default=default, help=help, serialized=serialized, readonly=readonly)
-
-    def _sphinx_type(self):
-        from ...util._sphinx import property_link
-        return f"{property_link(self)}({self.type_param._sphinx_type()})"
 
 #-----------------------------------------------------------------------------
 # Dev API
@@ -90,3 +83,8 @@ class NonNullable(SingleParameterizedProperty):
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
+
+@register_type_link(Nullable)
+@register_type_link(NonNullable)
+def _sphinx_type_link(obj):
+    return f"{property_link(obj)}({type_link(obj.type_param)})"

--- a/bokeh/core/property/nullable.py
+++ b/bokeh/core/property/nullable.py
@@ -65,11 +65,19 @@ class Nullable(SingleParameterizedProperty):
         msg = "" if not detail else f"expected either None or a value of type {self.type_param}, got {value!r}"
         raise ValueError(msg)
 
+    def _sphinx_type(self):
+        from ...util._sphinx import property_link
+        return f"{property_link(self)}({self.type_param._sphinx_type()})"
+
 class NonNullable(SingleParameterizedProperty):
     """ A property accepting a value of some other type while having undefined default. """
 
     def __init__(self, type_param, *, default=Undefined, help=None, serialized=None, readonly=False):
         super().__init__(type_param, default=default, help=help, serialized=serialized, readonly=readonly)
+
+    def _sphinx_type(self):
+        from ...util._sphinx import property_link
+        return f"{property_link(self)}({self.type_param._sphinx_type()})"
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/core/property/visual.py
+++ b/bokeh/core/property/visual.py
@@ -104,10 +104,6 @@ class DashPattern(Either):
         else:
             return value
 
-    def _sphinx_type(self):
-        from ...util._sphinx import property_link
-        return property_link(self)
-
 class FontSize(String):
 
     _font_size_re = re.compile(r"^[0-9]+(.[0-9]+)?(%|em|ex|ch|ic|rem|vw|vh|vi|vb|vmin|vmax|cm|mm|q|in|pc|pt|px)$", re.I)
@@ -137,10 +133,6 @@ class HatchPatternType(Either):
 
     def __str__(self):
         return self.__class__.__name__
-
-    def _sphinx_type(self):
-        from ...util._sphinx import property_link
-        return property_link(self)
 
 class Image(Property):
     """ Accept image file types, e.g PNG, JPEG, TIFF, etc.
@@ -245,10 +237,6 @@ class MinMaxBounds(Either):
 
         msg = "" if not detail else "Invalid bounds: maximum smaller than minimum. Correct usage: bounds=(min, max)"
         raise ValueError(msg)
-
-    def _sphinx_type(self):
-        from ...util._sphinx import property_link
-        return property_link(self)
 
 class MarkerType(Enum):
     """

--- a/bokeh/core/property/visual.py
+++ b/bokeh/core/property/visual.py
@@ -105,7 +105,8 @@ class DashPattern(Either):
             return value
 
     def _sphinx_type(self):
-        return self._sphinx_prop_link()
+        from ...util._sphinx import property_link
+        return property_link(self)
 
 class FontSize(String):
 
@@ -138,7 +139,8 @@ class HatchPatternType(Either):
         return self.__class__.__name__
 
     def _sphinx_type(self):
-        return self._sphinx_prop_link()
+        from ...util._sphinx import property_link
+        return property_link(self)
 
 class Image(Property):
     """ Accept image file types, e.g PNG, JPEG, TIFF, etc.
@@ -245,7 +247,8 @@ class MinMaxBounds(Either):
         raise ValueError(msg)
 
     def _sphinx_type(self):
-        return self._sphinx_prop_link()
+        from ...util._sphinx import property_link
+        return property_link(self)
 
 class MarkerType(Enum):
     """

--- a/bokeh/models/glyph.py
+++ b/bokeh/models/glyph.py
@@ -30,6 +30,7 @@ from inspect import Parameter
 
 # Bokeh imports
 from ..core.has_props import abstract
+from ..core.property._sphinx import type_link
 from ..model import Model
 
 #-----------------------------------------------------------------------------
@@ -81,7 +82,7 @@ class Glyph(Model):
                 # For positional arg properties, default=None means no default.
                 default=Parameter.empty if no_more_defaults else default
             )
-            typ = descriptor.property._sphinx_type()
+            typ = type_link(descriptor.property)
             arg_params.insert(0, (param, typ, descriptor.__doc__))
 
         # these are not really useful, and should also really be private, just skip them
@@ -97,7 +98,7 @@ class Glyph(Model):
                 kind=Parameter.KEYWORD_ONLY,
                 default=descriptor.class_default(cls)
             )
-            typ = descriptor.property._sphinx_type()
+            typ = type_link(descriptor.property)
             kwarg_params.append((param, typ, descriptor.__doc__))
 
         for kw, (typ, doc) in cls._extra_kws.items():

--- a/bokeh/models/glyph.py
+++ b/bokeh/models/glyph.py
@@ -90,7 +90,7 @@ class Glyph(Model):
 
         kwarg_params = []
 
-        kws = cls.properties() - set(cls._args) - omissions
+        kws = set(cls.properties()) - set(cls._args) - omissions
         for kw in kws:
             descriptor = cls.lookup(kw)
             param = Parameter(

--- a/bokeh/plotting/_renderer.py
+++ b/bokeh/plotting/_renderer.py
@@ -205,7 +205,7 @@ def pop_visuals(glyphclass, props, prefix="", defaults={}, override_defaults={})
     trait_defaults.setdefault('alpha', 1.0)
 
     result, traits = dict(), set()
-    glyphprops = glyphclass.properties()
+    glyphprops = list(glyphclass.properties())
     for pname in filter(is_visual, glyphprops):
         _, trait = split_feature_trait(pname)
 

--- a/bokeh/plotting/_renderer.py
+++ b/bokeh/plotting/_renderer.py
@@ -187,15 +187,6 @@ def pop_visuals(glyphclass, props, prefix="", defaults={}, override_defaults={})
         Feature trait 'text_color', as well as traits 'color' and 'alpha', have
         ultimate defaults in case those can't be deduced.
     """
-    def split_feature_trait(ft):
-        """Feature is up to first '_'. Ex. 'line_color' => ['line', 'color']"""
-        ft = ft.split('_', 1)
-        return ft if len(ft)==2 else ft+[None]
-
-    def is_visual(ft):
-        """Whether a feature trait name is visual"""
-        feature, trait = split_feature_trait(ft)
-        return feature in ('line', 'fill', 'text', 'global') and trait is not None
 
     defaults = defaults.copy()
     defaults.setdefault('text_color', 'black')
@@ -205,31 +196,31 @@ def pop_visuals(glyphclass, props, prefix="", defaults={}, override_defaults={})
     trait_defaults.setdefault('alpha', 1.0)
 
     result, traits = dict(), set()
-    glyphprops = list(glyphclass.properties())
-    for pname in filter(is_visual, glyphprops):
-        _, trait = split_feature_trait(pname)
+    prop_names = set(glyphclass.properties())
+    for name in filter(_is_visual, prop_names):
+        _, trait = _split_feature_trait(name)
 
         # e.g. "line_color", "selection_fill_alpha"
-        if prefix+pname in props:
-            result[pname] = props.pop(prefix+pname)
+        if prefix+name in props:
+            result[name] = props.pop(prefix+name)
 
         # e.g. "nonselection_alpha"
-        elif trait not in glyphprops and prefix+trait in props:
-            result[pname] = props[prefix+trait]
+        elif trait not in prop_names and prefix+trait in props:
+            result[name] = props[prefix+trait]
 
         # e.g. an alpha to use for nonselection if none is provided
         elif trait in override_defaults:
-            result[pname] = override_defaults[trait]
+            result[name] = override_defaults[trait]
 
         # e.g use values off the main glyph
-        elif pname in defaults:
-            result[pname] = defaults[pname]
+        elif name in defaults:
+            result[name] = defaults[name]
 
         # e.g. not specificed anywhere else
         elif trait in trait_defaults:
-            result[pname] = trait_defaults[trait]
+            result[name] = trait_defaults[trait]
 
-        if trait not in glyphprops:
+        if trait not in prop_names:
             traits.add(trait)
     for trait in traits:
         props.pop(prefix+trait, None)
@@ -249,10 +240,7 @@ def _convert_data_source(kwargs):
                 # try converting the source to ColumnDataSource
                 source = ColumnDataSource(source)
             except ValueError as err:
-                msg = "Failed to auto-convert {curr_type} to ColumnDataSource.\n Original error: {err}".format(
-                    curr_type=str(type(source)),
-                    err=err.message
-                )
+                msg = f"Failed to auto-convert {type(source)} to ColumnDataSource.\n Original error: {err}"
                 raise ValueError(msg).with_traceback(sys.exc_info()[2])
 
             # update kwargs so that others can use the new source
@@ -315,6 +303,16 @@ def _process_sequence_literals(glyphclass, kwargs, source, is_user_source):
             kwargs[var] = var
 
     return incompatible_literal_spec_values
+
+def _split_feature_trait(ft):
+    """Feature is up to first '_'. Ex. 'line_color' => ['line', 'color']"""
+    ft = ft.split('_', 1)
+    return ft if len(ft)==2 else ft+[None]
+
+def _is_visual(ft):
+    """Whether a feature trait name is visual"""
+    feature, trait = _split_feature_trait(ft)
+    return feature in ('line', 'fill', 'text', 'global') and trait is not None
 
 _GLYPH_SOURCE_MSG = """
 

--- a/bokeh/plotting/_renderer.py
+++ b/bokeh/plotting/_renderer.py
@@ -289,7 +289,7 @@ def _process_sequence_literals(glyphclass, kwargs, source, is_user_source):
             continue
 
         # similarly colorspecs handle color tuple sequences as-is
-        if (isinstance(dataspecs[var], ColorSpec) and isinstance(val, tuple) and len(val) in (3, 4) and all(isinstance(v, (float, int)) for v in val)):
+        if isinstance(dataspecs[var], ColorSpec) and dataspecs[var].is_color_tuple_shape(val):
             continue
 
         if isinstance(val, np.ndarray):

--- a/bokeh/plotting/_renderer.py
+++ b/bokeh/plotting/_renderer.py
@@ -269,7 +269,7 @@ def _pop_renderer_args(kwargs):
 
 def _process_sequence_literals(glyphclass, kwargs, source, is_user_source):
     incompatible_literal_spec_values = []
-    dataspecs = glyphclass.dataspecs_with_props()
+    dataspecs = glyphclass.dataspecs()
     for var, val in kwargs.items():
 
         # ignore things that are not iterable
@@ -289,11 +289,11 @@ def _process_sequence_literals(glyphclass, kwargs, source, is_user_source):
             continue
 
         # similarly colorspecs handle color tuple sequences as-is
-        if (isinstance(dataspecs[var].property, ColorSpec) and isinstance(val, tuple) and len(val) in (3, 4) and all(isinstance(v, (float, int)) for v in val)):
+        if (isinstance(dataspecs[var], ColorSpec) and isinstance(val, tuple) and len(val) in (3, 4) and all(isinstance(v, (float, int)) for v in val)):
             continue
 
         if isinstance(val, np.ndarray):
-            if isinstance(dataspecs[var].property, ColorSpec):
+            if isinstance(dataspecs[var], ColorSpec):
                 if val.dtype == "uint32" and val.ndim == 1:   # 0xRRGGBBAA
                     pass # TODO: handle byteorder
                 elif val.dtype == "uint8" and val.ndim == 1:  # greys

--- a/bokeh/sphinxext/bokeh_options.py
+++ b/bokeh/sphinxext/bokeh_options.py
@@ -57,6 +57,7 @@ from docutils.parsers.rst.directives import unchanged
 from sphinx.errors import SphinxError
 
 # Bokeh imports
+from bokeh.core.property._sphinx import type_link
 from bokeh.util.options import Options
 
 # Bokeh imports
@@ -118,7 +119,7 @@ class BokehOptionsDirective(BokehDirective):
             opts.append(
                 dict(
                     name=prop_name,
-                    type=descriptor.property._sphinx_type(),
+                    type=type_link(descriptor.property),
                     default=repr(descriptor.instance_default(options_obj)),
                     doc="" if descriptor.__doc__ is None else textwrap.dedent(descriptor.__doc__.rstrip()),
                 )

--- a/bokeh/sphinxext/bokeh_prop.py
+++ b/bokeh/sphinxext/bokeh_prop.py
@@ -61,6 +61,7 @@ from docutils.parsers.rst.directives import unchanged
 from sphinx.errors import SphinxError
 
 # Bokeh imports
+from bokeh.core.property._sphinx import type_link
 from bokeh.util.warnings import BokehDeprecationWarning
 
 # Bokeh imports
@@ -123,7 +124,7 @@ class BokehPropDirective(BokehDirective):
             name=prop_name,
             module=self.options["module"],
             default=repr(descriptor.instance_default(model_obj)),
-            type_info=descriptor.property._sphinx_type(),
+            type_info=type_link(descriptor.property),
             doc="" if descriptor.__doc__ is None else textwrap.dedent(descriptor.__doc__),
         )
 

--- a/bokeh/util/_sphinx.py
+++ b/bokeh/util/_sphinx.py
@@ -4,71 +4,55 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-""" Provide the Auto property.
+''' Functions useful for string manipulations or encoding.
 
-"""
+'''
 
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
-import logging # isort:skip
+import logging
+
 log = logging.getLogger(__name__)
 
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
 
-# Bokeh imports
-from .enum import Enum
+# Standard library imports
+from inspect import isclass
 
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
 
 __all__ = (
-    'Auto',
+    'model_link',
+    'property_link',
 )
 
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
 
-class Auto(Enum):
-    """ Accepts only the string "auto".
-
-    Useful for properties that can be configured to behave "automatically".
-
-    Example:
-
-        This property is often most useful in conjunction with the
-        :class:`~bokeh.core.properties.Either` property.
-
-        .. code-block:: python
-
-            >>> class AutoModel(HasProps):
-            ...     prop = Either(Float, Auto)
-            ...
-
-            >>> m = AutoModel()
-
-            >>> m.prop = 10.2
-
-            >>> m.prop = "auto"
-
-            >>> m.prop = "foo"      # ValueError !!
-
-            >>> m.prop = [1, 2, 3]  # ValueError !!
+def model_link(fullname):
+    """ Generate a sphinx :class: link to given named model.
 
     """
-    def __init__(self):
-        super().__init__("auto")
+    # (double) escaped space at the end is to appease Sphinx
+    # https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#gotchas
+    return f":class:`~{fullname}`\\ "
 
-    def __str__(self):
-        return self.__class__.__name__
+def property_link(cls_or_obj):
+    """ Generate a sphinx :class: link to a property.
 
-    def _sphinx_type(self):
-        from ...util._sphinx import property_link
-        return property_link(self)
+    """
+    # (double) escaped space at the end is to appease Sphinx
+    # https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#gotchas
+    if isclass(cls_or_obj):
+        return f":class:`~bokeh.core.properties.{cls_or_obj.__name__}`\\ "
+    else:
+        return f":class:`~bokeh.core.properties.{cls_or_obj.__class__.__name__}`\\ "
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/core/property/test_alias.py
+++ b/tests/unit/bokeh/core/property/test_alias.py
@@ -35,7 +35,7 @@ ALL = (
 class Test_Alias:
     def test_create_default(self) -> None:
         alias = bcpa.Alias("width", help="Object's width")
-        assert alias.name == "width"
+        assert alias.aliased_name == "width"
         assert alias.help == "Object's width"
 
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/core/property/test_dataspec.py
+++ b/tests/unit/bokeh/core/property/test_dataspec.py
@@ -266,6 +266,25 @@ class Test_ColorSpec:
         assert f.col == "field2"
         assert desc.serializable_value(f) == {"field": "field2"}
 
+    def test_isconst(self) -> None:
+        assert bcpd.ColorSpec.isconst("red")
+        assert bcpd.ColorSpec.isconst("#ff1234")
+
+        assert not bcpd.ColorSpec.isconst(None)
+        assert not bcpd.ColorSpec.isconst(10)
+        assert not bcpd.ColorSpec.isconst((1, 2, 3, 0.5))
+
+    def test_is_color_tuple_shape(self) -> None:
+        assert bcpd.ColorSpec.is_color_tuple_shape((1, 2, 3, 0.5))
+        assert bcpd.ColorSpec.is_color_tuple_shape((1.0, 2, 3, 0.5))
+        assert bcpd.ColorSpec.is_color_tuple_shape((1, 2.0, 3, 0.5))
+        assert bcpd.ColorSpec.is_color_tuple_shape((1, 2, 3.0, 0.5))
+
+        assert not bcpd.ColorSpec.is_color_tuple_shape("red")
+        assert not bcpd.ColorSpec.is_color_tuple_shape("#ff1234")
+        assert not bcpd.ColorSpec.is_color_tuple_shape(None)
+        assert not bcpd.ColorSpec.is_color_tuple_shape(10)
+
 class Test_DistanceSpec:
     def test_default_value(self) -> None:
         class Foo(HasProps):

--- a/tests/unit/bokeh/core/property/test_descriptors.py
+++ b/tests/unit/bokeh/core/property/test_descriptors.py
@@ -47,7 +47,7 @@ ALL = (
 class Foo:
     def prepare_value(self, owner, name, value):
         return value
-    def from_json(self, x, y=None):
+    def from_json(self, x, models=None, setter=None):
         return 10
 
 class Test_PropertyDescriptor:
@@ -72,7 +72,7 @@ class Test_PropertyDescriptor:
     def test_set_from_json(self, mock_get, mock_set) -> None:
         f = Foo()
         d = bcpd.PropertyDescriptor("foo", f)
-        d.set_from_json(f, "bar", 10)
+        d.set_from_json(f, "bar", models=10)
         assert mock_get.called_once_with((f, "bar", 10), {})
         assert mock_set.called_once_with((f, "bar", 10), {})
 

--- a/tests/unit/bokeh/core/property/test_descriptors.py
+++ b/tests/unit/bokeh/core/property/test_descriptors.py
@@ -30,7 +30,6 @@ import bokeh.core.property.descriptors as bcpd # isort:skip
 #-----------------------------------------------------------------------------
 
 ALL = (
-    'BasicPropertyDescriptor',
     'ColumnDataPropertyDescriptor',
     'DataSpecPropertyDescriptor',
     'PropertyDescriptor',
@@ -45,58 +44,37 @@ ALL = (
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------
-
+class Foo:
+    def prepare_value(self, owner, name, value):
+        return value
+    def from_json(self, x, y=None):
+        return 10
 
 class Test_PropertyDescriptor:
+
     def test___init__(self) -> None:
-        d = bcpd.PropertyDescriptor("foo")
+        class Foo:
+            '''doc'''
+            pass
+        f = Foo()
+        d = bcpd.PropertyDescriptor("foo", f)
         assert d.name == "foo"
+        assert d.property == f
+        assert d.__doc__ == f.__doc__
 
     def test___str__(self) -> None:
-        d = bcpd.PropertyDescriptor("foo")
-        assert str(d) == "PropertyDescriptor(foo)"
-
-    def test_abstract(self) -> None:
-        d = bcpd.PropertyDescriptor("foo")
-        class Foo:
-            pass
         f = Foo()
-        with pytest.raises(NotImplementedError):
-            d.__get__(f, f.__class__)
+        d = bcpd.PropertyDescriptor("foo", f)
+        assert str(d) == str(f)
 
-        with pytest.raises(NotImplementedError):
-            d.__set__(f, 11)
-
-        with pytest.raises(NotImplementedError):
-            d.__delete__(f)
-
-        with pytest.raises(NotImplementedError):
-            d.class_default(f)
-
-        with pytest.raises(NotImplementedError):
-            d.serialized
-
-        with pytest.raises(NotImplementedError):
-            d.readonly
-
-        with pytest.raises(NotImplementedError):
-            d.has_ref
-
-        with pytest.raises(NotImplementedError):
-            d.trigger_if_changed(f, 11)
-
-        with pytest.raises(NotImplementedError):
-            d._internal_set(f, 11)
-
-    @patch('bokeh.core.property.descriptors.PropertyDescriptor._internal_set')
-    def test_set_from_json(self, mock_iset) -> None:
-        class Foo:
-            pass
-
+    @patch('bokeh.core.property.descriptors.PropertyDescriptor._get')
+    @patch('bokeh.core.property.descriptors.PropertyDescriptor._set')
+    def test_set_from_json(self, mock_get, mock_set) -> None:
         f = Foo()
-        d = bcpd.PropertyDescriptor("foo")
+        d = bcpd.PropertyDescriptor("foo", f)
         d.set_from_json(f, "bar", 10)
-        assert mock_iset.called_once_with((f, "bar", 10), {})
+        assert mock_get.called_once_with((f, "bar", 10), {})
+        assert mock_set.called_once_with((f, "bar", 10), {})
 
     def test_erializable_value(self) -> None:
         result = {}
@@ -106,7 +84,7 @@ class Test_PropertyDescriptor:
         f = Foo()
         f.foo = 10
 
-        d = bcpd.PropertyDescriptor("foo")
+        d = bcpd.PropertyDescriptor("foo", f)
         d.property = Foo()
 
         # simulate the __get__ a subclass would have
@@ -115,41 +93,16 @@ class Test_PropertyDescriptor:
         d.serializable_value(f)
         assert result['foo'] == 10
 
-class Test_BasicPropertyDescriptor:
-    def test___init__(self) -> None:
-        class Foo:
-            '''doc'''
-            pass
-        f = Foo()
-        d = bcpd.BasicPropertyDescriptor("foo", f)
-        assert d.name == "foo"
-        assert d.property == f
-        assert d.__doc__ == f.__doc__
-
-    def test___str__(self) -> None:
-        class Foo:
-            pass
-
-        f = Foo()
-        d = bcpd.BasicPropertyDescriptor("foo", f)
-        assert str(d) == str(f)
-
     def test___get__improper(self) -> None:
-        class Foo:
-            pass
-
         f = Foo()
-        d = bcpd.BasicPropertyDescriptor("foo", f)
+        d = bcpd.PropertyDescriptor("foo", f)
         with pytest.raises(ValueError) as e:
             d.__get__(None, None)
         assert str(e.value).endswith("both 'obj' and 'owner' are None, don't know what to do")
 
     def test___set__improper(self) -> None:
-        class Foo:
-            pass
-
         f = Foo()
-        d = bcpd.BasicPropertyDescriptor("foo", f)
+        d = bcpd.PropertyDescriptor("foo", f)
         with pytest.raises(RuntimeError) as e:
             d.__set__("junk", None)
         assert str(e.value).endswith("Cannot set a property value 'foo' on a str instance before HasProps.__init__")
@@ -219,7 +172,7 @@ class Test_BasicPropertyDescriptor:
                 result['called'] = True
         f = Foo()
         f.readonly = "stuff"
-        d = bcpd.BasicPropertyDescriptor("foo", f)
+        d = bcpd.PropertyDescriptor("foo", f)
         d.class_default(d)
         assert result['called']
 
@@ -229,7 +182,7 @@ class Test_BasicPropertyDescriptor:
 
         f = Foo()
         f.serialized = "stuff"
-        d = bcpd.BasicPropertyDescriptor("foo", f)
+        d = bcpd.PropertyDescriptor("foo", f)
         assert d.serialized == "stuff"
 
     def test_readonly(self) -> None:
@@ -238,7 +191,7 @@ class Test_BasicPropertyDescriptor:
 
         f = Foo()
         f.readonly = "stuff"
-        d = bcpd.BasicPropertyDescriptor("foo", f)
+        d = bcpd.PropertyDescriptor("foo", f)
         assert d.readonly == "stuff"
 
     def test_has_ref(self) -> None:
@@ -247,10 +200,10 @@ class Test_BasicPropertyDescriptor:
 
         f = Foo()
         f.has_ref = "stuff"
-        d = bcpd.BasicPropertyDescriptor("foo", f)
+        d = bcpd.PropertyDescriptor("foo", f)
         assert d.has_ref == "stuff"
 
-    @patch('bokeh.core.property.descriptors.BasicPropertyDescriptor._trigger')
+    @patch('bokeh.core.property.descriptors.PropertyDescriptor._trigger')
     def test__trigger(self, mock_trigger) -> None:
         class Foo:
             _property_values = dict(foo=10, bar=20)
@@ -262,8 +215,8 @@ class Test_BasicPropertyDescriptor:
             def matches(*args, **kw): return False
         m = Match()
         nm = NoMatch()
-        d1 = bcpd.BasicPropertyDescriptor("foo", m)
-        d2 = bcpd.BasicPropertyDescriptor("bar", nm)
+        d1 = bcpd.PropertyDescriptor("foo", m)
+        d2 = bcpd.PropertyDescriptor("bar", nm)
 
         d1.trigger_if_changed(Foo, "junk")
         assert not mock_trigger.called

--- a/tests/unit/bokeh/core/property/test_descriptors.py
+++ b/tests/unit/bokeh/core/property/test_descriptors.py
@@ -30,6 +30,7 @@ import bokeh.core.property.descriptors as bcpd # isort:skip
 #-----------------------------------------------------------------------------
 
 ALL = (
+    'AliasPropertyDescriptor',
     'ColumnDataPropertyDescriptor',
     'DataSpecPropertyDescriptor',
     'PropertyDescriptor',
@@ -237,6 +238,18 @@ class Test_UnitSpecDescriptor:
         assert d.property == f
         assert d.__doc__ == f.__doc__
         assert d.units_prop == g
+
+class Test_AliasSpecDescriptor:
+    def test___init__(self) -> None:
+        class Foo:
+            '''doc'''
+            pass
+        f = Foo()
+        d = bcpd.AliasPropertyDescriptor("foo", "bar", f)
+        assert d.name == "foo"
+        assert d.aliased_name == "bar"
+        assert d.property == f
+        assert d.__doc__ == "This is a compatibility alias for the ``bar`` property"
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/tests/unit/bokeh/core/test_has_props.py
+++ b/tests/unit/bokeh/core/test_has_props.py
@@ -20,10 +20,7 @@ from mock import patch
 # Bokeh imports
 from bokeh.core.properties import Alias, AngleSpec, Either, Int, List, Nullable, NumberSpec, Override, String
 from bokeh.core.property.dataspec import field, value
-from bokeh.core.property.descriptors import (
-    BasicPropertyDescriptor,
-    DataSpecPropertyDescriptor,
-)
+from bokeh.core.property.descriptors import PropertyDescriptor, DataSpecPropertyDescriptor
 from bokeh.core.property.singletons import Intrinsic
 
 # Module under test
@@ -283,13 +280,13 @@ def test_HasProps_set_error() -> None:
 def test_HasProps_lookup() -> None:
     p = Parent()
     d = p.lookup('int1')
-    assert isinstance(d, BasicPropertyDescriptor)
+    assert isinstance(d, PropertyDescriptor)
     assert d.name == 'int1'
     d = p.lookup('ds1')
     assert isinstance(d, DataSpecPropertyDescriptor)
     assert d.name == 'ds1'
     d = p.lookup('lst1')
-    assert isinstance(d, BasicPropertyDescriptor)
+    assert isinstance(d, PropertyDescriptor)
     assert d.name == 'lst1'
 
 def test_HasProps_apply_theme() -> None:

--- a/tests/unit/bokeh/core/test_has_props.py
+++ b/tests/unit/bokeh/core/test_has_props.py
@@ -249,8 +249,8 @@ def test_HasProps_update_from_json_passes_models_and_setter(mock_set) -> None:
     c = Child()
     c.update_from_json(dict(lst1=[1,2]), models="foo", setter="bar")
     assert mock_set.called
-    assert mock_set.call_args[0] == ('lst1', [1, 2], 'foo', 'bar')
-    assert mock_set.call_args[1] == {}
+    assert mock_set.call_args[0] == ('lst1', [1, 2])
+    assert mock_set.call_args[1] == {'models': 'foo', 'setter': 'bar'}
 
 def test_HasProps_set() -> None:
     c = Child()

--- a/tests/unit/bokeh/core/test_properties.py
+++ b/tests/unit/bokeh/core/test_properties.py
@@ -240,22 +240,18 @@ class Basictest:
 
         b = Base()
         assert {"child"} == b.properties_with_refs()
-        assert {"container"} == b.properties_containers()
         assert {"num", "container", "child"} == b.properties()
 
         m = Mixin()
         assert m.properties_with_refs() == {"mixin_child"}
-        assert m.properties_containers() == {"mixin_container"}
         assert m.properties() == {"mixin_num", "mixin_container", "mixin_child"}
 
         s = Sub()
         assert s.properties_with_refs() == {"child", "sub_child", "mixin_child"}
-        assert s.properties_containers() == {"container", "sub_container", "mixin_container"}
         assert s.properties() == {"num", "container", "child", "mixin_num", "mixin_container", "mixin_child", "sub_num", "sub_container", "sub_child"}
 
         # verify caching
         assert s.properties_with_refs() is s.properties_with_refs()
-        assert s.properties_containers() is s.properties_containers()
         assert s.properties() is s.properties()
 
     def test_accurate_dataspecs(self) -> None:

--- a/tests/unit/bokeh/core/test_properties.py
+++ b/tests/unit/bokeh/core/test_properties.py
@@ -21,6 +21,7 @@ import numpy as np
 from bokeh._testing.util.api import verify_all
 from bokeh.core.has_props import HasProps
 from bokeh.core.properties import (
+    Alias,
     Dict,
     Enum,
     Float,
@@ -480,6 +481,23 @@ def test_HasProps_clone() -> None:
     p2 = p1._clone()
     c2 = p2.properties_with_values(include_defaults=False)
     assert c1 == c2
+
+def test_Alias() -> None:
+    class Foo(HasProps):
+        x = Int(12)
+        ax = Alias('x')
+
+    f = Foo(x=10)
+    assert f.x == 10
+    assert f.ax == 10
+
+    f.x = 20
+    assert f.x == 20
+    assert f.ax == 20
+
+    f.ax = 30
+    assert f.x == 30
+    assert f.ax == 30
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/core/test_properties.py
+++ b/tests/unit/bokeh/core/test_properties.py
@@ -140,7 +140,7 @@ class TestBasic:
         assert f.s is None
 
 
-        assert {"x", "y", "z", "zz", "s"} == set(f.properties())
+        assert {"x", "y", "z", "zz", "s"} == f.properties()
         with_defaults = f.properties_with_values(include_defaults=True)
         assert dict(x=12, y="hello", z=[1,2,3], zz={}, s=None) == with_defaults
         without_defaults = f.properties_with_values(include_defaults=False)
@@ -233,15 +233,15 @@ class TestBasic:
 
         b = Base()
         assert {"child"} == set(b.properties_with_refs())
-        assert {"num", "container", "child"} == set(b.properties())
+        assert {"num", "container", "child"} == b.properties()
 
         m = Mixin()
         assert set(m.properties_with_refs()) == {"mixin_child"}
-        assert set(m.properties()) == {"mixin_num", "mixin_container", "mixin_child"}
+        assert m.properties() == {"mixin_num", "mixin_container", "mixin_child"}
 
         s = Sub()
         assert set(s.properties_with_refs()) == {"child", "sub_child", "mixin_child"}
-        assert set(s.properties()) == {"num", "container", "child", "mixin_num", "mixin_container", "mixin_child", "sub_num", "sub_container", "sub_child"}
+        assert s.properties() == {"num", "container", "child", "mixin_num", "mixin_container", "mixin_child", "sub_num", "sub_container", "sub_child"}
 
         # verify caching
         assert s.properties_with_refs() is s.properties_with_refs()

--- a/tests/unit/bokeh/test_objects.py
+++ b/tests/unit/bokeh/test_objects.py
@@ -153,7 +153,7 @@ class TestModel:
         testObject2 = self.pObjectClass()
         assert testObject2.id is not None
 
-        assert testObject.properties() == {
+        assert set(testObject.properties()) == {
             "name",
             "tags",
             "js_property_callbacks",


### PR DESCRIPTION
- [x] issues: fixes #10950
- [x] tests added / passed

This is the final PR for now to clean up and simplify `HasProps`:

* Consolidates `BasicPropertyDescriptor` down in to `PropertyDescriptor`. 
* Gets all the private sphinx links code outside of HasProps. This is also better because inheritance was the wrong tool for this. We need a default that can be overridden in isolated type, but not necessarily subtypes.
* Made `Alias` a proper property, removed gorpy special casing inside `HasProps`
* Adds `difflib` property typo suggestions to `__getattr__`

Finally this PR improves all the caching and property methods on `HasProps`. The basis is a new `properties` method that returns a dict that maps names to actual property objects. @mattpap it occurred to me that this this the best compromise since using this dict in a list context will preserve existing behavior. 

Other methods now also always return the same sort of mapping, just filtered appropriately (e.g. dataspecs, or with refs). All of these methods now use `@lru_cache` to cache results and removes all explicit caching.


Edit: I also added a minor optimization in `__getattr__` and `__setattr__`: A call to `lookup` takes ~2.5x as long as a call to `.properties` and needing to lookup (to check for *Python* property) is much rarer to need. So I split the condition and don't call `lookup` unless actually necessary.