### PR TITLE
Add exception raising for validation errors

### DIFF
--- a/bokeh/core/validation/__init__.py
+++ b/bokeh/core/validation/__init__.py
@@ -47,7 +47,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Bokeh imports
-from .check import check_integrity, silence, silenced
+from .check import check_integrity, process_validations, silence, silenced
 from .decorators import error, warning
 
 #-----------------------------------------------------------------------------

--- a/bokeh/core/validation/__init__.py
+++ b/bokeh/core/validation/__init__.py
@@ -47,7 +47,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Bokeh imports
-from .check import check_integrity, process_validations, silence, silenced
+from .check import check_integrity, process_validation_issues, silence, silenced
 from .decorators import error, warning
 
 #-----------------------------------------------------------------------------

--- a/bokeh/core/validation/check.py
+++ b/bokeh/core/validation/check.py
@@ -23,7 +23,7 @@ import contextlib
 from typing import Set
 
 # Bokeh imports
-from ..settings import settings
+from ...settings import settings
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -148,7 +148,6 @@ def process_validation_issues(issues):
         code, name, desc, obj = msg
         if code not in __silencers__:
             log.warning("W-%d (%s): %s: %s" % msg)
-
     if settings.validation_level() == "errors":
         if len(issues['error']):
             raise RuntimeError("Errors encountered during validation (see log output)")

--- a/bokeh/core/validation/check.py
+++ b/bokeh/core/validation/check.py
@@ -89,7 +89,7 @@ def is_silenced(warning):
         bool
 
     '''
-    return code[0] in __silencers__
+    return warning[0] in __silencers__
 
 @contextlib.contextmanager
 def silenced(warning: int) -> None:

--- a/bokeh/core/validation/check.py
+++ b/bokeh/core/validation/check.py
@@ -89,10 +89,7 @@ def is_silenced(warning):
         bool
 
     '''
-    if len(warning) > 0:
-        code = warning[0]
-        return code in __silencers__
-    return False
+    return code[0] in __silencers__
 
 @contextlib.contextmanager
 def silenced(warning: int) -> None:
@@ -173,7 +170,7 @@ def process_validation_issues(issues):
 
     error_messages = []
     for code, name, desc, obj in sorted(errors):
-        msg = f"W-{code} ({name}): {desc}: {obj}"
+        msg = f"E-{code} ({name}): {desc}: {obj}"
         error_messages.append(msg)
         log.error(msg)
 
@@ -182,7 +179,7 @@ def process_validation_issues(issues):
             raise RuntimeError(f"Errors encountered during validation: {error_messages}")
     elif settings.validation_level() == "all":
         if len(errors) or len(warnings):
-            raise RuntimeError(f"Errors encountered during validation: {error_messages} {warning_messages}")
+            raise RuntimeError(f"Errors encountered during validation: {error_messages+warning_messages}")
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/core/validation/check.py
+++ b/bokeh/core/validation/check.py
@@ -105,7 +105,13 @@ def check_integrity(models):
         >>> empty_row = Row
 
         >>> check_integrity([empty_row])
-        dict(warning = [(1002, EMPTY_LAYOUT, Layout has no children, Row(id='2404a029-c69b-4e30-9b7d-4b7b6cdaad5b', ...))])
+        {
+            "warning": [
+                (1002, EMPTY_LAYOUT, Layout has no children, Row(id='2404a029-c69b-4e30-9b7d-4b7b6cdaad5b', ...),
+                ...
+            ],
+            "error": [...]
+        }
 
     '''
     messages = dict(error=[], warning=[])
@@ -154,10 +160,7 @@ def process_validation_issues(issues):
     elif settings.validation_level() == "all":
         if len(issues['error']) or len(issues['warning']):
             raise RuntimeError("Errors encountered during validation (see log output)")
-    # Is this correct for discerning between raising exceptions for warnings vs errors?
-    # Is there a way for RuntimeError to occur on each warning and error specifically?
-    # We're a little confused on how to use silencers if RunTimeError just automatically
-    # raises exceptions on all errors and warnings
+
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------

--- a/bokeh/core/validation/check.py
+++ b/bokeh/core/validation/check.py
@@ -85,24 +85,24 @@ def silenced(warning: int) -> None:
         silence(warning, False)
 
 def check_integrity(models):
-    ''' Apply validation and integrity checks to a collection of Bokeh models.
+    ''' Collect all warnings associated with a collection of Bokeh models.
 
     Args:
         models (seq[Model]) : a collection of Models to test
 
     Returns:
-        None
+        A dictionary of all warning and error messages
 
-    This function will emit log warning and error messages for all error or
-    warning conditions that are detected. For example, layouts without any
-    children will trigger a warning:
+    This function will return a dictionary containing all errors or 
+    warning conditions that are detected. For example, layouts without
+    any children will add a warning to the dictionary:
 
     .. code-block:: python
 
         >>> empty_row = Row
 
         >>> check_integrity([empty_row])
-        W-1002 (EMPTY_LAYOUT): Layout has no children: Row(id='2404a029-c69b-4e30-9b7d-4b7b6cdaad5b', ...)
+        dict()
 
     '''
     messages = dict(error=[], warning=[])
@@ -117,10 +117,31 @@ def check_integrity(models):
         for func in validators:
             messages[func.validator_type].extend(func())
 
-    for msg in sorted(messages['error']):
+    return messages
+
+def process_validations(validations):
+    ''' Log warning and error messages for a dictionary containing warnings and error messages.
+
+    Args:
+        validations (dict(error=[], warning=[])) : A dictionary of all warning and error messages
+
+    Returns:
+        None
+
+    This function will emit log warning and error messages for all error or
+    warning conditions in the dictionary. For example, a dictionary 
+    containing a warning for empty layout will trigger a warning:
+
+    .. code-block:: python
+
+        >>> process_validation(validations)
+        W-1002 (EMPTY_LAYOUT): Layout has no children: Row(id='2404a029-c69b-4e30-9b7d-4b7b6cdaad5b', ...)
+
+    '''
+    for msg in sorted(validations['error']):
         log.error("E-%d (%s): %s: %s" % msg)
 
-    for msg in sorted(messages['warning']):
+    for msg in sorted(validations['warning']):
         code, name, desc, obj = msg
         if code not in __silencers__:
             log.warning("W-%d (%s): %s: %s" % msg)

--- a/bokeh/core/validation/check.py
+++ b/bokeh/core/validation/check.py
@@ -125,10 +125,6 @@ def check_integrity(models):
         if code not in __silencers__:
             log.warning("W-%d (%s): %s: %s" % msg)
 
-    # This will be turned on in a future release
-    # if len(messages['error']) or (len(messages['warning']) and settings.strict()):
-    #     raise RuntimeError("Errors encountered during validation (see log output)")
-
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------

--- a/bokeh/document/document.py
+++ b/bokeh/document/document.py
@@ -48,10 +48,9 @@ from ..core.has_props import is_DataModel
 from ..core.json_encoder import serialize_json
 from ..core.query import find
 from ..core.templates import FILE
-from ..core.validation import check_integrity, process_validations
+from ..core.validation import check_integrity, process_validation_issues
 from ..events import _CONCRETE_EVENT_CLASSES, DocumentEvent, Event
 from ..model import Model
-from ..settings import settings
 from ..themes import Theme, built_in_themes
 from ..themes import default as default_theme
 from ..util.callback_manager import _check_callback
@@ -970,16 +969,9 @@ class Document:
         '''
         for r in self.roots:
             refs = r.references()
-            validations = check_integrity(refs) 
+            issues = check_integrity(refs)
 
-            process_validations(validations)
-
-            if settings.validation_level() == "errors":
-                if len(validations['error']):
-                    raise RuntimeError("Errors encountered during validation (see log output)")
-            elif settings.validation_level() == "all":
-                if len(validations['error']) or len(validations['warning']):
-                    raise RuntimeError("Errors encountered during validation (see log output)")
+            process_validation_issues(issues)
 
     # Private methods ---------------------------------------------------------
 

--- a/bokeh/document/document.py
+++ b/bokeh/document/document.py
@@ -971,6 +971,10 @@ class Document:
             refs = r.references()
             check_integrity(refs)
 
+            # Currently not sure how to access messages inside this function
+            if len(messages['error']) or (len(messages['warning']) and settings.strict()):
+                raise RuntimeError("Errors encountered during validation (see log output)")
+
     # Private methods ---------------------------------------------------------
 
     def _add_session_callback(self, callback_obj, callback, one_shot, originator):

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -425,7 +425,7 @@ class PrioritizedSetting:
         if self._convert is convert_bool: return "Bool"
         if self._convert is convert_logging: return "Log Level"
         if self._convert is convert_str_seq: return "List[String]"
-        if self._convert is convert_validation: return "Validation Level String"
+        if self._convert is convert_validation: return "Validation Level"
 
 _config_user_locations = (
     join(expanduser("~"), ".bokeh", "bokeh.yaml"),

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -608,8 +608,15 @@ class Settings:
     A password to decrypt the SSL keyfile, if necessary.
     """)
 
-    strict = PrioritizedSetting("strict", "BOKEH_STRICT", convert=convert_bool, help="""
-    Whether validation checks should be strict (i.e. raise errors).
+    validation_exceptions = PrioritizedSetting("validation_exceptions", "BOKEH_VALIDATION_EXCEPTIONS", default="none", help="""
+    Whether validation checks should log or raise exceptions on errors and warnings.
+
+    Valid values are:
+
+    - ``none``: no exceptions raised (default)
+    - ``errors``: exception raised on errors (but not on warnings)
+    - ``all``: exception raised on both errors and warnings
+
     """)
 
     xsrf_cookies = PrioritizedSetting("xsrf_cookies", "BOKEH_XSRF_COOKIES", default=False, convert=convert_bool, help="""

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -96,7 +96,7 @@ RuntimeError will be raised.
 
 API
 ~~~
-d
+
 There are a few methods on the ``settings`` object:
 
 .. autoclass:: Settings

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -243,6 +243,28 @@ def convert_logging(value):
 
     raise ValueError("Cannot convert {} to log level, valid values are: {}".format(value, ", ".join(_log_levels)))
 
+def convert_validation(value):
+    '''Convert a string to a validation level string
+
+    If a validation level string is passed in, it is returned as-is.
+
+    Args:
+        value (str):
+            A string value to convert to a validation level string
+
+    Returns:
+        string
+
+    Raises:
+        ValueError
+
+    '''
+
+    if value.lower() == "none" or value.lower() == "errors" or value.lower() = "all":
+        return value.lower()
+
+    raise ValueError("Cannot convert {} to validation level string, valid values are: none, errors, all".format(value)
+
 class _Unset: pass
 
 def is_dev():
@@ -401,6 +423,7 @@ class PrioritizedSetting:
         if self._convert is convert_bool: return "Bool"
         if self._convert is convert_logging: return "Log Level"
         if self._convert is convert_str_seq: return "List[String]"
+        if self._convert is convert_validation: return "Validation Level String"
 
 _config_user_locations = (
     join(expanduser("~"), ".bokeh", "bokeh.yaml"),
@@ -608,7 +631,7 @@ class Settings:
     A password to decrypt the SSL keyfile, if necessary.
     """)
 
-    validation_level = PrioritizedSetting("validation_level", "BOKEH_VALIDATION_LEVEL", default="none",help="""
+    validation_level = PrioritizedSetting("validation_level", "BOKEH_VALIDATION_LEVEL", default="none", convert=convert_validation, help="""
     Whether validation checks should log or raise exceptions on errors and warnings.
 
     Valid values are:

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -244,13 +244,13 @@ def convert_logging(value):
     raise ValueError("Cannot convert {} to log level, valid values are: {}".format(value, ", ".join(_log_levels)))
 
 def convert_validation(value):
-    '''Convert a string to a validation level string
+    '''Convert a string to a validation level
 
-    If a validation level string is passed in, it is returned as-is.
+    If a validation level is passed in, it is returned as-is.
 
     Args:
         value (str):
-            A string value to convert to a validation level string
+            A string value to convert to a validation level
 
     Returns:
         string
@@ -259,10 +259,13 @@ def convert_validation(value):
         ValueError
 
     '''
-    if value.lower() == "none" or value.lower() == "errors" or value.lower() == "all":
-        return value.lower()
+    VALID_LEVELS = {"none", "errors", "all"}
 
-    raise ValueError("Cannot convert {} to validation level string, valid values are: none, errors, all".format(value))
+    lowered = value.lower()
+    if lowered in VALID_LEVELS:
+        return lowered
+
+    raise ValueError(f"Cannot convert {value!r} to validation level, valid values are: {VALID_LEVELS!r}")
 
 class _Unset: pass
 

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -96,7 +96,7 @@ RuntimeError will be raised.
 
 API
 ~~~
-
+d
 There are a few methods on the ``settings`` object:
 
 .. autoclass:: Settings
@@ -608,12 +608,12 @@ class Settings:
     A password to decrypt the SSL keyfile, if necessary.
     """)
 
-    validation_exceptions = PrioritizedSetting("validation_exceptions", "BOKEH_VALIDATION_EXCEPTIONS", default="none", help="""
+    validation_level = PrioritizedSetting("validation_level", "BOKEH_VALIDATION_LEVEL", default="none",help="""
     Whether validation checks should log or raise exceptions on errors and warnings.
 
     Valid values are:
 
-    - ``none``: no exceptions raised (default)
+    - ``none``: no exceptions raised (default).
     - ``errors``: exception raised on errors (but not on warnings)
     - ``all``: exception raised on both errors and warnings
 

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -259,11 +259,10 @@ def convert_validation(value):
         ValueError
 
     '''
-
-    if value.lower() == "none" or value.lower() == "errors" or value.lower() = "all":
+    if value.lower() == "none" or value.lower() == "errors" or value.lower() == "all":
         return value.lower()
 
-    raise ValueError("Cannot convert {} to validation level string, valid values are: none, errors, all".format(value)
+    raise ValueError("Cannot convert {} to validation level string, valid values are: none, errors, all".format(value))
 
 class _Unset: pass
 

--- a/tests/unit/bokeh/core/test_validation.py
+++ b/tests/unit/bokeh/core/test_validation.py
@@ -97,6 +97,21 @@ class Mod(Model):
     def _check_warning(self):
         if self.foo < -5: return "wrn"
 
+def test_check_integrity_pass() -> None:
+    m = Mod()
+    issues = {'error': [], 'warning': []}
+    assert v.check_integrity([m]) == issues    
+
+def test_check_integrity_error() -> None:
+    m = Mod(foo = 10)
+    issues = {'error': [(9999, 'EXT:E', 'Custom extension reports error', 'err')], 'warning': []}
+    assert v.check_integrity([m]) == issues 
+
+def test_check_integrity_warning() -> None:
+    m = Mod(foo = -10)
+    issues = {'error': [], 'warning': [(9999, 'EXT:W', 'Custom extension reports warning', 'wrn')]}
+    assert v.check_integrity([m]) == issues 
+
 @patch('bokeh.core.validation.check.log.error')
 @patch('bokeh.core.validation.check.log.warning')
 def test_check_pass(mock_warn, mock_error) -> None:
@@ -120,7 +135,7 @@ def test_check_error(mock_warn, mock_error) -> None:
 @patch('bokeh.core.validation.check.log.warning')
 def test_check_warn(mock_warn, mock_error) -> None:
     m = Mod(foo=-10)
-    issues = v.check_integrity([m])
+    issues = v.check_integrity([m])    
     v.process_validation_issues(issues)
     assert not mock_error.called
     assert mock_warn.called
@@ -195,6 +210,34 @@ def test_silence_remove_warning_that_is_not_in_silencers_is_ok(mock_warn, mock_e
     v.process_validation_issues(issues)
     assert not mock_error.called
     assert mock_warn.called
+
+@patch('bokeh.core.validation.check.log.error')
+@patch('bokeh.core.validation.check.log.warning')
+def test_process_validation_issues_pass(mock_warn, mock_error) -> None:
+    m = Mod()
+    issues = {'error': [], 'warning': []}
+    v.process_validation_issues(issues)
+    assert not mock_error.called
+    assert not mock_warn.called
+
+@patch('bokeh.core.validation.check.log.error')
+@patch('bokeh.core.validation.check.log.warning')
+def test_process_validation_issues_warn(mock_warn, mock_error) -> None:
+    m = Mod(foo=10)
+    issues = {'error': [(9999, 'EXT:E', 'Custom extension reports error', 'err')], 'warning': []}
+    v.process_validation_issues(issues)
+    assert mock_error.called
+    assert not mock_warn.called
+
+@patch('bokeh.core.validation.check.log.error')
+@patch('bokeh.core.validation.check.log.warning')
+def test_process_validation_issues_error(mock_warn, mock_error) -> None:
+    m = Mod(foo=-10)
+    issues = {'error': [], 'warning': [(9999, 'EXT:W', 'Custom extension reports warning', 'wrn')]}
+    v.process_validation_issues(issues)
+    assert not mock_error.called
+    assert mock_warn.called    
+
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/core/test_validation.py
+++ b/tests/unit/bokeh/core/test_validation.py
@@ -102,7 +102,8 @@ class Mod(Model):
 def test_check_pass(mock_warn, mock_error) -> None:
     m = Mod()
 
-    v.check_integrity([m])
+    issues = v.check_integrity([m])
+    v.process_validation_issues(issues)
     assert not mock_error.called
     assert not mock_warn.called
 
@@ -110,7 +111,8 @@ def test_check_pass(mock_warn, mock_error) -> None:
 @patch('bokeh.core.validation.check.log.warning')
 def test_check_error(mock_warn, mock_error) -> None:
     m = Mod(foo=10)
-    v.check_integrity([m])
+    issues = v.check_integrity([m])
+    v.process_validation_issues(issues)
     assert mock_error.called
     assert not mock_warn.called
 
@@ -118,7 +120,8 @@ def test_check_error(mock_warn, mock_error) -> None:
 @patch('bokeh.core.validation.check.log.warning')
 def test_check_warn(mock_warn, mock_error) -> None:
     m = Mod(foo=-10)
-    v.check_integrity([m])
+    issues = v.check_integrity([m])
+    v.process_validation_issues(issues)
     assert not mock_error.called
     assert mock_warn.called
 
@@ -129,12 +132,14 @@ def test_silence_and_check_warn(mock_warn, mock_error) -> None:
     m = Mod(foo=-10)
     try:
         v.silence(EXT)  # turn the warning off
-        v.check_integrity([m])
+        issues = v.check_integrity([m])
+        v.process_validation_issues(issues)
         assert not mock_error.called
         assert not mock_warn.called
     finally:
         v.silence(EXT, False)  # turn the warning back on
-        v.check_integrity([m])
+        issues = v.check_integrity([m])
+        v.process_validation_issues(issues)
         assert not mock_error.called
         assert mock_warn.called
 
@@ -145,7 +150,8 @@ def test_silence_with_bad_input_and_check_warn(mock_warn, mock_error) -> None:
     with pytest.raises(ValueError, match=('Input to silence should be a '
                                           'warning object')):
         v.silence('EXT:W')
-    v.check_integrity([m])
+    issues = v.check_integrity([m])
+    v.process_validation_issues(issues)
     assert not mock_error.called
     assert mock_warn.called
 
@@ -160,12 +166,14 @@ def test_silence_warning_already_in_silencers_is_ok(mock_warn, mock_error) -> No
         assert len(silencers0) == 1
         assert silencers0 == silencers1  # silencers is same as before
 
-        v.check_integrity([m])
+        issues = v.check_integrity([m])
+        v.process_validation_issues(issues)
         assert not mock_error.called
         assert not mock_warn.called
     finally:
         v.silence(EXT, False)  # turn the warning back on
-        v.check_integrity([m])
+        issues = v.check_integrity([m])
+        v.process_validation_issues(issues)
         assert not mock_error.called
         assert mock_warn.called
 
@@ -183,7 +191,8 @@ def test_silence_remove_warning_that_is_not_in_silencers_is_ok(mock_warn, mock_e
     assert len(silencers1) == 0
     assert silencers1 == silencers2
 
-    v.check_integrity([m])
+    issues = v.check_integrity([m])
+    v.process_validation_issues(issues)
     assert not mock_error.called
     assert mock_warn.called
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/core/test_validation.py
+++ b/tests/unit/bokeh/core/test_validation.py
@@ -100,17 +100,17 @@ class Mod(Model):
 def test_check_integrity_pass() -> None:
     m = Mod()
     issues = {'error': [], 'warning': []}
-    assert v.check_integrity([m]) == issues    
+    assert v.check_integrity([m]) == issues
 
 def test_check_integrity_error() -> None:
     m = Mod(foo = 10)
     issues = {'error': [(9999, 'EXT:E', 'Custom extension reports error', 'err')], 'warning': []}
-    assert v.check_integrity([m]) == issues 
+    assert v.check_integrity([m]) == issues
 
 def test_check_integrity_warning() -> None:
     m = Mod(foo = -10)
     issues = {'error': [], 'warning': [(9999, 'EXT:W', 'Custom extension reports warning', 'wrn')]}
-    assert v.check_integrity([m]) == issues 
+    assert v.check_integrity([m]) == issues
 
 @patch('bokeh.core.validation.check.log.error')
 @patch('bokeh.core.validation.check.log.warning')
@@ -135,7 +135,7 @@ def test_check_error(mock_warn, mock_error) -> None:
 @patch('bokeh.core.validation.check.log.warning')
 def test_check_warn(mock_warn, mock_error) -> None:
     m = Mod(foo=-10)
-    issues = v.check_integrity([m])    
+    issues = v.check_integrity([m])
     v.process_validation_issues(issues)
     assert not mock_error.called
     assert mock_warn.called
@@ -236,7 +236,7 @@ def test_process_validation_issues_error(mock_warn, mock_error) -> None:
     issues = {'error': [], 'warning': [(9999, 'EXT:W', 'Custom extension reports warning', 'wrn')]}
     v.process_validation_issues(issues)
     assert not mock_error.called
-    assert mock_warn.called    
+    assert mock_warn.called
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/tests/unit/bokeh/core/test_validation.py
+++ b/tests/unit/bokeh/core/test_validation.py
@@ -214,7 +214,6 @@ def test_silence_remove_warning_that_is_not_in_silencers_is_ok(mock_warn, mock_e
 @patch('bokeh.core.validation.check.log.error')
 @patch('bokeh.core.validation.check.log.warning')
 def test_process_validation_issues_pass(mock_warn, mock_error) -> None:
-    m = Mod()
     issues = {'error': [], 'warning': []}
     v.process_validation_issues(issues)
     assert not mock_error.called
@@ -223,7 +222,6 @@ def test_process_validation_issues_pass(mock_warn, mock_error) -> None:
 @patch('bokeh.core.validation.check.log.error')
 @patch('bokeh.core.validation.check.log.warning')
 def test_process_validation_issues_warn(mock_warn, mock_error) -> None:
-    m = Mod(foo=10)
     issues = {'error': [(9999, 'EXT:E', 'Custom extension reports error', 'err')], 'warning': []}
     v.process_validation_issues(issues)
     assert mock_error.called
@@ -232,7 +230,6 @@ def test_process_validation_issues_warn(mock_warn, mock_error) -> None:
 @patch('bokeh.core.validation.check.log.error')
 @patch('bokeh.core.validation.check.log.warning')
 def test_process_validation_issues_error(mock_warn, mock_error) -> None:
-    m = Mod(foo=-10)
     issues = {'error': [], 'warning': [(9999, 'EXT:W', 'Custom extension reports warning', 'wrn')]}
     v.process_validation_issues(issues)
     assert not mock_error.called

--- a/tests/unit/bokeh/models/test_annotations.py
+++ b/tests/unit/bokeh/models/test_annotations.py
@@ -35,7 +35,7 @@ from _util_models import (
     prefix,
 )
 from bokeh.core.properties import field, value
-from bokeh.core.validation import check_integrity
+from bokeh.core.validation import check_integrity, process_validation_issues
 from bokeh.models import (
     Arrow,
     ArrowHead,
@@ -500,7 +500,8 @@ def test_can_add_multiple_glyph_renderers_to_legend_item() -> None:
     gr_2 = GlyphRenderer(data_source=ColumnDataSource())
     legend_item.renderers = [gr_1, gr_2]
     with mock.patch('bokeh.core.validation.check.log') as mock_logger:
-        check_integrity([legend_item])
+        issues = check_integrity([legend_item])
+        process_validation_issues(issues)
         assert mock_logger.error.call_count == 0
 
 
@@ -511,7 +512,8 @@ def test_legend_item_with_field_label_and_different_data_sources_raises_a_valida
     legend_item.label = field('label')
     legend_item.renderers = [gr_1, gr_2]
     with mock.patch('bokeh.core.validation.check.log') as mock_logger:
-        check_integrity([legend_item])
+        issues = check_integrity([legend_item])
+        process_validation_issues(issues)
         assert mock_logger.error.call_count == 1
 
 
@@ -522,7 +524,8 @@ def test_legend_item_with_value_label_and_different_data_sources_does_not_raise_
     legend_item.label = value('label')
     legend_item.renderers = [gr_1, gr_2]
     with mock.patch('bokeh.core.validation.check.log') as mock_logger:
-        check_integrity([legend_item])
+        issues = check_integrity([legend_item])
+        process_validation_issues(issues)
         assert mock_logger.error.call_count == 0
 
 
@@ -532,7 +535,8 @@ def test_legend_item_with_field_label_raises_error_if_field_not_in_cds() -> None
     legend_item.label = field('label')
     legend_item.renderers = [gr_1]
     with mock.patch('bokeh.core.validation.check.log') as mock_logger:
-        check_integrity([legend_item])
+        issues = check_integrity([legend_item])
+        process_validation_issues(issues)
         assert mock_logger.error.call_count == 1
 
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/models/test_mappers.py
+++ b/tests/unit/bokeh/models/test_mappers.py
@@ -19,7 +19,7 @@ from mock import patch
 
 # Bokeh imports
 from _util_models import check_properties_existence
-from bokeh.core.validation import check_integrity
+from bokeh.core.validation import check_integrity, process_validation_issues
 from bokeh.palettes import Spectral6
 
 # Module under test
@@ -50,7 +50,8 @@ class Test_CategoricalColorMapper:
     @patch("bokeh.core.validation.check.log.warning")
     def test_warning_with_short_palette(self, mock_warn, mock_error) -> None:
         m = bmm.CategoricalColorMapper(factors=["a", "b", "c"], palette=["red", "green"])
-        check_integrity([m])
+        issues = check_integrity([m])
+        process_validation_issues(issues)
         assert not mock_error.called
         assert mock_warn.called
 
@@ -58,7 +59,8 @@ class Test_CategoricalColorMapper:
     @patch("bokeh.core.validation.check.log.warning")
     def test_no_warning_with_long_palette(self, mock_warn, mock_error) -> None:
         m = bmm.CategoricalColorMapper(factors=["a", "b", "c"], palette=["red", "green", "orange", "blue"])
-        check_integrity([m])
+        issues = check_integrity([m])
+        process_validation_issues(issues)
         assert not mock_error.called
         assert not mock_warn.called
 

--- a/tests/unit/bokeh/models/test_plots.py
+++ b/tests/unit/bokeh/models/test_plots.py
@@ -19,7 +19,7 @@ import mock
 from mock import patch
 
 # Bokeh imports
-from bokeh.core.validation import check_integrity
+from bokeh.core.validation import check_integrity, process_validation_issues
 from bokeh.models import (
     CategoricalScale,
     CustomJS,
@@ -135,7 +135,8 @@ class TestPlotValidation:
         p = figure()
         p.renderers = []
         with mock.patch('bokeh.core.validation.check.log') as mock_logger:
-            check_integrity([p])
+            issues = check_integrity([p])
+            process_validation_issues(issues)
         assert mock_logger.warning.call_count == 1
         assert mock_logger.warning.call_args[0][0].startswith("W-1000 (MISSING_RENDERERS): Plot has no renderers")
 
@@ -161,7 +162,8 @@ class TestPlotValidation:
         p = figure()
         p.xaxis.x_range_name="junk"
         with mock.patch('bokeh.core.validation.check.log') as mock_logger:
-            check_integrity([p])
+            issues = check_integrity([p])
+            process_validation_issues(issues)
         assert mock_logger.error.call_count == 1
         assert mock_logger.error.call_args[0][0].startswith(
             "E-1020 (BAD_EXTRA_RANGE_NAME): An extra range name is configued with a name that does not correspond to any range: x_range_name='junk' [LinearAxis"
@@ -171,7 +173,8 @@ class TestPlotValidation:
         p.extra_x_ranges['foo'] = Range1d()
         p.grid.x_range_name="junk"
         with mock.patch('bokeh.core.validation.check.log') as mock_logger:
-            check_integrity([p])
+            issues = check_integrity([p])
+            process_validation_issues(issues)
         assert mock_logger.error.call_count == 1
         assert mock_logger.error.call_args[0][0].startswith(
             "E-1020 (BAD_EXTRA_RANGE_NAME): An extra range name is configued with a name that does not correspond to any range: x_range_name='junk' [Grid"
@@ -186,7 +189,8 @@ class TestPlotValidation:
         dep.grid.x_range_name="foo"
         p.grid[0].js_on_change("dimension", CustomJS(code = "", args = {"toto": dep.grid[0]}))
         with mock.patch('bokeh.core.validation.check.log') as mock_logger:
-            check_integrity([p])
+            issues = check_integrity([p])
+            process_validation_issues(issues)
         assert mock_logger.error.call_count == 0
 
 def test_plot_add_layout_raises_error_if_not_render() -> None:

--- a/tests/unit/bokeh/models/test_ranges.py
+++ b/tests/unit/bokeh/models/test_ranges.py
@@ -22,7 +22,7 @@ import mock
 
 # Bokeh imports
 from _util_models import check_properties_existence
-from bokeh.core.validation import check_integrity
+from bokeh.core.validation import check_integrity, process_validation_issues
 
 # Module under test
 from bokeh.models import Range1d, DataRange1d, FactorRange # isort:skip
@@ -228,17 +228,20 @@ class Test_FactorRange:
     def test_duplicate_factors_raises_validation_error(self) -> None:
         r = FactorRange("foo", "bar", "foo")
         with mock.patch('bokeh.core.validation.check.log') as mock_logger:
-            check_integrity([r])
+            issues = check_integrity([r])
+            process_validation_issues(issues)
         assert mock_logger.error.call_count == 1
 
         r = FactorRange(factors=[("foo", "a"), ("foo", "b"),  ("foo", "a")])
         with mock.patch('bokeh.core.validation.check.log') as mock_logger:
-            check_integrity([r])
+            issues = check_integrity([r])
+            process_validation_issues(issues)
         assert mock_logger.error.call_count == 1
 
         r = FactorRange(factors=[("foo", "a", "1"), ("foo", "a", "2"),  ("foo", "a", "1")])
         with mock.patch('bokeh.core.validation.check.log') as mock_logger:
-            check_integrity([r])
+            issues = check_integrity([r])
+            process_validation_issues(issues)
         assert mock_logger.error.call_count == 1
 
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/models/widgets/test_slider.py
+++ b/tests/unit/bokeh/models/widgets/test_slider.py
@@ -20,7 +20,7 @@ from datetime import date, datetime
 
 # Bokeh imports
 from bokeh.core.properties import UnsetValueError
-from bokeh.core.validation.check import check_integrity
+from bokeh.core.validation.check import check_integrity, process_validation_issues
 from bokeh.util.logconfig import basicConfig
 from bokeh.util.serialization import convert_date_to_datetime, convert_datetime_type
 
@@ -76,7 +76,8 @@ class TestRangeSlider:
         with caplog.at_level(logging.ERROR):
             assert len(caplog.records) == 0
             s.end = 0
-            check_integrity([s])
+            issues = check_integrity([s])
+            process_validation_issues(issues)
             assert len(caplog.records) == 1
 
 class TestDateSlider:

--- a/tests/unit/bokeh/test_layouts.py
+++ b/tests/unit/bokeh/test_layouts.py
@@ -18,7 +18,7 @@ import pytest ; pytest
 import mock
 
 # Bokeh imports
-from bokeh.core.validation import check_integrity
+from bokeh.core.validation import check_integrity, process_validation_issues
 from bokeh.layouts import GridSpec, column, grid, gridplot, layout, row
 from bokeh.models import Column, GridBox, LayoutDOM, Row, Spacer
 from bokeh.plotting import figure
@@ -171,7 +171,8 @@ def test_grid() -> None:
 def test_repeated_children() -> None:
     def test(layout: LayoutDOM) -> None:
         with mock.patch("bokeh.core.validation.check.log") as mock_logger:
-            check_integrity([layout])
+            issues = check_integrity([layout])
+            process_validation_issues(issues)
         assert mock_logger.error.call_count == 1
         assert mock_logger.error.call_args[0][0].startswith("E-1027 (REPEATED_LAYOUT_CHILD): The same model can't be used multiple times in a layout")
 

--- a/tests/unit/bokeh/test_settings.py
+++ b/tests/unit/bokeh/test_settings.py
@@ -163,6 +163,10 @@ class TestConverters:
     def test_convert_validation_good(self, value) -> None:
         assert bs.convert_validation(value) == value
 
+    def test_convert_validation_bad(self) -> None:
+        with pytest.raises(ValueError):
+            bs.convert_validation("junk")
+
 class TestPrioritizedSetting:
     def test_env_var_property(self) -> None:
         ps = bs.PrioritizedSetting("foo", env_var="BOKEH_FOO")

--- a/tests/unit/bokeh/test_settings.py
+++ b/tests/unit/bokeh/test_settings.py
@@ -94,7 +94,7 @@ class TestSettings:
 
         assert bs.settings.py_log_level.convert_type == "Log Level"
 
-        assert bs.settings.validation_level.convert_type == "Validation Level String"
+        assert bs.settings.validation_level.convert_type == "Validation Level"
 
         assert bs.settings.allowed_ws_origin.convert_type == "List[String]"
 

--- a/tests/unit/bokeh/test_settings.py
+++ b/tests/unit/bokeh/test_settings.py
@@ -65,7 +65,7 @@ _expected_settings = (
     'ssl_certfile',
     'ssl_keyfile',
     'ssl_password',
-    'strict',
+    'validation_level',
     'xsrf_cookies',
 )
 
@@ -90,10 +90,11 @@ class TestSettings:
         assert bs.settings.minified.convert_type == "Bool"
         assert bs.settings.perform_document_validation.convert_type == "Bool"
         assert bs.settings.simple_ids.convert_type == "Bool"
-        assert bs.settings.strict.convert_type == "Bool"
         assert bs.settings.xsrf_cookies.convert_type == "Bool"
 
         assert bs.settings.py_log_level.convert_type == "Log Level"
+
+        assert bs.settings.validation_level.convert_type == "Validation Level String"
 
         assert bs.settings.allowed_ws_origin.convert_type == "List[String]"
 
@@ -103,7 +104,7 @@ class TestSettings:
             'minified',
             'perform_document_validation',
             'simple_ids',
-            'strict',
+            'validation_level',
             'py_log_level',
             'allowed_ws_origin',
             'xsrf_cookies',
@@ -157,6 +158,10 @@ class TestConverters:
     def test_convert_logging_bad(self) -> None:
         with pytest.raises(ValueError):
             bs.convert_logging("junk")
+
+    @pytest.mark.parametrize("value", ["none", "errors", "all"])
+    def test_convert_validation_good(self, value) -> None:
+        assert bs.convert_validation(value) == value
 
 class TestPrioritizedSetting:
     def test_env_var_property(self) -> None:


### PR DESCRIPTION
Work in progress for issue #10733 

Added exception raising for validation errors and warnings and replaced env variable BOKEH_STRICT with BOKEH_VALIDATION_EXCEPTIONS

In a comment on the issue page (https://github.com/bokeh/bokeh/issues/10733#issuecomment-735002152), it was initially recommended for check_integrity to only be for returning messages, and to punt the potential exception raising downstream to the caller to avoid a muddled API. 
However, after changing BOKEH_STRICT to  BOKEH_VALIDATION EXCEPTIONS as recommended in this comment (https://github.com/bokeh/bokeh/issues/10733#issuecomment-735003520), I noticed that if potential exception raising was left in the caller, I wouldn't be able to access messages to check for a warning or error. In the original pull request made for this issue I saw a comment (https://github.com/bokeh/bokeh/pull/10780#r550380992) that said everything should be handled inside check_integrity, and so I was wondering if I should be doing potential exception raising in check_integrity? If not, how should I go about accessing messages from the validate function in document.py?
