### PR TITLE
Update "LogTickFormatter" to accept "min_exponent"

### DIFF
--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -286,6 +286,12 @@ class LogTickFormatter(TickFormatter):
     base to use. If unset, the formatter will use base 10 as a default.
     """)
 
+    min_exponent = Either(List(Int), Int, default=0, help="""
+    Minimum exponent to format in scientific notation.
+    If this is of type Int, the ticks from base^-(n-1) to base^(n-1) are printed without exponent.
+    Else the smallest value sets the lower bound, the highest value the upper one.
+    """)
+
 class CategoricalTickFormatter(TickFormatter):
     ''' Display tick values from categorical ranges as string
     values.

--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -286,10 +286,8 @@ class LogTickFormatter(TickFormatter):
     base to use. If unset, the formatter will use base 10 as a default.
     """)
 
-    min_exponent = Either(List(Int), Int, default=0, help="""
+    min_exponent = Int(0, help="""
     Minimum exponent to format in scientific notation.
-    If this is of type Int, the ticks from base^-(n-1) to base^(n-1) are printed without exponent.
-    Else the smallest value sets the lower bound, the highest value the upper one.
     """)
 
 class CategoricalTickFormatter(TickFormatter):

--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -289,7 +289,7 @@ class LogTickFormatter(TickFormatter):
     min_exponent = Int(0, help="""
     Minimum exponent to format in scientific notation. If not zero
     all ticks in range from base^-min_expont to base^min_exponent 
-    are printet without exponential notation.
+    are displayed without exponential notation.
     """)
 
 class CategoricalTickFormatter(TickFormatter):

--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -287,7 +287,9 @@ class LogTickFormatter(TickFormatter):
     """)
 
     min_exponent = Int(0, help="""
-    Minimum exponent to format in scientific notation.
+    Minimum exponent to format in scientific notation. If not zero
+    all ticks in range from base^-min_expont to base^min_exponent 
+    are printet without exponential notation.
     """)
 
 class CategoricalTickFormatter(TickFormatter):

--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -288,7 +288,7 @@ class LogTickFormatter(TickFormatter):
 
     min_exponent = Int(0, help="""
     Minimum exponent to format in scientific notation. If not zero
-    all ticks in range from base^-min_expont to base^min_exponent 
+    all ticks in range from base^-min_expont to base^min_exponent
     are displayed without exponential notation.
     """)
 

--- a/bokehjs/src/lib/models/formatters/log_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/log_tick_formatter.ts
@@ -53,8 +53,7 @@ export class LogTickFormatter extends TickFormatter {
           const b = new TextBox({text: unicode_replace(`${base**expo}`)})
           const e = new TextBox({text: ''})
           return new BaseExpo(b, e)
-        }
-        else {
+        } else {
           const b = new TextBox({text: unicode_replace(`${base}`)})
           const e = new TextBox({text: unicode_replace(`${expo}`)})
           return new BaseExpo(b, e)
@@ -91,6 +90,6 @@ export class LogTickFormatter extends TickFormatter {
           return unicode_replace(`${base**expo}`)
         else
           return unicode_replace(`${base}^${expo}`)
-    })
+      })
   }
 }

--- a/bokehjs/src/lib/models/formatters/log_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/log_tick_formatter.ts
@@ -50,13 +50,14 @@ export class LogTickFormatter extends TickFormatter {
     else {
       return expos.map((expo) => {
         if (abs(expo)<this.min_exponent){
-            const b = new TextBox({text: unicode_replace(`${base**expo}`)})
-            const e = new TextBox({text: ''})
-            return new BaseExpo(b, e)
-        }else{
-            const b = new TextBox({text: unicode_replace(`${base}`)})
-            const e = new TextBox({text: unicode_replace(`${expo}`)})
-            return new BaseExpo(b, e)
+          const b = new TextBox({text: unicode_replace(`${base**expo}`)})
+          const e = new TextBox({text: ''})
+          return new BaseExpo(b, e)
+        }
+        else {
+          const b = new TextBox({text: unicode_replace(`${base}`)})
+          const e = new TextBox({text: unicode_replace(`${expo}`)})
+          return new BaseExpo(b, e)
         }
       })
     }
@@ -90,7 +91,6 @@ export class LogTickFormatter extends TickFormatter {
           return unicode_replace(`${base**expo}`)
         else
           return unicode_replace(`${base}^${expo}`)
-      }
-    )
+    })
   }
 }

--- a/bokehjs/src/lib/models/formatters/log_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/log_tick_formatter.ts
@@ -4,14 +4,14 @@ import {LogTicker} from "../tickers/log_ticker"
 import {GraphicsBox, BaseExpo, TextBox} from "core/graphics"
 import * as p from "core/properties"
 
-const {min, max, log, round} = Math
+const {abs, log, round} = Math
 
 export namespace LogTickFormatter {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = TickFormatter.Props & {
     ticker: p.Property<LogTicker | null>
-    min_exponent: p.Property<number[] | number>
+    min_exponent: p.Property<number>
   }
 }
 
@@ -25,9 +25,9 @@ export class LogTickFormatter extends TickFormatter {
   }
 
   static init_LogTickFormatter(): void {
-    this.define<LogTickFormatter.Props>(({Or, Int, Array, Ref, Nullable}) => ({
+    this.define<LogTickFormatter.Props>(({Int, Ref, Nullable}) => ({
       ticker: [ Nullable(Ref(LogTicker)), null ],
-      min_exponent: [ Or(Array(Int), Int), 0 ],
+      min_exponent: [ Int, 0 ],
     }))
   }
 
@@ -48,10 +48,8 @@ export class LogTickFormatter extends TickFormatter {
     if (expos == null)
       return this.basic_formatter.format_graphics(ticks, opts)
     else {
-      let _low = (this.min_exponent.constructor === Array) ? min(...this.min_exponent) : -this.min_exponent
-      let _high = (this.min_exponent.constructor === Array) ? max(...this.min_exponent) : this.min_exponent
       return expos.map((expo) => {
-        if (_low<expo && expo<_high){
+        if (abs(expo)<this.min_exponent){
             const b = new TextBox({text: unicode_replace(`${base**expo}`)})
             const e = new TextBox({text: ''})
             return new BaseExpo(b, e)
@@ -87,11 +85,8 @@ export class LogTickFormatter extends TickFormatter {
     if (expos == null)
       return this.basic_formatter.doFormat(ticks, opts)
     else
-      console.log(this.min_exponent)
-      let _low = (this.min_exponent.constructor === Array) ?  min(...this.min_exponent) : -this.min_exponent
-      let _high = (this.min_exponent.constructor === Array) ?  max(...this.min_exponent) : this.min_exponent
       return expos.map((expo) => {
-        if (_low<expo && expo<_high)
+        if (abs(expo)<this.min_exponent)
           return unicode_replace(`${base**expo}`)
         else
           return unicode_replace(`${base}^${expo}`)

--- a/bokehjs/test/unit/models/formatters/log_tick_formatter.ts
+++ b/bokehjs/test/unit/models/formatters/log_tick_formatter.ts
@@ -22,7 +22,7 @@ describe("FuncTickFormatter", () => {
       const labels = formatter.doFormat([0.001, 0.1, 1, 10, 100], {loc: 0})
       expect(labels).to.be.equal(["10^-3", "0.1", "1", "10", "10^2"])
     })
-      
+
     it("should format numerical ticks appropriately with min_exponent equals 3 and base 2", () => {
       const ticker = new LogTicker({base: 2})
       const formatter = new LogTickFormatter({ticker: ticker, min_exponent: 3})

--- a/bokehjs/test/unit/models/formatters/log_tick_formatter.ts
+++ b/bokehjs/test/unit/models/formatters/log_tick_formatter.ts
@@ -5,22 +5,22 @@ import {LogTicker} from "@bokehjs/models/tickers/log_ticker"
 
 describe("FuncTickFormatter", () => {
   describe("doFormat method", () => {
-    it("should format numerical ticks appropriately", () => {
+    it("should format numerical ticks appropriately with min_exponent equals 0 by default", () => {
       const formatter = new LogTickFormatter()
       const labels = formatter.doFormat([0.001, 0.1, 1, 10, 100], {loc: 0})
-      expect(labels).to.be.equal(["10^\u22123", "10^\u22121", "10^0", "10^1", "10^2"])
+      expect(labels).to.be.equal(["10^−3", "10^−1", "10^0", "10^1", "10^2"])
     })
 
     it("should format numerical ticks appropriately with min_exponent equals 1", () => {
       const formatter = new LogTickFormatter({min_exponent: 1})
       const labels = formatter.doFormat([0.001, 0.1, 1, 10, 100], {loc: 0})
-      expect(labels).to.be.equal(["10^\u22123", "10^\u22121", "1", "10^1", "10^2"])
+      expect(labels).to.be.equal(["10^−3", "10^−1", "1", "10^1", "10^2"])
     })
 
     it("should format numerical ticks appropriately with min_exponent equals 2", () => {
       const formatter = new LogTickFormatter({min_exponent: 2})
       const labels = formatter.doFormat([0.001, 0.1, 1, 10, 100], {loc: 0})
-      expect(labels).to.be.equal(["10^\u22123", "0.1", "1", "10", "10^2"])
+      expect(labels).to.be.equal(["10^−3", "0.1", "1", "10", "10^2"])
     })
 
     it("should format numerical ticks appropriately with min_exponent equals 3 and base 2", () => {

--- a/bokehjs/test/unit/models/formatters/log_tick_formatter.ts
+++ b/bokehjs/test/unit/models/formatters/log_tick_formatter.ts
@@ -8,19 +8,19 @@ describe("FuncTickFormatter", () => {
     it("should format numerical ticks appropriately", () => {
       const formatter = new LogTickFormatter()
       const labels = formatter.doFormat([0.001, 0.1, 1, 10, 100], {loc: 0})
-      expect(labels).to.be.equal(["10^-3", "10^-1", "10^0", "10^1", "10^2"])
+      expect(labels).to.be.equal(["10^\u22123", "10^\u22121", "10^0", "10^1", "10^2"])
     })
 
     it("should format numerical ticks appropriately with min_exponent equals 1", () => {
       const formatter = new LogTickFormatter({min_exponent: 1})
       const labels = formatter.doFormat([0.001, 0.1, 1, 10, 100], {loc: 0})
-      expect(labels).to.be.equal(["10^-3", "10^-1", "1", "10^1", "10^2"])
+      expect(labels).to.be.equal(["10^\u22123", "10^\u22121", "1", "10^1", "10^2"])
     })
 
     it("should format numerical ticks appropriately with min_exponent equals 2", () => {
       const formatter = new LogTickFormatter({min_exponent: 2})
       const labels = formatter.doFormat([0.001, 0.1, 1, 10, 100], {loc: 0})
-      expect(labels).to.be.equal(["10^-3", "0.1", "1", "10", "10^2"])
+      expect(labels).to.be.equal(["10^\u22123", "0.1", "1", "10", "10^2"])
     })
 
     it("should format numerical ticks appropriately with min_exponent equals 3 and base 2", () => {

--- a/bokehjs/test/unit/models/formatters/log_tick_formatter.ts
+++ b/bokehjs/test/unit/models/formatters/log_tick_formatter.ts
@@ -1,0 +1,32 @@
+import {expect} from "assertions"
+
+import {LogTickFormatter} from "@bokehjs/models/formatters/log_tick_formatter"
+import {LogTicker} from "@bokehjs/models/tickers/log_tickers"
+
+describe("FuncTickFormatter", () => {
+  describe("doFormat method", () => {
+    it("should format numerical ticks appropriately", () => {
+      const formatter = new LogTickFormatter()
+      const labels = formatter.doFormat([0.001, 0.1, 1, 10, 100])
+      expect(labels).to.be.equal(["10^-3", "10^-1", "10^0", "10^1", "10^2"])
+    })
+
+    it("should format numerical ticks appropriately with min_exponent equals 1", () => {
+      const formatter = new LogTickFormatter({min_exponent: 1})
+      const labels = formatter.doFormat([0.001, 0.1, 1, 10, 100])
+      expect(labels).to.be.equal(["10^-3", "10^-1", "1", "10^1", "10^2"])
+    })
+
+    it("should format numerical ticks appropriately with min_exponent equals 2", () => {
+      const formatter = new LogTickFormatter({min_exponent: 2})
+      const labels = formatter.doFormat([0.001, 0.1, 1, 10, 100])
+      expect(labels).to.be.equal(["10^-3", "0.1", "1", "10", "10^2"])
+    })
+      
+    it("should format numerical ticks appropriately with min_exponent equals 3 and base 2", () => {
+      const formatter = new LogTickFormatter({ticker: LogTicker({base: 2}), min_exponent: 3})
+      const labels = formatter.doFormat([1, 4, 16, 64, 256])
+      expect(labels).to.be.equal(["1", "4", "2^4", "2^6", "2^8"])
+    })
+  })
+})

--- a/bokehjs/test/unit/models/formatters/log_tick_formatter.ts
+++ b/bokehjs/test/unit/models/formatters/log_tick_formatter.ts
@@ -1,31 +1,31 @@
 import {expect} from "assertions"
 
 import {LogTickFormatter} from "@bokehjs/models/formatters/log_tick_formatter"
-import {LogTicker} from "@bokehjs/models/tickers/log_tickers"
+import {LogTicker} from "@bokehjs/models/tickers/log_ticker"
 
 describe("FuncTickFormatter", () => {
   describe("doFormat method", () => {
     it("should format numerical ticks appropriately", () => {
       const formatter = new LogTickFormatter()
-      const labels = formatter.doFormat([0.001, 0.1, 1, 10, 100])
+      const labels = formatter.doFormat([0.001, 0.1, 1, 10, 100], {loc: 0})
       expect(labels).to.be.equal(["10^-3", "10^-1", "10^0", "10^1", "10^2"])
     })
 
     it("should format numerical ticks appropriately with min_exponent equals 1", () => {
       const formatter = new LogTickFormatter({min_exponent: 1})
-      const labels = formatter.doFormat([0.001, 0.1, 1, 10, 100])
+      const labels = formatter.doFormat([0.001, 0.1, 1, 10, 100], {loc: 0})
       expect(labels).to.be.equal(["10^-3", "10^-1", "1", "10^1", "10^2"])
     })
 
     it("should format numerical ticks appropriately with min_exponent equals 2", () => {
       const formatter = new LogTickFormatter({min_exponent: 2})
-      const labels = formatter.doFormat([0.001, 0.1, 1, 10, 100])
+      const labels = formatter.doFormat([0.001, 0.1, 1, 10, 100], {loc: 0})
       expect(labels).to.be.equal(["10^-3", "0.1", "1", "10", "10^2"])
     })
       
     it("should format numerical ticks appropriately with min_exponent equals 3 and base 2", () => {
       const formatter = new LogTickFormatter({ticker: LogTicker({base: 2}), min_exponent: 3})
-      const labels = formatter.doFormat([1, 4, 16, 64, 256])
+      const labels = formatter.doFormat([1, 4, 16, 64, 256], {loc: 0})
       expect(labels).to.be.equal(["1", "4", "2^4", "2^6", "2^8"])
     })
   })

--- a/bokehjs/test/unit/models/formatters/log_tick_formatter.ts
+++ b/bokehjs/test/unit/models/formatters/log_tick_formatter.ts
@@ -24,7 +24,8 @@ describe("FuncTickFormatter", () => {
     })
       
     it("should format numerical ticks appropriately with min_exponent equals 3 and base 2", () => {
-      const formatter = new LogTickFormatter({ticker: LogTicker({base: 2}), min_exponent: 3})
+      const ticker = new LogTicker({base: 2})
+      const formatter = new LogTickFormatter({ticker: ticker, min_exponent: 3})
       const labels = formatter.doFormat([1, 4, 16, 64, 256], {loc: 0})
       expect(labels).to.be.equal(["1", "4", "2^4", "2^6", "2^8"])
     })

--- a/bokehjs/test/unit/models/formatters/log_tick_formatter.ts
+++ b/bokehjs/test/unit/models/formatters/log_tick_formatter.ts
@@ -25,7 +25,7 @@ describe("FuncTickFormatter", () => {
 
     it("should format numerical ticks appropriately with min_exponent equals 3 and base 2", () => {
       const ticker = new LogTicker({base: 2})
-      const formatter = new LogTickFormatter({ticker: ticker, min_exponent: 3})
+      const formatter = new LogTickFormatter({ticker, min_exponent: 3})
       const labels = formatter.doFormat([1, 4, 16, 64, 256], {loc: 0})
       expect(labels).to.be.equal(["1", "4", "2^4", "2^6", "2^8"])
     })


### PR DESCRIPTION
This is the JS side to enable "min_exponent" if an axis is logarithmic.
- [ ] issues: fixes #11007
