### PR TITLE
Collect performance metrics during integration tests

### DIFF
--- a/bokehjs/test/.gitignore
+++ b/bokehjs/test/.gitignore
@@ -1,3 +1,1 @@
-/baselines/linux/report.json
-/baselines/macos/report.json
-/baselines/windows/report.json
+/baselines/*/report.json

--- a/bokehjs/test/devtools/metrics.html
+++ b/bokehjs/test/devtools/metrics.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>{{ title }}</title>
+    <style>
+      html, body {
+        box-sizing: border-box;
+      }
+
+      *, *:before, *:after {
+        box-sizing: inherit;
+      }
+
+      *, *:before, *:after {
+        margin: 0;
+        border: 0;
+        padding: 0;
+        background-image: none;
+      }
+    </style>
+    <script type="text/javascript" src="{{ js('bokeh') }}"></script>
+    <script type="text/javascript" src="{{ js('bokeh-api') }}"></script>
+  </head>
+  <body>
+    <script type="text/javascript">
+      const metrics = {{ metrics | dump | safe }}
+
+      const plots = []
+      for (const [name, y] of Object.entries(metrics)) {
+        const p = Bokeh.Plotting.figure({title: name, width: 800, height: 200})
+        p.y_range.start = 0
+        const x = Bokeh.LinAlg.range(y.length)
+        p.line(x, y)
+        plots.push([p])
+      }
+
+      const layout = Bokeh.Plotting.gridplot(plots)
+      Bokeh.Plotting.show(layout)
+    </script>
+  </body>
+</html>

--- a/bokehjs/test/devtools/report.html
+++ b/bokehjs/test/devtools/report.html
@@ -58,7 +58,7 @@
       <div class="header">Current</div>
       <div class="header">Diff</div>
       <div class="header">Reference</div>
-    {%- for description, status in tests %}
+    {%- for description, status in results %}
       {%- if status.failure %}
       <div class="description">{{ description | join(" ⇒ ") }}</div>
       <img src="data:image/png;base64,{{ status.image }}"></img>


### PR DESCRIPTION
This finally takes advantage of devtools' protocol beyond simple remote execution of javascript, and allows collection of certain performance metrics during evaluation of integration tests (e.g. JS heap utilization, DOM node count, event listener count, etc.).  Metrics are collected after each test. Results are available at http://localhost:5777/integration/metrics (similarly test report http://localhost:5777/integration/report). One can view metrics for specific platform with `?platform=linux` (or `windows`, `macos`).

The presentation is very rudimentary at this time.

![image](https://user-images.githubusercontent.com/27475/115953366-4f525e00-a4eb-11eb-9e87-2a9c9035bdcb.png)
