### PR TITLE
Ensure downstream build checks out all git tags

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -431,6 +431,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: 'latest'


### PR DESCRIPTION
The downstream CI build is sporadically failing because some downstream projects (e.g. `dask`) will try to do some `bokeh` version parsing which fails (xref the discussion starting here https://github.com/bokeh/bokeh/pull/11207#issuecomment-827133948). This _might_ be because GitHub actions isn't checking out all the `bokeh` git tags which results in `versioneer` getting `bokeh`s version incorrect. 
