### PR TITLE
Add support for lazy annotations boilerplate

### DIFF
--- a/bokeh/__init__.py
+++ b/bokeh/__init__.py
@@ -31,6 +31,8 @@ attributes:
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/__main__.py
+++ b/bokeh/__main__.py
@@ -22,6 +22,8 @@ is equivalent to
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/_testing/__init__.py
+++ b/bokeh/_testing/__init__.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/_testing/plugins/__init__.py
+++ b/bokeh/_testing/plugins/__init__.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/_testing/plugins/bokeh_server.py
+++ b/bokeh/_testing/plugins/bokeh_server.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/_testing/plugins/file_server.py
+++ b/bokeh/_testing/plugins/file_server.py
@@ -14,6 +14,8 @@ tests.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/_testing/plugins/ipython.py
+++ b/bokeh/_testing/plugins/ipython.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/_testing/plugins/jupyter_notebook.py
+++ b/bokeh/_testing/plugins/jupyter_notebook.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/_testing/plugins/log_file.py
+++ b/bokeh/_testing/plugins/log_file.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/_testing/plugins/managed_server_loop.py
+++ b/bokeh/_testing/plugins/managed_server_loop.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/_testing/plugins/pandas.py
+++ b/bokeh/_testing/plugins/pandas.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/_testing/plugins/project.py
+++ b/bokeh/_testing/plugins/project.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/_testing/plugins/selenium.py
+++ b/bokeh/_testing/plugins/selenium.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/_testing/util/api.py
+++ b/bokeh/_testing/util/api.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/_testing/util/compare.py
+++ b/bokeh/_testing/util/compare.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/_testing/util/examples.py
+++ b/bokeh/_testing/util/examples.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/_testing/util/filesystem.py
+++ b/bokeh/_testing/util/filesystem.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/_testing/util/screenshot.py
+++ b/bokeh/_testing/util/screenshot.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/_testing/util/selenium.py
+++ b/bokeh/_testing/util/selenium.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/application/__init__.py
+++ b/bokeh/application/__init__.py
@@ -17,6 +17,8 @@ method of any ``Handler`` objects that it is configured with.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/application/application.py
+++ b/bokeh/application/application.py
@@ -19,6 +19,8 @@ updated the Document, it is used to service the user session.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/application/handlers/__init__.py
+++ b/bokeh/application/handlers/__init__.py
@@ -12,6 +12,8 @@ Documents when sessions are created.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/application/handlers/code.py
+++ b/bokeh/application/handlers/code.py
@@ -29,6 +29,8 @@ applications that run off scripts and notebooks.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/application/handlers/code_runner.py
+++ b/bokeh/application/handlers/code_runner.py
@@ -12,6 +12,8 @@ Python source code.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/application/handlers/directory.py
+++ b/bokeh/application/handlers/directory.py
@@ -38,6 +38,8 @@ A full directory layout might look like:
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/application/handlers/document_lifecycle.py
+++ b/bokeh/application/handlers/document_lifecycle.py
@@ -12,6 +12,8 @@ on the Document.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/application/handlers/function.py
+++ b/bokeh/application/handlers/function.py
@@ -32,6 +32,8 @@ For complete examples of this technique, see
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/application/handlers/handler.py
+++ b/bokeh/application/handlers/handler.py
@@ -37,6 +37,8 @@ based off information in some database:
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/application/handlers/lifecycle.py
+++ b/bokeh/application/handlers/lifecycle.py
@@ -12,6 +12,8 @@ in a specified Python module.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/application/handlers/notebook.py
+++ b/bokeh/application/handlers/notebook.py
@@ -19,6 +19,8 @@ notebook code is executed, the Document being modified will be available as
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/application/handlers/request_handler.py
+++ b/bokeh/application/handlers/request_handler.py
@@ -12,6 +12,8 @@ in a specified Python module.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/application/handlers/script.py
+++ b/bokeh/application/handlers/script.py
@@ -36,6 +36,8 @@ Documents by adding an empty plot with a title taken from ``args``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/application/handlers/server_lifecycle.py
+++ b/bokeh/application/handlers/server_lifecycle.py
@@ -12,6 +12,8 @@ in a specified Python module.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/application/handlers/server_request_handler.py
+++ b/bokeh/application/handlers/server_request_handler.py
@@ -12,6 +12,8 @@ in a specified Python module.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/client/__init__.py
+++ b/bokeh/client/__init__.py
@@ -21,6 +21,8 @@ server using ``bokeh.client``, this practice is **HIGHLY DISCOURAGED**.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/client/connection.py
+++ b/bokeh/client/connection.py
@@ -15,6 +15,8 @@ instead for standard usage.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/client/session.py
+++ b/bokeh/client/session.py
@@ -24,6 +24,8 @@ A client session has two primary uses:
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/client/states.py
+++ b/bokeh/client/states.py
@@ -12,6 +12,8 @@ to a Bokeh server.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/client/util.py
+++ b/bokeh/client/util.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/client/websocket.py
+++ b/bokeh/client/websocket.py
@@ -12,6 +12,8 @@ and smooths some compatibility issues.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/colors/__init__.py
+++ b/bokeh/colors/__init__.py
@@ -12,6 +12,8 @@ define common named colors.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/colors/color.py
+++ b/bokeh/colors/color.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/colors/groups.py
+++ b/bokeh/colors/groups.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/colors/hsl.py
+++ b/bokeh/colors/hsl.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/colors/named.py
+++ b/bokeh/colors/named.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/colors/rgb.py
+++ b/bokeh/colors/rgb.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/colors/util.py
+++ b/bokeh/colors/util.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/command/bootstrap.py
+++ b/bokeh/command/bootstrap.py
@@ -33,6 +33,8 @@ The following are equivalent:
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/command/subcommand.py
+++ b/bokeh/command/subcommand.py
@@ -12,6 +12,8 @@ line application.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/command/subcommands/__init__.py
+++ b/bokeh/command/subcommands/__init__.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/command/subcommands/file_output.py
+++ b/bokeh/command/subcommands/file_output.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/command/subcommands/info.py
+++ b/bokeh/command/subcommands/info.py
@@ -43,6 +43,8 @@ This will produce output like what is shown below
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/command/subcommands/json.py
+++ b/bokeh/command/subcommands/json.py
@@ -38,6 +38,8 @@ indentation level with the ``--indent`` argument:
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/command/subcommands/sampledata.py
+++ b/bokeh/command/subcommands/sampledata.py
@@ -30,6 +30,8 @@ included in Bokeh's sample data.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/command/subcommands/secret.py
+++ b/bokeh/command/subcommands/secret.py
@@ -26,6 +26,8 @@ the ``BOKEH_SECRET_KEY`` environment variable.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -400,6 +400,8 @@ logging stats is 0 (disabled). Only positive integer values are accepted.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/command/subcommands/static.py
+++ b/bokeh/command/subcommands/static.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/command/util.py
+++ b/bokeh/command/util.py
@@ -10,6 +10,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/enums.py
+++ b/bokeh/core/enums.py
@@ -63,6 +63,8 @@ Enumerations can be easily documented in Sphinx documentation with the
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/has_props.py
+++ b/bokeh/core/has_props.py
@@ -18,6 +18,8 @@ serializable properties.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/json_encoder.py
+++ b/bokeh/core/json_encoder.py
@@ -43,6 +43,8 @@ In general, functions in this module convert values in the following way:
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -170,6 +170,8 @@ to control when type validation occurs.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/__init__.py
+++ b/bokeh/core/property/__init__.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/alias.py
+++ b/bokeh/core/property/alias.py
@@ -15,6 +15,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/any.py
+++ b/bokeh/core/property/any.py
@@ -14,6 +14,8 @@ any validation.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/auto.py
+++ b/bokeh/core/property/auto.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/bases.py
+++ b/bokeh/core/property/bases.py
@@ -17,6 +17,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/color.py
+++ b/bokeh/core/property/color.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/container.py
+++ b/bokeh/core/property/container.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/dataspec.py
+++ b/bokeh/core/property/dataspec.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/datetime.py
+++ b/bokeh/core/property/datetime.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/descriptor_factory.py
+++ b/bokeh/core/property/descriptor_factory.py
@@ -47,6 +47,8 @@ details around validation, serialization, and documentation.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/descriptors.py
+++ b/bokeh/core/property/descriptors.py
@@ -79,6 +79,8 @@ that can be used to attach Bokeh properties to Bokeh models.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/either.py
+++ b/bokeh/core/property/either.py
@@ -14,6 +14,8 @@ multiple possible types.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/enum.py
+++ b/bokeh/core/property/enum.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/factors.py
+++ b/bokeh/core/property/factors.py
@@ -9,6 +9,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/include.py
+++ b/bokeh/core/property/include.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/instance.py
+++ b/bokeh/core/property/instance.py
@@ -14,6 +14,8 @@ where one Bokeh model refers to another.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/json.py
+++ b/bokeh/core/property/json.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/nullable.py
+++ b/bokeh/core/property/nullable.py
@@ -9,6 +9,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/numeric.py
+++ b/bokeh/core/property/numeric.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/override.py
+++ b/bokeh/core/property/override.py
@@ -16,6 +16,8 @@ attributes.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/pandas.py
+++ b/bokeh/core/property/pandas.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/primitive.py
+++ b/bokeh/core/property/primitive.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/readonly.py
+++ b/bokeh/core/property/readonly.py
@@ -9,6 +9,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/singletons.py
+++ b/bokeh/core/property/singletons.py
@@ -9,6 +9,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/string.py
+++ b/bokeh/core/property/string.py
@@ -13,6 +13,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/struct.py
+++ b/bokeh/core/property/struct.py
@@ -12,6 +12,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/validation.py
+++ b/bokeh/core/property/validation.py
@@ -14,6 +14,8 @@ where one Bokeh model refers to another.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/visual.py
+++ b/bokeh/core/property/visual.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property/wrappers.py
+++ b/bokeh/core/property/wrappers.py
@@ -54,6 +54,8 @@ The classes in this module provide this functionality.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/property_mixins.py
+++ b/bokeh/core/property_mixins.py
@@ -61,6 +61,8 @@ specific to each property.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/query.py
+++ b/bokeh/core/query.py
@@ -12,6 +12,8 @@ models for instances that match specified criteria.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/templates.py
+++ b/bokeh/core/templates.py
@@ -26,6 +26,8 @@ models in various ways.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/validation/__init__.py
+++ b/bokeh/core/validation/__init__.py
@@ -39,6 +39,8 @@ function provided.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/validation/check.py
+++ b/bokeh/core/validation/check.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/validation/decorators.py
+++ b/bokeh/core/validation/decorators.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/validation/errors.py
+++ b/bokeh/core/validation/errors.py
@@ -106,6 +106,8 @@ validation checks.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/core/validation/warnings.py
+++ b/bokeh/core/validation/warnings.py
@@ -24,6 +24,8 @@ validation checks.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/document/__init__.py
+++ b/bokeh/document/__init__.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/document/document.py
+++ b/bokeh/document/document.py
@@ -24,6 +24,8 @@ figure below:
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/document/events.py
+++ b/bokeh/document/events.py
@@ -15,6 +15,8 @@ for :ref:`bokeh.events`.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/document/locking.py
+++ b/bokeh/document/locking.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/document/util.py
+++ b/bokeh/document/util.py
@@ -12,6 +12,8 @@ documents.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/driving.py
+++ b/bokeh/driving.py
@@ -36,6 +36,8 @@ Example:
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/embed/__init__.py
+++ b/bokeh/embed/__init__.py
@@ -12,6 +12,8 @@ web pages.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/embed/bundle.py
+++ b/bokeh/embed/bundle.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/embed/elements.py
+++ b/bokeh/embed/elements.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/embed/notebook.py
+++ b/bokeh/embed/notebook.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/embed/server.py
+++ b/bokeh/embed/server.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/embed/standalone.py
+++ b/bokeh/embed/standalone.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/embed/util.py
+++ b/bokeh/embed/util.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/embed/wrappers.py
+++ b/bokeh/embed/wrappers.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/events.py
+++ b/bokeh/events.py
@@ -56,6 +56,8 @@ event object that triggered the callback.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/io/__init__.py
+++ b/bokeh/io/__init__.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/io/doc.py
+++ b/bokeh/io/doc.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/io/export.py
+++ b/bokeh/io/export.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/io/notebook.py
+++ b/bokeh/io/notebook.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/io/output.py
+++ b/bokeh/io/output.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/io/saving.py
+++ b/bokeh/io/saving.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/io/showing.py
+++ b/bokeh/io/showing.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/io/state.py
+++ b/bokeh/io/state.py
@@ -34,6 +34,8 @@ ensures their proper configuration in many common usage scenarios.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/io/util.py
+++ b/bokeh/io/util.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/io/webdriver.py
+++ b/bokeh/io/webdriver.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/layouts.py
+++ b/bokeh/layouts.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/model.py
+++ b/bokeh/model.py
@@ -11,6 +11,8 @@ a Bokeh |Document|.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/__init__.py
+++ b/bokeh/models/__init__.py
@@ -20,6 +20,8 @@ a Bokeh scene graph are called :ref:`Models <bokeh.model>`.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -11,6 +11,8 @@ Bokeh plots
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/arrow_heads.py
+++ b/bokeh/models/arrow_heads.py
@@ -12,6 +12,8 @@ Arrow annotations.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/axes.py
+++ b/bokeh/models/axes.py
@@ -12,6 +12,8 @@ Bokeh plots
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/callbacks.py
+++ b/bokeh/models/callbacks.py
@@ -12,6 +12,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/expressions.py
+++ b/bokeh/models/expressions.py
@@ -31,6 +31,8 @@ browser by the JavaScript implementation of ``some_expression`` using a
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/filters.py
+++ b/bokeh/models/filters.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -12,6 +12,8 @@ labels on Bokeh plot axes.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/glyph.py
+++ b/bokeh/models/glyph.py
@@ -18,6 +18,8 @@ All these glyphs share a minimal common interface through their base class
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -27,6 +27,8 @@ All glyphs share a minimal common interface through the base class ``Glyph``:
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/grids.py
+++ b/bokeh/models/grids.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/labeling.py
+++ b/bokeh/models/labeling.py
@@ -9,6 +9,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/layouts.py
+++ b/bokeh/models/layouts.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/map_plots.py
+++ b/bokeh/models/map_plots.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/mappers.py
+++ b/bokeh/models/mappers.py
@@ -13,6 +13,8 @@ Mappers (as opposed to scales) are not presumed to be invertible.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/markers.py
+++ b/bokeh/models/markers.py
@@ -47,6 +47,8 @@ and ``hatch`` properties.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/ranges.py
+++ b/bokeh/models/ranges.py
@@ -13,6 +13,8 @@ and with options for "auto sizing".
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/renderers.py
+++ b/bokeh/models/renderers.py
@@ -11,6 +11,8 @@ types that Bokeh supports.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/scales.py
+++ b/bokeh/models/scales.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/selections.py
+++ b/bokeh/models/selections.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/textures.py
+++ b/bokeh/models/textures.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/tickers.py
+++ b/bokeh/models/tickers.py
@@ -12,6 +12,8 @@ of plots.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/tiles.py
+++ b/bokeh/models/tiles.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -30,6 +30,8 @@ always be active regardless of what other tools are currently active.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/transforms.py
+++ b/bokeh/models/transforms.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/util/__init__.py
+++ b/bokeh/models/util/__init__.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/widgets/__init__.py
+++ b/bokeh/models/widgets/__init__.py
@@ -9,6 +9,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/widgets/buttons.py
+++ b/bokeh/models/widgets/buttons.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/widgets/groups.py
+++ b/bokeh/models/widgets/groups.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/widgets/icons.py
+++ b/bokeh/models/widgets/icons.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/widgets/markups.py
+++ b/bokeh/models/widgets/markups.py
@@ -17,6 +17,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/widgets/panels.py
+++ b/bokeh/models/widgets/panels.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/widgets/sliders.py
+++ b/bokeh/models/widgets/sliders.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/widgets/tables.py
+++ b/bokeh/models/widgets/tables.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/models/widgets/widget.py
+++ b/bokeh/models/widgets/widget.py
@@ -16,6 +16,8 @@ in the browser,  or with python callbacks that execute on a Bokeh server.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/palettes.py
+++ b/bokeh/palettes.py
@@ -342,6 +342,8 @@ source file.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/plotting/__init__.py
+++ b/bokeh/plotting/__init__.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/plotting/_decorators.py
+++ b/bokeh/plotting/_decorators.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/plotting/_docstring.py
+++ b/bokeh/plotting/_docstring.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/plotting/_graph.py
+++ b/bokeh/plotting/_graph.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/plotting/_legends.py
+++ b/bokeh/plotting/_legends.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/plotting/_plot.py
+++ b/bokeh/plotting/_plot.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/plotting/_renderer.py
+++ b/bokeh/plotting/_renderer.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/plotting/_stack.py
+++ b/bokeh/plotting/_stack.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/plotting/_tools.py
+++ b/bokeh/plotting/_tools.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/plotting/figure.py
+++ b/bokeh/plotting/figure.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/plotting/gmap.py
+++ b/bokeh/plotting/gmap.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/plotting/graph.py
+++ b/bokeh/plotting/graph.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/protocol/__init__.py
+++ b/bokeh/protocol/__init__.py
@@ -12,6 +12,8 @@ Servers and clients.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/protocol/exceptions.py
+++ b/bokeh/protocol/exceptions.py
@@ -12,6 +12,8 @@ messages.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/protocol/message.py
+++ b/bokeh/protocol/message.py
@@ -47,6 +47,8 @@ The ``content`` fragment is defined by the specific message type.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/protocol/messages/__init__.py
+++ b/bokeh/protocol/messages/__init__.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/protocol/messages/ack.py
+++ b/bokeh/protocol/messages/ack.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/protocol/messages/error.py
+++ b/bokeh/protocol/messages/error.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/protocol/messages/ok.py
+++ b/bokeh/protocol/messages/ok.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/protocol/messages/patch_doc.py
+++ b/bokeh/protocol/messages/patch_doc.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/protocol/messages/pull_doc_reply.py
+++ b/bokeh/protocol/messages/pull_doc_reply.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/protocol/messages/pull_doc_req.py
+++ b/bokeh/protocol/messages/pull_doc_req.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/protocol/messages/push_doc.py
+++ b/bokeh/protocol/messages/push_doc.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/protocol/messages/server_info_reply.py
+++ b/bokeh/protocol/messages/server_info_reply.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/protocol/messages/server_info_req.py
+++ b/bokeh/protocol/messages/server_info_req.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/protocol/receiver.py
+++ b/bokeh/protocol/receiver.py
@@ -12,6 +12,8 @@ message objects that can be processed.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -24,6 +24,8 @@ Attributes:
 # -----------------------------------------------------------------------------
 # Boilerplate
 # -----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/sampledata/__init__.py
+++ b/bokeh/sampledata/__init__.py
@@ -41,6 +41,8 @@ This will cause the sample data to be stored in ``/tmp/bokeh_data``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/airport_routes.py
+++ b/bokeh/sampledata/airport_routes.py
@@ -23,6 +23,8 @@ This module contains two pandas Dataframes: ``airports`` and ``routes``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/airports.py
+++ b/bokeh/sampledata/airports.py
@@ -19,6 +19,8 @@ This module contains one pandas Dataframe: ``data``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/autompg.py
+++ b/bokeh/sampledata/autompg.py
@@ -24,6 +24,8 @@ The "clean" version has cleaned up the ``"mfr"`` and ``"origin"`` fields.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/autompg2.py
+++ b/bokeh/sampledata/autompg2.py
@@ -19,6 +19,8 @@ This module contains one pandas Dataframe: ``autompg``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/browsers.py
+++ b/bokeh/sampledata/browsers.py
@@ -24,6 +24,8 @@ logos for Chrome, Firefox, Safari, Opera, and IE.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/commits.py
+++ b/bokeh/sampledata/commits.py
@@ -17,6 +17,8 @@ This module contains one pandas Dataframe: ``data``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/daylight.py
+++ b/bokeh/sampledata/daylight.py
@@ -19,6 +19,8 @@ This module contains one pandas Dataframe: ``daylight_warsaw_2013``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/degrees.py
+++ b/bokeh/sampledata/degrees.py
@@ -19,6 +19,8 @@ This module contains one pandas Dataframe: ``data``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/gapminder.py
+++ b/bokeh/sampledata/gapminder.py
@@ -37,6 +37,8 @@ This module contains four pandas Dataframes: ``fertility``, ``life_expectancy``,
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/glucose.py
+++ b/bokeh/sampledata/glucose.py
@@ -17,6 +17,8 @@ This module contains one pandas Dataframe: ``data``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/haar_cascade.py
+++ b/bokeh/sampledata/haar_cascade.py
@@ -15,6 +15,8 @@ recognition that can be used by OpenCV.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/iris.py
+++ b/bokeh/sampledata/iris.py
@@ -17,6 +17,8 @@ This module contains one pandas Dataframe: ``flowers``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/les_mis.py
+++ b/bokeh/sampledata/les_mis.py
@@ -32,6 +32,8 @@ This module contains one dictionary: ``data``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/movies_data.py
+++ b/bokeh/sampledata/movies_data.py
@@ -19,6 +19,8 @@ to a SQLite database with the data.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/mtb.py
+++ b/bokeh/sampledata/mtb.py
@@ -17,6 +17,8 @@ This module contains one pandas Dataframe: ``obiszow_mtb_xcm``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/olympics2014.py
+++ b/bokeh/sampledata/olympics2014.py
@@ -24,6 +24,8 @@ country:
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/perceptions.py
+++ b/bokeh/sampledata/perceptions.py
@@ -25,6 +25,8 @@ This module contains two pandas Dataframes: ``probly`` and ``numberly``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/periodic_table.py
+++ b/bokeh/sampledata/periodic_table.py
@@ -17,6 +17,8 @@ This module contains one pandas Dataframe: ``elements``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/population.py
+++ b/bokeh/sampledata/population.py
@@ -23,6 +23,8 @@ This module contains one pandas Dataframe: ``data``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/sample_geojson.py
+++ b/bokeh/sampledata/sample_geojson.py
@@ -18,6 +18,8 @@ A snapshot of data available from NHS Choices on November 14th, 2015.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/sea_surface_temperature.py
+++ b/bokeh/sampledata/sea_surface_temperature.py
@@ -17,6 +17,8 @@ This module contains one pandas Dataframe: ``sea_surface_temperature``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/sprint.py
+++ b/bokeh/sampledata/sprint.py
@@ -17,6 +17,8 @@ This module contains one pandas Dataframe: ``sprint``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/stocks.py
+++ b/bokeh/sampledata/stocks.py
@@ -25,6 +25,8 @@ Each dictionary has the structure:
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/unemployment.py
+++ b/bokeh/sampledata/unemployment.py
@@ -24,6 +24,8 @@ has the unemployment rate (2009) as the value.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/unemployment1948.py
+++ b/bokeh/sampledata/unemployment1948.py
@@ -17,6 +17,8 @@ This module contains one pandas Dataframe: ``data``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/us_cities.py
+++ b/bokeh/sampledata/us_cities.py
@@ -18,6 +18,8 @@ This module contains one dict: ``data``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/us_counties.py
+++ b/bokeh/sampledata/us_counties.py
@@ -30,6 +30,8 @@ The combination of ``'detailed name'`` and ``'state'`` will always be unique.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/us_holidays.py
+++ b/bokeh/sampledata/us_holidays.py
@@ -28,6 +28,8 @@ This module contains one list: ``us_holidays``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/us_marriages_divorces.py
+++ b/bokeh/sampledata/us_marriages_divorces.py
@@ -22,6 +22,8 @@ This module contains one pandas Dataframe: ``data``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/us_states.py
+++ b/bokeh/sampledata/us_states.py
@@ -27,6 +27,8 @@ following structure:
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sampledata/world_cities.py
+++ b/bokeh/sampledata/world_cities.py
@@ -23,6 +23,8 @@ This module contains one pandas Dataframe: ``data``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/server/auth_provider.py
+++ b/bokeh/server/auth_provider.py
@@ -5,6 +5,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/server/callbacks.py
+++ b/bokeh/server/callbacks.py
@@ -12,6 +12,8 @@ Bokeh Documents and Sessions.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/server/connection.py
+++ b/bokeh/server/connection.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/server/contexts.py
+++ b/bokeh/server/contexts.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/server/django/consumers.py
+++ b/bokeh/server/django/consumers.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/server/django/routing.py
+++ b/bokeh/server/django/routing.py
@@ -9,6 +9,8 @@
 # Boilerplate
 #-----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/server/django/static.py
+++ b/bokeh/server/django/static.py
@@ -9,6 +9,8 @@
 # Boilerplate
 #-----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/server/protocol_handler.py
+++ b/bokeh/server/protocol_handler.py
@@ -12,6 +12,8 @@ receive.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/server/server.py
+++ b/bokeh/server/server.py
@@ -23,6 +23,8 @@ There are two public classes in this module:
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/server/session.py
+++ b/bokeh/server/session.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/server/urls.py
+++ b/bokeh/server/urls.py
@@ -45,6 +45,8 @@ built-in ``HTTPServer``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/server/util.py
+++ b/bokeh/server/util.py
@@ -12,6 +12,8 @@ components in ``bokeh.server``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/server/views/auth_mixin.py
+++ b/bokeh/server/views/auth_mixin.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/server/views/autoload_js_handler.py
+++ b/bokeh/server/views/autoload_js_handler.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/server/views/doc_handler.py
+++ b/bokeh/server/views/doc_handler.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/server/views/metadata_handler.py
+++ b/bokeh/server/views/metadata_handler.py
@@ -12,6 +12,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/server/views/multi_root_static_handler.py
+++ b/bokeh/server/views/multi_root_static_handler.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/server/views/root_handler.py
+++ b/bokeh/server/views/root_handler.py
@@ -12,6 +12,8 @@ or (if only one) redirects to the route of that applications.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/server/views/session_handler.py
+++ b/bokeh/server/views/session_handler.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/server/views/static_handler.py
+++ b/bokeh/server/views/static_handler.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/server/views/ws.py
+++ b/bokeh/server/views/ws.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -107,6 +107,8 @@ There are a few methods on the ``settings`` object:
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/sphinxext/bokeh_autodoc.py
+++ b/bokeh/sphinxext/bokeh_autodoc.py
@@ -20,6 +20,8 @@ configured:
 # -----------------------------------------------------------------------------
 # Boilerplate
 # -----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/sphinxext/bokeh_color.py
+++ b/bokeh/sphinxext/bokeh_color.py
@@ -24,6 +24,8 @@ in conjunction with the :ref:`bokeh.sphinxext.bokeh_autodoc` extension.
 # -----------------------------------------------------------------------------
 # Boilerplate
 # -----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/sphinxext/bokeh_dataframe.py
+++ b/bokeh/sphinxext/bokeh_dataframe.py
@@ -24,6 +24,8 @@ Will generate the output:
 # -----------------------------------------------------------------------------
 # Boilerplate
 # -----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/sphinxext/bokeh_directive.py
+++ b/bokeh/sphinxext/bokeh_directive.py
@@ -11,6 +11,8 @@
 # -----------------------------------------------------------------------------
 # Boilerplate
 # -----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/sphinxext/bokeh_enum.py
+++ b/bokeh/sphinxext/bokeh_enum.py
@@ -44,6 +44,8 @@ the same output above will be generated directly from the following code:
 # -----------------------------------------------------------------------------
 # Boilerplate
 # -----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/sphinxext/bokeh_gallery.py
+++ b/bokeh/sphinxext/bokeh_gallery.py
@@ -11,6 +11,8 @@
 # -----------------------------------------------------------------------------
 # Boilerplate
 # -----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/sphinxext/bokeh_jinja.py
+++ b/bokeh/sphinxext/bokeh_jinja.py
@@ -25,6 +25,8 @@ generate the following output:
 # -----------------------------------------------------------------------------
 # Boilerplate
 # -----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/sphinxext/bokeh_model.py
+++ b/bokeh/sphinxext/bokeh_model.py
@@ -43,6 +43,8 @@ in conjunction with the :ref:`bokeh.sphinxext.bokeh_autodoc` extension.
 # -----------------------------------------------------------------------------
 # Boilerplate
 # -----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/sphinxext/bokeh_options.py
+++ b/bokeh/sphinxext/bokeh_options.py
@@ -40,6 +40,8 @@ the above usage yields the output:
 # -----------------------------------------------------------------------------
 # Boilerplate
 # -----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/sphinxext/bokeh_palette.py
+++ b/bokeh/sphinxext/bokeh_palette.py
@@ -51,6 +51,8 @@ Will generate the output:
 # -----------------------------------------------------------------------------
 # Boilerplate
 # -----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/sphinxext/bokeh_palette_group.py
+++ b/bokeh/sphinxext/bokeh_palette_group.py
@@ -31,6 +31,8 @@ Generates the output:
 # -----------------------------------------------------------------------------
 # Boilerplate
 # -----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/sphinxext/bokeh_prop.py
+++ b/bokeh/sphinxext/bokeh_prop.py
@@ -43,6 +43,8 @@ in conjunction with the :ref:`bokeh.sphinxext.bokeh_autodoc` extension.
 # -----------------------------------------------------------------------------
 # Boilerplate
 # -----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/sphinxext/bokeh_releases.py
+++ b/bokeh/sphinxext/bokeh_releases.py
@@ -27,6 +27,8 @@ To avoid warnings about orphaned files, add the following to the Sphinx
 # -----------------------------------------------------------------------------
 # Boilerplate
 # -----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/sphinxext/bokeh_roles.py
+++ b/bokeh/sphinxext/bokeh_roles.py
@@ -43,6 +43,8 @@ updating all of the files in the :bokeh-tree:`examples` subdirectory.
 # -----------------------------------------------------------------------------
 # Boilerplate
 # -----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/sphinxext/bokeh_settings.py
+++ b/bokeh/sphinxext/bokeh_settings.py
@@ -21,6 +21,8 @@ This directive takes the name of a module attribute
 # -----------------------------------------------------------------------------
 # Boilerplate
 # -----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/sphinxext/bokeh_sitemap.py
+++ b/bokeh/sphinxext/bokeh_sitemap.py
@@ -19,6 +19,8 @@ configuration file ``conf.py``.
 # -----------------------------------------------------------------------------
 # Boilerplate
 # -----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/sphinxext/bokehjs_content.py
+++ b/bokeh/sphinxext/bokehjs_content.py
@@ -44,6 +44,8 @@ The inline example code above produces the following output:
 # -----------------------------------------------------------------------------
 # Boilerplate
 # -----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/sphinxext/collapsible_code_block.py
+++ b/bokeh/sphinxext/collapsible_code_block.py
@@ -39,6 +39,8 @@ The inline example code above produces the following output:
 # -----------------------------------------------------------------------------
 # Boilerplate
 # -----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/sphinxext/example_handler.py
+++ b/bokeh/sphinxext/example_handler.py
@@ -11,6 +11,8 @@
 # -----------------------------------------------------------------------------
 # Boilerplate
 # -----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/sphinxext/sample.py
+++ b/bokeh/sphinxext/sample.py
@@ -12,6 +12,8 @@
 # -----------------------------------------------------------------------------
 # Boilerplate
 # -----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/sphinxext/templates.py
+++ b/bokeh/sphinxext/templates.py
@@ -11,6 +11,8 @@
 # -----------------------------------------------------------------------------
 # Boilerplate
 # -----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/sphinxext/util.py
+++ b/bokeh/sphinxext/util.py
@@ -12,6 +12,8 @@
 # -----------------------------------------------------------------------------
 # Boilerplate
 # -----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/themes/__init__.py
+++ b/bokeh/themes/__init__.py
@@ -110,6 +110,8 @@ Theme
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/themes/theme.py
+++ b/bokeh/themes/theme.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/tile_providers.py
+++ b/bokeh/tile_providers.py
@@ -137,6 +137,8 @@ Tile Source for Wikimedia tile service.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/transform.py
+++ b/bokeh/transform.py
@@ -12,6 +12,8 @@ transformations to data fields or ``ColumnDataSource`` expressions.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/util/browser.py
+++ b/bokeh/util/browser.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/util/callback_manager.py
+++ b/bokeh/util/callback_manager.py
@@ -12,6 +12,8 @@ interfaces to classes.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/util/compiler.py
+++ b/bokeh/util/compiler.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/util/datatypes.py
+++ b/bokeh/util/datatypes.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/util/dependencies.py
+++ b/bokeh/util/dependencies.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/util/deprecation.py
+++ b/bokeh/util/deprecation.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/util/functions.py
+++ b/bokeh/util/functions.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/util/hex.py
+++ b/bokeh/util/hex.py
@@ -15,6 +15,8 @@ For more information on the concepts employed here, see this informative page
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/util/logconfig.py
+++ b/bokeh/util/logconfig.py
@@ -25,6 +25,8 @@ The default logging level is ``none``.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/util/options.py
+++ b/bokeh/util/options.py
@@ -12,6 +12,8 @@ options.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/util/paths.py
+++ b/bokeh/util/paths.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/util/sampledata.py
+++ b/bokeh/util/sampledata.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -18,6 +18,8 @@ performance and efficiency. The list of supported dtypes is:
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/util/session_id.py
+++ b/bokeh/util/session_id.py
@@ -15,6 +15,8 @@ other sessions hosted by the server.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/util/string.py
+++ b/bokeh/util/string.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging  # isort:skip
 
 log = logging.getLogger(__name__)

--- a/bokeh/util/terminal.py
+++ b/bokeh/util/terminal.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/util/token.py
+++ b/bokeh/util/token.py
@@ -15,6 +15,8 @@ other sessions hosted by the server.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/util/tornado.py
+++ b/bokeh/util/tornado.py
@@ -11,6 +11,8 @@
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/util/version.py
+++ b/bokeh/util/version.py
@@ -30,6 +30,8 @@ Functions:
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 

--- a/bokeh/util/warnings.py
+++ b/bokeh/util/warnings.py
@@ -14,6 +14,8 @@ displayed to users by default.
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import logging # isort:skip
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Given we dropped support for 3.6, then with 3.7 we can finally use lazy annotations, which simplifies static typing (self and forward references, etc.). Sadly this means sprinkling entire codebase with `from __future__ import annotations`.
