### PR TITLE
Full typescript for WebGL code

### DIFF
--- a/bokehjs/src/lib/models/glyphs/webgl/dash_cache.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/dash_cache.ts
@@ -2,10 +2,8 @@ import {gcd, is_pow_2} from "./utils/math"
 import {map} from "core/util/arrayable"
 import {Regl, Texture2D} from "regl"
 
-
 export type DashReturn = [[number, number, number, number], Texture2D, number]
 type TextureReturn = [[number, number, number, number], Texture2D]
-
 
 /*
  * DashCache creates and stores webgl resources for dashes that can be reused

--- a/bokehjs/src/lib/models/glyphs/webgl/line_gl.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/line_gl.ts
@@ -7,13 +7,11 @@ import {Texture2D} from "regl"
 import {cap_lookup, join_lookup} from "./webgl_utils"
 import {LineGlyphProps, LineDashGlyphProps} from "./types"
 
-
 // Avoiding use of nan or inf to represent missing data in webgl as shaders may
 // have reduced floating point precision.  So here using a large-ish negative
 // value instead.
 const missing_point = -10000.0
 const missing_point_threshold = -9000.0
-
 
 export class LineGL extends BaseGLGlyph {
   protected _nsegments: number

--- a/bokehjs/src/lib/models/glyphs/webgl/line_gl.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/line_gl.ts
@@ -5,6 +5,7 @@ import {color2rgba} from "core/util/color"
 import {resolve_line_dash} from "core/visuals/line"
 import {Texture2D} from "regl"
 import {cap_lookup, join_lookup} from "./webgl_utils"
+import {LineGlyphProps, LineDashGlyphProps} from "./types"
 
 
 // Avoiding use of nan or inf to represent missing data in webgl as shaders may
@@ -22,24 +23,20 @@ export class LineGL extends BaseGLGlyph {
   protected _color: number[]
   protected _miter_limit: number
   protected _line_dash: number[]
-  protected _dash_offset: number
   protected _is_closed: boolean
 
   // Only needed if line has dashes.
-  protected _length_so_far: Float32Array | undefined
-  protected _dash_tex: Texture2D | undefined
-  protected _dash_tex_info: number[] | undefined
-  protected _dash_scale: number | undefined
-
-  protected _debug_show_mesh: boolean
+  protected _length_so_far?: Float32Array
+  protected _dash_tex?: Texture2D
+  protected _dash_tex_info?: number[]
+  protected _dash_scale?: number
+  protected _dash_offset?: number
 
   constructor(regl_wrapper: ReglWrapper, readonly glyph: LineView) {
     super(regl_wrapper, glyph)
 
     this._antialias = 1.5   // Make this larger to test antialiasing at edges.
     this._miter_limit = 5.0 // Threshold for miters to be replaced by bevels.
-
-    this._debug_show_mesh = false
   }
 
   draw(_indices: number[], mainGlyph: LineView, transform: Transform): void {
@@ -59,54 +56,43 @@ export class LineGL extends BaseGLGlyph {
     const line_visuals = this.glyph.visuals.line
     const linewidth = line_visuals.line_width.value
     const antialias = Math.min(this._antialias, linewidth)
-    const cap_type = cap_lookup[line_visuals.line_cap.value]
-    const join_type = join_lookup[line_visuals.line_join.value]
+    const line_cap = cap_lookup[line_visuals.line_cap.value]
+    const line_join = join_lookup[line_visuals.line_join.value]
 
-    if (this._is_dashed())
-      this.regl_wrapper.dashed_line()({
+    if (this._is_dashed()) {
+      const props: LineDashGlyphProps = {
         canvas_size: [transform.width, transform.height],
         pixel_ratio: transform.pixel_ratio,
-        color: this._color,
+        line_color: this._color,
         linewidth,
         antialias,
         miter_limit: this._miter_limit,
         points: this._points,
         nsegments: this._nsegments,
-        join_type,
-        cap_type,
-        length_so_far: this._length_so_far,
-        dash_tex: this._dash_tex,
-        dash_tex_info: this._dash_tex_info,
-        dash_scale: this._dash_scale,
-        dash_offset: this._dash_offset,
-      })
-    else
-      this.regl_wrapper.solid_line()({
+        line_join,
+        line_cap,
+        length_so_far: this._length_so_far!,
+        dash_tex: this._dash_tex!,
+        dash_tex_info: this._dash_tex_info!,
+        dash_scale: this._dash_scale!,
+        dash_offset: this._dash_offset!,
+      }
+      this.regl_wrapper.dashed_line()(props)
+    } else {
+      const props: LineGlyphProps = {
         canvas_size: [transform.width, transform.height],
         pixel_ratio: transform.pixel_ratio,
-        color: this._color,
+        line_color: this._color,
         linewidth,
         antialias,
         miter_limit: this._miter_limit,
         points: this._points,
         nsegments: this._nsegments,
-        join_type,
-        cap_type,
-      })
-
-    if (this._debug_show_mesh)
-      this.regl_wrapper.line_mesh()({
-        canvas_size: [transform.width, transform.height],
-        pixel_ratio: transform.pixel_ratio,
-        color: [0, 0, 0, 1],
-        linewidth,
-        antialias,
-        miter_limit: this._miter_limit,
-        points: this._points,
-        nsegments: this._nsegments,
-        join_type,
-        cap_type,
-      })
+        line_join,
+        line_cap,
+      }
+      this.regl_wrapper.solid_line()(props)
+    }
   }
 
   protected _is_dashed(): boolean {

--- a/bokehjs/src/lib/models/glyphs/webgl/markers.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/markers.ts
@@ -7,12 +7,10 @@ import type {CircleView} from "../circle"
 import {color_to_uint8_array, prop_as_array} from "./webgl_utils"
 import {MarkerType} from "core/enums"
 
-
 // Avoiding use of nan or inf to represent missing data in webgl as shaders may
 // have reduced floating point precision.  So here using a large-ish negative
 // value instead.
 const missing_point = -10000
-
 
 type MarkerLikeView = ScatterView | CircleView
 

--- a/bokehjs/src/lib/models/glyphs/webgl/markers.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/markers.ts
@@ -1,5 +1,6 @@
 import {BaseGLGlyph, Transform} from "./base"
 import {ReglWrapper} from "./regl_wrap"
+import {MarkerGlyphProps} from "./types"
 import type {GlyphView} from "../glyph"
 import type {ScatterView} from "../scatter"
 import type {CircleView} from "../circle"
@@ -119,7 +120,7 @@ export class MarkerGL extends BaseGLGlyph {
         this._show[i] = 255
     }
 
-    this.regl_wrapper.marker(this._marker_type)({
+    const props: MarkerGlyphProps = {
       canvas_size: [transform.width, transform.height],
       pixel_ratio: transform.pixel_ratio,
       center: mainGlGlyph._centers,
@@ -131,7 +132,8 @@ export class MarkerGL extends BaseGLGlyph {
       line_color: this._line_rgba,
       fill_color: this._fill_rgba,
       show: this._show,
-    })
+    }
+    this.regl_wrapper.marker(this._marker_type)(props)
   }
 
   protected _set_data(): void {

--- a/bokehjs/src/lib/models/glyphs/webgl/rect.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/rect.ts
@@ -4,12 +4,10 @@ import {RectGlyphProps, RectHatchGlyphProps} from "./types"
 import {color_to_uint8_array, prop_as_array, hatch_pattern_prop_as_array, line_join_prop_as_array} from "./webgl_utils"
 import {RectView} from "../rect"
 
-
 // Avoiding use of nan or inf to represent missing data in webgl as shaders may
 // have reduced floating point precision.  So here using a large-ish negative
 // value instead.
 const missing_point = -10000
-
 
 export class RectGL extends BaseGLGlyph {
   protected _antialias: number

--- a/bokehjs/src/lib/models/glyphs/webgl/rect.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/rect.ts
@@ -1,5 +1,6 @@
 import {BaseGLGlyph, Transform} from "./base"
 import {ReglWrapper} from "./regl_wrap"
+import {RectGlyphProps, RectHatchGlyphProps} from "./types"
 import {color_to_uint8_array, prop_as_array, hatch_pattern_prop_as_array, line_join_prop_as_array} from "./webgl_utils"
 import {RectView} from "../rect"
 
@@ -26,10 +27,10 @@ export class RectGL extends BaseGLGlyph {
 
   // Only needed if have hatch pattern.
   protected _have_hatch: boolean
-  protected _hatch_patterns: number[] | Float32Array
-  protected _hatch_scales: number[] | Float32Array
-  protected _hatch_weights: number[] | Float32Array
-  protected _hatch_rgba: Uint8Array
+  protected _hatch_patterns?: number[] | Float32Array
+  protected _hatch_scales?: number[] | Float32Array
+  protected _hatch_weights?: number[] | Float32Array
+  protected _hatch_rgba?: Uint8Array
 
   constructor(regl_wrapper: ReglWrapper, readonly glyph: RectView) {
     super(regl_wrapper, glyph)
@@ -73,7 +74,7 @@ export class RectGL extends BaseGLGlyph {
     }
 
     if (this._have_hatch) {
-      this.regl_wrapper.rect_hatch()({
+      const props: RectHatchGlyphProps = {
         canvas_size: [transform.width, transform.height],
         pixel_ratio: transform.pixel_ratio,
         center: mainGlGlyph._centers,
@@ -87,13 +88,14 @@ export class RectGL extends BaseGLGlyph {
         fill_color: this._fill_rgba,
         line_join: this._line_joins,
         show: this._show,
-        hatch_pattern: this._hatch_patterns,
-        hatch_scale: this._hatch_scales,
-        hatch_weight: this._hatch_weights,
-        hatch_color: this._hatch_rgba,
-      })
+        hatch_pattern: this._hatch_patterns!,
+        hatch_scale: this._hatch_scales!,
+        hatch_weight: this._hatch_weights!,
+        hatch_color: this._hatch_rgba!,
+      }
+      this.regl_wrapper.rect_hatch()(props)
     } else {
-      this.regl_wrapper.rect_no_hatch()({
+      const props: RectGlyphProps = {
         canvas_size: [transform.width, transform.height],
         pixel_ratio: transform.pixel_ratio,
         center: mainGlGlyph._centers,
@@ -107,7 +109,8 @@ export class RectGL extends BaseGLGlyph {
         fill_color: this._fill_rgba,
         line_join: this._line_joins,
         show: this._show,
-      })
+      }
+      this.regl_wrapper.rect_no_hatch()(props)
     }
   }
 

--- a/bokehjs/src/lib/models/glyphs/webgl/regl_line.frag
+++ b/bokehjs/src/lib/models/glyphs/webgl/regl_line.frag
@@ -10,9 +10,9 @@ const int bevel_join = 2;
 
 uniform float u_linewidth;
 uniform float u_antialias;
-uniform float u_join_type;
-uniform float u_cap_type;
-uniform vec4 u_color;
+uniform float u_line_join;
+uniform float u_line_cap;
+uniform vec4 u_line_color;
 #ifdef DASHED
 uniform sampler2D u_dash_tex;
 uniform vec4 u_dash_tex_info;
@@ -126,8 +126,8 @@ mat2 rotation_matrix(in float sign_start)
 
 void main()
 {
-    int join_type = int(u_join_type + 0.5);
-    int cap_type = int(u_cap_type + 0.5);
+    int join_type = int(u_line_join + 0.5);
+    int cap_type = int(u_line_cap + 0.5);
     float halfwidth = 0.5*(u_linewidth + u_antialias);
 
     // Extract flags.
@@ -240,6 +240,6 @@ void main()
     }
 #endif
 
-    alpha = u_color.a*alpha;
-    gl_FragColor = vec4(u_color.rgb*alpha, alpha);  // Premultiplied alpha.
+    alpha = u_line_color.a*alpha;
+    gl_FragColor = vec4(u_line_color.rgb*alpha, alpha);  // Premultiplied alpha.
 }

--- a/bokehjs/src/lib/models/glyphs/webgl/regl_line.vert
+++ b/bokehjs/src/lib/models/glyphs/webgl/regl_line.vert
@@ -23,8 +23,8 @@ uniform float u_pixel_ratio;
 uniform vec2 u_canvas_size;
 uniform float u_linewidth;
 uniform float u_antialias;
-uniform float u_join_type;
-uniform float u_cap_type;
+uniform float u_line_join;
+uniform float u_line_cap;
 uniform float u_miter_limit;
 
 varying float v_segment_length;
@@ -66,8 +66,8 @@ void main()
 
     const float min_miter_factor_round_join_mesh = sqrt(2.0);
 
-    int join_type = int(u_join_type + 0.5);
-    int cap_type = int(u_cap_type + 0.5);
+    int join_type = int(u_line_join + 0.5);
+    int cap_type = int(u_line_cap + 0.5);
     float halfwidth = 0.5*(u_linewidth + u_antialias);
     vec2 segment_along = normalize(a_point_end - a_point_start); // unit vector.
     v_segment_length = length(a_point_end - a_point_start);

--- a/bokehjs/src/lib/models/glyphs/webgl/regl_wrap.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/regl_wrap.ts
@@ -10,7 +10,6 @@ import {MarkerType} from "core/enums"
 import rect_vertex_shader from "./rect.vert"
 import rect_fragment_shader from "./rect.frag"
 
-
 // All access to regl is performed via the get_regl() function that returns a
 // ReglWrapper object.  This ensures that regl is correctly initialised before
 // it is used, and is only initialised once.
@@ -23,9 +22,7 @@ export function get_regl(gl: WebGLRenderingContext): ReglWrapper {
   return regl_wrapper
 }
 
-
 type ReglRenderFunction = ({}) => void
-
 
 export class ReglWrapper {
   private _regl: Regl
@@ -101,7 +98,6 @@ export class ReglWrapper {
   }
 }
 
-
 // Regl rendering functions are here as some will be reused, e.g. lines may also
 // be used around polygons or for bezier curves.
 
@@ -128,12 +124,10 @@ const line_instance_geometry = [
 
 const line_triangle_indices = [[0, 1, 5], [1, 2, 5], [5, 2, 4], [2, 3, 4]]
 
-
 function regl_solid_line(regl: Regl): ReglRenderFunction {
   type Props = t.LineGlyphProps
   type Uniforms = t.LineGlyphUniforms
   type Attributes = t.LineGlyphAttributes
-  type Context = t.EmptyContext
 
   const config: DrawConfig<Uniforms, Attributes, Props> = {
     vert: line_vertex_shader,
@@ -144,27 +138,27 @@ function regl_solid_line(regl: Regl): ReglRenderFunction {
         buffer: regl.buffer(line_instance_geometry),
         divisor: 0,
       },
-      a_point_prev: (_: Context, props: Props) => {
+      a_point_prev(_, props) {
         return {
           buffer: regl.buffer(props.points),
           divisor: 1,
         }
       },
-      a_point_start: (_: Context, props: Props) => {
+      a_point_start(_, props) {
         return {
           buffer: regl.buffer(props.points),
           divisor: 1,
           offset: Float32Array.BYTES_PER_ELEMENT * 2,
         }
       },
-      a_point_end: (_: Context, props: Props) => {
+      a_point_end(_, props) {
         return {
           buffer: regl.buffer(props.points),
           divisor: 1,
           offset: Float32Array.BYTES_PER_ELEMENT * 4,
         }
       },
-      a_point_next: (_: Context, props: Props) => {
+      a_point_next(_, props) {
         return {
           buffer: regl.buffer(props.points),
           divisor: 1,
@@ -204,12 +198,10 @@ function regl_solid_line(regl: Regl): ReglRenderFunction {
   return regl<Uniforms, Attributes, Props>(config)
 }
 
-
 function regl_dashed_line(regl: Regl): ReglRenderFunction {
   type Props = t.LineDashGlyphProps
   type Uniforms = t.LineDashGlyphUniforms
   type Attributes = t.LineDashGlyphAttributes
-  type Context = t.EmptyContext
 
   const config: DrawConfig<Uniforms, Attributes, Props> = {
     vert: '#define DASHED\n\n' + line_vertex_shader,
@@ -220,34 +212,34 @@ function regl_dashed_line(regl: Regl): ReglRenderFunction {
         buffer: regl.buffer(line_instance_geometry),
         divisor: 0,
       },
-      a_point_prev: (_: Context, props: Props) => {
+      a_point_prev(_, props) {
         return {
           buffer: regl.buffer(props.points),
           divisor: 1,
         }
       },
-      a_point_start: (_: Context, props: Props) => {
+      a_point_start(_, props) {
         return {
           buffer: regl.buffer(props.points),
           divisor: 1,
           offset: Float32Array.BYTES_PER_ELEMENT * 2,
         }
       },
-      a_point_end: (_: Context, props: Props) => {
+      a_point_end(_, props) {
         return {
           buffer: regl.buffer(props.points),
           divisor: 1,
           offset: Float32Array.BYTES_PER_ELEMENT * 4,
         }
       },
-      a_point_next: (_: Context, props: Props) => {
+      a_point_next(_, props) {
         return {
           buffer: regl.buffer(props.points),
           divisor: 1,
           offset: Float32Array.BYTES_PER_ELEMENT * 6,
         }
       },
-      a_length_so_far: (_: Context, props: Props) => {
+      a_length_so_far(_, props) {
         return {
           buffer: regl.buffer(props.length_so_far),
           divisor: 1,
@@ -290,7 +282,6 @@ function regl_dashed_line(regl: Regl): ReglRenderFunction {
   return regl<Uniforms, Attributes, Props>(config)
 }
 
-
 // Return a ReGL AttributeConfig that corresponds to one value for
 // each marker or the same value for all markers.  Instanced rendering supports
 // the former using 'divisor = 1', but does not support the latter directly.
@@ -307,12 +298,10 @@ function one_each_or_constant(regl: Regl, prop: Float32Array | Uint8Array | numb
   }
 }
 
-
 function regl_marker(regl: Regl, marker_type: MarkerType): ReglRenderFunction {
   type Props = t.MarkerGlyphProps
   type Uniforms = t.CommonUniforms
   type Attributes = t.MarkerGlyphAttributes
-  type Context = t.EmptyContext
 
   const config: DrawConfig<Uniforms, Attributes, Props> = {
     vert: marker_vertex_shader,
@@ -323,28 +312,28 @@ function regl_marker(regl: Regl, marker_type: MarkerType): ReglRenderFunction {
         buffer: regl.buffer([[-0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [0.5, -0.5]]),
         divisor: 0,
       },
-      a_center: (_: Context, props: Props) => {
+      a_center(_, props) {
         return {
           buffer: regl.buffer(props.center),
           divisor: 1,
         }
       },
-      a_size: (_: Context, props: Props) => {
+      a_size(_, props) {
         return one_each_or_constant(regl, props.size, 1, false, props.nmarkers)
       },
-      a_angle: (_: Context, props: Props) => {
+      a_angle(_, props) {
         return one_each_or_constant(regl, props.angle, 1, false, props.nmarkers)
       },
-      a_linewidth: (_: Context, props: Props) => {
+      a_linewidth(_, props) {
         return one_each_or_constant(regl, props.linewidth, 1, false, props.nmarkers)
       },
-      a_line_color: (_: Context, props: Props) => {
+      a_line_color(_, props) {
         return one_each_or_constant(regl, props.line_color, 4, true, props.nmarkers)
       },
-      a_fill_color: (_: Context, props: Props) => {
+      a_fill_color(_, props) {
         return one_each_or_constant(regl, props.fill_color, 4, true, props.nmarkers)
       },
-      a_show: (_: Context, props: Props) => {
+      a_show(_, props) {
         return {
           buffer: regl.buffer(props.show),
           normalized: true,
@@ -378,12 +367,10 @@ function regl_marker(regl: Regl, marker_type: MarkerType): ReglRenderFunction {
   return regl<Uniforms, Attributes, Props>(config)
 }
 
-
 function regl_rect_no_hatch(regl: Regl): ReglRenderFunction {
   type Props = t.RectGlyphProps
   type Uniforms = t.CommonUniforms
   type Attributes = t.RectGlyphAttributes
-  type Context = t.EmptyContext
 
   const config: DrawConfig<Uniforms, Attributes, Props> = {
     vert: rect_vertex_shader,
@@ -394,34 +381,34 @@ function regl_rect_no_hatch(regl: Regl): ReglRenderFunction {
         buffer: regl.buffer([[-0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [0.5, -0.5]]),
         divisor: 0,
       },
-      a_center: (_: Context, props: Props) => {
+      a_center(_, props) {
         return {
           buffer: regl.buffer(props.center),
           divisor: 1,
         }
       },
-      a_width: (_: Context, props: Props) => {
+      a_width(_, props) {
         return one_each_or_constant(regl, props.width, 1, false, props.nmarkers)
       },
-      a_height: (_: Context, props: Props) => {
+      a_height(_, props) {
         return one_each_or_constant(regl, props.height, 1, false, props.nmarkers)
       },
-      a_angle: (_: Context, props: Props) => {
+      a_angle(_, props) {
         return one_each_or_constant(regl, props.angle, 1, false, props.nmarkers)
       },
-      a_linewidth: (_: Context, props: Props) => {
+      a_linewidth(_, props) {
         return one_each_or_constant(regl, props.linewidth, 1, false, props.nmarkers)
       },
-      a_line_color: (_: Context, props: Props) => {
+      a_line_color(_, props) {
         return one_each_or_constant(regl, props.line_color, 4, true, props.nmarkers)
       },
-      a_fill_color: (_: Context, props: Props) => {
+      a_fill_color(_, props) {
         return one_each_or_constant(regl, props.fill_color, 4, true, props.nmarkers)
       },
-      a_line_join: (_: Context, props: Props) => {
+      a_line_join(_, props) {
         return one_each_or_constant(regl, props.line_join, 1, false, props.nmarkers)
       },
-      a_show: (_: Context, props: Props) => {
+      a_show(_, props) {
         return {
           buffer: regl.buffer(props.show),
           normalized: true,
@@ -455,12 +442,10 @@ function regl_rect_no_hatch(regl: Regl): ReglRenderFunction {
   return regl<Uniforms, Attributes, Props>(config)
 }
 
-
 function regl_rect_hatch(regl: Regl): ReglRenderFunction {
   type Props = t.RectHatchGlyphProps
   type Uniforms = t.CommonUniforms
   type Attributes = t.RectHatchGlyphAttributes
-  type Context = t.EmptyContext
 
   const config: DrawConfig<Uniforms, Attributes, Props> = {
     vert: '#define HATCH\n\n' + rect_vertex_shader,
@@ -471,50 +456,50 @@ function regl_rect_hatch(regl: Regl): ReglRenderFunction {
         buffer: regl.buffer([[-0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [0.5, -0.5]]),
         divisor: 0,
       },
-      a_center: (_: Context, props: Props) => {
+      a_center(_, props) {
         return {
           buffer: regl.buffer(props.center),
           divisor: 1,
         }
       },
-      a_width: (_: Context, props: Props) => {
+      a_width(_, props) {
         return one_each_or_constant(regl, props.width, 1, false, props.nmarkers)
       },
-      a_height: (_: Context, props: Props) => {
+      a_height(_, props) {
         return one_each_or_constant(regl, props.height, 1, false, props.nmarkers)
       },
-      a_angle: (_: Context, props: Props) => {
+      a_angle(_, props) {
         return one_each_or_constant(regl, props.angle, 1, false, props.nmarkers)
       },
-      a_linewidth: (_: Context, props: Props) => {
+      a_linewidth(_, props) {
         return one_each_or_constant(regl, props.linewidth, 1, false, props.nmarkers)
       },
-      a_line_color: (_: Context, props: Props) => {
+      a_line_color(_, props) {
         return one_each_or_constant(regl, props.line_color, 4, true, props.nmarkers)
       },
-      a_fill_color: (_: Context, props: Props) => {
+      a_fill_color(_, props) {
         return one_each_or_constant(regl, props.fill_color, 4, true, props.nmarkers)
       },
-      a_line_join: (_: Context, props: Props) => {
+      a_line_join(_, props) {
         return one_each_or_constant(regl, props.line_join, 1, false, props.nmarkers)
       },
-      a_show: (_: Context, props: Props) => {
+      a_show(_, props) {
         return {
           buffer: regl.buffer(props.show),
           normalized: true,
           divisor: 1,
         }
       },
-      a_hatch_pattern: (_: Context, props: Props) => {
+      a_hatch_pattern(_, props) {
         return one_each_or_constant(regl, props.hatch_pattern, 1, false, props.nmarkers)
       },
-      a_hatch_scale: (_: Context, props: Props) => {
+      a_hatch_scale(_, props) {
         return one_each_or_constant(regl, props.hatch_scale, 1, false, props.nmarkers)
       },
-      a_hatch_weight: (_: Context, props: Props) => {
+      a_hatch_weight(_, props) {
         return one_each_or_constant(regl, props.hatch_weight, 1, false, props.nmarkers)
       },
-      a_hatch_color: (_: Context, props: Props) => {
+      a_hatch_color(_, props) {
         return one_each_or_constant(regl, props.hatch_color, 4, true, props.nmarkers)
       },
     },

--- a/bokehjs/src/lib/models/glyphs/webgl/regl_wrap.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/regl_wrap.ts
@@ -1,5 +1,6 @@
 import createRegl from "regl"
-import {Regl} from "regl"
+import {Regl, DrawConfig, AttributeConfig} from "regl"
+import * as t from "./types"
 import {DashCache, DashReturn} from "./dash_cache"
 import line_vertex_shader from "./regl_line.vert"
 import line_fragment_shader from "./regl_line.frag"
@@ -34,7 +35,6 @@ export class ReglWrapper {
   // Drawing functions.
   private _solid_line: ReglRenderFunction
   private _dashed_line: ReglRenderFunction
-  private _line_mesh: ReglRenderFunction
   private _marker_map: Map<MarkerType, ReglRenderFunction>
   private _rect_no_hatch: ReglRenderFunction
   private _rect_hatch: ReglRenderFunction
@@ -68,12 +68,6 @@ export class ReglWrapper {
       this._dash_cache = new DashCache(this._regl)
 
     return this._dash_cache.get(line_dash)
-  }
-
-  public line_mesh(): ReglRenderFunction {
-    if (this._line_mesh == null)
-      this._line_mesh = regl_line_mesh(this._regl)
-    return this._line_mesh
   }
 
   public marker(marker_type: MarkerType): ReglRenderFunction {
@@ -134,15 +128,14 @@ const line_instance_geometry = [
 
 const line_triangle_indices = [[0, 1, 5], [1, 2, 5], [5, 2, 4], [2, 3, 4]]
 
-// Indices for debug drawing of mesh used for lines.
-const line_mesh_indices = [
-  [0, 1], [1, 2], [2, 3], [3, 4], [4, 5], [5, 0],  // Edges.
-  [1, 5], [2, 5], [2, 4], // Diagonals.
-]
 
+function regl_solid_line(regl: Regl): ReglRenderFunction {
+  type Props = t.LineGlyphProps
+  type Uniforms = t.LineGlyphUniforms
+  type Attributes = t.LineGlyphAttributes
+  type Context = t.EmptyContext
 
-function regl_solid_line(regl: any): ReglRenderFunction {
-  return regl({
+  const config: DrawConfig<Uniforms, Attributes, Props> = {
     vert: line_vertex_shader,
     frag: line_fragment_shader,
 
@@ -151,43 +144,50 @@ function regl_solid_line(regl: any): ReglRenderFunction {
         buffer: regl.buffer(line_instance_geometry),
         divisor: 0,
       },
-      a_point_prev: {
-        buffer: regl.prop("points"),
-        divisor: 1,
-        offset: Float32Array.BYTES_PER_ELEMENT * 0,
+      a_point_prev: (_: Context, props: Props) => {
+        return {
+          buffer: regl.buffer(props.points),
+          divisor: 1,
+        }
       },
-      a_point_start: {
-        buffer: regl.prop("points"),
-        divisor: 1,
-        offset: Float32Array.BYTES_PER_ELEMENT * 2,
+      a_point_start: (_: Context, props: Props) => {
+        return {
+          buffer: regl.buffer(props.points),
+          divisor: 1,
+          offset: Float32Array.BYTES_PER_ELEMENT * 2,
+        }
       },
-      a_point_end: {
-        buffer: regl.prop("points"),
-        divisor: 1,
-        offset: Float32Array.BYTES_PER_ELEMENT * 4,
+      a_point_end: (_: Context, props: Props) => {
+        return {
+          buffer: regl.buffer(props.points),
+          divisor: 1,
+          offset: Float32Array.BYTES_PER_ELEMENT * 4,
+        }
       },
-      a_point_next: {
-        buffer: regl.prop("points"),
-        divisor: 1,
-        offset: Float32Array.BYTES_PER_ELEMENT * 6,
+      a_point_next: (_: Context, props: Props) => {
+        return {
+          buffer: regl.buffer(props.points),
+          divisor: 1,
+          offset: Float32Array.BYTES_PER_ELEMENT * 6,
+        }
       },
     },
 
     uniforms: {
-      u_canvas_size: regl.prop('canvas_size'),
-      u_pixel_ratio: regl.prop('pixel_ratio'),
-      u_color: regl.prop('color'),
-      u_linewidth: regl.prop('linewidth'),
-      u_antialias: regl.prop('antialias'),
-      u_miter_limit: regl.prop('miter_limit'),
-      u_join_type: regl.prop('join_type'),
-      u_cap_type: regl.prop('cap_type'),
+      u_canvas_size: regl.prop<Props, 'canvas_size'>('canvas_size'),
+      u_pixel_ratio: regl.prop<Props, 'pixel_ratio'>('pixel_ratio'),
+      u_antialias: regl.prop<Props, 'antialias'>('antialias'),
+      u_line_color: regl.prop<Props, 'line_color'>('line_color'),
+      u_linewidth: regl.prop<Props, 'linewidth'>('linewidth'),
+      u_miter_limit: regl.prop<Props, 'miter_limit'>('miter_limit'),
+      u_line_join: regl.prop<Props, 'line_join'>('line_join'),
+      u_line_cap: regl.prop<Props, 'line_cap'>('line_cap'),
     },
 
     elements: line_triangle_indices,
     count: 3*line_triangle_indices.length,
     primitive: 'triangles',
-    instances: regl.prop("nsegments"),
+    instances: regl.prop<Props, 'nsegments'>("nsegments"),
 
     blend: {
       enable: true,
@@ -199,12 +199,19 @@ function regl_solid_line(regl: any): ReglRenderFunction {
       },
     },
     depth: {enable: false},
-  })
+  }
+
+  return regl<Uniforms, Attributes, Props>(config)
 }
 
 
-function regl_dashed_line(regl: any): ReglRenderFunction {
-  return regl({
+function regl_dashed_line(regl: Regl): ReglRenderFunction {
+  type Props = t.LineDashGlyphProps
+  type Uniforms = t.LineDashGlyphUniforms
+  type Attributes = t.LineDashGlyphAttributes
+  type Context = t.EmptyContext
+
+  const config: DrawConfig<Uniforms, Attributes, Props> = {
     vert: '#define DASHED\n\n' + line_vertex_shader,
     frag: '#define DASHED\n\n' + line_fragment_shader,
 
@@ -213,51 +220,60 @@ function regl_dashed_line(regl: any): ReglRenderFunction {
         buffer: regl.buffer(line_instance_geometry),
         divisor: 0,
       },
-      a_point_prev: {
-        buffer: regl.prop("points"),
-        divisor: 1,
-        offset: Float32Array.BYTES_PER_ELEMENT * 0,
+      a_point_prev: (_: Context, props: Props) => {
+        return {
+          buffer: regl.buffer(props.points),
+          divisor: 1,
+        }
       },
-      a_point_start: {
-        buffer: regl.prop("points"),
-        divisor: 1,
-        offset: Float32Array.BYTES_PER_ELEMENT * 2,
+      a_point_start: (_: Context, props: Props) => {
+        return {
+          buffer: regl.buffer(props.points),
+          divisor: 1,
+          offset: Float32Array.BYTES_PER_ELEMENT * 2,
+        }
       },
-      a_point_end: {
-        buffer: regl.prop("points"),
-        divisor: 1,
-        offset: Float32Array.BYTES_PER_ELEMENT * 4,
+      a_point_end: (_: Context, props: Props) => {
+        return {
+          buffer: regl.buffer(props.points),
+          divisor: 1,
+          offset: Float32Array.BYTES_PER_ELEMENT * 4,
+        }
       },
-      a_point_next: {
-        buffer: regl.prop("points"),
-        divisor: 1,
-        offset: Float32Array.BYTES_PER_ELEMENT * 6,
+      a_point_next: (_: Context, props: Props) => {
+        return {
+          buffer: regl.buffer(props.points),
+          divisor: 1,
+          offset: Float32Array.BYTES_PER_ELEMENT * 6,
+        }
       },
-      a_length_so_far: {
-        buffer: regl.prop("length_so_far"),
-        divisor: 1,
+      a_length_so_far: (_: Context, props: Props) => {
+        return {
+          buffer: regl.buffer(props.length_so_far),
+          divisor: 1,
+        }
       },
     },
 
     uniforms: {
-      u_canvas_size: regl.prop('canvas_size'),
-      u_pixel_ratio: regl.prop('pixel_ratio'),
-      u_color: regl.prop('color'),
-      u_linewidth: regl.prop('linewidth'),
-      u_antialias: regl.prop('antialias'),
-      u_miter_limit: regl.prop('miter_limit'),
-      u_join_type: regl.prop('join_type'),
-      u_cap_type: regl.prop('cap_type'),
-      u_dash_tex: regl.prop('dash_tex'),
-      u_dash_tex_info: regl.prop('dash_tex_info'),
-      u_dash_scale: regl.prop('dash_scale'),
-      u_dash_offset: regl.prop('dash_offset'),
+      u_canvas_size: regl.prop<Props, 'canvas_size'>('canvas_size'),
+      u_pixel_ratio: regl.prop<Props, 'pixel_ratio'>('pixel_ratio'),
+      u_antialias: regl.prop<Props, 'antialias'>('antialias'),
+      u_line_color: regl.prop<Props, 'line_color'>('line_color'),
+      u_linewidth: regl.prop<Props, 'linewidth'>('linewidth'),
+      u_miter_limit: regl.prop<Props, 'miter_limit'>('miter_limit'),
+      u_line_join: regl.prop<Props, 'line_join'>('line_join'),
+      u_line_cap: regl.prop<Props, 'line_cap'>('line_cap'),
+      u_dash_tex: regl.prop<Props, 'dash_tex'>('dash_tex'),
+      u_dash_tex_info: regl.prop<Props, 'dash_tex_info'>('dash_tex_info'),
+      u_dash_scale: regl.prop<Props, 'dash_scale'>('dash_scale'),
+      u_dash_offset: regl.prop<Props, 'dash_offset'>('dash_offset'),
     },
 
     elements: line_triangle_indices,
     count: 3*line_triangle_indices.length,
     primitive: 'triangles',
-    instances: regl.prop("nsegments"),
+    instances: regl.prop<Props, 'nsegments'>("nsegments"),
 
     blend: {
       enable: true,
@@ -269,97 +285,36 @@ function regl_dashed_line(regl: any): ReglRenderFunction {
       },
     },
     depth: {enable: false},
-  })
+  }
+
+  return regl<Uniforms, Attributes, Props>(config)
 }
 
 
-function regl_line_mesh(regl: any): ReglRenderFunction {
-  return regl({
-    vert: line_vertex_shader,
-    frag: `
-    precision mediump float;
-    uniform vec4 u_color;
-    void main ()
-    {
-        gl_FragColor = u_color;
-    }`,
-
-    attributes: {
-      a_position: {
-        buffer: regl.buffer(line_instance_geometry),
-        divisor: 0,
-      },
-      a_point_prev: {
-        buffer: regl.prop("points"),
-        divisor: 1,
-        offset: Float32Array.BYTES_PER_ELEMENT * 0,
-      },
-      a_point_start: {
-        buffer: regl.prop("points"),
-        divisor: 1,
-        offset: Float32Array.BYTES_PER_ELEMENT * 2,
-      },
-      a_point_end: {
-        buffer: regl.prop("points"),
-        divisor: 1,
-        offset: Float32Array.BYTES_PER_ELEMENT * 4,
-      },
-      a_point_next: {
-        buffer: regl.prop("points"),
-        divisor: 1,
-        offset: Float32Array.BYTES_PER_ELEMENT * 6,
-      },
-    },
-
-    uniforms: {
-      u_canvas_size: regl.prop('canvas_size'),
-      u_pixel_ratio: regl.prop('pixel_ratio'),
-      u_color: regl.prop('color'),
-      u_linewidth: regl.prop('linewidth'),
-      u_antialias: regl.prop('antialias'),
-      u_miter_limit: regl.prop('miter_limit'),
-      u_join_type: regl.prop('join_type'),
-      u_cap_type: regl.prop('cap_type'),
-    },
-
-    elements: line_mesh_indices,
-    count: 2*line_mesh_indices.length,
-    primitive: 'lines',
-    instances: regl.prop("nsegments"),
-
-    blend: {
-      enable: true,
-      func: {
-        srcRGB:   'one',
-        srcAlpha: 'one',
-        dstRGB:   'one minus src alpha',
-        dstAlpha: 'one minus src alpha',
-      },
-    },
-    depth: {enable: false},
-  })
-}
-
-
-// Return a dictionary for a ReGL attribute that corresponds to one value for
+// Return a ReGL AttributeConfig that corresponds to one value for
 // each marker or the same value for all markers.  Instanced rendering supports
 // the former using 'divisor = 1', but does not support the latter directly.
 // We have to either repeat the attribute once for each marker, which is
 // wasteful for a large number of markers, or the solution used here which is to
 // repeat the value 4 times, once for each of the instanced vertices (using
 // 'divisor = 0').
-function one_each_or_constant(prop: Float32Array | Uint8Array | number[], nitems: number, norm: boolean, nmarkers: number): {[key: string]: any} {
+function one_each_or_constant(regl: Regl, prop: Float32Array | Uint8Array | number[], nitems: number, norm: boolean, nmarkers: number): AttributeConfig {
   const divisor = prop.length == nitems && nmarkers > 1 ? 0 : 1
   return {
-    buffer: divisor == 1 ? prop : [prop, prop, prop, prop],
+    buffer: regl.buffer(divisor == 1 ? prop : [prop, prop, prop, prop]),
     divisor,
     normalized: norm,
   }
 }
 
 
-function regl_marker(regl: any, marker_type: MarkerType): ReglRenderFunction {
-  return regl({
+function regl_marker(regl: Regl, marker_type: MarkerType): ReglRenderFunction {
+  type Props = t.MarkerGlyphProps
+  type Uniforms = t.CommonUniforms
+  type Attributes = t.MarkerGlyphAttributes
+  type Context = t.EmptyContext
+
+  const config: DrawConfig<Uniforms, Attributes, Props> = {
     vert: marker_vertex_shader,
     frag: '#define USE_' + marker_type.toUpperCase() + '\n\n' + marker_fragment_shader,
 
@@ -368,41 +323,45 @@ function regl_marker(regl: any, marker_type: MarkerType): ReglRenderFunction {
         buffer: regl.buffer([[-0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [0.5, -0.5]]),
         divisor: 0,
       },
-      a_center: {
-        buffer: regl.prop('center'),
-        divisor: 1,
+      a_center: (_: Context, props: Props) => {
+        return {
+          buffer: regl.buffer(props.center),
+          divisor: 1,
+        }
       },
-      a_size: (_: any, props: any) => {
-        return one_each_or_constant(props.size, 1, false, props.nmarkers)
+      a_size: (_: Context, props: Props) => {
+        return one_each_or_constant(regl, props.size, 1, false, props.nmarkers)
       },
-      a_angle: (_: any, props: any) => {
-        return one_each_or_constant(props.angle, 1, false, props.nmarkers)
+      a_angle: (_: Context, props: Props) => {
+        return one_each_or_constant(regl, props.angle, 1, false, props.nmarkers)
       },
-      a_linewidth: (_: any, props: any) => {
-        return one_each_or_constant(props.linewidth, 1, false, props.nmarkers)
+      a_linewidth: (_: Context, props: Props) => {
+        return one_each_or_constant(regl, props.linewidth, 1, false, props.nmarkers)
       },
-      a_line_color: (_: any, props: any) => {
-        return one_each_or_constant(props.line_color, 4, true, props.nmarkers)
+      a_line_color: (_: Context, props: Props) => {
+        return one_each_or_constant(regl, props.line_color, 4, true, props.nmarkers)
       },
-      a_fill_color: (_: any, props: any) => {
-        return one_each_or_constant(props.fill_color, 4, true, props.nmarkers)
+      a_fill_color: (_: Context, props: Props) => {
+        return one_each_or_constant(regl, props.fill_color, 4, true, props.nmarkers)
       },
-      a_show: {
-        buffer: regl.prop('show'),
-        normalized: true,
-        divisor: 1,
+      a_show: (_: Context, props: Props) => {
+        return {
+          buffer: regl.buffer(props.show),
+          normalized: true,
+          divisor: 1,
+        }
       },
     },
 
     uniforms: {
-      u_canvas_size: regl.prop('canvas_size'),
-      u_pixel_ratio: regl.prop('pixel_ratio'),
-      u_antialias: regl.prop('antialias'),
+      u_canvas_size: regl.prop<Props, 'canvas_size'>('canvas_size'),
+      u_pixel_ratio: regl.prop<Props, 'pixel_ratio'>('pixel_ratio'),
+      u_antialias: regl.prop<Props, 'antialias'>('antialias'),
     },
 
     count: 4,
     primitive: 'triangle fan',
-    instances: regl.prop('nmarkers'),
+    instances: regl.prop<Props, 'nmarkers'>('nmarkers'),
 
     blend: {
       enable: true,
@@ -414,12 +373,19 @@ function regl_marker(regl: any, marker_type: MarkerType): ReglRenderFunction {
       },
     },
     depth: {enable: false},
-  })
+  }
+
+  return regl<Uniforms, Attributes, Props>(config)
 }
 
 
-function regl_rect_no_hatch(regl: any): ReglRenderFunction {
-  return regl({
+function regl_rect_no_hatch(regl: Regl): ReglRenderFunction {
+  type Props = t.RectGlyphProps
+  type Uniforms = t.CommonUniforms
+  type Attributes = t.RectGlyphAttributes
+  type Context = t.EmptyContext
+
+  const config: DrawConfig<Uniforms, Attributes, Props> = {
     vert: rect_vertex_shader,
     frag: rect_fragment_shader,
 
@@ -428,47 +394,51 @@ function regl_rect_no_hatch(regl: any): ReglRenderFunction {
         buffer: regl.buffer([[-0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [0.5, -0.5]]),
         divisor: 0,
       },
-      a_center: {
-        buffer: regl.prop('center'),
-        divisor: 1,
+      a_center: (_: Context, props: Props) => {
+        return {
+          buffer: regl.buffer(props.center),
+          divisor: 1,
+        }
       },
-      a_width: (_: any, props: any) => {
-        return one_each_or_constant(props.width, 1, false, props.nmarkers)
+      a_width: (_: Context, props: Props) => {
+        return one_each_or_constant(regl, props.width, 1, false, props.nmarkers)
       },
-      a_height: (_: any, props: any) => {
-        return one_each_or_constant(props.height, 1, false, props.nmarkers)
+      a_height: (_: Context, props: Props) => {
+        return one_each_or_constant(regl, props.height, 1, false, props.nmarkers)
       },
-      a_angle: (_: any, props: any) => {
-        return one_each_or_constant(props.angle, 1, false, props.nmarkers)
+      a_angle: (_: Context, props: Props) => {
+        return one_each_or_constant(regl, props.angle, 1, false, props.nmarkers)
       },
-      a_linewidth: (_: any, props: any) => {
-        return one_each_or_constant(props.linewidth, 1, false, props.nmarkers)
+      a_linewidth: (_: Context, props: Props) => {
+        return one_each_or_constant(regl, props.linewidth, 1, false, props.nmarkers)
       },
-      a_line_color: (_: any, props: any) => {
-        return one_each_or_constant(props.line_color, 4, true, props.nmarkers)
+      a_line_color: (_: Context, props: Props) => {
+        return one_each_or_constant(regl, props.line_color, 4, true, props.nmarkers)
       },
-      a_fill_color: (_: any, props: any) => {
-        return one_each_or_constant(props.fill_color, 4, true, props.nmarkers)
+      a_fill_color: (_: Context, props: Props) => {
+        return one_each_or_constant(regl, props.fill_color, 4, true, props.nmarkers)
       },
-      a_line_join: (_: any, props: any) => {
-        return one_each_or_constant(props.line_join, 1, false, props.nmarkers)
+      a_line_join: (_: Context, props: Props) => {
+        return one_each_or_constant(regl, props.line_join, 1, false, props.nmarkers)
       },
-      a_show: {
-        buffer: regl.prop('show'),
-        normalized: true,
-        divisor: 1,
+      a_show: (_: Context, props: Props) => {
+        return {
+          buffer: regl.buffer(props.show),
+          normalized: true,
+          divisor: 1,
+        }
       },
     },
 
     uniforms: {
-      u_canvas_size: regl.prop('canvas_size'),
-      u_pixel_ratio: regl.prop('pixel_ratio'),
-      u_antialias: regl.prop('antialias'),
+      u_canvas_size: regl.prop<Props, 'canvas_size'>('canvas_size'),
+      u_pixel_ratio: regl.prop<Props, 'pixel_ratio'>('pixel_ratio'),
+      u_antialias: regl.prop<Props, 'antialias'>('antialias'),
     },
 
     count: 4,
     primitive: 'triangle fan',
-    instances: regl.prop('nmarkers'),
+    instances: regl.prop<Props, 'nmarkers'>('nmarkers'),
 
     blend: {
       enable: true,
@@ -480,12 +450,19 @@ function regl_rect_no_hatch(regl: any): ReglRenderFunction {
       },
     },
     depth: {enable: false},
-  })
+  }
+
+  return regl<Uniforms, Attributes, Props>(config)
 }
 
 
-function regl_rect_hatch(regl: any): ReglRenderFunction {
-  return regl({
+function regl_rect_hatch(regl: Regl): ReglRenderFunction {
+  type Props = t.RectHatchGlyphProps
+  type Uniforms = t.CommonUniforms
+  type Attributes = t.RectHatchGlyphAttributes
+  type Context = t.EmptyContext
+
+  const config: DrawConfig<Uniforms, Attributes, Props> = {
     vert: '#define HATCH\n\n' + rect_vertex_shader,
     frag: '#define HATCH\n\n' + rect_fragment_shader,
 
@@ -494,59 +471,63 @@ function regl_rect_hatch(regl: any): ReglRenderFunction {
         buffer: regl.buffer([[-0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [0.5, -0.5]]),
         divisor: 0,
       },
-      a_center: {
-        buffer: regl.prop('center'),
-        divisor: 1,
+      a_center: (_: Context, props: Props) => {
+        return {
+          buffer: regl.buffer(props.center),
+          divisor: 1,
+        }
       },
-      a_width: (_: any, props: any) => {
-        return one_each_or_constant(props.width, 1, false, props.nmarkers)
+      a_width: (_: Context, props: Props) => {
+        return one_each_or_constant(regl, props.width, 1, false, props.nmarkers)
       },
-      a_height: (_: any, props: any) => {
-        return one_each_or_constant(props.height, 1, false, props.nmarkers)
+      a_height: (_: Context, props: Props) => {
+        return one_each_or_constant(regl, props.height, 1, false, props.nmarkers)
       },
-      a_angle: (_: any, props: any) => {
-        return one_each_or_constant(props.angle, 1, false, props.nmarkers)
+      a_angle: (_: Context, props: Props) => {
+        return one_each_or_constant(regl, props.angle, 1, false, props.nmarkers)
       },
-      a_linewidth: (_: any, props: any) => {
-        return one_each_or_constant(props.linewidth, 1, false, props.nmarkers)
+      a_linewidth: (_: Context, props: Props) => {
+        return one_each_or_constant(regl, props.linewidth, 1, false, props.nmarkers)
       },
-      a_line_color: (_: any, props: any) => {
-        return one_each_or_constant(props.line_color, 4, true, props.nmarkers)
+      a_line_color: (_: Context, props: Props) => {
+        return one_each_or_constant(regl, props.line_color, 4, true, props.nmarkers)
       },
-      a_fill_color: (_: any, props: any) => {
-        return one_each_or_constant(props.fill_color, 4, true, props.nmarkers)
+      a_fill_color: (_: Context, props: Props) => {
+        return one_each_or_constant(regl, props.fill_color, 4, true, props.nmarkers)
       },
-      a_line_join: (_: any, props: any) => {
-        return one_each_or_constant(props.line_join, 1, false, props.nmarkers)
+      a_line_join: (_: Context, props: Props) => {
+        return one_each_or_constant(regl, props.line_join, 1, false, props.nmarkers)
       },
-      a_show: {
-        buffer: regl.prop('show'),
-        normalized: true,
-        divisor: 1,
+      a_show: (_: Context, props: Props) => {
+        return {
+          buffer: regl.buffer(props.show),
+          normalized: true,
+          divisor: 1,
+        }
       },
-      a_hatch_pattern: (_: any, props: any) => {
-        return one_each_or_constant(props.hatch_pattern, 1, false, props.nmarkers)
+      a_hatch_pattern: (_: Context, props: Props) => {
+        return one_each_or_constant(regl, props.hatch_pattern, 1, false, props.nmarkers)
       },
-      a_hatch_scale: (_: any, props: any) => {
-        return one_each_or_constant(props.hatch_scale, 1, false, props.nmarkers)
+      a_hatch_scale: (_: Context, props: Props) => {
+        return one_each_or_constant(regl, props.hatch_scale, 1, false, props.nmarkers)
       },
-      a_hatch_weight: (_: any, props: any) => {
-        return one_each_or_constant(props.hatch_weight, 1, false, props.nmarkers)
+      a_hatch_weight: (_: Context, props: Props) => {
+        return one_each_or_constant(regl, props.hatch_weight, 1, false, props.nmarkers)
       },
-      a_hatch_color: (_: any, props: any) => {
-        return one_each_or_constant(props.hatch_color, 4, true, props.nmarkers)
+      a_hatch_color: (_: Context, props: Props) => {
+        return one_each_or_constant(regl, props.hatch_color, 4, true, props.nmarkers)
       },
     },
 
     uniforms: {
-      u_canvas_size: regl.prop('canvas_size'),
-      u_pixel_ratio: regl.prop('pixel_ratio'),
-      u_antialias: regl.prop('antialias'),
+      u_canvas_size: regl.prop<Props, 'canvas_size'>('canvas_size'),
+      u_pixel_ratio: regl.prop<Props, 'pixel_ratio'>('pixel_ratio'),
+      u_antialias: regl.prop<Props, 'antialias'>('antialias'),
     },
 
     count: 4,
     primitive: 'triangle fan',
-    instances: regl.prop('nmarkers'),
+    instances: regl.prop<Props, 'nmarkers'>('nmarkers'),
 
     blend: {
       enable: true,
@@ -558,5 +539,7 @@ function regl_rect_hatch(regl: any): ReglRenderFunction {
       },
     },
     depth: {enable: false},
-  })
+  }
+
+  return regl<Uniforms, Attributes, Props>(config)
 }

--- a/bokehjs/src/lib/models/glyphs/webgl/types.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/types.ts
@@ -1,28 +1,28 @@
 import {AttributeConfig, Texture2D, Vec2, Vec4} from "regl"
 
-
-interface CommonProps {
+// Props are used to pass properties from GL glyph classes to ReGL functions.
+type CommonProps = {
   canvas_size: Vec2
   pixel_ratio: number
   antialias: number
 }
 
-interface LineProps {
+type LineProps = {
   linewidth: number[] | Float32Array
   line_color: Uint8Array
   line_join: number[] | Float32Array
 }
 
-interface LinePropsNoJoin {  // Only needed until Markers support line joins.
+type LinePropsNoJoin = {  // Only needed until Markers support line joins.
   linewidth: number[] | Float32Array
   line_color: Uint8Array
 }
 
-interface FillProps {
+type FillProps = {
   fill_color: Uint8Array
 }
 
-interface DashProps {
+type DashProps = {
   length_so_far: Float32Array
   dash_tex: Texture2D
   dash_tex_info: number[]
@@ -30,14 +30,14 @@ interface DashProps {
   dash_offset: number
 }
 
-interface HatchProps {
+type HatchProps = {
   hatch_pattern: number[] | Float32Array
   hatch_scale: number[] | Float32Array
   hatch_weight: number[] | Float32Array
   hatch_color: Uint8Array
 }
 
-export interface LineGlyphProps extends CommonProps {
+export type LineGlyphProps = CommonProps & {
   line_color: number[]
   linewidth: number
   miter_limit: number
@@ -47,9 +47,9 @@ export interface LineGlyphProps extends CommonProps {
   line_join: number
 }
 
-export interface LineDashGlyphProps extends LineGlyphProps, DashProps {}
+export type LineDashGlyphProps = LineGlyphProps & DashProps
 
-export interface MarkerGlyphProps extends CommonProps, LinePropsNoJoin, FillProps {
+export type MarkerGlyphProps = CommonProps & LinePropsNoJoin & FillProps & {
   center: Float32Array
   nmarkers: number
   size: number[] | Float32Array
@@ -57,7 +57,7 @@ export interface MarkerGlyphProps extends CommonProps, LinePropsNoJoin, FillProp
   show: Uint8Array
 }
 
-export interface RectGlyphProps extends CommonProps, LineProps, FillProps {
+export type RectGlyphProps = CommonProps & LineProps & FillProps & {
   center: Float32Array
   nmarkers: number
   width: Float32Array
@@ -66,23 +66,23 @@ export interface RectGlyphProps extends CommonProps, LineProps, FillProps {
   show: Uint8Array
 }
 
-export interface RectHatchGlyphProps extends RectGlyphProps, HatchProps {}
+export type RectHatchGlyphProps = RectGlyphProps & HatchProps
 
-
-export interface CommonUniforms {
+// Uniforms are used to pass GLSL uniform values from ReGL functions to shaders.
+export type CommonUniforms = {
   u_canvas_size: Vec2
   u_pixel_ratio: number
   u_antialias: number
 }
 
-export interface DashUniforms {
+export type DashUniforms = {
   u_dash_tex: Texture2D
   u_dash_tex_info: Vec4
   u_dash_scale: number
   u_dash_offset: number
 }
 
-export interface LineGlyphUniforms extends CommonUniforms {
+export type LineGlyphUniforms = CommonUniforms & {
   u_line_color: Vec4
   u_linewidth: number
   u_miter_limit: number
@@ -90,32 +90,32 @@ export interface LineGlyphUniforms extends CommonUniforms {
   u_line_cap: number
 }
 
-export interface LineDashGlyphUniforms extends LineGlyphUniforms, DashUniforms {}
+export type LineDashGlyphUniforms = LineGlyphUniforms & DashUniforms
 
-
-interface LineAttributes {
+// Attributes are used to pass GLSL attribute values from ReGL functions to shaders.
+type LineAttributes = {
   a_linewidth: AttributeConfig
   a_line_color: AttributeConfig
   a_line_join: AttributeConfig
 }
 
-interface LineAttributesNoJoin {  // Only needed until Markers support line joins.
+type LineAttributesNoJoin = {  // Only needed until Markers support line joins.
   a_linewidth: AttributeConfig
   a_line_color: AttributeConfig
 }
 
-interface FillAttributes {
+type FillAttributes = {
   a_fill_color: AttributeConfig
 }
 
-interface HatchAttributes {
+type HatchAttributes = {
   a_hatch_pattern: AttributeConfig
   a_hatch_scale: AttributeConfig
   a_hatch_weight: AttributeConfig
   a_hatch_color: AttributeConfig
 }
 
-export interface LineGlyphAttributes {
+export type LineGlyphAttributes = {
   a_position: AttributeConfig
   a_point_prev: AttributeConfig
   a_point_start: AttributeConfig
@@ -123,11 +123,11 @@ export interface LineGlyphAttributes {
   a_point_next: AttributeConfig
 }
 
-export interface LineDashGlyphAttributes extends LineGlyphAttributes {
+export type LineDashGlyphAttributes = LineGlyphAttributes & {
   a_length_so_far: AttributeConfig
 }
 
-export interface MarkerGlyphAttributes extends LineAttributesNoJoin, FillAttributes {
+export type MarkerGlyphAttributes = LineAttributesNoJoin & FillAttributes & {
   a_position: AttributeConfig
   a_center: AttributeConfig
   a_size: AttributeConfig
@@ -135,7 +135,7 @@ export interface MarkerGlyphAttributes extends LineAttributesNoJoin, FillAttribu
   a_show: AttributeConfig
 }
 
-export interface RectGlyphAttributes extends LineAttributes, FillAttributes {
+export type RectGlyphAttributes = LineAttributes & FillAttributes & {
   a_center: AttributeConfig
   a_show: AttributeConfig
   a_position: AttributeConfig
@@ -144,7 +144,4 @@ export interface RectGlyphAttributes extends LineAttributes, FillAttributes {
   a_angle: AttributeConfig
 }
 
-export interface RectHatchGlyphAttributes extends RectGlyphAttributes, HatchAttributes {}
-
-
-export interface EmptyContext {}  // Needed for callback.
+export type RectHatchGlyphAttributes = RectGlyphAttributes & HatchAttributes

--- a/bokehjs/src/lib/models/glyphs/webgl/types.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/types.ts
@@ -1,0 +1,150 @@
+import {AttributeConfig, Texture2D, Vec2, Vec4} from "regl"
+
+
+interface CommonProps {
+  canvas_size: Vec2
+  pixel_ratio: number
+  antialias: number
+}
+
+interface LineProps {
+  linewidth: number[] | Float32Array
+  line_color: Uint8Array
+  line_join: number[] | Float32Array
+}
+
+interface LinePropsNoJoin {  // Only needed until Markers support line joins.
+  linewidth: number[] | Float32Array
+  line_color: Uint8Array
+}
+
+interface FillProps {
+  fill_color: Uint8Array
+}
+
+interface DashProps {
+  length_so_far: Float32Array
+  dash_tex: Texture2D
+  dash_tex_info: number[]
+  dash_scale: number
+  dash_offset: number
+}
+
+interface HatchProps {
+  hatch_pattern: number[] | Float32Array
+  hatch_scale: number[] | Float32Array
+  hatch_weight: number[] | Float32Array
+  hatch_color: Uint8Array
+}
+
+export interface LineGlyphProps extends CommonProps {
+  line_color: number[]
+  linewidth: number
+  miter_limit: number
+  points: Float32Array
+  nsegments: number
+  line_cap: number
+  line_join: number
+}
+
+export interface LineDashGlyphProps extends LineGlyphProps, DashProps {}
+
+export interface MarkerGlyphProps extends CommonProps, LinePropsNoJoin, FillProps {
+  center: Float32Array
+  nmarkers: number
+  size: number[] | Float32Array
+  angle: number[] | Float32Array
+  show: Uint8Array
+}
+
+export interface RectGlyphProps extends CommonProps, LineProps, FillProps {
+  center: Float32Array
+  nmarkers: number
+  width: Float32Array
+  height: Float32Array
+  angle: number[] | Float32Array
+  show: Uint8Array
+}
+
+export interface RectHatchGlyphProps extends RectGlyphProps, HatchProps {}
+
+
+export interface CommonUniforms {
+  u_canvas_size: Vec2
+  u_pixel_ratio: number
+  u_antialias: number
+}
+
+export interface DashUniforms {
+  u_dash_tex: Texture2D
+  u_dash_tex_info: Vec4
+  u_dash_scale: number
+  u_dash_offset: number
+}
+
+export interface LineGlyphUniforms extends CommonUniforms {
+  u_line_color: Vec4
+  u_linewidth: number
+  u_miter_limit: number
+  u_line_join: number
+  u_line_cap: number
+}
+
+export interface LineDashGlyphUniforms extends LineGlyphUniforms, DashUniforms {}
+
+
+interface LineAttributes {
+  a_linewidth: AttributeConfig
+  a_line_color: AttributeConfig
+  a_line_join: AttributeConfig
+}
+
+interface LineAttributesNoJoin {  // Only needed until Markers support line joins.
+  a_linewidth: AttributeConfig
+  a_line_color: AttributeConfig
+}
+
+interface FillAttributes {
+  a_fill_color: AttributeConfig
+}
+
+interface HatchAttributes {
+  a_hatch_pattern: AttributeConfig
+  a_hatch_scale: AttributeConfig
+  a_hatch_weight: AttributeConfig
+  a_hatch_color: AttributeConfig
+}
+
+export interface LineGlyphAttributes {
+  a_position: AttributeConfig
+  a_point_prev: AttributeConfig
+  a_point_start: AttributeConfig
+  a_point_end: AttributeConfig
+  a_point_next: AttributeConfig
+}
+
+export interface LineDashGlyphAttributes extends LineGlyphAttributes {
+  a_length_so_far: AttributeConfig
+}
+
+export interface MarkerGlyphAttributes extends LineAttributesNoJoin, FillAttributes {
+  a_position: AttributeConfig
+  a_center: AttributeConfig
+  a_size: AttributeConfig
+  a_angle: AttributeConfig
+  a_show: AttributeConfig
+}
+
+export interface RectGlyphAttributes extends LineAttributes, FillAttributes {
+  a_center: AttributeConfig
+  a_show: AttributeConfig
+  a_position: AttributeConfig
+  a_width: AttributeConfig
+  a_height: AttributeConfig
+  a_angle: AttributeConfig
+}
+
+export interface RectHatchGlyphAttributes extends RectGlyphAttributes, HatchAttributes {}
+
+
+export interface EmptyContext {}  // Needed for callback.

--- a/bokehjs/src/lib/models/glyphs/webgl/utils/math.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/utils/math.ts
@@ -31,7 +31,6 @@ export function gcd(values: number[]): number {
   return ret
 }
 
-
 // From regl
 export function is_pow_2(v: number): boolean {
   return !(v & (v - 1)) && (!!v)

--- a/bokehjs/src/lib/models/glyphs/webgl/webgl_utils.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/webgl_utils.ts
@@ -5,7 +5,6 @@ import {uint32} from "core/types"
 import {HatchPattern} from "core/property_mixins"
 import {hatch_aliases} from "core/visuals/patterns"
 
-
 // WebGL shaders use integers for caps, joins and hatching.
 export const cap_lookup = {butt: 0, round: 1, square: 2}
 
@@ -30,7 +29,6 @@ const hatch_pattern_lookup: {[key: string]: number} = {
   vertical_wave: 15,
   criss_cross: 16,
 }
-
 
 function hatch_pattern_to_index(pattern: HatchPattern): number {
   return hatch_pattern_lookup[hatch_aliases[pattern] ?? pattern] ?? 0


### PR DESCRIPTION
This PR fully types the WebGL/ReGL code which previously contained many `any`s.  There is no associated issue but was last discussed/requested in PR #11159.  I have also removed the debug mesh renderer in `line_gl.ts` as it is no longer needed and certainly doesn't need typing.

The new `interface`s in `types.ts` are very useful; less so are the repeated
```typescript
u_canvas_size: regl.prop<Props, 'canvas_size'>('canvas_size'),
u_pixel_ratio: regl.prop<Props, 'pixel_ratio'>('pixel_ratio'),
u_antialias: regl.prop<Props, 'antialias'>('antialias'),
```
in `regl_wrap.ts`, but they are not difficult to understand or change so we may as well tolerate them.

I have tried not to make unrelated changes, so we are left with some duplication of code.  This will all be improved in the long run as the `interface` hierarchy will become cleaner when I implement missing functionality (e.g. hatching on markers), and the WebGL glyph member variables can be reduced/removed when I move some of the `regl_wrap.ts` functionality to the glyphs so that arrays are implemented as ReGL `Buffer`s to reduce the CPU to GPU communication and give much better performance.