### PR TITLE
Move WebGLRenderingContext use to ReGL

### DIFF
--- a/bokehjs/src/lib/models/glyphs/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/circle.ts
@@ -1,6 +1,5 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {MarkerGL} from "./webgl/markers"
-import {get_regl, ReglWrapper} from "./webgl/regl_wrap"
 import {PointGeometry, SpanGeometry, RectGeometry, PolyGeometry} from "core/geometry"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
 import * as visuals from "core/visuals"
@@ -40,7 +39,7 @@ export class CircleView extends XYGlyphView {
 
     const {webgl} = this.renderer.plot_view.canvas_view
     if (webgl != null) {
-      const regl_wrapper: ReglWrapper = get_regl(webgl.gl)
+      const {regl_wrapper} = webgl
       if (regl_wrapper.has_webgl) {
         this.glglyph = new MarkerGL(regl_wrapper, this, "circle")
       }

--- a/bokehjs/src/lib/models/glyphs/line.ts
+++ b/bokehjs/src/lib/models/glyphs/line.ts
@@ -1,7 +1,6 @@
 import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {generic_line_scalar_legend, line_interpolation} from "./utils"
 import {LineGL} from "./webgl/line_gl"
-import {get_regl, ReglWrapper} from "./webgl/regl_wrap"
 import {PointGeometry, SpanGeometry} from "core/geometry"
 import {Arrayable, Rect} from "core/types"
 import * as p from "core/properties"
@@ -27,7 +26,7 @@ export class LineView extends XYGlyphView {
 
     const {webgl} = this.renderer.plot_view.canvas_view
     if (webgl != null) {
-      const regl_wrapper: ReglWrapper = get_regl(webgl.gl)
+      const {regl_wrapper} = webgl
       if (regl_wrapper.has_webgl) {
         this.glglyph = new LineGL(regl_wrapper, this)
       }

--- a/bokehjs/src/lib/models/glyphs/rect.ts
+++ b/bokehjs/src/lib/models/glyphs/rect.ts
@@ -8,7 +8,6 @@ import {max} from "core/util/arrayable"
 import {Context2d} from "core/util/canvas"
 import {Selection} from "../selections/selection"
 import {Scale} from "../scales/scale"
-import {get_regl, ReglWrapper} from "./webgl/regl_wrap"
 import {RectGL} from "./webgl/rect"
 
 export type RectData = CenterRotatableData & {
@@ -31,7 +30,7 @@ export class RectView extends CenterRotatableView {
 
     const {webgl} = this.renderer.plot_view.canvas_view
     if (webgl != null) {
-      const regl_wrapper: ReglWrapper = get_regl(webgl.gl)
+      const {regl_wrapper} = webgl
       if (regl_wrapper.has_webgl) {
         this.glglyph = new RectGL(regl_wrapper, this)
       }

--- a/bokehjs/src/lib/models/glyphs/scatter.ts
+++ b/bokehjs/src/lib/models/glyphs/scatter.ts
@@ -1,7 +1,6 @@
 import {Marker, MarkerView, MarkerData} from "./marker"
 import {marker_funcs} from "./defs"
 import {MarkerGL} from "./webgl/markers"
-import {get_regl, ReglWrapper} from "./webgl/regl_wrap"
 import {MarkerType} from "core/enums"
 import {Rect} from "core/types"
 import * as p from "core/properties"
@@ -22,7 +21,7 @@ export class ScatterView extends MarkerView {
   protected _init_webgl(): void {
     const {webgl} = this.renderer.plot_view.canvas_view
     if (webgl != null) {
-      const regl_wrapper: ReglWrapper = get_regl(webgl.gl)
+      const {regl_wrapper} = webgl
       if (regl_wrapper.has_webgl) {
         const marker_types = new Set(this.marker)
         if (marker_types.size == 1) {

--- a/bokehjs/src/lib/models/glyphs/webgl/line_gl.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/line_gl.ts
@@ -58,6 +58,8 @@ export class LineGL extends BaseGLGlyph {
 
     if (this._is_dashed()) {
       const props: LineDashGlyphProps = {
+        scissor: this.regl_wrapper.scissor,
+        viewport: this.regl_wrapper.viewport,
         canvas_size: [transform.width, transform.height],
         pixel_ratio: transform.pixel_ratio,
         line_color: this._color,
@@ -77,6 +79,8 @@ export class LineGL extends BaseGLGlyph {
       this.regl_wrapper.dashed_line()(props)
     } else {
       const props: LineGlyphProps = {
+        scissor: this.regl_wrapper.scissor,
+        viewport: this.regl_wrapper.viewport,
         canvas_size: [transform.width, transform.height],
         pixel_ratio: transform.pixel_ratio,
         line_color: this._color,

--- a/bokehjs/src/lib/models/glyphs/webgl/markers.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/markers.ts
@@ -119,6 +119,8 @@ export class MarkerGL extends BaseGLGlyph {
     }
 
     const props: MarkerGlyphProps = {
+      scissor: this.regl_wrapper.scissor,
+      viewport: this.regl_wrapper.viewport,
       canvas_size: [transform.width, transform.height],
       pixel_ratio: transform.pixel_ratio,
       center: mainGlGlyph._centers,

--- a/bokehjs/src/lib/models/glyphs/webgl/rect.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/rect.ts
@@ -73,6 +73,8 @@ export class RectGL extends BaseGLGlyph {
 
     if (this._have_hatch) {
       const props: RectHatchGlyphProps = {
+        scissor: this.regl_wrapper.scissor,
+        viewport: this.regl_wrapper.viewport,
         canvas_size: [transform.width, transform.height],
         pixel_ratio: transform.pixel_ratio,
         center: mainGlGlyph._centers,
@@ -94,6 +96,8 @@ export class RectGL extends BaseGLGlyph {
       this.regl_wrapper.rect_hatch()(props)
     } else {
       const props: RectGlyphProps = {
+        scissor: this.regl_wrapper.scissor,
+        viewport: this.regl_wrapper.viewport,
         canvas_size: [transform.width, transform.height],
         pixel_ratio: transform.pixel_ratio,
         center: mainGlGlyph._centers,

--- a/bokehjs/src/lib/models/glyphs/webgl/regl_wrap.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/regl_wrap.ts
@@ -1,5 +1,5 @@
 import createRegl from "regl"
-import {Regl, DrawConfig, AttributeConfig} from "regl"
+import {Regl, DrawConfig, AttributeConfig, BoundingBox} from "regl"
 import * as t from "./types"
 import {DashCache, DashReturn} from "./dash_cache"
 import line_vertex_shader from "./regl_line.vert"
@@ -36,6 +36,10 @@ export class ReglWrapper {
   private _rect_no_hatch: ReglRenderFunction
   private _rect_hatch: ReglRenderFunction
 
+  // WebGL state variables.
+  private _scissor: BoundingBox
+  private _viewport: BoundingBox
+
   constructor(gl: WebGLRenderingContext) {
     try {
       this._regl = createRegl({
@@ -51,8 +55,25 @@ export class ReglWrapper {
     }
   }
 
+  clear(width: number, height: number): void {
+    this._viewport = {x: 0, y: 0, width, height}
+    this._regl.clear({color: [0, 0, 0, 0]})
+  }
+
   get has_webgl(): boolean {
     return this._regl_available
+  }
+
+  get scissor(): BoundingBox {
+    return this._scissor
+  }
+
+  set_scissor(x: number, y: number, width: number, height: number): void {
+    this._scissor = {x, y, width, height}
+  }
+
+  get viewport(): BoundingBox {
+    return this._viewport
   }
 
   public dashed_line(): ReglRenderFunction {
@@ -195,6 +216,11 @@ function regl_solid_line(regl: Regl): ReglRenderFunction {
       },
     },
     depth: {enable: false},
+    scissor: {
+      enable: true,
+      box: regl.prop<Props, 'scissor'>('scissor'),
+    },
+    viewport: regl.prop<Props, 'viewport'>('viewport'),
   }
 
   return regl<Uniforms, Attributes, Props>(config)
@@ -280,6 +306,11 @@ function regl_dashed_line(regl: Regl): ReglRenderFunction {
       },
     },
     depth: {enable: false},
+    scissor: {
+      enable: true,
+      box: regl.prop<Props, 'scissor'>('scissor'),
+    },
+    viewport: regl.prop<Props, 'viewport'>('viewport'),
   }
 
   return regl<Uniforms, Attributes, Props>(config)
@@ -365,6 +396,11 @@ function regl_marker(regl: Regl, marker_type: MarkerType): ReglRenderFunction {
       },
     },
     depth: {enable: false},
+    scissor: {
+      enable: true,
+      box: regl.prop<Props, 'scissor'>('scissor'),
+    },
+    viewport: regl.prop<Props, 'viewport'>('viewport'),
   }
 
   return regl<Uniforms, Attributes, Props>(config)
@@ -440,6 +476,11 @@ function regl_rect_no_hatch(regl: Regl): ReglRenderFunction {
       },
     },
     depth: {enable: false},
+    scissor: {
+      enable: true,
+      box: regl.prop<Props, 'scissor'>('scissor'),
+    },
+    viewport: regl.prop<Props, 'viewport'>('viewport'),
   }
 
   return regl<Uniforms, Attributes, Props>(config)
@@ -527,6 +568,11 @@ function regl_rect_hatch(regl: Regl): ReglRenderFunction {
       },
     },
     depth: {enable: false},
+    scissor: {
+      enable: true,
+      box: regl.prop<Props, 'scissor'>('scissor'),
+    },
+    viewport: regl.prop<Props, 'viewport'>('viewport'),
   }
 
   return regl<Uniforms, Attributes, Props>(config)

--- a/bokehjs/src/lib/models/glyphs/webgl/types.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/types.ts
@@ -1,7 +1,9 @@
-import {AttributeConfig, Texture2D, Vec2, Vec4} from "regl"
+import {AttributeConfig, BoundingBox, Texture2D, Vec2, Vec4} from "regl"
 
 // Props are used to pass properties from GL glyph classes to ReGL functions.
 type CommonProps = {
+  scissor: BoundingBox
+  viewport: BoundingBox
   canvas_size: Vec2
   pixel_ratio: number
   antialias: number


### PR DESCRIPTION
ReGL recommends that the underlying WebGLRenderingContext should not be used directly (https://github.com/regl-project/regl/blob/gh-pages/API.md#unsafe-escape-hatch).  There were a few uses in `bokehjs/src/lib/models/canvas/canvas.ts` to set the viewport, set the scissor box and clear the WebGL rendering buffer; this PR moves the functionality to `ReglWrapper`.

The `canvas.ts` `WebGLState` type now stores a `ReglWrapper` rather than a `WebGLRenderingContext` and this is what is passed to the various WebGL glyph constructors.