### PR TITLE
WebGL line glyphs reuse arrays and buffers

### DIFF
--- a/bokehjs/src/lib/models/glyphs/webgl/base.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/base.ts
@@ -2,6 +2,7 @@
 import {Context2d} from "core/util/canvas"
 import {GlyphView} from "../glyph"
 import {ReglWrapper} from "./regl_wrap"
+import {FloatBuffer} from "./types"
 
 export abstract class BaseGLGlyph {
   protected regl_wrapper: ReglWrapper
@@ -43,6 +44,34 @@ export abstract class BaseGLGlyph {
   }
 
   abstract draw(indices: number[], mainglyph: any, trans: Transform): void
+
+  // Return array from FloatBuffer, creating it if necessary.
+  protected get_buffer_array(float_buffer: FloatBuffer, length: number): Float32Array {
+    if (float_buffer == null || float_buffer.array.length != length)
+      return new Float32Array(length)
+    else
+      return float_buffer.array
+  }
+
+  // Update FloatBuffer with data contained in array.
+  protected update_buffer(float_buffer: FloatBuffer, array: Float32Array): FloatBuffer {
+    if (float_buffer == null) {
+      // Create new buffer.
+      float_buffer = {
+        array,
+        buffer: this.regl_wrapper.buffer({
+          usage: 'dynamic',
+          type: 'float',
+          data: array,
+        }),
+      }
+    } else {
+      // Reuse existing buffer.
+      float_buffer.array = array
+      float_buffer.buffer({data: array})
+    }
+    return float_buffer
+  }
 }
 
 export type Transform = {

--- a/bokehjs/src/lib/models/glyphs/webgl/base.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/base.ts
@@ -46,7 +46,7 @@ export abstract class BaseGLGlyph {
   abstract draw(indices: number[], mainglyph: any, trans: Transform): void
 
   // Return array from FloatBuffer, creating it if necessary.
-  protected get_buffer_array(float_buffer: FloatBuffer, length: number): Float32Array {
+  protected get_buffer_array(float_buffer: FloatBuffer | null, length: number): Float32Array {
     if (float_buffer == null || float_buffer.array.length != length)
       return new Float32Array(length)
     else
@@ -54,7 +54,7 @@ export abstract class BaseGLGlyph {
   }
 
   // Update FloatBuffer with data contained in array.
-  protected update_buffer(float_buffer: FloatBuffer, array: Float32Array): FloatBuffer {
+  protected update_buffer(float_buffer: FloatBuffer | null, array: Float32Array): FloatBuffer {
     if (float_buffer == null) {
       // Create new buffer.
       float_buffer = {

--- a/bokehjs/src/lib/models/glyphs/webgl/line_gl.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/line_gl.ts
@@ -5,7 +5,7 @@ import {color2rgba} from "core/util/color"
 import {resolve_line_dash} from "core/visuals/line"
 import {Texture2D} from "regl"
 import {cap_lookup, join_lookup} from "./webgl_utils"
-import {LineGlyphProps, LineDashGlyphProps} from "./types"
+import {FloatBuffer, LineGlyphProps, LineDashGlyphProps} from "./types"
 
 // Avoiding use of nan or inf to represent missing data in webgl as shaders may
 // have reduced floating point precision.  So here using a large-ish negative
@@ -15,7 +15,7 @@ const missing_point_threshold = -9000.0
 
 export class LineGL extends BaseGLGlyph {
   protected _nsegments: number
-  protected _points: Float32Array
+  protected _points: FloatBuffer
 
   protected _antialias: number
   protected _color: number[]
@@ -25,7 +25,7 @@ export class LineGL extends BaseGLGlyph {
   protected _is_closed: boolean
 
   // Only needed if line has dashes.
-  protected _length_so_far?: Float32Array
+  protected _length_so_far?: FloatBuffer
   protected _dash_tex?: Texture2D
   protected _dash_tex_info?: number[]
   protected _dash_scale?: number
@@ -66,11 +66,11 @@ export class LineGL extends BaseGLGlyph {
         linewidth: this._linewidth,
         antialias: this._antialias,
         miter_limit: this._miter_limit,
-        points: this._points,
-        nsegments: this._nsegments,
+        points: mainGlGlyph._points.buffer,
+        nsegments: mainGlGlyph._nsegments,
         line_join,
         line_cap,
-        length_so_far: this._length_so_far!,
+        length_so_far: mainGlGlyph._length_so_far!.buffer,
         dash_tex: this._dash_tex!,
         dash_tex_info: this._dash_tex_info!,
         dash_scale: this._dash_scale!,
@@ -87,8 +87,8 @@ export class LineGL extends BaseGLGlyph {
         linewidth: this._linewidth,
         antialias: this._antialias,
         miter_limit: this._miter_limit,
-        points: this._points,
-        nsegments: this._nsegments,
+        points: mainGlGlyph._points.buffer,
+        nsegments: mainGlGlyph._nsegments,
         line_join,
         line_cap,
       }
@@ -111,43 +111,45 @@ export class LineGL extends BaseGLGlyph {
                          isFinite(this.glyph.sy[0]))
     }
 
-    if (this._points == null)
-      this._points = new Float32Array((npoints+2)*2)
+    const points_array = this.get_buffer_array(this._points, (npoints+2)*2)
 
     for (let i = 1; i < npoints+1; i++) {
       if (isFinite(this.glyph.sx[i-1]) && isFinite(this.glyph.sy[i-1])) {
-        this._points[2*i  ] = this.glyph.sx[i-1]
-        this._points[2*i+1] = this.glyph.sy[i-1]
+        points_array[2*i  ] = this.glyph.sx[i-1]
+        points_array[2*i+1] = this.glyph.sy[i-1]
       } else {
-        this._points[2*i  ] = missing_point
-        this._points[2*i+1] = missing_point
+        points_array[2*i  ] = missing_point
+        points_array[2*i+1] = missing_point
       }
     }
 
     if (this._is_closed) {
-      this._points[0] = this._points[2*npoints-2]  // Last but one point.
-      this._points[1] = this._points[2*npoints-1]
-      this._points[2*npoints+2] = this._points[4]  // Second point.
-      this._points[2*npoints+3] = this._points[5]
+      points_array[0] = points_array[2*npoints-2]  // Last but one point.
+      points_array[1] = points_array[2*npoints-1]
+      points_array[2*npoints+2] = points_array[4]  // Second point.
+      points_array[2*npoints+3] = points_array[5]
     } else {
-      this._points[0] = missing_point
-      this._points[1] = missing_point
-      this._points[2*npoints+2] = missing_point
-      this._points[2*npoints+3] = missing_point
+      points_array[0] = missing_point
+      points_array[1] = missing_point
+      points_array[2*npoints+2] = missing_point
+      points_array[2*npoints+3] = missing_point
     }
 
+    this._points = this.update_buffer(this._points, points_array)
+
     if (this._is_dashed()) {
-      if (this._length_so_far == null)
-        this._length_so_far = new Float32Array(this._nsegments)
+      const lengths_array = this.get_buffer_array(this._length_so_far!, this._nsegments)
 
       let length = 0.0
       for (let i = 0; i < this._nsegments; i++) {
-        this._length_so_far[i] = length
-        if (this._points[2*i+2] > missing_point_threshold &&
-            this._points[2*i+4] > missing_point_threshold)
-          length += Math.sqrt((this._points[2*i+4] - this._points[2*i+2])**2 +
-                              (this._points[2*i+5] - this._points[2*i+3])**2)
+        lengths_array[i] = length
+        if (points_array[2*i+2] > missing_point_threshold &&
+            points_array[2*i+4] > missing_point_threshold)
+          length += Math.sqrt((points_array[2*i+4] - points_array[2*i+2])**2 +
+                              (points_array[2*i+5] - points_array[2*i+3])**2)
       }
+
+      this._length_so_far = this.update_buffer(this._length_so_far!, lengths_array)
     }
   }
 

--- a/bokehjs/src/lib/models/glyphs/webgl/types.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/types.ts
@@ -1,4 +1,11 @@
-import {AttributeConfig, BoundingBox, Texture2D, Vec2, Vec4} from "regl"
+import {AttributeConfig, BoundingBox, Buffer, Texture2D, Vec2, Vec4} from "regl"
+
+// Arrays are sent to GPU using ReGL Buffer objects.  CPU-side arrays used to
+// update the Buffers are also kept for reuse to avoid unnecessary reallocation.
+export type FloatBuffer = {
+  buffer: Buffer
+  array: Float32Array
+}
 
 // Props are used to pass properties from GL glyph classes to ReGL functions.
 type CommonProps = {
@@ -25,7 +32,7 @@ type FillProps = {
 }
 
 type DashProps = {
-  length_so_far: Float32Array
+  length_so_far: Buffer
   dash_tex: Texture2D
   dash_tex_info: number[]
   dash_scale: number
@@ -43,7 +50,7 @@ export type LineGlyphProps = CommonProps & {
   line_color: number[]
   linewidth: number
   miter_limit: number
-  points: Float32Array
+  points: Buffer
   nsegments: number
   line_cap: number
   line_join: number


### PR DESCRIPTION
Improvements to WebGL line glyphs to reuse `Float32Array` and ReGL `Buffer` objects rather than recreating them frequently. No change in functionality or rendered output.  Partially addresses the 5th item of issue #11052, but I need to do similar changes to the WebGL `rect` and `marker` glyphs to complete that item.

The motivation is performance improvement.  To demonstrate this I am tentatively stepping into the realm of benchmarking, but in a somewhat manual and rudimentary way.  I am using this modified version of the 10k lines example
```python
import numpy as np
np.random.seed(8417)
from bokeh.plotting import figure, curdoc

N = 500_000
backend = 'webgl'

p = figure(width=800, height=800, output_backend=backend, title=backend, lod_threshold=None)
x = np.linspace(0, 10*np.pi, N)
y = np.cos(x) + np.sin(2*x+1.25) + np.random.normal(0, 0.001, (N, ))
p.line(x, y, line_width=3)
curdoc().add_root(p)
```
which is a single line of half a million points in an 800x800 pixel canvas.  I am rendering it in chromium and once it is displayed I am panning it with a circular motion and seeing what the chromium FPS counter reports.  This is a very simple test but I have to start somewhere.  My dev machine is a new-ish low spec Dell business laptop with integrated graphics, so some WebGL capability but certainly nothing special.

FPS figures after these changes are 14.4 for webgl and 4.2 for canvas (measurement precision is apparently 0.6 FPS).  Before these changes (commit 4046480) webgl was 13.8 FPS so I haven't really improved it much with this PR.  Bokeh 2.2.3 with the previous webgl implementation gives 4.2 FPS for webgl and 3.6 for canvas.