### PR TITLE
Start statically type `bokeh.core.properties`

### DIFF
--- a/bokeh/_testing/util/examples.py
+++ b/bokeh/_testing/util/examples.py
@@ -75,7 +75,7 @@ class Example:
         self.pixels = 0
         self._has_ref = None
 
-    def __str__(self):
+    def __str__(self) -> str:
         flags = [
             "file"     if self.is_file     else "",
             "server"   if self.is_server   else "",

--- a/bokeh/colors/color.py
+++ b/bokeh/colors/color.py
@@ -37,7 +37,7 @@ class Color:
 
     '''
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.to_css()
 
     @staticmethod

--- a/bokeh/core/enums.py
+++ b/bokeh/core/enums.py
@@ -72,6 +72,12 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any, Dict
+
+# External imports
+from typing_extensions import Literal
+
 # Bokeh imports
 from .. import colors, palettes
 
@@ -163,7 +169,7 @@ class Enumeration:
             value = value.lower()
         return value in self._values
 
-    def __str__(self):
+    def __str__(self) -> str:
         if self._quote:
             return "Enumeration(%s)" % ", ".join(repr(x) for x in self._values)
         else:
@@ -174,7 +180,7 @@ class Enumeration:
 
     __repr__ = __str__
 
-def enumeration(*values, **kwargs):
+def enumeration(*values: str, case_sensitive: bool = True, quote: bool = False):
     ''' Create an |Enumeration| object from a sequence of values.
 
     Call ``enumeration`` with a sequence of (unique) strings to create an
@@ -213,12 +219,12 @@ def enumeration(*values, **kwargs):
     if len(values) != len(set(values)):
         raise ValueError("enumeration items must be unique, got %s" % values)
 
-    attrs = {value: value for value in values}
+    attrs: Dict[str, Any] = {value: value for value in values}
     attrs.update({
         "_values": list(values),
         "_default": values[0],
-        "_case_sensitive": kwargs.get("case_sensitive", True),
-        "_quote": kwargs.get("quote", False),
+        "_case_sensitive": case_sensitive,
+        "_quote": quote,
     })
 
     return type("Enumeration", (Enumeration,), attrs)()
@@ -345,7 +351,8 @@ LineDash = enumeration("solid", "dashed", "dotted", "dotdash", "dashdot")
 LineJoin = enumeration("miter", "round", "bevel")
 
 #: Specify a location in plot layouts
-Location = enumeration("above", "below", "left", "right")
+_Location = Literal["above", "below", "left", "right"]
+Location = enumeration(*_Location.__args__)
 
 #: Specify a style for a Google map
 MapType = enumeration("satellite", "roadmap", "terrain", "hybrid")
@@ -396,9 +403,9 @@ RoundingFunction = enumeration("round", "nearest", "floor", "rounddown", "ceil",
 SelectionMode = enumeration("replace", "append", "intersect", "subtract")
 
 #: Sizing mode policies
-SizingMode = enumeration("stretch_width", "stretch_height", "stretch_both",
-                         "scale_width", "scale_height", "scale_both",
-                         "fixed")
+_SizingMode = Literal["stretch_width", "stretch_height", "stretch_both",
+                      "scale_width", "scale_height", "scale_both", "fixed"]
+SizingMode = enumeration(*_SizingMode.__args__)
 
 #: Individual sizing mode policies
 SizingPolicy = enumeration("fixed", "fit", "min", "max")

--- a/bokeh/core/has_props.py
+++ b/bokeh/core/has_props.py
@@ -29,15 +29,35 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import difflib
-from functools import lru_cache
 from typing import (
+    TYPE_CHECKING,
     Any,
+    Callable,
     Dict,
+    Iterable,
+    List,
+    NoReturn,
     Optional,
     Set,
+    Type,
+    TypeVar,
     Union,
+    overload,
 )
 from warnings import warn
+
+# External imports
+from typing_extensions import Literal
+
+if TYPE_CHECKING:
+    F = TypeVar("F", bound=Callable[..., Any])
+    def lru_cache(arg: Optional[int]) -> Callable[[F], F]: ...
+else:
+    from functools import lru_cache
+
+if TYPE_CHECKING:
+    from .property.dataspec import DataSpec
+    from .property.bases import Property
 
 # Bokeh imports
 from ..util.string import append_docstring, nice_join
@@ -57,6 +77,8 @@ __all__ = (
     'MetaHasProps',
 )
 
+JSON = Any
+
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
@@ -65,7 +87,9 @@ __all__ = (
 # Dev API
 #-----------------------------------------------------------------------------
 
-def abstract(cls):
+C = TypeVar("C", bound=Type[Any])
+
+def abstract(cls: C) -> C:
     ''' A decorator to mark abstract base classes derived from |HasProps|.
 
     '''
@@ -74,12 +98,12 @@ def abstract(cls):
     cls.__doc__ = append_docstring(cls.__doc__, _ABSTRACT_ADMONITION)
     return cls
 
-def is_DataModel(cls):
+def is_DataModel(cls: Type[Any]) -> bool:
     from ..model import DataModel
     return issubclass(cls, HasProps) and getattr(cls, "__data_model__", False) and cls != DataModel
 
-def _overridden_defaults(class_dict):
-    overridden_defaults = {}
+def _overridden_defaults(class_dict: Dict[str, Any]) -> Dict[str, Any]:
+    overridden_defaults: Dict[str, Any] = {}
     for name, prop in tuple(class_dict.items()):
         if isinstance(prop, Override):
             del class_dict[name]
@@ -87,8 +111,8 @@ def _overridden_defaults(class_dict):
                 overridden_defaults[name] = prop.default
     return overridden_defaults
 
-def _generators(class_dict):
-    generators = dict()
+def _generators(class_dict: Dict[str, Any]):
+    generators: Dict[str, PropertyDescriptorFactory[Any]] = {}
     for name, generator in tuple(class_dict.items()):
         if isinstance(generator, PropertyDescriptorFactory):
             del class_dict[name]
@@ -106,7 +130,7 @@ class MetaHasProps(type):
 
     '''
 
-    def __new__(cls, class_name, bases, class_dict):
+    def __new__(cls, class_name: str, bases: List[Type[Any]], class_dict: Dict[str, Any]):
         '''
 
         '''
@@ -129,9 +153,9 @@ class MetaHasProps(type):
 
         return super().__new__(cls, class_name, bases, class_dict)
 
-    def __init__(cls, class_name, bases, __):
+    def __init__(cls, class_name: str, bases: List[Type[Any]], __):
         # Check for improperly redeclared a Property attribute.
-        base_properties = {}
+        base_properties: Dict[str, Any] = {}
         for base in (x for x in bases if issubclass(x, HasProps)):
             base_properties.update(base.properties(_with_props=True))
         own_properties = {k: v for k, v in cls.__dict__.items() if isinstance(v, PropertyDescriptor)}
@@ -155,21 +179,25 @@ class HasProps(metaclass=MetaHasProps):
     '''
     _initialized: bool = False
 
-    def __init__(self, **properties):
+    _property_values: Dict[str, Any]
+    _unstable_default_values: Dict[str, Any]
+    _unstable_themed_values: Dict[str, Any]
+
+    def __init__(self, **properties: Any):
         '''
 
         '''
         super().__init__()
-        self._property_values = dict()
-        self._unstable_default_values = dict()
-        self._unstable_themed_values = dict()
+        self._property_values = {}
+        self._unstable_default_values = {}
+        self._unstable_themed_values = {}
 
         for name, value in properties.items():
             setattr(self, name, value)
 
         self._initialized = True
 
-    def __setattr__(self, name, value):
+    def __setattr__(self, name: str, value: Any) -> None:
         ''' Intercept attribute setting on HasProps in order to special case
         a few situations:
 
@@ -197,7 +225,7 @@ class HasProps(metaclass=MetaHasProps):
 
         self._raise_attribute_error_with_matches(name, properties)
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         ''' Intercept attribute setting on HasProps in order to special case
         a few situations:
 
@@ -225,7 +253,7 @@ class HasProps(metaclass=MetaHasProps):
 
         self._raise_attribute_error_with_matches(name, properties)
 
-    def _raise_attribute_error_with_matches(self, name, properties):
+    def _raise_attribute_error_with_matches(self, name: str, properties: Iterable[str]) -> NoReturn:
         matches, text = difflib.get_close_matches(name.lower(), properties), "similar"
 
         if not matches:
@@ -247,7 +275,7 @@ class HasProps(metaclass=MetaHasProps):
     #
     # [1] https://docs.python.org/3/reference/datamodel.html#object.__hash__
     #
-    def equals(self, other):
+    def equals(self, other: HasProps) -> bool:
         ''' Structural equality of models.
 
         Args:
@@ -308,7 +336,8 @@ class HasProps(metaclass=MetaHasProps):
     def to_serializable(self, serializer):
         pass # TODO: new serializer, hopefully in near future
 
-    def set_from_json(self, name, json, *, models=None, setter=None):
+    def set_from_json(self, name: str, json: JSON, *,
+            models: Dict[str, HasProps] | None =None, setter: HasProps | None = None):
         ''' Set a property value on this object from JSON.
 
         Args:
@@ -337,13 +366,13 @@ class HasProps(metaclass=MetaHasProps):
 
         '''
         if name in self.properties(_with_props=True):
-            log.trace("Patching attribute %r of %r with %r", name, self, json)
+            log.trace(f"Patching attribute {name!r} of {self!r} with {json!r}")
             descriptor = self.lookup(name)
             descriptor.set_from_json(self, json, models=models, setter=setter)
         else:
             log.warning("JSON had attr %r on obj %r, which is a client-only or invalid attribute that shouldn't have been sent", name, self)
 
-    def update(self, **kwargs):
+    def update(self, **kwargs: Any) -> None:
         ''' Updates the object's properties from the given keyword arguments.
 
         Returns:
@@ -367,10 +396,11 @@ class HasProps(metaclass=MetaHasProps):
                 r.update(start=10, end=20)
 
         '''
-        for k,v in kwargs.items():
+        for k, v in kwargs.items():
             setattr(self, k, v)
 
-    def update_from_json(self, json_attributes, *, models=None, setter=None):
+    def update_from_json(self, json_attributes: Dict[str, JSON], *,
+            models: Dict[str, HasProps] | None = None, setter: HasProps | None = None) -> None:
         ''' Updates the object's properties from a JSON attributes dictionary.
 
         Args:
@@ -399,8 +429,16 @@ class HasProps(metaclass=MetaHasProps):
         for k, v in json_attributes.items():
             self.set_from_json(k, v, models=models, setter=setter)
 
+    @overload
     @classmethod
-    def lookup(cls, name: str, *, raises: bool = True) -> Optional[PropertyDescriptor]:
+    def lookup(cls, name: str, *, raises: Literal[True] = True) -> PropertyDescriptor[Any]: ...
+
+    @overload
+    @classmethod
+    def lookup(cls, name: str, *, raises: Literal[False] = False) -> PropertyDescriptor[Any] | None: ...
+
+    @classmethod
+    def lookup(cls, name: str, *, raises: bool = True) -> Optional[PropertyDescriptor[Any]]:
         ''' Find the ``PropertyDescriptor`` for a Bokeh property on a class,
         given the property name.
 
@@ -417,9 +455,19 @@ class HasProps(metaclass=MetaHasProps):
             return attr
         raise AttributeError(f"{cls.__name__}.{name} property descriptor does not exist")
 
+    @overload
     @classmethod
     @lru_cache(None)
-    def properties(cls, *, _with_props: bool = False) -> Union[Set[str], Dict[str, PropertyDescriptorFactory]]:
+    def properties(cls, *, _with_props: Literal[False] = False) -> Set[str]: ...
+
+    @overload
+    @classmethod
+    @lru_cache(None)
+    def properties(cls, *, _with_props: Literal[True] = True) -> Dict[str, Property[Any]]: ...
+
+    @classmethod
+    @lru_cache(None)
+    def properties(cls, *, _with_props: bool = False) -> Union[Set[str], Dict[str, Property[Any]]]:
         ''' Collect the names of properties on this class.
 
         .. warning::
@@ -431,7 +479,7 @@ class HasProps(metaclass=MetaHasProps):
             property names
 
         '''
-        props = dict()
+        props: Dict[str, Property[Any]] = {}
         for c in cls.__mro__:
             props.update(getattr(c, "__properties__", {}))
 
@@ -442,7 +490,7 @@ class HasProps(metaclass=MetaHasProps):
 
     @classmethod
     @lru_cache(None)
-    def properties_with_refs(cls):
+    def properties_with_refs(cls) -> Dict[str, Property[Any]]:
         ''' Collect the names of all properties on this class that also have
         references.
 
@@ -457,7 +505,7 @@ class HasProps(metaclass=MetaHasProps):
 
     @classmethod
     @lru_cache(None)
-    def dataspecs(cls):
+    def dataspecs(cls) -> Dict[str, DataSpec]:
         ''' Collect the names of all ``DataSpec`` properties on this class.
 
         This method *always* traverses the class hierarchy and includes
@@ -495,19 +543,20 @@ class HasProps(metaclass=MetaHasProps):
             include_defaults=include_defaults, include_undefined=include_undefined)
 
     @classmethod
-    def _overridden_defaults(cls):
+    def _overridden_defaults(cls) -> Dict[str, Any]:
         ''' Returns a dictionary of defaults that have been overridden.
 
         .. note::
             This is an implementation detail of ``Property``.
 
         '''
-        defaults = dict()
+        defaults: Dict[str, Any] = {}
         for c in reversed(cls.__mro__):
             defaults.update(getattr(c, "__overridden_defaults__", {}))
         return defaults
 
-    def query_properties_with_values(self, query, *, include_defaults: bool = True, include_undefined: bool = False):
+    def query_properties_with_values(self, query: Callable[[PropertyDescriptor[Any]], bool], *,
+            include_defaults: bool = True, include_undefined: bool = False) -> Dict[str, Any]:
         ''' Query the properties values of |HasProps| instances with a
         predicate.
 
@@ -524,8 +573,9 @@ class HasProps(metaclass=MetaHasProps):
             dict : mapping of property names and values for matching properties
 
         '''
-        themed_keys = set()
-        result = dict()
+        themed_keys: Set[str] = set()
+        result: Dict[str, Any] = {}
+
         if include_defaults:
             keys = self.properties(_with_props=True)
         else:
@@ -559,7 +609,7 @@ class HasProps(metaclass=MetaHasProps):
 
         return result
 
-    def themed_values(self):
+    def themed_values(self) -> Dict[str, Any] | None:
         ''' Get any theme-provided overrides.
 
         Results are returned as a dict from property name to value, or
@@ -571,7 +621,7 @@ class HasProps(metaclass=MetaHasProps):
         '''
         return getattr(self, '__themed_values__', None)
 
-    def apply_theme(self, property_values):
+    def apply_theme(self, property_values: Dict[str, Any]) -> None:
         ''' Apply a set of theme values which will be used rather than
         defaults, but will not override application-set values.
 
@@ -592,13 +642,13 @@ class HasProps(metaclass=MetaHasProps):
         if old_dict is property_values:  # lgtm [py/comparison-using-is]
             return
 
-        removed = set()
+        removed: Set[str] = set()
         # we're doing a little song-and-dance to avoid storing __themed_values__ or
         # an empty dict, if there's no theme that applies to this HasProps instance.
         if old_dict is not None:
             removed.update(set(old_dict.keys()))
         added = set(property_values.keys())
-        old_values = dict()
+        old_values: Dict[str, Any] = {}
         for k in added.union(removed):
             old_values[k] = getattr(self, k)
 
@@ -619,16 +669,16 @@ class HasProps(metaclass=MetaHasProps):
             if isinstance(descriptor, PropertyDescriptor):
                 descriptor.trigger_if_changed(self, v)
 
-    def unapply_theme(self):
+    def unapply_theme(self) -> None:
         ''' Remove any themed values and restore defaults.
 
         Returns:
             None
 
         '''
-        self.apply_theme(property_values=dict())
+        self.apply_theme(property_values={})
 
-    def _clone(self):
+    def _clone(self) -> HasProps:
         ''' Duplicate a HasProps object.
 
         Values that are containers are shallow-copied.

--- a/bokeh/core/property/any.py
+++ b/bokeh/core/property/any.py
@@ -91,7 +91,7 @@ class AnyRef(Any):
     """ Accept all values and force reference discovery. """
 
     @property
-    def has_ref(self):
+    def has_ref(self) -> bool:
         return True
 
 #-----------------------------------------------------------------------------

--- a/bokeh/core/property/auto.py
+++ b/bokeh/core/property/auto.py
@@ -65,7 +65,7 @@ class Auto(Enum):
     def __init__(self):
         super().__init__("auto")
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.__class__.__name__
 
 #-----------------------------------------------------------------------------

--- a/bokeh/core/property/bases.py
+++ b/bokeh/core/property/bases.py
@@ -29,7 +29,18 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import types
 from copy import copy
-from typing import Any, Type, Union
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 # External imports
 import numpy as np
@@ -41,7 +52,12 @@ from ..has_props import HasProps
 from ._sphinx import property_link, register_type_link, type_link
 from .descriptor_factory import PropertyDescriptorFactory
 from .descriptors import PropertyDescriptor
-from .singletons import Intrinsic, Undefined
+from .singletons import (
+    Intrinsic,
+    IntrinsicType,
+    Undefined,
+    UndefinedType,
+)
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -65,10 +81,16 @@ __all__ = (
 # Dev API
 #-----------------------------------------------------------------------------
 
+T = TypeVar("T")
+
+TypeOrInst = Union[Type[T], T]
+
+Init = Union[T, UndefinedType, IntrinsicType]
+
 class DeserializationError(Exception):
     pass
 
-class Property(PropertyDescriptorFactory):
+class Property(PropertyDescriptorFactory[T]):
     """ Base class for Bokeh property instances, which can be added to Bokeh
     Models.
 
@@ -92,9 +114,15 @@ class Property(PropertyDescriptorFactory):
     """
 
     # This class attribute is controlled by external helper API for validation
-    _should_validate = True
+    _should_validate: ClassVar[bool] = True
 
-    def __init__(self, default=Intrinsic, help=None, serialized=None, readonly=False):
+    _readonly: bool
+
+    alternatives: List[Tuple[Property[Any], Callable[[Property[Any]], T]]]
+    assertions: List[Tuple[Callable[[HasProps, T], bool], str | Callable[[HasProps, str, T], None]]]
+
+    def __init__(self, default: Init[T] = Intrinsic, help: Optional[str] = None,
+            serialized: Optional[bool] = None, readonly: bool = False):
         default = default if default is not Intrinsic else Undefined
 
         if serialized is None:
@@ -110,10 +138,10 @@ class Property(PropertyDescriptorFactory):
         self.alternatives = []
         self.assertions = []
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.__class__.__name__
 
-    def make_descriptors(self, base_name):
+    def make_descriptors(self, name: str) -> List[PropertyDescriptor[T]]:
         """ Return a list of ``PropertyDescriptor`` instances to install
         on a class, in order to delegate attribute access to this property.
 
@@ -126,9 +154,9 @@ class Property(PropertyDescriptorFactory):
         The descriptors returned are collected by the ``MetaHasProps``
         metaclass and added to ``HasProps`` subclasses during class creation.
         """
-        return [ PropertyDescriptor(base_name, self) ]
+        return [ PropertyDescriptor(name, self) ]
 
-    def _may_have_unstable_default(self):
+    def _may_have_unstable_default(self) -> bool:
         """ False if we have a default that is immutable, and will be the
         same every time (some defaults are generated on demand by a function
         to be called).
@@ -137,7 +165,7 @@ class Property(PropertyDescriptorFactory):
         return isinstance(self._default, types.FunctionType)
 
     @classmethod
-    def _copy_default(cls, default):
+    def _copy_default(cls, default: Callable[[], T] | T) -> T:
         """ Return a copy of the default, or a new value if the default
         is specified by a function.
 
@@ -147,7 +175,7 @@ class Property(PropertyDescriptorFactory):
         else:
             return default()
 
-    def _raw_default(self):
+    def _raw_default(self) -> T:
         """ Return the untransformed default value.
 
         The raw_default() needs to be validated and transformed by
@@ -157,7 +185,7 @@ class Property(PropertyDescriptorFactory):
         """
         return self._copy_default(self._default)
 
-    def themed_default(self, cls, name, theme_overrides):
+    def themed_default(self, cls: Type[HasProps], name: str, theme_overrides: Dict[str, Any] | None) -> T:
         """ The default, transformed by prepare_value() and the theme overrides.
 
         """
@@ -172,7 +200,7 @@ class Property(PropertyDescriptorFactory):
         return self.prepare_value(cls, name, default)
 
     @property
-    def serialized(self):
+    def serialized(self) -> bool:
         """ Whether the property should be serialized when serializing an object.
 
         This would be False for a "virtual" or "convenience" property that duplicates
@@ -181,7 +209,7 @@ class Property(PropertyDescriptorFactory):
         return self._serialized
 
     @property
-    def readonly(self):
+    def readonly(self) -> bool:
         """ Whether this property is read-only.
 
         Read-only properties may only be modified by the client (i.e., by BokehJS
@@ -190,7 +218,7 @@ class Property(PropertyDescriptorFactory):
         """
         return self._readonly
 
-    def matches(self, new, old):
+    def matches(self, new: T, old: T) -> bool:
         """ Whether two parameters match values.
 
         If either ``new`` or ``old`` is a NumPy array or Pandas Series or Index,
@@ -230,7 +258,7 @@ class Property(PropertyDescriptorFactory):
         except ValueError:
             return False
 
-    def from_json(self, json, *, models=None):
+    def from_json(self, json: Any, *, models: Dict[str, HasProps] | None = None) -> T:
         """ Convert from JSON-compatible values into a value for this property.
 
         JSON-compatible values are: list, dict, number, string, bool, None
@@ -238,13 +266,13 @@ class Property(PropertyDescriptorFactory):
         """
         return json
 
-    def serialize_value(self, value):
+    def serialize_value(self, value: T) -> Any:
         """ Change the value into a JSON serializable format.
 
         """
         return value
 
-    def transform(self, value):
+    def transform(self, value: Any) -> T:
         """ Change the value into the canonical format for this property.
 
         Args:
@@ -256,7 +284,7 @@ class Property(PropertyDescriptorFactory):
         """
         return value
 
-    def validate(self, value, detail=True):
+    def validate(self, value: Any, detail: bool = True) -> None:
         """ Determine whether we can set this property from this value.
 
         Validation happens before transform()
@@ -279,7 +307,7 @@ class Property(PropertyDescriptorFactory):
         """
         pass
 
-    def is_valid(self, value):
+    def is_valid(self, value: Any) -> bool:
         """ Whether the value passes validation
 
         Args:
@@ -297,13 +325,13 @@ class Property(PropertyDescriptorFactory):
         else:
             return True
 
-    def wrap(self, value):
+    def wrap(self, value: T) -> T:
         """ Some property types need to wrap their values in special containers, etc.
 
         """
         return value
 
-    def prepare_value(self, owner: Union[HasProps, Type[HasProps]], name: str, value: Any):
+    def prepare_value(self, owner: HasProps | Type[HasProps], name: str, value: Any) -> T:
         if value is Intrinsic:
             value = self._raw_default()
         if value is Undefined:
@@ -347,10 +375,10 @@ class Property(PropertyDescriptorFactory):
         return self.wrap(value)
 
     @property
-    def has_ref(self):
+    def has_ref(self) -> bool:
         return False
 
-    def accepts(self, tp, converter):
+    def accepts(self, tp: TypeOrInst[Property[Any]], converter: Callable[[Property[Any]], T]) -> Property[T]:
         """ Declare that other types may be converted to this property type.
 
         Args:
@@ -371,7 +399,7 @@ class Property(PropertyDescriptorFactory):
         self.alternatives.append((tp, converter))
         return self
 
-    def asserts(self, fn, msg_or_fn):
+    def asserts(self, fn: Callable[[HasProps, T], bool], msg_or_fn: str | Callable[[HasProps, str, T], None]) -> Property[T]:
         """ Assert that prepared values satisfy given conditions.
 
         Assertions are intended in enforce conditions beyond simple value
@@ -396,13 +424,15 @@ class Property(PropertyDescriptorFactory):
         self.assertions.append((fn, msg_or_fn))
         return self
 
-class ParameterizedProperty(Property):
+TItem = TypeVar("TItem", bound=Property[Any])
+
+class ParameterizedProperty(Property[TItem]):
     """ A base class for Properties that have type parameters, e.g. ``List(String)``.
 
     """
 
     @staticmethod
-    def _validate_type_param(type_param, *, help_allowed=False):
+    def _validate_type_param(type_param: TypeOrInst[Property[Any]], *, help_allowed: bool = False) -> Property[Any]:
         if isinstance(type_param, type):
             if issubclass(type_param, Property):
                 return type_param()
@@ -417,45 +447,46 @@ class ParameterizedProperty(Property):
         raise ValueError(f"expected a Property as type parameter, got {type_param}")
 
     @property
-    def type_params(self):
+    def type_params(self) -> List[Property[Any]]:
         raise NotImplementedError("abstract method")
 
     @property
-    def has_ref(self):
+    def has_ref(self) -> bool:
         return any(type_param.has_ref for type_param in self.type_params)
 
-class SingleParameterizedProperty(ParameterizedProperty):
+class SingleParameterizedProperty(ParameterizedProperty[T]):
     """ A parameterized property with a single type parameter. """
 
-    def __init__(self, type_param, *, default=Intrinsic, help=None, serialized=None, readonly=False):
+    def __init__(self, type_param: TypeOrInst[Property[Any]], *, default: Init[T] = Intrinsic,
+            help: Optional[str] = None, serialized: Optional[bool] = None, readonly: bool = False):
         self.type_param = self._validate_type_param(type_param)
         default = default if default is not Intrinsic else self.type_param._raw_default()
         super().__init__(default=default, help=help, serialized=serialized, readonly=readonly)
 
     @property
-    def type_params(self):
+    def type_params(self) -> List[Property[Any]]:
         return [self.type_param]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.__class__.__name__}({self.type_param})"
 
     def validate(self, value: Any, detail: bool = True) -> None:
         super().validate(value, detail=detail)
         self.type_param.validate(value, detail=detail)
 
-    def from_json(self, json, *, models=None):
+    def from_json(self, json: Any, *, models: Dict[str, HasProps] | None = None) -> T:
         return self.type_param.from_json(json, models=models)
 
-    def transform(self, value):
+    def transform(self, value: T) -> T:
         return self.type_param.transform(value)
 
-    def wrap(self, value):
+    def wrap(self, value: T) -> T:
         return self.type_param.wrap(value)
 
-    def _may_have_unstable_default(self):
+    def _may_have_unstable_default(self) -> bool:
         return self.type_param._may_have_unstable_default()
 
-class PrimitiveProperty(Property):
+class PrimitiveProperty(Property[T]):
     """ A base class for simple property types.
 
     Subclasses should define a class attribute ``_underlying_type`` that is
@@ -472,9 +503,9 @@ class PrimitiveProperty(Property):
 
     """
 
-    _underlying_type = None
+    _underlying_type: ClassVar[Tuple[Type[T]]]
 
-    def validate(self, value, detail=True):
+    def validate(self, value: Any, detail: bool = True) -> None:
         super().validate(value, detail)
 
         if isinstance(value, self._underlying_type):
@@ -487,23 +518,23 @@ class PrimitiveProperty(Property):
         msg = f"expected a value of type {expected_type}, got {value} of type {type(value).__name__}"
         raise ValueError(msg)
 
-    def from_json(self, json, *, models=None):
+    def from_json(self, json: Any, *, models: Dict[str, HasProps] | None = None) -> T:
         if isinstance(json, self._underlying_type):
             return json
         expected_type = nice_join([ cls.__name__ for cls in self._underlying_type ])
         msg = f"{self} expected {expected_type}, got {json} of type {type(json).__name__}"
         raise DeserializationError(msg)
 
-class ContainerProperty(ParameterizedProperty):
+class ContainerProperty(ParameterizedProperty[T]):
     """ A base class for Container-like type properties.
 
     """
 
-    def _may_have_unstable_default(self):
+    def _may_have_unstable_default(self) -> bool:
         # all containers are mutable, so the default can be modified
         return True
 
-def validation_on():
+def validation_on() -> bool:
     """ Check if property validation is currently active
 
     Returns:

--- a/bokeh/core/property/color.py
+++ b/bokeh/core/property/color.py
@@ -135,7 +135,7 @@ class Color(Either):
         help = f"{help or ''}\n{self._default_help}"
         super().__init__(*types, default=default, help=help)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.__class__.__name__
 
     def transform(self, value):

--- a/bokeh/core/property/container.py
+++ b/bokeh/core/property/container.py
@@ -67,7 +67,7 @@ class Seq(ContainerProperty):
         self.item_type = self._validate_type_param(item_type)
         super().__init__(default=default, help=help)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.__class__.__name__}({self.item_type})"
 
     @property
@@ -166,7 +166,7 @@ class Dict(ContainerProperty):
         self.values_type = self._validate_type_param(values_type)
         super().__init__(default=default, help=help)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.__class__.__name__}({self.keys_type}, {self.values_type})"
 
     @property
@@ -274,7 +274,7 @@ class Tuple(ContainerProperty):
         self._type_params = list(map(self._validate_type_param, (tp1, tp2) + type_params))
         super().__init__(default=kwargs.get("default", Undefined), help=kwargs.get("help"))
 
-    def __str__(self):
+    def __str__(self) -> str:
         item_types = ", ".join(str(x) for x in self.type_params)
         return f"{self.__class__.__name__}({item_types})"
 
@@ -320,7 +320,7 @@ class RelativeDelta(Dict):
         values = Int
         super().__init__(keys, values, default=default, help=help)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.__class__.__name__
 
 class RestrictedDict(Dict):

--- a/bokeh/core/property/dataspec.py
+++ b/bokeh/core/property/dataspec.py
@@ -403,7 +403,7 @@ class UnitsSpec(NumberSpec):
         """)
         self._units_type = self._validate_type_param(units_type, help_allowed=True)
 
-    def __str__(self):
+    def __str__(self) -> str:
         units_default = self._units_type._default
         return f"{self.__class__.__name__}(units_default={units_default!r})"
 

--- a/bokeh/core/property/descriptor_factory.py
+++ b/bokeh/core/property/descriptor_factory.py
@@ -56,6 +56,17 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import (
+    TYPE_CHECKING,
+    Generic,
+    List,
+    TypeVar,
+)
+
+if TYPE_CHECKING:
+    from .descriptors import PropertyDescriptor
+
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
@@ -72,7 +83,9 @@ __all__ = (
 # Dev API
 #-----------------------------------------------------------------------------
 
-class PropertyDescriptorFactory:
+T = TypeVar("T")
+
+class PropertyDescriptorFactory(Generic[T]):
     """ Base class for all Bokeh properties.
 
     A Bokeh property really consist of two parts: the familiar "property"
@@ -106,7 +119,7 @@ class PropertyDescriptorFactory:
 
     """
 
-    def make_descriptors(self, name):
+    def make_descriptors(self, name: str) -> List[PropertyDescriptor[T]]:
         """ Return a list of ``PropertyDescriptor`` instances to install on a
         class, in order to delegate attribute access to this property.
 

--- a/bokeh/core/property/descriptors.py
+++ b/bokeh/core/property/descriptors.py
@@ -90,7 +90,18 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from copy import copy
-from typing import Any
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Generic,
+    Type,
+    TypeVar,
+)
+
+if TYPE_CHECKING:
+    from ..has_props import HasProps
+    from .bases import Property
 
 # Bokeh imports
 from .singletons import Undefined
@@ -117,42 +128,51 @@ __all__ = (
 # Dev API
 #-----------------------------------------------------------------------------
 
+T = TypeVar("T")
+
 class UnsetValueError(ValueError):
     """ Represents state in which descriptor without value was accessed. """
 
-class AliasPropertyDescriptor:
+class AliasPropertyDescriptor(Generic[T]):
     """
 
     """
 
-    serialized = False
+    serialized: bool = False
 
-    def __init__(self, name, aliased_name, property):
+    def __init__(self, name: str, aliased_name: str, property: Property[T]):
         self.name = name
         self.aliased_name = aliased_name
         self.property = property
         self.__doc__ = f"This is a compatibility alias for the ``{aliased_name}`` property"
 
-    def __get__(self, obj, owner):
+    def __get__(self, obj: HasProps | None, owner: Type[HasProps] | None) -> T:
         if obj is not None:
             return getattr(obj, self.aliased_name)
         elif owner is not None:
             return self
 
-    def __set__(self, obj, value):
-        return setattr(obj, self.aliased_name, value)
+        # This should really never happen. If it does, __get__ was called in a bad way.
+        raise ValueError("both 'obj' and 'owner' are None, don't know what to do")
+
+    def __set__(self, obj: HasProps | None, value: T) -> None:
+        setattr(obj, self.aliased_name, value)
 
     @property
-    def readonly(self):
+    def readonly(self) -> bool:
         return self.property.readonly
 
-class PropertyDescriptor:
+class PropertyDescriptor(Generic[T]):
     """ A base class for Bokeh properties with simple get/set and serialization
     behavior.
 
     """
 
-    def __init__(self, name, property):
+    name: str
+    #property: Property[T]
+    __doc__: str | None
+
+    def __init__(self, name: str, property: Property[T]):
         """ Create a PropertyDescriptor for basic Bokeh properties.
 
         Args:
@@ -164,7 +184,7 @@ class PropertyDescriptor:
         self.property = property
         self.__doc__ = self.property.__doc__
 
-    def __str__(self):
+    def __str__(self) -> str:
         """ Basic string representation of ``PropertyDescriptor``.
 
         Delegates to ``self.property.__str__``
@@ -172,7 +192,7 @@ class PropertyDescriptor:
         """
         return f"{self.property}"
 
-    def __get__(self, obj, owner):
+    def __get__(self, obj: HasProps | None, owner: Type[HasProps] | None) -> T:
         """ Implement the getter for the Python `descriptor protocol`_.
 
         For instance attribute access, we delegate to the |Property|. For
@@ -218,7 +238,7 @@ class PropertyDescriptor:
         # This should really never happen. If it does, __get__ was called in a bad way.
         raise ValueError("both 'obj' and 'owner' are None, don't know what to do")
 
-    def __set__(self, obj, value, *, setter=None):
+    def __set__(self, obj: HasProps, value: T, *, setter: HasProps | None = None) -> None:
         """ Implement the setter for the Python `descriptor protocol`_.
 
         .. note::
@@ -292,7 +312,7 @@ class PropertyDescriptor:
         """
         return self.property.themed_default(cls, self.name, None)
 
-    def instance_default(self, obj):
+    def instance_default(self, obj: HasProps) -> T:
         """ Get the default value that will be used for a specific instance.
 
         Args:
@@ -304,7 +324,7 @@ class PropertyDescriptor:
         """
         return self.property.themed_default(obj.__class__, self.name, obj.themed_values())
 
-    def serializable_value(self, obj):
+    def serializable_value(self, obj: HasProps) -> Any:
         """ Produce the value as it should be serialized.
 
         Sometimes it is desirable for the serialized value to differ from
@@ -321,7 +341,8 @@ class PropertyDescriptor:
         value = self.__get__(obj, obj.__class__)
         return self.property.serialize_value(value)
 
-    def set_from_json(self, obj, json, *, models=None, setter=None):
+    def set_from_json(self, obj: HasProps, json: Any, *,
+            models: Dict[str, HasProps] | None = None, setter: HasProps | None = None):
         """Sets the value of this property from a JSON value.
 
         Args:
@@ -374,7 +395,7 @@ class PropertyDescriptor:
             self._trigger(obj, old, new_value)
 
     @property
-    def has_ref(self):
+    def has_ref(self) -> bool:
         """ Whether the property can refer to another ``HasProps`` instance.
 
         For basic properties, delegate to the ``has_ref`` attribute on the
@@ -384,7 +405,7 @@ class PropertyDescriptor:
         return self.property.has_ref
 
     @property
-    def readonly(self):
+    def readonly(self) -> bool:
         """ Whether this property is read-only.
 
         Read-only properties may only be modified by the client (i.e., by BokehJS
@@ -394,7 +415,7 @@ class PropertyDescriptor:
         return self.property.readonly
 
     @property
-    def serialized(self):
+    def serialized(self) -> bool:
         """ Whether the property should be serialized when serializing an
         object.
 
@@ -405,7 +426,7 @@ class PropertyDescriptor:
         """
         return self.property.serialized
 
-    def _get(self, obj):
+    def _get(self, obj: HasProps) -> T:
         """ Internal implementation of instance attribute access for the
         ``PropertyDescriptor`` getter.
 
@@ -433,7 +454,7 @@ class PropertyDescriptor:
         else:
             return obj._property_values[self.name]
 
-    def _get_default(self, obj):
+    def _get_default(self, obj: HasProps) -> T:
         """ Internal implementation of instance attribute access for default
         values.
 
@@ -444,7 +465,8 @@ class PropertyDescriptor:
             # this shouldn't happen because we should have checked before _get_default()
             raise RuntimeError("Bokeh internal error, does not handle the case of self.name already in _property_values")
 
-        is_themed = obj.themed_values() is not None and self.name in obj.themed_values()
+        themed_values = obj.themed_values()
+        is_themed = themed_values is not None and self.name in themed_values
 
         default = self.instance_default(obj)
 

--- a/bokeh/core/property/either.py
+++ b/bokeh/core/property/either.py
@@ -74,7 +74,7 @@ class Either(ParameterizedProperty):
         for tp in self._type_params:
             self.alternatives.extend(tp.alternatives)
 
-    def __str__(self):
+    def __str__(self) -> str:
         class_name = self.__class__.__name__
         item_types = ", ".join(str(x) for x in self.type_params)
         return f"{class_name}({item_types})"

--- a/bokeh/core/property/enum.py
+++ b/bokeh/core/property/enum.py
@@ -57,7 +57,7 @@ class Enum(String):
         default = default if default is not Intrinsic else enum._default
         super().__init__(default=default, help=help, serialized=serialized, readonly=readonly)
 
-    def __str__(self):
+    def __str__(self) -> str:
         class_name = self.__class__.__name__
         allowed_values = ", ".join(repr(x) for x in self.allowed_values)
         return f"{class_name}({allowed_values})"

--- a/bokeh/core/property/instance.py
+++ b/bokeh/core/property/instance.py
@@ -25,10 +25,21 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from importlib import import_module
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Optional,
+    Type,
+    TypeVar,
+)
+
+if TYPE_CHECKING:
+    from ..has_props import HasProps
 
 # Bokeh imports
 from ._sphinx import model_link, property_link, register_type_link
-from .bases import DeserializationError, Property
+from .bases import DeserializationError, Init, Property
 from .singletons import Undefined
 
 #-----------------------------------------------------------------------------
@@ -39,11 +50,15 @@ __all__ = (
     'Instance',
 )
 
+T = TypeVar("T", bound="HasProps")
+
+JSON = Any
+
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
 
-class Instance(Property):
+class Instance(Property[T]):
     """ Accept values that are instances of |HasProps|.
 
     Args:
@@ -52,7 +67,10 @@ class Instance(Property):
             (default: False)
 
     """
-    def __init__(self, instance_type, default=Undefined, help=None, readonly=False, serialized=None):
+    _instance_type: Type[T] | str
+
+    def __init__(self, instance_type: Type[T] | str, default: Init[T] = Undefined,
+            help: Optional[str] = None, readonly: bool = False, serialized: Optional[bool] = None):
         if not isinstance(instance_type, (type, str)):
             raise ValueError(f"expected a type or string, got {instance_type}")
 
@@ -64,24 +82,24 @@ class Instance(Property):
 
         super().__init__(default=default, help=help, readonly=readonly, serialized=serialized)
 
-    def __str__(self):
+    def __str__(self) -> str:
         class_name = self.__class__.__name__
         instance_type = self.instance_type.__name__
         return f"{class_name}({instance_type})"
 
     @property
-    def has_ref(self):
+    def has_ref(self) -> bool:
         return True
 
     @property
-    def instance_type(self):
+    def instance_type(self) -> Type[HasProps]:
         if isinstance(self._instance_type, str):
             module, name = self._instance_type.rsplit(".", 1)
             self._instance_type = getattr(import_module(module, "bokeh"), name)
 
         return self._instance_type
 
-    def from_json(self, json, *, models=None):
+    def from_json(self, json: JSON, *, models: Dict[str, HasProps] | None = None) -> T:
         if isinstance(json, dict):
             from ...model import Model
             if issubclass(self.instance_type, Model):
@@ -107,7 +125,7 @@ class Instance(Property):
         else:
             raise DeserializationError(f"{self} expected a dict, got {json}")
 
-    def validate(self, value, detail=True):
+    def validate(self, value: Any, detail: bool = True) -> None:
         super().validate(value, detail)
 
         if isinstance(value, self.instance_type):

--- a/bokeh/core/property/numeric.py
+++ b/bokeh/core/property/numeric.py
@@ -109,7 +109,7 @@ class Interval(ParameterizedProperty):
         self.end = end
         super().__init__(default=default, help=help)
 
-    def __str__(self):
+    def __str__(self) -> str:
         class_name = self.__class__.__name__
         return f"{class_name}({self.interval_type}, {self.start!r}, {self.end!r})"
 

--- a/bokeh/core/property/override.py
+++ b/bokeh/core/property/override.py
@@ -25,6 +25,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Generic, TypeVar
+
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
@@ -37,7 +40,9 @@ __all__ = (
 # General API
 #-----------------------------------------------------------------------------
 
-class Override:
+T = TypeVar("T")
+
+class Override(Generic[T]):
     """ Override attributes of Bokeh property in derived Models.
 
     When subclassing a Bokeh Model, it may be desirable to change some of the
@@ -87,14 +92,12 @@ class Override:
 
     """
 
-    def __init__(self, **kwargs):
-        if len(kwargs) == 0:
-            raise ValueError("Override() doesn't override anything, needs keyword args")
-        self.default_overridden = 'default' in kwargs
-        if self.default_overridden:
-            self.default = kwargs.pop('default')
-        if len(kwargs) > 0:
-            raise ValueError(f"Unknown keyword args to Override: {kwargs!r}")
+    default_overridden: bool
+    default: T
+
+    def __init__(self, *, default: T):
+        self.default_overridden = True
+        self.default = default
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/core/property/primitive.py
+++ b/bokeh/core/property/primitive.py
@@ -22,9 +22,10 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import numbers
+from typing import Optional
 
 # Bokeh imports
-from .bases import PrimitiveProperty
+from .bases import Init, PrimitiveProperty
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -52,7 +53,7 @@ __all__ = (
 # General API
 #-----------------------------------------------------------------------------
 
-class Null(PrimitiveProperty):
+class Null(PrimitiveProperty[None]):
     """ Accept only ``None`` value.
 
         Use this in conjunction with ``Either(Null, Type)`` or as ``Nullable(Type)``.
@@ -60,10 +61,11 @@ class Null(PrimitiveProperty):
 
     _underlying_type = (type(None),)
 
-    def __init__(self, default=None, *, help=None, serialized=None, readonly=False):
+    def __init__(self, default: Init[None] = None, *, help: Optional[str] = None,
+            serialized: Optional[bool] = None, readonly: bool = False):
         super().__init__(default=default, help=help, serialized=serialized, readonly=readonly)
 
-class Bool(PrimitiveProperty):
+class Bool(PrimitiveProperty[bool]):
     """ Accept boolean values.
 
     Args:
@@ -103,10 +105,11 @@ class Bool(PrimitiveProperty):
 
     _underlying_type = bokeh_bool_types
 
-    def __init__(self, default=False, *, help=None, serialized=None, readonly=False):
+    def __init__(self, default: Init[bool] = False, *, help: Optional[str] = None,
+            serialized: Optional[bool] = None, readonly: bool = False):
         super().__init__(default=default, help=help, serialized=serialized, readonly=readonly)
 
-class Complex(PrimitiveProperty):
+class Complex(PrimitiveProperty[complex]):
     """ Accept complex floating point values.
 
     Args:
@@ -130,10 +133,11 @@ class Complex(PrimitiveProperty):
 
     _underlying_type = (numbers.Complex,)
 
-    def __init__(self, default=0j, *, help=None, serialized=None, readonly=False):
+    def __init__(self, default: Init[complex] = 0j, *, help: Optional[str] = None,
+            serialized: Optional[bool] = None, readonly: bool = False):
         super().__init__(default=default, help=help, serialized=serialized, readonly=readonly)
 
-class Int(PrimitiveProperty):
+class Int(PrimitiveProperty[int]):
     """ Accept signed integer values.
 
     Args:
@@ -173,10 +177,11 @@ class Int(PrimitiveProperty):
 
     _underlying_type = bokeh_integer_types
 
-    def __init__(self, default=0, *, help=None, serialized=None, readonly=False):
+    def __init__(self, default: Init[int] = 0, *, help: Optional[str] = None,
+            serialized: Optional[bool] = None, readonly: bool = False):
         super().__init__(default=default, help=help, serialized=serialized, readonly=readonly)
 
-class Float(PrimitiveProperty):
+class Float(PrimitiveProperty[float]):
     """ Accept floating point values.
 
     Args:
@@ -217,10 +222,11 @@ class Float(PrimitiveProperty):
 
     _underlying_type = (numbers.Real,)
 
-    def __init__(self, default=0.0, *, help=None, serialized=None, readonly=False):
+    def __init__(self, default: Init[float] = 0.0, *, help: Optional[str] = None,
+            serialized: Optional[bool] = None, readonly: bool = False):
         super().__init__(default=default, help=help, serialized=serialized, readonly=readonly)
 
-class String(PrimitiveProperty):
+class String(PrimitiveProperty[str]):
     """ Accept string values.
 
     Args:
@@ -260,7 +266,8 @@ class String(PrimitiveProperty):
 
     _underlying_type = (str,)
 
-    def __init__(self, default="", *, help=None, serialized=None, readonly=False):
+    def __init__(self, default: Init[str] = "", *, help: Optional[str] = None,
+            serialized: Optional[bool] = None, readonly: bool = False):
         super().__init__(default=default, help=help, serialized=serialized, readonly=readonly)
 
 #-----------------------------------------------------------------------------

--- a/bokeh/core/property/singletons.py
+++ b/bokeh/core/property/singletons.py
@@ -35,10 +35,10 @@ __all__ = (
 # Dev API
 #-----------------------------------------------------------------------------
 
-class UndefinedType(object):
+class UndefinedType:
     """ Indicates no value set, which is not the same as setting ``None``. """
 
-    def __copy__(self) -> "UndefinedType":
+    def __copy__(self) -> UndefinedType:
         return self
 
     def __str__(self) -> str:
@@ -49,10 +49,10 @@ class UndefinedType(object):
 
 Undefined = UndefinedType()
 
-class IntrinsicType(object):
+class IntrinsicType:
     """ Indicates usage of the intrinsic default value of a property. """
 
-    def __copy__(self) -> "IntrinsicType":
+    def __copy__(self) -> IntrinsicType:
         return self
 
     def __str__(self) -> str:

--- a/bokeh/core/property/string.py
+++ b/bokeh/core/property/string.py
@@ -84,7 +84,7 @@ class Regex(String):
         self.regex = re.compile(regex)
         super().__init__(default=default, help=help)
 
-    def __str__(self):
+    def __str__(self) -> str:
         class_name = self.__class__.__name__
         return f"{class_name}({self.regex.pattern!r})"
 

--- a/bokeh/core/property/struct.py
+++ b/bokeh/core/property/struct.py
@@ -69,7 +69,7 @@ class Struct(ParameterizedProperty):
         msg = "" if not detail else f"expected an element of {self}, got {value!r}"
         raise ValueError(msg)
 
-    def __str__(self):
+    def __str__(self) -> str:
         class_name = self.__class__.__name__
         fields = ", ".join(f"{name}={typ}" for name, typ in self._fields.items())
         return f"{class_name}({fields})"

--- a/bokeh/core/property/visual.py
+++ b/bokeh/core/property/visual.py
@@ -92,7 +92,7 @@ class DashPattern(Either):
         types = Enum(enums.DashPattern), Regex(r"^(\d+(\s+\d+)*)?$"), Seq(Int)
         super().__init__(*types, default=default, help=help)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.__class__.__name__
 
     def transform(self, value):
@@ -133,7 +133,7 @@ class HatchPatternType(Either):
         types = Enum(enums.HatchPattern), Enum(enums.HatchPatternAbbreviation)
         super().__init__(*types, default=default, help=help)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.__class__.__name__
 
 class Image(Property):

--- a/bokeh/layouts.py
+++ b/bokeh/layouts.py
@@ -23,9 +23,15 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import math
 from collections import namedtuple
+from typing import Any, List, Optional
 
 # Bokeh imports
-from .core.enums import Location
+from .core.enums import (
+    Location,
+    SizingMode,
+    _Location,
+    _SizingMode,
+)
 from .models.layouts import (
     Box,
     Column,
@@ -207,9 +213,16 @@ def layout(*args, **kwargs):
     # Make the grid
     return _create_grid(children, sizing_mode, **kwargs)
 
-def gridplot(children, sizing_mode=None, toolbar_location='above', ncols=None,
-             width=None, height=None, plot_width=None, plot_height=None,
-             toolbar_options=None, merge_tools=True):
+def gridplot(children: List[List[LayoutDOM]] | GridSpec, *,
+        sizing_mode: _SizingMode | None = None,
+        toolbar_location: _Location = "above",
+        ncols: int | None = None,
+        width: int | None = None,
+        height: int | None = None,
+        plot_width: int | None = None,
+        plot_height: int | None = None,
+        toolbar_options: Any = None,
+        merge_tools: bool =True):
     ''' Create a grid of plots rendered on separate canvases.
 
     The ``gridplot`` function builds a single toolbar for all the plots in the
@@ -274,7 +287,7 @@ def gridplot(children, sizing_mode=None, toolbar_location='above', ncols=None,
 
     if toolbar_location:
         if not hasattr(Location, toolbar_location):
-            raise ValueError("Invalid value of toolbar_location: %s" % toolbar_location)
+            raise ValueError(f"Invalid value of toolbar_location: {toolbar_location}")
 
     children = _parse_children_arg(children=children)
     if ncols:
@@ -335,7 +348,8 @@ def gridplot(children, sizing_mode=None, toolbar_location='above', ncols=None,
     elif toolbar_location == 'right':
         return Row(children=[grid, toolbar], sizing_mode=sizing_mode)
 
-def grid(children=[], sizing_mode=None, nrows=None, ncols=None):
+def grid(children: List[LayoutDOM] | List[List[LayoutDOM]] | Row | Column = [], *,
+        sizing_mode: Optional[SizingMode] = None, nrows: int | None = None, ncols: int | None = None):
     """
     Conveniently create a grid of layoutable objects.
 
@@ -391,13 +405,13 @@ def grid(children=[], sizing_mode=None, nrows=None, ncols=None):
         Item = namedtuple("Item", ["layout", "r0", "c0", "r1", "c1"])
         Grid = namedtuple("Grid", ["nrows", "ncols", "items"])
 
-        def gcd(a, b):
+        def gcd(a: int, b: int) -> int:
             a, b = abs(a), abs(b)
             while b != 0:
                 a, b = b, a % b
             return a
 
-        def lcm(a, *rest):
+        def lcm(a: int, *rest: int) -> int:
             for b in rest:
                 a = (a*b) // gcd(a, b)
             return a

--- a/bokeh/protocol/__init__.py
+++ b/bokeh/protocol/__init__.py
@@ -72,7 +72,7 @@ class Protocol:
     def __init__(self):
         self._messages = SPEC
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Protocol()"
 
     def create(self, msgtype, *args, **kwargs):

--- a/bokeh/protocol/message.py
+++ b/bokeh/protocol/message.py
@@ -111,7 +111,7 @@ class Message:
         self.content = content
         self._buffers = []
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Message %r content: %r" % (self.msgtype, self.content)
 
     @classmethod

--- a/bokeh/protocol/messages/error.py
+++ b/bokeh/protocol/messages/error.py
@@ -59,7 +59,7 @@ class error(Message):
 
     msgtype  = 'ERROR'
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         msg = super().__repr__()
         msg += " --- "
         msg += self.content['text']

--- a/bokeh/util/compiler.py
+++ b/bokeh/util/compiler.py
@@ -91,7 +91,7 @@ class CompilationError(RuntimeError):
         else:
             self.text = error
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "\n" + self.text.strip()
 
 bokehjs_dir = settings.bokehjsdir()

--- a/bokeh/util/deprecation.py
+++ b/bokeh/util/deprecation.py
@@ -19,12 +19,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import warnings  # lgtm [py/import-and-import-from]
-from typing import (
-    Optional,
-    Tuple,
-    Union,
-    overload,
-)
+from typing import Optional, Tuple, overload
 
 # Bokeh imports
 from .warnings import BokehDeprecationWarning
@@ -48,14 +43,14 @@ def warn(message: str, stacklevel: int = 2) -> None:
     warnings.warn(message, BokehDeprecationWarning, stacklevel=stacklevel)
 
 @overload
-def deprecated(since_or_msg: Version, old: str, new: str, extra: str) -> None:
+def deprecated(since_or_msg: Version, old: str, new: str, extra: Optional[str] = None) -> None:
     ...
 
 @overload
 def deprecated(since_or_msg: str) -> None:
     ...
 
-def deprecated(since_or_msg: Union[Version, str],
+def deprecated(since_or_msg: Version | str,
         old: Optional[str] = None, new: Optional[str] = None, extra: Optional[str] = None) -> None:
     """ Issue a nicely formatted deprecation warning. """
 
@@ -63,21 +58,16 @@ def deprecated(since_or_msg: Union[Version, str],
         if old is None or new is None:
             raise ValueError("deprecated entity and a replacement are required")
 
-        if len(since_or_msg) != 3 or not all(isinstance(x, int) and x >= 0 for x in since_or_msg):
-            raise ValueError(f"invalid version tuple: {since_or_msg!r}")
-
         major, minor, patch = since_or_msg
         since = f"{major}.{minor}.{patch}"
         message = f"{old} was deprecated in Bokeh {since} and will be removed, use {new} instead."
         if extra is not None:
             message += " " + extra.strip()
-    elif isinstance(since_or_msg, str):
+    else:
         if not (old is None and new is None and extra is None):
             raise ValueError("deprecated(message) signature doesn't allow extra arguments")
 
         message = since_or_msg
-    else:
-        raise ValueError("expected a version tuple or string message")
 
     warn(message)
 

--- a/tests/unit/bokeh/core/property/test_override.py
+++ b/tests/unit/bokeh/core/property/test_override.py
@@ -39,17 +39,6 @@ class Test_Override:
         assert o.default_overridden
         assert o.default == 10
 
-    def test_create_no_args(self) -> None:
-        with pytest.raises(ValueError):
-            bcpo.Override()
-
-    def test_create_unkown_args(self) -> None:
-        with pytest.raises(ValueError):
-            bcpo.Override(default=10, junk=20)
-
-        with pytest.raises(ValueError):
-            bcpo.Override(junk=20)
-
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This is the first approximation, which is intended to fill in as many types as possible, without trying to establish overall type soundness. This will be done later on, when sufficiently large percent of code has been typed. Localized soundness may be have been established in some cases. This work is insufficient to allow static typing of models' properties, as our approach to descriptors is not supported by mypy (and won't be any time soon), at least not without some unspecified changes (perhaps there may be a way to work around this, without requiring major changes).