### PR TITLE
Correctly initialize WebGL non-base marker/scatter glyphs

### DIFF
--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -257,8 +257,12 @@ export abstract class GlyphView extends View {
       visual.update()
     }
 
+    this._set_visuals()
+
     this.glglyph?.set_visuals_changed()
   }
+
+  protected _set_visuals(): void {}
 
   set_data(source: ColumnarDataSource, indices: Indices, indices_to_update?: number[]): void {
     const {x_source, y_source} = this.renderer.coordinates

--- a/bokehjs/src/lib/models/glyphs/scatter.ts
+++ b/bokehjs/src/lib/models/glyphs/scatter.ts
@@ -23,7 +23,7 @@ export class ScatterView extends MarkerView {
     if (webgl != null) {
       const {regl_wrapper} = webgl
       if (regl_wrapper.has_webgl) {
-        const marker_types = new Set(this.marker)
+        const marker_types = new Set(this.base != null ? this.base.marker : this.marker)
         if (marker_types.size == 1) {
           const [marker_type] = [...marker_types]
 
@@ -40,8 +40,7 @@ export class ScatterView extends MarkerView {
     delete this.glglyph
   }
 
-  protected override _set_data(indices: number[] | null): void {
-    super._set_data(indices)
+  protected override _set_visuals(): void {
     this._init_webgl()
   }
 


### PR DESCRIPTION
Candidate fix for issue #11288.

Scatter glyphs using `output_backend="webgl"` have more complicated initialization that other WebGL glyphs as their marker types can be changed dynamically and it is necessary to check if our WebGL code supports the required marker type.  Currently when the marker type is set or changed then `ScatterView._set_data()` is called and this creates or recreates the `MarkerGL` as required.  However, this only occurs for the `base` glyph of the `GlyphRendererView`; other glyphs such as the selection glyph are not updated via `set_data` and so selection, etc, revert to using the canvas backend.

I've opted for the minimal change which is to move the `MarkerGL` update from `Glyph.set_data()` to `Glyph.set_visuals()` as all the glyphs are updated by the latter.

I have tested it manually, but I haven't added a CI test.  A simple visual test would appear to be OK because of the slight differences between the canvas and WebGL antialiasing, but the problem here would be if a future regression occurs then the pixel differences will be so small that we are liable to commit a baseline image change without noticing that it is due to a change of backend.