### PR TITLE
Add 'experimental' note to extensions chapter

### DIFF
--- a/sphinx/source/docs/user_guide/extensions.rst
+++ b/sphinx/source/docs/user_guide/extensions.rst
@@ -15,14 +15,15 @@ that let you:
 * Create highly specialized models for domain-specific use cases
 
 You can make and use custom extensions with standard releases and don't need to
-set up a development environment or build anything from source. With custom
-extensions, you can also try new features and improved functionality without
-having to wait for the core team to implement them into Bokeh itself.
+set up a development environment or build anything from source. This is the
+easiest way to get involved in Bokeh development. You can try new features and
+improved functionality without having to wait for the core team to implement
+them into Bokeh itself.
 
 .. note::
-    Extending Bokeh is a highly advanced feature. Several aspects of creating
-    and using extensions are still under development and should be considered
-    experimental.
+   Extending Bokeh is an advanced feature. Some aspects of creating and using
+   extensions are still under active development and should be considered
+   experimental.
 
 .. _userguide_extensions_structure:
 

--- a/sphinx/source/docs/user_guide/extensions.rst
+++ b/sphinx/source/docs/user_guide/extensions.rst
@@ -15,10 +15,14 @@ that let you:
 * Create highly specialized models for domain-specific use cases
 
 You can make and use custom extensions with standard releases and don't need to
-set up a development environment or build anything from source. This is the
-easiest way to get involved in Bokeh development. You can try new features and
-improved functionality without having to wait for the core team to implement
-them.
+set up a development environment or build anything from source. With custom
+extensions, you can also try new features and improved functionality without
+having to wait for the core team to implement them into Bokeh itself.
+
+.. note::
+    Extending Bokeh is a highly advanced feature. Several aspects of creating
+    and using extensions are still under development and should be considered
+    experimental.
 
 .. _userguide_extensions_structure:
 


### PR DESCRIPTION
As discussed in https://discourse.bokeh.org/t/compiled-components-final-step-help-needed-removing-nodejs-from-the-build-process/7668/4, this PR adds a note to the extensions chapter of the user guide.