### PR TITLE
Fix typo in AuthProvider._validate error message. login_url instead of logout_url

### DIFF
--- a/bokeh/server/auth_provider.py
+++ b/bokeh/server/auth_provider.py
@@ -147,7 +147,7 @@ class AuthProvider:
 
     @property
     def logout_url(self):
-        ''' A URL to redirect unathenticated users to for logout.
+        ''' A URL to redirect authenticated users to for logout.
 
         This proprty may return None.
 

--- a/bokeh/server/auth_provider.py
+++ b/bokeh/server/auth_provider.py
@@ -173,7 +173,7 @@ class AuthProvider:
         if self.logout_handler and not issubclass(self.logout_handler, RequestHandler):
             raise ValueError("LogoutHandler must be a Tornado RequestHandler")
         if self.logout_url and not probably_relative_url(self.logout_url):
-            raise ValueError("LogoutHandler can only be used with a relative login_url")
+            raise ValueError("LogoutHandler can only be used with a relative logout_url")
 
 class AuthModule(AuthProvider):
     ''' An AuthProvider configured from a Python module.


### PR DESCRIPTION
fixed typo : login_url in the error message instead of logout_url

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [ ] issues: fixes #xxxx
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
