### PR TITLE
Bryanv/11298 release build deps

### DIFF
--- a/ci/environment-release-build.yml
+++ b/ci/environment-release-build.yml
@@ -29,6 +29,7 @@ dependencies:
   - colorcet
   - firefox
   - geckodriver
+  - icalendar
   - networkx
   - pandas
   - pydot

--- a/ci/environment-test-3.7.yml
+++ b/ci/environment-test-3.7.yml
@@ -38,7 +38,7 @@ dependencies:
   - psutil
   - pydot
   - pygments
-  - pytest
+  - pytest 6.2*
   - pytest-asyncio
   - pytest-cov >=1.8.1
   - pytest-html

--- a/ci/environment-test-3.8.yml
+++ b/ci/environment-test-3.8.yml
@@ -38,7 +38,7 @@ dependencies:
   - psutil
   - pydot
   - pygments
-  - pytest
+  - pytest 6.2*
   - pytest-asyncio=0.12.0
   - pytest-cov >=1.8.1
   - pytest-html

--- a/ci/environment-test-3.9.yml
+++ b/ci/environment-test-3.9.yml
@@ -38,7 +38,7 @@ dependencies:
   - psutil
   - pydot
   - pygments
-  - pytest
+  - pytest 6.2*
   - pytest-asyncio
   - pytest-cov >=1.8.1
   - pytest-html

--- a/environment.yml
+++ b/environment.yml
@@ -52,7 +52,7 @@ dependencies:
   - pandas
   - psutil
   - pydot
-  - pytest 6.0*
+  - pytest 6.2*
   - pytest-asyncio >=0.12.0
   - pytest-cov >=1.8.1
   - pytest-html


### PR DESCRIPTION
- [x] issues: fixes #11928

Hopefully after this we can cut dev builds again. 

@mattpap note I set pytest to 6.2.x since use creating the env locally with the old env files was picking 6.0.x causing tests to fail. 