### PR TITLE
Add -f option for conda env

### DIFF
--- a/sphinx/source/docs/dev_guide/setup.rst
+++ b/sphinx/source/docs/dev_guide/setup.rst
@@ -82,7 +82,7 @@ At the top level of the repository, issue the following command in a terminal:
 
 .. code-block:: sh
 
-    conda env create environment.yml
+    conda env create -f environment.yml
 
 Then, activate the environment:
 


### PR DESCRIPTION
Adds the required `-f` option to the developers guide section explaining the use of `conda env` to create a local development environment. 

Partially fixes #11334 
