### PR TITLE
Use an exact extension's version in a CDN URL

### DIFF
--- a/bokeh/embed/bundle.py
+++ b/bokeh/embed/bundle.py
@@ -317,7 +317,7 @@ def _bundle_extensions(objs: Sequence[Model | Document], resources: Resources) -
             pkg_version = pkg.get("version", "latest")
             pkg_main = pkg.get("module", pkg.get("main", None))
             if pkg_main is not None:
-                cdn_url = f"{_default_cdn_host}/{pkg_name}@^{pkg_version}/{pkg_main}"
+                cdn_url = f"{_default_cdn_host}/{pkg_name}@{pkg_version}/{pkg_main}"
             else:
                 pkg_main = join(dist_dir, f"{name}.js")
             artifact_path = join(base_dir, normpath(pkg_main))

--- a/tests/unit/bokeh/embed/test_bundle.py
+++ b/tests/unit/bokeh/embed/test_bundle.py
@@ -120,7 +120,7 @@ class Test_bundle_custom_extensions:
         plot.add_layout(LatexLabel())
         bundle = beb.bundle_for_objs_and_resources([plot], "cdn")
         assert len(bundle.js_files) == 2
-        assert bundle.js_files[1] == "https://unpkg.com/latex_label@^0.0.1/dist/latex_label.js"
+        assert bundle.js_files[1] == "https://unpkg.com/latex_label@0.0.1/dist/latex_label.js"
 
     def test_with_Server_resources(self) -> None:
         from latex_label import LatexLabel


### PR DESCRIPTION
fixes #11380
