### PR TITLE
Consolidate pip dependencies

### DIFF
--- a/ci/environment-release-build.yml
+++ b/ci/environment-release-build.yml
@@ -38,8 +38,11 @@ dependencies:
   - scipy
   - sphinx >=3.5
   - sphinx-panels
+
+  # pip dependencies
   - pip
   - pip:
+    # docs
     - autoclasstoc
     - pydata_sphinx_theme
     - sphinxext-opengraph

--- a/ci/environment-test-3.7.yml
+++ b/ci/environment-test-3.7.yml
@@ -48,19 +48,6 @@ dependencies:
   - scipy
   - sphinx >=3.5
   - sphinx-panels
-  - pip
-  - pip:
-    - autoclasstoc
-    - pydata_sphinx_theme
-    - sphinxext-opengraph
-    - sphinx-reredirects
-    - types-boto
-    - types-colorama
-    - types-mock
-    - types-pillow
-    - types-pyyaml
-    - types-requests
-    - flake8-pyi
 
   # examples
   - flask >=1.0
@@ -73,3 +60,20 @@ dependencies:
   - pyshp
   - scikit-learn
   - sympy
+
+  # pip dependencies
+  - pip
+  - pip:
+    # docs
+    - autoclasstoc
+    - pydata_sphinx_theme
+    - sphinxext-opengraph
+    - sphinx-reredirects
+    # tests
+    - types-boto
+    - types-colorama
+    - types-mock
+    - types-pillow
+    - types-pyyaml
+    - types-requests
+    - flake8-pyi

--- a/ci/environment-test-3.8.yml
+++ b/ci/environment-test-3.8.yml
@@ -48,19 +48,6 @@ dependencies:
   - scipy
   - sphinx >=3.5
   - sphinx-panels
-  - pip
-  - pip:
-    - autoclasstoc
-    - pydata_sphinx_theme
-    - sphinxext-opengraph
-    - sphinx-reredirects
-    - types-boto
-    - types-colorama
-    - types-mock
-    - types-pillow
-    - types-pyyaml
-    - types-requests
-    - flake8-pyi
 
   # examples
   - flask >=1.0
@@ -73,3 +60,20 @@ dependencies:
   - pyshp
   - scikit-learn
   - sympy
+
+  # pip dependencies
+  - pip
+  - pip:
+    # docs
+    - autoclasstoc
+    - pydata_sphinx_theme
+    - sphinxext-opengraph
+    - sphinx-reredirects
+    # tests
+    - types-boto
+    - types-colorama
+    - types-mock
+    - types-pillow
+    - types-pyyaml
+    - types-requests
+    - flake8-pyi

--- a/ci/environment-test-3.9.yml
+++ b/ci/environment-test-3.9.yml
@@ -48,19 +48,6 @@ dependencies:
   - scipy
   - sphinx >=3.5
   - sphinx-panels
-  - pip
-  - pip:
-    - autoclasstoc
-    - pydata_sphinx_theme
-    - sphinxext-opengraph
-    - sphinx-reredirects
-    - types-boto
-    - types-colorama
-    - types-mock
-    - types-pillow
-    - types-pyyaml
-    - types-requests
-    - flake8-pyi
 
   # examples
   - flask >=1.0
@@ -73,3 +60,20 @@ dependencies:
   - pyshp
   - scikit-learn
   - sympy
+
+  # pip dependencies
+  - pip
+  - pip:
+    # docs
+    - autoclasstoc
+    - pydata_sphinx_theme
+    - sphinxext-opengraph
+    - sphinx-reredirects
+    # tests
+    - types-boto
+    - types-colorama
+    - types-mock
+    - types-pillow
+    - types-pyyaml
+    - types-requests
+    - flake8-pyi

--- a/environment.yml
+++ b/environment.yml
@@ -24,12 +24,6 @@ dependencies:
   - pygments
   - sphinx >=3.5
   - sphinx-panels
-  - pip
-  - pip:
-    - autoclasstoc
-    - pydata_sphinx_theme
-    - sphinxext-opengraph
-    - sphinx-reredirects
 
   # tests
   - beautifulsoup4
@@ -60,15 +54,6 @@ dependencies:
   - requests >=1.2.3
   - selenium >=3.8
   - scipy
-  - pip
-  - pip:
-    - types-boto
-    - types-colorama
-    - types-mock
-    - types-pillow
-    - types-pyyaml
-    - types-requests
-    - flake8-pyi
 
   # examples
   - flask >=1.0
@@ -85,3 +70,20 @@ dependencies:
   #- ipywidgets >=7.5.0
   #- ipyvolume
   #- ipyleaflet
+
+  # pip dependencies
+  - pip
+  - pip:
+    # docs
+    - autoclasstoc
+    - pydata_sphinx_theme
+    - sphinxext-opengraph
+    - sphinx-reredirects
+    # tests
+    - types-boto
+    - types-colorama
+    - types-mock
+    - types-pillow
+    - types-pyyaml
+    - types-requests
+    - flake8-pyi


### PR DESCRIPTION
This pull request fixes a problem with pip dependencies in `environment.yml`. We used to have two subsections listing pip dependencies, but yml only parses one pip subsection. This pr consolidates all pip dependencies in one subsection.
