### PR TITLE
Add legend item visibility to user guide

### DIFF
--- a/bokeh/models/annotations.py
+++ b/bokeh/models/annotations.py
@@ -204,7 +204,8 @@ class LegendItem(Model):
     """)
 
     visible = Bool(default=True, help="""
-    Whether the legend item should be displayed.
+    Whether the legend item should be displayed. See
+    :ref:`userguide_plotting_legends_item_visibility` in the user guide.
     """)
 
     @error(NON_MATCHING_DATA_SOURCES_ON_LEGEND_ITEM_RENDERERS)

--- a/bokeh/plotting/_docstring.py
+++ b/bokeh/plotting/_docstring.py
@@ -51,12 +51,11 @@ Keyword args:
 {_docstring_other()}
 
 It is also possible to set the color and alpha parameters of extra glyphs for
-selection, nonselection, hover, or muted. To do so, add the relevane prefix to
+selection, nonselection, hover, or muted. To do so, add the relevant prefix to
 any visual parameter. For example, pass ``nonselection_alpha`` to set the line
 and fill alpha for nonselect, or ``hover_fill_alpha`` to set the fill alpha for
-hover. See the `Glyphs`_ section od the User's Guide for full details.
-
-.. _Glyphs: https://docs.bokeh.org/en/latest/docs/user_guide/styling.html#glyphs
+hover. See the :ref:`userguide_styling_glyphs` section of the user guide for
+full details.
 
 Returns:
     :class:`~bokeh.models.renderers.GlyphRenderer`
@@ -121,18 +120,17 @@ Other Parameters:
     color (Color, optional) :
         An alias to set all color keyword arguments at once. (default: None)
 
-        Acceptable values for colors are described in the `Specifying Colors`_
-        section of the User's Guide.
+        See :ref:`userguide_styling_colors` in the user guide for different
+        options to define colors.
 
         Any explicitly set values for ``line_color``, etc. will override this
         setting.
 
-        .. _Specifying Colors: https://docs.bokeh.org/en/latest/docs/user_guide/styling.html#specifying-colors
-
     legend_field (str, optional) :
-        Specify that the glyph should produce multiple legend entried by
-        `Grouping in the Browser`_. The value of this parameter is the name of a
-        column in the data source that should be used or the grouping.
+        Specify that the glyph should produce multiple legend entries by
+        :ref:`grouping them in the browser <userguide_plotting_legends_legend_field>`.
+        The value of this parameter is the name of a column in the data source
+        that should be used or the grouping.
 
         The grouping is performed *in JavaScript*, at the time time the Bokeh
         content is rendered in the browser. If the data is subsequently updated,
@@ -142,12 +140,11 @@ Other Parameters:
             Only one of ``legend_field``, ``legend_group``, or ``legend_label``
             should be supplied
 
-        .. _Grouping in the Browser: https://docs.bokeh.org/en/latest/docs/user_guide/annotations.html#automatic-grouping-browser
-
     legend_group (str, optional) :
-        Specify that the glyph should produce multiple legend entried by
-        `Grouping in Python`_. The value of this parameter is the name of a
-        column in the data source that should be used or the grouping.
+        Specify that the glyph should produce multiple legend entries by
+        :ref:`grouping them in Python <userguide_plotting_legends_legend_group>`.
+        The value of this parameter is the name of a column in the data source
+        that should be used or the grouping.
 
         The grouping is performed in Python, before the Bokeh output is sent to
         a browser. If the date is subsequently updated, the legend will *not*
@@ -157,18 +154,15 @@ Other Parameters:
             Only one of ``legend_field``, ``legend_group``, or ``legend_label``
             should be supplied
 
-        .. _Grouping in Python: https://docs.bokeh.org/en/latest/docs/user_guide/annotations.html#automatic-grouping-python
-
     legend_label (str, optional) :
-        Specify that the glyph should produce a single `Basic Legend Label`_ in
-        the legend. The legend entry is labeled with exactly the text supplied
+        Specify that the glyph should produce a single
+        :ref:`basic legend label <userguide_plotting_legends_legend_label>` in
+        the legend. The legend entry is labeled with the exact text supplied
         here.
 
         .. note::
             Only one of ``legend_field``, ``legend_group``, or ``legend_label``
-            should be supplied
-
-        .. _Basic Legend Label: https://docs.bokeh.org/en/latest/docs/user_guide/annotations.html#basic-legend-label
+            should be supplied.
 
     muted (bool, optionall) :
         Whether the glyph should be rendered as muted (default: False)
@@ -194,7 +188,7 @@ Other Parameters:
         If supplied, Bokeh will use the supplied data source to drive the glyph.
         In this case, literal list or arrays may not be used for coordinates or
         other arguments. Only singular fixed valued (e.g. ``x=10``) or column
-        names in the data souce (e.g. ``x="time"``) are permitted.
+        names in the data source (e.g. ``x="time"``) are permitted.
 
     view (CDSView, optional) :
         A view for filtering the data source. (default: None)

--- a/sphinx/source/docs/user_guide/annotations.rst
+++ b/sphinx/source/docs/user_guide/annotations.rst
@@ -144,6 +144,20 @@ grouping happens in the browser.
 .. bokeh-plot:: docs/user_guide/examples/plotting_legend_field.py
     :source-position: above
 
+.. _userguide_plotting_legends_item_visibility:
+
+Hiding legend items
+~~~~~~~~~~~~~~~~~~~
+
+To manually control the visibility of individual legend items, set the
+``visible`` property of a :class:`~bokeh.models.annotations.LegendItem` to
+either ``True`` or ``False``.
+
+.. bokeh-plot:: docs/user_guide/examples/plotting_legends_item_visibility.py
+    :source-position: above
+
+If all items in a legend are invisible, the entire legend will be hidden.
+
 .. _userguide_plotting_legends_manual:
 
 Manual legends
@@ -158,7 +172,7 @@ Explicit index
 ~~~~~~~~~~~~~~
 
 To explicitly specify which index into a |ColumnDataSource| to use in a legend,
-set the ``index`` property of a ``LegendItem``.
+set the ``index`` property of a :class:`~bokeh.models.annotations.LegendItem`.
 
 This is useful for displaying multiple entries in a legend when you use glyphs
 that are rendered in several parts, such as

--- a/sphinx/source/docs/user_guide/annotations.rst
+++ b/sphinx/source/docs/user_guide/annotations.rst
@@ -156,7 +156,12 @@ either ``True`` or ``False``.
 .. bokeh-plot:: docs/user_guide/examples/plotting_legends_item_visibility.py
     :source-position: above
 
-If all items in a legend are invisible, the entire legend will be hidden.
+.. note::
+    If all items in a legend are invisible, the entire legend will be hidden.
+    Also, if you use
+    :ref:`automatic grouping on the browser side <userguide_plotting_legends_legend_field>`
+    and set the visibility of a ``legend_field`` item to ``False``, the entire
+    group will be invisible.
 
 .. _userguide_plotting_legends_manual:
 

--- a/sphinx/source/docs/user_guide/examples/plotting_legends_item_visibility.py
+++ b/sphinx/source/docs/user_guide/examples/plotting_legends_item_visibility.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-from bokeh.models import Legend, LegendItem
 from bokeh.plotting import figure, output_file, show
 
 x = np.linspace(0, 4*np.pi, 100)
@@ -15,7 +14,7 @@ main = p.circle(x, y, legend_label="Main")
 aux = p.line(x, 2*y, legend_label="Auxillary",
              line_dash=[4, 4], line_color="orange", line_width=2)
 
-# set legend label for second renderer to False
+# set legend label visibility for second renderer to False
 p.legend.items[1].visible = False
 
 show(p)

--- a/sphinx/source/docs/user_guide/examples/plotting_legends_item_visibility.py
+++ b/sphinx/source/docs/user_guide/examples/plotting_legends_item_visibility.py
@@ -15,7 +15,7 @@ main = p.circle(x, y, legend_label="Main")
 aux = p.line(x, 2*y, legend_label="Auxillary",
              line_dash=[4, 4], line_color="orange", line_width=2)
 
-# set legend label for aux_1 to False
+# set legend label for second renderer to False
 p.legend.items[1].visible = False
 
 show(p)

--- a/sphinx/source/docs/user_guide/examples/plotting_legends_item_visibility.py
+++ b/sphinx/source/docs/user_guide/examples/plotting_legends_item_visibility.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+from bokeh.models import Legend, LegendItem
+from bokeh.plotting import figure, output_file, show
+
+x = np.linspace(0, 4*np.pi, 100)
+y = np.cos(x)
+
+output_file("legend_item_visibility.html")
+
+p = figure(height=300)
+
+# create two renderers with legend labels
+main = p.circle(x, y, legend_label="Main")
+aux = p.line(x, 2*y, legend_label="Auxillary",
+             line_dash=[4, 4], line_color="orange", line_width=2)
+
+# set legend label for aux_1 to False
+p.legend.items[1].visible = False
+
+show(p)


### PR DESCRIPTION
This PR adds a section on toggling visibility for legend items. This is a follow-up to #11412 and also fixes #9261.
cc @bryevdv 