### PR TITLE
Parse docstrings in examples for gallery detail pages

### DIFF
--- a/bokeh/application/handlers/code_runner.py
+++ b/bokeh/application/handlers/code_runner.py
@@ -58,6 +58,7 @@ class CodeRunner:
     '''
 
     _code: CodeType | None
+    _doc: str | None
     _permanent_error: str | None
     _permanent_error_detail: str | None
     _path: PathLike
@@ -104,6 +105,9 @@ class CodeRunner:
         try:
             nodes = ast.parse(source, os.fspath(path))
             self._code = compile(nodes, filename=path, mode='exec', dont_inherit=True)
+            # use a zip to associate code names with values, to then find the contents of the docstring
+            d = dict(zip(self._code.co_names, self._code.co_consts))
+            self._doc = d.get('__doc__', None)
         except SyntaxError as e:
             self._code = None
             filename = os.path.basename(e.filename) if e.filename is not None else "???"
@@ -117,6 +121,13 @@ class CodeRunner:
         self.ran = False
 
     # Properties --------------------------------------------------------------
+
+    @property
+    def doc(self) -> str | None:
+        ''' Contents of docstring, if code contains one.
+
+        '''
+        return self._doc
 
     @property
     def error(self) -> str | None:

--- a/bokeh/sphinxext/_templates/gallery_detail.rst
+++ b/bokeh/sphinxext/_templates/gallery_detail.rst
@@ -7,4 +7,5 @@
 {{ '-' * filename|length }}
 
 .. bokeh-plot:: {{ source_path }}
+    :process-docstring:
     :source-position: below

--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -92,7 +92,6 @@ from uuid import uuid4
 
 # External imports
 from docutils import nodes
-#from docutils.parsers.rst import Directive
 from docutils.parsers.rst.directives import choice, flag
 from sphinx.errors import SphinxError
 from sphinx.util import copyfile, ensuredir, status_iterator
@@ -171,9 +170,10 @@ class BokehPlotDirective(BokehDirective):
         target = nodes.target("", "", ids=[target_id])
         result = [target]
 
-        if doc:
+        # if this is NOT an inline example and a docstring exists, add it
+        if not self.content and doc:
             docstring = self._parse(doc, '<bokeh-plot>')
-            result += [docstring[0]]
+            result += [elem for elem in docstring]
 
         linenos = self.options.get("linenos", False)
         code = nodes.literal_block(source, source, language="python", linenos=linenos, classes=[])

--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -171,14 +171,14 @@ class BokehPlotDirective(BokehDirective):
         target = nodes.target("", "", ids=[target_id])
         result = [target]
 
-        # if this is NOT an inline example and a docstring exists, add it
+        # if a docstring exists, add it
         if doc:
             docstring = self._parse(doc, '<bokeh-plot>')
             result += [elem for elem in docstring]
             source = _remove_module_docstring(source, doc)
 
         # strip leading/trailing whitespace from source code
-        source.strip()
+        source = source.strip()
 
         linenos = self.options.get("linenos", False)
         code = nodes.literal_block(source, source, language="python", linenos=linenos, classes=[])
@@ -282,7 +282,7 @@ def _process_script(source, filename, env, js_name, use_relative_paths=False):
     with open(js_path, "w") as f:
         f.write(js)
 
-    return (script, js, js_path, source, c.doc)
+    return (script, js, js_path, source, c.doc.strip())
 
 
 def _remove_module_docstring(source, doc):

--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -175,9 +175,8 @@ class BokehPlotDirective(BokehDirective):
         if doc:
             docstring = self._parse(doc, '<bokeh-plot>')
             result += [elem for elem in docstring]
-            # take docstring out of source so it doesn't show up twice
-            source = re.sub(rf'(\'\'\'|\"\"\")\s*{re.escape(doc)}\s*(\'\'\'|\"\"\")', "", source)
-            source = re.sub(r'^\s*', "", source)
+            source = _remove_module_docstring(source, doc)
+
 
         linenos = self.options.get("linenos", False)
         code = nodes.literal_block(source, source, language="python", linenos=linenos, classes=[])
@@ -283,6 +282,12 @@ def _process_script(source, filename, env, js_name, use_relative_paths=False):
 
     return (script, js, js_path, source, c.doc)
 
+
+def _remove_module_docstring(source, doc):
+    # take docstring out of source so it doesn't show up twice
+    source = re.sub(rf'(\'\'\'|\"\"\")\s*{re.escape(doc)}\s*(\'\'\'|\"\"\")', "", source)
+    # ...and strip leading whitespace
+    return re.sub(r'^\s*', "", source)
 
 # -----------------------------------------------------------------------------
 # Code

--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -42,6 +42,10 @@ used in docstrings.
 
 The ``bokeh-plot`` directive accepts the following options:
 
+process-docstring (bool):
+    Whether to display the docstring in a formatted block
+    separate from the source.
+
 source-position (enum('above', 'below', 'none')):
     Where to locate the the block of formatted source
     code (if anywhere).
@@ -129,6 +133,7 @@ class BokehPlotDirective(BokehDirective):
     optional_arguments = 2
 
     option_spec = {
+        "process-docstring": lambda x: True if flag(x) is None else False,
         "source-position": lambda x: choice(x, ("below", "above", "none")),
         "linenos": lambda x: True if flag(x) is None else False,
     }
@@ -171,8 +176,8 @@ class BokehPlotDirective(BokehDirective):
         target = nodes.target("", "", ids=[target_id])
         result = [target]
 
-        # if a docstring exists, add it
-        if doc:
+        process_docstring = self.options.get("process-docstring", False)
+        if doc and process_docstring:
             docstring = self._parse(doc, '<bokeh-plot>')
             result += [elem for elem in docstring]
             source = _remove_module_docstring(source, doc)
@@ -282,7 +287,7 @@ def _process_script(source, filename, env, js_name, use_relative_paths=False):
     with open(js_path, "w") as f:
         f.write(js)
 
-    return (script, js, js_path, source, c.doc.strip())
+    return (script, js, js_path, source, c.doc.strip() if c.doc else None)
 
 
 def _remove_module_docstring(source, doc):

--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -86,6 +86,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import warnings
+import re
 from os import getenv
 from os.path import basename, dirname, join
 from uuid import uuid4
@@ -174,9 +175,12 @@ class BokehPlotDirective(BokehDirective):
         if not self.content and doc:
             docstring = self._parse(doc, '<bokeh-plot>')
             result += [elem for elem in docstring]
+            # take docstring out of source so it doesn't show up twice
+            source = re.sub(rf'(\'\'\'|\"\"\")\s*{re.escape(doc)}\s*(\'\'\'|\"\"\")', "", source)
 
         linenos = self.options.get("linenos", False)
         code = nodes.literal_block(source, source, language="python", linenos=linenos, classes=[])
+
         set_source_info(self, code)
 
         source_position = self.options.get("source-position", "below")

--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -177,6 +177,8 @@ class BokehPlotDirective(BokehDirective):
             result += [elem for elem in docstring]
             source = _remove_module_docstring(source, doc)
 
+        # strip leading/trailing whitespace from source code
+        source.strip()
 
         linenos = self.options.get("linenos", False)
         code = nodes.literal_block(source, source, language="python", linenos=linenos, classes=[])
@@ -285,9 +287,7 @@ def _process_script(source, filename, env, js_name, use_relative_paths=False):
 
 def _remove_module_docstring(source, doc):
     # take docstring out of source so it doesn't show up twice
-    source = re.sub(rf'(\'\'\'|\"\"\")\s*{re.escape(doc)}\s*(\'\'\'|\"\"\")', "", source)
-    # ...and strip leading whitespace
-    return re.sub(r'^\s*', "", source)
+    return re.sub(rf'(\'\'\'|\"\"\")\s*{re.escape(doc)}\s*(\'\'\'|\"\"\")', "", source)
 
 # -----------------------------------------------------------------------------
 # Code

--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -85,8 +85,8 @@ log = logging.getLogger(__name__)
 # -----------------------------------------------------------------------------
 
 # Standard library imports
-import warnings
 import re
+import warnings
 from os import getenv
 from os.path import basename, dirname, join
 from uuid import uuid4
@@ -103,9 +103,9 @@ from bokeh.document import Document
 from bokeh.embed import autoload_static
 from bokeh.model import Model
 from bokeh.util.warnings import BokehDeprecationWarning
-from .bokeh_directive import BokehDirective
 
 # Bokeh imports
+from .bokeh_directive import BokehDirective
 from .example_handler import ExampleHandler
 from .util import get_sphinx_resources
 

--- a/bokeh/sphinxext/example_handler.py
+++ b/bokeh/sphinxext/example_handler.py
@@ -145,6 +145,10 @@ class ExampleHandler(Handler):
     def error_detail(self) -> str | None:
         return self._runner.error_detail
 
+    @property
+    def doc(self) -> str | None:
+        return self._runner.doc
+
 # -----------------------------------------------------------------------------
 # Private API
 # -----------------------------------------------------------------------------

--- a/examples/plotting/file/iris.py
+++ b/examples/plotting/file/iris.py
@@ -1,3 +1,5 @@
+''' Example docstring for iris.py. '''
+
 from bokeh.plotting import figure, output_file, show
 from bokeh.sampledata.iris import flowers
 

--- a/examples/plotting/file/iris.py
+++ b/examples/plotting/file/iris.py
@@ -1,4 +1,6 @@
-''' Example docstring for iris.py. '''
+''' A scatter plot using Fisher's *Iris* dataset to illustrate colormapping and basic plot elements.
+
+'''
 
 from bokeh.plotting import figure, output_file, show
 from bokeh.sampledata.iris import flowers
@@ -6,7 +8,7 @@ from bokeh.sampledata.iris import flowers
 colormap = {'setosa': 'red', 'versicolor': 'green', 'virginica': 'blue'}
 colors = [colormap[x] for x in flowers['species']]
 
-p = figure(title = "Iris Morphology")
+p = figure(title="Iris Morphology")
 p.xaxis.axis_label = 'Petal Length'
 p.yaxis.axis_label = 'Petal Width'
 

--- a/examples/plotting/file/iris.py
+++ b/examples/plotting/file/iris.py
@@ -1,7 +1,6 @@
 ''' A scatter plot using Fisher's *Iris* dataset to illustrate colormapping and basic plot elements.
 
 '''
-
 from bokeh.plotting import figure, output_file, show
 from bokeh.sampledata.iris import flowers
 

--- a/sphinx/source/docs/user_guide/examples/js_events.py
+++ b/sphinx/source/docs/user_guide/examples/js_events.py
@@ -1,5 +1,5 @@
-""" Demonstration of how to register event callbacks using an adaptation
-of the color_scatter example from the Bokeh gallery
+""" Demonstration of how to register event callbacks using an adaptation of the color_scatter example from the Bokeh gallery
+
 """
 import numpy as np
 

--- a/tests/unit/bokeh/application/handlers/test_code_runner.py
+++ b/tests/unit/bokeh/application/handlers/test_code_runner.py
@@ -43,6 +43,7 @@ class TestCodeRunner:
     def test_init(self) -> None:
         cr = bahc.CodeRunner("# test", "path", [])
         assert cr.failed is False
+        assert cr.doc is None
         assert cr.error is None
         assert cr.error_detail is None
         assert cr.ran is False

--- a/tests/unit/bokeh/application/handlers/test_code_runner.py
+++ b/tests/unit/bokeh/application/handlers/test_code_runner.py
@@ -174,6 +174,11 @@ class TestCodeRunner:
         cr.run(m, lambda: None)
         assert sys.path == old_path
 
+    def test_doc(self) -> None:
+        cr = bahc.CodeRunner("'''some docstring\n\nfoo bar'''", "path", [])
+        assert cr.failed is False
+        assert cr.doc == "some docstring\n\nfoo bar"
+
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
- [X] issues: fixes #11381


Parses docstrings by adding a `doc` property to both ExampleHandler and CodeRunner, adding the example's docstring as a formatted element on the gallery detail page, and then stripping the redundant docstring out of the source code that appears along with the plot.
![Selection_061](https://user-images.githubusercontent.com/43212692/126212010-322f8d52-1359-4dbf-a918-769f84bed3cd.png)
