### PR TITLE
Add default muted glyph unconditionally

### DIFF
--- a/bokeh/models/renderers.py
+++ b/bokeh/models/renderers.py
@@ -33,7 +33,6 @@ from ..core.properties import (
     Enum,
     Float,
     Instance,
-    Null,
     Nullable,
     Override,
     String,

--- a/bokeh/models/renderers.py
+++ b/bokeh/models/renderers.py
@@ -221,14 +221,14 @@ class GlyphRenderer(DataRenderer):
     and ranges.
     """)
 
-    selection_glyph = Nullable(Either(Auto, Instance(Glyph), Null, default="auto"), help=""""
+    selection_glyph = Nullable(Either(Auto, Instance(Glyph)), default="auto", help=""""
     An optional glyph used for selected points.
 
     If set to "auto" then the standard glyph will be used for selected
     points.
     """)
 
-    nonselection_glyph = Nullable(Either(Auto, Instance(Glyph), Null, default="auto"), help="""
+    nonselection_glyph = Nullable(Either(Auto, Instance(Glyph)), default="auto", help=""""
     An optional glyph used for explicitly non-selected points
     (i.e., non-selected when there are other points that are selected,
     but not when no points at all are selected.)
@@ -242,7 +242,7 @@ class GlyphRenderer(DataRenderer):
     being hovered over by a ``HoverTool``.
     """)
 
-    muted_glyph = Nullable(Either(Auto, Instance(Glyph), Null, default="auto"), help="""
+    muted_glyph = Nullable(Either(Auto, Instance(Glyph)), default="auto", help=""""
     """)
 
     muted = Bool(False, help="""

--- a/bokeh/models/renderers.py
+++ b/bokeh/models/renderers.py
@@ -242,7 +242,7 @@ class GlyphRenderer(DataRenderer):
     being hovered over by a ``HoverTool``.
     """)
 
-    muted_glyph = Nullable(Instance(Glyph), help="""
+    muted_glyph = Either(Auto, Instance(Glyph), Null, default="auto", help="""
     """)
 
     muted = Bool(False, help="""

--- a/bokeh/models/renderers.py
+++ b/bokeh/models/renderers.py
@@ -221,14 +221,14 @@ class GlyphRenderer(DataRenderer):
     and ranges.
     """)
 
-    selection_glyph = Either(Auto, Instance(Glyph), Null, default="auto", help="""
+    selection_glyph = Nullable(Either(Auto, Instance(Glyph), Null, default="auto"), help=""""
     An optional glyph used for selected points.
 
     If set to "auto" then the standard glyph will be used for selected
     points.
     """)
 
-    nonselection_glyph = Either(Auto, Instance(Glyph), Null, default="auto", help="""
+    nonselection_glyph = Nullable(Either(Auto, Instance(Glyph), Null, default="auto"), help="""
     An optional glyph used for explicitly non-selected points
     (i.e., non-selected when there are other points that are selected,
     but not when no points at all are selected.)
@@ -242,7 +242,7 @@ class GlyphRenderer(DataRenderer):
     being hovered over by a ``HoverTool``.
     """)
 
-    muted_glyph = Either(Auto, Instance(Glyph), Null, default="auto", help="""
+    muted_glyph = Nullable(Either(Auto, Instance(Glyph), Null, default="auto"), help="""
     """)
 
     muted = Bool(False, help="""

--- a/bokeh/plotting/_graph.py
+++ b/bokeh/plotting/_graph.py
@@ -101,11 +101,10 @@ def get_graph_kwargs(node_source, edge_source, **kwargs):
     else:
         hnode_visuals = None
 
-    if any(x.startswith('node_muted_') for x in kwargs):
-        mnode_visuals = pop_visuals(marker_type, kwargs, prefix="node_muted_", defaults=node_visuals)
-    else:
-        mnode_visuals = None
+    #Always set muted glyph
+    mnode_visuals = pop_visuals(marker_type, kwargs, prefix="node_muted_", defaults=node_visuals, override_defaults={'alpha':0.2})
 
+    #Always set nonselection glyph
     nsnode_visuals = pop_visuals(marker_type, kwargs, prefix="node_nonselection_", defaults=node_visuals)
 
     ## edge stuff
@@ -121,11 +120,10 @@ def get_graph_kwargs(node_source, edge_source, **kwargs):
     else:
         hedge_visuals = None
 
-    if any(x.startswith('edge_muted_') for x in kwargs):
-        medge_visuals = pop_visuals(MultiLine, kwargs, prefix="edge_muted_", defaults=edge_visuals)
-    else:
-        medge_visuals = None
+    #Always set muted glyph
+    medge_visuals = pop_visuals(MultiLine, kwargs, prefix="edge_muted_", defaults=edge_visuals, override_defaults={'alpha':0.2})
 
+    #Always set nonselection glyph
     nsedge_visuals = pop_visuals(MultiLine, kwargs, prefix="edge_nonselection_", defaults=edge_visuals)
 
     ## node stuff
@@ -143,7 +141,7 @@ def get_graph_kwargs(node_source, edge_source, **kwargs):
         selection_glyph=snode_glyph or "auto",
         nonselection_glyph=nsnode_glyph or "auto",
         hover_glyph=hnode_glyph,
-        muted_glyph=mnode_glyph,
+        muted_glyph=mnode_glyph or "auto",
     )
 
     ## edge stuff
@@ -161,7 +159,7 @@ def get_graph_kwargs(node_source, edge_source, **kwargs):
         selection_glyph=sedge_glyph or "auto",
         nonselection_glyph=nsedge_glyph or "auto",
         hover_glyph=hedge_glyph,
-        muted_glyph=medge_glyph,
+        muted_glyph=medge_glyph or "auto",
     )
 
     renderer_kwargs = {attr: kwargs.pop(attr) for attr in RENDERER_ARGS if attr in kwargs}

--- a/bokeh/plotting/_graph.py
+++ b/bokeh/plotting/_graph.py
@@ -101,10 +101,8 @@ def get_graph_kwargs(node_source, edge_source, **kwargs):
     else:
         hnode_visuals = None
 
-    #Always set muted glyph
     mnode_visuals = pop_visuals(marker_type, kwargs, prefix="node_muted_", defaults=node_visuals, override_defaults={'alpha':0.2})
 
-    #Always set nonselection glyph
     nsnode_visuals = pop_visuals(marker_type, kwargs, prefix="node_nonselection_", defaults=node_visuals)
 
     ## edge stuff
@@ -120,10 +118,8 @@ def get_graph_kwargs(node_source, edge_source, **kwargs):
     else:
         hedge_visuals = None
 
-    #Always set muted glyph
     medge_visuals = pop_visuals(MultiLine, kwargs, prefix="edge_muted_", defaults=edge_visuals, override_defaults={'alpha':0.2})
 
-    #Always set nonselection glyph
     nsedge_visuals = pop_visuals(MultiLine, kwargs, prefix="edge_nonselection_", defaults=edge_visuals)
 
     ## node stuff

--- a/bokeh/plotting/_renderer.py
+++ b/bokeh/plotting/_renderer.py
@@ -110,11 +110,8 @@ def create_renderer(glyphclass, plot, **kwargs):
     else:
         hover_visuals = None
 
-    # handle the mute glyph, if any properties were given
-    if any(x.startswith('muted_') for x in kwargs):
-        muted_visuals = pop_visuals(glyphclass, kwargs, prefix='muted_', defaults=glyph_visuals)
-    else:
-        muted_visuals = None
+    # handle the mute glyph, we always set one
+    muted_visuals = pop_visuals(glyphclass, kwargs, prefix='muted_', defaults=glyph_visuals, override_defaults={'alpha':0.2})
 
     glyph = make_glyph(glyphclass, kwargs, glyph_visuals)
     nonselection_glyph = make_glyph(glyphclass, kwargs, nonselection_visuals)
@@ -127,7 +124,7 @@ def create_renderer(glyphclass, plot, **kwargs):
         nonselection_glyph=nonselection_glyph or "auto",
         selection_glyph=selection_glyph or "auto",
         hover_glyph=hover_glyph,
-        muted_glyph=muted_glyph,
+        muted_glyph=muted_glyph or "auto",
         **renderer_kws)
 
     plot.renderers.append(glyph_renderer)

--- a/bokehjs/src/lib/api/plotting.ts
+++ b/bokehjs/src/lib/api/plotting.ts
@@ -906,7 +906,7 @@ export class Figure extends Plot {
     const nglyph_ca = this._pop_visuals(cls, attrs, "nonselection_", glyph_ca, {alpha: 0.1})
     const sglyph_ca = this._pop_visuals(cls, attrs, "selection_", glyph_ca)
     const hglyph_ca = this._pop_visuals(cls, attrs, "hover_", glyph_ca)
-    const mglyph_ca = this._pop_visuals(cls, attrs, "muted_", glyph_ca)
+    const mglyph_ca = this._pop_visuals(cls, attrs, "muted_", glyph_ca, {alpha: 0.2})
 
     this._fixup_values(cls, data,  glyph_ca)
     this._fixup_values(cls, data, nglyph_ca)
@@ -926,7 +926,7 @@ export class Figure extends Plot {
     const nglyph = !is_empty(nglyph_ca) ? _make_glyph(cls, attrs, nglyph_ca) : "auto"
     const sglyph = !is_empty(sglyph_ca) ? _make_glyph(cls, attrs, sglyph_ca) : "auto"
     const hglyph = !is_empty(hglyph_ca) ? _make_glyph(cls, attrs, hglyph_ca) : undefined
-    const mglyph = !is_empty(mglyph_ca) ? _make_glyph(cls, attrs, mglyph_ca) : undefined
+    const mglyph = !is_empty(mglyph_ca) ? _make_glyph(cls, attrs, mglyph_ca) : "auto"
 
     const glyph_renderer = new GlyphRenderer({
       data_source:        source,

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -96,7 +96,7 @@ export class GlyphRendererView extends DataRendererView {
     }
 
     let {selection_glyph, nonselection_glyph, hover_glyph, muted_glyph} = this.model
-    
+
     selection_glyph = glyph_from_mode(selection_defaults, selection_glyph)
     this.selection_glyph = await this.build_glyph_view(selection_glyph)
 

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -38,6 +38,11 @@ const nonselection_defaults: Defaults = {
   line: {},
 }
 
+const muted_defaults: Defaults = {
+  fill: {fill_alpha: 0.2},
+  line: {},
+}
+
 export class GlyphRendererView extends DataRendererView {
   override model: GlyphRenderer
 
@@ -45,7 +50,7 @@ export class GlyphRendererView extends DataRendererView {
   selection_glyph: GlyphView
   nonselection_glyph: GlyphView
   hover_glyph?: GlyphView
-  muted_glyph?: GlyphView
+  muted_glyph: GlyphView
   decimated_glyph: GlyphView
 
   get glyph_view(): GlyphView {
@@ -94,9 +99,12 @@ export class GlyphRendererView extends DataRendererView {
     if (hover_glyph != null)
       this.hover_glyph = await this.build_glyph_view(hover_glyph)
 
-    const {muted_glyph} = this.model
-    if (muted_glyph != null)
-      this.muted_glyph = await this.build_glyph_view(muted_glyph)
+    let {muted_glyph} = this.model
+    if (muted_glyph == null)
+      muted_glyph = mk_glyph({fill: {}, line: {}})
+    else if (muted_glyph == "auto")
+      muted_glyph = mk_glyph(muted_defaults)
+    this.muted_glyph = await this.build_glyph_view(muted_glyph)
 
     const decimated_glyph = mk_glyph(decimated_defaults)
     this.decimated_glyph = await this.build_glyph_view(decimated_glyph)
@@ -104,7 +112,7 @@ export class GlyphRendererView extends DataRendererView {
     this.selection_glyph.set_base(this.glyph)
     this.nonselection_glyph.set_base(this.glyph)
     this.hover_glyph?.set_base(this.glyph)
-    this.muted_glyph?.set_base(this.glyph)
+    this.muted_glyph.set_base(this.glyph)
     this.decimated_glyph.set_base(this.glyph)
 
     this.set_data()
@@ -119,7 +127,7 @@ export class GlyphRendererView extends DataRendererView {
     this.selection_glyph.remove()
     this.nonselection_glyph.remove()
     this.hover_glyph?.remove()
-    this.muted_glyph?.remove()
+    this.muted_glyph.remove()
     this.decimated_glyph.remove()
     super.remove()
   }
@@ -137,8 +145,7 @@ export class GlyphRendererView extends DataRendererView {
     this.connect(this.nonselection_glyph.model.change, update)
     if (this.hover_glyph != null)
       this.connect(this.hover_glyph.model.change, update)
-    if (this.muted_glyph != null)
-      this.connect(this.muted_glyph.model.change, update)
+    this.connect(this.muted_glyph.model.change, update)
     this.connect(this.decimated_glyph.model.change, update)
 
     this.connect(this.model.data_source.change, update)
@@ -379,7 +386,7 @@ export namespace GlyphRenderer {
     hover_glyph: p.Property<Glyph | null>
     nonselection_glyph: p.Property<Glyph | "auto" | null>
     selection_glyph: p.Property<Glyph | "auto" | null>
-    muted_glyph: p.Property<Glyph | null>
+    muted_glyph: p.Property<Glyph | "auto" | null>
     muted: p.Property<boolean>
   }
 }
@@ -404,7 +411,7 @@ export class GlyphRenderer extends DataRenderer {
       hover_glyph:        [ Nullable(Ref(Glyph)), null ],
       nonselection_glyph: [ Or(Ref(Glyph), Auto, Null), "auto" ],
       selection_glyph:    [ Or(Ref(Glyph), Auto, Null), "auto" ],
-      muted_glyph:        [ Nullable(Ref(Glyph)), null ],
+      muted_glyph:        [ Or(Ref(Glyph), Auto, Null), "auto" ],
       muted:              [ Boolean, false ],
     }))
   }

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -38,6 +38,11 @@ const nonselection_defaults: Defaults = {
   line: {},
 }
 
+const hover_defaults: Defaults = {
+  fill: {},
+  line: {},
+}
+
 const muted_defaults: Defaults = {
   fill: {fill_alpha: 0.2},
   line: {},
@@ -81,32 +86,30 @@ export class GlyphRendererView extends DataRendererView {
       return new (base_glyph.constructor as any)(attrs)
     }
 
-    let {selection_glyph} = this.model
-    if (selection_glyph == null)
-      selection_glyph = mk_glyph({fill: {}, line: {}})
-    else if (selection_glyph == "auto")
-      selection_glyph = mk_glyph(selection_defaults)
+    function glyph_from_mode(defaults: Defaults, glyph?: Glyph | "auto" | null): typeof base_glyph {
+      if (glyph instanceof Glyph){
+        return glyph
+      } else if (glyph == "auto"){
+        return mk_glyph(defaults)
+      }
+      return mk_glyph({fill: {}, line: {}})
+    }
+
+    let {selection_glyph, nonselection_glyph, hover_glyph, muted_glyph} = this.model
+    
+    selection_glyph = glyph_from_mode(selection_defaults, selection_glyph)
     this.selection_glyph = await this.build_glyph_view(selection_glyph)
 
-    let {nonselection_glyph} = this.model
-    if (nonselection_glyph == null)
-      nonselection_glyph = mk_glyph({fill: {}, line: {}})
-    else if (nonselection_glyph == "auto")
-      nonselection_glyph = mk_glyph(nonselection_defaults)
+    nonselection_glyph = glyph_from_mode(nonselection_defaults, selection_glyph)
     this.nonselection_glyph = await this.build_glyph_view(nonselection_glyph)
 
-    const {hover_glyph} = this.model
-    if (hover_glyph != null)
-      this.hover_glyph = await this.build_glyph_view(hover_glyph)
+    hover_glyph = glyph_from_mode(hover_defaults, hover_glyph)
+    this.hover_glyph = await this.build_glyph_view(hover_glyph)
 
-    let {muted_glyph} = this.model
-    if (muted_glyph == null)
-      muted_glyph = mk_glyph({fill: {}, line: {}})
-    else if (muted_glyph == "auto")
-      muted_glyph = mk_glyph(muted_defaults)
+    muted_glyph = glyph_from_mode(muted_defaults, muted_glyph)
     this.muted_glyph = await this.build_glyph_view(muted_glyph)
 
-    const decimated_glyph = mk_glyph(decimated_defaults)
+    const decimated_glyph = glyph_from_mode(decimated_defaults, "auto")
     this.decimated_glyph = await this.build_glyph_view(decimated_glyph)
 
     this.selection_glyph.set_base(this.glyph)

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -100,7 +100,7 @@ export class GlyphRendererView extends DataRendererView {
     selection_glyph = glyph_from_mode(selection_defaults, selection_glyph)
     this.selection_glyph = await this.build_glyph_view(selection_glyph)
 
-    nonselection_glyph = glyph_from_mode(nonselection_defaults, selection_glyph)
+    nonselection_glyph = glyph_from_mode(nonselection_defaults, nonselection_glyph)
     this.nonselection_glyph = await this.build_glyph_view(nonselection_glyph)
 
     hover_glyph = glyph_from_mode(hover_defaults, hover_glyph)

--- a/bokehjs/test/unit/models/renderers/glyph_renderer.ts
+++ b/bokehjs/test/unit/models/renderers/glyph_renderer.ts
@@ -1,5 +1,4 @@
 import {expect} from "assertions"
-
 import {ColumnDataSource} from "@bokehjs/models/sources/column_data_source"
 import {GlyphRenderer} from "@bokehjs/models/renderers/glyph_renderer"
 import {Circle} from "@bokehjs/models/glyphs"
@@ -55,6 +54,7 @@ describe("GlyphRendererView", async () => {
     glyph_renderer,
     {parent: await build_view(new Plot())},
   )
+
   const {glyph, selection_glyph, nonselection_glyph, hover_glyph, muted_glyph, decimated_glyph} = view
 
   it("should have default selection_glyph equal to main glyph", () => {
@@ -62,7 +62,7 @@ describe("GlyphRendererView", async () => {
   })
 
   it("should have default nonselection_glyph with 0.2 alpha", () => {
-    expect(nonselection_glyph.model.attributes.fill_alpha).to.be.equal({value: 0.2})
+    expect((nonselection_glyph.model as Circle).fill_alpha).to.be.equal({value: 0.2})
   })
 
   it("should have default hover_glyph model equal to main glyph model", () => {
@@ -70,12 +70,12 @@ describe("GlyphRendererView", async () => {
   })
 
   it("should have default muted_glyph with 0.2 alpha", () => {
-    expect(muted_glyph.model.attributes.fill_alpha).to.be.equal({value: 0.2})
+    expect((muted_glyph.model as Circle).fill_alpha).to.be.equal({value: 0.2})
   })
 
   it("should have default decimated_glyph with 0.3 line alpha and color grey", () => {
-    expect(decimated_glyph.model.attributes.line_alpha).to.be.equal({value: 0.3})
-    expect(decimated_glyph.model.attributes.line_color).to.be.equal({value: "grey"})
+    expect((decimated_glyph.model as Circle).line_alpha).to.be.equal({value: 0.3})
+    expect((decimated_glyph.model as Circle).line_color).to.be.equal({value: "grey"})
   })
 
 })

--- a/bokehjs/test/unit/models/renderers/glyph_renderer.ts
+++ b/bokehjs/test/unit/models/renderers/glyph_renderer.ts
@@ -2,23 +2,27 @@ import {expect} from "assertions"
 
 import {ColumnDataSource} from "@bokehjs/models/sources/column_data_source"
 import {GlyphRenderer} from "@bokehjs/models/renderers/glyph_renderer"
+import {Circle} from "@bokehjs/models/glyphs"
+import {build_view} from "@bokehjs/core/build_views"
+import {Plot} from "@bokehjs/models/plots"
+
+function mkrenderer(glyph_obj: Circle): GlyphRenderer {
+  const source = new ColumnDataSource({
+    data: {
+      x: [10, 20, 30, 40],
+      y: [1, 2, 3, 4],
+      color: ["red", "green", "red", "green"],
+      label: ["foo", "bar", "foo", "bar"],
+    },
+  })
+  return new GlyphRenderer({glyph: glyph_obj, data_source: source})
+}
 
 describe("GlyphRenderer", () => {
-
-  function mkrenderer(): GlyphRenderer {
-    const source = new ColumnDataSource({
-      data: {
-        x: [10, 20, 30, 40],
-        y: [1, 2, 3, 4],
-        color: ["red", "green", "red", "green"],
-        label: ["foo", "bar", "foo", "bar"],
-      },
-    })
-    return new GlyphRenderer({data_source: source})
-  }
+  const basic_circle = new Circle()
 
   describe("get_reference_point", () => {
-    const gr = mkrenderer()
+    const gr = mkrenderer(basic_circle)
 
     it("should return 0 if no field, value is passed", () => {
       const index = gr.get_reference_point(null)
@@ -40,4 +44,38 @@ describe("GlyphRenderer", () => {
       expect(index).to.be.equal(0)
     })
   })
+})
+
+describe("GlyphRendererView", async () => {
+  // Basic case with no all glyphs going to their defaults
+
+  const basic_circle = new Circle({fill_color: "red"})
+  const glyph_renderer = mkrenderer(basic_circle)
+  const view = await build_view(
+    glyph_renderer,
+    {parent: await build_view(new Plot())},
+  )
+  const {glyph, selection_glyph, nonselection_glyph, hover_glyph, muted_glyph, decimated_glyph} = view
+
+  it("should have default selection_glyph equal to main glyph", () => {
+    expect(selection_glyph.model.attributes).to.be.equal(glyph.model.attributes)
+  })
+
+  it("should have default nonselection_glyph with 0.2 alpha", () => {
+    expect(nonselection_glyph.model.attributes.fill_alpha).to.be.equal({value: 0.2})
+  })
+
+  it("should have default hover_glyph model equal to main glyph model", () => {
+    expect(hover_glyph?.model.attributes).to.be.equal(glyph.model.attributes)
+  })
+
+  it("should have default muted_glyph with 0.2 alpha", () => {
+    expect(muted_glyph.model.attributes.fill_alpha).to.be.equal({value: 0.2})
+  })
+
+  it("should have default decimated_glyph with 0.3 line alpha and color grey", () => {
+    expect(decimated_glyph.model.attributes.line_alpha).to.be.equal({value: 0.3})
+    expect(decimated_glyph.model.attributes.line_color).to.be.equal({value: "grey"})
+  })
+
 })

--- a/tests/unit/bokeh/plotting/test__graph.py
+++ b/tests/unit/bokeh/plotting/test__graph.py
@@ -17,7 +17,12 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Bokeh imports
-from bokeh.models import ColumnDataSource, Scatter, Circle, MultiLine
+from bokeh.models import (
+    Circle,
+    ColumnDataSource,
+    MultiLine,
+    Scatter,
+)
 
 # Module under test
 import bokeh.plotting._graph as bpg # isort:skip

--- a/tests/unit/bokeh/plotting/test__graph.py
+++ b/tests/unit/bokeh/plotting/test__graph.py
@@ -17,7 +17,7 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Bokeh imports
-from bokeh.models import ColumnDataSource, Scatter
+from bokeh.models import ColumnDataSource, Scatter, Circle, MultiLine
 
 # Module under test
 import bokeh.plotting._graph as bpg # isort:skip
@@ -108,6 +108,21 @@ class Test_get_graph_kwargs:
         assert r.nonselection_glyph.line_width == 23
         assert r.hover_glyph.line_width == 23
         assert r.muted_glyph.line_width == 23
+
+    def test_default_muted_glyph(self) -> None:
+        kwargs = dict(edge_line_color="purple", edge_line_alpha=0.7,
+                        node_fill_color="red", node_fill_alpha=0.8, node_line_color="blue")
+        kw = bpg.get_graph_kwargs({}, {}, **kwargs)
+
+        r = kw['edge_renderer']
+        assert isinstance(r.muted_glyph, MultiLine)
+        assert r.muted_glyph.line_color == "purple"
+        assert r.muted_glyph.line_alpha == 0.2
+        r = kw['node_renderer']
+        assert isinstance(r.muted_glyph, Circle)
+        assert r.muted_glyph.fill_color == "red"
+        assert r.muted_glyph.line_alpha == 0.2
+        assert r.muted_glyph.line_color == "blue"
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/tests/unit/bokeh/plotting/test__renderer.py
+++ b/tests/unit/bokeh/plotting/test__renderer.py
@@ -84,13 +84,12 @@ class Test__pop_visuals:
         assert ca["fill_color"] == "white"
         assert set(ca) == { "fill_color", "hatch_color", "line_color", "fill_alpha", "hatch_alpha", "line_alpha" }
 
-class Test__make_glyph:
+class Test_make_glyph:
     def test_null_visuals(self) -> None:
         kwargs = dict(fill_alpha=0.7, line_alpha=0.8, line_color="red")
         hover_visuals = None
         ca = bpr.make_glyph(Circle, kwargs, hover_visuals)
         assert ca is None
-    
     def test_default_mute_glyph_basic_prop(self) -> None:
         kwargs = dict(fill_alpha=0.7, line_alpha=0.8, line_color="red")
         glyph_visuals = bpr.pop_visuals(Circle, kwargs)

--- a/tests/unit/bokeh/plotting/test__renderer.py
+++ b/tests/unit/bokeh/plotting/test__renderer.py
@@ -84,6 +84,31 @@ class Test__pop_visuals:
         assert ca["fill_color"] == "white"
         assert set(ca) == { "fill_color", "hatch_color", "line_color", "fill_alpha", "hatch_alpha", "line_alpha" }
 
+class Test__make_glyph:
+    def test_null_visuals(self) -> None:
+        kwargs = dict(fill_alpha=0.7, line_alpha=0.8, line_color="red")
+        hover_visuals = None
+        ca = bpr.make_glyph(Circle, kwargs, hover_visuals)
+        assert ca is None
+    
+    def test_default_mute_glyph_basic_prop(self) -> None:
+        kwargs = dict(fill_alpha=0.7, line_alpha=0.8, line_color="red")
+        glyph_visuals = bpr.pop_visuals(Circle, kwargs)
+        muted_visuals = bpr.pop_visuals(Circle, kwargs, prefix='muted_', defaults=glyph_visuals, override_defaults={'alpha':0.2})
+        ca = bpr.make_glyph(Circle, kwargs, muted_visuals)
+        assert ca.fill_alpha == 0.2
+        assert ca.line_alpha == 0.2
+        assert isinstance(ca, Circle)
+
+    def test_user_specified_mute_glyph(self) -> None:
+        kwargs = dict(fill_alpha=0.7, line_alpha=0.8, line_color="red", muted_color="blue", muted_alpha=0.4)
+        glyph_visuals = bpr.pop_visuals(Circle, kwargs)
+        muted_visuals = bpr.pop_visuals(Circle, kwargs, prefix='muted_', defaults=glyph_visuals, override_defaults={'alpha':0.2})
+        ca = bpr.make_glyph(Circle, kwargs, muted_visuals)
+        assert ca.fill_alpha == 0.4
+        assert ca.line_alpha == 0.4
+        assert ca.line_color == "blue"
+        assert ca.fill_color == "blue"
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
#### Issue:
Muted glyphs are only handled if "muted_" properties were specified. This conflicts with `plot.legend.click_policy = 'mute'` since the click policy can be set without "muted_" glyph properties.

#### Solution:
Handle `muted_glyph` in the same manner as `nonselection_glyph` - unconditionally created, and if no "muted_" properties are specified, the default `muted_glyph` has the same properties as the main glyph, except alpha overridden at 0.2.

- [x] issues: fixes #8390
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
