### PR TITLE
Cleanup bokeh.sphinxext

### DIFF
--- a/bokeh/model.py
+++ b/bokeh/model.py
@@ -857,6 +857,10 @@ class Model(HasProps, PropertyCallbackManager, EventCallbackManager):
 
         return html
 
+    def _sphinx_height_hint(self) -> int|None:
+        return None
+
+
 @abstract
 class DataModel(Model):
     __data_model__ = True

--- a/bokeh/models/layouts.py
+++ b/bokeh/models/layouts.py
@@ -301,6 +301,11 @@ class LayoutDOM(Model):
         if not (min_height <= height <= max_height):
             return str(self)
 
+    def _sphinx_height_hint(self) -> int|None:
+        if self.sizing_mode in ("stretch_width", "fixed", None):
+            return self.height
+        return None
+
 @abstract
 class HTMLBox(LayoutDOM):
     ''' A component which size is determined by its HTML content.
@@ -432,6 +437,11 @@ class Row(Box):
 
     """)
 
+    def _sphinx_height_hint(self) -> int|None:
+        if any(x._sphinx_height_hint() is None for x in self.children):
+            return None
+        return max(x._sphinx_height_hint() for x in self.children)
+
 class Column(Box):
     ''' Lay out child components in a single vertical row.
 
@@ -447,6 +457,11 @@ class Column(Box):
         own discretion.
 
     """)
+
+    def _sphinx_height_hint(self) -> int|None:
+        if any(x._sphinx_height_hint() is None for x in self.children):
+            return None
+        return sum(x._sphinx_height_hint() for x in self.children)
 
 class Panel(Model):
     ''' A single-widget container with title bar and controls.

--- a/bokeh/sphinxext/_templates/sri_table.html
+++ b/bokeh/sphinxext/_templates/sri_table.html
@@ -1,0 +1,26 @@
+<table class="colwidths-given table">
+    <colgroup>
+        <col style="width: 25%" />
+        <col style="width: 75%" />
+    </colgroup>
+    <thead>
+        <tr>
+            <th class="head">
+                <p>Filename</p>
+            </th>
+            <th class="head">
+                <p>Hash</p>
+            </th>
+        </tr>
+    </thead>
+
+    <tbody style="font-size: small;">
+    {% for name, hash in table %}
+        <tr>
+            <td><p><code><span class="pre">{{ name }}</span></code></p></td>
+            <td><p><code><span class="pre">{{ hash }}</span></code></p></td>
+        </tr>
+    {% endfor %}
+    </tbody>
+
+</table>

--- a/bokeh/sphinxext/bokeh_directive.py
+++ b/bokeh/sphinxext/bokeh_directive.py
@@ -26,8 +26,8 @@ import re
 
 # External imports
 from docutils import nodes
-from docutils.parsers.rst import Directive
 from docutils.statemachine import ViewList
+from sphinx.util.docutils import SphinxDirective
 from sphinx.util.nodes import nested_parse_with_titles
 
 # -----------------------------------------------------------------------------
@@ -59,7 +59,7 @@ __all__ = (
 # -----------------------------------------------------------------------------
 
 
-class BokehDirective(Directive):
+class BokehDirective(SphinxDirective):
     def _parse(self, rst_text, annotation):
         result = ViewList()
         for line in rst_text.split("\n"):

--- a/bokeh/sphinxext/bokeh_directive.py
+++ b/bokeh/sphinxext/bokeh_directive.py
@@ -60,7 +60,8 @@ __all__ = (
 
 
 class BokehDirective(SphinxDirective):
-    def _parse(self, rst_text, annotation):
+
+    def parse(self, rst_text, annotation):
         result = ViewList()
         for line in rst_text.split("\n"):
             result.append(line, annotation)

--- a/bokeh/sphinxext/bokeh_enum.py
+++ b/bokeh/sphinxext/bokeh_enum.py
@@ -121,7 +121,7 @@ class BokehEnumDirective(BokehDirective):
             fullrepr=fullrepr,
         )
 
-        return self._parse(rst_text, "<bokeh-enum>")
+        return self.parse(rst_text, "<bokeh-enum>")
 
 
 def setup(app):

--- a/bokeh/sphinxext/bokeh_gallery.py
+++ b/bokeh/sphinxext/bokeh_gallery.py
@@ -66,9 +66,7 @@ class BokehGalleryDirective(BokehDirective):
     required_arguments = 1
 
     def run(self):
-        env = self.state.document.settings.env
-
-        docdir = dirname(env.doc2path(env.docname))
+        docdir = dirname(self.env.doc2path(self.env.docname))
 
         gallery_file = join(docdir, self.arguments[0])
 
@@ -81,7 +79,7 @@ class BokehGalleryDirective(BokehDirective):
 
         rst_text = GALLERY_PAGE.render(names=names)
 
-        return self._parse(rst_text, "<bokeh-gallery>")
+        return self.parse(rst_text, "<bokeh-gallery>")
 
 
 def config_inited_handler(app, config):

--- a/bokeh/sphinxext/bokeh_jinja.py
+++ b/bokeh/sphinxext/bokeh_jinja.py
@@ -89,10 +89,7 @@ class BokehJinjaDirective(BokehDirective):
 
         template_text = open(template.filename).read()
         m = _DOCPAT.match(template_text)
-        if m:
-            doc = m.group(1)
-        else:
-            doc = None
+        doc = m.group(1) if m else None
 
         filename = basename(template.filename)
         rst_text = JINJA_DETAIL.render(
@@ -105,7 +102,7 @@ class BokehJinjaDirective(BokehDirective):
             template_text=_DOCPAT.sub("", template_text),
         )
 
-        return self._parse(rst_text, "<bokeh-jinja>")
+        return self.parse(rst_text, "<bokeh-jinja>")
 
 
 def setup(app):

--- a/bokeh/sphinxext/bokeh_model.py
+++ b/bokeh/sphinxext/bokeh_model.py
@@ -132,7 +132,7 @@ class BokehModelDirective(BokehDirective):
             model_json=model_json,
         )
 
-        return self._parse(rst_text, "<bokeh-model>")
+        return self.parse(rst_text, "<bokeh-model>")
 
 
 def setup(app):

--- a/bokeh/sphinxext/bokeh_options.py
+++ b/bokeh/sphinxext/bokeh_options.py
@@ -129,7 +129,7 @@ class BokehOptionsDirective(BokehDirective):
 
         rst_text = OPTIONS_DETAIL.render(opts=opts)
 
-        return self._parse(rst_text, "<bokeh-options>")
+        return self.parse(rst_text, "<bokeh-options>")
 
 
 def setup(app):

--- a/bokeh/sphinxext/bokeh_palette_group.py
+++ b/bokeh/sphinxext/bokeh_palette_group.py
@@ -90,11 +90,7 @@ class bokeh_palette_group(nodes.General, nodes.Element):
         visitor.body.append("</div></div>")
         raise nodes.SkipNode
 
-    @staticmethod
-    def depart_html(_visitor, _node):
-        pass
-
-    html = visit_html.__func__, depart_html.__func__
+    html = visit_html.__func__, None
 
 
 class BokehPaletteGroupDirective(Directive):

--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -253,20 +253,7 @@ def _process_script(source, filename, env, js_name, use_relative_paths=False):
     # automatic mechanism is available
     Model._clear_extensions()
 
-    # quick and dirty way to inject Google API key
-    if "GOOGLE_API_KEY" in source:
-        GOOGLE_API_KEY = getenv("GOOGLE_API_KEY")
-        if GOOGLE_API_KEY is None:
-            if env.config.bokeh_missing_google_api_key_ok:
-                GOOGLE_API_KEY = "MISSING_API_KEY"
-            else:
-                raise SphinxError(
-                    "The GOOGLE_API_KEY environment variable is not set. Set GOOGLE_API_KEY to a valid API key, "
-                    "or set bokeh_missing_google_api_key_ok=True in conf.py to build anyway (with broken GMaps)"
-                )
-        run_source = source.replace("GOOGLE_API_KEY", GOOGLE_API_KEY)
-    else:
-        run_source = source
+    run_source = _check_google_api_key(source)
 
     c = ExampleHandler(source=run_source, filename=filename)
     d = Document()
@@ -298,8 +285,24 @@ def _process_script(source, filename, env, js_name, use_relative_paths=False):
     return (script, js, js_path, source, c.doc.strip() if c.doc else None, height_hint)
 
 
+# quick and dirty way to inject Google API key
+def _check_google_api_key(source: str) -> str:
+    if "GOOGLE_API_KEY" not in source:
+        return source
+
+    GOOGLE_API_KEY = getenv("GOOGLE_API_KEY")
+    if GOOGLE_API_KEY is None:
+        if env.config.bokeh_missing_google_api_key_ok:
+            GOOGLE_API_KEY = "MISSING_API_KEY"
+        else:
+            raise SphinxError(
+                "The GOOGLE_API_KEY environment variable is not set. Set GOOGLE_API_KEY to a valid API key, "
+                "or set bokeh_missing_google_api_key_ok=True in conf.py to build anyway (with broken GMaps)"
+            )
+    return source.replace("GOOGLE_API_KEY", GOOGLE_API_KEY)
+
+
 def _remove_module_docstring(source, doc):
-    # take docstring out of source so it doesn't show up twice
     return re.sub(rf'(\'\'\'|\"\"\")\s*{re.escape(doc)}\s*(\'\'\'|\"\"\")', "", source)
 
 # -----------------------------------------------------------------------------

--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -248,7 +248,7 @@ def setup(app):
 # -----------------------------------------------------------------------------
 
 
-def _process_script(source, filename, env, js_name, use_relative_paths=False):
+def _process_script(source, filename, env, js_name):
     # Explicitly make sure old extensions are not included until a better
     # automatic mechanism is available
     Model._clear_extensions()

--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -106,7 +106,6 @@ from sphinx.util.nodes import set_source_info
 from bokeh.document import Document
 from bokeh.embed import autoload_static
 from bokeh.model import Model
-from bokeh.models import Plot
 from bokeh.util.warnings import BokehDeprecationWarning
 
 # Bokeh imports
@@ -263,10 +262,7 @@ def _process_script(source, filename, env, js_name):
 
     root, docstring = _evaluate_source(source, filename, env)
 
-    height_hint = None
-    if isinstance(root, Plot):
-        if root.sizing_mode in ("stretch_width", "fixed", None):
-            height_hint = root.height
+    height_hint = root._sphinx_height_hint()
 
     js_path = join(env.bokeh_plot_auxdir, js_name)
     js, script = autoload_static(root, RESOURCES, js_name)

--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -113,7 +113,7 @@ from .bokeh_directive import BokehDirective
 from .example_handler import ExampleHandler
 from .util import get_sphinx_resources
 
-# -------------------------`----------------------------------------------------
+# -----------------------------------------------------------------------------
 # Globals and constants
 # -----------------------------------------------------------------------------
 

--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -269,15 +269,19 @@ def _process_script(source, filename, env, js_name, use_relative_paths=False):
     if c.error:
         raise RuntimeError(c.error_detail)
 
+    if len(d.roots) != 1:
+        raise RuntimeError(f"bokeh-plot directive expects a single Document root, got {len(d.roots)}")
+    root = d.roots[0]
+
     height_hint = None
-    if len(d.roots) == 1 and isinstance(d.roots[0], Plot):
+    if isinstance(root, Plot):
         plot = d.roots[0]
         if plot.sizing_mode in ("stretch_width", "fixed", None):
             height_hint = plot.height
 
     resources = get_sphinx_resources()
     js_path = join(env.bokeh_plot_auxdir, js_name)
-    js, script = autoload_static(d.roots[0], resources, js_name)
+    js, script = autoload_static(root, resources, js_name)
 
     with open(js_path, "w") as f:
         f.write(js)

--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -140,14 +140,11 @@ class autoload_script(nodes.General, nodes.Element):
         if height_hint:
             visitor.body.append(f'<div style="height:{height_hint}px;">')
         visitor.body.append(script_tag)
-
-    @staticmethod
-    def depart_html(visitor, node):
-        height_hint = node["height_hint"]
         if height_hint:
             visitor.body.append("</div>")
+        raise nodes.SkipNode
 
-    html = visit_html.__func__, depart_html.__func__
+    html = visit_html.__func__, None
 
 
 class BokehPlotDirective(BokehDirective):

--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -179,7 +179,7 @@ class BokehPlotDirective(BokehDirective):
         target = [nodes.target("", "", ids=[target_id])]
 
         process_docstring = self.options.get("process-docstring", False)
-        intro = self._parse(docstring, '<bokeh-content>') if docstring and process_docstring else []
+        intro = self.parse(docstring, '<bokeh-content>') if docstring and process_docstring else []
 
         above, below = self.process_code_block(source, docstring)
 

--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -281,7 +281,7 @@ def setup(app):
 
 
 # quick and dirty way to inject Google API key
-def _check_google_api_key(source: str, env) -> str:
+def _replace_google_api_key(source: str, env) -> str:
     if "GOOGLE_API_KEY" not in source:
         return source
 
@@ -297,14 +297,13 @@ def _check_google_api_key(source: str, env) -> str:
 
 
 def _evaluate_source(source: str, filename: str, env):
-    source = _check_google_api_key(source, env)
+    source = _replace_google_api_key(source, env)
 
     c = ExampleHandler(source=source, filename=filename)
     d = Document()
 
-    # We may need to instantiate deprecated objects as part of documenting
-    # them in the reference guide. Suppress any warnings here to keep the
-    # docs build clean just for this case
+    # We may need to instantiate deprecated objects as part of documenting them
+    # in the reference guide. Suppress warnings here to keep the build clean
     with warnings.catch_warnings():
         if "reference" in env.docname:
             warnings.filterwarnings("ignore", category=BokehDeprecationWarning)

--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -123,6 +123,10 @@ __all__ = (
     "setup",
 )
 
+GOOGLE_API_KEY = getenv("GOOGLE_API_KEY")
+
+RESOURCES = get_sphinx_resources()
+
 # -----------------------------------------------------------------------------
 # General API
 # -----------------------------------------------------------------------------
@@ -279,9 +283,8 @@ def _process_script(source, filename, env, js_name):
         if plot.sizing_mode in ("stretch_width", "fixed", None):
             height_hint = plot.height
 
-    resources = get_sphinx_resources()
     js_path = join(env.bokeh_plot_auxdir, js_name)
-    js, script = autoload_static(root, resources, js_name)
+    js, script = autoload_static(root, RESOURCES, js_name)
 
     with open(js_path, "w") as f:
         f.write(js)
@@ -294,15 +297,14 @@ def _check_google_api_key(source: str) -> str:
     if "GOOGLE_API_KEY" not in source:
         return source
 
-    GOOGLE_API_KEY = getenv("GOOGLE_API_KEY")
     if GOOGLE_API_KEY is None:
         if env.config.bokeh_missing_google_api_key_ok:
-            GOOGLE_API_KEY = "MISSING_API_KEY"
-        else:
-            raise SphinxError(
-                "The GOOGLE_API_KEY environment variable is not set. Set GOOGLE_API_KEY to a valid API key, "
-                "or set bokeh_missing_google_api_key_ok=True in conf.py to build anyway (with broken GMaps)"
-            )
+            return source.replace("GOOGLE_API_KEY", "MISSING_API_KEY")
+        raise SphinxError(
+            "The GOOGLE_API_KEY environment variable is not set. Set GOOGLE_API_KEY to a valid API key, "
+            "or set bokeh_missing_google_api_key_ok=True in conf.py to build anyway (with broken GMaps)"
+        )
+
     return source.replace("GOOGLE_API_KEY", GOOGLE_API_KEY)
 
 

--- a/bokeh/sphinxext/bokeh_prop.py
+++ b/bokeh/sphinxext/bokeh_prop.py
@@ -130,7 +130,7 @@ class BokehPropDirective(BokehDirective):
             doc="" if descriptor.__doc__ is None else textwrap.dedent(descriptor.__doc__),
         )
 
-        return self._parse(rst_text, "<bokeh-prop>")
+        return self.parse(rst_text, "<bokeh-prop>")
 
 
 def setup(app):

--- a/bokeh/sphinxext/bokeh_releases.py
+++ b/bokeh/sphinxext/bokeh_releases.py
@@ -73,8 +73,8 @@ class sri_table(nodes.General, nodes.Element):
     def visit_html(visitor, node):
         version = node["version"]
         table = node["table"]
-        visitor.body.append(f'<button type="button" class="collapsible">Table of SRI Hashes for version {version}</button>')
-        visitor.body.append('<div class="content">')
+        visitor.body.append(f'<button type="button" class="bk-collapsible">Table of SRI Hashes for version {version}</button>')
+        visitor.body.append('<div class="bk-collapsible-content">')
         visitor.body.append(SRI_TABLE.render(table=table))
         visitor.body.append("</div>")
 

--- a/bokeh/sphinxext/bokeh_releases.py
+++ b/bokeh/sphinxext/bokeh_releases.py
@@ -77,12 +77,9 @@ class sri_table(nodes.General, nodes.Element):
         visitor.body.append('<div class="bk-collapsible-content">')
         visitor.body.append(SRI_TABLE.render(table=table))
         visitor.body.append("</div>")
+        raise nodes.SkipNode
 
-    @staticmethod
-    def depart_html(_visitor, _node):
-        pass
-
-    html = visit_html.__func__, depart_html.__func__
+    html = visit_html.__func__, None
 
 
 class BokehReleases(BokehDirective):

--- a/bokeh/sphinxext/bokeh_settings.py
+++ b/bokeh/sphinxext/bokeh_settings.py
@@ -106,7 +106,7 @@ class BokehSettingsDirective(BokehDirective):
             settings.append(setting)
 
         rst_text = SETTINGS_DETAIL.render(name=obj_name, module_name=module_name, settings=settings)
-        return self._parse(rst_text, "<bokeh-settings>")
+        return self.parse(rst_text, "<bokeh-settings>")
 
 
 def setup(app):

--- a/bokeh/sphinxext/bokehjs_content.py
+++ b/bokeh/sphinxext/bokehjs_content.py
@@ -182,20 +182,19 @@ class BokehJSContent(CodeBlock):
         return [literal]
 
     def get_js_source(self):
-        env = self.state.document.settings.env
         js_file = self.options.get("js_file", False)
         # js_file *or* js code content, but not both
         if js_file and self.content:
             raise SphinxError("bokehjs-content:: directive can't have both js_file and content")
 
         if js_file:
-            log.debug(f"[bokehjs-content] handling external example in {env.docname!r}: {js_file}")
+            log.debug(f"[bokehjs-content] handling external example in {self.env.docname!r}: {js_file}")
             path = js_file
             if not js_file.startswith("/"):
-                path = join(env.app.srcdir, path)
+                path = join(self.env.app.srcdir, path)
             js_source = open(path).read()
         else:
-            log.debug(f"[bokehjs-content] handling inline example in {env.docname!r}")
+            log.debug(f"[bokehjs-content] handling inline example in {self.env.docname!r}")
             js_source = "\n".join(self.content)
 
         return js_source
@@ -213,12 +212,10 @@ class BokehJSContent(CodeBlock):
             return [js_source, "javascript"]
 
     def run(self):
-        env = self.state.document.settings.env
-
         rst_source = self.state_machine.node.document["source"]
         rst_filename = basename(rst_source)
 
-        serial_no = env.new_serialno("ccb")
+        serial_no = self.env.new_serialno("ccb")
         target_id = f"{rst_filename}.ccb-{serial_no}"
         target_id = target_id.replace(".", "-")
         target_node = nodes.target("", "", ids=[target_id])

--- a/bokeh/sphinxext/collapsible_code_block.py
+++ b/bokeh/sphinxext/collapsible_code_block.py
@@ -77,6 +77,7 @@ __all__ = (
 
 
 class collapsible_code_block(nodes.General, nodes.Element):
+
     @staticmethod
     def visit_html(visitor, node):
         heading = node["heading"]
@@ -95,25 +96,20 @@ class CollapsibleCodeBlock(CodeBlock):
     option_spec.update(heading=unchanged)
 
     def run(self):
-        env = self.state.document.settings.env
-
         rst_source = self.state_machine.node.document["source"]
         rst_filename = basename(rst_source)
 
-        serial_no = env.new_serialno("ccb")
-        target_id = f"{rst_filename}.ccb-{serial_no}"
-        target_id = target_id.replace(".", "-")
-        target_node = nodes.target("", "", ids=[target_id])
+        serial_no = self.env.new_serialno("ccb")
+        target_id = f"{rst_filename}.ccb-{serial_no}".replace(".", "-")
+        target = nodes.target("", "", ids=[target_id])
 
-        node = collapsible_code_block()
-        node["target_id"] = target_id
-        node["heading"] = self.options.get("heading", "Code")
+        block = collapsible_code_block(target_id=target_id, heading=self.options.get("heading", "Code"))
 
         cb = CodeBlock.run(self)
-        node.setup_child(cb[0])
-        node.children.append(cb[0])
+        block.setup_child(cb[0])
+        block.children.append(cb[0])
 
-        return [target_node, node]
+        return [target, block]
 
 
 def setup(app):

--- a/bokeh/sphinxext/templates.py
+++ b/bokeh/sphinxext/templates.py
@@ -33,7 +33,9 @@ from jinja2 import Environment, FileSystemLoader
 
 __all__ = (
     "BJS_CODEPEN_INIT",
+    "BJS_EPILOGUE",
     "BJS_HTML",
+    "BJS_PROLOGUE",
     "COLOR_DETAIL",
     "ENUM_DETAIL",
     "GALLERY_PAGE",
@@ -43,6 +45,8 @@ __all__ = (
     "PALETTE_DETAIL",
     "PALETTE_GROUP_DETAIL",
     "PROP_DETAIL",
+    "SETTINGS_DETAIL",
+    "SRI_TABLE",
 )
 
 # -----------------------------------------------------------------------------
@@ -67,7 +71,6 @@ BJS_EPILOGUE = _env.get_template("bokehjs_content_epilogue.html")
 BJS_CODEPEN_INIT = _env.get_template("bokehjs_codepen_init.html")
 BJS_HTML = _env.get_template("bokehjs_html_template.html")
 
-
 COLOR_DETAIL = _env.get_template("color_detail.html")
 
 ENUM_DETAIL = _env.get_template("enum_detail.rst")
@@ -88,6 +91,8 @@ PALETTE_GROUP_DETAIL = _env.get_template("palette_group_detail.html")
 PROP_DETAIL = _env.get_template("prop_detail.rst")
 
 SETTINGS_DETAIL = _env.get_template("settings_detail.rst")
+
+SRI_TABLE = _env.get_template("sri_table.html")
 
 # -----------------------------------------------------------------------------
 # Code

--- a/sphinx/source/_static/custom.css
+++ b/sphinx/source/_static/custom.css
@@ -268,3 +268,28 @@ using sphinx_panels */
      padding: 0.15rem;
      line-height: normal;
  }
+
+.collapsible {
+  background-color: #eee;
+  color: #444;
+  cursor: pointer;
+  padding: 18px;
+  width: 100%;
+  border: none;
+  text-align: left;
+  outline: none;
+  font-size: 15px;
+}
+
+/* Add a background color to the button if it is clicked on (add the .active class with JS), and when you move the mouse over it (hover) */
+.active, .collapsible:hover {
+  background-color: #ccc;
+}
+
+/* Style the collapsible content. Note: hidden by default */
+.content {
+  padding: 0 18px;
+  display: none;
+  overflow: hidden;
+  background-color: #f1f1f1;
+}

--- a/sphinx/source/_static/custom.css
+++ b/sphinx/source/_static/custom.css
@@ -269,7 +269,7 @@ using sphinx_panels */
      line-height: normal;
  }
 
-.collapsible {
+.bk-collapsible {
   background-color: #eee;
   color: #444;
   cursor: pointer;
@@ -282,12 +282,12 @@ using sphinx_panels */
 }
 
 /* Add a background color to the button if it is clicked on (add the .active class with JS), and when you move the mouse over it (hover) */
-.active, .collapsible:hover {
+.active.bk-collapsible:hover {
   background-color: #ccc;
 }
 
 /* Style the collapsible content. Note: hidden by default */
-.content {
+.bk-collapsible-content {
   padding: 0 18px;
   display: none;
   overflow: hidden;

--- a/sphinx/source/_templates/scripts.html
+++ b/sphinx/source/_templates/scripts.html
@@ -44,7 +44,7 @@
 </script>
 
 <script>
-  var coll = document.getElementsByClassName("collapsible");
+  var coll = document.getElementsByClassName("bk-collapsible");
   var i;
   debugger
   for (i = 0; i < coll.length; i++) {

--- a/sphinx/source/_templates/scripts.html
+++ b/sphinx/source/_templates/scripts.html
@@ -42,3 +42,20 @@
     })
   })
 </script>
+
+<script>
+  var coll = document.getElementsByClassName("collapsible");
+  var i;
+  debugger
+  for (i = 0; i < coll.length; i++) {
+    coll[i].addEventListener("click", function() {
+      this.classList.toggle("active");
+      var content = this.nextElementSibling;
+      if (content.style.display === "block") {
+        content.style.display = "none";
+      } else {
+        content.style.display = "block";
+      }
+    });
+  }
+</script>


### PR DESCRIPTION
- [x] issues: fixes #10137
- [x] release document entry (if new feature or API change)

OK ostensibly this fixes (or at least improves) the jumpy anchors. But I wanted to take the opportunity to also clean up many things in `bokeh.sphinxext`. Some highlights:

* improve jumpy anchors
* fix broken collapsible SRI hash tables (discovered during this PR)
* use consistent code pattern for custom node visitors
* refactor `bokeh-plot` into smaller functions

There's plenty more that could still be improved but this seemed like a good stopping point for now. @hyles-lineata please build the docs locally with this PR and check them out. Things look good to me but a second pair of eyes would be good. Additionally please leave any comments or questions on the changes themselves.