### PR TITLE
License tests compatible with Windows

### DIFF
--- a/examples/plotting/file/sprint.py
+++ b/examples/plotting/file/sprint.py
@@ -1,8 +1,9 @@
-# Based on http://www.nytimes.com/interactive/2012/08/05/sports/olympics/the-100-meter-dash-one-race-every-medalist-ever.html
+""" Based on http://www.nytimes.com/interactive/2012/08/05/sports/olympics/the-100-meter-dash-one-race-every-medalist-ever.html
 
-from bokeh.models import (Arrow, ColumnDataSource, CustomJS, DataRange1d,
-                          FixedTicker, HoverTool, Label, LinearAxis, NormalHead,
-                          Range1d, SingleIntervalTicker, TapTool)
+"""
+
+from bokeh.models import (Arrow, ColumnDataSource, CustomJS, Label,
+                          NormalHead, SingleIntervalTicker, TapTool)
 from bokeh.plotting import figure, output_file, show
 from bokeh.sampledata.sprint import sprint
 
@@ -28,18 +29,13 @@ abbrev_to_country = {
     "EUA": "United Team of Germany",
 }
 
-gold_fill   = "#efcf6d"
-gold_line   = "#c8a850"
-silver_fill = "#cccccc"
-silver_line = "#b0b0b1"
-bronze_fill = "#c59e8a"
-bronze_line = "#98715d"
+fill_color = { "gold": "#efcf6d", "silver": "#cccccc", "bronze": "#c59e8a" }
+line_color = { "gold": "#c8a850", "silver": "#b0b0b1", "bronze": "#98715d" }
 
-fill_color = { "gold": gold_fill, "silver": silver_fill, "bronze": bronze_fill }
-line_color = { "gold": gold_line, "silver": silver_line, "bronze": bronze_line }
 
 def selected_name(name, medal, year):
     return name if medal == "gold" and year in [1988, 1968, 1936, 1896] else ""
+
 
 t0 = sprint.Time[0]
 
@@ -54,14 +50,27 @@ sprint["SelectedName"] = sprint[["Name", "Medal", "Year"]].apply(tuple, axis=1).
 
 source = ColumnDataSource(sprint)
 
-xdr = Range1d(start=sprint.MetersBack.max()+2, end=0)               # XXX: +2 is poor-man's padding (otherwise misses last tick)
-ydr = DataRange1d(range_padding=4, range_padding_units="absolute")
+tooltips = """
+<div>
+    <span style="font-size: 15px;">@Name</span>&nbsp;
+    <span style="font-size: 10px; color: #666;">(@Abbrev)</span>
+</div>
+<div>
+    <span style="font-size: 17px; font-weight: bold;">@Time{0.00}</span>&nbsp;
+    <span style="font-size: 10px; color: #666;">@Year</span>
+</div>
+<div style="font-size: 11px; color: #666;">@{MetersBack}{0.00} meters behind</div>
+"""
 
 plot = figure(
-    x_range=xdr, y_range=ydr,
+    x_range=(sprint.MetersBack.max()+2, 0),
     width=1000, height=600,
     toolbar_location=None,
-    outline_line_color=None, y_axis_type=None)
+    outline_line_color=None,
+    y_axis_location="right",
+    tooltips=tooltips)
+plot.y_range.range_padding = 4
+plot.y_range.range_padding_units = "absolute"
 
 plot.title.text = "Usain Bolt vs. 116 years of Olympic sprinters"
 plot.title.text_font_size = "19px"
@@ -71,25 +80,29 @@ plot.xaxis.axis_line_color = None
 plot.xaxis.major_tick_line_color = None
 plot.xgrid.grid_line_dash = "dashed"
 
-yticker = FixedTicker(ticks=[1900, 1912, 1924, 1936, 1952, 1964, 1976, 1988, 2000, 2012])
-yaxis = LinearAxis(ticker=yticker, major_tick_in=-5, major_tick_out=10)
-plot.add_layout(yaxis, "right")
+plot.yaxis.ticker = [1900, 1912, 1924, 1936, 1952, 1964, 1976, 1988, 2000, 2012]
+plot.yaxis.major_tick_in = -5
+plot.yaxis.major_tick_out = 10
+plot.ygrid.grid_line_color = None
 
-medal = plot.circle(x="MetersBack", y="Year", radius=dict(value=5, units="screen"),
-    fill_color="MedalFill", line_color="MedalLine", fill_alpha=0.5, source=source, level="overlay")
+medal_circle = plot.circle(x="MetersBack", y="Year", radius=dict(value=5, units="screen"),
+                           fill_color="MedalFill", line_color="MedalLine", fill_alpha=0.5,
+                           source=source, level="overlay")
+plot.hover.renderers = [medal_circle]
 
 plot.text(x="MetersBack", y="Year", x_offset=10, y_offset=-5, text="SelectedName",
-    text_align="left", text_baseline="middle", text_font_size="12px", source=source)
+          text_align="left", text_baseline="middle", text_font_size="12px", source=source)
 
 no_olympics_label = Label(
     x=7.5, y=1942,
     text="No Olympics in 1940 or 1944",
     text_align="center", text_baseline="middle",
     text_font_size="12px", text_font_style="italic", text_color="silver")
-no_olympics = plot.add_layout(no_olympics_label)
+plot.add_layout(no_olympics_label)
 
 x = sprint[sprint.Year == 1900].MetersBack.min() - 0.5
-arrow = Arrow(x_start=x, x_end=5, y_start=1900, y_end=1900, start=NormalHead(fill_color="black", size=6), end=None, line_width=1.5)
+arrow = Arrow(x_start=x, x_end=5, y_start=1900, y_end=1900, start=NormalHead(fill_color="black", size=6),
+              end=None, line_width=1.5)
 plot.add_layout(arrow)
 
 meters_back = Label(
@@ -105,29 +118,15 @@ disclaimer = Label(
     text_font_size="11px", text_color="silver")
 plot.add_layout(disclaimer, "below")
 
-tooltips = """
-<div>
-    <span style="font-size: 15px;">@Name</span>&nbsp;
-    <span style="font-size: 10px; color: #666;">(@Abbrev)</span>
-</div>
-<div>
-    <span style="font-size: 17px; font-weight: bold;">@Time{0.00}</span>&nbsp;
-    <span style="font-size: 10px; color: #666;">@Year</span>
-</div>
-<div style="font-size: 11px; color: #666;">@{MetersBack}{0.00} meters behind</div>
-"""
-
-plot.add_tools(HoverTool(tooltips=tooltips, renderers=[medal]))
-
 open_url = CustomJS(args=dict(source=source), code="""
-source.inspected._1d.indices.forEach(function(index) {
+source.inspected.indices.forEach(function(index) {
     const name = source.data["Name"][index];
     const url = "http://en.wikipedia.org/wiki/" + encodeURIComponent(name);
     window.open(url);
 });
 """)
 
-plot.add_tools(TapTool(callback=open_url, renderers=[medal], behavior="inspect"))
+plot.add_tools(TapTool(callback=open_url, renderers=[medal_circle], behavior="inspect"))
 
 output_file("sprint.html", plot.title.text)
 show(plot)

--- a/tests/codebase/test_js_license_set.py
+++ b/tests/codebase/test_js_license_set.py
@@ -47,5 +47,5 @@ def test_js_license_set() -> None:
     '''
     os.chdir('bokehjs')
     cmd = ["npx", "license-checker", "--production", "--summary", "--onlyAllow", ";".join(LICENSES)]
-    proc = run(cmd, shell=True)
+    proc = run(cmd)
     assert proc.returncode == 0, "New BokehJS licenses detected"

--- a/tests/codebase/test_js_license_set.py
+++ b/tests/codebase/test_js_license_set.py
@@ -45,5 +45,5 @@ def test_js_license_set() -> None:
     '''
     os.chdir('bokehjs')
     cmd = ["npx", "license-checker", "--production", "--summary", "--onlyAllow", ";".join(LICENSES)]
-    proc = run(cmd)
+    proc = run(cmd, shell=True)
     assert proc.returncode == 0, "New BokehJS licenses detected"

--- a/tests/codebase/test_js_license_set.py
+++ b/tests/codebase/test_js_license_set.py
@@ -19,8 +19,8 @@ import pytest ; pytest
 
 # Standard library imports
 import os
-from subprocess import run
 import sys
+from subprocess import run
 
 #-----------------------------------------------------------------------------
 # Tests

--- a/tests/codebase/test_license.py
+++ b/tests/codebase/test_license.py
@@ -36,7 +36,5 @@ def test_license_set() -> None:
 
     '''
     chdir(TOP_PATH)
-    # Explicitly call git for Windows users
-    proc = run(["git", "diff", "LICENSE.txt", join("bokeh", "LICENSE.txt")], capture_output=True)
-    diff = proc.stdout.decode('utf-8')
-    assert diff == '', f"LICENSE.txt mismatch:\n{diff}"
+    proc = run(["diff", "LICENSE.txt", join("bokeh", "LICENSE.txt")], capture_output=True)
+    assert proc.returncode == 0, f"LICENSE.txt mismatch:\n{proc.stdout.decode('utf-8')}"

--- a/tests/codebase/test_license.py
+++ b/tests/codebase/test_license.py
@@ -34,5 +34,7 @@ def test_license_set() -> None:
 
     '''
     chdir(TOP_PATH)
-    proc = run(["diff", "LICENSE.txt", join("bokeh", "LICENSE.txt")], capture_output=True)
-    assert proc.returncode == 0, f"LICENSE.txt mismatch:\n{proc.stdout.decode('utf-8')}"
+    # Explicitly call git for Windows users
+    proc = run(["git", "diff", "LICENSE.txt", join("bokeh", "LICENSE.txt")], capture_output=True)
+    diff = proc.stdout.decode('utf-8')
+    assert diff == '', f"LICENSE.txt mismatch:\n{diff}"

--- a/tests/codebase/test_license.py
+++ b/tests/codebase/test_license.py
@@ -18,10 +18,10 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import sys
 from os import chdir
 from os.path import join
 from subprocess import run
-import sys
 
 from . import TOP_PATH
 


### PR DESCRIPTION
This PR is to address an issue with the codebase license checks failing on Windows.
Ultimately decided just to skip the license tests in Windows.

~For _tests/codebase/test_js_license_set.py_, I found a quick fix of `shell=True`. I've read online there are possible security concerns with this, so I'm not sure if this is acceptable or not.~

~For _tests/codebase/test_license.py_, I found a couple issues:~
1.  ~The command began with `"diff"` instead of `"git diff"`. I found OS X can interpret `"diff"` alone but Windows cannot.~
2.  ~The test asserted `proc.returncode == 0`, which I found is `True` whether the two LICENSE.txt are different or not. Instead I asserted the output `diff = proc.stdout.decode('utf-8')` should be blank.~

~These changes appear to work on my mac as well, so hopefully it's os-independent now.~
- [x] issues: fixes #11444
- [x] tests passed
