### PR TITLE
Update file_input.py

### DIFF
--- a/examples/plotting/file/file_input.py
+++ b/examples/plotting/file/file_input.py
@@ -12,8 +12,7 @@ callback = CustomJS(args=dict(para=para, file_input=file_input), code="""
 """)
 
 # Attach callback to FileInput widget
-file_input.js_on_change('change', callback)
-
+file_input.js_on_change('filename', callback)
 
 output_file("file_input.html")
 


### PR DESCRIPTION
This example is using `js_on_change` to respond to an internal "change" event instead of a specific property. I don't believe this has ever been officially endorsed and AFAIK this is not demonstrated any place else. Updating to respond to the `filename` property.

ref: https://discourse.bokeh.org/t/fileinput-widgets-callback-on-value-parameter-comes-before-filename-is-set/8209
