### PR TITLE
Skip svg export test

### DIFF
--- a/tests/unit/bokeh/io/test_export.py
+++ b/tests/unit/bokeh/io/test_export.py
@@ -141,7 +141,7 @@ def test_get_screenshot_as_png_with_unicode_unminified(webdriver: WebDriver) -> 
 
     assert len(png.tobytes()) > 0
 
-@flaky(max_runs=10)
+@pytest.mark.skip(reason="unknown diff in xlink:href")
 @pytest.mark.selenium
 def test_get_svg_no_svg_present() -> None:
     layout = Plot(x_range=Range1d(), y_range=Range1d(), height=20, width=20, toolbar_location=None)


### PR DESCRIPTION
Skips `test_get_svg_no_svg_present()` of `tests/unit/bokeh/io/test_export.py` due to unknown diff in `xlink:href` of output. This is currently causing universal failure of Bokeh-CI unit tests.

ref: #11460
