### PR TITLE
Make prepare_value more efficient for hinted ColumnData events

### DIFF
--- a/bokeh/core/property/descriptors.py
+++ b/bokeh/core/property/descriptors.py
@@ -591,7 +591,7 @@ class PropertyDescriptor(Generic[T]):
 
         # re-validate because the contents of 'old' have changed,
         # in some cases this could give us a new object for the value
-        value = self.property.prepare_value(obj, self.name, value)
+        value = self.property.prepare_value(obj, self.name, value, hint=hint)
 
         self._set(obj, old, value, hint=hint)
 

--- a/tests/unit/bokeh/core/property/test_bases.py
+++ b/tests/unit/bokeh/core/property/test_bases.py
@@ -212,6 +212,19 @@ class TestProperty:
         bcpb.Property._should_validate = True
         assert bcpb.validation_on()
 
+    def test__hinted_value_is_identity(self) -> None:
+        p = bcpb.Property()
+        assert p._hinted_value(10, "hint") == 10
+        assert p._hinted_value(10, None) == 10
+
+    @patch('bokeh.core.property.bases.Property._hinted_value')
+    def test_prepare_value_uses__hinted_value(self, mock_hv: MagicMock) -> None:
+        hp = HasProps()
+        p = bcpb.Property()
+
+        p.prepare_value(hp, "foo", 10)
+        assert mock_hv.called
+
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
- [x] issues: fixes #11138
- [x] tests added / passed

After a little back and forth, I think this is the most minimal change, that also makes no new public API commitments. I contemplated making `validate` accept a `hint` directly but that would have required a huge number of tedious changes, opened up a new public parameter, and also left open what to do if inapplicable hints were passed to the wrong targets. 

With this change the benchmark from the OP is now ~constant independent of the number of columns (about 1-2 ms on my laptop) cc @JulianHirsch

<img width="821" alt="Screen Shot 2021-08-02 at 17 25 52" src="https://user-images.githubusercontent.com/1078448/127941850-8aecf8b0-419c-4874-b2e8-031a3638acb1.png">

Here is the lightly updated benchmark:

<details>

```python
#Using Bokeh==2.3.0 as server app
import pandas as pd
from bokeh.plotting import figure, curdoc, show
from bokeh.models import ColumnDataSource
from bokeh.layouts import layout
import random
import time
import numpy as np

N_test = 3

times_list_cols = []

def update_data(n_cols, n_rows):
    # Prepare a CDS with some random value:
    df = pd.DataFrame({"Value1": [int(random.random()*10) for i in range(n_rows)]})

    # Add n_cols additional columns with random values
    for i in range(n_cols):
        df[f"col_{i}"] = df[f"Value1"]/i

    # Create actual CDS
    source = ColumnDataSource(df)

    # Update one column and make N_test time measurements
    new_column = source.data["Value1"]+1
    time_needed=[]
    for test_n in range(N_test):
        t0=time.time()
        source.data['Value1'] = new_column
        time_needed.append(time.time() - t0)

    return np.mean(time_needed)

# Check impact of columns and show results
times=[]
N_rows=5000
for n_cols in range(0,200):
    time_needed = update_data(n_cols=n_cols, n_rows=N_rows)
    times.append(time_needed)
    print(f"Time needed for {n_cols} cols and {N_rows} rows: {time_needed}")

plot_rows = figure(plot_width=800, plot_height=250)
plot_rows.line(x=np.arange(0,200), y=times)
plot_rows.yaxis.axis_label = 'Time in s'
plot_rows.xaxis.axis_label = 'Number of Columns in CDS'
plot_rows.title.text = "Increasing the number of COLUMNS in a CDS"

show(plot_rows)
```
</details>


As an aside this should also make some improvement for streaming column data as well (I added a branch to handle `ColumnsStreamed`)