### PR TITLE
Remove test and extra sections from meta.yaml

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -41,13 +41,6 @@ requirements:
     - {{ dep.lower() }}
     {% endfor %}
 
-test:
-  commands:
-    - bokeh -h
-
-  imports:
-    - bokeh
-
 about:
   home: https://www.bokeh.org
   license: {{ data['license'] }}

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -49,6 +49,14 @@ test:
     - bokeh
 
 about:
-  home: {{ data['url'] }}
+  home: https://www.bokeh.org
   license: {{ data['license'] }}
   summary: {{ data['description'] }}
+  description: |
+    Bokeh is a Python library for creating interactive visualizations
+    for modern web browsers. It helps you build beautiful graphics,
+    ranging from simple plots to complex dashboards with streaming
+    datasets. With Bokeh, you can create JavaScript-powered visualizations
+    without writing any JavaScript yourself.
+  doc_url: https://docs.bokeh.org
+  dev_url: {{ data['url'] }}

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -41,22 +41,7 @@ requirements:
     - {{ dep.lower() }}
     {% endfor %}
 
-    # examples
-    - flask >=1.0
-    - django
-    - h5py
-    - icalendar
-    - networkx
-    - notebook
-    - opencv
-    - pyshp
-    - scikit-learn
-    - sympy
-    #- ipywidgets_bokeh >=1.0.0
-    #- ipywidgets >=7.5.0
-    #- ipyvolume
-    #- ipyleaflet
-
+test:
   commands:
     - bokeh -h
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -41,46 +41,6 @@ requirements:
     - {{ dep.lower() }}
     {% endfor %}
 
-test:
-  requires:
-    # jinja2 installed by bokeh
-    # packaging installed by bokeh
-    # pyyaml installed by bokeh
-
-    # docs
-    - colorcet
-    - pygments
-    - sphinx >=1.8
-
-    # tests
-    - beautifulsoup4
-    - colorama
-    - channels
-    - coverage
-    - firefox
-    - flake8
-    - flaky
-    - geckodriver
-    - ipython
-    - isort >=4.3.21
-    - mock
-    - mypy >=0.900
-    - pandas-stubs
-    - nbconvert >=5.4
-    - networkx
-    - nodejs >=14
-    - numba
-    - pandas
-    - psutil
-    - pytest
-    - pytest-asyncio
-    - pytest-cov >=1.8.1
-    - pytest-html
-    - pytest-xdist
-    - requests >=1.2.3
-    - selenium >=3.8
-    - scipy
-
     # examples
     - flask >=1.0
     - django
@@ -107,10 +67,3 @@ about:
   home: {{ data['url'] }}
   license: {{ data['license'] }}
   summary: {{ data['description'] }}
-
-extra:
-  deploy:
-    - anaconda-client
-    - boto
-    - setuptools >=0.39
-    - twine >=1.11

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
     license='BSD-3-Clause',
     author='Bokeh Team',
     author_email='info@bokeh.org',
-    url='http://github.com/bokeh/bokeh',
+    url='https://github.com/bokeh/bokeh',
     classifiers=open("classifiers.txt").read().strip().split('\n'),
 
     # details needed by setup


### PR DESCRIPTION
While updating the [CI section](https://docs.bokeh.org/en/latest/docs/dev_guide/testing.html#continuous-integration) of the dev docs, I noticed some outdated information in `meta.yaml` (e.g. `sphinx >=1.8`).
This PR removes the sections `test` and `extra` that are no longer needed.

cc @bryevdv 