### PR TITLE
Add panel to downstream tests

### DIFF
--- a/ci/run_downstream_tests.sh
+++ b/ci/run_downstream_tests.sh
@@ -8,7 +8,7 @@ pushd `python -c "import site; print(site.getsitepackages()[0])"`
 pytest dask/diagnostics
 pytest distributed/dashboard
 pytest panel/tests
-pytest holoviews/tests/plotting/bokeh
+nosetests holoviews/tests/plotting/bokeh
 popd
 
 pytest Pandas-Bokeh/Tests/test_PandasBokeh.py

--- a/ci/run_downstream_tests.sh
+++ b/ci/run_downstream_tests.sh
@@ -7,7 +7,8 @@ set +e
 pushd `python -c "import site; print(site.getsitepackages()[0])"`
 pytest dask/diagnostics
 pytest distributed/dashboard
-nosetests holoviews/tests/plotting/bokeh
+pytest panel/tests
+pytest holoviews/tests/plotting/bokeh
 popd
 
 pytest Pandas-Bokeh/Tests/test_PandasBokeh.py


### PR DESCRIPTION
As the title says. Can also finally switch to pytest for HoloViews tests as soon as I tag a HoloViews 2.0 dev release.