### PR TITLE
Document Refs Cleanup (part 2)

### DIFF
--- a/bokeh/document/document.py
+++ b/bokeh/document/document.py
@@ -315,7 +315,7 @@ class Document:
 
         '''
         from ..server.callbacks import NextTickCallback
-        cb = NextTickCallback(self, None)
+        cb = NextTickCallback(None)
         return self._add_session_callback(cb, callback, one_shot=True, originator=self.add_next_tick_callback)
 
     def add_periodic_callback(self, callback: Callback, period_milliseconds: int) -> PeriodicCallback:
@@ -338,7 +338,7 @@ class Document:
 
         '''
         from ..server.callbacks import PeriodicCallback
-        cb = PeriodicCallback(self, None, period_milliseconds)
+        cb = PeriodicCallback(None, period_milliseconds)
         return self._add_session_callback(cb, callback, one_shot=False, originator=self.add_periodic_callback)
 
     def add_root(self, model: Model, setter: Setter | None = None) -> None:
@@ -397,7 +397,7 @@ class Document:
 
         '''
         from ..server.callbacks import TimeoutCallback
-        cb = TimeoutCallback(self, None, timeout_milliseconds)
+        cb = TimeoutCallback(None, timeout_milliseconds)
         return self._add_session_callback(cb, callback, one_shot=True, originator=self.add_timeout_callback)
 
     def apply_json_event(self, json: EventJson) -> None:

--- a/bokeh/document/document.py
+++ b/bokeh/document/document.py
@@ -157,7 +157,6 @@ class Document:
     _hold: HoldPolicyType | None = None
     _held_events: List[DocumentChangedEvent]
     _subscribed_models: Dict[str, Set[Model]]
-    _callback_objs_by_callable: Dict[Originator, Dict[Callback, Set[SessionCallback]]]
 
     def __init__(self, *, theme: Theme = default_theme, title: str = DEFAULT_TITLE) -> None:
         self._roots = []
@@ -183,12 +182,6 @@ class Document:
         # set of models subscribed to user events
         self._subscribed_models = defaultdict(set)
         self.on_message("bokeh_event", self.apply_json_event)
-
-        self._callback_objs_by_callable = {
-            self.add_next_tick_callback: defaultdict(set),
-            self.add_periodic_callback: defaultdict(set),
-            self.add_timeout_callback: defaultdict(set),
-        }
 
     # Properties --------------------------------------------------------------
 
@@ -316,7 +309,7 @@ class Document:
         '''
         from ..server.callbacks import NextTickCallback
         cb = NextTickCallback(None)
-        return self._add_session_callback(cb, callback, one_shot=True, originator=self.add_next_tick_callback)
+        return self._add_session_callback(cb, callback, one_shot=True)
 
     def add_periodic_callback(self, callback: Callback, period_milliseconds: int) -> PeriodicCallback:
         ''' Add a callback to be invoked on a session periodically.
@@ -339,7 +332,7 @@ class Document:
         '''
         from ..server.callbacks import PeriodicCallback
         cb = PeriodicCallback(None, period_milliseconds)
-        return self._add_session_callback(cb, callback, one_shot=False, originator=self.add_periodic_callback)
+        return self._add_session_callback(cb, callback, one_shot=False)
 
     def add_root(self, model: Model, setter: Setter | None = None) -> None:
         ''' Add a model as a root of this Document.
@@ -398,7 +391,7 @@ class Document:
         '''
         from ..server.callbacks import TimeoutCallback
         cb = TimeoutCallback(None, timeout_milliseconds)
-        return self._add_session_callback(cb, callback, one_shot=True, originator=self.add_timeout_callback)
+        return self._add_session_callback(cb, callback, one_shot=True)
 
     def apply_json_event(self, json: EventJson) -> None:
         event = Event.decode_json(json)
@@ -799,7 +792,7 @@ class Document:
             ValueError, if the callback was never added or has already been run or removed
 
         '''
-        self._remove_session_callback(callback_obj, self.add_next_tick_callback)
+        self._remove_session_callback(callback_obj)
 
     def remove_on_change(self, *callbacks: Any) -> None:
         ''' Remove a callback added earlier with ``on_change``.
@@ -824,7 +817,7 @@ class Document:
             ValueError, if the callback was never added or has already been removed
 
         '''
-        self._remove_session_callback(callback_obj, self.add_periodic_callback)
+        self._remove_session_callback(callback_obj)
 
     def remove_root(self, model: Model, setter: Setter | None = None) -> None:
         ''' Remove a model as root model from this Document.
@@ -871,7 +864,7 @@ class Document:
             ValueError, if the callback was never added or has already been run or removed
 
         '''
-        self._remove_session_callback(callback_obj, self.add_timeout_callback)
+        self._remove_session_callback(callback_obj)
 
     def replace_with_json(self, json: DocJson) -> None:
         ''' Overwrite everything in this document with the JSON-encoded
@@ -1003,8 +996,7 @@ class Document:
 
     # Private methods ---------------------------------------------------------
 
-    def _add_session_callback(self, callback_obj: SessionCallback, callback: Callback,
-            one_shot: bool, originator: Originator) -> SessionCallback:
+    def _add_session_callback(self, callback_obj: SessionCallback, callback: Callback, one_shot: bool) -> SessionCallback:
         ''' Internal implementation for adding session callbacks.
 
         Args:
@@ -1030,7 +1022,7 @@ class Document:
             @wraps(callback)
             def remove_then_invoke(*args, **kwargs):
                 if callback_obj in self._session_callbacks:
-                    self._remove_session_callback(callback_obj, originator)
+                    self._remove_session_callback(callback_obj)
                 return callback(*args, **kwargs)
             actual_callback = remove_then_invoke
         else:
@@ -1038,7 +1030,6 @@ class Document:
 
         callback_obj._callback = self._wrap_with_self_as_curdoc(actual_callback)
         self._session_callbacks.add(callback_obj)
-        self._callback_objs_by_callable[originator][callback].add(callback_obj)
 
         # emit event so the session is notified of the new callback
         self._trigger_on_change(SessionCallbackAdded(self, callback_obj))
@@ -1162,7 +1153,7 @@ class Document:
         self._all_models = recomputed
         self._all_models_by_name = recomputed_by_name
 
-    def _remove_session_callback(self, callback_obj: SessionCallback, originator: Originator) -> None:
+    def _remove_session_callback(self, callback_obj: SessionCallback) -> None:
         ''' Remove a callback added earlier with ``add_periodic_callback``,
         ``add_timeout_callback``, or ``add_next_tick_callback``.
 
@@ -1176,13 +1167,6 @@ class Document:
         try:
             callback_objs = [callback_obj]
             self._session_callbacks.remove(callback_obj)
-            for cb, cb_objs in list(self._callback_objs_by_callable[originator].items()):
-                try:
-                    cb_objs.remove(callback_obj)
-                    if not cb_objs:
-                        del self._callback_objs_by_callable[originator][cb]
-                except KeyError:
-                    pass
         except KeyError:
             raise ValueError("callback already ran or was already removed, cannot be removed again")
         # emit event so the session is notified and can remove the callback

--- a/bokeh/server/callbacks.py
+++ b/bokeh/server/callbacks.py
@@ -25,17 +25,13 @@ log = logging.getLogger(__name__)
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING, Callable, Sequence
 
-## External imports
-if TYPE_CHECKING:
-    from tornado.ioloop import IOLoop
-
 # Bokeh imports
 from ..core.types import ID
 from ..util.serialization import make_id
 from ..util.tornado import _CallbackGroup
 
 if TYPE_CHECKING:
-    from ..document import Document
+    from tornado.ioloop import IOLoop
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -62,19 +58,16 @@ class SessionCallback(metaclass=ABCMeta):
 
     _id: ID
 
-    def __init__(self, document: Document, callback: Callback, id: ID | None = None) -> None:
+    def __init__(self, callback: Callback, id: ID | None = None) -> None:
         '''
 
          Args:
-            document (Document) :
-
             callback (callable) :
 
             id (str, optional) :
 
         '''
         self._id = make_id() if id is None else id
-        self._document = document
         self._callback = callback
 
     @property
@@ -103,34 +96,30 @@ class NextTickCallback(SessionCallback):
     ''' Represent a callback to execute on the next ``IOLoop`` "tick".
 
     '''
-    def __init__(self, document: Document, callback: Callback, id: ID | None = None) -> None:
+    def __init__(self, callback: Callback, id: ID | None = None) -> None:
         '''
 
          Args:
-            document (Document) :
-
             callback (callable) :
 
             id (str, optional) :
 
         '''
-        super().__init__(document, callback, id)
+        super().__init__(callback, id)
 
     def _copy_with_changed_callback(self, new_callback: Callback) -> NextTickCallback:
         ''' Dev API used to wrap the callback with decorators. '''
-        return NextTickCallback(self._document, new_callback, self._id)
+        return NextTickCallback(new_callback, self._id)
 
 class PeriodicCallback(SessionCallback):
     ''' Represent a callback to execute periodically on the ``IOLoop`` at a
     specified periodic time interval.
 
     '''
-    def __init__(self, document: Document, callback: Callback, period: int, id: ID | None = None) -> None:
+    def __init__(self, callback: Callback, period: int, id: ID | None = None) -> None:
         '''
 
         Args:
-            document (Document) :
-
             callback (callable) :
 
             period (int) :
@@ -138,7 +127,7 @@ class PeriodicCallback(SessionCallback):
             id (str, optional) :
 
         '''
-        super().__init__(document, callback, id)
+        super().__init__(callback, id)
         self._period = period
 
     @property
@@ -151,19 +140,17 @@ class PeriodicCallback(SessionCallback):
 
     def _copy_with_changed_callback(self, new_callback: Callback) -> PeriodicCallback:
         ''' Dev API used to wrap the callback with decorators. '''
-        return PeriodicCallback(self._document, new_callback, self._period, self._id)
+        return PeriodicCallback(new_callback, self._period, self._id)
 
 class TimeoutCallback(SessionCallback):
     ''' Represent a callback to execute once on the ``IOLoop`` after a specified
     time interval passes.
 
     '''
-    def __init__(self, document: Document, callback: Callback, timeout: int, id: ID | None = None) -> None:
+    def __init__(self, callback: Callback, timeout: int, id: ID | None = None) -> None:
         '''
 
         Args:
-            document (Document) :
-
             callback (callable) :
 
             timeout (int) :
@@ -171,7 +158,7 @@ class TimeoutCallback(SessionCallback):
             id (str, optional) :
 
         '''
-        super().__init__(document, callback, id)
+        super().__init__(callback, id)
         self._timeout = timeout
 
     @property
@@ -183,7 +170,7 @@ class TimeoutCallback(SessionCallback):
 
     def _copy_with_changed_callback(self, new_callback: Callback) -> TimeoutCallback:
         ''' Dev API used to wrap the callback with decorators. '''
-        return TimeoutCallback(self._document, new_callback, self._timeout, self._id)
+        return TimeoutCallback(new_callback, self._timeout, self._id)
 
 #-----------------------------------------------------------------------------
 # Dev API


### PR DESCRIPTION
[Not ready for merge, will rebase after #11482 is merged]

This smaller PR removes the reference cycles introduced by our wrappers for Tornado's callbacks:

* The wrappers had a back-reference to `document` that is completely unused and unnecessary. This was removed.
* Removes the `_callback_objs_by_callable` cruft that has documents referencing session callback wrappers directly

Before this change,  uncollected documents could occur with referrers through the methods for these callback wrappers:
```
2021-08-09 13:15:08,752   uncollected Documents: 1
2021-08-09 13:15:08,757 [[<bokeh.document.document.Document object at 0x19de9efd0>], <bound method Document.add_next_tick_callback of <bokeh.document.document.Document object at 0x19de9efd0>>, <bound method Document.add_periodic_callback of <bokeh.document.document.Document object at 0x19de9efd0>>, <bound method Document.add_timeout_callback of <bokeh.document.document.Document object at 0x19de9efd0>>, <bound method Document.apply_json_event of <bokeh.document.document.Document object at 0x19de9efd0>>]
```
After this change, there is only a reference via the `apply_json_event` method (a different cause, to be resolved separately in the next PR)
```
2021-08-09 13:57:56,069   uncollected Documents: 1
2021-08-09 13:57:56,073 [[<bokeh.document.document.Document object at 0x1a0f524f0>], <bound method Document.apply_json_event of <bokeh.document.document.Document object at 0x1a0f524f0>>
```

---

@p-himik I know it has been some time since #7687 but I'd appreciate if you can take a quick look to confirm my conclusion that `_callback_objs_by_callable` is cruft. I *think* perhaps it was only needed to support the deprecated (now deleted) "remove by value" codepaths. Some observations I had:

* From inspecation, the bookkeeping around `_callback_objs_by_callable` seemed only to serve itself and was not used as part of any other current process I could find (it was previously part of the deprecated remover path, though)
* All current tests pass after simply removing everything associated with `_callback_objs_by_callable` 
* I ran two MREs for the OP (and a dupe of it) and could no reproduce any problems (on OSX) after this change. 
