### PR TITLE
Document Refs Cleanup (part 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 # tests/examples
 /tests/examples/report.html
 /examples.log
+/tests/**/examples.log
 /examples/custom/font-awesome/package-lock.json
 
 # conda build

--- a/bokeh/application/handlers/code.py
+++ b/bokeh/application/handlers/code.py
@@ -36,7 +36,6 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-import sys
 from contextlib import contextmanager
 from os.path import basename, splitext
 from types import ModuleType
@@ -161,8 +160,7 @@ class CodeHandler(Handler):
         # before the document is. A symptom of a gc'd module is that its globals
         # become None. Additionally stored modules are used to provide correct
         # paths to custom models resolver.
-        sys.modules[module.__name__] = module
-        doc._modules.append(module)
+        doc.modules.add(module)
 
         with _monkeypatch_io(self._loggers):
             with patch_curdoc(doc):

--- a/bokeh/core/query.py
+++ b/bokeh/core/query.py
@@ -46,9 +46,11 @@ __all__ = (
     'IN',
     'LEQ',
     'LT',
-    'match',
     'NEQ',
     'OR',
+    'find',
+    'match',
+    'is_single_string_selector',
 )
 
 SelectorType = Dict[Union[str, Type["_Operator"]], Any]
@@ -88,6 +90,20 @@ def find(objs: Iterable[Model], selector: SelectorType) -> Iterable[Model]:
 
     '''
     return (obj for obj in objs if match(obj, selector))
+
+
+def is_single_string_selector(selector: SelectorType, field: str) -> bool:
+    ''' Whether a selector is a simple single field, e.g. ``{name: "foo"}``
+
+    Args:
+        selector (JSON-like) : query selector
+        field (str) : field name to check for
+
+    Returns
+        bool
+
+    '''
+    return  len(selector) == 1 and field in selector and isinstance(selector[field], str)
 
 def match(obj: Model, selector: SelectorType) -> bool:
     ''' Test whether a given Bokeh model matches a given selector.

--- a/bokeh/document/document.py
+++ b/bokeh/document/document.py
@@ -56,7 +56,7 @@ from jinja2 import Template
 from ..core.enums import HoldPolicy, HoldPolicyType
 from ..core.has_props import is_DataModel
 from ..core.json_encoder import serialize_json
-from ..core.query import find
+from ..core.query import find, is_single_string_selector
 from ..core.templates import FILE
 from ..core.types import ID, Unknown
 from ..core.validation import check_integrity, process_validation_issues
@@ -834,7 +834,7 @@ class Document:
             seq[Model]
 
         '''
-        if self._is_single_string_selector(selector, 'name'):
+        if is_single_string_selector(selector, 'name'):
             # special-case optimization for by-name query
             return self.models.get_all_by_name(selector['name'])
 
@@ -1016,17 +1016,6 @@ class Document:
             dest_doc.add_root(r)
 
         dest_doc.title = self.title
-
-    def _is_single_string_selector(self, selector: SelectorType, field: str) -> bool:
-        '''
-
-        '''
-
-        if len(selector) != 1:
-            return False
-        if field not in selector:
-            return False
-        return isinstance(selector[field], str)
 
     def _notify_change(self, model: Model, attr: str, old: Unknown, new: Unknown,
             hint: DocumentPatchedEvent | None = None, setter: Setter | None = None, callback_invoker: Invoker | None = None) -> None:

--- a/bokeh/document/models.py
+++ b/bokeh/document/models.py
@@ -1,0 +1,288 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2021, Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+''' Encapulate the management of Document models with a DocumentModelManager
+class.
+
+'''
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import annotations
+
+import logging # isort:skip
+log = logging.getLogger(__name__)
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+import contextlib
+import weakref
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    Iterator,
+    List,
+    Set,
+)
+
+# Bokeh imports
+from ..core.types import ID
+from ..model import Model
+from ..util.datatypes import MultiValuedDict
+
+if TYPE_CHECKING:
+    from .document import Document
+
+#-----------------------------------------------------------------------------
+# Globals and constants
+#-----------------------------------------------------------------------------
+
+__all__ = (
+    'DocumentModelManager',
+)
+
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+class DocumentModelManager:
+    ''' Manage and provide access to all of the models that belong to a Bokeh
+    Document.
+
+    The set of "all models" means specifically all the models reachable from
+    references form a Document's roots.
+
+    '''
+
+    _document : weakref.ReferenceType[Document]
+    _freeze_count: int
+    _models: Dict[ID, Model]
+    _models_by_name: MultiValuedDict[str, Model]
+    _seen_model_ids: Set[ID] = set()
+
+    def __init__(self, document: Document):
+        '''
+
+        Args:
+            document (Document): A Document to manage models for
+                A weak reference to the Document will be retained
+
+        '''
+        self._document = weakref.ref(document)
+        self._freeze_count = 0
+        self._models = {}
+        self._models_by_name = MultiValuedDict()
+        self._seen_model_ids = set()
+
+    def __len__(self) -> int:
+        return len(self._models)
+
+    def __getitem__(self, id: ID) -> Model:
+        return self._models[id]
+
+    def __setitem__(self, id: ID, model: Model) -> None:
+        self._models[id] = model
+
+    def __contains__(self, id: ID) -> bool:
+        return id in self._models
+
+    def __iter__(self) -> Iterator[Model]:
+        return iter(self._models.values())
+
+    def destroy(self) -> None:
+        ''' Clean up references to the Documents models
+
+        '''
+
+        # probably better to implement a destroy protocol on models to
+        # untangle everything, then the collect below might not be needed
+        for m in self._models.values():
+            m._document = None
+            del m
+
+        del self._models
+        del self._models_by_name
+
+    @contextlib.contextmanager
+    def freeze(self) -> None:
+        ''' Defer expensive model recompuation until intermediate updates are
+        complete.
+
+        Making updates to the model graph might trigger events that cause more
+        updates. This context manager can be used to prevent expensive model
+        recompuation from happening until all events have finished and the
+        Document state is quiescent.
+
+        Example:
+
+        .. code-block:: python
+
+            with models.freeze():
+                # updates that might change the model graph, that might trigger
+                # updates that change the model graph, etc. Recompuation will
+                # happen once at the end.
+
+        '''
+        self._push_freeze()
+        yield
+        self._pop_freeze()
+
+    def get_all_by_name(self, name: str) -> List[Model]:
+        ''' Find all the models for this Document with a given name.
+
+        Args:
+            name (str) : the name of a model to search for
+
+        Returns
+            A list of models
+
+        '''
+        return self._models_by_name.get_all(name)
+
+    def get_by_id(self, id: ID) -> Model | None:
+        ''' Find the model for this Document with a given ID.
+
+        Args:
+            id (ID) : model ID to search for
+                If no model with the given ID exists, returns None
+
+        Return:
+            a Model or None
+
+        '''
+        return self._models.get(id, None)
+
+    def get_one_by_name(self, name: str) -> Model | None:
+        ''' Find a single model for this Document with a given name.
+
+        If multiple models are found with the name, an error is raised.
+
+        Args:
+            name (str) : the name of a model to search for
+
+        Returns
+            A model with the given name, or None
+
+        '''
+        return self._models_by_name.get_one(name, f"Found more than one model named '{name}'")
+
+    def invalidate(self) -> None:
+        ''' Recompute the set of all models, if not currently frozen
+
+        Returns:
+            None
+
+        '''
+        if self._freeze_count == 0:  # only recompute when competely unfrozen
+            self.recompute()
+
+    def recompute(self) -> None:
+        ''' Recompute the set of all models based on references reachable from
+        the Document's current roots.
+
+        This computation can be expensive. Use ``freeze`` to wrap operations
+        that update the model object graph to avoid over-recompuation
+
+        .. note::
+            Any models that remove during recomputation will be noted as
+            "previously seen"
+
+        '''
+        document = self._document()
+        if document is None:
+            return
+
+        new_models: Set[Model] = set()
+        for mr in document.roots:
+            new_models |= mr.references()
+
+        old_models = set(self._models.values())
+
+        to_detach = old_models - new_models
+        to_attach = new_models - old_models
+
+        recomputed: Dict[ID, Model] = {}
+        recomputed_by_name: MultiValuedDict[str, Model] = MultiValuedDict()
+
+        for mn in new_models:
+            recomputed[mn.id] = mn
+            if mn.name is not None:
+                recomputed_by_name.add_value(mn.name, mn)
+
+        for md in to_detach:
+            self._seen_model_ids.add(md.id)
+            md._detach_document()
+
+        for ma in to_attach:
+            ma._attach_document(document)
+
+        self._models = recomputed
+        self._models_by_name = recomputed_by_name
+
+    # XXX (bev) In theory, this is a potential issue for long-running apps that
+    # update the model graph continuously, since this set of "seen" model ids can
+    # grow without bound.
+    def seen(self, id: ID) -> bool:
+        ''' Report whether a model id has ever previously belonged to this
+        Document.
+
+        Args:
+            id (ID) : the model id of a model to check
+
+        Returns:
+            bool
+
+        '''
+        return id in self._seen_model_ids
+
+    def update_name(self, model: Model, old_name: str | None, new_name: str | None) -> None:
+        ''' Update the name for a model.
+
+        .. note::
+            This function and the internal name mapping exist to support
+            optimizing the common case of name lookup for models. Keeping a
+            dedicated name index is faster than using generic ``bokeh.query``
+            functions with a name selector
+
+        Args:
+            model (Model) : a model to update the name for
+
+            old_name(str, None) : a previous name for the model, or None
+
+            new_name(str, None) : a new name for the model, or None
+
+        Returns:
+            None
+
+        '''
+        if old_name is not None:
+            self._models_by_name.remove_value(old_name, model)
+        if new_name is not None:
+            self._models_by_name.add_value(new_name, model)
+
+    def _push_freeze(self) -> None:
+        self._freeze_count += 1
+
+    def _pop_freeze(self) -> None:
+        self._freeze_count -= 1
+        if self._freeze_count == 0:
+            self.recompute()
+
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------

--- a/bokeh/document/modules.py
+++ b/bokeh/document/modules.py
@@ -1,0 +1,139 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2021, Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+''' Encapulate the management of any modules that are created in the process
+of building a Bokeh Document in a DocumentModelManager class.
+
+'''
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import annotations
+
+import logging # isort:skip
+log = logging.getLogger(__name__)
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+import sys
+import weakref
+from types import ModuleType
+from typing import TYPE_CHECKING, List
+
+if TYPE_CHECKING:
+    from .document import Document
+
+#-----------------------------------------------------------------------------
+# Globals and constants
+#-----------------------------------------------------------------------------
+
+__all__ = (
+    'DocumentModuleManager',
+)
+
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+class DocumentModuleManager:
+    ''' Keep track of and clean up after modules created while building Bokeh
+    Documents.
+
+    '''
+
+    _document : weakref.ReferenceType[Document]
+    _modules: List[ModuleType]
+
+    def __init__(self, document: Document):
+        '''
+
+        Args:
+            document (Document): A Document to manage modules for
+                A weak reference to the Document will be retained
+
+        '''
+        self._document = weakref.ref(document)
+        self._modules = []
+
+    def __len__(self) -> int:
+        return len(self._modules)
+
+    def add(self, module: ModuleType):
+        ''' Add a module associated with a Document.
+
+        .. note::
+            This method will install the module in ``sys.modules``
+
+        Args:
+            module (Module) : a module to install for the configured Document
+
+        Returns:
+            None
+
+        '''
+        if module.__name__ in sys.modules:
+            raise RuntimeError(f"Add called already-added module {module.__name__!r} for {self._document()!r}")
+        sys.modules[module.__name__] = module
+        self._modules.append(module)
+
+    def destroy(self) -> None:
+        ''' Clean up any added modules, and check that there are no unexpected
+        referrers afterwards.
+
+        Returns:
+            None
+
+        '''
+        from gc import get_referrers
+        from types import FrameType
+
+        log.debug(f"Deleting {len(self._modules)} modules for document {self._document()!r}")
+
+        for module in self._modules:
+
+            # Modules created for a Document should have three referrers at this point:
+            #
+            # - sys.modules
+            # - self._modules
+            # - a frame object
+            #
+            # This function will take care of removing these expected references.
+            #
+            # If there are any additional referrers, this probably means the module will be
+            # leaked. Here we perform a detailed check that the only referrers are expected
+            # ones. Otherwise issue an error log message with details.
+            referrers = get_referrers(module)
+            referrers = [x for x in referrers if x is not sys.modules]  # lgtm [py/comparison-using-is]
+            referrers = [x for x in referrers if x is not self._modules]  # lgtm [py/comparison-using-is]
+            referrers = [x for x in referrers if not isinstance(x, FrameType)]
+            if len(referrers) != 0:
+                log.error(f"Module {module!r} has extra unexpected referrers! This could indicate a serious memory leak. Extra referrers: {referrers!r}")
+
+            # remove the reference from sys.modules
+            if module.__name__ in sys.modules:
+                del sys.modules[module.__name__]
+
+        # remove the references from self._modules
+        self._modules = []
+
+        # the frame reference will take care of itself
+
+
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------

--- a/bokeh/embed/util.py
+++ b/bokeh/embed/util.py
@@ -354,10 +354,10 @@ be used. For more information on building and running Bokeh applications, see:
 def _create_temp_doc(models: Sequence[Model]) -> Document:
     doc = Document()
     for m in models:
-        doc._all_models[m.id] = m
+        doc.models[m.id] = m
         m._temp_document = doc
         for ref in m.references():
-            doc._all_models[ref.id] = ref
+            doc.models[ref.id] = ref
             ref._temp_document = doc
     doc._roots = list(models)
     return doc

--- a/bokeh/io/notebook.py
+++ b/bokeh/io/notebook.py
@@ -145,7 +145,7 @@ class CommsHandle:
     # internal doc with the event so that it is collected (until a
     # call to push_notebook processes and clear colleted events)
     def _document_model_changed(self, event: ModelChangedEvent) -> None:
-        if event.model.id in self.doc._all_models:
+        if event.model.id in self.doc.models:
             self.doc._trigger_on_change(event)
 
 class Load(Protocol):

--- a/bokeh/model/model.py
+++ b/bokeh/model/model.py
@@ -553,7 +553,7 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
                 visit_value_and_its_immediate_references(new, mark_dirty)
                 visit_value_and_its_immediate_references(old, mark_dirty)
                 if dirty_count > 0:
-                    self.document._invalidate_all_models()
+                    self.document.models.invalidate()
         # chain up to invoke callbacks
         descriptor = self.lookup(attr)
         super().trigger(descriptor.name, old, new, hint=hint, setter=setter)

--- a/bokeh/sphinxext/example_handler.py
+++ b/bokeh/sphinxext/example_handler.py
@@ -21,7 +21,6 @@ log = logging.getLogger(__name__)
 # -----------------------------------------------------------------------------
 
 # Standard library imports
-import sys
 from typing import TYPE_CHECKING
 
 # Bokeh imports
@@ -69,8 +68,7 @@ class ExampleHandler(Handler):
 
         module = self._runner.new_module()
 
-        sys.modules[module.__name__] = module
-        doc._modules.append(module)
+        doc.modules.add(module)
 
         orig_curdoc = curdoc()
         set_curdoc(doc)

--- a/sphinx/source/docs/releases/2.4.0.rst
+++ b/sphinx/source/docs/releases/2.4.0.rst
@@ -40,6 +40,9 @@ to impact any typical usage).
 queries. This feature added unnecessary complication and was not used inside
 the Bokeh codebase (or ever demonstrated in docs or examples).
 
+``Document.delete_modules`` was deprecated and will be removed in the future.
+Use ``Document.models.destroy`` instead.
+
 Units Properties
 ~~~~~~~~~~~~~~~~
 

--- a/tests/unit/bokeh/core/test_query.py
+++ b/tests/unit/bokeh/core/test_query.py
@@ -272,6 +272,12 @@ def test_malformed_exception() -> None:
     with pytest.raises(ValueError):
         q.match(plot, {11: {q.EQ: 5}})
 
+def test_is_single_string_selector() -> None:
+    assert q.is_single_string_selector(dict(foo="c"), "foo")
+    assert not q.is_single_string_selector(dict(foo="c", bar="d"), "foo")
+    assert not q.is_single_string_selector(dict(foo=42), "foo")
+
+
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/document/examples.log
+++ b/tests/unit/bokeh/document/examples.log
@@ -1,1 +1,0 @@
-ERROR    bokeh.document.modules:modules.py:82 Module <test_modules.FakeMod object at 0x1146727c0> has extra unexpected referrers! This could indicate a serious memory leak. Extra referrers: [[<test_modules.FakeMod object at 0x1146727c0>]]

--- a/tests/unit/bokeh/document/examples.log
+++ b/tests/unit/bokeh/document/examples.log
@@ -1,0 +1,1 @@
+ERROR    bokeh.document.modules:modules.py:82 Module <test_modules.FakeMod object at 0x1146727c0> has extra unexpected referrers! This could indicate a serious memory leak. Extra referrers: [[<test_modules.FakeMod object at 0x1146727c0>]]

--- a/tests/unit/bokeh/document/test_document.py
+++ b/tests/unit/bokeh/document/test_document.py
@@ -178,30 +178,30 @@ class TestDocument:
     def test_all_models(self) -> None:
         d = document.Document()
         assert not d.roots
-        assert len(d._all_models) == 0
+        assert len(d.models) == 0
         m = SomeModelInTestDocument()
         m2 = AnotherModelInTestDocument()
         m.child = m2
         d.add_root(m)
         assert len(d.roots) == 1
-        assert len(d._all_models) == 2
+        assert len(d.models) == 2
         m.child = None
-        assert len(d._all_models) == 1
+        assert len(d.models) == 1
         m.child = m2
-        assert len(d._all_models) == 2
+        assert len(d.models) == 2
         d.remove_root(m)
-        assert len(d._all_models) == 0
+        assert len(d.models) == 0
 
     def test_get_model_by_id(self) -> None:
         d = document.Document()
         assert not d.roots
-        assert len(d._all_models) == 0
+        assert len(d.models) == 0
         m = SomeModelInTestDocument()
         m2 = AnotherModelInTestDocument()
         m.child = m2
         d.add_root(m)
         assert len(d.roots) == 1
-        assert len(d._all_models) == 2
+        assert len(d.models) == 2
         assert d.get_model_by_id(m.id) == m
         assert d.get_model_by_id(m2.id) == m2
         assert d.get_model_by_id("not a valid ID") is None
@@ -209,14 +209,13 @@ class TestDocument:
     def test_get_model_by_name(self) -> None:
         d = document.Document()
         assert not d.roots
-        assert len(d._all_models) == 0
+        assert len(d.models) == 0
         m = SomeModelInTestDocument(name="foo")
         m2 = AnotherModelInTestDocument(name="bar")
         m.child = m2
         d.add_root(m)
         assert len(d.roots) == 1
-        assert len(d._all_models) == 2
-        assert len(d._all_models_by_name._dict) == 2
+        assert len(d.models) == 2
         assert d.get_model_by_name(m.name) == m
         assert d.get_model_by_name(m2.name) == m2
         assert d.get_model_by_name("not a valid name") is None
@@ -341,7 +340,7 @@ class TestDocument:
     def test_all_models_with_multiple_references(self) -> None:
         d = document.Document()
         assert not d.roots
-        assert len(d._all_models) == 0
+        assert len(d.models) == 0
         root1 = SomeModelInTestDocument()
         root2 = SomeModelInTestDocument()
         child1 = AnotherModelInTestDocument()
@@ -350,24 +349,24 @@ class TestDocument:
         d.add_root(root1)
         d.add_root(root2)
         assert len(d.roots) == 2
-        assert len(d._all_models) == 3
+        assert len(d.models) == 3
         root1.child = None
-        assert len(d._all_models) == 3
+        assert len(d.models) == 3
         root2.child = None
-        assert len(d._all_models) == 2
+        assert len(d.models) == 2
         root1.child = child1
-        assert len(d._all_models) == 3
+        assert len(d.models) == 3
         root2.child = child1
-        assert len(d._all_models) == 3
+        assert len(d.models) == 3
         d.remove_root(root1)
-        assert len(d._all_models) == 2
+        assert len(d.models) == 2
         d.remove_root(root2)
-        assert len(d._all_models) == 0
+        assert len(d.models) == 0
 
     def test_all_models_with_cycles(self) -> None:
         d = document.Document()
         assert not d.roots
-        assert len(d._all_models) == 0
+        assert len(d.models) == 0
         root1 = SomeModelInTestDocument()
         root2 = SomeModelInTestDocument()
         child1 = SomeModelInTestDocument()
@@ -379,23 +378,23 @@ class TestDocument:
         print("adding root2")
         d.add_root(root2)
         assert len(d.roots) == 2
-        assert len(d._all_models) == 3
+        assert len(d.models) == 3
         print("clearing child of root1")
         root1.child = None
-        assert len(d._all_models) == 3
+        assert len(d.models) == 3
         print("clearing child of root2")
         root2.child = None
-        assert len(d._all_models) == 2
+        assert len(d.models) == 2
         print("putting child1 back in root1")
         root1.child = child1
-        assert len(d._all_models) == 3
+        assert len(d.models) == 3
 
         print("Removing root1")
         d.remove_root(root1)
-        assert len(d._all_models) == 1
+        assert len(d.models) == 1
         print("Removing root2")
         d.remove_root(root2)
-        assert len(d._all_models) == 0
+        assert len(d.models) == 0
 
     def test_change_notification(self) -> None:
         d = document.Document()
@@ -704,13 +703,13 @@ class TestDocument:
         assert d.title == "Foo"
         d.clear()
         assert not d.roots
-        assert not d._all_models
+        assert len(d.models) == 0
         assert d.title == "Foo" # do not reset title
 
     def test_serialization_one_model(self) -> None:
         d = document.Document()
         assert not d.roots
-        assert len(d._all_models) == 0
+        assert len(d.models) == 0
         root1 = SomeModelInTestDocument()
         d.add_root(root1)
         d.title = "Foo"
@@ -724,7 +723,7 @@ class TestDocument:
     def test_serialization_more_models(self) -> None:
         d = document.Document()
         assert not d.roots
-        assert len(d._all_models) == 0
+        assert len(d.models) == 0
         root1 = SomeModelInTestDocument(foo=42)
         root2 = SomeModelInTestDocument(foo=43)
         child1 = SomeModelInTestDocument(foo=44)
@@ -788,7 +787,7 @@ class TestDocument:
     def test_patch_integer_property(self) -> None:
         d = document.Document()
         assert not d.roots
-        assert len(d._all_models) == 0
+        assert len(d.models) == 0
         root1 = SomeModelInTestDocument(foo=42)
         root2 = SomeModelInTestDocument(foo=43)
         child1 = SomeModelInTestDocument(foo=44)
@@ -813,7 +812,7 @@ class TestDocument:
     def test_patch_spec_property(self) -> None:
         d = document.Document()
         assert not d.roots
-        assert len(d._all_models) == 0
+        assert len(d.models) == 0
         root1 = ModelWithSpecInTestDocument(foo=42)
         d.add_root(root1)
         assert len(d.roots) == 1
@@ -864,7 +863,7 @@ class TestDocument:
     def test_patch_reference_property(self) -> None:
         d = document.Document()
         assert not d.roots
-        assert len(d._all_models) == 0
+        assert len(d.models) == 0
         root1 = SomeModelInTestDocument(foo=42)
         root2 = SomeModelInTestDocument(foo=43)
         child1 = SomeModelInTestDocument(foo=44)
@@ -876,9 +875,9 @@ class TestDocument:
         d.add_root(root2)
         assert len(d.roots) == 2
 
-        assert child1.id in d._all_models
-        assert child2.id not in d._all_models
-        assert child3.id not in d._all_models
+        assert child1.id in d.models
+        assert child2.id not in d.models
+        assert child3.id not in d.models
 
         event1 = ModelChangedEvent(d, root1, 'child', root1.child, child3, child3)
         patch1, buffers = process_document_events([event1])
@@ -886,9 +885,9 @@ class TestDocument:
 
         assert root1.child.id == child3.id
         assert root1.child.child.id == child2.id
-        assert child1.id in d._all_models
-        assert child2.id in d._all_models
-        assert child3.id in d._all_models
+        assert child1.id in d.models
+        assert child2.id in d.models
+        assert child3.id in d.models
 
         # put it back how it was before
         event2 = ModelChangedEvent(d, root1, 'child', root1.child, child1, child1)
@@ -898,14 +897,14 @@ class TestDocument:
         assert root1.child.id == child1.id
         assert root1.child.child is None
 
-        assert child1.id in d._all_models
-        assert child2.id not in d._all_models
-        assert child3.id not in d._all_models
+        assert child1.id in d.models
+        assert child2.id not in d.models
+        assert child3.id not in d.models
 
     def test_patch_two_properties_at_once(self) -> None:
         d = document.Document()
         assert not d.roots
-        assert len(d._all_models) == 0
+        assert len(d.models) == 0
         root1 = SomeModelInTestDocument(foo=42)
         child1 = SomeModelInTestDocument(foo=43)
         root1.child = child1
@@ -934,7 +933,7 @@ class TestDocument:
         d = document.Document()
         set_curdoc(d)
         assert not d.roots
-        assert len(d._all_models) == 0
+        assert len(d.models) == 0
         p1 = figure(tools=[])
         N = 10
         x = np.linspace(0, 4 * np.pi, N)

--- a/tests/unit/bokeh/document/test_document.py
+++ b/tests/unit/bokeh/document/test_document.py
@@ -330,13 +330,6 @@ class TestDocument:
         d.set_select(AnotherModelInTestDocument, dict(name="B"))
         assert {root4} == set(d.select(dict(name="B")))
 
-    def test_is_single_string_selector(self) -> None:
-        d = document.Document()
-        # this is an implementation detail but just ensuring it works
-        assert d._is_single_string_selector(dict(foo="c"), "foo")
-        assert not d._is_single_string_selector(dict(foo="c", bar="d"), "foo")
-        assert not d._is_single_string_selector(dict(foo=42), "foo")
-
     def test_all_models_with_multiple_references(self) -> None:
         d = document.Document()
         assert not d.roots

--- a/tests/unit/bokeh/document/test_document.py
+++ b/tests/unit/bokeh/document/test_document.py
@@ -135,53 +135,6 @@ class TestDocumentHold:
         assert mock_trigger.call_args[0] == (3,)
         assert mock_trigger.call_args[1] == {}
 
-extra = []
-
-
-class Test_Document_delete_modules:
-    def test_basic(self) -> None:
-        d = document.Document()
-        assert not d.roots
-        class FakeMod:
-            __name__ = 'junkjunkjunk'
-        mod = FakeMod()
-        import sys
-        assert 'junkjunkjunk' not in sys.modules
-        sys.modules['junkjunkjunk'] = mod
-        d._modules.append(mod)
-        assert 'junkjunkjunk' in sys.modules
-        d.delete_modules()
-        assert 'junkjunkjunk' not in sys.modules
-        assert d._modules == []
-
-    def test_extra_referrer_error(self, caplog: pytest.LogCaptureFixture) -> None:
-        d = document.Document()
-        assert not d.roots
-        class FakeMod:
-            __name__ = 'junkjunkjunk'
-        mod = FakeMod()
-        import sys
-        assert 'junkjunkjunk' not in sys.modules
-        sys.modules['junkjunkjunk'] = mod
-        d._modules.append(mod)
-        assert 'junkjunkjunk' in sys.modules
-
-        # add an extra referrer for delete_modules to complain about
-        extra.append(mod)
-        import gc
-
-        # get_referrers behavior changed in Python 3.7, see https://github.com/bokeh/bokeh/issues/8221
-        assert len(gc.get_referrers(mod)) in (3,4)
-
-        with caplog.at_level(logging.ERROR):
-            d.delete_modules()
-            assert "Module %r has extra unexpected referrers! This could indicate a serious memory leak. Extra referrers:" % mod in caplog.text
-            assert len(caplog.records) == 1
-
-        assert 'junkjunkjunk' not in sys.modules
-        assert d._modules == []
-
-
 class TestDocument:
     def test_empty(self) -> None:
         d = document.Document()

--- a/tests/unit/bokeh/document/test_events__document.py
+++ b/tests/unit/bokeh/document/test_events__document.py
@@ -132,6 +132,9 @@ class TestModelChangedEvent:
         assert e.hint == None
         assert e.callback_invoker == None
 
+    def test_kind(self) -> None:
+        assert bde.ModelChangedEvent.kind == "ModelChanged"
+
     def test_init_ignores_hint_with_setter(self) -> None:
         e = bde.ModelChangedEvent("doc", "model", "attr", "old", "new", "snew", setter="setter", hint="hint", callback_invoker="invoker")
         assert e.document == "doc"
@@ -227,6 +230,9 @@ class TestColumnDataChangedEvent:
         assert e.setter == "setter"
         assert e.callback_invoker == "invoker"
 
+    def test_kind(self) -> None:
+        assert bde.ColumnDataChangedEvent.kind == "ColumnDataChanged"
+
     @patch("bokeh.util.serialization.transform_column_source_data")
     def test_generate(self, mock_tcds: MagicMock) -> None:
         mock_tcds.return_value = "new"
@@ -235,7 +241,7 @@ class TestColumnDataChangedEvent:
         refs = dict(foo=10)
         bufs = set()
         r = e.generate(refs, bufs)
-        assert r == dict(kind="ColumnDataChanged", column_source="ref", new="new", cols=[1,2])
+        assert r == dict(kind=e.kind, column_source="ref", new="new", cols=[1,2])
         assert refs == dict(foo=10)
         assert bufs == set()
 
@@ -268,13 +274,16 @@ class TestColumnsStreamedEvent:
         assert e.setter == "setter"
         assert e.callback_invoker == "invoker"
 
+    def test_kind(self) -> None:
+        assert bde.ColumnsStreamedEvent.kind == "ColumnsStreamed"
+
     def test_generate(self) -> None:
         m = FakeModel()
         e = bde.ColumnsStreamedEvent("doc", m, dict(foo=1), 200, "setter", "invoker")
         refs = dict(foo=10)
         bufs = set()
         r = e.generate(refs, bufs)
-        assert r == dict(kind="ColumnsStreamed", column_source="ref", data=dict(foo=1), rollover=200)
+        assert r == dict(kind=e.kind, column_source="ref", data=dict(foo=1), rollover=200)
         assert refs == dict(foo=10)
         assert bufs == set()
 
@@ -315,13 +324,16 @@ class TestColumnsPatchedEvent:
         assert e.setter == "setter"
         assert e.callback_invoker == "invoker"
 
+    def test_kind(self) -> None:
+        assert bde.ColumnsPatchedEvent.kind == "ColumnsPatched"
+
     def test_generate(self) -> None:
         m = FakeModel()
         e = bde.ColumnsPatchedEvent("doc", m, [1, 2], "setter", "invoker")
         refs = dict(foo=10)
         bufs = set()
         r = e.generate(refs, bufs)
-        assert r == dict(kind="ColumnsPatched", column_source="ref", patches=[1,2])
+        assert r == dict(kind=e.kind, column_source="ref", patches=[1,2])
         assert refs == dict(foo=10)
         assert bufs == set()
 
@@ -351,12 +363,15 @@ class TestTitleChangedEvent:
         assert e.setter == "setter"
         assert e.callback_invoker == "invoker"
 
+    def test_kind(self) -> None:
+        assert bde.TitleChangedEvent.kind == "TitleChanged"
+
     def test_generate(self) -> None:
         e = bde.TitleChangedEvent("doc", "title", "setter", "invoker")
         refs = dict(foo=10)
         bufs = set()
         r = e.generate(refs, bufs)
-        assert r == dict(kind="TitleChanged", title="title")
+        assert r == dict(kind=e.kind, title="title")
         assert refs == dict(foo=10)
         assert bufs == set()
 
@@ -407,13 +422,16 @@ class TestRootAddedEvent:
         assert e.setter == "setter"
         assert e.callback_invoker == "invoker"
 
+    def test_kind(self) -> None:
+        assert bde.RootAddedEvent.kind == "RootAdded"
+
     def test_generate(self) -> None:
         m = FakeModel()
         e = bde.RootAddedEvent("doc", m, "setter", "invoker")
         refs = dict(foo=10)
         bufs = set()
         r = e.generate(refs, bufs)
-        assert r == dict(kind="RootAdded", model="ref")
+        assert r == dict(kind=e.kind, model="ref")
         assert refs == dict(foo=10, ref1=1, ref2=2)
         assert bufs == set()
 
@@ -437,13 +455,16 @@ class TestRootRemovedEvent:
         assert e.setter == "setter"
         assert e.callback_invoker == "invoker"
 
+    def test_kind(self) -> None:
+        assert bde.RootRemovedEvent.kind == "RootRemoved"
+
     def test_generate(self) -> None:
         m = FakeModel()
         e = bde.RootRemovedEvent("doc", m, "setter", "invoker")
         refs = dict(foo=10)
         bufs = set()
         r = e.generate(refs, bufs)
-        assert r == dict(kind="RootRemoved", model="ref")
+        assert r == dict(kind=e.kind, model="ref")
         assert refs == dict(foo=10)
         assert bufs == set()
 

--- a/tests/unit/bokeh/document/test_models.py
+++ b/tests/unit/bokeh/document/test_models.py
@@ -1,0 +1,315 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2021, Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import annotations # isort:skip
+
+import pytest ; pytest
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+import gc
+
+# External imports
+from mock import MagicMock, patch
+
+# Bokeh imports
+from bokeh.document import Document
+from bokeh.models import Div, Row
+
+# Module under test
+import bokeh.document.models as bdm # isort:skip
+
+#-----------------------------------------------------------------------------
+# Setup
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+class TestDocumentModelManager:
+
+    def test_basic(self) -> None:
+        d = Document()
+        dm = bdm.DocumentModelManager(d)
+        assert len(dm) == 0
+
+        # module manager should only hold a weak ref
+        assert len(gc.get_referrers(d)) == 1
+
+    def test_len(self) -> None:
+        d = Document()
+        dm = d.models
+        assert len(dm) == 0
+
+        r1 = Row(children=[Div()])
+        r2 = Row(children=[Div(), Div()])
+
+        d.add_root(r1)
+        assert len(dm) == 2
+
+        d.add_root(r2)
+        assert len(dm) == 5
+
+        d.remove_root(r1)
+        assert len(dm) == 3
+
+        d.remove_root(r2)
+        assert len(dm) == 0
+
+    def test_setitem_getitem(self) -> None:
+        d = Document()
+        dm = bdm.DocumentModelManager(d)
+        assert len(dm) == 0
+
+        m = Div(id="foo")
+
+        dm["foo"] = m
+        assert len(dm) == 1
+
+        assert dm["foo"] is m
+
+        with pytest.raises(KeyError):
+            dm["junk"]
+
+    def test_contains(self) -> None:
+        d = Document()
+        dm = bdm.DocumentModelManager(d)
+        assert len(dm) == 0
+
+        m = Div(id="foo")
+
+        dm["foo"] = m
+
+        assert "foo" in dm
+        assert "junk" not in dm
+
+    def test_iter(self) -> None:
+        d = Document()
+        dm = bdm.DocumentModelManager(d)
+        assert len(dm) == 0
+
+        m1 = Div()
+        m2 = Div()
+        m3 = Div()
+
+        dm["m1"] = m1
+        dm["m2"] = m2
+        dm["m3"] = m3
+
+        result = set()
+        for m in dm:
+            result.add(m)
+
+        assert result == {m1, m2, m3}
+
+    def test_destroy(self) -> None:
+        d = Document()
+        dm = d.models
+        assert len(dm) == 0
+
+        m1 = Div()
+        m2 = Div()
+        m3 = Div()
+
+        d.add_root(m1)
+        d.add_root(m2)
+        d.add_root(m3)
+        for m in [m1, m2, m3]:
+            assert m._document is d
+
+        assert dm.destroy() is None
+
+        assert not hasattr(dm, "_models")
+        assert not hasattr(dm, "_models_by_name")
+
+        for m in [m1, m2, m3]:
+            assert m._document is None
+
+    @patch("bokeh.document.models.DocumentModelManager.recompute")
+    def test_freeze(self, mock_recompute: MagicMock) -> None:
+        d = Document()
+        dm = bdm.DocumentModelManager(d)
+
+        assert dm._freeze_count == 0
+
+        with dm.freeze():
+            assert dm._freeze_count == 1
+            assert not mock_recompute.called
+
+            with dm.freeze():
+                assert dm._freeze_count == 2
+                assert not mock_recompute.called
+
+            assert dm._freeze_count == 1
+            assert not mock_recompute.called
+
+        assert dm._freeze_count == 0
+        assert mock_recompute.called  # called here
+
+    def test_get_all_by_name(self) -> None:
+        d = Document()
+        dm = d.models
+        assert len(dm) == 0
+
+        m1 = Div(name="foo")
+        m2 = Div(name="foo")
+        m3 = Div(name="bar")
+
+        d.add_root(m1)
+        d.add_root(m2)
+        d.add_root(m3)
+
+        assert set(dm.get_all_by_name("foo")) == {m1, m2}
+        assert set(dm.get_all_by_name("bar")) == {m3}
+        assert set(dm.get_all_by_name("baz")) == set()
+
+    def test_get_all_by_id(self) -> None:
+        d = Document()
+        dm = d.models
+        assert len(dm) == 0
+
+        m1 = Div(id="m1")
+        m2 = Div(id="m2")
+
+        d.add_root(m1)
+        d.add_root(m2)
+
+        assert dm.get_by_id("m1") is m1
+        assert dm.get_by_id("m2") is m2
+        assert dm.get_by_id("junk") is None
+
+    def test_get_one_by_name(self) -> None:
+        d = Document()
+        dm = d.models
+        assert len(dm) == 0
+
+        m1 = Div(name="foo")
+        m2 = Div(name="foo")
+        m3 = Div(name="bar")
+
+        d.add_root(m1)
+        d.add_root(m2)
+        d.add_root(m3)
+
+        with pytest.raises(ValueError):
+            dm.get_one_by_name("foo")
+        assert dm.get_one_by_name("bar") is m3
+        assert dm.get_one_by_name("baz") is None
+
+    @patch("bokeh.document.models.DocumentModelManager.recompute")
+    def test_invalidate(self, mock_recompute: MagicMock) -> None:
+        d = Document()
+        dm = bdm.DocumentModelManager(d)
+
+        with dm.freeze():
+            dm.invalidate()
+            assert not mock_recompute.called
+
+        assert mock_recompute.call_count == 1
+
+        dm.invalidate()
+        assert mock_recompute.call_count == 2
+
+    # This is an indeirect test that documents are attached/detached
+    def test_recompute(self) -> None:
+        d = Document()
+        dm = d.models
+        assert len(dm) == 0
+
+        r1 = Row(children=[Div(id="d1", name="dr1")])
+        r2 = Row(children=[Div(id="d2", name="dr2"), Div(id="d3", name="dr2")])
+
+        d.add_root(r1)
+        d.add_root(r2)
+
+        assert set(dm._models_by_name._dict) == {"dr1", "dr2"}
+
+        for m in dm:
+            assert m._document is d
+
+        d.remove_root(r1)
+        for m in dm:
+            assert m._document is d
+
+        assert r1._document is None
+        assert r1.children[0]._document is None
+
+        assert set(dm._models_by_name._dict) == {"dr2"}
+
+
+
+    def test_seen(self) -> None:
+        d = Document()
+        dm = d.models
+        assert len(dm) == 0
+
+        m1 = Div(id="m1")
+        m2 = Div(id="m2")
+
+        d.add_root(m1)
+        d.add_root(m2)
+
+        assert not dm.seen("m1")
+        assert not dm.seen("m2")
+
+        d.remove_root(m2)
+
+        assert not dm.seen("m1")
+        assert dm.seen("m2")
+
+        d.remove_root(m1)
+
+        assert dm.seen("m1")
+        assert dm.seen("m2")
+
+    def test_update_name(self) -> None:
+        d = Document()
+        dm = d.models
+        assert len(dm) == 0
+
+        m1 = Div(name="foo")
+        m2 = Div()
+        m3 = Div(name="bar")
+
+        d.add_root(m1)
+        d.add_root(m2)
+        d.add_root(m3)
+
+        assert set(dm.get_all_by_name("foo")) == {m1}
+        assert set(dm.get_all_by_name("bar")) == {m3}
+
+        dm.update_name(m1, "foo", "baz")
+
+        assert set(dm.get_all_by_name("baz")) == {m1}
+        assert set(dm.get_all_by_name("foo")) == set()
+        assert set(dm.get_all_by_name("bar")) == {m3}
+
+        dm.update_name(m2, None, "baz")
+        dm.update_name(m3, "bar", "baz")
+
+        assert set(dm.get_all_by_name("baz")) == {m1, m2, m3}
+        assert set(dm.get_all_by_name("foo")) == set()
+        assert set(dm.get_all_by_name("bar")) == set()
+
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/document/test_modules.py
+++ b/tests/unit/bokeh/document/test_modules.py
@@ -1,0 +1,142 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2021, Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import annotations # isort:skip
+
+import pytest ; pytest
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+import gc
+import logging
+import sys
+
+# Bokeh imports
+from bokeh.document import Document
+from bokeh.util.logconfig import basicConfig
+
+# Module under test
+import bokeh.document.modules as bdm # isort:skip
+
+#-----------------------------------------------------------------------------
+# Setup
+#-----------------------------------------------------------------------------
+
+extra = []
+
+class FakeMod:
+    __name__ = 'FakeMod'
+
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+class TestDocumentModuleManager:
+
+    def test_basic(self) -> None:
+        d = Document()
+        dm = bdm.DocumentModuleManager(d)
+        assert len(dm) == 0
+
+        # module manager should only hold a weak ref
+        assert len(gc.get_referrers(d)) == 1
+
+    def test_add(self) -> None:
+        d = Document()
+        dm = bdm.DocumentModuleManager(d)
+
+        mod = FakeMod()
+        assert 'FakeMod' not in sys.modules
+
+        dm.add(mod)
+
+        assert 'FakeMod' in sys.modules
+        assert len(dm) == 1
+
+        del sys.modules["FakeMod"]
+
+    def test_add_twice_error(self) -> None:
+        d = Document()
+        dm = bdm.DocumentModuleManager(d)
+
+        mod = FakeMod()
+        assert 'FakeMod' not in sys.modules
+
+        dm.add(mod)
+
+        with pytest.raises(RuntimeError):
+            dm.add(mod)
+
+        del sys.modules["FakeMod"]
+
+    def test_destroy(self) -> None:
+        d = Document()
+        dm = bdm.DocumentModuleManager(d)
+
+        mod = FakeMod()
+        assert 'FakeMod' not in sys.modules
+
+        dm.add(mod)
+
+        assert 'FakeMod' in sys.modules
+        assert len(dm) == 1
+
+        dm.destroy()
+
+        assert len(dm) == 0
+        assert 'FakeMod' not in sys.modules
+
+    def test_extra_referrer_error(self, caplog: pytest.LogCaptureFixture) -> None:
+        d = Document()
+        dm = bdm.DocumentModuleManager(d)
+
+        mod = FakeMod()
+        assert 'FakeMod' not in sys.modules
+
+        dm.add(mod)
+
+        assert 'FakeMod' in sys.modules
+        assert len(dm) == 1
+
+        # add an extra referrer for delete_modules to complain about
+        extra.append(mod)
+
+        import gc
+
+        # get_referrers behavior changed in Python 3.7, see https://github.com/bokeh/bokeh/issues/8221
+        assert len(gc.get_referrers(mod)) in (3,4)
+
+        with caplog.at_level(logging.ERROR):
+            dm.destroy()
+            assert "Module %r has extra unexpected referrers! This could indicate a serious memory leak. Extra referrers:" % mod in caplog.text
+            assert len(caplog.records) == 1
+
+        assert 'FakeMod' not in sys.modules
+        assert len(dm) ==0
+
+
+
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------
+
+# needed for caplog tests to function
+basicConfig()

--- a/tests/unit/bokeh/server/test_session__server.py
+++ b/tests/unit/bokeh/server/test_session__server.py
@@ -58,7 +58,7 @@ def test_subscribe() -> None:
 def test_destroy_calls() -> None:
     d = Document()
     s = bss.ServerSession('some-id', d, 'ioloop')
-    with mock.patch('bokeh.document.Document.delete_modules') as docdm:
+    with mock.patch('bokeh.document.modules.DocumentModuleManager.destroy') as docdm:
         with mock.patch('bokeh.document.Document.remove_on_change') as docroc:
             s.destroy()
             assert s.destroyed


### PR DESCRIPTION
This continues preparatory cleanup work to improve Document event handling. This PR factors a few hundred lines out of `Document` by:

* delegating module handling to a new `DocumentModuleManager`
* delegating model ("all models") handling to a new `DocumentModelManager`
* consolidates processing (incoming JSON,  outgoing JSON, event objects to trigger) all on the event classes

as well as a few smaller cleanup moves. 

The new classes have full tests which makes these low-level corners of Bokeh more well-covered. 

cc @mattpap If you have time to take a quick look please do, but assuming downstream tests continue to look good, I plan to merge this tomorrow (unless there is some serious concern)

As an aside, for 3.0 I think we should work to disentangle some concepts from the very overloaded term "event", and express these changes in the codebase. E.g. 

* BokehJS internal -> "signal"
* User facing -> "events" and "changes"
* Python internal -> "actions" (since we them similar to the action pattern) 

cc @tcmetzger thoughts on above but also any comments on the docs added in this PR. 
