### PR TITLE
Support xyzservices.TileProvider as an input of get_provider

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -369,7 +369,7 @@ jobs:
 
       - name: Remove extra packages
         shell: bash -l {0}
-        run: conda remove --yes --quiet --no-pin pandas pandas-stubs scipy notebook scikit-learn sympy flask networkx
+        run: conda remove --yes --quiet --no-pin pandas pandas-stubs scipy notebook scikit-learn sympy flask networkx xyzservices
 
       - name: Run tests
         shell: bash -l {0}

--- a/bokeh/tile_providers.py
+++ b/bokeh/tile_providers.py
@@ -158,6 +158,8 @@ import types
 
 # Bokeh imports
 from bokeh.core.enums import enumeration
+
+# Bokeh imports
 from .util.dependencies import import_optional
 
 #-----------------------------------------------------------------------------

--- a/bokeh/tile_providers.py
+++ b/bokeh/tile_providers.py
@@ -10,11 +10,12 @@ get_provider
     Use this function to retrieve an instance of a predefined tile provider.
 
     Args:
-        provider_name (Union[str, Vendors])
+        provider_name (Union[str, Vendors, xyzservices.TileProvider])
             Name of the tile provider to supply.
 
             Use a ``tile_providers.Vendors`` enumeration value, or the string
-            name of one of the known providers.
+            name of one of the known providers. Use
+            :class:`xyzservices.TileProvider` to pass custom tile providers.
 
     Returns:
         WMTSTileProviderSource: The desired tile provider instance
@@ -30,6 +31,10 @@ get_provider
                 >>> get_provider(Vendors.CARTODBPOSITRON)
                 <class 'bokeh.models.tiles.WMTSTileSource'>
                 >>> get_provider('CARTODBPOSITRON')
+                <class 'bokeh.models.tiles.WMTSTileSource'>
+
+                >>> import xyzservices.providers as xyz
+                >>> get_provider(xyz.CartoDB.Positron)
                 <class 'bokeh.models.tiles.WMTSTileSource'>
 
 The available built-in tile providers are listed in the ``Vendors`` enum:
@@ -153,12 +158,14 @@ import types
 
 # Bokeh imports
 from bokeh.core.enums import enumeration
+from .util.dependencies import import_optional
 
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
 
 # __all__ defined at the bottom on the class module
+xyzservices = import_optional('xyzservices')
 
 #-----------------------------------------------------------------------------
 # General API
@@ -231,6 +238,15 @@ class _TileProvidersModule(types.ModuleType):
         if isinstance(provider_name, WMTSTileSource):
             # This allows `get_provider(CARTODBPOSITRON)` to work
             return WMTSTileSource(url=provider_name.url, attribution=provider_name.attribution)
+
+        if xyzservices:
+            if isinstance(provider_name, xyzservices.TileProvider):
+                return WMTSTileSource(
+                    url=provider_name.build_url(scale_factor="@2x"),
+                    attribution=provider_name.html_attribution,
+                    min_zoom=provider_name.get("min_zoom", 0),
+                    max_zoom=provider_name.get("max_zoom", 30),
+                )
 
         selected_provider = provider_name.upper()
 

--- a/ci/environment-test-3.7.yml
+++ b/ci/environment-test-3.7.yml
@@ -46,6 +46,7 @@ dependencies:
   - requests >=1.2.3
   - selenium >=3.8
   - scipy
+  - xyzservices
 
   # examples
   - flask >=1.0

--- a/ci/environment-test-3.8.yml
+++ b/ci/environment-test-3.8.yml
@@ -46,6 +46,7 @@ dependencies:
   - requests >=1.2.3
   - selenium >=3.8
   - scipy
+  - xyzservices
 
   # examples
   - flask >=1.0

--- a/ci/environment-test-3.9.yml
+++ b/ci/environment-test-3.9.yml
@@ -46,6 +46,7 @@ dependencies:
   - requests >=1.2.3
   - selenium >=3.8
   - scipy
+  - xyzservices
 
   # examples
   - flask >=1.0

--- a/environment.yml
+++ b/environment.yml
@@ -52,6 +52,7 @@ dependencies:
   - requests >=1.2.3
   - selenium >=3.8
   - scipy
+  - xyzservices
 
   # examples
   - flask >=1.0

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -86,7 +86,8 @@ bokeh_plot_pyfile_include_dirs = ['docs']
 intersphinx_mapping = {
     'python' : ('https://docs.python.org/3/', None),
     'pandas' : ('https://pandas.pydata.org/pandas-docs/stable/', None),
-    'numpy'  : ('https://numpy.org/doc/stable/', None)
+    'numpy'  : ('https://numpy.org/doc/stable/', None),
+    'xyzservices' : ('https://xyzservices.readthedocs.io/en/stable/', None),
 }
 
 napoleon_include_init_with_doc = True

--- a/sphinx/source/docs/user_guide/examples/geo_xyzservices.py
+++ b/sphinx/source/docs/user_guide/examples/geo_xyzservices.py
@@ -1,0 +1,14 @@
+from bokeh.plotting import figure, output_file, show
+from bokeh.tile_providers import get_provider
+import xyzservices.providers as xyz
+
+output_file("xyzservices.html")
+
+tile_provider = get_provider(xyz.OpenStreetMap.Mapnik)
+
+# range bounds supplied in web mercator coordinates
+p = figure(x_range=(-2000000, 6000000), y_range=(-1000000, 7000000),
+           x_axis_type="mercator", y_axis_type="mercator")
+p.add_tile(tile_provider)
+
+show(p)

--- a/sphinx/source/docs/user_guide/examples/geo_xyzservices.py
+++ b/sphinx/source/docs/user_guide/examples/geo_xyzservices.py
@@ -1,8 +1,7 @@
-from bokeh.plotting import figure, output_file, show
-from bokeh.tile_providers import get_provider
 import xyzservices.providers as xyz
 
-output_file("xyzservices.html")
+from bokeh.plotting import figure, show
+from bokeh.tile_providers import get_provider
 
 tile_provider = get_provider(xyz.OpenStreetMap.Mapnik)
 

--- a/sphinx/source/docs/user_guide/geo.rst
+++ b/sphinx/source/docs/user_guide/geo.rst
@@ -12,7 +12,6 @@ Tile provider maps
 
 Bokeh is compatible with several XYZ tile services that use the Web Mercator projection.
 The module :ref:`bokeh.tile_providers` contains several pre-configured tile sources with appropriate attribution.
-Alternatively, you can use any :class:`xyzservices.TileProvider`.
 To add these to a plot, use the method :func:`~bokeh.models.plots.Plot.add_tile`.
 
 .. bokeh-plot:: docs/user_guide/examples/geo_tile_source.py
@@ -21,6 +20,13 @@ To add these to a plot, use the method :func:`~bokeh.models.plots.Plot.add_tile`
 Notice that passing ``x_axis_type="mercator"`` and ``y_axis_type="mercator"``
 to ``figure`` generates axes with latitude and longitude labels, instead of raw Web
 Mercator coordinates.
+
+Alternatively, you can use any :class:`xyzservices.TileProvider`, either pre-defined in
+``xyzservices`` or a custom one.
+
+.. bokeh-plot:: docs/user_guide/examples/geo_xyzservices.py
+    :source-position: below
+
 
 .. _userguide_geo_google_maps:
 

--- a/sphinx/source/docs/user_guide/geo.rst
+++ b/sphinx/source/docs/user_guide/geo.rst
@@ -12,6 +12,7 @@ Tile provider maps
 
 Bokeh is compatible with several XYZ tile services that use the Web Mercator projection.
 The module :ref:`bokeh.tile_providers` contains several pre-configured tile sources with appropriate attribution.
+Alternatively, you can use any :class:`xyzservices.TileProvider`.
 To add these to a plot, use the method :func:`~bokeh.models.plots.Plot.add_tile`.
 
 .. bokeh-plot:: docs/user_guide/examples/geo_tile_source.py

--- a/tests/unit/bokeh/test_tile_providers.py
+++ b/tests/unit/bokeh/test_tile_providers.py
@@ -222,6 +222,15 @@ class Test_GetProvider:
         with pytest.raises(ValueError):
             bt.get_provider("This is not a valid tile vendor")
 
+    def test_xyzservices(self) -> None:
+        xyzservices = pytest.importorskip("xyzservices")
+        provider_data = xyzservices.providers.CartoDB.Positron
+        provider = bt.get_provider(provider_data)
+        assert isinstance(provider, WMTSTileSource)
+        assert provider.url == provider_data.build_url(scale_factor="@2x")
+        assert provider.attribution == provider_data.html_attribution
+        assert provider.min_zoom == provider_data.get("min_zoom", 0)
+        assert provider.max_zoom == provider_data.get("max_zoom", 30)
 
 #-----------------------------------------------------------------------------
 # Dev API


### PR DESCRIPTION
Adding support of `xyzservices.TileProvider` as an input of `get_provider` following the suggestion 1) from #11500.

- [x] issues: xref  #11500 
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
