### PR TITLE
Add note about canvas limitation for Line

### DIFF
--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -767,7 +767,7 @@ class Line(ConnectedXYGlyph, LineGlyph):
 
     .. note::
         Due to limitations in the underlying HTML canvas, it is possible that a
-        line is not drawn when one or more of its coordinates are far outside
+        line is not drawn when one or more of its coordinates is very far outside
         the viewport. This behavior is different for different browsers. See
         `issue #1149 <https://github.com/bokeh/bokeh/issues/11498>`_ for more
         information.

--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -769,8 +769,7 @@ class Line(ConnectedXYGlyph, LineGlyph):
         Due to limitations in the underlying HTML canvas, it is possible that a
         line is not drawn when one or more of its coordinates is very far outside
         the viewport. This behavior is different for different browsers. See
-        `issue #1149 <https://github.com/bokeh/bokeh/issues/11498>`_ for more
-        information.
+        :bokeh-issue:`11498` for more information.
 
     '''
     _args = ('x', 'y')

--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -765,6 +765,13 @@ class Line(ConnectedXYGlyph, LineGlyph):
     The ``Line`` glyph is different from most other glyphs in that the vector
     of values only produces one glyph on the Plot.
 
+    .. note::
+        Due to limitations in the underlying HTML canvas, it is possible that a
+        line is not drawn when one or more of its coordinates are far outside
+        the viewport. This behavior is different for different browsers. See
+        `issue #1149 <https://github.com/bokeh/bokeh/issues/11498>`_ for more
+        information.
+
     '''
     _args = ('x', 'y')
 


### PR DESCRIPTION
This PR adds a note to the docstring of Line about a limitation of HTML canvas with coordinates far outside the viewport.

(partially) fixes #11498