### PR TITLE
Fix simultaneous assignment properties in `FileInput` widget

### DIFF
--- a/bokehjs/src/lib/models/widgets/file_input.ts
+++ b/bokehjs/src/lib/models/widgets/file_input.ts
@@ -49,7 +49,7 @@ export class FileInputView extends WidgetView {
     }
 
     if (this.model.multiple)
-	    this.model.setv({value: values, filename: filenames, mime_type: mime_types})
+      this.model.setv({value: values, filename: filenames, mime_type: mime_types})
     else
       this.model.setv({value: values[0], filename: filenames[0], mime_type: mime_types[0]})
   }

--- a/bokehjs/src/lib/models/widgets/file_input.ts
+++ b/bokehjs/src/lib/models/widgets/file_input.ts
@@ -48,15 +48,10 @@ export class FileInputView extends WidgetView {
       mime_types.push(mime_type)
     }
 
-    if (this.model.multiple) {
-      this.model.value = values
-      this.model.filename = filenames
-      this.model.mime_type = mime_types
-    } else {
-      this.model.value = values[0]
-      this.model.filename = filenames[0]
-      this.model.mime_type = mime_types[0]
-    }
+    if (this.model.multiple)
+	    this.model.setv({value: values, filename: filenames, mime_type: mime_types})
+	  else
+	    this.model.setv({value: values[0], filename: filenames[0], mime_type: mime_types[0]})
   }
 
   protected _read_file(file: File): Promise<string> {

--- a/bokehjs/src/lib/models/widgets/file_input.ts
+++ b/bokehjs/src/lib/models/widgets/file_input.ts
@@ -50,8 +50,8 @@ export class FileInputView extends WidgetView {
 
     if (this.model.multiple)
 	    this.model.setv({value: values, filename: filenames, mime_type: mime_types})
-	  else
-	    this.model.setv({value: values[0], filename: filenames[0], mime_type: mime_types[0]})
+    else
+      this.model.setv({value: values[0], filename: filenames[0], mime_type: mime_types[0]})
   }
 
   protected _read_file(file: File): Promise<string> {

--- a/bokehjs/test/unit/models/widgets/file_input.ts
+++ b/bokehjs/test/unit/models/widgets/file_input.ts
@@ -55,7 +55,7 @@ describe("FileInputView", () => {
 	
     await view.load_files(files)
 
-    expect(model.value).to.be.equal(["foo","bar","baz"])
+    expect(model.value).to.be.equal([btoa("foo"),btoa("bar"),btoa("baz")])
     expect(model.filename).to.be.equal(["foo.txt","bar.txt","baz.txt"])
     expect(model.mime_type).to.be.equal(["text/plain","text/plain","text/plain"])
   })

--- a/bokehjs/test/unit/models/widgets/file_input.ts
+++ b/bokehjs/test/unit/models/widgets/file_input.ts
@@ -44,11 +44,11 @@ describe("FileInputView", () => {
     const view = (await build_view(model)).build()
 
     const getFileList = () => {
-	    const dt = new DataTransfer()
-	    dt.items.add(new File(["foo"], "foo.txt", {type: "text/plain"}))
-	    dt.items.add(new File(["bar"], "bar.txt", {type: "text/plain"}))
-	    dt.items.add(new File(["baz"], "baz.txt", {type: "text/plain"}))
-	    return dt.files
+      const dt = new DataTransfer()
+      dt.items.add(new File(["foo"], "foo.txt", {type: "text/plain"}))
+      dt.items.add(new File(["bar"], "bar.txt", {type: "text/plain"}))
+      dt.items.add(new File(["baz"], "baz.txt", {type: "text/plain"}))
+      return dt.files
     }
 
     const files = getFileList()

--- a/bokehjs/test/unit/models/widgets/file_input.ts
+++ b/bokehjs/test/unit/models/widgets/file_input.ts
@@ -38,4 +38,26 @@ describe("FileInputView", () => {
     expect(model.filename).to.be.equal("foo.txt")
     expect(model.mime_type).to.be.equal("") // XXX: why not "text/plain"?
   })
+
+  it("should allow reading multiple files from a FileList", async () => {
+    const model = new FileInput({accept: ".csv,.json.,.txt", multiple: true})
+    const view = (await build_view(model)).build()
+	
+  const getFileList = () => {
+	  const dt = new DataTransfer();
+	  dt.items.add(new File(["foo"], 'foo.txt', {type: "text/plain"}));
+	  dt.items.add(new File(["bar"], 'bar.txt', {type: "text/plain"}));
+	  dt.items.add(new File(["baz"], 'baz.txt', {type: "text/plain"}));
+	  return dt.files;
+  }
+
+    const files = getFileList()
+	
+    await view.load_files(files)
+
+    expect(model.value).to.be.equal(["foo","bar","baz"])
+    expect(model.filename).to.be.equal(["foo.txt","bar.txt","baz.txt"])
+    expect(model.mime_type).to.be.equal(["text/plain","text/plain","text/plain"])
+  })
+
 })

--- a/bokehjs/test/unit/models/widgets/file_input.ts
+++ b/bokehjs/test/unit/models/widgets/file_input.ts
@@ -42,22 +42,22 @@ describe("FileInputView", () => {
   it("should allow reading multiple files from a FileList", async () => {
     const model = new FileInput({accept: ".csv,.json.,.txt", multiple: true})
     const view = (await build_view(model)).build()
-	
-  const getFileList = () => {
-	  const dt = new DataTransfer();
-	  dt.items.add(new File(["foo"], 'foo.txt', {type: "text/plain"}));
-	  dt.items.add(new File(["bar"], 'bar.txt', {type: "text/plain"}));
-	  dt.items.add(new File(["baz"], 'baz.txt', {type: "text/plain"}));
-	  return dt.files;
-  }
+
+    const getFileList = () => {
+	    const dt = new DataTransfer();
+	    dt.items.add(new File(["foo"], "foo.txt", {type: "text/plain"}))
+	    dt.items.add(new File(["bar"], "bar.txt", {type: "text/plain"}))
+	    dt.items.add(new File(["baz"], "baz.txt", {type: "text/plain"}))
+	    return dt.files
+    }
 
     const files = getFileList()
-	
+
     await view.load_files(files)
 
-    expect(model.value).to.be.equal([btoa("foo"),btoa("bar"),btoa("baz")])
-    expect(model.filename).to.be.equal(["foo.txt","bar.txt","baz.txt"])
-    expect(model.mime_type).to.be.equal(["text/plain","text/plain","text/plain"])
+    expect(model.value).to.be.equal([btoa("foo"), btoa("bar"), btoa("baz")])
+    expect(model.filename).to.be.equal(["foo.txt", "bar.txt", "baz.txt"])
+    expect(model.mime_type).to.be.equal(["text/plain", "text/plain", "text/plain"])
   })
 
 })

--- a/bokehjs/test/unit/models/widgets/file_input.ts
+++ b/bokehjs/test/unit/models/widgets/file_input.ts
@@ -44,7 +44,7 @@ describe("FileInputView", () => {
     const view = (await build_view(model)).build()
 
     const getFileList = () => {
-	    const dt = new DataTransfer();
+	    const dt = new DataTransfer()
 	    dt.items.add(new File(["foo"], "foo.txt", {type: "text/plain"}))
 	    dt.items.add(new File(["bar"], "bar.txt", {type: "text/plain"}))
 	    dt.items.add(new File(["baz"], "baz.txt", {type: "text/plain"}))


### PR DESCRIPTION
**Fix simultanous assignment of filenames, values and mime_types of the FileInput widget**

- [x] issues: fixes #11276
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)

**Visual test:**

```python
from bokeh.models import FileInput, CustomJS, TextInput
from bokeh.io import curdoc
from bokeh.layouts import column

myFileNames = TextInput(value="", title="Number of file names:")
myFileValues = TextInput(value="", title="Number of file values:")

myFileInput = FileInput(accept='.pdf',multiple=True)

myFileInput.js_on_change("value", CustomJS(args=dict(myFileNames=myFileNames, myFileValues=myFileValues), code="""
    // get number of file names
    myFileNames.value = this.filename.length.toString();
    // get number of file values
    myFileValues.value = this.value.length.toString();
"""))

curdoc().add_root(column(myFileInput, myFileNames, myFileValues))
```

Before (v2.3.3):
![FileInput_result_v2 3 3](https://user-images.githubusercontent.com/56967998/129633278-e3cb60d0-a8a6-490c-bb13-22e37cdbbbc9.JPG)

After (v2.4dev):
![FileInput_result_v2 4dev](https://user-images.githubusercontent.com/56967998/129633325-cb09f5c9-ff69-4405-8ebd-77773d3b7e1d.JPG)