### PR TITLE
Allow extensions to modify applications in serve subcommand

### DIFF
--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -742,6 +742,13 @@ class Serve(Subcommand):
         )),
     )
 
+    def customize_applications(self, args: argparse.Namespace, applications: Dict[str, Any]) -> Dict[str, Any]:
+        '''Allows subclasses to customize ``applications``.
+
+        Should modify and return a copy of the ``applications`` dictionary.
+        '''
+        return dict(applications)
+
     def customize_kwargs(self, args: argparse.Namespace, server_kwargs: Dict[str, Any]) -> Dict[str, Any]:
         '''Allows subclasses to customize ``server_kwargs``.
 
@@ -891,6 +898,7 @@ class Serve(Subcommand):
             find_autoreload_targets(args.files[0])
             add_optional_autoreload_files(args.dev)
 
+        applications = self.customize_applications(args, applications)
         server_kwargs = self.customize_kwargs(args, server_kwargs)
 
         with report_server_init_errors(**server_kwargs):


### PR DESCRIPTION
Very simple extension which will allow frameworks which build on Bokeh (e.g. Panel) to extend the `bokeh serve` subcommand by modifying `applications` dictionary in the serve subcommand. I realize this is probably very narrowly useful for Panel in particular but would allow me to avoid various hacks/workarounds to add a monitoring application in `panel serve`.