### PR TITLE
Reassign value on numeric_input high-low change only if needed

### DIFF
--- a/bokehjs/src/lib/models/widgets/numeric_input.ts
+++ b/bokehjs/src/lib/models/widgets/numeric_input.ts
@@ -30,15 +30,15 @@ export class NumericInputView extends InputWidgetView {
       const {value, low, high} = this.model
       if (low != null && high != null)
         assert(low <= high, "Invalid bounds, low must be inferior to high")
-      if (value != null && low != null)
-        this.model.value = Math.max(value, low)
+      if (value != null && low != null && value < low)
+        this.model.value = low
     })
     this.connect(this.model.properties.high.change, () => {
       const {value, low, high} = this.model
       if (low != null && high != null)
         assert(high >= low, "Invalid bounds, high must be superior to low")
-      if (value != null && high != null)
-        this.model.value = Math.min(value, high)
+      if (value != null && high != null && value > high)
+        this.model.value = high
     })
     this.connect(this.model.properties.high.change, () => this.input_el.placeholder = this.model.placeholder)
     this.connect(this.model.properties.disabled.change, () => this.input_el.disabled = this.model.disabled)


### PR DESCRIPTION
Partial fix to suspected socket conflict in `widgets/numeric_inputs.ts` when the JS side assigns `model.value` the at the same time as the Python side.

Currently, `model.value` is reassigned at every `high.change` or `low.change` event, though this isn't necessary if `model.value` is already within those bounds.

This doesn't fully fix the issue because the conflict will arise if `model.value` is indeed _outside_ the new bounds and is correctly re-assigned on the JS side. Perhaps a bounding method on the Python side could help too?

- [X ] issues: partially addresses #11504