### PR TITLE
Misc docs build changes

### DIFF
--- a/bokeh/layouts.py
+++ b/bokeh/layouts.py
@@ -38,23 +38,23 @@ from typing import (
 
 # Bokeh imports
 from .core.enums import Location, LocationType, SizingModeType
-from .models.layouts import (
+from .models import (
     Box,
     Column,
     GridBox,
     LayoutDOM,
+    Plot,
+    ProxyToolbar,
     Row,
     Spacer,
+    ToolbarBox,
     WidgetBox,
 )
-from .models.plots import Plot
-from .models.tools import ProxyToolbar, ToolbarBox
 from .util.dataclasses import dataclass
 from .util.deprecation import deprecated
 
 if TYPE_CHECKING:
-    from .models.tools import Toolbar
-    from .models.widgets import Widget
+    from .models import Toolbar, Widget
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -85,19 +85,19 @@ def row(*children: LayoutDOM | List[LayoutDOM], sizing_mode: SizingModeType | No
     have the same sizing_mode, which is required for complex layouts to work.
 
     Args:
-        children (list of :class:`~bokeh.models.layouts.LayoutDOM` ): A list of instances for
+        children (list of :class:`~bokeh.models.LayoutDOM` ): A list of instances for
             the row. Can be any of the following - |Plot|,
-            :class:`~bokeh.models.widgets.widget.Widget`,
-            :class:`~bokeh.models.layouts.Row`,
-            :class:`~bokeh.models.layouts.Column`,
-            :class:`~bokeh.models.tools.ToolbarBox`,
-            :class:`~bokeh.models.layouts.Spacer`.
+            :class:`~bokeh.models.Widget`,
+            :class:`~bokeh.models.Row`,
+            :class:`~bokeh.models.Column`,
+            :class:`~bokeh.models.ToolbarBox`,
+            :class:`~bokeh.models.Spacer`.
 
         sizing_mode (``"fixed"``, ``"stretch_both"``, ``"scale_width"``, ``"scale_height"``, ``"scale_both"`` ): How
             will the items in the layout resize to fill the available space.
             Default is ``"fixed"``. For more information on the different
-            modes see :attr:`~bokeh.models.layouts.LayoutDOM.sizing_mode`
-            description on :class:`~bokeh.models.layouts.LayoutDOM`.
+            modes see :attr:`~bokeh.models.LayoutDOM.sizing_mode`
+            description on :class:`~bokeh.models.LayoutDOM`.
 
     Returns:
         Row: A row of LayoutDOM objects all with the same sizing_mode.
@@ -121,19 +121,19 @@ def column(*children: LayoutDOM | List[LayoutDOM], sizing_mode: SizingModeType |
     have the same sizing_mode, which is required for complex layouts to work.
 
     Args:
-        children (list of :class:`~bokeh.models.layouts.LayoutDOM` ): A list of instances for
+        children (list of :class:`~bokeh.models.LayoutDOM` ): A list of instances for
             the column. Can be any of the following - |Plot|,
-            :class:`~bokeh.models.widgets.widget.Widget`,
-            :class:`~bokeh.models.layouts.Row`,
-            :class:`~bokeh.models.layouts.Column`,
-            :class:`~bokeh.models.tools.ToolbarBox`,
-            :class:`~bokeh.models.layouts.Spacer`.
+            :class:`~bokeh.models.Widget`,
+            :class:`~bokeh.models.Row`,
+            :class:`~bokeh.models.Column`,
+            :class:`~bokeh.models.ToolbarBox`,
+            :class:`~bokeh.models.Spacer`.
 
         sizing_mode (``"fixed"``, ``"stretch_both"``, ``"scale_width"``, ``"scale_height"``, ``"scale_both"`` ): How
             will the items in the layout resize to fill the available space.
             Default is ``"fixed"``. For more information on the different
-            modes see :attr:`~bokeh.models.layouts.LayoutDOM.sizing_mode`
-            description on :class:`~bokeh.models.layouts.LayoutDOM`.
+            modes see :attr:`~bokeh.models.LayoutDOM.sizing_mode`
+            description on :class:`~bokeh.models.LayoutDOM`.
 
     Returns:
         Column: A column of LayoutDOM objects all with the same sizing_mode.
@@ -152,13 +152,13 @@ def widgetbox(*args: Widget, children: List[Widget] | None = None, sizing_mode: 
     """ Create a column of bokeh widgets with predefined styling.
 
     Args:
-        children (list of :class:`~bokeh.models.widgets.widget.Widget`): A list of widgets.
+        children (list of :class:`~bokeh.models.Widget`): A list of widgets.
 
         sizing_mode (``"fixed"``, ``"stretch_both"``, ``"scale_width"``, ``"scale_height"``, ``"scale_both"`` ): How
             will the items in the layout resize to fill the available space.
             Default is ``"fixed"``. For more information on the different
-            modes see :attr:`~bokeh.models.layouts.LayoutDOM.sizing_mode`
-            description on :class:`~bokeh.models.layouts.LayoutDOM`.
+            modes see :attr:`~bokeh.models.LayoutDOM.sizing_mode`
+            description on :class:`~bokeh.models.LayoutDOM`.
 
     Returns:
         WidgetBox: A column layout of widget instances all with the same ``sizing_mode``.
@@ -178,19 +178,19 @@ def layout(*args: LayoutDOM, children: List[LayoutDOM] | None = None, sizing_mod
     """ Create a grid-based arrangement of Bokeh Layout objects.
 
     Args:
-        children (list of lists of :class:`~bokeh.models.layouts.LayoutDOM` ): A list of lists of instances
+        children (list of lists of :class:`~bokeh.models.LayoutDOM` ): A list of lists of instances
             for a grid layout. Can be any of the following - |Plot|,
-            :class:`~bokeh.models.widgets.widget.Widget`,
-            :class:`~bokeh.models.layouts.Row`,
-            :class:`~bokeh.models.layouts.Column`,
-            :class:`~bokeh.models.tools.ToolbarBox`,
-            :class:`~bokeh.models.layouts.Spacer`.
+            :class:`~bokeh.models.Widget`,
+            :class:`~bokeh.models.Row`,
+            :class:`~bokeh.models.Column`,
+            :class:`~bokeh.models.ToolbarBox`,
+            :class:`~bokeh.models.Spacer`.
 
         sizing_mode (``"fixed"``, ``"stretch_both"``, ``"scale_width"``, ``"scale_height"``, ``"scale_both"`` ): How
             will the items in the layout resize to fill the available space.
             Default is ``"fixed"``. For more information on the different
-            modes see :attr:`~bokeh.models.layouts.LayoutDOM.sizing_mode`
-            description on :class:`~bokeh.models.layouts.LayoutDOM`.
+            modes see :attr:`~bokeh.models.LayoutDOM.sizing_mode`
+            description on :class:`~bokeh.models.LayoutDOM`.
 
     Returns:
         Column: A column of ``Row`` layouts of the children, all with the same sizing_mode.
@@ -237,8 +237,8 @@ def gridplot(
         sizing_mode (``"fixed"``, ``"stretch_both"``, ``"scale_width"``, ``"scale_height"``, ``"scale_both"`` ): How
             will the items in the layout resize to fill the available space.
             Default is ``"fixed"``. For more information on the different
-            modes see :attr:`~bokeh.models.layouts.LayoutDOM.sizing_mode`
-            description on :class:`~bokeh.models.layouts.LayoutDOM`.
+            modes see :attr:`~bokeh.models.LayoutDOM.sizing_mode`
+            description on :class:`~bokeh.models.LayoutDOM`.
 
         toolbar_location (``above``, ``below``, ``left``, ``right`` ): Where the
             toolbar will be located, with respect to the grid. Default is
@@ -254,7 +254,7 @@ def gridplot(
 
         toolbar_options (dict, optional) : A dictionary of options that will be
             used to construct the grid's toolbar (an instance of
-            :class:`~bokeh.models.tools.ToolbarBox`). If none is supplied,
+            :class:`~bokeh.models.ToolbarBox`). If none is supplied,
             ToolbarBox's defaults will be used.
 
         merge_tools (``True``, ``False``): Combine tools from all child plots into

--- a/bokeh/models/markers.py
+++ b/bokeh/models/markers.py
@@ -18,11 +18,6 @@ can be associated with data columns from
     their respective replacements using the
     :class:`~bokeh.models.glyphs.Scatter` glyph.
 
-The full list of markers accessible through this module:
-
-.. toctree::
-   :maxdepth: 2
-
 By definition, all markers accept the following set of properties:
 
 * ``x``, ``y`` position

--- a/bokeh/sphinxext/__init__.py
+++ b/bokeh/sphinxext/__init__.py
@@ -4,3 +4,20 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 # -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# Imports
+# -----------------------------------------------------------------------------
+
+# External imports
+from typing_extensions import TypedDict
+
+# -----------------------------------------------------------------------------
+# Globals and constants
+# ----------------------------------------------------------------------------
+
+class SphinxParallelSpec(TypedDict):
+    parallel_read_safe: bool
+    parallel_write_safe: bool
+
+PARALLEL_SAFE = SphinxParallelSpec(parallel_read_safe=True, parallel_write_safe=True)

--- a/bokeh/sphinxext/_templates/model_detail.rst
+++ b/bokeh/sphinxext/_templates/model_detail.rst
@@ -5,6 +5,7 @@
     :members:
     :show-inheritance:
     :inherited-members:
+    :exclude-members: js_event_callbacks, js_property_callbacks, subscribed_events
 
     .. _{{ name }}.json:
 

--- a/bokeh/sphinxext/bokeh_autodoc.py
+++ b/bokeh/sphinxext/bokeh_autodoc.py
@@ -115,6 +115,11 @@ def setup(app):
     app.add_autodocumenter(PropDocumenter)
     app.add_autodocumenter(ModelDocumenter)
 
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
+
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_autodoc.py
+++ b/bokeh/sphinxext/bokeh_autodoc.py
@@ -39,6 +39,9 @@ from bokeh.core.enums import Enumeration
 from bokeh.core.property.descriptors import PropertyDescriptor
 from bokeh.model import Model
 
+# Bokeh imports
+from . import PARALLEL_SAFE
+
 # -----------------------------------------------------------------------------
 # Globals and constants
 # -----------------------------------------------------------------------------
@@ -115,11 +118,7 @@ def setup(app):
     app.add_autodocumenter(PropDocumenter)
     app.add_autodocumenter(ModelDocumenter)
 
-    return {
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }
-
+    return PARALLEL_SAFE
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_color.py
+++ b/bokeh/sphinxext/bokeh_color.py
@@ -42,6 +42,7 @@ from docutils.parsers.rst.directives import unchanged
 from bokeh.colors import named
 
 # Bokeh imports
+from . import PARALLEL_SAFE
 from .bokeh_directive import BokehDirective
 from .templates import COLOR_DETAIL
 
@@ -83,11 +84,7 @@ def setup(app):
     """ Required Sphinx extension setup function. """
     app.add_directive_to_domain("py", "bokeh-color", BokehColorDirective)
 
-    return {
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }
-
+    return PARALLEL_SAFE
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_color.py
+++ b/bokeh/sphinxext/bokeh_color.py
@@ -83,6 +83,11 @@ def setup(app):
     """ Required Sphinx extension setup function. """
     app.add_directive_to_domain("py", "bokeh-color", BokehColorDirective)
 
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
+
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_dataframe.py
+++ b/bokeh/sphinxext/bokeh_dataframe.py
@@ -42,6 +42,9 @@ import pandas as pd
 from docutils import nodes
 from sphinx.errors import SphinxError
 
+# Bokeh imports
+from . import PARALLEL_SAFE
+
 # -----------------------------------------------------------------------------
 # Globals and constants
 # -----------------------------------------------------------------------------
@@ -93,10 +96,7 @@ def setup(app):
     """ Required Sphinx extension setup function. """
     app.add_role("bokeh-dataframe", bokeh_dataframe)
 
-    return {
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }
+    return PARALLEL_SAFE
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_dataframe.py
+++ b/bokeh/sphinxext/bokeh_dataframe.py
@@ -93,6 +93,10 @@ def setup(app):
     """ Required Sphinx extension setup function. """
     app.add_role("bokeh-dataframe", bokeh_dataframe)
 
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_enum.py
+++ b/bokeh/sphinxext/bokeh_enum.py
@@ -128,6 +128,10 @@ def setup(app):
     """ Required Sphinx extension setup function. """
     app.add_directive_to_domain("py", "bokeh-enum", BokehEnumDirective)
 
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_enum.py
+++ b/bokeh/sphinxext/bokeh_enum.py
@@ -63,6 +63,7 @@ from docutils.parsers.rst.directives import unchanged
 from sphinx.errors import SphinxError
 
 # Bokeh imports
+from . import PARALLEL_SAFE
 from .bokeh_directive import BokehDirective
 from .templates import ENUM_DETAIL
 
@@ -128,10 +129,7 @@ def setup(app):
     """ Required Sphinx extension setup function. """
     app.add_directive_to_domain("py", "bokeh-enum", BokehEnumDirective)
 
-    return {
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }
+    return PARALLEL_SAFE
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_example_metadata.py
+++ b/bokeh/sphinxext/bokeh_example_metadata.py
@@ -95,6 +95,11 @@ def setup(app):
     """ Required Sphinx extension setup function. """
     app.add_directive("bokeh-example-metadata", BokehExampleMetadataDirective)
 
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
+
 # -----------------------------------------------------------------------------
 # Private API
 # -----------------------------------------------------------------------------

--- a/bokeh/sphinxext/bokeh_example_metadata.py
+++ b/bokeh/sphinxext/bokeh_example_metadata.py
@@ -36,6 +36,7 @@ from docutils.parsers.rst.directives import unchanged
 from sphinx.errors import SphinxError
 
 # Bokeh imports
+from . import PARALLEL_SAFE
 from .bokeh_directive import BokehDirective
 from .templates import EXAMPLE_METADATA
 from .util import get_sphinx_resources
@@ -95,10 +96,7 @@ def setup(app):
     """ Required Sphinx extension setup function. """
     app.add_directive("bokeh-example-metadata", BokehExampleMetadataDirective)
 
-    return {
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }
+    return PARALLEL_SAFE
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_gallery.py
+++ b/bokeh/sphinxext/bokeh_gallery.py
@@ -132,6 +132,10 @@ def setup(app):
     app.connect("config-inited", config_inited_handler)
     app.add_directive("bokeh-gallery", BokehGalleryDirective)
 
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_gallery.py
+++ b/bokeh/sphinxext/bokeh_gallery.py
@@ -39,6 +39,7 @@ from sphinx.errors import SphinxError
 from sphinx.util import ensuredir, status_iterator
 
 # Bokeh imports
+from . import PARALLEL_SAFE
 from .bokeh_directive import BokehDirective
 from .templates import GALLERY_DETAIL, GALLERY_PAGE
 
@@ -132,10 +133,7 @@ def setup(app):
     app.connect("config-inited", config_inited_handler)
     app.add_directive("bokeh-gallery", BokehGalleryDirective)
 
-    return {
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }
+    return PARALLEL_SAFE
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_jinja.py
+++ b/bokeh/sphinxext/bokeh_jinja.py
@@ -109,6 +109,10 @@ def setup(app):
     """ Required Sphinx extension setup function. """
     app.add_directive_to_domain("py", "bokeh-jinja", BokehJinjaDirective)
 
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_jinja.py
+++ b/bokeh/sphinxext/bokeh_jinja.py
@@ -45,6 +45,7 @@ from os.path import basename
 from sphinx.errors import SphinxError
 
 # Bokeh imports
+from . import PARALLEL_SAFE
 from .bokeh_directive import BokehDirective
 from .templates import JINJA_DETAIL
 
@@ -109,10 +110,7 @@ def setup(app):
     """ Required Sphinx extension setup function. """
     app.add_directive_to_domain("py", "bokeh-jinja", BokehJinjaDirective)
 
-    return {
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }
+    return PARALLEL_SAFE
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_model.py
+++ b/bokeh/sphinxext/bokeh_model.py
@@ -142,6 +142,10 @@ def setup(app):
     """ Required Sphinx extension setup function. """
     app.add_directive_to_domain("py", "bokeh-model", BokehModelDirective)
 
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_model.py
+++ b/bokeh/sphinxext/bokeh_model.py
@@ -67,6 +67,7 @@ from bokeh.model import Model
 from bokeh.util.warnings import BokehDeprecationWarning
 
 # Bokeh imports
+from . import PARALLEL_SAFE
 from .bokeh_directive import BokehDirective, py_sig_re
 from .templates import MODEL_DETAIL
 
@@ -142,10 +143,7 @@ def setup(app):
     """ Required Sphinx extension setup function. """
     app.add_directive_to_domain("py", "bokeh-model", BokehModelDirective)
 
-    return {
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }
+    return PARALLEL_SAFE
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_model.py
+++ b/bokeh/sphinxext/bokeh_model.py
@@ -131,7 +131,7 @@ class BokehModelDirective(BokehDirective):
 
         rst_text = MODEL_DETAIL.render(
             name=model_name,
-            module_name=module_name,
+            module_name="bokeh.models" if module_name.startswith("bokeh.models") else module_name,
             model_json=model_json,
         )
 

--- a/bokeh/sphinxext/bokeh_options.py
+++ b/bokeh/sphinxext/bokeh_options.py
@@ -63,6 +63,7 @@ from bokeh.core.property._sphinx import type_link
 from bokeh.util.options import Options
 
 # Bokeh imports
+from . import PARALLEL_SAFE
 from .bokeh_directive import BokehDirective, py_sig_re
 from .templates import OPTIONS_DETAIL
 
@@ -136,10 +137,7 @@ def setup(app):
     """ Required Sphinx extension setup function. """
     app.add_directive_to_domain("py", "bokeh-options", BokehOptionsDirective)
 
-    return {
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }
+    return PARALLEL_SAFE
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_options.py
+++ b/bokeh/sphinxext/bokeh_options.py
@@ -136,6 +136,10 @@ def setup(app):
     """ Required Sphinx extension setup function. """
     app.add_directive_to_domain("py", "bokeh-options", BokehOptionsDirective)
 
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_palette.py
+++ b/bokeh/sphinxext/bokeh_palette.py
@@ -66,6 +66,7 @@ from docutils import nodes
 from sphinx.errors import SphinxError
 
 # Bokeh imports
+from . import PARALLEL_SAFE
 from .templates import PALETTE_DETAIL
 
 # -----------------------------------------------------------------------------
@@ -119,10 +120,7 @@ def setup(app):
     """ Required Sphinx extension setup function. """
     app.add_role("bokeh-palette", bokeh_palette)
 
-    return {
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }
+    return PARALLEL_SAFE
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_palette.py
+++ b/bokeh/sphinxext/bokeh_palette.py
@@ -119,6 +119,10 @@ def setup(app):
     """ Required Sphinx extension setup function. """
     app.add_role("bokeh-palette", bokeh_palette)
 
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_palette_group.py
+++ b/bokeh/sphinxext/bokeh_palette_group.py
@@ -109,6 +109,10 @@ def setup(app):
     app.add_node(bokeh_palette_group, html=bokeh_palette_group.html)
     app.add_directive("bokeh-palette-group", BokehPaletteGroupDirective)
 
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_palette_group.py
+++ b/bokeh/sphinxext/bokeh_palette_group.py
@@ -50,6 +50,7 @@ from sphinx.errors import SphinxError
 import bokeh.palettes as bp
 
 # Bokeh imports
+from . import PARALLEL_SAFE
 from .templates import PALETTE_GROUP_DETAIL
 
 # -----------------------------------------------------------------------------
@@ -109,10 +110,7 @@ def setup(app):
     app.add_node(bokeh_palette_group, html=bokeh_palette_group.html)
     app.add_directive("bokeh-palette-group", BokehPaletteGroupDirective)
 
-    return {
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }
+    return PARALLEL_SAFE
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -109,6 +109,7 @@ from bokeh.model import Model
 from bokeh.util.warnings import BokehDeprecationWarning
 
 # Bokeh imports
+from . import PARALLEL_SAFE
 from .bokeh_directive import BokehDirective
 from .example_handler import ExampleHandler
 from .util import get_sphinx_resources
@@ -274,10 +275,7 @@ def setup(app):
     app.connect("build-finished", build_finished)
     app.connect("env-merge-info", env_merge_info)
 
-    return {
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }
+    return PARALLEL_SAFE
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -262,6 +262,8 @@ def build_finished(app, exception):
         except OSError as e:
             raise SphinxError(f"cannot copy local file {file!r}, reason: {e}")
 
+def env_merge_info(app, env, docnames, other):
+    env.bokeh_plot_files |= other.bokeh_plot_files
 
 def setup(app):
     """ Required Sphinx extension setup function. """
@@ -270,7 +272,12 @@ def setup(app):
     app.add_config_value("bokeh_missing_google_api_key_ok", True, "html")
     app.connect("builder-inited", builder_inited)
     app.connect("build-finished", build_finished)
+    app.connect("env-merge-info", env_merge_info)
 
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_prop.py
+++ b/bokeh/sphinxext/bokeh_prop.py
@@ -137,6 +137,10 @@ def setup(app):
     """ Required Sphinx extension setup function. """
     app.add_directive_to_domain("py", "bokeh-prop", BokehPropDirective)
 
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_prop.py
+++ b/bokeh/sphinxext/bokeh_prop.py
@@ -67,6 +67,7 @@ from bokeh.core.property._sphinx import type_link
 from bokeh.util.warnings import BokehDeprecationWarning
 
 # Bokeh imports
+from . import PARALLEL_SAFE
 from .bokeh_directive import BokehDirective
 from .templates import PROP_DETAIL
 
@@ -137,10 +138,7 @@ def setup(app):
     """ Required Sphinx extension setup function. """
     app.add_directive_to_domain("py", "bokeh-prop", BokehPropDirective)
 
-    return {
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }
+    return PARALLEL_SAFE
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_releases.py
+++ b/bokeh/sphinxext/bokeh_releases.py
@@ -107,6 +107,10 @@ def setup(app):
     app.add_directive("bokeh-releases", BokehReleases)
     app.add_node(sri_table, html=sri_table.html)
 
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_releases.py
+++ b/bokeh/sphinxext/bokeh_releases.py
@@ -50,6 +50,7 @@ from bokeh import __version__
 from bokeh.resources import get_sri_hashes_for_version
 
 # Bokeh imports
+from . import PARALLEL_SAFE
 from .bokeh_directive import BokehDirective
 from .templates import SRI_TABLE
 
@@ -107,10 +108,7 @@ def setup(app):
     app.add_directive("bokeh-releases", BokehReleases)
     app.add_node(sri_table, html=sri_table.html)
 
-    return {
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }
+    return PARALLEL_SAFE
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_roles.py
+++ b/bokeh/sphinxext/bokeh_roles.py
@@ -217,6 +217,10 @@ def setup(app):
     app.add_role("bokeh-requires", bokeh_requires)
     app.add_role("bokeh-tree", bokeh_tree)
 
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_roles.py
+++ b/bokeh/sphinxext/bokeh_roles.py
@@ -63,6 +63,9 @@ from os.path import abspath, join, pardir
 from docutils import nodes, utils
 from docutils.parsers.rst.roles import set_classes
 
+# Bokeh imports
+from . import PARALLEL_SAFE
+
 # -----------------------------------------------------------------------------
 # Globals and constants
 # -----------------------------------------------------------------------------
@@ -217,10 +220,7 @@ def setup(app):
     app.add_role("bokeh-requires", bokeh_requires)
     app.add_role("bokeh-tree", bokeh_tree)
 
-    return {
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }
+    return PARALLEL_SAFE
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_settings.py
+++ b/bokeh/sphinxext/bokeh_settings.py
@@ -113,6 +113,10 @@ def setup(app):
     """ Required Sphinx extension setup function. """
     app.add_directive_to_domain("py", "bokeh-settings", BokehSettingsDirective)
 
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_settings.py
+++ b/bokeh/sphinxext/bokeh_settings.py
@@ -43,6 +43,7 @@ from sphinx.errors import SphinxError
 from bokeh.settings import PrioritizedSetting, _Unset
 
 # Bokeh imports
+from . import PARALLEL_SAFE
 from .bokeh_directive import BokehDirective, py_sig_re
 from .templates import SETTINGS_DETAIL
 
@@ -113,10 +114,7 @@ def setup(app):
     """ Required Sphinx extension setup function. """
     app.add_directive_to_domain("py", "bokeh-settings", BokehSettingsDirective)
 
-    return {
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }
+    return PARALLEL_SAFE
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_sitemap.py
+++ b/bokeh/sphinxext/bokeh_sitemap.py
@@ -85,6 +85,10 @@ def setup(app):
     app.connect("build-finished", build_finished)
     app.sitemap_links = set()
 
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokeh_sitemap.py
+++ b/bokeh/sphinxext/bokeh_sitemap.py
@@ -37,6 +37,9 @@ from os.path import join
 from sphinx.errors import SphinxError
 from sphinx.util import status_iterator
 
+# Bokeh imports
+from . import PARALLEL_SAFE
+
 # -----------------------------------------------------------------------------
 # Globals and constants
 # -----------------------------------------------------------------------------
@@ -85,10 +88,7 @@ def setup(app):
     app.connect("build-finished", build_finished)
     app.sitemap_links = set()
 
-    return {
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }
+    return PARALLEL_SAFE
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokehjs_content.py
+++ b/bokeh/sphinxext/bokehjs_content.py
@@ -67,6 +67,7 @@ from sphinx.util import logging, parselinenos
 from sphinx.util.nodes import set_source_info
 
 # Bokeh imports
+from . import PARALLEL_SAFE
 from .templates import (
     BJS_CODEPEN_INIT,
     BJS_EPILOGUE,
@@ -261,10 +262,7 @@ def setup(app):
     app.add_node(bokehjs_content, html=bokehjs_content.html)
     app.add_directive("bokehjs-content", BokehJSContent)
 
-    return {
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }
+    return PARALLEL_SAFE
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/bokehjs_content.py
+++ b/bokeh/sphinxext/bokehjs_content.py
@@ -261,6 +261,10 @@ def setup(app):
     app.add_node(bokehjs_content, html=bokehjs_content.html)
     app.add_directive("bokehjs-content", BokehJSContent)
 
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/collapsible_code_block.py
+++ b/bokeh/sphinxext/collapsible_code_block.py
@@ -57,6 +57,9 @@ from docutils import nodes
 from docutils.parsers.rst.directives import unchanged
 from sphinx.directives.code import CodeBlock
 
+# Bokeh imports
+from . import PARALLEL_SAFE
+
 # -----------------------------------------------------------------------------
 # Globals and constants
 # -----------------------------------------------------------------------------
@@ -117,10 +120,7 @@ def setup(app):
     app.add_node(collapsible_code_block, html=collapsible_code_block.html)
     app.add_directive("collapsible-code-block", CollapsibleCodeBlock)
 
-    return {
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }
+    return PARALLEL_SAFE
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/bokeh/sphinxext/collapsible_code_block.py
+++ b/bokeh/sphinxext/collapsible_code_block.py
@@ -117,6 +117,10 @@ def setup(app):
     app.add_node(collapsible_code_block, html=collapsible_code_block.html)
     app.add_directive("collapsible-code-block", CollapsibleCodeBlock)
 
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
 
 # -----------------------------------------------------------------------------
 # Private API

--- a/sphinx/Makefile
+++ b/sphinx/Makefile
@@ -18,10 +18,11 @@ clean:
 	-rm -rf source/docs/gallery/*
 
 html:
-	sphinx-build -b html -d $(BUILDDIR)/doctrees $(SPHINXOPTS) source -W $(BUILDDIR)/html
-	cp -r ../bokeh/server/static $(BUILDDIR)/html/
-	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+	@start=$$(date +%s) \
+	; sphinx-build -b html -d $(BUILDDIR)/doctrees $(SPHINXOPTS) source -W $(BUILDDIR)/html \
+	&& cp -r ../bokeh/server/static $(BUILDDIR)/html/ \
+	&& echo \
+	&& echo "Build finished in $$(($$(date +%s)-start)) seconds. The HTML pages are in $(BUILDDIR)/html."
 
 serve:
 	python docserver.py

--- a/sphinx/source/docs/reference/layouts.rst
+++ b/sphinx/source/docs/reference/layouts.rst
@@ -3,5 +3,71 @@
 bokeh.layouts
 =============
 
-.. automodule:: bokeh.layouts
-  :members:
+.. We can't use automodule here because of transitive imports of models
+.. from bokeh.models, which therefore need a :noindex: flag added. It would
+.. probably be good to deprecate usage of these models from this location
+
+.. module:: bokeh.layouts
+
+Functions for arranging bokeh layout objects.
+
+.. _bokeh.layouts.column:
+
+column
+------
+
+.. autofunction:: column
+
+.. _bokeh.layouts.grid:
+
+grid
+----
+
+.. autofunction:: grid
+
+.. _bokeh.layouts.gridplot:
+
+gridplot
+--------
+
+.. autofunction:: gridplot
+
+.. _bokeh.layouts.GridSpec:
+
+GridSpec
+--------
+
+.. autoclass:: GridSpec
+    :noindex:
+
+.. _bokeh.layouts.layout:
+
+layout
+------
+
+.. autofunction:: layout
+
+.. _bokeh.layouts.row:
+
+row
+---
+
+.. autofunction:: row
+
+.. _bokeh.layouts.Spacer:
+
+Spacer
+------
+
+.. autoclass:: Spacer
+    :noindex:
+
+.. _bokeh.layouts.widgetbox:
+
+widgetbox
+---------
+
+.. warning::
+    ``widgetbox`` is deprecated. Use ``column`` instead.
+
+.. autofunction:: widgetbox

--- a/sphinx/source/docs/reference/models/annotations.rst
+++ b/sphinx/source/docs/reference/models/annotations.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.annotations:
 
-bokeh.models.annotations
-------------------------
+annotations
+-----------
 
 .. automodule:: bokeh.models.annotations
    :members:

--- a/sphinx/source/docs/reference/models/arrow_heads.rst
+++ b/sphinx/source/docs/reference/models/arrow_heads.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.arrow_heads:
 
-bokeh.models.arrow_heads
-------------------------
+arrow_heads
+-----------
 
 .. automodule:: bokeh.models.arrow_heads
    :members:

--- a/sphinx/source/docs/reference/models/axes.rst
+++ b/sphinx/source/docs/reference/models/axes.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.axes:
 
-bokeh.models.axes
------------------
+axes
+----
 
 .. automodule:: bokeh.models.axes
    :members:

--- a/sphinx/source/docs/reference/models/callbacks.rst
+++ b/sphinx/source/docs/reference/models/callbacks.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.callbacks:
 
-bokeh.models.callbacks
-----------------------
+callbacks
+---------
 
 .. automodule:: bokeh.models.callbacks
    :members:

--- a/sphinx/source/docs/reference/models/expressions.rst
+++ b/sphinx/source/docs/reference/models/expressions.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.expressions:
 
-bokeh.models.expressions
-------------------------
+expressions
+-----------
 
 .. automodule:: bokeh.models.expressions
    :members:

--- a/sphinx/source/docs/reference/models/filters.rst
+++ b/sphinx/source/docs/reference/models/filters.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.filters:
 
-bokeh.models.filters
---------------------
+filters
+-------
 
 .. automodule:: bokeh.models.filters
    :members:

--- a/sphinx/source/docs/reference/models/formatters.rst
+++ b/sphinx/source/docs/reference/models/formatters.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.formatters:
 
-bokeh.models.formatters
------------------------
+formatters
+----------
 
 .. automodule:: bokeh.models.formatters
    :members:

--- a/sphinx/source/docs/reference/models/glyphs.rst
+++ b/sphinx/source/docs/reference/models/glyphs.rst
@@ -1,6 +1,6 @@
 .. _bokeh.models.glyphs:
 
-bokeh.models.glyphs
--------------------
+glyphs
+------
 
 .. automodule:: bokeh.models.glyphs

--- a/sphinx/source/docs/reference/models/graphs.rst
+++ b/sphinx/source/docs/reference/models/graphs.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.graphs:
 
-bokeh.models.graphs
--------------------
+graphs
+------
 
 .. automodule:: bokeh.models.graphs
    :members:

--- a/sphinx/source/docs/reference/models/grids.rst
+++ b/sphinx/source/docs/reference/models/grids.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.grids:
 
-bokeh.models.grids
-------------------
+grids
+-----
 
 .. automodule:: bokeh.models.grids
    :members:

--- a/sphinx/source/docs/reference/models/layouts.rst
+++ b/sphinx/source/docs/reference/models/layouts.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.layouts:
 
-bokeh.models.layouts
---------------------
+layouts
+-------
 
 .. automodule:: bokeh.models.layouts
    :members:

--- a/sphinx/source/docs/reference/models/map_plots.rst
+++ b/sphinx/source/docs/reference/models/map_plots.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.map_plots:
 
-bokeh.models.map_plots
-----------------------
+map_plots
+---------
 
 .. automodule:: bokeh.models.map_plots
    :members:

--- a/sphinx/source/docs/reference/models/mappers.rst
+++ b/sphinx/source/docs/reference/models/mappers.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.mappers:
 
-bokeh.models.mappers
---------------------
+mappers
+-------
 
 .. automodule:: bokeh.models.mappers
    :members:

--- a/sphinx/source/docs/reference/models/markers.rst
+++ b/sphinx/source/docs/reference/models/markers.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.markers:
 
-bokeh.models.markers
---------------------
+markers
+-------
 
 .. automodule:: bokeh.models.markers
 

--- a/sphinx/source/docs/reference/models/plots.rst
+++ b/sphinx/source/docs/reference/models/plots.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models_plots:
 
-bokeh.models.plots
-------------------
+plots
+-----
 
 .. automodule:: bokeh.models.plots
    :members:

--- a/sphinx/source/docs/reference/models/ranges.rst
+++ b/sphinx/source/docs/reference/models/ranges.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.ranges:
 
-bokeh.models.ranges
--------------------
+ranges
+------
 
 .. automodule:: bokeh.models.ranges
    :members:

--- a/sphinx/source/docs/reference/models/renderers.rst
+++ b/sphinx/source/docs/reference/models/renderers.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.renderers:
 
-bokeh.models.renderers
-----------------------
+renderers
+---------
 
 .. automodule:: bokeh.models.renderers
    :members:

--- a/sphinx/source/docs/reference/models/scales.rst
+++ b/sphinx/source/docs/reference/models/scales.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.scales:
 
-bokeh.models.scales
---------------------
+scales
+------
 
 .. automodule:: bokeh.models.scales
    :members:

--- a/sphinx/source/docs/reference/models/selections.rst
+++ b/sphinx/source/docs/reference/models/selections.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.selections:
 
-bokeh.models.selections
------------------------
+selections
+----------
 
 .. automodule:: bokeh.models.selections
    :members:

--- a/sphinx/source/docs/reference/models/sources.rst
+++ b/sphinx/source/docs/reference/models/sources.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.sources:
 
-bokeh.models.sources
---------------------
+sources
+-------
 
 .. automodule:: bokeh.models.sources
    :members:

--- a/sphinx/source/docs/reference/models/text.rst
+++ b/sphinx/source/docs/reference/models/text.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.text:
 
-bokeh.models.text
-----------------------
+text
+----
 
 .. automodule:: bokeh.models.text
    :members:

--- a/sphinx/source/docs/reference/models/textures.rst
+++ b/sphinx/source/docs/reference/models/textures.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.textures:
 
-bokeh.models.textures
----------------------
+textures
+--------
 
 .. automodule:: bokeh.models.textures
    :members:

--- a/sphinx/source/docs/reference/models/tickers.rst
+++ b/sphinx/source/docs/reference/models/tickers.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.tickers:
 
-bokeh.models.tickers
---------------------
+tickers
+-------
 
 .. automodule:: bokeh.models.tickers
    :members:

--- a/sphinx/source/docs/reference/models/tiles.rst
+++ b/sphinx/source/docs/reference/models/tiles.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.tiles:
 
-bokeh.models.tiles
-------------------
+tiles
+-----
 
 .. automodule:: bokeh.models.tiles
    :members:

--- a/sphinx/source/docs/reference/models/tools.rst
+++ b/sphinx/source/docs/reference/models/tools.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.tools:
 
-bokeh.models.tools
-------------------
+tools
+-----
 
 .. automodule:: bokeh.models.tools
    :members:

--- a/sphinx/source/docs/reference/models/transforms.rst
+++ b/sphinx/source/docs/reference/models/transforms.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.transforms:
 
-bokeh.models.transforms
------------------------
+transforms
+----------
 
 .. automodule:: bokeh.models.transforms
    :members:

--- a/sphinx/source/docs/reference/models/widgets.rst
+++ b/sphinx/source/docs/reference/models/widgets.rst
@@ -1,0 +1,20 @@
+.. _bokeh.models.widgets:
+
+widgets
+-------
+
+Display a variety of interactive widgets.
+
+.. note::
+    including widgets in Bokeh output requires that the separate
+    ``bokeh-widgets.js`` is loaded. Most Bokeh output functions will
+    take care of this automatically. For more advanced use-cases, see
+    :ref:`bokeh.resources`.
+
+The full list of wiget categories is below:
+
+.. toctree::
+   :maxdepth: 2
+   :glob:
+
+   widgets/*

--- a/sphinx/source/docs/reference/models/widgets/buttons.rst
+++ b/sphinx/source/docs/reference/models/widgets/buttons.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.widgets.buttons:
 
-bokeh.models.widgets.buttons
-----------------------------
+buttons
+-------
 
 .. automodule:: bokeh.models.widgets.buttons
    :members:

--- a/sphinx/source/docs/reference/models/widgets/groups.rst
+++ b/sphinx/source/docs/reference/models/widgets/groups.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.widgets.groups:
 
-bokeh.models.widgets.groups
----------------------------
+groups
+------
 
 .. automodule:: bokeh.models.widgets.groups
    :members:

--- a/sphinx/source/docs/reference/models/widgets/icons.rst
+++ b/sphinx/source/docs/reference/models/widgets/icons.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.widgets.icons:
 
-bokeh.models.widgets.icons
---------------------------
+icons
+-----
 
 .. automodule:: bokeh.models.widgets.icons
    :members:

--- a/sphinx/source/docs/reference/models/widgets/inputs.rst
+++ b/sphinx/source/docs/reference/models/widgets/inputs.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.widgets.inputs:
 
-bokeh.models.widgets.inputs
----------------------------
+inputs
+------
 
 .. automodule:: bokeh.models.widgets.inputs
    :members:

--- a/sphinx/source/docs/reference/models/widgets/markups.rst
+++ b/sphinx/source/docs/reference/models/widgets/markups.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.widgets.markups:
 
-bokeh.models.widgets.markups
-----------------------------
+markups
+-------
 
 .. automodule:: bokeh.models.widgets.markups
    :members:

--- a/sphinx/source/docs/reference/models/widgets/sliders.rst
+++ b/sphinx/source/docs/reference/models/widgets/sliders.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.widgets.sliders:
 
-bokeh.models.widgets.sliders
-----------------------------
+sliders
+-------
 
 .. automodule:: bokeh.models.widgets.sliders
    :members:

--- a/sphinx/source/docs/reference/models/widgets/tables.rst
+++ b/sphinx/source/docs/reference/models/widgets/tables.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.widgets.tables:
 
-bokeh.models.widgets.tables
----------------------------
+tables
+------
 
 .. automodule:: bokeh.models.widgets.tables
    :members:

--- a/sphinx/source/docs/reference/models/widgets/widget.rst
+++ b/sphinx/source/docs/reference/models/widgets/widget.rst
@@ -1,7 +1,7 @@
 .. _bokeh.models.widgets.widget:
 
-bokeh.models.widgets.widget
----------------------------
+widget
+------
 
 .. automodule:: bokeh.models.widgets.widget
    :members:


### PR DESCRIPTION
* submodule names removed from `bokeh.models` reference guide. They do still show up in some places (e.g. some function params) but this is still an incremental improvement IMO

* parallel builds enabled on OSX and Linux:
  ```
  BOKEH_DOCS_CDN="local" GOOGLE_API_KEY=junk make clean html serve SPHINXOPTS="-v -j auto"
  ```
  Note that sphinx disables parallel entirely on OSX 3.8+ so have to use 3.7 until they fix things on their end.  😞 

  Using this cuts clean build time at least in half on my machine. FYI I am not planning to add to CI, not enough savings to not just use the most conservative build options there. 

* Show the total build time at the end of the build (OSX and linux)

* I also hid these properties on all models: `js_event_callbacks`, `js_property_callbacks`, `subscribed_events` They really ought ot be private and users get the wrong idea that they can be useful to use directly. cc @mattpap 

cc @tcmetzger please try this out and let me know what you think. 
