### PR TITLE
Fix IE/legacy compatibility issues with bokeh 2.4

### DIFF
--- a/bokehjs/src/lib/core/types.ts
+++ b/bokehjs/src/lib/core/types.ts
@@ -49,7 +49,7 @@ export const ScreenArray = Float32Array
 
 export function to_screen(array: Iterable<number>): ScreenArray {
   if (!(array instanceof Float32Array))
-    return new Float32Array(array)
+    return Float32Array.from(array)
   else
     return array
 }

--- a/bokehjs/src/lib/core/util/canvas.ts
+++ b/bokehjs/src/lib/core/util/canvas.ts
@@ -162,7 +162,9 @@ export class CanvasLayer {
       ctx.scale(pixel_ratio, pixel_ratio)
       ctx.translate(0.5, 0.5)
     }
-    this._base_transform = ctx.getTransform()
+    if (typeof ctx.getTransform !== "undefined") { // XXX: remove this line when IE/legacy is dropped
+      this._base_transform = ctx.getTransform()
+    }
     this.clear()
   }
 

--- a/bokehjs/src/lib/core/util/ndarray.ts
+++ b/bokehjs/src/lib/core/util/ndarray.ts
@@ -34,6 +34,17 @@ export class Uint8NDArray extends Uint8Array implements NDArrayType {
     super(seq)
     this.shape = shape ?? (is_NDArray(seq) ? seq.shape : [this.length])
     this.dimension = this.shape.length
+    // TODO: remove this when IE/legacy is dropped
+    if (this[equals] == null) {
+      this[equals] = (that: this, cmp: Comparator): boolean => {
+        return Uint8NDArray.prototype[equals].call(this, that, cmp)
+      }
+    }
+    if (this[serialize] == null) {
+      this[serialize] = (serializer: Serializer): unknown => {
+        return Uint8NDArray.prototype[serialize].call(this, serializer)
+      }
+    }
   }
 
   [equals](that: this, cmp: Comparator): boolean {
@@ -55,6 +66,17 @@ export class Int8NDArray extends Int8Array implements NDArrayType {
     super(seq)
     this.shape = shape ?? (is_NDArray(seq) ? seq.shape : [this.length])
     this.dimension = this.shape.length
+    // TODO: remove this when IE/legacy is dropped
+    if (this[equals] == null) {
+      this[equals] = (that: this, cmp: Comparator): boolean => {
+        return Int8NDArray.prototype[equals].call(this, that, cmp)
+      }
+    }
+    if (this[serialize] == null) {
+      this[serialize] = (serializer: Serializer): unknown => {
+        return Int8NDArray.prototype[serialize].call(this, serializer)
+      }
+    }
   }
 
   [equals](that: this, cmp: Comparator): boolean {
@@ -76,6 +98,17 @@ export class Uint16NDArray extends Uint16Array implements NDArrayType {
     super(seq)
     this.shape = shape ?? (is_NDArray(seq) ? seq.shape : [this.length])
     this.dimension = this.shape.length
+    // TODO: remove this when IE/legacy is dropped
+    if (this[equals] == null) {
+      this[equals] = (that: this, cmp: Comparator): boolean => {
+        return Uint16NDArray.prototype[equals].call(this, that, cmp)
+      }
+    }
+    if (this[serialize] == null) {
+      this[serialize] = (serializer: Serializer): unknown => {
+        return Uint16NDArray.prototype[serialize].call(this, serializer)
+      }
+    }
   }
 
   [equals](that: this, cmp: Comparator): boolean {
@@ -97,6 +130,17 @@ export class Int16NDArray extends Int16Array implements NDArrayType {
     super(seq)
     this.shape = shape ?? (is_NDArray(seq) ? seq.shape : [this.length])
     this.dimension = this.shape.length
+    // TODO: remove this when IE/legacy is dropped
+    if (this[equals] == null) {
+      this[equals] = (that: this, cmp: Comparator): boolean => {
+        return Int16NDArray.prototype[equals].call(this, that, cmp)
+      }
+    }
+    if (this[serialize] == null) {
+      this[serialize] = (serializer: Serializer): unknown => {
+        return Int16NDArray.prototype[serialize].call(this, serializer)
+      }
+    }
   }
 
   [equals](that: this, cmp: Comparator): boolean {
@@ -118,6 +162,17 @@ export class Uint32NDArray extends Uint32Array implements NDArrayType {
     super(seq)
     this.shape = shape ?? (is_NDArray(seq) ? seq.shape : [this.length])
     this.dimension = this.shape.length
+    // TODO: remove this when IE/legacy is dropped
+    if (this[equals] == null) {
+      this[equals] = (that: this, cmp: Comparator): boolean => {
+        return Uint32NDArray.prototype[equals].call(this, that, cmp)
+      }
+    }
+    if (this[serialize] == null) {
+      this[serialize] = (serializer: Serializer): unknown => {
+        return Uint32NDArray.prototype[serialize].call(this, serializer)
+      }
+    }
   }
 
   [equals](that: this, cmp: Comparator): boolean {
@@ -139,6 +194,17 @@ export class Int32NDArray extends Int32Array implements NDArrayType {
     super(seq)
     this.shape = shape ?? (is_NDArray(seq) ? seq.shape : [this.length])
     this.dimension = this.shape.length
+    // TODO: remove this when IE/legacy is dropped
+    if (this[equals] == null) {
+      this[equals] = (that: this, cmp: Comparator): boolean => {
+        return Int32NDArray.prototype[equals].call(this, that, cmp)
+      }
+    }
+    if (this[serialize] == null) {
+      this[serialize] = (serializer: Serializer): unknown => {
+        return Int32NDArray.prototype[serialize].call(this, serializer)
+      }
+    }
   }
 
   [equals](that: this, cmp: Comparator): boolean {
@@ -160,6 +226,17 @@ export class Float32NDArray extends Float32Array implements NDArrayType {
     super(seq)
     this.shape = shape ?? (is_NDArray(seq) ? seq.shape : [this.length])
     this.dimension = this.shape.length
+    // TODO: remove this when IE/legacy is dropped
+    if (this[equals] == null) {
+      this[equals] = (that: this, cmp: Comparator): boolean => {
+        return Float32NDArray.prototype[equals].call(this, that, cmp)
+      }
+    }
+    if (this[serialize] == null) {
+      this[serialize] = (serializer: Serializer): unknown => {
+        return Float32NDArray.prototype[serialize].call(this, serializer)
+      }
+    }
   }
 
   [equals](that: this, cmp: Comparator): boolean {
@@ -181,6 +258,17 @@ export class Float64NDArray extends Float64Array implements NDArrayType {
     super(seq)
     this.shape = shape ?? (is_NDArray(seq) ? seq.shape : [this.length])
     this.dimension = this.shape.length
+    // TODO: remove this when IE/legacy is dropped
+    if (this[equals] == null) {
+      this[equals] = (that: this, cmp: Comparator): boolean => {
+        return Float64NDArray.prototype[equals].call(this, that, cmp)
+      }
+    }
+    if (this[serialize] == null) {
+      this[serialize] = (serializer: Serializer): unknown => {
+        return Float64NDArray.prototype[serialize].call(this, serializer)
+      }
+    }
   }
 
   [equals](that: this, cmp: Comparator): boolean {

--- a/bokehjs/src/lib/core/util/pretty.ts
+++ b/bokehjs/src/lib/core/util/pretty.ts
@@ -1,4 +1,4 @@
-import {isBoolean, isNumber, isString, isArray, isIterable, isObject, isPlainObject} from "./types"
+import {isBoolean, isNumber, isString, isSymbol, isArray, isIterable, isObject, isPlainObject} from "./types"
 import {PlainObject} from "../types"
 import {entries} from "./object"
 
@@ -46,6 +46,8 @@ export class Printer {
       return this.iterable(obj)
     else if (isPlainObject(obj))
       return this.object(obj)
+    else if (isSymbol(obj))
+      return this.symbol(obj)
     else
       return `${obj}`
   }
@@ -67,6 +69,10 @@ export class Printer {
 
   string(val: string): string {
     return `"${val.replace(/'/g, "\\'")}"`  // lgtm [js/incomplete-sanitization]
+  }
+
+  symbol(val: symbol): string {
+    return val.toString()
   }
 
   array(obj: Iterable<unknown>): string {

--- a/bokehjs/src/lib/core/util/types.ts
+++ b/bokehjs/src/lib/core/util/types.ts
@@ -24,10 +24,14 @@ export function isString(obj: unknown): obj is string {
   return toString.call(obj) === "[object String]"
 }
 
-export type Primitive = null | boolean | number | string
+export function isSymbol(obj: unknown): obj is symbol {
+  return typeof obj === "symbol"
+}
+
+export type Primitive = null | boolean | number | string | symbol
 
 export function isPrimitive(obj: unknown): obj is Primitive {
-  return obj === null || isBoolean(obj) || isNumber(obj) || isString(obj)
+  return obj === null || isBoolean(obj) || isNumber(obj) || isString(obj) || isSymbol(obj)
 }
 
 export function isFunction(obj: unknown): obj is Function {

--- a/bokehjs/src/lib/models/glyphs/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/circle.ts
@@ -92,7 +92,7 @@ export class CircleView extends XYGlyphView {
       } else
         this.sradius = to_screen(this.radius)
     } else {
-      const ssize = new ScreenArray(this.size)
+      const ssize = ScreenArray.from(this.size)
       this.sradius = map(ssize, (s) => s/2)
     }
   }

--- a/bokehjs/src/lib/models/widgets/button_group.ts
+++ b/bokehjs/src/lib/models/widgets/button_group.ts
@@ -10,7 +10,9 @@ export abstract class ButtonGroupView extends OrientedControlView {
   override model: ButtonGroup
 
   protected override get default_size(): number | undefined {
-    return this.orientation == "horizontal" ? super.default_size : undefined
+    return this.orientation == "horizontal" ? this.model.default_size : undefined
+    // TODO: restore this when IE/legacy is dropped
+    // return this.orientation == "horizontal" ? super.default_size : undefined
   }
 
   protected _buttons: HTMLElement[]

--- a/bokehjs/src/lib/polyfill.ts
+++ b/bokehjs/src/lib/polyfill.ts
@@ -46,6 +46,28 @@ if (typeof Uint8Array.prototype.fill === "undefined") {
   Float64Array.prototype.fill = fill
 }
 
+import {inplace_map} from "core/util/arrayable"
+
+if (typeof Uint8Array.from === "undefined") {
+  function from(this: any, ctor: any): any {
+    const that = this
+    return function(arrayLike: Iterable<number>, mapfn?: (v: number, k: number) => number, thisArg?: any): any {
+      const arr = new ctor([...arrayLike])
+      if (mapfn != null)
+        inplace_map(arr, (v: number, k) => mapfn.call(thisArg ?? that, v, k))
+      return arr
+    }
+  }
+  Uint8Array.from = from(Uint8Array)
+  Int8Array.from = from(Int8Array)
+  Uint16Array.from = from(Uint16Array)
+  Int16Array.from = from(Int16Array)
+  Uint32Array.from = from(Uint32Array)
+  Int32Array.from = from(Int32Array)
+  Float32Array.from = from(Float32Array)
+  Float64Array.from = from(Float64Array)
+}
+
 if (typeof Array.prototype[Symbol.iterator] === "undefined") {
   function iterator(this: Array<unknown>) {
     let i = 0

--- a/bokehjs/test/unit/core/util/pretty.ts
+++ b/bokehjs/test/unit/core/util/pretty.ts
@@ -19,6 +19,11 @@ describe("core/util/pretty module", () => {
       expect(to_string("a'b'c")).to.be.equal('"a\\\'b\\\'c"')
     })
 
+    it("that supports symbol type", () => {
+      expect(to_string(Symbol())).to.be.equal("Symbol()")
+      expect(to_string(Symbol("a"))).to.be.equal("Symbol(a)")
+    })
+
     it("that supports T[]", () => {
       expect(to_string([])).to.be.equal("[]")
       expect(to_string([1, 2, 3])).to.be.equal("[1, 2, 3]")


### PR DESCRIPTION
TODO:

- [x] undefined reading `default_size`
- [x] cannot convert `Symbol` value to a string
- [x] fix ndarray's ES5 compat layer
- [x] `anscombe` doesn't display circles/scatter

![image](https://user-images.githubusercontent.com/27475/132337524-ea18e34a-069a-422d-aa08-dcf484d283b4.png)

fixes #10391