### PR TITLE
Add version as request argument to extension to avoid browser caching

### DIFF
--- a/bokeh/embed/bundle.py
+++ b/bokeh/embed/bundle.py
@@ -330,10 +330,12 @@ def _bundle_extensions(objs: Sequence[Model | Document], resources: Resources) -
             artifact_path = join(base_dir, normpath(pkg_main))
             artifacts_dir = dirname(artifact_path)
             artifact_name = basename(artifact_path)
-            sha = hashlib.sha256()
-            sha.update(pkg_version.encode())
-            vstring = sha.hexdigest()
-            server_path = f"{name}/{artifact_name}?v={vstring}"
+            server_path = f"{name}/{artifact_name}"
+            if not settings.dev:
+                sha = hashlib.sha256()
+                sha.update(pkg_version.encode())
+                vstring = sha.hexdigest()
+                server_path = f"{server_path}?v={vstring}"
         else:
             for ext in extensions:
                 artifact_path = join(dist_dir, f"{name}{ext}")

--- a/bokeh/embed/bundle.py
+++ b/bokeh/embed/bundle.py
@@ -21,6 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import hashlib
 import json
 from dataclasses import dataclass
 from os.path import (
@@ -329,7 +330,10 @@ def _bundle_extensions(objs: Sequence[Model | Document], resources: Resources) -
             artifact_path = join(base_dir, normpath(pkg_main))
             artifacts_dir = dirname(artifact_path)
             artifact_name = basename(artifact_path)
-            server_path = f"{name}/{artifact_name}"
+            sha = hashlib.sha256()
+            sha.update(pkg_version.encode())
+            vstring = sha.hexdigest()
+            server_path = f"{name}/{artifact_name}?v={vstring}"
         else:
             for ext in extensions:
                 artifact_path = join(dist_dir, f"{name}{ext}")

--- a/tests/unit/bokeh/embed/test_bundle.py
+++ b/tests/unit/bokeh/embed/test_bundle.py
@@ -133,8 +133,10 @@ class Test_bundle_custom_extensions:
         plot = Plot()
         plot.add_layout(LatexLabel())
         bundle = beb.bundle_for_objs_and_resources([plot], "server")
+        version_hash = "6b13789e43e5485634533de16a65d8ba9d34c4c9758588b665805435f80eb115"
         assert len(bundle.js_files) == 2
-        assert bundle.js_files[1] == "http://localhost:5006/static/extensions/latex_label/latex_label.js?v=6b13789e43e5485634533de16a65d8ba9d34c4c9758588b665805435f80eb115"
+        assert (bundle.js_files[1] ==
+                f"http://localhost:5006/static/extensions/latex_label/latex_label.js?v={version_hash}")
 
     def test_with_Server_resources_dev(self) -> None:
         from latex_label import LatexLabel

--- a/tests/unit/bokeh/embed/test_bundle.py
+++ b/tests/unit/bokeh/embed/test_bundle.py
@@ -141,12 +141,14 @@ class Test_bundle_custom_extensions:
         plot = Plot()
         plot.add_layout(LatexLabel())
         try:
+            os.environ['BOKEH_RESOURCES'] = 'server'
             os.environ['BOKEH_DEV'] = 'True'
             bundle = beb.bundle_for_objs_and_resources([plot], "server")
         finally:
             del os.environ['BOKEH_DEV']
+            del os.environ['BOKEH_RESOURCES']
         assert len(bundle.js_files) == 2
-        assert bundle.js_files[1].endswith("latex_label.js")
+        assert bundle.js_files[1] == "http://localhost:5006/static/extensions/latex_label/latex_label.js"
 
 class Test_bundle_ext_package_no_main:
 

--- a/tests/unit/bokeh/embed/test_bundle.py
+++ b/tests/unit/bokeh/embed/test_bundle.py
@@ -134,7 +134,19 @@ class Test_bundle_custom_extensions:
         plot.add_layout(LatexLabel())
         bundle = beb.bundle_for_objs_and_resources([plot], "server")
         assert len(bundle.js_files) == 2
-        assert bundle.js_files[1] == "http://localhost:5006/static/extensions/latex_label/latex_label.js"
+        assert bundle.js_files[1] == "http://localhost:5006/static/extensions/latex_label/latex_label.js?v=6b13789e43e5485634533de16a65d8ba9d34c4c9758588b665805435f80eb115"
+
+    def test_with_Server_resources_dev(self) -> None:
+        from latex_label import LatexLabel
+        plot = Plot()
+        plot.add_layout(LatexLabel())
+        try:
+            os.environ['BOKEH_DEV'] = 'True'
+            bundle = beb.bundle_for_objs_and_resources([plot], "server")
+        finally:
+            del os.environ['BOKEH_DEV']
+        assert len(bundle.js_files) == 2
+        assert bundle.js_files[1].endswith("latex_label.js")
 
 class Test_bundle_ext_package_no_main:
 


### PR DESCRIPTION
Currently only bokeh resources served by the `StaticHandler` get a version hash appended ensuring that they are not cached when the version changes. Here we add an equivalent hash to any bokeh extensions served on the `/static/extensions/` endpoint of the server.

Ideally we would try to use the `StaticHandler.append_version` but that computes a version from the `settings.bokehjsdir()` and the bundling code is currently not structured in a way that makes this straightforward.

- [x] issues: fixes https://github.com/holoviz/panel/issues/2720
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
