### PR TITLE
Better formatting for args lists in docstrings

### DIFF
--- a/sphinx/source/_static/custom.css
+++ b/sphinx/source/_static/custom.css
@@ -333,3 +333,14 @@ img.image-border {
   overflow: hidden;
   background-color: #f1f1f1;
 }
+
+/* WAR for https://github.com/pydata/pydata-sphinx-theme/issues/464 */
+dl.field-list {
+    display: grid;
+    grid-template-columns: unset;
+}
+dt.field-odd, dt.field-even {
+    margin-top: 10px;
+    margin-bottom: 2px;
+    background-color: #eee;
+}


### PR DESCRIPTION
Quick fix for https://github.com/pydata/pydata-sphinx-theme/issues/464


## before

<img width="438" alt="Screen Shot 2021-09-08 at 14 06 28" src="https://user-images.githubusercontent.com/1078448/132585692-0a0702f2-b8b7-4554-a96a-7d51dadb9a97.png">

## after

<img width="448" alt="Screen Shot 2021-09-08 at 14 05 51" src="https://user-images.githubusercontent.com/1078448/132585737-7163c027-e1c6-4453-a63e-c096405bed85.png">
