### PR TITLE
Mathstring conveniences for axis_labels and tick labels

### DIFF
--- a/bokeh/core/property/string.py
+++ b/bokeh/core/property/string.py
@@ -115,28 +115,12 @@ class Base64String(String):
         return value
 
 class MathString(String):
-    """ transforms a string that starts and ends with $ in MathText model,
-    otherwise returns string.
+    """ A string with math TeX/LaTeX delimiters.
 
     Args:
-        value : a string to be converted
-
-    Returns:
-        :class:`~bokeh.models.text.MathText` | string
+        value : a string that contains math
 
     """
-
-    def transform(self, value):
-        from ...models.text import MathText
-        value = super().transform(value)
-
-        if not isinstance(value, str):
-            return value
-
-        if len(value) >= 2 and value[0] == value[-1] == "$":
-            return MathText(text=value[1:-1])
-
-        return value
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/embed/bundle.py
+++ b/bokeh/embed/bundle.py
@@ -412,6 +412,45 @@ def _use_widgets(objs: Sequence[Model | Document]) -> bool:
     from ..models.widgets import Widget
     return _any(objs, lambda obj: isinstance(obj, Widget)) or _ext_use_widgets(objs)
 
+def _is_tex_string(text: str) -> bool:
+    """Whether a string begins and ends with MathJax default delimiters
+
+    Args:
+        text (str): String to check
+
+    Returns:
+        bool: True if string begins and ends with delimiters, False if not
+    """
+    if text.startswith("$$") and text.endswith("$$"):
+        return True
+    elif text.startswith("\\[") and text.endswith("\\]"):
+        return True
+    elif text.startswith("\\(") and text.endswith("\\)"):
+        return True
+    else:
+        return False
+
+def _model_requires_mathjax(model: Model) -> bool:
+    """Whether a model requires MathJax to be loaded
+
+    Args:
+        model (Model): Model to check
+
+    Returns:
+        bool: True if MathJax required, False if not
+    """
+    from ..models.axes import Axis
+
+    if isinstance(model, Axis):
+        if isinstance(model.axis_label, str) and _is_tex_string(model.axis_label):
+            return True
+
+        for val in model.major_label_overrides.values():
+            if isinstance(val, str) and _is_tex_string(val):
+                return True
+
+    return False
+
 def _use_mathjax(objs: Sequence[Model | Document]) -> bool:
     ''' Whether a collection of Bokeh objects contains a model requesting MathJax
     Args:
@@ -420,33 +459,7 @@ def _use_mathjax(objs: Sequence[Model | Document]) -> bool:
         bool
     '''
     from ..models.text import MathText
-
-    def model_requires_mathjax(model: Model) -> bool:
-        from ..models.axes import Axis
-
-        def is_tex_string(text: str) -> bool:
-            if text.startswith("$$") and text.endswith("$$"):
-                return True
-
-            elif text.startswith("\\[") and text.endswith("\\]"):
-                return True
-
-            elif text.startswith("\\(") and text.endswith("\\)"):
-                return True
-
-            return False
-
-        if isinstance(model, Axis):
-            if isinstance(model.axis_label, str) and is_tex_string(model.axis_label):
-                return True
-
-            for val in model.major_label_overrides.values():
-                if isinstance(val, str) and is_tex_string(val):
-                    return True
-
-        return False
-
-    return _any(objs, lambda obj: isinstance(obj, MathText) or model_requires_mathjax(obj)) or _ext_use_mathjax(objs)
+    return _any(objs, lambda obj: isinstance(obj, MathText) or _model_requires_mathjax(obj)) or _ext_use_mathjax(objs)
 
 def _use_gl(objs: Sequence[Model | Document]) -> bool:
     ''' Whether a collection of Bokeh objects contains a plot requesting WebGL

--- a/bokeh/models/text.py
+++ b/bokeh/models/text.py
@@ -22,7 +22,6 @@ log = logging.getLogger(__name__)
 # Bokeh imports
 from ..core.has_props import abstract
 from ..core.properties import (
-    Bool,
     Dict,
     Either,
     Int,
@@ -72,12 +71,12 @@ class MathText(BaseText):
 
 class Ascii(MathText):
     """
-    Render mathematical content using `AsciiMath <http://asciimath.org/>` notation.
+    Render mathematical content using `AsciiMath <http://asciimath.org/>`_ notation.
     """
 
 class MathML(MathText):
     """
-    Render mathematical content using `MathML <https://www.w3.org/Math/>` notation.
+    Render mathematical content using `MathML <https://www.w3.org/Math/>`_ notation.
     """
 
 class TeX(MathText):

--- a/bokeh/models/text.py
+++ b/bokeh/models/text.py
@@ -22,6 +22,7 @@ log = logging.getLogger(__name__)
 # Bokeh imports
 from ..core.has_props import abstract
 from ..core.properties import (
+    Bool,
     Dict,
     Either,
     Int,
@@ -105,6 +106,11 @@ class TeX(MathText):
     .. code-block:: python
 
         TeX(text=r"\\R \\rightarrow \\R^2", macros={"RR": r"{\\bf R}"})
+
+    """)
+
+    inline = Bool(default=True, help="""
+    A boolean specifying whether the math is in display-mode or not (for TeX input). Default is true.
 
     """)
 

--- a/bokeh/models/text.py
+++ b/bokeh/models/text.py
@@ -109,11 +109,6 @@ class TeX(MathText):
 
     """)
 
-    inline = Bool(default=True, help="""
-    A boolean specifying whether the math is in display-mode or not (for TeX input). Default is true.
-
-    """)
-
 class PlainText(BaseText):
     """
     Represents plain text in contexts where text parsing is allowed.

--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -443,7 +443,7 @@ export class AxisView extends GuideRendererView {
     const {major_label_overrides} = this.model
     for (let i = 0; i < ticks.length; i++) {
       const override = major_label_overrides[ticks[i]]
-      if (override != null)  {
+      if (override != null) {
         const text = isString(override) ? override : override.text
 
         labels[i] = override instanceof MathText
@@ -451,6 +451,14 @@ export class AxisView extends GuideRendererView {
           : new TextBox({text})
       }
     }
+
+    Object.keys(this.major_label_math_text_views).forEach(key => {
+      if (!ticks.map(tick => tick.toString()).includes(key)) {
+        this.major_label_math_text_views[key].remove()
+        delete this.major_label_math_text_views[key]
+      }
+    })
+
     return new GraphicsBoxes(labels)
   }
 

--- a/bokehjs/src/lib/models/text/utils.ts
+++ b/bokehjs/src/lib/models/text/utils.ts
@@ -1,0 +1,31 @@
+import {isString} from "core/util/types"
+import {TeX} from "models/text/index"
+import {BaseText} from "./base_text"
+
+export function is_tex_string(text: unknown): text is string {
+  if (!isString(text)) return false
+
+  if (text.startsWith("$$") && text.endsWith("$$"))
+    return true
+
+  else if (text.startsWith("\\[") && text.endsWith("\\]"))
+    return true
+
+  else if (text.startsWith("\\(") && text.endsWith("\\)"))
+    return true
+
+  return false
+};
+
+export function tex_from_text_like(text: string | BaseText): TeX | null {
+  let math_text: TeX = new TeX()
+
+  if (text instanceof TeX)
+    math_text = text
+  else if (is_tex_string(text))
+    math_text.text = text.slice(2, -2)
+  else
+    return null
+
+  return math_text
+}

--- a/bokehjs/src/lib/models/text/utils.ts
+++ b/bokehjs/src/lib/models/text/utils.ts
@@ -2,7 +2,7 @@ import {isString} from "core/util/types"
 import {TeX} from "models/text/index"
 import {BaseText} from "./base_text"
 
-export function is_tex_string(text: unknown): text is string {
+export function is_tex_string(text: unknown): boolean {
   if (!isString(text)) return false
 
   if (text.startsWith("$$") && text.endsWith("$$"))
@@ -18,14 +18,11 @@ export function is_tex_string(text: unknown): text is string {
 };
 
 export function tex_from_text_like(text: string | BaseText): TeX | null {
-  let math_text: TeX = new TeX()
-
   if (text instanceof TeX)
-    math_text = text
-  else if (is_tex_string(text))
-    math_text.text = text.slice(2, -2)
-  else
-    return null
+    return text
 
-  return math_text
+  if (isString(text) && is_tex_string(text))
+    return new TeX({text: text.slice(2, -2)})
+
+  return null
 }

--- a/bokehjs/test/unit/models/axes/axis.ts
+++ b/bokehjs/test/unit/models/axes/axis.ts
@@ -45,7 +45,7 @@ describe("Axis", () => {
     const axis = new Axis({
       ticker,
       formatter,
-      major_label_overrides: {0: "zero", 4: new TeX({text: "\\pi"}), 10: "ten"},
+      major_label_overrides: {0: "zero", 4: new TeX({text: "\\pi"}), 10: "$ten$"},
     })
     plot.add_layout(axis, "below")
     const plot_view = (await build_view(plot)).build()
@@ -54,6 +54,24 @@ describe("Axis", () => {
     const labels = axis_view.compute_labels([0, 2, 4, 6, 8, 10])
     await display(plot)
     expect(labels.items.map((l) => (l as TextBox).text)).to.be.equal(["zero", "2", "\\pi", "6", "8", "ten"])
+    expect(labels.items.filter(l => l instanceof TeX).length).to.be.equal(2)
+  })
+
+  it("should convert mathstrings on axis labels to TeX", async () => {
+    const plot = new Plot({
+      x_range: new Range1d({start: 0, end: 10}),
+      y_range: new Range1d({start: 0, end: 10}),
+    })
+    const ticker = new BasicTicker()
+    const formatter = new BasicTickFormatter()
+    const axis = new Axis({
+      ticker,
+      formatter,
+      axis_label: "$$\\sin(x)$$"
+    })
+    plot.add_layout(axis, "below")
+    const plot_view = (await build_view(plot)).build()
+    expect(plot_view.axis_views.some(axis_view => axis_view.model.axis_label instanceof TeX)).to.be.true
   })
 
   it("loc should return numeric fixed_location", async () => {

--- a/bokehjs/test/unit/models/axes/axis.ts
+++ b/bokehjs/test/unit/models/axes/axis.ts
@@ -10,8 +10,7 @@ import {CategoricalScale} from "@bokehjs/models/scales/categorical_scale"
 import {Toolbar} from "@bokehjs/models/tools/toolbar"
 import {build_view} from "@bokehjs/core/build_views"
 import {TextBox} from "@bokehjs/core/graphics"
-import {TeX} from "@bokehjs/models/text"
-import {display} from "../../../framework"
+import {TeXView, TeX} from "@bokehjs/models/text/math_text"
 
 describe("Axis", () => {
 
@@ -45,33 +44,37 @@ describe("Axis", () => {
     const axis = new Axis({
       ticker,
       formatter,
-      major_label_overrides: {0: "zero", 4: new TeX({text: "\\pi"}), 10: "$ten$"},
+      major_label_overrides: {0: "zero", 4: new TeX({text: "\\pi"}), 10: "$$ten$$"},
     })
     plot.add_layout(axis, "below")
     const plot_view = (await build_view(plot)).build()
     const axis_view = plot_view.renderer_view(axis)!
 
     const labels = axis_view.compute_labels([0, 2, 4, 6, 8, 10])
-    await display(plot)
+
     expect(labels.items.map((l) => (l as TextBox).text)).to.be.equal(["zero", "2", "\\pi", "6", "8", "ten"])
-    expect(labels.items.filter(l => l instanceof TeX).length).to.be.equal(2)
+    expect(labels.items.filter(l => l instanceof TeXView).length).to.be.equal(2)
   })
 
   it("should convert mathstrings on axis labels to TeX", async () => {
-    const plot = new Plot({
-      x_range: new Range1d({start: 0, end: 10}),
-      y_range: new Range1d({start: 0, end: 10}),
-    })
     const ticker = new BasicTicker()
     const formatter = new BasicTickFormatter()
     const axis = new Axis({
       ticker,
       formatter,
-      axis_label: "$$\\sin(x)$$"
+      axis_label: "$$\\sin(x)$$",
+    })
+
+    const plot = new Plot({
+      x_range: new Range1d({start: 0, end: 10}),
+      y_range: new Range1d({start: 0, end: 10}),
     })
     plot.add_layout(axis, "below")
+
     const plot_view = (await build_view(plot)).build()
-    expect(plot_view.axis_views.some(axis_view => axis_view.model.axis_label instanceof TeX)).to.be.true
+    const axis_view = plot_view.renderer_view(axis)!
+
+    expect(axis_view.model.axis_label instanceof TeX).to.be.true
   })
 
   it("loc should return numeric fixed_location", async () => {

--- a/tests/unit/bokeh/embed/test_bundle.py
+++ b/tests/unit/bokeh/embed/test_bundle.py
@@ -67,6 +67,30 @@ def test_mathtext() -> None:
     test_mathtext = TeX()
     return test_mathtext
 
+@pytest.fixture
+def test_mathstring_axis_label() -> None:
+    from bokeh.models import LinearAxis
+    test_mathstring = LinearAxis(axis_label = "$$sin(x)$$")
+    return test_mathstring
+
+@pytest.fixture
+def test_mathstring_axis_label_with_parenthesis() -> None:
+    from bokeh.models import LinearAxis
+    test_mathstring = LinearAxis(axis_label = r"\(sin(x)\)")
+    return test_mathstring
+
+@pytest.fixture
+def test_mathstring_major_label_overrides() -> None:
+    from bokeh.models import LinearAxis
+    test_mathstring = LinearAxis(major_label_overrides = {0: r"\[sin(x)\]"})
+    return test_mathstring
+
+@pytest.fixture
+def test_plaintext() -> None:
+    from bokeh.models import PlainText
+    test_plaintext = PlainText("$$sin(x)$$")
+    return test_plaintext
+
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
@@ -288,12 +312,13 @@ class Test__use_mathjax:
         d.add_root(test_widget)
         assert beb._use_mathjax([d]) is False
 
-    def test_with_mathjax(self, test_plot, test_glplot, test_table, test_widget, test_mathtext) -> None:
+    def test_with_mathjax(self, test_plot, test_glplot, test_table, test_widget, test_mathtext, test_plaintext) -> None:
         assert beb._use_mathjax([test_mathtext]) is True
         assert beb._use_mathjax([test_plot, test_mathtext]) is True
         assert beb._use_mathjax([test_plot, test_glplot, test_mathtext]) is True
         assert beb._use_mathjax([test_plot, test_widget, test_mathtext]) is True
         assert beb._use_mathjax([test_plot, test_widget, test_table, test_mathtext]) is True
+        assert beb._use_mathjax([test_plot, test_plaintext, test_mathtext]) is True
         d = Document()
         d.add_root(test_plot)
         d.add_root(test_table)
@@ -301,6 +326,34 @@ class Test__use_mathjax:
         d.add_root(test_mathtext)
         assert beb._use_mathjax([d]) is True
 
+    def test_with_mathstring(self, test_plot, test_glplot, test_table, test_widget, test_mathtext, test_mathstring_axis_label, test_mathstring_major_label_overrides) -> None:
+        assert beb._use_mathjax([test_mathstring_axis_label]) is True
+        assert beb._use_mathjax([test_plot, test_mathstring_axis_label]) is True
+        assert beb._use_mathjax([test_plot, test_glplot, test_mathstring_axis_label]) is True
+        assert beb._use_mathjax([test_plot, test_widget, test_mathstring_axis_label]) is True
+        assert beb._use_mathjax([test_plot, test_widget, test_table, test_mathstring_axis_label]) is True
+        assert beb._use_mathjax([test_plot, test_mathtext, test_mathstring_axis_label]) is True
+        assert beb._use_mathjax([test_plot, test_mathstring_major_label_overrides]) is True
+        d = Document()
+        d.add_root(test_plot)
+        d.add_root(test_table)
+        d.add_root(test_widget)
+        d.add_root(test_mathstring_axis_label)
+        assert beb._use_mathjax([d]) is True
+
+    def test_with_plaintext(self, test_plot, test_glplot, test_table, test_widget, test_mathtext, test_plaintext) -> None:
+        assert beb._use_mathjax([test_plaintext]) is False
+        assert beb._use_mathjax([test_plot, test_plaintext]) is False
+        assert beb._use_mathjax([test_plot, test_glplot, test_plaintext]) is False
+        assert beb._use_mathjax([test_plot, test_widget, test_plaintext]) is False
+        assert beb._use_mathjax([test_plot, test_widget, test_table, test_plaintext]) is False
+        assert beb._use_mathjax([test_plot, test_mathtext, test_plaintext]) is True
+        d = Document()
+        d.add_root(test_plot)
+        d.add_root(test_table)
+        d.add_root(test_widget)
+        d.add_root(test_plaintext)
+        assert beb._use_mathjax([d]) is False
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/embed/test_bundle.py
+++ b/tests/unit/bokeh/embed/test_bundle.py
@@ -326,7 +326,8 @@ class Test__use_mathjax:
         d.add_root(test_mathtext)
         assert beb._use_mathjax([d]) is True
 
-    def test_with_mathstring(self, test_plot, test_glplot, test_table, test_widget, test_mathtext, test_mathstring_axis_label, test_mathstring_major_label_overrides) -> None:
+    def test_with_mathstring(self, test_plot, test_glplot, test_table, test_widget, test_mathtext,
+            test_mathstring_axis_label, test_mathstring_major_label_overrides) -> None:
         assert beb._use_mathjax([test_mathstring_axis_label]) is True
         assert beb._use_mathjax([test_plot, test_mathstring_axis_label]) is True
         assert beb._use_mathjax([test_plot, test_glplot, test_mathstring_axis_label]) is True

--- a/tests/unit/bokeh/models/test_axes.py
+++ b/tests/unit/bokeh/models/test_axes.py
@@ -45,10 +45,10 @@ def test_ticker_accepts_number_sequences() -> None:
     assert isinstance(a.ticker, FixedTicker)
     assert a.ticker.ticks == [-10, 0, 10, 20.7]
 
-def test_axis_label_accepts_math_text_with_dollar_signs_and_no_declaration() -> None:
+def test_axis_label_with_delimiters_do_not_convert_to_math_text_model() -> None:
     a = bma.Axis(axis_label=r"$\sin(x+1)$")
-    assert isinstance(a.axis_label, MathText)
-    assert a.axis_label.text == r"\sin(x+1)"
+    assert isinstance(a.axis_label, str)
+    assert a.axis_label == r"\sin(x+1)"
 
 def test_axis_label_accepts_math_text_with_declaration() -> None:
     a = bma.Axis(axis_label=TeX(text=r"\sin(x+2)"))

--- a/tests/unit/bokeh/models/test_axes.py
+++ b/tests/unit/bokeh/models/test_axes.py
@@ -46,9 +46,9 @@ def test_ticker_accepts_number_sequences() -> None:
     assert a.ticker.ticks == [-10, 0, 10, 20.7]
 
 def test_axis_label_with_delimiters_do_not_convert_to_math_text_model() -> None:
-    a = bma.Axis(axis_label=r"$\sin(x+1)$")
+    a = bma.Axis(axis_label=r"$$\sin(x+1)$$")
     assert isinstance(a.axis_label, str)
-    assert a.axis_label == r"\sin(x+1)"
+    assert a.axis_label == r"$$\sin(x+1)$$"
 
 def test_axis_label_accepts_math_text_with_declaration() -> None:
     a = bma.Axis(axis_label=TeX(text=r"\sin(x+2)"))


### PR DESCRIPTION
Strings with MathJax default TeX delimiters are now converted into TeX object.
Bokeh's bundler will check for those delimiters and include `bokeh-mathjax`.

- [x] issues: relates #11395
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

Discussion on bundler and finding mathstrings #11589 