### PR TITLE
Allow data models to inherit from non data models

### DIFF
--- a/bokeh/core/has_props.py
+++ b/bokeh/core/has_props.py
@@ -728,7 +728,7 @@ KindRef = Any # TODO
 
 class _PropertyDef(TypedDict):
     name: str
-    kind: KindRef | None
+    kind: KindRef
 
 class PropertyDef(_PropertyDef, total=False):
     default: Unknown
@@ -743,8 +743,8 @@ class ModelRef(TypedDict):
 
 class ModelDef(ModelRef):
     extends: ModelRef
-    properties: List[PropertyDef] | None
-    overrides: List[OverrideDef] | None
+    properties: List[PropertyDef]
+    overrides: List[OverrideDef]
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/bokehjs/src/lib/base.ts
+++ b/bokehjs/src/lib/base.ts
@@ -64,6 +64,7 @@ export class ModelResolver {
   protected _known_models: Map<string, typeof HasProps> = new Map()
 
   get(name: string): typeof HasProps
+  get<M extends typeof HasProps, T>(name: string, or_else: T): M | T
   get<T>(name: string, or_else: T): (typeof HasProps) | T
 
   get<T>(name: string, or_else?: T): (typeof HasProps) | T {

--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -68,8 +68,8 @@ export abstract class HasProps extends Signalable() implements Equatable, Printa
     return __module__ != null ? `${__module__}.${__name__}` : __name__
   }
 
-  static get [Symbol.toStringTag](): string {
-    return this.__name__
+  get [Symbol.toStringTag](): string {
+    return this.constructor.__name__
   }
 
   static {

--- a/bokehjs/src/lib/core/util/cloneable.ts
+++ b/bokehjs/src/lib/core/util/cloneable.ts
@@ -1,5 +1,5 @@
 import {entries} from "./object"
-import {isPlainObject, isObject, isArray, isBoolean, isNumber, isString} from "./types"
+import {isPrimitive, isPlainObject, isObject, isArray} from "./types"
 
 export type CloneableType =
   | null
@@ -9,8 +9,8 @@ export type CloneableType =
   | Cloneable
   | CloneableType[]
   | {[key: string]: CloneableType}
-  //| Map<CloneableType, CloneableType>
-  //| Set<CloneableType>
+  | Map<CloneableType, CloneableType>
+  | Set<CloneableType>
 
 export const clone = Symbol("clone")
 
@@ -31,9 +31,11 @@ export class Cloner {
   clone(obj: unknown): unknown
 
   clone(obj: unknown): unknown {
-    if (is_Cloneable(obj))
+    if (is_Cloneable(obj)) {
       return obj[clone](this)
-    else if (isArray(obj)) {
+    } else if (isPrimitive(obj)) {
+      return obj
+    } else if (isArray(obj)) {
       const n = obj.length
       const result: unknown[] = new Array(n)
       for (let i = 0; i < n; i++) {
@@ -47,8 +49,10 @@ export class Cloner {
         result[key] = this.clone(value)
       }
       return result
-    } else if (obj === null || isBoolean(obj) || isNumber(obj) || isString(obj)) {
-      return obj
+    } else if (obj instanceof Map) {
+      return new Map([...obj].map(([k, v]) => [this.clone(k), this.clone(v)]))
+    } else if (obj instanceof Set) {
+      return new Set([...obj].map((v) => this.clone(v)))
     } else
       throw new CloningError(`${Object.prototype.toString.call(obj)} is not cloneable`)
   }

--- a/bokehjs/src/lib/document/defs.ts
+++ b/bokehjs/src/lib/document/defs.ts
@@ -32,7 +32,7 @@ export type KindRef =
 
 export type PropertyDef = {
   name: string
-  kind?: KindRef
+  kind: KindRef
   default?: unknown
 }
 

--- a/bokehjs/src/lib/document/defs.ts
+++ b/bokehjs/src/lib/document/defs.ts
@@ -19,6 +19,7 @@ export type PrimitiveKindRef = "Any" | "Unknown" | "Boolean" | "Number" | "Int" 
 
 export type KindRef =
   PrimitiveKindRef |
+  ["Regex", string, string?] |
   ["Nullable", KindRef] |
   ["Or", ...KindRef[]] |
   ["Tuple", KindRef, ...KindRef[]] |
@@ -59,6 +60,10 @@ export function resolve_defs(defs: ModelDef[], resolver: ModelResolver): void {
       }
     } else {
       switch (ref[0]) {
+        case "Regex": {
+          const [, regex, flags] = ref
+          return kinds.Regex(new RegExp(regex, flags))
+        }
         case "Nullable": {
           const [, subref] = ref
           return kinds.Nullable(kind_of(subref))

--- a/bokehjs/test/unit/core/has_props.ts
+++ b/bokehjs/test/unit/core/has_props.ts
@@ -116,4 +116,12 @@ describe("core/has_props module", () => {
       expect(struct.subtype).to.be.equal("bar")
     })
   })
+
+  it("implements HasProps[toStringTag] method", () => {
+    const obj0 = new SubclassWithProps()
+    const obj1 = new SubSubclassWithProps()
+
+    expect(Object.prototype.toString.call(obj0)).to.be.equal("[object SubclassWithProps]")
+    expect(Object.prototype.toString.call(obj1)).to.be.equal("[object SubSubclassWithProps]")
+  })
 })

--- a/bokehjs/test/unit/core/util/cloneable.ts
+++ b/bokehjs/test/unit/core/util/cloneable.ts
@@ -96,6 +96,42 @@ describe("core/util/cloneable module", () => {
       expect(r2.k1).to.not.be.identical(v2.k1)
     })
 
+    it("that supports native Map objects", () => {
+      const v0 = new Map([[[1], ["a"]], [[1, 2], ["a", "b"]]])
+      const r0 = copy(v0)
+
+      // TODO: distinguish between ref-value and pure-value equality
+      // expect(r0).to.be.equal(v0)
+      expect(r0).to.not.be.identical(v0)
+
+      expect([...r0.keys()][0]).to.be.equal([...v0.keys()][0])
+      expect([...r0.keys()][1]).to.be.equal([...v0.keys()][1])
+
+      expect([...r0.keys()][0]).to.not.be.identical([...v0.keys()][0])
+      expect([...r0.keys()][1]).to.not.be.identical([...v0.keys()][1])
+
+      expect([...r0.values()][0]).to.be.equal([...v0.values()][0])
+      expect([...r0.values()][1]).to.be.equal([...v0.values()][1])
+
+      expect([...r0.values()][0]).to.not.be.identical([...v0.values()][0])
+      expect([...r0.values()][1]).to.not.be.identical([...v0.values()][1])
+    })
+
+    it("that supports native Set objects", () => {
+      const v0 = new Set([[1, 2], ["a", "b"]])
+      const r0 = copy(v0)
+
+      // TODO: distinguish between ref-value and pure-value equality
+      // expect(r0).to.be.equal(v0)
+      expect(r0).to.not.be.identical(v0)
+
+      expect([...r0][0]).to.be.equal([...v0][0])
+      expect([...r0][1]).to.be.equal([...v0][1])
+
+      expect([...r0][0]).to.not.be.identical([...v0][0])
+      expect([...r0][1]).to.not.be.identical([...v0][1])
+    })
+
     it("that supports objects implementing Cloneable interface", () => {
       class Some implements Cloneable, Equatable {
         constructor(readonly value: number[]) {}

--- a/bokehjs/test/unit/document/defs.ts
+++ b/bokehjs/test/unit/document/defs.ts
@@ -1,0 +1,295 @@
+import {expect} from "assertions"
+
+import {resolve_defs, ModelDef} from "@bokehjs/document/defs"
+import {ModelResolver} from "@bokehjs/base"
+import {Model} from "@bokehjs/model"
+import * as p from "@bokehjs/core/properties"
+import {assert} from "@bokehjs/core/util/assert"
+import {ColumnDataSource} from "@bokehjs/models"
+
+type int = number
+
+declare namespace _Some0 {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = Model.Props & {
+    prop0: p.Property<any>
+    prop1: p.Property<unknown>
+    prop2: p.Property<boolean>
+    prop3: p.Property<number>
+    prop4: p.Property<int>
+    prop5: p.Property<string>
+    prop6: p.Property<null>
+  }
+}
+
+declare interface _Some0 extends _Some0.Attrs {}
+
+declare class _Some0 extends Model {
+  override properties: _Some0.Props
+  constructor(attrs?: Partial<_Some0.Attrs>)
+}
+
+declare namespace _Some1 {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = Model.Props & {
+    prop0: p.Property<string>
+    prop1: p.Property<int | null>
+    prop2: p.Property<int | string>
+    prop3: p.Property<[int, string]>
+    prop4: p.Property<int[]>
+    prop5: p.Property<[int, string][]>
+    prop6: p.Property<{name0: int, name1: string}>
+    prop7: p.Property<{[key: string]: int}>
+    prop8: p.Property<Map<string[], int>>
+    prop9: p.Property<"enum0" | "enum1" | "enum2">
+  }
+}
+
+declare interface _Some1 extends _Some1.Attrs {}
+
+declare class _Some1 extends Model {
+  override properties: _Some1.Props
+  constructor(attrs?: Partial<_Some1.Attrs>)
+}
+
+declare namespace _Some2 {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = _Some1.Props & {
+    prop10: p.Property<_Some0>
+  }
+}
+
+declare interface _Some2 extends _Some2.Attrs {}
+
+declare class _Some2 extends _Some1 {
+  override properties: _Some2.Props
+  constructor(attrs?: Partial<_Some2.Attrs>)
+}
+
+declare namespace _Some3 {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = ColumnDataSource.Props & {
+    prop0: p.Property<int>
+  }
+}
+
+declare interface _Some3 extends _Some3.Attrs {}
+
+declare class _Some3 extends ColumnDataSource {
+  override properties: _Some3.Props
+  constructor(attrs?: Partial<_Some3.Attrs>)
+}
+
+declare namespace _Some4 {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = _Some3.Props & {
+    prop1: p.Property<int[]>
+  }
+}
+
+declare interface _Some4 extends _Some4.Attrs {}
+
+declare class _Some4 extends _Some3 {
+  override properties: _Some4.Props
+  constructor(attrs?: Partial<_Some4.Attrs>)
+}
+
+describe("document/defs module", () => {
+  describe("implements resolve_defs() function", () => {
+    it("that supports basic definitions", () => {
+      const defs: ModelDef[] = [{
+        name: "Some0",
+        module: "some",
+        extends: {name: "Model"},
+        properties: [
+          {name: "prop0", kind: "Any", default: 0},
+          {name: "prop1", kind: "Unknown", default: 1},
+          {name: "prop2", kind: "Boolean", default: true},
+          {name: "prop3", kind: "Number", default: 1.23},
+          {name: "prop4", kind: "Int", default: 123},
+          {name: "prop5", kind: "String", default: "abc"},
+          {name: "prop6", kind: "Null", default: null},
+        ],
+        overrides: [
+          {name: "tags", default: ["some", "default", "tags"]},
+        ],
+      }, {
+        name: "Some1",
+        module: "some",
+        extends: {name: "Model"},
+        properties: [
+          {name: "prop0", kind: ["Regex", "^[a-z][a-z0-9]*"], default: "a0"},
+          {name: "prop1", kind: ["Nullable", "Int"], default: null},
+          {name: "prop2", kind: ["Or", "Int", "String"], default: 1},
+          {name: "prop3", kind: ["Tuple", "Int", "String"], default: [1, "a"]},
+          {name: "prop4", kind: ["Array", "Int"], default: [0, 1, 2]},
+          {name: "prop5", kind: ["Array", ["Tuple", "Int", "String"]], default: [[0, "a"], [1, "b"], [2, "c"]]},
+          {name: "prop6", kind: ["Struct", ["name0", "Int"], ["name1", "String"]], default: {name0: 0, name1: "a"}},
+          {name: "prop7", kind: ["Dict", "Int"], default: {a: 0, b: 1, c: 2}},
+          {name: "prop8", kind: ["Map", ["Array", "String"], "Int"], default: new Map([[["a", "a"], 0], [["b"], 1]])},
+          {name: "prop9", kind: ["Enum", "enum0", "enum1", "enum2"], default: "enum2"},
+        ],
+        overrides: [],
+      }, {
+        name: "Some2",
+        module: "some",
+        extends: {name: "Some1", module: "some"},
+        properties: [
+          {name: "prop10", kind: ["Ref", {name: "Some0", module: "some"}], default: {id: "some001"}}, // TODO: resolve refs
+        ],
+        overrides: [
+          {name: "prop2", default: "a"},
+        ],
+      }, {
+        name: "Some3",
+        module: "some",
+        extends: {name: "ColumnDataSource"},
+        properties: [
+          {name: "prop0", kind: "Number", default: 1},
+        ],
+        overrides: [
+          {name: "data", default: {default_column: [0, 1, 2]}},
+        ],
+      }, {
+        name: "Some4",
+        module: "some",
+        extends: {name: "Some3", module: "some"},
+        properties: [
+          {name: "prop1", kind: ["Array", "Number"], default: [0, 1, 2]},
+        ],
+        overrides: [
+          {name: "data", default: {default_column: [3, 4, 5]}},
+          {name: "prop0", default: 2},
+        ],
+      }]
+
+      const resolver = new ModelResolver()
+      resolve_defs(defs, resolver)
+
+      const Some0 = resolver.get<typeof _Some0, null>("some.Some0", null)
+      const Some1 = resolver.get<typeof _Some1, null>("some.Some1", null)
+      const Some2 = resolver.get<typeof _Some2, null>("some.Some2", null)
+      const Some3 = resolver.get<typeof _Some3, null>("some.Some3", null)
+      const Some4 = resolver.get<typeof _Some4, null>("some.Some4", null)
+
+      assert(Some0 != null)
+      assert(Some1 != null)
+      assert(Some2 != null)
+      assert(Some3 != null)
+      assert(Some4 != null)
+
+      expect(Some0.prototype).to.be.instanceof(Model)
+      expect(Some1.prototype).to.be.instanceof(Model)
+      expect(Some2.prototype).to.be.instanceof(Model)
+      expect(Some2.prototype).to.be.instanceof(Some1)
+      expect(Some3.prototype).to.be.instanceof(ColumnDataSource)
+      expect(Some4.prototype).to.be.instanceof(ColumnDataSource)
+      expect(Some4.prototype).to.be.instanceof(Some3)
+
+      expect(Some0.__module__).to.be.equal("some")
+      expect(Some1.__module__).to.be.equal("some")
+      expect(Some2.__module__).to.be.equal("some")
+      expect(Some3.__module__).to.be.equal("some")
+      expect(Some4.__module__).to.be.equal("some")
+
+      const some0 = new Some0()
+      const some1 = new Some1()
+      const some2 = new Some2()
+      const some3 = new Some3()
+      const some4 = new Some4()
+
+      expect(some0).to.be.instanceof(Model)
+      expect(some1).to.be.instanceof(Model)
+      expect(some2).to.be.instanceof(Model)
+      expect(some2).to.be.instanceof(Some1)
+      expect(some3).to.be.instanceof(ColumnDataSource)
+      expect(some4).to.be.instanceof(ColumnDataSource)
+      expect(some4).to.be.instanceof(Some3)
+
+      const model_props = [
+        "tags",
+        "name",
+        "js_property_callbacks",
+        "js_event_callbacks",
+        "subscribed_events",
+        "syncable",
+      ]
+
+      const cds_props = [
+        "selected",
+        "selection_policy",
+        "inspected",
+        "data",
+      ]
+
+      expect([...some0].map((prop) => prop.attr)).to.be.equal([
+        ...model_props,
+        "prop0", "prop1", "prop2", "prop3", "prop4", "prop5", "prop6",
+      ])
+      expect([...some1].map((prop) => prop.attr)).to.be.equal([
+        ...model_props,
+        "prop0", "prop1", "prop2", "prop3", "prop4", "prop5", "prop6", "prop7", "prop8", "prop9",
+      ])
+      expect([...some2].map((prop) => prop.attr)).to.be.equal([
+        ...model_props,
+        "prop0", "prop1", "prop2", "prop3", "prop4", "prop5", "prop6", "prop7", "prop8", "prop9", "prop10"])
+      expect([...some3].map((prop) => prop.attr)).to.be.equal([
+        ...model_props,
+        ...cds_props,
+        "prop0",
+      ])
+      expect([...some4].map((prop) => prop.attr)).to.be.equal([
+        ...model_props,
+        ...cds_props,
+        "prop0", "prop1",
+      ])
+
+      expect(some0.prop0).to.be.equal(0)
+      expect(some0.prop1).to.be.equal(1)
+      expect(some0.prop2).to.be.equal(true)
+      expect(some0.prop3).to.be.equal(1.23)
+      expect(some0.prop4).to.be.equal(123)
+      expect(some0.prop5).to.be.equal("abc")
+      expect(some0.prop6).to.be.equal(null)
+
+      expect(some0.tags).to.be.equal(["some", "default", "tags"])
+
+      expect(some1.prop0).to.be.equal("a0")
+      expect(some1.prop1).to.be.equal(null)
+      expect(some1.prop2).to.be.equal(1)
+      expect(some1.prop3).to.be.equal([1, "a"])
+      expect(some1.prop4).to.be.equal([0, 1, 2])
+      expect(some1.prop5).to.be.equal([[0, "a"], [1, "b"], [2, "c"]])
+      expect(some1.prop6).to.be.equal({name0: 0, name1: "a"})
+      expect(some1.prop7).to.be.equal({a: 0, b: 1, c: 2})
+      // expect(some1.prop8).to.be.equal(new Map([[["a", "a"], 0], [["b"], 1]]))
+      expect(some1.prop9).to.be.equal("enum2")
+
+      expect(some1.tags).to.be.equal([])
+
+      expect(some2.prop0).to.be.equal("a0")
+      expect(some2.prop1).to.be.equal(null)
+      expect(some2.prop2).to.be.equal("a")
+      expect(some2.prop3).to.be.equal([1, "a"])
+      expect(some2.prop4).to.be.equal([0, 1, 2])
+      expect(some2.prop5).to.be.equal([[0, "a"], [1, "b"], [2, "c"]])
+      expect(some2.prop6).to.be.equal({name0: 0, name1: "a"})
+      expect(some2.prop7).to.be.equal({a: 0, b: 1, c: 2})
+      // expect(some2.prop8).to.be.equal(new Map([[["a", "a"], 0], [["b"], 1]]))
+      expect(some2.prop9).to.be.equal("enum2")
+      // expect(some2.prop10).to.be.equal(new Some0()) // TODO: resolve refs
+
+      expect(some3.data).to.be.equal({default_column: [0, 1, 2]})
+      expect(some3.prop0).to.be.equal(1)
+
+      expect(some4.data).to.be.equal({default_column: [3, 4, 5]})
+      expect(some4.prop0).to.be.equal(2)
+      expect(some4.prop1).to.be.equal([0, 1, 2])
+    })
+  })
+})

--- a/bokehjs/test/unit/models/text/utils.ts
+++ b/bokehjs/test/unit/models/text/utils.ts
@@ -49,7 +49,7 @@ describe("models/text/utils module", () => {
     expect(s11).to.be.equal(new PlainText({text: "$$test\\]"}))
     const s12 = parse_delimited_string("$$test $$ end $$")
     ;(s12 as any).id = wildcard
-    expect(s12).to.be.equal(new TeX({text: "$$test $$ end $$"}))
+    expect(s12).to.be.equal(new PlainText({text: "$$test $$ end $$"}))
     const s13 = parse_delimited_string("$$ \\[test end\\]")
     ;(s13 as any).id = wildcard
     expect(s13).to.be.equal(new PlainText({text: "$$ \\[test end\\]"}))
@@ -61,7 +61,7 @@ describe("models/text/utils module", () => {
     expect(s15).to.be.equal(new TeX({text: " tex [ tex ] tex "}))
     const s16 = parse_delimited_string("$$tex$$text$$tex$$")
     ;(s16 as any).id = wildcard
-    expect(s16).to.be.equal(new TeX({text: "$$tex$$text$$tex$$"}))
+    expect(s16).to.be.equal(new PlainText({text: "$$tex$$text$$tex$$"}))
     const s17 = parse_delimited_string("part0$$part1\\[part2\\(part3$$")
     ;(s17 as any).id = wildcard
     expect(s17).to.be.equal(new PlainText({text: "part0$$part1\\[part2\\(part3$$"}))

--- a/tests/unit/bokeh/document/test_document.py
+++ b/tests/unit/bokeh/document/test_document.py
@@ -71,7 +71,8 @@ class DerivedDataModel(SomeDataModel):
     prop3 = Int()
     prop4 = Int(default=112)
     prop5 = List(Int, default=[1, 2, 3, 4])
-    prop6 = Nullable(Instance(SomeDataModel))
+    prop6 = Instance(SomeDataModel)
+    prop7 = Nullable(Instance(SomeDataModel))
 
     prop2 = Override(default=119)
 
@@ -715,28 +716,32 @@ class TestDocument:
         doc.add_root(obj1)
 
         json = doc.to_json()
-        assert json["defs"] == [{
-            "extends": None,
-            "module": "test_document",
-            "name": "SomeDataModel",
-            "overrides": [],
-            "properties": [
-                {"default": 0, "kind": None, "name": "prop0"},
-                {"default": 111, "kind": None, "name": "prop1"},
-                {"default": [1, 2, 3], "kind": None, "name": "prop2"},
-            ],
-        }, {
-            "extends": {"module": "test_document", "name": "SomeDataModel"},
-            "module": "test_document",
-            "name": "DerivedDataModel",
-            "overrides": [{"default": 119, "name": "prop2"}],
-            "properties": [
-                {"default": 0, "kind": None, "name": "prop3"},
-                {"default": 112, "kind": None, "name": "prop4"},
-                {"default": [1, 2, 3, 4], "kind": None, "name": "prop5"},
-                {"default": None, "kind": None, "name": "prop6"},
-            ],
-        }]
+        assert json["defs"] == [
+            dict(
+                extends=dict(name="Model", module=None),
+                module="test_document",
+                name="SomeDataModel",
+                overrides=[],
+                properties=[
+                    dict(default=0, kind="Any", name="prop0"),
+                    dict(default=111, kind="Any", name="prop1"),
+                    dict(default=[1, 2, 3], kind="Any", name="prop2"),
+                ],
+            ),
+            dict(
+                extends=dict(module="test_document", name="SomeDataModel"),
+                module="test_document",
+                name="DerivedDataModel",
+                overrides=[dict(default=119, name="prop2")],
+                properties=[
+                    dict(default=0, kind="Any", name="prop3"),
+                    dict(default=112, kind="Any", name="prop4"),
+                    dict(default=[1, 2, 3, 4], kind="Any", name="prop5"),
+                    dict(kind="Any", name="prop6"),
+                    dict(default=None, kind="Any", name="prop7"),
+                ],
+            ),
+        ]
 
     def test_serialization_has_version(self) -> None:
         from bokeh import __version__

--- a/tests/unit/bokeh/document/test_document.py
+++ b/tests/unit/bokeh/document/test_document.py
@@ -76,6 +76,18 @@ class DerivedDataModel(SomeDataModel):
 
     prop2 = Override(default=119)
 
+class CDSDerivedDataModel(ColumnDataSource, DataModel):
+    prop0 = Int()
+    prop1 = Int(default=111)
+    prop2 = List(Int, default=[1, 2, 3])
+
+    data = Override(default={"default_column": [4, 5, 6]})
+
+class CDSDerivedDerivedDataModel(CDSDerivedDataModel):
+    prop3 = Instance(SomeDataModel, default=SomeDataModel())
+
+    data = Override(default={"default_column": [7, 8, 9]})
+
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
@@ -708,12 +720,16 @@ class TestDocument:
         assert some_root.child.foo == 44
 
     def test_serialization_data_models(self) -> None:
-        obj0 = SomeDataModel()
-        obj1 = DerivedDataModel(prop6=obj0)
+        #obj0 = SomeDataModel()
+        #obj1 = DerivedDataModel(prop6=obj0)
+        #obj2 = CDSDerivedDataModel()
+        #obj3 = CDSDerivedDerivedDataModel()
 
         doc = document.Document()
-        doc.add_root(obj0)
-        doc.add_root(obj1)
+        #doc.add_root(obj0)
+        #doc.add_root(obj1)
+        #doc.add_root(obj2)
+        #doc.add_root(obj3)
 
         json = doc.to_json()
         assert json["defs"] == [
@@ -732,7 +748,9 @@ class TestDocument:
                 extends=dict(module="test_document", name="SomeDataModel"),
                 module="test_document",
                 name="DerivedDataModel",
-                overrides=[dict(default=119, name="prop2")],
+                overrides=[
+                    dict(default=119, name="prop2"),
+                ],
                 properties=[
                     dict(default=0, kind="Any", name="prop3"),
                     dict(default=112, kind="Any", name="prop4"),
@@ -741,7 +759,32 @@ class TestDocument:
                     dict(default=None, kind="Any", name="prop7"),
                 ],
             ),
+            dict(
+                extends=dict(name="ColumnDataSource", module=None),
+                module="test_document",
+                name="CDSDerivedDataModel",
+                overrides=[
+                    dict(default={"default_column": [4, 5, 6]}, name="data"),
+                ],
+                properties=[
+                    dict(default=0, kind="Any", name="prop0"),
+                    dict(default=111, kind="Any", name="prop1"),
+                    dict(default=[1, 2, 3], kind="Any", name="prop2"),
+                ],
+            ),
+            dict(
+                extends=dict(name="CDSDerivedDataModel", module="test_document"),
+                module="test_document",
+                name="CDSDerivedDerivedDataModel",
+                overrides=[
+                    dict(default={"default_column": [7, 8, 9]}, name="data"),
+                ],
+                properties=[
+                    dict(default=CDSDerivedDerivedDataModel.prop3.property._default.ref, kind="Any", name="prop3"),
+                ],
+            ),
         ]
+        # TODO: assert json["roots"]["references"] == ...
 
     def test_serialization_has_version(self) -> None:
         from bokeh import __version__


### PR DESCRIPTION
Allows code like this to work:
```py
from bokeh.core.properties import Instance
from bokeh.models.sources import ColumnDataSource
from bokeh.layouts import Row
from bokeh.plotting import Figure, show
from bokeh.model import DataModel

class Base(Row, DataModel):

    cds = Instance(ColumnDataSource)

    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        self.cds = ColumnDataSource(data={'x': [0, 1], 'y': [2, 3]})

class Sub(Base):

    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        fig0 = Figure(width=200, height=200)
        fig0.line(self.cds.data['x'], self.cds.data['y'], line_color="red")
        self.children.append(fig0)
        fig1 = Figure(width=200, height=200)
        fig1.line(self.cds.data['x'], self.cds.data['y'], line_color="green")
        self.children.append(fig1)

show(Sub())
```

Also improves handling of default values (undefined and unstable).

fixes #11596