### PR TITLE
Don't use regular expressions for parsing delimited strings

### DIFF
--- a/bokehjs/src/lib/core/graphics.ts
+++ b/bokehjs/src/lib/core/graphics.ts
@@ -42,6 +42,7 @@ export abstract class GraphicsBox {
   padding?: Padding
   font_size_scale: number = 1.0
   text_height_metric?: TextHeightMetric
+  align: "left" | "center" | "right" | "justify" = "left"
 
   _base_font_size: number = 13 // the same as .bk-root's font-size (13px)
 
@@ -155,7 +156,6 @@ export class TextBox extends GraphicsBox {
   color: string
   font: string
   line_height: number
-  align: "left" | "center" | "right" | "justify" = "left"
   //padding: Padding
 
   set visuals(v: visuals.Text["Values"]) {

--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -230,7 +230,7 @@ export abstract class HasProps extends Signalable() implements Equatable, Printa
   [equals](that: this, cmp: Comparator): boolean {
     for (const p0 of this) {
       const p1 = that.property(p0.attr)
-      if (cmp.eq(p0.get_value(), p1.get_value()))
+      if (!cmp.eq(p0.get_value(), p1.get_value()))
         return false
     }
     return true

--- a/bokehjs/src/lib/model.ts
+++ b/bokehjs/src/lib/model.ts
@@ -4,6 +4,7 @@ import {ModelEvent} from "./core/bokeh_events"
 import * as p from "./core/properties"
 import {isString} from "./core/util/types"
 import {isEmpty, entries} from "./core/util/object"
+import {equals, Comparator} from "core/util/eq"
 import {logger} from "./core/logging"
 import {CallbackLike0} from "./models/callbacks/callback"
 
@@ -29,6 +30,10 @@ export class Model extends HasProps {
 
   override get is_syncable(): boolean {
     return this.syncable
+  }
+
+  override [equals](that: this, cmp: Comparator): boolean {
+    return cmp.eq(this.id, that.id) && super[equals](that, cmp)
   }
 
   constructor(attrs?: Partial<Model.Attrs>) {

--- a/bokehjs/src/lib/models/text/base_text.ts
+++ b/bokehjs/src/lib/models/text/base_text.ts
@@ -1,5 +1,15 @@
 import {Model} from "../../model"
+import {View} from "core/view"
+import {GraphicsBox} from "core/graphics"
 import * as p from "core/properties"
+import {RendererView} from "models/renderers/renderer"
+
+export abstract class BaseTextView extends View {
+  override model: BaseText
+  override parent: RendererView
+
+  abstract graphics(): GraphicsBox
+}
 
 export namespace BaseText {
   export type Attrs = p.AttrsOf<Props>
@@ -13,6 +23,7 @@ export interface BaseText extends BaseText.Attrs {}
 
 export class BaseText extends Model {
   override properties: BaseText.Props
+  override __view_type__: BaseTextView
 
   constructor(attrs?: Partial<BaseText.Attrs>) {
     super(attrs)

--- a/bokehjs/src/lib/models/text/math_text.ts
+++ b/bokehjs/src/lib/models/text/math_text.ts
@@ -6,21 +6,22 @@ import {load_image} from "core/util/image"
 import {CanvasImage} from "models/glyphs/image_url"
 import {color2css} from "core/util/color"
 import {Size} from "core/types"
-import {View} from "core/view"
-import {RendererView} from "models/renderers/renderer"
 import {GraphicsBox, TextHeightMetric, text_width, Position} from "core/graphics"
 import {font_metrics, parse_css_font_size} from "core/util/text"
 import {AffineTransform, Rect} from "core/util/affine"
 import {BBox} from "core/util/bbox"
-import {BaseText} from "./base_text"
+import {BaseText, BaseTextView} from "./base_text"
 import {MathJaxProvider, default_provider} from "./providers"
 
 /**
  * Helper class for rendering MathText into Canvas
  */
-export abstract class MathTextView extends View implements GraphicsBox {
+export abstract class MathTextView extends BaseTextView implements GraphicsBox {
   override model: MathText
-  override parent: RendererView
+
+  graphics(): GraphicsBox {
+    return this
+  }
 
   angle?: number
   _position: Position = {sx: 0, sy: 0}

--- a/bokehjs/src/lib/models/text/plain_text.ts
+++ b/bokehjs/src/lib/models/text/plain_text.ts
@@ -1,20 +1,36 @@
-import {BaseText} from "./base_text"
+import {BaseText, BaseTextView} from "./base_text"
+import {GraphicsBox, TextBox} from "core/graphics"
 import * as p from "core/properties"
+
+export class PlainTextView extends BaseTextView {
+  override model: PlainText
+
+  override initialize(): void {
+    super.initialize()
+    this._has_finished = true
+  }
+
+  graphics(): GraphicsBox {
+    return new TextBox({text: this.model.text})
+  }
+}
 
 export namespace PlainText {
   export type Attrs = p.AttrsOf<Props>
-
-  export type Props = BaseText.Props & {
-    text: p.Property<string>
-  }
+  export type Props = BaseText.Props
 }
 
 export interface PlainText extends PlainText.Attrs {}
 
 export class PlainText extends BaseText {
   override properties: PlainText.Props
+  override __view_type__: PlainTextView
 
   constructor(attrs?: Partial<PlainText.Attrs>) {
     super(attrs)
+  }
+
+  static {
+    this.prototype.default_view = PlainTextView
   }
 }

--- a/bokehjs/src/lib/models/text/utils.ts
+++ b/bokehjs/src/lib/models/text/utils.ts
@@ -1,23 +1,32 @@
 import {TeX} from "./math_text"
-import {isString} from "core/util/types"
 import {BaseText} from "./base_text"
+import {PlainText} from "./plain_text"
 
-export function is_tex_string(text: unknown): boolean {
-  if (!isString(text)) return false
-
-  const dollars = /^\$\$.*?\$\$$/s
-  const braces  = /^\\\[.*?\\\]$/s
-  const parens  = /^\\\(.*?\\\)$/s
-
-  return dollars.test(text) || braces.test(text) || parens.test(text)
+type Delimiter = {
+  start: string
+  end: string
+  inline: boolean
 }
 
-export function tex_from_text_like(text: string | BaseText): TeX | null {
-  if (text instanceof TeX)
-    return text
+const delimiters: Delimiter[] = [
+  {start: "$$", end: "$$", inline: false},
+  {start: "\\[", end: "\\]", inline: false},
+  {start: "\\(", end: "\\)", inline: true},
+]
 
-  if (isString(text) && is_tex_string(text))
-    return new TeX({text: text.slice(2, -2)})
+export function parse_delimited_string(text: string): BaseText {
+  for (const delim of delimiters) {
+    const n0 = text.indexOf(delim.start)
+    const m0 = n0 + delim.start.length
+    if (n0 == 0) {
+      const n1 = text.indexOf(delim.end, m0)
+      const m1 = n1
+      if (n1 == text.length - delim.end.length)
+        return new TeX({text: text.slice(m0, m1), inline: delim.inline})
+      else
+        break
+    }
+  }
 
-  return null
+  return new PlainText({text})
 }

--- a/bokehjs/test/unit/core/util/eq.ts
+++ b/bokehjs/test/unit/core/util/eq.ts
@@ -1,6 +1,32 @@
 import {expect} from "assertions"
 
 import {is_equal, equals, Equatable, Comparator} from "@bokehjs/core/util/eq"
+import {HasProps} from "@bokehjs/core/has_props"
+import * as p from "@bokehjs/core/properties"
+
+namespace SomeHasProps {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = HasProps.Props & {
+    prop: p.Property<number>
+  }
+}
+
+interface SomeHasProps extends SomeHasProps.Attrs {}
+
+class SomeHasProps extends HasProps {
+  override properties: SomeHasProps.Props
+
+  constructor(attrs?: Partial<SomeHasProps.Attrs>) {
+    super(attrs)
+  }
+
+  static {
+    this.define<SomeHasProps.Props>(({Number}) => ({
+      prop: [ Number, 0 ],
+    }))
+  }
+}
 
 describe("core/util/eq module", () => {
   describe("implements is_equal() function", () => {
@@ -183,6 +209,24 @@ describe("core/util/eq module", () => {
     expect(is_equal(div1, div2)).to.be.false
     expect(is_equal(div1, div1)).to.be.true
     expect(is_equal(div2, div2)).to.be.true
+  })
+
+  it("that supports HasProps instances", () => {
+    const x0 = new SomeHasProps({prop: 0})
+    const x1 = new SomeHasProps({prop: 1})
+    const x2 = new SomeHasProps({prop: 1})
+
+    expect(is_equal(x0, x0)).to.be.true
+    expect(is_equal(x1, x1)).to.be.true
+
+    expect(is_equal(x0, x1)).to.be.false
+    expect(is_equal(x1, x0)).to.be.false
+
+    expect(is_equal(x0, x2)).to.be.false
+    expect(is_equal(x2, x0)).to.be.false
+    expect(is_equal(x1, x2)).to.be.true   // no id
+    expect(is_equal(x2, x1)).to.be.true   // no id
+    expect(is_equal(x2, x2)).to.be.true
   })
 
   it("that throws on unknown types", () => {

--- a/bokehjs/test/unit/models/axes/axis.ts
+++ b/bokehjs/test/unit/models/axes/axis.ts
@@ -74,7 +74,7 @@ describe("Axis", () => {
     const plot_view = (await build_view(plot)).build()
     const axis_view = plot_view.renderer_view(axis)!
 
-    expect(axis_view.model.axis_label).to.be.instanceof(TeX)
+    expect(axis_view._axis_label_view).to.be.instanceof(TeXView)
   })
 
   it("should convert mathstrings with line breaks in between delimiters on axis labels to TeX", async () => {
@@ -97,7 +97,7 @@ describe("Axis", () => {
     const plot_view = (await build_view(plot)).build()
     const axis_view = plot_view.renderer_view(axis)!
 
-    expect(axis_view.model.axis_label).to.be.instanceof(TeX)
+    expect(axis_view._axis_label_view).to.be.instanceof(TeXView)
   })
 
   it("loc should return numeric fixed_location", async () => {

--- a/bokehjs/test/unit/models/text/utils.ts
+++ b/bokehjs/test/unit/models/text/utils.ts
@@ -2,58 +2,81 @@ import {expect} from "assertions"
 
 import {parse_delimited_string} from "@bokehjs/models/text/utils"
 import {TeX, PlainText} from "@bokehjs/models/text"
+import {wildcard} from "@bokehjs/core/util/eq"
 
 describe("models/text/utils module", () => {
   it("should provide parse_delimited_string() function", () => {
     const s0 = parse_delimited_string("$$test$$")
+    ;(s0 as any).id = wildcard // XXX: figure out how to deal with value equality with IDs
     expect(s0).to.be.equal(new TeX({text: "test"}))
     const s1 = parse_delimited_string("\\[test\\]")
+    ;(s1 as any).id = wildcard
     expect(s1).to.be.equal(new TeX({text: "test"}))
     const s2 = parse_delimited_string("\\(test\\)")
+    ;(s2 as any).id = wildcard
     expect(s2).to.be.equal(new TeX({text: "test", inline: true}))
 
     const s3 = parse_delimited_string("test$$")
+    ;(s3 as any).id = wildcard
     expect(s3).to.be.equal(new PlainText({text: "test$$"}))
     const s4 = parse_delimited_string("$$test")
+    ;(s4 as any).id = wildcard
     expect(s4).to.be.equal(new PlainText({text: "$$test"}))
 
     const s5 = parse_delimited_string("test\\]")
+    ;(s5 as any).id = wildcard
     expect(s5).to.be.equal(new PlainText({text: "test\\]"}))
     const s6 = parse_delimited_string("\\[test")
+    ;(s6 as any).id = wildcard
     expect(s6).to.be.equal(new PlainText({text: "\\[test"}))
 
     const s7 = parse_delimited_string("test\\)")
+    ;(s7 as any).id = wildcard
     expect(s7).to.be.equal(new PlainText({text: "test\\)"}))
     const s8 = parse_delimited_string("\\(test")
+    ;(s8 as any).id = wildcard
     expect(s8).to.be.equal(new PlainText({text: "\\(test"}))
 
     const s9 = parse_delimited_string("HTML <b>text</b> $$\\sin(x) and \\[x\\cdot\\pi\\]!")
+    ;(s9 as any).id = wildcard
     expect(s9).to.be.equal(new PlainText({text: "HTML <b>text</b> $$\\sin(x) and \\[x\\cdot\\pi\\]!"}))
     const s10 = parse_delimited_string("HTML <b>text</b> $$sin(x)$$ and [xcdotpi]!")
+    ;(s10 as any).id = wildcard
     expect(s10).to.be.equal(new PlainText({text: "HTML <b>text</b> $$sin(x)$$ and [xcdotpi]!"}))
 
     const s11 = parse_delimited_string("$$test\\]")
+    ;(s11 as any).id = wildcard
     expect(s11).to.be.equal(new PlainText({text: "$$test\\]"}))
     const s12 = parse_delimited_string("$$test $$ end $$")
+    ;(s12 as any).id = wildcard
     expect(s12).to.be.equal(new TeX({text: "$$test $$ end $$"}))
     const s13 = parse_delimited_string("$$ \\[test end\\]")
+    ;(s13 as any).id = wildcard
     expect(s13).to.be.equal(new PlainText({text: "$$ \\[test end\\]"}))
     const s14 = parse_delimited_string("text \\[text $$latex$$")
+    ;(s14 as any).id = wildcard
     expect(s14).to.be.equal(new PlainText({text: "text \\[text $$latex$$"}))
     const s15 = parse_delimited_string("$$ tex [ tex ] tex $$")
+    ;(s15 as any).id = wildcard
     expect(s15).to.be.equal(new TeX({text: " tex [ tex ] tex "}))
     const s16 = parse_delimited_string("$$tex$$text$$tex$$")
+    ;(s16 as any).id = wildcard
     expect(s16).to.be.equal(new TeX({text: "$$tex$$text$$tex$$"}))
     const s17 = parse_delimited_string("part0$$part1\\[part2\\(part3$$")
+    ;(s17 as any).id = wildcard
     expect(s17).to.be.equal(new PlainText({text: "part0$$part1\\[part2\\(part3$$"}))
     const s18 = parse_delimited_string("part0$$part1\\[part2\\(part3\\]")
+    ;(s18 as any).id = wildcard
     expect(s18).to.be.equal(new PlainText({text: "part0$$part1\\[part2\\(part3\\]"}))
     const s19 = parse_delimited_string("part0$$part1\\[part2\\(part3\\)")
+    ;(s19 as any).id = wildcard
     expect(s19).to.be.equal(new PlainText({text: "part0$$part1\\[part2\\(part3\\)"}))
 
     const s20 = parse_delimited_string("$$\ncos(x)\n$$")
+    ;(s20 as any).id = wildcard
     expect(s20).to.be.equal(new TeX({text: "\ncos(x)\n"}))
     const s21 = parse_delimited_string("$$\ncos(x)$$\n")
+    ;(s21 as any).id = wildcard
     expect(s21).to.be.equal(new PlainText({text: "$$\ncos(x)$$\n"}))
   })
 })

--- a/bokehjs/test/unit/models/text/utils.ts
+++ b/bokehjs/test/unit/models/text/utils.ts
@@ -1,32 +1,59 @@
 import {expect} from "assertions"
 
-import {is_tex_string} from "@bokehjs/models/text/utils"
+import {parse_delimited_string} from "@bokehjs/models/text/utils"
+import {TeX, PlainText} from "@bokehjs/models/text"
 
-describe("Text utils", () => {
-  it("is_tex_string", async () => {
-    expect(is_tex_string("$$test$$")).to.be.true
-    expect(is_tex_string("\\[test\\]")).to.be.true
-    expect(is_tex_string("\\(test\\)")).to.be.true
-    expect(is_tex_string("HTML <b>text</b> $$\\sin(x) and \\[x\\cdot\\pi\\]!")).to.be.false
-    expect(is_tex_string("\\[test\\]")).to.be.true
-    expect(is_tex_string("\\(test\\)")).to.be.true
-    expect(is_tex_string("test$$")).to.be.false
-    expect(is_tex_string("$$test")).to.be.false
-    expect(is_tex_string("HTML <b>text</b> $$sin(x)$$ and [xcdotpi]!")).to.be.false
-    expect(is_tex_string("$$test\\]")).to.be.false
-    expect(is_tex_string("$$test $$ end $$")).to.be.true
-    expect(is_tex_string("$$ \\[test end\\]")).to.be.false
-    expect(is_tex_string("text \\[text $$latex$$")).to.be.false
-    expect(is_tex_string("$$ tex [ tex ] tex $$")).to.be.true
-    expect(is_tex_string("$$tex$$text$$tex$$")).to.be.true
-    expect(is_tex_string("part0$$part1\\[part2\\(part3$$")).to.be.false
-    expect(is_tex_string("part0$$part1\\[part2\\(part3\\]")).to.be.false
-    expect(is_tex_string("part0$$part1\\[part2\\(part3\\)")).to.be.false
-    expect(is_tex_string(`$$
-      cos(x)
-    $$`)).to.be.true
-    expect(is_tex_string(`$$
-      cos(x)$$
-    `)).to.be.false
+describe("models/text/utils module", () => {
+  it("should provide parse_delimited_string() function", () => {
+    const s0 = parse_delimited_string("$$test$$")
+    expect(s0).to.be.equal(new TeX({text: "test"}))
+    const s1 = parse_delimited_string("\\[test\\]")
+    expect(s1).to.be.equal(new TeX({text: "test"}))
+    const s2 = parse_delimited_string("\\(test\\)")
+    expect(s2).to.be.equal(new TeX({text: "test", inline: true}))
+
+    const s3 = parse_delimited_string("test$$")
+    expect(s3).to.be.equal(new PlainText({text: "test$$"}))
+    const s4 = parse_delimited_string("$$test")
+    expect(s4).to.be.equal(new PlainText({text: "$$test"}))
+
+    const s5 = parse_delimited_string("test\\]")
+    expect(s5).to.be.equal(new PlainText({text: "test\\]"}))
+    const s6 = parse_delimited_string("\\[test")
+    expect(s6).to.be.equal(new PlainText({text: "\\[test"}))
+
+    const s7 = parse_delimited_string("test\\)")
+    expect(s7).to.be.equal(new PlainText({text: "test\\)"}))
+    const s8 = parse_delimited_string("\\(test")
+    expect(s8).to.be.equal(new PlainText({text: "\\(test"}))
+
+    const s9 = parse_delimited_string("HTML <b>text</b> $$\\sin(x) and \\[x\\cdot\\pi\\]!")
+    expect(s9).to.be.equal(new PlainText({text: "HTML <b>text</b> $$\\sin(x) and \\[x\\cdot\\pi\\]!"}))
+    const s10 = parse_delimited_string("HTML <b>text</b> $$sin(x)$$ and [xcdotpi]!")
+    expect(s10).to.be.equal(new PlainText({text: "HTML <b>text</b> $$sin(x)$$ and [xcdotpi]!"}))
+
+    const s11 = parse_delimited_string("$$test\\]")
+    expect(s11).to.be.equal(new PlainText({text: "$$test\\]"}))
+    const s12 = parse_delimited_string("$$test $$ end $$")
+    expect(s12).to.be.equal(new TeX({text: "$$test $$ end $$"}))
+    const s13 = parse_delimited_string("$$ \\[test end\\]")
+    expect(s13).to.be.equal(new PlainText({text: "$$ \\[test end\\]"}))
+    const s14 = parse_delimited_string("text \\[text $$latex$$")
+    expect(s14).to.be.equal(new PlainText({text: "text \\[text $$latex$$"}))
+    const s15 = parse_delimited_string("$$ tex [ tex ] tex $$")
+    expect(s15).to.be.equal(new TeX({text: " tex [ tex ] tex "}))
+    const s16 = parse_delimited_string("$$tex$$text$$tex$$")
+    expect(s16).to.be.equal(new TeX({text: "$$tex$$text$$tex$$"}))
+    const s17 = parse_delimited_string("part0$$part1\\[part2\\(part3$$")
+    expect(s17).to.be.equal(new PlainText({text: "part0$$part1\\[part2\\(part3$$"}))
+    const s18 = parse_delimited_string("part0$$part1\\[part2\\(part3\\]")
+    expect(s18).to.be.equal(new PlainText({text: "part0$$part1\\[part2\\(part3\\]"}))
+    const s19 = parse_delimited_string("part0$$part1\\[part2\\(part3\\)")
+    expect(s19).to.be.equal(new PlainText({text: "part0$$part1\\[part2\\(part3\\)"}))
+
+    const s20 = parse_delimited_string("$$\ncos(x)\n$$")
+    expect(s20).to.be.equal(new TeX({text: "\ncos(x)\n"}))
+    const s21 = parse_delimited_string("$$\ncos(x)$$\n")
+    expect(s21).to.be.equal(new PlainText({text: "$$\ncos(x)$$\n"}))
   })
 })


### PR DESCRIPTION
This also addresses some of my concerns from recent "math text" PRs. I also found a glaring bug in `HasProps` equality, which I fixed in this PR, but I still need to investigate a document unit test failure.

fixes #10391 