### PR TITLE
Reduce Tornado imports

### DIFF
--- a/bokeh/_testing/util/project.py
+++ b/bokeh/_testing/util/project.py
@@ -1,0 +1,85 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2021, Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+''' Provide functions for inspecting project structure and files.
+
+'''
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import annotations
+
+import logging # isort:skip
+log = logging.getLogger(__name__)
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+import os
+from pathlib import Path
+from subprocess import run
+from typing import List, Sequence
+
+#-----------------------------------------------------------------------------
+# Globals and constants
+#-----------------------------------------------------------------------------
+
+__all__ = (
+    'TOP_PATH',
+    'ls_files',
+    'ls_modules',
+    'verify_clean_imports',
+)
+
+TOP_PATH = Path(__file__).resolve().parent.parent.parent.parent
+
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+def ls_files(*patterns: str) -> List[str]:
+    proc = run(["git", "ls-files", "--", *patterns], capture_output=True)
+    return proc.stdout.decode("utf-8").split("\n")
+
+def ls_modules(*, dir: str = "bokeh", skip_prefixes: Sequence[str] = [], skip_main: bool = True) -> List[str]:
+    modules: List[str] = []
+
+    files = ls_files(f"{dir}/**.py")
+
+    for file in files:
+        if not file:
+            continue
+
+        if file.endswith("__main__.py") and skip_main:
+            continue
+
+        module = file.replace(os.sep, ".").replace(".py", "").replace(".__init__", "")
+
+        if any(module.startswith(prefix) for prefix in skip_prefixes):
+            continue
+
+        modules.append(module)
+
+    return modules
+
+def verify_clean_imports(target: str, modules: List[str]) -> str:
+    imports =  ";".join(f"import {m}" for m in modules)
+    return f"import sys; {imports}; sys.exit(1 if any({target!r} in x for x in sys.modules.keys()) else 0)"
+
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------

--- a/bokeh/application/application.py
+++ b/bokeh/application/application.py
@@ -41,15 +41,14 @@ from typing import (
     Tuple,
 )
 
-# External imports
-from tornado.httputil import HTTPServerRequest
-
 # Bokeh imports
 from ..core.types import ID
 from ..document import Document
 from ..settings import settings
 
 if TYPE_CHECKING:
+    from tornado.httputil import HTTPServerRequest
+
     from ..server.session import ServerSession
     from .handlers.handler import Handler
 

--- a/bokeh/application/handlers/directory.py
+++ b/bokeh/application/handlers/directory.py
@@ -66,7 +66,6 @@ from typing import (
 
 # External imports
 from jinja2 import Environment, FileSystemLoader, Template
-from tornado.httputil import HTTPServerRequest
 
 # Bokeh imports
 from ...core.types import PathLike
@@ -80,6 +79,8 @@ from .server_lifecycle import ServerLifecycleHandler
 from .server_request_handler import ServerRequestHandler
 
 if TYPE_CHECKING:
+    from tornado.httputil import HTTPServerRequest
+
     from ...themes import Theme
 
 #-----------------------------------------------------------------------------

--- a/bokeh/application/handlers/handler.py
+++ b/bokeh/application/handlers/handler.py
@@ -48,14 +48,13 @@ import sys
 import traceback
 from typing import TYPE_CHECKING, Any, Dict
 
-# External imports
-from tornado.httputil import HTTPServerRequest
-
 # Bokeh imports
 from ...document import Document
 from ..application import ServerContext, SessionContext
 
 if TYPE_CHECKING:
+    from tornado.httputil import HTTPServerRequest
+
     from .code_runner import CodeRunner
 
 #-----------------------------------------------------------------------------

--- a/bokeh/application/handlers/request_handler.py
+++ b/bokeh/application/handlers/request_handler.py
@@ -22,13 +22,18 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import Any, Callable, Dict
-
-# External imports
-from tornado.httputil import HTTPServerRequest
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+)
 
 # Bokeh imports
 from .handler import Handler
+
+if TYPE_CHECKING:
+    from tornado.httputil import HTTPServerRequest
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/bokeh/protocol/__init__.py
+++ b/bokeh/protocol/__init__.py
@@ -22,6 +22,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import json
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -32,7 +33,6 @@ from typing import (
 )
 
 # External imports
-from tornado.escape import json_decode
 from typing_extensions import Literal
 
 # Bokeh imports
@@ -150,7 +150,7 @@ class Protocol:
             message
 
         '''
-        header = json_decode(header_json)
+        header = json.loads(header_json)
         if 'msgtype' not in header:
             log.error(f"Bad header with no msgtype was: {header!r}")
             raise ProtocolError("No 'msgtype' in header")

--- a/bokeh/protocol/message.py
+++ b/bokeh/protocol/message.py
@@ -57,6 +57,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import json
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -69,7 +70,6 @@ from typing import (
 )
 
 # External imports
-from tornado.escape import json_decode, json_encode
 from typing_extensions import TypedDict
 
 # Bokeh imports
@@ -185,17 +185,17 @@ class Message(Generic[Content]):
         '''
 
         try:
-            header = json_decode(header_json)
+            header = json.loads(header_json)
         except ValueError:
             raise MessageError("header could not be decoded")
 
         try:
-            metadata = json_decode(metadata_json)
+            metadata = json.loads(metadata_json)
         except ValueError:
             raise MessageError("metadata could not be decoded")
 
         try:
-            content = json_decode(content_json)
+            content = json.loads(content_json)
         except ValueError:
             raise MessageError("content could not be decoded")
 
@@ -356,7 +356,7 @@ class Message(Generic[Content]):
     @property
     def header_json(self) -> str:
         if not self._header_json:
-            self._header_json = json_encode(self.header)
+            self._header_json = json.dumps(self.header)
         return self._header_json
 
     # content fragment properties
@@ -373,7 +373,7 @@ class Message(Generic[Content]):
     @property
     def content_json(self) -> str:
         if not self._content_json:
-            self._content_json = json_encode(self.content)
+            self._content_json = json.dumps(self.content)
         return self._content_json
 
     # metadata fragment properties
@@ -390,7 +390,7 @@ class Message(Generic[Content]):
     @property
     def metadata_json(self) -> str:
         if not self._metadata_json:
-            self._metadata_json = json_encode(self.metadata)
+            self._metadata_json = json.dumps(self.metadata)
         return self._metadata_json
 
     # buffer properties

--- a/tests/codebase/__init__.py
+++ b/tests/codebase/__init__.py
@@ -5,20 +5,3 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-
-from __future__ import annotations # isort:skip
-
-# Standard library imports
-from pathlib import Path
-from subprocess import run
-from typing import List
-
-TOP_PATH = Path(__file__).resolve().parent.parent.parent
-
-def ls_files(*patterns: str) -> List[str]:
-    proc = run(["git", "ls-files", "--", *patterns], capture_output=True)
-    return proc.stdout.decode("utf-8").split("\n")
-
-def verify_clean_imports(target: str, modules: List[str]) -> str:
-    imports =  ";".join(f"import {m}" for m in modules)
-    return f"import sys; {imports}; sys.exit(1 if any({target!r} in x for x in sys.modules.keys()) else 0)"

--- a/tests/codebase/test_eslint.py
+++ b/tests/codebase/test_eslint.py
@@ -21,7 +21,8 @@ import pytest ; pytest
 from os import chdir
 from subprocess import run
 
-from . import TOP_PATH
+# Bokeh imports
+from bokeh._testing.util.project import TOP_PATH
 
 #-----------------------------------------------------------------------------
 # Tests

--- a/tests/codebase/test_flake8.py
+++ b/tests/codebase/test_flake8.py
@@ -21,7 +21,8 @@ import pytest ; pytest
 from os import chdir
 from subprocess import run
 
-from . import TOP_PATH, ls_files
+# Bokeh imports
+from bokeh._testing.util.project import TOP_PATH, ls_files
 
 #-----------------------------------------------------------------------------
 # Tests

--- a/tests/codebase/test_isort.py
+++ b/tests/codebase/test_isort.py
@@ -21,7 +21,8 @@ import pytest ; pytest
 from os import chdir
 from subprocess import run
 
-from . import TOP_PATH
+# Bokeh imports
+from bokeh._testing.util.project import TOP_PATH
 
 #-----------------------------------------------------------------------------
 # Tests

--- a/tests/codebase/test_json.py
+++ b/tests/codebase/test_json.py
@@ -21,7 +21,8 @@ import pytest ; pytest
 import json
 from typing import List
 
-from . import TOP_PATH
+# Bokeh imports
+from bokeh._testing.util.project import TOP_PATH
 
 #-----------------------------------------------------------------------------
 # Tests

--- a/tests/codebase/test_license.py
+++ b/tests/codebase/test_license.py
@@ -23,7 +23,8 @@ from os import chdir
 from os.path import join
 from subprocess import run
 
-from . import TOP_PATH
+# Bokeh imports
+from bokeh._testing.util.project import TOP_PATH
 
 #-----------------------------------------------------------------------------
 # Tests

--- a/tests/codebase/test_no_client_server_common.py
+++ b/tests/codebase/test_no_client_server_common.py
@@ -21,7 +21,8 @@ import pytest ; pytest
 from subprocess import run
 from sys import executable as python
 
-from . import verify_clean_imports
+# Bokeh imports
+from bokeh._testing.util.project import verify_clean_imports
 
 #-----------------------------------------------------------------------------
 # Setup

--- a/tests/codebase/test_no_ipython_common.py
+++ b/tests/codebase/test_no_ipython_common.py
@@ -21,27 +21,32 @@ import pytest ; pytest
 from subprocess import run
 from sys import executable as python
 
-from . import verify_clean_imports
+# Bokeh imports
+from bokeh._testing.util.project import ls_modules, verify_clean_imports
 
 #-----------------------------------------------------------------------------
 # Tests
 #-----------------------------------------------------------------------------
 
-modules = [
-    "bokeh.application",
-    "bokeh.client",
-    "bokeh.embed",
-    "bokeh.io",
-    "bokeh.models",
-    "bokeh.plotting",
-    "bokeh.server",
-]
+# There should not be unprotected IPython imports /anywhere/
+IPYTHON_ALLOWED = (
+    "bokeh._testing",
+)
 
-def test_no_ipython_common() -> None:
+MODULES = ls_modules(skip_prefixes=IPYTHON_ALLOWED)
+
+# This test takes a long time to run, but if the combined test fails then
+# uncommenting it will locate exactly what module(s) are the problem
+# @pytest.mark.parametrize('module', MODULES)
+# def test_no_ipython_common_individual(module) -> None:
+#     proc = run([python, "-c", verify_clean_imports('IPython', [module])])
+#     assert proc.returncode == 0, f"IPython imported in common module {module}"
+
+def test_no_ipython_common_combined() -> None:
     ''' Basic usage of Bokeh should not result in any IPython code being
     imported. This test ensures that importing basic modules does not bring in
     IPython.
 
     '''
-    proc = run([python, "-c", verify_clean_imports('IPython', modules)])
+    proc = run([python, "-c", verify_clean_imports('IPython', MODULES)])
     assert proc.returncode == 0, "IPython imported in common modules"

--- a/tests/codebase/test_no_selenium_common.py
+++ b/tests/codebase/test_no_selenium_common.py
@@ -21,27 +21,33 @@ import pytest ; pytest
 from subprocess import run
 from sys import executable as python
 
-from . import verify_clean_imports
+# Bokeh imports
+from bokeh._testing.util.project import ls_modules, verify_clean_imports
 
 #-----------------------------------------------------------------------------
 # Tests
 #-----------------------------------------------------------------------------
 
-modules = [
-    "bokeh.application",
-    "bokeh.client",
-    "bokeh.embed",
-    "bokeh.io",
-    "bokeh.models",
-    "bokeh.plotting",
-    "bokeh.server",
-]
+SELENIUM_ALLOWED = (
+    "bokeh._testing",
+    "bokeh.io.webdriver",
+)
 
-def test_no_tornado_common() -> None:
+MODULES = ls_modules(skip_prefixes=SELENIUM_ALLOWED)
+
+
+# This test takes a long time to run, but if the combined test fails then
+# uncommenting it will locate exactly what module(s) are the problem
+# @pytest.mark.parametrize('module', MODULES)
+# def test_no_selenium_common_individual(module) -> None:
+#     proc = run([python, "-c", verify_clean_imports('selenium', [module])])
+#     assert proc.returncode == 0, f"Selenium imported in common module {module}"
+
+def test_no_selenium_common_combined() -> None:
     ''' Basic usage of Bokeh should not result in any Selenium code being
     imported. This test ensures that importing basic modules does not bring in
     Tornado.
 
     '''
-    proc = run([python, "-c", verify_clean_imports('selenium', modules)])
+    proc = run([python, "-c", verify_clean_imports('selenium', MODULES)])
     assert proc.returncode == 0, "Selenium imported in common modules"

--- a/tests/codebase/test_no_tornado_common.py
+++ b/tests/codebase/test_no_tornado_common.py
@@ -21,25 +21,36 @@ import pytest ; pytest
 from subprocess import run
 from sys import executable as python
 
-from . import verify_clean_imports
+# Bokeh imports
+from bokeh._testing.util.project import ls_modules, verify_clean_imports
 
 #-----------------------------------------------------------------------------
 # Tests
 #-----------------------------------------------------------------------------
 
-modules = [
+TORNADO_ALLOWED = (
+    "bokeh._testing",
     "bokeh.client",
-    "bokeh.embed",
-    "bokeh.io",
-    "bokeh.models",
-    "bokeh.plotting",
-]
+    "bokeh.command",
+    "bokeh.io.notebook",
+    "bokeh.server",
+    "bokeh.util.tornado",
+)
 
-def test_no_tornado_common() -> None:
+MODULES = ls_modules(skip_prefixes=TORNADO_ALLOWED)
+
+# This test takes a long time to run, but if the combined test fails then
+# uncommenting it will locate exactly what module(s) are the problem
+# @pytest.mark.parametrize('module', MODULES)
+# def test_no_tornado_common_individual(module) -> None:
+#     proc = run([python, "-c", verify_clean_imports('tornado', [module])])
+#     assert proc.returncode == 0, f"Tornado imported in common module {module}"
+
+def test_no_tornado_common_combined() -> None:
     ''' Basic usage of Bokeh should not result in any Tornado code being
     imported. This test ensures that importing basic modules does not bring in
     Tornado.
 
     '''
-    proc = run([python, "-c", verify_clean_imports('tornado', modules)])
-    assert proc.returncode == 0, "Tornado imported in common modules"
+    proc = run([python, "-c", verify_clean_imports('tornado', MODULES)])
+    assert proc.returncode == 0, "Tornado imported in collective common modules"

--- a/tests/codebase/test_python_execution_with_OO.py
+++ b/tests/codebase/test_python_execution_with_OO.py
@@ -18,18 +18,18 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-import os
 from subprocess import PIPE, Popen
 from sys import executable as python
-from typing import List, Set
+from typing import Sequence
 
-from . import TOP_PATH
+# Bokeh imports
+from bokeh._testing.util.project import ls_modules
 
 #-----------------------------------------------------------------------------
 # Tests
 #-----------------------------------------------------------------------------
 
-skiplist: Set[str] = set()
+SKIP: Sequence[str] = []
 
 def test_python_execution_with_OO() -> None:
     ''' Running python with -OO will discard docstrings (__doc__ is None)
@@ -40,33 +40,9 @@ def test_python_execution_with_OO() -> None:
     If you encounter a new problem with docstrings being formatted, try
     using format_docstring.
     '''
-    os.chdir(TOP_PATH)
+    imports = [f"import {mod}" for mod in ls_modules(skip_prefixes=SKIP)]
 
-    imports: List[str] = []
-    for path, _, files in os.walk("bokeh"):
-        if "tests" in path:
-            continue
-
-        for file in files:
-            if not file.endswith(".py"):
-                continue
-            if file.endswith("__main__.py"):
-                continue
-
-            if file.endswith("__init__.py"):
-                mod = path.replace(os.sep, ".")
-            else:
-                mod = path.replace(os.sep, ".") + "." + file[:-3]
-
-            if mod in skiplist:
-                continue
-
-            imports.append("import " + mod)
-
-    env = os.environ.copy()
-    env['BOKEH_DOCS_MISSING_API_KEY_OK'] = 'yes'
-
-    proc = Popen([python, "-OO", "-"], stdout=PIPE, stdin=PIPE, env=env)
+    proc = Popen([python, "-OO", "-"], stdout=PIPE, stdin=PIPE)
     proc.communicate("\n".join(imports).encode("utf-8"))
     proc.wait()
 

--- a/tests/codebase/test_windows_reserved_filenames.py
+++ b/tests/codebase/test_windows_reserved_filenames.py
@@ -23,6 +23,7 @@ from os.path import join, splitext
 from typing import List
 
 # Bokeh imports
+from bokeh._testing.util.project import TOP_PATH
 from bokeh.util.string import nice_join
 
 #-----------------------------------------------------------------------------
@@ -36,7 +37,7 @@ def test_windows_reserved_filenames() -> None:
 
     '''
     bad: List[str] = []
-    for path, _, files in os.walk("."):
+    for path, _, files in os.walk(TOP_PATH):
 
         for file in files:
             if splitext(file)[0].upper() in RESERVED_NAMES:


### PR DESCRIPTION
This PR removes unnecessary imports of tornado and refines the "no tornado test" to be much more comprehensive, covering every module unless explicitly noted in an allow-list. In the process other "no import tests" were also made more precise. 

This could certainly be backported, and presumably we will finish the mathtext work on `branch-2.4` so I will add the backport label.