### PR TITLE
Don't report successful flaky tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ max-line-length = 165
 ignore=D001
 
 [tool:pytest]
+addopts = --no-success-flaky-report
 norecursedirs = build _build node_modules
 python_files = *_tests.py *_test.py test_*.py
 markers =


### PR DESCRIPTION
Don't display report on successful flaky tests. Flaky will report only on tests that failed or failed intermittently.