### PR TITLE
Correct path in dev guide server instructions

### DIFF
--- a/sphinx/source/docs/dev_guide/setup.rst
+++ b/sphinx/source/docs/dev_guide/setup.rst
@@ -508,7 +508,7 @@ checkout* directory:
     .. code-tab:: doscon Windows (CMD)
 
         set BOKEH_DEV=false
-        python -m bokeh serve --show \examples\app\sliders.py
+        python -m bokeh serve --show examples\app\sliders.py
 
 This should open up a browser with an interactive figure:
 


### PR DESCRIPTION
Fixes path typo in dev guide setup instructions for Windows. Already discussed with @tcmetzger 
