### PR TITLE
Compute indices' set difference more efficiently

### DIFF
--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -9,7 +9,6 @@ import {CDSView} from "../sources/cds_view"
 import {Color, Indices} from "core/types"
 import * as p from "core/properties"
 import {filter} from "core/util/arrayable"
-import {difference} from "core/util/array"
 import {extend, clone} from "core/util/object"
 import {HitTestResult} from "core/hittest"
 import {Geometry} from "core/geometry"
@@ -291,8 +290,14 @@ export class GlyphRendererView extends DataRendererView {
       selection_glyph = this.selection_glyph
     }
 
-    if (this.hover_glyph != null && inspected_subset_indices.length)
-      indices = difference(indices, inspected_subset_indices)
+    if (this.hover_glyph != null && inspected_subset_indices.length) {
+      // TODO: keep working on Indices instead of converting back and forth
+      const set = new Set(indices)
+      for (const i of inspected_subset_indices) {
+        set.delete(i)
+      }
+      indices = [...set]
+    }
 
     // Render with no selection
     if (!selected_full_indices.length) {


### PR DESCRIPTION
This reduces render time from a few seconds to hundreds of milliseconds (based on the example from issue #11629). Further optimisations are possible.

fixes #11629 
