### PR TITLE
Correct MathText color, size and vertical alignment

### DIFF
--- a/bokehjs/src/lib/models/text/math_text.ts
+++ b/bokehjs/src/lib/models/text/math_text.ts
@@ -414,6 +414,8 @@ export class MathML extends MathText {
 export class TeXView extends MathTextView {
   override model: TeX
 
+  // add method to add color macro here
+
   protected _process_text(text: string): HTMLElement | undefined {
     // TODO: allow plot/document level configuration of macros
     return this.provider.MathJax?.tex2svg(text, undefined, this.model.macros)


### PR DESCRIPTION
Current display of mathtext have different colors, sizes and vertical alignment compared to other Bokeh text. Since we can't do much to change the actual [font MathJax outputs](http://docs.mathjax.org/en/latest/output/fonts.html), we can automatically add macros to match the color from the model it's been used on, and adjust the size and vertical alignment making roughly the same calculations a CSS engine would do if the SVG was displayed on a HTML file.

Currently, if you use 
```python
p.yaxis.axis_label = r"\[\sin(x)\]"
p.yaxis.text_color = "white"
```
MathJax will not know about the color property and the text generated by MathJax will appear in MathJax' default color, unless you explicitly include a MathJax macro, like `r"$${\color{white} \sin(x)}$$"`. This PR will enable styling for MathText, i.e. translate properties into MathJax macros. Only `text_color`, `text_font_size` will be available and more work should be done to respect all Bokeh's standard text properties (https://docs.bokeh.org/en/latest/docs/user_guide/styling.html#userguide-styling-text-properties).

A manually added macro overrides an object property, i.e:
```python
p.yaxis.axis_label = r"$${\color{white} \sin(x)}$$"
p.yaxis.text_color = "green"
```

Will result in a white text, not green.

As of vertical positioning, when we display MathJax on a normal web page it looks like this:
![image](https://user-images.githubusercontent.com/26139868/133868530-3991ce67-bfd7-42b8-a231-75805b502f21.png)
Now, if I give it a border we can see that there is some padding and some vertical alignment that display each element on roughly the alphabetical baseline:
![image](https://user-images.githubusercontent.com/26139868/133868586-748355d9-5cf7-40fc-a656-02ec31941d33.png)
![image](https://user-images.githubusercontent.com/26139868/133868622-cfd24c8f-5062-4e37-b4ba-6a211642e530.png)
We can calculate the same position on Canvas with the correct font metrics, [counting for line height](https://stackoverflow.com/questions/23247467/how-css-line-height-is-measured) and applying the vertical alignment numbers that MathJax includes in the `style` property of the outputted SVG.


- [ ] issues: fixes #xxxx
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
