### PR TITLE
Support "pip install ."

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -53,6 +53,18 @@ jobs:
           name: conda-bld-noarch
           path: conda-bld-noarch.tgz
 
+      - name: Build sdist package
+        shell: bash -l {0}
+        run: python setup.py sdist --install-js
+
+      - name: Build wheel package
+        shell: bash -l {0}
+        run: python setup.py bdist_wheel --install-js
+
+      - name: Verify pip install from sdist
+        shell: bash -l {0}
+        run: bash ci/verify_pip_install_from_sdist.sh
+
   codebase:
     runs-on: ${{ matrix.os }}
 

--- a/_setup_support.py
+++ b/_setup_support.py
@@ -184,8 +184,8 @@ def check_building_dist():
             sys.exit(1)
 
 def fixup_for_packaged():
-    ''' If we are installing FROM an sdist, then a pre-built BokehJS is
-    already installed in the python source tree.
+    ''' If we are installing or building FROM an sdist, then a pre-built
+    BokehJS is already installed in the python source tree.
 
     The command line options ``--build-js`` or ``--install-js`` are
     removed from ``sys.argv``, with a warning.
@@ -194,7 +194,7 @@ def fixup_for_packaged():
     already packaged.
 
     Returns:
-        None
+        True if we are installing or building FROM and sdist, else False
 
     '''
     ROOT = dirname(realpath(__file__))
@@ -208,6 +208,8 @@ def fixup_for_packaged():
                 sys.argv.remove('--install-js')
         if "--existing-js" not in sys.argv:
             sys.argv.append('--existing-js')
+
+        return "--existing-js" in sys.argv
 
 # -----------------------------------------------------------------------------
 # Helpers for operation in the bokehjs dir

--- a/_setup_support.py
+++ b/_setup_support.py
@@ -52,6 +52,9 @@ INSTALL_REQUIRES = [
     'typing_extensions >=3.10.0',
 ]
 
+BUILD_JS = "--build-js"
+INSTALL_JS = "--install-js"
+
 # -----------------------------------------------------------------------------
 # Helpers for command line operations
 # -----------------------------------------------------------------------------
@@ -72,14 +75,20 @@ def show_bokehjs(bokehjs_action, develop=False):
 
     '''
     print()
-    if develop:
-        print("Installed Bokeh for DEVELOPMENT:")
+
+    print("Installed Bokeh for DEVELOPMENT:" if develop else "Installed Bokeh:")
+
+    if bokehjs_action == "built":
+        kind = bright(yellow("NEWLY BUILT"))
+        loc = "bokehjs/build"
+    elif bokehjs_action == "installed":
+        kind = bright(yellow("PREVIOUSLY BUILT"))
+        loc = "bokehjs/build"
     else:
-        print("Installed Bokeh:")
-    if bokehjs_action in ['built', 'installed']:
-        print("  - using %s built BokehJS from bokehjs/build\n" % (bright(yellow("NEWLY")) if bokehjs_action=='built' else bright(yellow("PREVIOUSLY"))))
-    else:
-        print("  - using %s BokehJS, located in 'bokeh.server.static'\n" % bright(yellow("PACKAGED")))
+        kind = bright(yellow("PACKAGED"))
+        loc = "bokeh.server.static"
+    print(f"  - using {kind} BokehJS, from {loc}\n")
+
     print()
 
 def show_help(bokehjs_action):
@@ -94,7 +103,7 @@ def show_help(bokehjs_action):
 
     '''
     print()
-    if bokehjs_action in ['built', 'installed']:
+    if bokehjs_action in ('built', 'installed'):
         print("Bokeh-specific options available with 'install' or 'develop':")
         print()
         print("  --build-js          build and install a fresh BokehJS")
@@ -109,18 +118,18 @@ def show_help(bokehjs_action):
 # Other functions used directly by setup.py
 # -----------------------------------------------------------------------------
 
-def build_or_install_bokehjs():
+def build_or_install_bokehjs(is_packaged):
     ''' Build a new BokehJS (and install it) or install a previously build
     BokehJS.
 
     If no options ``--build-js`` or ``--install-js`` are detected, the
     user is prompted for what to do.
 
-    If ``--existing-js`` is detected, then this setup.py is being run from a
-    packaged sdist, no action is taken.
-
     Note that ``-build-js`` is only compatible with the following ``setup.py``
     commands: install, develop, sdist, egg_info, build
+
+    .. note:
+        If setup.py is being run from a packaged sdist, then no work is done.
 
     Returns:
         str : one of 'built', 'installed', 'packaged'
@@ -128,36 +137,30 @@ def build_or_install_bokehjs():
 
     '''
 
-    # This happens when building from inside a published, pre-packaged sdist
-    # The --existing-js option is not otherwise documented
-    if '--existing-js' in sys.argv:
-        sys.argv.remove('--existing-js')
+    # If (re-)building from inside a published, pre-packaged sdist, then no
+    # need to do anything -- BokehJS is already built and inside the package
+    if is_packaged:
         return "packaged"
 
-    if '--build-js' not in sys.argv and '--install-js' not in sys.argv:
-        jsbuild = jsbuild_prompt()
+    if BUILD_JS not in sys.argv and INSTALL_JS not in sys.argv:
+        sys.argv.append(jsbuild_prompt())
 
-    elif '--build-js' in sys.argv:
-        jsbuild = True
-        sys.argv.remove('--build-js')
-
-    # must be "--install-js"
-    else:
-        jsbuild = False
-        sys.argv.remove('--install-js')
-
-    jsbuild_ok = ('install', 'develop', 'sdist', 'bdist_wheel', 'egg_info', 'build')
-    if jsbuild and not any(arg in sys.argv for arg in jsbuild_ok):
-        print("Error: Option '--build-js' only valid with 'install', 'develop', 'sdist', 'bdist_wheel', or 'build', exiting.")
-        sys.exit(1)
-
-    if jsbuild:
-        build_js()
-        install_js()
-        return "built"
-    else:
+    if INSTALL_JS in sys.argv:
+        sys.argv.remove(INSTALL_JS)
         install_js()
         return "installed"
+
+    # must be "--build-js"
+    sys.argv.remove(BUILD_JS)
+
+    jsbuild_ok = ('install', 'develop', 'sdist', 'bdist_wheel', 'egg_info', 'build')
+    if not any(arg in sys.argv for arg in jsbuild_ok):
+        print("Error: Option --build-js only valid with 'install', 'develop', 'sdist', 'bdist_wheel', or 'build', exiting.")
+        sys.exit(1)
+
+    build_js()
+    install_js()
+    return "built"
 
 def conda_rendering():
     return os.getenv("CONDA_BUILD_STATE" ,"junk") == "RENDER"
@@ -166,21 +169,25 @@ def check_python():
     if sys.version_info[:2] < MIN_PYTHON_VERSION:
         raise RuntimeError("Bokeh requires Python >= " + ".".join(str(x) for x in MIN_PYTHON_VERSION))
 
+def check_packaged():
+    ROOT = dirname(realpath(__file__))
+    return exists(join(ROOT, 'PKG-INFO'))
+
 def check_building_dist():
     ''' Check for 'sdist' or `bdist_wheel` and ensure we always build or install
     BokehJS when packaging.
 
     Source distributions (sdists) and wheels do not ship with BokehJS source
     code, but  must ship with a pre-built BokehJS library. This function checks
-    ``sys.argv`` to ensure that ``--build-js`` or ``--install-js` is present.
+    ``sys.argv`` to ensure that ``--build-js`` or ``--install-js`` is present.
 
     Returns:
         None
 
     '''
     for dist in ("sdist", "bdist_wheel"):
-        if dist in sys.argv and ("--install-js" not in sys.argv and "--build-js" not in sys.argv):
-            print(f"Error: Option '--build-js' or '--install-js' must be present with {dist!r}, exiting.")
+        if dist in sys.argv and (INSTALL_JS not in sys.argv and BUILD_JS not in sys.argv):
+            print(f"Error: Option --build-js or --install-js must be present with {dist!r}, exiting.")
             sys.exit(1)
 
 def fixup_for_packaged():
@@ -190,26 +197,16 @@ def fixup_for_packaged():
     The command line options ``--build-js`` or ``--install-js`` are
     removed from ``sys.argv``, with a warning.
 
-    Also adds ``--existing-js`` to ``sys.argv`` to signal that BokehJS is
-    already packaged.
-
     Returns:
         True if we are installing or building FROM and sdist, else False
 
     '''
-    ROOT = dirname(realpath(__file__))
-
-    if exists(join(ROOT, 'PKG-INFO')):
-        if "--build-js" in sys.argv or "--install-js" in sys.argv:
-            print(SDIST_BUILD_WARNING)
-            if "--build-js" in sys.argv:
-                sys.argv.remove('--build-js')
-            if "--install-js" in sys.argv:
-                sys.argv.remove('--install-js')
-        if "--existing-js" not in sys.argv:
-            sys.argv.append('--existing-js')
-
-        return "--existing-js" in sys.argv
+    if BUILD_JS in sys.argv or INSTALL_JS in sys.argv:
+        print(SDIST_BUILD_WARNING)
+        if BUILD_JS in sys.argv:
+            sys.argv.remove(BUILD_JS)
+        if INSTALL_JS in sys.argv:
+            sys.argv.remove(INSTALL_JS)
 
 # -----------------------------------------------------------------------------
 # Helpers for operation in the bokehjs dir
@@ -219,14 +216,14 @@ def jsbuild_prompt():
     ''' Prompt users whether to build a new BokehJS or install an existing one.
 
     Returns:
-        bool : True, if a new build is requested, False otherwise
+        str
 
     '''
     print(BOKEHJS_BUILD_PROMPT)
-    mapping = {"1": True, "2": False}
+    mapping = {"1": BUILD_JS, "2": INSTALL_JS}
     value = input("Choice? ")  # lgtm [py/use-of-input]
     while value not in mapping:
-        print("Input '%s' not understood. Valid choices: 1, 2\n" % value)
+        print(f"Input {value!r} not understood. Valid choices: 1, 2\n")
         value = input("Choice? ")  # lgtm [py/use-of-input]
     return mapping[value]
 

--- a/ci/verify_pip_install_from_sdist.sh
+++ b/ci/verify_pip_install_from_sdist.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -x #echo on
+set -e #exit on error
+
+pushd dist
+tar xvzf bokeh-*.tar.gz
+cd `ls -d */ | cut -f1 -d'/'`
+pip install .
+bokeh info
+popd

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ from setuptools import find_packages, setup
 import versioneer
 
 from _setup_support import ( # isort:skip
-    build_or_install_bokehjs, check_building_dist, check_python,
+    build_or_install_bokehjs, check_building_dist, check_packaged, check_python,
     conda_rendering, fixup_for_packaged, install_js, show_bokehjs, show_help,
     INSTALL_REQUIRES,
 )
@@ -80,11 +80,14 @@ if len(sys.argv) == 2 and sys.argv[-1] == '--install-js':
 
 # if this is just conda-build skimming information, skip all this actual work
 if not conda_rendering():
-    is_packaged = fixup_for_packaged()  # --build-js and --install-js not valid FROM sdist
-    if not is_packaged:
+    is_packaged = check_packaged()
+
+    if is_packaged:
+        fixup_for_packaged()  # --build-js and --install-js not valid FROM sdist
+    else:
         check_building_dist()  # must build or install BokehJS when MAKING dists
 
-    bokehjs_action = build_or_install_bokehjs()
+    bokehjs_action = build_or_install_bokehjs(is_packaged)
 
 setup(
     # basic package metadata

--- a/setup.py
+++ b/setup.py
@@ -80,8 +80,9 @@ if len(sys.argv) == 2 and sys.argv[-1] == '--install-js':
 
 # if this is just conda-build skimming information, skip all this actual work
 if not conda_rendering():
-    fixup_for_packaged()   # --build_js and --install_js not valid FROM sdist
-    check_building_dist() # must build or install BokehJS when MAKING dists
+    is_packaged = fixup_for_packaged()  # --build-js and --install-js not valid FROM sdist
+    if not is_packaged:
+        check_building_dist()  # must build or install BokehJS when MAKING dists
 
     bokehjs_action = build_or_install_bokehjs()
 


### PR DESCRIPTION
This PR fixes argument checking to allow `setup.py bdist_wheel` to proceed FROM an sdist, using the pre-built BokehJS inside the sdist, without any additional command line arguments. As a consequence, `pip install .` now also works from inside an sdist. 

Steps have been added to confirm that all of the following function:

* `python setup.py sdist --install-js`  (what WE used to build official sdist)
* `python setup.py bdist_wheel --install-js` (what WE use  to build official wheel)
* `pip install .` from exploded sdist (what OTHERS use to re-package)

Additionally some of the extremely gorpy logic in the `setup.py` and `_setup_support.py` was streamlined and simplified. 

- [x] issues: fixes #11658
- [x] tests added / passed

cc @ocefpaf

```
~/work/bokeh/dist bryanv/11658_sdist_pip_install*
piptest ❯ cd bokeh-2.4.0+13.gf4a36c48c.dirty

~/work/bokeh/dist/bokeh-2.4.0+13.gf4a36c48c.dirty bryanv/11658_sdist_pip_install*
piptest ❯ pip install .
Processing /Users/bryan/work/bokeh/dist/bokeh-2.4.0+13.gf4a36c48c.dirty
  DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
   pip 21.3 will remove support for this functionality. You can find discussion regarding this at https://github.com/pypa/pip/issues/7555.
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Requirement already satisfied: tornado>=5.1 in /Users/bryan/anaconda/envs/piptest/lib/python3.9/site-packages (from bokeh==2.4.0+13.gf4a36c48c.dirty) (6.1)
Requirement already satisfied: PyYAML>=3.10 in /Users/bryan/anaconda/envs/piptest/lib/python3.9/site-packages (from bokeh==2.4.0+13.gf4a36c48c.dirty) (5.4.1)
Requirement already satisfied: pillow>=7.1.0 in /Users/bryan/anaconda/envs/piptest/lib/python3.9/site-packages (from bokeh==2.4.0+13.gf4a36c48c.dirty) (8.3.2)
Requirement already satisfied: Jinja2>=2.9 in /Users/bryan/anaconda/envs/piptest/lib/python3.9/site-packages (from bokeh==2.4.0+13.gf4a36c48c.dirty) (3.0.1)
Requirement already satisfied: packaging>=16.8 in /Users/bryan/anaconda/envs/piptest/lib/python3.9/site-packages (from bokeh==2.4.0+13.gf4a36c48c.dirty) (21.0)
Requirement already satisfied: numpy>=1.11.3 in /Users/bryan/anaconda/envs/piptest/lib/python3.9/site-packages (from bokeh==2.4.0+13.gf4a36c48c.dirty) (1.21.2)
Requirement already satisfied: typing-extensions>=3.10.0 in /Users/bryan/anaconda/envs/piptest/lib/python3.9/site-packages (from bokeh==2.4.0+13.gf4a36c48c.dirty) (3.10.0.2)
Requirement already satisfied: MarkupSafe>=2.0 in /Users/bryan/anaconda/envs/piptest/lib/python3.9/site-packages (from Jinja2>=2.9->bokeh==2.4.0+13.gf4a36c48c.dirty) (2.0.1)
Requirement already satisfied: pyparsing>=2.0.2 in /Users/bryan/anaconda/envs/piptest/lib/python3.9/site-packages (from packaging>=16.8->bokeh==2.4.0+13.gf4a36c48c.dirty) (2.4.7)
Building wheels for collected packages: bokeh
  Building wheel for bokeh (PEP 517) ... done
  Created wheel for bokeh: filename=bokeh-2.4.0+13.gf4a36c48c.dirty-py3-none-any.whl size=18435401 sha256=244da27e8e3342611aad8ee514e1c5011788466851e09d78d401a0dfdebc421e
  Stored in directory: /Users/bryan/Library/Caches/pip/wheels/bb/99/dd/a169981d055fed11ef0ba4e587ba8a419c3e3e905e3754370d
Successfully built bokeh
Installing collected packages: bokeh
Successfully installed bokeh-2.4.0+13.gf4a36c48c.dirty

~/work/bokeh/dist/bokeh-2.4.0+13.gf4a36c48c.dirty bryanv/11658_sdist_pip_install* 15s
piptest ❯ bokeh info
Python version      :  3.9.7 (default, Sep 16 2021, 08:50:36)
IPython version     :  (not installed)
Tornado version     :  6.1
Bokeh version       :  2.4.0+13.gf4a36c48c.dirty
BokehJS static path :  /Users/bryan/anaconda/envs/piptest/lib/python3.9/site-packages/bokeh/server/static
node.js version     :  (not installed)
npm version         :  (not installed)
```

