### PR TITLE
Implement MathText on titles

### DIFF
--- a/bokehjs/src/lib/models/annotations/title.ts
+++ b/bokehjs/src/lib/models/annotations/title.ts
@@ -1,16 +1,33 @@
 import {TextAnnotation, TextAnnotationView} from "./text_annotation"
 import {VerticalAlign, TextAlign} from "core/enums"
-import {TextBox} from "core/graphics"
 import {Size, Layoutable} from "core/layout"
 import {Panel} from "core/layout/side_panel"
 import * as mixins from "core/property_mixins"
 import * as p from "core/properties"
+import {BaseTextView} from "../text/base_text"
+import {BaseText} from "../text/base_text"
+import {build_view} from "core/build_views"
+import {isString} from "core/util/types"
+import {parse_delimited_string} from "models/text/utils"
 
 export class TitleView extends TextAnnotationView {
   override model: Title
   override visuals: Title.Visuals
   override layout: Layoutable
   override panel: Panel
+
+  /*private*/ _title_view: BaseTextView | null = null
+
+  override async lazy_initialize(): Promise<void> {
+    await super.lazy_initialize()
+
+    const title_temp = this.model.text
+    if (title_temp != null) {
+      const _title_temp = isString(title_temp) ? parse_delimited_string(title_temp) : title_temp
+      this._title_view = await build_view(_title_temp, {parent: this})
+    } else
+      this._title_view = null
+  }
 
   protected _get_location(): [number, number] {
     const hmargin = this.model.offset
@@ -69,24 +86,34 @@ export class TitleView extends TextAnnotationView {
 
   protected _render(): void {
     const {text} = this.model
-    if (text == null || text.length == 0)
+    if (text == null)
       return
 
     this.model.text_baseline = this.model.vertical_align
     this.model.text_align = this.model.align
 
     const [sx, sy] = this._get_location()
-    const angle = this.panel.get_label_angle_heuristic("parallel")
+    const position = {
+      sx,
+      sy,
+      x_anchor: this.model.align,
+      //y_anchor: this.model.vertical_align,
+    }
 
-    const draw = this.model.render_mode == "canvas" ? this._canvas_text.bind(this) : this._css_text.bind(this)
-    draw(this.layer.ctx, text, sx, sy, angle)
+    const title_graphics = this._title_view!.graphics()
+
+    title_graphics.visuals = this.visuals.text.values()
+    title_graphics.angle = this.panel.get_label_angle_heuristic("parallel")
+    title_graphics.position = position
+    title_graphics.align = this.model.align
+
+    title_graphics.paint(this.layer.ctx)
   }
 
   protected override _get_size(): Size {
-    const {text} = this.model
-    const graphics = new TextBox({text})
-    graphics.visuals = this.visuals.text.values()
-    const {width, height} = graphics.size()
+    const title_graphics = this._title_view!.graphics()
+    title_graphics.visuals = this.visuals.text.values()
+    const {width, height} = title_graphics.size()
     // XXX: The magic 2px is for backwards compatibility. This will be removed at
     // some point, but currently there is no point breaking half of visual tests.
     return {width, height: height == 0 ? 0 : 2 + height + this.model.standoff}
@@ -97,7 +124,7 @@ export namespace Title {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = TextAnnotation.Props & {
-    text: p.Property<string>
+    text: p.Property<string | BaseText | null>
     vertical_align: p.Property<VerticalAlign>
     align: p.Property<TextAlign>
     offset: p.Property<number>
@@ -131,8 +158,8 @@ export class Title extends TextAnnotation {
       ["background_", mixins.Fill],
     ])
 
-    this.define<Title.Props>(({Number, String}) => ({
-      text:             [ String, "" ],
+    this.define<Title.Props>(({Number, String, Or, Ref, Nullable}) => ({
+      text:             [ Nullable(Or(String, Ref(BaseText))), null],
       vertical_align:   [ VerticalAlign, "bottom" ],
       align:            [ TextAlign, "left" ],
       offset:           [ Number, 0 ],


### PR DESCRIPTION
WIP to add MathText to titles, which is item 1 of issue #11355 and is part of the CZI R3 grant.  So far the example code
```python
from bokeh.plotting import figure, curdoc
p = figure(width=300, height=250)
p.line([1, 2, 3], [2, 1, 3], line_width=15)
p.title = r"$$\gamma = 2\pi^2 + 3 \int \exp\left(\frac{\alpha}{2}\right) dx$$"
curdoc().add_root(p)
```
produces
![Screenshot 2021-09-23 at 16-10-09 Bokeh Application](https://user-images.githubusercontent.com/580326/134534517-c84b2351-05c1-4a25-bef3-1fc1ce2bc7f3.png)
Development process has been to follow a similar approach to that used for axis labels.  To do:
1. Vertical alignment is incorrect.
2. Non-MathText (i.e. string) titles no longer show correct background color, border lines to multi-line alignment.
3. Visual tests required.

