### PR TITLE
Fix duplicate value change in autocomplete_input

### DIFF
--- a/bokehjs/src/lib/models/widgets/autocomplete_input.ts
+++ b/bokehjs/src/lib/models/widgets/autocomplete_input.ts
@@ -40,8 +40,7 @@ export class AutocompleteInputView extends TextInputView {
       this.input_el.focus()
       this._hide_menu()
     }
-
-    if (!this.model.restrict) {
+    else if (!this.model.restrict) {
       super.change_input()
     }
   }

--- a/bokehjs/src/lib/models/widgets/autocomplete_input.ts
+++ b/bokehjs/src/lib/models/widgets/autocomplete_input.ts
@@ -39,8 +39,7 @@ export class AutocompleteInputView extends TextInputView {
       this.model.value = this.menu.children[this._hover_index].textContent!
       this.input_el.focus()
       this._hide_menu()
-    }
-    else if (!this.model.restrict) {
+    } else if (!this.model.restrict) {
       super.change_input()
     }
   }


### PR DESCRIPTION
- [x] issues: fixes #11670
- [x] integration tests added/passed

Issue: If `AutocompleteInput(...restrict=False)`, the input value would be assigned twice when selecting a valid completion.

Here's the solution in pseudocode:
```
    if (this._open && this.menu.children.length > 0) {
        // valid completion options are available, set value from menu
    } else if (!this.model.restrict) {
        // not restricted, so set as normal text input
    }
```