### PR TITLE
build BokehJS by default

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,9 +65,8 @@ from setuptools import find_packages, setup
 import versioneer
 
 from _setup_support import ( # isort:skip
-    build_or_install_bokehjs, check_building_dist, check_packaged, check_python,
-    conda_rendering, fixup_for_packaged, install_js, show_bokehjs, show_help,
-    INSTALL_REQUIRES,
+    build_or_install_bokehjs, check_packaged, check_python, conda_rendering,
+    install_js, show_bokehjs, show_help, INSTALL_REQUIRES,
 )
 
 # bail on unsupported Python versions
@@ -81,13 +80,7 @@ if len(sys.argv) == 2 and sys.argv[-1] == '--install-js':
 # if this is just conda-build skimming information, skip all this actual work
 if not conda_rendering():
     is_packaged = check_packaged()
-
-    if is_packaged:
-        fixup_for_packaged()  # --build-js and --install-js not valid FROM sdist
-    else:
-        check_building_dist()  # must build or install BokehJS when MAKING dists
-
-    bokehjs_action = build_or_install_bokehjs(is_packaged)
+    bokehjs_action = "packaged" if is_packaged else build_or_install_bokehjs()
 
 setup(
     # basic package metadata

--- a/sphinx/source/docs/dev_guide/setup.rst
+++ b/sphinx/source/docs/dev_guide/setup.rst
@@ -232,7 +232,7 @@ different local version instead, use the ``--install-js`` flag:
 
 .. _contributor_guide_setup_sample_data:
 
-1. Download sample data
+7. Download sample data
 -----------------------
 
 Several tests and examples require Bokeh's sample data to be available on your

--- a/sphinx/source/docs/dev_guide/setup.rst
+++ b/sphinx/source/docs/dev_guide/setup.rst
@@ -200,45 +200,26 @@ script is located at the top level of the *source checkout* directory.
 The ``setup.py`` script has two main modes of operation:
 
 ``python setup.py develop``
-    Bokeh will be installed to refer to the source directory. Any changes
-    you make to the python source code will be available immediately without
+    Bokeh will be installed to refer to your local source directory. Any changes
+    you make to the Python source code will be available immediately without
     any additional steps. **This is the recommended mode when working on the
     Bokeh codebase.**
 
 ``python setup.py install``
-    Bokeh will be installed in your Python ``site-packages`` directory.
+    Bokeh will be installed in your local Python ``site-packages`` directory.
     In this mode, any changes to the Python source code will have no effect
     until you run ``setup.py install`` again.
 
-With either mode, Bokeh asks you how to install :term:`BokehJS`. For
-example:
-
-.. code-block:: sh
-
-    python setup.py develop
-
-    Bokeh includes a JavaScript library (BokehJS) that has its own
-    build process. How would you like to handle BokehJS:
-
-    1) build and install fresh BokehJS
-    2) install last built BokehJS from bokeh/bokehjs/build
-
-    Choice?
-
-Unless you know what you are doing, you should choose option 1 here. At the very
-least, you need to build BokehJS the first time you set up your local
-development environment.
-
-You can skip this prompt by supplying the appropriate command-line option
-to ``setup.py``. For example:
-
-* ``python setup.py develop --build-js``
-* ``python setup.py develop --install-js``
+Running either of those two commands also builds and installs a local version of
+:term:`BokehJS`. If you want to skip building a new version of BokehJS and use a
+different local version instead, use the ``--install-js`` flag:
+``python setup.py develop --install-js``
 
 .. note::
     You need to **rebuild BokehJS each time the BokehJS source code changes**.
-    This can become necessary because you made changes yourself or because you
-    pulled updated code from GitHub.
+    This can be necessary because you made changes yourself or because you
+    pulled updated code from GitHub. Re-run ``python setup.py develop`` to build
+    and install BokehJS.
 
     Occasionally, the **list of JavaScript dependencies also changes**. If this
     happens, you will need to re-run the instructions in the
@@ -251,7 +232,7 @@ to ``setup.py``. For example:
 
 .. _contributor_guide_setup_sample_data:
 
-7. Download sample data
+1. Download sample data
 -----------------------
 
 Several tests and examples require Bokeh's sample data to be available on your


### PR DESCRIPTION
With this PR The following is possible

```
# These all behave same as --build-js
python setup.py install
python setup.py develop
python setup.py sdist
python setup.py bdist_wheel
pip install .
```

Flags `--build-js` or `--install-js` can be added to any of the above to be explicit. 

Additionally, building from sdist will still use the packaged BokehJS and warn/fixup if either `--build-js` or `--install-js` is supplied. 