### PR TITLE
drop sphinx layout template customizations

### DIFF
--- a/ci/environment-release-build.yml
+++ b/ci/environment-release-build.yml
@@ -44,7 +44,7 @@ dependencies:
   - pip:
     # docs
     - autoclasstoc
-    - pydata_sphinx_theme
+    - pydata_sphinx_theme >=0.7.1
     - sphinx >=4.1
     - sphinxext-opengraph
     - sphinx-panels

--- a/ci/environment-test-3.7.yml
+++ b/ci/environment-test-3.7.yml
@@ -66,7 +66,7 @@ dependencies:
   - pip:
     # docs
     - autoclasstoc
-    - pydata_sphinx_theme
+    - pydata_sphinx_theme >=0.7.1
     - sphinx >=4.1
     - sphinxext-opengraph
     - sphinx-panels

--- a/ci/environment-test-3.8.yml
+++ b/ci/environment-test-3.8.yml
@@ -66,7 +66,7 @@ dependencies:
   - pip:
     # docs
     - autoclasstoc
-    - pydata_sphinx_theme
+    - pydata_sphinx_theme >=0.7.1
     - sphinx >=4.1
     - sphinxext-opengraph
     - sphinx-panels

--- a/ci/environment-test-3.9.yml
+++ b/ci/environment-test-3.9.yml
@@ -66,7 +66,7 @@ dependencies:
   - pip:
     # docs
     - autoclasstoc
-    - pydata_sphinx_theme
+    - pydata_sphinx_theme >=0.7.1
     - sphinx >=4.1
     - sphinxext-opengraph
     - sphinx-panels

--- a/environment.yml
+++ b/environment.yml
@@ -77,7 +77,7 @@ dependencies:
   - pip:
     # docs
     - autoclasstoc
-    - pydata_sphinx_theme
+    - pydata_sphinx_theme >= 0.7.1
     - sphinx >=4.1
     - sphinxext-opengraph
     - sphinx-reredirects

--- a/sphinx/source/_templates/layout.html
+++ b/sphinx/source/_templates/layout.html
@@ -14,40 +14,6 @@
     <link rel="icon" type="image/png" sizes="16x16" href="https://static.bokeh.org/favicon/favicon-16x16.png">
 {%- endblock %}
 
-{% block docs_sidebar %}
-  <!-- Only show if we have sidebars configured -->
-  {% if sidebars %}
-  {{ super() }}
-  {% endif %}
-{% endblock %}
-
-{% block docs_toc %}
-  <!-- Only show if we have sidebars configured -->
-  {% if sidebars %}
-  {{ super() }}
-  {% endif %}
-{% endblock %}
-
-{% block docs_main %}
-{% if sidebars %}
-  {% set content_col_class = "col-md-9 col-xl-7" %}
-{% else %}
-  {% set content_col_class = "col-md-12" %}
-{% endif %}
-<main class="col-12 {{ content_col_class }} py-md-5 pl-md-5 pr-md-4 bd-content" role="main">
-    {% block docs_body %}
-    <div>
-      {% block body %} {% endblock %}
-    </div>
-    {% endblock %}
-    {% if theme_show_prev_next %}
-    <div class='prev-next-bottom'>
-      {{ prev_next(prev, next) }}
-    </div>
-    {% endif %}
-</main>
-{% endblock %}
-
 {%- block scripts_end %}
 {{ super() }}
 {%- include "scripts.html" %}


### PR DESCRIPTION
- [x] issues: fixes #11713
- [x] release document entry (if new feature or API change)


ref: https://github.com/pydata/pydata-sphinx-theme/issues/489

cc @tcmetzger After comparing out `layout.html` template customizations with the current state of the official theme template, I think we can just now drop most all of them. The only issue I see os that the prev/next links are not styled nicely anymore:

#### new

<img width="861" alt="Screen Shot 2021-10-03 at 12 29 14" src="https://user-images.githubusercontent.com/1078448/135768676-dabdc450-e109-43cb-ba21-b580eb1c23e7.png">

#### old


<img width="965" alt="Screen Shot 2021-10-03 at 12 30 46" src="https://user-images.githubusercontent.com/1078448/135768746-7e3ef8c4-03f5-486f-9702-095e489559c8.png">


But I assume that is just a CSS issue to resolve. 

Can you build this locally and see if there are any other issues I have missed? And if possible, see if there is a quick CSS change to improve the prev/next links. 

