### PR TITLE
Removed a manual file handler pitfall

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -1141,7 +1141,7 @@ def do_vcs_install(manifest_in, versionfile_source, ipy):
     files.append(versioneer_file)
     present = False
     try:
-        with open(".gitattributes", "r") as f: 
+        with open(".gitattributes", "r") as f:
             for line in f.readlines():
                 if line.strip().startswith(versionfile_source):
                     if "export-subst" in line.strip().split()[1:]:


### PR DESCRIPTION
**The problem**
There was a case where the code was using a manual file handler pitfall, where a file stream was being opened and closed manually. But since Python supports automatic stream closing using the block 'with', its better to use it instead of the manual close in order to remove a bug vector.

**Solution**
Refactored the code to remove the manual file handler