### PR TITLE
Include version pattern in workflow input description

### DIFF
--- a/.github/workflows/bokeh-release-build.yml
+++ b/.github/workflows/bokeh-release-build.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to build a release for"
+        description: "Version to build a release for (e.g. 3.0.0, 2.4.0dev8)"
         required: true
 
 env:

--- a/.github/workflows/bokeh-release-deploy.yml
+++ b/.github/workflows/bokeh-release-deploy.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to deploy a release for"
+        description: "Version to deploy a release for (e.g. 3.0.0, 2.4.0dev8)"
         required: true
 
 env:


### PR DESCRIPTION
I never remember what version pattern should I use, especially when publishing a dev release. Thus I added examples that will be displayed in `Run workflow` menu. It would be nice to also distinguish different workflow runs (currently it's all either `Release - Build` or `Release - Deploy`), but I'm not sure if that's possible with workflow file syntax.

/cc @bryevdv, @bokeh/dev