### PR TITLE
Remove `CDSView.source` and infer the source from `CDSView`'s parent

### DIFF
--- a/bokeh/core/validation/errors.py
+++ b/bokeh/core/validation/errors.py
@@ -43,10 +43,6 @@ validation checks.
     A |Scale| type is incompatible with one or more ranges on the same plot
     dimension (will result in blank plot).
 
-1010 *(CDSVIEW_SOURCE_DOESNT_MATCH)*
-    A |GlyphRenderer| has a ``CDSView`` whose source doesn't match the ``GlyphRenderer``'s
-    data source.
-
 1011 *(MALFORMED_GRAPH_SOURCE)*
     The ``GraphSource`` is incorrectly configured.
 
@@ -158,10 +154,6 @@ INCOMPATIBLE_SCALE_AND_RANGE = Error(
     1009,
     "INCOMPATIBLE_SCALE_AND_RANGE",
     "A Scale is incompatible with one or more ranges on the same plot dimension")
-CDSVIEW_SOURCE_DOESNT_MATCH = Error(
-    1010,
-    "CDSVIEW_SOURCE_DOESNT_MATCH",
-    "CDSView used by Glyph renderer must have a source that matches the Glyph renderer's data source")
 MALFORMED_GRAPH_SOURCE = Error(
     1011,
     "MALFORMED_GRAPH_SOURCE",

--- a/bokeh/models/renderers.py
+++ b/bokeh/models/renderers.py
@@ -44,7 +44,6 @@ from ..core.validation import error
 from ..core.validation.errors import (
     BAD_COLUMN_NAME,
     CDSVIEW_FILTERS_WITH_CONNECTED,
-    CDSVIEW_SOURCE_DOESNT_MATCH,
     MALFORMED_GRAPH_SOURCE,
     MISSING_GLYPH,
     NO_SOURCE_FOR_GLYPH,
@@ -175,10 +174,6 @@ class GlyphRenderer(DataRenderer):
     def _check_no_source_for_glyph(self):
         if not self.data_source: return str(self)
 
-    @error(CDSVIEW_SOURCE_DOESNT_MATCH)
-    def _check_cdsview_source(self):
-        if self.data_source is not self.view.source: return str(self)
-
     @error(BAD_COLUMN_NAME)
     def _check_bad_column_name(self):
         if not self.glyph: return
@@ -199,16 +194,11 @@ class GlyphRenderer(DataRenderer):
             missing = ['key "%s" value "%s' % (k, v) for v, k in missing_values]
             return "%s [renderer: %s]" % (", ".join(sorted(missing)), self)
 
-    def __init__(self, **kwargs) -> None:
-        super().__init__(**kwargs)
-        if "view" not in kwargs and "data_source" in kwargs:
-            self.view = CDSView(source=self.data_source)
-
     data_source = Instance(DataSource, help="""
     Local data source to use when rendering glyphs on the plot.
     """)
 
-    view = Instance(CDSView, help="""
+    view = Instance(CDSView, default=lambda: CDSView(), help="""
     A view into the data source to use when rendering glyphs. A default view
     of the entire data source is created when a view is not passed in during
     initialization.

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -731,11 +731,6 @@ class CDSView(Model):
     List of filters that the view comprises.
     """)
 
-    source = Instance(ColumnarDataSource, help="""
-    The ``ColumnDataSource`` associated with this view. Used to determine
-    the length of the columns.
-    """)
-
 class GeoJSONDataSource(ColumnarDataSource):
     '''
 

--- a/bokeh/models/util/structure.py
+++ b/bokeh/models/util/structure.py
@@ -333,7 +333,7 @@ class _BokehStructureGraph:
         model_id = self._node_source.data["index"][0]
         groupfilter = GroupFilter(column_name="id", group=model_id)
 
-        data_table2_view = CDSView(source=prop_source, filters=[groupfilter])
+        data_table2_view = CDSView(filters=[groupfilter])
         data_table2 = DataTable(
             source=prop_source,
             view=data_table2_view,

--- a/bokeh/models/widgets/tables.py
+++ b/bokeh/models/widgets/tables.py
@@ -632,16 +632,11 @@ class TableWidget(Widget):
     The source of data for the widget.
     """)
 
-    view = Instance(CDSView, help="""
+    view = Instance(CDSView, default=lambda: CDSView(), help="""
     A view into the data source to use when rendering table rows. A default view
     of the entire data source is created if a view is not passed in during
     initialization.
     """)
-
-    def __init__(self, **kw) -> None:
-        super().__init__(**kw)
-        if "view" not in kw:
-            self.view = CDSView(source=self.source)
 
 class DataTable(TableWidget):
     ''' Two-dimensional grid for visualization and editing large amounts

--- a/bokehjs/src/lib/api/figure.ts
+++ b/bokehjs/src/lib/api/figure.ts
@@ -16,7 +16,7 @@ import {
   Range, Range1d, DataRange1d, FactorRange,
   Scale, LinearScale, LogScale, CategoricalScale,
   LinearAxis, LogAxis, CategoricalAxis, DatetimeAxis, MercatorAxis,
-  ColumnarDataSource, ColumnDataSource, CDSView,
+  ColumnarDataSource, ColumnDataSource,
   Plot, Tool, ContinuousTicker,
   CoordinateMapping,
 } from "./models"
@@ -395,7 +395,7 @@ export class Figure extends BaseFigure {
     const data = clone(source.data)
     delete attrs.source
 
-    const view = attrs.view != null ? attrs.view : new CDSView({source})
+    const {view} = attrs
     delete attrs.view
 
     const legend = attrs.legend

--- a/bokehjs/src/lib/models/mappers/continuous_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/continuous_color_mapper.ts
@@ -74,6 +74,9 @@ export abstract class ContinuousColorMapper extends ColorMapper {
   protected *_collect(domain: [GlyphRenderer, string | string[]][]) {
     for (const [renderer, fields] of domain) {
       for (const field of isArray(fields) ? fields : [fields]) {
+        if (renderer.view.indices == null) // TODO: use is_unset
+          continue
+
         let array = renderer.data_source.get_column(field)!
         array = renderer.view.indices.select(array)
 

--- a/bokehjs/src/lib/models/sources/cds_view.ts
+++ b/bokehjs/src/lib/models/sources/cds_view.ts
@@ -1,16 +1,66 @@
 import {Model} from "../../model"
 import * as p from "core/properties"
 import {Selection} from "../selections/selection"
+import {View} from "core/view"
 import {Indices} from "core/types"
 import {Filter} from "../filters/filter"
 import {ColumnarDataSource} from "./columnar_data_source"
+
+export class CDSViewView extends View {
+  override model: CDSView
+  override parent: View & {readonly data_source: p.Property<ColumnarDataSource>}
+
+  override initialize(): void {
+    super.initialize()
+    this.compute_indices()
+  }
+
+  override connect_signals(): void {
+    super.connect_signals()
+
+    const {filters} = this.model.properties
+    this.on_change(filters, () => this.compute_indices())
+
+    const connect_listeners = () => {
+      const fn = () => this.compute_indices()
+      const source = this.parent.data_source.get_value()
+      this.connect(source.change, fn)
+      this.connect(source.streaming, fn)
+      this.connect(source.patching, fn)
+    }
+
+    connect_listeners()
+
+    const {data_source} = this.parent
+    this.on_change(data_source, () => {
+      // TODO: disconnect
+      connect_listeners()
+    })
+  }
+
+  compute_indices(): void {
+    // XXX: if the data source is empty, there still may be one
+    // index originating from glyph's scalar values.
+    const source = this.parent.data_source.get_value()
+
+    const size = source.get_length() ?? 1
+    const indices = Indices.all_set(size)
+
+    for (const filter of this.model.filters) {
+      indices.intersect(filter.compute_indices(source))
+    }
+
+    this.model.indices = indices
+    this.model._indices_map_to_subset()
+  }
+}
 
 export namespace CDSView {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = Model.Props & {
     filters: p.Property<Filter[]>
-    source: p.Property<ColumnarDataSource>
+    // internal
     indices: p.Property<Indices>
     indices_map: p.Property<{[key: string]: number}>
     masked: p.Property<Indices | null>
@@ -21,15 +71,17 @@ export interface CDSView extends CDSView.Attrs {}
 
 export class CDSView extends Model {
   override properties: CDSView.Props
+  override __view_type__: CDSViewView
 
   constructor(attrs?: Partial<CDSView.Attrs>) {
     super(attrs)
   }
 
   static {
+    this.prototype.default_view = CDSViewView
+
     this.define<CDSView.Props>(({Array, Ref}) => ({
       filters: [ Array(Ref(Filter)), [] ],
-      source:  [ Ref(ColumnarDataSource) ],
     }))
 
     this.internal<CDSView.Props>(({Int, Dict, Ref, Nullable}) => ({
@@ -39,65 +91,10 @@ export class CDSView extends Model {
     }))
   }
 
-  override initialize(): void {
-    super.initialize()
-    this.compute_indices()
-  }
-
-  override connect_signals(): void {
-    super.connect_signals()
-
-    this.connect(this.properties.filters.change, () => this.compute_indices())
-
-    const connect_listeners = () => {
-      const fn = () => this.compute_indices()
-
-      if (this.source != null) {
-        this.connect(this.source.change, fn)
-
-        if (this.source instanceof ColumnarDataSource) {
-          this.connect(this.source.streaming, fn)
-          this.connect(this.source.patching, fn)
-        }
-      }
-    }
-
-    let initialized = this.source != null
-
-    if (initialized)
-      connect_listeners()
-    else {
-      this.connect(this.properties.source.change, () => {
-        if (!initialized) {
-          connect_listeners()
-          initialized = true
-        }
-      })
-    }
-  }
-
-  compute_indices(): void {
-    const {source} = this
-    if (source == null)
-      return
-
-    // XXX: if the data source is empty, there still may be one
-    // index originating from glyph's scalar values.
-    const size = source.get_length() ?? 1
-    const indices = Indices.all_set(size)
-
-    for (const filter of this.filters) {
-      indices.intersect(filter.compute_indices(source))
-    }
-
-    this.indices = indices
-    this._indices = [...indices]
-    this.indices_map_to_subset()
-  }
-
   private _indices: number[]
 
-  indices_map_to_subset(): void {
+  _indices_map_to_subset(): void {
+    this._indices = [...this.indices]
     this.indices_map = {}
     for (let i = 0; i < this._indices.length; i++) {
       this.indices_map[this._indices[i]] = i

--- a/bokehjs/src/lib/models/widgets/tables/data_table.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_table.ts
@@ -16,7 +16,8 @@ import {ColumnType, Item, DTINDEX_NAME} from "./definitions"
 import {TableWidget} from "./table_widget"
 import {TableColumn} from "./table_column"
 import {ColumnDataSource} from "../../sources/column_data_source"
-import {CDSView} from "../../sources/cds_view"
+import {CDSView, CDSViewView} from "../../sources/cds_view"
+import {build_view} from "core/build_views"
 
 import tables_css, * as tables from "styles/widgets/tables.css"
 import slickgrid_css from "styles/widgets/slickgrid.css"
@@ -117,11 +118,28 @@ export class TableDataProvider implements DataProvider<Item> {
 export class DataTableView extends WidgetView {
   override model: DataTable
 
+  protected cds_view: CDSViewView
+
   protected data: TableDataProvider
   protected grid: SlickGrid<Item>
 
   protected _in_selection_update = false
   protected _width: number | null = null
+
+  get data_source(): p.Property<ColumnDataSource> {
+    return this.model.properties.source
+  }
+
+  override async lazy_initialize(): Promise<void> {
+    await super.lazy_initialize()
+    this.cds_view = await build_view(this.model.view, {parent: this})
+  }
+
+  override remove(): void {
+    this.cds_view.remove()
+    this.grid.destroy()
+    super.remove()
+  }
 
   override connect_signals(): void {
     super.connect_signals()
@@ -141,11 +159,6 @@ export class DataTableView extends WidgetView {
         this.render()
       })
     }
-  }
-
-  override remove(): void {
-    this.grid.destroy()
-    super.remove()
   }
 
   override styles(): string[] {
@@ -184,7 +197,7 @@ export class DataTableView extends WidgetView {
     // before passing to the DataProvider. This will result in extra calls to
     // compute_indices. This "over execution" will be addressed in a more
     // general look at events
-    this.model.view.compute_indices()
+    this.cds_view.compute_indices()
     this.data.init(this.model.source, this.model.view)
 
     // This is obnoxious but there is no better way to programmatically force

--- a/bokehjs/src/lib/models/widgets/tables/table_widget.ts
+++ b/bokehjs/src/lib/models/widgets/tables/table_widget.ts
@@ -27,13 +27,4 @@ export class TableWidget extends Widget {
       view:   [ Ref(CDSView), () => new CDSView() ],
     }))
   }
-
-  override initialize(): void {
-    super.initialize()
-
-    if (this.view.source == null) {
-      this.view.source = this.source
-      this.view.compute_indices()
-    }
-  }
 }

--- a/bokehjs/test/integration/color_mapping.ts
+++ b/bokehjs/test/integration/color_mapping.ts
@@ -100,7 +100,7 @@ describe("Color mapping", () => {
       const color_mapper = new EqHistColorMapper({palette})
 
       const p = fig([300, 300], {x_range: [0, 10], y_range: [0, 10]})
-      p.image({image: [data as any], x: 0, y: 0, dw: 10, dh: 10, color_mapper})
+      p.image({image: [data], x: 0, y: 0, dw: 10, dh: 10, color_mapper})
 
       const color_bar = new ColorBar({
         color_mapper,
@@ -180,7 +180,7 @@ describe("Color mapping", () => {
       const [x0, y0, r0] = data_flat(0.8)
       const g0 = p0.circle({
         x: x0, y: y0, radius: r0,
-        fill_color: {field: "radius", transform: mapper} as any, // XXX: bad types in VectorSpec, ColorMapper and Transform
+        fill_color: {field: "radius", transform: mapper},
         fill_alpha: 0.6, line_color: null,
       })
       mapper.domain.push([g0, "radius"])
@@ -189,7 +189,7 @@ describe("Color mapping", () => {
       const [x1, y1, r1] = data_flat(1.0)
       const g1 = p1.circle({
         x: x1, y: y1, radius: r1,
-        fill_color: {field: "radius", transform: mapper} as any,
+        fill_color: {field: "radius", transform: mapper},
         fill_alpha: 0.6, line_color: null,
       })
       mapper.domain.push([g1, "radius"])
@@ -198,7 +198,7 @@ describe("Color mapping", () => {
       const [x2, y2, r2] = data_flat(1.2)
       const g2 = p2.circle({
         x: x2, y: y2, radius: r2,
-        fill_color: {field: "radius", transform: mapper} as any,
+        fill_color: {field: "radius", transform: mapper},
         fill_alpha: 0.6, line_color: null,
       })
       mapper.domain.push([g2, "radius"])
@@ -207,7 +207,7 @@ describe("Color mapping", () => {
       const [x3, y3, r3] = data_sloped(2.0)
       const g3 = p3.circle({
         x: x3, y: y3, radius: r3,
-        fill_color: {field: "radius", transform: mapper} as any,
+        fill_color: {field: "radius", transform: mapper},
         fill_alpha: 0.6, line_color: null,
       })
       mapper.domain.push([g3, "radius"])

--- a/bokehjs/test/integration/regressions.ts
+++ b/bokehjs/test/integration/regressions.ts
@@ -233,7 +233,7 @@ describe("Bug", () => {
       const y = [0, 1, 2, 3]
       const c = ["black", "red", "green", "blue"]
       const source = new ColumnDataSource({data: {x, y, c}, selected})
-      const view = new CDSView({source, filters: [new BooleanFilter({booleans: [false, true, true, true]})]})
+      const view = new CDSView({filters: [new BooleanFilter({booleans: [false, true, true, true]})]})
       p.circle({field: "x"}, {field: "y"}, {source, view, color: {field: "c"}, size: 20})
       return p
     }
@@ -863,7 +863,7 @@ describe("Bug", () => {
         ys: [[0, 1], [0, 1], [0, 1]],
       }})
       const filter = new IndexFilter({indices: [0, 2]})
-      const view = new CDSView({source, filters: [filter]})
+      const view = new CDSView({filters: [filter]})
 
       const p = fig([200, 200])
       p.multi_line({field: "xs"}, {field: "ys"}, {view, source})
@@ -991,7 +991,7 @@ describe("Bug", () => {
         },
       })
 
-      const view = new CDSView({source})
+      const view = new CDSView() // shared view between renderers
 
       const circle_renderer = new GlyphRenderer({
         data_source: source,
@@ -1201,7 +1201,7 @@ describe("Bug", () => {
           },
         })
         const color_mapper = new LinearColorMapper({low: 0, high: 6, palette: Spectral11})
-        const cds_view = new CDSView({source, filters: [new IndexFilter({indices})]})
+        const cds_view = new CDSView({filters: [new IndexFilter({indices})]})
         const ir = p.image({
           image: {field: "image"},
           x: {field: "x"},

--- a/bokehjs/test/unit/core/selection_manager.ts
+++ b/bokehjs/test/unit/core/selection_manager.ts
@@ -36,7 +36,7 @@ describe("SelectionManager", () => {
       glyph_stub.returns(new Selection({indices: [0]}))
       const source = renderer_view.model.data_source
       const filter = new IndexFilter({indices: [1]})
-      renderer_view.model.view = new CDSView({source, filters: [filter]})
+      renderer_view.model.view = new CDSView({filters: [filter]})
 
       const did_hit = source.selection_manager.select([renderer_view], {type: "point", sx: 0, sy: 0}, true)
       expect(did_hit).to.be.true

--- a/bokehjs/test/unit/core/visuals.ts
+++ b/bokehjs/test/unit/core/visuals.ts
@@ -231,7 +231,7 @@ describe("core/visuals", () => {
         const renderer_view = await create_glyph_renderer_view(circle, data)
 
         const filter = new IndexFilter({indices: [1, 2]})
-        renderer_view.model.view = new CDSView({source: renderer_view.model.data_source, filters: [filter]})
+        renderer_view.model.view = new CDSView({filters: [filter]})
         // XXX: need to manually set_data because signals for renderer aren't connected by create_glyph_view util
         renderer_view.set_data()
 

--- a/bokehjs/test/unit/models/renderers/glyph_renderer.ts
+++ b/bokehjs/test/unit/models/renderers/glyph_renderer.ts
@@ -17,45 +17,39 @@ function mkrenderer(glyph_obj: Circle): GlyphRenderer {
   return new GlyphRenderer({glyph: glyph_obj, data_source: source})
 }
 
-describe("GlyphRenderer", () => {
-  const basic_circle = new Circle()
-
-  describe("get_reference_point", () => {
-    const gr = mkrenderer(basic_circle)
-
-    it("should return 0 if no field, value is passed", () => {
-      const index = gr.get_reference_point(null)
-      expect(index).to.be.equal(0)
-    })
-
-    it("should return 0 if field not in column data source", () => {
-      const index = gr.get_reference_point("milk", "bar")
-      expect(index).to.be.equal(0)
-    })
-
-    it("should return correct index if field and value in column data source", () => {
-      const index = gr.get_reference_point("label", "bar")
-      expect(index).to.be.equal(1)
-    })
-
-    it("should return 0 index if field in column data source but value not available", () => {
-      const index = gr.get_reference_point("label", "baz")
-      expect(index).to.be.equal(0)
-    })
-  })
-})
-
 describe("GlyphRendererView", async () => {
   // Basic case with no all glyphs going to their defaults
 
   const basic_circle = new Circle({fill_color: "red"})
   const glyph_renderer = mkrenderer(basic_circle)
-  const view = await build_view(
+  const grv = await build_view(
     glyph_renderer,
     {parent: await build_view(new Plot())},
   )
 
-  const {glyph, selection_glyph, nonselection_glyph, muted_glyph, decimated_glyph} = view
+  const {glyph, selection_glyph, nonselection_glyph, muted_glyph, decimated_glyph} = grv
+
+  describe("get_reference_point", () => {
+    it("should return 0 if no field, value is passed", () => {
+      const index = grv.get_reference_point(null)
+      expect(index).to.be.equal(0)
+    })
+
+    it("should return 0 if field not in column data source", () => {
+      const index = grv.get_reference_point("milk", "bar")
+      expect(index).to.be.equal(0)
+    })
+
+    it("should return correct index if field and value in column data source", () => {
+      const index = grv.get_reference_point("label", "bar")
+      expect(index).to.be.equal(1)
+    })
+
+    it("should return 0 index if field in column data source but value not available", () => {
+      const index = grv.get_reference_point("label", "baz")
+      expect(index).to.be.equal(0)
+    })
+  })
 
   it("should have default selection_glyph equal to main glyph", () => {
     expect(selection_glyph.model.attributes).to.be.equal(glyph.model.attributes)
@@ -66,8 +60,8 @@ describe("GlyphRendererView", async () => {
   })
 
   it("should have undefined hover_glyph if renderer hover_glyph is null", () => {
-    expect(view.model.hover_glyph).to.be.null
-    expect(view.hover_glyph).to.be.undefined
+    expect(grv.model.hover_glyph).to.be.null
+    expect(grv.hover_glyph).to.be.undefined
   })
 
   it("should have default muted_glyph with 0.2 alpha", () => {

--- a/bokehjs/test/unit/models/sources/cds_view.ts
+++ b/bokehjs/test/unit/models/sources/cds_view.ts
@@ -1,14 +1,59 @@
 import {expect} from "assertions"
 
-import {CDSView} from "@bokehjs/models/sources/cds_view"
+import {CDSView, CDSViewView} from "@bokehjs/models/sources/cds_view"
 import {Selection} from "@bokehjs/models/selections/selection"
 import {ColumnDataSource} from "@bokehjs/models/sources/column_data_source"
 import {IndexFilter} from "@bokehjs/models/filters/index_filter"
 import {GroupFilter} from "@bokehjs/models/filters/group_filter"
+import {build_view} from "@bokehjs/core/build_views"
+import * as p from "@bokehjs/core/properties"
+import {View} from "@bokehjs/core/view"
+import {Model} from "@bokehjs/model"
+
+class DummyView extends View {
+  override model: DummyModel
+
+  get data_source(): p.Property<ColumnDataSource> {
+    return this.model.properties.source
+  }
+}
+
+namespace DummyModel {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = Model.Props & {
+    source: p.Property<ColumnDataSource>
+  }
+}
+
+interface DummyModel extends DummyModel.Attrs {}
+
+class DummyModel extends Model {
+  override properties: DummyModel.Props
+  override __view_type__: DummyView
+
+  constructor(attrs?: Partial<DummyModel.Attrs>) {
+    super(attrs)
+  }
+
+  static {
+    this.prototype.default_view = DummyView
+
+    this.define<any>(({Ref}) => ({
+      source: [ Ref(ColumnDataSource) ],
+    }))
+  }
+}
+
+export async function build(cds: CDSView, source: ColumnDataSource): Promise<CDSViewView> {
+  const model = new DummyModel({source})
+  const parent = await build_view(model)
+  return await build_view(cds, {parent})
+}
 
 describe("CDSView", () => {
 
-  const cds = new ColumnDataSource({
+  const source = new ColumnDataSource({
     data: {
       x: ["a", "a", "b", "b", "b"],
       y: [1, 2, 3, 4, 5],
@@ -21,86 +66,97 @@ describe("CDSView", () => {
 
   describe("compute_indices", () => {
 
-    it("is called on init and sets the cds view's indices", () => {
-      const view = new CDSView({source: cds, filters: [filter1]})
-      expect([...view.indices]).to.be.equal([0, 1, 2])
+    it("is called on init and sets the cds view's indices", async () => {
+      const cds = new CDSView({filters: [filter1]})
+      await build(cds, source)
+      expect([...cds.indices]).to.be.equal([0, 1, 2])
     })
 
-    it("updates indices when filters is changed", () => {
-      const view = new CDSView({source: cds, filters: [filter1]})
+    it("updates indices when filters is changed", async () => {
+      const view = new CDSView({filters: [filter1]})
+      await build(view, source)
       expect([...view.indices]).to.be.equal([0, 1, 2])
       view.filters = [filter2]
       expect([...view.indices]).to.be.equal([1, 2, 3])
     })
 
-    it("computes indices based on the intersection of filters", () => {
-      const view = new CDSView({source: cds, filters: [filter1, filter2]})
+    it("computes indices based on the intersection of filters", async () => {
+      const view = new CDSView({filters: [filter1, filter2]})
+      await build(view, source)
       expect([...view.indices]).to.be.equal([1, 2])
     })
 
-    it("computes indices ignoring null filters", () => {
-      const view = new CDSView({source: cds, filters: [filter1, filter2, filter_null]})
+    it("computes indices ignoring null filters", async () => {
+      const view = new CDSView({filters: [filter1, filter2, filter_null]})
+      await build(view, source)
       expect([...view.indices]).to.be.equal([1, 2])
     })
   })
 
   describe("indices_map_to_subset", () => {
 
-    it("sets indices_map, a mapping from full data set indices to subset indices", () => {
-      const view = new CDSView({source: cds, filters: [filter1, filter2]})
+    it("sets indices_map, a mapping from full data set indices to subset indices", async () => {
+      const view = new CDSView({filters: [filter1, filter2]})
+      await build(view, source)
       expect(view.indices_map).to.be.equal({1: 0, 2: 1})
     })
   })
 
   describe("functions for converting selections and indices", () => {
 
-    it("convert_selection_from_subset", () => {
-      const view = new CDSView({source: cds, filters: [filter1, filter2]})
+    it("convert_selection_from_subset", async () => {
+      const view = new CDSView({filters: [filter1, filter2]})
+      await build(view, source)
       const selection = new Selection({indices: [0]})
       expect(view.convert_selection_from_subset(selection).indices).to.be.equal([1])
     })
 
-    it("convert_selection_to_subset", () => {
-      const view = new CDSView({source: cds, filters: [filter1, filter2]})
+    it("convert_selection_to_subset", async () => {
+      const view = new CDSView({filters: [filter1, filter2]})
+      await build(view, source)
       const selection = new Selection({indices: [1]})
       expect(view.convert_selection_to_subset(selection).indices).to.be.equal([0])
     })
 
-    it("convert_indices_from_subset", () => {
-      const view = new CDSView({source: cds, filters: [filter1, filter2]})
+    it("convert_indices_from_subset", async () => {
+      const view = new CDSView({filters: [filter1, filter2]})
+      await build(view, source)
       expect(view.convert_indices_from_subset([0, 1])).to.be.equal([1, 2])
     })
   })
 
-  it("should update its indices when its source streams new data", () => {
-    const cds = new ColumnDataSource({data: {x: [], y: []}})
+  it("should update its indices when its source streams new data", async () => {
+    const source = new ColumnDataSource({data: {x: [], y: []}})
     const new_data = {x: [1], y: [1]}
 
-    const view = new CDSView({source: cds})
+    const view = new CDSView()
+    await build(view, source)
     expect([...view.indices]).to.be.equal([])
-    cds.stream(new_data)
+    source.stream(new_data)
     expect([...view.indices]).to.be.equal([0])
   })
 
-  it("should update its indices when its source patches new data", () => {
-    const cds = new ColumnDataSource({data: {x: ["a"], y: [1]}})
+  it("should update its indices when its source patches new data", async () => {
+    const source = new ColumnDataSource({data: {x: ["a"], y: [1]}})
     const group_filter = new GroupFilter({column_name: "x", group: "b"})
 
-    const view = new CDSView({source: cds, filters: [group_filter]})
+    const view = new CDSView({filters: [group_filter]})
+    await build(view, source)
     expect([...view.indices]).to.be.equal([])
-    cds.patch({x: [[0, "b"]]})
+    source.patch({x: [[0, "b"]]})
     expect([...view.indices]).to.be.equal([0])
   })
 
-  it("should update its indices when its source's data changes", () => {
+  it("should update its indices when its source's data changes", async () => {
     const data1 = {x: ["a"], y: [1]}
     const data2 = {x: ["b"], y: [1]}
-    const cds = new ColumnDataSource({data: data1})
+    const source = new ColumnDataSource({data: data1})
     const group_filter = new GroupFilter({column_name: "x", group: "b"})
 
-    const view = new CDSView({source: cds, filters: [group_filter]})
+    const view = new CDSView({filters: [group_filter]})
+    await build(view, source)
     expect([...view.indices]).to.be.equal([])
-    cds.data = data2
+    source.data = data2
     expect([...view.indices]).to.be.equal([0])
   })
 })

--- a/bokehjs/test/unit/models/tools/edit/poly_edit_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/poly_edit_tool.ts
@@ -193,8 +193,6 @@ describe("PolyEditTool", (): void => {
       hit_test_stub.returns(new Selection({indices: [1]}))
       const tap_event = make_tap_event(300, 300)
       testcase.draw_tool_view._doubletap(tap_event)
-      // Have to call CDSView.compute_indices manually for testing
-      testcase.vertex_renderer.view.compute_indices()
       vertex_hit_test_stub.returns(new Selection({indices: [1]}))
       testcase.draw_tool_view._tap(tap_event)
       expect(testcase.vertex_source.selected.indices).to.be.equal([1])
@@ -209,8 +207,6 @@ describe("PolyEditTool", (): void => {
       hit_test_stub.returns(new Selection({indices: [1]}))
       const tap_event = make_tap_event(300, 300)
       testcase.draw_tool_view._doubletap(tap_event)
-      // Have to call CDSView.compute_indices manually for testing
-      testcase.vertex_renderer.view.compute_indices()
 
       vertex_hit_test_stub.returns(new Selection({indices: [1]}))
       testcase.draw_tool_view._tap(tap_event)
@@ -237,8 +233,6 @@ describe("PolyEditTool", (): void => {
       vertex_hit_test_stub.returns(null)
       const tap_event = make_tap_event(300, 300)
       testcase.draw_tool_view._doubletap(tap_event)
-      // Have to call CDSView.compute_indices manually for testing
-      testcase.vertex_renderer.view.compute_indices()
       vertex_hit_test_stub.returns(new Selection({indices: [1]}))
       const panstart_event = make_pan_event(300, 300)
       testcase.draw_tool_view._pan_start(panstart_event)
@@ -264,7 +258,6 @@ describe("PolyEditTool", (): void => {
       const tap_event = make_tap_event(300, 300)
       testcase.draw_tool_view._doubletap(tap_event) // Poly selected
       vertex_hit_test_stub.returns(new Selection({indices: [1]}))
-      testcase.vertex_renderer.view.compute_indices()
       testcase.draw_tool_view._doubletap(tap_event) // Vertex selected
       vertex_hit_test_stub.returns(new Selection({indices: [2]}))
       testcase.draw_tool_view._doubletap(make_tap_event(290, 290)) // Add new vertex
@@ -289,7 +282,6 @@ describe("PolyEditTool", (): void => {
       const tap_event = make_tap_event(300, 300)
       testcase.draw_tool_view._doubletap(tap_event) // Poly selected
       vertex_hit_test_stub.returns(new Selection({indices: [1]}))
-      testcase.vertex_renderer.view.compute_indices()
       testcase.draw_tool_view._doubletap(tap_event) // Vertex selected
       vertex_hit_test_stub.returns(new Selection({indices: [2]}))
       const tap_event2 = make_tap_event(290, 290)

--- a/bokehjs/test/unit/models/widgets/tables/data_cube.ts
+++ b/bokehjs/test/unit/models/widgets/tables/data_cube.ts
@@ -7,6 +7,8 @@ import {TableColumn} from "@bokehjs/models/widgets/tables/table_column"
 import {GroupingInfo, DataCubeProvider, DataCube} from "@bokehjs/models/widgets/tables/data_cube"
 import {SumAggregator} from "@bokehjs/models/widgets/tables/row_aggregators"
 
+import {build} from "../../sources/cds_view"
+
 describe("data_cube module", () => {
 
   describe("DataCube class", () => {
@@ -22,7 +24,7 @@ describe("data_cube module", () => {
     let columns: any[] // XXX TableColumn[]
     let grouping: GroupingInfo[]
 
-    before_each(() => {
+    before_each(async () => {
       source = new ColumnDataSource({
         data: {
           color: ["red", "red", "red", "green", "green", "blue"],
@@ -30,7 +32,9 @@ describe("data_cube module", () => {
           value: [10, 20, 30, 40, 50, 60],
         },
       })
-      view = new CDSView({source})
+      view = new CDSView()
+      await build(view, source)
+
       columns = [
         new TableColumn({field: "color"}),
         new TableColumn({field: "width"}),

--- a/bokehjs/test/unit/models/widgets/tables/data_table.ts
+++ b/bokehjs/test/unit/models/widgets/tables/data_table.ts
@@ -8,6 +8,8 @@ import {DTINDEX_NAME} from "@bokehjs/models/widgets/tables/definitions"
 
 import {range} from "@bokehjs/core/util/array"
 
+import {build} from "../../sources/cds_view"
+
 describe("data_table module", () => {
 
   it("should define DTINDEX_NAME", () => {
@@ -48,29 +50,33 @@ describe("data_table module", () => {
 
   describe("DataProvider class", () => {
 
-    it("should raise an error if DTINDEX_NAME is in source", () => {
+    it("should raise an error if DTINDEX_NAME is in source", async () => {
       const bad = new ColumnDataSource({data: {__bkdt_internal_index__: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
-      const view = new CDSView({source: bad})
+      const view = new CDSView()
+      await build(view, bad)
       expect(() => new TableDataProvider(bad, view)).to.throw()
     })
 
-    it("should construct an internal index", () => {
+    it("should construct an internal index", async () => {
       const source = new ColumnDataSource({data: {index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
-      const view = new CDSView({source})
+      const view = new CDSView()
+      await build(view, source)
       const dp = new TableDataProvider(source, view)
       expect(dp.index).to.be.equal([0, 1, 2, 3])
     })
 
-    it("should report the data source length", () => {
+    it("should report the data source length", async () => {
       const source = new ColumnDataSource({data: {index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
-      const view = new CDSView({source})
+      const view = new CDSView()
+      await build(view, source)
       const dp = new TableDataProvider(source, view)
       expect(dp.getLength()).to.be.equal(4)
     })
 
-    it("should return items when unsorted", () => {
+    it("should return items when unsorted", async () => {
       const source = new ColumnDataSource({data: {index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
-      const view = new CDSView({source})
+      const view = new CDSView()
+      await build(view, source)
       const dp = new TableDataProvider(source, view)
 
       expect(dp.getItems()).to.be.equal([
@@ -81,9 +87,10 @@ describe("data_table module", () => {
       ])
     })
 
-    it("should return all items when unsorted", () => {
+    it("should return all items when unsorted", async () => {
       const source = new ColumnDataSource({data: {index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
-      const view = new CDSView({source})
+      const view = new CDSView()
+      await build(view, source)
       const dp = new TableDataProvider(source, view)
 
       expect(dp.getItems()).to.be.equal([
@@ -94,9 +101,10 @@ describe("data_table module", () => {
       ])
     })
 
-    it("should return items when sorted", () => {
+    it("should return items when sorted", async () => {
       const source = new ColumnDataSource({data: {index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
-      const view = new CDSView({source})
+      const view = new CDSView()
+      await build(view, source)
       const dp = new TableDataProvider(source, view)
       const fake_col = {sortAsc: true, sortCol: {field: "bar"}}
       dp.sort([fake_col])
@@ -109,9 +117,10 @@ describe("data_table module", () => {
       ])
     })
 
-    it("should return fields when unsorted", () => {
+    it("should return fields when unsorted", async () => {
       const source = new ColumnDataSource({data: {index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
-      const view = new CDSView({source})
+      const view = new CDSView()
+      await build(view, source)
       const dp = new TableDataProvider(source, view)
 
       expect(dp.getField(0, "index")).to.be.equal(0)
@@ -130,9 +139,10 @@ describe("data_table module", () => {
       expect(dp.getField(3, DTINDEX_NAME)).to.be.equal(3)
     })
 
-    it("should return fields when sorted", () => {
+    it("should return fields when sorted", async () => {
       const source = new ColumnDataSource({data: {index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
-      const view = new CDSView({source})
+      const view = new CDSView()
+      await build(view, source)
       const dp = new TableDataProvider(source, view)
 
       const fake_col = {sortAsc: true, sortCol: {field: "bar"}}
@@ -154,9 +164,10 @@ describe("data_table module", () => {
       expect(dp.getField(3, DTINDEX_NAME)).to.be.equal(0)
     })
 
-    it("should get all records", () => {
+    it("should get all records", async () => {
       const source = new ColumnDataSource({data: {index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
-      const view = new CDSView({source})
+      const view = new CDSView()
+      await build(view, source)
       const dp = new TableDataProvider(source, view)
       expect(dp.getRecords()).to.be.equal(range(0, dp.getLength()).map((i) => dp.getItem(i)))
 
@@ -165,9 +176,10 @@ describe("data_table module", () => {
       expect(dp.getRecords()).to.be.equal(range(0, dp.getLength()).map((i) => dp.getItem(i)))
     })
 
-    it("should re-order only the index when sorted", () => {
+    it("should re-order only the index when sorted", async () => {
       const source = new ColumnDataSource({data: {index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
-      const view = new CDSView({source})
+      const view = new CDSView()
+      await build(view, source)
       const dp = new TableDataProvider(source, view)
       expect(dp.index).to.be.equal([0, 1, 2, 3])
 
@@ -177,9 +189,10 @@ describe("data_table module", () => {
       expect(dp.source.data).to.be.equal({index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]})
     })
 
-    it("should set fields when unsorted", () => {
+    it("should set fields when unsorted", async () => {
       const source = new ColumnDataSource({data: {index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
-      const view = new CDSView({source})
+      const view = new CDSView()
+      await build(view, source)
       const dp = new TableDataProvider(source, view)
 
       dp.setField(0, "index", 10.1)
@@ -189,9 +202,10 @@ describe("data_table module", () => {
       expect(dp.source.data).to.be.equal({index: [10.1, 1, 2, 10], bar: [3.4, 1.2, 100, -10]})
     })
 
-    it("should set fields when sorted", () => {
+    it("should set fields when sorted", async () => {
       const source = new ColumnDataSource({data: {index: [0, 1, 2, 10], bar: [3.4, 1.2, 0, -10]}})
-      const view = new CDSView({source})
+      const view = new CDSView()
+      await build(view, source)
       const dp = new TableDataProvider(source, view)
       const fake_col = {sortAsc: true, sortCol: {field: "bar"}}
       dp.sort([fake_col])
@@ -203,12 +217,13 @@ describe("data_table module", () => {
       expect(dp.source.data).to.be.equal({index: [0, 1, 2, 10.1], bar: [3.4, 100, 0, -10]})
     })
 
-    it("should support sorting NaNs and infinities", () => {
+    it("should support sorting NaNs and infinities", async () => {
       const source = new ColumnDataSource({data: {
         index: ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"],
         col0: [3.4, -Infinity, NaN, 1.21, 1.2, -Infinity, Infinity, 0, NaN, -10],
       }})
-      const view = new CDSView({source})
+      const view = new CDSView()
+      await build(view, source)
       const dp = new TableDataProvider(source, view)
 
       expect(dp.getItems()).to.be.equal([

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -73,9 +73,8 @@ describe("Bug", () => {
     it("prevents initializing GlyphRenderer with an empty data source", async () => {
       const plot = fig([200, 200])
       const data_source = new ColumnDataSource({data: {}})
-      const cds_view = new CDSView({source: data_source})
       const glyph = new Circle({x: {field: "x_field"}, y: {field: "y_field"}})
-      const renderer = new GlyphRenderer({data_source, glyph, view: cds_view})
+      const renderer = new GlyphRenderer({data_source, glyph})
       plot.add_renderers(renderer)
       const {view} = await display(plot)
       // XXX: no data (!= empty arrays) implies 1 data point, required for

--- a/examples/app/fourier_animated.py
+++ b/examples/app/fourier_animated.py
@@ -82,7 +82,7 @@ sum_plot.circle("xsum-circle", "ysum-circle", radius="r",
 
 sum_plot.circle("xsum-dot", "ysum-dot", size=5, color="color", source=items_source)
 
-segment_view =CDSView(source=items_source, filters=[IndexFilter([3])])
+segment_view = CDSView(filters=[IndexFilter([3])])
 sum_plot.segment(x0="xsum-dot", y0="ysum-dot", x1=2.5, y1="ysum-dot",
                  color="orange", source=items_source, view=segment_view)
 

--- a/examples/embed/file_html.py
+++ b/examples/embed/file_html.py
@@ -74,7 +74,7 @@ medal = Circle(x="MetersBack", y="Year", size=10, fill_color="MedalFill", line_c
 medal_renderer = plot.add_glyph(source, medal)
 
 #sprint[sprint.Medal=="gold" * sprint.Year in [1988, 1968, 1936, 1896]]
-plot.add_glyph(source, Text(x="MetersBack", y="Year", x_offset=10, text="Name"), view=CDSView(source=source, filters=filters))
+plot.add_glyph(source, Text(x="MetersBack", y="Year", x_offset=10, text="Name"), view=CDSView(filters=filters))
 
 plot.add_glyph(source, Text(x=7.5, y=1942, text=["No Olympics in 1940 or 1944"],
                             text_font_style="italic", text_color="silver"))

--- a/sphinx/source/docs/first_steps/examples/first_steps_8_filter.py
+++ b/sphinx/source/docs/first_steps/examples/first_steps_8_filter.py
@@ -6,7 +6,7 @@ from bokeh.plotting import figure, show
 source = ColumnDataSource(data=dict(x=[1, 2, 3, 4, 5], y=[1, 2, 3, 4, 5]))
 
 # create a view using an IndexFilter with the index positions [0, 2, 4]
-view = CDSView(source=source, filters=[IndexFilter([0, 2, 4])])
+view = CDSView(filters=[IndexFilter([0, 2, 4])])
 
 # setup tools
 tools = ["box_select", "hover", "reset"]

--- a/sphinx/source/docs/first_steps/first_steps_8.rst
+++ b/sphinx/source/docs/first_steps/first_steps_8.rst
@@ -90,10 +90,8 @@ Bokeh's :class:`~bokeh.models.sources.CDSView` class.
 To plot with a filtered subset of data, pass a ``CDSView`` object to the
 ``view`` argument of your renderer.
 
-A :class:`~bokeh.models.sources.CDSView` object has two properties:
+A :class:`~bokeh.models.sources.CDSView` object has one property:
 
-* ``source``: the :class:`~bokeh.models.sources.ColumnDataSource` that you want
-  to apply the filters to
 * ``filters``: a list of :class:`~bokeh.models.filters.Filter` objects
 
 The simplest filter is the :class:`~bokeh.models.filters.IndexFilter`. An

--- a/sphinx/source/docs/releases/3.0.0.rst
+++ b/sphinx/source/docs/releases/3.0.0.rst
@@ -109,6 +109,13 @@ Explicit sub-typing support was removed both from models and the protocol.
 If you want to extend existing models without the need for providing an
 implementation, then use data models (e.g. extend from ``DataModel``).
 
+``CDSView.source``
+..................
+
+``CDSView`` now implicitly uses the source provided by a glyph renderer it
+as assigned to. Previously providing a data source in both a glyph renderer
+and a source view was redundant.
+
 Runtime dependencies
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/sphinx/source/docs/user_guide/data.rst
+++ b/sphinx/source/docs/user_guide/data.rst
@@ -399,10 +399,8 @@ data. You can also share those views between different plots.
 To plot with a filtered subset of data, pass a |CDSView| to the ``view``
 argument of any renderer method on a Bokeh plot.
 
-A |CDSView| has two properties, ``source`` and ``filters``:
+A |CDSView| has one property, ``filters``:
 
-* ``source`` is the |ColumnDataSource| that the you want to apply the filters
-  to.
 * ``filters`` is a list of |Filter| objects, listed and described below.
 
 In this example, you create a |CDSView| called ``view``. ``view`` uses the
@@ -416,7 +414,7 @@ renderer function:
     from bokeh.models import ColumnDataSource, CDSView
 
     source = ColumnDataSource(some_data)
-    view = CDSView(source=source, filters=[filter1, filter2])
+    view = CDSView(filters=[filter1, filter2])
 
     p = figure()
     p.circle(x="x", y="y", source=source, view=view)

--- a/sphinx/source/docs/user_guide/examples/data_filtering_boolean_filter.py
+++ b/sphinx/source/docs/user_guide/examples/data_filtering_boolean_filter.py
@@ -4,7 +4,7 @@ from bokeh.plotting import figure, show
 
 source = ColumnDataSource(data=dict(x=[1, 2, 3, 4, 5], y=[1, 2, 3, 4, 5]))
 booleans = [True if y_val > 2 else False for y_val in source.data['y']]
-view = CDSView(source=source, filters=[BooleanFilter(booleans)])
+view = CDSView(filters=[BooleanFilter(booleans)])
 
 tools = ["box_select", "hover", "reset"]
 p = figure(height=300, width=300, tools=tools)

--- a/sphinx/source/docs/user_guide/examples/data_filtering_group_filter.py
+++ b/sphinx/source/docs/user_guide/examples/data_filtering_group_filter.py
@@ -4,7 +4,7 @@ from bokeh.plotting import figure, show
 from bokeh.sampledata.iris import flowers
 
 source = ColumnDataSource(flowers)
-view1 = CDSView(source=source, filters=[GroupFilter(column_name='species', group='versicolor')])
+view1 = CDSView(filters=[GroupFilter(column_name='species', group='versicolor')])
 
 plot_size_and_tools = {'height': 300, 'width': 300,
                         'tools':['box_select', 'reset', 'help']}

--- a/sphinx/source/docs/user_guide/examples/data_filtering_index_filter.py
+++ b/sphinx/source/docs/user_guide/examples/data_filtering_index_filter.py
@@ -3,7 +3,7 @@ from bokeh.models import CDSView, ColumnDataSource, IndexFilter
 from bokeh.plotting import figure, show
 
 source = ColumnDataSource(data=dict(x=[1, 2, 3, 4, 5], y=[1, 2, 3, 4, 5]))
-view = CDSView(source=source, filters=[IndexFilter([0, 2, 4])])
+view = CDSView(filters=[IndexFilter([0, 2, 4])])
 
 tools = ["box_select", "hover", "reset"]
 p = figure(height=300, width=300, tools=tools)

--- a/sphinx/source/docs/user_guide/examples/data_linked_brushing_subsets.py
+++ b/sphinx/source/docs/user_guide/examples/data_linked_brushing_subsets.py
@@ -12,7 +12,7 @@ y1 = [xx**2 for xx in x]
 source = ColumnDataSource(data=dict(x=x, y0=y0, y1=y1))
 
 # create a view of the source for one plot to use
-view = CDSView(source=source, filters=[BooleanFilter([True if y > 250 or y < 100 else False for y in y1])])
+view = CDSView(filters=[BooleanFilter([True if y > 250 or y < 100 else False for y in y1])])
 
 TOOLS = "box_select,lasso_select,hover,help"
 

--- a/tests/unit/bokeh/plotting/test__decorators.py
+++ b/tests/unit/bokeh/plotting/test__decorators.py
@@ -20,7 +20,7 @@ import pytest ; pytest
 from mock import mock
 
 # Bokeh imports
-from bokeh.models import CDSView, ColumnDataSource, Marker
+from bokeh.models import CDSView, Marker
 from bokeh.plotting import Figure
 from bokeh.plotting._renderer import RENDERER_ARGS
 
@@ -49,7 +49,7 @@ _renderer_args_values = dict(
     x_range_name=[None, "", "x range"],
     y_range_name=[None, "", "y range"],
     level=[None, "overlay"],
-    view=[None, CDSView(source=ColumnDataSource())],
+    view=[None, CDSView()],
     visible=[None, False, True],
     muted=[None, False, True],
 )

--- a/tests/unit/bokeh/plotting/test__renderer.py
+++ b/tests/unit/bokeh/plotting/test__renderer.py
@@ -120,7 +120,7 @@ class Test_make_glyph:
 #     'x_range_name': [None, '', 'x range'],
 #     'y_range_name': [None, '', 'y range'],
 #     'level': [None, 'overlay'],
-#     'view': [None, CDSView(source=None)],
+#     'view': [None, CDSView()],
 #     'visible': [None, False, True],
 #     'muted': [None, False, True]
 # }


### PR DESCRIPTION
Having a `GlyphRenderer` and its `CDSView` use different data sources is currently technically possible, but doesn't make sense. There is quite a bit of code making sure everything is configured correctly. All of that is unnecessary. This PR removes `CDSView.source` and adds a view for `CDSView` which infers the source from its parent.
