### PR TITLE
Add metadata to examples/models/file/daylight.py (#11765)

### DIFF
--- a/examples/models/file/daylight.py
+++ b/examples/models/file/daylight.py
@@ -1,3 +1,13 @@
+''' A plot shading the daylight hours in a city's local time (which are
+discontinuous due to summer time) using the Patch and Line plot elements to
+draw custom outlines and fills.
+
+.. bokeh-example-metadata::
+    :sampledata: daylight
+    :apis: bokeh.models.glyphs.Line, bokeh.models.glyphs.Patch, bokeh.models.plots.Plot.add_glyph, bokeh.document.document.Document
+    :refs: :ref:`userguide_plotting` > :ref:`userguide_plotting_line_glyphs`, :ref:`userguide_plotting` > :ref:`userguide_plotting_patch_polygon_glyphs`
+    :keywords: outline, shading, fill
+'''
 import datetime as dt
 from time import mktime
 

--- a/examples/models/file/daylight.py
+++ b/examples/models/file/daylight.py
@@ -1,6 +1,6 @@
-''' A plot shading the daylight hours in a city's local time (which are
-discontinuous due to summer time) using the Patch and Line plot elements to
-draw custom outlines and fills.
+''' A plot showing the daylight hours in a city's local time (which are
+discontinuous due to summer time) using the ``Patch`` and ``Line`` plot
+elements to draw custom outlines and fills.
 
 .. bokeh-example-metadata::
     :sampledata: daylight


### PR DESCRIPTION
This adds a metadata block for one example script among the Bokeh examples.

- [X] issues: addresses #11765