### PR TITLE
Docker dev image (#11352)

### DIFF
--- a/.github/workflows/bokeh-docker-build.yml
+++ b/.github/workflows/bokeh-docker-build.yml
@@ -1,0 +1,33 @@
+name: Docker image - Build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  docker_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build image
+        uses: docker/build-push-action@v2
+        with:
+          context: ci/docker
+          load: false
+          tags: bokeh-dev:latest
+
+      - name: Save image to file
+        run: |
+          docker save -o bokeh-dev.tar bokeh-dev
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: bokeh-dev.tar

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@
 /.mypy_cache/
 /.images-list
 /examples-report.html
+
+# used by docker container
+.conda_docker

--- a/bokehjs/make/tasks/test.ts
+++ b/bokehjs/make/tasks/test.ts
@@ -134,6 +134,10 @@ async function headless(port: number): Promise<ChildProcess> {
     "--force-color-profile=srgb",           // ^^^
     "--force-device-scale-factor=1",        // ^^^
   ]
+  const bokeh_in_docker = process.env.BOKEH_IN_DOCKER ?? ""
+  if (bokeh_in_docker == "1") {
+    args.push("--no-sandbox")
+  }
   const executable = chrome()
   const proc = spawn(executable, args, {stdio: "pipe"})
 

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -25,7 +25,6 @@ RUN addgroup --gid 1000 docker && \
 RUN curl -LO https://dl.google.com/linux/direct/$CHROME_DEB && \
     apt install --no-install-recommends -y ./$CHROME_DEB && \
     rm $CHROME_DEB && \
-    apt purge -y curl && \
     apt autoremove -y && \
     apt clean -y && \
     rm -rf /var/lib/apt/lists/*

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:20.04
+
+ARG CHROME_DEB=google-chrome-stable_current_amd64.deb
+ARG FIXUID_VERSION=0.5
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update -y && \
+    apt upgrade -y && \
+    apt install -y curl git sudo
+
+# User and group setup using fixuid.
+RUN addgroup --gid 1000 docker && \
+    adduser --uid 1000 --ingroup docker --home /home/docker --shell /bin/bash --disabled-password --gecos "" docker && \
+    USER=docker && \
+    GROUP=docker && \
+    ARCH="$(dpkg --print-architecture)" && \
+    curl -fsSL "https://github.com/boxboat/fixuid/releases/download/v$FIXUID_VERSION/fixuid-$FIXUID_VERSION-linux-$ARCH.tar.gz" | tar -C /usr/local/bin -xzf - && \
+    chown root:root /usr/local/bin/fixuid && \
+    chmod 4755 /usr/local/bin/fixuid && \
+    mkdir -p /etc/fixuid && \
+    printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
+
+# Cannot 'snap install chromium' in docker container, so instead install google-chrome deb.
+RUN curl -LO https://dl.google.com/linux/direct/$CHROME_DEB && \
+    apt install --no-install-recommends -y ./$CHROME_DEB && \
+    rm $CHROME_DEB && \
+    apt purge -y curl && \
+    apt autoremove -y && \
+    apt clean -y && \
+    rm -rf /var/lib/apt/lists/*
+
+EXPOSE 5006
+
+COPY entrypoint.sh /usr/bin/entrypoint.sh
+RUN chmod a+x /usr/bin/entrypoint.sh
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]
+
+ENV BOKEH_IN_DOCKER=1
+USER docker:docker
+WORKDIR /bokeh

--- a/ci/docker/bokeh_docker_build.sh
+++ b/ci/docker/bokeh_docker_build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu
+
+echo "Start of $0"
+
+bash ci/install_node_modules.sh
+python setup.py install
+
+python -m bokeh info
+
+echo "End of $0"

--- a/ci/docker/bokeh_docker_test.sh
+++ b/ci/docker/bokeh_docker_test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Note do not exit on error, as want remaining tests to run.
+set -u
+
+echo "Start of $0"
+
+python -m bokeh info
+bokeh sampledata
+
+# Run some of the tests.
+pytest tests/codebase
+cd bokehjs && node make test
+
+echo "End of $0"

--- a/ci/docker/entrypoint.sh
+++ b/ci/docker/entrypoint.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -eu
+
+CONDA_DIR=.conda_docker
+ENV_NAME=bkdev
+MINICONDA_SCRIPT=Miniconda3-latest-Linux-x86_64.sh
+
+eval "$(fixuid -q)"
+
+if [ ! -d .git ] || [ ! -f environment.yml ]; then
+    echo "Directory does not contain Bokeh git repo."
+    exit 1
+fi
+
+if [ ! -f "$CONDA_DIR/condabin/conda" ]; then
+    # Install miniconda into $CONDA_DIR
+    START_DIR=$(pwd)
+    cd /tmp
+    curl -LO "http://repo.continuum.io/miniconda/$MINICONDA_SCRIPT"
+    bash $MINICONDA_SCRIPT -p $START_DIR/$CONDA_DIR -b
+    rm $MINICONDA_SCRIPT
+    cd $START_DIR
+fi
+
+# Activate conda in .bashrc and in this shell.
+$CONDA_DIR/condabin/conda init bash > /dev/null
+. $CONDA_DIR/etc/profile.d/conda.sh
+
+if [ ! -d "$CONDA_DIR/envs/$ENV_NAME" ]; then
+    conda env create -f environment.yml
+fi
+
+# Ensure conda environment is activated in this shell and in new shells.
+conda activate $ENV_NAME
+echo "conda activate $ENV_NAME" >> ~/.bashrc
+
+google-chrome --version
+
+if [ "${BOKEH_DOCKER_BUILD:-0}" == 1 ]; then
+    bash ci/docker/bokeh_docker_build.sh
+fi
+
+if [ "${BOKEH_DOCKER_TEST:-0}" == 1 ]; then
+    bash ci/docker/bokeh_docker_test.sh
+fi
+
+/bin/bash "$@"


### PR DESCRIPTION
This partially addresses issue #11352 in providing the means to build a docker image for Bokeh development. Using the files here `docker build` and `docker run` work locally for me. The idea is to use github actions `workflow_dispatch` to build the image on demand via the github UI. For this to work, the workflow apparently needs to be in the default branch (`branch-3.0`), so this PR needs to be merged before I can correctly write the github action and test the docker image more widely. Therefore there will be at least one other PR to finalise this work, and probably another (with @tcmetzger's help) containing documentation.

Brief summary of docker image:
* It is based on Ubuntu 20.04, one of our officially supported platforms.
* Because docker isn't a fully-featured OS, neither `apt install chromium` or `snap install chromium` work as expected, so instead it downloads and installs the latest google-chrome deb file.
* Running headless chrome in a docker container requires the `--no-sandbox` command-line argument, hence the changes to `bokehjs/make/tasks/test.ts`.
* Image size is 636 MB.

To build the docker image locally, `cd` to the base directory of your bokeh git repo (with this branch checked out) and use
```bash
docker build -t bokeh-dev ci/docker
```
You can run the docker image that has been built locally from any directory using something like
```bash
docker run -v path_to_bokeh_git_repo:/bokeh -u 10000:10000 --rm -p 5006:5006 -it bokeh-dev
```
where you need to use the appropriate `path_to_bokeh_git_repo` and the correct uid and gid instead of `10000:10000` to allow correct read/write access to your git repo.

The first time you `docker run` it will create a new directory `.conda_docker` and install the `bkdev` conda environment into it before starting a bash shell to continue work in the container. Subsequent uses of `docker run` will identify that `bkdev` is available and hence start the bash shell straight away.

From here you can build bokeh in the usual manner, run tests and run `bokeh serve` commands which are mapped across to the host's `http://localhost:5006/whatever` as normal. There are only ~10 test failures at the moment, which I will look into.

Of the shell scripts in `ci/docker/`, `entrypoint.sh` is wrapped within the image and run as part of `docker run`. The other 2 scripts are intended to be optionally run within the CI `workflow_dispatch` to build and test bokeh within the running container.
