### PR TITLE
fix transform jitter example

### DIFF
--- a/examples/models/file/transform_jitter.py
+++ b/examples/models/file/transform_jitter.py
@@ -1,21 +1,27 @@
 import numpy as np
 
+from bokeh.core.properties import field
 from bokeh.models import Button, Column, ColumnDataSource, CustomJS, Jitter, LabelSet
-from bokeh.plotting import figure, output_file, show
+from bokeh.plotting import figure, show
 
-N = 1000
+x = np.ones(1000)
+y = np.random.random(1000)*10
 
-source = ColumnDataSource(data=dict(
-    x=np.ones(N), xn=2*np.ones(N), xu=3*np.ones(N), y=np.random.random(N)*10
-))
+source = ColumnDataSource(data=dict(x=x, xn=2*x, xu=3*x, y=y))
 
 normal = Jitter(width=0.2, distribution="normal")
 uniform = Jitter(width=0.2, distribution="uniform")
 
 p = figure(x_range=(0, 4), y_range=(0,10), toolbar_location=None, x_axis_location="above")
 p.circle(x='x',  y='y', color='firebrick', source=source, size=5, alpha=0.5)
-p.circle(x='xn', y='y', color='olive',     source=source, size=5, alpha=0.5)
-p.circle(x='xu', y='y', color='navy',      source=source, size=5, alpha=0.5)
+
+r1 = p.circle(x='xn', y='y', color='olive', source=source, size=5, alpha=0.5)
+n1 = p.circle(x=field('xn', normal), y='y', color='olive', source=source,
+              size=5, alpha=0.5, visible=False)
+
+r2 = p.circle(x='xu', y='y', color='navy', source=source, size=5, alpha=0.5)
+u2 = p.circle(x=field('xu', uniform), y='y', color='navy', source=source,
+              size=5, alpha=0.5, visible=False)
 
 label_data = ColumnDataSource(data=dict(
     x=[1,2,3], y=[0, 0, 0], t=['Original', 'Normal', 'Uniform']
@@ -24,20 +30,13 @@ label_set = LabelSet(x='x', y='y', text='t', y_offset=-4, source=label_data,
                      text_baseline="top", text_align='center')
 p.add_layout(label_set)
 
-callback = CustomJS(args=dict(source=source, normal=normal, uniform=uniform), code="""
-    const data = source.data;
-    for (let i = 0; i < data.y.length; i++) {
-        data.xn[i] = normal.compute(data.x[i] + 1);
-    }
-    for (let i = 0; i < data.y.length; i++) {
-        data.xu[i] = uniform.compute(data.x[i] + 2);
-    }
-    source.change.emit();
+callback = CustomJS(args=dict(r1=r1, n1=n1, r2=r2, u2=u2), code="""
+for (const r of [r1, n1, r2, u2]) {
+    r.visible = !r.visible
+}
 """)
 
-button = Button(label='Press to apply Jitter!', width=300)
+button = Button(label='Press to toggle Jitter!', width=300)
 button.js_on_click(callback)
-
-output_file("transform_jitter.html", title="Example Jitter Transform")
 
 show(Column(button, p))


### PR DESCRIPTION
The `transform_jitter.py` example was broken by https://github.com/bokeh/bokeh/pull/11400 however that example previously "demonstrated" the `Jitter` model in a way that no one should ever really emulate. I've updated the example to show proper usage (which also works with the change in #11400)