### PR TITLE
add a version query to custom.css

### DIFF
--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -123,7 +123,7 @@ html_context = {
     'VERSION': version,
 }
 
-html_css_files = ['custom.css']
+html_css_files = [f"custom.css?v={version}"]
 
 html_static_path = ['_static']
 


### PR DESCRIPTION
- [x] issues: fixes #11613

The change in his PR successfully adds a cache-busting version to the `custom.css` link:

```html
<link rel="stylesheet" type="text/css" href="_static/custom.css?v=3.0.0dev1+19.g860b2c4d3.dirty">
```

This will hopefully prevent any need for force-reloads when dev docs are re-published to a fixed branch URL or when  a new version is published to `latest`. 

However, I don't love the implementation, which just brute force appends a query string to the filename. AFIK it relies on some assumptions about Sphinx behavior that  are not actually defined, and that I could imagine changing in the future (sphinx could start adding their own query strings, conflicting, or adding the query string here could interfere with filename detection, etc). 

@tk0miya Is there a "proper" way to do something like this?  I know attributes can be added to the link tag by passing a tuple with an attrs dict, but I don't think that would affect caching. 
