### PR TITLE
Add OS to bokeh info

### DIFF
--- a/bokeh/command/subcommands/info.py
+++ b/bokeh/command/subcommands/info.py
@@ -17,14 +17,14 @@ This will print general information to standard output, such as Python and Bokeh
 
 .. code-block:: none
 
-    Python version      :  3.9.1 (default, Dec 11 2020, 06:28:49)
+    Python version      :  3.9.7 | packaged by conda-forge | (default, Sep 29 2021, 19:20:46)
     IPython version     :  7.20.0
     Tornado version     :  6.1
-    Bokeh version       :  2.3.0
+    Bokeh version       :  3.0.0
     BokehJS static path :  /opt/anaconda/envs/test/lib/python3.9/site-packages/bokeh/server/static
-    node.js version     :  v15.10.0
-    npm version         :  7.5.3
-    Operating system    :
+    node.js version     :  v16.12.0
+    npm version         :  7.24.2
+    Operating system    :  Linux-5.11.0-40-generic-x86_64-with-glibc2.31
 
 Sometimes it can be useful to get just paths to the BokehJS static files in order
 to configure other servers or processes. To do this, use the ``--static`` option

--- a/bokeh/command/subcommands/info.py
+++ b/bokeh/command/subcommands/info.py
@@ -24,6 +24,7 @@ This will print general information to standard output, such as Python and Bokeh
     BokehJS static path :  /opt/anaconda/envs/test/lib/python3.9/site-packages/bokeh/server/static
     node.js version     :  v15.10.0
     npm version         :  7.5.3
+    Operating system    :
 
 Sometimes it can be useful to get just paths to the BokehJS static files in order
 to configure other servers or processes. To do this, use the ``--static`` option
@@ -53,6 +54,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import platform
 import sys
 from argparse import Namespace
 
@@ -127,6 +129,7 @@ class Info(Subcommand):
             print(f"BokehJS static path :  {settings.bokehjsdir()}")
             print(f"node.js version     :  {if_installed(nodejs_version())}")
             print(f"npm version         :  {if_installed(npmjs_version())}")
+            print(f"Operating system    :  {platform.platform()}")
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/sphinx/source/docs/dev_guide/setup.rst
+++ b/sphinx/source/docs/dev_guide/setup.rst
@@ -425,13 +425,14 @@ You should see output similar to:
 
 .. code-block:: sh
 
-    Python version      :  3.9.6 | packaged by conda-forge | (default, Jul 11 2021, 03:39:48)
-    IPython version     :  7.25.0
+    Python version      :  3.9.7 | packaged by conda-forge | (default, Sep 29 2021, 19:20:46)
+    IPython version     :  7.20.0
     Tornado version     :  6.1
-    Bokeh version       :  2.4.0dev1+42.g9c3ee2f7e.dirty
-    BokehJS static path :  /home/user/bokeh/bokeh/server/static
-    node.js version     :  v15.14.0
-    npm version         :  7.19.1
+    Bokeh version       :  3.0.0dev1+20.g6c394d579
+    BokehJS static path :  /opt/anaconda/envs/test/lib/python3.9/site-packages/bokeh/server/static
+    node.js version     :  v16.12.0
+    npm version         :  7.24.2
+    Operating system    :  Linux-5.11.0-40-generic-x86_64-with-glibc2.31
 
 Run examples
 ~~~~~~~~~~~~

--- a/tests/unit/bokeh/command/subcommands/test_info.py
+++ b/tests/unit/bokeh/command/subcommands/test_info.py
@@ -73,7 +73,8 @@ def test_run(capsys: Capture) -> None:
     assert lines[4].startswith("BokehJS static")
     assert lines[5].startswith("node.js version")
     assert lines[6].startswith("npm version")
-    assert lines[7] == ""
+    assert lines[7].startswith("Operating system")
+    assert lines[8] == ""
     assert err == ""
 
 def test_run_static(capsys: Capture) -> None:

--- a/tests/unit/bokeh/command/subcommands/test_info.py
+++ b/tests/unit/bokeh/command/subcommands/test_info.py
@@ -65,7 +65,7 @@ def test_run(capsys: Capture) -> None:
     main(["bokeh", "info"])
     out, err = capsys.readouterr()
     lines = out.split("\n")
-    assert len(lines) == 8
+    assert len(lines) == 9
     assert lines[0].startswith("Python version")
     assert lines[1].startswith("IPython version")
     assert lines[2].startswith("Tornado version")


### PR DESCRIPTION
As discussed in https://github.com/bokeh/bokeh/pull/11795#discussion_r747914910, this PR adds OS information to the `bokeh info` command.

related to #11791
- [ ] tests added / passed
- [x] release document entry (if new feature or API change)
