### PR TITLE
add Python 3.10 to CI

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -314,7 +314,7 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
       - uses: actions/checkout@v2

--- a/ci/environment-test-3.10.yml
+++ b/ci/environment-test-3.10.yml
@@ -1,0 +1,82 @@
+name: bk-test
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+
+  # runtime
+  - jinja2 >=2.7
+  - numpy >=1.11.3
+  - packaging >=16.8
+  - pillow >=4.0
+  - python-dateutil >=2.1
+  - pyyaml >=3.10
+  - tornado >=5
+  - typing_extensions >=3.10.0
+  - xyzservices>=2021.09.1
+
+  # tests
+  - beautifulsoup4
+  - channels
+  - click
+  - colorama
+  - colorcet
+  - coverage
+  - firefox
+  - flake8
+  - flaky
+  - geckodriver
+  - ipython
+  - isort 5.8
+  - mock
+  - mypy >=0.910
+  - pandas-stubs
+  - nbconvert >=5.4
+  - networkx
+  - nodejs 14.*
+  #- numba
+  - pandas
+  - psutil
+  - pydot
+  - pygments
+  - pytest 6.2*
+  - pytest-asyncio
+  - pytest-cov >=1.8.1
+  - pytest-html
+  - pytest-xdist
+  - requests >=1.2.3
+  - selenium >=3.8
+  - scipy
+  - pre-commit
+
+  # examples
+  - flask >=1.0
+  - django
+  - h5py
+  - icalendar
+  - networkx
+  - notebook
+  - opencv
+  - pyshp
+  - scikit-learn
+  - sympy
+
+  # pip dependencies
+  - pip
+  - pip:
+    # docs
+    - autoclasstoc
+    - pydata_sphinx_theme >=0.7.1
+    - sphinx >=4.1,<4.3
+    - sphinxext-opengraph
+    - sphinx-panels
+    - sphinx-tabs
+    - sphinx-reredirects
+    # tests
+    - types-boto
+    - types-colorama
+    - types-mock
+    - types-pillow
+    - types-pyyaml
+    - types-requests
+    - flake8-pyi

--- a/ci/environment-test-3.10.yml
+++ b/ci/environment-test-3.10.yml
@@ -34,7 +34,6 @@ dependencies:
   - nbconvert >=5.4
   - networkx
   - nodejs 14.*
-  #- numba
   - pandas
   - psutil
   - pydot

--- a/ci/environment-test-3.10.yml
+++ b/ci/environment-test-3.10.yml
@@ -56,7 +56,6 @@ dependencies:
   - icalendar
   - networkx
   - notebook
-  - opencv
   - pyshp
   - scikit-learn
   - sympy

--- a/ci/environment-test-3.7.yml
+++ b/ci/environment-test-3.7.yml
@@ -34,7 +34,6 @@ dependencies:
   - nbconvert >=5.4
   - networkx
   - nodejs 14.*
-  - numba
   - pandas
   - psutil
   - pydot
@@ -56,7 +55,6 @@ dependencies:
   - icalendar
   - networkx
   - notebook
-  - opencv
   - pyshp
   - scikit-learn
   - sympy

--- a/ci/environment-test-3.8.yml
+++ b/ci/environment-test-3.8.yml
@@ -34,7 +34,6 @@ dependencies:
   - nbconvert >=5.4
   - networkx
   - nodejs 14.*
-  - numba
   - pandas
   - psutil
   - pydot
@@ -56,7 +55,6 @@ dependencies:
   - icalendar
   - networkx
   - notebook
-  - opencv
   - pyshp
   - scikit-learn
   - sympy

--- a/ci/environment-test-3.9.yml
+++ b/ci/environment-test-3.9.yml
@@ -34,7 +34,6 @@ dependencies:
   - nbconvert >=5.4
   - networkx
   - nodejs 14.*
-  #- numba
   - pandas
   - psutil
   - pydot
@@ -56,7 +55,6 @@ dependencies:
   - icalendar
   - networkx
   - notebook
-  - opencv
   - pyshp
   - scikit-learn
   - sympy

--- a/classifiers.txt
+++ b/classifiers.txt
@@ -17,6 +17,7 @@ Programming Language :: Python :: 3 :: Only
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
+Programming Language :: Python :: 3.10
 Programming Language :: JavaScript
 Topic :: Office/Business
 Topic :: Office/Business :: Financial

--- a/tests/examples.yaml
+++ b/tests/examples.yaml
@@ -20,7 +20,7 @@
 
 - path: "examples/app"
   type: server
-  skip: ["simple_hdf5", "spectrogram", "stocks"]
+  skip: ["faces", "simple_hdf5", "spectrogram", "stocks"]
 
 - path: "examples/integration/*"
 


### PR DESCRIPTION
This PR adds Python 3.10 to the unit testing matrix. This PR also removes numba and opencv from all test environments:

* they are the most problematic test dependencies
* the numba example runs w/o numba, just slowly — testing w/ numba adds nothing for us
* functionality in the opencv example is exercised in other examples