### PR TITLE
Remove automatic addition of `init_ModelName()`

### DIFF
--- a/bokehjs/src/compiler/compiler.ts
+++ b/bokehjs/src/compiler/compiler.ts
@@ -97,10 +97,6 @@ export function default_transformers(options: ts.CompilerOptions): ts.CustomTran
   const insert_class_name = transforms.insert_class_name()
   transformers.before.push(insert_class_name)
 
-  // TODO: remove this in 3.0
-  const add_init_class = transforms.add_init_class()
-  transformers.before.push(add_init_class)
-
   const base = options.baseUrl
   if (base != null) {
     const relativize_modules = transforms.relativize_modules((file, module_path) => {

--- a/bokehjs/src/compiler/transforms.ts
+++ b/bokehjs/src/compiler/transforms.ts
@@ -67,31 +67,6 @@ function is_static(node: ts.Node): boolean {
   return node.modifiers != null && node.modifiers.find((modifier) => modifier.kind == ts.SyntaxKind.StaticKeyword) != null
 }
 
-export function add_init_class() {
-  return (context: ts.TransformationContext) => (root: ts.SourceFile) => {
-    const {factory} = context
-
-    function visit(node: ts.Node): ts.VisitResult<ts.Node> {
-      node = ts.visitEachChild(node, visit, context)
-
-      if (ts.isClassDeclaration(node) && node.name != null) {
-        const name = `init_${node.name.getText()}`
-
-        if (node.members.find((member) => ts.isMethodDeclaration(member) && member.name.getText() == name && is_static(member)) != null) {
-          const init = factory.createExpressionStatement(
-            factory.createCallExpression(
-              factory.createPropertyAccessExpression(node.name, name), undefined, undefined))
-          return [node, init]
-        }
-      }
-
-      return node
-    }
-
-    return ts.visitNode(root, visit)
-  }
-}
-
 export function insert_class_name() {
   function has__name__(node: ts.ClassDeclaration): boolean {
     return node.members.find((member) => ts.isPropertyDeclaration(member) && member.name.getText() == "__name__" && is_static(member)) != null

--- a/sphinx/source/docs/releases/3.0.0.rst
+++ b/sphinx/source/docs/releases/3.0.0.rst
@@ -166,6 +166,13 @@ and the later with ``new HasProps(attrs)``, where ``attrs`` can not have an
 ``id`` field. As a side effect, duplicating model's identity is not permitted
 by default anymore, though one can still use deferred initializtion for this.
 
+``init_ModelName`` was removed
+..............................
+
+This static initializer was added automatically by bokehjs' build system and
+extensions' compiler. This isn't needed anymore as TypeScript supports ES2022
+static initialization blocks (``static {}``).
+
 Protocol changes
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This isn't needed anymore as TypeScript supports static initialization blocks (i.e. ``static {}``). This is a followup on PR #11503.