### PR TITLE
Clarify handling and internal types of partial messages

### DIFF
--- a/bokehjs/src/lib/client/connection.ts
+++ b/bokehjs/src/lib/client/connection.ts
@@ -2,7 +2,7 @@ import {logger} from "core/logging"
 import {Document, DocJson} from "document"
 import {Message} from "protocol/message"
 import {Receiver} from "protocol/receiver"
-import {ClientSession} from "./session"
+import {ClientSession, ErrorMsg} from "./session"
 
 export const DEFAULT_SERVER_WEBSOCKET_URL = "ws://localhost:5006/ws"
 export const DEFAULT_TOKEN = "eyJzZXNzaW9uX2lkIjogImRlZmF1bHQifQ"
@@ -11,7 +11,7 @@ let _connection_count: number = 0
 
 export type Rejecter = (error: Error | string) => void
 export type SessionResolver = (s: ClientSession) => void
-export type MessageResolver = (m: Message) => void
+export type MessageResolver = (m: Message<unknown>) => void
 export type PendingReply = {resolve: MessageResolver, reject: Rejecter}
 
 export type Token = {
@@ -37,9 +37,9 @@ export class ClientConnection {
   closed_permanently: boolean = false
   id: string
 
-  protected _current_handler: ((message: Message) => void) | null = null
+  protected _current_handler: ((message: Message<unknown>) => void) | null = null
   protected _pending_replies: Map<string, PendingReply> = new Map()
-  protected _pending_messages: Message[] = []
+  protected _pending_messages: Message<unknown>[] = []
   protected readonly _receiver: Receiver = new Receiver()
 
   constructor(readonly url: string = DEFAULT_SERVER_WEBSOCKET_URL,
@@ -113,27 +113,27 @@ export class ClientConnection {
     setTimeout(retry, milliseconds)
   }
 
-  send(message: Message): void {
+  send(message: Message<unknown>): void {
     if (this.socket == null)
       throw new Error(`not connected so cannot send ${message}`)
     message.send(this.socket)
   }
 
-  async send_with_reply(message: Message): Promise<Message> {
-    const reply = await new Promise<Message>((resolve, reject) => {
+  async send_with_reply<T>(message: Message<unknown>): Promise<Message<T>> {
+    const reply = await new Promise<Message<unknown>>((resolve, reject) => {
       this._pending_replies.set(message.msgid(), {resolve, reject})
       this.send(message)
     })
 
-    if (reply.msgtype() === "ERROR")
-      throw new Error(`Error reply ${reply.content.text}`)
+    if (reply.msgtype() == "ERROR")
+      throw new Error(`Error reply ${(reply as ErrorMsg).content.text}`)
     else
-      return reply
+      return reply as Message<T>
   }
 
   protected async _pull_doc_json(): Promise<DocJson> {
-    const message = Message.create("PULL-DOC-REQ", {})
-    const reply = await this.send_with_reply(message)
+    const message = Message.create("PULL-DOC-REQ", {}, {})
+    const reply = await this.send_with_reply<{doc: DocJson}>(message)
     if (!("doc" in reply.content))
       throw new Error("No 'doc' field in PULL-DOC-REPLY")
     return reply.content.doc
@@ -184,7 +184,7 @@ export class ClientConnection {
 
   protected _on_open(resolve: SessionResolver, reject: Rejecter): void {
     logger.info(`Websocket connection ${this._number} is now open`)
-    this._current_handler = (message: Message) => {
+    this._current_handler = (message: Message<unknown>) => {
       this._awaiting_ack_handler(message, resolve, reject)
     }
   }
@@ -235,9 +235,9 @@ export class ClientConnection {
       this.socket.close(1002, detail) // 1002 = protocol error
   }
 
-  protected _awaiting_ack_handler(message: Message, resolve: SessionResolver, reject: Rejecter): void {
+  protected _awaiting_ack_handler(message: Message<unknown>, resolve: SessionResolver, reject: Rejecter): void {
     if (message.msgtype() === "ACK") {
-      this._current_handler = (message: Message) => this._steady_state_handler(message)
+      this._current_handler = (message: Message<unknown>) => this._steady_state_handler(message)
 
       // Reload any sessions
       this._repull_session_doc(resolve, reject)
@@ -245,7 +245,7 @@ export class ClientConnection {
       this._close_bad_protocol("First message was not an ACK")
   }
 
-  protected _steady_state_handler(message: Message): void {
+  protected _steady_state_handler(message: Message<unknown>): void {
     const reqid = message.reqid()
     const pr = this._pending_replies.get(reqid)
     if (pr) {

--- a/bokehjs/src/lib/embed/notebook.ts
+++ b/bokehjs/src/lib/embed/notebook.ts
@@ -1,5 +1,6 @@
-import {Document} from "document"
+import {Document, Patch} from "document"
 import {Receiver} from "protocol/receiver"
+import {Message} from "protocol/message"
 import {logger} from "core/logging"
 import {stylesheet} from "core/dom"
 import {size, values} from "core/util/object"
@@ -29,7 +30,7 @@ function _handle_notebook_comms(this: Document, receiver: Receiver, comm_msg: Co
 
   const msg = receiver.message
   if (msg != null)
-    this.apply_json_patch(msg.content, msg.buffers)
+    this.apply_json_patch((msg as Message<Patch>).content, msg.buffers)
 }
 
 function _init_comms(target: string, doc: Document): void {

--- a/bokehjs/src/lib/protocol/receiver.ts
+++ b/bokehjs/src/lib/protocol/receiver.ts
@@ -1,14 +1,15 @@
 import {Message} from "protocol/message"
 import {isString} from "core/util/types"
+import {assert} from "core/util/assert"
 
 export type Fragment = string | ArrayBuffer
 
 export class Receiver {
-  message: Message | null = null
+  message: Message<unknown> | null = null
 
-  protected _partial: Message | null = null
+  protected _partial: Message<unknown> | null = null
 
-  protected _fragments: Fragment[] = []
+  protected _fragments: [string?, string?, string?] = []
 
   protected _buf_header: string | null = null
 
@@ -36,8 +37,8 @@ export class Receiver {
   _CONTENT(fragment: Fragment): void {
     this._assume_text(fragment)
     this._fragments.push(fragment)
-    const [header_json, metadata_json, content_json] =
-      this._fragments.slice(0, 3) as [string, string, string]
+    const [header_json, metadata_json, content_json] = this._fragments
+    assert(header_json != null && metadata_json != null && content_json != null)
     this._partial = Message.assemble(header_json, metadata_json, content_json)
     this._check_complete()
   }
@@ -50,7 +51,8 @@ export class Receiver {
 
   _BUFFER_PAYLOAD(fragment: Fragment): void {
     this._assume_binary(fragment)
-    this._partial!.assemble_buffer(this._buf_header!, fragment)
+    assert(this._partial != null && this._buf_header != null)
+    this._partial.assemble_buffer(this._buf_header, fragment)
     this._check_complete()
   }
 

--- a/bokehjs/test/unit/protocol/message.ts
+++ b/bokehjs/test/unit/protocol/message.ts
@@ -87,21 +87,6 @@ describe("protocol/message module", () => {
 
     describe("complete method", () => {
 
-      it("should return false if header is missing", () => {
-        const m = Message.assemble("null", '{"bar":2}', '{"baz":3}')
-        expect(m.complete()).to.be.false
-      })
-
-      it("should return false if content is missing", () => {
-        const m = Message.assemble('{"msgid": "10", "msgtype": "FOO"}', "null", '{"baz":3}')
-        expect(m.complete()).to.be.false
-      })
-
-      it("should return false if metadata is missing", () => {
-        const m = Message.assemble('{"msgid": "10", "msgtype": "FOO"}', '{"bar":2}', "null")
-        expect(m.complete()).to.be.false
-      })
-
       it("should return true if num_buffers matches", () => {
         const m0 = Message.assemble('{"msgid": "10", "msgtype": "FOO"}', '{"bar":2}', '{"baz":3}')
         expect(m0.complete()).to.be.true


### PR DESCRIPTION
This PR is a side effect of stricter analysis of conditional expressions (PR #11763). The primary task of this PR is to establish the structure of partial messages, i.e. if `header`, `metadata` and `content` can be `null`. The secondary concern is to allow better static typing of messages' contents (`any` -> type parameterized).