### PR TITLE
Correctly handle odd-length dash patterns in WebGL

### DIFF
--- a/bokehjs/src/lib/models/glyphs/webgl/dash_cache.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/dash_cache.ts
@@ -1,4 +1,5 @@
 import {gcd, is_pow_2} from "./utils/math"
+import {concat} from "core/util/array"
 import {map} from "core/util/arrayable"
 import {Regl, Texture2D} from "regl"
 
@@ -156,9 +157,9 @@ export class DashCache {
   }
 
   public get(pattern: number[]): DashReturn {
-    // Limit pattern to even number of items.
+    // Odd-length patterns are repeated to match canvas.
     if (pattern.length % 2 == 1)
-      pattern = pattern.slice(0, -1)
+      pattern = concat([pattern, pattern])
 
     return this._get_or_create(pattern)
   }

--- a/bokehjs/src/lib/models/glyphs/webgl/line_gl.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/line_gl.ts
@@ -172,10 +172,6 @@ export class LineGL extends BaseGLGlyph {
     }
 
     this._line_dash = resolve_line_dash(line_visuals.line_dash.value)
-    if (this._line_dash.length == 1)
-      // Dash pattern of single number means gap is same length as dash.
-      this._line_dash.push(this._line_dash[0])
-
     if (this._is_dashed()) {
       [this._dash_tex_info, this._dash_tex, this._dash_scale] =
         this.regl_wrapper.get_dash(this._line_dash)

--- a/bokehjs/test/integration/glyphs/line.ts
+++ b/bokehjs/test/integration/glyphs/line.ts
@@ -141,7 +141,8 @@ describe("Line glyph", () => {
       const X = () => [x+=0.15, 1+x, 2+x, 3+x, 4+x]
       const Y = () => [10 - (y+=5), 20-y, 14-y, 12-y, 40-y]
 
-      const dashes = [[4, 4], [10, 5, 10, 13], [20, 10]]
+      // Note first pattern has odd length so pattern will be repeated.
+      const dashes = [[4], [10, 5, 10, 13], [20, 10]]
 
       for (let i = 0; i < colors.length; i++) {
         for (let j = 0; j < linewidths.length; j++) {


### PR DESCRIPTION
Fixes item 6 of issue #11050.

Line dash patterns with an odd length were not handled correctly in the WebGL output backend, this PR fixes that. Correct behaviour to match the canvas backend is to repeat the dash pattern so that its length is even. Fix motivated by comment from @mattpap https://github.com/bokeh/bokeh/pull/10861#discussion_r592985851.

Dash patterns coming from Python are already sanitised before they reach the WebGL code, so this is only an issue for direct use of BokehJS.

I have modified an existing visual test that was using a dash pattern of `[4, 4]` to now use `[4]`. The PNG output is therefore the same as before, but is obtained by a slightly different code path. So strictly speaking this is not a full test in that it does not fail before the fix. I am happy to add an explicit full test if that is preferred.