### PR TITLE
Update branches in CI workflow configurations

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -3,7 +3,7 @@ name: Bokeh-CI
 on:
   push:
     branches:
-      - master
+      - main
       - branch-*
   pull_request:
 

--- a/.github/workflows/bokehjs-ci.yml
+++ b/.github/workflows/bokehjs-ci.yml
@@ -3,7 +3,8 @@ name: BokehJS-CI
 on:
   push:
     branches:
-      - master
+      - main
+      - branch-*
     paths:
       - 'bokehjs/**'
   pull_request:


### PR DESCRIPTION
Renames `master` to `main` and adds `branch-*` to bokehjs-ci's configuration (I noticed that CI is not run for bokehjs on push, only PRs).
