### PR TITLE
Force webgl backend when requested for testing

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -154,11 +154,17 @@ jobs:
         shell: bash -l {0}
         run: bash ci/install_bokeh_package.sh
 
-      - name: Upgrade chromium
+      - name: Install chromium
         if: runner.os == 'Linux'
         shell: bash
         run: |
-          sudo snap install chromium
+          VER=95.0.4638.69
+          REV=chromium_1810
+          URL=https://github.com/bokeh/chromium/raw/main/linux/$VER
+          wget --no-verbose $URL/$REV.assert
+          wget --no-verbose $URL/$REV.snap
+          sudo snap ack $REV.assert
+          sudo snap install $REV.snap
 
       - name: Start chrome headless
         working-directory: ./bokehjs
@@ -238,11 +244,17 @@ jobs:
         shell: bash -l {0}
         run: bash ci/install_bokeh_package.sh
 
-      - name: Upgrade chromium
+      - name: Install chromium
         if: runner.os == 'Linux'
         shell: bash
         run: |
-          sudo snap install chromium
+          VER=95.0.4638.69
+          REV=chromium_1810
+          URL=https://github.com/bokeh/chromium/raw/main/linux/$VER
+          wget --no-verbose $URL/$REV.assert
+          wget --no-verbose $URL/$REV.snap
+          sudo snap ack $REV.assert
+          sudo snap install $REV.snap
 
       - name: Run tests
         working-directory: bokehjs

--- a/.github/workflows/bokehjs-ci.yml
+++ b/.github/workflows/bokehjs-ci.yml
@@ -36,11 +36,17 @@ jobs:
         run: |
           npm install -g npm@7
 
-      - name: Upgrade chromium
+      - name: Install chromium
         if: runner.os == 'Linux'
         shell: bash
         run: |
-          sudo snap install chromium
+          VER=95.0.4638.69
+          REV=chromium_1810
+          URL=https://github.com/bokeh/chromium/raw/main/linux/$VER
+          wget --no-verbose $URL/$REV.assert
+          wget --no-verbose $URL/$REV.snap
+          sudo snap ack $REV.assert
+          sudo snap install $REV.snap
 
       - name: Install dependencies
         working-directory: ./bokehjs

--- a/bokehjs/src/lib/core/settings.ts
+++ b/bokehjs/src/lib/core/settings.ts
@@ -1,6 +1,7 @@
 export class Settings {
   private _dev = false
   private _wireframe = false
+  private _force_webgl = false
 
   set dev(dev: boolean) {
     this._dev = dev
@@ -16,6 +17,14 @@ export class Settings {
 
   get wireframe(): boolean {
     return this._wireframe
+  }
+
+  set force_webgl(force_webgl: boolean) {
+    this._force_webgl = force_webgl
+  }
+
+  get force_webgl(): boolean {
+    return this._force_webgl
   }
 }
 

--- a/bokehjs/src/lib/models/canvas/canvas.ts
+++ b/bokehjs/src/lib/models/canvas/canvas.ts
@@ -1,4 +1,5 @@
 import {HasProps} from "core/has_props"
+import {settings} from "core/settings"
 import {DOMView} from "core/dom_view"
 import {logger} from "core/logging"
 import * as p from "core/properties"
@@ -119,6 +120,8 @@ export class CanvasView extends DOMView {
 
     if (this.model.output_backend == "webgl") {
       this.webgl = await global_webgl()
+      if (settings.force_webgl && this.webgl == null)
+        throw new Error("webgl is not available")
     }
   }
 

--- a/bokehjs/test/devtools/test.html
+++ b/bokehjs/test/devtools/test.html
@@ -50,6 +50,7 @@
     <script type="text/javascript" src="{{ js('bokeh-mathjax') }}"></script>
     <script type="text/javascript">
       Bokeh.settings.dev = true
+      Bokeh.settings.force_webgl = true
     </script>
     <script type="text/javascript">
       const {require} = Bokeh


### PR DESCRIPTION
This will fail in HeadlessChrome/96.0.4664.45 due to `canvas.getContext("webgl")` (or `"webgl2"`) returning `null`. Things work in non-headless Chrome (same version).
