### PR TITLE
bokeh/bokeh#11640 Document Tool.icon in user guide

### DIFF
--- a/sphinx/source/docs/user_guide/examples/customizing_tools_icon.py
+++ b/sphinx/source/docs/user_guide/examples/customizing_tools_icon.py
@@ -1,0 +1,18 @@
+from bokeh.models.tools import BoxSelectTool
+from bokeh.plotting import figure, show
+
+# prepare some data
+x = [1, 2, 3, 4, 5]
+y = [1, 4, 2, 4, 5]
+
+# create a new figure with no tools
+p = figure(tools="", width=400, height=400)
+
+# Adding a tool with custom icon
+p.add_tools(BoxSelectTool(icon="xpan"))
+
+# add a line renderer with legend and line thickness
+p.line(x, y, legend_label="Temp.", line_width=2)
+
+# show the results
+show(p)

--- a/sphinx/source/docs/user_guide/examples/customizing_tools_tooltip.py
+++ b/sphinx/source/docs/user_guide/examples/customizing_tools_tooltip.py
@@ -1,0 +1,18 @@
+from bokeh.models.tools import BoxSelectTool
+from bokeh.plotting import figure, show
+
+# prepare some data
+x = [1, 2, 3, 4, 5]
+y = [1, 4, 2, 4, 5]
+
+# create a new plot, with no tools
+p = figure(tools="", width=400, height=400)
+
+# Adding a tool, with custom tooltip
+p.add_tools(BoxSelectTool(description="My tool"))
+
+# add a line renderer with legend and line thickness
+p.line(x, y, legend_label="Temp.", line_width=2)
+
+# show the results
+show(p)

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -132,17 +132,18 @@ You can pass:
         .. code-block:: python
 
             plot.add_tools(BoxSelectTool(icon="box_zoom"))
+
     2. A CSS selector
 
         .. code-block:: python
 
             plot.add_tools(BoxSelectTool(icon=".my-icon-class"))
+
     3. An image path
 
         .. code-block:: python
 
             plot.add_tools(BoxSelectTool(icon="path/to/icon"))
-
 
 .. _userguide_tools_setting_active_tools:
 

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -69,8 +69,8 @@ outside of the area where the axis is drawn.
 
 .. _userguide_tools_specifying_tools:
 
-Specifying tools
-----------------
+Specifying tools Trying
+-----------------------
 
 At the lowest |bokeh.models| level, you can add tools to a ``Plot`` by
 passing instances of ``Tool`` objects to the ``add_tools()`` method:
@@ -110,6 +110,49 @@ method with the figure() function's tools argument:
 
     plot = figure(tools="pan,wheel_zoom,box_zoom,reset")
     plot.add_tools(BoxSelectTool(dimensions="width"))
+
+
+.. _userguide_tools_customize_tools_icon:
+
+Customizing tools icon
+----------------------
+You can change the :ref:`bokeh.models.tools` tooltip by passing it to
+the ``description`` keyword using the ``add_tools()`` method of a plot or any
+of it's instances like |figure|.
+
+.. code-block:: python
+
+    plot.add_tools(BoxSelectTool(description="My tool"))
+
+
+It's also possible to change a tool icon using the ``icon`` keyword.
+
+You can pass:
+    1. A well known icon name
+
+        .. code-block:: python
+
+            plot.add_tools(BoxSelectTool(icon="box_zoom"))
+    2. A CSS selector
+
+        .. code-block:: python
+
+            plot.add_tools(BoxSelectTool(icon=".my-icon-class"))
+    3. An image path
+
+        .. code-block:: python
+
+            plot.add_tools(BoxSelectTool(icon="path/to/icon"))
+    4. A PIL Image instance
+
+        .. code-block:: python
+
+            from bokeh.models import BoxSelectTool
+            import PIL
+
+            my_icon = PIL.Image.open("path/to/icon").convert("RGB")
+
+            plot.add_tools(BoxSelectTool(icon=my_icon))
 
 .. _userguide_tools_setting_active_tools:
 

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -69,8 +69,8 @@ outside of the area where the axis is drawn.
 
 .. _userguide_tools_specifying_tools:
 
-Specifying tools Trying
------------------------
+Specifying tools
+----------------
 
 At the lowest |bokeh.models| level, you can add tools to a ``Plot`` by
 passing instances of ``Tool`` objects to the ``add_tools()`` method:

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -122,6 +122,7 @@ of it's instances like |figure|.
 .. code-block:: python
 
     plot.add_tools(BoxSelectTool(description="My tool"))
+
 It's also possible to change a tool icon using the ``icon`` keyword.
 
 You can pass:
@@ -131,13 +132,11 @@ You can pass:
         .. code-block:: python
 
             plot.add_tools(BoxSelectTool(icon="box_zoom"))
-            
     2. A CSS selector
 
         .. code-block:: python
 
             plot.add_tools(BoxSelectTool(icon=".my-icon-class"))
-            
     3. An image path
 
         .. code-block:: python

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -123,26 +123,28 @@ of it's instances like |figure|.
 .. code-block:: python
 
     plot.add_tools(BoxSelectTool(description="My tool"))
-
-
 It's also possible to change a tool icon using the ``icon`` keyword.
 
 You can pass:
+
     1. A well known icon name
 
         .. code-block:: python
 
             plot.add_tools(BoxSelectTool(icon="box_zoom"))
+            
     2. A CSS selector
 
         .. code-block:: python
 
             plot.add_tools(BoxSelectTool(icon=".my-icon-class"))
+            
     3. An image path
 
         .. code-block:: python
 
             plot.add_tools(BoxSelectTool(icon="path/to/icon"))
+            
     4. A PIL Image instance
 
         .. code-block:: python

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -111,7 +111,6 @@ method with the figure() function's tools argument:
     plot = figure(tools="pan,wheel_zoom,box_zoom,reset")
     plot.add_tools(BoxSelectTool(dimensions="width"))
 
-
 .. _userguide_tools_customize_tools_icon:
 
 Customizing tools icon
@@ -144,17 +143,7 @@ You can pass:
         .. code-block:: python
 
             plot.add_tools(BoxSelectTool(icon="path/to/icon"))
-            
-    4. A PIL Image instance
 
-        .. code-block:: python
-
-            from bokeh.models import BoxSelectTool
-            import PIL
-
-            my_icon = PIL.Image.open("path/to/icon").convert("RGB")
-
-            plot.add_tools(BoxSelectTool(icon=my_icon))
 
 .. _userguide_tools_setting_active_tools:
 


### PR DESCRIPTION
Added documentation based on #11640, had a problem with adding icons from an URL, tried PNG icons it gave the following error `icon given the invalid value` in the dev tool.

Tried passing a PIL Image object, and it gave me this error `Object of type Image is not JSON serializable`

So I need help figuring out if the way I'm trying to change the icon is correct, and if you got any feedback on the PR.