### PR TITLE
Robustify detection of changes during initialization

### DIFF
--- a/bokehjs/src/lib/core/deserializer.ts
+++ b/bokehjs/src/lib/core/deserializer.ts
@@ -6,6 +6,7 @@ import {Buffers, is_NDArray_ref, decode_NDArray} from "./util/serialization"
 import {ndarray} from "./util/ndarray"
 import {values, entries} from "./util/object"
 import {isArray, isPlainObject, isString, isNumber} from "./util/types"
+import {type Document} from "document"
 
 export type RefMap = Map<ID, HasProps>
 
@@ -153,7 +154,7 @@ export class Deserializer {
   // given a JSON representation of all models in a graph and new
   // model instances, set the properties on the models from the
   // JSON
-  static _initialize_references_json(references_json: Struct[], old_references: RefMap, new_references: RefMap, buffers: Buffers): void {
+  static _initialize_references_json(references_json: Struct[], old_references: RefMap, new_references: RefMap, buffers: Buffers, doc: Document | null): void {
     const to_update = new Map<ID, {instance: HasProps, is_new: boolean}>()
 
     for (const {id, attributes} of references_json) {
@@ -185,6 +186,11 @@ export class Deserializer {
           if (is_new) {
             // Finalizing here just to avoid iterating
             // over `ordered_instances` twice.
+
+            // finalize unset properties before this
+            instance.finalize_props()
+            if (doc != null)
+              instance.attach_document(doc)
             instance.finalize()
             // Preserving an ordered collection of instances
             // to avoid having to go through DFS again.

--- a/bokehjs/src/lib/document/defs.ts
+++ b/bokehjs/src/lib/document/defs.ts
@@ -133,7 +133,7 @@ export function resolve_defs(defs: ModelDef[], resolver: ModelResolver): void {
     }
 
     const references = Deserializer._instantiate_references_json(def.references, new Map(), resolver)
-    Deserializer._initialize_references_json(def.references, new Map(), references, new Map())
+    Deserializer._initialize_references_json(def.references, new Map(), references, new Map(), null)
 
     function resolve_refs(value: unknown): unknown {
       return Deserializer._resolve_refs(value, new Map(), references, new Map())

--- a/bokehjs/src/lib/models/plots/plot.ts
+++ b/bokehjs/src/lib/models/plots/plot.ts
@@ -192,14 +192,6 @@ export class Plot extends LayoutDOM {
     })
   }
 
-  protected override _doc_attached(): void {
-    super._doc_attached()
-    this._push_changes([
-      [this.properties.inner_height, null, this.inner_height],
-      [this.properties.inner_width, null, this.inner_width],
-    ])
-  }
-
   override initialize(): void {
     super.initialize()
 

--- a/bokehjs/test/unit/document/events.ts
+++ b/bokehjs/test/unit/document/events.ts
@@ -2,6 +2,7 @@ import {expect} from "assertions"
 
 import {HasProps} from "@bokehjs/core/has_props"
 import {Serializer} from "@bokehjs/core/serializer"
+import {is_equal} from "@bokehjs/core/util/eq"
 import {Document} from "@bokehjs/document/document"
 import * as events from "@bokehjs/document/events"
 
@@ -19,7 +20,7 @@ const EVENTS = [
 
 class TestModel extends HasProps {}
 
-class TestModelWithRefs extends HasProps {
+class TestModelWithProps extends HasProps {
   foo: number[]
 
   static {
@@ -53,6 +54,14 @@ describe("events module", () => {
         patches: {foo: [[1, 2]]},
       })
     })
+
+    it("should support equality", () => {
+      const doc = new Document()
+      const ev0 = new events.ColumnsPatchedEvent(doc, {id: "whatever"}, {column: [[0, "a"]]})
+      const ev1 = new events.ColumnsPatchedEvent(doc, {id: "whatever"}, {column: [[0, "b"]]})
+      expect(is_equal(ev0, ev0)).to.be.equal(true)
+      expect(is_equal(ev0, ev1)).to.be.equal(false)
+    })
   })
 
   describe("ColumnsStreamedEvent", () => {
@@ -83,6 +92,14 @@ describe("events module", () => {
         rollover: undefined,
       })
     })
+
+    it("should support equality", () => {
+      const doc = new Document()
+      const ev0 = new events.ColumnsStreamedEvent(doc, {id: "whatever"}, {x: [1]})
+      const ev1 = new events.ColumnsStreamedEvent(doc, {id: "whatever"}, {x: [2]})
+      expect(is_equal(ev0, ev0)).to.be.equal(true)
+      expect(is_equal(ev0, ev1)).to.be.equal(false)
+    })
   })
 
   describe("ModelChangedEvent", () => {
@@ -103,7 +120,7 @@ describe("events module", () => {
     it("should generating json with references", () =>{
       const d = new Document()
       const m = new TestModel()
-      const m2 = new TestModelWithRefs({foo: []})
+      const m2 = new TestModelWithProps({foo: []})
       const event = new events.ModelChangedEvent(d, m2, "foo", [], [m])
       const serializer = new Serializer()
       const result = serializer.to_serializable(event)
@@ -133,6 +150,15 @@ describe("events module", () => {
         rollover: undefined,
       })
     })
+
+    it("should support equality", () => {
+      const doc = new Document()
+      const model = new TestModel()
+      const ev0 = new events.ModelChangedEvent(doc, model, "foo", [], [1])
+      const ev1 = new events.ModelChangedEvent(doc, model, "foo", [], [2])
+      expect(is_equal(ev0, ev0)).to.be.equal(true)
+      expect(is_equal(ev0, ev1)).to.be.equal(false)
+    })
   })
 
   describe("TitleChangedEvent", () => {
@@ -145,6 +171,14 @@ describe("events module", () => {
         kind: "TitleChanged",
         title: "foo",
       })
+    })
+
+    it("should support equality", () => {
+      const doc = new Document()
+      const ev0 = new events.TitleChangedEvent(doc, "some")
+      const ev1 = new events.TitleChangedEvent(doc, "else")
+      expect(is_equal(ev0, ev0)).to.be.equal(true)
+      expect(is_equal(ev0, ev1)).to.be.equal(false)
     })
   })
 
@@ -160,6 +194,14 @@ describe("events module", () => {
         model: m.ref(),
       })
     })
+
+    it("should support equality", () => {
+      const doc = new Document()
+      const ev0 = new events.RootAddedEvent(doc, new TestModelWithProps({foo: [0]}))
+      const ev1 = new events.RootAddedEvent(doc, new TestModelWithProps({foo: [1]}))
+      expect(is_equal(ev0, ev0)).to.be.equal(true)
+      expect(is_equal(ev0, ev1)).to.be.equal(false)
+    })
   })
 
   describe("RootRemovedEvent", () => {
@@ -173,6 +215,14 @@ describe("events module", () => {
         kind: "RootRemoved",
         model: m.ref(),
       })
+    })
+
+    it("should support equality", () => {
+      const doc = new Document()
+      const ev0 = new events.RootRemovedEvent(doc, new TestModelWithProps({foo: [0]}))
+      const ev1 = new events.RootRemovedEvent(doc, new TestModelWithProps({foo: [1]}))
+      expect(is_equal(ev0, ev0)).to.be.equal(true)
+      expect(is_equal(ev0, ev1)).to.be.equal(false)
     })
   })
 })


### PR DESCRIPTION
This is a proof of concept. This removes `Document._compute_patch_since_json()` and changes when document is attached to models during initialization. This way we can use ordinary handling of model change events to propagate changes, that happen during initialization of models, to server.

- [x] API design
- [x] tests

fixes #11803
