### PR TITLE
Remove temporary WebGL circle fix

### DIFF
--- a/bokehjs/src/lib/models/glyphs/webgl/markers.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/markers.ts
@@ -53,11 +53,7 @@ export class MarkerGL extends BaseGLGlyph {
     // The main glyph has the data, this glyph has the visuals.
     const mainGlGlyph = main_glyph.glglyph!
 
-    // Temporary solution for circles to always force call to _set_data.
-    // Correct solution depends on keeping the webgl properties constant and
-    // only changing the indices, which in turn depends on the correct webgl
-    // instanced rendering.
-    if (mainGlGlyph.data_changed || is_CircleView(this.glyph)) {
+    if (mainGlGlyph.data_changed) {
       mainGlGlyph._set_data()
       mainGlGlyph.data_changed = false
     }


### PR DESCRIPTION
Fixes item 5 of issue #11051.

The original conversion of the WebGL code to ReGL used a temporary fix for `circle` markers to deal with their dual nature of either having a `radius` in data units or a `size` in screen units. This PR removes that temporary fix as it is no longer needed.

Most of the work here is not the code removal but the checking that it is OK to remove it.