### PR TITLE
Docker image build and use

### DIFF
--- a/.github/workflows/bokeh-docker-build.yml
+++ b/.github/workflows/bokeh-docker-build.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
+          name: artifact
           path: bokeh-dev.tar
 
       - name: Checkout source
@@ -53,3 +54,23 @@ jobs:
         if: ${{ github.event.inputs.run_tests }}
         run: |
           docker run -v $GITHUB_WORKSPACE:/bokeh -u $(id --user):$(id --group) --rm -e BOKEH_DOCKER_BUILD=1 -e BOKEH_DOCKER_TEST=1 bokeh-dev:latest
+
+      - name: Collect results
+        if: ${{ github.event.inputs.run_tests }}
+        run: |
+          OS=$(echo ${{ runner.os }} | tr '[:upper:]' '[:lower:]')
+          SRC="bokehjs/test/baselines/${OS}"
+          DST="bokehjs-report/${SRC}"
+          mkdir -p ${DST}
+          if [[ -e ${SRC}/report.json ]];
+          then
+            CHANGED=$(git status --short ${SRC}/\*.blf ${SRC}/\*.png | cut -c4-)
+            cp ${SRC}/report.json ${CHANGED} ${DST}
+          fi
+
+      - name: Upload test report
+        if: ${{ github.event.inputs.run_tests }}
+        uses: actions/upload-artifact@v1
+        with:
+          name: artifact
+          path: bokehjs-report

--- a/.github/workflows/bokeh-docker-build.yml
+++ b/.github/workflows/bokeh-docker-build.yml
@@ -36,14 +36,17 @@ jobs:
             bokeh-dev:latest
             bokeh-dev:${{ env.iso_date }}
 
-      - name: Tag image with chrome version
+      - name: Determine chrome version in image
         env:
           BOKEH_DOCKER_CHROME_VERSION: 1
         run: |
-          docker images
           echo "chrome_version=$(ci/docker/docker_run.sh bokeh-dev | tail -1 | awk -F'.' '{print $1}')" >> $GITHUB_ENV
-          docker image tag bokeh-dev bokeh-dev:chrome${{ env.chrome_version }}
-          docker images
+
+      - name: Tag image with chrome version
+        run: |
+          docker images bokeh-dev
+          docker image tag bokeh-dev bokeh-dev:chrome_${{ env.chrome_version }}
+          docker images bokeh-dev
 
       - name: Save image to tar file
         run: |

--- a/.github/workflows/bokeh-docker-build.yml
+++ b/.github/workflows/bokeh-docker-build.yml
@@ -52,4 +52,4 @@ jobs:
       - name: Run tests
         if: ${{ github.event.inputs.run_tests }}
         run: |
-          docker run -v $GITHUB_WORKSPACE:/bokeh -u $(id --user):$(id --group) --rm -e BOKEH_DOCKER_BUILD=1 bokeh-dev:latest
+          docker run -v $GITHUB_WORKSPACE:/bokeh -u $(id --user):$(id --group) --rm -e BOKEH_DOCKER_BUILD=1 -e BOKEH_DOCKER_TEST=1 bokeh-dev:latest

--- a/.github/workflows/bokeh-docker-build.yml
+++ b/.github/workflows/bokeh-docker-build.yml
@@ -2,11 +2,20 @@ name: Docker image - Build
 
 on:
   workflow_dispatch:
+    inputs:
+      run_tests:
+        description: 'Run tests (0 or 1)'
+        required: true
+        default: '0'
 
 jobs:
   docker_build:
     runs-on: ubuntu-latest
     steps:
+      - name: Set date environment variable
+        run: |
+          echo "iso_date=$(date -u --iso-8601)" >> $GITHUB_ENV
+
       - name: Checkout source
         uses: actions/checkout@v2
 
@@ -21,7 +30,9 @@ jobs:
         with:
           context: ci/docker
           load: true
-          tags: bokeh-dev:latest
+          tags: |
+            bokeh-dev:latest
+            bokeh-dev:${{ env.iso_date }}
 
       - name: Save image to file
         run: |
@@ -31,3 +42,14 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           path: bokeh-dev.tar
+
+      - name: Checkout source
+        if: ${{ github.event.inputs.run_tests }}
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Run tests
+        if: ${{ github.event.inputs.run_tests }}
+        run: |
+          docker run -v $GITHUB_WORKSPACE:/bokeh --rm -e BOKEH_DOCKER_BUILD=1 bokeh-dev:latest

--- a/.github/workflows/bokeh-docker-build.yml
+++ b/.github/workflows/bokeh-docker-build.yml
@@ -52,4 +52,4 @@ jobs:
       - name: Run tests
         if: ${{ github.event.inputs.run_tests }}
         run: |
-          docker run -v $GITHUB_WORKSPACE:/bokeh --rm -e BOKEH_DOCKER_BUILD=1 bokeh-dev:latest
+          docker run -v $GITHUB_WORKSPACE:/bokeh -u $(id --user):$(id --group) --rm -e BOKEH_DOCKER_BUILD=1 bokeh-dev:latest

--- a/.github/workflows/bokeh-docker-build.yml
+++ b/.github/workflows/bokeh-docker-build.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Checkout source
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -43,12 +45,6 @@ jobs:
         with:
           name: artifact
           path: bokeh-dev.tar
-
-      - name: Checkout source
-        if: ${{ github.event.inputs.run_tests }}
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Run tests
         if: ${{ github.event.inputs.run_tests }}

--- a/.github/workflows/bokeh-docker-build.yml
+++ b/.github/workflows/bokeh-docker-build.yml
@@ -36,7 +36,16 @@ jobs:
             bokeh-dev:latest
             bokeh-dev:${{ env.iso_date }}
 
-      - name: Save image to file
+      - name: Tag image with chrome version
+        env:
+          BOKEH_DOCKER_CHROME_VERSION: 1
+        run: |
+          docker images
+          echo "chrome_version=$(ci/docker/docker_run.sh bokeh-dev | tail -1 | awk -F'.' '{print $1}')" >> $GITHUB_ENV
+          docker image tag bokeh-dev bokeh-dev:chrome${{ env.chrome_version }}
+          docker images
+
+      - name: Save image to tar file
         run: |
           docker save -o bokeh-dev.tar bokeh-dev
 

--- a/.github/workflows/bokeh-docker-build.yml
+++ b/.github/workflows/bokeh-docker-build.yml
@@ -20,7 +20,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ci/docker
-          load: false
+          load: true
           tags: bokeh-dev:latest
 
       - name: Save image to file

--- a/ci/docker/docker_run.sh
+++ b/ci/docker/docker_run.sh
@@ -15,7 +15,7 @@ IMAGE_AND_TAG=$1
 UID_GID="`id --user`:`id --group`"
 
 ENV_VARS=""
-for name in BOKEH_DOCKER_CONDA BOKEH_DOCKER_PY BOKEH_DOCKER_BUILD BOKEH_DOCKER_TEST; do
+for name in BOKEH_DOCKER_CONDA BOKEH_DOCKER_PY BOKEH_DOCKER_BUILD BOKEH_DOCKER_TEST BOKEH_DOCKER_CHROME_VERSION; do
     if [ -n "${!name+set}" ]; then
         ENV_VARS="$ENV_VARS -e $name=${!name}"
     fi

--- a/ci/docker/docker_run.sh
+++ b/ci/docker/docker_run.sh
@@ -21,6 +21,12 @@ for name in BOKEH_DOCKER_CONDA BOKEH_DOCKER_PY BOKEH_DOCKER_BUILD BOKEH_DOCKER_T
     fi
 done
 
-CMD="docker run -v $PWD:/bokeh -u $UID_GID -p 5006:5006 $ENV_VARS -it $IMAGE_AND_TAG"
+INTERACTIVE="-it"
+if [ "${BOKEH_DOCKER_CHROME_VERSION:-0}" == 1 ]; then
+    # If only want chrome version, do not need to run interactively.
+    INTERACTIVE=""
+fi
+
+CMD="docker run -v $PWD:/bokeh -u $UID_GID -p 5006:5006 $ENV_VARS $INTERACTIVE $IMAGE_AND_TAG"
 echo $CMD
 $CMD

--- a/ci/docker/docker_run.sh
+++ b/ci/docker/docker_run.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Usage: docker_run.sh bokeh-dev:latest
+# Can put env vars first, e.g.
+#   BOKEH_DOCKER_PY=3.7 docker_run.sh bokeh-dev:latest
+
+set -eu
+
+if [ $# -ne 1 ]; then
+    echo "Usage: docker_run.sh <docker image and tag>, e.g. docker_run.sh bokeh-dev:latest"
+    exit 1
+fi
+
+IMAGE_AND_TAG=$1
+UID_GID="`id --user`:`id --group`"
+
+ENV_VARS=""
+for name in BOKEH_DOCKER_CONDA BOKEH_DOCKER_PY BOKEH_DOCKER_BUILD BOKEH_DOCKER_TEST; do
+    if [ -n "${!name+set}" ]; then
+        ENV_VARS="$ENV_VARS -e $name=${!name}"
+    fi
+done
+
+CMD="docker run -v $PWD:/bokeh -u $UID_GID -p 5006:5006 $ENV_VARS -it $IMAGE_AND_TAG"
+echo $CMD
+$CMD

--- a/ci/docker/entrypoint.sh
+++ b/ci/docker/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-CONDA_DIR=.conda_docker
+CONDA_DIR=/home/docker/conda_bokeh
 ENV_NAME=bkdev
 MINICONDA_SCRIPT=Miniconda3-latest-Linux-x86_64.sh
 
@@ -14,11 +14,11 @@ if [ ! -d .git ] || [ ! -f environment.yml ]; then
 fi
 
 if [ ! -f "$CONDA_DIR/condabin/conda" ]; then
-    # Install miniconda into $CONDA_DIR
+    # Install miniconda into $CONDA_DIR on docker filesystem.
     START_DIR=$(pwd)
     cd /tmp
     curl -LO "http://repo.continuum.io/miniconda/$MINICONDA_SCRIPT"
-    bash $MINICONDA_SCRIPT -p $START_DIR/$CONDA_DIR -b
+    bash $MINICONDA_SCRIPT -p $CONDA_DIR -b
     rm $MINICONDA_SCRIPT
     cd $START_DIR
 fi

--- a/ci/docker/entrypoint.sh
+++ b/ci/docker/entrypoint.sh
@@ -9,9 +9,15 @@ MINICONDA_SCRIPT=Miniconda3-latest-Linux-x86_64.sh
 
 eval "$(fixuid -q)"
 
+if [ "${BOKEH_DOCKER_CHROME_VERSION:-0}" == 1 ]; then
+    # Print numerical chrome version and exit.
+    google-chrome --version | awk '{print $NF}'
+    exit 1
+fi
+
 if [ ! -d .git ] || [ ! -f environment.yml ]; then
     echo "Directory does not contain Bokeh git repo."
-    exit 1
+    exit 2
 fi
 
 if [ "${BOKEH_DOCKER_CONDA:-1}" == 1 ]; then
@@ -20,7 +26,7 @@ if [ "${BOKEH_DOCKER_CONDA:-1}" == 1 ]; then
     ENV_YML_FILE=ci/environment-test-$BOKEH_DOCKER_PY.yml
     if [ ! -f $ENV_YML_FILE ]; then
         echo "Cannot find environment file $ENV_YML_FILE"
-        exit 1
+        exit 3
     fi
 
     if [ ! -f "$CONDA_DIR/condabin/conda" ]; then

--- a/ci/docker/entrypoint.sh
+++ b/ci/docker/entrypoint.sh
@@ -3,6 +3,7 @@
 set -eu
 
 CONDA_DIR=/home/docker/conda_bokeh
+DEFAULT_PY=3.9
 ENV_NAME=bkdev
 MINICONDA_SCRIPT=Miniconda3-latest-Linux-x86_64.sh
 
@@ -13,27 +14,38 @@ if [ ! -d .git ] || [ ! -f environment.yml ]; then
     exit 1
 fi
 
-if [ ! -f "$CONDA_DIR/condabin/conda" ]; then
-    # Install miniconda into $CONDA_DIR on docker filesystem.
-    START_DIR=$(pwd)
-    cd /tmp
-    curl -LO "http://repo.continuum.io/miniconda/$MINICONDA_SCRIPT"
-    bash $MINICONDA_SCRIPT -p $CONDA_DIR -b
-    rm $MINICONDA_SCRIPT
-    cd $START_DIR
+if [ "${BOKEH_DOCKER_CONDA:-1}" == 1 ]; then
+    # Check environment file exists.
+    BOKEH_DOCKER_PY=${BOKEH_DOCKER_PY:-$DEFAULT_PY}
+    ENV_YML_FILE=ci/environment-test-$BOKEH_DOCKER_PY.yml
+    if [ ! -f $ENV_YML_FILE ]; then
+        echo "Cannot find environment file $ENV_YML_FILE"
+        exit 1
+    fi
+
+    if [ ! -f "$CONDA_DIR/condabin/conda" ]; then
+        # Install miniconda into $CONDA_DIR on docker filesystem.
+        START_DIR=$(pwd)
+        cd /tmp
+        curl -LO "http://repo.continuum.io/miniconda/$MINICONDA_SCRIPT"
+        bash $MINICONDA_SCRIPT -p $CONDA_DIR -b
+        rm $MINICONDA_SCRIPT
+        cd $START_DIR
+    fi
+
+    # Activate conda in .bashrc and in this shell.
+    $CONDA_DIR/condabin/conda init bash > /dev/null
+    . $CONDA_DIR/etc/profile.d/conda.sh
+
+    if [ ! -d "$CONDA_DIR/envs/$ENV_NAME" ]; then
+        # Create conda environment and install required packagaes.
+        conda env create -n $ENV_NAME -f $ENV_YML_FILE
+    fi
+
+    # Ensure conda environment is activated in this shell and in new shells.
+    conda activate $ENV_NAME
+    echo "conda activate $ENV_NAME" >> ~/.bashrc
 fi
-
-# Activate conda in .bashrc and in this shell.
-$CONDA_DIR/condabin/conda init bash > /dev/null
-. $CONDA_DIR/etc/profile.d/conda.sh
-
-if [ ! -d "$CONDA_DIR/envs/$ENV_NAME" ]; then
-    conda env create -f environment.yml
-fi
-
-# Ensure conda environment is activated in this shell and in new shells.
-conda activate $ENV_NAME
-echo "conda activate $ENV_NAME" >> ~/.bashrc
 
 google-chrome --version
 


### PR DESCRIPTION
This PR updates the docker image to the point that it is usable, although probably not by end users yet. It closes issue #11352.

I will write a new "Working document" in the wiki to explain how it is used and built. Here is a summary of the improvements:

  * Image is built on demand in github actions using `.github/workflows/bokeh-docker-build.yml`. There is an option to build and run the tests or not, if you do then the failed visual test images are saved in an artifact as usual.
  * Image is tagged with 3 tags: `latest`, the date of building and major version of chrome. So a new image built today would be known as all of `bokeh-dev:latest`, `bokeh-dev:chrome_96` and `bokeh-dev:2021-12-06`.
  * Image is stored in an artifact for download. Need to add option to upload to docker hub.
  * Use of image is fully tested on Ubuntu and Windows 10. Care is needed with line endings on Windows.
  * There is now a script used to start the docker container so that users do not need to deal with uids/gids/paths, etc.
  * There is an option to use a particular version of python in conda via a particular `ci/environment-test-3.x.yml` file.
  * Conda is installed in user's home directory in docker container so that there are no problems with this being on a different filesystem.
  * When you close the docker container it is retained on disk for restarting so that you don't have to reinstall conda every time.

Test workflow now:
  1. Download latest docker image as artifact from https://github.com/bokeh/bokeh/actions/runs/1521258068
  2. Unzip `artifact.zip` to extract `bokeh-dev.tar`
  3. `docker load -i bokeh-dev.tar`
  4. `cd` to base directory of `bokeh` git repo on your local machine.
  5. `ci/docker/docker_run.sh bokeh-dev:latest` to start new container. May need to use `bash ci/docker/docker_run.sh bokeh-dev:latest` on Windows.
  6. The container will start, and download and install the `conda` requirements.
  7. When this is done, you will get a `bash` prompt in the container.
  8. Build bokeh (including installing `npm` etc) using `bash ci/install_node_modules.sh` then `python setup.py install`.
  9. Run tests as usual, e.g. `cd bokehjs; node make test:integration -k "Blackbody"`
  10. `exit` to leave the container and return to host command-line.
  11. If you want to restart the container, identify the container id using `docker ps -a` and start it using `docker start -i <container_id>`

Problems:
  * Cannot obtain old version of google-chrome for Ubuntu (`deb` file) from a reliable source, so we will need to build the image often enough to always have at least one tagged image for each chrome major version.
  * Need bokeh to work with chrome 96.
  * There are some visual test failures in the docker container relating to missing ellipses … and null ∅ characters. Need to check if these are unicode issues.

To do
  * Fully test use of image on macOS.
  * Add option to automatically upload to docker hub via github actions when build new image. It looks like this needs a username and password in GHA `secrets`.
