### PR TITLE
Update docs for Slider, RangeSlider

### DIFF
--- a/bokeh/models/widgets/sliders.py
+++ b/bokeh/models/widgets/sliders.py
@@ -83,7 +83,7 @@ class AbstractSlider(Widget):
     """)
 
     title = Nullable(String, default="", help="""
-    Slider's label.
+    The slider's label (supports :ref:`math text <userguide_styling_math>`).
     """)
 
     show_value = Bool(default=True, help="""

--- a/sphinx/source/docs/user_guide/examples/styling_math_text_latex_slider_widget_title.py
+++ b/sphinx/source/docs/user_guide/examples/styling_math_text_latex_slider_widget_title.py
@@ -1,0 +1,5 @@
+from bokeh.io import show
+from bokeh.models import Slider
+
+slider = Slider(start=0, end=10, value=1, step=.1, title=r"$$\delta \text{ (damping factor, 1/s)}$$")
+show(slider)

--- a/sphinx/source/docs/user_guide/interaction/widgets.rst
+++ b/sphinx/source/docs/user_guide/interaction/widgets.rst
@@ -256,6 +256,8 @@ A radio group uses standard radio button appearance:
 
 More information can be found in the Reference for |RadioGroup|.
 
+.. _userguide_interaction_widgets_range_slider:
+
 RangeSlider
 ~~~~~~~~~~~
 
@@ -276,6 +278,8 @@ A single selection widget:
     :source-position: below
 
 More information can be found in the Reference for |Select|.
+
+.. _userguide_interaction_widgets_slider:
 
 Slider
 ~~~~~~

--- a/sphinx/source/docs/user_guide/styling.rst
+++ b/sphinx/source/docs/user_guide/styling.rst
@@ -1164,8 +1164,8 @@ LaTeX and tick labels
 
 LaTeX on RangeSlider and Slider widget titles
     To use LaTeX notation in the title of a :ref:`userguide_interaction_widgets_range_slider`
-    or `userguide_interaction_widgets_slider` widget, pass a raw string literal
-    beginning and ending with `MathJax default delimiters`_ and containing
+    or :ref:`userguide_interaction_widgets_slider` widget, pass a raw string
+    literal beginning and ending with `MathJax default delimiters`_ and containing
     LaTeX notation as the ``title`` parameter. For example:
 
     .. bokeh-plot:: docs/user_guide/examples/styling_math_text_latex_slider_widget_title.py

--- a/sphinx/source/docs/user_guide/styling.rst
+++ b/sphinx/source/docs/user_guide/styling.rst
@@ -1119,6 +1119,8 @@ and MathML notations with the following elements:
 * Tick labels using :func:`~bokeh.models.Axis.major_label_overrides`
 * :ref:`userguide_annotations_titles`
 * :ref:`userguide_annotations_labels`
+* :ref:`RangeSlider widgets <userguide_interaction_widgets_range_slider>`
+* :ref:`Slider widgets <userguide_interaction_widgets_slider>`
 * :ref:`Div widgets <userguide_interaction_widgets_div>`
 * :ref:`Paragraph widgets <userguide_interaction_widgets_paragraph>`
 
@@ -1158,6 +1160,15 @@ LaTeX and tick labels
     Use this function to replace any plain text tick labels with LaTeX notation:
 
     .. bokeh-plot:: docs/user_guide/examples/styling_math_text_latex_tick_labels.py
+        :source-position: above
+
+LaTeX on RangeSlider and Slider widget titles
+    To use LaTeX notation in the title of a :ref:`userguide_interaction_widgets_range_slider`
+    or `userguide_interaction_widgets_slider` widget, pass a raw string literal
+    beginning and ending with `MathJax default delimiters`_ and containing
+    LaTeX notation as the ``title`` parameter. For example:
+
+    .. bokeh-plot:: docs/user_guide/examples/styling_math_text_latex_slider_widget_title.py
         :source-position: above
 
 LaTeX with div and paragraph widgets


### PR DESCRIPTION
This is a follow-up to #11815 and updates the user guide to describe adding mathtext to Sliders. 
Related to #11355.
