### PR TITLE
Add policy to find adjacent nodes by selecting node

### DIFF
--- a/bokeh/models/graphs.py
+++ b/bokeh/models/graphs.py
@@ -167,8 +167,8 @@ class NodesAndAdjacentNodes(GraphHitTestPolicy):
     With the ``NodesAndAdjacentNodes`` policy, inspection or selection of
     graph nodes will also result in the inspection or selection any nodes that
     are immediately adjacent (connected by a single edge). There is no
-    selection or inspection of graph edges, and indication of which node is the
-    tool-selected one.
+    selection or inspection of graph edges, and no indication of which node is
+    the tool-selected one from the policy-selected nodes.
 
     '''
 

--- a/bokeh/models/graphs.py
+++ b/bokeh/models/graphs.py
@@ -43,6 +43,7 @@ __all__ = (
     'GraphHitTestPolicy',
     'LayoutProvider',
     'NodeCoordinates',
+    'NodesAndAdjacentNodes',
     'NodesAndLinkedEdges',
     'NodesOnly',
     'StaticLayoutProvider',
@@ -156,6 +157,18 @@ class EdgesAndLinkedNodes(GraphHitTestPolicy):
     edges will result in the inspection or selection of the edge and of the
     linked graph nodes. There is no direct selection or inspection of graph
     nodes.
+
+    '''
+
+    pass
+
+class NodesAndAdjacentNodes(GraphHitTestPolicy):
+    '''
+    With the ``NodesAndAdjacentNodes`` policy, inspection or selection of 
+    graph nodes will result in the inspection or selection of the selected 
+    node and of its adjacent nodes (nodes connected to the selected or
+    inspected nodes by edges). There is no direct selection or inspection of 
+    graph edges or nodes.
 
     '''
 

--- a/bokeh/models/graphs.py
+++ b/bokeh/models/graphs.py
@@ -164,10 +164,10 @@ class EdgesAndLinkedNodes(GraphHitTestPolicy):
 
 class NodesAndAdjacentNodes(GraphHitTestPolicy):
     '''
-    With the ``NodesAndAdjacentNodes`` policy, inspection or selection of 
-    graph nodes will result in the inspection or selection of the selected 
+    With the ``NodesAndAdjacentNodes`` policy, inspection or selection of
+    graph nodes will result in the inspection or selection of the selected
     node and of its adjacent nodes (nodes connected to the selected or
-    inspected nodes by edges). There is no direct selection or inspection of 
+    inspected nodes by edges). There is no direct selection or inspection of
     graph edges or nodes.
 
     '''

--- a/bokeh/models/graphs.py
+++ b/bokeh/models/graphs.py
@@ -165,9 +165,9 @@ class EdgesAndLinkedNodes(GraphHitTestPolicy):
 class NodesAndAdjacentNodes(GraphHitTestPolicy):
     '''
     With the ``NodesAndAdjacentNodes`` policy, inspection or selection of
-    graph nodes will result in the inspection or selection of the node and
-    those directly connected to it by edges. There is no direct selection
-    or inspection of graph edges or nodes. The last entry in each list
+    graph nodes will also result in the inspection or selection any nodes that
+    are immediately adjacent (connected by a single edge). There is no
+    selection or inspection of graph edges. The last entry in each list
     returned by NodesAndAdjacentNodes refers to the original node that was
     inspected or selected.
 

--- a/bokeh/models/graphs.py
+++ b/bokeh/models/graphs.py
@@ -165,10 +165,11 @@ class EdgesAndLinkedNodes(GraphHitTestPolicy):
 class NodesAndAdjacentNodes(GraphHitTestPolicy):
     '''
     With the ``NodesAndAdjacentNodes`` policy, inspection or selection of
-    graph nodes will result in the inspection or selection of the selected
-    node and of its adjacent nodes (nodes connected to the selected or
-    inspected nodes by edges). There is no direct selection or inspection of
-    graph edges or nodes.
+    graph nodes will result in the inspection or selection of the node and
+    those directly connected to it by edges. There is no direct selection
+    or inspection of graph edges or nodes. The last entry in each list
+    returned by NodesAndAdjacentNodes refers to the original node that was
+    inspected or selected.
 
     '''
 

--- a/bokeh/models/graphs.py
+++ b/bokeh/models/graphs.py
@@ -167,9 +167,8 @@ class NodesAndAdjacentNodes(GraphHitTestPolicy):
     With the ``NodesAndAdjacentNodes`` policy, inspection or selection of
     graph nodes will also result in the inspection or selection any nodes that
     are immediately adjacent (connected by a single edge). There is no
-    selection or inspection of graph edges. The last entry in each list
-    returned by NodesAndAdjacentNodes refers to the original node that was
-    inspected or selected.
+    selection or inspection of graph edges, and indication of which node is the
+    tool-selected one.
 
     '''
 

--- a/bokehjs/src/lib/models/graphs/graph_hit_test_policy.ts
+++ b/bokehjs/src/lib/models/graphs/graph_hit_test_policy.ts
@@ -310,8 +310,8 @@ export class NodesAndAdjacentNodes extends GraphHitTestPolicy {
     } else if (mode == "inspection") {
       selected_node_indices = node_source.inspected.indices.map((i) => node_source.data.index[i])
     }
-    const adjacent_nodes = []
-    const selected_nodes = []
+    let adjacent_nodes = []
+    let selected_nodes = []
     for (let i = 0; i < edge_source.data.start.length; i++) {
       if (contains(selected_node_indices, edge_source.data.start[i])) {
         adjacent_nodes.push(edge_source.data.end[i])
@@ -326,7 +326,12 @@ export class NodesAndAdjacentNodes extends GraphHitTestPolicy {
       adjacent_nodes.push(selected_nodes[i])
 
     const adjacent_node_indices = uniq(adjacent_nodes).map((i) => indexOf(node_source.data.index, i))
+    //if (adjacent_node_indices.length == 0) {
+    //  return new Selection({indices: node_source.selected.indices})
+    //}
+    //else {
     return new Selection({indices: adjacent_node_indices})
+    //}
   }
 
   do_selection(hit_test_result: HitTestResult, graph: GraphRenderer, final: boolean, mode: SelectionMode): boolean {
@@ -338,7 +343,8 @@ export class NodesAndAdjacentNodes extends GraphHitTestPolicy {
 
     const final_node_selection = graph.node_renderer.data_source.selected
     const adjacent_nodes_selection = this.get_adjacent_nodes(graph.node_renderer.data_source, graph.edge_renderer.data_source, "selection")
-    final_node_selection.update(adjacent_nodes_selection, final, mode)
+    if (!adjacent_nodes_selection.is_empty())
+      final_node_selection.update(adjacent_nodes_selection, final, mode)
 
     graph.node_renderer.data_source._select.emit()
 
@@ -354,11 +360,11 @@ export class NodesAndAdjacentNodes extends GraphHitTestPolicy {
     graph_view.node_view.model.data_source.setv({inspected: initial_node_inspection}, {silent: true})
 
     const final_node_inspection = graph_view.node_view.model.data_source.selection_manager.get_or_create_inspector(graph_view.node_view.model)
-    const adjacent_nodes = this.get_adjacent_nodes(graph_view.node_view.model.data_source, graph_view.edge_view.model.data_source, "inspection")
-    final_node_inspection.update(adjacent_nodes, final, mode)
+    const adjacent_nodes_inspection = this.get_adjacent_nodes(graph_view.node_view.model.data_source, graph_view.edge_view.model.data_source, "inspection")
+    if (!adjacent_nodes_inspection.is_empty())
+      final_node_inspection.update(adjacent_nodes_inspection, final, mode)
+      graph_view.node_view.model.data_source.setv({inspected: final_node_inspection}, {silent: true})
 
-    // silently set inspected attr to avoid triggering data_source.change event and rerender
-    graph_view.node_view.model.data_source.setv({inspected: final_node_inspection}, {silent: true})
     graph_view.node_view.model.data_source.inspect.emit([graph_view.node_view.model, {geometry}])
 
     return !initial_node_inspection.is_empty()

--- a/bokehjs/src/lib/models/graphs/graph_hit_test_policy.ts
+++ b/bokehjs/src/lib/models/graphs/graph_hit_test_policy.ts
@@ -310,8 +310,8 @@ export class NodesAndAdjacentNodes extends GraphHitTestPolicy {
     } else if (mode == "inspection") {
       selected_node_indices = node_source.inspected.indices.map((i) => node_source.data.index[i])
     }
-    let adjacent_nodes = []
-    let selected_nodes = []
+    const adjacent_nodes = []
+    const selected_nodes = []
     for (let i = 0; i < edge_source.data.start.length; i++) {
       if (contains(selected_node_indices, edge_source.data.start[i])) {
         adjacent_nodes.push(edge_source.data.end[i])
@@ -326,12 +326,7 @@ export class NodesAndAdjacentNodes extends GraphHitTestPolicy {
       adjacent_nodes.push(selected_nodes[i])
 
     const adjacent_node_indices = uniq(adjacent_nodes).map((i) => indexOf(node_source.data.index, i))
-    //if (adjacent_node_indices.length == 0) {
-    //  return new Selection({indices: node_source.selected.indices})
-    //}
-    //else {
     return new Selection({indices: adjacent_node_indices})
-    //}
   }
 
   do_selection(hit_test_result: HitTestResult, graph: GraphRenderer, final: boolean, mode: SelectionMode): boolean {
@@ -361,12 +356,12 @@ export class NodesAndAdjacentNodes extends GraphHitTestPolicy {
 
     const final_node_inspection = graph_view.node_view.model.data_source.selection_manager.get_or_create_inspector(graph_view.node_view.model)
     const adjacent_nodes_inspection = this.get_adjacent_nodes(graph_view.node_view.model.data_source, graph_view.edge_view.model.data_source, "inspection")
-    if (!adjacent_nodes_inspection.is_empty())
+    if (!adjacent_nodes_inspection.is_empty()) {
       final_node_inspection.update(adjacent_nodes_inspection, final, mode)
       graph_view.node_view.model.data_source.setv({inspected: final_node_inspection}, {silent: true})
+    }
 
     graph_view.node_view.model.data_source.inspect.emit([graph_view.node_view.model, {geometry}])
-
     return !initial_node_inspection.is_empty()
   }
 }

--- a/bokehjs/src/lib/models/graphs/graph_hit_test_policy.ts
+++ b/bokehjs/src/lib/models/graphs/graph_hit_test_policy.ts
@@ -314,18 +314,17 @@ export class NodesAndAdjacentNodes extends GraphHitTestPolicy {
     const selected_nodes = []
     for (let i = 0; i < edge_source.data.start.length; i++) {
       if (contains(selected_node_indices, edge_source.data.start[i])) {
-	adjacent_nodes.push(edge_source.data.end[i])
-	selected_nodes.push(edge_source.data.start[i])
+        adjacent_nodes.push(edge_source.data.end[i])
+        selected_nodes.push(edge_source.data.start[i])
       }
       if (contains(selected_node_indices, edge_source.data.end[i])) {
         adjacent_nodes.push(edge_source.data.start[i])
-	selected_nodes.push(edge_source.data.end[i])
+        selected_nodes.push(edge_source.data.end[i])
       }
     }
     for (let i = 0; i < selected_nodes.length; i++)
       adjacent_nodes.push(selected_nodes[i])
 
-    // make map of node indices, making selected node the last node in the map
     const adjacent_node_indices = uniq(adjacent_nodes).map((i) => indexOf(node_source.data.index, i))
     return new Selection({indices: adjacent_node_indices})
   }

--- a/bokehjs/src/lib/models/graphs/graph_hit_test_policy.ts
+++ b/bokehjs/src/lib/models/graphs/graph_hit_test_policy.ts
@@ -333,35 +333,33 @@ export class NodesAndAdjacentNodes extends GraphHitTestPolicy {
     if (hit_test_result == null)
       return false
 
-    const initial_node_selection = graph.node_renderer.data_source.selected
-    initial_node_selection.update(hit_test_result, final, mode)
+    const node_selection = graph.node_renderer.data_source.selected
+    node_selection.update(hit_test_result, final, mode)
 
-    const final_node_selection = graph.node_renderer.data_source.selected
     const adjacent_nodes_selection = this.get_adjacent_nodes(graph.node_renderer.data_source, graph.edge_renderer.data_source, "selection")
     if (!adjacent_nodes_selection.is_empty())
-      final_node_selection.update(adjacent_nodes_selection, final, mode)
+      node_selection.update(adjacent_nodes_selection, final, mode)
 
     graph.node_renderer.data_source._select.emit()
 
-    return !initial_node_selection.is_empty()
+    return !node_selection.is_empty()
   }
 
   do_inspection(hit_test_result: HitTestResult, geometry: Geometry, graph_view: GraphRendererView, final: boolean, mode: SelectionMode): boolean {
     if (hit_test_result == null)
       return false
 
-    const initial_node_inspection = graph_view.node_view.model.data_source.selection_manager.get_or_create_inspector(graph_view.node_view.model)
-    initial_node_inspection.update(hit_test_result, final, mode)
-    graph_view.node_view.model.data_source.setv({inspected: initial_node_inspection}, {silent: true})
+    const node_inspection = graph_view.node_view.model.data_source.selection_manager.get_or_create_inspector(graph_view.node_view.model)
+    node_inspection.update(hit_test_result, final, mode)
+    graph_view.node_view.model.data_source.setv({inspected: node_inspection}, {silent: true})
 
-    const final_node_inspection = graph_view.node_view.model.data_source.selection_manager.get_or_create_inspector(graph_view.node_view.model)
     const adjacent_nodes_inspection = this.get_adjacent_nodes(graph_view.node_view.model.data_source, graph_view.edge_view.model.data_source, "inspection")
     if (!adjacent_nodes_inspection.is_empty()) {
-      final_node_inspection.update(adjacent_nodes_inspection, final, mode)
-      graph_view.node_view.model.data_source.setv({inspected: final_node_inspection}, {silent: true})
+      node_inspection.update(adjacent_nodes_inspection, final, mode)
+      graph_view.node_view.model.data_source.setv({inspected: node_inspection}, {silent: true})
     }
 
     graph_view.node_view.model.data_source.inspect.emit([graph_view.node_view.model, {geometry}])
-    return !initial_node_inspection.is_empty()
+    return !node_inspection.is_empty()
   }
 }

--- a/bokehjs/src/lib/models/graphs/graph_hit_test_policy.ts
+++ b/bokehjs/src/lib/models/graphs/graph_hit_test_policy.ts
@@ -283,3 +283,85 @@ export class EdgesAndLinkedNodes extends GraphHitTestPolicy {
     return !edge_inspection.is_empty()
   }
 }
+
+export namespace NodesAndAdjacentNodes {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = GraphHitTestPolicy.Props
+}
+
+export interface NodesAndAdjacentNodes extends NodesAndAdjacentNodes.Attrs {}
+
+export class NodesAndAdjacentNodes extends GraphHitTestPolicy {
+  override properties: NodesAndAdjacentNodes.Props
+
+  constructor(attrs?: Partial<NodesAndAdjacentNodes.Attrs>) {
+    super(attrs)
+  }
+
+  hit_test(geometry: Geometry, graph_view: GraphRendererView): HitTestResult {
+    return this._hit_test(geometry, graph_view, graph_view.node_view)
+  }
+
+  get_adjacent_nodes(node_source: ColumnarDataSource, edge_source: ColumnarDataSource, mode: string): Selection {
+    let selected_node_indices = []
+    if (mode == "selection") {
+      selected_node_indices = node_source.selected.indices.map((i) => node_source.data.index[i])
+    } else if (mode == "inspection") {
+      selected_node_indices = node_source.inspected.indices.map((i) => node_source.data.index[i])
+    }
+    const adjacent_nodes = []
+    const selected_nodes = []
+    for (let i = 0; i < edge_source.data.start.length; i++) {
+      if (contains(selected_node_indices, edge_source.data.start[i])) {
+	adjacent_nodes.push(edge_source.data.end[i])
+	selected_nodes.push(edge_source.data.start[i])
+      }
+      if (contains(selected_node_indices, edge_source.data.end[i])) {
+        adjacent_nodes.push(edge_source.data.start[i])
+	selected_nodes.push(edge_source.data.end[i])
+      }
+    }
+    for (let i = 0; i < selected_nodes.length; i++)
+      adjacent_nodes.push(selected_nodes[i])
+
+    // make map of node indices, making selected node the last node in the map
+    const adjacent_node_indices = uniq(adjacent_nodes).map((i) => indexOf(node_source.data.index, i))
+    return new Selection({indices: adjacent_node_indices})
+  }
+
+  do_selection(hit_test_result: HitTestResult, graph: GraphRenderer, final: boolean, mode: SelectionMode): boolean {
+    if (hit_test_result == null)
+      return false
+
+    const initial_node_selection = graph.node_renderer.data_source.selected
+    initial_node_selection.update(hit_test_result, final, mode)
+
+    const final_node_selection = graph.node_renderer.data_source.selected
+    const adjacent_nodes_selection = this.get_adjacent_nodes(graph.node_renderer.data_source, graph.edge_renderer.data_source, "selection")
+    final_node_selection.update(adjacent_nodes_selection, final, mode)
+
+    graph.node_renderer.data_source._select.emit()
+
+    return !initial_node_selection.is_empty()
+  }
+
+  do_inspection(hit_test_result: HitTestResult, geometry: Geometry, graph_view: GraphRendererView, final: boolean, mode: SelectionMode): boolean {
+    if (hit_test_result == null)
+      return false
+
+    const initial_node_inspection = graph_view.node_view.model.data_source.selection_manager.get_or_create_inspector(graph_view.node_view.model)
+    initial_node_inspection.update(hit_test_result, final, mode)
+    graph_view.node_view.model.data_source.setv({inspected: initial_node_inspection}, {silent: true})
+
+    const final_node_inspection = graph_view.node_view.model.data_source.selection_manager.get_or_create_inspector(graph_view.node_view.model)
+    const adjacent_nodes = this.get_adjacent_nodes(graph_view.node_view.model.data_source, graph_view.edge_view.model.data_source, "inspection")
+    final_node_inspection.update(adjacent_nodes, final, mode)
+
+    // silently set inspected attr to avoid triggering data_source.change event and rerender
+    graph_view.node_view.model.data_source.setv({inspected: final_node_inspection}, {silent: true})
+    graph_view.node_view.model.data_source.inspect.emit([graph_view.node_view.model, {geometry}])
+
+    return !initial_node_inspection.is_empty()
+  }
+}

--- a/bokehjs/test/unit/models/graphs/graph_hit_test_policy.ts
+++ b/bokehjs/test/unit/models/graphs/graph_hit_test_policy.ts
@@ -7,7 +7,7 @@ import {Range1d} from "@bokehjs/models/ranges/range1d"
 
 import {Circle} from "@bokehjs/models/glyphs/circle"
 import {MultiLine} from "@bokehjs/models/glyphs/multi_line"
-import {EdgesOnly, NodesOnly, NodesAndLinkedEdges, EdgesAndLinkedNodes} from "@bokehjs/models/graphs/graph_hit_test_policy"
+import {EdgesOnly, NodesOnly, NodesAndLinkedEdges, EdgesAndLinkedNodes, NodesAndAdjacentNodes} from "@bokehjs/models/graphs/graph_hit_test_policy"
 import {LayoutProvider} from "@bokehjs/models/graphs/layout_provider"
 import {GlyphRenderer} from "@bokehjs/models/renderers/glyph_renderer"
 import {GraphRenderer, GraphRendererView} from "@bokehjs/models/renderers/graph_renderer"
@@ -282,7 +282,7 @@ describe("GraphHitTestPolicy", () => {
     })
   })
 
-  describe("EdgedAndLinkedNodes", () => {
+  describe("EdgesAndLinkedNodes", () => {
 
     describe("do_selection method", () => {
 
@@ -332,6 +332,60 @@ describe("GraphHitTestPolicy", () => {
 
         expect(did_hit).to.be.true
         expect(node_source.inspected.indices).to.be.equal([0, 2])
+      })
+    })
+  })
+
+  describe("NodesAndAdjacentNodes", () => {
+
+    describe("do_selection method", () => {
+
+      it("should clear node selections if hit_test result is empty", () => {
+        const initial_selection = new Selection()
+        initial_selection.indices = [0, 1]
+        node_source.selected = initial_selection
+
+        const hit_test_result = new Selection()
+        const policy = new NodesAndAdjacentNodes()
+        policy.do_selection(hit_test_result, gr, true, "replace")
+
+        expect(node_source.selected.is_empty()).to.be.true
+      })
+
+      it("should select adjacent nodes if hit_test_result is not empty", () => {
+        const hit_test_result = new Selection()
+        hit_test_result.indices = [1]
+
+        const policy = new NodesAndAdjacentNodes()
+        policy.do_selection(hit_test_result, gr, true, "replace")
+
+        expect(node_source.selected.indices).to.be.equal([0, 2, 1])
+      })
+    })
+
+    describe("do_inspection method", () => {
+
+      it("should clear node inspections if hit_test_result is empty", () => {
+        // create initial inspection to clear
+        const initial_inspection = new Selection({indices: [0, 1]})
+        node_source.inspected = initial_inspection
+
+        const hit_test_result = new Selection()
+        const policy = new NodesAndAdjacentNodes()
+        const did_hit = policy.do_inspection(hit_test_result, {type: "point", sx: 0, sy: 0}, gv, true, "replace")
+
+        expect(did_hit).to.be.false
+        expect(node_source.inspected.is_empty()).to.be.true
+      })
+
+      it("should inspect adjacent nodes if hit_test_result is not empty", () => {
+        const hit_test_result = new Selection({indices: [1]})
+
+        const policy = new NodesAndAdjacentNodes()
+        const did_hit = policy.do_inspection(hit_test_result, {type: "point", sx: 0, sy: 0}, gv, true, "replace")
+
+        expect(did_hit).to.be.true
+        expect(node_source.inspected.indices).to.be.equal([0, 2, 1])
       })
     })
   })

--- a/examples/models/file/graphs.py
+++ b/examples/models/file/graphs.py
@@ -11,8 +11,8 @@ Journal of Anthropological Research, 33, 452-473.
 import networkx as nx
 
 from bokeh.io import curdoc, show
-from bokeh.models import (BoxSelectTool, Circle, Column, EdgesAndLinkedNodes, HoverTool,
-                          MultiLine, NodesAndLinkedEdges, Plot, Range1d, Row, TapTool)
+from bokeh.models import (BoxSelectTool, Circle, Column, EdgesAndLinkedNodes, HoverTool, MultiLine, 
+                          NodesAndAdjacentNodes, NodesAndLinkedEdges, Plot, Range1d, Row, TapTool)
 from bokeh.palettes import Spectral4
 from bokeh.plotting import from_networkx
 
@@ -57,7 +57,15 @@ plot_4 = create_graph(nx.fruchterman_reingold_layout, selection_policy=EdgesAndL
 plot_4.title.text = "FR Layout (EdgesAndLinkedNodes selection policy)"
 plot_4.add_tools(TapTool())
 
-layout = Column(Row(plot_1, plot_2), Row(plot_3, plot_4))
+plot_5 = create_graph(nx.circular_layout, inspection_policy=NodesAndAdjacentNodes(), scale=1, center=(0,0))
+plot_5.title.text = "Circular Layout (NodesAndAdjacentNodes inspection policy)"
+plot_5.add_tools(HoverTool(tooltips=None))
+
+plot_6 = create_graph(nx.fruchterman_reingold_layout, selection_policy=NodesAndAdjacentNodes(), scale=2, center=(0,0), dim=2)
+plot_6.title.text = "FR Layout (NodesAndAdjacentNodes selection policy)"
+plot_6.add_tools(TapTool())
+
+layout = Column(Row(plot_1, plot_2), Row(plot_3, plot_4), Row(plot_5, plot_6))
 
 doc = curdoc()
 doc.add_root(layout)

--- a/examples/models/file/graphs.py
+++ b/examples/models/file/graphs.py
@@ -11,8 +11,9 @@ Journal of Anthropological Research, 33, 452-473.
 import networkx as nx
 
 from bokeh.io import curdoc, show
-from bokeh.models import (BoxSelectTool, Circle, Column, EdgesAndLinkedNodes, HoverTool, MultiLine, 
-                          NodesAndAdjacentNodes, NodesAndLinkedEdges, Plot, Range1d, Row, TapTool)
+from bokeh.models import (BoxSelectTool, Circle, Column, EdgesAndLinkedNodes,
+                          HoverTool, MultiLine, NodesAndAdjacentNodes,
+                          NodesAndLinkedEdges, Plot, Range1d, Row, TapTool)
 from bokeh.palettes import Spectral4
 from bokeh.plotting import from_networkx
 

--- a/sphinx/source/docs/releases/3.0.0.rst
+++ b/sphinx/source/docs/releases/3.0.0.rst
@@ -6,7 +6,7 @@
 Bokeh Version ``3.0.0`` () is a major milestone of Bokeh project.
 
 * Support added for favicon.ico files
-* Support added for new selection policy NodesAndAdjacentNodes 
+* Support added for new selection policy NodesAndAdjacentNodes
 
 .. _release-3-0-0-migration:
 

--- a/sphinx/source/docs/releases/3.0.0.rst
+++ b/sphinx/source/docs/releases/3.0.0.rst
@@ -6,6 +6,7 @@
 Bokeh Version ``3.0.0`` () is a major milestone of Bokeh project.
 
 * Support added for favicon.ico files
+* Support added for new selection policy NodesAndAdjacentNodes 
 
 .. _release-3-0-0-migration:
 

--- a/sphinx/source/docs/user_guide/examples/graph_interaction.py
+++ b/sphinx/source/docs/user_guide/examples/graph_interaction.py
@@ -1,9 +1,8 @@
 import networkx as nx
 
 from bokeh.io import output_file, show
-from bokeh.models import (BoxSelectTool, Circle, EdgesAndLinkedNodes,
-                          HoverTool, MultiLine, NodesAndAdjacentEdges,
-                          NodesAndLinkedEdges, Plot, Range1d, TapTool)
+from bokeh.models import (BoxSelectTool, Circle, EdgesAndLinkedNodes, HoverTool,
+                          MultiLine, NodesAndLinkedEdges, Plot, Range1d, TapTool)
 from bokeh.palettes import Spectral4
 from bokeh.plotting import from_networkx
 

--- a/sphinx/source/docs/user_guide/examples/graph_interaction_edgeslinkednodes.py
+++ b/sphinx/source/docs/user_guide/examples/graph_interaction_edgeslinkednodes.py
@@ -2,8 +2,7 @@ import networkx as nx
 
 from bokeh.io import output_file, show
 from bokeh.models import (BoxSelectTool, Circle, EdgesAndLinkedNodes,
-                          HoverTool, MultiLine, NodesAndAdjacentEdges,
-                          NodesAndLinkedEdges, Plot, Range1d, TapTool)
+                          HoverTool, MultiLine, Plot, Range1d, TapTool)
 from bokeh.palettes import Spectral4
 from bokeh.plotting import from_networkx
 
@@ -25,7 +24,7 @@ graph_renderer.edge_renderer.glyph = MultiLine(line_color="#CCCCCC", line_alpha=
 graph_renderer.edge_renderer.selection_glyph = MultiLine(line_color=Spectral4[2], line_width=5)
 graph_renderer.edge_renderer.hover_glyph = MultiLine(line_color=Spectral4[1], line_width=5)
 
-graph_renderer.selection_policy = NodesAndLinkedEdges()
+graph_renderer.selection_policy = EdgesAndLinkedNodes()
 graph_renderer.inspection_policy = EdgesAndLinkedNodes()
 
 plot.renderers.append(graph_renderer)

--- a/sphinx/source/docs/user_guide/examples/graph_interaction_nodesadjacentnodes.py
+++ b/sphinx/source/docs/user_guide/examples/graph_interaction_nodesadjacentnodes.py
@@ -1,9 +1,8 @@
 import networkx as nx
 
 from bokeh.io import output_file, show
-from bokeh.models import (BoxSelectTool, Circle, EdgesAndLinkedNodes,
-                          HoverTool, MultiLine, NodesAndAdjacentEdges,
-                          NodesAndLinkedEdges, Plot, Range1d, TapTool)
+from bokeh.models import (BoxSelectTool, Circle, HoverTool, MultiLine,
+                          NodesAndAdjacentNodes, Plot, Range1d, TapTool)
 from bokeh.palettes import Spectral4
 from bokeh.plotting import from_networkx
 
@@ -25,8 +24,8 @@ graph_renderer.edge_renderer.glyph = MultiLine(line_color="#CCCCCC", line_alpha=
 graph_renderer.edge_renderer.selection_glyph = MultiLine(line_color=Spectral4[2], line_width=5)
 graph_renderer.edge_renderer.hover_glyph = MultiLine(line_color=Spectral4[1], line_width=5)
 
-graph_renderer.selection_policy = NodesAndLinkedEdges()
-graph_renderer.inspection_policy = EdgesAndLinkedNodes()
+graph_renderer.selection_policy = NodesAndAdjacentNodes()
+graph_renderer.inspection_policy = NodesAndAdjacentNodes()
 
 plot.renderers.append(graph_renderer)
 

--- a/sphinx/source/docs/user_guide/examples/graph_interaction_nodeslinkededges.py
+++ b/sphinx/source/docs/user_guide/examples/graph_interaction_nodeslinkededges.py
@@ -1,8 +1,7 @@
 import networkx as nx
 
 from bokeh.io import output_file, show
-from bokeh.models import (BoxSelectTool, Circle, EdgesAndLinkedNodes,
-                          HoverTool, MultiLine, NodesAndAdjacentEdges,
+from bokeh.models import (BoxSelectTool, Circle, HoverTool, MultiLine,
                           NodesAndLinkedEdges, Plot, Range1d, TapTool)
 from bokeh.palettes import Spectral4
 from bokeh.plotting import from_networkx
@@ -26,7 +25,7 @@ graph_renderer.edge_renderer.selection_glyph = MultiLine(line_color=Spectral4[2]
 graph_renderer.edge_renderer.hover_glyph = MultiLine(line_color=Spectral4[1], line_width=5)
 
 graph_renderer.selection_policy = NodesAndLinkedEdges()
-graph_renderer.inspection_policy = EdgesAndLinkedNodes()
+graph_renderer.inspection_policy = NodesAndLinkedEdges()
 
 plot.renderers.append(graph_renderer)
 

--- a/sphinx/source/docs/user_guide/graph.rst
+++ b/sphinx/source/docs/user_guide/graph.rst
@@ -162,11 +162,6 @@ Below are examples of graphs with added node and edge interactions:
 
 .. tabs::
 
-   .. tab:: NodesAndAdjacentNodes
-
-      .. bokeh-plot:: docs/user_guide/examples/graph_interaction_nodesadjacentnodes.py
-        :source-position: above
-
    .. tab:: NodesAndLinkedEdges
 
       .. bokeh-plot:: docs/user_guide/examples/graph_interaction_nodeslinkededges.py
@@ -175,7 +170,12 @@ Below are examples of graphs with added node and edge interactions:
    .. tab:: EdgesAndLinkedNodes
 
       .. bokeh-plot:: docs/user_guide/examples/graph_interaction_edgeslinkednodes.py
-        :source-position: above   
+        :source-position: above
+
+   .. tab:: NodesAndAdjacentNodes
+
+      .. bokeh-plot:: docs/user_guide/examples/graph_interaction_nodesadjacentnodes.py
+        :source-position: above
 
 Node and edge attributes
 ------------------------

--- a/sphinx/source/docs/user_guide/graph.rst
+++ b/sphinx/source/docs/user_guide/graph.rst
@@ -151,16 +151,31 @@ For example, setting ``selection_policy`` to ``NodesAndLinkedEdges()``
 lets you select a node and all associated edges. Similarly, setting
 ``inspection_policy`` to ``EdgesAndLinkedNodes()`` lets you inspect the
 ``"start"`` and ``"end"`` nodes of an edge by hovering over it with the
-HoverTool.
+HoverTool. ``NodesAndAdjacentNodes()`` lets you inspect a node and all
+other nodes connected to it by a graph edge.
 
 You can customize the ``selection_glyph``, ``nonselection_glyph``,
 and/or ``hover_glyph`` attributes of the edge and node sub-renderers
 to add dynamic visual elements to your graph interactions.
 
-Here is an example of a graph with added node and edge interactions:
+Below are examples of graphs with added node and edge interactions:
 
-.. bokeh-plot:: docs/user_guide/examples/graph_interaction.py
-    :source-position: above
+.. tabs::
+
+   .. tab:: NodesAndAdjacentNodes
+
+      .. bokeh-plot:: docs/user_guide/examples/graph_interaction_nodesadjacentnodes.py
+        :source-position: above
+
+   .. tab:: NodesAndLinkedEdges
+
+      .. bokeh-plot:: docs/user_guide/examples/graph_interaction_nodeslinkededges.py
+        :source-position: above
+
+   .. tab:: EdgesAndLinkedNodes
+
+      .. bokeh-plot:: docs/user_guide/examples/graph_interaction_edgeslinkednodes.py
+        :source-position: above   
 
 Node and edge attributes
 ------------------------


### PR DESCRIPTION
The NodesAndAdjacentNodes policy highlights the adjacent nodes (those which are connected by a linked edge) of an inspected/selected node. A single selection is set with all adjacent nodes and the inspected/selected node, with the inspected/selected node as the last entry to identify it from its adjacent nodes. If a node does not have any adjacent nodes, only the inspected/selected node is set in the selection.

I added a brief explanation of the policy that gets pulled into the reference guide, and an associated unit test similar to those for the NodesAndLinkedEdges and EdgesAndLinkedNodes selection policies.

- [x] issues: fixes #11806 
- [x] tests added / passed
- [x] release document entry (if new feature or API change)
