### PR TITLE
Color.lighten() and Color.darken() using RGB instead of HSL

### DIFF
--- a/bokeh/colors/color.py
+++ b/bokeh/colors/color.py
@@ -22,6 +22,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from abc import ABCMeta, abstractmethod
+import colorsys
 from typing import TYPE_CHECKING, Type, TypeVar
 
 ## Bokeh imports
@@ -98,7 +99,7 @@ class Color(metaclass=ABCMeta):
             Color
 
         '''
-        raise NotImplementedError
+        return self.lighten(-amount)
 
     @classmethod
     @abstractmethod
@@ -148,7 +149,14 @@ class Color(metaclass=ABCMeta):
             Color
 
         '''
-        raise NotImplementedError
+        rgb = self.to_rgb()
+        h, l, s = colorsys.rgb_to_hls(float(rgb.r)/255, float(rgb.g)/255, float(rgb.b)/255)
+        new_l = self.clamp(l + amount, 1)
+        r, g, b = colorsys.hls_to_rgb(h, new_l, s)
+        rgb.r = round(r * 255)
+        rgb.g = round(g * 255)
+        rgb.b = round(b * 255)
+        return self.from_rgb(rgb)
 
     @abstractmethod
     def to_css(self) -> str:

--- a/bokeh/colors/color.py
+++ b/bokeh/colors/color.py
@@ -21,8 +21,8 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from abc import ABCMeta, abstractmethod
 import colorsys
+from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING, Type, TypeVar
 
 ## Bokeh imports

--- a/bokeh/colors/color.py
+++ b/bokeh/colors/color.py
@@ -85,7 +85,6 @@ class Color(metaclass=ABCMeta):
         '''
         raise NotImplementedError
 
-    @abstractmethod
     def darken(self: Self, amount: float) -> Self:
         ''' Darken (reduce the luminance) of this color.
 
@@ -135,7 +134,6 @@ class Color(metaclass=ABCMeta):
         '''
         raise NotImplementedError
 
-    @abstractmethod
     def lighten(self: Self, amount: float) -> Self:
         ''' Lighten (increase the luminance) of this color.
 

--- a/bokeh/colors/color.py
+++ b/bokeh/colors/color.py
@@ -88,6 +88,8 @@ class Color(metaclass=ABCMeta):
     def darken(self: Self, amount: float) -> Self:
         ''' Darken (reduce the luminance) of this color.
 
+        *Subclasses must implement this method.*
+
         Args:
             amount (float) :
                 Amount to reduce the luminance by (clamped above zero)
@@ -96,9 +98,7 @@ class Color(metaclass=ABCMeta):
             Color
 
         '''
-        hsl = self.to_hsl()
-        hsl.l = self.clamp(hsl.l - amount)
-        return self.from_hsl(hsl)
+        raise NotImplementedError
 
     @classmethod
     @abstractmethod
@@ -138,6 +138,8 @@ class Color(metaclass=ABCMeta):
     def lighten(self: Self, amount: float) -> Self:
         ''' Lighten (increase the luminance) of this color.
 
+        *Subclasses must implement this method.*
+
         Args:
             amount (float) :
                 Amount to increase the luminance by (clamped above zero)
@@ -146,9 +148,7 @@ class Color(metaclass=ABCMeta):
             Color
 
         '''
-        hsl = self.to_hsl()
-        hsl.l = self.clamp(hsl.l + amount, 1)
-        return self.from_hsl(hsl)
+        raise NotImplementedError
 
     @abstractmethod
     def to_css(self) -> str:

--- a/bokeh/colors/color.py
+++ b/bokeh/colors/color.py
@@ -84,6 +84,7 @@ class Color(metaclass=ABCMeta):
         '''
         raise NotImplementedError
 
+    @abstractmethod
     def darken(self: Self, amount: float) -> Self:
         ''' Darken (reduce the luminance) of this color.
 
@@ -133,6 +134,7 @@ class Color(metaclass=ABCMeta):
         '''
         raise NotImplementedError
 
+    @abstractmethod
     def lighten(self: Self, amount: float) -> Self:
         ''' Lighten (increase the luminance) of this color.
 

--- a/bokeh/colors/hsl.py
+++ b/bokeh/colors/hsl.py
@@ -147,6 +147,36 @@ class HSL(Color):
         from .rgb import RGB  # prevent circular import
         r, g, b = colorsys.hls_to_rgb(float(self.h)/360, self.l, self.s)
         return RGB(round(r*255), round(g*255), round(b*255), self.a)
+    
+    def darken(self, amount: float) -> HSL:
+        ''' Darken (reduce the luminance) of this color.
+
+        Args:
+            amount (float) :
+                Amount to reduce the luminance by (clamped above zero)
+
+        Returns:
+            Color
+
+        '''
+        hsl = self.copy()
+        hsl.l = self.clamp(hsl.l - amount)
+        return self.from_hsl(hsl)
+        
+    def lighten(self, amount: float) -> HSL:
+        ''' Lighten (increase the luminance) of this color.
+
+        Args:
+            amount (float) :
+                Amount to increase the luminance by (clamped above zero)
+
+        Returns:
+            Color
+
+        '''
+        hsl = self.copy()
+        hsl.l = self.clamp(hsl.l + amount, 1)
+        return self.from_hsl(hsl)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/colors/hsl.py
+++ b/bokeh/colors/hsl.py
@@ -156,12 +156,10 @@ class HSL(Color):
                 Amount to reduce the luminance by (clamped above zero)
 
         Returns:
-            Color
+            :class:`~bokeh.colors.hsl.HSL`
 
         '''
-        hsl = self.copy()
-        hsl.l = self.clamp(hsl.l - amount)
-        return self.from_hsl(hsl)
+        return self.lighten(-amount)
         
     def lighten(self, amount: float) -> HSL:
         ''' Lighten (increase the luminance) of this color.
@@ -171,7 +169,7 @@ class HSL(Color):
                 Amount to increase the luminance by (clamped above zero)
 
         Returns:
-            Color
+            :class:`~bokeh.colors.hsl.HSL`
 
         '''
         hsl = self.copy()

--- a/bokeh/colors/hsl.py
+++ b/bokeh/colors/hsl.py
@@ -87,6 +87,19 @@ class HSL(Color):
         '''
         return HSL(self.h, self.s, self.l, self.a)
 
+    def darken(self, amount: float) -> HSL:
+        ''' Darken (reduce the luminance) of this color.
+
+        Args:
+            amount (float) :
+                Amount to reduce the luminance by (clamped above zero)
+
+        Returns:
+            :class:`~bokeh.colors.hsl.HSL`
+
+        '''
+        return self.lighten(-amount)
+
     @classmethod
     def from_hsl(cls, value: HSL) -> HSL:
         ''' Copy an HSL color from another HSL color value.
@@ -147,20 +160,7 @@ class HSL(Color):
         from .rgb import RGB  # prevent circular import
         r, g, b = colorsys.hls_to_rgb(float(self.h)/360, self.l, self.s)
         return RGB(round(r*255), round(g*255), round(b*255), self.a)
-    
-    def darken(self, amount: float) -> HSL:
-        ''' Darken (reduce the luminance) of this color.
 
-        Args:
-            amount (float) :
-                Amount to reduce the luminance by (clamped above zero)
-
-        Returns:
-            :class:`~bokeh.colors.hsl.HSL`
-
-        '''
-        return self.lighten(-amount)
-        
     def lighten(self, amount: float) -> HSL:
         ''' Lighten (increase the luminance) of this color.
 

--- a/bokeh/colors/rgb.py
+++ b/bokeh/colors/rgb.py
@@ -82,7 +82,7 @@ class RGB(Color):
         '''
         return RGB(self.r, self.g, self.b, self.a)
 
-    def darken(self, amount: float) -> HSL:
+    def darken(self, amount: float) -> RGB:
         ''' Darken (reduce the luminance) of this color.
 
         Args:
@@ -167,7 +167,7 @@ class RGB(Color):
         '''
         return self.copy()
 
-    def lighten(self, amount: float) -> HSL:
+    def lighten(self, amount: float) -> RGB:
         ''' Lighten (increase the luminance) of this color.
 
         Args:

--- a/bokeh/colors/rgb.py
+++ b/bokeh/colors/rgb.py
@@ -81,6 +81,19 @@ class RGB(Color):
 
         '''
         return RGB(self.r, self.g, self.b, self.a)
+    
+    def darken(self, amount: float) -> HSL:
+        ''' Darken (reduce the luminance) of this color.
+
+        Args:
+            amount (float) :
+                Amount to reduce the luminance by (clamped above zero)
+
+        Returns:
+            :class:`~bokeh.colors.rgb.RGB`
+
+        '''
+        return self.lighten(-amount)
 
     @classmethod
     def from_hsl(cls, value: HSL) -> RGB:
@@ -153,20 +166,7 @@ class RGB(Color):
 
         '''
         return self.copy()
-    
-    def darken(self, amount: float) -> HSL:
-        ''' Darken (reduce the luminance) of this color.
 
-        Args:
-            amount (float) :
-                Amount to reduce the luminance by (clamped above zero)
-
-        Returns:
-            :class:`~bokeh.colors.rgb.RGB`
-
-        '''
-        return self.lighten(-amount)
-        
     def lighten(self, amount: float) -> HSL:
         ''' Lighten (increase the luminance) of this color.
 

--- a/bokeh/colors/rgb.py
+++ b/bokeh/colors/rgb.py
@@ -82,19 +82,6 @@ class RGB(Color):
         '''
         return RGB(self.r, self.g, self.b, self.a)
 
-    def darken(self, amount: float) -> RGB:
-        ''' Darken (reduce the luminance) of this color.
-
-        Args:
-            amount (float) :
-                Amount to reduce the luminance by (clamped above zero)
-
-        Returns:
-            :class:`~bokeh.colors.rgb.RGB`
-
-        '''
-        return self.lighten(-amount)
-
     @classmethod
     def from_hsl(cls, value: HSL) -> RGB:
         ''' Create an RGB color from an HSL color value.
@@ -166,26 +153,6 @@ class RGB(Color):
 
         '''
         return self.copy()
-
-    def lighten(self, amount: float) -> RGB:
-        ''' Lighten (increase the luminance) of this color.
-
-        Args:
-            amount (float) :
-                Amount to increase the luminance by (clamped above zero)
-
-        Returns:
-            :class:`~bokeh.colors.rgb.RGB`
-
-        '''
-        rgb = self.copy()
-        h, l, s = colorsys.rgb_to_hls(float(rgb.r)/255, float(rgb.g)/255, float(rgb.b)/255)
-        new_l = self.clamp(l + amount, 1)
-        r, g, b = colorsys.hls_to_rgb(h, new_l, s)
-        rgb.r = round(r * 255)
-        rgb.g = round(g * 255)
-        rgb.b = round(b * 255)
-        return rgb
 
     @property
     def brightness(self) -> float:

--- a/bokeh/colors/rgb.py
+++ b/bokeh/colors/rgb.py
@@ -81,7 +81,7 @@ class RGB(Color):
 
         '''
         return RGB(self.r, self.g, self.b, self.a)
-    
+
     def darken(self, amount: float) -> HSL:
         ''' Darken (reduce the luminance) of this color.
 

--- a/bokeh/colors/rgb.py
+++ b/bokeh/colors/rgb.py
@@ -153,6 +153,39 @@ class RGB(Color):
 
         '''
         return self.copy()
+    
+    def darken(self, amount: float) -> HSL:
+        ''' Darken (reduce the luminance) of this color.
+
+        Args:
+            amount (float) :
+                Amount to reduce the luminance by (clamped above zero)
+
+        Returns:
+            :class:`~bokeh.colors.rgb.RGB`
+
+        '''
+        return self.lighten(-amount)
+        
+    def lighten(self, amount: float) -> HSL:
+        ''' Lighten (increase the luminance) of this color.
+
+        Args:
+            amount (float) :
+                Amount to increase the luminance by (clamped above zero)
+
+        Returns:
+            :class:`~bokeh.colors.rgb.RGB`
+
+        '''
+        rgb = self.copy()
+        h, l, s = colorsys.rgb_to_hls(float(rgb.r)/255, float(rgb.g)/255, float(rgb.b)/255)
+        new_l = self.clamp(l + amount, 1)
+        r, g, b = colorsys.hls_to_rgb(h, new_l, s)
+        rgb.r = round(r * 255)
+        rgb.g = round(g * 255)
+        rgb.b = round(b * 255)
+        return rgb
 
     @property
     def brightness(self) -> float:

--- a/tests/unit/bokeh/colors/test_color__colors.py
+++ b/tests/unit/bokeh/colors/test_color__colors.py
@@ -97,12 +97,12 @@ class Test_Color:
         assert c2.g == 52
         assert c2.b == 245
 
-        c2 = c.darken(1.2)
+        c2 = c.lighten(1.2)
         assert c2 is not c
         assert c2.a == 0.2
-        assert c2.r == 0
-        assert c2.g == 0
-        assert c2.b == 0
+        assert c2.r == 255
+        assert c2.g == 255
+        assert c2.b == 255
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/colors/test_color__colors.py
+++ b/tests/unit/bokeh/colors/test_color__colors.py
@@ -18,6 +18,7 @@ import pytest ; pytest
 
 # Bokeh imports
 from bokeh.colors.hsl import HSL
+from bokeh.colors.rgb import RGB
 
 # Module under test
 import bokeh.colors.color as bcc # isort:skip
@@ -55,6 +56,22 @@ class Test_Color:
         assert c2.s == 0.2
         assert c2.l == 0
 
+    def test_darken_rgb(self) -> None:
+        c = RGB(123, 12, 234, 0.2)
+        c2 = c.darken(0.1)
+        assert c2 is not c
+        assert c2.a == 0.2
+        assert c2.r == 97
+        assert c.g == 10
+        assert c.b == 185
+
+        c2 = c.darken(1.2)
+        assert c2 is not c
+        assert c2.a == 0.2
+        assert c2.r == 0
+        assert c.g == 0
+        assert c.b == 0
+
     def test_lighten(self) -> None:
         c = HSL(10, 0.2, 0.2, 0.2)
         c2 = c.lighten(0.2)
@@ -70,6 +87,22 @@ class Test_Color:
         assert c2.h == 10
         assert c2.s == 0.2
         assert c2.l == 1.0
+
+    def test_lighten_rgb(self) -> None:
+        c = RGB(123, 12, 234, 0.2)
+        c2 = c.lighten(0.1)
+        assert c2 is not c
+        assert c2.a == 0.2
+        assert c2.r == 148
+        assert c.g == 52
+        assert c.b == 245
+
+        c2 = c.darken(1.2)
+        assert c2 is not c
+        assert c2.a == 0.2
+        assert c2.r == 255
+        assert c.g == 255
+        assert c.b == 255
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/colors/test_color__colors.py
+++ b/tests/unit/bokeh/colors/test_color__colors.py
@@ -62,15 +62,15 @@ class Test_Color:
         assert c2 is not c
         assert c2.a == 0.2
         assert c2.r == 97
-        assert c.g == 10
-        assert c.b == 185
+        assert c2.g == 10
+        assert c2.b == 185
 
         c2 = c.darken(1.2)
         assert c2 is not c
         assert c2.a == 0.2
         assert c2.r == 0
-        assert c.g == 0
-        assert c.b == 0
+        assert c2.g == 0
+        assert c2.b == 0
 
     def test_lighten(self) -> None:
         c = HSL(10, 0.2, 0.2, 0.2)
@@ -94,15 +94,15 @@ class Test_Color:
         assert c2 is not c
         assert c2.a == 0.2
         assert c2.r == 148
-        assert c.g == 52
-        assert c.b == 245
+        assert c2.g == 52
+        assert c2.b == 245
 
         c2 = c.darken(1.2)
         assert c2 is not c
         assert c2.a == 0.2
         assert c2.r == 255
-        assert c.g == 255
-        assert c.b == 255
+        assert c2.g == 255
+        assert c2.b == 255
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/colors/test_color__colors.py
+++ b/tests/unit/bokeh/colors/test_color__colors.py
@@ -100,9 +100,9 @@ class Test_Color:
         c2 = c.darken(1.2)
         assert c2 is not c
         assert c2.a == 0.2
-        assert c2.r == 255
-        assert c2.g == 255
-        assert c2.b == 255
+        assert c2.r == 0
+        assert c2.g == 0
+        assert c2.b == 0
 
 #-----------------------------------------------------------------------------
 # Dev API


### PR DESCRIPTION
Fixes #11845 

This PR was developed with @cuevasm1

`Color.lighten()` and `Color.darken()` originally converted the object to an `HSL` object then adjusted the luminescence. However, this conversion triggered `HSL`'s deprecation warning.

In order to combat this warning, `Color.lighten()` and `Color.darken()` works as follows:
1. converts the object to an `RGB` object
2. extracts the hue, saturation, and luminescence using `colorsys.rgb_to_hls()`
3. adjusts the luminescence from **2.**
4. retrieves the new r, g, b value using `colorsys.hls_to_rgb()`
5. updates the `RGB` object from **1.** with the r, g, b values from **4.**
6. returns `self.from_rgb(<RGB object from **5.**>)`

However, this process destroyed the hue and saturation conservation when an HSL object was fully lightened or darkened. This was because the `colorsys_rgb_to_hls(0, 0, 0)` (white) defaults the hue and saturation to 0. Similarly, `colorsys.rgb_to_hls(1, 1, 1)` (black) also defaults the hue and saturation to 0. Therefore, `HSL.lighten()` and `HSL.darken()` methods were added in `HSL` class. The code content is the same as the original `Color.lighten()`/`darken()` methods.

In order to conserve codespace, `Color`/`HSL` `.darken(amount)` simply returns `Color`/`HSL` `.lighten(-amount)`

Appropriate tests were added to `tests/unit/bokeh/colors/test_color__colors.py`. The original tests were all conserved, but `test_darken_rgb()` and `test_lighten_rgb()` were added.