### PR TITLE
Cleaner white space/indentation in templates

### DIFF
--- a/bokeh/core/_templates/autoload_request_tag.html
+++ b/bokeh/core/_templates/autoload_request_tag.html
@@ -23,7 +23,7 @@ ID is not specified, the entire document will be rendered.
 .. note::
     This script injects a ``<div>`` in place, so must be placed under ``<body>``.
 
-#}
+-#}
 <script id="{{ elementid }}">
   (function() {
     const xhr = new XMLHttpRequest()

--- a/bokeh/core/_templates/autoload_tag.html
+++ b/bokeh/core/_templates/autoload_tag.html
@@ -20,5 +20,5 @@ ID is not specified, the entire document will be rendered.
 .. note::
     This script injects a ``<div>`` in place, so must be placed under ``<body>``.
 
-#}
+-#}
 <script src="{{ src_path }}" id="{{ elementid }}"></script>

--- a/bokeh/core/_templates/css_resources.html
+++ b/bokeh/core/_templates/css_resources.html
@@ -10,10 +10,10 @@ Resources object.
 
 -#}
 {% for file in css_files %}
-<link rel="stylesheet" href="{{ file }}" type="text/css" />
+    <link rel="stylesheet" href="{{ file }}" type="text/css" />
 {% endfor %}
 {% for css in css_raw %}
-<style>
-    {{ css|indent(8) }}
-</style>
+    <style>
+        {{ css }}
+    </style>
 {% endfor %}

--- a/bokeh/core/_templates/css_resources.html
+++ b/bokeh/core/_templates/css_resources.html
@@ -8,7 +8,7 @@ Resources object.
 :param css_raw: a list of raw CSS snippets to put between ``<style>`` tags
 :type css_raw: list[str]
 
-#}
+-#}
 {%- for file in css_files %}
 <link rel="stylesheet" href="{{ file }}" type="text/css" />
 {%- endfor %}

--- a/bokeh/core/_templates/css_resources.html
+++ b/bokeh/core/_templates/css_resources.html
@@ -9,11 +9,11 @@ Resources object.
 :type css_raw: list[str]
 
 -#}
-{%- for file in css_files %}
+{% for file in css_files %}
 <link rel="stylesheet" href="{{ file }}" type="text/css" />
-{%- endfor %}
-{%- for css in css_raw %}
+{% endfor %}
+{% for css in css_raw %}
 <style>
     {{ css|indent(8) }}
 </style>
-{%- endfor %}
+{% endfor %}

--- a/bokeh/core/_templates/css_resources.html
+++ b/bokeh/core/_templates/css_resources.html
@@ -12,7 +12,6 @@ Resources object.
 {%- for file in css_files %}
 <link rel="stylesheet" href="{{ file }}" type="text/css" />
 {%- endfor %}
-
 {%- for css in css_raw %}
 <style>
     {{ css|indent(8) }}

--- a/bokeh/core/_templates/file.html
+++ b/bokeh/core/_templates/file.html
@@ -22,15 +22,16 @@ that accepts these same parameters.
   {% block inner_head %}
     <meta charset="utf-8">
     <title>{% block title %}{{ title | e if title else "Bokeh Plot" }}{% endblock %}</title>
-  {%-  block preamble %}{% endblock %}
-  {%-  block resources %}
-  {%    block css_resources %}
-  {{- bokeh_css if bokeh_css }}
-  {%-    endblock css_resources %}
-  {%    block js_resources %}
-  {{- bokeh_js if bokeh_js }}
-  {%-    endblock js_resources %}
-  {% endblock resources %}
+
+  {%  block preamble -%}{%- endblock %}
+  {%  block resources -%}
+  {%   block css_resources -%}
+    {{- bokeh_css if bokeh_css }}
+  {%-  endblock css_resources %}
+  {%   block js_resources -%}
+    {{ bokeh_js if bokeh_js }}
+  {%-  endblock js_resources %}
+  {%  endblock resources %}
   {%  block postamble %}{% endblock %}
   {% endblock inner_head %}
   </head>
@@ -45,8 +46,8 @@ that accepts these same parameters.
   {%          block root scoped %}
   {{ embed(root) }}
   {%          endblock %}
-  {% endfor %}
-  {%    endfor %}
+  {%         endfor %}
+  {%      endfor %}
   {%    endblock contents %}
     {{ plot_script | indent(4) }}
   {%  endblock inner_body %}

--- a/bokeh/core/_templates/file.html
+++ b/bokeh/core/_templates/file.html
@@ -19,37 +19,37 @@ that accepts these same parameters.
 <html lang="en">
   {% block head %}
   <head>
-    {% block inner_head %}
-      <meta charset="utf-8">
-      <title>{% block title %}{{ title | e if title else "Bokeh Plot" }}{% endblock %}</title>
-      {% block preamble %}{% endblock %}
-      {% block resources %}
-        {% block css_resources %}
-          {{ bokeh_css | indent(8) if bokeh_css }}
-        {% endblock %}
-        {% block js_resources %}
-          {{ bokeh_js | indent(8) if bokeh_js }}
-        {% endblock %}
-      {% endblock %}
-      {% block postamble %}{% endblock %}
-    {% endblock %}
+  {% block inner_head %}
+    <meta charset="utf-8">
+    <title>{% block title %}{{ title | e if title else "Bokeh Plot" }}{% endblock %}</title>
+  {%-  block preamble %}{% endblock %}
+  {%-  block resources %}
+  {%    block css_resources %}
+  {{- bokeh_css if bokeh_css }}
+  {%-    endblock css_resources %}
+  {%    block js_resources %}
+  {{- bokeh_js if bokeh_js }}
+  {%-    endblock js_resources %}
+  {% endblock resources %}
+  {%  block postamble %}{% endblock %}
+  {% endblock inner_head %}
   </head>
-  {% endblock %}
+  {% endblock head%}
   {% block body %}
   <body>
-    {% block inner_body %}
-      {% block contents %}
-        {% for doc in docs %}
-          {{ embed(doc) if doc.elementid }}
-          {% for root in doc.roots %}
-            {% block root scoped %}
-              {{ embed(root) | indent(10) }}
-            {% endblock %}
-          {% endfor %}
-        {% endfor %}
-      {% endblock %}
-      {{ plot_script | indent(8) }}
-    {% endblock %}
+  {%  block inner_body %}
+  {%    block contents %}
+  {%      for doc in docs %}
+  {{ embed(doc) if doc.elementid }}
+  {%-        for root in doc.roots %}
+  {%          block root scoped %}
+  {{ embed(root) }}
+  {%          endblock %}
+  {% endfor %}
+  {%    endfor %}
+  {%    endblock contents %}
+    {{ plot_script | indent(4) }}
+  {%  endblock inner_body %}
   </body>
-  {% endblock %}
+  {% endblock body%}
 </html>

--- a/bokeh/core/_templates/file.html
+++ b/bokeh/core/_templates/file.html
@@ -14,9 +14,7 @@ Users can customize the file output by providing their own Jinja2 template
 that accepts these same parameters.
 
 -#}
-
 {% from macros import embed %}
-
 <!DOCTYPE html>
 <html lang="en">
   {% block head %}

--- a/bokeh/core/_templates/file.html
+++ b/bokeh/core/_templates/file.html
@@ -13,7 +13,7 @@ Renders Bokeh models into a basic .html file.
 Users can customize the file output by providing their own Jinja2 template
 that accepts these same parameters.
 
-#}
+-#}
 
 {% from macros import embed %}
 

--- a/bokeh/core/_templates/file.html
+++ b/bokeh/core/_templates/file.html
@@ -28,7 +28,7 @@ that accepts these same parameters.
     {{- bokeh_css if bokeh_css }}
   {%-  endblock css_resources %}
   {%   block js_resources -%}
-    {{ bokeh_js if bokeh_js }}
+    {{  bokeh_js if bokeh_js }}
   {%-  endblock js_resources %}
   {%  endblock resources %}
   {%  block postamble %}{% endblock %}
@@ -40,12 +40,12 @@ that accepts these same parameters.
   {%  block inner_body %}
   {%    block contents %}
   {%      for doc in docs %}
-  {{ embed(doc) if doc.elementid }}
-  {%-        for root in doc.roots %}
+  {{        embed(doc) if doc.elementid }}
+  {%-       for root in doc.roots %}
   {%          block root scoped %}
-  {{ embed(root) }}
+  {{            embed(root) }}
   {%          endblock %}
-  {%         endfor %}
+  {%        endfor %}
   {%      endfor %}
   {%    endblock contents %}
   {{ plot_script | indent(4) }}

--- a/bokeh/core/_templates/file.html
+++ b/bokeh/core/_templates/file.html
@@ -48,7 +48,7 @@ that accepts these same parameters.
   {%         endfor %}
   {%      endfor %}
   {%    endblock contents %}
-  {{ plot_script | indent(6) }}
+  {{ plot_script | indent(4) }}
   {%  endblock inner_body %}
   </body>
   {% endblock body%}

--- a/bokeh/core/_templates/file.html
+++ b/bokeh/core/_templates/file.html
@@ -22,7 +22,6 @@ that accepts these same parameters.
   {% block inner_head %}
     <meta charset="utf-8">
     <title>{% block title %}{{ title | e if title else "Bokeh Plot" }}{% endblock %}</title>
-
   {%  block preamble -%}{%- endblock %}
   {%  block resources -%}
   {%   block css_resources -%}
@@ -49,7 +48,7 @@ that accepts these same parameters.
   {%         endfor %}
   {%      endfor %}
   {%    endblock contents %}
-    {{ plot_script | indent(4) }}
+  {{ plot_script | indent(6) }}
   {%  endblock inner_body %}
   </body>
   {% endblock body%}

--- a/bokeh/core/_templates/js_resources.html
+++ b/bokeh/core/_templates/js_resources.html
@@ -11,7 +11,7 @@ configuration in a Resources object.
 :param js_raw: a list of raw JS snippets to put between ``<style>`` tags
 :type js_raw: list[str]
 
-#}
+-#}
 {%- for file in js_files %}
 <script type="text/javascript" src="{{ file }}"></script>
 {%- endfor %}

--- a/bokeh/core/_templates/js_resources.html
+++ b/bokeh/core/_templates/js_resources.html
@@ -15,7 +15,6 @@ configuration in a Resources object.
 {%- for file in js_files %}
 <script type="text/javascript" src="{{ file }}"></script>
 {%- endfor %}
-
 {%- for js in js_raw %}
 <script type="text/javascript">
     {{ js|indent(8) }}

--- a/bokeh/core/_templates/js_resources.html
+++ b/bokeh/core/_templates/js_resources.html
@@ -12,11 +12,11 @@ configuration in a Resources object.
 :type js_raw: list[str]
 
 -#}
-{%- for file in js_files %}
-<script type="text/javascript" src="{{ file }}"></script>
-{%- endfor %}
-{%- for js in js_raw %}
-<script type="text/javascript">
-    {{ js|indent(8) }}
-</script>
-{%- endfor %}
+{% for file in js_files %}
+    <script type="text/javascript" src="{{ file }}"></script>
+{% endfor %}
+{% for js in js_raw %}
+    <script type="text/javascript">
+        {{ js }}
+    </script>
+{% endfor %}

--- a/bokeh/core/_templates/notebook_load.html
+++ b/bokeh/core/_templates/notebook_load.html
@@ -25,7 +25,7 @@ Notebook according to a Resources object.
         <a href="https://bokeh.org" target="_blank" class="bk-logo bk-logo-small bk-logo-notebook"></a>
         <span id="{{ element_id }}">Loading BokehJS ...</span>
     </div>
-    {%- if verbose %}
+    {% if verbose %}
     <style>
         p.bokeh_notebook { margin-left: 24px; }
         table.bokeh_notebook {
@@ -66,7 +66,7 @@ Notebook according to a Resources object.
             <td class="bokeh_notebook">{{ css_info }}</td>
         </tr>
     </table>
-    {%- endif %}
-    {%- for warning in warnings %}
+    {% endif %}
+    {% for warning in warnings %}
     <p style="background-color: #f2d7dc;">{{ warning }}</p>
-    {%- endfor %}
+    {% endfor %}

--- a/bokeh/core/_templates/notebook_load.html
+++ b/bokeh/core/_templates/notebook_load.html
@@ -20,7 +20,7 @@ Notebook according to a Resources object.
 :param warnings: a list of warnings to display to user
 :type warnings: list[str]
 
-#}
+-#}
     <div class="bk-root">
         <a href="https://bokeh.org" target="_blank" class="bk-logo bk-logo-small bk-logo-notebook"></a>
         <span id="{{ element_id }}">Loading BokehJS ...</span>

--- a/bokeh/core/_templates/plot_div.html
+++ b/bokeh/core/_templates/plot_div.html
@@ -5,7 +5,7 @@ Renders a basic plot div, that can be used in conjunction with PLOT_JS.
     template should be configured with the same ``elementid``
 :type elementid: str
 
-#}
+-#}
 
 {% from macros import embed %}
 

--- a/bokeh/core/_templates/plot_div.html
+++ b/bokeh/core/_templates/plot_div.html
@@ -6,9 +6,7 @@ Renders a basic plot div, that can be used in conjunction with PLOT_JS.
 :type elementid: str
 
 -#}
-
 {% from macros import embed %}
-
 {{ embed(doc) if doc.elementid }}
 {% for root in doc.roots %}
   {{ embed(root) }}

--- a/bokeh/core/_templates/script_tag.html
+++ b/bokeh/core/_templates/script_tag.html
@@ -5,6 +5,8 @@ Renders a ``<script>`` tag for raw JavaScript code.
 :type js_code: str
 
 -#}
-<script type="{{ type }}"{%if id %} id="{{ id }}"{% endif %}>
-{{ js_code }}
+<script type="{{ type }}"{% if id %} id="{{ id }}"{% endif %}>
+{# Already indented in wrappers.py #}
+{{ js_code }} 
 </script>
+

--- a/bokeh/core/_templates/script_tag.html
+++ b/bokeh/core/_templates/script_tag.html
@@ -4,7 +4,7 @@ Renders a ``<script>`` tag for raw JavaScript code.
 :param js_code: raw JavaScript code to put in the tag.
 :type js_code: str
 
-#}
+-#}
 <script type="{{ type }}"{%if id %} id="{{ id }}"{% endif %}>
 {{ js_code }}
 </script>

--- a/bokeh/core/_templates/script_tag.html
+++ b/bokeh/core/_templates/script_tag.html
@@ -4,9 +4,9 @@ Renders a ``<script>`` tag for raw JavaScript code.
 :param js_code: raw JavaScript code to put in the tag.
 :type js_code: str
 
--#}
+#}
+
 <script type="{{ type }}"{% if id %} id="{{ id }}"{% endif %}>
 {# Already indented in wrappers.py #}
-{{ js_code }} 
+{{ js_code }}
 </script>
-

--- a/bokeh/core/templates.py
+++ b/bokeh/core/templates.py
@@ -78,7 +78,7 @@ def get_env():
         # Non-frozen Python and cx_Freeze can use __file__ directly
         templates_path = join(dirname(__file__), '_templates')
 
-    return Environment(loader=FileSystemLoader(templates_path))
+    return Environment(loader=FileSystemLoader(templates_path), trim_blocks=True, lstrip_blocks=True)
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/sphinx/source/docs/user_guide/embed.rst
+++ b/sphinx/source/docs/user_guide/embed.rst
@@ -572,37 +572,39 @@ Here's a full template with all the sections that you can override:
     <html lang="en">
     {% block head %}
     <head>
-        {% block inner_head %}
+    {% block inner_head %}
         <meta charset="utf-8">
         <title>{% block title %}{{ title | e if title else "Bokeh Plot" }}{% endblock %}</title>
-        {% block preamble %}{% endblock %}
-        {% block resources %}
-            {% block css_resources %}
-            {{ bokeh_css | indent(8) if bokeh_css }}
-            {% endblock %}
-            {% block js_resources %}
-            {{ bokeh_js | indent(8) if bokeh_js }}
-            {% endblock %}
-        {% endblock %}
-        {% block postamble %}{% endblock %}
-        {% endblock %}
+    {%  block preamble -%}{%- endblock %}
+    {%  block resources -%}
+    {%   block css_resources -%}
+        {{- bokeh_css if bokeh_css }}
+    {%-  endblock css_resources %}
+    {%   block js_resources -%}
+        {{  bokeh_js if bokeh_js }}
+    {%-  endblock js_resources %}
+    {%  endblock resources %}
+    {%  block postamble %}{% endblock %}
+    {% endblock inner_head %}
     </head>
-    {% endblock %}
+    {% endblock head%}
     {% block body %}
     <body>
-        {% block inner_body %}
-        {% block contents %}
-            {% for doc in docs %}
-            {{ embed(doc) if doc.elementid }}
-            {% for root in doc.roots %}
-                {{ embed(root) | indent(10) }}
-            {% endfor %}
-            {% endfor %}
-        {% endblock %}
-        {{ plot_script | indent(8) }}
-        {% endblock %}
+    {%  block inner_body %}
+    {%    block contents %}
+    {%      for doc in docs %}
+    {{        embed(doc) if doc.elementid }}
+    {%-       for root in doc.roots %}
+    {%          block root scoped %}
+    {{            embed(root) }}
+    {%          endblock %}
+    {%        endfor %}
+    {%      endfor %}
+    {%    endblock contents %}
+    {{ plot_script | indent(4) }}
+    {%  endblock inner_body %}
     </body>
-    {% endblock %}
+    {% endblock body%}
     </html>
 
 

--- a/tests/unit/bokeh/core/test_templates.py
+++ b/tests/unit/bokeh/core/test_templates.py
@@ -18,7 +18,14 @@ import pytest ; pytest
 
 # Standard library imports
 import hashlib
+import re
 from os.path import abspath, join, split
+from typing import List
+
+# Bokeh imports
+from bokeh.embed import file_html
+from bokeh.plotting import figure
+from bokeh.resources import JSResources
 
 # Module under test
 import bokeh.core.templates as bct # isort:skip
@@ -38,7 +45,6 @@ TOP_PATH = abspath(join(split(bct.__file__)[0]))
 #-----------------------------------------------------------------------------
 
 def _crlf_cr_2_lf_bin(s):
-    import re
     return re.sub(b"\r\n|\r|\n", b"\n", s)
 
 #-----------------------------------------------------------------------------
@@ -49,6 +55,12 @@ def compute_sha256(data):
     sha256 = hashlib.sha256()
     sha256.update(data)
     return sha256.hexdigest()
+
+def get_html_lines() -> List[str]:
+    p = figure()
+    p.scatter(x=[], y=[])
+    html = file_html(p, JSResources(mode="absolute"))
+    return html.split('\n')
 
 pinned_template_sha256 = "5d26be35712286918e36cc469c9354076b3d555eb39799aa63d04473c0566c29"
 
@@ -66,6 +78,10 @@ def test_autoload_template_has_changed() -> None:
             in notebooks has been completed successfully, update this test
             with the new file SHA256 signature."""
 
+def test_no_white_space_in_top_of_html() -> None:
+    lines = get_html_lines()
+    r = re.compile(r'\S')
+    assert(r.search(lines[0]) is not None)
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/core/test_templates.py
+++ b/tests/unit/bokeh/core/test_templates.py
@@ -83,23 +83,19 @@ def test_no_white_space_in_top_of_html() -> None:
     any_character = re.compile(r"\S")
     assert(any_character.search(lines[0]) is not None)
 
-def test_no_scripts_start_on_same_line() -> None:
+def test_no_two_scripts_start_on_same_line() -> None:
     lines = get_html_lines()
-    script_start = re.compile("<script")
     for line in lines:
-        start_match = script_start.findall(line)
-        if start_match:
-            assert len(start_match) == 1
+        if "<script" in line:
+            assert len(line.split("<script")) == 2
         
-def test_no_scripts_start_on_same_line_another_ends() -> None:
+def test_dont_start_script_on_same_line_after_another_ends() -> None:
     lines = get_html_lines()
-    script_start = re.compile("<script")
-    script_end = re.compile("</script>")
     for line in lines:
-        start_match = script_start.search(line)
-        end_match = script_end.search(line)
-        if  start_match and end_match:
-            assert start_match.start() < end_match.start()
+        if "<script" in line and "</script" in line:
+            start_match = line.rfind("<script")
+            end_match = line.rfind("</script")
+            assert start_match < end_match
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/core/test_templates.py
+++ b/tests/unit/bokeh/core/test_templates.py
@@ -80,8 +80,26 @@ def test_autoload_template_has_changed() -> None:
 
 def test_no_white_space_in_top_of_html() -> None:
     lines = get_html_lines()
-    r = re.compile(r'\S')
-    assert(r.search(lines[0]) is not None)
+    any_character = re.compile(r"\S")
+    assert(any_character.search(lines[0]) is not None)
+
+def test_no_scripts_start_on_same_line() -> None:
+    lines = get_html_lines()
+    script_start = re.compile("<script")
+    for line in lines:
+        start_match = script_start.findall(line)
+        if start_match:
+            assert len(start_match) == 1
+        
+def test_no_scripts_start_on_same_line_another_ends() -> None:
+    lines = get_html_lines()
+    script_start = re.compile("<script")
+    script_end = re.compile("</script>")
+    for line in lines:
+        start_match = script_start.search(line)
+        end_match = script_end.search(line)
+        if  start_match and end_match:
+            assert start_match.start() < end_match.start()
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/core/test_templates.py
+++ b/tests/unit/bokeh/core/test_templates.py
@@ -25,7 +25,7 @@ from typing import List
 # Bokeh imports
 from bokeh.embed import file_html
 from bokeh.plotting import figure
-from bokeh.resources import CSSResources, JSResources, ResourcesMode
+from bokeh.resources import Resources, ResourcesMode
 
 # Module under test
 import bokeh.core.templates as bct # isort:skip
@@ -59,7 +59,7 @@ def compute_sha256(data):
 def get_html_lines(resource_mode: ResourcesMode) -> List[str]:
     p = figure()
     p.scatter(x=[], y=[])
-    html = file_html(p, resources=(JSResources(mode=resource_mode), CSSResources(mode=resource_mode)))
+    html = file_html(p, resources=Resources(resource_mode))
     return html.split('\n')
 
 pinned_template_sha256 = "5d26be35712286918e36cc469c9354076b3d555eb39799aa63d04473c0566c29"

--- a/tests/unit/bokeh/core/test_templates.py
+++ b/tests/unit/bokeh/core/test_templates.py
@@ -25,7 +25,7 @@ from typing import List
 # Bokeh imports
 from bokeh.embed import file_html
 from bokeh.plotting import figure
-from bokeh.resources import JSResources, CSSResources, ResourcesMode
+from bokeh.resources import CSSResources, JSResources, ResourcesMode
 
 # Module under test
 import bokeh.core.templates as bct # isort:skip
@@ -82,7 +82,7 @@ def test_no_white_space_in_top_of_html() -> None:
     lines = get_html_lines("inline")
     any_character = re.compile(r"\S")
     assert(any_character.search(lines[0]) is not None)
-        
+
 def test_dont_start_script_on_same_line_after_another_ends() -> None:
     modes: List[ResourcesMode] = ["inline", "cdn", "server", "relative", "absolute"]
     for mode in modes:


### PR DESCRIPTION
- [x] issues: fixes #11811
- [x] tests added / passed

WIP - I'm not currently happy with how this looks because the templates still aren't "clean" - there's still manual wrangling to get the line breaks mostly right. And even then, there are still a couple unnecessary line breaks. So far my approach has been:

1. Set `trim_blocks=True, lstrip_blocks=True` in the Jinja environment
2. Add tests for immediate issue of white space at the top of HTML, and scripts being pulled up to the previous line
3. Remove most block indentation from `file.html`
4. Manually wrangle whatever didn't look right by selectively adding `{% -%}` or `{%- %}` or `indent(x)`

<details>
<summary>
Initial before/after comparison
</summary>
Before:
<img width="818" alt="Screen Shot 2021-12-07 at 7 43 19 PM" src="https://user-images.githubusercontent.com/61096711/145144762-5ba244e3-d73b-468e-8bc7-686c524b1473.png">
After:
<img width="818" alt="afterTemplate" src="https://user-images.githubusercontent.com/61096711/145144780-618dbf4a-4f4a-48a8-b3ad-28cef65fb3df.png">

</details>
