### PR TITLE
Update bokeh-release-build.yml

### DIFF
--- a/.github/workflows/bokeh-release-build.yml
+++ b/.github/workflows/bokeh-release-build.yml
@@ -8,7 +8,7 @@ on:
         required: true
 
 env:
-  CONDA_BASE_REQS: "conda=4.8.1 conda-build=3.18.10 conda-verify=3.4.2 ripgrep=0.10.0 jinja2"
+  CONDA_BASE_REQS: "conda=4.11.0 conda-build=3.21.7 conda-verify=3.4.2 ripgrep=0.10.0 jinja2"
   CONDA_ENV_REQS: "python=3.9 jinja2 yaml pyyaml"
 
 jobs:


### PR DESCRIPTION
Deploy job is currently failing due to some conda version incompatibilities. On the one hand, it seems conda/conda-build package updates are not locked down in the current deploy workflow as tightly as they have been in the previous automation. I'd like to address that but for now I would also just like to see if updating everything to latest also unsticks things, since it has been ahwhile. 

Will merge as soon as codebase tests pass. 