### PR TITLE
Add note on LaTeX support to wrapped extension examples (katex)

### DIFF
--- a/examples/custom/wrapped_extension_base/README.md
+++ b/examples/custom/wrapped_extension_base/README.md
@@ -1,3 +1,8 @@
 This example uses a custom extension, which requires compilation before
 the example can be run. Issue ``bokeh build latex_label`` to build the
 extension.
+
+Note: Bokeh supports LaTeX natively on several elements. The purpose of this
+example is to demonstrate how to use a custom extension. For more information
+about using LaTeX in Bokeh, see ['Adding mathematical notations' in the user guide]
+(https://docs.bokeh.org/en/latest/docs/user_guide/styling.html#adding-mathematical-notations).

--- a/examples/custom/wrapped_extension_base/latex_extension_base.py
+++ b/examples/custom/wrapped_extension_base/latex_extension_base.py
@@ -1,4 +1,10 @@
-""" The LaTeX example was derived from: http://matplotlib.org/users/usetex.html. """
+""" The LaTeX example was derived from: http://matplotlib.org/users/usetex.html.
+
+Note: Bokeh supports LaTeX natively on several elements. The purpose of this
+example is to demonstrate how to use a custom extension. For more information
+about using LaTeX in Bokeh, see 'Adding mathematical notations' in the user
+guide: https://docs.bokeh.org/en/latest/docs/user_guide/styling.html#adding-mathematical-notations.
+"""
 
 import numpy as np
 from scipy.special import jv

--- a/examples/custom/wrapped_extension_full/README.md
+++ b/examples/custom/wrapped_extension_full/README.md
@@ -1,3 +1,8 @@
 This example uses a custom extension, which requires compilation before
 the example can be run. Issue ``bokeh build latex_label`` to build the
 extension.
+
+Note: Bokeh supports LaTeX natively on several elements. The purpose of this
+example is to demonstrate how to use a custom extension. For more information
+about using LaTeX in Bokeh, see ['Adding mathematical notations' in the user guide]
+(https://docs.bokeh.org/en/latest/docs/user_guide/styling.html#adding-mathematical-notations).

--- a/examples/custom/wrapped_extension_full/latex_extension_full.py
+++ b/examples/custom/wrapped_extension_full/latex_extension_full.py
@@ -1,4 +1,10 @@
-""" The LaTeX example was derived from: http://matplotlib.org/users/usetex.html. """
+""" The LaTeX example was derived from: http://matplotlib.org/users/usetex.html.
+
+Note: Bokeh supports LaTeX natively on several elements. The purpose of this
+example is to demonstrate how to use a custom extension. For more information
+about using LaTeX in Bokeh, see 'Adding mathematical notations' in the user
+guide: https://docs.bokeh.org/en/latest/docs/user_guide/styling.html#adding-mathematical-notations.
+"""
 
 import numpy as np
 from scipy.special import jv


### PR DESCRIPTION
This PR adds notes to the wrapped extension examples using katex (`wrapped_extension_full` and `wrapped_extension_base`). 

- [x] issues: fixes #11870