### PR TITLE
initial logic to change pan cursor on plot hover

### DIFF
--- a/bokehjs/src/lib/core/ui_events.ts
+++ b/bokehjs/src/lib/core/ui_events.ts
@@ -433,6 +433,7 @@ export class UIEventBus implements EventListenerObject {
           this.trigger(signal, e, active_gesture.id)
 
         const active_inspectors = plot_view.model.toolbar.inspectors.filter(t => t.active)
+        const is_pan_selected = !!plot_view.model.toolbar.gestures.pan.active
         let cursor = "default"
 
         // the event happened on a renderer
@@ -443,9 +444,19 @@ export class UIEventBus implements EventListenerObject {
             // override event_type to cause inspectors to clear overlays
             signal = this.move_exit as any // XXX
           }
-
         // the event happened on the plot frame but off a renderer
         } else if (this._hit_test_frame(plot_view, e.sx, e.sy)) {
+          // If pan is selected, change cursor to make on-axis panning more discoverable
+          if (is_pan_selected) {
+            console.log(e.sx, e.sy, '|', plot_view.layout.bbox)
+            if(e.sx <= plot_view.layout.bbox["x1"] * 0.10){
+              cursor = "ns-resize"
+            } else if(e.sy >= plot_view.layout.bbox["y1"] * 0.90) {
+              cursor = "ew-resize"
+            } else {
+              cursor = "all-scroll"
+            }
+          }
           if (!is_empty(active_inspectors)) {
             cursor = "crosshair"
           }


### PR DESCRIPTION
This PR is still a WIP

The desired functionality is to make on-axis panning to be more discoverable. The status quo is that the cursor over a plot is a simple pointer, even when the panning gesture is selected. Thus, it is not intuitive to a user that they can pan along an axes. The proposed change in the issue is that the cursor take some sort of form that reflects that on-axis panning is possible. This PR aims to implement a system whereby when the cursor is hovered near an axis, it changes to either an ew-resize pointer (bidirectionally horizontal) or ns-resize (bidirectionally vertical).

- [x] issues: fixes #11032 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
