### PR TITLE
Add policy to highlight Linked Edges and Adjacent Nodes by selecting node.

### DIFF
--- a/bokeh/models/graphs.py
+++ b/bokeh/models/graphs.py
@@ -45,6 +45,7 @@ __all__ = (
     'NodeCoordinates',
     'NodesAndAdjacentNodes',
     'NodesAndLinkedEdges',
+    'NodesAndLinkedEdgesAndLinkedNodes',
     'NodesOnly',
     'StaticLayoutProvider',
 )
@@ -170,6 +171,19 @@ class NodesAndAdjacentNodes(GraphHitTestPolicy):
     selection or inspection of graph edges, and no indication of which node is
     the tool-selected one from the policy-selected nodes.
 
+    '''
+
+    pass
+
+class NodesAndLinkedEdgesAndLinkedNodes(GraphHitTestPolicy):
+    '''
+    With the ``NodesAndLinkedEdgesAndLinkedNodes`` policy, inspection or selection
+    of graph nodes will result in the inspection or selection of the node, any their
+    linked graph edges, and of the linked graph nodes. There is no selection or 
+    inspection of graph edges, and no indication of which node is the tool-selected 
+    one from the policy-selected nodes. There is no selection or inspection of graph 
+    edges, and no indication of which node is the tool-selected one from the 
+    policy-selected nodes.
     '''
 
     pass

--- a/bokeh/models/graphs.py
+++ b/bokeh/models/graphs.py
@@ -179,10 +179,10 @@ class NodesAndLinkedEdgesAndLinkedNodes(GraphHitTestPolicy):
     '''
     With the ``NodesAndLinkedEdgesAndLinkedNodes`` policy, inspection or selection
     of graph nodes will result in the inspection or selection of the node, any their
-    linked graph edges, and of the linked graph nodes. There is no selection or 
-    inspection of graph edges, and no indication of which node is the tool-selected 
-    one from the policy-selected nodes. There is no selection or inspection of graph 
-    edges, and no indication of which node is the tool-selected one from the 
+    linked graph edges, and of the linked graph nodes. There is no selection or
+    inspection of graph edges, and no indication of which node is the tool-selected
+    one from the policy-selected nodes. There is no selection or inspection of graph
+    edges, and no indication of which node is the tool-selected one from the
     policy-selected nodes.
     '''
 

--- a/bokehjs/package-lock.json
+++ b/bokehjs/package-lock.json
@@ -21,7 +21,7 @@
     },
     "make": {
       "name": "@bokeh/make",
-      "version": "3.0.0-dev.1",
+      "version": "3.0.0-dev.2",
       "license": "BSD-3-Clause",
       "workspaces": [
         "./src/compiler"
@@ -3559,7 +3559,7 @@
     },
     "src/compiler": {
       "name": "@bokeh/compiler",
-      "version": "3.0.0-dev.1",
+      "version": "3.0.0-dev.2",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@types/combine-source-map": "^0.8.2",
@@ -3592,7 +3592,7 @@
     },
     "src/lib": {
       "name": "@bokeh/lib",
-      "version": "3.0.0-dev.1",
+      "version": "3.0.0-dev.2",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@bokeh/numbro": "^1.6.2",
@@ -3619,7 +3619,7 @@
     },
     "test": {
       "name": "@bokeh/test",
-      "version": "3.0.0-dev.1",
+      "version": "3.0.0-dev.2",
       "license": "BSD-3-Clause",
       "workspaces": [
         "./src/lib"

--- a/bokehjs/src/lib/models/graphs/graph_hit_test_policy.ts
+++ b/bokehjs/src/lib/models/graphs/graph_hit_test_policy.ts
@@ -363,3 +363,96 @@ export class NodesAndAdjacentNodes extends GraphHitTestPolicy {
     return !node_inspection.is_empty()
   }
 }
+
+export namespace NodesAndLinkedEdgesAndLinkedNodes {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = GraphHitTestPolicy.Props
+}
+
+export interface NodesAndLinkedEdgesAndLinkedNodes extends NodesAndLinkedEdgesAndLinkedNodes.Attrs {}
+
+export class NodesAndLinkedEdgesAndLinkedNodes extends GraphHitTestPolicy {
+  override properties: NodesAndLinkedEdgesAndLinkedNodes.Props
+
+  constructor(attrs?: Partial<NodesAndLinkedEdgesAndLinkedNodes.Attrs>) {
+    super(attrs)
+  }
+
+  hit_test(geometry: Geometry, graph_view: GraphRendererView): HitTestResult {
+    return this._hit_test(geometry, graph_view, graph_view.node_view)
+  }
+
+  get_linked_edges(node_source: ColumnarDataSource, edge_source: ColumnarDataSource, mode: string): Selection {
+    let node_indices = []
+    if (mode == "selection") {
+      node_indices = node_source.selected.indices.map((i) => node_source.data.index[i])
+    } else if (mode == "inspection") {
+      node_indices = node_source.inspected.indices.map((i) => node_source.data.index[i])
+    }
+    const edge_indices = []
+    for (let i = 0; i < edge_source.data.start.length; i++) {
+      if (contains(node_indices, edge_source.data.start[i]) || contains(node_indices, edge_source.data.end[i]))
+        edge_indices.push(i)
+    }
+
+    const linked_edges = new Selection()
+    for (const i of edge_indices) {
+      linked_edges.multiline_indices[i] = [0] //currently only supports 2-element multilines, so this is all of it
+    }
+    linked_edges.indices = edge_indices
+
+    return linked_edges
+  }
+
+  get_linked_nodes(node_source: ColumnarDataSource, edge_source: ColumnarDataSource, mode: string): Selection {
+    let edge_indices: number[] = []
+    if (mode == "selection")
+      edge_indices = edge_source.selected.indices
+    else if (mode == "inspection")
+      edge_indices = edge_source.inspected.indices
+    const nodes = []
+    for (const i of edge_indices) {
+      nodes.push(edge_source.data.start[i])
+      nodes.push(edge_source.data.end[i])
+    }
+
+    const node_indices = uniq(nodes).map((i) => indexOf(node_source.data.index, i))
+    return new Selection({indices: node_indices})
+  }
+
+  do_selection(hit_test_result: HitTestResult, graph: GraphRenderer, final: boolean, mode: SelectionMode): boolean {
+    if (hit_test_result == null)
+      return false
+
+    const node_selection = graph.node_renderer.data_source.selected
+    node_selection.update(hit_test_result, final, mode)
+
+    const edge_selection = graph.edge_renderer.data_source.selected
+    const linked_edges_selection = this.get_linked_edges(graph.node_renderer.data_source, graph.edge_renderer.data_source, "selection")
+    edge_selection.update(linked_edges_selection, final, mode)
+
+    graph.node_renderer.data_source._select.emit()
+
+    return !node_selection.is_empty()
+  }
+
+  do_inspection(hit_test_result: HitTestResult, geometry: Geometry, graph_view: GraphRendererView, final: boolean, mode: SelectionMode): boolean {
+    if (hit_test_result == null)
+      return false
+
+    const node_inspection = graph_view.node_view.model.data_source.selection_manager.get_or_create_inspector(graph_view.node_view.model)
+    node_inspection.update(hit_test_result, final, mode)
+    graph_view.node_view.model.data_source.setv({inspected: node_inspection}, {silent: true})
+
+    const edge_inspection = graph_view.edge_view.model.data_source.selection_manager.get_or_create_inspector(graph_view.edge_view.model)
+    const linked_edges = this.get_linked_edges(graph_view.node_view.model.data_source, graph_view.edge_view.model.data_source, "inspection")
+    edge_inspection.update(linked_edges, final, mode)
+
+    //silently set inspected attr to avoid triggering data_source.change event and rerender
+    graph_view.edge_view.model.data_source.setv({inspected: edge_inspection}, {silent: true})
+    graph_view.node_view.model.data_source.inspect.emit([graph_view.node_view.model, {geometry}])
+
+    return !node_inspection.is_empty()
+  }
+}

--- a/bokehjs/test/unit/models/graphs/graph_hit_test_policy.ts
+++ b/bokehjs/test/unit/models/graphs/graph_hit_test_policy.ts
@@ -401,7 +401,7 @@ describe("GraphHitTestPolicy", () => {
         edge_source.selected = initial_selection
 
         const hit_test_result = new Selection()
-        const policy = new NodesAndLinkedEdges()
+        const policy = new NodesAndLinkedEdgesAndLinkedNodes()
         policy.do_selection(hit_test_result, gr, true, "replace")
 
         expect(edge_source.selected.is_empty()).to.be.true
@@ -409,7 +409,7 @@ describe("GraphHitTestPolicy", () => {
 
       it("should select linked edges if hit_test_result is not empty", () => {
         const hit_test_result = new Selection({indices: [0]})
-        const policy = new NodesAndLinkedEdges()
+        const policy = new NodesAndLinkedEdgesAndLinkedNodes()
 
         policy.do_selection(hit_test_result, gr, true, "replace")
 
@@ -422,20 +422,20 @@ describe("GraphHitTestPolicy", () => {
         node_source.selected = initial_selection
 
         const hit_test_result = new Selection()
-        const policy = new EdgesAndLinkedNodes()
+        const policy = new NodesAndLinkedEdgesAndLinkedNodes()
         policy.do_selection(hit_test_result, gr, true, "replace")
 
         expect(node_source.selected.is_empty()).to.be.true
       })
 
-      it("should select linked nodes if hit_test_result is not empty", () => {
-        const hit_test_result = new Selection()
-        hit_test_result.indices = [1]
+      it("should inspect adjacent nodes if hit_test_result is not empty", () => {
+        const hit_test_result = new Selection({indices: [1]})
 
-        const policy = new EdgesAndLinkedNodes()
-        policy.do_selection(hit_test_result, gr, true, "replace")
+        const policy = new NodesAndLinkedEdgesAndLinkedNodes()
+        const did_hit = policy.do_inspection(hit_test_result, {type: "point", sx: 0, sy: 0}, gv, true, "replace")
 
-        expect(node_source.selected.indices).to.be.equal([0, 2])
+        expect(did_hit).to.be.true
+        expect(node_source.inspected.indices).to.be.equal([0, 2, 1])
       })
     })
 
@@ -448,7 +448,7 @@ describe("GraphHitTestPolicy", () => {
         edge_source.inspected = initial_inspection
 
         const hit_test_result = new Selection()
-        const policy = new NodesAndLinkedEdges()
+        const policy = new NodesAndLinkedEdgesAndLinkedNodes()
         const did_hit = policy.do_inspection(hit_test_result, {type: "point", sx: 0, sy: 0}, gv, true, "replace")
 
         expect(did_hit).to.be.false
@@ -457,7 +457,7 @@ describe("GraphHitTestPolicy", () => {
 
       it("should select linked edges if hit_test_result is not empty", () => {
         const hit_test_result = new Selection({indices: [0]})
-        const policy = new NodesAndLinkedEdges()
+        const policy = new NodesAndLinkedEdgesAndLinkedNodes()
         const did_hit = policy.do_inspection(hit_test_result, {type: "point", sx: 0, sy: 0}, gv, true, "replace")
 
         expect(did_hit).to.be.true
@@ -469,22 +469,21 @@ describe("GraphHitTestPolicy", () => {
         node_source.inspected = initial_inspection
 
         const hit_test_result = new Selection()
-        const policy = new EdgesAndLinkedNodes()
+        const policy = new NodesAndLinkedEdgesAndLinkedNodes()
         const did_hit = policy.do_inspection(hit_test_result, {type: "point", sx: 0, sy: 0}, gv, true, "replace")
 
         expect(did_hit).to.be.false
         expect(node_source.inspected.is_empty()).to.be.true
       })
 
-      it("should inspect linked nodes if hit_test_result is not empty", () => {
-        const hit_test_result = new Selection()
-        hit_test_result.indices = [1]
+      it("should inspect adjacent nodes if hit_test_result is not empty", () => {
+        const hit_test_result = new Selection({indices: [1]})
 
-        const policy = new EdgesAndLinkedNodes()
+        const policy = new NodesAndLinkedEdgesAndLinkedNodes()
         const did_hit = policy.do_inspection(hit_test_result, {type: "point", sx: 0, sy: 0}, gv, true, "replace")
 
         expect(did_hit).to.be.true
-        expect(node_source.inspected.indices).to.be.equal([0, 2])
+        expect(node_source.inspected.indices).to.be.equal([0, 2, 1])
       })
     })
   })

--- a/bokehjs/test/unit/models/graphs/graph_hit_test_policy.ts
+++ b/bokehjs/test/unit/models/graphs/graph_hit_test_policy.ts
@@ -7,7 +7,7 @@ import {Range1d} from "@bokehjs/models/ranges/range1d"
 
 import {Circle} from "@bokehjs/models/glyphs/circle"
 import {MultiLine} from "@bokehjs/models/glyphs/multi_line"
-import {EdgesOnly, NodesOnly, NodesAndLinkedEdges, EdgesAndLinkedNodes, NodesAndAdjacentNodes} from "@bokehjs/models/graphs/graph_hit_test_policy"
+import {EdgesOnly, NodesOnly, NodesAndLinkedEdges, EdgesAndLinkedNodes, NodesAndLinkedEdgesAndLinkedNodes, NodesAndAdjacentNodes} from "@bokehjs/models/graphs/graph_hit_test_policy"
 import {LayoutProvider} from "@bokehjs/models/graphs/layout_provider"
 import {GlyphRenderer} from "@bokehjs/models/renderers/glyph_renderer"
 import {GraphRenderer, GraphRendererView} from "@bokehjs/models/renderers/graph_renderer"
@@ -386,6 +386,105 @@ describe("GraphHitTestPolicy", () => {
 
         expect(did_hit).to.be.true
         expect(node_source.inspected.indices).to.be.equal([0, 2, 1])
+      })
+    })
+  })
+
+  describe("NodesAndLinkedEdgesAndLinkedNodes", () => {
+
+    describe("do_selection method", () => {
+
+      it("should clear edge selections if hit_test_result is empty", () => {
+        // create initial inspection to clear
+        const initial_selection = new Selection()
+        initial_selection.multiline_indices = {0: [0, 1], 1: [0]}
+        edge_source.selected = initial_selection
+
+        const hit_test_result = new Selection()
+        const policy = new NodesAndLinkedEdges()
+        policy.do_selection(hit_test_result, gr, true, "replace")
+
+        expect(edge_source.selected.is_empty()).to.be.true
+      })
+
+      it("should select linked edges if hit_test_result is not empty", () => {
+        const hit_test_result = new Selection({indices: [0]})
+        const policy = new NodesAndLinkedEdges()
+
+        policy.do_selection(hit_test_result, gr, true, "replace")
+
+        expect(edge_source.selected.multiline_indices).to.be.equal({0: [ 0 ], 1: [ 0 ]})
+      })
+
+      it("should clear node selections if hit_test result is empty", () => {
+        const initial_selection = new Selection()
+        initial_selection.indices = [0, 1]
+        node_source.selected = initial_selection
+
+        const hit_test_result = new Selection()
+        const policy = new EdgesAndLinkedNodes()
+        policy.do_selection(hit_test_result, gr, true, "replace")
+
+        expect(node_source.selected.is_empty()).to.be.true
+      })
+
+      it("should select linked nodes if hit_test_result is not empty", () => {
+        const hit_test_result = new Selection()
+        hit_test_result.indices = [1]
+
+        const policy = new EdgesAndLinkedNodes()
+        policy.do_selection(hit_test_result, gr, true, "replace")
+
+        expect(node_source.selected.indices).to.be.equal([0, 2])
+      })
+    })
+
+    describe("do_inspection method", () => {
+
+      it("should clear edge inspections if hit_test_result is empty", () => {
+        // create initial inspection to clear
+        const initial_inspection = new Selection()
+        initial_inspection.multiline_indices = {0: [0, 1], 1: [0]}
+        edge_source.inspected = initial_inspection
+
+        const hit_test_result = new Selection()
+        const policy = new NodesAndLinkedEdges()
+        const did_hit = policy.do_inspection(hit_test_result, {type: "point", sx: 0, sy: 0}, gv, true, "replace")
+
+        expect(did_hit).to.be.false
+        expect(edge_source.inspected.is_empty()).to.be.true
+      })
+
+      it("should select linked edges if hit_test_result is not empty", () => {
+        const hit_test_result = new Selection({indices: [0]})
+        const policy = new NodesAndLinkedEdges()
+        const did_hit = policy.do_inspection(hit_test_result, {type: "point", sx: 0, sy: 0}, gv, true, "replace")
+
+        expect(did_hit).to.be.true
+        expect(edge_source.inspected.multiline_indices).to.be.equal({0: [ 0 ], 1: [ 0 ]})
+      })
+
+      it("should clear node inspections if hit_test_result is empty", () => {
+        const initial_inspection = new Selection({indices: [0, 1]})
+        node_source.inspected = initial_inspection
+
+        const hit_test_result = new Selection()
+        const policy = new EdgesAndLinkedNodes()
+        const did_hit = policy.do_inspection(hit_test_result, {type: "point", sx: 0, sy: 0}, gv, true, "replace")
+
+        expect(did_hit).to.be.false
+        expect(node_source.inspected.is_empty()).to.be.true
+      })
+
+      it("should inspect linked nodes if hit_test_result is not empty", () => {
+        const hit_test_result = new Selection()
+        hit_test_result.indices = [1]
+
+        const policy = new EdgesAndLinkedNodes()
+        const did_hit = policy.do_inspection(hit_test_result, {type: "point", sx: 0, sy: 0}, gv, true, "replace")
+
+        expect(did_hit).to.be.true
+        expect(node_source.inspected.indices).to.be.equal([0, 2])
       })
     })
   })

--- a/examples/models/file/graphs.py
+++ b/examples/models/file/graphs.py
@@ -12,8 +12,8 @@ import networkx as nx
 
 from bokeh.io import curdoc, show
 from bokeh.models import (BoxSelectTool, Circle, Column, EdgesAndLinkedNodes,
-                          HoverTool, MultiLine, NodesAndAdjacentNodes, 
-                          NodesAndLinkedEdges, NodesAndLinkedEdgesAndLinkedNodes, 
+                          HoverTool, MultiLine, NodesAndAdjacentNodes,
+                          NodesAndLinkedEdges, NodesAndLinkedEdgesAndLinkedNodes,
                           Plot, Range1d, Row, TapTool)
 from bokeh.palettes import Spectral4
 from bokeh.plotting import from_networkx

--- a/examples/models/file/graphs.py
+++ b/examples/models/file/graphs.py
@@ -71,8 +71,8 @@ plot_7 = create_graph(nx.circular_layout, inspection_policy=NodesAndLinkedEdgesA
 plot_7.title.text = "Circular Layout (NodesAndLinkedEdgesAndLinkedNodes inspection policy)"
 plot_7.add_tools(HoverTool(tooltips=None))
 
-plot_8 = create_graph(nx.spring_layout, selection_policy=NodesAndLinkedEdgesAndLinkedNodes(), scale=2, center=(0,0))
-plot_8.title.text = "Spring Layout (NodesAndLinkedEdgesAndLinkedNodes selection policy)"
+plot_8 = create_graph(nx.fruchterman_reingold_layout, selection_policy=NodesAndLinkedEdgesAndLinkedNodes(), scale=2, center=(0,0), dim=2)
+plot_8.title.text = "FR Layout (NodesAndLinkedEdgesAndLinkedNodes selection policy)"
 plot_8.add_tools(TapTool(), BoxSelectTool())
 
 layout = Column(Row(plot_1, plot_2), Row(plot_3, plot_4), Row(plot_5, plot_6), Row(plot_7, plot_8))

--- a/examples/models/file/graphs.py
+++ b/examples/models/file/graphs.py
@@ -12,8 +12,9 @@ import networkx as nx
 
 from bokeh.io import curdoc, show
 from bokeh.models import (BoxSelectTool, Circle, Column, EdgesAndLinkedNodes,
-                          HoverTool, MultiLine, NodesAndAdjacentNodes,
-                          NodesAndLinkedEdges, Plot, Range1d, Row, TapTool)
+                          HoverTool, MultiLine, NodesAndAdjacentNodes, 
+                          NodesAndLinkedEdges, NodesAndLinkedEdgesAndLinkedNodes, 
+                          Plot, Range1d, Row, TapTool)
 from bokeh.palettes import Spectral4
 from bokeh.plotting import from_networkx
 
@@ -66,7 +67,15 @@ plot_6 = create_graph(nx.fruchterman_reingold_layout, selection_policy=NodesAndA
 plot_6.title.text = "FR Layout (NodesAndAdjacentNodes selection policy)"
 plot_6.add_tools(TapTool())
 
-layout = Column(Row(plot_1, plot_2), Row(plot_3, plot_4), Row(plot_5, plot_6))
+plot_7 = create_graph(nx.circular_layout, inspection_policy=NodesAndLinkedEdgesAndLinkedNodes(), scale=1, center=(0,0))
+plot_7.title.text = "Circular Layout (NodesAndLinkedEdgesAndLinkedNodes inspection policy)"
+plot_7.add_tools(HoverTool(tooltips=None))
+
+plot_8 = create_graph(nx.spring_layout, selection_policy=NodesAndLinkedEdgesAndLinkedNodes(), scale=2, center=(0,0))
+plot_8.title.text = "Spring Layout (NodesAndLinkedEdgesAndLinkedNodes selection policy)"
+plot_8.add_tools(TapTool(), BoxSelectTool())
+
+layout = Column(Row(plot_1, plot_2), Row(plot_3, plot_4), Row(plot_5, plot_6), Row(plot_7, plot_8))
 
 doc = curdoc()
 doc.add_root(layout)


### PR DESCRIPTION
The NodesAndLinkedEdgesAndLinkedNodes policy highlights every edge leading in and out of a selected node, as well as highlights every adjacent node that is connected with the adjacent nodes. A single selection is highlighted with all connected edges adjacent nodes connected with the edges, with the selected node as the last entry to identify it from its adjacent nodes.  If a selected node does not have any edges, only that node is highlighted in the selection.

- [x] issues: fixes #9036 
- [x] tests added / passed
- [x] release document entry (if new feature or API change)
