### PR TITLE
Cap node version below v17

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -42,7 +42,7 @@ dependencies:
   - mypy >=0.920
   - nbconvert >=5.4
   - networkx
-  - nodejs >=14
+  - nodejs >=14, <17
   - numba
   - pandas
   - psutil


### PR DESCRIPTION
- [x] issues: workaround for #11911 

On a fresh environment this leaves me with node.js v16.13.0