### PR TITLE
add plot.remove_tools() method

### DIFF
--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -299,6 +299,23 @@ class Plot(LayoutDOM):
 
             self.toolbar.tools.append(tool)
 
+    def remove_tools(self, *tools: Tool) -> None:
+        ''' Removes tools from the plot.
+
+        Args:
+            *tools (Tool) : the tools to remove from the Plot
+
+        Returns:
+            None
+
+        '''
+        for tool in tools:
+            if not isinstance(tool, Tool):
+                raise ValueError("All arguments to remove_tool must be Tool subclasses.")
+            elif tool not in self.toolbar.tools:
+                raise ValueError(f"Invalid tool {tool} specified. Available tools are {nice_join(self.toolbar.tools)}")
+            self.toolbar.tools.remove(tool)
+
     @overload
     def add_glyph(self, glyph: Glyph, **kwargs: Any) -> GlyphRenderer: ...
     @overload

--- a/bokehjs/src/lib/models/plots/plot.ts
+++ b/bokehjs/src/lib/models/plots/plot.ts
@@ -252,8 +252,12 @@ export class Plot extends LayoutDOM {
   }
 
   remove_tools(...tools: Tool[]): void {
+    const {toolbar} = this
     for (const tool of tools) {
-      this.toolbar.tools.splice(this.toolbar.tools.indexOf(tool), 1)
+      if (toolbar.tools.includes(tool))
+        toolbar.tools.splice(toolbar.tools.indexOf(tool), 1)
+      else
+        throw new Error(`Invalid tool "${tool}" specified. Available tools are "${this.toolbar.tools.join(", ")}"`)
     }
 
   }

--- a/bokehjs/src/lib/models/plots/plot.ts
+++ b/bokehjs/src/lib/models/plots/plot.ts
@@ -251,6 +251,13 @@ export class Plot extends LayoutDOM {
     this.toolbar.tools = this.toolbar.tools.concat(tools)
   }
 
+  remove_tools(...tools: Tool[]): void {
+    for (const tool of tools) {
+      this.toolbar.tools.splice(this.toolbar.tools.indexOf(tool), 1)
+    }
+
+  }
+
   get panels(): (Annotation | Axis | Grid)[] {
     return [...this.side_panels, ...this.center]
   }

--- a/bokehjs/src/lib/models/plots/plot.ts
+++ b/bokehjs/src/lib/models/plots/plot.ts
@@ -252,14 +252,7 @@ export class Plot extends LayoutDOM {
   }
 
   remove_tools(...tools: Tool[]): void {
-    const {toolbar} = this
-    for (const tool of tools) {
-      if (toolbar.tools.includes(tool))
-        toolbar.tools.splice(toolbar.tools.indexOf(tool), 1)
-      else
-        throw new Error(`Invalid tool "${tool}" specified. Available tools are "${this.toolbar.tools.join(", ")}"`)
-    }
-
+    remove_by(this.toolbar.tools, (t) => tools.includes(t))
   }
 
   get panels(): (Annotation | Axis | Grid)[] {

--- a/bokehjs/test/unit/models/plots/plot.ts
+++ b/bokehjs/test/unit/models/plots/plot.ts
@@ -70,14 +70,6 @@ describe("Plot module", () => {
       const {tools} = plot.toolbar
       expect(tools.length).to.be.equal(0)
     })
-
-    it("should throw error when removing invalid tool", () => {
-      const {plot} = new_plot_with_tools()
-      const pan = new PanTool()
-
-      expect(() => plot.remove_tools(pan)).to.throw()
-
-    })
   })
 
 

--- a/bokehjs/test/unit/models/plots/plot.ts
+++ b/bokehjs/test/unit/models/plots/plot.ts
@@ -9,6 +9,7 @@ import {build_view} from "@bokehjs/core/build_views"
 import {Place} from "@bokehjs/core/enums"
 import {GraphRenderer, GraphRendererView} from "@bokehjs/models/renderers/graph_renderer"
 import {GlyphRenderer, GlyphRendererView} from "@bokehjs/models/renderers/glyph_renderer"
+import {ResetTool, PanTool, Toolbar} from "@bokehjs/models"
 import {Rect, Circle, MultiLine} from "@bokehjs/models/glyphs"
 import {ColumnDataSource} from "@bokehjs/models/sources"
 import {StaticLayoutProvider} from "@bokehjs/models/graphs"
@@ -25,7 +26,43 @@ async function new_plot_view(attrs: Partial<Plot.Attrs> = {}): Promise<PlotView>
 describe("Plot module", () => {
 
   describe("Plot", () => {
+    it("should add single tool using add_tools method", () => {
+      const plot = new Plot()
+      const reset = new ResetTool()
+      const pan = new PanTool()
+
+      plot.add_tools(reset, pan)
+
+      const {tools} = plot.toolbar
+      expect(tools.length).to.be.equal(2)
+      expect(tools[0]).to.be.identical(reset)
+      expect(tools[1]).to.be.identical(pan)
+    })
+
+    it("should remove a single tool using remove_tools method", () => {
+      const reset = new ResetTool()
+      const pan = new PanTool()
+      const plot = new Plot({toolbar: new Toolbar({tools: [reset, pan]})})
+
+      plot.remove_tools(pan)
+
+      const {tools} = plot.toolbar
+      expect(tools.length).to.be.equal(1)
+      expect(tools[0]).to.be.identical(reset)
+    })
+
+    it("should remove all tools using remove_tools method", () => {
+      const reset = new ResetTool()
+      const pan = new PanTool()
+      const plot = new Plot({toolbar: new Toolbar({tools: [reset, pan]})})
+
+      plot.remove_tools(pan, reset)
+
+      const {tools} = plot.toolbar
+      expect(tools.length).to.be.equal(0)
+    })
   })
+
 
   describe("PlotView", () => {
     it("should allow to resolve child renderers of its composite renderers", async () => {

--- a/bokehjs/test/unit/models/plots/plot.ts
+++ b/bokehjs/test/unit/models/plots/plot.ts
@@ -42,14 +42,12 @@ describe("Plot module", () => {
     it("should add single tool using add_tools method", () => {
       const plot = new Plot()
       const reset = new ResetTool()
-      const pan = new PanTool()
 
-      plot.add_tools(reset, pan)
+      plot.add_tools(reset)
 
       const {tools} = plot.toolbar
-      expect(tools.length).to.be.equal(2)
+      expect(tools.length).to.be.equal(1)
       expect(tools[0]).to.be.identical(reset)
-      expect(tools[1]).to.be.identical(pan)
     })
 
     it("should remove a single tool using remove_tools method", () => {

--- a/bokehjs/test/unit/models/plots/plot.ts
+++ b/bokehjs/test/unit/models/plots/plot.ts
@@ -23,6 +23,19 @@ async function new_plot_view(attrs: Partial<Plot.Attrs> = {}): Promise<PlotView>
   return (await build_view(plot)).build()
 }
 
+interface PlotWithTools {
+  plot: Plot
+  reset: ResetTool
+  pan: PanTool
+}
+
+function new_plot_with_tools(): PlotWithTools {
+  const reset = new ResetTool()
+  const pan = new PanTool()
+  const plot = new Plot({toolbar: new Toolbar({tools: [reset, pan]})})
+  return {plot, reset, pan}
+}
+
 describe("Plot module", () => {
 
   describe("Plot", () => {
@@ -40,9 +53,7 @@ describe("Plot module", () => {
     })
 
     it("should remove a single tool using remove_tools method", () => {
-      const reset = new ResetTool()
-      const pan = new PanTool()
-      const plot = new Plot({toolbar: new Toolbar({tools: [reset, pan]})})
+      const {plot, reset, pan} = new_plot_with_tools()
 
       plot.remove_tools(pan)
 
@@ -52,14 +63,20 @@ describe("Plot module", () => {
     })
 
     it("should remove all tools using remove_tools method", () => {
-      const reset = new ResetTool()
-      const pan = new PanTool()
-      const plot = new Plot({toolbar: new Toolbar({tools: [reset, pan]})})
+      const {plot, reset, pan} = new_plot_with_tools()
 
       plot.remove_tools(pan, reset)
 
       const {tools} = plot.toolbar
       expect(tools.length).to.be.equal(0)
+    })
+
+    it("should throw error when removing invalid tool", () => {
+      const {plot} = new_plot_with_tools()
+      const pan = new PanTool()
+
+      expect(() => plot.remove_tools(pan)).to.throw()
+
     })
   })
 

--- a/sphinx/source/docs/first_steps/first_steps_4.rst
+++ b/sphinx/source/docs/first_steps/first_steps_4.rst
@@ -386,8 +386,8 @@ toolbar:
 .. bokeh-plot:: docs/first_steps/examples/first_steps_4_tools.py
     :source-position: none
 
-To change the available tools at any time after creating your figure, you need
-to use the :func:`~bokeh.models.plots.Plot.add_tools` function.
+To change the available tools at any time after creating your figure,
+use the :func:`~bokeh.models.plots.Plot.add_tools` and :func:`~bokeh.models.plots.Plot.remove_tools` functions.
 
 All tools also offer various properties to define how they can be used. With the
 :class:`~bokeh.models.tools.PanTool`, for example, you can limit the movement to

--- a/sphinx/source/docs/releases/3.0.0.rst
+++ b/sphinx/source/docs/releases/3.0.0.rst
@@ -8,6 +8,7 @@ Bokeh Version ``3.0.0`` () is a major milestone of Bokeh project.
 * Support added for favicon.ico files
 * Initial import times reduced
 * Support added for new selection policy NodesAndAdjacentNodes
+* Plot.remove_tools() function added
 
 .. _release-3-0-0-migration:
 

--- a/sphinx/source/docs/user_guide/tools.rst
+++ b/sphinx/source/docs/user_guide/tools.rst
@@ -77,9 +77,13 @@ passing instances of ``Tool`` objects to the ``add_tools()`` method:
 
 .. code-block:: python
 
+    from bokeh.models import LassoSelectTool, Plot, WheelZoomTool
+
     plot = Plot()
     plot.add_tools(LassoSelectTool())
-    plot.add_tools(WheelZoomTool())
+
+    wheel = WheelZoomTool()
+    plot.add_tools(wheel)
 
 This way of adding tools works with any Bokeh ``Plot`` or ``Plot`` subclass,
 such as ``Figure``.
@@ -89,27 +93,33 @@ function. The tools parameter accepts a list of tool objects, for example:
 
 .. code-block:: python
 
-    tools = [BoxZoomTool(), ResetTool()]
+    from bokeh.models import BoxZoomTool, ResetTool
+    from bokeh.plotting import figure
+
+    plot = figure(tools=[BoxZoomTool(), ResetTool()])
 
 You can also add multiple tools with a comma-separated string
 containing tool shortcut names:
 
 .. code-block:: python
 
-    tools = "pan,wheel_zoom,box_zoom,reset"
+    from bokeh.plotting import figure
+
+    plot = figure(tools="pan,wheel_zoom,box_zoom,reset")
 
 This method does not allow setting properties of the tools.
 
-Finally, you can add new tools to a plot by passing a tool object
-to the ``add_tools()`` method of a plot. You can combine the add_tools()
-method with the figure() function's tools argument:
+Remove tools by passing a tool object to the ``remove_tools()`` method of a plot.
 
 .. code-block:: python
 
-    from bokeh.models import BoxSelectTool
+    from bokeh.models import BoxSelectTool, WheelZoomTool
+    from bokeh.plotting import figure
 
-    plot = figure(tools="pan,wheel_zoom,box_zoom,reset")
-    plot.add_tools(BoxSelectTool(dimensions="width"))
+    tools = box, wheel = BoxSelectTool(dimensions="width"), WheelZoomTool()
+    plot = figure(tools=tools)
+
+    plot.remove_tools(box)
 
 .. _userguide_tools_customize_tools_icon:
 

--- a/tests/unit/bokeh/models/test_plots.py
+++ b/tests/unit/bokeh/models/test_plots.py
@@ -39,6 +39,7 @@ from bokeh.models import (
     PanTool,
     Plot,
     Range1d,
+    ResetTool,
     Title,
     WMTSTileSource,
 )
@@ -372,6 +373,58 @@ def test_add_tile_tilesource():
     assert tile_source.url == mapnik.build_url()
     assert tile_source.attribution == mapnik.html_attribution
 
+def test_add_tools_single():
+    plot = Plot()
+    assert len(plot.tools) == 0
+
+    tool = PanTool()
+    plot.add_tools(tool)
+    assert plot.tools[0] == tool
+
+def test_add_tools_multiple():
+    plot = Plot()
+    first_tool = PanTool()
+    second_tool = ResetTool()
+
+    plot.add_tools(first_tool, second_tool)
+    assert plot.tools[0] == first_tool
+    assert plot.tools[1] == second_tool
+
+def test_add_tools_invalid():
+    plot = Plot()
+
+    with pytest.raises(ValueError) as e:
+        plot.add_tools("not a tool")
+        assert str(e.value) == "ValueError: All arguments to add_tool must be Tool subclasses."
+
+def test_remove_tools_single():
+    first_tool = PanTool()
+    second_tool = ResetTool()
+    plot=Plot(tools=[first_tool, second_tool])
+    assert plot.tools[0] == first_tool
+    assert plot.tools[1] == second_tool
+
+    plot.remove_tools(first_tool)
+    assert len(plot.tools) == 1
+    assert plot.tools[0] == second_tool
+
+def test_remove_tools_multiple():
+    first_tool = PanTool()
+    second_tool = ResetTool()
+    plot=Plot(tools=[first_tool, second_tool])
+
+    plot.remove_tools(first_tool, second_tool)
+    assert len(plot.tools) == 0
+
+def test_remove_tools_invalid():
+    first_tool = PanTool()
+    second_tool = ResetTool()
+    third_tool = PanTool()
+    plot=Plot(tools=[first_tool, second_tool])
+
+    with pytest.raises(ValueError) as e:
+        plot.remove_tools(third_tool)
+        assert str(e.value).startswith("ValueError: Invalid tool PanTool")
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/models/test_plots.py
+++ b/tests/unit/bokeh/models/test_plots.py
@@ -18,6 +18,7 @@ import pytest ; pytest
 
 # Standard library imports
 from math import isnan
+from typing import Tuple
 
 # External imports
 import mock
@@ -57,6 +58,13 @@ You are attempting to set `plot.legend.location` on a plot that has zero legends
 
 Before legend properties can be set, you must add a Legend explicitly, or call a glyph method with a legend parameter set.
 """
+
+def create_plot_and_tools(prefilled: bool = False) -> Tuple[Plot, PanTool, ResetTool]:
+    if prefilled:
+        pan = PanTool()
+        reset = ResetTool()
+        return (Plot(tools=[pan, reset]), pan, reset)
+    return (Plot(), PanTool(), ResetTool())
 
 #-----------------------------------------------------------------------------
 # General API
@@ -374,17 +382,14 @@ def test_add_tile_tilesource():
     assert tile_source.attribution == mapnik.html_attribution
 
 def test_add_tools_single():
-    plot = Plot()
+    plot, first_tool, _ = create_plot_and_tools()
     assert len(plot.tools) == 0
 
-    tool = PanTool()
-    plot.add_tools(tool)
-    assert plot.tools[0] == tool
+    plot.add_tools(first_tool)
+    assert plot.tools[0] == first_tool
 
 def test_add_tools_multiple():
-    plot = Plot()
-    first_tool = PanTool()
-    second_tool = ResetTool()
+    plot, first_tool, second_tool = create_plot_and_tools()
 
     plot.add_tools(first_tool, second_tool)
     assert plot.tools[0] == first_tool
@@ -398,29 +403,21 @@ def test_add_tools_invalid():
         assert str(e.value) == "ValueError: All arguments to add_tool must be Tool subclasses."
 
 def test_remove_tools_single():
-    first_tool = PanTool()
-    second_tool = ResetTool()
-    plot=Plot(tools=[first_tool, second_tool])
-    assert plot.tools[0] == first_tool
-    assert plot.tools[1] == second_tool
+    plot, first_tool, second_tool = create_plot_and_tools(prefilled=True)
 
     plot.remove_tools(first_tool)
     assert len(plot.tools) == 1
     assert plot.tools[0] == second_tool
 
 def test_remove_tools_multiple():
-    first_tool = PanTool()
-    second_tool = ResetTool()
-    plot=Plot(tools=[first_tool, second_tool])
+    plot, first_tool, second_tool = create_plot_and_tools(prefilled=True)
 
     plot.remove_tools(first_tool, second_tool)
     assert len(plot.tools) == 0
 
 def test_remove_tools_invalid():
-    first_tool = PanTool()
-    second_tool = ResetTool()
+    (plot, *_) = create_plot_and_tools(prefilled=True)
     third_tool = PanTool()
-    plot=Plot(tools=[first_tool, second_tool])
 
     with pytest.raises(ValueError) as e:
         plot.remove_tools(third_tool)


### PR DESCRIPTION
- [x] issues: fixes #11908 
- [x] tests added / passed
- [x] update docs (first steps, tools)
- [x] release document entry (if new feature or API change)

Notes:
- Added tests for `add_tools()` as well
- `add_tools()` was demonstrated twice in the docs, so replaced the latter with a demonstration of `remove_tools()`
- Added imports to the docs for additional clarity