### PR TITLE
Require nodejs 16.* LTS for dev and testing

### DIFF
--- a/.github/workflows/bokeh-release-build.yml
+++ b/.github/workflows/bokeh-release-build.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install NPM
         shell: bash -l {0}
-        run: npm install -g npm@7
+        run: npm install -g npm@8
 
       - name: Build Release Tarball
         shell: bash -l {0}

--- a/.github/workflows/bokehjs-ci.yml
+++ b/.github/workflows/bokehjs-ci.yml
@@ -21,7 +21,7 @@ jobs:
       max-parallel: 3
       matrix:
         os: [ubuntu-20.04, macos-latest, windows-latest]
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
       - name: Checkout the repository
@@ -35,7 +35,7 @@ jobs:
       - name: Upgrade npm
         shell: bash
         run: |
-          npm install -g npm@7
+          npm install -g npm@8
 
       - name: Install chromium
         if: runner.os == 'Linux'

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/bokeh/bokeh.git"
   },
   "engines": {
-    "node": ">=14",
-    "npm": ">=7.4"
+    "node": ">=16.0",
+    "npm": ">=8.0"
   },
   "files": [
     "build/js/bokeh*.min.js",

--- a/ci/environment-build.yml
+++ b/ci/environment-build.yml
@@ -6,7 +6,7 @@ dependencies:
   - conda-build=3.21.7
   - conda-verify=3.4.2
   - libiconv
-  - nodejs 14.*
+  - nodejs 16.*
   - ripgrep=0.10.0
   - setuptools
   - yaml

--- a/ci/environment-release-build.yml
+++ b/ci/environment-release-build.yml
@@ -21,7 +21,7 @@ dependencies:
   - conda-build=3.21.7
   - conda-verify=3.4.2
   - libiconv
-  - nodejs 14.*
+  - nodejs 16.*
   - ripgrep=0.10.0
   - setuptools
   - yaml

--- a/ci/environment-release-deploy.yml
+++ b/ci/environment-release-deploy.yml
@@ -8,7 +8,7 @@ dependencies:
   - anaconda-client
   - boto
   - colorama
-  - nodejs 14.*
+  - nodejs 16.*
   - setuptools
   - twine
   - yaml

--- a/ci/environment-test-3.10.yml
+++ b/ci/environment-test-3.10.yml
@@ -34,7 +34,7 @@ dependencies:
   - pandas-stubs
   - nbconvert >=5.4
   - networkx
-  - nodejs 14.*
+  - nodejs 16.*
   - pandas
   - psutil
   - pydot

--- a/ci/environment-test-3.7.yml
+++ b/ci/environment-test-3.7.yml
@@ -34,7 +34,7 @@ dependencies:
   - pandas-stubs
   - nbconvert >=5.4
   - networkx
-  - nodejs 14.*
+  - nodejs 16.*
   - pandas
   - psutil
   - pydot

--- a/ci/environment-test-3.8.yml
+++ b/ci/environment-test-3.8.yml
@@ -34,7 +34,7 @@ dependencies:
   - pandas-stubs
   - nbconvert >=5.4
   - networkx
-  - nodejs 14.*
+  - nodejs 16.*
   - pandas
   - psutil
   - pydot

--- a/ci/environment-test-3.9.yml
+++ b/ci/environment-test-3.9.yml
@@ -34,7 +34,7 @@ dependencies:
   - pandas-stubs
   - nbconvert >=5.4
   - networkx
-  - nodejs 14.*
+  - nodejs 16.*
   - pandas
   - psutil
   - pydot

--- a/ci/install_node_modules.sh
+++ b/ci/install_node_modules.sh
@@ -3,7 +3,7 @@
 set -x #echo on
 
 pushd bokehjs
-npm install -g npm@7
+npm install -g npm@8
 npm ci --no-progress
 node make examples --no-build
 popd

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -20,7 +20,7 @@ extra:
 requirements:
   build:
     - jinja2
-    - nodejs >=14
+    - nodejs 16.*
     - numpy
     - packaging
     - python

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
 
   # build
   - setuptools
-  - nodejs>=14
+  - nodejs 16.*
   - yaml
 
   # runtime
@@ -42,7 +42,7 @@ dependencies:
   - mypy >=0.920
   - nbconvert >=5.4
   - networkx
-  - nodejs >=14, <17
+  - nodejs 16.*
   - numba
   - pandas
   - psutil

--- a/sphinx/source/docs/dev_guide/setup.rst
+++ b/sphinx/source/docs/dev_guide/setup.rst
@@ -126,7 +126,7 @@ directory, and run the following commands:
 .. code-block:: sh
 
     cd bokehjs
-    npm install -g npm@7
+    npm install -g npm@8
 
 If you do not want to install npm globally, leave out the ``-g`` flag. In this
 case, you need to adjust all subsequent ``npm`` commands to use the local


### PR DESCRIPTION
Upgrading to the most recent LTS version (which will be valid until October 2022). Also requires npm@8 for the sake of consistency.