### PR TITLE
Fix gmaps' support and remove special handling

### DIFF
--- a/bokeh/models/map_plots.py
+++ b/bokeh/models/map_plots.py
@@ -176,6 +176,8 @@ class GMapPlot(MapPlot):
 
     border_fill_color = Override(default="#ffffff")
 
+    background_fill_alpha = Override(default=0.0)
+
     api_key = NonNullable(Base64String, help="""
     Google Maps API requires an API key. See https://developers.google.com/maps/documentation/javascript/get-api-key
     for more information on how to obtain your own.

--- a/bokeh/models/map_plots.py
+++ b/bokeh/models/map_plots.py
@@ -32,6 +32,7 @@ from ..core.properties import (
     Instance,
     Int,
     NonNullable,
+    Nullable,
     Override,
     String,
 )
@@ -112,7 +113,7 @@ class GMapOptions(MapOptions):
     Whether the Google map should display its distance scale control.
     """)
 
-    styles = NonNullable(JSON, help="""
+    styles = Nullable(JSON, default=None, help="""
     A JSON array of `map styles`_ to use for the ``GMapPlot``. Many example styles can
     `be found here`_.
 
@@ -180,7 +181,7 @@ class GMapPlot(MapPlot):
     for more information on how to obtain your own.
     """)
 
-    api_version = String(default="3.43", help="""
+    api_version = String(default="3.47", help="""
     The version of Google Maps API to use. See https://developers.google.com/maps/documentation/javascript/versions
     for more information.
 

--- a/bokehjs/src/lib/models/plots/gmap.ts
+++ b/bokehjs/src/lib/models/plots/gmap.ts
@@ -1,0 +1,33 @@
+import {GMapPlot, GMapPlotView} from "./gmap_plot"
+import {SerializableState} from "core/view"
+import * as p from "core/properties"
+
+export class GMapView extends GMapPlotView {
+  override model: GMap
+
+  // TODO: remove this before bokeh 3.0 and update *.blf files
+  override serializable_state(): SerializableState {
+    const state = super.serializable_state()
+    return {...state, type: "GMapPlot"}
+  }
+}
+
+export namespace GMap {
+  export type Attrs = p.AttrsOf<Props>
+  export type Props = GMapPlot.Props
+}
+
+export interface GMap extends GMap.Attrs {}
+
+export class GMap extends GMapPlot {
+  override properties: GMap.Props
+  override __view_type__: GMapView
+
+  constructor(attrs?: Partial<GMap.Attrs>) {
+    super(attrs)
+  }
+
+  static {
+    this.prototype.default_view = GMapView
+  }
+}

--- a/bokehjs/src/lib/models/plots/gmap_plot.ts
+++ b/bokehjs/src/lib/models/plots/gmap_plot.ts
@@ -101,6 +101,7 @@ export class GMapPlot extends Plot {
     this.override<GMapPlot.Props>({
       x_range: () => new Range1d(),
       y_range: () => new Range1d(),
+      background_fill_alpha: 0.0,
     })
   }
 }

--- a/bokehjs/src/lib/models/plots/gmap_plot.ts
+++ b/bokehjs/src/lib/models/plots/gmap_plot.ts
@@ -41,7 +41,7 @@ export namespace GMapOptions {
   export type Props = MapOptions.Props & {
     map_type: p.Property<string>
     scale_control: p.Property<boolean>
-    styles: p.Property<string>
+    styles: p.Property<string | null>
     tilt: p.Property<number>
   }
 }
@@ -56,11 +56,11 @@ export class GMapOptions extends MapOptions {
   }
 
   static {
-    this.define<GMapOptions.Props>(({Boolean, Int, String}) => ({
-      map_type:      [ MapType, "roadmap" ],
-      scale_control: [ Boolean, false     ],
-      styles:        [ String             ], // XXX: non-nullable, JSON
-      tilt:          [ Int,     45        ],
+    this.define<GMapOptions.Props>(({Boolean, Int, String, Nullable}) => ({
+      map_type:      [ MapType, "roadmap"],
+      scale_control: [ Boolean, false ],
+      styles:        [ Nullable(String), null ],
+      tilt:          [ Int, 45 ],
     }))
   }
 }
@@ -95,7 +95,7 @@ export class GMapPlot extends Plot {
     this.define<GMapPlot.Props>(({String, Ref}) => ({
       map_options: [ Ref(GMapOptions) ],
       api_key:     [ String ],
-      api_version: [ String, "3.43" ],
+      api_version: [ String, "3.47" ],
     }))
 
     this.override<GMapPlot.Props>({

--- a/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
@@ -22,7 +22,7 @@ declare global {
 }
 
 function has_maps_API(): boolean {
-  return typeof google == "undefined" || typeof google.maps == "undefined"
+  return typeof google != "undefined" && typeof google.maps != "undefined"
 }
 
 const gmaps_ready = new Signal0({}, "gmaps_ready")
@@ -70,7 +70,7 @@ export class GMapPlotView extends PlotView {
       logger.error(`api_key is required. See ${url} for more information on how to obtain your own.`)
     }
 
-    if (has_maps_API()) {
+    if (!has_maps_API()) {
       if (typeof window._bokeh_gmaps_callback === "undefined") {
         const {api_key, api_version} = this.model
         load_google_api(api_key, api_version)
@@ -157,7 +157,9 @@ export class GMapPlotView extends PlotView {
       tilt: mo.tilt,
     }
 
-    map_options.styles = JSON.parse(mo.styles)
+    if (mo.styles != null) {
+      map_options.styles = JSON.parse(mo.styles)
+    }
 
     // create the map with above options in div
     this.map_el = div({style: {position: "absolute"}})
@@ -247,7 +249,8 @@ export class GMapPlotView extends PlotView {
   }
 
   protected _update_styles(): void {
-    this.map.setOptions({styles: JSON.parse(this.model.map_options.styles)})
+    const {styles} = this.model.map_options
+    this.map.setOptions({styles: styles != null ? JSON.parse(styles) : null})
   }
 
   protected _update_zoom(): void {

--- a/bokehjs/src/lib/models/plots/index.ts
+++ b/bokehjs/src/lib/models/plots/index.ts
@@ -1,5 +1,6 @@
 export {MapOptions}     from "./gmap_plot"
 export {GMapOptions}    from "./gmap_plot"
 export {GMapPlot}       from "./gmap_plot"
+export {GMap}           from "./gmap"
 export {Plot}           from "./plot"
 export {Figure}         from "./figure"

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -665,7 +665,6 @@ export class PlotView extends LayoutDOMView implements Renderable {
       primary.prepare()
       this.canvas_view.prepare_webgl(frame_box)
 
-      this._map_hook(primary.ctx, frame_box)
       this._paint_empty(primary.ctx, frame_box)
       this._paint_outline(primary.ctx, frame_box)
 
@@ -727,8 +726,6 @@ export class PlotView extends LayoutDOMView implements Renderable {
       ctx.restore()
     }
   }
-
-  protected _map_hook(_ctx: Context2d, _frame_box: FrameBox): void {}
 
   protected _paint_empty(ctx: Context2d, frame_box: FrameBox): void {
     const [cx, cy, cw, ch] = [0, 0, this.layout.bbox.width, this.layout.bbox.height]

--- a/bokehjs/test/defaults/index.ts
+++ b/bokehjs/test/defaults/index.ts
@@ -142,7 +142,7 @@ function diff<T>(a: Set<T>, b: Set<T>): Set<T> {
 
 describe("Defaults", () => {
   const internal_models = new Set([
-    "Figure", "Canvas", "LinearInterpolationScale", "ScanningColorMapper",
+    "Figure", "GMap", "Canvas", "LinearInterpolationScale", "ScanningColorMapper",
     "ToolProxy", "CenterRotatable", "ButtonTool", "Spline",
   ])
 


### PR DESCRIPTION
GMaps' support was broken on multiple-levels by a few 3.0 PRs. This PR restores the support and removes any special handling of GMaps from `PlotCanvasView`.