### PR TITLE
Make `_may_have_unstable_defaults()` more robust

### DIFF
--- a/bokeh/core/property/bases.py
+++ b/bokeh/core/property/bases.py
@@ -492,7 +492,7 @@ class SingleParameterizedProperty(ParameterizedProperty[T]):
         return self.type_param.wrap(value)
 
     def _may_have_unstable_default(self) -> bool:
-        return self.type_param._may_have_unstable_default()
+        return super()._may_have_unstable_default() or self.type_param._may_have_unstable_default()
 
 class PrimitiveProperty(Property[T]):
     """ A base class for simple property types.
@@ -540,7 +540,7 @@ class ContainerProperty(ParameterizedProperty[T]):
 
     def _may_have_unstable_default(self) -> bool:
         # all containers are mutable, so the default can be modified
-        return True
+        return self._default is not Undefined
 
 def validation_on() -> bool:
     """ Check if property validation is currently active

--- a/bokeh/core/property/dataspec.py
+++ b/bokeh/core/property/dataspec.py
@@ -256,8 +256,10 @@ class NumberSpec(DataSpec):
         m.location = "foo" # field
 
     """
+    _value_type = Float
+
     def __init__(self, default=Undefined, help=None, key_type=_ExprFieldValueTransform, accept_datetime=True, accept_timedelta=True) -> None:
-        super().__init__(key_type, Float, default=default, help=help)
+        super().__init__(key_type, self._value_type, default=default, help=help)
         if accept_timedelta:
             self.accepts(TimeDelta, convert_timedelta_type)
         if accept_datetime:
@@ -481,6 +483,8 @@ class DistanceSpec(UnitsSpec):
         return super().prepare_value(cls, name, value)
 
 class NullDistanceSpec(DistanceSpec):
+
+    _value_type = Nullable(Float)
 
     def __init__(self, default=None, units_default="data", help=None) -> None:
         super().__init__(default=default, units_default=units_default, help=help)

--- a/bokeh/core/property/descriptors.py
+++ b/bokeh/core/property/descriptors.py
@@ -89,6 +89,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import types
 from copy import copy
 from typing import (
     TYPE_CHECKING,
@@ -477,7 +478,9 @@ class PropertyDescriptor(Generic[T]):
         if self.name in unstable_dict:
             return unstable_dict[self.name]
 
-        if self.property._may_have_unstable_default():
+        # _may_have_unstable_default() doesn't have access to overrides, so check manually
+        if self.property._may_have_unstable_default() or \
+                isinstance(obj.__class__.__overridden_defaults__.get(self.name, None), types.FunctionType):
             if isinstance(default, PropertyValueContainer):
                 default._register_owner(obj, self)
             unstable_dict[self.name] = default

--- a/bokeh/core/property/either.py
+++ b/bokeh/core/property/either.py
@@ -114,9 +114,9 @@ class Either(ParameterizedProperty):
             value = tp.wrap(value)
         return value
 
-    # TODO (bev) implement this
-    # def _may_have_unstable_default(self):
-    #     return any(tp._may_have_unstable_default() for tp in self.type_params)
+    def _may_have_unstable_default(self):
+        return super()._may_have_unstable_default() or \
+            any(tp._may_have_unstable_default() for tp in self.type_params)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/core/property/instance.py
+++ b/bokeh/core/property/instance.py
@@ -136,7 +136,7 @@ class Instance(Property[T]):
 
     def _may_have_unstable_default(self):
         # because the instance value is mutable
-        return True
+        return self._default is not Undefined
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/core/test_properties.py
+++ b/tests/unit/bokeh/core/test_properties.py
@@ -417,7 +417,7 @@ class TestBasic:
 
         assert 'x' not in f_base.properties_with_values(include_defaults=False)
         assert 'x' not in f_sub.properties_with_values(include_defaults=False)
-        assert 'x' not in f_sub_sub.properties_with_values(include_defaults=False)
+        assert 'x' in f_sub_sub.properties_with_values(include_defaults=False)
 
     # def test_kwargs_init(self) -> None:
     #     class Foo(HasProps):

--- a/tests/unit/bokeh/test_objects.py
+++ b/tests/unit/bokeh/test_objects.py
@@ -162,6 +162,7 @@ class TestCollectModels:
 
 class SomeModelToJson(Model):
     child = Instance(Model)
+    null_child = Nullable(Instance(Model))
     foo = Int()
     bar = String()
 
@@ -274,12 +275,14 @@ class TestModel:
 
     def test_to_json(self) -> None:
         child_obj = SomeModelToJson(foo=57, bar="hello")
-        obj = SomeModelToJson(child=child_obj,
-                              foo=42, bar="world")
+        obj = SomeModelToJson(child=child_obj, foo=42, bar="world")
+
         json = obj.to_json(include_defaults=True)
         json_string = obj.to_json_string(include_defaults=True)
+
         assert json == {
             "child": {"id": child_obj.id},
+            "null_child": None,
             "id": obj.id,
             "name": None,
             "tags": [],
@@ -298,9 +301,26 @@ class TestModel:
             '"js_event_callbacks":{},' +
             '"js_property_callbacks":{},' +
             '"name":null,' +
+            '"null_child":null,' +
             '"subscribed_events":[],' +
             '"syncable":true,' +
             '"tags":[]}'
+        ) % (child_obj.id, obj.id) == json_string
+
+        json = obj.to_json(include_defaults=False)
+        json_string = obj.to_json_string(include_defaults=False)
+
+        assert json == {
+            "child": {"id": child_obj.id},
+            "id": obj.id,
+            "foo": 42,
+            "bar": "world",
+        }
+        assert (
+            '{"bar":"world",' +
+            '"child":{"id":"%s"},' +
+            '"foo":42,' +
+            '"id":"%s"}'
         ) % (child_obj.id, obj.id) == json_string
 
     def test_no_units_in_json(self) -> None:


### PR DESCRIPTION
For example, `Nullable(Instance(Model))` does not have an unstable default. This avoids pointless serialization of e.g. `Renderer.coordinates`, which previously was always present in the serialized output, despite having `None` default value.
