### PR TITLE
Replace `typing_extensions` with `typing` wherever possible

### DIFF
--- a/bokeh/_testing/plugins/managed_server_loop.py
+++ b/bokeh/_testing/plugins/managed_server_loop.py
@@ -27,11 +27,11 @@ from typing import (
     Any,
     ContextManager,
     Iterator,
+    Protocol,
 )
 
 # External imports
 import pytest
-from typing_extensions import Protocol
 
 # Bokeh imports
 from bokeh.server.server import Server

--- a/bokeh/_testing/plugins/project.py
+++ b/bokeh/_testing/plugins/project.py
@@ -30,6 +30,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Protocol,
     Tuple,
 )
 
@@ -40,7 +41,6 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
 from tornado.ioloop import IOLoop
 from tornado.web import RequestHandler
-from typing_extensions import Protocol
 
 if TYPE_CHECKING:
     from selenium.webdriver.common.keys import _KeySeq

--- a/bokeh/_testing/util/examples.py
+++ b/bokeh/_testing/util/examples.py
@@ -34,11 +34,10 @@ from os.path import (
     relpath,
     splitext,
 )
-from typing import List, Union
+from typing import List, Literal, Union
 
 # External imports
 import yaml
-from typing_extensions import Literal
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/bokeh/_testing/util/screenshot.py
+++ b/bokeh/_testing/util/screenshot.py
@@ -29,10 +29,7 @@ from os.path import (
     pardir,
     split,
 )
-from typing import List
-
-# External imports
-from typing_extensions import TypedDict
+from typing import List, TypedDict
 
 # Bokeh imports
 from bokeh.util.terminal import fail, trace

--- a/bokeh/client/session.py
+++ b/bokeh/client/session.py
@@ -34,12 +34,15 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING, Any, Dict
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Literal,
+)
 from urllib.parse import quote_plus
 
-# External imports
-from typing_extensions import Literal
-
+## External imports
 if TYPE_CHECKING:
     from tornado.ioloop import IOLoop
 

--- a/bokeh/command/subcommand.py
+++ b/bokeh/command/subcommand.py
@@ -27,14 +27,12 @@ from argparse import ArgumentParser, Namespace
 from typing import (
     Any,
     ClassVar,
+    Literal,
     Sequence,
     Tuple,
     Type,
     Union,
 )
-
-# External imports
-from typing_extensions import Literal
 
 # Bokeh imports
 from ..util.dataclasses import (

--- a/bokeh/core/enums.py
+++ b/bokeh/core/enums.py
@@ -78,10 +78,9 @@ from typing import (
     Dict,
     Iterator,
     List,
+    Literal,
+    get_args,
 )
-
-# External imports
-from typing_extensions import Literal, get_args
 
 # Bokeh imports
 from .. import colors, palettes

--- a/bokeh/core/has_props.py
+++ b/bokeh/core/has_props.py
@@ -37,20 +37,20 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Literal,
     Mapping,
     NoReturn,
     Set,
     Tuple,
     Type,
+    TypedDict,
     TypeVar,
     Union,
     overload,
 )
 from warnings import warn
 
-# External imports
-from typing_extensions import Literal, TypedDict
-
+## External imports
 if TYPE_CHECKING:
     F = TypeVar("F", bound=Callable[..., Any])
     def lru_cache(arg: int | None) -> Callable[[F], F]: ...

--- a/bokeh/core/property/dataspec.py
+++ b/bokeh/core/property/dataspec.py
@@ -21,10 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING
-
-# External imports
-from typing_extensions import TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 # Bokeh imports
 from ... import colors

--- a/bokeh/core/types.py
+++ b/bokeh/core/types.py
@@ -25,13 +25,12 @@ import os  # lgtm [py/unused-import]
 from typing import (
     Any,
     Dict,
+    Literal,
     NewType,
     Sequence,
+    TypedDict,
     Union,
 )
-
-# External imports
-from typing_extensions import Literal, TypedDict
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/bokeh/core/validation/check.py
+++ b/bokeh/core/validation/check.py
@@ -26,11 +26,10 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Literal,
+    Protocol,
     Set,
 )
-
-# External imports
-from typing_extensions import Literal, Protocol
 
 # Bokeh imports
 from ...model import Model

--- a/bokeh/document/json.py
+++ b/bokeh/document/json.py
@@ -26,11 +26,10 @@ from typing import (
     Any,
     Dict,
     List,
+    Literal,
+    TypedDict,
     Union,
 )
-
-# External imports
-from typing_extensions import Literal, TypedDict
 
 ## Bokeh imports
 if TYPE_CHECKING:

--- a/bokeh/document/locking.py
+++ b/bokeh/document/locking.py
@@ -26,12 +26,11 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Literal,
+    Protocol,
     TypeVar,
     cast,
 )
-
-# External imports
-from typing_extensions import Literal, Protocol
 
 ## Bokeh imports
 if TYPE_CHECKING:

--- a/bokeh/embed/bundle.py
+++ b/bokeh/embed/bundle.py
@@ -42,11 +42,9 @@ from typing import (
     Set,
     Tuple,
     Type,
+    TypedDict,
 )
 from warnings import warn
-
-# External imports
-from typing_extensions import TypedDict
 
 # Bokeh imports
 from ..core.templates import CSS_RESOURCES, JS_RESOURCES

--- a/bokeh/embed/server.py
+++ b/bokeh/embed/server.py
@@ -21,12 +21,10 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING, Dict, Literal
 from urllib.parse import quote_plus, urlparse
 
-# External imports
-from typing_extensions import Literal
-
+## External imports
 if TYPE_CHECKING:
     from jinja2 import Template
 

--- a/bokeh/embed/standalone.py
+++ b/bokeh/embed/standalone.py
@@ -26,9 +26,11 @@ from typing import (
     Any,
     Dict,
     List,
+    Literal,
     Sequence,
     Tuple,
     Type,
+    TypedDict,
     Union,
     cast,
     overload,
@@ -36,7 +38,6 @@ from typing import (
 
 # External imports
 from jinja2 import Template
-from typing_extensions import Literal, TypedDict
 
 # Bokeh imports
 from .. import __version__

--- a/bokeh/events.py
+++ b/bokeh/events.py
@@ -70,11 +70,10 @@ from typing import (
     TYPE_CHECKING,
     ClassVar,
     Dict,
+    Literal,
     Type,
+    TypedDict,
 )
-
-# External imports
-from typing_extensions import Literal, TypedDict
 
 ## Bokeh imports
 if TYPE_CHECKING:

--- a/bokeh/io/notebook.py
+++ b/bokeh/io/notebook.py
@@ -28,15 +28,16 @@ from typing import (
     Callable,
     Dict,
     List,
+    Literal,
+    Protocol,
+    TypedDict,
     cast,
     overload,
 )
 from uuid import uuid4
 from warnings import warn
 
-# External imports
-from typing_extensions import Literal, Protocol, TypedDict
-
+## External imports
 if TYPE_CHECKING:
     from ipykernel.comm import Comm
 

--- a/bokeh/io/webdriver.py
+++ b/bokeh/io/webdriver.py
@@ -35,12 +35,11 @@ from os.path import (
     join,
 )
 from shutil import which
-from typing import List, Set
+from typing import List, Literal, Set
 
 # External imports
 from selenium import webdriver
 from selenium.webdriver.remote.webdriver import WebDriver
-from typing_extensions import Literal
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -22,11 +22,15 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import warnings
-from typing import Any, List as TList, overload
+from typing import (
+    Any,
+    List as TList,
+    Literal,
+    overload,
+)
 
 # External imports
 import xyzservices
-from typing_extensions import Literal
 
 # Bokeh imports
 from ..core.enums import (

--- a/bokeh/models/renderers.py
+++ b/bokeh/models/renderers.py
@@ -22,9 +22,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from difflib import get_close_matches
-
-# External imports
-from typing_extensions import Literal
+from typing import Literal
 
 # Bokeh imports
 from ..core.enums import RenderLevel

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -42,9 +42,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import difflib
 import typing as tp
-
-# External imports
-from typing_extensions import Literal
+from typing import Literal
 
 # Bokeh imports
 from ..core.enums import (

--- a/bokeh/plotting/_tools.py
+++ b/bokeh/plotting/_tools.py
@@ -28,14 +28,12 @@ from typing import (
     Dict,
     Iterator,
     List,
+    Literal,
     Sequence,
     Tuple,
     Union,
     cast,
 )
-
-# External imports
-from typing_extensions import Literal
 
 # Bokeh imports
 from ..models import (

--- a/bokeh/protocol/__init__.py
+++ b/bokeh/protocol/__init__.py
@@ -28,12 +28,10 @@ from typing import (
     Any,
     Dict,
     List,
+    Literal,
     Type,
     overload,
 )
-
-# External imports
-from typing_extensions import Literal
 
 # Bokeh imports
 from .exceptions import ProtocolError

--- a/bokeh/protocol/message.py
+++ b/bokeh/protocol/message.py
@@ -66,11 +66,9 @@ from typing import (
     Generic,
     List,
     Tuple,
+    TypedDict,
     TypeVar,
 )
-
-# External imports
-from typing_extensions import TypedDict
 
 # Bokeh imports
 import bokeh.util.serialization as bkserial

--- a/bokeh/protocol/messages/error.py
+++ b/bokeh/protocol/messages/error.py
@@ -20,10 +20,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import sys
 from traceback import format_exception
-from typing import Any
-
-# External imports
-from typing_extensions import TypedDict
+from typing import Any, TypedDict
 
 # Bokeh imports
 from ...core.types import ID

--- a/bokeh/protocol/messages/pull_doc_reply.py
+++ b/bokeh/protocol/messages/pull_doc_reply.py
@@ -18,10 +18,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING, Any
-
-# External imports
-from typing_extensions import TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 # Bokeh imports
 from ...core.types import ID

--- a/bokeh/protocol/messages/push_doc.py
+++ b/bokeh/protocol/messages/push_doc.py
@@ -18,10 +18,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING, Any
-
-# External imports
-from typing_extensions import TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 # Bokeh imports
 from ..exceptions import ProtocolError

--- a/bokeh/protocol/messages/server_info_reply.py
+++ b/bokeh/protocol/messages/server_info_reply.py
@@ -18,10 +18,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import Any
-
-# External imports
-from typing_extensions import TypedDict
+from typing import Any, TypedDict
 
 # Bokeh imports
 from bokeh import __version__

--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -43,13 +43,13 @@ from typing import (
     ClassVar,
     Dict,
     List,
+    Literal,
+    Protocol,
     Tuple,
     Union,
     cast,
+    get_args,
 )
-
-# External imports
-from typing_extensions import Literal, Protocol, get_args
 
 # Bokeh imports
 from . import __version__

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -126,6 +126,7 @@ from typing import (
     Dict,
     Generic,
     List,
+    Literal,
     Sequence,
     Type,
     TypeVar,
@@ -135,7 +136,6 @@ from typing import (
 
 # External imports
 import yaml
-from typing_extensions import Literal
 
 # Bokeh imports
 from .util.paths import bokehjsdir, serverdir

--- a/bokeh/sphinxext/__init__.py
+++ b/bokeh/sphinxext/__init__.py
@@ -9,8 +9,8 @@
 # Imports
 # -----------------------------------------------------------------------------
 
-# External imports
-from typing_extensions import TypedDict
+# Standard library imports
+from typing import TypedDict
 
 # -----------------------------------------------------------------------------
 # Globals and constants

--- a/bokeh/util/browser.py
+++ b/bokeh/util/browser.py
@@ -23,10 +23,12 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import webbrowser
 from os.path import abspath
-from typing import Dict, cast
-
-# External imports
-from typing_extensions import Literal, Protocol
+from typing import (
+    Dict,
+    Literal,
+    Protocol,
+    cast,
+)
 
 # Bokeh imports
 from ..settings import settings

--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -40,16 +40,18 @@ from typing import (
     Any,
     Dict,
     List,
+    Literal,
     Sequence,
     Set,
     Tuple,
+    TypedDict,
     Union,
     cast,
 )
 
 # External imports
 import numpy as np
-from typing_extensions import Literal, TypedDict, TypeGuard
+from typing_extensions import TypeGuard
 
 if TYPE_CHECKING:
     import numpy.typing as npt

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -33,6 +33,7 @@ from types import FrameType
 from typing import (
     Iterator,
     List,
+    Literal,
     NoReturn,
     Tuple,
     Union,
@@ -42,7 +43,6 @@ from typing import (
 import _pytest.config
 import _pytest.mark
 import _pytest.python
-from typing_extensions import Literal
 
 # Bokeh imports
 from bokeh._testing.util.examples import Example, Flags, collect_examples

--- a/typings/IPython/core/history.pyi
+++ b/typings/IPython/core/history.pyi
@@ -1,6 +1,4 @@
-from typing import List, Tuple, overload
-
-from typing_extensions import Literal
+from typing import List, Literal, Tuple, overload
 
 class HistoryAccessorBase:
     @overload

--- a/typings/bs4.pyi
+++ b/typings/bs4.pyi
@@ -1,8 +1,5 @@
 # Standard library imports
-from typing import IO, Any, Dict, List
-
-# External imports
-from typing_extensions import Literal
+from typing import IO, Any, Dict, List, Literal
 
 # XXX: this is incorrect
 class PageElement:

--- a/typings/selenium/webdriver/remote/webdriver.pyi
+++ b/typings/selenium/webdriver/remote/webdriver.pyi
@@ -1,6 +1,4 @@
-from typing import Any, List
-
-from typing_extensions import Literal, TypedDict
+from typing import Any, List, Literal, TypedDict
 
 from .webelement import WebElement
 

--- a/typings/selenium/webdriver/remote/webelement.pyi
+++ b/typings/selenium/webdriver/remote/webelement.pyi
@@ -1,8 +1,5 @@
 # Standard librarary imports
-from typing import Any, List
-
-# External imports
-from typing_extensions import TypedDict
+from typing import Any, List, TypedDict
 
 from ..common.keys import _KeySeq
 from ..remote.webdriver import WebDriver


### PR DESCRIPTION
This is a followup to PR #11931. We still need to keep `typing_extensions`, because of `TypeGuard` (Python 3.10).