### PR TITLE
Toggle button emits ButtonClick event

### DIFF
--- a/bokeh/models/widgets/buttons.py
+++ b/bokeh/models/widgets/buttons.py
@@ -135,11 +135,11 @@ class Toggle(AbstractButton):
             None
 
         """
-        self.on_change('active', lambda attr, old, new: handler(new))
+        self.on_event(ButtonClick, handler)
 
     def js_on_click(self, handler: Callback) -> None:
         """ Set up a JavaScript handler for button state changes (clicks). """
-        self.js_on_change('active', handler)
+        self.js_on_event(ButtonClick, handler)
 
 class Dropdown(AbstractButton):
     ''' A dropdown button.

--- a/bokeh/models/widgets/buttons.py
+++ b/bokeh/models/widgets/buttons.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 # Bokeh imports
 from ...core.enums import ButtonType
@@ -124,22 +124,6 @@ class Toggle(AbstractButton):
     The initial state of a button. Also used to trigger ``on_click`` event
     handler.
     """)
-
-    def on_click(self, handler: Callable[[bool], None]) -> None:
-        """ Set up a handler for button state changes (clicks).
-
-        Args:
-            handler (func) : handler function to call when button is toggled.
-
-        Returns:
-            None
-
-        """
-        self.on_event(ButtonClick, handler)
-
-    def js_on_click(self, handler: Callback) -> None:
-        """ Set up a JavaScript handler for button state changes (clicks). """
-        self.js_on_event(ButtonClick, handler)
 
 class Dropdown(AbstractButton):
     ''' A dropdown button.

--- a/bokeh/models/widgets/buttons.py
+++ b/bokeh/models/widgets/buttons.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 # Bokeh imports
 from ...core.enums import ButtonType
@@ -39,6 +39,7 @@ from ...core.properties import (
     Tuple,
 )
 from ...events import ButtonClick, MenuItemClick
+from ...util.deprecation import deprecated
 from ..callbacks import Callback
 from .icons import AbstractIcon
 from .widget import Widget
@@ -107,10 +108,12 @@ class Button(AbstractButton):
             None
 
         '''
+        deprecated((3, 0, 0), 'on_click(handler)', 'on_event("button_click", handler)')
         self.on_event(ButtonClick, handler)
 
     def js_on_click(self, handler: Callback) -> None:
         ''' Set up a JavaScript handler for button clicks. '''
+        deprecated((3, 0, 0), 'js_on_click(handler)', 'js_on_event("button_click", handler)')
         self.js_on_event(ButtonClick, handler)
 
 class Toggle(AbstractButton):
@@ -121,9 +124,23 @@ class Toggle(AbstractButton):
     label = Override(default="Toggle")
 
     active = Bool(False, help="""
-    The initial state of a button. Also used to trigger ``on_click`` event
-    handler.
+    The state of the toggle button.
     """)
+
+    def on_click(self, handler: Callable[[bool], None]) -> None:
+        """ Set up a handler for button state changes (clicks).
+        Args:
+            handler (func) : handler function to call when button is toggled.
+        Returns:
+            None
+        """
+        deprecated((3, 0, 0), 'on_click(handler)', 'on_event("button_click", handler)')
+        self.on_change('active', lambda attr, old, new: handler(new))
+
+    def js_on_click(self, handler: Callback) -> None:
+        """ Set up a JavaScript handler for button state changes (clicks). """
+        deprecated((3, 0, 0), 'js_on_click(handler)', 'js_on_event("button_click", handler)')
+        self.js_on_change('active', handler)
 
 class Dropdown(AbstractButton):
     ''' A dropdown button.
@@ -150,11 +167,13 @@ class Dropdown(AbstractButton):
             None
 
         '''
+        deprecated((3, 0, 0), 'on_click(handler)', 'on_event("button_click", handler) OR on_event("menu_item_click", handler)')
         self.on_event(ButtonClick, handler)
         self.on_event(MenuItemClick, handler)
 
     def js_on_click(self, handler: Callback) -> None:
         ''' Set up a JavaScript handler for button or menu item clicks. '''
+        deprecated((3, 0, 0), 'js_on_click(handler)', 'js_on_event("button_click", handler) OR js_on_event("menu_item_click", handler)')
         self.js_on_event(ButtonClick, handler)
         self.js_on_event(MenuItemClick, handler)
 

--- a/bokeh/models/widgets/buttons.py
+++ b/bokeh/models/widgets/buttons.py
@@ -129,8 +129,10 @@ class Toggle(AbstractButton):
 
     def on_click(self, handler: Callable[[bool], None]) -> None:
         """ Set up a handler for button state changes (clicks).
+
         Args:
             handler (func) : handler function to call when button is toggled.
+
         Returns:
             None
         """

--- a/bokeh/models/widgets/groups.py
+++ b/bokeh/models/widgets/groups.py
@@ -33,6 +33,7 @@ from ...core.properties import (
     Nullable,
     String,
 )
+from ...util.deprecation import deprecated
 from .buttons import ButtonLike
 from .widget import Widget
 
@@ -78,10 +79,12 @@ class AbstractGroup(Widget):
             None
 
         '''
+        deprecated((3, 0, 0), 'on_click(handler)', 'on_event("button_click", handler)')
         self.on_change('active', lambda attr, old, new: handler(new))
 
     def js_on_click(self, handler: Callback) -> None:
         ''' Set up a handler for button check/radio box clicks including the selected indices. '''
+        deprecated((3, 0, 0), 'js_on_click(handler)', 'js_on_event("button_click", handler)')
         self.js_on_change('active', handler)
 
 @abstract

--- a/bokeh/models/widgets/groups.py
+++ b/bokeh/models/widgets/groups.py
@@ -20,9 +20,6 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
-# Standard library imports
-from typing import TYPE_CHECKING, Callable, List as TList
-
 # Bokeh imports
 from ...core.has_props import abstract
 from ...core.properties import (
@@ -33,12 +30,8 @@ from ...core.properties import (
     Nullable,
     String,
 )
-from ...util.deprecation import deprecated
 from .buttons import ButtonLike
 from .widget import Widget
-
-if TYPE_CHECKING:
-    from ..callbacks import Callback
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -67,25 +60,6 @@ class AbstractGroup(Widget):
     labels = List(String, help="""
     List of text labels contained in this group.
     """)
-
-    def on_click(self, handler: Callable[[int], None] | Callable[[TList[int]], None]) -> None:
-        ''' Set up a handler for button check/radio box clicks including
-        the selected indices.
-
-        Args:
-            handler (func) : handler function to call when button is clicked.
-
-        Returns:
-            None
-
-        '''
-        deprecated((3, 0, 0), 'on_click(handler)', 'on_event("button_click", handler)')
-        self.on_change('active', lambda attr, old, new: handler(new))
-
-    def js_on_click(self, handler: Callback) -> None:
-        ''' Set up a handler for button check/radio box clicks including the selected indices. '''
-        deprecated((3, 0, 0), 'js_on_click(handler)', 'js_on_event("button_click", handler)')
-        self.js_on_change('active', handler)
 
 @abstract
 class ButtonGroup(AbstractGroup, ButtonLike):

--- a/bokehjs/src/lib/models/widgets/button_group.ts
+++ b/bokehjs/src/lib/models/widgets/button_group.ts
@@ -4,7 +4,6 @@ import {ButtonType} from "core/enums"
 import {div} from "core/dom"
 import * as p from "core/properties"
 
-
 import buttons_css, * as buttons from "styles/buttons.css"
 
 export abstract class ButtonGroupView extends OrientedControlView {

--- a/bokehjs/src/lib/models/widgets/button_group.ts
+++ b/bokehjs/src/lib/models/widgets/button_group.ts
@@ -1,8 +1,9 @@
 import {OrientedControl, OrientedControlView} from "./oriented_control"
-
+import {ButtonClick} from "core/bokeh_events"
 import {ButtonType} from "core/enums"
 import {div} from "core/dom"
 import * as p from "core/properties"
+
 
 import buttons_css, * as buttons from "styles/buttons.css"
 
@@ -39,7 +40,10 @@ export abstract class ButtonGroupView extends OrientedControlView {
         class: [buttons.btn, buttons[`btn_${this.model.button_type}` as const]],
         disabled: this.model.disabled,
       }, label)
-      button.addEventListener("click", () => this.change_active(i))
+      button.addEventListener("click", () => {
+        this.change_active(i)
+        this.model.trigger_event(new ButtonClick())
+      })
       return button
     })
 

--- a/bokehjs/src/lib/models/widgets/checkbox_group.ts
+++ b/bokehjs/src/lib/models/widgets/checkbox_group.ts
@@ -1,4 +1,5 @@
 import {InputGroup, InputGroupView} from "./input_group"
+import {ButtonClick} from "core/bokeh_events"
 
 import {input, label, div, span} from "core/dom"
 import {includes} from "core/util/array"
@@ -20,7 +21,10 @@ export class CheckboxGroupView extends InputGroupView {
     this._inputs = []
     for (let i = 0; i < labels.length; i++) {
       const checkbox = input({type: "checkbox", value: `${i}`})
-      checkbox.addEventListener("change", () => this.change_active(i))
+      checkbox.addEventListener("click", () => {
+        this.change_active(i)
+        this.model.trigger_event(new ButtonClick())
+      })
       this._inputs.push(checkbox)
 
       if (this.model.disabled)

--- a/bokehjs/src/lib/models/widgets/checkbox_group.ts
+++ b/bokehjs/src/lib/models/widgets/checkbox_group.ts
@@ -1,5 +1,4 @@
 import {InputGroup, InputGroupView} from "./input_group"
-import {ButtonClick} from "core/bokeh_events"
 
 import {input, label, div, span} from "core/dom"
 import {includes} from "core/util/array"
@@ -21,10 +20,7 @@ export class CheckboxGroupView extends InputGroupView {
     this._inputs = []
     for (let i = 0; i < labels.length; i++) {
       const checkbox = input({type: "checkbox", value: `${i}`})
-      checkbox.addEventListener("click", () => {
-        this.change_active(i)
-        this.model.trigger_event(new ButtonClick())
-      })
+      checkbox.addEventListener("change", () => this.change_active(i))
       this._inputs.push(checkbox)
 
       if (this.model.disabled)

--- a/bokehjs/src/lib/models/widgets/radio_group.ts
+++ b/bokehjs/src/lib/models/widgets/radio_group.ts
@@ -3,7 +3,6 @@ import {uniqueId} from "core/util/string"
 import * as p from "core/properties"
 
 import {InputGroup, InputGroupView} from "./input_group"
-import {ButtonClick} from "core/bokeh_events"
 
 import * as inputs from "styles/widgets/inputs.css"
 
@@ -22,10 +21,7 @@ export class RadioGroupView extends InputGroupView {
     this._inputs = []
     for (let i = 0; i < labels.length; i++) {
       const radio = input({type: "radio", name, value: `${i}`})
-      radio.addEventListener("click", () => {
-        this.change_active(i)
-        this.model.trigger_event(new ButtonClick())
-      })
+      radio.addEventListener("change", () => this.change_active(i))
       this._inputs.push(radio)
 
       if (this.model.disabled)

--- a/bokehjs/src/lib/models/widgets/radio_group.ts
+++ b/bokehjs/src/lib/models/widgets/radio_group.ts
@@ -3,6 +3,7 @@ import {uniqueId} from "core/util/string"
 import * as p from "core/properties"
 
 import {InputGroup, InputGroupView} from "./input_group"
+import {ButtonClick} from "core/bokeh_events"
 
 import * as inputs from "styles/widgets/inputs.css"
 
@@ -21,7 +22,10 @@ export class RadioGroupView extends InputGroupView {
     this._inputs = []
     for (let i = 0; i < labels.length; i++) {
       const radio = input({type: "radio", name, value: `${i}`})
-      radio.addEventListener("change", () => this.change_active(i))
+      radio.addEventListener("click", () => {
+        this.change_active(i)
+        this.model.trigger_event(new ButtonClick())
+      })
       this._inputs.push(radio)
 
       if (this.model.disabled)

--- a/bokehjs/src/lib/models/widgets/toggle.ts
+++ b/bokehjs/src/lib/models/widgets/toggle.ts
@@ -1,5 +1,6 @@
 import {AbstractButton, AbstractButtonView} from "./abstract_button"
 import {classes} from "core/dom"
+import {ButtonClick} from "core/bokeh_events"
 import * as p from "core/properties"
 
 import * as buttons from "styles/buttons.css"
@@ -19,6 +20,7 @@ export class ToggleView extends AbstractButtonView {
 
   override click(): void {
     this.model.active = !this.model.active
+    this.model.trigger_event(new ButtonClick())
     super.click()
   }
 

--- a/examples/app/export_csv/main.py
+++ b/examples/app/export_csv/main.py
@@ -27,7 +27,7 @@ slider = RangeSlider(title="Max Salary", start=10000, end=110000, value=(10000, 
 slider.on_change('value', lambda attr, old, new: update())
 
 button = Button(label="Download", button_type="success")
-button.js_on_click(CustomJS(args=dict(source=source),
+button.js_on_event("button_click", CustomJS(args=dict(source=source),
                             code=open(join(dirname(__file__), "download.js")).read()))
 
 columns = [

--- a/examples/app/gapminder/main.py
+++ b/examples/app/gapminder/main.py
@@ -82,7 +82,7 @@ def animate():
         curdoc().remove_periodic_callback(callback_id)
 
 button = Button(label='► Play', width=60)
-button.on_click(animate)
+button.on_event('button_click', animate)
 
 layout = layout([
     [plot],

--- a/examples/custom/font-awesome/font-awesome.py
+++ b/examples/custom/font-awesome/font-awesome.py
@@ -1,3 +1,4 @@
+from bokeh.events import ButtonClick
 from bokeh.layouts import column
 from bokeh.models import Button, CustomJS
 from bokeh.plotting import show
@@ -6,6 +7,6 @@ from fontawesome_icon import FontAwesomeIcon
 
 btn = Button(icon=FontAwesomeIcon(icon_name="thumbs-o-up", size=2),
              label="It works!")
-btn.js_on_click(CustomJS(code="alert('It works!')"))
+btn.js_on_event(ButtonClick, CustomJS(code="alert('It works!')"))
 
 show(column(btn))

--- a/examples/howto/ipywidgets/ipyvolume_camera.py
+++ b/examples/howto/ipywidgets/ipyvolume_camera.py
@@ -24,7 +24,7 @@ def randomize(button):
         scatter.z = z
 
 randomize_button = ipw.Button(description="Randomize")
-randomize_button.on_click(randomize)
+randomize_button.on_event("button_click", randomize)
 
 def change_anglex(change):
     v = round(np.degrees(change["new"])) % 360

--- a/examples/howto/server_auth/app.py
+++ b/examples/howto/server_auth/app.py
@@ -43,7 +43,7 @@ amplitude = Slider(title="amplitude", value=1.0, start=-5.0, end=5.0, step=0.1)
 phase = Slider(title="phase", value=0.0, start=0.0, end=2*np.pi)
 freq = Slider(title="frequency", value=1.0, start=0.1, end=5.1, step=0.1)
 logout = Button(label="logout")
-logout.js_on_click(CustomJS(code="window.location.href='%s'" % curdoc().session_context.logout_url))
+logout.js_on_event("button_click", CustomJS(code="window.location.href='%s'" % curdoc().session_context.logout_url))
 
 # Set up callbacks
 def update_title(attrname, old, new):

--- a/examples/howto/using_password_input.py
+++ b/examples/howto/using_password_input.py
@@ -29,7 +29,7 @@ verify = CustomJS(args=dict(user=user, password=password, secret=secret), code="
 """ % (USER, PASSWD))
 
 password.js_on_change('value', verify)
-button.js_on_click(verify)
+button.js_on_event('button_click', verify)
 
 layout = row(column(text, user, password, button), secret)
 

--- a/examples/models/file/buttons.py
+++ b/examples/models/file/buttons.py
@@ -6,29 +6,30 @@ from bokeh.resources import INLINE
 from bokeh.util.browser import view
 
 button = Button(label="Button (enabled) - has click event", button_type="primary")
-button.js_on_click(CustomJS(code="console.log('button: click ', this.toString())"))
+button.js_on_event("button_click", CustomJS(code="console.log('button: click ', this.toString())"))
+button.js_on_event("button_click", CustomJS(code="console.log('button: click ', this.toString())"))
 
 button_disabled = Button(label="Button (disabled) - no click event", button_type="primary", disabled=True)
-button_disabled.js_on_click(CustomJS(code="console.log('button(disabled): click ', this.toString())"))
+button_disabled.js_on_event("button_click", CustomJS(code="console.log('button(disabled): click ', this.toString())"))
 
 toggle_inactive = Toggle(label="Toggle button (initially inactive)", button_type="success")
-toggle_inactive.js_on_event('button_click', CustomJS(code="console.log('toggle(inactive): active=' + this.active, this.toString())"))
+toggle_inactive.js_on_event('button_click', CustomJS(code="console.log('toggle(inactive): active=' + this.origin.active, this.toString())"))
 
 toggle_active = Toggle(label="Toggle button (initially active)", button_type="success", active=True)
-toggle_active.js_on_event('button_click', CustomJS(code="console.log('toggle(active): active=' + this.active, this.toString())"))
+toggle_active.js_on_event('button_click', CustomJS(code="console.log('toggle(active): active=' + this.origin.active, this.toString())"))
 
 menu = [("Item 1", "item_1_value"), ("Item 2", "item_2_value"), None, ("Item 3", "item_3_value")]
 
 dropdown = Dropdown(label="Dropdown button", button_type="warning", menu=menu)
-dropdown.js_on_click(CustomJS(code="console.log('dropdown: click ' + this.toString())"))
+dropdown.js_on_event("button_click", CustomJS(code="console.log('dropdown: click ' + this.toString())"))
 dropdown.js_on_event("menu_item_click", CustomJS(code="console.log('dropdown: ' + this.item, this.toString())"))
 
 dropdown_disabled = Dropdown(label="Dropdown button (disabled)", button_type="warning", disabled=True, menu=menu)
-dropdown_disabled.js_on_click(CustomJS(code="console.log('dropdown(disabled): click ' + this.toString())"))
+dropdown_disabled.js_on_event("button_click", CustomJS(code="console.log('dropdown(disabled): click ' + this.toString())"))
 dropdown_disabled.js_on_event("menu_item_click", CustomJS(code="console.log('dropdown(disabled): ' + this.item, this.toString())"))
 
 dropdown_split = Dropdown(label="Split button", split=True, button_type="danger", menu=menu)
-dropdown_split.js_on_click(CustomJS(code="console.log('dropdown(split): click ' + this.toString())"))
+dropdown_split.js_on_event("button_click", CustomJS(code="console.log('dropdown(split): click ' + this.toString())"))
 dropdown_split.js_on_event("menu_item_click", CustomJS(code="console.log('dropdown(split): ' + this.item, this.toString())"))
 
 checkbox_group = CheckboxGroup(labels=["Option 1", "Option 2", "Option 3"], active=[0, 1])

--- a/examples/models/file/buttons.py
+++ b/examples/models/file/buttons.py
@@ -33,10 +33,10 @@ dropdown_split.js_on_event("button_click", CustomJS(code="console.log('dropdown(
 dropdown_split.js_on_event("menu_item_click", CustomJS(code="console.log('dropdown(split): ' + this.item, this.toString())"))
 
 checkbox_group = CheckboxGroup(labels=["Option 1", "Option 2", "Option 3"], active=[0, 1])
-checkbox_group.js_on_event('button_click', CustomJS(code="console.log('checkbox_group: active=' + this.origin.active, this.toString())"))
+checkbox_group.js_on_change('active', CustomJS(code="console.log('checkbox_group: active=' + this.active, this.toString())"))
 
 radio_group = RadioGroup(labels=["Option 1", "Option 2", "Option 3"], active=0)
-radio_group.js_on_event('button_click', CustomJS(code="console.log('radio_group: active=' + this.origin.active, this.toString())"))
+radio_group.js_on_change('active', CustomJS(code="console.log('radio_group: active=' + this.active, this.toString())"))
 
 checkbox_button_group = CheckboxButtonGroup(labels=["Option 1", "Option 2", "Option 3"], active=[0, 1])
 checkbox_button_group.js_on_event("button_click", CustomJS(code="console.log('checkbox_button_group: active=' + this.origin.active, this.toString())"))

--- a/examples/models/file/buttons.py
+++ b/examples/models/file/buttons.py
@@ -39,10 +39,10 @@ radio_group = RadioGroup(labels=["Option 1", "Option 2", "Option 3"], active=0)
 radio_group.js_on_click(CustomJS(code="console.log('radio_group: active=' + this.active, this.toString())"))
 
 checkbox_button_group = CheckboxButtonGroup(labels=["Option 1", "Option 2", "Option 3"], active=[0, 1])
-checkbox_button_group.js_on_click(CustomJS(code="console.log('checkbox_button_group: active=' + this.active, this.toString())"))
+checkbox_button_group.js_on_event("button_group", CustomJS(code="console.log('checkbox_button_group: active=' + this.origin.active, this.toString())"))
 
 radio_button_group = RadioButtonGroup(labels=["Option 1", "Option 2", "Option 3"], active=0)
-radio_button_group.js_on_click(CustomJS(code="console.log('radio_button_group: active=' + this.active, this.toString())"))
+radio_button_group.js_on_event("button_group", CustomJS(code="console.log('radio_button_group: active=' + this.origin.active, this.toString())"))
 
 widget_box = Column(children=[
     button, button_disabled,

--- a/examples/models/file/buttons.py
+++ b/examples/models/file/buttons.py
@@ -12,10 +12,10 @@ button_disabled = Button(label="Button (disabled) - no click event", button_type
 button_disabled.js_on_click(CustomJS(code="console.log('button(disabled): click ', this.toString())"))
 
 toggle_inactive = Toggle(label="Toggle button (initially inactive)", button_type="success")
-toggle_inactive.js_on_click(CustomJS(code="console.log('toggle(inactive): active=' + this.active, this.toString())"))
+toggle_inactive.js_on_event('button_click', CustomJS(code="console.log('toggle(inactive): active=' + this.active, this.toString())"))
 
 toggle_active = Toggle(label="Toggle button (initially active)", button_type="success", active=True)
-toggle_active.js_on_click(CustomJS(code="console.log('toggle(active): active=' + this.active, this.toString())"))
+toggle_active.js_on_event('button_click', CustomJS(code="console.log('toggle(active): active=' + this.active, this.toString())"))
 
 menu = [("Item 1", "item_1_value"), ("Item 2", "item_2_value"), None, ("Item 3", "item_3_value")]
 

--- a/examples/models/file/buttons.py
+++ b/examples/models/file/buttons.py
@@ -33,10 +33,10 @@ dropdown_split.js_on_event("button_click", CustomJS(code="console.log('dropdown(
 dropdown_split.js_on_event("menu_item_click", CustomJS(code="console.log('dropdown(split): ' + this.item, this.toString())"))
 
 checkbox_group = CheckboxGroup(labels=["Option 1", "Option 2", "Option 3"], active=[0, 1])
-checkbox_group.js_on_click(CustomJS(code="console.log('checkbox_group: active=' + this.active, this.toString())"))
+checkbox_group.js_on_event('button_click', CustomJS(code="console.log('checkbox_group: active=' + this.origin.active, this.toString())"))
 
 radio_group = RadioGroup(labels=["Option 1", "Option 2", "Option 3"], active=0)
-radio_group.js_on_click(CustomJS(code="console.log('radio_group: active=' + this.active, this.toString())"))
+radio_group.js_on_event('button_click', CustomJS(code="console.log('radio_group: active=' + this.origin.active, this.toString())"))
 
 checkbox_button_group = CheckboxButtonGroup(labels=["Option 1", "Option 2", "Option 3"], active=[0, 1])
 checkbox_button_group.js_on_event("button_group", CustomJS(code="console.log('checkbox_button_group: active=' + this.origin.active, this.toString())"))

--- a/examples/models/file/buttons.py
+++ b/examples/models/file/buttons.py
@@ -39,10 +39,10 @@ radio_group = RadioGroup(labels=["Option 1", "Option 2", "Option 3"], active=0)
 radio_group.js_on_event('button_click', CustomJS(code="console.log('radio_group: active=' + this.origin.active, this.toString())"))
 
 checkbox_button_group = CheckboxButtonGroup(labels=["Option 1", "Option 2", "Option 3"], active=[0, 1])
-checkbox_button_group.js_on_event("button_group", CustomJS(code="console.log('checkbox_button_group: active=' + this.origin.active, this.toString())"))
+checkbox_button_group.js_on_event("button_click", CustomJS(code="console.log('checkbox_button_group: active=' + this.origin.active, this.toString())"))
 
 radio_button_group = RadioButtonGroup(labels=["Option 1", "Option 2", "Option 3"], active=0)
-radio_button_group.js_on_event("button_group", CustomJS(code="console.log('radio_button_group: active=' + this.origin.active, this.toString())"))
+radio_button_group.js_on_event("button_click", CustomJS(code="console.log('radio_button_group: active=' + this.origin.active, this.toString())"))
 
 widget_box = Column(children=[
     button, button_disabled,

--- a/examples/models/file/transform_jitter.py
+++ b/examples/models/file/transform_jitter.py
@@ -37,6 +37,6 @@ for (const r of [r1, n1, r2, u2]) {
 """)
 
 button = Button(label='Press to toggle Jitter!', width=300)
-button.js_on_click(callback)
+button.js_on_event("button_click", callback)
 
 show(Column(button, p))

--- a/examples/reference/models/button_server.py
+++ b/examples/reference/models/button_server.py
@@ -12,7 +12,7 @@ source = ColumnDataSource(data=dict(x=x, y=y))
 
 plot_figure = figure(height=450, width=600,
               tools="save,reset",
-              x_range=[0,14], y_range=[0,12],toolbar_location="below")
+              x_range=[0,14], y_range=[0,12], toolbar_location="below")
 
 plot_figure.scatter('x', 'y', source=source, size=10)
 
@@ -21,7 +21,7 @@ button = Button(label="Click to set plot title", button_type="success")
 def button_click():
     plot_figure.title.text = 'Button Clicked'
 
-button.on_click(button_click)
+button.on_event('button_click', button_click)
 
 layout=row(button,plot_figure)
 

--- a/examples/webgl/line_compare.py
+++ b/examples/webgl/line_compare.py
@@ -65,7 +65,7 @@ def make_dropdown(prop, menu):
             glyph[prop] = cb_obj.item;
         }
     """)
-    dropdown.js_on_click(cb)
+    dropdown.js_on_event("menu_item_click", cb)
     return dropdown
 
 sliders = [

--- a/sphinx/source/docs/releases/3.0.0.rst
+++ b/sphinx/source/docs/releases/3.0.0.rst
@@ -130,6 +130,12 @@ implementation, then use data models (e.g. extend from ``DataModel``).
 as assigned to. Previously providing a data source in both a glyph renderer
 and a source view was redundant.
 
+``RadioGroup / CheckboxGroup on_click``
+..................
+
+``RadioGroup`` and ``CheckboxGroup`` no longer supports ``on_click`` event handlers.
+Use ``on_change('active', cb)`` instead.
+
 Renames
 ~~~~~~~
 
@@ -147,6 +153,9 @@ Deprecations
 ``tile_providers`` module providing ``get_providers`` and ``Vendors`` is now deprecated.
 Any tile specification (e.g. as string name) can be now passed directly to ``add_tile``
 instead.
+
+``on_click`` event handlers on button type widgets have been replaced with ``on_event``
+using ``bokeh.events.ButtonClick`` as the event type.
 
 API changes
 ~~~~~~~~~~~

--- a/sphinx/source/docs/releases/3.0.0.rst
+++ b/sphinx/source/docs/releases/3.0.0.rst
@@ -131,7 +131,7 @@ as assigned to. Previously providing a data source in both a glyph renderer
 and a source view was redundant.
 
 ``RadioGroup / CheckboxGroup on_click``
-..................
+.......................................
 
 ``RadioGroup`` and ``CheckboxGroup`` no longer supports ``on_click`` event handlers.
 Use ``on_change('active', cb)`` instead.

--- a/sphinx/source/docs/releases/3.0.0.rst
+++ b/sphinx/source/docs/releases/3.0.0.rst
@@ -155,7 +155,7 @@ Any tile specification (e.g. as string name) can be now passed directly to ``add
 instead.
 
 ``on_click`` event handlers on button type widgets have been replaced with ``on_event``
-using ``bokeh.events.ButtonClick`` as the event type.
+using ``bokeh.events.ButtonClick`` ("button_click") as the event type.
 
 API changes
 ~~~~~~~~~~~

--- a/sphinx/source/docs/user_guide/examples/interaction_button.py
+++ b/sphinx/source/docs/user_guide/examples/interaction_button.py
@@ -2,6 +2,6 @@ from bokeh.io import show
 from bokeh.models import Button, CustomJS
 
 button = Button(label="Foo", button_type="success")
-button.js_on_click(CustomJS(code="console.log('button: click!', this.toString())"))
+button.js_on_event("button_click", CustomJS(code="console.log('button: click!', this.toString())"))
 
 show(button)

--- a/sphinx/source/docs/user_guide/examples/interaction_checkbox_button_group.py
+++ b/sphinx/source/docs/user_guide/examples/interaction_checkbox_button_group.py
@@ -4,8 +4,8 @@ from bokeh.models import CheckboxButtonGroup, CustomJS
 LABELS = ["Option 1", "Option 2", "Option 3"]
 
 checkbox_button_group = CheckboxButtonGroup(labels=LABELS, active=[0, 1])
-checkbox_button_group.js_on_click(CustomJS(code="""
-    console.log('checkbox_button_group: active=' + this.active, this.toString())
+checkbox_button_group.js_on_event("button_click", CustomJS(code="""
+    console.log('checkbox_button_group: active=' + this.origin.active, this.toString())
 """))
 
 show(checkbox_button_group)

--- a/sphinx/source/docs/user_guide/examples/interaction_checkbox_button_group.py
+++ b/sphinx/source/docs/user_guide/examples/interaction_checkbox_button_group.py
@@ -4,8 +4,8 @@ from bokeh.models import CheckboxButtonGroup, CustomJS
 LABELS = ["Option 1", "Option 2", "Option 3"]
 
 checkbox_button_group = CheckboxButtonGroup(labels=LABELS, active=[0, 1])
-checkbox_button_group.js_on_event("button_click", CustomJS(code="""
-    console.log('checkbox_button_group: active=' + this.origin.active, this.toString())
+checkbox_button_group.js_on_event("button_click", CustomJS(args=dict(btn=checkbox_button_group), code="""
+    console.log('checkbox_button_group: active=' + btn.active, this.toString())
 """))
 
 show(checkbox_button_group)

--- a/sphinx/source/docs/user_guide/examples/interaction_checkbox_group.py
+++ b/sphinx/source/docs/user_guide/examples/interaction_checkbox_group.py
@@ -4,8 +4,8 @@ from bokeh.models import CheckboxGroup, CustomJS
 LABELS = ["Option 1", "Option 2", "Option 3"]
 
 checkbox_group = CheckboxGroup(labels=LABELS, active=[0, 1])
-checkbox_group.js_on_click(CustomJS(code="""
-    console.log('checkbox_group: active=' + this.active, this.toString())
+checkbox_group.js_on_event('button_click', CustomJS(code="""
+    console.log('checkbox_group: active=' + this.origin.active, this.toString())
 """))
 
 show(checkbox_group)

--- a/sphinx/source/docs/user_guide/examples/interaction_radio_button_group.py
+++ b/sphinx/source/docs/user_guide/examples/interaction_radio_button_group.py
@@ -4,7 +4,7 @@ from bokeh.models import CustomJS, RadioButtonGroup
 LABELS = ["Option 1", "Option 2", "Option 3"]
 
 radio_button_group = RadioButtonGroup(labels=LABELS, active=0)
-radio_button_group.js_on_click(CustomJS(code="""
+radio_button_group.js_on_event("button_click", CustomJS(code="""
     console.log('radio_button_group: active=' + this.active, this.toString())
 """))
 

--- a/sphinx/source/docs/user_guide/examples/interaction_radio_button_group.py
+++ b/sphinx/source/docs/user_guide/examples/interaction_radio_button_group.py
@@ -4,8 +4,8 @@ from bokeh.models import CustomJS, RadioButtonGroup
 LABELS = ["Option 1", "Option 2", "Option 3"]
 
 radio_button_group = RadioButtonGroup(labels=LABELS, active=0)
-radio_button_group.js_on_event("button_click", CustomJS(code="""
-    console.log('radio_button_group: active=' + this.active, this.toString())
+radio_button_group.js_on_event("button_click", CustomJS(args=dict(btn=radio_button_group), code="""
+    console.log('radio_button_group: active=' + radio_button_group.active, this.toString())
 """))
 
 show(radio_button_group)

--- a/sphinx/source/docs/user_guide/examples/interaction_radio_group.py
+++ b/sphinx/source/docs/user_guide/examples/interaction_radio_group.py
@@ -4,8 +4,8 @@ from bokeh.models import CustomJS, RadioGroup
 LABELS = ["Option 1", "Option 2", "Option 3"]
 
 radio_group = RadioGroup(labels=LABELS, active=0)
-radio_group.js_on_click(CustomJS(code="""
-    console.log('radio_group: active=' + this.active, this.toString())
+radio_group.js_on_event('button_click', CustomJS(code="""
+    console.log('radio_group: active=' + this.origin.active, this.toString())
 """))
 
 show(radio_group)

--- a/sphinx/source/docs/user_guide/examples/interaction_toggle_button.py
+++ b/sphinx/source/docs/user_guide/examples/interaction_toggle_button.py
@@ -2,8 +2,8 @@ from bokeh.io import show
 from bokeh.models import CustomJS, Toggle
 
 toggle = Toggle(label="Foo", button_type="success")
-toggle.js_on_click(CustomJS(code="""
-    console.log('toggle: active=' + this.active, this.toString())
+toggle.js_on_event('button_click', CustomJS(code="""
+    console.log('toggle: active=' + this.origin.active, this.toString())
 """))
 
 show(toggle)

--- a/sphinx/source/docs/user_guide/examples/interaction_toggle_button.py
+++ b/sphinx/source/docs/user_guide/examples/interaction_toggle_button.py
@@ -2,8 +2,8 @@ from bokeh.io import show
 from bokeh.models import CustomJS, Toggle
 
 toggle = Toggle(label="Foo", button_type="success")
-toggle.js_on_event('button_click', CustomJS(code="""
-    console.log('toggle: active=' + this.origin.active, this.toString())
+toggle.js_on_event('button_click', CustomJS(args=dict(btn=toggle), code="""
+    console.log('toggle: active=' + btn.active, this.toString())
 """))
 
 show(toggle)

--- a/sphinx/source/docs/user_guide/interaction/widgets.rst
+++ b/sphinx/source/docs/user_guide/interaction/widgets.rst
@@ -55,7 +55,7 @@ widgets with ``.on_event``, the handler is passed the new attribute value.
         print('Radio button option ' + str(new) + ' selected.')
 
     radio_group = RadioGroup(labels=["Option 1", "Option 2", "Option 3"], active=0)
-    radio_group.on_click(my_radio_handler)
+    radio_group.on_event('button_click', my_radio_handler)
 
 Bokeh provides a simple default set of widgets. Users can create their own
 custom widgets, or wrap different third party widget libraries by creating

--- a/sphinx/source/docs/user_guide/interaction/widgets.rst
+++ b/sphinx/source/docs/user_guide/interaction/widgets.rst
@@ -22,12 +22,12 @@ There are two ways to use a widget's functionality:
     * A ``CustomJS`` callback (see :ref:`userguide_interaction_jscallbacks`).
       This approach will work in standalone HTML documents or Bokeh server apps.
     * Use ``bokeh serve`` to start a Bokeh server and set up event handlers with
-      ``.on_change`` (or for some widgets, ``.on_click``).
+      ``.on_change`` or ``.on_event``.
 
 Event handlers are Python functions that users can attach to widgets. These
 functions are then called when certain attributes on the widget are changed.
 The function signature of event handlers is determined by how they are attached
-to widgets (whether by ``.on_change`` or ``.on_click``, for example).
+to widgets (whether by ``.on_change`` or ``.on_event``, for example).
 
 All widgets have an ``.on_change`` method that takes an attribute name and one
 or more event handlers as parameters. These handlers are expected to have the
@@ -45,9 +45,9 @@ values of the attribute.
     text_input.on_change("value", my_text_input_handler)
 
 Additionally, some widgets, including the button, dropdown, and checkbox, have
-an ``.on_click`` method that takes an event handler as its only parameter. For
+an ``.on_event`` method that takes an event handler as its only parameter. For
 a plain ``Button``, this handler is called without parameters. For the other
-widgets with ``.on_click``, the handler is passed the new attribute value.
+widgets with ``.on_event``, the handler is passed the new attribute value.
 
 .. code-block:: python
 

--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -198,7 +198,7 @@ Consider the following complete example.
 
     # add a button widget and configure with the call back
     button = Button(label="Press Me")
-    button.on_click(callback)
+    button.on_event('button_click', callback)
 
     # put the button and plot in a layout and add to the document
     curdoc().add_root(column(button, p))

--- a/tests/integration/models/test_datarange1d.py
+++ b/tests/integration/models/test_datarange1d.py
@@ -101,7 +101,7 @@ class Test_DataRange1d:
         plot.tags.append(CustomJS(name="custom-action", args=dict(p=plot), code=code))
         plot.toolbar_sticky = False
         button = Button()
-        button.js_on_click(CustomJS(args=dict(glyph=glyph), code="glyph.visible=false"))
+        button.js_on_event('button_click', CustomJS(args=dict(glyph=glyph), code="glyph.visible=false"))
 
         page = single_plot_page(column(plot, button))
 

--- a/tests/integration/models/test_sources.py
+++ b/tests/integration/models/test_sources.py
@@ -63,7 +63,7 @@ class Test_ColumnDataSource:
             plot = Plot(height=400, width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
             plot.tags.append(CustomJS(name="custom-action", args=dict(s=source), code=RECORD("data", "s.data")))
 
-            button.js_on_click(CustomJS(args=dict(s=source), code="s.patch({'x': [[1, 100]]})"))
+            button.js_on_event('button_click', CustomJS(args=dict(s=source), code="s.patch({'x': [[1, 100]]})"))
             doc.add_root(column(button, plot))
 
         page = bokeh_server_page(modify_doc)
@@ -109,7 +109,7 @@ class Test_ColumnDataSource:
             plot = Plot(height=400, width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
             plot.tags.append(CustomJS(name="custom-action", args=dict(s=source), code=RECORD("data", "s.data")))
 
-            button.js_on_click(CustomJS(args=dict(s=source), code="s.stream({'x': [100], 'y': [200]})"))
+            button.js_on_event('button_click', CustomJS(args=dict(s=source), code="s.stream({'x': [100], 'y': [200]})"))
             doc.add_root(column(button, plot))
 
         page = bokeh_server_page(modify_doc)

--- a/tests/integration/widgets/tables/test_source_updates.py
+++ b/tests/integration/widgets/tables/test_source_updates.py
@@ -86,9 +86,9 @@ class Test_DataTableSource:
             plot = Plot(height=400, width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
             plot.tags.append(CustomJS(name="custom-action", args=dict(s=source), code=RECORD("data", "s.data")))
 
-            @btn.on_click
-            def btn_click():
+            def btn_click(event):
                 source.patch({"x": [(0, 42)]})
+            btn.on_event('button_click', btn_click)
 
             doc.add_root(column(plot, table, btn))
 
@@ -141,9 +141,9 @@ class Test_DataTableSource:
             plot = Plot(height=400, width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
             plot.tags.append(CustomJS(name="custom-action", args=dict(s=source), code=RECORD("data", "s.data")))
 
-            @btn.on_click
-            def btn_click():
+            def btn_click(event):
                 source.stream({"x": [5], "y": [50]})
+            btn.on_event('button_click', btn_click)
 
             doc.add_root(column(plot, table, btn))
 
@@ -197,9 +197,9 @@ class Test_DataTableSource:
             plot = Plot(height=400, width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
             plot.tags.append(CustomJS(name="custom-action", args=dict(s=source), code=RECORD("data", "s.data")))
 
-            @btn.on_click
-            def btn_click():
+            def btn_click(event):
                 source.data = {'x': [5,6,7,8], 'y': [50,60,70,80]}
+            btn.on_event('button_click', btn_click)
 
             doc.add_root(column(plot, table, btn))
 
@@ -406,7 +406,7 @@ class Test_DataTableSource:
 
             def cb():
                 source.data =  {'x': [0,1,2,3,4,5,6,7], 'y': [70,60,50,40,30,20,10,0]}
-            button.on_click(cb)
+            button.on_event('button_click', cb)
 
             doc.add_root(column(plot, table, button))
 
@@ -464,7 +464,7 @@ class Test_DataTableSource:
 
             def cb():
                 source.patch({'y': [[2, 100]]})
-            button.on_click(cb)
+            button.on_event('button_click', cb)
 
             doc.add_root(column(plot, table, button))
 
@@ -522,7 +522,7 @@ class Test_DataTableSource:
 
             def cb():
                 source.stream({'x': [100], 'y': [100]})
-            button.on_click(cb)
+            button.on_event('button_click', cb)
 
             doc.add_root(column(plot, table, button))
 

--- a/tests/integration/widgets/test_button.py
+++ b/tests/integration/widgets/test_button.py
@@ -63,33 +63,6 @@ class Test_Button:
         assert typ in button.get_attribute('class')
 
     @flaky(max_runs=10)
-    def test_server_on_click_round_trip(self, bokeh_server_page: BokehServerPage) -> None:
-
-        button = Button()
-        def modify_doc(doc):
-            source = ColumnDataSource(dict(x=[1, 2], y=[1, 1]))
-            plot = Plot(height=400, width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
-            plot.add_glyph(source, Circle(x='x', y='y', size=20))
-            plot.tags.append(CustomJS(name="custom-action", args=dict(s=source), code=RECORD("data", "s.data")))
-            def cb(event):
-                source.data=dict(x=[10, 20], y=[10, 10])
-            button.on_click(cb)
-            doc.add_root(column(button, plot))
-
-        page = bokeh_server_page(modify_doc)
-
-        button_el = find_element_for(page.driver, button, ".bk-btn")
-        button_el.click()
-
-        page.eval_custom_action()
-
-        results = page.results
-        assert results == {'data': {'x': [10, 20], 'y': [10, 10]}}
-
-        # XXX (bev) disabled until https://github.com/bokeh/bokeh/issues/7970 is resolved
-        #assert page.has_no_console_errors()
-
-    @flaky(max_runs=10)
     def test_server_on_event_round_trip(self, bokeh_server_page: BokehServerPage) -> None:
 
         button = Button()
@@ -119,20 +92,6 @@ class Test_Button:
     def test_js_on_event_executes(self, bokeh_model_page: BokehModelPage) -> None:
         button = Button()
         button.js_on_event('button_click', CustomJS(code=RECORD("clicked", "true")))
-
-        page = bokeh_model_page(button)
-
-        button_el = find_element_for(page.driver, button, ".bk-btn")
-        button_el.click()
-
-        results = page.results
-        assert results == {'clicked': True}
-
-        assert page.has_no_console_errors()
-
-    def test_js_on_click_executes(self, bokeh_model_page: BokehModelPage) -> None:
-        button = Button()
-        button.js_on_click(CustomJS(code=RECORD("clicked", "true")))
 
         page = bokeh_model_page(button)
 

--- a/tests/integration/widgets/test_checkbox_button_group.py
+++ b/tests/integration/widgets/test_checkbox_button_group.py
@@ -54,9 +54,9 @@ class Test_CheckboxButtonGroup:
             plot = Plot(height=400, width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
             plot.add_glyph(source, Circle(x='x', y='y', size=20))
             plot.tags.append(CustomJS(name="custom-action", args=dict(s=source), code=RECORD("data", "s.data")))
-            def cb(active):
-                source.data['val'] = (active + [0, 0])[:2] # keep col length at 2, padded with zero
-            group.on_click(cb)
+            def cb(event):
+                source.data['val'] = (group.active + [0, 0])[:2] # keep col length at 2, padded with zero
+            group.on_event('button_click', cb)
             doc.add_root(column(group, plot))
 
         page = bokeh_server_page(modify_doc)
@@ -82,7 +82,7 @@ class Test_CheckboxButtonGroup:
 
     def test_js_on_change_executes(self, bokeh_model_page: BokehModelPage) -> None:
         group = CheckboxButtonGroup(labels=LABELS)
-        group.js_on_click(CustomJS(code=RECORD("active", "cb_obj.active")))
+        group.js_on_event('button_click', CustomJS(code=RECORD("active", "cb_obj.origin.active")))
 
         page = bokeh_model_page(group)
 

--- a/tests/integration/widgets/test_checkbox_group.py
+++ b/tests/integration/widgets/test_checkbox_group.py
@@ -69,9 +69,9 @@ class Test_CheckboxGroup:
             plot = Plot(height=400, width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
             plot.add_glyph(source, Circle(x='x', y='y', size=20))
             plot.tags.append(CustomJS(name="custom-action", args=dict(s=source), code=RECORD("data", "s.data")))
-            def cb(event):
+            def cb(attr, old, new):
                 source.data['val'] = (group.active + [0, 0])[:2] # keep col length at 2, padded with zero
-            group.on_event('button_click', cb)
+            group.on_change('active', cb)
             doc.add_root(column(group, plot))
 
         page = bokeh_server_page(modify_doc)
@@ -97,7 +97,7 @@ class Test_CheckboxGroup:
 
     def test_js_on_change_executes(self, bokeh_model_page: BokehModelPage) -> None:
         group = CheckboxGroup(labels=LABELS)
-        group.js_on_event('button_click', CustomJS(code=RECORD("active", "cb_obj.origin.active")))
+        group.js_on_change('active', CustomJS(code=RECORD("active", "cb_obj.active")))
 
         page = bokeh_model_page(group)
 

--- a/tests/integration/widgets/test_checkbox_group.py
+++ b/tests/integration/widgets/test_checkbox_group.py
@@ -69,9 +69,9 @@ class Test_CheckboxGroup:
             plot = Plot(height=400, width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
             plot.add_glyph(source, Circle(x='x', y='y', size=20))
             plot.tags.append(CustomJS(name="custom-action", args=dict(s=source), code=RECORD("data", "s.data")))
-            def cb(active):
-                source.data['val'] = (active + [0, 0])[:2] # keep col length at 2, padded with zero
-            group.on_click(cb)
+            def cb(event):
+                source.data['val'] = (group.active + [0, 0])[:2] # keep col length at 2, padded with zero
+            group.on_event('button_click', cb)
             doc.add_root(column(group, plot))
 
         page = bokeh_server_page(modify_doc)
@@ -97,7 +97,7 @@ class Test_CheckboxGroup:
 
     def test_js_on_change_executes(self, bokeh_model_page: BokehModelPage) -> None:
         group = CheckboxGroup(labels=LABELS)
-        group.js_on_click(CustomJS(code=RECORD("active", "cb_obj.active")))
+        group.js_on_event('button_click', CustomJS(code=RECORD("active", "cb_obj.origin.active")))
 
         page = bokeh_model_page(group)
 

--- a/tests/integration/widgets/test_radio_button_group.py
+++ b/tests/integration/widgets/test_radio_button_group.py
@@ -54,9 +54,9 @@ class Test_RadioButtonGroup:
             plot = Plot(height=400, width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
             plot.add_glyph(source, Circle(x='x', y='y', size=20))
             plot.tags.append(CustomJS(name="custom-action", args=dict(s=source), code=RECORD("data", "s.data")))
-            def cb(active):
-                source.data['val'] = [active, "b"]
-            group.on_click(cb)
+            def cb(event):
+                source.data['val'] = [group.active, "b"]
+            group.on_event('button_click', cb)
             doc.add_root(column(group, plot))
 
         page = bokeh_server_page(modify_doc)
@@ -82,7 +82,7 @@ class Test_RadioButtonGroup:
 
     def test_js_on_change_executes(self, bokeh_model_page: BokehModelPage) -> None:
         group = RadioButtonGroup(labels=LABELS)
-        group.js_on_click(CustomJS(code=RECORD("active", "cb_obj.active")))
+        group.js_on_event('button_click', CustomJS(code=RECORD("active", "cb_obj.origin.active")))
 
         page = bokeh_model_page(group)
 

--- a/tests/integration/widgets/test_radio_group.py
+++ b/tests/integration/widgets/test_radio_group.py
@@ -68,9 +68,9 @@ class Test_RadioGroup:
             plot = Plot(height=400, width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
             plot.add_glyph(source, Circle(x='x', y='y', size=20))
             plot.tags.append(CustomJS(name="custom-action", args=dict(s=source), code=RECORD("data", "s.data")))
-            def cb(event):
-                source.data['val'] = [group.active, "b"]
-            group.on_event('button_click', cb)
+            def cb(attr, old, new):
+                source.data['val'] = [new, "b"]
+            group.on_change('active', cb)
             doc.add_root(column(group, plot))
 
         page = bokeh_server_page(modify_doc)
@@ -96,7 +96,7 @@ class Test_RadioGroup:
 
     def test_js_on_change_executes(self, bokeh_model_page: BokehModelPage) -> None:
         group = RadioGroup(labels=LABELS)
-        group.js_on_event('button_click', CustomJS(code=RECORD("active", "cb_obj.origin.active")))
+        group.js_on_change('active', CustomJS(code=RECORD("active", "cb_obj.active")))
 
         page = bokeh_model_page(group)
 

--- a/tests/integration/widgets/test_radio_group.py
+++ b/tests/integration/widgets/test_radio_group.py
@@ -68,9 +68,9 @@ class Test_RadioGroup:
             plot = Plot(height=400, width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
             plot.add_glyph(source, Circle(x='x', y='y', size=20))
             plot.tags.append(CustomJS(name="custom-action", args=dict(s=source), code=RECORD("data", "s.data")))
-            def cb(active):
-                source.data['val'] = [active, "b"]
-            group.on_click(cb)
+            def cb(event):
+                source.data['val'] = [group.active, "b"]
+            group.on_event('button_click', cb)
             doc.add_root(column(group, plot))
 
         page = bokeh_server_page(modify_doc)
@@ -96,7 +96,7 @@ class Test_RadioGroup:
 
     def test_js_on_change_executes(self, bokeh_model_page: BokehModelPage) -> None:
         group = RadioGroup(labels=LABELS)
-        group.js_on_click(CustomJS(code=RECORD("active", "cb_obj.active")))
+        group.js_on_event('button_click', CustomJS(code=RECORD("active", "cb_obj.origin.active")))
 
         page = bokeh_model_page(group)
 

--- a/tests/integration/widgets/test_toggle.py
+++ b/tests/integration/widgets/test_toggle.py
@@ -70,12 +70,12 @@ class Test_Toggle:
             plot = Plot(height=400, width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
             plot.add_glyph(source, Circle(x='x', y='y', size=20))
             plot.tags.append(CustomJS(name="custom-action", args=dict(s=source), code=RECORD("data", "s.data")))
-            def cb(value):
-                if value:
+            def cb(event):
+                if button.active:
                     source.data=dict(x=[10, 20], y=[10, 10])
                 else:
                     source.data=dict(x=[100, 200], y=[100, 100])
-            button.on_click(cb)
+            button.on_event('button_click', cb)
             doc.add_root(column(button, plot))
 
         page = bokeh_server_page(modify_doc)
@@ -111,7 +111,7 @@ class Test_Toggle:
 
     def test_js_on_click_executes(self, bokeh_model_page: BokehModelPage) -> None:
         button = Toggle()
-        button.js_on_click(CustomJS(code=RECORD("value", "cb_obj.active")))
+        button.js_on_event('button_click', CustomJS(code=RECORD("value", "cb_obj.origin.active")))
 
         page = bokeh_model_page(button)
 

--- a/tests/unit/bokeh/document/test_document.py
+++ b/tests/unit/bokeh/document/test_document.py
@@ -998,12 +998,12 @@ class TestDocument:
         button1 = Button(label="1")
         button2 = Button(label="2")
         def clicked_1():
-            button2.on_click(clicked_2)
+            button2.on_event('button_click', clicked_2)
             d.add_root(button2)
         def clicked_2():
             pass
 
-        button1.on_click(clicked_1)
+        button1.on_event('button_click', clicked_1)
         d.add_root(button1)
 
         event_json = {"event_name": "button_click", "event_values": {"model": {"id": button1.id}}}


### PR DESCRIPTION
This PR allows one to programmatically set the state of the Toggle button without invoking the click callback.

I did not find any existing tests for this, and seemed to have some issues running `node make test:unit` so did not end up that far down this path.

I spot checked a number of existing example uses of this button and there does not appear to be a change in function.

Looking forward to any feedback.

- [x] issues: fixes #10424 
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)

**Summary of Buttons and their Use**
  | on_change | js_on_change | on_event | js_on_event | on_click | js_on_click
-- | -- | -- | -- | -- | -- | --
Button | no | no | yes | yes | deprecated | deprecated
Toggle | yes | yes | yes | yes | deprecated | deprecated
Dropdown | no | no | yes | yes | deprecated | deprecated
CheckboxGroup | yes | yes | no | no | removed | removed
RadioGroup | yes | yes | no | no | removed | removed
CheckboxButtonGroup | yes | yes | yes | yes | removed | removed
RadioButtonGroup | yes | yes | yes | yes | removed | removed

