### PR TITLE
Replace PNG tool icons with a new set of SVG icons

### DIFF
--- a/bokehjs/src/less/icons.less
+++ b/bokehjs/src/less/icons.less
@@ -31,6 +31,14 @@
   .tool-icon(--bokeh-icon-box-select, "BoxSelect");
 }
 
+.bk-tool-icon-x-box-select {
+  .tool-icon(--bokeh-icon-x-box-select, "BoxSelect");
+}
+
+.bk-tool-icon-y-box-select {
+  .tool-icon(--bokeh-icon-y-box-select, "BoxSelect");
+}
+
 .bk-tool-icon-box-zoom {
   .tool-icon(--bokeh-icon-box-zoom, "BoxZoom");
 }
@@ -39,8 +47,24 @@
   .tool-icon(--bokeh-icon-zoom-in, "ZoomIn");
 }
 
+.bk-tool-icon-x-zoom-in {
+  .tool-icon(--bokeh-icon-x-zoom-in, "ZoomIn");
+}
+
+.bk-tool-icon-y-zoom-in {
+  .tool-icon(--bokeh-icon-y-zoom-in, "ZoomIn");
+}
+
 .bk-tool-icon-zoom-out {
   .tool-icon(--bokeh-icon-zoom-out, "ZoomOut");
+}
+
+.bk-tool-icon-x-zoom-out {
+  .tool-icon(--bokeh-icon-x-zoom-out, "ZoomOut");
+}
+
+.bk-tool-icon-y-zoom-out {
+  .tool-icon(--bokeh-icon-y-zoom-out, "ZoomOut");
 }
 
 .bk-tool-icon-help {
@@ -63,12 +87,12 @@
   .tool-icon(--bokeh-icon-pan, "Pan");
 }
 
-.bk-tool-icon-xpan {
-  .tool-icon(--bokeh-icon-xpan, "XPan");
+.bk-tool-icon-x-pan {
+  .tool-icon(--bokeh-icon-x-pan, "XPan");
 }
 
-.bk-tool-icon-ypan {
-  .tool-icon(--bokeh-icon-ypan, "YPan");
+.bk-tool-icon-y-pan {
+  .tool-icon(--bokeh-icon-y-pan, "YPan");
 }
 
 .bk-tool-icon-range {
@@ -129,4 +153,38 @@
 
 .bk-tool-icon-line-edit {
   .tool-icon(--bokeh-icon-line-edit, "LineEdit");
+}
+
+:host {
+  --bokeh-icon-pan: data-uri("icons/pan.svg");
+  --bokeh-icon-x-pan: data-uri("icons/x-pan.svg");
+  --bokeh-icon-y-pan: data-uri("icons/y-pan.svg");
+
+  --bokeh-icon-zoom-in: data-uri("icons/zoom-in.svg");
+  --bokeh-icon-x-zoom-in: data-uri("icons/x-zoom-in.svg");
+  --bokeh-icon-y-zoom-in: data-uri("icons/y-zoom-in.svg");
+
+  --bokeh-icon-zoom-out: data-uri("icons/zoom-out.svg");
+  --bokeh-icon-x-zoom-out: data-uri("icons/x-zoom-out.svg");
+  --bokeh-icon-y-zoom-out: data-uri("icons/y-zoom-out.svg");
+
+  --bokeh-icon-undo: data-uri("icons/undo.svg");
+  --bokeh-icon-redo: data-uri("icons/redo.svg");
+  --bokeh-icon-reset: data-uri("icons/reset.svg");
+
+  --bokeh-icon-save: data-uri("icons/download.svg");
+  --bokeh-icon-copy: data-uri("icons/copy.svg");
+
+  --bokeh-icon-help: data-uri("icons/help.svg");
+
+  --bokeh-icon-hover: data-uri("icons/tooltip.svg");
+  --bokeh-icon-crosshair: data-uri("icons/crosshair.svg");
+
+  --bokeh-icon-box-select: data-uri("icons/box-select.svg");
+  --bokeh-icon-x-box-select: data-uri("icons/x-box-select.svg");
+  --bokeh-icon-y-box-select: data-uri("icons/y-box-select.svg");
+
+  --bokeh-icon-tap-select: data-uri("icons/tap-select.svg");
+
+  --bokeh-icon-clear-selection: data-uri("icons/clear-selection.svg");
 }

--- a/bokehjs/src/less/icons.less
+++ b/bokehjs/src/less/icons.less
@@ -1,190 +1,190 @@
-.tool-icon(@icon, @file) {
-  @path: "../../../sphinx/source/_images/icons";
-  background-image: var(@icon, data-uri("@{path}/@{file}.png"));
+.tool-icon(@icon, @default) {
+  mask-image: var(@icon, @default);
+  -webkit-mask-image: var(@icon, var(@default));
 }
 
 .bk-tool-icon-copy {
-  .tool-icon(--bokeh-icon-copy, "Copy");
+  .tool-icon(--bokeh-icon-copy, --bokeh-default-icon-copy);
 }
 
 .bk-tool-icon-replace-mode {
-  .tool-icon(--bokeh-icon-replace-mode, "ReplaceMode");
+  .tool-icon(--bokeh-icon-replace-mode, --bokeh-default-icon-replace-mode);
 }
 
 .bk-tool-icon-append-mode {
-  .tool-icon(--bokeh-icon-append-mode, "AppendMode");
+  .tool-icon(--bokeh-icon-append-mode, --bokeh-default-icon-append-mode);
 }
 
 .bk-tool-icon-intersect-mode {
-  .tool-icon(--bokeh-icon-intersect-mode, "IntersectMode");
+  .tool-icon(--bokeh-icon-intersect-mode, --bokeh-default-icon-intersect-mode);
 }
 
 .bk-tool-icon-subtract-mode {
-  .tool-icon(--bokeh-icon-subtract-mode, "SubtractMode");
+  .tool-icon(--bokeh-icon-subtract-mode, --bokeh-default-icon-subtract-mode);
 }
 
 .bk-tool-icon-clear-selection {
-  .tool-icon(--bokeh-icon-clear-selection, "ClearSelection");
+  .tool-icon(--bokeh-icon-clear-selection, --bokeh-default-icon-clear-selection);
 }
 
 .bk-tool-icon-box-select {
-  .tool-icon(--bokeh-icon-box-select, "BoxSelect");
+  .tool-icon(--bokeh-icon-box-select, --bokeh-default-icon-box-select);
 }
 
 .bk-tool-icon-x-box-select {
-  .tool-icon(--bokeh-icon-x-box-select, "BoxSelect");
+  .tool-icon(--bokeh-icon-x-box-select, --bokeh-default-icon-x-box-select);
 }
 
 .bk-tool-icon-y-box-select {
-  .tool-icon(--bokeh-icon-y-box-select, "BoxSelect");
+  .tool-icon(--bokeh-icon-y-box-select, --bokeh-default-icon-y-box-select);
 }
 
 .bk-tool-icon-box-zoom {
-  .tool-icon(--bokeh-icon-box-zoom, "BoxZoom");
+  .tool-icon(--bokeh-icon-box-zoom, --bokeh-default-icon-box-zoom);
 }
 
 .bk-tool-icon-zoom-in {
-  .tool-icon(--bokeh-icon-zoom-in, "ZoomIn");
+  .tool-icon(--bokeh-icon-zoom-in, --bokeh-default-icon-zoom-in);
 }
 
 .bk-tool-icon-x-zoom-in {
-  .tool-icon(--bokeh-icon-x-zoom-in, "ZoomIn");
+  .tool-icon(--bokeh-icon-x-zoom-in, --bokeh-default-icon-x-zoom-in);
 }
 
 .bk-tool-icon-y-zoom-in {
-  .tool-icon(--bokeh-icon-y-zoom-in, "ZoomIn");
+  .tool-icon(--bokeh-icon-y-zoom-in, --bokeh-default-icon-y-zoom-in);
 }
 
 .bk-tool-icon-zoom-out {
-  .tool-icon(--bokeh-icon-zoom-out, "ZoomOut");
+  .tool-icon(--bokeh-icon-zoom-out, --bokeh-default-icon-zoom-out);
 }
 
 .bk-tool-icon-x-zoom-out {
-  .tool-icon(--bokeh-icon-x-zoom-out, "ZoomOut");
+  .tool-icon(--bokeh-icon-x-zoom-out, --bokeh-default-icon-x-zoom-out);
 }
 
 .bk-tool-icon-y-zoom-out {
-  .tool-icon(--bokeh-icon-y-zoom-out, "ZoomOut");
+  .tool-icon(--bokeh-icon-y-zoom-out, --bokeh-default-icon-y-zoom-out);
 }
 
 .bk-tool-icon-help {
-  .tool-icon(--bokeh-icon-help, "Help");
+  .tool-icon(--bokeh-icon-help, --bokeh-default-icon-help);
 }
 
 .bk-tool-icon-hover {
-  .tool-icon(--bokeh-icon-hover, "Hover");
+  .tool-icon(--bokeh-icon-hover, --bokeh-default-icon-hover);
 }
 
 .bk-tool-icon-crosshair {
-  .tool-icon(--bokeh-icon-crosshair, "Crosshair");
+  .tool-icon(--bokeh-icon-crosshair, --bokeh-default-icon-crosshair);
 }
 
 .bk-tool-icon-lasso-select {
-  .tool-icon(--bokeh-icon-lasso-select, "LassoSelect");
+  .tool-icon(--bokeh-icon-lasso-select, --bokeh-default-icon-lasso-select);
 }
 
 .bk-tool-icon-pan {
-  .tool-icon(--bokeh-icon-pan, "Pan");
+  .tool-icon(--bokeh-icon-pan, --bokeh-default-icon-pan);
 }
 
 .bk-tool-icon-x-pan {
-  .tool-icon(--bokeh-icon-x-pan, "XPan");
+  .tool-icon(--bokeh-icon-x-pan, --bokeh-default-icon-x-pan);
 }
 
 .bk-tool-icon-y-pan {
-  .tool-icon(--bokeh-icon-y-pan, "YPan");
+  .tool-icon(--bokeh-icon-y-pan, --bokeh-default-icon-y-pan);
 }
 
 .bk-tool-icon-range {
-  .tool-icon(--bokeh-icon-range, "Range");
+  .tool-icon(--bokeh-icon-range, --bokeh-default-icon-range);
 }
 
 .bk-tool-icon-polygon-select {
-  .tool-icon(--bokeh-icon-polygon-select, "PolygonSelect");
+  .tool-icon(--bokeh-icon-polygon-select, --bokeh-default-icon-polygon-select);
 }
 
 .bk-tool-icon-redo {
-  .tool-icon(--bokeh-icon-redo, "Redo");
+  .tool-icon(--bokeh-icon-redo, --bokeh-default-icon-redo);
 }
 
 .bk-tool-icon-reset {
-  .tool-icon(--bokeh-icon-reset, "Reset");
+  .tool-icon(--bokeh-icon-reset, --bokeh-default-icon-reset);
 }
 
 .bk-tool-icon-save {
-  .tool-icon(--bokeh-icon-save, "Save");
+  .tool-icon(--bokeh-icon-save, --bokeh-default-icon-save);
 }
 
 .bk-tool-icon-tap-select {
-  .tool-icon(--bokeh-icon-tap-select, "Tap");
+  .tool-icon(--bokeh-icon-tap-select, --bokeh-default-icon-tap-select);
 }
 
 .bk-tool-icon-undo {
-  .tool-icon(--bokeh-icon-undo, "Undo");
+  .tool-icon(--bokeh-icon-undo, --bokeh-default-icon-undo);
 }
 
 .bk-tool-icon-wheel-pan {
-  .tool-icon(--bokeh-icon-wheel-pan, "WheelPan");
+  .tool-icon(--bokeh-icon-wheel-pan, --bokeh-default-icon-wheel-pan);
 }
 
 .bk-tool-icon-wheel-zoom {
-  .tool-icon(--bokeh-icon-wheel-zoom, "WheelZoom");
+  .tool-icon(--bokeh-icon-wheel-zoom, --bokeh-default-icon-wheel-zoom);
 }
 
 .bk-tool-icon-box-edit {
-  .tool-icon(--bokeh-icon-box-edit, "BoxEdit");
+  .tool-icon(--bokeh-icon-box-edit, --bokeh-default-icon-box-edit);
 }
 
 .bk-tool-icon-freehand-draw {
-  .tool-icon(--bokeh-icon-freehand-draw, "FreehandDraw");
+  .tool-icon(--bokeh-icon-freehand-draw, --bokeh-default-icon-freehand-draw);
 }
 
 .bk-tool-icon-poly-draw {
-  .tool-icon(--bokeh-icon-poly-draw, "PolyDraw");
+  .tool-icon(--bokeh-icon-poly-draw, --bokeh-default-icon-poly-draw);
 }
 
 .bk-tool-icon-point-draw {
-  .tool-icon(--bokeh-icon-point-draw, "PointDraw");
+  .tool-icon(--bokeh-icon-point-draw, --bokeh-default-icon-point-draw);
 }
 
 .bk-tool-icon-poly-edit {
-  .tool-icon(--bokeh-icon-poly-edit, "PolyEdit");
+  .tool-icon(--bokeh-icon-poly-edit, --bokeh-default-icon-poly-edit);
 }
 
 .bk-tool-icon-line-edit {
-  .tool-icon(--bokeh-icon-line-edit, "LineEdit");
+  .tool-icon(--bokeh-icon-line-edit, --bokeh-default-icon-line-edit);
 }
 
 :host {
-  --bokeh-icon-pan: data-uri("icons/pan.svg");
-  --bokeh-icon-x-pan: data-uri("icons/x-pan.svg");
-  --bokeh-icon-y-pan: data-uri("icons/y-pan.svg");
+  --bokeh-default-icon-pan: data-uri("icons/pan.svg");
+  --bokeh-default-icon-x-pan: data-uri("icons/x-pan.svg");
+  --bokeh-default-icon-y-pan: data-uri("icons/y-pan.svg");
 
-  --bokeh-icon-zoom-in: data-uri("icons/zoom-in.svg");
-  --bokeh-icon-x-zoom-in: data-uri("icons/x-zoom-in.svg");
-  --bokeh-icon-y-zoom-in: data-uri("icons/y-zoom-in.svg");
+  --bokeh-default-icon-zoom-in: data-uri("icons/zoom-in.svg");
+  --bokeh-default-icon-x-zoom-in: data-uri("icons/x-zoom-in.svg");
+  --bokeh-default-icon-y-zoom-in: data-uri("icons/y-zoom-in.svg");
 
-  --bokeh-icon-zoom-out: data-uri("icons/zoom-out.svg");
-  --bokeh-icon-x-zoom-out: data-uri("icons/x-zoom-out.svg");
-  --bokeh-icon-y-zoom-out: data-uri("icons/y-zoom-out.svg");
+  --bokeh-default-icon-zoom-out: data-uri("icons/zoom-out.svg");
+  --bokeh-default-icon-x-zoom-out: data-uri("icons/x-zoom-out.svg");
+  --bokeh-default-icon-y-zoom-out: data-uri("icons/y-zoom-out.svg");
 
-  --bokeh-icon-undo: data-uri("icons/undo.svg");
-  --bokeh-icon-redo: data-uri("icons/redo.svg");
-  --bokeh-icon-reset: data-uri("icons/reset.svg");
+  --bokeh-default-icon-undo: data-uri("icons/undo.svg");
+  --bokeh-default-icon-redo: data-uri("icons/redo.svg");
+  --bokeh-default-icon-reset: data-uri("icons/reset.svg");
 
-  --bokeh-icon-save: data-uri("icons/download.svg");
-  --bokeh-icon-copy: data-uri("icons/copy.svg");
+  --bokeh-default-icon-save: data-uri("icons/download.svg");
+  --bokeh-default-icon-copy: data-uri("icons/copy.svg");
 
-  --bokeh-icon-help: data-uri("icons/help.svg");
+  --bokeh-default-icon-help: data-uri("icons/help.svg");
 
-  --bokeh-icon-hover: data-uri("icons/tooltip.svg");
-  --bokeh-icon-crosshair: data-uri("icons/crosshair.svg");
+  --bokeh-default-icon-hover: data-uri("icons/tooltip.svg");
+  --bokeh-default-icon-crosshair: data-uri("icons/crosshair.svg");
 
-  --bokeh-icon-box-select: data-uri("icons/box-select.svg");
-  --bokeh-icon-x-box-select: data-uri("icons/x-box-select.svg");
-  --bokeh-icon-y-box-select: data-uri("icons/y-box-select.svg");
+  --bokeh-default-icon-box-select: data-uri("icons/box-select.svg");
+  --bokeh-default-icon-x-box-select: data-uri("icons/x-box-select.svg");
+  --bokeh-default-icon-y-box-select: data-uri("icons/y-box-select.svg");
 
-  --bokeh-icon-tap-select: data-uri("icons/tap-select.svg");
+  --bokeh-default-icon-tap-select: data-uri("icons/tap-select.svg");
 
-  --bokeh-icon-clear-selection: data-uri("icons/clear-selection.svg");
+  --bokeh-default-icon-clear-selection: data-uri("icons/clear-selection.svg");
 }

--- a/bokehjs/src/less/icons/box-select.svg
+++ b/bokehjs/src/less/icons/box-select.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="24" height="24">
+<g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<path d="M7,4H4V7"/>
+<path d="M4,11V13"/>
+<path d="M11,4H13"/>
+<path d="M11,20H13"/>
+<path d="M20,11V13"/>
+<path d="M17,4H20V7"/>
+<path d="M7,20H4V17"/>
+<path d="M17,20H20V17"/>
+</g>
+</svg>

--- a/bokehjs/src/less/icons/clear-selection.svg
+++ b/bokehjs/src/less/icons/clear-selection.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="24" height="24">
+<g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<path d="M7,4H4v3" />
+<path d="M4,11V13" />
+<path d="M11,20H13" />
+<path d="M20,11V13" />
+<path d="m17,4 h3v3" />
+<path d="M7,20H4V17" />
+<path d="m11,4 h2" />
+<path d="m16,16 5,5" />
+<path d="m21,16 -5,5" />
+</g>
+</svg>

--- a/bokehjs/src/less/icons/copy.svg
+++ b/bokehjs/src/less/icons/copy.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="24" height="24">
+<g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<path d="M19.4 20H9.6C9.26863 20 9 19.7314 9 19.4V9.6C9 9.26863 9.26863 9 9.6 9H19.4C19.7314 9 20 9.26863 20 9.6V19.4C20 19.7314 19.7314 20 19.4 20Z"/>
+<path d="M15 9V4.6C15 4.26863 14.7314 4 14.4 4H4.6C4.26863 4 4 4.26863 4 4.6V14.4C4 14.7314 4.26863 15 4.6 15H9"/>
+</g>
+</svg>

--- a/bokehjs/src/less/icons/crosshair.svg
+++ b/bokehjs/src/less/icons/crosshair.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="24" height="24">
+<g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<path d="M12,12m-9,0a9,9 0 1,0 18,0a9,9 0 1,0 -18,0" />
+<path d="M12,12m-9,0h4" />
+<path d="M12,12m9,0h-4" />
+<path d="M12,12m0,-9v4" />
+<path d="M12,12m0,9v-4" />
+</g>
+</svg>

--- a/bokehjs/src/less/icons/download.svg
+++ b/bokehjs/src/less/icons/download.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="24" height="24">
+<g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<path d="M6 20L18 20"/>
+<path d="M12 4V16M12 16L15.5 12.5M12 16L8.5 12.5"/>
+</g>
+</svg>

--- a/bokehjs/src/less/icons/help.svg
+++ b/bokehjs/src/less/icons/help.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="24" height="24">
+<g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"/>
+<path d="M9 9C9 5.49997 14.5 5.5 14.5 9C14.5 11.5 12 10.9999 12 13.9999"/>
+<path d="M12 18.01L12.01 17.9989"/>
+</g>
+</svg>

--- a/bokehjs/src/less/icons/pan.svg
+++ b/bokehjs/src/less/icons/pan.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="24" height="24">
+  <g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M 12,2 9,5 m 3,-3 3,3 m -3,17 3,-3 M 12,22 9,19 M 12,2 v 20" />
+    <path d="M 2,12 5,9 m -3,3 3,3 m 17,-3 -3,3 M 22,12 19,9 M 2,12 h 20" />
+  </g>
+</svg>

--- a/bokehjs/src/less/icons/redo.svg
+++ b/bokehjs/src/less/icons/redo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="24" height="24">
+<g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<path d="M19 9.5C15.5 9.5 12.5 9.5 9 9.5C8.83847 9.5 5 9.5 5 13.5C5 18 8.70237 18 9 18C12 18 14 18 17 18"/>
+<path d="M15.5 13C16.8668 11.6332 17.6332 10.8668 19 9.5C17.6332 8.13317 16.8668 7.36683 15.5 6"/>
+</g>
+</svg>

--- a/bokehjs/src/less/icons/reset.svg
+++ b/bokehjs/src/less/icons/reset.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="24" height="24">
+<g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<path d="M21.1679 8C19.6247 4.46819 16.1006 2 11.9999 2C6.81459 2 2.55104 5.94668 2.04932 11"/>
+<path d="M17 8H21.4C21.7314 8 22 7.73137 22 7.4V3"/>
+<path d="M2.88146 16C4.42458 19.5318 7.94874 22 12.0494 22C17.2347 22 21.4983 18.0533 22 13"/>
+<path d="M7.04932 16H2.64932C2.31795 16 2.04932 16.2686 2.04932 16.6V21"/>
+</g>
+</svg>

--- a/bokehjs/src/less/icons/tap-select.svg
+++ b/bokehjs/src/less/icons/tap-select.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="24" height="24">
+<g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<path d="M12 13C12.5523 13 13 12.5523 13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12C11 12.5523 11.4477 13 12 13Z" fill="currentColor"/>
+<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"/>
+</g>
+</svg>

--- a/bokehjs/src/less/icons/tooltip.svg
+++ b/bokehjs/src/less/icons/tooltip.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="24" height="24">
+<g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<path d="M7 12L17 12"/>
+<path d="M7 8L13 8"/>
+<path d="M3 20.2895V5C3 3.89543 3.89543 3 5 3H19C20.1046 3 21 3.89543 21 5V15C21 16.1046 20.1046 17 19 17H7.96125C7.35368 17 6.77906 17.2762 6.39951 17.7506L4.06852 20.6643C3.71421 21.1072 3 20.8567 3 20.2895Z"/>
+</g>
+</svg>

--- a/bokehjs/src/less/icons/undo.svg
+++ b/bokehjs/src/less/icons/undo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="24" height="24">
+<g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<path d="M5 9.5C8.5 9.5 11.5 9.5 15 9.5C15.1615 9.5 19 9.5 19 13.5C19 18 15.2976 18 15 18C12 18 10 18 7 18"/>
+<path d="M8.5 13C7.13317 11.6332 6.36683 10.8668 5 9.5C6.36683 8.13317 7.13317 7.36683 8.5 6"/>
+</g>
+</svg>

--- a/bokehjs/src/less/icons/x-box-select.svg
+++ b/bokehjs/src/less/icons/x-box-select.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="24" height="24">
+<g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<path d="M7,4H4V7"/>
+<path d="M4,11V13"/>
+<path d="M11,4H13"/>
+<path d="M11,20H13"/>
+<path d="M20,11V13"/>
+<path d="M17,4H20V7"/>
+<path d="M7,20H4V17"/>
+<path d="M17,20H20V17"/>
+</g>
+</svg>

--- a/bokehjs/src/less/icons/x-pan.svg
+++ b/bokehjs/src/less/icons/x-pan.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="24" height="24">
+  <g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M 2,12 5,9 m -3,3 3,3 m 17,-3 -3,3 M 22,12 19,9 M 2,12 h 20" />
+  </g>
+</svg>

--- a/bokehjs/src/less/icons/x-zoom-in.svg
+++ b/bokehjs/src/less/icons/x-zoom-in.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="24" height="24">
+<g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<path d="M12,8m-2,0h4m-2,-2v4" />
+<path d="M12,8m5,5l4,4" />
+<path d="M12,8m-7,0a7,7 0 1,0 14,0a7,7 0 1,0 -14,0" />
+<path d="M5,20l3,-3m-3,3l3,3m-3,-3h14l-3,-3m3,3l-3,3" />
+</g>
+</svg>

--- a/bokehjs/src/less/icons/x-zoom-out.svg
+++ b/bokehjs/src/less/icons/x-zoom-out.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="24" height="24">
+<g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<path d="M12,8m-2,0h4" />
+<path d="M12,8m5,5l4,4" />
+<path d="M12,8m-7,0a7,7 0 1,0 14,0a7,7 0 1,0 -14,0" />
+<path d="M5,20l3,-3m-3,3l3,3m-3,-3h14l-3,-3m3,3l-3,3" />
+</g>
+</svg>

--- a/bokehjs/src/less/icons/y-box-select.svg
+++ b/bokehjs/src/less/icons/y-box-select.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="24" height="24">
+<g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<path d="M7,4H4V7"/>
+<path d="M4,11V13"/>
+<path d="M11,4H13"/>
+<path d="M11,20H13"/>
+<path d="M20,11V13"/>
+<path d="M17,4H20V7"/>
+<path d="M7,20H4V17"/>
+<path d="M17,20H20V17"/>
+</g>
+</svg>

--- a/bokehjs/src/less/icons/y-pan.svg
+++ b/bokehjs/src/less/icons/y-pan.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="24" height="24">
+  <g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M 12,2 9,5 m 3,-3 3,3 m -3,17 3,-3 M 12,22 9,19 M 12,2 v 20" />
+  </g>
+</svg>

--- a/bokehjs/src/less/icons/y-zoom-in.svg
+++ b/bokehjs/src/less/icons/y-zoom-in.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="24" height="24">
+<g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<path d="M8,12m-2,0h4m-2,-2v4" />
+<path d="M8,12m5,5l4,4" />
+<path d="M8,12m-7,0a7,7 0 1,0 14,0a7,7 0 1,0 -14,0" />
+<path d="M20,5l-3,3m3,-3l3,3m-3,-3v14l-3,-3m3,3l3,-3" />
+</g>
+</svg>

--- a/bokehjs/src/less/icons/y-zoom-out.svg
+++ b/bokehjs/src/less/icons/y-zoom-out.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="24" height="24">
+<g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<path d="M8,12m-2,0h4" />
+<path d="M8,12m5,5l4,4" />
+<path d="M8,12m-7,0a7,7 0 1,0 14,0a7,7 0 1,0 -14,0" />
+<path d="M20,5l-3,3m3,-3l3,3m-3,-3v14l-3,-3m3,3l3,-3" />
+</g>
+</svg>

--- a/bokehjs/src/less/icons/zoom-in.svg
+++ b/bokehjs/src/less/icons/zoom-in.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="24" height="24">
+<g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<path d="M12,12m-2,0h4m-2,-2v4" />
+<path d="M12,12m5,5l4,4" />
+<path d="M12,12m-7,0a7,7 0 1,0 14,0a7,7 0 1,0 -14,0" />
+</g>
+</svg>

--- a/bokehjs/src/less/icons/zoom-out.svg
+++ b/bokehjs/src/less/icons/zoom-out.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="24" height="24">
+<g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<path d="M12,12m-2,0h4" />
+<path d="M12,12m5,5l4,4" />
+<path d="M12,12m-7,0a7,7 0 1,0 14,0a7,7 0 1,0 -14,0" />
+</g>
+</svg>

--- a/bokehjs/src/less/tool_button.less
+++ b/bokehjs/src/less/tool_button.less
@@ -8,16 +8,22 @@
 }
 
 .bk-toolbar-button {
+  display: flex;
+
+  align-items: center;
+  justify-content: center;
+
   width: var(--button-width);
   height: var(--button-height);
 
   cursor: pointer;
+}
 
-  background-size: 60% 60%;
-  background-origin: border-box;
-  background-color: transparent;
-  background-repeat: no-repeat;
-  background-position: center center;
+.icon {
+  width: 24px;
+  height: 24px;
+
+  background-color: #a1a6a9;
 }
 
 .bk-toolbar-button, .bk-tool-overflow {

--- a/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
@@ -51,10 +51,11 @@ export abstract class ZoomBaseTool extends ActionTool {
     }))
   }
 
+  readonly maintain_focus: boolean = true
+
   readonly sign: -1 | 1
 
   override get tooltip(): string {
     return this._get_dim_tooltip(this.dimensions)
   }
-  readonly maintain_focus: boolean = true
 }

--- a/bokehjs/src/lib/models/tools/actions/zoom_in_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_in_tool.ts
@@ -1,5 +1,5 @@
 import {ZoomBaseTool, ZoomBaseToolView} from "./zoom_base_tool"
-import {tool_icon_zoom_in} from "styles/icons.css"
+import * as icons from "styles/icons.css"
 
 export class ZoomInToolView extends ZoomBaseToolView {
   override model: ZoomBaseTool
@@ -25,5 +25,17 @@ export class ZoomInTool extends ZoomBaseTool {
 
   override sign = 1 as 1
   override tool_name = "Zoom In"
-  override tool_icon = tool_icon_zoom_in
+
+  override get computed_icon(): string {
+    const {icon} = this
+    if (icon != null)
+      return icon
+    else {
+      switch (this.dimensions) {
+        case "both":   return `.${icons.tool_icon_zoom_in}`
+        case "width":  return `.${icons.tool_icon_x_zoom_in}`
+        case "height": return `.${icons.tool_icon_y_zoom_in}`
+      }
+    }
+  }
 }

--- a/bokehjs/src/lib/models/tools/actions/zoom_out_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_out_tool.ts
@@ -1,5 +1,5 @@
 import {ZoomBaseTool, ZoomBaseToolView} from "./zoom_base_tool"
-import {tool_icon_zoom_out} from "styles/icons.css"
+import * as icons from "styles/icons.css"
 import * as p from "core/properties"
 
 export class ZoomOutToolView extends ZoomBaseToolView {
@@ -38,5 +38,17 @@ export class ZoomOutTool extends ZoomBaseTool {
 
   override sign = -1 as -1
   override tool_name = "Zoom Out"
-  override tool_icon = tool_icon_zoom_out
+
+  override get computed_icon(): string {
+    const {icon} = this
+    if (icon != null)
+      return icon
+    else {
+      switch (this.dimensions) {
+        case "both":   return `.${icons.tool_icon_zoom_out}`
+        case "width":  return `.${icons.tool_icon_x_zoom_out}`
+        case "height": return `.${icons.tool_icon_y_zoom_out}`
+      }
+    }
+  }
 }

--- a/bokehjs/src/lib/models/tools/button_tool.ts
+++ b/bokehjs/src/lib/models/tools/button_tool.ts
@@ -3,7 +3,7 @@ import Hammer, {Manager} from "hammerjs"
 import {Class} from "core/class"
 import {DOMView} from "core/dom_view"
 import {Tool, ToolView} from "./tool"
-import {empty, Keys} from "core/dom"
+import {div, empty, Keys} from "core/dom"
 import {Dimensions, ToolIcon} from "core/enums"
 import * as p from "core/properties"
 import {startsWith} from "core/util/string"
@@ -77,21 +77,26 @@ export abstract class ButtonToolButtonView extends DOMView {
 
   override render(): void {
     empty(this.el)
+
+    const icon_el = div({class: "icon"})
+    this.el.appendChild(icon_el)
+
     const icon = this.model.computed_icon
     if (icon != null) {
       if (startsWith(icon, "data:image")) {
         const url = `url("${encodeURI(icon)}")`
-        this.el.style.backgroundImage = url
+        icon_el.style.mask = url
       } else if (startsWith(icon, "--")) {
-        this.el.style.backgroundImage = `var(${icon})`
+        icon_el.style.mask = `var(${icon})`
       } else if (startsWith(icon, ".")) {
         const cls = icon.substring(1)
-        this.el.classList.add(cls)
+        icon_el.classList.add(cls)
       } else if (ToolIcon.valid(icon)) {
         const cls = `bk-tool-icon-${icon.replace(/_/g, "-")}`
-        this.el.classList.add(cls)
+        icon_el.classList.add(cls)
       }
     }
+
     this.el.title = this.model.tooltip
     this.el.tabIndex = 0
 

--- a/bokehjs/src/lib/models/tools/gestures/box_select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/box_select_tool.ts
@@ -4,7 +4,7 @@ import * as p from "core/properties"
 import {Dimensions, BoxOrigin, SelectionMode} from "core/enums"
 import {PanEvent} from "core/ui_events"
 import {RectGeometry} from "core/geometry"
-import {tool_icon_box_select} from "styles/icons.css"
+import * as icons from "styles/icons.css"
 
 export class BoxSelectToolView extends SelectToolView {
   override model: BoxSelectTool
@@ -117,11 +117,23 @@ export class BoxSelectTool extends SelectTool {
   }
 
   override tool_name = "Box Select"
-  override tool_icon = tool_icon_box_select
   override event_type = "pan" as "pan"
   override default_order = 30
 
   override get tooltip(): string {
     return this._get_dim_tooltip(this.dimensions)
+  }
+
+  override get computed_icon(): string {
+    const {icon} = this
+    if (icon != null)
+      return icon
+    else {
+      switch (this.dimensions) {
+        case "both":   return `.${icons.tool_icon_box_select}`
+        case "width":  return `.${icons.tool_icon_x_box_select}`
+        case "height": return `.${icons.tool_icon_y_box_select}`
+      }
+    }
   }
 }

--- a/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
@@ -162,8 +162,8 @@ export class PanTool extends GestureTool {
     else {
       switch (this.dimensions) {
         case "both":   return `.${icons.tool_icon_pan}`
-        case "width":  return `.${icons.tool_icon_xpan}`
-        case "height": return `.${icons.tool_icon_ypan}`
+        case "width":  return `.${icons.tool_icon_x_pan}`
+        case "height": return `.${icons.tool_icon_y_pan}`
       }
     }
   }


### PR DESCRIPTION
Early WIP. This replaces PNG icons with SVG. SVG don't have predefined color. This can be configured in CSS (using CSS masks). For now I covered maybe a third of the icons (gray background indicates missing images in the example below). I intend to cover the rest and add missing x/y variants as time permits, hopefully within 3.0 timeframe. Icons are based on [Iconoir](https://iconoir.com/) (MIT licensed), however I rewrote most of the icons I used, to adjust their appearance, simplify the SVG and reduce its size.

![image](https://user-images.githubusercontent.com/27475/149681746-214167c0-4fb3-455a-a996-9846454de16a.png)

fixes #10533
