### PR TITLE
Discover unstable defaults in `HasProps.__init__()`

### DIFF
--- a/bokeh/core/has_props.py
+++ b/bokeh/core/has_props.py
@@ -698,7 +698,8 @@ class HasProps(Serializable, metaclass=MetaHasProps):
         Values that are containers are shallow-copied.
 
         '''
-        return self.__class__(**self._property_values)
+        attrs = self.properties_with_values(include_defaults=False, include_undefined=True)
+        return self.__class__(**{key: val for key, val in attrs.items() if val is not Undefined})
 
 KindRef = Any # TODO
 

--- a/bokeh/core/has_props.py
+++ b/bokeh/core/has_props.py
@@ -301,7 +301,7 @@ class HasProps(Serializable, metaclass=MetaHasProps):
 
         self._raise_attribute_error_with_matches(name, properties)
 
-    def __getattr__(self, name: str) -> Unknown:
+    def __getattr__(self, name: str) -> Any:
         ''' Intercept attribute setting on HasProps in order to special case
         a few situations:
 
@@ -310,22 +310,21 @@ class HasProps(Serializable, metaclass=MetaHasProps):
 
         Args:
             name (str) : the name of the attribute to set on this object
-            value (obj) : the value to set
 
         Returns:
-            None
+            Any
 
         '''
         if name.startswith("_"):
-            return super().__getattr__(name)
+            return super().__getattribute__(name)
 
         properties = self.properties(_with_props=True)
         if name in properties:
-            return super().__getattr__(name)
+            return super().__getattribute__(name)
 
         descriptor = getattr(self.__class__, name, None)
         if isinstance(descriptor, property): # Python property
-            return super().__getattr__(name)
+            return super().__getattribute__(name)
 
         self._raise_attribute_error_with_matches(name, properties)
 

--- a/bokeh/core/property/_sphinx.py
+++ b/bokeh/core/property/_sphinx.py
@@ -20,6 +20,14 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Type,
+)
+
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
@@ -31,29 +39,29 @@ __all__ = (
     'type_link',
 )
 
-_type_links = {}
+_type_links: Dict[Type[Any], Callable[[Any], str]] = {}
 
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
 
-def model_link(fullname):
+def model_link(fullname: str) -> str:
     # (double) escaped space at the end is to appease Sphinx
     # https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#gotchas
     return f":class:`~{fullname}`\\ "
 
-def property_link(obj):
+def property_link(obj: Any) -> str:
     # (double) escaped space at the end is to appease Sphinx
     # https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#gotchas
     return f":class:`~bokeh.core.properties.{obj.__class__.__name__}`\\ "
 
-def register_type_link(cls):
-    def decorator(func):
+def register_type_link(cls: Type[Any]):
+    def decorator(func: Callable[[Any], str]):
         _type_links[cls] = func
         return func
     return decorator
 
-def type_link(obj):
+def type_link(obj: Any) -> str:
     return _type_links.get(obj.__class__, property_link)(obj)
 
 #-----------------------------------------------------------------------------

--- a/bokeh/core/property/bases.py
+++ b/bokeh/core/property/bases.py
@@ -161,7 +161,7 @@ class Property(PropertyDescriptorFactory[T]):
         return callable(self._default)
 
     @classmethod
-    def _copy_default(cls, default: Callable[[], T] | T, no_eval: bool = False) -> T:
+    def _copy_default(cls, default: Callable[[], T] | T, *, no_eval: bool = False) -> T:
         """ Return a copy of the default, or a new value if the default
         is specified by a function.
 
@@ -173,7 +173,7 @@ class Property(PropertyDescriptorFactory[T]):
                 return default
             return default()
 
-    def _raw_default(self, no_eval: bool = False) -> T:
+    def _raw_default(self, *, no_eval: bool = False) -> T:
         """ Return the untransformed default value.
 
         The raw_default() needs to be validated and transformed by
@@ -183,7 +183,7 @@ class Property(PropertyDescriptorFactory[T]):
         """
         return self._copy_default(self._default, no_eval=no_eval)
 
-    def themed_default(self, cls: Type[HasProps], name: str, theme_overrides: Dict[str, Any] | None, no_eval: bool = False) -> T:
+    def themed_default(self, cls: Type[HasProps], name: str, theme_overrides: Dict[str, Any] | None, *, no_eval: bool = False) -> T:
         """ The default, transformed by prepare_value() and the theme overrides.
 
         """
@@ -545,5 +545,5 @@ def validation_on() -> bool:
 #-----------------------------------------------------------------------------
 
 @register_type_link(SingleParameterizedProperty)
-def _sphinx_type(obj):
+def _sphinx_type(obj: SingleParameterizedProperty[Any]):
     return f"{property_link(obj)}({type_link(obj.type_param)})"

--- a/bokeh/core/property/bases.py
+++ b/bokeh/core/property/bases.py
@@ -325,7 +325,6 @@ class Property(PropertyDescriptorFactory[T]):
         if value is Undefined:
             return value
 
-
         error = None
         try:
             if validation_on():

--- a/bokeh/model/model.py
+++ b/bokeh/model/model.py
@@ -227,7 +227,7 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
 
     @classmethod
     @without_property_validation
-    def parameters(cls):
+    def parameters(cls: Type[Model]) -> List[Parameter]:
         ''' Generate Python ``Parameter`` values suitable for functions that are
         derived from the glyph.
 

--- a/tests/unit/bokeh/core/property/test_descriptors.py
+++ b/tests/unit/bokeh/core/property/test_descriptors.py
@@ -16,6 +16,9 @@ import pytest ; pytest
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+import typing as tp
+
 # External imports
 from mock import MagicMock, patch
 
@@ -103,50 +106,86 @@ class Test_PropertyDescriptor:
         f.baz
         f.quux
 
-        calls = []
+        calls: tp.List[str] = []
 
-        def cb(attr, old, new):
+        def cb(attr: str, old: tp.Any, new: tp.Any) -> None:
             calls.append(attr)
 
         for name in ['foo', 'bar', 'baz', 'quux']:
             f.on_change(name, cb)
 
+        model_unstable_default_values = dict(
+            js_event_callbacks={},
+            js_property_callbacks={},
+            subscribed_events=[],
+            tags=[],
+        )
+
         assert f._property_values == {}
-        assert f._unstable_default_values == dict(bar=[10], quux=[30])
+        assert f._unstable_default_values == dict(
+            **model_unstable_default_values,
+            bar=[10],
+            quux=[30],
+        )
 
         del f.foo
         assert f._property_values == {}
-        assert f._unstable_default_values == dict(bar=[10], quux=[30])
+        assert f._unstable_default_values == dict(
+            **model_unstable_default_values,
+            bar=[10],
+            quux=[30],
+        )
         assert calls == []
 
         f.baz = 50
 
         assert f.baz == 50
-        assert f._unstable_default_values == dict(bar=[10], quux=[30])
+        assert f._unstable_default_values == dict(
+            **model_unstable_default_values,
+            bar=[10],
+            quux=[30],
+        )
         assert calls == ['baz']
 
         del f.baz
         assert f.baz == 20
-        assert f._unstable_default_values == dict(bar=[10], quux=[30])
+        assert f._unstable_default_values == dict(
+            **model_unstable_default_values,
+            bar=[10],
+            quux=[30],
+        )
         assert calls == ['baz', 'baz']
 
         del f.bar
         assert f._property_values == {}
-        assert f._unstable_default_values == dict(quux=[30])
+        assert f._unstable_default_values == dict(
+            **model_unstable_default_values,
+            quux=[30],
+        )
         assert calls == ['baz', 'baz']
 
         f.bar = [60]
         assert f.bar == [60]
-        assert f._unstable_default_values == dict(quux=[30])
+        assert f._unstable_default_values == dict(
+            **model_unstable_default_values,
+            quux=[30],
+        )
         assert calls == ['baz', 'baz', 'bar']
 
         del f.bar
         assert f.bar == [10]
-        assert f._unstable_default_values == dict(bar=[10], quux=[30])
+        assert f._unstable_default_values == dict(
+            **model_unstable_default_values,
+            bar=[10],
+            quux=[30],
+        )
         assert calls == ['baz', 'baz', 'bar', 'bar']
 
         del f.quux
-        assert f._unstable_default_values == dict(bar=[10])
+        assert f._unstable_default_values == dict(
+            **model_unstable_default_values,
+            bar=[10],
+        )
         assert calls == ['baz', 'baz', 'bar', 'bar']
 
     def test_class_default(self) -> None:

--- a/tests/unit/bokeh/core/property/test_instance.py
+++ b/tests/unit/bokeh/core/property/test_instance.py
@@ -58,7 +58,7 @@ class Test_InstanceDefault:
 
     def test___repr__(self) -> None:
         m = bcpi.InstanceDefault(_TestModel, x=10, z=[10])
-        assert repr(m) == "<Instance: _TestModel(x=10, z=[10])>"
+        assert repr(m) == "<Instance: _util_property._TestModel(x=10, z=[10])>"
 
 class Test_Instance:
     def test_init(self) -> None:

--- a/tests/unit/bokeh/core/test_has_props.py
+++ b/tests/unit/bokeh/core/test_has_props.py
@@ -24,6 +24,7 @@ from bokeh.core.properties import (
     Alias,
     AngleSpec,
     Either,
+    Instance,
     Int,
     List,
     Nullable,
@@ -548,6 +549,31 @@ def test_qualified() -> None:
     assert TopLevelNonQualified.__qualified_model__ == "TopLevelNonQualified"
     assert InnerQualified.__qualified_model__ == "test_has_props.test_qualified.InnerQualified"
     assert InnerNonQualified.__qualified_model__ == "test_qualified.InnerNonQualified"
+
+def test_HasProps_properties_with_values_unstable():
+    class Some0HasProps(hp.HasProps, hp.Local):
+        f0 = Int(default=3)
+        f1 = List(Int, default=[3, 4, 5])
+
+    class Some1HasProps(hp.HasProps, hp.Local):
+        f0 = String(default="xyz")
+        f1 = List(String, default=["x", "y", "z"])
+
+    class Some2HasProps(hp.HasProps, hp.Local):
+        f0 = Instance(Some0HasProps, lambda: Some0HasProps())
+        f1 = Instance(Some1HasProps, lambda: Some1HasProps())
+        f2 = Int(default=1)
+        f3 = String(default="xyz")
+        f4 = List(Int, default=[1, 2, 3])
+
+    v0 = Some0HasProps()
+    assert v0.properties_with_values(include_defaults=False) == {}
+
+    v1 = Some1HasProps()
+    assert v1.properties_with_values(include_defaults=False) == {}
+
+    v2 = Some2HasProps()
+    assert v2.properties_with_values(include_defaults=False) == {"f0": v2.f0, "f1": v2.f1}
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/tests/unit/bokeh/core/test_has_props.py
+++ b/tests/unit/bokeh/core/test_has_props.py
@@ -16,6 +16,9 @@ import pytest ; pytest
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from types import MethodType
+
 # Bokeh imports
 from bokeh.core.properties import (
     Alias,
@@ -52,6 +55,20 @@ class Parent(hp.HasProps):
     ds1 = NumberSpec(default=field("x"))
     lst1 = List(String)
 
+    @property
+    def foo_prop(self) -> int:
+        return 110
+
+    def foo_func(self) -> int:
+        return 111
+
+    @property
+    def _foo_prop(self) -> int:
+        return 1100
+
+    def _foo_func(self) -> int:
+        return 1110
+
 class Child(Parent):
     int2 = Nullable(Int())
     str2 = String(default="foo")
@@ -71,6 +88,50 @@ class OverrideChild(Parent):
 class AliasedChild(Child):
     aliased_int1 = Alias("int1")
     aliased_int2 = Alias("int2")
+
+def test_HasProps_getattr() -> None:
+    p = Parent()
+
+    assert getattr(p, "int1") == 10
+    assert p.int1 == 10
+
+    assert getattr(p, "foo_prop") == 110
+    assert p.foo_prop == 110
+
+    assert isinstance(getattr(p, "foo_func"), MethodType)
+    assert isinstance(p.foo_func, MethodType)
+
+    assert getattr(p, "foo_func")() == 111
+    assert p.foo_func() == 111
+
+    assert getattr(p, "_foo_prop") == 1100
+    assert p._foo_prop == 1100
+
+    assert isinstance(getattr(p, "_foo_func"), MethodType)
+    assert isinstance(p._foo_func, MethodType)
+
+    assert getattr(p, "_foo_func")() == 1110
+    assert p._foo_func() == 1110
+
+    with pytest.raises(AttributeError):
+        getattr(p, "foo_prop2")
+    with pytest.raises(AttributeError):
+        p.foo_prop2
+
+    with pytest.raises(AttributeError):
+        getattr(p, "foo_func2")
+    with pytest.raises(AttributeError):
+        p.foo_func2
+
+    with pytest.raises(AttributeError):
+        getattr(p, "_foo_prop2")
+    with pytest.raises(AttributeError):
+        p._foo_prop2
+
+    with pytest.raises(AttributeError):
+        getattr(p, "_foo_func2")
+    with pytest.raises(AttributeError):
+        p._foo_func2
 
 def test_HasProps_default_init() -> None:
     p = Parent()

--- a/tests/unit/bokeh/document/test_document.py
+++ b/tests/unit/bokeh/document/test_document.py
@@ -85,7 +85,7 @@ class DerivedDataModel(SomeDataModel):
     prop6 = Instance(SomeDataModel)
     prop7 = Nullable(Instance(SomeDataModel))
 
-    prop2 = Override(default=119)
+    prop2 = Override(default=[4, 5, 6])
 
 class CDSDerivedDataModel(ColumnDataSource, DataModel):
     prop0 = Int()
@@ -754,7 +754,7 @@ class TestDocument:
                     PropertyDef(name="prop7", kind="Any", default=None),
                 ],
                 overrides=[
-                    OverrideDef(name="prop2", default=119),
+                    OverrideDef(name="prop2", default=[4, 5, 6]),
                 ],
             ),
             ModelDef(

--- a/tests/unit/bokeh/document/test_events__document.py
+++ b/tests/unit/bokeh/document/test_events__document.py
@@ -48,10 +48,13 @@ class FakeFullDispatcher:
     def _session_callback_added(self, event):   self.called.append('_session_callback_added')
     def _session_callback_removed(self, event): self.called.append('_session_callback_removed')
 
+class OtherModel(Model):
+    data = ColumnData(Any, Any, default={})
+
 class SomeModel(Model):
     data = ColumnData(Any, Any, default={})
-    ref1 = Instance(Model, default=lambda: SomeModel())
-    ref2 = Instance(Model, default=lambda: SomeModel())
+    ref1 = Instance(OtherModel, default=lambda: OtherModel())
+    ref2 = Instance(OtherModel, default=lambda: OtherModel())
 
 #-----------------------------------------------------------------------------
 # General API
@@ -440,8 +443,8 @@ class TestRootAddedEvent:
 
     def test_to_serializable(self) -> None:
         doc = Document()
-        ref1 = SomeModel()
-        ref2 = SomeModel()
+        ref1 = OtherModel()
+        ref2 = OtherModel()
         m = SomeModel(ref1=ref1, ref2=ref2)
         e = bde.RootAddedEvent(doc, m, "setter", "invoker")
         s = Serializer()
@@ -455,12 +458,12 @@ class TestRootAddedEvent:
                 attributes=dict(
                     ref1=ObjectRefRep(
                         type="object",
-                        name="test_events__document.SomeModel",
+                        name="test_events__document.OtherModel",
                         id=ref1.id,
                     ),
                     ref2=ObjectRefRep(
                         type="object",
-                        name="test_events__document.SomeModel",
+                        name="test_events__document.OtherModel",
                         id=ref2.id,
                     ),
                 ),


### PR DESCRIPTION
Serialization of unstable properties is different depending on what `HasProps` methods were called. e.g.:

Before this PR:
```py
In [1]: from bokeh.models import *
In [2]: p = Plot()

In [3]: p._to_json_like(include_defaults=False)
Out[3]: {}

In [4]: p._to_json_like(include_defaults=False)
Out[4]: {}

In [5]: p.references(); # this touches all values, thus resolves unstable defaults

In [6]: p._to_json_like(include_defaults=False)
Out[6]: 
{'y_scale': LinearScale(id='1005', ...),
 'toolbar': Toolbar(id='1007', ...),
 'x_range': DataRange1d(id='1002', ...),
 'y_range': DataRange1d(id='1003', ...),
 'x_scale': LinearScale(id='1004', ...),
 'title': Title(id='1006', ...)}
```
After this PR:
```py
In [1]: from bokeh.models import *
In [2]: p = Plot()

In [3]: p._to_json_like(include_defaults=False)
Out[3]: 
{'y_range': DataRange1d(id='1004', ...),
 'y_scale': LinearScale(id='1002', ...),
 'x_range': DataRange1d(id='1003', ...),
 'title': Title(id='1005', ...),
 'toolbar': Toolbar(id='1006', ...),
 'x_scale': LinearScale(id='1007', ...)}
```