### PR TITLE
Deprecate CDSView.source more gracefully

### DIFF
--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -53,6 +53,7 @@ from ..core.properties import (
 )
 from ..model import Model
 from ..util.dependencies import import_optional
+from ..util.deprecation import deprecated
 from ..util.serialization import convert_datetime_array
 from ..util.warnings import BokehUserWarning
 from .callbacks import CustomJS
@@ -725,6 +726,12 @@ class CDSView(Model):
     ''' A view into a ``ColumnDataSource`` that represents a row-wise subset.
 
     '''
+
+    def __init__(self, *args: TAny, **kwargs: TAny) -> None:
+        if "source" in kwargs:
+            del kwargs["source"]
+            deprecated("CDSView.source is no longer needed, and is now ignored. In a future release, passing source will result an error.")
+        super().__init__(*args, **kwargs)
 
     filters = List(Instance(Filter), default=[], help="""
     List of filters that the view comprises.

--- a/tests/unit/bokeh/models/test_sources.py
+++ b/tests/unit/bokeh/models/test_sources.py
@@ -27,6 +27,7 @@ import numpy as np
 # Bokeh imports
 from bokeh.models import Selection
 from bokeh.util.serialization import convert_datetime_array, transform_column_source_data
+from bokeh.util.warnings import BokehDeprecationWarning
 
 # Module under test
 import bokeh.models.sources as bms # isort:skip
@@ -39,6 +40,10 @@ import bokeh.models.sources as bms # isort:skip
 # General API
 #-----------------------------------------------------------------------------
 
+def test_CDSView_deprecated_source_property() -> None:
+    source = bms.ColumnDataSource()
+    with pytest.warns(BokehDeprecationWarning):
+        bms.CDSView(source=source)
 
 class TestColumnDataSource:
     def test_basic(self) -> None:


### PR DESCRIPTION
I've already had the annoying experience of fixing up example code from support questions to be able to test with `branch-3.0` at least a half a dozen times. I think we need to be more gentle with users about removing `CDSView.source`. 

cc @mattpap 