### PR TITLE
Track modified files in release build more carefully

### DIFF
--- a/release/build.py
+++ b/release/build.py
@@ -165,6 +165,7 @@ def update_bokehjs_versions(config: Config, system: System) -> ActionReturn:
             with open(filename, "w") as f:
                 json.dump(content, f, indent=2)
                 f.write("\n")
+            config.add_modified(filename)
         except Exception as e:
             return FAILED(f"Unable to write new version to file {filename!r}", details=e.args)
 
@@ -179,6 +180,7 @@ def update_changelog(config: Config, system: System) -> ActionReturn:
         system.pushd("scripts")
         system.run(f"python milestone.py -a {config.milestone_version}")
         system.popd()
+        config.add_modified("CHANGELOG")
         return PASSED("Updated CHANGELOG with new closed issues")
     except RuntimeError as e:
         return FAILED("CHANGELOG update failed", details=e.args)
@@ -190,6 +192,7 @@ def update_hash_manifest(config: Config, system: System) -> ActionReturn:
         system.cd("scripts")
         system.run(f"python sri.py {config.version}")
         system.cd("..")
+        config.add_modified("bokeh/_sri.json")
         return PASSED("Updated SRI hash manifest")
     except RuntimeError as e:
         return FAILED("SRI hash manifest update failed", details=e.args)

--- a/release/config.py
+++ b/release/config.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 # Standard library imports
 import re
-from typing import Dict, Tuple
+from typing import Dict, Set, Tuple
 
 # Bokeh imports
 from .enums import VersionType
@@ -42,6 +42,8 @@ class Config:
 
         self._secrets: Dict[str, str] = {}
 
+        self._modified: Set[str] = set()
+
     def add_secret(self, name: str, secret: str) -> None:
         """"""
         if name in self._secrets:
@@ -49,9 +51,16 @@ class Config:
         LOG.add_scrubber(Scrubber(secret, name=name))
         self._secrets[name] = secret
 
+    def add_modified(self, path: str) -> None:
+        self._modified.add(path)
+
     @property
     def secrets(self) -> Dict[str, str]:
         return self._secrets
+
+    @property
+    def modified(self) -> Set[str]:
+        return self._modified
 
     @property
     def prerelease(self) -> bool:

--- a/release/git.py
+++ b/release/git.py
@@ -50,17 +50,11 @@ def clean_repo(config: Config, system: System) -> ActionReturn:
 
 
 def commit_staging_branch(config: Config, system: System) -> ActionReturn:
-    paths = (
-        "CHANGELOG",
-        "bokehjs/package-lock.json",
-        "bokehjs/package.json",
-        "bokehjs/make/package.json",
-        "bokehjs/src/compiler/package.json",
-        "bokehjs/src/lib/package.json",
-        "bokehjs/test/package.json",
-        "bokeh/_sri.json",
-    )
-    for path in paths:
+    for path in config.modified:
+        try:
+            system.run(f"git ls-files --error-unmatch {path}")
+        except RuntimeError:
+            return FAILED("File {path!r} marked modified does not exist in the repo")
         try:
             system.run(f"git add {path}")
         except RuntimeError as e:

--- a/release/stages.py
+++ b/release/stages.py
@@ -106,6 +106,7 @@ BUILD_STEPS: StepListType = (
     dev_install,
     update_hash_manifest,
     commit_staging_branch,
+    check_checkout_is_clean,
     tag_release_version,
     build_npm_packages,
     build_conda_packages,


### PR DESCRIPTION
- [x] issues: fixes #11875

Will need to cut a release build to actually test this out, but this PR should:

* keep explicit track of files that have been modified by build steps
* only commit those files to the release branch (and make sure modified files not *new* files)
* verify that the repo is clean after files marked modified are commited 
