### PR TITLE
add functools.wraps to _needs_document_lock_wrapper

### DIFF
--- a/bokeh/server/session.py
+++ b/bokeh/server/session.py
@@ -24,6 +24,7 @@ log = logging.getLogger(__name__)
 import inspect
 import time
 from copy import copy
+from functools import wraps
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -74,6 +75,7 @@ def _needs_document_lock(func: F) -> F:
        method on ServerSession and transforms it into a coroutine
        if it wasn't already.
     '''
+    @wraps(func)
     async def _needs_document_lock_wrapper(self: ServerSession, *args, **kwargs):
         # while we wait for and hold the lock, prevent the session
         # from being discarded. This avoids potential weirdness


### PR DESCRIPTION
dask.distributed intermittently logs:
`RuntimeWarning: coroutine '_needs_document_lock.<locals>._needs_document_lock_wrapper' was never awaited`
with this wrapper it will be possible to see which method wasn't
awaited

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [x] issues: fixes #11977
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
