### PR TITLE
Add sphinx_copybutton

### DIFF
--- a/ci/environment-release-build.yml
+++ b/ci/environment-release-build.yml
@@ -36,7 +36,6 @@ dependencies:
   - pandas
   - pydot
   - pygments
-  - sphinx-copybutton
   - pyshp
   - scipy
 
@@ -47,6 +46,7 @@ dependencies:
     - autoclasstoc
     - pydata_sphinx_theme >=0.7.1
     - sphinx >=4.3.2
+    - sphinx-copybutton
     - sphinxext-opengraph
     - sphinx-panels
     - sphinx-tabs

--- a/ci/environment-release-build.yml
+++ b/ci/environment-release-build.yml
@@ -36,6 +36,7 @@ dependencies:
   - pandas
   - pydot
   - pygments
+  - sphinx-copybutton
   - pyshp
   - scipy
 

--- a/ci/environment-test-3.10.yml
+++ b/ci/environment-test-3.10.yml
@@ -39,6 +39,7 @@ dependencies:
   - psutil
   - pydot
   - pygments
+  - sphinx-copybutton
   - pytest 6.2*
   - pytest-asyncio
   - pytest-cov >=1.8.1

--- a/ci/environment-test-3.10.yml
+++ b/ci/environment-test-3.10.yml
@@ -39,7 +39,6 @@ dependencies:
   - psutil
   - pydot
   - pygments
-  - sphinx-copybutton
   - pytest 6.2*
   - pytest-asyncio
   - pytest-cov >=1.8.1
@@ -68,6 +67,7 @@ dependencies:
     - autoclasstoc
     - pydata_sphinx_theme >=0.7.1
     - sphinx >=4.3.2
+    - sphinx-copybutton
     - sphinxext-opengraph
     - sphinx-panels
     - sphinx-tabs

--- a/ci/environment-test-3.8.yml
+++ b/ci/environment-test-3.8.yml
@@ -39,6 +39,7 @@ dependencies:
   - psutil
   - pydot
   - pygments
+  - sphinx-copybutton
   - pytest 6.2*
   - pytest-asyncio=0.12.0
   - pytest-cov >=1.8.1

--- a/ci/environment-test-3.8.yml
+++ b/ci/environment-test-3.8.yml
@@ -39,7 +39,6 @@ dependencies:
   - psutil
   - pydot
   - pygments
-  - sphinx-copybutton
   - pytest 6.2*
   - pytest-asyncio=0.12.0
   - pytest-cov >=1.8.1
@@ -68,6 +67,7 @@ dependencies:
     - autoclasstoc
     - pydata_sphinx_theme >=0.7.1
     - sphinx >=4.3.2
+    - sphinx-copybutton
     - sphinxext-opengraph
     - sphinx-panels
     - sphinx-tabs

--- a/ci/environment-test-3.9.yml
+++ b/ci/environment-test-3.9.yml
@@ -39,6 +39,7 @@ dependencies:
   - psutil
   - pydot
   - pygments
+  - sphinx-copybutton
   - pytest 6.2*
   - pytest-asyncio
   - pytest-cov >=1.8.1

--- a/ci/environment-test-3.9.yml
+++ b/ci/environment-test-3.9.yml
@@ -39,7 +39,6 @@ dependencies:
   - psutil
   - pydot
   - pygments
-  - sphinx-copybutton
   - pytest 6.2*
   - pytest-asyncio
   - pytest-cov >=1.8.1
@@ -68,6 +67,7 @@ dependencies:
     - autoclasstoc
     - pydata_sphinx_theme >=0.7.1
     - sphinx >=4.3.2
+    - sphinx-copybutton
     - sphinxext-opengraph
     - sphinx-panels
     - sphinx-tabs

--- a/environment.yml
+++ b/environment.yml
@@ -23,6 +23,7 @@ dependencies:
   # docs
   - colorcet
   - pygments
+  - sphinx-copybutton
 
   # tests
   - beautifulsoup4

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,6 @@ dependencies:
   # docs
   - colorcet
   - pygments
-  - sphinx-copybutton
 
   # tests
   - beautifulsoup4
@@ -80,6 +79,7 @@ dependencies:
     - autoclasstoc
     - pydata_sphinx_theme >= 0.7.1
     - sphinx >=4.3.2
+    - sphinx-copybutton
     - sphinxext-opengraph
     - sphinx-reredirects
     - sphinx-panels

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -33,6 +33,7 @@ exclude_patterns = ['docs/releases/*']
 extensions = [
     'autoclasstoc',
     'sphinxext.opengraph',
+    'sphinx_copybutton',
     'sphinx_panels',
 #    'sphinx_reredirects',
     'sphinx_tabs.tabs',
@@ -75,6 +76,8 @@ autoclasstoc_sections = [
 ]
 
 autodoc_member_order = 'groupwise'
+
+copybutton_prompt_text = ">>> "
 
 bokeh_missing_google_api_key_ok = False
 


### PR DESCRIPTION
This PR adds the [sphinx_copybutton](https://sphinx-copybutton.readthedocs.io/en/latest/index.html) extension to the docs.

I have used a pretty standard configuration, the only customization is to enable stripping of command prompts (https://sphinx-copybutton.readthedocs.io/en/latest/use.html#strip-and-configure-input-prompts-for-code-cells). This is relevant for some examples in the Reference guide (e.g. http://localhost:5009/en/latest/docs/reference/layouts.html).