### PR TITLE
Add metadata to tile_source.py and fix various typos

### DIFF
--- a/examples/app/README.md
+++ b/examples/app/README.md
@@ -29,7 +29,7 @@ The demos container here are:
   <tr><td colspan="2">dash</td></tr>
   <tr>
     <td><a href="https://github.com/bokeh/bokeh/tree/master/examples/app/dash"><img src="https://docs.bokeh.org/static/dash_t.png" width=400></img></a></td>
-    <td>Demonstrates use of custom Boostrap template with a Bokeh application</td>
+    <td>Demonstrates use of custom Bootstrap template with a Bokeh application</td>
   </tr>
 
   <tr><td colspan="2">export_csv</td></tr>

--- a/examples/app/gapminder/main.py
+++ b/examples/app/gapminder/main.py
@@ -1,4 +1,4 @@
-''' A gapminder chart using a population, life expectancy, and ferility dataset.
+''' A gapminder chart using a population, life expectancy, and fertility dataset.
 This example shows the data visualization capability of Bokeh to recreate charts.
 
 '''

--- a/examples/app/spectrogram/description.html
+++ b/examples/app/spectrogram/description.html
@@ -30,7 +30,7 @@ code {
 }
 </style>
 
-<h1>A Live Audio Spectrogam</h1>
+<h1>A Live Audio Spectrogram</h1>
 
 <p>
 This example shows how Bokeh custom extension models can be used with

--- a/examples/custom/parallel_plot/parallel_selection_tool.ts
+++ b/examples/custom/parallel_plot/parallel_selection_tool.ts
@@ -136,7 +136,7 @@ export class ParallelSelectionView extends BoxSelectToolView {
     }
   }
 
-  _box_paramaters(index: number) {
+  _box_parameters(index: number) {
     const {xkey, ykey, wkey, hkey} = this._cds_select_keys
     const x = this.cds_select.get_array<number>(xkey)[index]
     const y = this.cds_select.get_array<number>(ykey)[index]
@@ -150,7 +150,7 @@ export class ParallelSelectionView extends BoxSelectToolView {
     if (nboxes != 0 && nboxes != null) {
       const [xtest, ytest] = [this.xscale.invert(sx), this.yscale.invert(sy)]
       for (let i = 0; i < nboxes; i++) {
-        const {x, y, w, h} = this._box_paramaters(i)
+        const {x, y, w, h} = this._box_parameters(i)
         if (xtest >= (x - w / 2) && xtest <= x + w / 2 &&
             ytest >= (y - h / 2) && ytest <= y + h / 2) {
           return i
@@ -174,7 +174,7 @@ export class ParallelSelectionView extends BoxSelectToolView {
     //Save y position of the drag start
     if (this.ind_active_box != null) {
       this._base_point = [this.xscale.invert(ev.sx), this.yscale.invert(ev.sy)]
-      this._base_box_parameters = this._box_paramaters(this.ind_active_box)
+      this._base_box_parameters = this._box_parameters(this.ind_active_box)
     }
   }
 

--- a/examples/embed/arguments/README.md
+++ b/examples/embed/arguments/README.md
@@ -2,7 +2,7 @@ To run this demo start the Bokeh server application:
 
     bokeh serve bokeh_server.py --allow-websocket-origin=127.0.0.1:5000
 
-And then in a seprate window execute:
+And then in a separate window execute:
 
     python flask_server.py
 

--- a/examples/embed/server_session/serve.py
+++ b/examples/embed/server_session/serve.py
@@ -10,7 +10,7 @@ app = Flask(__name__)
 @app.route('/')
 def bkapp_page():
 
-    # pull a new session from aunning Bokeh server
+    # pull a new session from running Bokeh server
     with pull_session(url=app_url) as session:
 
         # update or customize that session

--- a/examples/howto/Categorical Data.ipynb
+++ b/examples/howto/Categorical Data.ipynb
@@ -57,7 +57,7 @@
     "\n",
     "Bokeh displays the bars in the order the factors are given for the range. So, \"sorting\" bars in a bar plot is identical to sorting the factors for the range. \n",
     "\n",
-    "In the example below the fruit factors are sorted in increasing order according to their corresponing counts, causing the bars to be sorted."
+    "In the example below the fruit factors are sorted in increasing order according to their corresponding counts, causing the bars to be sorted."
    ]
   },
   {
@@ -117,7 +117,7 @@
    "source": [
     "### Bar Plot with Color Mapper\n",
     "\n",
-    "Another way to shade bars different colors is to provide a colormapper. The `factor_cmap` transform can be applied to map a categorical value into a colot. Other transorm include `linear_cmap` and `log_cmap` which can be used to map continuous numercical values to colors. \n",
+    "Another way to shade bars different colors is to provide a colormapper. The `factor_cmap` transform can be applied to map a categorical value into a color. Other transform include `linear_cmap` and `log_cmap` which can be used to map continuous numerical values to colors. \n",
     "\n",
     "The example below reproduces previous example using a `factor_cmap` to convert fruit types into colors."
    ]
@@ -158,7 +158,7 @@
     "\n",
     "    x_range = [ (\"Apples\", \"2015\"), (\"Apples\", \"2016\"), (\"Apples\", \"2017\"), ... ]\n",
     "    \n",
-    "The coordinates for the bars should be these same tuple values. When we create a hierarchcal range in this way, Bokeh will automatically create a visually grouped axis. \n",
+    "The coordinates for the bars should be these same tuple values. When we create a hierarchical range in this way, Bokeh will automatically create a visually grouped axis. \n",
     "\n",
     "The plot below displays fruit counts per year."
    ]
@@ -201,9 +201,9 @@
    "source": [
     "### Grouped Bars with Color Mapper\n",
     "\n",
-    "We can combine a color mapper with hierachical ranges, and in fact we can choose to apply a color mapping based on only \"part\" of a categorical factor. \n",
+    "We can combine a color mapper with hierarchical ranges, and in fact we can choose to apply a color mapping based on only \"part\" of a categorical factor. \n",
     "\n",
-    "In the example below, the arguments `start=1, end=2` are passed to `factor_cmap`. This means that for each factor value (which is a tuple), the value `factor[1:2]` is what shoud be used for colormapping. In this specific case, that translates to shading each bar according to the \"year\" portion."
+    "In the example below, the arguments `start=1, end=2` are passed to `factor_cmap`. This means that for each factor value (which is a tuple), the value `factor[1:2]` is what should be used for colormapping. In this specific case, that translates to shading each bar according to the \"year\" portion."
    ]
   },
   {
@@ -432,7 +432,7 @@
    "source": [
     "### Stacked and Grouped Bars\n",
     "\n",
-    "The above techiques for stacking and grouping may also be used together to create a stacked, grouped bar plot. \n",
+    "The above techniques for stacking and grouping may also be used together to create a stacked, grouped bar plot. \n",
     "\n",
     "Continuing the example above, we might stack each individual bar by region."
    ]
@@ -510,7 +510,7 @@
    "source": [
     "### Pandas to Simple Bars\n",
     "\n",
-    "Although Pandas is not required to use Bokeh, using Pandas can make many things simpler. For instance, Pandas `GroupBy` objects can be passed as the `source` argument to a glyph (or used to initialize a `ColumnDataSource`. When this is done, summary statistics for each group are automatically availanle in the data source.\n",
+    "Although Pandas is not required to use Bokeh, using Pandas can make many things simpler. For instance, Pandas `GroupBy` objects can be passed as the `source` argument to a glyph (or used to initialize a `ColumnDataSource`. When this is done, summary statistics for each group are automatically available in the data source.\n",
     "\n",
     "In the example below we pass `autompg.groupby(('cyl'))` as our source. Since the \"autompg\" DataFrame has and `mpg` column, our grouped data source automatically has an `mpg_mean` column we can use to drive glyphs."
    ]
@@ -666,9 +666,9 @@
    "source": [
     "### Categorical Heatmaps\n",
     "\n",
-    "Another kind of common categorical plot is the Categorical Heatmap, which has categorical ranges on both axes. Typically colormapped or shaded rectangles are diplayed for each *(x,y)* categorical comnination. \n",
+    "Another kind of common categorical plot is the Categorical Heatmap, which has categorical ranges on both axes. Typically colormapped or shaded rectangles are displayed for each *(x,y)* categorical combination. \n",
     "\n",
-    "The examples below demonstrates a catgorical heatmap using unemployment data. "
+    "The examples below demonstrates a categorical heatmap using unemployment data. "
    ]
   },
   {
@@ -816,7 +816,7 @@
    "source": [
     "### Ridge Plot (Categorical Offsets)\n",
     "\n",
-    "We have seen above how the `dodge` transform can be used to shift an entire column of categorical values. But it is possible to offset individual coordinates but putting the offset at the end of a tuple with a factor. For instance, if we have catefories `\"foo\"` and `\"bar\"` then \n",
+    "We have seen above how the `dodge` transform can be used to shift an entire column of categorical values. But it is possible to offset individual coordinates but putting the offset at the end of a tuple with a factor. For instance, if we have categories `\"foo\"` and `\"bar\"` then \n",
     "\n",
     "    (\"foo\", 0.1), (\"foo\", 0.2), (\"bar\", -0.3)\n",
     "\n",
@@ -856,7 +856,7 @@
    "source": [
     "def ridge(category, data, scale=20):\n",
     "    ''' For a given category and timeseries for that category, return categorical\n",
-    "    coordiantes with offsets scaled by the timeseries. \n",
+    "    coordinates with offsets scaled by the timeseries. \n",
     "    \n",
     "    '''\n",
     "    return list(zip([category]*len(data), scale*data))"

--- a/examples/howto/Linked panning.ipynb
+++ b/examples/howto/Linked panning.ipynb
@@ -6,9 +6,9 @@
    "source": [
     "## Linked Panning\n",
     "\n",
-    "\"Linked Panning\" is the capability of updating multiple plot ranges simultaneously as a result of panning one plot. In Bokeh, linked panning is acheived by shared `x_range` and/or `y_range` values between plots. \n",
+    "\"Linked Panning\" is the capability of updating multiple plot ranges simultaneously as a result of panning one plot. In Bokeh, linked panning is achieved by shared `x_range` and/or `y_range` values between plots. \n",
     "\n",
-    "Exeute the cells below and pan the resulting plots. "
+    "Execute the cells below and pan the resulting plots. "
    ]
   },
   {

--- a/examples/howto/ipywidgets/README.md
+++ b/examples/howto/ipywidgets/README.md
@@ -3,7 +3,7 @@ outside of JupyterLab or classical Notebook environments. All examples are bokeh
 examples, so you run them with `bokeh server app_name`, and then you have to navigate
 to `http://localhost:5006/app_name`:
 
-* `ipyvolume_camera.py` -- shows how to integrate a thirdparty widget and manipulate it
+* `ipyvolume_camera.py` -- shows how to integrate a third-party widget and manipulate it
 with Bokeh's and IPyWidgets' controls.
 
 * `ipyleaflet_tiles.py` -- IPyLeaflet and Bokeh's tile renderer side-by-side.

--- a/examples/howto/ipywidgets/README.md
+++ b/examples/howto/ipywidgets/README.md
@@ -1,9 +1,9 @@
 Examples in this directory show off bokeh's capability to integrate with Jupyer widgets
-outside of JupyerLab or classical Notebook environments. All examples are bokeh server
+outside of JupyterLab or classical Notebook environments. All examples are bokeh server
 examples, so you run them with `bokeh server app_name`, and then you have to navigate
 to `http://localhost:5006/app_name`:
 
-* `ipyvolume_camera.py` -- shows how to integrate a thridparty widget and manipulate it
+* `ipyvolume_camera.py` -- shows how to integrate a thirdparty widget and manipulate it
 with Bokeh's and IPyWidgets' controls.
 
 * `ipyleaflet_tiles.py` -- IPyLeaflet and Bokeh's tile renderer side-by-side.

--- a/examples/howto/layouts/words_and_plots.py
+++ b/examples/howto/layouts/words_and_plots.py
@@ -69,7 +69,7 @@ def intro():
         <p>This is an example of <code>scale_width</code> mode (happy to continue the conversations
         about what to name the modes). In <code>scale_width</code> everything responds to the width
         that's available to it. Plots alter their height to maintain their aspect ratio, and widgets
-        are allowed to grow as tall as they need to accomodate themselves. Often times widgets
+        are allowed to grow as tall as they need to accommodate themselves. Often times widgets
         stay the same height, but text is a good example of a widget that doesn't.</p>
         <h4>I want to stress that this was all written in python. There is no templating or
         use of <code>bokeh.embed</code>.</h4>

--- a/examples/howto/notebook_comms/Continuous Updating.ipynb
+++ b/examples/howto/notebook_comms/Continuous Updating.ipynb
@@ -99,7 +99,7 @@
     "    \n",
     "    p.axis.major_label_text_color = r.data_source.data['fill_color'][int(i%N)]\n",
     "\n",
-    "    # push updates to the plot continuously using the handle (intererrupt the notebook kernel to stop)\n",
+    "    # push updates to the plot continuously using the handle (interrupt the notebook kernel to stop)\n",
     "    push_notebook(handle=target)\n",
     "    time.sleep(0.1)"
    ]
@@ -112,7 +112,7 @@
    },
    "outputs": [],
    "source": [
-    "# Update the hover glyph propertes using the explicit handle (go hover over the plot)\n",
+    "# Update the hover glyph properties using the explicit handle (go hover over the plot)\n",
     "r.hover_glyph.fill_color = \"white\"\n",
     "r.hover_glyph.fill_alpha = 0.5\n",
     "hover.mode = \"vline\"\n",

--- a/examples/howto/notebook_comms/Numba Image Example.ipynb
+++ b/examples/howto/notebook_comms/Numba Image Example.ipynb
@@ -157,11 +157,11 @@
    "source": [
     "## 3x3 Image Kernels\n",
     "\n",
-    "Many image processing filters can be expressed as 3x3 matrices. This more sophisticated example demonstrates how numba can be used to compile kernels for arbitrary 3x3 kernels, and then provides serveral predefined kernels for the user to experiment with. \n",
+    "Many image processing filters can be expressed as 3x3 matrices. This more sophisticated example demonstrates how numba can be used to compile kernels for arbitrary 3x3 kernels, and then provides several predefined kernels for the user to experiment with. \n",
     "\n",
-    "The UI presents the image to process (along with a dropdown to select a different image) as well as a dropdown that lets the user select which kernel to apply. Additioanlly there are sliders the permit adjustment to the bias and scale of the final greyscale image. \n",
+    "The UI presents the image to process (along with a dropdown to select a different image) as well as a dropdown that lets the user select which kernel to apply. Additionally there are sliders the permit adjustment to the bias and scale of the final greyscale image. \n",
     "\n",
-    "*Note:* Right now, adjusting the scale and bias are not as efficient as possible, because the update function always also applies the kernel (even if it has not changed). A better implementation might have a class that keeps track of the current kernal and output image so that bias and scale can be applied by themselves. "
+    "*Note:* Right now, adjusting the scale and bias are not as efficient as possible, because the update function always also applies the kernel (even if it has not changed). A better implementation might have a class that keeps track of the current kernel and output image so that bias and scale can be applied by themselves. "
    ]
   },
   {
@@ -404,7 +404,7 @@
    "source": [
     "## Wavelet Decomposition\n",
     "\n",
-    "This last example demostrates a Haar wavelet decomposition using a Numba-compiled function. Play around with the slider to see different levels of decomposition of the image. "
+    "This last example demonstrates a Haar wavelet decomposition using a Numba-compiled function. Play around with the slider to see different levels of decomposition of the image."
    ]
   },
   {

--- a/examples/howto/server_embed/flask_gunicorn_embed.py
+++ b/examples/howto/server_embed/flask_gunicorn_embed.py
@@ -1,7 +1,7 @@
 try:
     import asyncio
 except ImportError:
-    raise RuntimeError("This example requries Python3 / asyncio")
+    raise RuntimeError("This example requires Python3 / asyncio")
 
 from threading import Thread
 

--- a/examples/howto/server_embed/flask_gunicorn_embed.py
+++ b/examples/howto/server_embed/flask_gunicorn_embed.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from threading import Thread
 
 from flask import Flask, render_template

--- a/examples/howto/server_embed/flask_gunicorn_embed.py
+++ b/examples/howto/server_embed/flask_gunicorn_embed.py
@@ -1,5 +1,4 @@
 import asyncio
-
 from threading import Thread
 
 from flask import Flask, render_template

--- a/examples/howto/server_embed/flask_gunicorn_embed.py
+++ b/examples/howto/server_embed/flask_gunicorn_embed.py
@@ -1,8 +1,3 @@
-try:
-    import asyncio
-except ImportError:
-    raise RuntimeError("This example requires Python3 / asyncio")
-
 from threading import Thread
 
 from flask import Flask, render_template

--- a/examples/howto/server_embed/notebook_embed.ipynb
+++ b/examples/howto/server_embed/notebook_embed.ipynb
@@ -32,7 +32,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are various application handlers that can be used to build up Bokeh documents. For example, there is a `ScriptHandler` that uses the code from a `.py` file to produce Bokeh documents. This is the handler that is used when we run `bokeh serve app.py`. In the notebook we can use a function to define a Bokehg application.\n",
+    "There are various application handlers that can be used to build up Bokeh documents. For example, there is a `ScriptHandler` that uses the code from a `.py` file to produce Bokeh documents. This is the handler that is used when we run `bokeh serve app.py`. In the notebook we can use a function to define a Bokeh application.\n",
     "\n",
     "Here is the function `bkapp(doc)` that defines our app:"
    ]

--- a/examples/models/file/iris_splom.py
+++ b/examples/models/file/iris_splom.py
@@ -1,5 +1,5 @@
 ''' A scatter plot matrix (SPLOM) chart using `Fisher's Iris dataset`_. This
-example demonstrates sharing ranged between plots to acheive linked panning.
+example demonstrates sharing ranged between plots to achieve linked panning.
 
 .. note::
     This example is maintained for historical compatibility. Please consider

--- a/examples/plotting/file/bessel.py
+++ b/examples/plotting/file/bessel.py
@@ -1,4 +1,4 @@
-''' Bessel functions of the first kind. This example demostrates the use of
+''' Bessel functions of the first kind. This example demonstrates the use of
 mathtext on titles, ``Label`` annotations and axis labels.
 
 .. bokeh-example-metadata::

--- a/examples/plotting/file/box_annotation.py
+++ b/examples/plotting/file/box_annotation.py
@@ -14,7 +14,7 @@ from bokeh.sampledata.glucose import data
 
 data = data.loc['2010-10-04':'2010-10-04']
 
-p = figure(title="Glocose Readings, Oct 4th\n(Red = Outside Range)",
+p = figure(title="Glucose Readings, Oct 4th\n(Red = Outside Range)",
            x_axis_type="datetime", tools="pan,wheel_zoom,box_zoom,reset,save")
 p.background_fill_color = "#efefef"
 p.xgrid.grid_line_color=None

--- a/examples/plotting/file/custom_layout.py
+++ b/examples/plotting/file/custom_layout.py
@@ -21,7 +21,7 @@ template = """
 {% block contents %}
 <div>
 <p>This example shows how different Bokeh Document roots may be embedded in custom
-templates. The individal plots were embedded in divs using the embed macro:
+templates. The individual plots were embedded in divs using the embed macro:
 
 <pre>
     &lt;div class="p"&gt;&#123;&#123; embed(roots.p0) &#125;&#125;&lt;/div&gt;

--- a/examples/plotting/file/latex_blackbody_radiation.py
+++ b/examples/plotting/file/latex_blackbody_radiation.py
@@ -22,7 +22,7 @@ p = figure(
 
 def spectral_radiance(nu, T):
     h = 6.626e-34   # Planck constant (Js)
-    k = 1.3806e-23  # Boltzman constant (J/K)
+    k = 1.3806e-23  # Boltzmann constant (J/K)
     c = 2.9979e8    # Speed of light in vacuum (m/s)
     return (2*h*nu**3/c**2) / (np.exp(h*nu/(k*T)) - 1.0)
 

--- a/examples/plotting/file/les_mis.py
+++ b/examples/plotting/file/les_mis.py
@@ -1,5 +1,5 @@
 ''' A reproduction of Mike Bostock's `Les Misérables Co-occurrence`_ chart.
-This example example demonostrates a basic hover tooltip.
+This example example demonstrates a basic hover tooltip.
 
 .. bokeh-example-metadata::
     :sampledata: les_mis

--- a/examples/plotting/file/ridgeplot.py
+++ b/examples/plotting/file/ridgeplot.py
@@ -1,6 +1,6 @@
 ''' A `ridgeline plot`_ using the `Perceptions of Probability`_ dataset.
 This example demonstrates the uses of categorical offsets to position
-categorical values explicitly. This chart shows the distributrion of responses
+categorical values explicitly. This chart shows the distribution of responses
 to the prompt *What probability would you assign to the phrase "Highly likely"*.
 
 .. bokeh-example-metadata::

--- a/examples/plotting/file/tile_source.py
+++ b/examples/plotting/file/tile_source.py
@@ -1,9 +1,9 @@
 """ This example displays a CartoDB Positron base world map.
 
 .. bokeh-example-metadata::
-    :apis: bokeh.plotting.Figure.add_tile
+    :apis: bokeh.plotting.figure.add_tile
     :refs:  :ref:`userguide_geo` > :ref:`userguide_tools`
-    :keywords: map, plot
+    :keywords: map, geo, tiles
 
 """
 

--- a/examples/plotting/file/tile_source.py
+++ b/examples/plotting/file/tile_source.py
@@ -1,3 +1,12 @@
+""" This example displays a CartoDB Positron base world map.
+
+.. bokeh-example-metadata::
+    :apis: bokeh.plotting.Figure.add_tile
+    :refs:  :ref:`userguide_geo` > :ref:`userguide_tools`
+    :keywords: map, plot
+
+"""
+
 from bokeh.plotting import figure, output_file, show
 
 output_file("tile_source.html")


### PR DESCRIPTION
This PR fixes part of #11765, supersedes #11901, and also includes typo fixes for various files under the `examples` directory.