### PR TITLE
Remove references to gen.coroutine from docs and update without_document_lock decorator

### DIFF
--- a/bokeh/document/locking.py
+++ b/bokeh/document/locking.py
@@ -82,6 +82,10 @@ def without_document_lock(func: F) -> NoLockCallback[F]:
     Attempts to otherwise access or change the Document will result in an
     exception being raised.
 
+    ``func`` can be a synchronous function, an async function, or a function
+    decorated with ``asyncio.coroutine``. The returned function will be an
+    async function if ``func`` is any of the latter two.
+
     '''
     if asyncio.iscoroutinefunction(func):
         @wraps(func)

--- a/tests/unit/bokeh/document/test_locking.py
+++ b/tests/unit/bokeh/document/test_locking.py
@@ -84,7 +84,7 @@ def test_without_document_lock_accepts_async_function() -> None:
 
     loop = asyncio.get_event_loop()
     loop.run_until_complete(callback_obj.callback())
-    
+
     assert callback_obj.callback.nolock == True
     assert i == 1
 


### PR DESCRIPTION
# Changes
Remove references to `tornado.gen.coroutine` in docs in favor of async functions.
Change `bokeh.document.locking.without_document_lock` to work for async functions and functions decorated with `asyncio.coroutine`.

- [ ] issues: fixes #11716
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
