### PR TITLE
Add Init signatures to Bokeh models

### DIFF
--- a/bokeh/core/has_props.py
+++ b/bokeh/core/has_props.py
@@ -29,7 +29,6 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import difflib
-import types
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -748,7 +747,7 @@ def _HasProps_to_serializable(cls: Type[HasProps], serializer: Serializer) -> Re
         if default is Undefined:
             prop_def = PropertyDef(name=prop_name, kind=kind)
         else:
-            if isinstance(default, types.FunctionType):
+            if callable(default):
                 default = default()
 
             prop_def = PropertyDef(name=prop_name, kind=kind, default=serializer.encode(default))

--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -89,7 +89,6 @@ Basic Properties
 .. autoclass:: Float
 .. autoclass:: FontSize
 .. autoclass:: Image
-.. autoclass:: Instance
 .. autoclass:: Int
 .. autoclass:: Interval
 .. autoclass:: JSON
@@ -144,6 +143,8 @@ Helpers
 Special Properties
 ------------------
 
+.. autoclass:: Instance
+.. autoclass:: InstanceDefault
 .. autoclass:: Include
 .. autoclass:: Nullable
 .. autoclass:: NonNullable
@@ -222,6 +223,7 @@ __all__ = (
     'Image',
     'Include',
     'Instance',
+    'InstanceDefault',
     'Int',
     'Interval',
     'JSON',
@@ -327,6 +329,7 @@ from .property.factors import FactorSeq; FactorSeq
 from .property.include import Include ; Include
 
 from .property.instance import Instance; Instance
+from .property.instance import InstanceDefault; InstanceDefault
 
 from .property.json import JSON; JSON
 

--- a/bokeh/core/property/descriptors.py
+++ b/bokeh/core/property/descriptors.py
@@ -89,7 +89,6 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-import types
 from copy import copy
 from typing import (
     TYPE_CHECKING,
@@ -300,19 +299,22 @@ class PropertyDescriptor(Generic[T]):
         if self.name in obj._unstable_default_values:
             del obj._unstable_default_values[self.name]
 
-    def class_default(self, cls):
+    def class_default(self, cls, no_eval: bool = False):
         """ Get the default value for a specific subtype of ``HasProps``,
         which may not be used for an individual instance.
 
         Args:
             cls (class) : The class to get the default value for.
 
+            no_eval (bool, optional) :
+                Whether to evaluate callables for defaults (default: False)
+
         Returns:
             object
 
 
         """
-        return self.property.themed_default(cls, self.name, None)
+        return self.property.themed_default(cls, self.name, None, no_eval=no_eval)
 
     def instance_default(self, obj: HasProps) -> T:
         """ Get the default value that will be used for a specific instance.
@@ -477,7 +479,7 @@ class PropertyDescriptor(Generic[T]):
 
         # _may_have_unstable_default() doesn't have access to overrides, so check manually
         if self.property._may_have_unstable_default() or \
-                isinstance(obj.__class__.__overridden_defaults__.get(self.name, None), types.FunctionType):
+                callable(obj.__class__.__overridden_defaults__.get(self.name, None)):
             if isinstance(default, PropertyValueContainer):
                 default._register_owner(obj, self)
             unstable_dict[self.name] = default

--- a/bokeh/model/data_model.py
+++ b/bokeh/model/data_model.py
@@ -44,6 +44,10 @@ __all__ = (
 class DataModel(Model):
     __data_model__ = True
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------

--- a/bokeh/model/model.py
+++ b/bokeh/model/model.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from inspect import isclass
+from inspect import Parameter, Signature, isclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -35,6 +35,8 @@ from typing import (
 # Bokeh imports
 from ..core import properties as p
 from ..core.has_props import HasProps, abstract
+from ..core.property._sphinx import type_link
+from ..core.property.validation import without_property_validation
 from ..core.serialization import ObjectRefRep, Ref, Serializer
 from ..core.types import ID, Unknown
 from ..events import Event
@@ -74,9 +76,23 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
 
     '''
 
+
+    # a canonical order for positional args that can be
+    # used for any functions derived from this class
+    _args = ()
+
+    _extra_kws = {}
+
     @classmethod
     def __init_subclass__(cls):
         super().__init_subclass__()
+
+        # in order to add an __init__ signature, the cls has to actually have an __init__ of its own. . .
+        # assert "__init__" in cls.__dict__, str(cls)
+
+        parameters = [x[0] for x in  cls.parameters()]
+        cls.__init__.__signature__ = Signature(parameters=parameters)
+
         process_example(cls)
 
     _id: ID
@@ -86,7 +102,7 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
         obj._id = kwargs.pop("id", make_id())
         return obj
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, *args, **kwargs: Any) -> None:
 
         # "id" is popped from **kw in __new__, so in an ideal world I don't
         # think it should be here too. But Python has subtle behavior here, so
@@ -210,6 +226,80 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
         return Ref(id=self._id)
 
     # Public methods ----------------------------------------------------------
+
+    @classmethod
+    @without_property_validation
+    def parameters(cls):
+        ''' Generate Python ``Parameter`` values suitable for functions that are
+        derived from the glyph.
+
+        Returns:
+            list(Parameter)
+
+        '''
+        arg_params = []
+        no_more_defaults = False
+
+        for arg in reversed(cls._args):
+            descriptor = cls.lookup(arg)
+            default = descriptor.class_default(cls, no_eval=True)
+            if default is None:
+                no_more_defaults = True
+
+            # simplify field(x) defaults to just present the column name
+            if isinstance(default, dict) and set(default) == {"field"}:
+                default = default["field"]
+
+            # make sure we don't hold on to references to actual Models
+            # assert not isinstance(default, Model)
+
+            param = Parameter(
+                name=arg,
+                kind=Parameter.POSITIONAL_OR_KEYWORD,
+                # For positional arg properties, default=None means no default.
+                default=Parameter.empty if no_more_defaults else default
+            )
+            if default:
+                del default
+            typ = type_link(descriptor.property)
+            arg_params.insert(0, (param, typ, descriptor.__doc__))
+
+        # these are not really useful, and should also really be private, just skip them
+        omissions = {'js_event_callbacks', 'js_property_callbacks', 'subscribed_events'}
+
+        kwarg_params = []
+
+        kws = set(cls.properties()) - set(cls._args) - omissions
+        for kw in kws:
+            descriptor = cls.lookup(kw)
+            default = descriptor.class_default(cls, no_eval=True)
+
+            # simplify field(x) defaults to just present the column name
+            if isinstance(default, dict) and set(default) == {"field"}:
+                default = default["field"]
+
+            # make sure we don't hold on to references to actual Models
+            # assert not isinstance(default, Model)
+
+            param = Parameter(
+                name=kw,
+                kind=Parameter.KEYWORD_ONLY,
+                default=default
+            )
+            del default
+            typ = type_link(descriptor.property)
+            kwarg_params.append((param, typ, descriptor.__doc__))
+
+        for kw, (typ, doc) in cls._extra_kws.items():
+            param = Parameter(
+                name=kw,
+                kind=Parameter.KEYWORD_ONLY,
+            )
+            kwarg_params.append((param, typ, doc))
+
+        kwarg_params.sort(key=lambda x: x[0].name)
+
+        return arg_params + kwarg_params
 
     def js_on_event(self, event: str | Type[Event], *callbacks: JSEventCallback) -> None:
         if isinstance(event, str):

--- a/bokeh/model/model.py
+++ b/bokeh/model/model.py
@@ -87,13 +87,11 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
     def __init_subclass__(cls):
         super().__init_subclass__()
 
-        # in order to add an __init__ signature, the cls has to actually have an __init__ of its own. . .
-        # assert "__init__" in cls.__dict__, str(cls)
-
-        parameters = [x[0] for x in  cls.parameters()]
-        cls.__init__.__signature__ = Signature(parameters=parameters)
-
-        process_example(cls)
+        if cls.__module__.startswith("bokeh.models"):
+            assert "__init__" in cls.__dict__, str(cls)
+            parameters = [x[0] for x in  cls.parameters()]
+            cls.__init__.__signature__ = Signature(parameters=parameters)
+            process_example(cls)
 
     _id: ID
 
@@ -250,8 +248,9 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
             if isinstance(default, dict) and set(default) == {"field"}:
                 default = default["field"]
 
-            # make sure we don't hold on to references to actual Models
-            # assert not isinstance(default, Model)
+            # make sure built-ins don't hold on to references to actual Models
+            if cls.__module__.startswith("bokeh.models"):
+                assert not isinstance(default, Model)
 
             param = Parameter(
                 name=arg,
@@ -278,8 +277,9 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
             if isinstance(default, dict) and set(default) == {"field"}:
                 default = default["field"]
 
-            # make sure we don't hold on to references to actual Models
-            # assert not isinstance(default, Model)
+            # make sure built-ins don't hold on to references to actual Models
+            if cls.__module__.startswith("bokeh.models"):
+                assert not isinstance(default, Model)
 
             param = Parameter(
                 name=kw,

--- a/bokeh/model/util.py
+++ b/bokeh/model/util.py
@@ -23,6 +23,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 from typing import (
     TYPE_CHECKING,
+    Any,
     Callable,
     List,
     Set,
@@ -222,6 +223,17 @@ def visit_value_and_its_immediate_references(obj: Unknown, visitor: Callable[[Mo
         else:
             # this isn't a Model, so recurse into it
             visit_immediate_value_references(obj, visitor)
+
+class InstanceDefault:
+    def __init__(self, model: Type[Model], **kwargs: Any) -> None:
+        self._model = model
+        self._kwargs = kwargs
+
+    def __call__(self) -> Model:
+        return self._model(**self._kwargs)
+
+    def __repr__(self) -> str:
+        return f"<Instance: {self._model.__name__}(" + ", ".join(f"{key}={val}" for key, val in self._kwargs.items()) +  ")>"
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/bokeh/model/util.py
+++ b/bokeh/model/util.py
@@ -23,7 +23,6 @@ log = logging.getLogger(__name__)
 # Standard library imports
 from typing import (
     TYPE_CHECKING,
-    Any,
     Callable,
     List,
     Set,
@@ -223,17 +222,6 @@ def visit_value_and_its_immediate_references(obj: Unknown, visitor: Callable[[Mo
         else:
             # this isn't a Model, so recurse into it
             visit_immediate_value_references(obj, visitor)
-
-class InstanceDefault:
-    def __init__(self, model: Type[Model], **kwargs: Any) -> None:
-        self._model = model
-        self._kwargs = kwargs
-
-    def __call__(self) -> Model:
-        return self._model(**self._kwargs)
-
-    def __repr__(self) -> str:
-        return f"<Instance: {self._model.__name__}(" + ", ".join(f"{key}={val}" for key, val in self._kwargs.items()) +  ")>"
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/bokeh/models/annotations/annotation.py
+++ b/bokeh/models/annotations/annotation.py
@@ -23,6 +23,7 @@ log = logging.getLogger(__name__)
 # Bokeh imports
 from ...core.has_props import abstract
 from ...core.properties import Instance, Override
+from ...model.util import InstanceDefault
 from ..renderers import Renderer
 from ..sources import ColumnDataSource, DataSource
 
@@ -44,6 +45,10 @@ class Annotation(Renderer):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     level = Override(default="annotation")
 
 @abstract
@@ -52,7 +57,11 @@ class DataAnnotation(Annotation):
 
     '''
 
-    source = Instance(DataSource, default=lambda: ColumnDataSource(), help="""
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+    source = Instance(DataSource, default=InstanceDefault(ColumnDataSource), help="""
     Local data source to use when rendering annotations on the plot.
     """)
 

--- a/bokeh/models/annotations/annotation.py
+++ b/bokeh/models/annotations/annotation.py
@@ -22,8 +22,7 @@ log = logging.getLogger(__name__)
 
 # Bokeh imports
 from ...core.has_props import abstract
-from ...core.properties import Instance, Override
-from ...model.util import InstanceDefault
+from ...core.properties import Instance, InstanceDefault, Override
 from ..renderers import Renderer
 from ..sources import ColumnDataSource, DataSource
 

--- a/bokeh/models/annotations/arrows.py
+++ b/bokeh/models/annotations/arrows.py
@@ -27,13 +27,13 @@ from ...core.properties import (
     Enum,
     Include,
     Instance,
+    InstanceDefault,
     Nullable,
     NumberSpec,
     Override,
     field,
 )
 from ...core.property_mixins import FillProps, LineProps
-from ...model.util import InstanceDefault
 from ..graphics import Marking
 from .annotation import DataAnnotation
 

--- a/bokeh/models/annotations/arrows.py
+++ b/bokeh/models/annotations/arrows.py
@@ -33,6 +33,7 @@ from ...core.properties import (
     field,
 )
 from ...core.property_mixins import FillProps, LineProps
+from ...model.util import InstanceDefault
 from ..graphics import Marking
 from .annotation import DataAnnotation
 
@@ -59,6 +60,10 @@ class ArrowHead(Marking):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     size = NumberSpec(default=25, help="""
     The size, in pixels, of the arrow head.
     """)
@@ -70,6 +75,10 @@ class OpenHead(ArrowHead):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     line_props = Include(LineProps, help="""
 
     The {prop} values for the arrow head outline.
@@ -79,6 +88,10 @@ class NormalHead(ArrowHead):
     ''' Render a closed-body arrow head.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     line_props = Include(LineProps, help="""
     The {prop} values for the arrow head outline.
@@ -95,6 +108,10 @@ class TeeHead(ArrowHead):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     line_props = Include(LineProps, help="""
     The {prop} values for the arrow head outline.
     """)
@@ -103,6 +120,10 @@ class VeeHead(ArrowHead):
     ''' Render a vee-style arrow head.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     line_props = Include(LineProps, help="""
     The {prop} values for the arrow head outline.
@@ -120,6 +141,10 @@ class Arrow(DataAnnotation):
     See :ref:`userguide_annotations_arrows` for information on plotting arrows.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     x_start = NumberSpec(default=field("x_start"), help="""
     The x-coordinates to locate the start of the arrows.
@@ -151,7 +176,7 @@ class Arrow(DataAnnotation):
     space" units by default.
     """)
 
-    end = Nullable(Instance(ArrowHead), default=lambda: OpenHead(), help="""
+    end = Nullable(Instance(ArrowHead), default=InstanceDefault(OpenHead), help="""
     Instance of ``ArrowHead``.
     """)
 

--- a/bokeh/models/annotations/geometry.py
+++ b/bokeh/models/annotations/geometry.py
@@ -30,6 +30,7 @@ from ...core.properties import (
     Float,
     Include,
     Instance,
+    InstanceDefault,
     Null,
     Nullable,
     NumberSpec,
@@ -44,7 +45,6 @@ from ...core.property_mixins import (
     ScalarHatchProps,
     ScalarLineProps,
 )
-from ...model.util import InstanceDefault
 from ...util.serialization import convert_datetime_type
 from .annotation import Annotation, DataAnnotation
 from .arrows import ArrowHead, TeeHead

--- a/bokeh/models/annotations/geometry.py
+++ b/bokeh/models/annotations/geometry.py
@@ -44,6 +44,7 @@ from ...core.property_mixins import (
     ScalarHatchProps,
     ScalarLineProps,
 )
+from ...model.util import InstanceDefault
 from ...util.serialization import convert_datetime_type
 from .annotation import Annotation, DataAnnotation
 from .arrows import ArrowHead, TeeHead
@@ -71,6 +72,10 @@ class BoxAnnotation(Annotation):
     See :ref:`userguide_annotations_box_annotations` for information on plotting box annotations.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     left = Either(Null, Auto, NumberSpec(), help="""
     The x-coordinates of the left edge of the box annotation.
@@ -146,6 +151,11 @@ class Band(DataAnnotation):
     See :ref:`userguide_annotations_bands` for information on plotting bands.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     lower = UnitsSpec(default=field("lower"), units_enum=SpatialUnits, units_default="data", help="""
     The coordinates of the lower portion of the filled area band.
     """)
@@ -187,6 +197,10 @@ class PolyAnnotation(Annotation):
     plotting polygon annotations.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     xs = Seq(Float, default=[], help="""
     The x-coordinates of the region to draw.
@@ -233,6 +247,10 @@ class Slope(Annotation):
 
     """
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     gradient = Nullable(Float, help="""
     The gradient of the line, in |data units|
     """)
@@ -251,6 +269,10 @@ class Span(Annotation):
     See :ref:`userguide_annotations_spans` for information on plotting spans.
 
     """
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     location = Nullable(Float, help="""
     The location of the span, along ``dimension``.
@@ -280,11 +302,15 @@ class Whisker(DataAnnotation):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     lower = UnitsSpec(default=field("lower"), units_enum=SpatialUnits, units_default="data", help="""
     The coordinates of the lower end of the whiskers.
     """)
 
-    lower_head = Nullable(Instance(ArrowHead), default=lambda: TeeHead(size=10), help="""
+    lower_head = Nullable(Instance(ArrowHead), default=InstanceDefault(TeeHead, size=10), help="""
     Instance of ``ArrowHead``.
     """)
 
@@ -292,7 +318,7 @@ class Whisker(DataAnnotation):
     The coordinates of the upper end of the whiskers.
     """)
 
-    upper_head = Nullable(Instance(ArrowHead), default=lambda: TeeHead(size=10), help="""
+    upper_head = Nullable(Instance(ArrowHead), default=InstanceDefault(TeeHead, size=10), help="""
     Instance of ``ArrowHead``.
     """)
 

--- a/bokeh/models/annotations/html/html_annotation.py
+++ b/bokeh/models/annotations/html/html_annotation.py
@@ -46,6 +46,11 @@ class HTMLAnnotation(Annotation):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------

--- a/bokeh/models/annotations/html/labels.py
+++ b/bokeh/models/annotations/html/labels.py
@@ -90,6 +90,10 @@ class HTMLLabel(HTMLAnnotation):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     x = NonNullable(Float, help="""
     The x-coordinate in screen coordinates to locate the text anchors.
 
@@ -181,6 +185,10 @@ class HTMLLabelSet(HTMLAnnotation, DataAnnotation):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     x = NumberSpec(default=field("x"), help="""
     The x-coordinates to locate the text anchors.
     """)
@@ -243,6 +251,10 @@ class HTMLTitle(HTMLAnnotation):
     See :ref:`userguide_annotations_titles` for information on plotting titles.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     text = String(default="", help="""
     The text value to render.

--- a/bokeh/models/annotations/html/toolbars.py
+++ b/bokeh/models/annotations/html/toolbars.py
@@ -37,6 +37,10 @@ __all__ = (
 
 class ToolbarPanel(HTMLAnnotation): # TODO: this shouldn't be an annotation
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     toolbar = Instance(".models.tools.Toolbar", help="""
     A toolbar to display.
     """)

--- a/bokeh/models/annotations/html/tooltips.py
+++ b/bokeh/models/annotations/html/tooltips.py
@@ -44,6 +44,11 @@ class Tooltip(HTMLAnnotation):
         directly from python.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     level = Override(default="overlay")
 
     attachment = Enum(TooltipAttachment, help="""

--- a/bokeh/models/annotations/labels.py
+++ b/bokeh/models/annotations/labels.py
@@ -74,6 +74,10 @@ class TextAnnotation(Annotation):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     text = TextLike(default="", help="""
     A text or LaTeX notation to render.
     """)
@@ -113,6 +117,10 @@ class Label(TextAnnotation):
     See :ref:`userguide_annotations_labels` for information on plotting labels.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     x = NonNullable(Float, help="""
     The x-coordinate in screen coordinates to locate the text anchors.
@@ -185,6 +193,10 @@ class LabelSet(DataAnnotation):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     x = NumberSpec(default=field("x"), help="""
     The x-coordinates to locate the text anchors.
     """)
@@ -247,6 +259,10 @@ class Title(TextAnnotation):
     See :ref:`userguide_annotations_titles` for information on plotting titles.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     vertical_align = Enum(VerticalAlign, default='bottom', help="""
     Alignment of the text in its enclosing space, *across* the direction of the text.

--- a/bokeh/models/annotations/legends.py
+++ b/bokeh/models/annotations/legends.py
@@ -51,6 +51,7 @@ from ...core.property_mixins import ScalarFillProps, ScalarLineProps, ScalarText
 from ...core.validation import error
 from ...core.validation.errors import BAD_COLUMN_NAME, NON_MATCHING_DATA_SOURCES_ON_LEGEND_ITEM_RENDERERS
 from ...model import Model
+from ...model.util import InstanceDefault
 from ..formatters import TickFormatter
 from ..labeling import LabelingPolicy, NoOverlap
 from ..mappers import ColorMapper
@@ -89,6 +90,10 @@ class ColorBar(Annotation):
         If the color bar is placed in a side panel, the location will likely
         have to be set to `(0,0)`.
     """)
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     orientation = Either(Enum(Orientation), Auto, default="auto", help="""
     Whether the color bar should be oriented vertically or horizontally.
@@ -135,7 +140,7 @@ class ColorBar(Annotation):
     override normal formatting.
     """)
 
-    major_label_policy = Instance(LabelingPolicy, default=lambda: NoOverlap(), help="""
+    major_label_policy = Instance(LabelingPolicy, default=InstanceDefault(NoOverlap), help="""
     Allows to filter out labels, e.g. declutter labels to avoid overlap.
     """)
 
@@ -279,6 +284,10 @@ class Legend(Annotation):
     See :ref:`userguide_annotations_legends` for information on plotting legends.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     location = Either(Enum(LegendLocation), Tuple(Float, Float), default="top_right", help="""
     The location where the legend should draw itself. It's either one of

--- a/bokeh/models/annotations/legends.py
+++ b/bokeh/models/annotations/legends.py
@@ -36,6 +36,7 @@ from ...core.properties import (
     Float,
     Include,
     Instance,
+    InstanceDefault,
     Int,
     List,
     Nullable,
@@ -51,7 +52,6 @@ from ...core.property_mixins import ScalarFillProps, ScalarLineProps, ScalarText
 from ...core.validation import error
 from ...core.validation.errors import BAD_COLUMN_NAME, NON_MATCHING_DATA_SOURCES_ON_LEGEND_ITEM_RENDERERS
 from ...model import Model
-from ...model.util import InstanceDefault
 from ..formatters import TickFormatter
 from ..labeling import LabelingPolicy, NoOverlap
 from ..mappers import ColorMapper

--- a/bokeh/models/axes.py
+++ b/bokeh/models/axes.py
@@ -44,6 +44,7 @@ from ..core.properties import (
     Tuple,
 )
 from ..core.property_mixins import ScalarLineProps, ScalarTextProps
+from ..model.util import InstanceDefault
 from .formatters import (
     BasicTickFormatter,
     CategoricalTickFormatter,
@@ -87,6 +88,10 @@ class Axis(GuideRenderer):
     ''' A base class that defines common properties for all axis types.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     bounds = Either(Auto, Tuple(Float, Float), Tuple(Datetime, Datetime), help="""
     Bounds for the rendered axis. If unset, the axis will span the
@@ -156,7 +161,7 @@ class Axis(GuideRenderer):
     override normal formatting.
     """)
 
-    major_label_policy = Instance(LabelingPolicy, default=lambda: AllLabels(), help="""
+    major_label_policy = Instance(LabelingPolicy, default=InstanceDefault(AllLabels), help="""
     Allows to filter out labels, e.g. declutter labels to avoid overlap.
     """)
 
@@ -217,25 +222,38 @@ class ContinuousAxis(Axis):
     ''' A base class for all numeric, non-categorical axes types.
 
     '''
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 class LinearAxis(ContinuousAxis):
     ''' An axis that picks nice numbers for tick locations on a
     linear scale. Configured with a ``BasicTickFormatter`` by default.
 
     '''
-    ticker = Override(default=lambda: BasicTicker())
 
-    formatter = Override(default=lambda: BasicTickFormatter())
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+    ticker = Override(default=InstanceDefault(BasicTicker))
+
+    formatter = Override(default=InstanceDefault(BasicTickFormatter))
 
 class LogAxis(ContinuousAxis):
     ''' An axis that picks nice numbers for tick locations on a
     log scale. Configured with a ``LogTickFormatter`` by default.
 
     '''
-    ticker = Override(default=lambda: LogTicker())
 
-    formatter = Override(default=lambda: LogTickFormatter())
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+    ticker = Override(default=InstanceDefault(LogTicker))
+
+    formatter = Override(default=InstanceDefault(LogTickFormatter))
 
 class CategoricalAxis(Axis):
     ''' An axis that displays ticks and labels for categorical ranges.
@@ -245,9 +263,14 @@ class CategoricalAxis(Axis):
     factors.
 
     '''
-    ticker = Override(default=lambda: CategoricalTicker())
 
-    formatter = Override(default=lambda: CategoricalTickFormatter())
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+    ticker = Override(default=InstanceDefault(CategoricalTicker))
+
+    formatter = Override(default=InstanceDefault(CategoricalTickFormatter))
 
     separator_props = Include(ScalarLineProps, prefix="separator", help="""
     The {prop} of the separator line between top-level categorical groups.
@@ -308,9 +331,13 @@ class DatetimeAxis(LinearAxis):
 
     '''
 
-    ticker = Override(default=lambda: DatetimeTicker())
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
-    formatter = Override(default=lambda: DatetimeTickFormatter())
+    ticker = Override(default=InstanceDefault(DatetimeTicker))
+
+    formatter = Override(default=InstanceDefault(DatetimeTickFormatter))
 
 class MercatorAxis(LinearAxis):
     ''' An axis that picks nice numbers for tick locations on a
@@ -322,8 +349,8 @@ class MercatorAxis(LinearAxis):
             (default: 'lat')
 
     '''
-    def __init__(self, dimension='lat', **kw) -> None:
-        super().__init__(**kw)
+    def __init__(self, dimension='lat', *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
         # Just being careful. It would be defeat the purpose for anyone to actually
         # configure this axis with different kinds of tickers or formatters.
@@ -332,9 +359,9 @@ class MercatorAxis(LinearAxis):
         if isinstance(self.formatter, MercatorTickFormatter):
             self.formatter.dimension = dimension
 
-    ticker = Override(default=lambda: MercatorTicker())
+    ticker = Override(default=InstanceDefault(MercatorTicker))
 
-    formatter = Override(default=lambda: MercatorTickFormatter())
+    formatter = Override(default=InstanceDefault(MercatorTickFormatter))
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/models/axes.py
+++ b/bokeh/models/axes.py
@@ -34,6 +34,7 @@ from ..core.properties import (
     Float,
     Include,
     Instance,
+    InstanceDefault,
     Int,
     Null,
     Nullable,
@@ -44,7 +45,6 @@ from ..core.properties import (
     Tuple,
 )
 from ..core.property_mixins import ScalarLineProps, ScalarTextProps
-from ..model.util import InstanceDefault
 from .formatters import (
     BasicTickFormatter,
     CategoricalTickFormatter,

--- a/bokeh/models/callbacks.py
+++ b/bokeh/models/callbacks.py
@@ -51,11 +51,19 @@ class Callback(Model):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 
 class OpenURL(Callback):
     ''' Open a URL in a new or current tab or window.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     url = String("http://", help="""
     The URL to direct the web browser to. This can be a template string,
@@ -78,6 +86,10 @@ class CustomJS(Callback):
         sanitize the user input prior to passing to Bokeh.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     args = Dict(String, AnyRef, help="""
     A mapping of names to Python objects. In particular those can be bokeh's models.

--- a/bokeh/models/canvas.py
+++ b/bokeh/models/canvas.py
@@ -18,9 +18,8 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Bokeh imports
-from ..core.properties import Instance
+from ..core.properties import Instance, InstanceDefault
 from ..model import Model
-from ..model.util import InstanceDefault
 from .ranges import DataRange1d, Range
 from .scales import LinearScale, Scale
 

--- a/bokeh/models/canvas.py
+++ b/bokeh/models/canvas.py
@@ -20,6 +20,7 @@ log = logging.getLogger(__name__)
 # Bokeh imports
 from ..core.properties import Instance
 from ..model import Model
+from ..model.util import InstanceDefault
 from .ranges import DataRange1d, Range
 from .scales import LinearScale, Scale
 
@@ -38,10 +39,14 @@ __all__ = (
 class CoordinateMapping(Model):
     """ A mapping between two coordinate systems. """
 
-    x_source = Instance(Range, default=lambda: DataRange1d())
-    y_source = Instance(Range, default=lambda: DataRange1d())
-    x_scale = Instance(Scale, default=lambda: LinearScale())
-    y_scale = Instance(Scale, default=lambda: LinearScale())
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+    x_source = Instance(Range, default=InstanceDefault(DataRange1d))
+    y_source = Instance(Range, default=InstanceDefault(DataRange1d))
+    x_scale = Instance(Scale, default=InstanceDefault(LinearScale))
+    y_scale = Instance(Scale, default=InstanceDefault(LinearScale))
     x_target = Instance(Range)
     y_target = Instance(Range)
 

--- a/bokeh/models/css.py
+++ b/bokeh/models/css.py
@@ -39,6 +39,10 @@ __all__ = (
 class Styles(Model, Qualified):
     """ Allows to configure style attribute of DOM elements. """
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     align_content = Nullable(String)
     align_items = Nullable(String)
     align_self = Nullable(String)

--- a/bokeh/models/dom.py
+++ b/bokeh/models/dom.py
@@ -57,29 +57,54 @@ __all__ = (
 class DOMNode(Model, Qualified):
     """ Base class for DOM nodes. """
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 class Text(DOMNode):
     """ DOM text node. """
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     content = String("")
 
 @abstract
 class DOMElement(DOMNode):
     """ Base class for DOM elements. """
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     style = Nullable(Either(Instance(Styles), Dict(String, String)))
 
     children = List(Either(String, Instance(DOMNode), Instance(LayoutDOM)), default=[])
 
 class Span(DOMElement):
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 class Div(DOMElement):
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 class Table(DOMElement):
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 class TableRow(DOMElement):
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 def vbox(children: List[DOMNode]) -> Div:
     return Div(style=Styles(display="flex", flex_direction="column"), children=children)
@@ -89,25 +114,54 @@ def hbox(children: List[DOMNode]) -> Div:
 
 @abstract
 class Action(Model, Qualified):
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 class Template(DOMElement):
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     actions = List(Instance(Action))
 
 class ToggleGroup(Action):
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     groups = List(Instance(RendererGroup))
 
 @abstract
 class Placeholder(DOMNode):
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 class Index(Placeholder):
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 class ValueRef(Placeholder):
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     field = NonNullable(String)
 
 class ColorRef(ValueRef):
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     hex = Bool(default=True)
     swatch = Bool(default=True)
 

--- a/bokeh/models/expressions.py
+++ b/bokeh/models/expressions.py
@@ -94,7 +94,11 @@ class Expression(Model):
         the source changes, implement ``_v_compute: (source)`` instead.
 
     '''
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 
 class CustomJSExpr(Expression):
     ''' Evaluate a JavaScript function/generator.
@@ -106,6 +110,10 @@ class CustomJSExpr(Expression):
         sanitize the user input prior to passing to Bokeh.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     args = Dict(String, AnyRef, help="""
     A mapping of names to Python objects. In particular those can be bokeh's models.
@@ -125,11 +133,16 @@ class CustomJSExpr(Expression):
     be collected into an array.
     """)
 
+
 class CumSum(Expression):
     ''' An expression for generating arrays by cumulatively summing a single
     column from a ``ColumnDataSource``.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     field = NonNullable(String, help="""
     The name of a ``ColumnDataSource`` column to cumulatively sum for new values.
@@ -153,6 +166,7 @@ class CumSum(Expression):
 
     """)
 
+
 class Stack(Expression):
     ''' An expression for generating arrays by summing different columns from
     a ``ColumnDataSource``.
@@ -161,6 +175,10 @@ class Stack(Expression):
     level.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     fields = Seq(String, default=[], help="""
     A sequence of fields from a ``ColumnDataSource`` to sum (elementwise). For
@@ -174,37 +192,45 @@ class Stack(Expression):
     of the ``'sales'`` and ``'marketing'`` columns of a data source.
     """)
 
+
 @abstract
 class ScalarExpression(Model):
     """ Base class for for scalar expressions. """
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+
 class Minimum(ScalarExpression):
     """ Computes minimum value of a data source's column. """
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     field = NonNullable(String)
     initial = Nullable(Float, default=float("+inf"))
 
+
 class Maximum(ScalarExpression):
     """ Computes maximum value of a data source's column. """
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     field = NonNullable(String)
     initial = Nullable(Float, default=float("-inf"))
 
-#-----------------------------------------------------------------------------
-# Dev API
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Private API
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Code
-#-----------------------------------------------------------------------------
 
 @abstract
 class CoordinateTransform(Expression):
     """ Base class for coordinate transforms. """
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     @property
     def x(self):
@@ -214,8 +240,13 @@ class CoordinateTransform(Expression):
     def y(self):
         return YComponent(transform=self)
 
+
 class PolarTransform(CoordinateTransform):
     """ Transform from polar to cartesian coordinates. """
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     radius = NumberSpec(default=field("radius"), help="""
     The radial coordinate (i.e. the distance from the origin).
@@ -232,14 +263,42 @@ class PolarTransform(CoordinateTransform):
     Whether ``angle`` measures clockwise or anti-clockwise from the reference axis.
     """)
 
+
 @abstract
 class XYComponent(Expression):
     """ Base class for bi-variate expressions. """
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     transform = Instance(CoordinateTransform)
+
 
 class XComponent(XYComponent):
     """ X-component of a coordinate system transform to cartesian coordinates. """
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+
 class YComponent(XYComponent):
     """ Y-component of a coordinate system transform to cartesian coordinates. """
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------

--- a/bokeh/models/filters.py
+++ b/bokeh/models/filters.py
@@ -53,6 +53,10 @@ class Filter(Model):
     data when applied to a ``ColumnDataSource``.
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 class IndexFilter(Filter):
     ''' An ``IndexFilter`` filters data by returning the subset of data at a given set of indices.
     '''
@@ -61,11 +65,11 @@ class IndexFilter(Filter):
     A list of integer indices representing the subset of data to select.
     """)
 
-    def __init__(self, *args, **kw) -> None:
-        if len(args) == 1 and "indices" not in kw:
-            kw["indices"] = args[0]
+    def __init__(self, *args, **kwargs) -> None:
+        if len(args) == 1 and "indices" not in kwargs:
+            kwargs["indices"] = args[0]
 
-        super().__init__(**kw)
+        super().__init__(**kwargs)
 
 class BooleanFilter(Filter):
     ''' A ``BooleanFilter`` filters data by returning the subset of data corresponding to indices
@@ -76,11 +80,11 @@ class BooleanFilter(Filter):
     A list of booleans indicating which rows of data to select.
     """)
 
-    def __init__(self, *args, **kw) -> None:
-        if len(args) == 1 and "booleans" not in kw:
-            kw["booleans"] = args[0]
+    def __init__(self, *args, **kwargs) -> None:
+        if len(args) == 1 and "booleans" not in kwargs:
+            kwargs["booleans"] = args[0]
 
-        super().__init__(**kw)
+        super().__init__(**kwargs)
 
 class GroupFilter(Filter):
     ''' A ``GroupFilter`` represents the rows of a ``ColumnDataSource`` where the values of the categorical
@@ -95,12 +99,12 @@ class GroupFilter(Filter):
     The value of the column indicating the rows of data to keep.
     """)
 
-    def __init__(self, *args, **kw) -> None:
-        if len(args) == 2 and "column_name" not in kw and "group" not in kw:
-            kw["column_name"] = args[0]
-            kw["group"] = args[1]
+    def __init__(self, *args, **kwargs) -> None:
+        if len(args) == 2 and "column_name" not in kwargs and "group" not in kwargs:
+            kwargs["column_name"] = args[0]
+            kwargs["group"] = args[1]
 
-        super().__init__(**kw)
+        super().__init__(**kwargs)
 
 class CustomJSFilter(Filter):
     ''' Filter data sources with a custom defined JavaScript function.
@@ -112,6 +116,10 @@ class CustomJSFilter(Filter):
         sanitize the user input prior to passing to Bokeh.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     args = RestrictedDict(String, AnyRef, disallow=("source",), help="""
     A mapping of names to Python objects. In particular those can be bokeh's models.

--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -79,13 +79,21 @@ class TickFormatter(Model):
     ''' A base class for all tick formatter types.
 
     '''
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 class BasicTickFormatter(TickFormatter):
     ''' Display tick values from continuous ranges as "basic numbers",
     using scientific notation when appropriate by default.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     precision = Either(Auto, Int, help="""
     How many digits of precision to display in tick labels.
     """)
@@ -120,6 +128,10 @@ class MercatorTickFormatter(BasicTickFormatter):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     dimension = Nullable(Enum(LatLon), help="""
     Specify whether to format ticks for Latitude or Longitude.
 
@@ -144,6 +156,10 @@ class MercatorTickFormatter(BasicTickFormatter):
 
 class NumeralTickFormatter(TickFormatter):
     ''' Tick formatter based on a human-readable format string. '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     format = String("0,0", help="""
     The number format, as defined in the following tables:
@@ -232,6 +248,10 @@ class NumeralTickFormatter(TickFormatter):
 class PrintfTickFormatter(TickFormatter):
     ''' Tick formatter based on a printf-style format string. '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     format = String("%s", help="""
     The number format, as defined as follows: the placeholder in the format
     string is marked by % and is followed by one or more of these elements,
@@ -283,6 +303,11 @@ class LogTickFormatter(TickFormatter):
     Most often useful in conjunction with a ``LogTicker``.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     ticker = Nullable(Instance(Ticker), help="""
     The corresponding ``LogTicker``, used to determine the correct
     base to use. If unset, the formatter will use base 10 as a default.
@@ -299,7 +324,10 @@ class CategoricalTickFormatter(TickFormatter):
     values.
 
     '''
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 class CustomJSTickFormatter(TickFormatter):
     ''' Display tick values that are formatted by a user-defined function.
@@ -311,6 +339,10 @@ class CustomJSTickFormatter(TickFormatter):
         sanitize the user input prior to passing to Bokeh.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     args = Dict(String, AnyRef, help="""
     A mapping of names to Python objects. In particular those can be bokeh's models.
@@ -546,6 +578,11 @@ class DatetimeTickFormatter(TickFormatter):
     .. _github issue: https://github.com/bokeh/bokeh/issues
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     microseconds = List(String,
                         help=_DATETIME_TICK_FORMATTER_HELP("``microseconds``"),
                         default=['%fus']).accepts(String, lambda fmt: [fmt])

--- a/bokeh/models/glyph.py
+++ b/bokeh/models/glyph.py
@@ -27,14 +27,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
-# Standard library imports
-from inspect import Parameter
-
 # Bokeh imports
 from ..core.has_props import abstract
 from ..core.properties import Instance, List
-from ..core.property._sphinx import type_link
-from ..core.property.validation import without_property_validation
 from ..model import Model
 from .graphics import Decoration
 
@@ -58,6 +53,10 @@ class Glyph(Model):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     decorations = List(Instance(Decoration), default=[], help="""
     A collection of glyph decorations, e.g. arrow heads.
 
@@ -70,93 +69,15 @@ class Glyph(Model):
         but they don't participate in hit testing, etc.
     """)
 
-    # a canonical order for positional args that can be
-    # used for any functions derived from this class
-    _args = ()
-
-    _extra_kws = {}
-
-    @classmethod
-    @without_property_validation
-    def parameters(cls):
-        ''' Generate Python ``Parameter`` values suitable for functions that are
-        derived from the glyph.
-
-        Returns:
-            list(Parameter)
-
-        '''
-        arg_params = []
-        no_more_defaults = False
-
-        for arg in reversed(cls._args):
-            descriptor = cls.lookup(arg)
-            default = descriptor.class_default(cls)
-            if default is None:
-                no_more_defaults = True
-
-            # simplify field(x) defaults to just present the column name
-            if isinstance(default, dict) and set(default) == {"field"}:
-                default = default["field"]
-
-            # make sure we don't hold on to references to actual Models
-            if isinstance(default, Model):
-                default = _ModelRepr(default)
-
-            param = Parameter(
-                name=arg,
-                kind=Parameter.POSITIONAL_OR_KEYWORD,
-                # For positional arg properties, default=None means no default.
-                default=Parameter.empty if no_more_defaults else default
-            )
-            if default:
-                del default
-            typ = type_link(descriptor.property)
-            arg_params.insert(0, (param, typ, descriptor.__doc__))
-
-        # these are not really useful, and should also really be private, just skip them
-        omissions = {'js_event_callbacks', 'js_property_callbacks', 'subscribed_events'}
-
-        kwarg_params = []
-
-        kws = set(cls.properties()) - set(cls._args) - omissions
-        for kw in kws:
-            descriptor = cls.lookup(kw)
-            default = descriptor.class_default(cls)
-
-            # simplify field(x) defaults to just present the column name
-            if isinstance(default, dict) and set(default) == {"field"}:
-                default = default["field"]
-
-            # make sure we don't hold on to references to actual Models
-            if isinstance(default, Model):
-                default = _ModelRepr(default)
-
-            param = Parameter(
-                name=kw,
-                kind=Parameter.KEYWORD_ONLY,
-                default=default
-            )
-            del default
-            typ = type_link(descriptor.property)
-            kwarg_params.append((param, typ, descriptor.__doc__))
-
-        for kw, (typ, doc) in cls._extra_kws.items():
-            param = Parameter(
-                name=kw,
-                kind=Parameter.KEYWORD_ONLY,
-            )
-            kwarg_params.append((param, typ, doc))
-
-        kwarg_params.sort(key=lambda x: x[0].name)
-
-        return arg_params + kwarg_params
-
 @abstract
 class XYGlyph(Glyph):
     ''' Base class of glyphs with `x` and `y` coordinate attributes.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 @abstract
 class ConnectedXYGlyph(XYGlyph):
@@ -165,25 +86,49 @@ class ConnectedXYGlyph(XYGlyph):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 @abstract
 class LineGlyph(Glyph):
     ''' Glyphs with line properties
+
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 @abstract
 class FillGlyph(Glyph):
     ''' Glyphs with fill properties
+
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 @abstract
 class TextGlyph(Glyph):
     ''' Glyphs with text properties
+
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 @abstract
 class HatchGlyph(Glyph):
     ''' Glyphs with Hatch properties
+
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 #-----------------------------------------------------------------------------
 # Dev API
@@ -192,15 +137,6 @@ class HatchGlyph(Glyph):
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------
-
-class _ModelRepr:
-    ''' This proxy is for storing reprs of Bokeh models that are property
-    defaults, so that holding references to those Models may be avoided.
-    '''
-    def __init__(self, model: Model) -> None:
-        self. _repr = repr(model)
-    def __repr__(self) -> str:
-        return self._repr
 
 #-----------------------------------------------------------------------------
 # Code

--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -142,6 +142,10 @@ class Marker(XYGlyph, LineGlyph, FillGlyph, HatchGlyph):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     _args = ('x', 'y', 'size', 'angle')
 
     x = NumberSpec(default=field("x"), help="""
@@ -183,6 +187,10 @@ class AnnularWedge(XYGlyph, LineGlyph, FillGlyph, HatchGlyph):
     ''' Render annular wedges.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/AnnularWedge.py"
 
@@ -233,6 +241,10 @@ class Annulus(XYGlyph, LineGlyph, FillGlyph, HatchGlyph):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     __example__ = "examples/reference/models/Annulus.py"
 
     _args = ('x', 'y', 'inner_radius', 'outer_radius')
@@ -269,6 +281,10 @@ class Arc(XYGlyph, LineGlyph):
     ''' Render arcs.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Arc.py"
 
@@ -310,6 +326,10 @@ class Bezier(LineGlyph):
     .. _Wikipedia article for Bezier curve: http://en.wikipedia.org/wiki/Bezier_curve
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Bezier.py"
 
@@ -356,6 +376,10 @@ class Block(LineGlyph, FillGlyph, HatchGlyph):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     __example__ = "examples/reference/models/Block.py"
 
     _args = ('x', 'y', 'width', 'height')
@@ -390,6 +414,10 @@ class Block(LineGlyph, FillGlyph, HatchGlyph):
 
 class Circle(Marker):
     ''' Render circle markers. '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Circle.py"
 
@@ -429,6 +457,10 @@ class Ellipse(XYGlyph, LineGlyph, FillGlyph, HatchGlyph):
     ''' Render ellipses.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Ellipse.py"
 
@@ -472,6 +504,10 @@ class HArea(LineGlyph, FillGlyph, HatchGlyph):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     __example__ = "examples/reference/models/HArea.py"
 
     _args = ('x1', 'x2', 'y')
@@ -501,6 +537,10 @@ class HBar(LineGlyph, FillGlyph, HatchGlyph):
     (``left``, ``right``) coordinates.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/HBar.py"
 
@@ -538,6 +578,10 @@ class HexTile(LineGlyph, FillGlyph, HatchGlyph):
     ''' Render horizontal tiles on a regular hexagonal grid.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/HexTile.py"
 
@@ -603,7 +647,7 @@ class Image(XYGlyph):
 
     '''
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, *args, **kwargs) -> None:
         if 'palette' in kwargs and 'color_mapper' in kwargs:
             raise ValueError("only one of 'palette' and 'color_mapper' may be specified")
         elif 'color_mapper' not in kwargs:
@@ -612,7 +656,7 @@ class Image(XYGlyph):
             mapper = LinearColorMapper(palette)
             kwargs['color_mapper'] = mapper
 
-        super().__init__(**kwargs)
+        super().__init__(*args, *kwargs)
 
     _args = ('image', 'x', 'y', 'dw', 'dh', 'dilate')
 
@@ -681,6 +725,10 @@ class ImageRGBA(XYGlyph):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     _args = ('image', 'x', 'y', 'dw', 'dh', 'dilate')
 
     image = NumberSpec(default=field("image"), help="""
@@ -731,6 +779,10 @@ class ImageURL(XYGlyph):
     ''' Render images loaded from given URLs.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/ImageURL.py"
 
@@ -811,6 +863,11 @@ class Line(ConnectedXYGlyph, LineGlyph):
         :bokeh-issue:`11498` for more information.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     _args = ('x', 'y')
 
     __example__ = "examples/reference/models/Line.py"
@@ -834,6 +891,10 @@ class MultiLine(LineGlyph):
     values is not a vector of scalars. Rather, it is a "list of lists".
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/MultiLine.py"
 
@@ -862,6 +923,10 @@ class MultiPolygons(LineGlyph, FillGlyph, HatchGlyph):
     selection box will be included.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/MultiPolygons.py"
 
@@ -904,6 +969,10 @@ class Patch(ConnectedXYGlyph, LineGlyph, FillGlyph, HatchGlyph):
     of values only produces one glyph on the Plot.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Patch.py"
 
@@ -950,6 +1019,10 @@ class Patches(LineGlyph, FillGlyph, HatchGlyph):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     __example__ = "examples/reference/models/Patches.py"
 
     _args = ('xs', 'ys')
@@ -989,6 +1062,10 @@ class Quad(LineGlyph, FillGlyph, HatchGlyph):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     __example__ = "examples/reference/models/Quad.py"
 
     _args = ('left', 'right', 'top', 'bottom')
@@ -1025,6 +1102,10 @@ class Quadratic(LineGlyph):
     ''' Render parabolas.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Quadratic.py"
 
@@ -1063,6 +1144,10 @@ class Ray(XYGlyph, LineGlyph):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     __example__ = "examples/reference/models/Ray.py"
 
     _args = ('x', 'y', 'length', 'angle')
@@ -1092,6 +1177,10 @@ class Rect(XYGlyph, LineGlyph, FillGlyph, HatchGlyph):
     ''' Render rectangles.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Rect.py"
 
@@ -1192,6 +1281,10 @@ class Scatter(Marker):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     __example__ = "examples/reference/models/Scatter.py"
 
     _args = ('x', 'y', 'size', 'angle', 'marker')
@@ -1205,6 +1298,10 @@ class Segment(LineGlyph):
     ''' Render segments.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Segment.py"
 
@@ -1241,6 +1338,10 @@ class Step(XYGlyph, LineGlyph):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     __example__ = "examples/reference/models/Step.py"
 
     _args = ('x', 'y')
@@ -1270,6 +1371,10 @@ class Text(XYGlyph, TextGlyph):
     ''' Render text.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Text.py"
 
@@ -1315,6 +1420,10 @@ class VArea(FillGlyph, HatchGlyph):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     __example__ = "examples/reference/models/VArea.py"
 
     _args = ('x', 'y1', 'y2')
@@ -1343,6 +1452,10 @@ class VBar(LineGlyph, FillGlyph, HatchGlyph):
     ''' Render vertical bars, given a center coordinate, width and (top, bottom) coordinates.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/VBar.py"
 
@@ -1380,6 +1493,10 @@ class Wedge(XYGlyph, LineGlyph, FillGlyph, HatchGlyph):
     ''' Render wedges.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Wedge.py"
 

--- a/bokeh/models/graphics.py
+++ b/bokeh/models/graphics.py
@@ -42,10 +42,18 @@ class Marking(Model):
 
     """
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 class Decoration(Model):
     """ Indicates a positioned marker, e.g. at a node of a glyph.
 
     """
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     marking = Instance(Marking, help="""
     The graphical marking associated with this decoration, e.g. an arrow head.

--- a/bokeh/models/graphs.py
+++ b/bokeh/models/graphs.py
@@ -61,6 +61,10 @@ class LayoutProvider(Model):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     @property
     def node_coordinates(self) -> NodeCoordinates:
         return NodeCoordinates(layout=self)
@@ -73,6 +77,10 @@ class StaticLayoutProvider(LayoutProvider):
     '''
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     # TODO: Seq(Any).length == 2
     graph_layout = Dict(Int, Seq(Any), default={}, help="""
@@ -95,6 +103,11 @@ class GraphCoordinates(CoordinateTransform):
     Abstract class for coordinate transform expression obtained from ``LayoutProvider``
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     layout = Instance(LayoutProvider)
 
 class NodeCoordinates(GraphCoordinates):
@@ -103,7 +116,10 @@ class NodeCoordinates(GraphCoordinates):
 
     '''
 
-    pass
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 
 class EdgeCoordinates(GraphCoordinates):
     '''
@@ -111,7 +127,10 @@ class EdgeCoordinates(GraphCoordinates):
 
     '''
 
-    pass
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 
 @abstract
 class GraphHitTestPolicy(Model):
@@ -119,7 +138,10 @@ class GraphHitTestPolicy(Model):
 
     '''
 
-    pass
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 
 class EdgesOnly(GraphHitTestPolicy):
     '''
@@ -128,7 +150,10 @@ class EdgesOnly(GraphHitTestPolicy):
 
     '''
 
-    pass
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 
 class NodesOnly(GraphHitTestPolicy):
     '''
@@ -137,7 +162,10 @@ class NodesOnly(GraphHitTestPolicy):
 
     '''
 
-    pass
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 
 class NodesAndLinkedEdges(GraphHitTestPolicy):
     '''
@@ -148,7 +176,10 @@ class NodesAndLinkedEdges(GraphHitTestPolicy):
 
     '''
 
-    pass
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 
 class EdgesAndLinkedNodes(GraphHitTestPolicy):
     '''
@@ -159,7 +190,10 @@ class EdgesAndLinkedNodes(GraphHitTestPolicy):
 
     '''
 
-    pass
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 
 class NodesAndAdjacentNodes(GraphHitTestPolicy):
     '''
@@ -171,7 +205,10 @@ class NodesAndAdjacentNodes(GraphHitTestPolicy):
 
     '''
 
-    pass
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/bokeh/models/grids.py
+++ b/bokeh/models/grids.py
@@ -55,6 +55,11 @@ class Grid(GuideRenderer):
     given by a supplied ``Ticker``.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     dimension = Int(0, help="""
     Which dimension the Axis Grid lines will intersect. The
     x-axis is dimension 0 (vertical Grid lines) and the y-axis

--- a/bokeh/models/labeling.py
+++ b/bokeh/models/labeling.py
@@ -47,15 +47,30 @@ __all__ = (
 class LabelingPolicy(Model):
     """ Base class for labeling policies. """
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+
 class AllLabels(LabelingPolicy):
     """ Select all labels even if they overlap. """
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 
 class NoOverlap(LabelingPolicy):
     """ Basic labeling policy avoiding label overlap. """
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     min_distance = Int(default=5, help="""
     Minimum distance between labels in pixels.
     """)
+
 
 class CustomLabelingPolicy(LabelingPolicy):
     ''' Select labels based on a user-defined policy function.
@@ -67,6 +82,10 @@ class CustomLabelingPolicy(LabelingPolicy):
         sanitize the user input prior to passing it to Bokeh.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     args = Dict(String, AnyRef, help="""
     A mapping of names to Python objects. In particular, those can be Bokeh's models.

--- a/bokeh/models/layouts.py
+++ b/bokeh/models/layouts.py
@@ -84,6 +84,10 @@ class LayoutDOM(Model):
 
     """
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     disabled = Bool(False, help="""
     Whether the widget will be disabled when rendered.
 
@@ -321,10 +325,20 @@ class HTMLBox(LayoutDOM):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+
 class Spacer(LayoutDOM):
     ''' A container for space used to fill an empty spot in a row or column.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 
 QuickTrackSizing = Either(Enum("auto", "min", "fit", "max"), Int)
 
@@ -345,6 +359,10 @@ ColSizing = Either(
 IntOrString = Either(Int, String) # XXX: work around issue #8166
 
 class GridBox(LayoutDOM):
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     children = List(Either(
         Tuple(Instance(LayoutDOM), Int, Int),
@@ -437,6 +455,10 @@ class Row(Box):
     that is a sequence, or using the ``children`` keyword argument.
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     cols = Either(QuickTrackSizing, Dict(IntOrString, ColSizing), default="auto", help="""
     Describes how the component should maintain its columns' widths.
 
@@ -458,6 +480,10 @@ class Column(Box):
     that is a sequence, or using the ``children`` keyword argument.
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     rows = Either(QuickTrackSizing, Dict(IntOrString, RowSizing), default="auto", help="""
     Describes how the component should maintain its rows' heights.
 
@@ -476,6 +502,10 @@ class Panel(Model):
     ''' A single-widget container with title bar and controls.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     title = String(default="", help="""
     The text title of the panel.
@@ -499,6 +529,10 @@ class Tabs(LayoutDOM):
     ''' A panel widget with navigation tabs.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     __example__ = "sphinx/source/docs/user_guide/examples/interaction_tab_panes.py"
 

--- a/bokeh/models/map_plots.py
+++ b/bokeh/models/map_plots.py
@@ -30,6 +30,7 @@ from ..core.properties import (
     Enum,
     Float,
     Instance,
+    InstanceDefault,
     Int,
     NonNullable,
     Nullable,
@@ -40,7 +41,6 @@ from ..core.validation import error, warning
 from ..core.validation.errors import INCOMPATIBLE_MAP_RANGE_TYPE, MISSING_GOOGLE_API_KEY, REQUIRED_RANGE
 from ..core.validation.warnings import MISSING_RENDERERS
 from ..model import Model
-from ..model.util import InstanceDefault
 from ..models.ranges import Range1d
 from .plots import Plot
 

--- a/bokeh/models/map_plots.py
+++ b/bokeh/models/map_plots.py
@@ -40,6 +40,7 @@ from ..core.validation import error, warning
 from ..core.validation.errors import INCOMPATIBLE_MAP_RANGE_TYPE, MISSING_GOOGLE_API_KEY, REQUIRED_RANGE
 from ..core.validation.warnings import MISSING_RENDERERS
 from ..model import Model
+from ..model.util import InstanceDefault
 from ..models.ranges import Range1d
 from .plots import Plot
 
@@ -64,6 +65,10 @@ class MapOptions(Model):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     lat = NonNullable(Float, help="""
     The latitude where the map should be centered.
     """)
@@ -82,12 +87,12 @@ class MapPlot(Plot):
 
     '''
 
-    def __init__(self, *args, **kw) -> None:
+    def __init__(self, *args, **kwargs) -> None:
         from ..models.ranges import Range1d
         for r in ('x_range', 'y_range'):
-            if r in kw and not isinstance(kw.get(r), Range1d):
-                raise ValueError('Invalid value for %r, MapPlot ranges may only be Range1d, not data ranges' % r)
-        super().__init__(*args, **kw)
+            if r in kwargs and not isinstance(kwargs.get(r), Range1d):
+                raise ValueError(f"Invalid value for {r!r}, MapPlot ranges may only be Range1d, not data ranges")
+        super().__init__(*args, **kwargs)
 
     @error(INCOMPATIBLE_MAP_RANGE_TYPE)
     def _check_incompatible_map_range_type(self):
@@ -101,6 +106,10 @@ class GMapOptions(MapOptions):
     ''' Options for ``GMapPlot`` objects.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     map_type = Enum(MapType, default="roadmap", help="""
     The `map type`_ to use for the ``GMapPlot``.
@@ -156,6 +165,10 @@ class GMapPlot(MapPlot):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     # TODO (bev) map plot might not have these
     @error(REQUIRED_RANGE)
     def _check_required_range(self):
@@ -192,9 +205,9 @@ class GMapPlot(MapPlot):
 
     """)
 
-    x_range = Override(default=lambda: Range1d())
+    x_range = Override(default=InstanceDefault(Range1d))
 
-    y_range = Override(default=lambda: Range1d())
+    y_range = Override(default=InstanceDefault(Range1d))
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/models/mappers.py
+++ b/bokeh/models/mappers.py
@@ -72,13 +72,22 @@ class Mapper(Transform):
     ''' Base class for mappers.
 
     '''
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 
 @abstract
 class ColorMapper(Mapper):
     ''' Base class for color mapper types.
 
     '''
+
+    def __init__(self, *args, **kwargs) -> None:
+        if len(args) == 1:
+            kwargs['palette'] = args[0]
+        super().__init__(**kwargs)
 
     palette = Seq(Color, help="""
     A sequence of colors to use as the target palette for mapping.
@@ -91,16 +100,16 @@ class ColorMapper(Mapper):
     Color to be used if data is NaN or otherwise not mappable.
     """)
 
-    def __init__(self, palette=None, **kwargs) -> None:
-        if palette is not None:
-            kwargs['palette'] = palette
-        super().__init__(**kwargs)
 
 @abstract
 class CategoricalMapper(Mapper):
     ''' Base class for mappers that map categorical factors to other values.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     factors = FactorSeq(help="""
     A sequence of factors / categories that map to the some target range. For
@@ -143,6 +152,10 @@ class CategoricalColorMapper(CategoricalMapper, ColorMapper):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     @warning(PALETTE_LENGTH_FACTORS_MISMATCH)
     def _check_palette_length(self):
         palette = self.palette
@@ -163,6 +176,10 @@ class CategoricalMarkerMapper(CategoricalMapper):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     markers = Seq(MarkerType, help="""
     A sequence of marker types to use as the target for mapping.
     """)
@@ -182,6 +199,10 @@ class CategoricalPatternMapper(CategoricalMapper):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     patterns = Seq(HatchPatternType, help="""
     A sequence of marker types to use as the target for mapping.
     """)
@@ -196,6 +217,10 @@ class ContinuousColorMapper(ColorMapper):
     ''' Base class for continuous color mapper types.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     domain = List(Tuple(Instance("bokeh.models.renderers.GlyphRenderer"), Either(String, List(String))), default=[], help="""
     A collection of glyph renderers to pool data from for establishing data metrics.
@@ -237,6 +262,10 @@ class LinearColorMapper(ContinuousColorMapper):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 class LogColorMapper(ContinuousColorMapper):
     ''' Map numbers in a range [*low*, *high*] into a sequence of colors
     (a palette) on a natural logarithm scale.
@@ -256,11 +285,27 @@ class LogColorMapper(ContinuousColorMapper):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 @abstract
 class ScanningColorMapper(ContinuousColorMapper):
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 
 class EqHistColorMapper(ScanningColorMapper):
+    '''
+
+    '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     bins = Int(default=256*256, help="Number of histogram bins")
 
 #-----------------------------------------------------------------------------

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -48,6 +48,7 @@ from ..core.properties import (
     Float,
     Include,
     Instance,
+    InstanceDefault,
     Int,
     List,
     Null,
@@ -69,7 +70,6 @@ from ..core.validation.errors import (
 )
 from ..core.validation.warnings import MISSING_RENDERERS
 from ..model import Model
-from ..model.util import InstanceDefault
 from ..util.string import nice_join
 from .annotations import Annotation, Legend, Title
 from .axes import Axis

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -69,6 +69,7 @@ from ..core.validation.errors import (
 )
 from ..core.validation.warnings import MISSING_RENDERERS
 from ..model import Model
+from ..model.util import InstanceDefault
 from ..util.string import nice_join
 from .annotations import Annotation, Legend, Title
 from .axes import Axis
@@ -120,6 +121,10 @@ class Plot(LayoutDOM):
     ''' Model representing a plot, containing glyphs, guides, annotations.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     def select(self, *args, **kwargs):
         ''' Query this object and all of its references for objects that
@@ -494,11 +499,11 @@ class Plot(LayoutDOM):
         if msg:
             return msg
 
-    x_range = Instance(Range, default=lambda: DataRange1d(), help="""
+    x_range = Instance(Range, default=InstanceDefault(DataRange1d), help="""
     The (default) data range of the horizontal dimension of the plot.
     """)
 
-    y_range = Instance(Range, default=lambda: DataRange1d(), help="""
+    y_range = Instance(Range, default=InstanceDefault(DataRange1d), help="""
     The (default) data range of the vertical dimension of the plot.
     """)
 
@@ -513,12 +518,12 @@ class Plot(LayoutDOM):
         else:
             raise ValueError(f"Unknown mapper_type: {scale}")
 
-    x_scale = Instance(Scale, default=lambda: LinearScale(), help="""
+    x_scale = Instance(Scale, default=InstanceDefault(LinearScale), help="""
     What kind of scale to use to convert x-coordinates in data space
     into x-coordinates in screen space.
     """)
 
-    y_scale = Instance(Scale, default=lambda: LinearScale(), help="""
+    y_scale = Instance(Scale, default=InstanceDefault(LinearScale), help="""
     What kind of scale to use to convert y-coordinates in data space
     into y-coordinates in screen space.
     """)
@@ -555,7 +560,7 @@ class Plot(LayoutDOM):
     Whether to use HiDPI mode when available.
     """)
 
-    title = Either(Null, Instance(Title), default=lambda: Title(text=""), help="""
+    title = Either(Null, Instance(Title), default=InstanceDefault(Title, text=""), help="""
     A title for the plot. Can be a text string or a Title annotation.
     """).accepts(String, lambda text: Title(text=text))
 
@@ -579,7 +584,7 @@ class Plot(LayoutDOM):
     setup is performed.
     """)
 
-    toolbar = Instance(Toolbar, default=lambda: Toolbar(), help="""
+    toolbar = Instance(Toolbar, default=InstanceDefault(Toolbar), help="""
     The toolbar associated with this plot which holds all the tools. It is
     automatically created with the plot if necessary.
     """)
@@ -810,9 +815,15 @@ class Plot(LayoutDOM):
     """)
 
 class GridPlot(LayoutDOM):
-    """ """
+    """
 
-    toolbar = Instance(ToolbarBase, default=lambda: Toolbar(), help="""
+    """
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+    toolbar = Instance(ToolbarBase, default=InstanceDefault(Toolbar), help="""
     The toolbar associated with this grid plot, which holds all the tools.
     It is automatically created with the plot if necessary.
     """)

--- a/bokeh/models/renderers.py
+++ b/bokeh/models/renderers.py
@@ -34,6 +34,7 @@ from ..core.properties import (
     Enum,
     Float,
     Instance,
+    InstanceDefault,
     Nullable,
     Override,
     String,
@@ -47,7 +48,6 @@ from ..core.validation.errors import (
     NO_SOURCE_FOR_GLYPH,
 )
 from ..model import Model
-from ..model.util import InstanceDefault
 from .canvas import CoordinateMapping
 from .glyphs import (
     Circle,

--- a/bokeh/models/renderers.py
+++ b/bokeh/models/renderers.py
@@ -47,6 +47,7 @@ from ..core.validation.errors import (
     NO_SOURCE_FOR_GLYPH,
 )
 from ..model import Model
+from ..model.util import InstanceDefault
 from .canvas import CoordinateMapping
 from .glyphs import (
     Circle,
@@ -91,6 +92,10 @@ class RendererGroup(Model):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     visible = Bool(default=True, help="""
     Makes all groupped renderers visible or not.
     """)
@@ -100,6 +105,10 @@ class Renderer(Model):
     '''An abstract base class for renderer types.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     level = Enum(RenderLevel, help="""
     Specifies the level in which to paint this renderer.
@@ -128,7 +137,11 @@ class TileRenderer(Renderer):
 
     '''
 
-    tile_source = Instance(TileSource, default=lambda: WMTSTileSource(), help="""
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+    tile_source = Instance(TileSource, default=InstanceDefault(WMTSTileSource), help="""
     Local data source to use when rendering glyphs on the plot.
     """)
 
@@ -152,12 +165,20 @@ class DataRenderer(Renderer):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     level = Override(default="glyph")
 
 class GlyphRenderer(DataRenderer):
     '''
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     @error(CDSVIEW_FILTERS_WITH_CONNECTED)
     def _check_cdsview_filters_with_connected(self):
@@ -196,7 +217,7 @@ class GlyphRenderer(DataRenderer):
     Local data source to use when rendering glyphs on the plot.
     """)
 
-    view = Instance(CDSView, default=lambda: CDSView(), help="""
+    view = Instance(CDSView, default=InstanceDefault(CDSView), help="""
     A view into the data source to use when rendering glyphs. A default view
     of the entire data source is created when a view is not passed in during
     initialization.
@@ -249,6 +270,10 @@ class GlyphRenderer(DataRenderer):
 
         return decoration
 
+
+# TODO: (bev) InstanceDefault woudl be better for these but the property
+# values are also model instances and that is too complicated for now
+
 _DEFAULT_NODE_RENDERER = lambda: GlyphRenderer(
     glyph=Circle(), data_source=ColumnDataSource(data=dict(index=[]))
 )
@@ -261,6 +286,10 @@ class GraphRenderer(DataRenderer):
     '''
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     @error(MALFORMED_GRAPH_SOURCE)
     def _check_malformed_graph_source(self):
@@ -289,12 +318,12 @@ class GraphRenderer(DataRenderer):
     rendered as the graph edges.
     """)
 
-    selection_policy = Instance(GraphHitTestPolicy, default=lambda: NodesOnly(), help="""
+    selection_policy = Instance(GraphHitTestPolicy, default=InstanceDefault(NodesOnly), help="""
     An instance of a ``GraphHitTestPolicy`` that provides the logic for selection
     of graph components.
     """)
 
-    inspection_policy = Instance(GraphHitTestPolicy, default=lambda: NodesOnly(), help="""
+    inspection_policy = Instance(GraphHitTestPolicy, default=InstanceDefault(NodesOnly), help="""
     An instance of a ``GraphHitTestPolicy`` that provides the logic for inspection
     of graph components.
     """)
@@ -305,6 +334,10 @@ class GuideRenderer(Renderer):
     not generally useful to instantiate on its own.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     level = Override(default="guide")
 

--- a/bokeh/models/scales.py
+++ b/bokeh/models/scales.py
@@ -65,33 +65,50 @@ class Scale(Transform):
         }
 
     '''
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 
 class ContinuousScale(Scale):
     ''' Represent a scale transformation between continuous ranges.
 
     '''
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 
 class LinearScale(ContinuousScale):
     ''' Represent a linear scale transformation between continuous ranges.
 
     '''
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 class LogScale(ContinuousScale):
     ''' Represent a log scale transformation between continuous ranges.
 
     '''
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 class CategoricalScale(Scale):
     ''' Represent a scale transformation between a categorical source range and
     continuous target range.
 
     '''
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/models/selections.py
+++ b/bokeh/models/selections.py
@@ -54,6 +54,10 @@ class Selection(Model):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     indices = Seq(Int, default=[], help="""
     The "scatter" level indices included in a selection. For example, for a
     selection on a ``Circle`` glyph, this list records the indices of which
@@ -91,7 +95,10 @@ class SelectionPolicy(Model):
 
     '''
 
-    pass
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 
 class IntersectRenderers(SelectionPolicy):
     '''
@@ -101,7 +108,10 @@ class IntersectRenderers(SelectionPolicy):
 
     '''
 
-    pass
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 
 class UnionRenderers(SelectionPolicy):
     '''
@@ -111,7 +121,10 @@ class UnionRenderers(SelectionPolicy):
 
     '''
 
-    pass
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -52,6 +52,7 @@ from ..core.properties import (
     String,
 )
 from ..model import Model
+from ..model.util import InstanceDefault
 from ..util.dependencies import import_optional
 from ..util.deprecation import deprecated
 from ..util.serialization import convert_datetime_array
@@ -99,7 +100,11 @@ class DataSource(Model):
 
     '''
 
-    selected = Readonly(Instance(Selection), default=lambda: Selection(), help="""
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+    selected = Readonly(Instance(Selection), default=InstanceDefault(Selection), help="""
     An instance of a ``Selection`` that indicates selected indices on this ``DataSource``.
     This is a read-only property. You may only change the attributes of this object
     to change the selection (e.g., ``selected.indices``).
@@ -112,7 +117,11 @@ class ColumnarDataSource(DataSource):
 
     '''
 
-    selection_policy = Instance(SelectionPolicy, default=lambda: UnionRenderers(), help="""
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+    selection_policy = Instance(SelectionPolicy, default=InstanceDefault(UnionRenderers), help="""
     An instance of a ``SelectionPolicy`` that determines how selections are set.
     """)
 
@@ -742,6 +751,10 @@ class GeoJSONDataSource(ColumnarDataSource):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     geojson = NonNullable(JSON, help="""
     GeoJSON that contains features for plotting. Currently
     ``GeoJSONDataSource`` can only process a ``FeatureCollection`` or
@@ -757,6 +770,10 @@ class WebDataSource(ColumnDataSource):
         This base class is typically not useful to instantiate on its own.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     adapter = Nullable(Instance(CustomJS), help="""
     A JavaScript callback to adapt raw JSON responses to Bokeh ``ColumnDataSource``
@@ -790,6 +807,10 @@ class ServerSentDataSource(WebDataSource):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 class AjaxDataSource(WebDataSource):
     ''' A data source that can populate columns by making Ajax calls to REST
     endpoints.
@@ -820,6 +841,10 @@ class AjaxDataSource(WebDataSource):
     A full example can be seen at :bokeh-tree:`examples/howto/ajax_source.py`
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     polling_interval = Nullable(Int, help="""
     A polling interval (in milliseconds) for updating data source.

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -41,6 +41,7 @@ from ..core.properties import (
     Dict,
     Enum,
     Instance,
+    InstanceDefault,
     Int,
     List,
     NonNullable,
@@ -52,7 +53,6 @@ from ..core.properties import (
     String,
 )
 from ..model import Model
-from ..model.util import InstanceDefault
 from ..util.dependencies import import_optional
 from ..util.deprecation import deprecated
 from ..util.serialization import convert_datetime_array

--- a/bokeh/models/text.py
+++ b/bokeh/models/text.py
@@ -66,28 +66,41 @@ class BaseText(Model):
 
 @abstract
 class MathText(BaseText):
+    """ Base class for renderers of mathematical content.
+
     """
-    Base class for renderers of mathematical content.
-    """
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 class Ascii(MathText):
-    """
-    Render mathematical content using `AsciiMath <http://asciimath.org/>`_
+    """ Render mathematical content using `AsciiMath <http://asciimath.org/>`_
     notation.
+
     """
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 class MathML(MathText):
-    """
-    Render mathematical content using `MathML <https://www.w3.org/Math/>`_
-    notation. See :ref:`userguide_styling_math` in the |user guide| for more
-    information.
+    """ Render mathematical content using `MathML <https://www.w3.org/Math/>`_
+    notation.
+
+    See :ref:`userguide_styling_math` in the |user guide| for more information.
+
     """
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 class TeX(MathText):
-    """
-    Render mathematical content using `LaTeX <https://www.latex-project.org/>`_
-    notation. See :ref:`userguide_styling_math` in the |user guide| for more
-    information.
+    """ Render mathematical content using `LaTeX <https://www.latex-project.org/>`_
+    notation.
+
+    See :ref:`userguide_styling_math` in the |user guide| for more information.
 
     .. note::
         Bokeh uses `MathJax <https://www.mathjax.org>`_ to render text
@@ -96,7 +109,12 @@ class TeX(MathText):
         MathJax only supports math-mode macros (no text-mode macros). You
         can see more about differences between standard TeX/LaTeX and MathJax
         here: https://docs.mathjax.org/en/latest/input/tex/differences.html
+
     """
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     macros = Dict(String, Either(String, Tuple(String, Int)), help="""
     User defined TeX macros.
@@ -118,9 +136,13 @@ class TeX(MathText):
     """)
 
 class PlainText(BaseText):
+    """ Represents plain text in contexts where text parsing is allowed.
+
     """
-    Represents plain text in contexts where text parsing is allowed.
-    """
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/models/textures.py
+++ b/bokeh/models/textures.py
@@ -46,6 +46,10 @@ class Texture(Model):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     repetition = Enum(TextureRepetition, default="repeat", help="""
 
     """)
@@ -54,6 +58,10 @@ class CanvasTexture(Texture):
     '''
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     code = NonNullable(String, help="""
     A snippet of JavaScript code to execute in the browser.
@@ -64,6 +72,10 @@ class ImageURLTexture(Texture):
     '''
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     url = NonNullable(String, help="""
     A URL to a drawable resource like image, video, etc.

--- a/bokeh/models/tickers.py
+++ b/bokeh/models/tickers.py
@@ -73,11 +73,19 @@ class Ticker(Model):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 @abstract
 class ContinuousTicker(Ticker):
     ''' A base class for non-categorical ticker types.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     num_minor_ticks = Int(5, help="""
     The number of minor tick positions to generate between
@@ -102,6 +110,10 @@ class FixedTicker(ContinuousTicker):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     ticks = Seq(Float, default=[], help="""
     List of major tick locations.
     """)
@@ -120,6 +132,10 @@ class AdaptiveTicker(ContinuousTicker):
         ..., 0.1, 0.2, 0.5, 1, 2, 5, 10, 20, 50, 100, ...
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     base = Float(10.0, help="""
     The multiplier to use for scaling mantissas.
@@ -149,6 +165,10 @@ class CompositeTicker(ContinuousTicker):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     tickers = Seq(Instance(Ticker), default=[], help="""
     A list of Ticker objects to combine at different scales in order
     to generate tick values. The supplied tickers should be in order.
@@ -164,6 +184,10 @@ class SingleIntervalTicker(ContinuousTicker):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     interval = NonNullable(Float, help="""
     The interval between adjacent ticks.
     """)
@@ -172,6 +196,11 @@ class DaysTicker(SingleIntervalTicker):
     ''' Generate ticks spaced apart by specific, even multiples of days.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     days = Seq(Int, default=[], help="""
     The intervals of days to use.
     """)
@@ -182,6 +211,11 @@ class MonthsTicker(SingleIntervalTicker):
     ''' Generate ticks spaced apart by specific, even multiples of months.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     months = Seq(Int, default=[], help="""
     The intervals of months to use.
     """)
@@ -191,6 +225,10 @@ class YearsTicker(SingleIntervalTicker):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 class BasicTicker(AdaptiveTicker):
     ''' Generate ticks on a linear scale.
 
@@ -199,10 +237,19 @@ class BasicTicker(AdaptiveTicker):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 class LogTicker(AdaptiveTicker):
     ''' Generate ticks on a log scale.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     mantissas = Override(default=[1, 5])
 
 
@@ -210,6 +257,10 @@ class MercatorTicker(BasicTicker):
     ''' Generate nice lat/lon ticks form underlying WebMercator coordinates.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     dimension = Nullable(Enum(LatLon), help="""
     Specify whether to generate ticks for Latitude or Longitude.
@@ -238,6 +289,10 @@ class CategoricalTicker(Ticker):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 ONE_MILLI = 1.0
 ONE_SECOND = 1000.0
 ONE_MINUTE = 60.0 * ONE_SECOND
@@ -251,8 +306,13 @@ class DatetimeTicker(CompositeTicker):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     num_minor_ticks = Override(default=0)
 
+    # TODO: (bev) InstanceDefault for this, someday
     tickers = Override(default=lambda: [
         AdaptiveTicker(
             mantissas=[1, 2, 5],
@@ -289,7 +349,13 @@ class DatetimeTicker(CompositeTicker):
     ])
 
 class BinnedTicker(Ticker):
-    """Ticker that aligns ticks exactly at bin boundaries of a scanning color mapper. """
+    """ Ticker that aligns ticks exactly at bin boundaries of a scanning color mapper.
+
+    """
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     mapper = Instance(ScanningColorMapper, help="""
     A scanning color mapper (e.g. ``EqHistColorMapper``) to use.

--- a/bokeh/models/tiles.py
+++ b/bokeh/models/tiles.py
@@ -58,6 +58,10 @@ class TileSource(Model):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     _args = ('url', 'tile_size', 'min_zoom', 'max_zoom', 'extra_url_vars')
 
     url = String("", help="""
@@ -105,6 +109,10 @@ class MercatorTileSource(TileSource):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     _args = ('url', 'tile_size', 'min_zoom', 'max_zoom', 'x_origin_offset', 'y_origin_offset', 'extra_url_vars', 'initial_resolution')
 
     x_origin_offset = Override(default=20037508.34)
@@ -135,7 +143,10 @@ class TMSTileSource(MercatorTileSource):
     custom tile sets, including non-spatial datasets.
 
     '''
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 class WMTSTileSource(MercatorTileSource):
     ''' Behaves much like ``TMSTileSource`` but has its tile-origin in the
@@ -146,7 +157,10 @@ class WMTSTileSource(MercatorTileSource):
     service which use the WMTS specification e.g. ``http://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png``.
 
     '''
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 class QUADKEYTileSource(MercatorTileSource):
     ''' Has the same tile origin as the ``WMTSTileSource`` but requests tiles using
@@ -154,7 +168,10 @@ class QUADKEYTileSource(MercatorTileSource):
     ``http://your.quadkey.tile.host/{Q}.png``
 
     '''
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 class BBoxTileSource(MercatorTileSource):
     ''' Has the same default tile origin as the ``WMTSTileSource`` but requested
@@ -162,6 +179,10 @@ class BBoxTileSource(MercatorTileSource):
     ``http://your.custom.tile.service?bbox={XMIN},{YMIN},{XMAX},{YMAX}``.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     use_latlon = Bool(default=False, help="""
     Flag which indicates option to output ``{XMIN}``, ``{YMIN}``, ``{XMAX}``, ``{YMAX}`` in meters or latitude and longitude.

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -94,6 +94,7 @@ from ..core.validation.errors import (
     NO_RANGE_TOOL_RANGES,
 )
 from ..model import Model
+from ..model.util import InstanceDefault
 from ..util.string import nice_join
 from .annotations import BoxAnnotation, PolyAnnotation
 from .callbacks import Callback
@@ -165,6 +166,10 @@ class Tool(Model):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     icon = Nullable(Either(Enum(ToolIcon), Regex(r"^\."), Image), help="""
     An icon to display in the toolbar.
 
@@ -204,41 +209,60 @@ class ActionTool(Tool):
     ''' A base class for tools that are buttons in the toolbar.
 
     '''
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 @abstract
 class GestureTool(Tool):
     ''' A base class for tools that respond to drag events.
 
     '''
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 @abstract
 class Drag(GestureTool):
     ''' A base class for tools that respond to drag events.
 
     '''
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 @abstract
 class Scroll(GestureTool):
     ''' A base class for tools that respond to scroll events.
 
     '''
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 @abstract
 class Tap(GestureTool):
     ''' A base class for tools that respond to tap/click events.
 
     '''
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 @abstract
 class SelectTool(GestureTool):
     ''' A base class for tools that perform "selections", e.g. ``BoxSelectTool``.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     renderers = Either(Auto, List(Instance(DataRenderer)), default="auto", help="""
     An explicit list of renderers to hit test against. If unset, defaults to
@@ -256,6 +280,11 @@ class InspectTool(GestureTool):
     ''' A base class for tools that perform "inspections", e.g. ``HoverTool``.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     toggleable = Bool(True, help="""
     Whether an on/off toggle button should appear in the toolbar for this
     inspection tool. If ``False``, the viewers of a plot will not be able to
@@ -267,6 +296,10 @@ class ToolbarBase(Model):
     ''' A base class for different toolbars.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     logo = Nullable(Enum("normal", "grey"), default="normal", help="""
     What version of the Bokeh logo to display on the toolbar. If
@@ -286,6 +319,10 @@ class Toolbar(ToolbarBase):
     ''' Collect tools to display for a single plot.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     active_drag: tp.Union[Literal["auto"], Drag, None] = Either(Null, Auto, Instance(Drag), default="auto", help="""
     Specify a drag tool to be active when the plot is displayed.
@@ -321,11 +358,19 @@ class ProxyToolbar(ToolbarBase):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 class ToolbarBox(LayoutDOM):
     ''' A layoutable toolbar that can accept the tools of multiple plots, and
     can merge the tools into a single button for convenience.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     toolbar = Instance(ToolbarBase, help="""
     A toolbar associated with a plot which holds all its tools.
@@ -348,6 +393,10 @@ class PanTool(Drag):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     dimensions = Enum(Dimensions, default="both", help="""
     Which dimensions the pan tool is constrained to act in. By default
     the pan tool will pan in any dimension, but can be configured to only
@@ -355,7 +404,7 @@ class PanTool(Drag):
     height of the plot.
     """)
 
-DEFAULT_RANGE_OVERLAY = lambda: BoxAnnotation(
+DEFAULT_RANGE_OVERLAY = InstanceDefault(BoxAnnotation,
     syncable=False,
     level="overlay",
     fill_color="lightgrey",
@@ -382,6 +431,10 @@ class RangeTool(Drag):
         :height: 24px
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     x_range = Nullable(Instance(Range1d), help="""
     A range synchronized to the x-dimension of the overlay. If None, the overlay
@@ -433,6 +486,10 @@ class WheelPanTool(Scroll):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     dimension = Enum(Dimension, default="width", help="""
     Which dimension the wheel pan tool is constrained to act in. By default the
     wheel pan tool will pan the plot along the x-axis.
@@ -453,6 +510,10 @@ class WheelZoomTool(Scroll):
         :height: 24px
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     dimensions = Enum(Dimensions, default="both", help="""
     Which dimensions the wheel zoom tool is constrained to act in. By default
@@ -493,6 +554,10 @@ class CustomAction(ActionTool):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     description = Override(default="Perform a Custom Action")
 
     callback = Nullable(Instance(Callback), help="""
@@ -514,6 +579,10 @@ class SaveTool(ActionTool):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     filename = Nullable(String, help="""
     Optional string specifying the filename of the saved image (extension not
     needed). If a filename is not provided or set to None, the user is prompted
@@ -532,7 +601,9 @@ class ResetTool(ActionTool):
 
     '''
 
-    pass
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 class TapTool(Tap, SelectTool):
     ''' *toolbar icon*: |tap_icon|
@@ -553,6 +624,10 @@ class TapTool(Tap, SelectTool):
         previous selection that might exist.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     behavior = Enum("select", "inspect", default="select", help="""
     This tool can be configured to either make selections or inspections
@@ -613,6 +688,10 @@ class CrosshairTool(InspectTool):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     dimensions = Enum(Dimensions, default="both", help="""
     Which dimensions the crosshair tool is to track. By default, both vertical
     and horizontal lines will be drawn. If only "width" is supplied, only a
@@ -632,7 +711,7 @@ class CrosshairTool(InspectTool):
     Stroke width in units of pixels.
     """)
 
-DEFAULT_BOX_OVERLAY = lambda: BoxAnnotation(
+DEFAULT_BOX_OVERLAY = InstanceDefault(BoxAnnotation,
     syncable=False,
     level="overlay",
     top_units="screen",
@@ -663,6 +742,10 @@ class BoxZoomTool(Drag):
         this tool to a ``GMapPlot`` will have no effect.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     dimensions = Enum(Dimensions, default="both", help="""
     Which dimensions the zoom box is to be free in. By default, users may
@@ -702,6 +785,11 @@ class ZoomInTool(ActionTool):
         :height: 24px
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     # TODO ZoomInTool dimensions should probably be constrained to be the same as ZoomOutTool
     dimensions = Enum(Dimensions, default="both", help="""
     Which dimensions the zoom-in tool is constrained to act in. By default the
@@ -724,6 +812,11 @@ class ZoomOutTool(ActionTool):
         :height: 24px
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     dimensions = Enum(Dimensions, default="both", help="""
     Which dimensions the zoom-out tool is constrained to act in. By default the
     zoom-out tool will zoom in any dimension, but can be configured to only
@@ -758,6 +851,10 @@ class BoxSelectTool(Drag, SelectTool):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     select_every_mousemove = Bool(False, help="""
     Whether a selection computation should happen on every mouse event, or only
     once, when the selection region is completed. Default: False
@@ -781,7 +878,7 @@ class BoxSelectTool(Drag, SelectTool):
     (top-left or bottom-right depending on direction) or the center of the box.
     """)
 
-DEFAULT_POLY_OVERLAY = lambda: PolyAnnotation(
+DEFAULT_POLY_OVERLAY = InstanceDefault(PolyAnnotation,
     syncable=False,
     level="overlay",
     xs_units="screen",
@@ -816,6 +913,10 @@ class LassoSelectTool(Drag, SelectTool):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     select_every_mousemove = Bool(True, help="""
     Whether a selection computation should happen on every mouse event, or only
     once, when the selection region is completed.
@@ -847,6 +948,10 @@ class PolySelectTool(Tap, SelectTool):
         :height: 24px
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     overlay = Instance(PolyAnnotation, default=DEFAULT_POLY_OVERLAY, help="""
     A shaded annotation drawn to indicate the selection region.
@@ -903,6 +1008,10 @@ class CustomJSHover(Model):
         sanitize the user input prior to passing to Bokeh.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     args = Dict(String, AnyRef, help="""
     A mapping of names to Bokeh plot objects. These objects are made available
@@ -1005,6 +1114,10 @@ class HoverTool(InspectTool):
         :height: 24px
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     renderers = Either(Auto, List(Instance(DataRenderer)), default="auto", help="""
     An explicit list of renderers to hit test against. If unset, defaults to
@@ -1175,6 +1288,10 @@ class HelpTool(ActionTool):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     description = Override(default=DEFAULT_HELP_TIP)
 
     redirect = String(default=DEFAULT_HELP_URL, help="""
@@ -1191,6 +1308,10 @@ class UndoTool(ActionTool):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 class RedoTool(ActionTool):
     ''' *toolbar icon*: |redo_icon|
 
@@ -1201,11 +1322,19 @@ class RedoTool(ActionTool):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 @abstract
 class EditTool(GestureTool):
     ''' A base class for all interactive draw tool types.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     empty_value = NonNullable(Either(Bool, Int, Float, Date, Datetime, Color, String), help="""
     Defines the value to insert on non-coordinate columns when a new
@@ -1223,6 +1352,10 @@ class EditTool(GestureTool):
 @abstract
 class PolyTool(EditTool):
     ''' A base class for polygon draw/edit tools. '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     vertex_renderer = Nullable(Instance(GlyphRenderer), help="""
     The renderer used to render the vertices of a selected line or polygon.
@@ -1274,6 +1407,10 @@ class BoxEditTool(EditTool, Drag, Tap):
     .. |box_edit_icon| image:: /_images/icons/BoxEdit.png
         :height: 24px
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     dimensions = Enum(Dimensions, default="both", help="""
     Which dimensions the box drawing is to be free in. By default, users may
@@ -1335,6 +1472,10 @@ class PointDrawTool(EditTool, Drag, Tap):
         :height: 24px
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     add = Bool(default=True, help="""
     Enables adding of new points on tap events.
     """)
@@ -1393,6 +1534,10 @@ class PolyDrawTool(PolyTool, Drag, Tap):
         :height: 24px
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     drag = Bool(default=True, help="""
     Enables dragging of existing patches and multi-lines on pan events.
     """)
@@ -1435,6 +1580,10 @@ class FreehandDrawTool(EditTool, Drag, Tap):
     .. |freehand_draw_icon| image:: /_images/icons/FreehandDraw.png
         :height: 24px
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     num_objects = Int(default=0, help="""
     Defines a limit on the number of patches or multi-lines that can be drawn.
@@ -1484,6 +1633,10 @@ class PolyEditTool(PolyTool, Drag, Tap):
         :height: 24px
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     @error(INCOMPATIBLE_POLY_EDIT_RENDERER)
     def _check_compatible_renderers(self):
         incompatible_renderers = []
@@ -1518,7 +1671,11 @@ class LineEditTool(EditTool, Drag, Tap):
 
     .. |line_edit_icon| image:: /_images/icons/LineEdit.png
         :height: 24px
-     '''
+    '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     intersection_renderer = Instance(GlyphRenderer, help="""
     The renderer used to render the intersections of a selected line

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -70,6 +70,7 @@ from ..core.properties import (
     Float,
     Image,
     Instance,
+    InstanceDefault,
     Int,
     List,
     NonNullable,
@@ -94,7 +95,6 @@ from ..core.validation.errors import (
     NO_RANGE_TOOL_RANGES,
 )
 from ..model import Model
-from ..model.util import InstanceDefault
 from ..util.string import nice_join
 from .annotations import BoxAnnotation, PolyAnnotation
 from .callbacks import Callback

--- a/bokeh/models/transforms.py
+++ b/bokeh/models/transforms.py
@@ -75,7 +75,10 @@ class Transform(Model):
         }
 
     '''
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 
 class CustomJSTransform(Transform):
@@ -88,6 +91,10 @@ class CustomJSTransform(Transform):
         sanitize the user input prior to passing to Bokeh.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     args = Dict(String, AnyRef, help="""
     A mapping of names to Python objects. In particular those can be bokeh's models.
@@ -139,6 +146,10 @@ class Dodge(Transform):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     value = Float(default=0, help="""
     The amount to dodge the input data.
     """)
@@ -153,6 +164,10 @@ class Jitter(Transform):
     ''' Apply either a uniform or normally sampled random jitter to data.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     mean = Float(default=0, help="""
     The central value for the random sample
@@ -203,6 +218,11 @@ class Interpolator(Transform):
     interpolation.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     x = NonNullable(Either(String, Seq(Float)), help="""
     Independent coordinate denoting the location of a point.
     """)
@@ -220,17 +240,16 @@ class Interpolator(Transform):
     If this is set to False, it will return the most value of the closest point.
     """)
 
-    # Define an initialization routine to do some cross checking of input values
-    def __init__(self, **kwargs) -> None:
-        super().__init__(**kwargs)
-
 
 class LinearInterpolator(Interpolator):
     ''' Compute a linear interpolation between the control points provided through
     the ``x``, ``y``, and ``data`` parameters.
 
     '''
-    pass
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 
 class StepInterpolator(Interpolator):
@@ -238,6 +257,10 @@ class StepInterpolator(Interpolator):
     the ``x``, ``y``, and ``data`` parameters.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     mode = Enum(StepMode, default="after", help="""
     Adjust the behavior of the returned value in relation to the control points.  The parameter can assume one of three values:

--- a/bokeh/models/ui.py
+++ b/bokeh/models/ui.py
@@ -44,6 +44,10 @@ __all__ = (
 class Inspector(HTMLBox, Qualified):
     """ A diagnostic and inspection tool for documents, models, properties, etc. """
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------

--- a/bokeh/models/widgets/buttons.py
+++ b/bokeh/models/widgets/buttons.py
@@ -69,6 +69,10 @@ class ButtonLike(HasProps):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     button_type = Enum(ButtonType, help="""
     A style for the button, signifying it's role.
     """)
@@ -78,6 +82,10 @@ class AbstractButton(Widget, ButtonLike):
     ''' A base class that defines common properties for all button types.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     label = String("Button", help="""
     The text label for the button to display.
@@ -95,6 +103,10 @@ class Button(AbstractButton):
     ''' A click button.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     label = Override(default="Button")
 
@@ -120,6 +132,10 @@ class Toggle(AbstractButton):
     ''' A two-state toggle button.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     label = Override(default="Toggle")
 
@@ -148,6 +164,10 @@ class Dropdown(AbstractButton):
     ''' A dropdown button.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     label = Override(default="Dropdown")
 

--- a/bokeh/models/widgets/groups.py
+++ b/bokeh/models/widgets/groups.py
@@ -57,6 +57,10 @@ class AbstractGroup(Widget):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     labels = List(String, help="""
     List of text labels contained in this group.
     """)
@@ -66,6 +70,10 @@ class ButtonGroup(AbstractGroup, ButtonLike):
     ''' Abstract base class for groups with items rendered as buttons.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     orientation = Enum("horizontal", "vertical", help="""
     Orient the button group either horizontally (default) or vertically.
@@ -77,6 +85,10 @@ class Group(AbstractGroup):
     boxes.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     inline = Bool(False, help="""
     Should items be arrange vertically (``False``) or horizontally
@@ -92,6 +104,10 @@ class CheckboxGroup(Group):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     active = List(Int, help="""
     The list of indices of selected check boxes.
     """)
@@ -100,6 +116,10 @@ class RadioGroup(Group):
     ''' A group of radio boxes.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     active = Nullable(Int, help="""
     The index of the selected radio box, or ``None`` if nothing is selected.
@@ -110,6 +130,10 @@ class CheckboxButtonGroup(ButtonGroup):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     active = List(Int, help="""
     The list of indices of selected check boxes.
     """)
@@ -118,6 +142,10 @@ class RadioButtonGroup(ButtonGroup):
     ''' A group of radio boxes rendered as toggle buttons.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     active = Nullable(Int, help="""
     The index of the selected radio box, or ``None`` if nothing is

--- a/bokeh/models/widgets/icons.py
+++ b/bokeh/models/widgets/icons.py
@@ -46,6 +46,10 @@ class AbstractIcon(Model):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------

--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -78,6 +78,10 @@ class InputWidget(Widget):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     title = String(default="", help="""
     Widget's label.
     """)
@@ -102,6 +106,10 @@ class FileInput(Widget):
     ''' Present a file-chooser dialog to users and return the contents of the
     selected files.
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     value = Readonly(Either(String, List(String)), default="", help='''
     The base64-enconded contents of the file or files that were loaded.
@@ -184,6 +192,10 @@ class NumericInput(InputWidget):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     value = Either(Null, Float, Int, help="""
     Initial or entered value.
 
@@ -219,11 +231,11 @@ class Spinner(NumericInput):
 
     '''
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, *args, **kwargs) -> None:
         if "value" in kwargs and "value_throttled" not in kwargs:
             kwargs["value_throttled"] = kwargs["value"]
 
-        super().__init__(**kwargs)
+        super().__init__(*args, **kwargs)
 
     value_throttled = Readonly(Either(Null, Float, Int), help="""
     value reported at the end of interactions
@@ -248,6 +260,10 @@ class Spinner(NumericInput):
 class Switch(Widget):
     """ A checkbox-like widget. """
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     active = Bool(default=False, help="""
     The state of the widget.
     """)
@@ -258,6 +274,10 @@ class TextLikeInput(InputWidget):
     ''' Base class for text-like input widgets.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     value = String(default="", help="""
     Initial or entered text value.
@@ -285,11 +305,19 @@ class TextInput(TextLikeInput):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 
 class TextAreaInput(TextLikeInput):
     ''' Multi-line input widget.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     cols = Int(default=20, help="""
     Specifies the width of the text area (in average character width). Default: 20
@@ -313,11 +341,19 @@ class PasswordInput(TextInput):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 
 class AutocompleteInput(TextInput):
     ''' Single-line input widget with auto-completion.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     completions = List(String, help="""
     A list of completion strings. This will be used to guide the
@@ -339,6 +375,11 @@ class Select(InputWidget):
     ''' Single-select widget.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     options = Either(List(Either(String, Tuple(String, String))),
         Dict(String, List(Either(String, Tuple(String, String)))), help="""
     Available selection options. Options may be provided either as a list of
@@ -357,6 +398,10 @@ class MultiSelect(InputWidget):
     ''' Multi-select widget.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     options = List(Either(String, Tuple(String, String)), help="""
     Available selection options. Options may be provided either as a list of
@@ -380,6 +425,10 @@ class MultiChoice(InputWidget):
     ''' MultiChoice widget.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     options = List(Either(String, Tuple(String, String)), help="""
     Available selection options. Options may be provided either as a list of
@@ -421,6 +470,10 @@ class DatePicker(InputWidget):
     ''' Calendar-based date picker widget.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     value = Date(help="""
     The initial or picked date.
@@ -466,6 +519,10 @@ class ColorPicker(InputWidget):
         as a simple text input).
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     color = ColorHex(default='#000000', help="""
     The initial color of the picked color (named or hexadecimal)

--- a/bokeh/models/widgets/markups.py
+++ b/bokeh/models/widgets/markups.py
@@ -58,6 +58,10 @@ class Markup(Widget):
     .. _`TeX and LaTeX input`: https://docs.mathjax.org/en/latest/basic/mathematics.html#tex-and-latex-input
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     text = String(default="", help="""
     The text or HTML contents of the widget.
 
@@ -86,6 +90,10 @@ class Paragraph(Markup):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     __example__ = "sphinx/source/docs/user_guide/examples/interaction_paragraph.py"
 
 class Div(Markup):
@@ -93,6 +101,10 @@ class Div(Markup):
 
     This Bokeh model corresponds to an HTML ``<div>`` element.
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     __example__ = "sphinx/source/docs/user_guide/examples/interaction_div.py"
 
@@ -107,6 +119,10 @@ class PreText(Paragraph):
     This Bokeh model corresponds to an HTML ``<pre>`` element.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     __example__ = "sphinx/source/docs/user_guide/examples/interaction_pretext.py"
 

--- a/bokeh/models/widgets/sliders.py
+++ b/bokeh/models/widgets/sliders.py
@@ -68,7 +68,7 @@ __all__ = (
 class AbstractSlider(Widget):
     """ """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, *args, **kwargs) -> None:
         if 'start' in kwargs and 'end' in kwargs:
             if kwargs['start'] == kwargs['end']:
                 raise ValueError("Slider 'start' and 'end' cannot be equal.")
@@ -76,7 +76,7 @@ class AbstractSlider(Widget):
         if "value" in kwargs and "value_throttled" not in kwargs:
             kwargs["value_throttled"] = kwargs["value"]
 
-        super().__init__(**kwargs)
+        super().__init__(*args, **kwargs)
 
     orientation = Enum("horizontal", "vertical", help="""
     Orient the slider either horizontally (default) or vertically.
@@ -115,6 +115,10 @@ class AbstractSlider(Widget):
 class Slider(AbstractSlider):
     """ Slider-based number selection widget. """
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     start = NonNullable(Float, help="""
     The minimum allowable value.
     """)
@@ -140,6 +144,10 @@ class Slider(AbstractSlider):
 class RangeSlider(AbstractSlider):
     """ Range-slider based number range selection widget. """
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     value = NonNullable(Tuple(Float, Float), help="""
     Initial or selected range.
     """)
@@ -164,6 +172,10 @@ class RangeSlider(AbstractSlider):
 
 class DateSlider(AbstractSlider):
     """ Slider-based date selection widget. """
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     @property
     def value_as_datetime(self) -> datetime | None:
@@ -218,6 +230,10 @@ class DateSlider(AbstractSlider):
 
 class DateRangeSlider(AbstractSlider):
     """ Slider-based date range selection widget. """
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     @property
     def value_as_datetime(self) -> tp.Tuple[datetime, datetime] | None:

--- a/bokeh/models/widgets/tables.py
+++ b/bokeh/models/widgets/tables.py
@@ -37,6 +37,7 @@ from ...core.properties import (
     Enum,
     Float,
     Instance,
+    InstanceDefault,
     Int,
     List,
     NonNullable,
@@ -45,7 +46,6 @@ from ...core.properties import (
     String,
 )
 from ...model import Model
-from ...model.util import InstanceDefault
 from ..sources import CDSView, ColumnDataSource, DataSource
 from .widget import Widget
 

--- a/bokeh/models/widgets/tables.py
+++ b/bokeh/models/widgets/tables.py
@@ -45,6 +45,7 @@ from ...core.properties import (
     String,
 )
 from ...model import Model
+from ...model.util import InstanceDefault
 from ..sources import CDSView, ColumnDataSource, DataSource
 from .widget import Widget
 
@@ -91,17 +92,30 @@ class CellFormatter(Model):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 @abstract
 class CellEditor(Model):
     ''' Abstract base class for data table's cell editors.
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 @abstract
 class RowAggregator(Model):
     ''' Abstract base class for data cube's row formatters.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     field_ = String('', help="""
     Refers to the table column being aggregated
     """)
@@ -114,6 +128,10 @@ class StringFormatter(CellFormatter):
     ''' Basic string cell formatter.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     font_style = Enum(FontStyle, default="normal", help="""
     An optional text font style, e.g. bold, italic.
@@ -131,6 +149,10 @@ class ScientificFormatter(StringFormatter):
     ''' Display numeric values from continuous ranges as "basic numbers",
     using scientific notation when appropriate by default.
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     nan_format = Nullable(String, help="""
     Formatting to apply to NaN and None values (falls back to scientific formatting if not set).
@@ -154,6 +176,10 @@ class NumberFormatter(StringFormatter):
     ''' Number cell formatter.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     format = String("0,0", help="""
     The number format, as defined in the following tables:
@@ -248,6 +274,10 @@ class BooleanFormatter(CellFormatter):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     icon = Enum('check', 'check-circle', 'check-circle-o', 'check-square', 'check-square-o', help="""
     The icon visualizing the check mark.
     """)
@@ -256,6 +286,10 @@ class DateFormatter(StringFormatter):
     ''' Date cell formatter.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     format = Either(Enum(DateFormat), String, default='ISO-8601', help="""
     The date format can be any standard  `strftime`_ format string, as well
@@ -495,6 +529,11 @@ class HTMLTemplateFormatter(CellFormatter):
         )
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     template = String('<%= value %>', help="""
     Template string to be used by Underscore's template method.
     """)
@@ -503,6 +542,10 @@ class StringEditor(CellEditor):
     ''' Basic string cell editor with auto-completion.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     completions = List(String, help="""
     An optional list of completion strings.
@@ -513,10 +556,18 @@ class TextEditor(CellEditor):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 class SelectEditor(CellEditor):
     ''' Select cell editor.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     options = List(String, help="""
     The list of options to select from.
@@ -527,15 +578,27 @@ class PercentEditor(CellEditor):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 class CheckboxEditor(CellEditor):
     ''' Boolean value cell editor.
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 class IntEditor(CellEditor):
     ''' Spinner-based integer cell editor.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     step = Int(1, help="""
     The major step value.
@@ -546,6 +609,10 @@ class NumberEditor(CellEditor):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     step = Float(0.01, help="""
     The major step value.
     """)
@@ -555,35 +622,63 @@ class TimeEditor(CellEditor):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 class DateEditor(CellEditor):
     ''' Calendar-based date cell editor.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 class AvgAggregator(RowAggregator):
     ''' Simple average across multiple rows.
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 class MinAggregator(RowAggregator):
     ''' Smallest value across multiple rows.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
 class MaxAggregator(RowAggregator):
     ''' Largest value across multiple rows.
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 class SumAggregator(RowAggregator):
     ''' Simple sum across multiple rows.
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
 class TableColumn(Model):
     ''' Table column widget.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     field = NonNullable(String, help="""
     The name of the field mapping to a column in the data source.
@@ -599,12 +694,12 @@ class TableColumn(Model):
     in pixels of this column.
     """)
 
-    formatter = Instance(CellFormatter, lambda: StringFormatter(), help="""
+    formatter = Instance(CellFormatter, InstanceDefault(StringFormatter), help="""
     The cell formatter for this column. By default, a simple string
     formatter is used.
     """)
 
-    editor = Instance(CellEditor, lambda: StringEditor(), help="""
+    editor = Instance(CellEditor, InstanceDefault(StringEditor), help="""
     The cell editor for this column. By default, a simple string editor
     is used.
     """)
@@ -628,11 +723,15 @@ class TableWidget(Widget):
 
     '''
 
-    source = Instance(DataSource, default=lambda: ColumnDataSource(), help="""
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+    source = Instance(DataSource, default=InstanceDefault(ColumnDataSource), help="""
     The source of data for the widget.
     """)
 
-    view = Instance(CDSView, default=lambda: CDSView(), help="""
+    view = Instance(CDSView, default=InstanceDefault(CDSView), help="""
     A view into the data source to use when rendering table rows. A default view
     of the entire data source is created if a view is not passed in during
     initialization.
@@ -643,6 +742,10 @@ class DataTable(TableWidget):
     of data.
 
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     autosize_mode = Enum(AutosizeMode, default="force_fit", help="""
     Describes the column autosizing mode with one of the following options:
@@ -763,7 +866,12 @@ class DataTable(TableWidget):
 
 class GroupingInfo(Model):
     '''Describes how to calculate totals and sub-totals
+
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     getter = String('', help="""
     References the column which generates the unique keys of this sub-total (groupby).
@@ -779,7 +887,12 @@ class GroupingInfo(Model):
 
 class DataCube(DataTable):
     '''Specialized DataTable with collapsing groups, totals, and sub-totals.
+
     '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
 
     grouping = List(Instance(GroupingInfo), help="""
     Describe what aggregation operations used to define sub-totals and totals

--- a/bokeh/models/widgets/widget.py
+++ b/bokeh/models/widgets/widget.py
@@ -52,6 +52,10 @@ class Widget(LayoutDOM):
 
     '''
 
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
     default_size = Int(default=300, help="""
     The default size (width or height) in the dominating dimension.
 

--- a/sphinx/source/docs/user_guide/examples/extensions_putting_together_ts.py
+++ b/sphinx/source/docs/user_guide/examples/extensions_putting_together_ts.py
@@ -96,7 +96,7 @@ class Custom(HTMLBox):
 
     slider = Instance(Slider)
 
-    margin = Override(default=5)
+    margin = Override(default=(5, 5, 5, 5))
 
 
 

--- a/tests/unit/bokeh/core/property/_util_property.py
+++ b/tests/unit/bokeh/core/property/_util_property.py
@@ -20,7 +20,7 @@ import pytest ; pytest
 from bokeh.core.has_props import HasProps
 
 # Module under test
-from bokeh.core.properties import Dict, Int, List, String # isort:skip
+from bokeh.core.properties import Dict, Int, List, Nullable, String # isort:skip
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -50,14 +50,14 @@ class _TestModel(HasProps):
     y = String("hello")
     z = List(Int, [1, 2, 3])
     zz = Dict(String, Int)
-    s = String(None)
+    s = Nullable(String ,default=None)
 
 class _TestModel2(HasProps):
     x = Int(12)
     y = String("hello")
     z = List(Int, [1, 2, 3])
     zz = Dict(String, Int)
-    s = String(None)
+    s = Nullable(String, default=None)
 
 #-----------------------------------------------------------------------------
 # Code

--- a/tests/unit/bokeh/core/test_properties.py
+++ b/tests/unit/bokeh/core/test_properties.py
@@ -80,6 +80,7 @@ ALL = (
     'Image',
     'Include',
     'Instance',
+    'InstanceDefault',
     'Int',
     'Interval',
     'JSON',


### PR DESCRIPTION
- [x] issues: fixes #6372 
- [x] tests added / passed

### Outcome

This PR adds automatically generated "Init Signatures" to all built-in Bokeh models, making the parameters and their default values discoverable in common IDEs:

<img width="448" alt="Screen Shot 2022-03-04 at 09 50 28" src="https://user-images.githubusercontent.com/1078448/156824583-236f3caf-08f4-4842-a3e9-3fcea709d311.png">

<img width="443" alt="Screen Shot 2022-03-04 at 09 50 43" src="https://user-images.githubusercontent.com/1078448/156824618-b2de11c1-b25d-40ba-8060-2c1cd13a672f.png">


### Import times

The changes in this PR do not appear to adversely affect import times:
```
dev-3.9 ❯ python -X importtime -c "import bokeh.plotting" 2>&1 | tail -1
import time:       227 |     443640 | bokeh.plotting
```

#### Questions/Comments

* In order to be able to add `__init__.__signature__` to models, the models must actually have an `__init__`. This PR adds a basic `__init__` that only passes args on to `super` everywhere that there was not already an `__init__`.  This is somewhat annoying for us but I consider it justifiable in order to afford a much better user experience in IDEs. Some alternatives:

  * I did try to automatically attach missing `__init__` dynamically, but that has lots of problems with MRO / `super` not working as expected. Open to any suggestions, though.
  * Alternatively, we could generate real text for `__init__` with real signatures, and then verify that that are up to date in tests. 

  Assuming we just go with basic initializers, I'd like to uncomment the assertions that `__init__` is present, *for bult-in models*. 

* The logic around dynamic instance default initializers seems a bit muddy in places. For now I switched to checking for `callable` but perhaps this is too general. 

* Adds an `InstanceDefault` that can be used the same as `default = lambda: ...` for `Instance` default values, but affords a nice repr for docstrings.  Currrently in `bokeh.model.utils` but should this be more public? In `bokeh.model` or `bokeh.core.properties` ? 

cc @mattpap 

#### Todo

* [x] Decide location of `InstanceDefault` and add more tests
* [x] ~~Try to handle existing special-case `__init__` with convenience args better~~
* [x] ~~Potential improvements to `sphinxext` based on `InstanceDefault`~~
* [x] Uncomment assertions 

Edit: not going worry about special-case inits. Most of them just make a convenience `arg` for a (now-documented) `kwarg` The docstrings were wrong before, now they are less wrong, even if not perfect. 