### PR TITLE
11765 add metadata to examples

### DIFF
--- a/examples/plotting/file/airports_map.py
+++ b/examples/plotting/file/airports_map.py
@@ -3,6 +3,7 @@ The left plot uses the built-in CartoDB tile source, and the right plot uses
 a customized tile source configured for OpenStreetMap.
 
 .. bokeh-example-metadata::
+    :sampledata: airport
     :apis: bokeh.plotting.figure.add_tile, bokeh.plotting.figure.circle
     :refs: :ref:`userguide_geo` > :ref:`userguide_geo_gmap`, :ref:`userguide_geo` > :ref:`userguide_geo_tile` > :ref:`userguide_geo_tile_source`
     :keywords: tile, map, field, elevation, geo

--- a/examples/plotting/file/airports_map.py
+++ b/examples/plotting/file/airports_map.py
@@ -1,6 +1,6 @@
 '''This example shows the same data on two separate tile plots.
 The left plot uses the built-in CartoDB tile source, and the right plot uses
-a customized tile source configured for OpenStreetMap
+a customized tile source configured for OpenStreetMap.
 
 .. bokeh-example-metadata::
     :apis: bokeh.plotting.figure.add_tile, bokeh.plotting.figure.circle
@@ -51,9 +51,9 @@ mq.x_range = carto.x_range
 mq.y_range = carto.y_range
 
 div = Div(text="""
-<p>This example shows the same data on two separate tile plots. The left plot
-is using a built-in CartoDB tile source, and is using  a customized tile source
-configured for OpenStreetMap.</p>
+<p>This example shows the same data on two separate tile plots.
+The left plot uses the built-in CartoDB tile source, and the right plot uses
+a customized tile source configured for OpenStreetMap.</p>
 """, width=800)
 
 layout = column(div, gridplot([[carto, mq]], toolbar_location="right"))

--- a/examples/plotting/file/multi_line.py
+++ b/examples/plotting/file/multi_line.py
@@ -1,3 +1,12 @@
+'''This example shows how to plot multiple lines with the `multi_line` call.
+
+.. bokeh-example-metadata::
+    :apis: bokeh.plotting.figure.multi_line, bokeh.models.HoverTool, bokeh.models.TapTool
+    :refs: :ref:`userguide_plotting` > :ref:`userguide_plotting_multi_lines`
+    :keywords: multi_line, HoverTool, TapTool
+
+'''
+
 from collections import defaultdict
 
 import numpy as np
@@ -6,7 +15,7 @@ from scipy.stats import norm
 from bokeh.layouts import gridplot
 from bokeh.models import HoverTool, TapTool
 from bokeh.palettes import Viridis6
-from bokeh.plotting import figure, show
+from bokeh.plotting import figure, output_file, show
 
 mass_spec = defaultdict(list)
 
@@ -46,5 +55,7 @@ mz_plot.multi_line(xs='MZ', ys='MZ_intensity', legend_field="Intensity_tip", **l
 mz_plot.legend.location = "top_center"
 mz_plot.xaxis.axis_label = "MZ"
 mz_plot.yaxis.axis_label = "Intensity"
+
+output_file("multi_line.html", title="multi_line.py example")
 
 show(gridplot([[rt_plot, mz_plot]]))

--- a/examples/plotting/file/rect.py
+++ b/examples/plotting/file/rect.py
@@ -4,7 +4,7 @@ and the third plot adds an angle to each rect.
 
 .. bokeh-example-metadata::
     :apis: bokeh.plotting.figure.rect
-    :refs: :ref:`userguide_plotting` > :ref:`userguide_plotting__bars_and_rectanglesrectangles`> :ref:`userguide_plotting_bars_and_rectangles_rectangles`
+    :refs: :ref:`userguide_plotting` > :ref:`userguide_plotting__bars_and_rectangles`> :ref:`userguide_plotting_bars_and_rectangles_rectangles`
     :keywords: rect
 
 '''

--- a/examples/plotting/file/rect.py
+++ b/examples/plotting/file/rect.py
@@ -1,3 +1,13 @@
+'''This example shows how to plot rectangles. The first figure uses a static
+width and height. The second applies a variable configuration for each rect 
+and the third plot adds an angle to each rect.
+
+.. bokeh-example-metadata::
+    :apis: bokeh.plotting.figure.rect
+    :refs: :ref:`userguide_plotting` > :ref:`userguide_plotting__bars_and_rectanglesrectangles`> :ref:`userguide_plotting_bars_and_rectangles_rectangles`
+    :keywords: rect
+
+'''
 import numpy as np
 
 from bokeh.layouts import gridplot

--- a/examples/plotting/file/rect.py
+++ b/examples/plotting/file/rect.py
@@ -4,7 +4,7 @@ and the third plot adds an angle to each rect.
 
 .. bokeh-example-metadata::
     :apis: bokeh.plotting.figure.rect
-    :refs: :ref:`userguide_plotting` > :ref:`userguide_plotting__bars_and_rectangles`> :ref:`userguide_plotting_bars_and_rectangles_rectangles`
+    :refs: :ref:`userguide_plotting` > :ref:`userguide_plotting_rectangles`
     :keywords: rect
 
 '''

--- a/examples/plotting/file/rect.py
+++ b/examples/plotting/file/rect.py
@@ -1,5 +1,5 @@
 '''This example shows how to plot rectangles. The first figure uses a static
-width and height. The second applies a variable configuration for each rect 
+width and height. The second applies a variable configuration for each rect
 and the third plot adds an angle to each rect.
 
 .. bokeh-example-metadata::

--- a/examples/plotting/file/scatter_selection.py
+++ b/examples/plotting/file/scatter_selection.py
@@ -2,7 +2,7 @@
 
 .. bokeh-example-metadata::
     :apis: bokeh.plotting.figure.circle, bokeh.plotting.figure.square, bokeh.model.select_one, bokeh.model.BoxSelectTool
-    :refs: :ref:`userguide_plotting` > :ref:`userguide_plotting_bars_and_rectanglesrectangles`> :ref:`userguide_plotting_bars_and_rectangles_rectangles`
+    :refs: :ref:`userguide_tools` > :ref:`userguide_tools_boxselecttool`
     :keywords: selection, tool, BoxSelectTool
 
 '''

--- a/examples/plotting/file/scatter_selection.py
+++ b/examples/plotting/file/scatter_selection.py
@@ -1,11 +1,9 @@
-'''This example shows how to plot rectangles. The first figure uses a static
-width and height. The second applies a variable configuration for each rect
-and the third plot adds an angle to each rect.
+'''This example shows how to select different behaviours of a selection tool.
 
 .. bokeh-example-metadata::
-    :apis: bokeh.plotting.figure.circle, 
-    :refs: :ref:`userguide_plotting` > :ref:`userguide_plotting__bars_and_rectanglesrectangles`> :ref:`userguide_plotting_bars_and_rectangles_rectangles`
-    :keywords: rect
+    :apis: bokeh.plotting.figure.circle, bokeh.plotting.figure.square, bokeh.model.select_one, bokeh.model.BoxSelectTool
+    :refs: :ref:`userguide_plotting` > :ref:`userguide_plotting_bars_and_rectanglesrectangles`> :ref:`userguide_plotting_bars_and_rectangles_rectangles`
+    :keywords: selection, tool, BoxSelectTool
 
 '''
 

--- a/examples/plotting/file/scatter_selection.py
+++ b/examples/plotting/file/scatter_selection.py
@@ -1,3 +1,14 @@
+'''This example shows how to plot rectangles. The first figure uses a static
+width and height. The second applies a variable configuration for each rect
+and the third plot adds an angle to each rect.
+
+.. bokeh-example-metadata::
+    :apis: bokeh.plotting.figure.circle, 
+    :refs: :ref:`userguide_plotting` > :ref:`userguide_plotting__bars_and_rectanglesrectangles`> :ref:`userguide_plotting_bars_and_rectangles_rectangles`
+    :keywords: rect
+
+'''
+
 import numpy as np
 
 from bokeh.layouts import column, gridplot

--- a/examples/plotting/file/toolbar_autohide.py
+++ b/examples/plotting/file/toolbar_autohide.py
@@ -3,11 +3,10 @@ leaves a canvas.
 
 .. bokeh-example-metadata::
     :apis: bokeh.plotting.figure.scatter, bokeh.models.tools.Toolbar.autohide
-    :refs: :ref:`reference` > :ref:`reference_models` > :ref:'reference_models_tools` > :ref:'reference_models_tools_Toolbar` > :ref:'reference_models_tools_Toolbar.autohide`
+    :refs: :ref:`reference` > :ref:`reference_models` > :ref:'reference_models_tools` > :ref:'reference_models_tools_Toolbar` > :ref:'reference_models_tools_Toolbar_autohide` # noqa: E501
     :keywords: autohide, Toolbar
 
 '''
-
 import numpy as np
 
 from bokeh.layouts import row

--- a/examples/plotting/file/toolbar_autohide.py
+++ b/examples/plotting/file/toolbar_autohide.py
@@ -3,7 +3,7 @@ leaves a canvas.
 
 .. bokeh-example-metadata::
     :apis: bokeh.plotting.figure.scatter, bokeh.models.tools.Toolbar.autohide
-    :refs: :ref:`reference` > :ref:`reference_models` > :ref:'reference_models_tools` > :ref:'reference_models_tools_Toolbar` > :ref:'reference_models_tools_Toolbar_autohide` # noqa: E501
+    :refs: :ref:`reference` > :ref:`reference_models` > :ref:'reference_models_tools` > :ref:'reference_models_tools_Toolbar` > :ref:'reference_models_tools_Toolbar_autohide`, :ref:`first_steps` > :ref:`first_steps_first_steps_4` > `first_steps_first_steps_4_deactivating_and_hiding_the_toolbar`# noqa: E501
     :keywords: autohide, Toolbar
 
 '''

--- a/examples/plotting/file/toolbar_autohide.py
+++ b/examples/plotting/file/toolbar_autohide.py
@@ -1,3 +1,13 @@
+'''This example shows how to activate a toolbar that disappears if the cursor
+leaves a canvas.
+
+.. bokeh-example-metadata::
+    :apis: bokeh.plotting.figure.scatter, bokeh.models.tools.Toolbar.autohide
+    :refs: :ref:`reference` > :ref:`reference_models` > :ref:'reference_models_tools` > :ref:'reference_models_tools_Toolbar` > :ref:'reference_models_tools_Toolbar.autohide`
+    :keywords: autohide, Toolbar
+
+'''
+
 import numpy as np
 
 from bokeh.layouts import row

--- a/examples/plotting/file/twin_axis.py
+++ b/examples/plotting/file/twin_axis.py
@@ -1,3 +1,13 @@
+'''This example shows how to add a secondary y-axis to a figure and set a color
+for the lable values.
+
+.. bokeh-example-metadata::
+    :apis: bokeh.plotting.figure.add_layout, bokeh.plotting.figure.cirlce, bokeh.models.LinearAxis
+    :refs: :ref:`userguide_plotting` > :ref:`userguide_plotting_twin_axes`
+    :keywords: add_layout, axis, axis_label, axis_label_text_color, cirlce, extra_y_ranges, LinearAxis
+
+'''
+
 from numpy import arange, linspace, pi, sin
 
 from bokeh.models import LinearAxis, Range1d


### PR DESCRIPTION
This PR adds metadata to 5 more examples and corrects metada in one example.

New are:
- toolbar_autohide.py
- rect.py
- scatter_selection.py
- twin_axis.py
- multi_line.py

Changes are in:
- airports_map.py

- [ ] issues: relates to #11765 
