### PR TITLE
Fixed typo: s/server/serve/

### DIFF
--- a/sphinx/source/docs/user_guide/server.rst
+++ b/sphinx/source/docs/user_guide/server.rst
@@ -839,7 +839,7 @@ Run the server as usual on the **remote host**.
 
 .. code-block:: sh
 
-    bokeh server
+    bokeh serve
 
 Next, issue the following command on the **local machine** to establish an SSH
 tunnel to the remote host:


### PR DESCRIPTION
It's just a 1 character typo fix. Do with it as you wish :)

- [x] issues: fixes #12045
- [ ] tests added / passed
- [x] release document entry (if new feature or API change)
