### PR TITLE
Clean up sample data attribution

### DIFF
--- a/bokeh/sampledata/airport_routes.py
+++ b/bokeh/sampledata/airport_routes.py
@@ -6,6 +6,8 @@
 #-----------------------------------------------------------------------------
 ''' Airport routes data from OpenFlights.org.
 
+License: `ODbL 1.0`_
+
 Sourced from https://openflights.org/data.html on September 07, 2017.
 
 This module contains two pandas Dataframes: ``airports`` and ``routes``.

--- a/bokeh/sampledata/airports.py
+++ b/bokeh/sampledata/airports.py
@@ -6,7 +6,9 @@
 #-----------------------------------------------------------------------------
 ''' US airports with field elevations > 1500 meters.
 
-Sourced from http://services.nationalmap.gov on October 15, 2015.
+License: `Public Domain`_
+
+Sourced from USGS service http://services.nationalmap.gov on October 15, 2015.
 
 This module contains one pandas Dataframe: ``data``.
 

--- a/bokeh/sampledata/anscombe.py
+++ b/bokeh/sampledata/anscombe.py
@@ -6,6 +6,10 @@
 #-----------------------------------------------------------------------------
 ''' The four data series that comprise `Anscombe's Quartet`_.
 
+License: `CC BY-SA 3.0`_
+
+Sourced from: https://en.wikipedia.org/wiki/Anscombe%27s_quartet
+
 This module contains one pandas Dataframe: ``data``.
 
 .. rubric:: ``data``

--- a/bokeh/sampledata/antibiotics.py
+++ b/bokeh/sampledata/antibiotics.py
@@ -7,6 +7,10 @@
 ''' A table of `Will Burtin's historical data`_ regarding antibiotic
 efficacies.
 
+License: `MIT license`_
+
+Sourced from: https://bl.ocks.org/borgar/cd32f1d804951034b224
+
 This module contains one pandas Dataframe: ``data``.
 
 .. rubric:: ``data``

--- a/bokeh/sampledata/autompg.py
+++ b/bokeh/sampledata/autompg.py
@@ -6,7 +6,9 @@
 #-----------------------------------------------------------------------------
 ''' A version of the Auto MPG data set.
 
-Derived from https://archive.ics.uci.edu/ml/datasets/auto+mpg
+License: `CC0`_
+
+Sourced from https://archive.ics.uci.edu/ml/datasets/auto+mpg
 
 This module contains two pandas Dataframes: ``autompg`` and ``autompg_clean``.
 The "clean" version has cleaned up the ``"mfr"`` and ``"origin"`` fields.

--- a/bokeh/sampledata/autompg2.py
+++ b/bokeh/sampledata/autompg2.py
@@ -6,7 +6,9 @@
 #-----------------------------------------------------------------------------
 ''' A version of the Auto MPG data set.
 
-Derived from https://archive.ics.uci.edu/ml/datasets/auto+mpg
+License: `CC0`_
+
+Sourced from https://archive.ics.uci.edu/ml/datasets/auto+mpg
 
 This module contains one pandas Dataframe: ``autompg``.
 

--- a/bokeh/sampledata/browsers.py
+++ b/bokeh/sampledata/browsers.py
@@ -6,7 +6,9 @@
 #-----------------------------------------------------------------------------
 ''' Browser market share by version from November 2013.
 
-Data sourced from http://gs.statcounter.com/#browser_version-ww-monthly-201311-201311-bar
+License: `CC BY-SA 3.0`_
+
+Sourced from http://gs.statcounter.com/#browser_version-ww-monthly-201311-201311-bar
 
 Icon images sourced from https://github.com/alrra/browser-logos
 

--- a/bokeh/sampledata/commits.py
+++ b/bokeh/sampledata/commits.py
@@ -6,6 +6,8 @@
 #-----------------------------------------------------------------------------
 ''' Time series of commits for a GitHub user between 2012 and 2016.
 
+License: `Public Domain`_
+
 This module contains one pandas Dataframe: ``data``.
 
 .. rubric:: ``data``

--- a/bokeh/sampledata/daylight.py
+++ b/bokeh/sampledata/daylight.py
@@ -6,6 +6,8 @@
 #-----------------------------------------------------------------------------
 ''' Provide 2013 Warsaw daylight hours.
 
+License: free to use and redistribute (see `this FAQ`_ for details).
+
 Sourced from http://www.sunrisesunset.com
 
 This module contains one pandas Dataframe: ``daylight_warsaw_2013``.
@@ -13,6 +15,8 @@ This module contains one pandas Dataframe: ``daylight_warsaw_2013``.
 .. rubric:: ``daylight_warsaw_2013``
 
 :bokeh-dataframe:`bokeh.sampledata.daylight.daylight_warsaw_2013`
+
+.. _this FAQ: https://www.sunrisesunset.com/faqs.asp#other_usage
 
 '''
 

--- a/bokeh/sampledata/degrees.py
+++ b/bokeh/sampledata/degrees.py
@@ -8,6 +8,10 @@
 
 The data is broken down by field for any given year.
 
+Licence: `CC0`_
+
+Sourced from: https://www.kaggle.com/datasets/sureshsrinivas/bachelorsdegreewomenusa
+
 This module contains one pandas Dataframe: ``data``.
 
 .. rubric:: ``data``

--- a/bokeh/sampledata/gapminder.py
+++ b/bokeh/sampledata/gapminder.py
@@ -6,9 +6,9 @@
 #-----------------------------------------------------------------------------
 ''' Four of the datasets from Gapminder.
 
-Sourced from https://www.gapminder.org/data/
+License: `CC BY 2.0`_
 
-Licensed under `CC-BY`_.
+Sourced from https://www.gapminder.org/data/
 
 This module contains four pandas Dataframes: ``fertility``, ``life_expectancy``,
 ``population``, and ``regions``.
@@ -28,8 +28,6 @@ This module contains four pandas Dataframes: ``fertility``, ``life_expectancy``,
 .. rubric:: ``regions``
 
 :bokeh-dataframe:`bokeh.sampledata.gapminder.regions`
-
-.. _CC-BY: https://creativecommons.org/licenses/by/2.0/
 
 '''
 

--- a/bokeh/sampledata/haar_cascade.py
+++ b/bokeh/sampledata/haar_cascade.py
@@ -6,9 +6,15 @@
 #-----------------------------------------------------------------------------
 ''' Provide a Haar cascade file for face recognition.
 
+License: `MIT license`_
+
+Sourced from the `OpenCV`_ project.
+
 This module contains an attribute ``frontalface_default_path`` . Use this
 attribute to obtain the path to a Haar cascade file for frontal face
 recognition that can be used by OpenCV.
+
+.. _OpenCV: https://opencv.org
 
 '''
 

--- a/bokeh/sampledata/iris.py
+++ b/bokeh/sampledata/iris.py
@@ -6,6 +6,10 @@
 #-----------------------------------------------------------------------------
 ''' Provide `Fisher's Iris dataset`_.
 
+License: `CC0`_
+
+Sourced from: https://www.kaggle.com/datasets/arshid/iris-flower-dataset
+
 This module contains one pandas Dataframe: ``flowers``.
 
 .. note::

--- a/bokeh/sampledata/les_mis.py
+++ b/bokeh/sampledata/les_mis.py
@@ -6,7 +6,9 @@
 #-----------------------------------------------------------------------------
 ''' Provide JSON data for co-occurrence of characters in Les Miserables.
 
-Derived from http://ftp.cs.stanford.edu/pub/sgb/jean.dat
+License: `CC BY-ND 4.0`_
+
+Source from http://ftp.cs.stanford.edu/pub/sgb/jean.dat
 
 This module contains one dictionary: ``data``.
 

--- a/bokeh/sampledata/movies_data.py
+++ b/bokeh/sampledata/movies_data.py
@@ -6,12 +6,13 @@
 #-----------------------------------------------------------------------------
 ''' A small subset of data from the `Open Movie Database`_.
 
-Data is licensed `CC BY-NC 4.0`_.
+License: `CC BY-NC 4.0`_
+
+Sourced from http://www.omdbapi.com
 
 This modules has an attribute ``movie_path``. This attribute contains the path
 to a SQLite database with the data.
 
-.. _CC BY-NC 4.0: https://creativecommons.org/licenses/by-nc/4.0/
 .. _Open Movie Database: http://www.omdbapi.com
 
 '''

--- a/bokeh/sampledata/mtb.py
+++ b/bokeh/sampledata/mtb.py
@@ -6,6 +6,8 @@
 #-----------------------------------------------------------------------------
 ''' Route data (including altitude) for a bike race in Eastern Europe.
 
+Sourced from https://bikemaraton.com.pl
+
 This module contains one pandas Dataframe: ``obiszow_mtb_xcm``.
 
 .. rubric:: ``obiszow_mtb_xcm``

--- a/bokeh/sampledata/olympics2014.py
+++ b/bokeh/sampledata/olympics2014.py
@@ -6,6 +6,8 @@
 #-----------------------------------------------------------------------------
 ''' Provide medal counts by country for the 2014 Olympics.
 
+Sourced from public news sources in 2014.
+
 This module contains a single dict: ``data``.
 
 The dictionary has a key ``"data"`` that lists sub-dictionaries, one for each

--- a/bokeh/sampledata/penguins.py
+++ b/bokeh/sampledata/penguins.py
@@ -6,9 +6,9 @@
 #-----------------------------------------------------------------------------
 ''' Provide data from the `Palmer Archipelago (Antarctica) penguin dataset`_.
 
-Derived from https://github.com/mwaskom/seaborn-data/blob/master/penguins.csv
+License: `CC0`_
 
-Data distributed under the `CC-0`_ license.
+Sourced from https://github.com/mwaskom/seaborn-data/blob/master/penguins.csv
 
 This module contains one pandas Dataframe: ``data``.
 
@@ -16,7 +16,6 @@ This module contains one pandas Dataframe: ``data``.
 
 :bokeh-dataframe:`bokeh.sampledata.penguins.data`
 
-.. _CC-0: https://creativecommons.org/share-your-work/public-domain/cc0/
 .. _Palmer Archipelago (Antarctica) penguin dataset: https://github.com/allisonhorst/palmerpenguins
 
 '''

--- a/bokeh/sampledata/perceptions.py
+++ b/bokeh/sampledata/perceptions.py
@@ -6,9 +6,9 @@
 #-----------------------------------------------------------------------------
 ''' Provides access to ``probly.csv`` and ``numberly.csv``.
 
-Sourced from: https://github.com/zonination/perceptions
+License: `MIT license`_
 
-Data distributed under the `MIT license`_.
+Sourced from: https://github.com/zonination/perceptions
 
 This module contains two pandas Dataframes: ``probly`` and ``numberly``.
 
@@ -19,8 +19,6 @@ This module contains two pandas Dataframes: ``probly`` and ``numberly``.
 .. rubric:: ``numberly``
 
 :bokeh-dataframe:`bokeh.sampledata.perceptions.numberly`
-
-.. _MIT license: https://opensource.org/licenses/MIT
 
 '''
 

--- a/bokeh/sampledata/periodic_table.py
+++ b/bokeh/sampledata/periodic_table.py
@@ -6,6 +6,8 @@
 #-----------------------------------------------------------------------------
 ''' Provide a periodic table data set.
 
+License: `Public Domain`_
+
 This module contains one pandas Dataframe: ``elements``.
 
 .. rubric:: ``elements``

--- a/bokeh/sampledata/population.py
+++ b/bokeh/sampledata/population.py
@@ -6,17 +6,15 @@
 #-----------------------------------------------------------------------------
 ''' Historical and projected population data by age, gender, and country.
 
-Sourced from: https://population.un.org/wpp/Download/Standard/Population/
+License: `CC BY 3.0 IGO`_
 
-Data is licenced `CC BY 3.0 IGO`_.
+Sourced from: https://population.un.org/wpp/Download/Standard/Population/
 
 This module contains one pandas Dataframe: ``data``.
 
 .. rubric:: ``data``
 
 :bokeh-dataframe:`bokeh.sampledata.population.data`
-
-.. _CC BY 3.0 IGO: https://creativecommons.org/licenses/by/3.0/igo/
 
 '''
 

--- a/bokeh/sampledata/sample_geojson.py
+++ b/bokeh/sampledata/sample_geojson.py
@@ -6,12 +6,11 @@
 #-----------------------------------------------------------------------------
 ''' Provide geojson data for the UK NHS England area teams.
 
-Sourced from https://github.com/JeniT/nhs-choices with data licensed under the
-`Open Government Licence`_.
+License: `Open Government Licence`_
+
+Sourced from https://github.com/JeniT/nhs-choices
 
 A snapshot of data available from NHS Choices on November 14th, 2015.
-
-.. _Open Government Licence: http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/
 
 '''
 

--- a/bokeh/sampledata/sea_surface_temperature.py
+++ b/bokeh/sampledata/sea_surface_temperature.py
@@ -6,11 +6,17 @@
 #-----------------------------------------------------------------------------
 ''' Time series of historical average sea surface temperatures.
 
+License: free to use and redistribute (see `this table`_ for details).
+
+Sourced from http://www.neracoos.org/erddap/tabledap/index.html (table *B01_sbe37_all*)
+
 This module contains one pandas Dataframe: ``sea_surface_temperature``.
 
 .. rubric:: ``sea_surface_temperature``
 
 :bokeh-dataframe:`bokeh.sampledata.sea_surface_temperature.sea_surface_temperature`
+
+.. _this table: http://www.neracoos.org/erddap/info/B01_sbe37_all/index.html
 
 '''
 

--- a/bokeh/sampledata/sprint.py
+++ b/bokeh/sampledata/sprint.py
@@ -6,6 +6,8 @@
 #-----------------------------------------------------------------------------
 ''' Historical results for Olympic sprints by year.
 
+Sourced from public news sources.
+
 This module contains one pandas Dataframe: ``sprint``.
 
 .. rubric:: ``sprint``

--- a/bokeh/sampledata/stocks.py
+++ b/bokeh/sampledata/stocks.py
@@ -6,6 +6,8 @@
 #-----------------------------------------------------------------------------
 ''' Provide historical ticker data for selected stocks.
 
+Sourced from public news sources.
+
 This module contains five dicts: ``AAPL``, ``FB``, ``GOOG``, ``IBM``, and ``MSFT``.
 
 Each dictionary has the structure:

--- a/bokeh/sampledata/unemployment.py
+++ b/bokeh/sampledata/unemployment.py
@@ -6,8 +6,11 @@
 #-----------------------------------------------------------------------------
 ''' Per-county unemployment data for Unites States in 2009.
 
-This module contains one dict: ``data``.
+License: `Public Domain`_
 
+Sourced from: https://www.bls.gov
+
+This module contains one dict: ``data``.
 
 The dict is indexed by the two-tuples containing ``(state_id, county_id)`` and
 has the unemployment rate (2009) as the value.

--- a/bokeh/sampledata/unemployment1948.py
+++ b/bokeh/sampledata/unemployment1948.py
@@ -6,6 +6,10 @@
 #-----------------------------------------------------------------------------
 ''' US Unemployment rate data by month and year, from 1948 to 2013.
 
+License: `Public Domain`_
+
+Sourced from: https://www.bls.gov
+
 This module contains one pandas Dataframe: ``data``.
 
 .. rubric:: ``data``

--- a/bokeh/sampledata/us_cities.py
+++ b/bokeh/sampledata/us_cities.py
@@ -6,6 +6,10 @@
 #-----------------------------------------------------------------------------
 ''' Locations of US cities with more than 5000 residents.
 
+License: `CC BY 2.0`_
+
+Sourced from http://www.geonames.org/export/ (subset of *cities5000.zip*)
+
 This module contains one dict: ``data``.
 
 .. code-block:: python

--- a/bokeh/sampledata/us_counties.py
+++ b/bokeh/sampledata/us_counties.py
@@ -8,7 +8,7 @@
 
 This module contains one dict: ``data``.
 
-The data is indexed by two-tuples of `` (state_id, county_id)`` that
+The data is indexed by two-tuples of ``(state_id, county_id)`` that
 have the following dictionaries as values:
 
 .. code-block:: ipython

--- a/bokeh/sampledata/us_holidays.py
+++ b/bokeh/sampledata/us_holidays.py
@@ -6,6 +6,8 @@
 #-----------------------------------------------------------------------------
 ''' Calendar file of US Holidays from Mozilla provided by `icalendar`_.
 
+License `CC BY-SA 3.0`_
+
 Sourced from: https://www.mozilla.org/en-US/projects/calendar/holidays/
 
 This module contains one list: ``us_holidays``.

--- a/bokeh/sampledata/us_marriages_divorces.py
+++ b/bokeh/sampledata/us_marriages_divorces.py
@@ -6,10 +6,9 @@
 #-----------------------------------------------------------------------------
 ''' Provide U.S. marriage and divorce statistics between 1867 and 2014
 
-Data from the CDC's National Center for Health Statistics (NHCS) database
-(http://www.cdc.gov/nchs/).
+License: `Public Domain`_
 
-Data organized by Randal S. Olson (http://www.randalolson.com)
+Sourced from http://www.cdc.gov/nchs/
 
 This module contains one pandas Dataframe: ``data``.
 

--- a/bokeh/sampledata/world_cities.py
+++ b/bokeh/sampledata/world_cities.py
@@ -6,17 +6,15 @@
 #-----------------------------------------------------------------------------
 ''' Names and locations of world cities with at least 5000 inhabitants.
 
-Derived from ``cities5000.zip`` file downloaded from http://www.geonames.org/export/
+License: `CC BY 2.0`_
 
-Licensed under `CC-BY`_.
+Sourced from http://www.geonames.org/export/ (*cities5000.zip*)
 
 This module contains one pandas Dataframe: ``data``.
 
 .. rubric:: ``data``
 
 :bokeh-dataframe:`bokeh.sampledata.world_cities.data`
-
-.. _CC-BY: https://creativecommons.org/licenses/by/2.0/
 
 '''
 

--- a/sphinx/source/rst_epilog.txt
+++ b/sphinx/source/rst_epilog.txt
@@ -45,3 +45,14 @@
 
 .. |named CSS colors| replace:: `named CSS colors`_
 .. _`named CSS colors`: https://www.w3.org/TR/css-color-4/#named-colors
+
+.. _CC BY 2.0: https://creativecommons.org/licenses/by/2.0/
+.. _CC BY 3.0 IGO: https://creativecommons.org/licenses/by/3.0/igo/
+.. _CC BY-NC 4.0: https://creativecommons.org/licenses/by-nc/4.0/
+.. _CC BY-ND 4.0: https://creativecommons.org/licenses/by-nd/4.0/
+.. _CC BY-SA 3.0: https://creativecommons.org/licenses/by-sa/3.0/
+.. _CC0: https://creativecommons.org/share-your-work/public-domain/cc0/
+.. _MIT license: https://opensource.org/licenses/MIT
+.. _ODbL 1.0: https://opendatacommons.org/licenses/odbl/1-0/
+.. _Open Government Licence: http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/
+.. _Public Domain: https://wiki.creativecommons.org/wiki/public_domain


### PR DESCRIPTION
Cleans up and makes sample data data attributions more consistent. Missing licenses added where available.

@mattpap do you know where the bike race data came from? It's only of the only missing licenses now. 

US Counties/Cities provenance is long gone. I think I grabbed it off some public google sheet yen years ago. Since ultimately all the same data is available via usgov sites, I am tempted to label them Public Domain. 