### PR TITLE
Fix Wedge and AnnualWedge glyph hitboxes

### DIFF
--- a/bokehjs/src/lib/models/glyphs/annular_wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/annular_wedge.ts
@@ -9,6 +9,7 @@ import * as p from "core/properties"
 import {angle_between} from "core/util/math"
 import {Context2d} from "core/util/canvas"
 import {Selection} from "../selections/selection"
+import {max} from "../../core/util/arrayable"
 
 export type AnnularWedgeData = XYGlyphData & p.UniformsOf<AnnularWedge.Mixins> & {
   readonly inner_radius: p.Uniform<number>
@@ -19,6 +20,7 @@ export type AnnularWedgeData = XYGlyphData & p.UniformsOf<AnnularWedge.Mixins> &
 
   sinner_radius: ScreenArray
   souter_radius: ScreenArray
+  max_souter_radius: number
 
   readonly max_inner_radius: number
   readonly max_outer_radius: number
@@ -40,6 +42,7 @@ export class AnnularWedgeView extends XYGlyphView {
       this.souter_radius = this.sdist(this.renderer.xscale, this._x, this.outer_radius)
     else
       this.souter_radius = to_screen(this.outer_radius)
+    this.max_souter_radius = max(this.souter_radius)
   }
 
   protected _render(ctx: Context2d, indices: number[], data?: AnnularWedgeData): void {
@@ -85,23 +88,12 @@ export class AnnularWedgeView extends XYGlyphView {
     const y = this.renderer.yscale.invert(sy)
 
     // check radius first
-    let x0: number, y0: number
-    let x1: number, y1: number
-    if (this.model.properties.outer_radius.units == "data") {
-      x0 = x - this.max_outer_radius
-      x1 = x + this.max_outer_radius
-
-      y0 = y - this.max_outer_radius
-      y1 = y + this.max_outer_radius
-    } else {
-      const sx0 = sx - this.max_outer_radius
-      const sx1 = sx + this.max_outer_radius
-      ;[x0, x1] = this.renderer.xscale.r_invert(sx0, sx1)
-
-      const sy0 = sy - this.max_outer_radius
-      const sy1 = sy + this.max_outer_radius
-      ;[y0, y1] = this.renderer.yscale.r_invert(sy0, sy1)
-    }
+    const sx0 = sx - this.max_souter_radius
+    const sx1 = sx + this.max_souter_radius
+    const [x0, x1] = this.renderer.xscale.r_invert(sx0, sx1)
+    const sy0 = sy - this.max_souter_radius
+    const sy1 = sy + this.max_souter_radius
+    const [y0, y1] = this.renderer.yscale.r_invert(sy0, sy1)
 
     const candidates: number[] = []
 

--- a/bokehjs/test/unit/models/glyphs/annular_wedge.ts
+++ b/bokehjs/test/unit/models/glyphs/annular_wedge.ts
@@ -1,0 +1,83 @@
+import {expect} from "assertions"
+
+import {create_glyph_renderer_view} from "./_util"
+import {AnnularWedge} from "@bokehjs/models/glyphs/annular_wedge"
+import {Geometry} from "@bokehjs/core/geometry"
+
+describe("Glyph (using AnnularWedge as a concrete Glyph)", () => {
+
+  describe("GlyphView", () => {
+    it("should hit test annular wedges against an index", async () => {
+      const data = {
+        start_angle: [-0.25*Math.PI, 0.25*Math.PI, 0.75*Math.PI, 1.25*Math.PI],
+        end_angle: [0.25*Math.PI, 0.75*Math.PI, 1.25*Math.PI, 1.75*Math.PI],
+      }
+      const glyph = new AnnularWedge({
+        x: {value: 50},
+        y: {value: 50},
+        inner_radius: {value: 25},
+        outer_radius: {value: 50},
+        start_angle: {field: "start_angle"},
+        end_angle: {field: "end_angle"},
+      })
+
+      const glyph_renderer = await create_glyph_renderer_view(glyph, data, {axis_type: "linear"})
+      const glyph_view = glyph_renderer.glyph
+
+      const geometries: Geometry[] = [
+        // Points just inside and outside the outer circle
+        {type: "point", sx: 100 +  90, sy: 100},        // Right, inside
+        {type: "point", sx: 100 + 110, sy: 100},        // Right, outside
+        {type: "point", sx: 100,       sy: 100 -  90},  // Top, inside
+        {type: "point", sx: 100,       sy: 100 - 110},  // Top, outside
+        {type: "point", sx: 100 -  90, sy: 100},        // Left, inside
+        {type: "point", sx: 100 - 110, sy: 100},        // Left, outside
+        {type: "point", sx: 100,       sy: 100 +  90},  // Bottom, inside
+        {type: "point", sx: 100,       sy: 100 + 110},  // Bottom, outside
+        // Points just inside and outside the inner circle
+        {type: "point", sx: 100 + 40, sy: 100},       // Right, inside
+        {type: "point", sx: 100 + 60, sy: 100},       // Right, outside
+        {type: "point", sx: 100,      sy: 100 - 40},  // Top, inside
+        {type: "point", sx: 100,      sy: 100 - 60},  // Top, outside
+        {type: "point", sx: 100 - 40, sy: 100},       // Left, inside
+        {type: "point", sx: 100 - 60, sy: 100},       // Left, outside
+        {type: "point", sx: 100,      sy: 100 + 40},  // Bottom, inside
+        {type: "point", sx: 100,      sy: 100 + 60},  // Bottom, outside
+      ]
+
+      const expected_hits = [
+        [0],
+        [],
+        [1],
+        [],
+        [2],
+        [],
+        [3],
+        [],
+        [],
+        [0],
+        [],
+        [1],
+        [],
+        [2],
+        [],
+        [3],
+      ]
+
+      for (let i = 0; i < geometries.length; i++) {
+        const result = glyph_view.hit_test(geometries[i])!
+        expect(result.indices).to.be.equal(expected_hits[i])
+      }
+
+      // Re-run hit tests with double the Y scale, keeping its center the same.
+      // Wedges are drawn as circles in screen space and the radius is defined
+      // along the X axis. This should not affect the hit-test result.
+      glyph_renderer.yscale.source_range.start -= 100
+      glyph_renderer.yscale.source_range.end += 100
+      for (let i = 0; i < geometries.length; i++) {
+        const result = glyph_view.hit_test(geometries[i])!
+        expect(result.indices).to.be.equal(expected_hits[i])
+      }
+    })
+  })
+})

--- a/bokehjs/test/unit/models/glyphs/wedge.ts
+++ b/bokehjs/test/unit/models/glyphs/wedge.ts
@@ -1,0 +1,65 @@
+import {expect} from "assertions"
+
+import {create_glyph_renderer_view} from "./_util"
+import {Wedge} from "@bokehjs/models/glyphs/wedge"
+import {Geometry} from "@bokehjs/core/geometry"
+
+describe("Glyph (using Wedge as a concrete Glyph)", () => {
+
+  describe("GlyphView", () => {
+    it("should hit test wedges against an index", async () => {
+      const data = {
+        start_angle: [-0.25*Math.PI, 0.25*Math.PI, 0.75*Math.PI, 1.25*Math.PI],
+        end_angle: [0.25*Math.PI, 0.75*Math.PI, 1.25*Math.PI, 1.75*Math.PI],
+      }
+      const glyph = new Wedge({
+        x: {value: 50},
+        y: {value: 50},
+        radius: {value: 50},
+        start_angle: {field: "start_angle"},
+        end_angle: {field: "end_angle"},
+      })
+
+      const glyph_renderer = await create_glyph_renderer_view(glyph, data, {axis_type: "linear"})
+      const glyph_view = glyph_renderer.glyph
+
+      const geometries: Geometry[] = [
+        // Points just inside and outside the circle
+        {type: "point", sx: 100 +  90, sy: 100},        // Right, inside
+        {type: "point", sx: 100 + 110, sy: 100},        // Right, outside
+        {type: "point", sx: 100,       sy: 100 -  90},  // Top, inside
+        {type: "point", sx: 100,       sy: 100 - 110},  // Top, outside
+        {type: "point", sx: 100 -  90, sy: 100},        // Left, inside
+        {type: "point", sx: 100 - 110, sy: 100},        // Left, outside
+        {type: "point", sx: 100,       sy: 100 +  90},  // Bottom, inside
+        {type: "point", sx: 100,       sy: 100 + 110},  // Bottom, outside
+      ]
+
+      const expected_hits = [
+        [0],
+        [],
+        [1],
+        [],
+        [2],
+        [],
+        [3],
+        [],
+      ]
+
+      for (let i = 0; i < geometries.length; i++) {
+        const result = glyph_view.hit_test(geometries[i])!
+        expect(result.indices).to.be.equal(expected_hits[i])
+      }
+
+      // Re-run hit tests with double the Y scale, keeping its center the same.
+      // Wedges are drawn as circles in screen space and the radius is defined
+      // along the X axis. This should not affect the hit-test result.
+      glyph_renderer.yscale.source_range.start -= 100
+      glyph_renderer.yscale.source_range.end += 100
+      for (let i = 0; i < geometries.length; i++) {
+        const result = glyph_view.hit_test(geometries[i])!
+        expect(result.indices).to.be.equal(expected_hits[i])
+      }
+    })
+  })
+})


### PR DESCRIPTION
All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [x] issues: fixes #12070
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)


This changes the hit-test calculations in Wedge and AnnularWedge so they are performed in screen-space, since the glyphs are rendered as circles in screen space.

This doesn't add any tests yet, but I'll work on that soon.