### PR TITLE
Fix passing of kwargs in Image glyph's constructor

### DIFF
--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -663,7 +663,7 @@ class Image(XYGlyph):
             mapper = LinearColorMapper(palette)
             kwargs['color_mapper'] = mapper
 
-        super().__init__(*args, *kwargs)
+        super().__init__(*args, **kwargs)
 
     _args = ('image', 'x', 'y', 'dw', 'dh', 'dilate')
 

--- a/tests/unit/bokeh/models/test_glyphs.py
+++ b/tests/unit/bokeh/models/test_glyphs.py
@@ -230,6 +230,14 @@ def test_Image() -> None:
         "color_mapper",
     ], GLYPH)
 
+def test_Image_kwargs() -> None:
+    glyph = Image(x=0, y=0, dw=10, dh=10)
+    assert glyph.image == field("image")
+    assert glyph.x == 0
+    assert glyph.y == 0
+    assert glyph.dw == 10
+    assert glyph.dh == 10
+    assert glyph.dilate is False
 
 def test_ImageRGBA() -> None:
     glyph = ImageRGBA()


### PR DESCRIPTION
fixes #12080 
