### PR TITLE
11765 typos in metadata documentation

### DIFF
--- a/bokeh/sphinxext/bokeh_plot.py
+++ b/bokeh/sphinxext/bokeh_plot.py
@@ -47,8 +47,7 @@ process-docstring (bool):
     separate from the source.
 
 source-position (enum('above', 'below', 'none')):
-    Where to locate the the block of formatted source
-    code (if anywhere).
+    Where to locate the block of formatted source code (if anywhere).
 
 linenos (bool):
     Whether to display line numbers along with the source.

--- a/examples/models/file/basic_plot.py
+++ b/examples/models/file/basic_plot.py
@@ -3,7 +3,6 @@ circle scatter markers with black outlines, using the low-level ``bokeh.models``
 API.
 
 .. bokeh-example-metadata::
-    :sampledata: sine wave
     :apis: bokeh.models.Circle, bokeh.models.Plot, bokeh.models.ColumnDataSource, bokeh.models.LinearAxis, bokeh.models.PanTool, bokeh.models.WheelZoomTool
     :refs: :ref:`userguide_plotting` > :ref:`userguide_plotting_scatter_markers`
     :keywords: circle, figure, scatter

--- a/examples/models/file/widgets.py
+++ b/examples/models/file/widgets.py
@@ -3,7 +3,7 @@ buttons, groups, inputs, panels, sliders, and tables, using the low-level
 ``bokeh.models`` API.
 
 .. bokeh-example-metadata::
-    :sampledata: autompg2
+    :sampledata: autompg2, iris
     :apis: bokeh.models.AutocompleteInput, bokeh.models.Button, bokeh.models.CheckboxButtonGroup, bokeh.models.CheckboxGroup, bokeh.models.ColorPicker, bokeh.models.Column, bokeh.models.ColumnDataSource, bokeh.models.DataTable, bokeh.models.DatePicker, bokeh.models.DateRangeSlider, bokeh.models.DateSlider, bokeh.models.Div, bokeh.models.Dropdown, bokeh.models.IntEditor, bokeh.models.MultiChoice, bokeh.models.MultiSelect, bokeh.models.NumberEditor, bokeh.models.NumberFormatter, bokeh.models.Panel, bokeh.models.Paragraph, bokeh.models.PreText, bokeh.models.RadioButtonGroup, bokeh.models.RadioGroup, bokeh.models.RangeSlider, bokeh.models.Row, bokeh.models.Select, bokeh.models.SelectEditor, bokeh.models.Slider, bokeh.models.Spinner, bokeh.models.StringEditor, bokeh.models.StringFormatter, bokeh.models.TableColumn, bokeh.models.Tabs, bokeh.models.TextAreaInput, bokeh.models.TextInput, bokeh.models.Toggle # noqa: E501
     :refs: :ref:`userguide_plotting` > :ref:`userguide_plotting_scatter_markers`
     :keywords: widgets, select, button, slider, figure

--- a/examples/plotting/file/airports_map.py
+++ b/examples/plotting/file/airports_map.py
@@ -3,7 +3,7 @@ The left plot uses the built-in CartoDB tile source, and the right plot uses
 a customized tile source configured for OpenStreetMap.
 
 .. bokeh-example-metadata::
-    :sampledata: airport
+    :sampledata: airports
     :apis: bokeh.plotting.figure.add_tile, bokeh.plotting.figure.circle
     :refs: :ref:`userguide_geo` > :ref:`userguide_geo_gmap`, :ref:`userguide_geo` > :ref:`userguide_geo_tile` > :ref:`userguide_geo_tile_source`
     :keywords: tile, map, field, elevation, geo

--- a/examples/plotting/file/periodic_shells.py
+++ b/examples/plotting/file/periodic_shells.py
@@ -1,3 +1,14 @@
+'''This example creates a periodic table of elements with a custom tooltip. The tooltip
+includes multiple chemical data as well as a bohr diagram for each element.
+
+.. bokeh-example-metadata::
+    :sampledata: periodic_table
+    :apis: bokeh.plotting.figure.circle, bokeh.transform.dodge, bokeh.transform.factor_cmap
+    :refs: :ref:`userguide_plotting` > :ref:`userguide_plotting_scatter`
+    :keywords: circle, RendererGroup, Template, ToggleGroup
+
+'''
+
 import re
 
 import numpy as np
@@ -69,11 +80,10 @@ def bohr_diagram():
     plot = figure(
         width=150, height=150,
         x_axis_type=None, y_axis_type=None,
+        x_range = (-8,8), y_range = (-8,8), 
         toolbar_location=None, outline_line_color=None,
         match_aspect=True,
     )
-    plot.x_range.only_visible = True
-    plot.y_range.only_visible = True
     groups = []
     for sc in df["electron shells"]:
         n = len(sc)

--- a/examples/plotting/file/periodic_shells.py
+++ b/examples/plotting/file/periodic_shells.py
@@ -80,7 +80,7 @@ def bohr_diagram():
     plot = figure(
         width=150, height=150,
         x_axis_type=None, y_axis_type=None,
-        x_range = (-8,8), y_range = (-8,8), 
+        x_range = (-8,8), y_range = (-8,8),
         toolbar_location=None, outline_line_color=None,
         match_aspect=True,
     )

--- a/examples/plotting/file/unemployment.py
+++ b/examples/plotting/file/unemployment.py
@@ -2,6 +2,7 @@
 adding a ``ColorBar`` to a plot.
 
 .. bokeh-example-metadata::
+    :sampledata: unemployment1948
     :apis: bokeh.plotting.figure.rect, bokeh.models.annotations.ColorBar
     :refs: :ref:`userguide_annotations` > :ref:`userguide_annotations_color_bars`
     :keywords: categorical, colorbar, heatmap, hover, tooltip

--- a/examples/plotting/file/us_marriages_divorces_hover.py
+++ b/examples/plotting/file/us_marriages_divorces_hover.py
@@ -1,3 +1,14 @@
+'''This example shows the number of marriages and divorces in the USA from 1867 to 2011
+as a basic line plot. Furthermore a custom tooltip is defined using the Arial font.
+
+.. bokeh-example-metadata::
+    :sampledata: us_marriages_divorces
+    :apis: bokeh.plotting.figure.line
+    :refs: :ref:`userguide_plotting` > :ref:`userguide_plotting_line_glyphs`
+    :keywords: line, NumeralTickFormatter, SingleIntervalTicker
+
+'''
+
 from bokeh.models import ColumnDataSource, NumeralTickFormatter, SingleIntervalTicker
 from bokeh.plotting import figure, output_file, show
 from bokeh.sampledata.us_marriages_divorces import data


### PR DESCRIPTION
While working on #12066 I found some missing "sampledata" tags, one was added without loading sampledata and some typos are corrected. Additional the "bokeh-example-metadata" is added for "periodic_shells.py" and "us_marriages_divorces_hover.py".
I want to merge this into main because I am not sure how my progress on #12066 will be.

- [ ] issues: addresses #11765
