### PR TITLE
11965 fixes that null value with unspecified nan_format crashes table rendering

### DIFF
--- a/bokeh/models/widgets/tables.py
+++ b/bokeh/models/widgets/tables.py
@@ -145,7 +145,7 @@ class StringFormatter(CellFormatter):
     An optional text color.
     """)
 
-    nan_format = String("", help="""
+    nan_format = String("-", help="""
     Formatting to apply to NaN and None values.
     """)
 

--- a/bokeh/models/widgets/tables.py
+++ b/bokeh/models/widgets/tables.py
@@ -145,6 +145,12 @@ class StringFormatter(CellFormatter):
     An optional text color.
     """)
 
+    nan_format = String("", help="""
+    Formatting to apply to NaN and None values.
+    """)
+
+
+
 class ScientificFormatter(StringFormatter):
     ''' Display numeric values from continuous ranges as "basic numbers",
     using scientific notation when appropriate by default.
@@ -153,10 +159,6 @@ class ScientificFormatter(StringFormatter):
     # explicit __init__ to support Init signatures
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-
-    nan_format = Nullable(String, help="""
-    Formatting to apply to NaN and None values (falls back to scientific formatting if not set).
-    """)
 
     precision = Int(10, help="""
     How many digits of precision to display.
@@ -259,10 +261,6 @@ class NumberFormatter(StringFormatter):
 
     language = Enum(NumeralLanguage, default="en", help="""
     The language to use for formatting language-specific features (e.g. thousands separator).
-    """)
-
-    nan_format = Nullable(String, help="""
-    Formatting to apply to NaN and None values (falls back to Numbro formatting if not set).
     """)
 
     rounding = Enum(RoundingFunction, help="""
@@ -494,10 +492,6 @@ class DateFormatter(StringFormatter):
     .. _timezone: http://bigeasy.github.io/timezone/
     .. _github issue: https://github.com/bokeh/bokeh/issues
 
-    """)
-
-    nan_format = Nullable(String, help="""
-    Formatting to apply to NaN and None values (falls back to regular date formatting if not set).
     """)
 
 

--- a/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
@@ -59,7 +59,7 @@ export class StringFormatter extends CellFormatter {
       font_style: [ FontStyle, "normal" ],
       text_align: [ TextAlign, "left"   ],
       text_color: [ Nullable(Color), null ],
-      nan_format: [ String, ""],
+      nan_format: [ String, "NaN"],
     }))
   }
 

--- a/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
@@ -129,8 +129,11 @@ export class ScientificFormatter extends StringFormatter {
       precision = 1
     }
 
-    if ((value == null || isNaN(value)) && this.nan_format != null)
-      value = this.nan_format
+    if (value == null || isNaN(value))
+      if (this.nan_format != null)
+        value = this.nan_format
+      else
+        value = ''
     else if (value == 0)
       value = to_fixed(value, 1)
     else if (need_sci)

--- a/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
@@ -59,7 +59,7 @@ export class StringFormatter extends CellFormatter {
       font_style: [ FontStyle, "normal" ],
       text_align: [ TextAlign, "left"   ],
       text_color: [ Nullable(Color), null ],
-      nan_format: [ String, "NaN"],
+      nan_format: [ String, "-"],
     }))
   }
 

--- a/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
@@ -133,7 +133,7 @@ export class ScientificFormatter extends StringFormatter {
       if (this.nan_format != null)
         value = this.nan_format
       else
-        value = ''
+        value = ""
     else if (value == 0)
       value = to_fixed(value, 1)
     else if (need_sci)

--- a/bokehjs/test/unit/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/test/unit/models/widgets/tables/cell_formatters.ts
@@ -123,6 +123,11 @@ describe("cell_formatters module", () => {
         expect(df.doFormat(0, 0, NaN, {}, {})).to.be.equal('<div style="text-align: left;">-</div>')
       })
 
+      it("should apply nan_format to null with nan_format is null", () => {
+        const df = new ScientificFormatter()
+        expect(df.doFormat(0, 0, null, {}, {})).to.be.equal('<div style="text-align: left;"></div>')
+      })
+
       it("should apply to_fixed if value is zero", () => {
         const df = new ScientificFormatter({precision: 3})
         expect(df.doFormat(0, 0, 0, {}, {})).to.be.equal('<div style="text-align: left;">0</div>')

--- a/bokehjs/test/unit/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/test/unit/models/widgets/tables/cell_formatters.ts
@@ -75,20 +75,24 @@ describe("cell_formatters module", () => {
     })
 
     describe("doFormat method", () => {
-
-      it("should apply nan_format to null", () => {
-        const df = new DateFormatter({nan_format: "-"})
+      it("should apply default nan_format to null", () => {
+        const df = new DateFormatter()
         expect(df.doFormat(0, 0, null, {}, {})).to.be.equal('<div style="text-align: left;">-</div>')
       })
 
+      it("should apply nan_format to null", () => {
+        const df = new DateFormatter({nan_format: "--"})
+        expect(df.doFormat(0, 0, null, {}, {})).to.be.equal('<div style="text-align: left;">--</div>')
+      })
+
       it("should apply nan_format to nan", () => {
-        const df = new DateFormatter({nan_format: "-"})
-        expect(df.doFormat(0, 0, NaN, {}, {})).to.be.equal('<div style="text-align: left;">-</div>')
+        const df = new DateFormatter({nan_format: "--"})
+        expect(df.doFormat(0, 0, NaN, {}, {})).to.be.equal('<div style="text-align: left;">--</div>')
       })
 
       it("should apply nan_format to NaT", () => {
-        const df = new DateFormatter({nan_format: "-"})
-        expect(df.doFormat(0, 0, -9223372036854776, {}, {})).to.be.equal('<div style="text-align: left;">-</div>')
+        const df = new DateFormatter({nan_format: "--"})
+        expect(df.doFormat(0, 0, -9223372036854776, {}, {})).to.be.equal('<div style="text-align: left;">--</div>')
       })
     })
   })
@@ -98,17 +102,17 @@ describe("cell_formatters module", () => {
     describe("doFormat method", () => {
       it("should apply default nan_format to null", () => {
         const df = new NumberFormatter()
-        expect(df.doFormat(0, 0, null, {}, {})).to.be.equal('<div style="text-align: left;">NaN</div>')
-      })
-
-      it("should apply nan_format to null", () => {
-        const df = new NumberFormatter({nan_format: "-"})
         expect(df.doFormat(0, 0, null, {}, {})).to.be.equal('<div style="text-align: left;">-</div>')
       })
 
+      it("should apply nan_format to null", () => {
+        const df = new NumberFormatter({nan_format: "--"})
+        expect(df.doFormat(0, 0, null, {}, {})).to.be.equal('<div style="text-align: left;">--</div>')
+      })
+
       it("should apply nan_format to nan", () => {
-        const df = new NumberFormatter({nan_format: "-"})
-        expect(df.doFormat(0, 0, NaN, {}, {})).to.be.equal('<div style="text-align: left;">-</div>')
+        const df = new NumberFormatter({nan_format: "--"})
+        expect(df.doFormat(0, 0, NaN, {}, {})).to.be.equal('<div style="text-align: left;">--</div>')
       })
     })
   })
@@ -116,20 +120,19 @@ describe("cell_formatters module", () => {
   describe("ScientificFormatter", () => {
 
     describe("doFormat method", () => {
-
-      it("should apply nan_format to null", () => {
-        const df = new ScientificFormatter({nan_format: "-"})
+      it("should apply default nan_format to null", () => {
+        const df = new ScientificFormatter()
         expect(df.doFormat(0, 0, null, {}, {})).to.be.equal('<div style="text-align: left;">-</div>')
       })
 
-      it("should apply nan_format to nan", () => {
-        const df = new ScientificFormatter({nan_format: "-"})
-        expect(df.doFormat(0, 0, NaN, {}, {})).to.be.equal('<div style="text-align: left;">-</div>')
+      it("should apply nan_format to null", () => {
+        const df = new ScientificFormatter({nan_format: "--"})
+        expect(df.doFormat(0, 0, null, {}, {})).to.be.equal('<div style="text-align: left;">--</div>')
       })
 
-      it("should apply nan_format to null with nan_format is null", () => {
-        const df = new ScientificFormatter()
-        expect(df.doFormat(0, 0, null, {}, {})).to.be.equal('<div style="text-align: left;"></div>')
+      it("should apply nan_format to nan", () => {
+        const df = new ScientificFormatter({nan_format: "--"})
+        expect(df.doFormat(0, 0, NaN, {}, {})).to.be.equal('<div style="text-align: left;">--</div>')
       })
 
       it("should apply to_fixed if value is zero", () => {

--- a/bokehjs/test/unit/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/test/unit/models/widgets/tables/cell_formatters.ts
@@ -96,6 +96,10 @@ describe("cell_formatters module", () => {
   describe("NumberFormatter", () => {
 
     describe("doFormat method", () => {
+      it("should apply default nan_format to null", () => {
+        const df = new NumberFormatter()
+        expect(df.doFormat(0, 0, null, {}, {})).to.be.equal('<div style="text-align: left;">NaN</div>')
+      })
 
       it("should apply nan_format to null", () => {
         const df = new NumberFormatter({nan_format: "-"})


### PR DESCRIPTION

- [X] issues: fixes #11965
- [X] tests added / passed: added unit test for issue in question
- [X] release document entry (if new feature or API change) - no change in behaviour

Note that this PR fixes the error when passing in a null value to the ScientificFormatter. The output is now the exact same as when you use a NumberFormatter:
![image](https://user-images.githubusercontent.com/7702207/165106115-7b3ecfd7-5470-4de9-b988-f31fd4fb613c.png)
