### PR TITLE
Fix Comparing singleton primitives with equality checking

### DIFF
--- a/examples/app/movies/main.py
+++ b/examples/app/movies/main.py
@@ -78,11 +78,11 @@ def select_movies():
         (movies.Oscars >= oscars.value)
     ]
     if (genre_val != "All"):
-        selected = selected[selected.Genre.str.contains(genre_val)==True]
+        selected = selected[selected.Genre.str.contains(genre_val) is True]
     if (director_val != ""):
-        selected = selected[selected.Director.str.contains(director_val)==True]
+        selected = selected[selected.Director.str.contains(director_val) is True]
     if (cast_val != ""):
-        selected = selected[selected.Cast.str.contains(cast_val)==True]
+        selected = selected[selected.Cast.str.contains(cast_val) is True]
     return selected
 
 

--- a/tests/integration/tools/test_custom_action.py
+++ b/tests/integration/tools/test_custom_action.py
@@ -42,6 +42,6 @@ class Test_CustomAction:
         page = single_plot_page(plot)
 
         page.get_toolbar_button("custom-action").click()
-        assert page.results["activated"] == True
+        assert page.results["activated"] is True
 
         assert page.has_no_console_errors()

--- a/tests/unit/bokeh/application/handlers/test_directory.py
+++ b/tests/unit/bokeh/application/handlers/test_directory.py
@@ -121,7 +121,7 @@ class Test_DirectoryHandler:
         }, load)
 
         assert len(doc.roots) == 2
-        assert results['package'] == True
+        assert results['package'] is True
 
     def test_directory_mainpy_adds_roots(self) -> None:
         doc = Document()

--- a/tests/unit/bokeh/application/handlers/test_handler.py
+++ b/tests/unit/bokeh/application/handlers/test_handler.py
@@ -38,7 +38,7 @@ class Test_Handler:
 
     def test_create(self) -> None:
         h = bahh.Handler()
-        assert h.failed == False
+        assert h.failed is False
         assert h.url_path() is None
         assert h.static_path() is None
         assert h.error is None

--- a/tests/unit/bokeh/application/handlers/test_notebook__handlers.py
+++ b/tests/unit/bokeh/application/handlers/test_notebook__handlers.py
@@ -59,7 +59,7 @@ class Test_NotebookHandler:
         def load(filename):
             handler = bahn.NotebookHandler(filename=filename)
             handler.modify_document(doc)
-            assert handler._runner.failed == False
+            assert handler._runner.failed is False
 
         with_script_contents(source, load)
 
@@ -71,7 +71,7 @@ class Test_NotebookHandler:
         def load(filename):
             handler = bahn.NotebookHandler(filename=filename)
             handler.modify_document(doc)
-            assert handler._runner.failed == False
+            assert handler._runner.failed is False
 
         with_script_contents(source, load)
 

--- a/tests/unit/bokeh/application/test_application.py
+++ b/tests/unit/bokeh/application/test_application.py
@@ -155,7 +155,7 @@ class Test_Application:
         a.add(handler)
         handler2 = FunctionHandler(add_one_root)
         a.add(handler2)
-        assert a.static_path == None
+        assert a.static_path is None
 
     def test_static_path(self) -> None:
         a = baa.Application()

--- a/tests/unit/bokeh/client/test_connection.py
+++ b/tests/unit/bokeh/client/test_connection.py
@@ -40,7 +40,7 @@ class Test_ClientConnection:
     def test_creation(self) -> None:
         c = bcc.ClientConnection("session", "wsurl")
         assert c.url == "wsurl"
-        assert c.connected == False
+        assert c.connected is False
         assert isinstance(c.io_loop, IOLoop)
 
         assert c._session == "session"
@@ -52,7 +52,7 @@ class Test_ClientConnection:
     def test_creation_with_arguments(self) -> None:
         c = bcc.ClientConnection("session", "wsurl", arguments=dict(foo="bar"))
         assert c.url == "wsurl"
-        assert c.connected == False
+        assert c.connected is False
         assert isinstance(c.io_loop, IOLoop)
 
         assert c._session == "session"

--- a/tests/unit/bokeh/client/test_session__client.py
+++ b/tests/unit/bokeh/client/test_session__client.py
@@ -40,7 +40,7 @@ def test_DEFAULT_SERVER_WEBSOCKET_URL() -> None:
 class Test_ClientSession:
     def test_creation_defaults(self) -> None:
         s = bcs.ClientSession()
-        assert s.connected == False
+        assert s.connected is False
         assert s.document is None
         assert s._connection._arguments is None
         assert isinstance(s.id, str)
@@ -48,14 +48,14 @@ class Test_ClientSession:
 
     def test_creation_with_session_id(self) -> None:
         s = bcs.ClientSession("sid")
-        assert s.connected == False
+        assert s.connected is False
         assert s.document is None
         assert s._connection._arguments is None
         assert s.id == "sid"
 
     def test_creation_with_ws_url(self) -> None:
         s = bcs.ClientSession(websocket_url="wsurl")
-        assert s.connected == False
+        assert s.connected is False
         assert s.document is None
         assert s._connection._arguments is None
         assert s._connection.url == "wsurl"
@@ -64,7 +64,7 @@ class Test_ClientSession:
 
     def test_creation_with_ioloop(self) -> None:
         s = bcs.ClientSession(io_loop="io_loop")
-        assert s.connected == False
+        assert s.connected is False
         assert s.document is None
         assert s._connection._arguments is None
         assert s._connection.io_loop == "io_loop"
@@ -73,7 +73,7 @@ class Test_ClientSession:
 
     def test_creation_with_arguments(self) -> None:
         s = bcs.ClientSession(arguments="args")
-        assert s.connected == False
+        assert s.connected is False
         assert s.document is None
         assert s._connection._arguments == "args"
         assert len(s.id) == 44

--- a/tests/unit/bokeh/client/test_states.py
+++ b/tests/unit/bokeh/client/test_states.py
@@ -90,7 +90,7 @@ async def test_DISCONNECTED() -> None:
 
 async def test_WAITING_FOR_REPLY() -> None:
     s = bcs.WAITING_FOR_REPLY("reqid")
-    assert s.reply == None
+    assert s.reply is None
     assert s.reqid == "reqid"
 
     c = MockConnection()

--- a/tests/unit/bokeh/command/subcommands/test_sampledata__subcommands.py
+++ b/tests/unit/bokeh/command/subcommands/test_sampledata__subcommands.py
@@ -57,7 +57,7 @@ def test_args() -> None:
 
 def test_run(capsys: Capture) -> None:
     main(["bokeh", "sampledata"])
-    assert did_call_download == True
+    assert did_call_download is True
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/tests/unit/bokeh/core/property/test_bases.py
+++ b/tests/unit/bokeh/core/property/test_bases.py
@@ -53,18 +53,18 @@ class TestProperty:
 
     def test_serialized_default(self) -> None:
         p = bcpb.Property()
-        assert p.serialized == True
-        assert p.readonly == False
+        assert p.serialized is True
+        assert p.readonly is False
 
         # readonly=True sets serialized=False if unspecified
         p = bcpb.Property(readonly=True)
-        assert p.serialized == False
-        assert p.readonly == True
+        assert p.serialized is False
+        assert p.readonly is True
 
         # explicit serialized value always respected
         p = bcpb.Property(readonly=True, serialized=True)
-        assert p.serialized == True
-        assert p.readonly == True
+        assert p.serialized is True
+        assert p.readonly is True
 
 
     def test_assert_bools(self) -> None:
@@ -202,7 +202,7 @@ class TestProperty:
         assert err == ""
 
     def test_validation_on(self) -> None:
-        assert bcpb.Property._should_validate == True
+        assert bcpb.Property._should_validate is True
         assert bcpb.validation_on()
 
         bcpb.Property._should_validate = False

--- a/tests/unit/bokeh/core/property/test_instance.py
+++ b/tests/unit/bokeh/core/property/test_instance.py
@@ -67,11 +67,11 @@ class Test_Instance:
 
     def test_serialized(self) -> None:
         prop = bcpi.Instance(_TestModel)
-        assert prop.serialized == True
+        assert prop.serialized is True
 
     def test_readonly(self) -> None:
         prop = bcpi.Instance(_TestModel)
-        assert prop.readonly == False
+        assert prop.readonly is False
 
     def test_valid(self) -> None:
         prop = bcpi.Instance(_TestModel)

--- a/tests/unit/bokeh/core/property/test_singletons.py
+++ b/tests/unit/bokeh/core/property/test_singletons.py
@@ -36,17 +36,17 @@ ALL = (
 #-----------------------------------------------------------------------------
 
 def test_Undefined() -> None:
-    assert (bcpu.Undefined == bcpu.Undefined) == True
-    assert (bcpu.Undefined != bcpu.Undefined) == False
-    assert (bcpu.Undefined is bcpu.Undefined) == True
-    assert (bcpu.Undefined is not bcpu.Undefined) == False
-    assert (copy(bcpu.Undefined) is bcpu.Undefined) == True
-    assert (copy(bcpu.Undefined) is not bcpu.Undefined) == False
+    assert (bcpu.Undefined == bcpu.Undefined) is True
+    assert (bcpu.Undefined != bcpu.Undefined) is False
+    assert (bcpu.Undefined is bcpu.Undefined) is True
+    assert (bcpu.Undefined is not bcpu.Undefined) is False
+    assert (copy(bcpu.Undefined) is bcpu.Undefined) is True
+    assert (copy(bcpu.Undefined) is not bcpu.Undefined) is False
 
 def test_Intrinsic() -> None:
-    assert (bcpu.Intrinsic == bcpu.Intrinsic) == True
-    assert (bcpu.Intrinsic != bcpu.Intrinsic) == False
-    assert (bcpu.Intrinsic is bcpu.Intrinsic) == True
-    assert (bcpu.Intrinsic is not bcpu.Intrinsic) == False
-    assert (copy(bcpu.Intrinsic) is bcpu.Intrinsic) == True
-    assert (copy(bcpu.Intrinsic) is not bcpu.Intrinsic) == False
+    assert (bcpu.Intrinsic == bcpu.Intrinsic) is True
+    assert (bcpu.Intrinsic != bcpu.Intrinsic) is False
+    assert (bcpu.Intrinsic is bcpu.Intrinsic) is True
+    assert (bcpu.Intrinsic is not bcpu.Intrinsic) is False
+    assert (copy(bcpu.Intrinsic) is bcpu.Intrinsic) is True
+    assert (copy(bcpu.Intrinsic) is not bcpu.Intrinsic) is False

--- a/tests/unit/bokeh/core/property/test_wrappers__property.py
+++ b/tests/unit/bokeh/core/property/test_wrappers__property.py
@@ -188,7 +188,7 @@ def test_PropertyValueColumnData__stream_list_to_list(mock_notify: MagicMock) ->
     event = mock_notify.call_args[1]['hint']
     assert isinstance(event, ColumnsStreamedEvent)
     assert event.setter == 'setter'
-    assert event.rollover == None
+    assert event.rollover is None
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
 def test_PropertyValueColumnData__stream_list_to_array(mock_notify: MagicMock) -> None:
@@ -207,7 +207,7 @@ def test_PropertyValueColumnData__stream_list_to_array(mock_notify: MagicMock) -
     event = mock_notify.call_args[1]['hint']
     assert isinstance(event, ColumnsStreamedEvent)
     assert event.setter == 'setter'
-    assert event.rollover == None
+    assert event.rollover is None
 
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
@@ -246,7 +246,7 @@ def test_PropertyValueColumnData__stream_array_to_array(mock_notify: MagicMock) 
     event = mock_notify.call_args[1]['hint']
     assert isinstance(event, ColumnsStreamedEvent)
     assert event.setter == 'setter'
-    assert event.rollover == None
+    assert event.rollover is None
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
 def test_PropertyValueColumnData__stream_array_to_list(mock_notify: MagicMock) -> None:
@@ -265,7 +265,7 @@ def test_PropertyValueColumnData__stream_array_to_list(mock_notify: MagicMock) -
     event = mock_notify.call_args[1]['hint']
     assert isinstance(event, ColumnsStreamedEvent)
     assert event.setter == 'setter'
-    assert event.rollover == None
+    assert event.rollover is None
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
 def test_PropertyValueColumnData__stream_array_with_rollover(mock_notify: MagicMock) -> None:

--- a/tests/unit/bokeh/core/test_has_props.py
+++ b/tests/unit/bokeh/core/test_has_props.py
@@ -144,7 +144,7 @@ def test_HasProps_default_init() -> None:
     assert c.int1 == 10
     assert c.ds1 == field("x")
     assert c.lst1 == []
-    assert c.int2 == None
+    assert c.int2 is None
     assert c.str2 == "foo"
     assert c.ds2 == field("y")
     assert c.lst2 == [1,2,3]
@@ -159,7 +159,7 @@ def test_HasProps_kw_init() -> None:
     assert c.int1 == 10
     assert c.ds1 == field("x")
     assert c.lst1 == []
-    assert c.int2 == None
+    assert c.int2 is None
     assert c.str2 == "bar"
     assert c.ds2 == 10
     assert c.lst2 == [2,3,4]
@@ -269,7 +269,7 @@ def test_HasProps_update() -> None:
     assert c.int1 == 25
     assert c.ds1 == value(123)
     assert c.lst1 == []
-    assert c.int2 == None
+    assert c.int2 is None
     assert c.str2 == "baz"
     assert c.ds2 == field("y")
     assert c.lst2 == [1,2]
@@ -280,7 +280,7 @@ def test_HasProps_set_from_json() -> None:
     assert c.int1 == 10
     assert c.ds1 == field("x")
     assert c.lst1 == []
-    assert c.int2 == None
+    assert c.int2 is None
     assert c.str2 == "foo"
     assert c.ds2 == field("y")
     assert c.lst2 == [1,2]
@@ -289,7 +289,7 @@ def test_HasProps_set_from_json() -> None:
     assert c.int1 == 10
     assert c.ds1 == "foo"
     assert c.lst1 == []
-    assert c.int2 == None
+    assert c.int2 is None
     assert c.str2 == "foo"
     assert c.ds2 == field("y")
     assert c.lst2 == [1,2]
@@ -310,7 +310,7 @@ def test_HasProps_set() -> None:
     assert c.int1 == 25
     assert c.ds1 == field("foo")
     assert c.lst1 == []
-    assert c.int2 == None
+    assert c.int2 is None
     assert c.str2 == "baz"
     assert c.ds2 == field("y")
     assert c.lst2 == [1,2]
@@ -392,7 +392,7 @@ def test_HasProps_unapply_theme() -> None:
     assert c.lst2 == [1,2,3]
 
     c.unapply_theme()
-    assert c.int2 == None
+    assert c.int2 is None
     assert c.lst1 == []
 
     assert c.int1 == 10
@@ -401,7 +401,7 @@ def test_HasProps_unapply_theme() -> None:
     assert c.ds2 == field("y")
     assert c.lst2 == [1,2,3]
 
-    assert c.themed_values() == None
+    assert c.themed_values() is None
 
 class EitherSimpleDefault(hp.HasProps):
     foo = Either(List(Int), Int, default=10)

--- a/tests/unit/bokeh/core/test_properties.py
+++ b/tests/unit/bokeh/core/test_properties.py
@@ -342,7 +342,7 @@ class TestBasic:
 
         o = Readonly()
         assert o.x == 12
-        assert o.y == None
+        assert o.y is None
         assert o.z == 'hello'
 
         # readonly props are still in the list of props
@@ -365,7 +365,7 @@ class TestBasic:
         o.z = "xyz"
 
         assert o.x == 12
-        assert o.y == None
+        assert o.y is None
         assert o.z == 'xyz'
 
     def test_include_defaults(self) -> None:

--- a/tests/unit/bokeh/core/test_serialization.py
+++ b/tests/unit/bokeh/core/test_serialization.py
@@ -95,8 +95,8 @@ class TestSerializer:
         encoder = Serializer()
 
         assert encoder.encode(None) is None
-        assert encoder.encode(False) == False
-        assert encoder.encode(True) == True
+        assert encoder.encode(False) is False
+        assert encoder.encode(True) is True
         assert encoder.encode("abc") == "abc"
 
         assert encoder.encode(1) == 1
@@ -729,7 +729,7 @@ class TestSerializer:
         encoder = Serializer()
         val = np.bool_(True)
         rep = encoder.encode(val)
-        assert rep == True
+        assert rep is True
         assert isinstance(rep, bool)
 
     def test_np_datetime64(self) -> None:

--- a/tests/unit/bokeh/document/test_callbacks__document.py
+++ b/tests/unit/bokeh/document/test_callbacks__document.py
@@ -122,7 +122,7 @@ class TestDocumentCallbackManager:
     def test_hold(self, policy: HoldPolicyType) -> None:
         d = Document()
         cm = bdc.DocumentCallbackManager(d)
-        assert cm.hold_value == None
+        assert cm.hold_value is None
         assert cm._held_events == []
 
         cm.hold(policy)
@@ -310,13 +310,13 @@ class TestDocumentCallbackManager:
     def test_unhold(self, policy: HoldPolicyType) -> None:
         d = Document()
         cm = bdc.DocumentCallbackManager(d)
-        assert cm.hold_value == None
+        assert cm.hold_value is None
         assert cm._held_events == []
 
         cm.hold(policy)
         assert cm.hold_value == policy
         cm.unhold()
-        assert cm.hold_value == None
+        assert cm.hold_value is None
 
     @patch("bokeh.document.callbacks.DocumentCallbackManager.trigger_on_change")
     def test_unhold_triggers_events(self, mock_trigger: MagicMock) -> None:

--- a/tests/unit/bokeh/document/test_document.py
+++ b/tests/unit/bokeh/document/test_document.py
@@ -290,7 +290,7 @@ class TestDocument:
 
         # select_one()
         assert root3 == d.select_one(dict(name='d'))
-        assert None is d.select_one(dict(name='nope'))
+        assert d.select_one(dict(name='nope')) is None
         got_error = False
         try:
             d.select_one(dict(name='c'))
@@ -300,7 +300,7 @@ class TestDocument:
         assert got_error
 
         # select_one() on object
-        assert None is root3.select_one(dict(name='a'))
+        assert root3.select_one(dict(name='a')) is None
         assert child3 == root3.select_one(dict(name='c'))
 
         # set_select()

--- a/tests/unit/bokeh/document/test_document.py
+++ b/tests/unit/bokeh/document/test_document.py
@@ -217,14 +217,14 @@ class TestDocument:
         d.add_root(m)
         assert d.get_model_by_name("foo") == m
         m.name = "bar"
-        assert d.get_model_by_name("foo") == None
+        assert d.get_model_by_name("foo") is None
         assert d.get_model_by_name("bar") == m
 
     def test_get_model_by_changed_from_none_name(self) -> None:
         d = document.Document()
         m = SomeModelInTestDocument(name=None)
         d.add_root(m)
-        assert d.get_model_by_name("bar") == None
+        assert d.get_model_by_name("bar") is None
         m.name = "bar"
         assert d.get_model_by_name("bar") == m
 
@@ -234,7 +234,7 @@ class TestDocument:
         d.add_root(m)
         assert d.get_model_by_name("bar") == m
         m.name = None
-        assert d.get_model_by_name("bar") == None
+        assert d.get_model_by_name("bar") is None
 
     def test_can_get_name_overriding_model_by_name(self) -> None:
         d = document.Document()
@@ -290,7 +290,7 @@ class TestDocument:
 
         # select_one()
         assert root3 == d.select_one(dict(name='d'))
-        assert None == d.select_one(dict(name='nope'))
+        assert None is d.select_one(dict(name='nope'))
         got_error = False
         try:
             d.select_one(dict(name='c'))
@@ -300,7 +300,7 @@ class TestDocument:
         assert got_error
 
         # select_one() on object
-        assert None == root3.select_one(dict(name='a'))
+        assert None is root3.select_one(dict(name='a'))
         assert child3 == root3.select_one(dict(name='c'))
 
         # set_select()

--- a/tests/unit/bokeh/document/test_events__document.py
+++ b/tests/unit/bokeh/document/test_events__document.py
@@ -68,19 +68,19 @@ class TestDocumentChangedEvent:
         doc = Document()
         e = bde.DocumentChangedEvent(doc)
         assert e.document == doc
-        assert e.setter == None
-        assert e.callback_invoker == None
+        assert e.setter is None
+        assert e.callback_invoker is None
 
         doc = Document()
         e = bde.DocumentChangedEvent(doc, "setter")
         assert e.document == doc
         assert e.setter == "setter"
-        assert e.callback_invoker == None
+        assert e.callback_invoker is None
 
         doc = Document()
         e = bde.DocumentChangedEvent(doc, callback_invoker="invoker")
         assert e.document == doc
-        assert e.setter == None
+        assert e.setter is None
         assert e.callback_invoker == "invoker"
 
         doc = Document()
@@ -101,7 +101,7 @@ class TestDocumentChangedEvent:
         doc = Document()
         e = bde.DocumentChangedEvent(doc, "setter", "invoker")
         e2 = bde.DocumentChangedEvent(doc, "setter", "invoker")
-        assert e.combine(e2) == False
+        assert e.combine(e2) is False
 
 # DocumentPatchedEvent --------------------------------------------------------
 
@@ -133,7 +133,7 @@ class TestDocumentPatchedEvent:
         doc = Document()
         e = bde.DocumentPatchedEvent(doc, "setter", "invoker")
         e2 = bde.DocumentPatchedEvent(doc, "setter", "invoker")
-        assert e.combine(e2) == False
+        assert e.combine(e2) is False
 
 # ModelChangedEvent -----------------------------------------------------------
 
@@ -143,12 +143,12 @@ class TestModelChangedEvent:
         doc = Document()
         e = bde.ModelChangedEvent(doc, "model", "attr", "new")
         assert e.document == doc
-        assert e.setter == None
-        assert e.callback_invoker == None
+        assert e.setter is None
+        assert e.callback_invoker is None
         assert e.model == "model"
         assert e.attr == "attr"
         assert e.new == "new"
-        assert e.callback_invoker == None
+        assert e.callback_invoker is None
 
     def test_kind(self) -> None:
         assert bde.ModelChangedEvent.kind == "ModelChanged"
@@ -167,37 +167,37 @@ class TestModelChangedEvent:
         doc = Document()
         e = bde.ModelChangedEvent(doc, "model", "attr", "new")
         e2 = bde.DocumentPatchedEvent(doc, "setter", "invoker")
-        assert e.combine(e2) == False
+        assert e.combine(e2) is False
 
     def test_combine_ignores_different_setter(self) -> None:
         doc = Document()
         e = bde.ModelChangedEvent(doc, "model", "attr", "new", "setter")
         e2 = bde.ModelChangedEvent(doc, "model", "attr", "new2", "setter2")
-        assert e.combine(e2) == False
+        assert e.combine(e2) is False
 
     def test_combine_ignores_different_doc(self) -> None:
         doc = Document()
         e = bde.ModelChangedEvent(doc, "model", "attr", "new")
         e2 = bde.ModelChangedEvent("doc2", "model", "attr", "new2")
-        assert e.combine(e2) == False
+        assert e.combine(e2) is False
 
     def test_combine_ignores_different_model(self) -> None:
         doc = Document()
         e = bde.ModelChangedEvent(doc, "model", "attr", "new")
         e2 = bde.ModelChangedEvent(doc, "model2", "attr", "new2")
-        assert e.combine(e2) == False
+        assert e.combine(e2) is False
 
     def test_combine_ignores_different_attr(self) -> None:
         doc = Document()
         e = bde.ModelChangedEvent(doc, "model", "attr", "new")
         e2 = bde.ModelChangedEvent(doc, "model", "attr2", "new2")
-        assert e.combine(e2) == False
+        assert e.combine(e2) is False
 
     def test_combine_with_matching_model_changed_event(self) -> None:
         doc = Document()
         e = bde.ModelChangedEvent(doc, "model", "attr", "new", callback_invoker="invoker")
         e2 = bde.ModelChangedEvent(doc, "model", "attr", "new2", callback_invoker="invoker2")
-        assert e.combine(e2) == True
+        assert e.combine(e2) is True
         assert e.new == "new2"
         assert e.callback_invoker == "invoker2"
 
@@ -208,7 +208,7 @@ class TestModelChangedEvent:
         m = SomeModel()
         e = bde.ColumnsStreamedEvent(doc, m, "data", dict(foo=1), 200, "setter", "invoker")
         e2 = bde.ColumnsStreamedEvent(doc, m, "data", dict(foo=2), 300, "setter", "invoker")
-        assert e.combine(e2) == False
+        assert e.combine(e2) is False
         assert mock_combine.call_count == 1
         assert mock_combine.call_args[0] == (e2,)
         assert mock_combine.call_args[1] == {}
@@ -259,7 +259,7 @@ class TestColumnDataChangedEvent:
         m = SomeModel()
         e = bde.ColumnDataChangedEvent(doc, m, "data", None, [1,2], "setter", "invoker")
         e2 = bde.ColumnDataChangedEvent(doc, m, "data", None, [3,4], "setter", "invoker")
-        assert e.combine(e2) == False
+        assert e.combine(e2) is False
         assert e.cols == [1,2]
 
 # ColumnsStreamedEvent --------------------------------------------------------
@@ -304,7 +304,7 @@ class TestColumnsStreamedEvent:
         m = SomeModel()
         e = bde.ColumnsStreamedEvent(doc, m, "data", dict(foo=1), 200, "setter", "invoker")
         e2 = bde.ColumnsStreamedEvent(doc, m, "data", dict(foo=2), 300, "setter", "invoker")
-        assert e.combine(e2) == False
+        assert e.combine(e2) is False
         assert e.model is m
         assert e.attr == "data"
         assert e.data == dict(foo=1)
@@ -359,7 +359,7 @@ class TestColumnsPatchedEvent:
         m = SomeModel()
         e = bde.ColumnsPatchedEvent(doc, m, "data", [1,2], "setter", "invoker")
         e2 = bde.ColumnsPatchedEvent(doc, m, "data", [3,4], "setter", "invoker")
-        assert e.combine(e2) == False
+        assert e.combine(e2) is False
         assert e.patches == [1,2]
 
 # TitleChangedEvent -----------------------------------------------------------
@@ -397,7 +397,7 @@ class TestTitleChangedEvent:
         doc = Document()
         e = bde.TitleChangedEvent(doc, "title", "setter", "invoker")
         e2 = bde.DocumentPatchedEvent(doc, "setter", "invoker")
-        assert e.combine(e2) == False
+        assert e.combine(e2) is False
         assert e.title == "title"
         assert e.callback_invoker == "invoker"
 
@@ -405,7 +405,7 @@ class TestTitleChangedEvent:
         doc = Document()
         e = bde.TitleChangedEvent(doc, "title", "setter", "invoker")
         e2 = bde.TitleChangedEvent(doc, "title2", "setter2", "invoker2")
-        assert e.combine(e2) == False
+        assert e.combine(e2) is False
         assert e.title == "title"
         assert e.callback_invoker == "invoker"
 
@@ -413,7 +413,7 @@ class TestTitleChangedEvent:
         doc = Document()
         e = bde.TitleChangedEvent(doc, "title", "setter", "invoker")
         e2 = bde.TitleChangedEvent("doc2", "title2", "setter2", "invoker2")
-        assert e.combine(e2) == False
+        assert e.combine(e2) is False
         assert e.title == "title"
         assert e.callback_invoker == "invoker"
 
@@ -421,7 +421,7 @@ class TestTitleChangedEvent:
         doc = Document()
         e = bde.TitleChangedEvent(doc, "title", "setter", "invoker")
         e2 = bde.TitleChangedEvent(doc, "title2", "setter", "invoker2")
-        assert e.combine(e2) == True
+        assert e.combine(e2) is True
         assert e.title == "title2"
         assert e.callback_invoker == "invoker2"
 
@@ -523,8 +523,8 @@ class TestSessionCallbackAdded:
         e = bde.SessionCallbackAdded(doc, "callback")
         assert e.document == doc
         assert e.callback == "callback"
-        assert e.setter == None
-        assert e.callback_invoker == None
+        assert e.setter is None
+        assert e.callback_invoker is None
 
     def test_dispatch(self) -> None:
         doc = Document()
@@ -538,7 +538,7 @@ class TestSessionCallbackAdded:
         doc = Document()
         e = bde.SessionCallbackAdded(doc, "setter")
         e2 = bde.SessionCallbackAdded(doc, "setter")
-        assert e.combine(e2) == False
+        assert e.combine(e2) is False
 
 # SessionCallbackRemoved ------------------------------------------------------
 
@@ -549,8 +549,8 @@ class TestSessionCallbackRemoved:
         e = bde.SessionCallbackRemoved(doc, "callback")
         assert e.document == doc
         assert e.callback == "callback"
-        assert e.setter == None
-        assert e.callback_invoker == None
+        assert e.setter is None
+        assert e.callback_invoker is None
 
     def test_dispatch(self) -> None:
         doc = Document()
@@ -564,7 +564,7 @@ class TestSessionCallbackRemoved:
         doc = Document()
         e = bde.SessionCallbackAdded(doc, "setter")
         e2 = bde.SessionCallbackAdded(doc, "setter")
-        assert e.combine(e2) == False
+        assert e.combine(e2) is False
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/document/test_locking.py
+++ b/tests/unit/bokeh/document/test_locking.py
@@ -66,7 +66,7 @@ def test_without_document_lock() -> None:
         curdoc_from_cb.append(curdoc())
     callback_obj = d.add_next_tick_callback(cb)
     callback_obj.callback()
-    assert callback_obj.callback.nolock == True
+    assert callback_obj.callback.nolock is True
     assert len(curdoc_from_cb) == 1
     assert curdoc_from_cb[0]._doc is d
     assert isinstance(curdoc_from_cb[0], locking.UnlockedDocumentProxy)
@@ -85,7 +85,7 @@ def test_without_document_lock_accepts_async_function() -> None:
     loop = asyncio.get_event_loop()
     loop.run_until_complete(callback_obj.callback())
 
-    assert callback_obj.callback.nolock == True
+    assert callback_obj.callback.nolock is True
     assert i == 1
 
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/embed/test_standalone.py
+++ b/tests/unit/bokeh/embed/test_standalone.py
@@ -118,7 +118,7 @@ class Test_autoload_static:
         scripts = driver.find_elements(By.CSS_SELECTOR, 'head script')
         assert len(scripts) == 5
         for script in scripts:
-            assert script.get_attribute("crossorigin") == None
+            assert script.get_attribute("crossorigin") is None
             assert script.get_attribute("integrity") == ""
 
     @pytest.mark.selenium
@@ -144,7 +144,7 @@ class Test_autoload_static:
             print(x.get_attribute("src"))
         assert len(scripts) == 4
         for script in scripts:
-            assert script.get_attribute("crossorigin") == None
+            assert script.get_attribute("crossorigin") is None
             assert script.get_attribute("integrity") == ""
 
     @pytest.mark.selenium
@@ -167,7 +167,7 @@ class Test_autoload_static:
             print(x.get_attribute("src"))
         assert len(scripts) == 5
         for script in scripts:
-            assert script.get_attribute("crossorigin") == None
+            assert script.get_attribute("crossorigin") is None
             assert script.get_attribute("integrity") == ""
 
     @pytest.mark.selenium
@@ -188,7 +188,7 @@ class Test_autoload_static:
         scripts = driver.find_elements(By.CSS_SELECTOR, 'head script')
         assert len(scripts) == 5
         for script in scripts:
-            assert script.get_attribute("crossorigin") == None
+            assert script.get_attribute("crossorigin") is None
             assert script.get_attribute("integrity") == ""
 
 
@@ -387,7 +387,7 @@ class Test_json_item:
     def test_without_target_id(self, test_plot: figure) -> None:
         out = bes.json_item(test_plot)
         assert set(out.keys()) == JSON_ITEMS_KEYS
-        assert out['target_id'] == None
+        assert out['target_id'] is None
 
     def test_doc_json(self, test_plot: figure) -> None:
         out = bes.json_item(test_plot, target=ID("foo"))

--- a/tests/unit/bokeh/io/test_showing.py
+++ b/tests/unit/bokeh/io/test_showing.py
@@ -144,7 +144,7 @@ def test__show_with_state_with_no_notebook(
 
     s.output_file("foo.html")
     bis._show_with_state("obj", s, "browser", "new")
-    assert s.notebook_type == None
+    assert s.notebook_type is None
 
     assert mock_show_doc.call_count == 0
 

--- a/tests/unit/bokeh/io/test_state.py
+++ b/tests/unit/bokeh/io/test_state.py
@@ -38,8 +38,8 @@ class Test_State:
     def test_creation(self) -> None:
         s = bis.State()
         assert isinstance(s.document, Document)
-        assert s.file == None
-        assert s.notebook == False
+        assert s.file is None
+        assert s.notebook is False
 
     def test_default_file_resources(self) -> None:
         s = bis.State()
@@ -52,7 +52,7 @@ class Test_State:
         assert s.file.filename == "foo.html"
         assert s.file.title == "Bokeh Plot"
         assert s.file.resources.log_level == 'info'
-        assert s.file.resources.minified == True
+        assert s.file.resources.minified is True
 
     @patch('bokeh.io.state.log')
     @patch('os.path.isfile')
@@ -63,7 +63,7 @@ class Test_State:
         assert s.file.filename == "foo.html"
         assert s.file.title == "Bokeh Plot"
         assert s.file.resources.log_level == 'info'
-        assert s.file.resources.minified == True
+        assert s.file.resources.minified is True
         assert mock_log.info.call_count == 1
         assert mock_log.info.call_args[0] == (
             "Session output file 'foo.html' already exists, will be overwritten.",
@@ -72,13 +72,13 @@ class Test_State:
     def test_output_notebook_noarg(self) -> None:
         s = bis.State()
         s.output_notebook()
-        assert s.notebook == True
+        assert s.notebook is True
         assert s.notebook_type == 'jupyter'
 
     def test_output_notebook_witharg(self) -> None:
         s = bis.State()
         s.output_notebook(notebook_type='notjup')
-        assert s.notebook == True
+        assert s.notebook is True
         assert s.notebook_type == 'notjup'
 
     def test_output_invalid_notebook(self) -> None:
@@ -94,8 +94,8 @@ class Test_State:
         s.output_file("foo.html")
         s.output_notebook()
         s.reset()
-        assert s.file == None
-        assert s.notebook == False
+        assert s.file is None
+        assert s.notebook is False
         assert isinstance(s.document, Document)
         assert s.document != d
 

--- a/tests/unit/bokeh/io/test_util__io.py
+++ b/tests/unit/bokeh/io/test_util__io.py
@@ -122,11 +122,11 @@ def test__shares_exec_prefix() -> None:
     old_ex = sys.exec_prefix
     try:
         sys.exec_prefix = "/foo/bar"
-        assert biu._shares_exec_prefix("/foo/bar") == True
+        assert biu._shares_exec_prefix("/foo/bar") is True
         sys.exec_prefix = "/baz/bar"
-        assert biu._shares_exec_prefix("/foo/bar") == False
+        assert biu._shares_exec_prefix("/foo/bar") is False
         sys.exec_prefix = None
-        assert biu._shares_exec_prefix("/foo/bar") == False
+        assert biu._shares_exec_prefix("/foo/bar") is False
     finally:
         sys.exec_prefix = old_ex
 

--- a/tests/unit/bokeh/io/test_webdriver.py
+++ b/tests/unit/bokeh/io/test_webdriver.py
@@ -66,13 +66,13 @@ class Test_webdriver_control:
         # other tests may have interacted with the global biw.webdriver_control,
         # so create a new instance only to check default values
         wc = biw._WebdriverState()
-        assert wc.reuse == True
-        assert wc.kind == None
+        assert wc.reuse is True
+        assert wc.kind is None
         assert wc.current is None
 
     def test_get_with_reuse(self) -> None:
         biw.webdriver_control.reuse = True
-        assert biw.webdriver_control.reuse == True
+        assert biw.webdriver_control.reuse is True
         d1 = biw.webdriver_control.get()
         d2 = biw.webdriver_control.get()
         assert d1 is d2
@@ -80,7 +80,7 @@ class Test_webdriver_control:
 
     def test_get_with_reuse_and_reset(self) -> None:
         biw.webdriver_control.reuse = True
-        assert biw.webdriver_control.reuse == True
+        assert biw.webdriver_control.reuse is True
         d1 = biw.webdriver_control.get()
         biw.webdriver_control.reset()
         d2 = biw.webdriver_control.get()
@@ -91,7 +91,7 @@ class Test_webdriver_control:
 
     def test_get_without_reuse(self) -> None:
         biw.webdriver_control.reuse = False
-        assert biw.webdriver_control.reuse == False
+        assert biw.webdriver_control.reuse is False
         d1 = biw.webdriver_control.get()
         d2 = biw.webdriver_control.get()
         assert d1 is not d2

--- a/tests/unit/bokeh/model/test_docs.py
+++ b/tests/unit/bokeh/model/test_docs.py
@@ -37,9 +37,9 @@ def test_html_repr() -> None:
     elts = list(html.children)
     assert len(elts) == 4
     assert elts[0].name == "div"
-    assert elts[1].name == None
+    assert elts[1].name is None
     assert elts[2].name == "script"
-    assert elts[3].name == None
+    assert elts[3].name is None
 
 def test_process_example() -> None:
     class Foo:

--- a/tests/unit/bokeh/model/test_model.py
+++ b/tests/unit/bokeh/model/test_model.py
@@ -237,15 +237,15 @@ def test_select() -> None:
 
     # select_one()
     assert root3 == root3.select_one(dict(name='d'))
-    assert None is root1.select_one(dict(name='nope'))
+    assert root1.select_one(dict(name='nope')) is None
 
     with pytest.raises(ValueError) as e:
         d.select_one(dict(name='d'))
     assert 'Found more than one' in repr(e)
 
     # select_one() on object
-    assert None is root3.select_one(dict(name='a'))
-    assert None is root3.select_one(dict(name='c'))
+    assert root3.select_one(dict(name='a')) is None
+    assert root3.select_one(dict(name='c')) is None
 
     # set_select()
     root1.set_select(dict(a=42), dict(name="c", a=44))

--- a/tests/unit/bokeh/model/test_model.py
+++ b/tests/unit/bokeh/model/test_model.py
@@ -237,15 +237,15 @@ def test_select() -> None:
 
     # select_one()
     assert root3 == root3.select_one(dict(name='d'))
-    assert None == root1.select_one(dict(name='nope'))
+    assert None is root1.select_one(dict(name='nope'))
 
     with pytest.raises(ValueError) as e:
         d.select_one(dict(name='d'))
     assert 'Found more than one' in repr(e)
 
     # select_one() on object
-    assert None == root3.select_one(dict(name='a'))
-    assert None == root3.select_one(dict(name='c'))
+    assert None is root3.select_one(dict(name='a'))
+    assert None is root3.select_one(dict(name='c'))
 
     # set_select()
     root1.set_select(dict(a=42), dict(name="c", a=44))

--- a/tests/unit/bokeh/models/test_annotations.py
+++ b/tests/unit/bokeh/models/test_annotations.py
@@ -119,11 +119,11 @@ def test_Legend() -> None:
 
 def test_LegendItem() -> None:
     item = LegendItem()
-    assert item.index== None
-    assert item.label == None
+    assert item.index is None
+    assert item.label is None
     assert item.name is None
     assert item.renderers == []
-    assert item.visible == True
+    assert item.visible is True
 
 def test_ColorBar() -> None:
     color_mapper = LinearColorMapper()

--- a/tests/unit/bokeh/models/test_layouts__models.py
+++ b/tests/unit/bokeh/models/test_layouts__models.py
@@ -40,7 +40,7 @@ def check_props_with_sizing_mode(layout):
     assert layout.width is None
     assert layout.height is None
     assert layout.children == []
-    assert layout.sizing_mode == None
+    assert layout.sizing_mode is None
 
 
 def check_children_prop(layout_callable):

--- a/tests/unit/bokeh/models/test_ranges.py
+++ b/tests/unit/bokeh/models/test_ranges.py
@@ -208,9 +208,9 @@ class Test_FactorRange:
         assert factor_range.factor_padding == 0
         assert factor_range.group_padding == 1.4
         assert factor_range.subgroup_padding == 0.8
-        assert factor_range.bounds == None
-        assert factor_range.min_interval == None
-        assert factor_range.max_interval == None
+        assert factor_range.bounds is None
+        assert factor_range.min_interval is None
+        assert factor_range.max_interval is None
 
     def test_init_with_positional_arguments(self) -> None:
         factor_range = FactorRange("a", "b")

--- a/tests/unit/bokeh/models/test_sources.py
+++ b/tests/unit/bokeh/models/test_sources.py
@@ -60,7 +60,7 @@ class TestColumnDataSource:
     def test_selected_serialized(self) -> None:
         ds = bms.ColumnDataSource()
         prop = ds.lookup('selected')
-        assert prop.serialized == True
+        assert prop.serialized is True
 
     def test_init_dict_arg(self) -> None:
         data = dict(a=[1], b=[2])

--- a/tests/unit/bokeh/models/test_transforms.py
+++ b/tests/unit/bokeh/models/test_transforms.py
@@ -55,7 +55,7 @@ def test_Jitter() -> None:
 
 def test_Interpolator() -> None:
     interpolator = Interpolator()
-    assert interpolator.clip == True
+    assert interpolator.clip is True
 
 
 def test_StepInterpolator() -> None:

--- a/tests/unit/bokeh/server/test_auth_provider.py
+++ b/tests/unit/bokeh/server/test_auth_provider.py
@@ -54,25 +54,25 @@ class TestNullAuth:
         assert null_auth.endpoints == []
 
     def test_get_user(self, null_auth: bsa.NullAuth) -> None:
-        assert null_auth.get_user == None
+        assert null_auth.get_user is None
 
     async def test_get_user_async(self, null_auth: bsa.NullAuth) -> None:
-        assert null_auth.get_user_async == None
+        assert null_auth.get_user_async is None
 
     def test_login_url(self, null_auth: bsa.NullAuth) -> None:
-        assert null_auth.login_url == None
+        assert null_auth.login_url is None
 
     def test_get_login_url(self, null_auth: bsa.NullAuth) -> None:
-        assert null_auth.get_login_url == None
+        assert null_auth.get_login_url is None
 
     def test_login_handler(self, null_auth: bsa.NullAuth) -> None:
-        assert null_auth.login_handler == None
+        assert null_auth.login_handler is None
 
     def test_logout_url(self, null_auth: bsa.NullAuth) -> None:
-        assert null_auth.logout_url == None
+        assert null_auth.logout_url is None
 
     def test_logout_handler(self, null_auth: bsa.NullAuth) -> None:
-        assert null_auth.logout_handler == None
+        assert null_auth.logout_handler is None
 
 class TestAuthModule_properties:
     def test_no_endpoints(self) -> None:

--- a/tests/unit/bokeh/server/test_server__server.py
+++ b/tests/unit/bokeh/server/test_server__server.py
@@ -244,7 +244,7 @@ def resource_files_requested(response, requested=True):
 def test_use_xheaders(ManagedServerLoop: MSL) -> None:
     application = Application()
     with ManagedServerLoop(application, use_xheaders=True) as server:
-        assert server._http.xheaders == True
+        assert server._http.xheaders is True
 
 def test_ssl_args_plumbing(ManagedServerLoop: MSL) -> None:
     with mock.patch.object(ssl, 'SSLContext'):

--- a/tests/unit/bokeh/server/test_util.py
+++ b/tests/unit/bokeh/server/test_util.py
@@ -38,39 +38,39 @@ def test_bind_sockets_with_zero_port() -> None:
     assert isinstance(port, int)
 
 def test_check_allowlist_rejects_port_mismatch() -> None:
-    assert False == util.check_allowlist("foo:100", ["foo:101", "foo:102"])
+    assert False is util.check_allowlist("foo:100", ["foo:101", "foo:102"])
 
 def test_check_allowlist_rejects_name_mismatch() -> None:
-    assert False == util.check_allowlist("foo:100", ["bar:100", "baz:100"])
+    assert False is util.check_allowlist("foo:100", ["bar:100", "baz:100"])
 
 def test_check_allowlist_accepts_name_port_match() -> None:
-    assert True == util.check_allowlist("foo:100", ["foo:100", "baz:100"])
+    assert True is util.check_allowlist("foo:100", ["foo:100", "baz:100"])
 
 def test_check_allowlist_accepts_implicit_port_80() -> None:
-    assert True == util.check_allowlist("foo", ["foo:80"])
+    assert True is util.check_allowlist("foo", ["foo:80"])
 
 def test_check_allowlist_accepts_all_on_star() -> None:
-    assert True == util.check_allowlist("192.168.0.1", ['*'])
-    assert True == util.check_allowlist("192.168.0.1:80", ['*'])
-    assert True == util.check_allowlist("192.168.0.1:5006", ['*'])
-    assert True == util.check_allowlist("192.168.0.1:80", ['*:80'])
-    assert False == util.check_allowlist("192.168.0.1:80", ['*:81'])
-    assert True == util.check_allowlist("192.168.0.1:5006", ['*:*'])
-    assert True == util.check_allowlist("192.168.0.1", ['192.168.0.*'])
-    assert True == util.check_allowlist("192.168.0.1:5006", ['192.168.0.*'])
-    assert False == util.check_allowlist("192.168.1.1", ['192.168.0.*'])
-    assert True == util.check_allowlist("foobarbaz", ['*'])
-    assert True == util.check_allowlist("192.168.0.1", ['192.168.0.*'])
-    assert False == util.check_allowlist("192.168.1.1", ['192.168.0.*'])
-    assert False == util.check_allowlist("192.168.0.1", ['192.168.0.*:5006'])
-    assert True == util.check_allowlist("192.168.0.1", ['192.168.0.*:80'])
-    assert True == util.check_allowlist("foobarbaz", ['*'])
-    assert True == util.check_allowlist("foobarbaz", ['*:*'])
-    assert True == util.check_allowlist("foobarbaz", ['*:80'])
-    assert False == util.check_allowlist("foobarbaz", ['*:5006'])
-    assert True == util.check_allowlist("foobarbaz:5006", ['*'])
-    assert True == util.check_allowlist("foobarbaz:5006", ['*:*'])
-    assert True == util.check_allowlist("foobarbaz:5006", ['*:5006'])
+    assert True is util.check_allowlist("192.168.0.1", ['*'])
+    assert True is util.check_allowlist("192.168.0.1:80", ['*'])
+    assert True is util.check_allowlist("192.168.0.1:5006", ['*'])
+    assert True is util.check_allowlist("192.168.0.1:80", ['*:80'])
+    assert False is util.check_allowlist("192.168.0.1:80", ['*:81'])
+    assert True is util.check_allowlist("192.168.0.1:5006", ['*:*'])
+    assert True is util.check_allowlist("192.168.0.1", ['192.168.0.*'])
+    assert True is util.check_allowlist("192.168.0.1:5006", ['192.168.0.*'])
+    assert False is util.check_allowlist("192.168.1.1", ['192.168.0.*'])
+    assert True is util.check_allowlist("foobarbaz", ['*'])
+    assert True is util.check_allowlist("192.168.0.1", ['192.168.0.*'])
+    assert False is util.check_allowlist("192.168.1.1", ['192.168.0.*'])
+    assert False is util.check_allowlist("192.168.0.1", ['192.168.0.*:5006'])
+    assert True is util.check_allowlist("192.168.0.1", ['192.168.0.*:80'])
+    assert True is util.check_allowlist("foobarbaz", ['*'])
+    assert True is util.check_allowlist("foobarbaz", ['*:*'])
+    assert True is util.check_allowlist("foobarbaz", ['*:80'])
+    assert False is util.check_allowlist("foobarbaz", ['*:5006'])
+    assert True is util.check_allowlist("foobarbaz:5006", ['*'])
+    assert True is util.check_allowlist("foobarbaz:5006", ['*:*'])
+    assert True is util.check_allowlist("foobarbaz:5006", ['*:5006'])
 
 def test_create_hosts_allowlist_no_host() -> None:
     hosts = util.create_hosts_allowlist(None, 1000)
@@ -108,20 +108,20 @@ def test_create_hosts_allowlist_bad_host_raises() -> None:
         util.create_hosts_allowlist([":80"], 1000)
 
 def test_match_host() -> None:
-        assert util.match_host('192.168.0.1:80', '192.168.0.1:80') == True
-        assert util.match_host('192.168.0.1:80', '192.168.0.1') == True
-        assert util.match_host('192.168.0.1:80', '192.168.0.1:8080') == False
-        assert util.match_host('192.168.0.1', '192.168.0.2') == False
-        assert util.match_host('192.168.0.1', '192.168.*.*') == True
-        assert util.match_host('alice', 'alice') == True
-        assert util.match_host('alice:80', 'alice') == True
-        assert util.match_host('alice', 'bob') == False
-        assert util.match_host('foo.example.com', 'foo.example.com.net') == False
-        assert util.match_host('alice', '*') == True
-        assert util.match_host('alice', '*:*') == True
-        assert util.match_host('alice:80', '*') == True
-        assert util.match_host('alice:80', '*:80') == True
-        assert util.match_host('alice:8080', '*:80') == False
+        assert util.match_host('192.168.0.1:80', '192.168.0.1:80') is True
+        assert util.match_host('192.168.0.1:80', '192.168.0.1') is True
+        assert util.match_host('192.168.0.1:80', '192.168.0.1:8080') is False
+        assert util.match_host('192.168.0.1', '192.168.0.2') is False
+        assert util.match_host('192.168.0.1', '192.168.*.*') is True
+        assert util.match_host('alice', 'alice') is True
+        assert util.match_host('alice:80', 'alice') is True
+        assert util.match_host('alice', 'bob') is False
+        assert util.match_host('foo.example.com', 'foo.example.com.net') is False
+        assert util.match_host('alice', '*') is True
+        assert util.match_host('alice', '*:*') is True
+        assert util.match_host('alice:80', '*') is True
+        assert util.match_host('alice:80', '*:80') is True
+        assert util.match_host('alice:8080', '*:80') is False
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/server/test_util.py
+++ b/tests/unit/bokeh/server/test_util.py
@@ -38,39 +38,39 @@ def test_bind_sockets_with_zero_port() -> None:
     assert isinstance(port, int)
 
 def test_check_allowlist_rejects_port_mismatch() -> None:
-    assert False is util.check_allowlist("foo:100", ["foo:101", "foo:102"])
+    assert util.check_allowlist("foo:100", ["foo:101", "foo:102"]) is False
 
 def test_check_allowlist_rejects_name_mismatch() -> None:
-    assert False is util.check_allowlist("foo:100", ["bar:100", "baz:100"])
+    assert util.check_allowlist("foo:100", ["bar:100", "baz:100"]) is False
 
 def test_check_allowlist_accepts_name_port_match() -> None:
-    assert True is util.check_allowlist("foo:100", ["foo:100", "baz:100"])
+    assert util.check_allowlist("foo:100", ["foo:100", "baz:100"]) is True
 
 def test_check_allowlist_accepts_implicit_port_80() -> None:
-    assert True is util.check_allowlist("foo", ["foo:80"])
+    assert util.check_allowlist("foo", ["foo:80"]) is True
 
 def test_check_allowlist_accepts_all_on_star() -> None:
-    assert True is util.check_allowlist("192.168.0.1", ['*'])
-    assert True is util.check_allowlist("192.168.0.1:80", ['*'])
-    assert True is util.check_allowlist("192.168.0.1:5006", ['*'])
-    assert True is util.check_allowlist("192.168.0.1:80", ['*:80'])
-    assert False is util.check_allowlist("192.168.0.1:80", ['*:81'])
-    assert True is util.check_allowlist("192.168.0.1:5006", ['*:*'])
-    assert True is util.check_allowlist("192.168.0.1", ['192.168.0.*'])
-    assert True is util.check_allowlist("192.168.0.1:5006", ['192.168.0.*'])
-    assert False is util.check_allowlist("192.168.1.1", ['192.168.0.*'])
-    assert True is util.check_allowlist("foobarbaz", ['*'])
-    assert True is util.check_allowlist("192.168.0.1", ['192.168.0.*'])
-    assert False is util.check_allowlist("192.168.1.1", ['192.168.0.*'])
-    assert False is util.check_allowlist("192.168.0.1", ['192.168.0.*:5006'])
-    assert True is util.check_allowlist("192.168.0.1", ['192.168.0.*:80'])
-    assert True is util.check_allowlist("foobarbaz", ['*'])
-    assert True is util.check_allowlist("foobarbaz", ['*:*'])
-    assert True is util.check_allowlist("foobarbaz", ['*:80'])
-    assert False is util.check_allowlist("foobarbaz", ['*:5006'])
-    assert True is util.check_allowlist("foobarbaz:5006", ['*'])
-    assert True is util.check_allowlist("foobarbaz:5006", ['*:*'])
-    assert True is util.check_allowlist("foobarbaz:5006", ['*:5006'])
+    assert util.check_allowlist("192.168.0.1", ['*']) is True
+    assert util.check_allowlist("192.168.0.1:80", ['*']) is True
+    assert util.check_allowlist("192.168.0.1:5006", ['*']) is True
+    assert util.check_allowlist("192.168.0.1:80", ['*:80']) is True
+    assert util.check_allowlist("192.168.0.1:80", ['*:81']) is False
+    assert util.check_allowlist("192.168.0.1:5006", ['*:*']) is True
+    assert util.check_allowlist("192.168.0.1", ['192.168.0.*']) is True
+    assert util.check_allowlist("192.168.0.1:5006", ['192.168.0.*']) is True
+    assert util.check_allowlist("192.168.1.1", ['192.168.0.*']) is False
+    assert util.check_allowlist("foobarbaz", ['*']) is True
+    assert util.check_allowlist("192.168.0.1", ['192.168.0.*']) is True
+    assert util.check_allowlist("192.168.1.1", ['192.168.0.*']) is False
+    assert util.check_allowlist("192.168.0.1", ['192.168.0.*:5006']) is False
+    assert util.check_allowlist("192.168.0.1", ['192.168.0.*:80']) is True
+    assert util.check_allowlist("foobarbaz", ['*']) is True
+    assert util.check_allowlist("foobarbaz", ['*:*']) is True
+    assert util.check_allowlist("foobarbaz", ['*:80']) is True
+    assert util.check_allowlist("foobarbaz", ['*:5006']) is False
+    assert util.check_allowlist("foobarbaz:5006", ['*']) is True
+    assert util.check_allowlist("foobarbaz:5006", ['*:*']) is True
+    assert util.check_allowlist("foobarbaz:5006", ['*:5006']) is True
 
 def test_create_hosts_allowlist_no_host() -> None:
     hosts = util.create_hosts_allowlist(None, 1000)

--- a/tests/unit/bokeh/test_events.py
+++ b/tests/unit/bokeh/test_events.py
@@ -313,7 +313,7 @@ def test_buttonclick_event_callbacks() -> None:
     button = Button()
     test_callback = EventCallback()
     button.on_event(events.ButtonClick, test_callback)
-    assert test_callback.event_name == None
+    assert test_callback.event_name is None
     button._trigger_event(events.ButtonClick(button))
     assert test_callback.event_name == events.ButtonClick.event_name
 
@@ -322,7 +322,7 @@ def test_atomic_plot_event_callbacks() -> None:
     for event_cls in [events.LODStart, events.LODEnd]:
         test_callback = EventCallback()
         plot.on_event(event_cls, test_callback)
-        assert test_callback.event_name == None
+        assert test_callback.event_name is None
         plot._trigger_event(event_cls(plot))
         assert test_callback.event_name == event_cls.event_name
 
@@ -333,7 +333,7 @@ def test_pointevent_callbacks() -> None:
     for event_cls in point_events:
         test_callback = EventCallback(['sx','sy','x','y'])
         plot.on_event(event_cls, test_callback)
-        assert test_callback.event_name == None
+        assert test_callback.event_name is None
         plot._trigger_event(event_cls(plot, **payload))
         assert test_callback.event_name == event_cls.event_name
         assert test_callback.payload == payload
@@ -343,7 +343,7 @@ def test_mousewheel_callbacks() -> None:
     payload = dict(sx=3, sy=-2, x=10, y=100, delta=5)
     test_callback = EventCallback(['sx','sy','x','y', 'delta'])
     plot.on_event(events.MouseWheel, test_callback)
-    assert test_callback.event_name == None
+    assert test_callback.event_name is None
     plot._trigger_event(events.MouseWheel(plot, **payload))
     assert test_callback.event_name == events.MouseWheel.event_name
     assert test_callback.payload == payload
@@ -353,7 +353,7 @@ def test_pan_callbacks() -> None:
     payload = dict(sx=3, sy=-2, x=10, y=100, delta_x=2, delta_y=3.2)
     test_callback = EventCallback(['sx','sy','x','y', 'delta_x', 'delta_y'])
     plot.on_event(events.Pan, test_callback)
-    assert test_callback.event_name == None
+    assert test_callback.event_name is None
     plot._trigger_event(events.Pan(plot, **payload))
     assert test_callback.event_name == events.Pan.event_name
     assert test_callback.payload == payload
@@ -363,7 +363,7 @@ def test_pinch_callbacks() -> None:
     payload = dict(sx=3, sy=-2, x=10, y=100, scale=42)
     test_callback = EventCallback(['sx','sy','x','y', 'scale'])
     plot.on_event(events.Pinch, test_callback)
-    assert test_callback.event_name == None
+    assert test_callback.event_name is None
     plot._trigger_event(events.Pinch(plot, **payload))
     assert test_callback.event_name == events.Pinch.event_name
     assert test_callback.payload == payload

--- a/tests/unit/bokeh/test_resources.py
+++ b/tests/unit/bokeh/test_resources.py
@@ -175,7 +175,7 @@ class TestResources:
     def test_inline(self) -> None:
         r = resources.Resources(mode="inline")
         assert r.mode == "inline"
-        assert r.dev == False
+        assert r.dev is False
 
         assert len(r.js_raw) == 6
         assert r.js_raw[-1] == DEFAULT_LOG_JS_RAW
@@ -192,7 +192,7 @@ class TestResources:
         monkeypatch.setattr(resources, "__version__", "1.0")
         r = resources.Resources(mode="cdn", version="1.0")
         assert r.mode == "cdn"
-        assert r.dev == False
+        assert r.dev is False
 
         assert r.js_raw == [DEFAULT_LOG_JS_RAW]
         assert r.css_raw == []
@@ -210,7 +210,7 @@ class TestResources:
     def test_server_default(self) -> None:
         r = resources.Resources(mode="server")
         assert r.mode == "server"
-        assert r.dev == False
+        assert r.dev is False
 
         assert r.js_raw == [DEFAULT_LOG_JS_RAW]
         assert r.css_raw == []
@@ -271,7 +271,7 @@ class TestResources:
     def test_server_dev(self) -> None:
         r = resources.Resources(mode="server-dev")
         assert r.mode == "server"
-        assert r.dev == True
+        assert r.dev is True
 
         assert len(r.js_raw) == 2
         assert r.css_raw == []
@@ -286,7 +286,7 @@ class TestResources:
     def test_relative(self) -> None:
         r = resources.Resources(mode="relative")
         assert r.mode == "relative"
-        assert r.dev == False
+        assert r.dev is False
 
         assert r.js_raw == [DEFAULT_LOG_JS_RAW]
         assert r.css_raw == []
@@ -295,7 +295,7 @@ class TestResources:
     def test_relative_dev(self) -> None:
         r = resources.Resources(mode="relative-dev")
         assert r.mode == "relative"
-        assert r.dev == True
+        assert r.dev is True
 
         assert r.js_raw == [DEFAULT_LOG_JS_RAW, "Bokeh.settings.dev = true"]
         assert r.css_raw == []
@@ -304,7 +304,7 @@ class TestResources:
     def test_absolute(self) -> None:
         r = resources.Resources(mode="absolute")
         assert r.mode == "absolute"
-        assert r.dev == False
+        assert r.dev is False
 
         assert r.js_raw == [DEFAULT_LOG_JS_RAW]
         assert r.css_raw == []
@@ -313,7 +313,7 @@ class TestResources:
     def test_absolute_dev(self) -> None:
         r = resources.Resources(mode="absolute-dev")
         assert r.mode == "absolute"
-        assert r.dev == True
+        assert r.dev is True
 
         assert r.js_raw == [DEFAULT_LOG_JS_RAW, "Bokeh.settings.dev = true"]
         assert r.css_raw == []

--- a/tests/unit/bokeh/test_settings.py
+++ b/tests/unit/bokeh/test_settings.py
@@ -146,13 +146,13 @@ class TestConverters:
         assert bs.convert_logging(value.lower()) == getattr(logging, value)
 
     def test_convert_logging_none(self) -> None:
-        assert bs.convert_logging("NONE") == None
+        assert bs.convert_logging("NONE") is None
 
         # check lowercase works
-        assert bs.convert_logging("none") == None
+        assert bs.convert_logging("none") is None
 
         # check value works
-        assert bs.convert_logging(None) == None
+        assert bs.convert_logging(None) is None
 
     @pytest.mark.parametrize("value", ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"])
     def test_convert_logging_identity(self, value) -> None:
@@ -334,46 +334,46 @@ class TestDefaults:
         assert bs.settings.allowed_ws_origin.default == []
 
     def test_auth_module(self):
-        assert bs.settings.auth_module.default == None
+        assert bs.settings.auth_module.default is None
 
     def test_browser(self):
-        assert bs.settings.browser.default == None
+        assert bs.settings.browser.default is None
 
     def test_cdn_version(self):
-        assert bs.settings.cdn_version.default == None
+        assert bs.settings.cdn_version.default is None
 
     def test_cookie_secret(self):
-        assert bs.settings.cookie_secret.default == None
+        assert bs.settings.cookie_secret.default is None
 
     def test_docs_alert(self):
-        assert bs.settings.docs_alert.default == None
+        assert bs.settings.docs_alert.default is None
 
     def test_docs_cdn(self):
-        assert bs.settings.docs_cdn.default == None
+        assert bs.settings.docs_cdn.default is None
 
     def test_docs_version(self):
-        assert bs.settings.docs_version.default == None
+        assert bs.settings.docs_version.default is None
 
     def test_ico_path(self):
         assert bs.settings.ico_path.default == "default"
 
     def test_ignore_filename(self):
-        assert bs.settings.ignore_filename.default == False
+        assert bs.settings.ignore_filename.default is False
 
     def test_log_level(self):
         assert bs.settings.log_level.default == "info"
 
     def test_minified(self):
-        assert bs.settings.minified.default == True
+        assert bs.settings.minified.default is True
 
     def test_nodejs_path(self):
-        assert bs.settings.nodejs_path.default == None
+        assert bs.settings.nodejs_path.default is None
 
     def test_perform_document_validation(self):
-        assert bs.settings.perform_document_validation.default == True
+        assert bs.settings.perform_document_validation.default is True
 
     def test_pretty(self):
-        assert bs.settings.pretty.default == False
+        assert bs.settings.pretty.default is False
 
     def test_py_log_level(self):
         assert bs.settings.py_log_level.default == "none"
@@ -382,31 +382,31 @@ class TestDefaults:
         assert bs.settings.resources.default == "cdn"
 
     def test_rootdir(self):
-        assert bs.settings.rootdir.default == None
+        assert bs.settings.rootdir.default is None
 
     def test_secret_key(self):
-        assert bs.settings.secret_key.default == None
+        assert bs.settings.secret_key.default is None
 
     def test_sign_sessions(self):
-        assert bs.settings.sign_sessions.default == False
+        assert bs.settings.sign_sessions.default is False
 
     def test_simple_ids(self):
-        assert bs.settings.simple_ids.default == True
+        assert bs.settings.simple_ids.default is True
 
     def test_ssl_certfile(self):
-        assert bs.settings.ssl_certfile.default == None
+        assert bs.settings.ssl_certfile.default is None
 
     def test_ssl_keyfile(self):
-        assert bs.settings.ssl_keyfile.default == None
+        assert bs.settings.ssl_keyfile.default is None
 
     def test_ssl_password(self):
-        assert bs.settings.ssl_password.default == None
+        assert bs.settings.ssl_password.default is None
 
     def test_validation_level(self):
         assert bs.settings.validation_level.default == "none"
 
     def test_xsrf_cookies(self):
-        assert bs.settings.xsrf_cookies.default == False
+        assert bs.settings.xsrf_cookies.default is False
 
 
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/test_transform.py
+++ b/tests/unit/bokeh/test_transform.py
@@ -65,14 +65,14 @@ class Test_cumsum:
         assert isinstance(val, Expr)
         assert isinstance(val.expr, CumSum)
         assert val.expr.field == 'foo'
-        assert val.expr.include_zero == False
+        assert val.expr.include_zero is False
 
     def test_include_zero(object) -> None:
         val = bt.cumsum("foo", include_zero=True)
         assert isinstance(val, Expr)
         assert isinstance(val.expr, CumSum)
         assert val.expr.field == 'foo'
-        assert val.expr.include_zero == True
+        assert val.expr.include_zero is True
 
 
 class Test_dodge:

--- a/tests/unit/bokeh/util/test_compiler.py
+++ b/tests/unit/bokeh/util/test_compiler.py
@@ -83,12 +83,12 @@ def test_nodejs_compile_less() -> None:
 
 def test_Implementation() -> None:
     obj = buc.Implementation()
-    assert obj.file == None
+    assert obj.file is None
 
 def test_Inline() -> None:
     obj = buc.Inline("code")
     assert obj.code == "code"
-    assert obj.file == None
+    assert obj.file is None
 
     obj = buc.Inline("code", "file")
     assert obj.code == "code"
@@ -98,21 +98,21 @@ def test_TypeScript() -> None:
     obj = buc.TypeScript("code")
     assert isinstance(obj, buc.Inline)
     assert obj.code == "code"
-    assert obj.file == None
+    assert obj.file is None
     assert obj.lang == "typescript"
 
 def test_JavaScript() -> None:
     obj = buc.JavaScript("code")
     assert isinstance(obj, buc.Inline)
     assert obj.code == "code"
-    assert obj.file == None
+    assert obj.file is None
     assert obj.lang == "javascript"
 
 def test_Less() -> None:
     obj = buc.Less("code")
     assert isinstance(obj, buc.Inline)
     assert obj.code == "code"
-    assert obj.file == None
+    assert obj.file is None
     assert obj.lang == "less"
 
 @patch("builtins.open")

--- a/tests/unit/bokeh/util/test_options.py
+++ b/tests/unit/bokeh/util/test_options.py
@@ -38,7 +38,7 @@ def test_empty() -> None:
     empty = dict()
     o = DummyOpts(empty)
     assert o.foo == "thing"
-    assert o.bar == None
+    assert o.bar is None
     assert empty == {}
 
 def test_exact() -> None:
@@ -59,7 +59,7 @@ def test_mixed() -> None:
     mixed = dict(foo="stuff", baz=22.2)
     o = DummyOpts(mixed)
     assert o.foo == "stuff"
-    assert o.bar == None
+    assert o.bar is None
     assert mixed == {'baz': 22.2}
 
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/util/test_string.py
+++ b/tests/unit/bokeh/util/test_string.py
@@ -42,19 +42,19 @@ class Test_format_docstring:
         doc__ = "hello world"
         assert bus.format_docstring(doc__) == doc__
         doc__ = None
-        assert bus.format_docstring(doc__) == None
+        assert bus.format_docstring(doc__) is None
 
     def test_arguments_unused(self) -> None:
         doc__ = "hello world"
         assert bus.format_docstring(doc__, 'hello ', not_used='world') == doc__
         doc__ = None
-        assert bus.format_docstring(doc__, 'hello ', not_used='world') == None
+        assert bus.format_docstring(doc__, 'hello ', not_used='world') is None
 
     def test_arguments(self) -> None:
         doc__ = "-- {}{as_parameter} --"
         assert bus.format_docstring(doc__, 'hello ', as_parameter='world') == "-- hello world --"
         doc__ = None
-        assert bus.format_docstring(doc__, 'hello ', as_parameter='world') == None
+        assert bus.format_docstring(doc__, 'hello ', as_parameter='world') is None
 
 class Test_format_url_query_arguments:
     def test_no_arguments(self) -> None:


### PR DESCRIPTION
As discussed with Bryan.

Singleton data types such as booleans should be compared using `is` and `is not` rather than `==` and `!=`.

Read more about this change [here](https://codereview.doctor/features/python/best-practice/avoid-equality-checking-boolean-none)
