### PR TITLE
#12088: sets Select value to first item in options if not specified m…

### DIFF
--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -379,9 +379,14 @@ class Select(InputWidget):
     # explicit __init__ to support Init signatures
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+        self.init_value(**kwargs)
 
+    def init_value(self, **kwargs):
+        """Initializes value as first option when it is not specified"""
         if not self.value and self.options and 'value' not in kwargs:
-            self.value = self.options[0]
+            opts = self.options
+            item = opts[0] if isinstance(opts, list) else list(opts.values())[0][0]
+            self.value = item if isinstance(item, str) else item[0]
 
     options = Either(List(Either(String, Tuple(String, String))),
         Dict(String, List(Either(String, Tuple(String, String)))), help="""

--- a/bokeh/models/widgets/inputs.py
+++ b/bokeh/models/widgets/inputs.py
@@ -380,6 +380,9 @@ class Select(InputWidget):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
+        if not self.value and self.options and 'value' not in kwargs:
+            self.value = self.options[0]
+
     options = Either(List(Either(String, Tuple(String, String))),
         Dict(String, List(Either(String, Tuple(String, String)))), help="""
     Available selection options. Options may be provided either as a list of
@@ -390,8 +393,8 @@ class Select(InputWidget):
     list format
     """).accepts(List(Either(Null, String)), lambda v: [ "" if item is None else item for item in v ])
 
-    value = String(default="", help="""
-    Initial or selected value.
+    value = String(default=None, help="""
+    Initial or selected value. Defaults to the first item in options.
     """).accepts(Null, lambda _: "")
 
 class MultiSelect(InputWidget):

--- a/tests/integration/widgets/test_select.py
+++ b/tests/integration/widgets/test_select.py
@@ -42,6 +42,11 @@ pytest_plugins = (
     "bokeh._testing.plugins.project",
 )
 
+class Test_Select_Python():
+    def test_without_specified_value_initialize_first_option_as_default_value(self) -> None:
+        select = Select(options=["Option 1", "Option 2", "Option 3"])
+        assert select.value == "Option 1"
+
 @pytest.mark.selenium
 class Test_Select:
     def test_displays_title(self, bokeh_model_page: BokehModelPage) -> None:
@@ -69,6 +74,21 @@ class Test_Select:
         for i, opt in enumerate(opts, 1):
             assert opt.text == "Option %d" % i
             assert opt.get_attribute('value') == "Option %d" % i
+
+        assert page.has_no_console_errors()
+
+    def test_without_specified_value_has_first_option_as_default_value(self, bokeh_model_page: BokehModelPage) -> None:
+        select = Select(options=["Option 1", "Option 2", "Option 3"])
+
+        page = bokeh_model_page(select)
+
+        el = find_element_for(page.driver, select, "label")
+        assert el.text == ""
+
+        el = find_element_for(page.driver, select, "select")
+        value = el.find_elements(By.TAG_NAME, 'value')
+
+        assert value == "Option 1"
 
         assert page.has_no_console_errors()
 

--- a/tests/integration/widgets/test_select.py
+++ b/tests/integration/widgets/test_select.py
@@ -47,6 +47,18 @@ class Test_Select_Python():
         select = Select(options=["Option 1", "Option 2", "Option 3"])
         assert select.value == "Option 1"
 
+    def test_without_specified_value_initialize_first_tuple_option_as_default_value(self) -> None:
+        select = Select(options=[("1", "Option 1"), ("2", "Option 2"), ("3", "Option 3")])
+        assert select.value == "1"
+
+    def test_without_specified_value_initialize_first_dict_option_as_default_value(self) -> None:
+        select = Select(options=dict(g1=["Option 11"], g2=["Option 21", "Option 22"]))
+        assert select.value == "Option 11"
+
+    def test_without_specified_value_initialize_first_dict_tuple_option_as_default_value(self) -> None:
+        select = Select(options=dict(g1=[("11", "Option 11")], g2=[("21", "Option 21"), ("22", "Option 22")]))
+        assert select.value == "11"
+
 @pytest.mark.selenium
 class Test_Select:
     def test_displays_title(self, bokeh_model_page: BokehModelPage) -> None:
@@ -77,21 +89,6 @@ class Test_Select:
 
         assert page.has_no_console_errors()
 
-    def test_without_specified_value_has_first_option_as_default_value(self, bokeh_model_page: BokehModelPage) -> None:
-        select = Select(options=["Option 1", "Option 2", "Option 3"])
-
-        page = bokeh_model_page(select)
-
-        el = find_element_for(page.driver, select, "label")
-        assert el.text == ""
-
-        el = find_element_for(page.driver, select, "select")
-        value = el.find_elements(By.TAG_NAME, 'value')
-
-        assert value == "Option 1"
-
-        assert page.has_no_console_errors()
-
     def test_displays_options_list_of_string_options_with_default_value(self, bokeh_model_page: BokehModelPage) -> None:
         select = Select(options=["Option 1", "Option 2", "Option 3"], value="Option 3")
 
@@ -109,7 +106,6 @@ class Test_Select:
             assert opt.get_attribute('value') == "Option %d" % i
 
         assert page.has_no_console_errors()
-
 
     def test_displays_list_of_tuple_options(self, bokeh_model_page: BokehModelPage) -> None:
         select = Select(options=[("1", "Option 1"), ("2", "Option 2"), ("3", "Option 3")])
@@ -263,7 +259,7 @@ class Test_Select:
         page.eval_custom_action()
 
         results = page.results
-        assert results['data']['val'] == ["", "Option 3"]
+        assert results['data']['val'] == ["Option 1", "Option 3"]
 
         el = find_element_for(page.driver, select, "select")
         el.click()


### PR DESCRIPTION
- [X] issues: fixes #12088
- [X] tests added / passed: tests added, need to check if the selenium one works correctly via this pull request
- [X] release document entry (if new feature or API change) - updated a line on value for Select


Note: 
- added two tests, one that depends on selenium, one that is pure Python. The full TestSelect class was marked as selenium. I am open for a different way of splitting the selenium and non-selenium tests than what I did now (add a new class)